### PR TITLE
DEV: scipy.interpolate b-splines (periodic case)

### DIFF
--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -668,11 +668,12 @@ def _woodbury_algorithm(A, ur, ll, b, k):
            and Brian P. Flannery, Numerical Recipes, 2007, Section 2.7.3
 
     '''
-    bs = int((k - 1) /2)
+    k_mod = k - k % 2
+    bs = int((k - 1) / 2) + (k + 1) % 2
 
     n = A.shape[1] + 1
-    U = np.zeros((n - 1, k - 1))
-    V = np.zeros((k - 1, n - 1)) # V transpose 
+    U = np.zeros((n - 1, k_mod))
+    V = np.zeros((k_mod, n - 1)) # V transpose 
 
     # upper right block 
     U[:bs, :bs] = ur
@@ -685,12 +686,12 @@ def _woodbury_algorithm(A, ur, ll, b, k):
     Z = solve_banded((bs, bs), A, U[:, 0]) # z0
     Z = np.expand_dims(Z, axis=0)
     
-    for i in range(1, k - 1):
+    for i in range(1, k_mod):
         zi = solve_banded((bs, bs), A, U[:, i])
         zi = np.expand_dims(zi, axis=0)
         Z = np.concatenate((Z, zi), axis=0)
 
-    H = np.linalg.inv(np.identity(k - 1) + V @ Z.T)
+    H = solve(np.identity(k_mod) + V @ Z.T, np.identity(k_mod))
 
     y = solve_banded((bs, bs), A, b)
     c = y - Z.T @ (H @ (V @ y))
@@ -702,6 +703,9 @@ def _periodic_knots(x, k):
     returns vector of nodes on circle
     '''
     xc = np.copy(x)
+    if k % 2 == 0:
+        dx = np.diff(xc)
+        xc[1: -1] -= dx[:-1] / 2 
     dx = np.diff(xc)
     t = np.zeros(len(xc) + 2 * k)
     t[:k] = [xc[0] - sum(dx[-i:]) for i in range(k, 0, -1)]
@@ -750,39 +754,47 @@ def _make_periodic_spline(x, y, t, k, axis):
     For now, this function works only for odd ``k``.
 
     '''
-    if k % 2 == 0:
-        raise NotImplementedError("Even k periodic case is not implemented yet.")    
     n = y.shape[0]
 
     if n <= k:
-        raise ValueError("n should be greater than k to form system.")
+        raise ValueError("Need at least k + 1 data points to fit a spline of degree k.")
     
-    # solving periodic case using Woodbury formula
-    # set up RHS
-    A = np.zeros((k, n - 1)) # matrix of diagonals suitable for 'solve_banded'
-    for i in range(n-1):
-        A[:,i] = _bspl.evaluate_all_bspl(t, k, x[i], i + k)[:-1][::-1]
-    offset = int((k-1)/2)
-    # upper right and lower left blocks of the original matrix
-    ur = np.zeros((offset,offset))
-    ll = np.zeros((offset,offset))
-    for i in range(1,offset + 1):
-        A[offset - i] = np.roll(A[offset - i],i)
-        if k % 2 == 1 or i < offset:
-            A[offset + i] = np.roll(A[offset + i], -i)
-            ur[-i:, i - 1] = np.copy(A[offset + i, -i:])
-        ll[-i, :i] = np.copy(A[offset - i, :i])
-    ur = ur.T
-    for i in range(1,offset):
-        ll[:, i] = np.roll(ll[:, i], i)
-        ur[:, -i-1] = np.roll(ur[:, -i - 1], -i)
+    nt = len(t) - k - 1
+
+    # size of block elements
+    kul = int(k / 2)
+    
+    # kl = ku = k
+    ab = np.zeros((3 * k + 1, nt), dtype=np.float_, order='F')
+
+    # upper right and lower left blocks
+    ur = np.zeros((kul, kul))
+    ll = np.zeros_like(ur)
+    
+    # `offset` is made to shift all the non-zero elements to the end of the
+    # matrix
+    _bspl._colloc(x, t, k, ab, offset=k)
+    
+    # remove zeros before the matrix
+    ab = ab[-k - (k + 1) % 2:, :]
+    
+    # The least elements in rows (except repetitions) are diagonals
+    # of block matricies. Upper right matrix is an upper triangular
+    # matrix while lower left is a lower triangular one.
+    for i in range(kul):
+        ur += np.diag(ab[-i - 1, i: kul], k=i)
+        ll += np.diag(ab[i, -kul - (k % 2): n - 1 + 2 * kul - i], k=-i)
+
+    # remove elements that occure in the last point
+    # (first and last points are equivalent)
+    A = ab[:, kul: -k + kul]
 
     extradim = prod(y.shape[1:])
     y_new = y.reshape(n, extradim)
-    c = np.zeros((n + k - 1,extradim))
+    c = np.zeros((n + k - 1, extradim))
     for i in range(extradim):
         cc = _woodbury_algorithm(A, ur, ll, y_new[:, i][:-1], k)
-        c[:, i] = np.concatenate((cc[-offset:], cc, cc[:offset + 1]))
+        c[:, i] = np.concatenate((cc[-kul:], cc, cc[:kul + k % 2]))
     c = np.ascontiguousarray(c.reshape((n + k - 1,) + y.shape[1:]))
     return BSpline.construct_fast(t, c, k, axis=axis)
 
@@ -895,17 +907,17 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
 
     Build a B-spline curve with 2 dimensional y
     
-    >>> x = np.linspace(0,2*np.pi,10)
-    >>> y = np.array([np.sin(x),np.cos(x)])
+    >>> x = np.linspace(0, 2*np.pi, 10)
+    >>> y = np.array([np.sin(x), np.cos(x)])
 
     Periodic condition is satisfied because y coordinates of points on the ends
     are equivalent
 
     >>> ax = plt.axes(projection='3d')
-    >>> xx = np.linspace(0,2*np.pi,100)
-    >>> bspl = make_interp_spline(x,y,k=5,bc_type='periodic',axis=1)
-    >>> ax.plot3D(xx,*bspl(xx))
-    >>> ax.scatter3D(x,*y,color='red')
+    >>> xx = np.linspace(0, 2*np.pi, 100)
+    >>> bspl = make_interp_spline(x, y, k=5, bc_type='periodic', axis=1)
+    >>> ax.plot3D(xx, *bspl(xx))
+    >>> ax.scatter3D(x, *y, color='red')
     >>> plt.show()
 
     See Also
@@ -937,9 +949,9 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
 
     y = np.rollaxis(y, axis)    # now internally interp axis is zero
 
-    if bc_type == 'periodic' and not np.allclose(y[0],y[-1],atol=1e-15):
-        raise ValueError("First and last points does not match while periodic case"
-                        " expected")
+    if bc_type == 'periodic' and not np.allclose(y[0], y[-1], atol=1e-15):
+        raise ValueError("First and last points does not match while periodic case "
+                         "expected")
 
     # special-case k=0 right away
     if k == 0:
@@ -969,15 +981,15 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
     # come up with a sensible knot vector, if needed
     if t is None:
         if deriv_l is None and deriv_r is None:
-            if k == 2:
+            if bc_type == 'periodic':
+                t = _periodic_knots(x, k)
+            elif k == 2:
                 # OK, it's a bit ad hoc: Greville sites + omit
                 # 2nd and 2nd-to-last points, a la not-a-knot
                 t = (x[1:] + x[:-1]) / 2.
                 t = np.r_[(x[0],)*(k+1),
                            t[1:-1],
                            (x[-1],)*(k+1)]
-            elif bc_type == 'periodic':
-                t = _periodic_knots(x, k)
             else:
                 t = _not_a_knot(x, k)
         else:

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -673,7 +673,7 @@ def _woodbury_algorithm(A, ur, ll, b, k):
 
     n = A.shape[1] + 1
     U = np.zeros((n - 1, k_mod))
-    V = np.zeros((k_mod, n - 1)) # V transpose 
+    V = np.zeros((k_mod, n - 1))  # V transpose 
 
     # upper right block 
     U[:bs, :bs] = ur
@@ -683,7 +683,7 @@ def _woodbury_algorithm(A, ur, ll, b, k):
     U[-bs:, -bs:] = ll
     V[np.arange(bs) - bs, np.arange(bs)] = 1
     
-    Z = solve_banded((bs, bs), A, U[:, 0]) # z0
+    Z = solve_banded((bs, bs), A, U[:, 0])  # z0
     Z = np.expand_dims(Z, axis=0)
     
     for i in range(1, k_mod):
@@ -744,20 +744,19 @@ def _make_periodic_spline(x, y, t, k, axis):
     coefficients of a spline function are the same, respectively. It follows
     from the fact that all ``k-1`` derivatives are equal term by term at ends
     and that the matrix of the original system of linear equations is
-    non-degenerate. So, we can reduce the number of equations to ``n - 1`` (first
-    ``k-1`` equations could be reduced). Another trick of this implementation is
-    cyclic shift of values of B-splines due to equality of ``k`` unknown
-    coefficients. With this we can receive matrix of the system with upper right
-    and lower left ‘blocks’, and ``k`` diagonals.  It allows to use Woodbury
-    formula to optimize the computations.
-
-    For now, this function works only for odd ``k``.
+    non-degenerate. So, we can reduce the number of equations to ``n - 1``
+    (first ``k-1`` equations could be reduced). Another trick of this 
+    implementation is cyclic shift of values of B-splines due to equality of
+    ``k`` unknown coefficients. With this we can receive matrix of the system
+    with upper right and lower left blocks, and ``k`` diagonals.  It allows
+    to use Woodbury formula to optimize the computations.
 
     '''
     n = y.shape[0]
 
     if n <= k:
-        raise ValueError("Need at least k + 1 data points to fit a spline of degree k.")
+        raise ValueError("Need at least k + 1 data points to fit a spline "
+                         "of degree k.")
     
     nt = len(t) - k - 1
 
@@ -830,10 +829,10 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
            equivalent to ``bc_type=([(1, 0.0)], [(1, 0.0)])``.
         * ``"natural"``: The second derivatives at ends are zero. This is
           equivalent to ``bc_type=([(2, 0.0)], [(2, 0.0)])``.
-        * ``"not-a-knot"`` (default): The first and second segments are the same
-          polynomial. This is equivalent to having ``bc_type=None``.
-        * ``"periodic"``: The values and the first ``k-1`` derivatives at the ends
-          are equivalent (for odd ``k`` only).
+        * ``"not-a-knot"`` (default): The first and second segments are the
+          same polynomial. This is equivalent to having ``bc_type=None``.
+        * ``"periodic"``: The values and the first ``k-1`` derivatives at the
+          ends are equivalent.
 
     axis : int, optional
         Interpolation axis. Default is 0.
@@ -950,8 +949,8 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
     y = np.rollaxis(y, axis)    # now internally interp axis is zero
 
     if bc_type == 'periodic' and not np.allclose(y[0], y[-1], atol=1e-15):
-        raise ValueError("First and last points does not match while periodic case "
-                         "expected")
+        raise ValueError("First and last points does not match while "
+                         "periodic case expected")
 
     # special-case k=0 right away
     if k == 0:
@@ -974,9 +973,9 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
 
     k = operator.index(k)
 
-    if bc_type == 'periodic' and not t is None:
-        raise ValueError("For periodic case t is constructed automatically and "
-                        "can not be passed manually")
+    if bc_type == 'periodic' and t is not None:
+        raise ValueError("For periodic case t is constructed automatically "
+                         "and can not be passed manually")
 
     # come up with a sensible knot vector, if needed
     if t is None:

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -820,7 +820,7 @@ class TestInterp(object):
             b = make_interp_spline(self.xx, self.yy, k)
             assert_allclose(b(self.xx), self.yy, atol=1e-14, rtol=1e-14)
 
-    @pytest.mark.parametrize('k', [3, 5])
+    @pytest.mark.parametrize('k', [2, 3, 4, 5])
     def test_periodic(self, k):
         b = make_interp_spline(self.xx, self.yy, k=k, bc_type='periodic')
         assert_allclose(b(self.xx), self.yy, atol=1e-14, rtol=1e-14)
@@ -878,7 +878,7 @@ class TestInterp(object):
         t = np.zeros(n + 2 * k)
         assert_raises(ValueError, make_interp_spline, x, y, k, t, 'periodic')
 
-    @pytest.mark.parametrize('k', [3, 5])
+    @pytest.mark.parametrize('k', [2, 3, 4, 5])
     def test_periodic_splev(self, k):
         # comparision values of periodic b-spline with splev
         b = make_interp_spline(self.xx, self.yy, k=k, bc_type='periodic')
@@ -1209,14 +1209,13 @@ def make_interp_full_matr(x, y, t, k):
     return c
 
 
-# a helper for test_periodic_full_matrix
 def make_interp_per_full_matr(x, y, t, k):
     x, y, t = map(np.asarray, (x, y, t))
 
     n = x.size
     nt = t.size - k - 1
 
-    # have n conditions for nt coefficients; need nt-n derivatives
+    # have `n` conditions for `nt` coefficients; need nt-n derivatives
     assert nt - n == k - 1
 
     # LHS: the collocation matrix + derivatives at edges

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -841,13 +841,13 @@ class TestInterp(object):
         x = np.sort(x)
         x[0] = 0.
         x[-1] = 2 * np.pi
-        y = np.zeros((2,n))
+        y = np.zeros((2, n))
         y[0] = np.sin(x)
         y[1] = np.cos(x)
-        b = make_interp_spline(x, y, k=5, bc_type='periodic',axis=1)
+        b = make_interp_spline(x, y, k=5, bc_type='periodic', axis=1)
         for i in range(n):
-            assert_allclose(b(x[i]),y[:,i],atol=1e-14)
-        assert_allclose(b(x[0]),b(x[-1]),atol=1e-14)
+            assert_allclose(b(x[i]), y[:, i], atol=1e-14)
+        assert_allclose(b(x[0]), b(x[-1]), atol=1e-14)
 
     def test_periodic_points_exception(self):
         # not enough points for interpolation
@@ -864,7 +864,7 @@ class TestInterp(object):
         n = 8
         x = np.sort(np.random.random_sample(n))
         y = np.random.random_sample(n)
-        y[0] = y[-1] - 1 # to be sure that they are not equal
+        y[0] = y[-1] - 1  # to be sure that they are not equal
         assert_raises(ValueError, make_interp_spline, x, y, k, None, 
         'periodic')
 
@@ -1178,7 +1178,8 @@ class TestInterp(object):
                 else:
                     d[i, j:] = np.diagonal(a, offset=j)
             b = np.random.random(n)
-            assert_allclose(_woodbury_algorithm(d, ur, ll, b, k), np.linalg.solve(a, b), atol=1e-14)
+            assert_allclose(_woodbury_algorithm(d, ur, ll, b, k),
+                            np.linalg.solve(a, b), atol=1e-14)
 
 
 def make_interp_full_matr(x, y, t, k):
@@ -1209,6 +1210,7 @@ def make_interp_full_matr(x, y, t, k):
     return c
 
 
+### XXX: 'periodic' interp spline using full matrices
 def make_interp_per_full_matr(x, y, t, k):
     x, y, t = map(np.asarray, (x, y, t))
 
@@ -1225,7 +1227,7 @@ def make_interp_per_full_matr(x, y, t, k):
 
     for i in range(k-1):
         bb = _bspl.evaluate_all_bspl(t, k, x[0], k, nu=i+1)
-        A[i,:k+1] = bb
+        A[i, :k+1] = bb
         bb = _bspl.evaluate_all_bspl(t, k, x[-1], n + k - 1, nu=i+1)[:-1]
         A[i, -k:] = -bb
 

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -820,19 +820,29 @@ class TestInterp(object):
             b = make_interp_spline(self.xx, self.yy, k)
             assert_allclose(b(self.xx), self.yy, atol=1e-14, rtol=1e-14)
 
-    @pytest.mark.parametrize('k', [2, 3, 4, 5])
-    def test_periodic(self, k):
-        b = make_interp_spline(self.xx, self.yy, k=k, bc_type='periodic')
+    def test_periodic(self):
+        # k = 5 here for more derivatives
+        b = make_interp_spline(self.xx, self.yy, k=5, bc_type='periodic')
         assert_allclose(b(self.xx), self.yy, atol=1e-14, rtol=1e-14)
         # in periodic case it is expected equality of k-1 first
         # derivatives at the boundaries
-        for i in range(k):
+        for i in range(1, 5):
             assert_allclose(b(self.xx[0], nu=i), b(self.xx[-1], nu=i), atol=1e-11)
         # tests for axis=-1
-        b = make_interp_spline(self.xx, self.yy, k=k, bc_type='periodic', axis=-1)
+        b = make_interp_spline(self.xx, self.yy, k=5, bc_type='periodic', axis=-1)
         assert_allclose(b(self.xx), self.yy, atol=1e-14, rtol=1e-14)
-        for i in range(k):
+        for i in range(1, 5):
             assert_allclose(b(self.xx[0], nu=i), b(self.xx[-1], nu=i), atol=1e-11)
+
+    @pytest.mark.parametrize('k', [2, 3, 4, 5, 6, 7])
+    def test_periodic_random(self, k):
+        n = 8
+        np.random.seed(1234)
+        x = np.sort(np.random.random_sample(n) * 10)
+        y = np.random.random_sample(n) * 100
+        y[0] = y[-1]
+        b = make_interp_spline(x, y, k=k, bc_type='periodic')
+        assert_allclose(b(x), y, atol=1e-14)
 
     def test_periodic_axis(self):
         n = self.xx.shape[0]
@@ -865,8 +875,8 @@ class TestInterp(object):
         x = np.sort(np.random.random_sample(n))
         y = np.random.random_sample(n)
         y[0] = y[-1] - 1  # to be sure that they are not equal
-        assert_raises(ValueError, make_interp_spline, x, y, k, None, 
-        'periodic')
+        with assert_raises(ValueError):
+            make_interp_spline(x, y, k=k, bc_type='periodic')
 
     def test_periodic_knots_exception(self):
         # `periodic` case does not work with passed vector of knots
@@ -876,7 +886,8 @@ class TestInterp(object):
         x = np.sort(np.random.random_sample(n))
         y = np.random.random_sample(n)
         t = np.zeros(n + 2 * k)
-        assert_raises(ValueError, make_interp_spline, x, y, k, t, 'periodic')
+        with assert_raises(ValueError):
+            make_interp_spline(x, y, k, t, 'periodic')
 
     @pytest.mark.parametrize('k', [2, 3, 4, 5])
     def test_periodic_splev(self, k):
@@ -887,9 +898,9 @@ class TestInterp(object):
         assert_allclose(spl, b(self.xx), atol=1e-14)
 
         # comparison derivatives of periodic b-spline with splev
-        for i in range(1, k + 1):
+        for i in range(1, k):
             spl = splev(self.xx, tck, der=i)
-            assert_allclose(spl, b.derivative(i)(self.xx), atol=1e-10)
+            assert_allclose(spl, b(self.xx, nu=i), atol=1e-10)
 
     def test_periodic_cubic(self):
         # comparison values of cubic periodic b-spline with CubicSpline
@@ -900,8 +911,8 @@ class TestInterp(object):
     def test_periodic_full_matrix(self):
         # comparison values of cubic periodic b-spline with
         # solution of the system with full matrix
-        b = make_interp_spline(self.xx, self.yy, k=3, bc_type='periodic')
         k = 3
+        b = make_interp_spline(self.xx, self.yy, k=k, bc_type='periodic')
         t = _periodic_knots(self.xx, k)
         c = make_interp_per_full_matr(self.xx, self.yy, t, k)
         b1 = np.vectorize(lambda x: _naive_eval(x, t, c, k))


### PR DESCRIPTION
#### What does this implement/fix?
We developed and implemented an algorithm for computing coefficients for B-splines of degree ``k`` in periodic case.  The algorithm builds a matrix with ``k`` diagonals and upper right and lower left blocks of size ``(k-1)/2 x (k-1)/2`` (for now ``k`` is assumed to be odd). This matrix is stored in a form suitable for ``scipy.linalg.solve_banded``.  Due to the special form of matrix, it is possible to use Woodbury formula to optimize the computations. 

#### Additional information
In periodic case, ordinates and values of the first ``k-1`` derivatives are equal at the ends. 