### PR TITLE
BUG: Fix precision issues for constant input in skew and kurtosis

### DIFF
--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -2290,12 +2290,12 @@ def skew(a, axis=0, bias=True):
     n = a.count(axis)
     m2 = moment(a, 2, axis)
     m3 = moment(a, 3, axis)
-    zero = (np.abs(m2) <= (np.finfo(m2.dtype).resolution * a.mean(axis))**2)
+    zero = (m2 <= (np.finfo(m2.dtype).resolution * a.mean(axis))**2)
     with np.errstate(all='ignore'):
         vals = ma.where(zero, 0, m3 / m2**1.5)
 
     if not bias and zero is not ma.masked and m2 is not ma.masked:
-        can_correct = ~zero & (n > 2) & (m2 > 0)
+        can_correct = ~zero & (n > 2)
         if can_correct.any():
             m2 = np.extract(can_correct, m2)
             m3 = np.extract(can_correct, m3)
@@ -2344,13 +2344,13 @@ def kurtosis(a, axis=0, fisher=True, bias=True):
     a, axis = _chk_asarray(a, axis)
     m2 = moment(a, 2, axis)
     m4 = moment(a, 4, axis)
-    zero = (np.abs(m2) <= (np.finfo(m2.dtype).resolution * a.mean(axis))**2)
+    zero = (m2 <= (np.finfo(m2.dtype).resolution * a.mean(axis))**2)
     with np.errstate(all='ignore'):
         vals = ma.where(zero, 0, m4 / m2**2.0)
 
     if not bias and zero is not ma.masked and m2 is not ma.masked:
         n = a.count(axis)
-        can_correct = ~zero & (n > 3) & (m2 > 0)
+        can_correct = ~zero & (n > 3)
         if can_correct.any():
             n = np.extract(can_correct, n)
             m2 = np.extract(can_correct, m2)

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -2290,8 +2290,9 @@ def skew(a, axis=0, bias=True):
     n = a.count(axis)
     m2 = moment(a, 2, axis)
     m3 = moment(a, 3, axis)
+    zero = (np.abs(m2) <= (np.finfo(m2.dtype).resolution * a.mean(axis))**2)
     with np.errstate(all='ignore'):
-        vals = ma.where(m2 == 0, 0, m3 / m2**1.5)
+        vals = ma.where(zero, 0, m3 / m2**1.5)
 
     if not bias:
         can_correct = (n > 2) & (m2 > 0)
@@ -2343,8 +2344,9 @@ def kurtosis(a, axis=0, fisher=True, bias=True):
     a, axis = _chk_asarray(a, axis)
     m2 = moment(a, 2, axis)
     m4 = moment(a, 4, axis)
+    zero = (np.abs(m2) <= (np.finfo(m2.dtype).resolution * a.mean(axis))**2)
     with np.errstate(all='ignore'):
-        vals = ma.where(m2 == 0, 0, m4 / m2**2.0)
+        vals = ma.where(zero, 0, m4 / m2**2.0)
 
     if not bias:
         n = a.count(axis)

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -2294,8 +2294,8 @@ def skew(a, axis=0, bias=True):
     with np.errstate(all='ignore'):
         vals = ma.where(zero, 0, m3 / m2**1.5)
 
-    if not bias:
-        can_correct = (n > 2) & (m2 > 0)
+    if not bias and zero is not ma.masked and m2 is not ma.masked:
+        can_correct = ~zero & (n > 2) & (m2 > 0)
         if can_correct.any():
             m2 = np.extract(can_correct, m2)
             m3 = np.extract(can_correct, m3)
@@ -2348,9 +2348,9 @@ def kurtosis(a, axis=0, fisher=True, bias=True):
     with np.errstate(all='ignore'):
         vals = ma.where(zero, 0, m4 / m2**2.0)
 
-    if not bias:
+    if not bias and zero is not ma.masked and m2 is not ma.masked:
         n = a.count(axis)
-        can_correct = (n > 3) & (m2 is not ma.masked and m2 > 0)
+        can_correct = ~zero & (n > 3) & (m2 > 0)
         if can_correct.any():
             n = np.extract(can_correct, n)
             m2 = np.extract(can_correct, m2)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1229,8 +1229,8 @@ def skew(a, axis=0, bias=True, nan_policy='propagate'):
 
     m2 = moment(a, 2, axis)
     m3 = moment(a, 3, axis)
-    zero = (np.abs(m2) <= (np.finfo(m2.dtype).resolution * a.mean(axis))**2)
     with np.errstate(all='ignore'):
+        zero = (np.abs(m2) <= (np.finfo(m2.dtype).resolution * a.mean(axis))**2)
         vals = np.where(zero, 0, m3 / m2**1.5)
     if not bias:
         can_correct = (n > 2) & (m2 > 0)
@@ -1338,8 +1338,8 @@ def kurtosis(a, axis=0, fisher=True, bias=True, nan_policy='propagate'):
     n = a.shape[axis]
     m2 = moment(a, 2, axis)
     m4 = moment(a, 4, axis)
-    zero = (np.abs(m2) <= (np.finfo(m2.dtype).resolution * a.mean(axis))**2)
     with np.errstate(all='ignore'):
+        zero = (np.abs(m2) <= (np.finfo(m2.dtype).resolution * a.mean(axis))**2)
         vals = np.where(zero, 0, m4 / m2**2.0)
 
     if not bias:

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1230,10 +1230,10 @@ def skew(a, axis=0, bias=True, nan_policy='propagate'):
     m2 = moment(a, 2, axis)
     m3 = moment(a, 3, axis)
     with np.errstate(all='ignore'):
-        zero = (np.abs(m2) <= (np.finfo(m2.dtype).resolution * a.mean(axis))**2)
+        zero = (m2 <= (np.finfo(m2.dtype).resolution * a.mean(axis))**2)
         vals = np.where(zero, 0, m3 / m2**1.5)
     if not bias:
-        can_correct = ~zero & (n > 2) & (m2 > 0)
+        can_correct = ~zero & (n > 2)
         if can_correct.any():
             m2 = np.extract(can_correct, m2)
             m3 = np.extract(can_correct, m3)
@@ -1339,11 +1339,11 @@ def kurtosis(a, axis=0, fisher=True, bias=True, nan_policy='propagate'):
     m2 = moment(a, 2, axis)
     m4 = moment(a, 4, axis)
     with np.errstate(all='ignore'):
-        zero = (np.abs(m2) <= (np.finfo(m2.dtype).resolution * a.mean(axis))**2)
+        zero = (m2 <= (np.finfo(m2.dtype).resolution * a.mean(axis))**2)
         vals = np.where(zero, 0, m4 / m2**2.0)
 
     if not bias:
-        can_correct = ~zero & (n > 3) & (m2 > 0)
+        can_correct = ~zero & (n > 3)
         if can_correct.any():
             m2 = np.extract(can_correct, m2)
             m4 = np.extract(can_correct, m4)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1233,7 +1233,7 @@ def skew(a, axis=0, bias=True, nan_policy='propagate'):
         zero = (np.abs(m2) <= (np.finfo(m2.dtype).resolution * a.mean(axis))**2)
         vals = np.where(zero, 0, m3 / m2**1.5)
     if not bias:
-        can_correct = (n > 2) & (m2 > 0)
+        can_correct = ~zero & (n > 2) & (m2 > 0)
         if can_correct.any():
             m2 = np.extract(can_correct, m2)
             m3 = np.extract(can_correct, m3)
@@ -1343,7 +1343,7 @@ def kurtosis(a, axis=0, fisher=True, bias=True, nan_policy='propagate'):
         vals = np.where(zero, 0, m4 / m2**2.0)
 
     if not bias:
-        can_correct = (n > 3) & (m2 > 0)
+        can_correct = ~zero & (n > 3) & (m2 > 0)
         if can_correct.any():
             m2 = np.extract(can_correct, m2)
             m4 = np.extract(can_correct, m4)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1229,10 +1229,9 @@ def skew(a, axis=0, bias=True, nan_policy='propagate'):
 
     m2 = moment(a, 2, axis)
     m3 = moment(a, 3, axis)
-    zero = (m2 == 0)
-    vals = _lazywhere(~zero, (m2, m3),
-                      lambda m2, m3: m3 / m2**1.5,
-                      0.)
+    zero = (np.abs(m2) <= (np.finfo(m2.dtype).resolution * a.mean(axis))**2)
+    with np.errstate(all='ignore'):
+        vals = np.where(zero, 0, m3 / m2**1.5)
     if not bias:
         can_correct = (n > 2) & (m2 > 0)
         if can_correct.any():
@@ -1339,7 +1338,7 @@ def kurtosis(a, axis=0, fisher=True, bias=True, nan_policy='propagate'):
     n = a.shape[axis]
     m2 = moment(a, 2, axis)
     m4 = moment(a, 4, axis)
-    zero = (m2 == 0)
+    zero = (np.abs(m2) <= (np.finfo(m2.dtype).resolution * a.mean(axis))**2)
     with np.errstate(all='ignore'):
         vals = np.where(zero, 0, m4 / m2**2.0)
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2562,6 +2562,10 @@ class TestMoments(object):
         assert stats.skew(a * float(2**50)) == 0.0
         assert stats.skew(a / float(2**50)) == 0.0
 
+        # similarly, from gh-11086:
+        assert stats.skew([14.3]*7) == 0.0
+        assert stats.skew(1 + np.arange(-3, 4)*1e-16) == 0
+
     def test_kurtosis(self):
         # Scalar test case
         y = stats.kurtosis(self.scalar_testcase)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2554,6 +2554,14 @@ class TestMoments(object):
             s = stats.skew(a, axis=1, nan_policy="propagate")
         np.testing.assert_allclose(s, [0, np.nan], atol=1e-15)
 
+    def test_skew_constant_value(self):
+        # Skewness of a constant input should be zero even when the mean is not
+        # exact (gh-13245)
+        a = np.repeat(-0.27829495, 10)
+        assert stats.skew(a) == 0.0
+        assert stats.skew(a * float(2**50)) == 0.0
+        assert stats.skew(a / float(2**50)) == 0.0
+
     def test_kurtosis(self):
         # Scalar test case
         y = stats.kurtosis(self.scalar_testcase)
@@ -2591,6 +2599,14 @@ class TestMoments(object):
         a[1, 0] = np.nan
         k = stats.kurtosis(a, axis=1, nan_policy="propagate")
         np.testing.assert_allclose(k, [-1.36, np.nan], atol=1e-15)
+
+    def test_kurtosis_constant_value(self):
+        # Kurtosis of a constant input should be zero, even when the mean is not
+        # exact (gh-13245)
+        a = np.repeat(-0.27829495, 10)
+        assert stats.kurtosis(a, fisher=False) == 0.0
+        assert stats.kurtosis(a * float(2**50), fisher=False) == 0.0
+        assert stats.kurtosis(a / float(2**50), fisher=False) == 0.0
 
     def test_moment_accuracy(self):
         # 'moment' must have a small enough error compared to the slower

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2561,6 +2561,7 @@ class TestMoments(object):
         assert stats.skew(a) == 0.0
         assert stats.skew(a * float(2**50)) == 0.0
         assert stats.skew(a / float(2**50)) == 0.0
+        assert stats.skew(a, bias=False) == 0.0
 
         # similarly, from gh-11086:
         assert stats.skew([14.3]*7) == 0.0
@@ -2611,6 +2612,7 @@ class TestMoments(object):
         assert stats.kurtosis(a, fisher=False) == 0.0
         assert stats.kurtosis(a * float(2**50), fisher=False) == 0.0
         assert stats.kurtosis(a / float(2**50), fisher=False) == 0.0
+        assert stats.kurtosis(a, fisher=False, bias=False) == 0.0
 
     def test_moment_accuracy(self):
         # 'moment' must have a small enough error compared to the slower


### PR DESCRIPTION
#### Reference issue
Fixes gh-13245
Fixed gh-11086

#### What does this implement/fix?
`skew`/`kurtosis` has a special case for when the second moment is zero, but in the example input the moment is `3.08e-33`. At the scale of the input this is essentially, but not precisely, zero. So, I expand the zero-handling to cover all cases where the second moment corresponds to a difference less than the resolution of the floating point type.

This handles exact and non-exact equality cases and is also robust against changing the scale of the input since we aren't comparing to a constant value. Of course, that will also zero out some inputs that consist of small perturbations about a constant value, but only at a scale where you'd be running out of precision anyway. For example,

```python
In [5]: np.random.seed(0)
   ...: r = np.random.rand(10)
   ...: res  = 2**np.ceil(np.log2(np.finfo(float).resolution))
   ...: for scale in (1, res * 4, res, res / 4):
   ...:     print(kurtosis(1 + r * scale, fisher=False))
```

On master, this outputs:
```
2.234618824144314
1.8269013128112266
3.2782369146005514
1.2499999999999998
```

but in this PR I get:
```
2.234618824144314
1.8269013128112266
0.0
0.0
```

We see the cases which get zeroed had already lost precision in the most significant digit anyway.
