### PR TITLE
TST, BUG: adjust tol on test_equivalence

### DIFF
--- a/scipy/optimize/tests/test__numdiff.py
+++ b/scipy/optimize/tests/test__numdiff.py
@@ -571,7 +571,8 @@ class TestApproxDerivativeSparse(object):
             J_dense = approx_derivative(self.fun, self.x0, method=method)
             J_sparse = approx_derivative(
                 self.fun, self.x0, sparsity=(structure, groups), method=method)
-            assert_equal(J_dense, J_sparse.toarray())
+            assert_allclose(J_dense, J_sparse.toarray(),
+                            rtol=5e-16, atol=7e-15)
 
     def test_check_derivative(self):
         def jac(x):


### PR DESCRIPTION
Fixes #13565

* `TestApproxDerivativeSparse.test_equivalence` has been
causing 32-bit Linux AMD64 failures on both `master` and
`maintenance/1.6.x` wheels repo builds

* nudge the tols up a bit above the failures reported
in test logs (we could also be more specific and only
do this for 32-bit & the specifically-sensitive method
`cs`)