### PR TITLE
BUG: signal: Fix data type of the numerator returned by ss2tf.

### DIFF
--- a/scipy/signal/lti_conversion.py
+++ b/scipy/signal/lti_conversion.py
@@ -246,7 +246,7 @@ def ss2tf(A, B, C, D, input=0):
 
     >>> from scipy.signal import ss2tf
     >>> ss2tf(A, B, C, D)
-    (array([[1, 3, 3]]), array([ 1.,  2.,  1.]))
+    (array([[1., 3., 3.]]), array([ 1.,  2.,  1.]))
     """
     # transfer function is C (sI - A)**(-1) B + D
 
@@ -273,7 +273,7 @@ def ss2tf(A, B, C, D, input=0):
         return num, den
 
     num_states = A.shape[0]
-    type_test = A[:, 0] + B[:, 0] + C[0, :] + D
+    type_test = A[:, 0] + B[:, 0] + C[0, :] + D + 0.0
     num = numpy.empty((nout, num_states + 1), type_test.dtype)
     for k in range(nout):
         Ck = atleast_2d(C[k, :])

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -1217,7 +1217,7 @@ class StateSpace(LinearTimeInvariant):
     Parameters
     ----------
     *system: arguments
-        The `StateSpace` class can be instantiated with 1 or 3 arguments.
+        The `StateSpace` class can be instantiated with 1 or 4 arguments.
         The following gives the number of input arguments and their
         interpretation:
 

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -349,6 +349,15 @@ class TestSS2TF:
         assert_allclose(num, [[0, 1, -3], [1, 2, 3]], rtol=1e-13)
         assert_allclose(den, [1, 6, 5], rtol=1e-13)
 
+    def test_all_int_arrays(self):
+        A = [[0, 1, 0], [0, 0, 1], [-3, -4, -2]]
+        B = [[0], [0], [1]]
+        C = [[5, 1, 0]]
+        D = [[0]]
+        num, den = ss2tf(A, B, C, D)
+        assert_allclose(num, [[0.0, 0.0, 1.0, 5.0]], rtol=1e-13, atol=1e-14)
+        assert_allclose(den, [1.0, 2.0, 4.0, 3.0], rtol=1e-13)
+
     def test_multioutput(self):
         # Regression test for gh-2669.
 


### PR DESCRIPTION
Ensure that the data type of the array of coefficients for the
numerator returned by `ss2tf` is floating point.

Also fix a typo in the `StateSpace` docstring.

Closes gh-13140.
