### PR TITLE
BUG: sparse: Create a utility function `getdata`

### DIFF
--- a/scipy/sparse/bsr.py
+++ b/scipy/sparse/bsr.py
@@ -11,8 +11,8 @@ import numpy as np
 from .data import _data_matrix, _minmax_mixin
 from .compressed import _cs_matrix
 from .base import isspmatrix, _formats, spmatrix
-from .sputils import (isshape, getdtype, to_native, upcast, get_index_dtype,
-                      check_shape)
+from .sputils import (isshape, getdtype, getdata, to_native, upcast,
+                      get_index_dtype, check_shape)
 from . import _sparsetools
 from ._sparsetools import (bsr_matvec, bsr_matvecs, csr_matmat_maxnnz,
                            bsr_matmat, bsr_transpose, bsr_sort_indices,
@@ -175,8 +175,7 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
                                             check_contents=True)
                 self.indices = np.array(indices, copy=copy, dtype=idx_dtype)
                 self.indptr = np.array(indptr, copy=copy, dtype=idx_dtype)
-                self.data = np.array(data, copy=copy,
-                                     dtype=getdtype(dtype, data, float))
+                self.data = getdata(data, copy=copy, dtype=dtype)
                 if self.data.ndim != 3:
                     raise ValueError(
                         'BSR data must be 3-dimensional, got shape=%s' % (

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -13,8 +13,8 @@ from ._sparsetools import coo_tocsr, coo_todense, coo_matvec
 from .base import isspmatrix, SparseEfficiencyWarning, spmatrix
 from .data import _data_matrix, _minmax_mixin
 from .sputils import (upcast, upcast_char, to_native, isshape, getdtype,
-                      get_index_dtype, downcast_intp_index, check_shape,
-                      check_reshape_kwargs, matrix)
+                      getdata, get_index_dtype, downcast_intp_index,
+                      check_shape, check_reshape_kwargs, matrix)
 
 import operator
 
@@ -155,10 +155,9 @@ class coo_matrix(_data_matrix, _minmax_mixin):
                     self._shape = check_shape((M, N))
 
                 idx_dtype = get_index_dtype(maxval=max(self.shape))
-                data_dtype = getdtype(dtype, obj, default=float)
                 self.row = np.array(row, copy=copy, dtype=idx_dtype)
                 self.col = np.array(col, copy=copy, dtype=idx_dtype)
-                self.data = np.array(obj, copy=copy, dtype=data_dtype)
+                self.data = getdata(obj, copy=copy, dtype=dtype)
                 self.has_canonical_format = False
         else:
             if isspmatrix(arg1):

--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -7,7 +7,7 @@ import warnings
 import numpy as np
 from scipy._lib._util import prod
 
-__all__ = ['upcast', 'getdtype', 'isscalarlike', 'isintlike',
+__all__ = ['upcast', 'getdtype', 'getdata', 'isscalarlike', 'isintlike',
            'isshape', 'issequence', 'isdense', 'ismatrix', 'get_sum_dtype']
 
 supported_dtypes = [np.bool_, np.byte, np.ubyte, np.short, np.ushort, np.intc,
@@ -114,6 +114,18 @@ def getdtype(dtype, a=None, default=None):
             warnings.warn("object dtype is not supported by sparse matrices")
 
     return newdtype
+
+
+def getdata(obj, dtype=None, copy=False):
+    """
+    This is a wrapper of `np.array(obj, dtype=dtype, copy=copy)`
+    that will generate a warning if the result is an object array.
+    """
+    data = np.array(obj, dtype=dtype, copy=copy)
+    # Defer to getdtype for checking that the dtype is OK.
+    # This is called for the validation only; we don't need the return value.
+    getdtype(data.dtype)
+    return data
 
 
 def get_index_dtype(arrays=(), maxval=None, check_contents=False):

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -4145,6 +4145,11 @@ class TestCOO(sparse_test_class(getset=False,
         with pytest.raises(ValueError, match=r'inconsistent shapes'):
             coo_matrix([0, 11, 22, 33], shape=(4, 4))
 
+    def test_constructor_data_ij_dtypeNone(self):
+        data = [1]
+        coo = coo_matrix((data, ([0], [0])), dtype=None)
+        assert coo.dtype == np.array(data).dtype
+
     @pytest.mark.xfail(run=False, reason='COO does not have a __getitem__')
     def test_iterator(self):
         pass
@@ -4338,6 +4343,14 @@ class TestBSR(sparse_test_class(getset=False,
         with assert_raises(ValueError):
             # mismatching blocksize
             bsr_matrix((data, indices, indptr), blocksize=(1, 1))
+
+    def test_default_dtype(self):
+        # As a numpy array, `values` has shape (2, 2, 1).
+        values = [[[1], [1]], [[1], [1]]]
+        indptr = np.array([0, 2], dtype=np.int32)
+        indices = np.array([0, 1], dtype=np.int32)
+        b = bsr_matrix((values, indices, indptr), blocksize=(2, 1))
+        assert b.dtype == np.array(values).dtype
 
     def test_bsr_tocsr(self):
         # check native conversion from BSR to CSR


### PR DESCRIPTION
Don't use `getdtype` for COO matrices constructed from an input
of the form (data (i, j)).  Just convert data to an array with
`np.array`, and let `np.array` infer the data type in the usual
way if the given dtype is None.

Closes gh-13585.
