### PR TITLE
BUG, DOC: signal: fix missing doc link, missing window functions, wrong needed arg info, and argument passing issue for get_window()

### DIFF
--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -696,10 +696,10 @@ def test_needs_params():
     for winstr in ['kaiser', 'ksr', 'gaussian', 'gauss', 'gss',
                    'general gaussian', 'general_gaussian',
                    'general gauss', 'general_gauss', 'ggs',
-                   'dss', 'dpss',
-                   'chebwin', 'cheb', 'exponential', 'poisson', 'tukey',
-                   'tuk', 'dpss']:
-        assert_raises(ValueError, get_window, winstr, 7)
+                   'dpss', 'chebwin', 'cheb', 'general_cosine',
+                   'general_hamming']:
+        with assert_raises(ValueError, match="window needs one or"):
+            get_window(winstr, 7)
 
 
 def test_deprecation():

--- a/scipy/signal/windows/windows.py
+++ b/scipy/signal/windows/windows.py
@@ -2017,7 +2017,7 @@ _win_equiv_raw = {
         'rect', 'rectangular'): (boxcar, False),
     ('chebwin', 'cheb'): (chebwin, True),
     ('cosine', 'halfcosine'): (cosine, False),
-    ('exponential', 'poisson'): (exponential, True),
+    ('exponential', 'poisson'): (exponential, False),
     ('flattop', 'flat', 'flt'): (flattop, False),
     ('gaussian', 'gauss', 'gss'): (gaussian, True),
     ('general gaussian', 'general_gaussian',
@@ -2029,7 +2029,10 @@ _win_equiv_raw = {
     ('parzen', 'parz', 'par'): (parzen, False),
     ('taylor', 'taylorwin'): (taylor, False),
     ('triangle', 'triang', 'tri'): (triang, False),
-    ('tukey', 'tuk'): (tukey, True),
+    ('tukey', 'tuk'): (tukey, False),
+    ('general_cosine',): (general_cosine, True),
+    ('general_hamming',): (general_hamming, True),
+    ('dpss',): (dpss, True),
 }
 
 # Fill dict with all valid window name strings
@@ -2082,13 +2085,16 @@ def get_window(window, Nx, fftbins=True):
     - `~scipy.signal.windows.blackmanharris`
     - `~scipy.signal.windows.nuttall`
     - `~scipy.signal.windows.barthann`
+    - `~scipy.signal.windows.cosine`
+    - `~scipy.signal.windows.exponential`
+    - `~scipy.signal.windows.tukey`
+    - `~scipy.signal.windows.general_cosine` (needs sequence of weights)
+    - `~scipy.signal.windows.general_hamming` (needs alpha)
     - `~scipy.signal.windows.kaiser` (needs beta)
     - `~scipy.signal.windows.gaussian` (needs standard deviation)
     - `~scipy.signal.windows.general_gaussian` (needs power, width)
     - `~scipy.signal.windows.dpss` (needs normalized half-bandwidth)
     - `~scipy.signal.windows.chebwin` (needs attenuation)
-    - `~scipy.signal.windows.exponential` (needs center, decay scale)
-    - `~scipy.signal.windows.tukey` (needs taper fraction)
     - `~scipy.signal.windows.taylor` (needs number of constant sidelobes,
       sidelobe level)
 
@@ -2145,9 +2151,8 @@ def get_window(window, Nx, fftbins=True):
         except KeyError as e:
             raise ValueError("Unknown window type.") from e
 
-        params = (Nx,) + args + (sym,)
+        params = (Nx,) + args
     else:
         winfunc = kaiser
-        params = (Nx, beta, sym)
-
-    return winfunc(*params)
+        params = (Nx, beta)
+    return winfunc(*params, sym=sym)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
fix #13158 

#### What does this implement/fix?
I fixed several issues of `signal.get_window()` function related codes.
1. fix missing and wrong window func docs
2. fix wrong flag settings that additional parameters are needed or not.
3. fix argument passing issue for window functions which has optional arguments.
4. fix test for above change
