### PR TITLE
MAINT: fft: Fix a C++ compiler warning.

### DIFF
--- a/scipy/fft/_pocketfft/pypocketfft.cxx
+++ b/scipy/fft/_pocketfft/pypocketfft.cxx
@@ -378,9 +378,9 @@ PyObject * good_size(PyObject * /*self*/, PyObject * args, PyObject * kwargs)
   {
   Py_ssize_t n_ = -1;
   int real = false;
-  char * keywords[] = {"target", "real", nullptr};
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "n|p:good_size", keywords,
-                                   &n_, &real))
+  const char * keywords[] = {"target", "real", nullptr};
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "n|p:good_size",
+                                   (char **) keywords, &n_, &real))
     return nullptr;
 
   if (n_<0)


### PR DESCRIPTION
This warning was being generated when the pocketfft code was compiled:

    g++: scipy/fft/_pocketfft/pypocketfft.cxx
    scipy/fft/_pocketfft/pypocketfft.cxx: In function ‘PyObject* {anonymous}::good_size(PyObject*, PyObject*, PyObject*)’:
    scipy/fft/_pocketfft/pypocketfft.cxx:381:24: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
      381 |   char * keywords[] = {"target", "real", nullptr};
          |                        ^~~~~~~~
    scipy/fft/_pocketfft/pypocketfft.cxx:381:34: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
      381 |   char * keywords[] = {"target", "real", nullptr};
          |                                  ^~~~~~

In ISO C++, the type of a string literal is `const char *`.  This commit
fixes the warnings by making the `keywords` array `const`, and then casting
away the constness when it is passed to PyArg_ParseTupleAndKeywords.
