### PR TITLE
DOC: Fix PCHIP references

### DIFF
--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -218,9 +218,10 @@ class PchipInterpolator(CubicHermiteSpline):
 
     References
     ----------
-    .. [1] F. N. Fritsch and R. E. Carlson, Monotone Piecewise Cubic Interpolation,
-           SIAM J. Numer. Anal., 17(2), 238 (1980).
-           :doi:`10.1137/0717021`.
+    .. [1] F. N. Fritsch and J. Butland,
+           A method for constructing local monotone piecewise cubic interpolants.
+           SIAM J. Sci. Comput., 5(2), 300–304 (1984).
+           :doi:`10.1137/0905021`.
     .. [2] see, e.g., C. Moler, Numerical Computing with Matlab, 2004.
            :doi:`10.1137/1.9780898717952`
 
@@ -292,7 +293,7 @@ class PchipInterpolator(CubicHermiteSpline):
         dk[1:-1][~condition] = 1.0 / whmean[~condition]
 
         # special case endpoints, as suggested in
-        # Cleve Moler, Numerical Computing with MATLAB, Chap 3.4
+        # Cleve Moler, Numerical Computing with MATLAB, Chap 3.6 (pchiptx.m)
         dk[0] = PchipInterpolator._edge_case(hk[0], hk[1], mk[0], mk[1])
         dk[-1] = PchipInterpolator._edge_case(hk[-1], hk[-2], mk[-1], mk[-2])
 

--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -219,7 +219,8 @@ class PchipInterpolator(CubicHermiteSpline):
     References
     ----------
     .. [1] F. N. Fritsch and J. Butland,
-           A method for constructing local monotone piecewise cubic interpolants.
+           A method for constructing local
+           monotone piecewise cubic interpolants,
            SIAM J. Sci. Comput., 5(2), 300–304 (1984).
            :doi:`10.1137/0905021`.
     .. [2] see, e.g., C. Moler, Numerical Computing with Matlab, 2004.

--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -221,7 +221,7 @@ class PchipInterpolator(CubicHermiteSpline):
     .. [1] F. N. Fritsch and J. Butland,
            A method for constructing local
            monotone piecewise cubic interpolants,
-           SIAM J. Sci. Comput., 5(2), 300–304 (1984).
+           SIAM J. Sci. Comput., 5(2), 300-304 (1984).
            :doi:`10.1137/0905021`.
     .. [2] see, e.g., C. Moler, Numerical Computing with Matlab, 2004.
            :doi:`10.1137/1.9780898717952`


### PR DESCRIPTION
#### What does this implement/fix?

The previous reference (Fritsch and Carlson 1980) does *not* describe the algorithm that's nowadays known as PCHIP.
It *does* describe necessary and sufficient conditions for monotonicity, but the suggested algorithm is different from PCHIP.

The actual PCHIP algorithm (which would more appropriately be called PCHIM, BTW) is described in Fritsch and Butland 1984, but they don't use the name "PCHIP" (nor "PCHIM").

The name PCHIP was coined in: F. N. Fritsch. Piecewise cubic Hermite interpolation package (final specifications). Technical Report UCID-30194, Lawrence Livermore National Laboratory, CA (USA), 1982. [doi:10.2172/6838406](https://doi.org/10.2172/6838406).
That reference, however, doesn't contain any equations nor the actual code.

The (probably) original code of PCHIP (including the `PCHIM` subroutine) is available at https://people.sc.fsu.edu/~jburkardt/f77_src/pchip/pchip.html.

Originally, "PCHIP" did *not* stand for "Piecewise Cubic Hermite Interpolating Polynomial" but for "Piecewise Cubic Hermite Interpolation Package".

The reference in the code comment is also wrong, because chapter 3.4 only contains this:

> This defines the `pchip` slopes at interior breakpoints, but the slopes d1 and dn at either end of the data interval are determined by a slightly different, one-sided analysis. The details are in `pchiptx.m`.

The actual details are in the code of the `pchipend()` function in the file `pchiptx.m`, which is listed in section 3.6.

#### Additional information

I've collected this information and more at https://splines.readthedocs.io/euclidean/piecewise-monotone.html