### PR TITLE
BUG: io/matlab: preserve dimensions of empty >=2D arrays

### DIFF
--- a/scipy/io/matlab/miobase.py
+++ b/scipy/io/matlab/miobase.py
@@ -294,10 +294,10 @@ def matdims(arr, oned_as='column'):
     """
     shape = arr.shape
     if shape == ():  # scalar
-        return (1,1)
+        return (1, 1)
     if len(shape) == 1:  # 1D
-        if functools.reduce(operator.mul, shape) == 0:  # zero elememts
-            return (0,0)
+        if shape[0] == 0:
+            return (0, 0)
         elif oned_as == 'column':
             return shape + (1,)
         elif oned_as == 'row':

--- a/scipy/io/matlab/miobase.py
+++ b/scipy/io/matlab/miobase.py
@@ -295,10 +295,10 @@ def matdims(arr, oned_as='column'):
     shape = arr.shape
     if shape == ():  # scalar
         return (1,1)
-    if functools.reduce(operator.mul, shape) == 0:  # zero elememts
-        return (0,) * np.max([arr.ndim, 2])
     if len(shape) == 1:  # 1D
-        if oned_as == 'column':
+        if functools.reduce(operator.mul, shape) == 0:  # zero elememts
+            return (0,0)
+        elif oned_as == 'column':
             return shape + (1,)
         elif oned_as == 'row':
             return (1,) + shape

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -948,6 +948,13 @@ def test_logical_out_type():
     assert_equal(var.dtype.type, np.uint8)
 
 
+def test_roundtrip_zero_dimensions():
+    stream = BytesIO()
+    savemat(stream, {'d':np.empty((10, 0))})
+    d = loadmat(stream)
+    assert d['d'].shape == (10, 0)
+
+
 def test_mat4_3d():
     # test behavior when writing 3-D arrays to matlab 4 files
     stream = BytesIO()

--- a/scipy/io/matlab/tests/test_miobase.py
+++ b/scipy/io/matlab/tests/test_miobase.py
@@ -11,18 +11,19 @@ from scipy.io.matlab.miobase import matdims
 
 def test_matdims():
     # Test matdims dimension finder
-    assert_equal(matdims(np.array(1)), (1, 1))  # NumPy scalar
-    assert_equal(matdims(np.array([1])), (1, 1))  # 1-D array, 1 element
-    assert_equal(matdims(np.array([1,2])), (2, 1))  # 1-D array, 2 elements
-    assert_equal(matdims(np.array([[2],[3]])), (2, 1))  # 2-D array, column vector
-    assert_equal(matdims(np.array([[2,3]])), (1, 2))  # 2-D array, row vector
+    assert_equal(matdims(np.array(1)), (1, 1))  # numpy scalar
+    assert_equal(matdims(np.array([1])), (1, 1))  # 1d array, 1 element
+    assert_equal(matdims(np.array([1,2])), (2, 1))  # 1d array, 2 elements
+    assert_equal(matdims(np.array([[2],[3]])), (2, 1))  # 2d array, column vector
+    assert_equal(matdims(np.array([[2,3]])), (1, 2))  # 2d array, row vector
     # 3d array, rowish vector
     assert_equal(matdims(np.array([[[2,3]]])), (1, 1, 2))
-    assert_equal(matdims(np.array([])), (0, 0))  # empty 1-D array
-    assert_equal(matdims(np.array([[]])), (0, 0))  # empty 2-D array
-    assert_equal(matdims(np.array([[[]]])), (0, 0, 0))  # empty 3-D array
+    assert_equal(matdims(np.array([])), (0, 0))  # empty 1d array
+    assert_equal(matdims(np.array([[]])), (1, 0))  # empty 2d
+    assert_equal(matdims(np.array([[[]]])), (1, 1, 0))  # empty 3d
+    assert_equal(matdims(np.empty((1, 0, 1))), (1, 0, 1))  # empty 3d
     # Optional argument flips 1-D shape behavior.
-    assert_equal(matdims(np.array([1,2]), 'row'), (1, 2))  # 1-D array, 2 elements
+    assert_equal(matdims(np.array([1,2]), 'row'), (1, 2))  # 1d array, 2 elements
     # The argument has to make sense though
     assert_raises(ValueError, matdims, np.array([1,2]), 'bizarre')
     # Check empty sparse matrices get their own shape

--- a/scipy/io/matlab/tests/test_miobase.py
+++ b/scipy/io/matlab/tests/test_miobase.py
@@ -11,19 +11,19 @@ from scipy.io.matlab.miobase import matdims
 
 def test_matdims():
     # Test matdims dimension finder
-    assert_equal(matdims(np.array(1)), (1, 1))  # numpy scalar
-    assert_equal(matdims(np.array([1])), (1, 1))  # 1d array, 1 element
-    assert_equal(matdims(np.array([1,2])), (2, 1))  # 1d array, 2 elements
-    assert_equal(matdims(np.array([[2],[3]])), (2, 1))  # 2d array, column vector
-    assert_equal(matdims(np.array([[2,3]])), (1, 2))  # 2d array, row vector
+    assert_equal(matdims(np.array(1)), (1, 1))  # NumPy scalar
+    assert_equal(matdims(np.array([1])), (1, 1))  # 1-D array, 1 element
+    assert_equal(matdims(np.array([1,2])), (2, 1))  # 1-D array, 2 elements
+    assert_equal(matdims(np.array([[2],[3]])), (2, 1))  # 2-D array, column vector
+    assert_equal(matdims(np.array([[2,3]])), (1, 2))  # 2-D array, row vector
     # 3d array, rowish vector
     assert_equal(matdims(np.array([[[2,3]]])), (1, 1, 2))
-    assert_equal(matdims(np.array([])), (0, 0))  # empty 1d array
-    assert_equal(matdims(np.array([[]])), (1, 0))  # empty 2d
-    assert_equal(matdims(np.array([[[]]])), (1, 1, 0))  # empty 3d
-    assert_equal(matdims(np.empty((1, 0, 1))), (1, 0, 1))  # empty 3d
+    assert_equal(matdims(np.array([])), (0, 0))  # empty 1-D array
+    assert_equal(matdims(np.array([[]])), (1, 0))  # empty 2-D array
+    assert_equal(matdims(np.array([[[]]])), (1, 1, 0))  # empty 3-D array
+    assert_equal(matdims(np.empty((1, 0, 1))), (1, 0, 1))  # empty 3-D array
     # Optional argument flips 1-D shape behavior.
-    assert_equal(matdims(np.array([1,2]), 'row'), (1, 2))  # 1d array, 2 elements
+    assert_equal(matdims(np.array([1,2]), 'row'), (1, 2))  # 1-D array, 2 elements
     # The argument has to make sense though
     assert_raises(ValueError, matdims, np.array([1,2]), 'bizarre')
     # Check empty sparse matrices get their own shape


### PR DESCRIPTION
#### Reference issue
Closes #13339

#### What does this implement/fix?
Saving 2D/3D/etc arrays to a Matlab file did not preserve the lengths of the dimensions, instead setting all the dimensions to zero length. This is inconsistent with Matlab itself.