### PR TITLE
DOC: add examples and tutorial links for interpolate functions which are missing Examples.

### DIFF
--- a/doc/source/tutorial/interpolate.rst
+++ b/doc/source/tutorial/interpolate.rst
@@ -147,6 +147,8 @@ that do not form a regular grid.
 Spline interpolation
 ====================
 
+.. _tutorial-interpolate_splXXX:
+
 Spline interpolation in 1-D: Procedural (interpolate.splXXX)
 ------------------------------------------------------------
 
@@ -222,6 +224,17 @@ example that follows.
    >>> plt.legend(['Cubic Spline', 'True'])
    >>> plt.axis([-0.05, 6.33, -1.05, 1.05])
    >>> plt.title('Derivative estimation from spline')
+   >>> plt.show()
+
+   All derivatives of spline
+
+   >>> yders = interpolate.spalde(xnew, tck)
+   >>> plt.figure()
+   >>> for i in range(len(yders[0])):
+   ...    plt.plot(xnew, [d[i] for d in yders], '--', label=f"{i} derivative")
+   >>> plt.legend()
+   >>> plt.axis([-0.05, 6.33, -1.05, 1.05])
+   >>> plt.title('All derivatives of a B-spline')
    >>> plt.show()
 
    Integral of spline
@@ -342,9 +355,10 @@ spline.
    >>> plt.title('Spline with Specified Interior Knots')
    >>> plt.show()
 
+.. _tutorial-interpolate_2d_spline:
 
 2-D spline representation: Procedural (:func:`bisplrep`)
---------------------------------------------------------------------
+-----------------------------------------------------------------
 
 For (smooth) spline-fitting to a 2-D surface, the function
 :func:`bisplrep` is available. This function takes as required inputs

--- a/doc/source/tutorial/interpolate.rst
+++ b/doc/source/tutorial/interpolate.rst
@@ -358,7 +358,7 @@ spline.
 .. _tutorial-interpolate_2d_spline:
 
 2-D spline representation: Procedural (:func:`bisplrep`)
------------------------------------------------------------------
+--------------------------------------------------------------------
 
 For (smooth) spline-fitting to a 2-D surface, the function
 :func:`bisplrep` is available. This function takes as required inputs

--- a/scipy/interpolate/_fitpack_impl.py
+++ b/scipy/interpolate/_fitpack_impl.py
@@ -883,6 +883,10 @@ def bisplrep(x, y, z, w=None, xb=None, xe=None, yb=None, ye=None,
     .. [3] Dierckx P.:Curve and surface fitting with splines, Monographs on
        Numerical Analysis, Oxford University Press, 1993.
 
+    Examples
+    --------
+    Examples are given :ref:`in the tutorial <tutorial-interpolate_2d_spline>`.
+
     """
     x, y, z = map(ravel, [x, y, z])  # ensure 1-d arrays.
     m = len(x)
@@ -1031,6 +1035,10 @@ def bisplev(x, y, tck, dx=0, dy=0):
        report tw50, Dept. Computer Science,K.U.Leuven, 1980.
     .. [3] Dierckx P. : Curve and surface fitting with splines,
        Monographs on Numerical Analysis, Oxford University Press, 1993.
+
+    Examples
+    --------
+    Examples are given :ref:`in the tutorial <tutorial-interpolate_2d_spline>`.
 
     """
     tx, ty, c, kx, ky = tck

--- a/scipy/interpolate/fitpack.py
+++ b/scipy/interpolate/fitpack.py
@@ -285,7 +285,8 @@ def splrep(x, y, w=None, xb=None, xe=None, k=3, task=0, s=None, t=None,
     >>> plt.plot(x, y, 'o', x2, y2)
     >>> plt.show()
 
-    Further examples are given :ref:`in the tutorial <tutorial-interpolate_splXXX>`.
+    Further examples are given
+    :ref:`in the tutorial <tutorial-interpolate_splXXX>`.
 
     """
     res = _impl.splrep(x, y, w, xb, xe, k, task, s, t, full_output, per, quiet)

--- a/scipy/interpolate/fitpack.py
+++ b/scipy/interpolate/fitpack.py
@@ -597,19 +597,19 @@ def insert(x, tck, m=1, per=0):
     >>> y = np.sin(x)
     >>> tck = splrep(x, y)
     >>> tck[0]
-    [ 0.  0.  0.  0.  5. 10. 10. 10. 10.]
+    array([ 0.,  0.,  0.,  0.,  5., 10., 10., 10., 10.])
 
     A knot is inserted:
 
     >>> tck_inserted = insert(3, tck)
     >>> tck_inserted[0]
-    [ 0.  0.  0.  0.  3.  5. 10. 10. 10. 10.]
+    array([ 0.,  0.,  0.,  0.,  3.,  5., 10., 10., 10., 10.])
 
     Some knots are inserted:
 
     >>> tck_inserted2 = insert(8, tck, m=3)
     >>> tck_inserted2[0]
-    [ 0.  0.  0.  0.  5.  8.  8.  8. 10. 10. 10. 10.]
+    array([ 0.,  0.,  0.,  0.,  5.,  8.,  8.,  8., 10., 10., 10., 10.])
 
     """
     if isinstance(tck, BSpline):

--- a/scipy/interpolate/fitpack.py
+++ b/scipy/interpolate/fitpack.py
@@ -273,6 +273,7 @@ def splrep(x, y, w=None, xb=None, xe=None, k=3, task=0, s=None, t=None,
 
     Examples
     --------
+    You can interpolate 1-D points with a B-spline curve:
 
     >>> import matplotlib.pyplot as plt
     >>> from scipy.interpolate import splev, splrep

--- a/scipy/interpolate/fitpack.py
+++ b/scipy/interpolate/fitpack.py
@@ -285,8 +285,7 @@ def splrep(x, y, w=None, xb=None, xe=None, k=3, task=0, s=None, t=None,
     >>> plt.plot(x, y, 'o', x2, y2)
     >>> plt.show()
 
-    Further examples are given
-    :ref:`in the tutorial <tutorial-interpolate_splXXX>`.
+    Further example is given :ref:`in the tutorial <tutorial-interpolate_splXXX>`.
 
     """
     res = _impl.splrep(x, y, w, xb, xe, k, task, s, t, full_output, per, quiet)

--- a/scipy/interpolate/fitpack.py
+++ b/scipy/interpolate/fitpack.py
@@ -273,8 +273,9 @@ def splrep(x, y, w=None, xb=None, xe=None, k=3, task=0, s=None, t=None,
 
     Examples
     --------
-    You can interpolate 1-D points with a B-spline curve:
-    Further examples are given :ref:`in the tutorial <tutorial-interpolate_splXXX>`.
+    You can interpolate 1-D points with a B-spline curve.
+    Further examples are given in
+    :ref:`in the tutorial <tutorial-interpolate_splXXX>`.
 
     >>> import matplotlib.pyplot as plt
     >>> from scipy.interpolate import splev, splrep

--- a/scipy/interpolate/fitpack.py
+++ b/scipy/interpolate/fitpack.py
@@ -273,16 +273,7 @@ def splrep(x, y, w=None, xb=None, xe=None, k=3, task=0, s=None, t=None,
 
     Examples
     --------
-
-    >>> import matplotlib.pyplot as plt
-    >>> from scipy.interpolate import splev, splrep
-    >>> x = np.linspace(0, 10, 10)
-    >>> y = np.sin(x)
-    >>> spl = splrep(x, y)
-    >>> x2 = np.linspace(0, 10, 200)
-    >>> y2 = splev(x2, spl)
-    >>> plt.plot(x, y, 'o', x2, y2)
-    >>> plt.show()
+    Examples are given :ref:`in the tutorial <tutorial-interpolate_splXXX>`.
 
     """
     res = _impl.splrep(x, y, w, xb, xe, k, task, s, t, full_output, per, quiet)
@@ -348,6 +339,10 @@ def splev(x, tck, der=0, ext=0):
     .. [3] P. Dierckx, "Curve and surface fitting with splines", Monographs
         on Numerical Analysis, Oxford University Press, 1993.
 
+    Examples
+    --------
+    Examples are given :ref:`in the tutorial <tutorial-interpolate_splXXX>`.
+
     """
     if isinstance(tck, BSpline):
         if tck.c.ndim > 1:
@@ -412,6 +407,10 @@ def splint(a, b, tck, full_output=0):
     .. [2] P. Dierckx, "Curve and surface fitting with splines", Monographs
         on Numerical Analysis, Oxford University Press, 1993.
 
+    Examples
+    --------
+    Examples are given :ref:`in the tutorial <tutorial-interpolate_splXXX>`.
+
     """
     if isinstance(tck, BSpline):
         if tck.c.ndim > 1:
@@ -472,6 +471,10 @@ def sproot(tck, mest=10):
     .. [3] P. Dierckx, "Curve and surface fitting with splines", Monographs
         on Numerical Analysis, Oxford University Press, 1993.
 
+    Examples
+    --------
+    Examples are given :ref:`in the tutorial <tutorial-interpolate_splXXX>`.
+
     """
     if isinstance(tck, BSpline):
         if tck.c.ndim > 1:
@@ -525,6 +528,10 @@ def spalde(x, tck):
        applics 10 (1972) 134-149.
     .. [3] P. Dierckx : Curve and surface fitting with splines, Monographs on
        Numerical Analysis, Oxford University Press, 1993.
+
+    Examples
+    --------
+    Examples are given :ref:`in the tutorial <tutorial-interpolate_splXXX>`.
 
     """
     if isinstance(tck, BSpline):
@@ -580,6 +587,29 @@ def insert(x, tck, m=1, per=0):
         Computer Aided Design, 12, p.199-201, 1980.
     .. [2] P. Dierckx, "Curve and surface fitting with splines, Monographs on
         Numerical Analysis", Oxford University Press, 1993.
+
+    Examples
+    --------
+    You can insert knots into a B-spline.
+
+    >>> from scipy.interpolate import splrep, insert
+    >>> x = np.linspace(0, 10, 5)
+    >>> y = np.sin(x)
+    >>> tck = splrep(x, y)
+    >>> tck[0]
+    [ 0.  0.  0.  0.  5. 10. 10. 10. 10.]
+
+    A knot is inserted:
+
+    >>> tck_inserted = insert(3, tck)
+    >>> tck_inserted[0]
+    [ 0.  0.  0.  0.  3.  5. 10. 10. 10. 10.]
+
+    Some knots are inserted:
+
+    >>> tck_inserted2 = insert(8, tck, m=3)
+    >>> tck_inserted2[0]
+    [ 0.  0.  0.  0.  5.  8.  8.  8. 10. 10. 10. 10.]
 
     """
     if isinstance(tck, BSpline):

--- a/scipy/interpolate/fitpack.py
+++ b/scipy/interpolate/fitpack.py
@@ -273,7 +273,18 @@ def splrep(x, y, w=None, xb=None, xe=None, k=3, task=0, s=None, t=None,
 
     Examples
     --------
-    Examples are given :ref:`in the tutorial <tutorial-interpolate_splXXX>`.
+
+    >>> import matplotlib.pyplot as plt
+    >>> from scipy.interpolate import splev, splrep
+    >>> x = np.linspace(0, 10, 10)
+    >>> y = np.sin(x)
+    >>> spl = splrep(x, y)
+    >>> x2 = np.linspace(0, 10, 200)
+    >>> y2 = splev(x2, spl)
+    >>> plt.plot(x, y, 'o', x2, y2)
+    >>> plt.show()
+
+    Further examples are given :ref:`in the tutorial <tutorial-interpolate_splXXX>`.
 
     """
     res = _impl.splrep(x, y, w, xb, xe, k, task, s, t, full_output, per, quiet)

--- a/scipy/interpolate/fitpack.py
+++ b/scipy/interpolate/fitpack.py
@@ -274,6 +274,7 @@ def splrep(x, y, w=None, xb=None, xe=None, k=3, task=0, s=None, t=None,
     Examples
     --------
     You can interpolate 1-D points with a B-spline curve:
+    Further examples are given :ref:`in the tutorial <tutorial-interpolate_splXXX>`.
 
     >>> import matplotlib.pyplot as plt
     >>> from scipy.interpolate import splev, splrep
@@ -284,8 +285,6 @@ def splrep(x, y, w=None, xb=None, xe=None, k=3, task=0, s=None, t=None,
     >>> y2 = splev(x2, spl)
     >>> plt.plot(x, y, 'o', x2, y2)
     >>> plt.show()
-
-    Further example is given :ref:`in the tutorial <tutorial-interpolate_splXXX>`.
 
     """
     res = _impl.splrep(x, y, w, xb, xe, k, task, s, t, full_output, per, quiet)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
fix a part of #7168 

#### What does this implement/fix?
Almost Examples missing functions have examples in its tutorial, so, I I added the tutorial link for these docstrings.
But, the tutorial did not use `spalde`, so I updated the tutorial for it.
`insert` function did not have examples, so I added it.


