### PR TITLE
DEP: remove deprecated slepian window

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -141,7 +141,6 @@ for key in (
         '\nWARNING. The coefficients',  # interpolate.LSQSphereBivariateSpline
         'The integral is probably divergent',  # stats.mielke example
         'underflow encountered in square',  # signal.filtfilt underflow
-        'slepian is deprecated',  # signal.windows.slepian deprecation
         'underflow encountered in multiply',  # scipy.spatial.HalfspaceIntersection
         '`frechet_l` is deprecated',  # stats.frechet_l
         '`frechet_r` is deprecated',  # stats.frechet_r

--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -314,7 +314,7 @@ from .windows import get_window  # keep this one in signal namespace
 deprecated_windows = ('boxcar', 'triang', 'parzen', 'bohman', 'blackman',
                       'nuttall', 'blackmanharris', 'flattop', 'bartlett',
                       'barthann', 'hamming', 'kaiser', 'gaussian',
-                      'general_gaussian', 'chebwin', 'slepian', 'cosine',
+                      'general_gaussian', 'chebwin', 'cosine',
                       'hann', 'exponential', 'tukey')
 
 # backward compatibility imports for actually deprecated windows not

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -30,7 +30,6 @@ window_funcs = [
     ('gaussian', (0.5,)),
     ('general_gaussian', (1.5, 2)),
     ('chebwin', (1,)),
-    ('slepian', (2,)),
     ('cosine', ()),
     ('hann', ()),
     ('exponential', ()),
@@ -569,7 +568,7 @@ def test_windowfunc_basics():
         window = getattr(windows, window_name)
         with suppress_warnings() as sup:
             sup.filter(UserWarning, "This window is not suitable")
-            if window_name in ('slepian', 'hanning'):
+            if window_name in ('hanning',):
                 sup.filter(DeprecationWarning)
             # Check symmetry for odd and even lengths
             w1 = window(8, *params, sym=True)
@@ -621,7 +620,7 @@ def test_needs_params():
     for winstr in ['kaiser', 'ksr', 'gaussian', 'gauss', 'gss',
                    'general gaussian', 'general_gaussian',
                    'general gauss', 'general_gauss', 'ggs',
-                   'slepian', 'optimal', 'slep', 'dss', 'dpss',
+                   'dss', 'dpss',
                    'chebwin', 'cheb', 'exponential', 'poisson', 'tukey',
                    'tuk', 'dpss']:
         assert_raises(ValueError, get_window, winstr, 7)

--- a/scipy/signal/windows/__init__.py
+++ b/scipy/signal/windows/__init__.py
@@ -32,7 +32,6 @@ The suite of window functions for filtering and spectral estimation.
    kaiser            -- Kaiser window
    nuttall           -- Nuttall's minimum 4-term Blackman-Harris window
    parzen            -- Parzen window
-   slepian           -- Slepian window
    triang            -- Triangular window
    tukey             -- Tukey window
 
@@ -43,5 +42,5 @@ from .windows import *
 __all__ = ['boxcar', 'triang', 'parzen', 'bohman', 'blackman', 'nuttall',
            'blackmanharris', 'flattop', 'bartlett', 'hanning', 'barthann',
            'hamming', 'kaiser', 'gaussian', 'general_gaussian', 'general_cosine',
-           'general_hamming', 'chebwin', 'slepian', 'cosine', 'hann',
+           'general_hamming', 'chebwin', 'cosine', 'hann',
            'exponential', 'tukey', 'get_window', 'dpss']

--- a/scipy/signal/windows/windows.py
+++ b/scipy/signal/windows/windows.py
@@ -9,7 +9,7 @@ from scipy import linalg, special, fft as sp_fft
 __all__ = ['boxcar', 'triang', 'parzen', 'bohman', 'blackman', 'nuttall',
            'blackmanharris', 'flattop', 'bartlett', 'hanning', 'barthann',
            'hamming', 'kaiser', 'gaussian', 'general_cosine','general_gaussian',
-           'general_hamming', 'chebwin', 'slepian', 'cosine', 'hann',
+           'general_hamming', 'chebwin', 'cosine', 'hann',
            'exponential', 'tukey', 'dpss', 'get_window']
 
 
@@ -1473,93 +1473,6 @@ def chebwin(M, at, sym=True):
     return _truncate(w, needs_trunc)
 
 
-def slepian(M, width, sym=True):
-    """Return a digital Slepian (DPSS) window.
-
-    Used to maximize the energy concentration in the main lobe.  Also called
-    the digital prolate spheroidal sequence (DPSS).
-
-    .. note:: Deprecated in SciPy 1.1.
-              `slepian` will be removed in a future version of SciPy, it is
-              replaced by `dpss`, which uses the standard definition of a
-              digital Slepian window.
-
-    Parameters
-    ----------
-    M : int
-        Number of points in the output window. If zero or less, an empty
-        array is returned.
-    width : float
-        Bandwidth
-    sym : bool, optional
-        When True (default), generates a symmetric window, for use in filter
-        design.
-        When False, generates a periodic window, for use in spectral analysis.
-
-    Returns
-    -------
-    w : ndarray
-        The window, with the maximum value always normalized to 1
-
-    See Also
-    --------
-    dpss
-
-    References
-    ----------
-    .. [1] D. Slepian & H. O. Pollak: "Prolate spheroidal wave functions,
-           Fourier analysis and uncertainty-I," Bell Syst. Tech. J., vol.40,
-           pp.43-63, 1961. https://archive.org/details/bstj40-1-43
-    .. [2] H. J. Landau & H. O. Pollak: "Prolate spheroidal wave functions,
-           Fourier analysis and uncertainty-II," Bell Syst. Tech. J. , vol.40,
-           pp.65-83, 1961. https://archive.org/details/bstj40-1-65
-
-    Examples
-    --------
-    Plot the window and its frequency response:
-
-    >>> from scipy import signal
-    >>> from scipy.fft import fft, fftshift
-    >>> import matplotlib.pyplot as plt
-
-    >>> window = signal.slepian(51, width=0.3)
-    >>> plt.plot(window)
-    >>> plt.title("Slepian (DPSS) window (BW=0.3)")
-    >>> plt.ylabel("Amplitude")
-    >>> plt.xlabel("Sample")
-
-    >>> plt.figure()
-    >>> A = fft(window, 2048) / (len(window)/2.0)
-    >>> freq = np.linspace(-0.5, 0.5, len(A))
-    >>> response = 20 * np.log10(np.abs(fftshift(A / abs(A).max())))
-    >>> plt.plot(freq, response)
-    >>> plt.axis([-0.5, 0.5, -120, 0])
-    >>> plt.title("Frequency response of the Slepian window (BW=0.3)")
-    >>> plt.ylabel("Normalized magnitude [dB]")
-    >>> plt.xlabel("Normalized frequency [cycles per sample]")
-
-    """
-    warnings.warn('slepian is deprecated and will be removed in a future '
-                  'version, use dpss instead', DeprecationWarning)
-    if _len_guards(M):
-        return np.ones(M)
-    M, needs_trunc = _extend(M, sym)
-
-    # our width is the full bandwidth
-    width = width / 2
-    # to match the old version
-    width = width / 2
-    m = np.arange(M, dtype='d')
-    H = np.zeros((2, M))
-    H[0, 1:] = m[1:] * (M - m[1:]) / 2
-    H[1, :] = ((M - 1 - 2 * m) / 2)**2 * np.cos(2 * np.pi * width)
-
-    _, win = linalg.eig_banded(H, select='i', select_range=(M-1, M-1))
-    win = win.ravel() / win.max()
-
-    return _truncate(win, needs_trunc)
-
-
 def cosine(M, sym=True):
     """Return a window with a simple cosine shape.
 
@@ -1999,7 +1912,6 @@ _win_equiv_raw = {
     ('kaiser', 'ksr'): (kaiser, True),
     ('nuttall', 'nutl', 'nut'): (nuttall, False),
     ('parzen', 'parz', 'par'): (parzen, False),
-    ('slepian', 'slep', 'optimal', 'dpss', 'dss'): (slepian, True),
     ('triangle', 'triang', 'tri'): (triang, False),
     ('tukey', 'tuk'): (tukey, True),
 }
@@ -2057,7 +1969,6 @@ def get_window(window, Nx, fftbins=True):
     - `~scipy.signal.windows.kaiser` (needs beta)
     - `~scipy.signal.windows.gaussian` (needs standard deviation)
     - `~scipy.signal.windows.general_gaussian` (needs power, width)
-    - `~scipy.signal.windows.slepian` (needs width)
     - `~scipy.signal.windows.dpss` (needs normalized half-bandwidth)
     - `~scipy.signal.windows.chebwin` (needs attenuation)
     - `~scipy.signal.windows.exponential` (needs decay scale)

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -143,7 +143,7 @@ REFGUIDE_AUTOSUMMARY_SKIPLIST = [
 for name in ('barthann', 'bartlett', 'blackmanharris', 'blackman', 'bohman',
              'boxcar', 'chebwin', 'cosine', 'exponential', 'flattop',
              'gaussian', 'general_gaussian', 'hamming', 'hann', 'hanning',
-             'kaiser', 'nuttall', 'parzen', 'slepian', 'triang', 'tukey'):
+             'kaiser', 'nuttall', 'parzen', 'triang', 'tukey'):
     REFGUIDE_AUTOSUMMARY_SKIPLIST.append(r'scipy\.signal\.' + name)
 
 HAVE_MATPLOTLIB = False


### PR DESCRIPTION
It was deprecated in 1.1.0 (see gh-7802), so removing it in 1.6.0 seems about time.

I noticed it because it gives a doc build error. There's more deprecated windows (that don't give annoying doc warnings), didn't look at those.