### PR TITLE
DOC One-word typo in the documentation of optimize.linprog_simplex

### DIFF
--- a/scipy/optimize/_linprog_doc.py
+++ b/scipy/optimize/_linprog_doc.py
@@ -1102,7 +1102,7 @@ def _linprog_simplex_doc(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
                          **unknown_options):
     r"""
     Linear programming: minimize a linear objective function subject to linear
-    equality and inequality constraints using the tabluea-based simplex method.
+    equality and inequality constraints using the tableau-based simplex method.
 
     Linear programming solves problems of the following form:
 


### PR DESCRIPTION
This solves my one-word typo issue #13494.

#### Reference issue
Closes #13494 

#### What does this implement/fix?
Just one word changed: tabluea-based => tableau-based.

#### Additional information
Thanks y'all for your amazing work on SciPy!