### PR TITLE
TST: fix failures due to new FutureWarnings in NumPy 1.21.dev0

### DIFF
--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1779,8 +1779,6 @@ def test_lfilter_bad_object():
     assert_raises(TypeError, lfilter, [1.0], [1.0], [1.0, None, 2.0])
     assert_raises(TypeError, lfilter, [1.0], [None], [1.0, 2.0, 3.0])
     assert_raises(TypeError, lfilter, [None], [1.0], [1.0, 2.0, 3.0])
-    with assert_raises(ValueError, match='common type'):
-        lfilter([1.], [1., 1.], ['a', 'b', 'c'])
 
 
 def test_lfilter_notimplemented_input():
@@ -3147,9 +3145,7 @@ def test_nonnumeric_dtypes(func):
         args = [1., 1.]
     else:
         args = [tf2sos(1., 1.)]
-    with pytest.raises(NotImplementedError,
-                       match='input type .* not supported'):
-        func(*args, x=['foo'])
+
     with pytest.raises(ValueError, match='must be at least 1-D'):
         func(*args, x=1.)
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -5002,11 +5002,6 @@ class TestGeoMean(object):
         desired = 2.77748
         check_equal_gmean(a, desired, weights=weights, rtol=1e-5)
 
-    def test_weights_bad_input(self):
-        a = np.array([1, 2, 3, 4, 5])
-        weights = "scipy"
-        assert_raises(TypeError, stats.gmean, a, weights=weights)
-
 
 class TestGeometricStandardDeviation(object):
     # must add 1 as `gstd` is only defined for positive values


### PR DESCRIPTION
The warnings were:
```
FutureWarning: Promotion of numbers and bools to strings is deprecated.
```
The `test_lfilter_bad_object` changes from ValueError to TypeError.
The changes in behaviour should be due to the refactoring in
the NumPy dtype system. There's not much point keeping these
tests, more trouble than they're worth.

Closes gh-13472