### PR TITLE
ENH: added arithmetic operations methods for lti class in ltisys.py

### DIFF
--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -369,7 +369,7 @@ class lti(LinearTimeInvariant):
         return (-1)*self
     
     def __truediv__(self, other):
-        """ divides two lti/int/float together """
+        """ Divides two lti/int/float together """
         if isinstance(other, (int, float)):
             return lti(
             self.num,  # numerator
@@ -383,7 +383,9 @@ class lti(LinearTimeInvariant):
         ) 
     
     def __rtruediv__(self, other):
-        """ divides two lti/int/float together """
+        """ Divides two lti/int/float together """
+        if type(self) not in (lti, TransferFunctionContinuous):
+                return NotImplemented
         if isinstance(other, (int, float)):
             return lti(
             np.polymul(other, self.to_tf().den),  # numerator

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -290,8 +290,112 @@ class lti(LinearTimeInvariant):
         """
         raise NotImplementedError('to_discrete is not implemented for this '
                                   'system class.')
-
-
+    
+    def __add__(self, other):
+        """ Adds two lti together """
+        if isinstance(other, (int, float)):
+            return lti(
+            np.polyadd(
+                np.polymul(self.num, 1), 
+                np.polymul(self.den, other)),  # numerator
+            np.polymul(self.den, 1)  # denominator
+        ) 
+          
+        elif not isinstance(other, type(self)):
+            raise TypeError(f"{other} is not of type {type(self)}")
+        return lti(
+            np.polyadd(
+                np.polymul(self.num, other.den), 
+                np.polymul(self.den, other.num)),  # numerator
+            np.polymul(self.den, other.den)  # denominator
+        ) 
+    
+    __radd__ = __add__
+    
+    def __mul__(self, other):
+        """ Multiplies two lti together """
+        if isinstance(other, (int, float)):
+            return lti(
+            np.polymul(self.num, other),  # numerator
+            np.polymul(self.den, 1)  # denominator
+        ) 
+        elif not isinstance(other, type(self)):
+            raise TypeError(f"{other} is not of type {type(self)}")
+        return lti(
+                np.polymul(self.num, other.num),  # numerator
+                np.polymul(self.den, other.den)  # denominator
+        )
+    
+    __rmul__ = __mul__
+    
+    def __sub__(self, other):
+        """ Subtracts one lti/int/float from another """
+        if isinstance(other, (int, float)):
+            return lti(
+            np.polysub(
+                self.num, 
+                np.polymul(self.den, other)),  # numerator
+            np.polymul(self.den, 1)  # denominator
+        )
+        elif not isinstance(other, type(self)):
+            raise TypeError(f"{other} must be of type {type(self)}")
+        return lti(
+            np.polysub(
+                np.polymul(self.num, other.den), 
+                np.polymul(self.den, other.num)),  # numerator
+            np.polymul(self.den, other.den)  # denominator
+        )
+    
+    def __rsub__(self, other):
+        """ Subtracts one lti/int/float from another """
+        if isinstance(other, (int, float)):
+            return lti(
+            np.polysub(
+                np.polymul(self.den, other),
+                self.num),  # numerator
+            np.polymul(self.den, 1)  # denominator
+        )
+        elif not isinstance(other, type(self)):
+            raise TypeError(f"{other} must be of type {type(self)}")
+        return lti(
+            np.polysub(
+                np.polymul(self.den, other.num),
+                np.polymul(self.num, other.den)),  # numerator
+            np.polymul(self.den, other.den)  # denominator
+        )
+    
+    def __neg__(self):
+        """ Negates (multiplies by -1 the lti itself """
+        return (-1)*self
+    
+    def __truediv__(self, other):
+        """ divides two lti/int/float together """
+        if isinstance(other, (int, float)):
+            return lti(
+            self.num,  # numerator
+            np.polymul(self.den, other)  # denominator
+        ) 
+        elif not isinstance(other, type(self)):
+            raise TypeError(f"{other} is not of type {type(self)}")
+        return lti(
+                np.polymul(self.num, other.den),  # numerator
+                np.polymul(self.den, other.num)  # denominator
+        ) 
+    
+    def __rtruediv__(self, other):
+        """ divides two lti/int/float together """
+        if isinstance(other, (int, float)):
+            return lti(
+            np.polymul(other, self.den),  # numerator
+            self.num  # denominator
+        )
+        elif not isinstance(other, type(self)):
+            raise TypeError(f"{other} is not of type {type(self)}")
+        return lti(
+                np.polymul(self.num, other.den),  # numerator
+                np.polymul(self.den, other.num)  # denominator
+        )
+    
 class dlti(LinearTimeInvariant):
     """
     Discrete-time linear time invariant system base class.

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -386,8 +386,8 @@ class lti(LinearTimeInvariant):
         """ divides two lti/int/float together """
         if isinstance(other, (int, float)):
             return lti(
-            np.polymul(other, self.den),  # numerator
-            self.num  # denominator
+            np.polymul(other, self.to_tf().den),  # numerator
+            self.to_tf().num  # denominator
         )
         elif not isinstance(other, type(self)):
             raise TypeError(f"{other} is not of type {type(self)}")


### PR DESCRIPTION
Added methods to __lti class__:
\_\_add__
\_\_mul__
\_\_rmul__
\_\_radd__
\_\_sub__
\_\_rsub__
\_\_neg__
\_\_truediv__
\_\_rtruediv__

I noticed that __scipy.signal.lti__ does not directly support operations like __G(s)+G(s)__ or even __2*G(s)__, so I gave some effort to contribute to the community and make our lives easier.

TODO: 
- Extend it to discrete (dlti)
- Check whether there is a zero/pole superposition. If so, try to cancel them ?
- Implement __pow__ (only valid for integers, as in gnu octave)

Thanks, and I hope you like the additions!