### PR TITLE
MAINT: stats: fix broadcasting for scipy.stats.entropy

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -2866,8 +2866,7 @@ def entropy(pk, qk=None, base=None, axis=0):
         vec = entr(pk)
     else:
         qk = asarray(qk)
-        if qk.shape != pk.shape:
-            raise ValueError("qk and pk must have same shape.")
+        pk, qk = np.broadcast_arrays(pk, qk)
         qk = 1.0*qk / np.sum(qk, axis=axis, keepdims=True)
         vec = rel_entr(pk, qk)
     S = np.sum(vec, axis=axis)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3052,6 +3052,21 @@ class TestEntropy(object):
         assert_array_almost_equal(stats.entropy(pk.T, qk.T).T,
                                   stats.entropy(pk, qk, axis=1))
 
+    def test_entropy_broadcasting(self):
+        np.random.rand(0)
+        x = np.random.rand(3)
+        y = np.random.rand(2, 1)
+        res = stats.entropy(x, y, axis=-1)
+        assert_equal(res[0], stats.entropy(x, y[0]))
+        assert_equal(res[1], stats.entropy(x, y[1]))
+
+    def test_entropy_shape_mismatch(self):
+        x = np.random.rand(10, 1, 12)
+        y = np.random.rand(11, 2)
+        message = "shape mismatch: objects cannot be broadcast"
+        with pytest.raises(ValueError, match=message):
+            stats.entropy(x, y)
+
 
 def TestArgsreduce():
     a = array([1, 3, 2, 1, 2, 3, 3])


### PR DESCRIPTION
#### Reference issue
Closes gh-13707

#### What does this implement/fix?
`scipy.stats.entropy` required shapes of input arrays to be identical. Instead, it should only require that the arrays be broadcastable.