### PR TITLE
DOC: special: Set Axes3D rect to avoid clipping labels in plot.

### DIFF
--- a/doc/source/tutorial/special.rst
+++ b/doc/source/tutorial/special.rst
@@ -54,6 +54,8 @@ drum head anchored at the edge:
    >>> ax.plot_surface(x, y, z, rstride=1, cstride=1, cmap='RdBu_r', vmin=-0.5, vmax=0.5)
    >>> ax.set_xlabel('X')
    >>> ax.set_ylabel('Y')
+   >>> ax.set_xticks(np.arange(-1, 1.1, 0.5))
+   >>> ax.set_yticks(np.arange(-1, 1.1, 0.5))
    >>> ax.set_zlabel('Z')
    >>> plt.show()
 

--- a/doc/source/tutorial/special.rst
+++ b/doc/source/tutorial/special.rst
@@ -50,7 +50,7 @@ drum head anchored at the edge:
    >>> from mpl_toolkits.mplot3d import Axes3D
    >>> from matplotlib import cm
    >>> fig = plt.figure()
-   >>> ax = Axes3D(fig)
+   >>> ax = Axes3D(fig, rect=(0, 0.05, 0.95, 0.95))
    >>> ax.plot_surface(x, y, z, rstride=1, cstride=1, cmap='RdBu_r', vmin=-0.5, vmax=0.5)
    >>> ax.set_xlabel('X')
    >>> ax.set_ylabel('Y')


### PR DESCRIPTION
This fixes the clipping of the axis ticks and labels in the
Bessel function plot in the `special` tutorial.
