### PR TITLE
DOC: Minor doc formatting.

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -32,10 +32,13 @@ def _lazywhere(cond, arrays, f, fillvalue=None, f2=None):
     """
     np.where(cond, x, fillvalue) always evaluates x even where cond is False.
     This one only evaluates f(arr1[cond], arr2[cond], ...).
-    For example,
+    
+    Examples
+    --------
+
     >>> a, b = np.array([1, 2, 3, 4]), np.array([5, 6, 7, 8])
     >>> def f(a, b):
-        return a*b
+    ...     return a*b
     >>> _lazywhere(a > 2, (a, b), f, np.nan)
     array([ nan,  nan,  21.,  32.])
 

--- a/scipy/cluster/vq.py
+++ b/scipy/cluster/vq.py
@@ -471,7 +471,7 @@ def _kpoints(data, k):
     k : int
         Number of samples to generate.
 
-   Returns
+    Returns
     -------
     x : ndarray
         A 'k' by 'N' containing the initial centroids

--- a/scipy/sparse/linalg/dsolve/linsolve.py
+++ b/scipy/sparse/linalg/dsolve/linsolve.py
@@ -520,7 +520,8 @@ def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False,
     Returns
     -------
     x : (M,) or (M, N) ndarray
-        Solution to the system ``A x = b``. Shape of return matches shape of `b`.
+        Solution to the system ``A x = b``. Shape of return matches shape
+        of `b`.
 
     Raises
     ------

--- a/scipy/sparse/linalg/dsolve/linsolve.py
+++ b/scipy/sparse/linalg/dsolve/linsolve.py
@@ -491,14 +491,14 @@ def factorized(A):
 def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False,
                        unit_diagonal=False):
     """
-    Solve the equation `A x = b` for `x`, assuming A is a triangular matrix.
+    Solve the equation ``A x = b`` for `x`, assuming A is a triangular matrix.
 
     Parameters
     ----------
     A : (M, M) sparse matrix
         A sparse square triangular matrix. Should be in CSR format.
     b : (M,) or (M, N) array_like
-        Right-hand side matrix in `A x = b`
+        Right-hand side matrix in ``A x = b``
     lower : bool, optional
         Whether `A` is a lower or upper triangular matrix.
         Default is lower triangular matrix.
@@ -520,7 +520,7 @@ def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False,
     Returns
     -------
     x : (M,) or (M, N) ndarray
-        Solution to the system `A x = b`. Shape of return matches shape of `b`.
+        Solution to the system ``A x = b``. Shape of return matches shape of `b`.
 
     Raises
     ------

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -4271,7 +4271,7 @@ def pointbiserialr(x, y):
     Notes
     -----
     `pointbiserialr` uses a t-test with ``n-1`` degrees of freedom.
-    It is equivalent to `pearsonr.`
+    It is equivalent to `pearsonr`.
 
     The value of the point-biserial correlation can be calculated from:
 


### PR DESCRIPTION
- use continuation prompt `...` for better parsing of example.
- Use double backticks when snippet is not supposed to be a reference.
- Mode a dot that ends a sentence outside of reference backticks.
- Use `Examples` section to detect examples.
- Properly indent "Returns" to be picked by numpydoc.
