### PR TITLE
BUG: fix signal.dlsim for complex input

### DIFF
--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -3462,9 +3462,10 @@ def dlsim(system, u, t=None, x0=None):
         out_samples = int(np.floor(stoptime / system.dt)) + 1
 
     # Pre-build output arrays
-    xout = np.zeros((out_samples, system.A.shape[0]))
-    yout = np.zeros((out_samples, system.C.shape[0]))
-    tout = np.linspace(0.0, stoptime, num=out_samples)
+    out_type = system.A.dtype
+    xout = np.zeros((out_samples, system.A.shape[0]), dtype=out_type)
+    yout = np.zeros((out_samples, system.C.shape[0]), dtype=out_type)
+    tout = np.linspace(0.0, stoptime, num=out_samples, dtype=out_type)
 
     # Check initial condition
     if x0 is None:

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -3462,7 +3462,10 @@ def dlsim(system, u, t=None, x0=None):
         out_samples = int(np.floor(stoptime / system.dt)) + 1
 
     # Pre-build output arrays
-    out_type = system.A.dtype
+    out_type = complex if (system.A.dtype == complex)\
+        or (system.B.dtype == complex)\
+        or (system.C.dtype == complex) else float
+
     xout = np.zeros((out_samples, system.A.shape[0]), dtype=out_type)
     yout = np.zeros((out_samples, system.C.shape[0]), dtype=out_type)
     tout = np.linspace(0.0, stoptime, num=out_samples, dtype=out_type)

--- a/scipy/signal/tests/test_dltisys.py
+++ b/scipy/signal/tests/test_dltisys.py
@@ -10,7 +10,7 @@ from pytest import raises as assert_raises
 from scipy.signal import (dlsim, dstep, dimpulse, tf2zpk, lti, dlti,
                           StateSpace, TransferFunction, ZerosPolesGain,
                           dfreqresp, dbode, BadCoefficients)
-
+from scipy.linalg import eig
 
 class TestDLTI(object):
 
@@ -596,3 +596,32 @@ class TestTransferFunctionZConversion(object):
         assert_equal(num, num2)
         assert_equal([5, 6, 0], den2)
 
+    def test_complex_dlsim(self):
+        # Example of simulation of diagonalized StateSpace system
+        # In this example the diagonalized system has complex values on the matrices
+
+        A = np.array([[0, 0, 1000], [0.1, 0, 0], [0, 0.5, 0.5]])
+        B = np.array([[0], [0], [1]])
+        C = np.array([[0, 0, 1]])
+        D = np.array([[0]])
+
+        eigenvectors_matrix = eig(A)[1]
+        Aw = np.matmul(np.matmul(np.linalg.inv(eigenvectors_matrix), A), eigenvectors_matrix)
+        Bw = np.matmul(np.linalg.inv(eigenvectors_matrix), B)
+        Cw = np.matmul(C, eigenvectors_matrix)
+        Dw = D
+
+        system_w = dlsim((Aw, Bw, Cw, Dw, 1), np.arange(10))
+
+        your_truth = np.array([[0.00000000e+00+0.00000000e+00j],
+                                 [0.00000000e+00+0.00000000e+00j],
+                                 [1.00000000e+00-4.27227788e-17j],
+                                 [2.50000000e+00+9.23967738e-17j],
+                                 [4.25000000e+00-2.12324961e-15j],
+                                 [5.61250000e+01-1.30680785e-14j],
+                                 [1.58062500e+02+4.34077628e-14j],
+                                 [2.97531250e+02-1.95676440e-13j],
+                                 [2.96201562e+03-1.34606639e-12j],
+                                 [9.39213281e+03+2.38330602e-12j]])
+
+        assert_array_almost_equal(your_truth, system_w[1])


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
The problem was that when trying to simulate a system with complex values in the state space matrices, it would perform a matrix multiplication between the input and output matrices, and the output matrices were float by default, so the multiplication casted everyone of them to float, removing the imaginary parts of the complex numbers, so the simulation was wrong.

#### What does this implement/fix?
I just set the type of the output matrices to be the same as the matrix A in the input, so that it works if the input is complex.

#### Additional information
<!--Any additional information you think is important.-->