### PR TITLE
BUG: Improve input validation for sepfir2d

### DIFF
--- a/doc/source/tutorial/signal.rst
+++ b/doc/source/tutorial/signal.rst
@@ -360,7 +360,7 @@ which is often used for blurring.
    >>> import matplotlib.pyplot as plt
 
    >>> image = misc.ascent()
-   >>> w = signal.gaussian(50, 10.0)
+   >>> w = signal.gaussian(51, 10.0)
    >>> image_new = signal.sepfir2d(image, w, w)
 
    >>> plt.figure()

--- a/scipy/signal/tests/test_bsplines.py
+++ b/scipy/signal/tests/test_bsplines.py
@@ -4,9 +4,11 @@ from numpy import array
 from numpy.testing import (assert_equal,
                            assert_allclose, assert_array_equal,
                            assert_almost_equal)
+import pytest
 from pytest import raises
 
 import scipy.signal.bsplines as bsp
+from scipy import signal
 
 
 class TestBSplines(object):
@@ -226,3 +228,33 @@ class TestBSplines(object):
                       7.32718426, 7.874, 7.81016848, 7.433, 7.03980488, 6.759,
                       6.71900226, 6.203, 4.49418159])
         assert_allclose(bsp.qspline1d_eval(cj, newx, dx=dx, x0=x[0]), newy)
+
+
+def test_sepfir2d_invalid_filter():
+    filt = np.array([1.0, 2.0, 4.0, 2.0, 1.0])
+    image = np.random.rand(7, 9)
+    # No error for odd lengths
+    signal.sepfir2d(image, filt, filt[2:])
+
+    # Row or column filter must be odd
+    with pytest.raises(ValueError, match="odd length"):
+        signal.sepfir2d(image, filt, filt[1:])
+    with pytest.raises(ValueError, match="odd length"):
+        signal.sepfir2d(image, filt[1:], filt)
+
+    # Filters must be 1-dimensional
+    with pytest.raises(ValueError, match="object too deep"):
+        signal.sepfir2d(image, filt.reshape(1, -1), filt)
+    with pytest.raises(ValueError, match="object too deep"):
+        signal.sepfir2d(image, filt, filt.reshape(1, -1))
+
+def test_sepfir2d_invalid_image():
+    filt = np.array([1.0, 2.0, 4.0, 2.0, 1.0])
+    image = np.random.rand(8, 8)
+
+    # Image must be 2 dimensional
+    with pytest.raises(ValueError, match="object too deep"):
+        signal.sepfir2d(image.reshape(4, 4, 4), filt, filt)
+
+    with pytest.raises(ValueError, match="object of too small depth"):
+        signal.sepfir2d(image[0], filt, filt)


### PR DESCRIPTION
#### Reference issue
Addresses the invalid memory accesses in gh-12691

#### What does this implement/fix?
Add some basic input validation to `sepfir2d` and add a couple small tests.