### PR TITLE
TST:linalg: set the seed for cossin test

### DIFF
--- a/scipy/linalg/tests/test_decomp_cossin.py
+++ b/scipy/linalg/tests/test_decomp_cossin.py
@@ -130,6 +130,7 @@ def test_cossin_error_partitioning():
 
 @pytest.mark.parametrize("dtype_", DTYPES)
 def test_cossin_separate(dtype_):
+    seed(1234)
     m, p, q = 250, 80, 170
 
     pfx = 'or' if dtype_ in REAL_DTYPES else 'un'


### PR DESCRIPTION

#### Reference issue
Fixes #13207 

#### What does this implement/fix?
Adds the missing seed fixer.
