### PR TITLE
MAINT: Use extern templates to improve sparsetools compile time

### DIFF
--- a/scipy/sparse/generate_sparsetools.py
+++ b/scipy/sparse/generate_sparsetools.py
@@ -301,26 +301,19 @@ def parse_routine(name, args, types):
     switch (j) {"""
     for j, I_typenum, T_typenum, I_type, T_type in types:
         arglist = get_arglist(I_type, T_type)
-        if T_type is None:
-            dispatch = "%s" % (I_type,)
-        else:
-            dispatch = "%s,%s" % (I_type, T_type)
-        if 'B' in arg_spec:
-            dispatch += ",npy_bool_wrapper"
 
         piece = """
         case %(j)s:"""
         if ret_spec == 'v':
             piece += """
-            (void)%(name)s<%(dispatch)s>(%(arglist)s);
+            (void)%(name)s(%(arglist)s);
             return 0;"""
         else:
             piece += """
-            return %(name)s<%(dispatch)s>(%(arglist)s);"""
+            return %(name)s(%(arglist)s);"""
         thunk_content += piece % dict(j=j, I_type=I_type, T_type=T_type,
                                       I_typenum=I_typenum, T_typenum=T_typenum,
-                                      arglist=arglist, name=name,
-                                      dispatch=dispatch)
+                                      arglist=arglist, name=name)
 
     thunk_content += """
     default:

--- a/scipy/sparse/setup.py
+++ b/scipy/sparse/setup.py
@@ -5,6 +5,7 @@ import subprocess
 
 def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
+    from scipy._build_utils.compiler_helper import set_cxx_flags_hook
 
     config = Configuration('sparse',parent_package,top_path)
 
@@ -41,7 +42,7 @@ def configuration(parent_package='',top_path=None):
                'sparsetools.h',
                'util.h']
     depends = [os.path.join('sparsetools', hdr) for hdr in depends],
-    config.add_extension('_sparsetools',
+    sparsetools = config.add_extension('_sparsetools',
                          define_macros=[('__STDC_FORMAT_MACROS', 1)],
                          depends=depends,
                          include_dirs=['sparsetools'],
@@ -52,6 +53,7 @@ def configuration(parent_package='',top_path=None):
                                   os.path.join('sparsetools', 'other.cxx'),
                                   get_sparsetools_sources]
                          )
+    sparsetools._pre_build_hook = set_cxx_flags_hook
 
     return config
 

--- a/scipy/sparse/sparsetools/csr.cxx
+++ b/scipy/sparse/sparsetools/csr.cxx
@@ -7,3 +7,35 @@
 extern "C" {
 #include "csr_impl.h"
 }
+
+#define SPTOOLS_CSR_DEFINE_TEMPLATE(I, T) \
+  template void csr_diagonal(const I k, const I n_row, const I n_col, const I Ap[], const I Aj[], const T Ax[], T Yx[]); \
+  template void csr_scale_rows(const I n_row, const I n_col, const I Ap[], const I Aj[], T Ax[], const T Xx[]); \
+  template void csr_scale_columns(const I n_row, const I n_col, const I Ap[], const I Aj[], T Ax[], const T Xx[]); \
+  template void csr_tobsr(const I n_row, const I n_col, const I R, const I C, const I Ap[], const I Aj[], const T Ax[], I Bp[], I Bj[], T Bx[]); \
+  template void csr_todense(const I n_row, const I n_col, const I Ap[], const I Aj[], const T Ax[], T Bx[]); \
+  template void csr_sort_indices(const I n_row, const I Ap[], I Aj[], T Ax[]); \
+  template void csr_tocsc(const I n_row, const I n_col, const I Ap[], const I Aj[], const T Ax[], I Bp[], I Bi[], T Bx[]); \
+  template void csr_toell(const I n_row, const I n_col, const I Ap[], const I Aj[], const T Ax[], const I row_length, I Bj[], T Bx[]); \
+  template void csr_matmat(const I n_row, const I n_col, const I Ap[], const I Aj[], const T Ax[], const I Bp[], const I Bj[], const T Bx[], I Cp[], I Cj[], T Cx[]); \
+  template void csr_binop_csr(const I n_row, const I n_col, const I Ap[], const I Aj[], const T Ax[], const I Bp[], const I Bj[], const T Bx[], I Cp[], I Cj[], T Cx[], const std::not_equal_to<T>& op); \
+  template void csr_binop_csr(const I n_row, const I n_col, const I Ap[], const I Aj[], const T Ax[], const I Bp[], const I Bj[], const T Bx[], I Cp[], I Cj[], T Cx[], const std::less<T>& op); \
+  template void csr_binop_csr(const I n_row, const I n_col, const I Ap[], const I Aj[], const T Ax[], const I Bp[], const I Bj[], const T Bx[], I Cp[], I Cj[], T Cx[], const std::less_equal<T>& op); \
+  template void csr_binop_csr(const I n_row, const I n_col, const I Ap[], const I Aj[], const T Ax[], const I Bp[], const I Bj[], const T Bx[], I Cp[], I Cj[], T Cx[], const std::greater_equal<T>& op); \
+  template void csr_binop_csr(const I n_row, const I n_col, const I Ap[], const I Aj[], const T Ax[], const I Bp[], const I Bj[], const T Bx[], I Cp[], I Cj[], T Cx[], const std::multiplies<T>& op); \
+  template void csr_binop_csr(const I n_row, const I n_col, const I Ap[], const I Aj[], const T Ax[], const I Bp[], const I Bj[], const T Bx[], I Cp[], I Cj[], T Cx[], const safe_divides<T>& op); \
+  template void csr_binop_csr(const I n_row, const I n_col, const I Ap[], const I Aj[], const T Ax[], const I Bp[], const I Bj[], const T Bx[], I Cp[], I Cj[], T Cx[], const std::plus<T>& op); \
+  template void csr_binop_csr(const I n_row, const I n_col, const I Ap[], const I Aj[], const T Ax[], const I Bp[], const I Bj[], const T Bx[], I Cp[], I Cj[], T Cx[], const std::minus<T>& op); \
+  template void csr_binop_csr(const I n_row, const I n_col, const I Ap[], const I Aj[], const T Ax[], const I Bp[], const I Bj[], const T Bx[], I Cp[], I Cj[], T Cx[], const maximum<T>& op); \
+  template void csr_binop_csr(const I n_row, const I n_col, const I Ap[], const I Aj[], const T Ax[], const I Bp[], const I Bj[], const T Bx[], I Cp[], I Cj[], T Cx[], const minimum<T>& op); \
+  template void csr_sum_duplicates(const I n_row, const I n_col, I Ap[], I Aj[], T Ax[]); \
+  template void csr_eliminate_zeros(const I n_row, const I n_col, I Ap[], I Aj[], T Ax[]); \
+  template void csr_matvec(const I n_row, const I n_col, const I Ap[], const I Aj[], const T Ax[], const T Xx[], T Yx[]); \
+  template void csr_matvecs(const I n_row, const I n_col, const I n_vecs, const I Ap[], const I Aj[], const T Ax[], const T Xx[], T Yx[]); \
+  template void get_csr_submatrix(const I n_row, const I n_col, const I Ap[], const I Aj[], const T Ax[], const I ir0, const I ir1, const I ic0, const I ic1, std::vector<I>* Bp, std::vector<I>* Bj, std::vector<T>* Bx); \
+  template void csr_row_index(const I n_row_idx, const I rows[], const I Ap[], const I Aj[], const T Ax[], I Bj[], T Bx[]); \
+  template void csr_row_slice(const I start, const I stop, const I step, const I Ap[], const I Aj[], const T Ax[], I Bj[], T Bx[]); \
+  template void csr_column_index2(const I col_order[], const I col_offsets[], const I nnz, const I Aj[], const T Ax[], I Bj[], T Bx[]); \
+  template void csr_sample_values(const I n_row, const I n_col, const I Ap[], const I Aj[], const T Ax[], const I n_samples, const I Bi[], const I Bj[], T Bx[]);
+
+SPTOOLS_FOR_EACH_INDEX_DATA_TYPE_COMBINATION(SPTOOLS_CSR_DEFINE_TEMPLATE)

--- a/scipy/sparse/sparsetools/csr.h
+++ b/scipy/sparse/sparsetools/csr.h
@@ -1625,10 +1625,42 @@ int csr_sample_offsets(const I n_row,
 /*
  * A test function checking the error handling
  */
-template <class T>
-int test_throw_error() {
+inline int test_throw_error() {
     throw std::bad_alloc();
     return 1;
 }
+
+#define SPTOOLS_CSR_EXTERN_TEMPLATE(I, T) \
+  extern template void csr_diagonal(const I k, const I n_row, const I n_col, const I Ap[], const I Aj[], const T Ax[], T Yx[]); \
+  extern template void csr_scale_rows(const I n_row, const I n_col, const I Ap[], const I Aj[], T Ax[], const T Xx[]); \
+  extern template void csr_scale_columns(const I n_row, const I n_col, const I Ap[], const I Aj[], T Ax[], const T Xx[]); \
+  extern template void csr_tobsr(const I n_row, const I n_col, const I R, const I C, const I Ap[], const I Aj[], const T Ax[], I Bp[], I Bj[], T Bx[]); \
+  extern template void csr_todense(const I n_row, const I n_col, const I Ap[], const I Aj[], const T Ax[], T Bx[]); \
+  extern template void csr_sort_indices(const I n_row, const I Ap[], I Aj[], T Ax[]); \
+  extern template void csr_tocsc(const I n_row, const I n_col, const I Ap[], const I Aj[], const T Ax[], I Bp[], I Bi[], T Bx[]); \
+  extern template void csr_toell(const I n_row, const I n_col, const I Ap[], const I Aj[], const T Ax[], const I row_length, I Bj[], T Bx[]); \
+  extern template void csr_matmat(const I n_row, const I n_col, const I Ap[], const I Aj[], const T Ax[], const I Bp[], const I Bj[], const T Bx[], I Cp[], I Cj[], T Cx[]); \
+  extern template void csr_binop_csr(const I n_row, const I n_col, const I Ap[], const I Aj[], const T Ax[], const I Bp[], const I Bj[], const T Bx[], I Cp[], I Cj[], T Cx[], const std::not_equal_to<T>& op); \
+  extern template void csr_binop_csr(const I n_row, const I n_col, const I Ap[], const I Aj[], const T Ax[], const I Bp[], const I Bj[], const T Bx[], I Cp[], I Cj[], T Cx[], const std::less<T>& op); \
+  extern template void csr_binop_csr(const I n_row, const I n_col, const I Ap[], const I Aj[], const T Ax[], const I Bp[], const I Bj[], const T Bx[], I Cp[], I Cj[], T Cx[], const std::less_equal<T>& op); \
+  extern template void csr_binop_csr(const I n_row, const I n_col, const I Ap[], const I Aj[], const T Ax[], const I Bp[], const I Bj[], const T Bx[], I Cp[], I Cj[], T Cx[], const std::greater_equal<T>& op); \
+  extern template void csr_binop_csr(const I n_row, const I n_col, const I Ap[], const I Aj[], const T Ax[], const I Bp[], const I Bj[], const T Bx[], I Cp[], I Cj[], T Cx[], const std::multiplies<T>& op); \
+  extern template void csr_binop_csr(const I n_row, const I n_col, const I Ap[], const I Aj[], const T Ax[], const I Bp[], const I Bj[], const T Bx[], I Cp[], I Cj[], T Cx[], const safe_divides<T>& op); \
+  extern template void csr_binop_csr(const I n_row, const I n_col, const I Ap[], const I Aj[], const T Ax[], const I Bp[], const I Bj[], const T Bx[], I Cp[], I Cj[], T Cx[], const std::plus<T>& op); \
+  extern template void csr_binop_csr(const I n_row, const I n_col, const I Ap[], const I Aj[], const T Ax[], const I Bp[], const I Bj[], const T Bx[], I Cp[], I Cj[], T Cx[], const std::minus<T>& op); \
+  extern template void csr_binop_csr(const I n_row, const I n_col, const I Ap[], const I Aj[], const T Ax[], const I Bp[], const I Bj[], const T Bx[], I Cp[], I Cj[], T Cx[], const maximum<T>& op); \
+  extern template void csr_binop_csr(const I n_row, const I n_col, const I Ap[], const I Aj[], const T Ax[], const I Bp[], const I Bj[], const T Bx[], I Cp[], I Cj[], T Cx[], const minimum<T>& op); \
+  extern template void csr_sum_duplicates(const I n_row, const I n_col, I Ap[], I Aj[], T Ax[]); \
+  extern template void csr_eliminate_zeros(const I n_row, const I n_col, I Ap[], I Aj[], T Ax[]); \
+  extern template void csr_matvec(const I n_row, const I n_col, const I Ap[], const I Aj[], const T Ax[], const T Xx[], T Yx[]); \
+  extern template void csr_matvecs(const I n_row, const I n_col, const I n_vecs, const I Ap[], const I Aj[], const T Ax[], const T Xx[], T Yx[]); \
+  extern template void get_csr_submatrix(const I n_row, const I n_col, const I Ap[], const I Aj[], const T Ax[], const I ir0, const I ir1, const I ic0, const I ic1, std::vector<I>* Bp, std::vector<I>* Bj, std::vector<T>* Bx); \
+  extern template void csr_row_index(const I n_row_idx, const I rows[], const I Ap[], const I Aj[], const T Ax[], I Bj[], T Bx[]); \
+  extern template void csr_row_slice(const I start, const I stop, const I step, const I Ap[], const I Aj[], const T Ax[], I Bj[], T Bx[]); \
+  extern template void csr_column_index2(const I col_order[], const I col_offsets[], const I nnz, const I Aj[], const T Ax[], I Bj[], T Bx[]); \
+  extern template void csr_sample_values(const I n_row, const I n_col, const I Ap[], const I Aj[], const T Ax[], const I n_samples, const I Bi[], const I Bj[], T Bx[]);
+
+SPTOOLS_FOR_EACH_INDEX_DATA_TYPE_COMBINATION(SPTOOLS_CSR_EXTERN_TEMPLATE)
+#undef SPTOOLS_CSR_EXTERN_TEMPLATE
 
 #endif

--- a/scipy/sparse/sparsetools/sparsetools.cxx
+++ b/scipy/sparse/sparsetools/sparsetools.cxx
@@ -34,6 +34,7 @@
 #include "numpy/ndarrayobject.h"
 
 #include "sparsetools.h"
+#include "util.h"
 
 #define MAX_ARGS 16
 
@@ -468,23 +469,7 @@ static void *allocate_std_vector_typenum(int typenum)
     }
 
     try {
-        PROCESS(NPY_BOOL, npy_bool_wrapper);
-        PROCESS(NPY_BYTE, npy_byte);
-        PROCESS(NPY_UBYTE, npy_ubyte);
-        PROCESS(NPY_SHORT, npy_short);
-        PROCESS(NPY_USHORT, npy_ushort);
-        PROCESS(NPY_INT, npy_int);
-        PROCESS(NPY_UINT, npy_uint);
-        PROCESS(NPY_LONG, npy_long);
-        PROCESS(NPY_ULONG, npy_ulong);
-        PROCESS(NPY_LONGLONG, npy_longlong);
-        PROCESS(NPY_ULONGLONG, npy_ulonglong);
-        PROCESS(NPY_FLOAT, npy_float);
-        PROCESS(NPY_DOUBLE, npy_double);
-        PROCESS(NPY_LONGDOUBLE, npy_longdouble);
-        PROCESS(NPY_CFLOAT, npy_cfloat_wrapper);
-        PROCESS(NPY_CDOUBLE, npy_cdouble_wrapper);
-        PROCESS(NPY_CLONGDOUBLE, npy_clongdouble_wrapper);
+        SPTOOLS_FOR_EACH_DATA_TYPE_CODE(PROCESS)
     } catch (std::exception &e) {
         /* failed */
     }
@@ -504,23 +489,7 @@ static void free_std_vector_typenum(int typenum, void *p)
         return;                                                 \
     }
 
-    PROCESS(NPY_BOOL, npy_bool_wrapper);
-    PROCESS(NPY_BYTE, npy_byte);
-    PROCESS(NPY_UBYTE, npy_ubyte);
-    PROCESS(NPY_SHORT, npy_short);
-    PROCESS(NPY_USHORT, npy_ushort);
-    PROCESS(NPY_INT, npy_int);
-    PROCESS(NPY_UINT, npy_uint);
-    PROCESS(NPY_LONG, npy_long);
-    PROCESS(NPY_ULONG, npy_ulong);
-    PROCESS(NPY_LONGLONG, npy_longlong);
-    PROCESS(NPY_ULONGLONG, npy_ulonglong);
-    PROCESS(NPY_FLOAT, npy_float);
-    PROCESS(NPY_DOUBLE, npy_double);
-    PROCESS(NPY_LONGDOUBLE, npy_longdouble);
-    PROCESS(NPY_CFLOAT, npy_cfloat_wrapper);
-    PROCESS(NPY_CDOUBLE, npy_cdouble_wrapper);
-    PROCESS(NPY_CLONGDOUBLE, npy_clongdouble_wrapper);
+    SPTOOLS_FOR_EACH_DATA_TYPE_CODE(PROCESS)
 
 #undef PROCESS
 }
@@ -540,23 +509,7 @@ static PyObject *array_from_std_vector_and_free(int typenum, void *p)
         return obj;                                             \
     }
 
-    PROCESS(NPY_BOOL, npy_bool_wrapper);
-    PROCESS(NPY_BYTE, npy_byte);
-    PROCESS(NPY_UBYTE, npy_ubyte);
-    PROCESS(NPY_SHORT, npy_short);
-    PROCESS(NPY_USHORT, npy_ushort);
-    PROCESS(NPY_INT, npy_int);
-    PROCESS(NPY_UINT, npy_uint);
-    PROCESS(NPY_LONG, npy_long);
-    PROCESS(NPY_ULONG, npy_ulong);
-    PROCESS(NPY_LONGLONG, npy_longlong);
-    PROCESS(NPY_ULONGLONG, npy_ulonglong);
-    PROCESS(NPY_FLOAT, npy_float);
-    PROCESS(NPY_DOUBLE, npy_double);
-    PROCESS(NPY_LONGDOUBLE, npy_longdouble);
-    PROCESS(NPY_CFLOAT, npy_cfloat_wrapper);
-    PROCESS(NPY_CDOUBLE, npy_cdouble_wrapper);
-    PROCESS(NPY_CLONGDOUBLE, npy_clongdouble_wrapper);
+    SPTOOLS_FOR_EACH_DATA_TYPE_CODE(PROCESS)
 
 #undef PROCESS
 

--- a/scipy/sparse/sparsetools/util.h
+++ b/scipy/sparse/sparsetools/util.h
@@ -47,4 +47,139 @@ struct minimum {
     }
 };
 
+#define SPTOOLS_FOR_EACH_DATA_TYPE_CODE(X)      \
+  X(NPY_BOOL, npy_bool_wrapper)                 \
+  X(NPY_BYTE, npy_byte)                         \
+  X(NPY_UBYTE, npy_ubyte)                       \
+  X(NPY_SHORT, npy_short)                       \
+  X(NPY_USHORT, npy_ushort)                     \
+  X(NPY_INT, npy_int)                           \
+  X(NPY_UINT, npy_uint)                         \
+  X(NPY_LONG, npy_long)                         \
+  X(NPY_ULONG, npy_ulong)                       \
+  X(NPY_LONGLONG, npy_longlong)                 \
+  X(NPY_ULONGLONG, npy_ulonglong)               \
+  X(NPY_FLOAT, npy_float)                       \
+  X(NPY_DOUBLE, npy_double)                     \
+  X(NPY_LONGDOUBLE, npy_longdouble)             \
+  X(NPY_CFLOAT, npy_cfloat_wrapper)             \
+  X(NPY_CDOUBLE, npy_cdouble_wrapper)           \
+  X(NPY_CLONGDOUBLE, npy_clongdouble_wrapper)
+
+// If npy_longdouble is distinct from npy_double
+#if NPY_SIZEOF_LONGDOUBLE != NPY_SIZEOF_DOUBLE
+
+#define SPTOOLS_FOR_EACH_DATA_TYPE(X)           \
+  X(NPY_BOOL, npy_bool_wrapper)                 \
+  X(NPY_BYTE, npy_byte)                         \
+  X(NPY_UBYTE, npy_ubyte)                       \
+  X(NPY_SHORT, npy_short)                       \
+  X(NPY_USHORT, npy_ushort)                     \
+  X(NPY_INT, npy_int)                           \
+  X(NPY_UINT, npy_uint)                         \
+  X(NPY_LONG, npy_long)                         \
+  X(NPY_ULONG, npy_ulong)                       \
+  X(NPY_LONGLONG, npy_longlong)                 \
+  X(NPY_ULONGLONG, npy_ulonglong)               \
+  X(NPY_FLOAT, npy_float)                       \
+  X(NPY_DOUBLE, npy_double)                     \
+  X(NPY_LONGDOUBLE, npy_longdouble)             \
+  X(NPY_CFLOAT, npy_cfloat_wrapper)             \
+  X(NPY_CDOUBLE, npy_cdouble_wrapper)           \
+  X(NPY_CLONGDOUBLE, npy_clongdouble_wrapper)
+
+
+#define SPTOOLS_FOR_EACH_INDEX_DATA_TYPE_COMBINATION(X) \
+  X(npy_int32, npy_bool_wrapper)                        \
+  X(npy_int32, npy_byte)                                \
+  X(npy_int32, npy_ubyte)                               \
+  X(npy_int32, npy_short)                               \
+  X(npy_int32, npy_ushort)                              \
+  X(npy_int32, npy_int)                                 \
+  X(npy_int32, npy_uint)                                \
+  X(npy_int32, npy_long)                                \
+  X(npy_int32, npy_ulong)                               \
+  X(npy_int32, npy_longlong)                            \
+  X(npy_int32, npy_ulonglong)                           \
+  X(npy_int32, npy_float)                               \
+  X(npy_int32, npy_double)                              \
+  X(npy_int32, npy_longdouble)                          \
+  X(npy_int32, npy_cfloat_wrapper)                      \
+  X(npy_int32, npy_cdouble_wrapper)                     \
+  X(npy_int32, npy_clongdouble_wrapper)                 \
+  X(npy_int64, npy_bool_wrapper)                        \
+  X(npy_int64, npy_byte)                                \
+  X(npy_int64, npy_ubyte)                               \
+  X(npy_int64, npy_short)                               \
+  X(npy_int64, npy_ushort)                              \
+  X(npy_int64, npy_int)                                 \
+  X(npy_int64, npy_uint)                                \
+  X(npy_int64, npy_long)                                \
+  X(npy_int64, npy_ulong)                               \
+  X(npy_int64, npy_longlong)                            \
+  X(npy_int64, npy_ulonglong)                           \
+  X(npy_int64, npy_float)                               \
+  X(npy_int64, npy_double)                              \
+  X(npy_int64, npy_longdouble)                          \
+  X(npy_int64, npy_cfloat_wrapper)                      \
+  X(npy_int64, npy_cdouble_wrapper)                     \
+  X(npy_int64, npy_clongdouble_wrapper)
+
+#else  // vvv npy_longdouble is npy_double vvv
+
+#define SPTOOLS_FOR_EACH_DATA_TYPE(X)           \
+  X(npy_bool_wrapper)                           \
+  X(npy_byte)                                   \
+  X(npy_ubyte)                                  \
+  X(npy_short)                                  \
+  X(npy_ushort)                                 \
+  X(npy_int)                                    \
+  X(npy_uint)                                   \
+  X(npy_long)                                   \
+  X(npy_ulong)                                  \
+  X(npy_longlong)                               \
+  X(npy_ulonglong)                              \
+  X(npy_float)                                  \
+  X(npy_double)                                 \
+  X(npy_cfloat_wrapper)                         \
+  X(npy_cdouble_wrapper)                        \
+  X(npy_clongdouble_wrapper)
+
+
+#define SPTOOLS_FOR_EACH_INDEX_DATA_TYPE_COMBINATION(X) \
+  X(npy_int32, npy_bool_wrapper)                        \
+  X(npy_int32, npy_byte)                                \
+  X(npy_int32, npy_ubyte)                               \
+  X(npy_int32, npy_short)                               \
+  X(npy_int32, npy_ushort)                              \
+  X(npy_int32, npy_int)                                 \
+  X(npy_int32, npy_uint)                                \
+  X(npy_int32, npy_long)                                \
+  X(npy_int32, npy_ulong)                               \
+  X(npy_int32, npy_longlong)                            \
+  X(npy_int32, npy_ulonglong)                           \
+  X(npy_int32, npy_float)                               \
+  X(npy_int32, npy_double)                              \
+  X(npy_int32, npy_cfloat_wrapper)                      \
+  X(npy_int32, npy_cdouble_wrapper)                     \
+  X(npy_int32, npy_clongdouble_wrapper)                 \
+  X(npy_int64, npy_bool_wrapper)                        \
+  X(npy_int64, npy_byte)                                \
+  X(npy_int64, npy_ubyte)                               \
+  X(npy_int64, npy_short)                               \
+  X(npy_int64, npy_ushort)                              \
+  X(npy_int64, npy_int)                                 \
+  X(npy_int64, npy_uint)                                \
+  X(npy_int64, npy_long)                                \
+  X(npy_int64, npy_ulong)                               \
+  X(npy_int64, npy_longlong)                            \
+  X(npy_int64, npy_ulonglong)                           \
+  X(npy_int64, npy_float)                               \
+  X(npy_int64, npy_double)                              \
+  X(npy_int64, npy_cfloat_wrapper)                      \
+  X(npy_int64, npy_cdouble_wrapper)                     \
+  X(npy_int64, npy_clongdouble_wrapper)
+
+#endif
+
 #endif


### PR DESCRIPTION
#### What does this implement/fix?
While trying to compile SciPy on a raspberry pi for gh-10463 I kept running into out of memory issues compiling `sparsetools/bsr.cxx`. Since its implementation relies on CSR for a bunch of functionality, it fully compiles the templates for both BSR _and_ CSR for  all type combinations. So, I use the C++11 [`extern template`](https://en.cppreference.com/w/cpp/language/class_template#Explicit_instantiation) syntax so the compiler doesn't generate code for non-inlined `csr_` routines when compiling `bsr.cxx`.

A really minor other issue was that `test_throw_error` is unnecessarily templated and gets compiled twice just because the code generator calls the function as `test_throw_error<npy_int32>` or `test_throw_error<npy_int64>`. So, I fixed the generator to support non-templated functions.

These additions not only reduce the compiler memory footprint but also makes compilation faster.