### PR TITLE
BUG: sparse: fix inner indexed assignment of a 1d array

### DIFF
--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -117,7 +117,8 @@ class IndexMixin(object):
         else:
             # Make x and i into the same shape
             x = np.asarray(x, dtype=self.dtype)
-            x, _ = _broadcast_arrays(x, i)
+            if x.squeeze().shape != i.squeeze().shape:
+                x = np.broadcast_to(x, i.shape)
             if x.size == 0:
                 return
             x = x.reshape(i.shape)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2630,12 +2630,21 @@ class _TestSlicingAssign(object):
         assert_raises(ValueError, A.__setitem__,
                       ([[1, 2, 3], [0, 3, 4], [4, 1, 3]],
                        [[1, 2, 4], [0, 1, 3]]), [2, 3, 4])
+        assert_raises(ValueError, A.__setitem__, (slice(4), 0),
+                      [[1, 2], [3, 4]])
 
     def test_assign_empty_spmatrix(self):
         A = self.spmatrix(np.ones((2, 3)))
         B = self.spmatrix((1, 2))
         A[1, :2] = B
         assert_array_equal(A.todense(), [[1, 1, 1], [0, 0, 1]])
+
+    def test_assign_1d_slice(self):
+        A = self.spmatrix(np.ones((3, 3)))
+        x = np.zeros(3)
+        A[:, 0] = x
+        A[1, :] = x
+        assert_array_equal(A.todense(), [[0, 1, 1], [0, 0, 0], [0, 1, 1]])
 
 class _TestFancyIndexing(object):
     """Tests fancy indexing features.  The tests for any matrix formats


### PR DESCRIPTION
Fixes gh-12857.

For an expression like `A[:3, 0] = np.ones(3)`, the logic in `__setitem__` produces the following canonicalized indexing arrays:
 - `i`: column vector `[[0, 1, 2]].T`
 - `j`: row vector `[[0,0,0]]`

The issue is that we would then try to broadcast the new values (`x`) against `i`, creating a 3x3 array. By checking whether a broadcast is necessary, we can avoid some extra work and prevent corner cases like this one.