### PR TITLE
MAINT: stats: chisquare check sum of observed/expected frequencies

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -6148,16 +6148,19 @@ def power_divergence(f_obs, f_exp=None, ddof=0, axis=0, lambda_=None):
     # cases of lambda_.
     if lambda_ == 1:
         f_obs = f_obs.astype(np.float64)
+        rtol = 1e-5  # to pass existing tests
         with np.errstate(invalid='ignore'):
             relative_diff = np.abs((f_obs - f_exp).sum(axis=axis)
                                    / np.minimum(f_obs, f_exp).sum(axis=axis))
-        rtol = 1e-5  # to pass existing tests
-        if (relative_diff > rtol).any():
-            raise ValueError(f"For each axis slice, the sum of the observed "
-                             f"frequencies must agree with the sum of the "
-                             f"expected frequencies to a relative tolerance "
-                             f"of {rtol}, but the percent differences are:\n"
-                             f"{relative_diff}")
+            diff_gt_tol = (relative_diff > rtol).any()
+        if diff_gt_tol:
+            msg = (f"For each axis slice, the sum of the observed "
+                   f"frequencies must agree with the sum of the "
+                   f"expected frequencies to a relative tolerance "
+                   f"of {rtol}, but the percent differences are:\n"
+                   f"{relative_diff}")
+            raise ValueError(msg)
+
         # Pearson's chi-squared statistic
         terms = (f_obs - f_exp)**2 / f_exp
     elif lambda_ == 0:

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -6148,7 +6148,10 @@ def power_divergence(f_obs, f_exp=None, ddof=0, axis=0, lambda_=None):
     f_obs_float = f_obs.astype(np.float64)
 
     if f_exp is not None:
-        f_exp = _m_broadcast_to(np.asanyarray(f_exp), f_obs_float.shape)
+        f_exp = np.asanyarray(f_exp)
+        bshape = _broadcast_shapes(f_obs_float.shape, f_exp.shape)
+        f_obs_float = _m_broadcast_to(f_obs_float, bshape)
+        f_exp = _m_broadcast_to(f_exp, bshape)
         rtol = 1e-8  # to pass existing tests
         with np.errstate(invalid='ignore'):
             f_obs_sum = f_obs_float.sum(axis=axis)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -6030,6 +6030,10 @@ def power_divergence(f_obs, f_exp=None, ddof=0, axis=0, lambda_=None):
     category are too small.  A typical rule is that all of the observed
     and expected frequencies should be at least 5.
 
+    Also, the sum of the observed and expected frequencies must be the same
+    for the test to be valid; `power_divergence` raises an error if the sums
+    do not agree within a relative tolerance of ``1e-8``.
+
     When `lambda_` is less than zero, the formula for the statistic involves
     dividing by `f_obs`, so a warning or error may be generated if any value
     in `f_obs` is 0.
@@ -6143,26 +6147,26 @@ def power_divergence(f_obs, f_exp=None, ddof=0, axis=0, lambda_=None):
         with np.errstate(invalid='ignore'):
             f_exp = f_obs.mean(axis=axis, keepdims=True)
 
+    f_obs_float = f_obs.astype(np.float64)
+    rtol = 1e-8  # to pass existing tests
+    with np.errstate(invalid='ignore'):
+        relative_diff = np.abs((f_obs_float - f_exp).sum(axis=axis)
+                               / np.minimum(f_obs_float, f_exp).sum(axis=axis))
+        diff_gt_tol = (relative_diff > rtol).any()
+    if diff_gt_tol:
+        msg = (f"For each axis slice, the sum of the observed "
+               f"frequencies must agree with the sum of the "
+               f"expected frequencies to a relative tolerance "
+               f"of {rtol}, but the percent differences are:\n"
+               f"{relative_diff}")
+        raise ValueError(msg)
+
     # `terms` is the array of terms that are summed along `axis` to create
     # the test statistic.  We use some specialized code for a few special
     # cases of lambda_.
     if lambda_ == 1:
-        f_obs = f_obs.astype(np.float64)
-        rtol = 1e-8  # to pass existing tests
-        with np.errstate(invalid='ignore'):
-            relative_diff = np.abs((f_obs - f_exp).sum(axis=axis)
-                                   / np.minimum(f_obs, f_exp).sum(axis=axis))
-            diff_gt_tol = (relative_diff > rtol).any()
-        if diff_gt_tol:
-            msg = (f"For each axis slice, the sum of the observed "
-                   f"frequencies must agree with the sum of the "
-                   f"expected frequencies to a relative tolerance "
-                   f"of {rtol}, but the percent differences are:\n"
-                   f"{relative_diff}")
-            raise ValueError(msg)
-
         # Pearson's chi-squared statistic
-        terms = (f_obs - f_exp)**2 / f_exp
+        terms = (f_obs_float - f_exp)**2 / f_exp
     elif lambda_ == 0:
         # Log-likelihood ratio (i.e. G-test)
         terms = 2.0 * special.xlogy(f_obs, f_obs / f_exp)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -6148,7 +6148,7 @@ def power_divergence(f_obs, f_exp=None, ddof=0, axis=0, lambda_=None):
     # cases of lambda_.
     if lambda_ == 1:
         f_obs = f_obs.astype(np.float64)
-        rtol = 1e-5  # to pass existing tests
+        rtol = 1e-8  # to pass existing tests
         with np.errstate(invalid='ignore'):
             relative_diff = np.abs((f_obs - f_exp).sum(axis=axis)
                                    / np.minimum(f_obs, f_exp).sum(axis=axis))

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2979,18 +2979,25 @@ class TestPowerDivergence(object):
         attributes = ('statistic', 'pvalue')
         check_named_results(res, attributes)
 
+    def test_power_divergence_gh_12282(self):
+        # The sums of observed and expected frequencies must match
+        f_obs = np.array([[10, 20], [30, 20]])
+        f_exp = np.array([[5, 15], [35, 25]])
+        with assert_raises(ValueError, match='For each axis slice...'):
+            stats.power_divergence(f_obs=[10, 20], f_exp=[30, 60])
+        with assert_raises(ValueError, match='For each axis slice...'):
+            stats.power_divergence(f_obs=f_obs, f_exp=f_exp, axis=1)
+        stat, pval = stats.power_divergence(f_obs=f_obs, f_exp=f_exp)
+        assert_allclose(stat, [5.71428571, 2.66666667])
+        assert_allclose(pval, [0.01682741, 0.10247043])
 
-def test_gh_12282():
-    # The sums of observed and expected frequencies must match
-    f_obs = np.array([[10, 20], [30, 20]])
-    f_exp = np.array([[5, 15], [35, 25]])
+
+def test_gh_chisquare_12282():
+    # Currently `chisquare` is implemented via power_divergence
+    # in case that ever changes, perform a basic test like
+    # test_power_divergence_gh_12282
     with assert_raises(ValueError, match='For each axis slice...'):
         stats.chisquare(f_obs=[10, 20], f_exp=[30, 60])
-    with assert_raises(ValueError, match='For each axis slice...'):
-        stats.chisquare(f_obs=f_obs, f_exp=f_exp, axis=1)
-    stat, pval = stats.chisquare(f_obs, f_exp)
-    assert_allclose(stat, [5.71428571, 2.66666667])
-    assert_allclose(pval, [0.01682741, 0.10247043])
 
 
 @pytest.mark.parametrize("n, dtype", [(200, np.uint8), (1000000, np.int32)])

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3093,7 +3093,8 @@ def test_power_divergence_against_cressie_read_data():
     # Table 4 data recalculated for greater precision according to:
     # Shelby J. Haberman, Analysis of Qualitative Data: Volume 1
     # Introductory Topics, Academic Press, New York, USA (1978).
-    obs = np.array([15, 11, 14, 17, 5, 11, 10, 4, 8, 10, 7, 9, 11, 3, 6, 1, 1, 4])
+    obs = np.array([15, 11, 14, 17, 5, 11, 10, 4, 8,
+                    10, 7, 9, 11, 3, 6, 1, 1, 4])
     beta = -0.083769  # Haberman (1978), p. 15
     i = np.arange(1, len(obs) + 1)
     alpha = np.log(obs.sum() / np.exp(beta*i).sum())

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2980,6 +2980,19 @@ class TestPowerDivergence(object):
         check_named_results(res, attributes)
 
 
+def test_gh_12282():
+    # The sums of observed and expected frequencies must match
+    f_obs = np.array([[10, 20], [30, 20]])
+    f_exp = np.array([[5, 15], [35, 25]])
+    with assert_raises(ValueError, match='For each axis slice...'):
+        stats.chisquare(f_obs=[10, 20], f_exp=[30, 60])
+    with assert_raises(ValueError, match='For each axis slice...'):
+        stats.chisquare(f_obs=f_obs, f_exp=f_exp, axis=1)
+    stat, pval = stats.chisquare(f_obs, f_exp)
+    assert_allclose(stat, [5.71428571, 2.66666667])
+    assert_allclose(pval, [0.01682741, 0.10247043])
+
+
 @pytest.mark.parametrize("n, dtype", [(200, np.uint8), (1000000, np.int32)])
 def test_chiquare_data_types(n, dtype):
     # Regression test for gh-10159.

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3083,28 +3083,18 @@ def test_power_divergence_against_cressie_read_data():
     # J. R. Statist. Soc. B (1984), Vol 46, No. 3, pp. 440-464.
     # This tests the calculation for several values of lambda.
 
+    # Table 4 data recalculated for greater precision according to:
+    # Shelby J. Haberman, Analysis of Qualitative Data: Volume 1
+    # Introductory Topics, Academic Press, New York, USA (1978).
+    obs = np.array([15, 11, 14, 17, 5, 11, 10, 4, 8, 10, 7, 9, 11, 3, 6, 1, 1, 4])
+    beta = -0.083769  # Haberman (1978), p. 15
+    i = np.arange(1, len(obs) + 1)
+    alpha = np.log(obs.sum() / np.exp(beta*i).sum())
+    expected_counts = np.exp(alpha + beta*i)
+
     # `table4` holds just the second and third columns from Table 4.
-    table4 = np.array([
-        # observed, expected,
-        15, 15.171,
-        11, 13.952,
-        14, 12.831,
-        17, 11.800,
-        5, 10.852,
-        11, 9.9796,
-        10, 9.1777,
-        4, 8.4402,
-        8, 7.7620,
-        10, 7.1383,
-        7, 6.5647,
-        9, 6.0371,
-        11, 5.5520,
-        3, 5.1059,
-        6, 4.6956,
-        1, 4.3183,
-        1, 3.9713,
-        4, 3.6522,
-        ]).reshape(-1, 2)
+    table4 = np.vstack((obs, expected_counts)).T
+
     table5 = np.array([
         # lambda, statistic
         -10.0, 72.2e3,


### PR DESCRIPTION
#### Reference issue
Closes gh-12282

#### What does this implement/fix?
There was no check in `scipy.stats.chisquare` that the sum of observed frequencies matched the sum of expected frequencies. This PR raises an error if the two do not agree within a certain tolerance. 

#### Additional information
The side effect is that it is no longer possible to express the expected frequencies in terms of probabilities; we can add automatic normalization of the observed frequencies for this case if desired.
A question is whether this should be specific to `chisquare` or is more generally applicable in `power_divergence`. Currently the check is performed in `power_divergence` whenever `lambda_ == 1` (Pearson).

@sam-data-guy would this address the concern?