### PR TITLE
CI: fix MacOS CI

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   test_macos:
 
-    if: "github.repository == 'scipy/scipy' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
+    if: "github.repository == 'tylerjereddy/scipy' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
     runs-on: macos-latest
     strategy:
       max-parallel: 3
@@ -69,9 +69,11 @@ jobs:
         # Also make it use the current install location for libgfortran, libquadmath, and libgcc_s.
         pushd openblas/lib
         install_name_tool -id $PWD/libopenblasp-r*.dylib libopenblas.dylib
-        install_name_tool -change /usr/local/gfortran/lib/libgfortran.3.dylib `$FC -v 2>&1 | perl -nle 'print $1 if m{--libdir=([^\s]+)}'`/libgfortran.3.dylib libopenblas.dylib
-        install_name_tool -change /usr/local/gfortran/lib/libquadmath.0.dylib `$FC -v 2>&1 | perl -nle 'print $1 if m{--libdir=([^\s]+)}'`/libquadmath.0.dylib libopenblas.dylib
-        install_name_tool -change /usr/local/gfortran/lib/libgcc_s.1.dylib `$FC -v 2>&1 | perl -nle 'print $1 if m{--libdir=([^\s]+)}'`/libgcc_s.1.dylib libopenblas.dylib
+        install_name_tool -change /usr/local/gfortran/lib/libgfortran.3.dylib /usr/local/Cellar/gcc@6/6.5.0_5/lib/gcc/6/libgfortran.3.dylib libopenblas.dylib
+        install_name_tool -change /usr/local/gfortran/lib/libquadmath.0.dylib /usr/local/Cellar/gcc@6/6.5.0_5/lib/gcc/6/libquadmath.0.dylib libopenblas.dylib
+        install_name_tool -change /usr/local/gfortran/lib/libgcc_s.1.dylib /usr/local/Cellar/gcc@6/6.5.0_5/lib/gcc/6/libgcc_s.1.dylib libopenblas.dylib
+        ls -tlrh
+        otool -L libopenblasp-r*.dylib
         popd
         echo "[openblas]" > site.cfg
         echo "libraries = openblas" >> site.cfg
@@ -82,7 +84,7 @@ jobs:
         rm -rf /usr/local/Cellar/gcc/9.2.0_2
         #
         export PATH="$PATH:$PWD/openblas"
-
+        ls -tlrh /usr/local/Cellar/gcc@6/6.5.0_5/lib/gcc/6
     - name: Install packages
       run: |
         pip install ${{ matrix.numpy-version }}
@@ -90,4 +92,5 @@ jobs:
 
     - name: Test SciPy
       run: |
+        export DYLD_LIBRARY_PATH=/usr/local/Cellar/gcc@6/6.5.0_5/lib/gcc/6/:$DYLD_LIBRARY_PATH
         python -u runtests.py

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   test_macos:
 
-    if: "github.repository == 'tylerjereddy/scipy' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
+    if: "github.repository == 'scipy/scipy' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
     runs-on: macos-latest
     strategy:
       max-parallel: 3
@@ -72,8 +72,6 @@ jobs:
         install_name_tool -change /usr/local/gfortran/lib/libgfortran.3.dylib /usr/local/Cellar/gcc@6/6.5.0_5/lib/gcc/6/libgfortran.3.dylib libopenblas.dylib
         install_name_tool -change /usr/local/gfortran/lib/libquadmath.0.dylib /usr/local/Cellar/gcc@6/6.5.0_5/lib/gcc/6/libquadmath.0.dylib libopenblas.dylib
         install_name_tool -change /usr/local/gfortran/lib/libgcc_s.1.dylib /usr/local/Cellar/gcc@6/6.5.0_5/lib/gcc/6/libgcc_s.1.dylib libopenblas.dylib
-        ls -tlrh
-        otool -L libopenblasp-r*.dylib
         popd
         echo "[openblas]" > site.cfg
         echo "libraries = openblas" >> site.cfg
@@ -84,7 +82,6 @@ jobs:
         rm -rf /usr/local/Cellar/gcc/9.2.0_2
         #
         export PATH="$PATH:$PWD/openblas"
-        ls -tlrh /usr/local/Cellar/gcc@6/6.5.0_5/lib/gcc/6
     - name: Install packages
       run: |
         pip install ${{ matrix.numpy-version }}


### PR DESCRIPTION
Fixes #13108 

* carefully specify the absolute path to OpenBLAS
    gcc lib runtime deps so that our MacOS CI is
    able to run the testsuite again

 * in the future, we may want to restore an approach
    that is not tied to a particular gcc toolchain
    version; however, as this involved i.e., the use
    of `perl` tricks, I suggest we open an issue to
    do that later