### PR TITLE
ENH: add faster implementation of Frobenius norm for sparse matrices …

### DIFF
--- a/scipy/sparse/linalg/_norm.py
+++ b/scipy/sparse/linalg/_norm.py
@@ -11,9 +11,15 @@ __all__ = ['norm']
 
 def _sparse_frobenius_norm(x):
     if np.issubdtype(x.dtype, np.complexfloating):
-        sqnorm = abs(x).power(2).sum()
+        try:
+            sqnorm = sum(abs(x[i,j])**2 for i, j in zip(*x.nonzero()))**(1/2)
+        except TypeError:
+            sqnorm = abs(x).power(2).sum()
     else:
-        sqnorm = x.power(2).sum()
+        try:
+            sqnorm = sum(x[i,j]**2 for i, j in zip(*x.nonzero()))**(1/2)
+        except TypeError:
+            sqnorm = x.power(2).sum()
     return sqrt(sqnorm)
 
 


### PR DESCRIPTION
…which support indexing in scipy.sparse.linalg

#### What does this implement/fix?

For large space matrices which support indexing (for example csr or dok sparse matrices) the current implementation of the Frobenius norm is unsuitable for large matrices (it is slow and eats up too much memory). I had to use this implementation of the norm in my own project in which I'm using very large sparse matrices. I thought I should open a PR since I don't think there is a situation in which the old implementation could be preferred.

#### Additional information

I've not been able to run tests locally due to some issues with getting LAPACK installed