### PR TITLE
ENH: Cythonize scipy.spatial.transform.Rotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -238,6 +238,7 @@ scipy/spatial/ckdtree.h
 scipy/spatial/_hausdorff.c
 scipy/spatial/qhull.c
 scipy/spatial/_voronoi.c
+scipy/spatial/transform/rotation.c
 scipy/special/_comb.c
 scipy/special/_ellip_harm_2.c
 scipy/special/_ellip_harm_2.h

--- a/benchmarks/benchmarks/spatial.py
+++ b/benchmarks/benchmarks/spatial.py
@@ -432,7 +432,7 @@ class GeometricSlerpBench(Benchmark):
                         t=self.t)
 
 class RotationBench(Benchmark):
-    params = [1, 10, 100]
+    params = [1, 10, 1000, 10000]
     param_names = ['num_rotations']
 
     def setup(self, num_rotations):

--- a/benchmarks/benchmarks/spatial.py
+++ b/benchmarks/benchmarks/spatial.py
@@ -25,6 +25,11 @@ try:
 except ImportError:
     pass
 
+try:
+    from scipy.spatial.transform import Rotation
+except ImportError:
+    pass
+
 from .common import Benchmark, LimitedParamBenchmark
 
 
@@ -425,3 +430,27 @@ class GeometricSlerpBench(Benchmark):
         geometric_slerp(start=self.start,
                         end=self.end,
                         t=self.t)
+
+class RotationBench(Benchmark):
+    params = [1, 10, 100]
+    param_names = ['num_rotations']
+
+    def setup(self, num_rotations):
+        np.random.seed(1234)
+        self.rotataions = Rotation.random(num_rotations)
+
+    def time_matrix_conversion(self, num_rotations):
+        '''Time converting rotation from and to matrices'''
+        Rotation.from_matrix(self.rotataions.as_matrix())
+
+    def time_euler_conversion(self, num_rotations):
+        '''Time converting rotation from and to euler angles'''
+        Rotation.from_euler("XYZ", self.rotataions.as_euler("XYZ"))
+
+    def time_rotvec_conversion(self, num_rotations):
+        '''Time converting rotation from and to rotation vectors'''
+        Rotation.from_rotvec(self.rotataions.as_rotvec())
+
+    def time_mul_inv(self, num_rotations):
+        '''Time multiplication and inverse of rotations'''
+        self.rotataions * self.rotataions.inv()

--- a/benchmarks/benchmarks/spatial.py
+++ b/benchmarks/benchmarks/spatial.py
@@ -437,20 +437,20 @@ class RotationBench(Benchmark):
 
     def setup(self, num_rotations):
         np.random.seed(1234)
-        self.rotataions = Rotation.random(num_rotations)
+        self.rotations = Rotation.random(num_rotations)
 
     def time_matrix_conversion(self, num_rotations):
         '''Time converting rotation from and to matrices'''
-        Rotation.from_matrix(self.rotataions.as_matrix())
+        Rotation.from_matrix(self.rotations.as_matrix())
 
     def time_euler_conversion(self, num_rotations):
         '''Time converting rotation from and to euler angles'''
-        Rotation.from_euler("XYZ", self.rotataions.as_euler("XYZ"))
+        Rotation.from_euler("XYZ", self.rotations.as_euler("XYZ"))
 
     def time_rotvec_conversion(self, num_rotations):
         '''Time converting rotation from and to rotation vectors'''
-        Rotation.from_rotvec(self.rotataions.as_rotvec())
+        Rotation.from_rotvec(self.rotations.as_rotvec())
 
     def time_mul_inv(self, num_rotations):
         '''Time multiplication and inverse of rotations'''
-        self.rotataions * self.rotataions.inv()
+        self.rotations * self.rotations.inv()

--- a/scipy/spatial/transform/rotation.pyx
+++ b/scipy/spatial/transform/rotation.pyx
@@ -1580,7 +1580,7 @@ cdef class Rotation(object):
         quat[:, -1] *= -1
         if self._single:
             quat = quat[0]
-        return self.__class__(quat, normalize=False, copy=False)
+        return self.__class__(quat, copy=False)
 
     @cython.boundscheck(False)
     @cython.wraparound(False)

--- a/scipy/spatial/transform/rotation.pyx
+++ b/scipy/spatial/transform/rotation.pyx
@@ -5,7 +5,8 @@ cimport numpy as np
 cimport cython
 from cython.view cimport array
 from cpython.array cimport array as pyarray
-from libc.math cimport sqrt, sin, cos, atan2, pi, acos, NAN, isnan
+from libc.math cimport sqrt, sin, cos, atan2, acos
+from numpy.math cimport PI as pi, NAN, isnan
 import scipy.linalg
 from scipy._lib._util import check_random_state
 from ._rotation_groups import create_group

--- a/scipy/spatial/transform/setup.py
+++ b/scipy/spatial/transform/setup.py
@@ -6,4 +6,7 @@ def configuration(parent_package='', top_path=None):
 
     config.add_data_dir('tests')
 
+    config.add_extension('rotation',
+                         sources=['rotation.c'])
+
     return config

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -854,9 +854,9 @@ def test_getitem():
     ])
     r = Rotation.from_matrix(mat)
 
-    assert_allclose(r[0].as_matrix(), mat[0])
-    assert_allclose(r[1].as_matrix(), mat[1])
-    assert_allclose(r[:-1].as_matrix(), np.expand_dims(mat[0], axis=0))
+    assert_allclose(r[0].as_matrix(), mat[0], atol=1e-15)
+    assert_allclose(r[1].as_matrix(), mat[1], atol=1e-15)
+    assert_allclose(r[:-1].as_matrix(), np.expand_dims(mat[0], axis=0), atol=1e-15)
 
 
 def test_n_rotations():

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -635,14 +635,22 @@ def test_single_identity_magnitude():
 def test_identity_invariance():
     n = 10
     p = Rotation.random(n)
-    result = p * Rotation.identity(n) * p.inv()
+
+    result = p * Rotation.identity(n)
+    assert_array_almost_equal(p.as_quat(), result.as_quat())
+
+    result = result * p.inv()
     assert_array_almost_equal(result.magnitude(), np.zeros(n))
 
 
 def test_single_identity_invariance():
     n = 10
     p = Rotation.random(n)
-    result = p * Rotation.identity() * p.inv()
+
+    result = p * Rotation.identity()
+    assert_array_almost_equal(p.as_quat(), result.as_quat())
+
+    result = result * p.inv()
     assert_array_almost_equal(result.magnitude(), np.zeros(n))
 
 
@@ -869,20 +877,6 @@ def test_n_rotations():
     assert_equal(len(r[0]), 1)
     assert_equal(len(r[1]), 1)
     assert_equal(len(r[:-1]), 1)
-
-
-def test_quat_ownership():
-    # Ensure that users cannot accidentally corrupt object
-    quat = np.array([
-        [1, 0, 0, 0],
-        [0, 1, 0, 0],
-        [0, 0, 1, 0]
-    ])
-    r = Rotation.from_quat(quat)
-    s = r[0:2]
-
-    r._quat[0] = np.array([0, -1, 0, 0])
-    assert_allclose(s._quat[0], np.array([1, 0, 0, 0]))
 
 
 def test_align_vectors_no_rotation():

--- a/scipy/spatial/transform/tests/test_rotation_spline.py
+++ b/scipy/spatial/transform/tests/test_rotation_spline.py
@@ -103,12 +103,12 @@ def test_constant_attitude():
 
     times_check = np.linspace(-1, 11)
     assert_allclose(spline(times_check).as_rotvec(), 1, rtol=1e-15)
-    assert_allclose(spline(times_check, 1), 0, atol=1e-19)
-    assert_allclose(spline(times_check, 2), 0, atol=1e-19)
+    assert_allclose(spline(times_check, 1), 0, atol=1e-17)
+    assert_allclose(spline(times_check, 2), 0, atol=1e-17)
 
     assert_allclose(spline(5.5).as_rotvec(), 1, rtol=1e-15)
-    assert_allclose(spline(5.5, 1), 0, atol=1e-19)
-    assert_allclose(spline(5.5, 2), 0, atol=1e-19)
+    assert_allclose(spline(5.5, 1), 0, atol=1e-17)
+    assert_allclose(spline(5.5, 2), 0, atol=1e-17)
 
 
 def test_spline_properties():


### PR DESCRIPTION
#### What does this implement/fix?
I cythonized part of the code in `scipy.spatial.transform.Rotation`. I used this package a lot in my own projects and I found that sometimes the quaternion operations could be a bottleneck, so I wrote a Cython version of the Rotation class.

I only implemented part of its member functions and left others as it was. I also ran the tests locally and they passed. Please help me with more testing and maybe more optimization.

Also note that since cython doesn't support `np.deprecate` decorator, I removed them in the cython version. Since those functions will be depricated in the next version, I think it will be ok.

#### Additional information
Here is a small benchmark
```python
import timeit

def benchmark():
    m, n = 10000, 10
    setup_str = '''
import numpy as np
from scipy.spatial.transform import Rotation
np.random.seed(12345)
'''

    matrix_test = f'''Rotation.from_matrix(Rotation.random({n}).as_matrix())'''
    print(timeit.timeit(matrix_test, setup=setup_str, number=m))

    euler_test = f'''Rotation.from_euler("XYZ", Rotation.random({n}).as_euler("XYZ"))'''
    print(timeit.timeit(euler_test, setup=setup_str, number=m))

    rotvec_test = f'''Rotation.from_rotvec(Rotation.random({n}).as_rotvec())'''
    print(timeit.timeit(rotvec_test, setup=setup_str, number=m))

    mul_inv_test = f'''Rotation.random({n}) * Rotation.random({n}).inv()'''
    print(timeit.timeit(mul_inv_test, setup=setup_str, number=m))

if __name__ == "__main__":
    benchmark()
```
In my PC, the original python version yields:
```
1.1189252500189468
3.943033237999771
0.8586579390102997
1.1278571970178746
```
Cython version yields
```
0.24510287103476003
1.0782683069701307
0.18285539897624403
0.28258025902323425
```

Although the difference of them will become smaller as n becomes larger, I still find it useful since usually I'm not storing the quaternions in a single Rotation object.