### PR TITLE
Fix edge case for mode='nearest' in ndimage.interpolation functions

### DIFF
--- a/scipy/ndimage/tests/test_interpolation.py
+++ b/scipy/ndimage/tests/test_interpolation.py
@@ -1011,6 +1011,20 @@ class TestNdimageInterpolation:
             x[::-1, ::-1],
         )
 
+    @pytest.mark.parametrize('order', range(0, 6))
+    @pytest.mark.parametrize('prefilter', [False, True])
+    def test_shift_nearest_boundary(self, order, prefilter):
+        # verify that shifting at least order // 2 beyond the end of the array
+        # gives a value equal to the edge value.
+        x = numpy.arange(16)
+        kwargs = dict(mode='nearest', order=order, prefilter=prefilter)
+        assert_array_almost_equal(
+            ndimage.shift(x, order // 2 + 1, **kwargs)[0], x[0],
+        )
+        assert_array_almost_equal(
+            ndimage.shift(x, -order // 2 - 1, **kwargs)[-1], x[-1],
+        )
+
     @pytest.mark.parametrize('mode', ['grid-constant', 'grid-wrap', 'nearest',
                                       'mirror', 'reflect'])
     @pytest.mark.parametrize('order', range(6))


### PR DESCRIPTION
This PR fixes a corner case I did not handle correctly when working on the other PRs for #12773

Specifically, there is a bug in ndimage interpolation functions for the case when `mode = "nearest"` in combination with `order > 1` and `prefilter=False`. This combination would previously result in values outside the original image extent having an unexpected DC offset.

For pixels outside the original range, the initial call to `map_coordinates` should not occur when mode = 'nearest'. Otherwise, any fractional pixel offset in the `cc` variable is lost because the `nearest_mode` just clips these values to either 0 or (len - 1). This clipping causes a later call to `get_spline_interpolation_weights` to compute the wrong weights.

Instead the unmapped `cc` coordinate should be used directly for setting the `start` point of the interpolation kernel and the subsequent calls to `map_coordinates` for setting `idx` in the inner loop will handle the boundary conditions appropriately.

A new test function that fails on master, but passes with these changes was added.

