### PR TITLE
DOC: In description of cluster.hierarchy.dendrogram 'level' parameter, changed "p merges from the …

### DIFF
--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -3058,7 +3058,7 @@ def dendrogram(Z, p=30, truncate_mode=None, color_threshold=None,
 
         ``'level'``
           No more than ``p`` levels of the dendrogram tree are displayed.
-          A "level" includes all nodes with ``p`` merges from the last merge.
+          A "level" includes all nodes with ``p`` merges from the final merge.
 
           Note: ``'mtica'`` is an alias for ``'level'`` that's kept for
           backward compatibility.


### PR DESCRIPTION
DOC: In description of 'level' parameter, changed "p merges from the last merge" to "p merges from the final merge"; "last" is ambiguous and could mean "previous" (which is how I read it).

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
N/A

#### What does this implement/fix?
Makes description of cluster.hierarchy.dendrogram 'level' parameter less ambiguous

#### Additional information
<!---->