### PR TITLE
DOC: stats: disambiguate location-shifted/noncentral

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1233,10 +1233,14 @@ chi = chi_gen(a=0.0, name='chi')
 ## Chi-squared (gamma-distributed with loc=0 and scale=2 and shape=df/2)
 class chi2_gen(rv_continuous):
     r"""A chi-squared continuous random variable.
-    
+
     For the noncentral chi-square distribution, see `ncx2`.
 
     %(before_notes)s
+
+    See Also
+    --------
+    ncx2
 
     Notes
     -----
@@ -1253,10 +1257,6 @@ class chi2_gen(rv_continuous):
     `chi2` takes ``df`` as a shape parameter.
 
     %(after_notes)s
-
-    See Also
-    --------
-    ncx2
 
     %(example)s
 
@@ -1851,10 +1851,14 @@ foldcauchy = foldcauchy_gen(a=0.0, name='foldcauchy')
 
 class f_gen(rv_continuous):
     r"""An F continuous random variable.
-    
+
     For the noncentral F distribution, see `ncf`.
 
     %(before_notes)s
+
+    See Also
+    --------
+    ncf
 
     Notes
     -----
@@ -1871,10 +1875,6 @@ class f_gen(rv_continuous):
     `f` takes ``dfn`` and ``dfd`` as shape parameters.
 
     %(after_notes)s
-
-    See Also
-    --------
-    ncf
 
     %(example)s
 
@@ -5938,10 +5938,14 @@ ncf = ncf_gen(a=0.0, name='ncf')
 
 class t_gen(rv_continuous):
     r"""A Student's t continuous random variable.
-    
+
     For the noncentral t distribution, see `nct`.
 
     %(before_notes)s
+
+    See Also
+    --------
+    nct
 
     Notes
     -----
@@ -5959,10 +5963,6 @@ class t_gen(rv_continuous):
     (`scipy.special.gamma`).
 
     %(after_notes)s
-
-    See Also
-    --------
-    nct
 
     %(example)s
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1232,7 +1232,8 @@ chi = chi_gen(a=0.0, name='chi')
 
 ## Chi-squared (gamma-distributed with loc=0 and scale=2 and shape=df/2)
 class chi2_gen(rv_continuous):
-    r"""A chi-squared continuous random variable.
+    r"""A chi-squared continuous random variable. For the noncentral
+    chi-square distribution, see `ncx2`.
 
     %(before_notes)s
 
@@ -1251,6 +1252,10 @@ class chi2_gen(rv_continuous):
     `chi2` takes ``df`` as a shape parameter.
 
     %(after_notes)s
+
+    See Also
+    --------
+    ncx2
 
     %(example)s
 
@@ -1844,7 +1849,8 @@ foldcauchy = foldcauchy_gen(a=0.0, name='foldcauchy')
 
 
 class f_gen(rv_continuous):
-    r"""An F continuous random variable.
+    r"""An F continuous random variable. For the noncentral
+    F distribution, see `ncf`.
 
     %(before_notes)s
 
@@ -1863,6 +1869,10 @@ class f_gen(rv_continuous):
     `f` takes ``dfn`` and ``dfd`` as shape parameters.
 
     %(after_notes)s
+
+    See Also
+    --------
+    ncf
 
     %(example)s
 
@@ -4159,7 +4169,7 @@ class laplace_asymmetric_gen(rv_continuous):
         return np.where(q <= kapinv/kappkapinv,
                         -np.log(q*kappkapinv*kappa)*kapinv,
                         np.log((1 - q)*kappkapinv/kappa)*kappa)
-    
+
     def _stats(self, kappa):
         kapinv = 1/kappa
         mn = kapinv - kappa
@@ -5925,7 +5935,8 @@ ncf = ncf_gen(a=0.0, name='ncf')
 
 
 class t_gen(rv_continuous):
-    r"""A Student's t continuous random variable.
+    r"""A Student's t continuous random variable. For the noncentral
+    chi-square distribution, see `nct`.
 
     %(before_notes)s
 
@@ -5945,6 +5956,10 @@ class t_gen(rv_continuous):
     (`scipy.special.gamma`).
 
     %(after_notes)s
+
+    See Also
+    --------
+    nct
 
     %(example)s
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1232,8 +1232,9 @@ chi = chi_gen(a=0.0, name='chi')
 
 ## Chi-squared (gamma-distributed with loc=0 and scale=2 and shape=df/2)
 class chi2_gen(rv_continuous):
-    r"""A chi-squared continuous random variable. For the noncentral
-    chi-square distribution, see `ncx2`.
+    r"""A chi-squared continuous random variable.
+    
+    For the noncentral chi-square distribution, see `ncx2`.
 
     %(before_notes)s
 
@@ -1849,8 +1850,9 @@ foldcauchy = foldcauchy_gen(a=0.0, name='foldcauchy')
 
 
 class f_gen(rv_continuous):
-    r"""An F continuous random variable. For the noncentral
-    F distribution, see `ncf`.
+    r"""An F continuous random variable.
+    
+    For the noncentral F distribution, see `ncf`.
 
     %(before_notes)s
 
@@ -5935,8 +5937,9 @@ ncf = ncf_gen(a=0.0, name='ncf')
 
 
 class t_gen(rv_continuous):
-    r"""A Student's t continuous random variable. For the noncentral
-    chi-square distribution, see `nct`.
+    r"""A Student's t continuous random variable.
+    
+    For the noncentral t distribution, see `nct`.
 
     %(before_notes)s
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -65,6 +65,10 @@ class ksone_gen(rv_continuous):
 
     %(before_notes)s
 
+    See Also
+    --------
+    kstwobign, kstwo, kstest
+
     Notes
     -----
     :math:`D_n^+` and :math:`D_n^-` are given by
@@ -80,10 +84,6 @@ class ksone_gen(rv_continuous):
     with CDF :math:`F`.
 
     %(after_notes)s
-
-    See Also
-    --------
-    kstwobign, kstwo, kstest
 
     References
     ----------
@@ -122,6 +122,10 @@ class kstwo_gen(rv_continuous):
 
     %(before_notes)s
 
+    See Also
+    --------
+    kstwobign, ksone, kstest
+
     Notes
     -----
     :math:`D_n` is given by
@@ -136,10 +140,6 @@ class kstwo_gen(rv_continuous):
     with CDF :math:`F`.
 
     %(after_notes)s
-
-    See Also
-    --------
-    kstwobign, ksone, kstest
 
     References
     ----------
@@ -184,6 +184,10 @@ class kstwobign_gen(rv_continuous):
 
     %(before_notes)s
 
+    See Also
+    --------
+    ksone, kstwo, kstest
+
     Notes
     -----
     :math:`\sqrt{n} D_n` is given by
@@ -198,10 +202,6 @@ class kstwobign_gen(rv_continuous):
     empirical CDF corresponds to i.i.d. random variates with CDF :math:`F`.
 
     %(after_notes)s
-
-    See Also
-    --------
-    ksone, kstwo, kstest
 
     References
     ----------
@@ -1056,6 +1056,10 @@ class fisk_gen(burr_gen):
 
     %(before_notes)s
 
+    See Also
+    --------
+    burr
+
     Notes
     -----
     The probability density function for `fisk` is:
@@ -1071,10 +1075,6 @@ class fisk_gen(burr_gen):
     `fisk` is a special case of `burr` or `burr12` with ``d=1``.
 
     %(after_notes)s
-
-    See Also
-    --------
-    burr
 
     %(example)s
 
@@ -4101,6 +4101,10 @@ class laplace_asymmetric_gen(rv_continuous):
 
     %(before_notes)s
 
+    See Also
+    --------
+    laplace : Laplace distribution
+
     Notes
     -----
     The probability density function for `laplace_asymmetric` is
@@ -4117,10 +4121,6 @@ class laplace_asymmetric_gen(rv_continuous):
     Laplace distribution.
 
     %(after_notes)s
-
-    See Also
-    --------
-    laplace : Laplace distribution
 
     References
     ----------
@@ -5843,6 +5843,10 @@ class ncf_gen(rv_continuous):
 
     %(before_notes)s
 
+    See Also
+    --------
+    scipy.stats.f : Fisher distribution
+
     Notes
     -----
     The probability density function for `ncf` is:
@@ -5871,10 +5875,6 @@ class ncf_gen(rv_continuous):
     the distribution becomes equivalent to the Fisher distribution.
 
     %(after_notes)s
-
-    See Also
-    --------
-    scipy.stats.f : Fisher distribution
 
     %(example)s
 
@@ -6932,6 +6932,10 @@ class semicircular_gen(rv_continuous):
 
     %(before_notes)s
 
+    See Also
+    --------
+    rdist
+
     Notes
     -----
     The probability density function for `semicircular` is:
@@ -6945,10 +6949,6 @@ class semicircular_gen(rv_continuous):
     The distribution is a special case of `rdist` with `c = 3`.
 
     %(after_notes)s
-
-    See Also
-    --------
-    rdist
 
     References
     ----------
@@ -8275,6 +8275,11 @@ class gennorm_gen(rv_continuous):
 
     %(before_notes)s
 
+    See Also
+    --------
+    laplace : Laplace distribution
+    norm : normal distribution
+
     Notes
     -----
     The probability density function for `gennorm` is [1]_:
@@ -8289,11 +8294,6 @@ class gennorm_gen(rv_continuous):
     For :math:`\beta = 1`, it is identical to a Laplace distribution.
     For :math:`\beta = 2`, it is identical to a normal distribution
     (with ``scale=1/sqrt(2)``).
-
-    See Also
-    --------
-    laplace : Laplace distribution
-    norm : normal distribution
 
     References
     ----------
@@ -8343,6 +8343,12 @@ class halfgennorm_gen(rv_continuous):
 
     %(before_notes)s
 
+    See Also
+    --------
+    gennorm : generalized normal distribution
+    expon : exponential distribution
+    halfnorm : half normal distribution
+
     Notes
     -----
     The probability density function for `halfgennorm` is:
@@ -8358,12 +8364,6 @@ class halfgennorm_gen(rv_continuous):
     For :math:`\beta = 1`, it is identical to an exponential distribution.
     For :math:`\beta = 2`, it is identical to a half normal distribution
     (with ``scale=1/sqrt(2)``).
-
-    See Also
-    --------
-    gennorm : generalized normal distribution
-    expon : exponential distribution
-    halfnorm : half normal distribution
 
     References
     ----------

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -206,7 +206,9 @@ The probability density above is defined in the "standardized" form. To shift
 and/or scale the distribution use the ``loc`` and ``scale`` parameters.
 Specifically, ``%(name)s.pdf(x, %(shapes)s, loc, scale)`` is identically
 equivalent to ``%(name)s.pdf(y, %(shapes)s) / scale`` with
-``y = (x - loc) / scale``.
+``y = (x - loc) / scale``. Note that shifting the location of a distribution
+does not make it a "noncentral" distribution; noncentral generalizations of
+some distributions are available in separate classes.
 """
 
 _doc_default = ''.join([_doc_default_longsummary,


### PR DESCRIPTION
There were a few issues caused by confusing shifting the location of a distribution with the noncentral generalization of that distribution. This PR attempts to address that.

@andrewfowlie @jorikdima Would this address your issue?

Closes gh-12102.
See also gh-11825.