### PR TITLE
MAINT: prevent reverse broadcasting

### DIFF
--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -872,7 +872,7 @@ class DifferentialEvolutionSolver(object):
         try:
             calc_energies = list(self._mapwrapper(self.func,
                                                   parameters_pop[0:nfevs]))
-            energies[0:nfevs] = calc_energies
+            energies[0:nfevs] = np.squeeze(calc_energies)
         except (TypeError, ValueError) as e:
             # wrong number of arguments for _mapwrapper
             # or wrong length returned from the mapper


### PR DESCRIPTION
see #12613, an error associated with numpy prewheels.

```
scipy/optimize/_differentialevolution.py:875: in _calculate_population_energies
    energies[0:nfevs] = calc_energies
E   ValueError: setting an array element with a sequence. The requested array would exceed the maximum number of dimension of 1.
        calc_energies = [array([45.34286517]), array([1.03163941]), array([0.9302832]), array([270.39415071]), array([6.52919529]), array([18.59346585]), ...]
        energies   = array([inf, inf, inf, inf, inf, inf, inf, inf, inf, inf, inf, inf, inf,
       inf, inf])
```