### PR TITLE
DOC: fix typo in sparse/base.py

### DIFF
--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -1146,7 +1146,7 @@ class spmatrix(object):
             New values of the diagonal elements.
 
             Values may have any length. If the diagonal is longer than values,
-            then the remaining diagonal entries will not be set. If values if
+            then the remaining diagonal entries will not be set. If values are
             longer than the diagonal, then the remaining values are ignored.
 
             If a scalar value is given, all of the diagonal is set to it.


### PR DESCRIPTION
typo in setdiag documentation

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
N/A
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
single word typo in documentation.
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->