### PR TITLE
DOC: spatial/stats: cross-ref random rotation matrix functions

### DIFF
--- a/scipy/spatial/transform/rotation.pyx
+++ b/scipy/spatial/transform/rotation.pyx
@@ -2124,6 +2124,12 @@ cdef class Rotation(object):
             Contains a single rotation if `num` is None. Otherwise contains a
             stack of `num` rotations.
 
+        Notes
+        -----
+        This function is optimized for efficiently sampling random rotation
+        matrices in three dimensions. For generating random rotation matrices
+        in higher dimensions, see `scipy.stats.special_ortho_group`.
+
         Examples
         --------
         >>> from scipy.spatial.transform import Rotation as R
@@ -2141,6 +2147,10 @@ cdef class Rotation(object):
                [  25.23835501,   45.02035145, -121.67867086],
                [ -51.51414184,  -15.29022692, -172.46870023],
                [ -81.63376847,  -27.39521579,    2.60408416]])
+
+        See Also
+        --------
+        scipy.stats.special_ortho_group
 
        """
         random_state = check_random_state(random_state)

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -3339,7 +3339,8 @@ class special_ortho_group_gen(multi_rv_generic):
     For more information see
     https://en.wikipedia.org/wiki/Orthogonal_matrix#Randomization
 
-    See also the similar `ortho_group`.
+    See also the similar `ortho_group`. For a random rotation in three
+    dimensions, see `scipy.spatial.transform.Rotation.random`.
 
     Examples
     --------
@@ -3357,6 +3358,10 @@ class special_ortho_group_gen(multi_rv_generic):
 
     This generates one random matrix from SO(3). It is orthogonal and
     has a determinant of 1.
+
+    See Also
+    --------
+    ortho_group, scipy.spatial.transform.Rotation.random
 
     """
 
@@ -3895,7 +3900,7 @@ mvt_docdict_noparams = {
 class multivariate_t_gen(multi_rv_generic):
     r"""
     A multivariate t-distributed random variable.
-    
+
     The `loc` parameter specifies the location. The `shape` parameter specifies
     the positive semidefinite shape matrix. The `df` parameter specifies the
     degrees of freedom.
@@ -3979,7 +3984,7 @@ class multivariate_t_gen(multi_rv_generic):
         """
         if df == np.inf:
             return multivariate_normal_frozen(mean=loc, cov=shape,
-                                              allow_singular=allow_singular, 
+                                              allow_singular=allow_singular,
                                               seed=seed)
         return multivariate_t_frozen(loc=loc, shape=shape, df=df,
                                      allow_singular=allow_singular, seed=seed)
@@ -4072,7 +4077,7 @@ class multivariate_t_gen(multi_rv_generic):
         dim : int
             Dimension of the quantiles x.
         rank : int
-            Rank of the shape matrix.   
+            Rank of the shape matrix.
 
         Notes
         -----


### PR DESCRIPTION
This PR is intended to address @rkern's [comment](https://github.com/scipy/scipy/issues/12874#issuecomment-696786019) in gh-12874
> For example, I think a reference to Rotation from special_ortho_group could be helpful for people who want a random 3D rotation, knows the "SO(3)" terminology and happened to run into special_ortho_group first in their search. The reverse link is probably less useful. Maybe mentioned in the context of generating random rotation matrices in higher-dimensional spaces. Also, explaining the implementation details, why Rotation.random() doesn't use special_ortho_group.rvs(), is probably a distraction for the documentation.

@nisace would this have helped you with gh-12874? Did you want it specially mentioned that they are uniformly distributed? If so, can you provide a specific suggestion for the wording?

Closes gh-12874