### PR TITLE
MAINT: stats: allow wishart dim - 1 < df < dim

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -1719,8 +1719,8 @@ class wishart_gen(multi_rv_generic):
     distribution :math:`W_1(\nu, 1)` collapses to the :math:`\chi^2(\nu)`
     distribution.
 
-    The algorithm [2]_ implemented by the `rvs` method occasionally
-    produces numerically singular matrices with :math:`p - 1 < \nu < p`; the
+    The algorithm [2]_ implemented by the `rvs` method may
+    produce numerically singular matrices with :math:`p - 1 < \nu < p`; the
     user may wish to check for this condition and generate replacement samples
     as necessary.
 

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -1651,7 +1651,9 @@ class wishart_gen(multi_rv_generic):
     specifies the scale matrix, which must be symmetric and positive definite.
     In this context, the scale matrix is often interpreted in terms of a
     multivariate normal precision matrix (the inverse of the covariance
-    matrix).
+    matrix). These arguments must satisfy the relationship
+    ``df > scale.ndim - 1``, but see notes on using the `rvs` method with
+    ``df < scale.ndim``.
 
     Methods
     -------
@@ -1717,6 +1719,12 @@ class wishart_gen(multi_rv_generic):
     distribution :math:`W_1(\nu, 1)` collapses to the :math:`\chi^2(\nu)`
     distribution.
 
+    The algorithm [2]_ implemented by the `rvs` method occasionally
+    produces numerically singular matrices with :math:`p - 1 < \nu < p`; the
+    user may wish to check for this condition and generate replacement samples
+    as necessary.
+
+
     .. versionadded:: 0.16.0
 
     References
@@ -1778,9 +1786,9 @@ class wishart_gen(multi_rv_generic):
             df = dim
         elif not np.isscalar(df):
             raise ValueError("Degrees of freedom must be a scalar.")
-        elif df < dim:
-            raise ValueError("Degrees of freedom cannot be less than dimension"
-                             " of scale matrix, but df = %d" % df)
+        elif df <= dim - 1:
+            raise ValueError("Degrees of freedom must be greater than the "
+                             "dimension of scale matrix minus 1.")
 
         return dim, df, scale
 

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -17,8 +17,8 @@ import numpy as np
 
 import scipy.linalg
 from scipy.stats._multivariate import (_PSD,
-                                       _lnB, 
-                                       _cho_inv_batch, 
+                                       _lnB,
+                                       _cho_inv_batch,
                                        multivariate_normal_frozen)
 from scipy.stats import (multivariate_normal, multivariate_hypergeom,
                          matrix_normal, special_ortho_group, ortho_group,
@@ -875,8 +875,12 @@ class TestWishart(object):
             assert_equal(w.scale, true_scale)
             assert_equal(w.scale.shape, true_scale.shape)
 
-        # We cannot call with a df < dim
+        # We cannot call with a df < dim - 1
         assert_raises(ValueError, wishart, 1, np.eye(2))
+
+        # But we can call with dim - 1 < df < dim
+        wishart(1.1, np.eye(2))  # no error
+        # see gh-5562
 
         # We cannot call with a 3-dimension array
         scale = np.array(1, ndmin=3)
@@ -1758,7 +1762,7 @@ class TestMultivariateT:
         assert mock.call_count == 2
 
     def test_shape_correctness(self):
-        # pdf and logpdf should return scalar when the 
+        # pdf and logpdf should return scalar when the
         # number of samples in x is one.
         dim = 4
         loc = np.zeros(dim)
@@ -1770,7 +1774,7 @@ class TestMultivariateT:
         res = multivariate_t(loc, shape, df).logpdf(x)
         assert np.isscalar(res)
 
-        # pdf() and logpdf() should return probabilities of shape 
+        # pdf() and logpdf() should return probabilities of shape
         # (n_samples,) when x has n_samples.
         n_samples = 7
         x = np.random.random((n_samples, dim))
@@ -1783,7 +1787,7 @@ class TestMultivariateT:
         res = multivariate_t(np.zeros(1), np.eye(1), 1).rvs()
         assert np.isscalar(res)
 
-        # rvs() should return vector of shape (size,) if size argument 
+        # rvs() should return vector of shape (size,) if size argument
         # is applied.
         size = 7
         res = multivariate_t(np.zeros(1), np.eye(1), 1).rvs(size=size)


### PR DESCRIPTION
#### Reference issue
Closes gh-5562

#### What does this implement/fix?
> The degrees of freedom $v$ of a Wishart distribution are currently limited to be equal or greater than the dimensions $p$ of the scale matrix. However, degrees of freedom do not have to be integers. In case of a float, they should be $v > p-1$.

The reason for this limit was that the `rvs` method produces singular matrices when $v < dim$, which are not within the support of the distribution. This seems to be a problem with the algorithm rather than the implementation, as Matlab suffers from the same problem.

As there is still value in using the distribution with $v < p$, one compromise is to allow $p - 1 < v < p$ but mention the RVS issue in the documentation. That's the approach I took.

#### Additional information
Matlab still suffers from the same problem; I checked the example code in gh-5562.