### PR TITLE
DOC: update MacOS quickstart with conda-forge compiler, make more similar to ubuntu

### DIFF
--- a/doc/source/building/faq.rst
+++ b/doc/source/building/faq.rst
@@ -8,7 +8,7 @@ Build/Install FAQ
 version that I use to do my job/research?*
 
 If you use the ``conda`` package manager, this is covered in the
-:ref:`quickstart-mac`, specifically in :ref:`quickstart-mac-install`.
+:ref:`quickstart-mac`.
 
 Another simple way to achieve this is to install the released version in
 site-packages, by using a binary installer or pip, for example, and set

--- a/doc/source/dev/contributor/quickstart_mac.rst
+++ b/doc/source/dev/contributor/quickstart_mac.rst
@@ -3,7 +3,7 @@
 .. _quickstart-mac:
 
 =======================================================
-Development environment quickstart guide (Ubuntu)
+Development environment quickstart guide (MacOS)
 =======================================================
 
 This quickstart guide will cover:
@@ -14,10 +14,7 @@ This quickstart guide will cover:
 * performing an in-place build of SciPy; and
 * creating a virtual environment that adds this development version of SciPy to the Python path
 
-in Ubuntu. (Tested on 16.04, 18.04, and 20.04). *Users running Windows can follow these
-instructions after setting up* `Windows Subsystem for Linux`_ *or an Amazon EC2
-instance with Ubuntu 20.04. However, the instructions for setting up a
-development environment with Docker may be more reliable.*
+in MacOS (Tested on 11.1).
 
 .. note::
 
@@ -25,7 +22,7 @@ development environment with Docker may be more reliable.*
 
 	This guide assumes that you are starting without an existing Python 3 installation. If you already have Python 3, you might want to uninstall it first to avoid ambiguity over which Python version is being used at the command line.
 
-.. _quickstart-ubuntu-build:
+.. _quickstart-macos-build:
 
 Building SciPy
 --------------
@@ -34,7 +31,7 @@ Building SciPy
 
    If you're installing using the terminal, be sure to follow the "Next Steps"
    listed after the installer finishes. You might also need to restart your
-   terminal window or enter ``source ~/.bashrc`` for all the changes to take
+   terminal window or enter ``source ~/.bash_profile`` for all the changes to take
    effect.
 
 #. (Optional) In a terminal window, enter ``conda list``. |br| This shows a list of all the Python packages that came with the Anaconda Distribution of Python. Note the latest released version of SciPy is among them; this is not the development version you are going to build and will be able to modify.
@@ -45,11 +42,13 @@ Building SciPy
 
       If ``conda`` is not a recognized command, try restarting your terminal. If it is still not recognized, please see "Should I add Anaconda to the macOS or Linux PATH?" in the `Anaconda FAQ`_.
 
-#. Enter ``conda create --name scipydev python=3.8 numpy pybind11 cython pytest gfortran_linux-64 gxx_linux-64 sphinx matplotlib mypy git``. |br| This tells ``conda`` to create a virtual environment named ``scipydev`` (or another name that you prefer) with several packages.
+#. Enter ``conda create --name scipydev`` to create an empty virtual environment named ``scipydev`` (or another name that you prefer). This tells ``conda`` to create a new, empty environment for our packages. Activate the environment with ``conda activate scipydev``. Note that you'll need to have this virtual environment active whenever you want to work with the development version of SciPy.
+
+#. Enter ``conda config --env --add channels conda-forge`` to tell ``conda`` the source we want for our packages. Then enter ``install python=3.8 numpy pybind11 cython pytest compilers sphinx matplotlib mypy git`` to install packages.
 
    * ``numpy pybind11 cython pytest`` are four packages that SciPy depends on.
 
-   * ``gfortran_linux-64 gxx_linux-64`` are compilers used to build SciPy's Fortran, C, and C++ source code.
+   * ``compilers`` holds compilers used to build SciPy's Fortran, C, and C++ source code.
 
    * ``sphinx`` and ``matplotlib`` are required to render the SciPy documentation.
 
@@ -58,16 +57,6 @@ Building SciPy
    * ``git`` is a version control system used to download and manage the SciPy source code.
 
    Note that we're installing SciPy's build dependencies and some other software, but not SciPy itself.
-
-   .. note::
-
-      You could ``conda create`` an empty virtual environment first, then
-      ``conda install`` the packages, but creating the virtual environment
-      with all the packages you need is preferable to installing packages
-      individually because it makes it easier for ``conda`` to solve
-      the package dependencies optimally.
-
-#. You're still in the base environment. Activate your new virtual environment by entering ``conda activate scipydev``. |br| If you're working with an old version of ``conda``, you might need to type ``source activate scipydev`` instead (see `here <https://stackoverflow.com/questions/49600611/python-anaconda-should-i-use-conda-activate-or-source-activate-in-linux)>`__). Note that you'll need to have this virtual environment active whenever you want to work with the development version of SciPy.
 
 #. Browse to the `SciPy repository on GitHub <https://github.com/scipy/scipy>`_ and `create your own fork <https://help.github.com/en/articles/fork-a-repo>`_. You'll need to create a GitHub account if you don't already have one.
 
@@ -97,19 +86,11 @@ Building SciPy
       1.6.0.dev0+be97f1a
 
 
-.. _Anaconda SciPy Dev\: Part I (macOS): https://youtu.be/1rPOSNd0ULI
-
-.. _Anaconda SciPy Dev\: Part II (macOS): https://youtu.be/Faz29u5xIZc
 
 .. _Anaconda Distribution of Python: https://www.anaconda.com/distribution/
 
-.. _Rename the file: https://www.maketecheasier.com/rename-files-in-linux/
-
 .. _Anaconda FAQ: https://docs.anaconda.com/anaconda/user-guide/faq/
 
-.. _Homebrew on Linux: https://docs.brew.sh/Homebrew-on-Linux
-
-.. _Windows Subsystem for Linux: https://docs.microsoft.com/en-us/windows/wsl/install-win10
 
 .. |PYTHONPATH| replace:: ``PYTHONPATH``
 .. _PYTHONPATH: https://docs.python.org/3/using/cmdline.html#environment-variables

--- a/doc/source/dev/contributor/quickstart_mac.rst
+++ b/doc/source/dev/contributor/quickstart_mac.rst
@@ -3,7 +3,7 @@
 .. _quickstart-mac:
 
 =======================================================
-Development environment quickstart guide (MacOS)
+Development environment quickstart guide (macOS)
 =======================================================
 
 This quickstart guide will cover:
@@ -14,7 +14,7 @@ This quickstart guide will cover:
 * performing an in-place build of SciPy; and
 * creating a virtual environment that adds this development version of SciPy to the Python path
 
-in MacOS (Tested on 11.1).
+in macOS (Tested on 11.1).
 
 .. note::
 
@@ -22,12 +22,12 @@ in MacOS (Tested on 11.1).
 
 	This guide assumes that you are starting without an existing Python 3 installation. If you already have Python 3, you might want to uninstall it first to avoid ambiguity over which Python version is being used at the command line.
 
-.. _quickstart-macos-build:
+.. _quickstart-mac-build:
 
 Building SciPy
 --------------
 
-#. If your system does not already have it, install command line tools: ``xcode-select --install``.
+#. Install Apple Developer Tools. An easy way to do this is to `open a terminal window <https://blog.teamtreehouse.com/introduction-to-the-mac-os-x-command-line>`_, enter the command ``xcode-select --install``, and follow the prompts. Apple Developer Tools includes `git <https://git-scm.com/>`_, the software we need to download and manage the SciPy source code.
 
 #. Download, install, and test the latest release of the `Anaconda Distribution of Python`_. In addition to the latest version of Python 3, the Anaconda Distribution includes dozens of the most popular Python packages for scientific computing, the ``conda`` package manager, and tools for managing virtual environments.
 
@@ -36,7 +36,7 @@ Building SciPy
    terminal window or enter ``source ~/.bash_profile`` for all the changes to take
    effect.
 
-#. (Optional) In a terminal window, enter ``conda list``. |br| This shows a list of all the Python packages that came with the Anaconda Distribution of Python. Note the latest released version of SciPy is among them; this is not the development version you are going to build and will be able to modify.
+#. (Optional) In a terminal window, enter ``conda list``. This shows a list of all the Python packages that came with the Anaconda Distribution of Python. Note the latest released version of SciPy is among them; this is not the development version you are going to build and will be able to modify.
 
    Ideally, we'd like to have both versions, and we'd like to be able to switch between the two as needed. `Virtual environments <https://medium.freecodecamp.org/why-you-need-python-environments-and-how-to-manage-them-with-conda-85f155f4353c>`_ can do just that. With a few keystrokes in the terminal or even the click of an icon, we can enable or disable our development version. Let's set that up.
 
@@ -46,7 +46,7 @@ Building SciPy
 
 #. Enter ``conda create --name scipydev`` to create an empty virtual environment named ``scipydev`` (or another name that you prefer). This tells ``conda`` to create a new, empty environment for our packages. Activate the environment with ``conda activate scipydev``. Note that you'll need to have this virtual environment active whenever you want to work with the development version of SciPy.
 
-#. Enter ``conda config --env --add channels conda-forge`` to tell ``conda`` the source we want for our packages. Then enter ``conda install python=3.8 numpy pybind11 cython pytest compilers sphinx matplotlib mypy git`` to install packages.
+#. Enter ``conda config --env --add channels conda-forge`` to tell Anaconda the source we want for our packages. Then enter ``conda install python=3.8 numpy pybind11 cython pytest compilers sphinx matplotlib mypy`` to install the following packages:
 
    * ``numpy pybind11 cython pytest`` are four packages that SciPy depends on.
 
@@ -55,8 +55,6 @@ Building SciPy
    * ``sphinx`` and ``matplotlib`` are required to render the SciPy documentation.
 
    * ``mypy`` is a static type checker for Python. Consider using it.
-
-   * ``git`` is a version control system used to download and manage the SciPy source code.
 
    Note that we're installing SciPy's build dependencies and some other software, but not SciPy itself.
 

--- a/doc/source/dev/contributor/quickstart_mac.rst
+++ b/doc/source/dev/contributor/quickstart_mac.rst
@@ -18,11 +18,6 @@ This quickstart guide will cover:
 
 in macOS.
 
-Its companion videos `Anaconda SciPy Dev: Part I (macOS)`_ and
-`Anaconda SciPy Dev: Part II (macOS)`_ show many of the steps being performed, albeit in a slightly
-different order. This guide may diverge slightly from the videos over time, with the goal of keeping
-this guide the simplest, up-to-date procedure.
-
 .. note::
 
 	This guide does not present the only way to set up a development environment;
@@ -150,11 +145,7 @@ icon, we can enable or disable our development version. Let's set that up.
 #. Enter ``conda develop /scipy``, where ``scipy`` is to be replaced with the
    full path of the SciPy root directory. |br| This will allow us to ``import``
    the development version of SciPy in Python regardless of Python's working
-   directory. *Note: this step replace the steps shown in*
-   `Anaconda SciPy Dev: Part II (macOS)`_ *that modify the ``PYTHONPATH``
-   environment variable when the ``scipydev`` virtual environment is activated.
-   You can ignore that part of the video from 0:38 to 1:38; this is much simpler!*
-
+   directory. 
 
 #. In a new terminal window, test your setup. If you activate your virtual
    environment (e.g., ``conda activate scipydev``) and run Python code that imports
@@ -172,24 +163,9 @@ icon, we can enable or disable our development version. Let's set that up.
       1.4.0.dev0+be97f1a
 
 
-
-
-
-
-*Consider following along with the companion video* `Anaconda SciPy Dev: Part II (macOS)`_
-
-
-.. _Anaconda SciPy Dev\: Part I (macOS): https://youtu.be/1rPOSNd0ULI
-
-.. _Anaconda SciPy Dev\: Part II (macOS): https://youtu.be/Faz29u5xIZc
-
 .. _Anaconda Distribution of Python: https://www.anaconda.com/distribution/
-
-.. _Homebrew: https://brew.sh/
-
 .. |PYTHONPATH| replace:: ``PYTHONPATH``
 .. _PYTHONPATH: https://docs.python.org/3/using/cmdline.html#environment-variables
-
 .. |br| raw:: html
 
     <br>

--- a/doc/source/dev/contributor/quickstart_mac.rst
+++ b/doc/source/dev/contributor/quickstart_mac.rst
@@ -2,170 +2,118 @@
 
 .. _quickstart-mac:
 
-================================================
-Development environment quickstart guide (macOS)
-================================================
+=======================================================
+Development environment quickstart guide (Ubuntu)
+=======================================================
 
 This quickstart guide will cover:
 
-* setting up and maintaining a development environment, including installing
-  compilers and SciPy build dependencies
-* creating a personal fork of the SciPy repository on GitHub
-* using git to manage a local repository with development branches
-* performing an in-place build of SciPy
-* creating a virtual environment that adds this development version of SciPy to
-  the Python path
+* setting up and maintaining a development environment, including installing compilers and SciPy build dependencies;
+* creating a personal fork of the SciPy repository on GitHub;
+* using git to manage a local repository with development branches;
+* performing an in-place build of SciPy; and
+* creating a virtual environment that adds this development version of SciPy to the Python path
 
-in macOS.
+in Ubuntu. (Tested on 16.04, 18.04, and 20.04). *Users running Windows can follow these
+instructions after setting up* `Windows Subsystem for Linux`_ *or an Amazon EC2
+instance with Ubuntu 20.04. However, the instructions for setting up a
+development environment with Docker may be more reliable.*
 
 .. note::
 
-	This guide does not present the only way to set up a development environment;
-	there are many valid choices of Python distribution, C/Fortran compiler, and
-	installation options. The steps here can often be adapted for other choices,
-	but we cannot provide documentation tailored for them.
+	This guide does not present the only way to set up a development environment; there are many valid choices of Python distribution, C/Fortran compiler, and installation options. The steps here can often be adapted for other choices, but we cannot provide documentation tailored for them.
 
-	This guide assumes that you are starting without an existing Python 3 installation.
-	If you already have Python 3, you might want to uninstall it first to avoid
-	ambiguity over which Python version is being used at the command line.
+	This guide assumes that you are starting without an existing Python 3 installation. If you already have Python 3, you might want to uninstall it first to avoid ambiguity over which Python version is being used at the command line.
 
-.. _quickstart-mac-install:
+.. _quickstart-ubuntu-build:
 
-Setting Up a Developer Environment
-----------------------------------
+Building SciPy
+--------------
 
-#. Download, install, and test the latest release of the `Anaconda Distribution of Python`_.
-   In addition to the latest version of Python 3, the Anaconda distribution includes
-   dozens of the most popular Python packages for scientific computing, the Spyder
-   integrated development environment (IDE), the ``conda`` package manager, and tools
-   for managing virtual environments.
+#. Download, install, and test the latest release of the `Anaconda Distribution of Python`_. In addition to the latest version of Python 3, the Anaconda Distribution includes dozens of the most popular Python packages for scientific computing, the ``conda`` package manager, and tools for managing virtual environments.
 
-#. Install Apple Developer Tools. An easy way to do this is to `open a terminal
-   window <https://blog.teamtreehouse.com/introduction-to-the-mac-os-x-command-line>`_,
-   enter the command ``xcode-select --install``, and follow the prompts. Apple
-   Developer Tools includes `git <https://git-scm.com/>`_, the software we need to
-   download and manage the SciPy source code.
+   If you're installing using the terminal, be sure to follow the "Next Steps"
+   listed after the installer finishes. You might also need to restart your
+   terminal window or enter ``source ~/.bashrc`` for all the changes to take
+   effect.
 
-#. In the terminal, ensure that all of SciPy's build dependencies are up to
-   date: ``conda install pybind11``, then ``conda update cython numpy pytest
-   pybind11``.
+#. (Optional) In a terminal window, enter ``conda list``. |br| This shows a list of all the Python packages that came with the Anaconda Distribution of Python. Note the latest released version of SciPy is among them; this is not the development version you are going to build and will be able to modify.
 
-#. In a terminal window, enter ``conda list``. |br| This shows a list of all
-   the Python packages that came with the Anaconda distribution of Python. Note
-   the latest released version of SciPy is among them; this is not the cutting-edge
-   development version you will be modifying.
+   Ideally, we'd like to have both versions, and we'd like to be able to switch between the two as needed. `Virtual environments <https://medium.freecodecamp.org/why-you-need-python-environments-and-how-to-manage-them-with-conda-85f155f4353c>`_ can do just that. With a few keystrokes in the terminal or even the click of an icon, we can enable or disable our development version. Let's set that up.
 
-#. Enter ``conda create --name scipydev``. |br| This tells ``conda`` to
-   create a virtual environment named ``scipydev``. Note that ``scipydev`` can
-   be replaced by any name you'd like to refer to your virtual environment.
+   .. note::
 
-#. You're still in the base environment. Activate your new virtual environment
-   by entering ``conda activate scipydev``. |br| If you're working with an old
-   version of ``conda``, you might need to type ``source activate scipydev``
-   instead (see `here <https://stackoverflow.com/questions/49600611/python-anaconda-should-i-use-conda-activate-or-source-activate-in-linux)>`__.
+      If ``conda`` is not a recognized command, try restarting your terminal. If it is still not recognized, please see "Should I add Anaconda to the macOS or Linux PATH?" in the `Anaconda FAQ`_.
 
-#. (Optional) Enter ``conda list`` again. Note that the new virtual environment
-   has no packages installed. If you were to open a Python interpreter now, you
-   wouldn't be able to import ``numpy``, ``scipy``, etc.
+#. Enter ``conda create --name scipydev python=3.8 numpy pybind11 cython pytest gfortran_linux-64 gxx_linux-64 sphinx matplotlib mypy git``. |br| This tells ``conda`` to create a virtual environment named ``scipydev`` (or another name that you prefer) with several packages.
 
-#. Enter ``conda install cython numpy pytest spyder pybind11 compilers``. |br| Note
-   that we're only installing SciPy's build dependencies (and Spyder so we can
-   use the IDE), but not SciPy itself.
-   
-.. note::
-   You may need to add another conda channel to access ``compilers``.
-   This can be done with the commmand: ``conda config --add channels conda-forge``
+   * ``numpy pybind11 cython pytest`` are four packages that SciPy depends on.
 
-.. _quickstart-mac-build:
+   * ``gfortran_linux-64 gxx_linux-64`` are compilers used to build SciPy's Fortran, C, and C++ source code.
 
-Building SciPy from Local Source Files
---------------------------------------
+   * ``sphinx`` and ``matplotlib`` are required to render the SciPy documentation.
 
-#. Browse to the `SciPy repository on GitHub <https://github.com/scipy/scipy>`_
-   and `create your own fork <https://help.github.com/en/articles/fork-a-repo>`_.
-   You'll need to create a GitHub account if you don't already have one.
+   * ``mypy`` is a static type checker for Python. Consider using it.
 
-#. Browse to your fork. Your fork will have a URL like
-   `https://github.com/mdhaber/scipy <https://github.com/mdhaber/scipy>`_,
-   except with your GitHub username in place of "mdhaber".
+   * ``git`` is a version control system used to download and manage the SciPy source code.
 
-#. Click on the big, green "Clone or download" button, and copy the ".git" URL to
-   the clipboard. The URL will be the same as your fork's URL, except it will end in ".git".
+   Note that we're installing SciPy's build dependencies and some other software, but not SciPy itself.
 
-#. Create a folder for the SciPy source code in a convenient place on your computer.
-   `Navigate to it in the terminal
-   <https://blog.teamtreehouse.com/introduction-to-the-mac-os-x-command-line>`_.
+   .. note::
 
-#. Enter the command ``git clone`` followed by your fork's .git URL. Note that
-   this creates in the terminal's working directory a ``scipy`` folder containing
-   the SciPy source code.
+      You could ``conda create`` an empty virtual environment first, then
+      ``conda install`` the packages, but creating the virtual environment
+      with all the packages you need is preferable to installing packages
+      individually because it makes it easier for ``conda`` to solve
+      the package dependencies optimally.
 
-#. In the terminal, navigate to the ``scipy`` root directory (e.g., ``cd scipy``).
+#. You're still in the base environment. Activate your new virtual environment by entering ``conda activate scipydev``. |br| If you're working with an old version of ``conda``, you might need to type ``source activate scipydev`` instead (see `here <https://stackoverflow.com/questions/49600611/python-anaconda-should-i-use-conda-activate-or-source-activate-in-linux)>`__). Note that you'll need to have this virtual environment active whenever you want to work with the development version of SciPy.
 
-#. (Optional) Check your present working directory by entering ``pwd`` at the
-   terminal. You should be in the root ``/scipy`` directory, not in a directory
-   ending ``/scipy/scipy``.
+#. Browse to the `SciPy repository on GitHub <https://github.com/scipy/scipy>`_ and `create your own fork <https://help.github.com/en/articles/fork-a-repo>`_. You'll need to create a GitHub account if you don't already have one.
 
-#. Do an in-place build: enter ``python3 setup.py build_ext --inplace``. |br|
-   This will compile the C, C++, and Fortran code that comes with SciPy.
-   We installed ``python3`` with Anaconda. ``setup.py`` is a script in the root
-   directory of SciPy, which is why you have to be in the SciPy root directory to
-   call it. ``build_ext`` is a command defined in ``setup.py``, and ``--inplace``
-   is an option we'll use to ensure that the compiling happens in the SciPy
-   directory you already have rather than the default location for Python packages.
-   By building in-place, you avoid having to re-build SciPy before you can test
-   changes to the Python code.
+#. Browse to your fork. Your fork will have a URL like `https://github.com/mdhaber/scipy <https://github.com/mdhaber/scipy>`_, except with your GitHub username in place of "mdhaber".
 
-#. Test the build: enter ``python3 runtests.py -v``. ``runtests.py`` is another
-   script in the SciPy root directory. It runs a suite of tests that make sure
-   SciPy is working as it should, and ``-v`` activates the ``--verbose`` option
-   to show all the test output.
+#. Click the big, green "Clone or download" button, and copy the ".git" URL to the clipboard. The URL will be the same as your fork's URL, except it will end in ".git".
 
-If the tests were successful, you now have a working development build of SciPy!
-You could stop here, but you would only be able to use this development build
-from within the SciPy root directory. This would be inconvenient, for instance,
-if you wrote a script that performs an ``import`` of something you changed in
-SciPy but wanted to save it elsewhere on your computer. Without taking
-additional steps to add this version of SciPy to the |PYTHONPATH|_ ,
-this script would ``import`` from the version of SciPy distributed with
-Anaconda rather than the development version you just built.
-(See `here <https://chrisyeh96.github.io/2017/08/08/definitive-guide-python-imports.html>`__
-for much more information about how Python imports modules.)
+#. Create a folder for the SciPy source code in a convenient place on your computer. Navigate to it in the terminal.
 
+#. Enter the command ``git clone`` followed by your fork's .git URL. Note that this creates in the terminal's working directory a ``scipy`` folder containing the SciPy source code.
 
-Linking Local SciPy Source to Development Environment
------------------------------------------------------
+#. In the terminal, navigate into the ``scipy`` root directory (e.g. ``cd scipy``).
 
-Currently we have *two* versions of SciPy: the latest release as installed by
-Anaconda, and the development version we just built. Ideally, we'd like to be
-able to switch between the two as needed. `Virtual environments <https://medium.freecodecamp.org/why-you-need-python-environments-and-how-to-manage-them-with-conda-85f155f4353c>`_
-can do just that. With a few keystrokes in the terminal or even the click of an
-icon, we can enable or disable our development version. Let's set that up.
+#. Do an in-place build: enter ``python3 setup.py build_ext --inplace``. |br| This will compile the C, C++, and Fortran code that comes with SciPy. We installed ``python3`` with Anaconda. ``setup.py`` is a script in the root directory of SciPy, which is why you have to be in the SciPy root directory to call it. ``build_ext`` is a command defined in ``setup.py``, and ``--inplace`` is an option we'll use to ensure that the compiling happens in the SciPy directory you already have rather than the default location for Python packages. By building in-place, you avoid having to re-build SciPy before you can test changes to the Python code.
 
-#. Enter ``conda develop /scipy``, where ``scipy`` is to be replaced with the
-   full path of the SciPy root directory. |br| This will allow us to ``import``
-   the development version of SciPy in Python regardless of Python's working
-   directory. 
+#. Test the build: enter ``python3 runtests.py -v``. ``runtests.py`` is another script in the SciPy root directory. It runs a suite of tests that make sure SciPy is working as it should, and ``-v`` activates the ``--verbose`` option to show all the test output. If the tests are successful, you now have a working development build of SciPy! You could stop here, but you would only be able to use this development build when the Python working directory is the SciPy root directory.
 
-#. In a new terminal window, test your setup. If you activate your virtual
-   environment (e.g., ``conda activate scipydev``) and run Python code that imports
-   from SciPy, any changes you make to the SciPy code should be reflected when
-   the code runs. After deactivating the virtual environment (``conda deactivate``),
-   Python imports from the version of SciPy installed by Anaconda. You can also
-   check which version of SciPy you're using by executing in Python::
+#. Enter ``conda develop .``, where ``.`` refers to the present directory. |br| This will allow us to ``import`` the development version of SciPy in Python regardless of Python's working directory.
+
+#. In a new terminal window, test your setup. If you activate your virtual environment (e.g. ``conda activate scipydev``) and run Python code that imports from SciPy, any changes you make to the SciPy code should be reflected when the code runs. After deactivating the virtual environment (``conda deactivate``), Python imports from the version of SciPy installed by Anaconda. You can also check which version of SciPy you're using by executing in Python::
 
       import scipy
       print(scipy.__version__)
 
-   If you have successfully imported a development version of SciPy, the word
-   ``dev`` will appear in the output, e.g.::
+   If you have successfully imported a development version of SciPy, the word ``dev`` will appear in the output, e.g.::
 
-      1.4.0.dev0+be97f1a
+      1.6.0.dev0+be97f1a
 
+
+.. _Anaconda SciPy Dev\: Part I (macOS): https://youtu.be/1rPOSNd0ULI
+
+.. _Anaconda SciPy Dev\: Part II (macOS): https://youtu.be/Faz29u5xIZc
 
 .. _Anaconda Distribution of Python: https://www.anaconda.com/distribution/
+
+.. _Rename the file: https://www.maketecheasier.com/rename-files-in-linux/
+
+.. _Anaconda FAQ: https://docs.anaconda.com/anaconda/user-guide/faq/
+
+.. _Homebrew on Linux: https://docs.brew.sh/Homebrew-on-Linux
+
+.. _Windows Subsystem for Linux: https://docs.microsoft.com/en-us/windows/wsl/install-win10
+
 .. |PYTHONPATH| replace:: ``PYTHONPATH``
 .. _PYTHONPATH: https://docs.python.org/3/using/cmdline.html#environment-variables
+
 .. |br| raw:: html
 
     <br>

--- a/doc/source/dev/contributor/quickstart_mac.rst
+++ b/doc/source/dev/contributor/quickstart_mac.rst
@@ -34,7 +34,7 @@ this guide the simplest, up-to-date procedure.
 	If you already have Python 3, you might want to uninstall it first to avoid
 	ambiguity over which Python version is being used at the command line.
 
-.. _quickstart-mac-build:
+.. _quickstart-mac-install:
 
 Setting Up a Developer Environment
 ----------------------------------
@@ -80,6 +80,8 @@ Setting Up a Developer Environment
 .. note::
    You may need to add another conda channel to access ``compilers``.
    This can be done with the commmand: ``conda config --add channels conda-forge``
+
+.. _quickstart-mac-build:
 
 Building SciPy from Local Source Files
 --------------------------------------
@@ -171,7 +173,7 @@ icon, we can enable or disable our development version. Let's set that up.
 
 
 
-.. _quickstart-mac-install:
+
 
 
 *Consider following along with the companion video* `Anaconda SciPy Dev: Part II (macOS)`_

--- a/doc/source/dev/contributor/quickstart_mac.rst
+++ b/doc/source/dev/contributor/quickstart_mac.rst
@@ -27,6 +27,8 @@ in MacOS (Tested on 11.1).
 Building SciPy
 --------------
 
+#. If your system does not already have it, install command line tools: ``xcode-select --install``.
+
 #. Download, install, and test the latest release of the `Anaconda Distribution of Python`_. In addition to the latest version of Python 3, the Anaconda Distribution includes dozens of the most popular Python packages for scientific computing, the ``conda`` package manager, and tools for managing virtual environments.
 
    If you're installing using the terminal, be sure to follow the "Next Steps"
@@ -44,7 +46,7 @@ Building SciPy
 
 #. Enter ``conda create --name scipydev`` to create an empty virtual environment named ``scipydev`` (or another name that you prefer). This tells ``conda`` to create a new, empty environment for our packages. Activate the environment with ``conda activate scipydev``. Note that you'll need to have this virtual environment active whenever you want to work with the development version of SciPy.
 
-#. Enter ``conda config --env --add channels conda-forge`` to tell ``conda`` the source we want for our packages. Then enter ``install python=3.8 numpy pybind11 cython pytest compilers sphinx matplotlib mypy git`` to install packages.
+#. Enter ``conda config --env --add channels conda-forge`` to tell ``conda`` the source we want for our packages. Then enter ``conda install python=3.8 numpy pybind11 cython pytest compilers sphinx matplotlib mypy git`` to install packages.
 
    * ``numpy pybind11 cython pytest`` are four packages that SciPy depends on.
 

--- a/doc/source/dev/contributor/quickstart_mac.rst
+++ b/doc/source/dev/contributor/quickstart_mac.rst
@@ -19,8 +19,8 @@ This quickstart guide will cover:
 in macOS.
 
 Its companion videos `Anaconda SciPy Dev: Part I (macOS)`_ and
-`Anaconda SciPy Dev: Part II (macOS)`_ show many of the steps being performed.
-This guide may diverge slightly from the videos over time, with the goal of keeping
+`Anaconda SciPy Dev: Part II (macOS)`_ show many of the steps being performed, albeit in a slightly
+different order. This guide may diverge slightly from the videos over time, with the goal of keeping
 this guide the simplest, up-to-date procedure.
 
 .. note::
@@ -36,10 +36,8 @@ this guide the simplest, up-to-date procedure.
 
 .. _quickstart-mac-build:
 
-Building SciPy
---------------
-
-*Consider following along with the companion video* `Anaconda SciPy Dev: Part I (macOS)`_
+Setting Up a Developer Environment
+----------------------------------
 
 #. Download, install, and test the latest release of the `Anaconda Distribution of Python`_.
    In addition to the latest version of Python 3, the Anaconda distribution includes
@@ -52,6 +50,39 @@ Building SciPy
    enter the command ``xcode-select --install``, and follow the prompts. Apple
    Developer Tools includes `git <https://git-scm.com/>`_, the software we need to
    download and manage the SciPy source code.
+
+#. In the terminal, ensure that all of SciPy's build dependencies are up to
+   date: ``conda install pybind11``, then ``conda update cython numpy pytest
+   pybind11``.
+
+#. In a terminal window, enter ``conda list``. |br| This shows a list of all
+   the Python packages that came with the Anaconda distribution of Python. Note
+   the latest released version of SciPy is among them; this is not the cutting-edge
+   development version you will be modifying.
+
+#. Enter ``conda create --name scipydev``. |br| This tells ``conda`` to
+   create a virtual environment named ``scipydev``. Note that ``scipydev`` can
+   be replaced by any name you'd like to refer to your virtual environment.
+
+#. You're still in the base environment. Activate your new virtual environment
+   by entering ``conda activate scipydev``. |br| If you're working with an old
+   version of ``conda``, you might need to type ``source activate scipydev``
+   instead (see `here <https://stackoverflow.com/questions/49600611/python-anaconda-should-i-use-conda-activate-or-source-activate-in-linux)>`__.
+
+#. (Optional) Enter ``conda list`` again. Note that the new virtual environment
+   has no packages installed. If you were to open a Python interpreter now, you
+   wouldn't be able to import ``numpy``, ``scipy``, etc.
+
+#. Enter ``conda install cython numpy pytest spyder pybind11 compilers``. |br| Note
+   that we're only installing SciPy's build dependencies (and Spyder so we can
+   use the IDE), but not SciPy itself.
+   
+.. note::
+   You may need to add another conda channel to access ``compilers``.
+   This can be done with the commmand: ``conda config --add channels conda-forge``
+
+Building SciPy from Local Source Files
+--------------------------------------
 
 #. Browse to the `SciPy repository on GitHub <https://github.com/scipy/scipy>`_
    and `create your own fork <https://help.github.com/en/articles/fork-a-repo>`_.
@@ -73,18 +104,6 @@ Building SciPy
    the SciPy source code.
 
 #. In the terminal, navigate to the ``scipy`` root directory (e.g., ``cd scipy``).
-
-#. Install `Homebrew`_. Enter into the terminal
-   |br| ``/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`` |br|
-   or follow the installation instructions listed on the `Homebrew website <https://brew.sh>`_.
-   Homebrew is a package manager for macOS that will help you download ``gcc``,
-   the software we will use to compile C, C++, and Fortran code included in SciPy.
-
-#. Use Homebrew to install ``gcc`` by entering the command ``brew install gcc``.
-
-#. In the terminal, ensure that all of SciPy's build dependencies are up to
-   date: ``conda install pybind11``, then ``conda update cython numpy pytest
-   pybind11``.
 
 #. (Optional) Check your present working directory by entering ``pwd`` at the
    terminal. You should be in the root ``/scipy`` directory, not in a directory
@@ -116,40 +135,15 @@ Anaconda rather than the development version you just built.
 (See `here <https://chrisyeh96.github.io/2017/08/08/definitive-guide-python-imports.html>`__
 for much more information about how Python imports modules.)
 
-.. _quickstart-mac-install:
 
-Installing SciPy
-----------------
-
-*Consider following along with the companion video* `Anaconda SciPy Dev: Part II (macOS)`_
+Linking Local SciPy Source to Development Environment
+-----------------------------------------------------
 
 Currently we have *two* versions of SciPy: the latest release as installed by
 Anaconda, and the development version we just built. Ideally, we'd like to be
 able to switch between the two as needed. `Virtual environments <https://medium.freecodecamp.org/why-you-need-python-environments-and-how-to-manage-them-with-conda-85f155f4353c>`_
 can do just that. With a few keystrokes in the terminal or even the click of an
 icon, we can enable or disable our development version. Let's set that up.
-
-#. In a terminal window, enter ``conda list``. |br| This shows a list of all
-   the Python packages that came with the Anaconda distribution of Python. Note
-   the latest released version of SciPy is among them; this is not the cutting-edge
-   development version you just built and can modify.
-
-#. Enter ``conda create --name scipydev``. |br| This tells ``conda`` to
-   create a virtual environment named ``scipydev``. Note that ``scipydev`` can
-   be replaced by any name you'd like to refer to your virtual environment.
-
-#. You're still in the base environment. Activate your new virtual environment
-   by entering ``conda activate scipydev``. |br| If you're working with an old
-   version of ``conda``, you might need to type ``source activate scipydev``
-   instead (see `here <https://stackoverflow.com/questions/49600611/python-anaconda-should-i-use-conda-activate-or-source-activate-in-linux)>`__.
-
-#. (Optional) Enter ``conda list`` again. Note that the new virtual environment
-   has no packages installed. If you were to open a Python interpreter now, you
-   wouldn't be able to import ``numpy``, ``scipy``, etc.
-
-#. Enter ``conda install cython numpy pytest spyder pybind11``. |br| Note
-   that we're only installing SciPy's build dependencies (and Spyder so we can
-   use the IDE), but not SciPy itself.
 
 #. Enter ``conda develop /scipy``, where ``scipy`` is to be replaced with the
    full path of the SciPy root directory. |br| This will allow us to ``import``
@@ -158,6 +152,7 @@ icon, we can enable or disable our development version. Let's set that up.
    `Anaconda SciPy Dev: Part II (macOS)`_ *that modify the ``PYTHONPATH``
    environment variable when the ``scipydev`` virtual environment is activated.
    You can ignore that part of the video from 0:38 to 1:38; this is much simpler!*
+
 
 #. In a new terminal window, test your setup. If you activate your virtual
    environment (e.g., ``conda activate scipydev``) and run Python code that imports
@@ -173,6 +168,14 @@ icon, we can enable or disable our development version. Let's set that up.
    ``dev`` will appear in the output, e.g.::
 
       1.4.0.dev0+be97f1a
+
+
+
+.. _quickstart-mac-install:
+
+
+*Consider following along with the companion video* `Anaconda SciPy Dev: Part II (macOS)`_
+
 
 .. _Anaconda SciPy Dev\: Part I (macOS): https://youtu.be/1rPOSNd0ULI
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

This fixes the issue described in and can close gh-13323. Recent MacOS updates have created difficulty in maintaining a functioning python-SciPy development environment. Specifically, issues that arise with trying to use `gcc` and the most recent version of MacOS (Big Sur 11.1 (20C69)) created a situation where SciPy was unable to build in place. 

This was the error that occured when building that I was unable to resolve in any other way:
```
/usr/local/bin/gfortran -Wall -g -arch x86_64 -Wall -g -undefined dynamic_lookup -bundle build/temp.macosx-10.9-x86_64-3.8/scipy/integrate/_quadpackmodule.o -L/Applications/anaconda3/envs/scipydev/lib -L/usr/local/Cellar/gcc/10.2.0/lib/gcc/10/gcc/x86_64-apple-darwin20/10.2.0 -L/usr/local/Cellar/gcc/10.2.0/lib/gcc/10/gcc/x86_64-apple-darwin20/10.2.0/../../.. -L/usr/local/Cellar/gcc/10.2.0/lib/gcc/10/gcc/x86_64-apple-darwin20/10.2.0/../../.. -Lbuild/temp.macosx-10.9-x86_64-3.8 -lquadpack -lmach -lmkl_rt -lpthread -lgfortran -o scipy/integrate/_quadpack.cpython-38-darwin.so
ld: library not found for -lSystem
collect2: error: ld returned 1 exit status
error: Command "/usr/local/bin/gfortran -Wall -g -arch x86_64 -Wall -g -undefined dynamic_lookup -bundle build/temp.macosx-10.9-x86_64-3.8/scipy/integrate/_quadpackmodule.o -L/Applications/anaconda3/envs/scipydev/lib -L/usr/local/Cellar/gcc/10.2.0/lib/gcc/10/gcc/x86_64-apple-darwin20/10.2.0 -L/usr/local/Cellar/gcc/10.2.0/lib/gcc/10/gcc/x86_64-apple-darwin20/10.2.0/../../.. -L/usr/local/Cellar/gcc/10.2.0/lib/gcc/10/gcc/x86_64-apple-darwin20/10.2.0/../../.. -Lbuild/temp.macosx-10.9-x86_64-3.8 -lquadpack -lmach -lmkl_rt -lpthread -lgfortran -o scipy/integrate/_quadpack.cpython-38-darwin.so" failed with exit status 1
```

#### What does this implement/fix?
<!--Please explain your changes.-->

**Instead** of using `gcc`, use `compilers` from `conda-forge` in the quickstart guide due to issues compiling. 

Basing it off of the existing ubuntu quickstart guide, which has recently had more attention, we can make a very similar macos guide.

#### Additional information
<!--Any additional information you think is important.-->


Proposed resolutions:
- film new videos (they have only 100-300 views each total, may not be worth it)
- keep links, note differences between them and guide
- remove links to videos all together