### PR TITLE
[DOC] Add example for daub and morlet in scipy.signal

### DIFF
--- a/scipy/signal/wavelets.py
+++ b/scipy/signal/wavelets.py
@@ -22,6 +22,14 @@ def daub(p):
     -------
     daub : ndarray
         Return
+        
+    Examples
+    --------
+    >>> from scipy import signal
+    >>> import matplotlib.pyplot as plt
+    
+    >>> p = 2
+    >>> coef_wavelets = signal.daub(p)
 
     """
     sqrt = np.sqrt
@@ -214,7 +222,7 @@ def morlet(M, w=5.0, s=1.0, complete=True):
     Returns
     -------
     morlet : (M,) ndarray
-
+    
     See Also
     --------
     morlet2 : Implementation of Morlet wavelet, compatible with `cwt`.
@@ -246,6 +254,18 @@ def morlet(M, w=5.0, s=1.0, complete=True):
 
     Note: This function was created before `cwt` and is not compatible
     with it.
+    
+    Examples
+    --------
+    >>> from scipy import signal
+    >>> import matplotlib.pyplot as plt
+    
+    >>> M = 100
+    >>> s = 4.0
+    >>> w = 2.0
+    >>> wavelet = signal.morlet(M, s, w)
+    >>> plt.plot(wavelet)
+    >>> plt.show()
 
     """
     x = np.linspace(-s * 2 * np.pi, s * 2 * np.pi, M)


### PR DESCRIPTION
#### Reference issue
Addresses part of #7168 

#### What does this implement/fix?
Adds example for daub and morlet in scipy.signal

#### Additional information
The example for daub needs to be properly written, since I am not able to frame a good example code for daub function.
