### PR TITLE
CI: bump gcc from 4.8 to 5.x

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -104,7 +104,7 @@ jobs:
       test_mode: fast
       numpy_spec: "numpy==1.17.4"
       use_sdist: true
-- job: wheel_optimized_gcc52
+- job: wheel_optimized_gcc5
   pool:
     vmImage: 'ubuntu-18.04'
   variables:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -112,15 +112,15 @@ jobs:
     # pytest-xdist plugin for load scheduling its workers don't pick up the
     # flag. This environment variable starts all Py instances in -OO mode.
     PYTHONOPTIMIZE: 2
-    # Use gcc version 5.2
-    CC: gcc-5.2
-    CXX: g++-5.2
+    # Use gcc version 5
+    CC: gcc-5
+    CXX: g++-5
   steps:
   - script: |
       set -e
       sudo apt update -y
-      sudo apt install -y g++-5.2 gcc-5.2
-    displayName: 'Install GCC 5.2'
+      sudo apt install -y g++-5 gcc-5
+    displayName: 'Install GCC 5'
   - task: UsePythonVersion@0
     inputs:
       versionSpec: '3.7'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -104,7 +104,7 @@ jobs:
       test_mode: fast
       numpy_spec: "numpy==1.17.4"
       use_sdist: true
-- job: wheel_optimized_gcc48
+- job: wheel_optimized_gcc52
   pool:
     vmImage: 'ubuntu-18.04'
   variables:
@@ -112,15 +112,15 @@ jobs:
     # pytest-xdist plugin for load scheduling its workers don't pick up the
     # flag. This environment variable starts all Py instances in -OO mode.
     PYTHONOPTIMIZE: 2
-    # Use gcc version 4.8
-    CC: gcc-4.8
-    CXX: g++-4.8
+    # Use gcc version 5.2
+    CC: gcc-5.2
+    CXX: g++-5.2
   steps:
   - script: |
       set -e
       sudo apt update -y
-      sudo apt install -y g++-4.8 gcc-4.8
-    displayName: 'Install GCC 4.8'
+      sudo apt install -y g++-5.2 gcc-5.2
+    displayName: 'Install GCC 5.2'
   - task: UsePythonVersion@0
     inputs:
       versionSpec: '3.7'

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -20,16 +20,16 @@ ARCHITECTURES = ['', 'windows', 'darwin', 'aarch64', 'x86', 'ppc64le', 's390x']
 sha256_vals = {
 'openblas64_-v0.3.9-macosx_10_9_x86_64-gf_1becaaa.tar.gz':
 '53f606a7da75d390287f1c51b2af7866b8fe7553a26d2474f827daf0e5c8a886',
-'openblas64_-v0.3.9-manylinux1_x86_64.tar.gz':
-'6fe5b1e2a4baa16833724bcc94a80b22e9c99fc1b9a2ddbce4f1f82a8002d906',
+'openblas64_-v0.3.9-manylinux2010_x86_64.tar.gz':
+'a9880e5b5316fed9b58ea35881a686c58a3d4dd666fcfaf6d9b2c0dfe8dddd9b',
 'openblas64_-v0.3.9-win_amd64-gcc_7_1_0.zip':
 '15d24a66c5b22cc7b3120e831658f491c7a063804c33813235044a6f8b56686d',
 'openblas-v0.3.9-macosx_10_9_x86_64-gf_1becaaa.tar.gz': 
 '8221397b9cfb8cb22f3efb7f228ef901e13f9fd89c7d7d0cb7b8a79b0610bf33',
-'openblas-v0.3.9-manylinux1_i686.tar.gz': 
-'31abf8eccb697a320a998ce0f59045edc964602f815d78690c5a23839819261c',
-'openblas-v0.3.9-manylinux1_x86_64.tar.gz':
-'d9c39acbafae9b1daef19c2738ec938109a59e9322f93eb9a3c50869d220deff',
+'openblas-v0.3.9-manylinux2010_i686.tar.gz': 
+'fde39b3a5a7b01530abf0ba69dd075cc75ea8fc82652a5e67a437aa6044ab381',
+'openblas-v0.3.9-manylinux2010_x86_64.tar.gz':
+'8e3b8ee31004cdc86fc4301beb4ee7238f2cf1e86136cb2bf9482bfc562dce5',
 'openblas-v0.3.9-win32-gcc_7_1_0.zip':
 '69a7dc265e8a8e45b358637d11cb1710ce88c4456634c7ce37d429b1d9bc9aaa',
 'openblas-v0.3.9-win_amd64-gcc_7_1_0.zip': 
@@ -81,9 +81,9 @@ def download_openblas(target, arch, ilp64):
         typ = 'zip'
     elif 'x86' in arch:
         if IS_32BIT:
-            suffix = 'manylinux1_i686.tar.gz'
+            suffix = 'manylinux2010_i686.tar.gz'
         else:
-            suffix = 'manylinux1_x86_64.tar.gz'
+            suffix = 'manylinux2010_x86_64.tar.gz'
         filename = f'{ANACONDA}/{OPENBLAS_LONG}/download/openblas{fnsuffix}-{OPENBLAS_LONG}-{suffix}'
         typ = 'tar.gz'
     if not filename:


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

- 2021 brings C++14 support according to [roadmap](https://docs.scipy.org/doc/scipy/reference/toolchain.html)
- also see discussion in gh-13328

#### What does this implement/fix?
<!--Please explain your changes.-->

- Azure CI `wheel_optimized_gcc48` job now uses GCC 5 instead of GCC 4.8

#### Additional information
<!--Any additional information you think is important.-->