### PR TITLE
ENH: Adding Modified Rodrigues Parameters to the Rotation class

### DIFF
--- a/benchmarks/benchmarks/spatial.py
+++ b/benchmarks/benchmarks/spatial.py
@@ -451,6 +451,10 @@ class RotationBench(Benchmark):
         '''Time converting rotation from and to rotation vectors'''
         Rotation.from_rotvec(self.rotations.as_rotvec())
 
+    def time_mrp_conversion(self, num_rotations):
+        '''Time converting rotation from and to Modified Rodrigues Parameters'''
+        Rotation.from_mrp(self.rotations.as_mrp())
+
     def time_mul_inv(self, num_rotations):
         '''Time multiplication and inverse of rotations'''
         self.rotations * self.rotations.inv()


### PR DESCRIPTION
#### Reference issue
N/A

#### What does this implement/fix?
The implements 2 new methods in the Rotation class of the spatial/transform package, as_mrp and from_mrp, which allow the class to accept input and provide output in the form of Modified Rodrigues Parameters.