### PR TITLE
ENH: linalg: Add LAPACK wrappers for trexc and trsen.

### DIFF
--- a/scipy/linalg/flapack_other.pyf.src
+++ b/scipy/linalg/flapack_other.pyf.src
@@ -131,6 +131,118 @@ subroutine <prefix2c>tgexc(wantq,wantz,n,a,lda,b,ldb,q,ldq,z,ldz,ifst,ilst,info)
 
 end subroutine <prefix2c>tgexc
 
+subroutine <prefix2>trsen(job,wantq,select,n,t,ldt,q,ldq,wr,wi,m,s,sep,work,lwork,iwork,liwork,info)
+
+    callstatement (*f2py_func)(job,(wantq?"V":"N"),select,&n,t,&ldt,q,&ldq,wr,wi,&m,&s,&sep,work,&lwork,iwork,&liwork,&info)
+    callprotoargument char*,char*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,F_INT*,F_INT*
+
+    character optional,intent(in),check(*job=='N'||*job=='E'||*job=='V'||*job=='B'):: job = 'B'
+    logical optional, intent(in),check(wantq==0||wantq==1) :: wantq=1
+    logical intent(in),dimension(n),depend(n) :: select
+    integer intent(hide),depend(t) :: n=shape(t,0)
+    <ftype2> intent(in,out,copy,out=ts),dimension(n,n) :: t
+    integer intent(hide),depend(t) :: ldt=MAX(1,shape(t,0))
+    <ftype2> intent(in,out,copy,out=qs),dimension(n,n),depend(n) :: q
+    integer intent(hide),depend(q) :: ldq=MAX(1,shape(q,0))
+    <ftype2> intent(out),dimension(n),depend(n) :: wr
+    <ftype2> intent(out),dimension(n),depend(n) :: wi
+    integer intent(out) :: m
+    <ftype2> intent(out) :: s
+    <ftype2> intent(out) :: sep
+    <ftype2> intent(hide),dimension(MAX(lwork,1)) :: work
+    ! These lwork and liwork values are bare minimum estiamates only for the case job == "N".
+    ! A separate lwork query is a prerequisite due to m dependence.
+    ! Depending on the m value lwork can go up to n**2 / 2 for n = 2m hence it is not
+    ! possible to give a minimal value without a potential excessive memory waste.
+    integer optional,intent(in),depend(n),check(lwork == -1 || lwork >= 1) :: lwork=MAX(1,n)
+    integer intent(hide),dimension(MAX(1,liwork)) :: iwork
+    integer optional,intent(in),check(liwork == -1 || liwork >= 1) :: liwork=1
+    integer intent(out) :: info
+
+end subroutine <prefix2>trsen
+
+subroutine <prefix2>trsen_lwork(job,wantq,select,n,t,ldt,q,ldq,wr,wi,m,s,sep,work,lwork,iwork,liwork,info)
+
+    fortranname <prefix2>trsen
+    callstatement (*f2py_func)(job,(wantq?"V":"N"),select,&n,t,&ldt,&q,&ldq,&wr,&wi,&m,&s,&sep,&work,&lwork,&iwork,&liwork,&info)
+    callprotoargument char*,char*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,F_INT*,F_INT*
+
+    character optional,intent(in),check(*job=='N'||*job=='E'||*job=='V'||*job=='B'):: job = 'B'
+    logical intent(in),dimension(n),depend(n) :: select
+    <ftype2> intent(in),dimension(n,n) :: t
+
+    logical intent(hide) :: wantq = 0
+    integer intent(hide),depend(t) :: n = shape(t,0)
+    integer intent(hide),depend(n) :: ldt = MAX(1, n)
+    <ftype2> intent(hide) :: q
+    integer intent(hide),depend(n) :: ldq = MAX(1, n)
+    <ftype2> intent(hide) :: wr
+    <ftype2> intent(hide) :: wi
+    integer intent(hide) :: m
+    <ftype2> intent(hide) :: s
+    <ftype2> intent(hide) :: sep
+    integer intent(hide):: lwork=-1
+    integer intent(hide) :: liwork=-1
+
+    <ftype2> intent(out) :: work
+    integer intent(out) :: iwork
+    integer intent(out) :: info
+
+end subroutine <prefix2>trsen_lwork
+
+subroutine <prefix2c>trsen(job,wantq,select,n,t,ldt,q,ldq,w,m,s,sep,work,lwork,info)
+
+    callstatement (*f2py_func)(job,(wantq?"V":"N"),select,&n,t,&ldt,q,&ldq,w,&m,&s,&sep,work,&lwork,&info)
+    callprotoargument char*,char*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2>*,<ctype2c>*,F_INT*,F_INT*
+
+    character optional,intent(in),check(*job=='N'||*job=='E'||*job=='V'||*job=='B'):: job = 'B'
+    logical optional, intent(in),check(wantq==0||wantq==1) :: wantq=1
+    logical intent(in),dimension(n),depend(n) :: select
+    integer intent(hide),depend(t) :: n=shape(t,0)
+    <ftype2c> intent(in,out,copy,out=ts),dimension(n,n) :: t
+    integer intent(hide),depend(t) :: ldt=MAX(1,shape(t,0))
+    <ftype2c> intent(in,out,copy,out=qs),dimension(n,n),depend(n) :: q
+    integer intent(hide),depend(q) :: ldq=MAX(1,shape(q,0))
+    <ftype2c> intent(out),dimension(n),depend(n) :: w
+    integer intent(out) :: m
+    <ftype2> intent(out) :: s
+    <ftype2> intent(out) :: sep
+    <ftype2c> intent(hide),dimension(MAX(lwork,1)) :: work
+    ! This lwork values is a bare minimum estiamate only for the case job == "N".
+    ! A separate lwork query is a prerequisite due to m dependence.
+    ! Depending on the m value lwork can go up to n**2 / 2 for n = 2m hence it is not
+    ! possible to give a minimal value without a potential excessive memory waste.
+    integer optional,intent(in),depend(n),check(lwork == -1 || lwork >= 1) :: lwork=MAX(1,n)
+    integer intent(out) :: info
+
+end subroutine <prefix2c>trsen
+
+subroutine <prefix2c>trsen_lwork(job,wantq,select,n,t,ldt,q,ldq,w,m,s,sep,work,lwork,info)
+
+    fortranname <prefix2c>trsen
+    callstatement (*f2py_func)(job,(wantq?"V":"N"),select,&n,t,&ldt,&q,&ldq,&w,&m,&s,&sep,&work,&lwork,&info)
+    callprotoargument char*,char*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2>*,<ctype2c>*,F_INT*,F_INT*
+
+    character optional,intent(in),check(*job=='N'||*job=='E'||*job=='V'||*job=='B'):: job = 'B'
+    logical intent(in),dimension(n),depend(n) :: select
+    <ftype2c> intent(in),dimension(n,n) :: t
+
+    logical intent(hide) :: wantq = 0
+    integer intent(hide),depend(t) :: n = shape(t,0)
+    integer intent(hide),depend(n) :: ldt = MAX(1, n)
+    <ftype2c> intent(hide) :: q
+    integer intent(hide),depend(n) :: ldq = MAX(1, n)
+    <ftype2c> intent(hide) :: w
+    integer intent(hide) :: m
+    <ftype2> intent(hide) :: s
+    <ftype2> intent(hide) :: sep
+    integer intent(hide):: lwork=-1
+
+    <ftype2c> intent(out) :: work
+    integer intent(out) :: info
+
+end subroutine <prefix2c>trsen_lwork
+
 subroutine <prefix2>tgsen(ijob,wantq,wantz,select,n,a,lda,b,ldb,alphar,alphai,beta,q,ldq,z,ldz,m,pl,pr,dif,work,lwork,iwork,liwork,info)
 
     callstatement (*f2py_func)(&ijob,&wantq,&wantz,select,&n,a,&lda,b,&ldb,alphar,alphai,beta,q,&ldq,z,&ldz,&m,&pl,&pr,dif,work,&lwork,iwork,&liwork,&info)
@@ -159,7 +271,7 @@ subroutine <prefix2>tgsen(ijob,wantq,wantz,select,n,a,lda,b,ldb,alphar,alphai,be
     <ftype2> intent(hide),dimension(MAX(lwork,1)) :: work
     ! these lwork and liwork values are bare minimum estiamates only for cases ijob == 1,2,4
     ! a separate lwork query is a prerequisite due to m dependence.
-    ! Depending on the m value lwork can go upto n**2 / 4 for n = 2m hence it is not
+    ! Depending on the m value lwork can go up to n**2 / 2 for n = 2m hence it is not
     ! possible to give a minimal value without a potential excessive memory waste
     integer optional,intent(in),depend(n),check(lwork == -1 || lwork >= 1) :: lwork=4*n+16
     integer intent(hide),dimension(MAX(1,liwork)) :: iwork
@@ -230,7 +342,7 @@ subroutine <prefix2c>tgsen(ijob,wantq,wantz,select,n,a,lda,b,ldb,alpha,beta,q,ld
     <ftype2c> intent(hide),dimension(MAX(lwork,1)) :: work
     ! these lwork and liwork values are bare minimum estiamates only for cases ijob ==0,1,2,4
     ! a separate lwork query is a prerequisite due to m dependence.
-    ! Depending on the m value lwork can go upto n**2 / 4 for n = 2m hence it is not
+    ! Depending on the m value lwork can go up to n**2 / 2 for n = 2m hence it is not
     ! possible to give a minimal value without a potential excessive memory waste
     integer optional,intent(in),depend(n,ijob),check(lwork == -1 || lwork >= 1) :: lwork=(ijob==0?1:n+2)
     integer intent(hide),dimension(liwork):: iwork

--- a/scipy/linalg/flapack_other.pyf.src
+++ b/scipy/linalg/flapack_other.pyf.src
@@ -42,6 +42,45 @@ subroutine <prefix2>gejsv(joba,jobu,jobv,jobr,jobt,jobp,m,n,a,lda,sva,u,ldu,v,ld
 
 end subroutine <prefix2>gejsv
 
+subroutine <prefix2>trexc(wantq,n,a,lda,q,ldq,ifst,ilst,work,info)
+    ! Reorder the Schur decomposition of a real matrix
+    ! using an orthogonal or unitary equivalence transformation.
+
+    callstatement (*f2py_func)((wantq?"V":"N"),&n,a,&lda,q,&ldq,&ifst,&ilst,work,&info)
+    callprotoargument char*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*
+
+    integer optional,intent(in),check(wantq==0||wantq==1) :: wantq=1
+    integer intent(hide),depend(a) :: n=shape(a,1)
+    <ftype2> intent(in,out,copy),dimension(lda,n) :: a
+    integer intent(hide),depend(a) :: lda=MAX(1,shape(a,0))
+    <ftype2> intent(in,out,copy),dimension(ldq,n) :: q
+    integer intent(hide),depend(q) :: ldq=MAX(1,shape(q,0))
+    integer intent(in) :: ifst
+    integer intent(in) :: ilst
+    <ftype2> intent(hide),depend(n),dimension(n) :: work
+    integer intent(out) :: info
+
+end subroutine <prefix2>trexc
+
+subroutine <prefix2c>trexc(wantq,n,a,lda,q,ldq,ifst,ilst,info)
+    ! Reorder the Schur decomposition of a complex matrix
+    ! using an orthogonal or unitary equivalence transformation.
+
+    callstatement (*f2py_func)((wantq?"V":"N"),&n,a,&lda,q,&ldq,&ifst,&ilst,&info)
+    callprotoargument char*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,F_INT*,F_INT*,F_INT*
+
+    integer optional,intent(in),check(wantq==0||wantq==1) :: wantq=1
+    integer intent(hide),depend(a) :: n=shape(a,1)
+    <ftype2c> intent(in,out,copy),dimension(lda,n) :: a
+    integer intent(hide),depend(a) :: lda=MAX(1,shape(a,0))
+    <ftype2c> intent(in,out,copy),dimension(ldq,n) :: q
+    integer intent(hide),depend(q) :: ldq=MAX(1,shape(q,0))
+    integer intent(in) :: ifst
+    integer intent(in) :: ilst
+    integer intent(out) :: info
+
+end subroutine <prefix2c>trexc
+
 subroutine <prefix2>tgexc(wantq,wantz,n,a,lda,b,ldb,q,ldq,z,ldz,ifst,ilst,work,lwork,info)
     ! Reorder the generalized Schur decomposition of a real matrix
     ! pair using an orthogonal or unitary equivalence transformation.

--- a/scipy/linalg/flapack_other.pyf.src
+++ b/scipy/linalg/flapack_other.pyf.src
@@ -49,20 +49,20 @@ subroutine <prefix2>tgexc(wantq,wantz,n,a,lda,b,ldb,q,ldq,z,ldz,ifst,ilst,work,l
     callstatement { ifst++; ilst++; (*f2py_func)(&wantq,&wantz,&n,a,&lda,b,&ldb,q,&ldq,z,&ldz,&ifst,&ilst,work,&lwork,&info); }
     callprotoargument F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,F_INT*
 
-    integer intent(hide),check(wantq==0||wantq==1) :: wantq=1
-    integer intent(hide),check(wantz==0||wantz==1) :: wantz=1
+    integer optional,intent(in),check(wantq==0||wantq==1) :: wantq=1
+    integer optional,intent(in),check(wantz==0||wantz==1) :: wantz=1
     integer intent(hide),depend(a) :: n=shape(a,1)
     <ftype2> intent(in,out,copy),dimension(lda,n) :: a
-    integer intent(hide),depend(a) :: lda=shape(a,0)
+    integer intent(hide),depend(a) :: lda=MAX(1,shape(a,0))
     <ftype2> intent(in,out,copy),dimension(ldb,n) :: b
-    integer intent(hide),depend(b) :: ldb=shape(b,0)
+    integer intent(hide),depend(b) :: ldb=MAX(1,shape(b,0))
     <ftype2> intent(in,out,copy),dimension(ldq,n) :: q
-    integer intent(hide),depend(q) :: ldq=shape(q,0)
+    integer intent(hide),depend(q) :: ldq=MAX(1,shape(q,0))
     <ftype2> intent(in,out,copy),dimension(ldz,n) :: z
-    integer intent(hide),depend(z) :: ldz=shape(z,0)
+    integer intent(hide),depend(z) :: ldz=MAX(1,shape(z,0))
     integer intent(in) :: ifst
     integer intent(in) :: ilst
-    <ftype2> intent(out),dimension(MAX(lwork,1)) :: work
+    <ftype2> intent(out),depend(lwork),dimension(MAX(lwork,1)) :: work
     integer optional,intent(in),depend(n),check(lwork == -1 || lwork >= 4*n+16) :: lwork=max(4*n+16,1)
     integer intent(out) :: info
 
@@ -75,17 +75,17 @@ subroutine <prefix2c>tgexc(wantq,wantz,n,a,lda,b,ldb,q,ldq,z,ldz,ifst,ilst,info)
     callstatement { ifst++; ilst++; (*f2py_func)(&wantq,&wantz,&n,a,&lda,b,&ldb,q,&ldq,z,&ldz,&ifst,&ilst,&info); }
     callprotoargument F_INT*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,F_INT*,F_INT*,F_INT*
 
-    integer intent(hide),check(wantq==0||wantq==1) :: wantq=1
-    integer intent(hide),check(wantz==0||wantz==1) :: wantz=1
+    integer optional,intent(in),check(wantq==0||wantq==1) :: wantq=1
+    integer optional,intent(in),check(wantz==0||wantz==1) :: wantz=1
     integer intent(hide),depend(a) :: n=shape(a,1)
     <ftype2c> intent(in,out,copy),dimension(lda,n) :: a
-    integer intent(hide),depend(a) :: lda=shape(a,0)
+    integer intent(hide),depend(a) :: lda=MAX(1,shape(a,0))
     <ftype2c> intent(in,out,copy),dimension(ldb,n) :: b
-    integer intent(hide),depend(b) :: ldb=shape(b,0)
+    integer intent(hide),depend(b) :: ldb=MAX(1,shape(b,0))
     <ftype2c> intent(in,out,copy),dimension(ldq,n) :: q
-    integer intent(hide),depend(q) :: ldq=shape(q,0)
+    integer intent(hide),depend(q) :: ldq=MAX(1,shape(q,0))
     <ftype2c> intent(in,out,copy),dimension(ldz,n) :: z
-    integer intent(hide),depend(z) :: ldz=shape(z,0)
+    integer intent(hide),depend(z) :: ldz=MAX(1,shape(z,0))
     integer intent(in) :: ifst
     integer intent(in) :: ilst
     integer intent(out) :: info

--- a/scipy/linalg/flapack_other.pyf.src
+++ b/scipy/linalg/flapack_other.pyf.src
@@ -46,7 +46,7 @@ subroutine <prefix2>tgexc(wantq,wantz,n,a,lda,b,ldb,q,ldq,z,ldz,ifst,ilst,work,l
     ! Reorder the generalized Schur decomposition of a real matrix
     ! pair using an orthogonal or unitary equivalence transformation.
 
-    callstatement { ifst++; ilst++; (*f2py_func)(&wantq,&wantz,&n,a,&lda,b,&ldb,q,&ldq,z,&ldz,&ifst,&ilst,work,&lwork,&info); }
+    callstatement (*f2py_func)(&wantq,&wantz,&n,a,&lda,b,&ldb,q,&ldq,z,&ldz,&ifst,&ilst,work,&lwork,&info)
     callprotoargument F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*,<ctype2>*,F_INT*,F_INT*
 
     integer optional,intent(in),check(wantq==0||wantq==1) :: wantq=1
@@ -72,7 +72,7 @@ subroutine <prefix2c>tgexc(wantq,wantz,n,a,lda,b,ldb,q,ldq,z,ldz,ifst,ilst,info)
     ! Reorder the generalized Schur decomposition of a complex matrix
     ! pair using an orthogonal or unitary equivalence transformation.
 
-    callstatement { ifst++; ilst++; (*f2py_func)(&wantq,&wantz,&n,a,&lda,b,&ldb,q,&ldq,z,&ldz,&ifst,&ilst,&info); }
+    callstatement (*f2py_func)(&wantq,&wantz,&n,a,&lda,b,&ldb,q,&ldq,z,&ldz,&ifst,&ilst,&info)
     callprotoargument F_INT*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,F_INT*,F_INT*,F_INT*
 
     integer optional,intent(in),check(wantq==0||wantq==1) :: wantq=1

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -705,6 +705,11 @@ All functions
    ctpttr
    ztpttr
 
+   strexc
+   dtrexc
+   ctrexc
+   ztrexc
+
    strsyl
    dtrsyl
    ctrsyl

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -710,6 +710,16 @@ All functions
    ctrexc
    ztrexc
 
+   strsen
+   dtrsen
+   ctrsen
+   ztrsen
+
+   strsen_lwork
+   dtrsen_lwork
+   ctrsen_lwork
+   ztrsen_lwork
+
    strsyl
    dtrsyl
    ctrsyl

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -3010,7 +3010,7 @@ def test_gges_tgexc(dtype):
     assert_allclose(q @ s @ z.conj().T, a, rtol=0, atol=atol)
     assert_allclose(q @ t @ z.conj().T, b, rtol=0, atol=atol)
 
-    result = tgexc(s, t, q, z, 6, 0)
+    result = tgexc(s, t, q, z, 7, 1)
     assert_equal(result[-1], 0)
 
     s = result[0]

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -3027,3 +3027,60 @@ def test_gges_tgexc(dtype):
 
     assert_allclose(s[0, 0] / t[0, 0], d2, rtol=0, atol=atol)
     assert_allclose(s[1, 1] / t[1, 1], d1, rtol=0, atol=atol)
+
+
+@pytest.mark.parametrize('dtype', DTYPES)
+def test_gges_tgsen(dtype):
+    seed(1234)
+    atol = np.finfo(dtype).eps*100
+
+    n = 10
+    a = generate_random_dtype_array([n, n], dtype=dtype)
+    b = generate_random_dtype_array([n, n], dtype=dtype)
+
+    gges, tgsen, tgsen_lwork = get_lapack_funcs(
+        ('gges', 'tgsen', 'tgsen_lwork'), dtype=dtype)
+
+    result = gges(lambda x: None, a, b, overwrite_a=False, overwrite_b=False)
+    assert_equal(result[-1], 0)
+
+    s = result[0]
+    t = result[1]
+    q = result[-4]
+    z = result[-3]
+
+    d1 = s[0, 0] / t[0, 0]
+    d2 = s[6, 6] / t[6, 6]
+
+    if dtype in COMPLEX_DTYPES:
+        assert_allclose(s, np.triu(s), rtol=0, atol=atol)
+        assert_allclose(t, np.triu(t), rtol=0, atol=atol)
+
+    assert_allclose(q @ s @ z.conj().T, a, rtol=0, atol=atol)
+    assert_allclose(q @ t @ z.conj().T, b, rtol=0, atol=atol)
+
+    select = np.zeros(n)
+    select[6] = 1
+
+    lwork = _compute_lwork(tgsen_lwork, select, s, t)
+
+    # off-by-one error in LAPACK, see gh-issue #13397
+    lwork = (lwork[0]+1, lwork[1])
+
+    result = tgsen(select, s, t, q, z, lwork=lwork)
+    assert_equal(result[-1], 0)
+
+    s = result[0]
+    t = result[1]
+    q = result[-7]
+    z = result[-6]
+
+    if dtype in COMPLEX_DTYPES:
+        assert_allclose(s, np.triu(s), rtol=0, atol=atol)
+        assert_allclose(t, np.triu(t), rtol=0, atol=atol)
+
+    assert_allclose(q @ s @ z.conj().T, a, rtol=0, atol=atol)
+    assert_allclose(q @ t @ z.conj().T, b, rtol=0, atol=atol)
+
+    assert_allclose(s[0, 0] / t[0, 0], d2, rtol=0, atol=atol)
+    assert_allclose(s[1, 1] / t[1, 1], d1, rtol=0, atol=atol)

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -3107,6 +3107,127 @@ def test_gges_tgexc(dtype):
 
 
 @pytest.mark.parametrize('dtype', DTYPES)
+def test_gees_trsen(dtype):
+    seed(1234)
+    atol = np.finfo(dtype).eps*100
+
+    n = 10
+    a = generate_random_dtype_array([n, n], dtype=dtype)
+
+    gees, trsen, trsen_lwork = get_lapack_funcs(
+        ('gees', 'trsen', 'trsen_lwork'), dtype=dtype)
+
+    result = gees(lambda x: None, a, overwrite_a=False)
+    assert_equal(result[-1], 0)
+
+    t = result[0]
+    z = result[-3]
+
+    d2 = t[6, 6]
+
+    if dtype in COMPLEX_DTYPES:
+        assert_allclose(t, np.triu(t), rtol=0, atol=atol)
+
+    assert_allclose(z @ t @ z.conj().T, a, rtol=0, atol=atol)
+
+    select = np.zeros(n)
+    select[6] = 1
+
+    lwork = _compute_lwork(trsen_lwork, select, t)
+
+    if dtype in COMPLEX_DTYPES:
+        result = trsen(select, t, z, lwork=lwork)
+    else:
+        result = trsen(select, t, z, lwork=lwork, liwork=lwork[1])
+    assert_equal(result[-1], 0)
+
+    t = result[0]
+    z = result[1]
+
+    if dtype in COMPLEX_DTYPES:
+        assert_allclose(t, np.triu(t), rtol=0, atol=atol)
+
+    assert_allclose(z @ t @ z.conj().T, a, rtol=0, atol=atol)
+
+    assert_allclose(t[0, 0], d2, rtol=0, atol=atol)
+
+
+@pytest.mark.parametrize(
+    "t, q, expect, select, expect_s, expect_sep",
+    [(np.array([[0.7995, -0.1144, 0.0060, 0.0336],
+                [0.0000, -0.0994, 0.2478, 0.3474],
+                [0.0000, -0.6483, -0.0994, 0.2026],
+                [0.0000, 0.0000, 0.0000, -0.1007]]),
+      np.array([[0.6551, 0.1037, 0.3450, 0.6641],
+                [0.5236, -0.5807, -0.6141, -0.1068],
+                [-0.5362, -0.3073, -0.2935, 0.7293],
+                [0.0956, 0.7467, -0.6463, 0.1249]]),
+      np.array([[0.3500, 0.4500, -0.1400, -0.1700],
+                [0.0900, 0.0700, -0.5399, 0.3500],
+                [-0.4400, -0.3300, -0.0300, 0.1700],
+                [0.2500, -0.3200, -0.1300, 0.1100]]),
+      np.array([1, 0, 0, 1]),
+      1.75e+00, 3.22e+00),
+     (np.array([[-6.0004 - 6.9999j, 0.3637 - 0.3656j,
+                 -0.1880 + 0.4787j, 0.8785 - 0.2539j],
+                [0.0000 + 0.0000j, -5.0000 + 2.0060j,
+                 -0.0307 - 0.7217j, -0.2290 + 0.1313j],
+                [0.0000 + 0.0000j, 0.0000 + 0.0000j,
+                 7.9982 - 0.9964j, 0.9357 + 0.5359j],
+                [0.0000 + 0.0000j, 0.0000 + 0.0000j,
+                 0.0000 + 0.0000j, 3.0023 - 3.9998j]]),
+      np.array([[-0.8347 - 0.1364j, -0.0628 + 0.3806j,
+                 0.2765 - 0.0846j, 0.0633 - 0.2199j],
+                [0.0664 - 0.2968j, 0.2365 + 0.5240j,
+                 -0.5877 - 0.4208j, 0.0835 + 0.2183j],
+                [-0.0362 - 0.3215j, 0.3143 - 0.5473j,
+                 0.0576 - 0.5736j, 0.0057 - 0.4058j],
+                [0.0086 + 0.2958j, -0.3416 - 0.0757j,
+                 -0.1900 - 0.1600j, 0.8327 - 0.1868j]]),
+      np.array([[-3.9702 - 5.0406j, -4.1108 + 3.7002j,
+                 -0.3403 + 1.0098j, 1.2899 - 0.8590j],
+                [0.3397 - 1.5006j, 1.5201 - 0.4301j,
+                 1.8797 - 5.3804j, 3.3606 + 0.6498j],
+                [3.3101 - 3.8506j, 2.4996 + 3.4504j,
+                 0.8802 - 1.0802j, 0.6401 - 1.4800j],
+                [-1.0999 + 0.8199j, 1.8103 - 1.5905j,
+                 3.2502 + 1.3297j, 1.5701 - 3.4397j]]),
+      np.array([1, 0, 0, 1]),
+      1.02e+00, 1.82e-01)])
+def test_trsen_NAG(t, q, select, expect, expect_s, expect_sep):
+    """
+    This test implements the example found in the NAG manual,
+    f08qgc, f08quc.
+    """
+    # NAG manual provides accuracy up to 4 and 2 decimals
+    atol = 1e-4
+    atol2 = 1e-2
+    trsen, trsen_lwork = get_lapack_funcs(
+        ('trsen', 'trsen_lwork'), dtype=t.dtype)
+
+    lwork = _compute_lwork(trsen_lwork, select, t)
+
+    if t.dtype in COMPLEX_DTYPES:
+        result = trsen(select, t, q, lwork=lwork)
+    else:
+        result = trsen(select, t, q, lwork=lwork, liwork=lwork[1])
+    assert_equal(result[-1], 0)
+
+    t = result[0]
+    q = result[1]
+    if t.dtype in COMPLEX_DTYPES:
+        s = result[4]
+        sep = result[5]
+    else:
+        s = result[5]
+        sep = result[6]
+
+    assert_allclose(expect, q @ t @ q.conj().T, atol=atol)
+    assert_allclose(expect_s, 1 / s, atol=atol2)
+    assert_allclose(expect_sep, 1 / sep, atol=atol2)
+
+
+@pytest.mark.parametrize('dtype', DTYPES)
 def test_gges_tgsen(dtype):
     seed(1234)
     atol = np.finfo(dtype).eps*100


### PR DESCRIPTION
#### Reference issue
Refs #10881

#### What does this implement/fix?
Adds wrappers for trexc and trsen which are required for sorting Schur decompositions. Wrappers for the generalized counterparts already exist, which these implementations are based upon.