### PR TITLE
BUG: fft.next_fast_len should accept keyword arguments

### DIFF
--- a/scipy/fft/_pocketfft/pypocketfft.cxx
+++ b/scipy/fft/_pocketfft/pypocketfft.cxx
@@ -374,11 +374,13 @@ py::array genuine_hartley(const py::array &in, const py::object &axes_,
   }
 
 // Export good_size in raw C-API to reduce overhead (~4x faster)
-PyObject * good_size(PyObject * /*self*/, PyObject * args)
+PyObject * good_size(PyObject * /*self*/, PyObject * args, PyObject * kwargs)
   {
   Py_ssize_t n_ = -1;
   int real = false;
-  if (!PyArg_ParseTuple(args, "n|p:good_size", &n_, &real))
+  char * keywords[] = {"target", "real", nullptr};
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "n|p:good_size", keywords,
+                                   &n_, &real))
     return nullptr;
 
   if (n_<0)
@@ -687,7 +689,7 @@ const char * good_size_DS = R"""(Returns a good length to pad an FFT to.
 
 Parameters
 ----------
-n : int
+target : int
     Minimum transform length
 real : bool, optional
     True if either input or output of FFT should be fully real.
@@ -724,6 +726,7 @@ PYBIND11_MODULE(pypocketfft, m)
     "out"_a=None, "nthreads"_a=1);
 
   static PyMethodDef good_size_meth[] =
-    {{"good_size", good_size, METH_VARARGS, good_size_DS}, {0}};
+    {{"good_size", (PyCFunction)good_size,
+      METH_VARARGS | METH_KEYWORDS, good_size_DS}, {0}};
   PyModule_AddFunctions(m.ptr(), good_size_meth);
   }

--- a/scipy/fft/_pocketfft/version.md
+++ b/scipy/fft/_pocketfft/version.md
@@ -4,17 +4,15 @@ pypocketfft version
 
 SciPy currently vendors [pypocketfft] at:
 
-    commit 8234f5c6adf74490e6bbf686d6c1a0041d772ac9
-    Merge: 7a39f78 c1e7bdf
+    commit bf2c431c21213b7c5e23c2f542009b0bd3ec1445
+    Merge: 8234f5c 9c252b2
     Author: Martin Reinecke <martin@mpa-garching.mpg.de>
-    Date:   Fri Sep 4 18:41:04 2020 +0200
+    Date:   Tue Oct 20 15:16:14 2020 +0200
 
-        Merge branch 'threadpool-fixes' into 'master'
+        Merge branch 'good_size_keywords' into 'master'
 
-        Threadpool fixes
+        Handle keyword args in good_size
 
-        Closes #14
-
-        See merge request mtr/pypocketfft!40
+        See merge request mtr/pypocketfft!41
 
 pypocketfft: https://gitlab.mpcdf.mpg.de/mtr/pypocketfft

--- a/scipy/fft/tests/test_helper.py
+++ b/scipy/fft/tests/test_helper.py
@@ -109,6 +109,10 @@ class TestNextFastLen(object):
         for x, y in hams.items():
             assert_equal(next_fast_len(x, True), y)
 
+    def test_keyword_args(self):
+        assert next_fast_len(11, real=True) == 12
+        assert next_fast_len(target=7, real=False) == 7
+
 
 class Test_init_nd_shape_and_axes(object):
 


### PR DESCRIPTION
#### Reference issue
Fixes https://github.com/scipy/scipy/pull/12978#discussion_r508468512

#### What does this implement/fix?
`next_fast_len` now accepts keyword arguemnts.