### PR TITLE
API: Disable len() and indexing of Rotation instances with single rotation

### DIFF
--- a/scipy/spatial/transform/_rotation_spline.py
+++ b/scipy/spatial/transform/_rotation_spline.py
@@ -363,12 +363,10 @@ class RotationSpline(object):
     def __init__(self, times, rotations):
         from scipy.interpolate import PPoly
 
-        try:
-            n_rotations = len(rotations)
-        except TypeError:
+        if rotations.single:
             raise ValueError("`rotations` must be a sequence of rotations.")
 
-        if n_rotations == 1:
+        if len(rotations) == 1:
             raise ValueError("`rotations` must contain at least 2 rotations.")
 
         times = np.asarray(times, dtype=float)

--- a/scipy/spatial/transform/_rotation_spline.py
+++ b/scipy/spatial/transform/_rotation_spline.py
@@ -363,7 +363,12 @@ class RotationSpline(object):
     def __init__(self, times, rotations):
         from scipy.interpolate import PPoly
 
-        if len(rotations) == 1:
+        try:
+            n_rotations = len(rotations)
+        except TypeError:
+            raise ValueError("`rotations` must be a sequence of rotations.")
+
+        if n_rotations == 1:
             raise ValueError("`rotations` must contain at least 2 rotations.")
 
         times = np.asarray(times, dtype=float)

--- a/scipy/spatial/transform/rotation.pyx
+++ b/scipy/spatial/transform/rotation.pyx
@@ -315,6 +315,10 @@ cdef class Rotation(object):
     To create `Rotation` objects use ``from_...`` methods (see examples below).
     ``Rotation(...)`` is not supposed to be instantiated directly.
 
+    Attributes
+    ----------
+    single
+
     Methods
     -------
     __len__
@@ -521,6 +525,11 @@ cdef class Rotation(object):
                     raise ValueError("Found zero norm quaternions in `quat`.")
         else:
             self._quat = quat.copy() if copy else quat
+
+    @property
+    def single(self):
+        """Whether this instance represents a single rotation."""
+        return self._single
 
     def __len__(self):
         """Number of rotations contained in this object.

--- a/scipy/spatial/transform/rotation.pyx
+++ b/scipy/spatial/transform/rotation.pyx
@@ -522,7 +522,13 @@ cdef class Rotation(object):
         length : int
             Number of rotations stored in object.
 
+        Raises
+        ------
+        TypeError if the instance was created as a single rotation.
         """
+        if self._single:
+            raise TypeError("Single rotation has no len().")
+
         return self._quat.shape[0]
 
     @classmethod
@@ -1188,7 +1194,7 @@ cdef class Rotation(object):
         (2, 3)
 
         """
-        cdef Py_ssize_t num_rotations = len(self)
+        cdef Py_ssize_t num_rotations = len(self._quat)
         cdef double angle, scale, angle2
         cdef double[:, :] rotvec = _empty2(num_rotations, 3)
         cdef double[:] quat
@@ -1460,7 +1466,7 @@ cdef class Rotation(object):
             matrix = matrix[None, :, :]
 
         n_vectors = vectors.shape[0]
-        n_rotations = len(self)
+        n_rotations = len(self._quat)
 
         if n_vectors != 1 and n_rotations != 1 and n_vectors != n_rotations:
             raise ValueError("Expected equal numbers of rotations and vectors "
@@ -1544,7 +1550,9 @@ cdef class Rotation(object):
                [ 0.33721128, -0.26362477,  0.26362477,  0.86446082]])
 
         """
-        if not(len(self) == 1 or len(other) == 1 or len(self) == len(other)):
+        len_self = len(self._quat)
+        len_other = len(other._quat)
+        if not(len_self == 1 or len_other == 1 or len_self == len_other):
             raise ValueError("Expected equal number of rotations in both "
                              "or a single rotation in either object, "
                              "got {} rotations in first and {} rotations in "
@@ -1751,13 +1759,19 @@ cdef class Rotation(object):
 
         # Find best indices from scalar components
         max_ind = np.argmax(np.reshape(qs, (len(qs), -1)), axis=1)
-        left_best = max_ind // len(right)
-        right_best = max_ind % len(right)
+        left_best = max_ind // len(rv)
+        right_best = max_ind % len(rv)
+
+        if len(lv) > 1:
+            left = left[left_best]
+        if len(rv) > 1:
+            right = right[right_best]
 
         # Reduce the rotation using the best indices
-        reduced = left[left_best] * p * right[right_best]
+        reduced = left * p * right
         if self._single:
-            reduced = reduced[0]
+            # Reduce the rotation using the best indices
+            reduced = self.__class__(reduced.as_quat()[0], normalize=False)
             left_best = left_best[0]
             right_best = right_best[0]
 
@@ -1828,6 +1842,10 @@ cdef class Rotation(object):
                 - a stack of rotation(s), if `indexer` is a slice, or and index
                   array.
 
+        Raises
+        ------
+        TypeError if the instance was created as a single rotation.
+
         Examples
         --------
         >>> from scipy.spatial.transform import Rotation as R
@@ -1854,6 +1872,9 @@ cdef class Rotation(object):
                [ 0.57735027,  0.57735027, -0.57735027,  0.        ]])
 
         """
+        if self._single:
+            raise TypeError("Single rotation is not subscriptable.")
+
         return self.__class__(np.asarray(self._quat)[indexer], normalize=False)
 
     @classmethod
@@ -2137,8 +2158,14 @@ class Slerp(object):
 
     """
     def __init__(self, times, rotations):
-        if len(rotations) == 1:
-            raise ValueError("`rotations` must contain at least 2 rotations.")
+        try:
+            n_rotations = len(rotations)
+        except TypeError:
+            raise ValueError("`rotations` must be a sequence of rotations.")
+
+        if n_rotations == 1:
+                raise ValueError("`rotations` must contain at least 2 "
+                                 "rotations.")
 
         times = np.asarray(times)
         if times.ndim != 1:

--- a/scipy/spatial/transform/rotation.pyx
+++ b/scipy/spatial/transform/rotation.pyx
@@ -1781,9 +1781,9 @@ cdef class Rotation(object):
         left_best = max_ind // len(rv)
         right_best = max_ind % len(rv)
 
-        if len(lv) > 1:
+        if not left.single:
             left = left[left_best]
-        if len(rv) > 1:
+        if not right.single:
             right = right[right_best]
 
         # Reduce the rotation using the best indices
@@ -2177,12 +2177,10 @@ class Slerp(object):
 
     """
     def __init__(self, times, rotations):
-        try:
-            n_rotations = len(rotations)
-        except TypeError:
+        if rotations.single:
             raise ValueError("`rotations` must be a sequence of rotations.")
 
-        if n_rotations == 1:
+        if len(rotations) == 1:
                 raise ValueError("`rotations` must contain at least 2 "
                                  "rotations.")
 

--- a/scipy/spatial/transform/rotation.pyx
+++ b/scipy/spatial/transform/rotation.pyx
@@ -459,6 +459,16 @@ cdef class Rotation(object):
     array([[0.        , 0.38268343, 0.        , 0.92387953],
            [0.39190384, 0.36042341, 0.43967974, 0.72331741]])
 
+    In fact it can be converted to numpy.array:
+
+    >>> r_array = np.asarray(r)
+    >>> r_array.shape
+    (3,)
+    >>> r_array[0].as_matrix()
+    array([[ 2.22044605e-16, -1.00000000e+00,  0.00000000e+00],
+           [ 1.00000000e+00,  2.22044605e-16,  0.00000000e+00],
+           [ 0.00000000e+00,  0.00000000e+00,  1.00000000e+00]])
+
     Multiple rotations can be composed using the ``*`` operator:
 
     >>> r1 = R.from_euler('z', 90, degrees=True)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -874,8 +874,6 @@ def test_n_rotations():
     r = Rotation.from_matrix(mat)
 
     assert_equal(len(r), 2)
-    assert_equal(len(r[0]), 1)
-    assert_equal(len(r[1]), 1)
     assert_equal(len(r[:-1]), 1)
 
 
@@ -1043,7 +1041,7 @@ def test_slerp():
 
 
 def test_slerp_single_rot():
-    with pytest.raises(ValueError, match="at least 2 rotations"):
+    with pytest.raises(ValueError, match="must be a sequence of rotations"):
         r = Rotation.from_quat([1, 2, 3, 4])
         Slerp([1], r)
 

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -1147,7 +1147,7 @@ def test_rotation_within_numpy_array():
     assert_allclose(array[0, 0].as_matrix(), multiple[0].as_matrix())
     assert_allclose(array[0, 1].as_matrix(), multiple[1].as_matrix())
 
-    array = np.array([single, multiple])
+    array = np.array([single, multiple], dtype=object)
     assert_equal(array.shape, (2,))
     assert_equal(array[0], single)
     assert_equal(array[1], multiple)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -1124,3 +1124,33 @@ def test_multiplication_stability():
     for q in qs:
         rs *= q * rs
         assert_allclose(np.linalg.norm(rs.as_quat(), axis=1), 1)
+
+
+def test_rotation_within_numpy_array():
+    single = Rotation.random()
+    multiple = Rotation.random(2)
+
+    array = np.array(single)
+    assert_equal(array.shape, ())
+
+    array = np.array(multiple)
+    assert_equal(array.shape, (2,))
+    assert_allclose(array[0].as_matrix(), multiple[0].as_matrix())
+    assert_allclose(array[1].as_matrix(), multiple[1].as_matrix())
+
+    array = np.array([single])
+    assert_equal(array.shape, (1,))
+    assert_equal(array[0], single)
+
+    array = np.array([multiple])
+    assert_equal(array.shape, (1, 2))
+    assert_allclose(array[0, 0].as_matrix(), multiple[0].as_matrix())
+    assert_allclose(array[0, 1].as_matrix(), multiple[1].as_matrix())
+
+    array = np.array([single, multiple])
+    assert_equal(array.shape, (2,))
+    assert_equal(array[0], single)
+    assert_equal(array[1], multiple)
+
+    array = np.array([multiple, multiple, multiple])
+    assert_equal(array.shape, (3, 2))


### PR DESCRIPTION
#### Reference issue
Closes #12162

#### What does this implement/fix?

This weird bug in #12162 happens because we don't properly differentiate between single (scalar) and multiple rotations. If we have a single rotation we shouldn't be able to compute `len` of it or index it. 

Adding `__array__` method which raises an exception didn't work, this is another reasons why I decided to do it this way.

Overall it looks like more solid and reasonable design from an abstract point of view. It seems to interact correctly with numpy now. It sure created some other inconveniences in the existing code, but I believe it is the correct way to handle this situation.

@pmla @rgommers what do you think?