### PR TITLE
Add new flag to authors tool 

### DIFF
--- a/tools/authors.py
+++ b/tools/authors.py
@@ -26,6 +26,8 @@ def main():
     p = optparse.OptionParser(__doc__.strip())
     p.add_option("-d", "--debug", action="store_true",
                  help="print debug output")
+    p.add_option("-n", "--new", action="store_true",
+                 help="print debug output")
     options, args = p.parse_args()
 
     if len(args) != 1:
@@ -96,6 +98,16 @@ def main():
         if surname.startswith(u'von '):
             surname = surname[4:]
         return (surname.lower(), forename.lower())
+
+    # generate set of all new authors
+    if vars(options)['new']:
+        new_authors = authors.difference(all_authors)
+        # Print some empty lines to separate
+        stdout_b.write(("\n\n").encode('utf-8'))
+        for author in new_authors:
+            stdout_b.write(("- %s\n" % author).encode('utf-8'))
+        # return for early exit so we only print new authors
+        return
 
     authors = list(authors)
     authors.sort(key=name_key)

--- a/tools/authors.py
+++ b/tools/authors.py
@@ -102,9 +102,11 @@ def main():
     # generate set of all new authors
     if vars(options)['new']:
         new_authors = authors.difference(all_authors)
+        n_authors = list(new_authors)
+        n_authors.sort(key=name_key)
         # Print some empty lines to separate
         stdout_b.write(("\n\n").encode('utf-8'))
-        for author in new_authors:
+        for author in n_authors:
             stdout_b.write(("- %s\n" % author).encode('utf-8'))
         # return for early exit so we only print new authors
         return


### PR DESCRIPTION
#### Reference issue
https://mail.python.org/pipermail/scipy-dev/2020-August/024331.html

#### What does this implement/fix?
Adds a `--new` or `-n` short flag to the `tools/authors.py` module. 

#### Additional information
Using the flag added in this PR will autogenerate the list of new authors to add to the scipy.org website. 
We'd still need to copy and paste the lines into the file 
https://github.com/rlucas7/scipy.org/blob/master/www/scipylib/donations.rst
and open a PR on that repo but otherwise that would be the extent of work effort. 

The `--new` flag does not provide what the contributor contributed to the scipy repo
so it may make sense to remove the additional context on:

https://github.com/scipy/scipy.org/pull/364

so we have a list of names only. 
Open to suggestions here if someone has a better idea. 

#### Example Usage 
Note here that 
```
4c0fd7939  -> 1.5.0 tag 
f533e9103  -> 1.4.0 tag 
```

So the current way to use the tool to get all authors between 1.4.0 and 1.5.0 release is:
```
python tools/authors.py f533e9103..4c0fd7939
```

If just the new authors are wanted for names to add to the scipy.org website repo use: 

```
python tools/authors.py f533e9103..4c0fd7939 --new
```

For me this latter command gives output: 

```
(scipy-dev) Lucass-MacBook:scipy rlucas$ python tools/authors.py f533e9103..4c0fd7939 -n | head -n 15


- Kale-ab Tessera
- Kevin Mader
- poom
- Berkay Antmen
- Milad Sadeghi DM
- Jan Vleeshouwers
- Matthias Bussonnier
- Shubham Mishra
- jeremie du boisberranger
- Jordão Bragantini
- Arne Küderle
- Nicholas McKibben
- James Wright
```