### PR TITLE
CI: pin xdist for Azure windows

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -126,7 +126,7 @@ jobs:
       choco install -y mingw --forcex86 --force --version=6.4.0
     displayName: 'Install 32-bit mingw for 32-bit builds'
     condition: and(succeeded(), eq(variables['BITS'], 32))
-  - script: python -m pip install numpy cython==0.29.18 pybind11 pytest==5.4.3 pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath
+  - script: python -m pip install numpy cython==0.29.18 pybind11 pytest==5.4.3 pytest-timeout pytest-xdist==1.34.0 pytest-env pytest-cov Pillow mpmath
     displayName: 'Install dependencies'
   - powershell: |
       python -m pip install matplotlib


### PR DESCRIPTION
* pin `pytest-xdist` version in Azure Windows CI
to prevent new issue causing multiple CI failures

* the simple method of diagnosis was that `pytest-xdist`
`2.0.0` was released yesterday, so a bit of an educated
guess really

* note that we're also pinning `pytest` itself for these
multi-core Windows test jobs:
https://github.com/pytest-dev/pytest/issues/7592

I should get around to making this multi-line `pip` dep specification into a nicely-formatted multi line yaml spec, but keeping diff simple for now.