### PR TITLE
BUG: cKDTreeNode use after free

### DIFF
--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -333,52 +333,46 @@ cdef class cKDTreeNode:
 
     """
     cdef:
+        readonly cKDTree      _parent
         readonly np.intp_t    level
         readonly np.intp_t    split_dim
         readonly np.intp_t    children
         readonly np.float64_t split
         ckdtreenode           *_node
-        np.ndarray            _data
-        np.ndarray            _indices
         readonly object       lesser
         readonly object       greater
 
-    cdef void _setup(cKDTreeNode self):
+    cdef void _setup(cKDTreeNode self, cKDTree parent, ckdtreenode *node, np.intp_t level):
         cdef cKDTreeNode n1, n2
-        self.split_dim = self._node.split_dim
-        self.children = self._node.children
-        self.split = self._node.split
+        self._parent = parent
+        self.level = level
+        self.split_dim = node.split_dim
+        self.children = node.children
+        self.split = node.split
+        self._node = node
         if self.split_dim == -1:
             self.lesser = None
             self.greater = None
         else:
             # setup lesser branch
             n1 = cKDTreeNode()
-            n1._node = self._node.less
-            n1._data = self._data
-            n1._indices = self._indices
-            n1.level = self.level + 1
-            n1._setup()
+            n1._setup(parent, node=node.less, level=level + 1)
             self.lesser = n1
             # setup greater branch
             n2 = cKDTreeNode()
-            n2._node = self._node.greater
-            n2._data = self._data
-            n2._indices = self._indices
-            n2.level = self.level + 1
-            n2._setup()
+            n2._setup(parent, node=node.greater, level=level + 1)
             self.greater = n2
 
     property data_points:
         def __get__(cKDTreeNode self):
-            return self._data[self.indices,:]
+            return self._parent.data[self.indices,:]
 
     property indices:
         def __get__(cKDTreeNode self):
             cdef np.intp_t start, stop
             start = self._node.start_idx
             stop = self._node.end_idx
-            return self._indices[start:stop]
+            return self._parent.indices[start:stop]
 
 
 # Main cKDTree class
@@ -506,11 +500,7 @@ cdef class cKDTree:
                 return self._python_tree
             else:
                 n = cKDTreeNode()
-                n._node = cself.ctree
-                n._data = self.data
-                n._indices = self.indices
-                n.level = 0
-                n._setup()
+                n._setup(self, node=cself.ctree, level=0)
                 self._python_tree = n
                 return self._python_tree
 

--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -333,23 +333,27 @@ cdef class cKDTreeNode:
 
     """
     cdef:
-        readonly cKDTree      _parent
         readonly np.intp_t    level
         readonly np.intp_t    split_dim
         readonly np.intp_t    children
+        readonly np.intp_t    start_idx
+        readonly np.intp_t    end_idx
         readonly np.float64_t split
-        ckdtreenode           *_node
+        np.ndarray            _data
+        np.ndarray            _indices
         readonly object       lesser
         readonly object       greater
 
     cdef void _setup(cKDTreeNode self, cKDTree parent, ckdtreenode *node, np.intp_t level):
         cdef cKDTreeNode n1, n2
-        self._parent = parent
         self.level = level
         self.split_dim = node.split_dim
         self.children = node.children
         self.split = node.split
-        self._node = node
+        self.start_idx = node.start_idx
+        self.end_idx = node.end_idx
+        self._data = parent.data
+        self._indices = parent.indices
         if self.split_dim == -1:
             self.lesser = None
             self.greater = None
@@ -365,14 +369,14 @@ cdef class cKDTreeNode:
 
     property data_points:
         def __get__(cKDTreeNode self):
-            return self._parent.data[self.indices,:]
+            return self._data[self.indices,:]
 
     property indices:
         def __get__(cKDTreeNode self):
             cdef np.intp_t start, stop
-            start = self._node.start_idx
-            stop = self._node.end_idx
-            return self._parent.indices[start:stop]
+            start = self.start_idx
+            stop = self.end_idx
+            return self._indices[start:stop]
 
 
 # Main cKDTree class

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -12,8 +12,6 @@ from scipy.spatial.ckdtree import cKDTreeNode
 from scipy.spatial import minkowski_distance
 
 import itertools
-import gc
-import sys
 
 def distance_box(a, b, p, boxsize):
     diff = a - b
@@ -1487,17 +1485,3 @@ def test_kdtree_complex_data():
 
     with pytest.raises(TypeError, match="complex data"):
         t.query_ball_point(points, r=1)
-
-
-def test_ckdtree_tree_refcount():
-    # Test cKDTreeNode keeps the refcount of its parent cKDTree object above 0
-    points = np.random.rand(100, 2)
-    t = cKDTree(points)
-    root = t.tree
-    # 1 refcount from the variable "t", the other is the argument to getrefcount
-    assert sys.getrefcount(t) > 2
-
-    # May crash if the tree has been freed
-    del t
-    gc.collect()
-    ll = root.lesser.data_points


### PR DESCRIPTION
#### What does this implement/fix?
There is a lifetime issue with `cKDTreeNode`. It holds a non-owning pointer to the `ckdtreenode` and so we can cause a use after free by accessing it after after the parent `cKDTree` instance has been GC'd:
```python
>>> from scipy.spatial import cKDTree
>>> import numpy as np
>>> x = np.random.rand(10, 10)
>>> t = cKDTree(x)
>>> root = t.tree
>>> root.indices
array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])

>>> del t
>>> root.indices
array([], dtype=int64)

```

Sometimes it just gives the wrong answer, sometimes it will segfault.

I fix this by ~holding a reference to the parent `cKDTree` object, thus extending the entire tree's lifetime~ copying all of the node's attributes into `cKDTreeNode` and not storing a pointer to the C++ structure.

#### Additional information
I noticed this issue when reviewing #12383, but `cKDTreeNode` has always been broken in this way. 

cc @sturlamolden 