### PR TITLE
BUG: bvls can fail catastrophically to converge

### DIFF
--- a/scipy/optimize/_lsq/bvls.py
+++ b/scipy/optimize/_lsq/bvls.py
@@ -14,17 +14,17 @@ def compute_kkt_optimality(g, on_bound):
     return np.max(g_kkt)
 
 
-def bvls(A, b, x_lsq, lb, ub, tol, max_iter, verbose):
+def bvls(A, b, x_lsq, lb, ub, tol, max_iter, verbose, rcond=None):
     m, n = A.shape
 
     x = x_lsq.copy()
     on_bound = np.zeros(n)
 
-    mask = x < lb
+    mask = x <= lb
     x[mask] = lb[mask]
     on_bound[mask] = -1
 
-    mask = x > ub
+    mask = x >= ub
     x[mask] = ub[mask]
     on_bound[mask] = 1
 
@@ -64,7 +64,7 @@ def bvls(A, b, x_lsq, lb, ub, tol, max_iter, verbose):
 
         A_free = A[:, free_set]
         b_free = b - A.dot(x * active_set)
-        z = lstsq(A_free, b_free, rcond=-1)[0]
+        z = lstsq(A_free, b_free, rcond=rcond)[0]
 
         lbv = z < lb[free_set]
         ubv = z > ub[free_set]
@@ -106,7 +106,7 @@ def bvls(A, b, x_lsq, lb, ub, tol, max_iter, verbose):
     # Main BVLS loop.
 
     optimality = compute_kkt_optimality(g, on_bound)
-    for iteration in range(iteration, max_iter):
+    for iteration in range(iteration, max_iter):  # BVLS Loop A
         if verbose == 2:
             print_iteration_linear(iteration, cost, cost_change,
                                    step_norm, optimality)
@@ -119,43 +119,48 @@ def bvls(A, b, x_lsq, lb, ub, tol, max_iter, verbose):
 
         move_to_free = np.argmax(g * on_bound)
         on_bound[move_to_free] = 0
-        free_set = on_bound == 0
-        active_set = ~free_set
-        free_set, = np.nonzero(free_set)
+        
+        while True:   # BVLS Loop B
 
-        x_free = x[free_set]
-        x_free_old = x_free.copy()
-        lb_free = lb[free_set]
-        ub_free = ub[free_set]
+            free_set = on_bound == 0
+            active_set = ~free_set
+            free_set, = np.nonzero(free_set)
+    
+            x_free = x[free_set]
+            x_free_old = x_free.copy()
+            lb_free = lb[free_set]
+            ub_free = ub[free_set]
 
-        A_free = A[:, free_set]
-        b_free = b - A.dot(x * active_set)
-        z = lstsq(A_free, b_free, rcond=-1)[0]
+            A_free = A[:, free_set]
+            b_free = b - A.dot(x * active_set)
+            z = lstsq(A_free, b_free, rcond=rcond)[0]
 
-        lbv, = np.nonzero(z < lb_free)
-        ubv, = np.nonzero(z > ub_free)
-        v = np.hstack((lbv, ubv))
+            lbv, = np.nonzero(z < lb_free)
+            ubv, = np.nonzero(z > ub_free)
+            v = np.hstack((lbv, ubv))
 
-        if v.size > 0:
-            alphas = np.hstack((
-                lb_free[lbv] - x_free[lbv],
-                ub_free[ubv] - x_free[ubv])) / (z[v] - x_free[v])
+            if v.size > 0:
+                alphas = np.hstack((
+                    lb_free[lbv] - x_free[lbv],
+                    ub_free[ubv] - x_free[ubv])) / (z[v] - x_free[v])
 
-            i = np.argmin(alphas)
-            i_free = v[i]
-            alpha = alphas[i]
+                i = np.argmin(alphas)
+                i_free = v[i]
+                alpha = alphas[i]
 
-            x_free *= 1 - alpha
-            x_free += alpha * z
+                x_free *= 1 - alpha
+                x_free += alpha * z
+                x[free_set] = x_free
 
-            if i < lbv.size:
-                on_bound[free_set[i_free]] = -1
+                if i < lbv.size:
+                    on_bound[free_set[i_free]] = -1
+                else:
+                    on_bound[free_set[i_free]] = 1
             else:
-                on_bound[free_set[i_free]] = 1
-        else:
-            x_free = z
+                x_free = z
+                x[free_set] = x_free
+                break
 
-        x[free_set] = x_free
         step_norm = norm(x_free - x_free_old)
 
         r = A.dot(x) - b

--- a/scipy/optimize/tests/test_lsq_linear.py
+++ b/scipy/optimize/tests/test_lsq_linear.py
@@ -156,7 +156,7 @@ class BaseMixin(object):
                       [-19., -32., -8.],
                       [-13., 10., 69.]])
         b = np.array([-41., -90., 47.])
-        bounds = np.array([[31., -44., 26.]
+        bounds = np.array([[31., -44., 26.],
                            [54., -32., 28.]])
 
         x2 = lsq_linear(A, b, bounds=bounds, method='bvls').x

--- a/scipy/optimize/tests/test_lsq_linear.py
+++ b/scipy/optimize/tests/test_lsq_linear.py
@@ -128,6 +128,45 @@ class BaseMixin(object):
         result = lsq_linear(A, b, method=self.method)
         assert_(result.cost < 1.1e-8)
 
+    # This is a test for issue #12709
+    def test_large_rank_deficient(self):
+        np.random.seed(0)
+        n, m = np.sort(np.random.randint(2, 1000, size=2))
+        m *= 2   # make m >> n
+        A = 1.*np.random.randint(-99, 99, size=[m, n])
+        b = 1.*np.random.randint(-99, 99, size=[m])
+        bounds = 1.*np.sort(np.random.randint(-99, 99, size=(2, n)), 0)
+        bounds[1, :] += 1  # ensure up > lb
+
+        # Make the A matrix strongly rank deficient by replicating some columns
+        w = np.random.choice(n, n)  # Select random columns with duplicates
+        A = A[:, w]
+
+        x2 = lsq_linear(A, b, bounds=bounds, method='bvls').x
+        x3 = lsq_linear(A, b, bounds=bounds, method='trf').x
+
+        chi2_2 = np.sum((A @ x2 - b)**2)
+        chi2_3 = np.sum((A @ x3 - b)**2)
+
+        assert_(abs(chi2_2 - chi2_3) < chi2_3*1e-10)
+
+    # This is a test for issue #12709
+    def test_convergence_small_matrix(self):
+        A = np.array([[49., 41., -32.],
+                      [-19., -32., -8.],
+                      [-13., 10., 69.]])
+        b = np.array([-41., -90., 47.])
+        bounds = np.array([[31., -44., 26.]
+                           [54., -32., 28.]])
+
+        x2 = lsq_linear(A, b, bounds=bounds, method='bvls').x
+        x3 = lsq_linear(A, b, bounds=bounds, method='trf').x
+
+        chi2_2 = np.sum((A @ x2 - b)**2)
+        chi2_3 = np.sum((A @ x3 - b)**2)
+
+        assert_(abs(chi2_2 - chi2_3) < chi2_3*1e-10)
+
 
 class SparseMixin(object):
     def test_sparse_and_LinearOperator(self):

--- a/scipy/optimize/tests/test_lsq_linear.py
+++ b/scipy/optimize/tests/test_lsq_linear.py
@@ -128,44 +128,42 @@ class BaseMixin(object):
         result = lsq_linear(A, b, method=self.method)
         assert_(result.cost < 1.1e-8)
 
-    # This is a test for issue #12709
     def test_large_rank_deficient(self):
         np.random.seed(0)
         n, m = np.sort(np.random.randint(2, 1000, size=2))
         m *= 2   # make m >> n
-        A = 1.*np.random.randint(-99, 99, size=[m, n])
-        b = 1.*np.random.randint(-99, 99, size=[m])
-        bounds = 1.*np.sort(np.random.randint(-99, 99, size=(2, n)), 0)
-        bounds[1, :] += 1  # ensure up > lb
+        A = 1.0 * np.random.randint(-99, 99, size=[m, n])
+        b = 1.0 * np.random.randint(-99, 99, size=[m])
+        bounds = 1.0 * np.sort(np.random.randint(-99, 99, size=(2, n)), axis=0)
+        bounds[1, :] += 1.0  # ensure up > lb
 
         # Make the A matrix strongly rank deficient by replicating some columns
         w = np.random.choice(n, n)  # Select random columns with duplicates
         A = A[:, w]
 
-        x2 = lsq_linear(A, b, bounds=bounds, method='bvls').x
-        x3 = lsq_linear(A, b, bounds=bounds, method='trf').x
+        x_bvls = lsq_linear(A, b, bounds=bounds, method='bvls').x
+        x_trf = lsq_linear(A, b, bounds=bounds, method='trf').x
 
-        chi2_2 = np.sum((A @ x2 - b)**2)
-        chi2_3 = np.sum((A @ x3 - b)**2)
+        cost_bvls = np.sum((A @ x_bvls - b)**2)
+        cost_trf = np.sum((A @ x_trf - b)**2)
 
-        assert_(abs(chi2_2 - chi2_3) < chi2_3*1e-10)
+        assert_(abs(cost_bvls - cost_trf) < cost_trf*1e-10)
 
-    # This is a test for issue #12709
     def test_convergence_small_matrix(self):
-        A = np.array([[49., 41., -32.],
-                      [-19., -32., -8.],
-                      [-13., 10., 69.]])
-        b = np.array([-41., -90., 47.])
-        bounds = np.array([[31., -44., 26.],
-                           [54., -32., 28.]])
+        A = np.array([[49.0, 41.0, -32.0],
+                      [-19.0, -32.0, -8.0],
+                      [-13.0, 10.0, 69.0]])
+        b = np.array([-41.0, -90.0, 47.0])
+        bounds = np.array([[31.0, -44.0, 26.0],
+                           [54.0, -32.0, 28.0]])
 
-        x2 = lsq_linear(A, b, bounds=bounds, method='bvls').x
-        x3 = lsq_linear(A, b, bounds=bounds, method='trf').x
+        x_bvls = lsq_linear(A, b, bounds=bounds, method='bvls').x
+        x_trf = lsq_linear(A, b, bounds=bounds, method='trf').x
 
-        chi2_2 = np.sum((A @ x2 - b)**2)
-        chi2_3 = np.sum((A @ x3 - b)**2)
+        cost_bvls = np.sum((A @ x_bvls - b)**2)
+        cost_trf = np.sum((A @ x_trf - b)**2)
 
-        assert_(abs(chi2_2 - chi2_3) < chi2_3*1e-10)
+        assert_(abs(cost_bvls - cost_trf) < cost_trf*1e-10)
 
 
 class SparseMixin(object):
@@ -206,4 +204,3 @@ class TestTRF(BaseMixin, SparseMixin):
 class TestBVLS(BaseMixin):
     method = 'bvls'
     lsq_solvers = ['exact']
-


### PR DESCRIPTION
The function `bvls`, which is called by `optimize.lsq_linear(... method='bvls')` can fail catastrophically to converge due to an incorrect implementation of the published BVLS algorithm. 

It is supposed to implement the BVLS algorithm by [Stak & Parker 1995](https://www.stat.berkeley.edu/~stark/Preprints/bvls.pdf), which is a small generalization of the classic NNLS algorithm 23.10 by [Lawson & Hanson (1995)](https://doi.org/10.1137/1.9781611971217).

However, the current Scipy implementation fails to implement the so-called loop-B in the notation of the above two papers.

The proposed changes fix the deficiency and allow the algorithm to converge in the cases where it currently fails.

#### Reference issue

Here is a minimal example where the current implementation fails

    seed = 159
    np.random.seed(seed)

    n, m = np.sort(np.random.randint(2, 4, size=2))
    A = 1.*np.random.randint(-99, 99, size=[m, n])
    b = 1.*np.random.randint(-99, 99, size=[m])
    bounds = 1.*np.sort(np.random.randint(-99, 99, size=(2, n)), 0)

    print("seed", seed, "dims:", m, n, "rank: ", np.linalg.matrix_rank(A))
    print(A)
    print(b)
    print(bounds)
    print("")

    x2 = optimize.lsq_linear(A, b, bounds=bounds, method='bvls', verbose=2).x
    x3 = optimize.lsq_linear(A, b, bounds=bounds, method='trf', verbose=2).x

    print(f"   x_bvls = {x2}")
    print(f"    x_trf = {x3}\n")

    chi2_2 = chi2(A @ x2 - b)
    chi2_3 = chi2(A @ x3 - b)
    chi2min = min(chi2_2, chi2_3)

    print(f"rel_err   bvls: {chi2_2/chi2min - 1:.2e}")
    print(f"rel_err    trf: {chi2_3/chi2min - 1:.2e}")

And here is the corresponding output of Scipy 1.5

    seed 159 dims: 3 3 rank:  3

    [[ 49.  41. -32.]
     [-19. -32.  -8.]
     [-13.  10.  69.]]

    [-41. -90.  47.]

    [[ 31. -44.  26.]
     [ 54. -32.  28.]]

    Iteration        Cost      Cost reduction    Step norm     Optimality   
           0         7.4506e+05                                    4.80e+04    
           1         3.5282e+05      3.92e+05       1.64e+01       1.68e+04    
           2         2.4232e+05      1.11e+05       1.03e+01       1.14e+04    
    The relative change of the cost function is less than `tol`.
    Number of iterations 3, initial cost 7.4506e+05, final cost 2.4232e+05, first-order optimality 1.14e+04.

       Iteration        Cost      Cost reduction    Step norm     Optimality   
           0         8.0576e+05                                    1.05e+06    
           1         3.9417e+05      4.12e+05       8.77e+00       2.59e+05    
           2         2.8801e+05      1.06e+05       5.67e+00       6.47e+04    
           3         2.3206e+05      5.60e+04       5.84e+00       1.08e+04    
           4         2.1981e+05      1.22e+04       1.60e+00       6.26e+02    
           5         2.1920e+05      6.11e+02       2.46e-01       1.73e+02    
           6         2.1915e+05      4.84e+01       1.21e-01       4.13e+01    
           7         2.1914e+05      7.86e+00       5.52e-02       8.58e+00    
           8         2.1914e+05      7.29e-01       1.95e-02       1.15e+00    
           9         2.1914e+05      1.83e-02       3.49e-03       4.08e-02    
          10         2.1914e+05      2.47e-05       1.33e-04       4.93e-05    
          11         2.1914e+05      2.43e-10       1.61e-07       1.35e-10    
    The relative change of the cost function is less than `tol`.
    Number of iterations 12, initial cost 8.0576e+05, final cost 2.1914e+05, first-order optimality 1.35e-10.

       x_bvls = [ 54.         -39.82549256  26.        ]
        x_trf = [ 54.         -43.89055258  26.        ]

    rel_err   bvls: 1.06e-01
    rel_err    trf: 0.00e+00

#### Additional information

The current implementation fails in various other examples, with more realistic larger arrays, and especially when the matrix A is rank deficient. However, I selected a very simple example to make it easy to understand what the code is doing differently in the proposed changes.

