### PR TITLE
MAINT: Run lint_diff.py against the merge target and only for PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,10 @@ matrix:
         # TODO: remove "ignore[import]" filter below when moving to pyflakes==2.1.2 or above
         - PYFLAKES_NODOCTEST=1 pyflakes scipy benchmarks/benchmarks 2>&1 | grep -E -v 'unable to detect undefined names|assigned to but never used|imported but unused|redefinition of unused|may be undefined, or defined from star imports|syntax error in type comment .ignore.import.' > test.out; cat test.out; test \! -s test.out
         - pycodestyle scipy benchmarks/benchmarks
-        - tools/lint_diff.py
+        - |
+          if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+             python tools/lint_diff.py --branch $TRAVIS_BRANCH
+          fi
         - tools/unicode-check.py
     - python: 3.7
       name: "ARM - Test Group 1"

--- a/tools/lint_diff.py
+++ b/tools/lint_diff.py
@@ -2,6 +2,7 @@
 import os
 import sys
 import subprocess
+from argparse import ArgumentParser
 
 CONFIG = os.path.join(
     os.path.abspath(os.path.dirname(__file__)),
@@ -31,8 +32,8 @@ def rev_list(branch, num_commits):
     return res.stdout.rstrip('\n').split('\n')
 
 
-def find_branch_point():
-    """Find when the current branch split off master.
+def find_branch_point(branch):
+    """Find when the current branch split off from the given branch.
 
     It is based off of this Stackoverflow post:
 
@@ -40,7 +41,7 @@ def find_branch_point():
 
     """
     branch_commits = rev_list('HEAD', 1000)
-    master_commits = set(rev_list('master', 1000))
+    master_commits = set(rev_list(branch, 1000))
     for branch_commit in branch_commits:
         if branch_commit in master_commits:
             return branch_commit
@@ -74,7 +75,12 @@ def run_pycodestyle(diff):
 
 
 def main():
-    branch_point = find_branch_point()
+    parser = ArgumentParser()
+    parser.add_argument("--branch", type=str, default='master',
+                        help="The branch to diff against")
+    args = parser.parse_args()
+
+    branch_point = find_branch_point(args.branch)
     diff = find_diff(branch_point)
     rc, errors = run_pycodestyle(diff)
     if errors:


### PR DESCRIPTION
#### Reference issue
Fixes gh-12966

#### What does this implement/fix?
`lint_diff.py`: remove direct reference to `master` and make the branch configurable.
`.travis.yaml`: Pass in the PR target branch to `lint_diff.py` and only run for PRs and not branch pushes.

Reference for the travis variables: https://docs.travis-ci.com/user/environment-variables/#default-environment-variables