### PR TITLE
MAINT: backport version pins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [build-system]
 requires = [
-    "wheel",
+    "wheel<0.37.0",
     "setuptools<=51.0.0",
-    "Cython>=0.29.18",
-    "pybind11>=2.4.3",
+    "Cython>=0.29.18,<3.0",
+    "pybind11>=2.4.3,<2.7.0",
 
     # NumPy dependencies - to update these, sync from
     # https://github.com/scipy/oldest-supported-numpy/, and then

--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -130,10 +130,13 @@ else:
     from . import _distributor_init
 
     from scipy._lib import _pep440
-    if _pep440.parse(__numpy_version__) < _pep440.Version('1.16.5'):
+    np_minversion = '1.16.5'
+    np_maxversion = '1.23.0'
+    if (_pep440.parse(__numpy_version__) < _pep440.Version(np_minversion) or
+            _pep440.parse(__numpy_version__) >= _pep440.Version(np_maxversion)):
         import warnings
-        warnings.warn("NumPy 1.16.5 or above is required for this version of "
-                      "SciPy (detected version %s)" % __numpy_version__,
+        warnings.warn(f"A NumPy version >={np_minversion} and <{np_maxversion} is required for this version of "
+                      f"SciPy (detected version {__numpy_version__})",
                       UserWarning)
 
     del _pep440

--- a/setup.py
+++ b/setup.py
@@ -517,7 +517,7 @@ def setup_package():
     np_minversion = '1.16.5'
     np_maxversion = '1.23.0'
     python_minversion = '3.7'
-    python_maxversion = '3.9'
+    python_maxversion = '3.10'
     if IS_RELEASE_BRANCH:
         req_np = 'numpy>={},<{}'.format(np_minversion, np_maxversion)
         req_py = '>={},<{}'.format(python_minversion, python_maxversion)

--- a/setup.py
+++ b/setup.py
@@ -517,7 +517,7 @@ def setup_package():
     np_minversion = '1.16.5'
     np_maxversion = '1.23.0'
     python_minversion = '3.7'
-    python_maxversion = '3.10'
+    python_maxversion = '3.9'
     if IS_RELEASE_BRANCH:
         req_np = 'numpy>={},<{}'.format(np_minversion, np_maxversion)
         req_py = '>={},<{}'.format(python_minversion, python_maxversion)

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ MAJOR = 1
 MINOR = 6
 MICRO = 2
 ISRELEASED = False
+IS_RELEASE_BRANCH = True
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
 
@@ -513,6 +514,17 @@ def configuration(parent_package='', top_path=None):
 
 
 def setup_package():
+    np_minversion = '1.16.5'
+    np_maxversion = '1.23.0'
+    python_minversion = '3.7'
+    python_maxversion = '3.10'
+    if IS_RELEASE_BRANCH:
+        req_np = 'numpy>={},<{}'.format(np_minversion, np_maxversion)
+        req_py = '>={},<{}'.format(python_minversion, python_maxversion)
+    else:
+        req_np = 'numpy>={}'.format(np_minversion)
+        req_py = '>={}'.format(python_minversion)
+
     # Rewrite the version file every time
     write_version_py()
 
@@ -538,10 +550,8 @@ def setup_package():
         classifiers=[_f for _f in CLASSIFIERS.split('\n') if _f],
         platforms=["Windows", "Linux", "Solaris", "Mac OS-X", "Unix"],
         test_suite='nose.collector',
-        install_requires=[
-            'numpy>=1.16.5',
-        ],
-        python_requires='>=3.7',
+        install_requires=[req_np],
+        python_requires=req_py,
     )
 
     if "--force" in sys.argv:

--- a/tools/cythonize.py
+++ b/tools/cythonize.py
@@ -71,15 +71,28 @@ def process_pyx(fromfile, tofile, cwd):
             for line in pt:
                 if "cython" not in line.lower():
                     continue
-                _, line = line.split('=')
-                required_version, _ = line.split('"')
+                line = ''.join(line.split('=')[1:])  # get rid of "Cython>="
+                if ',<' in line:
+                    # There's an upper bound as well
+                    split_on = ',<'
+                    if ',<=' in line:
+                        split_on = ',<='
+                    min_required_version, max_required_version = line.split(split_on)
+                    max_required_version, _ = max_required_version.split('"')
+                else:
+                    min_required_version, _ = line.split('"')
+
                 break
             else:
                 raise ImportError()
 
-        if LooseVersion(cython_version) < LooseVersion(required_version):
+        # Note: we only check lower bound, for upper bound we rely on pip
+        # respecting pyproject.toml. Reason: we want to be able to build/test
+        # with more recent Cython locally or on master, upper bound is for
+        # sdist in a release.
+        if LooseVersion(cython_version) < LooseVersion(min_required_version):
             raise Exception('Building SciPy requires Cython >= {}, found '
-                            '{}'.format(required_version, cython_version))
+                            '{}'.format(min_required_version, cython_version))
 
     except ImportError:
         pass


### PR DESCRIPTION
* improve longevity of source builds of `1.6.x` series
by backporting the changes described in gh-12862 and
cap build-time/run-time dependency upper version bounds

@rgommers you may want to check this since it is my first time trying to cap the version bounds (assuming you want to start doing this with `1.6.x` instead of `1.7.x`)