### PR TITLE
DOC Adds pythran to the quickstart contributing guide

### DIFF
--- a/doc/source/dev/contributor/quickstart_mac.rst
+++ b/doc/source/dev/contributor/quickstart_mac.rst
@@ -46,9 +46,9 @@ Building SciPy
 
 #. Enter ``conda create --name scipydev`` to create an empty virtual environment named ``scipydev`` (or another name that you prefer). This tells ``conda`` to create a new, empty environment for our packages. Activate the environment with ``conda activate scipydev``. Note that you'll need to have this virtual environment active whenever you want to work with the development version of SciPy.
 
-#. Enter ``conda config --env --add channels conda-forge`` to tell Anaconda the source we want for our packages. Then enter ``conda install python=3.8 numpy pybind11 cython pytest compilers sphinx matplotlib mypy`` to install the following packages:
+#. Enter ``conda config --env --add channels conda-forge`` to tell Anaconda the source we want for our packages. Then enter ``conda install python=3.8 numpy pybind11 cython pythran pytest compilers sphinx matplotlib mypy`` to install the following packages:
 
-   * ``numpy pybind11 cython pytest`` are four packages that SciPy depends on.
+   * ``numpy pybind11 cython pythran pytest`` are four packages that SciPy depends on.
 
    * ``compilers`` holds compilers used to build SciPy's Fortran, C, and C++ source code.
 

--- a/doc/source/dev/contributor/quickstart_ubuntu.rst
+++ b/doc/source/dev/contributor/quickstart_ubuntu.rst
@@ -45,9 +45,9 @@ Building SciPy
 
       If ``conda`` is not a recognized command, try restarting your terminal. If it is still not recognized, please see "Should I add Anaconda to the macOS or Linux PATH?" in the `Anaconda FAQ`_.
 
-#. Enter ``conda create --name scipydev python=3.8 numpy pybind11 cython pytest gfortran_linux-64 gxx_linux-64 sphinx matplotlib mypy git``. |br| This tells ``conda`` to create a virtual environment named ``scipydev`` (or another name that you prefer) with several packages.
+#. Enter ``conda create --name scipydev python=3.8 numpy pybind11 cython pythran pytest gfortran_linux-64 gxx_linux-64 sphinx matplotlib mypy git``. |br| This tells ``conda`` to create a virtual environment named ``scipydev`` (or another name that you prefer) with several packages.
 
-   * ``numpy pybind11 cython pytest`` are four packages that SciPy depends on.
+   * ``numpy pybind11 cython pythran pytest`` are four packages that SciPy depends on.
 
    * ``gfortran_linux-64 gxx_linux-64`` are compilers used to build SciPy's Fortran, C, and C++ source code.
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

<s>With `SCIPY_USE_PYTHRAN` on by default:

https://github.com/scipy/scipy/blob/b0936fe127983c4485c1d44a536524245686ba69/scipy/optimize/setup.py#L100

the contributing guide needs to include `pythran` as a build dependency.</s>

**Edit:** Just noticed https://github.com/scipy/scipy/pull/13681 resolves this issue.