### PR TITLE
BUG: KDTree should reject complex input points

### DIFF
--- a/scipy/spatial/kdtree.py
+++ b/scipy/spatial/kdtree.py
@@ -238,6 +238,9 @@ class KDTree(object):
     """
     def __init__(self, data, leafsize=10):
         self.data = np.asarray(data)
+        if self.data.dtype.kind == 'c':
+            raise TypeError("KDTree does not work with complex data")
+
         self.n, self.m = np.shape(self.data)
         self.leafsize = int(leafsize)
         if self.leafsize < 1:
@@ -486,6 +489,8 @@ class KDTree(object):
 
         """
         x = np.asarray(x)
+        if x.dtype.kind == 'c':
+            raise TypeError("KDTree does not work with complex data")
         if np.shape(x)[-1] != self.m:
             raise ValueError("x must consist of vectors of length %d but has shape %s" % (self.m, np.shape(x)))
         if p < 1:
@@ -619,6 +624,8 @@ class KDTree(object):
 
         """
         x = np.asarray(x)
+        if x.dtype.kind == 'c':
+            raise TypeError("KDTree does not work with complex data")
         if x.shape[-1] != self.m:
             raise ValueError("Searching for a %d-dimensional point in a "
                              "%d-dimensional KDTree" % (x.shape[-1], self.m))

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -1469,3 +1469,19 @@ class Test_sorted_query_ball_point(object):
         idxs_list_False = self.ckdt.query_ball_point(self.x, 1., return_sorted=False)
         for idxs0, idxs1 in zip(idxs_list_False, idxs_list_single):
             assert_array_equal(idxs0, idxs1)
+
+
+def test_kdtree_complex_data():
+    # Test that KDTree rejects complex input points (gh-9108)
+    points = np.random.rand(10, 2).view(complex)
+
+    with pytest.raises(TypeError, match="complex data"):
+        t = KDTree(points)
+
+    t = KDTree(points.real)
+
+    with pytest.raises(TypeError, match="complex data"):
+        t.query(points)
+
+    with pytest.raises(TypeError, match="complex data"):
+        t.query_ball_point(points, r=1)


### PR DESCRIPTION
#### Reference issue
Closes gh-9108

#### What does this implement/fix?
`KDTree` doesn't work properly with complex data, so should fail fast instead of silently producing incorrect results.