### PR TITLE
BUG: stats: Override _fitstart for the invweibull distribution.

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -3992,6 +3992,18 @@ class invweibull_gen(rv_continuous):
     def _entropy(self, c):
         return 1+_EULER + _EULER / c - np.log(c)
 
+    def _fitstart(self, data, args=None):
+        # The default implementation of _fitstart uses
+        #     args = (1.0,)*self.numargs
+        # These args are passed to _fit_loc_scale_support, which ultimately
+        # calls fit_loc_scale.  fit_loc_scale uses the moments to estimate
+        # parameters, but invweibull requires c > 1 for the first moment
+        # to exist.  So we use 2.0 instead.
+        if args is None:
+            args = (2.0,)*self.numargs
+        loc, scale = self._fit_loc_scale_support(data, *args)
+        return args + (loc, scale)
+
 
 invweibull = invweibull_gen(a=0, name='invweibull')
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -3993,16 +3993,9 @@ class invweibull_gen(rv_continuous):
         return 1+_EULER + _EULER / c - np.log(c)
 
     def _fitstart(self, data, args=None):
-        # The default implementation of _fitstart uses
-        #     args = (1.0,)*self.numargs
-        # These args are passed to _fit_loc_scale_support, which ultimately
-        # calls fit_loc_scale.  fit_loc_scale uses the moments to estimate
-        # parameters, but invweibull requires c > 1 for the first moment
-        # to exist.  So we use 2.0 instead.
-        if args is None:
-            args = (2.0,)*self.numargs
-        loc, scale = self._fit_loc_scale_support(data, *args)
-        return args + (loc, scale)
+        # invweibull requires c > 1 for the first moment to exist, so use 2.0
+        args = (2.0,) if args is None else args
+        return super(invweibull_gen, self)._fitstart(data, args=args)
 
 
 invweibull = invweibull_gen(a=0, name='invweibull')


### PR DESCRIPTION
When no initial guess is given, the _fitstart method uses 1.0
for the initial guess of shape parameters, and then uses the
distribution's moment to create a better guess.  The invweibull
distribution doesn't have a first moment when the shape parameter
c is 1, so _fitstart is overridden to use 2.0.

This fixes a warning that occurs when calling invweibull.fit.  E.g.

    >>> invweibull.fit([1, 2, 3, 10, 20], floc=0)
    [...]/scipy/stats/_distn_infrastructure.py:2494: RuntimeWarning:
    invalid value encountered in double_scalars
      Lhat = muhat - Shat*mu
    (1.094936085143949, 0, 2.435695425443909)

After this PR:

    >>> invweibull.fit([1, 2, 3, 10, 20], floc=0)
    (1.0949396631669803, 0, 2.435663730822117)
