### PR TITLE
BUG:linalg: eigh type parameter handling corrected

### DIFF
--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -460,8 +460,11 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
             raise ValueError("wrong b dimensions {}, should "
                              "be {}".format(b1.shape, a1.shape))
 
+        if type not in [1, 2, 3]:
+            raise ValueError('"type" can only accepts values 1, 2, and 3.')
+
         cplx = True if iscomplexobj(b1) else (cplx or False)
-        drv_args.update({'overwrite_b': overwrite_b})
+        drv_args.update({'overwrite_b': overwrite_b, 'itype': type})
 
     # backwards-compatibility handling
     subset_by_index = subset_by_index if (eigvals is None) else eigvals

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -461,7 +461,7 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
                              "be {}".format(b1.shape, a1.shape))
 
         if type not in [1, 2, 3]:
-            raise ValueError('"type" can only accepts values 1, 2, and 3.')
+            raise ValueError('"type" keyword only accepts 1, 2, and 3.')
 
         cplx = True if iscomplexobj(b1) else (cplx or False)
         drv_args.update({'overwrite_b': overwrite_b, 'itype': type})

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -852,7 +852,7 @@ class TestEigh:
     @pytest.mark.parametrize('type', (1, 2, 3))
     @pytest.mark.parametrize('driver', ("gv", "gvd", "gvx"))
     def test_various_drivers_generalized(self, driver, type):
-        atol = 1000*np.spacing(1.)
+        atol = np.spacing(5000.)
         a = _random_hermitian_matrix(20)
         b = _random_hermitian_matrix(20, posdef=True)
         w, v = eigh(a=a, b=b, driver=driver, type=type)


### PR DESCRIPTION
Closes #12533

Apparently I relied too much on the previous tests of `eigh` for existing functionality tests and `type` parameter slipped from the testing. This fixes the missing handling of the keyword and adds tests for it.