### PR TITLE
BUG: stats: fix typo in stable rvs per gh-12870

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4314,8 +4314,8 @@ class levy_stable_gen(rv_continuous):
     def _rvs(self, alpha, beta, size=None, random_state=None):
 
         def alpha1func(alpha, beta, TH, aTH, bTH, cosTH, tanTH, W):
-            return (2/np.pi*(np.pi/2 + bTH)*tanTH -
-                    beta*np.log((np.pi/2*W*cosTH)/(np.pi/2 + bTH)))
+            return (2/np.pi*((np.pi/2 + bTH)*tanTH -
+                    beta*np.log((np.pi/2*W*cosTH)/(np.pi/2 + bTH))))
 
         def beta0func(alpha, beta, TH, aTH, bTH, cosTH, tanTH, W):
             return (W/(cosTH/np.tan(aTH) + np.sin(TH)) *


### PR DESCRIPTION
It's looking like gh-9523 might not make it in the next release. In case not, I thought we could at least fix gh-12870. 

@bsdz does this address that issue?

Closes gh-12870