### PR TITLE
BUG: use ellipkm1 in elliptical filter design to prevent numerical issues

### DIFF
--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -4298,6 +4298,11 @@ def _ellipdeg(n, m1):
     return 16 * q * (num / den) ** 4
 
 
+# Maximum number of iterations in Landen transformation recursion
+# sequence.  10 is conservative; unit tests pass with 4, Orfanidis
+# (see _arc_jac_cn [1]) suggests 5.
+_ARC_JAC_SN_MAXITER = 10
+
 def _arc_jac_sn(w, m):
     """Inverse Jacobian elliptic sn
 
@@ -4335,10 +4340,14 @@ def _arc_jac_sn(w, m):
         return np.arctanh(w)
 
     ks = [k]
+    niter = 0
     while ks[-1] != 0:
         k_ = ks[-1]
         k_p = _complement(k_)
         ks.append((1 - k_p) / (1 + k_p))
+        niter += 1
+        if niter > _ARC_JAC_SN_MAXITER:
+            raise ValueError('Landen transformation not converging')
 
     K = np.product(1 + np.array(ks[1:])) * np.pi/2
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes gh-6384.

#### What does this implement/fix?
In computing the filter coefficients, calculations of the form ellipk(m) and ellipk(1-m) are used, with small m.  In this case the latter is more accurately computed with ellipkm1.

I also changed the inverse solvers for ellipk(m) / ellipk(1-m) and sn / cn when my initial ellipkm1 changes caused unit test failures.

The replaced `_kratio` function is a bit odd; it clips its argument to [0,1], but then uses abs(m); if `m > 1`, the return value is set to `-k_ratio`, but the *absolute* of the result is always returned.  I think the new implementation is simpler to understand.

The replaced `_v_ratio` and associated minimization worked with `abs(ineps - s /c)`.  `s/c` seems to be roughly analogous to `tan`, and like `tan` is notionally unbounded.  I've changed this to solve `inepsc * c - s`, which is bounded; the solution also takes advantage of the periodic nature of s and c to bracket the solution (`s/c` is, obviously, also periodic).  I observed in testing the previous solution would sometimes be in the second period, though this may not matter.

The 1000dB stop-band ripple unit test is not supposed to be practical, but is an extreme example requiring ellipkm1; the previously failing 150dB test also requires this fix, so the 1000dB test could be removed.

#### Additional information
<!--Any additional information you think is important.-->
I'm not knowledgeable on elliptic filter design, and it seems to rely on relatively advanced mathematics; I hope there is someone with more expertise who can review what I've done. 

I also don't have access to Lutova, Tosic, and Evans, the reference mentioned in the code.  I have used [1] for guidance; other than Wikipedia, this seems to be the only source of information on elliptic filter design not behind a paywall.  This reference seems to use different conventions than the Scipy solution (I think it normalizes frequencies differently), and I found it generally difficult to follow.

The ellipap code seems sparsely commented to me, but perhaps it is just a faithful rendering of an algorithm from Lutova et al.

[1] https://www.matheonics.com/Tutorials/Elliptic.html