### PR TITLE
MAINT: forward port 1.5.1 release notes

### DIFF
--- a/doc/release/1.5.1-notes.rst
+++ b/doc/release/1.5.1-notes.rst
@@ -1,0 +1,47 @@
+==========================
+SciPy 1.5.1 Release Notes
+==========================
+
+.. contents::
+
+SciPy 1.5.1 is a bug-fix release with no new features
+compared to 1.5.0. In particular, an issue where DLL loading
+can fail for SciPy wheels on Windows with Python 3.6 has been
+fixed.
+
+Authors
+=======
+
+* Peter Bell
+* Loïc Estève
+* Philipp Thölke +
+* Tyler Reddy
+* Paul van Mulbregt
+* Pauli Virtanen
+* Warren Weckesser
+
+A total of 7 people contributed to this release.
+People with a "+" by their names contributed a patch for the first time.
+This list of names is automatically generated, and may not be fully complete.
+
+
+Issues closed for 1.5.1
+-----------------------
+
+* `#9108 <https://github.com/scipy/scipy/issues/9108>`__: documentation: scipy.spatial.KDTree vs. scipy.spatial.cKDTree
+* `#12218 <https://github.com/scipy/scipy/issues/12218>`__: Type error in stats.ks_2samp when alternative != 'two-sided-
+* `#12406 <https://github.com/scipy/scipy/issues/12406>`__: DOC: Docstring in stats.anderson function not properly formatted
+* `#12418 <https://github.com/scipy/scipy/issues/12418>`__: Regression in hierarchy.dendogram
+
+
+Pull requests for 1.5.1
+-----------------------
+
+* `#12280 <https://github.com/scipy/scipy/pull/12280>`__: BUG: Fixes gh-12218, TypeError converting int to float inside...
+* `#12336 <https://github.com/scipy/scipy/pull/12336>`__: BUG: KDTree should reject complex input points
+* `#12344 <https://github.com/scipy/scipy/pull/12344>`__: MAINT: Don't use numpy's aliases of Python builtin objects.
+* `#12407 <https://github.com/scipy/scipy/pull/12407>`__: DOC: Fix docstring for dist param in anderson function
+* `#12410 <https://github.com/scipy/scipy/pull/12410>`__: CI: Run the Azure Windows Python36 32bit tests with mode 'fast'
+* `#12421 <https://github.com/scipy/scipy/pull/12421>`__: Fix regression in scipy 1.5.0 in dendogram when labels is a numpy...
+* `#12462 <https://github.com/scipy/scipy/pull/12462>`__: MAINT: move distributor_init import after __config__ import
+

--- a/doc/source/release.1.5.1.rst
+++ b/doc/source/release.1.5.1.rst
@@ -1,0 +1,1 @@
+.. include:: ../release/1.5.1-notes.rst

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -6,6 +6,7 @@ Release Notes
    :maxdepth: 1
 
    release.1.6.0
+   release.1.5.1
    release.1.5.0
    release.1.4.1
    release.1.4.0


### PR DESCRIPTION
Forward port SciPy `1.5.1` release notes following release yesterday.