### PR TITLE
BENCH: skip benchmarks instead of hiding them when SCIPY_XSLOW=0

### DIFF
--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -90,3 +90,10 @@ Some things to consider:
   benchmark results when the benchmark did not previously have a
   manual ``version`` attribute, the automatically computed default
   values can be found in ``results/benchmark.json``.
+
+- Benchmark attributes such as ``params`` and ``param_names`` must be
+  the same regardless of whether some features are available, or
+  e.g. SCIPY_XSLOW=1 is set.
+
+  Instead, benchmarks that should not be run can be skipped by raising
+  ``NotImplementedError`` in ``setup()``.

--- a/benchmarks/benchmarks/common.py
+++ b/benchmarks/benchmarks/common.py
@@ -18,6 +18,13 @@ class Benchmark(object):
     pass
 
 
+def is_xslow():
+    try:
+        return int(os.environ.get('SCIPY_XSLOW', '0'))
+    except ValueError:
+        return False
+
+
 class LimitedParamBenchmark(Benchmark):
     """
     Limits parameter combinations to `max_number` choices, chosen
@@ -27,10 +34,7 @@ class LimitedParamBenchmark(Benchmark):
     num_param_combinations = 0
 
     def setup(self, *args, **kwargs):
-        try:
-            slow = int(os.environ.get('SCIPY_XSLOW', '0'))
-        except ValueError:
-            slow = False
+        slow = is_xslow()
 
         if slow:
             # no need to skip


### PR DESCRIPTION
The "xslow" benchmarks should not be hidden from asv when the
environment variable is not set, because then any results obtained for
them appear to be for non-existing benchmarks, and may be deleted and
will not be included in reporting. Instead, skip the benchmarks with the
usual mechanism.
