### PR TITLE
ENH Small improvements for LSQR with damp

### DIFF
--- a/scipy/sparse/linalg/isolve/lsqr.py
+++ b/scipy/sparse/linalg/isolve/lsqr.py
@@ -525,26 +525,26 @@ def lsqr(A, b, damp=0.0, atol=1e-8, btol=1e-8, conlim=1e8,
         if test1 <= rtol:
             istop = 1
 
-        # See if it is time to print something.
-        prnt = False
-        if n <= 40:
-            prnt = True
-        if itn <= 10:
-            prnt = True
-        if itn >= iter_lim-10:
-            prnt = True
-        # if itn%10 == 0: prnt = True
-        if test3 <= 2*ctol:
-            prnt = True
-        if test2 <= 10*atol:
-            prnt = True
-        if test1 <= 10*rtol:
-            prnt = True
-        if istop != 0:
-            prnt = True
+        if show:
+            # See if it is time to print something.
+            prnt = False
+            if n <= 40:
+                prnt = True
+            if itn <= 10:
+                prnt = True
+            if itn >= iter_lim-10:
+                prnt = True
+            # if itn%10 == 0: prnt = True
+            if test3 <= 2*ctol:
+                prnt = True
+            if test2 <= 10*atol:
+                prnt = True
+            if test1 <= 10*rtol:
+                prnt = True
+            if istop != 0:
+                prnt = True
 
-        if prnt:
-            if show:
+            if prnt:
                 str1 = '%6g %12.5e' % (itn, x[0])
                 str2 = ' %10.3e %10.3e' % (r1norm, r2norm)
                 str3 = '  %8.1e %8.1e' % (test1, test2)

--- a/scipy/sparse/linalg/isolve/lsqr.py
+++ b/scipy/sparse/linalg/isolve/lsqr.py
@@ -317,13 +317,13 @@ def lsqr(A, b, damp=0.0, atol=1e-8, btol=1e-8, conlim=1e8,
     var = np.zeros(n)
 
     msg = ('The exact solution is  x = 0                              ',
-         'Ax - b is small enough, given atol, btol                  ',
-         'The least-squares solution is good enough, given atol     ',
-         'The estimate of cond(Abar) has exceeded conlim            ',
-         'Ax - b is small enough for this machine                   ',
-         'The least-squares solution is good enough for this machine',
-         'Cond(Abar) seems to be too large for this machine         ',
-         'The iteration limit has been reached                      ')
+           'Ax - b is small enough, given atol, btol                  ',
+           'The least-squares solution is good enough, given atol     ',
+           'The estimate of cond(Abar) has exceeded conlim            ',
+           'Ax - b is small enough for this machine                   ',
+           'The least-squares solution is good enough for this machine',
+           'Cond(Abar) seems to be too large for this machine         ',
+           'The iteration limit has been reached                      ')
 
     if show:
         print(' ')
@@ -353,10 +353,8 @@ def lsqr(A, b, damp=0.0, atol=1e-8, btol=1e-8, conlim=1e8,
     cs2 = -1
     sn2 = 0
 
-    """
-    Set up the first vectors u and v for the bidiagonalization.
-    These satisfy  beta*u = b - A*x,  alfa*v = A'*u.
-    """
+    # Set up the first vectors u and v for the bidiagonalization.
+    # These satisfy  beta*u = b - A*x,  alfa*v = A'*u.
     u = b
     bnorm = np.linalg.norm(b)
     if x0 is None:
@@ -408,12 +406,10 @@ def lsqr(A, b, damp=0.0, atol=1e-8, btol=1e-8, conlim=1e8,
     # Main iteration loop.
     while itn < iter_lim:
         itn = itn + 1
-        """
-        %     Perform the next step of the bidiagonalization to obtain the
-        %     next  beta, u, alfa, v.  These satisfy the relations
-        %                beta*u  =  a*v   -  alfa*u,
-        %                alfa*v  =  A'*u  -  beta*v.
-        """
+        # Perform the next step of the bidiagonalization to obtain the
+        # next  beta, u, alfa, v. These satisfy the relations
+        #     beta*u  =  a*v   -  alfa*u,
+        #     alfa*v  =  A'*u  -  beta*v.
         u = A.matvec(v) - alfa * u
         beta = np.linalg.norm(u)
 

--- a/scipy/sparse/linalg/isolve/lsqr.py
+++ b/scipy/sparse/linalg/isolve/lsqr.py
@@ -415,7 +415,7 @@ def lsqr(A, b, damp=0.0, atol=1e-8, btol=1e-8, conlim=1e8,
 
         if beta > 0:
             u = (1/beta) * u
-            anorm = sqrt(anorm**2 + alfa**2 + beta**2 + damp**2)
+            anorm = sqrt(anorm**2 + alfa**2 + beta**2 + dampsq)
             v = A.rmatvec(u) - beta * v
             alfa = np.linalg.norm(v)
             if alfa > 0:
@@ -423,7 +423,7 @@ def lsqr(A, b, damp=0.0, atol=1e-8, btol=1e-8, conlim=1e8,
 
         # Use a plane rotation to eliminate the damping parameter.
         # This alters the diagonal (rhobar) of the lower-bidiagonal matrix.
-        rhobar1 = sqrt(rhobar**2 + damp**2)
+        rhobar1 = sqrt(rhobar**2 + dampsq)
         cs1 = rhobar / rhobar1
         sn1 = damp / rhobar1
         psi = sn1 * phibar

--- a/scipy/sparse/linalg/isolve/lsqr.py
+++ b/scipy/sparse/linalg/isolve/lsqr.py
@@ -423,11 +423,16 @@ def lsqr(A, b, damp=0.0, atol=1e-8, btol=1e-8, conlim=1e8,
 
         # Use a plane rotation to eliminate the damping parameter.
         # This alters the diagonal (rhobar) of the lower-bidiagonal matrix.
-        rhobar1 = sqrt(rhobar**2 + dampsq)
-        cs1 = rhobar / rhobar1
-        sn1 = damp / rhobar1
-        psi = sn1 * phibar
-        phibar = cs1 * phibar
+        if damp > 0:
+            rhobar1 = sqrt(rhobar**2 + dampsq)
+            cs1 = rhobar / rhobar1
+            sn1 = damp / rhobar1
+            psi = sn1 * phibar
+            phibar = cs1 * phibar
+        else:
+            # cs1 = 1 and sn1 = 0
+            rhobar1 = rhobar
+            psi = 0.
 
         # Use a plane rotation to eliminate the subdiagonal element (beta)
         # of the lower-bidiagonal matrix, giving an upper-bidiagonal matrix.
@@ -481,10 +486,13 @@ def lsqr(A, b, damp=0.0, atol=1e-8, btol=1e-8, conlim=1e8,
         #    Estimate r1norm from
         #    r1norm = sqrt(r2norm^2 - damp^2*||x||^2).
         # Although there is cancellation, it might be accurate enough.
-        r1sq = rnorm**2 - dampsq * xxnorm
-        r1norm = sqrt(abs(r1sq))
-        if r1sq < 0:
-            r1norm = -r1norm
+        if damp > 0:
+            r1sq = rnorm**2 - dampsq * xxnorm
+            r1norm = sqrt(abs(r1sq))
+            if r1sq < 0:
+                r1norm = -r1norm
+        else:
+            r1norm = rnorm
         r2norm = rnorm
 
         # Now use these norms to estimate certain other quantities,

--- a/scipy/sparse/linalg/isolve/tests/test_lsqr.py
+++ b/scipy/sparse/linalg/isolve/tests/test_lsqr.py
@@ -35,6 +35,20 @@ def test_basic():
     xo = X[0]
     assert_(norm(svx - xo) < 1e-5)
 
+    # Now the same but with damp > 0.
+    # This is equivalent to solving extented system:
+    # ( G      ) * x = ( b )
+    # ( damp*I )       ( 0 )
+    damp = 1.5
+    X = lsqr(G, b, damp=damp, show=show, atol=tol, btol=tol, iter_lim=maxit)
+
+    Gext = np.r_[G, damp * np.eye(G.shape[1])]
+    bext = np.r_[b, np.zeros(G.shape[1])]
+    svx, _, _, _ = np.linalg.lstsq(Gext, bext, rcond=None)
+    xo = X[0]
+    assert_(norm(svx - xo) < 1e-5)
+
+
 def test_gh_2466():
     row = np.array([0, 0])
     col = np.array([0, 1])
@@ -127,8 +141,8 @@ if __name__ == "__main__":
     print(" ||x||  %9.4e  ||r|| %9.4e  ||Ar||  %9.4e " % (chio, phio, psio))
     print("Residual norms computed directly:")
     print(" ||x||  %9.4e  ||r|| %9.4e  ||Ar||  %9.4e" % (norm(xo),
-                                                          norm(G*xo - b),
-                                                          norm(G.T*(G*xo-b))))
+                                                         norm(G*xo - b),
+                                                         norm(G.T*(G*xo-b))))
     print("Direct solution norms:")
     print(" ||x||  %9.4e  ||r|| %9.4e " % (norm(svx), norm(G*svx - b)))
     print("")

--- a/scipy/sparse/linalg/isolve/tests/test_lsqr.py
+++ b/scipy/sparse/linalg/isolve/tests/test_lsqr.py
@@ -1,6 +1,7 @@
 import numpy as np
-from numpy.testing import (assert_, assert_equal, assert_almost_equal,
-                           assert_array_almost_equal)
+from numpy.testing import (assert_, assert_array_equal, assert_allclose,
+                           assert_almost_equal, assert_array_almost_equal,
+                           assert_equal)
 
 import scipy.sparse
 import scipy.sparse.linalg
@@ -28,25 +29,24 @@ maxit = None
 
 def test_basic():
     b_copy = b.copy()
-    X = lsqr(G, b, show=show, atol=tol, btol=tol, iter_lim=maxit)
-    assert_(np.all(b_copy == b))
+    xo, *_ = lsqr(G, b, show=show, atol=tol, btol=tol, iter_lim=maxit)
+    assert_array_equal(b_copy, b)
 
     svx = np.linalg.solve(G, b)
-    xo = X[0]
-    assert_(norm(svx - xo) < 1e-5)
+    assert_allclose(xo, svx, atol=tol, rtol=tol)
 
     # Now the same but with damp > 0.
-    # This is equivalent to solving extented system:
+    # This is equivalent to solving the extented system:
     # ( G      ) * x = ( b )
     # ( damp*I )       ( 0 )
     damp = 1.5
-    X = lsqr(G, b, damp=damp, show=show, atol=tol, btol=tol, iter_lim=maxit)
+    xo, *_ = lsqr(
+        G, b, damp=damp, show=show, atol=tol, btol=tol, iter_lim=maxit)
 
     Gext = np.r_[G, damp * np.eye(G.shape[1])]
     bext = np.r_[b, np.zeros(G.shape[1])]
-    svx, _, _, _ = np.linalg.lstsq(Gext, bext, rcond=None)
-    xo = X[0]
-    assert_(norm(svx - xo) < 1e-5)
+    svx, *_ = np.linalg.lstsq(Gext, bext, rcond=None)
+    assert_allclose(xo, svx, atol=tol, rtol=tol)
 
 
 def test_gh_2466():


### PR DESCRIPTION
#### What does this implement/fix?
This PR does 3 small improvements to LSQR:

- Use `dampsq = damp**2`
  `dampsq` was already defined but never used.
- Treat `damp = 0` specially.
- Put comments as comments, not as strings in code.