### PR TITLE
ENH: stats: add 'ddof' parameter to the 'variation' function

### DIFF
--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -2219,7 +2219,7 @@ def moment(a, moment=1, axis=0):
         return s.mean(axis)
 
 
-def variation(a, axis=0):
+def variation(a, axis=0, ddof=0):
     """
     Computes the coefficient of variation, the ratio of the biased standard
     deviation to the mean.
@@ -2231,6 +2231,8 @@ def variation(a, axis=0):
     axis : int or None, optional
         Axis along which to calculate the coefficient of variation. Default
         is 0. If None, compute over the whole array `a`.
+    ddof : int, optional
+        Delta degrees of freedom.  Default is 0.
 
     Returns
     -------
@@ -2258,7 +2260,7 @@ def variation(a, axis=0):
 
     """
     a, axis = _chk_asarray(a, axis)
-    return a.std(axis)/a.mean(axis)
+    return a.std(axis, ddof=ddof)/a.mean(axis)
 
 
 def skew(a, axis=0, bias=True):

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -2224,9 +2224,9 @@ def variation(a, axis=0, ddof=0):
     Compute the coefficient of variation.
 
     The coefficient of variation is the standard deviation divided by the
-    mean.  This function is equivalent to:
+    mean.  This function is equivalent to::
 
-    ``np.std(x, axis=axis, ddof=ddof) / np.mean(x)``
+        np.std(x, axis=axis, ddof=ddof) / np.mean(x)
 
     The default for ``ddof`` is 0, but many definitions of the coefficient
     of variation use the square root of the unbiased sample variance

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -2221,8 +2221,16 @@ def moment(a, moment=1, axis=0):
 
 def variation(a, axis=0, ddof=0):
     """
-    Computes the coefficient of variation, the ratio of the biased standard
-    deviation to the mean.
+    Compute the coefficient of variation.
+
+    The coefficient of variation is the standard deviation divided by the
+    mean.  This function is equivalent to:
+
+    ``np.std(x, axis=axis, ddof=ddof) / np.mean(x)``
+
+    The default for ``ddof`` is 0, but many definitions of the coefficient
+    of variation use the square root of the unbiased sample variance
+    for the sample standard deviation, which corresponds to ``ddof=1``.
 
     Parameters
     ----------

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1098,9 +1098,9 @@ def variation(a, axis=0, nan_policy='propagate', ddof=0):
     Compute the coefficient of variation.
 
     The coefficient of variation is the standard deviation divided by the
-    mean.  This function is equivalent to:
+    mean.  This function is equivalent to::
 
-    ``np.std(x, axis=axis, ddof=ddof) / np.mean(x)``
+        np.std(x, axis=axis, ddof=ddof) / np.mean(x)
 
     The default for ``ddof`` is 0, but many definitions of the coefficient
     of variation use the square root of the unbiased sample variance

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1093,7 +1093,7 @@ def _moment(a, moment, axis):
         return np.mean(s, axis)
 
 
-def variation(a, axis=0, nan_policy='propagate'):
+def variation(a, axis=0, nan_policy='propagate', ddof=0):
     """
     Compute the coefficient of variation.
 
@@ -1114,6 +1114,8 @@ def variation(a, axis=0, nan_policy='propagate'):
           * 'propagate': returns nan
           * 'raise': throws an error
           * 'omit': performs the calculations ignoring nan values
+    ddof : int, optional
+        Delta degrees of freedom.  Default is 0.
 
     Returns
     -------
@@ -1139,9 +1141,9 @@ def variation(a, axis=0, nan_policy='propagate'):
 
     if contains_nan and nan_policy == 'omit':
         a = ma.masked_invalid(a)
-        return mstats_basic.variation(a, axis)
+        return mstats_basic.variation(a, axis, ddof)
 
-    return a.std(axis) / a.mean(axis)
+    return a.std(axis, ddof=ddof) / a.mean(axis)
 
 
 def skew(a, axis=0, bias=True, nan_policy='propagate'):

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1097,8 +1097,14 @@ def variation(a, axis=0, nan_policy='propagate', ddof=0):
     """
     Compute the coefficient of variation.
 
-    The coefficient of variation is the ratio of the biased standard
-    deviation to the mean.
+    The coefficient of variation is the standard deviation divided by the
+    mean.  This function is equivalent to:
+
+    ``np.std(x, axis=axis, ddof=ddof) / np.mean(x)``
+
+    The default for ``ddof`` is 0, but many definitions of the coefficient
+    of variation use the square root of the unbiased sample variance
+    for the sample standard deviation, which corresponds to ``ddof=1``.
 
     Parameters
     ----------

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1117,9 +1117,10 @@ def variation(a, axis=0, nan_policy='propagate', ddof=0):
         Defines how to handle when input contains nan.
         The following options are available (default is 'propagate'):
 
-          * 'propagate': returns nan
-          * 'raise': throws an error
-          * 'omit': performs the calculations ignoring nan values
+        * 'propagate': returns nan
+        * 'raise': throws an error
+        * 'omit': performs the calculations ignoring nan values
+
     ddof : int, optional
         Delta degrees of freedom.  Default is 0.
 

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -545,6 +545,13 @@ class TestMoments(object):
         y = mstats.variation(self.testcase)
         assert_almost_equal(y,0.44721359549996, 10)
 
+    def test_variation_ddof(self):
+        # test variation with delta degrees of freedom
+        # regression test for gh-13341
+        a = np.array([1, 2, 3, 4, 5])
+        y = mstats.variation(a, ddof=1)
+        assert_almost_equal(y, 0.5270462766947299)
+
     def test_skewness(self):
         y = mstats.skew(self.testmathworks)
         assert_almost_equal(y,-0.29322304336607,10)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2567,6 +2567,16 @@ class TestMoments(object):
         vv = stats.variation(a, axis=1, nan_policy="propagate")
         np.testing.assert_allclose(vv, [0.7453559924999299, np.nan], atol=1e-15)
 
+    def test_variation_ddof(self):
+        # test variation with delta degrees of freedom
+        # regression test for gh-13341
+        a = array([1, 2, 3, 4, 5])
+        nan_a = array([1, 2, 3, np.nan, 4, 5, np.nan])
+        y = stats.variation(a, ddof=1)
+        nan_y = stats.variation(nan_a, nan_policy="omit", ddof=1)
+        assert_approx_equal(y, 0.5270462766947299)
+        np.testing.assert_equal(y, nan_y)
+
     def test_skewness(self):
         # Scalar test case
         y = stats.skew(self.scalar_testcase)


### PR DESCRIPTION
#### Reference issue
closes gh-13341

#### What does this implement/fix?
A 'ddof' parameter has been added to the 'variation' function in the 'stats' and 'mstats' module to let the user specify the delta degrees of freedom for the calculation of CV. This is useful, for instance, in the calculation of sample CV by setting 'ddof=1', hence, using the unbiased variance of the sample. Regression tests for it have also been added.