### PR TITLE
BUG: sparse: Propagate dtype through CSR/CSC constructors

### DIFF
--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -51,7 +51,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                 if len(arg1) == 2:
                     # (data, ij) format
                     from .coo import coo_matrix
-                    other = self.__class__(coo_matrix(arg1, shape=shape, dtype=dtype))
+                    other = self.__class__(coo_matrix(arg1, shape=shape,
+                                                      dtype=dtype))
                     self._set_self(other)
                 elif len(arg1) == 3:
                     # (data, indices, indptr) format

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -51,7 +51,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                 if len(arg1) == 2:
                     # (data, ij) format
                     from .coo import coo_matrix
-                    other = self.__class__(coo_matrix(arg1, shape=shape))
+                    other = self.__class__(coo_matrix(arg1, shape=shape, dtype=dtype))
                     self._set_self(other)
                 elif len(arg1) == 3:
                     # (data, indices, indptr) format

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -131,9 +131,10 @@ class coo_matrix(_data_matrix, _minmax_mixin):
                 M, N = arg1
                 self._shape = check_shape((M, N))
                 idx_dtype = get_index_dtype(maxval=max(M, N))
+                data_dtype = getdtype(dtype, default=float)
                 self.row = np.array([], dtype=idx_dtype)
                 self.col = np.array([], dtype=idx_dtype)
-                self.data = np.array([], getdtype(dtype, default=float))
+                self.data = np.array([], dtype=data_dtype)
                 self.has_canonical_format = True
             else:
                 try:
@@ -154,11 +155,11 @@ class coo_matrix(_data_matrix, _minmax_mixin):
                     self._shape = check_shape((M, N))
 
                 idx_dtype = get_index_dtype(maxval=max(self.shape))
+                data_dtype = getdtype(dtype, obj, default=float)
                 self.row = np.array(row, copy=copy, dtype=idx_dtype)
                 self.col = np.array(col, copy=copy, dtype=idx_dtype)
-                self.data = np.array(obj, copy=copy)
+                self.data = np.array(obj, copy=copy, dtype=data_dtype)
                 self.has_canonical_format = False
-
         else:
             if isspmatrix(arg1):
                 if isspmatrix_coo(arg1) and copy:

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3525,9 +3525,9 @@ class TestCSR(sparse_test_class()):
         assert_array_equal(arange(12).reshape(4,3),csr.todense())
         
         # using Python lists and a specified dtype
-        csr = csr_matrix(([2**63, 1], ([0, 1], [0, 1])), dtype=np.uint64)
-        dense = array([[2**63, 0], [0, 1]], dtype=np.uint64)
-        assert_array_equal(csr.toarray(), dense)
+        csr = csr_matrix(([2**63 + 1, 1], ([0, 1], [0, 1])), dtype=np.uint64)
+        dense = array([[2**63 + 1, 0], [0, 1]], dtype=np.uint64)
+        assert_array_equal(dense, csr.toarray())
 
     def test_constructor5(self):
         # infer dimensions from arrays
@@ -4091,12 +4091,15 @@ class TestCOO(sparse_test_class(getset=False,
         # unsorted triplet format
         row = array([2, 3, 1, 3, 0, 1, 3, 0, 2, 1, 2])
         col = array([0, 1, 0, 0, 1, 1, 2, 2, 2, 2, 1])
-        data = array([6., 10., 3., 9., 1., 4.,
-                              11., 2., 8., 5., 7.])
+        data = array([6., 10., 3., 9., 1., 4., 11., 2., 8., 5., 7.])
 
         coo = coo_matrix((data,(row,col)),(4,3))
-
         assert_array_equal(arange(12).reshape(4,3),coo.todense())
+
+        # using Python lists and a specified dtype
+        coo = coo_matrix(([2**63 + 1, 1], ([0, 1], [0, 1])), dtype=np.uint64)
+        dense = array([[2**63 + 1, 0], [0, 1]], dtype=np.uint64)
+        assert_array_equal(dense, coo.toarray())
 
     def test_constructor2(self):
         # unsorted triplet format with duplicates (which are summed)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3523,6 +3523,11 @@ class TestCSR(sparse_test_class()):
         ij = vstack((row,col))
         csr = csr_matrix((data,ij),(4,3))
         assert_array_equal(arange(12).reshape(4,3),csr.todense())
+        
+        # using Python lists and a specified dtype
+        csr = csr_matrix(([2**63, 1], ([0, 1], [0, 1])), dtype=np.uint64)
+        dense = array([[2**63, 0], [0, 1]], dtype=np.uint64)
+        assert_array_equal(csr.toarray(), dense)
 
     def test_constructor5(self):
         # infer dimensions from arrays


### PR DESCRIPTION
#### Reference issue
Fixes gh-13329

#### What does this implement/fix?
Propagates the `dtype` parameter through the intermediate COO format constructor.