### PR TITLE
CI: Pin setuptools on windows CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,7 +71,7 @@ install:
       ls $destination
 
   # Upgrade to the latest pip.
-  - '%CMD_IN_ENV% python -m pip install -U pip setuptools wheel'
+  - '%CMD_IN_ENV% python -m pip install -U pip "setuptools<50.0" wheel'
 
   # Install the scipy test dependencies.
   - '%CMD_IN_ENV% pip install -U --timeout 5 --retries 2 -r tools/ci/appveyor/requirements.txt'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -99,7 +99,8 @@ jobs:
       versionSpec: $(PYTHON_VERSION)
       addToPath: true
       architecture: $(PYTHON_ARCH)
-  - script: python -m pip install --upgrade pip setuptools wheel
+  - script: |
+      python -m pip install --upgrade pip "setuptools<50.0" wheel
     displayName: 'Install tools'
   - powershell: |
       $pyversion = python -c "import sys; print(sys.version.split()[0])"


### PR DESCRIPTION
Windows CI has all started failing with a distutils error, e.g. see gh-12788.

I think this is related to setuptools version 50.0.0 which was released late yesterday:
https://pypi.org/project/setuptools/#history