### PR TITLE
TST: bump test tolerance for `DifferentialEvolutionSolver.test_L4`

### DIFF
--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -998,12 +998,12 @@ class TestDifferentialEvolutionSolver(object):
         assert_allclose(f(x_opt), f_opt, atol=0.001)
         assert_allclose(res.fun, f_opt, atol=0.001)
 
-        # selectively use higher tol here for 32-bit
-        # Windows based on gh-11693
+        # use higher tol here for 32-bit Windows, see gh-11693
         if (platform.system() == 'Windows' and np.dtype(np.intp).itemsize < 8):
             assert_allclose(res.x, x_opt, rtol=2.4e-6, atol=0.0035)
         else:
-            assert_allclose(res.x, x_opt, atol=0.002)
+            # tolerance determined from macOS + MKL failure, see gh-12701
+            assert_allclose(res.x, x_opt, rtol=5e-6, atol=0.0024)
 
         assert res.success
         assert_(np.all(A @ res.x <= b))


### PR DESCRIPTION
Closes gh-12701