### PR TITLE
TST: make a couple of tests expected to fail on 32-bit architectures

### DIFF
--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -378,6 +378,7 @@ class TestConstructUtils(object):
         excinfo.match(r'Got blocks\[0,1\]\.shape\[0\] == 1, expected 2')
 
     @pytest.mark.slow
+    @pytest.mark.xfail_on_32bit("Can't create large array for test")
     def test_concatenate_int32_overflow(self):
         """ test for indptr overflow when concatenating matrices """
         check_free_memory(30000)

--- a/scipy/sparse/tests/test_sparsetools.py
+++ b/scipy/sparse/tests/test_sparsetools.py
@@ -61,6 +61,7 @@ def test_regression_std_vector_dtypes():
 
 
 @pytest.mark.slow
+@pytest.mark.xfail_on_32bit("Can't create large array for test")
 def test_nnz_overflow():
     # Regression test for gh-7230 / gh-7871, checking that coo_todense
     # with nnz > int32max doesn't overflow.


### PR DESCRIPTION
In `TestConstructUtils.test_concatenate_int32_overflow` and `test_nnz_overflow`, on a 32-bit architecture, in case `check_free_memory()` passes, `ValueError` is raised on an attempt to create a numpy array too large for a 32-bit architecture.
