### PR TITLE
Handle cval correctly for ndimage functions with complex-valued inputs

### DIFF
--- a/scipy/ndimage/interpolation.py
+++ b/scipy/ndimage/interpolation.py
@@ -329,12 +329,14 @@ def geometric_transform(input, mapping, output_shape=None,
     output = _ni_support._get_output(output, input, shape=output_shape,
                                      complex_output=complex_output)
     if complex_output:
-        kwargs = dict(order=order, mode=mode, cval=cval, prefilter=prefilter,
+        kwargs = dict(order=order, mode=mode, prefilter=prefilter,
                       output_shape=output_shape,
                       extra_arguments=extra_arguments,
                       extra_keywords=extra_keywords)
-        geometric_transform(input.real, mapping, output=output.real, **kwargs)
-        geometric_transform(input.imag, mapping, output=output.imag, **kwargs)
+        geometric_transform(input.real, mapping, output=output.real,
+                            cval=numpy.real(cval), **kwargs)
+        geometric_transform(input.imag, mapping, output=output.imag,
+                            cval=numpy.imag(cval), **kwargs)
         return output
 
     if prefilter and order > 1:
@@ -437,9 +439,11 @@ def map_coordinates(input, coordinates, output=None, order=3,
     output = _ni_support._get_output(output, input, shape=output_shape,
                                      complex_output=complex_output)
     if complex_output:
-        kwargs = dict(order=order, mode=mode, cval=cval, prefilter=prefilter)
-        map_coordinates(input.real, coordinates, output=output.real, **kwargs)
-        map_coordinates(input.imag, coordinates, output=output.imag, **kwargs)
+        kwargs = dict(order=order, mode=mode, prefilter=prefilter)
+        map_coordinates(input.real, coordinates, output=output.real,
+                        cval=numpy.real(cval), **kwargs)
+        map_coordinates(input.imag, coordinates, output=output.imag,
+                        cval=numpy.imag(cval), **kwargs)
         return output
     if prefilter and order > 1:
         padded, npad = _prepad_for_spline_filter(input, mode, cval)
@@ -554,9 +558,11 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None,
                                      complex_output=complex_output)
     if complex_output:
         kwargs = dict(offset=offset, output_shape=output_shape, order=order,
-                      mode=mode, cval=cval, prefilter=prefilter)
-        affine_transform(input.real, matrix, output=output.real, **kwargs)
-        affine_transform(input.imag, matrix, output=output.imag, **kwargs)
+                      mode=mode, prefilter=prefilter)
+        affine_transform(input.real, matrix, output=output.real,
+                         cval=numpy.real(cval), **kwargs)
+        affine_transform(input.imag, matrix, output=output.imag,
+                         cval=numpy.imag(cval), **kwargs)
         return output
     if prefilter and order > 1:
         padded, npad = _prepad_for_spline_filter(input, mode, cval)
@@ -658,9 +664,11 @@ def shift(input, shift, output=None, order=3, mode='constant', cval=0.0,
         # import under different name to avoid confusion with shift parameter
         from scipy.ndimage.interpolation import shift as _shift
 
-        kwargs = dict(order=order, mode=mode, cval=cval, prefilter=prefilter)
-        _shift(input.real, shift, output=output.real, **kwargs)
-        _shift(input.imag, shift, output=output.imag, **kwargs)
+        kwargs = dict(order=order, mode=mode, prefilter=prefilter)
+        _shift(input.real, shift, output=output.real, cval=numpy.real(cval),
+               **kwargs)
+        _shift(input.imag, shift, output=output.imag, cval=numpy.imag(cval),
+               **kwargs)
         return output
     if prefilter and order > 1:
         padded, npad = _prepad_for_spline_filter(input, mode, cval)
@@ -766,9 +774,11 @@ def zoom(input, zoom, output=None, order=3, mode='constant', cval=0.0,
         # import under different name to avoid confusion with zoom parameter
         from scipy.ndimage.interpolation import zoom as _zoom
 
-        kwargs = dict(order=order, mode=mode, cval=cval, prefilter=prefilter)
-        _zoom(input.real, zoom, output=output.real, **kwargs)
-        _zoom(input.imag, zoom, output=output.imag, **kwargs)
+        kwargs = dict(order=order, mode=mode, prefilter=prefilter)
+        _zoom(input.real, zoom, output=output.real, cval=numpy.real(cval),
+              **kwargs)
+        _zoom(input.imag, zoom, output=output.imag, cval=numpy.imag(cval),
+              **kwargs)
         return output
     if prefilter and order > 1:
         padded, npad = _prepad_for_spline_filter(input, mode, cval)

--- a/scipy/ndimage/src/ni_support.c
+++ b/scipy/ndimage/src/ni_support.c
@@ -310,6 +310,7 @@ int NI_ExtendLine(double *buffer, npy_intp line_length,
             break;
         /* kkkkkkkk|abcd]kkkkkkkk */
         case NI_EXTEND_CONSTANT:
+        case NI_EXTEND_GRID_CONSTANT:
             val = extend_value;
             dst = buffer;
             while (size_before--) {
@@ -670,6 +671,7 @@ int NI_InitFilterOffsets(PyArrayObject *array, npy_bool *footprint,
                         }
                         break;
                     case NI_EXTEND_CONSTANT:
+                    case NI_EXTEND_GRID_CONSTANT:
                         if (cc < 0 || cc >= len)
                             cc = *border_flag_value;
                         break;

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -20,7 +20,8 @@ def sumsq(a, b):
     return math.sqrt(((a - b)**2).sum())
 
 
-def _complex_correlate(array, kernel, real_dtype, convolve=False):
+def _complex_correlate(array, kernel, real_dtype, convolve=False,
+                       mode="reflect", cval=0, ):
     """Utility to perform a reference complex-valued convolutions.
 
     When convolve==False, correlation is performed instead
@@ -36,40 +37,54 @@ def _complex_correlate(array, kernel, real_dtype, convolve=False):
     if not convolve:
         kernel = kernel.conj()
     if complex_array and complex_kernel:
+        # use: real(cval) for array.real component
+        #      imag(cval) for array.imag component
         output = (
-            func(array.real, kernel.real, output=real_dtype) -
-            func(array.imag, kernel.imag, output=real_dtype) +
-            1j * func(array.imag, kernel.real, output=real_dtype) +
-            1j * func(array.real, kernel.imag, output=real_dtype)
+            func(array.real, kernel.real, output=real_dtype,
+                 mode=mode, cval=numpy.real(cval)) -
+            func(array.imag, kernel.imag, output=real_dtype,
+                 mode=mode, cval=numpy.imag(cval)) +
+            1j * func(array.imag, kernel.real, output=real_dtype,
+                      mode=mode, cval=numpy.imag(cval)) +
+            1j * func(array.real, kernel.imag, output=real_dtype,
+                      mode=mode, cval=numpy.real(cval))
         )
     elif complex_array:
         output = (
-            func(array.real, kernel, output=real_dtype) +
-            1j * func(array.imag, kernel, output=real_dtype)
+            func(array.real, kernel, output=real_dtype, mode=mode,
+                 cval=numpy.real(cval)) +
+            1j * func(array.imag, kernel, output=real_dtype, mode=mode,
+                      cval=numpy.imag(cval))
         )
     elif complex_kernel:
+        # real array so cval is real too
         output = (
-            func(array, kernel.real, output=real_dtype) +
-            1j * func(array, kernel.imag, output=real_dtype)
+            func(array, kernel.real, output=real_dtype, mode=mode, cval=cval) +
+            1j * func(array, kernel.imag, output=real_dtype, mode=mode,
+                      cval=cval)
         )
     return output
 
 
 class TestNdimageFilters:
 
-    def _validate_complex(self, array, kernel, type2):
+    def _validate_complex(self, array, kernel, type2, mode='reflect', cval=0):
         # utility for validating complex-valued correlations
         real_dtype = numpy.asarray([], dtype=type2).real.dtype
         expected = _complex_correlate(
-            array, kernel, real_dtype, convolve=False
+            array, kernel, real_dtype, convolve=False, mode=mode, cval=cval
         )
 
         if array.ndim == 1:
-            correlate = functools.partial(ndimage.correlate1d, axis=-1)
-            convolve = functools.partial(ndimage.convolve1d, axis=-1)
+            correlate = functools.partial(ndimage.correlate1d, axis=-1,
+                                          mode=mode, cval=cval)
+            convolve = functools.partial(ndimage.convolve1d, axis=-1,
+                                         mode=mode, cval=cval)
         else:
-            correlate = ndimage.correlate
-            convolve = ndimage.convolve
+            correlate = functools.partial(ndimage.correlate, mode=mode,
+                                          cval=cval)
+            convolve = functools.partial(ndimage.convolve, mode=mode,
+                                          cval=cval)
 
         # test correlate output dtype
         output = correlate(array, kernel, output=type2)
@@ -84,7 +99,7 @@ class TestNdimageFilters:
         # test convolve output dtype
         output = convolve(array, kernel, output=type2)
         expected = _complex_correlate(
-            array, kernel, real_dtype, convolve=True
+            array, kernel, real_dtype, convolve=True, mode=mode, cval=cval,
         )
         assert_array_almost_equal(expected, output)
         assert_equal(output.dtype.type, type2)
@@ -502,11 +517,51 @@ class TestNdimageFilters:
     @pytest.mark.parametrize('dtype_kernel', complex_types)
     @pytest.mark.parametrize('dtype_input', types)
     @pytest.mark.parametrize('dtype_output', complex_types)
+    @pytest.mark.parametrize('mode', ['grid-constant', 'constant'])
+    def test_correlate_complex_kernel_cval(self, dtype_input, dtype_kernel,
+                                           dtype_output, mode):
+        # test use of non-zero cval with complex inputs
+        # also verifies that mode 'grid-constant' does not segfault
+        kernel = numpy.array([[1, 0],
+                              [0, 1 + 1j]], dtype_kernel)
+        array = numpy.array([[1, 2, 3],
+                             [4, 5, 6]], dtype_input)
+        self._validate_complex(array, kernel, dtype_output, mode=mode,
+                               cval=5.0)
+
+    @pytest.mark.parametrize('dtype_kernel', complex_types)
+    @pytest.mark.parametrize('dtype_input', types)
+    def test_correlate_complex_kernel_invalid_cval(self, dtype_input,
+                                                   dtype_kernel):
+        # cannot give complex cval with a real image
+        kernel = numpy.array([[1, 0],
+                              [0, 1 + 1j]], dtype_kernel)
+        array = numpy.array([[1, 2, 3],
+                             [4, 5, 6]], dtype_input)
+        for func in [ndimage.convolve, ndimage.correlate, ndimage.convolve1d,
+                     ndimage.correlate1d]:
+            with pytest.raises(ValueError):
+                func(array, kernel, mode='constant', cval=5.0 + 1.0j,
+                     output=numpy.complex64)
+
+    @pytest.mark.parametrize('dtype_kernel', complex_types)
+    @pytest.mark.parametrize('dtype_input', types)
+    @pytest.mark.parametrize('dtype_output', complex_types)
     def test_correlate1d_complex_kernel(self, dtype_input, dtype_kernel,
                                         dtype_output):
         kernel = numpy.array([1, 1 + 1j], dtype_kernel)
         array = numpy.array([1, 2, 3, 4, 5, 6], dtype_input)
         self._validate_complex(array, kernel, dtype_output)
+
+    @pytest.mark.parametrize('dtype_kernel', complex_types)
+    @pytest.mark.parametrize('dtype_input', types)
+    @pytest.mark.parametrize('dtype_output', complex_types)
+    def test_correlate_complex_kernel_cval(self, dtype_input, dtype_kernel,
+                                           dtype_output):
+        kernel = numpy.array([1, 1 + 1j], dtype_kernel)
+        array = numpy.array([1, 2, 3, 4, 5, 6], dtype_input)
+        self._validate_complex(array, kernel, dtype_output, mode='constant',
+                               cval=5.0)
 
     @pytest.mark.parametrize('dtype_kernel', types)
     @pytest.mark.parametrize('dtype_input', complex_types)
@@ -528,6 +583,16 @@ class TestNdimageFilters:
         array = numpy.array([1, 2j, 3, 1 + 4j, 5, 6j], dtype_input)
         self._validate_complex(array, kernel, dtype_output)
 
+    @pytest.mark.parametrize('dtype_kernel', types)
+    @pytest.mark.parametrize('dtype_input', complex_types)
+    @pytest.mark.parametrize('dtype_output', complex_types)
+    def test_correlate1d_complex_input_cval(self, dtype_input, dtype_kernel,
+                                            dtype_output):
+        kernel = numpy.array([1, 0, 1], dtype_kernel)
+        array = numpy.array([1, 2j, 3, 1 + 4j, 5, 6j], dtype_input)
+        self._validate_complex(array, kernel, dtype_output, mode='constant',
+                               cval=5 - 3j)
+
     @pytest.mark.parametrize('dtype', complex_types)
     @pytest.mark.parametrize('dtype_output', complex_types)
     def test_correlate_complex_input_and_kernel(self, dtype, dtype_output):
@@ -539,10 +604,30 @@ class TestNdimageFilters:
 
     @pytest.mark.parametrize('dtype', complex_types)
     @pytest.mark.parametrize('dtype_output', complex_types)
+    def test_correlate_complex_input_and_kernel_cval(self, dtype,
+                                                     dtype_output):
+        kernel = numpy.array([[1, 0],
+                              [0, 1 + 1j]], dtype)
+        array = numpy.array([[1, 2, 3],
+                             [4, 5, 6]], dtype)
+        self._validate_complex(array, kernel, dtype_output, mode='constant',
+                               cval=5.0 + 2.0j)
+
+    @pytest.mark.parametrize('dtype', complex_types)
+    @pytest.mark.parametrize('dtype_output', complex_types)
     def test_correlate1d_complex_input_and_kernel(self, dtype, dtype_output):
         kernel = numpy.array([1, 1 + 1j], dtype)
         array = numpy.array([1, 2j, 3, 1 + 4j, 5, 6j], dtype)
         self._validate_complex(array, kernel, dtype_output)
+
+    @pytest.mark.parametrize('dtype', complex_types)
+    @pytest.mark.parametrize('dtype_output', complex_types)
+    def test_correlate1d_complex_input_and_kernel_cval(self, dtype,
+                                                       dtype_output):
+        kernel = numpy.array([1, 1 + 1j], dtype)
+        array = numpy.array([1, 2j, 3, 1 + 4j, 5, 6j], dtype)
+        self._validate_complex(array, kernel, dtype_output, mode='constant',
+                               cval=5.0 + 2.0j)
 
     def test_gauss01(self):
         input = numpy.array([[1, 2, 3],

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -556,8 +556,8 @@ class TestNdimageFilters:
     @pytest.mark.parametrize('dtype_kernel', complex_types)
     @pytest.mark.parametrize('dtype_input', types)
     @pytest.mark.parametrize('dtype_output', complex_types)
-    def test_correlate_complex_kernel_cval(self, dtype_input, dtype_kernel,
-                                           dtype_output):
+    def test_correlate1d_complex_kernel_cval(self, dtype_input, dtype_kernel,
+                                             dtype_output):
         kernel = numpy.array([1, 1 + 1j], dtype_kernel)
         array = numpy.array([1, 2, 3, 4, 5, 6], dtype_input)
         self._validate_complex(array, kernel, dtype_output, mode='constant',

--- a/scipy/ndimage/tests/test_interpolation.py
+++ b/scipy/ndimage/tests/test_interpolation.py
@@ -941,6 +941,26 @@ class TestNdimageInterpolation:
         assert_array_almost_equal(out, expected)
 
     @pytest.mark.parametrize('order', range(0, 6))
+    @pytest.mark.parametrize('mode', ['constant', 'grid-constant'])
+    @pytest.mark.parametrize('dtype', [numpy.float64, numpy.complex128])
+    def test_shift_with_nonzero_cval(self, order, mode, dtype):
+        data = numpy.array([[1, 1, 1, 1],
+                            [1, 1, 1, 1],
+                            [1, 1, 1, 1]], dtype=dtype)
+
+        expected = numpy.array([[0, 1, 1, 1],
+                                [0, 1, 1, 1],
+                                [0, 1, 1, 1]], dtype=dtype)
+
+        if data.dtype.kind == 'c':
+            data -= 1j * data
+            expected -= 1j * expected
+        cval = 5.0
+        expected[:, 0] = cval  # specific to shift of [0, 1] used below
+        out = ndimage.shift(data, [0, 1], order=order, mode=mode, cval=cval)
+        assert_array_almost_equal(out, expected)
+
+    @pytest.mark.parametrize('order', range(0, 6))
     def test_shift06(self, order):
         data = numpy.array([[4, 1, 3, 2],
                             [7, 6, 8, 5],


### PR DESCRIPTION

#### Reference issue
closes gh-13248 

#### What does this implement/fix?
The fix here is to use the real component of `cval` when filtering the real component of the image and the imaginary component of `cval` when filtering the imaginary component of the image.

There is also a separate fix for a segfault that could occur if the new interpolation mode, 'grid-constant', was passed to one of the ndimage.filters functions. For the filter purposes there are no non-integer locations and so 'grid-constant' and 'constant' are equivalent.

#### Additional information
New tests were added to validate the expected behavior (there were no existing tests for complex inputs with non-zero `cval`)

This fix will need to be backported to the 1.6.x branch