### PR TITLE
CI, MAINT: pin pytest for Azure win

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -126,7 +126,7 @@ jobs:
       choco install -y mingw --forcex86 --force --version=6.4.0
     displayName: 'Install 32-bit mingw for 32-bit builds'
     condition: and(succeeded(), eq(variables['BITS'], 32))
-  - script: python -m pip install numpy cython==0.29.18 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath
+  - script: python -m pip install numpy cython==0.29.18 pybind11 pytest==5.4.3 pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath
     displayName: 'Install dependencies'
   - powershell: |
       python -m pip install matplotlib


### PR DESCRIPTION
* `pytest` `6.0.0` was released yesterday and we've been
observing `pytest` related traceback in the Windows ilp64
Azure CI job consistently since yesterday, both in the main
repo and in backport CI:

- gh-12600
- gh-12626
- gh-12611

* here, the version of `pytest` is temporarily pinned to
the latest stable release before the new `6.x.x` series;
perhaps the complex ecosystem of `pytest` + plugins +
Windows + 64-bit integers is enough to expose an issue
that needs a bit more testing upstream

* not sure if this will actually fix the problem, but worth
a try...

* I should also refactor the yml list of deps to a nice alphabetical
list instead of a 100+ char line, but try to keep the diff as simple
as possible here