### PR TITLE
MAINT: fix a build warning in sigtoolsmodule.c

### DIFF
--- a/scipy/signal/sigtoolsmodule.c
+++ b/scipy/signal/sigtoolsmodule.c
@@ -843,7 +843,8 @@ CompareFunction compare_functions[] = \
 PyObject *PyArray_OrderFilterND(PyObject *op1, PyObject *op2, int order) {
 	PyArrayObject *ap1=NULL, *ap2=NULL, *ret=NULL;
 	npy_intp *a_ind=NULL, *b_ind=NULL, *temp_ind=NULL, *mode_dep=NULL, *check_ind=NULL;
-	npy_uintp *offsets=NULL, *offsets2=NULL;
+	npy_uintp *offsets=NULL;
+	npy_intp *offsets2=NULL;
 	npy_uintp offset1;
 	int i, n2, n2_nonzero, k, check, incr = 1;
 	int typenum, bytes_in_array;


### PR DESCRIPTION
Warning was:
```
gcc: scipy/signal/sigtoolsmodule.c
scipy/signal/sigtoolsmodule.c: In function ‘PyArray_OrderFilterND’:
scipy/signal/sigtoolsmodule.c:930:11: warning: pointer targets in assignment from ‘npy_intp *’ {aka ‘long int *’} to ‘npy_uintp *’ {aka ‘long unsigned int *’} differ in signedness [-Wpointer-sign]
  offsets2 = (npy_intp *)malloc(PyArray_NDIM(ap1)*sizeof(npy_intp));
           ^
scipy/signal/sigtoolsmodule.c:932:37: warning: pointer targets in passing argument 2 of ‘compute_offsets’ differ in signedness [-Wpointer-sign]
  offset1 = compute_offsets(offsets, offsets2, PyArray_DIMS(ap1),
                                     ^~~~~~~~
scipy/signal/sigtoolsmodule.c:58:17: note: expected ‘npy_intp *’ {aka ‘long int *’} but argument is of type ‘npy_uintp *’ {aka ‘long unsigned int *’}
 static npy_intp compute_offsets (npy_uintp *offsets, npy_intp *offsets2, npy_intp *dim1,
```

That whole `compute_offsets` function is slightly odd, but that's for another time.
