### PR TITLE
BUG: sparse: fix verbosity in sparse lsqr

### DIFF
--- a/scipy/sparse/linalg/isolve/lsqr.py
+++ b/scipy/sparse/linalg/isolve/lsqr.py
@@ -389,7 +389,8 @@ def lsqr(A, b, damp=0.0, atol=1e-8, btol=1e-8, conlim=1e8,
     # there was an error on return when arnorm==0
     arnorm = alfa * beta
     if arnorm == 0:
-        print(msg[0])
+        if show:
+            print(msg[0])
         return x, istop, itn, r1norm, r2norm, anorm, acond, arnorm, xnorm, var
 
     head1 = '   Itn      x[0]       r1norm     r2norm '


### PR DESCRIPTION
The sparse lsqr displays "Exact solution is x=0", I find it useful if this is not printed every time because these function could be called a lot of times while processing big datasets.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### What does this implement/fix?
Does not print "Exact solution is x=0" when we get a trivial solution, the `show` flag needs to be `True`