### PR TITLE
DOC: stats: clairify rv_continuous/discrete.stats example

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -162,7 +162,7 @@ Examples
 >>> import matplotlib.pyplot as plt
 >>> fig, ax = plt.subplots(1, 1)
 
-Calculate a few first moments:
+Calculate the first four moments:
 
 %(set_vals_stmt)s
 >>> mean, var, skew, kurt = %(name)s.stats(%(shapes)s, moments='mvsk')
@@ -291,7 +291,7 @@ Examples
 >>> import matplotlib.pyplot as plt
 >>> fig, ax = plt.subplots(1, 1)
 
-Calculate a few first moments:
+Calculate the first four moments:
 
 %(set_vals_stmt)s
 >>> mean, var, skew, kurt = %(name)s.stats(%(shapes)s, moments='mvsk')


### PR DESCRIPTION
#### Reference issue
Closes gh-13285

#### What does this implement/fix?
"Calculate a few first moments" in the statistical distribution examples can be misunderstood; this clarifies.