### PR TITLE
[DOC] Backtick and directive consistency.

### DIFF
--- a/scipy/fft/_realtransforms.py
+++ b/scipy/fft/_realtransforms.py
@@ -504,22 +504,22 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
     **Type I**
 
     There are several definitions of the DST-I; we use the following for
-    ``norm="backward"``. DST-I assumes the input is odd around `n=-1` and
-    `n=N`.
+    ``norm="backward"``. DST-I assumes the input is odd around :math:`n=-1` and
+    :math:`n=N`.
 
     .. math::
 
         y_k = 2 \sum_{n=0}^{N-1} x_n \sin\left(\frac{\pi(k+1)(n+1)}{N+1}\right)
 
     Note that the DST-I is only supported for input size > 1.
-    The (unnormalized) DST-I is its own inverse, up to a factor `2(N+1)`.
+    The (unnormalized) DST-I is its own inverse, up to a factor :math:`2(N+1)`.
     The orthonormalized DST-I is exactly its own inverse.
 
     **Type II**
 
     There are several definitions of the DST-II; we use the following for
-    ``norm="backward"``. DST-II assumes the input is odd around `n=-1/2` and
-    `n=N-1/2`; the output is odd around :math:`k=-1` and even around `k=N-1`
+    ``norm="backward"``. DST-II assumes the input is odd around :math:`n=-1/2` and
+    :math:`n=N-1/2`; the output is odd around :math:`k=-1` and even around :math:`k=N-1`
 
     .. math::
 
@@ -536,8 +536,8 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
     **Type III**
 
     There are several definitions of the DST-III, we use the following (for
-    ``norm="backward"``). DST-III assumes the input is odd around `n=-1` and
-    even around `n=N-1`
+    ``norm="backward"``). DST-III assumes the input is odd around :math:`n=-1` and
+    even around :math:`n=N-1`
 
     .. math::
 
@@ -545,20 +545,20 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
         \frac{\pi(2k+1)(n+1)}{2N}\right)
 
     The (unnormalized) DST-III is the inverse of the (unnormalized) DST-II, up
-    to a factor `2N`. The orthonormalized DST-III is exactly the inverse of the
+    to a factor :math:`2N`. The orthonormalized DST-III is exactly the inverse of the
     orthonormalized DST-II.
 
     **Type IV**
 
     There are several definitions of the DST-IV, we use the following (for
-    ``norm="backward"``). DST-IV assumes the input is odd around `n=-0.5` and
-    even around ``n=N-0.5``
+    ``norm="backward"``). DST-IV assumes the input is odd around :math:`n=-0.5` and
+    even around :math:`n=N-0.5`
 
     .. math::
 
         y_k = 2 \sum_{n=0}^{N-1} x_n \sin\left(\frac{\pi(2k+1)(2n+1)}{4N}\right)
 
-    The (unnormalized) DST-IV is its own inverse, up to a factor `2N`. The
+    The (unnormalized) DST-IV is its own inverse, up to a factor :math:`2N`. The
     orthonormalized DST-IV is exactly its own inverse.
 
     References


### PR DESCRIPTION
Some of the math in those docstrings was not using consistent directive;
it was sometime using double-backticks (verbatim), sometime using
simple-backticks (default directive, reference), and sometime
:math:-backticks which I believe is the correct one.

Where I spoted issues I now use :math:... consistently.
