### PR TITLE
DOC: next_fast_len output doesn't match docstring

### DIFF
--- a/scipy/fft/_helper.py
+++ b/scipy/fft/_helper.py
@@ -47,7 +47,7 @@ def next_fast_len(target, real=False):
     Zero-padding to the next regular length reduces computation time to
     1.6 ms, a speedup of 7.3 times:
 
-    >>> fft.next_fast_len(min_len, True)
+    >>> fft.next_fast_len(min_len, real=True)
     93312
     >>> b = fft.fft(a, 93312)
 

--- a/scipy/fft/_helper.py
+++ b/scipy/fft/_helper.py
@@ -19,8 +19,8 @@ def next_fast_len(target, real=False):
     target : int
         Length to start searching from. Must be a positive integer.
     real : bool, optional
-        True if the FFT involves real input or output (e.g., `rfft` or `hfft` but
-        not `fft`). Defaults to False.
+        True if the FFT involves real input or output (e.g., `rfft` or `hfft`
+        but not `fft`). Defaults to False.
 
     Returns
     -------
@@ -37,7 +37,7 @@ def next_fast_len(target, real=False):
 
     Examples
     --------
-    On a particular machine, an FFT of prime length takes 17 ms:
+    On a particular machine, an FFT of prime length takes 11.4 ms:
 
     >>> from scipy import fft
     >>> min_len = 93059  # prime length is worst case for speed
@@ -45,14 +45,14 @@ def next_fast_len(target, real=False):
     >>> b = fft.fft(a)
 
     Zero-padding to the next regular length reduces computation time to
-    1.3 ms, a speedup of 13 times:
+    1.6 ms, a speedup of 7.3 times:
 
-    >>> fft.next_fast_len(min_len)
+    >>> fft.next_fast_len(min_len, True)
     93312
     >>> b = fft.fft(a, 93312)
 
-    Rounding up to the next power of 2 is not optimal, taking 1.9 ms to
-    compute; 1.3 times longer than the size given by ``next_fast_len``:
+    Rounding up to the next power of 2 is not optimal, taking 3.0 ms to
+    compute; 1.9 times longer than the size given by ``next_fast_len``:
 
     >>> b = fft.fft(a, 131072)
 


### PR DESCRIPTION
Output is actually 93170, not 93312.  Also tested timing and replaced with actual results.

Unfortunately, 93312 is actually faster, taking 1.6 ms, so maybe that should be considered a bug, too.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->