### PR TITLE
DOC: document that pip >= 20.3.3 is needed for macOS 11

### DIFF
--- a/doc/release/1.6.1-notes.rst
+++ b/doc/release/1.6.1-notes.rst
@@ -7,6 +7,10 @@ SciPy 1.6.1 Release Notes
 SciPy 1.6.1 is a bug-fix release with no new features
 compared to 1.6.0.
 
+Please note that for SciPy wheels to correctly install with Pip on
+macOS 11, Pip >= 20.3.3 is needed.
+
+
 Authors
 =======
 


### PR DESCRIPTION
 Closes gh-13363
 Closes gh-13361
 xref gh-13102 (leaving open, because it contains build-from-source info)

Release notes seem to be the best place to document this.
