### PR TITLE
Add indicator in NDInterpolator docstring that N must be > 1

### DIFF
--- a/scipy/interpolate/interpnd.pyx
+++ b/scipy/interpolate/interpnd.pyx
@@ -207,7 +207,7 @@ class LinearNDInterpolator(NDInterpolatorBase):
     """
     LinearNDInterpolator(points, values, fill_value=np.nan, rescale=False)
 
-    Piecewise linear interpolant in N dimensions.
+    Piecewise linear interpolant in N > 1 dimensions.
 
     .. versionadded:: 0.9
 
@@ -874,9 +874,9 @@ class CloughTocher2DInterpolator(NDInterpolatorBase):
     griddata :
         Interpolate unstructured D-D data.
     LinearNDInterpolator :
-        Piecewise linear interpolant in N dimensions.
+        Piecewise linear interpolant in N > 1 dimensions.
     NearestNDInterpolator :
-        Nearest-neighbor interpolation in N dimensions.
+        Nearest-neighbor interpolation in N > 1 dimensions.
 
     References
     ----------

--- a/scipy/interpolate/ndgriddata.py
+++ b/scipy/interpolate/ndgriddata.py
@@ -21,7 +21,7 @@ class NearestNDInterpolator(NDInterpolatorBase):
     """
     NearestNDInterpolator(x, y)
 
-    Nearest-neighbor interpolation in N dimensions.
+    Nearest-neighbor interpolation in N > 1 dimensions.
 
     .. versionadded:: 0.9
 


### PR DESCRIPTION
I expected ND interpolators to also support 1D. This is not the case, so this is a minor tweak to update the docstring accordingly.