### PR TITLE
TST: remove IPython warning in debug session

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,6 +5,7 @@ junit_family=xunit2
 filterwarnings =
     error
     always::scipy._lib._testutils.FPUModeChangeWarning
+    ignore:.*deprecated and ignored since IPython.*:DeprecationWarning
     once:.*LAPACK bug 0038.*:RuntimeWarning
     ignore:Using or importing the ABCs from 'collections'*:DeprecationWarning
     ignore:can't resolve package from __spec__ or __package__, falling back on __name__ and __path__:ImportWarning


### PR DESCRIPTION
#### What does this implement/fix?
When starting a debug session in PyCharm, the console cannot be used due to IPython warnings being caught.

```python
Traceback (most recent call last):
  File "/Applications/PyCharm.app/Contents/plugins/python/helpers/pydev/_pydevd_bundle/pydevd_console_integration.py", line 84, in get_code_executor
    code_executor = getattr(__builtin__, 'interpreter')
AttributeError: module 'builtins' has no attribute 'interpreter'
During handling of the above exception, another exception occurred:
...
DeprecationWarning: The `use_readline` parameter is deprecated and ignored since IPython 6.0.
```

The fix consist in skipping the warning in the pytest configuration. Basically it's the first thing I do when I create a new branch to work on.

#### Additional information
This is also done here: https://github.com/mne-tools/mne-python/pull/8524