### PR TITLE
MAINT: stats: Add _fitstart method to wrapcauchy.

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -8414,6 +8414,12 @@ class wrapcauchy_gen(rv_continuous):
     def _entropy(self, c):
         return np.log(2*np.pi*(1-c*c))
 
+    def _fitstart(self, data):
+        # Use 0.5 as the initial guess of the shape parameter.
+        # For the location and scale, use the minimum and
+        # peak-to-peak/(2*pi), respectively.
+        return 0.5, np.min(data), np.ptp(data)/(2*np.pi)
+
 
 wrapcauchy = wrapcauchy_gen(a=0.0, b=2*np.pi, name='wrapcauchy')
 

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -57,11 +57,6 @@ skip_fit_test_mle = ['exponpow', 'exponweib', 'gausshyper', 'genexpon',
                      'nct', 'powerlognorm', 'powernorm', 'recipinvgauss',
                      'trapezoid', 'vonmises', 'vonmises_line', 'levy_stable',
                      'rv_histogram_instance']
-# wrapcauchy fails because the default initial guess for the shape that is
-# passed to the optimizer is 1, but 1 is not a valid parameter for the
-# distribution.
-fail_fit_test_mle = ['wrapcauchy']
-fail_fit_fix_test_mle = ['wrapcauchy']
 
 # these were really slow in `test_fit`.py.
 # note that this list is used to skip both fit_test and fit_fix tests
@@ -73,7 +68,6 @@ slow_fit_test_mm = ['argus', 'exponpow', 'exponweib', 'gausshyper', 'genexpon',
 # the first list fails due to non-finite distribution moments encountered
 # most of the rest fail due to integration warnings
 # pearson3 is overriden as not implemented due to gh-11746
-# see note about `wrapcauchy` above
 fail_fit_test_mm = (['alpha', 'betaprime', 'bradford', 'burr', 'burr12',
                      'cauchy', 'crystalball', 'f', 'fisk', 'foldcauchy',
                      'genextreme', 'genpareto', 'halfcauchy', 'invgamma',
@@ -82,9 +76,8 @@ fail_fit_test_mm = (['alpha', 'betaprime', 'bradford', 'burr', 'burr12',
                      'tukeylambda', 'invweibull']
                      + ['ksone', 'kstwo', 'nct', 'pareto', 'powernorm',
                         'powerlognorm', 'johnsonsu']
-                     + ['pearson3']
-                     + ['wrapcauchy'])
-skip_fit_test = {"MLE": skip_fit_test_mle + fail_fit_test_mle,
+                     + ['pearson3'])
+skip_fit_test = {"MLE": skip_fit_test_mle,
                  "MM": slow_fit_test_mm + fail_fit_test_mm}
 
 # skip check_fit_args_fix (test is slow)
@@ -97,7 +90,6 @@ skip_fit_fix_test_mle = ['burr', 'exponpow', 'exponweib', 'gausshyper',
 # the first list fails due to non-finite distribution moments encountered
 # most of the rest fail due to integration warnings
 # pearson3 is overriden as not implemented due to gh-11746
-# see note about `wrapcauchy` above
 fail_fit_fix_test_mm = (['alpha', 'betaprime', 'burr', 'burr12', 'cauchy',
                          'crystalball', 'f', 'fisk', 'foldcauchy',
                          'genextreme', 'genpareto', 'halfcauchy', 'invgamma',
@@ -106,9 +98,8 @@ fail_fit_fix_test_mm = (['alpha', 'betaprime', 'burr', 'burr12', 'cauchy',
                          'invweibull']
                          + ['ksone', 'kstwo', 'pareto', 'powernorm',
                             'powerlognorm', 'johnsonsu']
-                         + ['pearson3']
-                         + ['wrapcauchy'])
-skip_fit_fix_test = {"MLE": skip_fit_fix_test_mle + fail_fit_fix_test_mle,
+                         + ['pearson3'])
+skip_fit_fix_test = {"MLE": skip_fit_fix_test_mle,
                      "MM": slow_fit_test_mm + fail_fit_fix_test_mm}
 
 # These distributions fail the complex derivative test below.

--- a/scipy/stats/tests/test_fit.py
+++ b/scipy/stats/tests/test_fit.py
@@ -32,7 +32,6 @@ mle_failing_fits = [
         'truncexpon',
         'tukeylambda',
         'vonmises',
-        'wrapcauchy',
         'levy_stable',
         'trapezoid',
 ]
@@ -46,7 +45,7 @@ mm_failing_fits = ['alpha', 'betaprime', 'burr', 'burr12', 'cauchy', 'chi',
                    'levy_stable', 'loglaplace', 'lomax', 'mielke', 'ncf',
                    'nct', 'ncx2', 'pareto', 'powerlognorm', 'powernorm',
                    'skewcauchy', 't',
-                   'trapezoid', 'triang', 'tukeylambda', 'wrapcauchy']
+                   'trapezoid', 'triang', 'tukeylambda']
 
 # not sure if these fail, but they caused my patience to fail
 mm_slow_fits = ['argus', 'exponpow', 'exponweib', 'gausshyper', 'genexpon',


### PR DESCRIPTION
With an implementation of _fitstart that uses 0.5 as the default
initial guess for the shape parameter, we do not have to skip the
tests of fitting this distribution to data for either MLE or MM.
