### PR TITLE
MAINT: use f-strings

### DIFF
--- a/scipy/_build_utils/_fortran.py
+++ b/scipy/_build_utils/_fortran.py
@@ -233,15 +233,15 @@ def _blas_ilp64_pre_build_hook(cmd, ext, blas_info):
 
         text = ""
         for symbol in get_blas_lapack_symbols():
-            text += '#define {} {}{}_{}\n'.format(symbol, prefix, symbol, suffix)
-            text += '#define {} {}{}_{}\n'.format(symbol.upper(), prefix, symbol, suffix)
+            text += f'#define {symbol} {prefix}{symbol}_{suffix}\n'
+            text += f'#define {symbol.upper()} {prefix}{symbol}_{suffix}\n'
 
             # Code generation may give source codes with mixed-case names
             for j in (1, 2):
                 s = symbol[:j].lower() + symbol[j:].upper()
-                text += '#define {} {}{}_{}\n'.format(s, prefix, symbol, suffix)
+                text += f'#define {s} {prefix}{symbol}_{suffix}\n'
                 s = symbol[:j].upper() + symbol[j:].lower()
-                text += '#define {} {}{}_{}\n'.format(s, prefix, symbol, suffix)
+                text += f'#define {s} {prefix}{symbol}_{suffix}\n'
 
         write_file_content(include_fn_f, text)
 
@@ -250,7 +250,7 @@ def _blas_ilp64_pre_build_hook(cmd, ext, blas_info):
 
         # Patch sources to include it
         def patch_source(filename, old_text):
-            text = '#include "{}"\n'.format(include_name_f)
+            text = f'#include "{include_name_f}\"\n'
             text += old_text
             return text
     else:

--- a/scipy/_lib/_ccallback.py
+++ b/scipy/_lib/_ccallback.py
@@ -88,7 +88,7 @@ class LowLevelCallable(tuple):
         return tuple.__new__(cls, (item, function, user_data))
 
     def __repr__(self):
-        return "LowLevelCallable({!r}, {!r})".format(self.function, self.user_data)
+        return f"LowLevelCallable({self.function!r}, {self.user_data!r})"
 
     @property
     def function(self):
@@ -127,7 +127,7 @@ class LowLevelCallable(tuple):
         except AttributeError as e:
             raise ValueError("Given module is not a Cython module with __pyx_capi__ attribute") from e
         except KeyError as e:
-            raise ValueError("No function {!r} found in __pyx_capi__ of the module".format(name)) from e
+            raise ValueError(f"No function {name!r} found in __pyx_capi__ of the module") from e
         return cls(function, user_data, signature)
 
     @classmethod

--- a/scipy/_lib/_pep440.py
+++ b/scipy/_lib/_pep440.py
@@ -172,7 +172,7 @@ class LegacyVersion(_BaseVersion):
         return self._version
 
     def __repr__(self):
-        return "<LegacyVersion({0})>".format(repr(str(self)))
+        return f"<LegacyVersion({repr(str(self))})>"
 
     @property
     def public(self):
@@ -293,7 +293,7 @@ class Version(_BaseVersion):
         # Validate the version and parse it into pieces
         match = self._regex.search(version)
         if not match:
-            raise InvalidVersion("Invalid version: '{0}'".format(version))
+            raise InvalidVersion(f"Invalid version: '{version}'")
 
         # Store the parsed out pieces of the version
         self._version = _Version(
@@ -325,14 +325,14 @@ class Version(_BaseVersion):
         )
 
     def __repr__(self):
-        return "<Version({0})>".format(repr(str(self)))
+        return f"<Version({repr(str(self))})>"
 
     def __str__(self):
         parts = []
 
         # Epoch
         if self._version.epoch != 0:
-            parts.append("{0}!".format(self._version.epoch))
+            parts.append(f"{self._version.epoch}!")
 
         # Release segment
         parts.append(".".join(str(x) for x in self._version.release))
@@ -343,16 +343,16 @@ class Version(_BaseVersion):
 
         # Post-release
         if self._version.post is not None:
-            parts.append(".post{0}".format(self._version.post[1]))
+            parts.append(f".post{self._version.post[1]}")
 
         # Development release
         if self._version.dev is not None:
-            parts.append(".dev{0}".format(self._version.dev[1]))
+            parts.append(f".dev{self._version.dev[1]}")
 
         # Local version segment
         if self._version.local is not None:
             parts.append(
-                "+{0}".format(".".join(str(x) for x in self._version.local))
+                f"+{'.'.join(str(x) for x in self._version.local)}"
             )
 
         return "".join(parts)
@@ -367,7 +367,7 @@ class Version(_BaseVersion):
 
         # Epoch
         if self._version.epoch != 0:
-            parts.append("{0}!".format(self._version.epoch))
+            parts.append(f"{self._version.epoch}!")
 
         # Release segment
         parts.append(".".join(str(x) for x in self._version.release))

--- a/scipy/_lib/_threadsafety.py
+++ b/scipy/_lib/_threadsafety.py
@@ -52,7 +52,7 @@ def non_reentrant(err_msg=None):
     def decorator(func):
         msg = err_msg
         if msg is None:
-            msg = "%s is not re-entrant" % func.__name__
+            msg = f"{func.__name__} is not re-entrant"
         lock = ReentrancyLock(msg)
         return lock.decorate(func)
     return decorator

--- a/scipy/_lib/_uarray/_backend.py
+++ b/scipy/_lib/_uarray/_backend.py
@@ -59,7 +59,7 @@ def pickle_function(func):
 
     if test is not func:
         raise pickle.PicklingError(
-            "Can't pickle {}: it's not the same object as {}".format(func, test)
+            f"Can't pickle {func}: it's not the same object as {test}"
         )
 
     return unpickle_function, (mod_name, qname)

--- a/scipy/_lib/decorator.py
+++ b/scipy/_lib/decorator.py
@@ -98,8 +98,8 @@ class FunctionMaker(object):
                 elif self.kwonlyargs:
                     allargs.append('*')  # single star syntax
                 for a in self.kwonlyargs:
-                    allargs.append('%s=None' % a)
-                    allshortargs.append('%s=%s' % (a, a))
+                    allargs.append(f'{a}=None')
+                    allshortargs.append(f'{a}={a}')
                 if self.varkw:
                     allargs.append('**' + self.varkw)
                     allshortargs.append('**' + self.varkw)
@@ -122,7 +122,7 @@ class FunctionMaker(object):
         # check existence required attributes
         assert hasattr(self, 'name')
         if not hasattr(self, 'signature'):
-            raise TypeError('You are decorating a non-function: %s' % func)
+            raise TypeError(f'You are decorating a non-function: {func}')
 
     def update(self, func, **kw):
         "Update the signature of func with the data in self"
@@ -147,13 +147,13 @@ class FunctionMaker(object):
         evaldict = evaldict or {}
         mo = DEF.match(src)
         if mo is None:
-            raise SyntaxError('not a valid function template\n%s' % src)
+            raise SyntaxError(f'not a valid function template\n{src}')
         name = mo.group(1)  # extract the function name
         names = set([name] + [arg.strip(' *') for arg in
                               self.shortsignature.split(',')])
         for n in names:
             if n in ('_func_', '_call_'):
-                raise NameError('%s is overridden in\n%s' % (n, src))
+                raise NameError(f'{n} is overridden in\n{src}')
         if not src.endswith('\n'):  # add a newline just for safety
             src += '\n'  # this is needed in old versions of Python
 
@@ -238,7 +238,7 @@ def decorator(caller, _func=None):
     evaldict['_call_'] = caller
     evaldict['_decorate_'] = decorate
     return FunctionMaker.create(
-        '%s(func)' % name, 'return _decorate_(func, _call_)',
+        f'{name}(func)', 'return _decorate_(func, _call_)',
         evaldict, doc=doc, module=caller.__module__,
         __wrapped__=caller)
 
@@ -315,7 +315,7 @@ def dispatch_on(*dispatch_args):
         # first check the dispatch arguments
         argset = set(getfullargspec(func).args)
         if not set(dispatch_args) <= argset:
-            raise NameError('Unknown dispatch arguments %s' % dispatch_str)
+            raise NameError(f'Unknown dispatch arguments {dispatch_str}')
 
         typemap = {}
 
@@ -341,7 +341,7 @@ def dispatch_on(*dispatch_args):
                 n_vas = len(vas)
                 if n_vas > 1:
                     raise RuntimeError(
-                        'Ambiguous dispatch for %s: %s' % (t, vas))
+                        f'Ambiguous dispatch for {t}: {vas}')
                 elif n_vas == 1:
                     va, = vas
                     mro = type('t', (t, va), {}).__mro__[1:]
@@ -390,7 +390,7 @@ def dispatch_on(*dispatch_args):
             return func(*args, **kw)
 
         return FunctionMaker.create(
-            func, 'return _f_(%s, %%(shortsignature)s)' % dispatch_str,
+            func, f"return _f_(%s, %{dispatch_str['shortsignature']})",
             dict(_f_=_dispatch), register=register, default=func,
             typemap=typemap, vancestors=vancestors, ancestors=ancestors,
             dispatch_info=dispatch_info, __wrapped__=func)

--- a/scipy/_lib/deprecation.py
+++ b/scipy/_lib/deprecation.py
@@ -9,7 +9,7 @@ def _deprecated(msg, stacklevel=2):
     def wrap(fun):
         if isinstance(fun, type):
             warnings.warn(
-                "Trying to deprecate class {!r}".format(fun),
+                f"Trying to deprecate class {fun!r}",
                 category=RuntimeWarning, stacklevel=2)
             return fun
 
@@ -76,13 +76,12 @@ def deprecate_cython_api(module, routine_name, new_name=None, message=None):
     deprecation warning when they are imported.
 
     """
-    old_name = "{}.{}".format(module.__name__, routine_name)
+    old_name = f"{module.__name__}.{routine_name}"
 
     if new_name is None:
-        depdoc = "`%s` is deprecated!" % old_name
+        depdoc = f"`{old_name}` is deprecated!"
     else:
-        depdoc = "`%s` is deprecated, use `%s` instead!" % \
-                 (old_name, new_name)
+        depdoc = f"`{old_name}` is deprecated, use `{new_name}` instead!"
 
     if message is not None:
         depdoc += "\n" + message
@@ -93,7 +92,7 @@ def deprecate_cython_api(module, routine_name, new_name=None, message=None):
     j = 0
     has_fused = False
     while True:
-        fused_name = "__pyx_fuse_{}{}".format(j, routine_name)
+        fused_name = f"__pyx_fuse_{j}{routine_name}"
         if fused_name in d:
             has_fused = True
             d[_DeprecationHelperStr(fused_name, depdoc)] = d.pop(fused_name)

--- a/scipy/_lib/setup.py
+++ b/scipy/_lib/setup.py
@@ -33,7 +33,7 @@ def configuration(parent_package='',top_path=None):
                               'messagestream_config.h')
         with open(target, 'w') as f:
             for name, value in defines:
-                f.write('#define {0} {1}\n'.format(name, value))
+                f.write(f'#define {name} {value}\n')
 
     depends = [os.path.join(include_dir, 'messagestream.h')]
     config.add_extension("messagestream",

--- a/scipy/_lib/tests/test_import_cycles.py
+++ b/scipy/_lib/tests/test_import_cycles.py
@@ -48,5 +48,5 @@ def test_modules_importable():
     # Check that all modules are importable in a new Python process.
     # This is not necessarily true if there are import cycles present.
     for module in MODULES:
-        cmd = 'import {}'.format(module)
+        cmd = f'import {module}'
         subprocess.check_call([sys.executable, '-c', cmd])

--- a/scipy/_lib/tests/test_warnings.py
+++ b/scipy/_lib/tests/test_warnings.py
@@ -41,7 +41,7 @@ class FindFuncs(ast.NodeVisitor):
         if p.ls[-1] == 'simplefilter' or p.ls[-1] == 'filterwarnings':
             if node.args[0].s == "ignore":
                 self.bad_filters.append(
-                    "{}:{}".format(self.__filename, node.lineno))
+                    f"{self.__filename}:{node.lineno}")
 
         if p.ls[-1] == 'warn' and (
                 len(p.ls) == 1 or p.ls[-2] == 'warnings'):
@@ -56,7 +56,7 @@ class FindFuncs(ast.NodeVisitor):
             args = {kw.arg for kw in node.keywords}
             if "stacklevel" not in args:
                 self.bad_stacklevels.append(
-                    "{}:{}".format(self.__filename, node.lineno))
+                    f"{self.__filename}:{node.lineno}")
 
 
 @pytest.fixture(scope="session")

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -156,7 +156,7 @@ class ClusterWarning(UserWarning):
 
 
 def _warning(s):
-    warnings.warn('scipy.cluster: %s' % s, ClusterWarning, stacklevel=3)
+    warnings.warn(f'scipy.cluster: {s}', ClusterWarning, stacklevel=3)
 
 
 def _copy_array_if_base_present(a):
@@ -1041,7 +1041,7 @@ def linkage(y, method='single', metric='euclidean', optimal_ordering=False):
     >>> plt.show()
     """
     if method not in _LINKAGE_METHODS:
-        raise ValueError("Invalid method: {0}".format(method))
+        raise ValueError(f"Invalid method: {method}")
 
     y = _convert_to_double(np.asarray(y, order='c'))
 
@@ -1135,20 +1135,17 @@ class ClusterNode(object):
 
     def __lt__(self, node):
         if not isinstance(node, ClusterNode):
-            raise ValueError("Can't compare ClusterNode "
-                             "to type {}".format(type(node)))
+            raise ValueError(f"Can't compare ClusterNode to type {type(node)}")
         return self.dist < node.dist
 
     def __gt__(self, node):
         if not isinstance(node, ClusterNode):
-            raise ValueError("Can't compare ClusterNode "
-                             "to type {}".format(type(node)))
+            raise ValueError(f"Can't compare ClusterNode to type {type(node)}")
         return self.dist > node.dist
 
     def __eq__(self, node):
         if not isinstance(node, ClusterNode):
-            raise ValueError("Can't compare ClusterNode "
-                             "to type {}".format(type(node)))
+            raise ValueError(f"Can't compare ClusterNode to type {type(node)}")
         return self.dist == node.dist
 
     def get_id(self):
@@ -2133,7 +2130,7 @@ def is_valid_im(R, warning=False, throw=False, name=None):
     """
     R = np.asarray(R, order='c')
     valid = True
-    name_str = "%r " % name if name else ''
+    name_str = f"{name!r} " if name else ''
     try:
         if type(R) != np.ndarray:
             raise TypeError('Variable %spassed as inconsistency matrix is not '
@@ -2252,18 +2249,18 @@ def is_valid_linkage(Z, warning=False, throw=False, name=None):
     """
     Z = np.asarray(Z, order='c')
     valid = True
-    name_str = "%r " % name if name else ''
+    name_str = f"{name!r} " if name else ''
     try:
         if type(Z) != np.ndarray:
             raise TypeError('Passed linkage argument %sis not a valid array.' %
                             name_str)
         if Z.dtype != np.double:
-            raise TypeError('Linkage matrix %smust contain doubles.' % name_str)
+            raise TypeError(f'Linkage matrix {name_str}must contain doubles.')
         if len(Z.shape) != 2:
             raise ValueError('Linkage matrix %smust have shape=2 (i.e. be '
                              'two-dimensional).' % name_str)
         if Z.shape[1] != 4:
-            raise ValueError('Linkage matrix %smust have 4 columns.' % name_str)
+            raise ValueError(f'Linkage matrix {name_str}must have 4 columns.')
         if Z.shape[0] == 0:
             raise ValueError('Linkage must be computed on at least two '
                              'observations.')

--- a/scipy/cluster/vq.py
+++ b/scipy/cluster/vq.py
@@ -430,14 +430,13 @@ def kmeans(obs, k_or_guess, iter=20, thresh=1e-5, check_finite=True):
     """
     obs = _asarray_validated(obs, check_finite=check_finite)
     if iter < 1:
-        raise ValueError("iter must be at least 1, got %s" % iter)
+        raise ValueError(f"iter must be at least 1, got {iter}")
 
     # Determine whether a count (scalar) or an initial guess (array) was passed.
     if not np.isscalar(k_or_guess):
         guess = _asarray_validated(k_or_guess, check_finite=check_finite)
         if guess.size < 1:
-            raise ValueError("Asked for 0 clusters. Initial book was %s" %
-                             guess)
+            raise ValueError(f"Asked for 0 clusters. Initial book was {guess}")
         return _kmeans(obs, guess, thresh=thresh)
 
     # k_or_guess is a scalar, now verify that it's an integer
@@ -701,12 +700,11 @@ def kmeans2(data, k, iter=10, thresh=1e-5, minit='random',
 
     """
     if int(iter) < 1:
-        raise ValueError("Invalid iter (%s), "
-                         "must be a positive integer." % iter)
+        raise ValueError(f"Invalid iter ({iter}), must be a positive integer.")
     try:
         miss_meth = _valid_miss_meth[missing]
     except KeyError as e:
-        raise ValueError("Unknown missing method %r" % (missing,)) from e
+        raise ValueError(f"Unknown missing method {missing!r}") from e
 
     data = _asarray_validated(data, check_finite=check_finite)
     if data.ndim == 1:
@@ -739,7 +737,7 @@ def kmeans2(data, k, iter=10, thresh=1e-5, minit='random',
         try:
             init_meth = _valid_init_meth[minit]
         except KeyError as e:
-            raise ValueError("Unknown init method %r" % (minit,)) from e
+            raise ValueError(f"Unknown init method {minit!r}") from e
         else:
             code_book = init_meth(data, k)
 

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -37,7 +37,7 @@ def pytest_runtest_setup(item):
             pytest.skip("very slow test; set environment variable SCIPY_XSLOW=1 to run it")
     mark = _get_mark(item, 'xfail_on_32bit')
     if mark is not None and np.intp(0).itemsize < 8:
-        pytest.xfail('Fails on our 32-bit test platform(s): %s' % (mark.args[0],))
+        pytest.xfail(f'Fails on our 32-bit test platform(s): {mark.args[0]}')
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/scipy/fft/_backend.py
+++ b/scipy/fft/_backend.py
@@ -35,7 +35,7 @@ def _backend_from_arg(backend):
         try:
             backend = _named_backends[backend]
         except KeyError as e:
-            raise ValueError('Unknown backend {}'.format(backend)) from e
+            raise ValueError(f'Unknown backend {backend}') from e
 
     if backend.__ua_domain__ != 'numpy.scipy.fft':
         raise ValueError('Backend does not implement "numpy.scipy.fft"')

--- a/scipy/fft/_pocketfft/basic.py
+++ b/scipy/fft/_pocketfft/basic.py
@@ -88,8 +88,7 @@ def c2r(forward, x, n=None, axis=-1, norm=None, overwrite_x=False,
     if n is None:
         n = (tmp.shape[axis] - 1) * 2
         if n < 1:
-            raise ValueError("Invalid number of data points ({0}) specified"
-                             .format(n))
+            raise ValueError(f"Invalid number of data points ({n}) specified")
     else:
         tmp, _ = _fix_shape_1d(tmp, (n//2) + 1, axis)
 

--- a/scipy/fft/_pocketfft/helper.py
+++ b/scipy/fft/_pocketfft/helper.py
@@ -72,7 +72,7 @@ def _init_nd_shape_and_axes(x, shape, axes):
 
     if any(s < 1 for s in shape):
         raise ValueError(
-            "invalid number of data points ({0}) specified".format(shape))
+            f"invalid number of data points ({shape}) specified")
 
     return shape, axes
 
@@ -139,7 +139,7 @@ def _fix_shape(x, shape, axes):
 def _fix_shape_1d(x, n, axis):
     if n < 1:
         raise ValueError(
-            "invalid number of data points ({0}) specified".format(n))
+            f"invalid number of data points ({n}) specified")
 
     return _fix_shape(x, (n,), (axis,))
 

--- a/scipy/fft/_pocketfft/tests/test_basic.py
+++ b/scipy/fft/_pocketfft/tests/test_basic.py
@@ -37,7 +37,7 @@ SMALL_PRIME_SIZES = [
 
 def _assert_close_in_norm(x, y, rtol, size, rdt):
     # helper function for testing
-    err_msg = "size: %s  rdt: %s" % (size, rdt)
+    err_msg = f"size: {size}  rdt: {rdt}"
     assert_array_less(np.linalg.norm(x - y), rtol*np.linalg.norm(x), err_msg)
 
 
@@ -890,7 +890,7 @@ class TestOverwrite(object):
             sig = "%s(%s%r, %r, axis=%r, overwrite_x=%r)" % (
                 routine.__name__, x.dtype, x.shape, fftsize, axis, overwrite_x)
             if not should_overwrite:
-                assert_equal(x2, x, err_msg="spurious overwrite in %s" % sig)
+                assert_equal(x2, x, err_msg=f"spurious overwrite in {sig}")
 
     def _check_1d(self, routine, dtype, shape, axis, overwritable_dtypes,
                   fftsize, overwrite_x):

--- a/scipy/fft/_pocketfft/tests/test_real_transforms.py
+++ b/scipy/fft/_pocketfft/tests/test_real_transforms.py
@@ -408,7 +408,7 @@ def test_overwrite(routine, dtype, shape, axis, type, norm, overwrite_x):
     sig = "%s(%s%r, %r, axis=%r, overwrite_x=%r)" % (
         routine.__name__, x.dtype, x.shape, None, axis, overwrite_x)
     if not overwrite_x:
-        assert_equal(x2, x, err_msg="spurious overwrite in %s" % sig)
+        assert_equal(x2, x, err_msg=f"spurious overwrite in {sig}")
 
 
 class Test_DCTN_IDCTN(object):

--- a/scipy/fft/tests/test_helper.py
+++ b/scipy/fft/tests/test_helper.py
@@ -36,7 +36,7 @@ def _assert_n_smooth(x, n):
             x = q
 
     assert x == 1, \
-           'x={} is not {}-smooth, remainder={}'.format(x_orig, n, x)
+           f'x={x_orig} is not {n}-smooth, remainder={x}'
 
 
 class TestNextFastLen(object):

--- a/scipy/fftpack/tests/gen_fftw_ref.py
+++ b/scipy/fftpack/tests/gen_fftw_ref.py
@@ -15,7 +15,7 @@ def gen_data(dt):
     elif dt == np.float32:
         pg = './fftw_single'
     else:
-        raise ValueError("unknown: %s" % dt)
+        raise ValueError(f"unknown: {dt}")
     # Generate test data using FFTW for reference
     for type in [1, 2, 3, 4, 5, 6, 7, 8]:
         arrays[type] = {}

--- a/scipy/fftpack/tests/test_basic.py
+++ b/scipy/fftpack/tests/test_basic.py
@@ -34,7 +34,7 @@ SMALL_PRIME_SIZES = [
 
 def _assert_close_in_norm(x, y, rtol, size, rdt):
     # helper function for testing
-    err_msg = "size: %s  rdt: %s" % (size, rdt)
+    err_msg = f"size: {size}  rdt: {rdt}"
     assert_array_less(np.linalg.norm(x - y), rtol*np.linalg.norm(x), err_msg)
 
 
@@ -766,7 +766,7 @@ class TestOverwrite(object):
             sig = "%s(%s%r, %r, axis=%r, overwrite_x=%r)" % (
                 routine.__name__, x.dtype, x.shape, fftsize, axis, overwrite_x)
             if not overwrite_x:
-                assert_equal(x2, x, err_msg="spurious overwrite in %s" % sig)
+                assert_equal(x2, x, err_msg=f"spurious overwrite in {sig}")
 
     def _check_1d(self, routine, dtype, shape, axis, overwritable_dtypes,
                   fftsize, overwrite_x):

--- a/scipy/fftpack/tests/test_import.py
+++ b/scipy/fftpack/tests/test_import.py
@@ -28,4 +28,4 @@ class TestFFTPackImport(object):
             with tokenize.open(str(path)) as file:
                 assert_(all(not re.fullmatch(regexp, line)
                             for line in file),
-                        "{0} contains an import from fftpack".format(path))
+                        f"{path} contains an import from fftpack")

--- a/scipy/fftpack/tests/test_pseudo_diffs.py
+++ b/scipy/fftpack/tests/test_pseudo_diffs.py
@@ -332,7 +332,7 @@ class TestOverwrite(object):
             sig += repr(args)
         if kwargs:
             sig += repr(kwargs)
-        assert_equal(x2, x, err_msg="spurious overwrite in %s" % sig)
+        assert_equal(x2, x, err_msg=f"spurious overwrite in {sig}")
 
     def _check_1d(self, routine, dtype, shape, *args, **kwargs):
         np.random.seed(1234)

--- a/scipy/fftpack/tests/test_real_transforms.py
+++ b/scipy/fftpack/tests/test_real_transforms.py
@@ -700,7 +700,7 @@ class TestOverwrite(object):
         sig = "%s(%s%r, %r, axis=%r, overwrite_x=%r)" % (
             routine.__name__, x.dtype, x.shape, fftsize, axis, overwrite_x)
         if not overwrite_x:
-            assert_equal(x2, x, err_msg="spurious overwrite in %s" % sig)
+            assert_equal(x2, x, err_msg=f"spurious overwrite in {sig}")
 
     def _check_1d(self, routine, dtype, shape, axis):
         np.random.seed(1234)

--- a/scipy/integrate/_bvp.py
+++ b/scipy/integrate/_bvp.py
@@ -1024,7 +1024,7 @@ def solve_bvp(fun, bc, x, y, p=None, S=None, fun_jac=None, bc_jac=None,
         raise ValueError("`p` must be 1 dimensional.")
 
     if tol < 100 * EPS:
-        warn("`tol` is too low, setting to {:.2e}".format(100 * EPS))
+        warn(f"`tol` is too low, setting to {100 * EPS:.2e}")
         tol = 100 * EPS
 
     if verbose not in [0, 1, 2]:
@@ -1106,7 +1106,7 @@ def solve_bvp(fun, bc, x, y, p=None, S=None, fun_jac=None, bc_jac=None,
         if m + nodes_added > max_nodes:
             status = 1
             if verbose == 2:
-                nodes_added = "({})".format(nodes_added)
+                nodes_added = f"({nodes_added})"
                 print_iteration_progress(iteration, max_rms_res, max_bc_res,
                                          m, nodes_added)
             break

--- a/scipy/integrate/_ivp/common.py
+++ b/scipy/integrate/_ivp/common.py
@@ -43,7 +43,7 @@ def warn_extraneous(extraneous):
 def validate_tol(rtol, atol, n):
     """Validate tolerance values."""
     if rtol < 100 * EPS:
-        warn("`rtol` is too low, setting to {}".format(100 * EPS))
+        warn(f"`rtol` is too low, setting to {100 * EPS}")
         rtol = 100 * EPS
 
     atol = np.asarray(atol)

--- a/scipy/integrate/_ode.py
+++ b/scipy/integrate/_ode.py
@@ -869,7 +869,7 @@ class vode(IntegratorBase):
         elif re.match(method, r'bdf', re.I):
             self.meth = 2
         else:
-            raise ValueError('Unknown integration method %s' % method)
+            raise ValueError(f'Unknown integration method {method}')
         self.with_jacobian = with_jacobian
         self.rtol = rtol
         self.atol = atol
@@ -963,7 +963,7 @@ class vode(IntegratorBase):
         elif mf in [24, 25]:
             lrw = 22 + 11 * n + (3 * self.ml + 2 * self.mu) * n
         else:
-            raise ValueError('Unexpected mf=%s' % mf)
+            raise ValueError(f'Unexpected mf={mf}')
 
         if mf % 10 in [0, 3]:
             liw = 30
@@ -1009,7 +1009,7 @@ class vode(IntegratorBase):
         y1, t, istate = self.runner(*args)
         self.istate = istate
         if istate < 0:
-            unexpected_istate_msg = 'Unexpected istate={:d}'.format(istate)
+            unexpected_istate_msg = f'Unexpected istate={istate:d}'
             warnings.warn('{:s}: {:s}'.format(self.__class__.__name__,
                           self.messages.get(istate, unexpected_istate_msg)))
             self.success = 0
@@ -1177,7 +1177,7 @@ class dopri5(IntegratorBase):
                                           tuple(self.call_args) + (f_params,)))
         self.istate = istate
         if istate < 0:
-            unexpected_istate_msg = 'Unexpected istate={:d}'.format(istate)
+            unexpected_istate_msg = f'Unexpected istate={istate:d}'
             warnings.warn('{:s}: {:s}'.format(self.__class__.__name__,
                           self.messages.get(istate, unexpected_istate_msg)))
             self.success = 0
@@ -1313,7 +1313,7 @@ class lsoda(IntegratorBase):
         elif jt in [4, 5]:
             lrs = 22 + (self.max_order_s + 5 + 2 * self.ml + self.mu) * n
         else:
-            raise ValueError('Unexpected jt=%s' % jt)
+            raise ValueError(f'Unexpected jt={jt}')
         lrw = max(lrn, lrs)
         liw = 20 + n
         rwork = zeros((lrw,), float)
@@ -1348,7 +1348,7 @@ class lsoda(IntegratorBase):
         y1, t, istate = self.runner(*args)
         self.istate = istate
         if istate < 0:
-            unexpected_istate_msg = 'Unexpected istate={:d}'.format(istate)
+            unexpected_istate_msg = f'Unexpected istate={istate:d}'
             warnings.warn('{:s}: {:s}'.format(self.__class__.__name__,
                           self.messages.get(istate, unexpected_istate_msg)))
             self.success = 0

--- a/scipy/integrate/_quad_vec.py
+++ b/scipy/integrate/_quad_vec.py
@@ -255,7 +255,7 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, li
 
         return (res[0]*sgn,) + res[1:]
     elif not (np.isfinite(a) and np.isfinite(b)):
-        raise ValueError("invalid integration bounds a={}, b={}".format(a, b))
+        raise ValueError(f"invalid integration bounds a={a}, b={b}")
 
     norm_funcs = {
         None: _max_norm,
@@ -279,7 +279,7 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, li
                        'trapz': _quadrature_trapezoid,  # alias for backcompat
                        'trapezoid': _quadrature_trapezoid}[quadrature]
     except KeyError as e:
-        raise ValueError("unknown quadrature {!r}".format(quadrature)) from e
+        raise ValueError(f"unknown quadrature {quadrature!r}") from e
 
     # Initial interval set
     if points is None:

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -711,7 +711,7 @@ def _printresmat(function, interval, resmat):
     for i in range(len(resmat)):
         print('%6d %9f' % (2**i, (interval[1]-interval[0])/(2.**i)), end=' ')
         for j in range(i+1):
-            print('%9f' % (resmat[i][j]), end=' ')
+            print(f'{resmat[i][j]:9f}', end=' ')
         print('')
     print('')
     print('The final result is', resmat[i][j], end=' ')

--- a/scipy/integrate/quadpack.py
+++ b/scipy/integrate/quadpack.py
@@ -477,7 +477,7 @@ def _quad(func,a,b,args,full_output,epsabs,epsrel,limit,points):
 
 def _quad_weight(func,a,b,args,full_output,epsabs,epsrel,limlst,limit,maxp1,weight,wvar,wopts):
     if weight not in ['cos','sin','alg','alg-loga','alg-logb','alg-log','cauchy']:
-        raise ValueError("%s not a recognized weighting function." % weight)
+        raise ValueError(f"{weight} not a recognized weighting function.")
 
     strdict = {'cos':1,'sin':2,'alg':1,'alg-loga':2,'alg-logb':3,'alg-log':4}
 

--- a/scipy/integrate/tests/test_odeint_jac.py
+++ b/scipy/integrate/tests/test_odeint_jac.py
@@ -39,7 +39,7 @@ def check_odeint(jactype):
         mu = 1
         jacobian = bjac
     else:
-        raise ValueError("invalid jactype: %r" % (jactype,))
+        raise ValueError(f"invalid jactype: {jactype!r}")
 
     y0 = np.arange(1.0, 6.0)
     # These tolerances must match the tolerances used in banded5x5.f.

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -570,7 +570,7 @@ def _not_a_knot(x, k):
     cf de Boor, XIII(12)."""
     x = np.asarray(x)
     if k % 2 != 1:
-        raise ValueError("Odd degree for now only. Got %s." % k)
+        raise ValueError(f"Odd degree for now only. Got {k}.")
 
     m = (k - 1) // 2
     t = x[m+1:-m-1]
@@ -590,7 +590,7 @@ def _convert_string_aliases(deriv, target_shape):
         elif deriv == "natural":
             deriv = [(2, np.zeros(target_shape))]
         else:
-            raise ValueError("Unknown boundary condition : %s" % deriv)
+            raise ValueError(f"Unknown boundary condition : {deriv}")
     return deriv
 
 
@@ -730,7 +730,7 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
         try:
             deriv_l, deriv_r = bc_type
         except TypeError as e:
-            raise ValueError("Unknown boundary condition: %s" % bc_type) from e
+            raise ValueError(f"Unknown boundary condition: {bc_type}") from e
 
     y = np.asarray(y)
 
@@ -797,7 +797,7 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
         raise ValueError('Got %d knots, need at least %d.' %
                          (t.size, x.size + k + 1))
     if (x[0] < t[k]) or (x[-1] > t[-k]):
-        raise ValueError('Out of bounds w/ x = %s.' % x)
+        raise ValueError(f'Out of bounds w/ x = {x}.')
 
     # Here : deriv_l, r = [(nu, value), ...]
     deriv_l = _convert_string_aliases(deriv_l, y.shape[1:])
@@ -981,7 +981,7 @@ def make_lsq_spline(x, y, t, k=3, w=None, axis=0, check_finite=True):
         raise ValueError('Shapes of x {} and y {} are incompatible'
                          .format(x.shape, y.shape))
     if k > 0 and np.any((x < t[k]) | (x > t[-k])):
-        raise ValueError('Out of bounds w/ x = %s.' % x)
+        raise ValueError(f'Out of bounds w/ x = {x}.')
     if x.size != w.size:
         raise ValueError('Shapes of x {} and w {} are incompatible'
                          .format(x.shape, w.shape))

--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -821,7 +821,7 @@ class CubicSpline(CubicHermiteSpline):
                 elif bc in ['not-a-knot', 'periodic']:
                     validated_bc.append(bc)
                 else:
-                    raise ValueError("bc_type={} is not allowed.".format(bc))
+                    raise ValueError(f"bc_type={bc} is not allowed.")
             else:
                 try:
                     deriv_order, deriv_value = bc

--- a/scipy/interpolate/_fitpack_impl.py
+++ b/scipy/interpolate/_fitpack_impl.py
@@ -44,7 +44,7 @@ def _int_overflow(x, msg=None):
     """
     if x > iinfo(dfitpack_int).max:
         if msg is None:
-            msg = '%r cannot fit into an %r' % (x, dfitpack_int)
+            msg = f'{x!r} cannot fit into an {dfitpack_int!r}'
         raise OverflowError(msg)
     return dfitpack_int.type(x)
 
@@ -587,7 +587,7 @@ def splev(x, tck, der=0, ext=0):
         if not (0 <= der <= k):
             raise ValueError("0<=der=%d<=k=%d must hold" % (der, k))
         if ext not in (0, 1, 2, 3):
-            raise ValueError("ext = %s not in (0, 1, 2, 3) " % ext)
+            raise ValueError(f"ext = {ext} not in (0, 1, 2, 3) ")
 
         x = asarray(x)
         shape = x.shape

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -238,7 +238,7 @@ class UnivariateSpline(object):
         try:
             ext = _extrap_modes[ext]
         except KeyError as e:
-            raise ValueError("Unknown extrapolation mode %s." % ext) from e
+            raise ValueError(f"Unknown extrapolation mode {ext}.") from e
 
         return x, y, w, bbox, ext
 
@@ -275,7 +275,7 @@ class UnivariateSpline(object):
             # error
             if ier == 1:
                 self._set_class(LSQUnivariateSpline)
-            message = _curfit_messages.get(ier, 'ier=%s' % (ier))
+            message = _curfit_messages.get(ier, f'ier={ier}')
             warnings.warn(message)
 
     def _set_class(self, cls):
@@ -357,7 +357,7 @@ class UnivariateSpline(object):
             try:
                 ext = _extrap_modes[ext]
             except KeyError as e:
-                raise ValueError("Unknown extrapolation mode %s." % ext) from e
+                raise ValueError(f"Unknown extrapolation mode {ext}.") from e
         return fitpack.splev(x, self._eval_args, der=nu, ext=ext)
 
     def get_knots(self):
@@ -448,7 +448,7 @@ class UnivariateSpline(object):
         """
         d, ier = dfitpack.spalde(*(self._eval_args+(x,)))
         if not ier == 0:
-            raise ValueError("Error code returned by spalde: %s" % ier)
+            raise ValueError(f"Error code returned by spalde: {ier}")
         return d
 
     def roots(self):
@@ -460,7 +460,7 @@ class UnivariateSpline(object):
         if k == 3:
             z, m, ier = dfitpack.sproot(*self._eval_args[:2])
             if not ier == 0:
-                raise ValueError("Error code returned by spalde: %s" % ier)
+                raise ValueError(f"Error code returned by spalde: {ier}")
             return z[:m]
         raise NotImplementedError('finding roots unsupported for '
                                   'non-cubic splines')
@@ -903,11 +903,11 @@ class _BivariateSplineBase(object):
             if dx or dy:
                 z, ier = dfitpack.parder(tx, ty, c, kx, ky, dx, dy, x, y)
                 if not ier == 0:
-                    raise ValueError("Error code returned by parder: %s" % ier)
+                    raise ValueError(f"Error code returned by parder: {ier}")
             else:
                 z, ier = dfitpack.bispev(tx, ty, c, kx, ky, x, y)
                 if not ier == 0:
-                    raise ValueError("Error code returned by bispev: %s" % ier)
+                    raise ValueError(f"Error code returned by bispev: {ier}")
         else:
             # standard Numpy broadcasting
             if x.shape != y.shape:
@@ -923,11 +923,11 @@ class _BivariateSplineBase(object):
             if dx or dy:
                 z, ier = dfitpack.pardeu(tx, ty, c, kx, ky, dx, dy, x, y)
                 if not ier == 0:
-                    raise ValueError("Error code returned by pardeu: %s" % ier)
+                    raise ValueError(f"Error code returned by pardeu: {ier}")
             else:
                 z, ier = dfitpack.bispeu(tx, ty, c, kx, ky, x, y)
                 if not ier == 0:
-                    raise ValueError("Error code returned by bispeu: %s" % ier)
+                    raise ValueError(f"Error code returned by bispeu: {ier}")
 
             z = z.reshape(shape)
         return z
@@ -1164,7 +1164,7 @@ class SmoothBivariateSpline(BivariateSpline):
         if ier in [0, -1, -2]:  # normal return
             pass
         else:
-            message = _surfit_messages.get(ier, 'ier=%s' % (ier))
+            message = _surfit_messages.get(ier, f'ier={ier}')
             warnings.warn(message)
 
         self.fp = fp
@@ -1253,7 +1253,7 @@ class LSQBivariateSpline(BivariateSpline):
                 deficiency = (nx-kx-1)*(ny-ky-1)+ier
                 message = _surfit_messages.get(-3) % (deficiency)
             else:
-                message = _surfit_messages.get(ier, 'ier=%s' % (ier))
+                message = _surfit_messages.get(ier, f'ier={ier}')
             warnings.warn(message)
         self.fp = fp
         self.tck = tx1, ty1, c
@@ -1331,7 +1331,7 @@ class RectBivariateSpline(BivariateSpline):
                                                           ye, kx, ky, s)
 
         if ier not in [0, -1, -2]:
-            msg = _surfit_messages.get(ier, 'ier=%s' % (ier))
+            msg = _surfit_messages.get(ier, f'ier={ier}')
             raise ValueError(msg)
 
         self.fp = fp
@@ -1572,7 +1572,7 @@ class SmoothSphereBivariateSpline(SphereBivariateSpline):
                                                                 r, w=w, s=s,
                                                                 eps=eps)
         if ier not in [0, -1, -2]:
-            message = _spherefit_messages.get(ier, 'ier=%s' % (ier))
+            message = _spherefit_messages.get(ier, f'ier={ier}')
             raise ValueError(message)
 
         self.fp = fp
@@ -1716,7 +1716,7 @@ class LSQSphereBivariateSpline(SphereBivariateSpline):
         tt_, tp_, c, fp, ier = dfitpack.spherfit_lsq(theta, phi, r, tt_, tp_,
                                                      w=w, eps=eps)
         if ier > 0:
-            message = _spherefit_messages.get(ier, 'ier=%s' % (ier))
+            message = _spherefit_messages.get(ier, f'ier={ier}')
             raise ValueError(message)
 
         self.fp = fp
@@ -1971,7 +1971,7 @@ class RectSphereBivariateSpline(SphereBivariateSpline):
                                                                 r0, r1, s)
 
         if ier not in [0, -1, -2]:
-            msg = _spfit_messages.get(ier, 'ier=%s' % (ier))
+            msg = _spfit_messages.get(ier, f'ier={ier}')
             raise ValueError(msg)
 
         self.fp = fp

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -2424,7 +2424,7 @@ class RegularGridInterpolator(object):
     def __init__(self, points, values, method="linear", bounds_error=True,
                  fill_value=np.nan):
         if method not in ["linear", "nearest"]:
-            raise ValueError("Method '%s' is not defined" % method)
+            raise ValueError(f"Method '{method}' is not defined")
         self.method = method
         self.bounds_error = bounds_error
 
@@ -2478,7 +2478,7 @@ class RegularGridInterpolator(object):
         """
         method = self.method if method is None else method
         if method not in ["linear", "nearest"]:
-            raise ValueError("Method '%s' is not defined" % method)
+            raise ValueError(f"Method '{method}' is not defined")
 
         ndim = len(self.grid)
         xi = _ndim_coords_from_arrays(xi, ndim=ndim)

--- a/scipy/interpolate/polyint.py
+++ b/scipy/interpolate/polyint.py
@@ -106,7 +106,7 @@ class _Interpolator1D(object):
         if check and yi.shape[1:] != self._y_extra_shape:
             ok_shape = "%r + (N,) + %r" % (self._y_extra_shape[-self._y_axis:],
                                            self._y_extra_shape[:-self._y_axis])
-            raise ValueError("Data must be of shape %s" % ok_shape)
+            raise ValueError(f"Data must be of shape {ok_shape}")
         return yi.reshape((yi.shape[0], -1))
 
     def _set_yi(self, yi, xi=None, axis=None):

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -439,7 +439,7 @@ def test_knots_multiplicity():
         x = np.unique(t)
         x = np.r_[t[0]-0.1, 0.5*(x[1:] + x[:1]), t[-1]+0.1]
         assert_allclose(splev(x, (t, c, k), der), b(x, der),
-                atol=atol, rtol=rtol, err_msg='der = %s  k = %s' % (der, b.k))
+                atol=atol, rtol=rtol, err_msg=f'der = {der}  k = {b.k}')
 
     # test loop itself
     # [the index `j` is for interpreting the traceback in case of a failure]
@@ -526,7 +526,7 @@ def B_0123(x, der=0):
                  lambda x: -2.,
                  lambda x: 1.]
     else:
-        raise ValueError('never be here: der=%s' % der)
+        raise ValueError(f'never be here: der={der}')
     pieces = np.piecewise(x, conds, funcs)
     return pieces
 

--- a/scipy/interpolate/tests/test_fitpack.py
+++ b/scipy/interpolate/tests/test_fitpack.py
@@ -160,7 +160,7 @@ class TestSmokeTests(object):
                 err = abs(1-dr/f(dx,d))
                 tol = err_est(k, d)
                 assert_(err < tol, (k, d))
-                put(" %.1e %.1e" % (err, tol))
+                put(f" {err:.1e} {tol:.1e}")
                 d = d+1
             put("\n")
             k = k+1
@@ -195,7 +195,7 @@ class TestSmokeTests(object):
         x1 = a + (b-a)*arange(1,N,dtype=float)/float(N-1)  # middle points of the nodes
         v, _ = f(x),f(x1)
         put(" u = %s   N = %d" % (repr(round(dx,3)),N))
-        put("  k  :  [x(u), %s(x(u))]  Error of splprep  Error of splrep " % (f(0,None)))
+        put(f"  k  :  [x(u), {f(0, None)}(x(u))]  Error of splprep  Error of splrep ")
         for k in range(1,6):
             tckp,u = splprep([x,v],s=s,per=per,k=k,nest=-1)
             tck = splrep(x,v,s=s,per=per,k=k)
@@ -213,7 +213,7 @@ class TestSmokeTests(object):
         tckp,u = splprep([x,v],s=s,per=per,k=k,nest=-1)
         for d in range(1,k+1):
             uv = splev(dx,tckp,d)
-            put(" %s " % (repr(uv[0])))
+            put(f" {repr(uv[0])} ")
 
     def check_5(self,f=f2,kx=3,ky=3,xb=0,xe=2*pi,yb=0,ye=2*pi,Nx=20,Ny=20,s=0):
         x = xb+(xe-xb)*arange(Nx+1,dtype=float)/float(Nx)

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -293,7 +293,7 @@ class TestInterp1D(object):
                     for kind in spline_kinds:
                         f = interp1d(x, y, kind=kind, bounds_error=False)
                         assert_allclose(f(xnew), y, atol=1e-7,
-                                        err_msg="%s, %s %s" % (dtx, dty, dtn))
+                                        err_msg=f"{dtx}, {dty} {dtn}")
 
     def test_cubic(self):
         # Check the actual implementation of spline interpolation.
@@ -1416,7 +1416,7 @@ class TestPPoly(object):
                                 val = pp(rr, extrapolate=extrapolate)[:,i,j]
                                 cmpval = pp(rr, nu=1,
                                             extrapolate=extrapolate)[:,i,j]
-                                msg = "(%r) r = %s" % (extrapolate, repr(rr),)
+                                msg = f"({extrapolate!r}) r = {repr(rr)}"
                                 assert_allclose((val-y) / cmpval, 0, atol=1e-7,
                                                 err_msg=msg)
 

--- a/scipy/interpolate/tests/test_rbf.py
+++ b/scipy/interpolate/tests/test_rbf.py
@@ -105,7 +105,7 @@ def check_rbf1d_regularity(function, atol):
     rbf = Rbf(x, y, function=function)
     xi = linspace(0, 10, 100)
     yi = rbf(xi)
-    msg = "abs-diff: %f" % abs(yi - sin(xi)).max()
+    msg = f"abs-diff: {abs(yi - sin(xi)).max():f}"
     assert_(allclose(yi, sin(xi), atol=atol), msg)
 
 
@@ -133,7 +133,7 @@ def check_2drbf1d_regularity(function, atol):
     rbf = Rbf(x, y, function=function, mode='N-D')
     xi = linspace(0, 10, 100)
     yi = rbf(xi)
-    msg = "abs-diff: %f" % abs(yi - np.vstack([sin(xi), cos(xi)]).T).max()
+    msg = f"abs-diff: {abs(yi - np.vstack([sin(xi), cos(xi)]).T).max():f}"
     assert_(allclose(yi, np.vstack([sin(xi), cos(xi)]).T, atol=atol), msg)
 
 

--- a/scipy/io/_fortran.py
+++ b/scipy/io/_fortran.py
@@ -119,7 +119,7 @@ class FortranFile(object):
         if hasattr(filename, 'seek'):
             self._fp = filename
         else:
-            self._fp = open(filename, '%sb' % mode)
+            self._fp = open(filename, f'{mode}b')
 
         self._header_dtype = header_dtype
 
@@ -242,7 +242,7 @@ class FortranFile(object):
         """
         dtype = kwargs.pop('dtype', None)
         if kwargs:
-            raise ValueError("Unknown keyword arguments {}".format(tuple(kwargs.keys())))
+            raise ValueError(f"Unknown keyword arguments {tuple(kwargs.keys())}")
 
         if dtype is not None:
             dtypes = dtypes + (dtype,)

--- a/scipy/io/arff/arffread.py
+++ b/scipy/io/arff/arffread.py
@@ -330,7 +330,7 @@ class DateAttribute(Attribute):
         else:
             dt = datetime.datetime.strptime(date_str, self.date_format)
             return np.datetime64(dt).astype(
-                "datetime64[%s]" % self.datetime_unit)
+                f"datetime64[{self.datetime_unit}]")
 
     def __str__(self):
         return super(DateAttribute, self).__str__() + ',' + self.date_format
@@ -396,7 +396,7 @@ def to_attribute(name, attr_string):
         if attr is not None:
             return attr
 
-    raise ParseArffError("unknown attribute %s" % attr_string)
+    raise ParseArffError(f"unknown attribute {attr_string}")
 
 
 def csv_sniffer_has_bug_last_field():
@@ -554,7 +554,7 @@ def tokenize_attribute(iterable, attribute):
             # weka.
             raise ValueError("multi line not supported yet")
     else:
-        raise ValueError("First line unparsable: %s" % sattr)
+        raise ValueError(f"First line unparsable: {sattr}")
 
     attribute = to_attribute(name, type)
 
@@ -576,7 +576,7 @@ def tokenize_single_comma(val):
         except IndexError as e:
             raise ValueError("Error while tokenizing attribute") from e
     else:
-        raise ValueError("Error while tokenizing single %s" % val)
+        raise ValueError(f"Error while tokenizing single {val}")
     return name, type
 
 
@@ -591,7 +591,7 @@ def tokenize_single_wcomma(val):
         except IndexError as e:
             raise ValueError("Error while tokenizing attribute") from e
     else:
-        raise ValueError("Error while tokenizing single %s" % val)
+        raise ValueError(f"Error while tokenizing single {val}")
     return name, type
 
 
@@ -609,7 +609,7 @@ def read_relational_attribute(ofile, relational_attribute, i):
                 attr, i = tokenize_attribute(ofile, i)
                 relational_attribute.attributes.append(attr)
             else:
-                raise ValueError("Error parsing line %s" % i)
+                raise ValueError(f"Error parsing line {i}")
         else:
             i = next(ofile)
 
@@ -640,7 +640,7 @@ def read_header(ofile):
                 if isrel:
                     relation = isrel.group(1)
                 else:
-                    raise ValueError("Error parsing line %s" % i)
+                    raise ValueError(f"Error parsing line {i}")
                 i = next(ofile)
         else:
             i = next(ofile)
@@ -685,11 +685,11 @@ class MetaData(object):
 
     def __repr__(self):
         msg = ""
-        msg += "Dataset: %s\n" % self.name
+        msg += f"Dataset: {self.name}\n"
         for i in self._attributes:
-            msg += "\t%s's type is %s" % (i, self._attributes[i].type_name)
+            msg += f"\t{i}'s type is {self._attributes[i].type_name}"
             if self._attributes[i].range:
-                msg += ", range is %s" % str(self._attributes[i].range)
+                msg += f", range is {str(self._attributes[i].range)}"
             msg += '\n'
         return msg
 
@@ -882,7 +882,7 @@ def print_attribute(name, tp, data):
     type = tp.type_name
     if type == 'numeric' or type == 'real' or type == 'integer':
         min, max, mean, std = basic_stats(data)
-        print("%s,%s,%f,%f,%f,%f" % (name, type, min, max, mean, std))
+        print(f"{name},{type},{min:f},{max:f},{mean:f},{std:f}")
     else:
         print(str(tp))
 

--- a/scipy/io/harwell_boeing/_fortran_format_parser.py
+++ b/scipy/io/harwell_boeing/_fortran_format_parser.py
@@ -172,7 +172,7 @@ class Token(object):
         self.pos = pos
 
     def __str__(self):
-        return """Token('%s', "%s")""" % (self.type, self.value)
+        return f"""Token('{self.type}', "{self.value}")"""
 
     def __repr__(self):
         return self.__str__()
@@ -299,7 +299,7 @@ class FortranFormatParser(object):
                 min = None
             return ExpFormat(width, significand, min, repeat)
         else:
-            raise SyntaxError("Invalid formater type %s" % next.value)
+            raise SyntaxError(f"Invalid formater type {next.value}")
 
     def _next(self, tokens, tp):
         if not len(tokens) > 0:

--- a/scipy/io/harwell_boeing/hb.py
+++ b/scipy/io/harwell_boeing/hb.py
@@ -85,7 +85,7 @@ class HBInfo(object):
             elif values.dtype.kind in np.typecodes["AllInteger"]:
                 values_fmt = IntFormat.from_number(-np.max(np.abs(values)))
             else:
-                raise NotImplementedError("type %s not implemented yet" % values.dtype.kind)
+                raise NotImplementedError(f"type {values.dtype.kind} not implemented yet")
         else:
             raise NotImplementedError("fmt argument not supported yet.")
 
@@ -183,7 +183,7 @@ class HBInfo(object):
             raise ValueError("Only assembled matrices supported for now")
 
         if not line[3:14] == " " * 11:
-            raise ValueError("Malformed data for third line: %s" % line)
+            raise ValueError(f"Malformed data for third line: {line}")
 
         nrows = _expect_int(line[14:28])
         ncols = _expect_int(line[28:42])
@@ -198,7 +198,7 @@ class HBInfo(object):
 
         ct = line.split()
         if not len(ct) == 3:
-            raise ValueError("Expected 3 formats, got %s" % ct)
+            raise ValueError(f"Expected 3 formats, got {ct}")
 
         return cls(title, key,
                    total_nlines, pointer_nlines, indices_nlines, values_nlines,
@@ -222,7 +222,7 @@ class HBInfo(object):
         if key is None:
             key = "|No Key"
         if len(key) > 8:
-            warnings.warn("key is > 8 characters (key is %s)" % key, LineOverflow)
+            warnings.warn(f"key is > 8 characters (key is {key})", LineOverflow)
 
         self.total_nlines = total_nlines
         self.pointer_nlines = pointer_nlines
@@ -253,7 +253,7 @@ class HBInfo(object):
             # XXX: fortran int -> dtype association ?
             values_dtype = int
         else:
-            raise ValueError("Unsupported format for values %r" % (values_format,))
+            raise ValueError(f"Unsupported format for values {values_format!r}")
 
         self.pointer_format = pointer_format
         self.indices_format = indices_format
@@ -395,7 +395,7 @@ class HBMatrixType(object):
             storage = cls._f2q_storage[fmt[2]]
             return cls(value_type, structure, storage)
         except KeyError as e:
-            raise ValueError("Unrecognized format %s" % fmt) from e
+            raise ValueError(f"Unrecognized format {fmt}") from e
 
     def __init__(self, value_type, structure, storage="assembled"):
         self.value_type = value_type
@@ -403,11 +403,11 @@ class HBMatrixType(object):
         self.storage = storage
 
         if value_type not in self._q2f_type:
-            raise ValueError("Unrecognized type %s" % value_type)
+            raise ValueError(f"Unrecognized type {value_type}")
         if structure not in self._q2f_structure:
-            raise ValueError("Unrecognized structure %s" % structure)
+            raise ValueError(f"Unrecognized structure {structure}")
         if storage not in self._q2f_storage:
-            raise ValueError("Unrecognized storage %s" % storage)
+            raise ValueError(f"Unrecognized storage {storage}")
 
     @property
     def fortran_format(self):

--- a/scipy/io/idl.py
+++ b/scipy/io/idl.py
@@ -742,7 +742,7 @@ def readsav(file_name, idict=None, python_dict=False,
     # Read the signature, which should be 'SR'
     signature = _read_bytes(f, 2)
     if signature != b'SR':
-        raise Exception("Invalid SIGNATURE: %s" % signature)
+        raise Exception(f"Invalid SIGNATURE: {signature}")
 
     # Next, the record format, which is '\x00\x04' for normal .sav
     # files, and '\x00\x06' for compressed .sav files.
@@ -762,7 +762,7 @@ def readsav(file_name, idict=None, python_dict=False,
             fout = tempfile.NamedTemporaryFile(suffix='.sav')
 
         if verbose:
-            print(" -> expanding to %s" % fout.name)
+            print(f" -> expanding to {fout.name}")
 
         # Write header
         fout.write(b'SR\x00\x04')
@@ -811,7 +811,7 @@ def readsav(file_name, idict=None, python_dict=False,
         f.seek(4)
 
     else:
-        raise Exception("Invalid RECFMT: %s" % recfmt)
+        raise Exception(f"Invalid RECFMT: {recfmt}")
 
     # Loop through records, and add them to the list
     while True:
@@ -844,35 +844,35 @@ def readsav(file_name, idict=None, python_dict=False,
         for record in records:
             if record['rectype'] == "TIMESTAMP":
                 print("-"*50)
-                print("Date: %s" % record['date'])
-                print("User: %s" % record['user'])
-                print("Host: %s" % record['host'])
+                print(f"Date: {record['date']}")
+                print(f"User: {record['user']}")
+                print(f"Host: {record['host']}")
                 break
 
         # Print out version info about the file
         for record in records:
             if record['rectype'] == "VERSION":
                 print("-"*50)
-                print("Format: %s" % record['format'])
-                print("Architecture: %s" % record['arch'])
-                print("Operating System: %s" % record['os'])
-                print("IDL Version: %s" % record['release'])
+                print(f"Format: {record['format']}")
+                print(f"Architecture: {record['arch']}")
+                print(f"Operating System: {record['os']}")
+                print(f"IDL Version: {record['release']}")
                 break
 
         # Print out identification info about the file
         for record in records:
             if record['rectype'] == "IDENTIFICATON":
                 print("-"*50)
-                print("Author: %s" % record['author'])
-                print("Title: %s" % record['title'])
-                print("ID Code: %s" % record['idcode'])
+                print(f"Author: {record['author']}")
+                print(f"Title: {record['title']}")
+                print(f"ID Code: {record['idcode']}")
                 break
 
         # Print out descriptions saved with the file
         for record in records:
             if record['rectype'] == "DESCRIPTION":
                 print("-"*50)
-                print("Description: %s" % record['description'])
+                print(f"Description: {record['description']}")
                 break
 
         print("-"*50)
@@ -890,7 +890,7 @@ def readsav(file_name, idict=None, python_dict=False,
         if 'VARIABLE' in rectypes:
             print("Available variables:")
             for var in variables:
-                print(" - %s [%s]" % (var, type(variables[var])))
+                print(f" - {var} [{type(variables[var])}]")
             print("-"*50)
 
     if idict:

--- a/scipy/io/matlab/byteordercodes.py
+++ b/scipy/io/matlab/byteordercodes.py
@@ -65,4 +65,4 @@ def to_numpy_code(code):
         return swapped_code
     else:
         raise ValueError(
-            'We cannot handle byte order %s' % code)
+            f'We cannot handle byte order {code}')

--- a/scipy/io/matlab/mio.py
+++ b/scipy/io/matlab/mio.py
@@ -79,7 +79,7 @@ def mat_reader_factory(file_name, appendmat=True, **kwargs):
     elif mjv == 2:
         raise NotImplementedError('Please use HDF reader for matlab v7.3 files')
     else:
-        raise TypeError('Did not recognize version %s' % mjv)
+        raise TypeError(f'Did not recognize version {mjv}')
 
 
 @docfiller

--- a/scipy/io/matlab/mio4.py
+++ b/scipy/io/matlab/mio4.py
@@ -139,7 +139,7 @@ class VarReader4(object):
             # no current processing (below) makes sense for sparse
             return self.read_sparse_array(hdr)
         else:
-            raise TypeError('No reader for class code %s' % mclass)
+            raise TypeError(f'No reader for class code {mclass}')
         if process and self.squeeze_me:
             return squeeze_element(arr)
         return arr
@@ -290,7 +290,7 @@ class VarReader4(object):
 
             shape = (int(rows), int(cols))
         else:
-            raise TypeError('No reader for class code %s' % mclass)
+            raise TypeError(f'No reader for class code {mclass}')
 
         if self.squeeze_me:
             shape = tuple([x for x in shape if x != 1])

--- a/scipy/io/matlab/mio5.py
+++ b/scipy/io/matlab/mio5.py
@@ -333,10 +333,9 @@ class MatFile5Reader(MatFileReader):
                 res = self.read_var_array(hdr, process)
             except MatReadError as err:
                 warnings.warn(
-                    'Unreadable variable "%s", because "%s"' %
-                    (name, err),
+                    f'Unreadable variable "{name}", because "{err}"',
                     Warning, stacklevel=2)
-                res = "Read error: %s" % err
+                res = f"Read error: {err}"
             self.mat_stream.seek(next_position)
             mdict[name] = res
             if hdr.is_global:

--- a/scipy/io/matlab/miobase.py
+++ b/scipy/io/matlab/miobase.py
@@ -303,8 +303,7 @@ def matdims(arr, oned_as='column'):
         elif oned_as == 'row':
             return (1,) + shape
         else:
-            raise ValueError('1-D option "%s" is strange'
-                             % oned_as)
+            raise ValueError(f'1-D option "{oned_as}" is strange')
     return shape
 
 

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -254,8 +254,7 @@ def _check_level(label, expected, actual):
         return
     # Check types are as expected
     assert_(types_compatible(expected, actual),
-            "Expected type %s, got %s at %s" %
-            (type(expected), type(actual), label))
+            f"Expected type {type(expected)}, got {type(actual)} at {label}")
     # A field in a record array may not be an ndarray
     # A scalar from a record array will be type np.void
     if not isinstance(expected,
@@ -277,7 +276,7 @@ def _check_level(label, expected, actual):
         return
     if ex_dtype.fields:  # probably recarray
         for fn in ex_dtype.fields:
-            level_label = "%s, field %s, " % (label, fn)
+            level_label = f"{label}, field {fn}, "
             _check_level(level_label,
                          expected[fn], actual[fn])
         return
@@ -293,16 +292,16 @@ def _check_level(label, expected, actual):
 def _load_check_case(name, files, case):
     for file_name in files:
         matdict = loadmat(file_name, struct_as_record=True)
-        label = "test %s; file %s" % (name, file_name)
+        label = f"test {name}; file {file_name}"
         for k, expected in case.items():
-            k_label = "%s, variable %s" % (label, k)
-            assert_(k in matdict, "Missing key at %s" % k_label)
+            k_label = f"{label}, variable {k}"
+            assert_(k in matdict, f"Missing key at {k_label}")
             _check_level(k_label, expected, matdict[k])
 
 
 def _whos_check_case(name, files, case, classes):
     for file_name in files:
-        label = "test %s; file %s" % (name, file_name)
+        label = f"test {name}; file {file_name}"
 
         whos = whosmat(file_name)
 
@@ -312,7 +311,7 @@ def _whos_check_case(name, files, case, classes):
         whos.sort()
         expected_whos.sort()
         assert_equal(whos, expected_whos,
-                     "%s: %r != %r" % (label, whos, expected_whos)
+                     f"{label}: {whos!r} != {expected_whos!r}"
                      )
 
 
@@ -329,10 +328,10 @@ def test_load():
     for case in case_table4 + case_table5:
         name = case['name']
         expected = case['expected']
-        filt = pjoin(test_data_path, 'test%s_*.mat' % name)
+        filt = pjoin(test_data_path, f'test{name}_*.mat')
         files = glob(filt)
         assert_(len(files) > 0,
-                "No files for test %s using filter %s" % (name, filt))
+                f"No files for test {name} using filter {filt}")
         _load_check_case(name, files, expected)
 
 
@@ -342,10 +341,10 @@ def test_whos():
         name = case['name']
         expected = case['expected']
         classes = case['classes']
-        filt = pjoin(test_data_path, 'test%s_*.mat' % name)
+        filt = pjoin(test_data_path, f'test{name}_*.mat')
         files = glob(filt)
         assert_(len(files) > 0,
-                "No files for test %s using filter %s" % (name, filt))
+                f"No files for test {name} using filter {filt}")
         _whos_check_case(name, files, expected, classes)
 
 

--- a/scipy/io/mmio.py
+++ b/scipy/io/mmio.py
@@ -691,7 +691,7 @@ class MMFile:
 
         else:
             if not isspmatrix(a):
-                raise ValueError('unknown matrix type: %s' % type(a))
+                raise ValueError(f'unknown matrix type: {type(a)}')
 
             rep = 'coordinate'
             rows, cols = a.shape
@@ -733,7 +733,7 @@ class MMFile:
 
         # write comments
         for line in comment.split('\n'):
-            stream.write(asbytes('%%%s\n' % (line)))
+            stream.write(asbytes(f'%{line}\n'))
 
         template = self._field_template(field, precision)
         # write dense format
@@ -776,7 +776,7 @@ class MMFile:
                 raise ValueError('pattern type inconsisted with dense format')
 
             else:
-                raise TypeError('Unknown field type %s' % field)
+                raise TypeError(f'Unknown field type {field}')
 
         # write sparse format
         else:
@@ -807,7 +807,7 @@ class MMFile:
                     stream.write(asbytes(("%i %i " % (r, c)) +
                                          (template % (d.real, d.imag))))
             else:
-                raise TypeError('Unknown field type %s' % field)
+                raise TypeError(f'Unknown field type {field}')
 
 
 def _is_fromfile_compatible(stream):
@@ -842,4 +842,4 @@ if __name__ == '__main__':
         sys.stdout.flush()
         t = time.time()
         mmread(filename)
-        print('took %s seconds' % (time.time() - t))
+        print(f'took {time.time() - t} seconds')

--- a/scipy/io/netcdf.py
+++ b/scipy/io/netcdf.py
@@ -246,7 +246,7 @@ class netcdf_file(object):
         else:  # maybe it's a string
             self.filename = filename
             omode = 'r+' if mode == 'a' else mode
-            self.fp = open(self.filename, '%sb' % omode)
+            self.fp = open(self.filename, f'{omode}b')
             if mmap is None:
                 # Mmapped files on PyPy cannot be usually closed
                 # before the GC runs, so it's better to use mmap=False
@@ -385,7 +385,7 @@ class netcdf_file(object):
         type = dtype(type)
         typecode, size = type.char, type.itemsize
         if (typecode, size) not in REVERSE:
-            raise ValueError("NetCDF 3 does not support type %s" % type)
+            raise ValueError(f"NetCDF 3 does not support type {type}")
 
         data = empty(shape_, dtype=type.newbyteorder("B"))  # convert to big endian always for NetCDF 3
         self.variables[name] = netcdf_variable(
@@ -574,7 +574,7 @@ class netcdf_file(object):
                     break
 
         typecode, size = TYPEMAP[nc_type]
-        dtype_ = '>%s' % typecode
+        dtype_ = f'>{typecode}'
         # asarray() dies with bytes and '>c' in py3k. Change to 'S'
         dtype_ = 'S' if dtype_ == '>c' else dtype_
 
@@ -747,7 +747,7 @@ class netcdf_file(object):
         begin = [self._unpack_int, self._unpack_int64][self.version_byte-1]()
 
         typecode, size = TYPEMAP[nc_type]
-        dtype_ = '>%s' % typecode
+        dtype_ = f'>{typecode}'
 
         return name, dimensions, shape, attributes, typecode, size, dtype_, begin, vsize
 
@@ -762,7 +762,7 @@ class netcdf_file(object):
         self.fp.read(-count % 4)  # read padding
 
         if typecode != 'c':
-            values = frombuffer(values, dtype='>%s' % typecode).copy()
+            values = frombuffer(values, dtype=f'>{typecode}').copy()
             if values.shape == (1,):
                 values = values[0]
         else:

--- a/scipy/io/tests/test_fortran.py
+++ b/scipy/io/tests/test_fortran.py
@@ -23,7 +23,7 @@ def test_fortranfiles_read():
     for filename in iglob(path.join(DATA_PATH, "fortran-*-*x*x*.dat")):
         m = re.search(r'fortran-([^-]+)-(\d+)x(\d+)x(\d+).dat', filename, re.I)
         if not m:
-            raise RuntimeError("Couldn't match %s filename to regex" % filename)
+            raise RuntimeError(f"Couldn't match {filename} filename to regex")
 
         dims = (int(m.group(2)), int(m.group(3)), int(m.group(4)))
 
@@ -52,7 +52,7 @@ def test_fortranfiles_write():
     for filename in iglob(path.join(DATA_PATH, "fortran-*-*x*x*.dat")):
         m = re.search(r'fortran-([^-]+)-(\d+)x(\d+)x(\d+).dat', filename, re.I)
         if not m:
-            raise RuntimeError("Couldn't match %s filename to regex" % filename)
+            raise RuntimeError(f"Couldn't match {filename} filename to regex")
         dims = (int(m.group(2)), int(m.group(3)), int(m.group(4)))
 
         dtype = m.group(1).replace('s', '<')

--- a/scipy/io/tests/test_mmio.py
+++ b/scipy/io/tests/test_mmio.py
@@ -614,7 +614,7 @@ class TestMMIOCoordinate(object):
 
         mmwrite(self.fn, b)
 
-        fn_bzip2 = "%s.bz2" % self.fn
+        fn_bzip2 = f"{self.fn}.bz2"
         with open(self.fn, 'rb') as f_in:
             f_out = bz2.BZ2File(fn_bzip2, 'wb')
             f_out.write(f_in.read())
@@ -638,7 +638,7 @@ class TestMMIOCoordinate(object):
 
         mmwrite(self.fn, b)
 
-        fn_gzip = "%s.gz" % self.fn
+        fn_gzip = f"{self.fn}.gz"
         with open(self.fn, 'rb') as f_in:
             f_out = gzip.open(fn_gzip, 'wb')
             f_out.write(f_in.read())

--- a/scipy/io/wavfile.py
+++ b/scipy/io/wavfile.py
@@ -760,7 +760,7 @@ def write(filename, rate, data):
         dkind = data.dtype.kind
         if not (dkind == 'i' or dkind == 'f' or (dkind == 'u' and
                                                  data.dtype.itemsize == 1)):
-            raise ValueError("Unsupported data type '%s'" % data.dtype)
+            raise ValueError(f"Unsupported data type '{data.dtype}'")
 
         header_data = b''
 

--- a/scipy/linalg/_cython_signature_generator.py
+++ b/scipy/linalg/_cython_signature_generator.py
@@ -45,7 +45,7 @@ def make_signature(filename):
     args = ', '.join(arglist)
     # Eliminate strange variable naming that replaces rank with rank_bn.
     args = args.replace('rank_bn', 'rank')
-    return '{0} {1}({2})\n'.format(return_type, name, args)
+    return f'{return_type} {name}({args})\n'
 
 
 def get_sig_name(line):

--- a/scipy/linalg/_decomp_cossin.py
+++ b/scipy/linalg/_decomp_cossin.py
@@ -116,11 +116,9 @@ def cossin(X, p=None, q=None, separate=False,
                              " matrices, got {}".format(X.shape))
         m = X.shape[0]
         if p >= m or p <= 0:
-            raise ValueError("invalid p={}, 0<p<{} must hold"
-                             .format(p, X.shape[0]))
+            raise ValueError(f"invalid p={p}, 0<p<{X.shape[0]} must hold")
         if q >= m or q <= 0:
-            raise ValueError("invalid q={}, 0<q<{} must hold"
-                             .format(q, X.shape[0]))
+            raise ValueError(f"invalid q={q}, 0<q<{X.shape[0]} must hold")
 
         x11, x12, x21, x22 = X[:p, :q], X[:p, q:], X[p:, :q], X[p:, q:]
     elif not isinstance(X, Iterable):
@@ -135,7 +133,7 @@ def cossin(X, p=None, q=None, separate=False,
         for name, block in zip(["x11", "x12", "x21", "x22"],
                                [x11, x12, x21, x22]):
             if block.shape[1] == 0:
-                raise ValueError("{} can't be empty".format(name))
+                raise ValueError(f"{name} can't be empty")
         p, q = x11.shape
         mmp, mmq = x22.shape
 
@@ -175,7 +173,7 @@ def cossin(X, p=None, q=None, separate=False,
         raise ValueError('illegal value in argument {} of internal {}'
                          .format(-info, method_name))
     if info > 0:
-        raise LinAlgError("{} did not converge: {}".format(method_name, info))
+        raise LinAlgError(f"{method_name} did not converge: {info}")
 
     if separate:
         return (u1, u2), theta, (v1h, v2h)

--- a/scipy/linalg/_decomp_qz.py
+++ b/scipy/linalg/_decomp_qz.py
@@ -123,7 +123,7 @@ def _qz(A, B, output='real', lwork=None, sort=None, overwrite_a=False,
 
     info = result[-1]
     if info < 0:
-        raise ValueError("Illegal value in argument {} of gges".format(-info))
+        raise ValueError(f"Illegal value in argument {-info} of gges")
     elif info > 0 and info <= a_n:
         warnings.warn("The QZ iteration failed. (a,b) are not in Schur "
                       "form, but ALPHAR(j), ALPHAI(j), and BETA(j) should be "

--- a/scipy/linalg/_expm_frechet.py
+++ b/scipy/linalg/_expm_frechet.py
@@ -105,7 +105,7 @@ def expm_frechet(A, E, method=None, compute_expm=True, check_finite=True):
     elif method == 'blockEnlarge':
         expm_A, expm_frechet_AE = expm_frechet_block_enlarge(A, E)
     else:
-        raise ValueError('Unknown implementation %s' % method)
+        raise ValueError(f'Unknown implementation {method}')
     if compute_expm:
         return expm_A, expm_frechet_AE
     else:

--- a/scipy/linalg/_generate_pyx.py
+++ b/scipy/linalg/_generate_pyx.py
@@ -60,7 +60,7 @@ def arg_casts(arg):
     if arg in ['npy_complex64', 'npy_complex128', '_cselect1', '_cselect2',
                '_dselect2', '_dselect3', '_sselect2', '_sselect3',
                '_zselect1', '_zselect2']:
-        return '<{0}*>'.format(arg)
+        return f'<{arg}*>'
     return ''
 
 

--- a/scipy/linalg/_procrustes.py
+++ b/scipy/linalg/_procrustes.py
@@ -78,7 +78,7 @@ def orthogonal_procrustes(A, B, check_finite=True):
         A = np.asanyarray(A)
         B = np.asanyarray(B)
     if A.ndim != 2:
-        raise ValueError('expected ndim to be 2, but observed %s' % A.ndim)
+        raise ValueError(f'expected ndim to be 2, but observed {A.ndim}')
     if A.shape != B.shape:
         raise ValueError('the shapes of A and B differ (%s vs %s)' % (
             A.shape, B.shape))

--- a/scipy/linalg/_solvers.py
+++ b/scipy/linalg/_solvers.py
@@ -164,7 +164,7 @@ def solve_continuous_lyapunov(a, q):
             r_or_c = complex
 
         if not np.equal(*_.shape):
-            raise ValueError("Matrix {} should be square.".format("aq"[ind]))
+            raise ValueError(f"Matrix {'aq'[ind]} should be square.")
 
     # Shape consistency check
     if a.shape != q.shape:
@@ -317,7 +317,7 @@ def solve_discrete_lyapunov(a, q, method=None):
     elif meth == 'bilinear':
         x = _solve_discrete_lyapunov_bilinear(a, q)
     else:
-        raise ValueError('Unknown solver %s' % method)
+        raise ValueError(f'Unknown solver {method}')
 
     return x
 
@@ -791,7 +791,7 @@ def _are_validate_args(a, b, q, r, e, s, eq_type='care'):
             r_or_c = complex
 
         if not np.equal(*mat.shape):
-            raise ValueError("Matrix {} should be square.".format("aqr"[ind]))
+            raise ValueError(f"Matrix {'aqr'[ind]} should be square.")
 
     # Shape consistency checks
     m, n = b.shape

--- a/scipy/linalg/_testutils.py
+++ b/scipy/linalg/_testutils.py
@@ -58,6 +58,6 @@ def assert_no_overwrite(call, shapes, dtypes=None):
                 orig_inputs = [_get_array(s, dtype) for s in shapes]
                 inputs = [faker(x.copy(order)) for x in orig_inputs]
                 call(*inputs)
-                msg = "call modified inputs [%r, %r]" % (dtype, faker)
+                msg = f"call modified inputs [{dtype!r}, {faker!r}]"
                 for a, b in zip(inputs, orig_inputs):
                     np.testing.assert_equal(a, b, err_msg=msg)

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -167,8 +167,7 @@ def solve(a, b, sym_pos=False, lower=False, overwrite_a=False,
         assume_a = 'pos'
 
     if assume_a not in ('gen', 'sym', 'her', 'pos'):
-        raise ValueError('{} is not a recognized matrix structure'
-                         ''.format(assume_a))
+        raise ValueError(f'{assume_a} is not a recognized matrix structure')
 
     # Deprecate keyword "debug"
     if debug is not None:
@@ -707,7 +706,7 @@ def _get_axis_len(aname, a, axis):
         ax += a.ndim
     if 0 <= ax < a.ndim:
         return a.shape[ax]
-    raise ValueError("'%saxis' entry is out of bounds" % (aname,))
+    raise ValueError(f"'{aname}axis' entry is out of bounds")
 
 
 def solve_circulant(c, b, singular='raise', tol=None,
@@ -1178,10 +1177,10 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
     if driver is None:
         driver = lstsq.default_lapack_driver
     if driver not in ('gelsd', 'gelsy', 'gelss'):
-        raise ValueError('LAPACK driver "%s" is not found' % driver)
+        raise ValueError(f'LAPACK driver "{driver}" is not found')
 
     lapack_func, lapack_lwork = get_lapack_funcs((driver,
-                                                 '%s_lwork' % driver),
+                                                 f'{driver}_lwork'),
                                                  (a1, b1))
     real_data = True if (lapack_func.dtype.kind == 'f') else False
 

--- a/scipy/linalg/blas.py
+++ b/scipy/linalg/blas.py
@@ -356,7 +356,7 @@ def _get_funcs(names, arrays, dtype,
             module_name = module2[1]
         if func is None:
             raise ValueError(
-                '%s function %s could not be found' % (lib_name, func_name))
+                f'{lib_name} function {func_name} could not be found')
         func.module_name, func.typecode = module_name, prefix
         func.dtype = dtype
         if not ilp64:

--- a/scipy/linalg/decomp_cholesky.py
+++ b/scipy/linalg/decomp_cholesky.py
@@ -199,8 +199,7 @@ def cho_solve(c_and_lower, b, overwrite_b=False, check_finite=True):
     if c.ndim != 2 or c.shape[0] != c.shape[1]:
         raise ValueError("The factored matrix c is not square.")
     if c.shape[1] != b1.shape[0]:
-        raise ValueError("incompatible dimensions ({} and {})"
-                         .format(c.shape, b1.shape))
+        raise ValueError(f"incompatible dimensions ({c.shape} and {b1.shape})")
 
     overwrite_b = overwrite_b or _datacopied(b1, b)
 

--- a/scipy/linalg/decomp_schur.py
+++ b/scipy/linalg/decomp_schur.py
@@ -267,7 +267,7 @@ def rsf2csf(T, Z, check_finite=True):
 
     for ind, X in enumerate([Z, T]):
         if X.ndim != 2 or X.shape[0] != X.shape[1]:
-            raise ValueError("Input '{}' must be square.".format('ZT'[ind]))
+            raise ValueError(f"Input '{'ZT'[ind]}' must be square.")
 
     if T.shape[0] != Z.shape[0]:
         raise ValueError("Input array shapes must match: Z: {} vs. T: {}"

--- a/scipy/linalg/decomp_svd.py
+++ b/scipy/linalg/decomp_svd.py
@@ -455,13 +455,13 @@ def subspace_angles(A, B):
     # 1. Compute orthonormal bases of column-spaces
     A = _asarray_validated(A, check_finite=True)
     if len(A.shape) != 2:
-        raise ValueError('expected 2D array, got shape %s' % (A.shape,))
+        raise ValueError(f'expected 2D array, got shape {A.shape}')
     QA = orth(A)
     del A
 
     B = _asarray_validated(B, check_finite=True)
     if len(B.shape) != 2:
-        raise ValueError('expected 2D array, got shape %s' % (B.shape,))
+        raise ValueError(f'expected 2D array, got shape {B.shape}')
     if len(B) != len(QA):
         raise ValueError('A and B must have the same number of rows, got '
                          '%s and %s' % (QA.shape[0], B.shape[0]))

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -868,7 +868,7 @@ def backtickrepl(m):
         return ('with bounds ``{}`` with ``{}`` storage\n'
                 ''.format(m.group('b'), m.group('s')))
     else:
-        return 'with bounds ``{}``\n'.format(m.group('b'))
+        return f"with bounds ``{m.group('b')}``\n"
 
 
 for routine in [ssyevr, dsyevr, cheevr, zheevr,

--- a/scipy/linalg/setup.py
+++ b/scipy/linalg/setup.py
@@ -16,7 +16,7 @@ def configuration(parent_package='', top_path=None):
     atlas_version = ([v[3:-3] for k, v in lapack_opt.get('define_macros', [])
                       if k == 'ATLAS_INFO']+[None])[0]
     if atlas_version:
-        print(('ATLAS version: %s' % atlas_version))
+        print(f'ATLAS version: {atlas_version}')
 
     if uses_blas64():
         lapack_ilp64_opt = get_info('lapack_ilp64_opt', 2)

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -952,11 +952,11 @@ class TestLstsq(object):
                         x = out[0]
                         r = out[2]
                         assert_(r == 2,
-                                'expected efficient rank 2, got %s' % r)
+                                f'expected efficient rank 2, got {r}')
                         assert_allclose(dot(a, x), b,
                                         atol=25 * _eps_cast(a1.dtype),
                                         rtol=25 * _eps_cast(a1.dtype),
-                                        err_msg="driver: %s" % lapack_driver)
+                                        err_msg=f"driver: {lapack_driver}")
 
     def test_simple_overdet(self):
         for dtype in REAL_DTYPES:
@@ -976,16 +976,16 @@ class TestLstsq(object):
                     else:
                         residuals = out[1]
                     r = out[2]
-                    assert_(r == 2, 'expected efficient rank 2, got %s' % r)
+                    assert_(r == 2, f'expected efficient rank 2, got {r}')
                     assert_allclose(abs((dot(a, x) - b)**2).sum(axis=0),
                                     residuals,
                                     rtol=25 * _eps_cast(a1.dtype),
                                     atol=25 * _eps_cast(a1.dtype),
-                                    err_msg="driver: %s" % lapack_driver)
+                                    err_msg=f"driver: {lapack_driver}")
                     assert_allclose(x, (-0.428571428571429, 0.85714285714285),
                                     rtol=25 * _eps_cast(a1.dtype),
                                     atol=25 * _eps_cast(a1.dtype),
-                                    err_msg="driver: %s" % lapack_driver)
+                                    err_msg=f"driver: {lapack_driver}")
 
     def test_simple_overdet_complex(self):
         for dtype in COMPLEX_DTYPES:
@@ -1007,18 +1007,18 @@ class TestLstsq(object):
                     else:
                         residuals = out[1]
                     r = out[2]
-                    assert_(r == 2, 'expected efficient rank 2, got %s' % r)
+                    assert_(r == 2, f'expected efficient rank 2, got {r}')
                     assert_allclose(abs((dot(a, x) - b)**2).sum(axis=0),
                                     residuals,
                                     rtol=25 * _eps_cast(a1.dtype),
                                     atol=25 * _eps_cast(a1.dtype),
-                                    err_msg="driver: %s" % lapack_driver)
+                                    err_msg=f"driver: {lapack_driver}")
                     assert_allclose(
                                 x, (-0.4831460674157303 + 0.258426966292135j,
                                     0.921348314606741 + 0.292134831460674j),
                                 rtol=25 * _eps_cast(a1.dtype),
                                 atol=25 * _eps_cast(a1.dtype),
-                                err_msg="driver: %s" % lapack_driver)
+                                err_msg=f"driver: {lapack_driver}")
 
     def test_simple_underdet(self):
         for dtype in REAL_DTYPES:
@@ -1035,12 +1035,12 @@ class TestLstsq(object):
 
                     x = out[0]
                     r = out[2]
-                    assert_(r == 2, 'expected efficient rank 2, got %s' % r)
+                    assert_(r == 2, f'expected efficient rank 2, got {r}')
                     assert_allclose(x, (-0.055555555555555, 0.111111111111111,
                                         0.277777777777777),
                                     rtol=25 * _eps_cast(a1.dtype),
                                     atol=25 * _eps_cast(a1.dtype),
-                                    err_msg="driver: %s" % lapack_driver)
+                                    err_msg=f"driver: {lapack_driver}")
 
     def test_random_exact(self):
         for dtype in REAL_DTYPES:
@@ -1068,13 +1068,13 @@ class TestLstsq(object):
                                           dot(a, x), b,
                                           rtol=500 * _eps_cast(a1.dtype),
                                           atol=500 * _eps_cast(a1.dtype),
-                                          err_msg="driver: %s" % lapack_driver)
+                                          err_msg=f"driver: {lapack_driver}")
                             else:
                                 assert_allclose(
                                           dot(a, x), b,
                                           rtol=1000 * _eps_cast(a1.dtype),
                                           atol=1000 * _eps_cast(a1.dtype),
-                                          err_msg="driver: %s" % lapack_driver)
+                                          err_msg=f"driver: {lapack_driver}")
 
     def test_random_complex_exact(self):
         for dtype in COMPLEX_DTYPES:
@@ -1102,13 +1102,13 @@ class TestLstsq(object):
                                           dot(a, x), b,
                                           rtol=400 * _eps_cast(a1.dtype),
                                           atol=400 * _eps_cast(a1.dtype),
-                                          err_msg="driver: %s" % lapack_driver)
+                                          err_msg=f"driver: {lapack_driver}")
                             else:
                                 assert_allclose(
                                           dot(a, x), b,
                                           rtol=1000 * _eps_cast(a1.dtype),
                                           atol=1000 * _eps_cast(a1.dtype),
-                                          err_msg="driver: %s" % lapack_driver)
+                                          err_msg=f"driver: {lapack_driver}")
 
     def test_random_overdet(self):
         for dtype in REAL_DTYPES:
@@ -1135,7 +1135,7 @@ class TestLstsq(object):
                                           x, direct_lstsq(a, b, cmplx=0),
                                           rtol=25 * _eps_cast(a1.dtype),
                                           atol=25 * _eps_cast(a1.dtype),
-                                          err_msg="driver: %s" % lapack_driver)
+                                          err_msg=f"driver: {lapack_driver}")
 
     def test_random_complex_overdet(self):
         for dtype in COMPLEX_DTYPES:
@@ -1164,7 +1164,7 @@ class TestLstsq(object):
                                       x, direct_lstsq(a, b, cmplx=1),
                                       rtol=25 * _eps_cast(a1.dtype),
                                       atol=25 * _eps_cast(a1.dtype),
-                                      err_msg="driver: %s" % lapack_driver)
+                                      err_msg=f"driver: {lapack_driver}")
 
     def test_check_finite(self):
         with suppress_warnings() as sup:
@@ -1192,11 +1192,11 @@ class TestLstsq(object):
                         overwrite_b=overwrite)
             x = out[0]
             r = out[2]
-            assert_(r == 2, 'expected efficient rank 2, got %s' % r)
+            assert_(r == 2, f'expected efficient rank 2, got {r}')
             assert_allclose(dot(a, x), b,
                             rtol=25 * _eps_cast(a.dtype),
                             atol=25 * _eps_cast(a.dtype),
-                            err_msg="driver: %s" % lapack_driver)
+                            err_msg=f"driver: {lapack_driver}")
 
     def test_zero_size(self):
         for a_shape, b_shape in (((0, 2), (0,)),

--- a/scipy/linalg/tests/test_build.py
+++ b/scipy/linalg/tests/test_build.py
@@ -19,13 +19,13 @@ class FindDependenciesLdd:
         try:
             call(self.cmd, stdout=PIPE, stderr=PIPE)
         except OSError as e:
-            raise RuntimeError("command %s cannot be run" % self.cmd) from e
+            raise RuntimeError(f"command {self.cmd} cannot be run") from e
 
     def get_dependencies(self, file):
         p = Popen(self.cmd + [file], stdout=PIPE, stderr=PIPE)
         stdout, stderr = p.communicate()
         if not (p.returncode == 0):
-            raise RuntimeError("Failed to check dependencies for %s" % file)
+            raise RuntimeError(f"Failed to check dependencies for {file}")
 
         return stdout
 

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -94,7 +94,7 @@ def assert_dtype_equal(act, des):
         des = dtype(des)
 
     assert_(act == des,
-            'dtype mismatch: "{}" (should be "{}")'.format(act, des))
+            f'dtype mismatch: "{act}" (should be "{des}")')
 
 
 # XXX: This function should not be defined here, but somewhere in
@@ -224,7 +224,7 @@ class TestEig(object):
             A = asarray(A)
             B0 = B
             B = np.eye(*A.shape)
-        msg = "\n%r\n%r" % (A, B)
+        msg = f"\n{A!r}\n{B!r}"
 
         # Eigenvalues in homogeneous coordinates
         w, vr = eig(A, B0, homogeneous_eigvals=True)

--- a/scipy/linalg/tests/test_decomp_ldl.py
+++ b/scipy/linalg/tests/test_decomp_ldl.py
@@ -83,11 +83,11 @@ def test_permutations():
         # Test whether permutations lead to a triangular array
         u, d, p = ldl(x, lower=0)
         # lower part should be zero
-        assert_(not any(u[p, :][l_ind]), 'Spin {} failed'.format(_))
+        assert_(not any(u[p, :][l_ind]), f'Spin {_} failed')
 
         l, d, p = ldl(x, lower=1)
         # upper part should be zero
-        assert_(not any(l[p, :][u_ind]), 'Spin {} failed'.format(_))
+        assert_(not any(l[p, :][u_ind]), f'Spin {_} failed')
 
 
 def test_ldl_type_size_combinations():
@@ -97,7 +97,7 @@ def test_ldl_type_size_combinations():
     complex_dtypes = [complex64, complex128]
 
     for n, dtype in itertools.product(sizes, real_dtypes):
-        msg = ("Failed for size: {}, dtype: {}".format(n, dtype))
+        msg = f"Failed for size: {n}, dtype: {dtype}"
 
         x = rand(n, n).astype(dtype)
         x = x + x.T
@@ -110,8 +110,8 @@ def test_ldl_type_size_combinations():
         assert_allclose(u.dot(d2).dot(u.T), x, rtol=rtol, err_msg=msg)
 
     for n, dtype in itertools.product(sizes, complex_dtypes):
-        msg1 = ("Her failed for size: {}, dtype: {}".format(n, dtype))
-        msg2 = ("Sym failed for size: {}, dtype: {}".format(n, dtype))
+        msg1 = f"Her failed for size: {n}, dtype: {dtype}"
+        msg2 = f"Sym failed for size: {n}, dtype: {dtype}"
 
         # Complex hermitian upper/lower
         x = (rand(n, n)+1j*rand(n, n)).astype(dtype)

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -2177,7 +2177,7 @@ def test_pttrf_pttrs(ddtype, dtype):
     # test to assure that the inputs of ?pttrf are unmodified
     assert_array_equal(d, diag_cpy[0])
     assert_array_equal(e, diag_cpy[1])
-    assert_equal(info, 0, err_msg="pttrf: info = {}, should be 0".format(info))
+    assert_equal(info, 0, err_msg=f"pttrf: info = {info}, should be 0")
 
     # test that the factors from pttrf can be recombined to make A
     L = np.diag(_e, -1) + np.diag(np.ones(n))
@@ -2193,7 +2193,7 @@ def test_pttrf_pttrs(ddtype, dtype):
     # determine _x from pttrs
     pttrs = get_lapack_funcs('pttrs', dtype=dtype)
     _x, info = pttrs(_d, _e.conj(), b)
-    assert_equal(info, 0, err_msg="pttrs: info = {}, should be 0".format(info))
+    assert_equal(info, 0, err_msg=f"pttrs: info = {info}, should be 0")
 
     # test that _x from pttrs matches the expected x
     assert_allclose(x, _x, atol=atol)
@@ -2324,7 +2324,7 @@ def test_pteqr(dtype, realtype, compute_z):
     d, e, A, z = pteqr_get_d_e_A_z(dtype, realtype, n, compute_z)
 
     d_pteqr, e_pteqr, z_pteqr, info = pteqr(d=d, e=e, z=z, compute_z=compute_z)
-    assert_equal(info, 0, "info = {}, should be 0.".format(info))
+    assert_equal(info, 0, f"info = {info}, should be 0.")
 
     # compare the routine's eigenvalues with scipy.linalg.eig's.
     assert_allclose(np.sort(eigh(A)[0]), np.sort(d_pteqr), atol=atol)
@@ -2492,8 +2492,7 @@ def test_standard_eigh_lworks(pfx, driver):
         _compute_lwork(sc_dlw, n, lower=1)
         _compute_lwork(dz_dlw, n, lower=1)
     except Exception as e:
-        pytest.fail("{}_lwork raised unexpected exception: {}"
-                    "".format(pfx+driver, e))
+        pytest.fail(f"{pfx + driver}_lwork raised unexpected exception: {e}")
 
 
 @pytest.mark.parametrize("driver", ['gv', 'gvx'])
@@ -2508,8 +2507,7 @@ def test_generalized_eigh_lworks(pfx, driver):
         _compute_lwork(sc_dlw, n, uplo="L")
         _compute_lwork(dz_dlw, n, uplo="L")
     except Exception as e:
-        pytest.fail("{}_lwork raised unexpected exception: {}"
-                    "".format(pfx+driver, e))
+        pytest.fail(f"{pfx + driver}_lwork raised unexpected exception: {e}")
 
 
 @pytest.mark.parametrize("dtype_", DTYPES)
@@ -2611,7 +2609,7 @@ def test_gtsvx(dtype, trans_bool, fact):
     gtsvx_out = gtsvx(dl, d, du, b, fact=fact, trans=trans, dlf=dlf_, df=df_,
                       duf=duf_, du2=du2f_, ipiv=ipiv_)
     dlf, df, duf, du2f, ipiv, x_soln, rcond, ferr, berr, info = gtsvx_out
-    assert_(info == 0, "?gtsvx info = {}, should be zero".format(info))
+    assert_(info == 0, f"?gtsvx info = {info}, should be zero")
 
     # assure that inputs are unmodified
     assert_array_equal(dl, inputs_cpy[0])
@@ -2625,7 +2623,7 @@ def test_gtsvx(dtype, trans_bool, fact):
     # assert that the outputs are of correct type or shape
     # rcond should be a scalar
     assert_(hasattr(rcond, "__len__") is not True,
-            "rcond should be scalar but is {}".format(rcond))
+            f"rcond should be scalar but is {rcond}")
     # ferr should be length of # of cols in x
     assert_(ferr.shape[0] == b.shape[1], "ferr.shape is {} but shoud be {},"
             .format(ferr.shape[0], b.shape[1]))
@@ -2806,7 +2804,7 @@ def test_ptsvx(dtype, realtype, fact, df_de_lambda):
     assert_array_equal(d, diag_cpy[0])
     assert_array_equal(e, diag_cpy[1])
     assert_array_equal(b, diag_cpy[2])
-    assert_(info == 0, "info should be 0 but is {}.".format(info))
+    assert_(info == 0, f"info should be 0 but is {info}.")
     assert_array_almost_equal(x_soln, x)
 
     # test that the factors from ptsvx can be recombined to make A
@@ -2817,7 +2815,7 @@ def test_ptsvx(dtype, realtype, fact, df_de_lambda):
     # assert that the outputs are of correct type or shape
     # rcond should be a scalar
     assert not hasattr(rcond, "__len__"), \
-        "rcond should be scalar but is {}".format(rcond)
+        f"rcond should be scalar but is {rcond}"
     # ferr should be length of # of cols in x
     assert_(ferr.shape == (2,), "ferr.shape is {} but shoud be ({},)"
             .format(ferr.shape, x_soln.shape[1]))

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -127,7 +127,7 @@ class TestLogM(object):
 
                 # Eigenvalues are related to the branch cut.
                 W = np.linalg.eigvals(M)
-                err_msg = 'M:{0} eivals:{1}'.format(M, W)
+                err_msg = f'M:{M} eivals:{W}'
 
                 # Check sqrtm round trip because it is used within logm.
                 M_sqrtm, info = sqrtm(M, disp=False)

--- a/scipy/ndimage/tests/test_c_api.py
+++ b/scipy/ndimage/tests/test_c_api.py
@@ -46,7 +46,7 @@ def test_generic_filter():
                                      footprint=footprint)
         std = ndimage.generic_filter(im, filter2d, footprint=footprint,
                                      extra_arguments=(weights,))
-        assert_allclose(res, std, err_msg="#{} failed".format(j))
+        assert_allclose(res, std, err_msg=f"#{j} failed")
 
     for j, func in enumerate(FILTER2D_FUNCTIONS):
         check(j)
@@ -70,7 +70,7 @@ def test_generic_filter1d():
                                        filter_size)
         std = ndimage.generic_filter1d(im, filter1d, filter_size,
                                        extra_arguments=(filter_size,))
-        assert_allclose(res, std, err_msg="#{} failed".format(j))
+        assert_allclose(res, std, err_msg=f"#{j} failed")
 
     for j, func in enumerate(FILTER1D_FUNCTIONS):
         check(j)
@@ -88,7 +88,7 @@ def test_geometric_transform():
 
         res = ndimage.geometric_transform(im, func(shift))
         std = ndimage.geometric_transform(im, transform, extra_arguments=(shift,))
-        assert_allclose(res, std, err_msg="#{} failed".format(j))
+        assert_allclose(res, std, err_msg=f"#{j} failed")
 
     for j, func in enumerate(TRANSFORM_FUNCTIONS):
         check(j)

--- a/scipy/ndimage/tests/test_splines.py
+++ b/scipy/ndimage/tests/test_splines.py
@@ -41,7 +41,7 @@ def make_spline_knot_matrix(n, order, mode='mirror'):
     elif mode == 'wrap':
         start, step = -1, -1
     else:
-        raise ValueError('unsupported mode {}'.format(mode))
+        raise ValueError(f'unsupported mode {mode}')
 
     for row in range(len(knot_values) - 1):
         for idx, knot_value in enumerate(knot_values[row + 1:]):

--- a/scipy/odr/models.py
+++ b/scipy/odr/models.py
@@ -170,7 +170,7 @@ def polynomial(order):
     return Model(_poly_fcn, fjacd=_poly_fjacd, fjacb=_poly_fjacb,
                  estimate=_poly_est, extra_args=(powers,),
                  meta={'name': 'Sorta-general Polynomial',
-                 'equ': 'y = B_0 + Sum[i=1..%s, B_i * (x**i)]' % (len_beta-1),
+                 'equ': f'y = B_0 + Sum[i=1..{len_beta - 1}, B_i * (x**i)]',
                  'TeXequ': r'$y=\beta_0 + \sum_{i=1}^{%s} \beta_i x^i$' %
                         (len_beta-1)})
 

--- a/scipy/odr/odrpack.py
+++ b/scipy/odr/odrpack.py
@@ -290,7 +290,7 @@ class Data(object):
         if attr in self.meta:
             return self.meta[attr]
         else:
-            raise AttributeError("'%s' not in metadata" % attr)
+            raise AttributeError(f"'{attr}' not in metadata")
 
 
 class RealData(Data):
@@ -419,7 +419,7 @@ class RealData(Data):
             if attr in self.meta:
                 return self.meta[attr]
             else:
-                raise AttributeError("'%s' not in metadata" % attr)
+                raise AttributeError(f"'{attr}' not in metadata")
         else:
             func, arg = lookup_tbl[(attr, self._ga_flags[attr])]
 
@@ -538,7 +538,7 @@ class Model(object):
         if attr in self.meta:
             return self.meta[attr]
         else:
-            raise AttributeError("'%s' not in metadata" % attr)
+            raise AttributeError(f"'{attr}' not in metadata")
 
 
 class Output(object):
@@ -612,7 +612,7 @@ class Output(object):
             print('Inverse Condition #:', self.inv_condnum)
             print('Reason(s) for Halting:')
             for r in self.stopreason:
-                print('  %s' % r)
+                print(f'  {r}')
 
 
 class ODR(object):
@@ -847,24 +847,24 @@ class ODR(object):
         if res.shape not in fcn_perms:
             print(res.shape)
             print(fcn_perms)
-            raise OdrError("fcn does not output %s-shaped array" % y_s)
+            raise OdrError(f"fcn does not output {y_s}-shaped array")
 
         if self.model.fjacd is not None:
             res = self.model.fjacd(*arglist)
             if res.shape not in fjacd_perms:
                 raise OdrError(
-                    "fjacd does not output %s-shaped array" % repr((q, m, n)))
+                    f"fjacd does not output {repr((q, m, n))}-shaped array")
         if self.model.fjacb is not None:
             res = self.model.fjacb(*arglist)
             if res.shape not in fjacb_perms:
                 raise OdrError(
-                    "fjacb does not output %s-shaped array" % repr((q, p, n)))
+                    f"fjacb does not output {repr((q, p, n))}-shaped array")
 
         # check shape of delta0
 
         if self.delta0 is not None and self.delta0.shape != self.data.x.shape:
             raise OdrError(
-                "delta0 is not a %s-shaped array" % repr(self.data.x.shape))
+                f"delta0 is not a {repr(self.data.x.shape)}-shaped array")
 
         if self.data.x.size == 0:
             warn(("Empty data detected for ODR instance. "

--- a/scipy/optimize/_constraints.py
+++ b/scipy/optimize/_constraints.py
@@ -186,9 +186,9 @@ class Bounds(object):
 
     def __repr__(self):
         if np.any(self.keep_feasible):
-            return "{}({!r}, {!r}, keep_feasible={!r})".format(type(self).__name__, self.lb, self.ub, self.keep_feasible)
+            return f"{type(self).__name__}({self.lb!r}, {self.ub!r}, keep_feasible={self.keep_feasible!r})"
         else:
-            return "{}({!r}, {!r})".format(type(self).__name__, self.lb, self.ub)
+            return f"{type(self).__name__}({self.lb!r}, {self.ub!r})"
 
 
 class PreparedConstraint(object):
@@ -453,7 +453,7 @@ def old_constraint_to_new(ic, con):
         raise TypeError("Constraint's type must be a string.") from e
     else:
         if ctype not in ['eq', 'ineq']:
-            raise ValueError("Unknown constraint type '%s'." % con['type'])
+            raise ValueError(f"Unknown constraint type '{con['type']}'.")
     if 'fun' not in con:
         raise ValueError('Constraint %d has no function defined.' % ic)
 

--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -84,16 +84,16 @@ def linprog_verbose_callback(res):
 
     saved_printoptions = np.get_printoptions()
     np.set_printoptions(linewidth=500,
-                        formatter={'float': lambda x: "{0: 12.4f}".format(x)})
+                        formatter={'float': lambda x: f"{x: 12.4f}"})
     if status:
         print('--------- Simplex Early Exit -------\n'.format(nit))
-        print('The simplex method exited early with status {0:d}'.format(status))
+        print(f'The simplex method exited early with status {status:d}')
         print(message)
     elif complete:
         print('--------- Simplex Complete --------\n')
-        print('Iterations required: {}'.format(nit))
+        print(f'Iterations required: {nit}')
     else:
-        print('--------- Iteration {0:d}  ---------\n'.format(nit))
+        print(f'--------- Iteration {nit:d}  ---------\n')
 
     if nit > 0:
         if phase == 1:
@@ -156,7 +156,7 @@ def linprog_terse_callback(res):
 
     if nit == 0:
         print("Iter:   X:")
-    print("{0: <5d}   ".format(nit), end="")
+    print(f"{nit: <5d}   ", end="")
     print(x)
 
 
@@ -552,7 +552,7 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
                 c, c0=c0, A=A, b=b, x0=x0, callback=callback,
                 postsolve_args=postsolve_args, **solver_options)
         else:
-            raise ValueError('Unknown solver %s' % method)
+            raise ValueError(f'Unknown solver {method}')
 
     # Eliminate artificial variables, re-introduce presolved variables, etc.
     disp = solver_options.get('disp', False)

--- a/scipy/optimize/_linprog_util.py
+++ b/scipy/optimize/_linprog_util.py
@@ -1244,8 +1244,8 @@ def _display_summary(message, status, fun, iteration):
     """
     print(message)
     if status in (0, 1):
-        print("         Current function value: {0: <12.6f}".format(fun))
-    print("         Iterations: {0:d}".format(iteration))
+        print(f"         Current function value: {fun: <12.6f}")
+    print(f"         Iterations: {iteration:d}")
 
 
 def _postsolve(x, postsolve_args, complete=False):
@@ -1422,7 +1422,7 @@ def _check_result(x, fun, status, slack, con, bounds, tol, message):
     if status == 0 and not is_feasible:
         status = 4
         message = ("The solution does not satisfy the constraints within the "
-                   "required tolerance of " + "{:.2E}".format(tol) + ", yet "
+                   "required tolerance of " + f"{tol:.2E}" + ", yet "
                    "no errors were raised and there is no certificate of "
                    "infeasibility or unboundedness. This is known to occur "
                    "if the `presolve` option is False and the problem is "

--- a/scipy/optimize/_lsq/common.py
+++ b/scipy/optimize/_lsq/common.py
@@ -553,12 +553,12 @@ def print_iteration_nonlinear(iteration, nfev, cost, cost_reduction,
     if cost_reduction is None:
         cost_reduction = " " * 15
     else:
-        cost_reduction = "{0:^15.2e}".format(cost_reduction)
+        cost_reduction = f"{cost_reduction:^15.2e}"
 
     if step_norm is None:
         step_norm = " " * 15
     else:
-        step_norm = "{0:^15.2e}".format(step_norm)
+        step_norm = f"{step_norm:^15.2e}"
 
     print("{0:^15}{1:^15}{2:^15.4e}{3}{4}{5:^15.2e}"
           .format(iteration, nfev, cost, cost_reduction,
@@ -576,12 +576,12 @@ def print_iteration_linear(iteration, cost, cost_reduction, step_norm,
     if cost_reduction is None:
         cost_reduction = " " * 15
     else:
-        cost_reduction = "{0:^15.2e}".format(cost_reduction)
+        cost_reduction = f"{cost_reduction:^15.2e}"
 
     if step_norm is None:
         step_norm = " " * 15
     else:
-        step_norm = "{0:^15.2e}".format(step_norm)
+        step_norm = f"{step_norm:^15.2e}"
 
     print("{0:^15}{1:^15.4e}{2}{3}{4:^15.2e}".format(
         iteration, cost, cost_reduction, step_norm, optimality))

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -515,12 +515,12 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
     # check if optional parameters are supported by the selected method
     # - jac
     if meth in ('nelder-mead', 'powell', 'cobyla') and bool(jac):
-        warn('Method %s does not use gradient information (jac).' % method,
+        warn(f'Method {method} does not use gradient information (jac).',
              RuntimeWarning)
     # - hess
     if meth not in ('newton-cg', 'dogleg', 'trust-ncg', 'trust-constr',
                     'trust-krylov', 'trust-exact', '_custom') and hess is not None:
-        warn('Method %s does not use Hessian information (hess).' % method,
+        warn(f'Method {method} does not use Hessian information (hess).',
              RuntimeWarning)
     # - hessp
     if meth not in ('newton-cg', 'dogleg', 'trust-ncg', 'trust-constr',
@@ -531,21 +531,21 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
     # - constraints or bounds
     if (meth in ('nelder-mead', 'cg', 'bfgs', 'newton-cg', 'dogleg',
                  'trust-ncg') and (bounds is not None or np.any(constraints))):
-        warn('Method %s cannot handle constraints nor bounds.' % method,
+        warn(f'Method {method} cannot handle constraints nor bounds.',
              RuntimeWarning)
     if meth in ('l-bfgs-b', 'tnc', 'powell') and np.any(constraints):
-        warn('Method %s cannot handle constraints.' % method,
+        warn(f'Method {method} cannot handle constraints.',
              RuntimeWarning)
     if meth == 'cobyla' and bounds is not None:
-        warn('Method %s cannot handle bounds.' % method,
+        warn(f'Method {method} cannot handle bounds.',
              RuntimeWarning)
     # - callback
     if (meth in ('cobyla',) and callback is not None):
-        warn('Method %s does not support callback.' % method, RuntimeWarning)
+        warn(f'Method {method} does not support callback.', RuntimeWarning)
     # - return_all
     if (meth in ('l-bfgs-b', 'tnc', 'cobyla', 'slsqp') and
             options.get('return_all', False)):
-        warn('Method %s does not support the return_all option.' % method,
+        warn(f'Method {method} does not support the return_all option.',
              RuntimeWarning)
 
     # check gradient vector
@@ -642,7 +642,7 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
         return _minimize_trustregion_exact(fun, x0, args, jac, hess,
                                            callback=callback, **options)
     else:
-        raise ValueError('Unknown solver %s' % method)
+        raise ValueError(f'Unknown solver {method}')
 
 
 def minimize_scalar(fun, bracket=None, bounds=None, args=(),
@@ -800,7 +800,7 @@ def minimize_scalar(fun, bracket=None, bounds=None, args=(),
     elif meth == 'golden':
         return _minimize_scalar_golden(fun, bracket, args, **options)
     else:
-        raise ValueError('Unknown solver %s' % method)
+        raise ValueError(f'Unknown solver {method}')
 
 
 def standardize_bounds(bounds, x0, meth):

--- a/scipy/optimize/_nnls.py
+++ b/scipy/optimize/_nnls.py
@@ -59,17 +59,17 @@ def nnls(A, b, maxiter=None):
 
     if len(A.shape) != 2:
         raise ValueError("Expected a two-dimensional array (matrix)" +
-                         ", but the shape of A is %s" % (A.shape, ))
+                         f", but the shape of A is {A.shape}")
     if len(b.shape) != 1:
         raise ValueError("Expected a one-dimensional array (vector" +
-                         ", but the shape of b is %s" % (b.shape, ))
+                         f", but the shape of b is {b.shape}")
 
     m, n = A.shape
 
     if m != b.shape[0]:
         raise ValueError(
                 "Incompatible dimensions. The first dimension of " +
-                "A is %s, while the shape of b is %s" % (m, (b.shape[0], )))
+                f"A is {m}, while the shape of b is {b.shape[0],}")
 
     maxiter = -1 if maxiter is None else int(maxiter)
 

--- a/scipy/optimize/_numdiff.py
+++ b/scipy/optimize/_numdiff.py
@@ -357,7 +357,7 @@ def approx_derivative(fun, x0, method='3-point', rel_step=None, abs_step=None,
     array([ 2.])
     """
     if method not in ['2-point', '3-point', 'cs']:
-        raise ValueError("Unknown method '%s'. " % method)
+        raise ValueError(f"Unknown method '{method}'. ")
 
     x0 = np.atleast_1d(x0)
     if x0.ndim > 1:

--- a/scipy/optimize/_root.py
+++ b/scipy/optimize/_root.py
@@ -155,7 +155,7 @@ def root(fun, x0, args=(), method='hybr', jac=None, tol=None, callback=None,
         options = {}
 
     if callback is not None and meth in ('hybr', 'lm'):
-        warn('Method %s does not accept callback.' % method,
+        warn(f'Method {method} does not accept callback.',
              RuntimeWarning)
 
     # fun also returns the Jacobian
@@ -195,14 +195,14 @@ def root(fun, x0, args=(), method='hybr', jac=None, tol=None, callback=None,
                                  _method=meth, _callback=callback,
                                  **options)
     else:
-        raise ValueError('Unknown solver %s' % method)
+        raise ValueError(f'Unknown solver {method}')
 
     return sol
 
 
 def _warn_jac_unused(jac, method):
     if jac is not None:
-        warn('Method %s does not use the jacobian (jac).' % (method,),
+        warn(f'Method {method} does not use the jacobian (jac).',
              RuntimeWarning)
 
 

--- a/scipy/optimize/_root_scalar.py
+++ b/scipy/optimize/_root_scalar.py
@@ -236,44 +236,44 @@ def root_scalar(f, args=(), method=None, bracket=None,
     try:
         methodc = getattr(optzeros, map2underlying.get(meth, meth))
     except AttributeError as e:
-        raise ValueError('Unknown solver %s' % meth) from e
+        raise ValueError(f'Unknown solver {meth}') from e
 
     if meth in ['bisect', 'ridder', 'brentq', 'brenth', 'toms748']:
         if not isinstance(bracket, (list, tuple, np.ndarray)):
-            raise ValueError('Bracket needed for %s' % method)
+            raise ValueError(f'Bracket needed for {method}')
 
         a, b = bracket[:2]
         r, sol = methodc(f, a, b, args=args, **kwargs)
     elif meth in ['secant']:
         if x0 is None:
-            raise ValueError('x0 must not be None for %s' % method)
+            raise ValueError(f'x0 must not be None for {method}')
         if x1 is None:
-            raise ValueError('x1 must not be None for %s' % method)
+            raise ValueError(f'x1 must not be None for {method}')
         if 'xtol' in kwargs:
             kwargs['tol'] = kwargs.pop('xtol')
         r, sol = methodc(f, x0, args=args, fprime=None, fprime2=None,
                          x1=x1, **kwargs)
     elif meth in ['newton']:
         if x0 is None:
-            raise ValueError('x0 must not be None for %s' % method)
+            raise ValueError(f'x0 must not be None for {method}')
         if not fprime:
-            raise ValueError('fprime must be specified for %s' % method)
+            raise ValueError(f'fprime must be specified for {method}')
         if 'xtol' in kwargs:
             kwargs['tol'] = kwargs.pop('xtol')
         r, sol = methodc(f, x0, args=args, fprime=fprime, fprime2=None,
                          **kwargs)
     elif meth in ['halley']:
         if x0 is None:
-            raise ValueError('x0 must not be None for %s' % method)
+            raise ValueError(f'x0 must not be None for {method}')
         if not fprime:
-            raise ValueError('fprime must be specified for %s' % method)
+            raise ValueError(f'fprime must be specified for {method}')
         if not fprime2:
-            raise ValueError('fprime2 must be specified for %s' % method)
+            raise ValueError(f'fprime2 must be specified for {method}')
         if 'xtol' in kwargs:
             kwargs['tol'] = kwargs.pop('xtol')
         r, sol = methodc(f, x0, args=args, fprime=fprime, fprime2=fprime2, **kwargs)
     else:
-        raise ValueError('Unknown solver %s' % method)
+        raise ValueError(f'Unknown solver {method}')
 
     if is_memoized:
         # Replace the function_calls count with the memoized count.

--- a/scipy/optimize/_shgo.py
+++ b/scipy/optimize/_shgo.py
@@ -824,9 +824,9 @@ class SHGO(object):
                 # 2if (pe - self.f_tol) <= abs(1.0 / abs(self.f_min_true)):
                 if abs(pe) >= 2 * self.f_tol:
                     warnings.warn("A much lower value than expected f* =" +
-                                  " {} than".format(self.f_min_true) +
+                                  f" {self.f_min_true} than" +
                                   " the was found f_lowest =" +
-                                  "{} ".format(self.f_lowest))
+                                  f"{self.f_lowest} ")
             if pe <= self.f_tol:
                 self.stop_global = True
 
@@ -919,8 +919,8 @@ class SHGO(object):
                 if self.disp:
                     logging.info('=' * 60)
                     logging.info(
-                        'v.x = {} is minimizer'.format(self.HC.V[x].x_a))
-                    logging.info('v.f = {} is minimizer'.format(self.HC.V[x].f))
+                        f'v.x = {self.HC.V[x].x_a} is minimizer')
+                    logging.info(f'v.f = {self.HC.V[x].f} is minimizer')
                     logging.info('=' * 30)
 
                 if self.HC.V[x] not in self.minimizer_pool:
@@ -930,7 +930,7 @@ class SHGO(object):
                     logging.info('Neighbors:')
                     logging.info('=' * 30)
                     for vn in self.HC.V[x].nn:
-                        logging.info('x = {} || f = {}'.format(vn.x, vn.f))
+                        logging.info(f'x = {vn.x} || f = {vn.f}')
 
                     logging.info('=' * 60)
 
@@ -1078,8 +1078,8 @@ class SHGO(object):
                     cbounds[i][1] = x_i
 
         if self.disp:
-            logging.info('cbounds found for v_min.x_a = {}'.format(v_min.x_a))
-            logging.info('cbounds = {}'.format(cbounds))
+            logging.info(f'cbounds found for v_min.x_a = {v_min.x_a}')
+            logging.info(f'cbounds = {cbounds}')
 
         return cbounds
 
@@ -1120,7 +1120,7 @@ class SHGO(object):
         """
         # Use minima maps if vertex was already run
         if self.disp:
-            logging.info('Vertex minimiser maps = {}'.format(self.LMC.v_maps))
+            logging.info(f'Vertex minimiser maps = {self.LMC.v_maps}')
 
         if self.LMC[x_min].lres is not None:
             return self.LMC[x_min].lres
@@ -1128,12 +1128,10 @@ class SHGO(object):
         # TODO: Check discarded bound rules
 
         if self.callback is not None:
-            print('Callback for '
-                  'minimizer starting at {}:'.format(x_min))
+            print(f'Callback for minimizer starting at {x_min}:')
 
         if self.disp:
-            print('Starting '
-                  'minimization at {}...'.format(x_min))
+            print(f'Starting minimization at {x_min}...')
 
         if self.sampling_method == 'simplicial':
             x_min_t = tuple(x_min)
@@ -1159,7 +1157,7 @@ class SHGO(object):
         lres = minimize(self.func, x_min, **self.minimizer_kwargs)
 
         if self.disp:
-            print('lres = {}'.format(lres))
+            print(f'lres = {lres}')
 
         # Local function evals for all minimizers
         self.res.nlfev += lres.nfev
@@ -1268,7 +1266,7 @@ class SHGO(object):
 
             if self.disp:
                 logging.info(
-                    "Minimizer pool = SHGO.X_min = {}".format(self.X_min))
+                    f"Minimizer pool = SHGO.X_min = {self.X_min}")
         else:
             if self.disp:
                 print(
@@ -1572,10 +1570,9 @@ class SHGO(object):
         self.minimizer_pool = []
         # Note: Can easily be parralized
         if self.disp:
-            logging.info('self.fn = {}'.format(self.fn))
-            logging.info('self.nc = {}'.format(self.nc))
-            logging.info('np.shape(self.C)'
-                         ' = {}'.format(np.shape(self.C)))
+            logging.info(f'self.fn = {self.fn}')
+            logging.info(f'self.nc = {self.nc}')
+            logging.info(f'np.shape(self.C) = {np.shape(self.C)}')
         for ind in range(self.fn):
             min_bool = self.sample_delaunay_topo(ind)
             if min_bool:
@@ -1586,7 +1583,7 @@ class SHGO(object):
         # Sort to find minimum func value in min_pool
         self.sort_min_pool()
         if self.disp:
-            logging.info('self.minimizer_pool = {}'.format(self.minimizer_pool))
+            logging.info(f'self.minimizer_pool = {self.minimizer_pool}')
         if not len(self.minimizer_pool) == 0:
             self.X_min = self.C[self.minimizer_pool]
         else:

--- a/scipy/optimize/_shgo_lib/triangulation.py
+++ b/scipy/optimize/_shgo_lib/triangulation.py
@@ -287,8 +287,8 @@ class Complex:
 
         if printout:
             print("A sub hyper cube with:")
-            print("origin: {}".format(origin))
-            print("supremum: {}".format(supremum))
+            print(f"origin: {origin}")
+            print(f"supremum: {supremum}")
             for v in C_new():
                 v.print_out()
 
@@ -600,13 +600,13 @@ class Vertex:
         return self._min
 
     def print_out(self):
-        print("Vertex: {}".format(self.x))
+        print(f"Vertex: {self.x}")
         constr = 'Connections: '
         for vc in self.nn:
-            constr += '{} '.format(vc.x)
+            constr += f'{vc.x} '
 
         print(constr)
-        print('Order = {}'.format(self.order))
+        print(f'Order = {self.order}')
 
 
 class VertexCache:

--- a/scipy/optimize/_spectral.py
+++ b/scipy/optimize/_spectral.py
@@ -64,7 +64,7 @@ def _root_df_sane(func, x0, args=(), ftol=1e-8, fatol=1e-300, maxfev=1000,
     _check_unknown_options(unknown_options)
 
     if line_search not in ('cheng', 'cruz'):
-        raise ValueError("Invalid value %r for 'line_search'" % (line_search,))
+        raise ValueError(f"Invalid value {line_search!r} for 'line_search'")
 
     nexp = 2
 

--- a/scipy/optimize/_trustregion.py
+++ b/scipy/optimize/_trustregion.py
@@ -246,7 +246,7 @@ def _minimize_trust_region(fun, x0, args=(), jac=None, hess=None, hessp=None,
             print(status_messages[warnflag])
         else:
             print('Warning: ' + status_messages[warnflag])
-        print("         Current function value: %f" % m.fun)
+        print(f"         Current function value: {m.fun:f}")
         print("         Iterations: %d" % k)
         print("         Function evaluations: %d" % sf.nfev)
         print("         Gradient evaluations: %d" % sf.ngev)

--- a/scipy/optimize/_trustregion_constr/report.py
+++ b/scipy/optimize/_trustregion_constr/report.py
@@ -23,7 +23,7 @@ class ReportBase(object):
         args = list(args)
         args[3] = float(args[3])
 
-        iteration_format = ["{{:{}}}".format(x) for x in cls.ITERATION_FORMATS]
+        iteration_format = [f"{{:{x}}}" for x in cls.ITERATION_FORMATS]
         fmt = "|" + "|".join(iteration_format) + "|"
         print(fmt.format(*args))
 

--- a/scipy/optimize/cobyla.py
+++ b/scipy/optimize/cobyla.py
@@ -176,7 +176,7 @@ def fmin_cobyla(func, x0, cons, args=(), consargs=None, rhobeg=1.0,
     sol = _minimize_cobyla(func, x0, args, constraints=con,
                            **opts)
     if disp and not sol['success']:
-        print("COBYLA failed to find a solution: %s" % (sol.message,))
+        print(f"COBYLA failed to find a solution: {sol.message}")
     return sol['x']
 
 @synchronized

--- a/scipy/optimize/linesearch.py
+++ b/scipy/optimize/linesearch.py
@@ -432,7 +432,7 @@ def scalar_search_wolfe2(phi, derphi, phi0=None,
                 msg = 'Rounding errors prevent the line search from converging'
             else:
                 msg = "The line search algorithm could not find a solution " + \
-                      "less than or equal to amax: %s" % amax
+                      f"less than or equal to amax: {amax}"
 
             warn(msg, LineSearchWarning)
             break

--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -31,10 +31,10 @@ def _check_func(checker, argname, thefunc, x0, args, numinputs,
                   "shape of the '%s' argument" % (checker, argname)
             func_name = getattr(thefunc, '__name__', None)
             if func_name:
-                msg += " '%s'." % func_name
+                msg += f" '{func_name}'."
             else:
                 msg += "."
-            msg += 'Shape should be %s but it is %s.' % (output_shape, shape(res))
+            msg += f'Shape should be {output_shape} but it is {shape(res)}.'
             raise TypeError(msg)
     if issubdtype(res.dtype, inexact):
         dt = res.dtype
@@ -411,7 +411,7 @@ def leastsq(func, x0, args=(), Dfun=None, full_output=0,
     m = shape[0]
 
     if n > m:
-        raise TypeError('Improper input: N=%s must not exceed M=%s' % (n, m))
+        raise TypeError(f'Improper input: N={n} must not exceed M={m}')
 
     if epsfcn is None:
         epsfcn = finfo(dtype).eps

--- a/scipy/optimize/nonlin.py
+++ b/scipy/optimize/nonlin.py
@@ -519,7 +519,7 @@ class Jacobian(object):
                  "matmat", "todense", "shape", "dtype"]
         for name, value in kw.items():
             if name not in names:
-                raise ValueError("Unknown keyword argument %s" % name)
+                raise ValueError(f"Unknown keyword argument {name}")
             if value is not None:
                 setattr(self, name, kw[name])
 
@@ -1475,7 +1475,7 @@ class KrylovJacobian(Jacobian):
 
         for key, value in kw.items():
             if not key.startswith('inner_'):
-                raise ValueError("Unknown parameter %s" % key)
+                raise ValueError(f"Unknown parameter {key}")
             self.method_kw[key[6:]] = value
 
     def _update_diff_step(self):
@@ -1550,7 +1550,7 @@ def _nonlin_wrapper(name, jac):
     if kwkw_str:
         kwkw_str = kwkw_str + ", "
     if kwonlyargs:
-        raise ValueError('Unexpected signature %s' % signature)
+        raise ValueError(f'Unexpected signature {signature}')
 
     # Construct the wrapper function so that its keyword arguments
     # are visible in pydoc.help etc.

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -773,7 +773,7 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
         msg = _status_message['success']
         if disp:
             print(msg)
-            print(f"         Current function value: {fval:f}")
+            print("         Current function value: %f" % fval)
             print("         Iterations: %d" % iterations)
             print("         Function evaluations: %d" % fcalls[0])
 
@@ -1190,7 +1190,7 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
 
     if disp:
         print(f"{'Warning: ' if warnflag != 0 else ''}{msg}")
-        print(f"         Current function value: {fval:f}")
+        print("         Current function value: %f" % fval)
         print("         Iterations: %d" % k)
         print("         Function evaluations: %d" % sf.nfev)
         print("         Gradient evaluations: %d" % sf.ngev)
@@ -1515,8 +1515,8 @@ def _minimize_cg(fun, x0, args=(), jac=None, callback=None,
         msg = _status_message['success']
 
     if disp:
-        print(f"{'Warning: ' if warnflag != 0 else ''}{msg}")
-        print(f"         Current function value: {fval:f}")
+        print("%s%s" % ("Warning: " if warnflag != 0 else "", msg))
+        print("         Current function value: %f" % fval)
         print("         Iterations: %d" % k)
         print("         Function evaluations: %d" % sf.nfev)
         print("         Gradient evaluations: %d" % sf.ngev)
@@ -1687,7 +1687,7 @@ def _minimize_newtoncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
     def terminate(warnflag, msg):
         if disp:
             print(msg)
-            print(f"         Current function value: {old_fval:f}")
+            print("         Current function value: %f" % old_fval)
             print("         Iterations: %d" % k)
             print("         Function evaluations: %d" % sf.nfev)
             print("         Gradient evaluations: %d" % sf.ngev)
@@ -1933,7 +1933,7 @@ def _minimize_scalar_bounded(func, bounds, args=(),
     if disp > 2:
         print(" ")
         print(header)
-        print(f"%5.0f   %12.6g %12.6g {fmin_data + (step,)}")
+        print("%5.0f   %12.6g %12.6g %s" % (fmin_data + (step,)))
 
     while (np.abs(xf - xm) > (tol2 - 0.5 * (b - a))):
         golden = 1
@@ -1977,7 +1977,7 @@ def _minimize_scalar_bounded(func, bounds, args=(),
         num += 1
         fmin_data = (num, x, fu)
         if disp > 2:
-            print(f"%5.0f   %12.6g %12.6g {fmin_data + (step,)}")
+            print("%5.0f   %12.6g %12.6g %s" % (fmin_data + (step,)))
 
         if fu <= fx:
             if x >= xf:
@@ -3000,7 +3000,7 @@ def _minimize_powell(func, x0, args=(), callback=None, bounds=None,
         msg = _status_message['success']
         if disp:
             print(msg)
-            print(f"         Current function value: {fval:f}")
+            print("         Current function value: %f" % fval)
             print("         Iterations: %d" % iter)
             print("         Function evaluations: %d" % fcalls[0])
 

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -148,7 +148,7 @@ def _check_unknown_options(unknown_options):
         # Stack level 4: this is called from _minimize_*, which is
         # called from another function in SciPy. Level 4 is the first
         # level in user code.
-        warnings.warn("Unknown solver options: %s" % msg, OptimizeWarning, 4)
+        warnings.warn(f"Unknown solver options: {msg}", OptimizeWarning, 4)
 
 
 def is_array_scalar(x):
@@ -773,7 +773,7 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
         msg = _status_message['success']
         if disp:
             print(msg)
-            print("         Current function value: %f" % fval)
+            print(f"         Current function value: {fval:f}")
             print("         Iterations: %d" % iterations)
             print("         Function evaluations: %d" % fcalls[0])
 
@@ -898,8 +898,7 @@ def check_grad(func, grad, x0, *args, **kwargs):
     """
     step = kwargs.pop('epsilon', _epsilon)
     if kwargs:
-        raise ValueError("Unknown keyword arguments: %r" %
-                         (list(kwargs.keys()),))
+        raise ValueError(f"Unknown keyword arguments: {list(kwargs.keys())!r}")
     return sqrt(sum((grad(x0, *args) -
                      approx_fprime(x0, func, step, *args))**2))
 
@@ -1190,8 +1189,8 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
         msg = _status_message['success']
 
     if disp:
-        print("%s%s" % ("Warning: " if warnflag != 0 else "", msg))
-        print("         Current function value: %f" % fval)
+        print(f"{'Warning: ' if warnflag != 0 else ''}{msg}")
+        print(f"         Current function value: {fval:f}")
         print("         Iterations: %d" % k)
         print("         Function evaluations: %d" % sf.nfev)
         print("         Gradient evaluations: %d" % sf.ngev)
@@ -1516,8 +1515,8 @@ def _minimize_cg(fun, x0, args=(), jac=None, callback=None,
         msg = _status_message['success']
 
     if disp:
-        print("%s%s" % ("Warning: " if warnflag != 0 else "", msg))
-        print("         Current function value: %f" % fval)
+        print(f"{'Warning: ' if warnflag != 0 else ''}{msg}")
+        print(f"         Current function value: {fval:f}")
         print("         Iterations: %d" % k)
         print("         Function evaluations: %d" % sf.nfev)
         print("         Gradient evaluations: %d" % sf.ngev)
@@ -1688,7 +1687,7 @@ def _minimize_newtoncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
     def terminate(warnflag, msg):
         if disp:
             print(msg)
-            print("         Current function value: %f" % old_fval)
+            print(f"         Current function value: {old_fval:f}")
             print("         Iterations: %d" % k)
             print("         Function evaluations: %d" % sf.nfev)
             print("         Gradient evaluations: %d" % sf.ngev)
@@ -1934,7 +1933,7 @@ def _minimize_scalar_bounded(func, bounds, args=(),
     if disp > 2:
         print(" ")
         print(header)
-        print("%5.0f   %12.6g %12.6g %s" % (fmin_data + (step,)))
+        print(f"%5.0f   %12.6g %12.6g {fmin_data + (step,)}")
 
     while (np.abs(xf - xm) > (tol2 - 0.5 * (b - a))):
         golden = 1
@@ -1978,7 +1977,7 @@ def _minimize_scalar_bounded(func, bounds, args=(),
         num += 1
         fmin_data = (num, x, fu)
         if disp > 2:
-            print("%5.0f   %12.6g %12.6g %s" % (fmin_data + (step,)))
+            print(f"%5.0f   %12.6g %12.6g {fmin_data + (step,)}")
 
         if fu <= fx:
             if x >= xf:
@@ -2288,7 +2287,7 @@ def _minimize_scalar_brent(func, brack=None, args=(),
     _check_unknown_options(unknown_options)
     tol = xtol
     if tol < 0:
-        raise ValueError('tolerance should be >= 0, got %r' % tol)
+        raise ValueError(f'tolerance should be >= 0, got {tol!r}')
 
     brent = Brent(func=func, args=args, tol=tol,
                   full_output=True, maxiter=maxiter)
@@ -3001,7 +3000,7 @@ def _minimize_powell(func, x0, args=(), callback=None, bounds=None,
         msg = _status_message['success']
         if disp:
             print(msg)
-            print("         Current function value: %f" % fval)
+            print(f"         Current function value: {fval:f}")
             print("         Iterations: %d" % iter)
             print("         Function evaluations: %d" % fcalls[0])
 
@@ -3025,7 +3024,7 @@ def _endprint(x, flag, fval, maxfun, xtol, disp):
                   "increase maxfun argument.\n")
     if flag == 2:
         if disp:
-            print("\n{}".format(_status_message['nan']))
+            print(f"\n{_status_message['nan']}")
     return
 
 
@@ -3462,7 +3461,7 @@ def show_options(solver=None, method=None, disp=True):
     else:
         solver = solver.lower()
         if solver not in doc_routines:
-            raise ValueError('Unknown solver %r' % (solver,))
+            raise ValueError(f'Unknown solver {solver!r}')
 
         if method is None:
             text = []
@@ -3474,7 +3473,7 @@ def show_options(solver=None, method=None, disp=True):
             method = method.lower()
             methods = dict(doc_routines[solver])
             if method not in methods:
-                raise ValueError("Unknown method %r" % (method,))
+                raise ValueError(f"Unknown method {method!r}")
             name = methods[method]
 
             # Import function object

--- a/scipy/optimize/slsqp.py
+++ b/scipy/optimize/slsqp.py
@@ -264,7 +264,7 @@ def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
             raise TypeError("Constraint's type must be a string.") from e
         else:
             if ctype not in ['eq', 'ineq']:
-                raise ValueError("Unknown constraint type '%s'." % con['type'])
+                raise ValueError(f"Unknown constraint type '{con['type']}'.")
 
         # check function
         if 'fun' not in con:

--- a/scipy/optimize/tests/test__root.py
+++ b/scipy/optimize/tests/test__root.py
@@ -32,7 +32,7 @@ class TestRoot(object):
 
             sol1 = root(func, [1.1,1.1], jac=jac, tol=1e-4, method=method)
             sol2 = root(func, [1.1,1.1], jac=jac, tol=0.5, method=method)
-            msg = "%s: %s vs. %s" % (method, func(sol1.x), func(sol2.x))
+            msg = f"{method}: {func(sol1.x)} vs. {func(sol2.x)}"
             assert_(sol1.success, msg)
             assert_(sol2.success, msg)
             assert_(abs(func(sol1.x)).max() < abs(func(sol2.x)).max(),

--- a/scipy/optimize/tests/test__shgo.py
+++ b/scipy/optimize/tests/test__shgo.py
@@ -562,7 +562,7 @@ class TestShgoArguments(object):
             # unittests which run test4_1 normally
             minimizer_kwargs = {'method': solver,
                                 'constraints': test3_1.cons}
-            print("Solver = {}".format(solver))
+            print(f"Solver = {solver}")
             print("=" * 100)
             run_test(test3_1, n=100, test_atol=1e-3,
                      minimizer_kwargs=minimizer_kwargs, sampling_method='sobol')
@@ -588,7 +588,7 @@ class TestShgoArguments(object):
             minimizer_kwargs = {'method': solver,
                                 'jac': jac,
                                 'hess': hess}
-            logging.info("Solver = {}".format(solver))
+            logging.info(f"Solver = {solver}")
             logging.info("=" * 100)
             run_test(test1_1, n=100, test_atol=1e-3,
                      minimizer_kwargs=minimizer_kwargs, sampling_method='sobol')

--- a/scipy/optimize/tests/test_linesearch.py
+++ b/scipy/optimize/tests/test_linesearch.py
@@ -30,7 +30,7 @@ def assert_armijo(s, phi, c1=1e-4, err_msg=""):
     """
     phi1 = phi(s)
     phi0 = phi(0)
-    msg = "s = %s; phi(0) = %s; phi(s) = %s; %s" % (s, phi0, phi1, err_msg)
+    msg = f"s = {s}; phi(0) = {phi0}; phi(s) = {phi1}; {err_msg}"
     assert_(phi1 <= (1 - c1*s)*phi0, msg)
 
 
@@ -48,7 +48,7 @@ def assert_fp_equal(x, y, err_msg="", nulp=50):
     try:
         assert_array_almost_equal_nulp(x, y, nulp)
     except AssertionError as e:
-        raise AssertionError("%s\n%s" % (e, err_msg)) from e
+        raise AssertionError(f"{e}\n{err_msg}") from e
 
 
 class TestLineSearch(object):
@@ -150,7 +150,7 @@ class TestLineSearch(object):
             assert_fp_equal(phi1, phi(s), name)
             if derphi1 is not None:
                 assert_fp_equal(derphi1, derphi(s), name)
-            assert_wolfe(s, phi, derphi, err_msg="%s %g" % (name, old_phi0))
+            assert_wolfe(s, phi, derphi, err_msg=f"{name} {old_phi0:g}")
 
     def test_scalar_search_wolfe2_with_low_amax(self):
         def phi(alpha):
@@ -167,7 +167,7 @@ class TestLineSearch(object):
         for name, phi, derphi, old_phi0 in self.scalar_iter():
             s, phi1 = ls.scalar_search_armijo(phi, phi(0), derphi(0))
             assert_fp_equal(phi1, phi(s), name)
-            assert_armijo(s, phi, err_msg="%s %g" % (name, old_phi0))
+            assert_armijo(s, phi, err_msg=f"{name} {old_phi0:g}")
 
     # -- Generic line searches
 

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -59,8 +59,7 @@ def _assert_success(res, desired_fun=None, desired_x=None,
     # desired_fun: desired objective function value or None
     # desired_x: desired solution or None
     if not res.success:
-        msg = "linprog status {0}, message: {1}".format(res.status,
-                                                        res.message)
+        msg = f"linprog status {res.status}, message: {res.message}"
         raise AssertionError(msg)
 
     assert_equal(res.status, 0)

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -295,7 +295,7 @@ class TestLeastSq(object):
                               args=(self.y_meas, self.x),
                               full_output=True)
         params_fit, cov_x, infodict, mesg, ier = full_output
-        assert_(ier in (1,2,3,4), 'solution not found: %s' % mesg)
+        assert_(ier in (1,2,3,4), f'solution not found: {mesg}')
 
     def test_input_untouched(self):
         p0 = array([0,0,0],dtype=float64)
@@ -304,7 +304,7 @@ class TestLeastSq(object):
                               args=(self.y_meas, self.x),
                               full_output=True)
         params_fit, cov_x, infodict, mesg, ier = full_output
-        assert_(ier in (1,2,3,4), 'solution not found: %s' % mesg)
+        assert_(ier in (1,2,3,4), f'solution not found: {mesg}')
         assert_array_equal(p0, p0_copy)
 
     def test_wrong_shape_func_callable(self):

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -295,7 +295,7 @@ class TestLeastSq(object):
                               args=(self.y_meas, self.x),
                               full_output=True)
         params_fit, cov_x, infodict, mesg, ier = full_output
-        assert_(ier in (1,2,3,4), f'solution not found: {mesg}')
+        assert_(ier in (1, 2, 3, 4), f'solution not found: {mesg}')
 
     def test_input_untouched(self):
         p0 = array([0,0,0],dtype=float64)
@@ -304,7 +304,7 @@ class TestLeastSq(object):
                               args=(self.y_meas, self.x),
                               full_output=True)
         params_fit, cov_x, infodict, mesg, ier = full_output
-        assert_(ier in (1,2,3,4), f'solution not found: {mesg}')
+        assert_(ier in (1, 2, 3, 4), f'solution not found: {mesg}')
         assert_array_equal(p0, p0_copy)
 
     def test_wrong_shape_func_callable(self):

--- a/scipy/optimize/tests/test_nonlin.py
+++ b/scipy/optimize/tests/test_nonlin.py
@@ -296,7 +296,7 @@ class TestJacobianDotSolve(object):
             d = abs(a - b).max()
             f = tol + abs(b).max()*tol
             if d > f:
-                raise AssertionError('%s: err %g' % (msg, d))
+                raise AssertionError(f'{msg}: err {d:g}')
 
         self.A = rand(N, N)
 

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -967,7 +967,7 @@ class TestOptimizeSimple(CheckOptimize):
             sol2 = optimize.minimize(func, [1, 1], jac=jac, tol=1.0,
                                      method=method)
             assert_(func(sol1.x) < func(sol2.x),
-                    "%s: %s vs. %s" % (method, func(sol1.x), func(sol2.x)))
+                    f"{method}: {func(sol1.x)} vs. {func(sol2.x)}")
 
     @pytest.mark.parametrize('method',
                              ['fmin', 'fmin_powell', 'fmin_cg', 'fmin_bfgs',
@@ -1199,9 +1199,7 @@ class TestOptimizeSimple(CheckOptimize):
             res = optimize.minimize(f, x0, jac=g, method=method,
                                     options=options)
 
-            err_msg = "{0} {1}: {2}: {3}".format(method, scale,
-                                                 first_step_size,
-                                                 res)
+            err_msg = f"{method} {scale}: {first_step_size}: {res}"
 
             assert_(res.success, err_msg)
             assert_allclose(res.x, [1.0], err_msg=err_msg)
@@ -1293,7 +1291,7 @@ class TestOptimizeSimple(CheckOptimize):
         for i in range(1, len(self.trace)):
             if np.array_equal(self.trace[i - 1], self.trace[i]):
                 raise RuntimeError(
-                    "Duplicate evaluations made by {}".format(method))
+                    f"Duplicate evaluations made by {method}")
 
 
 class TestLBFGSBBounds(object):

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -75,7 +75,7 @@ class TestBasic(object):
             zero = r.root
             assert_(r.converged)
             assert_allclose(zero, 1.0, atol=xtol, rtol=rtol,
-                            err_msg='method %s, function %s' % (name, fname))
+                            err_msg=f'method {name}, function {fname}')
 
     def run_check(self, method, name):
         a = .5
@@ -87,7 +87,7 @@ class TestBasic(object):
                              full_output=True)
             assert_(r.converged)
             assert_allclose(zero, 1.0, atol=xtol, rtol=rtol,
-                            err_msg='method %s, function %s' % (name, fname))
+                            err_msg=f'method {name}, function {fname}')
 
     def run_check_lru_cached(self, method, name):
         # check that https://github.com/scipy/scipy/issues/10846 is fixed
@@ -96,7 +96,7 @@ class TestBasic(object):
         zero, r = method(f_lrucached, a, b, full_output=True)
         assert_(r.converged)
         assert_allclose(zero, 0,
-                        err_msg='method %s, function %s' % (name, 'f_lrucached'))
+                        err_msg=f"method {name}, function {'f_lrucached'}")
 
     def _run_one_test(self, tc, method, sig_args_keys=None,
                       sig_kwargs_keys=None, **kwargs):
@@ -475,7 +475,7 @@ def test_gh_5555():
     for method in methods:
         res = method(f, -1e8, 1e7, xtol=xtol, rtol=rtol)
         assert_allclose(root, res, atol=xtol, rtol=rtol,
-                        err_msg='method %s' % method.__name__)
+                        err_msg=f'method {method.__name__}')
 
 
 def test_gh_5557():

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -262,7 +262,7 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
 
     """
     if tol <= 0:
-        raise ValueError("tol too small (%g <= 0)" % tol)
+        raise ValueError(f"tol too small ({tol:g} <= 0)")
     maxiter = operator.index(maxiter)
     if maxiter < 1:
         raise ValueError("maxiter must be greater than 0")
@@ -332,7 +332,7 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
         for itr in range(maxiter):
             if q1 == q0:
                 if p1 != p0:
-                    msg = "Tolerance of %s reached." % (p1 - p0)
+                    msg = f"Tolerance of {p1 - p0} reached."
                     if disp:
                         msg += (
                             " Failed to converge after %d iterations, value is %s."
@@ -443,11 +443,11 @@ def _array_newton(func, x0, fprime, args, tol, maxiter, fprime2, full_output):
                     sum((p1[zero_der_nz_dp] - p[zero_der_nz_dp]) ** 2)
                 )
                 warnings.warn(
-                    'RMS of {:g} reached'.format(rms), RuntimeWarning)
+                    f'RMS of {rms:g} reached', RuntimeWarning)
         # Newton or Halley warnings
         else:
             all_or_some = 'all' if zero_der.all() else 'some'
-            msg = '{:s} derivatives were zero'.format(all_or_some)
+            msg = f'{all_or_some:s} derivatives were zero'
             warnings.warn(msg, RuntimeWarning)
     elif failures.any():
         all_or_some = 'all' if failures.all() else 'some'
@@ -543,9 +543,9 @@ def bisect(f, a, b, args=(),
         args = (args,)
     maxiter = operator.index(maxiter)
     if xtol <= 0:
-        raise ValueError("xtol too small (%g <= 0)" % xtol)
+        raise ValueError(f"xtol too small ({xtol:g} <= 0)")
     if rtol < _rtol:
-        raise ValueError("rtol too small (%g < %g)" % (rtol, _rtol))
+        raise ValueError(f"rtol too small ({rtol:g} < {_rtol:g})")
     r = _zeros._bisect(f, a, b, xtol, rtol, maxiter, args, full_output, disp)
     return results_c(full_output, r)
 
@@ -640,9 +640,9 @@ def ridder(f, a, b, args=(),
         args = (args,)
     maxiter = operator.index(maxiter)
     if xtol <= 0:
-        raise ValueError("xtol too small (%g <= 0)" % xtol)
+        raise ValueError(f"xtol too small ({xtol:g} <= 0)")
     if rtol < _rtol:
-        raise ValueError("rtol too small (%g < %g)" % (rtol, _rtol))
+        raise ValueError(f"rtol too small ({rtol:g} < {_rtol:g})")
     r = _zeros._ridder(f, a, b, xtol, rtol, maxiter, args, full_output, disp)
     return results_c(full_output, r)
 
@@ -770,9 +770,9 @@ def brentq(f, a, b, args=(),
         args = (args,)
     maxiter = operator.index(maxiter)
     if xtol <= 0:
-        raise ValueError("xtol too small (%g <= 0)" % xtol)
+        raise ValueError(f"xtol too small ({xtol:g} <= 0)")
     if rtol < _rtol:
-        raise ValueError("rtol too small (%g < %g)" % (rtol, _rtol))
+        raise ValueError(f"rtol too small ({rtol:g} < {_rtol:g})")
     r = _zeros._brentq(f, a, b, xtol, rtol, maxiter, args, full_output, disp)
     return results_c(full_output, r)
 
@@ -875,9 +875,9 @@ def brenth(f, a, b, args=(),
         args = (args,)
     maxiter = operator.index(maxiter)
     if xtol <= 0:
-        raise ValueError("xtol too small (%g <= 0)" % xtol)
+        raise ValueError(f"xtol too small ({xtol:g} <= 0)")
     if rtol < _rtol:
-        raise ValueError("rtol too small (%g < %g)" % (rtol, _rtol))
+        raise ValueError(f"rtol too small ({rtol:g} < {_rtol:g})")
     r = _zeros._brenth(f, a, b, xtol, rtol, maxiter, args, full_output, disp)
     return results_c(full_output, r)
 
@@ -1077,7 +1077,7 @@ class TOMS748Solver(object):
         fx = self.f(x, *self.args)
         self.function_calls += 1
         if not np.isfinite(fx) and error:
-            raise ValueError("Invalid function value: f(%f) -> %s " % (x, fx))
+            raise ValueError(f"Invalid function value: f({x:f}) -> {fx} ")
         return fx
 
     def get_result(self, x, flag=_ECONVERGED):
@@ -1096,18 +1096,18 @@ class TOMS748Solver(object):
         self.args = args
         self.ab[:] = [a, b]
         if not np.isfinite(a) or np.imag(a) != 0:
-            raise ValueError("Invalid x value: %s " % (a))
+            raise ValueError(f"Invalid x value: {a} ")
         if not np.isfinite(b) or np.imag(b) != 0:
-            raise ValueError("Invalid x value: %s " % (b))
+            raise ValueError(f"Invalid x value: {b} ")
 
         fa = self._callf(a)
         if not np.isfinite(fa) or np.imag(fa) != 0:
-            raise ValueError("Invalid function value: f(%f) -> %s " % (a, fa))
+            raise ValueError(f"Invalid function value: f({a:f}) -> {fa} ")
         if fa == 0:
             return _ECONVERGED, a
         fb = self._callf(b)
         if not np.isfinite(fb) or np.imag(fb) != 0:
-            raise ValueError("Invalid function value: f(%f) -> %s " % (b, fb))
+            raise ValueError(f"Invalid function value: f({b:f}) -> {fb} ")
         if fb == 0:
             return _ECONVERGED, b
 
@@ -1347,20 +1347,20 @@ def toms748(f, a, b, args=(), k=1,
                root: 1.0
     """
     if xtol <= 0:
-        raise ValueError("xtol too small (%g <= 0)" % xtol)
+        raise ValueError(f"xtol too small ({xtol:g} <= 0)")
     if rtol < _rtol / 4:
-        raise ValueError("rtol too small (%g < %g)" % (rtol, _rtol))
+        raise ValueError(f"rtol too small ({rtol:g} < {_rtol:g})")
     maxiter = operator.index(maxiter)
     if maxiter < 1:
         raise ValueError("maxiter must be greater than 0")
     if not np.isfinite(a):
-        raise ValueError("a is not finite %s" % a)
+        raise ValueError(f"a is not finite {a}")
     if not np.isfinite(b):
-        raise ValueError("b is not finite %s" % b)
+        raise ValueError(f"b is not finite {b}")
     if a >= b:
-        raise ValueError("a and b are not an interval [{}, {}]".format(a, b))
+        raise ValueError(f"a and b are not an interval [{a}, {b}]")
     if not k >= 1:
-        raise ValueError("k too small (%s < 1)" % k)
+        raise ValueError(f"k too small ({k} < 1)")
 
     if not isinstance(args, tuple):
         args = (args,)

--- a/scipy/signal/_peak_finding.py
+++ b/scipy/signal/_peak_finding.py
@@ -311,8 +311,7 @@ def _arg_wlen_as_expected(value):
             value = math.ceil(value)
         value = np.intp(value)
     else:
-        raise ValueError('`wlen` must be larger than 1, was {}'
-                         .format(value))
+        raise ValueError(f'`wlen` must be larger than 1, was {value}')
     return value
 
 

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -440,7 +440,7 @@ def freqz(b, a=1, worN=512, whole=False, plot=None, fs=2*pi, include_nyquist=Fal
         N = operator.index(worN)
         del worN
         if N < 0:
-            raise ValueError('worN must be nonnegative, got %s' % (N,))
+            raise ValueError(f'worN must be nonnegative, got {N}')
         lastpoint = 2 * pi if whole else pi
         # if include_nyquist is true and whole is false, w should include end point
         w = np.linspace(0, lastpoint, N, endpoint=include_nyquist and not whole)
@@ -2180,7 +2180,7 @@ def iirdesign(wp, ws, gpass, gstop, analog=False, ftype='ellip', output='ba',
     try:
         ordfunc = filter_dict[ftype][1]
     except KeyError as e:
-        raise ValueError("Invalid IIR filter type: %s" % ftype) from e
+        raise ValueError(f"Invalid IIR filter type: {ftype}") from e
     except IndexError as e:
         raise ValueError(("%s does not have order selection. Use "
                           "iirfilter function.") % ftype) from e
@@ -2340,15 +2340,15 @@ def iirfilter(N, Wn, rp=None, rs=None, btype='band', analog=False,
     try:
         btype = band_dict[btype]
     except KeyError as e:
-        raise ValueError("'%s' is an invalid bandtype for filter." % btype) from e
+        raise ValueError(f"'{btype}' is an invalid bandtype for filter.") from e
 
     try:
         typefunc = filter_dict[ftype][0]
     except KeyError as e:
-        raise ValueError("'%s' is not a valid basic IIR filter." % ftype) from e
+        raise ValueError(f"'{ftype}' is not a valid basic IIR filter.") from e
 
     if output not in ['ba', 'zpk', 'sos']:
-        raise ValueError("'%s' is not a valid output form." % output)
+        raise ValueError(f"'{output}' is not a valid output form.")
 
     if rp is not None and rp < 0:
         raise ValueError("passband ripple (rp) must be positive")
@@ -2377,7 +2377,7 @@ def iirfilter(N, Wn, rp=None, rs=None, btype='band', analog=False,
                              "elliptic filter.")
         z, p, k = typefunc(N, rp, rs)
     else:
-        raise NotImplementedError("'%s' not implemented in iirfilter." % ftype)
+        raise NotImplementedError(f"'{ftype}' not implemented in iirfilter.")
 
     # Pre-warp frequencies for digital filter design
     if not analog:
@@ -2414,7 +2414,7 @@ def iirfilter(N, Wn, rp=None, rs=None, btype='band', analog=False,
         elif btype == 'bandstop':
             z, p, k = lp2bs_zpk(z, p, k, wo=wo, bw=bw)
     else:
-        raise NotImplementedError("'%s' not implemented in iirfilter." % btype)
+        raise NotImplementedError(f"'{btype}' not implemented in iirfilter.")
 
     # Find discrete equivalent if necessary
     if not analog:
@@ -3493,7 +3493,7 @@ def band_stop_obj(wp, ind, passb, stopb, gpass, gstop, type):
         d1 = special.ellipk([arg1 ** 2, 1 - arg1 ** 2])
         n = (d0[0] * d1[1] / (d0[1] * d1[0]))
     else:
-        raise ValueError("Incorrect type: %s" % type)
+        raise ValueError(f"Incorrect type: {type}")
     return n
 
 
@@ -3654,7 +3654,7 @@ def buttord(wp, ws, gpass, gstop, analog=False, fs=None):
                    passb[0] * passb[1]))
         WN = numpy.sort(abs(WN))
     else:
-        raise ValueError("Bad type: %s" % filter_type)
+        raise ValueError(f"Bad type: {filter_type}")
 
     if not analog:
         wn = (2.0 / pi) * arctan(WN)

--- a/scipy/signal/fir_filter_design.py
+++ b/scipy/signal/fir_filter_design.py
@@ -973,7 +973,7 @@ def firls(numtaps, bands, desired, weight=None, nyq=None, fs=None):
     # normalize bands 0->1 and make it 2 columns
     nyq = float(nyq)
     if nyq <= 0:
-        raise ValueError('nyq must be positive, got %s <= 0.' % nyq)
+        raise ValueError(f'nyq must be positive, got {nyq} <= 0.')
     bands = np.asarray(bands).flatten() / nyq
     if len(bands) % 2 != 0:
         raise ValueError("bands must contain frequency pairs.")
@@ -1227,7 +1227,7 @@ def minimum_phase(h, method='homomorphic', n_fft=None):
         n_fft = 2 ** int(np.ceil(np.log2(2 * (len(h) - 1) / 0.01)))
     n_fft = int(n_fft)
     if n_fft < len(h):
-        raise ValueError('n_fft must be at least len(h)==%s' % len(h))
+        raise ValueError(f'n_fft must be at least len(h)=={len(h)}')
     if method == 'hilbert':
         w = np.arange(n_fft) * (2 * np.pi / n_fft * n_half)
         H = np.real(fft(h, n_fft) * np.exp(1j * w))

--- a/scipy/signal/lti_conversion.py
+++ b/scipy/signal/lti_conversion.py
@@ -497,6 +497,6 @@ def cont2discrete(system, dt, method="zoh", alpha=None):
         dd = c @ b * dt
 
     else:
-        raise ValueError("Unknown transformation method '%s'" % method)
+        raise ValueError(f"Unknown transformation method '{method}'")
 
     return ad, bd, cd, dd, dt

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -1435,8 +1435,7 @@ class StateSpace(LinearTimeInvariant):
         if isinstance(other, StateSpace):
             # Disallow mix of discrete and continuous systems.
             if type(other) is not type(self):
-                raise TypeError('Cannot add {} and {}'.format(type(self),
-                                                              type(other)))
+                raise TypeError(f'Cannot add {type(self)} and {type(other)}')
 
             if self.dt != other.dt:
                 raise TypeError('Cannot add systems with different `dt`.')

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -439,8 +439,7 @@ def _init_freq_conv_axes(in1, in2, mode, axes, sorted_axes=False):
 
     if not all(s1[a] == s2[a] or s1[a] == 1 or s2[a] == 1
                for a in range(in1.ndim) if a not in axes):
-        raise ValueError("incompatible shapes for in1 and in2:"
-                         " {0} and {1}".format(s1, s2))
+        raise ValueError(f"incompatible shapes for in1 and in2: {s1} and {s2}")
 
     # Check that input sizes are compatible with 'valid' mode.
     if _inputs_swap_needed(mode, s1, s2, axes=axes):
@@ -2002,7 +2001,7 @@ def lfilter(b, a, x, axis=-1, zi=None):
         dtype = np.result_type(*inputs)
 
         if dtype.char not in 'fdgFDGO':
-            raise NotImplementedError("input type '%s' not supported" % dtype)
+            raise NotImplementedError(f"input type '{dtype}' not supported")
 
         b = np.array(b, dtype=dtype)
         a = np.array(a, dtype=dtype, copy=False)
@@ -4179,7 +4178,7 @@ def sosfilt(sos, x, axis=-1, zi=None):
         inputs.append(np.asarray(zi))
     dtype = np.result_type(*inputs)
     if dtype.char not in 'fdgFDGO':
-        raise NotImplementedError("input type '%s' not supported" % dtype)
+        raise NotImplementedError(f"input type '{dtype}' not supported")
     if zi is not None:
         zi = np.array(zi, dtype)  # make a copy so that we can operate in place
         if zi.shape != x_zi_shape:

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -1407,7 +1407,7 @@ def istft(Zxx, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
         if len(win.shape) != 1:
             raise ValueError('window must be 1-D')
         if win.shape[0] != nperseg:
-            raise ValueError('window must have length of {0}'.format(nperseg))
+            raise ValueError(f'window must have length of {nperseg}')
 
     ifunc = sp_fft.irfft if input_onesided else sp_fft.ifft
     xsubs = ifunc(Zxx, axis=-2, n=nfft)[..., :nperseg, :]
@@ -1801,7 +1801,7 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
     elif scaling == 'spectrum':
         scale = 1.0 / win.sum()**2
     else:
-        raise ValueError('Unknown scaling: %r' % scaling)
+        raise ValueError(f'Unknown scaling: {scaling!r}')
 
     if mode == 'stft':
         scale = np.sqrt(scale)

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -31,7 +31,7 @@ except ImportError:
 def mpmath_check(min_ver):
     return pytest.mark.skipif(mpmath is None or
                               LooseVersion(mpmath.__version__) < LooseVersion(min_ver),
-                              reason="mpmath version >= %s required" % min_ver)
+                              reason=f"mpmath version >= {min_ver} required")
 
 
 class TestCplxPair(object):
@@ -635,7 +635,7 @@ class TestFreqz(object):
             a = as_[ii]
             expected_w = np.linspace(0, 2 * np.pi, len(b), endpoint=False)
             w, h = freqz(b, a, worN=expected_w, whole=True)  # polyval
-            err_msg = 'b = %s, a=%s' % (b, a)
+            err_msg = f'b = {b}, a={a}'
             assert_array_almost_equal(w, expected_w, err_msg=err_msg)
             assert_array_almost_equal(h, hs_whole[ii], err_msg=err_msg)
             w, h = freqz(b, a, worN=len(b), whole=True)  # FFT
@@ -3415,15 +3415,15 @@ def test_sos_consistency():
 
         b, a = func(2, *args, output='ba')
         sos = func(2, *args, output='sos')
-        assert_allclose(sos, [np.hstack((b, a))], err_msg="%s(2,...)" % name)
+        assert_allclose(sos, [np.hstack((b, a))], err_msg=f"{name}(2,...)")
 
         zpk = func(3, *args, output='zpk')
         sos = func(3, *args, output='sos')
-        assert_allclose(sos, zpk2sos(*zpk), err_msg="%s(3,...)" % name)
+        assert_allclose(sos, zpk2sos(*zpk), err_msg=f"{name}(3,...)")
 
         zpk = func(4, *args, output='zpk')
         sos = func(4, *args, output='sos')
-        assert_allclose(sos, zpk2sos(*zpk), err_msg="%s(4,...)" % name)
+        assert_allclose(sos, zpk2sos(*zpk), err_msg=f"{name}(4,...)")
 
 
 class TestIIRNotch(object):

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -805,7 +805,7 @@ class TestFindPeaksCwt(object):
         diffs = np.abs(found_locs - act_locs)
         max_diffs = np.array(sigmas) / 5
         np.testing.assert_array_less(diffs, max_diffs, 'Maximum location differed' +
-                                     'by more than %s' % (max_diffs))
+                                     f'by more than {max_diffs}')
 
     def test_find_peaks_nopeak(self):
         """

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2226,7 +2226,7 @@ class TestSOSFiltFilt(TestFiltFilt):
             sos = zpk2sos(*zpk)
             y = filtfilt(b, a, x)
             y_sos = sosfiltfilt(sos, x)
-            assert_allclose(y, y_sos, atol=1e-12, err_msg='order=%s' % order)
+            assert_allclose(y, y_sos, atol=1e-12, err_msg=f'order={order}')
 
 
 def filtfilt_gust_opt(b, a, x):

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -462,7 +462,7 @@ class TestWelch(object):
                       0.55555558, 0.55555552, 0.55555552, 0.38194442], 'f')
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
         assert_(p.dtype == q.dtype,
-                'dtype mismatch, %s, %s' % (p.dtype, q.dtype))
+                f'dtype mismatch, {p.dtype}, {q.dtype}')
 
     def test_padded_freqs(self):
         x = np.zeros(12)
@@ -827,7 +827,7 @@ class TestCSD:
                       0.55555558, 0.55555552, 0.55555552, 0.38194442], 'f')
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
         assert_(p.dtype == q.dtype,
-                'dtype mismatch, %s, %s' % (p.dtype, q.dtype))
+                f'dtype mismatch, {p.dtype}, {q.dtype}')
 
     def test_padded_freqs(self):
         x = np.zeros(12)
@@ -1220,7 +1220,7 @@ class TestSTFT(object):
             tr, xr = istft(zz, nperseg=nperseg, noverlap=noverlap,
                            window=window)
 
-            msg = '{0}, {1}'.format(window, noverlap)
+            msg = f'{window}, {noverlap}'
             assert_allclose(t, tr, err_msg=msg)
             assert_allclose(x, xr, err_msg=msg)
 
@@ -1235,7 +1235,7 @@ class TestSTFT(object):
         ]
 
         for window, N, nperseg, noverlap in settings:
-            msg = '{0}, {1}, {2}, {3}'.format(window, N, nperseg, noverlap)
+            msg = f'{window}, {N}, {nperseg}, {noverlap}'
             assert not check_NOLA(window, nperseg, noverlap), msg
 
             t = np.arange(N)
@@ -1263,7 +1263,7 @@ class TestSTFT(object):
                     ]
 
         for window, N, nperseg, noverlap in settings:
-            msg = '{0}, {1}, {2}'.format(window, nperseg, noverlap)
+            msg = f'{window}, {nperseg}, {noverlap}'
             assert check_NOLA(window, nperseg, noverlap), msg
             assert not check_COLA(window, nperseg, noverlap), msg
 
@@ -1277,7 +1277,7 @@ class TestSTFT(object):
             tr, xr = istft(zz, nperseg=nperseg, noverlap=noverlap,
                            window=window, boundary=True)
 
-            msg = '{0}, {1}'.format(window, noverlap)
+            msg = f'{window}, {noverlap}'
             assert_allclose(t, tr[:len(t)], err_msg=msg)
             assert_allclose(x, xr[:len(x)], err_msg=msg)
 
@@ -1297,7 +1297,7 @@ class TestSTFT(object):
             tr, xr = istft(zz, nperseg=nperseg, noverlap=noverlap,
                            window=window)
 
-            msg = '{0}, {1}'.format(window, noverlap)
+            msg = f'{window}, {noverlap}'
             assert_allclose(t, t, err_msg=msg)
             assert_allclose(x, xr, err_msg=msg, rtol=1e-4, atol=1e-5)
             assert_(x.dtype == xr.dtype)
@@ -1325,7 +1325,7 @@ class TestSTFT(object):
             tr, xr = istft(zz, nperseg=nperseg, noverlap=noverlap,
                            window=window, input_onesided=False)
 
-            msg = '{0}, {1}, {2}'.format(window, nperseg, noverlap)
+            msg = f'{window}, {nperseg}, {noverlap}'
             assert_allclose(t, tr, err_msg=msg)
             assert_allclose(x, xr, err_msg=msg)
 
@@ -1340,7 +1340,7 @@ class TestSTFT(object):
         tr, xr = istft(zz, nperseg=nperseg, noverlap=noverlap,
                        window=window, input_onesided=False)
 
-        msg = '{0}, {1}, {2}'.format(window, nperseg, noverlap)
+        msg = f'{window}, {nperseg}, {noverlap}'
         assert_allclose(t, tr, err_msg=msg)
         assert_allclose(x, xr, err_msg=msg)
 
@@ -1373,7 +1373,7 @@ class TestSTFT(object):
                 _, xr_ext = istft(zz_ext, noverlap=noverlap, window=window,
                                 boundary=True)
 
-                msg = '{0}, {1}, {2}'.format(window, noverlap, boundary)
+                msg = f'{window}, {noverlap}, {boundary}'
                 assert_allclose(x, xr, err_msg=msg)
                 assert_allclose(x, xr_ext, err_msg=msg)
 
@@ -1394,7 +1394,7 @@ class TestSTFT(object):
 
             tr, xr = istft(zz, noverlap=noverlap, window=window)
 
-            msg = '{0}, {1}'.format(window, noverlap)
+            msg = f'{window}, {noverlap}'
             # Account for possible zero-padding at the end
             assert_allclose(t, tr[:t.size], err_msg=msg)
             assert_allclose(x, xr[:x.size], err_msg=msg)
@@ -1429,7 +1429,7 @@ class TestSTFT(object):
             tr, xcr = istft(zc, nperseg=nperseg, noverlap=noverlap, nfft=nfft,
                             window=window, input_onesided=False)
 
-            msg = '{0}, {1}'.format(window, noverlap)
+            msg = f'{window}, {noverlap}'
             assert_allclose(t, tr, err_msg=msg)
             assert_allclose(x, xr, err_msg=msg)
             assert_allclose(xc, xcr, err_msg=msg)

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -485,19 +485,19 @@ class TestDPSS(object):
             win = windows.dpss(M, M / 2.1)
             expected = M % 2  # one for odd, none for even
             assert_equal(np.isclose(win, 1.).sum(), expected,
-                         err_msg='%s' % (win,))
+                         err_msg=f'{win}')
             # corrected w/subsample delay (slower)
             win_sub = windows.dpss(M, M / 2.1, norm='subsample')
             if M > 2:
                 # @M=2 the subsample doesn't do anything
                 assert_equal(np.isclose(win_sub, 1.).sum(), expected,
-                             err_msg='%s' % (win_sub,))
+                             err_msg=f'{win_sub}')
                 assert_allclose(win, win_sub, rtol=0.03)  # within 3%
             # not the same, l2-norm
             win_2 = windows.dpss(M, M / 2.1, norm=2)
             expected = 1 if M == 1 else 0
             assert_equal(np.isclose(win_2, 1.).sum(), expected,
-                         err_msg='%s' % (win_2,))
+                         err_msg=f'{win_2}')
 
     def test_extremes(self):
         # Test extremes of alpha

--- a/scipy/signal/waveforms.py
+++ b/scipy/signal/waveforms.py
@@ -218,9 +218,9 @@ def gausspulse(t, fc=1000, bw=0.5, bwr=-6, tpr=-60, retquad=False,
 
     """
     if fc < 0:
-        raise ValueError("Center frequency (fc=%.2f) must be >=0." % fc)
+        raise ValueError(f"Center frequency (fc={fc:.2f}) must be >=0.")
     if bw <= 0:
-        raise ValueError("Fractional bandwidth (bw=%.2f) must be > 0." % bw)
+        raise ValueError(f"Fractional bandwidth (bw={bw:.2f}) must be > 0.")
     if bwr >= 0:
         raise ValueError("Reference level for bandwidth (bwr=%.2f) must "
                          "be < 0 dB" % bwr)

--- a/scipy/signal/windows/windows.py
+++ b/scipy/signal/windows/windows.py
@@ -1789,8 +1789,7 @@ def dpss(M, NW, Kmax=None, sym=True, norm=None, return_ratios=False):
         norm = 'approximate' if Kmax is None else 2
     known_norms = (2, 'approximate', 'subsample')
     if norm not in known_norms:
-        raise ValueError('norm must be one of %s, got %s'
-                         % (known_norms, norm))
+        raise ValueError(f'norm must be one of {known_norms}, got {norm}')
     if Kmax is None:
         singleton = True
         Kmax = 1

--- a/scipy/sparse/_matrix_io.py
+++ b/scipy/sparse/_matrix_io.py
@@ -60,7 +60,7 @@ def save_npz(file, matrix, compressed=True):
     elif matrix.format == 'coo':
         arrays_dict.update(row=matrix.row, col=matrix.col)
     else:
-        raise NotImplementedError('Save is not implemented for sparse matrix of format {}.'.format(matrix.format))
+        raise NotImplementedError(f'Save is not implemented for sparse matrix of format {matrix.format}.')
     arrays_dict.update(
         format=matrix.format.encode('ascii'),
         shape=matrix.shape,
@@ -124,7 +124,7 @@ def load_npz(file):
         try:
             matrix_format = loaded['format']
         except KeyError as e:
-            raise ValueError('The file {} does not contain a sparse matrix.'.format(file)) from e
+            raise ValueError(f'The file {file} does not contain a sparse matrix.') from e
 
         matrix_format = matrix_format.item()
 
@@ -134,9 +134,9 @@ def load_npz(file):
             matrix_format = matrix_format.decode('ascii')
 
         try:
-            cls = getattr(scipy.sparse, '{}_matrix'.format(matrix_format))
+            cls = getattr(scipy.sparse, f'{matrix_format}_matrix')
         except AttributeError as e:
-            raise ValueError('Unknown matrix format "{}"'.format(matrix_format)) from e
+            raise ValueError(f'Unknown matrix format "{matrix_format}"') from e
 
         if matrix_format in ('csc', 'csr', 'bsr'):
             return cls((loaded['data'], loaded['indices'], loaded['indptr']), shape=loaded['shape'])

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -151,7 +151,7 @@ class spmatrix(object):
         """
         # As an inplace operation, this requires implementation in each format.
         raise NotImplementedError(
-            '{}.resize is not implemented'.format(type(self).__name__))
+            f'{type(self).__name__}.resize is not implemented')
 
     def astype(self, dtype, casting='unsafe', copy=True):
         """Cast the matrix elements to a specified type.
@@ -315,7 +315,7 @@ class spmatrix(object):
             try:
                 convert_method = getattr(self, 'to' + format)
             except AttributeError as e:
-                raise ValueError('Format {} is unknown.'.format(format)) from e
+                raise ValueError(f'Format {format} is unknown.') from e
 
             # Forward the copy kwarg, if it's accepted.
             try:

--- a/scipy/sparse/bsr.py
+++ b/scipy/sparse/bsr.py
@@ -137,7 +137,7 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
                     blocksize = (1,1)
                 else:
                     if not isshape(blocksize):
-                        raise ValueError('invalid blocksize=%s' % blocksize)
+                        raise ValueError(f'invalid blocksize={blocksize}')
                     blocksize = tuple(blocksize)
                 self.data = np.zeros((0,) + blocksize, getdtype(dtype, default=float))
 

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -186,8 +186,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                     raise ValueError("{} index values must be < {}"
                                      "".format(minor_name, minor_dim))
                 if self.indices.min() < 0:
-                    raise ValueError("{} index values must be >= 0"
-                                     "".format(minor_name))
+                    raise ValueError(f"{minor_name} index values must be >= 0")
                 if np.diff(self.indptr).min() < 0:
                     raise ValueError("index pointer values must form a "
                                      "non-decreasing sequence")

--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -210,7 +210,7 @@ class csr_matrix(_cs_matrix):
             M,N = self.shape
 
             if R < 1 or C < 1 or M % R != 0 or N % C != 0:
-                raise ValueError('invalid blocksize %s' % blocksize)
+                raise ValueError(f'invalid blocksize {blocksize}')
 
             blks = csr_count_blocks(M,N,R,C,self.indptr,self.indices)
 

--- a/scipy/sparse/generate_sparsetools.py
+++ b/scipy/sparse/generate_sparsetools.py
@@ -291,7 +291,7 @@ def parse_routine(name, args, types):
             elif t == 'l':
                 args.append("*(%snpy_int64*)a[%d]" % (const, j))
             else:
-                raise ValueError("Invalid spec character %r" % (t,))
+                raise ValueError(f"Invalid spec character {t!r}")
             j += 1
         return ", ".join(args)
 
@@ -302,9 +302,9 @@ def parse_routine(name, args, types):
     for j, I_typenum, T_typenum, I_type, T_type in types:
         arglist = get_arglist(I_type, T_type)
         if T_type is None:
-            dispatch = "%s" % (I_type,)
+            dispatch = f"{I_type}"
         else:
-            dispatch = "%s,%s" % (I_type, T_type)
+            dispatch = f"{I_type},{T_type}"
         if 'B' in arg_spec:
             dispatch += ",npy_bool_wrapper"
 
@@ -362,7 +362,7 @@ def main():
             try:
                 name, args = line.split(None, 1)
             except ValueError as e:
-                raise ValueError("Malformed line: %r" % (line,)) from e
+                raise ValueError(f"Malformed line: {line!r}") from e
 
             args = "".join(args.split())
             if 't' in args or 'T' in args:
@@ -371,7 +371,7 @@ def main():
                 thunk, method = parse_routine(name, args, i_types)
 
             if name in names:
-                raise ValueError("Duplicate routine %r" % (name,))
+                raise ValueError(f"Duplicate routine {name!r}")
 
             names.append(name)
             thunks.append(thunk)
@@ -382,7 +382,7 @@ def main():
                            'sparsetools',
                            unit_name + '_impl.h')
         if newer(__file__, dst) or options.force:
-            print("[generate_sparsetools] generating %r" % (dst,))
+            print(f"[generate_sparsetools] generating {dst!r}")
             with open(dst, 'w') as f:
                 write_autogen_blurb(f)
                 f.write(getter_code)
@@ -391,12 +391,12 @@ def main():
                 for method in methods:
                     f.write(method)
         else:
-            print("[generate_sparsetools] %r already up-to-date" % (dst,))
+            print(f"[generate_sparsetools] {dst!r} already up-to-date")
 
     # Generate code for method struct
     method_defs = ""
     for name in names:
-        method_defs += "NPY_VISIBILITY_HIDDEN PyObject *%s_method(PyObject *, PyObject *);\n" % (name,)
+        method_defs += f"NPY_VISIBILITY_HIDDEN PyObject *{name}_method(PyObject *, PyObject *);\n"
 
     method_struct = """\nstatic struct PyMethodDef sparsetools_methods[] = {"""
     for name in names:
@@ -412,13 +412,13 @@ def main():
                        'sparsetools_impl.h')
 
     if newer(__file__, dst) or options.force:
-        print("[generate_sparsetools] generating %r" % (dst,))
+        print(f"[generate_sparsetools] generating {dst!r}")
         with open(dst, 'w') as f:
             write_autogen_blurb(f)
             f.write(method_defs)
             f.write(method_struct)
     else:
-        print("[generate_sparsetools] %r already up-to-date" % (dst,))
+        print(f"[generate_sparsetools] {dst!r} already up-to-date")
 
 
 def write_autogen_blurb(stream):

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -178,7 +178,7 @@ class lil_matrix(spmatrix, IndexMixin):
         val = ''
         for i, row in enumerate(self.rows):
             for pos, j in enumerate(row):
-                val += "  %s\t%s\n" % (str((i, j)), str(self.data[i][pos]))
+                val += f"  {str((i, j))}\t{str(self.data[i][pos])}\n"
         return val[:-1]
 
     def getrowview(self, i):

--- a/scipy/sparse/linalg/dsolve/linsolve.py
+++ b/scipy/sparse/linalg/dsolve/linsolve.py
@@ -162,7 +162,7 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
     # validate input shapes
     M, N = A.shape
     if (M != N):
-        raise ValueError("matrix must be square (has shape %s)" % ((M, N),))
+        raise ValueError(f"matrix must be square (has shape {M, N})")
 
     if M != b.shape[0]:
         raise ValueError("matrix - rhs dimension mismatch (%s - %s)"
@@ -558,7 +558,7 @@ def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False,
 
     if A.shape[0] != A.shape[1]:
         raise ValueError(
-            'A must be a square matrix but its shape is {}.'.format(A.shape))
+            f'A must be a square matrix but its shape is {A.shape}.')
 
     # sum duplicates for non-canonical format
     A.sum_duplicates()
@@ -567,7 +567,7 @@ def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False,
 
     if b.ndim not in [1, 2]:
         raise ValueError(
-            'b must have 1 or 2 dims but its shape is {}.'.format(b.shape))
+            f'b must have 1 or 2 dims but its shape is {b.shape}.')
     if A.shape[0] != b.shape[0]:
         raise ValueError(
             'The size of the dimensions of A must be equal to '
@@ -609,7 +609,7 @@ def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False,
         if not unit_diagonal and (indptr_stop <= indptr_start
                                   or A.indices[A_diagonal_index_row_i] < i):
             raise LinAlgError(
-                'A is singular: diagonal {} is zero.'.format(i))
+                f'A is singular: diagonal {i} is zero.')
         if A.indices[A_diagonal_index_row_i] > i:
             raise LinAlgError(
                 'A is not triangular: A[{}, {}] is nonzero.'

--- a/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
@@ -379,7 +379,7 @@ class TestLinsolve(object):
             badops = [not_c_contig, not_1dim, bad_type, too_short]
 
             for badop in badops:
-                msg = "%r %r" % (spmatrix, badop)
+                msg = f"{spmatrix!r} {badop!r}"
                 # Not C-contiguous
                 assert_raises((ValueError, TypeError), _superlu.gssv,
                               N, A.nnz, badop(A.data), A.indices, A.indptr,
@@ -456,7 +456,7 @@ class TestSplu(object):
 
         # Input shapes
         for k in [None, 1, 2, self.n, self.n+2]:
-            msg = "k=%r" % (k,)
+            msg = f"k={k!r}"
 
             if k is None:
                 b = rng.rand(self.n)

--- a/scipy/sparse/linalg/eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/arpack.py
@@ -369,7 +369,7 @@ class _ArpackParams(object):
         try:
             ev, vec = self.extract(True)
         except ArpackError as err:
-            msg = "%s [%s]" % (msg, err)
+            msg = f"{msg} [{err}]"
             ev = np.zeros((0,))
             vec = np.zeros((self.n, 0))
             k_ok = 0
@@ -504,8 +504,7 @@ class _SymmetricArpackParams(_ArpackParams):
             raise ValueError("mode=%i not implemented" % mode)
 
         if which not in _SEUPD_WHICH:
-            raise ValueError("which must be one of %s"
-                             % ' '.join(_SEUPD_WHICH))
+            raise ValueError(f"which must be one of {' '.join(_SEUPD_WHICH)}")
         if k >= n:
             raise ValueError("k must be less than ndim(A), k=%d" % k)
 
@@ -513,7 +512,7 @@ class _SymmetricArpackParams(_ArpackParams):
                                ncv, v0, maxiter, which, tol)
 
         if self.ncv > n or self.ncv <= k:
-            raise ValueError("ncv must be k<ncv<=n, ncv=%s" % self.ncv)
+            raise ValueError(f"ncv must be k<ncv<=n, ncv={self.ncv}")
 
         # Use _aligned_zeros to work around a f2py bug in Numpy 1.9.1
         self.workd = _aligned_zeros(3 * n, self.tp)
@@ -696,7 +695,7 @@ class _UnsymmetricArpackParams(_ArpackParams):
                                ncv, v0, maxiter, which, tol)
 
         if self.ncv > n or self.ncv <= k + 1:
-            raise ValueError("ncv must be k+1<ncv<=n, ncv=%s" % self.ncv)
+            raise ValueError(f"ncv must be k+1<ncv<=n, ncv={self.ncv}")
 
         # Use _aligned_zeros to work around a f2py bug in Numpy 1.9.1
         self.workd = _aligned_zeros(3 * n, self.tp)
@@ -1248,7 +1247,7 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
 
     """
     if A.shape[0] != A.shape[1]:
-        raise ValueError('expected square matrix (shape=%s)' % (A.shape,))
+        raise ValueError(f'expected square matrix (shape={A.shape})')
     if M is not None:
         if M.shape != A.shape:
             raise ValueError('wrong M dimensions %s, should be %s'
@@ -1575,7 +1574,7 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
             return ret.real
 
     if A.shape[0] != A.shape[1]:
-        raise ValueError('expected square matrix (shape=%s)' % (A.shape,))
+        raise ValueError(f'expected square matrix (shape={A.shape})')
     if M is not None:
         if M.shape != A.shape:
             raise ValueError('wrong M dimensions %s, should be %s'
@@ -1679,7 +1678,7 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
 
         # unrecognized mode
         else:
-            raise ValueError("unrecognized mode '%s'" % mode)
+            raise ValueError(f"unrecognized mode '{mode}'")
 
     params = _SymmetricArpackParams(n, k, A.dtype.char, matvec, mode,
                                     M_matvec, Minv_matvec, sigma,

--- a/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
@@ -155,7 +155,7 @@ def argsort_which(eigenvalues, typ, k, which,
         elif mode == 'buckling':
             reval = eigenvalues / (eigenvalues - sigma)
         else:
-            raise ValueError("mode='%s' not recognized" % mode)
+            raise ValueError(f"mode='{mode}' not recognized")
 
         reval = np.round(reval, decimals=_ndigits[typ])
 
@@ -170,7 +170,7 @@ def argsort_which(eigenvalues, typ, k, which,
         else:
             ind = np.argsort(np.imag(reval))
     else:
-        raise ValueError("which='%s' is unrecognized" % which)
+        raise ValueError(f"which='{which}' is unrecognized")
 
     if which in ['LM', 'LA', 'LR', 'LI']:
         return ind[-k:]
@@ -277,7 +277,7 @@ class DictWithRepr(dict):
         self.name = name
 
     def __repr__(self):
-        return "<%s>" % self.name
+        return f"<{self.name}>"
 
 
 class SymmetricParams:
@@ -558,7 +558,7 @@ def sorted_svd(m, k, which='LM'):
     elif which == 'SM':
         ii = np.argsort(s)[:k]
     else:
-        raise ValueError("unknown which=%r" % (which,))
+        raise ValueError(f"unknown which={which!r}")
 
     return u[:, ii], s[ii], vh[ii]
 

--- a/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
@@ -40,7 +40,7 @@ def _report_nonhermitian(M, name):
     if nmd > tol:
         print('matrix %s of the type %s is not sufficiently Hermitian:'
               % (name, M.dtype))
-        print('condition: %.e < %e' % (nmd, tol))
+        print(f'condition: {nmd:.e} < {tol:e}')
 
 
 def _as2d(ar):

--- a/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
@@ -40,7 +40,7 @@ def _report_nonhermitian(M, name):
     if nmd > tol:
         print('matrix %s of the type %s is not sufficiently Hermitian:'
               % (name, M.dtype))
-        print(f'condition: {nmd:.e} < {tol:e}')
+        print('condition: %.e < %e' % (nmd, tol))
 
 
 def _as2d(ar):

--- a/scipy/sparse/linalg/interface.py
+++ b/scipy/sparse/linalg/interface.py
@@ -165,7 +165,7 @@ class LinearOperator(object):
 
         shape = tuple(shape)
         if not isshape(shape):
-            raise ValueError("invalid shape %r (must be 2-d)" % (shape,))
+            raise ValueError(f"invalid shape {shape!r} (must be 2-d)")
 
         self.dtype = dtype
         self.shape = shape
@@ -607,8 +607,7 @@ class _SumLinearOperator(LinearOperator):
                 not isinstance(B, LinearOperator):
             raise ValueError('both operands have to be a LinearOperator')
         if A.shape != B.shape:
-            raise ValueError('cannot add %r and %r: shape mismatch'
-                             % (A, B))
+            raise ValueError(f'cannot add {A!r} and {B!r}: shape mismatch')
         self.args = (A, B)
         super(_SumLinearOperator, self).__init__(_get_dtype([A, B]), A.shape)
 
@@ -690,7 +689,7 @@ class _PowerLinearOperator(LinearOperator):
         if not isinstance(A, LinearOperator):
             raise ValueError('LinearOperator expected as A')
         if A.shape[0] != A.shape[1]:
-            raise ValueError('square LinearOperator expected, got %r' % A)
+            raise ValueError(f'square LinearOperator expected, got {A!r}')
         if not isintlike(p) or p < 0:
             raise ValueError('non-negative integer expected as p')
 

--- a/scipy/sparse/linalg/isolve/_gcrotmk.py
+++ b/scipy/sparse/linalg/isolve/_gcrotmk.py
@@ -267,7 +267,7 @@ def gcrotmk(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
         raise ValueError("RHS must contain only finite numbers")
 
     if truncate not in ('oldest', 'smallest'):
-        raise ValueError("Invalid value for 'truncate': %r" % (truncate,))
+        raise ValueError(f"Invalid value for 'truncate': {truncate!r}")
 
     if atol is None:
         warnings.warn("scipy.sparse.linalg.gcrotmk called without specifying `atol`. "

--- a/scipy/sparse/linalg/isolve/iterative.py
+++ b/scipy/sparse/linalg/isolve/iterative.py
@@ -545,7 +545,7 @@ def gmres(A, b, x0=None, tol=1e-5, restart=None, maxiter=None, M=None, callback=
         callback_type = 'legacy'
 
     if callback_type not in ('x', 'pr_norm', 'legacy'):
-        raise ValueError("Unknown callback_type: {!r}".format(callback_type))
+        raise ValueError(f"Unknown callback_type: {callback_type!r}")
 
     if callback is None:
         callback_type = 'none'

--- a/scipy/sparse/linalg/isolve/minres.py
+++ b/scipy/sparse/linalg/isolve/minres.py
@@ -341,7 +341,7 @@ def minres(A, b, x0=None, shift=0.0, tol=1e-5, maxiter=None,
 
     if show:
         print()
-        print(last + ' istop   =  %3g               itn   =%5g' % (istop,itn))
+        print(last + f' istop   =  {istop:3g}               itn   ={itn:5g}')
         print(last + ' Anorm   =  %12.4e      Acond =  %12.4e' % (Anorm,Acond))
         print(last + ' rnorm   =  %12.4e      ynorm =  %12.4e' % (rnorm,ynorm))
         print(last + ' Arnorm  =  %12.4e' % (Arnorm,))

--- a/scipy/sparse/linalg/isolve/tests/demo_lgmres.py
+++ b/scipy/sparse/linalg/isolve/tests/demo_lgmres.py
@@ -9,11 +9,11 @@ problem = "SPARSKIT/drivcav/e05r0200"
 #problem = "misc/hamm/add32"
 
 mm = np.lib._datasource.Repository('ftp://math.nist.gov/pub/MatrixMarket2/')
-f = mm.open('%s.mtx.gz' % problem)
+f = mm.open(f'{problem}.mtx.gz')
 Am = io.mmread(f).tocsr()
 f.close()
 
-f = mm.open('%s_rhs1.mtx.gz' % problem)
+f = mm.open(f'{problem}_rhs1.mtx.gz')
 b = np.array(io.mmread(f)).ravel()
 f.close()
 
@@ -30,7 +30,7 @@ A = la.LinearOperator(matvec=matvec, shape=Am.shape, dtype=Am.dtype)
 
 M = 100
 
-print("MatrixMarket problem %s" % problem)
+print(f"MatrixMarket problem {problem}")
 print("Invert %d x %d matrix; nnz = %d" % (Am.shape[0], Am.shape[1], Am.nnz))
 
 count[0] = 0

--- a/scipy/sparse/linalg/isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/isolve/tests/test_iterative.py
@@ -39,7 +39,7 @@ class Case(object):
             self.nonconvergence = nonconvergence
 
     def __repr__(self):
-        return "<%s>" % self.name
+        return f"<{self.name}>"
 
 
 class IterativeParams(object):
@@ -197,7 +197,7 @@ def test_maxiter():
 def assert_normclose(a, b, tol=1e-8):
     residual = norm(a - b)
     tolerance = tol*norm(b)
-    msg = "residual (%g) not smaller than tolerance %g" % (residual, tolerance)
+    msg = f"residual ({residual:g}) not smaller than tolerance {tolerance:g}"
     assert_(residual < tolerance, msg=msg)
 
 

--- a/scipy/sparse/linalg/isolve/tests/test_lsqr.py
+++ b/scipy/sparse/linalg/isolve/tests/test_lsqr.py
@@ -122,8 +122,8 @@ if __name__ == "__main__":
 
     print('LSQR')
     print("Is linear operator symmetric? " + sym)
-    print("n: %3g  iterations:   %3g" % (n, k))
-    print("Norms computed in %.2fs by LSQR" % (time() - tic))
+    print(f"n: {n:3g}  iterations:   {k:3g}")
+    print(f"Norms computed in {time() - tic:.2f}s by LSQR")
     print(" ||x||  %9.4e  ||r|| %9.4e  ||Ar||  %9.4e " % (chio, phio, psio))
     print("Residual norms computed directly:")
     print(" ||x||  %9.4e  ||r|| %9.4e  ||Ar||  %9.4e" % (norm(xo),

--- a/scipy/sparse/linalg/isolve/utils.py
+++ b/scipy/sparse/linalg/isolve/utils.py
@@ -64,7 +64,7 @@ def make_system(A, M, x0, b):
     A = aslinearoperator(A)
 
     if A.shape[0] != A.shape[1]:
-        raise ValueError('expected square matrix, but got shape=%s' % (A.shape,))
+        raise ValueError(f'expected square matrix, but got shape={A.shape}')
 
     N = A.shape[0]
 

--- a/scipy/sparse/linalg/tests/test_onenormest.py
+++ b/scipy/sparse/linalg/tests/test_onenormest.py
@@ -214,7 +214,7 @@ class TestOnenormest(object):
         fast_estimate = self._help_product_norm_fast(A, B)
         exact_value = self._help_product_norm_slow(A, B)
         assert_(fast_estimate <= exact_value <= 3*fast_estimate,
-                'fast: %g\nexact:%g' % (fast_estimate, exact_value))
+                f'fast: {fast_estimate:g}\nexact:{exact_value:g}')
 
     def test_returns(self):
         np.random.seed(1234)

--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -48,7 +48,7 @@ def upcast(*args):
             _upcast_memo[hash(args)] = t
             return t
 
-    raise TypeError('no supported conversion for types: %r' % (args,))
+    raise TypeError(f'no supported conversion for types: {args!r}')
 
 
 def upcast_char(*args):

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -54,7 +54,7 @@ IS_COLAB = ('google.colab' in sys.modules)
 
 
 def assert_in(member, collection, msg=None):
-    assert_(member in collection, msg=msg if msg is not None else "%r not found in %r" % (member, collection))
+    assert_(member in collection, msg=msg if msg is not None else f"{member!r} not found in {collection!r}")
 
 
 def assert_array_equal_dtype(x, y, **kwargs):
@@ -2246,7 +2246,7 @@ class _TestGetSet(object):
         n, m = (5, 10)
 
         def _test_set(i, j, nitems):
-            msg = "%r ; %r ; %r" % (i, j, nitems)
+            msg = f"{i!r} ; {j!r} ; {nitems!r}"
             A = self.spmatrix((n, m))
             with suppress_warnings() as sup:
                 sup.filter(SparseEfficiencyWarning,
@@ -2515,7 +2515,7 @@ class _TestSlicingAssign(object):
         n, m = (5, 10)
 
         def _test_set(i, j):
-            msg = "i=%r; j=%r" % (i, j)
+            msg = f"i={i!r}; j={j!r}"
             A = self.spmatrix((n, m))
             with suppress_warnings() as sup:
                 sup.filter(SparseEfficiencyWarning,
@@ -3998,7 +3998,7 @@ class TestLIL(sparse_test_class(minmax=False)):
 
         for op, (other, expected) in data.items():
             result = A.copy()
-            getattr(result, '__i%s__' % op)(other)
+            getattr(result, f'__i{op}__')(other)
 
             assert_array_equal(result.todense(), expected.todense())
 
@@ -4693,7 +4693,7 @@ class Test64Bit(object):
         elif isinstance(m, dia_matrix):
             return (m.offsets.dtype == dtype)
         else:
-            raise ValueError("matrix %r has no integer indices" % (m,))
+            raise ValueError(f"matrix {m!r} has no integer indices")
 
     def test_decorator_maxval_limit(self):
         # Test that the with_64bit_maxval_limit decorator works

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -136,7 +136,7 @@ class TestConstructUtils(object):
                                                     [0, 1, -2]]))
 
         for d, o, shape, result in cases:
-            err_msg = "%r %r %r %r" % (d, o, shape, result)
+            err_msg = f"{d!r} {o!r} {shape!r} {result!r}"
             assert_equal(construct.diags(d, o, shape=shape).todense(),
                          result, err_msg=err_msg)
 

--- a/scipy/sparse/tests/test_sparsetools.py
+++ b/scipy/sparse/tests/test_sparsetools.py
@@ -285,7 +285,7 @@ def test_upcast():
 
     for a_dtype in supported_dtypes:
         for b_dtype in supported_dtypes:
-            msg = "(%r, %r)" % (a_dtype, b_dtype)
+            msg = f"({a_dtype!r}, {b_dtype!r})"
 
             if np.issubdtype(a_dtype, np.complexfloating):
                 a = a0.copy().astype(a_dtype)

--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -186,7 +186,7 @@ class SphericalVoronoi:
         self._rank = np.linalg.matrix_rank(self.points - self.points[0],
                                            tol=threshold * self.radius)
         if self._rank < self._dim:
-            raise ValueError("Rank of input points must be at least {0}".format(self._dim))
+            raise ValueError(f"Rank of input points must be at least {self._dim}")
 
         if cKDTree(self.points).query_pairs(threshold * self.radius):
             raise ValueError("Duplicate generators present.")

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -1736,12 +1736,12 @@ def _select_weighted_metric(mstr, kwargs, out):
     elif "w" in kwargs:
         if (mstr in _METRICS['seuclidean'].aka or
                 mstr in _METRICS['mahalanobis'].aka):
-            raise ValueError("metric %s incompatible with weights" % mstr)
+            raise ValueError(f"metric {mstr} incompatible with weights")
 
         # XXX: C-versions do not support weights
         # need to use python version for weighting
         kwargs['out'] = out
-        mstr = "test_%s" % mstr
+        mstr = f"test_{mstr}"
 
     return mstr, kwargs
 
@@ -2082,7 +2082,7 @@ def pdist(X, metric='euclidean', *args, **kwargs):
 
             # get pdist wrapper
             pdist_fn = getattr(_distance_wrap,
-                               "pdist_%s_%s_wrap" % (metric_name, typ))
+                               f"pdist_{metric_name}_{typ}_wrap")
             pdist_fn(X, dm, **kwargs)
             return dm
 
@@ -2105,9 +2105,9 @@ def pdist(X, metric='euclidean', *args, **kwargs):
             if mstr in _TEST_METRICS:
                 dm = pdist(X, _TEST_METRICS[mstr], **kwargs)
             else:
-                raise ValueError('Unknown "Test" Distance Metric: %s' % mstr[5:])
+                raise ValueError(f'Unknown "Test" Distance Metric: {mstr[5:]}')
         else:
-            raise ValueError('Unknown Distance Metric: %s' % mstr)
+            raise ValueError(f'Unknown Distance Metric: {mstr}')
     else:
         raise TypeError('2nd argument metric must be a string identifier '
                         'or a function.')
@@ -2803,7 +2803,7 @@ def cdist(XA, XB, metric='euclidean', *args, **kwargs):
 
             # get cdist wrapper
             cdist_fn = getattr(_distance_wrap,
-                               "cdist_%s_%s_wrap" % (metric_name, typ))
+                               f"cdist_{metric_name}_{typ}_wrap")
             cdist_fn(XA, XB, dm, **kwargs)
             return dm
 
@@ -2811,9 +2811,9 @@ def cdist(XA, XB, metric='euclidean', *args, **kwargs):
             if mstr in _TEST_METRICS:
                 dm = cdist(XA, XB, _TEST_METRICS[mstr], **kwargs)
             else:
-                raise ValueError('Unknown "Test" Distance Metric: %s' % mstr[5:])
+                raise ValueError(f'Unknown "Test" Distance Metric: {mstr[5:]}')
         else:
-            raise ValueError('Unknown Distance Metric: %s' % mstr)
+            raise ValueError(f'Unknown Distance Metric: {mstr}')
     else:
         raise TypeError('2nd argument metric must be a string identifier '
                         'or a function.')

--- a/scipy/spatial/kdtree.py
+++ b/scipy/spatial/kdtree.py
@@ -92,7 +92,7 @@ class Rectangle(object):
         self.m, = self.maxes.shape
 
     def __repr__(self):
-        return "<Rectangle %s>" % list(zip(self.mins, self.maxes))
+        return f"<Rectangle {list(zip(self.mins, self.maxes))}>"
 
     def volume(self):
         """Total volume."""

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -197,7 +197,7 @@ def _freq_weights(weights):
         return weights
     int_weights = weights.astype(int)
     if (weights != int_weights).any():
-        raise ValueError("frequency (integer count-type) weights required %s" % weights)
+        raise ValueError(f"frequency (integer count-type) weights required {weights}")
     return int_weights
 
 
@@ -356,7 +356,7 @@ def _weight_checked(fn, n_args=2, default_axis=None, key=lambda x: x, weight_arg
             # when some combination of arguments makes weighting impossible,
             #  this is the desired response
             if not silent:
-                warnings.warn("%s NotImplemented weights: %s" % (fn.__name__, e))
+                warnings.warn(f"{fn.__name__} NotImplemented weights: {e}")
         return result
     return wrapped
 

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -53,7 +53,7 @@ class ConsistencyTests:
                 continue
             hits += 1
             assert_almost_equal(near_d**2, np.sum((x-self.data[near_i])**2))
-            assert_(near_d < d+eps, "near_d=%g should be less than %g" % (near_d, d))
+            assert_(near_d < d+eps, f"near_d={near_d:g} should be less than {d:g}")
         assert_equal(np.sum(self.distance(self.data, x, 2) < d**2+eps), hits)
 
     def test_points_near_l1(self):
@@ -67,7 +67,7 @@ class ConsistencyTests:
                 continue
             hits += 1
             assert_almost_equal(near_d, self.distance(x, self.data[near_i], 1))
-            assert_(near_d < d+eps, "near_d=%g should be less than %g" % (near_d, d))
+            assert_(near_d < d+eps, f"near_d={near_d:g} should be less than {d:g}")
         assert_equal(np.sum(self.distance(self.data, x, 1) < d+eps), hits)
 
     def test_points_near_linf(self):
@@ -81,7 +81,7 @@ class ConsistencyTests:
                 continue
             hits += 1
             assert_almost_equal(near_d, self.distance(x, self.data[near_i], np.inf))
-            assert_(near_d < d+eps, "near_d=%g should be less than %g" % (near_d, d))
+            assert_(near_d < d+eps, f"near_d={near_d:g} should be less than {d:g}")
         assert_equal(np.sum(self.distance(self.data, x, np.inf) < d+eps), hits)
 
     def test_approx(self):

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -192,7 +192,7 @@ class TestUtilities(object):
                   (0.75, 0.75, 0),
                   (0.3, 0.2, 1)]:
             i = tri.find_simplex(p[:2])
-            assert_equal(i, p[2], err_msg='%r' % (p,))
+            assert_equal(i, p[2], err_msg=f'{p!r}')
             j = qhull.tsearch(tri, p[:2])
             assert_equal(i, j)
 
@@ -306,20 +306,20 @@ class TestUtilities(object):
         with np.errstate(invalid="ignore"):
             ok = np.isnan(c).all(axis=1) | (abs(c - sc)/sc < 0.1).all(axis=1)
 
-        assert_(ok.all(), "%s %s" % (err_msg, np.nonzero(~ok)))
+        assert_(ok.all(), f"{err_msg} {np.nonzero(~ok)}")
 
         # Invalid simplices must be (nearly) zero volume
         q = vertices[:,:-1,:] - vertices[:,-1,None,:]
         volume = np.array([np.linalg.det(q[k,:,:])
                            for k in range(tri.nsimplex)])
         ok = np.isfinite(tri.transform[:,0,0]) | (volume < np.sqrt(eps))
-        assert_(ok.all(), "%s %s" % (err_msg, np.nonzero(~ok)))
+        assert_(ok.all(), f"{err_msg} {np.nonzero(~ok)}")
 
         # Also, find_simplex for the centroid should end up in some
         # simplex for the non-degenerate cases
         j = tri.find_simplex(centroids)
         ok = (j != -1) | np.isnan(tri.transform[:,0,0])
-        assert_(ok.all(), "%s %s" % (err_msg, np.nonzero(~ok)))
+        assert_(ok.all(), f"{err_msg} {np.nonzero(~ok)}")
 
         if unit_cube:
             # If in unit cube, no interior point should be marked out of hull
@@ -327,7 +327,7 @@ class TestUtilities(object):
             at_boundary |= (centroids >= 1 - unit_cube_tol).any(axis=1)
 
             ok = (j != -1) | at_boundary
-            assert_(ok.all(), "%s %s" % (err_msg, np.nonzero(~ok)))
+            assert_(ok.all(), f"{err_msg} {np.nonzero(~ok)}")
 
     def test_degenerate_barycentric_transforms(self):
         # The triangulation should not produce invalid barycentric
@@ -397,7 +397,7 @@ class TestVertexNeighborVertices(object):
         got = [set(map(int, indices[indptr[j]:indptr[j+1]]))
                for j in range(tri.points.shape[0])]
 
-        assert_equal(got, expected, err_msg="%r != %r" % (got, expected))
+        assert_equal(got, expected, err_msg=f"{got!r} != {expected!r}")
 
     def test_triangle(self):
         points = np.array([(0,0), (0,1), (1,0)], dtype=np.double)

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -103,7 +103,7 @@ def _nonneg_int_or_fail(n, var_name, strict=True):
         if n < 0:
             raise ValueError()
     except (ValueError, TypeError) as err:
-        raise err.__class__("{} must be a non-negative integer".format(var_name)) from err
+        raise err.__class__(f"{var_name} must be a non-negative integer") from err
     return n
 
 

--- a/scipy/special/_mptestutils.py
+++ b/scipy/special/_mptestutils.py
@@ -277,9 +277,9 @@ class MpmathData(object):
 
     def __repr__(self):
         if self.is_complex:
-            return "<MpmathData: %s (complex)>" % (self.name,)
+            return f"<MpmathData: {self.name} (complex)>"
         else:
-            return "<MpmathData: %s>" % (self.name,)
+            return f"<MpmathData: {self.name}>"
 
 
 def assert_mpmath_equal(*a, **kw):
@@ -319,11 +319,11 @@ def trace_args(func):
             return float(x)
 
     def wrap(*a, **kw):
-        sys.stderr.write("%r: " % (tuple(map(tofloat, a)),))
+        sys.stderr.write(f"{tuple(map(tofloat, a))!r}: ")
         sys.stderr.flush()
         try:
             r = func(*a, **kw)
-            sys.stderr.write("-> %r" % r)
+            sys.stderr.write(f"-> {r!r}")
         finally:
             sys.stderr.write("\n")
             sys.stderr.flush()
@@ -449,6 +449,6 @@ def mp_assert_allclose(res, std, atol=0, rtol=1e-17):
         else:
             rdiff = mpmath.fabs((res[k] - std[k])/std[k])
             rdiff = mpmath.nstr(rdiff, 3)
-        msg.append("{}: {} != {} (rdiff {})".format(k, resrep, stdrep, rdiff))
+        msg.append(f"{k}: {resrep} != {stdrep} (rdiff {rdiff})")
     if failures:
         assert_(False, "\n".join(msg))

--- a/scipy/special/_precompute/expn_asy.py
+++ b/scipy/special/_precompute/expn_asy.py
@@ -39,14 +39,14 @@ def main():
     A = generate_A(K)
     with open(fn + '.new', 'w') as f:
         f.write(WARNING)
-        f.write("#define nA {}\n".format(len(A)))
+        f.write(f"#define nA {len(A)}\n")
         for k, Ak in enumerate(A):
             tmp = ', '.join([str(x.evalf(18)) for x in Ak.coeffs()])
-            f.write("static const double A{}[] = {{{}}};\n".format(k, tmp))
+            f.write(f"static const double A{k}[] = {{{tmp}}};\n")
         tmp = ", ".join(["A{}".format(k) for k in range(K + 1)])
-        f.write("static const double *A[] = {{{}}};\n".format(tmp))
+        f.write(f"static const double *A[] = {{{tmp}}};\n")
         tmp = ", ".join([str(Ak.degree()) for Ak in A])
-        f.write("static const int Adegs[] = {{{}}};\n".format(tmp))
+        f.write(f"static const int Adegs[] = {{{tmp}}};\n")
     os.rename(fn + '.new', fn)
 
 

--- a/scipy/special/_precompute/gammainc_data.py
+++ b/scipy/special/_precompute/gammainc_data.py
@@ -114,10 +114,10 @@ def main():
             dataset.append((a0, x0, func(a0, x0)))
         dataset = np.array(dataset)
         filename = os.path.join(pwd, '..', 'tests', 'data', 'local',
-                                '{}.txt'.format(func.__name__))
+                                f'{func.__name__}.txt')
         np.savetxt(filename, dataset)
 
-    print("{} minutes elapsed".format((time() - t0)/60))
+    print(f"{(time() - t0) / 60} minutes elapsed")
 
 
 if __name__ == "__main__":

--- a/scipy/special/_precompute/lambertw.py
+++ b/scipy/special/_precompute/lambertw.py
@@ -23,8 +23,8 @@ def main():
     with mpmath.workdps(50):
         p, q = lambertw_pade()
         p, q = p[::-1], q[::-1]
-        print("p = {}".format(p))
-        print("q = {}".format(q))
+        print(f"p = {p}")
+        print(f"q = {q}")
 
     x, y = np.linspace(-1.5, 1.5, 75), np.linspace(-1.5, 1.5, 75)
     x, y = np.meshgrid(x, y)

--- a/scipy/special/_testutils.py
+++ b/scipy/special/_testutils.py
@@ -23,9 +23,9 @@ class MissingModule(object):
 
 def check_version(module, min_ver):
     if type(module) == MissingModule:
-        return pytest.mark.skip(reason="{} is not installed".format(module.name))
+        return pytest.mark.skip(reason=f"{module.name} is not installed")
     return pytest.mark.skipif(LooseVersion(module.__version__) < LooseVersion(min_ver),
-                              reason="{} version >= {} required".format(module.__name__, min_ver))
+                              reason=f"{module.__name__} version >= {min_ver} required")
 
 
 #------------------------------------------------------------------------------
@@ -289,8 +289,8 @@ class FuncData(object):
             if np.any(bad_j):
                 # Some bad results: inform what, where, and how bad
                 msg = [""]
-                msg.append("Max |adiff|: %g" % diff[bad_j].max())
-                msg.append("Max |rdiff|: %g" % rdiff[bad_j].max())
+                msg.append(f"Max |adiff|: {diff[bad_j].max():g}")
+                msg.append(f"Max |rdiff|: {rdiff[bad_j].max():g}")
                 msg.append("Bad results (%d out of %d) for the following points (in output %d):"
                            % (np.sum(bad_j), point_count, output_num,))
                 for j in np.nonzero(bad_j)[0]:
@@ -300,7 +300,7 @@ class FuncData(object):
                     b = "  ".join(map(fmt, got))
                     c = "  ".join(map(fmt, wanted))
                     d = fmt(rdiff)
-                    msg.append("%s => %s != %s  (rdiff %s)" % (a, b, c, d))
+                    msg.append(f"{a} => {b} != {c}  (rdiff {d})")
                 assert_(False, "\n".join(msg))
 
     def __repr__(self):
@@ -313,4 +313,4 @@ class FuncData(object):
             return "<Data for %s%s: %s>" % (self.func.__name__, is_complex,
                                             os.path.basename(self.dataname))
         else:
-            return "<Data for %s%s>" % (self.func.__name__, is_complex)
+            return f"<Data for {self.func.__name__}{is_complex}>"

--- a/scipy/special/tests/test_cython_special.py
+++ b/scipy/special/tests/test_cython_special.py
@@ -293,7 +293,7 @@ def test_cython_api_completeness():
                 if cyfun is func:
                     break
             else:
-                raise RuntimeError("{} missing from tests!".format(name))
+                raise RuntimeError(f"{name} missing from tests!")
 
 
 @pytest.mark.parametrize("param", PARAMS, ids=IDS)
@@ -337,4 +337,4 @@ def test_cython_api(param):
                 sup.filter(DeprecationWarning)
                 pyval = pyfunc(*pt)
                 cyval = cy_spec_func(*pt)
-            assert_allclose(cyval, pyval, err_msg="{} {} {}".format(pt, typecodes, signature))
+            assert_allclose(cyval, pyval, err_msg=f"{pt} {typecodes} {signature}")

--- a/scipy/special/tests/test_kolmogorov.py
+++ b/scipy/special/tests/test_kolmogorov.py
@@ -89,7 +89,7 @@ class TestSmirnov(object):
         x = 0.4
         pvals = np.array([smirnov(n, x) for n in range(400, 1100, 20)])
         dfs = np.diff(pvals)
-        assert_(np.all(dfs <= 0), msg='Not all diffs negative %s' % dfs)
+        assert_(np.all(dfs <= 0), msg=f'Not all diffs negative {dfs}')
 
 
 class TestSmirnovi(object):

--- a/scipy/special/tests/test_nan_inputs.py
+++ b/scipy/special/tests/test_nan_inputs.py
@@ -52,7 +52,7 @@ def test_nan_inputs(func):
     if func in POSTPROCESSING:
         res = POSTPROCESSING[func](*res)
 
-    msg = "got {} instead of nan".format(res)
+    msg = f"got {res} instead of nan"
     assert_array_equal(np.isnan(res), True, err_msg=msg)
 
 

--- a/scipy/special/tests/test_sph_harm.py
+++ b/scipy/special/tests/test_sph_harm.py
@@ -34,4 +34,4 @@ def test_first_harmonics():
         assert_allclose(sc.sph_harm(m, n, theta, phi),
                         harm(theta, phi),
                         rtol=1e-15, atol=1e-15,
-                        err_msg="Y^{}_{} incorrect".format(m, n))
+                        err_msg=f"Y^{m}_{n} incorrect")

--- a/scipy/special/utils/convert.py
+++ b/scipy/special/utils/convert.py
@@ -67,7 +67,7 @@ def parse_ipp_file(filename):
         if m:
             d = int(m.group(1))
             n = int(m.group(2))
-            print("d = {0}, n = {1}".format(d, n))
+            print(f"d = {d}, n = {n}")
             cdata = []
             i += 1
             line = lines[i]
@@ -96,14 +96,14 @@ def dump_dataset(filename, data):
     fid = open(filename, 'w')
     try:
         for line in data:
-            fid.write("%s\n" % " ".join(line))
+            fid.write(f"{' '.join(line)}\n")
     finally:
         fid.close()
 
 
 def dump_datasets(filename):
     base, ext = os.path.splitext(os.path.basename(filename))
-    base += '_%s' % ext[1:]
+    base += f'_{ext[1:]}'
     datadir = os.path.join(DATA_DIR, base)
     os.makedirs(datadir)
     datasets = parse_ipp_file(filename)
@@ -121,5 +121,5 @@ if __name__ == '__main__':
                 continue
 
             path = os.path.join(BOOST_SRC, filename)
-            print("================= %s ===============" % path)
+            print(f"================= {path} ===============")
             dump_datasets(path)

--- a/scipy/special/utils/makenpz.py
+++ b/scipy/special/utils/makenpz.py
@@ -24,7 +24,7 @@ def main():
 
     # Skip rebuilding if no sources
     if os.path.isfile(outp) and not os.path.isdir(inp):
-        print("[makenpz] {} not rebuilt".format(outp))
+        print(f"[makenpz] {outp} not rebuilt")
         return
 
     # Find source files
@@ -51,14 +51,14 @@ def main():
         changed = changed or any(newer(fn, outp) for key, fn in files)
         changed = changed or newer(__file__, outp)
         if not changed:
-            print("[makenpz] {} is already up to date".format(outp))
+            print(f"[makenpz] {outp} is already up to date")
             return
 
     data = {}
     for key, fn in files:
         data[key] = np.loadtxt(fn)
 
-    print("[makenpz] generating {}".format(outp))
+    print(f"[makenpz] generating {outp}")
     np.savez_compressed(outp, **data)
 
 

--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -518,7 +518,7 @@ def binned_statistic_dd(sample, values, statistic='mean',
     """
     known_stats = ['mean', 'median', 'count', 'sum', 'std', 'min', 'max']
     if not callable(statistic) and statistic not in known_stats:
-        raise ValueError('invalid statistic %r' % (statistic,))
+        raise ValueError(f'invalid statistic {statistic!r}')
 
     try:
         bins = index(bins)
@@ -529,7 +529,7 @@ def binned_statistic_dd(sample, values, statistic='mean',
 
     # NOTE: for _bin_edges(), see e.g. gh-11365
     if isinstance(bins, int) and not np.isfinite(sample).all():
-        raise ValueError('%r contains non-finite values.' % (sample,))
+        raise ValueError(f'{sample!r} contains non-finite values.')
 
     # `Ndim` is the number of dimensions (e.g. `2` for `binned_statistic_2d`)
     # `Dlen` is the length of elements along each dimension.

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -52,7 +52,7 @@ def _remove_optimizer_parameters(kwds):
     kwds.pop('scale', None)
     kwds.pop('optimizer', None)
     if kwds:
-        raise TypeError("Unknown arguments: %s." % kwds)
+        raise TypeError(f"Unknown arguments: {kwds}.")
 
 
 ## Kolmogorov-Smirnov one-sided and two-sided test statistics
@@ -2526,7 +2526,7 @@ def _digammainv(y):
     value, info, ier, mesg = optimize.fsolve(func, x0, xtol=1e-11,
                                              full_output=True)
     if ier != 1:
-        raise RuntimeError("_digammainv: fsolve failed, y = %r" % y)
+        raise RuntimeError(f"_digammainv: fsolve failed, y = {y!r}")
 
     return value[0]
 
@@ -4937,7 +4937,7 @@ class lognorm_gen(rv_continuous):
                      'optimizer']:
             kwds.pop(name, None)
         if kwds:
-            raise TypeError("Unknown arguments: %s." % kwds)
+            raise TypeError(f"Unknown arguments: {kwds}.")
 
         # Special case: loc is fixed.  Use the maximum likelihood formulas
         # instead of the numerical solver.

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -420,7 +420,7 @@ def _fit_determine_optimizer(optimizer):
         try:
             optimizer = getattr(optimize, optimizer)
         except AttributeError as e:
-            raise ValueError("%s is not a valid optimizer" % optimizer) from e
+            raise ValueError(f"{optimizer} is not a valid optimizer") from e
     return optimizer
 
 
@@ -777,7 +777,7 @@ class rv_generic(object):
             tempdict['shapes_'] += ','
 
         if self.shapes:
-            tempdict['set_vals_stmt'] = '>>> %s = %s' % (self.shapes, vals)
+            tempdict['set_vals_stmt'] = f'>>> {self.shapes} = {vals}'
         else:
             tempdict['set_vals_stmt'] = ''
 
@@ -2390,7 +2390,7 @@ class rv_continuous(rv_generic):
         optimizer = _fit_determine_optimizer(optimizer)
         # by now kwds must be empty, since everybody took what they needed
         if kwds:
-            raise TypeError("Unknown arguments: %s." % kwds)
+            raise TypeError(f"Unknown arguments: {kwds}.")
 
         vals = optimizer(func, x0, args=(ravel(data),), disp=0)
         if restore is not None:
@@ -3559,7 +3559,7 @@ def _iter_chunked(x0, x1, chunksize=4, inc=1):
     if inc == 0:
         raise ValueError('Cannot increment by zero.')
     if chunksize <= 0:
-        raise ValueError('Chunk size must be positive; got %s.' % chunksize)
+        raise ValueError(f'Chunk size must be positive; got {chunksize}.')
 
     s = 1 if inc > 0 else -1
     stepsize = abs(chunksize * inc)

--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -82,9 +82,9 @@ def epps_singleton_2samp(x, y, t=(0.4, 0.8)):
     x, y, t = np.asarray(x), np.asarray(y), np.asarray(t)
     # check if x and y are valid inputs
     if x.ndim > 1:
-        raise ValueError('x must be 1d, but x.ndim equals {}.'.format(x.ndim))
+        raise ValueError(f'x must be 1d, but x.ndim equals {x.ndim}.')
     if y.ndim > 1:
-        raise ValueError('y must be 1d, but y.ndim equals {}.'.format(y.ndim))
+        raise ValueError(f'y must be 1d, but y.ndim equals {y.ndim}.')
     nx, ny = len(x), len(y)
     if (nx < 5) or (ny < 5):
         raise ValueError('x and y should have at least 5 elements, but len(x) '
@@ -97,7 +97,7 @@ def epps_singleton_2samp(x, y, t=(0.4, 0.8)):
 
     # check if t is valid
     if t.ndim > 1:
-        raise ValueError('t must be 1d, but t.ndim equals {}.'.format(t.ndim))
+        raise ValueError(f't must be 1d, but t.ndim equals {t.ndim}.')
     if np.less_equal(t, 0).any():
         raise ValueError('t must contain positive elements only.')
 

--- a/scipy/stats/_stats_mstats_common.py
+++ b/scipy/stats/_stats_mstats_common.py
@@ -235,7 +235,7 @@ def theilslopes(y, x=None, alpha=0.95):
     else:
         x = np.array(x, dtype=float).flatten()
         if len(x) != len(y):
-            raise ValueError("Incompatible lengths ! (%s<>%s)" % (len(y), len(x)))
+            raise ValueError(f"Incompatible lengths ! ({len(y)}<>{len(x)})")
 
     # Compute sorted slopes only when deltax > 0
     deltax = x[:, np.newaxis] - x
@@ -379,7 +379,7 @@ def siegelslopes(y, x=None, method="hierarchical"):
     else:
         x = np.asarray(x, dtype=float).ravel()
         if len(x) != len(y):
-            raise ValueError("Incompatible lengths ! (%s<>%s)" % (len(y), len(x)))
+            raise ValueError(f"Incompatible lengths ! ({len(y)}<>{len(x)})")
 
     deltax = x[:, np.newaxis] - x
     deltay = y[:, np.newaxis] - y

--- a/scipy/stats/kde.py
+++ b/scipy/stats/kde.py
@@ -283,9 +283,9 @@ class gaussian_kde(object):
         cov = atleast_2d(cov)
 
         if mean.shape != (self.d,):
-            raise ValueError("mean does not have dimension %s" % self.d)
+            raise ValueError(f"mean does not have dimension {self.d}")
         if cov.shape != (self.d, self.d):
-            raise ValueError("covariance does not have dimension %s" % self.d)
+            raise ValueError(f"covariance does not have dimension {self.d}")
 
         # make mean a column vector
         mean = mean[:, newaxis]

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -441,7 +441,7 @@ def _parse_dist_kw(dist, enforce_subclass=True):
         try:
             dist = getattr(distributions, dist)
         except AttributeError as e:
-            raise ValueError("%s is not a valid distribution name" % dist) from e
+            raise ValueError(f"{dist} is not a valid distribution name") from e
     elif enforce_subclass:
         msg = ("`dist` should be a stats.distributions instance or a string "
                "with the name of such a distribution.")
@@ -805,7 +805,7 @@ def ppcc_plot(x, a, b, dist='tukeylambda', plot=None, N=80):
         plot.plot(svals, ppcc, 'x')
         _add_axis_labels_title(plot, xlabel='Shape Values',
                                ylabel='Prob Plot Corr. Coef.',
-                               title='(%s) PPCC Plot' % dist)
+                               title=f'({dist}) PPCC Plot')
 
     return svals, ppcc
 
@@ -1157,7 +1157,7 @@ def boxcox_normmax(x, brack=(-2.0, 2.0), method='pearsonr'):
                'mle': _mle,
                'all': _all}
     if method not in methods.keys():
-        raise ValueError("Method %s not recognized." % method)
+        raise ValueError(f"Method {method} not recognized.")
 
     optimfunc = methods[method]
     return optimfunc(x, brack)
@@ -2061,11 +2061,11 @@ def anderson_ksamp(samples, midrank=True):
     sig = np.array([0.25, 0.1, 0.05, 0.025, 0.01, 0.005, 0.001])
     if A2 < critical.min():
         p = sig.max()
-        warnings.warn("p-value capped: true value larger than {}".format(p),
+        warnings.warn(f"p-value capped: true value larger than {p}",
                       stacklevel=2)
     elif A2 > critical.max():
         p = sig.min()
-        warnings.warn("p-value floored: true value smaller than {}".format(p),
+        warnings.warn(f"p-value floored: true value smaller than {p}",
                       stacklevel=2)
     else:
         # interpolation of probit of significance level

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -898,7 +898,7 @@ def theilslopes(y, x=None, alpha=0.95):
     else:
         x = ma.asarray(x).flatten()
         if len(x) != len(y):
-            raise ValueError("Incompatible lengths ! (%s<>%s)" % (len(y),len(x)))
+            raise ValueError(f"Incompatible lengths ! ({len(y)}<>{len(x)})")
 
     m = ma.mask_or(ma.getmask(x), ma.getmask(y))
     y._mask = x._mask = m
@@ -952,7 +952,7 @@ def siegelslopes(y, x=None, method="hierarchical"):
     else:
         x = ma.asarray(x).ravel()
         if len(x) != len(y):
-            raise ValueError("Incompatible lengths ! (%s<>%s)" % (len(y), len(x)))
+            raise ValueError(f"Incompatible lengths ! ({len(y)}<>{len(x)})")
 
     m = ma.mask_or(ma.getmask(x), ma.getmask(y))
     y._mask = x._mask = m
@@ -1468,10 +1468,10 @@ def trimr(a, limits=None, inclusive=(True, True), axis=None):
     errmsg = "The proportion to cut from the %s should be between 0. and 1."
     if lolim is not None:
         if lolim > 1. or lolim < 0:
-            raise ValueError(errmsg % 'beginning' + "(got %s)" % lolim)
+            raise ValueError(errmsg % 'beginning' + f"(got {lolim})")
     if uplim is not None:
         if uplim > 1. or uplim < 0:
-            raise ValueError(errmsg % 'end' + "(got %s)" % uplim)
+            raise ValueError(errmsg % 'end' + f"(got {uplim})")
 
     (loinc, upinc) = inclusive
 
@@ -1748,10 +1748,10 @@ def trimmed_stde(a, limits=(0.1,0.1), inclusive=(1,1), axis=None):
     errmsg = "The proportion to cut from the %s should be between 0. and 1."
     if lolim is not None:
         if lolim > 1. or lolim < 0:
-            raise ValueError(errmsg % 'beginning' + "(got %s)" % lolim)
+            raise ValueError(errmsg % 'beginning' + f"(got {lolim})")
     if uplim is not None:
         if uplim > 1. or uplim < 0:
-            raise ValueError(errmsg % 'end' + "(got %s)" % uplim)
+            raise ValueError(errmsg % 'end' + f"(got {uplim})")
 
     (loinc, upinc) = inclusive
     if (axis is None):
@@ -2145,10 +2145,10 @@ def winsorize(a, limits=None, inclusive=(True, True), inplace=False,
     errmsg = "The proportion to cut from the %s should be between 0. and 1."
     if lolim is not None:
         if lolim > 1. or lolim < 0:
-            raise ValueError(errmsg % 'beginning' + "(got %s)" % lolim)
+            raise ValueError(errmsg % 'beginning' + f"(got {lolim})")
     if uplim is not None:
         if uplim > 1. or uplim < 0:
-            raise ValueError(errmsg % 'end' + "(got %s)" % uplim)
+            raise ValueError(errmsg % 'end' + f"(got {uplim})")
 
     (loinc, upinc) = inclusive
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -2105,8 +2105,7 @@ def _histogram(a, numbins=10, defaultlimits=None, weights=None, printextras=Fals
     extrapoints = len([v for v in a
                        if defaultlimits[0] > v or v > defaultlimits[1]])
     if extrapoints > 0 and printextras:
-        warnings.warn("Points outside given histogram range = %s"
-                      % extrapoints)
+        warnings.warn(f"Points outside given histogram range = {extrapoints}")
 
     return HistogramResult(hist, defaultlimits[0], binsize, extrapoints)
 
@@ -2822,7 +2821,7 @@ def iqr(x, axis=None, rng=(25, 75), scale=1.0, nan_policy='propagate',
     if isinstance(scale, str):
         scale_key = scale.lower()
         if scale_key not in _scale_conversions:
-            raise ValueError("{0} not a valid scale for `iqr`".format(scale))
+            raise ValueError(f"{scale} not a valid scale for `iqr`")
         if scale_key == 'raw':
             warnings.warn(
                 "use of scale='raw' is deprecated, use scale=1.0 instead",
@@ -4168,7 +4167,7 @@ def spearmanr(a, b=None, axis=0, nan_policy='propagate'):
 
     """
     if axis is not None and axis > 1:
-        raise ValueError("spearmanr only handles 1-D or 2-D arrays, supplied axis argument {}, please use only values 0, 1 or None for axis".format(axis))
+        raise ValueError(f"spearmanr only handles 1-D or 2-D arrays, supplied axis argument {axis}, please use only values 0, 1 or None for axis")
 
     a, axisout = _chk_asarray(a, axis)
     if a.ndim > 2:
@@ -5028,13 +5027,11 @@ def multiscale_graphcorr(x, y, compute_distance=_euclidean_dist, reps=1000,
     if x.ndim == 1:
         x = x[:, np.newaxis]
     elif x.ndim != 2:
-        raise ValueError("Expected a 2-D array `x`, found shape "
-                         "{}".format(x.shape))
+        raise ValueError(f"Expected a 2-D array `x`, found shape {x.shape}")
     if y.ndim == 1:
         y = y[:, np.newaxis]
     elif y.ndim != 2:
-        raise ValueError("Expected a 2-D array `y`, found shape "
-                         "{}".format(y.shape))
+        raise ValueError(f"Expected a 2-D array `y`, found shape {y.shape}")
 
     nx, px = x.shape
     ny, py = y.shape
@@ -6288,7 +6285,7 @@ def ks_1samp(x, cdf, args=(), alternative='two-sided', mode='auto'):
     alternative = {'t': 'two-sided', 'g': 'greater', 'l': 'less'}.get(
        alternative.lower()[0], alternative)
     if alternative not in ['two-sided', 'greater', 'less']:
-        raise ValueError("Unexpected alternative %s" % alternative)
+        raise ValueError(f"Unexpected alternative {alternative}")
     if np.ma.is_masked(x):
         x = x.compressed()
 
@@ -6919,7 +6916,7 @@ def kstest(rvs, cdf, args=(), N=20, alternative='two-sided', mode='auto'):
     if alternative == 'two_sided':
         alternative = 'two-sided'
     if alternative not in ['two-sided', 'greater', 'less']:
-        raise ValueError("Unexpected alternative %s" % alternative)
+        raise ValueError(f"Unexpected alternative {alternative}")
     xvals, yvals, cdf = _parse_kstest_args(rvs, cdf, args, N)
     if cdf:
         return ks_1samp(xvals, cdf, args=args, alternative=alternative, mode=mode)
@@ -8042,7 +8039,7 @@ def rankdata(a, method='average', *, axis=None):
            [2. , 1. , 3. ]])
     """
     if method not in ('average', 'min', 'max', 'dense', 'ordinal'):
-        raise ValueError('unknown method "{0}"'.format(method))
+        raise ValueError(f'unknown method "{method}"')
 
     if axis is not None:
         a = np.asarray(a)

--- a/scipy/stats/tests/common_tests.py
+++ b/scipy/stats/tests/common_tests.py
@@ -47,14 +47,14 @@ def check_moment(distfn, arg, m, v, msg):
                             ' - 1st moment')
     else:                     # or np.isnan(m1),
         npt.assert_(np.isinf(m1),
-               msg + ' - 1st moment -infinite, m1=%s' % str(m1))
+               msg + f' - 1st moment -infinite, m1={str(m1)}')
 
     if not np.isinf(v):
         npt.assert_almost_equal(m2 - m1 * m1, v, decimal=10, err_msg=msg +
                             ' - 2ndt moment')
     else:                     # or np.isnan(m2),
         npt.assert_(np.isinf(m2),
-               msg + ' - 2nd moment -infinite, m2=%s' % str(m2))
+               msg + f' - 2nd moment -infinite, m2={str(m2)}')
 
 
 def check_mean_expect(distfn, arg, m, msg):
@@ -322,7 +322,7 @@ def check_freezing(distfn, args):
 def check_rvs_broadcast(distfunc, distname, allargs, shape, shape_only, otype):
     np.random.seed(123)
     sample = distfunc.rvs(*allargs)
-    assert_equal(sample.shape, shape, "%s: rvs failed to broadcast" % distname)
+    assert_equal(sample.shape, shape, f"{distname}: rvs failed to broadcast")
     if not shape_only:
         rvs = np.vectorize(lambda *allargs: distfunc.rvs(*allargs), otypes=otype)
         np.random.seed(123)

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -104,7 +104,7 @@ def test_rvs_broadcast(dist, shape_args):
         distfunc = getattr(stats, dist)
     except TypeError:
         distfunc = dist
-        dist = 'rv_discrete(values=(%r, %r))' % (dist.xk, dist.pk)
+        dist = f'rv_discrete(values=({dist.xk!r}, {dist.pk!r}))'
     loc = np.zeros(2)
     nargs = distfunc.numargs
     allargs = []

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -37,7 +37,7 @@ DOCSTRINGS_STRIPPED = sys.flags.optimize > 1
 
 def _assert_hasattr(a, b, msg=None):
     if msg is None:
-        msg = '%s does not have attribute %s' % (a, b)
+        msg = f'{a} does not have attribute {b}'
     assert_(hasattr(a, b), msg=msg)
 
 
@@ -2792,7 +2792,7 @@ class TestFitMethod(object):
     def test_fit_w_non_finite_data_values(self, dist, args):
         """gh-10300"""
         if dist in self.fitSkipNonFinite:
-            pytest.skip("%s fit known to fail or deprecated" % dist)
+            pytest.skip(f"{dist} fit known to fail or deprecated")
         x = np.array([1.6483, 2.7169, 2.4667, 1.1791, 3.5433, np.nan])
         y = np.array([1.6483, 2.7169, 2.4667, 1.1791, 3.5433, np.inf])
         distfunc = getattr(stats, dist)

--- a/scipy/stats/tests/test_fit.py
+++ b/scipy/stats/tests/test_fit.py
@@ -62,7 +62,7 @@ def test_cont_fit(distname, arg):
         except Exception:
             xfail = True
         if xfail:
-            msg = "Fitting %s doesn't work reliably yet" % distname
+            msg = f"Fitting {distname} doesn't work reliably yet"
             msg += " [Set environment variable SCIPY_XFAIL=1 to run this test nevertheless.]"
             pytest.xfail(msg)
 
@@ -93,17 +93,17 @@ def test_cont_fit(distname, arg):
             if np.all(np.abs(diff) <= diffthreshold):
                 break
     else:
-        txt = 'parameter: %s\n' % str(truearg)
-        txt += 'estimated: %s\n' % str(est)
-        txt += 'diff     : %s\n' % str(diff)
-        raise AssertionError('fit not very good in %s\n' % distfn.name + txt)
+        txt = f'parameter: {str(truearg)}\n'
+        txt += f'estimated: {str(est)}\n'
+        txt += f'diff     : {str(diff)}\n'
+        raise AssertionError(f'fit not very good in {distfn.name}\n' + txt)
 
 
 def _check_loc_scale_mle_fit(name, data, desired, atol=None):
     d = getattr(stats, name)
     actual = d.fit(data)[-2:]
     assert_allclose(actual, desired, atol=atol,
-                    err_msg='poor mle fit of (loc, scale) in %s' % name)
+                    err_msg=f'poor mle fit of (loc, scale) in {name}')
 
 
 def test_non_default_loc_scale_mle_fit():

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4502,10 +4502,10 @@ def test_binomtest():
 
     for p, res in zip(pp,results):
         assert_approx_equal(stats.binom_test(x, n, p), res,
-                            significant=12, err_msg='fail forp=%f' % p)
+                            significant=12, err_msg=f'fail forp={p:f}')
 
     assert_approx_equal(stats.binom_test(50,100,0.1), 5.8320387857343647e-024,
-                            significant=12, err_msg='fail forp=%f' % p)
+                            significant=12, err_msg=f'fail forp={p:f}')
 
 
 def test_binomtest2():
@@ -4807,7 +4807,7 @@ class TestFOneWay(object):
                 rtol = 1e-4
 
             assert_allclose(res[0], f, rtol=rtol,
-                            err_msg='Failing testcase: %s' % test_case)
+                            err_msg=f'Failing testcase: {test_case}')
 
     @pytest.mark.parametrize("a, b, expected", [
         (np.array([42, 42, 42]), np.array([7, 7, 7]), (np.inf, 0)),


### PR DESCRIPTION
#### What does this implement/fix?
As scipy no longer supports python 3.5, it's safe to migrate to f-strings. This should improve readability and be marginally faster.

#### Additional information
<!--Any additional information you think is important.-->
The change was derived by running `flynt scipy -ll 79 `. 

Stats:
```
Files modified:                            183
Character count reduction:                 4424 (0.04%)

Old style (`%`) expressions attempted:     636/1019 (62.4%)
`.format(...)` calls attempted:            401/412 (97.3%)
F-string expressions created:              678
```
It also reduces the line count by 33.