### PR TITLE
CI: enable Mypy CI job again

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -75,6 +75,11 @@ jobs:
     - name: Install packages
       run: |
         python3.9 -m pip install --user numpy setuptools wheel cython pytest pytest-xdist pybind11 pytest-xdist pythran
+        python3.9 -m pip install -r mypy_requirements.txt
+
+    - name: Mypy
+      run: |
+        python3.9 -u runtests.py --mypy
 
     - name: Test SciPy
       run: |


### PR DESCRIPTION
Reverts scipy/scipy#13620

Re-enables Mypy in one CI job. 

Thanks to @tirthasheshpatel for finding the root cause and verifying this CI step works (see https://github.com/scipy/scipy/pull/13448#discussion_r584267690).