### PR TITLE
ENH: Add norm={"forward", "backward"} to `scipy.fft`

### DIFF
--- a/scipy/fft/_basic.py
+++ b/scipy/fft/_basic.py
@@ -47,6 +47,10 @@ def fft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
         the forward transforms and scaling by ``1/n`` on the `ifft`.
         "forward" instead applies the ``1/n`` factor on the forward tranform.
         For ``norm="ortho"``, both directions are scaled by ``1/sqrt(n)``.
+
+        .. versionadded:: 1.6.0
+           ``norm={"forward", "backward"}`` options were added
+
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
         See the notes below for more details.
@@ -196,7 +200,7 @@ def ifft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
         Axis over which to compute the inverse DFT. If not given, the last
         axis is used.
     norm : {"backward", "ortho", "forward"}, optional
-        Normalization mode (see `fft`). Default is "backward".
+       Normalization mode (see `fft`). Default is "backward".
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.

--- a/scipy/fft/_basic.py
+++ b/scipy/fft/_basic.py
@@ -200,7 +200,7 @@ def ifft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
         Axis over which to compute the inverse DFT. If not given, the last
         axis is used.
     norm : {"backward", "ortho", "forward"}, optional
-       Normalization mode (see `fft`). Default is "backward".
+        Normalization mode (see `fft`). Default is "backward".
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.

--- a/scipy/fft/_basic.py
+++ b/scipy/fft/_basic.py
@@ -42,9 +42,10 @@ def fft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
     axis : int, optional
         Axis over which to compute the FFT. If not given, the last axis is
         used.
-    norm : {None, "ortho"}, optional
-        Normalization mode. Default is None, meaning no normalization on the
-        forward transforms and scaling by ``1/n`` on the `ifft`.
+    norm : {"backward", "ortho", "forward"}, optional
+        Normalization mode. Default is "backward", meaning no normalization on
+        the forward transforms and scaling by ``1/n`` on the `ifft`.
+        "forward" instead applies the ``1/n`` factor on the forward tranform.
         For ``norm="ortho"``, both directions are scaled by ``1/sqrt(n)``.
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
@@ -194,8 +195,8 @@ def ifft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
     axis : int, optional
         Axis over which to compute the inverse DFT. If not given, the last
         axis is used.
-    norm : {None, "ortho"}, optional
-        Normalization mode (see `fft`). Default is None.
+    norm : {"backward", "ortho", "forward"}, optional
+        Normalization mode (see `fft`). Default is "backward".
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
@@ -285,8 +286,8 @@ def rfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
     axis : int, optional
         Axis over which to compute the FFT. If not given, the last axis is
         used.
-    norm : {None, "ortho"}, optional
-        Normalization mode (see `fft`). Default is None.
+    norm : {"backward", "ortho", "forward"}, optional
+        Normalization mode (see `fft`). Default is "backward".
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
@@ -388,8 +389,8 @@ def irfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
     axis : int, optional
         Axis over which to compute the inverse FFT. If not given, the last
         axis is used.
-    norm : {None, "ortho"}, optional
-        Normalization mode (see `fft`). Default is None.
+    norm : {"backward", "ortho", "forward"}, optional
+        Normalization mode (see `fft`). Default is "backward".
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
@@ -479,8 +480,8 @@ def hfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
     axis : int, optional
         Axis over which to compute the FFT. If not given, the last
         axis is used.
-    norm : {None, "ortho"}, optional
-        Normalization mode (see `fft`). Default is None.
+    norm : {"backward", "ortho", "forward"}, optional
+        Normalization mode (see `fft`). Default is "backward".
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
         See `fft` for more details.
@@ -559,8 +560,8 @@ def ihfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
     axis : int, optional
         Axis over which to compute the inverse FFT. If not given, the last
         axis is used.
-    norm : {None, "ortho"}, optional
-        Normalization mode (see `fft`). Default is None.
+    norm : {"backward", "ortho", "forward"}, optional
+        Normalization mode (see `fft`). Default is "backward".
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
         See `fft` for more details.
@@ -631,8 +632,8 @@ def fftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
     axes : sequence of ints, optional
         Axes over which to compute the FFT. If not given, the last ``len(s)``
         axes are used, or all axes if `s` is also not specified.
-    norm : {None, "ortho"}, optional
-        Normalization mode (see `fft`). Default is None.
+    norm : {"backward", "ortho", "forward"}, optional
+        Normalization mode (see `fft`). Default is "backward".
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
@@ -742,8 +743,8 @@ def ifftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
     axes : sequence of ints, optional
         Axes over which to compute the IFFT.  If not given, the last ``len(s)``
         axes are used, or all axes if `s` is also not specified.
-    norm : {None, "ortho"}, optional
-        Normalization mode (see `fft`). Default is None.
+    norm : {"backward", "ortho", "forward"}, optional
+        Normalization mode (see `fft`). Default is "backward".
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
@@ -837,8 +838,8 @@ def fft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, *
     axes : sequence of ints, optional
         Axes over which to compute the FFT. If not given, the last two axes are
         used.
-    norm : {None, "ortho"}, optional
-        Normalization mode (see `fft`). Default is None.
+    norm : {"backward", "ortho", "forward"}, optional
+        Normalization mode (see `fft`). Default is "backward".
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
@@ -942,8 +943,8 @@ def ifft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, 
     axes : sequence of ints, optional
         Axes over which to compute the FFT. If not given, the last two
         axes are used.
-    norm : {None, "ortho"}, optional
-        Normalization mode (see `fft`). Default is None.
+    norm : {"backward", "ortho", "forward"}, optional
+        Normalization mode (see `fft`). Default is "backward".
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
@@ -1032,8 +1033,8 @@ def rfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
     axes : sequence of ints, optional
         Axes over which to compute the FFT. If not given, the last ``len(s)``
         axes are used, or all axes if `s` is also not specified.
-    norm : {None, "ortho"}, optional
-        Normalization mode (see `fft`). Default is None.
+    norm : {"backward", "ortho", "forward"}, optional
+        Normalization mode (see `fft`). Default is "backward".
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
@@ -1117,8 +1118,8 @@ def rfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, 
         Shape of the FFT.
     axes : sequence of ints, optional
         Axes over which to compute the FFT.
-    norm : {None, "ortho"}, optional
-        Normalization mode (see `fft`). Default is None.
+    norm : {"backward", "ortho", "forward"}, optional
+        Normalization mode (see `fft`). Default is "backward".
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
@@ -1187,8 +1188,8 @@ def irfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
     axes : sequence of ints, optional
         Axes over which to compute the inverse FFT. If not given, the last
         `len(s)` axes are used, or all axes if `s` is also not specified.
-    norm : {None, "ortho"}, optional
-        Normalization mode (see `fft`). Default is None.
+    norm : {"backward", "ortho", "forward"}, optional
+        Normalization mode (see `fft`). Default is "backward".
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
@@ -1274,8 +1275,8 @@ def irfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None,
     axes : sequence of ints, optional
         The axes over which to compute the inverse fft.
         Default is the last two axes.
-    norm : {None, "ortho"}, optional
-        Normalization mode (see `fft`). Default is None.
+    norm : {"backward", "ortho", "forward"}, optional
+        Normalization mode (see `fft`). Default is "backward".
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
@@ -1340,8 +1341,8 @@ def hfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
     axes : sequence of ints, optional
         Axes over which to compute the inverse FFT. If not given, the last
         `len(s)` axes are used, or all axes if `s` is also not specified.
-    norm : {None, "ortho"}, optional
-        Normalization mode (see `fft`). Default is None.
+    norm : {"backward", "ortho", "forward"}, optional
+        Normalization mode (see `fft`). Default is "backward".
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
@@ -1436,8 +1437,8 @@ def hfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, 
         Shape of the real output.
     axes : sequence of ints, optional
         Axes over which to compute the FFT.
-    norm : {None, "ortho"}, optional
-        Normalization mode (see `fft`). Default is None.
+    norm : {"backward", "ortho", "forward"}, optional
+        Normalization mode (see `fft`). Default is "backward".
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
         See `fft` for more details.
@@ -1497,8 +1498,8 @@ def ihfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
     axes : sequence of ints, optional
         Axes over which to compute the FFT. If not given, the last ``len(s)``
         axes are used, or all axes if `s` is also not specified.
-    norm : {None, "ortho"}, optional
-        Normalization mode (see `fft`). Default is None.
+    norm : {"backward", "ortho", "forward"}, optional
+        Normalization mode (see `fft`). Default is "backward".
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.
@@ -1579,8 +1580,8 @@ def ihfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None,
     axes : sequence of ints, optional
         The axes over which to compute the inverse fft.
         Default is the last two axes.
-    norm : {None, "ortho"}, optional
-        Normalization mode (see `fft`). Default is None.
+    norm : {"backward", "ortho", "forward"}, optional
+        Normalization mode (see `fft`). Default is "backward".
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
         See :func:`fft` for more details.

--- a/scipy/fft/_pocketfft/helper.py
+++ b/scipy/fft/_pocketfft/helper.py
@@ -144,17 +144,18 @@ def _fix_shape_1d(x, n, axis):
     return _fix_shape(x, (n,), (axis,))
 
 
+_NORM_MAP = { None: 0, 'backward': 0, 'ortho': 1, 'forward': 2}
+
+
 def _normalization(norm, forward):
     """Returns the pypocketfft normalization mode from the norm argument"""
-
-    if norm is None:
-        return 0 if forward else 2
-
-    if norm == 'ortho':
-        return 1
-
-    raise ValueError(
-        "Invalid norm value {}, should be None or \"ortho\".".format(norm))
+    try:
+        inorm = _NORM_MAP[norm]
+        return inorm if forward else (2 - inorm)
+    except KeyError:
+        raise ValueError(
+            f'Invalid norm value {norm!r}, should '
+            'be "backward", "ortho" or "forward"') from None
 
 
 def _workers(workers):

--- a/scipy/fft/_pocketfft/helper.py
+++ b/scipy/fft/_pocketfft/helper.py
@@ -144,7 +144,7 @@ def _fix_shape_1d(x, n, axis):
     return _fix_shape(x, (n,), (axis,))
 
 
-_NORM_MAP = { None: 0, 'backward': 0, 'ortho': 1, 'forward': 2}
+_NORM_MAP = {None: 0, 'backward': 0, 'ortho': 1, 'forward': 2}
 
 
 def _normalization(norm, forward):

--- a/scipy/fft/_pocketfft/tests/test_basic.py
+++ b/scipy/fft/_pocketfft/tests/test_basic.py
@@ -1002,7 +1002,8 @@ class TestOverwrite(object):
 def test_invalid_norm(func):
     x = np.arange(10, dtype=float)
     with assert_raises(ValueError,
-                       match='Invalid norm value o, should be None or "ortho"'):
+                       match='Invalid norm value \'o\', should be'
+                             ' "backward", "ortho" or "forward"'):
         func(x, norm='o')
 
 

--- a/scipy/fft/_pocketfft/tests/test_real_transforms.py
+++ b/scipy/fft/_pocketfft/tests/test_real_transforms.py
@@ -414,7 +414,7 @@ def test_overwrite(routine, dtype, shape, axis, type, norm, overwrite_x):
 class Test_DCTN_IDCTN(object):
     dec = 14
     dct_type = [1, 2, 3, 4]
-    norms = [None, 'ortho']
+    norms = [None, 'backward', 'ortho', 'forward']
     rstate = np.random.RandomState(1234)
     shape = (32, 16)
     data = rstate.randn(*shape)
@@ -443,7 +443,7 @@ class Test_DCTN_IDCTN(object):
 
     @pytest.mark.parametrize('funcn,func', [(idctn, idct), (idstn, idst)])
     @pytest.mark.parametrize('dct_type', dct_type)
-    @pytest.mark.parametrize('norm', [None, 'ortho'])
+    @pytest.mark.parametrize('norm', norms)
     def test_idctn_vs_2d_reference(self, funcn, func, dct_type, norm):
         fdata = dctn(self.data, type=dct_type, norm=norm)
         y1 = funcn(fdata, type=dct_type, norm=norm)

--- a/scipy/fft/_realtransforms.py
+++ b/scipy/fft/_realtransforms.py
@@ -29,8 +29,8 @@ def dctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
     axes : int or array_like of ints or None, optional
         Axes over which the DCT is computed. If not given, the last ``len(s)``
         axes are used, or all axes if `s` is also not specified.
-    norm : {None, 'ortho'}, optional
-        Normalization mode (see Notes). Default is None.
+    norm : {"backward", "ortho", "forward"}, optional
+        Normalization mode (see Notes). Default is "backward".
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional
@@ -87,8 +87,8 @@ def idctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
     axes : int or array_like of ints or None, optional
         Axes over which the IDCT is computed. If not given, the last ``len(s)``
         axes are used, or all axes if `s` is also not specified.
-    norm : {None, 'ortho'}, optional
-        Normalization mode (see Notes). Default is None.
+    norm : {"backward", "ortho", "forward"}, optional
+        Normalization mode (see Notes). Default is "backward".
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional
@@ -145,8 +145,8 @@ def dstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
     axes : int or array_like of ints or None, optional
         Axes over which the DST is computed. If not given, the last ``len(s)``
         axes are used, or all axes if `s` is also not specified.
-    norm : {None, 'ortho'}, optional
-        Normalization mode (see Notes). Default is None.
+    norm : {"backward", "ortho", "forward"}, optional
+        Normalization mode (see Notes). Default is "backward".
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional
@@ -203,8 +203,8 @@ def idstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
     axes : int or array_like of ints or None, optional
         Axes over which the IDST is computed. If not given, the last ``len(s)``
         axes are used, or all axes if `s` is also not specified.
-    norm : {None, 'ortho'}, optional
-        Normalization mode (see Notes). Default is None.
+    norm : {"backward", "ortho", "forward"}, optional
+        Normalization mode (see Notes). Default is "backward".
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional
@@ -239,8 +239,7 @@ def idstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
 
 @_dispatch
 def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
-    r"""
-    Return the Discrete Cosine Transform of arbitrary type sequence x.
+    r"""Return the Discrete Cosine Transform of arbitrary type sequence x.
 
     Parameters
     ----------
@@ -255,8 +254,8 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
     axis : int, optional
         Axis along which the dct is computed; the default is over the
         last axis (i.e., ``axis=-1``).
-    norm : {None, 'ortho'}, optional
-        Normalization mode (see Notes). Default is None.
+    norm : {"backward", "ortho", "forward"}, optional
+        Normalization mode (see Notes). Default is "backward".
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional
@@ -278,9 +277,11 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
     For a single dimension array ``x``, ``dct(x, norm='ortho')`` is equal to
     MATLAB ``dct(x)``.
 
-    For ``norm=None``, there is no scaling on `dct` and the `idct` is scaled by
-    ``1/N`` where ``N`` is the "logical" size of the DCT. For ``norm='ortho'``
-    both directions are scaled by the same factor ``1/sqrt(N)``.
+    For ``norm="backward"``, there is no scaling on `dct` and the `idct` is
+    scaled by ``1/N`` where ``N`` is the "logical" size of the DCT. For
+    ``norm="forward"`` the ``1/N`` normalization is applied to the forward
+    `dct` instead and the `idct` is unnormalized. For ``norm='ortho'`` both
+    directions are scaled by the same factor of ``1/sqrt(N)``.
 
     There are, theoretically, 8 types of the DCT, only the first 4 types are
     implemented in SciPy.'The' DCT generally refers to DCT type 2, and 'the'
@@ -289,7 +290,7 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
     **Type I**
 
     There are several definitions of the DCT-I; we use the following
-    (for ``norm=None``)
+    (for ``norm="backward"``)
 
     .. math::
 
@@ -312,13 +313,13 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
     **Type II**
 
     There are several definitions of the DCT-II; we use the following
-    (for ``norm=None``)
+    (for ``norm="backward"``)
 
     .. math::
 
        y_k = 2 \sum_{n=0}^{N-1} x_n \cos\left(\frac{\pi k(2n+1)}{2N} \right)
 
-    If ``norm='ortho'``, ``y[k]`` is multiplied by a scaling factor ``f``
+    If ``norm="ortho"``, ``y[k]`` is multiplied by a scaling factor ``f``
 
     .. math::
        f = \begin{cases}
@@ -330,13 +331,14 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
 
     **Type III**
 
-    There are several definitions, we use the following (for ``norm=None``)
+    There are several definitions, we use the following (for
+    ``norm="backward"``)
 
     .. math::
 
        y_k = x_0 + 2 \sum_{n=1}^{N-1} x_n \cos\left(\frac{\pi(2k+1)n}{2N}\right)
 
-    or, for ``norm='ortho'``
+    or, for ``norm="ortho"``
 
     .. math::
 
@@ -350,13 +352,13 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
     **Type IV**
 
     There are several definitions of the DCT-IV; we use the following
-    (for ``norm=None``)
+    (for ``norm="backward"``)
 
     .. math::
 
        y_k = 2 \sum_{n=0}^{N-1} x_n \cos\left(\frac{\pi(2k+1)(2n+1)}{4N} \right)
 
-    If ``norm='ortho'``, ``y[k]`` is multiplied by a scaling factor ``f``
+    If ``norm="ortho"``, ``y[k]`` is multiplied by a scaling factor ``f``
 
     .. math::
 
@@ -406,8 +408,8 @@ def idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
     axis : int, optional
         Axis along which the idct is computed; the default is over the
         last axis (i.e., ``axis=-1``).
-    norm : {None, 'ortho'}, optional
-        Normalization mode (see Notes). Default is None.
+    norm : {"backward", "ortho", "forward"}, optional
+        Normalization mode (see Notes). Default is "backward".
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional
@@ -453,8 +455,7 @@ def idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
 
 @_dispatch
 def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
-    r"""
-    Return the Discrete Sine Transform of arbitrary type sequence x.
+    r"""Return the Discrete Sine Transform of arbitrary type sequence x.
 
     Parameters
     ----------
@@ -469,8 +470,8 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
     axis : int, optional
         Axis along which the dst is computed; the default is over the
         last axis (i.e., ``axis=-1``).
-    norm : {None, 'ortho'}, optional
-        Normalization mode (see Notes). Default is None.
+    norm : {"backward", "ortho", "forward"}, optional
+        Normalization mode (see Notes). Default is "backward".
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional
@@ -491,7 +492,7 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
     -----
     For a single dimension array ``x``.
 
-    For ``norm=None``, there is no scaling on the `dst` and the `idst` is
+    For ``norm="backward"``, there is no scaling on the `dst` and the `idst` is
     scaled by ``1/N`` where ``N`` is the "logical" size of the DST. For
     ``norm='ortho'`` both directions are scaled by the same factor
     ``1/sqrt(N)``.
@@ -502,8 +503,9 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
 
     **Type I**
 
-    There are several definitions of the DST-I; we use the following
-    for ``norm=None``. DST-I assumes the input is odd around `n=-1` and `n=N`.
+    There are several definitions of the DST-I; we use the following for
+    ``norm="backward"``. DST-I assumes the input is odd around `n=-1` and
+    `n=N`.
 
     .. math::
 
@@ -516,7 +518,7 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
     **Type II**
 
     There are several definitions of the DST-II; we use the following for
-    ``norm=None``. DST-II assumes the input is odd around `n=-1/2` and
+    ``norm="backward"``. DST-II assumes the input is odd around `n=-1/2` and
     `n=N-1/2`; the output is odd around :math:`k=-1` and even around `k=N-1`
 
     .. math::
@@ -534,8 +536,8 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
     **Type III**
 
     There are several definitions of the DST-III, we use the following (for
-    ``norm=None``). DST-III assumes the input is odd around `n=-1` and even
-    around `n=N-1`
+    ``norm="backward"``). DST-III assumes the input is odd around `n=-1` and
+    even around `n=N-1`
 
     .. math::
 
@@ -549,8 +551,8 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
     **Type IV**
 
     There are several definitions of the DST-IV, we use the following (for
-    ``norm=None``). DST-IV assumes the input is odd around `n=-0.5` and even
-    around `n=N-0.5`
+    ``norm="backward"``). DST-IV assumes the input is odd around `n=-0.5` and
+    even around ``n=N-0.5``
 
     .. math::
 
@@ -587,8 +589,8 @@ def idst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
     axis : int, optional
         Axis along which the idst is computed; the default is over the
         last axis (i.e., ``axis=-1``).
-    norm : {None, 'ortho'}, optional
-        Normalization mode (see Notes). Default is None.
+    norm : {"backward", "ortho", "forward"}, optional
+        Normalization mode (see Notes). Default is "backward".
     overwrite_x : bool, optional
         If True, the contents of `x` can be destroyed; the default is False.
     workers : int, optional

--- a/scipy/fft/tests/test_numpy.py
+++ b/scipy/fft/tests/test_numpy.py
@@ -37,50 +37,64 @@ class TestFFT1D(object):
 
     def test_fft(self):
         x = random(30) + 1j*random(30)
-        assert_array_almost_equal(fft1(x), fft.fft(x))
-        assert_array_almost_equal(fft1(x) / np.sqrt(30),
+        expect = fft1(x)
+        assert_array_almost_equal(expect, fft.fft(x))
+        assert_array_almost_equal(expect, fft.fft(x, norm="backward"))
+        assert_array_almost_equal(expect / np.sqrt(30),
                                   fft.fft(x, norm="ortho"))
+        assert_array_almost_equal(expect / 30, fft.fft(x, norm="forward"))
 
     def test_ifft(self):
         x = random(30) + 1j*random(30)
         assert_array_almost_equal(x, fft.ifft(fft.fft(x)))
-        assert_array_almost_equal(
-            x, fft.ifft(fft.fft(x, norm="ortho"), norm="ortho"))
+        for norm in ["backward", "ortho", "forward"]:
+            assert_array_almost_equal(
+                x, fft.ifft(fft.fft(x, norm=norm), norm=norm))
 
     def test_fft2(self):
         x = random((30, 20)) + 1j*random((30, 20))
-        assert_array_almost_equal(fft.fft(fft.fft(x, axis=1), axis=0),
-                                  fft.fft2(x))
-        assert_array_almost_equal(fft.fft2(x) / np.sqrt(30 * 20),
+        expect = fft.fft(fft.fft(x, axis=1), axis=0)
+        assert_array_almost_equal(expect, fft.fft2(x))
+        assert_array_almost_equal(expect, fft.fft2(x, norm="backward"))
+        assert_array_almost_equal(expect / np.sqrt(30 * 20),
                                   fft.fft2(x, norm="ortho"))
+        assert_array_almost_equal(expect / (30 * 20),
+                                  fft.fft2(x, norm="forward"))
 
     def test_ifft2(self):
         x = random((30, 20)) + 1j*random((30, 20))
-        assert_array_almost_equal(fft.ifft(fft.ifft(x, axis=1), axis=0),
-                                  fft.ifft2(x))
-        assert_array_almost_equal(fft.ifft2(x) * np.sqrt(30 * 20),
+        expect = fft.ifft(fft.ifft(x, axis=1), axis=0)
+        assert_array_almost_equal(expect, fft.ifft2(x))
+        assert_array_almost_equal(expect, fft.ifft2(x, norm="backward"))
+        assert_array_almost_equal(expect * np.sqrt(30 * 20),
                                   fft.ifft2(x, norm="ortho"))
+        assert_array_almost_equal(expect * (30 * 20),
+                                  fft.ifft2(x, norm="forward"))
 
     def test_fftn(self):
         x = random((30, 20, 10)) + 1j*random((30, 20, 10))
-        assert_array_almost_equal(
-            fft.fft(fft.fft(fft.fft(x, axis=2), axis=1), axis=0),
-            fft.fftn(x))
-        assert_array_almost_equal(fft.fftn(x) / np.sqrt(30 * 20 * 10),
+        expect = fft.fft(fft.fft(fft.fft(x, axis=2), axis=1), axis=0)
+        assert_array_almost_equal(expect, fft.fftn(x))
+        assert_array_almost_equal(expect, fft.fftn(x, norm="backward"))
+        assert_array_almost_equal(expect / np.sqrt(30 * 20 * 10),
                                   fft.fftn(x, norm="ortho"))
+        assert_array_almost_equal(expect / (30 * 20 * 10),
+                                  fft.fftn(x, norm="forward"))
 
     def test_ifftn(self):
         x = random((30, 20, 10)) + 1j*random((30, 20, 10))
-        assert_array_almost_equal(
-            fft.ifft(fft.ifft(fft.ifft(x, axis=2), axis=1), axis=0),
-            fft.ifftn(x))
+        expect = fft.ifft(fft.ifft(fft.ifft(x, axis=2), axis=1), axis=0)
+        assert_array_almost_equal(expect, fft.ifftn(x))
+        assert_array_almost_equal(expect, fft.ifftn(x, norm="backward"))
         assert_array_almost_equal(fft.ifftn(x) * np.sqrt(30 * 20 * 10),
                                   fft.ifftn(x, norm="ortho"))
+        assert_array_almost_equal(expect * (30 * 20 * 10),
+                                  fft.ifftn(x, norm="forward"))
 
     def test_rfft(self):
-        x = random(30)
+        x = random(29)
         for n in [x.size, 2*x.size]:
-            for norm in [None, 'ortho']:
+            for norm in [None, "backward", "ortho", "forward"]:
                 assert_array_almost_equal(
                     fft.fft(x, n=n, norm=norm)[:(n//2 + 1)],
                     fft.rfft(x, n=n, norm=norm))
@@ -90,73 +104,98 @@ class TestFFT1D(object):
     def test_irfft(self):
         x = random(30)
         assert_array_almost_equal(x, fft.irfft(fft.rfft(x)))
-        assert_array_almost_equal(
-            x, fft.irfft(fft.rfft(x, norm="ortho"), norm="ortho"))
+        for norm in ["backward", "ortho", "forward"]:
+            assert_array_almost_equal(
+                x, fft.irfft(fft.rfft(x, norm=norm), norm=norm))
 
     def test_rfft2(self):
         x = random((30, 20))
-        assert_array_almost_equal(fft.fft2(x)[:, :11], fft.rfft2(x))
-        assert_array_almost_equal(fft.rfft2(x) / np.sqrt(30 * 20),
+        expect = fft.fft2(x)[:, :11]
+        assert_array_almost_equal(expect, fft.rfft2(x))
+        assert_array_almost_equal(expect, fft.rfft2(x, norm="backward"))
+        assert_array_almost_equal(expect / np.sqrt(30 * 20),
                                   fft.rfft2(x, norm="ortho"))
+        assert_array_almost_equal(expect / (30 * 20),
+                                  fft.rfft2(x, norm="forward"))
 
     def test_irfft2(self):
         x = random((30, 20))
         assert_array_almost_equal(x, fft.irfft2(fft.rfft2(x)))
-        assert_array_almost_equal(
-            x, fft.irfft2(fft.rfft2(x, norm="ortho"), norm="ortho"))
+        for norm in ["backward", "ortho", "forward"]:
+            assert_array_almost_equal(
+                x, fft.irfft2(fft.rfft2(x, norm=norm), norm=norm))
 
     def test_rfftn(self):
         x = random((30, 20, 10))
-        assert_array_almost_equal(fft.fftn(x)[:, :, :6], fft.rfftn(x))
-        assert_array_almost_equal(fft.rfftn(x) / np.sqrt(30 * 20 * 10),
+        expect = fft.fftn(x)[:, :, :6]
+        assert_array_almost_equal(expect, fft.rfftn(x))
+        assert_array_almost_equal(expect, fft.rfftn(x, norm="backward"))
+        assert_array_almost_equal(expect / np.sqrt(30 * 20 * 10),
                                   fft.rfftn(x, norm="ortho"))
+        assert_array_almost_equal(expect / (30 * 20 * 10),
+                                  fft.rfftn(x, norm="forward"))
 
     def test_irfftn(self):
         x = random((30, 20, 10))
         assert_array_almost_equal(x, fft.irfftn(fft.rfftn(x)))
-        assert_array_almost_equal(
-            x, fft.irfftn(fft.rfftn(x, norm="ortho"), norm="ortho"))
+        for norm in ["backward", "ortho", "forward"]:
+            assert_array_almost_equal(
+                x, fft.irfftn(fft.rfftn(x, norm=norm), norm=norm))
 
     def test_hfft(self):
         x = random(14) + 1j*random(14)
         x_herm = np.concatenate((random(1), x, random(1)))
         x = np.concatenate((x_herm, x[::-1].conj()))
-        assert_array_almost_equal(fft.fft(x), fft.hfft(x_herm))
-        assert_array_almost_equal(fft.hfft(x_herm) / np.sqrt(30),
+        expect = fft.fft(x)
+        assert_array_almost_equal(expect, fft.hfft(x_herm))
+        assert_array_almost_equal(expect, fft.hfft(x_herm, norm="backward"))
+        assert_array_almost_equal(expect / np.sqrt(30),
                                   fft.hfft(x_herm, norm="ortho"))
+        assert_array_almost_equal(expect / 30,
+                                  fft.hfft(x_herm, norm="forward"))
 
     def test_ihfft(self):
         x = random(14) + 1j*random(14)
         x_herm = np.concatenate((random(1), x, random(1)))
         x = np.concatenate((x_herm, x[::-1].conj()))
         assert_array_almost_equal(x_herm, fft.ihfft(fft.hfft(x_herm)))
-        assert_array_almost_equal(
-            x_herm, fft.ihfft(fft.hfft(x_herm, norm="ortho"),
-                                 norm="ortho"))
+        for norm in ["backward", "ortho", "forward"]:
+            assert_array_almost_equal(
+                x_herm, fft.ihfft(fft.hfft(x_herm, norm=norm), norm=norm))
 
     def test_hfft2(self):
         x = random((30, 20))
         assert_array_almost_equal(x, fft.hfft2(fft.ihfft2(x)))
-        assert_array_almost_equal(
-            x, fft.hfft2(fft.ihfft2(x, norm="ortho"), norm="ortho"))
+        for norm in ["backward", "ortho", "forward"]:
+            assert_array_almost_equal(
+                x, fft.hfft2(fft.ihfft2(x, norm=norm), norm=norm))
 
     def test_ihfft2(self):
         x = random((30, 20))
-        assert_array_almost_equal(fft.ifft2(x)[:, :11], fft.ihfft2(x))
-        assert_array_almost_equal(fft.ihfft2(x) * np.sqrt(30 * 20),
+        expect = fft.ifft2(x)[:, :11]
+        assert_array_almost_equal(expect, fft.ihfft2(x))
+        assert_array_almost_equal(expect, fft.ihfft2(x, norm="backward"))
+        assert_array_almost_equal(expect * np.sqrt(30 * 20),
                                   fft.ihfft2(x, norm="ortho"))
+        assert_array_almost_equal(expect * (30 * 20),
+                                  fft.ihfft2(x, norm="forward"))
 
     def test_hfftn(self):
         x = random((30, 20, 10))
         assert_array_almost_equal(x, fft.hfftn(fft.ihfftn(x)))
-        assert_array_almost_equal(
-            x, fft.hfftn(fft.ihfftn(x, norm="ortho"), norm="ortho"))
+        for norm in ["backward", "ortho", "forward"]:
+            assert_array_almost_equal(
+                x, fft.hfftn(fft.ihfftn(x, norm=norm), norm=norm))
 
     def test_ihfftn(self):
         x = random((30, 20, 10))
-        assert_array_almost_equal(fft.ifftn(x)[:, :, :6], fft.ihfftn(x))
-        assert_array_almost_equal(fft.ihfftn(x) * np.sqrt(30 * 20 * 10),
+        expect = fft.ifftn(x)[:, :, :6]
+        assert_array_almost_equal(expect, fft.ihfftn(x))
+        assert_array_almost_equal(expect, fft.ihfftn(x, norm="backward"))
+        assert_array_almost_equal(expect * np.sqrt(30 * 20 * 10),
                                   fft.ihfftn(x, norm="ortho"))
+        assert_array_almost_equal(expect * (30 * 20 * 10),
+                                  fft.ihfftn(x, norm="forward"))
 
     @pytest.mark.parametrize("op", [fft.fftn, fft.ifftn,
                                     fft.rfftn, fft.irfftn,
@@ -200,7 +239,7 @@ class TestFFT1D(object):
                       ]
         for forw, back in func_pairs:
             for n in [x.size, 2*x.size]:
-                for norm in [None, 'ortho']:
+                for norm in ['backward', 'ortho', 'forward']:
                     tmp = forw(x, n=n, norm=norm)
                     tmp = back(tmp, n=n, norm=norm)
                     assert_array_almost_equal(x_norm,

--- a/scipy/fft/tests/test_real_transforms.py
+++ b/scipy/fft/tests/test_real_transforms.py
@@ -16,7 +16,7 @@ from scipy import fftpack
 @pytest.mark.parametrize("type", [1, 2, 3, 4])
 @pytest.mark.parametrize("n", [2, 3, 4, 5, 10, 16])
 @pytest.mark.parametrize("axis", [0, 1])
-@pytest.mark.parametrize("norm", [None, 'ortho'])
+@pytest.mark.parametrize("norm", [None, 'backward', 'ortho', 'forward'])
 def test_identity_1d(forward, backward, type, n, axis, norm):
     # Test the identity f^-1(f(x)) == x
     x = np.random.rand(n, n)
@@ -38,7 +38,7 @@ def test_identity_1d(forward, backward, type, n, axis, norm):
 @pytest.mark.parametrize("dtype", [np.float16, np.float32, np.float64,
                                    np.complex64, np.complex128])
 @pytest.mark.parametrize("axis", [0, 1])
-@pytest.mark.parametrize("norm", [None, 'ortho'])
+@pytest.mark.parametrize("norm", [None, 'backward', 'ortho', 'forward'])
 @pytest.mark.parametrize("overwrite_x", [True, False])
 def test_identity_1d_overwrite(forward, backward, type, dtype, axis, norm,
                                overwrite_x):
@@ -71,7 +71,7 @@ def test_identity_1d_overwrite(forward, backward, type, dtype, axis, norm,
                              ((4, 5, 6), 1),
                              ((4, 5, 6), (0, 2)),
                          ])
-@pytest.mark.parametrize("norm", [None, 'ortho'])
+@pytest.mark.parametrize("norm", [None, 'backward', 'ortho', 'forward'])
 def test_identity_nd(forward, backward, type, shape, axes, norm):
     # Test the identity f^-1(f(x)) == x
 
@@ -110,7 +110,7 @@ def test_identity_nd(forward, backward, type, shape, axes, norm):
                          ])
 @pytest.mark.parametrize("dtype", [np.float16, np.float32, np.float64,
                                    np.complex64, np.complex128])
-@pytest.mark.parametrize("norm", [None, 'ortho'])
+@pytest.mark.parametrize("norm", [None, 'backward', 'ortho', 'forward'])
 @pytest.mark.parametrize("overwrite_x", [False, True])
 def test_identity_nd_overwrite(forward, backward, type, shape, axes, dtype,
                                norm, overwrite_x):
@@ -135,7 +135,7 @@ def test_identity_nd_overwrite(forward, backward, type, shape, axes, dtype,
 
 @pytest.mark.parametrize("func", ['dct', 'dst', 'dctn', 'dstn'])
 @pytest.mark.parametrize("type", [1, 2, 3, 4])
-@pytest.mark.parametrize("norm", [None, 'ortho'])
+@pytest.mark.parametrize("norm", [None, 'backward', 'ortho', 'forward'])
 def test_fftpack_equivalience(func, type, norm):
     x = np.random.rand(8, 16)
     fft_res = getattr(fft, func)(x, type, norm=norm)


### PR DESCRIPTION
#### Reference issue
See numpy/numpy#16476

#### What does this implement/fix?
This implements the additional normalization modes recently (today) merged into numpy master.

#### Additional information
These correspond exactly to the normalization modes used internally in `pypocketfft` already, so this is mainly a test/doc update.