### PR TITLE
BUG: Ensure factorial is not too large in mstats.kendalltau

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -6,6 +6,7 @@ import numbers
 from collections import namedtuple
 from multiprocessing import Pool
 import inspect
+import math
 
 import numpy as np
 
@@ -151,6 +152,14 @@ def prod(iterable):
     for x in iterable:
         product *= x
     return product
+
+
+def float_factorial(n: int) -> float:
+    """Compute the factorial and return as a float
+
+    Returns infinity when result is too large for a double
+    """
+    return float(math.factorial(n)) if n < 171 else np.inf
 
 
 class DeprecatedImport(object):

--- a/scipy/interpolate/polyint.py
+++ b/scipy/interpolate/polyint.py
@@ -1,7 +1,6 @@
 import numpy as np
 from scipy.special import factorial
-
-from scipy._lib._util import _asarray_validated
+from scipy._lib._util import _asarray_validated, float_factorial
 
 
 __all__ = ["KroghInterpolator", "krogh_interpolate", "BarycentricInterpolator",
@@ -299,7 +298,7 @@ class KroghInterpolator(_Interpolator1DWithDerivatives):
             while s <= k and xi[k-s] == xi[k]:
                 s += 1
             s -= 1
-            Vk[0] = self.yi[k]/float(factorial(s))
+            Vk[0] = self.yi[k]/float_factorial(s)
             for i in range(k-s):
                 if xi[i] == xi[k]:
                     raise ValueError("Elements if `xi` can't be equal.")
@@ -344,7 +343,7 @@ class KroghInterpolator(_Interpolator1DWithDerivatives):
             for i in range(1, n-k+1):
                 pi[i] = w[k+i-1]*pi[i-1] + pi[i]
                 cn[k] = cn[k] + pi[i, :, np.newaxis]*cn[k+i]
-            cn[k] *= factorial(k)
+            cn[k] *= float_factorial(k)
 
         cn[n, :, :] = 0
         return cn[:der]

--- a/scipy/signal/_savitzky_golay.py
+++ b/scipy/signal/_savitzky_golay.py
@@ -1,6 +1,6 @@
 import numpy as np
 from scipy.linalg import lstsq
-from math import factorial
+from scipy._lib._util import float_factorial
 from scipy.ndimage import convolve1d
 from ._arraytools import axis_slice
 
@@ -131,7 +131,7 @@ def savgol_coeffs(window_length, polyorder, deriv=0, delta=1.0, pos=None,
     y = np.zeros(polyorder + 1)
     # The coefficient assigned to y[deriv] scales the result to take into
     # account the order of the derivative and the sample spacing.
-    y[deriv] = factorial(deriv) / (delta ** deriv)
+    y[deriv] = float_factorial(deriv) / (delta ** deriv)
 
     # Find the least-squares solution of A*c = y
     coeffs, _, _, _ = lstsq(A, y)

--- a/scipy/signal/bsplines.py
+++ b/scipy/signal/bsplines.py
@@ -6,14 +6,11 @@ from numpy.core.umath import (sqrt, exp, greater, less, cos, add, sin,
 # From splinemodule.c
 from .spline import cspline2d, sepfir2d
 
-from scipy.special import comb, gamma
+from scipy.special import comb
+from scipy._lib._util import float_factorial
 
 __all__ = ['spline_filter', 'bspline', 'gauss_spline', 'cubic', 'quadratic',
            'cspline1d', 'qspline1d', 'cspline1d_eval', 'qspline1d_eval']
-
-
-def factorial(n):
-    return gamma(n + 1)
 
 
 def spline_filter(Iin, lmbda=5.0):
@@ -118,7 +115,7 @@ def _bspline_piecefunctions(order):
     #  in the general expression derived from the central difference
     #  operator (because they involve fewer terms).
 
-    fval = factorial(order)
+    fval = float_factorial(order)
 
     def piecefuncgen(num):
         Mk = order // 2 - num

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -17,6 +17,7 @@ from numpy.polynomial.polynomial import polyvalfromroots
 from scipy import special, optimize, fft as sp_fft
 from scipy.special import comb
 from scipy._lib._util import float_factorial
+import math
 
 
 __all__ = ['findfreqs', 'freqs', 'freqz', 'tf2zpk', 'zpk2tf', 'normalize',
@@ -4386,7 +4387,7 @@ def _bessel_poly(n, reverse=False):
     out = []
     for k in range(n + 1):
         num = _falling_factorial(2*n - k, n)
-        den = 2**(n - k) * float_factorial(k)
+        den = 2**(n - k) * math.factorial(k)
         out.append(num // den)
 
     if reverse:

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -15,7 +15,8 @@ from numpy.polynomial.polynomial import polyval as npp_polyval
 from numpy.polynomial.polynomial import polyvalfromroots
 
 from scipy import special, optimize, fft as sp_fft
-from scipy.special import comb, factorial
+from scipy.special import comb
+from scipy._lib._util import float_factorial
 
 
 __all__ = ['findfreqs', 'freqs', 'freqz', 'tf2zpk', 'zpk2tf', 'normalize',
@@ -4385,7 +4386,7 @@ def _bessel_poly(n, reverse=False):
     out = []
     for k in range(n + 1):
         num = _falling_factorial(2*n - k, n)
-        den = 2**(n - k) * factorial(k, exact=True)
+        den = 2**(n - k) * float_factorial(k)
         out.append(num // den)
 
     if reverse:
@@ -4999,7 +5000,7 @@ def gammatone(freq, ftype, order=None, numtaps=None, fs=None):
 
         # Scale the FIR filter so the frequency response is 1 at cutoff
         scale_factor = 2 * (2 * np.pi * bw) ** (order)
-        scale_factor /= np.math.factorial(order - 1)
+        scale_factor /= float_factorial(order - 1)
         scale_factor /= fs
         b *= scale_factor
         a = [1.0]

--- a/scipy/signal/tests/test_bsplines.py
+++ b/scipy/signal/tests/test_bsplines.py
@@ -13,10 +13,6 @@ class TestBSplines(object):
     """Test behaviors of B-splines. The values tested against were returned as of
     SciPy 1.1.0 and are included for regression testing purposes"""
 
-    def test_factorial(self):
-        # can't all be zero state
-        assert_equal(bsp.factorial(1), 1)
-
     def test_spline_filter(self):
         np.random.seed(12457)
         # Test the type-error branch

--- a/scipy/sparse/linalg/matfuncs.py
+++ b/scipy/sparse/linalg/matfuncs.py
@@ -10,11 +10,10 @@ Sparse matrix functions
 
 __all__ = ['expm', 'inv']
 
-import math
-
 import numpy as np
 
 import scipy.special
+from scipy._lib._util import float_factorial
 from scipy.linalg.basic import solve, solve_triangular
 
 from scipy.sparse.base import isspmatrix
@@ -841,7 +840,7 @@ def _ell(A, m):
     # The c_i are explained in (2.2) and (2.6) of the 2005 expm paper.
     # They are coefficients of terms of a generating function series expansion.
     choose_2m_m = scipy.special.comb(2*m, m, exact=True)
-    abs_c_recip = float(choose_2m_m * math.factorial(2*m + 1))
+    abs_c_recip = float(choose_2m_m) * float_factorial(2*m + 1)
 
     # This is explained after Eq. (1.2) of the 2009 expm paper.
     # It is the "unit roundoff" of IEEE double precision arithmetic.

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -45,6 +45,7 @@ from collections import namedtuple
 from . import distributions
 import scipy.special as special
 import scipy.stats.stats
+from scipy._lib._util import float_factorial
 
 from ._stats_mstats_common import (
         _find_repeats,
@@ -637,9 +638,9 @@ def kendalltau(x, y, use_ties=True, use_missing=False, method='auto'):
         elif n == 2:
             prob = 1.0
         elif c == 0:
-            prob = 2.0/np.math.factorial(n)
+            prob = 2.0/float_factorial(n)
         elif c == 1:
-            prob = 2.0/np.math.factorial(n-1)
+            prob = 2.0/float_factorial(n-1)
         elif 2*c == (n*(n-1))//2:
             prob = 1.0
         else:
@@ -653,7 +654,7 @@ def kendalltau(x, y, use_ties=True, use_missing=False, method='auto'):
                     new[k] += new[k-1]
                 for k in range(j,c+1):
                     new[k] += new[k-1] - old[k-j]
-            prob = 2.0*sum(new)/np.math.factorial(n)
+            prob = 2.0*sum(new)/float_factorial(n)
     elif method == 'asymptotic':
         var_s = n*(n-1)*(2*n+5)
         if use_ties:

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -174,7 +174,7 @@ from numpy import array, asarray, ma
 from scipy.spatial.distance import cdist
 from scipy.ndimage import measurements
 from scipy._lib._util import (_lazywhere, check_random_state, MapWrapper,
-                              rng_integers)
+                              rng_integers, float_factorial)
 import scipy.special as special
 from scipy import linalg
 from . import distributions
@@ -4502,9 +4502,9 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate', method='auto'
         elif size == 2:
             pvalue = 1.0
         elif c == 0:
-            pvalue = 2.0/math.factorial(size) if size < 171 else 0.0
+            pvalue = 2.0/float_factorial(size)
         elif c == 1:
-            pvalue = 2.0/math.factorial(size-1) if (size-1) < 171 else 0.0
+            pvalue = 2.0/float_factorial(size-1)
         elif 2*c == tot:
             pvalue = 1.0
         else:
@@ -4518,7 +4518,7 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate', method='auto'
                 for k in range(j,c+1):
                     new[k] += new[k-1] - old[k-j]
 
-            pvalue = 2.0*sum(new)/math.factorial(size) if size < 171 else 0.0
+            pvalue = 2.0*sum(new)/float_factorial(size)
 
     elif method == 'asymptotic':
         # con_minus_dis is approx normally distributed with this variance [3]_

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1191,8 +1191,9 @@ def test_segfault_issue_9710():
     # The code below also caused SEGFAULT
     stats.weightedtau([np.nan], [52])
 
+
 def test_kendall_tau_large():
-    n = 172.
+    n = 172
     x = np.arange(n)
     y = np.arange(n)
     _, pval = stats.kendalltau(x, y, method='exact')
@@ -1202,6 +1203,13 @@ def test_kendall_tau_large():
     assert_equal(pval, 0.0)
     y[-3], y[-4] = y[-4], y[-3]
     _, pval = stats.kendalltau(x, y, method='exact')
+    assert_equal(pval, 0.0)
+
+    # Test omit policy
+    x = np.arange(n + 1).astype(float)
+    y = np.arange(n + 1).astype(float)
+    y[-1] = np.nan
+    _, pval = stats.kendalltau(x, y, method='exact', nan_policy='omit')
     assert_equal(pval, 0.0)
 
 


### PR DESCRIPTION
#### Reference issue
Fixes https://github.com/scipy/scipy/issues/9611#issuecomment-669097418

#### What does this implement/fix?
This moves the fix from gh-10056 into a utility function `float_factorial` and uses it in both `stats.kendalltau` and `mstats.kendalltau`.
