### PR TITLE
DOC: capitalization and formatting in lsmr

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -243,7 +243,6 @@ Shashaank N for contributions to scipy.signal.
 Frank Torres for fixing a bug with solve_bvp for large problems.
 Ben West for updating the Gamma distribution documentation.
 Terry Davis for documentation improvements in scipy.ndimage.morphology
-Denali Molitor for documentation edits in lsmr.
 
 Institutions
 ------------

--- a/THANKS.txt
+++ b/THANKS.txt
@@ -243,6 +243,7 @@ Shashaank N for contributions to scipy.signal.
 Frank Torres for fixing a bug with solve_bvp for large problems.
 Ben West for updating the Gamma distribution documentation.
 Terry Davis for documentation improvements in scipy.ndimage.morphology
+Denali Molitor for documentation edits in lsmr.
 
 Institutions
 ------------

--- a/scipy/sparse/linalg/isolve/lsmr.py
+++ b/scipy/sparse/linalg/isolve/lsmr.py
@@ -32,8 +32,8 @@ def lsmr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
 
     lsmr solves the system of linear equations ``Ax = b``. If the system
     is inconsistent, it solves the least-squares problem ``min ||b - Ax||_2``.
-    A is a rectangular matrix of dimension m-by-n, where all cases are
-    allowed: m = n, m > n, or m < n. B is a vector of length m.
+    ``A`` is a rectangular matrix of dimension m-by-n, where all cases are
+    allowed: m = n, m > n, or m < n. ``b`` is a vector of length m.
     The matrix A may be dense or sparse (usually sparse).
 
     Parameters
@@ -44,7 +44,7 @@ def lsmr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
         produce ``Ax`` and ``A^H x`` using, e.g.,
         ``scipy.sparse.linalg.LinearOperator``.
     b : array_like, shape (m,)
-        Vector b in the linear system.
+        Vector ``b`` in the linear system.
     damp : float
         Damping factor for regularized least-squares. `lsmr` solves
         the regularized least-squares problem::
@@ -64,12 +64,12 @@ def lsmr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
         Otherwise, lsmr terminates when ``norm(A^H r) <=
         atol * norm(A) * norm(r)``.  If both tolerances are 1.0e-6 (say),
         the final ``norm(r)`` should be accurate to about 6
-        digits. (The final x will usually have fewer correct digits,
+        digits. (The final ``x`` will usually have fewer correct digits,
         depending on ``cond(A)`` and the size of LAMBDA.)  If `atol`
         or `btol` is None, a default value of 1.0e-6 will be used.
         Ideally, they should be estimates of the relative error in the
-        entries of A and B respectively.  For example, if the entries
-        of `A` have 7 correct digits, set atol = 1e-7. This prevents
+        entries of ``A`` and ``b`` respectively.  For example, if the entries
+        of ``A`` have 7 correct digits, set ``atol = 1e-7``. This prevents
         the algorithm from doing unnecessary work beyond the
         uncertainty of the input data.
     conlim : float, optional
@@ -88,7 +88,7 @@ def lsmr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
     show : bool, optional
         Print iterations logs if ``show=True``.
     x0 : array_like, shape (n,), optional
-        Initial guess of x, if None zeros are used.
+        Initial guess of ``x``, if None zeros are used.
 
         .. versionadded:: 1.0.0
     Returns

--- a/scipy/sparse/linalg/isolve/lsmr.py
+++ b/scipy/sparse/linalg/isolve/lsmr.py
@@ -91,6 +91,7 @@ def lsmr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
         Initial guess of ``x``, if None zeros are used.
 
         .. versionadded:: 1.0.0
+        
     Returns
     -------
     x : ndarray of float


### PR DESCRIPTION
#### What does this implement/fix?
Fixes capitalization of the vector b.
Formats variables to be formatted as code. (Maybe these should be surrounded by single quotes instead of double in places.)