### PR TITLE
DOC: maintain equal display range for ndimage.zoom example

### DIFF
--- a/scipy/ndimage/interpolation.py
+++ b/scipy/ndimage/interpolation.py
@@ -722,8 +722,8 @@ def zoom(input, zoom, output=None, order=3, mode='constant', cval=0.0,
     >>> ax2 = fig.add_subplot(122)  # right side
     >>> ascent = misc.ascent()
     >>> result = ndimage.zoom(ascent, 3.0)
-    >>> ax1.imshow(ascent)
-    >>> ax2.imshow(result)
+    >>> ax1.imshow(ascent, vmin=0, vmax=255)
+    >>> ax2.imshow(result, vmin=0, vmax=255)
     >>> plt.show()
 
     >>> print(ascent.shape)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
closes gh-8210  (The response by @pv in the issue seems correct to me so it could be closed now. This PR just updates the docs to make the brightness consistent)

#### What does this implement/fix?
<!--Please explain your changes.-->
keep equal brightness scaling in the plots of the ndimage.zoom example


#### Additional information
<!--Any additional information you think is important.-->
