### PR TITLE
TST: stats: mark many dimension permutation t-test slow

### DIFF
--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3883,6 +3883,7 @@ class Test_ttest_ind_permutations():
         assert_array_almost_equal(stat_a, stat_p, 5)
         assert_array_almost_equal(pvalue, p_d)
 
+    @pytest.mark.slow()
     def test_ttest_ind_permutations_many_dims(self):
         # Test that permutation test works on many-dimensional arrays
         np.random.seed(0)


### PR DESCRIPTION
#### Reference issue
gh-4824

#### What does this implement/fix?
Slowest test right now is
```
6.72s call     stats/tests/test_stats.py::Test_ttest_ind_permutations::test_ttest_ind_permutations_many_dims
```
It doesn't need to run all the time, so marking it slow.