### PR TITLE
ENH: stats: add `nan_policy' argument for `stats.wilcoxon`

### DIFF
--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -2845,9 +2845,10 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=False,
     mode : {"auto", "exact", "approx"}
         Method to calculate the p-value, see Notes. Default is "auto".
     nan_policy : {'propagate', 'raise', 'omit'}, optional
-        Defines how to handle when input contains nan. 'propagate' just return
-        nans, 'raise' throws an error, 'omit' performs the calculations
-        ignoring nan values. Default is 'omit'.
+        Defines how to handle the occurrence of nans in `x` and `y`.
+        'propagate' returns nan, 'raise' raises an exception, 'omit'
+        performs the calculations ignoring nan values. Default is
+        'omit'.
 
     Returns
     -------

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1118,6 +1118,24 @@ class TestWilcoxon(object):
         d = np.arange(1, 27)
         assert_equal(stats.wilcoxon(d), stats.wilcoxon(d, mode="approx"))
 
+    def test_nan_policy(self):
+
+        x1 = np.array([1, 2, 3])
+        x2 = np.array([1, 2, 3, np.nan])
+        assert_equal(stats.wilcoxon(x1), stats.wilcoxon(x2, nan_policy="omit"))
+        assert_equal((np.nan, np.nan),
+                     stats.wilcoxon(x2, nan_policy="propagate"))
+
+        assert_raises(ValueError, stats.wilcoxon, x2, nan_policy='raise')
+
+        x3 = np.array([5, 5, 5])
+        x4 = np.array([5, 5, 5, np.nan])
+
+        assert_equal(stats.wilcoxon(x1, x3),
+                     stats.wilcoxon(x2, x4, nan_policy="omit"))
+        assert_equal((np.nan, np.nan),
+                     stats.wilcoxon(x2, x4, nan_policy="propagate"))
+
 
 class TestKstat(object):
     def test_moments_normal_distribution(self):

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1150,6 +1150,7 @@ class TestWilcoxon(object):
         with assert_raises(ValueError, match="The input contains nan"):
             stats.wilcoxon(x1, x2, nan_policy='raise')
 
+
 class TestKstat(object):
     def test_moments_normal_distribution(self):
         np.random.seed(32149)

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1119,27 +1119,36 @@ class TestWilcoxon(object):
         assert_equal(stats.wilcoxon(d), stats.wilcoxon(d, mode="approx"))
 
     def test_nan_policy(self):
-
+        # 1 one-argument test
         x1 = np.array([1, 2, 3])
         x2 = np.array([1, 2, 3, np.nan])
+
+        # 1-1 omit test
         assert_equal(stats.wilcoxon(x1), stats.wilcoxon(x2, nan_policy="omit"))
+        # 1-2 propagate test
         assert_equal((np.nan, np.nan),
                      stats.wilcoxon(x2, nan_policy="propagate"))
+        # 1-3 raise test
+        with assert_raises(ValueError, match="The input contains nan"):
+            stats.wilcoxon(x2, nan_policy='raise')
 
-        assert_raises(ValueError, stats.wilcoxon, x2, nan_policy='raise')
-
+        # 2 two-argument test
         x3 = np.array([5, 5, 5])
         x4 = np.array([5, 5, 5, np.nan])
 
+        # 2-1 omit test
         assert_equal(stats.wilcoxon(x1, x3),
                      stats.wilcoxon(x1, x4, nan_policy="omit"))
+        # 2-2 propagate test
         assert_equal((np.nan, np.nan),
                      stats.wilcoxon(x1, x4, nan_policy="propagate"))
-
+        # 2-3 raise test
         x5 = np.array([6, 6, 6])
         x6 = np.array([7, 7, np.nan])
-        assert_raises(ValueError, stats.wilcoxon, x5, x6, nan_policy='omit')
-
+        with assert_raises(ValueError, match="The samples x and y must have"): 
+            stats.wilcoxon(x5, x6, nan_policy='omit')
+        with assert_raises(ValueError, match="The input contains nan"):
+            stats.wilcoxon(x1, x2, nan_policy='raise')
 
 class TestKstat(object):
     def test_moments_normal_distribution(self):

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1132,9 +1132,13 @@ class TestWilcoxon(object):
         x4 = np.array([5, 5, 5, np.nan])
 
         assert_equal(stats.wilcoxon(x1, x3),
-                     stats.wilcoxon(x2, x4, nan_policy="omit"))
+                     stats.wilcoxon(x1, x4, nan_policy="omit"))
         assert_equal((np.nan, np.nan),
-                     stats.wilcoxon(x2, x4, nan_policy="propagate"))
+                     stats.wilcoxon(x1, x4, nan_policy="propagate"))
+
+        x5 = np.array([6, 6, 6])
+        x6 = np.array([7, 7, np.nan])
+        assert_raises(ValueError, stats.wilcoxon, x5, x6, nan_policy='omit')
 
 
 class TestKstat(object):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
fix #11409 

#### What does this implement/fix?
I added nan_policy' argument for stats.rankdata based on [the doc](http://scipy.github.io/devdocs/dev/api-dev/nan_policy.html) and its test.
