### PR TITLE
CI: actions branch trigger fix

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -2,9 +2,13 @@ name: macOS tests
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+      - maintenance/**
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
+      - maintenance/**
 
 
 jobs:


### PR DESCRIPTION
Fixes #12493

* we should run CI for PRs to `maintenance/**` branches
so that MacOS is tested for backport PRs