### PR TITLE
Add docker run command for Windows cmd

### DIFF
--- a/doc/source/dev/contributor/quickstart_docker.rst
+++ b/doc/source/dev/contributor/quickstart_docker.rst
@@ -91,6 +91,10 @@ container do not persist after you close it.
    window::
 
       docker run -it --rm -v $PWD/:/home/scipy scipy/scipy-dev:<image-tag> /bin/bash
+   
+   If you are using Windows cmd, you may run the following command instead::
+
+      docker run -it --rm -v %cd%:/home/scipy scipy/scipy-dev:<image-tag> /bin/bash
 
    This command starts (``run``) an interactive (``-it``) Docker container
    named ``scipy-dev`` (based on Ubuntu focal) from the ``scipy``


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
N/A

#### What does this implement/fix?
<!--Please explain your changes.-->
The previous docker run command does not work in Windows cmd. A new instruction is added for it.

#### Additional information
<!--Any additional information you think is important.-->
In Windows cmd, `$PWD` isn't translated as the current working directory. So use `%cd%` instead.