### PR TITLE
DOC: fix list of "mode" options for ndimage

### DIFF
--- a/scipy/ndimage/_ni_docstrings.py
+++ b/scipy/ndimage/_ni_docstrings.py
@@ -68,7 +68,8 @@ _mode_reflect_doc = (
         This is a synonym for 'wrap'.""")
 
 _mode_interp_constant_doc = (
-"""mode : {'reflect', 'constant', 'nearest', 'mirror', 'wrap'}, optional
+"""mode : {'reflect', 'grid-mirror', 'constant', 'grid-constant', 'nearest', \
+           'mirror', 'grid-wrap', 'wrap'}, optional
     The `mode` parameter determines how the input array is extended
     beyond its boundaries. Default is 'constant'. Behavior for each valid
     value is as follows (see additional plots and details on


### PR DESCRIPTION
I believe the `\` should display properly with numpydoc, but in full
disclaimer I haven't tested a doc build.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->