### PR TITLE
[BUG] Consider 0/0 division in DOP853 error estimation 

### DIFF
--- a/scipy/integrate/_ivp/rk.py
+++ b/scipy/integrate/_ivp/rk.py
@@ -495,9 +495,10 @@ class DOP853(RungeKutta):
     def _estimate_error_norm(self, K, h, scale):
         err5 = np.dot(K.T, self.E5) / scale
         err3 = np.dot(K.T, self.E3) / scale
-
         err5_norm_2 = np.sum(err5**2)
         err3_norm_2 = np.sum(err3**2)
+        if err5_norm_2 == 0 and err3_norm_2 == 0:
+            return 0
         denom = err5_norm_2 + 0.01 * err3_norm_2
         return np.abs(h) * err5_norm_2 / np.sqrt(denom * len(scale))
 

--- a/scipy/integrate/_ivp/tests/test_ivp.py
+++ b/scipy/integrate/_ivp/tests/test_ivp.py
@@ -12,6 +12,10 @@ from scipy.integrate._ivp.base import ConstantDenseOutput
 from scipy.sparse import coo_matrix, csc_matrix
 
 
+def fun_zero(t, y):
+    return np.zeros_like(y)
+
+
 def fun_linear(t, y):
     return np.array([-y[0] - 5 * y[1], y[0] + y[1]])
 
@@ -968,3 +972,11 @@ def test_args():
     assert_allclose(y0events[0], np.ones_like(y0events[0]))
     assert_allclose(y0events[1], np.zeros_like(y0events[1]), atol=5e-14)
     assert_allclose(zfinalevents[2], [zfinal])
+
+
+@pytest.mark.parametrize('method', ['RK23', 'RK45', 'DOP853', 'Radau', 'BDF', 'LSODA'])
+def test_integration_zero_rhs(method):
+    result = solve_ivp(fun_zero, [0, 10], np.ones(3), method=method)
+    assert_(result.success)
+    assert_equal(result.status, 0)
+    assert_allclose(result.y, 1.0, rtol=1e-15)


### PR DESCRIPTION
#### Reference issue
Closes #12308

#### What does this implement/fix?
There is a special case when 0/0 division occurs. I handle it the same way as in Fortran DOP853 code. It doesn't look very good because direct comparison with 0 is used, but I don't have a deeper understanding how to approach that. And the very authors of the algorithm do the same, so I think it's good enough.