### PR TITLE
ENH: stats: Use only an analytical formula or scalar root-finding in rayleigh.fit. 

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -6430,8 +6430,9 @@ rdist = rdist_gen(a=-1.0, b=1.0, name="rdist")
 
 def _rayleigh_fit_check_error(ier, msg):
     if ier != 1:
-        raise RuntimeError('rayleigh.fit failed to find the root of the MLE '
-                           f'equation: {msg} (ier={ier})')
+        raise RuntimeError('rayleigh.fit: fsolve failed to find the root of '
+                           'the first-order conditions of the log-likelihood '
+                           f'function: {msg} (ier={ier})')
 
 
 class rayleigh_gen(rv_continuous):
@@ -6494,7 +6495,7 @@ class rayleigh_gen(rv_continuous):
         return _EULER/2.0 + 1 - 0.5*np.log(2)
 
     @extend_notes_in_docstring(rv_continuous, notes="""\
-        Notes specifically for rayleigh.fit: If the location is fixed with
+        Notes specifically for ``rayleigh.fit``: If the location is fixed with
         the `floc` parameter, this method uses an analytical formula to find
         the scale.  Otherwise, this function uses a numerical root finder on
         the first order conditions of the log-likelihood function to find the

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -6488,14 +6488,13 @@ class rayleigh_gen(rv_continuous):
         return _EULER/2.0 + 1 - 0.5*np.log(2)
 
     @extend_notes_in_docstring(rv_continuous, notes="""\
-        When the scale parameter is fixed by using the `fscale` argument,
-        this function uses the default optimization method to determine
-        the MLE. If the location parameter is fixed by using the `floc`
-        argument, the analytical formula for the estimate of the scale
-        is used. If neither parameter is fixed, the analytical MLE for
-        `scale` is used as a function of `loc` in numerical optimization
-        of `loc`, injecting corresponding analytical optimum for
-        `scale`.\n\n""")
+        Notes specifically for rayleigh.fit: If the location is fixed with
+        the `floc` parameter, this method uses an analytical formula to find
+        the scale.  Otherwise, this function uses a numerical root finder on
+        the first order conditions of the log-likelihood function to find the
+        MLE.  Only the (optional) `loc` parameter is used as the initial guess
+        for the root finder; the `scale` parameter and any other parameters
+        for the optimizer are ignored.\n\n""")
     def fit(self, data, *args, **kwds):
         data, floc, fscale = _check_fit_input_parameters(self, data,
                                                          args, kwds)

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -6428,6 +6428,12 @@ class rdist_gen(rv_continuous):
 rdist = rdist_gen(a=-1.0, b=1.0, name="rdist")
 
 
+def _rayleigh_fit_check_error(ier, msg):
+    if ier != 1:
+        raise RuntimeError('rayleigh.fit failed to find the root of the MLE '
+                           f'equation: {msg} (ier={ier})')
+
+
 class rayleigh_gen(rv_continuous):
     r"""A Rayleigh continuous random variable.
 
@@ -6534,13 +6540,17 @@ class rayleigh_gen(rv_continuous):
 
         if fscale is not None:
             # `scale` is fixed
-            loc = optimize.fsolve(loc_mle_scale_fixed, x0=loc0,
-                                  args=(fscale, data,), xtol=1e-10)
-            return loc[0], fscale
+            x, info, ier, msg = optimize.fsolve(loc_mle_scale_fixed, x0=loc0,
+                                                args=(fscale, data,),
+                                                xtol=1e-10, full_output=True)
+            _rayleigh_fit_check_error(ier, msg)
+            return x[0], fscale
         else:
             # Neither `loc` nor `scale` are fixed.
-            loc = optimize.fsolve(loc_mle, x0=loc0, args=(data,), xtol=1e-10)
-            return loc[0], scale_mle(loc, data)
+            x, info, ier, msg = optimize.fsolve(loc_mle, x0=loc0, args=(data,),
+                                                xtol=1e-10, full_output=True)
+            _rayleigh_fit_check_error(ier, msg)
+            return x[0], scale_mle(x[0], data)
 
 
 rayleigh = rayleigh_gen(a=0.0, name="rayleigh")

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3496,7 +3496,7 @@ class TestErlang(object):
 
 class TestRayleigh(object):
     def setup_method(self):
-        np.random.seed(1234)
+        np.random.seed(987654321)
 
     # gh-6227
     def test_logpdf(self):
@@ -3531,7 +3531,8 @@ class TestRayleigh(object):
         # test that `scale` is defined by its relation to `loc`
         assert_equal(scale, scale_mle(data, loc))
 
-    @pytest.mark.parametrize("rvs_loc,rvs_scale", [np.random.rand(2)])
+    @pytest.mark.parametrize("rvs_loc,rvs_scale", [[0.74, 0.01],
+                                                   np.random.rand(2)])
     def test_fit_comparison_super_method(self, rvs_loc, rvs_scale):
         # test that the objective function result of the analytical MLEs is
         # less than or equal to that of the numerically optimized estimate


### PR DESCRIPTION
This changes rayleigh.fit so that if the location parameter is not fixed, the numerical calculation involves only finding the root of a scalar equation for the location, whether or not the scale is fixed.

This fixes the failure demonstrated in the draft pull request gh-12967.

I put notes on the MLE calculations for the Rayleigh distribution at https://warrenweckesser.github.io/notes/mlenotes.html.
