### PR TITLE
MAINT: Minor cleanup of (c)KDTree tests

### DIFF
--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -725,8 +725,6 @@ class Test_sparse_distance_matrix_compiled(sparse_distance_matrix_consistency):
         data2 = np.random.randn(n,m)
         self.T1 = cKDTree(data1,leafsize=2)
         self.T2 = cKDTree(data2,leafsize=2)
-        self.ref_T1 = KDTree(data1, leafsize=2)
-        self.ref_T2 = KDTree(data2, leafsize=2)
         self.r = 0.5
         self.n = n
         self.m = m
@@ -734,10 +732,12 @@ class Test_sparse_distance_matrix_compiled(sparse_distance_matrix_consistency):
         self.data2 = data2
         self.p = 2
 
-    def test_consistency_with_python(self):
+    def test_consistency(self):
+        # Test consistency with a distance_matrix
         M1 = self.T1.sparse_distance_matrix(self.T2, self.r)
-        M2 = self.ref_T1.sparse_distance_matrix(self.ref_T2, self.r)
-        assert_array_almost_equal(M1.todense(), M2.todense(), decimal=14)
+        expected = distance_matrix(self.T1.data, self.T2.data)
+        expected[expected > self.r] = 0
+        assert_array_almost_equal(M1.todense(), expected, decimal=14)
 
     def test_against_logic_error_regression(self):
         # regression test for gh-5077 logic error

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -444,23 +444,12 @@ class Test_random_ball_linf_compiled_periodic(Test_random_ball_compiled_periodic
         self.p = np.inf
 
 
-def test_random_ball_vectorized():
-
-    n = 20
-    m = 5
-    T = KDTree(np.random.randn(n,m))
-
-    r = T.query_ball_point(np.random.randn(2,3,m),1)
-    assert_equal(r.shape,(2,3))
-    assert_(isinstance(r[0,0],list))
-
-
-def test_random_ball_vectorized_compiled():
-
+@pytest.mark.parametrize('TreeType', [KDTree, cKDTree])
+def test_random_ball_vectorized(TreeType):
     n = 20
     m = 5
     np.random.seed(1234)
-    T = cKDTree(np.random.randn(n,m))
+    T = TreeType(np.random.randn(n,m))
 
     r = T.query_ball_point(np.random.randn(2,3,m),1)
     assert_equal(r.shape,(2,3))
@@ -818,49 +807,28 @@ def check_onetree_query(T,d):
 
     assert_(s == T.query_pairs(d))
 
-def test_onetree_query():
+@pytest.mark.parametrize('TreeType', [KDTree, cKDTree])
+def test_onetree_query(TreeType):
     np.random.seed(0)
     n = 50
     k = 4
     points = np.random.randn(n,k)
-    T = KDTree(points)
+    T = TreeType(points)
     check_onetree_query(T, 0.1)
 
     points = np.random.randn(3*n,k)
     points[:n] *= 0.001
     points[n:2*n] += 2
-    T = KDTree(points)
+    T = TreeType(points)
     check_onetree_query(T, 0.1)
     check_onetree_query(T, 0.001)
     check_onetree_query(T, 0.00001)
     check_onetree_query(T, 1e-6)
 
 
-def test_onetree_query_compiled():
-    np.random.seed(0)
-    n = 100
-    k = 4
-    points = np.random.randn(n,k)
-    T = cKDTree(points)
-    check_onetree_query(T, 0.1)
-
-    points = np.random.randn(3*n,k)
-    points[:n] *= 0.001
-    points[n:2*n] += 2
-    T = cKDTree(points)
-    check_onetree_query(T, 0.1)
-    check_onetree_query(T, 0.001)
-    check_onetree_query(T, 0.00001)
-    check_onetree_query(T, 1e-6)
-
-
-def test_query_pairs_single_node():
-    tree = KDTree([[0, 1]])
-    assert_equal(tree.query_pairs(0.5), set())
-
-
-def test_query_pairs_single_node_compiled():
-    tree = cKDTree([[0, 1]])
+@pytest.mark.parametrize('TreeType', [KDTree, cKDTree])
+def test_query_pairs_single_node(TreeType):
+    tree = TreeType([[0, 1]])
     assert_equal(tree.query_pairs(0.5), set())
 
 

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -27,9 +27,9 @@ class ConsistencyTests:
     def test_nearest(self):
         x = self.x
         d, i = self.kdtree.query(x, 1)
-        assert_almost_equal(d**2,np.sum((x-self.data[i])**2))
+        assert_almost_equal(d**2, np.sum((x-self.data[i])**2))
         eps = 1e-8
-        assert_(np.all(np.sum((self.data-x[np.newaxis,:])**2,axis=1) > d**2-eps))
+        assert_(np.all(np.sum((self.data-x[np.newaxis, :])**2, axis=1) > d**2-eps))
 
     def test_m_nearest(self):
         x = self.x
@@ -37,9 +37,9 @@ class ConsistencyTests:
         dd, ii = self.kdtree.query(x, m)
         d = np.amax(dd)
         i = ii[np.argmax(dd)]
-        assert_almost_equal(d**2,np.sum((x-self.data[i])**2))
+        assert_almost_equal(d**2, np.sum((x-self.data[i])**2))
         eps = 1e-8
-        assert_equal(np.sum(np.sum((self.data-x[np.newaxis,:])**2,axis=1) < d**2+eps),m)
+        assert_equal(np.sum(np.sum((self.data-x[np.newaxis, :])**2, axis=1) < d**2+eps), m)
 
     def test_points_near(self):
         x = self.x
@@ -47,13 +47,13 @@ class ConsistencyTests:
         dd, ii = self.kdtree.query(x, k=self.kdtree.n, distance_upper_bound=d)
         eps = 1e-8
         hits = 0
-        for near_d, near_i in zip(dd,ii):
+        for near_d, near_i in zip(dd, ii):
             if near_d == np.inf:
                 continue
             hits += 1
-            assert_almost_equal(near_d**2,np.sum((x-self.data[near_i])**2))
-            assert_(near_d < d+eps, "near_d=%g should be less than %g" % (near_d,d))
-        assert_equal(np.sum(self.distance(self.data,x,2) < d**2+eps),hits)
+            assert_almost_equal(near_d**2, np.sum((x-self.data[near_i])**2))
+            assert_(near_d < d+eps, "near_d=%g should be less than %g" % (near_d, d))
+        assert_equal(np.sum(self.distance(self.data, x, 2) < d**2+eps), hits)
 
     def test_points_near_l1(self):
         x = self.x
@@ -61,13 +61,13 @@ class ConsistencyTests:
         dd, ii = self.kdtree.query(x, k=self.kdtree.n, p=1, distance_upper_bound=d)
         eps = 1e-8
         hits = 0
-        for near_d, near_i in zip(dd,ii):
+        for near_d, near_i in zip(dd, ii):
             if near_d == np.inf:
                 continue
             hits += 1
-            assert_almost_equal(near_d,self.distance(x,self.data[near_i],1))
-            assert_(near_d < d+eps, "near_d=%g should be less than %g" % (near_d,d))
-        assert_equal(np.sum(self.distance(self.data,x,1) < d+eps),hits)
+            assert_almost_equal(near_d, self.distance(x, self.data[near_i], 1))
+            assert_(near_d < d+eps, "near_d=%g should be less than %g" % (near_d, d))
+        assert_equal(np.sum(self.distance(self.data, x, 1) < d+eps), hits)
 
     def test_points_near_linf(self):
         x = self.x
@@ -75,13 +75,13 @@ class ConsistencyTests:
         dd, ii = self.kdtree.query(x, k=self.kdtree.n, p=np.inf, distance_upper_bound=d)
         eps = 1e-8
         hits = 0
-        for near_d, near_i in zip(dd,ii):
+        for near_d, near_i in zip(dd, ii):
             if near_d == np.inf:
                 continue
             hits += 1
-            assert_almost_equal(near_d,self.distance(x,self.data[near_i],np.inf))
-            assert_(near_d < d+eps, "near_d=%g should be less than %g" % (near_d,d))
-        assert_equal(np.sum(self.distance(self.data,x,np.inf) < d+eps),hits)
+            assert_almost_equal(near_d, self.distance(x, self.data[near_i], np.inf))
+            assert_(near_d < d+eps, "near_d=%g should be less than %g" % (near_d, d))
+        assert_equal(np.sum(self.distance(self.data, x, np.inf) < d+eps), hits)
 
     def test_approx(self):
         x = self.x
@@ -98,7 +98,7 @@ class Test_random(ConsistencyTests):
         self.m = 4
         np.random.seed(1234)
         self.data = np.random.randn(self.n, self.m)
-        self.kdtree = KDTree(self.data,leafsize=2)
+        self.kdtree = KDTree(self.data, leafsize=2)
         self.x = np.random.randn(self.m)
         self.d = 0.2
         self.k = 10
@@ -111,14 +111,14 @@ class Test_random_far(Test_random):
 
 class Test_small(ConsistencyTests):
     def setup_method(self):
-        self.data = np.array([[0,0,0],
-                              [0,0,1],
-                              [0,1,0],
-                              [0,1,1],
-                              [1,0,0],
-                              [1,0,1],
-                              [1,1,0],
-                              [1,1,1]])
+        self.data = np.array([[0, 0, 0],
+                              [0, 0, 1],
+                              [0, 1, 0],
+                              [0, 1, 1],
+                              [1, 0, 0],
+                              [1, 0, 1],
+                              [1, 1, 0],
+                              [1, 1, 1]])
         self.kdtree = KDTree(self.data)
         self.n = self.kdtree.n
         self.m = self.kdtree.m
@@ -129,19 +129,19 @@ class Test_small(ConsistencyTests):
 
     def test_nearest(self):
         assert_array_equal(
-                self.kdtree.query((0,0,0.1), 1),
-                (0.1,0))
+                self.kdtree.query((0, 0, 0.1), 1),
+                (0.1, 0))
 
     def test_nearest_two(self):
         assert_array_equal(
-                self.kdtree.query((0,0,0.1), 2),
-                ([0.1,0.9],[0,1]))
+                self.kdtree.query((0, 0, 0.1), 2),
+                ([0.1, 0.9], [0, 1]))
 
 
 class Test_small_nonleaf(Test_small):
     def setup_method(self):
         Test_small.setup_method(self)
-        self.kdtree = KDTree(self.data,leafsize=1)
+        self.kdtree = KDTree(self.data, leafsize=1)
 
 
 class Test_small_compiled(Test_small):
@@ -153,7 +153,7 @@ class Test_small_compiled(Test_small):
 class Test_small_nonleaf_compiled(Test_small):
     def setup_method(self):
         Test_small.setup_method(self)
-        self.kdtree = cKDTree(self.data,leafsize=1)
+        self.kdtree = cKDTree(self.data, leafsize=1)
 
 
 class Test_random_compiled(Test_random):
@@ -170,104 +170,104 @@ class Test_random_far_compiled(Test_random_far):
 
 class Test_vectorization:
     def setup_method(self):
-        self.data = np.array([[0,0,0],
-                              [0,0,1],
-                              [0,1,0],
-                              [0,1,1],
-                              [1,0,0],
-                              [1,0,1],
-                              [1,1,0],
-                              [1,1,1]])
+        self.data = np.array([[0, 0, 0],
+                              [0, 0, 1],
+                              [0, 1, 0],
+                              [0, 1, 1],
+                              [1, 0, 0],
+                              [1, 0, 1],
+                              [1, 1, 0],
+                              [1, 1, 1]])
         self.kdtree = KDTree(self.data)
 
     def test_single_query(self):
-        d, i = self.kdtree.query(np.array([0,0,0]))
-        assert_(isinstance(d,float))
+        d, i = self.kdtree.query(np.array([0, 0, 0]))
+        assert_(isinstance(d, float))
         assert_(np.issubdtype(i, np.signedinteger))
 
     def test_vectorized_query(self):
-        d, i = self.kdtree.query(np.zeros((2,4,3)))
-        assert_equal(np.shape(d),(2,4))
-        assert_equal(np.shape(i),(2,4))
+        d, i = self.kdtree.query(np.zeros((2, 4, 3)))
+        assert_equal(np.shape(d), (2, 4))
+        assert_equal(np.shape(i), (2, 4))
 
     def test_single_query_multiple_neighbors(self):
         s = 23
         kk = self.kdtree.n+s
-        d, i = self.kdtree.query(np.array([0,0,0]),k=kk)
-        assert_equal(np.shape(d),(kk,))
-        assert_equal(np.shape(i),(kk,))
+        d, i = self.kdtree.query(np.array([0, 0, 0]), k=kk)
+        assert_equal(np.shape(d), (kk,))
+        assert_equal(np.shape(i), (kk,))
         assert_(np.all(~np.isfinite(d[-s:])))
         assert_(np.all(i[-s:] == self.kdtree.n))
 
     def test_vectorized_query_multiple_neighbors(self):
         s = 23
         kk = self.kdtree.n+s
-        d, i = self.kdtree.query(np.zeros((2,4,3)),k=kk)
-        assert_equal(np.shape(d),(2,4,kk))
-        assert_equal(np.shape(i),(2,4,kk))
-        assert_(np.all(~np.isfinite(d[:,:,-s:])))
-        assert_(np.all(i[:,:,-s:] == self.kdtree.n))
+        d, i = self.kdtree.query(np.zeros((2, 4, 3)), k=kk)
+        assert_equal(np.shape(d), (2, 4, kk))
+        assert_equal(np.shape(i), (2, 4, kk))
+        assert_(np.all(~np.isfinite(d[:, :, -s:])))
+        assert_(np.all(i[:, :, -s:] == self.kdtree.n))
 
     def test_single_query_all_neighbors(self):
-        d, i = self.kdtree.query([0,0,0],k=None,distance_upper_bound=1.1)
-        assert_(isinstance(d,list))
-        assert_(isinstance(i,list))
+        d, i = self.kdtree.query([0, 0, 0], k=None, distance_upper_bound=1.1)
+        assert_(isinstance(d, list))
+        assert_(isinstance(i, list))
 
     def test_vectorized_query_all_neighbors(self):
-        d, i = self.kdtree.query(np.zeros((2,4,3)),k=None,distance_upper_bound=1.1)
-        assert_equal(np.shape(d),(2,4))
-        assert_equal(np.shape(i),(2,4))
+        d, i = self.kdtree.query(np.zeros((2, 4, 3)), k=None, distance_upper_bound=1.1)
+        assert_equal(np.shape(d), (2, 4))
+        assert_equal(np.shape(i), (2, 4))
 
-        assert_(isinstance(d[0,0],list))
-        assert_(isinstance(i[0,0],list))
+        assert_(isinstance(d[0, 0], list))
+        assert_(isinstance(i[0, 0], list))
 
 
 class Test_vectorization_compiled:
     def setup_method(self):
-        self.data = np.array([[0,0,0],
-                              [0,0,1],
-                              [0,1,0],
-                              [0,1,1],
-                              [1,0,0],
-                              [1,0,1],
-                              [1,1,0],
-                              [1,1,1]])
+        self.data = np.array([[0, 0, 0],
+                              [0, 0, 1],
+                              [0, 1, 0],
+                              [0, 1, 1],
+                              [1, 0, 0],
+                              [1, 0, 1],
+                              [1, 1, 0],
+                              [1, 1, 1]])
         self.kdtree = cKDTree(self.data)
 
     def test_single_query(self):
-        d, i = self.kdtree.query([0,0,0])
-        assert_(isinstance(d,float))
-        assert_(isinstance(i,int))
+        d, i = self.kdtree.query([0, 0, 0])
+        assert_(isinstance(d, float))
+        assert_(isinstance(i, int))
 
     def test_vectorized_query(self):
-        d, i = self.kdtree.query(np.zeros((2,4,3)))
-        assert_equal(np.shape(d),(2,4))
-        assert_equal(np.shape(i),(2,4))
+        d, i = self.kdtree.query(np.zeros((2, 4, 3)))
+        assert_equal(np.shape(d), (2, 4))
+        assert_equal(np.shape(i), (2, 4))
 
     def test_vectorized_query_noncontiguous_values(self):
         np.random.seed(1234)
-        qs = np.random.randn(3,1000).T
+        qs = np.random.randn(3, 1000).T
         ds, i_s = self.kdtree.query(qs)
-        for q, d, i in zip(qs,ds,i_s):
-            assert_equal(self.kdtree.query(q),(d,i))
+        for q, d, i in zip(qs, ds, i_s):
+            assert_equal(self.kdtree.query(q), (d, i))
 
     def test_single_query_multiple_neighbors(self):
         s = 23
         kk = self.kdtree.n+s
-        d, i = self.kdtree.query([0,0,0],k=kk)
-        assert_equal(np.shape(d),(kk,))
-        assert_equal(np.shape(i),(kk,))
+        d, i = self.kdtree.query([0, 0, 0], k=kk)
+        assert_equal(np.shape(d), (kk,))
+        assert_equal(np.shape(i), (kk,))
         assert_(np.all(~np.isfinite(d[-s:])))
         assert_(np.all(i[-s:] == self.kdtree.n))
 
     def test_vectorized_query_multiple_neighbors(self):
         s = 23
         kk = self.kdtree.n+s
-        d, i = self.kdtree.query(np.zeros((2,4,3)),k=kk)
-        assert_equal(np.shape(d),(2,4,kk))
-        assert_equal(np.shape(i),(2,4,kk))
-        assert_(np.all(~np.isfinite(d[:,:,-s:])))
-        assert_(np.all(i[:,:,-s:] == self.kdtree.n))
+        d, i = self.kdtree.query(np.zeros((2, 4, 3)), k=kk)
+        assert_equal(np.shape(d), (2, 4, kk))
+        assert_equal(np.shape(i), (2, 4, kk))
+        assert_(np.all(~np.isfinite(d[:, :, -s:])))
+        assert_(np.all(i[:, :, -s:] == self.kdtree.n))
 
 class ball_consistency:
     tol = 0.0
@@ -280,8 +280,8 @@ class ball_consistency:
         d = np.broadcast_to(self.d, x.shape[:-1])
         l = self.T.query_ball_point(x, self.d, p=self.p, eps=self.eps)
         for i, ind in enumerate(l):
-            dist = self.distance(self.data[ind], x[i],self.p) - d[i]*(1.+self.eps)
-            norm = self.distance(self.data[ind], x[i],self.p) + d[i]*(1.+self.eps)
+            dist = self.distance(self.data[ind], x[i], self.p) - d[i]*(1.+self.eps)
+            norm = self.distance(self.data[ind], x[i], self.p) + d[i]*(1.+self.eps)
             assert_array_equal(dist < self.tol * norm, True)
 
     def test_found_all(self):
@@ -291,8 +291,8 @@ class ball_consistency:
         for i, ind in enumerate(l):
             c = np.ones(self.T.n, dtype=bool)
             c[ind] = False
-            dist = self.distance(self.data[c], x[i],self.p) - d[i]/(1.+self.eps)
-            norm = self.distance(self.data[c], x[i],self.p) + d[i]/(1.+self.eps)
+            dist = self.distance(self.data[c], x[i], self.p) - d[i]/(1.+self.eps)
+            norm = self.distance(self.data[c], x[i], self.p) + d[i]/(1.+self.eps)
             assert_array_equal(dist > -self.tol * norm, True)
 
 class Test_random_ball(ball_consistency):
@@ -301,8 +301,8 @@ class Test_random_ball(ball_consistency):
         n = 100
         m = 4
         np.random.seed(1234)
-        self.data = np.random.randn(n,m)
-        self.T = KDTree(self.data,leafsize=2)
+        self.data = np.random.randn(n, m)
+        self.T = KDTree(self.data, leafsize=2)
         self.x = np.random.randn(m)
         self.p = 2.
         self.eps = 0
@@ -315,8 +315,8 @@ class Test_random_ball_compiled(ball_consistency):
         n = 100
         m = 4
         np.random.seed(1234)
-        self.data = np.random.randn(n,m)
-        self.T = cKDTree(self.data,leafsize=2)
+        self.data = np.random.randn(n, m)
+        self.T = cKDTree(self.data, leafsize=2)
         self.x = np.random.randn(m)
         self.p = 2.
         self.eps = 0
@@ -330,8 +330,8 @@ class Test_random_ball_compiled_periodic(ball_consistency):
         n = 10000
         m = 4
         np.random.seed(1234)
-        self.data = np.random.uniform(size=(n,m))
-        self.T = cKDTree(self.data,leafsize=2, boxsize=1)
+        self.data = np.random.uniform(size=(n, m))
+        self.T = cKDTree(self.data, leafsize=2, boxsize=1)
         self.x = np.full(m, 0.1)
         self.p = 2.
         self.eps = 0
@@ -340,20 +340,20 @@ class Test_random_ball_compiled_periodic(ball_consistency):
     def test_in_ball_outside(self):
         l = self.T.query_ball_point(self.x + 1.0, self.d, p=self.p, eps=self.eps)
         for i in l:
-            assert_(self.distance(self.data[i],self.x,self.p) <= self.d*(1.+self.eps))
+            assert_(self.distance(self.data[i], self.x, self.p) <= self.d*(1.+self.eps))
         l = self.T.query_ball_point(self.x - 1.0, self.d, p=self.p, eps=self.eps)
         for i in l:
-            assert_(self.distance(self.data[i],self.x,self.p) <= self.d*(1.+self.eps))
+            assert_(self.distance(self.data[i], self.x, self.p) <= self.d*(1.+self.eps))
 
     def test_found_all_outside(self):
-        c = np.ones(self.T.n,dtype=bool)
+        c = np.ones(self.T.n, dtype=bool)
         l = self.T.query_ball_point(self.x + 1.0, self.d, p=self.p, eps=self.eps)
         c[l] = False
-        assert_(np.all(self.distance(self.data[c],self.x,self.p) >= self.d/(1.+self.eps)))
+        assert_(np.all(self.distance(self.data[c], self.x, self.p) >= self.d/(1.+self.eps)))
 
         l = self.T.query_ball_point(self.x - 1.0, self.d, p=self.p, eps=self.eps)
         c[l] = False
-        assert_(np.all(self.distance(self.data[c],self.x,self.p) >= self.d/(1.+self.eps)))
+        assert_(np.all(self.distance(self.data[c], self.x, self.p) >= self.d/(1.+self.eps)))
 
 class Test_random_ball_compiled_largep_issue9890(ball_consistency):
 
@@ -449,30 +449,30 @@ def test_random_ball_vectorized(TreeType):
     n = 20
     m = 5
     np.random.seed(1234)
-    T = TreeType(np.random.randn(n,m))
+    T = TreeType(np.random.randn(n, m))
 
-    r = T.query_ball_point(np.random.randn(2,3,m),1)
-    assert_equal(r.shape,(2,3))
-    assert_(isinstance(r[0,0],list))
+    r = T.query_ball_point(np.random.randn(2, 3, m), 1)
+    assert_equal(r.shape, (2, 3))
+    assert_(isinstance(r[0, 0], list))
 
 
 def test_query_ball_point_multithreading():
     np.random.seed(0)
     n = 5000
     k = 2
-    points = np.random.randn(n,k)
+    points = np.random.randn(n, k)
     T = cKDTree(points)
-    l1 = T.query_ball_point(points,0.003,n_jobs=1)
-    l2 = T.query_ball_point(points,0.003,n_jobs=64)
-    l3 = T.query_ball_point(points,0.003,n_jobs=-1)
+    l1 = T.query_ball_point(points, 0.003, n_jobs=1)
+    l2 = T.query_ball_point(points, 0.003, n_jobs=64)
+    l3 = T.query_ball_point(points, 0.003, n_jobs=-1)
 
     for i in range(n):
         if l1[i] or l2[i]:
-            assert_array_equal(l1[i],l2[i])
+            assert_array_equal(l1[i], l2[i])
 
     for i in range(n):
         if l1[i] or l3[i]:
-            assert_array_equal(l1[i],l3[i])
+            assert_array_equal(l1[i], l3[i])
 
 
 class two_trees_consistency:
@@ -484,14 +484,14 @@ class two_trees_consistency:
         r = self.T1.query_ball_tree(self.T2, self.d, p=self.p, eps=self.eps)
         for i, l in enumerate(r):
             for j in l:
-                assert_(self.distance(self.data1[i],self.data2[j],self.p) <= self.d*(1.+self.eps))
+                assert_(self.distance(self.data1[i], self.data2[j], self.p) <= self.d*(1.+self.eps))
 
     def test_found_all(self):
         r = self.T1.query_ball_tree(self.T2, self.d, p=self.p, eps=self.eps)
         for i, l in enumerate(r):
-            c = np.ones(self.T2.n,dtype=bool)
+            c = np.ones(self.T2.n, dtype=bool)
             c[l] = False
-            assert_(np.all(self.distance(self.data2[c],self.data1[i],self.p) >= self.d/(1.+self.eps)))
+            assert_(np.all(self.distance(self.data2[c], self.data1[i], self.p) >= self.d/(1.+self.eps)))
 
 
 class Test_two_random_trees(two_trees_consistency):
@@ -500,10 +500,10 @@ class Test_two_random_trees(two_trees_consistency):
         n = 50
         m = 4
         np.random.seed(1234)
-        self.data1 = np.random.randn(n,m)
-        self.T1 = KDTree(self.data1,leafsize=2)
-        self.data2 = np.random.randn(n,m)
-        self.T2 = KDTree(self.data2,leafsize=2)
+        self.data1 = np.random.randn(n, m)
+        self.T1 = KDTree(self.data1, leafsize=2)
+        self.data2 = np.random.randn(n, m)
+        self.T2 = KDTree(self.data2, leafsize=2)
         self.p = 2.
         self.eps = 0
         self.d = 0.2
@@ -515,10 +515,10 @@ class Test_two_random_trees_compiled(two_trees_consistency):
         n = 50
         m = 4
         np.random.seed(1234)
-        self.data1 = np.random.randn(n,m)
-        self.T1 = cKDTree(self.data1,leafsize=2)
-        self.data2 = np.random.randn(n,m)
-        self.T2 = cKDTree(self.data2,leafsize=2)
+        self.data1 = np.random.randn(n, m)
+        self.T1 = cKDTree(self.data1, leafsize=2)
+        self.data2 = np.random.randn(n, m)
+        self.T2 = cKDTree(self.data2, leafsize=2)
         self.p = 2.
         self.eps = 0
         self.d = 0.2
@@ -531,10 +531,10 @@ class Test_two_random_trees_compiled_periodic(two_trees_consistency):
         n = 50
         m = 4
         np.random.seed(1234)
-        self.data1 = np.random.uniform(size=(n,m))
-        self.T1 = cKDTree(self.data1,leafsize=2, boxsize=1.0)
-        self.data2 = np.random.uniform(size=(n,m))
-        self.T2 = cKDTree(self.data2,leafsize=2, boxsize=1.0)
+        self.data1 = np.random.uniform(size=(n, m))
+        self.T1 = cKDTree(self.data1, leafsize=2, boxsize=1.0)
+        self.data2 = np.random.uniform(size=(n, m))
+        self.T2 = cKDTree(self.data2, leafsize=2, boxsize=1.0)
         self.p = 2.
         self.eps = 0
         self.d = 0.2
@@ -582,69 +582,69 @@ class Test_two_random_trees_linf_compiled_periodic(Test_two_random_trees_compile
 class Test_rectangle:
 
     def setup_method(self):
-        self.rect = Rectangle([0,0],[1,1])
+        self.rect = Rectangle([0, 0], [1, 1])
 
     def test_min_inside(self):
-        assert_almost_equal(self.rect.min_distance_point([0.5,0.5]),0)
+        assert_almost_equal(self.rect.min_distance_point([0.5, 0.5]), 0)
 
     def test_min_one_side(self):
-        assert_almost_equal(self.rect.min_distance_point([0.5,1.5]),0.5)
+        assert_almost_equal(self.rect.min_distance_point([0.5, 1.5]), 0.5)
 
     def test_min_two_sides(self):
-        assert_almost_equal(self.rect.min_distance_point([2,2]),np.sqrt(2))
+        assert_almost_equal(self.rect.min_distance_point([2, 2]), np.sqrt(2))
 
     def test_max_inside(self):
-        assert_almost_equal(self.rect.max_distance_point([0.5,0.5]),1/np.sqrt(2))
+        assert_almost_equal(self.rect.max_distance_point([0.5, 0.5]), 1/np.sqrt(2))
 
     def test_max_one_side(self):
-        assert_almost_equal(self.rect.max_distance_point([0.5,1.5]),np.hypot(0.5,1.5))
+        assert_almost_equal(self.rect.max_distance_point([0.5, 1.5]), np.hypot(0.5, 1.5))
 
     def test_max_two_sides(self):
-        assert_almost_equal(self.rect.max_distance_point([2,2]),2*np.sqrt(2))
+        assert_almost_equal(self.rect.max_distance_point([2, 2]), 2*np.sqrt(2))
 
     def test_split(self):
-        less, greater = self.rect.split(0,0.1)
-        assert_array_equal(less.maxes,[0.1,1])
-        assert_array_equal(less.mins,[0,0])
-        assert_array_equal(greater.maxes,[1,1])
-        assert_array_equal(greater.mins,[0.1,0])
+        less, greater = self.rect.split(0, 0.1)
+        assert_array_equal(less.maxes, [0.1, 1])
+        assert_array_equal(less.mins, [0, 0])
+        assert_array_equal(greater.maxes, [1, 1])
+        assert_array_equal(greater.mins, [0.1, 0])
 
 
 def test_distance_l2():
-    assert_almost_equal(minkowski_distance([0,0],[1,1],2),np.sqrt(2))
+    assert_almost_equal(minkowski_distance([0, 0], [1, 1], 2), np.sqrt(2))
 
 
 def test_distance_l1():
-    assert_almost_equal(minkowski_distance([0,0],[1,1],1),2)
+    assert_almost_equal(minkowski_distance([0, 0], [1, 1], 1), 2)
 
 
 def test_distance_linf():
-    assert_almost_equal(minkowski_distance([0,0],[1,1],np.inf),1)
+    assert_almost_equal(minkowski_distance([0, 0], [1, 1], np.inf), 1)
 
 
 def test_distance_vectorization():
     np.random.seed(1234)
-    x = np.random.randn(10,1,3)
-    y = np.random.randn(1,7,3)
-    assert_equal(minkowski_distance(x,y).shape,(10,7))
+    x = np.random.randn(10, 1, 3)
+    y = np.random.randn(1, 7, 3)
+    assert_equal(minkowski_distance(x, y).shape, (10, 7))
 
 
 class count_neighbors_consistency:
     def test_one_radius(self):
         r = 0.2
         assert_equal(self.T1.count_neighbors(self.T2, r),
-                np.sum([len(l) for l in self.T1.query_ball_tree(self.T2,r)]))
+                np.sum([len(l) for l in self.T1.query_ball_tree(self.T2, r)]))
 
     def test_large_radius(self):
         r = 1000
         assert_equal(self.T1.count_neighbors(self.T2, r),
-                np.sum([len(l) for l in self.T1.query_ball_tree(self.T2,r)]))
+                np.sum([len(l) for l in self.T1.query_ball_tree(self.T2, r)]))
 
     def test_multiple_radius(self):
-        rs = np.exp(np.linspace(np.log(0.01),np.log(10),3))
+        rs = np.exp(np.linspace(np.log(0.01), np.log(10), 3))
         results = self.T1.count_neighbors(self.T2, rs)
         assert_(np.all(np.diff(results) >= 0))
-        for r,result in zip(rs, results):
+        for r, result in zip(rs, results):
             assert_equal(self.T1.count_neighbors(self.T2, r), result)
 
 class Test_count_neighbors(count_neighbors_consistency):
@@ -653,8 +653,8 @@ class Test_count_neighbors(count_neighbors_consistency):
         n = 50
         m = 2
         np.random.seed(1234)
-        self.T1 = KDTree(np.random.randn(n,m),leafsize=2)
-        self.T2 = KDTree(np.random.randn(n,m),leafsize=2)
+        self.T1 = KDTree(np.random.randn(n, m), leafsize=2)
+        self.T2 = KDTree(np.random.randn(n, m), leafsize=2)
 
 
 class Test_count_neighbors_compiled(count_neighbors_consistency):
@@ -663,8 +663,8 @@ class Test_count_neighbors_compiled(count_neighbors_consistency):
         n = 50
         m = 2
         np.random.seed(1234)
-        self.T1 = cKDTree(np.random.randn(n,m),leafsize=2)
-        self.T2 = cKDTree(np.random.randn(n,m),leafsize=2)
+        self.T1 = cKDTree(np.random.randn(n, m), leafsize=2)
+        self.T2 = cKDTree(np.random.randn(n, m), leafsize=2)
 
 
 class sparse_distance_matrix_consistency:
@@ -675,12 +675,12 @@ class sparse_distance_matrix_consistency:
     def test_consistency_with_neighbors(self):
         M = self.T1.sparse_distance_matrix(self.T2, self.r)
         r = self.T1.query_ball_tree(self.T2, self.r)
-        for i,l in enumerate(r):
+        for i, l in enumerate(r):
             for j in l:
-                assert_almost_equal(M[i,j],
+                assert_almost_equal(M[i, j],
                                     self.distance(self.T1.data[i], self.T2.data[j], self.p),
                                     decimal=14)
-        for ((i,j),d) in M.items():
+        for ((i, j), d) in M.items():
             assert_(j in r[i])
 
     def test_zero_distance(self):
@@ -693,10 +693,10 @@ class Test_sparse_distance_matrix(sparse_distance_matrix_consistency):
         n = 50
         m = 4
         np.random.seed(1234)
-        data1 = np.random.randn(n,m)
-        data2 = np.random.randn(n,m)
-        self.T1 = cKDTree(data1,leafsize=2)
-        self.T2 = cKDTree(data2,leafsize=2)
+        data1 = np.random.randn(n, m)
+        data2 = np.random.randn(n, m)
+        self.T1 = cKDTree(data1, leafsize=2)
+        self.T2 = cKDTree(data2, leafsize=2)
         self.r = 0.5
         self.p = 2
         self.data1 = data1
@@ -710,10 +710,10 @@ class Test_sparse_distance_matrix_compiled(sparse_distance_matrix_consistency):
         n = 50
         m = 4
         np.random.seed(0)
-        data1 = np.random.randn(n,m)
-        data2 = np.random.randn(n,m)
-        self.T1 = cKDTree(data1,leafsize=2)
-        self.T2 = cKDTree(data2,leafsize=2)
+        data1 = np.random.randn(n, m)
+        data2 = np.random.randn(n, m)
+        self.T1 = cKDTree(data1, leafsize=2)
+        self.T2 = cKDTree(data2, leafsize=2)
         self.r = 0.5
         self.n = n
         self.m = m
@@ -738,28 +738,28 @@ class Test_sparse_distance_matrix_compiled(sparse_distance_matrix_consistency):
 
     def test_ckdtree_return_types(self):
         # brute-force reference
-        ref = np.zeros((self.n,self.n))
+        ref = np.zeros((self.n, self.n))
         for i in range(self.n):
             for j in range(self.n):
-                v = self.data1[i,:] - self.data2[j,:]
-                ref[i,j] = np.dot(v,v)
+                v = self.data1[i, :] - self.data2[j, :]
+                ref[i, j] = np.dot(v, v)
         ref = np.sqrt(ref)
         ref[ref > self.r] = 0.
         # test return type 'dict'
-        dist = np.zeros((self.n,self.n))
+        dist = np.zeros((self.n, self.n))
         r = self.T1.sparse_distance_matrix(self.T2, self.r, output_type='dict')
-        for i,j in r.keys():
-            dist[i,j] = r[(i,j)]
+        for i, j in r.keys():
+            dist[i, j] = r[(i, j)]
         assert_array_almost_equal(ref, dist, decimal=14)
         # test return type 'ndarray'
-        dist = np.zeros((self.n,self.n))
+        dist = np.zeros((self.n, self.n))
         r = self.T1.sparse_distance_matrix(self.T2, self.r,
             output_type='ndarray')
         for k in range(r.shape[0]):
             i = r['i'][k]
             j = r['j'][k]
             v = r['v'][k]
-            dist[i,j] = v
+            dist[i, j] = v
         assert_array_almost_equal(ref, dist, decimal=14)
         # test return type 'dok_matrix'
         r = self.T1.sparse_distance_matrix(self.T2, self.r,
@@ -776,13 +776,13 @@ def test_distance_matrix():
     n = 11
     k = 4
     np.random.seed(1234)
-    xs = np.random.randn(m,k)
-    ys = np.random.randn(n,k)
-    ds = distance_matrix(xs,ys)
-    assert_equal(ds.shape, (m,n))
+    xs = np.random.randn(m, k)
+    ys = np.random.randn(n, k)
+    ds = distance_matrix(xs, ys)
+    assert_equal(ds.shape, (m, n))
     for i in range(m):
         for j in range(n):
-            assert_almost_equal(minkowski_distance(xs[i],ys[j]),ds[i,j])
+            assert_almost_equal(minkowski_distance(xs[i], ys[j]), ds[i, j])
 
 
 def test_distance_matrix_looping():
@@ -790,20 +790,20 @@ def test_distance_matrix_looping():
     n = 11
     k = 4
     np.random.seed(1234)
-    xs = np.random.randn(m,k)
-    ys = np.random.randn(n,k)
-    ds = distance_matrix(xs,ys)
-    dsl = distance_matrix(xs,ys,threshold=1)
-    assert_equal(ds,dsl)
+    xs = np.random.randn(m, k)
+    ys = np.random.randn(n, k)
+    ds = distance_matrix(xs, ys)
+    dsl = distance_matrix(xs, ys, threshold=1)
+    assert_equal(ds, dsl)
 
 
-def check_onetree_query(T,d):
+def check_onetree_query(T, d):
     r = T.query_ball_tree(T, d)
     s = set()
     for i, l in enumerate(r):
         for j in l:
             if i < j:
-                s.add((i,j))
+                s.add((i, j))
 
     assert_(s == T.query_pairs(d))
 
@@ -812,11 +812,11 @@ def test_onetree_query(TreeType):
     np.random.seed(0)
     n = 50
     k = 4
-    points = np.random.randn(n,k)
+    points = np.random.randn(n, k)
     T = TreeType(points)
     check_onetree_query(T, 0.1)
 
-    points = np.random.randn(3*n,k)
+    points = np.random.randn(3*n, k)
     points[:n] *= 0.001
     points[n:2*n] += 2
     T = TreeType(points)
@@ -838,31 +838,31 @@ def test_ckdtree_query_pairs():
     k = 2
     r = 0.1
     r2 = r**2
-    points = np.random.randn(n,k)
+    points = np.random.randn(n, k)
     T = cKDTree(points)
     # brute force reference
     brute = set()
     for i in range(n):
-        for j in range(i+1,n):
-            v = points[i,:] - points[j,:]
-            if np.dot(v,v) <= r2:
-                brute.add((i,j))
+        for j in range(i+1, n):
+            v = points[i, :] - points[j, :]
+            if np.dot(v, v) <= r2:
+                brute.add((i, j))
     l0 = sorted(brute)
     # test default return type
     s = T.query_pairs(r)
     l1 = sorted(s)
-    assert_array_equal(l0,l1)
+    assert_array_equal(l0, l1)
     # test return type 'set'
     s = T.query_pairs(r, output_type='set')
     l1 = sorted(s)
-    assert_array_equal(l0,l1)
+    assert_array_equal(l0, l1)
     # test return type 'ndarray'
     s = set()
     arr = T.query_pairs(r, output_type='ndarray')
     for i in range(arr.shape[0]):
-        s.add((int(arr[i,0]),int(arr[i,1])))
+        s.add((int(arr[i, 0]), int(arr[i, 1])))
     l2 = sorted(s)
-    assert_array_equal(l0,l2)
+    assert_array_equal(l0, l2)
 
 
 def test_ball_point_ints():
@@ -1009,7 +1009,7 @@ def test_ckdtree_list_k():
     data = np.random.uniform(size=(n, m))
     kdtree = cKDTree(data, leafsize=1)
 
-    # check agreement between arange(1,k+1) and k
+    # check agreement between arange(1, k+1) and k
     dd, ii = kdtree.query(data, klist)
     dd1, ii1 = kdtree.query(data, kint)
     assert_equal(dd, dd1)
@@ -1112,7 +1112,7 @@ def simulate_periodic_box(kdtree, data, k, boxsize, p):
     result['ii'][:] = ii
     result['dd'][:] = dd
     result.sort(order='dd')
-    return result['dd'][:, :k], result['ii'][:,:k]
+    return result['dd'][:, :k], result['ii'][:, :k]
 
 
 @pytest.mark.skipif(python_implementation() == 'PyPy',
@@ -1226,18 +1226,18 @@ def test_len0_arrays():
     # make sure len-0 arrays are handled correctly
     # in range queries (gh-5639)
     np.random.seed(1234)
-    X = np.random.rand(10,2)
-    Y = np.random.rand(10,2)
+    X = np.random.rand(10, 2)
+    Y = np.random.rand(10, 2)
     tree = cKDTree(X)
     # query_ball_point (single)
-    d,i = tree.query([.5, .5], k=1)
+    d, i = tree.query([.5, .5], k=1)
     z = tree.query_ball_point([.5, .5], 0.1*d)
     assert_array_equal(z, [])
     # query_ball_point (multiple)
-    d,i = tree.query(Y, k=1)
+    d, i = tree.query(Y, k=1)
     mind = d.min()
     z = tree.query_ball_point(Y, 0.1*mind)
-    y = np.empty(shape=(10,), dtype=object)
+    y = np.empty(shape=(10, ), dtype=object)
     y.fill([])
     assert_array_equal(y, z)
     # query_ball_tree
@@ -1249,23 +1249,23 @@ def test_len0_arrays():
     assert_(y == 0)
     # sparse_distance_matrix
     y = tree.sparse_distance_matrix(other, 0.1*mind, output_type='dok_matrix')
-    assert_array_equal(y == np.zeros((10,10)), True)
+    assert_array_equal(y == np.zeros((10, 10)), True)
     y = tree.sparse_distance_matrix(other, 0.1*mind, output_type='coo_matrix')
-    assert_array_equal(y == np.zeros((10,10)), True)
+    assert_array_equal(y == np.zeros((10, 10)), True)
     y = tree.sparse_distance_matrix(other, 0.1*mind, output_type='dict')
     assert_equal(y, {})
-    y = tree.sparse_distance_matrix(other,0.1*mind, output_type='ndarray')
-    _dtype = [('i',np.intp), ('j',np.intp), ('v',np.float64)]
+    y = tree.sparse_distance_matrix(other, 0.1*mind, output_type='ndarray')
+    _dtype = [('i', np.intp), ('j', np.intp), ('v', np.float64)]
     res_dtype = np.dtype(_dtype, align=True)
-    z = np.empty(shape=(0,), dtype=res_dtype)
+    z = np.empty(shape=(0, ), dtype=res_dtype)
     assert_array_equal(y, z)
     # query_pairs
-    d,i = tree.query(X, k=2)
-    mind = d[:,-1].min()
+    d, i = tree.query(X, k=2)
+    mind = d[:, -1].min()
     y = tree.query_pairs(0.1*mind, output_type='set')
     assert_equal(y, set())
     y = tree.query_pairs(0.1*mind, output_type='ndarray')
-    z = np.empty(shape=(0,2), dtype=np.intp)
+    z = np.empty(shape=(0, 2), dtype=np.intp)
     assert_array_equal(y, z)
 
 def test_ckdtree_duplicated_inputs():
@@ -1310,7 +1310,7 @@ def test_short_knn():
         [0., 1., 0.],
         [0., 1.01, 0.],
         [1., 0., 0.],
-        [1., 1., 0.],],
+        [1., 1., 0.]],
     dtype='float64')
 
     ckdt = cKDTree(xyz)


### PR DESCRIPTION
#### What does this implement/fix?
In gh-8923 @sturlamolden mentions that we can't remove `KDTree` completely because it's used in the tests for `cKDTree`. In fact, I could only see it used as a reference in one test for `sparse_distance_matrix`, so switch that test to compare against `distance_matrix` instead.

Also noticed some copy-paste tests that only differ by using `cKDTree` instead of `KDTree` so used `pytest.mark.parametrize` to clean these up.