### PR TITLE
ENH: Multivariate t-distribution

### DIFF
--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -141,6 +141,7 @@ Multivariate distributions
    ortho_group           -- O(N) group
    unitary_group         -- U(N) group
    random_correlation    -- random correlation matrices
+   multivariate_t        -- Multivariate t-distribution
 
 Discrete distributions
 ======================

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -3860,7 +3860,8 @@ loc : array_like, optional
 shape : array_like, optional
     Positive semidefinite matrix of the distribution. (default ``1``)
 df : float, optional
-    Degrees of freedom of the distribution; must be greater than zero. If ``np.inf`` then results are multivariate normal. The default is ``1``. 
+    Degrees of freedom of the distribution; must be greater than zero.
+    If ``np.inf`` then results are multivariate normal. The default is ``1``.
 allow_singular : bool, optional
     Whether to allow a singular matrix. (default ``False``)
 """
@@ -3947,6 +3948,8 @@ class multivariate_t_gen(multi_rv_generic):
     >>> x, y = np.mgrid[-1:3:.01, -2:1.5:.01]
     >>> pos = np.dstack((x, y))
     >>> rv = multivariate_t([1.0, -0.5], [[2.1, 0.3], [0.3, 1.5]], df=2)
+    >>> fig, ax = plt.subplots(1, 1)
+    >>> ax.set_aspect('equal')
     >>> plt.contourf(x, y, rv.pdf(pos))
 
     """

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -24,7 +24,8 @@ __all__ = ['multivariate_normal',
            'special_ortho_group',
            'ortho_group',
            'random_correlation',
-           'unitary_group']
+           'unitary_group',
+           'multivariate_t']
 
 _LOG_2PI = np.log(2 * np.pi)
 _LOG_2 = np.log(2)
@@ -3850,3 +3851,405 @@ class unitary_group_gen(multi_rv_generic):
 
 
 unitary_group = unitary_group_gen()
+
+
+_mvt_doc_default_callparams = \
+"""
+loc : array_like, optional
+    Location of the distribution. (default ``0``)
+shape : array_like, optional
+    Positive definite matrix of the distribution. (default ``1``)
+df : integer, optional
+    Degrees of freedom of the distribution; must be a positive whole number. (default ``1``) 
+allow_singular : bool, optional
+    Whether to allow a singular matrix. (default ``False``)
+"""
+
+_mvt_doc_callparams_note = \
+"""Setting the parameter `loc` to ``None`` is equivalent to having `loc`
+be the zero-vector. The parameter `shape` can be a scalar, in which case
+the shape matrix is the identity times that value, a vector of
+diagonal entries for the shape matrix, or a two-dimensional array_like.
+"""
+
+_mvt_doc_frozen_callparams_note = \
+"""See class definition for a detailed description of parameters."""
+
+mvt_docdict_params = {
+    '_mvt_doc_default_callparams': _mvt_doc_default_callparams,
+    '_mvt_doc_callparams_note': _mvt_doc_callparams_note,
+    '_doc_random_state': _doc_random_state
+}
+
+mvt_docdict_noparams = {
+    '_mvt_doc_default_callparams': "",
+    '_mvt_doc_callparams_note': _mvt_doc_frozen_callparams_note,
+    '_doc_random_state': _doc_random_state
+}
+
+
+class multivariate_t_gen(multi_rv_generic):
+    r"""
+    A multivariate t-distributed random variable.
+    The `loc` parameter specifies the location. The `shape` parameter specifies
+    the positive definite shape matrix. The `df` parameter specifies the
+    degrees of freedom.
+
+    In addition to calling the methods below, the object itself may be called
+    as a function to fix the location, shape matrix, and degrees of freedom
+    parameters, returning a "frozen" multivariate t-distribution random.
+
+    Methods
+    -------
+    ``pdf(x, loc=None, shape=1, df=1, allow_singular=False)``
+        Probability density function.
+    ``logpdf(x, loc=None, shape=1, df=1, allow_singular=False)``
+        Log of the probability density function.
+    ``rvs(loc=None, shape=1, df=1, size=1, random_state=None)``
+        Draw random samples from a multivariate t-distribution.
+
+    Parameters
+    ----------
+    x : array_like
+        Quantiles, with the last axis of `x` denoting the components.
+    %(_mvt_doc_default_callparams)s
+    %(_doc_random_state)s
+
+    Notes
+    -----
+    %(_mvt_doc_callparams_note)s
+    The matrix `shape` must be a (symmetric) positive definite matrix. The
+    determinant and inverse of `shape` are computed as the pseudo-determinant
+    and pseudo-inverse, respectively, so that `shape` does not need to have
+    full rank.
+
+    The probability density function for `multivariate_t` is
+
+    .. math::
+
+        f(x) = \frac{\Gamma(\nu + p)/2}{\Gamma(\nu/2)\nu^{p/2}\pi^{p/2}|\Sigma|^{1/2}}
+               \exp\left[1 + \frac{1}{\nu} (\mathbf{x} - \boldsymbol{\mu})^{\top}
+               \boldsymbol{\Sigma}^{-1}
+               (\mathbf{x} - \boldsymbol{\mu}) \right]^{-(\nu + p)/2},
+
+    where :math:`p` is the dimension of :math:`\mathbf{x}`,
+    :math:`\boldsymbol{\mu}` is the :math:`p`-dimensional location,
+    :math:`\boldsymbol{\Sigma}` the :math:`p \times p`-dimensional shape
+    matrix, and :math:`\nu` is the degrees of freedom.
+
+    .. versionadded:: 1.5.0
+
+    Examples
+    --------
+    >>> import matplotlib.pyplot as plt
+    >>> from scipy.stats import multivariate_t
+    >>> x, y = np.mgrid[-1:1:.01, -1:1:.01]
+    >>> pos = np.dstack((x, y))
+    >>> rv = multivariate_t([1.0, -0.5], [[2.1, 0.3], [0.3, 1.5]], df=2)
+    >>> plt.contourf(x, y, rv.pdf(pos))
+
+    """
+
+    def __init__(self, seed=None):
+        """
+        Initialize a multivariate t-distributed random variable.
+
+        Parameters
+        ----------
+        seed : Random state.
+
+        """
+        super(multivariate_t_gen, self).__init__(seed)
+        self.__doc__ = doccer.docformat(self.__doc__, mvt_docdict_params)
+        self._random_state = check_random_state(seed)
+
+    def __call__(self, loc=None, shape=1, df=1, allow_singular=False,
+                 seed=None):
+        """
+        Create a frozen multivariate t-distribution. See
+        `multivariate_t_frozen` for parameters.
+
+        """
+        return multivariate_t_frozen(loc=loc, shape=shape, df=df,
+                                     allow_singular=allow_singular, seed=seed)
+
+    def pdf(self, x, loc=None, shape=1, df=1, allow_singular=False):
+        """
+        Multivariate t-distribution probability density function.
+
+        Parameters
+        ----------
+        x : array_like
+            Points at which to evaluate the probability density function.
+        %(_mvt_doc_default_callparams)s
+
+        Returns
+        -------
+        pdf : Probability density function evaluated at `x`.
+
+        Examples
+        --------
+        >>> from scipy.stats import multivariate_t
+        >>> x = [0.4, 5]
+        >>> loc = [0, 1]
+        >>> shape = [[1, 0.1], [0.1, 1]]
+        >>> df = 7
+        >>> multivariate_t.pdf(x, loc, shape, df)
+        array([0.00075713])
+
+        """
+        dim, loc, shape, df = self._process_parameters(loc, shape, df)
+        x = self._process_quantiles(x, dim)
+        shape_info = _PSD(shape, allow_singular=allow_singular)
+        logpdf = self._logpdf(x, loc, shape_info.U, shape_info.log_pdet, df,
+                              dim)
+        return np.exp(logpdf)
+
+    def logpdf(self, x, loc=None, shape=1, df=1):
+        """
+        Log of the multivariate t-distribution probability density function.
+
+        Parameters
+        ----------
+        x : array_like
+            Points at which to evaluate the log of the probability density
+            function.
+        %(_mvt_doc_default_callparams)s
+
+        Returns
+        -------
+        logpdf : Log of the probability density function evaluated at `x`.
+
+        Examples
+        --------
+        >>> from scipy.stats import multivariate_t
+        >>> x = [0.4, 5]
+        >>> loc = [0, 1]
+        >>> shape = [[1, 0.1], [0.1, 1]]
+        >>> df = 7
+        >>> multivariate_t.logpdf(x, loc, shape, df)
+        array([-7.1859802])
+
+        See Also
+        --------
+        pdf : Probability density function.
+
+        """
+        dim, loc, shape, df = self._process_parameters(loc, shape, df)
+        x = self._process_quantiles(x, dim)
+        shape_info = _PSD(shape)
+        return self._logpdf(x, loc, shape_info.U, shape_info.log_pdet, df, dim)
+
+    def _logpdf(self, x, loc, prec_U, log_pdet, df, dim):
+        """Utility method `pdf`, `logpdf` for parameters.
+
+        Parameters
+        ----------
+        x : ndarray
+            Points at which to evaluate the log of the probability density
+            function.
+        loc : ndarray
+            Location of the distribution.
+        prec_U : ndarray
+            A decomposition such that `np.dot(prec_U, prec_U.T)` is the inverse
+            of the shape matrix.
+        log_det_cov : float
+            Logarithm of the determinant of the shape matrix.
+        df : int
+            Degrees of freedom of the distribution.
+        dim : int
+            Dimension of the quantiles x.
+
+        Notes
+        -----
+        As this function does no argument checking, it should not be called
+        directly; use 'logpdf' instead.
+
+        """
+        dev  = x - loc
+        maha = np.square(np.dot(dev, prec_U)).sum(axis=-1)
+
+        t = 0.5 * (df + dim)
+        A = gammaln(t)
+        B = gammaln(0.5 * df)
+        C = dim/2. * np.log(df * np.pi)
+        D = 0.5 * log_pdet
+        E = -t * np.log(1 + (1./df) * maha)
+
+        return A - B - C - D + E
+
+    def rvs(self, loc=None, shape=1, df=1, size=1, random_state=None):
+        """
+        Draw random samples from a multivariate t-distribution.
+
+        Parameters
+        ----------
+        %(_mvt_doc_default_callparams)s
+        size : integer, optional
+            Number of samples to draw (default 1).
+        %(_doc_random_state)s
+
+        Returns
+        -------
+        rvs : ndarray or scalar
+            Random variates of size (`size`, `P`), where `P` is the
+            dimension of the random variable.
+
+        Examples
+        --------
+        >>> from scipy.stats import multivariate_t
+        >>> x = [0.4, 5]
+        >>> loc = [0, 1]
+        >>> shape = [[1, 0.1], [0.1, 1]]
+        >>> df = 7
+        >>> multivariate_t.rvs(loc, shape, df)
+        array([[0.93477495, 3.00408716]])
+
+        """
+        # For implementation details, see equation (3):
+        #
+        #    Hofert, "On Sampling from the Multivariatet Distribution", 2013
+        #
+        dim, loc, shape, df = self._process_parameters(loc, shape, df)
+        if random_state is not None:
+            rng = check_random_state(random_state)
+        else:
+            rng = self._random_state
+
+        if df == np.inf:
+            x = np.ones(size)
+        else:
+            x = rng.chisquare(df, size=size) / df
+
+        z = rng.multivariate_normal(np.zeros(dim), shape, size=size)
+        samples = loc + z / np.sqrt(x)[:, None]
+        return samples
+
+    def _process_quantiles(self, x, dim):
+        """
+        Adjust quantiles array so that last axis labels the components of
+        each data point.
+
+        """
+        x = np.asarray(x, dtype=float)
+        if x.ndim == 0:
+            x = x[np.newaxis]
+        elif x.ndim == 1:
+            if dim == 1:
+                x = x[:, np.newaxis]
+            else:
+                x = x[np.newaxis, :]
+        return x
+
+    def _process_parameters(self, loc, shape, df):
+        """
+        Infer dimensionality from location array and shape matrix, handle
+        defaults, and ensure compatible dimensions.
+
+        """
+        if loc is None and shape is None:
+            shape = np.asarray(1, dtype=float)
+            dim = 1
+        elif loc is None:
+            shape = np.asarray(shape, dtype=float)
+            if shape.ndim < 2:
+                dim = 1
+            else:
+                dim = shape.shape[0]
+            loc = np.zeros(dim)
+        else:
+            shape = np.asarray(shape, dtype=float)
+            loc = np.asarray(loc, dtype=float)
+            dim = loc.size
+
+        if dim == 1:
+            loc.shape = (1,)
+            shape.shape = (1, 1)
+
+        if loc.ndim != 1 or loc.shape[0] != dim:
+            raise ValueError("Array 'loc' must be a vector of length %d." %
+                             dim)
+        if shape.ndim == 0:
+            shape = shape * np.eye(dim)
+        elif shape.ndim == 1:
+            shape = np.diag(shape)
+        elif shape.ndim == 2 and shape.shape != (dim, dim):
+            rows, cols = shape.shape
+            if rows != cols:
+                msg = ("Array 'cov' must be square if it is two dimensional,"
+                       " but cov.shape = %s." % str(shape.shape))
+            else:
+                msg = ("Dimension mismatch: array 'cov' is of shape %s,"
+                       " but 'loc' is a vector of length %d.")
+                msg = msg % (str(shape.shape), len(loc))
+            raise ValueError(msg)
+        elif shape.ndim > 2:
+            raise ValueError("Array 'cov' must be at most two-dimensional,"
+                             " but cov.ndim = %d" % shape.ndim)
+
+        # Process degrees of freedom.
+        if df is None:
+            df = 1
+        if not isinstance(df, int) and not np.isinf(df):
+            raise ValueError("'df' must be an integer or 'np.inf' but is of "
+                             "type %s" % type(df))
+
+        return dim, loc, shape, df
+
+
+class multivariate_t_frozen(multi_rv_frozen):
+
+    def __init__(self, loc=None, shape=1, df=1, allow_singular=False,
+                 seed=None):
+        """
+        Create a frozen multivariate t distribution.
+
+        Parameters
+        ----------
+        %(_mvt_doc_default_callparams)s
+
+        Examples
+        --------
+        >>> loc = np.zeros(3)
+        >>> shape = np.eye(3)
+        >>> df = 10
+        >>> dist = multivariate_t(loc, shape, df)
+        >>> dist.rvs()
+        array([[ 0.81412036, -1.53612361,  0.42199647]])
+        >>> dist.pdf([1, 1, 1])
+        array([0.01237803])
+
+        """
+        self._dist = multivariate_t_gen(seed)
+        dim, loc, shape, df = self._dist._process_parameters(loc, shape, df)
+        self.dim, self.loc, self.shape, self.df = dim, loc, shape, df
+        self.shape_info = _PSD(shape, allow_singular=allow_singular)
+
+    def logpdf(self, x):
+        x = self._dist._process_quantiles(x, self.dim)
+        U = self.shape_info.U
+        log_pdet = self.shape_info.log_pdet
+        return self._dist._logpdf(x, self.loc, U, log_pdet, self.df, self.dim)
+
+    def pdf(self, x):
+        return np.exp(self.logpdf(x))
+
+    def rvs(self, size=1, random_state=None):
+        return self._dist.rvs(loc=self.loc,
+                              shape=self.shape,
+                              df=self.df,
+                              size=size,
+                              random_state=random_state)
+
+
+multivariate_t = multivariate_t_gen()
+
+
+# Set frozen generator docstrings from corresponding docstrings in
+# matrix_normal_gen and fill in default strings in class docstrings
+for name in ['logpdf', 'pdf', 'rvs']:
+    method = multivariate_t_gen.__dict__[name]
+    method_frozen = multivariate_t_frozen.__dict__[name]
+    method_frozen.__doc__ = doccer.docformat(method.__doc__,
+                                             mvt_docdict_noparams)
+    method.__doc__ = doccer.docformat(method.__doc__, mvt_docdict_params)

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -4213,7 +4213,7 @@ class multivariate_t_gen(multi_rv_generic):
         elif df <= 0:
             raise ValueError("'df' must be greater than zero.")
         elif np.isnan(df):
-            raise ValueError("'df' must be greater than zero or 'np.inf'.")
+            raise ValueError("'df' is 'nan' but must be greater than zero or 'np.inf'.")
 
         return dim, loc, shape, df
 

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -3858,7 +3858,7 @@ _mvt_doc_default_callparams = \
 loc : array_like, optional
     Location of the distribution. (default ``0``)
 shape : array_like, optional
-    Positive definite matrix of the distribution. (default ``1``)
+    Positive semidefinite matrix of the distribution. (default ``1``)
 df : integer, optional
     Degrees of freedom of the distribution; must be a positive whole number. (default ``1``) 
 allow_singular : bool, optional
@@ -3891,8 +3891,9 @@ mvt_docdict_noparams = {
 class multivariate_t_gen(multi_rv_generic):
     r"""
     A multivariate t-distributed random variable.
+    
     The `loc` parameter specifies the location. The `shape` parameter specifies
-    the positive definite shape matrix. The `df` parameter specifies the
+    the positive semidefinite shape matrix. The `df` parameter specifies the
     degrees of freedom.
 
     In addition to calling the methods below, the object itself may be called
@@ -3918,7 +3919,7 @@ class multivariate_t_gen(multi_rv_generic):
     Notes
     -----
     %(_mvt_doc_callparams_note)s
-    The matrix `shape` must be a (symmetric) positive definite matrix. The
+    The matrix `shape` must be a (symmetric) positive semidefinite matrix. The
     determinant and inverse of `shape` are computed as the pseudo-determinant
     and pseudo-inverse, respectively, so that `shape` does not need to have
     full rank.
@@ -3943,7 +3944,7 @@ class multivariate_t_gen(multi_rv_generic):
     --------
     >>> import matplotlib.pyplot as plt
     >>> from scipy.stats import multivariate_t
-    >>> x, y = np.mgrid[-1:1:.01, -1:1:.01]
+    >>> x, y = np.mgrid[-1:3:.01, -2:1.5:.01]
     >>> pos = np.dstack((x, y))
     >>> rv = multivariate_t([1.0, -0.5], [[2.1, 0.3], [0.3, 1.5]], df=2)
     >>> plt.contourf(x, y, rv.pdf(pos))
@@ -4109,6 +4110,7 @@ class multivariate_t_gen(multi_rv_generic):
         # For implementation details, see equation (3):
         #
         #    Hofert, "On Sampling from the Multivariatet Distribution", 2013
+        #     http://rjournal.github.io/archive/2013-2/hofert.pdf
         #
         dim, loc, shape, df = self._process_parameters(loc, shape, df)
         if random_state is not None:

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -3939,7 +3939,7 @@ class multivariate_t_gen(multi_rv_generic):
     :math:`\boldsymbol{\Sigma}` the :math:`p \times p`-dimensional shape
     matrix, and :math:`\nu` is the degrees of freedom.
 
-    .. versionadded:: 1.5.0
+    .. versionadded:: 1.6.0
 
     Examples
     --------

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -27,6 +27,9 @@ from scipy.stats import wishart, multinomial, invwishart, chi2, invgamma
 from scipy.stats import norm, uniform
 from scipy.stats import ks_2samp, kstest
 from scipy.stats import binom
+from scipy.stats import multivariate_t
+from scipy.stats import cauchy
+from scipy.stats import normaltest
 
 from scipy.integrate import romb
 from scipy.special import multigammaln
@@ -1634,6 +1637,187 @@ class TestUnitaryGroup(object):
         x = np.arctan2(eigs.imag, eigs.real)
         res = kstest(x.ravel(), uniform(-np.pi, 2*np.pi).cdf)
         assert_(res.pvalue > 0.05)
+
+
+class TestMultivariateT:
+
+    # These tests were created by running vpa(mvtpdf(...)) in MATLAB. The
+    # function takes no `mu` parameter. The tests were run as
+    #
+    # >> ans = vpa(mvtpdf(x - mu, shape, df));
+    #
+    MULTIVARIATE_T_TESTS = [(
+        # x
+        [
+            [1, 2],
+            [4, 1],
+            [2, 1],
+            [2, 4],
+            [1, 4],
+            [4, 1],
+            [3, 2],
+            [3, 3],
+            [4, 4],
+            [5, 1],
+        ],
+        # mu
+        [0, 0],
+        # shape
+        [
+            [1, 0],
+            [0, 1]
+        ],
+        # df
+        4,
+        # ans
+        [
+            0.013972450422333741737457302178882,
+            0.0010998721906793330026219646100571,
+            0.013972450422333741737457302178882,
+            0.00073682844024025606101402363634634,
+            0.0010998721906793330026219646100571,
+            0.0010998721906793330026219646100571,
+            0.0020732579600816823488240725481546,
+            0.00095660371505271429414668515889275,
+            0.00021831953784896498569831346792114,
+            0.00037725616140301147447000396084604
+        ]
+
+    ), (
+
+        # x
+        [
+            [0.9718, 0.1298, 0.8134],
+            [0.4922, 0.5522, 0.7185],
+            [0.3010, 0.1491, 0.5008],
+            [0.5971, 0.2585, 0.8940],
+            [0.5434, 0.5287, 0.9507],
+        ],
+        # mu
+        [-1, 1, 50],
+        # shape
+        [
+            [1.0000, 0.5000, 0.2500],
+            [0.5000, 1.0000, -0.1000],
+            [0.2500, -0.1000, 1.0000],
+        ],
+        # df
+        8,
+        # ans
+        [
+            0.00000000000000069609279697467772867405511133763,
+            0.00000000000000073700739052207366474839369535934,
+            0.00000000000000069522909962669171512174435447027,
+            0.00000000000000074212293557998314091880208889767,
+            0.00000000000000077039675154022118593323030449058,
+        ]
+    )]
+
+    @pytest.mark.parametrize("x, mu, df, shape, ans", MULTIVARIATE_T_TESTS)
+    def test_pdf_correctness(self, x, mu, df, shape, ans):
+        dist = multivariate_t(mu, df, shape, seed=0)
+        val = dist.pdf(x)
+        assert_array_almost_equal(val, ans)
+
+    @pytest.mark.parametrize("x, mu, df, shape, ans", MULTIVARIATE_T_TESTS)
+    def test_logpdf_correct(self, x, mu, df, shape, ans):
+        dist = multivariate_t(mu, df, shape, seed=0)
+        # We already test this elsewhere, but let's explicitly confirm the
+        # PDF is correct since this test requires checking the log of that
+        # value.
+        val1 = dist.pdf(x)
+        assert_array_almost_equal(val1, ans)
+        val2 = dist.logpdf(x)
+        assert_array_almost_equal(np.log(val1), val2)
+
+    # https://github.com/scipy/scipy/issues/10042#issuecomment-576795195
+    def test_mvt_with_df_one_is_cauchy(self):
+        x = [9, 7, 4, 1, -3, 9, 0, -3, -1, 3]
+        val = multivariate_t.pdf(x, df=1)
+        ans = cauchy.pdf(x)
+        assert_array_almost_equal(val, ans)
+
+    def test_mvt_with_high_df_is_approx_normal(self):
+        # `normaltest` returns the chi-squared statistic and the associated
+        # p-value. The null hypothesis is that `x` came from a normal
+        # distribution, so a low p-value represents rejecting the null, i.e.
+        # that it is unlikely that `x` came a normal distribution.
+        P_VAL_MIN = 0.1
+
+        dist = multivariate_t(0, 1, df=100000, seed=1)
+        samples = dist.rvs(size=100000)
+        _, p = normaltest(samples)
+        assert (p > P_VAL_MIN)
+
+        dist = multivariate_t([-2, 3], [[10, -1], [-1, 10]], df=100000,
+                              seed=42)
+        samples = dist.rvs(size=100000)
+        _, p = normaltest(samples)
+        assert ((p > P_VAL_MIN).all())
+
+        dist = multivariate_t(0, 1, df=np.inf, seed=7)
+        samples = dist.rvs(size=100000)
+        _, p = normaltest(samples)
+        assert (p > P_VAL_MIN)
+
+    def test_default_arguments(self):
+        dist = multivariate_t()
+        assert_equal(dist.loc, [0])
+        assert_equal(dist.shape, [[1]])
+        assert (dist.df == 1)
+
+    def test_reproducibility(self):
+        rng = np.random.RandomState(4)
+        loc = rng.random(3)
+        tmp = rng.random((20, 3))
+        shape = np.matmul(tmp.T, tmp)
+        dist1 = multivariate_t(loc, shape, df=3, seed=2)
+        dist2 = multivariate_t(loc, shape, df=3, seed=2)
+        samples1 = dist1.rvs(size=10)
+        samples2 = dist2.rvs(size=10)
+        assert_equal(samples1, samples2)
+
+    def test_scalar_list_and_ndarray_arguments(self):
+        dist = multivariate_t(-1, 2, 3)
+        assert(dist.loc == np.array([-1]))
+        assert(dist.shape == np.array([2]))
+        assert(dist.df == 3)
+
+        dist = multivariate_t([-1], [2], 3)
+        assert(dist.loc == np.array([-1]))
+        assert(dist.shape == np.array([2]))
+        assert(dist.df == 3)
+
+        dist = multivariate_t(np.array([-1]), np.array([2]), 3)
+        assert(dist.loc == np.array([-1]))
+        assert(dist.shape == np.array([2]))
+        assert(dist.df == 3)
+
+    def test_allow_singular(self):
+        loc = np.zeros(4)
+        shape = np.eye(4)
+        df = 1
+
+        try:
+            multivariate_t(loc, shape, df, allow_singular=False)
+        except np.linalg.LinAlgError:
+            pytest.fail("Test failed by unexpectedly raising `LinAlgError`.")
+
+        # Make shape singular and verify error was raised.
+        shape[2, 2] = 0
+        allow_singular = False
+        seed = 0
+        assert_raises(np.linalg.LinAlgError,
+                      multivariate_t,
+                      loc, shape, df, allow_singular, seed)
+
+        # Check that singular `shape` is when when `allow_singular=True`.
+        try:
+            multivariate_t(loc, shape, df, allow_singular=True)
+        except np.linalg.LinAlgError:
+            pytest.fail("Test failed by unexpectedly raising `LinAlgError`.")
+
+
 
 def check_pickling(distfn, args):
     # check that a distribution instance pickles and unpickles

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -1768,7 +1768,7 @@ class TestMultivariateT:
 
     def test_reproducibility(self):
         rng = np.random.RandomState(4)
-        loc = rng.random(3)
+        loc = rng.uniform(3)
         tmp = rng.random((20, 3))
         shape = np.matmul(tmp.T, tmp)
         dist1 = multivariate_t(loc, shape, df=3, seed=2)

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -1722,11 +1722,7 @@ class TestMultivariateT:
     @pytest.mark.parametrize("x, mu, df, shape, ans", MULTIVARIATE_T_TESTS)
     def test_logpdf_correct(self, x, mu, df, shape, ans):
         dist = multivariate_t(mu, df, shape, seed=0)
-        # We already test this elsewhere, but let's explicitly confirm the
-        # PDF is correct since this test requires checking the log of that
-        # value.
         val1 = dist.pdf(x)
-        assert_array_almost_equal(val1, ans)
         val2 = dist.logpdf(x)
         assert_array_almost_equal(np.log(val1), val2)
 

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -1768,9 +1768,8 @@ class TestMultivariateT:
 
     def test_reproducibility(self):
         rng = np.random.RandomState(4)
-        loc = rng.uniform(3)
-        tmp = rng.random((20, 3))
-        shape = np.matmul(tmp.T, tmp)
+        loc = rng.uniform(size=3)
+        shape = np.eye(3)
         dist1 = multivariate_t(loc, shape, df=3, seed=2)
         dist2 = multivariate_t(loc, shape, df=3, seed=2)
         samples1 = dist1.rvs(size=10)


### PR DESCRIPTION
### Reference issue

Closes https://github.com/scipy/scipy/issues/10042. Duplicates https://github.com/scipy/scipy/pull/11413 because the old branch was out-of-date.

### What does this implement/fix?

Adds support for the [multivariate t-distribution](https://en.wikipedia.org/wiki/Multivariate_t-distribution), particularly `pdf`, `logpdf`, and `rvs`. See [my blog post](http://gregorygundersen.com/blog/2020/01/20/multivariate-t/) for a high-level discussion of my approach.

### Additional information

**Completed:**

- [x] No licensing issues.
- [x] Unit tests comparing `logpdf` and `pdf` to MATLAB's `mvtpdf` function; unit tests for arguments, reproducibility (with `random_state`), and some testable mathematical properties.
- [x] All tests pass locally.
- [x] All public functions have docstrings and examples.
- [x] Code style follows existing content in `_multivariate.py`.
- [x] Docstrings with new functionality.
- [x] Added myself to `THANKS.txt`
- [x] Added a documentation page via the docstring. 

**Would appreciate feedback on:**

1. How to unit test `rvs`?
1. Should we support `cdf` and `logcdf` given that the multivariate t-distribution does not have a closed-form solution for the CDF? While I have seen some implementations (see https://github.com/scipy/scipy/issues/10042#issuecomment-576806054 in particular), I don't yet fully understand how they work and would prefer adding these methods to be a separate PR.
1. Should we support `entropy`? I don't know anything about the differential entropy of the multivariate t-distribution, and would also prefer punting that to a future PR.