### PR TITLE
DOC: fix typos where double :: for Sphinx directives were missing

### DIFF
--- a/doc/source/tutorial/csgraph.rst
+++ b/doc/source/tutorial/csgraph.rst
@@ -3,7 +3,7 @@ Compressed Sparse Graph Routines (`scipy.sparse.csgraph`)
 
 .. sectionauthor:: Jake Vanderplas <vanderplas@astro.washington.edu>
 
-.. currentmodule: scipy.sparse.csgraph
+.. currentmodule:: scipy.sparse.csgraph
 
 
 Example: Word Ladders

--- a/scipy/_lib/_disjoint_set.py
+++ b/scipy/_lib/_disjoint_set.py
@@ -7,7 +7,7 @@ import collections
 class DisjointSet:
     """ Disjoint set data structure for incremental connectivity queries.
 
-    .. versionadded: 1.6.0
+    .. versionadded:: 1.6.0
 
     Attributes
     ----------

--- a/scipy/linalg/_decomp_update.pyx.in
+++ b/scipy/linalg/_decomp_update.pyx.in
@@ -1,7 +1,7 @@
 """
 Routines for updating QR decompositions
 
-.. versionadded: 0.16.0
+.. versionadded:: 0.16.0
 
 """
 #


### PR DESCRIPTION
Without those :: the directives are interpreted as comments and ignored.