### PR TITLE
DOC: reorganize scipy.stats overview docs page

### DIFF
--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -7,8 +7,30 @@ Statistical functions (:mod:`scipy.stats`)
 
 .. currentmodule:: scipy.stats
 
-This module contains a large number of probability distributions as
-well as a growing library of statistical functions.
+This module contains a large number of probability distributions,
+summary and frequency statistics, correlation functions and statistical
+tests, masked statistics, kernel density estimation, quasi-Monte Carlo
+functionality, and more.
+
+Statistics is a very large area, and there are topics that are out of scope
+for SciPy and are covered by other packages. Some of the most important ones
+are:
+
+- `statsmodels <https://www.statsmodels.org/stable/index.html>`__:
+  regression, linear models, time series analysis, extensions to topics
+  also covered by ``scipy.stats``.
+- `Pandas <https://pandas.pydata.org/>`__: tabular data, time series
+  functionality, interfaces to other statistical languages.
+- `PyMC3 <https://docs.pymc.io/>`__: Bayesian statistical
+  modeling, probabilistic machine learning.
+- `scikit-learn <https://scikit-learn.org/>`__: classification, regression,
+  model selection.
+- `Seaborn <https://seaborn.pydata.org/>`__: statistical data visualization.
+- `rpy2 <https://rpy2.github.io/>`__: Python to R bridge.
+
+
+Probability distributions
+=========================
 
 Each univariate distribution is an instance of a subclass of `rv_continuous`
 (`rv_discrete` for discrete distributions):
@@ -21,7 +43,7 @@ Each univariate distribution is an instance of a subclass of `rv_continuous`
    rv_histogram
 
 Continuous distributions
-========================
+------------------------
 
 .. autosummary::
    :toctree: generated/
@@ -128,7 +150,7 @@ Continuous distributions
    wrapcauchy        -- Wrapped Cauchy
 
 Multivariate distributions
-==========================
+--------------------------
 
 .. autosummary::
    :toctree: generated/
@@ -147,7 +169,7 @@ Multivariate distributions
    multivariate_hypergeom -- Multivariate hypergeometric distribution
 
 Discrete distributions
-======================
+----------------------
 
 .. autosummary::
    :toctree: generated/
@@ -169,9 +191,8 @@ Discrete distributions
    zipf              -- Zipf
    yulesimon         -- Yule-Simon
 
-An overview of statistical functions is given below.
-Several of these functions have a similar version in
-`scipy.stats.mstats` which work for masked arrays.
+An overview of statistical functions is given below.  Many of these functions
+have a similar version in `scipy.stats.mstats` which work for masked arrays.
 
 Summary statistics
 ==================
@@ -291,7 +312,7 @@ Statistical tests
    normaltest
 
 Objects returned by some statistical tests
-==========================================
+------------------------------------------
 
 .. autosummary::
    :toctree: generated/
@@ -299,8 +320,28 @@ Objects returned by some statistical tests
    BinomTestResult
 
 
+Quasi-Monte Carlo
+=================
+
+.. toctree::
+   :maxdepth: 4
+
+   stats.qmc
+
+
+Masked statistics functions
+===========================
+
+.. toctree::
+
+   stats.mstats
+
+
+Other statistical functionality
+===============================
+
 Transformations
-===============
+---------------
 
 .. autosummary::
    :toctree: generated/
@@ -319,7 +360,7 @@ Transformations
    zscore
 
 Statistical distances
-=====================
+---------------------
 
 .. autosummary::
    :toctree: generated/
@@ -328,7 +369,7 @@ Statistical distances
    energy_distance
 
 Random variate generation
-=========================
+-------------------------
 
 .. autosummary::
    :toctree: generated/
@@ -336,7 +377,7 @@ Random variate generation
    rvs_ratio_uniforms
 
 Circular statistical functions
-==============================
+------------------------------
 
 .. autosummary::
    :toctree: generated/
@@ -346,7 +387,7 @@ Circular statistical functions
    circstd
 
 Contingency table functions
-===========================
+---------------------------
 
 .. autosummary::
    :toctree: generated/
@@ -359,7 +400,7 @@ Contingency table functions
    fisher_exact
 
 Plot-tests
-==========
+----------
 
 .. autosummary::
    :toctree: generated/
@@ -370,35 +411,16 @@ Plot-tests
    boxcox_normplot
    yeojohnson_normplot
 
-
-Masked statistics functions
-===========================
-
-.. toctree::
-
-   stats.mstats
-
-
 Univariate and multivariate kernel density estimation
-=====================================================
+-----------------------------------------------------
 
 .. autosummary::
    :toctree: generated/
 
    gaussian_kde
 
-
-Quasi-Monte Carlo
-=================
-
-.. toctree::
-   :maxdepth: 4
-
-   stats.qmc
-
-
 Warnings used in :mod:`scipy.stats`
-===================================
+-----------------------------------
 
 .. autosummary::
    :toctree: generated/
@@ -408,9 +430,6 @@ Warnings used in :mod:`scipy.stats`
    PearsonRConstantInputWarning
    PearsonRNearConstantInputWarning
    SpearmanRConstantInputWarning
-
-For many more stat related functions install the software R and the
-interface package rpy.
 
 """
 from .stats import *


### PR DESCRIPTION
I got triggered by the `stats.qmc` merge and the very outdated sentence on `rpy` at the end of the page. This should help get a much better sense of what's in `scipy.stats` and where else to look for areas of statistics.