### PR TITLE
ENH: Add weights parameter to stats.gmean

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -421,7 +421,8 @@ def gmean(a, axis=0, dtype=None, weights=None):
             else:
                 weights = np.asarray(weights, dtype=dtype)
 
-        assert weights.shape == log_a.shape, "Shape of a and weights must be identical."
+        if weights.shape != log_a.shape:
+            raise ValueError("Shape mismatch: Shape of a and weights must be identical.")
 
     return np.exp(np.average(log_a, axis=axis, weights=weights))
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -368,7 +368,7 @@ def gmean(a, axis=0, dtype=None, weights=None):
         platform integer is used.
     weights : array_like, optional
         The weights array can either be 1-D (in which case its length must be
-        the size of a along the given axis) or of the same shape as a.
+        the size of `a` along the given `axis`) or of the same shape as `a`.
         Default is None, which gives each value a weight of 1.0.
 
     Returns

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -413,7 +413,9 @@ def gmean(a, axis=0, dtype=None, weights=None):
         log_a = np.log(a)
 
     if weights:
-        weights = np.array(weights, dtype=dtype, copy=False)
+        if not isinstance(weights, np.ndarray):
+            # if not an ndarray object attempt to convert it
+            weights = np.array(weights, dtype=dtype)
         elif dtype:
             # Must change the default dtype allowing array type
             if isinstance(a, np.ma.MaskedArray):

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -346,7 +346,7 @@ def _broadcast_shapes_with_dropped_axis(a, b, axis):
     return shp
 
 
-def gmean(a, axis=0, dtype=None):
+def gmean(a, axis=0, dtype=None, weights=None):
     """
     Compute the geometric mean along the specified axis.
 
@@ -366,6 +366,9 @@ def gmean(a, axis=0, dtype=None):
         dtype of a, unless a has an integer dtype with a precision less than
         that of the default platform integer. In that case, the default
         platform integer is used.
+    weights : array_like, optional
+        The weights for each value in `a`. Default is None, which gives each
+        value a weight of 1.0
 
     Returns
     -------
@@ -408,7 +411,21 @@ def gmean(a, axis=0, dtype=None):
             log_a = np.log(np.asarray(a, dtype=dtype))
     else:
         log_a = np.log(a)
-    return np.exp(log_a.mean(axis=axis))
+
+    if weights:
+        if not isinstance(weights, np.ndarray):
+            # if not an ndarray object attempt to convert it
+            weights = np.array(weights, dtype=dtype)
+        elif dtype:
+            # Must change the default dtype allowing array type
+            if isinstance(a, np.ma.MaskedArray):
+                weights = np.ma.asarray(weights, dtype=dtype)
+            else:
+                weights = np.asarray(weights, dtype=dtype)
+
+        assert weights.shape == log_a.shape, "Shape of a and weights must be identical."
+
+    return np.exp(np.average(log_a, axis=axis, weights=weights))
 
 
 def hmean(a, axis=0, dtype=None):

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -392,6 +392,10 @@ def gmean(a, axis=0, dtype=None, weights=None):
     arise in the calculations such as Not a Number and infinity because masked
     arrays automatically mask any non-finite values.
 
+    References
+    ----------
+    .. [1] "Weighted Geometric Mean", *Wikipedia*, https://en.wikipedia.org/wiki/Weighted_geometric_mean.
+
     Examples
     --------
     >>> from scipy.stats import gmean

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -367,8 +367,9 @@ def gmean(a, axis=0, dtype=None, weights=None):
         that of the default platform integer. In that case, the default
         platform integer is used.
     weights : array_like, optional
-        The weights for each value in `a`. Default is None, which gives each
-        value a weight of 1.0
+        The weights array can either be 1-D (in which case its length must be
+        the size of a along the given axis) or of the same shape as a.
+        Default is None, which gives each value a weight of 1.0.
 
     Returns
     -------

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -418,10 +418,7 @@ def gmean(a, axis=0, dtype=None, weights=None):
         log_a = np.log(a)
 
     if weights is not None:
-        if isinstance(weights, np.ma.MaskedArray):
-            weights = weights.astype(dtype)
-        else:
-            weights = np.array(weights, dtype=dtype, copy=False)
+        weights = np.asanyarray(weights, dtype=dtype)
 
     return np.exp(np.average(log_a, axis=axis, weights=weights))
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -423,9 +423,6 @@ def gmean(a, axis=0, dtype=None, weights=None):
             else:
                 weights = np.asarray(weights, dtype=dtype)
 
-        if weights.shape != log_a.shape:
-            raise ValueError("Shape mismatch: Shape of a and weights must be identical.")
-
     return np.exp(np.average(log_a, axis=axis, weights=weights))
 
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -413,9 +413,7 @@ def gmean(a, axis=0, dtype=None, weights=None):
         log_a = np.log(a)
 
     if weights:
-        if not isinstance(weights, np.ndarray):
-            # if not an ndarray object attempt to convert it
-            weights = np.array(weights, dtype=dtype)
+        weights = np.array(weights, dtype=dtype, copy=False)
         elif dtype:
             # Must change the default dtype allowing array type
             if isinstance(a, np.ma.MaskedArray):

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -414,15 +414,10 @@ def gmean(a, axis=0, dtype=None, weights=None):
         log_a = np.log(a)
 
     if weights:
-        if not isinstance(weights, np.ndarray):
-            # if not an ndarray object attempt to convert it
-            weights = np.array(weights, dtype=dtype)
-        elif dtype:
-            # Must change the default dtype allowing array type
-            if isinstance(a, np.ma.MaskedArray):
-                weights = np.ma.asarray(weights, dtype=dtype)
-            else:
-                weights = np.asarray(weights, dtype=dtype)
+        if isinstance(weights, np.ma.MaskedArray):
+            weights = weights.astype(dtype)
+        else:
+            weights = np.array(weights, dtype=dtype, copy=False)
 
     return np.exp(np.average(log_a, axis=axis, weights=weights))
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -413,7 +413,7 @@ def gmean(a, axis=0, dtype=None, weights=None):
     else:
         log_a = np.log(a)
 
-    if weights:
+    if weights is not None:
         if isinstance(weights, np.ma.MaskedArray):
             weights = weights.astype(dtype)
         else:

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4288,9 +4288,9 @@ def test_obrientransform():
     assert_array_almost_equal(result[0], expected, decimal=4)
 
 
-def check_equal_gmean(array_like, desired, axis=None, dtype=None, rtol=1e-7):
+def check_equal_gmean(array_like, desired, axis=None, dtype=None, rtol=1e-7, weights=None):
     # Note this doesn't test when axis is not specified
-    x = stats.gmean(array_like, axis=axis, dtype=dtype)
+    x = stats.gmean(array_like, axis=axis, dtype=dtype, weights=weights)
     assert_allclose(x, desired, rtol=rtol)
     assert_equal(x.dtype, dtype)
 
@@ -4479,6 +4479,35 @@ class TestGeoMean(object):
         desired = np.nan  # due to log(-1) = nan
         with np.errstate(invalid='ignore'):
             check_equal_gmean(a, desired)
+
+    def test_weights_1d_list(self):
+        # Desired result from:
+        # https://www.dummies.com/education/math/business-statistics/how-to-find-the-weighted-geometric-mean-of-a-data-set/
+        weights = [2, 5, 6, 4, 3]
+        a = [1, 2, 3, 4, 5]
+        desired = 2.77748
+        check_equal_gmean(a, desired, weights=weights, rtol=1e-5)
+
+    def test_weights_1d_array(self):
+        # Desired result from:
+        # https://www.dummies.com/education/math/business-statistics/how-to-find-the-weighted-geometric-mean-of-a-data-set/
+        a = np.array([1, 2, 3, 4, 5])
+        weights = np.array([2, 5, 6, 4, 3])
+        desired = 2.77748
+        check_equal_gmean(a, desired, weights=weights, rtol=1e-5)
+
+    def test_weights_masked_1d_array(self):
+        # Desired result from:
+        # https://www.dummies.com/education/math/business-statistics/how-to-find-the-weighted-geometric-mean-of-a-data-set/
+        a = np.array([1, 2, 3, 4, 5, 6])
+        weights = np.ma.array([2, 5, 6, 4, 3, 5], mask=[0, 0, 0, 0, 0, 1])
+        desired = 2.77748
+        check_equal_gmean(a, desired, weights=weights, rtol=1e-5)
+
+    def test_weights_bad_input(self):
+        a = np.array([1, 2, 3, 4, 5])
+        weights = "scipy"
+        assert_raises(TypeError, stats.gmean, a, weights=weights)
 
 
 class TestGeometricStandardDeviation(object):


### PR DESCRIPTION
I propose the addition of a `weights` argument to `scipy.stats.gmean`, to support the calculation of the weighted geometric mean according to https://en.wikipedia.org/wiki/Weighted_geometric_mean.

#### What does this implement/fix?
Allows the calculation of the weighted geometric mean.

#### Additional information
Docstring inspired by https://github.com/scipy/scipy/pull/6931/files#diff-764f0cedd33e98726d12c935495b80333a11e877a5a270d8ce53c9db152dd976R382-R384