### PR TITLE
DOC: stats: note relationship between scaled-inv-chi2 and invgamma

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -3393,7 +3393,7 @@ class invgamma_gen(rv_continuous):
     Specifically, if the scaled inverse chi-squared distribution is
     parameterized with degrees of freedom :math:`\nu` and scaling parameter
     :math:`\tau^2`, then it can be modeled using `invgamma` with
-    ``a=`` :math:`\frac{\nu}{2}` and ``scale=`` :math:`\frac{\nu \tau^2}{2}`.
+    ``a=`` :math:`\nu/2` and ``scale=`` :math:`\nu \tau^2/2`.
 
     %(after_notes)s
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -3388,7 +3388,12 @@ class invgamma_gen(rv_continuous):
 
     `invgamma` takes ``a`` as a shape parameter for :math:`a`.
 
-    `invgamma` is a special case of `gengamma` with ``c=-1``.
+    `invgamma` is a special case of `gengamma` with ``c=-1``, and it is a
+    different parameterization of the scaled inverse chi-squared distribution.
+    Specifically, if the scaled inverse chi-squared distribution is
+    parameterized with degrees of freedom :math:`\nu` and scaling parameter
+    :math:`\tau^2`, then it can be modeled using `invgamma` with
+    ``a=`` :math:`\frac{\nu}{2}` and ``scale=`` :math:`\frac{\nu \tau^2}{2}`.
 
     %(after_notes)s
 


### PR DESCRIPTION
#### Reference issue
Closes gh-10933

#### What does this implement/fix?
gh-10933 requests the addition of the scaled inverse chi2 distribution, but it is a reparameterization of the inverse gamma distribution (`invgamma`), and we typically avoid reparameterizations of existing distributions. This PR suggests a compromise to address the issue: document the relationship between the two distributions so those looking for the scaled inverse chi2 distribution in SciPy can find information about it.

#### Additional information
The thought is that `invgamma` will come up in searches for the scaled inverse chi2. A manual scan of available stats distributions wouldn't suggest `invgamma` as-is. If that's important, we could add to the description of the distribution:

> An inverted gamma continuous random variable, **equivalent to the scaled inverse chi2**