### PR TITLE
BUG: forward port lint_diff shims

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,8 @@ matrix:
         - |
           if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
              git fetch --unshallow
-             git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
-             git fetch origin
+             git config remote.origin.fetch "+refs/heads/maintenance/*:refs/remotes/origin/maintenance/*"
+             git fetch origin --no-tags
              python tools/lint_diff.py --branch origin/$TRAVIS_BRANCH
           fi
         - tools/unicode-check.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,10 @@ matrix:
         - pycodestyle scipy benchmarks/benchmarks
         - |
           if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-             python tools/lint_diff.py --branch $TRAVIS_BRANCH
+             git fetch --unshallow
+             git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+             git fetch origin
+             python tools/lint_diff.py --branch origin/$TRAVIS_BRANCH
           fi
         - tools/unicode-check.py
     - python: 3.7


### PR DESCRIPTION
Fixes #13030

* forward port the Travis CI shallow clone-related
fixes required for `lint_diff.py` to run properly
on backport PRs from gh-13028

* a better fix might happen with the Python module
itself so that the module may be used within any
CI service (or at least provide some kind of warning
in the presence of a shallow clone); that said,
if such a fix is pursued, please do test with a "dummy
PR" against a maintenance branch as well