### PR TITLE
Zoom resize update

### DIFF
--- a/scipy/ndimage/interpolation.py
+++ b/scipy/ndimage/interpolation.py
@@ -773,13 +773,27 @@ def zoom(input, zoom, output=None, order=3, mode='constant', cval=0.0,
     else:
         npad = 0
         filtered = input
+    if grid_mode:
+        # warn about modes that may have surprising behavior
+        suggest_mode = None
+        if mode == 'constant':
+            suggest_mode = 'grid-constant'
+        elif mode == 'wrap':
+            suggest_mode = 'grid-wrap'
+        if suggest_mode is not None:
+            warnings.warn(
+                ("It is recommended to use mode = {} instead of {} when "
+                 "grid_mode is True."
+                ).format(suggest_mode, mode)
+            )
     mode = _ni_support._extend_mode_to_code(mode)
 
     zoom_div = numpy.array(output_shape, float)
-    zoom_nominator = numpy.array(input.shape)
+    zoom_nominator = numpy.array(input.shape, float)
     if not grid_mode:
         zoom_div -= 1
         zoom_nominator -= 1
+
     # Zooming to infinite values is unpredictable, so just choose
     # zoom factor 1 instead
     zoom = numpy.divide(zoom_nominator, zoom_div,

--- a/scipy/ndimage/interpolation.py
+++ b/scipy/ndimage/interpolation.py
@@ -597,7 +597,7 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None,
             "SciPy 0.18.0."
         )
         _nd_image.zoom_shift(filtered, matrix, offset/matrix, output, order,
-                             mode, cval, npad)
+                             mode, cval, npad, False)
     else:
         _nd_image.geometric_transform(filtered, None, None, matrix, offset,
                                       output, order, mode, cval, npad, None,
@@ -673,13 +673,13 @@ def shift(input, shift, output=None, order=3, mode='constant', cval=0.0,
     if not shift.flags.contiguous:
         shift = shift.copy()
     _nd_image.zoom_shift(filtered, None, shift, output, order, mode, cval,
-                         npad)
+                         npad, False)
     return output
 
 
 @docfiller
 def zoom(input, zoom, output=None, order=3, mode='constant', cval=0.0,
-         prefilter=True):
+         prefilter=True, *, grid_mode=False):
     """
     Zoom an array.
 
@@ -698,6 +698,21 @@ def zoom(input, zoom, output=None, order=3, mode='constant', cval=0.0,
     %(mode_interp_constant)s
     %(cval)s
     %(prefilter)s
+    grid_mode : bool, optional
+        If False, the distance from the pixel centers is zoomed. Otherwise, the
+        distance including the full pixel extent is used. For example, a 1d
+        signal of length 5 is considered to have length 4 when `grid_mode` is
+        False, but length 5 when `grid_mode` is True. See the following
+        visual illustration::
+
+        | pixel 1 | pixel 2 | pixel 3 | pixel 4 | pixel 5 |
+
+              |<------------------------------------>|
+                                vs.
+        |<----------------------------------------------->|
+
+        The starting point of the arrow in the diagram above corresponds to
+        coordinate location 0 in each mode.
 
     Returns
     -------
@@ -760,14 +775,19 @@ def zoom(input, zoom, output=None, order=3, mode='constant', cval=0.0,
         filtered = input
     mode = _ni_support._extend_mode_to_code(mode)
 
-    zoom_div = numpy.array(output_shape, float) - 1
+    zoom_div = numpy.array(output_shape, float)
+    zoom_nominator = numpy.array(input.shape)
+    if not grid_mode:
+        zoom_div -= 1
+        zoom_nominator -= 1
     # Zooming to infinite values is unpredictable, so just choose
     # zoom factor 1 instead
-    zoom = numpy.divide(numpy.array(input.shape) - 1, zoom_div,
+    zoom = numpy.divide(zoom_nominator, zoom_div,
                         out=numpy.ones_like(input.shape, dtype=numpy.float64),
                         where=zoom_div != 0)
     zoom = numpy.ascontiguousarray(zoom)
-    _nd_image.zoom_shift(filtered, zoom, None, output, order, mode, cval, npad)
+    _nd_image.zoom_shift(filtered, zoom, None, output, order, mode, cval, npad,
+                         grid_mode)
     return output
 
 

--- a/scipy/ndimage/interpolation.py
+++ b/scipy/ndimage/interpolation.py
@@ -789,8 +789,8 @@ def zoom(input, zoom, output=None, order=3, mode='constant', cval=0.0,
             )
     mode = _ni_support._extend_mode_to_code(mode)
 
-    zoom_div = numpy.array(output_shape, float)
-    zoom_nominator = numpy.array(input.shape, float)
+    zoom_div = numpy.array(output_shape)
+    zoom_nominator = numpy.array(input.shape)
     if not grid_mode:
         zoom_div -= 1
         zoom_nominator -= 1

--- a/scipy/ndimage/interpolation.py
+++ b/scipy/ndimage/interpolation.py
@@ -703,13 +703,14 @@ def zoom(input, zoom, output=None, order=3, mode='constant', cval=0.0,
         distance including the full pixel extent is used. For example, a 1d
         signal of length 5 is considered to have length 4 when `grid_mode` is
         False, but length 5 when `grid_mode` is True. See the following
-        visual illustration::
+        visual illustration:
 
-        | pixel 1 | pixel 2 | pixel 3 | pixel 4 | pixel 5 |
+        .. code-block:: none
 
-              |<------------------------------------>|
-                                vs.
-        |<----------------------------------------------->|
+                | pixel 1 | pixel 2 | pixel 3 | pixel 4 | pixel 5 |
+                     |<-------------------------------------->|
+                                        vs.
+                |<----------------------------------------------->|
 
         The starting point of the arrow in the diagram above corresponds to
         coordinate location 0 in each mode.

--- a/scipy/ndimage/interpolation.py
+++ b/scipy/ndimage/interpolation.py
@@ -705,7 +705,7 @@ def zoom(input, zoom, output=None, order=3, mode='constant', cval=0.0,
         False, but length 5 when `grid_mode` is True. See the following
         visual illustration:
 
-        .. code-block:: none
+        .. code-block:: text
 
                 | pixel 1 | pixel 2 | pixel 3 | pixel 4 | pixel 5 |
                      |<-------------------------------------->|

--- a/scipy/ndimage/src/nd_image.c
+++ b/scipy/ndimage/src/nd_image.c
@@ -819,18 +819,19 @@ static PyObject *Py_ZoomShift(PyObject *obj, PyObject *args)
 {
     PyArrayObject *input = NULL, *output = NULL, *shift = NULL;
     PyArrayObject *zoom = NULL;
-    int mode, order, nprepad;
+    int mode, order, nprepad, grid_mode;
     double cval;
 
-    if (!PyArg_ParseTuple(args, "O&O&O&O&iidi",
+    if (!PyArg_ParseTuple(args, "O&O&O&O&iidii",
                           NI_ObjectToInputArray, &input,
                           NI_ObjectToOptionalInputArray, &zoom,
                           NI_ObjectToOptionalInputArray, &shift,
                           NI_ObjectToOutputArray, &output,
-                          &order, &mode, &cval, &nprepad))
+                          &order, &mode, &cval, &nprepad, &grid_mode))
         goto exit;
 
-    NI_ZoomShift(input, zoom, shift, output, order, (NI_ExtendMode)mode, cval, nprepad);
+    NI_ZoomShift(input, zoom, shift, output, order, (NI_ExtendMode)mode, cval,
+                 nprepad, grid_mode);
     #ifdef HAVE_WRITEBACKIFCOPY
         PyArray_ResolveWritebackIfCopy(output);
     #endif

--- a/scipy/ndimage/src/ni_interpolation.c
+++ b/scipy/ndimage/src/ni_interpolation.c
@@ -59,7 +59,8 @@ map_coordinate(double in, npy_intp len, int mode)
                 npy_intp sz2 = 2 * len;
                 if (in < -sz2)
                     in = sz2 * (npy_intp)(-in / sz2) + in;
-                in = in < -len ? in + sz2 : -in - 1;
+                // -1e-15 check to avoid possibility that: (-in - 1) == -1
+                in = in < -len ? in + sz2 : (in > -1e-15 ? 1e-15 : -in) - 1;
             }
             break;
         case NI_EXTEND_WRAP:

--- a/scipy/ndimage/src/ni_interpolation.c
+++ b/scipy/ndimage/src/ni_interpolation.c
@@ -652,7 +652,7 @@ NI_GeometricTransform(PyArrayObject *input, int (*map)(npy_intp*, double*,
 
 int NI_ZoomShift(PyArrayObject *input, PyArrayObject* zoom_ar,
                  PyArrayObject* shift_ar, PyArrayObject *output,
-                 int order, int mode, double cval, int nprepad)
+                 int order, int mode, double cval, int nprepad, int grid_mode)
 {
     char *po, *pi;
     npy_intp **zeros = NULL, **offsets = NULL, ***edge_offsets = NULL;
@@ -782,7 +782,16 @@ int NI_ZoomShift(PyArrayObject *input, PyArrayObject* zoom_ar,
             if (shifts)
                 cc += shift;
             if (zooms)
-                cc *= zoom;
+            {
+                if (grid_mode)
+                {
+                    cc += 0.5;
+                    cc *= zoom;
+                    cc -= 0.5;
+                } else {
+                    cc *= zoom;
+                }
+            }
             cc += (double)nprepad;
             if (mode != NI_EXTEND_GRID_CONSTANT) {
                 /* if the input coordinate is outside the borders, map it: */

--- a/scipy/ndimage/src/ni_interpolation.h
+++ b/scipy/ndimage/src/ni_interpolation.h
@@ -38,6 +38,6 @@ int NI_GeometricTransform(PyArrayObject*, int (*)(npy_intp*, double*, int, int,
                                                     PyArrayObject*, PyArrayObject*, int, int,
                                                     double, int);
 int NI_ZoomShift(PyArrayObject*, PyArrayObject*, PyArrayObject*,
-                                 PyArrayObject*, int, int, double, int);
+                                 PyArrayObject*, int, int, double, int, int);
 
 #endif

--- a/scipy/ndimage/tests/test_interpolation.py
+++ b/scipy/ndimage/tests/test_interpolation.py
@@ -1113,8 +1113,7 @@ class TestNdimageInterpolation:
     @pytest.mark.parametrize('shape', [(2, 3), (4, 4)])
     @pytest.mark.parametrize('zoom', [(1, 1), (3, 5), (8, 2), (8, 8)])
     @pytest.mark.parametrize('mode', ['nearest', 'reflect', 'mirror',
-                                      'grid-wrap', 'grid-mirror',
-                                      'grid-constant'])
+                                      'grid-wrap', 'grid-constant'])
     def test_zoom_grid_by_int_order0(self, shape, zoom, mode):
         # When grid_mode is True,  order 0 zoom should be the same as
         # replication via numpy.kron. The only exceptions to this are the

--- a/scipy/ndimage/tests/test_interpolation.py
+++ b/scipy/ndimage/tests/test_interpolation.py
@@ -1093,18 +1093,45 @@ class TestNdimageInterpolation:
         out = ndimage.zoom(arr, zoom)
         assert_array_equal(out.shape, (4, 15, 29))
 
-    @pytest.mark.parametrize('zoom', [(1, 1), (8, 2), (8, 8)])
+    @pytest.mark.parametrize('zoom', [(1, 1), (3, 5), (8, 2), (8, 8)])
     @pytest.mark.parametrize('mode', ['nearest', 'constant', 'wrap', 'reflect',
                                       'mirror', 'grid-wrap', 'grid-mirror',
                                       'grid-constant'])
     def test_zoom_by_int_order0(self, zoom, mode):
         # order 0 zoom should be the same as replication via numpy.kron
+        # Note: This is not True for general x shapes when grid_mode is False,
+        #       but works here for all modes because the size ratio happens to
+        #       always be an integer when x.shape = (2, 2).
         x = numpy.array([[0, 1],
                          [2, 3]], dtype=float)
+        # x = numpy.arange(16, dtype=float).reshape(4, 4)
         assert_array_almost_equal(
             ndimage.zoom(x, zoom, order=0, mode=mode),
             numpy.kron(x, numpy.ones(zoom))
         )
+
+    @pytest.mark.parametrize('shape', [(2, 3), (4, 4)])
+    @pytest.mark.parametrize('zoom', [(1, 1), (3, 5), (8, 2), (8, 8)])
+    @pytest.mark.parametrize('mode', ['nearest', 'reflect', 'mirror',
+                                      'grid-wrap', 'grid-mirror',
+                                      'grid-constant'])
+    def test_zoom_grid_by_int_order0(self, shape, zoom, mode):
+        # When grid_mode is True,  order 0 zoom should be the same as
+        # replication via numpy.kron. The only exceptions to this are the
+        # non-grid modes 'constant' and 'wrap'.
+        x = numpy.arange(numpy.prod(shape), dtype=float).reshape(shape)
+        assert_array_almost_equal(
+            ndimage.zoom(x, zoom, order=0, mode=mode, grid_mode=True),
+            numpy.kron(x, numpy.ones(zoom))
+        )
+
+    @pytest.mark.parametrize('mode', ['constant', 'wrap'])
+    def test_zoom_grid_mode_warnings(self, mode):
+        # Warn on use of non-grid modes when grid_mode is True
+        x = numpy.arange(9, dtype=float).reshape((3, 3))
+        with pytest.warns(UserWarning,
+                          match="It is recommended to use mode"):
+            ndimage.zoom(x, 2, mode=mode, grid_mode=True),
 
     @pytest.mark.parametrize('order', range(0, 6))
     def test_rotate01(self, order):


### PR DESCRIPTION
#### Reference issue
closes gh-3203
closes gh-4922
closes gh-5223
closes gh-6713
closes gh-7324
closes gh-10620

#### What does this implement/fix?

Similar to the recent PR's implementing grid-constant and grid-wrap, this PR updates "zoom" so that it behaves consistently with this grid interpretation if the user provides a "grid_mode=True" kwarg. The new behavior with `grid_mode=True` is consistent with scikit-image's `rescale` function and user expections from gh-5223.

The default behavior of `zoom` is not modified, so this should not break any downstream code.

see the docstring description:
```
    grid_mode : bool, optional
        If False, the distance from the pixel centers is zoomed. Otherwise, the
        distance including the full pixel extent is used. For example, a 1d
        signal of length 5 is considered to have length 4 when `grid_mode` is
        False, but length 5 when `grid_mode` is True. See the following
        visual illustration::

        | pixel 1 | pixel 2 | pixel 3 | pixel 4 | pixel 5 |

              |<------------------------------------>|
                                vs.
        |<----------------------------------------------->|

        The starting point of the arrow in the diagram above corresponds to
        coordinate location 0 in each mode.
```

#### Additional information

The signal length assumed by modes 'constant' and 'wrap' is not really consistent with the `grid_mode=True` case, so I have raised a `UserWarning` if they are used suggesting the use of 'grid-constant' and 'grid-wrap', respectively. If it is preferred, we can make this a `ValueError` instead.
