### PR TITLE
MAINT: backports for SciPy 1.5.2

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -101,7 +101,7 @@ upload:
 	# SSH must be correctly configured for this to work.
 	# Assumes that ``make dist`` was already run
 	# Example usage: ``make upload USERNAME=rgommers RELEASE=0.17.0``
-	ssh $(USERNAME)@new.scipy.org mkdir $(UPLOAD_DIR)
+	ssh $(USERNAME)@new.scipy.org mkdir -p $(UPLOAD_DIR)
 	scp build/dist.tar.gz $(USERNAME)@new.scipy.org:$(UPLOAD_DIR)
 	ssh $(USERNAME)@new.scipy.org tar xvC $(UPLOAD_DIR) \
 	    -zf $(UPLOAD_DIR)/dist.tar.gz

--- a/doc/release/1.5.2-notes.rst
+++ b/doc/release/1.5.2-notes.rst
@@ -10,9 +10,63 @@ compared to 1.5.1.
 Authors
 =======
 
+* Peter Bell
+* Tobias Biester +
+* Evgeni Burovski
+* Ralf Gommers
+* Sturla Molden
+* Andrew Nelson
+* ofirr +
+* Sambit Panda
+* Ilhan Polat
+* Tyler Reddy
+* Atsushi Sakai
+* Pauli Virtanen
+
+A total of 12 people contributed to this release.
+People with a "+" by their names contributed a patch for the first time.
+This list of names is automatically generated, and may not be fully complete.
+
+
 Issues closed for 1.5.2
 -----------------------
+
+* `#3847 <https://github.com/scipy/scipy/issues/3847>`__: Crash of interpolate.splprep(task=-1)
+* `#7395 <https://github.com/scipy/scipy/issues/7395>`__: splprep segfaults if fixed knots are specified
+* `#10761 <https://github.com/scipy/scipy/issues/10761>`__: scipy.signal.convolve2d produces incorrect values for large arrays
+* `#11971 <https://github.com/scipy/scipy/issues/11971>`__: DOC: search in devdocs returns wrong link
+* `#12155 <https://github.com/scipy/scipy/issues/12155>`__: BUG: Fix permutation of distance matrices in scipy.stats.multiscale_graphcorr
+* `#12203 <https://github.com/scipy/scipy/issues/12203>`__: Unable to install on PyPy 7.3.1 (Python 3.6.9)
+* `#12316 <https://github.com/scipy/scipy/issues/12316>`__: negative scipy.spatial.distance.correlation
+* `#12422 <https://github.com/scipy/scipy/issues/12422>`__: BUG: slsqp: ValueError: failed to initialize intent(inout) array...
+* `#12428 <https://github.com/scipy/scipy/issues/12428>`__: stats.truncnorm.rvs() never returns a scalar in 1.5
+* `#12441 <https://github.com/scipy/scipy/issues/12441>`__: eigvalsh inconsistent eigvals= subset_by_index=
+* `#12445 <https://github.com/scipy/scipy/issues/12445>`__: DOC: scipy.linalg.eigh
+* `#12449 <https://github.com/scipy/scipy/issues/12449>`__: Warnings are not filtered in csr_matrix.sum()
+* `#12469 <https://github.com/scipy/scipy/issues/12469>`__: SciPy 1.9 exception in LSQSphereBivariateSpline
+* `#12487 <https://github.com/scipy/scipy/issues/12487>`__: BUG: optimize: incorrect result from approx_fprime
+* `#12493 <https://github.com/scipy/scipy/issues/12493>`__: CI: GitHub Actions for maintenance branches
+* `#12533 <https://github.com/scipy/scipy/issues/12533>`__: eigh gives incorrect results
 
 Pull requests for 1.5.2
 -----------------------
 
+* `#12156 <https://github.com/scipy/scipy/pull/12156>`__: BUG: Fix permutation of distance matrices in scipy.stats.multiscale_graphcorr
+* `#12238 <https://github.com/scipy/scipy/pull/12238>`__: BUG: Use 64-bit indexing in convolve2d to avoid overflow
+* `#12256 <https://github.com/scipy/scipy/pull/12256>`__: BLD: Build lsap as a single extension instead of extension +...
+* `#12320 <https://github.com/scipy/scipy/pull/12320>`__: BUG: spatial: avoid returning negative correlation distance
+* `#12383 <https://github.com/scipy/scipy/pull/12383>`__: ENH: Make cKDTree.tree more efficient
+* `#12392 <https://github.com/scipy/scipy/pull/12392>`__: DOC: update scipy-sphinx-theme
+* `#12430 <https://github.com/scipy/scipy/pull/12430>`__: BUG: truncnorm and geninvgauss never return scalars from rvs
+* `#12437 <https://github.com/scipy/scipy/pull/12437>`__: BUG: optimize: cast bounds to floats in new_bounds_to_old/old_bounds_to_new
+* `#12442 <https://github.com/scipy/scipy/pull/12442>`__: MAINT:linalg: Fix for input args of eigvalsh
+* `#12461 <https://github.com/scipy/scipy/pull/12461>`__: MAINT: sparse: write matrix/asmatrix wrappers without warning...
+* `#12478 <https://github.com/scipy/scipy/pull/12478>`__: BUG: fix array_like input defects and add tests for all functions...
+* `#12488 <https://github.com/scipy/scipy/pull/12488>`__: BUG: fix approx_derivative step size. Closes #12487
+* `#12500 <https://github.com/scipy/scipy/pull/12500>`__: CI: actions branch trigger fix
+* `#12501 <https://github.com/scipy/scipy/pull/12501>`__: CI: actions branch trigger fix
+* `#12504 <https://github.com/scipy/scipy/pull/12504>`__: BUG: cKDTreeNode use after free
+* `#12529 <https://github.com/scipy/scipy/pull/12529>`__: MAINT: allow graceful docs re-upload
+* `#12538 <https://github.com/scipy/scipy/pull/12538>`__: BUG:linalg: eigh type parameter handling corrected
+* `#12560 <https://github.com/scipy/scipy/pull/12560>`__: MAINT: truncnorm.rvs compatibility for \`Generator\`
+* `#12562 <https://github.com/scipy/scipy/pull/12562>`__: redo gh-12188: fix segfaults in splprep with fixed knots

--- a/scipy/_build_utils/compiler_helper.py
+++ b/scipy/_build_utils/compiler_helper.py
@@ -100,6 +100,6 @@ def set_cxx_flags_clib_hook(build_clib, build_info):
             new_args.append(min_macos_flag)
             new_link_args.append(min_macos_flag)
 
-    dict_append(build_info, extra_compile_args=new_args,
+    dict_append(build_info, extra_compiler_args=new_args,
                 extra_link_args=new_link_args)
 

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -1424,13 +1424,17 @@ class SmoothSphereBivariateSpline(SphereBivariateSpline):
 
     def __init__(self, theta, phi, r, w=None, s=0., eps=1E-16):
 
+        theta, phi, r = np.asarray(theta), np.asarray(phi), np.asarray(r)
+
         # input validation
         if not ((0.0 <= theta).all() and (theta <= np.pi).all()):
             raise ValueError('theta should be between [0, pi]')
         if not ((0.0 <= phi).all() and (phi <= 2.0 * np.pi).all()):
             raise ValueError('phi should be between [0, 2pi]')
-        if w is not None and not (w >= 0.0).all():
-            raise ValueError('w should be positive')
+        if w is not None:
+            w = np.asarray(w)
+            if not (w >= 0.0).all():
+                raise ValueError('w should be positive')
         if not s >= 0.0:
             raise ValueError('s should be positive')
         if not 0.0 < eps < 1.0:
@@ -1538,6 +1542,9 @@ class LSQSphereBivariateSpline(SphereBivariateSpline):
 
     def __init__(self, theta, phi, r, tt, tp, w=None, eps=1E-16):
 
+        theta, phi, r = np.asarray(theta), np.asarray(phi), np.asarray(r)
+        tt, tp = np.asarray(tt), np.asarray(tp)
+
         if not ((0.0 <= theta).all() and (theta <= np.pi).all()):
             raise ValueError('theta should be between [0, pi]')
         if not ((0.0 <= phi).all() and (phi <= 2*np.pi).all()):
@@ -1546,8 +1553,10 @@ class LSQSphereBivariateSpline(SphereBivariateSpline):
             raise ValueError('tt should be between (0, pi)')
         if not ((0.0 < tp).all() and (tp < 2*np.pi).all()):
             raise ValueError('tp should be between (0, 2pi)')
-        if w is not None and not (w >= 0.0).all():
-            raise ValueError('w should be positive')
+        if w is not None:
+            w = np.asarray(w)
+            if not (w >= 0.0).all():
+                raise ValueError('w should be positive')
         if not 0.0 < eps < 1.0:
             raise ValueError('eps should be between (0, 1)')
 
@@ -1763,6 +1772,7 @@ class RectSphereBivariateSpline(SphereBivariateSpline):
         ider[1], ider[3] = pole_flat
 
         u, v = np.ravel(u), np.ravel(v)
+        r = np.asarray(r)
 
         if not ((0.0 <= u).all() and (u <= np.pi).all()):
             raise ValueError('u should be between [0, pi]')

--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -499,7 +499,7 @@ fitpack_parcur(PyObject *dummy, PyObject *args)
     if (ap_t == NULL || ap_c == NULL) {
         goto fail;
     }
-    if (iopt == 0|| n > no) {
+    if (iopt != 1|| n > no) {
         Py_XDECREF(ap_wrk);
         ap_wrk = NULL;
         Py_XDECREF(ap_iwrk);

--- a/scipy/interpolate/tests/test_fitpack.py
+++ b/scipy/interpolate/tests/test_fitpack.py
@@ -459,6 +459,19 @@ def test_splev_der_k():
     assert_allclose(splev(x, (t, c, k), k), splev(x, tck2))
 
 
+def test_splprep_segfault():
+    # regression test for gh-3847: splprep segfaults if knots are specified
+    # for task=-1
+    t = np.arange(0, 1.1, 0.1)
+    x = np.sin(2*np.pi*t)
+    y = np.cos(2*np.pi*t)
+    tck, u = interpolate.splprep([x, y], s=0)
+    unew = np.arange(0, 1.01, 0.01)
+
+    uknots = tck[0]  # using the knots from the previous fitting
+    tck, u = interpolate.splprep([x, y], task=-1, t=uknots)  # here is the crash
+
+
 def test_bisplev_integer_overflow():
     np.random.seed(1)
 

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -309,6 +309,21 @@ class TestUnivariateSpline(object):
             LSQUnivariateSpline(x_values, y_values, t_values, k=6)
         assert "k should be 1 <= k <= 5" in str(info.value)
 
+    def test_array_like_input(self):
+        x_values = np.array([1, 2, 4, 6, 8.5])
+        y_values = np.array([0.5, 0.8, 1.3, 2.5, 2.8])
+        w_values = np.array([1.0, 1.0, 1.0, 1.0, 1.0])
+        bbox = np.array([-100, 100])
+        # np.array input
+        spl1 = UnivariateSpline(x=x_values, y=y_values, w=w_values,
+                                bbox=bbox)
+        # list input
+        spl2 = UnivariateSpline(x=x_values.tolist(), y=y_values.tolist(),
+                                w=w_values.tolist(), bbox=bbox.tolist())
+
+        assert_allclose(spl1([0.1, 0.5, 0.9, 0.99]),
+                        spl2([0.1, 0.5, 0.9, 0.99]))
+
 
 class TestLSQBivariateSpline(object):
     # NOTE: The systems in this test class are rank-deficient
@@ -430,6 +445,27 @@ class TestLSQBivariateSpline(object):
             LSQBivariateSpline(x, y, z, tx, ty, eps=1.0)
         assert "eps should be between (0, 1)" in str(exc_info.value)
 
+    def test_array_like_input(self):
+        s = 0.1
+        tx = np.array([1 + s, 3 - s])
+        ty = np.array([1 + s, 3 - s])
+        x = np.linspace(1.0, 10.0)
+        y = np.linspace(1.0, 10.0)
+        z = np.linspace(1.0, 10.0)
+        w = np.linspace(1.0, 10.0)
+        bbox = np.array([1.0, 10.0, 1.0, 10.0])
+
+        with suppress_warnings() as sup:
+            r = sup.record(UserWarning, "\nThe coefficients of the spline")
+            # np.array input
+            spl1 = LSQBivariateSpline(x, y, z, tx, ty, w=w, bbox=bbox)
+            # list input
+            spl2 = LSQBivariateSpline(x.tolist(), y.tolist(), z.tolist(),
+                                      tx.tolist(), ty.tolist(), w=w.tolist(),
+                                      bbox=bbox)
+            assert_allclose(spl1(2.0, 2.0), spl2(2.0, 2.0))
+            assert_equal(len(r), 2)
+
 
 class TestSmoothBivariateSpline(object):
     def test_linear_constant(self):
@@ -537,6 +573,20 @@ class TestSmoothBivariateSpline(object):
         with assert_raises(ValueError) as exc_info:
             SmoothBivariateSpline(x, y, z, eps=1.0)
         assert "eps should be between (0, 1)" in str(exc_info.value)
+
+    def test_array_like_input(self):
+        x = np.array([1, 1, 1, 2, 2, 2, 3, 3, 3])
+        y = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
+        z = np.array([3, 3, 3, 3, 3, 3, 3, 3, 3])
+        w = np.array([1, 1, 1, 1, 1, 1, 1, 1, 1])
+        bbox = np.array([1.0, 3.0, 1.0, 3.0])
+        # np.array input
+        spl1 = SmoothBivariateSpline(x, y, z, w=w, bbox=bbox, kx=1, ky=1)
+        # list input
+        spl2 = SmoothBivariateSpline(x.tolist(), y.tolist(), z.tolist(),
+                                     bbox=bbox.tolist(), w=w.tolist(),
+                                     kx=1, ky=1)
+        assert_allclose(spl1(0.1, 0.5), spl2(0.1, 0.5))
 
 
 class TestLSQSphereBivariateSpline(object):
@@ -651,6 +701,30 @@ class TestLSQSphereBivariateSpline(object):
                                      knotst, knotsp, eps=1.0)
         assert "eps should be between (0, 1)" in str(exc_info.value)
 
+    def test_array_like_input(self):
+        ntheta, nphi = 70, 90
+        theta = linspace(0.5 / (ntheta - 1), 1 - 0.5 / (ntheta - 1),
+                         ntheta) * pi
+        phi = linspace(0.5 / (nphi - 1), 1 - 0.5 / (nphi - 1),
+                       nphi) * 2. * pi
+        lats, lons = meshgrid(theta, phi)
+        data = ones((theta.shape[0], phi.shape[0]))
+        # define knots and extract data values at the knots
+        knotst = theta[::5]
+        knotsp = phi[::5]
+        w = ones((lats.ravel().shape[0]))
+
+        # np.array input
+        spl1 = LSQSphereBivariateSpline(lats.ravel(), lons.ravel(),
+                                        data.T.ravel(), knotst, knotsp, w=w)
+        # list input
+        spl2 = LSQSphereBivariateSpline(lats.ravel().tolist(),
+                                        lons.ravel().tolist(),
+                                        data.T.ravel().tolist(),
+                                        knotst.tolist(),
+                                        knotsp.tolist(), w=w.tolist())
+        assert_array_almost_equal(spl1(1.0, 1.0), spl2(1.0, 1.0))
+
 
 class TestSmoothSphereBivariateSpline(object):
     def setup_method(self):
@@ -719,6 +793,22 @@ class TestSmoothSphereBivariateSpline(object):
         with assert_raises(ValueError) as exc_info:
             SmoothSphereBivariateSpline(theta, phi, r, eps=1.0)
         assert "eps should be between (0, 1)" in str(exc_info.value)
+
+    def test_array_like_input(self):
+        theta = np.array([.25 * pi, .25 * pi, .25 * pi, .5 * pi, .5 * pi,
+                          .5 * pi, .75 * pi, .75 * pi, .75 * pi])
+        phi = np.array([.5 * pi, pi, 1.5 * pi, .5 * pi, pi, 1.5 * pi, .5 * pi,
+                        pi, 1.5 * pi])
+        r = np.array([3, 3, 3, 3, 3, 3, 3, 3, 3])
+        w = np.array([1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0])
+
+        # np.array input
+        spl1 = SmoothSphereBivariateSpline(theta, phi, r, w=w, s=1E10)
+
+        # list input
+        spl2 = SmoothSphereBivariateSpline(theta.tolist(), phi.tolist(),
+                                           r.tolist(), w=w.tolist(), s=1E10)
+        assert_array_almost_equal(spl1(1.0, 1.0), spl2(1.0, 1.0))
 
 
 class TestRectBivariateSpline(object):
@@ -825,6 +915,18 @@ class TestRectBivariateSpline(object):
             RectBivariateSpline(x, y, z, s=-1.0)
         assert "s should be s >= 0.0" in str(info.value)
 
+    def test_array_like_input(self):
+        x = array([1, 2, 3, 4, 5])
+        y = array([1, 2, 3, 4, 5])
+        z = array([[1, 2, 1, 2, 1], [1, 2, 1, 2, 1], [1, 2, 3, 2, 1],
+                   [1, 2, 2, 2, 1], [1, 2, 1, 2, 1]])
+        bbox = array([1, 5, 1, 5])
+
+        spl1 = RectBivariateSpline(x, y, z, bbox=bbox)
+        spl2 = RectBivariateSpline(x.tolist(), y.tolist(), z.tolist(),
+                                   bbox=bbox.tolist())
+        assert_array_almost_equal(spl1(1.0, 1.0), spl2(1.0, 1.0))
+
 
 class TestRectSphereBivariateSpline(object):
     def test_defaults(self):
@@ -924,6 +1026,20 @@ class TestRectSphereBivariateSpline(object):
             lons = np.linspace(10, 350, 18) * np.pi / 180.
             RectSphereBivariateSpline(lats, lons, data, s=-1)
         assert "s should be positive" in str(exc_info.value)
+
+    def test_array_like_input(self):
+        y = linspace(0.01, 2 * pi - 0.01, 7)
+        x = linspace(0.01, pi - 0.01, 7)
+        z = array([[1, 2, 1, 2, 1, 2, 1], [1, 2, 1, 2, 1, 2, 1],
+                   [1, 2, 3, 2, 1, 2, 1],
+                   [1, 2, 2, 2, 1, 2, 1], [1, 2, 1, 2, 1, 2, 1],
+                   [1, 2, 2, 2, 1, 2, 1],
+                   [1, 2, 1, 2, 1, 2, 1]])
+        # np.array input
+        spl1 = RectSphereBivariateSpline(x, y, z)
+        # list input
+        spl2 = RectSphereBivariateSpline(x.tolist(), y.tolist(), z.tolist())
+        assert_array_almost_equal(spl1(x, y), spl2(x, y))
 
 
 def _numdiff_2d(func, x, y, dx=0, dy=0, eps=1e-8):

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -460,8 +460,11 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
             raise ValueError("wrong b dimensions {}, should "
                              "be {}".format(b1.shape, a1.shape))
 
+        if type not in [1, 2, 3]:
+            raise ValueError('"type" can only accepts values 1, 2, and 3.')
+
         cplx = True if iscomplexobj(b1) else (cplx or False)
-        drv_args.update({'overwrite_b': overwrite_b})
+        drv_args.update({'overwrite_b': overwrite_b, 'itype': type})
 
     # backwards-compatibility handling
     subset_by_index = subset_by_index if (eigvals is None) else eigvals

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -461,7 +461,7 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
                              "be {}".format(b1.shape, a1.shape))
 
         if type not in [1, 2, 3]:
-            raise ValueError('"type" can only accepts values 1, 2, and 3.')
+            raise ValueError('"type" keyword only accepts 1, 2, and 3.')
 
         cplx = True if iscomplexobj(b1) else (cplx or False)
         drv_args.update({'overwrite_b': overwrite_b, 'itype': type})

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -293,7 +293,7 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
         If omitted, identity matrix is assumed.
     lower : bool, optional
         Whether the pertinent array data is taken from the lower or upper
-        triangle of `a`. (Default: lower)
+        triangle of ``a`` and, if applicable, ``b``. (Default: lower)
     eigvals_only : bool, optional
         Whether to calculate only eigenvalues and no eigenvectors.
         (Default: both are calculated)
@@ -905,7 +905,7 @@ def eigvalsh(a, b=None, lower=True, overwrite_a=False,
         If omitted, identity matrix is assumed.
     lower : bool, optional
         Whether the pertinent array data is taken from the lower or upper
-        triangle of `a`. (Default: lower)
+        triangle of ``a`` and, if applicable, ``b``. (Default: lower)
     eigvals_only : bool, optional
         Whether to calculate only eigenvalues and no eigenvectors.
         (Default: both are calculated)
@@ -1006,9 +1006,9 @@ def eigvalsh(a, b=None, lower=True, overwrite_a=False,
     """
     return eigh(a, b=b, lower=lower, eigvals_only=True,
                 overwrite_a=overwrite_a, overwrite_b=overwrite_b,
-                turbo=turbo, eigvals=None, type=type,
-                check_finite=check_finite, subset_by_index=eigvals,
-                subset_by_value=None, driver=None)
+                turbo=turbo, eigvals=eigvals, type=type,
+                check_finite=check_finite, subset_by_index=subset_by_index,
+                subset_by_value=subset_by_value, driver=driver)
 
 
 def eigvals_banded(a_band, lower=False, overwrite_a_band=False,

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -878,6 +878,20 @@ class TestEigh:
         diag2_ = diag(z.T.conj() @ b @ z).real
         assert_allclose(diag2_, ones(diag2_.shape[0]), rtol=0., atol=atol)
 
+    def test_eigvalsh_new_args(self):
+        a = _random_hermitian_matrix(5)
+        w = eigvalsh(a, eigvals=[1, 2])
+        assert_equal(len(w), 2)
+
+        w2 = eigvalsh(a, subset_by_index=[1, 2])
+        assert_equal(len(w2), 2)
+        assert_allclose(w, w2)
+
+        b = np.diag([1, 1.2, 1.3, 1.5, 2])
+        w3 = eigvalsh(b, subset_by_value=[1, 1.4])
+        assert_equal(len(w3), 2)
+        assert_allclose(w3, np.array([1.2, 1.3]))
+
 
 class TestLU(object):
     def setup_method(self):

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -39,7 +39,7 @@ from numpy import (array, diag, ones, full, linalg, argsort, zeros, arange,
 from numpy.random import seed, random
 
 from scipy.linalg._testutils import assert_no_overwrite
-from scipy.sparse.sputils import bmat, matrix
+from scipy.sparse.sputils import matrix
 
 
 def _random_hermitian_matrix(n, posdef=False, dtype=float):
@@ -304,8 +304,8 @@ class TestEig(object):
         D = array(([1, -1, 0], [-1, 1, 0], [0, 0, 0]))
         Z = zeros((3, 3))
         I3 = eye(3)
-        A = bmat([[I3, Z], [Z, -K]])
-        B = bmat([[Z, I3], [M, D]])
+        A = np.block([[I3, Z], [Z, -K]])
+        B = np.block([[Z, I3], [M, D]])
 
         with np.errstate(all='ignore'):
             self._check_gen_eig(A, B)

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -849,7 +849,7 @@ class TestEigh:
     @pytest.mark.parametrize('type', (1, 2, 3))
     @pytest.mark.parametrize('driver', ("gv", "gvd", "gvx"))
     def test_various_drivers_generalized(self, driver, type):
-        atol = 1000*np.spacing(1.)
+        atol = np.spacing(5000.)
         a = _random_hermitian_matrix(20)
         b = _random_hermitian_matrix(20, posdef=True)
         w, v = eigh(a=a, b=b, driver=driver, type=type)

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -780,6 +780,9 @@ class TestEigh:
         assert_raises(ValueError, eigh, np.ones([2, 2]), np.ones([2, 1]))
         # Incompatible a, b sizes
         assert_raises(ValueError, eigh, np.ones([3, 3]), np.ones([2, 2]))
+        # Wrong type parameter for generalized problem
+        assert_raises(ValueError, eigh, np.ones([3, 3]), np.ones([3, 3]),
+                      type=4)
         # Both value and index subsets requested
         assert_raises(ValueError, eigh, np.ones([3, 3]), np.ones([3, 3]),
                       subset_by_value=[1, 2], eigvals=[2, 4])
@@ -843,13 +846,19 @@ class TestEigh:
         w, v = eigh(a, driver=driver)
         assert_allclose(a @ v - (v * w), 0., atol=1000*np.spacing(1.), rtol=0.)
 
+    @pytest.mark.parametrize('type', (1, 2, 3))
     @pytest.mark.parametrize('driver', ("gv", "gvd", "gvx"))
-    def test_various_drivers_generalized(self, driver):
+    def test_various_drivers_generalized(self, driver, type):
+        atol = 1000*np.spacing(1.)
         a = _random_hermitian_matrix(20)
         b = _random_hermitian_matrix(20, posdef=True)
-        w, v = eigh(a=a, b=b, driver=driver)
-        assert_allclose(a @ v - w*(b @ v), 0.,
-                        atol=1000*np.spacing(1.), rtol=0.)
+        w, v = eigh(a=a, b=b, driver=driver, type=type)
+        if type == 1:
+            assert_allclose(a @ v - w*(b @ v), 0., atol=atol, rtol=0.)
+        elif type == 2:
+            assert_allclose(a @ b @ v - v * w, 0., atol=atol, rtol=0.)
+        else:
+            assert_allclose(b @ a @ v - v * w, 0., atol=atol, rtol=0.)
 
     # Old eigh tests kept for backwards compatibility
     @pytest.mark.parametrize('eigvals', (None, (2, 4)))

--- a/scipy/linalg/tests/test_solvers.py
+++ b/scipy/linalg/tests/test_solvers.py
@@ -79,10 +79,10 @@ class TestSolveLyapunov(object):
          np.eye(11)),
         # https://github.com/scipy/scipy/issues/4176
         (matrix([[0, 1], [-1/2, -1]]),
-         (matrix([0, 3]).T * matrix([0, 3]).T.T)),
+         (matrix([0, 3]).T @ matrix([0, 3]).T.T)),
         # https://github.com/scipy/scipy/issues/4176
         (matrix([[0, 1], [-1/2, -1]]),
-         (np.array(matrix([0, 3]).T * matrix([0, 3]).T.T))),
+         (np.array(matrix([0, 3]).T @ matrix([0, 3]).T.T))),
         ]
 
     def test_continuous_squareness_and_shape(self):

--- a/scipy/optimize/_constraints.py
+++ b/scipy/optimize/_constraints.py
@@ -298,8 +298,8 @@ def new_bounds_to_old(lb, ub, n):
     if ub.ndim == 0:
         ub = np.resize(ub, n)
 
-    lb = [x if x > -np.inf else None for x in lb]
-    ub = [x if x < np.inf else None for x in ub]
+    lb = [float(x) if x > -np.inf else None for x in lb]
+    ub = [float(x) if x < np.inf else None for x in ub]
 
     return list(zip(lb, ub))
 
@@ -314,8 +314,8 @@ def old_bound_to_new(bounds):
     -np.inf/np.inf.
     """
     lb, ub = zip(*bounds)
-    lb = np.array([x if x is not None else -np.inf for x in lb])
-    ub = np.array([x if x is not None else np.inf for x in ub])
+    lb = np.array([float(x) if x is not None else -np.inf for x in lb])
+    ub = np.array([float(x) if x is not None else np.inf for x in ub])
     return lb, ub
 
 

--- a/scipy/optimize/_numdiff.py
+++ b/scipy/optimize/_numdiff.py
@@ -403,7 +403,7 @@ def approx_derivative(fun, x0, method='3-point', rel_step=None, abs_step=None,
         else:
             # user specifies an absolute step
             sign_x0 = (x0 >= 0).astype(float) * 2 - 1
-            h = abs_step * sign_x0
+            h = abs_step
 
             # cannot have a zero step. This might happen if x0 is very large
             # or small. In which case fall back to relative step.

--- a/scipy/optimize/tests/test_constraints.py
+++ b/scipy/optimize/tests/test_constraints.py
@@ -161,6 +161,13 @@ def test_old_bounds_to_new():
     assert_array_equal(lb, lb_true)
     assert_array_equal(ub, ub_true)
 
+    bounds = [(-np.inf, np.inf), (np.array([1]), np.array([1]))]
+    lb, ub = old_bound_to_new(bounds)
+
+    assert_array_equal(lb, [-np.inf, 1])
+    assert_array_equal(ub, [np.inf, 1])
+
+
 def test_bounds_repr():
     from numpy import array, inf  # so that eval works
     for args in (

--- a/scipy/optimize/tests/test_slsqp.py
+++ b/scipy/optimize/tests/test_slsqp.py
@@ -312,6 +312,12 @@ class TestSLSQP(object):
         # This should not raise an exception
         fmin_slsqp(lambda z: z**2 - 1, [0], bounds=[[0, 1]], iprint=0)
 
+    def test_array_bounds(self):
+        # This should pass (1-element arrays are castable to floats in numpy)
+        bounds = [(-np.inf, np.inf), (np.array([2]), np.array([3]))]
+        x = fmin_slsqp(lambda z: np.sum(z**2 - 1), [2.5, 2.5], bounds=bounds, iprint=0)
+        assert_array_almost_equal(x, [0, 2])
+
     def test_obj_must_return_scalar(self):
         # Regression test for Github Issue #5433
         # If objective function does not return a scalar, raises ValueError

--- a/scipy/signal/firfilter.c
+++ b/scipy/signal/firfilter.c
@@ -1,9 +1,11 @@
 #define NO_IMPORT_ARRAY
 #include "numpy/ndarrayobject.h"
 #include "sigtools.h"
+#include <stdbool.h>
+#include <stdint.h>
 
 static int elsizes[] = {sizeof(npy_bool),
-			            sizeof(npy_byte),
+                        sizeof(npy_byte),
                         sizeof(npy_ubyte),
                         sizeof(npy_short),
                         sizeof(npy_ushort),
@@ -22,13 +24,12 @@ static int elsizes[] = {sizeof(npy_bool),
                         sizeof(void *),
 			0,0,0,0};
 
-typedef void (OneMultAddFunction) (char *, char *, npy_intp, char **, npy_intp);
+typedef void (OneMultAddFunction) (char *, char *, int64_t, char **, int64_t);
 
 #define MAKE_ONEMULTADD(fname, type) \
-static void fname ## _onemultadd(char *sum, char *term1, npy_intp str, char **pvals, npy_intp n) { \
-        npy_intp k; \
+static void fname ## _onemultadd(char *sum, char *term1, int64_t str, char **pvals, int64_t n) { \
         type dsum = *(type*)sum; \
-        for (k=0; k < n; k++) { \
+        for (int64_t k=0; k < n; k++) { \
           type tmp = *(type*)(term1 + k * str); \
           dsum += tmp * *(type*)pvals[k]; \
         } \
@@ -65,10 +66,9 @@ static void fname ## _onemultadd2(char *sum, char *term1, char *term2) { \
   return; }
 
 #define MAKE_C_ONEMULTADD2(fname, type) \
-static void fname ## _onemultadd(char *sum, char *term1, npy_intp str, \
-                                 char **pvals, npy_intp n) { \
-        npy_intp k; \
-        for (k=0; k < n; k++) { \
+static void fname ## _onemultadd(char *sum, char *term1, int64_t str, \
+                                 char **pvals, int64_t n) { \
+        for (int64_t k=0; k < n; k++) { \
           fname ## _onemultadd2(sum, term1 + k * str, pvals[k]); \
         } \
 }
@@ -114,104 +114,97 @@ int pylab_convolve_2d (char  *in,        /* Input data Ns[0] x Ns[1] */
 		       int   flag,       /* convolution parameters */
 		       char  *fillvalue) /* fill value */
 {
-  int bounds_pad_flag = 0;
-  int m, n, j, ind0, ind1;
-  int Os[2];
-  int new_m, new_n, ind0_memory=0;
-  int boundary, outsize, convolve, type_num, type_size;
-  char ** indices;
-  OneMultAddFunction *mult_and_add;
-
-  boundary = flag & BOUNDARY_MASK;  /* flag can be fill, reflecting, circular */
-  outsize = flag & OUTSIZE_MASK;
-  convolve = flag & FLIP_MASK;
-  type_num = (flag & TYPE_MASK) >> TYPE_SHIFT;
+  const int boundary = flag & BOUNDARY_MASK;  /* flag can be fill, reflecting, circular */
+  const int outsize = flag & OUTSIZE_MASK;
+  const int convolve = flag & FLIP_MASK;
+  const int type_num = (flag & TYPE_MASK) >> TYPE_SHIFT;
   /*type_size*/
 
-  mult_and_add = OneMultAdd[type_num];
+  OneMultAddFunction *mult_and_add = OneMultAdd[type_num];
   if (mult_and_add == NULL) return -5;  /* Not available for this type */
 
   if (type_num < 0 || type_num > MAXTYPES) return -4;  /* Invalid type */
-  type_size = elsizes[type_num];
+  const int type_size = elsizes[type_num];
 
+  int64_t Os[2];
   if (outsize == FULL) {Os[0] = Ns[0]+Nwin[0]-1; Os[1] = Ns[1]+Nwin[1]-1;}
   else if (outsize == SAME) {Os[0] = Ns[0]; Os[1] = Ns[1];}
   else if (outsize == VALID) {Os[0] = Ns[0]-Nwin[0]+1; Os[1] = Ns[1]-Nwin[1]+1;}
   else return -1; /* Invalid output flag */
-  
+
   if ((boundary != PAD) && (boundary != REFLECT) && (boundary != CIRCULAR))
     return -2; /* Invalid boundary flag */
 
-  indices = malloc(Nwin[1] * sizeof(indices[0]));
+  char **indices = malloc(Nwin[1] * sizeof(indices[0]));
   if (indices == NULL) return -3; /* No memory */
 
   /* Speed this up by not doing any if statements in the for loop.  Need 3*3*2=18 different
      loops executed for different conditions */
 
-  for (m=0; m < Os[0]; m++) {
+  for (int64_t m=0; m < Os[0]; m++) {
     /* Reposition index into input image based on requested output size */
+    int64_t new_m;
     if (outsize == FULL) new_m = convolve ? m : (m-Nwin[0]+1);
     else if (outsize == SAME) new_m = convolve ? (m+((Nwin[0]-1)>>1)) : (m-((Nwin[0]-1) >> 1));
     else new_m = convolve ? (m+Nwin[0]-1) : m; /* VALID */
 
-    for (n=0; n < Os[1]; n++) {  /* loop over columns */
+    for (int64_t n=0; n < Os[1]; n++) {  /* loop over columns */
       char * sum = out+m*outstr[0]+n*outstr[1];
       memset(sum, 0, type_size); /* sum = 0.0; */
 
+      int64_t new_n;
       if (outsize == FULL) new_n = convolve ? n : (n-Nwin[1]+1);
       else if (outsize == SAME) new_n = convolve ? (n+((Nwin[1]-1)>>1)) : (n-((Nwin[1]-1) >> 1));
       else new_n = convolve ? (n+Nwin[1]-1) : n;
 
       /* Sum over kernel, if index into image is out of bounds
 	 handle it according to boundary flag */
-      for (j=0; j < Nwin[0]; j++) {
-	ind0 = convolve ? (new_m-j): (new_m+j);
-	bounds_pad_flag = 0;
+      for (int64_t j=0; j < Nwin[0]; j++) {
+	int64_t ind0 = convolve ? (new_m-j): (new_m+j);
+	bool bounds_pad_flag = false;
 
 	if (ind0 < 0) {
 	  if (boundary == REFLECT) ind0 = -1-ind0;
 	  else if (boundary == CIRCULAR) ind0 = Ns[0] + ind0;
-	  else bounds_pad_flag = 1;
+	  else bounds_pad_flag = true;
 	}
 	else if (ind0 >= Ns[0]) {
 	  if (boundary == REFLECT) ind0 = Ns[0]+Ns[0]-1-ind0;
 	  else if (boundary == CIRCULAR) ind0 = ind0 - Ns[0];
-	  else bounds_pad_flag = 1;
+	  else bounds_pad_flag = true;
 	}
-	
-	if (!bounds_pad_flag) ind0_memory = ind0*instr[0];
 
-        if (bounds_pad_flag) {
-          npy_intp k;
-          for (k=0; k < Nwin[1]; k++) {
-              indices[k] = fillvalue;
-          }
-        }
-        else  {
-          npy_intp k;
-	  for (k=0; k < Nwin[1]; k++) {
-	    ind1 = convolve ? (new_n-k) : (new_n+k);
+	const int64_t ind0_memory = ind0*instr[0];
+
+	if (bounds_pad_flag) {
+	  for (int64_t k=0; k < Nwin[1]; k++) {
+	      indices[k] = fillvalue;
+	  }
+	}
+	else  {
+	  for (int64_t k=0; k < Nwin[1]; k++) {
+	    int64_t ind1 = convolve ? (new_n-k) : (new_n+k);
 	    if (ind1 < 0) {
 	      if (boundary == REFLECT) ind1 = -1-ind1;
 	      else if (boundary == CIRCULAR) ind1 = Ns[1] + ind1;
-	      else bounds_pad_flag = 1;
+	      else bounds_pad_flag = true;
 	    }
 	    else if (ind1 >= Ns[1]) {
 	      if (boundary == REFLECT) ind1 = Ns[1]+Ns[1]-1-ind1;
 	      else if (boundary == CIRCULAR) ind1 = ind1 - Ns[1];
-	      else bounds_pad_flag = 1;
+	      else bounds_pad_flag = true;
 	    }
 
 	    if (bounds_pad_flag) {
-              indices[k] = fillvalue;
-            }
+	      indices[k] = fillvalue;
+	    }
 	    else {
-              indices[k] = in+ind0_memory+ind1*instr[1];
-            }
-	    bounds_pad_flag = 0;
+	      indices[k] = in+ind0_memory+ind1*instr[1];
+	    }
+	    bounds_pad_flag = false;
 	  }
-        }
-        mult_and_add(sum, hvals+j*hstr[0], hstr[1], indices, Nwin[1]);
+	}
+	mult_and_add(sum, hvals+j*hstr[0], hstr[1], indices, Nwin[1]);
       }
     }
   }

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -418,9 +418,9 @@ class TestLsim(object):
 
     def test_double_integrator(self):
         # double integrator: y'' = 2u
-        A = matrix("0. 1.; 0. 0.")
-        B = matrix("0.; 1.")
-        C = matrix("2. 0.")
+        A = matrix([[0., 1.], [0., 0.]])
+        B = matrix([[0.], [1.]])
+        C = matrix([[2., 0.]])
         system = self.lti_nowarn(A, B, C, 0.)
         t = np.linspace(0,5)
         u = np.ones_like(t)
@@ -436,9 +436,9 @@ class TestLsim(object):
         #   x2' + x2 = u
         #   y = x1
         # Exact solution with u = 0 is y(t) = t exp(-t)
-        A = matrix("-1. 1.; 0. -1.")
-        B = matrix("0.; 1.")
-        C = matrix("1. 0.")
+        A = matrix([[-1., 1.], [0., -1.]])
+        B = matrix([[0.], [1.]])
+        C = matrix([[1., 0.]])
         system = self.lti_nowarn(A, B, C, 0.)
         t = np.linspace(0,5)
         u = np.zeros_like(t)

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -409,6 +409,7 @@ class TestConvolve2d(_TestConvolve2d):
         assert_raises(ValueError, convolve2d, [[[3]]], [[[4]]])
 
     @pytest.mark.slow
+    @pytest.mark.xfail_on_32bit("Can't create large array for test")
     def test_large_array(self):
         # Test indexing doesn't overflow an int (gh-10761)
         n = 2**31 // (1000 * np.int64().itemsize)

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -408,6 +408,20 @@ class TestConvolve2d(_TestConvolve2d):
         assert_raises(ValueError, convolve2d, [3], [4])
         assert_raises(ValueError, convolve2d, [[[3]]], [[[4]]])
 
+    @pytest.mark.slow
+    def test_large_array(self):
+        # Test indexing doesn't overflow an int (gh-10761)
+        n = 2**31 // (1000 * np.int64().itemsize)
+
+        # Create a chequered pattern of 1s and 0s
+        a = np.zeros(1001 * n, dtype=np.int64)
+        a[::2] = 1
+        a = np.lib.stride_tricks.as_strided(a, shape=(n, 1000), strides=(8008, 8))
+
+        count = signal.convolve2d(a, [[1, 1]])
+        fails = np.where(count > 1)
+        assert fails[0].size == 0
+
 
 class TestFFTConvolve(object):
 

--- a/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
@@ -21,7 +21,7 @@ import numpy as np
 from scipy.linalg import (inv, eigh, cho_factor, cho_solve, cholesky,
                           LinAlgError)
 from scipy.sparse.linalg import aslinearoperator
-from scipy.sparse.sputils import bmat
+from numpy import block as bmat
 
 __all__ = ['lobpcg']
 

--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -340,22 +340,15 @@ def is_pydata_spmatrix(m):
 ###############################################################################
 # Wrappers for NumPy types that are deprecated
 
+# Numpy versions of these functions raise deprecation warnings, the
+# ones below do not.
+
+
 def matrix(*args, **kwargs):
-    with warnings.catch_warnings(record=True):
-        warnings.filterwarnings(
-            'ignore', '.*the matrix subclass is not the recommended way.*')
-        return np.matrix(*args, **kwargs)
+    return np.array(*args, **kwargs).view(np.matrix)
 
 
-def asmatrix(*args, **kwargs):
-    with warnings.catch_warnings(record=True):
-        warnings.filterwarnings(
-            'ignore', '.*the matrix subclass is not the recommended way.*')
-        return np.asmatrix(*args, **kwargs)
-
-
-def bmat(*args, **kwargs):
-    with warnings.catch_warnings(record=True):
-        warnings.filterwarnings(
-            'ignore', '.*the matrix subclass is not the recommended way.*')
-        return np.bmat(*args, **kwargs)
+def asmatrix(data, dtype=None):
+    if isinstance(data, np.matrix) and (dtype is None or data.dtype == dtype):
+        return data
+    return np.asarray(data, dtype=dtype).view(np.matrix)

--- a/scipy/sparse/tests/test_sputils.py
+++ b/scipy/sparse/tests/test_sputils.py
@@ -153,3 +153,29 @@ class TestSparseUtils(object):
     def test_check_shape_overflow(self):
         new_shape = sputils.check_shape([(10, -1)], (65535, 131070))
         assert_equal(new_shape, (10, 858967245))
+
+    def test_matrix(self):
+        a = [[1, 2, 3]]
+        b = np.array(a)
+
+        assert isinstance(sputils.matrix(a), np.matrix)
+        assert isinstance(sputils.matrix(b), np.matrix)
+
+        c = sputils.matrix(b)
+        c[:, :] = 123
+        assert_equal(b, a)
+
+        c = sputils.matrix(b, copy=False)
+        c[:, :] = 123
+        assert_equal(b, [[123, 123, 123]])
+
+    def test_asmatrix(self):
+        a = [[1, 2, 3]]
+        b = np.array(a)
+
+        assert isinstance(sputils.asmatrix(a), np.matrix)
+        assert isinstance(sputils.asmatrix(b), np.matrix)
+
+        c = sputils.asmatrix(b)
+        c[:, :] = 123
+        assert_equal(b, [[123, 123, 123]])

--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -335,37 +335,35 @@ cdef class cKDTreeNode:
         readonly np.intp_t    level
         readonly np.intp_t    split_dim
         readonly np.intp_t    children
+        readonly np.intp_t    start_idx
+        readonly np.intp_t    end_idx
         readonly np.float64_t split
-        ckdtreenode           *_node
         np.ndarray            _data
         np.ndarray            _indices
         readonly object       lesser
         readonly object       greater
 
-    cdef void _setup(cKDTreeNode self):
+    cdef void _setup(cKDTreeNode self, cKDTree parent, ckdtreenode *node, np.intp_t level):
         cdef cKDTreeNode n1, n2
-        self.split_dim = self._node.split_dim
-        self.children = self._node.children
-        self.split = self._node.split
+        self.level = level
+        self.split_dim = node.split_dim
+        self.children = node.children
+        self.split = node.split
+        self.start_idx = node.start_idx
+        self.end_idx = node.end_idx
+        self._data = parent.data
+        self._indices = parent.indices
         if self.split_dim == -1:
             self.lesser = None
             self.greater = None
         else:
             # setup lesser branch
             n1 = cKDTreeNode()
-            n1._node = self._node.less
-            n1._data = self._data
-            n1._indices = self._indices
-            n1.level = self.level + 1
-            n1._setup()
+            n1._setup(parent, node=node.less, level=level + 1)
             self.lesser = n1
             # setup greater branch
             n2 = cKDTreeNode()
-            n2._node = self._node.greater
-            n2._data = self._data
-            n2._indices = self._indices
-            n2.level = self.level + 1
-            n2._setup()
+            n2._setup(parent, node=node.greater, level=level + 1)
             self.greater = n2
 
     property data_points:
@@ -375,8 +373,8 @@ cdef class cKDTreeNode:
     property indices:
         def __get__(cKDTreeNode self):
             cdef np.intp_t start, stop
-            start = self._node.start_idx
-            stop = self._node.end_idx
+            start = self.start_idx
+            stop = self.end_idx
             return self._indices[start:stop]
 
 
@@ -505,11 +503,7 @@ cdef class cKDTree:
                 return self._python_tree
             else:
                 n = cKDTreeNode()
-                n._node = cself.ctree
-                n._data = self.data
-                n._indices = self.indices
-                n.level = 0
-                n._setup()
+                n._setup(self, node=cself.ctree, level=0)
                 self._python_tree = n
                 return self._python_tree
 

--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -339,11 +339,34 @@ cdef class cKDTreeNode:
         ckdtreenode           *_node
         np.ndarray            _data
         np.ndarray            _indices
+        readonly object       lesser
+        readonly object       greater
 
     cdef void _setup(cKDTreeNode self):
+        cdef cKDTreeNode n1, n2
         self.split_dim = self._node.split_dim
         self.children = self._node.children
         self.split = self._node.split
+        if self.split_dim == -1:
+            self.lesser = None
+            self.greater = None
+        else:
+            # setup lesser branch
+            n1 = cKDTreeNode()
+            n1._node = self._node.less
+            n1._data = self._data
+            n1._indices = self._indices
+            n1.level = self.level + 1
+            n1._setup()
+            self.lesser = n1
+            # setup greater branch
+            n2 = cKDTreeNode()
+            n2._node = self._node.greater
+            n2._data = self._data
+            n2._indices = self._indices
+            n2.level = self.level + 1
+            n2._setup()
+            self.greater = n2
 
     property data_points:
         def __get__(cKDTreeNode self):
@@ -351,40 +374,10 @@ cdef class cKDTreeNode:
 
     property indices:
         def __get__(cKDTreeNode self):
-            cdef np.intp_t i, start, stop
-            if self.split_dim == -1:
-                start = self._node.start_idx
-                stop = self._node.end_idx
-                return self._indices[start:stop]
-            else:
-                return np.hstack([self.lesser.indices,
-                           self.greater.indices])
-
-    property lesser:
-        def __get__(cKDTreeNode self):
-            if self.split_dim == -1:
-                return None
-            else:
-                n = cKDTreeNode()
-                n._node = self._node.less
-                n._data = self._data
-                n._indices = self._indices
-                n.level = self.level + 1
-                n._setup()
-                return n
-
-    property greater:
-        def __get__(cKDTreeNode self):
-            if self.split_dim == -1:
-                return None
-            else:
-                n = cKDTreeNode()
-                n._node = self._node.greater
-                n._data = self._data
-                n._indices = self._indices
-                n.level = self.level + 1
-                n._setup()
-                return n
+            cdef np.intp_t start, stop
+            start = self._node.start_idx
+            stop = self._node.end_idx
+            return self._indices[start:stop]
 
 
 # Main cKDTree class
@@ -469,7 +462,10 @@ cdef class cKDTree:
     mins : ndarray, shape (m,)
         The minimum value in each dimension of the n data points.
     tree : object, class cKDTreeNode
-        This class exposes a Python view of the root node in the cKDTree object.
+        This attribute exposes a Python view of the root node in the cKDTree 
+        object. A full Python view of the kd-tree is created dynamically 
+        on the first access. This attribute allows you to create your own 
+        query functions in Python.
     size : int
         The number of nodes in the tree.
 
@@ -480,7 +476,7 @@ cdef class cKDTree:
     """
     cdef:
         ckdtree * cself
-        readonly cKDTreeNode     tree
+        object                   _python_tree
         readonly np.ndarray      data
         readonly np.ndarray      maxes
         readonly np.ndarray      mins
@@ -490,12 +486,32 @@ cdef class cKDTree:
 
     property n:
         def __get__(self): return self.cself.n
+    
     property m:
         def __get__(self): return self.cself.m
+    
     property leafsize:
         def __get__(self): return self.cself.leafsize
+    
     property size:
         def __get__(self): return self.cself.size
+
+    property tree:
+        # make the tree viewable from Python
+        def __get__(cKDTree self):
+            cdef cKDTreeNode n
+            cdef ckdtree *cself = self.cself
+            if self._python_tree is not None:
+                return self._python_tree
+            else:
+                n = cKDTreeNode()
+                n._node = cself.ctree
+                n._data = self.data
+                n._indices = self.indices
+                n.level = 0
+                n._setup()
+                self._python_tree = n
+                return self._python_tree
 
     def __cinit__(cKDTree self):
         self.cself = <ckdtree * > PyMem_Malloc(sizeof(ckdtree))
@@ -510,6 +526,8 @@ cdef class cKDTree:
             np.float64_t *ptmpmins
             ckdtree *cself = self.cself
             int compact, median
+
+        self._python_tree = None
 
         data = np.array(data, order='C', copy=copy_data, dtype=np.float64)
 
@@ -591,14 +609,6 @@ cdef class cKDTree:
         cself.size = cself.tree_buffer.size()
 
         self._post_init_traverse(cself.ctree)
-
-        # make the tree viewable from Python
-        self.tree = cKDTreeNode()
-        self.tree._node = cself.ctree
-        self.tree._data = self.data
-        self.tree._indices = self.indices
-        self.tree.level = 0
-        self.tree._setup()
 
     cdef _post_init_traverse(cKDTree self, ckdtreenode *node):
         cself = self.cself
@@ -1507,6 +1517,7 @@ cdef class cKDTree:
         mytree = np.asarray(<char[:tree.size]> <char*> cself.tree_buffer.data())
 
         # set raw pointers
+        self._python_tree = None
         self._pre_init()
 
         # copy the tree data

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -712,7 +712,7 @@ def correlation(u, v, w=None, centered=True):
     uu = np.average(np.square(u), weights=w)
     vv = np.average(np.square(v), weights=w)
     dist = 1.0 - uv / np.sqrt(uu * vv)
-    return dist
+    return np.abs(dist)
 
 
 def cosine(u, v, w=None):

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -712,6 +712,7 @@ def correlation(u, v, w=None, centered=True):
     uu = np.average(np.square(u), weights=w)
     vv = np.average(np.square(v), weights=w)
     dist = 1.0 - uv / np.sqrt(uu * vv)
+    # Return absolute value to avoid small negative value due to rounding
     return np.abs(dist)
 
 

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -1573,6 +1573,15 @@ class TestSomeDistanceFunctions(object):
             dist = wcorrelation(x, y)
             assert_almost_equal(dist, 1.0 - np.dot(xm, ym) / (norm(xm) * norm(ym)))
 
+    def test_correlation_positive(self):
+        x = np.array([ 0.,  0.,  0.,  0.,  0.,  0., -2.,  0.,  0.,  0., -2., -2., -2.,  0., -2.,  0., -2.,  0.,
+           0., -1., -2.,  0.,  1.,  0.,  0., -2.,  0.,  0., -2.,  0., -2., -2., -2., -2., -2., -2., 0.,])
+        y = np.array([ 1.,  1.,  1.,  1.,  1.,  1., -1.,  1.,  1.,  1., -1., -1., -1.,  1., -1.,  1., -1.,  1.,
+           1.,  0., -1.,  1.,  2.,  1.,  1., -1.,  1.,  1., -1.,  1., -1., -1., -1., -1., -1., -1., 1.,])
+        dist = wcorrelation(x,y)
+        assert dist >= 0
+        assert_almost_equal(dist, 0)
+
     def test_mahalanobis(self):
         x = np.array([1.0, 2.0, 3.0])
         y = np.array([1.0, 1.0, 5.0])

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -1574,13 +1574,15 @@ class TestSomeDistanceFunctions(object):
             assert_almost_equal(dist, 1.0 - np.dot(xm, ym) / (norm(xm) * norm(ym)))
 
     def test_correlation_positive(self):
-        x = np.array([ 0.,  0.,  0.,  0.,  0.,  0., -2.,  0.,  0.,  0., -2., -2., -2.,  0., -2.,  0., -2.,  0.,
-           0., -1., -2.,  0.,  1.,  0.,  0., -2.,  0.,  0., -2.,  0., -2., -2., -2., -2., -2., -2., 0.,])
-        y = np.array([ 1.,  1.,  1.,  1.,  1.,  1., -1.,  1.,  1.,  1., -1., -1., -1.,  1., -1.,  1., -1.,  1.,
-           1.,  0., -1.,  1.,  2.,  1.,  1., -1.,  1.,  1., -1.,  1., -1., -1., -1., -1., -1., -1., 1.,])
-        dist = wcorrelation(x,y)
-        assert dist >= 0
-        assert_almost_equal(dist, 0)
+        # Regression test for gh-12320 (negative return value due to rounding
+        x = np.array([0., 0., 0., 0., 0., 0., -2., 0., 0., 0., -2., -2., -2.,
+                      0., -2., 0., -2., 0., 0., -1., -2., 0., 1., 0., 0., -2.,
+                      0., 0., -2., 0., -2., -2., -2., -2., -2., -2., 0.])
+        y = np.array([1., 1., 1., 1., 1., 1., -1., 1., 1., 1., -1., -1., -1.,
+                      1., -1., 1., -1., 1., 1., 0., -1., 1., 2., 1., 1., -1.,
+                      1., 1., -1., 1., -1., -1., -1., -1., -1., -1., 1.])
+        dist = correlation(x, y)
+        assert 0 <= dist <= 10 * np.finfo(np.float64).eps
 
     def test_mahalanobis(self):
         x = np.array([1.0, 2.0, 3.0])

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -7697,7 +7697,7 @@ class truncnorm_gen(rv_continuous):
         size1d = tuple(np.atleast_1d(numsamples))
         N = np.prod(size1d)  # number of rvs needed, reshape upon return
         # Calculate some rvs
-        U = random_state.random_sample(N)
+        U = random_state.uniform(low=0, high=1, size=N)
         x = self._ppf(U, a, b)
         rvs = np.reshape(x, size1d)
         return rvs

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -7686,7 +7686,7 @@ class truncnorm_gen(rv_continuous):
                 it.iternext()
 
         if size == ():
-            out = out[()]
+            out = out.item()
         return out
 
     def _rvs_scalar(self, a, b, numsamples=None, random_state=None):

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -3749,7 +3749,7 @@ class geninvgauss_gen(rv_continuous):
                 it.iternext()
 
         if size == ():
-            out = out[()]
+            out = out.item()
         return out
 
     def _rvs_scalar(self, p, b, numsamples, random_state):

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -4714,24 +4714,22 @@ class _ParallelP(object):
     """
     Helper function to calculate parallel p-value.
     """
-    def __init__(self, x, y, compute_distance, random_states):
+    def __init__(self, x, y, random_states):
         self.x = x
         self.y = y
-        self.compute_distance = compute_distance
         self.random_states = random_states
 
     def __call__(self, index):
-        permx = self.random_states[index].permutation(self.x)
-        permy = self.random_states[index].permutation(self.y)
+        order = self.random_states[index].permutation(self.y.shape[0])
+        permy = self.y[order][:, order]
 
         # calculate permuted stats, store in null distribution
-        perm_stat = _mgc_stat(permx, permy, self.compute_distance)[0]
+        perm_stat = _mgc_stat(self.x, permy)[0]
 
         return perm_stat
 
 
-def _perm_test(x, y, stat, compute_distance, reps=1000, workers=-1,
-               random_state=None):
+def _perm_test(x, y, stat, reps=1000, workers=-1, random_state=None):
     r"""
     Helper function that calculates the p-value. See below for uses.
 
@@ -4741,10 +4739,6 @@ def _perm_test(x, y, stat, compute_distance, reps=1000, workers=-1,
         `x` and `y` have shapes `(n, p)` and `(n, q)`.
     stat : float
         The sample test statistic.
-    compute_distance : callable
-        A function that computes the distance or similarity among the samples
-        within each data matrix. Set to `None` if `x` and `y` are already
-        distance.
     reps : int, optional
         The number of replications used to estimate the null when using the
         permutation test. The default is 1000 replications.
@@ -4776,8 +4770,7 @@ def _perm_test(x, y, stat, compute_distance, reps=1000, workers=-1,
 
     # parallelizes with specified workers over number of reps and set seeds
     mapwrapper = MapWrapper(workers)
-    parallelp = _ParallelP(x=x, y=y, compute_distance=compute_distance,
-                           random_states=random_states)
+    parallelp = _ParallelP(x=x, y=y, random_states=random_states)
     null_dist = np.array(list(mapwrapper(parallelp, range(reps))))
 
     # calculate p-value and significant permutation map through list
@@ -4854,6 +4847,7 @@ def multiscale_graphcorr(x, y, compute_distance=_euclidean_dist, reps=1000,
         shapes ``(n, p)`` and ``(m, p)``, this optional will be overriden and
         set to ``True``. Set to ``True`` if ``x`` and ``y`` both have shapes
         ``(n, p)`` and a two sample test is desired. The default is ``False``.
+        Note that this will not run if inputs are distance matrices.
     random_state : int or np.random.RandomState instance, optional
         If already a RandomState instance, use it.
         If seed is an int, return a new RandomState instance seeded with seed.
@@ -4931,7 +4925,6 @@ def multiscale_graphcorr(x, y, compute_distance=_euclidean_dist, reps=1000,
 
     MGC requires at least 5 samples to run with reliable results. It can also
     handle high-dimensional data sets.
-
     In addition, by manipulating the input data matrices, the two-sample
     testing problem can be reduced to the independence testing problem [4]_.
     Given sample data :math:`U` and :math:`V` of sizes :math:`p \times n`
@@ -4941,7 +4934,6 @@ def multiscale_graphcorr(x, y, compute_distance=_euclidean_dist, reps=1000,
     .. math::
 
         X = [U | V] \in \mathcal{R}^{p \times (n + m)}
-
         Y = [0_{1 \times n} | 1_{1 \times m}] \in \mathcal{R}^{(n + m)}
 
     Then, the MGC statistic can be calculated as normal. This methodology can
@@ -5055,16 +5047,23 @@ def multiscale_graphcorr(x, y, compute_distance=_euclidean_dist, reps=1000,
         warnings.warn(msg, RuntimeWarning)
 
     if is_twosamp:
+        if compute_distance is None:
+            raise ValueError("Cannot run if inputs are distance matrices")
         x, y = _two_sample_transform(x, y)
 
+    if compute_distance is not None:
+        # compute distance matrices for x and y
+        x = compute_distance(x)
+        y = compute_distance(y)
+
     # calculate MGC stat
-    stat, stat_dict = _mgc_stat(x, y, compute_distance)
+    stat, stat_dict = _mgc_stat(x, y)
     stat_mgc_map = stat_dict["stat_mgc_map"]
     opt_scale = stat_dict["opt_scale"]
 
     # calculate permutation MGC p-value
-    pvalue, null_dist = _perm_test(x, y, stat, compute_distance, reps=reps,
-                                   workers=workers, random_state=random_state)
+    pvalue, null_dist = _perm_test(x, y, stat, reps=reps, workers=workers,
+                                   random_state=random_state)
 
     # save all stats (other than stat/p-value) in dictionary
     mgc_dict = {"mgc_map": stat_mgc_map,
@@ -5074,7 +5073,7 @@ def multiscale_graphcorr(x, y, compute_distance=_euclidean_dist, reps=1000,
     return MGCResult(stat, pvalue, mgc_dict)
 
 
-def _mgc_stat(x, y, compute_distance):
+def _mgc_stat(distx, disty):
     r"""
     Helper function that calculates the MGC stat. See above for use.
 
@@ -5083,10 +5082,6 @@ def _mgc_stat(x, y, compute_distance):
     x, y : ndarray
         `x` and `y` have shapes `(n, p)` and `(n, q)` or `(n, n)` and `(n, n)`
         if distance matrices.
-    compute_distance : callable
-        A function that computes the distance or similarity among the samples
-        within each data matrix. Set to `None` if `x` and `y` are already
-        distance.
 
     Returns
     -------
@@ -5095,20 +5090,12 @@ def _mgc_stat(x, y, compute_distance):
     stat_dict : dict
         Contains additional useful additional returns containing the following
         keys:
+
             - stat_mgc_map : ndarray
                 MGC-map of the statistics.
             - opt_scale : (float, float)
                 The estimated optimal scale as a `(x, y)` pair.
     """
-    # set distx and disty to x and y when compute_distance = None
-    distx = x
-    disty = y
-
-    if compute_distance is not None:
-        # compute distance matrices for x and y
-        distx = compute_distance(x)
-        disty = compute_distance(y)
-
     # calculate MGC map and optimal scale
     stat_mgc_map = _local_correlations(distx, disty, global_corr='mgc')
 
@@ -5181,7 +5168,6 @@ def _threshold_mgc_map(stat_mgc_map, samp_size):
 def _smooth_mgc_map(sig_connect, stat_mgc_map):
     """
     Finds the smoothed maximal within the significant region R.
-
     If area of R is too small it returns the last local correlation. Otherwise,
     returns the maximum within significant_connected_region.
 
@@ -5238,7 +5224,7 @@ def _two_sample_transform(u, v):
     Parameters
     ----------
     u, v : ndarray
-        `u` and `v` have shapes `(n, p)` and `(m, p)`,
+        `u` and `v` have shapes `(n, p)` and `(m, p)`.
 
     Returns
     -------

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -188,6 +188,23 @@ def test_cont_basic(distname, arg):
             check_fit_args_fix(distfn, arg, rvs[0:200])
 
 
+@pytest.mark.parametrize('distname,arg', cases_test_cont_basic())
+def test_rvs_scalar(distname, arg):
+    # rvs should return a scalar when given scalar arguments (gh-12428)
+    try:
+        distfn = getattr(stats, distname)
+    except TypeError:
+        distfn = distname
+        distname = 'rv_histogram_instance'
+
+    with npt.suppress_warnings() as sup:
+        sup.filter(category=DeprecationWarning, message=".*frechet_")
+        rvs = distfn.rvs(*arg)
+        assert np.isscalar(distfn.rvs(*arg))
+        assert np.isscalar(distfn.rvs(*arg, size=()))
+        assert np.isscalar(distfn.rvs(*arg, size=None))
+
+
 def test_levy_stable_random_state_property():
     # levy_stable only implements rvs(), so it is skipped in the
     # main loop in test_cont_basic(). Here we apply just the test
@@ -644,3 +661,4 @@ def test_methods_with_lists(method, distname, args):
         npt.assert_allclose(result,
                             [f(*v) for v in zip(x, *shape2, loc, scale)],
                             rtol=1e-15, atol=1e-15)
+

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -623,6 +623,12 @@ class TestTruncnorm(object):
         assert_(np.all(low <= x.min(axis=0)))
         assert_(np.all(x.max(axis=0) <= high))
 
+    def test_rvs_Generator(self):
+        # check that rvs can use a Generator
+        if hasattr(np.random, "default_rng")
+            stats.truncnorm.rvs(-10, -5, size=5,
+                                random_state=np.random.default_rng())
+
 class TestHypergeom(object):
     def setup_method(self):
         np.random.seed(1234)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -625,7 +625,7 @@ class TestTruncnorm(object):
 
     def test_rvs_Generator(self):
         # check that rvs can use a Generator
-        if hasattr(np.random, "default_rng")
+        if hasattr(np.random, "default_rng"):
             stats.truncnorm.rvs(-10, -5, size=5,
                                 random_state=np.random.default_rng())
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -27,6 +27,7 @@ from scipy.stats._ksstats import kolmogn
 from scipy.special._testutils import FuncData
 from .common_tests import check_named_results
 from scipy.sparse.sputils import matrix
+from scipy.spatial.distance import cdist
 
 """ Numbers in docstrings beginning with 'W' refer to the section numbers
     and headings found in the STATISTICS QUIZ of Leland Wilkinson.  These are
@@ -5508,7 +5509,7 @@ class TestMGCErrorWarnings(object):
         assert_raises(ValueError, stats.multiscale_graphcorr, x, y)
 
     def test_error_wrongdisttype(self):
-        # raises error if compute_distance is not a function
+        # raises error if metric is not a function
         x = np.arange(20)
         compute_distance = 0
         assert_raises(ValueError, stats.multiscale_graphcorr, x, x,
@@ -5627,6 +5628,7 @@ class TestMGCStat(object):
         assert_approx_equal(stat, 1.0, significant=1)
         assert_approx_equal(pvalue, 0.001, significant=1)
 
+    @pytest.mark.slow
     def test_workers(self):
         np.random.seed(12345678)
 
@@ -5647,3 +5649,17 @@ class TestMGCStat(object):
         stat, pvalue, _ = stats.multiscale_graphcorr(x, y, random_state=1)
         assert_approx_equal(stat, 0.97, significant=1)
         assert_approx_equal(pvalue, 0.001, significant=1)
+
+    @pytest.mark.slow
+    def test_dist_perm(self):
+        np.random.seed(12345678)
+        # generate x and y
+        x, y = self._simulations(samps=100, dims=1, sim_type="nonlinear")
+        distx = cdist(x, x, metric="euclidean")
+        disty = cdist(y, y, metric="euclidean")
+
+        stat_dist, pvalue_dist, _ = stats.multiscale_graphcorr(distx, disty,
+                                                               compute_distance=None,
+                                                               random_state=1)
+        assert_approx_equal(stat_dist, 0.163, significant=1)
+        assert_approx_equal(pvalue_dist, 0.001, significant=1)


### PR DESCRIPTION
- backport the already-large number of PRs suitable for the maintenance branch,
and I re-milestoned the associated PRs/issues to `1.5.2` (so that lists scripts can be used
to auto-generate author/PR lists)
- update the release notes for SciPy `1.5.2` to reflect the backports
- known issues include at least 1 new author without a properly-mailmapped name,
some PRs were captured twice because both the main and backport PR were milestoned,
and we have previously observed consistent ARM64 CI fails in backport PRs for
`test_lgmres.py:109: in test_arnoldi` (we'll see if that continues here, but I've been ignoring
it)