### PR TITLE
BUG: Add explicit cast to _tmp sum.

### DIFF
--- a/scipy/ndimage/src/ni_filters.c
+++ b/scipy/ndimage/src/ni_filters.c
@@ -516,7 +516,7 @@ case _TYPE:                                                              \
         _oo = _offsets[_ii];                                             \
         _tmp = _oo == _mv ? _cv : *(_type *)(_pi + _oo);                 \
         if (_ss != NULL) {                                               \
-            _tmp += _ss[_ii];                                            \
+            _tmp += (_type) _ss[_ii];                                    \
         }                                                                \
         if (_minimum) {                                                  \
             if (_tmp < _res) {                                           \


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Fixes a bug that manifests on Apple Silicon platform.

#### What does this implement/fix?
<!--Please explain your changes.-->
When building scipy with conda-forge for Apple Silicon (`osx-arm64`) there is one test that fails.  I tracked this down to the macro `CASE_MIN_OR_MAX_POINT` which implicitly adds a `double` to a `npy_bool` (this is specifically in the tests, but it will implicitly add a `double` to whichever the `_type` is in the case statement).  For some reason, this implicit promotion is not working on `osx-arm64`, but changing it to an explicit cast (which I believe is what should be done in any case) works.

#### Additional information
<!--Any additional information you think is important.-->
Unfortunately, there are currently no publicly accessible machines that can be used to verify that this does fix the problem.