### PR TITLE
CI: Add GCC 4.8 entry to travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -267,7 +267,7 @@ script:
         USE_WHEEL_BUILD="--no-build"
     fi
   - export SCIPY_AVAILABLE_MEM=3G
-  - python -u runtests.py -g -j2 --build-only $USE_WHEEL_BUILD
+  - python -u runtests.py -g -j2 --build-only $COVERAGE $USE_WHEEL_BUILD
   # Only run tests against pull-requests
   - |
     if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -121,8 +121,18 @@ matrix:
         - NUMPYSPEC="numpy==1.17.4"
         - USE_SDIST=1
     - python: 3.6
-      name: "Wheel, Optimised"
+      name: "Wheel, Optimised, GCC 4.8"
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - *common_packages
+            - g++-4.8
+            - gcc-4.8
       env:
+        - CC="gcc-4.8"
+        - CXX="g++-4.8"
         - TESTMODE=fast
         - COVERAGE=
         - USE_WHEEL=1
@@ -164,12 +174,14 @@ before_install:
       echo "runtime_library_dirs = $target/lib" >> site.cfg
     fi
   - export CCACHE_COMPRESS=1
+  - if [ -n "$CC" ]; then ln -s `which ccache` "/usr/lib/ccache/$CC" || true; fi
+  - if [ -n "$CXX" ]; then ln -s `which ccache` "/usr/lib/ccache/$CXX" || true; fi
   - python --version # just to check
   - export NPY_NUM_BUILD_JOBS=2
   - uname -a
   - df -h
   - ulimit -a
-  - set -o pipefail
+  - set -e -o pipefail
   - mkdir builds
   - cd builds
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -131,6 +131,7 @@ matrix:
             - g++-4.8
             - gcc-4.8
       env:
+        # GCC 4.8 is used by manylinux1 wheel builds
         - CC="gcc-4.8"
         - CXX="g++-4.8"
         - TESTMODE=fast

--- a/runtests.py
+++ b/runtests.py
@@ -364,8 +364,8 @@ def build_project(args):
             cvars = distutils.sysconfig.get_config_vars()
             env['OPT'] = '-O0 -ggdb'
             env['FOPT'] = '-O0 -ggdb'
-            env['CC'] = cvars['CC'] + ' --coverage'
-            env['CXX'] = cvars['CXX'] + ' --coverage'
+            env['CC'] = env.get('CC', cvars['CC']) + ' --coverage'
+            env['CXX'] = env.get('CXX', cvars['CXX']) + ' --coverage'
             env['F77'] = 'gfortran --coverage '
             env['F90'] = 'gfortran --coverage '
             env['LDSHARED'] = cvars['LDSHARED'] + ' --coverage'

--- a/scipy/signal/setup.py
+++ b/scipy/signal/setup.py
@@ -18,7 +18,7 @@ def configuration(parent_package='', top_path=None):
                          depends=['sigtools.h'],
                          include_dirs=['.'],
                          **numpy_nodepr_api)
-    sigtools._pre_build_hook = set_c_flags_hook
+    # sigtools._pre_build_hook = set_c_flags_hook
 
     config.add_extension(
         '_spectral', sources=['_spectral.c'])

--- a/scipy/signal/setup.py
+++ b/scipy/signal/setup.py
@@ -18,7 +18,7 @@ def configuration(parent_package='', top_path=None):
                          depends=['sigtools.h'],
                          include_dirs=['.'],
                          **numpy_nodepr_api)
-    # sigtools._pre_build_hook = set_c_flags_hook
+    sigtools._pre_build_hook = set_c_flags_hook
 
     config.add_extension(
         '_spectral', sources=['_spectral.c'])


### PR DESCRIPTION
#### Reference issue
Ref gh-12579

#### What does this implement/fix?
This makes one of the CI entries use the same compilers as the `manylinux1` image.

I expect the first build to fail as I based this off of a commit from before gh-12586