### PR TITLE
TST: Add pybind11 to tox environments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,7 @@ deps=
     pytest
     numpy
     cython
+    pybind11
 changedir={envdir}
 commands=
     {envpython} {toxinidir}/runtests.py {posargs: --mode full}


### PR DESCRIPTION
This is needed to build scipy now, so tox fails without this listed

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### What does this implement/fix?
<!--Please explain your changes.-->
Tox sets up the environment with the listed dependencies, then attempts to install the package into the environment.  If a build dependency is not listed, this apparently fails (I'm guessing this means tox is doing `python setup.py bdist_wheel && pip install dist/scipy-new.whl` rather than `pip install .`).  This adds `pybind11` to the packages in an environment so that running `tox` actually gets to the running tests part.
