### PR TITLE
ENH|DOC: fix docstring and input validation in interpolate.RectSphereBivariateSpline

### DIFF
--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -1765,8 +1765,8 @@ class RectSphereBivariateSpline(SphereBivariateSpline):
     ----------
     u : array_like
         1-D array of colatitude coordinates in strictly ascending order.
-        Coordinates must be given in radians and lie within the interval
-        ``[0, pi]``.
+        Coordinates must be given in radians and lie within the open interval
+        ``(0, pi)``.
     v : array_like
         1-D array of longitude coordinates in strictly ascending order.
         Coordinates must be given in radians. First element (``v[0]``) must lie
@@ -1934,8 +1934,8 @@ class RectSphereBivariateSpline(SphereBivariateSpline):
         u, v = np.ravel(u), np.ravel(v)
         r = np.asarray(r)
 
-        if not ((0.0 <= u).all() and (u <= np.pi).all()):
-            raise ValueError('u should be between [0, pi]')
+        if not (0.0 < u[0] and u[-1] < np.pi):
+            raise ValueError('u should be between (0, pi)')
         if not -np.pi <= v[0] < np.pi:
             raise ValueError('v[0] should be between [-pi, pi)')
         if not v[-1] <= v[0] + 2*np.pi:

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -998,16 +998,16 @@ class TestRectSphereBivariateSpline(object):
                       np.atleast_2d(180. - np.abs(np.linspace(0., 350., 9)))).T
 
         with assert_raises(ValueError) as exc_info:
-            lats = np.linspace(-1, 170, 9) * np.pi / 180.
+            lats = np.linspace(0, 170, 9) * np.pi / 180.
             lons = np.linspace(0, 350, 18) * np.pi / 180.
             RectSphereBivariateSpline(lats, lons, data)
-        assert "u should be between [0, pi]" in str(exc_info.value)
+        assert "u should be between (0, pi)" in str(exc_info.value)
 
         with assert_raises(ValueError) as exc_info:
-            lats = np.linspace(10, 181, 9) * np.pi / 180.
+            lats = np.linspace(10, 180, 9) * np.pi / 180.
             lons = np.linspace(0, 350, 18) * np.pi / 180.
             RectSphereBivariateSpline(lats, lons, data)
-        assert "u should be between [0, pi]" in str(exc_info.value)
+        assert "u should be between (0, pi)" in str(exc_info.value)
 
         with assert_raises(ValueError) as exc_info:
             lats = np.linspace(10, 170, 9) * np.pi / 180.


### PR DESCRIPTION


<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
See #13359.

#### What does this implement/fix?
<!--Please explain your changes.-->
This fixes a bug in scipy.interpolate.RectSphereBivariateSpline where
the function expects colatitudes in the closed interval [0, pi] as
detailed in the docstring and checked during input validation.
The underlying Fortran code however expects colatitudes in the open
interval (0, pi).