### PR TITLE
CI: travis: Remove some unnecessary code from .travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -197,12 +197,6 @@ before_install:
     travis_retry pip install --upgrade pip setuptools wheel $OTHERSPEC cython pytest pytest-xdist mpmath argparse gmpy2 pybind11
     travis_retry pip install --upgrade $NUMPYSPEC
   - |
-    if [ -n "${USE_DEBUG}" ]; then
-        # see gh-10676; need to pin pytest version with debug
-        # Python 3.6
-        travis_retry pip install pytest
-    fi
-  - |
     if [ -z "${USE_DEBUG}" -a "${TRAVIS_CPU_ARCH}" == "amd64" -a "${TRAVIS_PYTHON_VERSION}" != "3.8" ]; then
         if ! expr "$NUMPYSPEC" : ".*--pre.*" > /dev/null; then
             # Install these only when not using Numpy prerelease


### PR DESCRIPTION
The code being removed had been used to pin the version of pytest at 5.0.1.
That version specification was removed in gh-12014.  pytest is installed by
a previous command in .travis.yml, so if we're not pinning the pytest
version, we no longer need this part of the script.
