### PR TITLE
 MAINT: sparse: write matrix/asmatrix wrappers without warning manipulations

### DIFF
--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -39,7 +39,7 @@ from numpy import (array, diag, ones, full, linalg, argsort, zeros, arange,
 from numpy.random import seed, random
 
 from scipy.linalg._testutils import assert_no_overwrite
-from scipy.sparse.sputils import bmat, matrix
+from scipy.sparse.sputils import matrix
 
 from scipy._lib._testutils import check_free_memory
 from scipy.linalg.blas import HAS_ILP64
@@ -307,8 +307,8 @@ class TestEig(object):
         D = array(([1, -1, 0], [-1, 1, 0], [0, 0, 0]))
         Z = zeros((3, 3))
         I3 = eye(3)
-        A = bmat([[I3, Z], [Z, -K]])
-        B = bmat([[Z, I3], [M, D]])
+        A = np.block([[I3, Z], [Z, -K]])
+        B = np.block([[Z, I3], [M, D]])
 
         with np.errstate(all='ignore'):
             self._check_gen_eig(A, B)

--- a/scipy/linalg/tests/test_solvers.py
+++ b/scipy/linalg/tests/test_solvers.py
@@ -79,10 +79,10 @@ class TestSolveLyapunov(object):
          np.eye(11)),
         # https://github.com/scipy/scipy/issues/4176
         (matrix([[0, 1], [-1/2, -1]]),
-         (matrix([0, 3]).T * matrix([0, 3]).T.T)),
+         (matrix([0, 3]).T @ matrix([0, 3]).T.T)),
         # https://github.com/scipy/scipy/issues/4176
         (matrix([[0, 1], [-1/2, -1]]),
-         (np.array(matrix([0, 3]).T * matrix([0, 3]).T.T))),
+         (np.array(matrix([0, 3]).T @ matrix([0, 3]).T.T))),
         ]
 
     def test_continuous_squareness_and_shape(self):

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -418,9 +418,9 @@ class TestLsim(object):
 
     def test_double_integrator(self):
         # double integrator: y'' = 2u
-        A = matrix("0. 1.; 0. 0.")
-        B = matrix("0.; 1.")
-        C = matrix("2. 0.")
+        A = matrix([[0., 1.], [0., 0.]])
+        B = matrix([[0.], [1.]])
+        C = matrix([[2., 0.]])
         system = self.lti_nowarn(A, B, C, 0.)
         t = np.linspace(0,5)
         u = np.ones_like(t)
@@ -436,9 +436,9 @@ class TestLsim(object):
         #   x2' + x2 = u
         #   y = x1
         # Exact solution with u = 0 is y(t) = t exp(-t)
-        A = matrix("-1. 1.; 0. -1.")
-        B = matrix("0.; 1.")
-        C = matrix("1. 0.")
+        A = matrix([[-1., 1.], [0., -1.]])
+        B = matrix([[0.], [1.]])
+        C = matrix([[1., 0.]])
         system = self.lti_nowarn(A, B, C, 0.)
         t = np.linspace(0,5)
         u = np.zeros_like(t)

--- a/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
@@ -21,7 +21,7 @@ import numpy as np
 from scipy.linalg import (inv, eigh, cho_factor, cho_solve, cholesky,
                           LinAlgError)
 from scipy.sparse.linalg import aslinearoperator
-from scipy.sparse.sputils import bmat
+from numpy import block as bmat
 
 __all__ = ['lobpcg']
 

--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -340,22 +340,15 @@ def is_pydata_spmatrix(m):
 ###############################################################################
 # Wrappers for NumPy types that are deprecated
 
+# Numpy versions of these functions raise deprecation warnings, the
+# ones below do not.
+
+
 def matrix(*args, **kwargs):
-    with warnings.catch_warnings(record=True):
-        warnings.filterwarnings(
-            'ignore', '.*the matrix subclass is not the recommended way.*')
-        return np.matrix(*args, **kwargs)
+    return np.array(*args, **kwargs).view(np.matrix)
 
 
-def asmatrix(*args, **kwargs):
-    with warnings.catch_warnings(record=True):
-        warnings.filterwarnings(
-            'ignore', '.*the matrix subclass is not the recommended way.*')
-        return np.asmatrix(*args, **kwargs)
-
-
-def bmat(*args, **kwargs):
-    with warnings.catch_warnings(record=True):
-        warnings.filterwarnings(
-            'ignore', '.*the matrix subclass is not the recommended way.*')
-        return np.bmat(*args, **kwargs)
+def asmatrix(data, dtype=None):
+    if isinstance(data, np.matrix) and (dtype is None or data.dtype == dtype):
+        return data
+    return np.asarray(data, dtype=dtype).view(np.matrix)

--- a/scipy/sparse/tests/test_sputils.py
+++ b/scipy/sparse/tests/test_sputils.py
@@ -153,3 +153,29 @@ class TestSparseUtils(object):
     def test_check_shape_overflow(self):
         new_shape = sputils.check_shape([(10, -1)], (65535, 131070))
         assert_equal(new_shape, (10, 858967245))
+
+    def test_matrix(self):
+        a = [[1, 2, 3]]
+        b = np.array(a)
+
+        assert isinstance(sputils.matrix(a), np.matrix)
+        assert isinstance(sputils.matrix(b), np.matrix)
+
+        c = sputils.matrix(b)
+        c[:, :] = 123
+        assert_equal(b, a)
+
+        c = sputils.matrix(b, copy=False)
+        c[:, :] = 123
+        assert_equal(b, [[123, 123, 123]])
+
+    def test_asmatrix(self):
+        a = [[1, 2, 3]]
+        b = np.array(a)
+
+        assert isinstance(sputils.asmatrix(a), np.matrix)
+        assert isinstance(sputils.asmatrix(b), np.matrix)
+
+        c = sputils.asmatrix(b)
+        c[:, :] = 123
+        assert_equal(b, [[123, 123, 123]])


### PR DESCRIPTION
#### Reference issue
Closes: gh-12449

#### What does this implement/fix?
`warnings.catch_warnings` is not threadsafe and has some other bugs (see gh-12449).
Replace using it by constructs that avoid the Numpy matrix warnings.

#### Additional information
The scipy.sparse `__init__.py` currently silences matrix warnings at import time. This could in principle now be removed, but it may be better for downstream to keep it, since e.g. multiplying dense matrices extracted from sparse would still raise warnings.

There are a few other places still in scipy that use catch_warnings, that could be cleaned up (however, less straightforward so should go to separate PR).