### PR TITLE
MAINT: stats: No need to suppress frechet deprecation warnings. 

### DIFF
--- a/scipy/stats/tests/test_fit.py
+++ b/scipy/stats/tests/test_fit.py
@@ -1,7 +1,7 @@
 import os
 
 import numpy as np
-from numpy.testing import assert_allclose, suppress_warnings
+from numpy.testing import assert_allclose
 import pytest
 from scipy import stats
 
@@ -96,8 +96,7 @@ def test_cont_fit(distname, arg, method):
         # Note that if a fit succeeds, the other fit_sizes are skipped
         np.random.seed(1234)
 
-        with np.errstate(all='ignore'), suppress_warnings() as sup:
-            sup.filter(category=DeprecationWarning, message=".*frechet_")
+        with np.errstate(all='ignore'):
             rvs = distfn.rvs(size=fit_size, *arg)
             est = distfn.fit(rvs, method=method)  # start with default values
 

--- a/scipy/stats/tests/test_fit.py
+++ b/scipy/stats/tests/test_fit.py
@@ -64,7 +64,8 @@ skip_fit = [
 def cases_test_cont_fit():
     # this tests the closeness of the estimated parameters to the true
     # parameters with fit method of continuous distributions
-    # Note: is slow, some distributions don't converge with sample size <= 10000
+    # Note: is slow, some distributions don't converge with sample
+    # size <= 10000
     for distname, arg in distcont:
         if distname not in skip_fit:
             yield distname, arg
@@ -82,7 +83,8 @@ def test_cont_fit(distname, arg, method):
             xfail = True
         if xfail:
             msg = "Fitting %s doesn't work reliably yet" % distname
-            msg += " [Set environment variable SCIPY_XFAIL=1 to run this test nevertheless.]"
+            msg += (" [Set environment variable SCIPY_XFAIL=1 to run this"
+                    " test nevertheless.]")
             pytest.xfail(msg)
 
     distfn = getattr(stats, distname)
@@ -103,7 +105,8 @@ def test_cont_fit(distname, arg, method):
         diff = est - truearg
 
         # threshold for location
-        diffthreshold[-2] = np.max([np.abs(rvs.mean())*thresh_percent,thresh_min])
+        diffthreshold[-2] = np.max([np.abs(rvs.mean())*thresh_percent,
+                                    thresh_min])
 
         if np.any(np.isnan(est)):
             raise AssertionError('nan returned in fit')
@@ -135,4 +138,3 @@ def test_expon_fit():
     data = [0, 0, 0, 0, 2, 2, 2, 2]
     phat = stats.expon.fit(data, floc=0)
     assert_allclose(phat, [0, 1.0], atol=1e-3)
-


### PR DESCRIPTION
The Frechet distributions have been removed, so there is no
longer any need to suppress the associated deprecation warnings
in test_fit.py.