### PR TITLE
ENH, MAINT: Bring KDTree interface to feature-parity with cKDTree

### DIFF
--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -423,25 +423,6 @@ cdef class cKDTree:
     which can be used to rapidly look up the nearest neighbors of any
     point.
 
-    The algorithm used is described in Maneewongvatana and Mount 1999.
-    The general idea is that the kd-tree is a binary tree, each of whose
-    nodes represents an axis-aligned hyperrectangle. Each node specifies
-    an axis and splits the set of points based on whether their coordinate
-    along that axis is greater than or less than a particular value.
-
-    During construction, the axis and splitting point are chosen by the
-    "sliding midpoint" rule, which ensures that the cells do not all
-    become long and thin.
-
-    The tree can be queried for the r closest neighbors of any given point
-    (optionally returning only those within some maximum distance of the
-    point). It can also be queried, with a substantial gain in efficiency,
-    for the r approximate closest neighbors.
-
-    For large dimensions (20 is already large) do not expect this to run
-    significantly faster than brute force. High-dimensional nearest-neighbor
-    queries are a substantial open problem in computer science.
-
     Parameters
     ----------
     data : array_like, shape (n,m)
@@ -472,6 +453,27 @@ cdef class cKDTree:
         into :math:`[0, L_i)`. A ValueError is raised if any of the data is
         outside of this bound.
 
+    Notes
+    -----
+    The algorithm used is described in Maneewongvatana and Mount 1999.
+    The general idea is that the kd-tree is a binary tree, each of whose
+    nodes represents an axis-aligned hyperrectangle. Each node specifies
+    an axis and splits the set of points based on whether their coordinate
+    along that axis is greater than or less than a particular value.
+
+    During construction, the axis and splitting point are chosen by the
+    "sliding midpoint" rule, which ensures that the cells do not all
+    become long and thin.
+
+    The tree can be queried for the r closest neighbors of any given point
+    (optionally returning only those within some maximum distance of the
+    point). It can also be queried, with a substantial gain in efficiency,
+    for the r approximate closest neighbors.
+
+    For large dimensions (20 is already large) do not expect this to run
+    significantly faster than brute force. High-dimensional nearest-neighbor
+    queries are a substantial open problem in computer science.
+
     Attributes
     ----------
     data : ndarray, shape (n,m)
@@ -497,10 +499,6 @@ cdef class cKDTree:
         query functions in Python.
     size : int
         The number of nodes in the tree.
-
-    See Also
-    --------
-    KDTree : Implementation of `cKDTree` in pure Python
 
     """
     cdef:
@@ -900,6 +898,17 @@ cdef class cKDTree:
         >>> tree.query_ball_point([2, 0], 1)
         [4, 8, 9, 12]
 
+        Query multiple points and plot the results:
+
+        >>> import matplotlib.pyplot as plt
+        >>> points = np.asarray(points)
+        >>> plt.plot(points[:,0], points[:,1], '.')
+        >>> for results in tree.query_ball_point(([2, 0], [3, 3]), 1):
+        ...     nearby_points = points[results]
+        ...     plt.plot(nearby_points[:,0], nearby_points[:,1], 'o')
+        >>> plt.margins(0.1, 0.1)
+        >>> plt.show()
+
         """
 
         cdef:
@@ -1180,16 +1189,17 @@ cdef class cKDTree:
         """
         count_neighbors(self, other, r, p=2., weights=None, cumulative=True)
 
-        Count how many nearby pairs can be formed. (pair-counting)
+        Count how many nearby pairs can be formed.
 
-        Count the number of pairs (x1,x2) can be formed, with x1 drawn
-        from self and x2 drawn from ``other``, and where
+        Count the number of pairs ``(x1,x2)`` can be formed, with ``x1`` drawn
+        from ``self`` and ``x2`` drawn from ``other``, and where
         ``distance(x1, x2, p) <= r``.
 
-        Data points on self and other are optionally weighted by the ``weights``
-        argument. (See below)
+        Data points on ``self`` and ``other`` are optionally weighted by the
+        ``weights`` argument. (See below)
 
-        The algorithm we implement here is based on [1]_. See notes for further discussion.
+        This is adapted from the "two-point correlation" algorithm described by
+        Gray and Moore [1]_.  See notes for further discussion.
 
         Parameters
         ----------

--- a/scipy/spatial/kdtree.py
+++ b/scipy/spatial/kdtree.py
@@ -183,17 +183,39 @@ class KDTree(cKDTree):
     """
     kd-tree for quick nearest-neighbor lookup
 
-    This class provides an index into a set of k-D points which
-    can be used to rapidly look up the nearest neighbors of any point.
+    This class provides an index into a set of k-dimensional points
+    which can be used to rapidly look up the nearest neighbors of any
+    point.
 
     Parameters
     ----------
-    data : (N,K) array_like
-        The data points to be indexed. This array is not copied, and
-        so modifying this data will result in bogus results.
-    leafsize : int, optional
+    data : array_like, shape (n,m)
+        The n data points of dimension m to be indexed. This array is
+        not copied unless this is necessary to produce a contiguous
+        array of doubles, and so modifying this data will result in
+        bogus results. The data are also copied if the kd-tree is built
+        with copy_data=True.
+    leafsize : positive int, optional
         The number of points at which the algorithm switches over to
-        brute-force.  Has to be positive.
+        brute-force.  Default: 10.
+    compact_nodes : bool, optional
+        If True, the kd-tree is built to shrink the hyperrectangles to
+        the actual data range. This usually gives a more compact tree that
+        is robust against degenerated input data and gives faster queries
+        at the expense of longer build time. Default: True.
+    copy_data : bool, optional
+        If True the data is always copied to protect the kd-tree against
+        data corruption. Default: False.
+    balanced_tree : bool, optional
+        If True, the median is used to split the hyperrectangles instead of
+        the midpoint. This usually gives a more compact tree and
+        faster queries at the expense of longer build time. Default: True.
+    boxsize : array_like or scalar, optional
+        Apply a m-d toroidal topology to the KDTree.. The topology is generated
+        by :math:`x_i + n_i L_i` where :math:`n_i` are integers and :math:`L_i`
+        is the boxsize along i-th dimension. The input data shall be wrapped
+        into :math:`[0, L_i)`. A ValueError is raised if any of the data is
+        outside of this bound.
 
     Notes
     -----
@@ -216,10 +238,26 @@ class KDTree(cKDTree):
     significantly faster than brute force. High-dimensional nearest-neighbor
     queries are a substantial open problem in computer science.
 
-    The tree also supports all-neighbors queries, both with arrays of points
-    and with other kd-trees. These do use a reasonably efficient algorithm,
-    but the kd-tree is not necessarily the best data structure for this
-    sort of calculation.
+    Attributes
+    ----------
+    data : ndarray, shape (n,m)
+        The n data points of dimension m to be indexed. This array is
+        not copied unless this is necessary to produce a contiguous
+        array of doubles. The data are also copied if the kd-tree is built
+        with `copy_data=True`.
+    leafsize : positive int
+        The number of points at which the algorithm switches over to
+        brute-force.
+    m : int
+        The dimension of a single data-point.
+    n : int
+        The number of data points.
+    maxes : ndarray, shape (m,)
+        The maximum value in each dimension of the n data points.
+    mins : ndarray, shape (m,)
+        The minimum value in each dimension of the n data points.
+    size : int
+        The number of nodes in the tree.
 
     """
 
@@ -289,24 +327,27 @@ class KDTree(cKDTree):
 
         return self._tree
 
-    def __init__(self, data, leafsize=10):
+    def __init__(self, data, leafsize=10, compact_nodes=True, copy_data=False,
+                 balanced_tree=True, boxsize=None):
         data = np.asarray(data)
         if data.dtype.kind == 'c':
             raise TypeError("KDTree does not work with complex data")
 
         # Note KDTree has different default leafsize from cKDTree
-        super().__init__(data, leafsize)
+        super().__init__(data, leafsize, compact_nodes, copy_data,
+                         balanced_tree, boxsize)
 
-    def query(self, x, k=1, eps=0, p=2, distance_upper_bound=np.inf):
-        """
-        Query the kd-tree for nearest neighbors
+    def query(
+            self, x, k=1, eps=0, p=2, distance_upper_bound=np.inf, workers=1):
+        """Query the kd-tree for nearest neighbors
 
         Parameters
         ----------
         x : array_like, last dimension self.m
             An array of points to query.
-        k : int, optional
-            The number of nearest neighbors to return.
+        k : int or Sequence[int], optional
+            Either the number of nearest neighbors to return, or a list of the
+            k-th nearest neighbors to return, starting from 1.
         eps : nonnegative float, optional
             Return approximate nearest neighbors; the kth returned value
             is guaranteed to be no further than (1+eps) times the
@@ -316,68 +357,85 @@ class KDTree(cKDTree):
             1 is the sum-of-absolute-values "Manhattan" distance
             2 is the usual Euclidean distance
             infinity is the maximum-coordinate-difference distance
+            A large, finite p may cause a ValueError if overflow can occur.
         distance_upper_bound : nonnegative float, optional
             Return only neighbors within this distance. This is used to prune
             tree searches, so if you are doing a series of nearest-neighbor
             queries, it may help to supply the distance to the nearest neighbor
             of the most recent point.
+        workers : int, optional
+            Number of workers to use for parallel processing. If -1 is given
+            all CPU threads are used. Default: 1.
+
+            .. versionadded:: 1.6.0
 
         Returns
         -------
         d : float or array of floats
             The distances to the nearest neighbors.
-            If x has shape tuple+(self.m,), then d has shape tuple if
-            k is one, or tuple+(k,) if k is larger than one. Missing
-            neighbors (e.g. when k > n or distance_upper_bound is
-            given) are indicated with infinite distances.  If k is None,
-            then d is an object array of shape tuple, containing lists
-            of distances. In either case the hits are sorted by distance
-            (nearest first).
+            If ``x`` has shape ``tuple+(self.m,)``, then ``d`` has shape
+            ``tuple+(k,)``.
+            When k == 1, the last dimension of the output is squeezed.
+            Missing neighbors are indicated with infinite distances.
+            Hits are sorted by distance (nearest first).
+
+            .. deprecated:: 1.6.0
+               If ``k=None``, then ``d`` is an object array of shape ``tuple``,
+               containing lists of distances. This behavior is deprecated and
+               will be removed in SciPy 1.8.0, use ``query_ball_point``
+               instead.
+
         i : integer or array of integers
-            The locations of the neighbors in self.data. i is the same
-            shape as d.
+            The locations of the neighbors in ``self.data``.
+            ``i`` is the same shape as d.
+            Missing neighbors are indicated with ``self.n``.
 
         Examples
         --------
-        >>> from scipy import spatial
+
+        >>> import numpy as np
+        >>> from scipy.spatial import KDTree
         >>> x, y = np.mgrid[0:5, 2:8]
-        >>> tree = spatial.KDTree(list(zip(x.ravel(), y.ravel())))
-        >>> tree.data
-        array([[0, 2],
-               [0, 3],
-               [0, 4],
-               [0, 5],
-               [0, 6],
-               [0, 7],
-               [1, 2],
-               [1, 3],
-               [1, 4],
-               [1, 5],
-               [1, 6],
-               [1, 7],
-               [2, 2],
-               [2, 3],
-               [2, 4],
-               [2, 5],
-               [2, 6],
-               [2, 7],
-               [3, 2],
-               [3, 3],
-               [3, 4],
-               [3, 5],
-               [3, 6],
-               [3, 7],
-               [4, 2],
-               [4, 3],
-               [4, 4],
-               [4, 5],
-               [4, 6],
-               [4, 7]])
-        >>> pts = np.array([[0, 0], [2.1, 2.9]])
-        >>> tree.query(pts)
-        (array([ 2.        ,  0.14142136]), array([ 0, 13]))
-        >>> tree.query(pts[0])
-        (2.0, 0)
+        >>> tree = KDTree(np.c_[x.ravel(), y.ravel()])
+
+        To query the nearest neighbours and return squeezed result, use
+
+        >>> dd, ii = tree.query([[0, 0], [2.1, 2.9]], k=1)
+        >>> print(dd, ii)
+        [2.         0.14142136] [ 0 13]
+
+        To query the nearest neighbours and return unsqueezed result, use
+
+        >>> dd, ii = tree.query([[0, 0], [2.1, 2.9]], k=[1])
+        >>> print(dd, ii)
+        [[2.        ]
+         [0.14142136]] [[ 0]
+         [13]]
+
+        To query the second nearest neighbours and return unsqueezed result,
+        use
+
+        >>> dd, ii = tree.query([[0, 0], [2.1, 2.9]], k=[2])
+        >>> print(dd, ii)
+        [[2.23606798]
+         [0.90553851]] [[ 6]
+         [12]]
+
+        To query the first and second nearest neighbours, use
+
+        >>> dd, ii = tree.query([[0, 0], [2.1, 2.9]], k=2)
+        >>> print(dd, ii)
+        [[2.         2.23606798]
+         [0.14142136 0.90553851]] [[ 0  6]
+         [13 12]]
+
+        or, be more specific
+
+        >>> dd, ii = tree.query([[0, 0], [2.1, 2.9]], k=[1, 2])
+        >>> print(dd, ii)
+        [[2.         2.23606798]
+         [0.14142136 0.90553851]] [[ 0  6]
+         [13 12]]
 
         """
         x = np.asarray(x)
@@ -399,7 +457,8 @@ class KDTree(cKDTree):
                 return [d for d, i in hits], [i for d, i in hits]
 
             x = np.asarray(x, dtype=np.float64)
-            inds = super().query_ball_point(x, distance_upper_bound, p, eps)
+            inds = super().query_ball_point(
+                x, distance_upper_bound, p, eps, workers)
 
             if isinstance(inds, list):
                 return inds_to_hits(x, inds)
@@ -410,27 +469,46 @@ class KDTree(cKDTree):
 
             return dists, inds
 
-        d, i = super().query(x, k, eps, p, distance_upper_bound)
+        d, i = super().query(x, k, eps, p, distance_upper_bound, workers)
         if isinstance(i, int):
             i = np.intp(i)
         return d, i
 
-    def query_ball_point(self, x, r, p=2., eps=0):
+    def query_ball_point(self, x, r, p=2., eps=0, workers=1,
+                         return_sorted=None, return_length=False):
         """Find all points within distance r of point(s) x.
 
         Parameters
         ----------
         x : array_like, shape tuple + (self.m,)
             The point or points to search for neighbors of.
-        r : positive float
-            The radius of points to return.
+        r : array_like, float
+            The radius of points to return, must broadcast to the length of x.
         p : float, optional
             Which Minkowski p-norm to use.  Should be in the range [1, inf].
+            A finite large p may cause a ValueError if overflow can occur.
         eps : nonnegative float, optional
             Approximate search. Branches of the tree are not explored if their
             nearest points are further than ``r / (1 + eps)``, and branches are
             added in bulk if their furthest points are nearer than
             ``r * (1 + eps)``.
+        workers : int, optional
+            Number of jobs to schedule for parallel processing. If -1 is given
+            all processors are used. Default: 1.
+
+            .. versionadded:: 1.6.0
+        return_sorted : bool, optional
+            Sorts returned indicies if True and does not sort them if False. If
+            None, does not sort single point queries, but does sort
+            multi-point queries which was the behavior before this option
+            was added.
+
+            .. versionadded:: 1.6.0
+        return_length: bool, optional
+            Return the number of points inside the radius instead of a list
+            of the indices.
+
+            .. versionadded:: 1.6.0
 
         Returns
         -------
@@ -469,7 +547,8 @@ class KDTree(cKDTree):
         x = np.asarray(x)
         if x.dtype.kind == 'c':
             raise TypeError("KDTree does not work with complex data")
-        return super().query_ball_point(x, r, p, eps)
+        return super().query_ball_point(
+            x, r, p, eps, workers, return_sorted, return_length)
 
     def query_ball_tree(self, other, r, p=2., eps=0):
         """
@@ -521,7 +600,7 @@ class KDTree(cKDTree):
         """
         return super().query_ball_tree(other, r, p, eps)
 
-    def query_pairs(self, r, p=2., eps=0):
+    def query_pairs(self, r, p=2., eps=0, output_type='set'):
         """
         Find all pairs of points in `self` whose distance is at most r.
 
@@ -537,12 +616,17 @@ class KDTree(cKDTree):
             if their nearest points are further than ``r/(1+eps)``, and
             branches are added in bulk if their furthest points are nearer
             than ``r * (1+eps)``.  `eps` has to be non-negative.
+        output_type : string, optional
+            Choose the output container, 'set' or 'ndarray'. Default: 'set'
+
+            .. versionadded:: 1.6.0
 
         Returns
         -------
-        results : set
+        results : set or ndarray
             Set of pairs ``(i,j)``, with ``i < j``, for which the corresponding
-            positions are close.
+            positions are close. If output_type is 'ndarray', an ndarry is
+            returned instead of a set.
 
         Examples
         --------
@@ -563,33 +647,131 @@ class KDTree(cKDTree):
         >>> plt.show()
 
         """
-        return super().query_pairs(r, p, eps)
+        return super().query_pairs(r, p, eps, output_type)
 
-    def count_neighbors(self, other, r, p=2.):
-        """
-        Count how many nearby pairs can be formed.
+    def count_neighbors(self, other, r, p=2., weights=None, cumulative=True):
+        """Count how many nearby pairs can be formed.
 
-        Count the number of pairs (x1,x2) can be formed, with x1 drawn
-        from self and x2 drawn from ``other``, and where
+        Count the number of pairs ``(x1,x2)`` can be formed, with ``x1`` drawn
+        from ``self`` and ``x2`` drawn from ``other``, and where
         ``distance(x1, x2, p) <= r``.
-        This is the "two-point correlation" described in Gray and Moore 2000,
-        "N-body problems in statistical learning", and the code here is based
-        on their algorithm.
+
+        Data points on ``self`` and ``other`` are optionally weighted by the
+        ``weights`` argument. (See below)
+
+        This is adapted from the "two-point correlation" algorithm described by
+        Gray and Moore [1]_.  See notes for further discussion.
 
         Parameters
         ----------
-        other : KDTree instance
-            The other tree to draw points from.
+        other : KDTree
+            The other tree to draw points from, can be the same tree as self.
         r : float or one-dimensional array of floats
             The radius to produce a count for. Multiple radii are searched with
             a single tree traversal.
-        p : float, 1<=p<=infinity, optional
-            Which Minkowski p-norm to use
+            If the count is non-cumulative(``cumulative=False``), ``r`` defines
+            the edges of the bins, and must be non-decreasing.
+        p : float, optional
+            1<=p<=infinity.
+            Which Minkowski p-norm to use.
+            Default 2.0.
+            A finite large p may cause a ValueError if overflow can occur.
+        weights : tuple, array_like, or None, optional
+            If None, the pair-counting is unweighted.
+            If given as a tuple, weights[0] is the weights of points in
+            ``self``, and weights[1] is the weights of points in ``other``;
+            either can be None to indicate the points are unweighted.
+            If given as an array_like, weights is the weights of points in
+            ``self`` and ``other``. For this to make sense, ``self`` and
+            ``other`` must be the same tree. If ``self`` and ``other`` are two
+            different trees, a ``ValueError`` is raised.
+            Default: None
+
+            .. versionadded:: 1.6.0
+        cumulative : bool, optional
+            Whether the returned counts are cumulative. When cumulative is set
+            to ``False`` the algorithm is optimized to work with a large number
+            of bins (>10) specified by ``r``. When ``cumulative`` is set to
+            True, the algorithm is optimized to work with a small number of
+            ``r``. Default: True
+
+            .. versionadded:: 1.6.0
 
         Returns
         -------
-        result : int or 1-D array of ints
-            The number of pairs.
+        result : scalar or 1-D array
+            The number of pairs. For unweighted counts, the result is integer.
+            For weighted counts, the result is float.
+            If cumulative is False, ``result[i]`` contains the counts with
+            ``(-inf if i == 0 else r[i-1]) < R <= r[i]``
+
+        Notes
+        -----
+        Pair-counting is the basic operation used to calculate the two point
+        correlation functions from a data set composed of position of objects.
+
+        Two point correlation function measures the clustering of objects and
+        is widely used in cosmology to quantify the large scale structure
+        in our Universe, but it may be useful for data analysis in other fields
+        where self-similar assembly of objects also occur.
+
+        The Landy-Szalay estimator for the two point correlation function of
+        ``D`` measures the clustering signal in ``D``. [2]_
+
+        For example, given the position of two sets of objects,
+
+        - objects ``D`` (data) contains the clustering signal, and
+
+        - objects ``R`` (random) that contains no signal,
+
+        .. math::
+
+             \\xi(r) = \\frac{<D, D> - 2 f <D, R> + f^2<R, R>}{f^2<R, R>},
+
+        where the brackets represents counting pairs between two data sets
+        in a finite bin around ``r`` (distance), corresponding to setting
+        `cumulative=False`, and ``f = float(len(D)) / float(len(R))`` is the
+        ratio between number of objects from data and random.
+
+        The algorithm implemented here is loosely based on the dual-tree
+        algorithm described in [1]_. We switch between two different
+        pair-cumulation scheme depending on the setting of ``cumulative``.
+        The computing time of the method we use when for
+        ``cumulative == False`` does not scale with the total number of bins.
+        The algorithm for ``cumulative == True`` scales linearly with the
+        number of bins, though it is slightly faster when only
+        1 or 2 bins are used. [5]_.
+
+        As an extension to the naive pair-counting,
+        weighted pair-counting counts the product of weights instead
+        of number of pairs.
+        Weighted pair-counting is used to estimate marked correlation functions
+        ([3]_, section 2.2),
+        or to properly calculate the average of data per distance bin
+        (e.g. [4]_, section 2.1 on redshift).
+
+        .. [1] Gray and Moore,
+               "N-body problems in statistical learning",
+               Mining the sky, 2000,
+               https://arxiv.org/abs/astro-ph/0012333
+
+        .. [2] Landy and Szalay,
+               "Bias and variance of angular correlation functions",
+               The Astrophysical Journal, 1993,
+               http://adsabs.harvard.edu/abs/1993ApJ...412...64L
+
+        .. [3] Sheth, Connolly and Skibba,
+               "Marked correlations in galaxy formation models",
+               Arxiv e-print, 2005,
+               https://arxiv.org/abs/astro-ph/0511773
+
+        .. [4] Hawkins, et al.,
+               "The 2dF Galaxy Redshift Survey: correlation functions,
+               peculiar velocities and the matter density of the Universe",
+               Monthly Notices of the Royal Astronomical Society, 2002,
+               http://adsabs.harvard.edu/abs/2003MNRAS.346...78H
+
+        .. [5] https://github.com/scipy/scipy/pull/5647#issuecomment-168474926
 
         Examples
         --------
@@ -613,9 +795,10 @@ class KDTree(cKDTree):
         9
 
         """
-        return super().count_neighbors(other, r, p)
+        return super().count_neighbors(other, r, p, weights, cumulative)
 
-    def sparse_distance_matrix(self, other, max_distance, p=2.):
+    def sparse_distance_matrix(
+            self, other, max_distance, p=2., output_type='dok_matrix'):
         """
         Compute a sparse distance matrix
 
@@ -628,12 +811,23 @@ class KDTree(cKDTree):
 
         max_distance : positive float
 
-        p : float, optional
+        p : float, 1<=p<=infinity
+            Which Minkowski p-norm to use.
+            A finite large p may cause a ValueError if overflow can occur.
+
+        output_type : string, optional
+            Which container to use for output data. Options: 'dok_matrix',
+            'coo_matrix', 'dict', or 'ndarray'. Default: 'dok_matrix'.
+
+            .. versionadded:: 1.6.0
 
         Returns
         -------
-        result : dok_matrix
-            Sparse matrix representing the results in "dictionary of keys" format.
+        result : dok_matrix, coo_matrix, dict or ndarray
+            Sparse matrix representing the results in "dictionary of keys"
+            format. If a dict is returned the keys are (i,j) tuples of indices.
+            If output_type is 'ndarray' a record array with fields 'i', 'j',
+            and 'v' is returned,
 
         Examples
         --------
@@ -665,7 +859,8 @@ class KDTree(cKDTree):
             [0.17308768, 0.32837991, 0.72760803, 0.24823138, 0.75017239]])
 
         """
-        return super().sparse_distance_matrix(other, max_distance, p)
+        return super().sparse_distance_matrix(
+            other, max_distance, p, output_type)
 
 
 def distance_matrix(x, y, p=2, threshold=1000000):

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -15,6 +15,31 @@ from scipy.spatial import minkowski_distance
 
 import itertools
 
+@pytest.fixture(params=[KDTree, cKDTree])
+def kdtree_type(request):
+    return request.param
+
+
+def KDTreeTest(kls):
+    """Class decorator to create test cases for KDTree and cKDTree
+
+    Tests use the class variable ``kdtree_type`` as the tree constructor.
+    """
+    if not kls.__name__.startswith('_Test'):
+        raise RuntimeError("Expected a class name starting with _Test")
+
+    for tree in (KDTree, cKDTree):
+        test_name = kls.__name__[1:] + '_' + tree.__name__
+
+        if test_name in globals():
+            raise RuntimeError("Duplicated test name: " + test_name)
+
+        # Create a new sub-class with kdtree_type defined
+        test_case = type(test_name, (kls,), {'kdtree_type': tree})
+        globals()[test_name] = test_case
+    return kls
+
+
 def distance_box(a, b, p, boxsize):
     diff = a - b
     diff[diff > 0.5 * boxsize] -= boxsize
@@ -94,24 +119,28 @@ class ConsistencyTests:
         assert_(np.all(d <= d_real*(1+eps)))
 
 
-class Test_random(ConsistencyTests):
+@KDTreeTest
+class _Test_random(ConsistencyTests):
     def setup_method(self):
         self.n = 100
         self.m = 4
         np.random.seed(1234)
         self.data = np.random.randn(self.n, self.m)
-        self.kdtree = KDTree(self.data, leafsize=2)
+        self.kdtree = self.kdtree_type(self.data, leafsize=2)
         self.x = np.random.randn(self.m)
         self.d = 0.2
         self.k = 10
 
-class Test_random_far(Test_random):
+
+@KDTreeTest
+class _Test_random_far(_Test_random):
     def setup_method(self):
-        Test_random.setup_method(self)
+        super().setup_method()
         self.x = np.random.randn(self.m)+10
 
 
-class Test_small(ConsistencyTests):
+@KDTreeTest
+class _Test_small(ConsistencyTests):
     def setup_method(self):
         self.data = np.array([[0, 0, 0],
                               [0, 0, 1],
@@ -121,7 +150,7 @@ class Test_small(ConsistencyTests):
                               [1, 0, 1],
                               [1, 1, 0],
                               [1, 1, 1]])
-        self.kdtree = KDTree(self.data)
+        self.kdtree = self.kdtree_type(self.data)
         self.n = self.kdtree.n
         self.m = self.kdtree.m
         np.random.seed(1234)
@@ -140,37 +169,14 @@ class Test_small(ConsistencyTests):
                 ([0.1, 0.9], [0, 1]))
 
 
-class Test_small_nonleaf(Test_small):
+@KDTreeTest
+class _Test_small_nonleaf(_Test_small):
     def setup_method(self):
-        Test_small.setup_method(self)
-        self.kdtree = KDTree(self.data, leafsize=1)
+        super().setup_method()
+        self.kdtree = self.kdtree_type(self.data, leafsize=1)
 
 
-class Test_small_compiled(Test_small):
-    def setup_method(self):
-        Test_small.setup_method(self)
-        self.kdtree = cKDTree(self.data)
-
-
-class Test_small_nonleaf_compiled(Test_small):
-    def setup_method(self):
-        Test_small.setup_method(self)
-        self.kdtree = cKDTree(self.data, leafsize=1)
-
-
-class Test_random_compiled(Test_random):
-    def setup_method(self):
-        Test_random.setup_method(self)
-        self.kdtree = cKDTree(self.data)
-
-
-class Test_random_far_compiled(Test_random_far):
-    def setup_method(self):
-        Test_random_far.setup_method(self)
-        self.kdtree = cKDTree(self.data)
-
-
-class Test_vectorization:
+class Test_vectorization_KDTree:
     def setup_method(self):
         self.data = np.array([[0, 0, 0],
                               [0, 0, 1],
@@ -252,7 +258,7 @@ class Test_vectorization:
                     points[idx], self.kdtree.data[ind]))
 
 
-class Test_vectorization_compiled:
+class Test_vectorization_cKDTree:
     def setup_method(self):
         self.data = np.array([[0, 0, 0],
                               [0, 0, 1],
@@ -325,34 +331,22 @@ class ball_consistency:
             norm = self.distance(self.data[c], x[i], self.p) + d[i]/(1.+self.eps)
             assert_array_equal(dist > -self.tol * norm, True)
 
-class Test_random_ball(ball_consistency):
-
+@KDTreeTest
+class _Test_random_ball(ball_consistency):
     def setup_method(self):
         n = 100
         m = 4
         np.random.seed(1234)
         self.data = np.random.randn(n, m)
-        self.T = KDTree(self.data, leafsize=2)
+        self.T = self.kdtree_type(self.data, leafsize=2)
         self.x = np.random.randn(m)
         self.p = 2.
         self.eps = 0
         self.d = 0.2
 
 
-class Test_random_ball_compiled(ball_consistency):
-
-    def setup_method(self):
-        n = 100
-        m = 4
-        np.random.seed(1234)
-        self.data = np.random.randn(n, m)
-        self.T = cKDTree(self.data, leafsize=2)
-        self.x = np.random.randn(m)
-        self.p = 2.
-        self.eps = 0
-        self.d = 0.2
-
-class Test_random_ball_compiled_periodic(ball_consistency):
+@KDTreeTest
+class _Test_random_ball_periodic(ball_consistency):
     def distance(self, a, b, p):
         return distance_box(a, b, p, 1.0)
 
@@ -361,7 +355,7 @@ class Test_random_ball_compiled_periodic(ball_consistency):
         m = 4
         np.random.seed(1234)
         self.data = np.random.uniform(size=(n, m))
-        self.T = cKDTree(self.data, leafsize=2, boxsize=1)
+        self.T = self.kdtree_type(self.data, leafsize=2, boxsize=1)
         self.x = np.full(m, 0.1)
         self.p = 2.
         self.eps = 0
@@ -385,7 +379,9 @@ class Test_random_ball_compiled_periodic(ball_consistency):
         c[l] = False
         assert_(np.all(self.distance(self.data[c], self.x, self.p) >= self.d/(1.+self.eps)))
 
-class Test_random_ball_compiled_largep_issue9890(ball_consistency):
+
+@KDTreeTest
+class _Test_random_ball_largep_issue9890(ball_consistency):
 
     # allow some roundoff errors due to numerical issues
     tol = 1e-13
@@ -395,103 +391,77 @@ class Test_random_ball_compiled_largep_issue9890(ball_consistency):
         m = 2
         np.random.seed(123)
         self.data = np.random.randint(100, 1000, size=(n, m))
-        self.T = cKDTree(self.data)
+        self.T = self.kdtree_type(self.data)
         self.x = self.data
         self.p = 100
         self.eps = 0
         self.d = 10
 
-class Test_random_ball_approx(Test_random_ball):
+
+@KDTreeTest
+class _Test_random_ball_approx(_Test_random_ball):
 
     def setup_method(self):
-        Test_random_ball.setup_method(self)
+        super().setup_method()
         self.eps = 0.1
 
 
-class Test_random_ball_approx_compiled(Test_random_ball_compiled):
+@KDTreeTest
+class _Test_random_ball_approx_periodic(_Test_random_ball):
 
     def setup_method(self):
-        Test_random_ball_compiled.setup_method(self)
-        self.eps = 0.1
-
-class Test_random_ball_approx_compiled_periodic(Test_random_ball_compiled_periodic):
-
-    def setup_method(self):
-        Test_random_ball_compiled_periodic.setup_method(self)
+        super().setup_method()
         self.eps = 0.1
 
 
-class Test_random_ball_far(Test_random_ball):
+@KDTreeTest
+class _Test_random_ball_far(_Test_random_ball):
 
     def setup_method(self):
-        Test_random_ball.setup_method(self)
+        super().setup_method()
+        self.d = 2.
+
+@KDTreeTest
+class _Test_random_ball_far_periodic(_Test_random_ball_periodic):
+
+    def setup_method(self):
+        super().setup_method()
         self.d = 2.
 
 
-class Test_random_ball_far_compiled(Test_random_ball_compiled):
+@KDTreeTest
+class _Test_random_ball_l1(_Test_random_ball):
 
     def setup_method(self):
-        Test_random_ball_compiled.setup_method(self)
-        self.d = 2.
-
-class Test_random_ball_far_compiled_periodic(Test_random_ball_compiled_periodic):
-
-    def setup_method(self):
-        Test_random_ball_compiled_periodic.setup_method(self)
-        self.d = 2.
-
-
-class Test_random_ball_l1(Test_random_ball):
-
-    def setup_method(self):
-        Test_random_ball.setup_method(self)
+        super().setup_method()
         self.p = 1
 
 
-class Test_random_ball_l1_compiled(Test_random_ball_compiled):
+@KDTreeTest
+class _Test_random_ball_linf(_Test_random_ball):
 
     def setup_method(self):
-        Test_random_ball_compiled.setup_method(self)
-        self.p = 1
-
-class Test_random_ball_l1_compiled_periodic(Test_random_ball_compiled_periodic):
-
-    def setup_method(self):
-        Test_random_ball_compiled_periodic.setup_method(self)
-        self.p = 1
-
-
-class Test_random_ball_linf(Test_random_ball):
-
-    def setup_method(self):
-        Test_random_ball.setup_method(self)
-        self.p = np.inf
-
-class Test_random_ball_linf_compiled_periodic(Test_random_ball_compiled_periodic):
-
-    def setup_method(self):
-        Test_random_ball_compiled_periodic.setup_method(self)
+        super().setup_method()
         self.p = np.inf
 
 
-@pytest.mark.parametrize('TreeType', [KDTree, cKDTree])
-def test_random_ball_vectorized(TreeType):
+def test_random_ball_vectorized(kdtree_type):
     n = 20
     m = 5
     np.random.seed(1234)
-    T = TreeType(np.random.randn(n, m))
+    T = kdtree_type(np.random.randn(n, m))
 
     r = T.query_ball_point(np.random.randn(2, 3, m), 1)
     assert_equal(r.shape, (2, 3))
     assert_(isinstance(r[0, 0], list))
 
 
-def test_query_ball_point_multithreading():
+def test_query_ball_point_multithreading(kdtree_type):
     np.random.seed(0)
     n = 5000
     k = 2
     points = np.random.randn(n, k)
-    T = cKDTree(points)
+    T = kdtree_type(points)
     l1 = T.query_ball_point(points, 0.003, workers=1)
     l2 = T.query_ball_point(points, 0.003, workers=64)
     l3 = T.query_ball_point(points, 0.003, workers=-1)
@@ -541,36 +511,24 @@ class two_trees_consistency:
             assert_(np.all(self.distance(self.data2[c], self.data1[i], self.p) >= self.d/(1.+self.eps)))
 
 
-class Test_two_random_trees(two_trees_consistency):
+@KDTreeTest
+class _Test_two_random_trees(two_trees_consistency):
 
     def setup_method(self):
         n = 50
         m = 4
         np.random.seed(1234)
         self.data1 = np.random.randn(n, m)
-        self.T1 = KDTree(self.data1, leafsize=2)
+        self.T1 = self.kdtree_type(self.data1, leafsize=2)
         self.data2 = np.random.randn(n, m)
-        self.T2 = KDTree(self.data2, leafsize=2)
+        self.T2 = self.kdtree_type(self.data2, leafsize=2)
         self.p = 2.
         self.eps = 0
         self.d = 0.2
 
 
-class Test_two_random_trees_compiled(two_trees_consistency):
-
-    def setup_method(self):
-        n = 50
-        m = 4
-        np.random.seed(1234)
-        self.data1 = np.random.randn(n, m)
-        self.T1 = cKDTree(self.data1, leafsize=2)
-        self.data2 = np.random.randn(n, m)
-        self.T2 = cKDTree(self.data2, leafsize=2)
-        self.p = 2.
-        self.eps = 0
-        self.d = 0.2
-
-class Test_two_random_trees_compiled_periodic(two_trees_consistency):
+@KDTreeTest
+class _Test_two_random_trees_periodic(two_trees_consistency):
     def distance(self, a, b, p):
         return distance_box(a, b, p, 1.0)
 
@@ -579,50 +537,43 @@ class Test_two_random_trees_compiled_periodic(two_trees_consistency):
         m = 4
         np.random.seed(1234)
         self.data1 = np.random.uniform(size=(n, m))
-        self.T1 = cKDTree(self.data1, leafsize=2, boxsize=1.0)
+        self.T1 = self.kdtree_type(self.data1, leafsize=2, boxsize=1.0)
         self.data2 = np.random.uniform(size=(n, m))
-        self.T2 = cKDTree(self.data2, leafsize=2, boxsize=1.0)
+        self.T2 = self.kdtree_type(self.data2, leafsize=2, boxsize=1.0)
         self.p = 2.
         self.eps = 0
         self.d = 0.2
 
-class Test_two_random_trees_far(Test_two_random_trees):
+
+@KDTreeTest
+class _Test_two_random_trees_far(_Test_two_random_trees):
 
     def setup_method(self):
-        Test_two_random_trees.setup_method(self)
+        super().setup_method()
         self.d = 2
 
 
-class Test_two_random_trees_far_compiled(Test_two_random_trees_compiled):
+@KDTreeTest
+class _Test_two_random_trees_far_periodic(_Test_two_random_trees_periodic):
 
     def setup_method(self):
-        Test_two_random_trees_compiled.setup_method(self)
-        self.d = 2
-
-class Test_two_random_trees_far_compiled_periodic(Test_two_random_trees_compiled_periodic):
-
-    def setup_method(self):
-        Test_two_random_trees_compiled_periodic.setup_method(self)
+        super().setup_method()
         self.d = 2
 
 
-class Test_two_random_trees_linf(Test_two_random_trees):
+@KDTreeTest
+class _Test_two_random_trees_linf(_Test_two_random_trees):
 
     def setup_method(self):
-        Test_two_random_trees.setup_method(self)
+        super().setup_method()
         self.p = np.inf
 
 
-class Test_two_random_trees_linf_compiled(Test_two_random_trees_compiled):
+@KDTreeTest
+class _Test_two_random_trees_linf_periodic(_Test_two_random_trees_periodic):
 
     def setup_method(self):
-        Test_two_random_trees_compiled.setup_method(self)
-        self.p = np.inf
-
-class Test_two_random_trees_linf_compiled_periodic(Test_two_random_trees_compiled_periodic):
-
-    def setup_method(self):
-        Test_two_random_trees_compiled_periodic.setup_method(self)
+        super().setup_method()
         self.p = np.inf
 
 
@@ -694,24 +645,14 @@ class count_neighbors_consistency:
         for r, result in zip(rs, results):
             assert_equal(self.T1.count_neighbors(self.T2, r), result)
 
-class Test_count_neighbors(count_neighbors_consistency):
-
+@KDTreeTest
+class _Test_count_neighbors(count_neighbors_consistency):
     def setup_method(self):
         n = 50
         m = 2
         np.random.seed(1234)
-        self.T1 = KDTree(np.random.randn(n, m), leafsize=2)
-        self.T2 = KDTree(np.random.randn(n, m), leafsize=2)
-
-
-class Test_count_neighbors_compiled(count_neighbors_consistency):
-
-    def setup_method(self):
-        n = 50
-        m = 2
-        np.random.seed(1234)
-        self.T1 = cKDTree(np.random.randn(n, m), leafsize=2)
-        self.T2 = cKDTree(np.random.randn(n, m), leafsize=2)
+        self.T1 = self.kdtree_type(np.random.randn(n, m), leafsize=2)
+        self.T2 = self.kdtree_type(np.random.randn(n, m), leafsize=2)
 
 
 class sparse_distance_matrix_consistency:
@@ -734,40 +675,6 @@ class sparse_distance_matrix_consistency:
         # raises an exception for bug 870 (FIXME: Does it?)
         self.T1.sparse_distance_matrix(self.T1, self.r)
 
-class Test_sparse_distance_matrix(sparse_distance_matrix_consistency):
-
-    def setup_method(self):
-        n = 50
-        m = 4
-        np.random.seed(1234)
-        data1 = np.random.randn(n, m)
-        data2 = np.random.randn(n, m)
-        self.T1 = cKDTree(data1, leafsize=2)
-        self.T2 = cKDTree(data2, leafsize=2)
-        self.r = 0.5
-        self.p = 2
-        self.data1 = data1
-        self.data2 = data2
-        self.n = n
-        self.m = m
-
-class Test_sparse_distance_matrix_compiled(sparse_distance_matrix_consistency):
-
-    def setup_method(self):
-        n = 50
-        m = 4
-        np.random.seed(0)
-        data1 = np.random.randn(n, m)
-        data2 = np.random.randn(n, m)
-        self.T1 = cKDTree(data1, leafsize=2)
-        self.T2 = cKDTree(data2, leafsize=2)
-        self.r = 0.5
-        self.n = n
-        self.m = m
-        self.data1 = data1
-        self.data2 = data2
-        self.p = 2
-
     def test_consistency(self):
         # Test consistency with a distance_matrix
         M1 = self.T1.sparse_distance_matrix(self.T2, self.r)
@@ -779,7 +686,8 @@ class Test_sparse_distance_matrix_compiled(sparse_distance_matrix_consistency):
         # regression test for gh-5077 logic error
         np.random.seed(0)
         too_many = np.array(np.random.randn(18, 2), dtype=int)
-        tree = cKDTree(too_many, balanced_tree=False, compact_nodes=False)
+        tree = self.kdtree_type(
+            too_many, balanced_tree=False, compact_nodes=False)
         d = tree.sparse_distance_matrix(tree, 3).todense()
         assert_array_almost_equal(d, d.T, decimal=14)
 
@@ -818,6 +726,24 @@ class Test_sparse_distance_matrix_compiled(sparse_distance_matrix_consistency):
         assert_array_almost_equal(ref, r.todense(), decimal=14)
 
 
+@KDTreeTest
+class _Test_sparse_distance_matrix(sparse_distance_matrix_consistency):
+    def setup_method(self):
+        n = 50
+        m = 4
+        np.random.seed(1234)
+        data1 = np.random.randn(n, m)
+        data2 = np.random.randn(n, m)
+        self.T1 = self.kdtree_type(data1, leafsize=2)
+        self.T2 = self.kdtree_type(data2, leafsize=2)
+        self.r = 0.5
+        self.p = 2
+        self.data1 = data1
+        self.data2 = data2
+        self.n = n
+        self.m = m
+
+
 def test_distance_matrix():
     m = 10
     n = 11
@@ -854,39 +780,37 @@ def check_onetree_query(T, d):
 
     assert_(s == T.query_pairs(d))
 
-@pytest.mark.parametrize('TreeType', [KDTree, cKDTree])
-def test_onetree_query(TreeType):
+def test_onetree_query(kdtree_type):
     np.random.seed(0)
     n = 50
     k = 4
     points = np.random.randn(n, k)
-    T = TreeType(points)
+    T = kdtree_type(points)
     check_onetree_query(T, 0.1)
 
     points = np.random.randn(3*n, k)
     points[:n] *= 0.001
     points[n:2*n] += 2
-    T = TreeType(points)
+    T = kdtree_type(points)
     check_onetree_query(T, 0.1)
     check_onetree_query(T, 0.001)
     check_onetree_query(T, 0.00001)
     check_onetree_query(T, 1e-6)
 
 
-@pytest.mark.parametrize('TreeType', [KDTree, cKDTree])
-def test_query_pairs_single_node(TreeType):
-    tree = TreeType([[0, 1]])
+def test_query_pairs_single_node(kdtree_type):
+    tree = kdtree_type([[0, 1]])
     assert_equal(tree.query_pairs(0.5), set())
 
 
-def test_ckdtree_query_pairs():
+def test_kdtree_query_pairs(kdtree_type):
     np.random.seed(0)
     n = 50
     k = 2
     r = 0.1
     r2 = r**2
     points = np.random.randn(n, k)
-    T = cKDTree(points)
+    T = kdtree_type(points)
     # brute force reference
     brute = set()
     for i in range(n):
@@ -912,15 +836,15 @@ def test_ckdtree_query_pairs():
     assert_array_equal(l0, l2)
 
 
-def test_ball_point_ints():
+def test_ball_point_ints(kdtree_type):
     # Regression test for #1373.
     x, y = np.mgrid[0:4, 0:4]
     points = list(zip(x.ravel(), y.ravel()))
-    tree = KDTree(points)
+    tree = kdtree_type(points)
     assert_equal(sorted([4, 8, 9, 12]),
                  sorted(tree.query_ball_point((2, 0), 1)))
     points = np.asarray(points, dtype=float)
-    tree = KDTree(points)
+    tree = kdtree_type(points)
     assert_equal(sorted([4, 8, 9, 12]),
                  sorted(tree.query_ball_point((2, 0), 1)))
 
@@ -931,24 +855,23 @@ def test_kdtree_comparisons():
     assert_equal(sorted(nodes), sorted(nodes[::-1]))
 
 
-def test_ckdtree_build_modes():
-    # check if different build modes for cKDTree give
-    # similar query results
+def test_kdtree_build_modes(kdtree_type):
+    # check if different build modes for KDTree give similar query results
     np.random.seed(0)
     n = 5000
     k = 4
     points = np.random.randn(n, k)
-    T1 = cKDTree(points).query(points, k=5)[-1]
-    T2 = cKDTree(points, compact_nodes=False).query(points, k=5)[-1]
-    T3 = cKDTree(points, balanced_tree=False).query(points, k=5)[-1]
-    T4 = cKDTree(points, compact_nodes=False, balanced_tree=False).query(points, k=5)[-1]
+    T1 = kdtree_type(points).query(points, k=5)[-1]
+    T2 = kdtree_type(points, compact_nodes=False).query(points, k=5)[-1]
+    T3 = kdtree_type(points, balanced_tree=False).query(points, k=5)[-1]
+    T4 = kdtree_type(points, compact_nodes=False,
+                     balanced_tree=False).query(points, k=5)[-1]
     assert_array_equal(T1, T2)
     assert_array_equal(T1, T3)
     assert_array_equal(T1, T4)
 
-def test_ckdtree_pickle():
-    # test if it is possible to pickle
-    # a cKDTree
+def test_kdtree_pickle(kdtree_type):
+    # test if it is possible to pickle a KDTree
     try:
         import cPickle as pickle
     except ImportError:
@@ -957,16 +880,15 @@ def test_ckdtree_pickle():
     n = 50
     k = 4
     points = np.random.randn(n, k)
-    T1 = cKDTree(points)
+    T1 = kdtree_type(points)
     tmp = pickle.dumps(T1)
     T2 = pickle.loads(tmp)
     T1 = T1.query(points, k=5)[-1]
     T2 = T2.query(points, k=5)[-1]
     assert_array_equal(T1, T2)
 
-def test_ckdtree_pickle_boxsize():
-    # test if it is possible to pickle a periodic
-    # cKDTree
+def test_kdtree_pickle_boxsize(kdtree_type):
+    # test if it is possible to pickle a periodic KDTree
     try:
         import cPickle as pickle
     except ImportError:
@@ -975,14 +897,14 @@ def test_ckdtree_pickle_boxsize():
     n = 50
     k = 4
     points = np.random.uniform(size=(n, k))
-    T1 = cKDTree(points, boxsize=1.0)
+    T1 = kdtree_type(points, boxsize=1.0)
     tmp = pickle.dumps(T1)
     T2 = pickle.loads(tmp)
     T1 = T1.query(points, k=5)[-1]
     T2 = T2.query(points, k=5)[-1]
     assert_array_equal(T1, T2)
 
-def test_ckdtree_copy_data():
+def test_kdtree_copy_data(kdtree_type):
     # check if copy_data=True makes the kd-tree
     # impervious to data corruption by modification of
     # the data arrray
@@ -990,22 +912,20 @@ def test_ckdtree_copy_data():
     n = 5000
     k = 4
     points = np.random.randn(n, k)
-    T = cKDTree(points, copy_data=True)
+    T = kdtree_type(points, copy_data=True)
     q = points.copy()
     T1 = T.query(q, k=5)[-1]
     points[...] = np.random.randn(n, k)
     T2 = T.query(q, k=5)[-1]
     assert_array_equal(T1, T2)
 
-
-def test_ckdtree_parallel(monkeypatch):
-    # check if parallel=True also generates correct
-    # query results
+def test_ckdtree_parallel(kdtree_type, monkeypatch):
+    # check if parallel=True also generates correct query results
     np.random.seed(0)
     n = 5000
     k = 4
     points = np.random.randn(n, k)
-    T = cKDTree(points)
+    T = kdtree_type(points)
     T1 = T.query(points, k=5, workers=64)[-1]
     T2 = T.query(points, k=5, workers=-1)[-1]
     T3 = T.query(points, k=5)[-1]
@@ -1048,11 +968,11 @@ def test_ckdtree_view():
     # check that data_points are correctly retrieved
     assert_array_equal(kdtree.data[n.indices, :], n.data_points)
 
-# cKDTree is specialized to type double points, so no need to make
+# KDTree is specialized to type double points, so no need to make
 # a unit test corresponding to test_ball_point_ints()
 
-def test_ckdtree_list_k():
-    # check ckdtree periodic boundary
+def test_kdtree_list_k(kdtree_type):
+    # check kdtree periodic boundary
     n = 200
     m = 2
     klist = [1, 2, 3]
@@ -1060,7 +980,7 @@ def test_ckdtree_list_k():
 
     np.random.seed(1234)
     data = np.random.uniform(size=(n, m))
-    kdtree = cKDTree(data, leafsize=1)
+    kdtree = kdtree_type(data, leafsize=1)
 
     # check agreement between arange(1, k+1) and k
     dd, ii = kdtree.query(data, klist)
@@ -1085,17 +1005,17 @@ def test_ckdtree_list_k():
     assert_equal(dd, np.ravel(dd1))
     assert_equal(ii, np.ravel(ii1))
 
-def test_ckdtree_box():
+def test_kdtree_box(kdtree_type):
     # check ckdtree periodic boundary
     n = 2000
     m = 3
     k = 3
     np.random.seed(1234)
     data = np.random.uniform(size=(n, m))
-    kdtree = cKDTree(data, leafsize=1, boxsize=1.0)
+    kdtree = kdtree_type(data, leafsize=1, boxsize=1.0)
 
     # use the standard python KDTree for the simulated periodic box
-    kdtree2 = cKDTree(data, leafsize=1)
+    kdtree2 = kdtree_type(data, leafsize=1)
 
     for p in [1, 2, 3.0, np.inf]:
         dd, ii = kdtree.query(data, k, p=p)
@@ -1112,17 +1032,17 @@ def test_ckdtree_box():
         assert_almost_equal(dd, dd2)
         assert_equal(ii, ii2)
 
-def test_ckdtree_box_0boxsize():
+def test_kdtree_box_0boxsize(kdtree_type):
     # check ckdtree periodic boundary that mimics non-periodic
     n = 2000
     m = 2
     k = 3
     np.random.seed(1234)
     data = np.random.uniform(size=(n, m))
-    kdtree = cKDTree(data, leafsize=1, boxsize=0.0)
+    kdtree = kdtree_type(data, leafsize=1, boxsize=0.0)
 
     # use the standard python KDTree for the simulated periodic box
-    kdtree2 = cKDTree(data, leafsize=1)
+    kdtree2 = kdtree_type(data, leafsize=1)
 
     for p in [1, 2, np.inf]:
         dd, ii = kdtree.query(data, k, p=p)
@@ -1131,17 +1051,19 @@ def test_ckdtree_box_0boxsize():
         assert_almost_equal(dd, dd1)
         assert_equal(ii, ii1)
 
-def test_ckdtree_box_upper_bounds():
+def test_kdtree_box_upper_bounds(kdtree_type):
     data = np.linspace(0, 2, 10).reshape(-1, 2)
     data[:, 1] += 10
-    assert_raises(ValueError, cKDTree, data, leafsize=1, boxsize=1.0)
-    assert_raises(ValueError, cKDTree, data, leafsize=1, boxsize=(0.0, 2.0))
+    with pytest.raises(ValueError):
+        kdtree_type(data, leafsize=1, boxsize=1.0)
+    with pytest.raises(ValueError):
+        kdtree_type(data, leafsize=1, boxsize=(0.0, 2.0))
     # skip a dimension.
-    cKDTree(data, leafsize=1, boxsize=(2.0, 0.0))
+    kdtree_type(data, leafsize=1, boxsize=(2.0, 0.0))
 
-def test_ckdtree_box_lower_bounds():
+def test_kdtree_box_lower_bounds(kdtree_type):
     data = np.linspace(-1, 1, 10)
-    assert_raises(ValueError, cKDTree, data, leafsize=1, boxsize=1.0)
+    assert_raises(ValueError, kdtree_type, data, leafsize=1, boxsize=1.0)
 
 def simulate_periodic_box(kdtree, data, k, boxsize, p):
     dd = []
@@ -1211,10 +1133,10 @@ def test_ckdtree_memuse():
     # outside cKDTree
     assert_(num_leaks < 10)
 
-def test_ckdtree_weights():
+def test_kdtree_weights(kdtree_type):
 
     data = np.linspace(0, 1, 4).reshape(-1, 1)
-    tree1 = cKDTree(data, leafsize=1)
+    tree1 = kdtree_type(data, leafsize=1)
     weights = np.ones(len(data), dtype='f4')
 
     nw = tree1._build_weights(weights)
@@ -1243,7 +1165,7 @@ def test_ckdtree_weights():
         w1 = weights.copy()
         w1[i] = 0
         data2 = data[w1 != 0]
-        tree2 = cKDTree(data2)
+        tree2 = kdtree_type(data2)
 
         c1 = tree1.count_neighbors(tree1, np.linspace(0, 10, 100),
                 weights=(w1, w1))
@@ -1257,12 +1179,12 @@ def test_ckdtree_weights():
         assert_raises(ValueError, tree1.count_neighbors,
             tree2, np.linspace(0, 10, 100), weights=w1)
 
-def test_ckdtree_count_neighbous_multiple_r():
+def test_kdtree_count_neighbous_multiple_r(kdtree_type):
     n = 2000
     m = 2
     np.random.seed(1234)
     data = np.random.normal(size=(n, m))
-    kdtree = cKDTree(data, leafsize=1)
+    kdtree = kdtree_type(data, leafsize=1)
     r0 = [0, 0.01, 0.01, 0.02, 0.05]
     i0 = np.arange(len(r0))
     n0 = kdtree.count_neighbors(kdtree, r0)
@@ -1275,13 +1197,13 @@ def test_ckdtree_count_neighbous_multiple_r():
         n = kdtree.count_neighbors(kdtree, r)
         assert_array_equal(n, n0[list(i)])
 
-def test_len0_arrays():
+def test_len0_arrays(kdtree_type):
     # make sure len-0 arrays are handled correctly
     # in range queries (gh-5639)
     np.random.seed(1234)
     X = np.random.rand(10, 2)
     Y = np.random.rand(10, 2)
-    tree = cKDTree(X)
+    tree = kdtree_type(X)
     # query_ball_point (single)
     d, i = tree.query([.5, .5], k=1)
     z = tree.query_ball_point([.5, .5], 0.1*d)
@@ -1294,7 +1216,7 @@ def test_len0_arrays():
     y.fill([])
     assert_array_equal(y, z)
     # query_ball_tree
-    other = cKDTree(Y)
+    other = kdtree_type(Y)
     y = tree.query_ball_tree(other, 0.1*mind)
     assert_array_equal(10*[[]], y)
     # count_neighbors
@@ -1321,8 +1243,8 @@ def test_len0_arrays():
     z = np.empty(shape=(0, 2), dtype=np.intp)
     assert_array_equal(y, z)
 
-def test_ckdtree_duplicated_inputs():
-    # check ckdtree with duplicated inputs
+def test_kdtree_duplicated_inputs(kdtree_type):
+    # check kdtree with duplicated inputs
     n = 1024
     for m in range(1, 8):
         data = np.concatenate([
@@ -1331,29 +1253,29 @@ def test_ckdtree_duplicated_inputs():
 
         # it shall not divide more than 3 nodes.
         # root left (1), and right (2)
-        kdtree = cKDTree(data, leafsize=1)
+        kdtree = kdtree_type(data, leafsize=1)
         assert_equal(kdtree.size, 3)
 
-        kdtree = cKDTree(data)
+        kdtree = kdtree_type(data)
         assert_equal(kdtree.size, 3)
 
         # if compact_nodes are disabled, the number
         # of nodes is n (per leaf) + (m - 1)* 2 (splits per dimension) + 1
         # and the root
-        kdtree = cKDTree(data, compact_nodes=False, leafsize=1)
+        kdtree = kdtree_type(data, compact_nodes=False, leafsize=1)
         assert_equal(kdtree.size, n + m * 2 - 1)
 
-def test_ckdtree_noncumulative_nondecreasing():
-    # check ckdtree with duplicated inputs
+def test_kdtree_noncumulative_nondecreasing(kdtree_type):
+    # check kdtree with duplicated inputs
 
     # it shall not divide more than 3 nodes.
     # root left (1), and right (2)
-    kdtree = cKDTree([[0]], leafsize=1)
+    kdtree = kdtree_type([[0]], leafsize=1)
 
     assert_raises(ValueError, kdtree.count_neighbors,
         kdtree, [0.1, 0], cumulative=False)
 
-def test_short_knn():
+def test_short_knn(kdtree_type):
 
     # The test case is based on github: #6425 by @SteveDoyle2
 
@@ -1366,7 +1288,7 @@ def test_short_knn():
         [1., 1., 0.]],
     dtype='float64')
 
-    ckdt = cKDTree(xyz)
+    ckdt = kdtree_type(xyz)
 
     deq, ieq = ckdt.query(xyz, k=4, distance_upper_bound=0.2)
 
@@ -1378,12 +1300,12 @@ def test_short_knn():
             [0., 0.01, np.inf, np.inf],
             [0., np.inf, np.inf, np.inf]])
 
-def test_query_ball_point_vector_r():
+def test_query_ball_point_vector_r(kdtree_type):
 
     np.random.seed(1234)
     data = np.random.normal(size=(100, 3))
     query = np.random.normal(size=(100, 3))
-    tree = cKDTree(data)
+    tree = kdtree_type(data)
     d = np.random.uniform(0, 0.3, size=len(query))
 
     rvector = tree.query_ball_point(query, d)
@@ -1391,12 +1313,12 @@ def test_query_ball_point_vector_r():
     for a, b in zip(rvector, rscalar):
         assert_array_equal(sorted(a), sorted(b))
 
-def test_query_ball_point_length():
+def test_query_ball_point_length(kdtree_type):
 
     np.random.seed(1234)
     data = np.random.normal(size=(100, 3))
     query = np.random.normal(size=(100, 3))
-    tree = cKDTree(data)
+    tree = kdtree_type(data)
     d = 0.3
 
     length = tree.query_ball_point(query, d, return_length=True)
@@ -1407,7 +1329,7 @@ def test_query_ball_point_length():
     assert_array_equal(length, length3)
     assert_array_equal(length, length4)
 
-def test_discontiguous():
+def test_discontiguous(kdtree_type):
 
     np.random.seed(1234)
     data = np.random.normal(size=(100, 3))
@@ -1419,7 +1341,7 @@ def test_discontiguous():
     assert query_discontiguous.strides[-1] != query_contiguous.strides[-1]
     assert d_discontiguous.strides[-1] != d_contiguous.strides[-1]
 
-    tree = cKDTree(data)
+    tree = kdtree_type(data)
 
     length1 = tree.query_ball_point(query_contiguous,
                                     d_contiguous, return_length=True)
@@ -1440,14 +1362,15 @@ def test_discontiguous():
      (True, True),
      (False, False),
      (False, True)])
-def test_cdktree_empty_input(balanced_tree, compact_nodes):
+def test_kdtree_empty_input(kdtree_type, balanced_tree, compact_nodes):
     # https://github.com/scipy/scipy/issues/5040
     np.random.seed(1234)
     empty_v3 = np.empty(shape=(0, 3))
     query_v3 = np.ones(shape=(1, 3))
     query_v2 = np.ones(shape=(2, 3))
 
-    tree = cKDTree(empty_v3, balanced_tree=balanced_tree, compact_nodes=compact_nodes)
+    tree = kdtree_type(empty_v3, balanced_tree=balanced_tree,
+                       compact_nodes=compact_nodes)
     length = tree.query_ball_point(query_v3, 0.3, return_length=True)
     assert length == 0
 
@@ -1462,12 +1385,12 @@ def test_cdktree_empty_input(balanced_tree, compact_nodes):
     M = tree.sparse_distance_matrix(tree, 0.3)
     assert M.shape == (0, 0)
 
-class Test_sorted_query_ball_point(object):
-
+@KDTreeTest
+class _Test_sorted_query_ball_point(object):
     def setup_method(self):
         np.random.seed(1234)
         self.x = np.random.randn(100, 1)
-        self.ckdt = cKDTree(self.x)
+        self.ckdt = self.kdtree_type(self.x)
 
     def test_return_sorted_True(self):
         idxs_list = self.ckdt.query_ball_point(self.x, 1., return_sorted=True)


### PR DESCRIPTION
#### Reference issue
Ref gh-8923

#### What does this implement/fix?
This expands the `KDTree` interface to expose all of the `cKDTree` functionality. I've also merged the two classes documentation together so they're almost identical, except for `deprecation` and `versionadded` messages.

Most of the tests are now parametrized on the tree type as well, so the exact same tests are run for`KDTree` and `cKDTree` with minimal code duplication. This is done through pytest fixtures for functional tests and with a special class decorator for class-style tests.