### PR TITLE
MAINT:linalg: Fix tgsen family wrapper and ordqz

### DIFF
--- a/scipy/linalg/_decomp_qz.py
+++ b/scipy/linalg/_decomp_qz.py
@@ -281,10 +281,12 @@ def ordqz(A, B, sort='lhp', output='real', overwrite_a=False,
         complex matrix pairs both ``alpha`` and ``beta`` can be
         complex. The callable must be able to accept a NumPy
         array. Alternatively, string parameters may be used:
+
             - 'lhp'   Left-hand plane (x.real < 0.0)
             - 'rhp'   Right-hand plane (x.real > 0.0)
             - 'iuc'   Inside the unit circle (x*x.conjugate() < 1.0)
             - 'ouc'   Outside the unit circle (x*x.conjugate() > 1.0)
+
         With the predefined sorting functions, an infinite eigenvalue
         (i.e., ``alpha != 0`` and ``beta = 0``) is considered to lie in
         neither the left-hand nor the right-hand plane, but it is
@@ -302,6 +304,7 @@ def ordqz(A, B, sort='lhp', output='real', overwrite_a=False,
         If true checks the elements of `A` and `B` are finite numbers. If
         false does no checking and passes matrix through to
         underlying algorithm.
+
     Returns
     -------
     AA : (N, N) ndarray
@@ -316,6 +319,7 @@ def ordqz(A, B, sort='lhp', output='real', overwrite_a=False,
         The left Schur vectors.
     Z : (N, N) ndarray
         The right Schur vectors.
+
     Notes
     -----
     On exit, ``(ALPHAR(j) + ALPHAI(j)*i)/BETA(j), j=1,...,N``, will be the
@@ -339,9 +343,12 @@ def ordqz(A, B, sort='lhp', output='real', overwrite_a=False,
     >>> A = np.array([[2, 5, 8, 7], [5, 2, 2, 8], [7, 5, 6, 6], [5, 4, 4, 8]])
     >>> B = np.array([[0, 6, 0, 0], [5, 0, 2, 1], [5, 2, 6, 6], [4, 7, 7, 7]])
     >>> AA, BB, alpha, beta, Q, Z = ordqz(A, B, sort='lhp')
+
     Since we have sorted for left half plane eigenvalues, negatives come first
+
     >>> (alpha/beta).real < 0
     array([ True,  True, False, False], dtype=bool)
+
     """
     result, typ = _qz(A, B, output=output, sort=None,
                       overwrite_a=overwrite_a, overwrite_b=overwrite_b,

--- a/scipy/linalg/flapack_other.pyf.src
+++ b/scipy/linalg/flapack_other.pyf.src
@@ -47,63 +47,143 @@ subroutine <prefix2>tgsen(ijob,wantq,wantz,select,n,a,lda,b,ldb,alphar,alphai,be
     callstatement (*f2py_func)(&ijob,&wantq,&wantz,select,&n,a,&lda,b,&ldb,alphar,alphai,beta,q,&ldq,z,&ldz,&m,&pl,&pr,dif,work,&lwork,iwork,&liwork,&info)
     callprotoargument F_INT*,F_INT*,F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,F_INT*,F_INT*
 
-    integer intent(hide) :: ijob=4
-    integer intent(hide),check(wantq==0||wantq==1) :: wantq=1
-    integer intent(hide),check(wantz==0||wantz==1) :: wantz=1
-    logical intent(in),dimension(n) :: select
-    integer intent(hide),depend(a) :: n=shape(a,1)
-    <ftype2> intent(in,out,copy),dimension(lda,n) :: a
-    integer intent(hide),depend(a) :: lda=shape(a,0)
-    <ftype2> intent(in,out,copy),dimension(ldb,n) :: b
-    integer intent(hide),depend(b) :: ldb=shape(b,0)
-    <ftype2> intent(out),dimension(n) :: alphar
-    <ftype2> intent(out),dimension(n) :: alphai
-    <ftype2> intent(out),dimension(n) :: beta
-    <ftype2> intent(in,out,copy),dimension(ldq,n) :: q
-    integer intent(hide),depend(q) :: ldq=shape(q,0)
-    <ftype2> intent(in,out,copy),dimension(ldz,n) :: z
-    integer intent(hide),depend(z) :: ldz=shape(z,0)
+    integer optional, intent(in),check(ijob>=0&&ijob<=5) :: ijob=4
+    logical optional, intent(in),check(wantq==0||wantq==1) :: wantq=1
+    logical optional, intent(in),check(wantz==0||wantz==1) :: wantz=1
+    logical intent(in),dimension(n),depend(n) :: select
+    integer intent(hide),depend(a) :: n=shape(a,0)
+    <ftype2> intent(in,out,copy,out=as),dimension(n,n) :: a
+    integer intent(hide),depend(a) :: lda=MAX(1,shape(a,0))
+    <ftype2> intent(in,out,copy,out=bs),dimension(n,n) :: b
+    integer intent(hide),depend(b) :: ldb = MAX(1, shape(b,0))
+    <ftype2> intent(out),dimension(n),depend(n) :: alphar
+    <ftype2> intent(out),dimension(n),depend(n) :: alphai
+    <ftype2> intent(out),dimension(n),depend(n) :: beta
+    <ftype2> intent(in,out,copy,out=qs),dimension(n,n),depend(n) :: q
+    integer intent(hide),depend(q) :: ldq=MAX(1,shape(q,0))
+    <ftype2> intent(in,out,copy,out=zs),dimension(n,n),depend(n) :: z
+    integer intent(hide),depend(z) :: ldz=MAX(1,shape(z,0))
     integer intent(out) :: m
     <ftype2> intent(out) :: pl
     <ftype2> intent(out) :: pr
     <ftype2> intent(out),dimension(2) :: dif
-    <ftype2> intent(out),dimension(MAX(lwork,1)) :: work
-    integer optional,intent(in),depend(m,n),check(lwork == -1 || lwork >= MAX(4*n+16,2*m*(n-m))) :: lwork=max(MAX(4*n+16,2*m*(n-m)),1)
-    integer intent(out),dimension(MAX(1,liwork)) :: iwork
-    integer optional,intent(in),depend(n),check(liwork == -1 || liwork >= n+6) :: liwork=n+6
+    <ftype2> intent(hide),dimension(MAX(lwork,1)) :: work
+    ! these lwork and liwork values are bare minimum estiamates only for cases ijob == 1,2,4
+    ! a separate lwork query is a prerequisite due to m dependence.
+    ! Depending on the m value lwork can go upto n**2 / 4 for n = 2m hence it is not
+    ! possible to give a minimal value without a potential excessive memory waste
+    integer optional,intent(in),depend(n),check(lwork == -1 || lwork >= 1) :: lwork=4*n+16
+    integer intent(hide),dimension(MAX(1,liwork)) :: iwork
+    integer optional,intent(in),depend(n),check(liwork == -1 || liwork >= 1) :: liwork=n+6
     integer intent(out) :: info
 
 end subroutine <prefix2>tgsen
+
+subroutine <prefix2>tgsen_lwork(ijob,wantq,wantz,select,n,a,lda,b,ldb,alphar,alphai,beta,q,ldq,z,ldz,m,pl,pr,dif,work,lwork,iwork,liwork,info)
+
+    fortranname <prefix2>tgsen
+    callstatement (*f2py_func)(&ijob,&wantq,&wantz,select,&n,a,&lda,&b,&ldb,&alphar,&alphai,&beta,&q,&ldq,&z,&ldz,&m,&pl,&pr,&dif,&work,&lwork,&iwork,&liwork,&info)
+    callprotoargument F_INT*,F_INT*,F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,F_INT*,F_INT*
+
+    integer optional, intent(in),check(ijob>=0&&ijob<=5) :: ijob = 4
+    logical intent(in),dimension(n),depend(n) :: select
+    <ftype2> intent(in),dimension(n,n) :: a
+
+    logical intent(hide) :: wantq = 0
+    logical intent(hide) :: wantz = 0
+    integer intent(hide),depend(a) :: n = shape(a,0)
+    integer intent(hide),depend(n) :: lda = MAX(1, n)
+    <ftype2> intent(hide) :: b
+    integer intent(hide),depend(n) :: ldb = MAX(1, n)
+    <ftype2> intent(hide) :: alphar
+    <ftype2> intent(hide) :: alphai
+    <ftype2> intent(hide) :: beta
+    <ftype2> intent(hide) :: q
+    integer intent(hide),depend(n) :: ldq = MAX(1, n)
+    <ftype2> intent(hide) :: z
+    integer intent(hide),depend(n) :: ldz = MAX(1, n)
+    integer intent(hide) :: m
+    <ftype2> intent(hide) :: pl
+    <ftype2> intent(hide) :: pr
+    <ftype2> intent(hide),dimension(2) :: dif
+    integer intent(hide):: lwork=-1
+    integer intent(hide) :: liwork=-1
+
+    <ftype2> intent(out) :: work
+    integer intent(out) :: iwork
+    integer intent(out) :: info
+
+end subroutine <prefix2>tgsen_lwork
 
 subroutine <prefix2c>tgsen(ijob,wantq,wantz,select,n,a,lda,b,ldb,alpha,beta,q,ldq,z,ldz,m,pl,pr,dif,work,lwork,iwork,liwork,info)
     callstatement (*f2py_func)(&ijob,&wantq,&wantz,select,&n,a,&lda,b,&ldb,alpha,beta,q,&ldq,z,&ldz,&m,&pl,&pr,dif,work,&lwork,iwork,&liwork,&info)
     callprotoargument F_INT*,F_INT*,F_INT*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,<ctype2c>*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2c>*,F_INT*,F_INT*,F_INT*,F_INT*
 
-    integer intent(hide) :: ijob=4
-    integer intent(hide),check(wantq==0||wantq==1) :: wantq=1
-    integer intent(hide),check(wantz==0||wantz==1) :: wantz=1
-    logical intent(in),dimension(n) :: select
-    integer intent(hide),depend(a) :: n=shape(a,1)
-    <ftype2c> intent(in,out,copy),dimension(lda,n) :: a
-    integer intent(hide),depend(a) :: lda=shape(a,0)
-    <ftype2c> intent(in,out,copy),dimension(ldb,n) :: b
-    integer intent(hide),depend(b) :: ldb=shape(b,0)
-    <ftype2c> intent(out),dimension(n) :: alpha
-    <ftype2c> intent(out),dimension(n) :: beta
-    <ftype2c> intent(in,out,copy),dimension(ldq,n) :: q
-    integer intent(hide),depend(q) :: ldq=shape(q,0)
-    <ftype2c> intent(in,out,copy),dimension(ldz,n) :: z
-    integer intent(hide),depend(z) :: ldz=shape(z,0)
+    integer optional, intent(in),check(ijob>=0&&ijob<=5) :: ijob=4
+    logical optional, intent(in),check(wantq==0||wantq==1) :: wantq=1
+    logical optional, intent(in),check(wantz==0||wantz==1) :: wantz=1
+    logical intent(in),dimension(n),depend(n) :: select
+    integer intent(hide),depend(a) :: n=shape(a,0)
+    <ftype2c> intent(in,out,copy,out=as),dimension(n,n) :: a
+    integer intent(hide),depend(a) :: lda=MAX(1,shape(a,0))
+    <ftype2c> intent(in,out,copy,out=bs),dimension(n,n) :: b
+    integer intent(hide),depend(b) :: ldb = MAX(1, shape(b,0))
+    <ftype2c> intent(out),dimension(n),depend(n) :: alpha
+    <ftype2c> intent(out),dimension(n),depend(n) :: beta
+    <ftype2c> intent(in,out,copy,out=qs),dimension(n,n),depend(n) :: q
+    integer intent(hide),depend(q) :: ldq=MAX(1,shape(q,0))
+    <ftype2c> intent(in,out,copy,out=zs),dimension(n,n),depend(n) :: z
+    integer intent(hide),depend(z) :: ldz=MAX(1,shape(z,0))
     integer intent(out) :: m
     <ftype2> intent(out) :: pl
     <ftype2> intent(out) :: pr
     <ftype2> intent(out),dimension(2) :: dif
-    <ftype2c> intent(out),dimension(MAX(lwork,1)) :: work
-    integer optional,intent(in),depend(m,n),check(lwork == -1 || lwork >= 2*m*(n-m)) :: lwork=max(2*m*(n-m),1)
-    integer intent(out),dimension(MAX(1,liwork)):: iwork
-    integer optional,intent(in),depend(n),check(liwork == -1 || liwork>=n+2) :: liwork=n+2
+    <ftype2c> intent(hide),dimension(MAX(lwork,1)) :: work
+    ! these lwork and liwork values are bare minimum estiamates only for cases ijob ==0,1,2,4
+    ! a separate lwork query is a prerequisite due to m dependence.
+    ! Depending on the m value lwork can go upto n**2 / 4 for n = 2m hence it is not
+    ! possible to give a minimal value without a potential excessive memory waste
+    integer optional,intent(in),depend(n,ijob),check(lwork == -1 || lwork >= 1) :: lwork=(ijob==0?1:n+2)
+    integer intent(hide),dimension(liwork):: iwork
+    integer optional,intent(in),depend(n,ijob),check(liwork == -1 || liwork>=1) :: liwork=(ijob==0?1:n+2)
     integer intent(out) :: info
+
 end subroutine <prefix2c>tgsen
+
+subroutine <prefix2c>tgsen_lwork(ijob,wantq,wantz,select,n,a,lda,b,ldb,alpha,beta,q,ldq,z,ldz,m,pl,pr,dif,work,lwork,iwork,liwork,info)
+
+    fortranname <prefix2c>tgsen
+    callstatement (*f2py_func)(&ijob,&wantq,&wantz,select,&n,a,&lda,b,&ldb,alpha,beta,&q,&ldq,&z,&ldz,&m,&pl,&pr,&dif,&work,&lwork,&iwork,&liwork,&info)
+    callprotoargument F_INT*,F_INT*,F_INT*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,<ctype2c>*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2c>*,F_INT*,F_INT*,F_INT*,F_INT*
+
+    integer optional, intent(in),check(ijob>=0&&ijob<=5) :: ijob = 4
+    logical intent(in),dimension(n),depend(n) :: select
+    <ftype2c> intent(in),dimension(n,n) :: a
+    <ftype2c> intent(in),dimension(n,n) :: b
+
+    logical intent(hide) :: wantq = 0
+    logical intent(hide) :: wantz = 0
+    integer intent(hide),depend(a) :: n = shape(a,0)
+    integer intent(hide),depend(n) :: lda = MAX(1, n)
+    integer intent(hide),depend(n) :: ldb = MAX(1, n)
+    <ftype2c> intent(hide),dimension(n) :: alpha
+    <ftype2c> intent(hide),dimension(n) :: beta
+    <ftype2c> intent(hide) :: q
+    integer intent(hide),depend(n) :: ldq = MAX(1, n)
+    <ftype2c> intent(hide) :: z
+    integer intent(hide),depend(n) :: ldz = MAX(1, n)
+    integer intent(hide) :: m
+    <ftype2> intent(hide) :: pl
+    <ftype2> intent(hide) :: pr
+    <ftype2> intent(hide),dimension(2) :: dif
+    integer intent(hide):: lwork=-1
+    integer intent(hide) :: liwork=-1
+
+    <ftype2c> intent(out) :: work
+    integer intent(out) :: iwork
+    integer intent(out) :: info
+
+end subroutine <prefix2c>tgsen_lwork
 
 subroutine <prefix2>pbtrf(lower,n,kd,ab,ldab,info)
     ! Compute Cholesky decomposition of banded symmetric positive definite

--- a/scipy/linalg/flapack_other.pyf.src
+++ b/scipy/linalg/flapack_other.pyf.src
@@ -105,7 +105,7 @@ subroutine <prefix2>tgsen_lwork(ijob,wantq,wantz,select,n,a,lda,b,ldb,alphar,alp
     integer intent(hide) :: m
     <ftype2> intent(hide) :: pl
     <ftype2> intent(hide) :: pr
-    <ftype2> intent(hide),dimension(2) :: dif
+    <ftype2> intent(hide) :: dif
     integer intent(hide):: lwork=-1
     integer intent(hide) :: liwork=-1
 
@@ -175,7 +175,7 @@ subroutine <prefix2c>tgsen_lwork(ijob,wantq,wantz,select,n,a,lda,b,ldb,alpha,bet
     integer intent(hide) :: m
     <ftype2> intent(hide) :: pl
     <ftype2> intent(hide) :: pr
-    <ftype2> intent(hide),dimension(2) :: dif
+    <ftype2> intent(hide) :: dif
     integer intent(hide):: lwork=-1
     integer intent(hide) :: liwork=-1
 

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -694,6 +694,11 @@ All functions
    ctgsen
    ztgsen
 
+   stgsen_lwork
+   dtgsen_lwork
+   ctgsen_lwork
+   ztgsen_lwork
+
    stpttf
    dtpttf
    ctpttf


### PR DESCRIPTION
#### Reference issue
Closes #13243

#### What does this implement/fix?
The tgsen family was apart from a few trivial cases were impossible to use due to the wrappers depending on the output values at the input. I think this is also related to the ancient QZ sorting segfaults. 

Pinging @Sbte in case you want to test it.