### PR TITLE
ENH: Support complex-valued images and kernels for many ndimage filters

### DIFF
--- a/scipy/ndimage/_ni_support.py
+++ b/scipy/ndimage/_ni_support.py
@@ -65,17 +65,27 @@ def _normalize_sequence(input, rank):
     return normalized
 
 
-def _get_output(output, input, shape=None):
+def _get_output(output, input, shape=None, complex_output=False):
     if shape is None:
         shape = input.shape
     if output is None:
-        output = numpy.zeros(shape, dtype=input.dtype.name)
+        if not complex_output:
+            output = numpy.zeros(shape, dtype=input.dtype.name)
+        else:
+            complex_type = numpy.promote_types(input.dtype, numpy.complex64)
+            output = numpy.zeros(shape, dtype=complex_type)
     elif isinstance(output, (type, numpy.dtype)):
         # Classes (like `np.float32`) and dtypes are interpreted as dtype
+        if complex_output and numpy.dtype(output).kind != 'c':
+            raise RuntimeError("output must have complex dtype")
         output = numpy.zeros(shape, dtype=output)
     elif isinstance(output, str):
         output = numpy.typeDict[output]
+        if complex_output and numpy.dtype(output).kind != 'c':
+            raise RuntimeError("output must have complex dtype")
         output = numpy.zeros(shape, dtype=output)
     elif output.shape != shape:
         raise RuntimeError("output shape not correct")
+    elif complex_output and output.dtype.kind != 'c':
+        raise RuntimeError("output must have complex dtype")
     return output

--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -51,6 +51,26 @@ def _invalid_origin(origin, lenw):
     return (origin < -(lenw // 2)) or (origin > (lenw - 1) // 2)
 
 
+def _complex_via_real_components(func, input, weights, output, **kwargs):
+    """Complex convolution via a linear combination of real convolutions."""
+    complex_input = input.dtype.kind == 'c'
+    complex_weights = weights.dtype.kind == 'c'
+    if complex_input and complex_weights:
+        # real component of the output
+        func(input.real, weights.real, output=output.real, **kwargs)
+        output.real -= func(input.imag, weights.imag, output=None, **kwargs)
+        # imaginary component of the output
+        func(input.real, weights.imag, output=output.imag, **kwargs)
+        output.imag += func(input.imag, weights.real, output=None, **kwargs)
+    elif complex_input:
+        func(input.real, weights, output=output.real, **kwargs)
+        func(input.imag, weights, output=output.imag, **kwargs)
+    else:
+        func(input, weights.real, output=output.real, **kwargs)
+        func(input, weights.imag, output=output.imag, **kwargs)
+    return output
+
+
 @_ni_docstrings.docfiller
 def correlate1d(input, weights, axis=-1, output=None, mode="reflect",
                 cval=0.0, origin=0):
@@ -77,8 +97,17 @@ def correlate1d(input, weights, axis=-1, output=None, mode="reflect",
     array([ 8, 26,  8, 12,  7, 28, 36,  9])
     """
     input = numpy.asarray(input)
-    if numpy.iscomplexobj(input):
-        raise TypeError('Complex type not supported')
+    complex_input = input.dtype.kind == 'c'
+    complex_weights = weights.dtype.kind == 'c'
+    if complex_input or complex_weights:
+        if complex_weights:
+            weights = weights.conj()
+            weights = weights.astype(numpy.complex128, copy=False)
+        kwargs = dict(axis=axis, mode=mode, cval=cval, origin=origin)
+        output = _ni_support._get_output(output, input, complex_output=True)
+        return _complex_via_real_components(correlate1d, input, weights,
+                                            output, **kwargs)
+
     output = _ni_support._get_output(output, input)
     weights = numpy.asarray(weights, dtype=numpy.float64)
     if weights.ndim != 1 or weights.shape[0] < 1:
@@ -130,6 +159,9 @@ def convolve1d(input, weights, axis=-1, output=None, mode="reflect",
     origin = -origin
     if not len(weights) & 1:
         origin -= 1
+    if weights.dtype.kind == 'c':
+        # pre-conjugate here to counteract the conjugation in correlate1d
+        weights = weights.conj()
     return correlate1d(input, weights, axis, output, mode, cval, origin)
 
 
@@ -596,8 +628,20 @@ def gaussian_gradient_magnitude(input, sigma, output=None,
 def _correlate_or_convolve(input, weights, output, mode, cval, origin,
                            convolution):
     input = numpy.asarray(input)
-    if numpy.iscomplexobj(input):
-        raise TypeError('Complex type not supported')
+    complex_input = input.dtype.kind == 'c'
+    complex_weights = weights.dtype.kind == 'c'
+    if complex_input or complex_weights:
+        if complex_weights and not convolution:
+            # As for numpy.correlate, conjugate weights rather than input.
+            weights = weights.conj()
+        kwargs = dict(
+            mode=mode, cval=cval, origin=origin, convolution=convolution
+        )
+        output = _ni_support._get_output(output, input, complex_output=True)
+
+        return _complex_via_real_components(_correlate_or_convolve, input,
+                                            weights, output, **kwargs)
+
     origins = _ni_support._normalize_sequence(origin, input.ndim)
     weights = numpy.asarray(weights, dtype=numpy.float64)
     wshape = [ii for ii in weights.shape if ii > 0]

--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -160,6 +160,7 @@ def convolve1d(input, weights, axis=-1, output=None, mode="reflect",
     origin = -origin
     if not len(weights) & 1:
         origin -= 1
+    weights = numpy.asarray(weights)
     if weights.dtype.kind == 'c':
         # pre-conjugate here to counteract the conjugation in correlate1d
         weights = weights.conj()

--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -97,6 +97,7 @@ def correlate1d(input, weights, axis=-1, output=None, mode="reflect",
     array([ 8, 26,  8, 12,  7, 28, 36,  9])
     """
     input = numpy.asarray(input)
+    weights = numpy.asarray(weights)
     complex_input = input.dtype.kind == 'c'
     complex_weights = weights.dtype.kind == 'c'
     if complex_input or complex_weights:
@@ -628,6 +629,7 @@ def gaussian_gradient_magnitude(input, sigma, output=None,
 def _correlate_or_convolve(input, weights, output, mode, cval, origin,
                            convolution):
     input = numpy.asarray(input)
+    weights = numpy.asarray(weights)
     complex_input = input.dtype.kind == 'c'
     complex_weights = weights.dtype.kind == 'c'
     if complex_input or complex_weights:

--- a/scipy/ndimage/tests/__init__.py
+++ b/scipy/ndimage/tests/__init__.py
@@ -8,4 +8,6 @@ integer_types = [
 
 float_types = [numpy.float32, numpy.float64]
 
+complex_types = [numpy.complex64, numpy.complex128]
+
 types = integer_types + float_types

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -108,7 +108,6 @@ class TestNdimageFilters:
         with assert_raises(RuntimeError):
             convolve(array, kernel, output=output_real)
 
-
     def test_correlate01(self):
         array = numpy.array([1, 2])
         weights = numpy.array([2])
@@ -485,7 +484,6 @@ class TestNdimageFilters:
 
         y = ndimage.correlate1d(numpy.ones(1), numpy.ones(5), mode='mirror')
         assert_array_equal(y, numpy.array(5.))
-
 
     @pytest.mark.parametrize('dtype_kernel', complex_types)
     @pytest.mark.parametrize('dtype_input', types)

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -808,6 +808,13 @@ class TestNdimageFilters:
         output = ndimage.uniform_filter1d(array, size, origin=-1)
         assert_array_almost_equal([3, 5, 6], output)
 
+    def test_uniform01_complex(self):
+        array = numpy.array([2 + 1j, 4 + 2j, 6 + 3j], dtype=numpy.complex128)
+        size = 2
+        output = ndimage.uniform_filter1d(array, size, origin=-1)
+        assert_array_almost_equal([3, 5, 6], output.real)
+        assert_array_almost_equal([1.5, 2.5, 3], output.imag)
+
     def test_uniform02(self):
         array = numpy.array([1, 2, 3])
         filter_shape = [0]
@@ -841,6 +848,17 @@ class TestNdimageFilters:
         output = ndimage.uniform_filter(
             array, filter_shape, output=dtype_output)
         assert_array_almost_equal([[4, 6, 10], [10, 12, 16]], output)
+        assert_equal(output.dtype.type, dtype_output)
+
+    @pytest.mark.parametrize('dtype_array', complex_types)
+    @pytest.mark.parametrize('dtype_output', complex_types)
+    def test_uniform06_complex(self, dtype_array, dtype_output):
+        filter_shape = [2, 2]
+        array = numpy.array([[4, 8 + 5j, 12],
+                             [16, 20, 24]], dtype_array)
+        output = ndimage.uniform_filter(
+            array, filter_shape, output=dtype_output)
+        assert_array_almost_equal([[4, 6, 10], [10, 12, 16]], output.real)
         assert_equal(output.dtype.type, dtype_output)
 
     def test_minimum_filter01(self):

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -1,4 +1,5 @@
 ''' Some tests for filters '''
+import functools
 import math
 import numpy
 
@@ -12,14 +13,101 @@ from pytest import raises as assert_raises
 from scipy import ndimage
 from scipy.ndimage.filters import _gaussian_kernel1d, rank_filter
 
-from . import types, float_types
+from . import types, float_types, complex_types
 
 
 def sumsq(a, b):
     return math.sqrt(((a - b)**2).sum())
 
 
+def _complex_correlate(array, kernel, real_dtype, convolve=False):
+    """Utility to perform a reference complex-valued convolutions.
+
+    When convolve==False, correlation is performed instead
+    """
+    array = numpy.asarray(array)
+    kernel = numpy.asarray(kernel)
+    complex_array = array.dtype.kind == 'c'
+    complex_kernel = kernel.dtype.kind == 'c'
+    if array.ndim == 1:
+        func = ndimage.convolve1d if convolve else ndimage.correlate1d
+    else:
+        func = ndimage.convolve if convolve else ndimage.correlate
+    if not convolve:
+        kernel = kernel.conj()
+    if complex_array and complex_kernel:
+        output = (
+            func(array.real, kernel.real, output=real_dtype) -
+            func(array.imag, kernel.imag, output=real_dtype) +
+            1j * func(array.imag, kernel.real, output=real_dtype) +
+            1j * func(array.real, kernel.imag, output=real_dtype)
+        )
+    elif complex_array:
+        output = (
+            func(array.real, kernel, output=real_dtype) +
+            1j * func(array.imag, kernel, output=real_dtype)
+        )
+    elif complex_kernel:
+        output = (
+            func(array, kernel.real, output=real_dtype) +
+            1j * func(array, kernel.imag, output=real_dtype)
+        )
+    return output
+
+
 class TestNdimageFilters:
+
+    def _validate_complex(self, array, kernel, type2):
+        # utility for validating complex-valued correlations
+        real_dtype = numpy.asarray([], dtype=type2).real.dtype
+        expected = _complex_correlate(
+            array, kernel, real_dtype, convolve=False
+        )
+
+        if array.ndim == 1:
+            correlate = functools.partial(ndimage.correlate1d, axis=-1)
+            convolve = functools.partial(ndimage.convolve1d, axis=-1)
+        else:
+            correlate = ndimage.correlate
+            convolve = ndimage.convolve
+
+        # test correlate output dtype
+        output = correlate(array, kernel, output=type2)
+        assert_array_almost_equal(expected, output)
+        assert_equal(output.dtype.type, type2)
+
+        # test correlate with pre-allocated output
+        output = numpy.zeros_like(array, dtype=type2)
+        correlate(array, kernel, output=output)
+        assert_array_almost_equal(expected, output)
+
+        # test convolve output dtype
+        output = convolve(array, kernel, output=type2)
+        expected = _complex_correlate(
+            array, kernel, real_dtype, convolve=True
+        )
+        assert_array_almost_equal(expected, output)
+        assert_equal(output.dtype.type, type2)
+
+        # convolve with pre-allocated output
+        convolve(array, kernel, output=output)
+        assert_array_almost_equal(expected, output)
+        assert_equal(output.dtype.type, type2)
+
+        # output cannot be real
+        with assert_raises(RuntimeError):
+            correlate(array, kernel, output=real_dtype)
+
+        with assert_raises(RuntimeError):
+            convolve(array, kernel, output=real_dtype)
+
+        output_real = numpy.zeros_like(array, dtype=real_dtype)
+        with assert_raises(RuntimeError):
+            correlate(array, kernel, output=output_real)
+
+        with assert_raises(RuntimeError):
+            convolve(array, kernel, output=output_real)
+
 
     def test_correlate01(self):
         array = numpy.array([1, 2])
@@ -398,6 +486,63 @@ class TestNdimageFilters:
         y = ndimage.correlate1d(numpy.ones(1), numpy.ones(5), mode='mirror')
         assert_array_equal(y, numpy.array(5.))
 
+
+    @pytest.mark.parametrize('dtype_kernel', complex_types)
+    @pytest.mark.parametrize('dtype_input', types)
+    @pytest.mark.parametrize('dtype_output', complex_types)
+    def test_correlate_complex_kernel(self, dtype_input, dtype_kernel,
+                                      dtype_output):
+        kernel = numpy.array([[1, 0],
+                              [0, 1 + 1j]], dtype_kernel)
+        array = numpy.array([[1, 2, 3],
+                             [4, 5, 6]], dtype_input)
+        self._validate_complex(array, kernel, dtype_output)
+
+    @pytest.mark.parametrize('dtype_kernel', complex_types)
+    @pytest.mark.parametrize('dtype_input', types)
+    @pytest.mark.parametrize('dtype_output', complex_types)
+    def test_correlate1d_complex_kernel(self, dtype_input, dtype_kernel,
+                                        dtype_output):
+        kernel = numpy.array([1, 1 + 1j], dtype_kernel)
+        array = numpy.array([1, 2, 3, 4, 5, 6], dtype_input)
+        self._validate_complex(array, kernel, dtype_output)
+
+    @pytest.mark.parametrize('dtype_kernel', types)
+    @pytest.mark.parametrize('dtype_input', complex_types)
+    @pytest.mark.parametrize('dtype_output', complex_types)
+    def test_correlate_complex_input(self, dtype_input, dtype_kernel,
+                                     dtype_output):
+        kernel = numpy.array([[1, 0],
+                              [0, 1]], dtype_kernel)
+        array = numpy.array([[1, 2j, 3],
+                             [1 + 4j, 5, 6j]], dtype_input)
+        self._validate_complex(array, kernel, dtype_output)
+
+    @pytest.mark.parametrize('dtype_kernel', types)
+    @pytest.mark.parametrize('dtype_input', complex_types)
+    @pytest.mark.parametrize('dtype_output', complex_types)
+    def test_correlate1d_complex_input(self, dtype_input, dtype_kernel,
+                                       dtype_output):
+        kernel = numpy.array([1, 0, 1], dtype_kernel)
+        array = numpy.array([1, 2j, 3, 1 + 4j, 5, 6j], dtype_input)
+        self._validate_complex(array, kernel, dtype_output)
+
+    @pytest.mark.parametrize('dtype', complex_types)
+    @pytest.mark.parametrize('dtype_output', complex_types)
+    def test_correlate_complex_input_and_kernel(self, dtype, dtype_output):
+        kernel = numpy.array([[1, 0],
+                              [0, 1 + 1j]], dtype)
+        array = numpy.array([[1, 2j, 3],
+                             [1 + 4j, 5, 6j]], dtype)
+        self._validate_complex(array, kernel, dtype_output)
+
+    @pytest.mark.parametrize('dtype', complex_types)
+    @pytest.mark.parametrize('dtype_output', complex_types)
+    def test_correlate1d_complex_input_and_kernel(self, dtype, dtype_output):
+        kernel = numpy.array([1, 1 + 1j], dtype)
+        array = numpy.array([1, 2j, 3, 1 + 4j, 5, 6j], dtype)
+        self._validate_complex(array, kernel, dtype_output)
+
     def test_gauss01(self):
         input = numpy.array([[1, 2, 3],
                              [2, 4, 6]], numpy.float32)
@@ -460,7 +605,7 @@ class TestNdimageFilters:
         ndimage.gaussian_filter(input, 1.0, output=input)
         assert_array_almost_equal(output1, input)
 
-    @pytest.mark.parametrize('dtype', types)
+    @pytest.mark.parametrize('dtype', types + complex_types)
     def test_prewitt01(self, dtype):
         array = numpy.array([[3, 2, 5, 1, 4],
                              [5, 8, 3, 7, 1],
@@ -470,7 +615,7 @@ class TestNdimageFilters:
         output = ndimage.prewitt(array, 0)
         assert_array_almost_equal(t, output)
 
-    @pytest.mark.parametrize('dtype', types)
+    @pytest.mark.parametrize('dtype', types + complex_types)
     def test_prewitt02(self, dtype):
         array = numpy.array([[3, 2, 5, 1, 4],
                              [5, 8, 3, 7, 1],
@@ -481,7 +626,7 @@ class TestNdimageFilters:
         ndimage.prewitt(array, 0, output)
         assert_array_almost_equal(t, output)
 
-    @pytest.mark.parametrize('dtype', types)
+    @pytest.mark.parametrize('dtype', types + complex_types)
     def test_prewitt03(self, dtype):
         array = numpy.array([[3, 2, 5, 1, 4],
                              [5, 8, 3, 7, 1],
@@ -491,7 +636,7 @@ class TestNdimageFilters:
         output = ndimage.prewitt(array, 1)
         assert_array_almost_equal(t, output)
 
-    @pytest.mark.parametrize('dtype', types)
+    @pytest.mark.parametrize('dtype', types + complex_types)
     def test_prewitt04(self, dtype):
         array = numpy.array([[3, 2, 5, 1, 4],
                              [5, 8, 3, 7, 1],
@@ -500,7 +645,7 @@ class TestNdimageFilters:
         output = ndimage.prewitt(array, 1)
         assert_array_almost_equal(t, output)
 
-    @pytest.mark.parametrize('dtype', types)
+    @pytest.mark.parametrize('dtype', types + complex_types)
     def test_sobel01(sel, dtype):
         array = numpy.array([[3, 2, 5, 1, 4],
                              [5, 8, 3, 7, 1],
@@ -510,7 +655,7 @@ class TestNdimageFilters:
         output = ndimage.sobel(array, 0)
         assert_array_almost_equal(t, output)
 
-    @pytest.mark.parametrize('dtype', types)
+    @pytest.mark.parametrize('dtype', types + complex_types)
     def test_sobel02(self, dtype):
         array = numpy.array([[3, 2, 5, 1, 4],
                              [5, 8, 3, 7, 1],
@@ -521,7 +666,7 @@ class TestNdimageFilters:
         ndimage.sobel(array, 0, output)
         assert_array_almost_equal(t, output)
 
-    @pytest.mark.parametrize('dtype', types)
+    @pytest.mark.parametrize('dtype', types + complex_types)
     def test_sobel03(self, dtype):
         array = numpy.array([[3, 2, 5, 1, 4],
                              [5, 8, 3, 7, 1],
@@ -532,7 +677,7 @@ class TestNdimageFilters:
         output = ndimage.sobel(array, 1)
         assert_array_almost_equal(t, output)
 
-    @pytest.mark.parametrize('dtype', types)
+    @pytest.mark.parametrize('dtype', types + complex_types)
     def test_sobel04(self, dtype):
         array = numpy.array([[3, 2, 5, 1, 4],
                              [5, 8, 3, 7, 1],
@@ -542,7 +687,8 @@ class TestNdimageFilters:
         assert_array_almost_equal(t, output)
 
     @pytest.mark.parametrize('dtype',
-                             [numpy.int32, numpy.float32, numpy.float64])
+                             [numpy.int32, numpy.float32, numpy.float64,
+                              numpy.complex64, numpy.complex128])
     def test_laplace01(self, dtype):
         array = numpy.array([[3, 2, 5, 1, 4],
                              [5, 8, 3, 7, 1],
@@ -553,7 +699,8 @@ class TestNdimageFilters:
         assert_array_almost_equal(tmp1 + tmp2, output)
 
     @pytest.mark.parametrize('dtype',
-                             [numpy.int32, numpy.float32, numpy.float64])
+                             [numpy.int32, numpy.float32, numpy.float64,
+                              numpy.complex64, numpy.complex128])
     def test_laplace02(self, dtype):
         array = numpy.array([[3, 2, 5, 1, 4],
                              [5, 8, 3, 7, 1],
@@ -565,7 +712,8 @@ class TestNdimageFilters:
         assert_array_almost_equal(tmp1 + tmp2, output)
 
     @pytest.mark.parametrize('dtype',
-                             [numpy.int32, numpy.float32, numpy.float64])
+                             [numpy.int32, numpy.float32, numpy.float64,
+                              numpy.complex64, numpy.complex128])
     def test_gaussian_laplace01(self, dtype):
         array = numpy.array([[3, 2, 5, 1, 4],
                              [5, 8, 3, 7, 1],
@@ -576,7 +724,8 @@ class TestNdimageFilters:
         assert_array_almost_equal(tmp1 + tmp2, output)
 
     @pytest.mark.parametrize('dtype',
-                             [numpy.int32, numpy.float32, numpy.float64])
+                             [numpy.int32, numpy.float32, numpy.float64,
+                              numpy.complex64, numpy.complex128])
     def test_gaussian_laplace02(self, dtype):
         array = numpy.array([[3, 2, 5, 1, 4],
                              [5, 8, 3, 7, 1],
@@ -587,7 +736,7 @@ class TestNdimageFilters:
         ndimage.gaussian_laplace(array, 1.0, output)
         assert_array_almost_equal(tmp1 + tmp2, output)
 
-    @pytest.mark.parametrize('dtype', types)
+    @pytest.mark.parametrize('dtype', types + complex_types)
     def test_generic_laplace01(self, dtype):
         def derivative2(input, axis, output, mode, cval, a, b):
             sigma = [a, b / 2.0]
@@ -607,7 +756,8 @@ class TestNdimageFilters:
         assert_array_almost_equal(tmp, output)
 
     @pytest.mark.parametrize('dtype',
-                             [numpy.int32, numpy.float32, numpy.float64])
+                             [numpy.int32, numpy.float32, numpy.float64,
+                              numpy.complex64, numpy.complex128])
     def test_gaussian_gradient_magnitude01(self, dtype):
         array = numpy.array([[3, 2, 5, 1, 4],
                              [5, 8, 3, 7, 1],
@@ -620,7 +770,8 @@ class TestNdimageFilters:
         assert_array_almost_equal(expected, output)
 
     @pytest.mark.parametrize('dtype',
-                             [numpy.int32, numpy.float32, numpy.float64])
+                             [numpy.int32, numpy.float32, numpy.float64,
+                              numpy.complex64, numpy.complex128])
     def test_gaussian_gradient_magnitude02(self, dtype):
         array = numpy.array([[3, 2, 5, 1, 4],
                              [5, 8, 3, 7, 1],


### PR DESCRIPTION
#### Reference issue
None

#### What does this implement/fix?
This PR allows the functions within `scipy.ndimage.filters` that are based on correlation or convolution to operate on complex-valued `input` and/or with complex-valued `weights`. Examples are:

`convolve`, `correlate`, `gaussian_filter`, `laplace`, `prewitt`, `sobel`, `uniform_filter`, etc.

Complex values remain unsupported by `generic_filter` and the various rank filters.

#### Additional information
The `weights` in `ndimage.correlate` are conjugated. This definition of correlation is consistent with `numpy.correlate`, where the second argument is conjugated. It is also consistent with the definition used by `xcorr` and `xcorr2` in Matlab's signal processing toolbox.

The general approach is to decompose the convolution of two complex-valued components into a combination of four real-valued convolutions. These are the equivalent of the four terms on the right hand side of the complex scalar multiplication shown below:

**(a + jb) * (g + jh) = ag + jbg + jah - bh**

If either the `input` or `weights` are real then only two real-valued convolutions need to be combined.

This approach is MUCH simpler than modifying the underlying ndimage C code which does not currently have complex-value support anywhere. Adding it there would require much more work, not only in `ni_filters.c` but also in `ni_support.c`, because the line buffers used by ndimage are currently always allocated in (real) double precision.
