### PR TITLE
CI: arm64 numpy now available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -171,17 +171,6 @@ before_install:
   - df -h
   - ulimit -a
   - set -o pipefail
-  - if [[ "${TRAVIS_CPU_ARCH}" == "arm64" ]]; then
-      wget -q "https://github.com/conda-forge/miniforge/releases/download/4.8.2-1/Miniforge3-4.8.2-1-Linux-aarch64.sh"  -O miniconda.sh;
-      chmod +x miniconda.sh;
-      ./miniconda.sh -b -p $HOME/miniconda3;
-      export PATH=$HOME/miniconda3/bin:$PATH;
-      conda config --set always_yes yes --set auto_update_conda false;
-      conda install pip conda;
-      conda update -n base conda;
-      conda info -a;
-      conda install pytest pytest-xdist $NUMPYSPEC mpmath gmpy2 Cython pybind11;
-    fi
   - mkdir builds
   - cd builds
   - |
@@ -192,13 +181,9 @@ before_install:
     fi
   - python -V -V
   - python -c 'import sys; print("Python debug build:", hasattr(sys, "gettotalrefcount"))'
-  # arm64 build uses conda (there aren't any arm64 wheels on PyPI, need
-  # Miniforge / conda-forge), so skip arm64 here
   - |
-    if [[ "$TRAVIS_CPU_ARCH" != "arm64" ]]; then
-         travis_retry pip install --upgrade pip setuptools wheel $OTHERSPEC cython pytest pytest-xdist mpmath argparse Pillow codecov gmpy2 pybind11
-         travis_retry pip install --upgrade $NUMPYSPEC
-    fi
+    travis_retry pip install --upgrade pip setuptools wheel $OTHERSPEC cython pytest pytest-xdist mpmath argparse Pillow codecov gmpy2 pybind11
+    travis_retry pip install --upgrade $NUMPYSPEC
   - |
     if [ -n "${USE_DEBUG}" ]; then
         # see gh-10676; need to pin pytest version with debug
@@ -231,9 +216,7 @@ before_install:
         travis_retry pip install "asv>=0.4.1"
     fi
   - |
-    if [ "${TRAVIS_CPU_ARCH}" != "arm64" ]; then
-         pip uninstall -y nose
-    fi
+    pip uninstall -y nose
   - ccache -s
   - cd ..
 


### PR DESCRIPTION
arm64 numpy is now available. Previous experience shows that CI via miniconda tends to be slower than via pip, so try the travisCI arm run with pip