### PR TITLE
DOC: Minor RST section renaming.

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -6468,8 +6468,8 @@ def _count_paths_outside_method(m, n, g, h):
         The number of paths that go low.
         The calculation may overflow - check for a finite answer.
 
-    Exceptions
-    ----------
+    Raises
+    ------
     FloatingPointError: Raised if the intermediate computation goes outside
     the range of a float.
 


### PR DESCRIPTION
This this the only function as far as I can tel, where this is named
Exception and not Raises (which is recommended by the numpy doc format).