### PR TITLE
ENH: linalg: Allow supplying a sequence of matrices to linalg.expm

### DIFF
--- a/scipy/sparse/linalg/matfuncs.py
+++ b/scipy/sparse/linalg/matfuncs.py
@@ -598,6 +598,8 @@ def _expm(A, use_exact_onenorm):
     # Avoid indiscriminate asarray() to allow sparse or other strange arrays.
     if isinstance(A, (list, tuple, np.matrix)):
         A = np.asarray(A)
+    if len(A.shape) == 3:
+        return np.asarray([_expm(A_i, use_exact_onenorm) for A_i in A])
     if len(A.shape) != 2 or A.shape[0] != A.shape[1]:
         raise ValueError('expected a square matrix')
 

--- a/scipy/sparse/linalg/tests/test_matfuncs.py
+++ b/scipy/sparse/linalg/tests/test_matfuncs.py
@@ -550,6 +550,9 @@ class TestExpM(object):
 
         assert_allclose(E1, E2)
 
+    def test_expm_on_matrix_sequence(self):
+        A = [matrix([[0.,0],[0,0]]) for _ in range(3)]
+        assert_array_almost_equal(expm(A), [[[1,0],[0,1]] for _ in range(3)])
 
 class TestOperators(object):
 

--- a/scipy/sparse/linalg/tests/test_matfuncs.py
+++ b/scipy/sparse/linalg/tests/test_matfuncs.py
@@ -551,8 +551,8 @@ class TestExpM(object):
         assert_allclose(E1, E2)
 
     def test_expm_on_matrix_sequence(self):
-        A = [matrix([[0.,0],[0,0]]) for _ in range(3)]
-        assert_array_almost_equal(expm(A), [[[1,0],[0,1]] for _ in range(3)])
+        A = [matrix([[0., 0], [0, 0]]) for _ in range(3)]
+        assert_array_almost_equal(expm(A), [[[1, 0], [0, 1]] for _ in range(3)])
 
 class TestOperators(object):
 

--- a/scipy/sparse/linalg/tests/test_matfuncs.py
+++ b/scipy/sparse/linalg/tests/test_matfuncs.py
@@ -552,7 +552,8 @@ class TestExpM(object):
 
     def test_expm_on_matrix_sequence(self):
         A = [matrix([[0., 0], [0, 0]]) for _ in range(3)]
-        assert_array_almost_equal(expm(A), [[[1, 0], [0, 1]] for _ in range(3)])
+        assert_array_almost_equal(expm(A),
+                                  [[[1, 0], [0, 1]] for _ in range(3)])
 
 class TestOperators(object):
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue

Fixes [#12838](https://github.com/scipy/scipy/issues/12838).

#### What does this implement/fix?

This PR allows users to supply a sequence of square matrices to `linalg.expm` which before only accepted a single square matrix as an argument. The implementation simply checks if the input is 3-dimensional and if so, iterates over the topmost indexing and recursively calls the function on each of the arguments.

Right now this extension only works on sequences of matrices that are _all_ the same size, but if the project maintainers prefer to support sequences of matrices with different sizes I can change the code to do so 😄 