### PR TITLE
BUG: fix `gaussian_kernel_estimate` on S390X

### DIFF
--- a/scipy/stats/_stats.pyx
+++ b/scipy/stats/_stats.pyx
@@ -566,7 +566,7 @@ def gaussian_kernel_estimate(points, values, xi, precision, dtype, real _=0):
     values_ = values.astype(dtype, copy=False)
 
     # Evaluate the normalisation
-    norm = (2 * PI) ** (- d / 2)
+    norm = math.pow((2 * PI) ,(- d / 2))
     for i in range(d):
         norm *= whitening[i, i]
 


### PR DESCRIPTION

#### Reference issue

https://github.com/scipy/scipy/issues/13512

#### What does this implement/fix?
used `math.pow()` over exponentiation operator to fix unexpected behavior on S390X.

#### Additional information
https://github.com/scipy/scipy/issues/13512#issuecomment-780246692