### PR TITLE
ENH: linalg: Add LAPACK wrapper for tgexc.

### DIFF
--- a/scipy/linalg/flapack_other.pyf.src
+++ b/scipy/linalg/flapack_other.pyf.src
@@ -42,6 +42,56 @@ subroutine <prefix2>gejsv(joba,jobu,jobv,jobr,jobt,jobp,m,n,a,lda,sva,u,ldu,v,ld
 
 end subroutine <prefix2>gejsv
 
+subroutine <prefix2>tgexc(wantq,wantz,n,a,lda,b,ldb,q,ldq,z,ldz,ifst,ilst,work,lwork,info)
+    ! Reorder the generalized Schur decomposition of a real matrix
+    ! pair using an orthogonal or unitary equivalence transformation.
+
+    callstatement { ifst++; ilst++; (*f2py_func)(&wantq,&wantz,&n,a,&lda,b,&ldb,q,&ldq,z,&ldz,&ifst,&ilst,work,&lwork,&info); }
+    callprotoargument F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,F_INT*
+
+    integer intent(hide),check(wantq==0||wantq==1) :: wantq=1
+    integer intent(hide),check(wantz==0||wantz==1) :: wantz=1
+    integer intent(hide),depend(a) :: n=shape(a,1)
+    <ftype2> intent(in,out,copy),dimension(lda,n) :: a
+    integer intent(hide),depend(a) :: lda=shape(a,0)
+    <ftype2> intent(in,out,copy),dimension(ldb,n) :: b
+    integer intent(hide),depend(b) :: ldb=shape(b,0)
+    <ftype2> intent(in,out,copy),dimension(ldq,n) :: q
+    integer intent(hide),depend(q) :: ldq=shape(q,0)
+    <ftype2> intent(in,out,copy),dimension(ldz,n) :: z
+    integer intent(hide),depend(z) :: ldz=shape(z,0)
+    integer intent(in) :: ifst
+    integer intent(in) :: ilst
+    <ftype2> intent(out),dimension(MAX(lwork,1)) :: work
+    integer optional,intent(in),depend(n),check(lwork == -1 || lwork >= 4*n+16) :: lwork=max(4*n+16,1)
+    integer intent(out) :: info
+
+end subroutine <prefix2>tgexc
+
+subroutine <prefix2c>tgexc(wantq,wantz,n,a,lda,b,ldb,q,ldq,z,ldz,ifst,ilst,info)
+    ! Reorder the generalized Schur decomposition of a complex matrix
+    ! pair using an orthogonal or unitary equivalence transformation.
+
+    callstatement { ifst++; ilst++; (*f2py_func)(&wantq,&wantz,&n,a,&lda,b,&ldb,q,&ldq,z,&ldz,&ifst,&ilst,&info); }
+    callprotoargument F_INT*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,F_INT*,F_INT*,F_INT*
+
+    integer intent(hide),check(wantq==0||wantq==1) :: wantq=1
+    integer intent(hide),check(wantz==0||wantz==1) :: wantz=1
+    integer intent(hide),depend(a) :: n=shape(a,1)
+    <ftype2c> intent(in,out,copy),dimension(lda,n) :: a
+    integer intent(hide),depend(a) :: lda=shape(a,0)
+    <ftype2c> intent(in,out,copy),dimension(ldb,n) :: b
+    integer intent(hide),depend(b) :: ldb=shape(b,0)
+    <ftype2c> intent(in,out,copy),dimension(ldq,n) :: q
+    integer intent(hide),depend(q) :: ldq=shape(q,0)
+    <ftype2c> intent(in,out,copy),dimension(ldz,n) :: z
+    integer intent(hide),depend(z) :: ldz=shape(z,0)
+    integer intent(in) :: ifst
+    integer intent(in) :: ilst
+    integer intent(out) :: info
+
+end subroutine <prefix2c>tgexc
+
 subroutine <prefix2>tgsen(ijob,wantq,wantz,select,n,a,lda,b,ldb,alphar,alphai,beta,q,ldq,z,ldz,m,pl,pr,dif,work,lwork,iwork,liwork,info)
 
     callstatement (*f2py_func)(&ijob,&wantq,&wantz,select,&n,a,&lda,b,&ldb,alphar,alphai,beta,q,&ldq,z,&ldz,&m,&pl,&pr,dif,work,&lwork,iwork,&liwork,&info)

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -689,6 +689,11 @@ All functions
    ctfttr
    ztfttr
 
+   stgexc
+   dtgexc
+   ctgexc
+   ztgexc
+
    stgsen
    dtgsen
    ctgsen

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -2979,3 +2979,51 @@ def test_pptrs_pptri_pptrf_ppsv_ppcon(dtype, lower):
     rcond, info = ppcon(n, ap, anorm=anorm, lower=lower)
     assert_equal(info, 0)
     assert_(abs(1/rcond - np.linalg.cond(a, p=1))*rcond < 1)
+
+
+@pytest.mark.parametrize('dtype', DTYPES)
+def test_gges_tgexc(dtype):
+    seed(1234)
+    atol = np.finfo(dtype).eps*100
+
+    n = 10
+    a = generate_random_dtype_array([n, n], dtype=dtype)
+    b = generate_random_dtype_array([n, n], dtype=dtype)
+
+    gges, tgexc = get_lapack_funcs(('gges', 'tgexc'), dtype=dtype)
+
+    result = gges(lambda x: None, a, b, overwrite_a=False, overwrite_b=False)
+    assert_equal(result[-1], 0)
+
+    s = result[0]
+    t = result[1]
+    q = result[-4]
+    z = result[-3]
+
+    d1 = s[0, 0] / t[0, 0]
+    d2 = s[6, 6] / t[6, 6]
+
+    if dtype in COMPLEX_DTYPES:
+        assert_allclose(s, np.triu(s), rtol=0, atol=atol)
+        assert_allclose(t, np.triu(t), rtol=0, atol=atol)
+
+    assert_allclose(q @ s @ z.conj().T, a, rtol=0, atol=atol)
+    assert_allclose(q @ t @ z.conj().T, b, rtol=0, atol=atol)
+
+    result = tgexc(s, t, q, z, 6, 0)
+    assert_equal(result[-1], 0)
+
+    s = result[0]
+    t = result[1]
+    q = result[2]
+    z = result[3]
+
+    if dtype in COMPLEX_DTYPES:
+        assert_allclose(s, np.triu(s), rtol=0, atol=atol)
+        assert_allclose(t, np.triu(t), rtol=0, atol=atol)
+
+    assert_allclose(q @ s @ z.conj().T, a, rtol=0, atol=atol)
+    assert_allclose(q @ t @ z.conj().T, b, rtol=0, atol=atol)
+
+    assert_allclose(s[0, 0] / t[0, 0], d2, rtol=0, atol=atol)
+    assert_allclose(s[1, 1] / t[1, 1], d1, rtol=0, atol=atol)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Refs #10881

#### What does this implement/fix?
Adds an interface to tgexc which I needed to sort my generalized Schur form (tgsen can't be used to actually properly sort it, just split it into two blocks).