### PR TITLE
DOC: Fix deprecated directive syntax

### DIFF
--- a/ci/azure-travis-template.yaml
+++ b/ci/azure-travis-template.yaml
@@ -81,7 +81,7 @@ steps:
   - script: pip install pytest-cov coverage codecov
     displayName: 'Install coverage dependencies'
 - ${{ if eq(parameters.refguide_check, true) }}:
-  - script: pip install matplotlib Sphinx==1.7.2
+  - script: pip install matplotlib sphinx==3.1
     displayName: 'Install documentation dependencies'
   - script: sudo apt-get install -y wamerican-small
     displayName: 'Install word list (for csgraph tutorial)'
@@ -172,5 +172,3 @@ steps:
       # Skip running gcov since we have already done it
       ./codecov-upload.sh -X gcov
     displayName: 'Upload coverage information'
-
-

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -950,14 +950,15 @@ def eigvalsh(a, b=None, lower=True, overwrite_a=False,
         *Deprecated by ``driver=gvd`` option*. Has no significant effect for
         eigenvalue computations since no eigenvectors are requested.
 
-        ..Deprecated in v1.5.0
+        .. deprecated:: 1.5.0
+
     eigvals : tuple (lo, hi), optional
         *Deprecated by ``subset_by_index`` keyword*. Indexes of the smallest
         and largest (in ascending order) eigenvalues and corresponding
         eigenvectors to be returned: 0 <= lo <= hi <= M-1. If omitted, all
         eigenvalues and eigenvectors are returned.
 
-        .. Deprecated in v1.5.0
+        .. deprecated:: 1.5.0
 
     Returns
     -------

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -335,7 +335,7 @@ def validate_rst_syntax(text, name, dots=True):
     ok_unknown_items = set([
         'mod', 'currentmodule', 'autosummary', 'data',
         'obj', 'versionadded', 'versionchanged', 'module', 'class', 'meth',
-        'ref', 'func', 'toctree', 'moduleauthor',
+        'ref', 'func', 'toctree', 'moduleauthor', 'deprecated',
         'sectionauthor', 'codeauthor', 'eq', 'doi', 'DOI', 'arXiv', 'arxiv'
     ])
 


### PR DESCRIPTION
Unless it was supposed to be a comment in which case there still need to
be a space after the double dot in the first case.