### PR TITLE
MAINT: fix linter on master

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -4080,7 +4080,7 @@ class multivariate_t_gen(multi_rv_generic):
         if df == np.inf:
             return multivariate_normal._logpdf(x, loc, prec_U, log_pdet, rank)
 
-        dev  = x - loc
+        dev = x - loc
         maha = np.square(np.dot(dev, prec_U)).sum(axis=-1)
 
         t = 0.5 * (df + dim)

--- a/scipy/stats/tests/test_rank.py
+++ b/scipy/stats/tests/test_rank.py
@@ -182,6 +182,7 @@ class TestRankData(object):
 
     methods = ["average", "min", "max", "dense", "ordinal"]
     dtypes = [np.float64] + [np.int_]*4
+
     @pytest.mark.parametrize("axis", [0, 1])
     @pytest.mark.parametrize("method, dtype", zip(methods, dtypes))
     def test_size_0_axis(self, axis, method, dtype):


### PR DESCRIPTION
#### Reference issue
N/A

#### What does this implement/fix?
When I merged 
https://github.com/scipy/scipy/pull/12582
I missed a whitespace that causes linter to fail. 
This PR removes the whitespace character that offends the linter. 
