### PR TITLE
BUG: use special.sindg in ndimage.rotate

### DIFF
--- a/scipy/ndimage/interpolation.py
+++ b/scipy/ndimage/interpolation.py
@@ -34,6 +34,7 @@ import warnings
 import numpy
 from numpy.core.multiarray import normalize_axis_index
 
+from scipy import special
 from . import _ni_support
 from . import _nd_image
 from ._ni_docstrings import docfiller
@@ -730,8 +731,7 @@ def rotate(input, angle, axes=(1, 0), reshape=True, output=None, order=3,
 
     axes.sort()
 
-    angle_rad = numpy.deg2rad(angle)
-    c, s = numpy.cos(angle_rad), numpy.sin(angle_rad)
+    c, s = special.cosdg(angle), special.sindg(angle)
 
     rot_matrix = numpy.array([[c, s],
                               [-s, c]])

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -2387,6 +2387,11 @@ class TestNdimage:
         out = ndimage.rotate(data, angle=12, reshape=False)
         assert_array_almost_equal(out, expected)
 
+    def test_rotate_exact_180(self):
+        a = numpy.tile(numpy.arange(5), (5, 1))
+        b = ndimage.rotate(ndimage.rotate(a, 180), -180)
+        assert_equal(a, b)
+
     def test_watershed_ift01(self):
         data = numpy.array([[0, 0, 0, 0, 0, 0, 0],
                             [0, 1, 1, 1, 1, 1, 0],


### PR DESCRIPTION
This makes `np.all(a == ndimage.rotate(ndimage.rotate(a, 180), -180))` be `True` when a has integral dtype.

Even if this isn't a perfect fix, there is no reason not to use `sindg` instead of converting to radians.  And getting this case correct is why these functions exist.

fixes gh-12543.
