### PR TITLE
BLD: Add -std=c99 to sigtools to compile with C99

### DIFF
--- a/scipy/_build_utils/compiler_helper.py
+++ b/scipy/_build_utils/compiler_helper.py
@@ -62,10 +62,39 @@ def get_cxx_std_flag(compiler):
     return None
 
 
+def get_c_std_flag(compiler):
+    """Detects compiler flag to enable C99"""
+    gnu_flag = '-std=c99'
+    flag_by_cc = {
+        'msvc': None,
+        'intelw': '/Qstd=c99',
+        'intelem': '-std=c99'
+    }
+    flag = flag_by_cc.get(compiler.compiler_type, gnu_flag)
+
+    if flag is None:
+        return None
+
+    if has_flag(compiler, flag):
+        return flag
+
+    from numpy.distutils import log
+    log.warn('Could not detect c99 standard flag')
+    return None
+
+
 def try_add_flag(args, compiler, flag, ext=None):
     """Appends flag to the list of arguments if supported by the compiler"""
     if try_compile(compiler, flags=args+[flag], ext=ext):
         args.append(flag)
+
+
+def set_c_flags_hook(build_ext, ext):
+    """Sets basic compiler flags for compiling C99 code"""
+    std_flag = get_c_std_flag(build_ext.compiler)
+    if std_flag is not None:
+        ext.extra_compile_args.append(std_flag)
+
 
 def set_cxx_flags_hook(build_ext, ext):
     """Sets basic compiler flags for compiling C++11 code"""

--- a/scipy/signal/setup.py
+++ b/scipy/signal/setup.py
@@ -3,6 +3,7 @@ from scipy._build_utils import numpy_nodepr_api
 
 def configuration(parent_package='', top_path=None):
     from numpy.distutils.misc_util import Configuration
+    from scipy._build_utils.compiler_helper import set_c_flags_hook
 
     config = Configuration('signal', parent_package, top_path)
 
@@ -10,13 +11,14 @@ def configuration(parent_package='', top_path=None):
 
     config.add_subpackage('windows')
 
-    config.add_extension('sigtools',
+    sigtools = config.add_extension('sigtools',
                          sources=['sigtoolsmodule.c', 'firfilter.c',
                                   'medianfilter.c', 'lfilter.c.src',
                                   'correlate_nd.c.src'],
                          depends=['sigtools.h'],
                          include_dirs=['.'],
                          **numpy_nodepr_api)
+    sigtools._pre_build_hook = set_c_flags_hook
 
     config.add_extension(
         '_spectral', sources=['_spectral.c'])


### PR DESCRIPTION
#### Reference issue
Should fix gh-12579

#### What does this implement/fix?
Adds `-std=c99` flag to sigtools. This uses the same `build_ext` hook system used to add the `-std=` flag for C++ code.