### PR TITLE
DOC: stats: respond to query about Kruskal-Wallis test being one-sided (gh-12231)

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -7141,7 +7141,8 @@ def kruskal(*args, **kwargs):
        The Kruskal-Wallis H statistic, corrected for ties.
     pvalue : float
        The p-value for the test using the assumption that H has a chi
-       square distribution.
+       square distribution. The p-value returned is the survival function of
+       the chi square distribution evaluated at H.
 
     See Also
     --------


### PR DESCRIPTION
Closes gh-12231.

Perhaps gh-12231 can be closed without this, but I thought I'd add this for good measure.