### PR TITLE
ENH: Add support for μ-law encoded PCM to scipy.io.wavfile.   This implementation decodes to 16-bit PCM.

### DIFF
--- a/scipy/io/wavfile.py
+++ b/scipy/io/wavfile.py
@@ -384,32 +384,45 @@ def _read_fmt_chunk(fid, is_big_endian):
     return (size, format_tag, channels, fs, bytes_per_second, block_align,
             bit_depth)
 
-# Source: https://github.com/coderByNeed/BOB404/blob/master/audio/compressions.py
-## :D G.711 µ LAw
-# :D MULAW decoding from 8bit integer to 16bit integer
+_mulaw_pcm_table = [
+        -32124,-31100,-30076,-29052,-28028,-27004,-25980,-24956,
+        -23932,-22908,-21884,-20860,-19836,-18812,-17788,-16764,
+        -15996,-15484,-14972,-14460,-13948,-13436,-12924,-12412,
+        -11900,-11388,-10876,-10364, -9852, -9340, -8828, -8316,
+        -7932, -7676, -7420, -7164, -6908, -6652, -6396, -6140,
+        -5884, -5628, -5372, -5116, -4860, -4604, -4348, -4092,
+        -3900, -3772, -3644, -3516, -3388, -3260, -3132, -3004,
+        -2876, -2748, -2620, -2492, -2364, -2236, -2108, -1980,
+        -1884, -1820, -1756, -1692, -1628, -1564, -1500, -1436,
+        -1372, -1308, -1244, -1180, -1116, -1052,  -988,  -924,
+        -876,  -844,  -812,  -780,  -748,  -716,  -684,  -652,
+        -620,  -588,  -556,  -524,  -492,  -460,  -428,  -396,
+        -372,  -356,  -340,  -324,  -308,  -292,  -276,  -260,
+        -244,  -228,  -212,  -196,  -180,  -164,  -148,  -132,
+        -120,  -112,  -104,   -96,   -88,   -80,   -72,   -64,
+        -56,   -48,   -40,   -32,   -24,   -16,    -8,     -1,
+        32124, 31100, 30076, 29052, 28028, 27004, 25980, 24956,
+        23932, 22908, 21884, 20860, 19836, 18812, 17788, 16764,
+        15996, 15484, 14972, 14460, 13948, 13436, 12924, 12412,
+        11900, 11388, 10876, 10364,  9852,  9340,  8828,  8316,
+        7932,  7676,  7420,  7164,  6908,  6652,  6396,  6140,
+        5884,  5628,  5372,  5116,  4860,  4604,  4348,  4092,
+        3900,  3772,  3644,  3516,  3388,  3260,  3132,  3004,
+        2876,  2748,  2620,  2492,  2364,  2236,  2108,  1980,
+        1884,  1820,  1756,  1692,  1628,  1564,  1500,  1436,
+        1372,  1308,  1244,  1180,  1116,  1052,   988,   924,
+        876,   844,   812,   780,   748,   716,   684,   652,
+        620,   588,   556,   524,   492,   460,   428,   396,
+        372,   356,   340,   324,   308,   292,   276,   260,
+        244,   228,   212,   196,   180,   164,   148,   132,
+        120,   112,   104,    96,    88,    80,    72,    64,
+        56,    48,    40,    32,    24,    16,     8,     0
+    ]
+
 def uLaw_d(i8bit):
-    i8bit &= 0xff # marginalising data larger than byte
-    i8bit ^= 0xff #flipping back bytes
-    sign = False
-    
-    if i8bit&0x80==0x80: # if it is signed negative 1000 0000
-        sign = True # bool option since sign is not really used
-        i8bit &= 0x7f # removing the sign of value
-    
-    
-    pos = ( (i8bit&0xf0) >> 4 )+5 # grabing initial value for mantisa
-    
-    # generating decoded data
-    decoded = i8bit&0xf # grabing 1st nibble from 8 bit integer
-    decoded <<= pos-4   # shifting by position -4 aka generating mantisa for 16 bit integer
-    decoded |= 1 << ( pos-5 ) # OR gate for specific bit
-    decoded |= 1<<pos   # OR gate for another specific bit
-    decoded -= 0x21 # removing the 10 0001 from value to generate exact value
-    
-    if not sign:
-        return decoded  # if positive number will be returned as is
-    else:
-        return -decoded # if negative the number will be returned inverted
+    i8bit &= 0xff
+    return _mulaw_pcm_table[i8bit]
+
 
 def _read_data_chunk(fid, format_tag, channels, bit_depth, is_big_endian,
                      block_align, mmap=False):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
N/A

#### What does this implement/fix?
Adds support for MULAW PCM formatted audio files to scipy.io.wavfile

#### Additional information
<!--Any additional information you think is important.-->