### PR TITLE
DOC: correct comparisons between median filter functions

### DIFF
--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -1367,6 +1367,16 @@ def median_filter(input, size=None, footprint=None, output=None,
     median_filter : ndarray
         Filtered array. Has the same shape as `input`.
 
+    See also
+    --------
+    scipy.signal.medfilt2d
+
+    Notes
+    -----
+    For 2-dimensional images with `np.ubyte`, `np.single` or `np.double`
+    datatypes the specialised function `scipy.signal.medfilt2d` is faster but
+    is limited to constant mode with ``cval=0``.
+
     Examples
     --------
     >>> from scipy import ndimage, misc

--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -1374,8 +1374,8 @@ def median_filter(input, size=None, footprint=None, output=None,
     Notes
     -----
     For 2-dimensional images with `np.ubyte`, `np.single` or `np.double`
-    datatypes the specialised function `scipy.signal.medfilt2d` is faster but
-    is limited to constant mode with ``cval=0``.
+    datatypes the specialised function `scipy.signal.medfilt2d` may be faster
+    but is limited to constant mode with ``cval=0``.
 
     Examples
     --------

--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -1373,9 +1373,9 @@ def median_filter(input, size=None, footprint=None, output=None,
 
     Notes
     -----
-    For 2-dimensional images with `np.ubyte`, `np.single` or `np.double`
-    datatypes the specialised function `scipy.signal.medfilt2d` may be faster
-    but is limited to constant mode with ``cval=0``.
+    For 2-dimensional images with ``uint8``, ``float32`` or ``float64`` dtypes
+    the specialised function `scipy.signal.medfilt2d` may be faster. It is
+    however limited to constant mode with ``cval=0``.
 
     Examples
     --------

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1506,7 +1506,7 @@ def medfilt(volume, kernel_size=None):
     The more general function `scipy.ndimage.median_filter` has a more
     efficient implementation of a median filter and therefore runs much faster.
     For 2-dimensional images with `np.ubyte`, `np.single` or `np.double`
-    datatypes the specialised function `scipy.signal.medfilt2d` is fastest.
+    datatypes the specialised function `scipy.signal.medfilt2d` may be faster.
 
     """
     volume = np.atleast_1d(volume)
@@ -1829,7 +1829,8 @@ def medfilt2d(input, kernel_size=3):
     This is faster than `scipy.signal.medfilt` when `input.dtype.type`
     is `np.ubyte`, `np.single`, or `np.double`. For other types, this
     falls back to `scipy.signal.medfilt`; you should use
-    `scipy.ndimage.median_filter` instead as it is much faster.
+    `scipy.ndimage.median_filter` instead as it is much faster. In some
+    situations, `scipy.ndimage.median_filter` may be faster than this function.
 
     """
     image = np.asarray(input)

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1505,8 +1505,9 @@ def medfilt(volume, kernel_size=None):
     -----
     The more general function `scipy.ndimage.median_filter` has a more
     efficient implementation of a median filter and therefore runs much faster.
-    For 2-dimensional images with `np.ubyte`, `np.single` or `np.double`
-    datatypes the specialised function `scipy.signal.medfilt2d` may be faster.
+
+    For 2-dimensional images with ``uint8``, ``float32`` or ``float64`` dtypes,
+    the specialised function `scipy.signal.medfilt2d` may be faster.
 
     """
     volume = np.atleast_1d(volume)
@@ -1826,11 +1827,11 @@ def medfilt2d(input, kernel_size=3):
 
     Notes
     -----
-    This is faster than `scipy.signal.medfilt` when `input.dtype.type`
-    is `np.ubyte`, `np.single`, or `np.double`. For other types, this
-    falls back to `scipy.signal.medfilt`; you should use
-    `scipy.ndimage.median_filter` instead as it is much faster. In some
-    situations, `scipy.ndimage.median_filter` may be faster than this function.
+    This is faster than `medfilt` when the input dtype is ``uint8``,
+    ``float32``, or ``float64``; for other types, this falls back to
+    `medfilt`; you should use `scipy.ndimage.median_filter` instead as it is
+    much faster.  In some situations, `scipy.ndimage.median_filter` may be
+    faster than this function.
 
     """
     image = np.asarray(input)

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1499,11 +1499,15 @@ def medfilt(volume, kernel_size=None):
     See Also
     --------
     scipy.ndimage.median_filter
+    scipy.signal.medfilt2d
 
     Notes
     -----
     The more general function `scipy.ndimage.median_filter` has a more
     efficient implementation of a median filter and therefore runs much faster.
+    For 2-dimensional images with `np.ubyte`, `np.single` or `np.double`
+    datatypes the specialised function `scipy.signal.medfilt2d` is fastest.
+
     """
     volume = np.atleast_1d(volume)
     if kernel_size is None:
@@ -1823,11 +1827,10 @@ def medfilt2d(input, kernel_size=3):
     Notes
     -----
     This is faster than `scipy.signal.medfilt` when `input.dtype.type`
-    is `np.ubyte`, `np.single`, or `np.double`; for other types, this
-    falls back to `scipy.signal.medfilt`
+    is `np.ubyte`, `np.single`, or `np.double`. For other types, this
+    falls back to `scipy.signal.medfilt`; you should use
+    `scipy.ndimage.median_filter` instead as it is much faster.
 
-    The more general function `scipy.ndimage.median_filter` has a more
-    efficient implementation of a median filter and therefore runs much faster.
     """
     image = np.asarray(input)
 


### PR DESCRIPTION
#### What does this implement/fix?

As per the timings reported in GH #13509, the signal.medfilt2d function
is actually faster than ndimage.median_filter for its specific usecase.
Change the docstring of medfilt2d to reflect this, and mention medfilt2d
in both median_filter and signal.medfilt.