### PR TITLE
ENH: support interpolation of complex-valued images

### DIFF
--- a/scipy/ndimage/_ni_support.py
+++ b/scipy/ndimage/_ni_support.py
@@ -29,6 +29,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from collections.abc import Iterable
+import warnings
 import numpy
 
 
@@ -81,7 +82,8 @@ def _get_output(output, input, shape=None, complex_output=False):
     elif isinstance(output, (type, numpy.dtype)):
         # Classes (like `np.float32`) and dtypes are interpreted as dtype
         if complex_output and numpy.dtype(output).kind != 'c':
-            raise RuntimeError("output must have complex dtype")
+            warnings.warn("promoting specified output dtype to complex")
+            output = numpy.promote_types(output, numpy.complex64)
         output = numpy.zeros(shape, dtype=output)
     elif isinstance(output, str):
         output = numpy.typeDict[output]

--- a/scipy/ndimage/interpolation.py
+++ b/scipy/ndimage/interpolation.py
@@ -110,9 +110,13 @@ def spline_filter1d(input, order=3, axis=-1, output=numpy.float64,
     if order < 0 or order > 5:
         raise RuntimeError('spline order not supported')
     input = numpy.asarray(input)
-    if numpy.iscomplexobj(input):
-        raise TypeError('Complex type not supported')
-    output = _ni_support._get_output(output, input)
+    complex_output = numpy.iscomplexobj(input)
+    output = _ni_support._get_output(output, input,
+                                     complex_output=complex_output)
+    if complex_output:
+        spline_filter1d(input.real, order, axis, output.real, mode)
+        spline_filter1d(input.imag, order, axis, output.imag, mode)
+        return output
     if order in [0, 1]:
         output[...] = numpy.array(input)
     else:
@@ -161,9 +165,13 @@ def spline_filter(input, order=3, output=numpy.float64, mode='mirror'):
     if order < 2 or order > 5:
         raise RuntimeError('spline order not supported')
     input = numpy.asarray(input)
-    if numpy.iscomplexobj(input):
-        raise TypeError('Complex type not supported')
-    output = _ni_support._get_output(output, input)
+    complex_output = numpy.iscomplexobj(input)
+    output = _ni_support._get_output(output, input,
+                                     complex_output=complex_output)
+    if complex_output:
+        spline_filter(input.real, order, output.real, mode)
+        spline_filter(input.imag, order, output.imag, mode)
+        return output
     if order not in [0, 1] and input.ndim > 0:
         for axis in range(input.ndim):
             spline_filter1d(input, order, axis, output=output, mode=mode)
@@ -295,12 +303,22 @@ def geometric_transform(input, mapping, output_shape=None,
     if order < 0 or order > 5:
         raise RuntimeError('spline order not supported')
     input = numpy.asarray(input)
-    if numpy.iscomplexobj(input):
-        raise TypeError('Complex type not supported')
     if output_shape is None:
         output_shape = input.shape
     if input.ndim < 1 or len(output_shape) < 1:
         raise RuntimeError('input and output rank must be > 0')
+    complex_output = numpy.iscomplexobj(input)
+    output = _ni_support._get_output(output, input, shape=output_shape,
+                                     complex_output=complex_output)
+    if complex_output:
+        kwargs = dict(order=order, mode=mode, cval=cval, prefilter=prefilter,
+                      output_shape=output_shape,
+                      extra_arguments=extra_arguments,
+                      extra_keywords=extra_keywords)
+        geometric_transform(input.real, mapping, output=output.real, **kwargs)
+        geometric_transform(input.imag, mapping, output=output.imag, **kwargs)
+        return output
+
     if prefilter and order > 1:
         padded, npad = _prepad_for_spline_filter(input, mode, cval)
         filtered = spline_filter(padded, order, output=numpy.float64,
@@ -309,7 +327,6 @@ def geometric_transform(input, mapping, output_shape=None,
         npad = 0
         filtered = input
     mode = _ni_support._extend_mode_to_code(mode)
-    output = _ni_support._get_output(output, input, shape=output_shape)
     _nd_image.geometric_transform(filtered, mapping, None, None, None, output,
                                   order, mode, cval, npad, extra_arguments,
                                   extra_keywords)
@@ -382,8 +399,6 @@ def map_coordinates(input, coordinates, output=None, order=3,
     if order < 0 or order > 5:
         raise RuntimeError('spline order not supported')
     input = numpy.asarray(input)
-    if numpy.iscomplexobj(input):
-        raise TypeError('Complex type not supported')
     coordinates = numpy.asarray(coordinates)
     if numpy.iscomplexobj(coordinates):
         raise TypeError('Complex type not supported')
@@ -392,6 +407,14 @@ def map_coordinates(input, coordinates, output=None, order=3,
         raise RuntimeError('input and output rank must be > 0')
     if coordinates.shape[0] != input.ndim:
         raise RuntimeError('invalid shape for coordinate array')
+    complex_output = numpy.iscomplexobj(input)
+    output = _ni_support._get_output(output, input, shape=output_shape,
+                                     complex_output=complex_output)
+    if complex_output:
+        kwargs = dict(order=order, mode=mode, cval=cval, prefilter=prefilter)
+        map_coordinates(input.real, coordinates, output=output.real, **kwargs)
+        map_coordinates(input.imag, coordinates, output=output.imag, **kwargs)
+        return output
     if prefilter and order > 1:
         padded, npad = _prepad_for_spline_filter(input, mode, cval)
         filtered = spline_filter(padded, order, output=numpy.float64,
@@ -399,8 +422,6 @@ def map_coordinates(input, coordinates, output=None, order=3,
     else:
         npad = 0
         filtered = input
-    output = _ni_support._get_output(output, input,
-                                     shape=output_shape)
     mode = _ni_support._extend_mode_to_code(mode)
     _nd_image.geometric_transform(filtered, None, coordinates, None, None,
                                   output, order, mode, cval, npad, None, None)
@@ -489,12 +510,19 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None,
     if order < 0 or order > 5:
         raise RuntimeError('spline order not supported')
     input = numpy.asarray(input)
-    if numpy.iscomplexobj(input):
-        raise TypeError('Complex type not supported')
     if output_shape is None:
         output_shape = input.shape
     if input.ndim < 1 or len(output_shape) < 1:
         raise RuntimeError('input and output rank must be > 0')
+    complex_output = numpy.iscomplexobj(input)
+    output = _ni_support._get_output(output, input, shape=output_shape,
+                                     complex_output=complex_output)
+    if complex_output:
+        kwargs = dict(offset=offset, output_shape=output_shape, order=order,
+                      mode=mode, cval=cval, prefilter=prefilter)
+        affine_transform(input.real, matrix, output=output.real, **kwargs)
+        affine_transform(input.imag, matrix, output=output.imag, **kwargs)
+        return output
     if prefilter and order > 1:
         padded, npad = _prepad_for_spline_filter(input, mode, cval)
         filtered = spline_filter(padded, order, output=numpy.float64,
@@ -503,8 +531,6 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None,
         npad = 0
         filtered = input
     mode = _ni_support._extend_mode_to_code(mode)
-    output = _ni_support._get_output(output, input,
-                                     shape=output_shape)
     matrix = numpy.asarray(matrix, dtype=numpy.float64)
     if matrix.ndim not in [1, 2] or matrix.shape[0] < 1:
         raise RuntimeError('no proper affine matrix provided')
@@ -580,10 +606,19 @@ def shift(input, shift, output=None, order=3, mode='constant', cval=0.0,
     if order < 0 or order > 5:
         raise RuntimeError('spline order not supported')
     input = numpy.asarray(input)
-    if numpy.iscomplexobj(input):
-        raise TypeError('Complex type not supported')
     if input.ndim < 1:
         raise RuntimeError('input and output rank must be > 0')
+    complex_output = numpy.iscomplexobj(input)
+    output = _ni_support._get_output(output, input,
+                                     complex_output=complex_output)
+    if complex_output:
+        # import under different name to avoid confusion with shift parameter
+        from scipy.ndimage.interpolation import shift as _shift
+
+        kwargs = dict(order=order, mode=mode, cval=cval, prefilter=prefilter)
+        _shift(input.real, shift, output=output.real, **kwargs)
+        _shift(input.imag, shift, output=output.imag, **kwargs)
+        return output
     if prefilter and order > 1:
         padded, npad = _prepad_for_spline_filter(input, mode, cval)
         filtered = spline_filter(padded, order, output=numpy.float64,
@@ -592,7 +627,6 @@ def shift(input, shift, output=None, order=3, mode='constant', cval=0.0,
         npad = 0
         filtered = input
     mode = _ni_support._extend_mode_to_code(mode)
-    output = _ni_support._get_output(output, input)
     shift = _ni_support._normalize_sequence(shift, input.ndim)
     shift = [-ii for ii in shift]
     shift = numpy.asarray(shift, dtype=numpy.float64)
@@ -653,10 +687,22 @@ def zoom(input, zoom, output=None, order=3, mode='constant', cval=0.0,
     if order < 0 or order > 5:
         raise RuntimeError('spline order not supported')
     input = numpy.asarray(input)
-    if numpy.iscomplexobj(input):
-        raise TypeError('Complex type not supported')
     if input.ndim < 1:
         raise RuntimeError('input and output rank must be > 0')
+    zoom = _ni_support._normalize_sequence(zoom, input.ndim)
+    output_shape = tuple(
+            [int(round(ii * jj)) for ii, jj in zip(input.shape, zoom)])
+    complex_output = numpy.iscomplexobj(input)
+    output = _ni_support._get_output(output, input, shape=output_shape,
+                                     complex_output=complex_output)
+    if complex_output:
+        # import under different name to avoid confusion with zoom parameter
+        from scipy.ndimage.interpolation import zoom as _zoom
+
+        kwargs = dict(order=order, mode=mode, cval=cval, prefilter=prefilter)
+        _zoom(input.real, zoom, output=output.real, **kwargs)
+        _zoom(input.imag, zoom, output=output.imag, **kwargs)
+        return output
     if prefilter and order > 1:
         padded, npad = _prepad_for_spline_filter(input, mode, cval)
         filtered = spline_filter(padded, order, output=numpy.float64,
@@ -665,9 +711,6 @@ def zoom(input, zoom, output=None, order=3, mode='constant', cval=0.0,
         npad = 0
         filtered = input
     mode = _ni_support._extend_mode_to_code(mode)
-    zoom = _ni_support._normalize_sequence(zoom, input.ndim)
-    output_shape = tuple(
-            [int(round(ii * jj)) for ii, jj in zip(input.shape, zoom)])
 
     zoom_div = numpy.array(output_shape, float) - 1
     # Zooming to infinite values is unpredictable, so just choose
@@ -675,9 +718,6 @@ def zoom(input, zoom, output=None, order=3, mode='constant', cval=0.0,
     zoom = numpy.divide(numpy.array(input.shape) - 1, zoom_div,
                         out=numpy.ones_like(input.shape, dtype=numpy.float64),
                         where=zoom_div != 0)
-
-    output = _ni_support._get_output(output, input,
-                                     shape=output_shape)
     zoom = numpy.ascontiguousarray(zoom)
     _nd_image.zoom_shift(filtered, zoom, None, output, order, mode, cval, npad)
     return output
@@ -789,7 +829,9 @@ def rotate(input, angle, axes=(1, 0), reshape=True, output=None, order=3,
     output_shape[axes] = out_plane_shape
     output_shape = tuple(output_shape)
 
-    output = _ni_support._get_output(output, input_arr, shape=output_shape)
+    complex_output = numpy.iscomplexobj(input_arr)
+    output = _ni_support._get_output(output, input_arr, shape=output_shape,
+                                     complex_output=complex_output)
 
     if ndim <= 2:
         affine_transform(input_arr, rot_matrix, offset, output_shape, output,

--- a/scipy/ndimage/interpolation.py
+++ b/scipy/ndimage/interpolation.py
@@ -198,7 +198,7 @@ def _prepad_for_spline_filter(input, mode, cval):
         npad = 12
         if mode == 'grid-constant':
             padded = numpy.pad(input, npad, mode='constant',
-                              constant_values=cval)
+                               constant_values=cval)
         elif mode == 'nearest':
             padded = numpy.pad(input, npad, mode='edge')
     else:

--- a/scipy/ndimage/interpolation.py
+++ b/scipy/ndimage/interpolation.py
@@ -83,6 +83,12 @@ def spline_filter1d(input, order=3, axis=-1, output=numpy.float64,
     parameter, the result will only be correct if it matches the `mode`
     used when filtering.
 
+    For complex-valued `input`, this function processes the real and imaginary
+    components independently.
+
+    .. versionadded:: 1.6.0
+        Complex-valued support added.
+
     See Also
     --------
     spline_filter : Multidimensional spline filter.
@@ -143,6 +149,12 @@ def spline_filter(input, order=3, output=numpy.float64, mode='mirror'):
     in the same data type as the output. Therefore, for output types
     with a limited precision, the results may be imprecise because
     intermediate results may be stored with insufficient precision.
+
+    For complex-valued `input`, this function processes the real and imaginary
+    components independently.
+
+    .. versionadded:: 1.6.0
+        Complex-valued support added.
 
     Examples
     --------
@@ -272,6 +284,12 @@ def geometric_transform(input, mapping, output_shape=None,
     are accepted, but these are for backward compatibility only and should
     not be used in new code.
 
+    For complex-valued `input`, this function transforms the real and imaginary
+    components independently.
+
+    .. versionadded:: 1.6.0
+        Complex-valued support added.
+
     Examples
     --------
     >>> import numpy as np
@@ -371,6 +389,14 @@ def map_coordinates(input, coordinates, output=None, order=3,
     See Also
     --------
     spline_filter, geometric_transform, scipy.interpolate
+
+    Notes
+    -----
+    For complex-valued `input`, this function maps the real and imaginary
+    components independently.
+
+    .. versionadded:: 1.6.0
+        Complex-valued support added.
 
     Examples
     --------
@@ -503,6 +529,12 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None,
         was determined from the input image at position
         ``matrix * (o + offset)``.
 
+    For complex-valued `input`, this function transforms the real and imaginary
+    components independently.
+
+    .. versionadded:: 1.6.0
+        Complex-valued support added.
+
     References
     ----------
     .. [1] https://en.wikipedia.org/wiki/Homogeneous_coordinates
@@ -602,6 +634,14 @@ def shift(input, shift, output=None, order=3, mode='constant', cval=0.0,
     shift : ndarray
         The shifted input.
 
+    Notes
+    -----
+    For complex-valued `input`, this function shifts the real and imaginary
+    components independently.
+
+    .. versionadded:: 1.6.0
+        Complex-valued support added.
+
     """
     if order < 0 or order > 5:
         raise RuntimeError('spline order not supported')
@@ -663,6 +703,14 @@ def zoom(input, zoom, output=None, order=3, mode='constant', cval=0.0,
     -------
     zoom : ndarray
         The zoomed input.
+
+    Notes
+    -----
+    For complex-valued `input`, this function zooms the real and imaginary
+    components independently.
+
+    .. versionadded:: 1.6.0
+        Complex-valued support added.
 
     Examples
     --------
@@ -755,6 +803,14 @@ def rotate(input, angle, axes=(1, 0), reshape=True, output=None, order=3,
     -------
     rotate : ndarray
         The rotated input.
+
+    Notes
+    -----
+    For complex-valued `input`, this function rotates the real and imaginary
+    components independently.
+
+    .. versionadded:: 1.6.0
+        Complex-valued support added.
 
     Examples
     --------

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -94,13 +94,16 @@ class TestNdimageFilters:
         assert_array_almost_equal(expected, output)
         assert_equal(output.dtype.type, type2)
 
-        # output cannot be real
-        with assert_raises(RuntimeError):
+        # warns if the output is not a complex dtype
+        with pytest.warns(UserWarning,
+                          match="promoting specified output dtype to complex"):
             correlate(array, kernel, output=real_dtype)
 
-        with assert_raises(RuntimeError):
+        with pytest.warns(UserWarning,
+                          match="promoting specified output dtype to complex"):
             convolve(array, kernel, output=real_dtype)
 
+        # raises if output array is provided, but is not complex-valued
         output_real = numpy.zeros_like(array, dtype=real_dtype)
         with assert_raises(RuntimeError):
             correlate(array, kernel, output=output_real)

--- a/scipy/ndimage/tests/test_interpolation.py
+++ b/scipy/ndimage/tests/test_interpolation.py
@@ -167,19 +167,24 @@ class TestNdimageInterpolation:
         assert_array_almost_equal(out, [0, 4, 1, 3])
 
     @pytest.mark.parametrize('order', range(0, 6))
-    def test_geometric_transform05(self, order):
+    @pytest.mark.parametrize('dtype', [numpy.float64, numpy.complex128])
+    def test_geometric_transform05(self, order, dtype):
         data = numpy.array([[1, 1, 1, 1],
                             [1, 1, 1, 1],
-                            [1, 1, 1, 1]])
+                            [1, 1, 1, 1]], dtype=dtype)
+        expected = numpy.array([[0, 1, 1, 1],
+                                [0, 1, 1, 1],
+                                [0, 1, 1, 1]], dtype=dtype)
+        if data.dtype.kind == 'c':
+            data -= 1j * data
+            expected -= 1j * expected
 
         def mapping(x):
             return (x[0], x[1] - 1)
 
         out = ndimage.geometric_transform(data, mapping, data.shape,
                                           order=order)
-        assert_array_almost_equal(out, [[0, 1, 1, 1],
-                                        [0, 1, 1, 1],
-                                        [0, 1, 1, 1]])
+        assert_array_almost_equal(out, expected)
 
     @pytest.mark.parametrize('order', range(0, 6))
     def test_geometric_transform06(self, order):
@@ -466,17 +471,23 @@ class TestNdimageInterpolation:
         assert_array_almost_equal(out, [1])
 
     @pytest.mark.parametrize('order', range(0, 6))
-    def test_map_coordinates01(self, order):
+    @pytest.mark.parametrize('dtype', [numpy.float64, numpy.complex128])
+    def test_map_coordinates01(self, order, dtype):
         data = numpy.array([[4, 1, 3, 2],
                             [7, 6, 8, 5],
                             [3, 5, 3, 6]])
+        expected = numpy.array([[0, 0, 0, 0],
+                                [0, 4, 1, 3],
+                                [0, 7, 6, 8]])
+        if data.dtype.kind == 'c':
+            data = data - 1j * data
+            expected = expected - 1j * expected
+
         idx = numpy.indices(data.shape)
         idx -= 1
 
         out = ndimage.map_coordinates(data, idx, order=order)
-        assert_array_almost_equal(out, [[0, 0, 0, 0],
-                                        [0, 4, 1, 3],
-                                        [0, 7, 6, 8]])
+        assert_array_almost_equal(out, expected)
 
     @pytest.mark.parametrize('order', range(0, 6))
     def test_map_coordinates02(self, order):
@@ -573,15 +584,20 @@ class TestNdimageInterpolation:
         assert_array_almost_equal(out, [0, 4, 1, 3])
 
     @pytest.mark.parametrize('order', range(0, 6))
-    def test_affine_transform05(self, order):
+    @pytest.mark.parametrize('dtype', [numpy.float64, numpy.complex128])
+    def test_affine_transform05(self, order, dtype):
         data = numpy.array([[1, 1, 1, 1],
                             [1, 1, 1, 1],
-                            [1, 1, 1, 1]])
+                            [1, 1, 1, 1]], dtype=dtype)
+        expected = numpy.array([[0, 1, 1, 1],
+                                [0, 1, 1, 1],
+                                [0, 1, 1, 1]], dtype=dtype)
+        if data.dtype.kind == 'c':
+            data -= 1j * data
+            expected -= 1j * expected
         out = ndimage.affine_transform(data, [[1, 0], [0, 1]],
                                        [0, -1], order=order)
-        assert_array_almost_equal(out, [[0, 1, 1, 1],
-                                        [0, 1, 1, 1],
-                                        [0, 1, 1, 1]])
+        assert_array_almost_equal(out, expected)
 
     @pytest.mark.parametrize('order', range(0, 6))
     def test_affine_transform06(self, order):
@@ -894,14 +910,19 @@ class TestNdimageInterpolation:
         assert_array_almost_equal(out, [0, 4, 1, 3])
 
     @pytest.mark.parametrize('order', range(0, 6))
-    def test_shift05(self, order):
+    @pytest.mark.parametrize('dtype', [numpy.float64, numpy.complex128])
+    def test_shift05(self, order, dtype):
         data = numpy.array([[1, 1, 1, 1],
                             [1, 1, 1, 1],
-                            [1, 1, 1, 1]])
+                            [1, 1, 1, 1]], dtype=dtype)
+        expected = numpy.array([[0, 1, 1, 1],
+                                [0, 1, 1, 1],
+                                [0, 1, 1, 1]], dtype=dtype)
+        if data.dtype.kind == 'c':
+            data -= 1j * data
+            expected -= 1j * expected
         out = ndimage.shift(data, [0, 1], order=order)
-        assert_array_almost_equal(out, [[0, 1, 1, 1],
-                                        [0, 1, 1, 1],
-                                        [0, 1, 1, 1]])
+        assert_array_almost_equal(out, expected)
 
     @pytest.mark.parametrize('order', range(0, 6))
     def test_shift06(self, order):
@@ -1037,10 +1058,13 @@ class TestNdimageInterpolation:
         assert_array_almost_equal(out2, numpy.array([[1, 1, 2, 2]]))
 
     @pytest.mark.parametrize('order', range(0, 6))
-    def test_zoom_affine01(self, order):
-        data = [[1, 2, 3, 4],
-                [5, 6, 7, 8],
-                [9, 10, 11, 12]]
+    @pytest.mark.parametrize('dtype', [numpy.float64, numpy.complex128])
+    def test_zoom_affine01(self, order, dtype):
+        data = numpy.asarray([[1, 2, 3, 4],
+                              [5, 6, 7, 8],
+                              [9, 10, 11, 12]], dtype=dtype)
+        if data.dtype.kind == 'c':
+            data -= 1j * data
         with suppress_warnings() as sup:
             sup.filter(UserWarning,
                        'The behavior of affine_transform with a 1-D array .* '
@@ -1103,15 +1127,19 @@ class TestNdimageInterpolation:
         assert_array_almost_equal(out, expected)
 
     @pytest.mark.parametrize('order', range(0, 6))
-    def test_rotate03(self, order):
+    @pytest.mark.parametrize('dtype', [numpy.float64, numpy.complex128])
+    def test_rotate03(self, order, dtype):
         data = numpy.array([[0, 0, 0, 0, 0],
                             [0, 1, 1, 0, 0],
-                            [0, 0, 0, 0, 0]], dtype=numpy.float64)
+                            [0, 0, 0, 0, 0]], dtype=dtype)
         expected = numpy.array([[0, 0, 0],
                                [0, 0, 0],
                                [0, 1, 0],
                                [0, 1, 0],
-                               [0, 0, 0]], dtype=numpy.float64)
+                               [0, 0, 0]], dtype=dtype)
+        if data.dtype.kind == 'c':
+            data -= 1j * data
+            expected -= 1j * expected
         out = ndimage.rotate(data, 90, order=order)
         assert_array_almost_equal(out, expected)
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
None

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR allows interpolation of complex-valued images via separable application of interpolation to the real and imaginary components.  Although this is already relatively easy for end-users to do on their own, I think it is nice to provide built-in capability for this. 

#### Additional information
<!--Any additional information you think is important.-->

As far as I can tell, ITK provides a class `ComplexBSplineInterpolateImageFunction` which functions similarly, calling `BSplineInterpolateImageFunction` [on the real and imaginary components separately](https://itk.org/Doxygen320/html/classitk_1_1ComplexBSplineInterpolateImageFunction.html#_details)

Two-domains where complex-valued images or volumes are commonly encountered are magnetic resonance imaging (MRI) and synthetic-aperture radar (SAR) imaging.

The changes made to `_get_output` here overlap with those made in the related PR, gh-12725.
