### PR TITLE
DOC: Clarify area/volume in scipy.spatial.ConvexHull docstrings

### DIFF
--- a/scipy/spatial/qhull.pyx
+++ b/scipy/spatial/qhull.pyx
@@ -2323,11 +2323,13 @@ class ConvexHull(_QhullUser):
 
         .. versionadded:: 1.3.0
     area : float
-        Area of the convex hull.
+        Surface area of the convex hull when input dimension > 2. 
+        When input `points` are 2-dimensional, this is the perimeter of the convex hull.
 
         .. versionadded:: 0.17.0
     volume : float
-        Volume of the convex hull.
+        Volume of the convex hull when input dimension > 2. 
+        When input `points` are 2-dimensional, this is the area of the convex hull. 
 
         .. versionadded:: 0.17.0
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
This clarifies the docstrings for convex hull areas/volumes in `scipy.spatial` for 2-dimensional input, resolving #12290 

#### What does this implement/fix?
<!--Please explain your changes.-->
This changes docstrings for `scipy.spatial.ConvexHull`. 
#### Additional information
<!--Any additional information you think is important.-->
None. 