### PR TITLE
BUG: optimize: cast bounds to floats in new_bounds_to_old/old_bounds_to_new

### DIFF
--- a/scipy/optimize/_constraints.py
+++ b/scipy/optimize/_constraints.py
@@ -298,8 +298,8 @@ def new_bounds_to_old(lb, ub, n):
     if ub.ndim == 0:
         ub = np.resize(ub, n)
 
-    lb = [x if x > -np.inf else None for x in lb]
-    ub = [x if x < np.inf else None for x in ub]
+    lb = [float(x) if x > -np.inf else None for x in lb]
+    ub = [float(x) if x < np.inf else None for x in ub]
 
     return list(zip(lb, ub))
 
@@ -314,8 +314,8 @@ def old_bound_to_new(bounds):
     -np.inf/np.inf.
     """
     lb, ub = zip(*bounds)
-    lb = np.array([x if x is not None else -np.inf for x in lb])
-    ub = np.array([x if x is not None else np.inf for x in ub])
+    lb = np.array([float(x) if x is not None else -np.inf for x in lb])
+    ub = np.array([float(x) if x is not None else np.inf for x in ub])
     return lb, ub
 
 

--- a/scipy/optimize/tests/test_constraints.py
+++ b/scipy/optimize/tests/test_constraints.py
@@ -161,6 +161,13 @@ def test_old_bounds_to_new():
     assert_array_equal(lb, lb_true)
     assert_array_equal(ub, ub_true)
 
+    bounds = [(-np.inf, np.inf), (np.array([1]), np.array([1]))]
+    lb, ub = old_bound_to_new(bounds)
+
+    assert_array_equal(lb, [-np.inf, 1])
+    assert_array_equal(ub, [np.inf, 1])
+
+
 def test_bounds_repr():
     from numpy import array, inf  # so that eval works
     for args in (

--- a/scipy/optimize/tests/test_slsqp.py
+++ b/scipy/optimize/tests/test_slsqp.py
@@ -312,6 +312,12 @@ class TestSLSQP(object):
         # This should not raise an exception
         fmin_slsqp(lambda z: z**2 - 1, [0], bounds=[[0, 1]], iprint=0)
 
+    def test_array_bounds(self):
+        # This should pass (1-element arrays are castable to floats in numpy)
+        bounds = [(-np.inf, np.inf), (np.array([2]), np.array([3]))]
+        x = fmin_slsqp(lambda z: np.sum(z**2 - 1), [2.5, 2.5], bounds=bounds, iprint=0)
+        assert_array_almost_equal(x, [0, 2])
+
     def test_obj_must_return_scalar(self):
         # Regression test for Github Issue #5433
         # If objective function does not return a scalar, raises ValueError


### PR DESCRIPTION
#### Reference issue
Closes gh-12422

#### What does this implement/fix?
Ensures the returned bounds arrays/lists contain numbers, instead of
being potentially arbitrary object arrays causing failures at a later
stage.

The optimization algorithms that use these functions expect work in
double precision, so we can just cast to floats.
