### PR TITLE
TST, MAINT: infeasible_2 context

### DIFF
--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -432,8 +432,13 @@ class LinprogCommonTests(object):
                 res = linprog(c, bounds=bounds, method=self.method, options=self.options)
                 return res
 
-            assert_raises(RuntimeWarning, g, c, bounds=bounds_1)
-            assert_raises(RuntimeWarning, g, c, bounds=bounds_2)
+            with pytest.warns(RuntimeWarning):
+                with pytest.raises(IndexError):
+                    g(c, bounds=bounds_1)
+
+            with pytest.warns(RuntimeWarning):
+                with pytest.raises(IndexError):
+                    g(c, bounds=bounds_2)
         else:
             res = linprog(c=c, bounds=bounds_1, method=self.method, options=self.options)
             _assert_infeasible(res)


### PR DESCRIPTION
Fixes #12578

* `test_bounds_infeasible_2` previously used `pytest.raises`
to catch a `RuntimeWarning`, but the behavior was not always
consistent in different environments, and the test started
failing on the wheels repo

* closer testing combined with feedback in gh-12578 suggests
that there are two separate behaviors that we can test for
here: a) `RuntimeWarning` related to Python operations involving
`inf`; b) an `IndexError` that may not be raised if the `RuntimeWarning`
is converted to an `Exception` first

* on balance, given that Python warnings capture is not thread safe
and that warnings->exception conversions can be controlled in various
config files, environment variables, and via `np.seterr(...)`, it seems
safer to be more specific/explicit about each of the behaviors we are
testing instead of assuming that the `RuntimeWarning` will be converted
to an error and caught first

* changing the object (type) specified for the warning or the exception
in either of the two cases triggers a test failure locally with the new
test code, which is at least an informal indicator of improved specificity