### PR TITLE
ENH: Return array scalars for skew and kurtosis

### DIFF
--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -2302,7 +2302,7 @@ def skew(a, axis=0, bias=True):
             np.place(vals, can_correct, nval)
     # Add 0 to ensure a scalar result is returned
     # https://github.com/scipy/scipy/issues/12548
-    return vals + 0
+    return vals.data + 0
 
 
 def kurtosis(a, axis=0, fisher=True, bias=True):
@@ -2360,6 +2360,7 @@ def kurtosis(a, axis=0, fisher=True, bias=True):
 
     # Add 0 to ensure a scalar result is returned
     # https://github.com/scipy/scipy/issues/12548
+    vals = vals.data
     if fisher:
         return vals - 3
     else:

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -2418,10 +2418,7 @@ def describe(a, axis=0, ddof=0, bias=True):
                  mask=False,
            fill_value=999999), masked_array(data=2,
                  mask=False,
-           fill_value=999999)), mean=1.0, variance=0.6666666666666666,
-           skewness=masked_array(data=0., mask=False, fill_value=1e+20),
-            kurtosis=-1.5)
-
+           fill_value=999999)), mean=1.0, variance=0.6666666666666666, skewness=0.0, kurtosis=-1.5)
     """
     a, axis = _chk_asarray(a, axis)
     n = a.count(axis)

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -2300,7 +2300,9 @@ def skew(a, axis=0, bias=True):
             m3 = np.extract(can_correct, m3)
             nval = ma.sqrt((n-1.0)*n)/(n-2.0)*m3/m2**1.5
             np.place(vals, can_correct, nval)
-    return vals
+    # Add 0 to ensure a scalar result is returned
+    # https://github.com/scipy/scipy/issues/12548
+    return vals + 0
 
 
 def kurtosis(a, axis=0, fisher=True, bias=True):
@@ -2355,10 +2357,13 @@ def kurtosis(a, axis=0, fisher=True, bias=True):
             m4 = np.extract(can_correct, m4)
             nval = 1.0/(n-2)/(n-3)*((n*n-1.0)*m4/m2**2.0-3*(n-1)**2.0)
             np.place(vals, can_correct, nval+3.0)
+
+    # Add 0 to ensure a scalar result is returned
+    # https://github.com/scipy/scipy/issues/12548
     if fisher:
         return vals - 3
     else:
-        return vals
+        return vals + 0
 
 
 DescribeResult = namedtuple('DescribeResult', ('nobs', 'minmax', 'mean',

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -2277,7 +2277,7 @@ def skew(a, axis=0, bias=True):
 
     Returns
     -------
-    skewness : ndarray
+    skewness : float or ndarray
         The skewness of values along an axis, returning 0 where all values are
         equal.
 
@@ -2333,7 +2333,7 @@ def kurtosis(a, axis=0, fisher=True, bias=True):
 
     Returns
     -------
-    kurtosis : array
+    kurtosis : float or ndarray
         The kurtosis of values along an axis. If all values are equal,
         return -3 for Fisher's definition and 0 for Pearson's definition.
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1173,7 +1173,7 @@ def skew(a, axis=0, bias=True, nan_policy='propagate'):
 
     Returns
     -------
-    skewness : ndarray
+    skewness : float or ndarray
         The skewness of values along an axis, returning 0 where all values are
         equal.
 
@@ -1279,7 +1279,7 @@ def kurtosis(a, axis=0, fisher=True, bias=True, nan_policy='propagate'):
 
     Returns
     -------
-    kurtosis : array
+    kurtosis : float or ndarray
         The kurtosis of values along an axis. If all values are equal,
         return -3 for Fisher's definition and 0 for Pearson's definition.
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2366,6 +2366,13 @@ class TestMoments(object):
             s = stats.skew(a, axis=1, nan_policy="propagate")
         np.testing.assert_allclose(s, [0, np.nan], atol=1e-15)
 
+    def test_skew_omit_nan(self):
+        # Test that skew returns a scalar when nan_policy is omit
+        # https://github.com/scipy/scipy/issues/12548
+        s = stats.skew([1, 5, 4, 6, np.nan], nan_policy='omit')
+        np.testing.assert_allclose(s, -0.68724319)
+        assert isinstance(s, float)
+
     def test_kurtosis(self):
         # Scalar test case
         y = stats.kurtosis(self.scalar_testcase)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2403,6 +2403,11 @@ class TestMoments(object):
     def test_kurtosis_array_scalar(self):
         assert_equal(type(stats.kurtosis([1,2,3])), float)
 
+    def test_kurtosis_array_scalar_omits_nan(self):
+        k = stats.kurtosis([1, 5, 4, 6, np.nan], fisher=False, nan_policy="omit")
+        assert_allclose(k, 2)
+        assert isinstance(k, float)
+
     def test_kurtosis_propagate_nan(self):
         # Check that the shape of the result is the same for inputs
         # with and without nans, cf gh-5817


### PR DESCRIPTION
This PR returns array scalars for the mstats version of skew and kurtosis and adds a test that the returned value is indeed a scalar value.

#### Reference issue
fixes #12548
#### What does this implement/fix?
The masked skew and kurtosis function have branches  where the resultant masked array is not converted to an array scalar leading to a masked array being returned as below:

```python
>>> kurtosis([1,5,4,6,nan], fisher=False, nan_policy="omit")
masked_array(data=2.,  #  Correct value but a masked array
             mask=False,
       fill_value=1e+20)
```

This PR adds an addition step so that, in the case of a 1d array, a scalar value is returned.

```python
>>> kurtosis([1,5,4,6,nan], fisher=False, nan_policy="omit")
2.0
```

#### Additional information
I'm not sure whether this is the correct approach; and haven't worked in the mstats modules enough to know if there is a better approach. I'd appreciate if someone with more experience could give their opinion on whether there is a better way to handle it.