### PR TITLE
BUG: added line.strip() to split_data_line() 

### DIFF
--- a/scipy/io/arff/arffread.py
+++ b/scipy/io/arff/arffread.py
@@ -475,7 +475,10 @@ def split_data_line(line, dialect=None):
     # Remove the line end if any
     if line[-1] == '\n':
         line = line[:-1]
-
+    
+    # Remove potential trailing whitespace
+    line = line.strip()
+    
     sniff_line = line
 
     # Add a delimiter if none is present, so that the csv.Sniffer

--- a/scipy/io/arff/tests/data/test11.arff
+++ b/scipy/io/arff/tests/data/test11.arff
@@ -1,0 +1,11 @@
+@RELATION test11
+
+@ATTRIBUTE attr0	REAL
+@ATTRIBUTE attr1 	REAL
+@ATTRIBUTE attr2 	REAL
+@ATTRIBUTE attr3	REAL
+@ATTRIBUTE class 	{ class0, class1, class2, class3 }
+@DATA
+0.1, 0.2, 0.3, 0.4,class1
+-0.1, -0.2, -0.3, -0.4,class2
+1, 2, 3, 4,class3

--- a/scipy/io/arff/tests/test_arffread.py
+++ b/scipy/io/arff/tests/test_arffread.py
@@ -59,7 +59,7 @@ class TestData(object):
         self._test(test6)
         
     def test4(self):
-        # Parsing trivial file with class attribute that includes trailing and leading spaces in attribute declaration.
+        # Parsing trivial file with trailing spaces in attribute declaration.
         self._test(test11)
 
     def _test(self, test_file):

--- a/scipy/io/arff/tests/test_arffread.py
+++ b/scipy/io/arff/tests/test_arffread.py
@@ -60,7 +60,7 @@ class TestData(object):
         
     def test11(self):
         # Parsing trivial file with class attribute that includes trailing and leading spaces in attribute declaration.
-        self._test(test6)
+        self._test(test11)
 
     def _test(self, test_file):
         data, meta = loadarff(test_file)

--- a/scipy/io/arff/tests/test_arffread.py
+++ b/scipy/io/arff/tests/test_arffread.py
@@ -57,6 +57,10 @@ class TestData(object):
     def test3(self):
         # Parsing trivial file with nominal attribute of 1 character.
         self._test(test6)
+        
+    def test11(self):
+        # Parsing trivial file with class attribute that includes trailing and leading spaces in attribute declaration.
+        self._test(test6)
 
     def _test(self, test_file):
         data, meta = loadarff(test_file)

--- a/scipy/io/arff/tests/test_arffread.py
+++ b/scipy/io/arff/tests/test_arffread.py
@@ -58,7 +58,7 @@ class TestData(object):
         # Parsing trivial file with nominal attribute of 1 character.
         self._test(test6)
         
-    def test11(self):
+    def test4(self):
         # Parsing trivial file with class attribute that includes trailing and leading spaces in attribute declaration.
         self._test(test11)
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes: #12904

#### What does this implement/fix?
Prevents class attributes from being parsed with trailing spaces if there is a trailing space in attribute declaration

#### Additional information
Added a unit test and minimal test data set.