### PR TITLE
BLD: fix musl compilation

### DIFF
--- a/scipy/optimize/rectangular_lsap/rectangular_lsap.cpp
+++ b/scipy/optimize/rectangular_lsap/rectangular_lsap.cpp
@@ -44,6 +44,7 @@ Author: PM Larsen
 #include <cmath>
 #include "rectangular_lsap.h"
 #include <vector>
+#include <stdint.h>
 
 static int
 augmenting_path(int nc, std::vector<double>& cost, std::vector<double>& u,


### PR DESCRIPTION
Includes `stdint.h` for `int64_t` on musl.

Fixes https://travis-ci.org/github/void-linux/void-packages/jobs/693626521.