### PR TITLE
CI: pin numpy to 1.19.5 on Appveyor

### DIFF
--- a/tools/ci/appveyor/requirements.txt
+++ b/tools/ci/appveyor/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy==1.19.5
 cython
 pythran
 pybind11


### PR DESCRIPTION
This job started failing after the NumPy 1.20.0 release, see https://github.com/scipy/scipy/issues/13464#issuecomment-770409801