### PR TITLE
BUG: truncnorm and geninvgauss never return scalars from rvs

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -7686,7 +7686,7 @@ class truncnorm_gen(rv_continuous):
                 it.iternext()
 
         if size == ():
-            out = out[()]
+            out = out.item()
         return out
 
     def _rvs_scalar(self, a, b, numsamples=None, random_state=None):

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -3749,7 +3749,7 @@ class geninvgauss_gen(rv_continuous):
                 it.iternext()
 
         if size == ():
-            out = out[()]
+            out = out.item()
         return out
 
     def _rvs_scalar(self, p, b, numsamples, random_state):

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -188,6 +188,23 @@ def test_cont_basic(distname, arg):
             check_fit_args_fix(distfn, arg, rvs[0:200])
 
 
+@pytest.mark.parametrize('distname,arg', cases_test_cont_basic())
+def test_rvs_scalar(distname, arg):
+    # rvs should return a scalar when given scalar arguments (gh-12428)
+    try:
+        distfn = getattr(stats, distname)
+    except TypeError:
+        distfn = distname
+        distname = 'rv_histogram_instance'
+
+    with npt.suppress_warnings() as sup:
+        sup.filter(category=DeprecationWarning, message=".*frechet_")
+        rvs = distfn.rvs(*arg)
+        assert np.isscalar(distfn.rvs(*arg))
+        assert np.isscalar(distfn.rvs(*arg, size=()))
+        assert np.isscalar(distfn.rvs(*arg, size=None))
+
+
 def test_levy_stable_random_state_property():
     # levy_stable only implements rvs(), so it is skipped in the
     # main loop in test_cont_basic(). Here we apply just the test
@@ -644,3 +661,4 @@ def test_methods_with_lists(method, distname, args):
         npt.assert_allclose(result,
                             [f(*v) for v in zip(x, *shape2, loc, scale)],
                             rtol=1e-15, atol=1e-15)
+


### PR DESCRIPTION
#### Reference issue
Fixes gh-12428

#### What does this implement/fix?
For scalar inputs, `truncnorm`'s `rvs` does a single call to `_rvs_scalar` which always returns an array. The code does check for `shape=()` and tries to return a python scalar by returning `out[()]` but the array is actually 1d not 0d, so `out[()]` is just a no-op. `.item()` does work for 1-d arrays though.

Testing also revealed that `geninvgauss` is broken in the exactly the same way.