### PR TITLE
MAINT: Move LSAP logic into solver code

### DIFF
--- a/scipy/optimize/_lsap.py
+++ b/scipy/optimize/_lsap.py
@@ -91,7 +91,5 @@ def linear_sum_assignment(cost_matrix, maximize=False):
         raise ValueError("expected a matrix containing numerical entries, got %s"
                          % (cost_matrix.dtype,))
 
-    if maximize:
-        cost_matrix = -cost_matrix
-
-    return _lsap_module.calculate_assignment(cost_matrix.astype(np.double))
+    return _lsap_module.calculate_assignment(cost_matrix.astype(np.double),
+                                             maximize)

--- a/scipy/optimize/_lsap.py
+++ b/scipy/optimize/_lsap.py
@@ -94,12 +94,4 @@ def linear_sum_assignment(cost_matrix, maximize=False):
     if maximize:
         cost_matrix = -cost_matrix
 
-    cost_matrix = cost_matrix.astype(np.double)
-
-    # The algorithm expects more columns than rows in the cost matrix.
-    if cost_matrix.shape[1] < cost_matrix.shape[0]:
-        a, b = _lsap_module.calculate_assignment(cost_matrix.T)
-        indices = np.argsort(b)
-        return (b[indices], a[indices])
-    else:
-        return _lsap_module.calculate_assignment(cost_matrix)
+    return _lsap_module.calculate_assignment(cost_matrix.astype(np.double))

--- a/scipy/optimize/_lsap_module.c
+++ b/scipy/optimize/_lsap_module.c
@@ -40,7 +40,8 @@ calculate_assignment(PyObject* self, PyObject* args)
     PyObject* b = NULL;
     PyObject* result = NULL;
     PyObject* obj_cost = NULL;
-    if (!PyArg_ParseTuple(args, "O", &obj_cost))
+    int maximize = 0;
+    if (!PyArg_ParseTuple(args, "Op", &obj_cost, &maximize))
         return NULL;
 
     PyArrayObject* obj_cont =
@@ -66,7 +67,7 @@ calculate_assignment(PyObject* self, PyObject* args)
         goto cleanup;
 
     int ret = solve_rectangular_linear_sum_assignment(
-      num_rows, num_cols, cost_matrix,
+      num_rows, num_cols, cost_matrix, maximize,
       PyArray_DATA((PyArrayObject*)a),
       PyArray_DATA((PyArrayObject*)b));
     if (ret == RECTANGULAR_LSAP_INFEASIBLE) {

--- a/scipy/optimize/rectangular_lsap/rectangular_lsap.cpp
+++ b/scipy/optimize/rectangular_lsap/rectangular_lsap.cpp
@@ -119,11 +119,15 @@ augmenting_path(intptr_t nc, std::vector<double>& cost, std::vector<double>& u,
 static int
 solve(intptr_t nr, intptr_t nc, double* input_cost, int64_t* output_col4row)
 {
-
     // build a non-negative cost matrix
     std::vector<double> cost(nr * nc);
     double minval = *std::min_element(input_cost, input_cost + nr * nc);
     for (intptr_t i = 0; i < nr * nc; i++) {
+        // test for NaN and -inf entries
+        if (input_cost[i] != input_cost[i] || input_cost[i] == -INFINITY) {
+            return -2;
+        }
+
         cost[i] = input_cost[i] - minval;
     }
 

--- a/scipy/optimize/rectangular_lsap/rectangular_lsap.h
+++ b/scipy/optimize/rectangular_lsap/rectangular_lsap.h
@@ -31,6 +31,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef RECTANGULAR_LSAP_H
 #define RECTANGULAR_LSAP_H
 
+#define RECTANGULAR_LSAP_INFEASIBLE -1
+#define RECTANGULAR_LSAP_INVALID -2
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -38,7 +41,7 @@ extern "C" {
 #include <stdint.h>
 
 int solve_rectangular_linear_sum_assignment(intptr_t nr, intptr_t nc, double* input_cost,
-                                            int64_t* col4row);
+                                            int64_t* a, int64_t* b);
 
 #ifdef __cplusplus
 }

--- a/scipy/optimize/rectangular_lsap/rectangular_lsap.h
+++ b/scipy/optimize/rectangular_lsap/rectangular_lsap.h
@@ -41,7 +41,7 @@ extern "C" {
 #include <stdint.h>
 
 int solve_rectangular_linear_sum_assignment(intptr_t nr, intptr_t nc, double* input_cost,
-                                            int64_t* a, int64_t* b);
+                                            int maximize, int64_t* a, int64_t* b);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

The linear sum assignment code consists of three parts:
* `_lsap.py` - python interface, contains docs
 * `_lsap_module.c` interface between python and c++ solver code
 * `rectangular_lsap.cpp` solver code

Currently the solver logic is interspersed throughout all three:
* `_lsap.py` handles the `maximize` parameter and transposes tall rectangular cost matrices.
* `_lsap_module.c` checks the cost matrix for invalid entries and does some initialization of the result object.
* `rectangular_lsap.cpp` does the rest.

In this PR I have moved all the logic into `rectangular_lsap.cpp`.

What is the advantage of this?
* Collect all the logic in one place. This makes it easier to make changes in future.
* Faster performance for small input matrices.
* Other projects (not necessarily python projects) can get all the functionality by copying the C++ code.