### PR TITLE
BUG: stats: Don't raise ZeroDivisionError in _unequal_var_ttest_denom

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5606,6 +5606,10 @@ def ttest_ind_from_stats(mean1, std1, nobs1, mean2, std2, nobs2,
     Ttest_indResult(statistic=-0.5627179589855622, pvalue=0.573989277115258)
 
     """
+    mean1 = np.asarray(mean1)
+    std1 = np.asarray(std1)
+    mean2 = np.asarray(mean2)
+    std2 = np.asarray(std2)
     if equal_var:
         df, denom = _equal_var_ttest_denom(std1**2, nobs1, std2**2, nobs2)
     else:

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4009,6 +4009,12 @@ def test_gh5686():
     stats.ttest_ind_from_stats(mean1, std1, nobs1, mean2, std2, nobs2)
 
 
+def test_ttest_ind_from_stats_inputs_zero():
+    # Regression test for gh-6409.
+    result = stats.ttest_ind_from_stats(0, 0, 6, 0, 0, 6, equal_var=False)
+    assert_equal(result, [np.nan, np.nan])
+
+
 def test_ttest_1samp_new():
     n1, n2, n3 = (10,15,20)
     rvn1 = stats.norm.rvs(loc=5,scale=10,size=(n1,n2,n3))


### PR DESCRIPTION
When both standard deviations given to ttest_ind_from_stats were Python
floating point zeros and the parameter equal_var was False, the private
function _unequal_var_ttest_denom would raise a ZeroDivisionError.  The
code that raised the exception is wrapped in a np.errstate context
manager to catch such errors, but that context manager does not catch
an exception if it is raised by the division of Python floats.

The fix is to convert the inputs of ttest_ind_from_stats to NumPy arrays
before doing any calculations.  Then the exception raised by the
calculation in _unequal_var_ttest_denom will be caught by the context
manager.

Closes gh-6409.
