### PR TITLE
MAINT: Make keywords array static

### DIFF
--- a/scipy/fft/_pocketfft/pypocketfft.cxx
+++ b/scipy/fft/_pocketfft/pypocketfft.cxx
@@ -378,7 +378,7 @@ PyObject * good_size(PyObject * /*self*/, PyObject * args, PyObject * kwargs)
   {
   Py_ssize_t n_ = -1;
   int real = false;
-  const char * keywords[] = {"target", "real", nullptr};
+  static const char * keywords[] = {"target", "real", nullptr};
   if (!PyArg_ParseTupleAndKeywords(args, kwargs, "n|p:good_size",
                                    (char **) keywords, &n_, &real))
     return nullptr;


### PR DESCRIPTION
This is necessary to avoid reinitializing the array on every function call (the compiler has no way to know that `PyArg_ParseTupleAndKeywords` doesn't modify the array). Run `git grep -F 'kwlist[]'` to see similar code in SciPy where the arrays were already marked `static`.