### PR TITLE
MAINT: streamlined kwargs for minimizer in dual_annealing

### DIFF
--- a/scipy/optimize/_dual_annealing.py
+++ b/scipy/optimize/_dual_annealing.py
@@ -7,6 +7,8 @@
 A Dual Annealing global optimization algorithm
 """
 
+import warnings
+
 import numpy as np
 from scipy.optimize import OptimizeResult
 from scipy.optimize import minimize
@@ -432,10 +434,10 @@ class LocalSearchWrapper:
 
 
 def dual_annealing(func, bounds, args=(), maxiter=1000,
-                   local_search_options={}, initial_temp=5230.,
+                   minimizer_kwargs={}, initial_temp=5230.,
                    restart_temp_ratio=2.e-5, visit=2.62, accept=-5.0,
                    maxfun=1e7, seed=None, no_local_search=False,
-                   callback=None, x0=None):
+                   callback=None, x0=None, local_search_options={}):
     """
     Find the global minimum of a function using Dual Annealing.
 
@@ -454,7 +456,7 @@ def dual_annealing(func, bounds, args=(), maxiter=1000,
         objective function.
     maxiter : int, optional
         The maximum number of global search iterations. Default value is 1000.
-    local_search_options : dict, optional
+    minimizer_kwargs : dict, optional
         Extra keyword arguments to be passed to the local minimizer
         (`minimize`). Some important options could be:
         ``method`` for the minimizer method to use and ``args`` for
@@ -512,6 +514,9 @@ def dual_annealing(func, bounds, args=(), maxiter=1000,
         If the callback implementation returns True, the algorithm will stop.
     x0 : ndarray, shape(n,), optional
         Coordinates of a single N-D starting point.
+    local_search_options : dict, optional
+        Backwards compatible flag for `minimizer_kwargs`, only one of these
+        should be supplied.
 
     Returns
     -------
@@ -631,9 +636,18 @@ def dual_annealing(func, bounds, args=(), maxiter=1000,
 
     # Wrapper for the objective function
     func_wrapper = ObjectiveFunWrapper(func, maxfun, *args)
-    # Wrapper fot the minimizer
+    # Wrapper for the minimizer
+    if local_search_options and minimizer_kwargs:
+        raise ValueError("dual_annealing only allows either 'minimizer_kwargs' (preferred) or "
+                         "'local_search_options' (deprecated); not both!")
+    if local_search_options:
+        warnings.warn("dual_annealing argument 'local_search_options' is "
+                      "deprecated in favor of 'minimizer_kwargs'",
+                      category=DeprecationWarning, stacklevel=2)
+        minimizer_kwargs = local_search_options
     minimizer_wrapper = LocalSearchWrapper(
-        bounds, func_wrapper, **local_search_options)
+        bounds, func_wrapper, **minimizer_kwargs)
+
     # Initialization of random Generator for reproducible runs if seed provided
     rand_state = check_random_state(seed)
     # Initialization of the energy state

--- a/scipy/optimize/_dual_annealing.py
+++ b/scipy/optimize/_dual_annealing.py
@@ -434,10 +434,10 @@ class LocalSearchWrapper:
 
 
 def dual_annealing(func, bounds, args=(), maxiter=1000,
-                   minimizer_kwargs={}, initial_temp=5230.,
+                   minimizer_kwargs=None, initial_temp=5230.,
                    restart_temp_ratio=2.e-5, visit=2.62, accept=-5.0,
                    maxfun=1e7, seed=None, no_local_search=False,
-                   callback=None, x0=None, local_search_options={}):
+                   callback=None, x0=None, local_search_options=None):
     """
     Find the global minimum of a function using Dual Annealing.
 
@@ -640,11 +640,15 @@ def dual_annealing(func, bounds, args=(), maxiter=1000,
     if local_search_options and minimizer_kwargs:
         raise ValueError("dual_annealing only allows either 'minimizer_kwargs' (preferred) or "
                          "'local_search_options' (deprecated); not both!")
-    if local_search_options:
+    if local_search_options is not None:
         warnings.warn("dual_annealing argument 'local_search_options' is "
                       "deprecated in favor of 'minimizer_kwargs'",
                       category=DeprecationWarning, stacklevel=2)
         minimizer_kwargs = local_search_options
+
+    # minimizer_kwargs has to be a dict, not None
+    minimizer_kwargs = minimizer_kwargs or {}
+
     minimizer_wrapper = LocalSearchWrapper(
         bounds, func_wrapper, **minimizer_kwargs)
 

--- a/scipy/optimize/tests/test__dual_annealing.py
+++ b/scipy/optimize/tests/test__dual_annealing.py
@@ -183,48 +183,33 @@ class TestDualAnnealing:
         bounds = list(zip([-6, -5], [6, 5]))
         # Test bounds can be passed (see gh-10831)
 
-        with np.testing.suppress_warnings() as sup:
-            sup.record(RuntimeWarning, "Values in x were outside bounds ")
-
+        with pytest.warns(RuntimeWarning, "Values in x were outside bounds "):
             dual_annealing(
                 func,
                 bounds=bounds,
                 minimizer_kwargs={"method": "SLSQP", "bounds": bounds})
 
-        with np.testing.suppress_warnings() as sup:
-            sup.record(RuntimeWarning, "Method CG cannot handle ")
-
-            dual_annealing(
+        with pytest.warns(RuntimeWarning, "Method CG cannot handle "):
+                dual_annealing(
                 func,
                 bounds=bounds,
                 minimizer_kwargs={"method": "CG", "bounds": bounds})
-
-            # Verify warning happened for Method cannot handle bounds.
-            assert sup.log
-
 
     def test_deprecated_local_search_options_bounds(self):
         func = lambda x: np.sum((x-5) * (x-1))
         bounds = list(zip([-6, -5], [6, 5]))
         # Test bounds can be passed (see gh-10831)
-        with np.testing.suppress_warnings() as sup:
-            sup.record(DeprecationWarning, "dual_annealing argument 'local_search_options'")
+        with pytest.warns(RuntimeWarning, "dual_annealing argument "):
             dual_annealing(
                 func,
                 bounds=bounds,
                 local_search_options={"method": "SLSQP", "bounds": bounds})
 
-        with np.testing.suppress_warnings() as sup:
-            sup.record(RuntimeWarning, "Method CG cannot handle ")
-
+        with pytest.warns(RuntimeWarning, "Method CG cannot handle "):
             dual_annealing(
                 func,
                 bounds=bounds,
                 minimizer_kwargs={"method": "CG", "bounds": bounds})
-
-            # Verify warning happened for Method cannot handle bounds.
-            assert sup.log
-
             
     def test_minimizer_kwargs_bounds(self):
         func = lambda x: np.sum((x-5) * (x-1))
@@ -235,16 +220,11 @@ class TestDualAnnealing:
             bounds=bounds,
             minimizer_kwargs={"method": "SLSQP", "bounds": bounds})
 
-        with np.testing.suppress_warnings() as sup:
-            sup.record(RuntimeWarning, "Method CG cannot handle ")
-
+        with pytest.warns(RuntimeWarning, "Method CG cannot handle "):
             dual_annealing(
                 func,
                 bounds=bounds,
                 minimizer_kwargs={"method": "CG", "bounds": bounds})
-
-            # Verify warning happened for Method cannot handle bounds.
-            assert sup.log
 
     def test_max_fun_ls(self):
         ret = dual_annealing(self.func, self.ld_bounds, maxfun=100,

--- a/scipy/optimize/tests/test__dual_annealing.py
+++ b/scipy/optimize/tests/test__dual_annealing.py
@@ -178,34 +178,17 @@ class TestDualAnnealing:
         assert_raises(ValueError, dual_annealing, self.func,
                       invalid_bounds)
 
-    def test_minimizer_kwargs_bounds(self):
-        func = lambda x: np.sum((x-5) * (x-1))
-        bounds = list(zip([-6, -5], [6, 5]))
-        # Test bounds can be passed (see gh-10831)
-
-        with pytest.warns(RuntimeWarning, "Values in x were outside bounds "):
-            dual_annealing(
-                func,
-                bounds=bounds,
-                minimizer_kwargs={"method": "SLSQP", "bounds": bounds})
-
-        with pytest.warns(RuntimeWarning, "Method CG cannot handle "):
-                dual_annealing(
-                func,
-                bounds=bounds,
-                minimizer_kwargs={"method": "CG", "bounds": bounds})
-
     def test_deprecated_local_search_options_bounds(self):
         func = lambda x: np.sum((x-5) * (x-1))
         bounds = list(zip([-6, -5], [6, 5]))
         # Test bounds can be passed (see gh-10831)
-        with pytest.warns(RuntimeWarning, "dual_annealing argument "):
+        with pytest.warns(DeprecationWarning, match=r"dual_annealing argument "):
             dual_annealing(
                 func,
                 bounds=bounds,
                 local_search_options={"method": "SLSQP", "bounds": bounds})
 
-        with pytest.warns(RuntimeWarning, "Method CG cannot handle "):
+        with pytest.warns(RuntimeWarning, match=r"Method CG cannot handle "):
             dual_annealing(
                 func,
                 bounds=bounds,
@@ -220,7 +203,7 @@ class TestDualAnnealing:
             bounds=bounds,
             minimizer_kwargs={"method": "SLSQP", "bounds": bounds})
 
-        with pytest.warns(RuntimeWarning, "Method CG cannot handle "):
+        with pytest.warns(RuntimeWarning, match=r"Method CG cannot handle "):
             dual_annealing(
                 func,
                 bounds=bounds,

--- a/scipy/optimize/tests/test__dual_annealing.py
+++ b/scipy/optimize/tests/test__dual_annealing.py
@@ -178,7 +178,7 @@ class TestDualAnnealing:
         assert_raises(ValueError, dual_annealing, self.func,
                       invalid_bounds)
 
-    def test_local_search_option_bounds(self):
+    def test_minimizer_kwargs_bounds(self):
         func = lambda x: np.sum((x-5) * (x-1))
         bounds = list(zip([-6, -5], [6, 5]))
         # Test bounds can be passed (see gh-10831)
@@ -186,6 +186,29 @@ class TestDualAnnealing:
         with np.testing.suppress_warnings() as sup:
             sup.record(RuntimeWarning, "Values in x were outside bounds ")
 
+            dual_annealing(
+                func,
+                bounds=bounds,
+                minimizer_kwargs={"method": "SLSQP", "bounds": bounds})
+
+        with np.testing.suppress_warnings() as sup:
+            sup.record(RuntimeWarning, "Method CG cannot handle ")
+
+            dual_annealing(
+                func,
+                bounds=bounds,
+                minimizer_kwargs={"method": "CG", "bounds": bounds})
+
+            # Verify warning happened for Method cannot handle bounds.
+            assert sup.log
+
+
+    def test_deprecated_local_search_options_bounds(self):
+        func = lambda x: np.sum((x-5) * (x-1))
+        bounds = list(zip([-6, -5], [6, 5]))
+        # Test bounds can be passed (see gh-10831)
+        with np.testing.suppress_warnings() as sup:
+            sup.record(DeprecationWarning, "dual_annealing argument 'local_search_options'")
             dual_annealing(
                 func,
                 bounds=bounds,
@@ -197,7 +220,28 @@ class TestDualAnnealing:
             dual_annealing(
                 func,
                 bounds=bounds,
-                local_search_options={"method": "CG", "bounds": bounds})
+                minimizer_kwargs={"method": "CG", "bounds": bounds})
+
+            # Verify warning happened for Method cannot handle bounds.
+            assert sup.log
+
+            
+    def test_minimizer_kwargs_bounds(self):
+        func = lambda x: np.sum((x-5) * (x-1))
+        bounds = list(zip([-6, -5], [6, 5]))
+        # Test bounds can be passed (see gh-10831)
+        dual_annealing(
+            func,
+            bounds=bounds,
+            minimizer_kwargs={"method": "SLSQP", "bounds": bounds})
+
+        with np.testing.suppress_warnings() as sup:
+            sup.record(RuntimeWarning, "Method CG cannot handle ")
+
+            dual_annealing(
+                func,
+                bounds=bounds,
+                minimizer_kwargs={"method": "CG", "bounds": bounds})
 
             # Verify warning happened for Method cannot handle bounds.
             assert sup.log
@@ -257,7 +301,7 @@ class TestDualAnnealing:
     ])
     def test_multi_ls_minimizer(self, method, atol):
         ret = dual_annealing(self.func, self.ld_bounds,
-                             local_search_options=dict(method=method),
+                             minimizer_kwargs=dict(method=method),
                              seed=self.seed)
         assert_allclose(ret.fun, 0., atol=atol)
 
@@ -272,7 +316,7 @@ class TestDualAnnealing:
             'jac': self.rosen_der_wrapper,
         }
         ret = dual_annealing(rosen, self.ld_bounds,
-                             local_search_options=minimizer_opts,
+                             minimizer_kwargs=minimizer_opts,
                              seed=self.seed)
         assert ret.njev == self.ngev
 


### PR DESCRIPTION
This fixes so that all global optimization strategies uses
`minimizer_kwargs` as the arguments for the `minimizer`.
This makes it compatible with `shgo` and `bassin_hopping`.

The `dual_annealing` previously only had `local_search_options`
as the kwarg, which is not compatible with the other ones.

The old name is kept for backward compatibility but is marked as deprecated.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->
