### PR TITLE
ENH: Allow QAP to accept adjacency matrices of different sizes

### DIFF
--- a/scipy/optimize/_qap.py
+++ b/scipy/optimize/_qap.py
@@ -520,12 +520,8 @@ def _quadratic_assignment_faq(A, B,
 
 
 def _adj_pad(A, B, method):
-    # pads the matrix with less nodes such that A & B are same size
-    # schemes according to section 2.5 of [2]
-    def pad(X, n):
-        X_pad = np.zeros((n[1], n[1]))
-        X_pad[: n[0], : n[0]] = X
-        return X_pad
+    # pads the smaller of A and B to be the same size as the larger
+    # padding schemes according to section 2.5 of [2]
 
     A_n = A.shape[0]
     B_n = B.shape[0]
@@ -535,9 +531,9 @@ def _adj_pad(A, B, method):
         B = 2 * B - np.ones((B_n, B_n))
 
     if A.shape[0] == n[0]:
-        A = pad(A, n)
+        A = np.pad(A, (0, n[1]-n[0]))
     else:
-        B = pad(B, n)
+        B = np.pad(B, (0, n[1]-n[0]))
 
     return A, B
 

--- a/scipy/optimize/_qap.py
+++ b/scipy/optimize/_qap.py
@@ -531,9 +531,9 @@ def _adj_pad(A, B, method):
         B = 2 * B - np.ones((B_n, B_n))
 
     if A.shape[0] == n[0]:
-        A = np.pad(A, (0, n[1]-n[0]))
+        A = np.pad(A, (0, n[1]-n[0]), 'constant')
     else:
-        B = np.pad(B, (0, n[1]-n[0]))
+        B = np.pad(B, (0, n[1]-n[0]), 'constant')
 
     return A, B
 

--- a/scipy/optimize/_qap.py
+++ b/scipy/optimize/_qap.py
@@ -206,8 +206,6 @@ def _common_input_validation(A, B, partial_match):
         msg = "`B` must be square"
     elif A.ndim != 2 or B.ndim != 2:
         msg = "`A` and `B` must have exactly two dimensions"
-    elif A.shape != B.shape:
-        msg = "`A` and `B` matrices must be of equal size"
     elif partial_match.shape[0] > A.shape[0]:
         msg = "`partial_match` can have only as many seeds as there are nodes"
     elif partial_match.shape[1] != 2:
@@ -523,6 +521,7 @@ def _quadratic_assignment_faq(A, B,
 
 def _adj_pad(A, B, method):
     # pads the matrix with less nodes such that A & B are same size
+    # schemes according to section 2.5 of [2]
     def pad(X, n):
         X_pad = np.zeros((n[1], n[1]))
         X_pad[: n[0], : n[0]] = X
@@ -691,7 +690,9 @@ def _quadratic_assignment_2opt(A, B, maximize=False, rng=None,
     partial_guess = np.atleast_2d(partial_guess).astype(int)
 
     msg = None
-    if partial_guess.shape[0] > A.shape[0]:
+    if A.shape != B.shape:
+        msg = "`A` and `B` matrices must be of equal size"
+    elif partial_guess.shape[0] > A.shape[0]:
         msg = ("`partial_guess` can have only as "
                "many entries as there are nodes")
     elif partial_guess.shape[1] != 2:

--- a/scipy/optimize/_qap.py
+++ b/scipy/optimize/_qap.py
@@ -407,7 +407,13 @@ def _quadratic_assignment_faq(A, B,
     # ValueError check
     A, B, partial_match = _common_input_validation(A, B, partial_match)
     # pads A and B according to section 2.5 of [2]
+    adopted = False
     if A.shape[0] != B.shape[0]:
+        # store the adjacency matrices to calculate score later
+        if padding == 'adopted':
+            As, Bs = _adj_pad(A, B, 'naive')
+            adopted = True
+
         A, B = _adj_pad(A, B, padding)
 
     msg = None
@@ -514,7 +520,11 @@ def _quadratic_assignment_faq(A, B,
     unshuffled_perm = np.zeros(n, dtype=int)
     unshuffled_perm[perm_A] = perm_B[perm]
 
-    score = _calc_score(A, B, unshuffled_perm)
+    if adopted:
+        score = _calc_score(As, Bs, unshuffled_perm)
+    else:
+        score = _calc_score(A, B, unshuffled_perm)
+
     res = {"col_ind": unshuffled_perm, "fun": score, "nit": n_iter}
     return OptimizeResult(res)
 

--- a/scipy/optimize/tests/test_quadratic_assignment.py
+++ b/scipy/optimize/tests/test_quadratic_assignment.py
@@ -197,6 +197,16 @@ class TestFAQ(QAPCommonTests):
                                    options={'P0': K})
         assert_(11156 <= res.fun < 21000)
 
+        # test padded qap
+        n = 50
+        p = 0.4
+        G1 = _er_matrix(n, p)
+        G2 = G1[: (n - 1), : (n - 1)]  # remove two nodes
+        res = quadratic_assignment(G1, G2,
+                                   options={'maximize': True})
+
+        assert 1.0 == (sum(res.col_ind == np.arange(n)) / n)
+
     def test_specific_input_validation(self):
 
         A = np.identity(2)
@@ -356,6 +366,7 @@ class TestQAPOnce():
             quadratic_assignment(
                 np.random.random((3, 3)),
                 np.random.random((4, 4)),
+                method='2opt'
             )
         # can't have more seed nodes than cost/dist nodes
         _rm = _range_matrix
@@ -429,3 +440,10 @@ def _doubly_stochastic(P, tol=1e-3):
         P_eps = r[:, None] * P * c
 
     return P_eps
+
+
+def _er_matrix(n, p):
+    x = np.triu(np.random.rand(n, n))
+    m = x + x.T
+    m[range(n), range(n)] = 0
+    return (m < p).astype(int)

--- a/scipy/optimize/tests/test_quadratic_assignment.py
+++ b/scipy/optimize/tests/test_quadratic_assignment.py
@@ -200,8 +200,8 @@ class TestFAQ(QAPCommonTests):
         # test padded qap
         n = 50
         p = 0.4
-        G1 = _er_matrix(n, p)
-        G2 = G1[: (n - 1), : (n - 1)]  # remove two nodes
+        G1 = _er_matrix(n, p)  # generate an Erdos-Renyi graph
+        G2 = G1[: -1, : -1]  # remove one node
         res = quadratic_assignment(G1, G2,
                                    options={'maximize': True})
 
@@ -443,7 +443,10 @@ def _doubly_stochastic(P, tol=1e-3):
 
 
 def _er_matrix(n, p):
+    # generate an undirected Erdos-Renyi graph
+    # n specifies number of nodes
+    # p specifies the probability an edge exists between any two nodes
     x = np.triu(np.random.rand(n, n))
     m = x + x.T
-    m[range(n), range(n)] = 0
+    np.fill_diagonal(m, 0)
     return (m < p).astype(int)

--- a/scipy/optimize/tests/test_quadratic_assignment.py
+++ b/scipy/optimize/tests/test_quadratic_assignment.py
@@ -446,7 +446,6 @@ def _er_matrix(n, p):
     # generate an undirected Erdos-Renyi graph
     # n specifies number of nodes
     # p specifies the probability an edge exists between any two nodes
-    x = np.triu(np.random.rand(n, n))
+    x = np.triu(np.random.rand(n, n), k=1)
     m = x + x.T
-    np.fill_diagonal(m, 0)
     return (m < p).astype(int)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR implements "padding" to the `quadratic_assignment()` function in scipy.optimize, allowing users to input matrices `A` and `B` of different sizes. Two different padding schemes are implemented here, and the user is given the option to choose between the two. `adopted` (default) padding matches the appropriate induced subgraphs, and `naive` matches the appropriate subgraphs. More information can be found in section 2.5 of ["Seeded Graph Matching"](https://arxiv.org/pdf/1209.0367.pdf)
#### Additional information
<!--Any additional information you think is important.-->