### PR TITLE
ENH: `sparse.lil_matrix`: support direct constructor

### DIFF
--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -111,6 +111,29 @@ class lil_matrix(spmatrix, IndexMixin):
                 for i in range(M):
                     self.rows[i] = []
                     self.data[i] = []
+            elif len(arg1) == 2:
+                # (data, rows) format
+                (data, rows) = arg1
+                rows_len = len(rows)
+
+                if len(data) != rows_len:
+                    raise ValueError('data and rows should have same length')
+                
+                if shape is None:
+                    raise ValueError('shape parameter is required with (data, rows) format')
+
+                self._shape = check_shape(shape)
+                
+                if shape[0] != rows_len:
+                    raise ValueError('shape should match with length of data and rows') 
+
+                self.data = np.empty(rows_len, dtype=object)
+                self.rows = np.empty(rows_len, dtype=object)
+
+                for i in range(rows_len):
+                    self.data[i] = list(data[i])
+                    self.rows[i] = list(rows[i])
+                
             else:
                 raise TypeError('unrecognized lil_matrix constructor usage')
         else:

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -36,6 +36,10 @@ class lil_matrix(spmatrix, IndexMixin):
             to construct an empty matrix with shape (M, N)
             dtype is optional, defaulting to dtype='d'.
 
+        lil_matrix((data, rows), shape=(M, N), [dtype])
+            to construct matrix of shape (M, N) directly with existing data
+            and rows.
+
     Attributes
     ----------
     dtype : dtype

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -36,9 +36,10 @@ class lil_matrix(spmatrix, IndexMixin):
             to construct an empty matrix with shape (M, N)
             dtype is optional, defaulting to dtype='d'.
 
-        lil_matrix((data, rows), shape=(M, N), [dtype])
+        lil_matrix((data, rows), [shape=(M, N)])
             to construct matrix of shape (M, N) directly with existing data
             and rows.
+            When shape is not specified, it is inferred from the rows array
 
     Attributes
     ----------
@@ -118,23 +119,23 @@ class lil_matrix(spmatrix, IndexMixin):
             elif len(arg1) == 2:
                 # (data, rows) format
                 (data, rows) = arg1
-                rows_len = len(rows)
+                M = len(rows)
 
-                if len(data) != rows_len:
+                if len(data) != M:
                     raise ValueError('data and rows should have same length')
                 
                 if shape is None:
-                    raise ValueError('shape parameter is required with (data, rows) format')
+                    shape = (M, max(max(r) for r in rows) + 1)
 
                 self._shape = check_shape(shape)
                 
-                if shape[0] != rows_len:
+                if self._shape[0] != M:
                     raise ValueError('shape should match with length of data and rows') 
 
-                self.data = np.empty(rows_len, dtype=object)
-                self.rows = np.empty(rows_len, dtype=object)
+                self.data = np.empty(M, dtype=object)
+                self.rows = np.empty(M, dtype=object)
 
-                for i in range(rows_len):
+                for i in range(M):
                     self.data[i] = list(data[i])
                     self.rows[i] = list(rows[i])
                 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3982,9 +3982,9 @@ class TestLIL(sparse_test_class(minmax=False)):
         assert_array_equal(A, B.todense())
         assert_equal(B.sum(), A.sum())
 
-        with assert_raises(ValueError):
-            # no shape
-            lil_matrix((data1, rows1))
+        # check shape infer from rows array
+        C = lil_matrix((data1, rows1))
+        assert_equal((3,3), C.shape)
 
         with assert_raises(ValueError):
             # shape mismatch

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3972,6 +3972,28 @@ class TestLIL(sparse_test_class(minmax=False)):
     spmatrix = lil_matrix
     math_dtypes = [np.int_, np.float_, np.complex_]
 
+    def test_constructor1(self):
+        # (data, rows), shape=(M, N) format
+        data1 = [[1], [2], [3]]
+        rows1 = [[0], [1], [2]]
+        A = diag([1, 2, 3])
+        B = lil_matrix((data1, rows1), shape=(3, 3))
+
+        assert_array_equal(A, B.todense())
+        assert_equal(B.sum(), A.sum())
+
+        with assert_raises(ValueError):
+            # no shape
+            lil_matrix((data1, rows1))
+
+        with assert_raises(ValueError):
+            # shape mismatch
+            lil_matrix((data1, rows1), shape=(2, 2))
+
+        with assert_raises(ValueError):
+            # data and rows length mismatch
+            lil_matrix((data1[:1], rows1), shape=(3, 3))        
+
     def test_dot(self):
         A = zeros((10, 10), np.complex128)
         A[0, 3] = 10


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
gh-13142

#### What does this implement/fix?
<!--Please explain your changes.-->

Support direct initialization of `lil_matrix` using existing `data` and `rows`.
Proposed ctor - `lil_matrix((data, rows), shape=(M, N)) `

```python
data = [[1], [], [3]]
rows = [[0], [], [2]]
x = sps.lil_matrix((data, rows), shape=(3,3))
print(x.todense())
# [[1. 0. 0.]
#  [0. 0. 0.]
#  [0. 0. 3.]]
```

#### Additional information
<!--Any additional information you think is important.-->
- `shape` param would be required as we can only infer `M` (no. of rows) from `len(rows)` .
- validation checks
  - `len(data) == len(rows)` for obvious reasons
  - `shape[0]` (i.e `M`) should be equal to `len(rows)`

#### Things to consider
Should we also check for the contents of `rows` and `data`? for example:-
If `rows` has invalid column index 
```python
data = [[1], []]
rows = [[3], []]
x = sps.lil_matrix((data, rows), shape=(2,2))
x.todense()              # ----> IndexError: index 3 is out of bounds for axis 1 with size 2
```