### PR TITLE
MAINT: backports for SciPy 1.6.2

### DIFF
--- a/doc/release/1.6.2-notes.rst
+++ b/doc/release/1.6.2-notes.rst
@@ -5,16 +5,37 @@ SciPy 1.6.2 Release Notes
 .. contents::
 
 SciPy 1.6.2 is a bug-fix release with no new features
-compared to 1.6.1.
+compared to 1.6.1. This is also the first SciPy release
+to place upper bounds on some dependencies to improve
+the long-term repeatability of source builds.
 
 Authors
 =======
 
+* Pradipta Ghosh +
+* Tyler Reddy
+* Ralf Gommers
+* Martin K. Scherer +
+* Robert Uhl
+* Warren Weckesser
+
+A total of 6 people contributed to this release.
+People with a "+" by their names contributed a patch for the first time.
+This list of names is automatically generated, and may not be fully complete.
 
 Issues closed for 1.6.2
 -----------------------
 
+* `#13512 <https://github.com/scipy/scipy/issues/13512>`__: \`stats.gaussian_kde.evaluate\` broken on S390X
+* `#13584 <https://github.com/scipy/scipy/issues/13584>`__: rotation._compute_euler_from_matrix() creates an array with negative...
+* `#13585 <https://github.com/scipy/scipy/issues/13585>`__: Behavior change in coo_matrix when dtype=None
+* `#13686 <https://github.com/scipy/scipy/issues/13686>`__: delta0 argument of scipy.odr.ODR() ignored
 
 Pull requests for 1.6.2
 -----------------------
 
+* `#12862 <https://github.com/scipy/scipy/pull/12862>`__: REL: put upper bounds on versions of dependencies
+* `#13575 <https://github.com/scipy/scipy/pull/13575>`__: BUG: fix \`gaussian_kernel_estimate\` on S390X
+* `#13586 <https://github.com/scipy/scipy/pull/13586>`__: BUG: sparse: Create a utility function \`getdata\`
+* `#13598 <https://github.com/scipy/scipy/pull/13598>`__: MAINT, BUG: enforce contiguous layout for output array in Rotation.as_euler
+* `#13687 <https://github.com/scipy/scipy/pull/13687>`__: BUG: fix scipy.odr to consider given delta0 argument

--- a/scipy/odr/odrpack.py
+++ b/scipy/odr/odrpack.py
@@ -1086,7 +1086,7 @@ class ODR(object):
                  'ndigit', 'taufac', 'sstol', 'partol', 'maxit', 'stpb',
                  'stpd', 'sclb', 'scld', 'work', 'iwork']
 
-        if self.delta0 is not None and self.job % 1000 // 10 == 1:
+        if self.delta0 is not None and (self.job // 10000) % 10 == 0:
             # delta0 provided and fit is not a restart
             self._gen_work()
 

--- a/scipy/sparse/bsr.py
+++ b/scipy/sparse/bsr.py
@@ -11,8 +11,8 @@ import numpy as np
 from .data import _data_matrix, _minmax_mixin
 from .compressed import _cs_matrix
 from .base import isspmatrix, _formats, spmatrix
-from .sputils import (isshape, getdtype, to_native, upcast, get_index_dtype,
-                      check_shape)
+from .sputils import (isshape, getdtype, getdata, to_native, upcast,
+                      get_index_dtype, check_shape)
 from . import _sparsetools
 from ._sparsetools import (bsr_matvec, bsr_matvecs, csr_matmat_maxnnz,
                            bsr_matmat, bsr_transpose, bsr_sort_indices,
@@ -175,8 +175,7 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
                                             check_contents=True)
                 self.indices = np.array(indices, copy=copy, dtype=idx_dtype)
                 self.indptr = np.array(indptr, copy=copy, dtype=idx_dtype)
-                self.data = np.array(data, copy=copy,
-                                     dtype=getdtype(dtype, data, float))
+                self.data = getdata(data, copy=copy, dtype=dtype)
                 if self.data.ndim != 3:
                     raise ValueError(
                         'BSR data must be 3-dimensional, got shape=%s' % (

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -13,8 +13,8 @@ from ._sparsetools import coo_tocsr, coo_todense, coo_matvec
 from .base import isspmatrix, SparseEfficiencyWarning, spmatrix
 from .data import _data_matrix, _minmax_mixin
 from .sputils import (upcast, upcast_char, to_native, isshape, getdtype,
-                      get_index_dtype, downcast_intp_index, check_shape,
-                      check_reshape_kwargs, matrix)
+                      getdata, get_index_dtype, downcast_intp_index,
+                      check_shape, check_reshape_kwargs, matrix)
 
 import operator
 
@@ -155,10 +155,9 @@ class coo_matrix(_data_matrix, _minmax_mixin):
                     self._shape = check_shape((M, N))
 
                 idx_dtype = get_index_dtype(maxval=max(self.shape))
-                data_dtype = getdtype(dtype, obj, default=float)
                 self.row = np.array(row, copy=copy, dtype=idx_dtype)
                 self.col = np.array(col, copy=copy, dtype=idx_dtype)
-                self.data = np.array(obj, copy=copy, dtype=data_dtype)
+                self.data = getdata(obj, copy=copy, dtype=dtype)
                 self.has_canonical_format = False
         else:
             if isspmatrix(arg1):

--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -7,7 +7,7 @@ import warnings
 import numpy as np
 from scipy._lib._util import prod
 
-__all__ = ['upcast', 'getdtype', 'isscalarlike', 'isintlike',
+__all__ = ['upcast', 'getdtype', 'getdata', 'isscalarlike', 'isintlike',
            'isshape', 'issequence', 'isdense', 'ismatrix', 'get_sum_dtype']
 
 supported_dtypes = [np.bool_, np.byte, np.ubyte, np.short, np.ushort, np.intc,
@@ -114,6 +114,18 @@ def getdtype(dtype, a=None, default=None):
             warnings.warn("object dtype is not supported by sparse matrices")
 
     return newdtype
+
+
+def getdata(obj, dtype=None, copy=False):
+    """
+    This is a wrapper of `np.array(obj, dtype=dtype, copy=copy)`
+    that will generate a warning if the result is an object array.
+    """
+    data = np.array(obj, dtype=dtype, copy=copy)
+    # Defer to getdtype for checking that the dtype is OK.
+    # This is called for the validation only; we don't need the return value.
+    getdtype(data.dtype)
+    return data
 
 
 def get_index_dtype(arrays=(), maxval=None, check_contents=False):

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -4145,6 +4145,11 @@ class TestCOO(sparse_test_class(getset=False,
         with pytest.raises(ValueError, match=r'inconsistent shapes'):
             coo_matrix([0, 11, 22, 33], shape=(4, 4))
 
+    def test_constructor_data_ij_dtypeNone(self):
+        data = [1]
+        coo = coo_matrix((data, ([0], [0])), dtype=None)
+        assert coo.dtype == np.array(data).dtype
+
     @pytest.mark.xfail(run=False, reason='COO does not have a __getitem__')
     def test_iterator(self):
         pass
@@ -4318,6 +4323,14 @@ class TestBSR(sparse_test_class(getset=False,
         indptr = np.array([0, n], dtype=np.int32)
         indices = np.arange(n, dtype=np.int32)
         bsr_matrix((data, indices, indptr), blocksize=(n, 1), copy=False)
+
+    def test_default_dtype(self):
+        # As a numpy array, `values` has shape (2, 2, 1).
+        values = [[[1], [1]], [[1], [1]]]
+        indptr = np.array([0, 2], dtype=np.int32)
+        indices = np.array([0, 1], dtype=np.int32)
+        b = bsr_matrix((values, indices, indptr), blocksize=(2, 1))
+        assert b.dtype == np.array(values).dtype
 
     def test_bsr_tocsr(self):
         # check native conversion from BSR to CSR

--- a/scipy/spatial/transform/rotation.pyx
+++ b/scipy/spatial/transform/rotation.pyx
@@ -176,7 +176,7 @@ cdef double[:, :] _compute_euler_from_matrix(
                 _angles[2] = -atan2(matrix_trans[1, 0] + matrix_trans[0, 1],
                                     matrix_trans[0, 0] - matrix_trans[1, 1])
         else:
-            # For instrinsic, set third angle to zero
+            # For intrinsic, set third angle to zero
             # 6a
             if not safe:
                 _angles[2] = 0
@@ -209,16 +209,16 @@ cdef double[:, :] _compute_euler_from_matrix(
             elif _angles[i] > pi:
                 _angles[i] -= 2 * pi
 
+        if extrinsic:
+            # reversal
+            _angles[0], _angles[2] = _angles[2], _angles[0]
+
         # Step 8
         if not safe:
             warnings.warn("Gimbal lock detected. Setting third angle to zero "
                           "since it is not possible to uniquely determine "
                           "all angles.")
 
-    # Reverse role of extrinsic and intrinsic rotations, but let third angle be
-    # zero for gimbal locked cases. Take a copy, to enforce contiguous memory layout.
-    if extrinsic:
-        angles = angles[:, ::-1].copy()
     return angles
 
 @cython.boundscheck(False)

--- a/scipy/spatial/transform/rotation.pyx
+++ b/scipy/spatial/transform/rotation.pyx
@@ -216,9 +216,9 @@ cdef double[:, :] _compute_euler_from_matrix(
                           "all angles.")
 
     # Reverse role of extrinsic and intrinsic rotations, but let third angle be
-    # zero for gimbal locked cases
+    # zero for gimbal locked cases. Take a copy, to enforce contiguous memory layout.
     if extrinsic:
-        angles = angles[:, ::-1]
+        angles = angles[:, ::-1].copy()
     return angles
 
 @cython.boundscheck(False)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -1262,3 +1262,14 @@ def test_deepcopy():
     r = Rotation.from_quat([0, 0, np.sin(np.pi/4), np.cos(np.pi/4)])
     r1 = copy.deepcopy(r)
     assert_allclose(r.as_matrix(), r1.as_matrix(), atol=1e-15)
+
+
+def test_as_euler_contiguous():
+    r = Rotation.from_quat([0, 0, 0, 1])
+    e1 = r.as_euler('xyz')  # extrinsic euler rotation
+    e2 = r.as_euler('XYZ')  # intrinsic
+    assert e1.flags['C_CONTIGUOUS'] is True
+    assert e2.flags['C_CONTIGUOUS'] is True
+    assert all(i >= 0 for i in e1.strides)
+    assert all(i >= 0 for i in e2.strides)
+

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -191,7 +191,7 @@ def test_matrix_calculation_pipeline():
 
 def test_from_matrix_ortho_output():
     rnd = np.random.RandomState(0)
-    mat = rnd.random((100, 3, 3))
+    mat = rnd.random_sample((100, 3, 3))
     ortho_mat = Rotation.from_matrix(mat).as_matrix()
 
     mult_result = np.einsum('...ij,...jk->...ik', ortho_mat,

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -190,8 +190,8 @@ def test_matrix_calculation_pipeline():
 
 
 def test_from_matrix_ortho_output():
-    np.random.seed(0)
-    mat = np.random.random((100, 3, 3))
+    rnd = np.random.RandomState(0)
+    mat = rnd.random((100, 3, 3))
     ortho_mat = Rotation.from_matrix(mat).as_matrix()
 
     mult_result = np.einsum('...ij,...jk->...ik', ortho_mat,
@@ -424,8 +424,8 @@ def test_single_intrinsic_extrinsic_rotation():
 
 def test_from_euler_rotation_order():
     # Intrinsic rotation is same as extrinsic with order reversed
-    np.random.seed(0)
-    a = np.random.randint(low=0, high=180, size=(6, 3))
+    rnd = np.random.RandomState(0)
+    a = rnd.randint(low=0, high=180, size=(6, 3))
     b = a[:, ::-1]
     x = Rotation.from_euler('xyz', a, degrees=True).as_quat()
     y = Rotation.from_euler('ZYX', b, degrees=True).as_quat()
@@ -552,12 +552,12 @@ def test_from_euler_extrinsic_rotation_313():
 
 
 def test_as_euler_asymmetric_axes():
-    np.random.seed(0)
+    rnd = np.random.RandomState(0)
     n = 10
     angles = np.empty((n, 3))
-    angles[:, 0] = np.random.uniform(low=-np.pi, high=np.pi, size=(n,))
-    angles[:, 1] = np.random.uniform(low=-np.pi / 2, high=np.pi / 2, size=(n,))
-    angles[:, 2] = np.random.uniform(low=-np.pi, high=np.pi, size=(n,))
+    angles[:, 0] = rnd.uniform(low=-np.pi, high=np.pi, size=(n,))
+    angles[:, 1] = rnd.uniform(low=-np.pi / 2, high=np.pi / 2, size=(n,))
+    angles[:, 2] = rnd.uniform(low=-np.pi, high=np.pi, size=(n,))
 
     for seq_tuple in permutations('xyz'):
         # Extrinsic rotations
@@ -569,12 +569,12 @@ def test_as_euler_asymmetric_axes():
 
 
 def test_as_euler_symmetric_axes():
-    np.random.seed(0)
+    rnd = np.random.RandomState(0)
     n = 10
     angles = np.empty((n, 3))
-    angles[:, 0] = np.random.uniform(low=-np.pi, high=np.pi, size=(n,))
-    angles[:, 1] = np.random.uniform(low=0, high=np.pi, size=(n,))
-    angles[:, 2] = np.random.uniform(low=-np.pi, high=np.pi, size=(n,))
+    angles[:, 0] = rnd.uniform(low=-np.pi, high=np.pi, size=(n,))
+    angles[:, 1] = rnd.uniform(low=0, high=np.pi, size=(n,))
+    angles[:, 2] = rnd.uniform(low=-np.pi, high=np.pi, size=(n,))
 
     for axis1 in ['x', 'y', 'z']:
         for axis2 in ['x', 'y', 'z']:
@@ -669,9 +669,9 @@ def test_as_euler_degenerate_symmetric_axes():
 
 
 def test_inv():
-    np.random.seed(0)
+    rnd = np.random.RandomState(0)
     n = 10
-    p = Rotation.from_quat(np.random.normal(size=(n, 4)))
+    p = Rotation.from_quat(rnd.normal(size=(n, 4)))
     q = p.inv()
 
     p_mat = p.as_matrix()
@@ -687,8 +687,8 @@ def test_inv():
 
 
 def test_inv_single_rotation():
-    np.random.seed(0)
-    p = Rotation.from_quat(np.random.normal(size=(4,)))
+    rnd = np.random.RandomState(0)
+    p = Rotation.from_quat(rnd.normal(size=(4,)))
     q = p.inv()
 
     p_mat = p.as_matrix()
@@ -982,8 +982,8 @@ def test_align_vectors_no_rotation():
 
 
 def test_align_vectors_no_noise():
-    np.random.seed(0)
-    c = Rotation.from_quat(np.random.normal(size=4))
+    rnd = np.random.RandomState(0)
+    c = Rotation.from_quat(rnd.normal(size=4))
     b = np.random.normal(size=(5, 3))
     a = c.apply(b)
 
@@ -1019,13 +1019,13 @@ def test_align_vectors_scaled_weights():
 
 
 def test_align_vectors_noise():
-    np.random.seed(0)
+    rnd = np.random.RandomState(0)
     n_vectors = 100
-    rot = Rotation.from_euler('xyz', np.random.normal(size=3))
+    rot = Rotation.from_euler('xyz', rnd.normal(size=3))
     vectors = np.random.normal(size=(n_vectors, 3))
     result = rot.apply(vectors)
 
-    # The paper adds noise as indepedently distributed angular errors
+    # The paper adds noise as independently distributed angular errors
     sigma = np.deg2rad(1)
     tolerance = 1.5 * sigma
     noise = Rotation.from_rotvec(
@@ -1092,9 +1092,9 @@ def test_random_rotation_shape():
 
 
 def test_slerp():
-    np.random.seed(0)
+    rnd = np.random.RandomState(0)
 
-    key_rots = Rotation.from_quat(np.random.uniform(size=(5, 4)))
+    key_rots = Rotation.from_quat(rnd.uniform(size=(5, 4)))
     key_quats = key_rots.as_quat()
 
     key_times = [0, 1, 2, 3, 4]
@@ -1144,8 +1144,8 @@ def test_slerp_single_rot():
 def test_slerp_time_dim_mismatch():
     with pytest.raises(ValueError,
                        match="times to be specified in a 1 dimensional array"):
-        np.random.seed(0)
-        r = Rotation.from_quat(np.random.uniform(size=(2, 4)))
+        rnd = np.random.RandomState(0)
+        r = Rotation.from_quat(rnd.uniform(size=(2, 4)))
         t = np.array([[1],
                       [2]])
         Slerp(t, r)
@@ -1154,31 +1154,31 @@ def test_slerp_time_dim_mismatch():
 def test_slerp_num_rotations_mismatch():
     with pytest.raises(ValueError, match="number of rotations to be equal to "
                                          "number of timestamps"):
-        np.random.seed(0)
-        r = Rotation.from_quat(np.random.uniform(size=(5, 4)))
+        rnd = np.random.RandomState(0)
+        r = Rotation.from_quat(rnd.uniform(size=(5, 4)))
         t = np.arange(7)
         Slerp(t, r)
 
 
 def test_slerp_equal_times():
     with pytest.raises(ValueError, match="strictly increasing order"):
-        np.random.seed(0)
-        r = Rotation.from_quat(np.random.uniform(size=(5, 4)))
+        rnd = np.random.RandomState(0)
+        r = Rotation.from_quat(rnd.uniform(size=(5, 4)))
         t = [0, 1, 2, 2, 4]
         Slerp(t, r)
 
 
 def test_slerp_decreasing_times():
     with pytest.raises(ValueError, match="strictly increasing order"):
-        np.random.seed(0)
-        r = Rotation.from_quat(np.random.uniform(size=(5, 4)))
+        rnd = np.random.RandomState(0)
+        r = Rotation.from_quat(rnd.uniform(size=(5, 4)))
         t = [0, 1, 3, 2, 4]
         Slerp(t, r)
 
 
 def test_slerp_call_time_dim_mismatch():
-    np.random.seed(0)
-    r = Rotation.from_quat(np.random.uniform(size=(5, 4)))
+    rnd = np.random.RandomState(0)
+    r = Rotation.from_quat(rnd.uniform(size=(5, 4)))
     t = np.arange(5)
     s = Slerp(t, r)
 
@@ -1190,8 +1190,8 @@ def test_slerp_call_time_dim_mismatch():
 
 
 def test_slerp_call_time_out_of_range():
-    np.random.seed(0)
-    r = Rotation.from_quat(np.random.uniform(size=(5, 4)))
+    rnd = np.random.RandomState(0)
+    r = Rotation.from_quat(rnd.uniform(size=(5, 4)))
     t = np.arange(5) + 1
     s = Slerp(t, r)
 

--- a/scipy/stats/_stats.pyx
+++ b/scipy/stats/_stats.pyx
@@ -566,7 +566,7 @@ def gaussian_kernel_estimate(points, values, xi, precision, dtype, real _=0):
     values_ = values.astype(dtype, copy=False)
 
     # Evaluate the normalisation
-    norm = (2 * PI) ** (- d / 2)
+    norm = math.pow((2 * PI) ,(- d / 2))
     for i in range(d):
         norm *= whitening[i, i]
 


### PR DESCRIPTION
Current backports included:

- gh-13575
- gh-13586
- gh-13598
- gh-13687

Also, updates release notes, including a mention of the dependency version caps backported separately before this.