### PR TITLE
BLD, BUG: add c99 compiler flag to HiGHS basiclu library

### DIFF
--- a/scipy/optimize/_highs/setup.py
+++ b/scipy/optimize/_highs/setup.py
@@ -13,6 +13,14 @@ def pre_build_hook(build_ext, ext):
     if std_flag is not None:
         ext.extra_compile_args.append(std_flag)
 
+def basiclu_pre_build_hook(build_clib, build_info):
+    from scipy._build_utils.compiler_helper import get_c_std_flag
+    c_flag = get_c_std_flag(build_clib.compiler)
+    if c_flag is not None:
+        if 'extra_compiler_args' not in build_info:
+            build_info['extra_compiler_args'] = []
+        build_info['extra_compiler_args'].append(c_flag)
+
 def _get_sources(CMakeLists, start_token, end_token):
     # Read in sources from CMakeLists.txt
     CMakeLists = pathlib.Path(__file__).parent / CMakeLists
@@ -90,6 +98,7 @@ def configuration(parent_package='', top_path=None):
         ],
         language='c',
         macros=DEFINE_MACROS,
+        _pre_build_hook=basiclu_pre_build_hook,
     )
 
     # highs_wrapper:


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Related to issues:
- https://github.com/scipy/scipy/issues/13085
- https://github.com/scipy/scipy/issues/13088

#### What does this implement/fix?
<!--Please explain your changes.-->

- Explicitly adds `-std=c99` flag to basiclu library to fix compilation issues encountered on MacOS builds

#### Additional information
<!--Any additional information you think is important.-->

@mdhaber @tylerjereddy