### PR TITLE
WIP/ENH: Sinkhorn normal form

### DIFF
--- a/scipy/linalg/__init__.py
+++ b/scipy/linalg/__init__.py
@@ -96,6 +96,7 @@ Decompositions
    hessenberg - Hessenberg form of a matrix
    cdf2rdf - Complex diagonal form to real diagonal block form
    cossin - Cosine sine decomposition of a unitary or orthogonal matrix
+   sinkhorn - Sinkhorn decomposition of a matrix
 
 .. seealso::
 
@@ -211,6 +212,7 @@ from ._procrustes import *
 from ._decomp_update import *
 from ._sketches import *
 from ._decomp_cossin import *
+from ._decomp_sinkhorn import *
 
 __all__ = [s for s in dir() if not s.startswith('_')]
 

--- a/scipy/linalg/__init__.py
+++ b/scipy/linalg/__init__.py
@@ -96,7 +96,7 @@ Decompositions
    hessenberg - Hessenberg form of a matrix
    cdf2rdf - Complex diagonal form to real diagonal block form
    cossin - Cosine sine decomposition of a unitary or orthogonal matrix
-   sinkhorn - Sinkhorn decomposition of a matrix
+   sinkhorn - Sinkhorn normal form of a matrix
 
 .. seealso::
 

--- a/scipy/linalg/_decomp_sinkhorn.py
+++ b/scipy/linalg/_decomp_sinkhorn.py
@@ -29,7 +29,7 @@ def sinkhorn(a):
     Raises
     ------
     LinAlgError
-        Raised if decomposition fails
+        Raised if normal form calculation fails
 
     Notes
     -----

--- a/scipy/linalg/_decomp_sinkhorn.py
+++ b/scipy/linalg/_decomp_sinkhorn.py
@@ -61,10 +61,10 @@ def sinkhorn(a):
     c = np.ones(N)
     S = A.copy()
 
-    eps = np.finfo(a.dtype).eps * N
+    rtol = np.finfo(a.dtype).eps * N
     for it in range(10000):
-        prow = np.allclose(np.sum(S, axis=1), 1, atol=0, rtol=eps)
-        pcol = np.allclose(np.sum(S, axis=0), 1, atol=0, rtol=eps)
+        prow = np.allclose(np.sum(S, axis=1), 1, atol=0, rtol=rtol)
+        pcol = np.allclose(np.sum(S, axis=0), 1, atol=0, rtol=rtol)
         if prow and pcol:
             D1 = np.diag(1 / r)
             D2 = np.diag(1 / c)

--- a/scipy/linalg/_decomp_sinkhorn.py
+++ b/scipy/linalg/_decomp_sinkhorn.py
@@ -1,0 +1,77 @@
+import numpy as np
+from .misc import LinAlgError
+
+__all__ = ['sinkhorn']
+
+
+def sinkhorn(a):
+    """
+    Compute Sinkhorn normal form of a matrix.
+
+    Calculate the Sinkhorm normal form ``A = D1 S D2`` where S is doubly
+    stochastic and D1 and D2 are diagonal.
+
+    Parameters
+    ----------
+    a : (N, N) array_like
+        Matrix to be decomposed. Must be square and real with strictly positive
+        elements.
+
+    Returns
+    -------
+    D1 : ndarray
+        Diagonal matrix of shape (N, N).
+    S : ndarray
+        Doubly stochastic matrix of shape (M, N).
+    D2 : ndarray
+        Diagonal matrix of shape (N, N).
+
+    Raises
+    ------
+    LinAlgError
+        Raised if decomposition fails
+
+    Notes
+    -----
+    .. versionadded:: 1.6.0
+
+    Examples
+    --------
+    >>> from scipy import linalg
+    >>> a = np.random.uniform(0, 1)
+
+    >>> D1, S, D2 = linalg.sinkhorn(a)
+    >>> np.allclose(a, D1 @ S @ D2)
+    True
+
+    """
+    A = np.asarray_chkfinite(a)
+
+    if A.ndim != 2 or A.shape[0] != A.shape[1]:
+        raise ValueError("input matrix must be square")
+
+    if np.any(A <= 0):
+        raise ValueError("input matrix must be strictly positive")
+
+    if np.any(np.iscomplex(A)):
+        raise ValueError("input matrix must be real")
+
+    N = len(A)
+    r = np.ones(N)
+    c = np.ones(N)
+    S = A.copy()
+
+    eps = np.finfo(a.dtype).eps * N
+    for it in range(10000):
+        prow = np.allclose(np.sum(S, axis=1), 1, atol=0, rtol=eps)
+        pcol = np.allclose(np.sum(S, axis=0), 1, atol=0, rtol=eps)
+        if prow and pcol:
+            D1 = np.diag(1 / r)
+            D2 = np.diag(1 / c)
+            return D1, S, D2
+
+        c = 1 / (r @ A)
+        r = 1 / (A @ c)
+        S = r[:, None] * A * c
+
+    raise LinAlgError("Sinkhorn-Knopp did not converge.")

--- a/scipy/linalg/_decomp_sinkhorn.py
+++ b/scipy/linalg/_decomp_sinkhorn.py
@@ -38,7 +38,7 @@ def sinkhorn(a):
     Examples
     --------
     >>> from scipy import linalg
-    >>> a = np.random.uniform(0, 1)
+    >>> a = np.random.uniform(size=(5, 5))
 
     >>> D1, S, D2 = linalg.sinkhorn(a)
     >>> np.allclose(a, D1 @ S @ D2)

--- a/scipy/linalg/tests/test_sinkhorn.py
+++ b/scipy/linalg/tests/test_sinkhorn.py
@@ -34,7 +34,7 @@ def test_inf_nan(value):
 @pytest.mark.parametrize("seed", range(4))
 def test_row_columns_sums(seed):
     n = 10
-    rng = np.random.RandomState(seed=0)
+    rng = np.random.RandomState(seed=seed)
     A = rng.uniform(0, 10, (n, n))
     D1, S, D2 = sinkhorn(A)
 

--- a/scipy/linalg/tests/test_sinkhorn.py
+++ b/scipy/linalg/tests/test_sinkhorn.py
@@ -1,0 +1,50 @@
+import pytest
+from pytest import raises as assert_raises
+import numpy as np
+from numpy.testing import assert_allclose, assert_equal
+from scipy.linalg import sinkhorn
+
+
+def test_square():
+    with assert_raises(ValueError, match="square"):
+        sinkhorn(np.ones(4))
+
+    with assert_raises(ValueError, match="square"):
+        sinkhorn(np.ones((4, 5)))
+
+
+def test_positive():
+    with assert_raises(ValueError, match="strictly positive"):
+        sinkhorn(-np.ones((5, 5)))
+
+
+def test_complex():
+    with assert_raises(ValueError, match="real"):
+        sinkhorn(np.ones((5, 5)) + 1j)
+
+
+@pytest.mark.parametrize("value", [float("inf"), float("NaN")])
+def test_inf_nan(value):
+    with assert_raises(ValueError, match="must not contain infs or NaNs"):
+        a = np.ones((5, 5))
+        a[0, 0] = value
+        sinkhorn(a)
+
+
+@pytest.mark.parametrize("seed", range(4))
+def test_row_columns_sums(seed):
+    n = 10
+    rng = np.random.RandomState(seed=0)
+    A = rng.uniform(0, 10, (n, n))
+    D1, S, D2 = sinkhorn(A)
+
+    # test correct product
+    assert_allclose(A, D1 @ S @ D2)
+
+    # test doubly stochastic
+    assert_allclose(np.sum(S, axis=0), 1)
+    assert_allclose(np.sum(S, axis=1), 1)
+
+    # test diagonal matrices
+    assert_equal(D1, np.diag(np.diag(D1)))
+    assert_equal(D2, np.diag(np.diag(D2)))


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

This PR adds the Sinkhorn normal form to `scipy.linalg`, using Sinkhorn-Knopp iteration.

#### Additional information
<!--Any additional information you think is important.-->
The Sinkhorn normal form is used in #11862. I propose that we make it a public function.
I have not included any of the usual decomposition options such as `overwrite_a` and `check_finite` as even a single iteration of  Sinkhorn-Knopp is more costly than these savings.



@ilayn, can I interest you in this?