### PR TITLE
DOC: clarify "location" in docstring of cKDTree.query

### DIFF
--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -706,7 +706,7 @@ cdef class cKDTree:
             When k == 1, the last dimension of the output is squeezed.
             Missing neighbors are indicated with infinite distances.
         i : ndarray of ints
-            The index of the neighbors in ``self.data``.
+            The index of each neighbor in ``self.data``.
             If ``x`` has shape ``tuple+(self.m,)``, then ``i`` has shape ``tuple+(k,)``.
             When k == 1, the last dimension of the output is squeezed.
             Missing neighbors are indicated with ``self.n``.

--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -706,7 +706,7 @@ cdef class cKDTree:
             When k == 1, the last dimension of the output is squeezed.
             Missing neighbors are indicated with infinite distances.
         i : ndarray of ints
-            The index locations of the neighbors in ``self.data``.
+            The index of the neighbors in ``self.data``.
             If ``x`` has shape ``tuple+(self.m,)``, then ``i`` has shape ``tuple+(k,)``.
             When k == 1, the last dimension of the output is squeezed.
             Missing neighbors are indicated with ``self.n``.

--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -706,7 +706,7 @@ cdef class cKDTree:
             When k == 1, the last dimension of the output is squeezed.
             Missing neighbors are indicated with infinite distances.
         i : ndarray of ints
-            The locations of the neighbors in ``self.data``.
+            The index locations of the neighbors in ``self.data``.
             If ``x`` has shape ``tuple+(self.m,)``, then ``i`` has shape ``tuple+(k,)``.
             When k == 1, the last dimension of the output is squeezed.
             Missing neighbors are indicated with ``self.n``.

--- a/scipy/spatial/kdtree.py
+++ b/scipy/spatial/kdtree.py
@@ -85,6 +85,7 @@ class Rectangle(object):
 
     Represents a Cartesian product of intervals.
     """
+
     def __init__(self, maxes, mins):
         """Construct a hyperrectangle."""
         self.maxes = np.maximum(maxes,mins).astype(float)
@@ -386,7 +387,7 @@ class KDTree(cKDTree):
                instead.
 
         i : integer or array of integers
-            The locations of the neighbors in ``self.data``.
+            The index of the neighbors in ``self.data``.
             ``i`` is the same shape as d.
             Missing neighbors are indicated with ``self.n``.
 

--- a/scipy/spatial/kdtree.py
+++ b/scipy/spatial/kdtree.py
@@ -85,7 +85,6 @@ class Rectangle(object):
 
     Represents a Cartesian product of intervals.
     """
-
     def __init__(self, maxes, mins):
         """Construct a hyperrectangle."""
         self.maxes = np.maximum(maxes,mins).astype(float)
@@ -387,7 +386,7 @@ class KDTree(cKDTree):
                instead.
 
         i : integer or array of integers
-            The index of the neighbors in ``self.data``.
+            The index of each neighbor in ``self.data``.
             ``i`` is the same shape as d.
             Missing neighbors are indicated with ``self.n``.
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Perhaps a small thing, but I think for the cKDTree.query return, the `i` should be unambiguously described as an index. 
The current description: "The locations of the neighbors..." implies to me that it returns the coordinate locations of the neighbours, and I spent a few minutes wondering why my 2D coordinates were not being returned until I realised it was the index.

#### What does this implement/fix?
It may clarify at a glance what this method is returning.
