### PR TITLE
DOC: improve docstrings of interpolate.NearestNDInterpolator.__call__ & LinearNDInterpolator.__call__

### DIFF
--- a/scipy/interpolate/interpnd.pyx
+++ b/scipy/interpolate/interpnd.pyx
@@ -133,10 +133,10 @@ class NDInterpolatorBase(object):
 
         Parameters
         ----------
-        x1, x2, ... xn: array_like of float
+        x1, x2, ... xn: array-like of float
             Points where to interpolate data at.
-            x1, x2, ... xn can be array_like of float with broadcastable shape.
-            or x1 can be array_like of float with shape (..., ndim)
+            x1, x2, ... xn can be array-like of float with broadcastable shape.
+            or x1 can be array-like of float with shape ``(..., ndim)``
 
         """
         xi = _ndim_coords_from_arrays(args, ndim=self.points.shape[1])

--- a/scipy/interpolate/interpnd.pyx
+++ b/scipy/interpolate/interpnd.pyx
@@ -135,7 +135,7 @@ class NDInterpolatorBase(object):
         ----------
         x1, x2, ... xn: array_like of float
             Points where to interpolate data at.
-            x1, x2, ... xn can be array_like of float with broadcastible shape.
+            x1, x2, ... xn can be array_like of float with broadcastable shape.
             or x1 can be array_like of float with shape (..., ndim)
 
         """

--- a/scipy/interpolate/interpnd.pyx
+++ b/scipy/interpolate/interpnd.pyx
@@ -133,8 +133,10 @@ class NDInterpolatorBase(object):
 
         Parameters
         ----------
-        xi : ndarray of float, shape (..., ndim)
+        x1, x2, ... xn: array_like of float
             Points where to interpolate data at.
+            x1, x2, ... xn can be array_like of float with broadcastible shape.
+            or x1 can be array_like of float with shape (..., ndim)
 
         """
         xi = _ndim_coords_from_arrays(args, ndim=self.points.shape[1])

--- a/scipy/interpolate/ndgriddata.py
+++ b/scipy/interpolate/ndgriddata.py
@@ -68,10 +68,10 @@ class NearestNDInterpolator(NDInterpolatorBase):
 
         Parameters
         ----------
-        x1, x2, ... xn: array_like of float
+        x1, x2, ... xn: array-like of float
             Points where to interpolate data at.
-            x1, x2, ... xn can be array_like of float with broadcastable shape.
-            or x1 can be array_like of float with shape (..., ndim)
+            x1, x2, ... xn can be array-like of float with broadcastable shape.
+            or x1 can be array-like of float with shape ``(..., ndim)``
 
         """
         xi = _ndim_coords_from_arrays(args, ndim=self.points.shape[1])

--- a/scipy/interpolate/ndgriddata.py
+++ b/scipy/interpolate/ndgriddata.py
@@ -68,8 +68,10 @@ class NearestNDInterpolator(NDInterpolatorBase):
 
         Parameters
         ----------
-        xi : ndarray of float, shape (..., ndim)
+        x1, x2, ... xn: array_like of float
             Points where to interpolate data at.
+            x1, x2, ... xn can be array_like of float with broadcastible shape.
+            or x1 can be array_like of float with shape (..., ndim)
 
         """
         xi = _ndim_coords_from_arrays(args, ndim=self.points.shape[1])

--- a/scipy/interpolate/ndgriddata.py
+++ b/scipy/interpolate/ndgriddata.py
@@ -70,7 +70,7 @@ class NearestNDInterpolator(NDInterpolatorBase):
         ----------
         x1, x2, ... xn: array_like of float
             Points where to interpolate data at.
-            x1, x2, ... xn can be array_like of float with broadcastible shape.
+            x1, x2, ... xn can be array_like of float with broadcastable shape.
             or x1 can be array_like of float with shape (..., ndim)
 
         """

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -2595,18 +2595,23 @@ class TestRegularGridInterpolator(object):
         X, Y = np.meshgrid(X, Y)
         XY = np.vstack((X.ravel(), Y.ravel())).T
 
-        for itype in (NearestNDInterpolator, LinearNDInterpolator,
-                      CloughTocher2DInterpolator):
-            interp = itype(list(zip(x, y)), z)
+        for interpolator in (NearestNDInterpolator, LinearNDInterpolator,
+                             CloughTocher2DInterpolator):
+            interp = interpolator(list(zip(x, y)), z)
             # single array input
             interp_points0 = interp(XY)
-            # broadcastable input
+            # tuple input
             interp_points1 = interp((X, Y))
             interp_points2 = interp((X, 0.0))
+            # broadcastable input
+            interp_points3 = interp(X, Y)
+            interp_points4 = interp(X, 0.0)
 
             assert_equal(interp_points0.size ==
                          interp_points1.size ==
-                         interp_points2.size, True)
+                         interp_points2.size ==
+                         interp_points3.size ==
+                         interp_points4.size, True)
 
 
 class MyValue(object):

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -2581,6 +2581,17 @@ class TestRegularGridInterpolator(object):
         RegularGridInterpolator(points, values)
         RegularGridInterpolator(points, values, fill_value=0.)
 
+    def test_ndim_broadcastible_arrays_input(self):
+        shape = (4, 5, 6, 7)
+        ndims = len(shape)
+        x_0 = [np.arange(0, n, dtype=float) for n in shape]
+        pts = np.moveaxis(
+            np.meshgrid(*x_0, indexing='ij'), 0, -1
+        ).reshape(-1, ndims)
+        values = np.sum(pts, axis=1)
+        for itype in (NearestNDInterpolator, LinearNDInterpolator):
+            interp = itype(pts, values)
+
 
 class MyValue(object):
     """


### PR DESCRIPTION
#### Reference issue
fix #12378 

#### What does this implement/fix?
I improved docstrings `interpolate.NearestNDInterpolator.__call__` & `LinearNDInterpolator.__call__`.

Because, these functions also accepts ndim broadcastible arrays as an argument.
