### PR TITLE
ENH: stats: add skewed Cauchy distribution

### DIFF
--- a/doc/source/tutorial/stats.rst
+++ b/doc/source/tutorial/stats.rst
@@ -98,7 +98,7 @@ introspection:
     >>> dist_discrete = [d for d in dir(stats) if
     ...                  isinstance(getattr(stats, d), stats.rv_discrete)]
     >>> print('number of continuous distributions: %d' % len(dist_continu))
-    number of continuous distributions: 101
+    number of continuous distributions: 102
     >>> print('number of discrete distributions:   %d' % len(dist_discrete))
     number of discrete distributions:   16
 

--- a/doc/source/tutorial/stats/continuous.rst
+++ b/doc/source/tutorial/stats/continuous.rst
@@ -217,6 +217,7 @@ Continuous Distributions in `scipy.stats`
    continuous_burr
    continuous_burr12
    continuous_cauchy
+   continuous_skewcauchy
    continuous_chi
    continuous_chi2
    continuous_cosine

--- a/doc/source/tutorial/stats/continuous_skewcauchy.rst
+++ b/doc/source/tutorial/stats/continuous_skewcauchy.rst
@@ -1,0 +1,31 @@
+.. _continuous-skew-cauchy:
+
+Skewed Cauchy Distribution
+==========================
+
+This distribution is a generalization of the Cauchy distribution. It
+has a single shape parameter :math:`-1 < a < 1` that skews the distribution.
+The special case :math:`a=0` yields the Cauchy distribution.
+
+Functions
+---------
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*}
+    f(x, a) & = & \frac{1}{\pi \left(\frac{x^2}{\left(a x + 1 \right)^2} + 1 \right)},\quad x\ge0; \\
+                 & = & \frac{1}{\pi \left(\frac{x^2}{\left(-a x + 1 \right)^2} + 1 \right)},\quad x<0. \\
+    F(x, a) & = & \frac{1 - a}{2} + \frac{1 + a}{\pi} \arctan\left(\frac{x}{1 + a} \right),\quad x\ge0; \\
+                 & = & \frac{1 - a}{2} + \frac{1 - a}{\pi} \arctan\left(\frac{x}{1 - a} \right),\quad x<0.
+    \end{eqnarray*}
+
+The mean, variance, skewness, and kurtosis are all undefined.
+
+References
+----------
+
+-  "Skewed generalized *t* distribution", Wikipedia
+   https://en.wikipedia.org/wiki/Skewed_generalized_t_distribution#Skewed_Cauchy_distribution
+
+Implementation: `scipy.stats.skewcauchy`

--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -111,6 +111,7 @@ Continuous distributions
    rice              -- Rice
    recipinvgauss     -- Reciprocal Inverse Gaussian
    semicircular      -- Semicircular
+   skewcauchy        -- Skew Cauchy
    skewnorm          -- Skew normal
    t                 -- Student's T
    trapezoid         -- Trapezoidal

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -7029,7 +7029,7 @@ class skew_cauchy_gen(rv_continuous):
     -----
     The pdf is::
 
-        skewcauchy.pdf(x, a) = 1 / (np.pi * (x**2 / (a * np.sign(x) + 1)**2 + 1))
+        skewcauchy.pdf(x, a) = 1 / (pi * (x**2 / (a * sign(x) + 1)**2 + 1))
 
     `skewcauchy` takes ``a`` as a skewness parameter
     When a=0 the distribution is identical to the usual Cauchy distribution.
@@ -7040,27 +7040,23 @@ class skew_cauchy_gen(rv_continuous):
     """
 
     def _argcheck(self, a):
-        return np.isfinite(a)
+        return np.isfinite(a) and np.abs(a) != 1
 
     def _pdf(self, x, a):
         return 1 / (np.pi * (x**2 / (a * np.sign(x) + 1)**2 + 1))
 
     def _cdf(self, x, a):
-        if x <= 0:
-            return (a - 1) / np.pi * (np.arctan(x / (a - 1)) + np.pi / 2)
-        else if x > 0:
-            return (a - 1) / 2 + (a + 1) / np.pi * np.arctan(x / (a + 1))
+        return np.where(x <= 0,
+                        (1 - a) / 2.0 + (1 - a) / np.pi * np.arctan(x / (1 - a)),
+                        (1 - a) / 2.0 + (1 + a) / np.pi * np.arctan(x / (1 + a)))
 
     def _ppf(self, x, a):
-        if x <= 0:
-            return (1 - a) / np.tan(np.pi * x / (a - 1))
-        else if x > 0:
-            return np.tan(np.pi / (a + 1) * (x - (a - 1) / 2)) / (a + 1)
+        return np.where(x <= 0,
+                        np.tan(np.pi / (1 - a) * (x - (1 - a) / 2)) * (1 - a),
+                        np.tan(np.pi / (1 + a) * (x - (1 - a) / 2)) * (1 + a))
 
     def _stats(self, a, moments='mvsk'):
-        output = [np.nan, np.nan, np.nan, np.nan]
-        return output
-
+        return np.nan, np.nan, np.nan, np.nan
 
 skewcauchy = skew_cauchy_gen(name='skewcauchy')
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -7020,6 +7020,41 @@ class semicircular_gen(rv_continuous):
 semicircular = semicircular_gen(a=-1.0, b=1.0, name="semicircular")
 
 
+class skew_cauchy_gen(rv_continuous):
+    """A skewed Cauchy random variable.
+
+    %(before_notes)s
+
+    Notes
+    -----
+    The pdf is::
+
+        skewcauchy.pdf(x, a) = 1 / (np.pi * (x**2 / (a * np.sign(x) + 1)**2 + 1))
+
+    `skewcauchy` takes ``a`` as a skewness parameter
+    When a=0 the distribution is identical to the usual Cauchy distribution.
+
+    %(after_notes)s
+
+    %(example)s
+    """  
+
+    def _argcheck(self, a):
+        return np.isfinite(a)
+
+    def _pdf(self, x, a):
+        return 1 / (np.pi * (x**2 / (a * np.sign(x) + 1)**2 + 1))
+
+    def _stats(self, a, moments='mvsk'):
+        output = [np.nan, np.nan, np.nan, np.nan]
+        const = np.sqrt(2/np.pi) * a/np.sqrt(1 + a**2)
+
+        return output
+
+
+skewcauchy = skew_cauchy_gen(name='skewcauchy')
+
+
 class skew_norm_gen(rv_continuous):
     r"""A skew-normal random variable.
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -7037,7 +7037,7 @@ class skew_cauchy_gen(rv_continuous):
     %(after_notes)s
 
     %(example)s
-    """  
+    """
 
     def _argcheck(self, a):
         return np.isfinite(a)
@@ -7045,10 +7045,20 @@ class skew_cauchy_gen(rv_continuous):
     def _pdf(self, x, a):
         return 1 / (np.pi * (x**2 / (a * np.sign(x) + 1)**2 + 1))
 
+    def _cdf(self, x, a):
+        if x <= 0:
+            return (a - 1) / np.pi * (np.arctan(x / (a - 1)) + np.pi / 2)
+        else if x > 0:
+            return (a - 1) / 2 + (a + 1) / np.pi * np.arctan(x / (a + 1))
+
+    def _ppf(self, x, a):
+        if x <= 0:
+            return (1 - a) / np.tan(np.pi * x / (a - 1))
+        else if x > 0:
+            return np.tan(np.pi / (a + 1) * (x - (a - 1) / 2)) / (a + 1)
+
     def _stats(self, a, moments='mvsk'):
         output = [np.nan, np.nan, np.nan, np.nan]
-        const = np.sqrt(2/np.pi) * a/np.sqrt(1 + a**2)
-
         return output
 
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -7021,42 +7021,60 @@ semicircular = semicircular_gen(a=-1.0, b=1.0, name="semicircular")
 
 
 class skew_cauchy_gen(rv_continuous):
-    """A skewed Cauchy random variable.
+    r"""A skewed Cauchy random variable.
 
     %(before_notes)s
 
+    See Also
+    --------
+    cauchy : Cauchy distribution
+
     Notes
     -----
-    The pdf is::
 
-        skewcauchy.pdf(x, a) = 1 / (pi * (x**2 / (a * sign(x) + 1)**2 + 1))
+    The probability density function for `skewcauchy` is:
 
-    `skewcauchy` takes ``a`` as a skewness parameter
-    When a=0 the distribution is identical to the usual Cauchy distribution.
+    .. math::
+
+        f(x) = \frac{1}{\pi \left(\frac{x^2}{\left(a\, \text{sign}(x) + 1
+                                                   \right)^2} + 1 \right)}
+
+    for a real number :math:`x` and skewness parameter :math:`-1 < a < 1`.
+
+    When :math:`a=0`, the distribution reduces to the usual Cauchy
+    distribution.
 
     %(after_notes)s
 
+    References
+    ----------
+    .. [1] "Skewed generalized *t* distribution", Wikipedia
+       https://en.wikipedia.org/wiki/Skewed_generalized_t_distribution#Skewed_Cauchy_distribution
+
     %(example)s
+
     """
 
     def _argcheck(self, a):
-        return np.isfinite(a) and np.abs(a) != 1
+        return np.abs(a) < 1
 
     def _pdf(self, x, a):
         return 1 / (np.pi * (x**2 / (a * np.sign(x) + 1)**2 + 1))
 
     def _cdf(self, x, a):
         return np.where(x <= 0,
-                        (1 - a) / 2.0 + (1 - a) / np.pi * np.arctan(x / (1 - a)),
-                        (1 - a) / 2.0 + (1 + a) / np.pi * np.arctan(x / (1 + a)))
+                        (1 - a) / 2 + (1 - a) / np.pi * np.arctan(x / (1 - a)),
+                        (1 - a) / 2 + (1 + a) / np.pi * np.arctan(x / (1 + a)))
 
     def _ppf(self, x, a):
-        return np.where(x <= 0,
+        i = x < self._cdf(0, a)
+        return np.where(i,
                         np.tan(np.pi / (1 - a) * (x - (1 - a) / 2)) * (1 - a),
                         np.tan(np.pi / (1 + a) * (x - (1 - a) / 2)) * (1 + a))
 
     def _stats(self, a, moments='mvsk'):
         return np.nan, np.nan, np.nan, np.nan
+
 
 skewcauchy = skew_cauchy_gen(name='skewcauchy')
 

--- a/scipy/stats/_distr_params.py
+++ b/scipy/stats/_distr_params.py
@@ -94,6 +94,7 @@ distcont = [
     ['reciprocal', (0.01, 1)],
     ['rice', (0.7749725210111873,)],
     ['semicircular', ()],
+    ['skewcauchy', (4.025168762123,)],
     ['skewnorm', (4.0,)],
     ['t', (2.7433514990818093,)],
     ['trapezoid', (0.2, 0.8)],

--- a/scipy/stats/_distr_params.py
+++ b/scipy/stats/_distr_params.py
@@ -94,7 +94,7 @@ distcont = [
     ['reciprocal', (0.01, 1)],
     ['rice', (0.7749725210111873,)],
     ['semicircular', ()],
-    ['skewcauchy', (4.025168762123,)],
+    ['skewcauchy', (0.5,)],
     ['skewnorm', (4.0,)],
     ['t', (2.7433514990818093,)],
     ['trapezoid', (0.2, 0.8)],

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2155,6 +2155,20 @@ class TestRvDiscrete(object):
                         sum(v**2 * w for v, w in zip(y, py)), atol=1e-14)
 
 
+class TestSkewCauchy(object):
+    def setup_method(self):
+        np.random.seed(1234)
+
+    def test_cauchy(self):
+        x = np.linspace(-5, 5, 100)
+        assert_array_almost_equal(stats.skewcauchy.pdf(x, a=0),
+                                  stats.cauchy.pdf(x))
+        assert_array_almost_equal(stats.skewcauchy.cdf(x, a=0),
+                                  stats.cauchy.cdf(x))
+        assert_array_almost_equal(stats.skewcauchy.ppf(x, a=0),
+                                  stats.cauchy.ppf(x))
+
+
 class TestSkewNorm(object):
     def setup_method(self):
         self.rng = check_random_state(1234)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2156,9 +2156,6 @@ class TestRvDiscrete(object):
 
 
 class TestSkewCauchy(object):
-    def setup_method(self):
-        np.random.seed(1234)
-
     def test_cauchy(self):
         x = np.linspace(-5, 5, 100)
         assert_array_almost_equal(stats.skewcauchy.pdf(x, a=0),
@@ -2167,6 +2164,40 @@ class TestSkewCauchy(object):
                                   stats.cauchy.cdf(x))
         assert_array_almost_equal(stats.skewcauchy.ppf(x, a=0),
                                   stats.cauchy.ppf(x))
+
+    def test_skewcauchy_R(self):
+        # options(digits=16)
+        # library(sgt)
+        # # lmbda, x contain the values generated for a, x below
+        # lmbda <- c(0.0976270078546495, 0.430378732744839, 0.2055267521432877,
+        #            0.0897663659937937, -0.15269040132219, 0.2917882261333122,
+        #            -0.12482557747462, 0.7835460015641595, 0.9273255210020589,
+        #            -0.2331169623484446)
+        # x <- c(2.917250380826646, 0.2889491975290444, 0.6804456109393229,
+        #        4.25596638292661, -4.289639418021131, -4.1287070029845925,
+        #        -4.797816025596743, 3.32619845547938, 2.7815675094985046,
+        #        3.700121482468191)
+        # pdf = dsgt(x, mu=0, lambda=lambda, sigma=1, q=1/2, mean.cent=FALSE,
+        #            var.adj = sqrt(2))
+        # cdf = psgt(x, mu=0, lambda=lambda, sigma=1, q=1/2, mean.cent=FALSE,
+        #            var.adj = sqrt(2))
+        # qsgt(cdf, mu=0, lambda=lambda, sigma=1, q=1/2, mean.cent=FALSE,
+        #      var.adj = sqrt(2))
+
+        np.random.seed(0)
+        a = np.random.rand(10) * 2 - 1
+        x = np.random.rand(10) * 10 - 5
+        pdf = [0.039473975217333909, 0.305829714049903223, 0.24140158118994162,
+               0.019585772402693054, 0.021436553695989482, 0.00909817103867518,
+               0.01658423410016873, 0.071083288030394126, 0.103250045941454524,
+               0.013110230778426242]
+        cdf = [0.87426677718213752, 0.37556468910780882, 0.59442096496538066,
+               0.91304659850890202, 0.09631964100300605, 0.03829624330921733,
+               0.08245240578402535, 0.72057062945510386, 0.62826415852515449,
+               0.95011308463898292]
+        assert_allclose(stats.skewcauchy.pdf(x, a), pdf)
+        assert_allclose(stats.skewcauchy.cdf(x, a), cdf)
+        assert_allclose(stats.skewcauchy.ppf(cdf, a), x)
 
 
 class TestSkewNorm(object):


### PR DESCRIPTION
#### Reference issue
Identical to gh-7702 (`git diff d1894489c06fc530a8f7e2d4272f3ce3cde12c4d`) aside from commit history. Creating a new PR to avoid force-pushing to original author's repo after git surgery.
Closes gh-7437
Closes gh-7702

#### What does this implement/fix?
Adds the skewed Cauchy distribution.