### PR TITLE
Add dpss for get_window function

### DIFF
--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -617,6 +617,11 @@ class TestGetWindow(object):
             w = windows.get_window(('chebwin', 40), 54, fftbins=False)
         assert_array_almost_equal(w, cheb_even_true, decimal=4)
 
+    def test_dpss(self):
+        win1 = windows.get_window(('dpss', 3), 64)
+        win2 = windows.dpss(64, 3)
+        assert_array_almost_equal(win1, win2, decimal=4)
+
     def test_kaiser_float(self):
         win1 = windows.get_window(7.2, 64)
         win2 = windows.kaiser(64, 7.2, False)

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -618,7 +618,7 @@ class TestGetWindow(object):
         assert_array_almost_equal(w, cheb_even_true, decimal=4)
 
     def test_dpss(self):
-        win1 = windows.get_window(('dpss', 3), 64)
+        win1 = windows.get_window(('dpss', 3), 64, fftbins=False)
         win2 = windows.dpss(64, 3)
         assert_array_almost_equal(win1, win2, decimal=4)
 

--- a/scipy/signal/windows/windows.py
+++ b/scipy/signal/windows/windows.py
@@ -2017,6 +2017,7 @@ _win_equiv_raw = {
         'rect', 'rectangular'): (boxcar, False),
     ('chebwin', 'cheb'): (chebwin, True),
     ('cosine', 'halfcosine'): (cosine, False),
+    ('dpss',): (dpss, True),
     ('exponential', 'poisson'): (exponential, True),
     ('flattop', 'flat', 'flt'): (flattop, False),
     ('gaussian', 'gauss', 'gss'): (gaussian, True),
@@ -2030,7 +2031,6 @@ _win_equiv_raw = {
     ('taylor', 'taylorwin'): (taylor, False),
     ('triangle', 'triang', 'tri'): (triang, False),
     ('tukey', 'tuk'): (tukey, True),
-    ('dpss'): (dpss, True),
 }
 
 # Fill dict with all valid window name strings

--- a/scipy/signal/windows/windows.py
+++ b/scipy/signal/windows/windows.py
@@ -2146,7 +2146,10 @@ def get_window(window, Nx, fftbins=True):
         except KeyError as e:
             raise ValueError("Unknown window type.") from e
 
-        params = (Nx,) + args + (sym,)
+        if winfunc is dpss:
+            params = (Nx,) + args + (None, sym)
+        else:
+            params = (Nx,) + args + (sym,)
     else:
         winfunc = kaiser
         params = (Nx, beta, sym)

--- a/scipy/signal/windows/windows.py
+++ b/scipy/signal/windows/windows.py
@@ -2030,6 +2030,7 @@ _win_equiv_raw = {
     ('taylor', 'taylorwin'): (taylor, False),
     ('triangle', 'triang', 'tri'): (triang, False),
     ('tukey', 'tuk'): (tukey, True),
+    ('dpss'): (dpss, True),
 }
 
 # Fill dict with all valid window name strings

--- a/scipy/signal/windows/windows.py
+++ b/scipy/signal/windows/windows.py
@@ -2017,7 +2017,7 @@ _win_equiv_raw = {
         'rect', 'rectangular'): (boxcar, False),
     ('chebwin', 'cheb'): (chebwin, True),
     ('cosine', 'halfcosine'): (cosine, False),
-    ('dpss',): (dpss, True),
+    ('dpss', 'slepian'): (dpss, True),
     ('exponential', 'poisson'): (exponential, True),
     ('flattop', 'flat', 'flt'): (flattop, False),
     ('gaussian', 'gauss', 'gss'): (gaussian, True),

--- a/scipy/signal/windows/windows.py
+++ b/scipy/signal/windows/windows.py
@@ -2017,7 +2017,7 @@ _win_equiv_raw = {
         'rect', 'rectangular'): (boxcar, False),
     ('chebwin', 'cheb'): (chebwin, True),
     ('cosine', 'halfcosine'): (cosine, False),
-    ('dpss', 'slepian'): (dpss, True),
+    ('dpss',): (dpss, True),
     ('exponential', 'poisson'): (exponential, True),
     ('flattop', 'flat', 'flt'): (flattop, False),
     ('gaussian', 'gauss', 'gss'): (gaussian, True),


### PR DESCRIPTION
In the [documentation](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.get_window.html) of `scipy.signal.get_window`  there has dpss window, but not implemented in the code of `get_window` function. This change may add dpss window into get_window.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
No reference issue.

#### What does this implement/fix?
<!--Please explain your changes.-->
This change may add dpss window into get_window.

#### Additional information
<!--Any additional information you think is important.-->