### PR TITLE
BUG: avoid overflow in sum() for 32-bit systems

### DIFF
--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -466,7 +466,7 @@ class lil_matrix(spmatrix, IndexMixin):
             idx_dtype = get_index_dtype(maxval=N)
             lengths = np.empty(M, dtype=idx_dtype)
             _csparsetools.lil_get_lengths(self.rows, lengths)
-            nnz = lengths.sum()
+            nnz = lengths.sum(dtype=np.int64)
             idx_dtype = get_index_dtype(maxval=max(N, nnz))
             indptr = np.empty(M + 1, dtype=idx_dtype)
             indptr[0] = 0


### PR DESCRIPTION
### Reference issue
Fixes gh-12340.

#### What does this implement/fix?
On systems where the native `int` type is 32-bit, this call to `sum()` may overflow. Specifying an explicit dtype will ensure all systems behave the same way (and don't overflow).