### PR TITLE
MAINT: Ensure that total function calls is < 'maxfev'

### DIFF
--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -2936,6 +2936,8 @@ def _minimize_powell(func, x0, args=(), callback=None, bounds=None,
             if (fx2 - fval) > delta:
                 delta = fx2 - fval
                 bigind = i
+            if fcalls[0] >= maxfun:
+                break
         iter += 1
         if callback is not None:
             callback(x)


### PR DESCRIPTION
The count of total function calls were checked only after an iteration was completed. This led to an issue due to which the main purpose of option 'maxfev' was defeated. The current change would ensure that the total function evaluations is less than 'maxfev'.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
See #12271

#### What does this implement/fix?
Ensures that the 'maxfev' option is not violated.
