### PR TITLE
BENCH: Refactor stats.Distribution to easily add new distributions

### DIFF
--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -68,8 +68,9 @@ class DistributionsAll(Benchmark):
                 'stats_m', 'stats_k', 'stats_mvsk', 'entropy']
     ]
     dist_data = dict(distcont + distdiscrete)
-    # maintain previous benchmarks' values
-    custom_input = {'gamma': [5], 'beta': [5, 3]}
+    # custom shape values can be provided for any distribution in the format
+    # `dist_name`: [shape1, shape2, ...]
+    custom_input = {}
 
     # these are the distributions that are the slowest
     slow_dists = ['nct', 'ncx2', 'argus', 'cosine', 'foldnorm', 'gausshyper',

--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -73,8 +73,20 @@ class Distribution(Benchmark):
     # maintain previous benchmarks' values
     custom_input = {'gamma': [5], 'beta': [5, 3]}
 
+    # these distributions are the slowest quartile and are only run if is_xslow
+    # is set
+    slow_dists = ['alpha', 'argus', 'cosine', 'exponnorm', 'exponweib',
+                  'f', 'foldcauchy', 'foldnorm', 'genlogistic', 'genexpon',
+                  'gausshyper', 'gumbel_r', 'halfgennorm', 'invgauss',
+                  'johnsonsu', 'kappa4', 'ksone', 'kstwo', 'levy_stable',
+                  'lognorm', 'ncx2', 'nct', 'pearson3', 'powerlognorm',
+                  'powernorm', 'recipinvgauss', 'vonmises',
+                  'vonmises_line', 'wald']
+
     def setup(self, distribution, properties):
-        if not is_xslow():
+
+        if not is_xslow() and (distribution in self.slow_dists or
+                               properties in self.slow_methods):
             raise NotImplementedError("Skipped")
 
         self.dist = getattr(stats, distribution)

--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -58,7 +58,7 @@ class InferentialStats(Benchmark):
 
 class DistributionsAll(Benchmark):
     # all distributions are in this list. A conversion to a set is used to
-    # remove duplicates that are files under `distcont` and `distdiscrete`.
+    # remove duplicates that are included in both `distcont` and `distdiscrete`.
     dists = sorted(list(set([d[0] for d in distcont + distdiscrete])))
 
     param_names = ['distribution', 'properties']

--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -56,7 +56,7 @@ class InferentialStats(Benchmark):
         stats.ttest_ind(self.a, self.c, equal_var=False)
 
 
-class Distribution(Benchmark):
+class DistributionsAll(Benchmark):
     # all distributions are in this list. A conversion to a set is used to
     # remove duplicates that are files under `distcont` and `distdiscrete`.
     dists = sorted(list(set([d[0] for d in distcont + distdiscrete])))
@@ -142,15 +142,51 @@ class Distribution(Benchmark):
         self.method(*self.args, **self.kwds)
 
 
-class Distribution_old(Benchmark):
-    param_names = ['distribution', 'properties']
-    params = [[], []]
+class Distribution(Benchmark):
+    # though there is a new version of this benchmark that runs all the
+    # distributions, at the time of writing there was odd behavior on
+    # the asv for this benchmark, so it is retained.
+    # https://pv.github.io/scipy-bench/#stats.Distribution.time_distribution
 
-    def setup(self):
-        pass
+    param_names = ['distribution', 'properties']
+    params = [
+        ['cauchy', 'gamma', 'beta'],
+        ['pdf', 'cdf', 'rvs', 'fit']
+    ]
+
+    def setup(self, distribution, properties):
+        np.random.seed(12345678)
+        self.x = np.random.rand(100)
 
     def time_distribution(self, distribution, properties):
-        pass
+        if distribution == 'gamma':
+            if properties == 'pdf':
+                stats.gamma.pdf(self.x, a=5, loc=4, scale=10)
+            elif properties == 'cdf':
+                stats.gamma.cdf(self.x, a=5, loc=4, scale=10)
+            elif properties == 'rvs':
+                stats.gamma.rvs(size=1000, a=5, loc=4, scale=10)
+            elif properties == 'fit':
+                stats.gamma.fit(self.x, loc=4, scale=10)
+        elif distribution == 'cauchy':
+            if properties == 'pdf':
+                stats.cauchy.pdf(self.x, loc=4, scale=10)
+            elif properties == 'cdf':
+                stats.cauchy.cdf(self.x, loc=4, scale=10)
+            elif properties == 'rvs':
+                stats.cauchy.rvs(size=1000, loc=4, scale=10)
+            elif properties == 'fit':
+                stats.cauchy.fit(self.x, loc=4, scale=10)
+        elif distribution == 'beta':
+            if properties == 'pdf':
+                stats.beta.pdf(self.x, a=5, b=3, loc=4, scale=10)
+            elif properties == 'cdf':
+                stats.beta.cdf(self.x, a=5, b=3, loc=4, scale=10)
+            elif properties == 'rvs':
+                stats.beta.rvs(size=1000, a=5, b=3, loc=4, scale=10)
+            elif properties == 'fit':
+                stats.beta.fit(self.x, loc=4, scale=10)
+        self.method(*self.args, **self.kwds)
     # Retain old benchmark results (remove this if changing the benchmark)
     time_distribution.version = "fb22ae5386501008d945783921fe44aef3f82c1dafc40cddfaccaeec38b792b0"
 

--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -57,17 +57,15 @@ class InferentialStats(Benchmark):
 
 
 class Distribution(Benchmark):
-    # add distributions here
-    dists = ([d[0] for d in distcont + distdiscrete] +
-             ['laplace_asymmetric', 'nhypergeom', 'reciprocal',
-             'trapezoid'])
+    # all distributions are in this list. A conversion to a set is used to
+    # remove duplicates that are files under `distcont` and `distdiscrete`.
+    dists = sorted(list(set([d[0] for d in distcont + distdiscrete])))
 
     param_names = ['distribution', 'properties']
     params = [
         dists, ['pdf/pmf', 'logpdf/logpmf', 'cdf', 'logcdf', 'rvs', 'fit',
                 'sf', 'logsf', 'ppf', 'isf', 'moment', 'stats_s', 'stats_v',
-                'stats_m', 'stats_k', 'stats_mvsk', 'entropy', 'median',
-                'mean', 'var', 'std', 'interval', 'expect']
+                'stats_m', 'stats_k', 'stats_mvsk', 'entropy']
     ]
     distcont = dict(distcont + distdiscrete)
     # maintain previous benchmarks' values
@@ -82,6 +80,7 @@ class Distribution(Benchmark):
                   'lognorm', 'ncx2', 'nct', 'pearson3', 'powerlognorm',
                   'powernorm', 'recipinvgauss', 'vonmises',
                   'vonmises_line', 'wald']
+    slow_methods = ['moment']
 
     def setup(self, distribution, properties):
 
@@ -114,20 +113,22 @@ class Distribution(Benchmark):
         elif properties == 'pdf/pmf':
             # picking arbitrary value for this
             self.args = [.99, *args[1:]]
-            properties = 'pmf' if isinstance(self.dist, stats.rv_discrete) else 'pdf' 
+            properties = ('pmf' if isinstance(self.dist, stats.rv_discrete)
+                          else 'pdf')
         elif properties == 'logpdf/logpmf':
-            properties = 'logpmf' if isinstance(self.dist, stats.rv_discrete) else 'logpdf'
+            properties = ('logpmf' if isinstance(self.dist, stats.rv_discrete)
+                          else 'logpdf')
             self.args = args
         elif properties == 'isf':
             self.args = [.99, *args[1:]]
         elif properties == 'moment':
-            self.args = [2, *args[1:]]
+            self.args = [5, *args[1:]]
         elif properties.startswith('stats_'):
             properties = 'stats'
             self.args = args[1:]
             kwds['moments'] = properties[6:]
             self.kwds = kwds
-        elif properties in ['entropy', 'median', 'mean', 'var', 'std']:
+        elif properties in ['entropy']:
             self.args = args[1:]
         elif properties == 'expect':
             self.args = []
@@ -147,6 +148,16 @@ class Distribution(Benchmark):
     def time_distribution(self, distribution, properties):
         self.method(*self.args, **self.kwds)
 
+
+class Distribution_old(Benchmark):
+    param_names = ['distribution', 'properties']
+    params = [[], []]
+
+    def setup(self):
+        pass
+
+    def time_distribution(self, distribution, properties):
+        pass
     # Retain old benchmark results (remove this if changing the benchmark)
     time_distribution.version = "fb22ae5386501008d945783921fe44aef3f82c1dafc40cddfaccaeec38b792b0"
 

--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -58,7 +58,7 @@ class InferentialStats(Benchmark):
 
 class DistributionsAll(Benchmark):
     # all distributions are in this list. A conversion to a set is used to
-    # remove duplicates that are included in both `distcont` and
+    # remove duplicates that appear twince in either `distcont` or
     # `distdiscrete`.
     dists = sorted(list(set([d[0] for d in distcont + distdiscrete])))
 

--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -186,7 +186,6 @@ class Distribution(Benchmark):
                 stats.beta.rvs(size=1000, a=5, b=3, loc=4, scale=10)
             elif properties == 'fit':
                 stats.beta.fit(self.x, loc=4, scale=10)
-        self.method(*self.args, **self.kwds)
     # Retain old benchmark results (remove this if changing the benchmark)
     time_distribution.version = "fb22ae5386501008d945783921fe44aef3f82c1dafc40cddfaccaeec38b792b0"
 

--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -83,14 +83,14 @@ class DistributionsAll(Benchmark):
                   'foldcauchy', 'kstwo', 'levy_stable', 'skewnorm']
     slow_methods = ['moment']
 
-    def setup(self, distribution, method):
-        if not is_xslow() and (distribution in self.slow_dists
+    def setup(self, dist_name, method):
+        if not is_xslow() and (dist_name in self.slow_dists
                                or method in self.slow_methods):
             raise NotImplementedError("Skipped")
 
-        self.dist = getattr(stats, distribution)
+        self.dist = getattr(stats, dist_name)
 
-        dist_shapes = self.dist_data[distribution]
+        dist_shapes = self.dist_data[dist_name]
 
         if isinstance(self.dist, stats.rv_discrete):
             # discrete distributions only use location
@@ -103,7 +103,7 @@ class DistributionsAll(Benchmark):
 
         bounds = self.dist.interval(.99, *dist_shapes, **kwds)
         x = np.linspace(*bounds, 100)
-        args = [x, *self.custom_input.get(distribution, dist_shapes)]
+        args = [x, *self.custom_input.get(dist_name, dist_shapes)]
         self.args = args
         self.kwds = kwds
         if method == 'fit':
@@ -112,10 +112,11 @@ class DistributionsAll(Benchmark):
                 raise NotImplementedError("This attribute is not a member "
                                           "of the distribution")
             # the only positional argument is the data to be fitted
-            self.args = [self.dist.rvs(*dist_shapes, size=100, **kwds)]
+            self.args = [self.dist.rvs(*dist_shapes, size=100, random_state=0, **kwds)]
         elif method == 'rvs':
             # add size keyword argument for data creation
             kwds['size'] = 1000
+            kwds['random_state'] = 0
             # keep shapes as positional arguments, omit linearly spaced data
             self.args = args[1:]
         elif method == 'pdf/pmf':
@@ -138,7 +139,7 @@ class DistributionsAll(Benchmark):
 
         self.method = getattr(self.dist, method)
 
-    def time_distribution(self, distribution, method):
+    def time_distribution(self, dist_name, method):
         self.method(*self.args, **self.kwds)
 
 

--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -59,8 +59,8 @@ class InferentialStats(Benchmark):
 class Distribution(Benchmark):
     # add distributions here
     dists = ([d[0] for d in distcont + distdiscrete] +
-             ['frechet_l', 'frechet_r', 'trapz', 'laplace_asymmetric',
-              'nhypergeom', 'reciprocal', 'trapezoid'])
+             ['laplace_asymmetric', 'nhypergeom', 'reciprocal',
+             'trapezoid'])
 
     param_names = ['distribution', 'properties']
     params = [
@@ -109,7 +109,7 @@ class Distribution(Benchmark):
         elif properties == 'isf':
             self.args = [.99, *args[1:]]
         elif properties == 'moment':
-            self.args = [10, *args[1:]]
+            self.args = [2, *args[1:]]
         elif properties.startswith('stats_'):
             properties = 'stats'
             self.args = args[1:]

--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -128,8 +128,9 @@ class DistributionsAll(Benchmark):
         elif method == 'moment':
             # the first four moments may be optimized, so compute the fifth
             self.args = [5, *args[1:]]
-        elif properties.startswith('stats_'):
-            properties = 'stats'
+        elif method.startswith('stats_'):
+            kwds['moments'] = method[6:]
+            method = 'stats'
             self.args = args[1:]
         elif method == 'entropy':
             self.args = args[1:]

--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -62,9 +62,12 @@ class Distribution(Benchmark):
 
     param_names = ['distribution', 'properties']
     params = [
-        dists, ['pdf', 'cdf', 'rvs', 'fit']
+        dists, ['pdf', 'logpdf', 'cdf', 'logcdf', 'rvs', 'fit', 'sf', 'logsf',
+                'ppf', 'isf', 'moment', 'stats', 'entropy', 'median', 'mean',
+                'var', 'std']
     ]
     distcont = dict(distcont)
+    # maintain previous benchmarks' values
     custom_input = {'gamma': [5], 'beta': [5, 3]}
 
     def setup(self, distribution, properties):
@@ -77,9 +80,22 @@ class Distribution(Benchmark):
         kwds = dict(zip(names, values))
 
         if properties == 'fit':
+            # provide only the data to fit in args
             self.args = args[:1]
         elif properties == 'rvs':
+            # add size for creation of data
             kwds['size'] = 1000
+            self.args = args[1:]
+        elif properties == 'ppf' or properties == 'isf':
+            # picking arbitrary value for this
+            self.args = [.99, *args[1:]]
+        elif properties == 'moment':
+            self.args = [10, *args[1:]]
+        elif properties == 'stats':
+            self.args = args[1:]
+            kwds['moments'] = 'mv'
+            self.kwds = kwds
+        elif properties in ['entropy', 'median', 'mean', 'var', 'std']:
             self.args = args[1:]
         else:
             self.args = [*args]

--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -63,7 +63,7 @@ class Distribution(Benchmark):
     param_names = ['distribution', 'properties']
     params = [
         dists, ['pdf', 'logpdf', 'cdf', 'logcdf', 'rvs', 'fit', 'sf', 'logsf',
-                'ppf', 'isf', 'moment', 'stats', 'entropy', 'median', 'mean',
+                'ppf', 'isf', 'moment', 'stats_s', 'stats_v', 'stats_m', 'stats_k', 'stats_mvsk', 'entropy', 'median', 'mean',
                 'var', 'std', 'interval', 'expect']
     ]
     distcont = dict(distcont)
@@ -71,12 +71,7 @@ class Distribution(Benchmark):
     custom_input = {'gamma': [5], 'beta': [5, 3]}
 
     def setup(self, distribution, properties):
-        try: 
-            self.dist = getattr(stats, distribution)
-            self.method = getattr(self.dist, properties)
-        except AttributeError as e:
-            raise NotImplementedError("This attribute is not a member "
-                                      "of the distribution")
+        self.dist = getattr(stats, distribution)
       
         shapes = self.distcont[distribution]
 
@@ -103,9 +98,10 @@ class Distribution(Benchmark):
             self.args = [.99, *args[1:]]
         elif properties == 'moment':
             self.args = [10, *args[1:]]
-        elif properties == 'stats':
+        elif properties.startswith('stats_'):
+            properties = 'stats'
             self.args = args[1:]
-            kwds['moments'] = 'mv'
+            kwds['moments'] =  properties[6:]
             self.kwds = kwds
         elif properties in ['entropy', 'median', 'mean', 'var', 'std']:
             self.args = args[1:]
@@ -117,6 +113,12 @@ class Distribution(Benchmark):
         else:
             self.args = [*args]
         self.kwds = kwds
+    
+        try:
+            self.method = getattr(self.dist, properties)
+        except AttributeError as e:
+            raise NotImplementedError("This attribute is not a member "
+                                      "of the distribution")
 
     def time_distribution(self, distribution, properties):
         self.method(*self.args, **self.kwds)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

As mentioned in https://github.com/mdhaber/scipy/pull/48#issuecomment-743958760, it is hard to test the speed of new distributions in the stats.Distribution benchmark.

#### What does this implement/fix?
<!--Please explain your changes.-->
The goal of this PR is to make it so that all you need to do is add the name of the distribution and then it will be tested. 
#### Additional information
<!--Any additional information you think is important.-->
Example:

At present: 
<img width="685" alt="Screen Shot 2020-12-13 at 1 38 11 AM" src="https://user-images.githubusercontent.com/44255917/102008220-de509d80-3ce3-11eb-9eeb-89f82cbd928b.png">

Try adding a distribution with no shapes and one with shapes:


<img width="450" alt="Screen Shot 2020-12-13 at 1 39 10 AM" src="https://user-images.githubusercontent.com/44255917/102008242-00e2b680-3ce4-11eb-951a-5ce0d7dbabf2.png">

<img width="625" alt="Screen Shot 2020-12-13 at 1 40 36 AM" src="https://user-images.githubusercontent.com/44255917/102008283-34254580-3ce4-11eb-9c82-bd199205cf72.png">