### PR TITLE
MAINT: add .theia/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 *.tmp
 *.vim
 tags
+.theia/
 
 # Compiled source #
 ###################


### PR DESCRIPTION
This avoids having an untracked file in Gitpod workspaces

[ci skip]

How this is now showing up:

<img width="297" alt="image" src="https://user-images.githubusercontent.com/98330/110539203-3a7d5f00-8125-11eb-99d7-3e265a0d5d1e.png">

