### PR TITLE
ENH: improve stats.binned_statistic_dd performance

### DIFF
--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -152,23 +152,25 @@ class GroupSampling(Benchmark):
         stats.special_ortho_group.rvs(dim)
 
 
-class BinnedStatistic(Benchmark):
+class BinnedStatisticDD(Benchmark):
 
-    def setup(self):
+    params = ["count", "sum", "mean", "min", "max", "median", "std", np.std]
+
+    def setup(self, statistic):
         np.random.seed(12345678)
         self.inp = np.random.rand(9999).reshape(3, 3333) * 200
         self.subbin_x_edges = np.arange(0, 200, dtype=np.float32)
         self.subbin_y_edges = np.arange(0, 200, dtype=np.float64)
         self.ret = stats.binned_statistic_dd(
-            [self.inp[0], self.inp[1]], self.inp[2], statistic="std",
+            [self.inp[0], self.inp[1]], self.inp[2], statistic=statistic,
             bins=[self.subbin_x_edges, self.subbin_y_edges])
 
-    def time_binned_statistic_dd_std(self):
+    def time_binned_statistic_dd(self, statistic):
         stats.binned_statistic_dd(
-            [self.inp[0], self.inp[1]], self.inp[2], statistic="std",
+            [self.inp[0], self.inp[1]], self.inp[2], statistic=statistic,
             bins=[self.subbin_x_edges, self.subbin_y_edges])
 
-    def time_binned_statistic_dd_std_reuse_bin(self):
+    def time_binned_statistic_dd_reuse_bin(self, statistic):
         stats.binned_statistic_dd(
-            [self.inp[0], self.inp[1]], self.inp[2], statistic="std",
+            [self.inp[0], self.inp[1]], self.inp[2], statistic=statistic,
             binned_statistic_result=self.ret)

--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -583,15 +583,7 @@ def binned_statistic_dd(sample, values, statistic='mean',
             result[vv, a] = flatsum[a] / flatcount[a]
     elif statistic == 'std':
         result.fill(0)
-        flatcount = np.bincount(binnumbers, None)
-        a = flatcount.nonzero()
-        for vv in builtins.range(Vdim):
-            for i in np.unique(binnumbers):
-                # NOTE: take std dev by bin, np.std() is 2-pass and stable
-                binned_data = values[vv, binnumbers == i]
-                # calc std only when binned data is 2 or more for speed up.
-                if len(binned_data) >= 2:
-                    result[vv, i] = np.std(binned_data)
+        _calc_binned_statistic(Vdim, binnumbers, result, values, np.std)
     elif statistic == 'count':
         result.fill(0)
         flatcount = np.bincount(binnumbers, None)
@@ -605,19 +597,13 @@ def binned_statistic_dd(sample, values, statistic='mean',
             result[vv, a] = flatsum
     elif statistic == 'median':
         result.fill(np.nan)
-        for i in np.unique(binnumbers):
-            for vv in builtins.range(Vdim):
-                result[vv, i] = np.median(values[vv, binnumbers == i])
+        _calc_binned_statistic(Vdim, binnumbers, result, values, np.median)
     elif statistic == 'min':
         result.fill(np.nan)
-        for i in np.unique(binnumbers):
-            for vv in builtins.range(Vdim):
-                result[vv, i] = np.min(values[vv, binnumbers == i])
+        _calc_binned_statistic(Vdim, binnumbers, result, values, np.min)
     elif statistic == 'max':
         result.fill(np.nan)
-        for i in np.unique(binnumbers):
-            for vv in builtins.range(Vdim):
-                result[vv, i] = np.max(values[vv, binnumbers == i])
+        _calc_binned_statistic(Vdim, binnumbers, result, values, np.max)
     elif callable(statistic):
         with np.errstate(invalid='ignore'), suppress_warnings() as sup:
             sup.filter(RuntimeWarning)
@@ -626,9 +612,8 @@ def binned_statistic_dd(sample, values, statistic='mean',
             except Exception:
                 null = np.nan
         result.fill(null)
-        for i in np.unique(binnumbers):
-            for vv in builtins.range(Vdim):
-                result[vv, i] = statistic(values[vv, binnumbers == i])
+        _calc_binned_statistic(Vdim, binnumbers, result, values, statistic,
+                               is_callable=True)
 
     # Shape into a proper matrix
     result = result.reshape(np.append(Vdim, nbin))
@@ -648,6 +633,32 @@ def binned_statistic_dd(sample, values, statistic='mean',
     result = result.reshape(input_shape[:-1] + list(nbin-2))
 
     return BinnedStatisticddResult(result, edges, binnumbers)
+
+
+def _calc_binned_statistic(Vdim, bin_numbers, result, values, stat_func,
+                           is_callable=False):
+    unique_bin_numbers = np.unique(bin_numbers)
+    for vv in builtins.range(Vdim):
+        bin_map = _create_binned_data(bin_numbers, unique_bin_numbers, values, vv)
+        for i in unique_bin_numbers:
+            # if the stat_func is callable, all results should be updated
+            # if the stat_func is np.std, calc std only when binned data is 2
+            # or more for speed up.
+            if is_callable or not (stat_func is np.std and len(bin_map[i]) < 2):
+                result[vv, i] = stat_func(bin_map[i])
+
+
+def _create_binned_data(bin_numbers, unique_bin_numbers, values, vv):
+    """ Create hashmap of bin ids to values in bins
+    key: bin number
+    value: list of binned data
+    """
+    bin_map = dict()
+    for i in unique_bin_numbers:
+        bin_map[i] = []
+    for i in builtins.range(len(bin_numbers)):
+        bin_map[bin_numbers[i]].append(values[vv, i])
+    return bin_map
 
 
 def _bin_edges(sample, bins=None, range=None):

--- a/scipy/stats/tests/test_binned_statistic.py
+++ b/scipy/stats/tests/test_binned_statistic.py
@@ -437,15 +437,16 @@ class TestBinnedStatistic(object):
         v = self.v
         w = self.w
 
-        stat1v, edges1v, bc1v = binned_statistic_dd(X, v, np.std, bins=8)
-        stat1w, edges1w, bc1w = binned_statistic_dd(X, w, np.std, bins=8)
-        stat2, edges2, bc2 = binned_statistic_dd(X, [v, w], np.std, bins=8)
-
-        assert_allclose(stat2[0], stat1v)
-        assert_allclose(stat2[1], stat1w)
-        assert_allclose(edges1v, edges2)
-        assert_allclose(edges1w, edges2)
-        assert_allclose(bc1v, bc2)
+        for stat in ["count", "sum", "mean", "std", "min", "max", "median",
+                     np.std]:
+            stat1v, edges1v, bc1v = binned_statistic_dd(X, v, stat, bins=8)
+            stat1w, edges1w, bc1w = binned_statistic_dd(X, w, stat, bins=8)
+            stat2, edges2, bc2 = binned_statistic_dd(X, [v, w], stat, bins=8)
+            assert_allclose(stat2[0], stat1v)
+            assert_allclose(stat2[1], stat1w)
+            assert_allclose(edges1v, edges2)
+            assert_allclose(edges1w, edges2)
+            assert_allclose(bc1v, bc2)
 
     def test_dd_binnumbers_unraveled(self):
         X = self.X


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Related #11468 

#### What does this implement/fix?
In #11757, we improved `binned_statistic_dd` performance for `std` to avoid unnecessary np.std call.

I achieved more better performances only for `max`, `min`, `median`, `std` statistic when I improved binned data search.
I changed to create a binned data hashmap before calculating statistics because searching binned values 

`values[vv, binnumbers == i]`

looks bottleneck.
 
Also, I improved the `test_dd_multi_values` test to test all statistics, and I added benchmarks to evaluate performance in all statistics.

#### Additional information
<!--Any additional information you think is important.-->

These are the benchmark result

Before:
<img width="1383" alt="SS 2020-06-21 at 20 52 32" src="https://user-images.githubusercontent.com/3813847/85227769-4bad0100-b41a-11ea-92b2-656f778b3d0c.png">

After:
<img width="1385" alt="SS 2020-06-21 at 23 28 53" src="https://user-images.githubusercontent.com/3813847/85227774-549dd280-b41a-11ea-8930-4c54385d0ebf.png">

`max` and `min` improved about 50%, `std` improved about 70%, and `median`  improved about 15%.

