### PR TITLE
BUG: sparse: csc_matrix.argmax() integer overflow

### DIFF
--- a/scipy/sparse/data.py
+++ b/scipy/sparse/data.py
@@ -271,7 +271,9 @@ class _minmax_mixin(object):
                 m = mat.data[am]
 
                 if compare(m, zero):
-                    return mat.row[am] * mat.shape[1] + mat.col[am]
+                    # cast at least 1 to Python int to avoid overflow
+                    # and RuntimeError
+                    return int(mat.row[am]) * mat.shape[1] + mat.col[am]
                 else:
                     size = np.prod(mat.shape)
                     if size == mat.nnz:

--- a/scipy/sparse/data.py
+++ b/scipy/sparse/data.py
@@ -271,9 +271,9 @@ class _minmax_mixin(object):
                 m = mat.data[am]
 
                 if compare(m, zero):
-                    # cast at least 1 to Python int to avoid overflow
+                    # cast to Python int to avoid overflow
                     # and RuntimeError
-                    return int(mat.row[am]) * mat.shape[1] + mat.col[am]
+                    return int(mat.row[am])*mat.shape[1] + int(mat.col[am])
                 else:
                     size = np.prod(mat.shape)
                     if size == mat.nnz:

--- a/scipy/sparse/tests/test_csc.py
+++ b/scipy/sparse/tests/test_csc.py
@@ -1,6 +1,6 @@
 import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_
-from scipy.sparse import csr_matrix, csc_matrix
+from scipy.sparse import csr_matrix, csc_matrix, lil_matrix
 
 import pytest
 
@@ -69,3 +69,15 @@ def test_csc_empty_slices(matrix_input, axis, expected_shape):
 
     assert actual_shape_1 == expected_shape
     assert actual_shape_1 == actual_shape_2
+
+
+def test_argmax_overflow():
+    '''
+    See gh-13646: Windows integer overflow for large sparse matrices.
+    '''
+    dim = (100000, 100000)
+    A = lil_matrix(dim)
+    A[-2, -2] = 42
+    A = csc_matrix(A)
+    idx = np.unravel_index(A.argmax(), dim)
+    assert A[idx] == A[-2, -2]


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

- closes gh-13646 

#### What does this implement/fix?
<!--Please explain your changes.-->

- explicitly casts integer as Python `int` type to catch any potential overflows for large sparse matrices

#### Additional information
<!--Any additional information you think is important.-->