### PR TITLE
TST: Remove hack for old win-amd64 bug

### DIFF
--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -15,9 +15,6 @@ types = [np.int8, np.uint8, np.int16,
          np.float32, np.float64]
 
 
-np.mod(1., 1)  # Silence fmod bug on win-amd64. See #1408 and #1238.
-
-
 class Test_measurements_stats(object):
     """ndimage.measurements._stats() is a utility function used by other functions."""
 


### PR DESCRIPTION
From looking at a cache of https://support.microsoft.com/en-us/help/972497 this appears to have been fixed since 2010. I doubt many people use `64-bit Microsoft Visual C++ 2008 Service Pack 1`

This line only affects tests, the worst case is that some of the tests start breaking again (in which case I'll apologize and learn to leave legacy code alone)

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->