### PR TITLE
CI, MAINT: migrate Lint to Azure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,27 +25,6 @@ env:
 
 matrix:
   include:
-    - python: 3.6
-      name: "Lint"
-      env:
-        - PYFLAKES=1
-        - PEP8=1
-        - NUMPYSPEC="--upgrade numpy"
-      before_install:
-        - pip install pycodestyle==2.5.0
-        - pip install pyflakes==2.1.1
-      script:
-        # TODO: remove "ignore[import]" filter below when moving to pyflakes==2.1.2 or above
-        - PYFLAKES_NODOCTEST=1 pyflakes scipy benchmarks/benchmarks 2>&1 | grep -E -v 'unable to detect undefined names|assigned to but never used|imported but unused|redefinition of unused|may be undefined, or defined from star imports|syntax error in type comment .ignore.import.' > test.out; cat test.out; test \! -s test.out
-        - pycodestyle scipy benchmarks/benchmarks
-        - |
-          if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-             git fetch --unshallow
-             git config remote.origin.fetch "+refs/heads/maintenance/*:refs/remotes/origin/maintenance/*"
-             git fetch origin --no-tags
-             python tools/lint_diff.py --branch origin/$TRAVIS_BRANCH
-          fi
-        - tools/unicode-check.py
     - python: 3.7
       name: "ARM - Test Group 1"
       arch: arm64

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,34 @@ variables:
     openblas_version: 0.3.9
 
 jobs:
+- job: Lint
+  condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))  # skip for PR merges
+  pool:
+    vmImage: 'ubuntu-18.04'
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.8'
+      addToPath: true
+      architecture: 'x64'
+  - script: >-
+      python -m pip install
+      pycodestyle==2.5.0
+      pyflakes==2.1.1
+    displayName: 'Install tools'
+    failOnStderr: true
+  - script: |
+      PYFLAKES_NODOCTEST=1 pyflakes scipy benchmarks/benchmarks 2>&1 | grep -E -v 'unable to detect undefined names|assigned to but never used|imported but unused|redefinition of unused|may be undefined, or defined from star imports|syntax error in type comment .ignore.import.' > test.out; cat test.out; test \! -s test.out
+      pycodestyle scipy benchmarks/benchmarks
+      # for Travis CI we used to do: git fetch --unshallow
+      # but apparently Azure clones are not as shallow
+      # so does not appear to be needed to fetch maintenance
+      # branches (which Azure logs show being checked out
+      # in Checkout stage)
+      python tools/lint_diff.py --branch origin/$(System.PullRequest.TargetBranch)
+      tools/unicode-check.py
+    displayName: 'Run Lint Checks'
+    failOnStderr: true
 - job: Linux_Python_36_32bit_full
   condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))  # skip for PR merges
   pool:


### PR DESCRIPTION
* migrate CI linting code from Travis CI
to Azure because of Travis build limit
restrictions recently imposed