### PR TITLE
BUG: stats: Tweak test parameters so rayleigh.fit fails consistently.

### DIFF
--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3496,7 +3496,7 @@ class TestErlang(object):
 
 class TestRayleigh(object):
     def setup_method(self):
-        np.random.seed(1234)
+        np.random.seed(987654321)
 
     # gh-6227
     def test_logpdf(self):
@@ -3531,7 +3531,7 @@ class TestRayleigh(object):
         # test that `scale` is defined by its relation to `loc`
         assert_equal(scale, scale_mle(data, loc))
 
-    @pytest.mark.parametrize("rvs_loc,rvs_scale", [np.random.rand(2)])
+    @pytest.mark.parametrize("rvs_loc,rvs_scale", [[0.74, 0.01]])
     def test_fit_comparison_super_method(self, rvs_loc, rvs_scale):
         # test that the objective function result of the analytical MLEs is
         # less than or equal to that of the numerically optimized estimate


### PR DESCRIPTION
Occasionally I had been getting a failure of the `rayleigh.fit` method, and I noticed the same failure in https://github.com/scipy/scipy/pull/12737.  This PR tweaks one of the tests of `rayleigh.fit` so that it fails consistently.

Do not merge this PR.  It is really a bug report, not a bug fix.