### PR TITLE
DOC: stats: correct weightedtau documentation - LOW rank -> HIGH score

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -4591,10 +4591,10 @@ def weightedtau(x, y, rank=True, weigher=None, additive=True):
     lexicographical rank by (`x`, `y`) and by (`y`, `x`). This is the
     behavior with default parameters.
 
-    Note that if you are computing the weighted :math:`\tau` on arrays of
-    ranks, rather than of scores (i.e., a larger value implies a lower
-    rank) you must negate the ranks, so that elements of higher rank are
-    associated with a larger value.
+    Note that the inputs `x` and `y` must be scores, not ranks.
+    If you are working with arrays of ranks rather than
+    arrays of scores, negate the ranks so that elements
+    of lower rank are associated with higher (less negative) scores.
 
     Parameters
     ----------


### PR DESCRIPTION
The documentation of [`weightedtau`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.weightedtau.html) states:

> Note that if you are computing the weighted \tau on arrays of ranks, rather than of scores (i.e., a larger value implies a lower rank) you must negate the ranks, so that elements of higher rank are associated with a larger value.

This is incorrect; negating ranks would turn elements of _lower_ rank into larger (less negative) values.

@stde Thanks for your patience! Does this address your concern in gh-12778? 

Closes gh-12778

