### PR TITLE
MAINT: prepare for SciPy 1.5.4

### DIFF
--- a/doc/release/1.5.4-notes.rst
+++ b/doc/release/1.5.4-notes.rst
@@ -1,0 +1,18 @@
+==========================
+SciPy 1.5.4 Release Notes
+==========================
+
+.. contents::
+
+SciPy 1.5.4 is a bug-fix release with no new features
+compared to 1.5.3.
+
+Authors
+=======
+
+Issues closed for 1.5.4
+-----------------------
+
+Pull requests for 1.5.4
+-----------------------
+

--- a/doc/source/release.1.5.4.rst
+++ b/doc/source/release.1.5.4.rst
@@ -1,0 +1,1 @@
+.. include:: ../release/1.5.4-notes.rst

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
    :maxdepth: 1
 
+   release.1.5.4
    release.1.5.3
    release.1.5.2
    release.1.5.1

--- a/pavement.py
+++ b/pavement.py
@@ -113,10 +113,10 @@ except AttributeError:
 #-----------------------------------
 
 # Source of the release notes
-RELEASE = 'doc/release/1.5.3-notes.rst'
+RELEASE = 'doc/release/1.5.4-notes.rst'
 
 # Start/end of the log (from git)
-LOG_START = 'v1.5.2'
+LOG_START = 'v1.5.3'
 LOG_END = 'maintenance/1.5.x'
 
 

--- a/setup.py
+++ b/setup.py
@@ -55,8 +55,8 @@ Operating System :: MacOS
 
 MAJOR = 1
 MINOR = 5
-MICRO = 3
-ISRELEASED = True
+MICRO = 4
+ISRELEASED = False
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
 


### PR DESCRIPTION
* add new files associated with the new
release notes for SciPy `1.5.4`

* bump maintenance branch version to `1.5.4`
unreleased

* the need for `1.5.4` is likely high given
the alternative would be waiting until December
to release wheels for Python `3.9`