### PR TITLE
[BUG] sparse: Avoid using size attribute in LIL __setitem__

### DIFF
--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -109,7 +109,7 @@ class IndexMixin(object):
             if not ((broadcast_row or x.shape[0] == i.shape[0]) and
                     (broadcast_col or x.shape[1] == i.shape[1])):
                 raise ValueError('shape mismatch in assignment')
-            if x.size == 0:
+            if x.shape[0] == 0 or x.shape[1] == 0:
                 return
             x = x.tocoo(copy=True)
             x.sum_duplicates()

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -809,7 +809,11 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         broadcast_row = M != 1 and x.shape[0] == 1
         broadcast_col = N != 1 and x.shape[1] == 1
         r, c = x.row, x.col
+
         x = np.asarray(x.data, dtype=self.dtype)
+        if x.size == 0:
+            return
+
         if broadcast_row:
             r = np.repeat(np.arange(M), len(r))
             c = np.tile(c, M)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2631,6 +2631,11 @@ class _TestSlicingAssign(object):
                       ([[1, 2, 3], [0, 3, 4], [4, 1, 3]],
                        [[1, 2, 4], [0, 1, 3]]), [2, 3, 4])
 
+    def test_assign_empty_spmatrix(self):
+        A = self.spmatrix(np.ones((2, 3)))
+        B = self.spmatrix((1, 2))
+        A[1, :2] = B
+        assert_array_equal(A.todense(), [[1, 1, 1], [0, 0, 1]])
 
 class _TestFancyIndexing(object):
     """Tests fancy indexing features.  The tests for any matrix formats


### PR DESCRIPTION
For scipy.sparse matrices, `.size` is an alias for `.nnz`, not `prod(shape)` like it means for ndarray.

Fixes gh-12819.