### PR TITLE
MAINT: add git to docker env

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -40,7 +40,7 @@ RUN apt-get update && \
 RUN apt-get update && apt-get install -y \
 	python3.7 \
 	python3.7-dev \
-	python3-pip git \
+	python3-pip \
 	build-essential \
 	vim \
 	libatlas-base-dev \
@@ -51,7 +51,9 @@ RUN apt-get update && apt-get install -y \
 	libgmp-dev \
 	libmpfr-dev \
 	libsuitesparse-dev \
-	libmpc-dev
+	libmpc-dev \
+	git
+
 
 # setup pips, pip3.7 and pip3.8
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3.7 get-pip.py && python3.8 get-pip.py && rm get-pip.py

--- a/tools/docker_dev/Dockerfile
+++ b/tools/docker_dev/Dockerfile
@@ -77,19 +77,19 @@ ENV DEBIAN_FRONTEND noninteractive
 # hadolint ignore=DL3008
 RUN apt-get update && \ 
     apt-get install -yq --no-install-recommends \
-    software-properties-common \
     build-essential \
-    libatlas-base-dev \
-    vim \
+    ca-certificates \
     curl \
-    wget \
     git \
-    ca-certificates && \
+    libatlas-base-dev \
+    software-properties-common \
+    vim \
+    wget \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/* &&\
-    rm -rf /var/cache/apt/* && \
+    rm -rf /tmp/* && \
     rm -rf /var/lib/apt/lists/* && \
-    rm -rf /tmp/*
+    rm -rf /var/cache/apt/* && \
+    rm -rf /var/lib/apt/lists/*
 
 # -----------------------------------------------------------------------------
 
@@ -102,10 +102,10 @@ RUN sed -i 's/^#force_color_prompt=yes/force_color_prompt=yes/' /etc/skel/.bashr
 # -----------------------------------------------------------------------------
 
 # Enable basic vim defaults in ~/.vimrc
-RUN echo "set number" >> ~/.vimrc && \
-    echo "syntax enable" >> ~/.vimrc && \
-    echo "filetype plugin indent on" >> ~/.vimrc && \
-    echo "set colorcolumn=80" >> ~/.vimrc
+RUN echo "filetype plugin indent on" >> ~/.vimrc && \
+    echo "set colorcolumn=80" >> ~/.vimrc && \
+    echo "set number" >> ~/.vimrc && \
+    echo "syntax enable" >> ~/.vimrc
 
 # -----------------------------------------------------------------------------
 # ---- Installing conda  ----

--- a/tools/docker_dev/Dockerfile
+++ b/tools/docker_dev/Dockerfile
@@ -83,6 +83,7 @@ RUN apt-get update && \
     vim \
     curl \
     wget \
+    git \
     ca-certificates && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* &&\
@@ -97,6 +98,14 @@ RUN apt-get update && \
 RUN sed -i 's/^#force_color_prompt=yes/force_color_prompt=yes/' /etc/skel/.bashrc && \
     # Add call to conda init script see https://stackoverflow.com/a/58081608/4413446
     echo 'eval "$(command conda shell.bash hook 2> /dev/null)"' >> /etc/skel/.bashrc 
+
+# -----------------------------------------------------------------------------
+
+# Enable basic vim defaults in ~/.vimrc
+RUN echo "set number" >> ~/.vimrc && \
+    echo "syntax enable" >> ~/.vimrc && \
+    echo "filetype plugin indent on" >> ~/.vimrc && \
+    echo "set colorcolumn=80" >> ~/.vimrc
 
 # -----------------------------------------------------------------------------
 # ---- Installing conda  ----


### PR DESCRIPTION
#### Reference issue
N/A

#### What does this implement/fix?
Adds `git` to the env in the docker container(s) by default. 

#### Additional information
When I setup the docker container for development I noticed there wasn't git enabled by default. Not a big deal to add but any development environment will need it so adding by default in this PR. 

I also added a couple vim settings inside a `~/.vimrc` file. If there are objections to those settings or other settings that we think we should add for default happy to add/remove. Arguments can be made for using `stow` instead of container defaults.

I'm not sure how to test this to confirm the settings work as expected-suggestions welcome. 

Some follow ups from gh-13447
