### PR TITLE
BUG: DifferentialEvolutionSolver.__del__ can fail in garbage collection

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -387,10 +387,6 @@ class MapWrapper(object):
     def __enter__(self):
         return self
 
-    def __del__(self):
-        self.close()
-        self.terminate()
-
     def terminate(self):
         if self._own_pool:
             self.pool.terminate()

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -962,14 +962,7 @@ class DifferentialEvolutionSolver(object):
         return self
 
     def __exit__(self, *args):
-        # to make sure resources are closed down
-        self._mapwrapper.close()
-        self._mapwrapper.terminate()
-
-    def __del__(self):
-        # to make sure resources are closed down
-        self._mapwrapper.close()
-        self._mapwrapper.terminate()
+        return self._mapwrapper.__exit__(*args)
 
     def _accept_trial(self, energy_trial, feasible_trial, cv_trial,
                       energy_orig, feasible_orig, cv_orig):


### PR DESCRIPTION
I noticed an exception being reported from `DifferentialEvolutionSolver.__del__` in CI. It doesn't cause CI to fail because exceptions can't propagate out of `__del__`, which is probably why it has gone unnoticed. See the log [here](https://dev.azure.com/scipy-org/SciPy/_build/results?buildId=9345&view=logs&j=6cac4766-9adb-5b92-83ee-b21ac03a0321&t=91c05f48-75b8-58d0-e0be-5f0ceaaac72f&l=14377).
```
Exception ignored in: <function DifferentialEvolutionSolver.__del__ at 0xec8a62fc>
Traceback (most recent call last):
  File "/scipy/build/testenv/lib/python3.7/site-packages/scipy/optimize/_differentialevolution.py", line 971, in __del__
    self._mapwrapper.close()
AttributeError: 'DifferentialEvolutionSolver' object has no attribute '_mapwrapper'
```

I can't see any code path where `self._mapwrapper` could be `None`, so I suspect this is happening as part of collecting a reference cycle and the GC may have cleared `self.__dict__`. Whatever the reason, I don't think `DifferentialEvolutionSolver` or `MapWrapper` actually need finalizers at all. The `Pool` object has its own finalizer and should be responsible for cleaning up its own resources.