### PR TITLE
MAINT: Replace scipy.take with numpy.take in FFT function docstrings.

### DIFF
--- a/scipy/fft/_helper.py
+++ b/scipy/fft/_helper.py
@@ -79,7 +79,7 @@ def _init_nd_shape_and_axes(x, shape, axes):
     shape : int or array_like of ints or None
         The shape of the result. If both `shape` and `axes` (see below) are
         None, `shape` is ``x.shape``; if `shape` is None but `axes` is
-        not None, then `shape` is ``scipy.take(x.shape, axes, axis=0)``.
+        not None, then `shape` is ``numpy.take(x.shape, axes, axis=0)``.
         If `shape` is -1, the size of the corresponding dimension of `x` is
         used.
     axes : int or array_like of ints or None

--- a/scipy/fft/_realtransforms.py
+++ b/scipy/fft/_realtransforms.py
@@ -20,7 +20,7 @@ def dctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
     s : int or array_like of ints or None, optional
         The shape of the result. If both `s` and `axes` (see below) are None,
         `s` is ``x.shape``; if `s` is None but `axes` is not None, then `s` is
-        ``scipy.take(x.shape, axes, axis=0)``.
+        ``numpy.take(x.shape, axes, axis=0)``.
         If ``s[i] > x.shape[i]``, the ith dimension is padded with zeros.
         If ``s[i] < x.shape[i]``, the ith dimension is truncated to length
         ``s[i]``.
@@ -78,7 +78,7 @@ def idctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
     s : int or array_like of ints or None, optional
         The shape of the result.  If both `s` and `axes` (see below) are
         None, `s` is ``x.shape``; if `s` is None but `axes` is
-        not None, then `s` is ``scipy.take(x.shape, axes, axis=0)``.
+        not None, then `s` is ``numpy.take(x.shape, axes, axis=0)``.
         If ``s[i] > x.shape[i]``, the ith dimension is padded with zeros.
         If ``s[i] < x.shape[i]``, the ith dimension is truncated to length
         ``s[i]``.
@@ -136,7 +136,7 @@ def dstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
     s : int or array_like of ints or None, optional
         The shape of the result.  If both `s` and `axes` (see below) are None,
         `s` is ``x.shape``; if `s` is None but `axes` is not None, then `s` is
-        ``scipy.take(x.shape, axes, axis=0)``.
+        ``numpy.take(x.shape, axes, axis=0)``.
         If ``s[i] > x.shape[i]``, the ith dimension is padded with zeros.
         If ``s[i] < x.shape[i]``, the ith dimension is truncated to length
         ``s[i]``.
@@ -194,7 +194,7 @@ def idstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
     s : int or array_like of ints or None, optional
         The shape of the result.  If both `s` and `axes` (see below) are None,
         `s` is ``x.shape``; if `s` is None but `axes` is not None, then `s` is
-        ``scipy.take(x.shape, axes, axis=0)``.
+        ``numpy.take(x.shape, axes, axis=0)``.
         If ``s[i] > x.shape[i]``, the ith dimension is padded with zeros.
         If ``s[i] < x.shape[i]``, the ith dimension is truncated to length
         ``s[i]``.

--- a/scipy/fftpack/basic.py
+++ b/scipy/fftpack/basic.py
@@ -291,7 +291,7 @@ def fftn(x, shape=None, axes=None, overwrite_x=False):
     shape : int or array_like of ints or None, optional
         The shape of the result. If both `shape` and `axes` (see below) are
         None, `shape` is ``x.shape``; if `shape` is None but `axes` is
-        not None, then `shape` is ``scipy.take(x.shape, axes, axis=0)``.
+        not None, then `shape` is ``numpy.take(x.shape, axes, axis=0)``.
         If ``shape[i] > x.shape[i]``, the ith dimension is padded with zeros.
         If ``shape[i] < x.shape[i]``, the ith dimension is truncated to
         length ``shape[i]``.

--- a/scipy/fftpack/realtransforms.py
+++ b/scipy/fftpack/realtransforms.py
@@ -23,7 +23,7 @@ def dctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
     shape : int or array_like of ints or None, optional
         The shape of the result. If both `shape` and `axes` (see below) are
         None, `shape` is ``x.shape``; if `shape` is None but `axes` is
-        not None, then `shape` is ``scipy.take(x.shape, axes, axis=0)``.
+        not None, then `shape` is ``numpy.take(x.shape, axes, axis=0)``.
         If ``shape[i] > x.shape[i]``, the ith dimension is padded with zeros.
         If ``shape[i] < x.shape[i]``, the ith dimension is truncated to
         length ``shape[i]``.
@@ -76,7 +76,7 @@ def idctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
     shape : int or array_like of ints or None, optional
         The shape of the result.  If both `shape` and `axes` (see below) are
         None, `shape` is ``x.shape``; if `shape` is None but `axes` is
-        not None, then `shape` is ``scipy.take(x.shape, axes, axis=0)``.
+        not None, then `shape` is ``numpy.take(x.shape, axes, axis=0)``.
         If ``shape[i] > x.shape[i]``, the ith dimension is padded with zeros.
         If ``shape[i] < x.shape[i]``, the ith dimension is truncated to
         length ``shape[i]``.
@@ -130,7 +130,7 @@ def dstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
     shape : int or array_like of ints or None, optional
         The shape of the result.  If both `shape` and `axes` (see below) are
         None, `shape` is ``x.shape``; if `shape` is None but `axes` is
-        not None, then `shape` is ``scipy.take(x.shape, axes, axis=0)``.
+        not None, then `shape` is ``numpy.take(x.shape, axes, axis=0)``.
         If ``shape[i] > x.shape[i]``, the ith dimension is padded with zeros.
         If ``shape[i] < x.shape[i]``, the ith dimension is truncated to
         length ``shape[i]``.
@@ -183,7 +183,7 @@ def idstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False):
     shape : int or array_like of ints or None, optional
         The shape of the result.  If both `shape` and `axes` (see below) are
         None, `shape` is ``x.shape``; if `shape` is None but `axes` is
-        not None, then `shape` is ``scipy.take(x.shape, axes, axis=0)``.
+        not None, then `shape` is ``numpy.take(x.shape, axes, axis=0)``.
         If ``shape[i] > x.shape[i]``, the ith dimension is padded with zeros.
         If ``shape[i] < x.shape[i]``, the ith dimension is truncated to
         length ``shape[i]``.


### PR DESCRIPTION
Use `numpy.take` in the docstrings instead of the deprecated `scipy.take`.