### PR TITLE
MAINT: dogbox ensure x is within bounds closes #11403

### DIFF
--- a/scipy/optimize/_lsq/dogbox.py
+++ b/scipy/optimize/_lsq/dogbox.py
@@ -260,7 +260,9 @@ def dogbox(fun, jac, x0, f0, J0, lb, ub, ftol, xtol, gtol, max_nfev, x_scale,
             elif tr_solver == 'lsmr':
                 predicted_reduction = -evaluate_quadratic(Jop, g, step)
 
-            x_new = x + step
+            # gh11403 ensure that solution is fully within bounds.
+            x_new = np.clip(x + step, lb, ub)
+
             f_new = fun(x_new)
             nfev += 1
 

--- a/scipy/optimize/tests/test_slsqp.py
+++ b/scipy/optimize/tests/test_slsqp.py
@@ -214,11 +214,11 @@ class TestSLSQP(object):
         # jacobian doesn't try to exceed that bound using a finite difference.
         # gh11403
         def c(x):
-            assert 0 <= x[0] <= 1 and 0 <= x[1] <=1, x
+            assert 0 <= x[0] <= 1 and 0 <= x[1] <= 1, x
             return x[0] ** 0.5 + x[1]
 
         def f(x):
-            assert 0 <= x[0] <= 1 and 0 <= x[1] <=1, x
+            assert 0 <= x[0] <= 1 and 0 <= x[1] <= 1, x
             return -x[0] ** 2 + x[1] ** 2
 
         cns = [NonlinearConstraint(c, 0, 1.5)]


### PR DESCRIPTION
#11403 has an issue where `least_squares --> dogbox` asks for evaluation of the jacobian with `x` values outside the lower/upper bounds of the problem. `approx_derivative` doesn't like that and raises an Exception. Whilst a problem for the OP it's not been possible to reproduce it on a maintainers computer, making it difficult to create a fix, or decide whether to close the issue.
In comparison to [`trf`](https://github.com/andyfaff/scipy/blob/gh11403/scipy/optimize/_lsq/trf.py#L337) `dogbox` may not  fully ensure that `x_new` is strictly within bounds, although it does [do something towards this](https://github.com/andyfaff/scipy/blob/gh11403/scipy/optimize/_lsq/dogbox.py#L299).

This PR presents a pragmatic approach to this issue by simply clipping `x` to within the lb/ub, meaning that `approx_derivative` should never get sent an `x` outside the bounds.

The dogbox/trf code isn't easy for a non-original maintainer to keep up with, so it would be good to have experts look over this and confirm that the change is ok.
