### PR TITLE
Do not pin the version of numpy in unsupported python versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,11 @@ requires = [
     "Cython>=0.29.18",
     "numpy==1.14.5; python_version=='3.6' and platform_system!='AIX'",
     "numpy==1.14.5; python_version=='3.7' and platform_system!='AIX'",
-    "numpy==1.17.3; python_version>='3.8' and platform_system!='AIX'",
+    "numpy==1.17.3; python_version=='3.8' and platform_system!='AIX'",
     "numpy==1.16.0; python_version=='3.6' and platform_system=='AIX'",
     "numpy==1.16.0; python_version=='3.7' and platform_system=='AIX'",
-    "numpy==1.17.3; python_version>='3.8' and platform_system=='AIX'",
+    "numpy==1.17.3; python_version=='3.8' and platform_system=='AIX'",
+    # do not pin numpy on future versions of python to avoid incompatible numpy and python versions
+    "numpy; python_version>='3.9'",
     "pybind11>=2.4.3",
 ]


### PR DESCRIPTION
This means that users who are building scipy against a bleeding edge python version are not forced into pulling in a very old numpy that does not support that python version.

This closes numpy/numpy#17044, where attempting to build scipy on Python 3.10 resulted in an error in numpy, since scipy was pinning to an unreasonably old version.

The intent here is that the last line should always be `"numpy; python_version>='not-yet-supported-by-scipy'",`.
I'm not suggesting that scipy stop pinning numpy in all future versions of python, just that it pin against them one-by-one as it commits to supporting those python versions.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->
