### PR TITLE
MAINT: remove "blacklist" terminology from code base

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -183,9 +183,9 @@ def _convert_to_type(X, out_type):
     return np.ascontiguousarray(X, dtype=out_type)
 
 
-def _filter_deprecated_kwargs(kwargs, args_blacklist):
+def _filter_deprecated_kwargs(kwargs, args_blocklist):
     # Filtering out old default keywords
-    for k in args_blacklist:
+    for k in args_blocklist:
         if k in kwargs:
             del kwargs[k]
             warnings.warn('Got unexpected kwarg %s. This will raise an error'
@@ -2001,29 +2001,29 @@ def pdist(X, metric='euclidean', *args, **kwargs):
             raise ValueError("Output array must be double type.")
         dm = out
 
-    # compute blacklist for deprecated kwargs
+    # compute blocklist for deprecated kwargs
     if(metric in _METRICS['jensenshannon'].aka
        or metric == 'test_jensenshannon' or metric == jensenshannon):
-        kwargs_blacklist = ["p", "w", "V", "VI"]
+        kwargs_blocklist = ["p", "w", "V", "VI"]
 
     elif(metric in _METRICS['minkowski'].aka
          or metric in _METRICS['wminkowski'].aka
          or metric in ['test_minkowski', 'test_wminkowski']
          or metric in [minkowski, wminkowski]):
-        kwargs_blacklist = ["V", "VI"]
+        kwargs_blocklist = ["V", "VI"]
 
     elif(metric in _METRICS['seuclidean'].aka or
          metric == 'test_seuclidean' or metric == seuclidean):
-        kwargs_blacklist = ["p", "w", "VI"]
+        kwargs_blocklist = ["p", "w", "VI"]
 
     elif(metric in _METRICS['mahalanobis'].aka
          or metric == 'test_mahalanobis' or metric == mahalanobis):
-        kwargs_blacklist = ["p", "w", "V"]
+        kwargs_blocklist = ["p", "w", "V"]
 
     else:
-        kwargs_blacklist = ["p", "V", "VI"]
+        kwargs_blocklist = ["p", "V", "VI"]
 
-    _filter_deprecated_kwargs(kwargs, kwargs_blacklist)
+    _filter_deprecated_kwargs(kwargs, kwargs_blocklist)
 
     if callable(metric):
         mstr = getattr(metric, '__name__', 'UnknownCustomMetric')
@@ -2726,22 +2726,22 @@ def cdist(XA, XB, metric='euclidean', *args, **kwargs):
             raise ValueError("Output array must be double type.")
         dm = out
 
-    # compute blacklist for deprecated kwargs
+    # compute blocklist for deprecated kwargs
     if(metric in _METRICS['minkowski'].aka or
        metric in _METRICS['wminkowski'].aka or
        metric in ['test_minkowski', 'test_wminkowski'] or
        metric in [minkowski, wminkowski]):
-        kwargs_blacklist = ["V", "VI"]
+        kwargs_blocklist = ["V", "VI"]
     elif(metric in _METRICS['seuclidean'].aka or
          metric == 'test_seuclidean' or metric == seuclidean):
-        kwargs_blacklist = ["p", "w", "VI"]
+        kwargs_blocklist = ["p", "w", "VI"]
     elif(metric in _METRICS['mahalanobis'].aka or
          metric == 'test_mahalanobis' or metric == mahalanobis):
-        kwargs_blacklist = ["p", "w", "V"]
+        kwargs_blocklist = ["p", "w", "V"]
     else:
-        kwargs_blacklist = ["p", "V", "VI"]
+        kwargs_blocklist = ["p", "V", "VI"]
 
-    _filter_deprecated_kwargs(kwargs, kwargs_blacklist)
+    _filter_deprecated_kwargs(kwargs, kwargs_blocklist)
 
     if callable(metric):
 


### PR DESCRIPTION
Related to discussion in gh-12446, and the broader discussion around terminology
that implies white is good/allowed and black is bad/disallowed.