### PR TITLE
DOC: Correct dual annealing visiting param range.

### DIFF
--- a/scipy/optimize/_dual_annealing.py
+++ b/scipy/optimize/_dual_annealing.py
@@ -36,7 +36,7 @@ class VisitingDistribution(object):
         Parameter for visiting distribution. Default value is 2.62.
         Higher values give the visiting distribution a heavier tail, this
         makes the algorithm jump to a more distant region.
-        The value range is (0, 3]. It's value is fixed for the life of the
+        The value range is (1, 3]. It's value is fixed for the life of the
         object.
     rand_gen : {`~numpy.random.RandomState`, `~numpy.random.Generator`}
         A `~numpy.random.RandomState`, `~numpy.random.Generator` object
@@ -464,7 +464,7 @@ def dual_annealing(func, bounds, args=(), maxiter=1000,
     visit : float, optional
         Parameter for visiting distribution. Default value is 2.62. Higher
         values give the visiting distribution a heavier tail, this makes
-        the algorithm jump to a more distant region. The value range is (0, 3].
+        the algorithm jump to a more distant region. The value range is (1, 3].
     accept : float, optional
         Parameter for acceptance distribution. It is used to control the
         probability of acceptance. The lower the acceptance parameter, the


### PR DESCRIPTION
Dual annealing's visiting parameter cannot be less than 1, lest one
encounters domain errors in constructing VisitingDistribution.

#### Reference issue
Addresses #11781, which is premised on incorrect docs. Does not address #12384, which deserves some investigation into the actual numerical details of this implementation and the distribution it aims to sample.

#### What does this implement/fix?
This corrects documentation, which incorrectly implies that visiting parameters between 0 and 1 are valid.

#### Additional information
Numerical divergence in this logarithm when `self._visiting_param` is less or equal to 1: https://github.com/scipy/scipy/blob/master/scipy/optimize/_dual_annealing.py#L61