### PR TITLE
REL: add necessary setuptools and numpy version pins in pyproject.toml for 1.6.x branch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "wheel",
-    "setuptools",
+    "setuptools<=51.0.0",
     "Cython>=0.29.18",
     "numpy==1.16.5; python_version=='3.7'",
     "numpy==1.17.3; python_version=='3.8'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,8 @@ requires = [
     "Cython>=0.29.18",
     "numpy==1.16.5; python_version=='3.7'",
     "numpy==1.17.3; python_version=='3.8'",
+    "numpy==1.19.3; python_version=='3.9'",
     # do not pin numpy on future versions of python to avoid incompatible numpy and python versions
-    "numpy; python_version>='3.9'",
+    "numpy; python_version>='3.10'",
     "pybind11>=2.4.3",
 ]


### PR DESCRIPTION
These are only the most essential parts of gh-12862 (which I need to get back to sometime soon). 

Change 1:
```
    REL: pin setuptools to <= 51.0.0
    
    This is the latest released version as of now. Because setuptools
    now vendors distutils and plans on making backwards incompatible
    changes to it, we need to pin it so builds from sdist don't break
    after release.
    
    We only do this on 1.6.x for now, not on master (there we will
    continue to detect failures if setuptools breaks something).
```

Change 2:
```
    REL: add a missing numpy version pin for py39 in pyproject.toml
    
    Taken over from https://github.com/scipy/oldest-supported-numpy,
    NumPy 1.19.3 is the first release to support Python 3.9
    
    Note that this is just the minimal fix for 1.6.x, more changes
    are needed on master.

```
