### PR TITLE
BUG: stats.binned_statistic_2d user function expecting arrays

### DIFF
--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -645,7 +645,7 @@ def _calc_binned_statistic(Vdim, bin_numbers, result, values, stat_func,
             # if the stat_func is np.std, calc std only when binned data is 2
             # or more for speed up.
             if is_callable or not (stat_func is np.std and len(bin_map[i]) < 2):
-                result[vv, i] = stat_func(bin_map[i])
+                result[vv, i] = stat_func(np.array(bin_map[i]))
 
 
 def _create_binned_data(bin_numbers, unique_bin_numbers, values, vv):


### PR DESCRIPTION
The documentation states:

> function : a user-defined function which takes a 1D array of values, and outputs a single numerical statistic. This function will be called on the values in each bin. Empty bins will be represented by function([]), or NaN if this returns an error.

As shown in gh-13608, users can expect in their functions a numpy array.

I propose to not change the doc and just give a numpy array to the function.

Closes gh-13608