### PR TITLE
DOC: use support rather than a/b in stats tutorial

### DIFF
--- a/doc/source/tutorial/stats.rst
+++ b/doc/source/tutorial/stats.rst
@@ -65,7 +65,7 @@ docstring: ``print(stats.norm.__doc__)``.
 To find the support, i.e., upper and lower bounds of the distribution,
 call:
 
-    >>> print('bounds of distribution lower: %s, upper: %s' % (norm.a, norm.b))
+    >>> print('bounds of distribution lower: %s, upper: %s' % norm.support())
     bounds of distribution lower: -inf, upper: inf
 
 We can list all methods and properties of the distribution with


### PR DESCRIPTION
The [scipy stats tutorial uses](https://docs.scipy.org/doc/scipy/reference/tutorial/stats.html#getting-help) `.a` and `.b` to get a distribution's support. This gives incorrect results on frozen distributions, as discussed in https://github.com/scipy/scipy/issues/13225. This PR changes the tutorial to recommend the `support` method instead. 

There was some discussion in https://github.com/scipy/scipy/issues/13225 and https://github.com/scipy/scipy/issues/13228 about whether the `a` and `b` attributes should be considered public. It looks like the conclusion was "No", though this didn't consider this rather prominent occurrence in the documentation -- the very first non-import code cell of the tutorial. Regardless, it seems clear that `.support()` is the recommended method for getting supports, not `.a` and `.b`.