### PR TITLE
BUG: stats: preserve sample dtype for bin edges

### DIFF
--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -694,13 +694,16 @@ def _bin_edges(sample, bins=None, range=None):
             smin[i] = smin[i] - .5
             smax[i] = smax[i] + .5
 
+    # Preserve sample floating point precision in bin edges
+    edges_dtype = sample.dtype if np.issubdtype(sample.dtype, np.floating) else float
+
     # Create edge arrays
     for i in builtins.range(Ndim):
         if np.isscalar(bins[i]):
             nbin[i] = bins[i] + 2  # +2 for outlier bins
-            edges[i] = np.linspace(smin[i], smax[i], nbin[i] - 1, dtype=sample.dtype)
+            edges[i] = np.linspace(smin[i], smax[i], nbin[i] - 1, dtype=edges_dtype)
         else:
-            edges[i] = np.asarray(bins[i], sample.dtype)
+            edges[i] = np.asarray(bins[i], edges_dtype)
             nbin[i] = len(edges[i]) + 1  # +1 for outlier bins
         dedges[i] = np.diff(edges[i])
 

--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -698,9 +698,9 @@ def _bin_edges(sample, bins=None, range=None):
     for i in builtins.range(Ndim):
         if np.isscalar(bins[i]):
             nbin[i] = bins[i] + 2  # +2 for outlier bins
-            edges[i] = np.linspace(smin[i], smax[i], nbin[i] - 1)
+            edges[i] = np.linspace(smin[i], smax[i], nbin[i] - 1, dtype=sample.dtype)
         else:
-            edges[i] = np.asarray(bins[i], float)
+            edges[i] = np.asarray(bins[i], sample.dtype)
             nbin[i] = len(edges[i]) + 1  # +1 for outlier bins
         dedges[i] = np.diff(edges[i])
 

--- a/scipy/stats/tests/test_binned_statistic.py
+++ b/scipy/stats/tests/test_binned_statistic.py
@@ -510,3 +510,8 @@ class TestBinnedStatistic(object):
                 match='range given for 1 dimensions; 2 required'):
             binned_statistic_dd([self.x, self.y], self.v,
                                 range=[[0, 1]])
+
+    def test_binned_statistic_float32(self):
+        X = np.array([0, 0.42358226], dtype=np.float32)
+        stat, _, _ = binned_statistic(X, None, 'count', bins=5)
+        assert_allclose(stat, np.array([1, 0, 0, 0, 1], dtype=np.float64))


### PR DESCRIPTION
#### Reference issue
Closes gh-13587.

#### What does this implement/fix?
I ran across a case in which the max value of a single precision sample gets excluded from the right-most bin in `binned_statistic`. I propose maintaining the same `dtype` for the `edges` as in the `sample` by specifying the `dtype` kwarg to the `linspace` or `asarray` calls that create the `edges` array.

#### Additional information
The sample value used in my unit test is the one I discovered empirically.