### PR TITLE
BUG: Use uint16 for cost in NI_WatershedElement

### DIFF
--- a/scipy/ndimage/src/ni_measure.c
+++ b/scipy/ndimage/src/ni_measure.c
@@ -204,8 +204,8 @@ break
 typedef struct {
     npy_intp index;
     void *next, *prev;
-    npy_uint16 done;
     npy_uint16 cost;
+    npy_uint8 done;
 } NI_WatershedElement;
 
 int NI_WatershedIFT(PyArrayObject* input, PyArrayObject* markers,

--- a/scipy/ndimage/src/ni_measure.c
+++ b/scipy/ndimage/src/ni_measure.c
@@ -205,7 +205,7 @@ typedef struct {
     npy_intp index;
     void *next, *prev;
     npy_uint16 done;
-    npy_uint8 cost;
+    npy_uint16 cost;
 } NI_WatershedElement;
 
 int NI_WatershedIFT(PyArrayObject* input, PyArrayObject* markers,

--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -1325,3 +1325,15 @@ class TestWatershedIft:
                     [-1, -1, -1, -1, -1, -1, -1],
                     [-1, -1, -1, -1, -1, -1, -1]]
         assert_array_almost_equal(out, expected)
+
+    def test_watershed_ift08(self):
+        # Test cost larger than uint8. See gh-10069.
+        shape = (2, 2)
+        data = np.array([[256, 0],
+                         [0, 0]], np.uint16)
+        markers = np.array([[1, 0],
+                            [0, 0]], np.int8)
+        out = ndimage.watershed_ift(data, markers)
+        expected = [[1, 1],
+                    [1, 1]]
+        assert_array_almost_equal(out, expected)


### PR DESCRIPTION
#### Reference issue
Fixes gh-10069.

#### What does this implement/fix?
`uint8` was not enough for `uint16` input. It caused strange output containing zeros in some cases.

#### Additional information
This was regressed in v1.0.0