### PR TITLE
BLD: drop Python 3.6 support (NEP 29)

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
         numpy-version: ['--upgrade numpy']
 
     steps:

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ matrix:
         - NUMPYSPEC="--pre --upgrade --timeout=60 -i $PRE_WHEELS numpy"
         - OTHERSPEC="--pre --upgrade --timeout=60"
         - NPY_USE_BLAS_ILP64=1
-    - python: 3.6
+    - python: 3.7
       name: "Refguide-check, Latest NumPy"
       env:
         - TESTMODE=fast
@@ -98,14 +98,14 @@ matrix:
         - REFGUIDE_CHECK=1
         - NUMPYSPEC="--upgrade numpy"
         - ASV_CHECK=1
-    - python: 3.6
+    - python: 3.7
       name: "Source Distribution"
       env:
         - TESTMODE=fast
         - COVERAGE=
         - NUMPYSPEC="numpy==1.17.4"
         - USE_SDIST=1
-    - python: 3.6
+    - python: 3.7
       name: "Wheel, Optimised, GCC 4.8"
       addons:
         apt:
@@ -127,7 +127,7 @@ matrix:
         # pytest-xdist plugin for load scheduling its workers don't pick up the
         # flag. This environment variable starts all Py instances in -OO mode.
         - PYTHONOPTIMIZE=2
-    - python: 3.6
+    - python: 3.7
       name: "Power PC"
       os: linux
       arch: ppc64le

--- a/INSTALL.rst.txt
+++ b/INSTALL.rst.txt
@@ -31,7 +31,7 @@ PREREQUISITES
 
 SciPy requires the following software installed for your platform:
 
-1) Python__ >= 3.6
+1) Python__ >= 3.7
 
 __ https://www.python.org
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,7 +52,7 @@ jobs:
       tools/unicode-check.py
     displayName: 'Run Lint Checks'
     failOnStderr: true
-- job: Linux_Python_36_32bit_full
+- job: Linux_Python_37_32bit_full
   condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))  # skip for PR merges
   pool:
     vmImage: 'ubuntu-16.04'
@@ -61,28 +61,28 @@ jobs:
            docker pull i386/ubuntu:bionic
            docker run -v $(pwd):/scipy i386/ubuntu:bionic /bin/bash -c "cd scipy && \
            apt-get -y update && \
-           apt-get -y install curl python3.6-dev python3.6 python3-distutils pkg-config libpng-dev libjpeg8-dev libfreetype6-dev && \
+           apt-get -y install curl python3.7-dev python3.7 python3-distutils pkg-config libpng-dev libjpeg8-dev libfreetype6-dev && \
            curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
-           python3.6 get-pip.py && \
+           python3.7 get-pip.py && \
            pip3 --version && \
            pip3 install setuptools wheel numpy==1.16.6 cython==0.29.18 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath matplotlib==3.1.3 --user && \
            apt-get -y install gcc-5 g++-5 gfortran-5 wget && \
            cd .. && \
            mkdir openblas && cd openblas && \
-           target=\$(python3.6 ../scipy/tools/openblas_support.py) && \
+           target=\$(python3.7 ../scipy/tools/openblas_support.py) && \
            cp -r \$target/lib/* /usr/lib && \
            cp \$target/include/* /usr/include && \
            cd ../scipy && \
-           CC=gcc-5 CXX=g++-5 F77=gfortran-5 F90=gfortran-5 python3.6 setup.py install && \
-           python3.6 tools/openblas_support.py --check_version $(openblas_version) && \
-           CC=gcc-5 CXX=g++-5 F77=gfortran-5 F90=gfortran-5 python3.6 runtests.py --mode=full -- -n auto -s --junitxml=junit/test-results.xml --cov-config=.coveragerc --cov-report=xml --cov-report=html"
+           CC=gcc-5 CXX=g++-5 F77=gfortran-5 F90=gfortran-5 python3.7 setup.py install && \
+           python3.7 tools/openblas_support.py --check_version $(openblas_version) && \
+           CC=gcc-5 CXX=g++-5 F77=gfortran-5 F90=gfortran-5 python3.7 runtests.py --mode=full -- -n auto -s --junitxml=junit/test-results.xml --cov-config=.coveragerc --cov-report=xml --cov-report=html"
     displayName: 'Run 32-bit Ubuntu Docker Build / Tests'
   - task: PublishTestResults@2
     condition: succeededOrFailed()
     inputs:
       testResultsFiles: '**/test-*.xml'
       failTaskOnFailedTests: true
-      testRunTitle: 'Publish test results for Python 3.6-32 bit full Linux'
+      testRunTitle: 'Publish test results for Python 3.7-32 bit full Linux'
   - task: PublishCodeCoverageResults@1
     inputs:
       codeCoverageTool: Cobertura
@@ -99,16 +99,11 @@ jobs:
   strategy:
     maxParallel: 4
     matrix:
-        Python36-32bit-fast:
-          PYTHON_VERSION: '3.6'
+        Python37-32bit-fast:
+          PYTHON_VERSION: '3.7'
           PYTHON_ARCH: 'x86'
           TEST_MODE: fast
           BITS: 32
-        Python36-64bit-full:
-          PYTHON_VERSION: '3.6'
-          PYTHON_ARCH: 'x64'
-          TEST_MODE: full
-          BITS: 64
         Python37-64bit-full:
           PYTHON_VERSION: '3.7'
           PYTHON_ARCH: 'x64'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ requires = [
     "wheel",
     "setuptools",
     "Cython>=0.29.18",
-    "numpy==1.16.5; python_version=='3.6'",
     "numpy==1.16.5; python_version=='3.7'",
     "numpy==1.17.3; python_version=='3.8'",
     # do not pin numpy on future versions of python to avoid incompatible numpy and python versions

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,8 @@ import sysconfig
 from distutils.version import LooseVersion
 
 
-if sys.version_info[:2] < (3, 6):
-    raise RuntimeError("Python version >= 3.6 required.")
+if sys.version_info[:2] < (3, 7):
+    raise RuntimeError("Python version >= 3.7 required.")
 
 import builtins
 
@@ -41,7 +41,6 @@ License :: OSI Approved :: BSD License
 Programming Language :: C
 Programming Language :: Python
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
 Programming Language :: Python :: 3.9
@@ -542,7 +541,7 @@ def setup_package():
         install_requires=[
             'numpy>=1.16.5',
         ],
-        python_requires='>=3.6',
+        python_requires='>=3.7',
     )
 
     if "--force" in sys.argv:

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@
 # installed and that they can be run as 'python3.6', 'python3.7', etc.
 
 [tox]
-envlist = py36,py37,py38
+envlist = py37,py38,py39
 skipsdist=True
 
 [testenv]


### PR DESCRIPTION
Pending the final discussion on mailing list.

Probably incomplete/not perfect yet; gh-13078 proposes to remove the remaning 3.6 entry in Travis