### PR TITLE
CI: Run travis builds on master to keep cache up to date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
 matrix:
   include:
     - python: 3.6
-      if: type = pull_request
+      name: "Lint"
       env:
         - PYFLAKES=1
         - PEP8=1
@@ -42,7 +42,7 @@ matrix:
         - |
           grep -rlIP '[^\x00-\x7F]' scipy | grep '\.pyx\?' | sort > unicode.out; grep -rlI '# -\*- coding: \(utf-8\|latin-1\) -\*-' scipy | grep '\.pyx\?' | sort > coding.out; comm -23 unicode.out coding.out > test_code.out; cat test_code.out;  test \! -s test_code.out
     - python: 3.7
-      if: type = pull_request
+      name: "ARM - Test Group 1"
       arch: arm64
       dist: bionic
       env:
@@ -54,7 +54,7 @@ matrix:
         - TEST_GROUP_COUNT=2
         - TEST_GROUP=1
     - python: 3.7
-      if: type = pull_request
+      name: "ARM - Test Group 2"
       arch: arm64
       dist: bionic
       env:
@@ -66,7 +66,7 @@ matrix:
         - TEST_GROUP_COUNT=2
         - TEST_GROUP=2
     - python: 3.7
-      if: type = pull_request
+      name: "Pre-release Dependencies, Source Dist"
       env:
         - TESTMODE=fast
         - COVERAGE=
@@ -77,7 +77,7 @@ matrix:
         # specify in pyproject.toml (will be older than --pre --upgrade) works
         - USE_SDIST=1
     - python: 3.7
-      if: type = pull_request
+      name: "Coverage, Full test suite"
       env:
         - TESTMODE=full
         - COVERAGE="--coverage --gcov"
@@ -86,7 +86,7 @@ matrix:
     # However travis only specifies regular or development builds of Python
     # so we must install python3.6-dbg using apt.
     - language: generic
-      if: type = pull_request
+      name: "Python 3.7 Debug"
       dist: bionic
       env:
         - USE_DEBUG=python3.7-dbg
@@ -99,14 +99,14 @@ matrix:
             - python3.7-dbg
             - python3.7-dev
     - python: 3.8
-      if: type = pull_request
+      name: "Pre-release Deps, 64-bit BLAS"
       env:
         - TESTMODE=full
         - NUMPYSPEC="--pre --upgrade --timeout=60 -i $PRE_WHEELS numpy"
         - OTHERSPEC="--pre --upgrade --timeout=60"
         - NPY_USE_BLAS_ILP64=1
     - python: 3.6
-      if: type = pull_request
+      name: "Refguide-check, Latest NumPy"
       env:
         - TESTMODE=fast
         - COVERAGE=
@@ -115,14 +115,14 @@ matrix:
         - NUMPYSPEC="--upgrade numpy"
         - ASV_CHECK=1
     - python: 3.6
-      if: type = pull_request
+      name: "Source Distribution"
       env:
         - TESTMODE=fast
         - COVERAGE=
         - NUMPYSPEC="numpy==1.17.4"
         - USE_SDIST=1
     - python: 3.6
-      if: type = pull_request
+      name: "Wheel, Optimised"
       env:
         - TESTMODE=fast
         - COVERAGE=
@@ -133,7 +133,7 @@ matrix:
         # flag. This environment variable starts all Py instances in -OO mode.
         - PYTHONOPTIMIZE=2
     - python: 3.6
-      if: type = pull_request
+      name: "Power PC"
       os: linux
       arch: ppc64le
       env:
@@ -268,20 +268,33 @@ script:
         USE_WHEEL_BUILD="--no-build"
     fi
   - export SCIPY_AVAILABLE_MEM=3G
-  - python -u runtests.py -g -m $TESTMODE $COVERAGE $USE_WHEEL_BUILD -- -rfEX --durations=10 -n 3 $TEST_GROUP_ARGS 2>&1 | tee runtests.log
-
-  - tools/validate_runtests_log.py $TESTMODE < runtests.log
-  - if [ "${REFGUIDE_CHECK}" == "1" ]; then python runtests.py -g --refguide-check; fi
-  - if [ "${ASV_CHECK}" == "1" ]; then (cd benchmarks && python -masv check -E existing); fi
+  - python -u runtests.py -g -j2 --build-only $USE_WHEEL_BUILD
+  # Only run tests against pull-requests
+  - |
+    if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
+      python -u runtests.py -g -j2 -m $TESTMODE $COVERAGE $USE_WHEEL_BUILD -- -rfEX --durations=10 $TEST_GROUP_ARGS 2>&1 | tee runtests.log
+      tools/validate_runtests_log.py $TESTMODE < runtests.log
+    fi
+  - |
+    if [ "${TRAVIS_PULL_REQUEST}" != "false" ] && [ "${REFGUIDE_CHECK}" == "1" ]; then
+      python runtests.py -g --refguide-check
+    fi
+  - |
+    if [ "${TRAVIS_PULL_REQUEST}" != "false" ] && [ "${ASV_CHECK}" == "1" ]; then
+      (cd benchmarks && python -masv check -E existing)
+    fi
   # Check dynamic symbol hiding works on Linux
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./tools/check_pyext_symbol_hiding.sh build; fi
+  - |
+    if [ "${TRAVIS_PULL_REQUEST}" != "false" ] && [ "$TRAVIS_OS_NAME" == "linux" ]; then
+      ./tools/check_pyext_symbol_hiding.sh build
+    fi
 
 
 after_script:
   - ccache -s
   # Upload coverage information
   - |
-    if [ -n "${COVERAGE}" ]; then
+    if [ "${TRAVIS_PULL_REQUEST}" != "false" ] && [ -n "${COVERAGE}" ]; then
         RUN_DIR=`echo build/testenv/lib/python*/site-packages`
         # Produce gcov output for codecov to find
         find build -name '*.gcno' -type f -exec gcov -pb {} +

--- a/.travis.yml
+++ b/.travis.yml
@@ -154,6 +154,7 @@ before_install:
     if [ "$TRAVIS_OS_NAME" == "linux" ]; then
       free -m
       export PATH=/usr/lib/ccache:$PATH
+      ccache --zero-stats
     fi
   - |
     if [[ "$NPY_USE_BLAS_ILP64" == "1" ]]; then


### PR DESCRIPTION
When a PR first runs on travis-ci, the cache from the master branch is used as the basis for the first build. Since gh-11287, travis-ci no longer runs on the master branch. This means all PRs start with either outdated caches, or no cache at all.

For example, the newly added ARM test group builds have no cache whatsoever and have to do a full rebuild for each new PR. See the "setting up build cache" in this travis log, where it says "could not download cache":
https://travis-ci.org/github/scipy/scipy/jobs/693779972#L308

As a middle ground, this PR runs the build on master but not the tests. That should be sufficient to prime the caches but still put less strain on the travis workers. I also added a name for each job since it's very hard to tell which jobs are which at a glance in the travis UI.