### PR TITLE
DOC: stats: fix typo in Yeo-Johnson LL function documentation

### DIFF
--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1411,7 +1411,7 @@ def yeojohnson_llf(lmb, data):
 
     .. math::
 
-        llf = N/2 \log(\hat{\sigma}^2) + (\lambda - 1)
+        llf = -N/2 \log(\hat{\sigma}^2) + (\lambda - 1)
               \sum_i \text{ sign }(x_i)\log(|x_i| + 1)
 
     where :math:`\hat{\sigma}^2` is estimated variance of the the Yeo-Johnson
@@ -1482,7 +1482,7 @@ def yeojohnson_llf(lmb, data):
 def yeojohnson_normmax(x, brack=(-2, 2)):
     """
     Compute optimal Yeo-Johnson transform parameter.
-    
+
     Compute optimal Yeo-Johnson transform parameter for input data, using
     maximum likelihood estimation.
 
@@ -2829,7 +2829,7 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=False,
         two sets of measurements.)  Must be one-dimensional.
     zero_method : {"pratt", "wilcox", "zsplit"}, optional
         The following options are available (default is "wilcox"):
-     
+
           * "pratt": Includes zero-differences in the ranking process,
             but drops the ranks of the zeros, see [4]_, (more conservative).
           * "wilcox": Discards all zero-differences, the default.
@@ -2866,8 +2866,8 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=False,
     is that the differences are symmetric, see [2]_.
     The two-sided test has the null hypothesis that the median of the
     differences is zero against the alternative that it is different from
-    zero. The one-sided test has the null hypothesis that the median is 
-    positive against the alternative that it is negative 
+    zero. The one-sided test has the null hypothesis that the median is
+    positive against the alternative that it is negative
     (``alternative == 'less'``), or vice versa (``alternative == 'greater.'``).
 
     To derive the p-value, the exact distribution (``mode == 'exact'``)


### PR DESCRIPTION
#### Reference issue
Closes gh-13272

#### What does this implement/fix?
There is a minus sign missing in the Yeo-Johnson log-likelihood function docstring.
![image](https://user-images.githubusercontent.com/6570539/102723403-7e965b80-42bc-11eb-949b-6fa5d55c89d7.png)

The first term should begin "-N/2" as it is in the code:
```python3
    loglike = -n_samples / 2 * np.log(trans.var(axis=0))
    loglike += (lmb - 1) * (np.sign(data) * np.log(np.abs(data) + 1)).sum(axis=0)
```
