### PR TITLE
DOC: use :doi: and :arxiv: directives for references

### DIFF
--- a/doc/source/tutorial/optimize.rst
+++ b/doc/source/tutorial/optimize.rst
@@ -369,12 +369,12 @@ Hessian product example:
 
 .. [TRLIB] F. Lenders, C. Kirches, A. Potschka: "trlib: A vector-free
            implementation of the GLTR method for iterative solution of
-           the trust region problem", https://arxiv.org/abs/1611.04718
+           the trust region problem", :arxiv:`1611.04718`
 
 .. [GLTR]  N. Gould, S. Lucidi, M. Roma, P. Toint: "Solving the
            Trust-Region Subproblem using the Lanczos Method",
            SIAM J. Optim., 9(2), 504--525, (1999).
-           https://doi.org/10.1137/S1052623497322735
+           :doi:`10.1137/S1052623497322735`
 
 
 Trust-Region Nearly Exact Algorithm (``method='trust-exact'``)
@@ -1548,7 +1548,7 @@ Some further reading and related software, such as Newton-Krylov [KK]_,
 PETSc [PP]_, and PyAMG [AMG]_:
 
 .. [KK] D.A. Knoll and D.E. Keyes, "Jacobian-free Newton-Krylov methods",
-        J. Comp. Phys. 193, 357 (2004). doi:10.1016/j.jcp.2003.08.010
+        J. Comp. Phys. 193, 357 (2004). :doi:`10.1016/j.jcp.2003.08.010`
 
 .. [PP] PETSc https://www.mcs.anl.gov/petsc/ and its Python bindings
         https://bitbucket.org/petsc/petsc4py/

--- a/scipy/linalg/_decomp_ldl.py
+++ b/scipy/linalg/_decomp_ldl.py
@@ -115,7 +115,7 @@ def ldl(A, lower=True, hermitian=True, overwrite_a=False, check_finite=True):
     ----------
     .. [1] J.R. Bunch, L. Kaufman, Some stable methods for calculating
        inertia and solving symmetric linear systems, Math. Comput. Vol.31,
-       1977. DOI: 10.2307/2005787
+       1977. :doi:`10.2307/2005787`
 
     """
     a = atleast_2d(_asarray_validated(A, check_finite=check_finite))

--- a/scipy/linalg/_solvers.py
+++ b/scipy/linalg/_solvers.py
@@ -412,7 +412,7 @@ def solve_continuous_are(a, b, q, r, e=None, s=None, balanced=True):
     ----------
     .. [1]  P. van Dooren , "A Generalized Eigenvalue Approach For Solving
        Riccati Equations.", SIAM Journal on Scientific and Statistical
-       Computing, Vol.2(2), DOI: 10.1137/0902010
+       Computing, Vol.2(2), :doi:`10.1137/0902010`
 
     .. [2] A.J. Laub, "A Schur Method for Solving Algebraic Riccati
        Equations.", Massachusetts Institute of Technology. Laboratory for
@@ -420,7 +420,7 @@ def solve_continuous_are(a, b, q, r, e=None, s=None, balanced=True):
        http://hdl.handle.net/1721.1/1301
 
     .. [3] P. Benner, "Symplectic Balancing of Hamiltonian Matrices", 2001,
-       SIAM J. Sci. Comput., 2001, Vol.22(5), DOI: 10.1137/S1064827500367993
+       SIAM J. Sci. Comput., 2001, Vol.22(5), :doi:`10.1137/S1064827500367993`
 
     Examples
     --------
@@ -617,7 +617,7 @@ def solve_discrete_are(a, b, q, r, e=None, s=None, balanced=True):
     ----------
     .. [1]  P. van Dooren , "A Generalized Eigenvalue Approach For Solving
        Riccati Equations.", SIAM Journal on Scientific and Statistical
-       Computing, Vol.2(2), DOI: 10.1137/0902010
+       Computing, Vol.2(2), :doi:`10.1137/0902010`
 
     .. [2] A.J. Laub, "A Schur Method for Solving Algebraic Riccati
        Equations.", Massachusetts Institute of Technology. Laboratory for
@@ -625,7 +625,7 @@ def solve_discrete_are(a, b, q, r, e=None, s=None, balanced=True):
        http://hdl.handle.net/1721.1/1301
 
     .. [3] P. Benner, "Symplectic Balancing of Hamiltonian Matrices", 2001,
-       SIAM J. Sci. Comput., 2001, Vol.22(5), DOI: 10.1137/S1064827500367993
+       SIAM J. Sci. Comput., 2001, Vol.22(5), :doi:`10.1137/S1064827500367993`
 
     Examples
     --------

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -1564,11 +1564,10 @@ def matrix_balance(A, permute=True, scale=True, separate=False,
     ----------
     .. [1] : B.N. Parlett and C. Reinsch, "Balancing a Matrix for
        Calculation of Eigenvalues and Eigenvectors", Numerische Mathematik,
-       Vol.13(4), 1969, DOI:10.1007/BF02165404
+       Vol.13(4), 1969, :doi:`10.1007/BF02165404`
 
     .. [2] : R. James, J. Langou, B.R. Lowery, "On matrix balancing and
-       eigenvector computation", 2014, Available online:
-       https://arxiv.org/abs/1401.5766
+       eigenvector computation", 2014, :arxiv:`1401.5766`
 
     .. [3] :  D.S. Watkins. A case where balancing is harmful.
        Electron. Trans. Numer. Anal, Vol.23, 2006.

--- a/scipy/optimize/_dual_annealing.py
+++ b/scipy/optimize/_dual_annealing.py
@@ -578,7 +578,8 @@ def dual_annealing(func, bounds, args=(), maxiter=1000,
         Simulated Annealing for Efficient Global Optimization: the GenSA
         Package for R. The R Journal, Volume 5/1 (2013).
     .. [6] Mullen, K. Continuous Global Optimization in R. Journal of
-        Statistical Software, 60(6), 1 - 45, (2014). DOI:10.18637/jss.v060.i06
+        Statistical Software, 60(6), 1 - 45, (2014).
+        :doi:`10.18637/jss.v060.i06`
 
     Examples
     --------

--- a/scipy/optimize/_lsap.py
+++ b/scipy/optimize/_lsap.py
@@ -64,7 +64,7 @@ def linear_sum_assignment(cost_matrix, maximize=False):
 
     2. DF Crouse. On implementing 2D rectangular assignment algorithms.
        *IEEE Transactions on Aerospace and Electronic Systems*,
-       52(4):1679-1696, August 2016, https://doi.org/10.1109/TAES.2016.140952
+       52(4):1679-1696, August 2016, :doi:`10.1109/TAES.2016.140952`
 
     Examples
     --------

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -418,7 +418,7 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
        Trust region methods. 2000. Siam. pp. 169-200.
     .. [14] F. Lenders, C. Kirches, A. Potschka: "trlib: A vector-free
        implementation of the GLTR method for iterative solution of
-       the trust region problem", https://arxiv.org/abs/1611.04718
+       the trust region problem", :arxiv:`1611.04718`
     .. [15] N. Gould, S. Lucidi, M. Roma, P. Toint: "Solving the
        Trust-Region Subproblem using the Lanczos Method",
        SIAM J. Optim., 9(2), 504--525, (1999).

--- a/scipy/optimize/_qap.py
+++ b/scipy/optimize/_qap.py
@@ -108,11 +108,11 @@ def quadratic_assignment(A, B, method="faq", options=None):
            S.G. Kratzer, E.T. Harley, D.E. Fishkind, R.J. Vogelstein, and
            C.E. Priebe, "Fast approximate quadratic programming for graph
            matching," PLOS one, vol. 10, no. 4, p. e0121002, 2015,
-           https://doi.org/10.1371/journal.pone.0121002
+           :doi:`10.1371/journal.pone.0121002`
 
     .. [2] D. Fishkind, S. Adali, H. Patsolic, L. Meng, D. Singh, V. Lyzinski,
            C. Priebe, "Seeded graph matching", Pattern Recognit. 87 (2019):
-           203-215, https://doi.org/10.1016/j.patcog.2018.09.014
+           203-215, :doi:`10.1016/j.patcog.2018.09.014`
 
     .. [3] "2-opt," Wikipedia.
            https://en.wikipedia.org/wiki/2-opt
@@ -419,11 +419,11 @@ def _quadratic_assignment_faq(A, B,
            S.G. Kratzer, E.T. Harley, D.E. Fishkind, R.J. Vogelstein, and
            C.E. Priebe, "Fast approximate quadratic programming for graph
            matching," PLOS one, vol. 10, no. 4, p. e0121002, 2015,
-           https://doi.org/10.1371/journal.pone.0121002
+           :doi:`10.1371/journal.pone.0121002`
 
     .. [2] D. Fishkind, S. Adali, H. Patsolic, L. Meng, D. Singh, V. Lyzinski,
            C. Priebe, "Seeded graph matching", Pattern Recognit. 87 (2019):
-           203-215, https://doi.org/10.1016/j.patcog.2018.09.014
+           203-215, :doi:`10.1016/j.patcog.2018.09.014`
     """
 
     _check_unknown_options(unknown_options)

--- a/scipy/signal/fir_filter_design.py
+++ b/scipy/signal/fir_filter_design.py
@@ -1197,7 +1197,7 @@ def minimum_phase(h, method='homomorphic', n_fft=None):
            complex minimum phase digital FIR filters," Acoustics, Speech,
            and Signal Processing, 1999. Proceedings., 1999 IEEE International
            Conference on, Phoenix, AZ, 1999, pp. 1145-1148 vol.3.
-           doi: 10.1109/ICASSP.1999.756179
+           :doi:`10.1109/ICASSP.1999.756179`
     .. [2] X. Chen and T. W. Parks, "Design of optimal minimum phase FIR
            filters by direct factorization," Signal Processing,
            vol. 10, no. 4, pp. 369-383, Jun. 1986.

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -1983,7 +1983,7 @@ def _median_bias(n):
     Returns the bias of the median of a set of periodograms relative to
     the mean.
 
-    See arXiv:gr-qc/0509116 Appendix B for details.
+    See Appendix B from [1]_ for details.
 
     Parameters
     ----------
@@ -1994,6 +1994,13 @@ def _median_bias(n):
     -------
     bias : float
         Calculated bias.
+
+    References
+    ----------
+    .. [1] B. Allen, W.G. Anderson, P.R. Brady, D.A. Brown, J.D.E. Creighton.
+           "FINDCHIRP: an algorithm for detection of gravitational waves from
+           inspiraling compact binaries", Physical Review D 85, 2012,
+           :arxiv:`gr-qc/0509116`
     """
     ii_2 = 2 * np.arange(1., (n-1) // 2 + 1)
     return 1 + np.sum(1. / (ii_2 + 1) - 1. / ii_2)

--- a/scipy/sparse/csgraph/_matching.pyx
+++ b/scipy/sparse/csgraph/_matching.pyx
@@ -59,7 +59,7 @@ def maximum_bipartite_matching(graph, perm_type='row'):
     ----------
     .. [1] John E. Hopcroft and Richard M. Karp. "An n^{5 / 2} Algorithm for
            Maximum Matchings in Bipartite Graphs" In: SIAM Journal of Computing
-           2.4 (1973), pp. 225--231. <https://dx.doi.org/10.1137/0202019>.
+           2.4 (1973), pp. 225--231. :doi:`10.1137/0202019`
 
     Examples
     --------

--- a/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
@@ -7,11 +7,11 @@ References
        Toward the Optimal Preconditioned Eigensolver: Locally Optimal
        Block Preconditioned Conjugate Gradient Method.
        SIAM Journal on Scientific Computing 23, no. 2,
-       pp. 517-541. http://dx.doi.org/10.1137/S1064827500366124
+       pp. 517-541. :doi:`10.1137/S1064827500366124`
 
 .. [2] A. V. Knyazev, I. Lashuk, M. E. Argentati, and E. Ovchinnikov (2007),
        Block Locally Optimal Preconditioned Eigenvalue Xolvers (BLOPEX)
-       in hypre and PETSc.  https://arxiv.org/abs/0705.2626
+       in hypre and PETSc.  :arxiv:`0705.2626`
 
 .. [3] A. V. Knyazev's C and MATLAB implementations:
        https://github.com/lobpcg/blopex
@@ -197,8 +197,7 @@ def lobpcg(A, X,
     It is not that ``n`` should be large for the LOBPCG to work, but rather the
     ratio ``n / m`` should be large. It you call LOBPCG with ``m=1``
     and ``n=10``, it works though ``n`` is small. The method is intended
-    for extremely large ``n / m``, see e.g., reference [28] in
-    https://arxiv.org/abs/0705.2626
+    for extremely large ``n / m`` [4]_.
 
     The convergence speed depends basically on two factors:
 
@@ -218,14 +217,20 @@ def lobpcg(A, X,
            Toward the Optimal Preconditioned Eigensolver: Locally Optimal
            Block Preconditioned Conjugate Gradient Method.
            SIAM Journal on Scientific Computing 23, no. 2,
-           pp. 517-541. http://dx.doi.org/10.1137/S1064827500366124
+           pp. 517-541. :doi:`10.1137/S1064827500366124`
 
     .. [2] A. V. Knyazev, I. Lashuk, M. E. Argentati, and E. Ovchinnikov
            (2007), Block Locally Optimal Preconditioned Eigenvalue Xolvers
-           (BLOPEX) in hypre and PETSc. https://arxiv.org/abs/0705.2626
+           (BLOPEX) in hypre and PETSc. :arxiv:`0705.2626`
 
     .. [3] A. V. Knyazev's C and MATLAB implementations:
            https://bitbucket.org/joseroman/blopex
+
+    .. [4] S. Yamada, T. Imamura, T. Kano, and M. Machida (2006),
+           High-performance computing for exact numerical approaches to
+           quantum many-body problems on the earth simulator. In Proceedings
+           of the 2006 ACM/IEEE Conference on Supercomputing.
+           :doi:`10.1145/1188455.1188504`
 
     Examples
     --------

--- a/scipy/sparse/linalg/isolve/lsmr.py
+++ b/scipy/sparse/linalg/isolve/lsmr.py
@@ -135,7 +135,7 @@ def lsmr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
     .. [1] D. C.-L. Fong and M. A. Saunders,
            "LSMR: An iterative algorithm for sparse least-squares problems",
            SIAM J. Sci. Comput., vol. 33, pp. 2950-2971, 2011.
-           https://arxiv.org/abs/1006.0758
+           :arxiv:`1006.0758`
     .. [2] LSMR Software, https://web.stanford.edu/group/SOL/software/lsmr/
 
     Examples

--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -1273,24 +1273,21 @@ cdef class cKDTree:
 
         .. [1] Gray and Moore,
                "N-body problems in statistical learning",
-               Mining the sky, 2000,
-               https://arxiv.org/abs/astro-ph/0012333
+               Mining the sky, 2000, :arxiv:`astro-ph/0012333`
 
         .. [2] Landy and Szalay,
                "Bias and variance of angular correlation functions",
-               The Astrophysical Journal, 1993,
-               http://adsabs.harvard.edu/abs/1993ApJ...412...64L
+               The Astrophysical Journal, 1993, :doi:`10.1086/172900`
 
         .. [3] Sheth, Connolly and Skibba,
                "Marked correlations in galaxy formation models",
-               Arxiv e-print, 2005,
-               https://arxiv.org/abs/astro-ph/0511773
+               2005, :arxiv:`astro-ph/0511773`
 
         .. [4] Hawkins, et al.,
                "The 2dF Galaxy Redshift Survey: correlation functions,
                peculiar velocities and the matter density of the Universe",
                Monthly Notices of the Royal Astronomical Society, 2002,
-               http://adsabs.harvard.edu/abs/2003MNRAS.346...78H
+               :doi:`10.1046/j.1365-2966.2003.07063.x`
 
         .. [5] https://github.com/scipy/scipy/pull/5647#issuecomment-168474926
 

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -872,7 +872,7 @@ def jaccard(u, v, w=None):
     ----------
     .. [1] https://en.wikipedia.org/wiki/Jaccard_index
     .. [2] S. Kosub, "A note on the triangle inequality for the Jaccard
-       distance", 2016, Available online: https://arxiv.org/pdf/1612.02696.pdf
+       distance", 2016, :arxiv:`1612.02696`
 
     Examples
     --------

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -5197,7 +5197,7 @@ class kappa4_gen(rv_continuous):
     B. Kumphon, A. Kaew-Man, P. Seenoi, "A Rainfall Distribution for the Lampao
     Site in the Chi River Basin, Thailand", Journal of Water Resource and
     Protection, vol. 4, 866-869, (2012).
-    https://doi.org/10.4236/jwarp.2012.410101
+    :doi:`10.4236/jwarp.2012.410101`
 
     C. Winchester, "On Estimation of the Four-Parameter Kappa Distribution", A
     Thesis Submitted to Dalhousie University, Halifax, Nova Scotia, (March
@@ -5398,11 +5398,11 @@ class kappa3_gen(rv_continuous):
     P.W. Mielke and E.S. Johnson, "Three-Parameter Kappa Distribution Maximum
     Likelihood and Likelihood Ratio Tests", Methods in Weather Research,
     701-707, (September, 1973),
-    https://doi.org/10.1175/1520-0493(1973)101<0701:TKDMLE>2.3.CO;2
+    :doi:`10.1175/1520-0493(1973)101<0701:TKDMLE>2.3.CO;2`
 
     B. Kumphon, "Maximum Entropy and Maximum Likelihood Estimation for the
     Three-Parameter Kappa Distribution", Open Journal of Statistics, vol 2,
-    415-419 (2012), https://doi.org/10.4236/ojs.2012.24050
+    415-419 (2012), :doi:`10.4236/ojs.2012.24050`
 
     %(after_notes)s
 
@@ -6707,7 +6707,7 @@ class skew_norm_gen(rv_continuous):
     ----------
     .. [1] A. Azzalini and A. Capitanio (1999). Statistical applications of the
         multivariate skew-normal distribution. J. Roy. Statist. Soc., B 61, 579-602.
-        https://arxiv.org/abs/0911.2093
+        :arxiv:`0911.2093`
 
     """
     def _argcheck(self, a):
@@ -6788,7 +6788,7 @@ class trapz_gen(rv_continuous):
     ----------
     .. [1] Kacker, R.N. and Lawrence, J.F. (2007). Trapezoidal and triangular
        distributions for Type B evaluation of standard uncertainty.
-       Metrologia 44, 117-127. https://doi.org/10.1088/0026-1394/44/2/003
+       Metrologia 44, 117-127. :doi:`10.1088/0026-1394/44/2/003`
 
 
     """

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -3783,7 +3783,7 @@ class unitary_group_gen(multi_rv_generic):
     References
     ----------
     .. [1] F. Mezzadri, "How to generate random matrices from the classical
-           compact groups", arXiv:math-ph/0609050v2.
+           compact groups", :arXiv:`math-ph/0609050v2`.
 
     Examples
     --------

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -4308,7 +4308,7 @@ def pointbiserialr(x, y):
 
     .. [3] D. Kornbrot "Point Biserial Correlation", In Wiley StatsRef:
            Statistics Reference Online (eds N. Balakrishnan, et al.), 2014.
-           https://doi.org/10.1002/9781118445112.stat06227
+           :doi:`10.1002/9781118445112.stat06227`
 
     Examples
     --------
@@ -4980,13 +4980,13 @@ def multiscale_graphcorr(x, y, compute_distance=_euclidean_dist, reps=1000,
     .. [2] Panda, S., Palaniappan, S., Xiong, J., Swaminathan, A.,
            Ramachandran, S., Bridgeford, E. W., ... Vogelstein, J. T. (2019).
            mgcpy: A Comprehensive High Dimensional Independence Testing Python
-           Package. ArXiv:1907.02088 [Cs, Stat].
+           Package. :arXiv:`1907.02088`
     .. [3] Shen, C., Priebe, C.E., & Vogelstein, J. T. (2019). From distance
            correlation to multiscale graph correlation. Journal of the American
            Statistical Association.
     .. [4] Shen, C. & Vogelstein, J. T. (2018). The Exact Equivalence of
-           Distance and Kernel Methods for Hypothesis Testing. ArXiv:1806.05514
-           [Cs, Stat].
+           Distance and Kernel Methods for Hypothesis Testing.
+           :arXiv:`1806.05514`
 
     Examples
     --------


### PR DESCRIPTION
This PR uses the `:doi:` and `:arxiv:` directives for references in the documentation. This allows more consistent navigation to primary references.