### PR TITLE
CI: Azure: Don't run tests on merge commits, except for coverage

### DIFF
--- a/ci/azure-travis-template.yaml
+++ b/ci/azure-travis-template.yaml
@@ -139,6 +139,9 @@ steps:
       COVERAGE: '--coverage --gcov'
     ${{ if or(eq(parameters.use_wheel, true), eq(parameters.use_sdist, true))}}:
       USE_WHEEL_BUILD: '--no-build'
+  # Only run tests on master for the coverage build
+  ${{ if eq(parameters.coverage, false) }}:
+    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))  # skip for PR merges
   displayName: 'Run tests'
 - ${{ if and(ne(variables['Build.SourceBranch'], 'refs/heads/master'), eq(parameters.refguide_check, true)) }}:
   - script: python runtests.py -g --refguide-check
@@ -154,7 +157,7 @@ steps:
   displayName: "Check dynamic symbol hiding works"
   condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
   failOnStderr: true
-- ${{ if and(ne(variables['Build.SourceBranch'], 'refs/heads/master'), eq(parameters.coverage, true)) }}:
+- ${{ if eq(parameters.coverage, true) }}:
   - script: |
       set -e
       RUN_DIR=`echo build/testenv/lib/python*/site-packages`


### PR DESCRIPTION
#### What does this implement/fix?
Following the merge of #13138, I noticed I forgot to skip running tests on master which the travis script does here:
https://github.com/scipy/scipy/blob/75df04600672bbf62e310f8931cc3957b9a120a2/.travis.yml#L189-L192

As a reminder, we can't skip the CI job entirely or the ccache files won't be cached for PR builds to use. See gh-12302.

Also, a slight deviation from the travis script, It is useful to do the coverage build on master so `codecov.io` can create accurate coverage diffs. This was discussed before (https://github.com/scipy/scipy/pull/12253#issuecomment-638974289) but nothing was done.