### PR TITLE
BUG: stats: improve numerical stability of covariance matrix to fix gh-10205

### DIFF
--- a/scipy/stats/kde.py
+++ b/scipy/stats/kde.py
@@ -559,12 +559,19 @@ class gaussian_kde(object):
         """Computes the covariance matrix for each Gaussian kernel using
         covariance_factor().
         """
+
         self.factor = self.covariance_factor()
         # Cache covariance and inverse covariance of the data
         if not hasattr(self, '_data_inv_cov'):
             self._data_covariance = atleast_2d(cov(self.dataset, rowvar=1,
                                                bias=False,
                                                aweights=self.weights))
+            # Small multiple of identity added to covariance matrix for
+            # numerical stability. Fixes gh-10205. For justification, see
+            # https://juanitorduz.github.io/multivariate_normal/ and primary
+            # source http://www.gaussianprocess.org/gpml/chapters/RWA.pdf
+            eps_I = 1e-14*np.eye(self.d)
+            self._data_covariance += eps_I
             self._data_inv_cov = linalg.inv(self._data_covariance)
 
         self.covariance = self._data_covariance * self.factor**2

--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -485,3 +485,15 @@ def test_seed():
     test_seed_sub(gkde_2d)
     gkde_2d_weighted = stats.gaussian_kde(xn_2d, weights=wn)
     test_seed_sub(gkde_2d_weighted)
+
+
+def test_gh10205():
+    # check that bug reported in gh-10205 (not positive definite) is resolved
+    np.random.seed(0)
+    mu = np.array([1,10,20])
+    sigma = np.matrix([[4,10,0],[10,25,0],[0,0,100]])
+    data = np.random.multivariate_normal(mu,sigma,1000)
+    values = data.T
+    stats.gaussian_kde(values)
+    # don't need to check for a particular result;
+    # just shouldn't raise an error

--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -490,10 +490,9 @@ def test_seed():
 def test_gh10205():
     # check that bug reported in gh-10205 (not positive definite) is resolved
     np.random.seed(0)
-    mu = np.array([1,10,20])
-    sigma = np.matrix([[4,10,0],[10,25,0],[0,0,100]])
-    data = np.random.multivariate_normal(mu,sigma,1000)
-    values = data.T
-    stats.gaussian_kde(values)
+    mu = np.array([1, 10, 20])
+    sigma = np.array([[4, 10, 0], [10, 25, 0], [0, 0, 100]])
+    data = np.random.multivariate_normal(mu, sigma, 1000)
+    stats.gaussian_kde(data.T)
     # don't need to check for a particular result;
     # just shouldn't raise an error


### PR DESCRIPTION
#### Reference issue
Closes gh-10205

#### What does this implement/fix?
Cholesky decomposition in `scipy.stats.gaussian_kde` fails if the data covariance matrix is not positive definite. This patch adds a small multiple of the identity matrix to the data covariance matrix for numerical stability.

See [here](http://www.gaussianprocess.org/gpml/chapters/RWA.pdf) for potential justification:
![image](https://user-images.githubusercontent.com/6570539/101962449-0bf0f600-3bc1-11eb-8b70-a843045224df.png)

#### Additional information
I don't know anything about this particular subject, so please check that this fix is justified. I'd also appreciate thoughts on the magnitude of the stabilization.