### PR TITLE
MAINT: stats: fix crystalball entropy

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -34,6 +34,7 @@ def _lazywhere(cond, arrays, f, fillvalue=None, f2=None):
     broadcasted together.
 
     """
+    cond = np.asarray(cond)
     if fillvalue is None:
         if f2 is None:
             raise ValueError("One of (fillvalue, f2) must be given.")

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -8579,7 +8579,7 @@ class crystalball_gen(rv_continuous):
                             N A (B - x)^{-m}  &\text{for } x \le -\beta
                           \end{cases}
 
-    where :math:`A = (m / |\beta|)^n  \exp(-\beta^2 / 2)`,
+    where :math:`A = (m / |\beta|)^m  \exp(-\beta^2 / 2)`,
     :math:`B = m/|\beta| - |\beta|` and :math:`N` is a normalisation constant.
 
     `crystalball` takes :math:`\beta > 0` and :math:`m > 1` as shape

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -25,7 +25,7 @@ import scipy.stats as stats
 from scipy.stats._distn_infrastructure import argsreduce
 import scipy.stats.distributions
 
-from scipy.special import xlogy, polygamma
+from scipy.special import xlogy, polygamma, entr
 from .test_continuous_basic import distcont, invdistcont
 from .test_discrete_basic import distdiscrete, invdistdiscrete
 from scipy.stats._continuous_distns import FitDataError
@@ -5141,6 +5141,16 @@ def test_crystalball_function_moments():
     expected_5th_moment = a / norm
     calculated_5th_moment = stats.crystalball._munp(5, beta, m)
     assert_allclose(expected_5th_moment, calculated_5th_moment, rtol=0.001)
+
+
+def test_crystalball_entropy():
+    cb = stats.crystalball(2, 3)
+    res1 = cb.entropy()
+    res2 = quad(lambda x: entr(cb.pdf(x)), -np.inf, np.inf)[0]
+    N, lo, hi = 10000, -100, 20
+    res3 = entr(cb.pdf(np.linspace(lo, hi, N))).sum()*(hi-lo)/N
+    assert_allclose(res1, res2)
+    assert_allclose(res1, res3, rtol=1e-3)
 
 
 @pytest.mark.parametrize(

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -20,7 +20,7 @@ from numpy import typecodes, array
 from numpy.lib.recfunctions import rec_append_fields
 from scipy import special
 from scipy._lib._util import check_random_state
-from scipy.integrate import IntegrationWarning, quad
+from scipy.integrate import IntegrationWarning, quad, trapezoid
 import scipy.stats as stats
 from scipy.stats._distn_infrastructure import argsreduce
 import scipy.stats.distributions
@@ -5144,13 +5144,14 @@ def test_crystalball_function_moments():
 
 
 def test_crystalball_entropy():
+    # regression test for gh-13602
     cb = stats.crystalball(2, 3)
     res1 = cb.entropy()
-    res2 = quad(lambda x: entr(cb.pdf(x)), -np.inf, np.inf)[0]
-    N, lo, hi = 10000, -100, 20
-    res3 = entr(cb.pdf(np.linspace(lo, hi, N))).sum()*(hi-lo)/N
-    assert_allclose(res1, res2)
-    assert_allclose(res1, res3, rtol=1e-3)
+    # -20000 and 30 are negative and positive infinity, respectively
+    lo, hi, N = -20000, 30, 200000
+    x = np.linspace(lo, hi, N)
+    res2 = trapezoid(entr(cb.pdf(x)), x)
+    assert_allclose(res1, res2, rtol=1e-7)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
#### Reference issue
Closes gh-13602
gh-13370

#### What does this implement/fix?
`_lazywhere` in master does not handle scalar inputs properly, causing problems in `stats.crystalball.entropy`. 
This PR implements @WarrenWeckesser's [suggested fix](https://github.com/scipy/scipy/pull/13370#pullrequestreview-564665361) and adds a test. 