### PR TITLE
MAINT: allow graceful docs re-upload

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -101,7 +101,7 @@ upload:
 	# SSH must be correctly configured for this to work.
 	# Assumes that ``make dist`` was already run
 	# Example usage: ``make upload USERNAME=rgommers RELEASE=0.17.0``
-	ssh $(USERNAME)@new.scipy.org mkdir $(UPLOAD_DIR)
+	ssh $(USERNAME)@new.scipy.org mkdir -p $(UPLOAD_DIR)
 	scp build/dist.tar.gz $(USERNAME)@new.scipy.org:$(UPLOAD_DIR)
 	ssh $(USERNAME)@new.scipy.org tar xvC $(UPLOAD_DIR) \
 	    -zf $(UPLOAD_DIR)/dist.tar.gz


### PR DESCRIPTION
* use `mkdir -p` instead of plain `mkdir` in the
`make upload ...` SciPy docs upload workflow so
that requests to rebuild specific point releases
do not fail because the target directory already
exists on the docs server

* this was required to handle the request here:
https://github.com/scipy/scipy/issues/11971#issuecomment-656950387
