### PR TITLE
MAINT: optimize: loosen redundancy remove and constraint check tolerances

### DIFF
--- a/scipy/optimize/_linprog_util.py
+++ b/scipy/optimize/_linprog_util.py
@@ -1432,7 +1432,9 @@ def _check_result(x, fun, status, slack, con, bounds, tol, message):
         A string descriptor of the exit status of the optimization.
     """
     # Somewhat arbitrary
-    tol = np.sqrt(tol) * 10
+    # Factor of 10 fixed some issues, 100 fixed gh-13200.
+    # Should make this a relative tolerance at some point.
+    tol = np.sqrt(tol) * 100
 
     if x is None:
         # HiGHS does not provide x if infeasible/unbounded

--- a/scipy/optimize/_remove_redundancy.py
+++ b/scipy/optimize/_remove_redundancy.py
@@ -432,7 +432,8 @@ def _remove_redundancy_svd(A, b):
                        "off redundancy removal, or try turning off presolve "
                        "altogether.")
             break
-        if np.any(np.abs(v.dot(b)) > tol * 100):  # factor of 100 to fix 10038 and 10349
+        # factor fixes gh-10038, gh-10349, and gh-13200
+        if np.any(np.abs(v.dot(b)) > tol * 1e4):
             status = 2
             message = ("There is a linear combination of rows of A_eq that "
                        "results in zero, suggesting a redundant constraint. "


### PR DESCRIPTION
#### Reference issue
gh-13200

#### What does this implement/fix?
Two tolerances were loosened.

One tolerance is for an early check of infeasibility. When the redunancy removal routine identifies linearly dependent rows of the constraint matrix, it checks the right hand side for compatibility (i.e. does the same linear combination result in zero on both the left and right hand sides of the constraints). The tolerance for "nearly zero" needed to be increased. (See also gh-10038, gh-10349). If the problem is infeasible, then the infeasibility will be detected in the main algorithm. 

The other tolerance is a sanity check on whether the solution satisfies the constraints. Interior point found the right solution, but not to sufficient tolerance to pass the check. The tolerance in the check is arbitrary, so I loosened it.

#### Additional information
Ultimately it would be nice to make both of these tolerances smart (adapting to the numbers in the problem) but that has been planned for a while (gh-9671) and is a project for later.