### PR TITLE
DOC: improve and clean up *Spline docstrings in fitpack2.py

### DIFF
--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -121,7 +121,7 @@ class UnivariateSpline(object):
     See Also
     --------
     BivariateSpline :
-        base class for bivariate splines.
+        a base class for bivariate splines.
     SmoothBivariateSpline :
         a smooth bivariate spline through the given points
     LSQBivariateSpline :
@@ -131,15 +131,27 @@ class UnivariateSpline(object):
     SmoothSphereBivariateSpline :
         a smooth bivariate spline in spherical coordinates
     LSQSphereBivariateSpline :
-        a bivariate spline in spherical coordinates using
-        weighted least-squares fitting
+        a bivariate spline in spherical coordinates using weighted
+        least-squares fitting
     RectBivariateSpline :
-        a bivariate spline over a rectangular mesh.
-    bisplrep : older wrapping of FITPACK
-    bisplev : older wrapping of FITPACK
-    InterpolatedUnivariateSpline : Subclass with smoothing forced to 0
-    splrep : An older, non object-oriented wrapping of FITPACK
-    splev, sproot, splint, spalde
+        a bivariate spline over a rectangular mesh
+    InterpolatedUnivariateSpline :
+        a interpolating unicariate spline for a given set of data points.
+    bisplrep :
+        a function to find a bivariate B-spline representation of a surface
+    bisplev :
+        a function to evaluate a bivariate B-spline and its derivatives
+    splrep :
+        a function to find the B-spline representation of a 1-D curve
+    splev :
+        a function to evaluate a B-spline or its derivatives
+    sproot :
+        a function to find the roots of a cubic B-spline
+    splint :
+        a function to evaluate the definite integral of a B-spline between two
+        given points
+    spalde :
+        a function to evaluate all derivatives of a B-spline
 
     Notes
     -----
@@ -599,13 +611,25 @@ class InterpolatedUnivariateSpline(UnivariateSpline):
 
     See Also
     --------
-    UnivariateSpline : Superclass -- allows knots to be selected by a
-        smoothing condition
-    LSQUnivariateSpline : spline for which knots are user-selected
-    BivariateSpline :
-        base class for bivariate splines.
-    splrep : An older, non object-oriented wrapping of FITPACK
-    splev, sproot, splint, spalde
+    UnivariateSpline :
+        a smooth univariate spline to fit a given set of data points.
+    LSQUnivariateSpline :
+        a spline for which knots are user-selected
+    SmoothBivariateSpline :
+        a smooth bivariate spline through the given points
+    LSQBivariateSpline :
+        a bivariate spline using weighted least-squares fitting
+    splrep :
+        a function to find the B-spline representation of a 1-D curve
+    splev :
+        a function to evaluate a B-spline or its derivatives
+    sproot :
+        a function to find the roots of a cubic B-spline
+    splint :
+        a function to evaluate the definite integral of a B-spline between two
+        given points
+    spalde :
+        a function to evaluate all derivatives of a B-spline
 
     Notes
     -----
@@ -710,13 +734,21 @@ class LSQUnivariateSpline(UnivariateSpline):
 
     See Also
     --------
-    UnivariateSpline : Superclass -- knots are specified by setting a
-        smoothing condition
-    InterpolatedUnivariateSpline : spline passing through all points
-    splrep : An older, non object-oriented wrapping of FITPACK
-    splev, sproot, splint, spalde
-    BivariateSpline :
-        base class for bivariate splines.
+    UnivariateSpline :
+        a smooth univariate spline to fit a given set of data points.
+    InterpolatedUnivariateSpline :
+        a interpolating unicariate spline for a given set of data points.
+    splrep :
+        a function to find the B-spline representation of a 1-D curve
+    splev :
+        a function to evaluate a B-spline or its derivatives
+    sproot :
+        a function to find the roots of a cubic B-spline
+    splint :
+        a function to evaluate the definite integral of a B-spline between two
+        given points
+    spalde :
+        a function to evaluate all derivatives of a B-spline
 
     Notes
     -----
@@ -797,11 +829,14 @@ class _BivariateSplineBase(object):
 
     See Also
     --------
-    bisplrep, bisplev : an older wrapping of FITPACK
+    bisplrep :
+        a function to find a bivariate B-spline representation of a surface
+    bisplev :
+        a function to evaluate a bivariate B-spline and its derivatives
     BivariateSpline :
-        base class for bivariate splines.
+        a base class for bivariate splines.
     SphereBivariateSpline :
-        implementation of bivariate spline interpolation on a spherical grid
+        a bivariate spline on a spherical grid
     """
 
     def get_residual(self):
@@ -955,7 +990,7 @@ class BivariateSpline(_BivariateSplineBase):
     See Also
     --------
     UnivariateSpline :
-        a similar class for univariate spline interpolation
+        a smooth univariate spline to fit a given set of data points.
     SmoothBivariateSpline :
         a smooth bivariate spline through the given points
     LSQBivariateSpline :
@@ -969,8 +1004,10 @@ class BivariateSpline(_BivariateSplineBase):
         least-squares fitting
     RectBivariateSpline :
         a bivariate spline over a rectangular mesh.
-    bisplrep : older wrapping of FITPACK
-    bisplev : older wrapping of FITPACK
+    bisplrep :
+        a function to find a bivariate B-spline representation of a surface
+    bisplev :
+        a function to evaluate a bivariate B-spline and its derivatives
     """
 
     @classmethod
@@ -1076,9 +1113,9 @@ class SmoothBivariateSpline(BivariateSpline):
     See Also
     --------
     BivariateSpline :
-        base class for bivariate splines.
+        a base class for bivariate splines.
     UnivariateSpline :
-        a similar class for univariate spline interpolation
+        a smooth univariate spline to fit a given set of data points.
     LSQBivariateSpline :
         a bivariate spline using weighted least-squares fitting
     RectSphereBivariateSpline :
@@ -1089,9 +1126,11 @@ class SmoothBivariateSpline(BivariateSpline):
         a bivariate spline in spherical coordinates using weighted
         least-squares fitting
     RectBivariateSpline :
-        a bivariate spline over a rectangular mesh.
-    bisplrep : older wrapping of FITPACK
-    bisplev : older wrapping of FITPACK
+        a bivariate spline over a rectangular mesh
+    bisplrep :
+        a function to find a bivariate B-spline representation of a surface
+    bisplev :
+        a function to evaluate a bivariate B-spline and its derivatives
 
     Notes
     -----
@@ -1159,9 +1198,9 @@ class LSQBivariateSpline(BivariateSpline):
     See Also
     --------
     BivariateSpline :
-        base class for bivariate splines.
+        a base class for bivariate splines.
     UnivariateSpline :
-        a similar class for univariate spline interpolation
+        a smooth univariate spline to fit a given set of data points.
     SmoothBivariateSpline :
         a smooth bivariate spline through the given points
     RectSphereBivariateSpline :
@@ -1173,8 +1212,10 @@ class LSQBivariateSpline(BivariateSpline):
         least-squares fitting
     RectBivariateSpline :
         a bivariate spline over a rectangular mesh.
-    bisplrep : older wrapping of FITPACK
-    bisplev : older wrapping of FITPACK
+    bisplrep :
+        a function to find a bivariate B-spline representation of a surface
+    bisplev :
+        a function to evaluate a bivariate B-spline and its derivatives
 
     Notes
     -----
@@ -1245,9 +1286,9 @@ class RectBivariateSpline(BivariateSpline):
     See Also
     --------
     BivariateSpline :
-        base class for bivariate splines.
+        a base class for bivariate splines.
     UnivariateSpline :
-        a similar class for univariate spline interpolation
+        a smooth univariate spline to fit a given set of data points.
     SmoothBivariateSpline :
         a smooth bivariate spline through the given points
     LSQBivariateSpline :
@@ -1259,8 +1300,10 @@ class RectBivariateSpline(BivariateSpline):
     LSQSphereBivariateSpline :
         a bivariate spline in spherical coordinates using weighted
         least-squares fitting
-    bisplrep : older wrapping of FITPACK
-    bisplev : older wrapping of FITPACK
+    bisplrep :
+        a function to find a bivariate B-spline representation of a surface
+    bisplev :
+        a function to evaluate a bivariate B-spline and its derivatives
 
     """
 
@@ -1329,12 +1372,16 @@ class SphereBivariateSpline(_BivariateSplineBase):
 
     See Also
     --------
-    bisplrep, bisplev : an older wrapping of FITPACK
-    UnivariateSpline : a similar class for univariate spline interpolation
+    bisplrep :
+        a function to find a bivariate B-spline representation of a surface
+    bisplev :
+        a function to evaluate a bivariate B-spline and its derivatives
+    UnivariateSpline :
+        a smooth univariate spline to fit a given set of data points.
     SmoothUnivariateSpline :
-        a smooth bivariate spline through the given points
+        a smooth univariate spline through the given points
     LSQUnivariateSpline :
-        a bivariate spline using weighted least-squares fitting
+        a univariate spline using weighted least-squares fitting
     """
 
     def __call__(self, theta, phi, dtheta=0, dphi=0, grid=True):
@@ -1429,9 +1476,9 @@ class SmoothSphereBivariateSpline(SphereBivariateSpline):
     See Also
     --------
     BivariateSpline :
-        base class for bivariate splines.
+        a base class for bivariate splines.
     UnivariateSpline :
-        a similar class for univariate spline interpolation
+        a smooth univariate spline to fit a given set of data points.
     SmoothBivariateSpline :
         a smooth bivariate spline through the given points
     LSQBivariateSpline :
@@ -1443,8 +1490,10 @@ class SmoothSphereBivariateSpline(SphereBivariateSpline):
         least-squares fitting
     RectBivariateSpline :
         a bivariate spline over a rectangular mesh.
-    bisplrep : older wrapping of FITPACK
-    bisplev : older wrapping of FITPACK
+    bisplrep :
+        a function to find a bivariate B-spline representation of a surface
+    bisplev :
+        a function to evaluate a bivariate B-spline and its derivatives
 
     Notes
     -----
@@ -1561,9 +1610,9 @@ class LSQSphereBivariateSpline(SphereBivariateSpline):
     See Also
     --------
     BivariateSpline :
-        base class for bivariate splines.
+        a base class for bivariate splines.
     UnivariateSpline :
-        a similar class for univariate spline interpolation
+        a smooth univariate spline to fit a given set of data points.
     SmoothBivariateSpline :
         a smooth bivariate spline through the given points
     LSQBivariateSpline :
@@ -1574,8 +1623,10 @@ class LSQSphereBivariateSpline(SphereBivariateSpline):
         a smooth bivariate spline in spherical coordinates
     RectBivariateSpline :
         a bivariate spline over a rectangular mesh.
-    bisplrep : older wrapping of FITPACK
-    bisplev : older wrapping of FITPACK
+    bisplrep :
+        a function to find a bivariate B-spline representation of a surface
+    bisplev :
+        a function to evaluate a bivariate B-spline and its derivatives
 
     Notes
     -----
@@ -1750,9 +1801,9 @@ class RectSphereBivariateSpline(SphereBivariateSpline):
     See Also
     --------
     BivariateSpline :
-        base class for bivariate splines.
+        a base class for bivariate splines.
     UnivariateSpline :
-        a similar class for univariate spline interpolation
+        a smooth univariate spline to fit a given set of data points.
     SmoothBivariateSpline :
         a smooth bivariate spline through the given points
     LSQBivariateSpline :
@@ -1764,8 +1815,10 @@ class RectSphereBivariateSpline(SphereBivariateSpline):
         least-squares fitting
     RectBivariateSpline :
         a bivariate spline over a rectangular mesh.
-    bisplrep : older wrapping of FITPACK
-    bisplev : older wrapping of FITPACK
+    bisplrep :
+        a function to find a bivariate B-spline representation of a surface
+    bisplev :
+        a function to evaluate a bivariate B-spline and its derivatives
 
     Notes
     -----

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -1237,8 +1237,8 @@ class RectBivariateSpline(BivariateSpline):
         Degrees of the bivariate spline. Default is 3.
     s : float, optional
         Positive smoothing factor defined for estimation condition:
-        ``sum((z[i]-s(x[i], y[i]))**2, axis=0) <= s``
-        Default is ``s=0``, which is for interpolation.
+        ``sum((z[i]-f(x[i], y[i]))**2, axis=0) <= s`` where f is a spline
+        function. Default is ``s=0``, which is for interpolation.
 
     See Also
     --------

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -123,20 +123,20 @@ class UnivariateSpline(object):
     BivariateSpline :
         a base class for bivariate splines.
     SmoothBivariateSpline :
-        a smooth bivariate spline through the given points
+        a smoothing bivariate spline through the given points
     LSQBivariateSpline :
         a bivariate spline using weighted least-squares fitting
     RectSphereBivariateSpline :
         a bivariate spline over a rectangular mesh on a sphere
     SmoothSphereBivariateSpline :
-        a smooth bivariate spline in spherical coordinates
+        a smoothing bivariate spline in spherical coordinates
     LSQSphereBivariateSpline :
         a bivariate spline in spherical coordinates using weighted
         least-squares fitting
     RectBivariateSpline :
         a bivariate spline over a rectangular mesh
     InterpolatedUnivariateSpline :
-        a interpolating unicariate spline for a given set of data points.
+        a interpolating univariate spline for a given set of data points.
     bisplrep :
         a function to find a bivariate B-spline representation of a surface
     bisplev :
@@ -616,7 +616,7 @@ class InterpolatedUnivariateSpline(UnivariateSpline):
     LSQUnivariateSpline :
         a spline for which knots are user-selected
     SmoothBivariateSpline :
-        a smooth bivariate spline through the given points
+        a smoothing bivariate spline through the given points
     LSQBivariateSpline :
         a bivariate spline using weighted least-squares fitting
     splrep :
@@ -737,7 +737,7 @@ class LSQUnivariateSpline(UnivariateSpline):
     UnivariateSpline :
         a smooth univariate spline to fit a given set of data points.
     InterpolatedUnivariateSpline :
-        a interpolating unicariate spline for a given set of data points.
+        a interpolating univariate spline for a given set of data points.
     splrep :
         a function to find the B-spline representation of a 1-D curve
     splev :
@@ -992,13 +992,13 @@ class BivariateSpline(_BivariateSplineBase):
     UnivariateSpline :
         a smooth univariate spline to fit a given set of data points.
     SmoothBivariateSpline :
-        a smooth bivariate spline through the given points
+        a smoothing bivariate spline through the given points
     LSQBivariateSpline :
         a bivariate spline using weighted least-squares fitting
     RectSphereBivariateSpline :
         a bivariate spline over a rectangular mesh on a sphere
     SmoothSphereBivariateSpline :
-        a smooth bivariate spline in spherical coordinates
+        a smoothing bivariate spline in spherical coordinates
     LSQSphereBivariateSpline :
         a bivariate spline in spherical coordinates using weighted
         least-squares fitting
@@ -1121,7 +1121,7 @@ class SmoothBivariateSpline(BivariateSpline):
     RectSphereBivariateSpline :
         a bivariate spline over a rectangular mesh on a sphere
     SmoothSphereBivariateSpline :
-        a smooth bivariate spline in spherical coordinates
+        a smoothing bivariate spline in spherical coordinates
     LSQSphereBivariateSpline :
         a bivariate spline in spherical coordinates using weighted
         least-squares fitting
@@ -1202,11 +1202,11 @@ class LSQBivariateSpline(BivariateSpline):
     UnivariateSpline :
         a smooth univariate spline to fit a given set of data points.
     SmoothBivariateSpline :
-        a smooth bivariate spline through the given points
+        a smoothing bivariate spline through the given points
     RectSphereBivariateSpline :
         a bivariate spline over a rectangular mesh on a sphere
     SmoothSphereBivariateSpline :
-        a smooth bivariate spline in spherical coordinates
+        a smoothing bivariate spline in spherical coordinates
     LSQSphereBivariateSpline :
         a bivariate spline in spherical coordinates using weighted
         least-squares fitting
@@ -1290,13 +1290,13 @@ class RectBivariateSpline(BivariateSpline):
     UnivariateSpline :
         a smooth univariate spline to fit a given set of data points.
     SmoothBivariateSpline :
-        a smooth bivariate spline through the given points
+        a smoothing bivariate spline through the given points
     LSQBivariateSpline :
         a bivariate spline using weighted least-squares fitting
     RectSphereBivariateSpline :
         a bivariate spline over a rectangular mesh on a sphere
     SmoothSphereBivariateSpline :
-        a smooth bivariate spline in spherical coordinates
+        a smoothing bivariate spline in spherical coordinates
     LSQSphereBivariateSpline :
         a bivariate spline in spherical coordinates using weighted
         least-squares fitting
@@ -1480,7 +1480,7 @@ class SmoothSphereBivariateSpline(SphereBivariateSpline):
     UnivariateSpline :
         a smooth univariate spline to fit a given set of data points.
     SmoothBivariateSpline :
-        a smooth bivariate spline through the given points
+        a smoothing bivariate spline through the given points
     LSQBivariateSpline :
         a bivariate spline using weighted least-squares fitting
     RectSphereBivariateSpline :
@@ -1585,7 +1585,7 @@ class LSQSphereBivariateSpline(SphereBivariateSpline):
     Weighted least-squares bivariate spline approximation in spherical
     coordinates.
 
-    Determines a smooth bicubic spline according to a given
+    Determines a smoothing bicubic spline according to a given
     set of knots in the `theta` and `phi` directions.
 
     .. versionadded:: 0.11.0
@@ -1614,13 +1614,13 @@ class LSQSphereBivariateSpline(SphereBivariateSpline):
     UnivariateSpline :
         a smooth univariate spline to fit a given set of data points.
     SmoothBivariateSpline :
-        a smooth bivariate spline through the given points
+        a smoothing bivariate spline through the given points
     LSQBivariateSpline :
         a bivariate spline using weighted least-squares fitting
     RectSphereBivariateSpline :
         a bivariate spline over a rectangular mesh on a sphere
     SmoothSphereBivariateSpline :
-        a smooth bivariate spline in spherical coordinates
+        a smoothing bivariate spline in spherical coordinates
     RectBivariateSpline :
         a bivariate spline over a rectangular mesh.
     bisplrep :
@@ -1805,11 +1805,11 @@ class RectSphereBivariateSpline(SphereBivariateSpline):
     UnivariateSpline :
         a smooth univariate spline to fit a given set of data points.
     SmoothBivariateSpline :
-        a smooth bivariate spline through the given points
+        a smoothing bivariate spline through the given points
     LSQBivariateSpline :
         a bivariate spline using weighted least-squares fitting
     SmoothSphereBivariateSpline :
-        a smooth bivariate spline in spherical coordinates
+        a smoothing bivariate spline in spherical coordinates
     LSQSphereBivariateSpline :
         a bivariate spline in spherical coordinates using weighted
         least-squares fitting

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -121,20 +121,20 @@ class UnivariateSpline(object):
     See Also
     --------
     BivariateSpline :
-        to create a bivariate spline on a plane grid
+        base class for bivariate splines.
     SmoothBivariateSpline :
-        to create a bivariate spline through the given points
+        a smooth bivariate spline through the given points
     LSQBivariateSpline :
-        to create a bivariate spline using weighted least-squares fitting
+        a bivariate spline using weighted least-squares fitting
     RectSphereBivariateSpline :
-        to create a bivariate spline over a rectangular mesh on a sphere
+        a bivariate spline over a rectangular mesh on a sphere
     SmoothSphereBivariateSpline :
-        to create a smooth bivariate spline in spherical coordinates
+        a smooth bivariate spline in spherical coordinates
     LSQSphereBivariateSpline :
-        to create a bivariate spline in spherical coordinates using
+        a bivariate spline in spherical coordinates using
         weighted least-squares fitting
     RectBivariateSpline :
-        to create a bivariate spline over a rectangular mesh.
+        a bivariate spline over a rectangular mesh.
     bisplrep : older wrapping of FITPACK
     bisplev : older wrapping of FITPACK
     InterpolatedUnivariateSpline : Subclass with smoothing forced to 0
@@ -602,7 +602,8 @@ class InterpolatedUnivariateSpline(UnivariateSpline):
     UnivariateSpline : Superclass -- allows knots to be selected by a
         smoothing condition
     LSQUnivariateSpline : spline for which knots are user-selected
-    BivariateSpline : A similar class for two-dimensional spline interpolation
+    BivariateSpline :
+        base class for bivariate splines.
     splrep : An older, non object-oriented wrapping of FITPACK
     splev, sproot, splint, spalde
 
@@ -714,7 +715,8 @@ class LSQUnivariateSpline(UnivariateSpline):
     InterpolatedUnivariateSpline : spline passing through all points
     splrep : An older, non object-oriented wrapping of FITPACK
     splev, sproot, splint, spalde
-    BivariateSpline : A similar class for two-dimensional spline interpolation
+    BivariateSpline :
+        base class for bivariate splines.
 
     Notes
     -----
@@ -797,7 +799,7 @@ class _BivariateSplineBase(object):
     --------
     bisplrep, bisplev : an older wrapping of FITPACK
     BivariateSpline :
-        implementation of bivariate spline interpolation on a plane grid
+        base class for bivariate splines.
     SphereBivariateSpline :
         implementation of bivariate spline interpolation on a spherical grid
     """
@@ -955,18 +957,18 @@ class BivariateSpline(_BivariateSplineBase):
     UnivariateSpline :
         a similar class for univariate spline interpolation
     SmoothBivariateSpline :
-        to create a bivariate spline through the given points
+        a smooth bivariate spline through the given points
     LSQBivariateSpline :
-        to create a bivariate spline using weighted least-squares fitting
+        a bivariate spline using weighted least-squares fitting
     RectSphereBivariateSpline :
-        to create a bivariate spline over a rectangular mesh on a sphere
+        a bivariate spline over a rectangular mesh on a sphere
     SmoothSphereBivariateSpline :
-        to create a smooth bivariate spline in spherical coordinates
+        a smooth bivariate spline in spherical coordinates
     LSQSphereBivariateSpline :
-        to create a bivariate spline in spherical coordinates using
-        weighted least-squares fitting
+        a bivariate spline in spherical coordinates using weighted
+        least-squares fitting
     RectBivariateSpline :
-        to create a bivariate spline over a rectangular mesh.
+        a bivariate spline over a rectangular mesh.
     bisplrep : older wrapping of FITPACK
     bisplev : older wrapping of FITPACK
     """
@@ -1074,20 +1076,20 @@ class SmoothBivariateSpline(BivariateSpline):
     See Also
     --------
     BivariateSpline :
-        to create a bivariate spline on a plane grid
+        base class for bivariate splines.
     UnivariateSpline :
         a similar class for univariate spline interpolation
     LSQBivariateSpline :
-        to create a bivariate spline using weighted least-squares fitting
+        a bivariate spline using weighted least-squares fitting
     RectSphereBivariateSpline :
-        to create a bivariate spline over a rectangular mesh on a sphere
+        a bivariate spline over a rectangular mesh on a sphere
     SmoothSphereBivariateSpline :
-        to create a smooth bivariate spline in spherical coordinates
+        a smooth bivariate spline in spherical coordinates
     LSQSphereBivariateSpline :
-        to create a bivariate spline in spherical coordinates using
-        weighted least-squares fitting
+        a bivariate spline in spherical coordinates using weighted
+        least-squares fitting
     RectBivariateSpline :
-        to create a bivariate spline over a rectangular mesh.
+        a bivariate spline over a rectangular mesh.
     bisplrep : older wrapping of FITPACK
     bisplev : older wrapping of FITPACK
 
@@ -1157,20 +1159,20 @@ class LSQBivariateSpline(BivariateSpline):
     See Also
     --------
     BivariateSpline :
-        to create a bivariate spline on a plane grid
+        base class for bivariate splines.
     UnivariateSpline :
         a similar class for univariate spline interpolation
     SmoothBivariateSpline :
-        to create a bivariate spline through the given points
+        a smooth bivariate spline through the given points
     RectSphereBivariateSpline :
-        to create a bivariate spline over a rectangular mesh on a sphere
+        a bivariate spline over a rectangular mesh on a sphere
     SmoothSphereBivariateSpline :
-        to create a smooth bivariate spline in spherical coordinates
+        a smooth bivariate spline in spherical coordinates
     LSQSphereBivariateSpline :
-        to create a bivariate spline in spherical coordinates using
-        weighted least-squares fitting
+        a bivariate spline in spherical coordinates using weighted
+        least-squares fitting
     RectBivariateSpline :
-        to create a bivariate spline over a rectangular mesh.
+        a bivariate spline over a rectangular mesh.
     bisplrep : older wrapping of FITPACK
     bisplev : older wrapping of FITPACK
 
@@ -1243,20 +1245,20 @@ class RectBivariateSpline(BivariateSpline):
     See Also
     --------
     BivariateSpline :
-        to create a bivariate spline on a plane grid
+        base class for bivariate splines.
     UnivariateSpline :
         a similar class for univariate spline interpolation
     SmoothBivariateSpline :
-        to create a bivariate spline through the given points
+        a smooth bivariate spline through the given points
     LSQBivariateSpline :
-        to create a bivariate spline using weighted least-squares fitting
+        a bivariate spline using weighted least-squares fitting
     RectSphereBivariateSpline :
-        to create a bivariate spline over a rectangular mesh on a sphere
+        a bivariate spline over a rectangular mesh on a sphere
     SmoothSphereBivariateSpline :
-        to create a smooth bivariate spline in spherical coordinates
+        a smooth bivariate spline in spherical coordinates
     LSQSphereBivariateSpline :
-        to create a bivariate spline in spherical coordinates using
-        weighted least-squares fitting
+        a bivariate spline in spherical coordinates using weighted
+        least-squares fitting
     bisplrep : older wrapping of FITPACK
     bisplev : older wrapping of FITPACK
 
@@ -1330,9 +1332,9 @@ class SphereBivariateSpline(_BivariateSplineBase):
     bisplrep, bisplev : an older wrapping of FITPACK
     UnivariateSpline : a similar class for univariate spline interpolation
     SmoothUnivariateSpline :
-        to create a BivariateSpline through the given points
+        a smooth bivariate spline through the given points
     LSQUnivariateSpline :
-        to create a BivariateSpline using weighted least-squares fitting
+        a bivariate spline using weighted least-squares fitting
     """
 
     def __call__(self, theta, phi, dtheta=0, dphi=0, grid=True):
@@ -1427,20 +1429,20 @@ class SmoothSphereBivariateSpline(SphereBivariateSpline):
     See Also
     --------
     BivariateSpline :
-        to create a bivariate spline on a plane grid
+        base class for bivariate splines.
     UnivariateSpline :
         a similar class for univariate spline interpolation
     SmoothBivariateSpline :
-        to create a bivariate spline through the given points
+        a smooth bivariate spline through the given points
     LSQBivariateSpline :
-        to create a bivariate spline using weighted least-squares fitting
+        a bivariate spline using weighted least-squares fitting
     RectSphereBivariateSpline :
-        to create a bivariate spline over a rectangular mesh on a sphere
+        a bivariate spline over a rectangular mesh on a sphere
     LSQSphereBivariateSpline :
-        to create a bivariate spline in spherical coordinates using
-        weighted least-squares fitting
+        a bivariate spline in spherical coordinates using weighted
+        least-squares fitting
     RectBivariateSpline :
-        to create a bivariate spline over a rectangular mesh.
+        a bivariate spline over a rectangular mesh.
     bisplrep : older wrapping of FITPACK
     bisplev : older wrapping of FITPACK
 
@@ -1559,19 +1561,19 @@ class LSQSphereBivariateSpline(SphereBivariateSpline):
     See Also
     --------
     BivariateSpline :
-        to create a bivariate spline on a plane grid
+        base class for bivariate splines.
     UnivariateSpline :
         a similar class for univariate spline interpolation
     SmoothBivariateSpline :
-        to create a bivariate spline through the given points
+        a smooth bivariate spline through the given points
     LSQBivariateSpline :
-        to create a bivariate spline using weighted least-squares fitting
+        a bivariate spline using weighted least-squares fitting
     RectSphereBivariateSpline :
-        to create a bivariate spline over a rectangular mesh on a sphere
+        a bivariate spline over a rectangular mesh on a sphere
     SmoothSphereBivariateSpline :
-        to create a smooth bivariate spline in spherical coordinates
+        a smooth bivariate spline in spherical coordinates
     RectBivariateSpline :
-        to create a bivariate spline over a rectangular mesh.
+        a bivariate spline over a rectangular mesh.
     bisplrep : older wrapping of FITPACK
     bisplev : older wrapping of FITPACK
 
@@ -1748,20 +1750,20 @@ class RectSphereBivariateSpline(SphereBivariateSpline):
     See Also
     --------
     BivariateSpline :
-        to create a bivariate spline on a plane grid
+        base class for bivariate splines.
     UnivariateSpline :
         a similar class for univariate spline interpolation
     SmoothBivariateSpline :
-        to create a bivariate spline through the given points
+        a smooth bivariate spline through the given points
     LSQBivariateSpline :
-        to create a bivariate spline using weighted least-squares fitting
+        a bivariate spline using weighted least-squares fitting
     SmoothSphereBivariateSpline :
-        to create a smooth bivariate spline in spherical coordinates
+        a smooth bivariate spline in spherical coordinates
     LSQSphereBivariateSpline :
-        to create a bivariate spline in spherical coordinates using
-        weighted least-squares fitting
+        a bivariate spline in spherical coordinates using weighted
+        least-squares fitting
     RectBivariateSpline :
-        to create a bivariate spline over a rectangular mesh.
+        a bivariate spline over a rectangular mesh.
     bisplrep : older wrapping of FITPACK
     bisplev : older wrapping of FITPACK
 

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -120,12 +120,26 @@ class UnivariateSpline(object):
 
     See Also
     --------
+    BivariateSpline :
+        to create a bivariate spline on a plane grid
+    SmoothBivariateSpline :
+        to create a bivariate spline through the given points
+    LSQBivariateSpline :
+        to create a bivariate spline using weighted least-squares fitting
+    RectSphereBivariateSpline :
+        to create a bivariate spline over a rectangular mesh on a sphere
+    SmoothSphereBivariateSpline :
+        to create a smooth bivariate spline in spherical coordinates
+    LSQSphereBivariateSpline :
+        to create a bivariate spline in spherical coordinates using
+        weighted least-squares fitting
+    RectBivariateSpline :
+        to create a bivariate spline over a rectangular mesh.
+    bisplrep : older wrapping of FITPACK
+    bisplev : older wrapping of FITPACK
     InterpolatedUnivariateSpline : Subclass with smoothing forced to 0
-    LSQUnivariateSpline : Subclass in which knots are user-selected instead of
-        being set by smoothing condition
     splrep : An older, non object-oriented wrapping of FITPACK
     splev, sproot, splint, spalde
-    BivariateSpline : A similar class for two-dimensional spline interpolation
 
     Notes
     -----
@@ -588,9 +602,9 @@ class InterpolatedUnivariateSpline(UnivariateSpline):
     UnivariateSpline : Superclass -- allows knots to be selected by a
         smoothing condition
     LSQUnivariateSpline : spline for which knots are user-selected
+    BivariateSpline : A similar class for two-dimensional spline interpolation
     splrep : An older, non object-oriented wrapping of FITPACK
     splev, sproot, splint, spalde
-    BivariateSpline : A similar class for two-dimensional spline interpolation
 
     Notes
     -----
@@ -934,7 +948,7 @@ class BivariateSpline(_BivariateSplineBase):
 
     This class is meant to be subclassed, not instantiated directly.
     To construct these splines, call either `SmoothBivariateSpline` or
-    `LSQBivariateSpline`.
+    `LSQBivariateSpline` or `RectBivariateSpline`.
 
     See Also
     --------
@@ -951,6 +965,8 @@ class BivariateSpline(_BivariateSplineBase):
     LSQSphereBivariateSpline :
         to create a bivariate spline in spherical coordinates using
         weighted least-squares fitting
+    RectBivariateSpline :
+        to create a bivariate spline over a rectangular mesh.
     bisplrep : older wrapping of FITPACK
     bisplev : older wrapping of FITPACK
     """
@@ -1057,10 +1073,23 @@ class SmoothBivariateSpline(BivariateSpline):
 
     See Also
     --------
-    bisplrep : an older wrapping of FITPACK
-    bisplev : an older wrapping of FITPACK
-    UnivariateSpline : a similar class for univariate spline interpolation
-    LSQBivariateSpline : to create a BivariateSpline using weighted least-squares fitting
+    BivariateSpline :
+        to create a bivariate spline on a plane grid
+    UnivariateSpline :
+        a similar class for univariate spline interpolation
+    LSQBivariateSpline :
+        to create a bivariate spline using weighted least-squares fitting
+    RectSphereBivariateSpline :
+        to create a bivariate spline over a rectangular mesh on a sphere
+    SmoothSphereBivariateSpline :
+        to create a smooth bivariate spline in spherical coordinates
+    LSQSphereBivariateSpline :
+        to create a bivariate spline in spherical coordinates using
+        weighted least-squares fitting
+    RectBivariateSpline :
+        to create a bivariate spline over a rectangular mesh.
+    bisplrep : older wrapping of FITPACK
+    bisplev : older wrapping of FITPACK
 
     Notes
     -----
@@ -1127,10 +1156,23 @@ class LSQBivariateSpline(BivariateSpline):
 
     See Also
     --------
-    bisplrep : an older wrapping of FITPACK
-    bisplev : an older wrapping of FITPACK
-    UnivariateSpline : a similar class for univariate spline interpolation
-    SmoothBivariateSpline : create a smoothing BivariateSpline
+    BivariateSpline :
+        to create a bivariate spline on a plane grid
+    UnivariateSpline :
+        a similar class for univariate spline interpolation
+    SmoothBivariateSpline :
+        to create a bivariate spline through the given points
+    RectSphereBivariateSpline :
+        to create a bivariate spline over a rectangular mesh on a sphere
+    SmoothSphereBivariateSpline :
+        to create a smooth bivariate spline in spherical coordinates
+    LSQSphereBivariateSpline :
+        to create a bivariate spline in spherical coordinates using
+        weighted least-squares fitting
+    RectBivariateSpline :
+        to create a bivariate spline over a rectangular mesh.
+    bisplrep : older wrapping of FITPACK
+    bisplev : older wrapping of FITPACK
 
     Notes
     -----
@@ -1190,20 +1232,33 @@ class RectBivariateSpline(BivariateSpline):
     bbox : array_like, optional
         Sequence of length 4 specifying the boundary of the rectangular
         approximation domain.  By default,
-        ``bbox=[min(x,tx),max(x,tx), min(y,ty),max(y,ty)]``.
+        ``bbox=[min(x), max(x), min(y), max(y)]``.
     kx, ky : ints, optional
         Degrees of the bivariate spline. Default is 3.
     s : float, optional
         Positive smoothing factor defined for estimation condition:
-        ``sum((w[i]*(z[i]-s(x[i], y[i])))**2, axis=0) <= s``
+        ``sum((z[i]-s(x[i], y[i]))**2, axis=0) <= s``
         Default is ``s=0``, which is for interpolation.
 
     See Also
     --------
-    SmoothBivariateSpline : a smoothing bivariate spline for scattered data
-    bisplrep : an older wrapping of FITPACK
-    bisplev : an older wrapping of FITPACK
-    UnivariateSpline : a similar class for univariate spline interpolation
+    BivariateSpline :
+        to create a bivariate spline on a plane grid
+    UnivariateSpline :
+        a similar class for univariate spline interpolation
+    SmoothBivariateSpline :
+        to create a bivariate spline through the given points
+    LSQBivariateSpline :
+        to create a bivariate spline using weighted least-squares fitting
+    RectSphereBivariateSpline :
+        to create a bivariate spline over a rectangular mesh on a sphere
+    SmoothSphereBivariateSpline :
+        to create a smooth bivariate spline in spherical coordinates
+    LSQSphereBivariateSpline :
+        to create a bivariate spline in spherical coordinates using
+        weighted least-squares fitting
+    bisplrep : older wrapping of FITPACK
+    bisplev : older wrapping of FITPACK
 
     """
 
@@ -1369,6 +1424,26 @@ class SmoothSphereBivariateSpline(SphereBivariateSpline):
         linear system of equations. `eps` should have a value within the open
         interval ``(0, 1)``, the default is 1e-16.
 
+    See Also
+    --------
+    BivariateSpline :
+        to create a bivariate spline on a plane grid
+    UnivariateSpline :
+        a similar class for univariate spline interpolation
+    SmoothBivariateSpline :
+        to create a bivariate spline through the given points
+    LSQBivariateSpline :
+        to create a bivariate spline using weighted least-squares fitting
+    RectSphereBivariateSpline :
+        to create a bivariate spline over a rectangular mesh on a sphere
+    LSQSphereBivariateSpline :
+        to create a bivariate spline in spherical coordinates using
+        weighted least-squares fitting
+    RectBivariateSpline :
+        to create a bivariate spline over a rectangular mesh.
+    bisplrep : older wrapping of FITPACK
+    bisplev : older wrapping of FITPACK
+
     Notes
     -----
     For more information, see the FITPACK_ site about this function.
@@ -1480,6 +1555,25 @@ class LSQSphereBivariateSpline(SphereBivariateSpline):
         A threshold for determining the effective rank of an over-determined
         linear system of equations. `eps` should have a value within the
         open interval ``(0, 1)``, the default is 1e-16.
+
+    See Also
+    --------
+    BivariateSpline :
+        to create a bivariate spline on a plane grid
+    UnivariateSpline :
+        a similar class for univariate spline interpolation
+    SmoothBivariateSpline :
+        to create a bivariate spline through the given points
+    LSQBivariateSpline :
+        to create a bivariate spline using weighted least-squares fitting
+    RectSphereBivariateSpline :
+        to create a bivariate spline over a rectangular mesh on a sphere
+    SmoothSphereBivariateSpline :
+        to create a smooth bivariate spline in spherical coordinates
+    RectBivariateSpline :
+        to create a bivariate spline over a rectangular mesh.
+    bisplrep : older wrapping of FITPACK
+    bisplev : older wrapping of FITPACK
 
     Notes
     -----
@@ -1653,8 +1747,23 @@ class RectSphereBivariateSpline(SphereBivariateSpline):
 
     See Also
     --------
-    RectBivariateSpline : bivariate spline approximation over a rectangular
-        mesh
+    BivariateSpline :
+        to create a bivariate spline on a plane grid
+    UnivariateSpline :
+        a similar class for univariate spline interpolation
+    SmoothBivariateSpline :
+        to create a bivariate spline through the given points
+    LSQBivariateSpline :
+        to create a bivariate spline using weighted least-squares fitting
+    SmoothSphereBivariateSpline :
+        to create a smooth bivariate spline in spherical coordinates
+    LSQSphereBivariateSpline :
+        to create a bivariate spline in spherical coordinates using
+        weighted least-squares fitting
+    RectBivariateSpline :
+        to create a bivariate spline over a rectangular mesh.
+    bisplrep : older wrapping of FITPACK
+    bisplev : older wrapping of FITPACK
 
     Notes
     -----


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
fix #11756 

#### What does this implement/fix?
<!--Please explain your changes.-->
I improved and cleaned up *Spline docstrings in fitpack2.py to fix some issues reported in #11756.

##### Issue 1.
> In BivariateSpline class, as far as I understand, RectBivariateSpline should be added to the end of the sentence, because it subclasses BivariateSpline

I added.

##### Issue 2.
> In BivariateSpline class, as far as I understand, RectBivariateSpline should be added to the end of the sentence, because it subclasses BivariateSpline

I think this is a doc bug, this function does not use `tx`, `ty`. 
`bbox` is just use min-max of x and y based on this code:
https://github.com/scipy/scipy/blob/fd6f6d670909681127be0e545bc1a116d6b74a79/scipy/interpolate/src/fitpack.pyf#L465-L468
So, I fixed it.

##### Issue 3

> I have a feeling that "See Also" sections in different Spline's might be more... broad? Consistent? There's not so many of that classes, so why not to mention them all, or at least ensure that if A -> B and A -> C (-> means subclassing), then B mentions C in "See Also" and vice versa?

I cleaned up docstrings of some *Spline. These uses a same "See Also" contents.

##### Issue 4

> I've got a feeling that two last checks of these 4 are redundant, but I'm not sure 

Already, these redundant input check were removed in the master code.

##### Issue 5

> The docstring of the smoothing factor s of the class RectBivariateSpline mentions the vector w as part of the estimation condition:

I think this is a doc bug, this function does not use `w` discussed in #9718. So I removed it. Also I updated estimation function docstring. Because there are two 's', first one is spline function. I clarified it.
