### PR TITLE
ENH: Add single-sided p-values to t-tests

### DIFF
--- a/doc/source/tutorial/stats.rst
+++ b/doc/source/tutorial/stats.rst
@@ -872,7 +872,7 @@ Test with sample with different means:
 
     >>> rvs3 = stats.norm.rvs(loc=8, scale=10, size=500)
     >>> stats.ttest_ind(rvs1, rvs3)
-    Ttest_indResult(statistic=-4.533414290175026, pvalue=6.507128186505895e-06)
+    Ttest_indResult(statistic=-4.533414290175026, pvalue=6.507128186389019e-06)
 
 Kolmogorov-Smirnov test for two samples ks_2samp
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/tutorial/stats.rst
+++ b/doc/source/tutorial/stats.rst
@@ -872,7 +872,7 @@ Test with sample with different means:
 
     >>> rvs3 = stats.norm.rvs(loc=8, scale=10, size=500)
     >>> stats.ttest_ind(rvs1, rvs3)
-    Ttest_indResult(statistic=-4.533414290175026, pvalue=6.507128186389019e-06)
+    Ttest_indResult(statistic=-4.533414290175026, pvalue=6.507128186505895e-06)
 
 Kolmogorov-Smirnov test for two samples ks_2samp
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5368,7 +5368,7 @@ def _ttest_finish(df, t, alternative):
     elif alternative == 'two-sided':
         prob = 2 * distributions.t.sf(np.abs(t), df)
     else:
-        raise ValueError("alternative should be "
+        raise ValueError("alternative must be "
                          "'less', 'greater' or 'two-sided'")
 
     if t.ndim == 0:

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5503,7 +5503,7 @@ def ttest_ind_from_stats(mean1, std1, nobs1, mean2, std2, nobs2,
     >>> group1 = np.array([1]*30 + [0]*(150-30))
     >>> group2 = np.array([1]*45 + [0]*(200-45))
     >>> ttest_ind(group1, group2)
-    Ttest_indResult(statistic=-0.5627179589855622, pvalue=0.573989277115258)
+    Ttest_indResult(statistic=-0.5627179589855622, pvalue=0.5739892771152579)
 
     """
     if equal_var:

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -348,7 +348,7 @@ def _broadcast_shapes_with_dropped_axis(a, b, axis):
 
 def _convert_symmetric_p_value(pvalue, root_func, alternative):
     """
-    Convert a one-sided, symmetric P-value to a one or two-sided p-value. root_func
+    Convert a one-sided p-value from a symmetric distribution to a one or two-sided p-value.
     describes the source distribution function ('sf' or 'cdf')
     """
     if alternative not in ["two-sided", "greater", "less"]:

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5312,7 +5312,7 @@ def ttest_1samp(a, popmean, axis=0, nan_policy='propagate',
 
     Examples using axis and non-scalar dimension for population mean.
 
-    >>> result = stats.ttest_1samp(rvs,[5.0,0.0])
+    >>> result = stats.ttest_1samp(rvs, [5.0, 0.0])
     >>> result.statistic
     array([-0.68014479,  4.11038784]),
     >>> result.pvalue

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -348,17 +348,21 @@ def _broadcast_shapes_with_dropped_axis(a, b, axis):
 
 def _convert_symmetric_p_value(pvalue, root_tail, alternative):
     """
-    Convert a one-sided p-value from a symmetric distribution to a one or two-sided p-value.
+    Convert a one-sided p-value from a symmetric distribution to a one or
+    two-sided p-value.
     """
     if alternative not in {"two-sided", "greater", "less"}:
-        raise ValueError("alternative should be 'less', 'greater' or 'two-sided'")
+        raise ValueError("alternative should be "
+                         "'less', 'greater' or 'two-sided'")
 
     if root_tail not in {"greater", "less"}:
         raise ValueError("root_func should be 'less' or 'greater'")
 
-    if (alternative, root_tail) in {("greater", "greater"), ("less", "less")}:
+    if (alternative, root_tail) in {("greater", "greater"),
+                                    ("less", "less")}:
         return pvalue
-    elif (alternative, root_tail) in {("greater", "less"), ("less", "greater")}:
+    elif (alternative, root_tail) in {("greater", "less"),
+                                      ("less", "greater")}:
         return 1 - pvalue
     elif alternative == "two-sided":
         return 2 * np.minimum(pvalue, 1 - pvalue)
@@ -5269,7 +5273,8 @@ def _two_sample_transform(u, v):
 Ttest_1sampResult = namedtuple('Ttest_1sampResult', ('statistic', 'pvalue'))
 
 
-def ttest_1samp(a, popmean, axis=0, nan_policy='propagate', alternative="two-sided"):
+def ttest_1samp(a, popmean, axis=0, nan_policy='propagate',
+                alternative="two-sided"):
     """
     Calculate the T-test for the mean of ONE group of scores.
 
@@ -5330,13 +5335,15 @@ def ttest_1samp(a, popmean, axis=0, nan_policy='propagate', alternative="two-sid
     Examples using axis and non-scalar dimension for population mean.
 
     >>> stats.ttest_1samp(rvs,[5.0,0.0])
-    (array([-0.68014479,  4.11038784]), array([  4.99613833e-01,   1.49986458e-04]))
+    (array([-0.68014479,  4.11038784]), array([  4.99613833e-01,
+    1.49986458e-04]))
     >>> stats.ttest_1samp(rvs.T,[5.0,0.0],axis=1)
-    (array([-0.68014479,  4.11038784]), array([  4.99613833e-01,   1.49986458e-04]))
+    (array([-0.68014479,  4.11038784]), array([  4.99613833e-01,
+    1.49986458e-04]))
     >>> stats.ttest_1samp(rvs,[[5.0],[0.0]])
     (array([[-0.68014479, -0.04323899],
-           [ 2.77025808,  4.11038784]]), array([[  4.99613833e-01,   9.65686743e-01],
-           [  7.89094663e-03,   1.49986458e-04]]))
+           [ 2.77025808,  4.11038784]]), array([[  4.99613833e-01,
+           9.65686743e-01], [  7.89094663e-03,   1.49986458e-04]]))
 
     """
     a, axis = _chk_asarray(a, axis)
@@ -5567,7 +5574,8 @@ def _ttest_nans(a, b, axis, namedtuple_type):
     return namedtuple_type(t, p)
 
 
-def ttest_ind(a, b, axis=0, equal_var=True, nan_policy='propagate', alternative="two-sided"):
+def ttest_ind(a, b, axis=0, equal_var=True, nan_policy='propagate',
+              alternative="two-sided"):
     """
     Calculate the T-test for the means of *two independent* samples of scores.
 
@@ -5698,7 +5706,8 @@ def ttest_ind(a, b, axis=0, equal_var=True, nan_policy='propagate', alternative=
     else:
         df, denom = _unequal_var_ttest_denom(v1, n1, v2, n2)
 
-    res = _ttest_ind_from_stats(np.mean(a, axis), np.mean(b, axis), denom, df, alternative)
+    res = _ttest_ind_from_stats(np.mean(a, axis), np.mean(b, axis), denom, df,
+                                alternative)
 
     return Ttest_indResult(*res)
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5330,29 +5330,22 @@ def ttest_1samp(a, popmean, axis=0, nan_policy='propagate',
     >>> result.pvalue
     array([[4.99613833e-01, 9.65686743e-01],
            [7.89094663e-03, 1.49986458e-04]])
+
+
     """
+    a, axis = _chk_asarray(a, axis)
 
     contains_nan, nan_policy = _contains_nan(a, nan_policy)
 
-    # Check if passed `a` is masked/contains nan and setup appropriately
     if contains_nan and nan_policy == 'omit':
         a = ma.masked_invalid(a)
-        n = a.count(axis)
-    elif isinstance(a, np.ma.MaskedArray):
-        a = ma.asanyarray(a)
-        n = a.count(axis)
-    else:
-        a, axis = _chk_asarray(a, axis)
-        n = a.shape[axis]
+        return mstats_basic.ttest_1samp(a, popmean, axis)
 
+    n = a.shape[axis]
     df = n - 1
 
-    # a.mean and a.var throw warnings with empty arrays - ignore them.
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", category=RuntimeWarning)
-        d = a.mean(axis=axis) - popmean
-        v = a.var(axis=axis, ddof=1)
-
+    d = np.mean(a, axis) - popmean
+    v = np.var(a, axis, ddof=1)
     denom = np.sqrt(v / n)
 
     with np.errstate(divide='ignore', invalid='ignore'):

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5318,7 +5318,7 @@ def ttest_1samp(a, popmean, axis=0, nan_policy='propagate',
     >>> result.pvalue
     array([  4.99613833e-01, 1.49986458e-04])
 
-    >>> result = stats.ttest_1samp(rvs.T,[5.0,0.0],axis=1)
+    >>> result = stats.ttest_1samp(rvs.T, [5.0, 0.0], axis=1)
     >>> result.statistic
     array([-0.68014479,  4.11038784])
     >>> result.pvalue

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -349,18 +349,16 @@ def _broadcast_shapes_with_dropped_axis(a, b, axis):
 def _convert_symmetric_p_value(pvalue, root_func, alternative):
     """
     Convert a one-sided p-value from a symmetric distribution to a one or two-sided p-value.
-    describes the source distribution function ('sf' or 'cdf')
     """
-    if alternative not in ["two-sided", "greater", "less"]:
+    if alternative not in {"two-sided", "greater", "less"}:
         raise ValueError("alternative should be 'less', 'greater' or 'two-sided'")
 
-    if root_func not in ["sf", "cdf"]:
+    if root_func not in {"sf", "cdf"}:
         raise ValueError("root_func should be 'sf' or 'cdf'")
 
-    op_type = alternative + "_" + root_func
-    if op_type == "greater_sf" or op_type == "less_cdf":
+    if (alternative, root_func) in {("greater", "sf"), ("less", "cdf")}:
         return pvalue
-    elif op_type == "less_sf" or op_type == "greater_cdf":
+    elif (alternative, root_func) in {("greater", "cdf"), ("less", "sf")}:
         return 1 - pvalue
     elif alternative == "two-sided":
         return 2 * np.minimum(pvalue, 1 - pvalue)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5324,7 +5324,7 @@ def ttest_1samp(a, popmean, axis=0, nan_policy='propagate',
     >>> result.pvalue
     array([  4.99613833e-01, 1.49986458e-04])
 
-    >>> result = stats.ttest_1samp(rvs,[[5.0],[0.0]])
+    >>> result = stats.ttest_1samp(rvs, [[5.0], [0.0]])
     >>> result.statistic
     array([[-0.68014479, -0.04323899],
            [ 2.77025808,  4.11038784]])

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5338,6 +5338,10 @@ def ttest_1samp(a, popmean, axis=0, nan_policy='propagate',
     contains_nan, nan_policy = _contains_nan(a, nan_policy)
 
     if contains_nan and nan_policy == 'omit':
+        if alternative != 'two-sided':
+            raise ValueError("nan-containing/masked inputs with "
+                             "nan_policy='omit' are currently not "
+                             "supported by one-sided alternatives.")
         a = ma.masked_invalid(a)
         return mstats_basic.ttest_1samp(a, popmean, axis)
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5348,9 +5348,9 @@ def _ttest_finish(df, t, alternative):
     prob = distributions.t.sf(t, df)
 
     if alternative == "greater":
-        prob = 1 - prob
-    elif alternative == "less":
         pass
+    elif alternative == "less":
+        prob = 1 - prob
     elif alternative == "two-sided":
         prob = 2 * np.minimum(prob, 1-prob)
     else:

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5318,13 +5318,18 @@ def ttest_1samp(a, popmean, axis=0, nan_policy='propagate',
     >>> result.pvalue
     array([  4.99613833e-01, 1.49986458e-04])
 
-    >>> stats.ttest_1samp(rvs.T,[5.0,0.0],axis=1)
-    (array([-0.68014479,  4.11038784]), array([  4.99613833e-01,
-    1.49986458e-04]))
-    >>> stats.ttest_1samp(rvs,[[5.0],[0.0]])
-    (array([[-0.68014479, -0.04323899],
-           [ 2.77025808,  4.11038784]]), array([[  4.99613833e-01,
-           9.65686743e-01], [  7.89094663e-03,   1.49986458e-04]]))
+    >>> result = stats.ttest_1samp(rvs.T,[5.0,0.0],axis=1)
+    >>> result.statistic
+    array([-0.68014479,  4.11038784])
+    >>> result.pvalue
+    array([  4.99613833e-01, 1.49986458e-04])
+
+    >>> result = stats.ttest_1samp(rvs,[[5.0],[0.0]])
+    >>> result.statistic
+    array([[-0.68014479, -0.04323899], [ 2.77025808,  4.11038784]])
+    >>> result.pvalue
+    array([[  4.99613833e-01, 9.65686743e-01], [  7.89094663e-03,
+    1.49986458e-04]]))
 
     """
     a, axis = _chk_asarray(a, axis)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5322,7 +5322,7 @@ def ttest_1samp(a, popmean, axis=0, nan_policy='propagate',
     >>> result.statistic
     array([-0.68014479,  4.11038784])
     >>> result.pvalue
-    array([  4.99613833e-01, 1.49986458e-04])
+    array([4.99613833e-01, 1.49986458e-04])
 
     >>> result = stats.ttest_1samp(rvs, [[5.0], [0.0]])
     >>> result.statistic

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5688,6 +5688,10 @@ def ttest_ind(a, b, axis=0, equal_var=True, nan_policy='propagate',
         nan_policy = 'omit'
 
     if contains_nan and nan_policy == 'omit':
+        if alternative != 'two-sided':
+            raise ValueError("nan-containing/masked inputs with "
+                             "nan_policy='omit' are currently not "
+                             "supported by one-sided alternatives.")
         a = ma.masked_invalid(a)
         b = ma.masked_invalid(b)
         return mstats_basic.ttest_ind(a, b, axis, equal_var)
@@ -5801,6 +5805,10 @@ def ttest_rel(a, b, axis=0, nan_policy='propagate', alternative="two-sided"):
         nan_policy = 'omit'
 
     if contains_nan and nan_policy == 'omit':
+        if alternative != 'two-sided':
+            raise ValueError("nan-containing/masked inputs with "
+                             "nan_policy='omit' are currently not "
+                             "supported by one-sided alternatives.")
         a = ma.masked_invalid(a)
         b = ma.masked_invalid(b)
         m = ma.mask_or(ma.getmask(a), ma.getmask(b))

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5326,7 +5326,8 @@ def ttest_1samp(a, popmean, axis=0, nan_policy='propagate',
 
     >>> result = stats.ttest_1samp(rvs,[[5.0],[0.0]])
     >>> result.statistic
-    array([[-0.68014479, -0.04323899], [ 2.77025808,  4.11038784]])
+    array([[-0.68014479, -0.04323899],
+           [ 2.77025808,  4.11038784]])
     >>> result.pvalue
     array([[4.99613833e-01, 9.65686743e-01],
            [7.89094663e-03, 1.49986458e-04]])

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -346,18 +346,6 @@ def _broadcast_shapes_with_dropped_axis(a, b, axis):
     return shp
 
 
-def _evaluate_distribution_p(distribution, alternative, statistic, *args):
-    if alternative == 'less':
-        return distribution.cdf(statistic, *args)
-    elif alternative == 'greater':
-        return distribution.sf(statistic, *args)
-    elif alternative == 'two-sided':
-        return 2 * distribution.sf(np.abs(statistic), *args)
-    else:
-        raise ValueError("alternative should be "
-                         "'less', 'greater' or 'two-sided'")
-
-
 def gmean(a, axis=0, dtype=None):
     """
     Compute the geometric mean along the specified axis.
@@ -5379,7 +5367,6 @@ def _ttest_finish(df, t, alternative):
         raise ValueError("alternative should be "
                          "'less', 'greater' or 'two-sided'")
 
-    prob = _evaluate_distribution_p(distributions.t, alternative, t, df)
     if t.ndim == 0:
         t = t[()]
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -7188,7 +7188,8 @@ def kruskal(*args, **kwargs):
        The Kruskal-Wallis H statistic, corrected for ties.
     pvalue : float
        The p-value for the test using the assumption that H has a chi
-       square distribution.
+       square distribution. The p-value returned is the survival function of
+       the chi square distribution evaluated at H.
 
     See Also
     --------

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5316,7 +5316,7 @@ def ttest_1samp(a, popmean, axis=0, nan_policy='propagate',
     >>> result.statistic
     array([-0.68014479,  4.11038784]),
     >>> result.pvalue
-    array([  4.99613833e-01, 1.49986458e-04])
+    array([4.99613833e-01, 1.49986458e-04])
 
     >>> result = stats.ttest_1samp(rvs.T, [5.0, 0.0], axis=1)
     >>> result.statistic

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -1037,40 +1037,36 @@ class TestTtest_1samp():
         res3 = mstats.ttest_1samp(outcome[:, :2], outcome[:, 2:])
         assert_allclose(res2, res3)
 
-    @pytest.mark.parametrize("func", [mstats.ttest_1samp, stats.ttest_1samp])
-    def test_fully_masked(self, func):
+    def test_fully_masked(self):
         np.random.seed(1234567)
         outcome = ma.masked_array(np.random.randn(3), mask=[1, 1, 1])
         expected = (np.nan, np.nan)
         with suppress_warnings() as sup:
             sup.filter(RuntimeWarning, "invalid value encountered in absolute")
             for pair in [((np.nan, np.nan), 0.0), (outcome, 0.0)]:
-                t, p = func(*pair)
+                t, p = mstats.ttest_1samp(*pair)
                 assert_array_equal(p, expected)
                 assert_array_equal(t, expected)
 
-    @pytest.mark.parametrize("func", [mstats.ttest_1samp, stats.ttest_1samp])
-    def test_result_attributes(self, func):
+    def test_result_attributes(self):
         np.random.seed(1234567)
         outcome = np.random.randn(20, 4) + [0, 0, 1, 2]
 
-        res = func(outcome[:, 0], 1)
+        res = mstats.ttest_1samp(outcome[:, 0], 1)
         attributes = ('statistic', 'pvalue')
         check_named_results(res, attributes, ma=True)
 
-    @pytest.mark.parametrize("func", [mstats.ttest_1samp, stats.ttest_1samp])
-    def test_empty(self, func):
-        res1 = func([], 1)
+    def test_empty(self):
+        res1 = mstats.ttest_1samp([], 1)
         assert_(np.all(np.isnan(res1)))
 
-    @pytest.mark.parametrize("func", [mstats.ttest_1samp, stats.ttest_1samp])
-    def test_zero_division(self, func):
-        t, p = func([0, 0, 0], 1)
+    def test_zero_division(self):
+        t, p = mstats.ttest_1samp([0, 0, 0], 1)
         assert_equal((np.abs(t), p), (np.inf, 0))
 
         with suppress_warnings() as sup:
             sup.filter(RuntimeWarning, "invalid value encountered in absolute")
-            t, p = func([0, 0, 0], 0)
+            t, p = mstats.ttest_1samp([0, 0, 0], 0)
             assert_(np.isnan(t))
             assert_array_equal(p, (np.nan, np.nan))
 

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -1037,36 +1037,40 @@ class TestTtest_1samp():
         res3 = mstats.ttest_1samp(outcome[:, :2], outcome[:, 2:])
         assert_allclose(res2, res3)
 
-    def test_fully_masked(self):
+    @pytest.mark.parametrize("func", [mstats.ttest_1samp, stats.ttest_1samp])
+    def test_fully_masked(self, func):
         np.random.seed(1234567)
         outcome = ma.masked_array(np.random.randn(3), mask=[1, 1, 1])
         expected = (np.nan, np.nan)
         with suppress_warnings() as sup:
             sup.filter(RuntimeWarning, "invalid value encountered in absolute")
             for pair in [((np.nan, np.nan), 0.0), (outcome, 0.0)]:
-                t, p = mstats.ttest_1samp(*pair)
+                t, p = func(*pair)
                 assert_array_equal(p, expected)
                 assert_array_equal(t, expected)
 
-    def test_result_attributes(self):
+    @pytest.mark.parametrize("func", [mstats.ttest_1samp, stats.ttest_1samp])
+    def test_result_attributes(self, func):
         np.random.seed(1234567)
         outcome = np.random.randn(20, 4) + [0, 0, 1, 2]
 
-        res = mstats.ttest_1samp(outcome[:, 0], 1)
+        res = func(outcome[:, 0], 1)
         attributes = ('statistic', 'pvalue')
         check_named_results(res, attributes, ma=True)
 
-    def test_empty(self):
-        res1 = mstats.ttest_1samp([], 1)
+    @pytest.mark.parametrize("func", [mstats.ttest_1samp, stats.ttest_1samp])
+    def test_empty(self, func):
+        res1 = func([], 1)
         assert_(np.all(np.isnan(res1)))
 
-    def test_zero_division(self):
-        t, p = mstats.ttest_1samp([0, 0, 0], 1)
+    @pytest.mark.parametrize("func", [mstats.ttest_1samp, stats.ttest_1samp])
+    def test_zero_division(self, func):
+        t, p = func([0, 0, 0], 1)
         assert_equal((np.abs(t), p), (np.inf, 0))
 
         with suppress_warnings() as sup:
             sup.filter(RuntimeWarning, "invalid value encountered in absolute")
-            t, p = mstats.ttest_1samp([0, 0, 0], 0)
+            t, p = func([0, 0, 0], 0)
             assert_(np.isnan(t))
             assert_array_equal(p, (np.nan, np.nan))
 

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -1028,9 +1028,10 @@ class TestTtest_1samp():
         res1 = stats.ttest_1samp(outcome[:, 0], outcome[:, 1], axis=None)
         res2 = mstats.ttest_1samp(outcome[:, 0], outcome[:, 1], axis=None)
         assert_allclose(res1, res2)
+
         res1 = stats.ttest_1samp(outcome[:, :2], outcome[:, 2:], axis=0)
         res2 = mstats.ttest_1samp(outcome[:, :2], outcome[:, 2:], axis=0)
-        assert_allclose(res1, res2)
+        assert_allclose(res1, res2, atol=1e-15)
 
         # Check default is axis=0
         res3 = mstats.ttest_1samp(outcome[:, :2], outcome[:, 2:])

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2472,7 +2472,8 @@ class TestStudentTest(object):
                           nan_policy='foobar')
 
     def test_1samp_alternative(self):
-        assert_raises(ValueError, stats.ttest_1samp, self.X1, 0, alternative="error")
+        assert_raises(ValueError, stats.ttest_1samp, self.X1, 0,
+                      alternative="error")
 
         t, p = stats.ttest_1samp(self.X1, 1, alternative="less")
         assert_array_almost_equal(p, self.P1_1_l)
@@ -3326,7 +3327,8 @@ def test_ttest_rel():
     assert_array_almost_equal(np.abs(p), pr)
     assert_equal(t.shape, (2, 3))
 
-    t,p = stats.ttest_rel(np.rollaxis(rvs1_3D,2), np.rollaxis(rvs2_3D,2), axis=2)
+    t,p = stats.ttest_rel(np.rollaxis(rvs1_3D,2), np.rollaxis(rvs2_3D,2),
+                          axis=2)
     assert_array_almost_equal(np.abs(t), tr)
     assert_array_almost_equal(np.abs(p), pr)
     assert_equal(t.shape, (3, 2))
@@ -3485,14 +3487,16 @@ def test_ttest_ind():
     assert_array_almost_equal(np.abs(p), pr)
     assert_equal(t.shape, (2, 3))
 
-    t,p = stats.ttest_ind(np.rollaxis(rvs1_3D,2), np.rollaxis(rvs2_3D,2), axis=2)
+    t,p = stats.ttest_ind(np.rollaxis(rvs1_3D,2), np.rollaxis(rvs2_3D,2),
+                          axis=2)
     assert_array_almost_equal(np.abs(t), np.abs(tr))
     assert_array_almost_equal(np.abs(p), pr)
     assert_equal(t.shape, (3, 2))
 
     # test alternative parameter
     assert_raises(ValueError, stats.ttest_ind, rvs1, rvs2, alternative="error")
-    assert_raises(ValueError, stats.ttest_ind_from_stats, *_desc_stats(rvs1_2D.T, rvs2_2D.T), alternative="error")
+    assert_raises(ValueError, stats.ttest_ind_from_stats,
+                  *_desc_stats(rvs1_2D.T, rvs2_2D.T), alternative="error")
 
     t, p = stats.ttest_ind(rvs1, rvs2, alternative="less")
     assert_array_almost_equal(p, 1 - (pr/2))
@@ -3502,14 +3506,17 @@ def test_ttest_ind():
     assert_array_almost_equal(p, pr/2)
     assert_array_almost_equal(t, tr)
 
-    # Below makes sure ttest_ind_from_stats p-val functions identically to ttest_ind
+    # Below makes sure ttest_ind_from_stats p-val functions identically to
+    # ttest_ind
     t, p = stats.ttest_ind(rvs1_2D.T, rvs2_2D.T, axis=0, alternative="less")
     args = _desc_stats(rvs1_2D.T, rvs2_2D.T)
-    assert_array_almost_equal(stats.ttest_ind_from_stats(*args, alternative="less"), [t, p])
+    assert_array_almost_equal(
+        stats.ttest_ind_from_stats(*args, alternative="less"), [t, p])
 
     t, p = stats.ttest_ind(rvs1_2D.T, rvs2_2D.T, axis=0, alternative="greater")
     args = _desc_stats(rvs1_2D.T, rvs2_2D.T)
-    assert_array_almost_equal(stats.ttest_ind_from_stats(*args, alternative="greater"), [t, p])
+    assert_array_almost_equal(
+        stats.ttest_ind_from_stats(*args, alternative="greater"), [t, p])
 
     # check nan policy
     np.random.seed(12345678)
@@ -3661,7 +3668,8 @@ def test_ttest_ind_nan_2nd_arg():
     # x = c(NA, 2.0, 3.0, 4.0)
     # y = c(1.0, 2.0, 1.0, 2.0)
     # t.test(x, y, var.equal=TRUE)
-    assert_allclose(r2, (-2.5354627641855498, 0.052181400457057901), atol=1e-15)
+    assert_allclose(r2, (-2.5354627641855498, 0.052181400457057901),
+                    atol=1e-15)
 
 
 def test_ttest_ind_empty_1d_returns_nan():

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3327,7 +3327,7 @@ def test_ttest_rel():
     assert_array_almost_equal(np.abs(p), pr)
     assert_equal(t.shape, (2, 3))
 
-    t,p = stats.ttest_rel(np.rollaxis(rvs1_3D,2), np.rollaxis(rvs2_3D,2),
+    t, p = stats.ttest_rel(np.rollaxis(rvs1_3D, 2), np.rollaxis(rvs2_3D, 2),
                           axis=2)
     assert_array_almost_equal(np.abs(t), tr)
     assert_array_almost_equal(np.abs(p), pr)
@@ -3487,7 +3487,7 @@ def test_ttest_ind():
     assert_array_almost_equal(np.abs(p), pr)
     assert_equal(t.shape, (2, 3))
 
-    t,p = stats.ttest_ind(np.rollaxis(rvs1_3D,2), np.rollaxis(rvs2_3D,2),
+    t, p = stats.ttest_ind(np.rollaxis(rvs1_3D, 2), np.rollaxis(rvs2_3D, 2),
                           axis=2)
     assert_array_almost_equal(np.abs(t), np.abs(tr))
     assert_array_almost_equal(np.abs(p), pr)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3515,7 +3515,7 @@ def test_ttest_ind():
 
     t, p = stats.ttest_ind(rvs1_2D.T, rvs2_2D.T, axis=0, alternative="greater")
     args = _desc_stats(rvs1_2D.T, rvs2_2D.T)
-    assert_array_almost_equal(
+    assert_allclose(
         stats.ttest_ind_from_stats(*args, alternative="greater"), [t, p])
 
     # check nan policy

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3334,11 +3334,11 @@ def test_ttest_rel():
     # test alternative parameter
     assert_raises(ValueError, stats.ttest_rel, rvs1, rvs2, alternative="error")
 
-    t,p = stats.ttest_rel(rvs1, rvs2, axis=0, alternative="less")
+    t, p = stats.ttest_rel(rvs1, rvs2, axis=0, alternative="less")
     assert_array_almost_equal(p, 1 - pr/2)
     assert_array_almost_equal(t, tr)
 
-    t,p = stats.ttest_rel(rvs1, rvs2, axis=0, alternative="greater")
+    t, p = stats.ttest_rel(rvs1, rvs2, axis=0, alternative="greater")
     assert_array_almost_equal(p, pr/2)
     assert_array_almost_equal(t, tr)
 
@@ -3771,7 +3771,6 @@ def test_ttest_1samp_new():
     pc = converter(tr, pr, "less")
     assert_array_almost_equal(p, pc)
     assert_array_almost_equal(t, tr)
-
 
     with np.errstate(all='ignore'):
         assert_equal(stats.ttest_1samp([0, 0, 0], 0), (np.nan, np.nan))

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2418,8 +2418,8 @@ class TestStudentTest(object):
     X2 = np.array([0, 1, 2])
     T1_0 = 0
     P1_0 = 1
-    T1_1 = -1.732051
-    P1_1 = 0.2254033
+    T1_1 = -1.7320508075
+    P1_1 = 0.22540333075
     T1_2 = -3.464102
     P1_2 = 0.0741799
     T2_0 = 1.732051
@@ -2476,12 +2476,12 @@ class TestStudentTest(object):
                       alternative="error")
 
         t, p = stats.ttest_1samp(self.X1, 1, alternative="less")
-        assert_array_almost_equal(p, self.P1_1_l)
-        assert_array_almost_equal(t, self.T1_1)
+        assert_allclose(p, self.P1_1_l)
+        assert_allclose(t, self.T1_1)
 
         t, p = stats.ttest_1samp(self.X1, 1, alternative="greater")
-        assert_array_almost_equal(p, self.P1_1_g)
-        assert_array_almost_equal(t, self.T1_1)
+        assert_allclose(p, self.P1_1_g)
+        assert_allclose(t, self.T1_1)
 
 def test_percentileofscore():
     pcos = stats.percentileofscore
@@ -3337,12 +3337,12 @@ def test_ttest_rel():
     assert_raises(ValueError, stats.ttest_rel, rvs1, rvs2, alternative="error")
 
     t, p = stats.ttest_rel(rvs1, rvs2, axis=0, alternative="less")
-    assert_array_almost_equal(p, 1 - pr/2)
-    assert_array_almost_equal(t, tr)
+    assert_allclose(p, 1 - pr/2)
+    assert_allclose(t, tr)
 
     t, p = stats.ttest_rel(rvs1, rvs2, axis=0, alternative="greater")
-    assert_array_almost_equal(p, pr/2)
-    assert_array_almost_equal(t, tr)
+    assert_allclose(p, pr/2)
+    assert_allclose(t, tr)
 
     # check nan policy
     np.random.seed(12345678)
@@ -3499,12 +3499,12 @@ def test_ttest_ind():
                   *_desc_stats(rvs1_2D.T, rvs2_2D.T), alternative="error")
 
     t, p = stats.ttest_ind(rvs1, rvs2, alternative="less")
-    assert_array_almost_equal(p, 1 - (pr/2))
-    assert_array_almost_equal(t, tr)
+    assert_allclose(p, 1 - (pr/2))
+    assert_allclose(t, tr)
 
     t, p = stats.ttest_ind(rvs1, rvs2, alternative="greater")
-    assert_array_almost_equal(p, pr/2)
-    assert_array_almost_equal(t, tr)
+    assert_allclose(p, pr/2)
+    assert_allclose(t, tr)
 
     # Below makes sure ttest_ind_from_stats p-val functions identically to
     # ttest_ind
@@ -3773,13 +3773,13 @@ def test_ttest_1samp_new():
 
     t, p = stats.ttest_1samp(rvn1[:, :, :], 1, alternative="greater")
     pc = converter(tr, pr, "greater")
-    assert_array_almost_equal(p, pc)
-    assert_array_almost_equal(t, tr)
+    assert_allclose(p, pc)
+    assert_allclose(t, tr)
 
     t, p = stats.ttest_1samp(rvn1[:, :, :], 1, alternative="less")
     pc = converter(tr, pr, "less")
-    assert_array_almost_equal(p, pc)
-    assert_array_almost_equal(t, tr)
+    assert_allclose(p, pc)
+    assert_allclose(t, tr)
 
     with np.errstate(all='ignore'):
         assert_equal(stats.ttest_1samp([0, 0, 0], 0), (np.nan, np.nan))

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3328,7 +3328,7 @@ def test_ttest_rel():
     assert_equal(t.shape, (2, 3))
 
     t, p = stats.ttest_rel(np.rollaxis(rvs1_3D, 2), np.rollaxis(rvs2_3D, 2),
-                          axis=2)
+                           axis=2)
     assert_array_almost_equal(np.abs(t), tr)
     assert_array_almost_equal(np.abs(p), pr)
     assert_equal(t.shape, (3, 2))
@@ -3488,7 +3488,7 @@ def test_ttest_ind():
     assert_equal(t.shape, (2, 3))
 
     t, p = stats.ttest_ind(np.rollaxis(rvs1_3D, 2), np.rollaxis(rvs2_3D, 2),
-                          axis=2)
+                           axis=2)
     assert_array_almost_equal(np.abs(t), np.abs(tr))
     assert_array_almost_equal(np.abs(p), pr)
     assert_equal(t.shape, (3, 2))
@@ -3543,6 +3543,7 @@ def test_ttest_ind():
         anan = np.array([[1, np.nan], [-1, 1]])
         assert_equal(stats.ttest_ind(anan, np.zeros((2, 2))),
                      ([0, np.nan], [1, np.nan]))
+
 
 def test_ttest_ind_with_uneq_var():
     # check vs. R

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2476,9 +2476,11 @@ class TestStudentTest(object):
 
         t, p = stats.ttest_1samp(self.X1, 1, alternative="less")
         assert_array_almost_equal(p, self.P1_1_l)
+        assert_array_almost_equal(t, self.T1_1)
 
         t, p = stats.ttest_1samp(self.X1, 1, alternative="greater")
         assert_array_almost_equal(p, self.P1_1_g)
+        assert_array_almost_equal(t, self.T1_1)
 
 def test_percentileofscore():
     pcos = stats.percentileofscore
@@ -3333,12 +3335,12 @@ def test_ttest_rel():
     assert_raises(ValueError, stats.ttest_rel, rvs1, rvs2, alternative="error")
 
     t,p = stats.ttest_rel(rvs1, rvs2, axis=0, alternative="less")
-    assert_array_almost_equal(np.abs(p), 1 - pr/2)
-    assert_array_almost_equal(np.abs(t), tr)
+    assert_array_almost_equal(p, 1 - pr/2)
+    assert_array_almost_equal(t, tr)
 
     t,p = stats.ttest_rel(rvs1, rvs2, axis=0, alternative="greater")
-    assert_array_almost_equal(np.abs(p), pr/2)
-    assert_array_almost_equal(np.abs(t), tr)
+    assert_array_almost_equal(p, pr/2)
+    assert_array_almost_equal(t, tr)
 
     # check nan policy
     np.random.seed(12345678)
@@ -3493,12 +3495,12 @@ def test_ttest_ind():
     assert_raises(ValueError, stats.ttest_ind_from_stats, *_desc_stats(rvs1_2D.T, rvs2_2D.T), alternative="error")
 
     t, p = stats.ttest_ind(rvs1, rvs2, alternative="less")
-    assert_array_almost_equal(np.abs(p), 1 - (pr/2))
-    assert_array_almost_equal(np.abs(t), tr)
+    assert_array_almost_equal(p, 1 - (pr/2))
+    assert_array_almost_equal(t, tr)
 
     t, p = stats.ttest_ind(rvs1, rvs2, alternative="greater")
-    assert_array_almost_equal(np.abs(p), pr/2)
-    assert_array_almost_equal(np.abs(t), tr)
+    assert_array_almost_equal(p, pr/2)
+    assert_array_almost_equal(t, tr)
 
     # Below makes sure ttest_ind_from_stats p-val functions identically to ttest_ind
     t, p = stats.ttest_ind(rvs1_2D.T, rvs2_2D.T, axis=0, alternative="less")

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2424,6 +2424,14 @@ class TestStudentTest(object):
     P1_2 = 0.0741799
     T2_0 = 1.732051
     P2_0 = 0.2254033
+    P1_1_l = 0.1127016
+    P1_1_g = 0.8872983
+    P12_l = 0.1439320
+    P12_g = 0.8560679
+    RVS1 = np.linspace(1,100,100)
+    RVS2 = np.linspace(1.01,99.989,100)
+    PR12_l = 0.7907688274431891
+    PR12_g = 0.2092311725568109
 
     def test_onesample(self):
         with suppress_warnings() as sup, np.errstate(invalid="ignore"):
@@ -2468,6 +2476,50 @@ class TestStudentTest(object):
             assert_raises(ValueError, stats.ttest_1samp, x, 5.0, nan_policy='raise')
             assert_raises(ValueError, stats.ttest_1samp, x, 5.0,
                           nan_policy='foobar')
+
+    def test_alternative_error(self):
+        alternative = "error"
+        rvs1_2D = np.array([self.RVS1, self.RVS2])
+        rvs2_2D = np.array([self.RVS2, self.RVS1])
+
+        assert_(alternative not in ["two-sided", "greater", "less"])
+        assert_raises(ValueError, stats.ttest_1samp, self.X1, 0, alternative=alternative)
+        assert_raises(ValueError, stats.ttest_ind, self.X1, self.X2, alternative=alternative)
+        assert_raises(ValueError, stats.ttest_ind_from_stats, *_desc_stats(rvs1_2D.T, rvs2_2D.T), alternative=alternative)
+        assert_raises(ValueError, stats.ttest_rel, self.RVS1, self.RVS2, alternative=alternative)
+
+    def test_1samp_alternative(self):
+        t, p = stats.ttest_1samp(self.X1, 1, alternative="less")
+        assert_array_almost_equal(p, self.P1_1_l)
+
+        t, p = stats.ttest_1samp(self.X1, 1, alternative="greater")
+        assert_array_almost_equal(p, self.P1_1_g)
+
+    def test_ind_alternative(self):
+        t, p = stats.ttest_ind(self.X1, self.X2, alternative="less")
+        assert_array_almost_equal(p, self.P12_l)
+
+        t, p = stats.ttest_ind(self.X1, self.X2, alternative="greater")
+        assert_array_almost_equal(p, self.P12_g)
+
+    def test_ind_from_stats_alternative(self):
+        rvs1_2D = np.array([self.RVS1, self.RVS2])
+        rvs2_2D = np.array([self.RVS2, self.RVS1])
+
+        t, p = stats.ttest_ind(rvs1_2D.T, rvs2_2D.T, axis=0, alternative="less")
+        args = _desc_stats(rvs1_2D.T, rvs2_2D.T)
+        assert_array_almost_equal(stats.ttest_ind_from_stats(*args, alternative="less"), [t, p])
+
+        t, p = stats.ttest_ind(rvs1_2D.T, rvs2_2D.T, axis=0, alternative="greater")
+        args = _desc_stats(rvs1_2D.T, rvs2_2D.T)
+        assert_array_almost_equal(stats.ttest_ind_from_stats(*args, alternative="greater"), [t, p])
+
+    def test_rel_alternative(self):
+        t, p = stats.ttest_rel(self.RVS1, self.RVS2, alternative="less")
+        assert_array_almost_equal(p, self.PR12_l)
+
+        t, p = stats.ttest_rel(self.RVS1, self.RVS2, alternative="greater")
+        assert_array_almost_equal(p, self.PR12_g)
 
 
 def test_percentileofscore():

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3753,6 +3753,26 @@ def test_ttest_1samp_new():
     t, p = stats.ttest_1samp([0, 0, 0], 1)
     assert_equal((np.abs(t), p), (np.inf, 0))
 
+    # test alternative parameter
+    # Convert from two-sided p-values to one sided using T result data.
+    def convert(t, p, alt):
+        if (t < 0 and alt == "less") or (t > 0 and alt == "greater"):
+            return p / 2
+        return 1 - (p / 2)
+    converter = np.vectorize(convert)
+    tr, pr = stats.ttest_1samp(rvn1[:, :, :], 1)
+
+    t, p = stats.ttest_1samp(rvn1[:, :, :], 1, alternative="greater")
+    pc = converter(tr, pr, "greater")
+    assert_array_almost_equal(p, pc)
+    assert_array_almost_equal(t, tr)
+
+    t, p = stats.ttest_1samp(rvn1[:, :, :], 1, alternative="less")
+    pc = converter(tr, pr, "less")
+    assert_array_almost_equal(p, pc)
+    assert_array_almost_equal(t, tr)
+
+
     with np.errstate(all='ignore'):
         assert_equal(stats.ttest_1samp([0, 0, 0], 0), (np.nan, np.nan))
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2424,14 +2424,8 @@ class TestStudentTest(object):
     P1_2 = 0.0741799
     T2_0 = 1.732051
     P2_0 = 0.2254033
-    P1_1_l = 0.1127016
-    P1_1_g = 0.8872983
-    P12_l = 0.1439320
-    P12_g = 0.8560679
-    RVS1 = np.linspace(1,100,100)
-    RVS2 = np.linspace(1.01,99.989,100)
-    PR12_l = 0.7907688274431891
-    PR12_g = 0.2092311725568109
+    P1_1_l = P1_1 / 2
+    P1_1_g = 1 - (P1_1 / 2)
 
     def test_onesample(self):
         with suppress_warnings() as sup, np.errstate(invalid="ignore"):
@@ -2477,50 +2471,14 @@ class TestStudentTest(object):
             assert_raises(ValueError, stats.ttest_1samp, x, 5.0,
                           nan_policy='foobar')
 
-    def test_alternative_error(self):
-        alternative = "error"
-        rvs1_2D = np.array([self.RVS1, self.RVS2])
-        rvs2_2D = np.array([self.RVS2, self.RVS1])
-
-        assert_(alternative not in ["two-sided", "greater", "less"])
-        assert_raises(ValueError, stats.ttest_1samp, self.X1, 0, alternative=alternative)
-        assert_raises(ValueError, stats.ttest_ind, self.X1, self.X2, alternative=alternative)
-        assert_raises(ValueError, stats.ttest_ind_from_stats, *_desc_stats(rvs1_2D.T, rvs2_2D.T), alternative=alternative)
-        assert_raises(ValueError, stats.ttest_rel, self.RVS1, self.RVS2, alternative=alternative)
-
     def test_1samp_alternative(self):
+        assert_raises(ValueError, stats.ttest_1samp, self.X1, 0, alternative="error")
+
         t, p = stats.ttest_1samp(self.X1, 1, alternative="less")
         assert_array_almost_equal(p, self.P1_1_l)
 
         t, p = stats.ttest_1samp(self.X1, 1, alternative="greater")
         assert_array_almost_equal(p, self.P1_1_g)
-
-    def test_ind_alternative(self):
-        t, p = stats.ttest_ind(self.X1, self.X2, alternative="less")
-        assert_array_almost_equal(p, self.P12_l)
-
-        t, p = stats.ttest_ind(self.X1, self.X2, alternative="greater")
-        assert_array_almost_equal(p, self.P12_g)
-
-    def test_ind_from_stats_alternative(self):
-        rvs1_2D = np.array([self.RVS1, self.RVS2])
-        rvs2_2D = np.array([self.RVS2, self.RVS1])
-
-        t, p = stats.ttest_ind(rvs1_2D.T, rvs2_2D.T, axis=0, alternative="less")
-        args = _desc_stats(rvs1_2D.T, rvs2_2D.T)
-        assert_array_almost_equal(stats.ttest_ind_from_stats(*args, alternative="less"), [t, p])
-
-        t, p = stats.ttest_ind(rvs1_2D.T, rvs2_2D.T, axis=0, alternative="greater")
-        args = _desc_stats(rvs1_2D.T, rvs2_2D.T)
-        assert_array_almost_equal(stats.ttest_ind_from_stats(*args, alternative="greater"), [t, p])
-
-    def test_rel_alternative(self):
-        t, p = stats.ttest_rel(self.RVS1, self.RVS2, alternative="less")
-        assert_array_almost_equal(p, self.PR12_l)
-
-        t, p = stats.ttest_rel(self.RVS1, self.RVS2, alternative="greater")
-        assert_array_almost_equal(p, self.PR12_g)
-
 
 def test_percentileofscore():
     pcos = stats.percentileofscore
@@ -3371,6 +3329,14 @@ def test_ttest_rel():
     assert_array_almost_equal(np.abs(p), pr)
     assert_equal(t.shape, (3, 2))
 
+    # test alternative parameter
+    assert_raises(ValueError, stats.ttest_rel, rvs1, rvs2, alternative="error")
+
+    t,p = stats.ttest_rel(rvs1, rvs2, axis=0, alternative="less")
+    assert_array_almost_equal([t,p],(tr,1 - pr/2))
+
+    t,p = stats.ttest_rel(rvs1, rvs2, axis=0, alternative="greater")
+    assert_array_almost_equal([t,p],(tr,pr/2))
     # check nan policy
     np.random.seed(12345678)
     x = stats.norm.rvs(loc=5, scale=10, size=501)
@@ -3519,6 +3485,24 @@ def test_ttest_ind():
     assert_array_almost_equal(np.abs(p), pr)
     assert_equal(t.shape, (3, 2))
 
+    # test alternative parameter
+    assert_raises(ValueError, stats.ttest_ind, rvs1, rvs2, alternative="error")
+    assert_raises(ValueError, stats.ttest_ind_from_stats, *_desc_stats(rvs1_2D.T, rvs2_2D.T), alternative="error")
+
+    t, p = stats.ttest_ind(rvs1, rvs2, alternative="less")
+    assert_array_almost_equal([t,p],(tr, 1 - (pr/2)))
+
+    t, p = stats.ttest_ind(rvs1, rvs2, alternative="greater")
+    assert_array_almost_equal([t,p],(tr,pr/2))
+
+    t, p = stats.ttest_ind(rvs1_2D.T, rvs2_2D.T, axis=0, alternative="less")
+    args = _desc_stats(rvs1_2D.T, rvs2_2D.T)
+    assert_array_almost_equal(stats.ttest_ind_from_stats(*args, alternative="less"), [t, p])
+
+    t, p = stats.ttest_ind(rvs1_2D.T, rvs2_2D.T, axis=0, alternative="greater")
+    args = _desc_stats(rvs1_2D.T, rvs2_2D.T)
+    assert_array_almost_equal(stats.ttest_ind_from_stats(*args, alternative="greater"), [t, p])
+
     # check nan policy
     np.random.seed(12345678)
     x = stats.norm.rvs(loc=5, scale=10, size=501)
@@ -3544,7 +3528,6 @@ def test_ttest_ind():
         anan = np.array([[1, np.nan], [-1, 1]])
         assert_equal(stats.ttest_ind(anan, np.zeros((2, 2))),
                      ([0, np.nan], [1, np.nan]))
-
 
 def test_ttest_ind_with_uneq_var():
     # check vs. R

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3510,7 +3510,7 @@ def test_ttest_ind():
     # ttest_ind
     t, p = stats.ttest_ind(rvs1_2D.T, rvs2_2D.T, axis=0, alternative="less")
     args = _desc_stats(rvs1_2D.T, rvs2_2D.T)
-    assert_array_almost_equal(
+    assert_allclose(
         stats.ttest_ind_from_stats(*args, alternative="less"), [t, p])
 
     t, p = stats.ttest_ind(rvs1_2D.T, rvs2_2D.T, axis=0, alternative="greater")

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3333,10 +3333,13 @@ def test_ttest_rel():
     assert_raises(ValueError, stats.ttest_rel, rvs1, rvs2, alternative="error")
 
     t,p = stats.ttest_rel(rvs1, rvs2, axis=0, alternative="less")
-    assert_array_almost_equal([t,p],(tr,1 - pr/2))
+    assert_array_almost_equal(np.abs(p), 1 - pr/2)
+    assert_array_almost_equal(np.abs(t), tr)
 
     t,p = stats.ttest_rel(rvs1, rvs2, axis=0, alternative="greater")
-    assert_array_almost_equal([t,p],(tr,pr/2))
+    assert_array_almost_equal(np.abs(p), pr/2)
+    assert_array_almost_equal(np.abs(t), tr)
+
     # check nan policy
     np.random.seed(12345678)
     x = stats.norm.rvs(loc=5, scale=10, size=501)
@@ -3490,11 +3493,14 @@ def test_ttest_ind():
     assert_raises(ValueError, stats.ttest_ind_from_stats, *_desc_stats(rvs1_2D.T, rvs2_2D.T), alternative="error")
 
     t, p = stats.ttest_ind(rvs1, rvs2, alternative="less")
-    assert_array_almost_equal([t,p],(tr, 1 - (pr/2)))
+    assert_array_almost_equal(np.abs(p), 1 - (pr/2))
+    assert_array_almost_equal(np.abs(t), tr)
 
     t, p = stats.ttest_ind(rvs1, rvs2, alternative="greater")
-    assert_array_almost_equal([t,p],(tr,pr/2))
+    assert_array_almost_equal(np.abs(p), pr/2)
+    assert_array_almost_equal(np.abs(t), tr)
 
+    # Below makes sure ttest_ind_from_stats p-val functions identically to ttest_ind
     t, p = stats.ttest_ind(rvs1_2D.T, rvs2_2D.T, axis=0, alternative="less")
     args = _desc_stats(rvs1_2D.T, rvs2_2D.T)
     assert_array_almost_equal(stats.ttest_ind_from_stats(*args, alternative="less"), [t, p])


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Part of work being done for gh-12506.

#### What does this implement/fix?
This enhancement implements the "alternative" parameter in SciPy's t-tests to allow the selection and return of single-sided p-values. 

#### Additional information
•Implementation closely follows the method found in the brunnermunzel test with modifications made to support arrays. •Selection is done by setting the alternative parameter to one of three strings ("two-sided", "less", or "greater") with the default value being "two-sided" for backwards-compatibility.
•I'm still in the process of writing unit tests. They will be implemented as a method in the "TestStudentTest" class in test_stats.py, if it's the best place.
