### PR TITLE
DOC: stats: discrete distribution shape parameter restrictions 

### DIFF
--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -28,11 +28,11 @@ class binom_gen(rv_discrete):
 
        f(k) = \binom{n}{k} p^k (1-p)^{n-k}
 
-    for ``k`` in ``{0, 1,..., n}``, :math:`0 \leq p \leq 1`
+    for :math:`k \in \{0, 1, \dots, n\}`, :math:`0 \leq p \leq 1`
 
-    `binom` takes ``n`` and ``p`` as shape parameters,
-    where :math:`p` is the probability of a single success 
-    and :math:`1-p` is the probability of a single failure. 
+    `binom` takes :math:`n` and :math:`p` as shape parameters,
+    where :math:`p` is the probability of a single success
+    and :math:`1-p` is the probability of a single failure.
 
     %(after_notes)s
 
@@ -113,8 +113,8 @@ class bernoulli_gen(binom_gen):
     for :math:`k` in :math:`\{0, 1\}`, :math:`0 \leq p \leq 1`
 
     `bernoulli` takes :math:`p` as shape parameter,
-    where :math:`p` is the probability of a single success 
-    and :math:`1-p` is the probability of a single failure. 
+    where :math:`p` is the probability of a single success
+    and :math:`1-p` is the probability of a single failure.
 
     %(after_notes)s
 
@@ -174,7 +174,7 @@ class betabinom_gen(rv_discrete):
 
        f(k) = \binom{n}{k} \frac{B(k + a, n - k + b)}{B(a, b)}
 
-    for ``k`` in ``{0, 1,..., n}``, :math:`n \geq 0`, :math:`a > 0`,
+    for :math:`k \in \{0, 1, \dots, n\}`, :math:`n \geq 0`, :math:`a > 0`,
     :math:`b > 0`, where :math:`B(a, b)` is the beta function.
 
     `betabinom` takes :math:`n`, :math:`a`, and :math:`b` as shape parameters.
@@ -258,8 +258,8 @@ class nbinom_gen(rv_discrete):
     for :math:`k \ge 0`, :math:`0 < p \leq 1`
 
     `nbinom` takes :math:`n` and :math:`p` as shape parameters where n is the
-    number of successes, :math:`p` is the probability of a single success, 
-    and :math:`1-p` is the probability of a single failure. 
+    number of successes, :math:`p` is the probability of a single success,
+    and :math:`1-p` is the probability of a single failure.
 
     %(after_notes)s
 
@@ -327,8 +327,8 @@ class geom_gen(rv_discrete):
 
     for :math:`k \ge 1`, :math:`0 < p \leq 1`
 
-    `geom` takes :math:`p` as shape parameter, 
-    where :math:`p` is the probability of a single success 
+    `geom` takes :math:`p` as shape parameter,
+    where :math:`p` is the probability of a single success
     and :math:`1-p` is the probability of a single failure.
 
     %(after_notes)s
@@ -742,9 +742,9 @@ class poisson_gen(rv_discrete):
 
     for :math:`k \ge 0`.
 
-    `poisson` takes :math:`\mu` as shape parameter.
-    When mu = 0 then at quantile k = 0, ``pmf`` method
-    returns `1.0`.
+    `poisson` takes :math:`\mu \geq 0` as shape parameter.
+    When :math:`\mu = 0`, the ``pmf`` method
+    returns ``1.0`` at quantile :math:`k = 0`.
 
     %(after_notes)s
 
@@ -810,7 +810,7 @@ class planck_gen(rv_discrete):
 
     `planck` takes :math:`\lambda` as shape parameter. The Planck distribution
     can be written as a geometric distribution (`geom`) with
-    :math:`p = 1 - \exp(-\lambda)` shifted by `loc = -1`.
+    :math:`p = 1 - \exp(-\lambda)` shifted by ``loc = -1``.
 
     %(after_notes)s
 
@@ -938,11 +938,12 @@ class randint_gen(rv_discrete):
 
     .. math::
 
-        f(k) = \frac{1}{high - low}
+        f(k) = \frac{1}{\texttt{high} - \texttt{low}}
 
-    for ``k = low, ..., high - 1``.
+    for :math:`k \in \{\texttt{low}, \dots, \texttt{high} - 1\}`.
 
-    `randint` takes ``low`` and ``high`` as shape parameters.
+    `randint` takes :math:`\texttt{low}` and :math:`\texttt{high}` as shape
+    parameters.
 
     %(after_notes)s
 
@@ -1020,7 +1021,7 @@ class zipf_gen(rv_discrete):
 
     for :math:`k \ge 1`.
 
-    `zipf` takes :math:`a` as shape parameter. :math:`\zeta` is the
+    `zipf` takes :math:`a > 1` as shape parameter. :math:`\zeta` is the
     Riemann zeta function (`scipy.special.zeta`)
 
     %(after_notes)s
@@ -1106,7 +1107,7 @@ class dlaplace_gen(rv_discrete):
         #     https://www.sciencedirect.com/science/
         #     article/abs/pii/S0378375804003519
         # Furthermore, the two-sided geometric distribution is
-        # equivalent to the difference between two iid geometric 
+        # equivalent to the difference between two iid geometric
         # distributions.
         #   Reference (page 179):
         #     https://pdfs.semanticscholar.org/61b3/


### PR DESCRIPTION
#### Reference issue
gh-13283

#### What does this implement/fix?
While reviewing gh-13283, I noticed that some discrete distribution parameter restrictions were not documented. This corrects the ones I noticed, and also tries to make the stylization (e.g. math vs teletype) a bit more consistent. (I can't claim to have fixed all issues, as what should be done is sometimes ambiguous unless we spell out the relationship between the math symbols and code parameters.)