### PR TITLE
MAINT: stats: Loosen some test tolerances.

### DIFF
--- a/scipy/stats/tests/common_tests.py
+++ b/scipy/stats/tests/common_tests.py
@@ -327,4 +327,4 @@ def check_rvs_broadcast(distfunc, distname, allargs, shape, shape_only, otype):
         rvs = np.vectorize(lambda *allargs: distfunc.rvs(*allargs), otypes=otype)
         np.random.seed(123)
         expected = rvs(*allargs)
-        assert_allclose(sample, expected, rtol=1e-15)
+        assert_allclose(sample, expected, rtol=1e-13)

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -653,4 +653,4 @@ def test_methods_with_lists(method, distname, args):
     result = f(x, *shape2, loc=loc, scale=scale)
     npt.assert_allclose(result,
                         [f(*v) for v in zip(x, *shape2, loc, scale)],
-                        rtol=1e-15, atol=1e-15)
+                        rtol=1e-14, atol=5e-14)


### PR DESCRIPTION
When run with the development version of numpy, these tests were
failing.

This "fixes" the failures in the stats module reported in gh-12613.
