### PR TITLE
DOC: document remote gpg2 (release management)

### DIFF
--- a/doc/source/dev/core-dev/releasing.rst.inc
+++ b/doc/source/dev/core-dev/releasing.rst.inc
@@ -75,6 +75,10 @@ creating a GPG key if you do not have one. Note that on some platforms
 it may be more suitable to use ``gpg2`` instead of ``gpg`` so that
 passwords may be stored by ``gpg-agent`` as discussed in
 https://github.com/scipy/scipy/issues/10189.
+When preparing a release remotely, it may be necessary to set
+``pinentry-mode loopback`` in ``~/.gnupg/gpg-agent.conf`` because
+use of ``gpg2`` will otherwise proceed via an inaccessible graphical
+password prompt.
 
 To make your key more readily identifiable as you, consider sending your key
 to public keyservers, with a command such as::


### PR DESCRIPTION
* recent versions of `gpg2`/gpg-agent may suffer from an issue where
they interact with `pinentry` in such a way that using them to
sign remotely (working over ssh) is impossible because the key-signing
password prompt is graphics-only with no terminal fallback:
https://bugs.launchpad.net/ubuntu/+source/gnupg2/+bug/1775923

* this can cost a release manager a few hours of debugging, and
we do need to change machines/platforms sometimes because of
i.e.: gh-13369

* so, document the workaround
