### PR TITLE
Pythran implementation of scipy.signal._spectral

### DIFF
--- a/scipy/signal/_spectral.py
+++ b/scipy/signal/_spectral.py
@@ -1,0 +1,83 @@
+# Author: Pim Schellart
+# 2010 - 2011
+
+"""Tools for spectral analysis of unequally sampled signals."""
+
+import numpy as np
+
+#pythran export _lombscargle(float64[], float64[], float64[])
+def _lombscargle(x, y, freqs):
+    """
+    _lombscargle(x, y, freqs)
+
+    Computes the Lomb-Scargle periodogram.
+
+    Parameters
+    ----------
+    x : array_like
+        Sample times.
+    y : array_like
+        Measurement values (must be registered so the mean is zero).
+    freqs : array_like
+        Angular frequencies for output periodogram.
+
+    Returns
+    -------
+    pgram : array_like
+        Lomb-Scargle periodogram.
+
+    Raises
+    ------
+    ValueError
+        If the input arrays `x` and `y` do not have the same shape.
+
+    See also
+    --------
+    lombscargle
+
+    """
+
+    # Check input sizes
+    if x.shape != y.shape:
+        raise ValueError("Input arrays do not have the same size.")
+
+    # Create empty array for output periodogram
+    pgram = np.empty_like(freqs)
+
+    c = np.empty_like(x)
+    s = np.empty_like(x)
+
+    for i in range(freqs.shape[0]):
+
+        xc = 0.
+        xs = 0.
+        cc = 0.
+        ss = 0.
+        cs = 0.
+
+        c[:] = np.cos(freqs[i] * x)
+        s[:] = np.sin(freqs[i] * x)
+
+        for j in range(x.shape[0]):
+            xc += y[j] * c[j]
+            xs += y[j] * s[j]
+            cc += c[j] * c[j]
+            ss += s[j] * s[j]
+            cs += c[j] * s[j]
+
+        if freqs[i] == 0:
+            raise ZeroDivisionError()
+
+        tau = np.arctan2(2 * cs, cc - ss) / (2 * freqs[i])
+        c_tau = np.cos(freqs[i] * tau)
+        s_tau = np.sin(freqs[i] * tau)
+        c_tau2 = c_tau * c_tau
+        s_tau2 = s_tau * s_tau
+        cs_tau = 2 * c_tau * s_tau
+
+        pgram[i] = 0.5 * (((c_tau * xc + s_tau * xs)**2 / \
+            (c_tau2 * cc + cs_tau * cs + s_tau2 * ss)) + \
+            ((c_tau * xs - s_tau * xc)**2 / \
+            (c_tau2 * ss - cs_tau * cs + s_tau2 * cc)))
+
+    return pgram

--- a/scipy/signal/setup.py
+++ b/scipy/signal/setup.py
@@ -21,16 +21,21 @@ def configuration(parent_package='', top_path=None):
                          **numpy_nodepr_api)
     sigtools._pre_build_hook = set_c_flags_hook
 
-    config.add_extension(
-        '_spectral', sources=['_spectral.c'])
-
     if int(os.environ.get('SCIPY_USE_PYTHRAN', 0)):
         import pythran
         ext = pythran.dist.PythranExtension(
             'scipy.signal._max_len_seq_inner',
             sources=["scipy/signal/_max_len_seq_inner.py"])
         config.ext_modules.append(ext)
+
+        ext = pythran.dist.PythranExtension(
+            'scipy.signal._spectral',
+            sources=["scipy/signal/_spectral.py"])
+        config.ext_modules.append(ext)
     else:
+        config.add_extension(
+            '_spectral', sources=['_spectral.c'])
+
         config.add_extension(
             '_max_len_seq_inner', sources=['_max_len_seq_inner.c'])
 


### PR DESCRIPTION
As a follow-up to #13308 convert an extra function to Pythran.
Notable change wrt. Cython version:

- Pythran detects that all access are inbound, so no decorator needed
- Use `np.empty_like` instead of `np.empty`
- create a temporary array to hold some computations, instead of doing everything using plain scalar. This as almost no impact on performance (slightly better)

Comparison with cython on the following micro-benchmark:

```console
python -m timeit -s 'from numpy.random import random; n=400; x = random(n); y = random(n); z=random(n); from _spectral import _lombscargle as l' 'l(x, y, z)'
```

time in ms.

```
n    | cython | pythran
-----+---------+-----------
100  | 0.230   | 0.227
200  | 0.901   | 0.910
400  | 3.67    | 3.69
800  | 14.4    | 14.5
```