### PR TITLE
ENH: Implement ppf and isf for invgauss

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4202,7 +4202,7 @@ class invgauss_gen(rv_continuous):
             lp = self._logpdf(x0, mu)
             delta = _lazywhere(np.abs(d) < 1e-5, (d, q, lq, lp, lx), f, f2=f2)
             x = x0 + sign * delta
-            if np.all(np.isclose(x, x0)):
+            if np.allclose(x, x0, atol=1e-08):
                 break
             x0 = x
             iterations += 1

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4222,14 +4222,14 @@ class invgauss_gen(rv_continuous):
             eps = logprob[not_done] - lx
             mask = np.abs(eps) < 1e-05
             delta[not_done][mask] = (
-                eps[mask] * np.exp(logprob[not_done][mask]
-                + np.log1p(-eps[mask] / 2))
+                eps[mask] *
+                np.exp(logprob[not_done][mask] + np.log1p(-eps[mask] / 2))
             )
             delta[not_done][~mask] = q[not_done] - np.exp(lx[~mask])
 
             x[not_done] = (
-                x0[not_done] + sign * delta[not_done]
-                / self._pdf(x0[not_done], m[not_done])
+                x0[not_done] + sign * delta[not_done] /
+                self._pdf(x0[not_done], m[not_done])
             )
             has_converged = np.isclose(x, x0, atol=1e-08, equal_nan=True)
             x0[...] = x[...]

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4167,7 +4167,7 @@ class invgauss_gen(rv_continuous):
         based on Gyner & Smyth (2016) and uses newton's method with carefully
         selected starting points that guarantee convergence regardless of the
         probability."""
-        x0 = np.empty(np.broadcast(q, mu).shape)
+        x0 = np.empty(np.broadcast(np.atleast_1d(q), np.atleast_1d(mu)).shape)
         q = np.broadcast_to(q, x0.shape)
         mu = np.broadcast_to(mu, x0.shape)
 
@@ -4176,9 +4176,9 @@ class invgauss_gen(rv_continuous):
         # if the left tail is tiny.
         tiny_left = q < 1e-05
         tiny_right = q > 0.99999  # 1 - 1e-05
-        if tiny_left.size:
+        if any(tiny_left):
             x0[tiny_left] = mu[tiny_left] / (_norm_ppf(q[tiny_left]) ** 2)
-        if tiny_right.size:
+        if any(tiny_right):
             # when the right tail probability is less than 10^-5, we use the
             # corresponding quantile of the gamma distribution with the same
             # mean and variance as the inverse-gaussian (IG) that produced
@@ -4229,7 +4229,7 @@ class invgauss_gen(rv_continuous):
 
             x[not_done] = (
                 x0[not_done] + sign * delta[not_done] /
-                self._pdf(x0[not_done], m[not_done])
+                self._pdf(x0[not_done], mu[not_done])
             )
             has_converged = np.isclose(x, x0, atol=1e-08, equal_nan=True)
             x0[...] = x[...]

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4094,7 +4094,7 @@ class invgauss_gen(rv_continuous):
             np.isposinf(mu),
             (x, mu),
             lambda x, mu: invgamma.logpdf(x, 0.5, scale=0.5),
-            f2=lambda x, mu: a - 1.5*np.log(x) - 0.5 * (x - mu)**2 / (x * mu**2)
+            f2=lambda x, mu: a - 1.5*np.log(x) - 0.5 * (x-mu)**2 / (x * mu**2)
         )
         return out
 
@@ -4185,7 +4185,7 @@ class invgauss_gen(rv_continuous):
         x0[~mask] = _lazywhere(
             mu[~mask] > 100,
             (mu[~mask], k),
-            lambda mu, k: mu * (0.5 / k - 0.125 / (k ** 3) + 0.0625 / (k ** 6)),
+            lambda mu, k: mu * (0.5 / k - 0.125 / (k ** 3) + 0.0625 / (k**6)),
             f2=lambda mu, k: mu * (np.sqrt(1 + k * k) - k)
         )
 
@@ -4202,8 +4202,12 @@ class invgauss_gen(rv_continuous):
             # page 8 of Giner & Smyth (2016)
             d = lq - lx
             mask = np.abs(d) < 1e-05
-            delta[mask] = d[mask] * np.exp(lq[mask] + np.log1p(-0.5 * d[mask]) - lp[mask])
-            delta[~mask] = q[~mask] * np.exp(-lp[~mask]) - np.exp(lx[~mask] - lp[~mask])
+            delta[mask] = (
+                d[mask] * np.exp(lq[mask] + np.log1p(-0.5*d[mask]) - lp[mask])
+            )
+            delta[~mask] = (
+                q[~mask] * np.exp(-lp[~mask]) - np.exp(lx[~mask] - lp[~mask])
+            )
 
             x = x0 + sign * delta
             if np.allclose(x, x0, atol=1e-08):

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4214,7 +4214,7 @@ class invgauss_gen(rv_continuous):
         # 1000 seems like a reasonable max number of iterations given that
         # convergence is guaranteed in this setup.
         while not all(has_converged):
-            not_done = x0[~has_converged]
+            not_done = np.nonzero(~has_converged)[0]
             lx = logF(x0[not_done], mu[not_done])
             # to avoid subtractive cancellation when `d` is very small we use a
             # taylor series expansion to approximate (p - p(xn)) as shown in
@@ -4222,11 +4222,15 @@ class invgauss_gen(rv_continuous):
             eps = logprob[not_done] - lx
             mask = np.abs(eps) < 1e-05
             delta[not_done][mask] = (
-                eps[mask] * np.exp(logprob[not_done][mask] + np.log1p(-eps[mask] / 2))
+                eps[mask] * np.exp(logprob[not_done][mask]
+                + np.log1p(-eps[mask] / 2))
             )
             delta[not_done][~mask] = q[not_done] - np.exp(lx[~mask])
 
-            x[not_done] = x0[not_done] + sign * delta[not_done] / self._pdf(x0[not_done], m[not_done])
+            x[not_done] = (
+                x0[not_done] + sign * delta[not_done]
+                / self._pdf(x0[not_done], m[not_done])
+            )
             has_converged = np.isclose(x, x0, atol=1e-08, equal_nan=True)
             x0[...] = x[...]
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4175,7 +4175,8 @@ class invgauss_gen(rv_continuous):
             """select the start values for the newton using the quantiles of
             the gamma (if right tail is required) or normal distribution"""
             if upper:
-                return gamma.isf(q, 1 / mu, scale=mu * mu)
+                mu3 = mu ** 3
+                return sc.gammainccinv(1 / mu3, q) / mu3
             return mu / (_norm_ppf(q) ** 2),
 
         k = 1.5 * mu

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2278,9 +2278,9 @@ class TestInvgauss:
             match="invalid value encountered in multiply"):
              assert_equal(stats.invgauss.isf(1e-17, mu=1.05) / 0.7, np.nan)
         # test if correct  out is returned for boundary values
-        assert np.allclose(stats.invgauss.ppf([0, 0.5, 1, 2, np.nan], mu=1),
-                           [0, 0.67584131, np.inf, np.nan, np.nan],
-                           equal_nan=True, atol=1e-08)
+       # assert np.allclose(stats.invgauss.ppf([0, 0.5, 1, 2, np.nan], mu=1),
+       #                    [0, 0.67584131, np.inf, np.nan, np.nan],
+       #                    equal_nan=True, atol=1e-08)
         # test if invalid values for the mean are detected
         assert np.allclose(stats.invgauss.ppf(0.5, mu=[0, 1, 2]),
                            [np.nan, 0.67584131, 1.02845978],

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2261,7 +2261,7 @@ class TestInvgauss:
             abs_error, [0, 25, 50, np.mean(abs_error), 75, 100]
         )
         assert_allclose(fns, [0., 0., 1.27054940e-21, 1.96413583e-17,
-                        2.16840434e-19, 2.22044605e-16], atol=1e-12)
+                        2.16840434e-19, 2.22044605e-16], atol=1e-08)
 
         q = stats.invgauss.ppf(p, mu=1)
         q1 = stats.invgauss.ppf(stats.invgauss.cdf(q, mu=1), mu=1)
@@ -2270,14 +2270,14 @@ class TestInvgauss:
             rel_error, [0, 25, 50, np.mean(rel_error), 75, 100]
         )
         assert_allclose(fns2, [0., 0., 0., 9.15882970e-17, 1.16804249e-16,
-                        4.92818217e-16], atol=1e-12)
+                        4.92818217e-16], atol=1e-08)
 
         # tests if algorithm does not diverge for small probabilities.
-        assert np.isclose(stats.invgauss.ppf(0.00013, mu=1, scale=3),
-                          0.15039762631802803, atol=2.22e-16)
+        assert np.isclose(stats.invgauss.ppf(0.00013, mu=1),
+                          0.06067806, atol=1e-08)
         # test if it returns right tail values accurately
-        assert np.isclose(stats.invgauss.isf(1e-20, mu=1.5, scale=1 / 0.7),
-                          126.3493, atol=2.22e-16)
+        assert np.isclose(stats.invgauss.isf(1e-20, mu=1.5),
+                          177.723, atol=1e-08)
         # test if correct  out is returned for boundary values
         with np.errstate(invalid='ignore'):
             # because probabilities must be in the interval [0, 1] a

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2279,12 +2279,11 @@ class TestInvgauss:
             match="invalid value encountered in multiply"):
              assert_equal(stats.invgauss.isf(1e-17, mu=1.05) / 0.7, np.nan)
         # test if correct  out is returned for boundary values
-        with warnings.catch_warnings():
+        with np.errstate(invalid='ignore'):
             # because probabilities must be in the interval [0, 1] a
             # RuntimeError warning is raised when passing NaN to the ppf
             # function. So its necessary to silence these warnings to avoid
             # CI build failure.
-            warnings.simplefilter('ignore', RuntimeWarning)
             assert_allclose(stats.invgauss.ppf([0, 0.5, 1, 2, np.nan], mu=1),
                             [0, 0.67584131, np.inf, np.nan, np.nan], atol=1e-08)
         # test if invalid values for the mean are detected

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2251,7 +2251,7 @@ class TestInvgauss:
         # extreme values have zero density for any finite mean value
         assert_allclose(stats.invgauss.pdf([-1, 0, np.inf], mu=1), [0, 0, 0])
 
-    def test_ppf_sf(self):
+    def test_ppf_isf(self):
         p = [0.000001, 0.00001, 0.0001, 0.001, 0.01, 0.1, 0.5, 0.9, 0.99,
              0.999, 0.9999, 0.99999, 0.999999]
         p1 = stats.invgauss.cdf(stats.invgauss.ppf(p, mu=1), mu=1)
@@ -2260,8 +2260,8 @@ class TestInvgauss:
         fns = np.percentile(
             abs_error, [0, 25, 50, np.mean(abs_error), 75, 100]
         )
-        assert_allclose(fns, [0., 0., 8.13151629e-20, 0.,
-                        5.55111512e-17, 2.22044605e-16], atol=1e-08)
+        assert_allclose(fns, [0., 0., 1.27054940e-21, 1.96413583e-17,
+                        2.16840434e-19, 2.22044605e-16], atol=1e-12)
 
         q = stats.invgauss.ppf(p, mu=1)
         q1 = stats.invgauss.ppf(stats.invgauss.cdf(q, mu=1), mu=1)
@@ -2269,17 +2269,15 @@ class TestInvgauss:
         fns2 = np.percentile(
             rel_error, [0, 25, 50, np.mean(rel_error), 75, 100]
         )
-        assert_allclose(fns2, [0., 0., 1.17819649e-16, 0.,
-                        3.50412747e-16, 1.68867330e-11], atol=1e-08)
+        assert_allclose(fns2, [0., 0., 0., 9.15882970e-17, 1.16804249e-16,
+                        4.92818217e-16], atol=1e-12)
 
         # tests if algorithm does not diverge for small probabilities.
-        assert np.isclose(stats.invgauss.ppf(0.00013, mu=1 / 3) * 3,
-                          0.15039762631802803, atol=1e-17)
+        assert np.isclose(stats.invgauss.ppf(0.00013, mu=1, scale=3),
+                          0.15039762631802803, atol=2.22e-16)
         # test if it returns right tail values accurately
-        assert np.isclose(stats.invgauss.isf(1e-17, mu=1.05) / 0.7,
-                          105.42079072389444, atol=1e-14)
-        assert np.isclose(stats.invgauss.isf(1e-50, mu=1.05) / 0.7,
-                          339.3560284841935, atol=1e-13)
+        assert np.isclose(stats.invgauss.isf(1e-20, mu=1.5, scale=1 / 0.7),
+                          126.3493, atol=2.22e-16)
         # test if correct  out is returned for boundary values
         with np.errstate(invalid='ignore'):
             # because probabilities must be in the interval [0, 1] a
@@ -2291,8 +2289,8 @@ class TestInvgauss:
                 [0, 0.67584131, np.inf, np.nan, np.nan], atol=1e-08
             )
         # test if invalid values for the mean are detected
-        assert_allclose(stats.invgauss.ppf(0.5, mu=[0, 1, 2]),
-                        [np.nan, 0.67584131, 1.02845978], atol=1e-08)
+        assert_allclose(stats.invgauss.ppf(0.5, mu=[0, 1, 2, np.inf]),
+                        [np.nan, 0.67584131, 1.02845978, 2.1981093], atol=1e-08)
 
 
 class TestLaplace:

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2264,8 +2264,8 @@ class TestInvgauss:
         q1 = stats.invgauss.ppf(stats.invgauss.cdf(q, mu=1), mu=1)
         rel_error = np.abs(q1 - q) / q
         fns2 = np.percentile(rel_error, [0, 25, 50, np.mean(rel_error), 75, 100])
-        assert_allclose(fns, [0., 0., 8.131516e-20, 0.,
-                        5.551115e-17, 2.220446e-16])
+        assert_allclose(fns2, [0., 0., 1.17819649e-16, 0.,
+                        3.50412747e-16, 1.68867330e-11])
 
         # tests if algorithm does not diverge for small probabilities.
         assert_equal(stats.invgauss.ppf(0.00013, mu=1 / 3) * 3, 0.15039762631802803)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2258,14 +2258,14 @@ class TestInvgauss:
         # five-number summary of the absolute error
         fns = np.percentile(abs_error, [0, 25, 50, np.mean(abs_error), 75, 100])
         assert_allclose(fns, [0., 0., 8.13151629e-20, 0.,
-                        5.55111512e-17, 2.22044605e-16])
+                        5.55111512e-17, 2.22044605e-16], atol=1e-15)
 
         q = stats.invgauss.ppf(p, mu=1)
         q1 = stats.invgauss.ppf(stats.invgauss.cdf(q, mu=1), mu=1)
         rel_error = np.abs(q1 - q) / q
         fns2 = np.percentile(rel_error, [0, 25, 50, np.mean(rel_error), 75, 100])
         assert_allclose(fns2, [0., 0., 1.17819649e-16, 0.,
-                        3.50412747e-16, 1.68867330e-11])
+                        3.50412747e-16, 1.68867330e-11], atol=1e-15)
 
         # tests if algorithm does not diverge for small probabilities.
         assert_equal(stats.invgauss.ppf(0.00013, mu=1 / 3) * 3, 0.15039762631802803)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2243,12 +2243,14 @@ class TestInvgauss:
         # these tests are bases on Gyner & Smyth (2016)
 
         # infinite mean corresponds to an inverse-chisquare pdf.
-        assert_allclose(
+        assert np.allclose(
             stats.invgauss.pdf([-1, 0, 1, 2, np.inf, np.nan], mu=np.inf),
-            [0., 0., 0.24197072, 0.10984782, 0., np.nan]
+            [0., 0., 0.24197072, 0.10984782, 0., np.nan],
+            equal_nan=True,
+            atol=1e-08
         )
         # extreme values have zero density for any finite mean value
-        assert_allclose(stats.invgauss.pdf([-1, 0, np.inf], mu=1), [0, 0, 0])
+        assert np.allclose(stats.invgauss.pdf([-1, 0, np.inf], mu=1), [0, 0, 0])
 
     def test_ppf_sf(self):
         p = [0.000001, 0.00001, 0.0001, 0.001, 0.01, 0.1, 0.5, 0.9, 0.99,
@@ -2257,15 +2259,15 @@ class TestInvgauss:
         abs_error = np.abs(p - p1)
         # five-number summary of the absolute error
         fns = np.percentile(abs_error, [0, 25, 50, np.mean(abs_error), 75, 100])
-        assert_allclose(fns, [0., 0., 8.13151629e-20, 0.,
-                        5.55111512e-17, 2.22044605e-16], atol=1e-08)
+        assert np.allclose(fns, [0., 0., 8.13151629e-20, 0.,
+                           5.55111512e-17, 2.22044605e-16], atol=1e-08)
 
         q = stats.invgauss.ppf(p, mu=1)
         q1 = stats.invgauss.ppf(stats.invgauss.cdf(q, mu=1), mu=1)
         rel_error = np.abs(q1 - q) / q
         fns2 = np.percentile(rel_error, [0, 25, 50, np.mean(rel_error), 75, 100])
-        assert_allclose(fns2, [0., 0., 1.17819649e-16, 0.,
-                        3.50412747e-16, 1.68867330e-11], atol=1e-08)
+        assert np.allclose(fns2, [0., 0., 1.17819649e-16, 0.,
+                           3.50412747e-16, 1.68867330e-11], atol=1e-08)
 
         # tests if algorithm does not diverge for small probabilities.
         assert_equal(stats.invgauss.ppf(0.00013, mu=1 / 3) * 3, 0.15039762631802803)
@@ -2276,11 +2278,13 @@ class TestInvgauss:
             match="invalid value encountered in multiply"):
              assert_equal(stats.invgauss.isf(1e-17, mu=1.05) / 0.7, np.nan)
         # test if correct  out is returned for boundary values
-        assert_allclose(stats.invgauss.ppf([0, 0.5, 1, 2, np.nan], mu=1),
-                        [0, 0.67584131, np.inf, np.nan, np.nan], atol=1e-08)
+        assert np.allclose(stats.invgauss.ppf([0, 0.5, 1, 2, np.nan], mu=1),
+                           [0, 0.67584131, np.inf, np.nan, np.nan],
+                           equal_nan=True, atol=1e-08)
         # test if invalid values for the mean are detected
-        assert_allclose(stats.invgauss.ppf(0.5, mu=[0, 1, 2]),
-                        [np.nan, 0.67584131, 1.02845978], atol=1e-08)
+        assert np.allclose(stats.invgauss.ppf(0.5, mu=[0, 1, 2]),
+                           [np.nan, 0.67584131, 1.02845978],
+                           equal_nan=True, atol=1e-08)
 
 
 class TestLaplace:

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2270,14 +2270,12 @@ class TestInvgauss:
 
         # tests if algorithm does not diverge for small probabilities.
         assert np.isclose(stats.invgauss.ppf(0.00013, mu=1 / 3) * 3,
-                          0.15039762631802803, atol=1e-08)
+                          0.15039762631802803, atol=1e-17)
         # test if it returns right tail values accurately
-        assert np.isclose(stats.invgauss.isf(1e-16, mu=1.05) / 0.7,
-                          98.47905825943425, atol=1e-08)
-        # test if it overflows for input 1e-17 or less
-        with pytest.warns(RuntimeWarning,
-            match="invalid value encountered in multiply"):
-             assert_equal(stats.invgauss.isf(1e-17, mu=1.05) / 0.7, np.nan)
+        assert np.isclose(stats.invgauss.isf(1e-17, mu=1.05) / 0.7,
+                          105.42079072389444, atol=1e-14)
+        assert np.isclose(stats.invgauss.isf(1e-50, mu=1.05) / 0.7,
+                          339.3560284841935, atol=1e-13)
         # test if correct  out is returned for boundary values
         with np.errstate(invalid='ignore'):
             # because probabilities must be in the interval [0, 1] a

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2257,14 +2257,18 @@ class TestInvgauss:
         p1 = stats.invgauss.cdf(stats.invgauss.ppf(p, mu=1), mu=1)
         abs_error = np.abs(p - p1)
         # five-number summary of the absolute error
-        fns = np.percentile(abs_error, [0, 25, 50, np.mean(abs_error), 75, 100])
+        fns = np.percentile(
+            abs_error, [0, 25, 50, np.mean(abs_error), 75, 100]
+        )
         assert_allclose(fns, [0., 0., 8.13151629e-20, 0.,
                         5.55111512e-17, 2.22044605e-16], atol=1e-08)
 
         q = stats.invgauss.ppf(p, mu=1)
         q1 = stats.invgauss.ppf(stats.invgauss.cdf(q, mu=1), mu=1)
         rel_error = np.abs(q1 - q) / q
-        fns2 = np.percentile(rel_error, [0, 25, 50, np.mean(rel_error), 75, 100])
+        fns2 = np.percentile(
+            rel_error, [0, 25, 50, np.mean(rel_error), 75, 100]
+        )
         assert_allclose(fns2, [0., 0., 1.17819649e-16, 0.,
                         3.50412747e-16, 1.68867330e-11], atol=1e-08)
 
@@ -2282,8 +2286,10 @@ class TestInvgauss:
             # RuntimeError warning is raised when passing NaN to the ppf
             # function. So its necessary to silence these warnings to avoid
             # CI build failure.
-            assert_allclose(stats.invgauss.ppf([0, 0.5, 1, 2, np.nan], mu=1),
-                            [0, 0.67584131, np.inf, np.nan, np.nan], atol=1e-08)
+            assert_allclose(
+                stats.invgauss.ppf([0, 0.5, 1, 2, np.nan], mu=1),
+                [0, 0.67584131, np.inf, np.nan, np.nan], atol=1e-08
+            )
         # test if invalid values for the mean are detected
         assert_allclose(stats.invgauss.ppf(0.5, mu=[0, 1, 2]),
                         [np.nan, 0.67584131, 1.02845978], atol=1e-08)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2243,14 +2243,13 @@ class TestInvgauss:
         # these tests are bases on Gyner & Smyth (2016)
 
         # infinite mean corresponds to an inverse-chisquare pdf.
-        assert np.allclose(
+        assert_allclose(
             stats.invgauss.pdf([-1, 0, 1, 2, np.inf, np.nan], mu=np.inf),
             [0., 0., 0.24197072, 0.10984782, 0., np.nan],
-            equal_nan=True,
             atol=1e-08
         )
         # extreme values have zero density for any finite mean value
-        assert np.allclose(stats.invgauss.pdf([-1, 0, np.inf], mu=1), [0, 0, 0])
+        assert_allclose(stats.invgauss.pdf([-1, 0, np.inf], mu=1), [0, 0, 0])
 
     def test_ppf_sf(self):
         p = [0.000001, 0.00001, 0.0001, 0.001, 0.01, 0.1, 0.5, 0.9, 0.99,
@@ -2259,32 +2258,38 @@ class TestInvgauss:
         abs_error = np.abs(p - p1)
         # five-number summary of the absolute error
         fns = np.percentile(abs_error, [0, 25, 50, np.mean(abs_error), 75, 100])
-        assert np.allclose(fns, [0., 0., 8.13151629e-20, 0.,
-                           5.55111512e-17, 2.22044605e-16], atol=1e-08)
+        assert_allclose(fns, [0., 0., 8.13151629e-20, 0.,
+                        5.55111512e-17, 2.22044605e-16], atol=1e-08)
 
         q = stats.invgauss.ppf(p, mu=1)
         q1 = stats.invgauss.ppf(stats.invgauss.cdf(q, mu=1), mu=1)
         rel_error = np.abs(q1 - q) / q
         fns2 = np.percentile(rel_error, [0, 25, 50, np.mean(rel_error), 75, 100])
-        assert np.allclose(fns2, [0., 0., 1.17819649e-16, 0.,
-                           3.50412747e-16, 1.68867330e-11], atol=1e-08)
+        assert_allclose(fns2, [0., 0., 1.17819649e-16, 0.,
+                        3.50412747e-16, 1.68867330e-11], atol=1e-08)
 
         # tests if algorithm does not diverge for small probabilities.
-        assert_equal(stats.invgauss.ppf(0.00013, mu=1 / 3) * 3, 0.15039762631802803)
+        assert np.isclose(stats.invgauss.ppf(0.00013, mu=1 / 3) * 3,
+                          0.15039762631802803, atol=1e-08)
         # test if it returns right tail values accurately
-        assert_equal(stats.invgauss.isf(1e-16, mu=1.05) / 0.7, 98.47905825943425)
+        assert np.isclose(stats.invgauss.isf(1e-16, mu=1.05) / 0.7,
+                          98.47905825943425, atol=1e-08)
         # test if it overflows for input 1e-17 or less
         with pytest.warns(RuntimeWarning,
             match="invalid value encountered in multiply"):
              assert_equal(stats.invgauss.isf(1e-17, mu=1.05) / 0.7, np.nan)
         # test if correct  out is returned for boundary values
-       # assert np.allclose(stats.invgauss.ppf([0, 0.5, 1, 2, np.nan], mu=1),
-       #                    [0, 0.67584131, np.inf, np.nan, np.nan],
-       #                    equal_nan=True, atol=1e-08)
+        with warnings.catch_warnings():
+            # because probabilities must be in the interval [0, 1] a
+            # RuntimeError warning is raised when passing NaN to the ppf
+            # function. So its necessary to silence these warnings to avoid
+            # CI build failure.
+            warnings.simplefilter('ignore', RuntimeWarning)
+            assert_allclose(stats.invgauss.ppf([0, 0.5, 1, 2, np.nan], mu=1),
+                            [0, 0.67584131, np.inf, np.nan, np.nan], atol=1e-08)
         # test if invalid values for the mean are detected
-        assert np.allclose(stats.invgauss.ppf(0.5, mu=[0, 1, 2]),
-                           [np.nan, 0.67584131, 1.02845978],
-                           equal_nan=True, atol=1e-08)
+        assert_allclose(stats.invgauss.ppf(0.5, mu=[0, 1, 2]),
+                        [np.nan, 0.67584131, 1.02845978], atol=1e-08)
 
 
 class TestLaplace:

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2258,14 +2258,14 @@ class TestInvgauss:
         # five-number summary of the absolute error
         fns = np.percentile(abs_error, [0, 25, 50, np.mean(abs_error), 75, 100])
         assert_allclose(fns, [0., 0., 8.13151629e-20, 0.,
-                        5.55111512e-17, 2.22044605e-16], atol=1e-15)
+                        5.55111512e-17, 2.22044605e-16], atol=1e-08)
 
         q = stats.invgauss.ppf(p, mu=1)
         q1 = stats.invgauss.ppf(stats.invgauss.cdf(q, mu=1), mu=1)
         rel_error = np.abs(q1 - q) / q
         fns2 = np.percentile(rel_error, [0, 25, 50, np.mean(rel_error), 75, 100])
         assert_allclose(fns2, [0., 0., 1.17819649e-16, 0.,
-                        3.50412747e-16, 1.68867330e-11], atol=1e-15)
+                        3.50412747e-16, 1.68867330e-11], atol=1e-08)
 
         # tests if algorithm does not diverge for small probabilities.
         assert_equal(stats.invgauss.ppf(0.00013, mu=1 / 3) * 3, 0.15039762631802803)
@@ -2277,10 +2277,10 @@ class TestInvgauss:
              assert_equal(stats.invgauss.isf(1e-17, mu=1.05) / 0.7, np.nan)
         # test if correct  out is returned for boundary values
         assert_allclose(stats.invgauss.ppf([0, 0.5, 1, 2, np.nan], mu=1),
-                        [0, 0.67584131, np.inf, np.nan, np.nan])
+                        [0, 0.67584131, np.inf, np.nan, np.nan], atol=1e-08)
         # test if invalid values for the mean are detected
         assert_allclose(stats.invgauss.ppf(0.5, mu=[0, 1, 2]),
-                        [np.nan, 0.67584131, 1.02845978])
+                        [np.nan, 0.67584131, 1.02845978], atol=1e-08)
 
 
 class TestLaplace:


### PR DESCRIPTION
#### Reference issue
Follow up to #13616 and closes #13666

#### What does this implement/fix?
This PR adds methods `ppf` and `isf` to `invgauss` distribution.

#### Additional information
This PR adds an implementation of `ppf` and `isf` for `invgauss` and while also improving the `pdf` method so that it is able to return the correct value when the mean is infinity. The implementation is described in [1]. The tests are based on the examples presented in the article.

References
----------
[1] Giner, Goknur and G. Smyth. “statmod: Probability Calculations for the Inverse Gaussian Distribution.” R J. 8 (2016): 339.