### PR TITLE
BLD: fix cython error on master-branch cython

### DIFF
--- a/scipy/spatial/transform/rotation.pyx
+++ b/scipy/spatial/transform/rotation.pyx
@@ -1010,7 +1010,11 @@ cdef class Rotation(object):
                              "num_axes), got {}.".format(angles.shape))
 
         quat = _elementary_quat_compose(seq.encode(), angles, intrinsic)
-        return cls(quat[0] if is_single else quat, normalize=False, copy=False)
+
+        if is_single:
+            return cls(quat[0], normalize=False, copy=False)
+        else:
+            return cls(quat, normalize=False, copy=False)
 
     def as_quat(self):
         """Represent as quaternions.


### PR DESCRIPTION
Cython now complains if the types of the two branches in the ternary statement do not match (here 1D vs 2D).

With this change scipy cythonizes with ~cython master and fails without it.

This should be backported as far as it can be.