### PR TITLE
Fix large sparse nnz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,6 +186,7 @@ scipy/linalg/cython_blas.pyx
 scipy/linalg/cython_lapack.pxd
 scipy/linalg/cython_lapack.pyx
 scipy/linalg/src/id_dist/src/*_subr_*.f
+scipy/linalg/_matfuncs_sqrtm_triu.c
 scipy/ndimage/src/_ni_label.c
 scipy/ndimage/src/_cytest.c
 scipy/optimize/_bglu_dense.c

--- a/scipy/sparse/sparsetools/csr.h
+++ b/scipy/sparse/sparsetools/csr.h
@@ -586,7 +586,7 @@ npy_intp csr_matmat_maxnnz(const I n_row,
 
         npy_intp next_nnz = nnz + row_nnz;
 
-        if (row_nnz > NPY_MAX_INTP - nnz || next_nnz != (I)next_nnz) {
+        if (row_nnz > NPY_MAX_INTP - nnz) {
             /*
              * Index overflowed. Note that row_nnz <= n_col and cannot overflow
              */


### PR DESCRIPTION
Consider the case of A @ B where A and B have 32 bit index arrays, but their product has nnz > INT32_MAX. The check that nnz will fit into 32bit is a bug because we are going to use the new nnz value to decide that we need 64 bit indexing arrays.

This was overlooked in gh-11478.

This is a probable fix for gh-12495.