### PR TITLE
BUG: add const for Read-only views in interpnd.pyx

### DIFF
--- a/scipy/interpolate/interpnd.pyx
+++ b/scipy/interpolate/interpnd.pyx
@@ -259,7 +259,7 @@ class LinearNDInterpolator(NDInterpolatorBase):
     def _do_evaluate(self, double[:,::1] xi, double_or_complex dummy):
         cdef const double_or_complex[:,::1] values = self.values
         cdef double_or_complex[:,::1] out
-        cdef double[:,::1] points = self.points
+        cdef const double[:,::1] points = self.points
         cdef int[:,::1] simplices = self.tri.simplices
         cdef double c[NPY_MAXDIMS]
         cdef double_or_complex fill_value
@@ -860,7 +860,7 @@ class CloughTocher2DInterpolator(NDInterpolatorBase):
         cdef const double_or_complex[:,::1] values = self.values
         cdef double_or_complex[:,:,:] grad = self.grad
         cdef double_or_complex[:,::1] out
-        cdef double[:,::1] points = self.points
+        cdef const double[:,::1] points = self.points
         cdef int[:,::1] simplices = self.tri.simplices
         cdef double c[NPY_MAXDIMS]
         cdef double_or_complex f[NPY_MAXDIMS+1]

--- a/scipy/interpolate/interpnd.pyx
+++ b/scipy/interpolate/interpnd.pyx
@@ -256,7 +256,7 @@ class LinearNDInterpolator(NDInterpolatorBase):
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
-    def _do_evaluate(self, double[:,::1] xi, double_or_complex dummy):
+    def _do_evaluate(self, const double[:,::1] xi, double_or_complex dummy):
         cdef const double_or_complex[:,::1] values = self.values
         cdef double_or_complex[:,::1] out
         cdef const double[:,::1] points = self.points
@@ -856,7 +856,7 @@ class CloughTocher2DInterpolator(NDInterpolatorBase):
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
-    def _do_evaluate(self, double[:,::1] xi, double_or_complex dummy):
+    def _do_evaluate(self, const double[:,::1] xi, double_or_complex dummy):
         cdef const double_or_complex[:,::1] values = self.values
         cdef double_or_complex[:,:,:] grad = self.grad
         cdef double_or_complex[:,::1] out

--- a/scipy/interpolate/interpnd.pyx
+++ b/scipy/interpolate/interpnd.pyx
@@ -257,7 +257,7 @@ class LinearNDInterpolator(NDInterpolatorBase):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     def _do_evaluate(self, double[:,::1] xi, double_or_complex dummy):
-        cdef double_or_complex[:,::1] values = self.values
+        cdef const double_or_complex[:,::1] values = self.values
         cdef double_or_complex[:,::1] out
         cdef double[:,::1] points = self.points
         cdef int[:,::1] simplices = self.tri.simplices
@@ -491,7 +491,7 @@ cdef int _estimate_gradients_2d_global(qhull.DelaunayInfo_t *d, double *data,
 @cython.boundscheck(False)
 @cython.wraparound(False)
 cpdef estimate_gradients_2d_global(tri, y, int maxiter=400, double tol=1e-6):
-    cdef double[:,::1] data
+    cdef const double[:,::1] data
     cdef double[:,:,::1] grad
     cdef qhull.DelaunayInfo_t info
     cdef int k, ret, nvalues
@@ -857,7 +857,7 @@ class CloughTocher2DInterpolator(NDInterpolatorBase):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     def _do_evaluate(self, double[:,::1] xi, double_or_complex dummy):
-        cdef double_or_complex[:,::1] values = self.values
+        cdef const double_or_complex[:,::1] values = self.values
         cdef double_or_complex[:,:,:] grad = self.grad
         cdef double_or_complex[:,::1] out
         cdef double[:,::1] points = self.points

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -2613,6 +2613,29 @@ class TestRegularGridInterpolator(object):
                          interp_points3.size ==
                          interp_points4.size, True)
 
+    def test_read_only(self):
+        # input data
+        np.random.seed(0)
+        x = np.random.random(10)
+        y = np.random.random(10)
+        z = np.hypot(x, y)
+        
+        # x-y grid for interpolation
+        X = np.linspace(min(x), max(x))
+        Y = np.linspace(min(y), max(y))
+        X, Y = np.meshgrid(X, Y)
+
+        x.setflags(write=False)
+        y.setflags(write=False)
+        z.setflags(write=False)
+        X.setflags(write=False)
+        Y.setflags(write=False)
+
+        for interpolator in (NearestNDInterpolator, LinearNDInterpolator,
+                             CloughTocher2DInterpolator):
+            interp = interpolator(list(zip(x, y)), z)
+            interp((X, Y))
+
 
 class MyValue(object):
     """

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -2616,8 +2616,8 @@ class TestRegularGridInterpolator(object):
     def test_read_only(self):
         # input data
         np.random.seed(0)
-        x = np.random.random(10)
-        y = np.random.random(10)
+        xy = np.random.random((10, 2))
+        x, y = xy[:, 0], xy[:, 1]
         z = np.hypot(x, y)
         
         # x-y grid for interpolation
@@ -2625,16 +2625,15 @@ class TestRegularGridInterpolator(object):
         Y = np.linspace(min(y), max(y))
         X, Y = np.meshgrid(X, Y)
 
-        x.setflags(write=False)
-        y.setflags(write=False)
+        xy.setflags(write=False)
         z.setflags(write=False)
         X.setflags(write=False)
         Y.setflags(write=False)
 
         for interpolator in (NearestNDInterpolator, LinearNDInterpolator,
                              CloughTocher2DInterpolator):
-            interp = interpolator(list(zip(x, y)), z)
-            interp((X, Y))
+            interp = interpolator(xy, z)
+            interp(X, Y)
 
 
 class MyValue(object):

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -2624,16 +2624,16 @@ class TestRegularGridInterpolator(object):
         X = np.linspace(min(x), max(x))
         Y = np.linspace(min(y), max(y))
         X, Y = np.meshgrid(X, Y)
+        XY = np.vstack((X.ravel(), Y.ravel())).T
 
         xy.setflags(write=False)
         z.setflags(write=False)
-        X.setflags(write=False)
-        Y.setflags(write=False)
+        XY.setflags(write=False)
 
         for interpolator in (NearestNDInterpolator, LinearNDInterpolator,
                              CloughTocher2DInterpolator):
             interp = interpolator(xy, z)
-            interp(X, Y)
+            interp(XY)
 
 
 class MyValue(object):

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -2620,8 +2620,8 @@ class TestRegularGridInterpolator(object):
         x, y = xy[:, 0], xy[:, 1]
         z = np.hypot(x, y)
         
-        # x-y grid for interpolation
-        XY = np.linspace((min(x), min(y)),(max(x), max(y)))
+        # interpolation points
+        XY = np.random.random((50, 2))
 
         xy.setflags(write=False)
         z.setflags(write=False)

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -2621,10 +2621,7 @@ class TestRegularGridInterpolator(object):
         z = np.hypot(x, y)
         
         # x-y grid for interpolation
-        X = np.linspace(min(x), max(x))
-        Y = np.linspace(min(y), max(y))
-        X, Y = np.meshgrid(X, Y)
-        XY = np.vstack((X.ravel(), Y.ravel())).T
+        XY = np.linspace((min(x), min(y)),(max(x), max(y)))
 
         xy.setflags(write=False)
         z.setflags(write=False)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
fix #12499 

#### What does this implement/fix?
I added const for Read-only views in interpnd.pyx and add a test for it.


#### Additional information
Ref: https://cython.readthedocs.io/en/latest/src/userguide/memoryviews.html#read-only-views