### PR TITLE
WIP, ENH: io: different integer output formats for `wavfile.read` 

### DIFF
--- a/scipy/io/tests/test_wavfile.py
+++ b/scipy/io/tests/test_wavfile.py
@@ -28,7 +28,7 @@ def test_read_1():
 
         del data
 
-    rate, data = wavfile.read(datafile(filename), mmap=False, int_form='rj')
+    rate, data = wavfile.read(datafile(filename), mmap=False, int_format='rj')
 
     assert_equal(rate, 44100)
     assert data.dtype == np.int32  # actually np.intc on Windows
@@ -47,7 +47,7 @@ def test_read_2():
 
         del data
 
-    rate, data = wavfile.read(datafile(filename), mmap=False, int_form='rj')
+    rate, data = wavfile.read(datafile(filename), mmap=False, int_format='rj')
 
     assert_equal(rate, 8000)
     assert_(np.issubdtype(data.dtype, np.int8))  # signed
@@ -62,11 +62,11 @@ def test_read_2():
 
 def test_read_3():
     # Little-endian float
-    for mmap, int_form in [(False, 'lj'), (False, 'rj'),
-                           (False, 'fp'), (False, 'fs'), (True, 'lj')]:
+    for mmap, int_format in [(False, 'lj'), (False, 'rj'),
+                             (False, 'fp'), (False, 'fs'), (True, 'lj')]:
         filename = 'test-44100Hz-2ch-32bit-float-le.wav'
         rate, data = wavfile.read(datafile(filename), mmap=mmap,
-                                  int_form=int_form)
+                                  int_format=int_format)
 
         assert_equal(rate, 44100)
         assert_(np.issubdtype(data.dtype, np.float32))
@@ -134,7 +134,7 @@ def test_5_bit_odd_size_no_pad():
 
         del data
 
-    rate, data = wavfile.read(datafile(filename), mmap=False, int_form='rj')
+    rate, data = wavfile.read(datafile(filename), mmap=False, int_format='rj')
 
     assert_equal(rate, 8000)
     assert_(np.issubdtype(data.dtype, np.int8))  # signed
@@ -193,7 +193,7 @@ def test_24_bit_odd_size_with_pad():
                         [+0x7fff_ff00, +0x7fff_ff00, +0x200]])
     #                     ^ clipped
 
-    rate, data = wavfile.read(datafile(filename), mmap=False, int_form='rj')
+    rate, data = wavfile.read(datafile(filename), mmap=False, int_format='rj')
 
     assert_equal(rate, 8000)
     assert data.dtype == np.int32  # actually np.intc on Windows
@@ -211,7 +211,7 @@ def test_24_bit_odd_size_with_pad():
                         [+0x7fffff, +0x7fffff, +2]])
     #                     ^ clipped
 
-    rate, data = wavfile.read(datafile(filename), mmap=False, int_form='fp')
+    rate, data = wavfile.read(datafile(filename), mmap=False, int_format='fp')
 
     assert_equal(rate, 8000)
     assert_(np.issubdtype(data.dtype, np.float64))
@@ -220,7 +220,7 @@ def test_24_bit_odd_size_with_pad():
     assert_equal(data[:4, 0], [-1, -0.5, 0, 0.5])
     assert_equal(data[:, 2], np.array([-2, -1, 0, 1, 2]) / (2**23))
 
-    rate, data = wavfile.read(datafile(filename), mmap=False, int_form='fs')
+    rate, data = wavfile.read(datafile(filename), mmap=False, int_format='fs')
 
     assert_equal(rate, 8000)
     assert_(np.issubdtype(data.dtype, np.float64))

--- a/scipy/io/wavfile.py
+++ b/scipy/io/wavfile.py
@@ -639,14 +639,15 @@ def read(filename, mmap=False, int_format='lj'):
     This converts the integer values to float, dividing by 2**(N-1), which
     interprets them as fixed-point numbers with the binary point
     to the right of the MSbit, so it can reach -1.0 but cannot reach +1.0.
-    [3]_ [4]_
+    [3]_ [4]_  This behaves the same as MATLAB's ``audioread`` function. [5]_
+    [6]_
 
     An 8-bit file would reach from -1.0 to 0.992 (127/128), for example.
 
     **Full-scale format**
     This converts the integer values to float, dividing by 2**(N-1) - 1, using
     the convention that full-scale is defined by the highest positive
-    code. [5]_ [6]_
+    code. [7]_ [8]_
 
     An 8-bit file would reach from -1.008 (-128/127) to +1.0, for example.
 
@@ -662,8 +663,13 @@ def read(filename, mmap=False, int_format='lj'):
     .. [4] Universal Serial Bus Device Class Definition for Audio Data Formats,
        Release 3.0, 2016, Section 2.3.1.6.1 "PCM Format"
        https://www.usb.org/document-library/usb-audio-devices-rev-30-and-adopters-agreement
-    .. [5] AES17-1998 (r2009)
-    .. [6] IEC 61606-3:2008
+    .. [5] MATLAB audioread function
+       https://www.mathworks.com/help/matlab/ref/audioread.html
+    .. [6] Walter Roberson, Response to "What does the 'audioread' function
+       actually do?", MATLAB Answers, 7 Jul 2016
+       https://www.mathworks.com/matlabcentral/answers/294112-what-does-the-audioread-function-actually-do#comment_377989
+    .. [7] AES17-1998 (r2009)
+    .. [8] IEC 61606-3:2008
 
     Examples
     --------

--- a/scipy/io/wavfile.py
+++ b/scipy/io/wavfile.py
@@ -538,7 +538,7 @@ def _handle_pad_byte(fid, size):
         fid.seek(1, 1)
 
 
-def read(filename, mmap=False, int_form='lj'):
+def read(filename, mmap=False, int_format='lj'):
     """
     Open a WAV file.
 
@@ -553,7 +553,7 @@ def read(filename, mmap=False, int_form='lj'):
         with some bit depths; see Notes.  Only to be used on real files.
 
         .. versionadded:: 0.12.0
-    int_form : {'lj', 'rj', 'fp', 'fs'}
+    int_format : {'lj', 'rj', 'fp', 'fs'}
         The format of the returned data for integer PCM files.  (Float files
         are always returned in their native type.)  See Notes for details on
         each format.
@@ -704,7 +704,7 @@ def read(filename, mmap=False, int_form='lj'):
     else:
         fid = open(filename, 'rb')
 
-    if mmap and int_form != 'lj':
+    if mmap and int_format != 'lj':
         raise ValueError('mmap must lj')
 
     try:
@@ -751,24 +751,24 @@ def read(filename, mmap=False, int_form='lj'):
                                         is_big_endian, block_align, mmap)
                 if format_tag == WAVE_FORMAT.IEEE_FLOAT:
                     continue
-                if int_form == 'lj':
+                if int_format == 'lj':
                     pass
-                elif int_form == 'rj':
+                elif int_format == 'rj':
                     if bit_depth <= 8:
                         data = (data - 128).view(numpy.int8)
                     data = data >> (data.itemsize*8 - bit_depth)
-                elif int_form == 'fp':
+                elif int_format == 'fp':
                     if bit_depth <= 8:
                         data = (data - 128).view(numpy.int8)
                     data = data >> (data.itemsize*8 - bit_depth)
                     data = data / (2**(bit_depth - 1))
-                elif int_form == 'fs':
+                elif int_format == 'fs':
                     if bit_depth <= 8:
                         data = (data - 128).view(numpy.int8)
                     data = data >> (data.itemsize*8 - bit_depth)
                     data = data / (2**(bit_depth - 1) - 1)
                 else:
-                    raise ValueError('int_form not understood')
+                    raise ValueError('int_format not understood')
             elif chunk_id == b'LIST':
                 # Someday this could be handled properly but for now skip it
                 _skip_unknown_chunk(fid, is_big_endian)


### PR DESCRIPTION
#### Reference issue
Finishes read() half of #12059
Adds on to #12287 ([diff vs that PR](https://github.com/endolith/scipy/compare/all_bit_depths_int...endolith:right-justified))

#### What does this implement/fix?
Four different formats for reading WAV files.

#### Additional information
Posting this as a draft for feedback on the parameter names, whether all these options are necessary, etc.  I'm not good at coming up with names.

* `lj` = left-justified integers, which is the native format that's used inside the WAV file. 8-bit and under are unsigned, 9-bit and over are signed, 24-bit gets put in a 32-bit container, left-justified.  This is the only form that's compatible with mmap.  read() doesn't currently output bit depth of WAV, so you have to already know what it is to work with this format.
* `rj` = right-justified integers. Always signed ints, even for 8-bit and below.  Right-justified so that, for instance, 4-bit files reach from -8 to +7.   Ocenaudio displays these values when you look at Statistics.  Still not possible to know for sure what the bit depth is, but a +1 above midpoint stored in any integer WAV format will be output as +1 in the numpy array.
* `fp` = fixed-point float?  Because the integer in the WAV file is treated as a fixed-point number with the binary point to the right of the most significant bit, and then that value is converted to floating point (except that ≤8 bit is offset to signed first).  MATLAB's `audioread`, [USB Audio](http://dl.project-voodoo.org/usb-audio-spec/USB%20Audio%20v2.0/Frmts20%20final.pdf#page=16) and [Android](https://source.android.com/devices/audio/data_formats#fixed ) all interpret integer PCM data as fixed-point
* `fs` = full-scale float?  Named because signal can reach full-scale ±1.0, as described [here](https://gist.github.com/endolith/e8597a58bcd11a6462f33fa8eb75c43d).  Technically it doesn't say that full-scale should be equal to 1.0, but I think that's implied?  [JACK Audio Connection Kit uses this int to float conversion](https://github.com/jackaudio/jack2/blob/master/common/memops.c#L49), as does other software.  With this format it doesn't matter that read() doesn't return the bit depth of the WAV, because full-scale of all formats gets mapped to the same amplitude and type.

For float WAV files, the int_form is ignored, so you can just set it to `fs` and open any file and it will be float dtype with full-scale of the WAV mapped from -1 to +1, so it behaves like default PySoundFile. That's what I would use 99% of the time.

The difference between fp and fs is very slight for normal bit depths, but does exist in different software: http://blog.bjornroche.com/2009/12/int-float-int-its-jungle-out-there.html

Even I'm confused about all the different combinations, so I made a chart:

![WAV stuff](https://user-images.githubusercontent.com/58611/86862894-22d27000-c098-11ea-8b9f-5574d1646c4c.png)

Keep in mind that WAVs with container sizes 5-8 probably don't actually exist in the real world.  Most are 8/16/24-bit int or 32-bit float.