### PR TITLE
DOC: improve consistency and clarity of docs in linalg and sparse/linalg

### DIFF
--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -127,7 +127,7 @@ def solve(a, b, sym_pos=False, lower=False, overwrite_a=False,
     despite the apparent size mismatch. This is compatible with the
     numpy.dot() behavior and the returned result is still 1-D array.
 
-    The generic, symmetric, hermitian and positive definite solutions are
+    The generic, symmetric, Hermitian and positive definite solutions are
     obtained via calling ?GESV, ?SYSV, ?HESV, and ?POSV routines of
     LAPACK respectively.
     """

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -370,7 +370,7 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
 
     Notes
     -----
-    This function does not check the input array for being hermitian/symmetric
+    This function does not check the input array for being Hermitian/symmetric
     in order to allow for representing arrays with only their upper/lower
     triangular parts. Also, note that even though not taken into account,
     finiteness check applies to the whole array and unaffected by "lower"

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -723,7 +723,7 @@ def eig_banded(a_band, lower=False, eigvals_only=False, overwrite_a_band=False,
     eigvals_banded : eigenvalues for symmetric/Hermitian band matrices
     eig : eigenvalues and right eigenvectors of general arrays.
     eigh : eigenvalues and right eigenvectors for symmetric/Hermitian arrays
-    eigh_tridiagonal : eigenvalues and right eiegenvectors for
+    eigh_tridiagonal : eigenvalues and right eigenvectors for
         symmetric/Hermitian tridiagonal matrices
 
     Examples

--- a/scipy/linalg/decomp_cholesky.py
+++ b/scipy/linalg/decomp_cholesky.py
@@ -255,7 +255,7 @@ def cholesky_banded(ab, overwrite_ab=False, lower=False, check_finite=True):
     See also
     --------
     cho_solve_banded : Solve a linear set equations, given the Cholesky factorization
-                of a banded hermitian.
+                of a banded Hermitian.
 
     Examples
     --------
@@ -288,7 +288,7 @@ def cholesky_banded(ab, overwrite_ab=False, lower=False, check_finite=True):
 def cho_solve_banded(cb_and_lower, b, overwrite_b=False, check_finite=True):
     """
     Solve the linear equations ``A x = b``, given the Cholesky factorization of
-    the banded hermitian ``A``.
+    the banded Hermitian ``A``.
 
     Parameters
     ----------

--- a/scipy/sparse/linalg/eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/arpack.py
@@ -1122,8 +1122,8 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
 
             A * x = w * M * x.
 
-        M must represent a real, symmetric matrix if A is real, and must
-        represent a complex, hermitian matrix if A is complex. For best
+        M must represent a real symmetric matrix if A is real, and must
+        represent a complex Hermitian matrix if A is complex. For best
         results, the data type of M should be the same as that of A.
         Additionally:
 
@@ -1353,7 +1353,7 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
           Minv=None, OPinv=None, mode='normal'):
     """
     Find k eigenvalues and eigenvectors of the real symmetric square matrix
-    or complex hermitian matrix A.
+    or complex Hermitian matrix A.
 
     Solves ``A * x[i] = w[i] * x[i]``, the standard eigenvalue problem for
     w[i] eigenvalues with corresponding eigenvectors x[i].
@@ -1363,14 +1363,14 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
     with corresponding eigenvectors x[i].
 
     Note that there is no specialized routine for the case when A is a complex
-    hermitian matrix. In this case, ``eigsh()`` will call ``eigs()`` and return the
+    Hermitian matrix. In this case, ``eigsh()`` will call ``eigs()`` and return the
     real parts of the eigenvalues thus obtained.
 
     Parameters
     ----------
     A : ndarray, sparse matrix or LinearOperator
         A square operator representing the operation ``A * x``, where ``A`` is
-        real symmetric or complex hermitian. For buckling mode (see below)
+        real symmetric or complex Hermitian. For buckling mode (see below)
         ``A`` must additionally be positive-definite.
     k : int, optional
         The number of eigenvalues and eigenvectors desired.
@@ -1392,8 +1392,8 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
 
             A @ x = w * M @ x.
 
-        M must represent a real, symmetric matrix if A is real, and must
-        represent a complex, hermitian matrix if A is complex. For best
+        M must represent a real symmetric matrix if A is real, and must
+        represent a complex Hermitian matrix if A is complex. For best
         results, the data type of M should be the same as that of A.
         Additionally:
 
@@ -1436,7 +1436,7 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
         smaller than n; it is recommended that ``ncv > 2*k``.
         Default: ``min(n, max(2*k + 1, 20))``
     which : str ['LM' | 'SM' | 'LA' | 'SA' | 'BE']
-        If A is a complex hermitian matrix, 'BE' is invalid.
+        If A is a complex Hermitian matrix, 'BE' is invalid.
         Which `k` eigenvectors and eigenvalues to find:
 
             'LM' : Largest (in magnitude) eigenvalues.
@@ -1553,7 +1553,7 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
     (13, 6)
 
     """
-    # complex hermitian matrices should be solved with eigs
+    # complex Hermitian matrices should be solved with eigs
     if np.issubdtype(A.dtype, np.complexfloating):
         if mode != 'normal':
             raise ValueError("mode=%s cannot be used with "

--- a/scipy/sparse/linalg/eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/arpack.py
@@ -1362,6 +1362,10 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
     generalized eigenvalue problem for w[i] eigenvalues
     with corresponding eigenvectors x[i].
 
+    Note that there is no specialized routine for the case when A is a complex
+    hermitian matrix. In this case, ``eigsh()`` will call ``eigs()`` and return the
+    real parts of the eigenvalues thus obtained.
+
     Parameters
     ----------
     A : ndarray, sparse matrix or LinearOperator

--- a/scipy/sparse/linalg/eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/arpack.py
@@ -14,11 +14,10 @@ Uses ARPACK: http://www.caam.rice.edu/software/ARPACK/
 # - (s,d,c,z)neupd: single,double,complex,double complex general matrix
 # This wrapper puts the *neupd (general matrix) interfaces in eigs()
 # and the *seupd (symmetric matrix) in eigsh().
-# There is no Hermitian complex/double complex interface.
-# To find eigenvalues of a Hermitian matrix you
-# must use eigs() and not eigsh()
-# It might be desirable to handle the Hermitian case differently
-# and, for example, return real eigenvalues.
+# There is no specialized interface for complex Hermitian matrices.
+# To find eigenvalues of a complex Hermitian matrix you
+# may use eigsh(), but eigsh() will simply call eigs()
+# and return the real part of the eigenvalues thus obtained.
 
 # Number of eigenvalues returned and complex eigenvalues
 # ------------------------------------------------------

--- a/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
@@ -28,7 +28,7 @@ __all__ = ['lobpcg']
 
 def _report_nonhermitian(M, name):
     """
-    Report if `M` is not a hermitian matrix given its type.
+    Report if `M` is not a Hermitian matrix given its type.
     """
     from scipy.linalg import norm
 


### PR DESCRIPTION
#### Reference issue
Closes #12337

#### What does this implement/fix?
Fixes a misleading, stale comment at the top of arpack.py and adds helpful information to the docstring of `eigsh`

#### Additional information
Also imposes greater consistency in linalg and sparse/linalg with regard to the spelling of "Hermitian" and makes some other minor grammatical / spelling fixes in the docs