### PR TITLE
ENH: stats: implement nbinom _logcdf

### DIFF
--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -292,9 +292,12 @@ class nbinom_gen(rv_discrete):
         k = floor(x)
         cdf = self._cdf(k, n, p)
         cond = cdf > 0.5
-        f1 = lambda k, n, p: np.log1p(-special.betainc(k + 1, n, 1 - p))
-        f2 = lambda k, n, p: np.log(cdf)
-        return _lazywhere(cond, (x, n, p), f=f1, f2=f2)
+        def f1(k, n, p):
+            return np.log1p(-special.betainc(k + 1, n, 1 - p))
+        def f2(k, n, p):
+            return np.log(cdf)
+        with np.errstate(divide='ignore'):
+            return _lazywhere(cond, (x, n, p), f=f1, f2=f2)
 
     def _sf_skip(self, x, n, p):
         # skip because special.nbdtrc doesn't work for 0<n<1

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -288,6 +288,14 @@ class nbinom_gen(rv_discrete):
         k = floor(x)
         return special.betainc(n, k+1, p)
 
+    def _logcdf(self, x, n, p):
+        k = floor(x)
+        cdf = self._cdf(k, n, p)
+        cond = cdf > 0.5
+        f1 = lambda k, n, p: np.log1p(-special.betainc(k + 1, n, 1 - p))
+        f2 = lambda k, n, p: np.log(cdf)
+        return _lazywhere(cond, (x, n, p), f=f1, f2=f2)
+
     def _sf_skip(self, x, n, p):
         # skip because special.nbdtrc doesn't work for 0<n<1
         k = floor(x)

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -292,10 +292,13 @@ class nbinom_gen(rv_discrete):
         k = floor(x)
         cdf = self._cdf(k, n, p)
         cond = cdf > 0.5
+        
         def f1(k, n, p):
             return np.log1p(-special.betainc(k + 1, n, 1 - p))
+            
         def f2(k, n, p):
             return np.log(cdf)
+            
         with np.errstate(divide='ignore'):
             return _lazywhere(cond, (x, n, p), f=f1, f2=f2)
 

--- a/scipy/stats/tests/test_discrete_distns.py
+++ b/scipy/stats/tests/test_discrete_distns.py
@@ -1,8 +1,9 @@
 from scipy.stats import (betabinom, hypergeom, nhypergeom, bernoulli,
-                         boltzmann, skellam)
+                         boltzmann, skellam, nbinom)
 
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal, assert_allclose
+import pytest
 
 
 def test_hypergeom_logpmf():
@@ -99,6 +100,7 @@ def test_betabinom_bernoulli():
     expected = bernoulli(a / (a + b)).pmf(k)
     assert_almost_equal(p, expected)
 
+
 def test_skellam_gh11474():
     # test issue reported in gh-11474 caused by `cdfchn`
     mu = [1, 10, 100, 1000, 5000, 5050, 5100, 5250, 6000]
@@ -112,3 +114,16 @@ def test_skellam_gh11474():
                     0.5044605891382528, 0.5019947363350450, 0.5019848365953181,
                     0.5019750827993392, 0.5019466621805060, 0.5018209330219539]
     assert_allclose(cdf, cdf_expected)
+
+
+@pytest.mark.parametrize("mu, q, expected",
+                         [[10, 120, -1.240089881791596e-38],
+                          [1500, 0, -86.61466680572661]])
+def test_nbinom_11465(mu, q, expected):
+    # test nbinom.logcdf at extreme tails
+    size = 20
+    n, p = size, size/(size+mu)
+    # In R:
+    # options(digits=16)
+    # pnbinom(mu=10, size=20, q=120, log.p=TRUE)
+    assert_allclose(nbinom.logcdf(q, n, p), expected)


### PR DESCRIPTION
#### Reference issue
Addresses another point in gh-11465

#### What does this implement/fix?
This implements the `_logcdf` method of the `nbinom` distribution. When `cdf` is close to 1, the default implementation loses precision. This change exploits a symmetry of the incomplete beta function to get around that.

#### Additional information
Please check my math!