### PR TITLE
MAINT: remove warning from LSQSphereBivariateSpline

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -138,7 +138,6 @@ warnings.filterwarnings(  # matplotlib<->pyparsing issue
 # TODO: eventually these should be eliminated!
 for key in (
         'invalid escape sequence',  # numpydoc 0.8 has some bad escape chars
-        '\nWARNING. The coefficients',  # interpolate.LSQSphereBivariateSpline
         'The integral is probably divergent',  # stats.mielke example
         'underflow encountered in square',  # signal.filtfilt underflow
         'underflow encountered in multiply',  # scipy.spatial.HalfspaceIntersection

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -1492,8 +1492,11 @@ class LSQSphereBivariateSpline(SphereBivariateSpline):
     Suppose we have global data on a coarse grid (the input data does not
     have to be on a grid):
 
-    >>> theta = np.linspace(0., np.pi, 7)
-    >>> phi = np.linspace(0., 2*np.pi, 9)
+    >>> from scipy.interpolate import LSQSphereBivariateSpline
+    >>> import matplotlib.pyplot as plt
+
+    >>> theta = np.linspace(0, np.pi, num=7)
+    >>> phi = np.linspace(0, 2*np.pi, num=9)
     >>> data = np.empty((theta.shape[0], phi.shape[0]))
     >>> data[:,0], data[0,:], data[-1,:] = 0., 0., 0.
     >>> data[1:-1,1], data[1:-1,-1] = 1., 1.
@@ -1512,7 +1515,6 @@ class LSQSphereBivariateSpline(SphereBivariateSpline):
     >>> knotst[-1] -= .0001
     >>> knotsp[0] += .0001
     >>> knotsp[-1] -= .0001
-    >>> from scipy.interpolate import LSQSphereBivariateSpline
     >>> lut = LSQSphereBivariateSpline(lats.ravel(), lons.ravel(),
     ...                                data.T.ravel(), knotst, knotsp)
 
@@ -1525,10 +1527,8 @@ class LSQSphereBivariateSpline(SphereBivariateSpline):
 
     >>> fine_lats = np.linspace(0., np.pi, 70)
     >>> fine_lons = np.linspace(0., 2*np.pi, 90)
-
     >>> data_lsq = lut(fine_lats, fine_lons)
 
-    >>> import matplotlib.pyplot as plt
     >>> fig = plt.figure()
     >>> ax1 = fig.add_subplot(131)
     >>> ax1.imshow(data, interpolation='nearest')
@@ -1568,11 +1568,7 @@ class LSQSphereBivariateSpline(SphereBivariateSpline):
         tt_[-4:], tp_[-4:] = np.pi, 2. * np.pi
         tt_, tp_, c, fp, ier = dfitpack.spherfit_lsq(theta, phi, r, tt_, tp_,
                                                      w=w, eps=eps)
-        if ier < -2:
-            deficiency = 6 + (nt_ - 8) * (np_ - 7) + ier
-            message = _spherefit_messages.get(-3) % (deficiency, -ier)
-            warnings.warn(message, stacklevel=2)
-        elif ier not in [0, -1, -2]:
+        if ier > 0:
             message = _spherefit_messages.get(ier, 'ier=%s' % (ier))
             raise ValueError(message)
 


### PR DESCRIPTION
This warning is shown a lot, making it go away by tweaking the
example is not easy. And the results are completely valid, so
showing that warning doesn't really make sense. As far as I can
tell, it was taken over from the original Fortran sources without
much thought.