### PR TITLE
ENH: Make cKDTree.tree more efficient 

### DIFF
--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -344,7 +344,6 @@ cdef class cKDTreeNode:
         ckdtreenode           *_node
         np.ndarray            _data
         np.ndarray            _indices
-        readonly object       _subtree_indices
         readonly object       lesser
         readonly object       greater
 
@@ -353,7 +352,6 @@ cdef class cKDTreeNode:
         self.split_dim = self._node.split_dim
         self.children = self._node.children
         self.split = self._node.split
-        self._subtree_indices = None
         if self.split_dim == -1:
             self.lesser = None
             self.greater = None
@@ -381,33 +379,10 @@ cdef class cKDTreeNode:
 
     property indices:
         def __get__(cKDTreeNode self):
-            cdef: 
-                np.intp_t s0, s1, s2
-                np.intp_t *d0
-                np.intp_t *d1
-                np.intp_t *d2
-                np.ndarray i0
-                np.ndarray i2
-                np.ndarray i3
-            if self._subtree_indices is None:
-                if self.split_dim == -1:
-                    start = self._node.start_idx
-                    stop = self._node.end_idx
-                    self._subtree_indices = self._indices[start:stop]
-                else:
-                    i1 = self.lesser.indices
-                    i2 = self.greater.indices
-                    s1 = np.PyArray_DIMS(i1)[0]
-                    d1 = <np.intp_t*> np.PyArray_DATA(i1)
-                    s2 = np.PyArray_DIMS(i2)[0]
-                    d2 = <np.intp_t*> np.PyArray_DATA(i2)
-                    s0 = s1 + s2
-                    i0 = np.PyArray_SimpleNew(1, &s0, np.NPY_INTP)
-                    d0 = <np.intp_t*> np.PyArray_DATA(i0)
-                    copy(d1, d1+s1, d0)
-                    copy(d2, d2+s2, d0+s1)
-                    self._subtree_indices = i0
-            return self._subtree_indices 
+            cdef np.intp_t start, stop
+            start = self._node.start_idx
+            stop = self._node.end_idx
+            return self._indices[start:stop]
 
 
 # Main cKDTree class

--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -320,14 +320,11 @@ cdef class cKDTreeNode:
     children : int
         The number of data points sorted to this node.
     data_points : ndarray of float64
-        An array with the data points sorted to this node. This attribute is 
-        created dynamically on the first access and to save memory it should 
-        only be accessed in leafnodes. 
+        An array with the data points sorted to this node.
     indices : ndarray of intp
         An array with the indices of the data points sorted to this node. The
         indices refer to the position in the data set used to construct the
-        kd-tree. This attribute is created dynamically on the first access
-        and to save memory it should only be accessed in leafnodes. 
+        kd-tree.
     lesser : cKDTreeNode or None
         Subnode with the 'lesser' data points. This attribute is None for
         leafnodes.

--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -11,6 +11,7 @@ import scipy.sparse
 
 cimport numpy as np
 from numpy.math cimport INFINITY
+np.import_array()
 
 from cpython.mem cimport PyMem_Malloc, PyMem_Realloc, PyMem_Free
 from libcpp.vector cimport vector
@@ -319,11 +320,14 @@ cdef class cKDTreeNode:
     children : int
         The number of data points sorted to this node.
     data_points : ndarray of float64
-        An array with the data points sorted to this node.
+        An array with the data points sorted to this node. This attribute is 
+        created dynamically on the first access and to save memory it should 
+        only be accessed in leafnodes. 
     indices : ndarray of intp
         An array with the indices of the data points sorted to this node. The
         indices refer to the position in the data set used to construct the
-        kd-tree.
+        kd-tree. This attribute is created dynamically on the first access
+        and to save memory it should only be accessed in leafnodes. 
     lesser : cKDTreeNode or None
         Subnode with the 'lesser' data points. This attribute is None for
         leafnodes.
@@ -340,11 +344,36 @@ cdef class cKDTreeNode:
         ckdtreenode           *_node
         np.ndarray            _data
         np.ndarray            _indices
+        readonly object       _subtree_indices
+        readonly object       lesser
+        readonly object       greater
 
     cdef void _setup(cKDTreeNode self):
+        cdef cKDTreeNode n1, n2
         self.split_dim = self._node.split_dim
         self.children = self._node.children
         self.split = self._node.split
+        self._subtree_indices = None
+        if self.split_dim == -1:
+            self.lesser = None
+            self.greater = None
+        else:
+            # setup lesser branch
+            n1 = cKDTreeNode()
+            n1._node = self._node.less
+            n1._data = self._data
+            n1._indices = self._indices
+            n1.level = self.level + 1
+            n1._setup()
+            self.lesser = n1
+            # setup greater branch
+            n2 = cKDTreeNode()
+            n2._node = self._node.greater
+            n2._data = self._data
+            n2._indices = self._indices
+            n2.level = self.level + 1
+            n2._setup()
+            self.greater = n2
 
     property data_points:
         def __get__(cKDTreeNode self):
@@ -352,40 +381,33 @@ cdef class cKDTreeNode:
 
     property indices:
         def __get__(cKDTreeNode self):
-            cdef np.intp_t i, start, stop
-            if self.split_dim == -1:
-                start = self._node.start_idx
-                stop = self._node.end_idx
-                return self._indices[start:stop]
-            else:
-                return np.hstack([self.lesser.indices,
-                           self.greater.indices])
-
-    property lesser:
-        def __get__(cKDTreeNode self):
-            if self.split_dim == -1:
-                return None
-            else:
-                n = cKDTreeNode()
-                n._node = self._node.less
-                n._data = self._data
-                n._indices = self._indices
-                n.level = self.level + 1
-                n._setup()
-                return n
-
-    property greater:
-        def __get__(cKDTreeNode self):
-            if self.split_dim == -1:
-                return None
-            else:
-                n = cKDTreeNode()
-                n._node = self._node.greater
-                n._data = self._data
-                n._indices = self._indices
-                n.level = self.level + 1
-                n._setup()
-                return n
+            cdef: 
+                np.intp_t s0, s1, s2
+                np.intp_t *d0
+                np.intp_t *d1
+                np.intp_t *d2
+                np.ndarray i0
+                np.ndarray i2
+                np.ndarray i3
+            if self._subtree_indices is None:
+                if self.split_dim == -1:
+                    start = self._node.start_idx
+                    stop = self._node.end_idx
+                    self._subtree_indices = self._indices[start:stop]
+                else:
+                    i1 = self.lesser.indices
+                    i2 = self.greater.indices
+                    s1 = np.PyArray_DIMS(i1)[0]
+                    d1 = <np.intp_t*> np.PyArray_DATA(i1)
+                    s2 = np.PyArray_DIMS(i2)[0]
+                    d2 = <np.intp_t*> np.PyArray_DATA(i2)
+                    s0 = s1 + s2
+                    i0 = np.PyArray_SimpleNew(1, &s0, np.NPY_INTP)
+                    d0 = <np.intp_t*> np.PyArray_DATA(i0)
+                    copy(d1, d1+s1, d0)
+                    copy(d2, d2+s2, d0+s1)
+                    self._subtree_indices = i0
+            return self._subtree_indices 
 
 
 # Main cKDTree class
@@ -470,7 +492,10 @@ cdef class cKDTree:
     mins : ndarray, shape (m,)
         The minimum value in each dimension of the n data points.
     tree : object, class cKDTreeNode
-        This class exposes a Python view of the root node in the cKDTree object.
+        This attribute exposes a Python view of the root node in the cKDTree 
+        object. A full Python view of the kd-tree is created dynamically 
+        on the first access. This attribute allows you to create your own 
+        query functions in Python.
     size : int
         The number of nodes in the tree.
 
@@ -481,7 +506,7 @@ cdef class cKDTree:
     """
     cdef:
         ckdtree * cself
-        readonly cKDTreeNode     tree
+        object                   _python_tree
         readonly np.ndarray      data
         readonly np.ndarray      maxes
         readonly np.ndarray      mins
@@ -491,12 +516,32 @@ cdef class cKDTree:
 
     property n:
         def __get__(self): return self.cself.n
+    
     property m:
         def __get__(self): return self.cself.m
+    
     property leafsize:
         def __get__(self): return self.cself.leafsize
+    
     property size:
         def __get__(self): return self.cself.size
+
+    property tree:
+        # make the tree viewable from Python
+        def __get__(cKDTree self):
+            cdef cKDTreeNode n
+            cdef ckdtree *cself = self.cself
+            if self._python_tree is not None:
+                return self._python_tree
+            else:
+                n = cKDTreeNode()
+                n._node = cself.ctree
+                n._data = self.data
+                n._indices = self.indices
+                n.level = 0
+                n._setup()
+                self._python_tree = n
+                return self._python_tree
 
     def __cinit__(cKDTree self):
         self.cself = <ckdtree * > PyMem_Malloc(sizeof(ckdtree))
@@ -511,6 +556,8 @@ cdef class cKDTree:
             np.float64_t *ptmpmins
             ckdtree *cself = self.cself
             int compact, median
+
+        self._python_tree = None
 
         data = np.array(data, order='C', copy=copy_data, dtype=np.float64)
 
@@ -593,14 +640,6 @@ cdef class cKDTree:
         cself.size = cself.tree_buffer.size()
 
         self._post_init_traverse(cself.ctree)
-
-        # make the tree viewable from Python
-        self.tree = cKDTreeNode()
-        self.tree._node = cself.ctree
-        self.tree._data = self.data
-        self.tree._indices = self.indices
-        self.tree.level = 0
-        self.tree._setup()
 
     cdef _post_init_traverse(cKDTree self, ckdtreenode *node):
         cself = self.cself
@@ -1541,6 +1580,7 @@ cdef class cKDTree:
         mytree = np.asarray(<char[:tree.size]> <char*> cself.tree_buffer.data())
 
         # set raw pointers
+        self._python_tree = None
         self._pre_init()
 
         # copy the tree data

--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -11,7 +11,6 @@ import scipy.sparse
 
 cimport numpy as np
 from numpy.math cimport INFINITY
-np.import_array()
 
 from cpython.mem cimport PyMem_Malloc, PyMem_Realloc, PyMem_Free
 from libcpp.vector cimport vector


### PR DESCRIPTION

#### What does this implement/fix?
Traversal of ```cKDTree.tree``` dynamically creates ```cKDTreeNode``` objects for each attribute access when travering the kd-tree in Python. Data indices are collected recursively when the ```indices``` and ```data_point``` properties are called, making it potentially very inefficient. 

This PR makes the whole ```cKDTree.tree``` appear in all its glory at the first access and also collects data indices as the tree is created. It makes it possible to subclass ```cKDTree``` from Python and make reasonably efficient custom queries.

#### Additional information
<!--Any additional information you think is important.-->