### PR TITLE
BUG: spatial: make Rotation picklable

### DIFF
--- a/scipy/spatial/transform/rotation.pyx
+++ b/scipy/spatial/transform/rotation.pyx
@@ -529,6 +529,14 @@ cdef class Rotation(object):
         else:
             self._quat = quat.copy() if copy else quat
 
+    def __getstate__(self):
+        return np.asarray(self._quat, dtype=float), self._single
+
+    def __setstate__(self, state):
+        quat, single = state
+        self._quat = quat.copy()
+        self._single = single
+
     @property
     def single(self):
         """Whether this instance represents a single rotation."""

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -7,6 +7,8 @@ from scipy.spatial.transform import Rotation, Slerp
 from scipy.stats import special_ortho_group
 from itertools import permutations
 
+import pickle
+import copy
 
 def test_generic_quat_matrix():
     x = np.array([[3, 4, 0, 0], [5, 12, 0, 0]])
@@ -1247,3 +1249,16 @@ def test_rotation_within_numpy_array():
 
     array = np.array([multiple, multiple, multiple])
     assert_equal(array.shape, (3, 2))
+
+
+def test_pickling():
+    r = Rotation.from_quat([0, 0, np.sin(np.pi/4), np.cos(np.pi/4)])
+    pkl = pickle.dumps(r)
+    unpickled = pickle.loads(pkl)
+    assert_allclose(r.as_matrix(), unpickled.as_matrix(), atol=1e-15)
+
+
+def test_deepcopy():
+    r = Rotation.from_quat([0, 0, np.sin(np.pi/4), np.cos(np.pi/4)])
+    r1 = copy.deepcopy(r)
+    assert_allclose(r.as_matrix(), r1.as_matrix(), atol=1e-15)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

gh-13358

#### What does this implement/fix?
<!--Please explain your changes.-->

Implement `Rotation.__setstate__` and `__getstate__` so that it pickles.

#### Additional information
<!--Any additional information you think is important.-->

Testing here is very minimal. More testing with real workloads (e.g. multiprocessing) would be nice. (Probaly outside of the test suite though.)

This stuff is fairly esoteric, esp for mutable objects --- I *think* simply copying the underlying data would be enough, but I'm not familiar with details of this code. 