### PR TITLE
ENH: optimize: add bound constraint support for nelder-mead solver

### DIFF
--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -607,7 +607,8 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
         constraints = standardize_constraints(constraints, x0, meth)
 
     if meth == 'nelder-mead':
-        return _minimize_neldermead(fun, x0, args, callback, bounds, **options)
+        return _minimize_neldermead(fun, x0, args, callback, bounds=bounds,
+                                    **options)
     elif meth == 'powell':
         return _minimize_powell(fun, x0, args, callback, bounds, **options)
     elif meth == 'cg':

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -144,7 +144,7 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
         dimension (n,) and `args` is a tuple with the fixed
         parameters.
     bounds : sequence or `Bounds`, optional
-        Bounds on variables for L-BFGS-B, TNC, SLSQP, Powell, and
+        Bounds on variables for Nelder-Mead, L-BFGS-B, TNC, SLSQP, Powell, and
         trust-constr methods. There are two ways to specify the bounds:
 
             1. Instance of `Bounds` class.
@@ -532,11 +532,11 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
         warn('Method %s does not use Hessian-vector product '
              'information (hessp).' % method, RuntimeWarning)
     # - constraints or bounds
-    if (meth in ('nelder-mead', 'cg', 'bfgs', 'newton-cg', 'dogleg',
-                 'trust-ncg') and (bounds is not None or np.any(constraints))):
+    if (meth in ('cg', 'bfgs', 'newton-cg', 'dogleg', 'trust-ncg')
+            and (bounds is not None or np.any(constraints))):
         warn('Method %s cannot handle constraints nor bounds.' % method,
              RuntimeWarning)
-    if meth in ('l-bfgs-b', 'tnc', 'powell') and np.any(constraints):
+    if meth in ('nelder-mead', 'l-bfgs-b', 'tnc', 'powell') and np.any(constraints):
         warn('Method %s cannot handle constraints.' % method,
              RuntimeWarning)
     if meth == 'cobyla' and bounds is not None:
@@ -607,7 +607,7 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
         constraints = standardize_constraints(constraints, x0, meth)
 
     if meth == 'nelder-mead':
-        return _minimize_neldermead(fun, x0, args, callback, **options)
+        return _minimize_neldermead(fun, x0, args, callback, bounds, **options)
     elif meth == 'powell':
         return _minimize_powell(fun, x0, args, callback, bounds, **options)
     elif meth == 'cg':
@@ -808,7 +808,7 @@ def minimize_scalar(fun, bracket=None, bounds=None, args=(),
 
 def standardize_bounds(bounds, x0, meth):
     """Converts bounds to the form required by the solver."""
-    if meth in {'trust-constr', 'powell'}:
+    if meth in {'trust-constr', 'powell', 'nelder-mead'}:
         if not isinstance(bounds, Bounds):
             lb, ub = old_bound_to_new(bounds)
             bounds = Bounds(lb, ub)

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -626,6 +626,13 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
     adaptive : bool, optional
         Adapt algorithm parameters to dimensionality of problem. Useful for
         high-dimensional minimization [1]_.
+    bounds : sequence or `Bounds`, optional
+        Bounds on variables. There are two ways to specify the bounds:
+            1. Instance of `Bounds` class.
+            2. Sequence of ``(min, max)`` pairs for each element in `x`. None
+               is used to specify no bound.
+        Note that this function just clips all vertices in simplex based on
+        the bounds.
 
     References
     ----------

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -679,9 +679,7 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
 
     x0 = asfarray(x0).flatten()
 
-    if bounds is None:
-        lower_bound, upper_bound = np.array((-np.inf, np.inf))
-    else:
+    if bounds is not None:
         lower_bound, upper_bound = bounds.lb, bounds.ub
         # check bounds
         if (lower_bound > upper_bound).any():
@@ -690,7 +688,8 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
             warnings.warn("Initial guess is not within the specified bounds",
                           OptimizeWarning, 3)
 
-    x0 = np.clip(x0, lower_bound, upper_bound)
+    if bounds is not None:
+        x0 = np.clip(x0, lower_bound, upper_bound)
 
     if initial_simplex is None:
         N = len(x0)
@@ -732,7 +731,8 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
         else:
             maxfun = np.inf
 
-    sim = np.clip(sim, lower_bound, upper_bound)
+    if bounds is not None:
+        sim = np.clip(sim, lower_bound, upper_bound)
 
     one2np1 = list(range(1, N + 1))
     fsim = np.empty((N + 1,), float)
@@ -754,13 +754,15 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
 
         xbar = np.add.reduce(sim[:-1], 0) / N
         xr = (1 + rho) * xbar - rho * sim[-1]
-        xr = np.clip(xr, lower_bound, upper_bound)
+        if bounds is not None:
+            xr = np.clip(xr, lower_bound, upper_bound)
         fxr = func(xr)
         doshrink = 0
 
         if fxr < fsim[0]:
             xe = (1 + rho * chi) * xbar - rho * chi * sim[-1]
-            xe = np.clip(xe, lower_bound, upper_bound)
+            if bounds is not None:
+                xe = np.clip(xe, lower_bound, upper_bound)
             fxe = func(xe)
 
             if fxe < fxr:
@@ -777,7 +779,8 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
                 # Perform contraction
                 if fxr < fsim[-1]:
                     xc = (1 + psi * rho) * xbar - psi * rho * sim[-1]
-                    xc = np.clip(xc, lower_bound, upper_bound)
+                    if bounds is not None:
+                        xc = np.clip(xc, lower_bound, upper_bound)
                     fxc = func(xc)
 
                     if fxc <= fxr:
@@ -788,7 +791,8 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
                 else:
                     # Perform an inside contraction
                     xcc = (1 - psi) * xbar + psi * sim[-1]
-                    xcc = np.clip(xcc, lower_bound, upper_bound)
+                    if bounds is not None:
+                        xcc = np.clip(xcc, lower_bound, upper_bound)
                     fxcc = func(xcc)
 
                     if fxcc < fsim[-1]:
@@ -800,7 +804,8 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
                 if doshrink:
                     for j in one2np1:
                         sim[j] = sim[0] + sigma * (sim[j] - sim[0])
-                        sim[j] = np.clip(sim[j], lower_bound, upper_bound)
+                        if bounds is not None:
+                            sim[j] = np.clip(sim[j], lower_bound, upper_bound)
                         fsim[j] = func(sim[j])
 
         ind = np.argsort(fsim)

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -628,10 +628,12 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
         high-dimensional minimization [1]_.
     bounds : sequence or `Bounds`, optional
         Bounds on variables. There are two ways to specify the bounds:
+
             1. Instance of `Bounds` class.
             2. Sequence of ``(min, max)`` pairs for each element in `x`. None
                is used to specify no bound.
-        Note that this function just clips all vertices in simplex based on
+
+        Note that this just clips all vertices in simplex based on
         the bounds.
 
     References

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -590,10 +590,10 @@ def fmin(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None, maxfun=None,
             return res['x']
 
 
-def _minimize_neldermead(func, x0, args=(), callback=None, bounds=None,
+def _minimize_neldermead(func, x0, args=(), callback=None,
                          maxiter=None, maxfev=None, disp=False,
                          return_all=False, initial_simplex=None,
-                         xatol=1e-4, fatol=1e-4, adaptive=False,
+                         xatol=1e-4, fatol=1e-4, adaptive=False, bounds=None,
                          **unknown_options):
     """
     Minimization of scalar function of one or more variables using the

--- a/scipy/optimize/tests/test_minimize_constrained.py
+++ b/scipy/optimize/tests/test_minimize_constrained.py
@@ -745,8 +745,8 @@ class TestBoundedNelderMead(TestCase):
 
     def test_invalid_bounds(self):
         prob = Rosenbrock()
-       with raises(ValueError, match=r"one of the lower bounds "
-                                      "is greater than an upper bound."):
+        with raises(ValueError, match=r"one of the lower bounds is greater "
+                                      r"than an upper bound."):
             bounds = Bounds([-np.inf, 1.0], [4.0, -5.0])
             minimize(prob.fun, [-10, 3],
                      method='Nelder-Mead',
@@ -754,8 +754,8 @@ class TestBoundedNelderMead(TestCase):
 
     def test_outside_bounds_warning(self):
         prob = Rosenbrock()
-        with raises(UserWarning, match=r"Initial guess is not "
-                                        "within the specified bounds"):
+        with raises(UserWarning, match=r"Initial guess is not within "
+                                       r"the specified bounds"):
             bounds = Bounds([-np.inf, 1.0], [4.0, 5.0])
             minimize(prob.fun, [-10, 8],
                      method='Nelder-Mead',

--- a/scipy/optimize/tests/test_minimize_constrained.py
+++ b/scipy/optimize/tests/test_minimize_constrained.py
@@ -678,70 +678,25 @@ def test_bug_11886():
     minimize(opt, 2*[1], constraints = lin_cons)  # just checking that there are no errors
 
 
-class TestBoundedNelderMead(TestCase):
+class TestBoundedNelderMead:
 
-    def test_rosen_brock0(self):
+    @pytest.mark.parametrize('bounds',
+                             [Bounds(-np.inf, np.inf),
+                              Bounds(-np.inf, -0.8),
+                              Bounds(3.0, np.inf),
+                              Bounds([3.0, 1.0], [4.0, 5.0]),
+                              ])
+    def test_rosen_brock_with_bounds(self, bounds):
         prob = Rosenbrock()
-        bounds = Bounds(-np.inf, np.inf)
-
-        result = minimize(prob.fun, prob.x0,
-                          method='Nelder-Mead',
-                          bounds=bounds)
-        assert_allclose(result.x, [1.0, 1.0], rtol=10 ** -3)
-
-        result_no_bounds = minimize(prob.fun, prob.x0,
-                                    method='Nelder-Mead')
-        assert_allclose(result.x, result_no_bounds.x)
-
-    def test_rosen_brock1(self):
-        prob = Rosenbrock()
-        bounds = Bounds(-np.inf, -0.8)
-        result = minimize(prob.fun, [-10, -10],
-                          method='Nelder-Mead',
-                          bounds=bounds)
-        assert np.less_equal(bounds.lb, result.x).all()
-        assert np.less_equal(result.x, bounds.ub).all()
-        assert np.allclose(prob.fun(result.x), result.fun)
-
-    def test_rosen_brock2(self):
-        prob = Rosenbrock()
-        bounds = Bounds(3.0, np.inf)
-        result = minimize(prob.fun, [3, 100],
-                          method='Nelder-Mead',
-                          bounds=bounds)
-        assert np.less_equal(bounds.lb, result.x).all()
-        assert np.less_equal(result.x, bounds.ub).all()
-        assert np.allclose(prob.fun(result.x), result.fun)
-
-    def test_rosen_brock3(self):
-        prob = Rosenbrock()
-        bounds = Bounds([3.0, 1.0], [4.0, 5.0])
-        result = minimize(prob.fun, [3, 1],
-                          method='Nelder-Mead',
-                          bounds=bounds)
-        assert np.less_equal(bounds.lb, result.x).all()
-        assert np.less_equal(result.x, bounds.ub).all()
-        assert np.allclose(prob.fun(result.x), result.fun)
-
-    def test_rosen_brock4(self):
-        prob = Rosenbrock()
-        bounds = Bounds([-np.inf, 1.0], [4.0, 5.0])
-        result = minimize(prob.fun, [-10, 5],
-                          method='Nelder-Mead',
-                          bounds=bounds)
-        assert np.less_equal(bounds.lb, result.x).all()
-        assert np.less_equal(result.x, bounds.ub).all()
-        assert np.allclose(prob.fun(result.x), result.fun)
-
-    def test_rosen_brock5(self):
-        prob = Rosenbrock()
-        bounds = [(-np.inf, 4.0), (1.0, 5.0)]
-        result = minimize(prob.fun, [-10, 3],
-                          method='Nelder-Mead',
-                          bounds=bounds)
-        assert bounds[0][0] <= result.x[0] <= bounds[0][1]
-        assert bounds[1][0] <= result.x[1] <= bounds[1][1]
-        assert np.allclose(prob.fun(result.x), result.fun)
+        with suppress_warnings() as sup:
+            sup.filter(UserWarning, "Initial guess is not within "
+                                    "the specified bounds")
+            result = minimize(prob.fun, [-10, -10],
+                              method='Nelder-Mead',
+                              bounds=bounds)
+            assert np.less_equal(bounds.lb, result.x).all()
+            assert np.less_equal(result.x, bounds.ub).all()
+            assert np.allclose(prob.fun(result.x), result.fun)
 
     def test_equal_all_bounds(self):
         prob = Rosenbrock()

--- a/scipy/optimize/tests/test_minimize_constrained.py
+++ b/scipy/optimize/tests/test_minimize_constrained.py
@@ -755,10 +755,9 @@ class TestBoundedNelderMead(TestCase):
 
     def test_outside_bounds_warning(self):
         prob = Rosenbrock()
-        with warns(UserWarning) as exc_info:
+        with raises(UserWarning, match=r"Initial guess is not "
+                                        "within the specified bounds"):
             bounds = Bounds([-np.inf, 1.0], [4.0, 5.0])
             minimize(prob.fun, [-10, 8],
                      method='Nelder-Mead',
                      bounds=bounds)
-        assert "Initial guess is not within the specified bounds" in str(
-            exc_info[0].message.args[0])

--- a/scipy/optimize/tests/test_minimize_constrained.py
+++ b/scipy/optimize/tests/test_minimize_constrained.py
@@ -743,6 +743,28 @@ class TestBoundedNelderMead(TestCase):
         assert bounds[1][0] <= result.x[1] <= bounds[1][1]
         assert np.allclose(prob.fun(result.x), result.fun)
 
+    def test_equal_all_bounds(self):
+        prob = Rosenbrock()
+        bounds = Bounds([4.0, 5.0], [4.0, 5.0])
+        with suppress_warnings() as sup:
+            sup.filter(UserWarning, "Initial guess is not within "
+                                    "the specified bounds")
+            result = minimize(prob.fun, [-10, 8],
+                              method='Nelder-Mead',
+                              bounds=bounds)
+            assert np.allclose(result.x, [4.0, 5.0])
+
+    def test_equal_one_bounds(self):
+        prob = Rosenbrock()
+        bounds = Bounds([4.0, 5.0], [4.0, 20.0])
+        with suppress_warnings() as sup:
+            sup.filter(UserWarning, "Initial guess is not within "
+                                    "the specified bounds")
+            result = minimize(prob.fun, [-10, 8],
+                              method='Nelder-Mead',
+                              bounds=bounds)
+            assert np.allclose(result.x, [4.0, 16.0])
+
     def test_invalid_bounds(self):
         prob = Rosenbrock()
         with raises(ValueError, match=r"one of the lower bounds is greater "

--- a/scipy/optimize/tests/test_minimize_constrained.py
+++ b/scipy/optimize/tests/test_minimize_constrained.py
@@ -745,13 +745,12 @@ class TestBoundedNelderMead(TestCase):
 
     def test_invalid_bounds(self):
         prob = Rosenbrock()
-        with raises(ValueError) as exc_info:
+       with raises(ValueError, match=r"one of the lower bounds "
+                                      "is greater than an upper bound."):
             bounds = Bounds([-np.inf, 1.0], [4.0, -5.0])
             minimize(prob.fun, [-10, 3],
                      method='Nelder-Mead',
                      bounds=bounds)
-        assert "one of the lower bounds is greater than an upper bound." \
-               in str(exc_info.value)
 
     def test_outside_bounds_warning(self):
         prob = Rosenbrock()

--- a/scipy/optimize/tests/test_minimize_constrained.py
+++ b/scipy/optimize/tests/test_minimize_constrained.py
@@ -680,13 +680,13 @@ def test_bug_11886():
 
 class TestBoundedNelderMead:
 
-    @pytest.mark.parametrize('bounds',
-                             [Bounds(-np.inf, np.inf),
-                              Bounds(-np.inf, -0.8),
-                              Bounds(3.0, np.inf),
-                              Bounds([3.0, 1.0], [4.0, 5.0]),
+    @pytest.mark.parametrize('bounds, x_opt',
+                             [(Bounds(-np.inf, np.inf), Rosenbrock().x_opt),
+                              (Bounds(-np.inf, -0.8), [-0.8, -0.8]),
+                              (Bounds(3.0, np.inf), [3.0, 9.0]),
+                              (Bounds([3.0, 1.0], [4.0, 5.0]), [3., 5.]),
                               ])
-    def test_rosen_brock_with_bounds(self, bounds):
+    def test_rosen_brock_with_bounds(self, bounds, x_opt):
         prob = Rosenbrock()
         with suppress_warnings() as sup:
             sup.filter(UserWarning, "Initial guess is not within "
@@ -697,6 +697,7 @@ class TestBoundedNelderMead:
             assert np.less_equal(bounds.lb, result.x).all()
             assert np.less_equal(result.x, bounds.ub).all()
             assert np.allclose(prob.fun(result.x), result.fun)
+            assert np.allclose(result.x, x_opt, atol=1.e-3)
 
     def test_equal_all_bounds(self):
         prob = Rosenbrock()


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
fix #11050

#### What does this implement/fix?
<!--Please explain your changes.-->
As in #11050, some users are looking for bound constraint support for nelder-mead solver. So, I added it.
The bound constraint implementation is based on Appendix A in [this paper](https://www.google.com/url?sa=t&source=web&rct=j&url=https://www.emse.fr/~leriche/GBNM_SMO_1026_final.pdf&ved=2ahUKEwizuuntypPnAhW04HMBHd43B4YQFjABegQIBRAB&usg=AOvVaw0Ox-n6PW-v7Uq2OMUyXlYo&cshid=1579571904651). (Just clipping the variables)
I also added some tests for it.
