### PR TITLE
BUG: fix scipy.odr to consider given delta0 argument

### DIFF
--- a/scipy/odr/odrpack.py
+++ b/scipy/odr/odrpack.py
@@ -1086,7 +1086,7 @@ class ODR(object):
                  'ndigit', 'taufac', 'sstol', 'partol', 'maxit', 'stpb',
                  'stpd', 'sclb', 'scld', 'work', 'iwork']
 
-        if self.delta0 is not None and self.job % 1000 // 10 == 1:
+        if self.delta0 is not None and (self.job // 10000) % 10 == 0:
             # delta0 provided and fit is not a restart
             self._gen_work()
 


### PR DESCRIPTION
#### Reference issue
Closes #13686

#### What does this implement/fix?
Fix such that scipy.odr considers the given numpy.array for delta0.
As a result, for a non-zero delta0 array ODR's output is non-zero for SUM OF SQUARED WEIGHTED DELTAS:

```
 --- INITIAL WEIGHTED SUM OF SQUARES        =                    1.57660852D-04
         SUM OF SQUARED WEIGHTED DELTAS     =   3.60000000D-05
         SUM OF SQUARED WEIGHTED EPSILONS   =   1.21660852D-04
```

Before, different from what has been described in the table on page 31 of the ODRPACK's user's guide, not I5 has been checked for 0 ("not a restart").
Instead, a here meaningless combination of I2 and I3 has been checked.