### PR TITLE
BUG: DOP853

### DIFF
--- a/scipy/integrate/_ivp/rk.py
+++ b/scipy/integrate/_ivp/rk.py
@@ -500,6 +500,7 @@ class DOP853(RungeKutta):
         if err5_norm_2 == 0 and err3_norm_2 == 0:
             return 0.0
         denom = err5_norm_2 + 0.01 * err3_norm_2
+        denom = denom or 1.
         return np.abs(h) * err5_norm_2 / np.sqrt(denom * len(scale))
 
     def _dense_output_impl(self):


### PR DESCRIPTION
div by zero can occur, causing problems with interpolation. 

Simple example:

    import numpy as np
    from scipy.integrate import solve_ivp

    problem = {'fun': lambda t, y: 0. if t< 0.5 else -y, 't_span': [0., 1.], 
               'y0': [1.], 't_eval': np.linspace(0,1)}

    sol = solve_ivp(**problem)
    print('success RK45:', sol.success)
    sol = solve_ivp(**problem, method='DOP853')
    print('success DOP853:', sol.success)`

The default method works, but DOP853 crashes.

The solution for this bug was found in the fortran source code  of DOP853 at https://github.com/jacobwilliams/dop853 .
