### PR TITLE
ENH: stats: Add nan_policy to zmap.

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -2457,7 +2457,7 @@ def _quiet_nanmean(x):
         return np.mean(y, keepdims=True)
 
 
-def _quiet_nanstd(x):
+def _quiet_nanstd(x, ddof=0):
     """
     Compute nanstd for the 1d array x, but quietly return nan if x is all nan.
 
@@ -2468,7 +2468,7 @@ def _quiet_nanstd(x):
     if y.size == 0:
         return np.array([np.nan])
     else:
-        return np.std(y, keepdims=True)
+        return np.std(y, keepdims=True, ddof=ddof)
 
 
 def zscore(a, axis=0, ddof=0, nan_policy='propagate'):
@@ -2602,11 +2602,11 @@ def zmap(scores, compare, axis=0, ddof=0, nan_policy='propagate'):
     if contains_nan and nan_policy == 'omit':
         if axis is None:
             mn = _quiet_nanmean(a.ravel())
-            std = _quiet_nanstd(a.ravel())
+            std = _quiet_nanstd(a.ravel(), ddof=ddof)
             isconst = _isconst(a.ravel())
         else:
             mn = np.apply_along_axis(_quiet_nanmean, axis, a)
-            std = np.apply_along_axis(_quiet_nanstd, axis, a)
+            std = np.apply_along_axis(_quiet_nanstd, axis, a, ddof=ddof)
             isconst = np.apply_along_axis(_isconst, axis, a)
     else:
         mn = a.mean(axis=axis, keepdims=True)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -2539,7 +2539,60 @@ def zscore(a, axis=0, ddof=0, nan_policy='propagate'):
     array([[-1.13490897, -0.37830299,         nan, -0.08718406,  1.60039602],
            [-0.91611681, -0.89090508,  1.4983032 ,  0.88731639, -0.5785977 ]])
     """
-    a = np.asanyarray(a)
+    return zmap(a, a, axis=axis, ddof=ddof, nan_policy=nan_policy)
+
+
+def zmap(scores, compare, axis=0, ddof=0, nan_policy='propagate'):
+    """
+    Calculate the relative z-scores.
+
+    Return an array of z-scores, i.e., scores that are standardized to
+    zero mean and unit variance, where mean and variance are calculated
+    from the comparison array.
+
+    Parameters
+    ----------
+    scores : array_like
+        The input for which z-scores are calculated.
+    compare : array_like
+        The input from which the mean and standard deviation of the
+        normalization are taken; assumed to have the same dimension as
+        `scores`.
+    axis : int or None, optional
+        Axis over which mean and variance of `compare` are calculated.
+        Default is 0. If None, compute over the whole array `scores`.
+    ddof : int, optional
+        Degrees of freedom correction in the calculation of the
+        standard deviation. Default is 0.
+    nan_policy : {'propagate', 'raise', 'omit'}, optional
+        Defines how to handle the occurrence of nans in `compare`.
+        'propagate' returns nan, 'raise' raises an exception, 'omit'
+        performs the calculations ignoring nan values. Default is
+        'propagate'. Note that when the value is 'omit', nans in `scores`
+        also propagate to the output, but they do not affect the z-scores
+        computed for the non-nan values.
+
+    Returns
+    -------
+    zscore : array_like
+        Z-scores, in the same shape as `scores`.
+
+    Notes
+    -----
+    This function preserves ndarray subclasses, and works also with
+    matrices and masked arrays (it uses `asanyarray` instead of
+    `asarray` for parameters).
+
+    Examples
+    --------
+    >>> from scipy.stats import zmap
+    >>> a = [0.5, 2.0, 2.5, 3]
+    >>> b = [0, 1, 2, 3, 4]
+    >>> zmap(a, b)
+    array([-1.06066017,  0.        ,  0.35355339,  0.70710678])
+
+    """
+    a = np.asanyarray(compare)
 
     if a.size == 0:
         return np.empty(a.shape)
@@ -2565,59 +2618,10 @@ def zscore(a, axis=0, ddof=0, nan_policy='propagate'):
 
     # Set std deviations that are 0 to 1 to avoid division by 0.
     std[isconst] = 1.0
-    z = (a - mn) / std
+    z = (scores - mn) / std
     # Set the outputs associated with a constant input to nan.
     z[np.broadcast_to(isconst, z.shape)] = np.nan
     return z
-
-
-def zmap(scores, compare, axis=0, ddof=0):
-    """
-    Calculate the relative z-scores.
-
-    Return an array of z-scores, i.e., scores that are standardized to
-    zero mean and unit variance, where mean and variance are calculated
-    from the comparison array.
-
-    Parameters
-    ----------
-    scores : array_like
-        The input for which z-scores are calculated.
-    compare : array_like
-        The input from which the mean and standard deviation of the
-        normalization are taken; assumed to have the same dimension as
-        `scores`.
-    axis : int or None, optional
-        Axis over which mean and variance of `compare` are calculated.
-        Default is 0. If None, compute over the whole array `scores`.
-    ddof : int, optional
-        Degrees of freedom correction in the calculation of the
-        standard deviation. Default is 0.
-
-    Returns
-    -------
-    zscore : array_like
-        Z-scores, in the same shape as `scores`.
-
-    Notes
-    -----
-    This function preserves ndarray subclasses, and works also with
-    matrices and masked arrays (it uses `asanyarray` instead of
-    `asarray` for parameters).
-
-    Examples
-    --------
-    >>> from scipy.stats import zmap
-    >>> a = [0.5, 2.0, 2.5, 3]
-    >>> b = [0, 1, 2, 3, 4]
-    >>> zmap(a, b)
-    array([-1.06066017,  0.        ,  0.35355339,  0.70710678])
-
-    """
-    scores, compare = map(np.asanyarray, [scores, compare])
-    mns = compare.mean(axis=axis, keepdims=True)
-    sstd = compare.std(axis=axis, ddof=ddof, keepdims=True)
-    return (scores - mns) / sstd
 
 
 def gstd(a, axis=0, ddof=1):

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2060,6 +2060,12 @@ class TestZmapZscore:
                              ])
         assert_array_almost_equal(z, expected)
 
+    def test_zscore_nan_omit_with_ddof(self):
+        x = np.array([np.nan, 1.0, 3.0, 5.0, 7.0, 9.0])
+        z = stats.zscore(x, ddof=1, nan_policy='omit')
+        expected = np.r_[np.nan, stats.zscore(x[1:], ddof=1)]
+        assert_allclose(z, expected, rtol=1e-13)
+
     def test_zscore_nan_raise(self):
         x = np.array([1, 2, np.nan, 4, 5])
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1967,25 +1967,30 @@ class TestZmapZscore:
         assert_array_almost_equal(z[0], z0_expected)
         assert_array_almost_equal(z[1], z1_expected)
 
-    def test_zmap_nan_policy_omit(self):
+    @pytest.mark.parametrize('ddof', [0, 2])
+    def test_zmap_nan_policy_omit(self, ddof):
         # nans in `scores` are propagated, regardless of `nan_policy`.
         # `nan_policy` only affects how nans in `compare` are handled.
         scores = np.array([-3, -1, 2, np.nan])
         compare = np.array([-8, -3, 2, 7, 12, np.nan])
-        z = stats.zmap(scores, compare, nan_policy='omit')
-        assert_allclose(z, stats.zmap(scores, compare[~np.isnan(compare)]))
+        z = stats.zmap(scores, compare, ddof=ddof, nan_policy='omit')
+        assert_allclose(z, stats.zmap(scores, compare[~np.isnan(compare)],
+                                      ddof=ddof))
 
-    def test_zmap_nan_policy_omit_with_axis(self):
+    @pytest.mark.parametrize('ddof', [0, 2])
+    def test_zmap_nan_policy_omit_with_axis(self, ddof):
         scores = np.arange(-5.0, 9.0).reshape(2, -1)
         compare = np.linspace(-8, 6, 24).reshape(2, -1)
         compare[0, 4] = np.nan
         compare[0, 6] = np.nan
         compare[1, 1] = np.nan
-        z = stats.zmap(scores, compare, nan_policy='omit', axis=1)
+        z = stats.zmap(scores, compare, nan_policy='omit', axis=1, ddof=ddof)
         expected = np.array([stats.zmap(scores[0],
-                                        compare[0][~np.isnan(compare[0])]),
+                                        compare[0][~np.isnan(compare[0])],
+                                        ddof=ddof),
                              stats.zmap(scores[1],
-                                        compare[1][~np.isnan(compare[1])])])
+                                        compare[1][~np.isnan(compare[1])],
+                                        ddof=ddof)])
         assert_allclose(z, expected, rtol=1e-14)
 
     def test_zmap_nan_policy_raise(self):

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1918,18 +1918,16 @@ class TestSEM:
 
 class TestZmapZscore:
 
-    # Expected values were computed independently "by hand"
-    # using the formula for the z-score.
     @pytest.mark.parametrize(
-        'x, y, expected',
-        [([1, 2, 3, 4], [1, 2, 3, 4],
-          [-1.3416407864999, -0.44721359549996, 0.44721359549996,
-           1.3416407864999]),
-         ([1, 2, 3], [0, 1, 2, 3, 4],
-          [-0.7071067811865476, 0, 0.7071067811865476]),]
+        'x, y',
+        [([1, 2, 3, 4], [1, 2, 3, 4]),
+         ([1, 2, 3], [0, 1, 2, 3, 4])]
     )
-    def test_zmap(self, x, y, expected):
+    def test_zmap(self, x, y):
         z = stats.zmap(x, y)
+        # For these simple cases, calculate the expected result directly
+        # by using the formula for the z-score.
+        expected = (x - np.mean(y))/np.std(y)
         assert_allclose(z, expected, rtol=1e-12)
 
     def test_zmap_axis(self):


### PR DESCRIPTION
The change moves the zscore code to zmap, with the obvious
change at the end to compute the z-scores for `scores`.
zscore is now just a one-liner that calls zmap.

Closes gh-12403.
