### PR TITLE
 BUG: spatial: avoid returning negative correlation distance

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -712,7 +712,7 @@ def correlation(u, v, w=None, centered=True):
     uu = np.average(np.square(u), weights=w)
     vv = np.average(np.square(v), weights=w)
     dist = 1.0 - uv / np.sqrt(uu * vv)
-    return dist
+    return np.abs(dist)
 
 
 def cosine(u, v, w=None):

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -712,6 +712,7 @@ def correlation(u, v, w=None, centered=True):
     uu = np.average(np.square(u), weights=w)
     vv = np.average(np.square(v), weights=w)
     dist = 1.0 - uv / np.sqrt(uu * vv)
+    # Return absolute value to avoid small negative value due to rounding
     return np.abs(dist)
 
 

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -1573,6 +1573,15 @@ class TestSomeDistanceFunctions(object):
             dist = wcorrelation(x, y)
             assert_almost_equal(dist, 1.0 - np.dot(xm, ym) / (norm(xm) * norm(ym)))
 
+    def test_correlation_positive(self):
+        x = np.array([ 0.,  0.,  0.,  0.,  0.,  0., -2.,  0.,  0.,  0., -2., -2., -2.,  0., -2.,  0., -2.,  0.,
+           0., -1., -2.,  0.,  1.,  0.,  0., -2.,  0.,  0., -2.,  0., -2., -2., -2., -2., -2., -2., 0.,])
+        y = np.array([ 1.,  1.,  1.,  1.,  1.,  1., -1.,  1.,  1.,  1., -1., -1., -1.,  1., -1.,  1., -1.,  1.,
+           1.,  0., -1.,  1.,  2.,  1.,  1., -1.,  1.,  1., -1.,  1., -1., -1., -1., -1., -1., -1., 1.,])
+        dist = wcorrelation(x,y)
+        assert dist >= 0
+        assert_almost_equal(dist, 0)
+
     def test_mahalanobis(self):
         x = np.array([1.0, 2.0, 3.0])
         y = np.array([1.0, 1.0, 5.0])

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -1574,13 +1574,15 @@ class TestSomeDistanceFunctions(object):
             assert_almost_equal(dist, 1.0 - np.dot(xm, ym) / (norm(xm) * norm(ym)))
 
     def test_correlation_positive(self):
-        x = np.array([ 0.,  0.,  0.,  0.,  0.,  0., -2.,  0.,  0.,  0., -2., -2., -2.,  0., -2.,  0., -2.,  0.,
-           0., -1., -2.,  0.,  1.,  0.,  0., -2.,  0.,  0., -2.,  0., -2., -2., -2., -2., -2., -2., 0.,])
-        y = np.array([ 1.,  1.,  1.,  1.,  1.,  1., -1.,  1.,  1.,  1., -1., -1., -1.,  1., -1.,  1., -1.,  1.,
-           1.,  0., -1.,  1.,  2.,  1.,  1., -1.,  1.,  1., -1.,  1., -1., -1., -1., -1., -1., -1., 1.,])
-        dist = wcorrelation(x,y)
-        assert dist >= 0
-        assert_almost_equal(dist, 0)
+        # Regression test for gh-12320 (negative return value due to rounding
+        x = np.array([0., 0., 0., 0., 0., 0., -2., 0., 0., 0., -2., -2., -2.,
+                      0., -2., 0., -2., 0., 0., -1., -2., 0., 1., 0., 0., -2.,
+                      0., 0., -2., 0., -2., -2., -2., -2., -2., -2., 0.])
+        y = np.array([1., 1., 1., 1., 1., 1., -1., 1., 1., 1., -1., -1., -1.,
+                      1., -1., 1., -1., 1., 1., 0., -1., 1., 2., 1., 1., -1.,
+                      1., 1., -1., 1., -1., -1., -1., -1., -1., -1., 1.])
+        dist = correlation(x, y)
+        assert 0 <= dist <= 10 * np.finfo(np.float64).eps
 
     def test_mahalanobis(self):
         x = np.array([1.0, 2.0, 3.0])


### PR DESCRIPTION
Correlation distance should be positive but negative values are possible due to rounding errors.

#### Reference issue
Closes issue #12316

#### What does this implement/fix?
Added absolute value on return value to resolve this issue.
Added a test with matching example and assertion.
