### PR TITLE
BUG: Fix GIL handling in _sosfilt

### DIFF
--- a/scipy/signal/_sosfilt.pyx
+++ b/scipy/signal/_sosfilt.pyx
@@ -76,11 +76,11 @@ def _sosfilt_object(object [:, ::1] sos,
                 zi[i, s, 1] = (sos[s, 2] * x_n - sos[s, 5] * x[i, n])
 
 
-cpdef void _sosfilt(DTYPE_t [:, ::1] sos,
+def _sosfilt(DTYPE_t [:, ::1] sos,
              DTYPE_t [:, ::1] x,
-             DTYPE_t [:, :, ::1] zi) nogil:
+             DTYPE_t [:, :, ::1] zi):
     if DTYPE_t is object:
-        with gil:
-            _sosfilt_object(sos, x, zi)
+        _sosfilt_object(sos, x, zi)
     else:
-        _sosfilt_float(sos, x, zi)
+        with nogil:
+            _sosfilt_float(sos, x, zi)


### PR DESCRIPTION

#### Reference issue
Follow up to https://github.com/scipy/scipy/pull/13087#discussion_r525265920

#### What does this implement/fix?
The `nogil` annotation doesn't actually release the gil, you do still need the `with nogil`. Also, `cpdef` doesn't do anything if the function isn't actually called from a C or cythonized function.