### PR TITLE
Fix regression in scipy 1.5.0 in dendogram when labels is a numpy array.

### DIFF
--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -3274,7 +3274,7 @@ def dendrogram(Z, p=30, truncate_mode=None, color_threshold=None,
         raise ValueError("orientation must be one of 'top', 'left', "
                          "'bottom', or 'right'")
 
-    if labels and Z.shape[0] + 1 != len(labels):
+    if labels is not None and Z.shape[0] + 1 != len(labels):
         raise ValueError("Dimensions of Z and labels must be consistent.")
 
     is_valid_linkage(Z, throw=True, name='Z')

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -812,6 +812,13 @@ class TestDendrogram(object):
         Z = linkage(hierarchy_test_data.ytdist, 'single')
         assert_raises(ValueError, dendrogram, Z, orientation="foo")
 
+    def test_can_take_label_as_array_or_list(self):
+        Z = linkage(hierarchy_test_data.ytdist, 'single')
+        labels = np.array([1, 3, 2, 6, 4, 5])
+        result1 = dendrogram(Z, labels=labels, no_plot=True)
+        result2 = dendrogram(Z, labels=labels.tolist(), no_plot=True)
+        assert result1 == result2
+
     @pytest.mark.skipif(not have_matplotlib, reason="no matplotlib")
     def test_valid_label_size(self):
         link = np.array([

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -812,7 +812,7 @@ class TestDendrogram(object):
         Z = linkage(hierarchy_test_data.ytdist, 'single')
         assert_raises(ValueError, dendrogram, Z, orientation="foo")
 
-    def test_can_take_label_as_array_or_list(self):
+    def test_labels_as_array_or_list(self):
         Z = linkage(hierarchy_test_data.ytdist, 'single')
         labels = np.array([1, 3, 2, 6, 4, 5])
         result1 = dendrogram(Z, labels=labels, no_plot=True)
@@ -831,6 +831,12 @@ class TestDendrogram(object):
             dendrogram(link, labels=list(range(100)))
         assert "Dimensions of Z and labels must be consistent."\
                in str(exc_info.value)
+
+        with pytest.raises(
+                ValueError,
+                match="Dimensions of Z and labels must be consistent."):
+            dendrogram(link, labels=[])
+
         plt.close()
 
     @pytest.mark.skipif(not have_matplotlib, reason="no matplotlib")

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -813,6 +813,7 @@ class TestDendrogram(object):
         assert_raises(ValueError, dendrogram, Z, orientation="foo")
 
     def test_labels_as_array_or_list(self):
+        # test for gh-12418
         Z = linkage(hierarchy_test_data.ytdist, 'single')
         labels = np.array([1, 3, 2, 6, 4, 5])
         result1 = dendrogram(Z, labels=labels, no_plot=True)


### PR DESCRIPTION
#### Reference issue
Fix #12418.

#### What does this implement/fix?
This fixes a regression when `labels` is a numpy array.

I added a test but I am not too familiar with dendrogram so let me know if the labels I chose do not make sense.
