### PR TITLE
TST: Cleanup print statements in tests

### DIFF
--- a/scipy/interpolate/tests/test_interpnd.py
+++ b/scipy/interpolate/tests/test_interpnd.py
@@ -233,8 +233,8 @@ class TestCloughTocher2DInterpolator(object):
         try:
             assert_allclose(a, b, **kw)
         except AssertionError:
-            print(abs(a - b))
-            print(ip.grad)
+            print("_check_accuracy: abs(a-b):", abs(a - b))
+            print("ip.grad:", ip.grad)
             raise
 
     def test_linear_smoketest(self):

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -1034,7 +1034,6 @@ class TestDifferentialEvolutionSolver(object):
 
         x_opt = (1.22797135, 4.24537337)
         f_opt = -0.095825
-        print(res)
         assert_allclose(f(x_opt), f_opt, atol=2e-5)
         assert_allclose(res.fun, f_opt, atol=1e-4)
         assert res.success

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1499,7 +1499,6 @@ class TestF(object):
         data = [[stats.f, (2, 1), 1.0]]
         for _f, _args, _correct in data:
             ans = _f.pdf(_f.a, *_args)
-            print(_f, (_args), ans, _correct, ans == _correct)
 
         ans = [_f.pdf(_f.a, *_args) for _f, _args, _ in data]
         correct = [_correct_ for _f, _args, _correct_ in data]

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3209,7 +3209,6 @@ class TestKSTwoSamples(object):
         np.random.seed(123456)
         x = np.random.normal(size=3000)
         y = np.random.normal(size=3001) * 1.5
-        print(x[0], x[-1], y[0], y[-1])
         self._testOne(x, y, 'two-sided', 0.11292880151060758, 2.7755575615628914e-15, mode='asymp')
         self._testOne(x, y, 'two-sided', 0.11292880151060758, 2.7755575615628914e-15, mode='exact')
 
@@ -3218,7 +3217,6 @@ class TestKSTwoSamples(object):
         np.random.seed(123456)
         x = np.random.normal(size=10000)
         y = np.random.normal(size=10001) * 1.5
-        print(x[0], x[-1], y[0], y[-1])
         self._testOne(x, y, 'two-sided', 0.10597913208679133, 3.3149311398483503e-49, mode='asymp')
         self._testOne(x, y, 'two-sided', 0.10597913208679133, 2.7755575615628914e-15, mode='exact')
         self._testOne(x, y, 'greater', 0.10597913208679133, 2.7947433906389253e-41, mode='asymp')


### PR DESCRIPTION
It would be nice if `python runtests.py -- -s` didn't have so many random print statements.

Not all of these are triggered under `--mode fast` but feels nice to remove prints that lack context.

I looked at Azure logs and it doesn't seem any of these are flaky tests.