### PR TITLE
BUG: slsqp should be able to use rel_step

### DIFF
--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -96,7 +96,7 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
 
         where ``x`` is an array with shape (n,) and ``args`` is a tuple with
         the fixed parameters. If `jac` is a Boolean and is True, `fun` is
-        assumed to return and objective and gradient as and ``(f, g)`` tuple.
+        assumed to return and objective and gradient as an ``(f, g)`` tuple.
         Methods 'Newton-CG', 'trust-ncg', 'dogleg', 'trust-exact', and
         'trust-krylov' require that either a callable be supplied, or that
         `fun` return the objective and gradient.
@@ -557,8 +557,8 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
         fun = MemoizeJac(fun)
         jac = fun.derivative
     elif (jac in FD_METHODS and
-          meth in ['trust-constr', 'bfgs', 'cg', 'l-bfgs-b', 'tnc']):
-        # finite differences
+          meth in ['trust-constr', 'bfgs', 'cg', 'l-bfgs-b', 'tnc', 'slsqp']):
+        # finite differences with relative step
         pass
     elif meth in ['trust-constr']:
         # default jac calculation for this method


### PR DESCRIPTION
Without this change SLSQP would never be able to use a relative step size for numerical differentiation