### PR TITLE
MAINT: stats: Fix a test.

### DIFF
--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -429,7 +429,7 @@ def check_sample_var(sv, n, popvar):
     # two-sided chisquare test for sample variance equal to
     # hypothesized variance
     df = n-1
-    chi2 = (n-1)*popvar/float(popvar)
+    chi2 = (n - 1)*sv/popvar
     pval = stats.distributions.chi2.sf(chi2, df) * 2
     npt.assert_(pval > 0.01, 'var fail, t, pval = %f, %f, v, sv=%f, %f' %
                 (chi2, pval, popvar, sv))


### PR DESCRIPTION
This test of the sample variance has had an incorrect formula
for more than 10 years.  The test is based on

  https://en.wikipedia.org/wiki/Variance#Distribution_of_the_sample_variance

but instead of computing (n - 1) times the sample variance divided
by the population variance, it divided the population variance by
itself, so the chi2 statistic was always n - 1.
