### PR TITLE
DOC: Add cKDTree note comparing it with KDTree

### DIFF
--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -423,6 +423,13 @@ cdef class cKDTree:
     which can be used to rapidly look up the nearest neighbors of any
     point.
 
+    .. note::
+       `cKDTree` is functionally identical to `KDTree`. Prior to SciPy
+       v1.6.0, `cKDTree` had better performance and slightly different
+       functionality but now the two names exist only for
+       backward-compatibility reasons. If compatibility with SciPy < 1.6 is not
+       a concern, prefer `KDTree`.
+
     Parameters
     ----------
     data : array_like, shape (n,m)


### PR DESCRIPTION
#### Reference issue
https://github.com/scipy/scipy/issues/8923#issuecomment-796924434

#### What does this implement/fix?
Add note to `cKDTree` about current and historic differences from `KDTree`. I'm using a note directive near the top instead of putting it in the notes section to draw more attention to it.