### PR TITLE
DOC: Quick fix - adds newline to correlation_lags docstring Examples section

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -306,6 +306,7 @@ def correlation_lags(in1_len, in2_len, mode='full'):
     Examples
     --------
     Cross-correlation of a signal with its time-delayed self.
+
     >>> from scipy import signal
     >>> rng = np.random.RandomState(0)
     >>> x = rng.standard_normal(1000)


### PR DESCRIPTION
Follow up to ENH: Adds correlation_lags function to scipy.signal #11068

Adds a newline to the Examples section of the docstring to ensure Sphinx formats appropriately.