### PR TITLE
BUG: fix cosine distance range to 0-2

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -772,7 +772,8 @@ def cosine(u, v, w=None):
     """
     # cosine distance is also referred to as 'uncentered correlation',
     #   or 'reflective correlation'
-    return correlation(u, v, w=w, centered=False)
+    # clamp the result to 0-2
+    return max(0, min(correlation(u, v, w=w, centered=False), 2.0))
 
 
 def hamming(u, v, w=None):


### PR DESCRIPTION
#### Reference issue
Closes #13454

#### What does this implement/fix?
This PR fix the issue 'cosine distance can be greater than 2' . In `distance.cosine` , I clamp the result to the range 0~2.



