### PR TITLE
scipy/stats: Add laplace_asymmetric continuous distribution

### DIFF
--- a/doc/source/tutorial/stats.rst
+++ b/doc/source/tutorial/stats.rst
@@ -98,7 +98,7 @@ introspection:
     >>> dist_discrete = [d for d in dir(stats) if
     ...                  isinstance(getattr(stats, d), stats.rv_discrete)]
     >>> print('number of continuous distributions: %d' % len(dist_continu))
-    number of continuous distributions: 100
+    number of continuous distributions: 101
     >>> print('number of discrete distributions:   %d' % len(dist_discrete))
     number of discrete distributions:   16
 

--- a/doc/source/tutorial/stats/continuous.rst
+++ b/doc/source/tutorial/stats/continuous.rst
@@ -258,6 +258,7 @@ Continuous Distributions in `scipy.stats`
    continuous_kstwo
    continuous_kstwobign
    continuous_laplace
+   continuous_laplace_asymmetric
    continuous_levy_l
    continuous_levy
    continuous_logistic

--- a/doc/source/tutorial/stats/continuous_laplace_asymmetric.rst
+++ b/doc/source/tutorial/stats/continuous_laplace_asymmetric.rst
@@ -27,7 +27,7 @@ Functions
     \begin{eqnarray*}
     \mu & = & \kappa^{-1}-\kappa\\
     \mu_2 & = & \kappa^{-2}+\kappa^2\\
-    \gamma_1 & = & \frac{2(1-\kappa^6)}{(1+\kappa^4)^{3/2}}
+    \gamma_1 & = & \frac{2(1-\kappa^6)}{(1+\kappa^4)^{3/2}}\\
     \gamma_2 & = & \frac{6(1+\kappa^8)}{(1+\kappa^4)^2}
     \end{eqnarray*}
 

--- a/doc/source/tutorial/stats/continuous_laplace_asymmetric.rst
+++ b/doc/source/tutorial/stats/continuous_laplace_asymmetric.rst
@@ -1,8 +1,15 @@
-
-.. _continuous-laplace:
+.. _continuous-laplace-asymmetric:
 
 Asymmetric Laplace Distribution
 ================================================================
+
+This distribution is a generalization of the Laplace distribution. It
+has a single shape parameter :math:`\kappa>0` that species the
+distribution's asymmetry. The special case :math:`\kappa=1` yields the
+Laplace distribution.
+
+Functions
+---------
 
 .. math::
    :nowrap:
@@ -19,8 +26,9 @@ Asymmetric Laplace Distribution
 
     \begin{eqnarray*}
     \mu & = & \kappa^{-1}-\kappa\\
-    \sigma^2 & = & \kappa^{-2}-\kappa^2\\
-    \tilde\mu_3 & = & \frac{2(1-\kappa^6)}{(1+\kappa^4)^{3/2}}
+    \mu_2 & = & \kappa^{-2}+\kappa^2\\
+    \gamma_1 & = & \frac{2(1-\kappa^6)}{(1+\kappa^4)^{3/2}}
+    \gamma_2 & = & \frac{6(1+\kappa^8)}{(1+\kappa^4)^2}
     \end{eqnarray*}
 
 
@@ -30,7 +38,7 @@ References
 -  "Asymmetric Laplace distribution", Wikipedia
    https://en.wikipedia.org/wiki/Asymmetric_Laplace_distribution
 
--  Kozubowski TJ and Podg\'orski K, "A Multivariate and Asymmetric
+-  Kozubowski TJ and Podgórski K, "A Multivariate and Asymmetric
    Generalization of Laplace Distribution," *Computational Statistics*
    15, 531--540 (2000). :doi:`10.1007/PL00022717`
 

--- a/doc/source/tutorial/stats/continuous_laplace_asymmetric.rst
+++ b/doc/source/tutorial/stats/continuous_laplace_asymmetric.rst
@@ -1,0 +1,38 @@
+
+.. _continuous-laplace:
+
+Asymmetric Laplace Distribution
+================================================================
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*}
+    F(x, \kappa) & = & 1-\frac{\kappa^{-1}}{\kappa+\kappa^{-1}}\exp(-x\kappa),\quad x\ge0; \\
+                 & = & \frac{\kappa}{\kappa+\kappa^{-1}}\exp(x/\kappa),\quad x<0. \\
+    f(x, \kappa) & = & \frac{1}{\kappa+\kappa^{-1}}\exp(-x\kappa),\quad x\ge0; \\
+                 & = & \frac{1}{\kappa+\kappa^{-1}}\exp(x/\kappa),\quad x<0.
+    \end{eqnarray*}
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*}
+    \mu & = & \kappa^{-1}-\kappa\\
+    \sigma^2 & = & \kappa^{-2}-\kappa^2\\
+    \tilde\mu_3 & = & \frac{2(1-\kappa^6)}{(1+\kappa^4)^{3/2}}
+    \end{eqnarray*}
+
+
+References
+----------
+
+-  "Asymmetric Laplace distribution", Wikipedia
+   https://en.wikipedia.org/wiki/Asymmetric_Laplace_distribution
+
+-  Kozubowski TJ and Podg\'orski K, "A Multivariate and Asymmetric
+   Generalization of Laplace Distribution," *Computational Statistics*
+   15, 531--540 (2000). :doi:`10.1007/PL00022717`
+
+
+Implementation: `scipy.stats.laplace_asymmetric`

--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -82,6 +82,7 @@ Continuous distributions
    kstwo             -- Distribution of Kolmogorov-Smirnov two-sided test statistic
    kstwobign         -- Limiting Distribution of scaled Kolmogorov-Smirnov two-sided test statistic.
    laplace           -- Laplace
+   laplace_asymmetric    -- Asymmetric Laplace
    levy              -- Levy
    levy_l
    levy_stable

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4107,7 +4107,7 @@ class laplace_asymmetric_gen(rv_continuous):
     .. [1] "Asymmetric Laplace distribution", Wikipedia
             https://en.wikipedia.org/wiki/Asymmetric_Laplace_distribution
 
-    .. [2] Kozubowski TJ and Podg\'orski K. A Multivariate and
+    .. [2] Kozubowski TJ and Podgórski K. A Multivariate and
            Asymmetric Generalization of Laplace Distribution,
            Computational Statistics 15, 531--540 (2000).
            :doi:`10.1007/PL00022717`

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4104,7 +4104,10 @@ class laplace_asymmetric_gen(rv_continuous):
 
     References
     ----------
-    .. [1] Kozubowski TJ and Podg\'orski K. A Multivariate and
+    .. [1] "Asymmetric Laplace distribution", Wikipedia
+            https://en.wikipedia.org/wiki/Asymmetric_Laplace_distribution
+
+    .. [2] Kozubowski TJ and Podg\'orski K. A Multivariate and
            Asymmetric Generalization of Laplace Distribution,
            Computational Statistics 15, 531--540 (2000).
            :doi:`10.1007/PL00022717`
@@ -4112,19 +4115,12 @@ class laplace_asymmetric_gen(rv_continuous):
     %(example)s
 
     """
-    def _rvs(self, kappa, size=None, random_state=None):
-        kapinv = 1/kappa
-        u = -kappa + (kappa+kapinv)*random_state.uniform(size=size)
-        return -np.where(u >= 0,
-            kapinv*np.log1p(-u*kappa),
-            -kappa*np.log1p(u*kapinv))
-
     def _pdf(self, x, kappa):
         return np.exp(self._logpdf(x, kappa))
 
     def _logpdf(self, x, kappa):
         kapinv = 1/kappa
-        lPx = np.where(x >= 0, -x*kappa, x*kapinv)
+        lPx = x * np.where(x >= 0, -kappa, kapinv)
         lPx -= np.log(kappa+kapinv)
         return lPx
 
@@ -4132,8 +4128,8 @@ class laplace_asymmetric_gen(rv_continuous):
         kapinv = 1/kappa
         kappkapinv = kappa+kapinv
         return np.where(x >= 0,
-            1-np.exp(-x*kappa)*(kapinv/kappkapinv),
-            np.exp(x*kapinv)*(kappa/kappkapinv))
+                        1 - np.exp(-x*kappa)*(kapinv/kappkapinv),
+                        np.exp(x*kapinv)*(kappa/kappkapinv))
 
     def _sf(self, x, kappa):
         kapinv = 1/kappa
@@ -4146,15 +4142,15 @@ class laplace_asymmetric_gen(rv_continuous):
         kapinv = 1/kappa
         kappkapinv = kappa+kapinv
         return np.where(q >= kappa/kappkapinv,
-            -np.log((1-q)*kappkapinv*kappa)*kapinv,
-            np.log(q*kappkapinv/kappa)*kappa)
+                        -np.log((1 - q)*kappkapinv*kappa)*kapinv,
+                        np.log(q*kappkapinv/kappa)*kappa)
 
     def _isf(self, q, kappa):
         kapinv = 1/kappa
         kappkapinv = kappa+kapinv
         return np.where(q <= kapinv/kappkapinv,
-            -np.log(q*kappkapinv*kappa)*kapinv,
-            np.log((1-q)*kappkapinv/kappa)*kappa)
+                        -np.log(q*kappkapinv*kappa)*kapinv,
+                        np.log((1 - q)*kappkapinv/kappa)*kappa)
     
     def _stats(self, kappa):
         kapinv = 1/kappa

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4135,8 +4135,8 @@ class laplace_asymmetric_gen(rv_continuous):
         kapinv = 1/kappa
         kappkapinv = kappa+kapinv
         return np.where(x >= 0,
-            np.exp(-x*kappa)*(kapinv/kappkapinv),
-            1-np.exp(x*kapinv)*(kappa/kappkapinv))
+                        np.exp(-x*kappa)*(kapinv/kappkapinv),
+                        1 - np.exp(x*kapinv)*(kappa/kappkapinv))
 
     def _ppf(self, q, kappa):
         kapinv = 1/kappa

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4076,6 +4076,101 @@ class laplace_gen(rv_continuous):
 laplace = laplace_gen(name='laplace')
 
 
+class laplace_asymmetric_gen(rv_continuous):
+    r"""An asymmetric Laplace continuous random variable.
+
+    %(before_notes)s
+
+    Notes
+    -----
+    The probability density function for `laplace_asymmetric` is
+
+    .. math::
+
+        f(x, \kappa) &= \frac{1}{\kappa+\kappa^{-1}}\exp(-x\kappa),\quad x\ge0\\
+                     &= \frac{1}{\kappa+\kappa^{-1}}\exp(x/\kappa),\quad x<0\\
+
+    for :math:`-\infty < x < \infty`, :math:`\kappa > 0`.
+
+    `laplace_asymmetric` takes ``kappa`` as a shape parameter for
+    :math:`\kappa`. For :math:`\kappa = 1`, it is identical to a
+    Laplace distribution.
+
+    %(after_notes)s
+
+    See Also
+    --------
+    laplace : Laplace distribution
+
+    References
+    ----------
+    .. [1] Kozubowski TJ and Podg\'orski K. A Multivariate and
+           Asymmetric Generalization of Laplace Distribution,
+           Computational Statistics 15, 531--540 (2000).
+           :doi:`10.1007/PL00022717`
+
+    %(example)s
+
+    """
+    def _rvs(self, kappa, size=None, random_state=None):
+        kapinv = 1/kappa
+        u = -kappa + (kappa+kapinv)*random_state.uniform(size=size)
+        return -np.where(u >= 0,
+            kapinv*np.log1p(-u*kappa),
+            -kappa*np.log1p(u*kapinv))
+
+    def _pdf(self, x, kappa):
+        return np.exp(self._logpdf(x, kappa))
+
+    def _logpdf(self, x, kappa):
+        kapinv = 1/kappa
+        lPx = np.where(x >= 0, -x*kappa, x*kapinv)
+        lPx -= np.log(kappa+kapinv)
+        return lPx
+
+    def _cdf(self, x, kappa):
+        kapinv = 1/kappa
+        kappkapinv = kappa+kapinv
+        return np.where(x >= 0,
+            1-np.exp(-x*kappa)*(kapinv/kappkapinv),
+            np.exp(x*kapinv)*(kappa/kappkapinv))
+
+    def _sf(self, x, kappa):
+        kapinv = 1/kappa
+        kappkapinv = kappa+kapinv
+        return np.where(x >= 0,
+            np.exp(-x*kappa)*(kapinv/kappkapinv),
+            1-np.exp(x*kapinv)*(kappa/kappkapinv))
+
+    def _ppf(self, q, kappa):
+        kapinv = 1/kappa
+        kappkapinv = kappa+kapinv
+        return np.where(q >= kappa/kappkapinv,
+            -np.log((1-q)*kappkapinv*kappa)*kapinv,
+            np.log(q*kappkapinv/kappa)*kappa)
+
+    def _isf(self, q, kappa):
+        kapinv = 1/kappa
+        kappkapinv = kappa+kapinv
+        return np.where(q <= kapinv/kappkapinv,
+            -np.log(q*kappkapinv*kappa)*kapinv,
+            np.log((1-q)*kappkapinv/kappa)*kappa)
+    
+    def _stats(self, kappa):
+        kapinv = 1/kappa
+        mn = kapinv - kappa
+        var = kapinv*kapinv + kappa*kappa
+        g1 = 2.0*(1-np.power(kappa, 6))/np.power(1+np.power(kappa, 4), 1.5)
+        g2 = 6.0*(1+np.power(kappa, 8))/np.power(1+np.power(kappa, 4), 2)
+        return mn, var, g1, g2
+
+    def _entropy(self, kappa):
+        return 1 + np.log(kappa+1/kappa)
+
+
+laplace_asymmetric = laplace_asymmetric_gen(name='laplace_asymmetric')
+
+
 def _check_fit_input_parameters(dist, data, args, kwds):
     data = np.asarray(data)
     floc = kwds.get('floc', None)

--- a/scipy/stats/_distr_params.py
+++ b/scipy/stats/_distr_params.py
@@ -64,6 +64,7 @@ distcont = [
     ['kstwo', (10,)],
     ['kstwobign', ()],
     ['laplace', ()],
+    ['laplace_asymmetric', (2,)],
     ['levy', ()],
     ['levy_l', ()],
     ['levy_stable', (1.8, -0.5)],

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -524,7 +524,7 @@ class TestLaplaceasymmetric(object):
         points = np.array([1, 2, 3])
         pdf1 = stats.laplace_asymmetric.pdf(points, 1)
         pdf2 = stats.laplace.pdf(points)
-        assert_almost_equal(pdf1, pdf2)
+        assert_allclose(pdf1, pdf2)
 
     def test_asymmetric_laplace_pdf(self):
         # test assymetric Laplace
@@ -533,18 +533,24 @@ class TestLaplaceasymmetric(object):
         kapinv = 1/kappa
         pdf1 = stats.laplace_asymmetric.pdf(points, kappa)
         pdf2 = stats.laplace_asymmetric.pdf(points*(kappa**2), kapinv)
-        assert_almost_equal(pdf1, pdf2)
+        assert_allclose(pdf1, pdf2)
 
     def test_asymmetric_laplace_log_10_16(self):
         # test assymetric Laplace
         points = np.array([-np.log(16), np.log(10)])
         kappa = 2
-        kapinv = 1/kappa
         pdf1 = stats.laplace_asymmetric.pdf(points, kappa)
         cdf1 = stats.laplace_asymmetric.cdf(points, kappa)
+        sf1 = stats.laplace_asymmetric.sf(points, kappa)
         pdf2 = np.array([1/10, 1/250])
         cdf2 = np.array([1/5, 1 - 1/500])
-        assert_almost_equal(np.concatenate((pdf1, cdf1)), np.concatenate((pdf1, cdf1)))
+        sf2 = np.array([4/5, 1/500])
+        ppf1 = stats.laplace_asymmetric.isf(cdf2, kappa)
+        ppf2 = points
+        isf1 = stats.laplace_asymmetric.isf(sf2, kappa)
+        isf2 = points
+        assert_allclose(np.concatenate((pdf1, cdf1, sf1, ppf1, isf1)),
+                        np.concatenate((pdf1, cdf1, sf2, ppf2, isf2)))
 
 class TestTruncnorm(object):
     def setup_method(self):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -518,6 +518,23 @@ class TestHalfgennorm(object):
         assert_almost_equal(pdf1, 2*pdf2)
 
 
+class TestLaplaceasymmetric(object):
+    def test_laplace(self):
+        # test against Laplace (special case for kappa=1)
+        points = np.array([1, 2, 3])
+        pdf1 = stats.laplace_asymmetric.pdf(points, 1)
+        pdf2 = stats.laplace.pdf(points)
+        assert_almost_equal(pdf1, pdf2)
+
+    def test_asymmetric_laplace(self):
+        # test assymetric Laplace
+        points = np.array([1, 2, 3])
+        kappa = 2
+        kapinv = 1/kappa
+        pdf1 = stats.laplace_asymmetric.pdf(points, kappa)
+        pdf2 = stats.laplace_asymmetric.pdf(points*(kappa**2), kapinv)
+        assert_almost_equal(pdf1, pdf2)
+
 class TestTruncnorm(object):
     def setup_method(self):
         np.random.seed(1234)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -545,7 +545,7 @@ class TestLaplaceasymmetric(object):
         pdf2 = np.array([1/10, 1/250])
         cdf2 = np.array([1/5, 1 - 1/500])
         sf2 = np.array([4/5, 1/500])
-        ppf1 = stats.laplace_asymmetric.isf(cdf2, kappa)
+        ppf1 = stats.laplace_asymmetric.ppf(cdf2, kappa)
         ppf2 = points
         isf1 = stats.laplace_asymmetric.isf(sf2, kappa)
         isf2 = points

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -526,7 +526,7 @@ class TestLaplaceasymmetric(object):
         pdf2 = stats.laplace.pdf(points)
         assert_almost_equal(pdf1, pdf2)
 
-    def test_asymmetric_laplace(self):
+    def test_asymmetric_laplace_pdf(self):
         # test assymetric Laplace
         points = np.array([1, 2, 3])
         kappa = 2
@@ -534,6 +534,17 @@ class TestLaplaceasymmetric(object):
         pdf1 = stats.laplace_asymmetric.pdf(points, kappa)
         pdf2 = stats.laplace_asymmetric.pdf(points*(kappa**2), kapinv)
         assert_almost_equal(pdf1, pdf2)
+
+    def test_asymmetric_laplace_log_10_16(self):
+        # test assymetric Laplace
+        points = np.array([-np.log(16), np.log(10)])
+        kappa = 2
+        kapinv = 1/kappa
+        pdf1 = stats.laplace_asymmetric.pdf(points, kappa)
+        cdf1 = stats.laplace_asymmetric.cdf(points, kappa)
+        pdf2 = np.array([1/10, 1/250])
+        cdf2 = np.array([1/5, 1 - 1/500])
+        assert_almost_equal(np.concatenate((pdf1, cdf1)), np.concatenate((pdf1, cdf1)))
 
 class TestTruncnorm(object):
     def setup_method(self):

--- a/tools/unicode-check.py
+++ b/tools/unicode-check.py
@@ -10,7 +10,7 @@ import argparse
 # The set of Unicode code points greater than 127 that we
 # allow in the source code.
 box_drawing_chars = set(chr(cp) for cp in range(0x2500, 0x2580))
-allowed = (set(['®', 'é', 'ö', 'λ', 'π', 'ω', '∫', '≠']) |
+allowed = (set(['®', 'é', 'ó', 'ö', 'λ', 'π', 'ω', '∫', '≠']) |
            box_drawing_chars)
 
 


### PR DESCRIPTION
scipy/stats: Add laplace_asymmetric continuous distribution

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

This PR adds the [asymmetric Laplace distribution](https://en.wikipedia.org/wiki/Asymmetric_Laplace_distribution) as an `rv_continuous`.

#### Additional information
<!--Any additional information you think is important.-->