### PR TITLE
BUG: `has_sorted_indices` and `has_canonical_format` should be bools

### DIFF
--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -1074,8 +1074,9 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             # not sorted => not canonical
             self._has_canonical_format = False
         elif not hasattr(self, '_has_canonical_format'):
-            self.has_canonical_format = _sparsetools.csr_has_canonical_format(
-                len(self.indptr) - 1, self.indptr, self.indices)
+            self.has_canonical_format = bool(
+                _sparsetools.csr_has_canonical_format(
+                    len(self.indptr) - 1, self.indptr, self.indices))
         return self._has_canonical_format
 
     def __set_has_canonical_format(self, val):
@@ -1113,8 +1114,9 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
         # first check to see if result was cached
         if not hasattr(self, '_has_sorted_indices'):
-            self._has_sorted_indices = _sparsetools.csr_has_sorted_indices(
-                len(self.indptr) - 1, self.indptr, self.indices)
+            self._has_sorted_indices = bool(
+                _sparsetools.csr_has_sorted_indices(
+                    len(self.indptr) - 1, self.indptr, self.indices))
         return self._has_sorted_indices
 
     def __set_sorted(self, val):

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3636,6 +3636,7 @@ class TestCSR(sparse_test_class()):
         indptr = np.array([0, 2])
         M = csr_matrix((data, sorted_inds, indptr)).copy()
         assert_equal(True, M.has_sorted_indices)
+        assert type(M.has_sorted_indices) == bool
 
         M = csr_matrix((data, unsorted_inds, indptr)).copy()
         assert_equal(False, M.has_sorted_indices)
@@ -3667,6 +3668,7 @@ class TestCSR(sparse_test_class()):
 
         M = csr_matrix((data, indices, indptr)).copy()
         assert_equal(False, M.has_canonical_format)
+        assert type(M.has_canonical_format) == bool
 
         # set by deduplicating
         M.sum_duplicates()


### PR DESCRIPTION
#### Reference issue
Fixes gh-13408

#### What does this implement/fix?
`csr_has_sorted_indices` and `csr_has_canonical_format` both return `bool` in C++ but the sparsetools bindings generator only handles int and long, so the python interface returns `int`. Cast the result to `bool` is thus safe and fixes the issue.