### PR TITLE
MAINT: mypy: don't install numpy-stubs

### DIFF
--- a/mypy_requirements.txt
+++ b/mypy_requirements.txt
@@ -1,3 +1,2 @@
 mypy
 typing_extensions
-git+git://github.com/numpy/numpy-stubs.git@master


### PR DESCRIPTION
#### Reference issue

na

#### What does this implement/fix?

`numpy-stubs` has been archived a while ago and so it doesn't contain more recent type hints. e.g. `np.typing.DTypeLike`. Moreover, `numpy >= 1.20.0` ships with all the stubs so we don't need to install them separately again.

#### Additional information
na