### PR TITLE
MAINT: prepare for SciPy 1.5.3

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -126,7 +126,7 @@ jobs:
       choco install -y mingw --forcex86 --force --version=6.4.0
     displayName: 'Install 32-bit mingw for 32-bit builds'
     condition: and(succeeded(), eq(variables['BITS'], 32))
-  - script: python -m pip install numpy cython==0.29.18 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath
+  - script: python -m pip install numpy cython==0.29.18 pybind11 pytest==5.4.3 pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath
     displayName: 'Install dependencies'
   - powershell: |
       python -m pip install matplotlib

--- a/doc/release/1.5.3-notes.rst
+++ b/doc/release/1.5.3-notes.rst
@@ -1,0 +1,18 @@
+==========================
+SciPy 1.5.3 Release Notes
+==========================
+
+.. contents::
+
+SciPy 1.5.3 is a bug-fix release with no new features
+compared to 1.5.2.
+
+Authors
+=======
+
+Issues closed for 1.5.3
+-----------------------
+
+Pull requests for 1.5.3
+-----------------------
+

--- a/doc/source/release.1.5.3.rst
+++ b/doc/source/release.1.5.3.rst
@@ -1,0 +1,1 @@
+.. include:: ../release/1.5.3-notes.rst

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
    :maxdepth: 1
 
+   release.1.5.3
    release.1.5.2
    release.1.5.1
    release.1.5.0

--- a/pavement.py
+++ b/pavement.py
@@ -113,10 +113,10 @@ except AttributeError:
 #-----------------------------------
 
 # Source of the release notes
-RELEASE = 'doc/release/1.5.2-notes.rst'
+RELEASE = 'doc/release/1.5.3-notes.rst'
 
 # Start/end of the log (from git)
-LOG_START = 'v1.5.1'
+LOG_START = 'v1.5.2'
 LOG_END = 'maintenance/1.5.x'
 
 

--- a/scipy/optimize/_constraints.py
+++ b/scipy/optimize/_constraints.py
@@ -8,6 +8,13 @@ from warnings import warn
 from numpy.testing import suppress_warnings
 from scipy.sparse import issparse
 
+
+def _arr_to_scalar(x):
+    # If x is a numpy array, return x.item().  This will
+    # fail if the array has more than one element.
+    return x.item() if isinstance(x, np.ndarray) else x
+
+
 class NonlinearConstraint(object):
     """Nonlinear constraint on the variables.
 
@@ -314,8 +321,14 @@ def old_bound_to_new(bounds):
     -np.inf/np.inf.
     """
     lb, ub = zip(*bounds)
-    lb = np.array([float(x) if x is not None else -np.inf for x in lb])
-    ub = np.array([float(x) if x is not None else np.inf for x in ub])
+
+    # Convert occurrences of None to -inf or inf, and replace occurrences of
+    # any numpy array x with x.item(). Then wrap the results in numpy arrays.
+    lb = np.array([float(_arr_to_scalar(x)) if x is not None else -np.inf
+                   for x in lb])
+    ub = np.array([float(_arr_to_scalar(x)) if x is not None else np.inf
+                   for x in ub])
+
     return lb, ub
 
 

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -872,7 +872,7 @@ class DifferentialEvolutionSolver(object):
         try:
             calc_energies = list(self._mapwrapper(self.func,
                                                   parameters_pop[0:nfevs]))
-            energies[0:nfevs] = calc_energies
+            energies[0:nfevs] = np.squeeze(calc_energies)
         except (TypeError, ValueError):
             # wrong number of arguments for _mapwrapper
             # or wrong length returned from the mapper

--- a/scipy/optimize/slsqp.py
+++ b/scipy/optimize/slsqp.py
@@ -22,7 +22,7 @@ from numpy import (zeros, array, linalg, append, asfarray, concatenate, finfo,
 from .optimize import (OptimizeResult, _check_unknown_options,
                        _prepare_scalar_function)
 from ._numdiff import approx_derivative
-from ._constraints import old_bound_to_new
+from ._constraints import old_bound_to_new, _arr_to_scalar
 
 
 __docformat__ = "restructuredtext en"
@@ -346,7 +346,8 @@ def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
         xl.fill(np.nan)
         xu.fill(np.nan)
     else:
-        bnds = array(bounds, float)
+        bnds = array([(_arr_to_scalar(l), _arr_to_scalar(u))
+                      for (l, u) in bounds], float)
         if bnds.shape[0] != n:
             raise IndexError('SLSQP Error: the length of bounds is not '
                              'compatible with that of x0.')

--- a/scipy/optimize/tests/test_slsqp.py
+++ b/scipy/optimize/tests/test_slsqp.py
@@ -313,9 +313,12 @@ class TestSLSQP(object):
         fmin_slsqp(lambda z: z**2 - 1, [0], bounds=[[0, 1]], iprint=0)
 
     def test_array_bounds(self):
-        # This should pass (1-element arrays are castable to floats in numpy)
+        # NumPy used to treat n-dimensional 1-element arrays as scalars
+        # in some cases.  The handling of `bounds` by `fmin_slsqp` still
+        # supports this behavior.
         bounds = [(-np.inf, np.inf), (np.array([2]), np.array([3]))]
-        x = fmin_slsqp(lambda z: np.sum(z**2 - 1), [2.5, 2.5], bounds=bounds, iprint=0)
+        x = fmin_slsqp(lambda z: np.sum(z**2 - 1), [2.5, 2.5], bounds=bounds,
+                       iprint=0)
         assert_array_almost_equal(x, [0, 2])
 
     def test_obj_must_return_scalar(self):

--- a/scipy/stats/tests/common_tests.py
+++ b/scipy/stats/tests/common_tests.py
@@ -321,4 +321,4 @@ def check_rvs_broadcast(distfunc, distname, allargs, shape, shape_only, otype):
             rvs = np.vectorize(lambda *allargs: distfunc.rvs(*allargs), otypes=otype)
             np.random.seed(123)
             expected = rvs(*allargs)
-            assert_allclose(sample, expected, rtol=1e-15)
+            assert_allclose(sample, expected, rtol=1e-13)

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -660,5 +660,4 @@ def test_methods_with_lists(method, distname, args):
         result = f(x, *shape2, loc=loc, scale=scale)
         npt.assert_allclose(result,
                             [f(*v) for v in zip(x, *shape2, loc, scale)],
-                            rtol=1e-15, atol=1e-15)
-
+                            rtol=1e-14, atol=5e-14)

--- a/setup.py
+++ b/setup.py
@@ -55,8 +55,8 @@ Operating System :: MacOS
 
 MAJOR = 1
 MINOR = 5
-MICRO = 2
-ISRELEASED = True
+MICRO = 3
+ISRELEASED = False
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
 


### PR DESCRIPTION
* add new files associated with the
new bug-fix release notes for SciPy `1.5.3`

* bump maintenance branch version to `1.5.3`
unreleased