### PR TITLE
 Address concerns in gh-12999 for ks_2samp in exact mode.

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -6724,7 +6724,7 @@ def _attempt_exact_2kssamp(n1, n2, g, d, alternative):
                 # subtractive cancellation.  If that possibly occurred, declare
                 # prob to have lost all precision and raise FloatingPointError
                 if complementary_prob * (1 + relative_error) >= 1.0:
-                    raise FloatingPointError
+                    raise FloatingPointError()
                 prob = 1 - complementary_prob
         else:
             if n1 == n2:

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3473,6 +3473,17 @@ class TestKSTwoSamples(object):
         stats.ks_2samp(rvs1, rvs2, alternative='less', mode='asymp')
         stats.ks_2samp(rvs1, rvs2, alternative='two-sided', mode='asymp')
 
+    def test_gh12999(self):
+        np.random.seed(123456)
+        for x in range(1000, 12000, 1000):
+            vals1 = np.random.normal(100, 10, x)
+            vals2 = np.random.normal(95, 10, x+10)
+            ans1 = stats.ks_2samp(vals1, vals2)
+            ans2 = stats.ks_2samp(vals1, vals2, mode='asymp')
+            # these two p-values should be in line with each other
+            assert_allclose(ans1.pvalue, ans2.pvalue)
+            assert_allclose(ans2.pvalue, ans1.pvalue)
+
 
 def test_ttest_rel():
     # regression test


### PR DESCRIPTION
Return an estimate of the relative error of the probability computed by
stats._compute_prob_inside_method(). As the desired probability is the
complement of the one computed, subtractive cancellation can occur.
Check if it may have, and declare the attempt a failure.  This prevents
a probability ~ 1e-16 being reported when the actual probability is many orders
of magnitude lower.

#### Reference issue
Closes gh-12999

#### What does this implement/fix?
Checks if the computation of a probability in stats._compute_prob_inside_method(), using exact algorithm, may have lost too much precision to be used as a complementary probability.  If so, back off to the asymptotic computation.
In stats. _compute_prob_outside_square(), do a pre-check to determine if the computation will definitely overflow.  If so, return immediately.
