### PR TITLE
ENH: release the GIL inside medfilt2d

### DIFF
--- a/benchmarks/benchmarks/signal_filtering.py
+++ b/benchmarks/benchmarks/signal_filtering.py
@@ -1,7 +1,6 @@
 import numpy as np
-from numpy.testing import assert_allclose
 import timeit
-from concurrent.futures import ThreadPoolExecutor, as_completed, wait
+from concurrent.futures import ThreadPoolExecutor, wait
 
 from .common import Benchmark, safe_import
 
@@ -87,51 +86,19 @@ class Sosfilt(Benchmark):
 
 
 class MedFilt2D(Benchmark):
-    def setup_cache(self):
+    param_names = ['threads']
+    params = [[1, 2, 4]]
+
+    def setup(self, threads):
         np.random.seed(8176)
-        data = np.random.randn(2000, 4000)
-        expected = medfilt2d(data, 5)
-        np.save("medfilt2d_data.npy", data)
-        np.save("medfilt2d_expected.npy", expected)
+        self.chunks = np.array_split(np.random.randn(250, 349), threads)
 
-    def setup(self):
-        self.data = np.load("medfilt2d_data.npy")
-        self.expected = np.load("medfilt2d_expected.npy")
+    def _medfilt2d(self, threads):
+        with ThreadPoolExecutor(max_workers=threads) as pool:
+            wait({pool.submit(medfilt2d, chunk, 5) for chunk in self.chunks})
 
-    def teardown(self):
-        assert_allclose(self.output, self.expected)
+    def time_medfilt2d(self, threads):
+        self._medfilt2d(threads)
 
-    def _multithreaded(self):
-        # Lets take four overlapping chunks over the last axis. First pair of
-        # values is range to select from input, second pair range of the result
-        # to use, last pair the range of the output array to store it in.
-        chunks = (
-            (0, 1002, None, -2, 0, 1000),
-            (998, 2002, 2, -2, 1000, 2000),
-            (1998, 3002, 2, -2, 2000, 3000),
-            (2998, 4000, 2, None, 3000, 4000)
-        )
-
-        self.output = np.empty(self.data.shape, dtype=self.data.dtype)
-
-        def apply(chunk):
-            return medfilt2d(self.data[:, chunk[0]:chunk[1]], 5)
-
-        with ThreadPoolExecutor(max_workers=4) as executor:
-            futures = {executor.submit(apply, chk): chk for chk in chunks}
-            for future in as_completed(futures):
-                chk = futures[future]
-                result = future.result()
-                self.output[:, chk[4]:chk[5]] = result[:, chk[2]:chk[3]]
-
-    def time_singlethreaded(self):
-        self.output = medfilt2d(self.data, 5)
-
-    def time_multithreaded(self):
-        self._multithreaded()
-
-    def peakmem_singlethreaded(self):
-        self.output = medfilt2d(self.data, 5)
-
-    def peakmem_multithreaded(self):
-        self._multithreaded()
+    def peakmem_medfilt2d(self, threads):
+        self._medfilt2d(threads)

--- a/benchmarks/benchmarks/signal_filtering.py
+++ b/benchmarks/benchmarks/signal_filtering.py
@@ -1,11 +1,13 @@
 import numpy as np
+from numpy.testing import assert_allclose
 import timeit
-from concurrent.futures import ThreadPoolExecutor, wait
+from concurrent.futures import ThreadPoolExecutor, as_completed, wait
 
 from .common import Benchmark, safe_import
 
 with safe_import():
-    from scipy.signal import lfilter, firwin, decimate, butter, sosfilt
+    from scipy.signal import (lfilter, firwin, decimate, butter, sosfilt,
+                              medfilt2d)
 
 
 class Decimate(Benchmark):
@@ -82,3 +84,54 @@ class Sosfilt(Benchmark):
 
     def time_sosfilt_basic(self, n_samples, order):
         sosfilt(self.sos, self.y)
+
+
+class MedFilt2D(Benchmark):
+    def setup_cache(self):
+        np.random.seed(8176)
+        data = np.random.randn(2000, 4000)
+        expected = medfilt2d(data, 5)
+        np.save("medfilt2d_data.npy", data)
+        np.save("medfilt2d_expected.npy", expected)
+
+    def setup(self):
+        self.data = np.load("medfilt2d_data.npy")
+        self.expected = np.load("medfilt2d_expected.npy")
+
+    def teardown(self):
+        assert_allclose(self.output, self.expected)
+
+    def _multithreaded(self):
+        # Lets take four overlapping chunks over the last axis. First pair of
+        # values is range to select from input, second pair range of the result
+        # to use, last pair the range of the output array to store it in.
+        chunks = (
+            (0, 1002, None, -2, 0, 1000),
+            (998, 2002, 2, -2, 1000, 2000),
+            (1998, 3002, 2, -2, 2000, 3000),
+            (2998, 4000, 2, None, 3000, 4000)
+        )
+
+        self.output = np.empty(self.data.shape, dtype=self.data.dtype)
+
+        def apply(chunk):
+            return medfilt2d(self.data[:, chunk[0]:chunk[1]], 5)
+
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            futures = {executor.submit(apply, chk): chk for chk in chunks}
+            for future in as_completed(futures):
+                chk = futures[future]
+                result = future.result()
+                self.output[:, chk[4]:chk[5]] = result[:, chk[2]:chk[3]]
+
+    def time_singlethreaded(self):
+        self.output = medfilt2d(self.data, 5)
+
+    def time_multithreaded(self):
+        self._multithreaded()
+
+    def peakmem_singlethreaded(self):
+        self.output = medfilt2d(self.data, 5)
+
+    def peakmem_multithreaded(self):
+        self._multithreaded()

--- a/scipy/signal/medianfilter.c
+++ b/scipy/signal/medianfilter.c
@@ -82,6 +82,8 @@ void NAME(TYPE* in, TYPE* out, npy_intp* Nwin, npy_intp* Ns)                    
     totN = Nwin[0] * Nwin[1];                                           \
     myvals = (TYPE *) check_malloc( totN * sizeof(TYPE));               \
                                                                         \
+    Py_BEGIN_ALLOW_THREADS                                              \
+                                                                        \
     hN[0] = Nwin[0] >> 1;                                               \
     hN[1] = Nwin[1] >> 1;                                               \
     ptr1 = in;                                                          \
@@ -112,6 +114,9 @@ void NAME(TYPE* in, TYPE* out, npy_intp* Nwin, npy_intp* Ns)                    
             /*      *fptr1++ = median(myvals,totN); */                  \
             *fptr1++ = SELECT(myvals,totN);                             \
         }                                                               \
+                                                                        \
+    Py_END_ALLOW_THREADS                                                \
+                                                                        \
     free(myvals);                                                       \
 }
 


### PR DESCRIPTION
#### What does this implement/fix?

The actual calculation for medfilt2d is done by low-level functions (created through the `MEDIAN_FILTER_2D` macro function in `scipy/signal/medianfilter.c`) using C-level data access rather than accessing the data through Python structures. I think it should therefore be possible to release the GIL during the calculation. In particular, this allows the data to be split into chunks and the median filter output calculated in parallel.

#### Additional information

A question about releasing the GIL was included in GH-9476 but not addressed. 

I am working with large datasets (70,000 by 5,000 pixel images are typical) and median filtering is the slowest part of the analysis at the moment. I created an xarray+Dask wrapper to split the median filtering into chunks ([dask.array.overlap](https://docs.dask.org/en/latest/array-api.html#dask.array.overlap.overlap) is very useful!) but this didn't result in any speedup due to the calculation holding the GIL. With this PR, the GIL is released and filtering in chunks becomes possible (100% usage of all cores == much faster).

A comparison between the output before and after this commit results in `np.all(a == b)` for one of my datasets. All of the tests pass locally. However, this is the first time I've played with the GIL so I'm not sure if there are other potential issues this might cause. I would assume that the higher-level code has taken care of the reference counting and so the memory should not be deallocated during the calculation, and if there is code in another thread modifying the data simultaneously then that will cause issues whether the GIL is held or not.