### PR TITLE
MAINT: prepare for SciPy 1.5.0 "final"

### DIFF
--- a/doc/release/1.5.0-notes.rst
+++ b/doc/release/1.5.0-notes.rst
@@ -2,8 +2,6 @@
 SciPy 1.5.0 Release Notes
 ==========================
 
-.. note:: Scipy 1.5.0 is not released yet!
-
 .. contents::
 
 SciPy 1.5.0 is the culmination of 6 months of hard work. It contains

--- a/setup.py
+++ b/setup.py
@@ -56,8 +56,8 @@ Operating System :: MacOS
 MAJOR = 1
 MINOR = 5
 MICRO = 0
-ISRELEASED = True
-VERSION = '%d.%d.%drc2' % (MAJOR, MINOR, MICRO)
+ISRELEASED = False
+VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
 
 # Return the git revision as a string


### PR DESCRIPTION
* there are no backports needed for SciPy `1.5.0`
final

* set the version number to `1.5.0` (removing the `rc2`)
unreleased

* remove the `Note:` in the release notes about `1.5.0`
not being released yet