### PR TITLE
DOC: Fix docstring for dist param in anderson function

### DIFF
--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1717,8 +1717,7 @@ def anderson(x, dist='norm'):
     ----------
     x : array_like
         Array of sample data.
-    dist : {'norm', 'expon', 'logistic', 'gumbel', 'gumbel_l', 'gumbel_r',
-        'extreme1'}, optional
+    dist : {'norm', 'expon', 'logistic', 'gumbel', 'gumbel_l', 'gumbel_r', 'extreme1'}, optional
         The type of distribution to test against.  The default is 'norm'.
         The names 'extreme1', 'gumbel_l' and 'gumbel' are synonyms for the
         same distribution.


### PR DESCRIPTION
Closes #12406 
This PR fixes the documentation for the dist parameter in the anderson function (scipy.stats.anderson).