### PR TITLE
MAINT: optimize: using np.isclose instead of _within_tolerance.

### DIFF
--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -888,13 +888,6 @@ def brenth(f, a, b, args=(),
 #  See [1]
 
 
-def _within_tolerance(x, y, rtol, atol):
-    diff = np.abs(x - y)
-    z = np.abs(y)
-    result = (diff <= (atol + rtol * z))
-    return result
-
-
 def _notclose(fs, rtol=_rtol, atol=_xtol):
     # Ensure not None, not 0, all finite, and not very close to each other
     notclosefvals = (
@@ -1121,7 +1114,7 @@ class TOMS748Solver(object):
     def get_status(self):
         """Determine the current status."""
         a, b = self.ab[:2]
-        if _within_tolerance(a, b, self.rtol, self.xtol):
+        if np.isclose(a, b, rtol=self.rtol, atol=self.xtol):
             return _ECONVERGED, sum(self.ab) / 2.0
         if self.iterations >= self.maxiter:
             return _ECONVERR, sum(self.ab) / 2.0


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
fix #13536

#### What does this implement/fix?
<!--Please explain your changes.-->
This is a small clean up PR. 
As suggested in #13536, the  `_within_tolerance` can be replaced by [np.isclose](https://numpy.org/doc/stable/reference/generated/numpy.isclose.html). 
So, I replaced it and removed `_within_tolerance`.
