### PR TITLE
BUG: Fix Python crash by allocating larger array in LSQBivariateSpline

### DIFF
--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -1233,17 +1233,24 @@ class LSQBivariateSpline(BivariateSpline):
 
         nx = 2*kx+2+len(tx)
         ny = 2*ky+2+len(ty)
-        tx1 = zeros((nx,), float)
-        ty1 = zeros((ny,), float)
+        # The Fortran subroutine "surfit" (called as dfitpack.surfit_lsq)
+        # requires that the knot arrays passed as input should be "real
+        # array(s) of dimension nmax" where "nmax" refers to the greater of nx
+        # and ny. We pad the tx1/ty1 arrays here so that this is satisfied, and
+        # slice them to the desired sizes upon return.
+        nmax = max(nx, ny)
+        tx1 = zeros((nmax,), float)
+        ty1 = zeros((nmax,), float)
         tx1[kx+1:nx-kx-1] = tx
         ty1[ky+1:ny-ky-1] = ty
 
         xb, xe, yb, ye = bbox
-        tx1, ty1, c, fp, ier = dfitpack.surfit_lsq(x, y, z, tx1, ty1, w,
-                                                   xb, xe, yb, ye,
+        tx1, ty1, c, fp, ier = dfitpack.surfit_lsq(x, y, z, nx, tx1, ny, ty1,
+                                                   w, xb, xe, yb, ye,
                                                    kx, ky, eps, lwrk2=1)
         if ier > 10:
-            tx1, ty1, c, fp, ier = dfitpack.surfit_lsq(x, y, z, tx1, ty1, w,
+            tx1, ty1, c, fp, ier = dfitpack.surfit_lsq(x, y, z,
+                                                       nx, tx1, ny, ty1, w,
                                                        xb, xe, yb, ye,
                                                        kx, ky, eps, lwrk2=ier)
         if ier in [0, -1, -2]:  # normal return
@@ -1256,7 +1263,7 @@ class LSQBivariateSpline(BivariateSpline):
                 message = _surfit_messages.get(ier, 'ier=%s' % (ier))
             warnings.warn(message)
         self.fp = fp
-        self.tck = tx1, ty1, c
+        self.tck = tx1[:nx], ty1[:ny], c
         self.degrees = kx, ky
 
 

--- a/scipy/interpolate/src/fitpack.pyf
+++ b/scipy/interpolate/src/fitpack.pyf
@@ -497,7 +497,7 @@ static F_INT calc_regrid_lwrk(F_INT mx, F_INT my, F_INT kx, F_INT ky,
      subroutine surfit_lsq(iopt,m,x,y,z,w,xb,xe,yb,ye,kx,ky,s,nxest,nyest,&
           nmax,eps,nx,tx,ny,ty,c,fp,wrk1,lwrk1,wrk2,lwrk2,&
           iwrk,kwrk,ier)
-       ! tx,ty,c,fp,ier = surfit_lsq(x,y,z,tx,ty,[w,xb,xe,yb,ye,kx,ky,eps,lwrk2])
+       ! tx,ty,c,fp,ier = surfit_lsq(x,y,z,nx,tx,ny,ty,[w,xb,xe,yb,ye,kx,ky,eps,lwrk2])
 
        fortranname surfit
        threadsafe
@@ -520,10 +520,10 @@ static F_INT calc_regrid_lwrk(F_INT mx, F_INT my, F_INT kx, F_INT ky,
        integer intent(hide),depend(ny) :: nyest = ny
        integer intent(hide),depend(nx,ny) :: nmax=MAX(nx,ny)
        real*8 optional,check(0.0<eps && eps<1.0) :: eps = 1e-16
-       integer intent(hide),depend(tx,kx),check(2*kx+2<=nx) :: nx = len(tx)
-       real*8 dimension(nx),intent(in,out,overwrite) :: tx
-       integer intent(hide),depend(ty,ky),check(2*ky+2<=ny) :: ny = len(ty)
-       real*8 dimension(ny),intent(in,out,overwrite) :: ty
+       integer intent(in),depend(kx),check(2*kx+2<=nx) :: nx
+       real*8 dimension(nmax),depend(nmax),intent(in,out,overwrite) :: tx
+       integer intent(in),depend(ky),check(2*ky+2<=ny) :: ny
+       real*8 dimension(nmax),depend(nmax),intent(in,out,overwrite) :: ty
        real*8 dimension((nx-kx-1)*(ny-ky-1)),depend(kx,ky,nx,ny),intent(out) :: c
        real*8 intent(out) :: fp
        real*8 dimension(lwrk1),intent(cache,hide),depend(lwrk1) :: wrk1

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -466,6 +466,23 @@ class TestLSQBivariateSpline(object):
             assert_allclose(spl1(2.0, 2.0), spl2(2.0, 2.0))
             assert_equal(len(r), 2)
 
+    def test_unequal_length_of_knots(self):
+        """Test for the case when the input knot-location arrays in x and y are
+        of different lengths.
+        """
+        x, y = np.mgrid[0:100, 0:100]
+        x = x.ravel()
+        y = y.ravel()
+        z = 3.0 * np.ones_like(x)
+        tx = np.linspace(0.1, 98.0, 29)
+        ty = np.linspace(0.1, 98.0, 33)
+        with suppress_warnings() as sup:
+            r = sup.record(UserWarning, "\nThe coefficients of the spline")
+            lut = LSQBivariateSpline(x,y,z,tx,ty)
+            assert_equal(len(r), 1)
+
+        assert_almost_equal(lut(x, y, grid=False), z)
+
 
 class TestSmoothBivariateSpline(object):
     def test_linear_constant(self):


### PR DESCRIPTION
#### Reference issue
Closes gh-13356.

#### What does this implement/fix?
In `scipy.interpolate.LSQBivariateSpline`, which calls the Fortran subroutine `surfit` as `dfitpack.surfit_lsq` via F2PY, pad both of the knot arrays to the size demanded by the Fortran routine. This fixes the memory error when the sizes of the input knot arrays are different.

#### Additional information
**Note**: The call signature to `dfitpack.surfit_lsq` is changed as a result of this fix. The input parameters `nx` and `ny` **are no longer optional**. This will break client code that calls the F2PY-generated `dfitpack.surfit_lsq()` function directly.

An additional test is added that explicitly set the knot arrays to be unequal lengths. The input sizes in the test are also larger than the typical ones we've had so far.