### PR TITLE
BUG: Improve error messages for `range` arg of binned_statistic_dd

### DIFF
--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -676,9 +676,16 @@ def _bin_edges(sample, bins=None, range=None):
         smin = np.atleast_1d(np.array(sample.min(axis=0), float))
         smax = np.atleast_1d(np.array(sample.max(axis=0), float))
     else:
+        if len(range) != Ndim:
+            raise ValueError(
+                f"range given for {len(range)} dimensions; {Ndim} required")
         smin = np.empty(Ndim)
         smax = np.empty(Ndim)
         for i in builtins.range(Ndim):
+            if range[i][1] < range[i][0]:
+                raise ValueError(
+                    "In {}range, start must be <= stop".format(
+                        f"dimension {i + 1} of " if Ndim > 1 else ""))
             smin[i], smax[i] = range[i]
 
     # Make sure the bins have a finite width.

--- a/scipy/stats/tests/test_binned_statistic.py
+++ b/scipy/stats/tests/test_binned_statistic.py
@@ -487,3 +487,26 @@ class TestBinnedStatistic(object):
         bins = (bins, bins, bins)
         with assert_raises(ValueError, match='difference is numerically 0'):
             binned_statistic_dd(x, v, 'mean', bins=bins)
+    
+    def test_dd_range_errors(self):
+        # Test that descriptive exceptions are raised as appropriate for bad
+        # values of the `range` argument. (See gh-12996)
+        with assert_raises(ValueError,
+                           match='In range, start must be <= stop'):
+            binned_statistic_dd([self.y], self.v,
+                                range=[[1, 0]])
+        with assert_raises(
+                ValueError,
+                match='In dimension 1 of range, start must be <= stop'):
+            binned_statistic_dd([self.x, self.y], self.v,
+                                range=[[1, 0], [0, 1]])
+        with assert_raises(
+                ValueError,
+                match='In dimension 2 of range, start must be <= stop'):
+            binned_statistic_dd([self.x, self.y], self.v,
+                                range=[[0, 1], [1, 0]])
+        with assert_raises(
+                ValueError,
+                match='range given for 1 dimensions; 2 required'):
+            binned_statistic_dd([self.x, self.y], self.v,
+                                range=[[0, 1]])


### PR DESCRIPTION
#### Reference issue
n/a

#### What does this implement/fix?
This PR produces meaningful error messages for two specific scenarios involving the `range` argument of `scipy.stats.binned_statistic_dd` (as well as the 1D and 2D wrappers `binned_statistic` and `binned_statistic_2d`). The `range` argument must be a sequence of ranges, one for each dimension of the data, where the range given for each dimension must itself be a sequence listing the lower and upper bounds (in that order) of the range.

The first scenario is when the bounds for any one dimension are given in the wrong order, i.e. upper and then lower bounds. (I encountered this scenario "in the wild" when using `binned_statistic_2d` with quantities which are conventionally plotted with the axes running backwards). This scenario generates an un-helpful exception (note that the first range is given in the wrong order):
```
>>> scipy.stats.binned_statistic_2d(
...         np.arange(10), np.arange(10), np.arange(10),
...         range=[[10, 0], [0, 10]])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/path/scipy/scipy/stats/_binned_statistic.py", line 348, in binned_statistic_2d
    medians, edges, binnumbers = binned_statistic_dd(
  File "/path/scipy/scipy/stats/_binned_statistic.py", line 567, in binned_statistic_dd
    binnumbers = _bin_numbers(sample, nbin, edges, dedges)
  File "/path/scipy/scipy/stats/_binned_statistic.py", line 723, in _bin_numbers
    decimal = int(-np.log10(dedges_min)) + 6
ValueError: cannot convert float NaN to integer
```

With this PR, the error is:
```
>>> scipy.stats.binned_statistic_2d(
...         np.arange(10), np.arange(10), np.arange(10),
...         range=[[10, 0], [0, 10]])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/path/scipy/scipy/stats/_binned_statistic.py", line 348, in binned_statistic_2d
    medians, edges, binnumbers = binned_statistic_dd(
  File "/path/scipy/scipy/stats/_binned_statistic.py", line 566, in binned_statistic_dd
    nbin, edges, dedges = _bin_edges(sample, bins, range)
  File "/path/scipy/scipy/stats/_binned_statistic.py", line 686, in _bin_edges
    raise ValueError(
ValueError: In dimension 1 of range, start must be <= stop
```

(When using 1D data, including via the 1D wrapper `binned_statistic`, this message is reduced to "ValueError: In range, start must be <= stop".)


The second scenario is when the number of ranges provided is not correct, given the dimensions of the data. Again, an unhelpful error is generated (note that two ranges are provided for 3D data):

```
>>> scipy.stats.binned_statistic_dd(
...         [np.arange(10), np.arange(10), np.arange(10)],
...         np.arange(10),
...         range=[[0, 10], [0, 10]])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/path/scipy/scipy/stats/_binned_statistic.py", line 566, in binned_statistic_dd
    nbin, edges, dedges = _bin_edges(sample, bins, range)
  File "/path/scipy/scipy/stats/_binned_statistic.py", line 682, in _bin_edges
    smin[i], smax[i] = range[i]
IndexError: list index out of range
```

With this PR, the error is:
```
>>> scipy.stats.binned_statistic_dd(
...         [np.arange(10), np.arange(10), np.arange(10)],
...         np.arange(10),
...         range=[[0, 10], [0, 10]])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/path/scipy/scipy/stats/_binned_statistic.py", line 566, in binned_statistic_dd
    nbin, edges, dedges = _bin_edges(sample, bins, range)
  File "/path/scipy/scipy/stats/_binned_statistic.py", line 680, in _bin_edges
    raise ValueError(
ValueError: range given for 2 dimensions; 3 required
```

#### Additional information
I made the change in the function `_bin_edges`, which is where the `range` argument is actually parsed. To shorten the stack trace, the checking and exception-raising could instead happen in `binned_statistic_dd` (which is the only function currently calling `_bin_edges`, and is itself called by the 1D and 2D versions), but putting it in `_bin_edges` allows the checking to be inherited by any future function that builds directly on `_bin_edges`.