### PR TITLE
ENH: Replace KDTree with a thin wrapper over cKDTree

### DIFF
--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -343,10 +343,6 @@ cdef class cKDTreeNode:
         readonly object       lesser
         readonly object       greater
 
-    def _compare(self, cKDTreeNode other):
-        # Helper function used by KDTree.node
-        return (self._node - other._node)
-
     cdef void _setup(cKDTreeNode self):
         cdef cKDTreeNode n1, n2
         self.split_dim = self._node.split_dim

--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -343,6 +343,21 @@ cdef class cKDTreeNode:
         readonly object       lesser
         readonly object       greater
 
+    def __lt__(self, cKDTreeNode other):
+        return self._node < other._node
+
+    def __gt__(self, cKDTreeNode other):
+        return self._node > other._node
+
+    def __le__(self, cKDTreeNode other):
+        return self._node <= other._node
+
+    def __ge__(self, cKDTreeNode other):
+        return self._node >= other._node
+
+    def __eq__(self, cKDTreeNode other):
+        return self._node == other._node
+
     cdef void _setup(cKDTreeNode self):
         cdef cKDTreeNode n1, n2
         self.split_dim = self._node.split_dim

--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -343,20 +343,9 @@ cdef class cKDTreeNode:
         readonly object       lesser
         readonly object       greater
 
-    def __lt__(self, cKDTreeNode other):
-        return self._node < other._node
-
-    def __gt__(self, cKDTreeNode other):
-        return self._node > other._node
-
-    def __le__(self, cKDTreeNode other):
-        return self._node <= other._node
-
-    def __ge__(self, cKDTreeNode other):
-        return self._node >= other._node
-
-    def __eq__(self, cKDTreeNode other):
-        return self._node == other._node
+    def _compare(self, cKDTreeNode other):
+        # Helper function used by KDTree.node
+        return (self._node - other._node)
 
     cdef void _setup(cKDTreeNode self):
         cdef cKDTreeNode n1, n2

--- a/scipy/spatial/kdtree.py
+++ b/scipy/spatial/kdtree.py
@@ -242,27 +242,27 @@ class KDTree(cKDTree):
         def __lt__(self, other):
             if not isinstance(other, KDTree.node):
                 return False
-            return self._node._compare(other._node) < 0
+            return id(self._node) < id(other._node)
 
         def __le__(self, other):
             if not isinstance(other, KDTree.node):
                 return False
-            return self._node._compare(other._node) <= 0
+            return id(self._node) <= id(other._node)
 
         def __gt__(self, other):
             if not isinstance(other, KDTree.node):
                 return True
-            return self._node._compare(other._node) > 0
+            return id(self._node) > id(other._node)
 
         def __ge__(self, other):
             if not isinstance(other, KDTree.node):
                 return True
-            return self._node._compare(other._node) >= 0
+            return id(self._node) >= id(other._node)
 
         def __eq__(self, other):
             if not isinstance(other, KDTree.node):
                 return False
-            return self._node._compare(other._node) == 0
+            return id(self._node) == id(other._node)
 
     class leafnode(node):
         @property

--- a/scipy/spatial/kdtree.py
+++ b/scipy/spatial/kdtree.py
@@ -225,14 +225,14 @@ class KDTree(cKDTree):
 
     class node:
         @staticmethod
-        def __new__(cls, ckdtree_node=None):
+        def _create(ckdtree_node=None):
             """Create either an inner or leaf node, wrapping a cKDTreeNode instance"""
             if ckdtree_node is None:
-                return super().__new__(cls)
+                return node(ckdtree_node)
             elif ckdtree_node.split_dim == -1:
-                return super().__new__(KDTree.leafnode)
+                return KDTree.leafnode(ckdtree_node)
             else:
-                return super().__new__(KDTree.innernode)
+                return KDTree.innernode(ckdtree_node)
 
         def __init__(self, ckdtree_node=None):
             if ckdtree_node is None:
@@ -287,15 +287,15 @@ class KDTree(cKDTree):
             return self._node.children
         @property
         def less(self):
-            return KDTree.node(self._node.lesser)
+            return KDTree.node._create(self._node.lesser)
 
         @property
         def greater(self):
-            return KDTree.node(self._node.greater)
+            return KDTree.node._create(self._node.greater)
 
     @property
     def tree(self):
-        return KDTree.node(super().tree)
+        return KDTree.node._create(super().tree)
 
     def __init__(self, data, leafsize=10):
         data = np.asarray(data)

--- a/scipy/spatial/kdtree.py
+++ b/scipy/spatial/kdtree.py
@@ -451,7 +451,7 @@ class KDTree(cKDTree):
         >>> x, y = np.mgrid[0:5, 0:5]
         >>> points = np.c_[x.ravel(), y.ravel()]
         >>> tree = spatial.KDTree(points)
-        >>> tree.query_ball_point([2, 0], 1)
+        >>> sorted(tree.query_ball_point([2, 0], 1))
         [5, 10, 11, 15]
 
         Query multiple points and plot the results:

--- a/scipy/spatial/kdtree.py
+++ b/scipy/spatial/kdtree.py
@@ -613,16 +613,7 @@ class KDTree(cKDTree):
         9
 
         """
-        counts = super().count_neighbors(other, r, p)
-        if isinstance(counts, np.ndarray):
-            # If there is no overflow, cast to np.int_ for back-compatibility
-            max_int = np.iinfo(np.int_).max
-            can_cast = (counts.dtype.itemsize <= np.int_().itemsize or
-                        other.n <= max_int or
-                        (counts <= max_int).all())
-            if can_cast:
-                counts = counts.astype(np.int_, copy=False)
-        return counts
+        return super().count_neighbors(other, r, p)
 
     def sparse_distance_matrix(self, other, max_distance, p=2.):
         """

--- a/scipy/spatial/kdtree.py
+++ b/scipy/spatial/kdtree.py
@@ -228,7 +228,7 @@ class KDTree(cKDTree):
         def _create(ckdtree_node=None):
             """Create either an inner or leaf node, wrapping a cKDTreeNode instance"""
             if ckdtree_node is None:
-                return node(ckdtree_node)
+                return KDTree.node(ckdtree_node)
             elif ckdtree_node.split_dim == -1:
                 return KDTree.leafnode(ckdtree_node)
             else:

--- a/scipy/spatial/kdtree.py
+++ b/scipy/spatial/kdtree.py
@@ -3,6 +3,8 @@
 import numpy as np
 from heapq import heappush, heappop
 import scipy.sparse
+from .ckdtree import cKDTree, cKDTreeNode
+import warnings
 
 __all__ = ['minkowski_distance_p', 'minkowski_distance',
            'distance_matrix',
@@ -179,7 +181,7 @@ class Rectangle(object):
         return minkowski_distance(0, np.maximum(self.maxes-other.mins,other.maxes-self.mins),p)
 
 
-class KDTree(object):
+class KDTree(cKDTree):
     """
     kd-tree for quick nearest-neighbor lookup
 
@@ -194,20 +196,6 @@ class KDTree(object):
     leafsize : int, optional
         The number of points at which the algorithm switches over to
         brute-force.  Has to be positive.
-
-    Raises
-    ------
-    RuntimeError
-        The maximum recursion limit can be exceeded for large data
-        sets.  If this happens, either increase the value for the `leafsize`
-        parameter or increase the recursion limit by::
-
-            >>> import sys
-            >>> sys.setrecursionlimit(10000)
-
-    See Also
-    --------
-    cKDTree : Implementation of `KDTree` in Cython
 
     Notes
     -----
@@ -236,174 +224,34 @@ class KDTree(object):
     sort of calculation.
 
     """
+
+    node = cKDTreeNode
+
+    # cKDTree does not have distinct types for inner and leaf nodes
+    # Emulate the old behavior by using a metaclass to overwrite isinstance
+    class _InnerNodeMeta(type):
+        def __instancecheck__(cls, inst):
+            return (isinstance(inst, cKDTreeNode) and
+                    inst.split_dim >= 0)
+
+    class innernode(cKDTreeNode, metaclass=_InnerNodeMeta):
+        pass
+
+    class _LeafNodeMeta(type):
+        def __instancecheck__(cls, inst):
+            return (isinstance(inst, cKDTreeNode) and
+                    inst.split_dim == -1)
+
+    class leafnode(cKDTreeNode, metaclass=_LeafNodeMeta):
+        pass
+
     def __init__(self, data, leafsize=10):
-        self.data = np.asarray(data)
-        if self.data.dtype.kind == 'c':
+        data = np.asarray(data)
+        if data.dtype.kind == 'c':
             raise TypeError("KDTree does not work with complex data")
 
-        self.n, self.m = np.shape(self.data)
-        self.leafsize = int(leafsize)
-        if self.leafsize < 1:
-            raise ValueError("leafsize must be at least 1")
-        self.maxes = np.amax(self.data,axis=0)
-        self.mins = np.amin(self.data,axis=0)
-
-        self.tree = self.__build(np.arange(self.n), self.maxes, self.mins)
-
-    class node(object):
-        def __lt__(self, other):
-            return id(self) < id(other)
-
-        def __gt__(self, other):
-            return id(self) > id(other)
-
-        def __le__(self, other):
-            return id(self) <= id(other)
-
-        def __ge__(self, other):
-            return id(self) >= id(other)
-
-        def __eq__(self, other):
-            return id(self) == id(other)
-
-    class leafnode(node):
-        def __init__(self, idx):
-            self.idx = idx
-            self.children = len(idx)
-
-    class innernode(node):
-        def __init__(self, split_dim, split, less, greater):
-            self.split_dim = split_dim
-            self.split = split
-            self.less = less
-            self.greater = greater
-            self.children = less.children+greater.children
-
-    def __build(self, idx, maxes, mins):
-        if len(idx) <= self.leafsize:
-            return KDTree.leafnode(idx)
-        else:
-            data = self.data[idx]
-            # maxes = np.amax(data,axis=0)
-            # mins = np.amin(data,axis=0)
-            d = np.argmax(maxes-mins)
-            maxval = maxes[d]
-            minval = mins[d]
-            if maxval == minval:
-                # all points are identical; warn user?
-                return KDTree.leafnode(idx)
-            data = data[:,d]
-
-            # sliding midpoint rule; see Maneewongvatana and Mount 1999
-            # for arguments that this is a good idea.
-            split = (maxval+minval)/2
-            less_idx = np.nonzero(data <= split)[0]
-            greater_idx = np.nonzero(data > split)[0]
-            if len(less_idx) == 0:
-                split = np.amin(data)
-                less_idx = np.nonzero(data <= split)[0]
-                greater_idx = np.nonzero(data > split)[0]
-            if len(greater_idx) == 0:
-                split = np.amax(data)
-                less_idx = np.nonzero(data < split)[0]
-                greater_idx = np.nonzero(data >= split)[0]
-            if len(less_idx) == 0:
-                # _still_ zero? all must have the same value
-                if not np.all(data == data[0]):
-                    raise ValueError("Troublesome data array: %s" % data)
-                split = data[0]
-                less_idx = np.arange(len(data)-1)
-                greater_idx = np.array([len(data)-1])
-
-            lessmaxes = np.copy(maxes)
-            lessmaxes[d] = split
-            greatermins = np.copy(mins)
-            greatermins[d] = split
-            return KDTree.innernode(d, split,
-                    self.__build(idx[less_idx],lessmaxes,mins),
-                    self.__build(idx[greater_idx],maxes,greatermins))
-
-    def __query(self, x, k=1, eps=0, p=2, distance_upper_bound=np.inf):
-
-        side_distances = np.maximum(0,np.maximum(x-self.maxes,self.mins-x))
-        if p != np.inf:
-            side_distances **= p
-            min_distance = np.sum(side_distances)
-        else:
-            min_distance = np.amax(side_distances)
-
-        # priority queue for chasing nodes
-        # entries are:
-        #  minimum distance between the cell and the target
-        #  distances between the nearest side of the cell and the target
-        #  the head node of the cell
-        q = [(min_distance,
-              tuple(side_distances),
-              self.tree)]
-        # priority queue for the nearest neighbors
-        # furthest known neighbor first
-        # entries are (-distance**p, i)
-        neighbors = []
-
-        if eps == 0:
-            epsfac = 1
-        elif p == np.inf:
-            epsfac = 1/(1+eps)
-        else:
-            epsfac = 1/(1+eps)**p
-
-        if p != np.inf and distance_upper_bound != np.inf:
-            distance_upper_bound = distance_upper_bound**p
-
-        while q:
-            min_distance, side_distances, node = heappop(q)
-            if isinstance(node, KDTree.leafnode):
-                # brute-force
-                data = self.data[node.idx]
-                ds = minkowski_distance_p(data,x[np.newaxis,:],p)
-                for i in range(len(ds)):
-                    if ds[i] < distance_upper_bound:
-                        if len(neighbors) == k:
-                            heappop(neighbors)
-                        heappush(neighbors, (-ds[i], node.idx[i]))
-                        if len(neighbors) == k:
-                            distance_upper_bound = -neighbors[0][0]
-            else:
-                # we don't push cells that are too far onto the queue at all,
-                # but since the distance_upper_bound decreases, we might get
-                # here even if the cell's too far
-                if min_distance > distance_upper_bound*epsfac:
-                    # since this is the nearest cell, we're done, bail out
-                    break
-                # compute minimum distances to the children and push them on
-                if x[node.split_dim] < node.split:
-                    near, far = node.less, node.greater
-                else:
-                    near, far = node.greater, node.less
-
-                # near child is at the same distance as the current node
-                heappush(q,(min_distance, side_distances, near))
-
-                # far child is further by an amount depending only
-                # on the split value
-                sd = list(side_distances)
-                if p == np.inf:
-                    min_distance = max(min_distance, abs(node.split-x[node.split_dim]))
-                elif p == 1:
-                    sd[node.split_dim] = np.abs(node.split-x[node.split_dim])
-                    min_distance = min_distance - side_distances[node.split_dim] + sd[node.split_dim]
-                else:
-                    sd[node.split_dim] = np.abs(node.split-x[node.split_dim])**p
-                    min_distance = min_distance - side_distances[node.split_dim] + sd[node.split_dim]
-
-                # far child might be too far, if so, don't bother pushing it
-                if min_distance <= distance_upper_bound*epsfac:
-                    heappush(q,(min_distance, tuple(sd), far))
-
-        if p == np.inf:
-            return sorted([(-d,i) for (d,i) in neighbors])
-        else:
-            return sorted([((-d)**(1./p),i) for (d,i) in neighbors])
+        # Note KDTree has different default leafsize from cKDTree
+        super().__init__(data, leafsize)
 
     def query(self, x, k=1, eps=0, p=2, distance_upper_bound=np.inf):
         """
@@ -491,86 +339,34 @@ class KDTree(object):
         x = np.asarray(x)
         if x.dtype.kind == 'c':
             raise TypeError("KDTree does not work with complex data")
-        if np.shape(x)[-1] != self.m:
-            raise ValueError("x must consist of vectors of length %d but has shape %s" % (self.m, np.shape(x)))
-        if p < 1:
-            raise ValueError("Only p-norms with 1<=p<=infinity permitted")
-        retshape = np.shape(x)[:-1]
-        if retshape != ():
-            if k is None:
-                dd = np.empty(retshape,dtype=object)
-                ii = np.empty(retshape,dtype=object)
-            elif k > 1:
-                dd = np.empty(retshape+(k,),dtype=float)
-                dd.fill(np.inf)
-                ii = np.empty(retshape+(k,),dtype=int)
-                ii.fill(self.n)
-            elif k == 1:
-                dd = np.empty(retshape,dtype=float)
-                dd.fill(np.inf)
-                ii = np.empty(retshape,dtype=int)
-                ii.fill(self.n)
-            else:
-                raise ValueError("Requested %s nearest neighbors; acceptable numbers are integers greater than or equal to one, or None")
-            for c in np.ndindex(retshape):
-                hits = self.__query(x[c], k=k, eps=eps, p=p, distance_upper_bound=distance_upper_bound)
-                if k is None:
-                    dd[c] = [d for (d,i) in hits]
-                    ii[c] = [i for (d,i) in hits]
-                elif k > 1:
-                    for j in range(len(hits)):
-                        dd[c+(j,)], ii[c+(j,)] = hits[j]
-                elif k == 1:
-                    if len(hits) > 0:
-                        dd[c], ii[c] = hits[0]
-                    else:
-                        dd[c] = np.inf
-                        ii[c] = self.n
-            return dd, ii
-        else:
-            hits = self.__query(x, k=k, eps=eps, p=p, distance_upper_bound=distance_upper_bound)
-            if k is None:
-                return [d for (d,i) in hits], [i for (d,i) in hits]
-            elif k == 1:
-                if len(hits) > 0:
-                    return hits[0]
-                else:
-                    return np.inf, self.n
-            elif k > 1:
-                dd = np.empty(k,dtype=float)
-                dd.fill(np.inf)
-                ii = np.empty(k,dtype=int)
-                ii.fill(self.n)
-                for j in range(len(hits)):
-                    dd[j], ii[j] = hits[j]
-                return dd, ii
-            else:
-                raise ValueError("Requested %s nearest neighbors; acceptable numbers are integers greater than or equal to one, or None")
 
-    def __query_ball_point(self, x, r, p=2., eps=0):
-        R = Rectangle(self.maxes, self.mins)
+        if k is None:
+            # k=None, return all neighbors
+            warnings.warn(
+                "KDTree.query with k=None is deprecated and will be removed "
+                "in SciPy 1.8.0. Use KDTree.query_ball_point instead.",
+                DeprecationWarning)
 
-        def traverse_checking(node, rect):
-            if rect.min_distance_point(x, p) > r / (1. + eps):
-                return []
-            elif rect.max_distance_point(x, p) < r * (1. + eps):
-                return traverse_no_checking(node)
-            elif isinstance(node, KDTree.leafnode):
-                d = self.data[node.idx]
-                return node.idx[minkowski_distance(d, x, p) <= r].tolist()
-            else:
-                less, greater = rect.split(node.split_dim, node.split)
-                return traverse_checking(node.less, less) + \
-                       traverse_checking(node.greater, greater)
+            x = np.asarray(x, dtype=np.float64)
+            inds = super().query_ball_point(x, distance_upper_bound, p, eps)
 
-        def traverse_no_checking(node):
-            if isinstance(node, KDTree.leafnode):
-                return node.idx.tolist()
-            else:
-                return traverse_no_checking(node.less) + \
-                       traverse_no_checking(node.greater)
+            if isinstance(inds, list):
+                d = list(minkowski_distance(x, self.data[inds], p=p))
+                return d, inds
 
-        return traverse_checking(self.tree, R)
+            d = np.empty_like(inds)
+            with np.nditer([inds], flags=['refs_ok', 'multi_index']) as it:
+                while not it.finished:
+                    d[it.multi_index] = list(minkowski_distance(
+                        x[it.multi_index], self.data[inds[it.multi_index]], p))
+                    it.iternext()
+
+            return d, inds
+
+        d, i = super().query(x, k, eps, p, distance_upper_bound)
+        if isinstance(i, int):
+            i = np.int64(i)
+        return d, i
 
     def query_ball_point(self, x, r, p=2., eps=0):
         """Find all points within distance r of point(s) x.
@@ -626,17 +422,7 @@ class KDTree(object):
         x = np.asarray(x)
         if x.dtype.kind == 'c':
             raise TypeError("KDTree does not work with complex data")
-        if x.shape[-1] != self.m:
-            raise ValueError("Searching for a %d-dimensional point in a "
-                             "%d-dimensional KDTree" % (x.shape[-1], self.m))
-        if len(x.shape) == 1:
-            return self.__query_ball_point(x, r, p, eps)
-        else:
-            retshape = x.shape[:-1]
-            result = np.empty(retshape, dtype=object)
-            for c in np.ndindex(retshape):
-                result[c] = self.__query_ball_point(x[c], r, p=p, eps=eps)
-            return result
+        return super().query_ball_point(x, r, p, eps)
 
     def query_ball_tree(self, other, r, p=2., eps=0):
         """
@@ -686,49 +472,7 @@ class KDTree(object):
         >>> plt.show()
 
         """
-        results = [[] for i in range(self.n)]
-
-        def traverse_checking(node1, rect1, node2, rect2):
-            if rect1.min_distance_rectangle(rect2, p) > r/(1.+eps):
-                return
-            elif rect1.max_distance_rectangle(rect2, p) < r*(1.+eps):
-                traverse_no_checking(node1, node2)
-            elif isinstance(node1, KDTree.leafnode):
-                if isinstance(node2, KDTree.leafnode):
-                    d = other.data[node2.idx]
-                    for i in node1.idx:
-                        results[i] += node2.idx[minkowski_distance(d,self.data[i],p) <= r].tolist()
-                else:
-                    less, greater = rect2.split(node2.split_dim, node2.split)
-                    traverse_checking(node1,rect1,node2.less,less)
-                    traverse_checking(node1,rect1,node2.greater,greater)
-            elif isinstance(node2, KDTree.leafnode):
-                less, greater = rect1.split(node1.split_dim, node1.split)
-                traverse_checking(node1.less,less,node2,rect2)
-                traverse_checking(node1.greater,greater,node2,rect2)
-            else:
-                less1, greater1 = rect1.split(node1.split_dim, node1.split)
-                less2, greater2 = rect2.split(node2.split_dim, node2.split)
-                traverse_checking(node1.less,less1,node2.less,less2)
-                traverse_checking(node1.less,less1,node2.greater,greater2)
-                traverse_checking(node1.greater,greater1,node2.less,less2)
-                traverse_checking(node1.greater,greater1,node2.greater,greater2)
-
-        def traverse_no_checking(node1, node2):
-            if isinstance(node1, KDTree.leafnode):
-                if isinstance(node2, KDTree.leafnode):
-                    for i in node1.idx:
-                        results[i] += node2.idx.tolist()
-                else:
-                    traverse_no_checking(node1, node2.less)
-                    traverse_no_checking(node1, node2.greater)
-            else:
-                traverse_no_checking(node1.less, node2)
-                traverse_no_checking(node1.greater, node2)
-
-        traverse_checking(self.tree, Rectangle(self.maxes, self.mins),
-                          other.tree, Rectangle(other.maxes, other.mins))
-        return results
+        return super().query_ball_tree(other, r, p, eps)
 
     def query_pairs(self, r, p=2., eps=0):
         """
@@ -772,88 +516,7 @@ class KDTree(object):
         >>> plt.show()
 
         """
-        results = set()
-
-        def traverse_checking(node1, rect1, node2, rect2):
-            if rect1.min_distance_rectangle(rect2, p) > r/(1.+eps):
-                return
-            elif rect1.max_distance_rectangle(rect2, p) < r*(1.+eps):
-                traverse_no_checking(node1, node2)
-            elif isinstance(node1, KDTree.leafnode):
-                if isinstance(node2, KDTree.leafnode):
-                    # Special care to avoid duplicate pairs
-                    if id(node1) == id(node2):
-                        d = self.data[node2.idx]
-                        for i in node1.idx:
-                            for j in node2.idx[minkowski_distance(d,self.data[i],p) <= r]:
-                                if i < j:
-                                    results.add((i,j))
-                    else:
-                        d = self.data[node2.idx]
-                        for i in node1.idx:
-                            for j in node2.idx[minkowski_distance(d,self.data[i],p) <= r]:
-                                if i < j:
-                                    results.add((i,j))
-                                elif j < i:
-                                    results.add((j,i))
-                else:
-                    less, greater = rect2.split(node2.split_dim, node2.split)
-                    traverse_checking(node1,rect1,node2.less,less)
-                    traverse_checking(node1,rect1,node2.greater,greater)
-            elif isinstance(node2, KDTree.leafnode):
-                less, greater = rect1.split(node1.split_dim, node1.split)
-                traverse_checking(node1.less,less,node2,rect2)
-                traverse_checking(node1.greater,greater,node2,rect2)
-            else:
-                less1, greater1 = rect1.split(node1.split_dim, node1.split)
-                less2, greater2 = rect2.split(node2.split_dim, node2.split)
-                traverse_checking(node1.less,less1,node2.less,less2)
-                traverse_checking(node1.less,less1,node2.greater,greater2)
-
-                # Avoid traversing (node1.less, node2.greater) and
-                # (node1.greater, node2.less) (it's the same node pair twice
-                # over, which is the source of the complication in the
-                # original KDTree.query_pairs)
-                if id(node1) != id(node2):
-                    traverse_checking(node1.greater,greater1,node2.less,less2)
-
-                traverse_checking(node1.greater,greater1,node2.greater,greater2)
-
-        def traverse_no_checking(node1, node2):
-            if isinstance(node1, KDTree.leafnode):
-                if isinstance(node2, KDTree.leafnode):
-                    # Special care to avoid duplicate pairs
-                    if id(node1) == id(node2):
-                        for i in node1.idx:
-                            for j in node2.idx:
-                                if i < j:
-                                    results.add((i,j))
-                    else:
-                        for i in node1.idx:
-                            for j in node2.idx:
-                                if i < j:
-                                    results.add((i,j))
-                                elif j < i:
-                                    results.add((j,i))
-                else:
-                    traverse_no_checking(node1, node2.less)
-                    traverse_no_checking(node1, node2.greater)
-            else:
-                # Avoid traversing (node1.less, node2.greater) and
-                # (node1.greater, node2.less) (it's the same node pair twice
-                # over, which is the source of the complication in the
-                # original KDTree.query_pairs)
-                if id(node1) == id(node2):
-                    traverse_no_checking(node1.less, node2.less)
-                    traverse_no_checking(node1.less, node2.greater)
-                    traverse_no_checking(node1.greater, node2.greater)
-                else:
-                    traverse_no_checking(node1.less, node2)
-                    traverse_no_checking(node1.greater, node2)
-
-        traverse_checking(self.tree, Rectangle(self.maxes, self.mins),
-                          self.tree, Rectangle(self.maxes, self.mins))
-        return results
+        return super().query_pairs(r, p, eps)
 
     def count_neighbors(self, other, r, p=2.):
         """
@@ -904,54 +567,7 @@ class KDTree(object):
         9
 
         """
-        def traverse(node1, rect1, node2, rect2, idx):
-            min_r = rect1.min_distance_rectangle(rect2,p)
-            max_r = rect1.max_distance_rectangle(rect2,p)
-            c_greater = r[idx] > max_r
-            result[idx[c_greater]] += node1.children*node2.children
-            idx = idx[(min_r <= r[idx]) & (r[idx] <= max_r)]
-            if len(idx) == 0:
-                return
-
-            if isinstance(node1,KDTree.leafnode):
-                if isinstance(node2,KDTree.leafnode):
-                    ds = minkowski_distance(self.data[node1.idx][:,np.newaxis,:],
-                                  other.data[node2.idx][np.newaxis,:,:],
-                                  p).ravel()
-                    ds.sort()
-                    result[idx] += np.searchsorted(ds,r[idx],side='right')
-                else:
-                    less, greater = rect2.split(node2.split_dim, node2.split)
-                    traverse(node1, rect1, node2.less, less, idx)
-                    traverse(node1, rect1, node2.greater, greater, idx)
-            else:
-                if isinstance(node2,KDTree.leafnode):
-                    less, greater = rect1.split(node1.split_dim, node1.split)
-                    traverse(node1.less, less, node2, rect2, idx)
-                    traverse(node1.greater, greater, node2, rect2, idx)
-                else:
-                    less1, greater1 = rect1.split(node1.split_dim, node1.split)
-                    less2, greater2 = rect2.split(node2.split_dim, node2.split)
-                    traverse(node1.less,less1,node2.less,less2,idx)
-                    traverse(node1.less,less1,node2.greater,greater2,idx)
-                    traverse(node1.greater,greater1,node2.less,less2,idx)
-                    traverse(node1.greater,greater1,node2.greater,greater2,idx)
-
-        R1 = Rectangle(self.maxes, self.mins)
-        R2 = Rectangle(other.maxes, other.mins)
-        if np.shape(r) == ():
-            r = np.array([r])
-            result = np.zeros(1,dtype=int)
-            traverse(self.tree, R1, other.tree, R2, np.arange(1))
-            return result[0]
-        elif len(np.shape(r)) == 1:
-            r = np.asarray(r)
-            n, = r.shape
-            result = np.zeros(n,dtype=int)
-            traverse(self.tree, R1, other.tree, R2, np.arange(n))
-            return result
-        else:
-            raise ValueError("r must be either a single value or a one-dimensional array of values")
+        return super().count_neighbors(other, r, p)
 
     def sparse_distance_matrix(self, other, max_distance, p=2.):
         """
@@ -1003,37 +619,7 @@ class KDTree(object):
             [0.17308768, 0.32837991, 0.72760803, 0.24823138, 0.75017239]])
 
         """
-        result = scipy.sparse.dok_matrix((self.n,other.n))
-
-        def traverse(node1, rect1, node2, rect2):
-            if rect1.min_distance_rectangle(rect2, p) > max_distance:
-                return
-            elif isinstance(node1, KDTree.leafnode):
-                if isinstance(node2, KDTree.leafnode):
-                    for i in node1.idx:
-                        for j in node2.idx:
-                            d = minkowski_distance(self.data[i],other.data[j],p)
-                            if d <= max_distance:
-                                result[i,j] = d
-                else:
-                    less, greater = rect2.split(node2.split_dim, node2.split)
-                    traverse(node1,rect1,node2.less,less)
-                    traverse(node1,rect1,node2.greater,greater)
-            elif isinstance(node2, KDTree.leafnode):
-                less, greater = rect1.split(node1.split_dim, node1.split)
-                traverse(node1.less,less,node2,rect2)
-                traverse(node1.greater,greater,node2,rect2)
-            else:
-                less1, greater1 = rect1.split(node1.split_dim, node1.split)
-                less2, greater2 = rect2.split(node2.split_dim, node2.split)
-                traverse(node1.less,less1,node2.less,less2)
-                traverse(node1.less,less1,node2.greater,greater2)
-                traverse(node1.greater,greater1,node2.less,less2)
-                traverse(node1.greater,greater1,node2.greater,greater2)
-        traverse(self.tree, Rectangle(self.maxes, self.mins),
-                 other.tree, Rectangle(other.maxes, other.mins))
-
-        return result
+        return super().sparse_distance_matrix(other, max_distance, p)
 
 
 def distance_matrix(x, y, p=2, threshold=1000000):

--- a/scipy/spatial/kdtree.py
+++ b/scipy/spatial/kdtree.py
@@ -575,7 +575,6 @@ class KDTree(cKDTree):
             counts = counts.astype(int)
         return counts
 
-
     def sparse_distance_matrix(self, other, max_distance, p=2.):
         """
         Compute a sparse distance matrix

--- a/scipy/spatial/kdtree.py
+++ b/scipy/spatial/kdtree.py
@@ -240,29 +240,19 @@ class KDTree(cKDTree):
             self._node = ckdtree_node
 
         def __lt__(self, other):
-            if not isinstance(other, KDTree.node):
-                return False
-            return id(self._node) < id(other._node)
-
-        def __le__(self, other):
-            if not isinstance(other, KDTree.node):
-                return False
-            return id(self._node) <= id(other._node)
+            return id(self) < id(other)
 
         def __gt__(self, other):
-            if not isinstance(other, KDTree.node):
-                return True
-            return id(self._node) > id(other._node)
+            return id(self) > id(other)
+
+        def __le__(self, other):
+            return id(self) <= id(other)
 
         def __ge__(self, other):
-            if not isinstance(other, KDTree.node):
-                return True
-            return id(self._node) >= id(other._node)
+            return id(self) >= id(other)
 
         def __eq__(self, other):
-            if not isinstance(other, KDTree.node):
-                return False
-            return id(self._node) == id(other._node)
+            return id(self) == id(other)
 
     class leafnode(node):
         @property
@@ -274,6 +264,12 @@ class KDTree(cKDTree):
             return self._node.children
 
     class innernode(node):
+        def __init__(self, ckdtreenode):
+            assert isinstance(ckdtreenode, cKDTreeNode)
+            super().__init__(ckdtreenode)
+            self.less = KDTree.node._create(ckdtreenode.lesser)
+            self.greater = KDTree.node._create(ckdtreenode.greater)
+
         @property
         def split_dim(self):
             return self._node.split_dim
@@ -286,17 +282,12 @@ class KDTree(cKDTree):
         def children(self):
             return self._node.children
 
-        @property
-        def less(self):
-            return KDTree.node._create(self._node.lesser)
-
-        @property
-        def greater(self):
-            return KDTree.node._create(self._node.greater)
-
     @property
     def tree(self):
-        return KDTree.node._create(super().tree)
+        if not hasattr(self, "_tree"):
+            self._tree = KDTree.node._create(super().tree)
+
+        return self._tree
 
     def __init__(self, data, leafsize=10):
         data = np.asarray(data)

--- a/scipy/spatial/kdtree.py
+++ b/scipy/spatial/kdtree.py
@@ -285,6 +285,7 @@ class KDTree(cKDTree):
         @property
         def children(self):
             return self._node.children
+
         @property
         def less(self):
             return KDTree.node._create(self._node.lesser)

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -1485,6 +1485,7 @@ def test_kdtree_complex_data():
 
 
 def test_kdtree_tree_access():
+    # Test KDTree.tree can be used to traverse the KDTree
     np.random.seed(1234)
     points = np.random.rand(100, 4)
     t = KDTree(points)
@@ -1511,3 +1512,24 @@ def test_kdtree_tree_access():
             assert n.children == n.less.children + n.greater.children
             nodes.append(n.greater)
             nodes.append(n.less)
+
+
+def test_kdtree_attributes():
+    # Test KDTree's attributes are available
+    np.random.seed(1234)
+    points = np.random.rand(100, 4)
+    t = KDTree(points)
+
+    assert isinstance(t.m, int)
+    assert t.n == points.shape[0]
+
+    assert isinstance(t.n, int)
+    assert t.m == points.shape[1]
+
+    assert isinstance(t.leafsize, int)
+    assert t.leafsize == 10
+
+    assert_array_equal(t.maxes, np.amax(points, axis=0))
+    assert_array_equal(t.mins, np.amin(points, axis=0))
+    assert t.data is points
+

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -213,7 +213,8 @@ class Test_vectorization:
     def test_single_query_all_neighbors(self, r):
         np.random.seed(1234)
         point = np.random.rand(self.kdtree.m)
-        d, i = self.kdtree.query(point, k=None, distance_upper_bound=r)
+        with pytest.warns(DeprecationWarning, match="k=None"):
+            d, i = self.kdtree.query(point, k=None, distance_upper_bound=r)
         assert isinstance(d, list)
         assert isinstance(i, list)
 
@@ -232,7 +233,8 @@ class Test_vectorization:
         r = 1.1
         np.random.seed(1234)
         points = np.random.rand(*query_shape, self.kdtree.m)
-        d, i = self.kdtree.query(points, k=None, distance_upper_bound=r)
+        with pytest.warns(DeprecationWarning, match="k=None"):
+            d, i = self.kdtree.query(points, k=None, distance_upper_bound=r)
         assert_equal(np.shape(d), query_shape)
         assert_equal(np.shape(i), query_shape)
 

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -1482,3 +1482,32 @@ def test_kdtree_complex_data():
 
     with pytest.raises(TypeError, match="complex data"):
         t.query_ball_point(points, r=1)
+
+
+def test_kdtree_tree_access():
+    np.random.seed(1234)
+    points = np.random.rand(100, 4)
+    t = KDTree(points)
+    root = t.tree
+
+    assert isinstance(root, KDTree.innernode)
+    assert root.children == points.shape[0]
+
+    # Visit the tree and assert some basic properties for each node
+    nodes = [root]
+    while nodes:
+        n = nodes.pop(-1)
+
+        if isinstance(n, KDTree.leafnode):
+            assert isinstance(n.children, int)
+            assert n.children == len(n.idx)
+            assert_array_equal(points[n.idx], n._node.data_points)
+        else:
+            assert isinstance(n, KDTree.innernode)
+            assert isinstance(n.split_dim, int)
+            assert 0 <= n.split_dim < t.m
+            assert isinstance(n.split, float)
+            assert isinstance(n.children, int)
+            assert n.children == n.less.children + n.greater.children
+            nodes.append(n.greater)
+            nodes.append(n.less)


### PR DESCRIPTION
#### Reference issue
First step towards gh-8923

#### What does this implement/fix?
This removes the `KDTree` python implementation in favor of `cKDTree`.

It turns out these are not actually 100% compatible, so instead of completely replacing `KDTree`, this makes `KDTree` a thin compatibility layer over a `cKDTree`.

#### Additional information
gh-12372 needs to be merged before this, so we aren't testing `cKDTree` against itself.

I've been searching for inconsistencies between the two APIs. So far I've found these:

- `KDTree` has a different default `leafsize`.
- `cKDTreeNode` is the only node type for `cKDTree` whereas `KDTree` had seperate `leafnode` and `innernode` classes. However, neither of these are a documented part of the `KDTree` api so maybe we can just drop these?
- `KDTree.query` supports an undocumented `query_all_neighbors` mode by passing `k=None`. That is in effect just `query_ball_point` but it returns distances as well as indices.
- There are several places where `KDTree` returns `np.int_` and `cKDTree` returns `np.intp`. These are aliases on linux, but are different types on 64-bit windows.

