### PR TITLE
BUG: pavement.py file handle fixes

### DIFF
--- a/pavement.py
+++ b/pavement.py
@@ -209,7 +209,7 @@ def compute_md5(idirs):
     for fn in sorted(released):
         with open(fn, 'rb') as f:
             m = md5(f.read())
-        checksums.append('%s  %s' % (m.hexdigest(), os.path.basename(f)))
+        checksums.append('%s  %s' % (m.hexdigest(), os.path.basename(fn)))
 
     return checksums
 
@@ -221,7 +221,7 @@ def compute_sha256(idirs):
     for fn in sorted(released):
         with open(fn, 'rb') as f:
             m = sha256(f.read())
-        checksums.append('%s  %s' % (m.hexdigest(), os.path.basename(f)))
+        checksums.append('%s  %s' % (m.hexdigest(), os.path.basename(fn)))
 
     return checksums
 


### PR DESCRIPTION
Fixes #13221

* the changes made to `pavement.py`, as described in gh-13221,
modernized some file handling code blocks as suggested by static
analysis

* however, this broke the usage of `paver release` (which is not
tested in CI), because the meaning of those code blocks was changed
from passing a path-like object to `os.path.basename()` to passing
an open file handle to `basename()`

* this two-character patch restores the originally intended meaning
(passing a path-like object to `basename()`) while preserving
the modernized file context managers; I confirmed locally that
`paver release` works again with this patch