### PR TITLE
FIX: fix numerical overflow in gamma.isf method

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -2644,6 +2644,9 @@ class gamma_gen(rv_continuous):
     def _ppf(self, q, a):
         return sc.gammaincinv(a, q)
 
+    def _isf(self, q, a):
+        return sc.gammainccinv(a, q)
+
     def _stats(self, a):
         return a, a, 2.0/np.sqrt(a), 6.0/a
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2666,7 +2666,6 @@ class TestGamma(object):
         #                           regularized=True))
         # 1.000000000000028e-50
         #
-.```
         assert np.isclose(stats.gamma.isf(1e-17, 1),
                           39.14394658089878, atol=1e-14)
         assert np.isclose(stats.gamma.isf(1e-50, 100),

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2649,6 +2649,13 @@ class TestGamma(object):
         x = [0.1, 0.5, 0.6]
         assert_raises(TypeError, stats.gamma.fit, x, floc=0, plate="shrimp")
 
+    def test_isf(self):
+        # test cases for when the probability is very small. se gh-13664
+        assert np.isclose(stats.gamma.isf(1e-17, 1),
+                          39.14394658089878, atol=1e-14)
+        assert np.isclose(stats.gamma.isf(1e-50, 100),
+                          330.6557590436547, atol=1e-13)
+
 
 class TestChi2(object):
     # regression tests after precision improvements, ticket:1041, not verified

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2650,7 +2650,23 @@ class TestGamma(object):
         assert_raises(TypeError, stats.gamma.fit, x, floc=0, plate="shrimp")
 
     def test_isf(self):
-        # test cases for when the probability is very small. se gh-13664
+        # Test cases for when the probability is very small. See gh-13664.
+        # The expected values can be checked with mpmath.  With mpmath,
+        # the survival function sf(x, k) can be computed as
+        #
+        #     mpmath.gammainc(k, x, mpmath.inf, regularized=True)
+        #
+        # Here we have:
+        #
+        # >>> mpmath.mp.dps = 60
+        # >>> float(mpmath.gammainc(1, 39.14394658089878, mpmath.inf,
+        # ...                       regularized=True))
+        # 9.99999999999999e-18
+        # >>> float(mpmath.gammainc(100, 330.6557590436547, mpmath.inf,
+        #                           regularized=True))
+        # 1.000000000000028e-50
+        #
+.```
         assert np.isclose(stats.gamma.isf(1e-17, 1),
                           39.14394658089878, atol=1e-14)
         assert np.isclose(stats.gamma.isf(1e-50, 100),


### PR DESCRIPTION
closes #13664 

this PR fixes the overflow issue of `stats.gamma.isf` when computing quantiles using a very small probability.