### PR TITLE
DOC: add API methods summary for NdPPoly

### DIFF
--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -1928,6 +1928,10 @@ class NdPPoly(object):
     Methods
     -------
     __call__
+    derivative
+    antiderivative
+    integrate
+    integrate_1d
     construct_fast
 
     See also


### PR DESCRIPTION
Added lost summary for the following API methods:

- derivative
- antiderivative
- integrate
- integrate_1d

The methods summary will be displayed in `NdPPoly` documentation [page](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.NdPPoly.html#scipy.interpolate.NdPPoly).