### PR TITLE
MAINT: upgrade python version (drop python 3.6) for docker dev environment

### DIFF
--- a/doc/source/dev/contributor/quickstart_docker.rst
+++ b/doc/source/dev/contributor/quickstart_docker.rst
@@ -85,7 +85,7 @@ container do not persist after you close it.
       docker run -it --rm -v $PWD/:/home/scipy scipy/scipy-dev /bin/bash
 
    This command starts (``run``) an interactive (``-it``) Docker container
-   named ``scipy-dev`` (based on Ubuntu Bionic) from the ``scipy``
+   named ``scipy-dev`` (based on Ubuntu focal) from the ``scipy``
    `Docker Hub repository`_. When the Docker container starts, the
    ``scipy`` directory from the current directory of the host (``$PWD``) is
    made available in the container as ``/home/scipy``. The changes you make
@@ -104,16 +104,16 @@ container do not persist after you close it.
 
       cd /home/scipy
 
-#. The container has both Python 3.6 and Python 3.7 available. To start
+#. The container has both Python 3.7 and Python 3.8 available. To start
    using/building SciPy, we need to install some dependencies::
 
-      pip3.7 install numpy cython pytest pybind11
+      pip3.8 install numpy cython pytest pybind11
 
-   If you want to work with Python 3.6 use the ``pip3.6`` command instead.
+   If you want to work with Python 3.7 use the ``pip3.7`` command instead.
 
 #. Do an in-place build by entering::
 
-      python3.7 setup.py build_ext --inplace
+      python3.8 setup.py build_ext --inplace
 
    This will compile the C,
    C++, and Fortran code that comes with SciPy. ``setup.py`` is a
@@ -122,11 +122,11 @@ container do not persist after you close it.
    defined in ``setup.py``, and ``--inplace`` is an option we’ll use to
    ensure that the compiling happens in the SciPy directory you already
    have rather than some other folder on your computer. If you want to
-   work with Python 3.6, replace ``python3.7`` with ``python3.6``.
+   work with Python 3.7, replace ``python3.8`` with ``python3.7``.
 
 #. Test the build by entering::
 
-      python3.7 runtests.py -v
+      python3.8 runtests.py -v
 
    ``runtests.py`` is another script in the SciPy root directory. It runs a
    suite of tests that make sure SciPy is working as it should, and ``-v``
@@ -136,11 +136,11 @@ container do not persist after you close it.
    or import SciPy from any directory other than the SciPy root, you should
    set up SciPy for development::
 
-      python3.7 setup.py develop
+      python3.8 setup.py develop
 
-From here, you can start a Python console (e.g., enter ``python3.7``) or
+From here, you can start a Python console (e.g., enter ``python3.8``) or
 execute Python scripts from the command line (e.g.,
-``python3.7 scriptname.py``).
+``python3.8 scriptname.py``).
 
 You can make changes to files in the ``scipy`` directory in a text editor/IDE
 in your host OS, and those changes will be reflected

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -17,16 +17,25 @@
 #
 # docker run -it --rm -v $PWD/:/home/scipy scipy/scipy-dev /bin/bash
 #
-# The available Python executables are python3.6 and python3.7 (along with
-# pip3.6 and pip3.7.
+# The available Python executables are python3.7 and python3.8 (along with
+# pip3.7 and pip3.8.
 # The image does not come bundled with cython/numpy/pytest/pybind11, those need to
 # be installed with pip before trying to build/run scipy.
 #
 # pip3 install cython numpy pytest pybind11
 #
+# You can find the detailed guide in:
+# Development environment quickstart guide (Docker)
+# http://scipy.github.io/devdocs/dev/contributor/quickstart_docker.html#quickstart-docker
 
 
-FROM ubuntu:bionic
+# ubuntu focal has python 3.8 as default
+FROM ubuntu:focal
+
+# add deadsnakes ppa to install python 3.7
+RUN apt-get update && \
+    apt-get install -y software-properties-common && \
+    add-apt-repository ppa:deadsnakes/ppa
 
 RUN apt-get update && apt-get install -y \
 	python3.7 \
@@ -36,6 +45,7 @@ RUN apt-get update && apt-get install -y \
 	vim \
 	libatlas-base-dev \
 	gfortran \
+	libgfortran4 \
 	liblapack-dev \
 	curl \
 	libgmp-dev \
@@ -43,5 +53,5 @@ RUN apt-get update && apt-get install -y \
 	libsuitesparse-dev \
 	libmpc-dev
 
-# setup pips, pip3.6 and pip3.7
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3.7 get-pip.py && python3.6 get-pip.py && rm get-pip.py
+# setup pips, pip3.7 and pip3.8
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3.7 get-pip.py && python3.8 get-pip.py && rm get-pip.py


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
fix #13101 

#### What does this implement/fix?
I upgraded python version , dropping 3.6, and adding 3.8 in the docker file.
I upgrade ubuntu version to focal (ubuntu 20.04) in the docker file.
I updated dev docs based on it.