### PR TITLE
MAINT: 1.5.3 backports related to ARM64

### DIFF
--- a/doc/release/1.5.3-notes.rst
+++ b/doc/release/1.5.3-notes.rst
@@ -5,7 +5,7 @@ SciPy 1.5.3 Release Notes
 .. contents::
 
 SciPy 1.5.3 is a bug-fix release with no new features
-compared to 1.5.2. In particular, ARM64 wheels are now
+compared to 1.5.2. In particular, Linux ARM64 wheels are now
 available and a compatibility issue with XCode 12 has
 been fixed.
 
@@ -17,6 +17,7 @@ Authors
 * Thomas Duvernay +
 * Gregory Lee
 * Eric Moore
+* odidev
 * Dima Pasechnik
 * Tyler Reddy
 * Simon Segerblom Rex +
@@ -24,7 +25,7 @@ Authors
 * Will Tirone +
 * Warren Weckesser
 
-A total of 11 people contributed to this release.
+A total of 12 people contributed to this release.
 People with a "+" by their names contributed a patch for the first time.
 This list of names is automatically generated, and may not be fully complete.
 
@@ -53,6 +54,7 @@ Pull requests for 1.5.3
 * `#12623 <https://github.com/scipy/scipy/pull/12623>`__: MAINT: stats: Loosen some test tolerances.
 * `#12638 <https://github.com/scipy/scipy/pull/12638>`__: CI, MAINT: pin pytest for Azure win
 * `#12668 <https://github.com/scipy/scipy/pull/12668>`__: BUG: Ensure factorial is not too large in mstats.kendalltau
+* `#12705 <https://github.com/scipy/scipy/pull/12705>`__: MAINT: \`openblas_support\` added sha256 hash
 * `#12706 <https://github.com/scipy/scipy/pull/12706>`__: BUG: fix incorrect 1d case of the fourier_ellipsoid filter
 * `#12721 <https://github.com/scipy/scipy/pull/12721>`__: BUG: use special.sindg in ndimage.rotate
 * `#12724 <https://github.com/scipy/scipy/pull/12724>`__: BUG: per #12654 adjusted mudholkar_george method to combine p...

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -33,7 +33,9 @@ sha256_vals = {
 'openblas-v0.3.9-win32-gcc_7_1_0.zip':
 '69a7dc265e8a8e45b358637d11cb1710ce88c4456634c7ce37d429b1d9bc9aaa',
 'openblas-v0.3.9-win_amd64-gcc_7_1_0.zip': 
-'0cea06f4a2afebaa6255854f73f237802fc6b58eaeb1a8b1c22d87cc399e0d48'
+'0cea06f4a2afebaa6255854f73f237802fc6b58eaeb1a8b1c22d87cc399e0d48',
+'openblas-v0.3.9-manylinux2014_aarch64.tar.gz':
+'10d5ef5e9e19af5c199b59a17f43763e0c85ecf13cbc8f2d91e076f7847cdb5e'
 }
 
 IS_32BIT = sys.maxsize < 2**32


### PR DESCRIPTION
* backport gh-12705 to allow `openblas_support.py` to pull in `aarch64` OpenBLAS binary--this is the current cause of `v1.5.x` wheels Linux ARM64 CI failure here: https://github.com/MacPython/scipy-wheels/pull/99 

* update the SciPy `1.5.3` release notes to clarify that we are planning to release *Linux* ARM64 wheels

If the CI remains green for this backport PR, I'll merge and then adjust the above scipy-wheels repo PR to point at the tip of `maintenance/1.5.x` to see if we are "good to go" for the Linux ARM64 wheel builds there.