### PR TITLE
ENH: shortcut for positive definite matrices in SciPy.linalg.logm

### DIFF
--- a/scipy/linalg/_matfuncs_inv_ssq.py
+++ b/scipy/linalg/_matfuncs_inv_ssq.py
@@ -760,12 +760,19 @@ def _logm_triu(T):
 
     # Construct T0 with the appropriate type,
     # depending on the dtype and the spectrum of T.
-    T_diag = np.diag(T)
+    T_diag = T.diagonal()
     keep_it_real = np.isrealobj(T) and np.min(T_diag) >= 0
     if keep_it_real:
         T0 = T
     else:
         T0 = T.astype(complex)
+
+    # Check if T0 is diagonal, if so return logarithm of the diagonal
+    # Reshape it so that diagonal becomes first columnn
+    T0_diagonal_reshape = T0.reshape(-1)[:-1].reshape(n-1,n+1)
+    is_diagonal = np.allclose(T0_diagonal_reshape[:,1:], 0)
+    if is_diagonal:
+        return np.diag(np.log(T0.diagonal()))
 
     # Define bounds given in Table (2.1).
     theta = (None,

--- a/scipy/linalg/_matfuncs_inv_ssq.py
+++ b/scipy/linalg/_matfuncs_inv_ssq.py
@@ -772,7 +772,7 @@ def _logm_triu(T):
     # Reshape it so that diagonal becomes first columnn, then slice it out
     off_diagonal_view = T0.reshape(-1)[:-1].reshape(n-1, n+1)[:, 1:]
     min_diag = np.min(np.abs(T0.diagonal()))
-    max_off_diag = np.max(np.abs(off_diagonal_view))
+    max_off_diag = np.max(np.abs(off_diagonal_view), initial=0.0)
     if max_off_diag / min_diag < 1e-8:
         return np.diag(np.log(T0.diagonal()))
 

--- a/scipy/linalg/_matfuncs_inv_ssq.py
+++ b/scipy/linalg/_matfuncs_inv_ssq.py
@@ -768,10 +768,12 @@ def _logm_triu(T):
         T0 = T.astype(complex)
 
     # Check if T0 is diagonal, if so return logarithm of the diagonal
-    # Reshape it so that diagonal becomes first columnn
-    T0_diagonal_reshape = T0.reshape(-1)[:-1].reshape(n-1,n+1)
-    is_diagonal = np.allclose(T0_diagonal_reshape[:,1:], 0)
-    if is_diagonal:
+    # We use ratio between biggest off-diagonal and smallest diagonal element
+    # Reshape it so that diagonal becomes first columnn, then slice it out
+    off_diagonal_view = T0.reshape(-1)[:-1].reshape(n-1, n+1)[:, 1:]
+    min_diag = np.min(np.abs(T0.diagonal()))
+    max_off_diag = np.max(np.abs(off_diagonal_view))
+    if max_off_diag / min_diag < 1e-8:
         return np.diag(np.log(T0.diagonal()))
 
     # Define bounds given in Table (2.1).

--- a/scipy/linalg/matfuncs.py
+++ b/scipy/linalg/matfuncs.py
@@ -137,7 +137,7 @@ def fractional_matrix_power(A, t):
     return scipy.linalg._matfuncs_inv_ssq._fractional_matrix_power(A, t)
 
 
-def logm(A, disp=True):
+def logm(A, disp=True, assume_a='gen'):
     """
     Compute matrix logarithm.
 
@@ -151,6 +151,12 @@ def logm(A, disp=True):
     disp : bool, optional
         Print warning if error in the result is estimated large
         instead of returning estimated error. (Default: True)
+    assume_a : str, optional
+        Make assumptions on the matrix A. Available options:
+            'gen' Generic (no assumptions)
+            'nor' Normal
+            'her' Hermitian
+            'pos' Positive definite
 
     Returns
     -------
@@ -194,7 +200,7 @@ def logm(A, disp=True):
     A = _asarray_square(A)
     # Avoid circular import ... this is OK, right?
     import scipy.linalg._matfuncs_inv_ssq
-    F = scipy.linalg._matfuncs_inv_ssq._logm(A)
+    F = scipy.linalg._matfuncs_inv_ssq._logm(A, assume_a=assume_a)
     F = _maybe_real(A, F)
     errtol = 1000*eps
     #TODO use a better error approximation


### PR DESCRIPTION
#### Reference issue
Closes #12464 

#### What does this implement/fix?
When computing the matrix logarithm of a positive definite matrix, we can take a shortcut. If A is PD and A = ZTZ* is the Schur decomposition, then T is diagonal (in general it is upper triangular). The matrix logarithm of T is then simply np.diag(np.log(T.diagonal())), and we don't need the machinery for computing the matrix log of an upper triangular matrix at all. 

I have therefore modified the method `linalg._matfuncs_inv_ssq.logm_triu` to check if the triangular matrix is actually a diagonal matrix, and if so use this simplified version of computing the log. This check has low overhead.

For depending on the size of the matrix, this can cause a speedup of up to a factor 10.