### PR TITLE
MAINT: Ignore pytest's PytestConfigWarning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -10,3 +10,4 @@ filterwarnings =
     ignore:can't resolve package from __spec__ or __package__, falling back on __name__ and __path__:ImportWarning
     once:the imp module is deprecated in favour of importlib.*:DeprecationWarning
     once:the imp module is deprecated in favour of importlib.*:PendingDeprecationWarning
+    ignore:assertions not in test modules or plugins:pytest.PytestConfigWarning


### PR DESCRIPTION
When pytest is run with python optimization set by the environment variable
PYTHONOPTIMIZE=2, it generates the warning

    pytest.PytestConfigWarning: assertions not in test modules or plugins
    will be ignored because assert statements are not executed by the
    underlying Python interpreter (are you using python -O?)

Apparently this warning causes the test suite to fail.  In this change,
I've added

    ignore:assertions not in test modules or plugins:pytest.PytestConfigWarning

to the filter warnings used by pytest, so the PytestConfigWarning is
ignored.

