### PR TITLE
BUG: fix incorrect 1d case of the fourier_ellipsoid filter

### DIFF
--- a/scipy/ndimage/src/ni_fourier.c
+++ b/scipy/ndimage/src/ni_fourier.c
@@ -352,7 +352,7 @@ int NI_FourierFilter(PyArrayObject *input, PyArrayObject* parameter_array,
             switch (PyArray_NDIM(input)) {
             case 1:
                 tmp = params[0][ii.coordinates[0]];
-                tmp = fabs(tmp) > 0.0 ? sin(tmp) / (tmp) : 1.0;
+                tmp = tmp != 0 ? sin(tmp) / (tmp) : 1.0;
                 break;
             case 2:
                 tmp = 0.0;

--- a/scipy/ndimage/src/ni_fourier.c
+++ b/scipy/ndimage/src/ni_fourier.c
@@ -352,7 +352,7 @@ int NI_FourierFilter(PyArrayObject *input, PyArrayObject* parameter_array,
             switch (PyArray_NDIM(input)) {
             case 1:
                 tmp = params[0][ii.coordinates[0]];
-                tmp = tmp > 0.0 ? sin(tmp) / (tmp) : 1.0;
+                tmp = fabs(tmp) > 0.0 ? sin(tmp) / (tmp) : 1.0;
                 break;
             case 2:
                 tmp = 0.0;

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -1420,6 +1420,16 @@ class TestNdimage:
                 a = fft.ifft(a, shape[0], 0)
                 assert_almost_equal(ndimage.sum(a.real), 1.0, decimal=dec)
 
+    def test_fourier_ellipsoid_1d_complex(self):
+        # expected result of 1d ellipsoid is the same as for fourier_uniform
+        for shape in [(32, ), (31, )]:
+            for type_, dec in zip([numpy.complex64, numpy.complex128],
+                                  [5, 14]):
+                x = numpy.ones(shape, dtype=type_)
+                a = ndimage.fourier_ellipsoid(x, 5, -1, 0)
+                b = ndimage.fourier_uniform(x, 5, -1, 0)
+                assert_array_almost_equal(a, b, decimal=dec)
+
     def test_spline01(self):
         for type_ in self.types:
             data = numpy.ones([], type_)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
None

#### What does this implement/fix?
<!--Please explain your changes.-->

This PR fixes a bug in the C code underlying `scipy.ndimage.fourier_ellipsoid` if the input data is 1D. Specifically, in the 1D case, this is filter is the same as `fourier_uniform` and should result in a sinc-shaped window being applied to the input. Due to a missing `abs`, the output is currently asymmetric with all values where the frequency is < 0 incorrectly set to 1.0.

```Python
import numpy as np
import scipy.ndimage as ndi
import matplotlib.pyplot as plt
plt.figure()
plt.plot(ndi.fourier_uniform(np.ones(64), 16))
```
![1d_error](https://user-images.githubusercontent.com/6528957/89954147-8c491f80-dbfe-11ea-9753-163dcbf2a215.png)


whereas the expected result (generated after this PR or by calling `fourier_uniform` instead is):
![1d_fix](https://user-images.githubusercontent.com/6528957/89954159-910dd380-dbfe-11ea-8cc1-570282f72161.png)


#### Additional information
<!--Any additional information you think is important.-->