### PR TITLE
BLD: Specify file extension for language standard version tests

### DIFF
--- a/scipy/_build_utils/compiler_helper.py
+++ b/scipy/_build_utils/compiler_helper.py
@@ -54,7 +54,7 @@ def get_cxx_std_flag(compiler):
         if flag is None:
             return None
 
-        if has_flag(compiler, flag):
+        if has_flag(compiler, flag, ext='.cpp'):
             return flag
 
     from numpy.distutils import log
@@ -75,7 +75,7 @@ def get_c_std_flag(compiler):
     if flag is None:
         return None
 
-    if has_flag(compiler, flag):
+    if has_flag(compiler, flag, ext='.c'):
         return flag
 
     from numpy.distutils import log


### PR DESCRIPTION
#### Reference issue
Possible fix for gh-13085

#### What does this implement/fix?
In the issue, the C++11 standard flag isn't being used because the test compile fails with this error:
```
gcc: /var/folders/4k/76ttf7d50r784690pqkr3bkm0000gn/T/tmp040hghpc/main.c
error: invalid argument '-std=c++11' not allowed with 'C'
```

Notice the test file for the C++ standard has been given the ".c" extension, which seems to be why it fails. When not specified, the extension comes from `compiler.src_extensions[0]` so I'm guessing the compiler object has support for C and C++ code. Passing the extension explicitly should fix the flag detection and the library should be compiled with C++11.

cc @rlucas7