### PR TITLE
MAINT: update numpydoc to v1.1.0

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -113,6 +113,21 @@ pygments_style = 'sphinx'
 
 # Ensure all our internal links work
 nitpicky = True
+nitpick_ignore = [
+    # This ignores errors for classes (OptimizeResults, sparse.dok_matrix)
+    # which inherit methods from `dict`. missing references to builtins get
+    # ignored by default (see https://github.com/sphinx-doc/sphinx/pull/7254),
+    # but that fix doesn't work for inherited methods.
+    ("py:class", "a shallow copy of D"),
+    ("py:class", "a set-like object providing a view on D's keys"),
+    ("py:class", "a set-like object providing a view on D's items"),
+    ("py:class", "an object providing a view on D's values"),
+    ("py:class", "None.  Remove all items from D."),
+    ("py:class", "(k, v), remove and return some (key, value) pair as a"),
+    ("py:class", "None.  Update D from dict/iterable E and F."),
+    ("py:class", "v, remove specified key and return the corresponding value."),
+]
+
 exclude_patterns = [  # glob-style
 
 ]

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1501,7 +1501,7 @@ def medfilt(volume, kernel_size=None):
     scipy.ndimage.median_filter
 
     Notes
-    -------
+    -----
     The more general function `scipy.ndimage.median_filter` has a more
     efficient implementation of a median filter and therefore runs much faster.
     """
@@ -1821,7 +1821,7 @@ def medfilt2d(input, kernel_size=3):
     scipy.ndimage.median_filter
 
     Notes
-    -------
+    -----
     This is faster than `scipy.signal.medfilt` when `input.dtype.type`
     is `np.ubyte`, `np.single`, or `np.double`; for other types, this
     falls back to `scipy.signal.medfilt`
@@ -2211,7 +2211,7 @@ def hilbert(x, N=None, axis=-1):
     original signal from ``np.real(hilbert(x))``.
 
     Examples
-    ---------
+    --------
     In this example we use the Hilbert transform to determine the amplitude
     envelope and instantaneous frequency of an amplitude-modulated signal.
 

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -458,8 +458,7 @@ def csd(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
         detrend='constant', return_onesided=True, scaling='density',
         axis=-1, average='mean'):
     r"""
-    Estimate the cross power spectral density, Pxy, using Welch's
-    method.
+    Estimate the cross power spectral density, Pxy, using Welch's method.
 
     Parameters
     ----------
@@ -526,7 +525,7 @@ def csd(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
     coherence: Magnitude squared coherence by Welch's method.
 
     Notes
-    --------
+    -----
     By convention, Pxy is computed with the conjugate FFT of X
     multiplied by the FFT of Y.
 
@@ -1514,7 +1513,7 @@ def coherence(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
     csd: Cross spectral density by Welch's method.
 
     Notes
-    --------
+    -----
     An appropriate amount of overlap will depend on the choice of window
     and on your requirements. For the default Hann window an overlap of
     50% is a reasonable trade off between accurately estimating the

--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -68,7 +68,7 @@ class SphericalVoronoi:
         of the vertices belonging to the n-th point in points
 
     Methods
-    ----------
+    -------
     calculate_areas
         Calculates the areas of the Voronoi regions. For 2D point sets, the
         regions are circular arcs. The sum of the areas is `2 * pi * radius`.

--- a/scipy/stats/contingency.py
+++ b/scipy/stats/contingency.py
@@ -316,7 +316,7 @@ def association(observed, method="cramer", correction=False, lambda_=None):
         Value of the test statistic
 
     Notes
-    ------
+    -----
     Cramer's V, Tschuprow's T and Pearson's Contingency Coefficient, all
     measure the degree to which two nominal or ordinal variables are related,
     or the level of their association. This differs from correlation, although

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -3002,7 +3002,7 @@ def brunnermunzel(x, y, alternative="two-sided", distribution="t"):
     mannwhitneyu : Mann-Whitney rank test on two samples.
 
     Notes
-    -------
+    -----
     For more details on `brunnermunzel`, see `stats.brunnermunzel`.
 
     """


### PR DESCRIPTION
The main issue was annoying to track down. These are new warnings that showed up due to a change in numpydoc:

<details>

```
/home/rgommers/code/scipy/scipy/optimize/__init__.py:docstring of scipy.optimize.OptimizeResult.clear:: WARNING: py:class reference target not found: None.  Remove all items from D.                                                                                                 
/home/rgommers/code/scipy/scipy/optimize/__init__.py:docstring of scipy.optimize.OptimizeResult.copy:: WARNING: py:class reference target not found: a shallow copy of D                                                                                                              
/home/rgommers/code/scipy/scipy/optimize/__init__.py:docstring of scipy.optimize.OptimizeResult.items:: WARNING: py:class reference target not found: a set-like object providing a view on D's items                                                                                 
/home/rgommers/code/scipy/scipy/optimize/__init__.py:docstring of scipy.optimize.OptimizeResult.keys:: WARNING: py:class reference target not found: a set-like object providing a view on D's keys                                                                                   
/home/rgommers/code/scipy/scipy/optimize/__init__.py:docstring of scipy.optimize.OptimizeResult.pop:: WARNING: py:class reference target not found: v, remove specified key and return the corresponding value.                                                                       
/home/rgommers/code/scipy/scipy/optimize/__init__.py:docstring of scipy.optimize.OptimizeResult.popitem:: WARNING: py:class reference target not found: (k, v), remove and return some (key, value) pair as a                                                                         
/home/rgommers/code/scipy/scipy/optimize/__init__.py:docstring of scipy.optimize.OptimizeResult.update:: WARNING: py:class reference target not found: None.  Update D from dict/iterable E and F.                                                                                    
/home/rgommers/code/scipy/scipy/optimize/__init__.py:docstring of scipy.optimize.OptimizeResult.values:: WARNING: py:class reference target not found: an object providing a view on D's values                                                                                       
/home/rgommers/code/scipy/scipy/sparse/__init__.py:docstring of scipy.sparse.dok_matrix.clear:: WARNING: py:class reference target not found: None.  Remove all items from D.                                                                                                         
/home/rgommers/code/scipy/scipy/sparse/__init__.py:docstring of scipy.sparse.dok_matrix.items:: WARNING: py:class reference target not found: a set-like object providing a view on D's items                                                                                         
/home/rgommers/code/scipy/scipy/sparse/__init__.py:docstring of scipy.sparse.dok_matrix.keys:: WARNING: py:class reference target not found: a set-like object providing a view on D's keys                                                                                           
/home/rgommers/code/scipy/scipy/sparse/__init__.py:docstring of scipy.sparse.dok_matrix.pop:: WARNING: py:class reference target not found: v, remove specified key and return the corresponding value.                                                                               
/home/rgommers/code/scipy/scipy/sparse/__init__.py:docstring of scipy.sparse.dok_matrix.popitem:: WARNING: py:class reference target not found: (k, v), remove and return some (key, value) pair as a                                                                                 
/home/rgommers/code/scipy/scipy/sparse/dok.py:docstring of scipy.sparse.dok.dok_matrix.update:: WARNING: py:class reference target not found: None.  Update D from dict/iterable E and F.                                                                                             
/home/rgommers/code/scipy/scipy/sparse/__init__.py:docstring of scipy.sparse.dok_matrix.values:: WARNING: py:class reference target not found: an object providing a view on D's values
```

</details>

The root cause is that `dict` methods don't have proper html docs that can be found via intersphinx (see https://bugs.python.org/issue11975). That is fixed by ignoring reference issues for builtins in Sphinx, see https://github.com/sphinx-doc/sphinx/pull/7254. 

It's not clear to me if the warnings appearing now is a regression in numpydoc, or a correct fix that made the issue show up. The two candidate changes in numpydoc that touched this behaviour are:
- https://github.com/numpy/numpydoc/pull/269 (@larsoner)
- https://github.com/numpy/numpydoc/pull/271 (@rossbar)
Maybe this means something to one of you?

I couldn't upgrade to numpydoc latest master due to another issue, but that's for another time.