### PR TITLE
BUG: mmwrite correctly serializes non skew-symmetric arrays

### DIFF
--- a/scipy/io/mmio.py
+++ b/scipy/io/mmio.py
@@ -357,25 +357,31 @@ class MMFile:
                 for ((i, j), aij) in a.items():
                     if i > j:
                         aji = a[j, i]
-                        yield (aij, aji)
+                        yield (aij, aji, False)
+                    elif i == j:
+                        yield (aij, aij, True)
 
         # non-sparse input
         else:
             # define iterator over symmetric pair entries
             def symm_iterator():
                 for j in range(n):
-                    for i in range(j+1, n):
+                    for i in range(j, n):
                         aij, aji = a[i][j], a[j][i]
-                        yield (aij, aji)
+                        yield (aij, aji, i == j)
 
         # check for symmetry
-        for (aij, aji) in symm_iterator():
-            if issymm and aij != aji:
-                issymm = False
-            if isskew and aij != -aji:
+        # yields aij, aji, is_diagonal
+        for (aij, aji, is_diagonal) in symm_iterator():
+            if isskew and is_diagonal and aij != 0:
                 isskew = False
-            if isherm and aij != conj(aji):
-                isherm = False
+            else:
+                if issymm and aij != aji:
+                    issymm = False
+                if isskew and aij != -aji:
+                    isskew = False
+                if isherm and aij != conj(aji):
+                    isherm = False
             if not (issymm or isskew or isherm):
                 break
 

--- a/scipy/io/tests/test_mmio.py
+++ b/scipy/io/tests/test_mmio.py
@@ -140,6 +140,7 @@ class TestMMIOArray(object):
         self.check(array([[1, 2], [-2, 99.]], dtype=np.float32),
                    (2, 2, 4, 'array', 'real', 'general'))
 
+
 class TestMMIOSparseCSR(TestMMIOArray):
     def setup_method(self):
         self.tmpdir = mkdtemp()

--- a/scipy/io/tests/test_mmio.py
+++ b/scipy/io/tests/test_mmio.py
@@ -132,6 +132,14 @@ class TestMMIOArray(object):
         with pytest.raises(ValueError, match='not of length 2'):
             scipy.io.mmread(io.BytesIO(text))
 
+    @pytest.mark.parametrize("dtype, typeval", [
+        (np.int32, 'integer'),
+        (np.float32, 'real'),
+    ])
+    def test_gh13634_non_skew_symmetric(self, dtype, typeval):
+        self.check_exact(array([[1, 2], [-2, 99]], dtype=dtype),
+                         (2, 2, 4, 'array', typeval, 'general'))
+
 
 class TestMMIOSparseCSR(TestMMIOArray):
     def setup_method(self):
@@ -218,12 +226,12 @@ class TestMMIOSparseCSR(TestMMIOArray):
                          (2, 2, 3, 'coordinate', typeval, 'symmetric'))
 
     def test_simple_skew_symmetric_integer(self):
-        self.check_exact(scipy.sparse.csr_matrix([[1, 2], [-2, 4]]),
-                         (2, 2, 3, 'coordinate', 'integer', 'skew-symmetric'))
+        self.check_exact(scipy.sparse.csr_matrix([[0, 2], [-2, 0]]),
+                         (2, 2, 1, 'coordinate', 'integer', 'skew-symmetric'))
 
     def test_simple_skew_symmetric_float(self):
-        self.check(scipy.sparse.csr_matrix(array([[1, 2], [-2.0, 4]], 'f')),
-                   (2, 2, 3, 'coordinate', 'real', 'skew-symmetric'))
+        self.check(scipy.sparse.csr_matrix(array([[0, 2], [-2.0, 0]], 'f')),
+                   (2, 2, 1, 'coordinate', 'real', 'skew-symmetric'))
 
     def test_simple_hermitian_complex(self):
         self.check(scipy.sparse.csr_matrix([[1, 2+3j], [2-3j, 4]]),
@@ -251,6 +259,14 @@ class TestMMIOSparseCSR(TestMMIOArray):
         assert_equal(mminfo(self.fn), info)
         b = mmread(self.fn)
         assert_array_almost_equal(p, b.todense())
+
+    @pytest.mark.parametrize("dtype, typeval", [
+        (np.int32, 'integer'),
+        (np.float32, 'real'),
+    ])
+    def test_gh13634_non_skew_symmetric(self, dtype, typeval):
+        a = scipy.sparse.csr_matrix([[1, 2], [-2, 99]], dtype=dtype)
+        self.check_exact(a, (2, 2, 4, 'coordinate', typeval, 'general'))
 
 
 _32bit_integer_dense_example = '''\

--- a/scipy/io/tests/test_mmio.py
+++ b/scipy/io/tests/test_mmio.py
@@ -265,7 +265,7 @@ class TestMMIOSparseCSR(TestMMIOArray):
         self.check_exact(a, (2, 2, 4, 'coordinate', 'integer', 'general'))
 
     def test_gh13634_non_skew_symmetric_float(self):
-        a = scipy.sparse.csr_matrix([[1, 2], [-2, 99]], dtype=np.float32)
+        a = scipy.sparse.csr_matrix([[1, 2], [-2, 99.]], dtype=np.float32)
         self.check(a, (2, 2, 4, 'coordinate', 'real', 'general'))
 
 

--- a/scipy/io/tests/test_mmio.py
+++ b/scipy/io/tests/test_mmio.py
@@ -132,14 +132,13 @@ class TestMMIOArray(object):
         with pytest.raises(ValueError, match='not of length 2'):
             scipy.io.mmread(io.BytesIO(text))
 
-    @pytest.mark.parametrize("dtype, typeval", [
-        (np.int32, 'integer'),
-        (np.float32, 'real'),
-    ])
-    def test_gh13634_non_skew_symmetric(self, dtype, typeval):
-        self.check_exact(array([[1, 2], [-2, 99]], dtype=dtype),
-                         (2, 2, 4, 'array', typeval, 'general'))
+    def test_gh13634_non_skew_symmetric_int(self):
+        self.check_exact(array([[1, 2], [-2, 99]], dtype=np.int32),
+                         (2, 2, 4, 'array', 'integer', 'general'))
 
+    def test_gh13634_non_skew_symmetric_float(self):
+        self.check(array([[1, 2], [-2, 99.]], dtype=np.float32),
+                   (2, 2, 4, 'array', 'real', 'general'))
 
 class TestMMIOSparseCSR(TestMMIOArray):
     def setup_method(self):
@@ -260,13 +259,13 @@ class TestMMIOSparseCSR(TestMMIOArray):
         b = mmread(self.fn)
         assert_array_almost_equal(p, b.todense())
 
-    @pytest.mark.parametrize("dtype, typeval", [
-        (np.int32, 'integer'),
-        (np.float32, 'real'),
-    ])
-    def test_gh13634_non_skew_symmetric(self, dtype, typeval):
-        a = scipy.sparse.csr_matrix([[1, 2], [-2, 99]], dtype=dtype)
-        self.check_exact(a, (2, 2, 4, 'coordinate', typeval, 'general'))
+    def test_gh13634_non_skew_symmetric_int(self):
+        a = scipy.sparse.csr_matrix([[1, 2], [-2, 99]], dtype=np.int32)
+        self.check_exact(a, (2, 2, 4, 'coordinate', 'integer', 'general'))
+
+    def test_gh13634_non_skew_symmetric_float(self):
+        a = scipy.sparse.csr_matrix([[1, 2], [-2, 99]], dtype=np.float32)
+        self.check(a, (2, 2, 4, 'coordinate', 'real', 'general'))
 
 
 _32bit_integer_dense_example = '''\


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes https://github.com/scipy/scipy/issues/13634

#### What does this implement/fix?
This PR updates `symm_iterator` to generate diagonal entries used to check for skew-symmetry.

#### Additional information
<!--Any additional information you think is important.-->
`test_simple_skew_symmetric_integer` and `test_simple_skew_symmetric_float` were updated with actual skew-symmetric arrays.