### PR TITLE
DOC: make explicit docstring that interpolate.interp1d only accepts float convertible input.

### DIFF
--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -334,18 +334,14 @@ class interp1d(_Interpolator1D):
     ``y = f(x)``. This class returns a function whose call method uses
     interpolation to find the value of new points.
 
-    Note that calling `interp1d` with NaNs present in input values results in
-    undefined behaviour.
-
+    
     Parameters
     ----------
     x : (N,) array_like
-        A 1-D array of real values. These values must be convertible to `float`
-        values.
+        A 1-D array of real values. 
     y : (...,N,...) array_like
-        A N-D array of real values. These values must be convertible to `float`
-        values. The length of `y` along the interpolation axis must be equal
-        to the length of `x`.
+        A N-D array of real values. The length of `y` along the interpolation 
+        axis must be equal to the length of `x`.
     kind : str or int, optional
         Specifies the kind of interpolation as a string
         ('linear', 'nearest', 'zero', 'slinear', 'quadratic', 'cubic',
@@ -401,6 +397,15 @@ class interp1d(_Interpolator1D):
         Spline interpolation/smoothing based on FITPACK.
     UnivariateSpline : An object-oriented wrapper of the FITPACK routines.
     interp2d : 2-D interpolation
+
+    Notes
+    -----
+    Calling `interp1d` with NaNs present in input values results in
+    undefined behaviour.
+
+    Input values `x` and `y` must be convertible to `float` values like 
+    `int` or `float`.
+
 
     Examples
     --------

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -340,10 +340,12 @@ class interp1d(_Interpolator1D):
     Parameters
     ----------
     x : (N,) array_like
-        A 1-D array of real values.
+        A 1-D array of real values. These values must be convertible to `float`
+        values.
     y : (...,N,...) array_like
-        A N-D array of real values. The length of `y` along the interpolation
-        axis must be equal to the length of `x`.
+        A N-D array of real values. These values must be convertible to `float`
+        values. The length of `y` along the interpolation axis must be equal
+        to the length of `x`.
     kind : str or int, optional
         Specifies the kind of interpolation as a string
         ('linear', 'nearest', 'zero', 'slinear', 'quadratic', 'cubic',

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -338,9 +338,9 @@ class interp1d(_Interpolator1D):
     Parameters
     ----------
     x : (N,) array_like
-        A 1-D array of real values. 
+        A 1-D array of real values.
     y : (...,N,...) array_like
-        A N-D array of real values. The length of `y` along the interpolation 
+        A N-D array of real values. The length of `y` along the interpolation
         axis must be equal to the length of `x`.
     kind : str or int, optional
         Specifies the kind of interpolation as a string

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -334,7 +334,6 @@ class interp1d(_Interpolator1D):
     ``y = f(x)``. This class returns a function whose call method uses
     interpolation to find the value of new points.
 
-    
     Parameters
     ----------
     x : (N,) array_like

--- a/scipy/interpolate/polyint.py
+++ b/scipy/interpolate/polyint.py
@@ -61,14 +61,18 @@ class _Interpolator1D(object):
         Parameters
         ----------
         x : array_like
-            Points to evaluate the interpolant at. These values must be
-            convertible to `float` values.
+            Points to evaluate the interpolant at.
 
         Returns
         -------
         y : array_like
             Interpolated values. Shape is determined by replacing
             the interpolation axis in the original array with the shape of x.
+
+        Notes
+        -----
+        Input values `x` must be convertible to `float` values like `int` 
+        or `float`.
 
         """
         x, x_shape = self._prepare_x(x)

--- a/scipy/interpolate/polyint.py
+++ b/scipy/interpolate/polyint.py
@@ -61,7 +61,8 @@ class _Interpolator1D(object):
         Parameters
         ----------
         x : array_like
-            Points to evaluate the interpolant at.
+            Points to evaluate the interpolant at. These values must be
+            convertible to `float` values.
 
         Returns
         -------


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
fix #11093 and fix #12222 

#### What does this implement/fix?
I updated docstring to make explicit that `interpolate.interp1d` only accepts `float` convertible input.
In #11093, #12222, some users requested interpolate.interp1d accept not `float` convertible input (datetime, categorical data). But, as discussions in #11093, #12222, it looks out of scope of `interp1d`. So, I clarified it.
