### PR TITLE
scipy.stats: rv_histogram fit method

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -8399,7 +8399,10 @@ class rv_histogram(rv_continuous):
     >>> data = scipy.stats.norm.rvs(size=100000, loc=0, scale=1.5, random_state=123)
     >>> hist = np.histogram(data, bins=100)
     >>> hist_dist = scipy.stats.rv_histogram(hist)
-
+    
+    As for continuous distribution, the fit method can be used
+    >>> # hist_dist = scipy.stats.rv_histogram( *scipy.stats.rv_histogram.fit(hist) )
+    
     Behaves like an ordinary scipy rv_continuous distribution
 
     >>> hist_dist.pdf(1.0)
@@ -8501,7 +8504,14 @@ class rv_histogram(rv_continuous):
         dct = super(rv_histogram, self)._updated_ctor_param()
         dct['histogram'] = self._histogram
         return dct
-
+    
+    def fit( data , **kwds ):
+        """
+        Fit the histogram of the data. Just call and return the value of the
+        function numpy.histogram, and takes the same arguments.
+        """
+        return np.histogram( data , **kwds )
+    
 
 # Collect names of classes and objects in this module.
 pairs = list(globals().items())

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -8401,7 +8401,7 @@ class rv_histogram(rv_continuous):
     >>> hist_dist = scipy.stats.rv_histogram(hist)
     
     As for continuous distribution, the fit method can be used
-    >>> # hist_dist = scipy.stats.rv_histogram( *scipy.stats.rv_histogram.fit(hist) )
+    >>> # hist_dist = scipy.stats.rv_histogram( *scipy.stats.rv_histogram.fit(data) )
     
     Behaves like an ordinary scipy rv_continuous distribution
 
@@ -8510,7 +8510,11 @@ class rv_histogram(rv_continuous):
         Fit the histogram of the data. Just call and return the value of the
         function numpy.histogram, and takes the same arguments.
         """
-        return np.histogram( data , **kwds )
+        bins = kwds.get("bins")
+        if bins is None:
+            bins = 100
+            kwds["bins"] = bins
+        return (np.histogram( data , **kwds ),bins)
     
 
 # Collect names of classes and objects in this module.


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
DEV: Overload the fit method of scipy.stats.rv_histogram. The
rv_histogram class can now be defined with the same syntax that
continuous distribution : rv_data = dist( *dist.fit(data) ).


Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
No reference ?

#### What does this implement/fix?
All continuous distribution can be defined with syntax
"dist( *dist.fit(data) )", except rv_histogram. I propose
a fit method for rv_histogram. An example has been
added to the documentation of rv_histogram class.

#### Additional information
Already implemented in "SBCK.tools.rv_histogram" class,
see the file "python/SBCK/tools/__rv_extend.py" of the 
repository  "https://github.com/yrobink/SBCK".