### PR TITLE
DOC: fix typo in cluster/_hierarchy.pyx

### DIFF
--- a/scipy/cluster/_hierarchy.pyx
+++ b/scipy/cluster/_hierarchy.pyx
@@ -500,7 +500,7 @@ def inconsistent(double[:, :] Z, double[:, :] R, int n, int d):
     Z : ndarray
         The linkage matrix.
     R : ndarray
-        A (n - 1) x 5 matrix to store the result. The inconsistency statistics
+        A (n - 1) x 4 matrix to store the result. The inconsistency statistics
         `R[i]` are calculated over `d` levels below cluster i. `R[i, 0]` is the
         mean of distances. `R[i, 1]` is the standard deviation of distances.
         `R[i, 2]` is the number of clusters included. `R[i, 3]` is the


### PR DESCRIPTION
There is a typo in the description of function `def inconsistent(double[:, :] Z, double[:, :] R, int n, int d):`. The parameter R should be a (n-1) x 4 matrix, but it was mistakenly written as a (n-1) x 5 matrix.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #12547 
