### PR TITLE
ENH: interpolate: add input validation to check input x-y is strictly increasing for fitpack.bispev and fitpack.parder

### DIFF
--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -900,6 +900,11 @@ class _BivariateSplineBase(object):
             if x.size == 0 or y.size == 0:
                 return np.zeros((x.size, y.size), dtype=self.tck[2].dtype)
 
+            if (x.size >= 2) and (not np.all(np.diff(x) >= 0.0)):
+                raise ValueError("x must be strictly increasing when `grid` is True")
+            if (y.size >= 2) and (not np.all(np.diff(y) >= 0.0)):
+                raise ValueError("y must be strictly increasing when `grid` is True")
+
             if dx or dy:
                 z, ier = dfitpack.parder(tx, ty, c, kx, ky, dx, dy, x, y)
                 if not ier == 0:

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -955,15 +955,23 @@ class TestRectBivariateSpline(object):
 
         NLon = 6
         NLat = 3
-        GridPosLons = np.arange(NLon) / NLon * 2 * np.pi
         GridPosLats = np.arange(NLat) / NLat * np.pi
-        LatsGrid, LonsGrid = np.meshgrid(GridPosLats, GridPosLons)
-        Lats = LatsGrid.ravel()
-        Lons = LonsGrid.ravel()
+        GridPosLons = np.arange(NLon) / NLon * 2 * np.pi
 
+        # No error
+        Interpolator(GridPosLats, GridPosLons)
+
+        nonGridPosLats = GridPosLats.copy()
+        nonGridPosLats[2] = 0.001
         with assert_raises(ValueError) as exc_info:
-            Interpolator(Lats, Lons)
+            Interpolator(nonGridPosLats, GridPosLons)
         assert "x must be strictly increasing" in str(exc_info.value)
+
+        nonGridPosLons = GridPosLons.copy()
+        nonGridPosLons[2] = 0.001
+        with assert_raises(ValueError) as exc_info:
+            Interpolator(GridPosLats, nonGridPosLons)
+        assert "y must be strictly increasing" in str(exc_info.value)
 
 
 class TestRectSphereBivariateSpline(object):

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -961,8 +961,9 @@ class TestRectBivariateSpline(object):
         Lats = LatsGrid.ravel()
         Lons = LonsGrid.ravel()
 
-        with assert_raises(ValueError):
+        with assert_raises(ValueError) as exc_info:
             Interpolator(Lats, Lons)
+        assert "x must be strictly increasing" in str(exc_info.value)
 
 
 class TestRectSphereBivariateSpline(object):

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -944,6 +944,26 @@ class TestRectBivariateSpline(object):
                                    bbox=bbox.tolist())
         assert_array_almost_equal(spl1(1.0, 1.0), spl2(1.0, 1.0))
 
+    def test_not_increasing_input(self):
+        # gh-8565
+        NSamp = 20
+        Theta = np.random.uniform(0, np.pi, NSamp)
+        Phi = np.random.uniform(0, 2 * np.pi, NSamp)
+        Data = np.ones(NSamp)
+
+        Interpolator = SmoothSphereBivariateSpline(Theta, Phi, Data, s=3.5)
+
+        NLon = 6
+        NLat = 3
+        GridPosLons = np.arange(NLon) / NLon * 2 * np.pi
+        GridPosLats = np.arange(NLat) / NLat * np.pi
+        LatsGrid, LonsGrid = np.meshgrid(GridPosLats, GridPosLons)
+        Lats = LatsGrid.ravel()
+        Lons = LonsGrid.ravel()
+
+        with assert_raises(ValueError):
+            Interpolator(Lats, Lons)
+
 
 class TestRectSphereBivariateSpline(object):
     def test_defaults(self):


### PR DESCRIPTION

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
fix #8565 

#### What does this implement/fix?
Some scipy users are confusing this fitpack error message.
https://github.com/scipy/scipy/blob/1d10a4afe95cdd4bcae80db5f312c466d9921d4e/scipy/interpolate/fitpack2.py#L910

like: 
- #8565, 
- https://github.com/cmbant/CAMB/issues/40
- [python \- Unable to use \`scipy\.interpolate\.RectBivariateSpline\` with \`matplotlib\.pyplot,plot\_surface\` \- Stack Overflow](https://stackoverflow.com/questions/29262962/unable-to-use-scipy-interpolate-rectbivariatespline-with-matplotlib-pyplot-pl), 
-  [python: How to pass arrays into Scipy Interpolate RectBivariateSpline?](http://pythonx47a.blogspot.com/2015/05/how-to-pass-arrays-into-scipy.html)

The reason of this error message is the input data is invalid, which is validated in fitpack.bispev
https://github.com/scipy/scipy/blob/2a9e4923aa2be5cd54ccf2196fc0da32fe459e76/scipy/interpolate/fitpack/bispev.f#L45-L50
and in fitpack.parder (when derivative is calculated)
https://github.com/scipy/scipy/blob/5f4c4d802e5a56708d86909af6e5685cd95e6e66/scipy/interpolate/fitpack/parder.f#L50-L54

This restriction offers that input array `x` and `y` needs to be strictly increasing, but the python code does not check it and just showing the FORTRAN error code. 
Actually, the [doc](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.SmoothSphereBivariateSpline.__call__.html#scipy.interpolate.SmoothSphereBivariateSpline.__call__) stated that "If grid is True: The arrays must be sorted to increasing order.", but it seems that some users do not recognize it.

So, I added the input validation for these fitpack functions to check input x-y is strictly increasing and its test.
I think there is no backward compatible breaking because the new validation throws ValueError as before. 