### PR TITLE
TST: Enable previous disabled tests for PyPy

### DIFF
--- a/scipy/sparse/linalg/isolve/tests/test_lgmres.py
+++ b/scipy/sparse/linalg/isolve/tests/test_lgmres.py
@@ -5,7 +5,6 @@ from numpy.testing import (assert_, assert_allclose, assert_equal,
                            suppress_warnings)
 
 import pytest
-from platform import python_implementation
 
 import numpy as np
 from numpy import zeros, array, allclose
@@ -88,8 +87,6 @@ class TestLGMRES(object):
         assert_(count_1 < count_0/2)
         assert_(allclose(x1, x0, rtol=1e-14))
 
-    @pytest.mark.skipif(python_implementation() == 'PyPy',
-                        reason="Fails on PyPy CI runs. See #9507")
     def test_arnoldi(self):
         np.random.rand(1234)
 

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -6,7 +6,6 @@ from numpy.testing import (assert_equal, assert_array_equal, assert_,
                            assert_allclose)
 from pytest import raises as assert_raises
 import pytest
-from platform import python_implementation
 import numpy as np
 from scipy.spatial import KDTree, Rectangle, distance_matrix, cKDTree
 from scipy.spatial.ckdtree import cKDTreeNode
@@ -1142,8 +1141,6 @@ def simulate_periodic_box(kdtree, data, k, boxsize, p):
     return result['dd'][:, :k], result['ii'][:, :k]
 
 
-@pytest.mark.skipif(python_implementation() == 'PyPy',
-                    reason="Fails on PyPy CI runs. See #9507")
 def test_ckdtree_memuse():
     # unit test adaptation of gh-5630
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
#9507 and #9508 don't give any context for why we should expect these to be broken in PyPy, given it's been ~2 years I think it's worth testing if they are still broken. Locally they pass.

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->