### PR TITLE
numpy.linspace calls edited to ensure correct spacing.

### DIFF
--- a/doc/source/tutorial/fft.rst
+++ b/doc/source/tutorial/fft.rst
@@ -81,15 +81,15 @@ The example plots the FFT of the sum of two sines.
 
 .. plot::
 
-    >>> from scipy.fft import fft
+    >>> from scipy.fft import fft, fftfreq
     >>> # Number of sample points
     >>> N = 600
     >>> # sample spacing
     >>> T = 1.0 / 800.0
-    >>> x = np.linspace(0.0, N*T, N)
+    >>> x = np.linspace(0.0, N*T, N, endpoint=False)
     >>> y = np.sin(50.0 * 2.0*np.pi*x) + 0.5*np.sin(80.0 * 2.0*np.pi*x)
     >>> yf = fft(y)
-    >>> xf = np.linspace(0.0, 1.0/(2.0*T), N//2)
+    >>> xf = fftfreq(N, T)[:N//2]
     >>> import matplotlib.pyplot as plt
     >>> plt.plot(xf, 2.0/N * np.abs(yf[0:N//2]))
     >>> plt.grid()
@@ -108,18 +108,18 @@ truncated for illustrative purposes).
 
 .. plot::
 
-    >>> from scipy.fft import fft
+    >>> from scipy.fft import fft, fftfreq
     >>> # Number of sample points
     >>> N = 600
     >>> # sample spacing
     >>> T = 1.0 / 800.0
-    >>> x = np.linspace(0.0, N*T, N)
+    >>> x = np.linspace(0.0, N*T, N, endpoint=False)
     >>> y = np.sin(50.0 * 2.0*np.pi*x) + 0.5*np.sin(80.0 * 2.0*np.pi*x)
     >>> yf = fft(y)
     >>> from scipy.signal import blackman
     >>> w = blackman(N)
     >>> ywf = fft(y*w)
-    >>> xf = np.linspace(0.0, 1.0/(2.0*T), N//2)
+    >>> xf = fftfreq(N, T)[:N//2]
     >>> import matplotlib.pyplot as plt
     >>> plt.semilogy(xf[1:N//2], 2.0/N * np.abs(yf[1:N//2]), '-b')
     >>> plt.semilogy(xf[1:N//2], 2.0/N * np.abs(ywf[1:N//2]), '-r')
@@ -157,7 +157,7 @@ asymmetric spectrum.
     >>> N = 400
     >>> # sample spacing
     >>> T = 1.0 / 800.0
-    >>> x = np.linspace(0.0, N*T, N)
+    >>> x = np.linspace(0.0, N*T, N, endpoint=False)
     >>> y = np.exp(50.0 * 1.j * 2.0*np.pi*x) + 0.5*np.exp(-80.0 * 1.j * 2.0*np.pi*x)
     >>> yf = fft(y)
     >>> xf = fftfreq(N, T)
@@ -431,21 +431,21 @@ provides a five-fold compression rate.
     >>> from scipy.fft import dct, idct
     >>> import matplotlib.pyplot as plt
     >>> N = 100
-    >>> t = np.linspace(0,20,N)
+    >>> t = np.linspace(0,20,N, endpoint=False)
     >>> x = np.exp(-t/3)*np.cos(2*t)
     >>> y = dct(x, norm='ortho')
     >>> window = np.zeros(N)
     >>> window[:20] = 1
     >>> yr = idct(y*window, norm='ortho')
     >>> sum(abs(x-yr)**2) / sum(abs(x)**2)
-    0.0010901402257
+    0.0009872817275276098
     >>> plt.plot(t, x, '-bx')
     >>> plt.plot(t, yr, 'ro')
     >>> window = np.zeros(N)
     >>> window[:15] = 1
     >>> yr = idct(y*window, norm='ortho')
     >>> sum(abs(x-yr)**2) / sum(abs(x)**2)
-    0.0718818065008
+    0.06196643004256714
     >>> plt.plot(t, yr, 'g+')
     >>> plt.legend(['x', '$x_{20}$', '$x_{15}$'])
     >>> plt.grid()


### PR DESCRIPTION
In the FFT documentation, cf. https://docs.scipy.org/doc/scipy/reference/tutorial/fft.html , 
replaced `x = np.linspace(0.0, N*T, N)` with `x = np.linspace(0.0, N*T, N, , endpoint=False)`.
Likewise for generating the frequency linspace.