### PR TITLE
BENCH: Add benchmarks for fit method analytical MLE overrides

### DIFF
--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -20,7 +20,7 @@
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
-    //"pythons": ["3.6"],
+    "pythons": ["3.6"],
 
     // The matrix of dependencies to test.  Each key is the name of a
     // package (in PyPI) and the values are version numbers.  An empty

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -20,7 +20,7 @@
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
-    "pythons": ["3.6"],
+    //"pythons": ["3.6"],
 
     // The matrix of dependencies to test.  Each key is the name of a
     // package (in PyPI) and the values are version numbers.  An empty

--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -188,11 +188,11 @@ class BinnedStatisticDD(Benchmark):
 
 class ContinuousFitAnalyticalMLEOverride(Benchmark):
     # list of distributions to time
-    dists = ["pareto", "laplace", "beta", "ncf"]
+    dists = ["pareto", "laplace", "rayleigh", "invgauss"]
     # add custom values for rvs and fit, if desired, for any distribution:
     # key should match name in dists and value should be list of loc, scale,
     # and shapes
-    custom_input = {"beta": [1, 1, 1, 1]}
+    custom_input = {}
     fnames = ['floc', 'fscale', 'f0', 'f1', 'f2']
     fixed = {}
     distcont = dict(distcont)
@@ -227,7 +227,7 @@ class ContinuousFitAnalyticalMLEOverride(Benchmark):
         # with keys from self.fnames and values from parameter_values
         self.fixed = dict(zip(compress(self.fnames, relevant_parameters),
                           compress(param_values, relevant_parameters)))
-        self.data = self.distn.rvs(*param_values, size=10000)
+        self.data = self.distn.rvs(*param_values, size=1000)
 
     def time_fit(self, dist_name, loc_fixed, scale_fixed, shape1_fixed,
                  shape2_fixed, shape3_fixed):

--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -174,3 +174,24 @@ class BinnedStatisticDD(Benchmark):
         stats.binned_statistic_dd(
             [self.inp[0], self.inp[1]], self.inp[2], statistic=statistic,
             binned_statistic_result=self.ret)
+
+
+class ContinuousFitAnalyticalMLEOverride(Benchmark):
+    pretty_name = "Fit Methods Overriden with Analytical MLEs"
+    param_names = ['distribution name']
+    params = ["pareto", "laplace"]
+
+    distributions = {"pareto": {"self": stats.pareto, "shapes": {"b": 2},
+                                "fixed_param": {"floc": 0}},
+                     "laplace": {"self": stats.laplace, "shapes": {},
+                                 "fixed_param": {}}
+                     }
+
+    def setup(self, dist_name):
+        self.distn = self.distributions[dist_name]["self"]
+        self.shapes = self.distributions[dist_name]["shapes"]
+        self.fixed_param = self.distributions[dist_name]["fixed_param"]
+        self.data = self.distn.rvs(size=10000, **self.shapes)
+
+    def time_fit(self, distn):
+        self.distn.fit(self.data, **self.fixed_param)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Shows speed improvements from gh-11782. 
#### What does this implement/fix?
<!--Please explain your changes.-->
The purpose of adding this benchmark is to illustrate the speed benefit of analytical maximum likelihood estimation fit method overrides from gh-11782.
#### Additional information
<!--Any additional information you think is important.-->
It appears that parametrization of asv only allows you to parametrize combinations, not pass in `dist` ` shapes` and `fixed_param` for each distribution together like I would in pytest. Passing in these three as a tuple confused it and made it think there were too many parameters. To increase readability I passed in the distribution name as a string and then put the associated distribution, shapes, and always fixed parameters in a dictionary at that key.


![Screen Shot 2020-07-29 at 10 01 14 PM](https://user-images.githubusercontent.com/44255917/88885372-41d2a680-d1ed-11ea-884f-f667b64598e6.png)


Additional consideration: There is already some benchmarking for a few distributions [here](https://pv.github.io/scipy-bench/#stats.Distribution.time_distribution?p-properties='fit'). I don't know why these 3 are the only ones, they don't all have MLEs that are being timed. 

@mdhaber Thoughts?