### PR TITLE
Keep correct dtype when loading empty mat arrays.

### DIFF
--- a/scipy/io/matlab/mio_utils.pyx
+++ b/scipy/io/matlab/mio_utils.pyx
@@ -12,7 +12,7 @@ cpdef object squeeze_element(cnp.ndarray arr):
     The returned object may not be an ndarray - for example if we do
     ``arr.item`` to return a ``mat_struct`` object from a struct array '''
     if not arr.size:
-        return np.array([])
+        return np.array([], dtype=arr.dtype)
     cdef cnp.ndarray arr2 = np.squeeze(arr)
     # We want to squeeze 0d arrays, unless they are record arrays
     if arr2.ndim == 0 and arr2.dtype.kind != 'V':

--- a/scipy/io/matlab/tests/test_mio_utils.py
+++ b/scipy/io/matlab/tests/test_mio_utils.py
@@ -18,6 +18,9 @@ def test_squeeze_element():
     # Unless it's a structured array
     sq_sa = squeeze_element(np.zeros((1,1),dtype=[('f1', 'f')]))
     assert_(isinstance(sq_sa, np.ndarray))
+    # Squeezing empty arrays maintain their dtypes.
+    sq_empty = squeeze_element(np.empty(0, np.uint8))
+    assert sq_empty.dtype == np.uint8
 
 
 def test_chars_strings():


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #6096.

#### What does this implement/fix?
Keep correct dtype when loading empty mat arrays.  See discussion in linked issue.

#### Additional information
<!--Any additional information you think is important.-->