### PR TITLE
MAINT, CI: Azure windows deps multiline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -126,11 +126,20 @@ jobs:
       choco install -y mingw --forcex86 --force --version=6.4.0
     displayName: 'Install 32-bit mingw for 32-bit builds'
     condition: and(succeeded(), eq(variables['BITS'], 32))
-  - script: python -m pip install numpy cython==0.29.18 pybind11 pytest==5.4.3 pytest-timeout pytest-xdist==1.34.0 pytest-env pytest-cov Pillow mpmath
+  - script: >-
+      python -m pip install
+      cython==0.29.18
+      matplotlib
+      mpmath
+      numpy
+      Pillow
+      pybind11
+      pytest==5.4.3
+      pytest-cov
+      pytest-env
+      pytest-timeout
+      pytest-xdist==1.34.0
     displayName: 'Install dependencies'
-  - powershell: |
-      python -m pip install matplotlib
-    displayName: 'Install matplotlib'
   # DLL resolution mechanics were changed in
   # Python 3.8: https://bugs.python.org/issue36085
   # While we normally leave adjustment of _distributor_init.py


### PR DESCRIPTION
* use proper yaml multiline syntax to split
the Azure CI Windows `pip` dependency line,
which is currently approaching 200 chars, to
an alphabetically-sorted list with 1 dependency
per line (for readability/cleaner diffs)

* for reference: https://yaml-multiline.info/

* there's also no longer a need for a separate step
for `matplotlib` install

* I realize some folks may prefer abstracting the
info to a file, although these are just the Windows
CI installs and that abstraction has been tried before
for i.e., Appveyor and isn't always consistently used anyway
