### PR TITLE
CI: add Windows Python 3.9 to CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -93,6 +93,11 @@ jobs:
           NPY_USE_BLAS_ILP64: 1
           BITS: 64
           OPENBLAS64_: $(OPENBLAS)
+        Python39-64bit-full:
+          PYTHON_VERSION: '3.9'
+          PYTHON_ARCH: 'x64'
+          TEST_MODE: full
+          BITS: 64
   steps:
   - task: UsePythonVersion@0
     inputs:


### PR DESCRIPTION
* we do not currently have SciPy tested in CI for
Windows with Python 3.9; this may also be useful
to have in place before releasing 3.9 wheels on
the `1.5.x` branch