### PR TITLE
redo gh-12188: fix segfaults in splprep with fixed knots

### DIFF
--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -499,7 +499,7 @@ fitpack_parcur(PyObject *dummy, PyObject *args)
     if (ap_t == NULL || ap_c == NULL) {
         goto fail;
     }
-    if (iopt == 0|| n > no) {
+    if (iopt != 1|| n > no) {
         Py_XDECREF(ap_wrk);
         ap_wrk = NULL;
         Py_XDECREF(ap_iwrk);

--- a/scipy/interpolate/tests/test_fitpack.py
+++ b/scipy/interpolate/tests/test_fitpack.py
@@ -459,6 +459,19 @@ def test_splev_der_k():
     assert_allclose(splev(x, (t, c, k), k), splev(x, tck2))
 
 
+def test_splprep_segfault():
+    # regression test for gh-3847: splprep segfaults if knots are specified
+    # for task=-1
+    t = np.arange(0, 1.1, 0.1)
+    x = np.sin(2*np.pi*t)
+    y = np.cos(2*np.pi*t)
+    tck, u = interpolate.splprep([x, y], s=0)
+    unew = np.arange(0, 1.01, 0.01)
+
+    uknots = tck[0]  # using the knots from the previous fitting
+    tck, u = interpolate.splprep([x, y], task=-1, t=uknots)  # here is the crash
+
+
 def test_bisplev_integer_overflow():
     np.random.seed(1)
 


### PR DESCRIPTION
Incorporate the fix from gh-12188 and a test from gh-3847

Supersedes and closes gh-12188, closes gh-7395, closes gh-3847