### PR TITLE
BUG: prevent error accumulation in `Rotation` multiplication

### DIFF
--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -1413,7 +1413,7 @@ class Rotation(object):
         result = _compose_quat(self._quat, other._quat)
         if self._single and other._single:
             result = result[0]
-        return self.__class__(result, normalize=False, copy=False)
+        return self.__class__(result, normalize=True, copy=False)
 
     def inv(self):
         """Invert this rotation.

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -1124,3 +1124,11 @@ def test_slerp_call_scalar_time():
     delta = r_interpolated * r_interpolated_expected.inv()
 
     assert_allclose(delta.magnitude(), 0, atol=1e-16)
+
+
+def test_multiplication_stability():
+    qs = Rotation.random(50, random_state=0)
+    rs = Rotation.random(1000, random_state=1)
+    for q in qs:
+        rs *= q * rs
+        assert_allclose(np.linalg.norm(rs.as_quat(), axis=1), 1)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #12314

#### What does this implement/fix?
<!--Please explain your changes.-->
After multiplication, the quaternions used in the internal representation of the `Rotation` class are normalized. This prevents error accumulation in the quaternion norms.

#### Additional information
<!--Any additional information you think is important.-->
Normalization incurs a small performance penalty, but I think this is a good trade-off considering that the `Rotation` class can otherwise mysteriously turn into NaNs.

Perhaps a backport candidate?