### PR TITLE
ENH: add `leaves_color_list` for cluster.dendrogram dictionary.

### DIFF
--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -3223,6 +3223,10 @@ def dendrogram(Z, p=30, truncate_mode=None, color_threshold=None,
           ``i``-th leaf node corresponds to an original observation.
           Otherwise, it corresponds to a non-singleton cluster.
 
+        ``'leaves_color_list'``
+          A list of color names. The k'th element represents the color of the
+          k'th leaf.
+
     See Also
     --------
     linkage, set_link_color_palette
@@ -3358,7 +3362,21 @@ def dendrogram(Z, p=30, truncate_mode=None, color_threshold=None,
                          ax=ax,
                          above_threshold_color=above_threshold_color)
 
+    R["leaves_color_list"] = _get_leaves_color_list(R)
+
     return R
+
+
+def _get_leaves_color_list(R):
+    leaves_color_list = [None] * len(R['leaves'])
+    for link_x, link_y, link_color in zip(R['icoord'],
+                                          R['dcoord'],
+                                          R['color_list']):
+        for (xi, yi) in zip(link_x, link_y):
+            if yi == 0.0:  # if yi is 0.0, the point is a leaf
+                # xi is 5, 15, 25, 35, ...
+                leaves_color_list[(int(xi) - 5) // 10] = link_color
+    return leaves_color_list
 
 
 def _append_singleton_leaf_node(Z, p, n, level, lvs, ivl, leaf_label_func,

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -3374,8 +3374,11 @@ def _get_leaves_color_list(R):
                                           R['color_list']):
         for (xi, yi) in zip(link_x, link_y):
             if yi == 0.0:  # if yi is 0.0, the point is a leaf
-                # xi is 5, 15, 25, 35, ...
-                leaves_color_list[(int(xi) - 5) // 10] = link_color
+                # xi of leaves are      5, 15, 25, 35, ... (see `iv_ticks`)
+                # index of leaves are   0,  1,  2,  3, ... as below
+                leaf_index = (int(xi) - 5) // 10
+                # each leaf has a same color of its link.
+                leaves_color_list[leaf_index] = link_color
     return leaves_color_list
 
 

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -860,7 +860,9 @@ class TestDendrogram(object):
                                [25.0, 25.0, 42.5, 42.5],
                                [10.0, 10.0, 33.75, 33.75]],
                     'ivl': ['2', '5', '1', '0', '3', '4'],
-                    'leaves': [2, 5, 1, 0, 3, 4]}
+                    'leaves': [2, 5, 1, 0, 3, 4],
+                    'leaves_color_list': ['C1', 'C1', 'C0', 'C0', 'C0', 'C0'],
+                    }
 
         fig = plt.figure()
         ax = fig.add_subplot(221)
@@ -913,7 +915,9 @@ class TestDendrogram(object):
                          'dcoord': [[0.0, 295.0, 295.0, 0.0]],
                          'icoord': [[5.0, 5.0, 15.0, 15.0]],
                          'ivl': ['(2)', '(4)'],
-                         'leaves': [6, 9]})
+                         'leaves': [6, 9],
+                         'leaves_color_list': ['C0', 'C0'],
+                         })
 
         R = dendrogram(Z, 2, 'mtica', show_contracted=True)
         plt.close()
@@ -927,7 +931,9 @@ class TestDendrogram(object):
                                     [25.0, 25.0, 40.0, 40.0],
                                     [10.0, 10.0, 32.5, 32.5]],
                          'ivl': ['2', '5', '1', '0', '(2)'],
-                         'leaves': [2, 5, 1, 0, 7]})
+                         'leaves': [2, 5, 1, 0, 7],
+                         'leaves_color_list': ['C1', 'C1', 'C0', 'C0', 'C0'],
+                         })
 
     def test_dendrogram_colors(self):
         # Tests dendrogram plots with alternate colors


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
fix #12190 

#### What does this implement/fix?
I added a new key `leaves_color_list` in the dendrogram dictionary informing about color leaves.
This PR enables for users to retrieve leaves colors from it.


#### Additional information
This is a sample usage:
```
import matplotlib.pyplot as plt
import numpy as np

from scipy.cluster.hierarchy import linkage, dendrogram

x = np.array([[5, 3],
              [10, 15],
              [15, 12],
              [24, 10],
              [30, 30],
              [85, 70],
              [71, 80]])
z = linkage(x, 'single')
d = dendrogram(z)
points = d['leaves']
colors = d['leaves_color_list']
for point, color in zip(points, colors):
    plt.plot(x[point, 0], x[point, 1], 'o', color=color)
plt.show()
```
<img width="595" alt="SS 2020-06-30 at 22 18 33" src="https://user-images.githubusercontent.com/3813847/86130830-bb5c7380-bb1f-11ea-9dfd-9eecd3f78b65.png">
