### PR TITLE
DEP: Deprecate `distance.wminkowski`

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -580,8 +580,8 @@ def wminkowski(u, v, p, w):
 
     """
     warnings.warn(
-        message="scipy.distance.wminkowski is deprecated and will be removed in"
-                " SciPy 1.8.0, use scipy.distance.minkowski instead.",
+        message="scipy.distance.wminkowski is deprecated and will be removed "
+                "in SciPy 1.8.0, use scipy.distance.minkowski instead.",
         category=DeprecationWarning)
     w = _validate_weights(w)
     return minkowski(u, v, p=p, w=w**p)

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -350,7 +350,7 @@ def _validate_weights(w, dtype=np.double):
 
 @_deprecated(
     msg="'wminkowski' metric is deprecated and will be removed in"
-        " SciPy 1.8, use 'minkowski' instead.")
+        " SciPy 1.8.0, use 'minkowski' instead.")
 def _validate_wminkowski_kwargs(X, m, n, **kwargs):
     w = kwargs.pop('w', None)
     if w is None:
@@ -531,9 +531,6 @@ def minkowski(u, v, p=2, w=None):
     return dist
 
 
-@_deprecated(
-    msg="scipy.distance.wminkowski is deprecated and will be removed in"
-        " SciPy 1.8, use scipy.distance.minkowski instead.")
 def wminkowski(u, v, p, w):
     """
     Compute the weighted Minkowski distance between two 1-D arrays.
@@ -562,9 +559,8 @@ def wminkowski(u, v, p, w):
 
     Notes
     -----
-    .. deprecated:: 1.6
-       `wminkowski` is deprecated and will be removed in SciPy 1.8.
-       Use the `minkowski` with the ``w`` argument instead.
+    `wminkowski` is deprecated and will be removed in SciPy 1.8.0.
+    Use `minkowski` with the ``w`` argument instead.
 
     Examples
     --------
@@ -583,6 +579,10 @@ def wminkowski(u, v, p, w):
     1.0
 
     """
+    warnings.warn(
+        message="scipy.distance.wminkowski is deprecated and will be removed in"
+                " SciPy 1.8.0, use scipy.distance.minkowski instead.",
+        category=DeprecationWarning)
     w = _validate_weights(w)
     return minkowski(u, v, p=p, w=w**p)
 
@@ -1972,8 +1972,7 @@ def pdist(X, metric='euclidean', *args, **kwargs):
        Computes the weighted Minkowski distance between each pair of
        vectors. (see wminkowski function documentation)
 
-    .. deprecated:: 1.6
-       'wminkowski' is deprecated and will be removed in SciPy 1.8.
+       'wminkowski' is deprecated and will be removed in SciPy 1.8.0.
        Use 'minkowski' instead.
 
     23. ``Y = pdist(X, f)``
@@ -2658,8 +2657,7 @@ def cdist(XA, XB, metric='euclidean', *args, **kwargs):
        Computes the weighted Minkowski distance between the
        vectors. (see `wminkowski` function documentation)
 
-    .. deprecated:: 1.6
-       'wminkowski' is deprecated and will be removed in SciPy 1.8.
+       'wminkowski' is deprecated and will be removed in SciPy 1.8.0.
        Use 'minkowski' instead.
 
     23. ``Y = cdist(XA, XB, f)``

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -114,6 +114,7 @@ import numpy as np
 from functools import partial
 from collections import namedtuple
 from scipy._lib._util import _asarray_validated
+from scipy._lib.deprecation import _deprecated
 
 from . import _distance_wrap
 from . import _hausdorff
@@ -347,6 +348,9 @@ def _validate_weights(w, dtype=np.double):
     return w
 
 
+@_deprecated(
+    msg="'wminkowski' metric is deprecated and will be removed in"
+        " SciPy 1.8, use 'minkowski' instead.")
 def _validate_wminkowski_kwargs(X, m, n, **kwargs):
     w = kwargs.pop('w', None)
     if w is None:
@@ -527,10 +531,9 @@ def minkowski(u, v, p=2, w=None):
     return dist
 
 
-# `minkowski` gained weights in scipy 1.0.  Once we're at say version 1.3,
-# deprecated `wminkowski`.  Not done at once because it would be annoying for
-# downstream libraries that used `wminkowski` and support multiple scipy
-# versions.
+@_deprecated(
+    msg="scipy.distance.wminkowski is deprecated and will be removed in"
+        " SciPy 1.8, use scipy.distance.minkowski instead.")
 def wminkowski(u, v, p, w):
     """
     Compute the weighted Minkowski distance between two 1-D arrays.
@@ -559,9 +562,9 @@ def wminkowski(u, v, p, w):
 
     Notes
     -----
-    `wminkowski` is DEPRECATED. It implements a definition where weights
-    are powered. It is recommended to use the weighted version of `minkowski`
-    instead. This function will be removed in a future version of scipy.
+    .. deprecated:: 1.6
+       `wminkowski` is deprecated and will be removed in SciPy 1.8.
+       Use the `minkowski` with the ``w`` argument instead.
 
     Examples
     --------
@@ -1969,6 +1972,10 @@ def pdist(X, metric='euclidean', *args, **kwargs):
        Computes the weighted Minkowski distance between each pair of
        vectors. (see wminkowski function documentation)
 
+    .. deprecated:: 1.6
+       'wminkowski' is deprecated and will be removed in SciPy 1.8.
+       Use 'minkowski' instead.
+
     23. ``Y = pdist(X, f)``
 
        Computes the distance between all pairs of vectors in X
@@ -2650,6 +2657,10 @@ def cdist(XA, XB, metric='euclidean', *args, **kwargs):
 
        Computes the weighted Minkowski distance between the
        vectors. (see `wminkowski` function documentation)
+
+    .. deprecated:: 1.6
+       'wminkowski' is deprecated and will be removed in SciPy 1.8.
+       Use 'minkowski' instead.
 
     23. ``Y = cdist(XA, XB, f)``
 

--- a/scipy/spatial/src/distance_wrap.c
+++ b/scipy/spatial/src/distance_wrap.c
@@ -283,8 +283,39 @@ static PyObject *cdist_seuclidean_double_wrap(PyObject *self, PyObject *args,
   return Py_BuildValue("d", 0.0);
 }
 
-static PyObject *cdist_weighted_minkowski_double_wrap(
-                            PyObject *self, PyObject *args, PyObject *kwargs) 
+static PyObject *cdist_weighted_chebyshev_double_wrap(
+    PyObject *self, PyObject *args, PyObject *kwargs)
+{
+  PyArrayObject *XA_, *XB_, *dm_, *w_;
+  int mA, mB, n;
+  double *dm;
+  const double *XA, *XB, *w;
+  double p;
+  static char *kwlist[] = {"XA", "XB", "dm", "w", NULL};
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs,
+            "O!O!O!O!:cdist_weighted_chebyshev_double_wrap", kwlist,
+            &PyArray_Type, &XA_, &PyArray_Type, &XB_,
+            &PyArray_Type, &dm_,
+            &PyArray_Type, &w_)) {
+    return 0;
+  }
+  else {
+    NPY_BEGIN_ALLOW_THREADS;
+    XA = (const double*)XA_->data;
+    XB = (const double*)XB_->data;
+    w = (const double*)w_->data;
+    dm = (double*)dm_->data;
+    mA = XA_->dimensions[0];
+    mB = XB_->dimensions[0];
+    n = XA_->dimensions[1];
+    cdist_weighted_chebyshev(XA, XB, dm, mA, mB, n, w);
+    NPY_END_ALLOW_THREADS;
+  }
+  return Py_BuildValue("d", 0.0);
+}
+
+static PyObject *cdist_old_weighted_minkowski_double_wrap(
+  PyObject *self, PyObject *args, PyObject *kwargs)
 {
   PyArrayObject *XA_, *XB_, *dm_, *w_;
   int mA, mB, n;
@@ -292,9 +323,46 @@ static PyObject *cdist_weighted_minkowski_double_wrap(
   const double *XA, *XB, *w;
   double p;
   static char *kwlist[] = {"XA", "XB", "dm", "p", "w", NULL};
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs, 
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs,
+                                   "O!O!O!dO!:cdist_old_weighted_minkowski_double_wrap", kwlist,
+                                   &PyArray_Type, &XA_, &PyArray_Type, &XB_,
+                                   &PyArray_Type, &dm_,
+                                   &p,
+                                   &PyArray_Type, &w_)) {
+    return 0;
+  }
+  else {
+    int res;
+    NPY_BEGIN_ALLOW_THREADS;
+    XA = (const double*)XA_->data;
+    XB = (const double*)XB_->data;
+    w = (const double*)w_->data;
+    dm = (double*)dm_->data;
+    mA = XA_->dimensions[0];
+    mB = XB_->dimensions[0];
+    n = XA_->dimensions[1];
+    res = cdist_old_weighted_minkowski(XA, XB, dm, mA, mB, n, p, w);
+    NPY_END_ALLOW_THREADS;
+
+    if (res) {
+      return PyErr_NoMemory();
+    }
+  }
+  return Py_BuildValue("d", 0.0);
+}
+
+static PyObject *cdist_weighted_minkowski_double_wrap(
+                            PyObject *self, PyObject *args, PyObject *kwargs)
+{
+  PyArrayObject *XA_, *XB_, *dm_, *w_;
+  int mA, mB, n;
+  double *dm;
+  const double *XA, *XB, *w;
+  double p;
+  static char *kwlist[] = {"XA", "XB", "dm", "p", "w", NULL};
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs,
             "O!O!O!dO!:cdist_weighted_minkowski_double_wrap", kwlist,
-            &PyArray_Type, &XA_, &PyArray_Type, &XB_, 
+            &PyArray_Type, &XA_, &PyArray_Type, &XB_,
             &PyArray_Type, &dm_,
             &p,
             &PyArray_Type, &w_)) {
@@ -537,15 +605,78 @@ static PyObject *pdist_seuclidean_double_wrap(PyObject *self, PyObject *args,
   return Py_BuildValue("d", 0.0);
 }
 
-static PyObject *pdist_weighted_minkowski_double_wrap(
-                            PyObject *self, PyObject *args, PyObject *kwargs) 
+static PyObject *pdist_weighted_chebyshev_double_wrap(
+  PyObject *self, PyObject *args, PyObject *kwargs)
+{
+  PyArrayObject *X_, *dm_, *w_;
+  int m, n;
+  double *dm, *X, *w;
+  double p;
+  static char *kwlist[] = {"X", "dm", "w", NULL};
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs,
+                                   "O!O!O!:pdist_weighted_minkowski_double_wrap", kwlist,
+                                   &PyArray_Type, &X_,
+                                   &PyArray_Type, &dm_,
+                                   &PyArray_Type, &w_)) {
+    return 0;
+  }
+  else {
+    NPY_BEGIN_ALLOW_THREADS;
+    X = (double*)X_->data;
+    dm = (double*)dm_->data;
+    w = (double*)w_->data;
+    m = X_->dimensions[0];
+    n = X_->dimensions[1];
+
+    pdist_weighted_chebyshev(X, dm, m, n, w);
+    NPY_END_ALLOW_THREADS;
+  }
+  return Py_BuildValue("d", 0.0);
+}
+
+static PyObject *pdist_old_weighted_minkowski_double_wrap(
+  PyObject *self, PyObject *args, PyObject *kwargs)
 {
   PyArrayObject *X_, *dm_, *w_;
   int m, n;
   double *dm, *X, *w;
   double p;
   static char *kwlist[] = {"X", "dm", "p", "w", NULL};
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs, 
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs,
+                                   "O!O!dO!:pdist_weighted_minkowski_double_wrap", kwlist,
+                                   &PyArray_Type, &X_,
+                                   &PyArray_Type, &dm_,
+                                   &p,
+                                   &PyArray_Type, &w_)) {
+    return 0;
+  }
+  else {
+    int res;
+    NPY_BEGIN_ALLOW_THREADS;
+    X = (double*)X_->data;
+    dm = (double*)dm_->data;
+    w = (double*)w_->data;
+    m = X_->dimensions[0];
+    n = X_->dimensions[1];
+
+    res = pdist_old_weighted_minkowski(X, dm, m, n, p, w);
+    NPY_END_ALLOW_THREADS;
+    if (res) {
+      return PyErr_NoMemory();
+    }
+  }
+  return Py_BuildValue("d", 0.0);
+}
+
+static PyObject *pdist_weighted_minkowski_double_wrap(
+                            PyObject *self, PyObject *args, PyObject *kwargs)
+{
+  PyArrayObject *X_, *dm_, *w_;
+  int m, n;
+  double *dm, *X, *w;
+  double p;
+  static char *kwlist[] = {"X", "dm", "p", "w", NULL};
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs,
             "O!O!dO!:pdist_weighted_minkowski_double_wrap", kwlist,
             &PyArray_Type, &X_,
             &PyArray_Type, &dm_,
@@ -664,7 +795,13 @@ static PyMethodDef _distanceWrapMethods[] = {
   {"cdist_minkowski_double_wrap",
    (PyCFunction) cdist_minkowski_double_wrap,
    METH_VARARGS | METH_KEYWORDS},
-  {"cdist_wminkowski_double_wrap",
+  {"cdist_weighted_chebyshev_double_wrap",
+   (PyCFunction) cdist_weighted_chebyshev_double_wrap,
+   METH_VARARGS | METH_KEYWORDS},
+  {"cdist_old_weighted_minkowski_double_wrap",
+   (PyCFunction) cdist_old_weighted_minkowski_double_wrap,
+   METH_VARARGS | METH_KEYWORDS},
+  {"cdist_weighted_minkowski_double_wrap",
    (PyCFunction) cdist_weighted_minkowski_double_wrap,
    METH_VARARGS | METH_KEYWORDS},
   {"cdist_rogerstanimoto_bool_wrap",
@@ -733,7 +870,13 @@ static PyMethodDef _distanceWrapMethods[] = {
   {"pdist_minkowski_double_wrap",
    (PyCFunction) pdist_minkowski_double_wrap,
    METH_VARARGS | METH_KEYWORDS},
-  {"pdist_wminkowski_double_wrap",
+  {"pdist_weighted_chebyshev_double_wrap",
+   (PyCFunction) pdist_weighted_chebyshev_double_wrap,
+   METH_VARARGS | METH_KEYWORDS},
+  {"pdist_old_weighted_minkowski_double_wrap",
+   (PyCFunction) pdist_old_weighted_minkowski_double_wrap,
+   METH_VARARGS | METH_KEYWORDS},
+  {"pdist_weighted_minkowski_double_wrap",
    (PyCFunction) pdist_weighted_minkowski_double_wrap,
    METH_VARARGS | METH_KEYWORDS},
   {"pdist_rogerstanimoto_bool_wrap",

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -580,7 +580,8 @@ class TestCdist(object):
         X2 = eo['cdist-X2']
         out_r, out_c = X1.shape[0], X2.shape[0]
         with suppress_warnings() as sup:
-            sup.filter(DeprecationWarning, message="'wminkowski' metric is deprecated")
+            sup.filter(DeprecationWarning,
+                       message="'wminkowski' metric is deprecated")
             for metric in _METRICS_NAMES:
                 kwargs = dict()
                 if metric in ['minkowski', 'wminkowski']:
@@ -596,15 +597,20 @@ class TestCdist(object):
                 assert_(Y2 is out1)
                 # test for incorrect shape
                 out2 = np.empty((out_r-1, out_c+1), dtype=np.double)
-                assert_raises(ValueError, cdist, X1, X2, metric, out=out2, **kwargs)
+                assert_raises(ValueError,
+                              cdist, X1, X2, metric, out=out2, **kwargs)
                 # test for C-contiguous order
-                out3 = np.empty((2 * out_r, 2 * out_c), dtype=np.double)[::2, ::2]
+                out3 = np.empty(
+                    (2 * out_r, 2 * out_c), dtype=np.double)[::2, ::2]
                 out4 = np.empty((out_r, out_c), dtype=np.double, order='F')
-                assert_raises(ValueError, cdist, X1, X2, metric, out=out3, **kwargs)
-                assert_raises(ValueError, cdist, X1, X2, metric, out=out4, **kwargs)
+                assert_raises(ValueError,
+                              cdist, X1, X2, metric, out=out3, **kwargs)
+                assert_raises(ValueError,
+                              cdist, X1, X2, metric, out=out4, **kwargs)
                 # test for incorrect dtype
                 out5 = np.empty((out_r, out_c), dtype=np.int64)
-                assert_raises(ValueError, cdist, X1, X2, metric, out=out5, **kwargs)
+                assert_raises(ValueError,
+                              cdist, X1, X2, metric, out=out5, **kwargs)
 
     def test_striding(self):
         # test that striding is handled correct with calls to
@@ -1491,7 +1497,8 @@ class TestPdist(object):
         assert_(X_copy.flags.c_contiguous)
 
         with suppress_warnings() as sup:
-            sup.filter(DeprecationWarning, message="'wminkowski' metric is deprecated")
+            sup.filter(DeprecationWarning,
+                       message="'wminkowski' metric is deprecated")
             for metric in _METRICS_NAMES:
                 kwargs = dict()
                 if metric in ['minkowski', 'wminkowski']:
@@ -1526,15 +1533,18 @@ class TestSomeDistanceFunctions(object):
             assert_almost_equal(dist1p5, (1.0 + 2.0**1.5)**(2. / 3))
             wminkowski(x, y, p=2)
 
-        # Check that casting input to minimum scalar type doesn't affect result (issue #10262).
-        # This could be extended to more test inputs with np.min_scalar_type(np.max(input_matrix)).
+        # Check that casting input to minimum scalar type doesn't affect result
+        # (issue #10262). This could be extended to more test inputs with
+        # np.min_scalar_type(np.max(input_matrix)).
         a = np.array([352, 916])
         b = np.array([350, 660])
-        assert_equal(minkowski(a, b), minkowski(a.astype('uint16'), b.astype('uint16')))
+        assert_equal(minkowski(a, b),
+                     minkowski(a.astype('uint16'), b.astype('uint16')))
 
     def test_old_wminkowski(self):
         with suppress_warnings() as wrn:
-            wrn.filter(DeprecationWarning, message=".*wminkowski is deprecated")
+            wrn.filter(DeprecationWarning,
+                       message=".*wminkowski is deprecated")
             w = np.array([1.0, 2.0, 0.5])
             for x, y in self.cases:
                 dist1 = old_wminkowski(x, y, p=1, w=w)
@@ -2041,7 +2051,8 @@ def test_Xdist_deprecated_args():
         with suppress_warnings() as w:
             log = w.record(message=warn_msg_args)
             w.filter(message=warn_msg_kwargs)
-            w.filter(DeprecationWarning, message="'wminkowski' metric is deprecated")
+            w.filter(DeprecationWarning,
+                     message="'wminkowski' metric is deprecated")
             cdist(X1, X1, metric, 2., **kwargs)
             pdist(X1, metric, 2., **kwargs)
             assert_(len(log) == 2)
@@ -2061,7 +2072,8 @@ def test_Xdist_deprecated_args():
 
         with suppress_warnings() as w:
             log = w.record(message=warn_msg_kwargs)
-            w.filter(DeprecationWarning, message="'wminkowski' metric is deprecated")
+            w.filter(DeprecationWarning,
+                     message="'wminkowski' metric is deprecated")
             cdist(X1, X1, metric, **kwargs)
             pdist(X1, metric, **kwargs)
             assert_(len(log) == 2)
@@ -2072,7 +2084,8 @@ def test_Xdist_non_negative_weights():
     w = np.ones(X.shape[1])
     w[::5] = -w[::5]
     with suppress_warnings() as sup:
-        sup.filter(DeprecationWarning, message="'wminkowski' metric is deprecated")
+        sup.filter(DeprecationWarning,
+                   message="'wminkowski' metric is deprecated")
         for metric in _METRICS_NAMES:
             if metric in ['seuclidean', 'mahalanobis', 'jensenshannon']:
                 continue

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -579,30 +579,32 @@ class TestCdist(object):
         X1 = eo['cdist-X1']
         X2 = eo['cdist-X2']
         out_r, out_c = X1.shape[0], X2.shape[0]
-        for metric in _METRICS_NAMES:
-            kwargs = dict()
-            if metric in ['minkowski', 'wminkowski']:
-                kwargs['p'] = 1.23
-            if metric == 'wminkowski':
-                kwargs['w'] = 1.0 / X1.std(axis=0)
-            out1 = np.empty((out_r, out_c), dtype=np.double)
-            Y1 = cdist(X1, X2, metric, **kwargs)
-            Y2 = cdist(X1, X2, metric, out=out1, **kwargs)
-            # test that output is numerically equivalent
-            _assert_within_tol(Y1, Y2, eps, verbose > 2)
-            # test that Y_test1 and out1 are the same object
-            assert_(Y2 is out1)
-            # test for incorrect shape
-            out2 = np.empty((out_r-1, out_c+1), dtype=np.double)
-            assert_raises(ValueError, cdist, X1, X2, metric, out=out2, **kwargs)
-            # test for C-contiguous order
-            out3 = np.empty((2 * out_r, 2 * out_c), dtype=np.double)[::2, ::2]
-            out4 = np.empty((out_r, out_c), dtype=np.double, order='F')
-            assert_raises(ValueError, cdist, X1, X2, metric, out=out3, **kwargs)
-            assert_raises(ValueError, cdist, X1, X2, metric, out=out4, **kwargs)
-            # test for incorrect dtype
-            out5 = np.empty((out_r, out_c), dtype=np.int64)
-            assert_raises(ValueError, cdist, X1, X2, metric, out=out5, **kwargs)
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning, message="'wminkowski' metric is deprecated")
+            for metric in _METRICS_NAMES:
+                kwargs = dict()
+                if metric in ['minkowski', 'wminkowski']:
+                    kwargs['p'] = 1.23
+                    if metric == 'wminkowski':
+                        kwargs['w'] = 1.0 / X1.std(axis=0)
+                out1 = np.empty((out_r, out_c), dtype=np.double)
+                Y1 = cdist(X1, X2, metric, **kwargs)
+                Y2 = cdist(X1, X2, metric, out=out1, **kwargs)
+                # test that output is numerically equivalent
+                _assert_within_tol(Y1, Y2, eps, verbose > 2)
+                # test that Y_test1 and out1 are the same object
+                assert_(Y2 is out1)
+                # test for incorrect shape
+                out2 = np.empty((out_r-1, out_c+1), dtype=np.double)
+                assert_raises(ValueError, cdist, X1, X2, metric, out=out2, **kwargs)
+                # test for C-contiguous order
+                out3 = np.empty((2 * out_r, 2 * out_c), dtype=np.double)[::2, ::2]
+                out4 = np.empty((out_r, out_c), dtype=np.double, order='F')
+                assert_raises(ValueError, cdist, X1, X2, metric, out=out3, **kwargs)
+                assert_raises(ValueError, cdist, X1, X2, metric, out=out4, **kwargs)
+                # test for incorrect dtype
+                out5 = np.empty((out_r, out_c), dtype=np.int64)
+                assert_raises(ValueError, cdist, X1, X2, metric, out=out5, **kwargs)
 
     def test_striding(self):
         # test that striding is handled correct with calls to
@@ -622,16 +624,18 @@ class TestCdist(object):
         assert_(X1_copy.flags.c_contiguous)
         assert_(X2_copy.flags.c_contiguous)
 
-        for metric in _METRICS_NAMES:
-            kwargs = dict()
-            if metric in ['minkowski', 'wminkowski']:
-                kwargs['p'] = 1.23
-                if metric == 'wminkowski':
-                    kwargs['w'] = 1.0 / X1.std(axis=0)
-            Y1 = cdist(X1, X2, metric, **kwargs)
-            Y2 = cdist(X1_copy, X2_copy, metric, **kwargs)
-            # test that output is numerically equivalent
-            _assert_within_tol(Y1, Y2, eps, verbose > 2)
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning, "'wminkowski' metric is deprecated")
+            for metric in _METRICS_NAMES:
+                kwargs = dict()
+                if metric in ['minkowski', 'wminkowski']:
+                    kwargs['p'] = 1.23
+                    if metric == 'wminkowski':
+                        kwargs['w'] = 1.0 / X1.std(axis=0)
+                Y1 = cdist(X1, X2, metric, **kwargs)
+                Y2 = cdist(X1_copy, X2_copy, metric, **kwargs)
+                # test that output is numerically equivalent
+                _assert_within_tol(Y1, Y2, eps, verbose > 2)
 
 class TestPdist(object):
 
@@ -1450,28 +1454,30 @@ class TestPdist(object):
         eps = 1e-07
         X = eo['random-float32-data'][::5, ::2]
         out_size = int((X.shape[0] * (X.shape[0] - 1)) / 2)
-        for metric in _METRICS_NAMES:
-            kwargs = dict()
-            if metric in ['minkowski', 'wminkowski']:
-                kwargs['p'] = 1.23
-            if metric == 'wminkowski':
-                kwargs['w'] = 1.0 / X.std(axis=0)
-            out1 = np.empty(out_size, dtype=np.double)
-            Y_right = pdist(X, metric, **kwargs)
-            Y_test1 = pdist(X, metric, out=out1, **kwargs)
-            # test that output is numerically equivalent
-            _assert_within_tol(Y_test1, Y_right, eps)
-            # test that Y_test1 and out1 are the same object
-            assert_(Y_test1 is out1)
-            # test for incorrect shape
-            out2 = np.empty(out_size + 3, dtype=np.double)
-            assert_raises(ValueError, pdist, X, metric, out=out2, **kwargs)
-            # test for (C-)contiguous output
-            out3 = np.empty(2 * out_size, dtype=np.double)[::2]
-            assert_raises(ValueError, pdist, X, metric, out=out3, **kwargs)
-            # test for incorrect dtype
-            out5 = np.empty(out_size, dtype=np.int64)
-            assert_raises(ValueError, pdist, X, metric, out=out5, **kwargs)
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning, "'wminkowski' metric is deprecated")
+            for metric in _METRICS_NAMES:
+                kwargs = dict()
+                if metric in ['minkowski', 'wminkowski']:
+                    kwargs['p'] = 1.23
+                if metric == 'wminkowski':
+                    kwargs['w'] = 1.0 / X.std(axis=0)
+                out1 = np.empty(out_size, dtype=np.double)
+                Y_right = pdist(X, metric, **kwargs)
+                Y_test1 = pdist(X, metric, out=out1, **kwargs)
+                # test that output is numerically equivalent
+                _assert_within_tol(Y_test1, Y_right, eps)
+                # test that Y_test1 and out1 are the same object
+                assert_(Y_test1 is out1)
+                # test for incorrect shape
+                out2 = np.empty(out_size + 3, dtype=np.double)
+                assert_raises(ValueError, pdist, X, metric, out=out2, **kwargs)
+                # test for (C-)contiguous output
+                out3 = np.empty(2 * out_size, dtype=np.double)[::2]
+                assert_raises(ValueError, pdist, X, metric, out=out3, **kwargs)
+                # test for incorrect dtype
+                out5 = np.empty(out_size, dtype=np.int64)
+                assert_raises(ValueError, pdist, X, metric, out=out5, **kwargs)
 
     def test_striding(self):
         # test that striding is handled correct with calls to
@@ -1484,16 +1490,18 @@ class TestPdist(object):
         assert_(not X.flags.c_contiguous)
         assert_(X_copy.flags.c_contiguous)
 
-        for metric in _METRICS_NAMES:
-            kwargs = dict()
-            if metric in ['minkowski', 'wminkowski']:
-                kwargs['p'] = 1.23
-            if metric == 'wminkowski':
-                kwargs['w'] = 1.0 / X.std(axis=0)
-            Y1 = pdist(X, metric, **kwargs)
-            Y2 = pdist(X_copy, metric, **kwargs)
-            # test that output is numerically equivalent
-            _assert_within_tol(Y1, Y2, eps, verbose > 2)
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning, message="'wminkowski' metric is deprecated")
+            for metric in _METRICS_NAMES:
+                kwargs = dict()
+                if metric in ['minkowski', 'wminkowski']:
+                    kwargs['p'] = 1.23
+                if metric == 'wminkowski':
+                    kwargs['w'] = 1.0 / X.std(axis=0)
+                Y1 = pdist(X, metric, **kwargs)
+                Y2 = pdist(X_copy, metric, **kwargs)
+                # test that output is numerically equivalent
+                _assert_within_tol(Y1, Y2, eps, verbose > 2)
 
 class TestSomeDistanceFunctions(object):
 
@@ -1511,24 +1519,22 @@ class TestSomeDistanceFunctions(object):
         self.cases = [(x, y), (x31, y31), (x13, y13)]
 
     def test_minkowski(self):
-        with suppress_warnings() as w:
-            w.filter(message="`wminkowski` is deprecated")
-            for x, y in self.cases:
-                dist1 = wminkowski(x, y, p=1)
-                assert_almost_equal(dist1, 3.0)
-                dist1p5 = wminkowski(x, y, p=1.5)
-                assert_almost_equal(dist1p5, (1.0 + 2.0**1.5)**(2. / 3))
-                wminkowski(x, y, p=2)
+        for x, y in self.cases:
+            dist1 = wminkowski(x, y, p=1)
+            assert_almost_equal(dist1, 3.0)
+            dist1p5 = wminkowski(x, y, p=1.5)
+            assert_almost_equal(dist1p5, (1.0 + 2.0**1.5)**(2. / 3))
+            wminkowski(x, y, p=2)
 
-            # Check that casting input to minimum scalar type doesn't affect result (issue #10262).
-            # This could be extended to more test inputs with np.min_scalar_type(np.max(input_matrix)).
-            a = np.array([352, 916])
-            b = np.array([350, 660])
-            assert_equal(minkowski(a, b), minkowski(a.astype('uint16'), b.astype('uint16')))
+        # Check that casting input to minimum scalar type doesn't affect result (issue #10262).
+        # This could be extended to more test inputs with np.min_scalar_type(np.max(input_matrix)).
+        a = np.array([352, 916])
+        b = np.array([350, 660])
+        assert_equal(minkowski(a, b), minkowski(a.astype('uint16'), b.astype('uint16')))
 
     def test_old_wminkowski(self):
         with suppress_warnings() as wrn:
-            wrn.filter(message="`wminkowski` is deprecated")
+            wrn.filter(DeprecationWarning, message=".*wminkowski is deprecated")
             w = np.array([1.0, 2.0, 0.5])
             for x, y in self.cases:
                 dist1 = old_wminkowski(x, y, p=1, w=w)
@@ -1874,10 +1880,8 @@ class TestIsValidY(object):
 def test_bad_p():
     # Raise ValueError if p < 1.
     p = 0.5
-    with suppress_warnings() as w:
-        w.filter(message="`wminkowski` is deprecated")
-        assert_raises(ValueError, wminkowski, [1, 2], [3, 4], p)
-        assert_raises(ValueError, wminkowski, [1, 2], [3, 4], p, [1, 1])
+    assert_raises(ValueError, wminkowski, [1, 2], [3, 4], p)
+    assert_raises(ValueError, wminkowski, [1, 2], [3, 4], p, [1, 1])
 
 
 def test_sokalsneath_all_false():
@@ -2015,7 +2019,7 @@ def test_modifies_input():
                      [22.2, 23.3, 44.4]])
     X1_copy = X1.copy()
     with suppress_warnings() as w:
-        w.filter(message="`wminkowski` is deprecated")
+        w.filter(message="'wminkowski' metric is deprecated")
         for metric in _METRICS_NAMES:
             kwargs = {"w": 1.0 / X1.std(axis=0)} if metric == "wminkowski" else {}
             cdist(X1, X1, metric, **kwargs)
@@ -2037,7 +2041,7 @@ def test_Xdist_deprecated_args():
         with suppress_warnings() as w:
             log = w.record(message=warn_msg_args)
             w.filter(message=warn_msg_kwargs)
-            w.filter(message="`wminkowski` is deprecated")
+            w.filter(DeprecationWarning, message="'wminkowski' metric is deprecated")
             cdist(X1, X1, metric, 2., **kwargs)
             pdist(X1, metric, 2., **kwargs)
             assert_(len(log) == 2)
@@ -2045,35 +2049,37 @@ def test_Xdist_deprecated_args():
         for arg in ["p", "V", "VI"]:
             kwargs = {arg:"foo"}
 
-            if metric == "wminkowski":
-                if "p" in kwargs or "w" in kwargs:
-                    continue
-                kwargs["w"] = weights
-
-            if((arg == "V" and metric == "seuclidean") or
-               (arg == "VI" and metric == "mahalanobis") or
-               (arg == "p" and metric == "minkowski")):
+        if metric == "wminkowski":
+            if "p" in kwargs or "w" in kwargs:
                 continue
+            kwargs["w"] = weights
 
-            with suppress_warnings() as w:
-                log = w.record(message=warn_msg_kwargs)
-                w.filter(message="`wminkowski` is deprecated")
-                cdist(X1, X1, metric, **kwargs)
-                pdist(X1, metric, **kwargs)
-                assert_(len(log) == 2)
+        if((arg == "V" and metric == "seuclidean") or
+           (arg == "VI" and metric == "mahalanobis") or
+           (arg == "p" and metric == "minkowski")):
+            continue
+
+        with suppress_warnings() as w:
+            log = w.record(message=warn_msg_kwargs)
+            w.filter(DeprecationWarning, message="'wminkowski' metric is deprecated")
+            cdist(X1, X1, metric, **kwargs)
+            pdist(X1, metric, **kwargs)
+            assert_(len(log) == 2)
 
 
 def test_Xdist_non_negative_weights():
     X = eo['random-float32-data'][::5, ::2]
     w = np.ones(X.shape[1])
     w[::5] = -w[::5]
-    for metric in _METRICS_NAMES:
-        if metric in ['seuclidean', 'mahalanobis', 'jensenshannon']:
-            continue
+    with suppress_warnings() as sup:
+        sup.filter(DeprecationWarning, message="'wminkowski' metric is deprecated")
+        for metric in _METRICS_NAMES:
+            if metric in ['seuclidean', 'mahalanobis', 'jensenshannon']:
+                continue
 
-        for m in [metric, eval(metric), "test_" + metric]:
-            assert_raises(ValueError, pdist, X, m, w=w)
-            assert_raises(ValueError, cdist, X, X, m, w=w)
+            for m in [metric, eval(metric), "test_" + metric]:
+                assert_raises(ValueError, pdist, X, m, w=w)
+                assert_raises(ValueError, cdist, X, X, m, w=w)
 
 
 def test__validate_vector():


### PR DESCRIPTION
#### Reference issue
See gh-7893

#### What does this implement/fix?
`wminkowski` was "soft deprecated" in gh-7905 (SciPy 1.0) and, as per gh-7893, should have started raising a warning in SciPy 1.3. This (belatedly) marks it as fully deprecated and also repurposes the native `cdist` and `pdist` implementation for `wminkowski` so that it works for weighted `minkowski`. That way there is no performance regression for users switching over to `minkowski` from `wminkowski`.