### PR TITLE
BUG: maintain dtype of SphericalVoronoi regions

### DIFF
--- a/scipy/spatial/_voronoi.pyx
+++ b/scipy/spatial/_voronoi.pyx
@@ -75,4 +75,4 @@ def sort_vertices_of_regions(int[:,::1] simplices, regions):
             remaining_count += 1
             remaining_filter(remaining, current_simplex)
         regions_arr = np.asarray(sorted_vertices)
-        regions[n] = regions_arr[regions_arr > ARRAY_FILLER].tolist()
+        regions[n] = list(regions_arr[regions_arr > ARRAY_FILLER])

--- a/scipy/spatial/tests/test_spherical_voronoi.py
+++ b/scipy/spatial/tests/test_spherical_voronoi.py
@@ -347,3 +347,13 @@ class TestSphericalVoronoi(object):
         assert sv.points.dtype is np.dtype(np.float64)
         assert sv.center.dtype is np.dtype(np.float64)
         assert isinstance(sv.radius, float)
+
+    def test_region_types(self):
+        # Tests that region integer type does not change
+        # See Issue #13412
+        sv = SphericalVoronoi(self.points)
+        dtype = type(sv.regions[0][0])
+        sv.sort_vertices_of_regions()
+        assert type(sv.regions[0][0]) == dtype
+        sv.sort_vertices_of_regions()
+        assert type(sv.regions[0][0]) == dtype


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #13412

#### What does this implement/fix?
<!--Please explain your changes.-->
The `sort_vertices_of_regions` method calls [`numpy.ndarray.tolist`](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.tolist.html) which converts the region types to built-in Python types. This produces a crash on Windows machines when `sort_vertices_of_regions` is called again.

Here I have replaced the `.tolist()` call with `list()`, which maintains the dtype

@tylerjereddy