### PR TITLE
TST: xfail test_maxiter_worsening()

### DIFF
--- a/scipy/sparse/linalg/isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/isolve/tests/test_iterative.py
@@ -3,6 +3,7 @@
 
 import itertools
 import platform
+import sys
 import numpy as np
 
 from numpy.testing import (assert_equal, assert_array_equal,
@@ -447,7 +448,10 @@ def test_zero_rhs(solver):
 
 
 @pytest.mark.parametrize("solver", [
-    gmres, qmr,
+    pytest.param(gmres, marks=pytest.mark.xfail(platform.machine() == 'aarch64'
+                                                and sys.version_info[1] == 9,
+                                                reason="gh-13019")),
+    qmr,
     pytest.param(lgmres, marks=pytest.mark.xfail(platform.machine() == 'ppc64le',
                                                  reason="fails on ppc64le")),
     pytest.param(cgs, marks=pytest.mark.xfail),


### PR DESCRIPTION
* selectively `xfail` `test_maxiter_worsening()` for the Linux ARM64 +
Python `3.9` scenario where it is currently failing in the wheels repo,
as described in gh-13019 (only for the `gmres` parameter)

* while a proper fix for the issue would be most welcome, I suspect we
don't want to hold up a release with `3.9` wheels & XCode `12.x` build
fixes for a single test tolerance issue on ARM64