### PR TITLE
TST: mark kde.logpdf overflow test as xslow

### DIFF
--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -396,7 +396,7 @@ def test_pdf_logpdf_weighted():
     assert_almost_equal(pdf, pdf2, decimal=12)
 
 
-@pytest.mark.slow
+@pytest.mark.xslow
 def test_logpdf_overflow():
     # regression test for gh-12988; testing against linalg instability for
     # very high dimensionality kde


### PR DESCRIPTION
I caught this test consistently taken 48 seconds on my machine. It may depend on BLAS version, this was with OpenBLAS 0.3.13.
It's not important enough to invest a lot of time in, just not running it in CI is fine for now.

[ci skip]

Note that this test was introduced recently in gh-12989, and marked as `slow` in gh-13216 (it took 1.3 sec there).