### PR TITLE
Rename integrate.simps to integrate.simpsons in documentation examples

### DIFF
--- a/doc/source/tutorial/examples/4-1
+++ b/doc/source/tutorial/examples/4-1
@@ -12,7 +12,7 @@
 
    trapezoid            -- Use trapezoidal rule to compute integral.
    cumulative_trapezoid -- Use trapezoidal rule to cumulatively compute integral.
-   simps                -- Use Simpson's rule to compute integral from samples.
+   simpson              -- Use Simpson's rule to compute integral from samples.
    romb                 -- Use Romberg Integration to compute integral from
                         -- (2**k + 1) evenly-spaced samples.
 

--- a/doc/source/tutorial/integrate.rst
+++ b/doc/source/tutorial/integrate.rst
@@ -285,8 +285,8 @@ of order 2 or less.
 ...
 >>> x = np.array([1,3,4])
 >>> y1 = f1(x)
->>> from scipy.integrate import simps
->>> I1 = simps(y1, x)
+>>> from scipy import integrate
+>>> I1 = integrate.simpson(y1, x)
 >>> print(I1)
 21.0
 
@@ -300,7 +300,7 @@ This corresponds exactly to
 whereas integrating the second function
 
 >>> y2 = f2(x)
->>> I2 = integrate.simps(y2, x)
+>>> I2 = integrate.simpson(y2, x)
 >>> print(I2)
 61.5
 


### PR DESCRIPTION
#### Reference issue
Small leftover from https://github.com/scipy/scipy/issues/12924

#### What does this implement/fix?
After https://github.com/scipy/scipy/pull/12927 , there is an inconsistency in the [integration using samples](https://docs.scipy.org/doc/scipy/reference/tutorial/integrate.html#integrating-using-samples) documentation examples using `simps` and the documentation for `integrate` which doesn't mention the alias


