### PR TITLE
MAINT: tests for tall cost matrices in `linear_sum_assignment`

### DIFF
--- a/scipy/sparse/csgraph/tests/test_matching.py
+++ b/scipy/sparse/csgraph/tests/test_matching.py
@@ -208,24 +208,39 @@ linear_sum_assignment_test_cases = product(
           [300, 225, 300]],
          [150, 400, 300]),
 
-        # Rectangular variant
+        # Wide rectangular variant
         ([[400, 150, 400, 1],
           [400, 450, 600, 2],
           [300, 225, 300, 3]],
          [150, 2, 300]),
 
+        # Tall rectangular variant
+        ([[400, 400, 300],
+          [150, 450, 225],
+          [400, 600, 300],
+          [1, 2, 3]],
+          [150, 300, 2]),
+
+        # Square
         ([[10, 10, 8],
           [9, 8, 1],
           [9, 7, 4]],
          [10, 1, 7]),
 
-        # Square
+        # Wide rectangular variant
         ([[10, 10, 8, 11],
           [9, 8, 1, 1],
           [9, 7, 4, 10]],
          [10, 1, 4]),
 
-        # Rectangular variant
+        # Tall rectangular variant
+        ([[10, 9, 9],
+          [10, 8, 7],
+          [8, 1, 4],
+          [11, 1, 10]],
+          [10, 4, 1]),
+
+        # Square with positive infinities
         ([[10, float("inf"), float("inf")],
           [float("inf"), float("inf"), 1],
           [float("inf"), 7, float("inf")]],


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

The `linear_sum_assignment` function supports wide and tall cost matrices. Tests for tall rectangular matrices are missing, so I have added them here.