### PR TITLE
MAINT: move distributor_init import after __config__ import

### DIFF
--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -100,9 +100,6 @@ for _key in _sci.__all__:
         _fun = _deprecated(_msg.format(_key))(_fun)
     globals()[_key] = _fun
 
-# Allow distributors to run custom init code
-from . import _distributor_init
-
 __all__ += _num.__all__
 __all__ += ['randn', 'rand', 'fft', 'ifft']
 
@@ -134,6 +131,10 @@ else:
         raise ImportError(msg)
 
     from scipy.version import version as __version__
+
+    # Allow distributors to run custom init code
+    from . import _distributor_init
+
     from scipy._lib import _pep440
     if _pep440.parse(__numpy_version__) < _pep440.Version('1.14.5'):
         import warnings


### PR DESCRIPTION
#### Reference issue
See https://github.com/MacPython/scipy-wheels/pull/88
See https://github.com/scipy/scipy/issues/12400

#### What does this implement/fix?
Move _distributor_init import after `__config__` (and .version) imports,
as `__config__` can set up DLL search paths.  The import is now in a
similar place as what Numpy does currently.