### PR TITLE
BLD: update reqs based on oldest-supported-numpy in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,10 +3,33 @@ requires = [
     "wheel",
     "setuptools",
     "Cython>=0.29.18",
-    "pythran",
-    "numpy==1.16.5; python_version=='3.7'",
-    "numpy==1.17.3; python_version=='3.8'",
-    # do not pin numpy on future versions of python to avoid incompatible numpy and python versions
-    "numpy; python_version>='3.9'",
     "pybind11>=2.4.3",
+    "pythran",
+
+    # NumPy dependencies - to update these, sync from
+    # https://github.com/scipy/oldest-supported-numpy/, and then
+    # update minimum version to match our install_requires min version
+    # ----------------------------------------------------------------
+
+    # numpy 1.19 was the first minor release to provide aarch64 wheels, but
+    # wheels require fixes contained in numpy 1.19.2
+    "numpy==1.19.2; python_version=='3.6' and platform_machine=='aarch64'",
+    "numpy==1.19.2; python_version=='3.7' and platform_machine=='aarch64'",
+
+    # default numpy requirements
+    "numpy==1.16.5; python_version=='3.6' and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'",
+    "numpy==1.16.5; python_version=='3.7' and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'",
+    "numpy==1.17.3; python_version=='3.8' and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'",
+    "numpy==1.19.3; python_version=='3.9' and platform_python_implementation != 'PyPy'",
+
+    # First PyPy versions for which there are numpy wheels
+    "numpy==1.19.0; python_version=='3.6' and platform_python_implementation=='PyPy'",
+    "numpy==1.20.0; python_version=='3.7' and platform_python_implementation=='PyPy'",
+
+    # For Python versions which aren't yet officially supported,
+    # we specify an unpinned NumPy which allows source distributions
+    # to be used and allows wheels to be used as soon as they
+    # become available.
+    "numpy; python_version>='3.10'",
+    "numpy; python_version>='3.8' and platform_python_implementation=='PyPy'",
 ]


### PR DESCRIPTION
See https://github.com/scipy/oldest-supported-numpy/

This is becoming a real pain to maintain separately, and we should depend on these details in a single place.

Note that scikit-learn also just started depending on oldest-supported-numpy.

EDIT: this PR ended up NOT using `oldest-supported-numpy` directly, see comment below.