### PR TITLE
root_scalar: a new method that improves upon the Newton's method 

### DIFF
--- a/doc/source/optimize.root_scalar-exnewton.rst
+++ b/doc/source/optimize.root_scalar-exnewton.rst
@@ -1,0 +1,9 @@
+.. _optimize.root_scalar-exnewton:
+
+root_scalar(method='exnewton')
+------------------------------
+
+.. scipy-optimize:function:: scipy.optimize.root_scalar
+   :impl: scipy.optimize._root_scalar._root_scalar_exnewton_doc
+   :method: exnewton
+

--- a/scipy/optimize/__init__.py
+++ b/scipy/optimize/__init__.py
@@ -150,7 +150,7 @@ Scalar functions
    brenth - Brent method, modified by Harris with hyperbolic extrapolation.
    ridder - Ridder's method.
    bisect - Bisection method.
-   newton - Newton's method (also Secant and Halley's methods).
+   newton - Newton's method (also Secant, extended-Newton, and Halley's methods).
    toms748 - Alefeld, Potra & Shi Algorithm 748.
    RootResults - The root finding result returned by some root finders.
 
@@ -163,6 +163,7 @@ The `root_scalar` function supports the following methods:
    optimize.root_scalar-bisect
    optimize.root_scalar-ridder
    optimize.root_scalar-newton
+   optimize.root_scalar-exnewton
    optimize.root_scalar-toms748
    optimize.root_scalar-secant
    optimize.root_scalar-halley
@@ -194,6 +195,8 @@ functions defined on (a subset of) the complex plane.
 | `R` or `C`  | No       | No       | No        | secant      | No          | 1.62 (1.62)    |
 +-------------+----------+----------+-----------+-------------+-------------+----------------+
 | `R` or `C`  | No       | Yes      | No        | newton      | No          | 2.00 (1.41)    |
++-------------+----------+----------+-----------+-------------+-------------+----------------+
+| `R` or `C`  | No       | Yes      | No        | exnewton    | No	    | >2.00 (1.41)   |
 +-------------+----------+----------+-----------+-------------+-------------+----------------+
 | `R` or `C`  | No       | Yes      | Yes       | halley      | No          | 3.00 (1.44)    |
 +-------------+----------+----------+-----------+-------------+-------------+----------------+

--- a/scipy/optimize/_root_scalar.py
+++ b/scipy/optimize/_root_scalar.py
@@ -186,7 +186,7 @@ def root_scalar(f, args=(), method=None, bracket=None,
 
     >>> sol = optimize.root_scalar(f_p_pp, x0=0.2, fprime=True, method='exnewton')
     >>> sol.root, sol.iterations, sol.function_calls
-    (0.9999999999999999, 7, 15)
+    (0.9999999999999999, 7, 8)
 
     >>> sol = optimize.root_scalar(f_p_pp, x0=0.2, fprime=True, fprime2=True, method='halley')
     >>> sol.root, sol.iterations, sol.function_calls

--- a/scipy/optimize/_root_scalar.py
+++ b/scipy/optimize/_root_scalar.py
@@ -136,11 +136,15 @@ def root_scalar(f, args=(), method=None, bracket=None,
     select one of the derivative-based methods.
     If no method is judged applicable, it will raise an Exception.
 
-    Method :ref:`exnewton<optimize.root_scalar-exnewton>` uses the first derivative and an additional starting point to improve upon the traditional `newton` method, it is known as the "extended-Newton" method [1]_.
+    Method :ref:`exnewton<optimize.root_scalar-exnewton>` uses the 
+    first derivative and an additional starting point to improve 
+    upon the traditional `newton` method, 
+    it is known as the "extended-Newton" method [1]_.
 
     References
     ----------
-    .. [1] A. Aggarwal and S. Pant. "Beyond Newton: A New Root-Finding Fixed-Point Iteration for Nonlinear Equations," Algorithms 2020, 13, 78.
+    .. [1] A. Aggarwal and S. Pant. "Beyond Newton: A New Root-Finding 
+    Fixed-Point Iteration for Nonlinear Equations," Algorithms 2020, 13, 78.
        <https://doi.org/10.3390/a13040078>
 
     Examples

--- a/scipy/optimize/_root_scalar.py
+++ b/scipy/optimize/_root_scalar.py
@@ -169,7 +169,7 @@ def root_scalar(f, args=(), method=None, bracket=None,
 
     The :ref:`exnewton<optimize.root_scalar-exnewton>` method uses the first derivative
     and takes as input two points `x0` and `x1`.
-    `x1` is an optional argument. If not supplied, a perturbation of `x0` is used (:math:`x1=x0+\epsilon`).
+    `x1` is an optional argument. If not supplied, a perturbation of `x0` is used.
 
     >>> sol = optimize.root_scalar(f, x0=0.2, x1=0., fprime=fprime, method='exnewton')
     >>> sol.root, sol.iterations, sol.function_calls

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -3254,6 +3254,7 @@ def show_options(solver=None, method=None, disp=True):
             ('toms748', 'scipy.optimize._root_scalar._root_scalar_toms748_doc'),
             ('secant', 'scipy.optimize._root_scalar._root_scalar_secant_doc'),
             ('newton', 'scipy.optimize._root_scalar._root_scalar_newton_doc'),
+            ('exnewton', 'scipy.optimize._root_scalar._root_scalar_exnewton_doc'),
             ('halley', 'scipy.optimize._root_scalar._root_scalar_halley_doc'),
         ),
         'linprog': (

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -138,7 +138,7 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
     x1 : float, optional
         Another estimate of the zero that should be somewhere near the
         actual zero. Used with Secant method if `fprime` is not provided.
-	Otherwise, it is used with extended Newton method.
+        Otherwise, it is used with extended Newton method.
     rtol : float, optional
         Tolerance (relative) for termination.
     full_output : bool, optional


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### What does this implement/fix?
<!--Please explain your changes.-->
An "extended-Newton" method is implemented in root_scalar function based on https://doi.org/10.3390/a13040078 

This extension improves the domain of convergence, especially for non Lipschitz functions without any extra computation required (still uses only one function and first derivative evaluation per iteration). The only extra is a second guess x1, which if not supplied is assigned as a perturbation of x0. The new method can also be seen as a combination of Newton and secant methods, and somewhere between Newton's and Halley's methods.

#### Additional information
<!--Any additional information you think is important.-->
I have tried to maintain the backward compatability. The default options remain the same and the standard Newton continues to work as is. I have also added the necessary documentation for the new method. 