### PR TITLE
MAINT: prepare for 1.6.0 final

### DIFF
--- a/doc/release/1.6.0-notes.rst
+++ b/doc/release/1.6.0-notes.rst
@@ -2,8 +2,6 @@
 SciPy 1.6.0 Release Notes
 ==========================
 
-.. note:: Scipy 1.6.0 is not released yet!
-
 .. contents::
 
 SciPy 1.6.0 is the culmination of 6 months of hard work. It contains
@@ -591,6 +589,7 @@ Issues closed for 1.6.0
 * `#13191 <https://github.com/scipy/scipy/issues/13191>`__: \`scipy.linalg.lapack.dgesjv\` overwrites original arrays if...
 * `#13207 <https://github.com/scipy/scipy/issues/13207>`__: TST: Erratic test failure in test_cossin_separate
 * `#13221 <https://github.com/scipy/scipy/issues/13221>`__: BUG: pavement.py glitch
+* `#13239 <https://github.com/scipy/scipy/issues/13239>`__: Segmentation fault with \`eigh(..., driver="evx")\` for 10x10...
 * `#13248 <https://github.com/scipy/scipy/issues/13248>`__: ndimage: improper cval handling for complex-valued inputs
 
 Pull requests for 1.6.0
@@ -938,5 +937,7 @@ Pull requests for 1.6.0
 * `#13226 <https://github.com/scipy/scipy/pull/13226>`__: BUG: pavement.py file handle fixes
 * `#13249 <https://github.com/scipy/scipy/pull/13249>`__: Handle cval correctly for ndimage functions with complex-valued...
 * `#13253 <https://github.com/scipy/scipy/pull/13253>`__: BUG,MAINT: Ensure all Pool objects are closed
+* `#13255 <https://github.com/scipy/scipy/pull/13255>`__: BUG:linalg: Fix heevx wrappers and add new tests
 * `#13260 <https://github.com/scipy/scipy/pull/13260>`__: CI: fix macOS testing
 * `#13269 <https://github.com/scipy/scipy/pull/13269>`__: CI: github actions: In the linux dbg tests, update apt before...
+* `#13279 <https://github.com/scipy/scipy/pull/13279>`__: MAINT: 1.6.0 rc2 backports

--- a/scipy/linalg/flapack_sym_herm.pyf.src
+++ b/scipy/linalg/flapack_sym_herm.pyf.src
@@ -757,8 +757,8 @@ subroutine <prefix2>syevr(compute_v,range,lower,n,a,lda,vl,vu,il,iu,abstol,w,z,m
     integer optional,intent(in),check(compute_v==1||compute_v==0):: compute_v = 1
     character optional,intent(in),check(*range=='A'||*range=='V' ||*range=='I') :: range='A'
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
-    integer optional,intent(in),check(il>=1) :: il=1
-    integer optional,intent(in),check(iu>=il||iu<=n),depend(il,n) :: iu=n
+    integer optional,intent(in),check(il>=1&&il<=n),depend(n) :: il=1
+    integer optional,intent(in),check(n>=iu&&iu>=il),depend(n,il) :: iu=n
     <ftype2> optional,intent(in) :: vl=0.0
     <ftype2> optional,intent(in),check(vu>=vl),depend(vl) :: vu=1.0
     <ftype2> intent(in) :: abstol=0.0
@@ -827,8 +827,8 @@ subroutine <prefix2c>heevr(compute_v,range,lower,n,a,lda,vl,vu,il,iu,abstol,w,z,
     integer optional,intent(in),check(compute_v==1||compute_v==0):: compute_v = 1
     character optional,intent(in),check(*range=='A'||*range=='V' ||*range=='I') :: range='A'
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
-    integer optional,intent(in),check(il>=1) :: il=1
-    integer optional,intent(in),check(iu>=il||iu<=n),depend(il,n) :: iu=n
+    integer optional,intent(in),check(il>=1&&il<=n),depend(n) :: il=1
+    integer optional,intent(in),check(n>=iu&&iu>=il),depend(n,il) :: iu=n
     <ftype2> optional,intent(in) :: vl=0.0
     <ftype2> optional,intent(in),check(vu>vl),depend(vl) :: vu=1.0
     <ftype2> intent(in) :: abstol=0.0
@@ -905,15 +905,15 @@ subroutine <prefix2>syevx(compute_v,range,lower,n,a,lda,vl,vu,il,iu,abstol,w,z,m
     character optional,intent(in),check(*range=='A'||*range=='V' ||*range=='I') :: range='A'
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
     integer intent(hide),depend(a) :: n=shape(a,0)
-    integer optional,intent(in) :: il=1
-    integer optional,intent(in),depend(n) :: iu=n
+    integer optional,intent(in),check(il>=1&&il<=n),depend(n) :: il=1
+    integer optional,intent(in),check(n>=iu&&iu>=il),depend(n,il) :: iu=n
     <ftype2> optional,intent(in) :: vl=0.0
     <ftype2> optional,intent(in),check(vu>vl),depend(vl) :: vu=1.0
-    <ftype2> intent(in) :: abstol=0.0
+    <ftype2> optional,intent(in) :: abstol=0.0
     integer optional,intent(in),depend(n),check(lwork>=1||lwork==-1) :: lwork=max(8*n,1)
 
     <ftype2> intent(in,copy),check(shape(a,0)==shape(a,1)),dimension(n,n) :: a
-    integer intent(hide),depend(n) :: lda=max(1,n)
+    integer intent(hide),depend(a) :: lda=max(1,shape(a,0))
     integer intent(hide),depend(z) :: ldz=max(1,shape(z,0))
     <ftype2>  intent(hide),dimension(lwork),depend(lwork) :: work
     integer intent(hide),dimension(5*n),depend(n) :: iwork
@@ -956,37 +956,37 @@ subroutine <prefix2>syevx_lwork(lower,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,work,
 
 end subroutine <prefix2>syevx_lwork
 
-subroutine <prefix2c>heevx(compute_v,range,lower,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,work,lwork,rwork,iwork,ifail,info)
+subroutine <prefix2c>heevx(compute_v,range,lower,n,a,lda,vl,vu,il,iu,abstol,w,z,m,ldz,work,lwork,rwork,iwork,ifail,info)
     ! (C/Z)HEEVX computes selected eigenvalues and, optionally, eigenvectors
     ! of a complex Hermitian matrix A.  Eigenvalues and eigenvectors can
     ! be selected by specifying either a range of values or a range of
     ! indices for the desired eigenvalues.
 
-    callstatement (*f2py_func)((compute_v?"V":"N"),range,(lower?"L":"U"),&n,a,&lda,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,work,&lwork,&rwork,iwork,ifail,&info)
+    callstatement (*f2py_func)((compute_v?"V":"N"),range,(lower?"L":"U"),&n,a,&lda,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,work,&lwork,rwork,iwork,ifail,&info)
     callprotoargument char*,char*,char*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*
     
     integer optional,intent(in),check(compute_v==1||compute_v==0):: compute_v = 1
     character optional,intent(in),check(*range=='A'||*range=='V' ||*range=='I') :: range='A'
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
-    integer intent(hide),depend(a) :: n=shape(a,0)
-    integer optional,intent(in) :: il=1
-    integer optional,intent(in),depend(n) :: iu=n
+    integer optional,intent(in),check(il>=1&&il<=n),depend(n) :: il=1
+    integer optional,intent(in),check(n>=iu&&iu>=il),depend(n,il) :: iu=n
     <ftype2> optional,intent(in) :: vl=0.0
     <ftype2> optional,intent(in),check(vu>vl),depend(vl) :: vu=1.0
-    <ftype2> intent(in) :: abstol=0.0
+    <ftype2> optional,intent(in) :: abstol=0.0
     integer optional,intent(in),depend(n),check(lwork>=1||lwork==-1) :: lwork=max(2*n,1)
 
     <ftype2c> intent(in,copy),check(shape(a,0)==shape(a,1)),dimension(n,n) :: a
-    integer intent(hide),depend(n) :: lda=max(1,n)
+    integer intent(hide),depend(a) :: n=shape(a,0)
+    integer intent(hide),depend(a) :: lda=max(1,shape(a,0))
     integer intent(hide),depend(z) :: ldz=max(1,shape(z,0))
-    <ftype2c>  intent(hide),dimension(lwork),depend(lwork) :: work
+    <ftype2c> intent(hide),dimension(lwork),depend(lwork) :: work
     integer intent(hide),dimension(5*n),depend(n) :: iwork
-    <ftype2> intent(hide),dimenion(7*n),depend(n) :: rwork
+    <ftype2> intent(hide),dimension(7*n),depend(n) :: rwork
 
     <ftype2> intent(out),dimension(n),depend(n) :: w
-    <ftype2c> intent(out),dimension((compute_v?MAX(0,n):0),(compute_v?(*range=='I'?iu-il+1:MAX(1,n)):0)),depend(n,compute_v,range,iu,il) :: z
+    <ftype2c> intent(out),dimension((compute_v*n),(compute_v?(*range=='I'?iu-il+1:MAX(1,n)):0)),depend(compute_v,range,n,iu,il) :: z
     integer intent(out) :: m
-    integer intent(out),dimension((compute_v?n:0)),depend(compute_v,n):: ifail
+    integer intent(out),dimension(compute_v*n),depend(compute_v,n):: ifail
     integer intent(out) :: info
     
 end subroutine <prefix2c>heevx

--- a/setup.py
+++ b/setup.py
@@ -56,8 +56,8 @@ Operating System :: MacOS
 MAJOR = 1
 MINOR = 6
 MICRO = 0
-ISRELEASED = True
-VERSION = '%d.%d.%drc2' % (MAJOR, MINOR, MICRO)
+ISRELEASED = False
+VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
 
 # Return the git revision as a string


### PR DESCRIPTION
* backport gh-13255 (the code patch proper but not the testing changes--see comments in PR)

* update the `1.6.0` release notes after the backporting of gh-13255
    (the patch proper, but not the testing changes--see comments there)
    and to remove the "Note" about `1.6.0` not being released yet

 * bump the version to `1.6.0` "final" (removing the rc2)
    unreleased