### PR TITLE
CI: use numpy 1.20.0 again in macOS CI

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -78,6 +78,4 @@ jobs:
 
     - name: Test SciPy
       run: |
-        # This is currently broken in combination with NumPy >=1.20.0, see gh-13464
-        #SCIPY_USE_PYTHRAN=`test ${{ matrix.python-version }} != 3.9; echo $?` python -u runtests.py
-        python -u runtests.py
+        SCIPY_USE_PYTHRAN=`test ${{ matrix.python-version }} != 3.9; echo $?` python -u runtests.py

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,7 +20,7 @@ jobs:
       max-parallel: 3
       matrix:
         python-version: [3.7, 3.8, 3.9]
-        numpy-version: ['numpy==1.19.5']
+        numpy-version: ['--upgrade numpy']
 
     steps:
     - uses: actions/checkout@v2
@@ -78,4 +78,6 @@ jobs:
 
     - name: Test SciPy
       run: |
-        SCIPY_USE_PYTHRAN=`test ${{ matrix.python-version }} != 3.9; echo $?` python -u runtests.py
+        # This is currently broken in combination with NumPy >=1.20.0, see gh-13464
+        #SCIPY_USE_PYTHRAN=`test ${{ matrix.python-version }} != 3.9; echo $?` python -u runtests.py
+        python -u runtests.py


### PR DESCRIPTION
Reverts gh-13477, after gh-13484 solved the issue with Accelerate being detected when building a Pythran extension.

See https://github.com/scipy/scipy/issues/13464#issuecomment-770454512 for more details on the Pythran interaction that triggers the Accelerate detection which errors out.