### PR TITLE
DOC|ENH: type hinting in scipy.integrate.simpson

### DIFF
--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -404,7 +404,7 @@ def _basic_simpson(y, start, stop, x, dx, axis):
 
 # Note: alias kept for backwards compatibility. simps was renamed to simpson
 # because the former is a slur in colloquial English (see gh-12924).
-def simps(y, x=None, dx=1, axis=-1, even='avg'):
+def simps(y, x=None, dx=1.0, axis=-1, even='avg'):
     """`An alias of `simpson`.
 
     `simps` is kept for backwards compatibility. For new code, prefer
@@ -413,7 +413,7 @@ def simps(y, x=None, dx=1, axis=-1, even='avg'):
     return simpson(y, x=x, dx=dx, axis=axis, even=even)
 
 
-def simpson(y, x=None, dx=1, axis=-1, even='avg'):
+def simpson(y, x=None, dx=1.0, axis=-1, even='avg'):
     """
     Integrate y(x) using samples along the given axis and the composite
     Simpson's rule. If x is None, spacing of dx is assumed.
@@ -428,7 +428,7 @@ def simpson(y, x=None, dx=1, axis=-1, even='avg'):
         Array to be integrated.
     x : array_like, optional
         If given, the points at which `y` is sampled.
-    dx : int, optional
+    dx : float, optional
         Spacing of integration points along axis of `x`. Only used when
         `x` is None. Default is 1.
     axis : int, optional


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->


#### What does this implement/fix?

The (optional) parameter `dx` of the Simpson integration rule was
described in the documentation to be of type `int`. This messed up the
static type checking for example in an IDE like PyCharm (and presumably
other tools).

This commit fixes that nuisance and also changes the default value for this
parameter accordingly.

#### Additional information
The change is consistent with e.g. the similar case of the
`cumulative_trapezoid` function, where the docstring already expects a
floating point value.