### PR TITLE
BUG: correct `np.asanyarray` use in `scipy.constants.lambda2nu`

### DIFF
--- a/scipy/constants/constants.py
+++ b/scipy/constants/constants.py
@@ -273,7 +273,7 @@ def lambda2nu(lambda_):
     array([  2.99792458e+08,   1.00000000e+00])
 
     """
-    return _np.asanyarray(c) / lambda_
+    return c / _np.asanyarray(lambda_)
 
 
 def nu2lambda(nu):

--- a/scipy/constants/tests/test_constants.py
+++ b/scipy/constants/tests/test_constants.py
@@ -27,9 +27,9 @@ def test_convert_temperature():
 
 
 def test_lambda_to_nu():
-    assert_equal(sc.lambda2nu(sc.speed_of_light), 1)
+    assert_equal(sc.lambda2nu([sc.speed_of_light, 1]), [1, sc.speed_of_light])
 
 
 def test_nu_to_lambda():
-    assert_equal(sc.nu2lambda(1), sc.speed_of_light)
+    assert_equal(sc.lambda2nu([sc.speed_of_light, 1]), [1, sc.speed_of_light])
 

--- a/scipy/constants/tests/test_constants.py
+++ b/scipy/constants/tests/test_constants.py
@@ -31,5 +31,5 @@ def test_lambda_to_nu():
 
 
 def test_nu_to_lambda():
-    assert_equal(sc.lambda2nu([sc.speed_of_light, 1]), [1, sc.speed_of_light])
+    assert_equal(sc.nu2lambda([sc.speed_of_light, 1]), [1, sc.speed_of_light])
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #12604

#### What does this implement/fix?
This implements the intuitive conversion of the argument in `scipt.constants.lambda2nu` as in `nu2lambda` instead of converting the constant speed of light float.

#### Additional information
See issue for more informations.