### PR TITLE
MAINT: rename integrate.simps to simpson

### DIFF
--- a/doc/source/tutorial/integrate.rst
+++ b/doc/source/tutorial/integrate.rst
@@ -265,7 +265,7 @@ performs Richardson extrapolation on these estimates to approximate
 the integral with a higher degree of accuracy.
 
 In case of arbitrary spaced samples, the two functions :func:`~numpy.trapz`
-and :obj:`simps` are available. They are using Newton-Coates formulas
+and :obj:`simpson` are available. They are using Newton-Coates formulas
 of order 1 and 2 respectively to perform integration. The trapezoidal rule
 approximates the function as a straight line between adjacent points, while
 Simpson's rule approximates the function between three adjacent points as a

--- a/scipy/integrate/__init__.py
+++ b/scipy/integrate/__init__.py
@@ -32,7 +32,7 @@ Integrating functions, given fixed samples
 
    trapz         -- Use trapezoidal rule to compute integral.
    cumtrapz      -- Use trapezoidal rule to cumulatively compute integral.
-   simps         -- Use Simpson's rule to compute integral from samples.
+   simpson       -- Use Simpson's rule to compute integral from samples.
    romb          -- Use Romberg Integration to compute integral from
                  -- (2**k + 1) evenly-spaced samples.
 

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -10,8 +10,8 @@ from numpy import trapz
 from scipy.special import roots_legendre
 from scipy.special import gammaln
 
-__all__ = ['fixed_quad', 'quadrature', 'romberg', 'trapz', 'simps', 'romb',
-           'cumtrapz', 'newton_cotes', 'AccuracyWarning']
+__all__ = ['fixed_quad', 'quadrature', 'romberg', 'trapz', 'simps', 'simpson',
+           'romb', 'cumtrapz', 'newton_cotes', 'AccuracyWarning']
 
 
 # Make See Also linking for our local copy work properly
@@ -86,7 +86,7 @@ def fixed_quad(func, a, b, args=(), n=5):
     romberg : adaptive Romberg quadrature
     quadrature : adaptive Gaussian quadrature
     romb : integrators for sampled data
-    simps : integrators for sampled data
+    simpson : integrators for sampled data
     cumtrapz : cumulative integration for sampled data
     ode : ODE integrator
     odeint : ODE integrator
@@ -208,7 +208,7 @@ def quadrature(func, a, b, args=(), tol=1.49e-8, rtol=1.49e-8, maxiter=50,
     dblquad: double integrals
     tplquad: triple integrals
     romb: integrator for sampled data
-    simps: integrator for sampled data
+    simpson: integrator for sampled data
     cumtrapz: cumulative integration for sampled data
     ode: ODE integrator
     odeint: ODE integrator
@@ -346,7 +346,7 @@ def cumtrapz(y, x=None, dx=1.0, axis=-1, initial=None):
     return res
 
 
-def _basic_simps(y, start, stop, x, dx, axis):
+def _basic_simpson(y, start, stop, x, dx, axis):
     nd = len(y.shape)
     if start is None:
         start = 0
@@ -377,7 +377,18 @@ def _basic_simps(y, start, stop, x, dx, axis):
     return result
 
 
+# Note: alias kept for backwards compatibility. simps was renamed to simpson
+# because the former is a slur in colloquial English (see gh-12924).
 def simps(y, x=None, dx=1, axis=-1, even='avg'):
+    """`An alias of `simpson`.
+
+    `simps` is kept for backwards compatibility. For new code, prefer
+    `simpson` instead.
+    """
+    return simpson(y, x=x, dx=dx, axis=axis, even=even)
+
+
+def simpson(y, x=None, dx=1, axis=-1, even='avg'):
     """
     Integrate y(x) using samples along the given axis and the composite
     Simpson's rule. If x is None, spacing of dx is assumed.
@@ -434,16 +445,16 @@ def simps(y, x=None, dx=1, axis=-1, even='avg'):
     >>> x = np.arange(0, 10)
     >>> y = np.arange(0, 10)
 
-    >>> integrate.simps(y, x)
+    >>> integrate.simpson(y, x)
     40.5
 
     >>> y = np.power(x, 3)
-    >>> integrate.simps(y, x)
+    >>> integrate.simpson(y, x)
     1642.5
     >>> integrate.quad(lambda x: x**3, 0, 9)[0]
     1640.25
 
-    >>> integrate.simps(y, x, even='first')
+    >>> integrate.simpson(y, x, even='first')
     1644.5
 
     """
@@ -482,7 +493,7 @@ def simps(y, x=None, dx=1, axis=-1, even='avg'):
             if x is not None:
                 last_dx = x[slice1] - x[slice2]
             val += 0.5*last_dx*(y[slice1]+y[slice2])
-            result = _basic_simps(y, 0, N-3, x, dx, axis)
+            result = _basic_simpson(y, 0, N-3, x, dx, axis)
         # Compute using Simpson's rule on last set of intervals
         if even in ['avg', 'last']:
             slice1 = tupleset(slice1, axis, 0)
@@ -490,13 +501,13 @@ def simps(y, x=None, dx=1, axis=-1, even='avg'):
             if x is not None:
                 first_dx = x[tuple(slice2)] - x[tuple(slice1)]
             val += 0.5*first_dx*(y[slice2]+y[slice1])
-            result += _basic_simps(y, 1, N-2, x, dx, axis)
+            result += _basic_simpson(y, 1, N-2, x, dx, axis)
         if even == 'avg':
             val /= 2.0
             result /= 2.0
         result = result + val
     else:
-        result = _basic_simps(y, 0, N-2, x, dx, axis)
+        result = _basic_simpson(y, 0, N-2, x, dx, axis)
     if returnshape:
         x = x.reshape(saveshape)
     return result
@@ -532,7 +543,7 @@ def romb(y, dx=1.0, axis=-1, show=False):
     fixed_quad : fixed-order Gaussian quadrature
     dblquad : double integrals
     tplquad : triple integrals
-    simps : integrators for sampled data
+    simpson : integrators for sampled data
     cumtrapz : cumulative integration for sampled data
     ode : ODE integrators
     odeint : ODE integrators
@@ -731,7 +742,7 @@ def romberg(function, a, b, args=(), tol=1.48e-8, rtol=1.48e-8, show=False,
     dblquad : Double integrals.
     tplquad : Triple integrals.
     romb : Integrators for sampled data.
-    simps : Integrators for sampled data.
+    simpson : Integrators for sampled data.
     cumtrapz : Cumulative integration for sampled data.
     ode : ODE integrator.
     odeint : ODE integrator.

--- a/scipy/integrate/quadpack.py
+++ b/scipy/integrate/quadpack.py
@@ -146,7 +146,7 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
     quadrature : adaptive Gaussian quadrature
     odeint : ODE integrator
     ode : ODE integrator
-    simps : integrator for sampled data
+    simpson : integrator for sampled data
     romb : integrator for sampled data
     scipy.special : for coefficients and roots of orthogonal polynomials
 
@@ -577,7 +577,7 @@ def dblquad(func, a, b, gfun, hfun, args=(), epsabs=1.49e-8, epsrel=1.49e-8):
     quadrature : adaptive Gaussian quadrature
     odeint : ODE integrator
     ode : ODE integrator
-    simps : integrator for sampled data
+    simpson : integrator for sampled data
     romb : integrator for sampled data
     scipy.special : for coefficients and roots of orthogonal polynomials
 
@@ -652,7 +652,7 @@ def tplquad(func, a, b, gfun, hfun, qfun, rfun, args=(), epsabs=1.49e-8,
     dblquad: Double integrals
     nquad : N-dimensional integrals
     romb: Integrators for sampled data
-    simps: Integrators for sampled data
+    simpson: Integrators for sampled data
     ode: ODE integrators
     odeint: ODE integrators
     scipy.special: For coefficients and roots of orthogonal polynomials

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -4,7 +4,7 @@ from numpy.testing import (assert_equal, assert_almost_equal, assert_allclose,
                            assert_, suppress_warnings)
 
 from scipy.integrate import (quadrature, romberg, romb, newton_cotes,
-                             cumtrapz, quad, simps, fixed_quad,
+                             cumtrapz, quad, simpson, simps, fixed_quad,
                              AccuracyWarning)
 
 
@@ -141,17 +141,24 @@ class TestQuadrature(object):
         numeric_integral = np.dot(wts, y)
         assert_almost_equal(numeric_integral, exact_integral)
 
-    def test_simps(self):
+    def test_simpson(self):
         y = np.arange(17)
-        assert_equal(simps(y), 128)
-        assert_equal(simps(y, dx=0.5), 64)
-        assert_equal(simps(y, x=np.linspace(0, 4, 17)), 32)
+        assert_equal(simpson(y), 128)
+        assert_equal(simpson(y, dx=0.5), 64)
+        assert_equal(simpson(y, x=np.linspace(0, 4, 17)), 32)
 
         y = np.arange(4)
         x = 2**y
-        assert_equal(simps(y, x=x, even='avg'), 13.875)
-        assert_equal(simps(y, x=x, even='first'), 13.75)
-        assert_equal(simps(y, x=x, even='last'), 14)
+        assert_equal(simpson(y, x=x, even='avg'), 13.875)
+        assert_equal(simpson(y, x=x, even='first'), 13.75)
+        assert_equal(simpson(y, x=x, even='last'), 14)
+
+    def test_simps(self):
+        # Basic coverage test for the alias
+        y = np.arange(4)
+        x = 2**y
+        assert_equal(simpson(y, x=x, dx=0.5, even='first'),
+                     simps(y, x=x, dx=0.5, even='first'))
 
 
 class TestCumtrapz(object):

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -133,6 +133,7 @@ REFGUIDE_AUTOSUMMARY_SKIPLIST = [
     r'scipy\.special\..*_roots',  # old aliases for scipy.special.*_roots
     r'scipy\.special\.jn',  # alias for jv
     r'scipy\.ndimage\.sum',   # alias for sum_labels
+    r'scipy\.integrate\.simps',   # alias for simpson
     r'scipy\.linalg\.solve_lyapunov',  # deprecated name
     r'scipy\.stats\.contingency\.chi2_contingency',
     r'scipy\.stats\.contingency\.expected_freq',


### PR DESCRIPTION
Keep `simps` as an undocumented alias, for backward compatibility.  Addresses part of gh-12924.