### PR TITLE
PERF: Avoid np.zeros when custom initialization is needed anyway

### DIFF
--- a/scipy/interpolate/interpnd.pyx
+++ b/scipy/interpolate/interpnd.pyx
@@ -271,7 +271,7 @@ class LinearNDInterpolator(NDInterpolatorBase):
 
         qhull._get_delaunay_info(&info, self.tri, 1, 0, 0)
 
-        out = np.zeros((xi.shape[0], self.values.shape[1]),
+        out = np.empty((xi.shape[0], self.values.shape[1]),
                        dtype=self.values.dtype)
         nvalues = out.shape[1]
 

--- a/scipy/optimize/_linprog_simplex.py
+++ b/scipy/optimize/_linprog_simplex.py
@@ -383,9 +383,9 @@ def _solve_simplex(T, n, basis, callback, postsolve_args,
                 nit += 1
 
     if len(basis[:m]) == 0:
-        solution = np.zeros(T.shape[1] - 1, dtype=np.float64)
+        solution = np.empty(T.shape[1] - 1, dtype=np.float64)
     else:
-        solution = np.zeros(max(T.shape[1] - 1, max(basis[:m]) + 1),
+        solution = np.empty(max(T.shape[1] - 1, max(basis[:m]) + 1),
                             dtype=np.float64)
 
     while not complete:

--- a/scipy/optimize/_shgo_lib/sobol_seq.py
+++ b/scipy/optimize/_shgo_lib/sobol_seq.py
@@ -285,7 +285,7 @@ class Sobol:
                 # Expand this bit pattern to separate
                 # components of the logical array INCLUD.
                 j = self.poly[i - 1]
-                includ = np.zeros(m)
+                includ = np.empty(m)
                 for k in range(m, 0, -1):
                     j2 = j // 2
                     includ[k - 1] = (j != 2 * j2)

--- a/scipy/optimize/lbfgsb.py
+++ b/scipy/optimize/lbfgsb.py
@@ -459,7 +459,7 @@ class LbfgsInvHessProduct(LinearOperator):
         if q.ndim == 2 and q.shape[1] == 1:
             q = q.reshape(-1)
 
-        alpha = np.zeros(n_corrs)
+        alpha = np.empty(n_corrs)
 
         for i in range(n_corrs-1, -1, -1):
             alpha[i] = rho[i] * np.dot(s[i], q)

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -645,7 +645,7 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
     if initial_simplex is None:
         N = len(x0)
 
-        sim = np.zeros((N + 1, N), dtype=x0.dtype)
+        sim = np.empty((N + 1, N), dtype=x0.dtype)
         sim[0] = x0
         for k in range(N):
             y = np.array(x0, copy=True)
@@ -683,7 +683,7 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
             maxfun = np.inf
 
     one2np1 = list(range(1, N + 1))
-    fsim = np.zeros((N + 1,), float)
+    fsim = np.empty((N + 1,), float)
 
     for k in range(N + 1):
         fsim[k] = func(sim[k])
@@ -3236,8 +3236,8 @@ def brute(func, ranges, args=(), Ns=20, full_output=0, finish=fmin,
     Nshape = shape(Jout)
 
     indx = argmin(Jout.ravel(), axis=-1)
-    Nindx = zeros(N, int)
-    xmin = zeros(N, float)
+    Nindx = np.empty(N, int)
+    xmin = np.empty(N, float)
     for k in range(N - 1, -1, -1):
         thisN = Nshape[k]
         Nindx[k] = indx % Nshape[k]

--- a/scipy/signal/_peak_finding.py
+++ b/scipy/signal/_peak_finding.py
@@ -1168,7 +1168,7 @@ def _filter_ridge_lines(cwt, ridge_lines, window_size=None, min_length=None,
 
     # Filter based on SNR
     row_one = cwt[0, :]
-    noises = np.zeros_like(row_one)
+    noises = np.empty_like(row_one)
     for ind, val in enumerate(row_one):
         window_start = max(ind - hf_window, 0)
         window_end = min(ind + hf_window + odd, num_points)

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -1101,7 +1101,7 @@ def zpk2tf(z, p, k):
     k = atleast_1d(k)
     if len(z.shape) > 1:
         temp = poly(z[0])
-        b = zeros((z.shape[0], z.shape[1] + 1), temp.dtype.char)
+        b = np.empty((z.shape[0], z.shape[1] + 1), temp.dtype.char)
         if len(k) == 1:
             k = [k[0]] * z.shape[0]
         for i in range(z.shape[0]):
@@ -1864,8 +1864,8 @@ def lp2bp(b, a, wo=1.0, bw=1.0):
     ma = max([N, D])
     Np = N + ma
     Dp = D + ma
-    bprime = numpy.zeros(Np + 1, artype)
-    aprime = numpy.zeros(Dp + 1, artype)
+    bprime = numpy.empty(Np + 1, artype)
+    aprime = numpy.empty(Dp + 1, artype)
     wosq = wo * wo
     for j in range(Np + 1):
         val = 0.0
@@ -1951,8 +1951,8 @@ def lp2bs(b, a, wo=1.0, bw=1.0):
     M = max([N, D])
     Np = M + M
     Dp = M + M
-    bprime = numpy.zeros(Np + 1, artype)
-    aprime = numpy.zeros(Dp + 1, artype)
+    bprime = numpy.empty(Np + 1, artype)
+    aprime = numpy.empty(Dp + 1, artype)
     wosq = wo * wo
     for j in range(Np + 1):
         val = 0.0
@@ -2031,8 +2031,8 @@ def bilinear(b, a, fs=1.0):
     M = max([N, D])
     Np = M
     Dp = M
-    bprime = numpy.zeros(Np + 1, artype)
-    aprime = numpy.zeros(Dp + 1, artype)
+    bprime = numpy.empty(Np + 1, artype)
+    aprime = numpy.empty(Dp + 1, artype)
     for j in range(Np + 1):
         val = 0.0
         for i in range(N + 1):
@@ -3638,7 +3638,7 @@ def buttord(wp, ws, gpass, gstop, analog=False, fs=None):
     elif filter_type == 2:  # high
         WN = passb / W0
     elif filter_type == 3:  # stop
-        WN = numpy.zeros(2, float)
+        WN = numpy.empty(2, float)
         discr = sqrt((passb[1] - passb[0]) ** 2 +
                      4 * W0 ** 2 * passb[0] * passb[1])
         WN[0] = ((passb[1] - passb[0]) + discr) / (2 * W0)
@@ -3947,13 +3947,13 @@ def cheb2ord(wp, ws, gpass, gstop, analog=False, fs=None):
     elif filter_type == 2:
         nat = passb * new_freq
     elif filter_type == 3:
-        nat = numpy.zeros(2, float)
+        nat = numpy.empty(2, float)
         nat[0] = (new_freq / 2.0 * (passb[0] - passb[1]) +
                   sqrt(new_freq ** 2 * (passb[1] - passb[0]) ** 2 / 4.0 +
                        passb[1] * passb[0]))
         nat[1] = passb[1] * passb[0] / nat[0]
     elif filter_type == 4:
-        nat = numpy.zeros(2, float)
+        nat = numpy.empty(2, float)
         nat[0] = (1.0 / (2.0 * new_freq) * (passb[0] - passb[1]) +
                   sqrt((passb[1] - passb[0]) ** 2 / (4.0 * new_freq ** 2) +
                        passb[1] * passb[0]))
@@ -5032,8 +5032,8 @@ def gammatone(freq, ftype, order=None, numtaps=None, fs=None):
         g = np.abs(g)
 
         # Create empty filter coefficient lists
-        b = np.zeros((5))
-        a = np.zeros((9))
+        b = np.empty((5))
+        a = np.empty((9))
 
         # Calculate the numerator coefficients
         b[0] = (T ** 4) / g

--- a/scipy/signal/lti_conversion.py
+++ b/scipy/signal/lti_conversion.py
@@ -274,7 +274,7 @@ def ss2tf(A, B, C, D, input=0):
 
     num_states = A.shape[0]
     type_test = A[:, 0] + B[:, 0] + C[0, :] + D
-    num = numpy.zeros((nout, num_states + 1), type_test.dtype)
+    num = numpy.empty((nout, num_states + 1), type_test.dtype)
     for k in range(nout):
         Ck = atleast_2d(C[k, :])
         num[k] = poly(A - dot(B, Ck)) + (D[k] - 1) * den

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -2059,7 +2059,7 @@ def lsim(system, U, T, X0=None, interp=True):
     n_steps = T.size
     if X0 is None:
         X0 = zeros(n_states, sys.A.dtype)
-    xout = zeros((n_steps, n_states), sys.A.dtype)
+    xout = np.empty((n_steps, n_states), sys.A.dtype)
 
     if T[0] == 0:
         xout[0] = X0

--- a/scipy/signal/wavelets.py
+++ b/scipy/signal/wavelets.py
@@ -139,7 +139,7 @@ def cascade(hk, J=7):
 
     indx1 = np.clip(2 * nn - kk, -1, N + 1)
     indx2 = np.clip(2 * nn - kk + 1, -1, N + 1)
-    m = np.zeros((2, 2, N, N), 'd')
+    m = np.empty((2, 2, N, N), 'd')
     m[0, 0] = np.take(thk, indx1, 0)
     m[0, 1] = np.take(thk, indx2, 0)
     m[1, 0] = np.take(tgk, indx1, 0)
@@ -465,7 +465,7 @@ def cwt(data, wavelet, widths, dtype=None, **kwargs):
         else:
             dtype = np.float64
 
-    output = np.zeros((len(widths), len(data)), dtype=dtype)
+    output = np.empty((len(widths), len(data)), dtype=dtype)
     for ind, width in enumerate(widths):
         N = np.min([10 * width, len(data)])
         # the conditional block below and the window_size

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -548,8 +548,7 @@ def dijkstra(csgraph, directed=True, indices=None,
         dist_matrix = np.full(N, np.inf, dtype=DTYPE)
         dist_matrix[indices] = 0
     else:
-        dist_matrix = np.zeros((len(indices), N), dtype=DTYPE)
-        dist_matrix.fill(np.inf)
+        dist_matrix = np.full((len(indices), N), np.inf, dtype=DTYPE)
         dist_matrix[np.arange(len(indices)), indices] = 0
 
     #------------------------------

--- a/scipy/spatial/_voronoi.pyx
+++ b/scipy/spatial/_voronoi.pyx
@@ -35,7 +35,7 @@ def sort_vertices_of_regions(int[:,::1] simplices, regions):
     cdef np.npy_intp current_simplex, current_vertex, remaining_count
     cdef np.npy_intp cs_identified, remaining_size
     cdef np.npy_intp[:] remaining
-    cdef np.npy_intp[:] sorted_vertices = np.zeros(max([len(region) for region
+    cdef np.npy_intp[:] sorted_vertices = np.empty(max([len(region) for region
                                                    in regions]),
                                                    dtype=np.intp)
 

--- a/scipy/spatial/qhull.pyx
+++ b/scipy/spatial/qhull.pyx
@@ -704,7 +704,7 @@ cdef class _Qhull:
             point_ndim += 1
 
         numpoints = self._qh.num_points
-        points = np.zeros((numpoints, point_ndim))
+        points = np.empty((numpoints, point_ndim))
 
         with nogil:
             point = self._qh.first_point
@@ -1100,7 +1100,7 @@ def _get_barycentric_transforms(np.ndarray[np.double_t, ndim=2] points,
     ndim = points.shape[1]
     nsimplex = simplices.shape[0]
 
-    T = np.zeros((ndim, ndim), dtype=np.double)
+    T = np.empty((ndim, ndim), dtype=np.double)
     Tinvs = np.zeros((nsimplex, ndim+1, ndim), dtype=np.double)
 
     # Maximum inverse condition number to allow: we want at least three

--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -676,8 +676,8 @@ def _bin_edges(sample, bins=None, range=None):
         smin = np.atleast_1d(np.array(sample.min(axis=0), float))
         smax = np.atleast_1d(np.array(sample.max(axis=0), float))
     else:
-        smin = np.zeros(Ndim)
-        smax = np.zeros(Ndim)
+        smin = np.empty(Ndim)
+        smax = np.empty(Ndim)
         for i in builtins.range(Ndim):
             smin[i], smax[i] = range[i]
 

--- a/scipy/stats/_ksstats.py
+++ b/scipy/stats/_ksstats.py
@@ -139,7 +139,7 @@ def _kolmogn_DMTW(n, d, cdf=True):
     # q = k-th row of H (actually i!/n^i*H^i)
     intm = np.arange(1, m + 1)
     v = 1.0 - h ** intm
-    w = np.zeros(m)
+    w = np.empty(m)
     fac = 1.0
     for j in intm:
         w[j - 1] = fac
@@ -228,9 +228,9 @@ def _kolmogn_Pomeranz(n, x, cdf=True):
     ceilf = (1 if f > 0 else 0)
     roundf = (1 if f > 0.5 else 0)
     npwrs = 2 * (ll + 1)    # Maximum number of powers needed in convolutions
-    gpower = np.zeros(npwrs)  # gpower = (g/n)^m/m!
-    twogpower = np.zeros(npwrs)  # twogpower = (2g/n)^m/m!
-    onem2gpower = np.zeros(npwrs)  # onem2gpower = ((1-2g)/n)^m/m!
+    gpower = np.empty(npwrs)  # gpower = (g/n)^m/m!
+    twogpower = np.empty(npwrs)  # twogpower = (2g/n)^m/m!
+    onem2gpower = np.empty(npwrs)  # onem2gpower = ((1-2g)/n)^m/m!
     # gpower etc are *almost* Poisson probs, just missing normalizing factor.
 
     gpower[0] = 1.0

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -1863,9 +1863,9 @@ class wishart_gen(multi_rv_generic):
         # gives us a 1-dim vector of determinants
 
         # Retrieve tr(scale^{-1} x)
-        log_det_x = np.zeros(x.shape[-1])
-        scale_inv_x = np.zeros(x.shape)
-        tr_scale_inv_x = np.zeros(x.shape[-1])
+        log_det_x = np.empty(x.shape[-1])
+        scale_inv_x = np.empty(x.shape)
+        tr_scale_inv_x = np.empty(x.shape[-1])
         for i in range(x.shape[-1]):
             _, log_det_x[i] = self._cholesky_logdet(x[:, :, i])
             scale_inv_x[:, :, i] = scipy.linalg.cho_solve((C, True), x[:, :, i])
@@ -2509,13 +2509,13 @@ class invwishart_gen(wishart_gen):
         called directly; use 'logpdf' instead.
 
         """
-        log_det_x = np.zeros(x.shape[-1])
+        log_det_x = np.empty(x.shape[-1])
         x_inv = np.copy(x).T
         if dim > 1:
             _cho_inv_batch(x_inv)  # works in-place
         else:
             x_inv = 1./x_inv
-        tr_scale_x_inv = np.zeros(x.shape[-1])
+        tr_scale_x_inv = np.empty(x.shape[-1])
 
         for i in range(x.shape[-1]):
             C, lower = scipy.linalg.cho_factor(x[:, :, i], lower=True)

--- a/scipy/stats/kde.py
+++ b/scipy/stats/kde.py
@@ -603,7 +603,7 @@ class gaussian_kde(object):
 
         if m >= self.n:
             # there are more points than data, so loop over data
-            energy = zeros((self.n, m), dtype=float)
+            energy = np.empty((self.n, m), dtype=float)
             for i in range(self.n):
                 diff = self.dataset[:, i, newaxis] - points
                 tdiff = dot(self.inv_cov, diff)
@@ -612,7 +612,7 @@ class gaussian_kde(object):
                                b=self.weights / self._norm_factor, axis=1)
         else:
             # loop over points
-            result = zeros((m,), dtype=float)
+            result = np.empty((m,), dtype=float)
             for i in range(m):
                 diff = self.dataset - points[:, i, newaxis]
                 tdiff = dot(self.inv_cov, diff)

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -411,7 +411,7 @@ def _calc_uniform_order_statistic_medians(n):
     >>> plt.plot(x, pdfs[0], x, pdfs[1], x, pdfs[2], x, pdfs[3])
 
     """
-    v = np.zeros(n, dtype=np.float64)
+    v = np.empty(n, dtype=np.float64)
     v[-1] = 0.5**(1.0 / n)
     v[0] = 1 - v[-1]
     i = np.arange(2, n)
@@ -1148,7 +1148,7 @@ def boxcox_normmax(x, brack=(-2.0, 2.0), method='pearsonr'):
         return optimize.brent(_eval_mle, brack=brack, args=(x,))
 
     def _all(x, brack):
-        maxlog = np.zeros(2, dtype=float)
+        maxlog = np.empty(2, dtype=float)
         maxlog[0] = _pearsonr(x, brack)
         maxlog[1] = _mle(x, brack)
         return maxlog
@@ -2293,8 +2293,8 @@ def bartlett(*args):
     k = len(args)
     if k < 2:
         raise ValueError("Must enter at least two input sample vectors.")
-    Ni = zeros(k)
-    ssq = zeros(k, 'd')
+    Ni = np.empty(k)
+    ssq = np.empty(k, 'd')
     for j in range(k):
         Ni[j] = len(args[j])
         ssq[j] = np.var(args[j], ddof=1)
@@ -2406,8 +2406,8 @@ def levene(*args, **kwds):
         if np.asanyarray(args[j]).ndim > 1:
             raise ValueError('Samples must be one-dimensional.')
 
-    Ni = zeros(k)
-    Yci = zeros(k, 'd')
+    Ni = np.empty(k)
+    Yci = np.empty(k, 'd')
 
     if center not in ['mean', 'median', 'trimmed']:
         raise ValueError("Keyword argument <center> must be 'mean', 'median'"
@@ -2433,7 +2433,7 @@ def levene(*args, **kwds):
         Zij[i] = abs(asarray(args[i]) - Yci[i])
 
     # compute Zbari
-    Zbari = zeros(k, 'd')
+    Zbari = np.empty(k, 'd')
     Zbar = 0.0
     for i in range(k):
         Zbari[i] = np.mean(Zij[i], axis=0)
@@ -2801,7 +2801,7 @@ def mood(x, y, axis=0):
     # Generalized to the n-dimensional case by adding the axis argument, and
     # using for loops, since rankdata is not vectorized.  For improving
     # performance consider vectorizing rankdata function.
-    all_ranks = np.zeros_like(xy)
+    all_ranks = np.empty_like(xy)
     for j in range(xy.shape[1]):
         all_ranks[:, j] = stats.rankdata(xy[:, j])
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -567,7 +567,7 @@ def mode(a, axis=0, nan_policy='propagate'):
 
     inds = np.ndindex(a_view.shape[:-1])
     modes = np.empty(a_view.shape[:-1], dtype=a.dtype)
-    counts = np.zeros(a_view.shape[:-1], dtype=np.int_)
+    counts = np.empty(a_view.shape[:-1], dtype=np.int_)
     for ind in inds:
         modes[ind], counts[ind] = _mode1D(a_view[ind])
     newshape = list(a.shape)


### PR DESCRIPTION
Requesting an uninitialized array from NumPy (instead of requesting that NumPy initialize the array to zero) saves a little time if the array has to be initialized to other values anyway.

To facilitate code review, in this pull request I have only changed the calls to np.zeros that are clearly safe to replace.