### PR TITLE
CI: Don't report name errors after an exception in refguide-check

### DIFF
--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -493,6 +493,7 @@ class DTRunner(doctest.DocTestRunner):
 
     def __init__(self, item_name, checker=None, verbose=None, optionflags=0):
         self._item_name = item_name
+        self._had_unexpected_error = False
         doctest.DocTestRunner.__init__(self, checker=checker, verbose=verbose,
                                        optionflags=optionflags)
 
@@ -512,9 +513,15 @@ class DTRunner(doctest.DocTestRunner):
         return doctest.DocTestRunner.report_success(self, out, test, example, got)
 
     def report_unexpected_exception(self, out, test, example, exc_info):
+        # Ignore name errors after failing due to an unexpected exception
+        exception_type = exc_info[0]
+        if self._had_unexpected_error and exception_type is NameError:
+            return
+        self._had_unexpected_error = True
+
         self._report_item_name(out)
-        return doctest.DocTestRunner.report_unexpected_exception(
-            self, out, test, example, exc_info)
+        return super().report_unexpected_exception(
+            out, test, example, exc_info)
 
     def report_failure(self, out, test, example, got):
         self._report_item_name(out)


### PR DESCRIPTION
#### What does this implement/fix?
Looking at gh-13111, the root cause of the CI failure was buried by `NameError`s from trying to run the rest of the tutorial without the `word_list` variable defined. This suppresses `NameErrors` that happen after another unexpected exception. That brings the root cause of the failure to the bottom of the error log, where it's most likely to be seen.

#### Additional information
Comparison with the suggestions in https://github.com/scipy/scipy/pull/13113#discussion_r528282941:
- If you are missing the words file, you can still run the remaining doctests without issues. For someone adding new docs elsewhere, blocking the doctest runs entirely isn't helpful.
- Doing something like an xfail might be useful for developers, but would have also made it harder to see that it wasn't being run in CI. This preserves the test failure, but minimises the log spam.
- This is a general solution that makes the error log more readable for all failures, not just this specific failure.