### PR TITLE
DOC: stats: fix MGF of arcsine and entropy of t in tutorial

### DIFF
--- a/doc/source/tutorial/stats/continuous_arcsine.rst
+++ b/doc/source/tutorial/stats/continuous_arcsine.rst
@@ -39,6 +39,6 @@ References
 
 - Norman Johnson, Samuel Kotz, and N. Balakrishnan, Continuous Univariate Distributions, second edition, Volumes I and II, Wiley & Sons, 1994.
 
-.. - "Arcsine Distribution", Wikipedia, https://en.wikipedia.org/wiki/Arcsine_distribution
+- "Arcsine Distribution", Wikipedia, https://en.wikipedia.org/wiki/Arcsine_distribution
 
 Implementation: `scipy.stats.arcsine`

--- a/doc/source/tutorial/stats/continuous_arcsine.rst
+++ b/doc/source/tutorial/stats/continuous_arcsine.rst
@@ -4,7 +4,7 @@
 Arcsine Distribution
 ====================
 
-Defined over :math:`x\in\left[0,1\right]`.  To get the definition in [1], substitute :math:`x=\frac{u+1}{2}.` i.e. :math:`L=-1` and :math:`S=2.`
+Defined over :math:`x\in\left[0,1\right]`.  To get the definition presented in Johnson, Kotz, and Balakrishnan, substitute :math:`x=\frac{u+1}{2}.` i.e. :math:`L=-1` and :math:`S=2.`
 
 .. math::
    :nowrap:
@@ -37,8 +37,8 @@ Defined over :math:`x\in\left[0,1\right]`.  To get the definition in [1], substi
 References
 ----------
 
-.. [1] Norman Johnson, Samuel Kotz, and N. Balakrishnan, Continuous Univariate Distributions, second edition, Volumes I and II, Wiley & Sons, 1994.
+- Norman Johnson, Samuel Kotz, and N. Balakrishnan, Continuous Univariate Distributions, second edition, Volumes I and II, Wiley & Sons, 1994.
 
-.. [2] "Arcsine Distribution", Wikipedia, https://en.wikipedia.org/wiki/Student%27s_t-distribution
+.. - "Arcsine Distribution", Wikipedia, https://en.wikipedia.org/wiki/Arcsine_distribution
 
 Implementation: `scipy.stats.arcsine`

--- a/doc/source/tutorial/stats/continuous_arcsine.rst
+++ b/doc/source/tutorial/stats/continuous_arcsine.rst
@@ -4,7 +4,7 @@
 Arcsine Distribution
 ====================
 
-Defined over :math:`x\in\left[0,1\right]`.  To get the JKB definition put :math:`x=\frac{u+1}{2}.` i.e. :math:`L=-1` and :math:`S=2.`
+Defined over :math:`x\in\left[0,1\right]`.  To get the definition in [1], substitute :math:`x=\frac{u+1}{2}.` i.e. :math:`L=-1` and :math:`S=2.`
 
 .. math::
    :nowrap:
@@ -13,7 +13,7 @@ Defined over :math:`x\in\left[0,1\right]`.  To get the JKB definition put :math:
 
 .. math::
 
-     M\left(t\right)=E^{t/2}I_{0}\left(\frac{t}{2}\right)
+     M\left(t\right)=1 + \sum_{k=1}^\infty \left( \prod_{r=0}^{k-1} \frac{2r + 1}{2r+2} \right) \frac{t^k}{k!}
 
 .. math::
    :nowrap:
@@ -33,5 +33,12 @@ Defined over :math:`x\in\left[0,1\right]`.  To get the JKB definition put :math:
 .. math::
 
      l_{\mathbf{x}}\left(\cdot\right)=N\log\pi+\frac{N}{2}\overline{\log\mathbf{x}}+\frac{N}{2}\overline{\log\left(1-\mathbf{x}\right)}
+
+References
+----------
+
+.. [1] Norman Johnson, Samuel Kotz, and N. Balakrishnan, Continuous Univariate Distributions, second edition, Volumes I and II, Wiley & Sons, 1994.
+
+.. [2] "Arcsine Distribution", Wikipedia, https://en.wikipedia.org/wiki/Student%27s_t-distribution
 
 Implementation: `scipy.stats.arcsine`

--- a/doc/source/tutorial/stats/continuous_t.rst
+++ b/doc/source/tutorial/stats/continuous_t.rst
@@ -42,6 +42,6 @@ As :math:`\nu\rightarrow\infty,` this distribution approaches the standard norma
 References
 ----------
 
-.. - "Student's t-distribution", Wikipedia, https://en.wikipedia.org/wiki/Student%27s_t-distribution
+- "Student's t-distribution", Wikipedia, https://en.wikipedia.org/wiki/Student%27s_t-distribution
 
 Implementation: `scipy.stats.t`

--- a/doc/source/tutorial/stats/continuous_t.rst
+++ b/doc/source/tutorial/stats/continuous_t.rst
@@ -39,6 +39,9 @@ As :math:`\nu\rightarrow\infty,` this distribution approaches the standard norma
 
      h\left[X\right]=\frac{\nu+1}{2} \left[\psi \left(\frac{1+\nu}{2} \right) -\psi \left(\frac{\nu}{2} \right) \right] + \ln \left[ \sqrt{\nu} B \left( \frac{\nu}{2}, \frac{1}{2} \right) \right]
 
+where :math:`\psi(x)` is the digamma function and :math:`B(x, y)` is the
+beta function.
+
 References
 ----------
 

--- a/doc/source/tutorial/stats/continuous_t.rst
+++ b/doc/source/tutorial/stats/continuous_t.rst
@@ -42,6 +42,6 @@ As :math:`\nu\rightarrow\infty,` this distribution approaches the standard norma
 References
 ----------
 
-.. [1] "Student's t-distribution", Wikipedia, https://en.wikipedia.org/wiki/Student%27s_t-distribution
+.. - "Student's t-distribution", Wikipedia, https://en.wikipedia.org/wiki/Student%27s_t-distribution
 
 Implementation: `scipy.stats.t`

--- a/doc/source/tutorial/stats/continuous_t.rst
+++ b/doc/source/tutorial/stats/continuous_t.rst
@@ -37,12 +37,11 @@ As :math:`\nu\rightarrow\infty,` this distribution approaches the standard norma
 
 .. math::
 
-     h\left[X\right]=\frac{1}{4}\log\left(\frac{\pi c\Gamma^{2}\left(\frac{c}{2}\right)}{\Gamma^{2}\left(\frac{c+1}{2}\right)}\right)-\frac{\left(c+1\right)}{4}\left[\Psi\left(\frac{c}{2}\right)-cZ\left(c\right)+\pi\tan\left(\frac{\pi c}{2}\right)+\gamma+2\log2\right]
+     h\left[X\right]=\frac{\nu+1}{2} \left[\psi \left(\frac{1+\nu}{2} \right) -\psi \left(\frac{\nu}{2} \right) \right] + \ln \left[ \sqrt{\nu} B \left( \frac{\nu}{2}, \frac{1}{2} \right) \right]
 
-where
+References
+----------
 
-.. math::
-
-     Z\left(c\right)=\,_{3}F_{2}\left(1,1,1+\frac{c}{2};\frac{3}{2},2;1\right)=\sum_{k=0}^{\infty}\frac{k!}{k+1}\frac{\Gamma\left(\frac{c}{2}+1+k\right)}{\Gamma\left(\frac{c}{2}+1\right)}\frac{\Gamma\left(\frac{3}{2}\right)}{\Gamma\left(\frac{3}{2}+k\right)}
+.. [1] "Student's t-distribution", Wikipedia, https://en.wikipedia.org/wiki/Student%27s_t-distribution
 
 Implementation: `scipy.stats.t`


### PR DESCRIPTION
#### Reference issue
Closes gh-7542

#### What does this implement/fix?
@pvanmulbregt mentioned in gh-7542 that the MGF of the arcsine distribution and the entropy of Student's t-distribution were not clear. The suggestion from @rgommers was to replace the definitions with those from Wikipedia. This PR does that.