### PR TITLE
ENH: Allow user configuration of pocketfft's plan caches

### DIFF
--- a/scipy/fft/__init__.py
+++ b/scipy/fft/__init__.py
@@ -59,6 +59,8 @@ Helper functions
    get_workers - Get the current default number of workers
    get_plan_cache_size - Query the size of the plan caches
    set_plan_cache_size - Set maximum number of transform plans to cache
+   get_plan_cache_max_memsize - Query the maximum size of plan to cache
+   set_plan_cache_max_memsize - Set maximum memory to use in caching a single plan
    clear_plan_cache - Free any cached transform plans
 
 Backend control
@@ -83,8 +85,11 @@ from ._helper import next_fast_len
 from ._backend import (set_backend, skip_backend, set_global_backend,
                        register_backend)
 from numpy.fft import fftfreq, rfftfreq, fftshift, ifftshift
-from ._pocketfft.helper import (set_workers, get_workers, get_plan_cache_size,
-                                set_plan_cache_size, clear_plan_cache)
+from ._pocketfft.helper import (set_workers, get_workers)
+from ._pocketfft.pypocketfft import (
+    get_plan_cache_size, set_plan_cache_size,
+    get_plan_cache_max_memsize, set_plan_cache_max_memsize,
+    clear_plan_cache)
 
 __all__ = [
     'fft', 'ifft', 'fft2','ifft2', 'fftn', 'ifftn',
@@ -95,7 +100,9 @@ __all__ = [
     'dct', 'idct', 'dst', 'idst', 'dctn', 'idctn', 'dstn', 'idstn',
     'set_backend', 'skip_backend', 'set_global_backend', 'register_backend',
     'get_workers', 'set_workers',
-    'get_plan_cache_size', 'set_plan_cache_size', 'clear_plan_cache']
+    'get_plan_cache_size', 'set_plan_cache_size',
+    'get_plan_cache_max_memsize', 'set_plan_cache_max_memsize',
+    'clear_plan_cache']
 
 
 from scipy._lib._testutils import PytestTester

--- a/scipy/fft/__init__.py
+++ b/scipy/fft/__init__.py
@@ -57,6 +57,9 @@ Helper functions
    next_fast_len - Find the optimal length to zero-pad an FFT for speed
    set_workers - Context manager to set default number of workers
    get_workers - Get the current default number of workers
+   get_plan_cache_size - Query the size of the plan caches
+   set_plan_cache_size - Set maximum number of transform plans to cache
+   clear_plan_cache - Free any cached transform plans
 
 Backend control
 ===============
@@ -80,7 +83,8 @@ from ._helper import next_fast_len
 from ._backend import (set_backend, skip_backend, set_global_backend,
                        register_backend)
 from numpy.fft import fftfreq, rfftfreq, fftshift, ifftshift
-from ._pocketfft.helper import set_workers, get_workers
+from ._pocketfft.helper import (set_workers, get_workers, get_plan_cache_size,
+                                set_plan_cache_size, clear_plan_cache)
 
 __all__ = [
     'fft', 'ifft', 'fft2','ifft2', 'fftn', 'ifftn',
@@ -90,7 +94,8 @@ __all__ = [
     'next_fast_len',
     'dct', 'idct', 'dst', 'idst', 'dctn', 'idctn', 'dstn', 'idstn',
     'set_backend', 'skip_backend', 'set_global_backend', 'register_backend',
-    'get_workers', 'set_workers']
+    'get_workers', 'set_workers',
+    'get_plan_cache_size', 'set_plan_cache_size', 'clear_plan_cache']
 
 
 from scipy._lib._testutils import PytestTester

--- a/scipy/fft/_pocketfft/helper.py
+++ b/scipy/fft/_pocketfft/helper.py
@@ -6,6 +6,7 @@ import contextlib
 
 import numpy as np
 # good_size is exposed (and used) from this import
+from . import pypocketfft
 from .pypocketfft import good_size
 
 _config = threading.local()
@@ -211,3 +212,18 @@ def get_workers():
     4
     """
     return getattr(_config, 'default_workers', 1)
+
+
+def get_plan_cache_size():
+    """Returns the current maximum number of plans that may be cached."""
+    return pypocketfft.get_plan_cache_size()
+
+
+def set_plan_cache_size(new_size):
+    """Sets the maximum number of plans that may be cached."""
+    return pypocketfft.set_plan_cache_size(new_size)
+
+
+def clear_plan_cache():
+    """Clears the transform plan cache, freeing any used memory"""
+    return pypocketfft.clear_plan_cache()

--- a/scipy/fft/_pocketfft/helper.py
+++ b/scipy/fft/_pocketfft/helper.py
@@ -212,18 +212,3 @@ def get_workers():
     4
     """
     return getattr(_config, 'default_workers', 1)
-
-
-def get_plan_cache_size():
-    """Returns the current maximum number of plans that may be cached."""
-    return pypocketfft.get_plan_cache_size()
-
-
-def set_plan_cache_size(new_size):
-    """Sets the maximum number of plans that may be cached."""
-    return pypocketfft.set_plan_cache_size(new_size)
-
-
-def clear_plan_cache():
-    """Clears the transform plan cache, freeing any used memory"""
-    return pypocketfft.clear_plan_cache()

--- a/scipy/fft/_pocketfft/pocketfft_hdronly.h
+++ b/scipy/fft/_pocketfft/pocketfft_hdronly.h
@@ -2755,7 +2755,7 @@ public:
     size_ = new_max;
     if (new_max == 0)
       {
-      clear();
+      cache_.clear();
       return;
       }
 

--- a/scipy/fft/_pocketfft/pocketfft_hdronly.h
+++ b/scipy/fft/_pocketfft/pocketfft_hdronly.h
@@ -2844,12 +2844,12 @@ public:
     auto * cache = new PlanCache(
         cache_size_,
         max_memsize_,
-        +[](size_t length)
-        {
-        auto plan = std::make_shared<T>(length);
-        auto memsize = plan->memsize();
-        return PlanCache::PlanInfo{std::move(plan), memsize};
-        });
+        [](size_t length)
+          {
+          auto plan = std::make_shared<T>(length);
+          auto memsize = plan->memsize();
+          return PlanCache::PlanInfo{std::move(plan), memsize};
+          });
     caches_.push_back(std::unique_ptr<PlanCache>(cache));
     return *cache;
     }

--- a/scipy/fft/_pocketfft/pypocketfft.cxx
+++ b/scipy/fft/_pocketfft/pypocketfft.cxx
@@ -408,6 +408,16 @@ void set_plan_cache_size(size_t new_size)
   return pocketfft::detail::CacheManager::instance().resize(new_size);
   }
 
+size_t get_plan_cache_max_memsize()
+  {
+  return pocketfft::detail::CacheManager::instance().get_max_memsize();
+  }
+
+void set_plan_cache_max_memsize(size_t new_max)
+  {
+  return pocketfft::detail::CacheManager::instance().set_max_memsize(new_max);
+  }
+
 void clear_plan_cache()
   {
   return pocketfft::detail::CacheManager::instance().clear();
@@ -739,6 +749,8 @@ PYBIND11_MODULE(pypocketfft, m)
     "out"_a=None, "nthreads"_a=1);
   m.def("get_plan_cache_size", get_plan_cache_size);
   m.def("set_plan_cache_size", set_plan_cache_size, "new_size"_a);
+  m.def("get_plan_cache_max_memsize", get_plan_cache_max_memsize);
+  m.def("set_plan_cache_max_memsize", set_plan_cache_max_memsize, "new_size"_a);
   m.def("clear_plan_cache", clear_plan_cache);
 
   static PyMethodDef good_size_meth[] =

--- a/scipy/fft/_pocketfft/pypocketfft.cxx
+++ b/scipy/fft/_pocketfft/pypocketfft.cxx
@@ -398,6 +398,21 @@ PyObject * good_size(PyObject * /*self*/, PyObject * args)
     real ? util::good_size_real(n) : util::good_size_cmplx(n));
   }
 
+size_t get_plan_cache_size()
+  {
+  return pocketfft::detail::CacheManager::instance().size();
+  }
+
+void set_plan_cache_size(size_t new_size)
+  {
+  return pocketfft::detail::CacheManager::instance().resize(new_size);
+  }
+
+void clear_plan_cache()
+  {
+  return pocketfft::detail::CacheManager::instance().clear();
+  }
+
 const char *pypocketfft_DS = R"""(Fast Fourier and Hartley transforms.
 
 This module supports
@@ -722,6 +737,9 @@ PYBIND11_MODULE(pypocketfft, m)
     "out"_a=None, "nthreads"_a=1);
   m.def("dst", dst, dst_DS, "a"_a, "type"_a, "axes"_a=None, "inorm"_a=0,
     "out"_a=None, "nthreads"_a=1);
+  m.def("get_plan_cache_size", get_plan_cache_size);
+  m.def("set_plan_cache_size", set_plan_cache_size, "new_size"_a);
+  m.def("clear_plan_cache", clear_plan_cache);
 
   static PyMethodDef good_size_meth[] =
     {{"good_size", good_size, METH_VARARGS, good_size_DS}, {0}};


### PR DESCRIPTION
#### Reference issue
Closes gh-12297

#### What does this implement/fix?
This allows the user to interface with `scipy.fft`'s plan caches using 3 utility functions:
- `set_plan_cache_size(new_size)`
- `get_plan_cache_size()`
- `clear_plan_cache()`

Limitations: 
- ~Only controls the number of plans, not amount of memory.~
- For simplicity, all plan types have the same size of cache.

#### Additional information
The C++ implementation introduces two new classes, `PlanCache` and `CacheManager`.  A plan cache handles LRU caching for a single plan type, similar to what `get_plan` did before. `PlanCache` instances are constructed within the `CacheManager` which keeps an internal reference to every cache. This way I can query and manipulate the caches uniformly by iterating over the `CacheManager`'s internal list of caches.

Note that inside of any given transform, `get_plan()` interacts directly with the `PlanCache` and doesn't need to go through the `CacheManager`. So it exists only for configuration purposes.

TODO:

- [ ] Add tests
- [ ] Expand documentaion

cc @mreineck, @larsoner 