### PR TITLE
DOC: fix eigvalsh documentation (#13651)

### DIFF
--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -909,9 +909,38 @@ def eigvalsh(a, b=None, lower=True, overwrite_a=False,
     lower : bool, optional
         Whether the pertinent array data is taken from the lower or upper
         triangle of ``a`` and, if applicable, ``b``. (Default: lower)
-    eigvals_only : bool, optional
-        Whether to calculate only eigenvalues and no eigenvectors.
-        (Default: both are calculated)
+    overwrite_a : bool, optional
+        Whether to overwrite data in ``a`` (may improve performance). Default
+        is False.
+    overwrite_b : bool, optional
+        Whether to overwrite data in ``b`` (may improve performance). Default
+        is False.
+    turbo : bool, optional
+        *Deprecated by ``driver=gvd`` option*. Has no significant effect for
+        eigenvalue computations since no eigenvectors are requested.
+
+        ..Deprecated in v1.5.0
+    eigvals : tuple (lo, hi), optional
+        *Deprecated by ``subset_by_index`` keyword*. Indexes of the smallest
+        and largest (in ascending order) eigenvalues and corresponding
+        eigenvectors to be returned: 0 <= lo <= hi <= M-1. If omitted, all
+        eigenvalues and eigenvectors are returned.
+
+        .. Deprecated in v1.5.0
+    type : int, optional
+        For the generalized problems, this keyword specifies the problem type
+        to be solved for ``w`` and ``v`` (only takes 1, 2, 3 as possible
+        inputs)::
+
+            1 =>     a @ v = w @ b @ v
+            2 => a @ b @ v = w @ v
+            3 => b @ a @ v = w @ v
+
+        This keyword is ignored for standard problems.
+    check_finite : bool, optional
+        Whether to check that the input matrices contain only finite numbers.
+        Disabling may give a performance gain, but may result in problems
+        (crashes, non-termination) if the inputs do contain infinities or NaNs.
     subset_by_index : iterable, optional
         If provided, this two-element iterable defines the start and the end
         indices of the desired eigenvalues (ascending order and 0-indexed).
@@ -929,38 +958,6 @@ def eigvalsh(a, b=None, lower=True, overwrite_a=False,
         "evd", "evr", "evx" for standard problems and "gv", "gvd", "gvx" for
         generalized (where b is not None) problems. See the Notes section of
         `scipy.linalg.eigh`.
-    type : int, optional
-        For the generalized problems, this keyword specifies the problem type
-        to be solved for ``w`` and ``v`` (only takes 1, 2, 3 as possible
-        inputs)::
-
-            1 =>     a @ v = w @ b @ v
-            2 => a @ b @ v = w @ v
-            3 => b @ a @ v = w @ v
-
-        This keyword is ignored for standard problems.
-    overwrite_a : bool, optional
-        Whether to overwrite data in ``a`` (may improve performance). Default
-        is False.
-    overwrite_b : bool, optional
-        Whether to overwrite data in ``b`` (may improve performance). Default
-        is False.
-    check_finite : bool, optional
-        Whether to check that the input matrices contain only finite numbers.
-        Disabling may give a performance gain, but may result in problems
-        (crashes, non-termination) if the inputs do contain infinities or NaNs.
-    turbo : bool, optional
-        *Deprecated by ``driver=gvd`` option*. Has no significant effect for
-        eigenvalue computations since no eigenvectors are requested.
-
-        ..Deprecated in v1.5.0
-    eigvals : tuple (lo, hi), optional
-        *Deprecated by ``subset_by_index`` keyword*. Indexes of the smallest
-        and largest (in ascending order) eigenvalues and corresponding
-        eigenvectors to be returned: 0 <= lo <= hi <= M-1. If omitted, all
-        eigenvalues and eigenvectors are returned.
-
-        .. Deprecated in v1.5.0
 
     Returns
     -------

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -915,18 +915,6 @@ def eigvalsh(a, b=None, lower=True, overwrite_a=False,
     overwrite_b : bool, optional
         Whether to overwrite data in ``b`` (may improve performance). Default
         is False.
-    turbo : bool, optional
-        *Deprecated by ``driver=gvd`` option*. Has no significant effect for
-        eigenvalue computations since no eigenvectors are requested.
-
-        ..Deprecated in v1.5.0
-    eigvals : tuple (lo, hi), optional
-        *Deprecated by ``subset_by_index`` keyword*. Indexes of the smallest
-        and largest (in ascending order) eigenvalues and corresponding
-        eigenvectors to be returned: 0 <= lo <= hi <= M-1. If omitted, all
-        eigenvalues and eigenvectors are returned.
-
-        .. Deprecated in v1.5.0
     type : int, optional
         For the generalized problems, this keyword specifies the problem type
         to be solved for ``w`` and ``v`` (only takes 1, 2, 3 as possible
@@ -958,6 +946,18 @@ def eigvalsh(a, b=None, lower=True, overwrite_a=False,
         "evd", "evr", "evx" for standard problems and "gv", "gvd", "gvx" for
         generalized (where b is not None) problems. See the Notes section of
         `scipy.linalg.eigh`.
+    turbo : bool, optional
+        *Deprecated by ``driver=gvd`` option*. Has no significant effect for
+        eigenvalue computations since no eigenvectors are requested.
+
+        ..Deprecated in v1.5.0
+    eigvals : tuple (lo, hi), optional
+        *Deprecated by ``subset_by_index`` keyword*. Indexes of the smallest
+        and largest (in ascending order) eigenvalues and corresponding
+        eigenvectors to be returned: 0 <= lo <= hi <= M-1. If omitted, all
+        eigenvalues and eigenvectors are returned.
+
+        .. Deprecated in v1.5.0
 
     Returns
     -------


### PR DESCRIPTION
#### Reference issue
Closes #13651

#### What does this implement/fix?
Per #13651, an `eigvals_only` parameter was in the docstring for `scipy.linalg.eigvalsh`.
I also reordered the docstring parameters to match the function parameter order.