### PR TITLE
BUG: stats: fix wrong shape output of burr and fisk distributions

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -940,6 +940,7 @@ class burr_gen(rv_continuous):
         return (q**(-1.0/d) - 1)**(-1.0/c)
 
     def _stats(self, c, d):
+        c, d = np.broadcast_arrays(c, d)
         nc = np.arange(1, 5).reshape(4,1) / c
         #ek is the kth raw moment, e1 is the mean e2-e1**2 variance etc.
         e1, e2, e3, e4 = sc.beta(d + nc, 1. - nc) * d
@@ -957,6 +958,8 @@ class burr_gen(rv_continuous):
             lambda c, e1, e2, e3, e4, mu2_if_c: (
                 ((e4 - 4*e3*e1 + 6*e2*e1**2 - 3*e1**4) / mu2_if_c**2) - 3),
             fillvalue=np.nan)
+        if c.ndim == 0:
+            return mu.item(), mu2.item(), g1.item(), g2.item()
         return mu, mu2, g1, g2
 
     def _munp(self, n, c, d):

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -940,7 +940,6 @@ class burr_gen(rv_continuous):
         return (q**(-1.0/d) - 1)**(-1.0/c)
 
     def _stats(self, c, d):
-        c, d = np.broadcast_arrays(c, d)
         nc = np.arange(1, 5).reshape(4,1) / c
         #ek is the kth raw moment, e1 is the mean e2-e1**2 variance etc.
         e1, e2, e3, e4 = sc.beta(d + nc, 1. - nc) * d
@@ -958,7 +957,7 @@ class burr_gen(rv_continuous):
             lambda c, e1, e2, e3, e4, mu2_if_c: (
                 ((e4 - 4*e3*e1 + 6*e2*e1**2 - 3*e1**4) / mu2_if_c**2) - 3),
             fillvalue=np.nan)
-        if c.ndim == 0:
+        if np.ndim(c) == 0:
             return mu.item(), mu2.item(), g1.item(), g2.item()
         return mu, mu2, g1, g2
 

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -654,3 +654,11 @@ def test_methods_with_lists(method, distname, args):
     npt.assert_allclose(result,
                         [f(*v) for v in zip(x, *shape2, loc, scale)],
                         rtol=1e-14, atol=5e-14)
+
+
+def test_burr_fisk_moment_gh13234_regression():
+    vals0 = stats.burr.moment(1, 5, 4)
+    npt.assert_(isinstance(vals0, float))
+
+    vals1 = stats.fisk.moment(1, 8)
+    npt.assert_(isinstance(vals1, float))

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -658,7 +658,7 @@ def test_methods_with_lists(method, distname, args):
 
 def test_burr_fisk_moment_gh13234_regression():
     vals0 = stats.burr.moment(1, 5, 4)
-    npt.assert_(isinstance(vals0, float))
+    assert isinstance(vals0, float)
 
     vals1 = stats.fisk.moment(1, 8)
-    npt.assert_(isinstance(vals1, float))
+    assert isinstance(vals1, float)


### PR DESCRIPTION
#### Reference issue

closes gh-13234

#### What does this implement/fix?

As described in gh-13234, 'burr' and 'fisk' distributions returned a bad shaped array when scalar arguments were passed to the 'moment' method leading to an API inconsistency. This was because the call to '_stats' method from the 'moment' method when n<5 and n>1 returned a bad shaped array. The '_stats' method (in 'burr' distribution) has been fixed to return floating points when scalar arguments are passed. Regression tests for it have also been added.

#### Additional information

Maybe wait for gh-12197 that adds support for array arguments in the `moment` method. I think this fix should work with array arguments too (but there may be edge cases I haven't considered). I hope my approach isn't contentious!