### PR TITLE
BUG: fix_integer_overflow_check in _fitpackmodule.c

### DIFF
--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -160,7 +160,7 @@ static PyObject *
 fitpack_bispev(PyObject *dummy, PyObject *args)
 {
     F_INT nx, ny, kx, ky, mx, my, lwrk, *iwrk, kwrk, ier, lwa, nux, nuy;
-    npy_intp mxy;
+    size_t mxy;
     double *tx, *ty, *c, *x, *y, *z, *wrk, *wa = NULL;
     PyArrayObject *ap_x = NULL, *ap_y = NULL, *ap_z = NULL, *ap_tx = NULL;
     PyArrayObject *ap_ty = NULL, *ap_c = NULL;
@@ -191,7 +191,7 @@ fitpack_bispev(PyObject *dummy, PyObject *args)
     ny = ap_ty->dimensions[0];
     mx = ap_x->dimensions[0];
     my = ap_y->dimensions[0];
-    mxy = mx*my;
+    mxy = (size_t)mx * (size_t)my;
     if (my != 0 && mxy/my != mx) {
         /* Integer overflow */
         PyErr_Format(PyExc_RuntimeError,

--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -192,7 +192,7 @@ fitpack_bispev(PyObject *dummy, PyObject *args)
     mx = ap_x->dimensions[0];
     my = ap_y->dimensions[0];
     mxy = (size_t)mx * (size_t)my;
-    if (my != 0 && mxy/my != mx) {
+    if (my != 0 && INTPTR_MAX/my < mx) {
         /* Integer overflow */
         PyErr_Format(PyExc_RuntimeError,
                      "Cannot produce output of size %dx%d (size too large)",


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
defect, fitpack.interpolate #12471 
#### What does this implement/fix?
<!--Please explain your changes.-->
It fixes incorrect checking of signed integer overflow in [_fitpackmodule.c:195](https://github.com/scipy/scipy/blob/master/scipy/interpolate/src/_fitpackmodule.c#L195) which result in segmentation fault in later code (in fortran code, but program should never reach there in such a case).
Since changed values are used for length, the simplest way was to change type of those variables from `F_INT` to `size_t`.
#### Additional information
<!--Any additional information you think is important.-->
See issue for more specific informations.