### PR TITLE
DOC: add a note in poisson distribution when mu=0 and k=0 in pmf method

### DIFF
--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -584,6 +584,8 @@ class poisson_gen(rv_discrete):
     for :math:`k \ge 0`.
 
     `poisson` takes :math:`\mu` as shape parameter.
+    When mu = 0 then at quantile k = 0, ``pmf`` method
+    returns `1.0`.
 
     %(after_notes)s
 


### PR DESCRIPTION
### Reference issue

Fixes #12113. A rework for #12142

### What does this implement/fix?

I have added a note in Poisson distribution docs to warn that the pmf will return 1.0 at quantile `k = 0.` when `rate = 0.`

cc: @rlucas7 