### PR TITLE
BUG: io: Fix an error that occurs when attempting to raise a ValueError.

### DIFF
--- a/scipy/io/mmio.py
+++ b/scipy/io/mmio.py
@@ -251,12 +251,14 @@ class MMFile:
             split_line = line.split()
             if format == self.FORMAT_ARRAY:
                 if not len(split_line) == 2:
-                    raise ValueError("Header line not of length 2: " + line)
+                    raise ValueError("Header line not of length 2: " +
+                                     line.decode('ascii'))
                 rows, cols = map(int, split_line)
                 entries = rows * cols
             else:
                 if not len(split_line) == 3:
-                    raise ValueError("Header line not of length 3: " + line)
+                    raise ValueError("Header line not of length 3: " +
+                                     line.decode('ascii'))
                 rows, cols, entries = map(int, split_line)
 
             return (rows, cols, entries, format, field.lower(),

--- a/scipy/io/tests/test_mmio.py
+++ b/scipy/io/tests/test_mmio.py
@@ -2,10 +2,11 @@ from tempfile import mkdtemp, mktemp
 import os
 import io
 import shutil
+import textwrap
 
 import numpy as np
 from numpy import array, transpose, pi
-from numpy.testing import (assert_equal,
+from numpy.testing import (assert_equal, assert_allclose,
                            assert_array_equal, assert_array_almost_equal)
 import pytest
 from pytest import raises as assert_raises
@@ -112,6 +113,24 @@ class TestMMIOArray(object):
         sz = (20, 15)
         a = np.random.random(sz)
         self.check(a, (20, 15, 300, 'array', 'real', 'general'))
+
+    def test_bad_number_of_array_header_fields(self):
+        s = """\
+            %%MatrixMarket matrix array real general
+              3  3 999
+            1.0
+            2.0
+            3.0
+            4.0
+            5.0
+            6.0
+            7.0
+            8.0
+            9.0
+            """
+        text = textwrap.dedent(s).encode('ascii')
+        with pytest.raises(ValueError, match='not of length 2'):
+            scipy.io.mmread(io.BytesIO(text))
 
 
 class TestMMIOSparseCSR(TestMMIOArray):
@@ -298,6 +317,7 @@ _over64bit_integer_sparse_example = '''\
 1  1            2147483648
 2  2  19223372036854775808
 '''
+
 
 class TestMMIOReadLargeIntegers(object):
     def setup_method(self):
@@ -695,8 +715,24 @@ class TestMMIOCoordinate(object):
                 # check for right entries in matrix
                 assert_array_equal(A.row, [n-1])
                 assert_array_equal(A.col, [n-1])
-                assert_array_almost_equal(A.data,
-                    [float('%%.%dg' % precision % value)])
+                assert_allclose(A.data, [float('%%.%dg' % precision % value)])
+
+    def test_bad_number_of_coordinate_header_fields(self):
+        s = """\
+            %%MatrixMarket matrix coordinate real general
+              5  5  8 999
+                1     1   1.000e+00
+                2     2   1.050e+01
+                3     3   1.500e-02
+                1     4   6.000e+00
+                4     2   2.505e+02
+                4     4  -2.800e+02
+                4     5   3.332e+01
+                5     5   1.200e+01
+            """
+        text = textwrap.dedent(s).encode('ascii')
+        with pytest.raises(ValueError, match='not of length 3'):
+            scipy.io.mmread(io.BytesIO(text))
 
 
 def test_gh11389():


### PR DESCRIPTION
The Matrix Market files are read as bytes, so when a line from the file
is concatenated to a string to create an error message, the line must be
decoded.  The Matrix Market file format is documented to be an ASCII
file format, so decode the bytes as ASCII.

Before this change, the lines that were changed would raise a TypeError
because a string can not be added to a bytes object.  Now they will
raise the expected ValueError.
