### PR TITLE
BENCH: optimize: benchmark only HiGHS methods; add bigger linprog benchmarks

### DIFF
--- a/benchmarks/benchmarks/optimize_linprog.py
+++ b/benchmarks/benchmarks/optimize_linprog.py
@@ -8,57 +8,30 @@ from .common import Benchmark, is_xslow, safe_import
 with safe_import():
     from scipy.optimize import linprog, OptimizeWarning
 
-with safe_import() as exc:
+with safe_import():
     from scipy.optimize.tests.test_linprog import lpgen_2d, magic_square
-    from scipy.optimize._remove_redundancy import (
-        _remove_redundancy_svd,
-        _remove_redundancy_pivot_sparse,
-        _remove_redundancy_pivot_dense,
-        _remove_redundancy_id
-    )
-    from scipy.optimize._linprog_util import (
-        _presolve,
-        _clean_inputs,
-        _LPProblem
-    )
-if exc.error:
-    _remove_redundancy_svd = None
-    _remove_redundancy_pivot_sparse = None
-    _remove_redundancy_pivot_dense = None
-    _remove_redundancy_id = None
 
 with safe_import():
     from scipy.linalg import toeplitz
 
-with safe_import():
-    from scipy.sparse import csc_matrix, csr_matrix, issparse
-
-methods = [("interior-point", {"sparse": True}),
-           ("interior-point", {"sparse": False}),
-           ("revised simplex", {}),
-           ("highs-ipm", {}),
+methods = [("highs-ipm", {}),
            ("highs-ds", {})]
-rr_methods = [_remove_redundancy_svd, _remove_redundancy_pivot_sparse,
-              _remove_redundancy_pivot_dense, _remove_redundancy_id]
-presolve_methods = ['sparse', 'dense']
 
 problems = ['25FV47', '80BAU3B', 'ADLITTLE', 'AFIRO', 'AGG', 'AGG2', 'AGG3',
             'BANDM', 'BEACONFD', 'BLEND', 'BNL1', 'BNL2', 'BORE3D', 'BRANDY',
-            'CAPRI', 'CYCLE', 'CZPROB', 'D6CUBE', 'DEGEN2', 'DEGEN3', 'E226',
-            'ETAMACRO', 'FFFFF800', 'FINNIS', 'FIT1D', 'FIT1P', 'GANGES',
-            'GFRD-PNC', 'GROW15', 'GROW22', 'GROW7', 'ISRAEL', 'KB2', 'LOTFI',
-            'MAROS', 'MODSZK1', 'PEROLD', 'PILOT', 'PILOT-WE', 'PILOT4',
-            'PILOTNOV', 'QAP8', 'RECIPE', 'SC105', 'SC205', 'SC50A', 'SC50B',
-            'SCAGR25', 'SCAGR7', 'SCFXM1', 'SCFXM2', 'SCFXM3', 'SCORPION',
-            'SCRS8', 'SCSD1', 'SCSD6', 'SCSD8', 'SCTAP1', 'SCTAP2', 'SCTAP3',
-            'SHARE1B', 'SHARE2B', 'SHELL', 'SHIP04L', 'SHIP04S', 'SHIP08L',
-            'SHIP08S', 'SHIP12L', 'SHIP12S', 'SIERRA', 'STAIR', 'STANDATA',
-            'STANDMPS', 'STOCFOR1', 'STOCFOR2', 'TRUSS', 'TUFF', 'VTP-BASE',
+            'CAPRI', 'CYCLE', 'CZPROB', 'D2Q06C', 'D6CUBE', 'DEGEN2', 'DEGEN3',
+            'DFL001', 'E226', 'ETAMACRO', 'FFFFF800', 'FINNIS', 'FIT1D',
+            'FIT1P', 'FIT2D', 'FIT2P', 'GANGES', 'GFRD-PNC', 'GREENBEA',
+            'GREENBEB', 'GROW15', 'GROW22', 'GROW7', 'ISRAEL', 'KB2', 'LOTFI',
+            'MAROS', 'MAROS-R7', 'MODSZK1', 'PEROLD', 'PILOT', 'PILOT4',
+            'PILOT87', 'PILOT-JA', 'PILOTNOV', 'PILOT-WE', 'QAP8', 'QAP12',
+            'QAP15', 'RECIPE', 'SC105', 'SC205', 'SC50A', 'SC50B', 'SCAGR25',
+            'SCAGR7', 'SCFXM1', 'SCFXM2', 'SCFXM3', 'SCORPION', 'SCRS8',
+            'SCSD1', 'SCSD6', 'SCSD8', 'SCTAP1', 'SCTAP2', 'SCTAP3', 'SHARE1B',
+            'SHARE2B', 'SHELL', 'SHIP04L', 'SHIP04S', 'SHIP08L', 'SHIP08S',
+            'SHIP12L', 'SHIP12S', 'SIERRA', 'STAIR', 'STANDATA', 'STANDMPS',
+            'STOCFOR1', 'STOCFOR2', 'STOCFOR3', 'TRUSS', 'TUFF', 'VTP-BASE',
             'WOOD1P', 'WOODW']
-presolve_problems = problems
-rr_problems = ['AFIRO', 'BLEND', 'FINNIS', 'RECIPE', 'SCSD6', 'VTP-BASE',
-               'BORE3D', 'CYCLE', 'DEGEN2', 'DEGEN3', 'ETAMACRO', 'PILOTNOV',
-               'QAP8', 'RECIPE', 'SCORPION', 'SHELL', 'SIERRA', 'WOOD1P']
 infeasible_problems = ['bgdbg1', 'bgetam', 'bgindy', 'bgprtr', 'box1',
                        'ceria3d', 'chemcom', 'cplex1', 'cplex2', 'ex72a',
                        'ex73a', 'forest6', 'galenet', 'gosh', 'gran',
@@ -69,17 +42,12 @@ infeasible_problems = ['bgdbg1', 'bgetam', 'bgindy', 'bgprtr', 'box1',
 if not is_xslow():
     enabled_problems = ['ADLITTLE', 'AFIRO', 'BLEND', 'BEACONFD', 'GROW7',
                         'LOTFI', 'SC105', 'SCTAP1', 'SHARE2B', 'STOCFOR1']
-    enabled_presolve_problems = enabled_problems
-    enabled_rr_problems = ['AFIRO', 'BLEND', 'FINNIS', 'RECIPE', 'SCSD6',
-                           'VTP-BASE', 'DEGEN2', 'ETAMACRO', 'RECIPE']
     enabled_infeasible_problems = ['bgdbg1', 'bgprtr', 'box1', 'chemcom',
                                    'cplex2', 'ex72a', 'ex73a', 'forest6',
                                    'galenet', 'itest2', 'itest6', 'klein1',
                                    'refinery', 'woodinfe']
 else:
     enabled_problems = problems
-    enabled_presolve_problems = enabled_problems
-    enabled_rr_problems = rr_problems
     enabled_infeasible_problems = infeasible_problems
 
 
@@ -218,100 +186,6 @@ class Netlib(Benchmark):
         self.abs_error = np.abs(self.fun - self.obj)
         self.rel_error = np.abs((self.fun - self.obj)/self.obj)
         return min(self.abs_error, self.rel_error)
-
-
-class Netlib_RR(Benchmark):
-    params = [
-        rr_methods,
-        rr_problems
-    ]
-    param_names = ['method', 'problems']
-    # sparse routine returns incorrect matrix on BORE3D and PILOTNOV
-    # SVD fails (doesn't converge) on QAP8
-    known_fails = {('_remove_redundancy_svd', 'QAP8'),
-                   ('_remove_redundancy_pivot_sparse', 'BORE3D'),
-                   ('_remove_redundancy_pivot_sparse', 'PILOTNOV')}
-
-    def setup(self, meth, prob):
-        if prob not in enabled_rr_problems:
-            raise NotImplementedError("skipped")
-
-        if (meth.__name__, prob) in self.known_fails:
-            raise NotImplementedError("Known issues with these benchmarks.")
-
-        dir_path = os.path.dirname(os.path.realpath(__file__))
-        datafile = os.path.join(dir_path, "linprog_benchmark_files",
-                                prob + ".npz")
-        data = np.load(datafile, allow_pickle=True)
-
-        c, A_eq, A_ub, b_ub, b_eq = (data["c"], data["A_eq"], data["A_ub"],
-                                     data["b_ub"], data["b_eq"])
-        bounds = np.squeeze(data["bounds"])
-        x0 = np.zeros(c.shape)
-
-        lp = _LPProblem(c, A_ub, b_ub, A_eq, b_eq, bounds, x0)
-        lp_cleaned = _clean_inputs(lp)
-        # rr_method is None here because we're not using RR
-        res = _presolve(lp_cleaned, rr=False, rr_method=None, tol=1e-9)[0]
-
-        self.A_eq, self.b_eq = res.A_eq, res.b_eq
-        self.true_rank = np.linalg.matrix_rank(self.A_eq)
-        if meth == _remove_redundancy_pivot_sparse:
-            self.A_eq = csc_matrix(self.A_eq)
-        self.rr_A = None
-
-    def time_netlib_rr(self, meth, prob):
-        self.rr_A, b, status, message = meth(self.A_eq, self.b_eq)
-
-    def track_netlib_rr(self, meth, prob):
-        if self.rr_A is None:
-            self.time_netlib_rr(meth, prob)
-
-        if meth == _remove_redundancy_pivot_sparse:
-            self.rr_A = self.rr_A.todense()
-
-        rr_rank = np.linalg.matrix_rank(self.rr_A)
-        rr_rows = self.rr_A.shape[0]
-
-        self.error1 = rr_rank - self.true_rank
-        self.error2 = rr_rows - self.true_rank
-
-        if abs(self.error1) > abs(self.error2):
-            return float(self.error1)
-        else:
-            return float(self.error2)
-
-
-class Netlib_presolve(Benchmark):
-    params = [
-        presolve_methods,
-        presolve_problems
-    ]
-    param_names = ['method', 'problems']
-
-    def setup(self, meth, prob):
-        if prob not in enabled_presolve_problems:
-            raise NotImplementedError("skipped")
-
-        dir_path = os.path.dirname(os.path.realpath(__file__))
-        datafile = os.path.join(dir_path, "linprog_benchmark_files",
-                                prob + ".npz")
-        data = np.load(datafile, allow_pickle=True)
-
-        c, A_eq, A_ub, b_ub, b_eq = (data["c"], data["A_eq"], data["A_ub"],
-                                     data["b_ub"], data["b_eq"])
-        bounds = np.squeeze(data["bounds"])
-        x0 = np.zeros(c.shape)
-
-        if meth == "sparse":
-            A_eq = csr_matrix(A_eq)
-            A_ub = csr_matrix(A_ub)
-
-        lp = _LPProblem(c, A_ub, b_ub, A_eq, b_eq, bounds, x0)
-        self.lp_cleaned = _clean_inputs(lp)
-
-    def time_netlib_presolve(self, meth, prob):
-        _presolve(self.lp_cleaned, rr=False, rr_method=None, tol=1e-9)
 
 
 class Netlib_infeasible(Benchmark):


### PR DESCRIPTION
#### Reference issue
gh-13197

#### What does this implement/fix?
Some `linprog` redundancy removal benchmarks are timing out intermittently (e.g. ETAMACRO in gh-13564 [here](https://circleci.com/gh/scipy/scipy/26642?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)). I had already suggested removing the non-HiGHS benchmarks in gh-13197, so it seems like now's a good time to do that. 

In addition to removing the `interior-point` and `revised simplex` methods, I'm removing the presolve and redundancy removal benchmarks, as HiGHS has its own routines for those things. 

Since HiGHS is faster, I'm also adding some of the bigger, slower NETLIB benchmarks.

Next should probably make `'highs'` the default method for `linprog`...