### PR TITLE
DOC: fix docstring errors in in stats.wilcoxon

### DIFF
--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -2819,21 +2819,21 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=False,
     Parameters
     ----------
     x : array_like
-        Either the first set of measurements (in which case `y` is the second
+        Either the first set of measurements (in which case ``y`` is the second
         set of measurements), or the differences between two sets of
-        measurements (in which case `y` is not to be specified.)  Must be
+        measurements (in which case ``y`` is not to be specified.)  Must be
         one-dimensional.
     y : array_like, optional
-        Either the second set of measurements (if `x` is the first set of
-        measurements), or not specified (if `x` is the differences between
+        Either the second set of measurements (if ``x`` is the first set of
+        measurements), or not specified (if ``x`` is the differences between
         two sets of measurements.)  Must be one-dimensional.
-    zero_method : {'pratt', 'wilcox', 'zsplit'}, optional
-        The following options are available (default is 'wilcox'):
+    zero_method : {"pratt", "wilcox", "zsplit"}, optional
+        The following options are available (default is "wilcox"):
      
-          * 'pratt': Includes zero-differences in the ranking process,
+          * "pratt": Includes zero-differences in the ranking process,
             but drops the ranks of the zeros, see [4]_, (more conservative).
-          * 'wilcox': Discards all zero-differences, the default.
-          * 'zsplit': Includes zero-differences in the ranking process and 
+          * "wilcox": Discards all zero-differences, the default.
+          * "zsplit": Includes zero-differences in the ranking process and
             split the zero rank between positive and negative ones.
     correction : bool, optional
         If True, apply continuity correction by adjusting the Wilcoxon rank
@@ -2848,11 +2848,11 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=False,
     Returns
     -------
     statistic : float
-        If `alternative` is "two-sided", the sum of the ranks of the
+        If ``alternative`` is "two-sided", the sum of the ranks of the
         differences above or below zero, whichever is smaller.
         Otherwise the sum of the ranks of the differences above zero.
     pvalue : float
-        The p-value for the test depending on `alternative` and `mode`.
+        The p-value for the test depending on ``alternative`` and ``mode``.
 
     See Also
     --------


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Fix #12985 

#### What does this implement/fix?
Fixed some docstring errors in stats.wilcoxon.
I changed single backticks to double backticks for arguments and to double quotations for strings.
