### PR TITLE
MAINT: Add suite-sparse and sksparse installation check

### DIFF
--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -28,6 +28,7 @@ from ._linprog_util import _postsolve
 has_umfpack = True
 has_cholmod = True
 try:
+    import sksparse
     from sksparse.cholmod import cholesky as cholmod
     from sksparse.cholmod import analyze as cholmod_analyze
 except ImportError:

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -21,6 +21,7 @@ except ImportError:
 has_cholmod = True
 try:
     import sksparse
+    from sksparse.cholmod import cholesky as cholmod
 except ImportError:
     has_cholmod = False
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
fix #11963 

#### What does this implement/fix?
I added `suite-sparse` and `sksparse` installation check based on #11963 proposal.
`suite-sparse` installation is checked by `from sksparse.cholmod import cholesky as cholmod`.
`sksparse` installation is checked by `import sksparse`. 