### PR TITLE
CI: pin numpy to 1.19.5 in the 4 parallel Windows builds on Azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -279,7 +279,7 @@ jobs:
       cython==0.29.18
       matplotlib
       mpmath
-      numpy
+      numpy==1.19.5
       Pillow
       pybind11
       pythran


### PR DESCRIPTION
These were failing with:
```
scipy/integrate/quadpack/dqag_blas64.f:181: undefined reference to `xerror_'
```
see gh-13072

There's still an issue, this just gets CI green again.