### PR TITLE
DOC: Remove double section and too long header underline.

### DIFF
--- a/scipy/interpolate/_fitpack_impl.py
+++ b/scipy/interpolate/_fitpack_impl.py
@@ -390,13 +390,6 @@ def splrep(x, y, w=None, xb=None, xe=None, k=3, task=0, s=None, t=None,
     msg : str, optional
         A message corresponding to the integer flag, ier.
 
-    Notes
-    -----
-    See splev for evaluation of the spline and its derivatives.
-
-    The user is responsible for assuring that the values of *x* are unique.
-    Otherwise, *splrep* will not return sensible results.
-
     See Also
     --------
     UnivariateSpline, BivariateSpline
@@ -407,6 +400,9 @@ def splrep(x, y, w=None, xb=None, xe=None, k=3, task=0, s=None, t=None,
     -----
     See splev for evaluation of the spline and its derivatives. Uses the
     FORTRAN routine curfit from FITPACK.
+
+    The user is responsible for assuring that the values of *x* are unique.
+    Otherwise, *splrep* will not return sensible results.
 
     If provided, knots `t` must satisfy the Schoenberg-Whitney conditions,
     i.e., there must be a subset of data points ``x[j]`` such that

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -3322,7 +3322,7 @@ class special_ortho_group_gen(multi_rv_generic):
         Dimension of matrices
 
     Notes
-    ----------
+    -----
     This class is wrapping the random_rot code from the MDP Toolkit,
     https://github.com/mdp-toolkit/mdp-toolkit
 
@@ -3479,7 +3479,7 @@ class ortho_group_gen(multi_rv_generic):
         Dimension of matrices
 
     Notes
-    ----------
+    -----
     This class is closely related to `special_ortho_group`.
 
     Some care is taken to avoid numerical error, as per the paper by Mezzadri.
@@ -3586,7 +3586,7 @@ class random_correlation_gen(multi_rv_generic):
         Eigenvalues of correlation matrix.
 
     Notes
-    ----------
+    -----
 
     Generates a random correlation matrix following a numerically stable
     algorithm spelled out by Davies & Higham. This algorithm uses a single O(N)
@@ -3777,7 +3777,7 @@ class unitary_group_gen(multi_rv_generic):
         Dimension of matrices
 
     Notes
-    ----------
+    -----
     This class is similar to `ortho_group`.
 
     References


### PR DESCRIPTION
Numpydoc choke on the double section, the longer header is mostly
aesthetic.
