### PR TITLE
BUG: raise NotImplementedError in fourier_ellipsoid when ndim > 3

### DIFF
--- a/scipy/ndimage/fourier.py
+++ b/scipy/ndimage/fourier.py
@@ -238,6 +238,8 @@ def fourier_ellipsoid(input, size, n=-1, axis=-1, output=None):
     >>> plt.show()
     """
     input = numpy.asarray(input)
+    if input.ndim > 3:
+        raise NotImplementedError("Only 1d, 2d and 3d inputs are supported")
     output = _get_output_fourier(output, input)
     axis = normalize_axis_index(axis, input.ndim)
     sizes = _ni_support._normalize_sequence(size, input.ndim)

--- a/scipy/ndimage/tests/test_fourier.py
+++ b/scipy/ndimage/tests/test_fourier.py
@@ -121,6 +121,12 @@ class TestNdimageFourier:
         a = fft.ifft(a, shape[0], 0)
         assert_almost_equal(ndimage.sum(a.real), 1.0, decimal=dec)
 
+    def test_fourier_ellipsoid_unimplemented_ndim(self):
+        # arrays with ndim > 3 raise NotImplementedError
+        x = numpy.ones((4, 6, 8, 10), dtype=numpy.complex128)
+        with pytest.raises(NotImplementedError):
+            a = ndimage.fourier_ellipsoid(x, 3)
+
     def test_fourier_ellipsoid_1d_complex(self):
         # expected result of 1d ellipsoid is the same as for fourier_uniform
         for shape in [(32, ), (31, )]:


### PR DESCRIPTION


<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
Previously, no error was raised on inputs > 3d, but the image returned would be just filtered with 1.0 at all points rather than an ellipsoid. The source of this behavior is the following [switch statement](https://github.com/scipy/scipy/blob/6d43f64ec3920d78215dcfcacdabce96793cb25b/scipy/ndimage/src/ni_fourier.c#L351-L379) which only has cases for 1, 2 and 3 dimensions.


#### Additional information

Rather than silently doing nothing, we should raise `NotImplementedError` for inputs with ndim > 3.