### PR TITLE
DOC: interpolate: improved docstring examples of `interpolate.interpn()` for different dimensional input.

### DIFF
--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -2613,17 +2613,17 @@ def interpn(points, values, xi, method="linear", bounds_error=True,
     >>> from scipy.interpolate import interpn
     >>> def value_func_3d(x, y, z):
     ...     return 2 * x + 3 * y - z
-    >>> x = np.linspace(0, 5)
-    >>> y = np.linspace(0, 5)
-    >>> z = np.linspace(0, 5)
+    >>> x = np.linspace(0, 4, 5)
+    >>> y = np.linspace(0, 5, 6)
+    >>> z = np.linspace(0, 6, 7)
     >>> points = (x, y, z)
-    >>> values = value_func_3d(*np.meshgrid(*points))
+    >>> values = value_func_3d(*np.meshgrid(*points, indexing='ij'))
 
     Evaluate the interpolating function at a point
 
     >>> point = np.array([2.21, 3.12, 1.15])
     >>> print(interpn(points, values, point))
-    [11.72]
+    [12.63]
 
     See also
     --------


### PR DESCRIPTION

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
fix #12622

#### What does this implement/fix?
<!--Please explain your changes.-->
I improved docstring examples of `interpolate.interpn()` for different dimensional input.
The previous example cannot handle different dimensional input because of misusing np.meshgrid, so it is fixed.
