### PR TITLE
DOC: Clarify that using sos as output type for iirdesign can have performance costs

### DIFF
--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -2111,12 +2111,14 @@ def iirdesign(wp, ws, gpass, gstop, analog=False, ftype='ellip', output='ba',
             - Bessel/Thomson: 'bessel'
 
     output : {'ba', 'zpk', 'sos'}, optional
-        Type of output:  numerator/denominator ('ba'), pole-zero ('zpk'), or
-        second-order sections ('sos'). Default is 'ba' for backwards compatibility. 
-        In general 'sos' is recommended because inferring the 'ba' coëfficients 
-        suffers from numerical instabilities. Using the 'sos' filter is sometimes 
-        associated with additional computational costs, for data-intense use cases 
-        it is therefore recommended to also investigate the 'ba'-filter format.
+        Type of output:  numerator/denominator ('ba'), pole-zero
+        ('zpk'), or second-order sections ('sos'). Default is 'ba' for
+        backwards compatibility. In general 'sos' is recommended
+        because inferring the 'ba' coefficients suffers from numerical
+        instabilities. Using the 'sos' filter is sometimes associated
+        with additional computational costs, for data-intense use cases
+        it is therefore recommended to also investigate the 'ba'-filter
+        format.
     fs : float, optional
         The sampling frequency of the digital system.
 

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -2112,8 +2112,11 @@ def iirdesign(wp, ws, gpass, gstop, analog=False, ftype='ellip', output='ba',
 
     output : {'ba', 'zpk', 'sos'}, optional
         Type of output:  numerator/denominator ('ba'), pole-zero ('zpk'), or
-        second-order sections ('sos'). Default is 'ba' for backwards
-        compatibility, but 'sos' should be used for general-purpose filtering.
+        second-order sections ('sos'). Default is 'ba' for backwards compatibility. 
+        In general 'sos' is recommended because inferring the 'ba' coëfficients 
+        suffers from numerical instabilities. Using the 'sos' filter is sometimes 
+        associated with additional computational costs, for data-intense use cases 
+        it is therefore recommended to also investigate the 'ba'-filter format.
     fs : float, optional
         The sampling frequency of the digital system.
 

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -2111,16 +2111,24 @@ def iirdesign(wp, ws, gpass, gstop, analog=False, ftype='ellip', output='ba',
             - Bessel/Thomson: 'bessel'
 
     output : {'ba', 'zpk', 'sos'}, optional
-        Type of output:  
-            numerator/denominator ('ba'), 
-            pole-zero ('zpk'), 
-            second-order sections ('sos'). 
-        Default output is 'ba' for backwards compatibility. In general 
-        'sos' is recommended because inferring the 'ba' coefficients 
-        suffers from numerical instabilities. Using the 'sos' filter is 
-        sometimes associated with additional computational costs, for 
-        data-intense use cases it is therefore recommended to also 
-        investigate the 'ba'-filter format.
+        Filter form of the output:
+
+            - second-order sections (recommended): 'sos'
+            - numerator/denominator (default)    : 'ba'
+            - pole-zero                          : 'zpk'
+
+        In general the second-order sections ('sos') form  is
+        recommended because inferring the coefficients for the
+        numerator/denominator form ('ba') suffers from numerical
+        instabilities. For reasons of backward compatibility the default
+        form is the numerator/denominator form ('ba'), where the 'b'
+        and the 'a' in 'ba' refer to the commonly used names of the
+        coefficients used.
+
+        Note: Using the second-order sections form ('sos') is sometimes
+        associated with additional computational costs: for
+        data-intense use cases it is therefore recommended to also
+        investigate the numerator/denominator form ('ba').
 
     fs : float, optional
         The sampling frequency of the digital system.
@@ -2265,9 +2273,25 @@ def iirfilter(N, Wn, rp=None, rs=None, btype='band', analog=False,
             - Bessel/Thomson: 'bessel'
 
     output : {'ba', 'zpk', 'sos'}, optional
-        Type of output:  numerator/denominator ('ba'), pole-zero ('zpk'), or
-        second-order sections ('sos'). Default is 'ba' for backwards
-        compatibility, but 'sos' should be used for general-purpose filtering.
+        Filter form of the output:
+
+            - second-order sections (recommended): 'sos'
+            - numerator/denominator (default)    : 'ba'
+            - pole-zero                          : 'zpk'
+
+        In general the second-order sections ('sos') form  is
+        recommended because inferring the coefficients for the
+        numerator/denominator form ('ba') suffers from numerical
+        instabilities. For reasons of backward compatibility the default
+        form is the numerator/denominator form ('ba'), where the 'b'
+        and the 'a' in 'ba' refer to the commonly used names of the
+        coefficients used.
+
+        Note: Using the second-order sections form ('sos') is sometimes
+        associated with additional computational costs: for
+        data-intense use cases it is therefore recommended to also
+        investigate the numerator/denominator form ('ba').
+
     fs : float, optional
         The sampling frequency of the digital system.
 

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -2111,14 +2111,17 @@ def iirdesign(wp, ws, gpass, gstop, analog=False, ftype='ellip', output='ba',
             - Bessel/Thomson: 'bessel'
 
     output : {'ba', 'zpk', 'sos'}, optional
-        Type of output:  numerator/denominator ('ba'), pole-zero
-        ('zpk'), or second-order sections ('sos'). Default is 'ba' for
-        backwards compatibility. In general 'sos' is recommended
-        because inferring the 'ba' coefficients suffers from numerical
-        instabilities. Using the 'sos' filter is sometimes associated
-        with additional computational costs, for data-intense use cases
-        it is therefore recommended to also investigate the 'ba'-filter
-        format.
+        Type of output:  
+            numerator/denominator ('ba'), 
+            pole-zero ('zpk'), 
+            second-order sections ('sos'). 
+        Default output is 'ba' for backwards compatibility. In general 
+        'sos' is recommended because inferring the 'ba' coefficients 
+        suffers from numerical instabilities. Using the 'sos' filter is 
+        sometimes associated with additional computational costs, for 
+        data-intense use cases it is therefore recommended to also 
+        investigate the 'ba'-filter format.
+
     fs : float, optional
         The sampling frequency of the digital system.
 


### PR DESCRIPTION
Reference issue

Closes scipy#12970:
Documentation presents second order sections as the correct choice where there is an engineering decision to be made

What does this implement/fix?

It clarifies in the documentation string of iirdesign that although 'sos'-filters are generally recommended as the correct choice of filter form there are sometimes computational costs involved during filter application.

Additional information

Issue scipy#12970 provide code for reproducing a simple computational costs measurement. Also output for two example configurations is provided there.