### PR TITLE
DOC: clarify docstrings of `query_ball_tree` and `query_pairs`

### DIFF
--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -995,7 +995,7 @@ cdef class cKDTree:
         """
         query_ball_tree(self, other, r, p=2., eps=0)
 
-        Find all pairs of points whose distance is at most r
+        Find all indexes of points whose distance is at most r
 
         Parameters
         ----------

--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -995,7 +995,7 @@ cdef class cKDTree:
         """
         query_ball_tree(self, other, r, p=2., eps=0)
 
-        Find all indexes of points whose distance is at most r
+        Find all pairs of points between `self` tree and `other` tree whose distance is at most r
 
         Parameters
         ----------
@@ -1086,7 +1086,7 @@ cdef class cKDTree:
         """
         query_pairs(self, r, p=2., eps=0)
 
-        Find all pairs of points whose distance is at most r.
+        Find all pairs of points in `self` tree whose distance is at most r.
 
         Parameters
         ----------

--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -995,7 +995,7 @@ cdef class cKDTree:
         """
         query_ball_tree(self, other, r, p=2., eps=0)
 
-        Find all pairs of points between `self` tree and `other` tree whose distance is at most r
+        Find all pairs of points between `self` and `other` whose distance is at most r
 
         Parameters
         ----------
@@ -1086,7 +1086,7 @@ cdef class cKDTree:
         """
         query_pairs(self, r, p=2., eps=0)
 
-        Find all pairs of points in `self` tree whose distance is at most r.
+        Find all pairs of points in `self` whose distance is at most r.
 
         Parameters
         ----------

--- a/scipy/spatial/kdtree.py
+++ b/scipy/spatial/kdtree.py
@@ -632,7 +632,8 @@ class KDTree(object):
             return result
 
     def query_ball_tree(self, other, r, p=2., eps=0):
-        """Find all pairs of points whose distance is at most r
+        """
+        Find all indexes of points whose distance is at most r
 
         Parameters
         ----------
@@ -702,7 +703,7 @@ class KDTree(object):
 
     def query_pairs(self, r, p=2., eps=0):
         """
-        Find all pairs of points within a distance.
+        Find all pairs of points whose distance is at most r
 
         Parameters
         ----------

--- a/scipy/spatial/kdtree.py
+++ b/scipy/spatial/kdtree.py
@@ -633,7 +633,7 @@ class KDTree(object):
 
     def query_ball_tree(self, other, r, p=2., eps=0):
         """
-        Find all indexes of points whose distance is at most r
+        Find all pairs of points between `self` tree and `other` tree whose distance is at most r
 
         Parameters
         ----------
@@ -703,7 +703,7 @@ class KDTree(object):
 
     def query_pairs(self, r, p=2., eps=0):
         """
-        Find all pairs of points whose distance is at most r
+        Find all pairs of points in `self` tree whose distance is at most r.
 
         Parameters
         ----------

--- a/scipy/spatial/kdtree.py
+++ b/scipy/spatial/kdtree.py
@@ -633,7 +633,7 @@ class KDTree(object):
 
     def query_ball_tree(self, other, r, p=2., eps=0):
         """
-        Find all pairs of points between `self` tree and `other` tree whose distance is at most r
+        Find all pairs of points between `self` and `other` whose distance is at most r
 
         Parameters
         ----------
@@ -703,7 +703,7 @@ class KDTree(object):
 
     def query_pairs(self, r, p=2., eps=0):
         """
-        Find all pairs of points in `self` tree whose distance is at most r.
+        Find all pairs of points in `self` whose distance is at most r.
 
         Parameters
         ----------


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### What does this implement/fix?
I found some minor doc issues of `spatial.KDTree` and `spatial.cKDTree`.

I think current docstrings of `query_ball_tree` and `query_pairs` of `spatial.KDTree` and `spatial.cKDTree` are not good at below points:
1. docstrings are not consistent between `spatial.KDTree` and `spatial.cKDTree`.
2. `query_ball_tree` returns indexes of data, but docstring says that it find pairs of data.

So, I fixed docstrings of `query_ball_tree` and `query_pairs` of `spatial.KDTree` and `spatial.cKDTree`.

