### PR TITLE
BUG: stats: fix the cdf method of rv_discrete class

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -3182,8 +3182,8 @@ class rv_discrete(rv_generic):
         cond2 = (k >= _b)
         cond = cond0 & cond1
         output = zeros(shape(cond), 'd')
-        place(output, (1-cond0) + np.isnan(k), self.badvalue)
         place(output, cond2*(cond0 == cond0), 1.0)
+        place(output, (1-cond0) + np.isnan(k), self.badvalue)
 
         if np.any(cond):
             goodargs = argsreduce(cond, *((k,)+args))

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -297,5 +297,5 @@ def test_methods_with_lists(method, distname, args):
 def test_cdf_gh13280_regression(dist, x, args):
     # Test for nan output when shape parameters are invalid
     vals = dist.cdf(x, *args)
-    expected = np.array(x.size*[np.nan])
+    expected = np.nan
     npt.assert_equal(vals, expected)

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -273,11 +273,28 @@ def test_methods_with_lists(method, distname, args):
                         rtol=1e-15, atol=1e-15)
 
 
-def test_cdf_gh13280_regression():
-    vals0 = stats.hypergeom.cdf(np.arange(5), 3, 3, 4)
-    expected0 = np.array(5*[np.nan])
-    npt.assert_equal(vals0, expected0)
-
-    vals1 = stats.nhypergeom.cdf(np.arange(-2, 6), 5, 2, 8)
-    expected1 = np.array(8*[np.nan])
-    npt.assert_equal(vals1, expected1)
+@pytest.mark.parametrize(
+    'dist, x, args',
+    [
+        (stats.hypergeom, np.arange(5), (3, 3, 4)),
+        (stats.nhypergeom, np.arange(-2, 5), (5, 2, 8)),
+        (stats.bernoulli, np.arange(5), (1.5, )),
+        (stats.binom, np.arange(15), (10, 1.5)),
+        (stats.betabinom, np.arange(15), (10, -0.4, -0.5)),
+        (stats.boltzmann, np.arange(5), (-1, 4)),
+        (stats.dlaplace, np.arange(5), (-0.5, )),
+        (stats.geom, np.arange(5), (1.5, )),
+        (stats.logser, np.arange(5), (1.5, )),
+        (stats.nbinom, np.arange(15), (10, 1.5)),
+        (stats.planck, np.arange(5), (-0.5, )),
+        (stats.poisson, np.arange(5), (-0.5, )),
+        (stats.randint, np.arange(5), (5, 2)),
+        (stats.skellam, np.arange(5), (-5, -2)),
+        (stats.zipf, np.arange(5), (-2, )),
+        (stats.yulesimon, np.arange(5), (-2, ))
+    ]
+)
+def test_cdf_gh13280_regression(dist, x, args):
+    vals = dist.cdf(x, *args)
+    expected = np.array(x.size*[np.nan])
+    npt.assert_equal(vals, expected)

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -275,7 +275,7 @@ def test_methods_with_lists(method, distname, args):
 
 @pytest.mark.parametrize(
     'dist, x, args',
-    [
+    [  # In each of the following, at least one shape parameter is invalid
         (stats.hypergeom, np.arange(5), (3, 3, 4)),
         (stats.nhypergeom, np.arange(-2, 5), (5, 2, 8)),
         (stats.bernoulli, np.arange(5), (1.5, )),
@@ -295,6 +295,7 @@ def test_methods_with_lists(method, distname, args):
     ]
 )
 def test_cdf_gh13280_regression(dist, x, args):
+    # Test for nan output when shape parameters are invalid
     vals = dist.cdf(x, *args)
     expected = np.array(x.size*[np.nan])
     npt.assert_equal(vals, expected)

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -275,9 +275,9 @@ def test_methods_with_lists(method, distname, args):
 
 def test_cdf_gh13280_regression():
     vals0 = stats.hypergeom.cdf(np.arange(5), 3, 3, 4)
-    expected0 = np.array(5*[np.nan], dtype='d')
+    expected0 = np.array(5*[np.nan])
     npt.assert_equal(vals0, expected0)
 
     vals1 = stats.nhypergeom.cdf(np.arange(-2, 6), 5, 2, 8)
-    expected1 = np.array(8*[np.nan], dtype='d')
+    expected1 = np.array(8*[np.nan])
     npt.assert_equal(vals1, expected1)

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -271,3 +271,13 @@ def test_methods_with_lists(method, distname, args):
     npt.assert_allclose(result,
                         [dist.pmf(*v) for v in zip(z, *p2, loc)],
                         rtol=1e-15, atol=1e-15)
+
+
+def test_cdf_gh13280_regression():
+    vals0 = stats.hypergeom.cdf(np.arange(5), 3, 3, 4)
+    expected0 = np.array(5*[np.nan], dtype='d')
+    npt.assert_equal(vals0, expected0)
+
+    vals1 = stats.nhypergeom.cdf(np.arange(-2, 6), 5, 2, 8)
+    expected1 = np.array(8*[np.nan], dtype='d')
+    npt.assert_equal(vals1, expected1)


### PR DESCRIPTION
#### Reference issue
closes gh-13280

#### What does this implement/fix?
As described in gh-13280, the cdf method failed for 'hypergeom' and 'nhypergeom' distributions when invalid arguments were passed. The fix is to fill in the 'nan' values for invalid arguments after filling in the '1' values for quantiles greater than the upper bound in the 'cdf' method of 'rv_discrete' class. This fix has been implemented and regression tests for it have been added.