### PR TITLE
BUG,MAINT: Ensure all Pool objects are closed

### DIFF
--- a/scipy/_lib/tests/test__util.py
+++ b/scipy/_lib/tests/test__util.py
@@ -124,8 +124,7 @@ def test_mapwrapper_parallel():
     assert_(excinfo.type is ValueError)
 
     # can also set a PoolWrapper up with a map-like callable instance
-    try:
-        p = Pool(2)
+    with Pool(2) as p:
         q = MapWrapper(p.map)
 
         assert_(q._own_pool is False)
@@ -135,8 +134,6 @@ def test_mapwrapper_parallel():
         # because it didn't create it
         out = p.map(np.sin, in_arg)
         assert_equal(list(out), out_arg)
-    finally:
-        p.close()
 
 
 # get our custom ones and a few from the "import *" cases

--- a/scipy/integrate/_quad_vec.py
+++ b/scipy/integrate/_quad_vec.py
@@ -267,7 +267,6 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, li
     else:
         norm_func = norm_funcs[norm]
 
-    mapwrapper = MapWrapper(workers)
 
     parallel_count = 128
     min_intervals = 2
@@ -341,7 +340,7 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, li
     }
 
     # Process intervals
-    with mapwrapper:
+    with MapWrapper(workers) as mapwrapper:
         ier = NOT_CONVERGED
 
         while intervals and len(intervals) < limit:

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -39,11 +39,8 @@ def dummy_func(x, shape):
 
 
 def sequence_parallel(fs):
-    pool = ThreadPool(len(fs))
-    try:
+    with ThreadPool(len(fs)) as pool:
         return pool.map(lambda f: f(), fs)
-    finally:
-        pool.terminate()
 
 
 # Function and Jacobian for tests of solvers for systems of nonlinear

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -4866,9 +4866,9 @@ def _perm_test(x, y, stat, reps=1000, workers=-1, random_state=None):
                      size=4, dtype=np.uint32)) for _ in range(reps)]
 
     # parallelizes with specified workers over number of reps and set seeds
-    mapwrapper = MapWrapper(workers)
     parallelp = _ParallelP(x=x, y=y, random_states=random_states)
-    null_dist = np.array(list(mapwrapper(parallelp, range(reps))))
+    with MapWrapper(workers) as mapwrapper:
+        null_dist = np.array(list(mapwrapper(parallelp, range(reps))))
 
     # calculate p-value and significant permutation map through list
     pvalue = (null_dist >= stat).sum() / reps


### PR DESCRIPTION
#### Reference issue
I noticed this pytest failure in #13249 due to a `multiprocessing.Pool` object not being closed:
https://dev.azure.com/scipy-org/SciPy/_build/results?buildId=9613&view=logs&j=e177c0b2-361c-5cee-6783-4418e98d3ffa&t=663e3bfe-bbaf-5419-7ee8-d9a433818df8&l=671

#### What does this implement/fix?
The main fix is in the `_perm_test` helper from `stats.multiscale_graphcorr` which uses a `MapWrapper` without closing it. Changing to a `with` statement ensures the pool is closed properly.


I also audited for other cases where `Pool` or `MapWrapper` was being misused. `quad_vec` has a chance of leaking the pool if an exception is thrown between `MapWrapper` creation and the actual `with` statement. Moving construction into the `with` fixes that. I also updated a few benign instances of `try-finally` to use `with` just for readability.

#### Additional information
Before #13161, the unclosed `Pool` warning was being hidden by the `__del__` method closing the pool. So, that PR has helped catch this bug which is nice.