### PR TITLE
MAINT: SciPy 1.5.0rc2 backports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
             . venv/bin/activate
             pip install --install-option="--no-cython-compile" cython
             pip install numpy
-            pip install nose mpmath argparse Pillow codecov matplotlib Sphinx
+            pip install nose mpmath argparse Pillow codecov matplotlib "Sphinx!=3.1.0"
             pip install pybind11
 
       - run:

--- a/.travis.yml
+++ b/.travis.yml
@@ -206,8 +206,11 @@ before_install:
     fi
   - |
     if [ -z "${USE_DEBUG}" -a "${TRAVIS_CPU_ARCH}" == "amd64" -a "${TRAVIS_PYTHON_VERSION}" != "3.8" ]; then
-        travis_retry pip install numba==0.49.1
-        travis_retry pip install --only-binary=:all: sparse
+        if ! expr "$NUMPYSPEC" : ".*--pre.*" > /dev/null; then
+            # Install these only when not using Numpy prerelease
+            travis_retry pip install numba==0.49.1
+            travis_retry pip install --only-binary=:all: sparse
+        fi
     fi
   - |
     if [ -n "${TEST_GROUP_COUNT}" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,20 @@ matrix:
         - USE_WHEEL=1
         - PIP_NO_CACHE_DIR=off
         - NUMPYSPEC="numpy"
+        - TEST_GROUP_COUNT=2
+        - TEST_GROUP=1
+    - python: 3.7
+      if: type = pull_request
+      arch: arm64
+      dist: bionic
+      env:
+        - TESTMODE=fast
+        - COVERAGE=
+        - USE_WHEEL=1
+        - PIP_NO_CACHE_DIR=off
+        - NUMPYSPEC="numpy"
+        - TEST_GROUP_COUNT=2
+        - TEST_GROUP=2
     - python: 3.7
       if: type = pull_request
       env:
@@ -155,6 +169,18 @@ before_install:
   - uname -a
   - df -h
   - ulimit -a
+  - set -o pipefail
+  - if [[ "${TRAVIS_CPU_ARCH}" == "arm64" ]]; then
+      wget -q "https://github.com/conda-forge/miniforge/releases/download/4.8.2-1/Miniforge3-4.8.2-1-Linux-aarch64.sh"  -O miniconda.sh;
+      chmod +x miniconda.sh;
+      ./miniconda.sh -b -p $HOME/miniconda3;
+      export PATH=$HOME/miniconda3/bin:$PATH;
+      conda config --set always_yes yes --set auto_update_conda false;
+      conda install pip conda;
+      conda update -n base conda;
+      conda info -a;
+      conda install pytest pytest-xdist $NUMPYSPEC mpmath gmpy2 Cython pybind11;
+    fi
   - mkdir builds
   - cd builds
   - |
@@ -184,6 +210,11 @@ before_install:
         travis_retry pip install --only-binary=:all: sparse
     fi
   - |
+    if [ -n "${TEST_GROUP_COUNT}" ]; then
+        travis_retry pip install pytest-test-groups
+        export TEST_GROUP_ARGS="--test-group-count=${TEST_GROUP_COUNT} --test-group=${TEST_GROUP} --test-group-random-seed=1234"
+    fi
+  - |
     if [ "${TESTMODE}" == "full" ]; then
         travis_retry pip install pytest-cov coverage matplotlib scikit-umfpack scikit-sparse
     fi
@@ -201,18 +232,6 @@ before_install:
     fi
   - ccache -s
   - cd ..
-  - set -o pipefail
-  - if [[ "${TRAVIS_CPU_ARCH}" == "arm64" ]]; then
-      wget -q "https://github.com/conda-forge/miniforge/releases/download/4.8.2-1/Miniforge3-4.8.2-1-Linux-aarch64.sh"  -O miniconda.sh;
-      chmod +x miniconda.sh;
-      ./miniconda.sh -b -p $HOME/miniconda3;
-      export PATH=$HOME/miniconda3/bin:$PATH;
-      conda config --set always_yes yes --set auto_update_conda false;
-      conda install pip conda;
-      conda update -n base conda;
-      conda info -a;
-      conda install pytest pytest-xdist $NUMPYSPEC mpmath gmpy2 Cython pybind11;
-    fi
 
 
 script:
@@ -246,7 +265,7 @@ script:
         USE_WHEEL_BUILD="--no-build"
     fi
   - export SCIPY_AVAILABLE_MEM=3G
-  - python -u runtests.py -g -m $TESTMODE $COVERAGE $USE_WHEEL_BUILD -- -rfEX --durations=10 -n 3 2>&1 | tee runtests.log
+  - python -u runtests.py -g -m $TESTMODE $COVERAGE $USE_WHEEL_BUILD -- -rfEX --durations=10 -n 3 $TEST_GROUP_ARGS 2>&1 | tee runtests.log
 
   - tools/validate_runtests_log.py $TESTMODE < runtests.log
   - if [ "${REFGUIDE_CHECK}" == "1" ]; then python runtests.py -g --refguide-check; fi

--- a/doc/release/1.5.0-notes.rst
+++ b/doc/release/1.5.0-notes.rst
@@ -1130,6 +1130,7 @@ Pull requests for 1.5.0
 * `#12229 <https://github.com/scipy/scipy/pull/12229>`__: MAINT: tools/gh_lists.py: fix http header case sensitivity issue
 * `#12236 <https://github.com/scipy/scipy/pull/12236>`__: DOC: Fix a couple grammatical mistakes in 1.5.0-notes.rst.
 * `#12276 <https://github.com/scipy/scipy/pull/12276>`__: TST: skip `test_heequb`, it fails intermittently.
+* `#12285 <https://github.com/scipy/scipy/pull/12285>`__: CI: split travis arm64 run into two
 * `#12317 <https://github.com/scipy/scipy/pull/12317>`__: BUG: prevent error accumulation in `Rotation` multiplication
 * `#12318 <https://github.com/scipy/scipy/pull/12318>`__: BUG: sparse: avoid np.prod overflow in check_shape
 * `#12319 <https://github.com/scipy/scipy/pull/12319>`__: BUG: Make cobyla threadsafe

--- a/doc/release/1.5.0-notes.rst
+++ b/doc/release/1.5.0-notes.rst
@@ -384,6 +384,7 @@ Authors
 * Kevin Green +
 * Martin Grignard +
 * Maja Gwozdz
+* Sturla Molden
 * gyu-don +
 * Matt Haberland
 * hakeemo +
@@ -507,6 +508,7 @@ Issues closed for 1.5.0
 * `#9212 <https://github.com/scipy/scipy/issues/9212>`__: EIGH very very slow --> suggesting an easy fix
 * `#9553 <https://github.com/scipy/scipy/issues/9553>`__: ndimage routines behave badly when output has memory overlap...
 * `#9632 <https://github.com/scipy/scipy/issues/9632>`__: ndimage.maximum_filter undocumented behaviour using footprint...
+* `#9658 <https://github.com/scipy/scipy/issues/9658>`__: `scipy.optimize.minimize(method='COBYLA')` not threadsafe
 * `#9710 <https://github.com/scipy/scipy/issues/9710>`__: stats.weightedtau([1], [1.0]) SEGFAULTs
 * `#9797 <https://github.com/scipy/scipy/issues/9797>`__: Master Tracker for some Kolmogorov-Smirnov test Issues
 * `#9844 <https://github.com/scipy/scipy/issues/9844>`__: scipy.signal.upfirdn gives different length matrix versus MATLAB...
@@ -651,6 +653,8 @@ Issues closed for 1.5.0
 * `#12178 <https://github.com/scipy/scipy/issues/12178>`__: BUG: stats: Some discrete distributions don't accept lists of...
 * `#12220 <https://github.com/scipy/scipy/issues/12220>`__: BUG, REL: gh_lists.py compromised scraping
 * `#12239 <https://github.com/scipy/scipy/issues/12239>`__: BUG: median absolute deviation handling of nan 
+* `#12301 <https://github.com/scipy/scipy/issues/12301>`__: integer overflow in scipy.sparse.sputils.check_shape when matrix size > 2^32
+* `#12314 <https://github.com/scipy/scipy/issues/12314>`__: scipy.spatial.transform.Rotation multiplication does not normalize quaternion
 
 Pull requests for 1.5.0
 -----------------------
@@ -1125,4 +1129,8 @@ Pull requests for 1.5.0
 * `#12227 <https://github.com/scipy/scipy/pull/12227>`__: BLD: Set macos min version when building rectangular_lsap
 * `#12229 <https://github.com/scipy/scipy/pull/12229>`__: MAINT: tools/gh_lists.py: fix http header case sensitivity issue
 * `#12236 <https://github.com/scipy/scipy/pull/12236>`__: DOC: Fix a couple grammatical mistakes in 1.5.0-notes.rst.
+* `#12276 <https://github.com/scipy/scipy/pull/12276>`__: TST: skip `test_heequb`, it fails intermittently.
+* `#12317 <https://github.com/scipy/scipy/pull/12317>`__: BUG: prevent error accumulation in `Rotation` multiplication
+* `#12318 <https://github.com/scipy/scipy/pull/12318>`__: BUG: sparse: avoid np.prod overflow in check_shape
+* `#12319 <https://github.com/scipy/scipy/pull/12319>`__: BUG: Make cobyla threadsafe
 

--- a/doc/release/1.5.0-notes.rst
+++ b/doc/release/1.5.0-notes.rst
@@ -1133,4 +1133,5 @@ Pull requests for 1.5.0
 * `#12317 <https://github.com/scipy/scipy/pull/12317>`__: BUG: prevent error accumulation in `Rotation` multiplication
 * `#12318 <https://github.com/scipy/scipy/pull/12318>`__: BUG: sparse: avoid np.prod overflow in check_shape
 * `#12319 <https://github.com/scipy/scipy/pull/12319>`__: BUG: Make cobyla threadsafe
+* `#12335 <https://github.com/scipy/scipy/pull/12335>`__: MAINT: Work around Sphinx bug
 

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -140,6 +140,19 @@ def _prune_array(array):
     return array
 
 
+def prod(iterable):
+    """
+    Product of a sequence of numbers.
+
+    Faster than np.prod for short lists like array shapes, and does
+    not overflow if using Python integers.
+    """
+    product = 1
+    for x in iterable:
+        product *= x
+    return product
+
+
 class DeprecatedImport(object):
     """
     Deprecated import with redirection and warning.

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -8,16 +8,9 @@ from scipy.linalg import (get_lapack_funcs, LinAlgError,
 from . import _bspl
 from . import _fitpack_impl
 from . import _fitpack as _dierckx
+from scipy._lib._util import prod
 
 __all__ = ["BSpline", "make_interp_spline", "make_lsq_spline"]
-
-
-# copy-paste from interpolate.py
-def prod(x):
-    """Product of a list of numbers; ~40x faster vs np.prod for Python tuples"""
-    if len(x) == 0:
-        return 1
-    return functools.reduce(operator.mul, x)
 
 
 def _get_dtype(dtype):

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -12,6 +12,7 @@ from numpy import (array, transpose, searchsorted, atleast_1d, atleast_2d,
 
 import scipy.special as spec
 from scipy.special import comb
+from scipy._lib._util import prod
 
 from . import fitpack
 from . import dfitpack
@@ -21,13 +22,6 @@ from . import _ppoly
 from .fitpack2 import RectBivariateSpline
 from .interpnd import _ndim_coords_from_arrays
 from ._bsplines import make_interp_spline, BSpline
-
-
-def prod(x):
-    """Product of a list of numbers; ~40x faster vs np.prod for Python tuples"""
-    if len(x) == 0:
-        return 1
-    return functools.reduce(operator.mul, x)
 
 
 def lagrange(x, w):

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -1748,6 +1748,7 @@ def test_syequb():
         assert_equal(np.log2(s).astype(int), desired_log2s)
 
 
+@pytest.mark.skipif(True, reason="Failing on some OpenBLAS version, see gh-12276")
 def test_heequb():
     # zheequb has a bug for versions =< LAPACK 3.9.0
     # See Reference-LAPACK gh-61 and gh-408

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -1972,7 +1972,42 @@ class TestBrute:
         assert_allclose(resbrute1[-1], resbrute[-1])
         assert_allclose(resbrute1[0], resbrute[0])
 
+         
+def test_cobyla_threadsafe():
+   
+    # Verify that cobyla is threadsafe. Will segfault if it is not.
 
+    import concurrent.futures
+    import time
+
+    def objective1(x):
+        time.sleep(0.1)
+        return x[0]**2
+
+    def objective2(x):
+        time.sleep(0.1)
+        return (x[0]-1)**2
+
+    min_method = "COBYLA"
+
+    def minimizer1():
+        return optimize.minimize(objective1,
+                                      [0.0],
+                                      method=min_method)
+
+    def minimizer2():
+        return optimize.minimize(objective2,
+                                      [0.0],
+                                      method=min_method)
+
+    with concurrent.futures.ThreadPoolExecutor() as pool:
+        tasks = []
+        tasks.append(pool.submit(minimizer1))
+        tasks.append(pool.submit(minimizer2))
+        for t in tasks:
+            res = t.result()
+   
+   
 class TestIterationLimits(object):
     # Tests that optimisation does not give up before trying requested
     # number of iterations or evaluations. And that it does not succeed

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -9,6 +9,7 @@ from . import sigtools, dlti
 from ._upfirdn import upfirdn, _output_len, _upfirdn_modes
 from scipy import linalg, fft as sp_fft
 from scipy.fft._helper import _init_nd_shape_and_axes
+from scipy._lib._util import prod as _prod
 import numpy as np
 from scipy.special import lambertw
 from .windows import get_window
@@ -875,17 +876,6 @@ def _numeric_arrays(arrays, kinds='buifc'):
         if array_.dtype.kind not in kinds:
             return False
     return True
-
-
-def _prod(iterable):
-    """
-    Product of a list of numbers.
-    Faster than np.prod for short lists like array shapes.
-    """
-    product = 1
-    for x in iterable:
-        product *= x
-    return product
 
 
 def _conv_ops(x_shape, h_shape, mode):

--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -5,6 +5,7 @@ import sys
 import operator
 import warnings
 import numpy as np
+from scipy._lib._util import prod
 
 __all__ = ['upcast', 'getdtype', 'isscalarlike', 'isintlike',
            'isshape', 'issequence', 'isdense', 'ismatrix', 'get_sum_dtype']
@@ -284,18 +285,18 @@ def check_shape(args, current_shape=None):
 
     else:
         # Check the current size only if needed
-        current_size = np.prod(current_shape, dtype=int)
+        current_size = prod(current_shape)
 
         # Check for negatives
         negative_indexes = [i for i, x in enumerate(new_shape) if x < 0]
         if len(negative_indexes) == 0:
-            new_size = np.prod(new_shape, dtype=int)
+            new_size = prod(new_shape)
             if new_size != current_size:
                 raise ValueError('cannot reshape array of size {} into shape {}'
                                  .format(current_size, new_shape))
         elif len(negative_indexes) == 1:
             skip = negative_indexes[0]
-            specified = np.prod(new_shape[0:skip] + new_shape[skip+1:])
+            specified = prod(new_shape[0:skip] + new_shape[skip+1:])
             unspecified, remainder = divmod(current_size, specified)
             if remainder != 0:
                 err_shape = tuple('newshape' if x < 0 else x for x in new_shape)

--- a/scipy/sparse/tests/test_sputils.py
+++ b/scipy/sparse/tests/test_sputils.py
@@ -149,3 +149,7 @@ class TestSparseUtils(object):
             np.dtype(sputils.get_index_dtype((a1, a2), maxval=too_big)),
             np.dtype('int64')
         )
+
+    def test_check_shape_overflow(self):
+        new_shape = sputils.check_shape([(10, -1)], (65535, 131070))
+        assert_equal(new_shape, (10, 858967245))

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -1413,7 +1413,7 @@ class Rotation(object):
         result = _compose_quat(self._quat, other._quat)
         if self._single and other._single:
             result = result[0]
-        return self.__class__(result, normalize=False, copy=False)
+        return self.__class__(result, normalize=True, copy=False)
 
     def inv(self):
         """Invert this rotation.

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -1124,3 +1124,11 @@ def test_slerp_call_scalar_time():
     delta = r_interpolated * r_interpolated_expected.inv()
 
     assert_allclose(delta.magnitude(), 0, atol=1e-16)
+
+
+def test_multiplication_stability():
+    qs = Rotation.random(50, random_state=0)
+    rs = Rotation.random(1000, random_state=1)
+    for q in qs:
+        rs *= q * rs
+        assert_allclose(np.linalg.norm(rs.as_quat(), axis=1), 1)


### PR DESCRIPTION
Backports included for those PRs with `1.6.0` milestone and a current backport label:

- #12276 
- #12285
- #12317 
- #12318 
- #12319 
- #12335

I have a lingering suspicion I may also need to backport a CircleCI sphinx version pinning for CI to pass as well, though no such PR was labelled as above--I guess we'll see what happens.

Release notes also updated based on above backports.