### PR TITLE
ENH: Speed up hdquantiles_sd()

### DIFF
--- a/scipy/stats/mstats_extras.py
+++ b/scipy/stats/mstats_extras.py
@@ -162,12 +162,10 @@ def hdquantiles_sd(data, prob=list([.25,.5,.75]), axis=None):
         vv = np.arange(n) / float(n-1)
         betacdf = beta.cdf
         
-        idx = np.fromiter(range(n), dtype=int_)
-
         for (i,p) in enumerate(prob):
             _w = betacdf(vv, (n+1)*p, (n+1)*(1-p))
             w = _w[1:] - _w[:-1]
-            mx_ = np.fromiter([np.dot(w,xsorted[idx != k])
+            mx_ = np.fromiter([np.dot(w, np.delete(xsorted, k))
                                for k in range(n)], dtype=float_)
             mx_var = np.array(mx_.var(), copy=False, ndmin=1) * n / float(n-1)
             hdsd[i] = float(n-1) * np.sqrt(np.diag(mx_var).diagonal() / float(n))

--- a/scipy/stats/mstats_extras.py
+++ b/scipy/stats/mstats_extras.py
@@ -165,7 +165,7 @@ def hdquantiles_sd(data, prob=list([.25,.5,.75]), axis=None):
         for (i,p) in enumerate(prob):
             _w = betacdf(vv, (n+1)*p, (n+1)*(1-p))
             w = _w[1:] - _w[:-1]
-            mx_ = np.fromiter([np.dot(w, np.delete(xsorted, k))
+            mx_ = np.fromiter([w[:k] @ xsorted[:k] + w[k:] @ xsorted[k+1:]
                                for k in range(n)], dtype=float_)
             mx_var = np.array(mx_.var(), copy=False, ndmin=1) * n / float(n-1)
             hdsd[i] = float(n-1) * np.sqrt(np.diag(mx_var).diagonal() / float(n))

--- a/scipy/stats/mstats_extras.py
+++ b/scipy/stats/mstats_extras.py
@@ -161,13 +161,14 @@ def hdquantiles_sd(data, prob=list([.25,.5,.75]), axis=None):
 
         vv = np.arange(n) / float(n-1)
         betacdf = beta.cdf
+        
+        idx = np.fromiter(range(n), dtype=int_)
 
         for (i,p) in enumerate(prob):
             _w = betacdf(vv, (n+1)*p, (n+1)*(1-p))
             w = _w[1:] - _w[:-1]
-            mx_ = np.fromiter([np.dot(w,xsorted[np.r_[list(range(0,k)),
-                                                      list(range(k+1,n))].astype(int_)])
-                                  for k in range(n)], dtype=float_)
+            mx_ = np.fromiter([np.dot(w,xsorted[idx != k])
+                               for k in range(n)], dtype=float_)
             mx_var = np.array(mx_.var(), copy=False, ndmin=1) * n / float(n-1)
             hdsd[i] = float(n-1) * np.sqrt(np.diag(mx_var).diagonal() / float(n))
         return hdsd


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
By changing the indexing of `xsorted` as proposed, the function speeds up substantially. The code also becomes more readable.

After a couple of iterations of this PR (with suggestions from @mdhaber ), for a vector with 60000 samples we get a speed up factor of ~537x. The speed up factor increases with the number of data samples, which is good too.

#### Additional information
Relevant local tests pass:

$ python runtests.py -v -t scipy.stats.tests.test_mstats_extras   
Building, see build.log...
Build OK (0:00:02.504088 elapsed)
======================================================== test session starts =========================================================
platform linux -- Python 3.7.9, pytest-6.2.2, py-1.10.0, pluggy-0.13.1 -- /home/rcasero/Software/miniconda3/envs/scipy_test/bin/python
cachedir: .pytest_cache
rootdir: /home/rcasero/Software/scipy, configfile: pytest.ini
collected 9 items                                                                                                                    

scipy/stats/tests/test_mstats_extras.py::test_compare_medians_ms PASSED                                                        [ 11%]
scipy/stats/tests/test_mstats_extras.py::test_hdmedian PASSED                                                                  [ 22%]
scipy/stats/tests/test_mstats_extras.py::test_rsh PASSED                                                                       [ 33%]
scipy/stats/tests/test_mstats_extras.py::test_mjci PASSED                                                                      [ 44%]
scipy/stats/tests/test_mstats_extras.py::test_trimmed_mean_ci PASSED                                                           [ 55%]
scipy/stats/tests/test_mstats_extras.py::test_idealfourths PASSED                                                              [ 66%]
scipy/stats/tests/test_mstats_extras.py::TestQuantiles::test_hdquantiles PASSED                                                [ 77%]
scipy/stats/tests/test_mstats_extras.py::TestQuantiles::test_hdquantiles_sd PASSED                                             [ 88%]
scipy/stats/tests/test_mstats_extras.py::TestQuantiles::test_mquantiles_cimj PASSED                                            [100%]

========================================================= 9 passed in 0.18s ==========================================================
