### PR TITLE
BLD: replace the #include of libqull_r.h with with this of qhull_ra.h in qhull_misc.c

### DIFF
--- a/scipy/spatial/qhull_misc.c
+++ b/scipy/spatial/qhull_misc.c
@@ -1,4 +1,4 @@
-#include "qhull_src/src/libqhull_r.h"
+#include "qhull_src/src/qhull_ra.h"
 
 #define trace1(args) {}
 


### PR DESCRIPTION
These are needed for a sucessful build on macOS using Xcode 12 (Apple's clang 12).

Without it, it errors out with `error: implicit declaration of function...`


#### Reference issue
Closes #12860

#### What does this implement/fix?
  - `#include <string.h>` is needed for a prototype for strncmp; this include is missing in `libqhull_r.h`.
  - prototypes for internal functions `qh_setfeasible` and `qh_prepare_output` are missing in `libqhull_r.h`