### PR TITLE
BUG: KDTree weighted count_neighbors doesn't work between two trees

### DIFF
--- a/scipy/spatial/ckdtree/src/count_neighbors.cxx
+++ b/scipy/spatial/ckdtree/src/count_neighbors.cxx
@@ -136,13 +136,13 @@ traverse(
                         for (l = start; l < end; ++l) {
                             if (d <= *l) {
                                 results[l - params->r] += WeightType::get_weight(&params->self, sindices[i])
-                                                        * WeightType::get_weight(&params->other, sindices[j]);
+                                                        * WeightType::get_weight(&params->other, oindices[j]);
                             }
                         }
                     } else {
                         const double *l = std::lower_bound(start, end, d);
                         results[l - params->r] += WeightType::get_weight(&params->self, sindices[i])
-                                                * WeightType::get_weight(&params->other, sindices[j]);
+                                                * WeightType::get_weight(&params->other, oindices[j]);
                     }
                 }
             }

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -1479,3 +1479,27 @@ def test_kdtree_attributes():
     assert_array_equal(t.maxes, np.amax(points, axis=0))
     assert_array_equal(t.mins, np.amin(points, axis=0))
     assert t.data is points
+
+
+@pytest.mark.parametrize("kdtree_class", [KDTree, cKDTree])
+def test_kdtree_count_neighbors_weighted(kdtree_class):
+    np.random.seed(1234)
+    r = np.arange(0.05, 1, 0.05)
+
+    A = np.random.random(21).reshape((7,3))
+    B = np.random.random(45).reshape((15,3))
+
+    wA = np.random.random(7)
+    wB = np.random.random(15)
+
+    kdA = kdtree_class(A)
+    kdB = kdtree_class(B)
+
+    nAB = kdA.count_neighbors(kdB, r, cumulative=False, weights=(wA,wB))
+
+    # Compare against brute-force
+    weights = wA[None, :] * wB[:, None]
+    dist = np.linalg.norm(A[None, :, :] - B[:, None, :], axis=-1)
+    expect = [np.sum(weights[(prev_radius < dist) & (dist <= radius)])
+              for prev_radius, radius in zip(itertools.chain([0], r[:-1]), r)]
+    assert_allclose(nAB, expect)


### PR DESCRIPTION
#### Reference issue
Fixes gh-13465

#### What does this implement/fix?
`count_neighbors` is using the `self` tree's indices to index into `other`. So, if the trees are the same size, we get the wrong weights. Or if they are different sizes, it accesses invalid memory.