### PR TITLE
ENH: Add a Bunch-like class to use as a backwards compatible return value.

### DIFF
--- a/scipy/_lib/_bunch.py
+++ b/scipy/_lib/_bunch.py
@@ -1,0 +1,146 @@
+
+import sys as _sys
+from keyword import iskeyword as _iskeyword
+
+
+def _validate_names(typename, field_names, extra_field_names):
+    """
+    Ensure that all the given names are valid Python identifiers that
+    do not start with '_'.  Also check that there are no duplicates
+    among field_names + extra_field_names.
+    """
+    for name in [typename] + field_names + extra_field_names:
+        if type(name) is not str:
+            raise TypeError('typename and all field names must be strings')
+        if not name.isidentifier():
+            raise ValueError('typename and all field names must be valid '
+                             f'identifiers: {name!r}')
+        if _iskeyword(name):
+            raise ValueError('typename and all field names cannot be a '
+                             f'keyword: {name!r}')
+
+    seen = set()
+    for name in field_names + extra_field_names:
+        if name.startswith('_'):
+            raise ValueError('Field names cannot start with an underscore: '
+                             f'{name!r}')
+        if name in seen:
+            raise ValueError(f'Duplicate field name: {name!r}')
+        seen.add(name)
+
+
+# Note: This code is adapted from CPython:Lib/collections/__init__.py
+def make_tuple_bunch(typename, field_names, extra_field_names=None,
+                     module=None):
+    if len(field_names) == 0:
+        raise ValueError('field_names must contain at least one name')
+
+    if extra_field_names is None:
+        extra_field_names = []
+    _validate_names(typename, field_names, extra_field_names)
+
+    typename = _sys.intern(str(typename))
+    field_names = tuple(map(_sys.intern, field_names))
+    extra_field_names = tuple(map(_sys.intern, extra_field_names))
+
+    all_names = field_names + extra_field_names
+    arg_list = ', '.join(field_names)
+    full_list = ', '.join(all_names)
+    repr_fmt = ''.join(('(',
+                        ', '.join(f'{name}=%({name})r' for name in all_names),
+                        ')'))
+    tuple_new = tuple.__new__
+    _dict, _tuple, _zip = dict, tuple, zip
+
+    # Create all the named tuple methods to be added to the class namespace
+
+    s = f"""\
+def __new__(_cls, {arg_list}, **extra_fields):
+    return _tuple_new(_cls, ({arg_list},))
+
+def __init__(self, {arg_list}, **extra_fields):
+    for key in self._extra_fields:
+        if key not in extra_fields:
+            raise TypeError("missing keyword argument '%s'" % (key,))
+    for key, val in extra_fields.items():
+        if key not in self._extra_fields:
+            raise TypeError("unexpected keyword argument '%s'" % (key,))
+        self.__dict__[key] = val
+
+def __setattr__(self, key, val):
+    raise AttributeError("can't set attribute %r of class %r"
+                         % (key, self.__class__.__name__))
+"""
+    del arg_list
+    namespace = {'_tuple_new': tuple_new,
+                 '__builtins__': dict(TypeError=TypeError,
+                                      AttributeError=AttributeError),
+                 '__name__': f'namedtuple_{typename}'}
+    exec(s, namespace)
+    __new__ = namespace['__new__']
+    __new__.__doc__ = f'Create new instance of {typename}({full_list})'
+    __init__ = namespace['__init__']
+    __init__.__doc__ = f'Instantiate instance of {typename}({full_list})'
+    __setattr__ = namespace['__setattr__']
+
+    def __repr__(self):
+        'Return a nicely formatted representation string'
+        return self.__class__.__name__ + repr_fmt % self._asdict()
+
+    def _asdict(self):
+        'Return a new dict which maps field names to their values.'
+        out = _dict(_zip(self._fields, self))
+        out.update(self.__dict__)
+        return out
+
+    def __getnewargs_ex__(self):
+        'Return self as a plain tuple.  Used by copy and pickle.'
+        return _tuple(self), self.__dict__
+
+    # Modify function metadata to help with introspection and debugging
+    for method in (__new__, __repr__, _asdict, __getnewargs_ex__):
+        method.__qualname__ = f'{typename}.{method.__name__}'
+
+    # Build-up the class namespace dictionary
+    # and use type() to build the result class
+    class_namespace = {
+        '__doc__': f'{typename}({full_list})',
+        '_fields': field_names,
+        '__new__': __new__,
+        '__init__': __init__,
+        '__repr__': __repr__,
+        '__setattr__': __setattr__,
+        '_asdict': _asdict,
+        '_extra_fields': extra_field_names,
+        '__getnewargs_ex__': __getnewargs_ex__,
+    }
+    for index, name in enumerate(field_names):
+        doc = _sys.intern(f'Alias for field number {index}')
+
+        def _get(self, index=index):
+            return self[index]
+        class_namespace[name] = property(_get, doc=doc)
+    for name in extra_field_names:
+        doc = _sys.intern(f'Alias for name {name}')
+
+        def _get(self, name=name):
+            return self.__dict__[name]
+        class_namespace[name] = property(_get, doc=doc)
+
+    result = type(typename, (tuple,), class_namespace)
+
+    # For pickling to work, the __module__ variable needs to be set to the
+    # frame where the named tuple is created.  Bypass this step in environments
+    # where sys._getframe is not defined (Jython for example) or sys._getframe
+    # is not defined for arguments greater than 0 (IronPython), or where the
+    # user has specified a particular module.
+    if module is None:
+        try:
+            module = _sys._getframe(1).f_globals.get('__name__', '__main__')
+        except (AttributeError, ValueError):
+            pass
+    if module is not None:
+        result.__module__ = module
+        __new__.__module__ = module
+
+    return result

--- a/scipy/_lib/_bunch.py
+++ b/scipy/_lib/_bunch.py
@@ -30,8 +30,8 @@ def _validate_names(typename, field_names, extra_field_names):
 
 
 # Note: This code is adapted from CPython:Lib/collections/__init__.py
-def make_tuple_bunch(typename, field_names, extra_field_names=None,
-                     module=None):
+def _make_tuple_bunch(typename, field_names, extra_field_names=None,
+                      module=None):
     """
     Create a namedtuple-like class with additional attributes.
 
@@ -82,12 +82,12 @@ def make_tuple_bunch(typename, field_names, extra_field_names=None,
 
     Examples
     --------
-    >>> from scipy._lib._bunch import make_tuple_bunch
+    >>> from scipy._lib._bunch import _make_tuple_bunch
 
     Create a class that acts like a namedtuple with length 2 (with field
     names `x` and `y`) that will also have the attributes `w` and `beta`:
 
-    >>> Result = make_tuple_bunch('Result', ['x', 'y'], ['w', 'beta'])
+    >>> Result = _make_tuple_bunch('Result', ['x', 'y'], ['w', 'beta'])
 
     `Result` is the new class.  We call it with keyword arguments to create
     a new instance with given values.

--- a/scipy/_lib/_bunch.py
+++ b/scipy/_lib/_bunch.py
@@ -32,6 +32,85 @@ def _validate_names(typename, field_names, extra_field_names):
 # Note: This code is adapted from CPython:Lib/collections/__init__.py
 def make_tuple_bunch(typename, field_names, extra_field_names=None,
                      module=None):
+    """
+    Create a namedtuple-like class with additional attributes.
+
+    This function creates a subclass of tuple that acts like a namedtuple
+    and that has additional attributes.
+
+    The additional attributes are listed in `extra_field_names`.  The
+    values assigned to these attributes are not part of the tuple.
+
+    The reason this function exists is to allow functions in SciPy
+    that currently return a tuple or a namedtuple to returned objects
+    that have additional attributes, while maintaining backwards
+    compatibility.
+
+    This should only be used to enhance *existing* functions in SciPy.
+    New functions are free to create objects as return values without
+    having to maintain backwards compatibility with an old tuple or
+    namedtuple return value.
+
+    Parameters
+    ----------
+    typename : str
+        The name of the type.
+    field_names : list of str
+        List of names of the values to be stored in the tuple. These names
+        will also be attributes of instances, so the values in the tuple
+        can be accessed by indexing or as attributes.  At least one name
+        is required.  See the Notes for additional restrictions.
+    extra_field_names : list of str, optional
+        List of names of values that will be stored as attributes of the
+        object.  See the notes for additional restrictions.
+
+    Returns
+    -------
+    cls : type
+        The new class.
+
+    Notes
+    -----
+    There are restrictions on the names that may be used in `field_names`
+    and `extra_field_names`:
+
+    * The names must be unique--no duplicates allowed.
+    * The names must be valid Python identifiers, and must not begin with
+      an underscore.
+    * The names must not be Python keywords (e.g. 'def', 'and', etc., are
+      not allowed).
+
+    Examples
+    --------
+    >>> from scipy._lib._bunch import make_tuple_bunch
+
+    Create a class that acts like a namedtuple with length 2 (with field
+    names `x` and `y`) that will also have the attributes `w` and `beta`:
+
+    >>> Result = make_tuple_bunch('Result', ['x', 'y'], ['w', 'beta'])
+
+    `Result` is the new class.  We call it with keyword arguments to create
+    a new instance with given values.
+
+    >>> result1 = Result(x=1, y=2, w=99, beta=0.5)
+    >>> result1
+    Result(x=1, y=2, w=99, beta=0.5)
+
+    `result1` acts like a tuple of length 2:
+
+    >>> len(result1)
+    2
+    >>> result1[:]
+    (1, 2)
+
+    The values assigned when the instance was created are available as
+    attributes:
+
+    >>> result1.y
+    2
+    >>> result1.beta
+    0.5
+    """
     if len(field_names) == 0:
         raise ValueError('field_names must contain at least one name')
 

--- a/scipy/_lib/tests/test_bunch.py
+++ b/scipy/_lib/tests/test_bunch.py
@@ -1,0 +1,151 @@
+
+import pytest
+import pickle
+from numpy.testing import assert_equal
+from scipy._lib._bunch import make_tuple_bunch
+
+
+# `Result` is defined at the top level of the module so it can be
+# used to test pickling.
+Result = make_tuple_bunch('Result', ['x', 'y', 'z'], ['w', 'beta'])
+
+
+class TestMakeTupleBunch:
+
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    # Tests with Result
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+    def setup(self):
+        # Set up an instance of Result.
+        self.result = Result(x=1, y=2, z=3, w=99, beta=0.5)
+
+    def test_attribute_access(self):
+        assert_equal(self.result.x, 1)
+        assert_equal(self.result.y, 2)
+        assert_equal(self.result.z, 3)
+        assert_equal(self.result.w, 99)
+        assert_equal(self.result.beta, 0.5)
+
+    def test_indexing(self):
+        assert_equal(self.result[0], 1)
+        assert_equal(self.result[1], 2)
+        assert_equal(self.result[2], 3)
+
+    def test_unpacking(self):
+        x0, y0, z0 = self.result
+        assert_equal((x0, y0, z0), (1, 2, 3))
+
+    def test_slice(self):
+        assert_equal(self.result[1:], (2, 3))
+
+    def test_repr(self):
+        s = repr(self.result)
+        assert_equal(s, 'Result(x=1, y=2, z=3, w=99, beta=0.5)')
+
+    def test_pickle(self):
+        s = pickle.dumps(self.result)
+        obj = pickle.loads(s)
+        assert isinstance(obj, Result)
+        assert_equal(obj.x, self.result.x)
+        assert_equal(obj.y, self.result.y)
+        assert_equal(obj.z, self.result.z)
+        assert_equal(obj.w, self.result.w)
+        assert_equal(obj.beta, self.result.beta)
+
+    def test_read_only_existing(self):
+        with pytest.raises(AttributeError, match="can't set attribute"):
+            self.result.x = -1
+
+    def test_read_only_new(self):
+        with pytest.raises(AttributeError, match="can't set attribute"):
+            self.result.plate_of_shrimp = "lattice of coincidence"
+
+    def test_constructor_missing_parameter(self):
+        with pytest.raises(TypeError, match='missing'):
+            # `w` is missing.
+            Result(x=1, y=2, z=3, beta=0.75)
+
+    def test_constructor_incorrect_parameter(self):
+        with pytest.raises(TypeError, match='unexpected'):
+            # `foo` is not an existing field.
+            Result(x=1, y=2, z=3, w=123, beta=0.75, foo=999)
+
+    def test_module(self):
+        m = 'scipy._lib.tests.test_bunch'
+        assert_equal(Result.__module__, m)
+        assert_equal(self.result.__module__, m)
+
+    def test_extra_fields_per_instance(self):
+        # This test exists to ensure that instances of the same class
+        # store their own values for the extra fields. That is, the values
+        # are stored per instance and not in the class.
+        result1 = Result(x=1, y=2, z=3, w=-1, beta=0.0)
+        result2 = Result(x=4, y=5, z=6, w=99, beta=1.0)
+        assert_equal(result1.w, -1)
+        assert_equal(result1.beta, 0.0)
+        # The rest of these checks aren't essential, but let's check
+        # them anyway.
+        assert_equal(result1[:], (1, 2, 3))
+        assert_equal(result2.w, 99)
+        assert_equal(result2.beta, 1.0)
+        assert_equal(result2[:], (4, 5, 6))
+
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    # Other tests
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+    def test_extra_field_names_is_optional(self):
+        Square = make_tuple_bunch('Square', ['width', 'height'])
+        sq = Square(width=1, height=2)
+        assert_equal(sq.width, 1)
+        assert_equal(sq.height, 2)
+        s = repr(sq)
+        assert_equal(s, 'Square(width=1, height=2)')
+
+    def test_tuple_like(self):
+        Tup = make_tuple_bunch('Tup', ['a', 'b'])
+        tu = Tup(a=1, b=2)
+        assert isinstance(tu, tuple)
+        assert isinstance(tu + (1,), tuple)
+
+    def test_explicit_module(self):
+        m = 'some.module.name'
+        Foo = make_tuple_bunch('Foo', ['x'], ['a', 'b'], module=m)
+        foo = Foo(x=1, a=355, b=113)
+        assert_equal(Foo.__module__, m)
+        assert_equal(foo.__module__, m)
+
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    # Argument validation
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+    @pytest.mark.parametrize('args', [('123', ['a'], ['b']),
+                                      ('Foo', ['-3'], ['x']),
+                                      ('Foo', ['a'], ['+-*/'])])
+    def test_identifiers_not_allowed(self, args):
+        with pytest.raises(ValueError, match='identifiers'):
+            make_tuple_bunch(*args)
+
+    @pytest.mark.parametrize('args', [('Foo', ['a', 'b', 'a'], ['x']),
+                                      ('Foo', ['a', 'b'], ['b', 'x'])])
+    def test_repeated_field_names(self, args):
+        with pytest.raises(ValueError, match='Duplicate'):
+            make_tuple_bunch(*args)
+
+    @pytest.mark.parametrize('args', [('Foo', ['_a'], ['x']),
+                                      ('Foo', ['a'], ['_x'])])
+    def test_leading_underscore_not_allowed(self, args):
+        with pytest.raises(ValueError, match='underscore'):
+            make_tuple_bunch(*args)
+
+    @pytest.mark.parametrize('args', [('Foo', ['def'], ['x']),
+                                      ('Foo', ['a'], ['or']),
+                                      ('and', ['a'], ['x'])])
+    def test_keyword_not_allowed_in_fields(self, args):
+        with pytest.raises(ValueError, match='keyword'):
+            make_tuple_bunch(*args)
+
+    def test_at_least_one_field_name_required(self):
+        with pytest.raises(ValueError, match='at least one name'):
+            make_tuple_bunch('Qwerty', [], ['a', 'b'])

--- a/scipy/_lib/tests/test_bunch.py
+++ b/scipy/_lib/tests/test_bunch.py
@@ -31,17 +31,29 @@ class TestMakeTupleBunch:
         assert_equal(self.result[0], 1)
         assert_equal(self.result[1], 2)
         assert_equal(self.result[2], 3)
+        assert_equal(self.result[-1], 3)
+        with pytest.raises(IndexError, match='index out of range'):
+            self.result[3]
 
     def test_unpacking(self):
         x0, y0, z0 = self.result
         assert_equal((x0, y0, z0), (1, 2, 3))
+        assert_equal(self.result, (1, 2, 3))
 
     def test_slice(self):
         assert_equal(self.result[1:], (2, 3))
+        assert_equal(self.result[::2], (1, 3))
+        assert_equal(self.result[::-1], (3, 2, 1))
+
+    def test_len(self):
+        assert_equal(len(self.result), 3)
 
     def test_repr(self):
         s = repr(self.result)
         assert_equal(s, 'Result(x=1, y=2, z=3, w=99, beta=0.5)')
+
+    def test_hash(self):
+        assert_equal(hash(self.result), hash((1, 2, 3)))
 
     def test_pickle(self):
         s = pickle.dumps(self.result)

--- a/scipy/_lib/tests/test_bunch.py
+++ b/scipy/_lib/tests/test_bunch.py
@@ -2,12 +2,12 @@
 import pytest
 import pickle
 from numpy.testing import assert_equal
-from scipy._lib._bunch import make_tuple_bunch
+from scipy._lib._bunch import _make_tuple_bunch
 
 
 # `Result` is defined at the top level of the module so it can be
 # used to test pickling.
-Result = make_tuple_bunch('Result', ['x', 'y', 'z'], ['w', 'beta'])
+Result = _make_tuple_bunch('Result', ['x', 'y', 'z'], ['w', 'beta'])
 
 
 class TestMakeTupleBunch:
@@ -108,7 +108,7 @@ class TestMakeTupleBunch:
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
     def test_extra_field_names_is_optional(self):
-        Square = make_tuple_bunch('Square', ['width', 'height'])
+        Square = _make_tuple_bunch('Square', ['width', 'height'])
         sq = Square(width=1, height=2)
         assert_equal(sq.width, 1)
         assert_equal(sq.height, 2)
@@ -116,14 +116,14 @@ class TestMakeTupleBunch:
         assert_equal(s, 'Square(width=1, height=2)')
 
     def test_tuple_like(self):
-        Tup = make_tuple_bunch('Tup', ['a', 'b'])
+        Tup = _make_tuple_bunch('Tup', ['a', 'b'])
         tu = Tup(a=1, b=2)
         assert isinstance(tu, tuple)
         assert isinstance(tu + (1,), tuple)
 
     def test_explicit_module(self):
         m = 'some.module.name'
-        Foo = make_tuple_bunch('Foo', ['x'], ['a', 'b'], module=m)
+        Foo = _make_tuple_bunch('Foo', ['x'], ['a', 'b'], module=m)
         foo = Foo(x=1, a=355, b=113)
         assert_equal(Foo.__module__, m)
         assert_equal(foo.__module__, m)
@@ -137,27 +137,27 @@ class TestMakeTupleBunch:
                                       ('Foo', ['a'], ['+-*/'])])
     def test_identifiers_not_allowed(self, args):
         with pytest.raises(ValueError, match='identifiers'):
-            make_tuple_bunch(*args)
+            _make_tuple_bunch(*args)
 
     @pytest.mark.parametrize('args', [('Foo', ['a', 'b', 'a'], ['x']),
                                       ('Foo', ['a', 'b'], ['b', 'x'])])
     def test_repeated_field_names(self, args):
         with pytest.raises(ValueError, match='Duplicate'):
-            make_tuple_bunch(*args)
+            _make_tuple_bunch(*args)
 
     @pytest.mark.parametrize('args', [('Foo', ['_a'], ['x']),
                                       ('Foo', ['a'], ['_x'])])
     def test_leading_underscore_not_allowed(self, args):
         with pytest.raises(ValueError, match='underscore'):
-            make_tuple_bunch(*args)
+            _make_tuple_bunch(*args)
 
     @pytest.mark.parametrize('args', [('Foo', ['def'], ['x']),
                                       ('Foo', ['a'], ['or']),
                                       ('and', ['a'], ['x'])])
     def test_keyword_not_allowed_in_fields(self, args):
         with pytest.raises(ValueError, match='keyword'):
-            make_tuple_bunch(*args)
+            _make_tuple_bunch(*args)
 
     def test_at_least_one_field_name_required(self):
         with pytest.raises(ValueError, match='at least one name'):
-            make_tuple_bunch('Qwerty', [], ['a', 'b'])
+            _make_tuple_bunch('Qwerty', [], ['a', 'b'])


### PR DESCRIPTION
The new function `make_tuple_bunch()` is intended to replace the use
of `namedtuple` when we want to add additional outputs to a function
while maintaining backwards compatibility.

Closes gh-3665.
