### PR TITLE
ENH: stats: Add `binomtest` to replace `binom_test`.

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -21,7 +21,7 @@ def _lazywhere(cond, arrays, f, fillvalue=None, f2=None):
     """
     np.where(cond, x, fillvalue) always evaluates x even where cond is False.
     This one only evaluates f(arr1[cond], arr2[cond], ...).
-    
+
     Examples
     --------
 
@@ -270,6 +270,34 @@ def _asarray_validated(a, check_finite=True,
     return a
 
 
+def _validate_int(k, name, minimum=None):
+    """
+    Validate a scalar integer.
+
+    This functon can be used to validate an argument to a function
+    that expects the value to be an integer.  It uses `operator.index`
+    to validate the value (so, for example, k=2.0 results in a
+    TypeError).
+
+    Parameters
+    ----------
+    k : int (presumably!)
+        The value to be validated.
+    name : str
+        The name of the parameter.
+    minimum : int, optional
+        An optional lower bound.
+    """
+    try:
+        k = operator.index(k)
+    except TypeError:
+        raise TypeError(f'{name} must be an integer.') from None
+    if minimum is not None and k < minimum:
+        raise ValueError(f'{name} must be an integer not less '
+                         f'than {minimum}') from None
+    return k
+
+
 # Add a replacement for inspect.getfullargspec()/
 # The version below is borrowed from Django,
 # https://github.com/django/django/pull/4846.
@@ -286,6 +314,7 @@ def _asarray_validated(a, check_finite=True,
 FullArgSpec = namedtuple('FullArgSpec',
                          ['args', 'varargs', 'varkw', 'defaults',
                           'kwonlyargs', 'kwonlydefaults', 'annotations'])
+
 
 def getfullargspec_no_self(func):
     """inspect.getfullargspec replacement using inspect.signature.
@@ -327,7 +356,7 @@ def getfullargspec_no_self(func):
     defaults = tuple(
         p.default for p in sig.parameters.values()
         if (p.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD and
-           p.default is not p.empty)
+            p.default is not p.empty)
     ) or None
     kwonlyargs = [
         p.name for p in sig.parameters.values()
@@ -382,7 +411,8 @@ class MapWrapper(object):
                 self._own_pool = True
             else:
                 raise RuntimeError("Number of workers specified must be -1,"
-                                   " an int >= 1, or an object with a 'map' method")
+                                   " an int >= 1, or an object with a 'map' "
+                                   "method")
 
     def __enter__(self):
         return self

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -281,7 +281,7 @@ def _validate_int(k, name, minimum=None):
 
     Parameters
     ----------
-    k : int (presumably!)
+    k : int
         The value to be validated.
     name : str
         The name of the parameter.

--- a/scipy/_lib/tests/test__util.py
+++ b/scipy/_lib/tests/test__util.py
@@ -2,6 +2,7 @@ from multiprocessing import Pool
 from multiprocessing.pool import Pool as PWL
 import os
 import math
+from fractions import Fraction
 
 import numpy as np
 from numpy.testing import assert_equal, assert_
@@ -250,13 +251,15 @@ def test_rng_integers():
 
 class TestValidateInt:
 
-    def test_validate_int(self):
-        n = _validate_int(4, 'n')
+    @pytest.mark.parametrize('n', [4, np.uint8(4), np.int16(4), np.array(4)])
+    def test_validate_int(self, n):
+        n = _validate_int(n, 'n')
         assert n == 4
 
-    def test_validate_int_bad1(self):
+    @pytest.mark.parametrize('n', [4.0, np.array([4]), Fraction(4, 1)])
+    def test_validate_int_bad(self, n):
         with pytest.raises(TypeError, match='n must be an integer'):
-            _validate_int(4.0, 'n')
+            _validate_int(n, 'n')
 
     def test_validate_int_below_min(self):
         with pytest.raises(ValueError, match='n must be an integer not '

--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -277,6 +277,7 @@ Statistical tests
    anderson
    anderson_ksamp
    binom_test
+   binomtest
    fligner
    median_test
    mood
@@ -389,6 +390,7 @@ interface package rpy.
 from .stats import *
 from .distributions import *
 from .morestats import *
+from ._binomtest import binomtest
 from ._binned_statistic import *
 from .kde import gaussian_kde
 from . import mstats

--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -285,6 +285,15 @@ Statistical tests
    kurtosistest
    normaltest
 
+Objects returned by some statistical tests
+==========================================
+
+.. autosummary::
+   :toctree: generated/
+
+   BinomTestResult
+
+
 Transformations
 ===============
 
@@ -390,7 +399,7 @@ interface package rpy.
 from .stats import *
 from .distributions import *
 from .morestats import *
-from ._binomtest import binomtest
+from ._binomtest import binomtest, BinomTestResult
 from ._binned_statistic import *
 from .kde import gaussian_kde
 from . import mstats

--- a/scipy/stats/_binomtest.py
+++ b/scipy/stats/_binomtest.py
@@ -190,9 +190,9 @@ def _validate_nonneg_int(k, name):
     try:
         k = operator.index(k)
     except TypeError:
-        raise TypeError(f'{name} must be an integer.')
+        raise TypeError(f'{name} must be an integer.') from None
     if k < 0:
-        raise ValueError(f'{name} must be nonnegative')
+        raise ValueError(f'{name} must be nonnegative') from None
     return k
 
 

--- a/scipy/stats/_binomtest.py
+++ b/scipy/stats/_binomtest.py
@@ -1,0 +1,258 @@
+from collections import namedtuple
+from math import sqrt
+import numpy as np
+from scipy.optimize import brentq
+from scipy.special import ndtri
+from ._discrete_distns import binom
+
+
+ConfidenceInterval = namedtuple('ConfidenceInterval', ['low', 'high'])
+
+
+class BinomTestResult:
+
+    def __init__(self, k, n, alternative, pvalue, proportion_estimate):
+        self.k = k
+        self.n = n
+        self.alternative = alternative
+        self.proportion_estimate = proportion_estimate
+        self.pvalue = pvalue
+
+    def __repr__(self):
+        s = ("BinomTestResult("
+             f"k={self.k}, "
+             f"n={self.n}, "
+             f"alternative={self.alternative!r}, "
+             f"proportion_estimate={self.proportion_estimate}, "
+             f"pvalue={self.pvalue})")
+        return s
+
+    def proportion_ci(self, confidence_level=0.95, method='exact'):
+        """
+        Compute the confidence interval for the estimated proportion.
+
+        Parameters
+        ----------
+        confidence_level : float, optional
+            Confidence level for the computed confidence interval
+            of the estimated proportion. Default is 0.95.
+        method : {'exact', 'wilson', 'wilsoncc'}, optional
+            Selects the method used to compute the confidence interval
+            for the estimate of the proportion:
+
+                ``'exact'`` :
+                    Use the Clopper-Pearson exact method
+                ``'wilson'`` :
+                    Wilson's method, without continuity correction
+                ``'wilsoncc'`` :
+                    Wilson's method, with continuity correction
+
+            Default is ``'exact'``.
+
+        Returns
+        -------
+        ci : A namedtuple containing the lower and upper limits
+            of the confidence interval.
+        """
+        if method not in ('exact', 'wilson', 'wilsoncc'):
+            raise ValueError("method must be one of 'exact', 'wilson' or "
+                             "'wilsoncc'.")
+        if method == 'exact':
+            low, high = _binom_exact_conf_int(self.k, self.n,
+                                              confidence_level,
+                                              self.alternative)
+        else:
+            # method is 'wilson' or 'wilsoncc'
+            low, high = _binom_wilson_conf_int(self.k, self.n,
+                                               confidence_level,
+                                               self.alternative,
+                                               correction=method == 'wilsoncc')
+        return ConfidenceInterval(low=low, high=high)
+
+
+def _binom_exact_conf_int(k, n, confidence_level, alternative):
+    """
+    Compute the estimate and confidence interval for the binomial test.
+
+    Returns proportion, prop_low, prop_high
+    """
+    if alternative == 'two-sided':
+        alpha = (1 - confidence_level) / 2
+        if k == 0:
+            plow = 0.0
+        else:
+            plow = brentq(lambda p: binom.sf(k-1, n, p) - alpha, 0, 1)
+        if k == n:
+            phigh = 1.0
+        else:
+            phigh = brentq(lambda p: binom.cdf(k, n, p) - alpha, 0, 1)
+    elif alternative == 'less':
+        alpha = 1 - confidence_level
+        plow = 0.0
+        if k == n:
+            phigh = 1.0
+        else:
+            phigh = brentq(lambda p: binom.cdf(k, n, p) - alpha, 0, 1)
+    elif alternative == 'greater':
+        alpha = 1 - confidence_level
+        if k == 0:
+            plow = 0.0
+        else:
+            plow = brentq(lambda p: binom.sf(k-1, n, p) - alpha, 0, 1)
+        phigh = 1.0
+    return plow, phigh
+
+
+def _binom_wilson_conf_int(k, n, confidence_level, alternative, correction):
+    # This function assumes that the arguments have already been validated.
+    # In particular, `alternative` must be one of 'two-sided', 'less' or
+    # 'greater'.
+    p = k / n
+    if alternative == 'two-sided':
+        z = ndtri(0.5 + 0.5*confidence_level)
+    else:
+        z = ndtri(confidence_level)
+
+    t = 1 + z**2/n
+    r = (p + z**2/(2*n)) / t
+
+    if correction:
+        if alternative == 'less' or k == 0:
+            lo = 0.0
+        else:
+            dlo = ((z * sqrt(z**2 - 1/n + 4*n*p*(1 - p) + (4*p - 2)) + 1) /
+                   (2*n*t))
+            lo = r - dlo
+        if alternative == 'greater' or k == n:
+            hi = 1.0
+        else:
+            dhi = ((z * sqrt(z**2 - 1/n + 4*n*p*(1 - p) - (4*p - 2)) + 1) /
+                   (2*n*t))
+            hi = r + dhi
+    else:
+        d = z/t * sqrt(p*(1-p)/n + (z/(2*n))**2)
+        if alternative == 'less' or k == 0:
+            lo = 0.0
+        else:
+            lo = r - d
+        if alternative == 'greater' or k == n:
+            hi = 1.0
+        else:
+            hi = r + d
+
+    return lo, hi
+
+
+def binomtest(k, *, n=None, p=0.5, alternative='two-sided'):
+    """
+    Perform a test that the probability of success is p.
+
+    This is a test of the null hypothesis that the probability of success
+    in a Bernoulli experiment is `p`.
+
+    Parameters
+    ----------
+    k : int or array_like
+        The number of successes, or if k has length 2, it is the
+        number of successes and the number of failures.
+    n : int
+        The number of trials.  This is ignored if k gives both the
+        number of successes and failures.
+    p : float, optional
+        The hypothesized probability of success.  ``0 <= p <= 1``. The
+        default value is ``p = 0.5``.
+    alternative : {'two-sided', 'greater', 'less'}, optional
+        Indicates the alternative hypothesis. The default value is
+        'two-sided'.
+
+    Returns
+    -------
+    result : BinomTestResult instance
+        The return value is an object with the following attributes:
+
+        * `k` : int
+        * `n` : int
+        * `alternative` : str
+        * `pvalue` : float
+        * `proportion_estimate` : float
+
+        The object has the following methods:
+
+        * `proportion_ci(confidence_level=0.95, method='exact')`
+            Compute the confidence interval for ``proportion_estimate``.
+
+    References
+    ----------
+    .. [1] https://en.wikipedia.org/wiki/Binomial_test
+
+    Examples
+    --------
+    >>> from scipy.stats import binomtest
+
+    A car manufacturer claims that no more than 10% of their cars are unsafe.
+    15 cars are inspected for safety, 3 were found to be unsafe. Test the
+    manufacturer's claim:
+
+    >>> result = binomtest(3, n=15, p=0.1, alternative='greater')
+    >>> result.pvalue
+    0.18406106910639114
+
+    The null hypothesis cannot be rejected at the 5% level of significance
+    because the returned p-value is greater than the critical value of 5%.
+
+    The estimated proportion is simply ``3/15``:
+
+    >>> result.proportion_estimate
+    0.2
+
+    We can use the `proportion_ci()` method of the result to compute the
+    confidence interval of the estimate:
+
+    >>> result.proportion_ci(confidence_level=0.95)
+    ConfidenceInterval(low=0.056846867590246826, high=1.0)
+
+    """
+    k = np.atleast_1d(k).astype(np.int_)
+    if len(k) == 2:
+        n = k[1] + k[0]
+        k = k[0]
+    elif len(k) == 1:
+        k = k[0]
+        if n is None or n < k:
+            raise ValueError("n must be >= k")
+        n = np.int_(n)
+    else:
+        raise ValueError("Incorrect length for k.")
+
+    if (p > 1.0) or (p < 0.0):
+        raise ValueError("p must be in range [0,1]")
+
+    if alternative not in ('two-sided', 'less', 'greater'):
+        raise ValueError("alternative not recognized\n"
+                         "must be 'two-sided', 'less' or 'greater'")
+
+    if alternative == 'less':
+        pval = binom.cdf(k, n, p)
+    elif alternative == 'greater':
+        pval = binom.sf(k-1, n, p)
+    else:
+        # alternative is 'two-sided'
+        d = binom.pmf(k, n, p)
+        rerr = 1 + 1e-7
+        if k == p * n:
+            # special case as shortcut, would also be handled by `else` below
+            pval = 1.
+        elif k < p * n:
+            i = np.arange(np.ceil(p * n), n+1)
+            y = np.sum(binom.pmf(i, n, p) <= d*rerr, axis=0)
+            pval = binom.cdf(k, n, p) + binom.sf(n - y, n, p)
+        else:
+            i = np.arange(np.floor(p*n) + 1)
+            y = np.sum(binom.pmf(i, n, p) <= d*rerr, axis=0)
+            pval = binom.cdf(y-1, n, p) + binom.sf(k-1, n, p)
+
+        pval = min(1.0, pval)
+
+    result = BinomTestResult(k=k, n=n, alternative=alternative,
+                             proportion_estimate=k/n, pvalue=pval)
+    return result

--- a/scipy/stats/_binomtest.py
+++ b/scipy/stats/_binomtest.py
@@ -1,7 +1,7 @@
 from collections import namedtuple
-import operator
 from math import sqrt
 import numpy as np
+from scipy._lib._util import _validate_int
 from scipy.optimize import brentq
 from scipy.special import ndtri
 from ._discrete_distns import binom
@@ -186,16 +186,6 @@ def _binom_wilson_conf_int(k, n, confidence_level, alternative, correction):
     return lo, hi
 
 
-def _validate_nonneg_int(k, name):
-    try:
-        k = operator.index(k)
-    except TypeError:
-        raise TypeError(f'{name} must be an integer.') from None
-    if k < 0:
-        raise ValueError(f'{name} must be nonnegative') from None
-    return k
-
-
 def binomtest(k, n, p=0.5, alternative='two-sided'):
     """
     Perform a test that the probability of success is p.
@@ -275,8 +265,8 @@ def binomtest(k, n, p=0.5, alternative='two-sided'):
     ConfidenceInterval(low=0.056846867590246826, high=1.0)
 
     """
-    k = _validate_nonneg_int(k, 'k')
-    n = _validate_nonneg_int(n, 'n')
+    k = _validate_int(k, 'k', minimum=0)
+    n = _validate_int(n, 'n', minimum=1)
     if k > n:
         raise ValueError('k must not be greater than n.')
 

--- a/scipy/stats/_binomtest.py
+++ b/scipy/stats/_binomtest.py
@@ -1,4 +1,4 @@
-from collections import namedtuple
+from dataclasses import dataclass
 from math import sqrt
 import numpy as np
 from scipy._lib._util import _validate_int
@@ -7,7 +7,13 @@ from scipy.special import ndtri
 from ._discrete_distns import binom
 
 
-ConfidenceInterval = namedtuple('ConfidenceInterval', ['low', 'high'])
+@dataclass
+class ConfidenceInterval:
+    """
+    Class for confidence intervals.
+    """
+    low: float
+    high: float
 
 
 class BinomTestResult:

--- a/scipy/stats/_binomtest.py
+++ b/scipy/stats/_binomtest.py
@@ -91,8 +91,8 @@ class BinomTestResult:
         >>> result = binomtest(k=7, n=50, p=0.1)
         >>> result.proportion_estimate
         0.14
-        >>> result.proportion_ci
-        ConfidenceInterval(low=0.04246878737883377, high=0.30910696596481874)
+        >>> result.proportion_ci()
+        ConfidenceInterval(low=0.05819170033997341, high=0.2673960024970084)
         """
         if method not in ('exact', 'wilson', 'wilsoncc'):
             raise ValueError("method must be one of 'exact', 'wilson' or "

--- a/scipy/stats/_binomtest.py
+++ b/scipy/stats/_binomtest.py
@@ -203,8 +203,9 @@ def binomtest(k, n, p=0.5, alternative='two-sided'):
     n : int
         The number of trials.
     p : float, optional
-        The hypothesized probability of success.  ``0 <= p <= 1``. The
-        default value is ``p = 0.5``.
+        The hypothesized probability of success, i.e. the expected
+        proportion of successes.  The value must be in the interval
+        ``0 <= p <= 1``. The default value is ``p = 0.5``.
     alternative : {'two-sided', 'greater', 'less'}, optional
         Indicates the alternative hypothesis. The default value is
         'two-sided'.

--- a/scipy/stats/_binomtest.py
+++ b/scipy/stats/_binomtest.py
@@ -57,6 +57,8 @@ class BinomTestResult:
         if method not in ('exact', 'wilson', 'wilsoncc'):
             raise ValueError("method must be one of 'exact', 'wilson' or "
                              "'wilsoncc'.")
+        if not (0 <= confidence_level <= 1):
+            raise ValueError('confidence_level must be in the interval [0, 1].')
         if method == 'exact':
             low, high = _binom_exact_conf_int(self.k, self.n,
                                               confidence_level,

--- a/scipy/stats/_binomtest.py
+++ b/scipy/stats/_binomtest.py
@@ -168,32 +168,32 @@ def _binom_wilson_conf_int(k, n, confidence_level, alternative, correction):
     else:
         z = ndtri(confidence_level)
 
-    t = 1 + z**2/n
-    r = (p + z**2/(2*n)) / t
-
+    # For reference, the formulas implemented here are from
+    # Newcombe (1998) (ref. [3] in the proportion_ci docstring).
+    denom = 2*(n + z**2)
+    center = (2*n*p + z**2)/denom
+    q = 1 - p
     if correction:
         if alternative == 'less' or k == 0:
             lo = 0.0
         else:
-            dlo = ((z * sqrt(z**2 - 1/n + 4*n*p*(1 - p) + (4*p - 2)) + 1) /
-                   (2*n*t))
-            lo = r - dlo
+            dlo = (1 + z*sqrt(z**2 - 2 - 1/n + 4*p*(n*q + 1))) / denom
+            lo = center - dlo
         if alternative == 'greater' or k == n:
             hi = 1.0
         else:
-            dhi = ((z * sqrt(z**2 - 1/n + 4*n*p*(1 - p) - (4*p - 2)) + 1) /
-                   (2*n*t))
-            hi = r + dhi
+            dhi = (1 + z*sqrt(z**2 + 2 - 1/n + 4*p*(n*q - 1))) / denom
+            hi = center + dhi
     else:
-        d = z/t * sqrt(p*(1-p)/n + (z/(2*n))**2)
+        delta = z/denom * sqrt(4*n*p*q + z**2)
         if alternative == 'less' or k == 0:
             lo = 0.0
         else:
-            lo = r - d
+            lo = center - delta
         if alternative == 'greater' or k == n:
             hi = 1.0
         else:
-            hi = r + d
+            hi = center + delta
 
     return lo, hi
 

--- a/scipy/stats/_binomtest.py
+++ b/scipy/stats/_binomtest.py
@@ -76,8 +76,9 @@ class BinomTestResult:
 
         Returns
         -------
-        ci : namedtuple with fields ``low`` and ``high``
-            Contains the lower and upper bounds of the confidence interval.
+        ci : ``ConfidenceInterval`` object
+            The object has attributes ``low`` and ``high`` that hold the
+            lower and upper bounds of the confidence interval.
 
         References
         ----------

--- a/scipy/stats/_binomtest.py
+++ b/scipy/stats/_binomtest.py
@@ -11,7 +11,25 @@ ConfidenceInterval = namedtuple('ConfidenceInterval', ['low', 'high'])
 
 
 class BinomTestResult:
+    """
+    Result of `scipy.stats.binomtest`.
 
+    Attributes
+    ----------
+    k : int
+        The number of successes (copied from `binomtest` input).
+    n : int
+        The number of trials (copied from `binomtest` input).
+    alternative : str
+        Indicates the alternative hypothesis specified in the input
+        to `binomtest`.  It will be one of ``'two-sided'``, ``'greater'``,
+        or ``'less'``.
+    pvalue : float
+        The p-value of the hypothesis test.
+    proportion_estimate : float
+        The estimate of the proportion of successes.
+
+    """
     def __init__(self, k, n, alternative, pvalue, proportion_estimate):
         self.k = k
         self.n = n
@@ -66,6 +84,15 @@ class BinomTestResult:
         .. [3] Robert G. Newcombe, Two-sided confidence intervals for the
                single proportion: comparison of seven methods, Statistics
                in Medicine, 17, pp 857-872 (1998).
+
+        Examples
+        --------
+        >>> from scipy.stats import binomtest
+        >>> result = binomtest(k=7, n=50, p=0.1)
+        >>> result.proportion_estimate
+        0.14
+        >>> result.proportion_ci
+        ConfidenceInterval(low=0.04246878737883377, high=0.30910696596481874)
         """
         if method not in ('exact', 'wilson', 'wilsoncc'):
             raise ValueError("method must be one of 'exact', 'wilson' or "
@@ -194,15 +221,17 @@ def binomtest(k, *, n=None, p=0.5, alternative='two-sided'):
 
     Returns
     -------
-    result : BinomTestResult instance
+    result : `BinomTestResult` instance
         The return value is an object with the following attributes:
 
         k : int
-            Copied from the input.
+            The number of successes (copied from `binomtest` input).
         n : int
-            Copied from the input.
+            The number of trials (copied from `binomtest` input).
         alternative : str
-            Copied from the input.
+            Indicates the alternative hypothesis specified in the input
+            to `binomtest`.  It will be one of ``'two-sided'``, ``'greater'``,
+            or ``'less'``.
         pvalue : float
             The p-value of the hypothesis test.
         proportion_estimate : float

--- a/scipy/stats/_binomtest.py
+++ b/scipy/stats/_binomtest.py
@@ -228,7 +228,7 @@ def binomtest(k, *, n=None, p=0.5, alternative='two-sided'):
     if k > n:
         raise ValueError('k must not be greater than n.')
 
-    if (p > 1.0) or (p < 0.0):
+    if not (0 <= p <= 1):
         raise ValueError("p must be in range [0,1]")
 
     if alternative not in ('two-sided', 'less', 'greater'):

--- a/scipy/stats/_binomtest.py
+++ b/scipy/stats/_binomtest.py
@@ -41,25 +41,38 @@ class BinomTestResult:
             Selects the method used to compute the confidence interval
             for the estimate of the proportion:
 
-                ``'exact'`` :
-                    Use the Clopper-Pearson exact method
-                ``'wilson'`` :
-                    Wilson's method, without continuity correction
-                ``'wilsoncc'`` :
-                    Wilson's method, with continuity correction
+            'exact' :
+                Use the Clopper-Pearson exact method [1]_.
+            'wilson' :
+                Wilson's method, without continuity correction ([2]_, [3]_).
+            'wilsoncc' :
+                Wilson's method, with continuity correction ([2]_, [3]_).
 
             Default is ``'exact'``.
 
         Returns
         -------
-        ci : A namedtuple containing the lower and upper limits
-            of the confidence interval.
+        ci : namedtuple with fields ``low`` and ``high``
+            Contains the lower and upper bounds of the confidence interval.
+
+        References
+        ----------
+        .. [1] C. J. Clopper and E. S. Pearson, The use of confidence or
+               fiducial limits illustrated in the case of the binomial,
+               Biometrika, Vol. 26, No. 4, pp 404-413 (Dec. 1934).
+        .. [2] E. B. Wilson, Probable inference, the law of succession, and
+               statistical inference, J. Amer. Stat. Assoc., 22, pp 209-212
+               (1927).
+        .. [3] Robert G. Newcombe, Two-sided confidence intervals for the
+               single proportion: comparison of seven methods, Statistics
+               in Medicine, 17, pp 857-872 (1998).
         """
         if method not in ('exact', 'wilson', 'wilsoncc'):
             raise ValueError("method must be one of 'exact', 'wilson' or "
                              "'wilsoncc'.")
         if not (0 <= confidence_level <= 1):
-            raise ValueError('confidence_level must be in the interval [0, 1].')
+            raise ValueError('confidence_level must be in the interval '
+                             '[0, 1].')
         if method == 'exact':
             low, high = _binom_exact_conf_int(self.k, self.n,
                                               confidence_level,
@@ -160,8 +173,11 @@ def binomtest(k, *, n=None, p=0.5, alternative='two-sided'):
     """
     Perform a test that the probability of success is p.
 
-    This is a test of the null hypothesis that the probability of success
-    in a Bernoulli experiment is `p`.
+    The binomial test [1]_ is a test of the null hypothesis that the
+    probability of success in a Bernoulli experiment is `p`.
+
+    Details of the test can be found in many texts on statistics, such
+    as section 24.5 of [2]_.
 
     Parameters
     ----------
@@ -181,20 +197,27 @@ def binomtest(k, *, n=None, p=0.5, alternative='two-sided'):
     result : BinomTestResult instance
         The return value is an object with the following attributes:
 
-        * `k` : int
-        * `n` : int
-        * `alternative` : str
-        * `pvalue` : float
-        * `proportion_estimate` : float
+        k : int
+            Copied from the input.
+        n : int
+            Copied from the input.
+        alternative : str
+            Copied from the input.
+        pvalue : float
+            The p-value of the hypothesis test.
+        proportion_estimate : float
+            The estimate of the proportion of successes.
 
         The object has the following methods:
 
-        * `proportion_ci(confidence_level=0.95, method='exact')`
+        proportion_ci(confidence_level=0.95, method='exact') :
             Compute the confidence interval for ``proportion_estimate``.
 
     References
     ----------
-    .. [1] https://en.wikipedia.org/wiki/Binomial_test
+    .. [1] Binomial test, https://en.wikipedia.org/wiki/Binomial_test
+    .. [2] Jerrold H. Zar, Biostatistical Analysis (fifth edition),
+           Prentice Hall, Upper Saddle River, New Jersey USA (2010)
 
     Examples
     --------

--- a/scipy/stats/_binomtest.py
+++ b/scipy/stats/_binomtest.py
@@ -196,7 +196,7 @@ def _validate_nonneg_int(k, name):
     return k
 
 
-def binomtest(k, *, n=None, p=0.5, alternative='two-sided'):
+def binomtest(k, n, p=0.5, alternative='two-sided'):
     """
     Perform a test that the probability of success is p.
 

--- a/scipy/stats/_binomtest.py
+++ b/scipy/stats/_binomtest.py
@@ -252,6 +252,10 @@ def binomtest(k, n, p=0.5, alternative='two-sided'):
         proportion_ci(confidence_level=0.95, method='exact') :
             Compute the confidence interval for ``proportion_estimate``.
 
+    Notes
+    -----
+    .. versionadded:: 1.7.0
+
     References
     ----------
     .. [1] Binomial test, https://en.wikipedia.org/wiki/Binomial_test

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -2441,6 +2441,7 @@ def levene(*args, center='median', proportiontocut=0.05):
     return LeveneResult(W, pval)
 
 
+@np.deprecate(new_name='binomtest')
 def binom_test(x, n=None, p=0.5, alternative='two-sided'):
     """
     Perform a test that the probability of success is p.

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -2441,7 +2441,8 @@ def levene(*args, center='median', proportiontocut=0.05):
     return LeveneResult(W, pval)
 
 
-@np.deprecate(new_name='binomtest')
+@np.deprecate(new_name='binomtest',
+              message='`binom_test` will be removed from SciPy 1.8.')
 def binom_test(x, n=None, p=0.5, alternative='two-sided'):
     """
     Perform a test that the probability of success is p.

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -2441,11 +2441,12 @@ def levene(*args, center='median', proportiontocut=0.05):
     return LeveneResult(W, pval)
 
 
-@np.deprecate(new_name='binomtest',
-              message='`binom_test` will be removed from SciPy 1.9.')
 def binom_test(x, n=None, p=0.5, alternative='two-sided'):
     """
     Perform a test that the probability of success is p.
+
+    Note: `binom_test` is deprecated; it is recommended that `binomtest`
+    be used instead.
 
     This is an exact, two-sided test of the null hypothesis
     that the probability of success in a Bernoulli experiment

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -2442,7 +2442,7 @@ def levene(*args, center='median', proportiontocut=0.05):
 
 
 @np.deprecate(new_name='binomtest',
-              message='`binom_test` will be removed from SciPy 1.8.')
+              message='`binom_test` will be removed from SciPy 1.9.')
 def binom_test(x, n=None, p=0.5, alternative='two-sided'):
     """
     Perform a test that the probability of success is p.

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -798,6 +798,11 @@ class TestBinomTest:
                            match="must be an integer not less than"):
             stats.binomtest(k, n)
 
+    def test_invalid_k_too_big(self):
+        with pytest.raises(ValueError,
+                           match="k must not be greater than n"):
+            stats.binomtest(11, 10, 0.25)
+
     def test_invalid_confidence_level(self):
         res = stats.binomtest(3, n=10, p=0.1)
         with pytest.raises(ValueError, match="must be in the interval"):

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -725,6 +725,12 @@ class TestBinomTest:
         ci = res.proportion_ci(confidence_level=conf, method=method)
         assert_allclose(ci, (ci_low, ci_high), rtol=1e-6)
 
+    @pytest.mark.parametrize('k, n', [(0, 0), (-1, 2)])
+    def test_invalid_k_n(self, k, n):
+        with pytest.raises(ValueError,
+                           match="must be an integer not less than"):
+            stats.binomtest(k, n)
+
     def test_invalid_confidence_level(self):
         res = stats.binomtest(3, n=10, p=0.1)
         with pytest.raises(ValueError, match="must be in the interval"):

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -792,6 +792,14 @@ class TestBinomTest:
         ci = res.proportion_ci(confidence_level=conf, method=method)
         assert_allclose(ci, (ci_low, ci_high), rtol=1e-6)
 
+    def test_estimate_equals_hypothesized_prop(self):
+        # Test the special case where the estimated proportion equals
+        # the hypothesized proportion.  When alternative is 'two-sided',
+        # the p-value is 1.
+        res = stats.binomtest(4, 16, 0.25)
+        assert_equal(res.proportion_estimate, 0.25)
+        assert_equal(res.pvalue, 1.0)
+
     @pytest.mark.parametrize('k, n', [(0, 0), (-1, 2)])
     def test_invalid_k_n(self, k, n):
         with pytest.raises(ValueError,

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -708,8 +708,8 @@ class TestBinomTest:
         res = stats.binomtest(20, n=100, p=0.25, alternative=alternative)
         assert_allclose(res.pvalue, pval, rtol=1e-6)
         assert_equal(res.proportion_estimate, 0.2)
-        proportion_ci = res.proportion_ci(confidence_level=0.95)
-        assert_allclose(proportion_ci, (ci_low, ci_high), rtol=1e-6)
+        ci = res.proportion_ci(confidence_level=0.95)
+        assert_allclose((ci.low, ci.high), (ci_low, ci_high), rtol=1e-6)
 
     # Expected results here are from R 3.6.2 binom.test.
     @pytest.mark.parametrize('alternative, pval, ci_low, ci_high',
@@ -723,8 +723,8 @@ class TestBinomTest:
         res = stats.binomtest(3, n=50, p=0.2, alternative=alternative)
         assert_allclose(res.pvalue, pval, rtol=1e-6)
         assert_equal(res.proportion_estimate, 0.06)
-        proportion_ci = res.proportion_ci(confidence_level=0.99)
-        assert_allclose(proportion_ci, (ci_low, ci_high), rtol=1e-6)
+        ci = res.proportion_ci(confidence_level=0.99)
+        assert_allclose((ci.low, ci.high), (ci_low, ci_high), rtol=1e-6)
 
     # Expected results here are from R 3.6.2 binom.test.
     @pytest.mark.parametrize('alternative, pval, ci_high',
@@ -735,9 +735,9 @@ class TestBinomTest:
         # Test with k=0, n = 10.
         res = stats.binomtest(0, 10, p=0.25, alternative=alternative)
         assert_allclose(res.pvalue, pval, rtol=1e-6)
-        proportion_ci = res.proportion_ci(confidence_level=0.95)
-        assert_equal(proportion_ci.low, 0.0)
-        assert_allclose(proportion_ci.high, ci_high, rtol=1e-6)
+        ci = res.proportion_ci(confidence_level=0.95)
+        assert_equal(ci.low, 0.0)
+        assert_allclose(ci.high, ci_high, rtol=1e-6)
 
     # Expected results here are from R 3.6.2 binom.test.
     @pytest.mark.parametrize('alternative, pval, ci_low',
@@ -748,9 +748,9 @@ class TestBinomTest:
         # Test with k = n = 10.
         res = stats.binomtest(10, 10, p=0.25, alternative=alternative)
         assert_allclose(res.pvalue, pval, rtol=1e-6)
-        proportion_ci = res.proportion_ci(confidence_level=0.95)
-        assert_equal(proportion_ci.high, 1.0)
-        assert_allclose(proportion_ci.low, ci_low, rtol=1e-6)
+        ci = res.proportion_ci(confidence_level=0.95)
+        assert_equal(ci.high, 1.0)
+        assert_allclose(ci.low, ci_low, rtol=1e-6)
 
     # Expected results are from the prop.test function in R 3.6.2.
     @pytest.mark.parametrize(
@@ -790,7 +790,7 @@ class TestBinomTest:
         else:
             method = 'wilson'
         ci = res.proportion_ci(confidence_level=conf, method=method)
-        assert_allclose(ci, (ci_low, ci_high), rtol=1e-6)
+        assert_allclose((ci.low, ci.high), (ci_low, ci_high), rtol=1e-6)
 
     def test_estimate_equals_hypothesized_prop(self):
         # Test the special case where the estimated proportion equals

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -725,6 +725,11 @@ class TestBinomTest:
         ci = res.proportion_ci(confidence_level=conf, method=method)
         assert_allclose(ci, (ci_low, ci_high), rtol=1e-6)
 
+    def test_invalid_confidence_level(self):
+        res = stats.binomtest(3, n=10, p=0.1)
+        with pytest.raises(ValueError, match="must be in the interval"):
+            res.proportion_ci(confidence_level=-1)
+
 
 class TestFligner(object):
 

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -624,53 +624,37 @@ class TestBinomP:
     binom_test_func = staticmethod(stats.binom_test)
 
     def test_data(self):
-        with suppress_warnings() as sup:
-            sup.filter(DeprecationWarning,
-                       message='.*`binom_test` is deprecated.*')
-            pval = self.binom_test_func(100, 250)
-            assert_almost_equal(pval, 0.0018833009350757682, 11)
-            pval = self.binom_test_func(201, 405)
-            assert_almost_equal(pval, 0.92085205962670713, 11)
-            pval = self.binom_test_func([682, 243], p=3/4)
-            assert_almost_equal(pval, 0.38249155957481695, 11)
+        pval = self.binom_test_func(100, 250)
+        assert_almost_equal(pval, 0.0018833009350757682, 11)
+        pval = self.binom_test_func(201, 405)
+        assert_almost_equal(pval, 0.92085205962670713, 11)
+        pval = self.binom_test_func([682, 243], p=3/4)
+        assert_almost_equal(pval, 0.38249155957481695, 11)
 
     def test_bad_len_x(self):
         # Length of x must be 1 or 2.
-        with suppress_warnings() as sup:
-            sup.filter(DeprecationWarning,
-                       message='.*`binom_test` is deprecated.*')
-            assert_raises(ValueError, self.binom_test_func, [1, 2, 3])
+        assert_raises(ValueError, self.binom_test_func, [1, 2, 3])
 
     def test_bad_n(self):
         # len(x) is 1, but n is invalid.
         # Missing n
-        with suppress_warnings() as sup:
-            sup.filter(DeprecationWarning,
-                       message='.*`binom_test` is deprecated.*')
-            assert_raises(ValueError, self.binom_test_func, [100])
-            # n less than x[0]
-            assert_raises(ValueError, self.binom_test_func, [100], n=50)
+        assert_raises(ValueError, self.binom_test_func, [100])
+        # n less than x[0]
+        assert_raises(ValueError, self.binom_test_func, [100], n=50)
 
     def test_bad_p(self):
-        with suppress_warnings() as sup:
-            sup.filter(DeprecationWarning,
-                       message='.*`binom_test` is deprecated.*')
-            assert_raises(ValueError,
-                          self.binom_test_func, [50, 50], p=2.0)
+        assert_raises(ValueError,
+                      self.binom_test_func, [50, 50], p=2.0)
 
     def test_alternatives(self):
-        with suppress_warnings() as sup:
-            sup.filter(DeprecationWarning,
-                       message='.*`binom_test` is deprecated.*')
+        res = self.binom_test_func(51, 235, p=1/6, alternative='less')
+        assert_almost_equal(res, 0.982022657605858)
 
-            res = self.binom_test_func(51, 235, p=1/6, alternative='less')
-            assert_almost_equal(res, 0.982022657605858)
+        res = self.binom_test_func(51, 235, p=1/6, alternative='greater')
+        assert_almost_equal(res, 0.02654424571169085)
 
-            res = self.binom_test_func(51, 235, p=1/6, alternative='greater')
-            assert_almost_equal(res, 0.02654424571169085)
-
-            res = self.binom_test_func(51, 235, p=1/6, alternative='two-sided')
-            assert_almost_equal(res, 0.0437479701823997)
+        res = self.binom_test_func(51, 235, p=1/6, alternative='two-sided')
+        assert_almost_equal(res, 0.0437479701823997)
 
 
 class TestBinomTestP(TestBinomP):

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4500,11 +4500,16 @@ def test_binomtest():
     0.12044570587262322, 0.88154763174802508, 0.027120993063129286,
     2.6102587134694721e-006]
 
-    for p, res in zip(pp,results):
-        assert_approx_equal(stats.binom_test(x, n, p), res,
-                            significant=12, err_msg='fail forp=%f' % p)
+    with suppress_warnings() as sup:
+        sup.filter(DeprecationWarning,
+                   message='.*`binom_test` is deprecated.*')
 
-    assert_approx_equal(stats.binom_test(50,100,0.1), 5.8320387857343647e-024,
+        for p, res in zip(pp, results):
+            assert_approx_equal(stats.binom_test(x, n, p), res,
+                                significant=12, err_msg='fail forp=%f' % p)
+
+        assert_approx_equal(stats.binom_test(50, 100, 0.1),
+                            5.8320387857343647e-024,
                             significant=12, err_msg='fail forp=%f' % p)
 
 
@@ -4526,20 +4531,32 @@ def test_binomtest2():
      0.753906250,0.343750000,0.109375000,0.021484375,0.001953125]
     ]
 
-    for k in range(1, 11):
-        res1 = [stats.binom_test(v, k, 0.5) for v in range(k + 1)]
-        assert_almost_equal(res1, res2[k-1], decimal=10)
+    with suppress_warnings() as sup:
+        sup.filter(DeprecationWarning,
+                   message='.*`binom_test` is deprecated.*')
+
+        for k in range(1, 11):
+            res1 = [stats.binom_test(v, k, 0.5) for v in range(k + 1)]
+            assert_almost_equal(res1, res2[k-1], decimal=10)
 
 
 def test_binomtest3():
     # test added for issue #2384
     # test when x == n*p and neighbors
-    res3 = [stats.binom_test(v, v*k, 1./k) for v in range(1, 11)
-                                           for k in range(2, 11)]
+    with suppress_warnings() as sup:
+        sup.filter(DeprecationWarning,
+                   message='.*`binom_test` is deprecated.*')
+        res3 = [stats.binom_test(v, v*k, 1./k)
+                for v in range(1, 11) for k in range(2, 11)]
     assert_equal(res3, np.ones(len(res3), int))
 
-    #> bt=c()
-    #> for(i in as.single(1:10)){for(k in as.single(2:10)){bt = c(bt, binom.test(i-1, k*i,(1/k))$p.value); print(c(i+1, k*i,(1/k)))}}
+    # > bt=c()
+    # > for(i in as.single(1:10)) {
+    # +     for(k in as.single(2:10)) {
+    # +         bt = c(bt, binom.test(i-1, k*i,(1/k))$p.value);
+    # +         print(c(i+1, k*i,(1/k)))
+    # +     }
+    # + }
     binom_testm1 = np.array([
          0.5, 0.5555555555555556, 0.578125, 0.5904000000000003,
          0.5981224279835393, 0.603430543396034, 0.607304096221924,
@@ -4573,7 +4590,12 @@ def test_binomtest3():
         ])
 
     # > bt=c()
-    # > for(i in as.single(1:10)){for(k in as.single(2:10)){bt = c(bt, binom.test(i+1, k*i,(1/k))$p.value); print(c(i+1, k*i,(1/k)))}}
+    # > for(i in as.single(1:10)) {
+    # +     for(k in as.single(2:10)) {
+    # +         bt = c(bt, binom.test(i+1, k*i,(1/k))$p.value);
+    # +         print(c(i+1, k*i,(1/k)))
+    # +     }
+    # + }
 
     binom_testp1 = np.array([
          0.5, 0.259259259259259, 0.26171875, 0.26272, 0.2632244513031551,
@@ -4606,10 +4628,13 @@ def test_binomtest3():
          0.736270323773157, 0.737718376096348
         ])
 
-    res4_p1 = [stats.binom_test(v+1, v*k, 1./k) for v in range(1, 11)
-                                                for k in range(2, 11)]
-    res4_m1 = [stats.binom_test(v-1, v*k, 1./k) for v in range(1, 11)
-                                                for k in range(2, 11)]
+    with suppress_warnings() as sup:
+        sup.filter(DeprecationWarning,
+                   message='.*`binom_test` is deprecated.*')
+        res4_p1 = [stats.binom_test(v+1, v*k, 1./k)
+                   for v in range(1, 11) for k in range(2, 11)]
+        res4_m1 = [stats.binom_test(v-1, v*k, 1./k)
+                   for v in range(1, 11) for k in range(2, 11)]
 
     assert_almost_equal(res4_p1, binom_testp1, decimal=13)
     assert_almost_equal(res4_m1, binom_testm1, decimal=13)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4488,66 +4488,58 @@ class TestGeometricStandardDeviation(object):
 
 def test_binomtest():
     # precision tests compared to R for ticket:986
-    pp = np.concatenate((np.linspace(0.1,0.2,5), np.linspace(0.45,0.65,5),
-                          np.linspace(0.85,0.95,5)))
+    pp = np.concatenate((np.linspace(0.1, 0.2, 5),
+                         np.linspace(0.45, 0.65, 5),
+                         np.linspace(0.85, 0.95, 5)))
     n = 501
     x = 450
     results = [0.0, 0.0, 1.0159969301994141e-304,
-    2.9752418572150531e-275, 7.7668382922535275e-250,
-    2.3381250925167094e-099, 7.8284591587323951e-081,
-    9.9155947819961383e-065, 2.8729390725176308e-050,
-    1.7175066298388421e-037, 0.0021070691951093692,
-    0.12044570587262322, 0.88154763174802508, 0.027120993063129286,
-    2.6102587134694721e-006]
+               2.9752418572150531e-275, 7.7668382922535275e-250,
+               2.3381250925167094e-099, 7.8284591587323951e-081,
+               9.9155947819961383e-065, 2.8729390725176308e-050,
+               1.7175066298388421e-037, 0.0021070691951093692,
+               0.12044570587262322, 0.88154763174802508, 0.027120993063129286,
+               2.6102587134694721e-006]
 
-    with suppress_warnings() as sup:
-        sup.filter(DeprecationWarning,
-                   message='.*`binom_test` is deprecated.*')
-
-        for p, res in zip(pp, results):
-            assert_approx_equal(stats.binom_test(x, n, p), res,
-                                significant=12, err_msg='fail forp=%f' % p)
-
-        assert_approx_equal(stats.binom_test(50, 100, 0.1),
-                            5.8320387857343647e-024,
+    for p, res in zip(pp, results):
+        assert_approx_equal(stats.binom_test(x, n, p), res,
                             significant=12, err_msg='fail forp=%f' % p)
+
+    assert_approx_equal(stats.binom_test(50, 100, 0.1),
+                        5.8320387857343647e-024,
+                        significant=12)
 
 
 def test_binomtest2():
     # test added for issue #2384
     res2 = [
-    [1.0, 1.0],
-    [0.5,1.0,0.5],
-    [0.25,1.00,1.00,0.25],
-    [0.125,0.625,1.000,0.625,0.125],
-    [0.0625,0.3750,1.0000,1.0000,0.3750,0.0625],
-    [0.03125,0.21875,0.68750,1.00000,0.68750,0.21875,0.03125],
-    [0.015625,0.125000,0.453125,1.000000,1.000000,0.453125,0.125000,0.015625],
-    [0.0078125,0.0703125,0.2890625,0.7265625,1.0000000,0.7265625,0.2890625,
-     0.0703125,0.0078125],
-    [0.00390625,0.03906250,0.17968750,0.50781250,1.00000000,1.00000000,
-     0.50781250,0.17968750,0.03906250,0.00390625],
-    [0.001953125,0.021484375,0.109375000,0.343750000,0.753906250,1.000000000,
-     0.753906250,0.343750000,0.109375000,0.021484375,0.001953125]
+        [1.0, 1.0],
+        [0.5, 1.0, 0.5],
+        [0.25, 1.00, 1.00, 0.25],
+        [0.125, 0.625, 1.000, 0.625, 0.125],
+        [0.0625, 0.3750, 1.0000, 1.0000, 0.3750, 0.0625],
+        [0.03125, 0.21875, 0.68750, 1.00000, 0.68750, 0.21875, 0.03125],
+        [0.015625, 0.125000, 0.453125, 1.000000, 1.000000, 0.453125, 0.125000,
+         0.015625],
+        [0.0078125, 0.0703125, 0.2890625, 0.7265625, 1.0000000, 0.7265625,
+         0.2890625, 0.0703125, 0.0078125],
+        [0.00390625, 0.03906250, 0.17968750, 0.50781250, 1.00000000,
+         1.00000000, 0.50781250, 0.17968750, 0.03906250, 0.00390625],
+        [0.001953125, 0.021484375, 0.109375000, 0.343750000, 0.753906250,
+         1.000000000, 0.753906250, 0.343750000, 0.109375000, 0.021484375,
+         0.001953125]
     ]
 
-    with suppress_warnings() as sup:
-        sup.filter(DeprecationWarning,
-                   message='.*`binom_test` is deprecated.*')
-
-        for k in range(1, 11):
-            res1 = [stats.binom_test(v, k, 0.5) for v in range(k + 1)]
-            assert_almost_equal(res1, res2[k-1], decimal=10)
+    for k in range(1, 11):
+        res1 = [stats.binom_test(v, k, 0.5) for v in range(k + 1)]
+        assert_almost_equal(res1, res2[k-1], decimal=10)
 
 
 def test_binomtest3():
     # test added for issue #2384
     # test when x == n*p and neighbors
-    with suppress_warnings() as sup:
-        sup.filter(DeprecationWarning,
-                   message='.*`binom_test` is deprecated.*')
-        res3 = [stats.binom_test(v, v*k, 1./k)
-                for v in range(1, 11) for k in range(2, 11)]
+    res3 = [stats.binom_test(v, v*k, 1./k)
+            for v in range(1, 11) for k in range(2, 11)]
     assert_equal(res3, np.ones(len(res3), int))
 
     # > bt=c()
@@ -4628,13 +4620,10 @@ def test_binomtest3():
          0.736270323773157, 0.737718376096348
         ])
 
-    with suppress_warnings() as sup:
-        sup.filter(DeprecationWarning,
-                   message='.*`binom_test` is deprecated.*')
-        res4_p1 = [stats.binom_test(v+1, v*k, 1./k)
-                   for v in range(1, 11) for k in range(2, 11)]
-        res4_m1 = [stats.binom_test(v-1, v*k, 1./k)
-                   for v in range(1, 11) for k in range(2, 11)]
+    res4_p1 = [stats.binom_test(v+1, v*k, 1./k)
+               for v in range(1, 11) for k in range(2, 11)]
+    res4_m1 = [stats.binom_test(v-1, v*k, 1./k)
+               for v in range(1, 11) for k in range(2, 11)]
 
     assert_almost_equal(res4_p1, binom_testp1, decimal=13)
     assert_almost_equal(res4_m1, binom_testm1, decimal=13)


### PR DESCRIPTION
Add a new function, `binomtest`, similar to `binom_test` but that returns an object with both the estimated proportion and the p-value as attributes, and that has a method to compute the confidence interval of the estimated proportion.

Also "doc-deprecate" `binom_test`.

