### PR TITLE
MAINT: optimize: Handle nonscalar size 1 arrays in fmin_slsqp bounds.

### DIFF
--- a/scipy/optimize/_constraints.py
+++ b/scipy/optimize/_constraints.py
@@ -8,6 +8,13 @@ from warnings import warn
 from numpy.testing import suppress_warnings
 from scipy.sparse import issparse
 
+
+def _arr_to_scalar(x):
+    # If x is a numpy array, return x.item().  This will
+    # fail if the array has more than one element.
+    return x.item() if isinstance(x, np.ndarray) else x
+
+
 class NonlinearConstraint(object):
     """Nonlinear constraint on the variables.
 
@@ -314,8 +321,14 @@ def old_bound_to_new(bounds):
     -np.inf/np.inf.
     """
     lb, ub = zip(*bounds)
-    lb = np.array([float(x) if x is not None else -np.inf for x in lb])
-    ub = np.array([float(x) if x is not None else np.inf for x in ub])
+
+    # Convert occurrences of None to -inf or inf, and replace occurrences of
+    # any numpy array x with x.item(). Then wrap the results in numpy arrays.
+    lb = np.array([float(_arr_to_scalar(x)) if x is not None else -np.inf
+                   for x in lb])
+    ub = np.array([float(_arr_to_scalar(x)) if x is not None else np.inf
+                   for x in ub])
+
     return lb, ub
 
 

--- a/scipy/optimize/slsqp.py
+++ b/scipy/optimize/slsqp.py
@@ -22,7 +22,7 @@ from numpy import (zeros, array, linalg, append, asfarray, concatenate, finfo,
 from .optimize import (OptimizeResult, _check_unknown_options,
                        _prepare_scalar_function)
 from ._numdiff import approx_derivative
-from ._constraints import old_bound_to_new
+from ._constraints import old_bound_to_new, _arr_to_scalar
 
 
 __docformat__ = "restructuredtext en"
@@ -346,7 +346,8 @@ def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
         xl.fill(np.nan)
         xu.fill(np.nan)
     else:
-        bnds = array(bounds, float)
+        bnds = array([(_arr_to_scalar(l), _arr_to_scalar(u))
+                      for (l, u) in bounds], float)
         if bnds.shape[0] != n:
             raise IndexError('SLSQP Error: the length of bounds is not '
                              'compatible with that of x0.')

--- a/scipy/optimize/tests/test_slsqp.py
+++ b/scipy/optimize/tests/test_slsqp.py
@@ -313,9 +313,12 @@ class TestSLSQP(object):
         fmin_slsqp(lambda z: z**2 - 1, [0], bounds=[[0, 1]], iprint=0)
 
     def test_array_bounds(self):
-        # This should pass (1-element arrays are castable to floats in numpy)
+        # NumPy used to treat n-dimensional 1-element arrays as scalars
+        # in some cases.  The handling of `bounds` by `fmin_slsqp` still
+        # supports this behavior.
         bounds = [(-np.inf, np.inf), (np.array([2]), np.array([3]))]
-        x = fmin_slsqp(lambda z: np.sum(z**2 - 1), [2.5, 2.5], bounds=bounds, iprint=0)
+        x = fmin_slsqp(lambda z: np.sum(z**2 - 1), [2.5, 2.5], bounds=bounds,
+                       iprint=0)
         assert_array_almost_equal(x, [0, 2])
 
     def test_obj_must_return_scalar(self):


### PR DESCRIPTION
Fixes the error in TestSLSQP.test_array_bounds that results from the
recent change in how numpy handles "reverse broadcasting".