### PR TITLE
Update ckdtree.pyx

### DIFF
--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -394,7 +394,7 @@ cdef class cKDTree:
     point.
 
     The algorithm used is described in Maneewongvatana and Mount 1999.
-    The general idea is that the kd-tree is a binary trie, each of whose
+    The general idea is that the kd-tree is a binary tree, each of whose
     nodes represents an axis-aligned hyperrectangle. Each node specifies
     an axis and splits the set of points based on whether their coordinate
     along that axis is greater than or less than a particular value.


### PR DESCRIPTION
I was teaching some undergraduates with SciPy and I was browsing with them the documentation of [cKDTree](https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.cKDTree.html) and they noticed a typo. I am fixing this typo in the documentation

`... The general idea is that the kd-tree is a binary trie, each of whose nodes...` was changed to `The general idea is that the kd-tree is a binary tree, each of whose nodes ...```

