### PR TITLE
CI: move sdist/pre-release test Azure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,17 +50,6 @@ matrix:
         - TEST_GROUP_COUNT=2
         - TEST_GROUP=2
     - python: 3.7
-      name: "Pre-release Dependencies, Source Dist"
-      env:
-        - TESTMODE=fast
-        - COVERAGE=
-        - NUMPYSPEC="--pre --upgrade --timeout=60 -i $PRE_WHEELS numpy"
-        - OTHERSPEC="--pre --upgrade --timeout=60"
-        # Need a test with most recent Python version where we build from an
-        # sdist (uses pip build isolation), to check that the version we
-        # specify in pyproject.toml (will be older than --pre --upgrade) works
-        - USE_SDIST=1
-    - python: 3.7
       name: "Coverage, Full test suite"
       env:
         - TESTMODE=full

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,7 @@ jobs:
   - script: >-
       python -m pip install --upgrade
       pip==20.2.4
-      "setuptools<50"
+      setuptools
       wheel
     displayName: 'Install deps'
     failOnStderr: true
@@ -55,12 +55,14 @@ jobs:
     displayName: 'Install pre-release NumPy wheel'
     failOnStderr: true
   - script: |
+        git submodule init
+        git submodule update
         python tools/suppress_output.py python setup.py sdist
         cd dist
         python -m pip install $PWD/scipy* -v
         cd ..
     displayName: 'SciPy sdist install'
-    failOnStderr: true
+    failOnStderr: false
   - script: |
         python -u runtests.py -g -j2 -m fast -n -- -rfEX --durations=10 2>&1 | tee runtests.log
         tools/validate_runtests_log.py fast < runtests.log

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,52 @@ variables:
     openblas_version: 0.3.9
 
 jobs:
+- job: pre_release_deps_source_dist
+  condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))  # skip for PR merges
+  pool:
+    vmImage: 'ubuntu-18.04'
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.7'
+      addToPath: true
+      architecture: 'x64'
+  - script: >-
+      python -m pip install --upgrade
+      pip==20.2.4
+      "setuptools<50"
+      wheel
+    displayName: 'Install deps'
+    failOnStderr: true
+  - script: >-
+      python -m pip install --pre --upgrade --timeout=60
+      cython
+      mpmath
+      pybind11
+      pytest
+      pytest-xdist
+    displayName: 'Install pre-release deps'
+    failOnStderr: true
+  - script: |
+      python -m pip install --pre --upgrade --timeout=60 -i https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
+    displayName: 'Install pre-release NumPy wheel'
+    failOnStderr: true
+  - script: |
+        python tools/suppress_output.py python setup.py sdist
+        cd dist
+        python -m pip install $PWD/scipy* -v
+        cd ..
+    displayName: 'SciPy sdist install'
+    failOnStderr: true
+  - script: |
+        python -u runtests.py -g -j2 -m fast -n -- -rfEX --durations=10 2>&1 | tee runtests.log
+        tools/validate_runtests_log.py fast < runtests.log
+    displayName: 'Run Fast SciPy tests'
+    failOnStderr: true
+  - script: |
+         ./tools/check_pyext_symbol_hiding.sh build
+    displayName: 'Check dynamic symbol hiding works on Linux'
+    failOnStderr: true
 - job: refguide_asv_check
   condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))  # skip for PR merges
   pool:


### PR DESCRIPTION
* move the sdist/NumPy pre-release wheel
CI entry from Travis CI to Azure CI

Not working yet though, unfortunately.