### PR TITLE
Improve error message on friedmanchisquare function

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -7297,7 +7297,7 @@ def friedmanchisquare(*args):
     """
     k = len(args)
     if k < 3:
-        raise ValueError('Less than 3 levels.  Friedman test not appropriate.')
+        raise ValueError('At least 3 sets of measurements must be given for Friedman test, got {}.'.format(k))
 
     n = len(args[0])
     for i in range(1, k):


### PR DESCRIPTION
The error message “Less than 3 levels. Friedman test not appropriate” is  confusing and misleading.

For example, 
```
a = np.array([[1, 2, 3], [2, 3, 4] ,[4, 5, 6]])
print stats.friedmanchisquare([a[i, :] for i in range(a.shape[0])])
```

Got:
`ValueError: Less than 3 levels.  Friedman test not appropriate.
`

The error message `Friedman test not appropriate` is misleading, since in this case the Friedman test is indeed intended. The real error is that the input is passed in the wrong way -- simply adding the `*`-operator to the input would work (see this post https://stackoverflow.com/a/31196158/636398).

#### What does this implement/fix?
The error message changed to `At least 3 sets of measurements must be given for Friedman test, got 1.`maybe better.