### PR TITLE
TST: skip Fortran I/O test for ODR

### DIFF
--- a/scipy/odr/tests/test_odr.py
+++ b/scipy/odr/tests/test_odr.py
@@ -1,12 +1,14 @@
-# SciPy imports.
 import tempfile
 import shutil
 import os
+
 import numpy as np
 from numpy import pi
 from numpy.testing import (assert_array_almost_equal,
                            assert_equal, assert_warns)
+import pytest
 from pytest import raises as assert_raises
+
 from scipy.odr import (Data, Model, ODR, RealData, OdrStop, OdrWarning,
                        multilinear, exponential, unilinear, quadratic,
                        polynomial)
@@ -499,6 +501,8 @@ class TestODR(object):
         assert_array_almost_equal(out.sd_beta,
                                   out.work[sd_ind:sd_ind + len(out.sd_beta)])
 
+    @pytest.mark.skipif(True, reason="Fortran I/O prone to crashing so better "
+                                     "not to run this test, see gh-13127")
     def test_output_file_overwrite(self):
         """
         Verify fix for gh-1892


### PR DESCRIPTION
Closes gh-13127

This should go in before branching 1.6.x, to avoid possible issues.