### PR TITLE
CI: fix 32-bit Linux build failure on Azure CI runs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,16 +38,16 @@ jobs:
            python3.6 get-pip.py && \
            pip3 --version && \
            pip3 install setuptools wheel numpy==1.14.5 cython==0.29.18 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath matplotlib==3.1.3 --user && \
-           apt-get -y install gfortran-5 wget && \
+           apt-get -y install gcc-5 g++-5 gfortran-5 wget && \
            cd .. && \
            mkdir openblas && cd openblas && \
            target=\$(python3.6 ../scipy/tools/openblas_support.py) && \
            cp -r \$target/lib/* /usr/lib && \
            cp \$target/include/* /usr/include && \
            cd ../scipy && \
-           F77=gfortran-5 F90=gfortran-5 python3.6 setup.py install && \
+           CC=gcc-5 CXX=g++-5 F77=gfortran-5 F90=gfortran-5 python3.6 setup.py install && \
            python3.6 tools/openblas_support.py --check_version $(openblas_version) && \
-           F77=gfortran-5 F90=gfortran-5 python3.6 runtests.py --mode=full -- -n auto -s --junitxml=junit/test-results.xml --cov-config=.coveragerc --cov-report=xml --cov-report=html"
+           CC=gcc-5 CXX=g++-5 F77=gfortran-5 F90=gfortran-5 python3.6 runtests.py --mode=full -- -n auto -s --junitxml=junit/test-results.xml --cov-config=.coveragerc --cov-report=xml --cov-report=html"
     displayName: 'Run 32-bit Ubuntu Docker Build / Tests'
   - task: PublishTestResults@2
     condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,7 @@ jobs:
            curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
            python3.6 get-pip.py && \
            pip3 --version && \
-           pip3 install setuptools wheel numpy==1.14.5 cython==0.29.18 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath matplotlib==3.1.3 --user && \
+           pip3 install setuptools wheel numpy==1.16.6 cython==0.29.18 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath matplotlib==3.1.3 --user && \
            apt-get -y install gcc-5 g++-5 gfortran-5 wget && \
            cd .. && \
            mkdir openblas && cd openblas && \

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -125,6 +125,10 @@ def load_testing_files():
 load_testing_files()
 
 
+def _is_32bit():
+    return np.intp(0).itemsize < 8
+
+
 def _chk_asarrays(arrays, axis=None):
     arrays = [np.asanyarray(a) for a in arrays]
     if axis is None:
@@ -1149,7 +1153,12 @@ class TestPdist(object):
         _assert_within_tol(Y_test2, Y_right, eps)
 
     def test_pdist_jensenshannon_iris(self):
-        eps = 1e-12
+        if _is_32bit():
+            # Test failing on 32-bit Linux on Azure otherwise, see gh-12810
+            eps = 1.5e-10
+        else:
+            eps = 1e-12
+
         X = eo['iris']
         Y_right = eo['pdist-jensenshannon-iris']
         Y_test1 = pdist(X, 'jensenshannon')


### PR DESCRIPTION
Azure uses Ubuntu Bionic (16.04 LTS) including backports; that now picks up gcc-7 in addition to gcc-5, and by default builds with gcc-7. Only gfortran-5 is available though, not gfortran-7.

So explicitly use gcc-5 and g++-5