### PR TITLE
CI: pin numpy to 1.19.5 for the three macOS CI jobs

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,7 +20,7 @@ jobs:
       max-parallel: 3
       matrix:
         python-version: [3.7, 3.8, 3.9]
-        numpy-version: ['--upgrade numpy']
+        numpy-version: ['numpy==1.19.5']
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Should reduce the failures with numpy 1.20.0, which started picking up Accelerate, to one.