### PR TITLE
MAINT: approx_derivative with FP32 closes #12991

### DIFF
--- a/scipy/optimize/_numdiff.py
+++ b/scipy/optimize/_numdiff.py
@@ -87,7 +87,7 @@ def _adjust_scheme_to_bounds(x0, h, num_steps, scheme, lb, ub):
     return h_adjusted, use_one_sided
 
 
-@functools.lru_cache
+@functools.lru_cache()
 def _eps_for_method(x0_dtype, f0_dtype, method):
     """
     Calculates relative EPS step to use for a given data type

--- a/scipy/optimize/_numdiff.py
+++ b/scipy/optimize/_numdiff.py
@@ -96,7 +96,7 @@ def _eps_for_method(f0, method):
 
     Parameters
     ----------
-    f0: np.ndarray or scalar
+    f0: np.ndarray
 
     method: {'2-point', '3-point', 'cs'}
     """

--- a/scipy/optimize/_numdiff.py
+++ b/scipy/optimize/_numdiff.py
@@ -1,5 +1,5 @@
 """Routines for numerical differentiation."""
-from functools import lru_cache
+import functools
 import numpy as np
 from numpy.linalg import norm
 
@@ -87,7 +87,7 @@ def _adjust_scheme_to_bounds(x0, h, num_steps, scheme, lb, ub):
     return h_adjusted, use_one_sided
 
 
-@lru_cache
+@functools.lru_cache
 def _eps_for_method(x0_dtype, f0_dtype, method):
     """
     Calculates relative EPS step to use for a given data type

--- a/scipy/optimize/tests/test__numdiff.py
+++ b/scipy/optimize/tests/test__numdiff.py
@@ -56,18 +56,23 @@ def test_correct_eps():
         )
 
     # check another FP size
+    EPS = np.finfo(np.float32).eps
+    relative_step = {"2-point": EPS**0.5,
+                    "3-point": EPS**(1/3),
+                     "cs": EPS**0.5}
+
     for method in ['2-point', '3-point', 'cs']:
         assert_allclose(
             _eps_for_method(np.float64, np.float32, method),
-            np.sqrt(np.finfo(np.float32).eps)
+            relative_step[method]
         )
         assert_allclose(
             _eps_for_method(np.float32, np.float64, method),
-            np.sqrt(np.finfo(np.float32).eps)
+            relative_step[method]
         )
         assert_allclose(
             _eps_for_method(np.float32, np.float32, method),
-            np.sqrt(np.finfo(np.float32).eps)
+            relative_step[method]
         )
 
 

--- a/scipy/optimize/tests/test__numdiff.py
+++ b/scipy/optimize/tests/test__numdiff.py
@@ -48,31 +48,27 @@ def test_correct_eps():
                      "cs": EPS**0.5}
     for method in ['2-point', '3-point', 'cs']:
         assert_allclose(
-            _eps_for_method(np.array(0.1), method),
-            relative_step[method]
-        )
+            _eps_for_method(np.float64, np.float64, method),
+            relative_step[method])
         assert_allclose(
-            _eps_for_method(np.array([0.1], dtype=np.float64), method),
-            relative_step[method]
-        )
-        assert_allclose(
-            _eps_for_method(np.empty((1,), dtype=np.complex128), method),
+            _eps_for_method(np.complex128, np.complex128, method),
             relative_step[method]
         )
 
     # check another FP size
-    assert_allclose(
-        _eps_for_method(np.zeros((1,), dtype=np.float32), "2-point"),
-        np.sqrt(np.finfo(np.float32).eps)
-    )
-    assert_allclose(
-        _eps_for_method(np.zeros((1,), dtype=np.float32), "3-point"),
-        (np.finfo(np.float32).eps)**(1/3)
-    )
-    assert_allclose(
-        _eps_for_method(np.zeros((1,), dtype=np.float32), "cs"),
-        np.sqrt(np.finfo(np.float32).eps)
-    )
+    for method in ['2-point', '3-point', 'cs']:
+        assert_allclose(
+            _eps_for_method(np.float64, np.float32, method),
+            np.sqrt(np.finfo(np.float32).eps)
+        )
+        assert_allclose(
+            _eps_for_method(np.float32, np.float64, method),
+            np.sqrt(np.finfo(np.float32).eps)
+        )
+        assert_allclose(
+            _eps_for_method(np.float32, np.float32, method),
+            np.sqrt(np.finfo(np.float32).eps)
+        )
 
 
 class TestAdjustSchemeToBounds(object):

--- a/scipy/optimize/tests/test__numdiff.py
+++ b/scipy/optimize/tests/test__numdiff.py
@@ -47,29 +47,29 @@ def test_correct_eps():
                     "3-point": EPS**(1/3),
                      "cs": EPS**0.5}
     for method in ['2-point', '3-point', 'cs']:
-        assert_equal(
-            _eps_for_method(0.1, method),
+        assert_allclose(
+            _eps_for_method(np.array(0.1), method),
             relative_step[method]
         )
-        assert_equal(
+        assert_allclose(
             _eps_for_method(np.array([0.1], dtype=np.float64), method),
             relative_step[method]
         )
-        assert_equal(
+        assert_allclose(
             _eps_for_method(np.empty((1,), dtype=np.complex128), method),
             relative_step[method]
         )
 
     # check another FP size
-    assert_equal(
+    assert_allclose(
         _eps_for_method(np.zeros((1,), dtype=np.float32), "2-point"),
         np.sqrt(np.finfo(np.float32).eps)
     )
-    assert_equal(
+    assert_allclose(
         _eps_for_method(np.zeros((1,), dtype=np.float32), "3-point"),
-        (np.finfo(np.float32).eps)**1/3
+        (np.finfo(np.float32).eps)**(1/3)
     )
-    assert_equal(
+    assert_allclose(
         _eps_for_method(np.zeros((1,), dtype=np.float32), "cs"),
         np.sqrt(np.finfo(np.float32).eps)
     )

--- a/scipy/optimize/tests/test__numdiff.py
+++ b/scipy/optimize/tests/test__numdiff.py
@@ -437,13 +437,21 @@ class TestApproxDerivativesDense(object):
 
         x = np.linspace(0, 1, 100, dtype=np.float64)
         y = np.random.random(100).astype(np.float64)
-        x0 = [-1.0, -1.0]
+        p0 = np.array([-1.0, -1.0])
 
-        jac_fp64 = approx_derivative(err, x0, method='2-point', args=(x, y))
+        jac_fp64 = approx_derivative(err, p0, method='2-point', args=(x, y))
 
-        x32 = x.astype(np.float32)
-        y32 = y.astype(np.float32)
-        jac_fp = approx_derivative(err, x0, method='2-point', args=(x32, y32))
+        # parameter vector is float32, func output is float64
+        jac_fp = approx_derivative(err, p0.astype(np.float32),
+                                   method='2-point', args=(x, y))
+        assert err(p0, x, y).dtype == np.float64
+        assert_allclose(jac_fp, jac_fp64, atol=1e-3)
+
+        # parameter vector is float64, func output is float32
+        err_fp32 = lambda p: err(p, x, y).astype(np.float32)
+        jac_fp = approx_derivative(err_fp32, p0,
+                                   method='2-point')
+        assert err_fp32(p0).dtype == np.float32
         assert_allclose(jac_fp, jac_fp64, atol=1e-3)
 
     def test_check_derivative(self):

--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -763,6 +763,7 @@ def test_fp32_gh12991():
 
     x = np.linspace(0, 1, 100).astype("float32")
     y = np.random.random(100).astype("float32")
+
     def func(p, x):
         return p[0] + p[1] * x
 
@@ -777,4 +778,4 @@ def test_fp32_gh12991():
     # It was terminating early because the underlying approx_derivative
     # used a step size for FP64 when the working space was FP32.
     assert res.nfev > 3
-    assert_allclose(res.x, np.array([0.4082241 , 0.15530563]), atol=5e-5)
+    assert_allclose(res.x, np.array([0.4082241, 0.15530563]), atol=5e-5)

--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -754,3 +754,27 @@ def test_small_tolerances_for_lm():
                              (1e-13, 1e-13, None)]:
         assert_raises(ValueError, least_squares, fun_trivial, 2.0, xtol=xtol,
                       ftol=ftol, gtol=gtol, method='lm')
+
+
+def test_fp32_gh12991():
+    # checks that smaller FP sizes can be used in least_squares
+    # this is the minimum working example reported for gh12991
+    np.random.seed(1)
+
+    x = np.linspace(0, 1, 100).astype("float32")
+    y = np.random.random(100).astype("float32")
+    def func(p, x):
+        return p[0] + p[1] * x
+
+    def err(p, x, y):
+        return func(p, x) - y
+
+    res = least_squares(err, [-1.0, -1.0], args=(x, y))
+    # previously the initial jacobian calculated for this would be all 0
+    # and the minimize would terminate immediately, with nfev=1, would
+    # report a successful minimization (it shouldn't have done), but be
+    # unchanged from the initial solution.
+    # It was terminating early because the underlying approx_derivative
+    # used a step size for FP64 when the working space was FP32.
+    assert res.nfev > 3
+    assert_allclose(res.x, np.array([0.4082241 , 0.15530563]), rtol=1e-4)

--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -777,4 +777,4 @@ def test_fp32_gh12991():
     # It was terminating early because the underlying approx_derivative
     # used a step size for FP64 when the working space was FP32.
     assert res.nfev > 3
-    assert_allclose(res.x, np.array([0.4082241 , 0.15530563]), rtol=1e-4)
+    assert_allclose(res.x, np.array([0.4082241 , 0.15530563]), atol=5e-5)


### PR DESCRIPTION
#12991 reports that `optimize.least_squares` stops prematurely when the problem is specified with `np.float32`. This is because `approx_derivative` only chooses step sizes suitable for working with `np.float64`. This PR changes `approx_derivative` to choose a step size that is determined by `np.finfo(fun(x0).dtype).eps`.

I tried to add some tests, but they are basic, and might need more improving.

closes #12991 