### PR TITLE
MAINT:linalg: Fix for input args of eigvalsh

### DIFF
--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -293,7 +293,7 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
         If omitted, identity matrix is assumed.
     lower : bool, optional
         Whether the pertinent array data is taken from the lower or upper
-        triangle of `a`. (Default: lower)
+        triangle of ``a`` and, if applicable, ``b``. (Default: lower)
     eigvals_only : bool, optional
         Whether to calculate only eigenvalues and no eigenvectors.
         (Default: both are calculated)
@@ -905,7 +905,7 @@ def eigvalsh(a, b=None, lower=True, overwrite_a=False,
         If omitted, identity matrix is assumed.
     lower : bool, optional
         Whether the pertinent array data is taken from the lower or upper
-        triangle of `a`. (Default: lower)
+        triangle of ``a`` and, if applicable, ``b``. (Default: lower)
     eigvals_only : bool, optional
         Whether to calculate only eigenvalues and no eigenvectors.
         (Default: both are calculated)

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -1006,8 +1006,8 @@ def eigvalsh(a, b=None, lower=True, overwrite_a=False,
     """
     return eigh(a, b=b, lower=lower, eigvals_only=True,
                 overwrite_a=overwrite_a, overwrite_b=overwrite_b,
-                turbo=turbo, type=type, check_finite=check_finite,
-                subset_by_index=eigvals or subset_by_index,
+                turbo=turbo, eigvals=eigvals, type=type,
+                check_finite=check_finite, subset_by_index=subset_by_index,
                 subset_by_value=subset_by_value, driver=driver)
 
 

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -1006,9 +1006,9 @@ def eigvalsh(a, b=None, lower=True, overwrite_a=False,
     """
     return eigh(a, b=b, lower=lower, eigvals_only=True,
                 overwrite_a=overwrite_a, overwrite_b=overwrite_b,
-                turbo=turbo, eigvals=None, type=type,
-                check_finite=check_finite, subset_by_index=eigvals,
-                subset_by_value=None, driver=None)
+                turbo=turbo, type=type, check_finite=check_finite,
+                subset_by_index=eigvals or subset_by_index,
+                subset_by_value=subset_by_value, driver=driver)
 
 
 def eigvals_banded(a_band, lower=False, overwrite_a_band=False,

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -881,6 +881,20 @@ class TestEigh:
         diag2_ = diag(z.T.conj() @ b @ z).real
         assert_allclose(diag2_, ones(diag2_.shape[0]), rtol=0., atol=atol)
 
+    def test_eigvalsh_new_args(self):
+        a = _random_hermitian_matrix(5)
+        w = eigvalsh(a, eigvals=[1, 2])
+        assert_equal(len(w), 2)
+
+        w2 = eigvalsh(a, subset_by_index=[1, 2])
+        assert_equal(len(w2), 2)
+        assert_allclose(w, w2)
+
+        b = np.diag([1, 1.2, 1.3, 1.5, 2])
+        w3 = eigvalsh(b, subset_by_value=[1, 1.4])
+        assert_equal(len(w3), 2)
+        assert_allclose(w3, np.array([1.2, 1.3]))
+
 
 class TestLU(object):
     def setup_method(self):


### PR DESCRIPTION
Fixes #12441
Fixes #12445 

Somehow, I completely forgot to modify the signature in `linalg.eigvalsh` during the revamp (possibly  after a copy/paste). This PR fixes it and adds more tests.