### PR TITLE
BUG: improved the stability of kde for highly (1000s) multi-dimension inputs

### DIFF
--- a/scipy/stats/kde.py
+++ b/scipy/stats/kde.py
@@ -570,7 +570,7 @@ class gaussian_kde(object):
         self.covariance = self._data_covariance * self.factor**2
         self.inv_cov = self._data_inv_cov / self.factor**2
         itemsize = self.covariance.dtype.itemsize
-        if itemsize == 16:
+        if itemsize in (12, 16):
             self.log_det = np.abs(np.log(linalg.det(2.0*pi*self.covariance)))
             self.log_sign = np.log(np.sign(self.log_det))
         else:

--- a/scipy/stats/kde.py
+++ b/scipy/stats/kde.py
@@ -571,8 +571,8 @@ class gaussian_kde(object):
         self.inv_cov = self._data_inv_cov / self.factor**2
         itemsize = self.covariance.dtype.itemsize
         if itemsize == 16:
-            self.log_sign = np.log(1)
-            self.log_det = np.log(linalg.det(2.0*pi*self.covariance))
+            self.log_det = np.abs(np.log(linalg.det(2.0*pi*self.covariance)))
+            self.log_sign = np.log(np.sign(self.log_det))
         else:
             sign, self.log_det = np.linalg.slogdet(2.0*pi*self.covariance)
             self.log_sign = np.log(sign)

--- a/scipy/stats/kde.py
+++ b/scipy/stats/kde.py
@@ -569,7 +569,13 @@ class gaussian_kde(object):
 
         self.covariance = self._data_covariance * self.factor**2
         self.inv_cov = self._data_inv_cov / self.factor**2
-        self._norm_factor = sqrt(linalg.det(2*pi*self.covariance))
+        itemsize = self.covariance.dtype.itemsize
+        if itemsize == 16:
+            self.log_sign = np.log(1)
+            self.log_det = np.log(linalg.det(2.0*pi*self.covariance))
+        else:
+            sign, self.log_det = np.linalg.slogdet(2.0*pi*self.covariance)
+            self.log_sign = np.log(sign)
 
     def pdf(self, x):
         """
@@ -607,18 +613,20 @@ class gaussian_kde(object):
             for i in range(self.n):
                 diff = self.dataset[:, i, newaxis] - points
                 tdiff = dot(self.inv_cov, diff)
-                energy[i] = sum(diff*tdiff, axis=0) / 2.0
-            result = logsumexp(-energy.T,
-                               b=self.weights / self._norm_factor, axis=1)
+                energy[i] = sum(diff*tdiff, axis=0)
+            log_to_sum = 2.0 * np.log(
+                self.weights) - self.log_det - energy.T - self.log_sign
+            result = logsumexp(0.5 * log_to_sum, axis=1)
         else:
             # loop over points
             result = np.empty((m,), dtype=float)
             for i in range(m):
                 diff = self.dataset - points[:, i, newaxis]
                 tdiff = dot(self.inv_cov, diff)
-                energy = sum(diff * tdiff, axis=0) / 2.0
-                result[i] = logsumexp(-energy, b=self.weights /
-                                      self._norm_factor)
+                energy = sum(diff * tdiff, axis=0)
+                log_to_sum = 2.0 * np.log(
+                    self.weights) - self.log_det - energy - self.log_sign
+                result[i] = logsumexp(0.5 * log_to_sum)
 
         return result
 

--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -401,7 +401,7 @@ def test_logpdf_overflow():
     # very high dimensionality kde
     np.random.seed(1)
     n_dimensions = 2500
-    n_samples = 1000
+    n_samples = 1500
     xn = np.array([np.random.randn(n_samples) + (n) for n in range(
         0, n_dimensions)])
 

--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -396,6 +396,23 @@ def test_pdf_logpdf_weighted():
     assert_almost_equal(pdf, pdf2, decimal=12)
 
 
+def test_logpdf_overflow():
+    # regression test for gh-12988; testing against linalg instability for
+    # very high dimensionality kde
+    np.random.seed(1)
+    n_dimensions = 2500
+    n_samples = 1000
+    xn = np.array([np.random.randn(n_samples) + (n) for n in range(
+        0, n_dimensions)])
+
+    # Default
+    gkde = stats.gaussian_kde(xn)
+
+    logpdf = gkde.logpdf(np.arange(0, n_dimensions))
+    np.testing.assert_equal(np.isneginf(logpdf[0]), False)
+    np.testing.assert_equal(np.isnan(logpdf[0]), False)
+
+
 def test_weights_intact():
     # regression test for gh-9709: weights are not modified
     np.random.seed(12345)

--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -401,7 +401,7 @@ def test_logpdf_overflow():
     # very high dimensionality kde
     np.random.seed(1)
     n_dimensions = 2500
-    n_samples = 1500
+    n_samples = 500
     xn = np.array([np.random.randn(n_samples) + (n) for n in range(
         0, n_dimensions)])
 

--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -401,7 +401,7 @@ def test_logpdf_overflow():
     # very high dimensionality kde
     np.random.seed(1)
     n_dimensions = 2500
-    n_samples = 500
+    n_samples = 5000
     xn = np.array([np.random.randn(n_samples) + (n) for n in range(
         0, n_dimensions)])
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes: #12988 

#### What does this implement/fix?
It appeared that this problem was due to the instability in `linalg.det()` for very large matrices (as in line 572 of [kde.py](https://github.com/scipy/scipy/blob/d286f8525c16b2cd4e179dea2c77b6b09622aff9/scipy/stats/kde.py#L572)). 
This has been fixed by using the `np.linalg.slogdet()` function where possible (not possible for `float128` or `float96`objects which are not supported by `np.linalg`), and carrying the logarithmic result through in the `logpdf()` function.

#### Additional information
Simple `%%timeit` testing suggests that this implementation may actually be (slightly) faster. 