### PR TITLE
Fix levy_stable.pdf 'best' method to match documentation

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4256,7 +4256,7 @@ class levy_stable_gen(rv_continuous):
 
     @staticmethod
     def _pdf_single_value_best(x, alpha, beta):
-        if alpha != 1. or (alpha == 1. and beta == 0.):
+        if alpha == 1.:
             return levy_stable_gen._pdf_single_value_zolotarev(x, alpha, beta)
         else:
             return levy_stable_gen._pdf_single_value_cf_integrate(x, alpha, beta)


### PR DESCRIPTION
According to the documentation (emphasis mine), Zolotarev's method is supposed to be used when alpha=1.

> The default method is ‘best’ which **uses Zolotarev’s method if alpha = 1** and integration of characteristic function otherwise. The default method can be changed by setting levy_stable.pdf_default_method to either ‘zolotarev’, ‘quadrature’ or ‘best’.

This reverts a change from 47e9a9b9ec2b053645044082e9e64451ab819892.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

This closes #12658.

#### What does this implement/fix?
<!--Please explain your changes.-->

This fixes a few accuracy issues. See the linked issue for more details, but for example, in 1.5.2 we have
```python
>>> from scipy.stats import levy_stable
>>> levy_stable.pdf(-0.015, alpha=1.025, beta=0.0)
1.2093136435052321e-10
>>> print(levy_stable.pdf(-20, alpha=1.025, beta=0.0))
1.0354285422392917e-11
>>> print(levy_stable.pdf(-20, alpha=1.01, beta=0.0))
/scipy/stats/_continuous_distns.py:4523: IntegrationWarning: The maximum number of subdivisions (50) has been achieved.
  If increasing the limit yields no improvement it is advised to analyze 
  the integrand in order to determine the difficulties.  If the position of a 
  local difficulty can be determined (singularity, discontinuity) one will 
  probably gain from splitting up the interval and calling the integrator 
  on the subranges.  Perhaps a special-purpose integrator should be used.
  intg = integrate.quad(f, -xi, np.pi/2, **intg_kwargs)[0]
nan
```
and in this PR we have
```python
>>> from scipy.stats import levy_stable
>>> levy_stable.pdf(-0.015, alpha=1.025, beta=0.0)
0.31503978336707106
>>> print(levy_stable.pdf(-20, alpha=1.025, beta=0.0))
0.0007468445127072013
>>> print(levy_stable.pdf(-20, alpha=1.01, beta=0.0))
0.0007748017658593994
```
which is significantly more accurate. We compare this to
```python
>>> quad_weight_pdf(-0.015, alpha=1.025)
0.3150397833582416
>>> quad_weight_pdf(-20, alpha=1.025)
0.0007468445147808974
>>> quad_weight_pdf(-20, alpha=1.01)
0.0007748017705594546
```
where `quad_weight_pdf` is one of the sanity-check implementations that I wrote in the linked issue.

#### Additional information
<!--Any additional information you think is important.-->

With this change `levy_stable.pdf` is still ~50-100x slower than I would expect
```
$ python3 -m timeit "levy_stable.pdf(-20, alpha=1.025, beta=0.0)"
10 loops, best of 3: 25 msec per loop
$ python3 -m timeit "quad_weight_pdf(-20, alpha=1.025)"
1000 loops, best of 3: 380 usec per loop
```
but that is unrelated to the accuracy issue.