### PR TITLE
MAINT: stats: frozen distribution attributes a and b should consider parameters

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -437,7 +437,7 @@ class rv_frozen(object):
         self.dist = dist.__class__(**dist._updated_ctor_param())
 
         shapes, _, _ = self.dist._parse_args(*args, **kwds)
-        self.a, self.b = self.dist._get_support(*shapes)
+        self.a, self.b = self.dist.support(*self.args, **self.kwds)
 
     @property
     def random_state(self):

--- a/scipy/stats/tests/common_tests.py
+++ b/scipy/stats/tests/common_tests.py
@@ -308,15 +308,17 @@ def check_pickling(distfn, args):
 
 def check_freezing(distfn, args):
     # regression test for gh-11089: freezing a distribution fails
-    # if loc and/or scale are specified
+    # if loc and/or scale are specified. Modified to resolve gh-13225;
+    # loc and scale _should_ affect `a` and `b`
     if isinstance(distfn, stats.rv_continuous):
         locscale = {'loc': 1, 'scale': 2}
     else:
         locscale = {'loc': 1}
 
-    rv = distfn(*args, **locscale)
-    assert rv.a == distfn(*args).a
-    assert rv.b == distfn(*args).b
+    rv1 = distfn(*args)
+    rv2 = distfn(*args, **locscale)
+    assert rv2.a == rv1.a * locscale.get('scale', 1) + locscale.get('loc')
+    assert rv2.b == rv1.b * locscale.get('scale', 1) + locscale.get('loc')
 
 
 def check_rvs_broadcast(distfunc, distname, allargs, shape, shape_only, otype):


### PR DESCRIPTION
#### Reference issue
Closes gh-13225

#### What does this implement/fix?
The `a` and `b` attributes of frozen distributions currently hold the lower and upper bounds of the support of the unscaled, unshifted distribution. It seems that they should hold the support of the distribution considering the location, scale, and shape parameters. 