### PR TITLE
ENH: enable stats.shapiro() to take n-dimension input, handle nan and assign axis

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -243,6 +243,7 @@ Shashaank N for contributions to scipy.signal.
 Frank Torres for fixing a bug with solve_bvp for large problems.
 Ben West for updating the Gamma distribution documentation.
 Terry Davis for documentation improvements in scipy.ndimage.morphology
+Po-Wen Kao for improving stats.shapiro() API.
 
 Institutions
 ------------

--- a/THANKS.txt
+++ b/THANKS.txt
@@ -243,7 +243,6 @@ Shashaank N for contributions to scipy.signal.
 Frank Torres for fixing a bug with solve_bvp for large problems.
 Ben West for updating the Gamma distribution documentation.
 Terry Davis for documentation improvements in scipy.ndimage.morphology
-Po-Wen Kao for improving stats.shapiro() API.
 
 Institutions
 ------------

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1619,7 +1619,7 @@ def shapiro(x, axis=None, nan_policy="propagate"):
         Array of sample data.
     axis: int or None, optional
         Axis along which to compute test.
-        If None, input is flatterned into 1d array.
+        If None, input is flattened into 1d array.
         Default is None.
     nan_policy: {'propagate', 'raise', 'omit'}, optional
         Defines how to handle when input contains nan.

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1606,7 +1606,7 @@ def yeojohnson_normplot(x, la, lb, plot=None, N=80):
 
 ShapiroResult = namedtuple('ShapiroResult', ('statistic', 'pvalue'))
 
-def shapiro(x, axis=None, nan_policy="propagate"):
+def shapiro(x, axis=0, nan_policy="propagate"):
     """
     Perform the Shapiro-Wilk test for normality.
 
@@ -1620,7 +1620,7 @@ def shapiro(x, axis=None, nan_policy="propagate"):
     axis: int or None, optional
         Axis along which to compute test.
         If None, input is flattened into 1d array.
-        Default is None.
+        Default is 0.
     nan_policy: {'propagate', 'raise', 'omit'}, optional
         Defines how to handle when input contains nan.
         The following options are available (default is 'propagate'):

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1690,7 +1690,7 @@ def shapiro(x, axis=None, nan_policy="propagate"):
     if contains_nan and nan_policy == "omit":
         x = np.ma.masked_invalid(x)
 
-    result = np.apply_along_axis(_apply_sharipo_1d, axis, x)
+    result = np.apply_along_axis(_apply_shapiro_1d, axis, x)
     result = np.moveaxis(result, axis, 0)
 
     w = result[0]
@@ -1699,7 +1699,7 @@ def shapiro(x, axis=None, nan_policy="propagate"):
     return ShapiroResult(w, pw)
 
 
-def _apply_sharipo_1d(x: np.ma.MaskedArray):
+def _apply_shapiro_1d(x: np.ma.MaskedArray):
     """
    Perform the Shapiro-Wilk test for normality of 1d array.
 

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1618,7 +1618,9 @@ def shapiro(x, axis=None, nan_policy="propagate"):
     x : array_like
         Array of sample data.
     axis: int or None, optional
-        Axis along which to compute test. If None, input is flatterned into 1d array. Default is None.
+        Axis along which to compute test.
+        If None, input is flatterned into 1d array.
+        Default is None.
     nan_policy: {'propagate', 'raise', 'omit'}, optional
         Defines how to handle when input contains nan.
         The following options are available (default is 'propagate'):

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -155,21 +155,43 @@ class TestShapiro(object):
         assert_almost_equal(shapiro_test.pvalue, p_expected, decimal=5)
 
     def test_2d(self):
-        x1 = [[0.11, 7.87, 4.61, 10.14, 7.95, 3.14, 0.46,
-              4.43, 0.21, 4.75], [0.71, 1.52, 3.24,
-              0.93, 0.42, 4.97, 9.53, 4.55, 0.47, 6.66]]
-        w, pw = stats.shapiro(x1)
-        shapiro_test = stats.shapiro(x1)
+        x1 = [[0.11, 7.87, 4.61, 10.14, 7.95, 3.14, 0.46, 4.43, 0.21, 4.75],
+              [0.71, 1.52, 3.24, 0.93, 0.42, 4.97, 9.53, 4.55, 0.47, 6.66]]
+
+        x2 = [[1.36, 1.14, 2.92, 2.55, 1.46, 1.06, 5.27, -1.11, 3.48, 1.10],
+              [0.88, -0.51, 1.46, 0.52, 6.20, 1.69, 0.08, 3.67, 2.81, 3.49]]
+
+        # `axis == 0` [Default]
+        # verify against R
+        expected_w1 = [0.91938411862063074, 0.87539493317108474]
+        expected_pw1 = [0.35184684100656749, 0.11547995299080738]
+        w, pw = stats.shapiro(np.asarray(x1).T)
+        shapiro_test = stats.shapiro(np.asarray(x1).T)
+        assert_almost_equal(w, expected_w1, decimal=6)
+        assert_almost_equal(shapiro_test.statistic, expected_w1, decimal=6)
+        assert_almost_equal(pw, expected_pw1, decimal=6)
+        assert_almost_equal(shapiro_test.pvalue, expected_pw1, decimal=6)
+
+        # verify against R
+        expected_w2 = [0.94241143292741636, 0.94215958869940897]
+        expected_pw2 = [0.58014490927435836, 0.57728464675493796]
+        w, pw = stats.shapiro(np.asarray(x2).T)
+        shapiro_test = stats.shapiro(np.asarray(x2).T)
+        assert_almost_equal(w, expected_w2, decimal=6)
+        assert_almost_equal(shapiro_test.statistic, expected_w2, decimal=6)
+        assert_almost_equal(pw, expected_pw2, decimal=3)
+        assert_almost_equal(shapiro_test.pvalue, expected_pw2, decimal=3)
+
+        # `axis == None`, input will be flattened
+        w, pw = stats.shapiro(x1, axis=None)
+        shapiro_test = stats.shapiro(x1, axis=None)
         assert_almost_equal(w, 0.90047299861907959, decimal=6)
         assert_almost_equal(shapiro_test.statistic, 0.90047299861907959, decimal=6)
         assert_almost_equal(pw, 0.042089745402336121, decimal=6)
         assert_almost_equal(shapiro_test.pvalue, 0.042089745402336121, decimal=6)
 
-        x2 = [[1.36, 1.14, 2.92, 2.55, 1.46, 1.06, 5.27, -1.11,
-              3.48, 1.10], [0.88, -0.51, 1.46, 0.52, 6.20, 1.69,
-              0.08, 3.67, 2.81, 3.49]]
-        w, pw = stats.shapiro(x2)
-        shapiro_test = stats.shapiro(x2)
+        w, pw = stats.shapiro(x2, axis=None)
+        shapiro_test = stats.shapiro(x2, axis=None)
         assert_almost_equal(w, 0.9590270, decimal=6)
         assert_almost_equal(shapiro_test.statistic, 0.9590270, decimal=6)
         assert_almost_equal(pw, 0.52460, decimal=3)

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -215,11 +215,11 @@ class TestShapiro(object):
 
         # multi dimensions case
         n1 = self.nd.copy()
-        n1[0, 0, 0] = np.NaN
+        n1[0, 0, 0] = np.nan
         w1, pw1 = stats.shapiro(n1, axis=1)
         shapiro_test = stats.shapiro(n1, axis=1)
 
-        expect_w1 = [[np.NaN, 0.92373675927168242]]
+        expect_w1 = [[np.nan, 0.92373675927168242]]
         expect_pw1 = [[1, 0.38917735845393642]]
 
         assert_almost_equal(w1, expect_w1, decimal=6)
@@ -229,7 +229,7 @@ class TestShapiro(object):
 
     def test_nan_policies(self):
         n1 = self.nd.copy()
-        n1[0, 0, 0] = np.NaN
+        n1[0, 0, 0] = np.nan
 
         # [propagate]
         # already tested as default setting

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -181,10 +181,13 @@ class TestShapiro(object):
         shapiro_test = stats.shapiro(self.nd.copy(), axis=1)
 
         # verify against R
-        assert_almost_equal(w1, [[0.94757220950073784, 0.92373675927168242]], decimal=6)
-        assert_almost_equal(shapiro_test.statistic, [[0.94757220950073784, 0.92373675927168242]], decimal=6)
-        assert_almost_equal(pw1, [[0.63987350188392544, 0.38917735845393642]], decimal=3)
-        assert_almost_equal(shapiro_test.pvalue, [[0.63987350188392544, 0.38917735845393642]], decimal=3)
+        expect_w1 = [[0.94757220950073784, 0.92373675927168242]]
+        expect_pw1 = [[0.63987350188392544, 0.38917735845393642]]
+
+        assert_almost_equal(w1, expect_w1, decimal=6)
+        assert_almost_equal(shapiro_test.statistic, expect_w1, decimal=6)
+        assert_almost_equal(pw1, expect_pw1, decimal=3)
+        assert_almost_equal(shapiro_test.pvalue, expect_pw1, decimal=3)
 
     def test_empty_input(self):
         assert_raises(ValueError, stats.shapiro, [])
@@ -215,10 +218,14 @@ class TestShapiro(object):
         n1[0, 0, 0] = np.NaN
         w1, pw1 = stats.shapiro(n1, axis=1)
         shapiro_test = stats.shapiro(n1, axis=1)
-        assert_almost_equal(w1, [[np.NaN, 0.92373675927168242]], decimal=6)
-        assert_almost_equal(shapiro_test.statistic, [[np.NaN, 0.92373675927168242]], decimal=6)
-        assert_almost_equal(pw1, [[1, 0.38917735845393642]], decimal=3)
-        assert_almost_equal(shapiro_test.pvalue, [[1, 0.38917735845393642]], decimal=3)
+
+        expect_w1 = [[np.NaN, 0.92373675927168242]]
+        expect_pw1 = [[1, 0.38917735845393642]]
+
+        assert_almost_equal(w1, expect_w1, decimal=6)
+        assert_almost_equal(shapiro_test.statistic, expect_w1, decimal=6)
+        assert_almost_equal(pw1, expect_pw1, decimal=3)
+        assert_almost_equal(shapiro_test.pvalue, expect_pw1, decimal=3)
 
     def test_nan_policies(self):
         n1 = self.nd.copy()
@@ -231,14 +238,18 @@ class TestShapiro(object):
         w1, pw1 = stats.shapiro(n1, axis=1, nan_policy="omit")
         shapiro_test = stats.shapiro(n1, axis=1, nan_policy="omit")
 
+        expected_w1 = [[0.96561990493900784, 0.92373675927168242]]
+        expected_pw1 = [[0.85489472509292730, 0.38917735845393642]]
+
         # verify against R
-        assert_almost_equal(w1, [[0.96561990493900784, 0.92373675927168242]], decimal=6)
-        assert_almost_equal(shapiro_test.statistic, [[0.96561990493900784, 0.92373675927168242]], decimal=6)
-        assert_almost_equal(pw1, [[0.85489472509292730, 0.38917735845393642]], decimal=3)
-        assert_almost_equal(shapiro_test.pvalue, [[0.85489472509292730, 0.38917735845393642]], decimal=3)
+        assert_almost_equal(w1, expected_w1, decimal=6)
+        assert_almost_equal(shapiro_test.statistic, expected_w1, decimal=6)
+        assert_almost_equal(pw1, expected_pw1, decimal=3)
+        assert_almost_equal(shapiro_test.pvalue, expected_pw1, decimal=3)
 
         # [raise]
-        assert_raises(ValueError, stats.shapiro, n1, axis=1, nan_policy="raise")
+        assert_raises(ValueError, stats.shapiro, n1,
+                      axis=1, nan_policy="raise")
 
 
 class TestAnderson(object):


### PR DESCRIPTION
#### Reference issue

#### What does this implement/fix?
Very often scipy is used with Pandas and users might want to verify the normality of multiple columns.
A function that accepts only 1d input and not able to omit np.nan is cumbersome.
Such interface is not consistent with other API like `stats.ttest_ind()` either.

An improvement is proposed here to handle np.nan according to the given `nan_policy`.
Operation on a multi-dimension array is possible and can compute along a given `axis`.
The default behavior remains the same as the old implementation.
Only assigning `axis` and `nan_policy` options cause different behavior when handling input array.

Any comment is welcome :D
#### Additional information