### PR TITLE
BUG: Avoid negative variances in circular statistics

### DIFF
--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -3415,8 +3415,9 @@ def circvar(samples, high=2*pi, low=0, axis=None, nan_policy='propagate'):
         sin_mean = sin_samp.sum(axis=axis) / nsum
         cos_mean = cos_samp.sum(axis=axis) / nsum
     R = hypot(sin_mean, cos_mean)
+    R = np.minimum(R, 1)  # hypot can go slightly above 1 due to rounding errors
 
-    return ((high - low)/2.0/pi)**2 * 2 * log(1/R)
+    return ((high - low)/2.0/pi)**2 * -2 * log(R)
 
 
 def circstd(samples, high=2*pi, low=0, axis=None, nan_policy='propagate'):
@@ -3469,5 +3470,6 @@ def circstd(samples, high=2*pi, low=0, axis=None, nan_policy='propagate'):
         sin_mean = sin_samp.sum(axis=axis) / nsum
         cos_mean = cos_samp.sum(axis=axis) / nsum
     R = hypot(sin_mean, cos_mean)
+    R = np.minimum(R, 1)  # hypot can go slightly above 1 due to rounding errors
 
     return ((high - low)/2.0/pi) * sqrt(-2*log(R))

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -3414,8 +3414,8 @@ def circvar(samples, high=2*pi, low=0, axis=None, nan_policy='propagate'):
         nsum[nsum == 0] = np.nan
         sin_mean = sin_samp.sum(axis=axis) / nsum
         cos_mean = cos_samp.sum(axis=axis) / nsum
-    R = hypot(sin_mean, cos_mean)
-    R = np.minimum(R, 1)  # hypot can go slightly above 1 due to rounding errors
+    # hypot can go slightly above 1 due to rounding errors
+    R = np.minimum(1, hypot(sin_mean, cos_mean))
 
     return ((high - low)/2.0/pi)**2 * -2 * log(R)
 
@@ -3469,7 +3469,7 @@ def circstd(samples, high=2*pi, low=0, axis=None, nan_policy='propagate'):
         nsum[nsum == 0] = np.nan
         sin_mean = sin_samp.sum(axis=axis) / nsum
         cos_mean = cos_samp.sum(axis=axis) / nsum
-    R = hypot(sin_mean, cos_mean)
-    R = np.minimum(R, 1)  # hypot can go slightly above 1 due to rounding errors
+    # hypot can go slightly above 1 due to rounding errors
+    R = np.minimum(1, hypot(sin_mean, cos_mean))
 
     return ((high - low)/2.0/pi) * sqrt(-2*log(R))

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -3415,7 +3415,8 @@ def circvar(samples, high=2*pi, low=0, axis=None, nan_policy='propagate'):
         sin_mean = sin_samp.sum(axis=axis) / nsum
         cos_mean = cos_samp.sum(axis=axis) / nsum
     # hypot can go slightly above 1 due to rounding errors
-    R = np.minimum(1, hypot(sin_mean, cos_mean))
+    with np.errstate(invalid='ignore'):
+        R = np.minimum(1, hypot(sin_mean, cos_mean))
 
     return ((high - low)/2.0/pi)**2 * -2 * log(R)
 
@@ -3470,6 +3471,7 @@ def circstd(samples, high=2*pi, low=0, axis=None, nan_policy='propagate'):
         sin_mean = sin_samp.sum(axis=axis) / nsum
         cos_mean = cos_samp.sum(axis=axis) / nsum
     # hypot can go slightly above 1 due to rounding errors
-    R = np.minimum(1, hypot(sin_mean, cos_mean))
+    with np.errstate(invalid='ignore'):
+        R = np.minimum(1, hypot(sin_mean, cos_mean))
 
     return ((high - low)/2.0/pi) * sqrt(-2*log(R))

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1638,6 +1638,17 @@ class TestCircFuncs(object):
         S2 = stats.circstd(x, high=360)
         assert_allclose(S2, S1, rtol=1e-4)
 
+    @pytest.mark.parametrize("test_func, numpy_func",
+                             [(stats.circmean, np.mean),
+                              (stats.circvar, np.var),
+                              (stats.circstd, np.std)])
+    def test_circfuncs_close(self, test_func, numpy_func):
+        # circfuncs should handle very similar inputs (gh-12740)
+        x = np.array([0.12675364631578953] * 10 + [0.12675365920187928] * 100)
+        circstat = test_func(x)
+        normal = numpy_func(x)
+        assert_allclose(circstat, normal, atol=1e-8)
+
     def test_circmean_axis(self):
         x = np.array([[355, 5, 2, 359, 10, 350],
                       [351, 7, 4, 352, 9, 349],


### PR DESCRIPTION
#### Reference issue
Fixes gh-12740

#### What does this implement/fix?
In the example, the inputs are so close that the result should be numerically 0. However, due to rounding errors the `hypot` comes out as above 1. Simply limiting the upper bound for `R` to 1 gives zero as expected.