### PR TITLE
MAINT: stats: fix issues with scipy.stats.pearson3 docs, moment, and cdf

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -5963,7 +5963,7 @@ class pearson3_gen(rv_continuous):
 
             \beta = \frac{2}{\kappa}
 
-            \alpha = \beta^2 = \frac{4}{\kappa**2}
+            \alpha = \beta^2 = \frac{4}{\kappa^2}
 
             \zeta = -\frac{\alpha}{\beta} = -\beta
 
@@ -6057,22 +6057,23 @@ class pearson3_gen(rv_continuous):
         return ans
 
     def _cdf(self, x, skew):
-        ans, x, transx, mask, invmask, beta, alpha, zeta = (
+        ans, x, transx, mask, invmask, _, alpha, _ = (
             self._preprocess(x, skew))
 
         ans[mask] = _norm_cdf(x[mask])
-        invmask1 = np.logical_and(invmask, skew > 0)
-        transx1 = beta[invmask1] * (x[invmask1] - zeta[invmask1])
-        ans[invmask1] = gamma._cdf(transx1, alpha[invmask1])
+
+        invmask1a = np.logical_and(invmask, skew > 0)
+        invmask1b = skew[invmask] > 0
+        ans[invmask1a] = gamma._cdf(transx[invmask1b], alpha[invmask1b])
 
         # The gamma._cdf approach wasn't working with negative skew.
         # Note that multiplying the skew by -1 reflects about x=0.
         # So instead of evaluating the CDF with negative skew at x,
         # evaluate the SF with positive skew at -x.
-        invmask2 = np.logical_and(invmask, skew < 0)
-        transx2 = -beta[invmask2] * (-x[invmask2] + zeta[invmask2])
-        # gamma._sf produces NaNs when transx2 < 0, so use gamma.sf
-        ans[invmask2] = gamma.sf(transx2, alpha[invmask2])
+        invmask2a = np.logical_and(invmask, skew < 0)
+        invmask2b = skew[invmask] < 0
+        # gamma._sf produces NaNs when transx < 0, so use gamma.sf
+        ans[invmask2a] = gamma.sf(transx[invmask2b], alpha[invmask2b])
 
         return ans
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -5953,22 +5953,23 @@ class pearson3_gen(rv_continuous):
 
     .. math::
 
-        f(x, skew) = \frac{|\beta|}{\Gamma(\alpha)}
-                     (\beta (x - \zeta))^{\alpha - 1}
-                     \exp(-\beta (x - \zeta))
+        f(x, \kappa) = \frac{|\beta|}{\Gamma(\alpha)}
+                       (\beta (x - \zeta))^{\alpha - 1}
+                       \exp(-\beta (x - \zeta))
 
     where:
 
     .. math::
 
-            \beta = \frac{2}{skew  stddev}
+            \beta = \frac{2}{\kappa}
 
-            \alpha = (stddev \beta)^2
+            \alpha = \beta^2 = \frac{4}{\kappa**2}
 
-            \zeta = loc - \frac{\alpha}{\beta}
+            \zeta = -\frac{\alpha}{\beta} = -\beta
 
     :math:`\Gamma` is the gamma function (`scipy.special.gamma`).
-    `pearson3` takes ``skew`` as a shape parameter for :math:`skew`.
+    Pass the skew :math:`\kappa` into `pearson3` as the shape parameter
+    ``skew``.
 
     %(after_notes)s
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -6053,7 +6053,9 @@ class pearson3_gen(rv_continuous):
             self._preprocess(x, skew))
 
         ans[mask] = np.log(_norm_pdf(x[mask]))
-        ans[invmask] = np.log(abs(beta)) + gamma._logpdf(transx, alpha)
+        # use logpdf instead of _logpdf to fix bug mentioned in gh-12640
+        # (_logpdf does not return correct result for alpha = -1)
+        ans[invmask] = np.log(abs(beta)) + gamma.logpdf(transx, alpha)
         return ans
 
     def _cdf(self, x, skew):
@@ -6064,6 +6066,8 @@ class pearson3_gen(rv_continuous):
 
         invmask1a = np.logical_and(invmask, skew > 0)
         invmask1b = skew[invmask] > 0
+        # use cdf instead of _cdf to fix bug mentioned in gh-12640
+        # (_cdf produces NaNs for inputs outside support)
         ans[invmask1a] = gamma.cdf(transx[invmask1b], alpha[invmask1b])
 
         # The gamma._cdf approach wasn't working with negative skew.

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -6054,7 +6054,7 @@ class pearson3_gen(rv_continuous):
 
         ans[mask] = np.log(_norm_pdf(x[mask]))
         # use logpdf instead of _logpdf to fix issue mentioned in gh-12640
-        # (_logpdf does not return correct result for alpha = -1)
+        # (_logpdf does not return correct result for alpha = 1)
         ans[invmask] = np.log(abs(beta)) + gamma.logpdf(transx, alpha)
         return ans
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -6024,8 +6024,8 @@ class pearson3_gen(rv_continuous):
         return np.ones(np.shape(skew), dtype=bool)
 
     def _stats(self, skew):
-        m = 0
-        v = 1
+        m = 0.0
+        v = 1.0
         s = skew
         k = 1.5*skew**2
         return m, v, s, k

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -6023,12 +6023,10 @@ class pearson3_gen(rv_continuous):
         return np.ones(np.shape(skew), dtype=bool)
 
     def _stats(self, skew):
-        _, _, _, _, _, beta, alpha, zeta = (
-            self._preprocess([1], skew))
-        m = zeta + alpha / beta
-        v = alpha / (beta**2)
-        s = 2.0 / (alpha**0.5) * np.sign(beta)
-        k = 6.0 / alpha
+        m = 0
+        v = 1
+        s = skew
+        k = 1.5*skew**2
         return m, v, s, k
 
     def _pdf(self, x, skew):

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -5962,7 +5962,9 @@ class pearson3_gen(rv_continuous):
     .. math::
 
             \beta = \frac{2}{skew  stddev}
+
             \alpha = (stddev \beta)^2
+
             \zeta = loc - \frac{\alpha}{\beta}
 
     :math:`\Gamma` is the gamma function (`scipy.special.gamma`).

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -6064,7 +6064,7 @@ class pearson3_gen(rv_continuous):
 
         invmask1a = np.logical_and(invmask, skew > 0)
         invmask1b = skew[invmask] > 0
-        ans[invmask1a] = gamma._cdf(transx[invmask1b], alpha[invmask1b])
+        ans[invmask1a] = gamma.cdf(transx[invmask1b], alpha[invmask1b])
 
         # The gamma._cdf approach wasn't working with negative skew.
         # Note that multiplying the skew by -1 reflects about x=0.

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -6053,7 +6053,7 @@ class pearson3_gen(rv_continuous):
             self._preprocess(x, skew))
 
         ans[mask] = np.log(_norm_pdf(x[mask]))
-        # use logpdf instead of _logpdf to fix bug mentioned in gh-12640
+        # use logpdf instead of _logpdf to fix issue mentioned in gh-12640
         # (_logpdf does not return correct result for alpha = -1)
         ans[invmask] = np.log(abs(beta)) + gamma.logpdf(transx, alpha)
         return ans

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -6066,7 +6066,7 @@ class pearson3_gen(rv_continuous):
 
         invmask1a = np.logical_and(invmask, skew > 0)
         invmask1b = skew[invmask] > 0
-        # use cdf instead of _cdf to fix bug mentioned in gh-12640
+        # use cdf instead of _cdf to fix issue mentioned in gh-12640
         # (_cdf produces NaNs for inputs outside support)
         ans[invmask1a] = gamma.cdf(transx[invmask1b], alpha[invmask1b])
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -6057,11 +6057,23 @@ class pearson3_gen(rv_continuous):
         return ans
 
     def _cdf(self, x, skew):
-        ans, x, transx, mask, invmask, _, alpha, _ = (
+        ans, x, transx, mask, invmask, beta, alpha, zeta = (
             self._preprocess(x, skew))
 
         ans[mask] = _norm_cdf(x[mask])
-        ans[invmask] = gamma._cdf(transx, alpha)
+        invmask1 = np.logical_and(invmask, skew > 0)
+        transx1 = beta[invmask1] * (x[invmask1] - zeta[invmask1])
+        ans[invmask1] = gamma._cdf(transx1, alpha[invmask1])
+
+        # The gamma._cdf approach wasn't working with negative skew.
+        # Note that multiplying the skew by -1 reflects about x=0.
+        # So instead of evaluating the CDF with negative skew at x,
+        # evaluate the SF with positive skew at -x.
+        invmask2 = np.logical_and(invmask, skew < 0)
+        transx2 = -beta[invmask2] * (-x[invmask2] + zeta[invmask2])
+        # gamma._sf produces NaNs when transx2 < 0, so use gamma.sf
+        ans[invmask2] = gamma.sf(transx2, alpha[invmask2])
+
         return ans
 
     def _rvs(self, skew, size=None, random_state=None):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -21,7 +21,7 @@ from numpy import typecodes, array
 from numpy.lib.recfunctions import rec_append_fields
 from scipy import special
 from scipy._lib._util import check_random_state
-from scipy.integrate import IntegrationWarning
+from scipy.integrate import IntegrationWarning, quad
 import scipy.stats as stats
 from scipy.stats._distn_infrastructure import argsreduce
 import scipy.stats.distributions
@@ -1118,6 +1118,28 @@ class TestPearson3(object):
         vals = stats.pearson3.cdf([-3, -2, -1, 0, 1], 0.1)
         assert_allclose(vals, [8.22563821e-04, 1.99860448e-02, 1.58550710e-01,
                                5.06649130e-01, 8.41442111e-01], atol=1e-6)
+
+    def test_negative_cdf_bug_11186(self):
+        # incorrect CDFs for negative skews in gh-11186; fixed in gh-12640
+        # Also check vectorization w/ negative, zero, and positive skews
+        skews = [-3, -1, 0, 0.5]
+        x_eval = 0.5
+        neg_inf = -30  # avoid RuntimeWarning caused by np.log(0)
+        cdfs = stats.pearson3.cdf(x_eval, skews)
+        int_pdfs = [quad(stats.pearson3(skew).pdf, neg_inf, x_eval)[0]
+                    for skew in skews]
+        assert_allclose(cdfs, int_pdfs)
+
+    def test_return_array_bug_11746(self):
+        # pearson3.moment was returning size 0 or 1 array instead of float
+        # The first moment is equal to the loc, which defaults to zero
+        moment = stats.pearson3.moment(1, 2)
+        assert_equal(moment, 0)
+        assert_equal(type(moment), float)
+
+        moment = stats.pearson3.moment(1, 0.000001)
+        assert_equal(moment, 0)
+        assert_equal(type(moment), float)
 
 
 class TestKappa4(object):


### PR DESCRIPTION
Closes gh-9168, closes gh-11186, closes gh-11746

Probably should wait for gh-12197 to see what should happen when `moment` method accepts arrays.

Also, hopefully gh-11695 will merge before this. If so, remove the override of the `pearson3.fit` method and allow `check_fit_args` and `check_fit_args_fix` to run in `test_continuous_basic.py` by removing `pearson3` from `fail_fit_test_mm`/`fail_fit_fix__test_mm`.