### PR TITLE
FIX: Return correct output for invgauss.cdf when mu is very small

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -3504,8 +3504,16 @@ class invgauss_gen(rv_continuous):
     def _cdf(self, x, mu):
         fac = np.sqrt(1.0/x)
         # Numerical accuracy for small `mu` is bad.  See #869.
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", message="overflow encountered in exp",
+                category=RuntimeWarning
+            )
+            e = np.exp(1.0 / mu)
+            e[np.argwhere(~np.isfinite(e))] = np.finfo(np.double).max
+
         C1 = _norm_cdf(fac*(x-mu)/mu)
-        C1 += np.exp(1.0/mu) * _norm_cdf(-fac*(x+mu)/mu) * np.exp(1.0/mu)
+        C1 += e * _norm_cdf(-fac*(x+mu)/mu) * e
         return C1
 
     def _stats(self, mu):

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -3497,15 +3497,19 @@ class invgauss_gen(rv_continuous):
     def _logpdf(self, x, mu):
         return -0.5*np.log(2*np.pi) - 1.5*np.log(x) - ((x-mu)/mu)**2/(2*x)
 
+    # approach adapted from equations in
+    # https://journal.r-project.org/archive/2016-1/giner-smyth.pdf,
+    # not R code. see gh-13616
+
     def _logcdf(self, x, mu):
         fac = 1 / np.sqrt(x)
-        a = _norm_logcdf(fac * ((x  / mu) - 1))
+        a = _norm_logcdf(fac * ((x / mu) - 1))
         b = 2 / mu + _norm_logcdf(-fac * ((x / mu) + 1))
         return a + np.log1p(np.exp(b - a))
 
     def _logsf(self, x, mu):
         fac = 1 / np.sqrt(x)
-        a = _norm_logsf(fac * ((x  / mu) - 1))
+        a = _norm_logsf(fac * ((x / mu) - 1))
         b = 2 / mu + _norm_logcdf(-fac * (x + mu) / mu)
         return a + np.log1p(-np.exp(b - a))
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -3513,7 +3513,7 @@ class invgauss_gen(rv_continuous):
             e[np.argwhere(~np.isfinite(e))] = np.finfo(np.double).max
 
         C1 = _norm_cdf(fac*(x-mu)/mu)
-        C1 += e * _norm_cdf(-fac*(x+mu)/mu) * e
+        C1 += np.exp(2.0/mu + _norm_logcdf(-fac*(x+mu)/mu))
         return C1
 
     def _stats(self, mu):

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -3498,14 +3498,14 @@ class invgauss_gen(rv_continuous):
         return -0.5*np.log(2*np.pi) - 1.5*np.log(x) - ((x-mu)/mu)**2/(2*x)
 
     def _logcdf(self, x, mu):
-        fac = np.sqrt(1 / x)
-        a = _norm_logcdf(fac * (x - mu) / mu)
-        b = 2 / mu + _norm_logcdf(-fac * (x + mu) / mu)
+        fac = 1 / np.sqrt(x)
+        a = _norm_logcdf(fac * ((x  / mu) - 1))
+        b = 2 / mu + _norm_logcdf(-fac * ((x / mu) + 1))
         return a + np.log1p(np.exp(b - a))
 
     def _logsf(self, x, mu):
-        fac = np.sqrt(1 / x)
-        a = _norm_logsf(fac * (x - mu) / mu)
+        fac = 1 / np.sqrt(x)
+        a = _norm_logsf(fac * ((x  / mu) - 1))
         b = 2 / mu + _norm_logcdf(-fac * (x + mu) / mu)
         return a + np.log1p(-np.exp(b - a))
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -8355,11 +8355,20 @@ class wald_gen(invgauss_gen):
         # wald.pdf(x) = 1/sqrt(2*pi*x**3) * exp(-(x-1)**2/(2*x))
         return invgauss._pdf(x, 1.0)
 
+    def _cdf(self, x):
+        return invgauss._cdf(x, 1.0)
+
+    def _sf(self, x):
+        return invgauss._sf(x, 1.0)
+
     def _logpdf(self, x):
         return invgauss._logpdf(x, 1.0)
 
-    def _cdf(self, x):
-        return invgauss._cdf(x, 1.0)
+    def _logcdf(self, x):
+        return invgauss._logcdf(x, 1.0)
+
+    def _logsf(self, x):
+        return invgauss._logsf(x, 1.0)
 
     def _stats(self):
         return 1.0, 1.0, 3.0, 15.0

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -3504,14 +3504,6 @@ class invgauss_gen(rv_continuous):
     def _cdf(self, x, mu):
         fac = np.sqrt(1.0/x)
         # Numerical accuracy for small `mu` is bad.  See #869.
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore", message="overflow encountered in exp",
-                category=RuntimeWarning
-            )
-            e = np.exp(1.0 / mu)
-            e[np.argwhere(~np.isfinite(e))] = np.finfo(np.double).max
-
         C1 = _norm_cdf(fac*(x-mu)/mu)
         C1 += np.exp(2.0/mu + _norm_logcdf(-fac*(x+mu)/mu))
         return C1

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1810,6 +1810,14 @@ class TestInvgauss(object):
             stats.invgauss.fit([1, 2, 3], floc=2)
 
     def test_cdf_sf(self):
+        # Regression tests for gh-13614.
+        # Ground truth from R's statmod library (pinvgauss), e.g.
+        # library(statmod)
+        # options(digits=15)
+        # mu = c(4.17022005e-04, 7.20324493e-03, 1.14374817e-06,
+        #        3.02332573e-03, 1.46755891e-03)
+        # print(pinvgauss(5, mu, 1))
+
         # make sure a finite value is returned when mu is very small. see
         # GH-13614
         mu = [4.17022005e-04, 7.20324493e-03, 1.14374817e-06,
@@ -1817,34 +1825,42 @@ class TestInvgauss(object):
         expected = [1, 1, 1, 1, 1]
         actual = stats.invgauss.cdf(0.4, mu=mu)
         assert_equal(expected, actual)
-        # test if the function can distinguish small left/right tail probabilities
-        # from zero.
+
+        # test if the function can distinguish small left/right tail
+        # probabilities from zero.
         cdf_actual = stats.invgauss.cdf(0.001, mu=1.05)
-        assert cdf_actual > 0
+        assert_allclose(cdf_actual, 4.65246506892667e-219)
         sf_actual = stats.invgauss.sf(110, mu=1.05)
-        assert sf_actual > 0
-        # test if x does not cause numrical issues when mu is very small and x
-        # is close to mu in value.
+        assert_allclose(sf_actual, 4.12851625944048e-25)
+
+        # test if x does not cause numerical issues when mu is very small
+        # and x is close to mu in value.
+
         # slightly smaller than mu
         actual = stats.invgauss.cdf(0.00009, 0.0001)
-        assert np.isfinite(actual)
-        assert actual > 0  # no underflow
+        assert_allclose(actual, 2.9458022894924e-26)
+
         # slightly bigger than mu
         actual = stats.invgauss.cdf(0.000102, 0.0001)
-        assert np.isfinite(actual)
-        assert actual > 0.95 and actual < 1.0  # close to 1 but not quite 1.
+        assert_allclose(actual, 0.976445540507925)
 
     def test_logcdf_logsf(self):
-        # test if logcdf and logsf can be compute reliably values too small to
+        # Regression tests for improvements made in gh-13616.
+        # Ground truth from R's statmod library (pinvgauss), e.g.
+        # library(statmod)
+        # options(digits=15)
+        # print(pinvgauss(0.001, 1.05, 1, log.p=TRUE, lower.tail=FALSE))
+
+        # test if logcdf and logsf can compute values too small to
         # be represented on the unlogged scale. See: gh-13616
         logcdf = stats.invgauss.logcdf(0.0001, mu=1.05)
-        assert np.isfinite(logcdf)
+        assert_allclose(logcdf, -5003.87872590367)
         logcdf = stats.invgauss.logcdf(110, 1.05)
-        assert logcdf < 0
+        assert_allclose(logcdf, -4.12851625944087e-25)
         logsf = stats.invgauss.logsf(0.001, mu=1.05)
-        assert logsf < 0
-        logsf = stats.invgauss.logcdf(110, 1.05)
-        assert np.isfinite(logsf)
+        assert_allclose(logsf, -4.65246506892676e-219)
+        logsf = stats.invgauss.logsf(110, 1.05)
+        assert_allclose(logsf, -56.1467092416426)
 
 
 class TestLaplace(object):


### PR DESCRIPTION


#### Reference issue
closes #13614

#### What does this implement/fix?
This PR returns the correct values for `invgauss.cdf` when `mu` is very small. Previously a `NaN` was returned. See #13614

#### Additional information
n/a