### PR TITLE
CI: prevent Codecov giving false CI failures and wrong PR annotations

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -11,9 +11,13 @@ coverage:
         target: 1
     patch:
       default:
-        target: 90
+        # Must be 0%, because many PRs touch files that we don't have coverage
+        # results for (build files, scripts, tools/, etc.)
+        target: 0
         if_no_uploads: error
         if_not_found: success
         if_ci_failed: failure
     changes: false
 comment: off
+github_checks:
+    annotations: false


### PR DESCRIPTION
See, e.g., gh-13040 for an example of a PR with hundreds of comments on lines that weren't even touched.

See also https://docs.codecov.io/docs/unexpected-coverage-changes for the very many reasons why Codecov can be wrong.