### PR TITLE
MAINT: Cleanup unneeded void* cast in setlist.pxd

### DIFF
--- a/scipy/spatial/setlist.pxd
+++ b/scipy/spatial/setlist.pxd
@@ -30,18 +30,18 @@ cdef inline int init(setlist_t *setlist, size_t n, size_t size_guess) except -1:
 
     setlist.sets = <int**>libc.stdlib.malloc(sizeof(int*) * n)
     if setlist.sets == NULL:
-        raise MemoryError
+        raise MemoryError("Failed to allocate memory in setlist.init()")
 
     setlist.sizes = <size_t*>libc.stdlib.malloc(sizeof(size_t) * n)
     if setlist.sizes == NULL:
-        libc.stdlib.free(<void*>setlist.sets)
-        raise MemoryError
+        libc.stdlib.free(setlist.sets)
+        raise MemoryError("Failed to allocate memory in setlist.init()")
 
     setlist.alloc_sizes = <size_t*>libc.stdlib.malloc(sizeof(size_t) * n)
     if setlist.alloc_sizes == NULL:
-        libc.stdlib.free(<void*>setlist.sets)
-        libc.stdlib.free(<void*>setlist.sizes)
-        raise MemoryError
+        libc.stdlib.free(setlist.sets)
+        libc.stdlib.free(setlist.sizes)
+        raise MemoryError("Failed to allocate memory in setlist.init()")
 
     for j in range(n):
         setlist.sizes[j] = 0
@@ -49,11 +49,11 @@ cdef inline int init(setlist_t *setlist, size_t n, size_t size_guess) except -1:
         setlist.sets[j] = <int*>libc.stdlib.malloc(sizeof(int) * size_guess)
         if setlist.sets[j] == NULL:
             for i in range(j):
-                libc.stdlib.free(<void*>setlist.sets[i])
-            libc.stdlib.free(<void*>setlist.sets)
-            libc.stdlib.free(<void*>setlist.sizes)
-            libc.stdlib.free(<void*>setlist.alloc_sizes)
-            raise MemoryError
+                libc.stdlib.free(setlist.sets[i])
+            libc.stdlib.free(setlist.sets)
+            libc.stdlib.free(setlist.sizes)
+            libc.stdlib.free(setlist.alloc_sizes)
+            raise MemoryError("Failed to allocate memory in setlist.init()")
 
     return 0
 
@@ -64,10 +64,10 @@ cdef inline void free(setlist_t *setlist):
 
     cdef int j
     for j in range(setlist.n):
-        libc.stdlib.free(<void*>setlist.sets[j])
-    libc.stdlib.free(<void*>setlist.sets)
-    libc.stdlib.free(<void*>setlist.sizes)
-    libc.stdlib.free(<void*>setlist.alloc_sizes)
+        libc.stdlib.free(setlist.sets[j])
+    libc.stdlib.free(setlist.sets)
+    libc.stdlib.free(setlist.sizes)
+    libc.stdlib.free(setlist.alloc_sizes)
     setlist.sets = NULL
     setlist.sizes = NULL
     setlist.alloc_sizes = NULL


### PR DESCRIPTION
This is a follow up from a previous PR.

`grep -ri 'stblib.free(.*void' scipy`
shows no other uses

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->