### PR TITLE
DOC: clarify range of `a` parameter fpr johnsonsu/johnsonsb

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -3975,7 +3975,8 @@ class johnsonsb_gen(rv_continuous):
 
         f(x, a, b) = \frac{b}{x(1-x)}  \phi(a + b \log \frac{x}{1-x} )
 
-    for :math:`0 <= x < =1` and :math:`a, b > 0`, and :math:`\phi` is the normal
+    for all :math:`(x, a, b) \in \mathbb{R}^3` where
+    :math:`0 <= x < =1` and :math:`b > 0`, and :math:`\phi` is the normal
     pdf.
 
     `johnsonsb` takes :math:`a` and :math:`b` as shape parameters.

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4024,7 +4024,7 @@ class johnsonsu_gen(rv_continuous):
         f(x, a, b) = \frac{b}{\sqrt{x^2 + 1}}
                      \phi(a + b \log(x + \sqrt{x^2 + 1}))
 
-    for all :math:`(x, a, b) \in \mathbb{R}^3` where :math:`x, b > 0`,
+    for all :math:`(x, a, b) \in \mathbb{R}^3` where :math:`b > 0`,
     and :math:`\phi` is the normal pdf.
 
     `johnsonsu` takes :math:`a` and :math:`b` as shape parameters.

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -3975,9 +3975,9 @@ class johnsonsb_gen(rv_continuous):
 
         f(x, a, b) = \frac{b}{x(1-x)}  \phi(a + b \log \frac{x}{1-x} )
 
-    for all :math:`(x, a, b) \in \mathbb{R}^3` where
-    :math:`0 \leq x \leq 1` and :math:`b > 0`, and :math:`\phi` is the normal
-    pdf.
+    for all :math:`x \in \mathbb{R}, a \in \mathbb{R}`, and :math:`b \in
+    \mathbb{R}`, where :math:`0 \leq x \leq 1`, :math:`b > 0`,
+    and :math:`\phi` is the normal pdf.
 
     `johnsonsb` takes :math:`a` and :math:`b` as shape parameters.
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4024,7 +4024,8 @@ class johnsonsu_gen(rv_continuous):
         f(x, a, b) = \frac{b}{\sqrt{x^2 + 1}}
                      \phi(a + b \log(x + \sqrt{x^2 + 1}))
 
-    for all :math:`x, a, b > 0`, and :math:`\phi` is the normal pdf.
+    for all :math:`(x, a, b) \in \mathbb{R}^3` where :math:`x, b > 0`,
+    and :math:`\phi` is the normal pdf.
 
     `johnsonsu` takes :math:`a` and :math:`b` as shape parameters.
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -3976,7 +3976,7 @@ class johnsonsb_gen(rv_continuous):
         f(x, a, b) = \frac{b}{x(1-x)}  \phi(a + b \log \frac{x}{1-x} )
 
     for all :math:`(x, a, b) \in \mathbb{R}^3` where
-    :math:`0 <= x < =1` and :math:`b > 0`, and :math:`\phi` is the normal
+    :math:`0 \leq x \leq 1` and :math:`b > 0`, and :math:`\phi` is the normal
     pdf.
 
     `johnsonsb` takes :math:`a` and :math:`b` as shape parameters.


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes gh-13353.

#### What does this implement/fix?
This modifies the doc according to the true definition of Johnson's SU and Johnson's SB distribution (see [wikipedia article](https://en.wikipedia.org/wiki/Johnson%27s_SU-distribution#Johnson's_SB-distribution))