### PR TITLE
BUG: stats: fix bug in spearmanr nan propagation

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -4280,7 +4280,7 @@ def spearmanr(a, b=None, axis=0, nan_policy='propagate'):
             else:
                 # Keep track of variables with NaNs, set the outputs to NaN
                 # only for those variables
-                variable_has_nan = np.isnan(a).sum(axis=axisout)
+                variable_has_nan = np.isnan(a).any(axis=axisout)
 
     a_ranked = np.apply_along_axis(rankdata, axisout, a)
     rs = np.corrcoef(a_ranked, rowvar=axisout)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -603,7 +603,7 @@ class TestCorrSpearmanr(object):
         x[1, 0] = np.nan
         x[3, -1] = np.nan
         corr, pvalue = stats.spearmanr(x, axis=1, nan_policy="propagate")
-        res = [[stats.spearmanr(x[i,:], x[j,:]).correlation for i in range(m)]
+        res = [[stats.spearmanr(x[i, :], x[j, :]).correlation for i in range(m)]
                for j in range(m)]
         assert_allclose(corr, res)
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -595,6 +595,18 @@ class TestCorrSpearmanr(object):
         assert_allclose(corx, cory, atol=1e-14)
         assert_allclose(px, py, atol=1e-14)
 
+    def test_nan_policy_bug_12411(self):
+        np.random.seed(5)
+        m = 5
+        n = 10
+        x = np.random.randn(m, n)
+        x[1, 0] = np.nan
+        x[3, -1] = np.nan
+        corr, pvalue = stats.spearmanr(x, axis=1, nan_policy="propagate")
+        res = [[stats.spearmanr(x[i,:], x[j,:]).correlation for i in range(m)]
+               for j in range(m)]
+        assert_allclose(corr, res)
+
     def test_sXX(self):
         y = stats.spearmanr(X,X)
         r = y[0]


### PR DESCRIPTION
 As @urimerhav posted in gh-12411, `spearmanr` with `nan_policy="propagate"` intends to create logical indices of the rows (or columns, depending on axis) that contain nans, perform the calculations, then nan-out the appropriate rows and columns in the output. However, the code:
```
np.isnan(a).sum(axis=axisout)
```
sums the _number_ of nans along the axis rather than returning the logical array that can be used for indexing. The solution is to use `any` rather than `sum`.
Made the fix and added a test.
Closes gh-12411