### PR TITLE
BUG: fix `scipy.optimize.show_options` for unknown methods. and add *_METHODS list for each solver script and fix show_options doc

### DIFF
--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -31,6 +31,8 @@ __all__ = ['linprog', 'linprog_verbose_callback', 'linprog_terse_callback']
 
 __docformat__ = "restructuredtext en"
 
+LINPROG_METHODS = ['simplex', 'revised simplex', 'interior-point']
+
 
 def linprog_verbose_callback(res):
     """

--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -35,6 +35,8 @@ __all__ = ['linprog', 'linprog_verbose_callback', 'linprog_terse_callback']
 
 __docformat__ = "restructuredtext en"
 
+LINPROG_METHODS = ['simplex', 'revised simplex', 'interior-point']
+
 
 def linprog_verbose_callback(res):
     """

--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -35,7 +35,7 @@ __all__ = ['linprog', 'linprog_verbose_callback', 'linprog_terse_callback']
 
 __docformat__ = "restructuredtext en"
 
-LINPROG_METHODS = ['simplex', 'revised simplex', 'interior-point']
+LINPROG_METHODS = ['simplex', 'revised simplex', 'interior-point', 'highs', 'highs-ds', 'highs-ipm']
 
 
 def linprog_verbose_callback(res):

--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -31,7 +31,7 @@ __all__ = ['linprog', 'linprog_verbose_callback', 'linprog_terse_callback']
 
 __docformat__ = "restructuredtext en"
 
-LINPROG_METHODS = ['simplex', 'revised simplex', 'interior-point']
+LINPROG_METHODS = ['simplex', 'revised simplex', 'interior-point', 'highs', 'highs-ds', 'highs-ipm']
 
 
 def linprog_verbose_callback(res):

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -40,6 +40,7 @@ MINIMIZE_METHODS = ['nelder-mead', 'powell', 'cg', 'bfgs', 'newton-cg',
                     'l-bfgs-b', 'tnc', 'cobyla', 'slsqp', 'trust-constr',
                     'dogleg', 'trust-ncg', 'trust-exact', 'trust-krylov']
 
+MINIMIZE_SCALAR_METHODS = ['Brent', 'Bounded', 'Golden']
 
 def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
              hessp=None, bounds=None, constraints=(), tol=None,

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -40,7 +40,7 @@ MINIMIZE_METHODS = ['nelder-mead', 'powell', 'cg', 'bfgs', 'newton-cg',
                     'l-bfgs-b', 'tnc', 'cobyla', 'slsqp', 'trust-constr',
                     'dogleg', 'trust-ncg', 'trust-exact', 'trust-krylov']
 
-MINIMIZE_SCALAR_METHODS = ['Brent', 'Bounded', 'Golden']
+MINIMIZE_SCALAR_METHODS = ['brent', 'bounded', 'golden']
 
 def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
              hessp=None, bounds=None, constraints=(), tol=None,

--- a/scipy/optimize/_qap.py
+++ b/scipy/optimize/_qap.py
@@ -6,6 +6,7 @@ from .optimize import _check_unknown_options
 from scipy._lib._util import check_random_state
 import itertools
 
+QUADRATIC_ASSIGNMENT_METHODS = ['faq', '2opt']
 
 def quadratic_assignment(A, B, method="faq", options=None):
     r"""

--- a/scipy/optimize/_root.py
+++ b/scipy/optimize/_root.py
@@ -9,6 +9,9 @@ __all__ = ['root']
 
 import numpy as np
 
+ROOT_METHODS = ['hybr', 'lm', 'broyden1', 'broyden2', 'anderson',
+                'linearmixing', 'diagbroyden', 'excitingmixing', 'krylov',
+                'df-sane']
 
 from warnings import warn
 

--- a/scipy/optimize/_root_scalar.py
+++ b/scipy/optimize/_root_scalar.py
@@ -12,6 +12,9 @@ from . import zeros as optzeros
 
 __all__ = ['root_scalar']
 
+ROOT_SCALAR_METHODS = ['bisect', 'brentq', 'brenth', 'ridder', 'toms748',
+                       'newton', 'secant', 'halley']
+
 
 class MemoizeDer(object):
     """Decorator that caches the value and derivative(s) of function each

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -3398,14 +3398,14 @@ def show_options(solver=None, method=None, disp=True):
 
     `scipy.optimize.root_scalar`
 
-    - :ref:'bisect  <optimize.root_scalar-bisect>`
-    - :ref:'brentq  <optimize.root_scalar-brentq>`
-    - :ref:'brenth  <optimize.root_scalar-brenth>`
-    - :ref:'ridder  <optimize.root_scalar-ridder>`
-    - :ref:'toms748 <optimize.root_scalar-toms748>`
-    - :ref:'newton  <optimize.root_scalar-newton>`
-    - :ref:'secant  <optimize.root_scalar-secant>`
-    - :ref:'halley  <optimize.root_scalar-halley>`
+    - :ref:`bisect  <optimize.root_scalar-bisect>`
+    - :ref:`brentq  <optimize.root_scalar-brentq>`
+    - :ref:`brenth  <optimize.root_scalar-brenth>`
+    - :ref:`ridder  <optimize.root_scalar-ridder>`
+    - :ref:`toms748 <optimize.root_scalar-toms748>`
+    - :ref:`newton  <optimize.root_scalar-newton>`
+    - :ref:`secant  <optimize.root_scalar-secant>`
+    - :ref:`halley  <optimize.root_scalar-halley>`
 
     `scipy.optimize.linprog`
 

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -3454,9 +3454,11 @@ def show_options(solver=None, method=None, disp=True):
             ('powell', 'scipy.optimize.optimize._minimize_powell'),
             ('slsqp', 'scipy.optimize.slsqp._minimize_slsqp'),
             ('tnc', 'scipy.optimize.tnc._minimize_tnc'),
-            ('trust-ncg', 'scipy.optimize._trustregion_ncg._minimize_trust_ncg'),
+            ('trust-ncg',
+             'scipy.optimize._trustregion_ncg._minimize_trust_ncg'),
             ('trust-constr',
-             'scipy.optimize._trustregion_constr._minimize_trustregion_constr'),
+             'scipy.optimize._trustregion_constr.'
+             '_minimize_trustregion_constr'),
             ('trust-exact',
              'scipy.optimize._trustregion_exact._minimize_trustregion_exact'),
             ('trust-krylov',

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -3345,7 +3345,7 @@ def show_options(solver=None, method=None, disp=True):
     ----------
     solver : str
         Type of optimization solver. One of 'minimize', 'minimize_scalar',
-        'root', or 'linprog'.
+        'root', 'root_scalar', 'linprog', or 'quadratic_assignment'.
     method : str, optional
         If not given, shows all methods of the specified solver. Otherwise,
         show only the options for the specified method. Valid values

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -3396,6 +3396,17 @@ def show_options(solver=None, method=None, disp=True):
     - :ref:`golden      <optimize.minimize_scalar-golden>`
     - :ref:`bounded     <optimize.minimize_scalar-bounded>`
 
+    `scipy.optimize.root_scalar`
+
+    - :ref:'bisect  <optimize.root_scalar-bisect>`
+    - :ref:'brentq  <optimize.root_scalar-brentq>`
+    - :ref:'brenth  <optimize.root_scalar-brenth>`
+    - :ref:'ridder  <optimize.root_scalar-ridder>`
+    - :ref:'toms748 <optimize.root_scalar-toms748>`
+    - :ref:'newton  <optimize.root_scalar-newton>`
+    - :ref:'secant  <optimize.root_scalar-secant>`
+    - :ref:'halley  <optimize.root_scalar-halley>`
+
     `scipy.optimize.linprog`
 
     - :ref:`simplex         <optimize.linprog-simplex>`
@@ -3441,6 +3452,12 @@ def show_options(solver=None, method=None, disp=True):
             ('slsqp', 'scipy.optimize.slsqp._minimize_slsqp'),
             ('tnc', 'scipy.optimize.tnc._minimize_tnc'),
             ('trust-ncg', 'scipy.optimize._trustregion_ncg._minimize_trust_ncg'),
+            ('trust-constr',
+             'scipy.optimize._trustregion_constr._minimize_trustregion_constr'),
+            ('trust-exact',
+             'scipy.optimize._trustregion_exact._minimize_trustregion_exact'),
+            ('trust-krylov',
+             'scipy.optimize._trustregion_krylov._minimize_trust_krylov'),
         ),
         'root': (
             ('hybr', 'scipy.optimize.minpack._root_hybr'),

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -3451,9 +3451,11 @@ def show_options(solver=None, method=None, disp=True):
             ('powell', 'scipy.optimize.optimize._minimize_powell'),
             ('slsqp', 'scipy.optimize.slsqp._minimize_slsqp'),
             ('tnc', 'scipy.optimize.tnc._minimize_tnc'),
-            ('trust-ncg', 'scipy.optimize._trustregion_ncg._minimize_trust_ncg'),
+            ('trust-ncg',
+             'scipy.optimize._trustregion_ncg._minimize_trust_ncg'),
             ('trust-constr',
-             'scipy.optimize._trustregion_constr._minimize_trustregion_constr'),
+             'scipy.optimize._trustregion_constr.'
+             '_minimize_trustregion_constr'),
             ('trust-exact',
              'scipy.optimize._trustregion_exact._minimize_trustregion_exact'),
             ('trust-krylov',

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -3396,6 +3396,17 @@ def show_options(solver=None, method=None, disp=True):
     - :ref:`golden      <optimize.minimize_scalar-golden>`
     - :ref:`bounded     <optimize.minimize_scalar-bounded>`
 
+    `scipy.optimize.root_scalar`
+
+    - :ref:'bisect  <optimize.root_scalar-bisect>`
+    - :ref:'brentq  <optimize.root_scalar-brentq>`
+    - :ref:'brenth  <optimize.root_scalar-brenth>`
+    - :ref:'ridder  <optimize.root_scalar-ridder>`
+    - :ref:'toms748 <optimize.root_scalar-toms748>`
+    - :ref:'newton  <optimize.root_scalar-newton>`
+    - :ref:'secant  <optimize.root_scalar-secant>`
+    - :ref:'halley  <optimize.root_scalar-halley>`
+
     `scipy.optimize.linprog`
 
     - :ref:`simplex           <optimize.linprog-simplex>`
@@ -3444,6 +3455,12 @@ def show_options(solver=None, method=None, disp=True):
             ('slsqp', 'scipy.optimize.slsqp._minimize_slsqp'),
             ('tnc', 'scipy.optimize.tnc._minimize_tnc'),
             ('trust-ncg', 'scipy.optimize._trustregion_ncg._minimize_trust_ncg'),
+            ('trust-constr',
+             'scipy.optimize._trustregion_constr._minimize_trustregion_constr'),
+            ('trust-exact',
+             'scipy.optimize._trustregion_exact._minimize_trustregion_exact'),
+            ('trust-krylov',
+             'scipy.optimize._trustregion_krylov._minimize_trust_krylov'),
         ),
         'root': (
             ('hybr', 'scipy.optimize.minpack._root_hybr'),

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -2199,4 +2199,12 @@ def test_show_options():
         for method in methods:
             # testing that `show_options` works without error
             show_options(solver, method)
-            
+
+    unknown_solver_method = {
+        'minimize': "ekki",  # unknown method
+        'maximize': "cg",  # unknown solver
+        'maximize': "ekki",  # unknown solver and method
+    }
+    for solver, method in unknown_solver_method.items():
+        # testing that `show_options` raises ValueError
+        assert_raises(ValueError, show_options, solver, method)

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -2197,4 +2197,6 @@ def test_show_options():
     }
     for solver, methods in solver_methods.items():
         for method in methods:
+            # testing that `show_options` works without error
             show_options(solver, method)
+            

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -2208,3 +2208,4 @@ def test_show_options():
     for solver, method in unknown_solver_method.items():
         # testing that `show_options` raises ValueError
         assert_raises(ValueError, show_options, solver, method)
+        

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -19,9 +19,13 @@ import pytest
 from pytest import raises as assert_raises
 
 from scipy import optimize
-from scipy.optimize._minimize import MINIMIZE_METHODS
+from scipy.optimize._minimize import MINIMIZE_METHODS, MINIMIZE_SCALAR_METHODS
+from scipy.optimize._linprog import LINPROG_METHODS
+from scipy.optimize._root import ROOT_METHODS
+from scipy.optimize._root_scalar import ROOT_SCALAR_METHODS
+from scipy.optimize._qap import QUADRATIC_ASSIGNMENT_METHODS
 from scipy.optimize._differentiable_functions import ScalarFunction
-from scipy.optimize.optimize import MemoizeJac
+from scipy.optimize.optimize import MemoizeJac, show_options
 
 
 def test_check_grad():
@@ -2174,8 +2178,23 @@ def test_memoize_jac_with_bfgs(function_with_gradient):
     scalar_function.fun(x0 + 0.2)
     assert function_with_gradient.number_of_calls == 3
 
+
 def test_gh12696():
     # Test that optimize doesn't throw warning gh-12696
     with assert_no_warnings():
         optimize.fminbound(
             lambda x: np.array([x**2]), -np.pi, np.pi, disp=False)
+
+
+def test_show_options():
+    solver_methods = {
+        'minimize': MINIMIZE_METHODS,
+        'minimize_scalar': MINIMIZE_SCALAR_METHODS,
+        'root': ROOT_METHODS,
+        'root_scalar': ROOT_SCALAR_METHODS,
+        'linprog': LINPROG_METHODS,
+        'quadratic_assignment': QUADRATIC_ASSIGNMENT_METHODS,
+    }
+    for solver, methods in solver_methods.items():
+        for method in methods:
+            show_options(solver, method)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
fix #10782 

#### What does this implement/fix?
I fixed `scipy.optimize.show_options` for unknown methods and added a test for it.
I added a global *_METHODS list for each solver script which is proposed in #10782 
I fixed `show_options` docstring because it is missing `scipy.optimize.root_scalar` doc links.
