### PR TITLE
CI: use OpenBLAS 0.3.13

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ cache:
 
 environment:
   global:
-      MINGW_64: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin
+      MINGW_64: C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin
       NUMPY_HEAD: https://github.com/numpy/numpy.git
       NUMPY_BRANCH: master
       APPVEYOR_SAVE_CACHE_ON_ERROR: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -257,9 +257,8 @@ jobs:
       }
     displayName: 'Download / Install OpenBLAS'
   - powershell: |
-      # wheels appear to use mingw64 version 6.3.0, but 6.4.0
-      # is the closest match available from choco package manager
-      choco install -y mingw --forcex86 --force --version=6.4.0
+      # wheels appear to use mingw64 version 8.1.0
+      choco install -y mingw --forcex86 --force --version=8.1.0
     displayName: 'Install 32-bit mingw for 32-bit builds'
     condition: and(succeeded(), eq(variables['BITS'], 32))
   - script: >-

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ pr:
 # the version of OpenBLAS used is currently 0.3.8.dev
 # and should be updated to match scipy-wheels as appropriate
 variables:
-    openblas_version: 0.3.9
+    openblas_version: 0.3.13
     pre_wheels: https://pypi.anaconda.org/scipy-wheels-nightly/simple
     CCACHE_DIR: $(Pipeline.Workspace)/ccache
     SCIPY_AVAILABLE_MEM: 3G

--- a/scipy/linalg/tests/test_interpolative.py
+++ b/scipy/linalg/tests/test_interpolative.py
@@ -88,7 +88,7 @@ class TestInterpolativeDecomposition(object):
         t = time.time() - t0
         B = pymatrixid.reconstruct_matrix_from_id(A[:, idx[:k]], idx, proj)
         _debug_print(fmt % (t, np.allclose(A, B, eps)))
-        assert_(np.allclose(A, B, eps))
+        assert_allclose(A, B, rtol=0., atol=eps)
 
         _debug_print("Calling iddp_aid / idzp_aid ...",)
         t0 = time.time()

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -12,31 +12,11 @@ from urllib.error import HTTPError
 import zipfile
 import tarfile
 
-OPENBLAS_V = 'v0.3.9'
-OPENBLAS_LONG = 'v0.3.9'
+OPENBLAS_V = 'v0.3.13'
+OPENBLAS_LONG = 'v0.3.13'
 BASE_LOC = ''
 ANACONDA = 'https://anaconda.org/multibuild-wheels-staging/openblas-libs'
 ARCHITECTURES = ['', 'windows', 'darwin', 'aarch64', 'x86', 'ppc64le', 's390x']
-sha256_vals = {
-'openblas64_-v0.3.9-macosx_10_9_x86_64-gf_1becaaa.tar.gz':
-'53f606a7da75d390287f1c51b2af7866b8fe7553a26d2474f827daf0e5c8a886',
-'openblas64_-v0.3.9-manylinux1_x86_64.tar.gz':
-'6fe5b1e2a4baa16833724bcc94a80b22e9c99fc1b9a2ddbce4f1f82a8002d906',
-'openblas64_-v0.3.9-win_amd64-gcc_7_1_0.zip':
-'15d24a66c5b22cc7b3120e831658f491c7a063804c33813235044a6f8b56686d',
-'openblas-v0.3.9-macosx_10_9_x86_64-gf_1becaaa.tar.gz': 
-'8221397b9cfb8cb22f3efb7f228ef901e13f9fd89c7d7d0cb7b8a79b0610bf33',
-'openblas-v0.3.9-manylinux1_i686.tar.gz': 
-'31abf8eccb697a320a998ce0f59045edc964602f815d78690c5a23839819261c',
-'openblas-v0.3.9-manylinux1_x86_64.tar.gz':
-'d9c39acbafae9b1daef19c2738ec938109a59e9322f93eb9a3c50869d220deff',
-'openblas-v0.3.9-win32-gcc_7_1_0.zip':
-'69a7dc265e8a8e45b358637d11cb1710ce88c4456634c7ce37d429b1d9bc9aaa',
-'openblas-v0.3.9-win_amd64-gcc_7_1_0.zip': 
-'0cea06f4a2afebaa6255854f73f237802fc6b58eaeb1a8b1c22d87cc399e0d48',
-'openblas-v0.3.9-manylinux2014_aarch64.tar.gz':
-'10d5ef5e9e19af5c199b59a17f43763e0c85ecf13cbc8f2d91e076f7847cdb5e'
-}
 
 IS_32BIT = sys.maxsize < 2**32
 def get_arch():
@@ -74,9 +54,9 @@ def download_openblas(target, arch, ilp64):
         typ = 'tar.gz'
     elif arch == 'windows':
         if IS_32BIT:
-            suffix = 'win32-gcc_7_1_0.zip'
+            suffix = 'win32-gcc_8_1_0.zip'
         else:
-            suffix = 'win_amd64-gcc_7_1_0.zip'
+            suffix = 'win_amd64-gcc_8_1_0.zip'
         filename = f'{ANACONDA}/{OPENBLAS_LONG}/download/openblas{fnsuffix}-{OPENBLAS_LONG}-{suffix}'
         typ = 'zip'
     elif 'x86' in arch:
@@ -97,13 +77,6 @@ def download_openblas(target, arch, ilp64):
             headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.3'}
             req = Request(url=filename, headers=headers)
             fid.write(urlopen(req).read())
-        with open(target, 'rb') as binary_to_check:
-            data = binary_to_check.read()
-            sha256_returned = hashlib.sha256(data).hexdigest()
-            sha256_expected = sha256_vals[os.path.basename(filename)]
-            if sha256_returned != sha256_expected:
-                raise ValueError('sha256 hash mismatch for downloaded OpenBLAS')
-
     except HTTPError as e:
         print(f'Could not download "{filename}"')
         print(f'Error message: {e}')


### PR DESCRIPTION
* bump to latest stable release of OpenBLAS for use
in some CI testing

* remove the `sha256` hash checks, because these have proven
quite impractical to keep updated and NumPy just did the same:
https://github.com/numpy/numpy/pull/18011

* we haven't been able to update to a recent version of OpenBLAS
for some time now because of sensitivity to `ilp64` testing issues,
so we'll see if this finally succeeds..