### PR TITLE
BUG: sparse: Correct output format of kron

### DIFF
--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -330,7 +330,7 @@ def kron(A, B, format=None):
 
         if A.nnz == 0 or B.nnz == 0:
             # kronecker product is the zero matrix
-            return coo_matrix(output_shape)
+            return coo_matrix(output_shape).asformat(format)
 
         # expand entries of a into blocks
         row = A.row.repeat(B.nnz)

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -316,7 +316,7 @@ def kron(A, B, format=None):
 
         if A.nnz == 0 or B.nnz == 0:
             # kronecker product is the zero matrix
-            return coo_matrix(output_shape)
+            return coo_matrix(output_shape).asformat(format)
 
         B = B.toarray()
         data = A.data.repeat(B.size).reshape(-1,B.shape[0],B.shape[1])

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -271,12 +271,15 @@ class TestConstructUtils(object):
         cases.append(array([[5,4,4],[1,0,0],[6,0,8]]))
         cases.append(array([[0,1,0,2,0,5,8]]))
         cases.append(array([[0.5,0.125,0,3.25],[0,2.5,0,0]]))
-
+        
         for a in cases:
             for b in cases:
-                result = construct.kron(csr_matrix(a),csr_matrix(b)).todense()
-                expected = np.kron(a,b)
-                assert_array_equal(result,expected)
+                for fmt in sparse_formats:
+                    result_s = construct.kron(csr_matrix(a),csr_matrix(b),format=fmt) 
+                    result_d = result_s.todense()
+                    expected = np.kron(a,b)
+                    assert_equal(result_s.format,fmt)
+                    assert_array_equal(result_d,expected)
 
     def test_kron_large(self):
         n = 2**16

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -271,15 +271,14 @@ class TestConstructUtils(object):
         cases.append(array([[5,4,4],[1,0,0],[6,0,8]]))
         cases.append(array([[0,1,0,2,0,5,8]]))
         cases.append(array([[0.5,0.125,0,3.25],[0,2.5,0,0]]))
-        
+
         for a in cases:
             for b in cases:
+                expected = np.kron(a, b)
                 for fmt in sparse_formats:
-                    result_s = construct.kron(csr_matrix(a),csr_matrix(b),format=fmt) 
-                    result_d = result_s.todense()
-                    expected = np.kron(a,b)
-                    assert_equal(result_s.format,fmt)
-                    assert_array_equal(result_d,expected)
+                    result = construct.kron(csr_matrix(a), csr_matrix(b), format=fmt) 
+                    assert_equal(result_s.format, fmt)
+                    assert_array_equal(result.todense(), expected)
 
     def test_kron_large(self):
         n = 2**16

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -277,7 +277,7 @@ class TestConstructUtils(object):
                 expected = np.kron(a, b)
                 for fmt in sparse_formats:
                     result = construct.kron(csr_matrix(a), csr_matrix(b), format=fmt) 
-                    assert_equal(result_s.format, fmt)
+                    assert_equal(result.format, fmt)
                     assert_array_equal(result.todense(), expected)
 
     def test_kron_large(self):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Fixes #13099

#### What does this implement/fix?
<!--Please explain your changes.-->
1. Change the output format of kron for zero matrix inputs
2. Add this functionality to test suite

#### Additional information
<!--Any additional information you think is important.-->
Sorry about the not-100-percent-correctly-formatted commit messages (and the typos "iron" -> "kron")