### PR TITLE
ENH: optimize: Nelder-Mead: allow passing initial simplex as x0 & add adaptive parameter to fmin

### DIFF
--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -441,7 +441,8 @@ def wrap_function(function, args):
 
 
 def fmin(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None, maxfun=None,
-         full_output=0, disp=1, retall=0, callback=None, initial_simplex=None):
+         full_output=0, disp=1, retall=0, callback=None, initial_simplex=None,
+         adaptive=False, ):
     """
     Minimize a function using the downhill simplex algorithm.
 
@@ -485,6 +486,9 @@ def fmin(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None, maxfun=None,
         ``initial_simplex[j,:]`` should contain the coordinates of
         the jth vertex of the ``N+1`` vertices in the simplex, where
         ``N`` is the dimension.
+    adaptive : bool, optional
+        Adapt algorithm parameters to dimensionality of problem. Useful for
+        high-dimensional minimization [3]_.
 
     Returns
     -------
@@ -547,6 +551,10 @@ def fmin(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None, maxfun=None,
            Griffiths and G.A. Watson (Eds.), Addison Wesley Longman,
            Harlow, UK, pp. 191-208.
 
+    .. [3] Gao, F. and Han, L. (2012), "Implementing the Nelder-Mead simplex
+           algorithm with adaptive parameters", Computational Optimization and
+           Applications, 51:1, pp. 259-277
+
     """
     opts = {'xatol': xtol,
             'fatol': ftol,
@@ -554,19 +562,16 @@ def fmin(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None, maxfun=None,
             'maxfev': maxfun,
             'disp': disp,
             'return_all': retall,
-            'initial_simplex': initial_simplex}
+            'initial_simplex': initial_simplex,
+            'adaptive': adaptive, }
 
     res = _minimize_neldermead(func, x0, args, callback=callback, **opts)
+    retlist = res['x'],
     if full_output:
-        retlist = res['x'], res['fun'], res['nit'], res['nfev'], res['status']
-        if retall:
-            retlist += (res['allvecs'], )
-        return retlist
-    else:
-        if retall:
-            return res['x'], res['allvecs']
-        else:
-            return res['x']
+        retlist += res['fun'], res['nit'], res['nfev'], res['status'],
+    if retall:
+        retlist += res['allvecs'],
+    return retlist
 
 
 def _minimize_neldermead(func, x0, args=(), callback=None,

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -500,6 +500,12 @@ def test_neldermead_adaptive():
                             options={'adaptive': True})
     assert_equal(res.success, True)
 
+    res_list = optimize.fmin(func, p0, full_output=True)
+    assert_equal(res_list[-1], 1)
+
+    res_list = optimize.fmin(func, p0, full_output=True, adaptive=True)
+    assert_equal(res_list[-1], 0)
+
 
 def test_bounded_powell_outsidebounds():
     # With the bounded Powell method if you start outside the bounds the final

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -307,10 +307,10 @@ class CheckOptimizeParameterized(CheckOptimize):
                                                            res['status'])
             assert_allclose(res['allvecs'][0], simplex[0])
         else:
-            retval = optimize.fmin(self.func, self.startparams,
+            retval = optimize.fmin(self.func, simplex,
                                    args=(), maxiter=self.maxiter,
                                    full_output=True, disp=False, retall=False,
-                                   initial_simplex=simplex)
+                                   )
 
             (params, fopt, numiter, func_calls, warnflag) = retval
 
@@ -354,10 +354,9 @@ class CheckOptimizeParameterized(CheckOptimize):
                               options=opts)
             else:
                 assert_raises(ValueError, optimize.fmin,
-                              self.func, self.startparams,
+                              self.func, simplex,
                               args=(), maxiter=self.maxiter,
-                              full_output=True, disp=False, retall=False,
-                              initial_simplex=simplex)
+                              full_output=True, disp=False, retall=False, )
 
     def test_ncg_negative_maxiter(self):
         # Regression test for gh-8241


### PR DESCRIPTION
Closes gh-13000

* Allows passing initial simplex as `x0`, which gives it more prominence, removes the need to also pass an initial guess, and removes the need for the separate `initial_simplex` parameter
* Makes the `adaptive` parameter available in the `fmin` function (at present `adaptive` can only be set when using the `minimize` function).

I've also adapted the tests accordingly.