### PR TITLE
BUG: Fixes a ValueError yielded upon calling Scipy Interpolator objects

### DIFF
--- a/scipy/interpolate/interpnd.pyx
+++ b/scipy/interpolate/interpnd.pyx
@@ -291,7 +291,7 @@ class LinearNDInterpolator(NDInterpolatorBase):
         cdef const double_or_complex[:,::1] values = self.values
         cdef double_or_complex[:,::1] out
         cdef const double[:,::1] points = self.points
-        cdef int[:,::1] simplices = self.tri.simplices
+        cdef const int[:,::1] simplices = self.tri.simplices
         cdef double c[NPY_MAXDIMS]
         cdef double_or_complex fill_value
         cdef int i, j, k, m, ndim, isimplex, inside, start, nvalues

--- a/scipy/interpolate/interpnd.pyx
+++ b/scipy/interpolate/interpnd.pyx
@@ -920,10 +920,10 @@ class CloughTocher2DInterpolator(NDInterpolatorBase):
     @cython.wraparound(False)
     def _do_evaluate(self, const double[:,::1] xi, double_or_complex dummy):
         cdef const double_or_complex[:,::1] values = self.values
-        cdef double_or_complex[:,:,:] grad = self.grad
+        cdef const double_or_complex[:,:,:] grad = self.grad
         cdef double_or_complex[:,::1] out
         cdef const double[:,::1] points = self.points
-        cdef int[:,::1] simplices = self.tri.simplices
+        cdef const int[:,::1] simplices = self.tri.simplices
         cdef double c[NPY_MAXDIMS]
         cdef double_or_complex f[NPY_MAXDIMS+1]
         cdef double_or_complex df[2*NPY_MAXDIMS+2]


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
The bug this PR attempts to fix is described in #12834.

#### What does this implement/fix?
<!--Please explain your changes.-->
Similarly to #12602, I have appended the keyword `const` to the `simplices` variable in  `LinearNDInterpolator` and both `simplices` and `grad` in `CloughTocher2DInterpolator`.

#### Additional information
<!--Any additional information you think is important.-->
I realise that the reproducer provided in #12834 is not strictly minimal as it requires to import a huge external library - [Ray](https://github.com/ray-project/ray). I am potentially happy to investigate what is happening behind the scenes there if that is necessary, but I guess a Ray developer would be better suited for this task.
Also, I have two commits as I had forgotten to apply the fix to `LinearNDInterpolator`, I hope that is fine.