### PR TITLE
MAINT: add tests of trivial cost matrices for linear sum assignment

### DIFF
--- a/scipy/optimize/tests/test_linear_assignment.py
+++ b/scipy/optimize/tests/test_linear_assignment.py
@@ -52,6 +52,14 @@ def test_constant_cost_matrix():
     assert_array_equal(col_ind, np.arange(n))
 
 
+@pytest.mark.parametrize('num_rows,num_cols', [(0, 0), (2, 0), (0, 3)])
+def test_linear_sum_assignment_trivial_cost(num_rows, num_cols):
+    C = np.empty(shape=(num_cols, num_rows))
+    row_ind, col_ind = linear_sum_assignment(C)
+    assert len(row_ind) == 0
+    assert len(col_ind) == 0
+
+
 @pytest.mark.parametrize('sign,test_case', linear_sum_assignment_test_cases)
 def test_linear_sum_assignment_small_inputs(sign, test_case):
     linear_sum_assignment_assertions(


### PR DESCRIPTION
Similar tests used to be part of the general test that the method finds the expected results, but as pointed out by @rgommers in [this comment](https://github.com/scipy/scipy/pull/13175#issuecomment-743987172), those tests disappeared during an earlier refactoring, which aimed to reduce duplication between these tests and those of `min_weight_full_bipartite_matching`. Here, we reintroduce the tests that went missing.

Note that the tests naturally looks like the one for `min_weight_full_bipartite_matching` but due to the difference in how `np.array` and `csr_matrix` handles indexing, bundling the two tests together in `linear_sum_assignment_assertions` is somewhat impractical.