### PR TITLE
FIX: optimize: use npy_intp to store array dims for lsap

### DIFF
--- a/scipy/optimize/_lsap_module.c
+++ b/scipy/optimize/_lsap_module.c
@@ -81,7 +81,7 @@ calculate_assignment(PyObject* self, PyObject* args)
     for (npy_intp i = 0; i < num_rows; i++)
         adata[i] = i;
 
-    npy_intp ret = solve_rectangular_linear_sum_assignment(
+    int ret = solve_rectangular_linear_sum_assignment(
       num_rows, num_cols, cost_matrix, PyArray_DATA((PyArrayObject*)b));
     if (ret != 0) {
         PyErr_SetString(PyExc_ValueError, "cost matrix is infeasible");

--- a/scipy/optimize/_lsap_module.c
+++ b/scipy/optimize/_lsap_module.c
@@ -56,11 +56,11 @@ calculate_assignment(PyObject* self, PyObject* args)
         goto cleanup;
     }
 
-    int num_rows = PyArray_DIM(obj_cont, 0);
-    int num_cols = PyArray_DIM(obj_cont, 1);
+    npy_intp num_rows = PyArray_DIM(obj_cont, 0);
+    npy_intp num_cols = PyArray_DIM(obj_cont, 1);
 
     // test for NaN and -inf entries
-    for (size_t i=0;i<(size_t)num_rows*num_cols;i++) {
+    for (npy_intp i = 0; i < num_rows*num_cols; i++) {
         if (cost_matrix[i] != cost_matrix[i] || cost_matrix[i] == -INFINITY) {
             PyErr_SetString(PyExc_ValueError,
                             "matrix contains invalid numeric entries");
@@ -78,10 +78,10 @@ calculate_assignment(PyObject* self, PyObject* args)
         goto cleanup;
 
     int64_t* adata = PyArray_DATA((PyArrayObject*)a);
-    for (int i=0;i<num_rows;i++)
+    for (npy_intp i = 0; i < num_rows; i++)
         adata[i] = i;
 
-    int ret = solve_rectangular_linear_sum_assignment(
+    npy_intp ret = solve_rectangular_linear_sum_assignment(
       num_rows, num_cols, cost_matrix, PyArray_DATA((PyArrayObject*)b));
     if (ret != 0) {
         PyErr_SetString(PyExc_ValueError, "cost matrix is infeasible");

--- a/scipy/optimize/rectangular_lsap/rectangular_lsap.cpp
+++ b/scipy/optimize/rectangular_lsap/rectangular_lsap.cpp
@@ -45,20 +45,20 @@ Author: PM Larsen
 #include "rectangular_lsap.h"
 #include <vector>
 
-static int
-augmenting_path(int nc, std::vector<double>& cost, std::vector<double>& u,
-                std::vector<double>& v, std::vector<int>& path,
-                std::vector<int>& row4col,
-                std::vector<double>& shortestPathCosts, int i,
+static intptr_t
+augmenting_path(intptr_t nc, std::vector<double>& cost, std::vector<double>& u,
+                std::vector<double>& v, std::vector<intptr_t>& path,
+                std::vector<intptr_t>& row4col,
+                std::vector<double>& shortestPathCosts, intptr_t i,
                 std::vector<bool>& SR, std::vector<bool>& SC, double* p_minVal)
 {
     double minVal = 0;
 
     // Crouse's pseudocode uses set complements to keep track of remaining
     // nodes.  Here we use a vector, as it is more efficient in C++.
-    int num_remaining = nc;
-    std::vector<int> remaining(nc);
-    for (int it = 0; it < nc; it++) {
+    intptr_t num_remaining = nc;
+    std::vector<intptr_t> remaining(nc);
+    for (intptr_t it = 0; it < nc; it++) {
         // Filling this up in reverse order ensures that the solution of a
         // constant cost matrix is the identity matrix (c.f. #11602).
         remaining[it] = nc - it - 1;
@@ -69,15 +69,15 @@ augmenting_path(int nc, std::vector<double>& cost, std::vector<double>& u,
     std::fill(shortestPathCosts.begin(), shortestPathCosts.end(), INFINITY);
 
     // find shortest augmenting path
-    int sink = -1;
+    intptr_t sink = -1;
     while (sink == -1) {
 
-        int index = -1;
+        intptr_t index = -1;
         double lowest = INFINITY;
         SR[i] = true;
 
-        for (int it = 0; it < num_remaining; it++) {
-            int j = remaining[it];
+        for (intptr_t it = 0; it < num_remaining; it++) {
+            intptr_t j = remaining[it];
 
             double r = minVal + cost[i * nc + j] - u[i] - v[j];
             if (r < shortestPathCosts[j]) {
@@ -96,7 +96,7 @@ augmenting_path(int nc, std::vector<double>& cost, std::vector<double>& u,
         }
 
         minVal = lowest;
-        int j = remaining[index];
+        intptr_t j = remaining[index];
         if (minVal == INFINITY) { // infeasible cost matrix
             return -1;
         }
@@ -116,14 +116,14 @@ augmenting_path(int nc, std::vector<double>& cost, std::vector<double>& u,
     return sink;
 }
 
-static int
-solve(int nr, int nc, double* input_cost, int64_t* output_col4row)
+static intptr_t
+solve(intptr_t nr, intptr_t nc, double* input_cost, int64_t* output_col4row)
 {
 
     // build a non-negative cost matrix
     std::vector<double> cost(nr * nc);
     double minval = *std::min_element(input_cost, input_cost + nr * nc);
-    for (int i = 0; i < nr * nc; i++) {
+    for (intptr_t i = 0; i < nr * nc; i++) {
         cost[i] = input_cost[i] - minval;
     }
 
@@ -131,40 +131,40 @@ solve(int nr, int nc, double* input_cost, int64_t* output_col4row)
     std::vector<double> u(nr, 0);
     std::vector<double> v(nc, 0);
     std::vector<double> shortestPathCosts(nc);
-    std::vector<int> path(nc, -1);
-    std::vector<int> col4row(nr, -1);
-    std::vector<int> row4col(nc, -1);
+    std::vector<intptr_t> path(nc, -1);
+    std::vector<intptr_t> col4row(nr, -1);
+    std::vector<intptr_t> row4col(nc, -1);
     std::vector<bool> SR(nr);
     std::vector<bool> SC(nc);
 
     // iteratively build the solution
-    for (int curRow = 0; curRow < nr; curRow++) {
+    for (intptr_t curRow = 0; curRow < nr; curRow++) {
 
         double minVal;
-        int sink = augmenting_path(nc, cost, u, v, path, row4col,
-                                   shortestPathCosts, curRow, SR, SC, &minVal);
+        intptr_t sink = augmenting_path(nc, cost, u, v, path, row4col,
+                                        shortestPathCosts, curRow, SR, SC, &minVal);
         if (sink < 0) {
             return -1;
         }
 
         // update dual variables
         u[curRow] += minVal;
-        for (int i = 0; i < nr; i++) {
+        for (intptr_t i = 0; i < nr; i++) {
             if (SR[i] && i != curRow) {
                 u[i] += minVal - shortestPathCosts[col4row[i]];
             }
         }
 
-        for (int j = 0; j < nc; j++) {
+        for (intptr_t j = 0; j < nc; j++) {
             if (SC[j]) {
                 v[j] -= minVal - shortestPathCosts[j];
             }
         }
 
         // augment previous solution
-        int j = sink;
+        intptr_t j = sink;
         while (1) {
-            int i = path[j];
+            intptr_t i = path[j];
             row4col[j] = i;
             std::swap(col4row[i], j);
             if (i == curRow) {
@@ -173,7 +173,7 @@ solve(int nr, int nc, double* input_cost, int64_t* output_col4row)
         }
     }
 
-    for (int i = 0; i < nr; i++) {
+    for (intptr_t i = 0; i < nr; i++) {
         output_col4row[i] = col4row[i];
     }
 
@@ -184,8 +184,8 @@ solve(int nr, int nc, double* input_cost, int64_t* output_col4row)
 extern "C" {
 #endif
 
-int
-solve_rectangular_linear_sum_assignment(int nr, int nc, double* input_cost,
+intptr_t
+solve_rectangular_linear_sum_assignment(intptr_t nr, intptr_t nc, double* input_cost,
                                         int64_t* col4row)
 {
     return solve(nr, nc, input_cost, col4row);

--- a/scipy/optimize/rectangular_lsap/rectangular_lsap.cpp
+++ b/scipy/optimize/rectangular_lsap/rectangular_lsap.cpp
@@ -116,7 +116,7 @@ augmenting_path(intptr_t nc, std::vector<double>& cost, std::vector<double>& u,
     return sink;
 }
 
-static intptr_t
+static int
 solve(intptr_t nr, intptr_t nc, double* input_cost, int64_t* output_col4row)
 {
 
@@ -184,7 +184,7 @@ solve(intptr_t nr, intptr_t nc, double* input_cost, int64_t* output_col4row)
 extern "C" {
 #endif
 
-intptr_t
+int
 solve_rectangular_linear_sum_assignment(intptr_t nr, intptr_t nc, double* input_cost,
                                         int64_t* col4row)
 {

--- a/scipy/optimize/rectangular_lsap/rectangular_lsap.h
+++ b/scipy/optimize/rectangular_lsap/rectangular_lsap.h
@@ -37,8 +37,8 @@ extern "C" {
 
 #include <stdint.h>
 
-int solve_rectangular_linear_sum_assignment(int nr, int nc, double* input_cost,
-                                            int64_t* col4row);
+intptr_t solve_rectangular_linear_sum_assignment(intptr_t nr, intptr_t nc, double* input_cost,
+                                                 int64_t* col4row);
 
 #ifdef __cplusplus
 }

--- a/scipy/optimize/rectangular_lsap/rectangular_lsap.h
+++ b/scipy/optimize/rectangular_lsap/rectangular_lsap.h
@@ -37,8 +37,8 @@ extern "C" {
 
 #include <stdint.h>
 
-intptr_t solve_rectangular_linear_sum_assignment(intptr_t nr, intptr_t nc, double* input_cost,
-                                                 int64_t* col4row);
+int solve_rectangular_linear_sum_assignment(intptr_t nr, intptr_t nc, double* input_cost,
+                                            int64_t* col4row);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

- closes gh-13421

#### What does this implement/fix?
<!--Please explain your changes.-->

- avoids unsafe downcast from `npy_intp` to `int`
- allows for any size 2d array (up to max allowed by numpy)
- requires use of `intptr_t` instead of `int` for index comparisons; potentially larger memory footprint

#### Additional information
<!--Any additional information you think is important.-->

- needs to be verified that this fixes the issue's reproducer (I don't have a machine with enough memory in front of me right now and I didn't think it would be fair to the CI to allocate a 20GiB array...) _EDIT: confirmed fix_
- Effect on memory consumption and performance should be examined due to change from `int` to `intptr_t`