### PR TITLE
MAINT: Avoid sphinx deprecated aliases for SeeAlso and Only

### DIFF
--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -48,7 +48,7 @@ from numpydoc.docscrape_sphinx import get_doc_object
 
 if parse_version(sphinx.__version__) >= parse_version('1.5'):
     # Enable specific Sphinx directives
-    from sphinx.directives import SeeAlso, Only
+    from sphinx.directives.other import SeeAlso, Only
     directives.register_directive('seealso', SeeAlso)
     directives.register_directive('only', Only)
 else:


### PR DESCRIPTION
Fixes two ``RemovedInSphinx40Warning`` warnings
```
/home/peter/git/scipy/tools/refguide_check.py:51: RemovedInSphinx40Warning: sphinx.directives.SeeAlso is deprecated. Check CHANGES for Sphinx API modifications.
  from sphinx.directives import SeeAlso, Only
/home/peter/git/scipy/tools/refguide_check.py:51: RemovedInSphinx40Warning: sphinx.directives.Only is deprecated. Check CHANGES for Sphinx API modifications.
```

Which makes it sound like `seealso` is being deprecated, but it seems to just be the import path that's changed.