### PR TITLE
MAINT: truncnorm.rvs compatibility for `Generator`

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -7697,7 +7697,7 @@ class truncnorm_gen(rv_continuous):
         size1d = tuple(np.atleast_1d(numsamples))
         N = np.prod(size1d)  # number of rvs needed, reshape upon return
         # Calculate some rvs
-        U = random_state.random_sample(N)
+        U = random_state.uniform(low=0, high=1, size=N)
         x = self._ppf(U, a, b)
         rvs = np.reshape(x, size1d)
         return rvs

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -623,6 +623,12 @@ class TestTruncnorm(object):
         assert_(np.all(low <= x.min(axis=0)))
         assert_(np.all(x.max(axis=0) <= high))
 
+    def test_rvs_Generator(self):
+        # check that rvs can use a Generator
+        if hasattr(np.random, "default_rng")
+            stats.truncnorm.rvs(-10, -5, size=5,
+                                random_state=np.random.default_rng())
+
 class TestHypergeom(object):
     def setup_method(self):
         np.random.seed(1234)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -625,7 +625,7 @@ class TestTruncnorm(object):
 
     def test_rvs_Generator(self):
         # check that rvs can use a Generator
-        if hasattr(np.random, "default_rng")
+        if hasattr(np.random, "default_rng"):
             stats.truncnorm.rvs(-10, -5, size=5,
                                 random_state=np.random.default_rng())
 


### PR DESCRIPTION
`truncnorm.rvs` was using `np.random.random_sample` internally for the generation of random numbers in the interval [0, 1). The `random_sample` function is not available for new-style `np.random.Generator`, which is preferred in new code.

Compatibility can be retained by using the `uniform` method on the random number generator. If any new code is added to stats it should ensure it works with either a `RandomState` or a `Generator`.

@pvanmulbregt