### PR TITLE
BUG: sparse: Better validation for BSR ctor

### DIFF
--- a/scipy/sparse/bsr.py
+++ b/scipy/sparse/bsr.py
@@ -154,7 +154,11 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
             elif len(arg1) == 2:
                 # (data,(row,col)) format
                 from .coo import coo_matrix
-                self._set_self(coo_matrix(arg1, dtype=dtype).tobsr(blocksize=blocksize))
+                self._set_self(
+                    coo_matrix(arg1, dtype=dtype, shape=shape).tobsr(
+                        blocksize=blocksize
+                    )
+                )
 
             elif len(arg1) == 3:
                 # (data,indices,indptr) format
@@ -167,11 +171,22 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
                     maxval = max(shape)
                 if blocksize is not None:
                     maxval = max(maxval, max(blocksize))
-                idx_dtype = get_index_dtype((indices, indptr), maxval=maxval, check_contents=True)
-
+                idx_dtype = get_index_dtype((indices, indptr), maxval=maxval,
+                                            check_contents=True)
                 self.indices = np.array(indices, copy=copy, dtype=idx_dtype)
                 self.indptr = np.array(indptr, copy=copy, dtype=idx_dtype)
-                self.data = np.array(data, copy=copy, dtype=getdtype(dtype, data))
+                self.data = np.array(data, copy=copy,
+                                     dtype=getdtype(dtype, data, float))
+                if self.data.ndim != 3:
+                    raise ValueError(
+                        'BSR data must be 3-dimensional, got shape=%s' % (
+                            self.data.shape,))
+                if blocksize is not None:
+                    if not isshape(blocksize):
+                        raise ValueError('invalid blocksize=%s' % (blocksize,))
+                    if tuple(blocksize) != self.data.shape[1:]:
+                        raise ValueError('mismatching blocksize=%s vs %s' % (
+                            blocksize, self.data.shape[1:]))
             else:
                 raise ValueError('unrecognized bsr_matrix constructor usage')
         else:


### PR DESCRIPTION
See gh-13241 for an example where ignoring the given `blocksize` parameter was causing confusion.

This PR includes:

 * passing `shape` along to the COO constructor
 * providing a default dtype for the `data` array
 * checking the `ndim` of the processed `data` array
 * checking that an explicitly passed `blocksize` parameter matches the implicitly-derived block size