### PR TITLE
ENH: Add single-sided p-values to t-tests

### DIFF
--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -81,14 +81,8 @@ _msg = ('scipy.{0} is deprecated and will be removed in SciPy 2.0.0, '
         'use numpy.random.{0} instead')
 rand = _deprecated(_msg.format('rand'))(rand)
 randn = _deprecated(_msg.format('randn'))(randn)
-from numpy.fft import fft, ifft
-# fft is especially problematic, so we deprecate it with a shorter window
-fft_msg = ('Using scipy.fft as a function is deprecated and will be '
-           'removed in SciPy 1.5.0, use scipy.fft.fft instead.')
-# for wrapping in scipy.fft.__call__, so the stacklevel is one off from the
-# usual (2)
-_dep_fft = _deprecated(fft_msg, stacklevel=3)(fft)
-fft = _deprecated(fft_msg)(fft)
+# fft is especially problematic, so was removed in SciPy 1.6.0
+from numpy.fft import ifft
 ifft = _deprecated('scipy.ifft is deprecated and will be removed in SciPy '
                    '2.0.0, use scipy.fft.ifft instead')(ifft)
 import numpy.lib.scimath as _sci
@@ -101,7 +95,7 @@ for _key in _sci.__all__:
     globals()[_key] = _fun
 
 __all__ += _num.__all__
-__all__ += ['randn', 'rand', 'fft', 'ifft']
+__all__ += ['randn', 'rand', 'ifft']
 
 del _num
 # Remove the linalg imported from NumPy so that the scipy.linalg package can be
@@ -152,4 +146,3 @@ else:
 
     # This makes "from scipy import fft" return scipy.fft, not np.fft
     del fft
-    from . import fft

--- a/scipy/_lib/tests/test__util.py
+++ b/scipy/_lib/tests/test__util.py
@@ -141,21 +141,17 @@ def test_mapwrapper_parallel():
 
 # get our custom ones and a few from the "import *" cases
 @pytest.mark.parametrize(
-    'key', ('fft', 'ifft', 'diag', 'arccos',
-            'randn', 'rand', 'array'))
+    'key', ('ifft', 'diag', 'arccos', 'randn', 'rand', 'array'))
 def test_numpy_deprecation(key):
     """Test that 'from numpy import *' functions are deprecated."""
-    if key in ('fft', 'ifft', 'diag', 'arccos'):
+    if key in ('ifft', 'diag', 'arccos'):
         arg = [1.0, 0.]
     elif key == 'finfo':
         arg = float
     else:
         arg = 2
     func = getattr(scipy, key)
-    if key == 'fft':
-        match = r'scipy\.fft.*deprecated.*1.5.0.*'
-    else:
-        match = r'scipy\.%s is deprecated.*2\.0\.0' % key
+    match = r'scipy\.%s is deprecated.*2\.0\.0' % key
     with deprecated_call(match=match) as dep:
         func(arg)  # deprecated
     # in case we catch more than one dep warning
@@ -164,7 +160,7 @@ def test_numpy_deprecation(key):
     assert 'test__util' in basenames
     if key in ('rand', 'randn'):
         root = np.random
-    elif key in ('fft', 'ifft'):
+    elif key == 'ifft':
         root = np.fft
     else:
         root = np

--- a/scipy/fft/__init__.py
+++ b/scipy/fft/__init__.py
@@ -96,20 +96,3 @@ __all__ = [
 from scipy._lib._testutils import PytestTester
 test = PytestTester(__name__)
 del PytestTester
-
-
-# Hack to allow numpy.fft.fft to be called as scipy.fft
-import sys
-class _FFTModule(sys.modules[__name__].__class__):
-    @staticmethod
-    def __call__(*args, **kwargs):
-        from scipy import _dep_fft
-        return _dep_fft(*args, **kwargs)
-
-
-import os
-if os.environ.get('_SCIPY_BUILDING_DOC') != 'True':
-    sys.modules[__name__].__class__ = _FFTModule
-del os
-del _FFTModule
-del sys

--- a/scipy/fft/tests/test_fft_function.py
+++ b/scipy/fft/tests/test_fft_function.py
@@ -1,36 +1,46 @@
+import numpy as np
+import subprocess
+import sys
+
+TEST_BODY = r"""
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
+import scipy
+import sys
+import pytest
 
+if hasattr(scipy, 'fft'):
+    raise AssertionError("scipy.fft should require an explicit import")
+
+np.random.seed(1234)
+x = np.random.randn(10) + 1j * np.random.randn(10)
+X = np.fft.fft(x)
+# Callable before scipy.fft is imported
+with pytest.deprecated_call(match=r'2\.0\.0'):
+    y = scipy.ifft(X)
+assert_allclose(y, x)
+
+# Callable after scipy.fft is imported
+import scipy.fft
+with pytest.deprecated_call(match=r'2\.0\.0'):
+    y = scipy.ifft(X)
+assert_allclose(y, x)
+
+"""
 
 def test_fft_function():
-    # Many NumPy symbols are imported into the scipy namespace, including
-    # numpy.fft.fft as scipy.fft, conflicting with this module (gh-10253)
-    np.random.seed(1234)
+    # Historically, scipy.fft was an alias for numpy.fft.fft
+    # Ensure there are no conflicts with the FFT module (gh-10253)
 
-    # Callable before scipy.fft is imported
-    import scipy
-    x = np.random.randn(10) + 1j * np.random.randn(10)
-    with pytest.deprecated_call(match=r'1\.5\.0'):
-        X = scipy.fft(x)
-    with pytest.deprecated_call(match=r'2\.0\.0'):
-        y = scipy.ifft(X)
-    assert_allclose(y, x)
+    # Test must run in a subprocess so scipy.fft is not already imported
+    subprocess.check_call([sys.executable, '-c', TEST_BODY])
 
-    # Callable after scipy.fft is imported
-    import scipy.fft
-    assert_allclose(X, scipy.fft.fft(x))
-    with pytest.deprecated_call(match=r'1\.5\.0'):
-        X = scipy.fft(x)
-    assert_allclose(X, scipy.fft.fft(x))
-    with pytest.deprecated_call(match=r'2\.0\.0'):
-        y = scipy.ifft(X)
-    assert_allclose(y, x)
-
-    # Callable when imported using from
+    # scipy.fft is the correct module
     from scipy import fft
-    with pytest.deprecated_call(match=r'1\.5\.0'):
-        X = fft(x)
-    with pytest.deprecated_call(match=r'2\.0\.0'):
-        y = scipy.ifft(X)
-    assert_allclose(y, x)
+    assert not callable(fft)
+    assert fft.__name__ == 'scipy.fft'
+
+    from scipy import ifft
+    assert ifft.__wrapped__ is np.fft.ifft
+

--- a/scipy/odr/__odrpack.c
+++ b/scipy/odr/__odrpack.c
@@ -396,7 +396,7 @@ PyObject *gen_output(F_INT n, F_INT m, F_INT np, F_INT nq, F_INT ldwe, F_INT ld2
             ",s:" F_INT_PYFMT ",s:" F_INT_PYFMT ",s:" F_INT_PYFMT ",s:" F_INT_PYFMT
             ",s:" F_INT_PYFMT ",s:" F_INT_PYFMT ",s:" F_INT_PYFMT ",s:" F_INT_PYFMT
             ",s:" F_INT_PYFMT "}"),
-         "delta", delta, "eps", eps, "xplus", xplus, "fn", fn, "sd", sd, "sd",
+         "delta", delta, "eps", eps, "xplus", xplus, "fn", fn, "sd", sd, "vcv",
          vcv, "rvar", rvar, "wss", wss, "wssde", wssde, "wssep", wssep,
          "rcond", rcond, "eta", eta, "olmav", olmav, "tau", tau, "alpha",
          alpha, "actrs", actrs, "pnorm", pnorm, "rnors", rnors, "prers",

--- a/scipy/odr/odrpack.py
+++ b/scipy/odr/odrpack.py
@@ -549,7 +549,7 @@ class Output(object):
     beta : ndarray
         Estimated parameter values, of shape (q,).
     sd_beta : ndarray
-        Standard errors of the estimated parameters, of shape (p,).
+        Standard deviations of the estimated parameters, of shape (p,).
     cov_beta : ndarray
         Covariance matrix of the estimated parameters, of shape (p,p).
     delta : ndarray, optional

--- a/scipy/odr/tests/test_odr.py
+++ b/scipy/odr/tests/test_odr.py
@@ -472,3 +472,26 @@ class TestODR(object):
         output = odr_obj.run()
         assert_array_almost_equal(output.beta, [1.0, 2.0, 3.0])
 
+    def test_work_ind(self):
+
+        def func(par, x):
+            b0, b1 = par
+            return b0 + b1 * x
+
+        # generate some data
+        n_data = 4
+        x = np.arange(n_data)
+        y = np.where(x % 2, x + 0.1, x - 0.1)
+        x_err = np.full(n_data, 0.1)
+        y_err = np.full(n_data, 0.1)
+
+        # do the fitting
+        linear_model = Model(func)
+        real_data = RealData(x, y, sx=x_err, sy=y_err)
+        odr_obj = ODR(real_data, linear_model, beta0=[0.4, 0.4])
+        odr_obj.set_job(fit_type=0)
+        out = odr_obj.run()
+
+        sd_ind = out.work_ind['sd']
+        assert_array_almost_equal(out.sd_beta,
+                                  out.work[sd_ind:sd_ind + len(out.sd_beta)])

--- a/scipy/special/orthogonal.py
+++ b/scipy/special/orthogonal.py
@@ -437,7 +437,7 @@ def sh_jacobi(n, p, q, monic=False):
         return orthopoly1d([], [], 1.0, 1.0, wfunc, (-1, 1), monic,
                            eval_func=np.ones_like)
     n1 = n
-    x, w, mu0 = roots_sh_jacobi(n1, p, q, mu=True)
+    x, w = roots_sh_jacobi(n1, p, q)
     hn = _gam(n + 1) * _gam(n + q) * _gam(n + p) * _gam(n + p - q + 1)
     hn /= (2 * n + p) * (_gam(2 * n + p)**2)
     # kn = 1.0 in standard form so monic is redundant. Kept for compatibility.
@@ -565,7 +565,7 @@ def genlaguerre(n, alpha, monic=False):
         n1 = n + 1
     else:
         n1 = n
-    x, w, mu0 = roots_genlaguerre(n1, alpha, mu=True)
+    x, w = roots_genlaguerre(n1, alpha)
     wfunc = lambda x: exp(-x) * x**alpha
     if n == 0:
         x, w = [], []
@@ -656,7 +656,7 @@ def laguerre(n, monic=False):
         n1 = n + 1
     else:
         n1 = n
-    x, w, mu0 = roots_laguerre(n1, mu=True)
+    x, w = roots_laguerre(n1)
     if n == 0:
         x, w = [], []
     hn = 1.0
@@ -1151,7 +1151,7 @@ def hermite(n, monic=False):
         n1 = n + 1
     else:
         n1 = n
-    x, w, mu0 = roots_hermite(n1, mu=True)
+    x, w = roots_hermite(n1)
     wfunc = lambda x: exp(-x * x)
     if n == 0:
         x, w = [], []
@@ -1276,7 +1276,7 @@ def hermitenorm(n, monic=False):
         n1 = n + 1
     else:
         n1 = n
-    x, w, mu0 = roots_hermitenorm(n1, mu=True)
+    x, w = roots_hermitenorm(n1)
     wfunc = lambda x: exp(-x * x / 2.0)
     if n == 0:
         x, w = [], []
@@ -1690,7 +1690,7 @@ def chebyc(n, monic=False):
         n1 = n + 1
     else:
         n1 = n
-    x, w, mu0 = roots_chebyc(n1, mu=True)
+    x, w = roots_chebyc(n1)
     if n == 0:
         x, w = [], []
     hn = 4 * pi * ((n == 0) + 1)
@@ -1796,7 +1796,7 @@ def chebys(n, monic=False):
         n1 = n + 1
     else:
         n1 = n
-    x, w, mu0 = roots_chebys(n1, mu=True)
+    x, w = roots_chebys(n1)
     if n == 0:
         x, w = [], []
     hn = pi
@@ -2074,7 +2074,7 @@ def legendre(n, monic=False):
         n1 = n + 1
     else:
         n1 = n
-    x, w, mu0 = roots_legendre(n1, mu=True)
+    x, w = roots_legendre(n1)
     if n == 0:
         x, w = [], []
     hn = 2.0 / (2 * n + 1)
@@ -2164,7 +2164,7 @@ def sh_legendre(n, monic=False):
     if n == 0:
         return orthopoly1d([], [], 1.0, 1.0, wfunc, (0, 1), monic,
                            lambda x: eval_sh_legendre(n, x))
-    x, w, mu0 = roots_sh_legendre(n, mu=True)
+    x, w = roots_sh_legendre(n)
     hn = 1.0 / (2 * n + 1.0)
     kn = _gam(2 * n + 1) / _gam(n + 1)**2
     p = orthopoly1d(x, w, hn, kn, wfunc, limits=(0, 1), monic=monic,

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5276,8 +5276,15 @@ def ttest_1samp(a, popmean, axis=0, nan_policy='propagate', alternative="two-sid
           * 'propagate': returns nan
           * 'raise': throws an error
           * 'omit': performs the calculations ignoring nan values
-    alternative: "two-sided", "less", "greater"
-        The alternative hypothesis to test for.
+    alternative : {'two-sided', 'less', 'greater'}, optional
+        Defines the alternative hypothesis.
+        The following options are available (default is 'two-sided'):
+
+          * 'two-sided'
+          * 'less': one-sided
+          * 'greater': one-sided
+
+        .. versionadded:: 1.6.0
 
     Returns
     -------
@@ -5416,8 +5423,15 @@ def ttest_ind_from_stats(mean1, std1, nobs1, mean2, std2, nobs2,
         that assumes equal population variances [1]_.
         If False, perform Welch's t-test, which does not assume equal
         population variance [2]_.
-    alternative: "two-sided", "less", "greater"
-        The alternative hypothesis to test for.
+    alternative : {'two-sided', 'less', 'greater'}, optional
+        Defines the alternative hypothesis.
+        The following options are available (default is 'two-sided'):
+
+          * 'two-sided'
+          * 'less': one-sided
+          * 'greater': one-sided
+
+        .. versionadded:: 1.6.0
 
     Returns
     -------
@@ -5574,8 +5588,15 @@ def ttest_ind(a, b, axis=0, equal_var=True, nan_policy='propagate', alternative=
           * 'propagate': returns nan
           * 'raise': throws an error
           * 'omit': performs the calculations ignoring nan values
-    alternative: "two-sided", "less", "greater"
-        The alternative hypothesis to test for.
+    alternative : {'two-sided', 'less', 'greater'}, optional
+        Defines the alternative hypothesis.
+        The following options are available (default is 'two-sided'):
+
+          * 'two-sided'
+          * 'less': one-sided
+          * 'greater': one-sided
+
+        .. versionadded:: 1.6.0
 
     Returns
     -------
@@ -5705,8 +5726,15 @@ def ttest_rel(a, b, axis=0, nan_policy='propagate', alternative="two-sided"):
           * 'propagate': returns nan
           * 'raise': throws an error
           * 'omit': performs the calculations ignoring nan values
-    alternative: "two-sided", "less", "greater"
-        The alternative hypothesis to test for.
+    alternative : {'two-sided', 'less', 'greater'}, optional
+        Defines the alternative hypothesis.
+        The following options are available (default is 'two-sided'):
+
+          * 'two-sided'
+          * 'less': one-sided
+          * 'greater': one-sided
+
+          .. versionadded:: 1.6.0
 
     Returns
     -------

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5276,6 +5276,8 @@ def ttest_1samp(a, popmean, axis=0, nan_policy='propagate', alternative="two-sid
           * 'propagate': returns nan
           * 'raise': throws an error
           * 'omit': performs the calculations ignoring nan values
+    alternative: "two-sided", "less", "greater"
+        The alternative hypothesis to test for.
 
     Returns
     -------
@@ -5414,6 +5416,8 @@ def ttest_ind_from_stats(mean1, std1, nobs1, mean2, std2, nobs2,
         that assumes equal population variances [1]_.
         If False, perform Welch's t-test, which does not assume equal
         population variance [2]_.
+    alternative: "two-sided", "less", "greater"
+        The alternative hypothesis to test for.
 
     Returns
     -------
@@ -5570,6 +5574,8 @@ def ttest_ind(a, b, axis=0, equal_var=True, nan_policy='propagate', alternative=
           * 'propagate': returns nan
           * 'raise': throws an error
           * 'omit': performs the calculations ignoring nan values
+    alternative: "two-sided", "less", "greater"
+        The alternative hypothesis to test for.
 
     Returns
     -------
@@ -5699,6 +5705,8 @@ def ttest_rel(a, b, axis=0, nan_policy='propagate', alternative="two-sided"):
           * 'propagate': returns nan
           * 'raise': throws an error
           * 'omit': performs the calculations ignoring nan values
+    alternative: "two-sided", "less", "greater"
+        The alternative hypothesis to test for.
 
     Returns
     -------

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -1028,9 +1028,10 @@ class TestTtest_1samp():
         res1 = stats.ttest_1samp(outcome[:, 0], outcome[:, 1], axis=None)
         res2 = mstats.ttest_1samp(outcome[:, 0], outcome[:, 1], axis=None)
         assert_allclose(res1, res2)
+
         res1 = stats.ttest_1samp(outcome[:, :2], outcome[:, 2:], axis=0)
         res2 = mstats.ttest_1samp(outcome[:, :2], outcome[:, 2:], axis=0)
-        assert_allclose(res1, res2)
+        assert_allclose(res1, res2, atol=1e-15)
 
         # Check default is axis=0
         res3 = mstats.ttest_1samp(outcome[:, :2], outcome[:, 2:])


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Part of work being done for gh-12506.

#### What does this implement/fix?
This enhancement implements the "alternative" parameter in SciPy's t-tests to allow the selection and return of single-sided p-values. 

#### Additional information
•Implementation closely follows the method found in the brunnermunzel test with modifications made to support arrays. •Selection is done by setting the alternative parameter to one of three strings ("two-sided", "less", or "greater") with the default value being "two-sided" for backwards-compatibility.
•This is a draft PR is because tests still need to be written. Before I do so, however, I'd like to verify that everything looks correct.

#### Edit:
Currently working through some rebase issues, sorry for the duplicate commits.