### PR TITLE
BUG: fftpack doesn't work with ndarray shape argument

### DIFF
--- a/scipy/fftpack/helper.py
+++ b/scipy/fftpack/helper.py
@@ -101,7 +101,7 @@ def _good_shape(x, shape, axes):
 
     scipy.fftpack does not support len(shape) < x.ndim when axes is not given.
     """
-    if shape and not axes:
+    if shape is not None and axes is None:
         shape = _helper._iterable_of_int(shape, 'shape')
         if len(shape) != np.ndim(x):
             raise ValueError("when given, axes and shape arguments"

--- a/scipy/fftpack/tests/test_basic.py
+++ b/scipy/fftpack/tests/test_basic.py
@@ -856,3 +856,22 @@ class TestOverwrite(object):
                            overwrite_x)
         self._check_nd_one(ifftn, dtype, shape, axes, overwritable,
                            overwrite_x)
+
+
+@pytest.mark.parametrize('func', [fftn, ifftn, fft2])
+def test_shape_axes_ndarray(func):
+    # Test fftn and ifftn work with NumPy arrays for shape and axes arguments
+    # Regression test for gh-13342
+    a = np.random.rand(10, 10)
+
+    expect = func(a, shape=(5, 5))
+    actual = func(a, shape=np.array([5, 5]))
+    assert_equal(expect, actual)
+
+    expect = func(a, axes=(-1,))
+    actual = func(a, axes=np.array([-1,]))
+    assert_equal(expect, actual)
+
+    expect = func(a, shape=(4, 7), axes=(1, 0))
+    actual = func(a, shape=np.array([4, 7]), axes=np.array([1, 0]))
+    assert_equal(expect, actual)


### PR DESCRIPTION
#### Reference issue
Fixes gh-13342

#### What does this implement/fix?
Using object truthiness works to distinguish `None` from list and tuple but fails for ndarray. Instead I explicitly check for `is None` and added a test for this.

Also, I confirmed that this used to work before the FFT rewrite in 1.4 so it seems the use-case should be supported.