### PR TITLE
ENH: stats: Add an sf method to levy_l for improved precision.

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4127,6 +4127,9 @@ class levy_l_gen(rv_continuous):
         val = _norm_ppf((q + 1.0) / 2)
         return -1.0 / (val * val)
 
+    def _isf(self, p):
+        return -1/_norm_isf(p/2)**2
+
     def _stats(self):
         return np.inf, np.inf, np.nan, np.nan
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4119,6 +4119,10 @@ class levy_l_gen(rv_continuous):
         ax = abs(x)
         return 2 * _norm_cdf(1 / np.sqrt(ax)) - 1
 
+    def _sf(self, x):
+        ax = abs(x)
+        return 2 * _norm_sf(1 / np.sqrt(ax))
+
     def _ppf(self, q):
         val = _norm_ppf((q + 1.0) / 2)
         return -1.0 / (val * val)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3960,6 +3960,14 @@ def test_levy_l_sf():
     assert_allclose(y, expected, rtol=1e-13)
 
 
+def test_levy_l_isf():
+    # Test roundtrip sf(isf(p)), including a small input value.
+    p = np.array([3.0e-15, 0.25, 0.99])
+    x = stats.levy_l.isf(p)
+    q = stats.levy_l.sf(x)
+    assert_allclose(q, p, rtol=5e-14)
+
+
 def test_hypergeom_interval_1802():
     # these two had endless loops
     assert_equal(stats.hypergeom.interval(.95, 187601, 43192, 757),

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3948,6 +3948,18 @@ def test_levy_sf():
     assert_allclose(y, expected, rtol=1e-14)
 
 
+def test_levy_l_sf():
+    # Test levy_l.sf for small arguments.
+    x = np.array([-0.016, -0.01, -0.005, -0.0015])
+    # Expected values were calculated with mpmath.
+    expected = np.array([2.6644463892359302e-15,
+                         1.523970604832107e-23,
+                         2.0884875837625492e-45,
+                         5.302850374626878e-147])
+    y = stats.levy_l.sf(x)
+    assert_allclose(y, expected, rtol=1e-13)
+
+
 def test_hypergeom_interval_1802():
     # these two had endless loops
     assert_equal(stats.hypergeom.interval(.95, 187601, 43192, 757),


### PR DESCRIPTION
The CDF of `levy_l` is implemented as `2*F - 1`, where `F` is the output
of the CDF of the normal distribution evaluated at a function of x.  The
survival function is `1 - CDF = 1 - (2*F - 1) = 2*(1 - F) = 2*S`, where
`S` is the survival function of the normal distribution evaluated at the
same function of x.  By using that expression in the `_sf` method, we
avoid the subtraction that results in the catastrophic loss of precision.

A matching implementation for the inverse survival function is also added.