### PR TITLE
DOC: signal.win -> signal.windows.win in Examples

### DIFF
--- a/doc/source/tutorial/signal.rst
+++ b/doc/source/tutorial/signal.rst
@@ -360,7 +360,7 @@ which is often used for blurring.
    >>> import matplotlib.pyplot as plt
 
    >>> image = misc.ascent()
-   >>> w = signal.gaussian(51, 10.0)
+   >>> w = signal.windows.gaussian(51, 10.0)
    >>> image_new = signal.sepfir2d(image, w, w)
 
    >>> plt.figure()

--- a/scipy/signal/fir_filter_design.py
+++ b/scipy/signal/fir_filter_design.py
@@ -167,7 +167,7 @@ def kaiserord(ripple, width):
     -----
     There are several ways to obtain the Kaiser window:
 
-    - ``signal.kaiser(numtaps, beta, sym=True)``
+    - ``signal.windows.kaiser(numtaps, beta, sym=True)``
     - ``signal.get_window(beta, numtaps)``
     - ``signal.get_window(('kaiser', beta), numtaps)``
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -622,7 +622,8 @@ def fftconvolve(in1, in2, mode="full", axes=None):
 
     >>> from scipy import misc
     >>> face = misc.face(gray=True)
-    >>> kernel = np.outer(signal.gaussian(70, 8), signal.gaussian(70, 8))
+    >>> kernel = np.outer(signal.windows.gaussian(70, 8),
+    ...                   signal.windows.gaussian(70, 8))
     >>> blurred = signal.fftconvolve(face, kernel, mode='same')
 
     >>> fig, (ax_orig, ax_kernel, ax_blurred) = plt.subplots(3, 1,
@@ -1354,7 +1355,7 @@ def convolve(in1, in2, mode='full', method='auto'):
 
     >>> from scipy import signal
     >>> sig = np.repeat([0., 1., 0.], 100)
-    >>> win = signal.hann(50)
+    >>> win = signal.windows.hann(50)
     >>> filtered = signal.convolve(sig, win, mode='same') / sum(win)
 
     >>> import matplotlib.pyplot as plt

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -837,29 +837,29 @@ def check_COLA(window, nperseg, noverlap, tol=1e-10):
 
     Confirm COLA condition for rectangular window of 75% (3/4) overlap:
 
-    >>> signal.check_COLA(signal.boxcar(100), 100, 75)
+    >>> signal.check_COLA(signal.windows.boxcar(100), 100, 75)
     True
 
     COLA is not true for 25% (1/4) overlap, though:
 
-    >>> signal.check_COLA(signal.boxcar(100), 100, 25)
+    >>> signal.check_COLA(signal.windows.boxcar(100), 100, 25)
     False
 
     "Symmetrical" Hann window (for filter design) is not COLA:
 
-    >>> signal.check_COLA(signal.hann(120, sym=True), 120, 60)
+    >>> signal.check_COLA(signal.windows.hann(120, sym=True), 120, 60)
     False
 
     "Periodic" or "DFT-even" Hann window (for FFT analysis) is COLA for
     overlap of 1/2, 2/3, 3/4, etc.:
 
-    >>> signal.check_COLA(signal.hann(120, sym=False), 120, 60)
+    >>> signal.check_COLA(signal.windows.hann(120, sym=False), 120, 60)
     True
 
-    >>> signal.check_COLA(signal.hann(120, sym=False), 120, 80)
+    >>> signal.check_COLA(signal.windows.hann(120, sym=False), 120, 80)
     True
 
-    >>> signal.check_COLA(signal.hann(120, sym=False), 120, 90)
+    >>> signal.check_COLA(signal.windows.hann(120, sym=False), 120, 90)
     True
 
     """
@@ -958,17 +958,17 @@ def check_NOLA(window, nperseg, noverlap, tol=1e-10):
 
     Confirm NOLA condition for rectangular window of 75% (3/4) overlap:
 
-    >>> signal.check_NOLA(signal.boxcar(100), 100, 75)
+    >>> signal.check_NOLA(signal.windows.boxcar(100), 100, 75)
     True
 
     NOLA is also true for 25% (1/4) overlap:
 
-    >>> signal.check_NOLA(signal.boxcar(100), 100, 25)
+    >>> signal.check_NOLA(signal.windows.boxcar(100), 100, 25)
     True
 
     "Symmetrical" Hann window (for filter design) is also NOLA:
 
-    >>> signal.check_NOLA(signal.hann(120, sym=True), 120, 60)
+    >>> signal.check_NOLA(signal.windows.hann(120, sym=True), 120, 60)
     True
 
     As long as there is overlap, it takes quite a pathological window to fail
@@ -982,11 +982,11 @@ def check_NOLA(window, nperseg, noverlap, tol=1e-10):
     If there is not enough overlap, a window with zeros at the ends will not
     work:
 
-    >>> signal.check_NOLA(signal.hann(64), 64, 0)
+    >>> signal.check_NOLA(signal.windows.hann(64), 64, 0)
     False
-    >>> signal.check_NOLA(signal.hann(64), 64, 1)
+    >>> signal.check_NOLA(signal.windows.hann(64), 64, 1)
     False
-    >>> signal.check_NOLA(signal.hann(64), 64, 2)
+    >>> signal.check_NOLA(signal.windows.hann(64), 64, 2)
     True
     """
 

--- a/scipy/signal/windows/windows.py
+++ b/scipy/signal/windows/windows.py
@@ -145,7 +145,7 @@ def boxcar(M, sym=True):
     >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
-    >>> window = signal.boxcar(51)
+    >>> window = signal.windows.boxcar(51)
     >>> plt.plot(window)
     >>> plt.title("Boxcar window")
     >>> plt.ylabel("Amplitude")
@@ -202,7 +202,7 @@ def triang(M, sym=True):
     >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
-    >>> window = signal.triang(51)
+    >>> window = signal.windows.triang(51)
     >>> plt.plot(window)
     >>> plt.title("Triangular window")
     >>> plt.ylabel("Amplitude")
@@ -267,7 +267,7 @@ def parzen(M, sym=True):
     >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
-    >>> window = signal.parzen(51)
+    >>> window = signal.windows.parzen(51)
     >>> plt.plot(window)
     >>> plt.title("Parzen window")
     >>> plt.ylabel("Amplitude")
@@ -326,7 +326,7 @@ def bohman(M, sym=True):
     >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
-    >>> window = signal.bohman(51)
+    >>> window = signal.windows.bohman(51)
     >>> plt.plot(window)
     >>> plt.title("Bohman window")
     >>> plt.ylabel("Amplitude")
@@ -417,7 +417,7 @@ def blackman(M, sym=True):
     >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
-    >>> window = signal.blackman(51)
+    >>> window = signal.windows.blackman(51)
     >>> plt.plot(window)
     >>> plt.title("Blackman window")
     >>> plt.ylabel("Amplitude")
@@ -478,7 +478,7 @@ def nuttall(M, sym=True):
     >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
-    >>> window = signal.nuttall(51)
+    >>> window = signal.windows.nuttall(51)
     >>> plt.plot(window)
     >>> plt.title("Nuttall window")
     >>> plt.ylabel("Amplitude")
@@ -525,7 +525,7 @@ def blackmanharris(M, sym=True):
     >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
-    >>> window = signal.blackmanharris(51)
+    >>> window = signal.windows.blackmanharris(51)
     >>> plt.plot(window)
     >>> plt.title("Blackman-Harris window")
     >>> plt.ylabel("Amplitude")
@@ -586,7 +586,7 @@ def flattop(M, sym=True):
     >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
-    >>> window = signal.flattop(51)
+    >>> window = signal.windows.flattop(51)
     >>> plt.plot(window)
     >>> plt.title("Flat top window")
     >>> plt.ylabel("Amplitude")
@@ -676,7 +676,7 @@ def bartlett(M, sym=True):
     >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
-    >>> window = signal.bartlett(51)
+    >>> window = signal.windows.bartlett(51)
     >>> plt.plot(window)
     >>> plt.title("Bartlett window")
     >>> plt.ylabel("Amplitude")
@@ -765,7 +765,7 @@ def hann(M, sym=True):
     >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
-    >>> window = signal.hann(51)
+    >>> window = signal.windows.hann(51)
     >>> plt.plot(window)
     >>> plt.title("Hann window")
     >>> plt.ylabel("Amplitude")
@@ -832,7 +832,7 @@ def tukey(M, alpha=0.5, sym=True):
     >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
-    >>> window = signal.tukey(51)
+    >>> window = signal.windows.tukey(51)
     >>> plt.plot(window)
     >>> plt.title("Tukey window")
     >>> plt.ylabel("Amplitude")
@@ -902,7 +902,7 @@ def barthann(M, sym=True):
     >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
-    >>> window = signal.barthann(51)
+    >>> window = signal.windows.barthann(51)
     >>> plt.plot(window)
     >>> plt.title("Bartlett-Hann window")
     >>> plt.ylabel("Amplitude")
@@ -1074,7 +1074,7 @@ def hamming(M, sym=True):
     >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
-    >>> window = signal.hamming(51)
+    >>> window = signal.windows.hamming(51)
     >>> plt.plot(window)
     >>> plt.title("Hamming window")
     >>> plt.ylabel("Amplitude")
@@ -1183,7 +1183,7 @@ def kaiser(M, beta, sym=True):
     >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
-    >>> window = signal.kaiser(51, beta=14)
+    >>> window = signal.windows.kaiser(51, beta=14)
     >>> plt.plot(window)
     >>> plt.title(r"Kaiser window ($\beta$=14)")
     >>> plt.ylabel("Amplitude")
@@ -1248,7 +1248,7 @@ def gaussian(M, std, sym=True):
     >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
-    >>> window = signal.gaussian(51, std=7)
+    >>> window = signal.windows.gaussian(51, std=7)
     >>> plt.plot(window)
     >>> plt.title(r"Gaussian window ($\sigma$=7)")
     >>> plt.ylabel("Amplitude")
@@ -1318,7 +1318,7 @@ def general_gaussian(M, p, sig, sym=True):
     >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
-    >>> window = signal.general_gaussian(51, p=1.5, sig=7)
+    >>> window = signal.windows.general_gaussian(51, p=1.5, sig=7)
     >>> plt.plot(window)
     >>> plt.title(r"Generalized Gaussian window (p=1.5, $\sigma$=7)")
     >>> plt.ylabel("Amplitude")
@@ -1415,7 +1415,7 @@ def chebwin(M, at, sym=True):
     >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
-    >>> window = signal.chebwin(51, at=100)
+    >>> window = signal.windows.chebwin(51, at=100)
     >>> plt.plot(window)
     >>> plt.title("Dolph-Chebyshev window (100 dB)")
     >>> plt.ylabel("Amplitude")
@@ -1505,7 +1505,7 @@ def cosine(M, sym=True):
     >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
-    >>> window = signal.cosine(51)
+    >>> window = signal.windows.cosine(51)
     >>> plt.plot(window)
     >>> plt.title("Cosine window")
     >>> plt.ylabel("Amplitude")
@@ -1580,7 +1580,7 @@ def exponential(M, center=None, tau=1., sym=True):
 
     >>> M = 51
     >>> tau = 3.0
-    >>> window = signal.exponential(M, tau=tau)
+    >>> window = signal.windows.exponential(M, tau=tau)
     >>> plt.plot(window)
     >>> plt.title("Exponential Window (tau=3.0)")
     >>> plt.ylabel("Amplitude")
@@ -1599,7 +1599,7 @@ def exponential(M, center=None, tau=1., sym=True):
     This function can also generate non-symmetric windows:
 
     >>> tau2 = -(M-1) / np.log(0.01)
-    >>> window2 = signal.exponential(M, 0, tau2, False)
+    >>> window2 = signal.windows.exponential(M, 0, tau2, False)
     >>> plt.figure()
     >>> plt.plot(window2)
     >>> plt.ylabel("Amplitude")


### PR DESCRIPTION
For instance, scipy.signal.hann is deprecated in favor of
scipy.signal.windows.hann, so I changed many similar examples to the
updated namespace.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Inspired by https://github.com/scipy/scipy/pull/12777#discussion_r519939696

#### What does this implement/fix?
Updates documentation to use signal.windows namespace

#### Additional information
<!--Any additional information you think is important.-->