### PR TITLE
BENCH: remove obsolete goal_time param

### DIFF
--- a/benchmarks/benchmarks/common.py
+++ b/benchmarks/benchmarks/common.py
@@ -15,7 +15,7 @@ class Benchmark(object):
     """
     Base class with sensible options
     """
-    goal_time = 0.25
+    pass
 
 
 class LimitedParamBenchmark(Benchmark):


### PR DESCRIPTION
`goal_time` is obsolete since `asv` [0.3.0](https://asv.readthedocs.io/en/stable/changelog.html?highlight=goal_time#id7).