### PR TITLE
PERF: Improve cKDTree.query_ball_point constant time cython overhead

### DIFF
--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -1498,7 +1498,7 @@ cdef np.intp_t num_points(np.ndarray x, np.intp_t pdim) except -1:
     return n
 
 cdef np.ndarray broadcast_contiguous(object x, tuple shape, object dtype) except +:
-    """Same as ``ascontiguousarray``, but broadcasting to ``shape`` first"""
+    """Broadcast ``x`` to ``shape`` and make contiguous, possibly by copying"""
     # Avoid copying if possible
     try:
         if x.shape == shape:

--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -117,13 +117,14 @@ cdef extern from "ckdtree_decl.h":
                            int cumulative) nogil except +
 
     int query_ball_point(const ckdtree *self,
-                            const np.float64_t *x,
-                            const np.float64_t *r,
-                            const np.float64_t p,
-                            const np.float64_t eps,
-                            const np.intp_t n_queries,
-                            vector[np.intp_t] *results,
-                            const int return_length) nogil except +
+                         const np.float64_t *x,
+                         const np.float64_t *r,
+                         const np.float64_t p,
+                         const np.float64_t eps,
+                         const np.intp_t n_queries,
+                         vector[np.intp_t] *results,
+                         const bool return_length,
+                         const bool sort_output) nogil except +
 
     int query_ball_tree(const ckdtree *self,
                            const ckdtree *other,
@@ -922,16 +923,13 @@ cdef class cKDTree:
 
             with nogil:
                 query_ball_point(cself, pvxx,
-                                 pvrr, p, eps, stop - start, vvres.data(), rlen)
+                                 pvrr, p, eps, stop - start, vvres.data(),
+                                 rlen, sort_output)
 
             for i in range(stop - start):
                 if rlen:
                     vlen[start + i] = vvres[i].front()
                     continue
-
-                if sort_output:
-                    with nogil:
-                        sort(vvres[i].begin(), vvres[i].end())
 
                 m = <np.intp_t> (vvres[i].size())
                 tmp = m * [None]
@@ -1013,8 +1011,6 @@ cdef class cKDTree:
             m = <np.intp_t> (vvres[i].size())
             if NPY_LIKELY(m > 0):
                 tmp = m * [None]
-                with nogil:
-                    sort(vvres[i].begin(), vvres[i].end())
                 cur = vvres[i].data()
                 for j in range(m):
                     tmp[j] = cur[j]

--- a/scipy/spatial/ckdtree/src/ckdtree_decl.h
+++ b/scipy/spatial/ckdtree/src/ckdtree_decl.h
@@ -110,7 +110,8 @@ query_ball_point(const ckdtree *self,
                  const double eps,
                  const ckdtree_intp_t n_queries,
                  std::vector<ckdtree_intp_t> *results,
-                 const int return_length);
+                 const bool return_length,
+                 const bool sort_output);
 
 int
 query_ball_tree(const ckdtree *self,

--- a/scipy/spatial/ckdtree/src/ckdtree_decl.h
+++ b/scipy/spatial/ckdtree/src/ckdtree_decl.h
@@ -109,7 +109,7 @@ query_ball_point(const ckdtree *self,
                  const double p,
                  const double eps,
                  const ckdtree_intp_t n_queries,
-                 std::vector<ckdtree_intp_t> **results,
+                 std::vector<ckdtree_intp_t> *results,
                  const int return_length);
 
 int
@@ -118,7 +118,7 @@ query_ball_tree(const ckdtree *self,
                 const double r,
                 const double p,
                 const double eps,
-                std::vector<ckdtree_intp_t> **results
+                std::vector<ckdtree_intp_t> *results
                 );
 
 int

--- a/scipy/spatial/ckdtree/src/query_ball_point.cxx
+++ b/scipy/spatial/ckdtree/src/query_ball_point.cxx
@@ -2,6 +2,7 @@
 #include <cstdlib>
 #include <cstring>
 
+#include <algorithm>
 #include <vector>
 #include <string>
 #include <sstream>
@@ -109,7 +110,9 @@ int
 query_ball_point(const ckdtree *self, const double *x,
                  const double *r, const double p, const double eps,
                  const ckdtree_intp_t n_queries,
-                 std::vector<ckdtree_intp_t> *results, const int return_length)
+                 std::vector<ckdtree_intp_t> *results,
+                 const bool return_length,
+                 const bool sort_output)
 {
 #define HANDLE(cond, kls) \
     if(cond) { \
@@ -139,6 +142,10 @@ query_ball_point(const ckdtree *self, const double *x,
             HANDLE(ckdtree_isinf(p), BoxMinkowskiDistPinf)
             HANDLE(1, BoxMinkowskiDistPp)
             {}
+        }
+
+        if (!return_length && sort_output) {
+            std::sort(results[i].begin(), results[i].end());
         }
     }
     return 0;

--- a/scipy/spatial/ckdtree/src/query_ball_point.cxx
+++ b/scipy/spatial/ckdtree/src/query_ball_point.cxx
@@ -17,7 +17,7 @@
 static void
 traverse_no_checking(const ckdtree *self,
                      const int return_length,
-                     std::vector<ckdtree_intp_t> *results,
+                     std::vector<ckdtree_intp_t> &results,
                      const ckdtreenode *node)
 {
     const ckdtree_intp_t *indices = self->raw_indices;
@@ -30,9 +30,9 @@ traverse_no_checking(const ckdtree *self,
         const ckdtree_intp_t end = lnode->end_idx;
         for (i = start; i < end; ++i) {
             if (return_length) {
-                (*results)[0] ++;
+                results[0] ++;
             } else {
-                results->push_back(indices[i]);
+                results.push_back(indices[i]);
             }
         }
     }
@@ -46,7 +46,7 @@ traverse_no_checking(const ckdtree *self,
 template <typename MinMaxDist> static void
 traverse_checking(const ckdtree *self,
                   const int return_length,
-                  std::vector<ckdtree_intp_t> *results,
+                  std::vector<ckdtree_intp_t> &results,
                   const ckdtreenode *node,
                   RectRectDistanceTracker<MinMaxDist> *tracker
 )
@@ -87,9 +87,9 @@ traverse_checking(const ckdtree *self,
 
             if (d <= tub) {
                 if(return_length) {
-                    (*results)[0] ++;
+                    results[0] ++;
                 } else {
-                    results->push_back((ckdtree_intp_t) indices[i]);
+                    results.push_back((ckdtree_intp_t) indices[i]);
                 }
             }
         }
@@ -109,11 +109,11 @@ int
 query_ball_point(const ckdtree *self, const double *x,
                  const double *r, const double p, const double eps,
                  const ckdtree_intp_t n_queries,
-                 std::vector<ckdtree_intp_t> **results, const int return_length)
+                 std::vector<ckdtree_intp_t> *results, const int return_length)
 {
 #define HANDLE(cond, kls) \
     if(cond) { \
-        if(return_length) results[i]->push_back(0); \
+        if(return_length) results[i].push_back(0); \
         RectRectDistanceTracker<kls> tracker(self, point, rect, p, eps, r[i]); \
         traverse_checking(self, return_length, results[i], self->ctree, &tracker); \
     } else

--- a/scipy/spatial/ckdtree/src/query_ball_tree.cxx
+++ b/scipy/spatial/ckdtree/src/query_ball_tree.cxx
@@ -2,6 +2,7 @@
 #include <cstdlib>
 #include <cstring>
 
+#include <algorithm>
 #include <vector>
 #include <string>
 #include <sstream>
@@ -207,5 +208,10 @@ query_ball_tree(const ckdtree *self, const ckdtree *other,
         HANDLE(1, BoxMinkowskiDistPp)
         {}
     }
+
+    for (size_t i = 0; i < self->n; ++i) {
+        std::sort(results[i].begin(), results[i].end());
+    }
+
     return 0;
 }

--- a/scipy/spatial/ckdtree/src/query_ball_tree.cxx
+++ b/scipy/spatial/ckdtree/src/query_ball_tree.cxx
@@ -16,14 +16,13 @@
 
 static void
 traverse_no_checking(const ckdtree *self, const ckdtree *other,
-                     std::vector<ckdtree_intp_t> **results,
+                     std::vector<ckdtree_intp_t> *results,
                      const ckdtreenode *node1, const ckdtreenode *node2)
 {
     const ckdtreenode *lnode1;
     const ckdtreenode *lnode2;
     const ckdtree_intp_t *sindices = self->raw_indices;
     const ckdtree_intp_t *oindices = other->raw_indices;
-    std::vector<ckdtree_intp_t> *results_i;
     ckdtree_intp_t i, j;
 
     if (node1->split_dim == -1) {   /* leaf node */
@@ -38,9 +37,9 @@ traverse_no_checking(const ckdtree *self, const ckdtree *other,
             const ckdtree_intp_t end2 = lnode2->end_idx;
 
             for (i = start1; i < end1; ++i) {
-                results_i = results[sindices[i]];
+                auto &results_i = results[sindices[i]];
                 for (j = start2; j < end2; ++j)
-                    results_i->push_back(oindices[j]);
+                    results_i.push_back(oindices[j]);
             }
         }
         else {
@@ -57,13 +56,12 @@ traverse_no_checking(const ckdtree *self, const ckdtree *other,
 
 template <typename MinMaxDist> static void
 traverse_checking(const ckdtree *self, const ckdtree *other,
-                  std::vector<ckdtree_intp_t> **results,
+                  std::vector<ckdtree_intp_t> *results,
                   const ckdtreenode *node1, const ckdtreenode *node2,
                   RectRectDistanceTracker<MinMaxDist> *tracker)
 {
     const ckdtreenode *lnode1;
     const ckdtreenode *lnode2;
-    std::vector<ckdtree_intp_t> *results_i;
     double d;
     ckdtree_intp_t i, j;
 
@@ -106,7 +104,7 @@ traverse_checking(const ckdtree *self, const ckdtree *other,
                 if (start2 < end2 - 1)
                     CKDTREE_PREFETCH(odata + oindices[start2+1] * m, 0, m);
 
-                results_i = results[sindices[i]];
+                auto &results_i = results[sindices[i]];
 
                 for (j = start2; j < end2; ++j) {
 
@@ -120,7 +118,7 @@ traverse_checking(const ckdtree *self, const ckdtree *other,
                             p, m, tmd);
 
                     if (d <= tub)
-                        results_i->push_back(other->raw_indices[j]);
+                        results_i.push_back(other->raw_indices[j]);
                 }
             }
 
@@ -183,7 +181,7 @@ traverse_checking(const ckdtree *self, const ckdtree *other,
 int
 query_ball_tree(const ckdtree *self, const ckdtree *other,
                 const double r, const double p, const double eps,
-                std::vector<ckdtree_intp_t> **results)
+                std::vector<ckdtree_intp_t> *results)
 {
 
 #define HANDLE(cond, kls) \


### PR DESCRIPTION
#### Reference issue
Closes gh-10216

#### What does this implement/fix?
Profiling showed most of the time spent for small queries is in the cython wrapper code, not the actual query itself. So, this focuses on removing a number of constant time overheads from the cython code for `query_ball_point` and to a lesser extent, some of the other `cKDTree` query methods. 

- adding appropriate typing to variables and using `cdef` for helper functions
- reverted from memory views back to pointers. I found they have significant construction overhead and by forcing you to reshape the arrays, add yet more python calls.
- Avoiding `broadcast_to` which was quite expensive in my tests.

On my machine, the query time from the issue goes from 42 us to 14 us, or a 3x speedup. For comparison, SciPy 1.2 takes 9 us on my machine to run the same test case.

Note that some of the remaining difference is because the ball radius is now an array rather than a scalar. I think it's reasonable to accept a small performance hit for additional features in the vector queries.