### PR TITLE
CI, MAINT: refguide/asv checks to azure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,15 +90,6 @@ matrix:
         - OTHERSPEC="--pre --upgrade --timeout=60"
         - NPY_USE_BLAS_ILP64=1
     - python: 3.7
-      name: "Refguide-check, Latest NumPy"
-      env:
-        - TESTMODE=fast
-        - COVERAGE=
-        - USE_WHEEL=1
-        - REFGUIDE_CHECK=1
-        - NUMPYSPEC="--upgrade numpy"
-        - ASV_CHECK=1
-    - python: 3.7
       name: "Source Distribution"
       env:
         - TESTMODE=fast

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,56 @@ variables:
     openblas_version: 0.3.9
 
 jobs:
+- job: refguide_asv_check
+  condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))  # skip for PR merges
+  pool:
+    vmImage: 'ubuntu-18.04'
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.8'
+      addToPath: true
+      architecture: 'x64'
+  - script: >-
+      python -m pip install
+      asv>=0.4.1
+      cython
+      matplotlib
+      numpy
+      numpydoc
+      pip==20.2.4
+      pybind11
+      pytest
+      pytest-xdist
+      setuptools
+      Sphinx==1.7.2
+      wheel
+    displayName: 'Install deps'
+    failOnStderr: true
+  - script: |
+        # this step naturally writes to stderr, even on success
+        python tools/suppress_output.py python setup.py build
+        python tools/suppress_output.py pip wheel --no-build-isolation .
+        pip install --no-cache-dir scipy*.whl
+    displayName: 'Build/Install SciPy Wheel'
+    failOnStderr: false
+  - script: |
+        python -u runtests.py -g -j2 -m fast -n -- -rfEX --durations=10 2>&1 | tee runtests.log
+        tools/validate_runtests_log.py fast < runtests.log
+    displayName: 'Run Fast SciPy tests'
+    failOnStderr: true
+  - script: |
+        python runtests.py -g --refguide-check
+    displayName: 'Run refguide check'
+    failOnStderr: true
+  - script: |
+        cd benchmarks && python -masv check -E existing && ! SCIPY_ALLOW_BENCH_IMPORT_ERRORS=0 python -masv check -E existing > /dev/null
+    displayName: 'Run asv check'
+    failOnStderr: true
+  - script: |
+         ./tools/check_pyext_symbol_hiding.sh build
+    displayName: 'Check dynamic symbol hiding works on Linux'
+    failOnStderr: true
 - job: Lint
   condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))  # skip for PR merges
   pool:


### PR DESCRIPTION
* migrate refguide/asv CI checks from Travis to Azure
as per gh-13109

* some of the extra tests run by this new Azure job
may not really be needed, but I'm trying to maintain
fidelity with what Travis CI did for this matrix entry,
within reason

* this migration may introduce a bit of duplication
that could later be simplified with better matrix
organization

* I did the pre-testing for this change on my fork; I believe
we'll see that refguide-check is already failing on `master`,
but my plan would be to merge this in if we reproduce
that failure correctly here, then open an issue to resolve it
