### PR TITLE
DOC: stats: fix small doc errors in 'multivariate_hypergeom'

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -4693,7 +4693,8 @@ class multivariate_hypergeom_gen(multi_rv_generic):
         ----------
         %(_doc_default_callparams)s
         size : integer or iterable of integers, optional
-            Number of samples to draw (default ``None``).
+            Number of samples to draw. Default is ``None``, in which case a
+            single variate is returned as an array with shape ``m.shape``.
         %(_doc_random_state)s
 
         Returns

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -4693,13 +4693,14 @@ class multivariate_hypergeom_gen(multi_rv_generic):
         ----------
         %(_doc_default_callparams)s
         size : integer or iterable of integers, optional
-            Number of samples to draw (default 1).
+            Number of samples to draw (default ``None``).
         %(_doc_random_state)s
 
         Returns
         -------
         rvs : array_like
-            Random variates of shape (`size`, `len(p)`)
+            Random variates of shape ``size`` or ``m.shape``
+            (if ``size=None``).
 
         Notes
         -----


### PR DESCRIPTION
#### What does this implement/fix?

This is a small follow-up of gh-12839.

The `rvs` method of `multivaraite_hypergeom` distribution said that it returned an array of shape `(size, len(p))` but `len(p)` has no meaning in this context as there exists no parameter `p`. This inconsistency was present as `multivariate_hypergeom` inherited docs from the `multinomial` distribution. It has now been fixed by replacing `(size, len(p))` with `size or m.shape (if size=None)` which is the correct shape of the returned array. Also, `default size=1` has been changed to `default size=None`.

#### Additional information

Some minor comments:
- IIRC, these docs are not shown on the website. So, probably this is only a trivial fix.
- I haven't touched the docs of `multinomial` distribution as they have more such inconsistencies and, IMO, should be resolved separately.