### PR TITLE
Make scalar, iterative root finding methods robust against steps outside domain

### DIFF
--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -329,7 +329,9 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
         funcalls += 1
         if abs(q1) < abs(q0):
             p0, p1, q0, q1 = p1, p0, q1, q0
-        for itr in range(maxiter):
+
+        itr = 0
+        while itr < maxiter - 1:
             if q1 == q0:
                 if p1 != p0:
                     msg = "Tolerance of %s reached." % (p1 - p0)
@@ -352,15 +354,15 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
                     full_output, (p, funcalls, itr + 1, _ECONVERGED))
             p0, q0 = p1, q1
             p1 = p
-            while True:
+            while itr < maxiter:
                 q1 = func(p1, *args)
                 funcalls += 1
+                itr += 1
                 if np.isfinite(q1):
                     break
                 else:
                     # We stepped outside the domain of the function,
                     # we try a point closer to the previous one
-                    # TODO: Should we increase the iteration count?
                     p1 = (p0 + p1) / 2
 
     if disp:

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -10,7 +10,7 @@ _xtol = 2e-12
 _rtol = 4 * np.finfo(float).eps
 
 __all__ = ['newton', 'bisect', 'ridder', 'brentq', 'brenth', 'toms748',
-           'RootResults']
+           'RootResults', 'OutOfDomainWarning']
 
 # Must agree with CONVERGED, SIGNERR, CONVERR, ...  in zeros.h
 _ECONVERGED = 0
@@ -28,6 +28,10 @@ INPROGRESS = 'No error'
 
 flag_map = {_ECONVERGED: CONVERGED, _ESIGNERR: SIGNERR, _ECONVERR: CONVERR,
             _EVALUEERR: VALUEERR, _EINPROGRESS: INPROGRESS}
+
+
+class OutOfDomainWarning(UserWarning):
+    """Iterative method stepped out of function domain."""
 
 
 class RootResults(object):
@@ -363,6 +367,11 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
                 else:
                     # We stepped outside the domain of the function,
                     # we try a point closer to the previous one
+                    warnings.warn(
+                        "Iteration resulted in non finite or NaN, "
+                        "trying to get closer to previous region",
+                        OutOfDomainWarning,
+                    )
                     p1 = (p0 + p1) / 2
 
     if disp:

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -352,8 +352,16 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
                     full_output, (p, funcalls, itr + 1, _ECONVERGED))
             p0, q0 = p1, q1
             p1 = p
-            q1 = func(p1, *args)
-            funcalls += 1
+            while True:
+                q1 = func(p1, *args)
+                funcalls += 1
+                if np.isfinite(q1):
+                    break
+                else:
+                    # We stepped outside the domain of the function,
+                    # we try a point closer to the previous one
+                    # TODO: Should we increase the iteration count?
+                    p1 = (p0 + p1) / 2
 
     if disp:
         msg = ("Failed to converge after %d iterations, value is %s."

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -97,7 +97,7 @@ def _results_select(full_output, r):
 
 def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
            fprime2=None, x1=None, rtol=0.0,
-           full_output=False, disp=True):
+           full_output=False, disp=True, avoid_out_of_domain=True):
     """
     Find a zero of a real or complex function using the Newton-Raphson
     (or secant or Halley's) method.
@@ -158,6 +158,11 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
         Ignored if `x0` is not scalar.
         *Note: this has little to do with displaying, however,
         the `disp` keyword cannot be renamed for backwards compatibility.*
+    avoid_out_of_domain : bool, optional
+        If True, try to backtrack to previously known point if the
+        algorithm steps out of the domain of the function. Otherwise,
+        iteration will likely fail to converge and raise a RuntimeError.
+        Default to True.
 
     Returns
     -------
@@ -362,7 +367,7 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
                 q1 = func(p1, *args)
                 funcalls += 1
                 itr += 1
-                if np.isfinite(q1):
+                if not avoid_out_of_domain or np.isfinite(q1):
                     break
                 else:
                     # We stepped outside the domain of the function,


### PR DESCRIPTION
#### Reference issue

Closes gh-12625.

#### What does this implement/fix?

A simple method to "backtrack" to previously known points inside the domain.

#### Additional information

This makes `newton` work for `log(x)`, which on current `master` fails as described in gh-12625:

```python
In [1]: import numpy as np 
   ...: from scipy.optimize import newton 
   ...: def f(x): 
   ...:     return np.log(x) 
   ...:      
   ...: newton(f, 3)         
<ipython-input-1-1799d1561f0e>:4: RuntimeWarning: invalid value encountered in log
  return np.log(x)
Out[1]: 1.0

```

and makes the code more robust than MATLAB and as robust as GNU Octave:

```python
In [2]: newton(f, 10)        
<ipython-input-1-1799d1561f0e>:4: RuntimeWarning: invalid value encountered in log
  return np.log(x)
Out[2]: 1.0

In [3]: newton(f, 15)        
<ipython-input-1-1799d1561f0e>:4: RuntimeWarning: invalid value encountered in log
  return np.log(x)
Out[3]: 0.9999999999999989

In [4]: newton(f, 100)       
<ipython-input-1-1799d1561f0e>:4: RuntimeWarning: invalid value encountered in log
  return np.log(x)
Out[4]: 1.0

In [5]: newton(f, 1000)      
<ipython-input-1-1799d1561f0e>:4: RuntimeWarning: invalid value encountered in log
  return np.log(x)
Out[5]: 1.0000000000000009

In [6]: newton(f, 10000)     
<ipython-input-1-1799d1561f0e>:4: RuntimeWarning: invalid value encountered in log
  return np.log(x)
Out[6]: 1.0
```

This PR is incomplete and requires some discussion. In particular:

- Should this behavior be opt-in?
- Should we implement this as a separate method?

If we decide to extend Secant, Newton and Halley (instead of adding this as a separate method) and to _not_ make this behavior optional or configurable (my current approach), this PR is missing a couple of things:

- [ ] Extend this to Newton and Halley methods as well
- [x] Add tests (where? I found `scipy/optimize/tests/test_zeros.py` a bit daunting, and the test functions `f1` and such seem to be repeated)
- [x] Increase the iteration count if we need to change `p1`?

cc @alexs12 @martosc