### PR TITLE
MAINT: signal: force LTI state-space matrices to have inexact type

### DIFF
--- a/scipy/signal/lti_conversion.py
+++ b/scipy/signal/lti_conversion.py
@@ -146,6 +146,12 @@ def _restore(M, shape):
         return M
 
 
+def _inexact(m):
+    if not np.issubdtype(m.dtype, np.inexact):
+        m = m.astype(np.float_)
+    return m
+
+
 def abcd_normalize(A=None, B=None, C=None, D=None):
     """Check state-space matrices and ensure they are 2-D.
 
@@ -163,7 +169,7 @@ def abcd_normalize(A=None, B=None, C=None, D=None):
     Returns
     -------
     A, B, C, D : array
-        Properly shaped state-space matrices.
+        Properly shaped state-space matrices, with np.inexact dtypes.
 
     Raises
     ------
@@ -189,6 +195,8 @@ def abcd_normalize(A=None, B=None, C=None, D=None):
     B = _restore(B, (p, q))
     C = _restore(C, (r, p))
     D = _restore(D, (r, q))
+
+    A, B, C, D = map(_inexact, (A, B, C, D))
 
     return A, B, C, D
 

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -174,10 +174,10 @@ class lti(LinearTimeInvariant):
 
     >>> signal.lti(1, 2, 3, 4)
     StateSpaceContinuous(
-    array([[1]]),
-    array([[2]]),
-    array([[3]]),
-    array([[4]]),
+    array([[1.]]),
+    array([[2.]]),
+    array([[3.]]),
+    array([[4.]]),
     dt: None
     )
 
@@ -342,19 +342,19 @@ class dlti(LinearTimeInvariant):
 
     >>> signal.dlti(1, 2, 3, 4)
     StateSpaceDiscrete(
-    array([[1]]),
-    array([[2]]),
-    array([[3]]),
-    array([[4]]),
+    array([[1.]]),
+    array([[2.]]),
+    array([[3.]]),
+    array([[4.]]),
     dt: True
     )
 
     >>> signal.dlti(1, 2, 3, 4, dt=0.1)
     StateSpaceDiscrete(
-    array([[1]]),
-    array([[2]]),
-    array([[3]]),
-    array([[4]]),
+    array([[1.]]),
+    array([[2.]]),
+    array([[3.]]),
+    array([[4.]]),
     dt: 0.1
     )
 
@@ -1254,12 +1254,12 @@ class StateSpace(LinearTimeInvariant):
     >>> sys = signal.StateSpace(a, b, c, d)
     >>> print(sys)
     StateSpaceContinuous(
-    array([[0, 1],
-           [0, 0]]),
-    array([[0],
-           [1]]),
-    array([[1, 0]]),
-    array([[0]]),
+    array([[0., 1.],
+           [0., 0.]]),
+    array([[0.],
+           [1.]]),
+    array([[1., 0.]]),
+    array([[0.]]),
     dt: None
     )
 
@@ -1269,8 +1269,8 @@ class StateSpace(LinearTimeInvariant):
            [0. , 1. ]]),
     array([[0.005],
            [0.1  ]]),
-    array([[1, 0]]),
-    array([[0]]),
+    array([[1., 0.]]),
+    array([[0.]]),
     dt: 0.1
     )
 
@@ -1283,8 +1283,8 @@ class StateSpace(LinearTimeInvariant):
            [0. , 1. ]]),
     array([[0.005],
            [0.1  ]]),
-    array([[1, 0]]),
-    array([[0]]),
+    array([[1., 0.]]),
+    array([[0.]]),
     dt: 0.1
     )
 

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -1091,6 +1091,15 @@ class Test_abcd_normalize(object):
     def test_missing_CD_fails(self):
         assert_raises(ValueError, abcd_normalize, A=self.A, B=self.B)
 
+    def test_int_becomes_float(self):
+        # regression test for gh-13125
+        ABCD = [np.atleast_2d(m) for m in (1, 2, 3, 4)]
+        A, B, C, D = abcd_normalize(*ABCD)
+        assert_(np.issubdtype(A.dtype, np.inexact))
+        assert_(np.issubdtype(B.dtype, np.inexact))
+        assert_(np.issubdtype(C.dtype, np.inexact))
+        assert_(np.issubdtype(D.dtype, np.inexact))
+
 
 class Test_bode(object):
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes gh-13125.

#### What does this implement/fix?
Forces LTI state space arrays A, B, C, and D to have inexact type.

Previously, when matrices were all of integer-type, step, lsim, etc. gave unexpected results.

This will restrict StateSpace to float32, float64, complex64, and complex128 types. So, a possible objection to the change is that it would previously have allowed more general types for ABCD, but I don't know if this is intended or required.
