### PR TITLE
MAINT: stats: Improve vonmises PDF calculation.

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -7836,8 +7836,11 @@ class vonmises_gen(rv_continuous):
         return random_state.vonmises(0.0, kappa, size=size)
 
     def _pdf(self, x, kappa):
-        # vonmises.pdf(x, \kappa) = exp(\kappa * cos(x)) / (2*pi*I[0](\kappa))
-        return np.exp(kappa * np.cos(x)) / (2*np.pi*sc.i0(kappa))
+        # vonmises.pdf(x, kappa) = exp(kappa * cos(x)) / (2*pi*I[0](kappa))
+        #                        = exp(kappa * (cos(x) - 1)) /
+        #                          (2*pi*exp(-kappa)*I[0](kappa))
+        #                        = exp(kappa * cosm1(x)) / (2*pi*i0e(kappa))
+        return np.exp(kappa*sc.cosm1(x)) / (2*np.pi*sc.i0e(kappa))
 
     def _cdf(self, x, kappa):
         return _stats.von_mises_cdf(kappa, x)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -77,6 +77,28 @@ def test_vonmises_numerical():
     assert_almost_equal(vm.cdf(0), 0.5)
 
 
+# Expected values of the vonmises PDF were computed using
+# mpmath with 50 digits of precision:
+#
+# def vmpdf_mp(x, kappa):
+#     x = mpmath.mpf(x)
+#     kappa = mpmath.mpf(kappa)
+#     num = mpmath.exp(kappa*mpmath.cos(x))
+#     den = 2 * mpmath.pi * mpmath.besseli(0, kappa)
+#     return num/den
+#
+@pytest.mark.parametrize('x, kappa, expected_pdf',
+                         [(0.1, 0.01, 0.16074242744907072),
+                          (0.1, 25.0, 1.7515464099118245),
+                          (0.1, 800, 0.2073272544458798),
+                          (2.0, 0.01, 0.15849003875385817),
+                          (2.0, 25.0, 8.356882934278192e-16),
+                          (2.0, 800, 0.0)])
+def test_vonmises_pdf(x, kappa, expected_pdf):
+    pdf = stats.vonmises.pdf(x, kappa)
+    assert_allclose(pdf, expected_pdf, rtol=1e-15)
+
+
 def _assert_lessthan_loglike(dist, data, func, **kwds):
     mle_analytical = dist.fit(data, **kwds)
     numerical_opt = super(type(dist), dist).fit(data, **kwds)


### PR DESCRIPTION
Reformulate the computation of vonmises.pdf, using

    vonmises.pdf(x, kappa) = exp(kappa * cos(x)) / (2*pi*I[0](kappa))
                           = exp(kappa * (cos(x) - 1)) /
                             (2*pi*exp(-kappa)*I[0](kappa))
                           = exp(kappa * cosm1(x)) / (2*pi*i0e(kappa))

This avoids overflow in the terms, which can lead to a return value
of nan.

For example, before this change:

    >>> vonmises.pdf(0.1, 800)
    <...snip...>: RuntimeWarning: overflow encountered in exp
      return np.exp(kappa * np.cos(x)) / (2*np.pi*sc.i0(kappa))
    <...snip...>: RuntimeWarning: invalid value encountered in true_divide
      return np.exp(kappa * np.cos(x)) / (2*np.pi*sc.i0(kappa))

After this change:

    >>> vonmises.pdf(0.1, 800)
    0.20732725444587974
