### PR TITLE
ENH:signal: Speed-up Cython implementation of _sosfilt

### DIFF
--- a/scipy/signal/_sosfilt.pyx
+++ b/scipy/signal/_sosfilt.pyx
@@ -33,17 +33,21 @@ cdef void _sosfilt_float(DTYPE_floating_t [:, ::1] sos,
     cdef Py_ssize_t n_sections = sos.shape[0]
     cdef Py_ssize_t i, n, s
     cdef DTYPE_floating_t x_new, x_cur
+    cdef DTYPE_floating_t[:, ::1] zi_slice
 
+    # jumping through a few memoryview hoops to reduce array lookups,
+    # the original version is still in the gil version below.
     for i in xrange(n_signals):
+        zi_slice = zi[i, :, :]
         for n in xrange(n_samples):
 
             x_cur = x[i, n]
 
             for s in xrange(n_sections):
-                x_new = sos[s, 0] * x_cur + zi[i, s, 0]
-                zi[i, s, 0] = (sos[s, 1] * x_cur - sos[s, 4] * x_new
-                               + zi[i, s, 1])
-                zi[i, s, 1] = sos[s, 2] * x_cur - sos[s, 5] * x_new
+                x_new = sos[s, 0] * x_cur + zi_slice[s, 0]
+                zi_slice[s, 0] = (sos[s, 1] * x_cur - sos[s, 4] * x_new
+                                  + zi_slice[s, 1])
+                zi_slice[s, 1] = sos[s, 2] * x_cur - sos[s, 5] * x_new
                 x_cur = x_new
 
             x[i, n] = x_cur

--- a/scipy/signal/_sosfilt.pyx
+++ b/scipy/signal/_sosfilt.pyx
@@ -1,13 +1,16 @@
 cimport numpy as np
 cimport cython
 
-ctypedef fused DTYPE_t:
+ctypedef fused DTYPE_floating_t:
     float
     float complex
     double
     double complex
     long double
     long double complex
+
+ctypedef fused DTYPE_t:
+    DTYPE_floating_t
     object
 
 
@@ -21,38 +24,59 @@ ctypedef fused DTYPE_t:
 @cython.cdivision(True)
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def _sosfilt(DTYPE_t [:, ::1] sos,
-             DTYPE_t [:, ::1] x,
-             DTYPE_t [:, :, ::1] zi):
+cdef void _sosfilt_float(DTYPE_floating_t [:, ::1] sos,
+                         DTYPE_floating_t [:, ::1] x,
+                         DTYPE_floating_t [:, :, ::1] zi) nogil:
     # Modifies x and zi in place
     cdef Py_ssize_t n_signals = x.shape[0]
     cdef Py_ssize_t n_samples = x.shape[1]
     cdef Py_ssize_t n_sections = sos.shape[0]
     cdef Py_ssize_t i, n, s
-    cdef DTYPE_t x_n
-    cdef DTYPE_t [:, ::1] b = sos[:, :3]
-    # We ignore sos[:, 3] here because _validate_sos guarantees it's 1.
-    cdef DTYPE_t [:, ::1] a = sos[:, 4:]
+    cdef DTYPE_floating_t x_new, x_cur
+
+    for i in xrange(n_signals):
+        for n in xrange(n_samples):
+
+            x_cur = x[i, n]
+
+            for s in xrange(n_sections):
+                x_new = sos[s, 0] * x_cur + zi[i, s, 0]
+                zi[i, s, 0] = sos[s, 1] * x_cur - sos[s, 4] * x_new +\
+                              zi[i, s, 1]
+                zi[i, s, 1] = sos[s, 2] * x_cur - sos[s, 5] * x_new
+                x_cur = x_new
+
+            x[i, n] = x_cur
+
+
+@cython.cdivision(True)
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def _sosfilt_object(object [:, ::1] sos,
+                    object [:, ::1] x,
+                    object [:, :, ::1] zi):
+    # Modifies x and zi in place
+    cdef Py_ssize_t n_signals = x.shape[0]
+    cdef Py_ssize_t n_samples = x.shape[1]
+    cdef Py_ssize_t n_sections = sos.shape[0]
+    cdef Py_ssize_t i, n, s
+    cdef object x_n
+    for i in xrange(n_signals):
+        for n in xrange(n_samples):
+            for s in xrange(n_sections):
+                x_n = x[i, n]  # make a temporary copy
+                # Use direct II transposed structure:
+                x[i, n] = sos[s, 0] * x_n + zi[i, s, 0]
+                zi[i, s, 0] = (sos[s, 1] * x_n - sos[s, 4] * x[i, n] +
+                               zi[i, s, 1])
+                zi[i, s, 1] = (sos[s, 2] * x_n - sos[s, 5] * x[i, n])
+
+
+cpdef void _sosfilt(DTYPE_t [:, ::1] sos,
+             DTYPE_t [:, ::1] x,
+             DTYPE_t [:, :, ::1] zi) nogil:
     if DTYPE_t is object:
-        for i in range(n_signals):
-            for n in range(n_samples):
-                for s in range(n_sections):
-                    x_n = x[i, n]  # make a temporary copy
-                    # Use direct II transposed structure:
-                    x[i, n] = b[s, 0] * x_n + zi[i, s, 0]
-                    zi[i, s, 0] = (
-                        b[s, 1] * x_n - a[s, 0] * x[i, n] + zi[i, s, 1])
-                    zi[i, s, 1] = (
-                        b[s, 2] * x_n - a[s, 1] * x[i, n])
+        with gil:
+            _sosfilt_object(sos, x, zi)
     else:
-        with nogil:
-            for i in range(n_signals):
-                for n in range(n_samples):
-                    for s in range(n_sections):
-                        x_n = x[i, n]  # make a temporary copy
-                        # Use direct II transposed structure:
-                        x[i, n] = b[s, 0] * x_n + zi[i, s, 0]
-                        zi[i, s, 0] = (
-                            b[s, 1] * x_n - a[s, 0] * x[i, n] + zi[i, s, 1])
-                        zi[i, s, 1] = (
-                            b[s, 2] * x_n - a[s, 1] * x[i, n])
+        _sosfilt_float(sos, x, zi)

--- a/scipy/signal/_sosfilt.pyx
+++ b/scipy/signal/_sosfilt.pyx
@@ -41,8 +41,8 @@ cdef void _sosfilt_float(DTYPE_floating_t [:, ::1] sos,
 
             for s in xrange(n_sections):
                 x_new = sos[s, 0] * x_cur + zi[i, s, 0]
-                zi[i, s, 0] = sos[s, 1] * x_cur - sos[s, 4] * x_new +\
-                              zi[i, s, 1]
+                zi[i, s, 0] = (sos[s, 1] * x_cur - sos[s, 4] * x_new
+                               + zi[i, s, 1])
                 zi[i, s, 1] = sos[s, 2] * x_cur - sos[s, 5] * x_new
                 x_cur = x_new
 


### PR DESCRIPTION
As per the discussion on #12970, `sosfilt` implementation is accelerated through some rearrangements of the loops. Before this change as shown in the issue the speed difference was occasionally hitting x2 slowdowns.

Continuing the example from the linked issue for `dt=[10, 100, 1000]`  I get the following "almost" equal performance, measured through 

```python
%timeit timeseries_lp_sos = scipy.signal.sosfilt(lp_sos, timeseries)
%timeit timeseries_lp = scipy.signal.lfilter(lp_numerator, lp_denominator, timeseries)
```

```bash
dt = 10
6.74 ms ± 108 µs per loop (mean ± std. dev. of 7 runs, 100 loops each) # This PR
6.1 ms ± 75.9 µs per loop (mean ± std. dev. of 7 runs, 100 loops each) # ba performance

dt = 100
67.1 ms ± 940 µs per loop (mean ± std. dev. of 7 runs, 10 loops each) # This PR
63.6 ms ± 932 µs per loop (mean ± std. dev. of 7 runs, 10 loops each) # ba performance

dt = 1000
640 ms ± 9.23 ms per loop (mean ± std. dev. of 7 runs, 1 loop each) # This PR
595 ms ± 9.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each) # ba performance
```

Pinging @RonaldAJ ; could I please bother you for a verification of these results? 

