### PR TITLE
MAINT, BUG: enforce contiguous layout for output array in Rotation.as_euler

### DIFF
--- a/scipy/spatial/transform/rotation.pyx
+++ b/scipy/spatial/transform/rotation.pyx
@@ -176,7 +176,7 @@ cdef double[:, :] _compute_euler_from_matrix(
                 _angles[2] = -atan2(matrix_trans[1, 0] + matrix_trans[0, 1],
                                     matrix_trans[0, 0] - matrix_trans[1, 1])
         else:
-            # For instrinsic, set third angle to zero
+            # For intrinsic, set third angle to zero
             # 6a
             if not safe:
                 _angles[2] = 0
@@ -209,16 +209,16 @@ cdef double[:, :] _compute_euler_from_matrix(
             elif _angles[i] > pi:
                 _angles[i] -= 2 * pi
 
+        if extrinsic:
+            # reversal
+            _angles[0], _angles[2] = _angles[2], _angles[0]
+
         # Step 8
         if not safe:
             warnings.warn("Gimbal lock detected. Setting third angle to zero "
                           "since it is not possible to uniquely determine "
                           "all angles.")
 
-    # Reverse role of extrinsic and intrinsic rotations, but let third angle be
-    # zero for gimbal locked cases. Take a copy, to enforce contiguous memory layout.
-    if extrinsic:
-        angles = angles[:, ::-1].copy()
     return angles
 
 @cython.boundscheck(False)

--- a/scipy/spatial/transform/rotation.pyx
+++ b/scipy/spatial/transform/rotation.pyx
@@ -216,9 +216,9 @@ cdef double[:, :] _compute_euler_from_matrix(
                           "all angles.")
 
     # Reverse role of extrinsic and intrinsic rotations, but let third angle be
-    # zero for gimbal locked cases
+    # zero for gimbal locked cases. Take a copy, to enforce contiguous memory layout.
     if extrinsic:
-        angles = angles[:, ::-1]
+        angles = angles[:, ::-1].copy()
     return angles
 
 @cython.boundscheck(False)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -1262,3 +1262,14 @@ def test_deepcopy():
     r = Rotation.from_quat([0, 0, np.sin(np.pi/4), np.cos(np.pi/4)])
     r1 = copy.deepcopy(r)
     assert_allclose(r.as_matrix(), r1.as_matrix(), atol=1e-15)
+
+
+def test_as_euler_contiguous():
+    r = Rotation.from_quat([0, 0, 0, 1])
+    e1 = r.as_euler('xyz')  # extrinsic euler rotation
+    e2 = r.as_euler('XYZ')  # intrinsic
+    assert e1.flags['C_CONTIGUOUS'] is True
+    assert e2.flags['C_CONTIGUOUS'] is True
+    assert all(i >= 0 for i in e1.strides)
+    assert all(i >= 0 for i in e2.strides)
+

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -191,7 +191,7 @@ def test_matrix_calculation_pipeline():
 
 def test_from_matrix_ortho_output():
     rnd = np.random.RandomState(0)
-    mat = rnd.random((100, 3, 3))
+    mat = rnd.random_sample((100, 3, 3))
     ortho_mat = Rotation.from_matrix(mat).as_matrix()
 
     mult_result = np.einsum('...ij,...jk->...ik', ortho_mat,

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -190,8 +190,8 @@ def test_matrix_calculation_pipeline():
 
 
 def test_from_matrix_ortho_output():
-    np.random.seed(0)
-    mat = np.random.random((100, 3, 3))
+    rnd = np.random.RandomState(0)
+    mat = rnd.random((100, 3, 3))
     ortho_mat = Rotation.from_matrix(mat).as_matrix()
 
     mult_result = np.einsum('...ij,...jk->...ik', ortho_mat,
@@ -424,8 +424,8 @@ def test_single_intrinsic_extrinsic_rotation():
 
 def test_from_euler_rotation_order():
     # Intrinsic rotation is same as extrinsic with order reversed
-    np.random.seed(0)
-    a = np.random.randint(low=0, high=180, size=(6, 3))
+    rnd = np.random.RandomState(0)
+    a = rnd.randint(low=0, high=180, size=(6, 3))
     b = a[:, ::-1]
     x = Rotation.from_euler('xyz', a, degrees=True).as_quat()
     y = Rotation.from_euler('ZYX', b, degrees=True).as_quat()
@@ -552,12 +552,12 @@ def test_from_euler_extrinsic_rotation_313():
 
 
 def test_as_euler_asymmetric_axes():
-    np.random.seed(0)
+    rnd = np.random.RandomState(0)
     n = 10
     angles = np.empty((n, 3))
-    angles[:, 0] = np.random.uniform(low=-np.pi, high=np.pi, size=(n,))
-    angles[:, 1] = np.random.uniform(low=-np.pi / 2, high=np.pi / 2, size=(n,))
-    angles[:, 2] = np.random.uniform(low=-np.pi, high=np.pi, size=(n,))
+    angles[:, 0] = rnd.uniform(low=-np.pi, high=np.pi, size=(n,))
+    angles[:, 1] = rnd.uniform(low=-np.pi / 2, high=np.pi / 2, size=(n,))
+    angles[:, 2] = rnd.uniform(low=-np.pi, high=np.pi, size=(n,))
 
     for seq_tuple in permutations('xyz'):
         # Extrinsic rotations
@@ -569,12 +569,12 @@ def test_as_euler_asymmetric_axes():
 
 
 def test_as_euler_symmetric_axes():
-    np.random.seed(0)
+    rnd = np.random.RandomState(0)
     n = 10
     angles = np.empty((n, 3))
-    angles[:, 0] = np.random.uniform(low=-np.pi, high=np.pi, size=(n,))
-    angles[:, 1] = np.random.uniform(low=0, high=np.pi, size=(n,))
-    angles[:, 2] = np.random.uniform(low=-np.pi, high=np.pi, size=(n,))
+    angles[:, 0] = rnd.uniform(low=-np.pi, high=np.pi, size=(n,))
+    angles[:, 1] = rnd.uniform(low=0, high=np.pi, size=(n,))
+    angles[:, 2] = rnd.uniform(low=-np.pi, high=np.pi, size=(n,))
 
     for axis1 in ['x', 'y', 'z']:
         for axis2 in ['x', 'y', 'z']:
@@ -669,9 +669,9 @@ def test_as_euler_degenerate_symmetric_axes():
 
 
 def test_inv():
-    np.random.seed(0)
+    rnd = np.random.RandomState(0)
     n = 10
-    p = Rotation.from_quat(np.random.normal(size=(n, 4)))
+    p = Rotation.from_quat(rnd.normal(size=(n, 4)))
     q = p.inv()
 
     p_mat = p.as_matrix()
@@ -687,8 +687,8 @@ def test_inv():
 
 
 def test_inv_single_rotation():
-    np.random.seed(0)
-    p = Rotation.from_quat(np.random.normal(size=(4,)))
+    rnd = np.random.RandomState(0)
+    p = Rotation.from_quat(rnd.normal(size=(4,)))
     q = p.inv()
 
     p_mat = p.as_matrix()
@@ -982,8 +982,8 @@ def test_align_vectors_no_rotation():
 
 
 def test_align_vectors_no_noise():
-    np.random.seed(0)
-    c = Rotation.from_quat(np.random.normal(size=4))
+    rnd = np.random.RandomState(0)
+    c = Rotation.from_quat(rnd.normal(size=4))
     b = np.random.normal(size=(5, 3))
     a = c.apply(b)
 
@@ -1019,13 +1019,13 @@ def test_align_vectors_scaled_weights():
 
 
 def test_align_vectors_noise():
-    np.random.seed(0)
+    rnd = np.random.RandomState(0)
     n_vectors = 100
-    rot = Rotation.from_euler('xyz', np.random.normal(size=3))
+    rot = Rotation.from_euler('xyz', rnd.normal(size=3))
     vectors = np.random.normal(size=(n_vectors, 3))
     result = rot.apply(vectors)
 
-    # The paper adds noise as indepedently distributed angular errors
+    # The paper adds noise as independently distributed angular errors
     sigma = np.deg2rad(1)
     tolerance = 1.5 * sigma
     noise = Rotation.from_rotvec(
@@ -1092,9 +1092,9 @@ def test_random_rotation_shape():
 
 
 def test_slerp():
-    np.random.seed(0)
+    rnd = np.random.RandomState(0)
 
-    key_rots = Rotation.from_quat(np.random.uniform(size=(5, 4)))
+    key_rots = Rotation.from_quat(rnd.uniform(size=(5, 4)))
     key_quats = key_rots.as_quat()
 
     key_times = [0, 1, 2, 3, 4]
@@ -1144,8 +1144,8 @@ def test_slerp_single_rot():
 def test_slerp_time_dim_mismatch():
     with pytest.raises(ValueError,
                        match="times to be specified in a 1 dimensional array"):
-        np.random.seed(0)
-        r = Rotation.from_quat(np.random.uniform(size=(2, 4)))
+        rnd = np.random.RandomState(0)
+        r = Rotation.from_quat(rnd.uniform(size=(2, 4)))
         t = np.array([[1],
                       [2]])
         Slerp(t, r)
@@ -1154,31 +1154,31 @@ def test_slerp_time_dim_mismatch():
 def test_slerp_num_rotations_mismatch():
     with pytest.raises(ValueError, match="number of rotations to be equal to "
                                          "number of timestamps"):
-        np.random.seed(0)
-        r = Rotation.from_quat(np.random.uniform(size=(5, 4)))
+        rnd = np.random.RandomState(0)
+        r = Rotation.from_quat(rnd.uniform(size=(5, 4)))
         t = np.arange(7)
         Slerp(t, r)
 
 
 def test_slerp_equal_times():
     with pytest.raises(ValueError, match="strictly increasing order"):
-        np.random.seed(0)
-        r = Rotation.from_quat(np.random.uniform(size=(5, 4)))
+        rnd = np.random.RandomState(0)
+        r = Rotation.from_quat(rnd.uniform(size=(5, 4)))
         t = [0, 1, 2, 2, 4]
         Slerp(t, r)
 
 
 def test_slerp_decreasing_times():
     with pytest.raises(ValueError, match="strictly increasing order"):
-        np.random.seed(0)
-        r = Rotation.from_quat(np.random.uniform(size=(5, 4)))
+        rnd = np.random.RandomState(0)
+        r = Rotation.from_quat(rnd.uniform(size=(5, 4)))
         t = [0, 1, 3, 2, 4]
         Slerp(t, r)
 
 
 def test_slerp_call_time_dim_mismatch():
-    np.random.seed(0)
-    r = Rotation.from_quat(np.random.uniform(size=(5, 4)))
+    rnd = np.random.RandomState(0)
+    r = Rotation.from_quat(rnd.uniform(size=(5, 4)))
     t = np.arange(5)
     s = Slerp(t, r)
 
@@ -1190,8 +1190,8 @@ def test_slerp_call_time_dim_mismatch():
 
 
 def test_slerp_call_time_out_of_range():
-    np.random.seed(0)
-    r = Rotation.from_quat(np.random.uniform(size=(5, 4)))
+    rnd = np.random.RandomState(0)
+    r = Rotation.from_quat(rnd.uniform(size=(5, 4)))
     t = np.arange(5) + 1
     s = Slerp(t, r)
 


### PR DESCRIPTION
The output array (or memoryview) used to have a negative stride, which may cause problems later on when trying to
wrap it in an ndarray again.

Fixes #13584

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
closes gh-13584

#### What does this implement/fix?
This enforces contiguous layout for output angle (extrinsic). Prior this change the output was not contiguous (e.g. negative stride of -8), which causes problems downstream.