### PR TITLE
BUG: update median averaging in signal.csd

### DIFF
--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -505,7 +505,9 @@ def csd(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
         Axis along which the CSD is computed for both inputs; the
         default is over the last axis (i.e. ``axis=-1``).
     average : { 'mean', 'median' }, optional
-        Method to use when averaging periodograms. Defaults to 'mean'.
+        Method to use when averaging periodograms. If the spectrum is
+        complex, the average is computed separately for the real and
+        imaginary parts. Defaults to 'mean'.
 
         .. versionadded:: 1.2.0
 

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -585,7 +585,13 @@ def csd(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
     if len(Pxy.shape) >= 2 and Pxy.size > 0:
         if Pxy.shape[-1] > 1:
             if average == 'median':
-                Pxy = np.median(Pxy, axis=-1) / _median_bias(Pxy.shape[-1])
+                # np.median must be passed real arrays for the desired result
+                if np.iscomplexobj(Pxy):
+                    Pxy = (np.median(np.real(Pxy), axis=-1)
+                           + 1j * np.median(np.imag(Pxy), axis=-1))
+                    Pxy /= _median_bias(Pxy.shape[-1])
+                else:
+                    Pxy = np.median(Pxy, axis=-1) / _median_bias(Pxy.shape[-1])
             elif average == 'mean':
                 Pxy = Pxy.mean(axis=-1)
             else:


### PR DESCRIPTION
Separately median-average real and imaginary components of complex
CSDs. This avoids unexpected behavior when np.median is passed a
complex array.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #12669

#### What does this implement/fix?
Currently, when `average='median'` is passed to `signal.csd`, the CSD array is passed directly through `np.median`. This is fine for PSDs, which are always real, but for complex CSDs the resulting imaginary component is far too large. This is because `np.median(Pxy)` of a complex array `Pxy` does not return the same result as `np.median(np.real(Pxy)) + 1j*np.median(np.imag(Pxy))`, as might have been expected. For median averaging, this fix checks if the CSD array is complex, and if so it separately takes medians of the real and imaginary components and then recombines the result in to a complex median-averaged CSD.