### PR TITLE
BUG: fmin_powell return for size 1 array

### DIFF
--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -2657,7 +2657,8 @@ def _linesearch_powell(func, p, xi, tol=1e-3,
 
     # if xi is zero, then don't optimize
     if not np.any(xi):
-        return ((fval, p, xi) if fval is not None else (func(p), p, xi))
+        fret = fval if fval is not None else func(p)
+        return (np.squeeze(fret), p, xi)
     elif lower_bound is None and upper_bound is None:
         # non-bounded minimization
         alpha_min, fret, _, _ = brent(myfunc, full_output=1, tol=tol)
@@ -2813,6 +2814,7 @@ def fmin_powell(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None,
             'return_all': retall}
 
     res = _minimize_powell(func, x0, args, callback=callback, **opts)
+    res['x'] = squeeze(res['x'])
 
     if full_output:
         retlist = (res['x'], res['fun'], res['direc'], res['nit'],

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -257,6 +257,22 @@ class CheckOptimizeParameterized(CheckOptimize):
             assert self.funccalls <= 131 + 20
             assert self.gradcalls == 0
 
+    def test_powell_return_length_1(self):
+        # the historic behaviour of fmin_powell was to return np.array(0) for
+        # a minimize whose x0 has size 1. See gh12298. This is probably a bug
+        # we we retain for back compatibility.
+        # x0 = np.array([0]) --> np.array(0)
+        dummy_func = lambda x: x**2
+
+        if self.use_wrapper:
+            res = optimize.minimize(dummy_func, [1], method='Powell')
+            xopt = res.x
+            assert xopt.shape == (1,)
+        else:
+            xopt = optimize.fmin_powell(dummy_func, [1])
+            assert xopt.shape == ()
+        assert xopt.size == 1
+
     def test_neldermead(self):
         # Nelder-Mead simplex algorithm
         if self.use_wrapper:


### PR DESCRIPTION
Fixes #12298. However, I think the original behaviour was a bug. The original behaviour for `fmin_powell` was:
```
x0 = np.array([0.])
x0.shape = (1,)
x0.size = 1

# the result array is
res.x = np.array(0.)
res.x.shape = ()
res.x.size=1
```

 This PR ensures back compatibility. However, I think the desired behaviour should be:
```
res.x = np.array([0.])
res.x.shape = (1,)
res.x.size = 1
```

If it's important to maintain this (buggy?) back compatibility then we should merge the PR and make sure it gets cherry picked into 1.5.0 (@tylerjereddy ).

@pv, @josef-pkt 