### PR TITLE
TST: test more values for `visiting_param` input to `dual_annealing`

### DIFF
--- a/scipy/optimize/tests/test__dual_annealing.py
+++ b/scipy/optimize/tests/test__dual_annealing.py
@@ -60,12 +60,15 @@ class TestDualAnnealing:
         self.ngev += 1
         return rosen_der(x, *args)
 
-    def test_visiting_stepping(self):
+    # FIXME: there are some discontinuities in behaviour as a function of `qv`,
+    #        this needs investigating - see gh-12384
+    @pytest.mark.parametrize('qv', [1.1, 1.41, 2, 2.62, 2.9])
+    def test_visiting_stepping(self, qv):
         lu = list(zip(*self.ld_bounds))
         lower = np.array(lu[0])
         upper = np.array(lu[1])
         dim = lower.size
-        vd = VisitingDistribution(lower, upper, self.qv, self.rs)
+        vd = VisitingDistribution(lower, upper, qv, self.rs)
         values = np.zeros(dim)
         x_step_low = vd.visiting(values, 0, self.high_temperature)
         # Make sure that only the first component is changed
@@ -75,11 +78,12 @@ class TestDualAnnealing:
         # Make sure that component other than at dim has changed
         assert_equal(np.not_equal(x_step_high[0], 0), True)
 
-    def test_visiting_dist_high_temperature(self):
+    @pytest.mark.parametrize('qv', [2.25, 2.62, 2.9])
+    def test_visiting_dist_high_temperature(self, qv):
         lu = list(zip(*self.ld_bounds))
         lower = np.array(lu[0])
         upper = np.array(lu[1])
-        vd = VisitingDistribution(lower, upper, self.qv, self.rs)
+        vd = VisitingDistribution(lower, upper, qv, self.rs)
         # values = np.zeros(self.nbtestvalues)
         # for i in np.arange(self.nbtestvalues):
         #     values[i] = vd.visit_fn(self.high_temperature)


### PR DESCRIPTION
xref gh-12384

Doesn't fix the issue, but at least verifies that the documented input range is now correct and points to the issue for further investigation.
