### PR TITLE
BUG: avoid boolean or integer addition error in ndimage.measurements.median

### DIFF
--- a/scipy/ndimage/measurements.py
+++ b/scipy/ndimage/measurements.py
@@ -893,7 +893,12 @@ def _select(input, labels=None, index=None, find_min=False, find_max=False,
         step = (hi - lo) // 2
         lo += step
         hi -= step
-        result += [(input[lo] + input[hi]) / 2.0]
+        if (np.issubdtype(input.dtype, np.integer)
+                or np.issubdtype(input.dtype, np.bool_)):
+            # avoid integer overflow or boolean addition (gh-12836)
+            result += [(input[lo].astype('d') + input[hi].astype('d')) / 2.0]
+        else:
+            result += [(input[lo] + input[hi]) / 2.0]
 
     return result
 

--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -700,7 +700,7 @@ def test_median03():
 
 def test_median_gh12836_bool():
     # test boolean addition fix on example from gh-12836
-    a = np.asarray([1, 1], dtype=np.bool)
+    a = np.asarray([1, 1], dtype=bool)
     output = ndimage.median(a, labels=np.ones((2,)), index=[1])
     assert_array_almost_equal(output, [1.0])
 

--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -698,6 +698,20 @@ def test_median03():
     assert_almost_equal(output, 3.0)
 
 
+def test_median_gh12836_bool():
+    # test boolean addition fix on example from gh-12836
+    a = np.asarray([1, 1], dtype=np.bool)
+    output = ndimage.median(a, labels=np.ones((2,)), index=[1,])
+    assert_array_almost_equal(output, [1.0])
+
+
+def test_median_no_int_overflow():
+    # test integer overflow fix on example from gh-12836
+    a = np.asarray([65, 70], dtype=np.int8)
+    output = ndimage.median(a, labels=np.ones((2,)), index=[1,])
+    assert_array_almost_equal(output, [67.5])
+
+
 def test_variance01():
     with np.errstate(all='ignore'):
         for type in types:

--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -701,14 +701,14 @@ def test_median03():
 def test_median_gh12836_bool():
     # test boolean addition fix on example from gh-12836
     a = np.asarray([1, 1], dtype=np.bool)
-    output = ndimage.median(a, labels=np.ones((2,)), index=[1,])
+    output = ndimage.median(a, labels=np.ones((2,)), index=[1])
     assert_array_almost_equal(output, [1.0])
 
 
 def test_median_no_int_overflow():
     # test integer overflow fix on example from gh-12836
     a = np.asarray([65, 70], dtype=np.int8)
-    output = ndimage.median(a, labels=np.ones((2,)), index=[1,])
+    output = ndimage.median(a, labels=np.ones((2,)), index=[1])
     assert_array_almost_equal(output, [67.5])
 
 


### PR DESCRIPTION




<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
closes gh-12836

#### What does this implement/fix?
<!--Please explain your changes.-->

Cast boolean or integer arrays to float when averaging values during median computation. This avoid the integer overflow or boolean addition issues encountered in gh-12836.

#### Additional information
<!--Any additional information you think is important.-->
Note sure if the verbose `np.issubdtype` checks as used here are preferred or if a more compact notation such as

```Python
if input.dtype.kind in 'iub':
```

is preferred.