### PR TITLE
BUG: segfault in ndimage.fourier_ellipsoid with length-1 dims

### DIFF
--- a/scipy/ndimage/src/ni_fourier.c
+++ b/scipy/ndimage/src/ni_fourier.c
@@ -225,10 +225,12 @@ int NI_FourierFilter(PyArrayObject *input, PyArrayObject* parameter_array,
         params[kk] = NULL;
     }
     for (kk = 0; kk < PyArray_NDIM(input); kk++) {
-        params[kk] = malloc(PyArray_DIM(input, kk) * sizeof(double));
-        if (!params[kk]) {
-            PyErr_NoMemory();
-            goto exit;
+        if (PyArray_DIM(input, kk) > 1 || filter_type == _NI_ELLIPSOID) {
+            params[kk] = malloc(PyArray_DIM(input, kk) * sizeof(double));
+            if (!params[kk]) {
+                PyErr_NoMemory();
+                goto exit;
+            }
         }
     }
 

--- a/scipy/ndimage/src/ni_fourier.c
+++ b/scipy/ndimage/src/ni_fourier.c
@@ -225,12 +225,10 @@ int NI_FourierFilter(PyArrayObject *input, PyArrayObject* parameter_array,
         params[kk] = NULL;
     }
     for (kk = 0; kk < PyArray_NDIM(input); kk++) {
-        if (PyArray_DIM(input, kk) > 1) {
-            params[kk] = malloc(PyArray_DIM(input, kk) * sizeof(double));
-            if (!params[kk]) {
-                PyErr_NoMemory();
-                goto exit;
-            }
+        params[kk] = malloc(PyArray_DIM(input, kk) * sizeof(double));
+        if (!params[kk]) {
+            PyErr_NoMemory();
+            goto exit;
         }
     }
 

--- a/scipy/ndimage/tests/test_fourier.py
+++ b/scipy/ndimage/tests/test_fourier.py
@@ -132,14 +132,14 @@ class TestNdimageFourier:
                 assert_array_almost_equal(a, b, decimal=dec)
 
     @pytest.mark.parametrize('shape', [(0, ), (0, 10), (10, 0)])
-    @pytest.mark.parametrize('dtype, dec',
-                             [(numpy.float32, 5), (numpy.float64, 14),
-                              (numpy.complex64, 5), (numpy.complex128, 14)])
+    @pytest.mark.parametrize('dtype',
+                             [numpy.float32, numpy.float64,
+                              numpy.complex64, numpy.complex128])
     @pytest.mark.parametrize('test_func',
                              [ndimage.fourier_ellipsoid,
                               ndimage.fourier_gaussian,
                               ndimage.fourier_uniform])
-    def test_fourier_zero_length_dims(self, shape, dtype, dec, test_func):
+    def test_fourier_zero_length_dims(self, shape, dtype, test_func):
         a = numpy.ones(shape, dtype)
         b = test_func(a, 3)
         assert_equal(a, b)

--- a/scipy/ndimage/tests/test_fourier.py
+++ b/scipy/ndimage/tests/test_fourier.py
@@ -9,7 +9,7 @@ from scipy import ndimage
 
 class TestNdimageFourier:
 
-    @pytest.mark.parametrize('shape', [(32, 16), (31, 15)])
+    @pytest.mark.parametrize('shape', [(32, 16), (31, 15), (1, 10)])
     @pytest.mark.parametrize('dtype, dec',
                              [(numpy.float32, 6), (numpy.float64, 14)])
     def test_fourier_gaussian_real01(self, shape, dtype, dec):
@@ -35,7 +35,7 @@ class TestNdimageFourier:
         a = fft.ifft(a, shape[0], 0)
         assert_almost_equal(ndimage.sum(a.real), 1.0, decimal=dec)
 
-    @pytest.mark.parametrize('shape', [(32, 16), (31, 15)])
+    @pytest.mark.parametrize('shape', [(32, 16), (31, 15), (1, 10)])
     @pytest.mark.parametrize('dtype, dec',
                              [(numpy.float32, 6), (numpy.float64, 14)])
     def test_fourier_uniform_real01(self, shape, dtype, dec):
@@ -93,7 +93,7 @@ class TestNdimageFourier:
         assert_array_almost_equal(a.imag, numpy.zeros(shape),
                                   decimal=dec)
 
-    @pytest.mark.parametrize('shape', [(32, 16), (31, 15)])
+    @pytest.mark.parametrize('shape', [(32, 16), (31, 15), (1, 10)])
     @pytest.mark.parametrize('dtype, dec',
                              [(numpy.float32, 5), (numpy.float64, 14)])
     def test_fourier_ellipsoid_real01(self, shape, dtype, dec):

--- a/scipy/ndimage/tests/test_fourier.py
+++ b/scipy/ndimage/tests/test_fourier.py
@@ -1,6 +1,7 @@
 import numpy
 from numpy import fft
-from numpy.testing import (assert_almost_equal, assert_array_almost_equal)
+from numpy.testing import (assert_almost_equal, assert_array_almost_equal,
+                           assert_equal)
 
 import pytest
 
@@ -129,3 +130,16 @@ class TestNdimageFourier:
                 a = ndimage.fourier_ellipsoid(x, 5, -1, 0)
                 b = ndimage.fourier_uniform(x, 5, -1, 0)
                 assert_array_almost_equal(a, b, decimal=dec)
+
+    @pytest.mark.parametrize('shape', [(0, ), (0, 10), (10, 0)])
+    @pytest.mark.parametrize('dtype, dec',
+                             [(numpy.float32, 5), (numpy.float64, 14),
+                              (numpy.complex64, 5), (numpy.complex128, 14)])
+    @pytest.mark.parametrize('test_func',
+                             [ndimage.fourier_ellipsoid,
+                              ndimage.fourier_gaussian,
+                              ndimage.fourier_uniform])
+    def test_fourier_zero_length_dims(self, shape, dtype, dec, test_func):
+        a = numpy.ones(shape, dtype)
+        b = test_func(a, 3)
+        assert_equal(a, b)


### PR DESCRIPTION
#### Reference issue
Closes gh-12763

#### What does this implement/fix?
Replaces a segmentation fault with a `ValueError`.

The three python functions `ndimage.fourier_ellipsoid`, `fourier_gaussian` and `fourier_uniform` call the C function `NI_FourierFilter` in `ndimage/src/ni_fourier.c`. If the size of any of the dimensions of the supplied input array is less than 2 a segmentation fault occurs in the C code. This PR checks the input array dimension sizes and raises a `ValueError` instead.

The new code is in the C function rather than repeated 3 times in the python functions.

#### Additional information
Test added and docstrings updated.