### PR TITLE
DEP: Clean up spent deprecations in spatial.distance

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -122,46 +122,6 @@ from ..linalg import norm
 from ..special import rel_entr
 
 
-def _args_to_kwargs_xdist(args, kwargs, metric, func_name):
-    """
-    Convert legacy positional arguments to keyword arguments for pdist/cdist.
-    """
-    if not args:
-        return kwargs
-
-    if (callable(metric) and metric not in [
-            braycurtis, canberra, chebyshev, cityblock, correlation, cosine,
-            dice, euclidean, hamming, jaccard, jensenshannon, kulsinski,
-            mahalanobis, matching, minkowski, rogerstanimoto, russellrao,
-            seuclidean, sokalmichener, sokalsneath, sqeuclidean, yule,
-            wminkowski]):
-        raise TypeError('When using a custom metric arguments must be passed'
-                        'as keyword (i.e., ARGNAME=ARGVALUE)')
-
-    if func_name == 'pdist':
-        old_arg_names = ['p', 'w', 'V', 'VI']
-    else:
-        old_arg_names = ['p', 'V', 'VI', 'w']
-
-    num_args = len(args)
-    warnings.warn('%d metric parameters have been passed as positional.'
-                  'This will raise an error in a future version.'
-                  'Please pass arguments as keywords(i.e., ARGNAME=ARGVALUE)'
-                  % num_args, DeprecationWarning)
-
-    if num_args > 4:
-        raise ValueError('Deprecated %s signature accepts only 4'
-                         'positional arguments (%s), %d given.'
-                         % (func_name, ', '.join(old_arg_names), num_args))
-
-    for old_arg, arg in zip(old_arg_names, args):
-        if old_arg in kwargs:
-            raise TypeError('%s() got multiple values for argument %s'
-                            % (func_name, old_arg))
-        kwargs[old_arg] = arg
-    return kwargs
-
-
 def _copy_array_if_base_present(a):
     """Copy the array if its base points to a parent array."""
     if a.base is not None:
@@ -1748,7 +1708,7 @@ def _select_weighted_metric(mstr, kwargs, out):
     return mstr, kwargs
 
 
-def pdist(X, metric='euclidean', *args, **kwargs):
+def pdist(X, metric='euclidean', **kwargs):
     """
     Pairwise distances between observations in n-dimensional space.
 
@@ -1766,8 +1726,6 @@ def pdist(X, metric='euclidean', *args, **kwargs):
         'jaccard', 'jensenshannon', 'kulsinski', 'mahalanobis', 'matching',
         'minkowski', 'rogerstanimoto', 'russellrao', 'seuclidean',
         'sokalmichener', 'sokalsneath', 'sqeuclidean', 'yule'.
-    *args : tuple. Deprecated.
-        Additional arguments should be passed as keyword arguments
     **kwargs : dict, optional
         Extra arguments to `metric`: refer to each metric documentation for a
         list of all possible arguments.
@@ -2009,8 +1967,6 @@ def pdist(X, metric='euclidean', *args, **kwargs):
 
     X = _asarray_validated(X, sparse_ok=False, objects_ok=True, mask_ok=True,
                            check_finite=False)
-    kwargs = _args_to_kwargs_xdist(args, kwargs, metric, "pdist")
-
     X = np.asarray(X, order='c')
 
     s = X.shape
@@ -2415,7 +2371,7 @@ def num_obs_y(Y):
     return d
 
 
-def cdist(XA, XB, metric='euclidean', *args, **kwargs):
+def cdist(XA, XB, metric='euclidean', **kwargs):
     """
     Compute distance between each pair of the two collections of inputs.
 
@@ -2438,8 +2394,6 @@ def cdist(XA, XB, metric='euclidean', *args, **kwargs):
         'kulsinski', 'mahalanobis', 'matching', 'minkowski', 'rogerstanimoto',
         'russellrao', 'seuclidean', 'sokalmichener', 'sokalsneath', 'sqeuclidean',
         'wminkowski', 'yule'.
-    *args : tuple. Deprecated.
-        Additional arguments should be passed as keyword arguments
     **kwargs : dict, optional
         Extra arguments to `metric`: refer to each metric documentation for a
         list of all possible arguments.
@@ -2713,8 +2667,6 @@ def cdist(XA, XB, metric='euclidean', *args, **kwargs):
     # where 'abc' is the metric being tested.  This computes the distance
     # between all pairs of vectors in XA and XB using the distance metric 'abc'
     # but with a more succinct, verifiable, but less efficient implementation.
-
-    kwargs = _args_to_kwargs_xdist(args, kwargs, metric, "cdist")
 
     XA = np.asarray(XA, order='c')
     XB = np.asarray(XB, order='c')

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -2087,22 +2087,6 @@ def pdist(X, metric='euclidean', *args, **kwargs):
                                "pdist_%s_%s_wrap" % (metric_name, typ))
             pdist_fn(X, dm, **kwargs)
             return dm
-
-        elif mstr in ['old_cosine', 'old_cos']:
-            warnings.warn('"old_cosine" is deprecated and will be removed in '
-                          'a future version. Use "cosine" instead.',
-                          DeprecationWarning)
-            X = _convert_to_double(X)
-            norms = np.einsum('ij,ij->i', X, X, dtype=np.double)
-            np.sqrt(norms, out=norms)
-            nV = norms.reshape(m, 1)
-            # The numerator u * v
-            nm = np.dot(X, X.T)
-            # The denom. ||u||*||v||
-            de = np.dot(nV, nV.T)
-            dm = 1.0 - (nm / de)
-            dm[range(0, m), range(0, m)] = 0.0
-            dm = squareform(dm)
         elif mstr.startswith("test_"):
             if mstr in _TEST_METRICS:
                 dm = pdist(X, _TEST_METRICS[mstr], **kwargs)

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -144,15 +144,6 @@ def _convert_to_type(X, out_type):
     return np.ascontiguousarray(X, dtype=out_type)
 
 
-def _filter_deprecated_kwargs(kwargs, args_blocklist):
-    # Filtering out old default keywords
-    for k in args_blocklist:
-        if k in kwargs:
-            del kwargs[k]
-            warnings.warn('Got unexpected kwarg %s. This will raise an error'
-                          ' in a future version.' % k, DeprecationWarning)
-
-
 def _nbool_correspond_all(u, v, w=None):
     if u.dtype == v.dtype == bool and w is None:
         not_u = ~u
@@ -1698,7 +1689,7 @@ def _select_weighted_metric(mstr, kwargs, out):
     elif "w" in kwargs:
         if (mstr in _METRICS['seuclidean'].aka or
                 mstr in _METRICS['mahalanobis'].aka):
-            raise ValueError("metric %s incompatible with weights" % mstr)
+            raise TypeError(f"metric {mstr} incompatible with weights")
 
         # XXX: C-versions do not support weights
         # need to use python version for weighting
@@ -1985,30 +1976,6 @@ def pdist(X, metric='euclidean', **kwargs):
         if out.dtype != np.double:
             raise ValueError("Output array must be double type.")
         dm = out
-
-    # compute blocklist for deprecated kwargs
-    if(metric in _METRICS['jensenshannon'].aka
-       or metric == 'test_jensenshannon' or metric == jensenshannon):
-        kwargs_blocklist = ["p", "w", "V", "VI"]
-
-    elif(metric in _METRICS['minkowski'].aka
-         or metric in _METRICS['wminkowski'].aka
-         or metric in ['test_minkowski', 'test_wminkowski']
-         or metric in [minkowski, wminkowski]):
-        kwargs_blocklist = ["V", "VI"]
-
-    elif(metric in _METRICS['seuclidean'].aka or
-         metric == 'test_seuclidean' or metric == seuclidean):
-        kwargs_blocklist = ["p", "w", "VI"]
-
-    elif(metric in _METRICS['mahalanobis'].aka
-         or metric == 'test_mahalanobis' or metric == mahalanobis):
-        kwargs_blocklist = ["p", "w", "V"]
-
-    else:
-        kwargs_blocklist = ["p", "V", "VI"]
-
-    _filter_deprecated_kwargs(kwargs, kwargs_blocklist)
 
     if callable(metric):
         mstr = getattr(metric, '__name__', 'UnknownCustomMetric')
@@ -2696,23 +2663,6 @@ def cdist(XA, XB, metric='euclidean', **kwargs):
         if out.dtype != np.double:
             raise ValueError("Output array must be double type.")
         dm = out
-
-    # compute blocklist for deprecated kwargs
-    if(metric in _METRICS['minkowski'].aka or
-       metric in _METRICS['wminkowski'].aka or
-       metric in ['test_minkowski', 'test_wminkowski'] or
-       metric in [minkowski, wminkowski]):
-        kwargs_blocklist = ["V", "VI"]
-    elif(metric in _METRICS['seuclidean'].aka or
-         metric == 'test_seuclidean' or metric == seuclidean):
-        kwargs_blocklist = ["p", "w", "VI"]
-    elif(metric in _METRICS['mahalanobis'].aka or
-         metric == 'test_mahalanobis' or metric == mahalanobis):
-        kwargs_blocklist = ["p", "w", "V"]
-    else:
-        kwargs_blocklist = ["p", "V", "VI"]
-
-    _filter_deprecated_kwargs(kwargs, kwargs_blocklist)
 
     if callable(metric):
 

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -2053,7 +2053,6 @@ def test_Xdist_deprecated_args():
                      [2.2, 2.3, 4.4],
                      [22.2, 23.3, 44.4]])
     weights = np.arange(3)
-    warn_msg_kwargs = "Got unexpected kwarg"
     for metric in _METRICS_NAMES:
         kwargs = {"w": weights} if metric == "wminkowski" else dict()
         with suppress_warnings() as w:
@@ -2081,10 +2080,10 @@ def test_Xdist_deprecated_args():
             with suppress_warnings() as w:
                 w.filter(DeprecationWarning,
                         message="'wminkowski' metric is deprecated")
-                with pytest.warns(DeprecationWarning, match=warn_msg_kwargs):
+                with pytest.raises(TypeError):
                     cdist(X1, X1, metric, **kwargs)
 
-                with pytest.warns(DeprecationWarning, match=warn_msg_kwargs):
+                with pytest.raises(TypeError):
                     pdist(X1, metric, **kwargs)
 
 

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -2054,38 +2054,38 @@ def test_Xdist_deprecated_args():
                      [22.2, 23.3, 44.4]])
     weights = np.arange(3)
     warn_msg_kwargs = "Got unexpected kwarg"
-    warn_msg_args = "[0-9]* metric parameters have been passed as positional"
     for metric in _METRICS_NAMES:
         kwargs = {"w": weights} if metric == "wminkowski" else dict()
         with suppress_warnings() as w:
-            log = w.record(message=warn_msg_args)
-            w.filter(message=warn_msg_kwargs)
             w.filter(DeprecationWarning,
-                     message="'wminkowski' metric is deprecated")
-            cdist(X1, X1, metric, 2., **kwargs)
-            pdist(X1, metric, 2., **kwargs)
-            assert_(len(log) == 2)
+                    message="'wminkowski' metric is deprecated")
+            with pytest.raises(TypeError):
+                cdist(X1, X1, metric, 2., **kwargs)
+
+            with pytest.raises(TypeError):
+                pdist(X1, metric, 2., **kwargs)
 
         for arg in ["p", "V", "VI"]:
             kwargs = {arg:"foo"}
 
-        if metric == "wminkowski":
-            if "p" in kwargs or "w" in kwargs:
+            if metric == "wminkowski":
+                if "p" in kwargs or "w" in kwargs:
+                    continue
+                kwargs["w"] = weights
+
+            if((arg == "V" and metric == "seuclidean") or
+            (arg == "VI" and metric == "mahalanobis") or
+            (arg == "p" and metric == "minkowski")):
                 continue
-            kwargs["w"] = weights
 
-        if((arg == "V" and metric == "seuclidean") or
-           (arg == "VI" and metric == "mahalanobis") or
-           (arg == "p" and metric == "minkowski")):
-            continue
+            with suppress_warnings() as w:
+                w.filter(DeprecationWarning,
+                        message="'wminkowski' metric is deprecated")
+                with pytest.warns(DeprecationWarning, match=warn_msg_kwargs):
+                    cdist(X1, X1, metric, **kwargs)
 
-        with suppress_warnings() as w:
-            log = w.record(message=warn_msg_kwargs)
-            w.filter(DeprecationWarning,
-                     message="'wminkowski' metric is deprecated")
-            cdist(X1, X1, metric, **kwargs)
-            pdist(X1, metric, **kwargs)
-            assert_(len(log) == 2)
+                with pytest.warns(DeprecationWarning, match=warn_msg_kwargs):
+                    pdist(X1, metric, **kwargs)
 
 
 def test_Xdist_non_negative_weights():


### PR DESCRIPTION
#### What does this implement/fix?
- Removes `old_cosine` metric, deprecated in #7043 (SciPy 0.17)
- Removes `_filter_deprecated_kwargs`, also deprecated in #7043 (SciPy 0.17)
- Removes `*args` from `pdist`/`cdist` which was deprecated in #7629 (SciPy 1.0)

These have all been deprecated for >= 6 releases.