### PR TITLE
BUG: Fix DOP853 error norm for complex problems

### DIFF
--- a/scipy/integrate/_ivp/rk.py
+++ b/scipy/integrate/_ivp/rk.py
@@ -495,10 +495,10 @@ class DOP853(RungeKutta):
     def _estimate_error_norm(self, K, h, scale):
         err5 = np.dot(K.T, self.E5) / scale
         err3 = np.dot(K.T, self.E3) / scale
-        err5_norm_2 = np.linalg.norm(err5)
-        err3_norm_2 = np.linalg.norm(err3)
+        err5_norm_2 = np.linalg.norm(err5)**2
+        err3_norm_2 = np.linalg.norm(err3)**2
         if err5_norm_2 == 0 and err3_norm_2 == 0:
-            return 0
+            return 0.0
         denom = err5_norm_2 + 0.01 * err3_norm_2
         return np.abs(h) * err5_norm_2 / np.sqrt(denom * len(scale))
 

--- a/scipy/integrate/_ivp/rk.py
+++ b/scipy/integrate/_ivp/rk.py
@@ -495,8 +495,8 @@ class DOP853(RungeKutta):
     def _estimate_error_norm(self, K, h, scale):
         err5 = np.dot(K.T, self.E5) / scale
         err3 = np.dot(K.T, self.E3) / scale
-        err5_norm_2 = np.sum(err5**2)
-        err3_norm_2 = np.sum(err3**2)
+        err5_norm_2 = np.linalg.norm(err5)
+        err3_norm_2 = np.linalg.norm(err3)
         if err5_norm_2 == 0 and err3_norm_2 == 0:
             return 0
         denom = err5_norm_2 + 0.01 * err3_norm_2

--- a/scipy/integrate/_ivp/setup.py
+++ b/scipy/integrate/_ivp/setup.py
@@ -1,0 +1,12 @@
+
+def configuration(parent_package='', top_path=None):
+    from numpy.distutils.misc_util import Configuration
+
+    config = Configuration('_ivp', parent_package, top_path)
+    config.add_data_dir('tests')
+    return config
+
+
+if __name__ == '__main__':
+    from numpy.distutils.core import setup
+    setup(**configuration(top_path='').todict())

--- a/scipy/integrate/_ivp/tests/test_ivp.py
+++ b/scipy/integrate/_ivp/tests/test_ivp.py
@@ -232,24 +232,24 @@ def test_integration_complex():
         if method == 'DOP853':
             assert res.nfev < 50
         else:
-            assert_(res.nfev < 25)
+            assert res.nfev < 25
 
         if method == 'BDF':
             assert_equal(res.njev, 1)
-            assert_(res.nlu < 6)
+            assert res.nlu < 6
         else:
-            assert_equal(res.njev, 0)
-            assert_equal(res.nlu, 0)
+            assert res.njev == 0
+            assert res.nlu == 0
 
         y_true = sol_complex(res.t)
         e = compute_error(res.y, y_true, rtol, atol)
-        assert_(np.all(e < 5))
+        assert np.all(e < 5)
 
         yc_true = sol_complex(tc)
         yc = res.sol(tc)
         e = compute_error(yc, yc_true, rtol, atol)
 
-        assert_(np.all(e < 5))
+        assert np.all(e < 5)
 
 
 def test_integration_sparse_difference():

--- a/scipy/integrate/_ivp/tests/test_ivp.py
+++ b/scipy/integrate/_ivp/tests/test_ivp.py
@@ -137,7 +137,7 @@ def sol_complex(t):
 
 def compute_error(y, y_true, rtol, atol):
     e = (y - y_true) / (atol + rtol * np.abs(y_true))
-    return np.sqrt(np.sum(np.real(e * e.conj()), axis=0) / e.shape[0])
+    return np.sqrt(np.linalg.norm(e, axis=0) / e.shape[0])
 
 
 def test_integration():
@@ -230,7 +230,7 @@ def test_integration_complex():
         assert_equal(res.status, 0)
 
         if method == 'DOP853':
-            assert_(res.nfev < 35)
+            assert res.nfev < 50
         else:
             assert_(res.nfev < 25)
 

--- a/scipy/integrate/_ivp/tests/test_ivp.py
+++ b/scipy/integrate/_ivp/tests/test_ivp.py
@@ -137,7 +137,7 @@ def sol_complex(t):
 
 def compute_error(y, y_true, rtol, atol):
     e = (y - y_true) / (atol + rtol * np.abs(y_true))
-    return np.sqrt(np.linalg.norm(e, axis=0) / e.shape[0])
+    return np.linalg.norm(e, axis=0) / np.sqrt(e.shape[0])
 
 
 def test_integration():
@@ -230,7 +230,7 @@ def test_integration_complex():
         assert_equal(res.status, 0)
 
         if method == 'DOP853':
-            assert res.nfev < 50
+            assert res.nfev < 35
         else:
             assert res.nfev < 25
 

--- a/scipy/integrate/_ivp/tests/test_rk.py
+++ b/scipy/integrate/_ivp/tests/test_rk.py
@@ -26,3 +26,11 @@ def test_error_estimation(solver_class):
     error_estimate = solver._estimate_error(solver.K, step)
     error = solver.y - np.exp([step])
     assert_(np.abs(error) < np.abs(error_estimate))
+
+
+@pytest.mark.parametrize("solver_class", [RK23, RK45, DOP853])
+def test_error_estimation_complex(solver_class):
+    h = 0.2
+    solver = solver_class(lambda t, y: 1j * y, 0, [1j], 1, first_step=h)
+    err_norm = solver._estimate_error_norm(solver.K, h, scale=[1])
+    assert err_norm.dtype.kind == 'f'

--- a/scipy/integrate/_ivp/tests/test_rk.py
+++ b/scipy/integrate/_ivp/tests/test_rk.py
@@ -32,5 +32,6 @@ def test_error_estimation(solver_class):
 def test_error_estimation_complex(solver_class):
     h = 0.2
     solver = solver_class(lambda t, y: 1j * y, 0, [1j], 1, first_step=h)
+    solver.step()
     err_norm = solver._estimate_error_norm(solver.K, h, scale=[1])
-    assert err_norm.dtype.kind == 'f'
+    assert np.isrealobj(err_norm)


### PR DESCRIPTION
#### Reference issue
Fixes gh-11972, fixes gh-11260

#### What does this implement/fix?
Use `np.linal.norm(x)**2` instead of `np.sum(x**2)` for complex number support. I also noticed the tests in `_ivp` weren't being run when using `runtests.py` because the tests aren't packaged correctly.