### PR TITLE
BUG: fix approx_derivative step size. Closes #12487

### DIFF
--- a/scipy/optimize/_numdiff.py
+++ b/scipy/optimize/_numdiff.py
@@ -403,7 +403,7 @@ def approx_derivative(fun, x0, method='3-point', rel_step=None, abs_step=None,
         else:
             # user specifies an absolute step
             sign_x0 = (x0 >= 0).astype(float) * 2 - 1
-            h = abs_step * sign_x0
+            h = abs_step
 
             # cannot have a zero step. This might happen if x0 is very large
             # or small. In which case fall back to relative step.


### PR DESCRIPTION
#12487 reports that if a positive step size is used in `approx_fprime` for a discontinuous function, then backwards differences were being used instead of forward differences. This PR fixes that bug, and adds several regression tests based on the issue, checking that if a positive absolute step is used, then forwards differences are employed, and vice-versa.