### PR TITLE
MAINT: Fix a DeprecationWarning in validate_runtests_log.py.

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -125,9 +125,9 @@ warnings.filterwarnings('error')
 warnings.filterwarnings('default', module='sphinx')  # internal warnings
 # global weird ones that can be safely ignored
 for key in (
-        "'U' mode is deprecated",  # sphinx io
-        "OpenSSL\.rand is deprecated",  # OpenSSL package in linkcheck
-        "Using or importing the ABCs from",  # 3.5 importlib._bootstrap
+        r"'U' mode is deprecated",  # sphinx io
+        r"OpenSSL\.rand is deprecated",  # OpenSSL package in linkcheck
+        r"Using or importing the ABCs from",  # 3.5 importlib._bootstrap
         ):
     warnings.filterwarnings(  # deal with other modules having bad imports
         'ignore', message=".*" + key, category=DeprecationWarning)

--- a/scipy/io/arff/arffread.py
+++ b/scipy/io/arff/arffread.py
@@ -39,7 +39,7 @@ r_datameta = re.compile(r'^@[Dd][Aa][Tt][Aa]')
 r_relation = re.compile(r'^@[Rr][Ee][Ll][Aa][Tt][Ii][Oo][Nn]\s*(\S*)')
 r_attribute = re.compile(r'^\s*@[Aa][Tt][Tt][Rr][Ii][Bb][Uu][Tt][Ee]\s*(..*$)')
 
-r_nominal = re.compile('{(.+)}')
+r_nominal = re.compile(r'{(.+)}')
 r_date = re.compile(r"[Dd][Aa][Tt][Ee]\s+[\"']?(.+?)[\"']?$")
 
 # To get attributes name enclosed with ''

--- a/tools/authors.py
+++ b/tools/authors.py
@@ -133,7 +133,7 @@ def load_name_map(filename):
             if line.startswith(u"#") or not line:
                 continue
 
-            m = re.match(u'^(.*?)\s*<(.*?)>(.*?)\s*<(.*?)>\s*$', line)
+            m = re.match(r'^(.*?)\s*<(.*?)>(.*?)\s*<(.*?)>\s*$', line)
             if not m:
                 print("Invalid line in .mailmap: '{!r}'".format(line), file=sys.stderr)
                 sys.exit(1)

--- a/tools/cythonize.py
+++ b/tools/cythonize.py
@@ -279,7 +279,7 @@ def find_process_files(root_dir):
                     toext = ".c"
                     with open(os.path.join(cur_dir, filename), 'rb') as f:
                         data = f.read()
-                        m = re.search(br"^\s*#\s*distutils:\s*language\s*=\s*c\+\+\s*$", data, re.I|re.M)
+                        m = re.search(br"^\s*#\s*distutils:\s*language\s*=\s*c\+\+\s*$", data, re.I | re.M)
                         if m:
                             toext = ".cxx"
                     fromfile = filename

--- a/tools/cythonize.py
+++ b/tools/cythonize.py
@@ -181,9 +181,9 @@ def get_cython_dependencies(fullfrompath):
     fullfromdir = os.path.dirname(fullfrompath)
     deps = set()
     with open(fullfrompath, 'r') as f:
-        pxipattern = re.compile('include "([a-zA-Z0-9_]+\.pxi)"')
-        pxdpattern1 = re.compile('from \. cimport ([a-zA-Z0-9_]+)')
-        pxdpattern2 = re.compile('from \.([a-zA-Z0-9_]+) cimport')
+        pxipattern = re.compile(r'include "([a-zA-Z0-9_]+\.pxi)"')
+        pxdpattern1 = re.compile(r'from \. cimport ([a-zA-Z0-9_]+)')
+        pxdpattern2 = re.compile(r'from \.([a-zA-Z0-9_]+) cimport')
 
         for line in f:
             m = pxipattern.match(line)

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -238,7 +238,7 @@ def test_setup(arches):
         try:
             try:
                 target = setup_openblas(arch, ilp64)
-            except:
+            except Exception:
                 print(f'Could not setup {arch}')
                 raise
             if not target:
@@ -272,7 +272,7 @@ def test_version(expected_version, ilp64=get_ilp64()):
         get_config = dll.openblas_get_config64_
     else:
         get_config = dll.openblas_get_config
-    get_config.restype=ctypes.c_char_p
+    get_config.restype = ctypes.c_char_p
     res = get_config()
     print('OpenBLAS get_config returned', str(res))
     check_str = b'OpenBLAS %s' % expected_version[0].encode()
@@ -286,10 +286,11 @@ def test_version(expected_version, ilp64=get_ilp64()):
     else:
         assert b"USE64BITINT" not in res
 
+
 if __name__ == '__main__':
     import argparse
     parser = argparse.ArgumentParser(
-        description='Download and expand an OpenBLAS archive for this ' \
+        description='Download and expand an OpenBLAS archive for this '
                     'architecture')
     parser.add_argument('--test', nargs='*', default=None,
         help='Test different architectures. "all", or any of %s' % ARCHITECTURES)

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -518,7 +518,7 @@ class DTRunner(doctest.DocTestRunner):
                                                     example, got)
 
 class Checker(doctest.OutputChecker):
-    obj_pattern = re.compile('at 0x[0-9a-fA-F]+>')
+    obj_pattern = re.compile(r'at 0x[0-9a-fA-F]+>')
     vanilla = doctest.OutputChecker()
     rndm_markers = {'# random', '# Random', '#random', '#Random', "# may vary"}
     stopwords = {'plt.', '.hist', '.show', '.ylim', '.subplot(',
@@ -590,9 +590,9 @@ class Checker(doctest.OutputChecker):
             # and then compare the tuples.
             try:
                 num = len(a_want)
-                regex = ('[\w\d_]+\(' +
-                         ', '.join(['[\w\d_]+=(.+)']*num) +
-                         '\)')
+                regex = (r'[\w\d_]+\(' +
+                         ', '.join([r'[\w\d_]+=(.+)']*num) +
+                         r'\)')
                 grp = re.findall(regex, got.replace('\n', ' '))
                 if len(grp) > 1:  # no more than one for now
                     return False

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -406,7 +406,6 @@ def check_rest(module, names, dots=True):
         # python 3
         skip_types = (dict, str, float, int)
 
-
     results = []
 
     if module.__name__[6:] not in OTHER_MODULE_DOCS:
@@ -607,9 +606,9 @@ class Checker(doctest.OutputChecker):
             return self._do_check(a_want, a_got)
         except Exception:
             # heterog tuple, eg (1, np.array([1., 2.]))
-           try:
+            try:
                 return all(self._do_check(w, g) for w, g in zip(a_want, a_got))
-           except (TypeError, ValueError):
+            except (TypeError, ValueError):
                 return False
 
     def _do_check(self, want, got):
@@ -636,6 +635,7 @@ def _run_doctests(tests, full_name, verbose, doctest_warnings):
     success = True
     # Redirect stderr to the stdout or output
     tmp_stderr = sys.stdout if doctest_warnings else output
+
     @contextmanager
     def temp_cwd():
         cwd = os.getcwd()
@@ -775,7 +775,7 @@ def check_doctests_testfile(fname, verbose, ns=None,
     PSEUDOCODE = set(['some_function', 'some_module', 'import example',
                       'ctypes.CDLL',     # likely need compiling, skip it
                       'integrate.nquad(func,'  # ctypes integrate tutotial
-    ])
+                      ])
 
     # split the text into "blocks" and try to detect and omit pseudocode blocks.
     parser = doctest.DocTestParser()
@@ -908,7 +908,8 @@ def main(argv):
             tut_results = check_doctests_testfile(filename, (args.verbose >= 2),
                     dots=dots, doctest_warnings=args.doctest_warnings)
 
-            def scratch(): pass        # stub out a "module", see below
+            def scratch():
+                pass        # stub out a "module", see below
             scratch.__name__ = filename
             results.append((scratch, tut_results))
 

--- a/tools/refguide_summaries.py
+++ b/tools/refguide_summaries.py
@@ -77,7 +77,7 @@ def main():
                         doc = getattr(module, func).__doc__.split('\n')
                         i = 0 if doc[0].strip() else 1
                         while True:
-                            if re.match(func + '\(.*\)', doc[i].strip()):
+                            if re.match(func + r'\(.*\)', doc[i].strip()):
                                 # ufunc docstrings contain the signature
                                 i +=2
                             else:

--- a/tools/refguide_summaries.py
+++ b/tools/refguide_summaries.py
@@ -59,14 +59,14 @@ def main():
         while line:
             if '.. autosummary::' in line:
                 fnew.append(line.rstrip())
-                fnew.append(f.readline().rstrip()) # :toctree: generated/
-                fnew.append(f.readline().rstrip()) # blank line
+                fnew.append(f.readline().rstrip())  # :toctree: generated/
+                fnew.append(f.readline().rstrip())  # blank line
                 line = f.readline()
                 summaries = []
                 maxlen = 0
                 while line.strip():
                     func = line.split('--')[0].strip()
-                    ufunc = not '[+]' in line
+                    ufunc = '[+]' not in line
                     if len(func) > maxlen:
                         maxlen = len(func)
 
@@ -79,7 +79,7 @@ def main():
                         while True:
                             if re.match(func + r'\(.*\)', doc[i].strip()):
                                 # ufunc docstrings contain the signature
-                                i +=2
+                                i += 2
                             else:
                                 break
                         while i < len(doc) and doc[i].strip():

--- a/tools/suppress_output.py
+++ b/tools/suppress_output.py
@@ -182,8 +182,8 @@ def test_suppress_long_ok(tmpdir):
                                            'sys.exit(0)')
     assert returncode == 0
     assert out == b''
-    assert re.match(b'^    \.\.\. in progress \([0-9 sminh]* elapsed\)\n'
-                    b'    \.\.\. ok \([0-9 sminh]* elapsed\)\n$', err,
+    assert re.match(rb'^    \.\.\. in progress \([0-9 sminh]* elapsed\)\n'
+                    rb'    \.\.\. ok \([0-9 sminh]* elapsed\)\n$', err,
                     re.S)
 
 
@@ -197,8 +197,8 @@ def test_suppress_long_failed(tmpdir):
                                            'sys.exit(1)')
     assert returncode == 1
     assert out == b'OUTERR'
-    assert re.match(b'^    \.\.\. in progress \([0-9 sminh]* elapsed\)\n'
-                    b'    \.\.\. failed \([0-9 sminh]* elapsed, exit code 1\)\n$', err,
+    assert re.match(rb'^    \.\.\. in progress \([0-9 sminh]* elapsed\)\n'
+                    rb'    \.\.\. failed \([0-9 sminh]* elapsed, exit code 1\)\n$', err,
                     re.S)
 
 

--- a/tools/validate_runtests_log.py
+++ b/tools/validate_runtests_log.py
@@ -35,8 +35,8 @@ if __name__ == "__main__":
                      'fast': 10000}
 
     # read in the log, parse for the pytest printout
-    r1 = re.compile("(?P<num_failed>\d+) failed, (?P<num_passed>\d+) passed,.* in (?P<time>\d+\S+)")
-    r2 = re.compile("(?P<num_passed>\d+) passed,.* in (?P<time>\d+\S+)")
+    r1 = re.compile(r"(?P<num_failed>\d+) failed, (?P<num_passed>\d+) passed,.* in (?P<time>\d+\S+)")
+    r2 = re.compile(r"(?P<num_passed>\d+) passed,.* in (?P<time>\d+\S+)")
 
     found_it = False
     while True:


### PR DESCRIPTION
Turned some regex string literals in validate_runtests_log.py into raw string literals.
Fix some pycodestyle warnings in tools/ and doc/

#### Reference issue
Closes gh-11366

#### What does this implement/fix?
Added raw qualifier onto some string literals used for regular expressions,

