### PR TITLE
MAINT: deal with cases in `minimize` for `(bounds.lb == bounds.ub).any()`

### DIFF
--- a/scipy/optimize/_numdiff.py
+++ b/scipy/optimize/_numdiff.py
@@ -516,7 +516,19 @@ def _dense_difference(fun, x0, f0, h, use_one_sided, method):
         else:
             raise RuntimeError("Never be here.")
 
-        J_transposed[i] = df / dx
+        if np.count_nonzero(dx == 0.0):
+            # this can happen for entries with lb == ub
+            with np.errstate(invalid='ignore'):
+                # filter warning for 0 / 0
+                # However a 1.0 / 0.0 will still raise a
+                # RuntimeWarning: divide by zero encountered in true_divide
+                g = np.asarray(df / dx)
+            idxs = np.array(dx) == 0
+            g[idxs] = 0.0
+        else:
+            g = df / dx
+
+        J_transposed[i] = g
 
     if m == 1:
         J_transposed = np.ravel(J_transposed)


### PR DESCRIPTION
In `1.5` the underlying finite difference numerical differentiation for all the minimizer methods was changed to `approx_derivative`. `approx_derivative` is more sophisticated, and it also obeys lower and upper bounds when calculating the finite difference step. This solved several issues where the function was being evaluated outside the bounds. However, the change then caused issues for situations where the bounds were used to fix a parameter, `bounds.lb == bounds.ub`. The issue arises because the `dx` forward/backward difference step was equal to 0, so `df / dx` gave rise to a  0.0 / 0.0 error in numpy.

The fix presented here:

- adds regression test
- in approx_derivative if a 0 / 0 situation is encountered, then filter that divide and set that derivative entry to 0 (instead of nan). I think a derivative of 0 is correct because `df` should not vary at all if `dx` is changed for a 'fixed' parameter.

However, TNC still fails the test for situations where `lb == ub` because the `'Linear search failed'`. This might have to be special cased.

@bashtage 

closes gh-12502
