### PR TITLE
BUG: per #12654 adjusted mudholkar_george method to combine p values

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -242,7 +242,6 @@ Mark Borgerding for contributing linalg.convolution_matrix.
 Shashaank N for contributions to scipy.signal.
 Frank Torres for fixing a bug with solve_bvp for large problems.
 Ben West for updating the Gamma distribution documentation.
-Will Tirone for contributing to scipy.stats
 
 Institutions
 ------------

--- a/THANKS.txt
+++ b/THANKS.txt
@@ -242,6 +242,7 @@ Mark Borgerding for contributing linalg.convolution_matrix.
 Shashaank N for contributions to scipy.signal.
 Frank Torres for fixing a bug with solve_bvp for large problems.
 Ben West for updating the Gamma distribution documentation.
+Will Tirone for contributing to scipy.stats
 
 Institutions
 ------------

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -7552,10 +7552,11 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
         statistic = -2 * np.sum(np.log1p(-pvalues))
         pval = distributions.chi2.sf(statistic, 2 * len(pvalues))
     elif method == 'mudholkar_george':
+        normalizing_factor = np.sqrt(3/len(pvalues))/np.pi
         statistic = -np.sum(np.log(pvalues)) + np.sum(np.log1p(-pvalues))
         nu = 5 * len(pvalues) + 4
         approx_factor = np.sqrt(nu / (nu - 2))
-        pval = distributions.t.sf(statistic * approx_factor, nu)
+        pval = distributions.t.sf(statistic * normalizing_factor * approx_factor, nu)
     elif method == 'tippett':
         statistic = np.min(pvalues)
         pval = distributions.beta.sf(statistic, 1, len(pvalues))

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -5019,10 +5019,10 @@ class TestCombinePvalues(object):
     def test_tippett(self):
         Z, p = stats.combine_pvalues([.01, .2, .3], method='tippett')
         assert_approx_equal(p, 0.970299, significant=4)
-
+        
     def test_mudholkar_george(self):
-        Z, p = stats.combine_pvalues([.01, .2, .3], method='mudholkar_george')
-        assert_approx_equal(p, 3.7191571041915e-07, significant=4)
+        Z, p = stats.combine_pvalues([.1, .1, .1], method='mudholkar_george')
+        assert_approx_equal(p, 0.019462, significant=4)
 
     def test_mudholkar_george_equal_fisher_minus_pearson(self):
         Z, p = stats.combine_pvalues([.01, .2, .3], method='mudholkar_george')

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -5019,7 +5019,7 @@ class TestCombinePvalues(object):
     def test_tippett(self):
         Z, p = stats.combine_pvalues([.01, .2, .3], method='tippett')
         assert_approx_equal(p, 0.970299, significant=4)
-        
+
     def test_mudholkar_george(self):
         Z, p = stats.combine_pvalues([.1, .1, .1], method='mudholkar_george')
         assert_approx_equal(p, 0.019462, significant=4)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #12654: from discussion on issue, "scipy.stats.combine_pvalues seems to work incorrectly with method='mudholkar_george'"

#### What does this implement/fix?
"According to the original article approx_factor should be equal to np.sqrt(nu / (nu - 2)) / scipy.pi * np.sqrt(3 / len(pvalues)), not np.sqrt(nu / (nu - 2))"

p-values are now calculated correctly as described in the [article](https://www.researchgate.net/publication/235117023_The_Logit_Statistic_for_Combining_Probabilities_-_An_Overview)

#### Additional information
I've made a few attempts at contributing in the past but was unsuccessful, so please review carefully. I did the following: 

1. followed the scipy dev guide 
2. removed the old unit test that was comparing an incorrect value and added a new one 
3. All tests pass in test_stats.py 
4. Let me know what I need to do to credit @M1kss for the code - he adjusted the method and I edited / tested; I'm not sure what the usual protocol is here. 