### PR TITLE
lazily import multiprocessing.Pool in MapWrapper 

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -4,7 +4,6 @@ import sys
 import warnings
 import numbers
 from collections import namedtuple
-from multiprocessing import Pool
 import inspect
 import math
 
@@ -367,6 +366,7 @@ class MapWrapper(object):
             self.pool = pool
             self._mapfunc = self.pool
         else:
+            from multiprocessing import Pool
             # user supplies a number
             if int(pool) == -1:
                 # use as many processors as possible

--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -18,8 +18,7 @@ from libcpp.algorithm cimport sort
 from libcpp cimport bool
 
 cimport cython
-
-from multiprocessing import cpu_count
+from os import cpu_count
 import threading
 import operator
 import warnings

--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -18,7 +18,7 @@ from libcpp.algorithm cimport sort
 from libcpp cimport bool
 
 cimport cython
-from os import cpu_count
+import os
 import threading
 import operator
 import warnings
@@ -26,7 +26,6 @@ import warnings
 cdef extern from "<limits.h>":
     long LONG_MAX
 
-cdef int number_of_processors = cpu_count()
 
 __all__ = ['cKDTree']
 
@@ -399,7 +398,12 @@ cdef np.intp_t get_num_workers(workers: object, kwargs: dict) except -1:
 
     cdef np.intp_t n = operator.index(workers)
     if n == -1:
-        n = number_of_processors
+        num = os.cpu_count()
+        if num is None:
+            raise NotImplementedError(
+                'Cannot determine the number of cpus using os.cpu_count(), '
+                'cannot use -1 for the number of workers')
+        n = num
     elif n <= 0:
         raise ValueError(f'Invalid number of workers {workers}, must be -1 or > 0')
     return n
@@ -487,9 +491,9 @@ cdef class cKDTree:
     mins : ndarray, shape (m,)
         The minimum value in each dimension of the n data points.
     tree : object, class cKDTreeNode
-        This attribute exposes a Python view of the root node in the cKDTree 
-        object. A full Python view of the kd-tree is created dynamically 
-        on the first access. This attribute allows you to create your own 
+        This attribute exposes a Python view of the root node in the cKDTree
+        object. A full Python view of the kd-tree is created dynamically
+        on the first access. This attribute allows you to create your own
         query functions in Python.
     size : int
         The number of nodes in the tree.
@@ -511,13 +515,13 @@ cdef class cKDTree:
 
     property n:
         def __get__(self): return self.cself.n
-    
+
     property m:
         def __get__(self): return self.cself.m
-    
+
     property leafsize:
         def __get__(self): return self.cself.leafsize
-    
+
     property size:
         def __get__(self): return self.cself.size
 

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -1,6 +1,7 @@
 # Copyright Anne M. Archibald 2008
 # Released under the scipy license
 
+import os
 from numpy.testing import (assert_equal, assert_array_equal, assert_,
                            assert_almost_equal, assert_array_almost_equal,
                            assert_allclose)
@@ -996,7 +997,8 @@ def test_ckdtree_copy_data():
     T2 = T.query(q, k=5)[-1]
     assert_array_equal(T1, T2)
 
-def test_ckdtree_parallel():
+
+def test_ckdtree_parallel(monkeypatch):
     # check if parallel=True also generates correct
     # query results
     np.random.seed(0)
@@ -1009,6 +1011,11 @@ def test_ckdtree_parallel():
     T3 = T.query(points, k=5)[-1]
     assert_array_equal(T1, T2)
     assert_array_equal(T1, T3)
+
+    monkeypatch.setattr(os, 'cpu_count', lambda: None)
+    with pytest.raises(NotImplementedError, match="Cannot determine the"):
+        T.query(points, 1, workers=-1)
+
 
 def test_ckdtree_view():
     # Check that the nodes can be correctly viewed from Python.
@@ -1549,4 +1556,3 @@ def test_kdtree_attributes():
     assert_array_equal(t.maxes, np.amax(points, axis=0))
     assert_array_equal(t.mins, np.amin(points, axis=0))
     assert t.data is points
-


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
@andyfaff rationale for late multiprocessing import: bugs.python.org/issue32596

#### Additional information
<!--Any additional information you think is important.-->