### PR TITLE
TST: stats: break up and mark slow tests

### DIFF
--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -45,9 +45,9 @@ distcont_extra = [
 ]
 
 
-distslow = ['kstwo', 'ksone', 'kappa4', 'gausshyper', 'recipinvgauss',
-            'genexpon', 'vonmises', 'vonmises_line', 'cosine', 'invweibull',
-            'powerlognorm', 'johnsonsu', 'kstwobign']
+distslow = ['kstwo', 'genexpon', 'ksone', 'recipinvgauss', 'vonmises',
+            'kappa4', 'vonmises_line', 'gausshyper', 'norminvgauss',
+            'geninvgauss']
 # distslow are sorted by speed (very slow to slow)
 
 # skip check_fit_args (test is slow)

--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -396,6 +396,7 @@ def test_pdf_logpdf_weighted():
     assert_almost_equal(pdf, pdf2, decimal=12)
 
 
+@pytest.mark.slow
 def test_logpdf_overflow():
     # regression test for gh-12988; testing against linalg instability for
     # very high dimensionality kde

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -332,6 +332,14 @@ class TestCorr(object):
                             25, 80, 80, 80, 80, 80, 80, 0, 10, 45, np.nan, 0])
         result = mstats.kendalltau(x, y)
         assert_almost_equal(np.asarray(result), [-0.1585188, 0.4128009])
+
+        # test for namedtuple attributes
+        attributes = ('correlation', 'pvalue')
+        check_named_results(result, attributes, ma=True)
+
+
+    @pytest.mark.slow
+    def test_kendalltau_large(self):
         # make sure internal variable use correct precision with
         # larger arrays
         x = np.arange(2000, dtype=float)
@@ -340,10 +348,6 @@ class TestCorr(object):
         y = np.concatenate((y[1000:], y[:1000]))
         assert_(np.isfinite(mstats.kendalltau(x, y)[1]))
 
-        # test for namedtuple attributes
-        res = mstats.kendalltau(x, y)
-        attributes = ('correlation', 'pvalue')
-        check_named_results(res, attributes, ma=True)
 
     def test_kendalltau_seasonal(self):
         # Tests the seasonal Kendall tau.
@@ -358,27 +362,37 @@ class TestCorr(object):
                             [0.18,0.53,0.20,0.04])
 
 
-def test_kendall_p_exact_large():
-    # Test for the exact method with large samples (n >= 171)
-    # expected values generated using SymPy
-    expectations = {(100, 2393): 0.62822615287956040664,
-                    (101, 2436): 0.60439525773513602669,
-                    (170, 0): 2.755801935583541e-307,
-                    (171, 0): 0.0,
-                    (171, 1): 2.755801935583541e-307,
-                    (172, 1): 0.0,
-                    (200, 9797): 0.74753983745929675209,
-                    (201, 9656): 0.40959218958120363618,
-                    (400, 38965): 0.48444283672113314099,
-                    (401, 39516): 0.66363159823474837662,
-                    (800, 156772): 0.42265448483120932055,
-                    (801, 157849): 0.53437553412194416236,
-                    (1600, 637472): 0.84200727400323538419,
-                    (1601, 630304): 0.34465255088058593946}
-    
-    for nc, expected in expectations.items():
-        res = mstats_basic._kendall_p_exact(nc[0], nc[1])
-        assert_almost_equal(res, expected)
+    def test_kendall_p_exact_medium(self):
+        # Test for the exact method with medium samples (some n >= 171)
+        # expected values generated using SymPy
+        expectations = {(100, 2393): 0.62822615287956040664,
+                        (101, 2436): 0.60439525773513602669,
+                        (170, 0): 2.755801935583541e-307,
+                        (171, 0): 0.0,
+                        (171, 1): 2.755801935583541e-307,
+                        (172, 1): 0.0,
+                        (200, 9797): 0.74753983745929675209,
+                        (201, 9656): 0.40959218958120363618}
+        for nc, expected in expectations.items():
+            res = mstats_basic._kendall_p_exact(nc[0], nc[1])
+            assert_almost_equal(res, expected)
+
+
+    @pytest.mark.slow
+    def test_kendall_p_exact_large(self):
+        # Test for the exact method with large samples (n >= 171)
+        # expected values generated using SymPy
+        expectations = {(400, 38965): 0.48444283672113314099,
+                        (401, 39516): 0.66363159823474837662,
+                        (800, 156772): 0.42265448483120932055,
+                        (801, 157849): 0.53437553412194416236,
+                        (1600, 637472): 0.84200727400323538419,
+                        (1601, 630304): 0.34465255088058593946}
+
+        for nc, expected in expectations.items():
+            res = mstats_basic._kendall_p_exact(nc[0], nc[1])
+            assert_almost_equal(res, expected)
+
 
     def test_pointbiserial(self):
         x = [1,0,1,1,1,1,0,1,0,0,0,1,1,0,0,0,1,1,1,0,0,0,0,0,0,0,0,1,0,

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -337,7 +337,8 @@ class TestCorr(object):
         attributes = ('correlation', 'pvalue')
         check_named_results(result, attributes, ma=True)
 
-
+    @pytest.mark.skipif(platform.machine() == 'ppc64le',
+                        reason="fails/crashes on ppc64le")
     @pytest.mark.slow
     def test_kendalltau_large(self):
         # make sure internal variable use correct precision with

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3463,6 +3463,8 @@ class TestKSTwoSamples(object):
         assert_raises(ValueError, stats.ks_2samp, [1], [])
         assert_raises(ValueError, stats.ks_2samp, [], [])
 
+
+    @pytest.mark.slow
     def test_gh12218(self):
         """Ensure gh-12218 is fixed."""
         # gh-1228 triggered a TypeError calculating sqrt(n1*n2*(n1+n2)).


### PR DESCRIPTION
#### Reference issue
Closes gh-12132

#### What does this implement/fix?
Skips some slow stats tests, including
16.43s call     scipy/stats/tests/test_mstats_basic.py::test_kendall_p_exact_large (split up into medium and large)
1.64s call     scipy/stats/tests/test_stats.py::TestKSTwoSamples::test_gh12218
1.50s call     scipy/stats/tests/test_continuous_basic.py::test_cont_basic[norminvgauss-arg77]
1.36s call     scipy/stats/tests/test_kdeoth.py::test_logpdf_overflow
1.17s call     scipy/stats/tests/test_mstats_basic.py::TestCorr::test_kendalltau - moved slow part to separate test

I also reconsidered the list of distributions to skip for `test_cont_basic`, adding some quick ones back in. 

I'll comment on the changes and reach out about the two bug tests inline.