### PR TITLE
BUG: Interpolate: use stable sort

### DIFF
--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -273,8 +273,8 @@ class interp2d(object):
             raise ValueError("x and y should both be 1-D arrays")
 
         if not assume_sorted:
-            x = np.sort(x)
-            y = np.sort(y)
+            x = np.sort(x, kind="mergesort")
+            y = np.sort(y, kind="mergesort")
 
         if self.bounds_error or self.fill_value is not None:
             out_of_bounds_x = (x < self.x_min) | (x > self.x_max)
@@ -437,7 +437,7 @@ class interp1d(_Interpolator1D):
         y = array(y, copy=self.copy)
 
         if not assume_sorted:
-            ind = np.argsort(x)
+            ind = np.argsort(x, kind="mergesort")
             x = x[ind]
             y = np.take(y, ind, axis=axis)
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes gh-12373 gh-9886

#### What does this implement/fix?
<!--Please explain your changes.-->

Calls to numpy.sort and argsort in interpolate.py are changed to use kind="mergesort" instead of the default kind.   This avoids a bug where interpolate produces incorrect (or at least: very surprising) results if the user supplied data contains duplicate x values, and assume_sorted=True is not passed to the interp1d or interp2d call (thus scipy performs a sort).  The default numpy sort is unstable; if the user data was already sorted, the default numpy sort may still rearrange the x values some of the time, and thus swap interpolation target y values to something other than the provided order.  Additionally, the output is random: whether any specific point is swapped depends on the exact data passed in (the whole x array, not just the points being interpolated between).

Implementation: numpy has had a stable sort with `np.sort(x, kind="mergesort")` since at least version 1.3.x; in 1.15.0, `kind="stable"` was introduced as a synonym for mergesort; and additionally mergesort may use a different stable implementation under the hood, depending on the data type (but is still guaranteed stable). 

For forward compatibility, it may be better to check the numpy version here and call kind="stable" if the version is >= 1.15.0.  However, kind="mergesort" provides identical behavior in all current and old versions of numpy, and avoids an explicit version check.


See also:
https://numpy.org/doc/stable/release/1.15.0-notes.html?highlight=numpy%20ufunc%20types#sort-functions-accept-kind-stable


#### Additional information
<!--Any additional information you think is important.-->