### PR TITLE
API: Rename cKDTree n_jobs argument to workers

### DIFF
--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -21,6 +21,8 @@ cimport cython
 
 from multiprocessing import cpu_count
 import threading
+import operator
+import warnings
 
 cdef extern from "<limits.h>":
     long LONG_MAX
@@ -379,6 +381,29 @@ cdef class cKDTreeNode:
             return self._indices[start:stop]
 
 
+cdef np.intp_t get_num_workers(workers: object, kwargs: dict) except -1:
+    """Handle the workers argument, translating the old n_jobs name"""
+    if workers is None:
+        if 'n_jobs' in kwargs:
+            warnings.warn('The n_jobs argument has been renamed "workers"',
+                          DeprecationWarning)
+            workers = kwargs.pop('n_jobs')
+        else:
+            workers = 1
+
+    if len(kwargs) > 0:
+        raise TypeError(
+            f"Unexpected keyword argument{'s' if len(kwargs) > 1 else ''} "
+            f"{kwargs}")
+
+    cdef np.intp_t n = operator.index(workers)
+    if n == -1:
+        n = number_of_processors
+    elif n <= 0:
+        raise ValueError(f'Invalid number of workers {workers}, must be -1 or > 0')
+    return n
+
+
 # Main cKDTree class
 # ==================
 
@@ -633,9 +658,9 @@ cdef class cKDTree:
     @cython.boundscheck(False)
     def query(cKDTree self, object x, object k=1, np.float64_t eps=0,
               np.float64_t p=2, np.float64_t distance_upper_bound=INFINITY,
-              np.intp_t n_jobs=1):
+              object workers=None, **kwargs):
         """
-        query(self, x, k=1, eps=0, p=2, distance_upper_bound=np.inf, n_jobs=1)
+        query(self, x, k=1, eps=0, p=2, distance_upper_bound=np.inf, workers=1)
 
         Query the kd-tree for nearest neighbors
 
@@ -662,9 +687,10 @@ cdef class cKDTree:
             tree searches, so if you are doing a series of nearest-neighbor
             queries, it may help to supply the distance to the nearest neighbor
             of the most recent point.
-        n_jobs : int, optional
-            Number of jobs to schedule for parallel processing. If -1 is given
-            all processors are used. Default: 1.
+        workers : int, optional
+            Number of workers to use for parallel processing. If -1 is given
+            all CPU threads are used. Default: 1.
+            Note: This argument was renamed from "n_jobs" in SciPy version 1.6.0
 
         Returns
         -------
@@ -742,6 +768,7 @@ cdef class cKDTree:
             const np.float64_t [:, ::1] xx
             np.ndarray x_arr = np.ascontiguousarray(x, dtype=np.float64)
             ckdtree *cself = self.cself
+            np.intp_t num_workers = get_num_workers(workers, kwargs)
 
         n = num_points(x_arr, cself.m)
         xx = x_arr.reshape(n, cself.m)
@@ -780,10 +807,7 @@ cdef class cKDTree:
                 query_knn(cself, pdd, pii,
                     pxx, stop-start, pkk, kk.shape[0], kmax, eps, p, distance_upper_bound)
 
-        if (n_jobs == -1):
-            n_jobs = number_of_processors
-
-        _run_threads(_thread_func, n, n_jobs)
+        _run_threads(_thread_func, n, num_workers)
 
         ddret = np.reshape(dd, retshape + (len(k),))
         iiret = np.reshape(ii, retshape + (len(k),))
@@ -803,11 +827,12 @@ cdef class cKDTree:
     # ----------------
 
     def query_ball_point(cKDTree self, object x, object r,
-                         np.float64_t p=2., np.float64_t eps=0, np.intp_t n_jobs=1,
+                         np.float64_t p=2., np.float64_t eps=0, object workers=None,
                          return_sorted=None,
-                         return_length=False):
+                         return_length=False, **kwargs):
         """
-        query_ball_point(self, x, r, p=2., eps=0)
+        query_ball_point(self, x, r, p=2., eps=0, workers=1, return_sorted=None,
+                         return_length=False)
 
         Find all points within distance r of point(s) x.
 
@@ -825,9 +850,10 @@ cdef class cKDTree:
             nearest points are further than ``r / (1 + eps)``, and branches are
             added in bulk if their furthest points are nearer than
             ``r * (1 + eps)``.
-        n_jobs : int, optional
+        workers : int, optional
             Number of jobs to schedule for parallel processing. If -1 is given
             all processors are used. Default: 1.
+            Note: This argument was renamed from "n_jobs" in SciPy version 1.6.0
         return_sorted : bool, optional
             Sorts returned indicies if True and does not sort them if False. If
             None, does not sort single point queries, but does sort
@@ -874,6 +900,7 @@ cdef class cKDTree:
             bool sort_output = return_sorted or (
                 return_sorted is None and x_arr.ndim > 1)
 
+            np.intp_t num_workers = get_num_workers(workers, kwargs)
             np.intp_t n = num_points(x_arr, cself.m)
             tuple retshape = np.shape(x_arr)[:-1]
             np.ndarray r_arr = broadcast_contiguous(r, shape=retshape,
@@ -920,11 +947,7 @@ cdef class cKDTree:
                     tmp[j] = cur[j]
                 vout[start + i] = tmp
 
-        # multithreading logic is similar to cKDTree.query
-        if n_jobs == -1:
-            n_jobs = number_of_processors
-
-        _run_threads(_thread_func, n, n_jobs)
+        _run_threads(_thread_func, n, num_workers)
 
         if x_arr.ndim == 1: # scalar query, unpack result.
             result = result[()]

--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -385,8 +385,10 @@ cdef np.intp_t get_num_workers(workers: object, kwargs: dict) except -1:
     """Handle the workers argument, translating the old n_jobs name"""
     if workers is None:
         if 'n_jobs' in kwargs:
-            warnings.warn('The n_jobs argument has been renamed "workers"',
-                          DeprecationWarning)
+            warnings.warn(
+                'The n_jobs argument has been renamed "workers". '
+                'The old name "n_jobs" will stop working in SciPy 1.8.0.',
+                DeprecationWarning)
             workers = kwargs.pop('n_jobs')
         else:
             workers = 1
@@ -690,7 +692,10 @@ cdef class cKDTree:
         workers : int, optional
             Number of workers to use for parallel processing. If -1 is given
             all CPU threads are used. Default: 1.
-            Note: This argument was renamed from "n_jobs" in SciPy version 1.6.0
+
+            .. versionchanged:: 1.6.0
+               The "n_jobs" argument was renamed "workers". The old name
+               "n_jobs" is deprecated and will stop working in SciPy 1.8.0.
 
         Returns
         -------
@@ -853,7 +858,11 @@ cdef class cKDTree:
         workers : int, optional
             Number of jobs to schedule for parallel processing. If -1 is given
             all processors are used. Default: 1.
-            Note: This argument was renamed from "n_jobs" in SciPy version 1.6.0
+
+            .. versionchanged:: 1.6.0
+               The "n_jobs" argument was renamed "workers". The old name
+               "n_jobs" is deprecated and will stop working in SciPy 1.8.0.
+
         return_sorted : bool, optional
             Sorts returned indicies if True and does not sort them if False. If
             None, does not sort single point queries, but does sort

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -491,9 +491,9 @@ def test_query_ball_point_multithreading():
     k = 2
     points = np.random.randn(n, k)
     T = cKDTree(points)
-    l1 = T.query_ball_point(points, 0.003, n_jobs=1)
-    l2 = T.query_ball_point(points, 0.003, n_jobs=64)
-    l3 = T.query_ball_point(points, 0.003, n_jobs=-1)
+    l1 = T.query_ball_point(points, 0.003, workers=1)
+    l2 = T.query_ball_point(points, 0.003, workers=64)
+    l3 = T.query_ball_point(points, 0.003, workers=-1)
 
     for i in range(n):
         if l1[i] or l2[i]:
@@ -502,6 +502,23 @@ def test_query_ball_point_multithreading():
     for i in range(n):
         if l1[i] or l3[i]:
             assert_array_equal(l1[i], l3[i])
+
+
+def test_n_jobs():
+    # Test for the deprecated argument name "n_jobs" aliasing "workers"
+    points = np.random.randn(50, 2)
+    T = cKDTree(points)
+    with pytest.deprecated_call(match="n_jobs argument has been renamed"):
+        T.query_ball_point(points, 0.003, n_jobs=1)
+
+    with pytest.deprecated_call(match="n_jobs argument has been renamed"):
+        T.query(points, 1, n_jobs=1)
+
+    with pytest.raises(TypeError, match="Unexpected keyword argument"):
+        T.query_ball_point(points, 0.003, workers=1, n_jobs=1)
+
+    with pytest.raises(TypeError, match="Unexpected keyword argument"):
+        T.query(points, 1, workers=1, n_jobs=1)
 
 
 class two_trees_consistency:
@@ -987,8 +1004,8 @@ def test_ckdtree_parallel():
     k = 4
     points = np.random.randn(n, k)
     T = cKDTree(points)
-    T1 = T.query(points, k=5, n_jobs=64)[-1]
-    T2 = T.query(points, k=5, n_jobs=-1)[-1]
+    T1 = T.query(points, k=5, workers=64)[-1]
+    T2 = T.query(points, k=5, workers=-1)[-1]
     T3 = T.query(points, k=5)[-1]
     assert_array_equal(T1, T2)
     assert_array_equal(T1, T3)


### PR DESCRIPTION
#### What does this implement/fix?
This renames the `n_jobs` argument for multithreaded `cKDTree` queries to `workers`. The justification for this is consistency with other SciPy functions. There aren't yet that many which offer multithreading, but a quick [search of the docs](https://docs.scipy.org/doc/scipy/reference/search.html?q=n_jobs) shows `cKDTree` is the only part of SciPy to use `n_jobs` as the convention, whereas [`workers`](https://docs.scipy.org/doc/scipy/reference/search.html?q=workers) is used in `scipy.fft`, `scipy.optimize.brute`, `scipy.optimize.differential_evolution` and `scipy.stats.multiscale_graphcorr`.

This PR maintains backwards compatibility by defaulting the workers argument to `None` and using `**kwargs` to allow the user to pass `n_jobs` as a keyword argument like before. If only `n_jobs` is passed, this gives a depreaction warning. If both `workers` and `n_jobs` is given, then this raises an error instead of silently ignoring one.

