### PR TITLE
MAINT: additional SciPy 1.5.2 backports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -122,8 +122,19 @@ matrix:
         - NUMPYSPEC="numpy==1.17.4"
         - USE_SDIST=1
     - python: 3.6
-      if: type = pull_request
+      name: "Wheel, Optimised, GCC 4.8"
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - *common_packages
+            - g++-4.8
+            - gcc-4.8
       env:
+        # GCC 4.8 is used by manylinux1 wheel builds
+        - CC="gcc-4.8"
+        - CXX="g++-4.8"
         - TESTMODE=fast
         - COVERAGE=
         - USE_WHEEL=1
@@ -164,12 +175,13 @@ before_install:
       echo "runtime_library_dirs = $target/lib" >> site.cfg
     fi
   - export CCACHE_COMPRESS=1
+  - if [ -n "$CC" ]; then ln -s `which ccache` "/usr/lib/ccache/$CC" || true; fi
+  - if [ -n "$CXX" ]; then ln -s `which ccache` "/usr/lib/ccache/$CXX" || true; fi
   - python --version # just to check
   - export NPY_NUM_BUILD_JOBS=2
   - uname -a
   - df -h
   - ulimit -a
-  - set -o pipefail
   - if [[ "${TRAVIS_CPU_ARCH}" == "arm64" ]]; then
       wget -q "https://github.com/conda-forge/miniforge/releases/download/4.8.2-1/Miniforge3-4.8.2-1-Linux-aarch64.sh"  -O miniconda.sh;
       chmod +x miniconda.sh;
@@ -181,6 +193,7 @@ before_install:
       conda info -a;
       conda install pytest pytest-xdist $NUMPYSPEC mpmath gmpy2 Cython pybind11;
     fi
+  - set -e -o pipefail
   - mkdir builds
   - cd builds
   - |

--- a/doc/release/1.5.2-notes.rst
+++ b/doc/release/1.5.2-notes.rst
@@ -13,6 +13,7 @@ Authors
 * Peter Bell
 * Tobias Biester +
 * Evgeni Burovski
+* Thomas A Caswell
 * Ralf Gommers
 * Sturla Molden
 * Andrew Nelson
@@ -23,7 +24,7 @@ Authors
 * Atsushi Sakai
 * Pauli Virtanen
 
-A total of 12 people contributed to this release.
+A total of 13 people contributed to this release.
 People with a "+" by their names contributed a patch for the first time.
 This list of names is automatically generated, and may not be fully complete.
 
@@ -47,6 +48,7 @@ Issues closed for 1.5.2
 * `#12487 <https://github.com/scipy/scipy/issues/12487>`__: BUG: optimize: incorrect result from approx_fprime
 * `#12493 <https://github.com/scipy/scipy/issues/12493>`__: CI: GitHub Actions for maintenance branches
 * `#12533 <https://github.com/scipy/scipy/issues/12533>`__: eigh gives incorrect results
+* `#12579 <https://github.com/scipy/scipy/issues/12579>`__: BLD, MAINT: distutils issues in wheels repo
 
 Pull requests for 1.5.2
 -----------------------
@@ -70,3 +72,6 @@ Pull requests for 1.5.2
 * `#12538 <https://github.com/scipy/scipy/pull/12538>`__: BUG:linalg: eigh type parameter handling corrected
 * `#12560 <https://github.com/scipy/scipy/pull/12560>`__: MAINT: truncnorm.rvs compatibility for \`Generator\`
 * `#12562 <https://github.com/scipy/scipy/pull/12562>`__: redo gh-12188: fix segfaults in splprep with fixed knots
+* `#12586 <https://github.com/scipy/scipy/pull/12586>`__: BLD: Add -std=c99 to sigtools to compile with C99
+* `#12590 <https://github.com/scipy/scipy/pull/12590>`__: CI: Add GCC 4.8 entry to travis build matrix
+* `#12591 <https://github.com/scipy/scipy/pull/12591>`__: BLD: fix cython error on master-branch cython

--- a/runtests.py
+++ b/runtests.py
@@ -364,8 +364,8 @@ def build_project(args):
             cvars = distutils.sysconfig.get_config_vars()
             env['OPT'] = '-O0 -ggdb'
             env['FOPT'] = '-O0 -ggdb'
-            env['CC'] = cvars['CC'] + ' --coverage'
-            env['CXX'] = cvars['CXX'] + ' --coverage'
+            env['CC'] = env.get('CC', cvars['CC']) + ' --coverage'
+            env['CXX'] = env.get('CXX', cvars['CXX']) + ' --coverage'
             env['F77'] = 'gfortran --coverage '
             env['F90'] = 'gfortran --coverage '
             env['LDSHARED'] = cvars['LDSHARED'] + ' --coverage'

--- a/scipy/_build_utils/compiler_helper.py
+++ b/scipy/_build_utils/compiler_helper.py
@@ -62,10 +62,39 @@ def get_cxx_std_flag(compiler):
     return None
 
 
+def get_c_std_flag(compiler):
+    """Detects compiler flag to enable C99"""
+    gnu_flag = '-std=c99'
+    flag_by_cc = {
+        'msvc': None,
+        'intelw': '/Qstd=c99',
+        'intelem': '-std=c99'
+    }
+    flag = flag_by_cc.get(compiler.compiler_type, gnu_flag)
+
+    if flag is None:
+        return None
+
+    if has_flag(compiler, flag):
+        return flag
+
+    from numpy.distutils import log
+    log.warn('Could not detect c99 standard flag')
+    return None
+
+
 def try_add_flag(args, compiler, flag, ext=None):
     """Appends flag to the list of arguments if supported by the compiler"""
     if try_compile(compiler, flags=args+[flag], ext=ext):
         args.append(flag)
+
+
+def set_c_flags_hook(build_ext, ext):
+    """Sets basic compiler flags for compiling C99 code"""
+    std_flag = get_c_std_flag(build_ext.compiler)
+    if std_flag is not None:
+        ext.extra_compile_args.append(std_flag)
+
 
 def set_cxx_flags_hook(build_ext, ext):
     """Sets basic compiler flags for compiling C++11 code"""

--- a/scipy/signal/setup.py
+++ b/scipy/signal/setup.py
@@ -3,6 +3,7 @@ from scipy._build_utils import numpy_nodepr_api
 
 def configuration(parent_package='', top_path=None):
     from numpy.distutils.misc_util import Configuration
+    from scipy._build_utils.compiler_helper import set_c_flags_hook
 
     config = Configuration('signal', parent_package, top_path)
 
@@ -10,13 +11,14 @@ def configuration(parent_package='', top_path=None):
 
     config.add_subpackage('windows')
 
-    config.add_extension('sigtools',
+    sigtools = config.add_extension('sigtools',
                          sources=['sigtoolsmodule.c', 'firfilter.c',
                                   'medianfilter.c', 'lfilter.c.src',
                                   'correlate_nd.c.src'],
                          depends=['sigtools.h'],
                          include_dirs=['.'],
                          **numpy_nodepr_api)
+    sigtools._pre_build_hook = set_c_flags_hook
 
     config.add_extension(
         '_spectral', sources=['_spectral.c'])

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -861,7 +861,11 @@ class Rotation(object):
                              "num_axes), got {}.".format(angles.shape))
 
         quat = _elementary_quat_compose(seq, angles, intrinsic)
-        return cls(quat[0] if is_single else quat, normalize=False, copy=False)
+
+        if is_single:
+            return cls(quat[0], normalize=False, copy=False)
+        else:
+            return cls(quat, normalize=False, copy=False)
 
     def as_quat(self):
         """Represent as quaternions.


### PR DESCRIPTION
- the first attempt at building wheels for SciPy `1.5.2` failed, so a few more backports are added here:

1. #12586
2. #12590 (**merge conflicts** cc @peterbell10 -- tons of differences in Travis CI config already..)
3. #12591 (**merge conflicts** cc @nmayorov -- there's an `seq.encode()` before/after difference vs. `master` I think)

- non-trivial merge conflicts were resolved manually as labelled above, so we'll have to see what the CI says...
- since the `v1.5.2` tag was never pushed, but the remote `maintenance/1.5.x` branch  is *protected* , I've opted to delete the `v1.5.2` tag locally and it will most likely be reassigned to a non-`REL` commit (i.e., the most recent commit at release prepartion time, which might be the merge commit from this PR when it is ready)
- update the `1.5.2` release notes to reflect the additional backports included here