### PR TITLE
MAINT: backports for SciPy 1.5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,10 @@ matrix:
         # TODO: remove "ignore[import]" filter below when moving to pyflakes==2.1.2 or above
         - PYFLAKES_NODOCTEST=1 pyflakes scipy benchmarks/benchmarks 2>&1 | grep -E -v 'unable to detect undefined names|assigned to but never used|imported but unused|redefinition of unused|may be undefined, or defined from star imports|syntax error in type comment .ignore.import.' > test.out; cat test.out; test \! -s test.out
         - pycodestyle scipy benchmarks/benchmarks
-        - tools/lint_diff.py
+        - |
+          if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+             python tools/lint_diff.py --branch $TRAVIS_BRANCH
+          fi
         - |
           grep -rlIP '[^\x00-\x7F]' scipy | grep '\.pyx\?' | sort > unicode.out; grep -rlI '# -\*- coding: \(utf-8\|latin-1\) -\*-' scipy | grep '\.pyx\?' | sort > coding.out; comm -23 unicode.out coding.out > test_code.out; cat test_code.out;  test \! -s test_code.out
     - python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,10 @@ matrix:
         - pycodestyle scipy benchmarks/benchmarks
         - |
           if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-             python tools/lint_diff.py --branch $TRAVIS_BRANCH
+             git fetch --unshallow
+             git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+             git fetch origin
+             python tools/lint_diff.py --branch origin/$TRAVIS_BRANCH
           fi
         - |
           grep -rlIP '[^\x00-\x7F]' scipy | grep '\.pyx\?' | sort > unicode.out; grep -rlI '# -\*- coding: \(utf-8\|latin-1\) -\*-' scipy | grep '\.pyx\?' | sort > coding.out; comm -23 unicode.out coding.out > test_code.out; cat test_code.out;  test \! -s test_code.out

--- a/.travis.yml
+++ b/.travis.yml
@@ -211,7 +211,7 @@ before_install:
   # Miniforge / conda-forge), so skip arm64 here
   - |
     if [[ "$TRAVIS_CPU_ARCH" != "arm64" ]]; then
-         travis_retry pip install --upgrade pip setuptools wheel $OTHERSPEC cython pytest pytest-xdist mpmath argparse Pillow codecov gmpy2 pybind11
+         travis_retry pip install --upgrade pip==20.2.4 setuptools wheel $OTHERSPEC cython pytest pytest-xdist mpmath argparse Pillow codecov gmpy2 pybind11
          travis_retry pip install --upgrade $NUMPYSPEC
     fi
   - |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -93,6 +93,11 @@ jobs:
           NPY_USE_BLAS_ILP64: 1
           BITS: 64
           OPENBLAS64_: $(OPENBLAS)
+        Python39-64bit-full:
+          PYTHON_VERSION: '3.9'
+          PYTHON_ARCH: 'x64'
+          TEST_MODE: full
+          BITS: 64
   steps:
   - task: UsePythonVersion@0
     inputs:

--- a/doc/release/1.5.4-notes.rst
+++ b/doc/release/1.5.4-notes.rst
@@ -5,14 +5,48 @@ SciPy 1.5.4 Release Notes
 .. contents::
 
 SciPy 1.5.4 is a bug-fix release with no new features
-compared to 1.5.3.
+compared to 1.5.3. Importantly, wheels are now available
+for Python 3.9 and a more complete fix has been applied for
+issues building with XCode 12.
 
 Authors
 =======
 
+* Peter Bell
+* CJ Carey
+* Andrew McCluskey +
+* Andrew Nelson
+* Tyler Reddy
+* Eli Rykoff +
+* Ian Thomas +
+
+A total of 7 people contributed to this release.
+People with a "+" by their names contributed a patch for the first time.
+This list of names is automatically generated, and may not be fully complete.
+
 Issues closed for 1.5.4
 -----------------------
+
+* `#12763 <https://github.com/scipy/scipy/issues/12763>`__: ndimage.fourier_ellipsoid segmentation fault
+* `#12789 <https://github.com/scipy/scipy/issues/12789>`__: TestConvolve2d.test_large_array failing on Windows ILP64 CI job
+* `#12857 <https://github.com/scipy/scipy/issues/12857>`__: sparse A[0,:] = ndarray is ok, A[:,0] = ndarray ValueError from...
+* `#12860 <https://github.com/scipy/scipy/issues/12860>`__: BUG: Build failure with Xcode 12
+* `#12935 <https://github.com/scipy/scipy/issues/12935>`__: Failure to build with Python 3.9.0 on macOS
+* `#12966 <https://github.com/scipy/scipy/issues/12966>`__: MAINT: lint_diff.py on some backport PRs
+* `#12988 <https://github.com/scipy/scipy/issues/12988>`__: BUG: Highly multi-dimensional \`gaussian_kde\` giving \`-inf\`...
 
 Pull requests for 1.5.4
 -----------------------
 
+* `#12790 <https://github.com/scipy/scipy/pull/12790>`__: TST: Skip TestConvolve2d.test_large_array if not enough memory
+* `#12851 <https://github.com/scipy/scipy/pull/12851>`__: BUG: sparse: fix inner indexed assignment of a 1d array
+* `#12875 <https://github.com/scipy/scipy/pull/12875>`__: BUG: segfault in ndimage.fourier_ellipsoid with length-1 dims
+* `#12937 <https://github.com/scipy/scipy/pull/12937>`__: CI: macOS3.9 testing
+* `#12957 <https://github.com/scipy/scipy/pull/12957>`__: MAINT: fixes XCode 12/ python 3.9.0 build for 1.5.x maint branch
+* `#12959 <https://github.com/scipy/scipy/pull/12959>`__: CI: add Windows Python 3.9 to CI
+* `#12974 <https://github.com/scipy/scipy/pull/12974>`__: MAINT: Run lint_diff.py against the merge target and only for...
+* `#12978 <https://github.com/scipy/scipy/pull/12978>`__: DOC: next_fast_len output doesn't match docstring
+* `#12979 <https://github.com/scipy/scipy/pull/12979>`__: BUG: fft.next_fast_len should accept keyword arguments
+* `#12989 <https://github.com/scipy/scipy/pull/12989>`__: BUG: improved the stability of kde for highly (1000s) multi-dimension...
+* `#13017 <https://github.com/scipy/scipy/pull/13017>`__: BUG: Add explicit cast to _tmp sum.
+* `#13022 <https://github.com/scipy/scipy/pull/13022>`__: TST: xfail test_maxiter_worsening()

--- a/scipy/fft/_pocketfft/pypocketfft.cxx
+++ b/scipy/fft/_pocketfft/pypocketfft.cxx
@@ -374,11 +374,13 @@ py::array genuine_hartley(const py::array &in, const py::object &axes_,
   }
 
 // Export good_size in raw C-API to reduce overhead (~4x faster)
-PyObject * good_size(PyObject * /*self*/, PyObject * args)
+PyObject * good_size(PyObject * /*self*/, PyObject * args, PyObject * kwargs)
   {
   Py_ssize_t n_ = -1;
   int real = false;
-  if (!PyArg_ParseTuple(args, "n|p:good_size", &n_, &real))
+  char * keywords[] = {"target", "real", nullptr};
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "n|p:good_size", keywords,
+                                   &n_, &real))
     return nullptr;
 
   if (n_<0)
@@ -687,7 +689,7 @@ const char * good_size_DS = R"""(Returns a good length to pad an FFT to.
 
 Parameters
 ----------
-n : int
+target : int
     Minimum transform length
 real : bool, optional
     True if either input or output of FFT should be fully real.
@@ -724,6 +726,7 @@ PYBIND11_MODULE(pypocketfft, m)
     "out"_a=None, "nthreads"_a=1);
 
   static PyMethodDef good_size_meth[] =
-    {{"good_size", good_size, METH_VARARGS, good_size_DS}, {0}};
+    {{"good_size", (PyCFunction)good_size,
+      METH_VARARGS | METH_KEYWORDS, good_size_DS}, {0}};
   PyModule_AddFunctions(m.ptr(), good_size_meth);
   }

--- a/scipy/fft/_pocketfft/version.md
+++ b/scipy/fft/_pocketfft/version.md
@@ -4,15 +4,15 @@ pypocketfft version
 
 SciPy currently vendors [pypocketfft] at:
 
-    commit 2147aaf37c6274cc77160f6b355ed9d120cfdc57
-    Merge: 80bb41a 99599e1
+    commit bf2c431c21213b7c5e23c2f542009b0bd3ec1445
+    Merge: 8234f5c 9c252b2
     Author: Martin Reinecke <martin@mpa-garching.mpg.de>
-    Date:   Sat Jan 11 17:09:17 2020 +0100
+    Date:   Tue Oct 20 15:16:14 2020 +0200
 
-        Merge branch 'more_clang_fixes' into 'master'
+        Merge branch 'good_size_keywords' into 'master'
 
-        address more problems with clang (and follow its optimization hints)
+        Handle keyword args in good_size
 
-        See merge request mtr/pypocketfft!35
+        See merge request mtr/pypocketfft!41
 
 pypocketfft: https://gitlab.mpcdf.mpg.de/mtr/pypocketfft

--- a/scipy/fft/tests/test_helper.py
+++ b/scipy/fft/tests/test_helper.py
@@ -109,6 +109,10 @@ class TestNextFastLen(object):
         for x, y in hams.items():
             assert_equal(next_fast_len(x, True), y)
 
+    def test_keyword_args(self):
+        assert next_fast_len(11, real=True) == 12
+        assert next_fast_len(target=7, real=False) == 7
+
 
 class Test_init_nd_shape_and_axes(object):
 

--- a/scipy/ndimage/src/ni_filters.c
+++ b/scipy/ndimage/src/ni_filters.c
@@ -516,7 +516,7 @@ case _TYPE:                                                              \
         _oo = _offsets[_ii];                                             \
         _tmp = _oo == _mv ? _cv : *(_type *)(_pi + _oo);                 \
         if (_ss != NULL) {                                               \
-            _tmp += _ss[_ii];                                            \
+            _tmp += (_type) _ss[_ii];                                    \
         }                                                                \
         if (_minimum) {                                                  \
             if (_tmp < _res) {                                           \

--- a/scipy/ndimage/src/ni_fourier.c
+++ b/scipy/ndimage/src/ni_fourier.c
@@ -225,7 +225,7 @@ int NI_FourierFilter(PyArrayObject *input, PyArrayObject* parameter_array,
         params[kk] = NULL;
     }
     for (kk = 0; kk < PyArray_NDIM(input); kk++) {
-        if (PyArray_DIM(input, kk) > 1) {
+        if (PyArray_DIM(input, kk) > 1 || filter_type == _NI_ELLIPSOID) {
             params[kk] = malloc(PyArray_DIM(input, kk) * sizeof(double));
             if (!params[kk]) {
                 PyErr_NoMemory();

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -31,6 +31,7 @@ from scipy.signal.windows import hann
 from scipy.signal.signaltools import (_filtfilt_gust, _compute_factors,
                                       _group_poles)
 from scipy.signal._upfirdn import _upfirdn_modes
+from scipy._lib import _testutils
 
 
 class _TestConvolve(object):
@@ -413,6 +414,7 @@ class TestConvolve2d(_TestConvolve2d):
     def test_large_array(self):
         # Test indexing doesn't overflow an int (gh-10761)
         n = 2**31 // (1000 * np.int64().itemsize)
+        _testutils.check_free_memory(2 * n * 1001 * np.int64().itemsize / 1e6)
 
         # Create a chequered pattern of 1s and 0s
         a = np.zeros(1001 * n, dtype=np.int64)

--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -117,7 +117,8 @@ class IndexMixin(object):
         else:
             # Make x and i into the same shape
             x = np.asarray(x, dtype=self.dtype)
-            x, _ = _broadcast_arrays(x, i)
+            if x.squeeze().shape != i.squeeze().shape:
+                x = np.broadcast_to(x, i.shape)
             if x.size == 0:
                 return
             x = x.reshape(i.shape)

--- a/scipy/sparse/linalg/isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/isolve/tests/test_iterative.py
@@ -3,6 +3,7 @@
 
 import itertools
 import platform
+import sys
 import numpy as np
 
 from numpy.testing import (assert_equal, assert_array_equal,
@@ -447,7 +448,10 @@ def test_zero_rhs(solver):
 
 
 @pytest.mark.parametrize("solver", [
-    gmres, qmr,
+    pytest.param(gmres, marks=pytest.mark.xfail(platform.machine() == 'aarch64'
+                                                and sys.version_info[1] == 9,
+                                                reason="gh-13019")),
+    qmr,
     pytest.param(lgmres, marks=pytest.mark.xfail(platform.machine() == 'ppc64le',
                                                  reason="fails on ppc64le")),
     pytest.param(cgs, marks=pytest.mark.xfail),

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2630,12 +2630,21 @@ class _TestSlicingAssign(object):
         assert_raises(ValueError, A.__setitem__,
                       ([[1, 2, 3], [0, 3, 4], [4, 1, 3]],
                        [[1, 2, 4], [0, 1, 3]]), [2, 3, 4])
+        assert_raises(ValueError, A.__setitem__, (slice(4), 0),
+                      [[1, 2], [3, 4]])
 
     def test_assign_empty_spmatrix(self):
         A = self.spmatrix(np.ones((2, 3)))
         B = self.spmatrix((1, 2))
         A[1, :2] = B
         assert_array_equal(A.todense(), [[1, 1, 1], [0, 0, 1]])
+
+    def test_assign_1d_slice(self):
+        A = self.spmatrix(np.ones((3, 3)))
+        x = np.zeros(3)
+        A[:, 0] = x
+        A[1, :] = x
+        assert_array_equal(A.todense(), [[0, 1, 1], [0, 0, 0], [0, 1, 1]])
 
 class _TestFancyIndexing(object):
     """Tests fancy indexing features.  The tests for any matrix formats

--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -396,6 +396,23 @@ def test_pdf_logpdf_weighted():
     assert_almost_equal(pdf, pdf2, decimal=12)
 
 
+def test_logpdf_overflow():
+    # regression test for gh-12988; testing against linalg instability for
+    # very high dimensionality kde
+    np.random.seed(1)
+    n_dimensions = 2500
+    n_samples = 5000
+    xn = np.array([np.random.randn(n_samples) + (n) for n in range(
+        0, n_dimensions)])
+
+    # Default
+    gkde = stats.gaussian_kde(xn)
+
+    logpdf = gkde.logpdf(np.arange(0, n_dimensions))
+    np.testing.assert_equal(np.isneginf(logpdf[0]), False)
+    np.testing.assert_equal(np.isnan(logpdf[0]), False)
+
+
 def test_weights_intact():
     # regression test for gh-9709: weights are not modified
     np.random.seed(12345)

--- a/tools/lint_diff.py
+++ b/tools/lint_diff.py
@@ -2,6 +2,7 @@
 import os
 import sys
 import subprocess
+from argparse import ArgumentParser
 
 CONFIG = os.path.join(
     os.path.abspath(os.path.dirname(__file__)),
@@ -31,8 +32,8 @@ def rev_list(branch, num_commits):
     return res.stdout.rstrip('\n').split('\n')
 
 
-def find_branch_point():
-    """Find when the current branch split off master.
+def find_branch_point(branch):
+    """Find when the current branch split off from the given branch.
 
     It is based off of this Stackoverflow post:
 
@@ -40,7 +41,7 @@ def find_branch_point():
 
     """
     branch_commits = rev_list('HEAD', 1000)
-    master_commits = set(rev_list('master', 1000))
+    master_commits = set(rev_list(branch, 1000))
     for branch_commit in branch_commits:
         if branch_commit in master_commits:
             return branch_commit
@@ -74,7 +75,12 @@ def run_pycodestyle(diff):
 
 
 def main():
-    branch_point = find_branch_point()
+    parser = ArgumentParser()
+    parser.add_argument("--branch", type=str, default='master',
+                        help="The branch to diff against")
+    args = parser.parse_args()
+
+    branch_point = find_branch_point(args.branch)
     diff = find_diff(branch_point)
     rc, errors = run_pycodestyle(diff)
     if errors:


### PR DESCRIPTION
SciPy `1.5.4` contains some high-priority fixes, including wheels for Python 3.9 and the actual fix for building on XCode 12.

This PR contains a number of backports and an update to the `1.5.4` release notes.