### PR TITLE
MAINT: Don't use numpy's aliases of Python builtin objects.

### DIFF
--- a/benchmarks/benchmarks/sparse_csgraph_djisktra.py
+++ b/benchmarks/benchmarks/sparse_csgraph_djisktra.py
@@ -21,8 +21,8 @@ class Dijkstra(Benchmark):
         np.random.seed(1234)
         # make a random connectivity matrix
         data = scipy.sparse.rand(n, n, density=0.2, format='csc',
-                                 random_state=42, dtype=np.bool)
-        data.setdiag(np.zeros(n, dtype=np.bool))
+                                 random_state=42, dtype=np.bool_)
+        data.setdiag(np.zeros(n, dtype=np.bool_))
         self.data = data
         # choose some random vertices
         v = np.arange(n)

--- a/scipy/interpolate/interpnd.pyx
+++ b/scipy/interpolate/interpnd.pyx
@@ -94,7 +94,8 @@ class NDInterpolatorBase(object):
             self.is_complex = np.issubdtype(self.values.dtype, np.complexfloating)
             if self.is_complex:
                 if need_contiguous:
-                    self.values = np.ascontiguousarray(self.values, dtype=np.complex)
+                    self.values = np.ascontiguousarray(self.values,
+                                                       dtype=np.complex128)
                 self.fill_value = complex(fill_value)
             else:
                 if need_contiguous:

--- a/scipy/io/matlab/mio5_utils.pyx
+++ b/scipy/io/matlab/mio5_utils.pyx
@@ -107,7 +107,7 @@ cdef bint sys_is_le = sys.byteorder == 'little'
 swapped_code = '>' if sys_is_le else '<'
 
 cdef cnp.dtype OPAQUE_DTYPE = mio5p.OPAQUE_DTYPE
-cdef cnp.dtype BOOL_DTYPE = np.dtype(np.bool)
+cdef cnp.dtype BOOL_DTYPE = np.dtype(np.bool_)
 
 
 cpdef cnp.uint32_t byteswap_u4(cnp.uint32_t u4):
@@ -415,7 +415,7 @@ cdef class VarReader5:
 
         The type of the array is usually given by the ``mdtype`` returned via
         ``read_element``.  Sparse logical arrays are an exception, where the
-        type of the array may be ``np.bool`` even if the ``mdtype`` claims the
+        type of the array may be ``np.bool_`` even if the ``mdtype`` claims the
         data is of float64 type.
 
         Parameters

--- a/scipy/io/tests/test_fortran.py
+++ b/scipy/io/tests/test_fortran.py
@@ -221,7 +221,7 @@ def test_fortran_eof_broken_record(tmpdir):
 def test_fortran_eof_multidimensional(tmpdir):
     filename = path.join(str(tmpdir), "scratch")
     n, m, q = 3, 5, 7
-    dt = np.dtype([("field", np.float, (n, m))])
+    dt = np.dtype([("field", np.float64, (n, m))])
     a = np.zeros(q, dtype=dt)
     with FortranFile(filename, 'w') as f:
         f.write_record(a[0])

--- a/scipy/linalg/_decomp_qz.py
+++ b/scipy/linalg/_decomp_qz.py
@@ -115,7 +115,7 @@ def _qz(A, B, output='real', lwork=None, sort=None, overwrite_a=False,
     if lwork is None or lwork == -1:
         # get optimal work array size
         result = gges(lambda x: None, a1, b1, lwork=-1)
-        lwork = result[-2][0].real.astype(np.int)
+        lwork = result[-2][0].real.astype(np.int_)
 
     sfunction = lambda x: None
     result = gges(sfunction, a1, b1, lwork=lwork, overwrite_a=overwrite_a,
@@ -369,7 +369,7 @@ def ordqz(A, B, sort='lhp', output='real', overwrite_a=False,
 
     if lwork is None or lwork == -1:
         result = tgsen(select, AA, BB, Q, Z, lwork=-1)
-        lwork = result[-3][0].real.astype(np.int)
+        lwork = result[-3][0].real.astype(np.int_)
         # looks like wrong value passed to ZTGSYL if not
         lwork += 1
 

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -75,7 +75,7 @@ def _geneig(a1, b1, left, right, overwrite_a, overwrite_b,
     ggev, = get_lapack_funcs(('ggev',), (a1, b1))
     cvl, cvr = left, right
     res = ggev(a1, b1, lwork=-1)
-    lwork = res[-2][0].real.astype(numpy.int)
+    lwork = res[-2][0].real.astype(numpy.int_)
     if ggev.typecode in 'cz':
         alpha, beta, vl, vr, work, info = ggev(a1, b1, cvl, cvr, lwork,
                                                overwrite_a, overwrite_b)

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -15,7 +15,7 @@ def safecall(f, name, *args, **kwargs):
     if lwork in (None, -1):
         kwargs['lwork'] = -1
         ret = f(*args, **kwargs)
-        kwargs['lwork'] = ret[-2][0].real.astype(numpy.int)
+        kwargs['lwork'] = ret[-2][0].real.astype(numpy.int_)
     ret = f(*args, **kwargs)
     if ret[-1] < 0:
         raise ValueError("illegal value in %dth argument of internal %s"

--- a/scipy/linalg/decomp_schur.py
+++ b/scipy/linalg/decomp_schur.py
@@ -134,7 +134,7 @@ def schur(a, output='real', lwork=None, overwrite_a=False, sort=None,
     if lwork is None or lwork == -1:
         # get optimal work array
         result = gees(lambda x: None, a1, lwork=-1)
-        lwork = result[-2][0].real.astype(numpy.int)
+        lwork = result[-2][0].real.astype(numpy.int_)
 
     if sort is None:
         sort_t = 0

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -2442,7 +2442,7 @@ class TestOrdQZWorkspaceSize(object):
             _ = ordqz(A, B, sort=lambda alpha, beta: alpha < beta,
                       output='real')
 
-        for ddtype in [np.complex, np.complex64]:
+        for ddtype in [np.complex128, np.complex64]:
             A = random((N, N)).astype(ddtype)
             B = random((N, N)).astype(ddtype)
             _ = ordqz(A, B, sort=lambda alpha, beta: alpha < beta,
@@ -2454,7 +2454,7 @@ class TestOrdQZWorkspaceSize(object):
         N = 202
 
         # segfaults if lwork parameter to dtrsen is too small
-        for ddtype in [np.float32, np.float64, np.complex, np.complex64]:
+        for ddtype in [np.float32, np.float64, np.complex128, np.complex64]:
             A = random((N, N)).astype(ddtype)
             B = random((N, N)).astype(ddtype)
             S, T, alpha, beta, U, V = ordqz(A, B, sort='ouc')

--- a/scipy/linalg/tests/test_decomp_cossin.py
+++ b/scipy/linalg/tests/test_decomp_cossin.py
@@ -70,7 +70,7 @@ def test_cossin(dtype_, m, p, q, swap_sign):
 
 def test_cossin_mixed_types():
     seed(1234)
-    x = np.array(ortho_group.rvs(4), dtype=np.float)
+    x = np.array(ortho_group.rvs(4), dtype=np.float64)
     u, cs, vh = cossin([x[:2, :2],
                         np.array(x[:2, 2:], dtype=np.complex128),
                         x[2:, :2],
@@ -117,7 +117,7 @@ def test_cossin_error_non_square():
         cossin(np.array([[1, 2]]), 1, 1)
 
 def test_cossin_error_partitioning():
-    x = np.array(ortho_group.rvs(4), dtype=np.float)
+    x = np.array(ortho_group.rvs(4), dtype=np.float64)
     with pytest.raises(ValueError, match="invalid p=0.*0<p<4.*"):
         cossin(x, 0, 1)
     with pytest.raises(ValueError, match="invalid p=4.*0<p<4.*"):

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -606,7 +606,7 @@ class TestTbtrs(object):
         """Test if invalid values of uplo, trans and diag raise exceptions"""
         # Argument checks occur independently of used datatype.
         # This mean we must not parameterize all available datatypes.
-        tbtrs = get_lapack_funcs('tbtrs', dtype=np.float)
+        tbtrs = get_lapack_funcs('tbtrs', dtype=np.float64)
         ab = rand(4, 2)
         b = rand(2, 4)
         assert_raises(Exception, tbtrs, ab, b, uplo, trans, diag)

--- a/scipy/ndimage/measurements.py
+++ b/scipy/ndimage/measurements.py
@@ -554,7 +554,7 @@ def _stats(input, labels=None, index=None, centered=False):
         if centered:
             sums_c = _sum_centered(labels)
         # make sure all index values are valid
-        idxs = numpy.asanyarray(index, numpy.int).copy()
+        idxs = numpy.asanyarray(index, numpy.int_).copy()
         found = (idxs >= 0) & (idxs < counts.size)
         idxs[~found] = 0
 
@@ -665,7 +665,7 @@ def mean(input, labels=None, index=None):
     """
 
     count, sum = _stats(input, labels, index)
-    return sum / numpy.asanyarray(count).astype(numpy.float)
+    return sum / numpy.asanyarray(count).astype(numpy.float64)
 
 
 def variance(input, labels=None, index=None):
@@ -831,7 +831,7 @@ def _select(input, labels=None, index=None, find_min=False, find_max=False,
         found = (unique_labels[idxs] == index)
     else:
         # labels are an integer type, and there aren't too many
-        idxs = numpy.asanyarray(index, numpy.int).copy()
+        idxs = numpy.asanyarray(index, numpy.int_).copy()
         found = (idxs >= 0) & (idxs <= labels.max())
 
     idxs[~ found] = labels.max() + 1
@@ -864,9 +864,9 @@ def _select(input, labels=None, index=None, find_min=False, find_max=False,
         result += [maxpos[idxs]]
     if find_median:
         locs = numpy.arange(len(labels))
-        lo = numpy.zeros(labels.max() + 2, numpy.int)
+        lo = numpy.zeros(labels.max() + 2, numpy.int_)
         lo[labels[::-1]] = locs[::-1]
-        hi = numpy.zeros(labels.max() + 2, numpy.int)
+        hi = numpy.zeros(labels.max() + 2, numpy.int_)
         hi[labels] = locs
         lo = lo[idxs]
         hi = hi[idxs]

--- a/scipy/ndimage/src/_ni_label.pyx
+++ b/scipy/ndimage/src/_ni_label.pyx
@@ -209,7 +209,7 @@ cpdef _label(np.ndarray input,
         ("Shapes must match for input and output,"
          "{} != {}".format((<object> input).shape, (<object> output).shape))
 
-    structure = np.asanyarray(structure, dtype=np.int).copy()
+    structure = np.asanyarray(structure, dtype=np.int_).copy()
     assert input.ndim == structure.ndim, \
         ("Structuring element must have same "
          "# of dimensions as input, "
@@ -228,9 +228,9 @@ cpdef _label(np.ndarray input,
     assert input.ndim > 0 and input.size > 0, "Cannot label scalars or empty arrays"
 
     # if we're handed booleans, we treat them as uint8s
-    if input.dtype == np.bool:
+    if input.dtype == np.bool_:
         input = input.view(dtype=np.uint8)
-    if output.dtype == np.bool:
+    if output.dtype == np.bool_:
         # XXX - trigger special check for bit depth?
         output = output.view(dtype=np.uint8)
 

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -4633,7 +4633,7 @@ class TestNdimage:
         structure = numpy.ones((3, 3), dtype=numpy.bool_)
 
         # Check that type mismatch is properly handled
-        output = numpy.empty_like(array, dtype=numpy.float)
+        output = numpy.empty_like(array, dtype=numpy.float64)
         ndimage.white_tophat(array, structure=structure, output=output)
 
     def test_black_tophat01(self):
@@ -4688,7 +4688,7 @@ class TestNdimage:
         structure = numpy.ones((3, 3), dtype=numpy.bool_)
 
         # Check that type mismatch is properly handled
-        output = numpy.empty_like(array, dtype=numpy.float)
+        output = numpy.empty_like(array, dtype=numpy.float64)
         ndimage.black_tophat(array, structure=structure, output=output)
 
     def test_hit_or_miss01(self):

--- a/scipy/optimize/_linprog_util.py
+++ b/scipy/optimize/_linprog_util.py
@@ -253,7 +253,7 @@ def _clean_inputs(lp):
         raise TypeError
 
     try:
-        c = np.array(c, dtype=np.float, copy=True).squeeze()
+        c = np.array(c, dtype=np.float64, copy=True).squeeze()
     except ValueError:
         raise TypeError(
             "Invalid input for linprog: c must be a 1-D array of numerical "

--- a/scipy/optimize/_lsap.py
+++ b/scipy/optimize/_lsap.py
@@ -82,7 +82,7 @@ def linear_sum_assignment(cost_matrix, maximize=False):
                          % (cost_matrix.shape,))
 
     if not (np.issubdtype(cost_matrix.dtype, np.number) or
-            cost_matrix.dtype == np.dtype(np.bool)):
+            cost_matrix.dtype == np.dtype(np.bool_)):
         raise ValueError("expected a matrix containing numerical entries, got %s"
                          % (cost_matrix.dtype,))
 

--- a/scipy/optimize/_trlib/_trlib.pyx
+++ b/scipy/optimize/_trlib/_trlib.pyx
@@ -27,7 +27,7 @@ class TRLIBQuadraticSubproblem(BaseQuadraticSubproblem):
         if fwork_view.shape[0] > 0:
             fwork_ptr = &fwork_view[0]
         ctrlib.trlib_krylov_prepare_memory(itmax, fwork_ptr)
-        self.iwork = np.zeros([iwork_size], dtype=np.int)
+        self.iwork = np.zeros([iwork_size], dtype=np.int_)
         self.s  = np.empty(self.jac.shape)
         self.g  = np.empty(self.jac.shape)
         self.v  = np.empty(self.jac.shape)
@@ -36,7 +36,7 @@ class TRLIBQuadraticSubproblem(BaseQuadraticSubproblem):
         self.Hp = np.empty(self.jac.shape)
         self.Q  = np.empty([self.itmax+1, self.jac.shape[0]])
         self.timing = np.zeros([ctrlib.trlib_krylov_timing_size()],
-                               dtype=np.int)
+                               dtype=np.int_)
         self.init = ctrlib._TRLIB_CLS_INIT
 
     def solve(self, double trust_radius):

--- a/scipy/optimize/_trustregion_constr/canonical_constraint.py
+++ b/scipy/optimize/_trustregion_constr/canonical_constraint.py
@@ -88,7 +88,7 @@ class CanonicalConstraint(object):
         def hess(x, v_eq, v_ineq):
             return empty_hess
 
-        return cls(0, 0, fun, jac, hess, np.empty(0, dtype=np.bool))
+        return cls(0, 0, fun, jac, hess, np.empty(0, dtype=np.bool_))
 
     @classmethod
     def concatenate(cls, canonical_constraints, sparse_jacobian):

--- a/scipy/optimize/tests/test_linear_assignment.py
+++ b/scipy/optimize/tests/test_linear_assignment.py
@@ -77,7 +77,7 @@ def test_linear_sum_assignment_input_validation():
                        linear_sum_assignment(matrix(C)))
 
     I = np.identity(3)
-    assert_array_equal(linear_sum_assignment(I.astype(np.bool)),
+    assert_array_equal(linear_sum_assignment(I.astype(np.bool_)),
                        linear_sum_assignment(I))
     assert_raises(ValueError, linear_sum_assignment, I.astype(str))
 

--- a/scipy/signal/_peak_finding_utils.pyx
+++ b/scipy/signal/_peak_finding_utils.pyx
@@ -154,7 +154,7 @@ def _select_by_peak_distance(np.intp_t[::1] peaks not None,
                 keep[k] = 0
                 k += 1
 
-    return keep.base.view(dtype=np.bool)  # Return as boolean array
+    return keep.base.view(dtype=np.bool_)  # Return as boolean array
 
 
 class PeakPropertyWarning(RuntimeWarning):

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -1925,7 +1925,7 @@ def _cast_to_array_dtype(in1, in2):
 
     Those can be raised when casting complex to real.
     """
-    if numpy.issubdtype(in2.dtype, numpy.float):
+    if numpy.issubdtype(in2.dtype, numpy.float64):
         # dtype to cast to is not complex, so use .real
         in1 = in1.real.astype(in2.dtype)
     else:

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -3653,7 +3653,7 @@ class TestIIRFilter(object):
 
     def test_int_inputs(self):
         # Using integer frequency arguments and large N should not produce
-        # np.ints that wraparound to negative numbers
+        # numpy integers that wraparound to negative numbers
         k = iirfilter(24, 100, btype='low', analog=True, ftype='bessel',
                       output='zpk')[2]
         k2 = 9.999999999999989e+47

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -176,8 +176,8 @@ def test_dijkstra_indices_min_only(directed, SP_ans, indices):
 def test_shortest_path_min_only_random(n):
     np.random.seed(1234)
     data = scipy.sparse.rand(n, n, density=0.5, format='lil',
-                             random_state=42, dtype=np.float)
-    data.setdiag(np.zeros(n, dtype=np.bool))
+                             random_state=42, dtype=np.float64)
+    data.setdiag(np.zeros(n, dtype=np.bool_))
     # choose some random vertices
     v = np.arange(n)
     np.random.shuffle(v)

--- a/scipy/sparse/linalg/dsolve/linsolve.py
+++ b/scipy/sparse/linalg/dsolve/linsolve.py
@@ -574,7 +574,7 @@ def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False,
             '{} and the shape of b is {}.'.format(A.shape, b.shape))
 
     # Init x as (a copy of) b.
-    x_dtype = np.result_type(A.data, b, np.float)
+    x_dtype = np.result_type(A.data, b, np.float64)
     if overwrite_b:
         if np.can_cast(b.dtype, x_dtype, casting='same_kind'):
             x = b

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3947,11 +3947,11 @@ class TestLIL(sparse_test_class(minmax=False)):
     math_dtypes = [np.int_, np.float_, np.complex_]
 
     def test_dot(self):
-        A = zeros((10,10), np.complex)
+        A = zeros((10,10), np.complex128)
         A[0,3] = 10
         A[5,6] = 20j
 
-        B = lil_matrix((10,10), dtype=np.complex)
+        B = lil_matrix((10,10), dtype=np.complex128)
         B[0,3] = 10
         B[5,6] = 20j
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3947,13 +3947,13 @@ class TestLIL(sparse_test_class(minmax=False)):
     math_dtypes = [np.int_, np.float_, np.complex_]
 
     def test_dot(self):
-        A = zeros((10,10), np.complex128)
-        A[0,3] = 10
-        A[5,6] = 20j
+        A = zeros((10, 10), np.complex128)
+        A[0, 3] = 10
+        A[5, 6] = 20j
 
-        B = lil_matrix((10,10), dtype=np.complex128)
-        B[0,3] = 10
-        B[5,6] = 20j
+        B = lil_matrix((10, 10), dtype=np.complex128)
+        B[0, 3] = 10
+        B[5, 6] = 20j
 
         # TODO: properly handle this assertion on ppc64le
         if platform.machine() != 'ppc64le':
@@ -3962,86 +3962,87 @@ class TestLIL(sparse_test_class(minmax=False)):
         assert_array_equal(A @ A.conjugate().T, (B * B.H).todense())
 
     def test_scalar_mul(self):
-        x = lil_matrix((3,3))
-        x[0,0] = 2
+        x = lil_matrix((3, 3))
+        x[0, 0] = 2
 
         x = x*2
-        assert_equal(x[0,0],4)
+        assert_equal(x[0, 0], 4)
 
         x = x*0
-        assert_equal(x[0,0],0)
+        assert_equal(x[0, 0], 0)
 
     def test_inplace_ops(self):
-        A = lil_matrix([[0,2,3],[4,0,6]])
-        B = lil_matrix([[0,1,0],[0,2,3]])
+        A = lil_matrix([[0, 2, 3], [4, 0, 6]])
+        B = lil_matrix([[0, 1, 0], [0, 2, 3]])
 
-        data = {'add': (B,A + B),
-                'sub': (B,A - B),
-                'mul': (3,A * 3)}
+        data = {'add': (B, A + B),
+                'sub': (B, A - B),
+                'mul': (3, A * 3)}
 
-        for op,(other,expected) in data.items():
+        for op, (other, expected) in data.items():
             result = A.copy()
             getattr(result, '__i%s__' % op)(other)
 
             assert_array_equal(result.todense(), expected.todense())
 
         # Ticket 1604.
-        A = lil_matrix((1,3), dtype=np.dtype('float64'))
-        B = array([0.1,0.1,0.1])
-        A[0,:] += B
-        assert_array_equal(A[0,:].toarray().squeeze(), B)
+        A = lil_matrix((1, 3), dtype=np.dtype('float64'))
+        B = array([0.1, 0.1, 0.1])
+        A[0, :] += B
+        assert_array_equal(A[0, :].toarray().squeeze(), B)
 
     def test_lil_iteration(self):
-        row_data = [[1,2,3],[4,5,6]]
+        row_data = [[1, 2, 3], [4, 5, 6]]
         B = lil_matrix(array(row_data))
-        for r,row in enumerate(B):
-            assert_array_equal(row.todense(),array(row_data[r],ndmin=2))
+        for r, row in enumerate(B):
+            assert_array_equal(row.todense(), array(row_data[r], ndmin=2))
 
     def test_lil_from_csr(self):
         # Tests whether a lil_matrix can be constructed from a
         # csr_matrix.
-        B = lil_matrix((10,10))
-        B[0,3] = 10
-        B[5,6] = 20
-        B[8,3] = 30
-        B[3,8] = 40
-        B[8,9] = 50
+        B = lil_matrix((10, 10))
+        B[0, 3] = 10
+        B[5, 6] = 20
+        B[8, 3] = 30
+        B[3, 8] = 40
+        B[8, 9] = 50
         C = B.tocsr()
         D = lil_matrix(C)
         assert_array_equal(C.A, D.A)
 
     def test_fancy_indexing_lil(self):
-        M = asmatrix(arange(25).reshape(5,5))
+        M = asmatrix(arange(25).reshape(5, 5))
         A = lil_matrix(M)
 
-        assert_equal(A[array([1,2,3]),2:3].todense(), M[array([1,2,3]),2:3])
+        assert_equal(A[array([1, 2, 3]), 2:3].todense(),
+                     M[array([1, 2, 3]), 2:3])
 
     def test_point_wise_multiply(self):
-        l = lil_matrix((4,3))
-        l[0,0] = 1
-        l[1,1] = 2
-        l[2,2] = 3
-        l[3,1] = 4
+        l = lil_matrix((4, 3))
+        l[0, 0] = 1
+        l[1, 1] = 2
+        l[2, 2] = 3
+        l[3, 1] = 4
 
-        m = lil_matrix((4,3))
-        m[0,0] = 1
-        m[0,1] = 2
-        m[2,2] = 3
-        m[3,1] = 4
-        m[3,2] = 4
+        m = lil_matrix((4, 3))
+        m[0, 0] = 1
+        m[0, 1] = 2
+        m[2, 2] = 3
+        m[3, 1] = 4
+        m[3, 2] = 4
 
         assert_array_equal(l.multiply(m).todense(),
                            m.multiply(l).todense())
 
         assert_array_equal(l.multiply(m).todense(),
-                           [[1,0,0],
-                            [0,0,0],
-                            [0,0,9],
-                            [0,16,0]])
+                           [[1, 0, 0],
+                            [0, 0, 0],
+                            [0, 0, 9],
+                            [0, 16, 0]])
 
     def test_lil_multiply_removal(self):
         # Ticket #1427.
-        a = lil_matrix(np.ones((3,3)))
+        a = lil_matrix(np.ones((3, 3)))
         a *= 2.
         a[0, :] = 0
 
@@ -4666,8 +4667,7 @@ class Test64Bit(object):
 
     def _compare_index_dtype(self, m, dtype):
         dtype = np.dtype(dtype)
-        if isinstance(m, csc_matrix) or isinstance(m, csr_matrix) \
-               or isinstance(m, bsr_matrix):
+        if isinstance(m, (csc_matrix, csr_matrix, bsr_matrix)):
             return (m.indices.dtype == dtype) and (m.indptr.dtype == dtype)
         elif isinstance(m, coo_matrix):
             return (m.row.dtype == dtype) and (m.col.dtype == dtype)

--- a/scipy/spatial/tests/test_spherical_voronoi.py
+++ b/scipy/spatial/tests/test_spherical_voronoi.py
@@ -290,7 +290,7 @@ class TestSphericalVoronoi(object):
 
         # generate points of the hypercube
         expected = np.vstack(list(itertools.product([-1, 1], repeat=dim)))
-        expected = expected.astype(np.float) / np.sqrt(dim)
+        expected = expected.astype(np.float64) / np.sqrt(dim)
 
         # test that Voronoi vertices are correctly placed
         dist = distance.cdist(sv.vertices, expected)
@@ -304,7 +304,7 @@ class TestSphericalVoronoi(object):
 
         # generate points of the hypercube
         points = np.vstack(list(itertools.product([-1, 1], repeat=dim)))
-        points = points.astype(np.float) / np.sqrt(dim)
+        points = points.astype(np.float64) / np.sqrt(dim)
         sv = SphericalVoronoi(points)
 
         # generate points of the cross-polytope

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2328,7 +2328,7 @@ def factorial(n, exact=False):
             n = asarray(n)
             un = np.unique(n).astype(object)
 
-            # Convert to object array of long ints if np.int can't handle size
+            # Convert to object array of long ints if np.int_ can't handle size
             if np.isnan(n).any():
                 dt = float
             elif un[-1] > 20:
@@ -2336,7 +2336,7 @@ def factorial(n, exact=False):
             elif un[-1] > 12:
                 dt = np.int64
             else:
-                dt = np.int
+                dt = np.int_
 
             out = np.empty_like(n, dtype=dt)
 

--- a/scipy/special/_test_round.pyx
+++ b/scipy/special/_test_round.pyx
@@ -33,10 +33,10 @@ def have_fenv():
 def random_double(size):
     # This code is a little hacky to work around some issues:
     # - randint doesn't have a dtype keyword until 1.11
-    #   and the default type of randint is np.int
+    #   and the default type of randint is np.int_
     # - Something like
-    #   >>> low = np.iinfo(np.int).min
-    #   >>> high = np.iinfo(np.int).max + 1
+    #   >>> low = np.iinfo(np.int_).min
+    #   >>> high = np.iinfo(np.int_).max + 1
     #   >>> np.random.randint(low=low, high=high)
     #   fails in NumPy 1.10.4 (note that the 'high' value in randint
     #   is exclusive); this is fixed in 1.11.

--- a/scipy/special/orthogonal.py
+++ b/scipy/special/orthogonal.py
@@ -76,7 +76,7 @@ References
 
 # SciPy imports.
 import numpy as np
-from numpy import (exp, inf, pi, sqrt, floor, sin, cos, around, int,
+from numpy import (exp, inf, pi, sqrt, floor, sin, cos, around,
                    hstack, arccos, arange)
 from scipy import linalg
 from scipy.special import airy

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4502,7 +4502,8 @@ class levy_stable_gen(rv_continuous):
                                 (np.cos(alpha*xi+(alpha-1)*theta)/np.cos(theta))
             if x0 > zeta:
                 def g(theta):
-                    return V(theta)*np.real(np.complex(x0-zeta)**(alpha/(alpha-1)))
+                    return (V(theta) *
+                            np.real(np.complex128(x0-zeta)**(alpha/(alpha-1))))
 
                 def f(theta):
                     return g(theta) * np.exp(-g(theta))
@@ -4566,7 +4567,8 @@ class levy_stable_gen(rv_continuous):
                 c_1 = 1 if alpha > 1 else .5 - xi/np.pi
 
                 def f(theta):
-                    return np.exp(-V(theta)*np.real(np.complex(x0-zeta)**(alpha/(alpha-1))))
+                    z = np.complex128(x0 - zeta)
+                    return np.exp(-V(theta) * np.real(z**(alpha/(alpha-1))))
 
                 with np.errstate(all="ignore"):
                     # spare calculating integral on null set
@@ -7603,7 +7605,8 @@ class truncnorm_gen(rv_continuous):
             return moments[-1]
 
         return _lazywhere((n >= 0) & (a == a) & (b == b), (n, a, b),
-                          np.vectorize(n_th_moment, otypes=[np.float]), np.nan)
+                          np.vectorize(n_th_moment, otypes=[np.float64]),
+                          np.nan)
 
     def _stats(self, a, b, moments='mv'):
         pA, pB = self._pdf(np.array([a, b]), a, b)
@@ -8370,7 +8373,7 @@ class crystalball_gen(rv_continuous):
             return A * lhs + rhs
 
         return N * _lazywhere(n + 1 < m, (n, beta, m),
-                              np.vectorize(n_th_moment, otypes=[np.float]),
+                              np.vectorize(n_th_moment, otypes=[np.float64]),
                               np.inf)
 
     def _argcheck(self, beta, m):

--- a/scipy/stats/_ksstats.py
+++ b/scipy/stats/_ksstats.py
@@ -522,7 +522,8 @@ def kolmogn(n, x, cdf=True):
 
     The return value has shape the result of numpy broadcasting n and x.
     """
-    it = np.nditer([n, x, cdf, None], op_dtypes=[None, np.float, np.bool, np.float])
+    it = np.nditer([n, x, cdf, None],
+                   op_dtypes=[None, np.float64, np.bool_, np.float64])
     for _n, _x, _cdf, z in it:
         if np.isnan(_n):
             z[...] = _n

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -3032,7 +3032,7 @@ class multinomial_gen(multi_rv_generic):
         pcond = np.any(p < 0, axis=-1)
         pcond |= np.any(p > 1, axis=-1)
 
-        n = np.array(n, dtype=np.int, copy=True)
+        n = np.array(n, dtype=np.int_, copy=True)
 
         # true for bad n
         ncond = n <= 0
@@ -3046,7 +3046,7 @@ class multinomial_gen(multi_rv_generic):
         x_ is an int array; xcond is a boolean array flagging values out of the
         domain.
         """
-        xx = np.asarray(x, dtype=np.int)
+        xx = np.asarray(x, dtype=np.int_)
 
         if xx.ndim == 0:
             raise ValueError("x must be an array.")

--- a/scipy/stats/_stats.pyx
+++ b/scipy/stats/_stats.pyx
@@ -334,7 +334,7 @@ def _center_distance_matrix(distx, global_corr='mgc', is_ranked=True):
         rank_distx = _rank_distance_matrix(distx)
 
     if global_corr == "rank":
-        distx = rank_distx.astype(np.float, copy=False)
+        distx = rank_distx.astype(np.float64, copy=False)
 
     # 'mgc' distance transform (col-wise mean) - default
     cdef ndarray exp_distx = np.repeat(((distx.mean(axis=0) * n) / (n-1)), n).reshape(-1, n).T

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -567,7 +567,7 @@ def mode(a, axis=0, nan_policy='propagate'):
 
     inds = np.ndindex(a_view.shape[:-1])
     modes = np.empty(a_view.shape[:-1], dtype=a.dtype)
-    counts = np.zeros(a_view.shape[:-1], dtype=np.int)
+    counts = np.zeros(a_view.shape[:-1], dtype=np.int_)
     for ind in inds:
         modes[ind], counts[ind] = _mode1D(a_view[ind])
     newshape = list(a.shape)
@@ -6715,7 +6715,7 @@ def ks_2samp(data1, data2, alternative='two-sided', mode='auto'):
         mode = 'exact' if max(n1, n2) <= MAX_AUTO_N else 'asymp'
     elif mode == 'exact':
         # If lcm(n1, n2) is too big, switch from exact to asymp
-        if n1g >= np.iinfo(np.int).max / n2g:
+        if n1g >= np.iinfo(np.int_).max / n2g:
             mode = 'asymp'
             warnings.warn(
                 "Exact ks_2samp calculation not possible with samples sizes "


### PR DESCRIPTION
Don't use `np.int`, `np.float`, etc.  These numpy names will
be deprecated; see https://github.com/numpy/numpy/pull/14882.
