### PR TITLE
check if column in spearman rho is entirely NaN or Inf

### DIFF
--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -503,6 +503,10 @@ def spearmanr(x, y=None, use_ties=True, axis=None, nan_policy='propagate'):
         x = ma.mask_rowcols(x, axis=0)
         x = x[~x.mask.any(axis=1), :]
 
+        # If either column is entirely NaN or Inf
+        if not np.any(x.data):
+            return SpearmanrResult(np.nan, np.nan)
+
         m = ma.getmask(x)
         n_obs = x.shape[0]
         dof = n_obs - 2 - int(m.sum(axis=0)[0])

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -582,7 +582,8 @@ class TestCorrSpearmanr(object):
         assert_raises(ValueError, stats.spearmanr, x, x, nan_policy='foobar')
 
     def test_nan_policy_bug_12458(self):
-        x = np.random.default_rng(5).uniform(0, 1, 50).reshape(5,10)
+        np.random.seed(5)
+        x = np.random.rand(5, 10)
         k = 6
         x[:, k] = np.nan
         y = np.delete(x, k, axis=1)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -582,8 +582,7 @@ class TestCorrSpearmanr(object):
         assert_raises(ValueError, stats.spearmanr, x, x, nan_policy='foobar')
 
     def test_nan_policy_bug_12458(self):
-        np.random.seed(5)
-        x = np.random.rand(5, 10)
+        x = np.random.default_rng(5).uniform(0, 1, 50).reshape(5,10)
         k = 6
         x[:, k] = np.nan
         y = np.delete(x, k, axis=1)
@@ -591,7 +590,7 @@ class TestCorrSpearmanr(object):
         cory, py = stats.spearmanr(y)
         corx = np.delete(np.delete(corx, k, axis=1), k, axis=0)
         px = np.delete(np.delete(px, k, axis=1), k, axis=0)
-        assert_allclose(corx, cory)
+        assert_allclose(corx, cory, atol=1e-14)
         assert_allclose(px, py, atol=1e-14)
 
     def test_sXX(self):

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -581,6 +581,19 @@ class TestCorrSpearmanr(object):
         assert_raises(ValueError, stats.spearmanr, x, x, nan_policy='raise')
         assert_raises(ValueError, stats.spearmanr, x, x, nan_policy='foobar')
 
+    def test_nan_policy_bug_12458(self):
+        np.random.seed(5)
+        x = np.random.rand(5, 10)
+        k = 6
+        x[:, k] = np.nan
+        y = np.delete(x, k, axis=1)
+        corx, px = stats.spearmanr(x, nan_policy='omit')
+        cory, py = stats.spearmanr(y)
+        corx = np.delete(np.delete(corx, k, axis=1), k, axis=0)
+        px = np.delete(np.delete(px, k, axis=1), k, axis=0)
+        assert_allclose(corx, cory)
+        assert_allclose(px, py, atol=1e-14)
+
     def test_sXX(self):
         y = stats.spearmanr(X,X)
         r = y[0]


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes Issue [12458](https://github.com/scipy/scipy/issues/12458)

#### What does this implement/fix?
<!--Please explain your changes.-->

Running current version of ```spearmanr``` with an entire column of NaN or Inf, using nan_policy='omit', results in a raised ```ValueError```.  This error is produced by ```mstats_basic.spearmanr._spearmanr_2cols```, after masking the numpy array.  The masked array (with a constant NaN or Inf column) is empty with shape=(0,2), and raises a ```ValueError``` in the next few lines.

The code now checks for the empty masked array and returns ```SpearmanResult(np.nan, np.nan)```, as would be expected when using nan_policy='omit'.

#### Additional information
<!--Any additional information you think is important.-->