### PR TITLE
MAINT: stats: raise error when input to kruskal has >1 dim

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -7271,7 +7271,7 @@ def kruskal(*args, nan_policy='propagate'):
     ----------
     sample1, sample2, ... : array_like
        Two or more arrays with the sample measurements can be given as
-       arguments.
+       arguments. Samples may not have more than one non-singleton dimension.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
         Defines how to handle when input contains nan.
         The following options are available (default is 'propagate'):
@@ -7324,6 +7324,7 @@ def kruskal(*args, nan_policy='propagate'):
 
     """
     args = list(map(np.asarray, args))
+
     num_groups = len(args)
     if num_groups < 2:
         raise ValueError("Need at least two groups in stats.kruskal()")
@@ -7331,6 +7332,10 @@ def kruskal(*args, nan_policy='propagate'):
     for arg in args:
         if arg.size == 0:
             return KruskalResult(np.nan, np.nan)
+        elif np.squeeze(arg).ndim > 1:  # 0d (scalar) is ok
+            raise ValueError("Samples may not have more than one "
+                             "non-singleton dimension.")
+
     n = np.asarray(list(map(len, args)))
 
     if nan_policy not in ('propagate', 'raise', 'omit'):

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -7271,7 +7271,7 @@ def kruskal(*args, nan_policy='propagate'):
     ----------
     sample1, sample2, ... : array_like
        Two or more arrays with the sample measurements can be given as
-       arguments. Samples may not have more than one non-singleton dimension.
+       arguments. Samples must be one-dimensional.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
         Defines how to handle when input contains nan.
         The following options are available (default is 'propagate'):
@@ -7332,9 +7332,8 @@ def kruskal(*args, nan_policy='propagate'):
     for arg in args:
         if arg.size == 0:
             return KruskalResult(np.nan, np.nan)
-        elif np.squeeze(arg).ndim > 1:  # 0d (scalar) is ok
-            raise ValueError("Samples may not have more than one "
-                             "non-singleton dimension.")
+        elif arg.ndim != 1: 
+            raise ValueError("Samples must be one-dimensional.")
 
     n = np.asarray(list(map(len, args)))
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -5187,6 +5187,19 @@ class TestKruskal(object):
         z = []
         assert_equal(stats.kruskal(x, y, z), (np.nan, np.nan))
 
+    def test_nd_arrays(self):
+        # N-d arrays are OK...
+        x = [[1]]
+        y = [[2]]  # this is fine
+        h, p = stats.kruskal(x, y)
+        assert_equal(h, 1.0)
+        assert_approx_equal(p, stats.distributions.chi2.sf(h, 1))
+
+        # but only one non-singleton dimension is allowed
+        z = np.random.rand(2, 2)
+        with assert_raises(ValueError, match="Samples may not have more"):
+            stats.kruskal(x, y, z)
+
     def test_kruskal_result_attributes(self):
         x = [1, 3, 5, 7, 9]
         y = [2, 4, 6, 8, 10]

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -5188,16 +5188,11 @@ class TestKruskal(object):
         assert_equal(stats.kruskal(x, y, z), (np.nan, np.nan))
 
     def test_nd_arrays(self):
-        # N-d arrays are OK...
-        x = [[1]]
-        y = [[2]]  # this is fine
-        h, p = stats.kruskal(x, y)
-        assert_equal(h, 1.0)
-        assert_approx_equal(p, stats.distributions.chi2.sf(h, 1))
-
-        # but only one non-singleton dimension is allowed
+        # Inputs must be exactly one-dimensional
+        x = [1]
+        y = [2]
         z = np.random.rand(2, 2)
-        with assert_raises(ValueError, match="Samples may not have more"):
+        with assert_raises(ValueError, match="Samples must be one-dimensional."):
             stats.kruskal(x, y, z)
 
     def test_kruskal_result_attributes(self):


### PR DESCRIPTION
#### Reference issue
Closes gh-9981

#### What does this implement/fix?
`scipy.stats.kruskal` only works on 1D arrays (and scalars), but this isn't documented, and no error is raised if this condition is not met. This PR adds a check that the samples have no more than 1 non-singleton dimension