### PR TITLE
MAINT: Use platform.python_implementation to determine IS_PYPY

### DIFF
--- a/scipy/_lib/_gcutils.py
+++ b/scipy/_lib/_gcutils.py
@@ -11,14 +11,14 @@ Module for testing automatic garbage collection of objects
 """
 import weakref
 import gc
-import sys
 
 from contextlib import contextmanager
+from platform import python_implementation
 
 __all__ = ['set_gc_state', 'gc_state', 'assert_deallocated']
 
 
-IS_PYPY = '__pypy__' in sys.modules
+IS_PYPY = python_implementation() == 'PyPy'
 
 
 class ReferenceError(AssertionError):

--- a/scipy/io/netcdf.py
+++ b/scipy/io/netcdf.py
@@ -34,11 +34,11 @@ which has a similar API.
 __all__ = ['netcdf_file', 'netcdf_variable']
 
 
-import sys
 import warnings
 import weakref
 from operator import mul
 from collections import OrderedDict
+from platform import python_implementation
 
 import mmap as mm
 
@@ -49,7 +49,7 @@ from numpy import little_endian as LITTLE_ENDIAN
 from functools import reduce
 
 
-IS_PYPY = ('__pypy__' in sys.modules)
+IS_PYPY = python_implementation() == 'PyPy'
 
 ABSENT = b'\x00\x00\x00\x00\x00\x00\x00\x00'
 ZERO = b'\x00\x00\x00\x00'


### PR DESCRIPTION
I noticed this in a test and it seems less hacky.

https://docs.python.org/3/library/platform.html#platform.python_implementation

After this change these are the mentions of to 'PyPy' in non c/cxx files
```
$ grep -ri --exclude={*.c,*.cxx} 'pypy' scipy
scipy/_lib/tests/test__gcutils.py:                                 ReferenceError, IS_PYPY)
scipy/_lib/tests/test__gcutils.py:@pytest.mark.skipif(IS_PYPY, reason="Test not meaningful on PyPy") (4 copies)
scipy/_lib/_gcutils.py:IS_PYPY = python_implementation() == 'PyPy'
scipy/_lib/_gcutils.py:    This check is not available on PyPy.
scipy/_lib/_gcutils.py:    if IS_PYPY:
scipy/_lib/_gcutils.py:        raise RuntimeError("assert_deallocated is unavailable on PyPy")
scipy/interpolate/tests/test_interpolate.py:from scipy._lib._gcutils import assert_deallocated, IS_PYPY
scipy/interpolate/tests/test_interpolate.py:    @pytest.mark.skipif(IS_PYPY, reason="Test not meaningful on PyPy")
scipy/integrate/_quad_vec.py:        # occurs on pypy
scipy/io/tests/test_netcdf.py:from scipy.io.netcdf import netcdf_file, IS_PYPY
scipy/io/tests/test_netcdf.py:            # Using mmap is the default (but not on pypy)
scipy/io/tests/test_netcdf.py:            assert_equal(f.use_mmap, not IS_PYPY)
scipy/io/tests/test_netcdf.py:            if IS_PYPY:
scipy/io/tests/test_netcdf.py:    if not IS_PYPY:
scipy/io/matlab/mio5.py:        # NumPy scalars are never mappings (PyPy issue workaround)
scipy/io/netcdf.py:IS_PYPY = python_implementation() == 'PyPy'
scipy/io/netcdf.py:                # Mmapped files on PyPy cannot be usually closed
scipy/io/netcdf.py:                mmap = (not IS_PYPY)
scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py:from scipy._lib._gcutils import assert_deallocated, IS_PYPY
scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py:@pytest.mark.skipif(IS_PYPY, reason="Test not meaningful on PyPy")
scipy/sparse/linalg/isolve/tests/test_lgmres.py:    @pytest.mark.skipif(python_implementation() == 'PyPy',
scipy/sparse/linalg/isolve/tests/test_lgmres.py:                        reason="Fails on PyPy CI runs. See #9507")
scipy/spatial/tests/test_kdtree.py:@pytest.mark.skipif(python_implementation() == 'PyPy',
scipy/spatial/tests/test_kdtree.py:                    reason="Fails on PyPy CI runs. See #9507")
scipy/spatial/qhull.pyx:        # call PyObject_GetAttrStr(self, "close") which on Pypy
```