### PR TITLE
MAINT: use super() as described by PEP 3135

### DIFF
--- a/benchmarks/benchmarks/lsq_problems.py
+++ b/benchmarks/benchmarks/lsq_problems.py
@@ -125,7 +125,7 @@ class AlphaPineneDirect(LSQBenchmarkProblem):
     ]
 
     def __init__(self, x0):
-        super(AlphaPineneDirect, self).__init__(5, 40, 2.064572e1, x0)
+        super().__init__(5, 40, 2.064572e1, x0)
         self.t = np.array([0, 1230, 3060, 4920, 7800, 10680, 15030, 22620,
                            36420], dtype=float)
         self.y0 = np.array([100, 0, 0, 0, 0], dtype=float)
@@ -185,7 +185,7 @@ class CoatingThickness(LSQBenchmarkProblem):
     ]
 
     def __init__(self, x0):
-        super(CoatingThickness, self).__init__(134, 252, 0.5054986, x0)
+        super().__init__(134, 252, 0.5054986, x0)
         self.n0 = self.m // 4
         self.xi = np.array([
             [0.7140, 0.7169, 0.7232, 0.7151, 0.6848, 0.7070, 0.7177, 0.7073,
@@ -283,7 +283,7 @@ class ExponentialFitting(LSQBenchmarkProblem):
     ]
 
     def __init__(self, x0):
-        super(ExponentialFitting, self).__init__(5, 33, 5.464895e-5, x0)
+        super().__init__(5, 33, 5.464895e-5, x0)
         self.t = np.arange(self.m, dtype=float) * 10
         self.y = 1e-1 * np.array(
             [8.44, 9.08, 9.32, 9.36, 9.25, 9.08, 8.81, 8.5, 8.18,
@@ -321,7 +321,7 @@ class GaussianFitting(LSQBenchmarkProblem):
     ]
 
     def __init__(self, x0):
-        super(GaussianFitting, self).__init__(11, 65, 4.013772e-02, x0)
+        super().__init__(11, 65, 4.013772e-02, x0)
         self.t = np.arange(self.m, dtype=float) * 1e-1
         self.y = np.array(
             [1.366, 1.191, 1.112, 1.013, 9.91e-1, 8.85e-1, 8.31e-1, 8.47e-1,
@@ -375,7 +375,7 @@ class ThermistorResistance(LSQBenchmarkProblem):
     ]
 
     def __init__(self, x0_ind):
-        super(ThermistorResistance, self).__init__(3, 16, 87.94585, x0_ind)
+        super().__init__(3, 16, 87.94585, x0_ind)
         self.t = 5 + 45 * (1 + np.arange(self.m, dtype=float))
         self.y = np.array(
             [3.478e4, 2.861e4, 2.365e4, 1.963e4, 1.637e4, 1.372e4, 1.154e4,
@@ -408,7 +408,7 @@ class EnzymeReaction(LSQBenchmarkProblem):
     ]
 
     def __init__(self, x0_ind):
-        super(EnzymeReaction, self).__init__(4, 11, 3.075057e-04, x0_ind)
+        super().__init__(4, 11, 3.075057e-04, x0_ind)
         self.u = np.array([4.0, 2.0, 1.0, 5.0e-1, 2.5e-1, 1.67e-1,
                            1.25e-1, 1.0e-1, 8.33e-2, 7.14e-2, 6.25e-2])
         self.y = np.array([1.957e-1, 1.947e-1, 1.735e-1, 1.6e-1, 8.44e-2,
@@ -444,7 +444,7 @@ class ChebyshevQuadrature(LSQBenchmarkProblem):
     ]
 
     def __init__(self, x0):
-        super(ChebyshevQuadrature, self).__init__(11, 11, 2.799761e-03, x0)
+        super().__init__(11, 11, 2.799761e-03, x0)
         cp = Chebyshev(1)
         self.T_all = [cp.basis(i, domain=[0.0, 1.0]) for i in range(11)]
 

--- a/doc/source/scipyoptdoc.py
+++ b/doc/source/scipyoptdoc.py
@@ -60,7 +60,7 @@ class ScipyOptimizeInterfaceDomain(PythonDomain):
     name = 'scipy-optimize'
 
     def __init__(self, *a, **kw):
-        super(ScipyOptimizeInterfaceDomain, self).__init__(*a, **kw)
+        super().__init__(*a, **kw)
         self.directives = dict(self.directives)
         self.directives['function'] = wrap_mangling_directive(self.directives['function'])
 

--- a/scipy/integrate/_ivp/base.py
+++ b/scipy/integrate/_ivp/base.py
@@ -262,7 +262,7 @@ class ConstantDenseOutput(DenseOutput):
     or a system with 0 equations.
     """
     def __init__(self, t_old, t, value):
-        super(ConstantDenseOutput, self).__init__(t_old, t)
+        super().__init__(t_old, t)
         self.value = value
 
     def _call_impl(self, t):

--- a/scipy/integrate/_ivp/bdf.py
+++ b/scipy/integrate/_ivp/bdf.py
@@ -185,8 +185,8 @@ class BDF(OdeSolver):
                  rtol=1e-3, atol=1e-6, jac=None, jac_sparsity=None,
                  vectorized=False, first_step=None, **extraneous):
         warn_extraneous(extraneous)
-        super(BDF, self).__init__(fun, t0, y0, t_bound, vectorized,
-                                  support_complex=True)
+        super().__init__(fun, t0, y0, t_bound, vectorized,
+                         support_complex=True)
         self.max_step = validate_max_step(max_step)
         self.rtol, self.atol = validate_tol(rtol, atol, self.n)
         f = self.fun(self.t, self.y)
@@ -443,7 +443,7 @@ class BDF(OdeSolver):
 
 class BdfDenseOutput(DenseOutput):
     def __init__(self, t_old, t, h, order, D):
-        super(BdfDenseOutput, self).__init__(t_old, t)
+        super().__init__(t_old, t)
         self.order = order
         self.t_shift = self.t - h * np.arange(self.order)
         self.denom = h * (1 + np.arange(self.order))

--- a/scipy/integrate/_ivp/lsoda.py
+++ b/scipy/integrate/_ivp/lsoda.py
@@ -106,7 +106,7 @@ class LSODA(OdeSolver):
                  max_step=np.inf, rtol=1e-3, atol=1e-6, jac=None, lband=None,
                  uband=None, vectorized=False, **extraneous):
         warn_extraneous(extraneous)
-        super(LSODA, self).__init__(fun, t0, y0, t_bound, vectorized)
+        super().__init__(fun, t0, y0, t_bound, vectorized)
 
         if first_step is None:
             first_step = 0  # LSODA value for automatic selection.
@@ -174,7 +174,7 @@ class LSODA(OdeSolver):
 
 class LsodaDenseOutput(DenseOutput):
     def __init__(self, t_old, t, h, order, yh):
-        super(LsodaDenseOutput, self).__init__(t_old, t)
+        super().__init__(t_old, t)
         self.h = h
         self.yh = yh
         self.p = np.arange(order + 1)

--- a/scipy/integrate/_ivp/radau.py
+++ b/scipy/integrate/_ivp/radau.py
@@ -283,7 +283,7 @@ class Radau(OdeSolver):
                  rtol=1e-3, atol=1e-6, jac=None, jac_sparsity=None,
                  vectorized=False, first_step=None, **extraneous):
         warn_extraneous(extraneous)
-        super(Radau, self).__init__(fun, t0, y0, t_bound, vectorized)
+        super().__init__(fun, t0, y0, t_bound, vectorized)
         self.y_old = None
         self.max_step = validate_max_step(max_step)
         self.rtol, self.atol = validate_tol(rtol, atol, self.n)
@@ -537,7 +537,7 @@ class Radau(OdeSolver):
 
 class RadauDenseOutput(DenseOutput):
     def __init__(self, t_old, t, y_old, Q):
-        super(RadauDenseOutput, self).__init__(t_old, t)
+        super().__init__(t_old, t)
         self.h = t - t_old
         self.Q = Q
         self.order = Q.shape[1] - 1

--- a/scipy/integrate/_ivp/rk.py
+++ b/scipy/integrate/_ivp/rk.py
@@ -86,8 +86,8 @@ class RungeKutta(OdeSolver):
                  rtol=1e-3, atol=1e-6, vectorized=False,
                  first_step=None, **extraneous):
         warn_extraneous(extraneous)
-        super(RungeKutta, self).__init__(fun, t0, y0, t_bound, vectorized,
-                                         support_complex=True)
+        super().__init__(fun, t0, y0, t_bound, vectorized,
+                         support_complex=True)
         self.y_old = None
         self.max_step = validate_max_step(max_step)
         self.rtol, self.atol = validate_tol(rtol, atol, self.n)
@@ -476,9 +476,8 @@ class DOP853(RungeKutta):
     def __init__(self, fun, t0, y0, t_bound, max_step=np.inf,
                  rtol=1e-3, atol=1e-6, vectorized=False,
                  first_step=None, **extraneous):
-        super(DOP853, self).__init__(fun, t0, y0, t_bound, max_step,
-                                     rtol, atol, vectorized, first_step,
-                                     **extraneous)
+        super().__init__(fun, t0, y0, t_bound, max_step, rtol, atol,
+                         vectorized, first_step, **extraneous)
         self.K_extended = np.empty((dop853_coefficients.N_STAGES_EXTENDED,
                                     self.n), dtype=self.y.dtype)
         self.K = self.K_extended[:self.n_stages + 1]
@@ -526,7 +525,7 @@ class DOP853(RungeKutta):
 
 class RkDenseOutput(DenseOutput):
     def __init__(self, t_old, t, y_old, Q):
-        super(RkDenseOutput, self).__init__(t_old, t)
+        super().__init__(t_old, t)
         self.h = t - t_old
         self.Q = Q
         self.order = Q.shape[1] - 1
@@ -551,7 +550,7 @@ class RkDenseOutput(DenseOutput):
 
 class Dop853DenseOutput(DenseOutput):
     def __init__(self, t_old, t, y_old, F):
-        super(Dop853DenseOutput, self).__init__(t_old, t)
+        super().__init__(t_old, t)
         self.h = t - t_old
         self.F = F
         self.y_old = y_old

--- a/scipy/integrate/_ode.py
+++ b/scipy/integrate/_ode.py
@@ -1212,10 +1212,8 @@ class dop853(dopri5):
                  method=None,
                  verbosity=-1,  # no messages if negative
                  ):
-        super(self.__class__, self).__init__(rtol, atol, nsteps, max_step,
-                                             first_step, safety, ifactor,
-                                             dfactor, beta, method,
-                                             verbosity)
+        super().__init__(rtol, atol, nsteps, max_step, first_step, safety,
+                         ifactor, dfactor, beta, method, verbosity)
 
     def reset(self, n, has_jac):
         work = zeros((11 * n + 21,), float)

--- a/scipy/integrate/_quad_vec.py
+++ b/scipy/integrate/_quad_vec.py
@@ -15,7 +15,7 @@ class LRUDict(collections.OrderedDict):
 
     def __setitem__(self, key, value):
         existing_key = (key in self)
-        super(LRUDict, self).__setitem__(key, value)
+        super().__setitem__(key, value)
         if existing_key:
             self.move_to_end(key)
         elif len(self) > self.__max_size:

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -169,7 +169,7 @@ class BSpline(object):
 
     """
     def __init__(self, t, c, k, extrapolate=True, axis=0):
-        super(BSpline, self).__init__()
+        super().__init__()
 
         self.k = operator.index(k)
         self.c = np.asarray(c)

--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -149,7 +149,7 @@ class CubicHermiteSpline(PPoly):
         c[2] = dydx[:-1]
         c[3] = y[:-1]
 
-        super(CubicHermiteSpline, self).__init__(c, x, extrapolate=extrapolate)
+        super().__init__(c, x, extrapolate=extrapolate)
         self.axis = axis
 
 
@@ -232,8 +232,7 @@ class PchipInterpolator(CubicHermiteSpline):
         x, _, y, axis, _ = prepare_input(x, y, axis)
         xp = x.reshape((x.shape[0],) + (1,)*(y.ndim-1))
         dk = self._find_derivatives(xp, y)
-        super(PchipInterpolator, self).__init__(x, y, dk, axis=0,
-                                                extrapolate=extrapolate)
+        super().__init__(x, y, dk, axis=0, extrapolate=extrapolate)
         self.axis = axis
 
     @staticmethod
@@ -442,8 +441,7 @@ class Akima1DInterpolator(CubicHermiteSpline):
         t[ind] = (f1[ind] * m[(x_ind + 1,) + y_ind] +
                   f2[ind] * m[(x_ind + 2,) + y_ind]) / f12[ind]
 
-        super(Akima1DInterpolator, self).__init__(x, y, t, axis=0,
-                                                  extrapolate=False)
+        super().__init__(x, y, t, axis=0, extrapolate=False)
         self.axis = axis
 
     def extend(self, c, x, right=True):
@@ -783,8 +781,7 @@ class CubicSpline(CubicHermiteSpline):
                 s = solve_banded((1, 1), A, b, overwrite_ab=True,
                                  overwrite_b=True, check_finite=False)
 
-        super(CubicSpline, self).__init__(x, y, s, axis=0,
-                                          extrapolate=extrapolate)
+        super().__init__(x, y, s, axis=0, extrapolate=extrapolate)
         self.axis = axis
 
     @staticmethod

--- a/scipy/io/arff/arffread.py
+++ b/scipy/io/arff/arffread.py
@@ -333,7 +333,7 @@ class DateAttribute(Attribute):
                 "datetime64[%s]" % self.datetime_unit)
 
     def __str__(self):
-        return super(DateAttribute, self).__str__() + ',' + self.date_format
+        return super().__str__() + ',' + self.date_format
 
 
 class RelationalAttribute(Attribute):
@@ -380,7 +380,7 @@ class RelationalAttribute(Attribute):
                         [(a.name, a.dtype) for a in self.attributes])
 
     def __str__(self):
-        return (super(RelationalAttribute, self).__str__() + '\n\t' +
+        return (super().__str__() + '\n\t' +
                 '\n\t'.join(str(a) for a in self.attributes))
 
 

--- a/scipy/io/idl.py
+++ b/scipy/io/idl.py
@@ -650,10 +650,10 @@ class AttrDict(dict):
         dict.__init__(self, init)
 
     def __getitem__(self, name):
-        return super(AttrDict, self).__getitem__(name.lower())
+        return super().__getitem__(name.lower())
 
     def __setitem__(self, key, value):
-        return super(AttrDict, self).__setitem__(key.lower(), value)
+        return super().__setitem__(key.lower(), value)
 
     __getattr__ = __getitem__
     __setattr__ = __setitem__

--- a/scipy/io/matlab/mio4.py
+++ b/scipy/io/matlab/mio4.py
@@ -306,7 +306,7 @@ class MatFile4Reader(MatFileReader):
     %(matstream_arg)s
     %(load_args)s
         '''
-        super(MatFile4Reader, self).__init__(mat_stream, *args, **kwargs)
+        super().__init__(mat_stream, *args, **kwargs)
         self._matrix_reader = None
 
     def guess_byte_order(self):

--- a/scipy/io/matlab/mio5.py
+++ b/scipy/io/matlab/mio5.py
@@ -189,7 +189,7 @@ class MatFile5Reader(MatFileReader):
         Set codec to use for uint16 char arrays (e.g., 'utf-8').
         Use system default codec if None
         '''
-        super(MatFile5Reader, self).__init__(
+        super().__init__(
             mat_stream,
             byte_order,
             mat_dtype,

--- a/scipy/linalg/tests/test_decomp_update.py
+++ b/scipy/linalg/tests/test_decomp_update.py
@@ -630,7 +630,7 @@ class TestQRdelete_D(BaseQRdelete):
 
 class BaseQRinsert(BaseQRdeltas):
     def generate(self, type, mode='full', which='row', p=1):
-        a, q, r = super(BaseQRinsert, self).generate(type, mode)
+        a, q, r = super().generate(type, mode)
 
         assert_(p > 0)
 
@@ -1172,7 +1172,7 @@ class TestQRinsert_D(BaseQRinsert):
 
 class BaseQRupdate(BaseQRdeltas):
     def generate(self, type, mode='full', p=1):
-        a, q, r = super(BaseQRupdate, self).generate(type, mode)
+        a, q, r = super().generate(type, mode)
 
         # super call set the seed...
         if p == 1:

--- a/scipy/optimize/_differentiable_functions.py
+++ b/scipy/optimize/_differentiable_functions.py
@@ -588,4 +588,4 @@ class IdentityVectorFunction(LinearVectorFunction):
         else:
             A = np.eye(n)
             sparse_jacobian = False
-        super(IdentityVectorFunction, self).__init__(A, x0, sparse_jacobian)
+        super().__init__(A, x0, sparse_jacobian)

--- a/scipy/optimize/_hessian_update_strategy.py
+++ b/scipy/optimize/_hessian_update_strategy.py
@@ -287,7 +287,7 @@ class BFGS(FullHessianUpdateStrategy):
             raise ValueError("`exception_strategy` must be 'skip_update' "
                              "or 'damp_update'.")
 
-        super(BFGS, self).__init__(init_scale)
+        super().__init__(init_scale)
         self.exception_strategy = exception_strategy
 
     def _update_inverse_hessian(self, ys, Hy, yHy, s):
@@ -404,7 +404,7 @@ class SR1(FullHessianUpdateStrategy):
 
     def __init__(self, min_denominator=1e-8, init_scale='auto'):
         self.min_denominator = min_denominator
-        super(SR1, self).__init__(init_scale)
+        super().__init__(init_scale)
 
     def _update_implementation(self, delta_x, delta_grad):
         # Auxiliary variables w and z

--- a/scipy/optimize/_shgo_lib/triangulation.py
+++ b/scipy/optimize/_shgo_lib/triangulation.py
@@ -510,7 +510,7 @@ class Cell(VertexGroup):
     """
 
     def __init__(self, p_gen, p_hgr, origin, supremum):
-        super(Cell, self).__init__(p_gen, p_hgr)
+        super().__init__(p_gen, p_hgr)
 
         self.origin = origin
         self.supremum = supremum
@@ -525,7 +525,7 @@ class Simplex(VertexGroup):
     """
 
     def __init__(self, p_gen, p_hgr, generation_cycle, dim):
-        super(Simplex, self).__init__(p_gen, p_hgr)
+        super().__init__(p_gen, p_hgr)
 
         self.generation_cycle = (generation_cycle + 1) % (dim - 1)
 

--- a/scipy/optimize/_trlib/_trlib.pyx
+++ b/scipy/optimize/_trlib/_trlib.pyx
@@ -11,7 +11,7 @@ class TRLIBQuadraticSubproblem(BaseQuadraticSubproblem):
 
     def __init__(self, x, fun, jac, hess, hessp, tol_rel_i=-2.0, tol_rel_b=-3.0,
                  disp=False):
-        super(TRLIBQuadraticSubproblem, self).__init__(x, fun, jac, hess, hessp)
+        super().__init__(x, fun, jac, hess, hessp)
         self.tol_rel_i = tol_rel_i
         self.tol_rel_b = tol_rel_b
         self.disp = disp

--- a/scipy/optimize/_trustregion_exact.py
+++ b/scipy/optimize/_trustregion_exact.py
@@ -213,7 +213,7 @@ class IterativeSubproblem(BaseQuadraticSubproblem):
     def __init__(self, x, fun, jac, hess, hessp=None,
                  k_easy=0.1, k_hard=0.2):
 
-        super(IterativeSubproblem, self).__init__(x, fun, jac, hess)
+        super().__init__(x, fun, jac, hess)
 
         # When the trust-region shrinks in two consecutive
         # calculations (``tr_radius < previous_tr_radius``)

--- a/scipy/optimize/lbfgsb.py
+++ b/scipy/optimize/lbfgsb.py
@@ -431,8 +431,7 @@ class LbfgsInvHessProduct(LinearOperator):
             raise ValueError('sk and yk must have matching shape, (n_corrs, n)')
         n_corrs, n = sk.shape
 
-        super(LbfgsInvHessProduct, self).__init__(
-            dtype=np.float64, shape=(n, n))
+        super().__init__(dtype=np.float64, shape=(n, n))
 
         self.sk = sk
         self.yk = yk

--- a/scipy/optimize/tests/test__basinhopping.py
+++ b/scipy/optimize/tests/test__basinhopping.py
@@ -48,11 +48,11 @@ class MyTakeStep1(RandomDisplacement):
     make sure it's actually being used."""
     def __init__(self):
         self.been_called = False
-        super(MyTakeStep1, self).__init__()
+        super().__init__()
 
     def __call__(self, x):
         self.been_called = True
-        return super(MyTakeStep1, self).__call__(x)
+        return super().__call__(x)
 
 
 def myTakeStep2(x):

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -1697,7 +1697,7 @@ class TestLinprogSimplexDefault(LinprogSimplexTests):
         # even if the solution is wrong, the appropriate warning is issued.
         self.options.update({'tol': 1e-12})
         with pytest.warns(OptimizeWarning):
-            super(TestLinprogSimplexDefault, self).test_bug_8174()
+            super().test_bug_8174()
 
 
 class TestLinprogSimplexBland(LinprogSimplexTests):
@@ -1714,7 +1714,7 @@ class TestLinprogSimplexBland(LinprogSimplexTests):
         self.options.update({'tol': 1e-12})
         with pytest.raises(AssertionError):
             with pytest.warns(OptimizeWarning):
-                super(TestLinprogSimplexBland, self).test_bug_8174()
+                super().test_bug_8174()
 
 
 class TestLinprogSimplexNoPresolve(LinprogSimplexTests):
@@ -1729,7 +1729,7 @@ class TestLinprogSimplexNoPresolve(LinprogSimplexTests):
         condition=is_32_bit and is_linux,
         reason='Fails with warning on 32-bit linux')
     def test_bug_5400(self):
-        super(TestLinprogSimplexNoPresolve, self).test_bug_5400()
+        super().test_bug_5400()
 
     def test_bug_6139_low_tol(self):
         # Linprog(method='simplex') fails to find a basic feasible solution
@@ -1738,7 +1738,7 @@ class TestLinprogSimplexNoPresolve(LinprogSimplexTests):
         # Without ``presolve`` eliminating such rows the result is incorrect.
         self.options.update({'tol': 1e-12})
         with pytest.raises(AssertionError, match='linprog status 4'):
-            return super(TestLinprogSimplexNoPresolve, self).test_bug_6139()
+            return super().test_bug_6139()
 
     def test_bug_7237_low_tol(self):
         pytest.skip("Simplex fails on this problem.")
@@ -1748,7 +1748,7 @@ class TestLinprogSimplexNoPresolve(LinprogSimplexTests):
         # even if the solution is wrong, the appropriate warning is issued.
         self.options.update({'tol': 1e-12})
         with pytest.warns(OptimizeWarning):
-            super(TestLinprogSimplexNoPresolve, self).test_bug_8174()
+            super().test_bug_8174()
 
     def test_unbounded_no_nontrivial_constraints_1(self):
         pytest.skip("Tests behavior specific to presolve")
@@ -1786,12 +1786,12 @@ class TestLinprogIPSparse(LinprogIPTests):
                                 "perturbations in linear system solution in "
                                 "_linprog_ip._sym_solve.")
     def test_bug_6139(self):
-        super(TestLinprogIPSparse, self).test_bug_6139()
+        super().test_bug_6139()
 
     @pytest.mark.xfail(reason='Fails with ATLAS, see gh-7877')
     def test_bug_6690(self):
         # Test defined in base class, but can't mark as xfail there
-        super(TestLinprogIPSparse, self).test_bug_6690()
+        super().test_bug_6690()
 
     def test_magic_square_sparse_no_presolve(self):
         # test linprog with a problem with a rank-deficient A_eq matrix
@@ -1836,7 +1836,7 @@ class TestLinprogIPSparsePresolve(LinprogIPTests):
                                 "perturbations in linear system solution in "
                                 "_linprog_ip._sym_solve.")
     def test_bug_6139(self):
-        super(TestLinprogIPSparsePresolve, self).test_bug_6139()
+        super().test_bug_6139()
 
     def test_enzo_example_c_with_infeasibility(self):
         pytest.skip('_sparse_presolve=True incompatible with presolve=False')
@@ -1844,7 +1844,7 @@ class TestLinprogIPSparsePresolve(LinprogIPTests):
     @pytest.mark.xfail(reason='Fails with ATLAS, see gh-7877')
     def test_bug_6690(self):
         # Test defined in base class, but can't mark as xfail there
-        super(TestLinprogIPSparsePresolve, self).test_bug_6690()
+        super().test_bug_6690()
 
 
 class TestLinprogIPSpecific(object):

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -51,7 +51,7 @@ class LinearTimeInvariant(object):
             raise NotImplementedError('The LinearTimeInvariant class is not '
                                       'meant to be used directly, use `lti` '
                                       'or `dlti` instead.')
-        return super(LinearTimeInvariant, cls).__new__(cls)
+        return super().__new__(cls)
 
     def __init__(self):
         """
@@ -59,7 +59,7 @@ class LinearTimeInvariant(object):
 
         The heavy lifting is done by the subclasses.
         """
-        super(LinearTimeInvariant, self).__init__()
+        super().__init__()
 
         self.inputs = None
         self.outputs = None
@@ -219,7 +219,7 @@ class lti(LinearTimeInvariant):
                 raise ValueError("`system` needs to be an instance of `lti` "
                                  "or have 2, 3 or 4 arguments.")
         # __new__ was called from a subclass, let it call its own functions
-        return super(lti, cls).__new__(cls)
+        return super().__new__(cls)
 
     def __init__(self, *system):
         """
@@ -227,7 +227,7 @@ class lti(LinearTimeInvariant):
 
         The heavy lifting is done by the subclasses.
         """
-        super(lti, self).__init__(*system)
+        super().__init__(*system)
 
     def impulse(self, X0=None, T=None, N=None):
         """
@@ -403,7 +403,7 @@ class dlti(LinearTimeInvariant):
                 raise ValueError("`system` needs to be an instance of `dlti` "
                                  "or have 2, 3 or 4 arguments.")
         # __new__ was called from a subclass, let it call its own functions
-        return super(dlti, cls).__new__(cls)
+        return super().__new__(cls)
 
     def __init__(self, *system, **kwargs):
         """
@@ -412,7 +412,7 @@ class dlti(LinearTimeInvariant):
         The heavy lifting is done by the subclasses.
         """
         dt = kwargs.pop('dt', True)
-        super(dlti, self).__init__(*system, **kwargs)
+        super().__init__(*system, **kwargs)
 
         self.dt = dt
 
@@ -583,7 +583,7 @@ class TransferFunction(LinearTimeInvariant):
                     **kwargs)
 
         # No special conversion needed
-        return super(TransferFunction, cls).__new__(cls)
+        return super().__new__(cls)
 
     def __init__(self, *system, **kwargs):
         """Initialize the state space LTI system."""
@@ -592,7 +592,7 @@ class TransferFunction(LinearTimeInvariant):
             return
 
         # Remove system arguments, not needed by parents anymore
-        super(TransferFunction, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self._num = None
         self._den = None
@@ -965,7 +965,7 @@ class ZerosPolesGain(LinearTimeInvariant):
                     )
 
         # No special conversion needed
-        return super(ZerosPolesGain, cls).__new__(cls)
+        return super().__new__(cls)
 
     def __init__(self, *system, **kwargs):
         """Initialize the zeros, poles, gain system."""
@@ -973,7 +973,7 @@ class ZerosPolesGain(LinearTimeInvariant):
         if isinstance(system[0], LinearTimeInvariant):
             return
 
-        super(ZerosPolesGain, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self._zeros = None
         self._poles = None
@@ -1328,7 +1328,7 @@ class StateSpace(LinearTimeInvariant):
                                                   *system, **kwargs)
 
         # No special conversion needed
-        return super(StateSpace, cls).__new__(cls)
+        return super().__new__(cls)
 
     def __init__(self, *system, **kwargs):
         """Initialize the state space lti/dlti system."""
@@ -1337,7 +1337,7 @@ class StateSpace(LinearTimeInvariant):
             return
 
         # Remove system arguments, not needed by parents anymore
-        super(StateSpace, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self._A = None
         self._B = None

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -51,7 +51,7 @@ class LinearTimeInvariant(object):
             raise NotImplementedError('The LinearTimeInvariant class is not '
                                       'meant to be used directly, use `lti` '
                                       'or `dlti` instead.')
-        return super().__new__(cls)
+        return super(LinearTimeInvariant, cls).__new__(cls)
 
     def __init__(self):
         """
@@ -219,7 +219,7 @@ class lti(LinearTimeInvariant):
                 raise ValueError("`system` needs to be an instance of `lti` "
                                  "or have 2, 3 or 4 arguments.")
         # __new__ was called from a subclass, let it call its own functions
-        return super().__new__(cls)
+        return super(lti, cls).__new__(cls)
 
     def __init__(self, *system):
         """
@@ -403,7 +403,7 @@ class dlti(LinearTimeInvariant):
                 raise ValueError("`system` needs to be an instance of `dlti` "
                                  "or have 2, 3 or 4 arguments.")
         # __new__ was called from a subclass, let it call its own functions
-        return super().__new__(cls)
+        return super(dlti, cls).__new__(cls)
 
     def __init__(self, *system, **kwargs):
         """
@@ -583,7 +583,7 @@ class TransferFunction(LinearTimeInvariant):
                     **kwargs)
 
         # No special conversion needed
-        return super().__new__(cls)
+        return super(TransferFunction, cls).__new__(cls)
 
     def __init__(self, *system, **kwargs):
         """Initialize the state space LTI system."""
@@ -965,7 +965,7 @@ class ZerosPolesGain(LinearTimeInvariant):
                     )
 
         # No special conversion needed
-        return super().__new__(cls)
+        return super(ZerosPolesGain, cls).__new__(cls)
 
     def __init__(self, *system, **kwargs):
         """Initialize the zeros, poles, gain system."""
@@ -1328,7 +1328,7 @@ class StateSpace(LinearTimeInvariant):
                                                   *system, **kwargs)
 
         # No special conversion needed
-        return super().__new__(cls)
+        return super(StateSpace, cls).__new__(cls)
 
     def __init__(self, *system, **kwargs):
         """Initialize the state space lti/dlti system."""

--- a/scipy/sparse/linalg/interface.py
+++ b/scipy/sparse/linalg/interface.py
@@ -15,7 +15,7 @@ represent an all-ones matrix::
     >>> import numpy as np
     >>> class Ones(LinearOperator):
     ...     def __init__(self, shape):
-    ...         super(Ones, self).__init__(dtype=None, shape=shape)
+    ...         super().__init__(dtype=None, shape=shape)
     ...     def _matvec(self, x):
     ...         return np.repeat(x.sum(), self.shape[0])
 
@@ -142,9 +142,9 @@ class LinearOperator(object):
     def __new__(cls, *args, **kwargs):
         if cls is LinearOperator:
             # Operate as _CustomLinearOperator factory.
-            return super(LinearOperator, cls).__new__(_CustomLinearOperator)
+            return super().__new__(_CustomLinearOperator)
         else:
-            obj = super(LinearOperator, cls).__new__(cls)
+            obj = super().__new__(cls)
 
             if (type(obj)._matvec == LinearOperator._matvec
                     and type(obj)._matmat == LinearOperator._matmat):
@@ -509,7 +509,7 @@ class _CustomLinearOperator(LinearOperator):
 
     def __init__(self, shape, matvec, rmatvec=None, matmat=None,
                  dtype=None, rmatmat=None):
-        super(_CustomLinearOperator, self).__init__(dtype, shape)
+        super().__init__(dtype, shape)
 
         self.args = ()
 
@@ -524,7 +524,7 @@ class _CustomLinearOperator(LinearOperator):
         if self.__matmat_impl is not None:
             return self.__matmat_impl(X)
         else:
-            return super(_CustomLinearOperator, self)._matmat(X)
+            return super()._matmat(X)
 
     def _matvec(self, x):
         return self.__matvec_impl(x)
@@ -539,7 +539,7 @@ class _CustomLinearOperator(LinearOperator):
         if self.__rmatmat_impl is not None:
             return self.__rmatmat_impl(X)
         else:
-            return super(_CustomLinearOperator, self)._rmatmat(X)
+            return super()._rmatmat(X)
 
     def _adjoint(self):
         return _CustomLinearOperator(shape=(self.shape[1], self.shape[0]),
@@ -554,7 +554,7 @@ class _AdjointLinearOperator(LinearOperator):
     """Adjoint of arbitrary Linear Operator"""
     def __init__(self, A):
         shape = (A.shape[1], A.shape[0])
-        super(_AdjointLinearOperator, self).__init__(dtype=A.dtype, shape=shape)
+        super().__init__(dtype=A.dtype, shape=shape)
         self.A = A
         self.args = (A,)
 
@@ -574,7 +574,7 @@ class _TransposedLinearOperator(LinearOperator):
     """Transposition of arbitrary Linear Operator"""
     def __init__(self, A):
         shape = (A.shape[1], A.shape[0])
-        super(_TransposedLinearOperator, self).__init__(dtype=A.dtype, shape=shape)
+        super().__init__(dtype=A.dtype, shape=shape)
         self.A = A
         self.args = (A,)
 
@@ -610,7 +610,7 @@ class _SumLinearOperator(LinearOperator):
             raise ValueError('cannot add %r and %r: shape mismatch'
                              % (A, B))
         self.args = (A, B)
-        super(_SumLinearOperator, self).__init__(_get_dtype([A, B]), A.shape)
+        super().__init__(_get_dtype([A, B]), A.shape)
 
     def _matvec(self, x):
         return self.args[0].matvec(x) + self.args[1].matvec(x)
@@ -637,7 +637,7 @@ class _ProductLinearOperator(LinearOperator):
         if A.shape[1] != B.shape[0]:
             raise ValueError('cannot multiply %r and %r: shape mismatch'
                              % (A, B))
-        super(_ProductLinearOperator, self).__init__(_get_dtype([A, B]),
+        super().__init__(_get_dtype([A, B]),
                                                      (A.shape[0], B.shape[1]))
         self.args = (A, B)
 
@@ -665,7 +665,7 @@ class _ScaledLinearOperator(LinearOperator):
         if not np.isscalar(alpha):
             raise ValueError('scalar expected as alpha')
         dtype = _get_dtype([A], [type(alpha)])
-        super(_ScaledLinearOperator, self).__init__(dtype, A.shape)
+        super().__init__(dtype, A.shape)
         self.args = (A, alpha)
 
     def _matvec(self, x):
@@ -694,7 +694,7 @@ class _PowerLinearOperator(LinearOperator):
         if not isintlike(p) or p < 0:
             raise ValueError('non-negative integer expected as p')
 
-        super(_PowerLinearOperator, self).__init__(_get_dtype([A]), A.shape)
+        super().__init__(_get_dtype([A]), A.shape)
         self.args = (A, p)
 
     def _power(self, fun, x):
@@ -722,7 +722,7 @@ class _PowerLinearOperator(LinearOperator):
 
 class MatrixLinearOperator(LinearOperator):
     def __init__(self, A):
-        super(MatrixLinearOperator, self).__init__(A.dtype, A.shape)
+        super().__init__(A.dtype, A.shape)
         self.A = A
         self.__adj = None
         self.args = (A,)
@@ -752,7 +752,7 @@ class _AdjointMatrixOperator(MatrixLinearOperator):
 
 class IdentityOperator(LinearOperator):
     def __init__(self, shape, dtype=None):
-        super(IdentityOperator, self).__init__(dtype, shape)
+        super().__init__(dtype, shape)
 
     def _matvec(self, x):
         return x

--- a/scipy/sparse/linalg/interface.py
+++ b/scipy/sparse/linalg/interface.py
@@ -142,9 +142,9 @@ class LinearOperator(object):
     def __new__(cls, *args, **kwargs):
         if cls is LinearOperator:
             # Operate as _CustomLinearOperator factory.
-            return super().__new__(_CustomLinearOperator)
+            return super(LinearOperator, cls).__new__(_CustomLinearOperator)
         else:
-            obj = super().__new__(cls)
+            obj = super(LinearOperator, cls).__new__(cls)
 
             if (type(obj)._matvec == LinearOperator._matvec
                     and type(obj)._matmat == LinearOperator._matmat):

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -373,7 +373,7 @@ def test_inheritance():
 
     class Identity(interface.LinearOperator):
         def __init__(self, n):
-            super(Identity, self).__init__(dtype=None, shape=(n, n))
+            super().__init__(dtype=None, shape=(n, n))
 
         def _matvec(self, x):
             return x
@@ -384,7 +384,7 @@ def test_inheritance():
 
     class MatmatOnly(interface.LinearOperator):
         def __init__(self, A):
-            super(MatmatOnly, self).__init__(A.dtype, A.shape)
+            super().__init__(A.dtype, A.shape)
             self.A = A
 
         def _matmat(self, x):

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -4532,7 +4532,7 @@ class _NonCanonicalMixin(object):
     def spmatrix(self, D, sorted_indices=False, **kwargs):
         """Replace D with a non-canonical equivalent: containing
         duplicate elements and explicit zeros"""
-        construct = super(_NonCanonicalMixin, self).spmatrix
+        construct = super().spmatrix
         M = construct(D, **kwargs)
 
         zero_pos = (M.A == 0).nonzero()

--- a/scipy/special/_generate_pyx.py
+++ b/scipy/special/_generate_pyx.py
@@ -675,7 +675,7 @@ class Ufunc(Func):
 
     """
     def __init__(self, name, signatures):
-        super(Ufunc, self).__init__(name, signatures)
+        super().__init__(name, signatures)
         self.doc = add_newdocs.get(name)
         if self.doc is None:
             raise ValueError("No docstring for ufunc %r" % name)
@@ -786,7 +786,7 @@ class FusedFunc(Func):
 
     """
     def __init__(self, name, signatures):
-        super(FusedFunc, self).__init__(name, signatures)
+        super().__init__(name, signatures)
         self.doc = "See the documentation for scipy.special." + self.name
         # "codes" are the keys for CY_TYPES
         self.incodes, self.outcodes = self._get_codes()

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -634,7 +634,7 @@ class beta_gen(rv_continuous):
             ku *= 6
             return [sk-g1, ku-g2]
         a, b = optimize.fsolve(func, (1.0, 1.0))
-        return super(beta_gen, self)._fitstart(data, args=(a, b))
+        return super()._fitstart(data, args=(a, b))
 
     @_call_super_mom
     @extend_notes_in_docstring(rv_continuous, notes="""\
@@ -651,7 +651,7 @@ class beta_gen(rv_continuous):
 
         if floc is None or fscale is None:
             # do general fit
-            return super(beta_gen, self).fit(data, *args, **kwds)
+            return super().fit(data, *args, **kwds)
 
         # We already got these from kwds, so just pop them.
         kwds.pop('floc', None)
@@ -2528,7 +2528,7 @@ class genextreme_gen(rv_continuous):
             a = 0.5
         else:
             a = -0.5
-        return super(genextreme_gen, self)._fitstart(data, args=(a,))
+        return super()._fitstart(data, args=(a,))
 
     def _munp(self, n, c):
         k = np.arange(0, n+1)
@@ -2661,7 +2661,7 @@ class gamma_gen(rv_continuous):
         # denominator to allow for degenerate data where the skewness
         # is close to 0.
         a = 4 / (1e-8 + _skew(data)**2)
-        return super(gamma_gen, self)._fitstart(data, args=(a,))
+        return super()._fitstart(data, args=(a,))
 
     @extend_notes_in_docstring(rv_continuous, notes="""\
         When the location is fixed by using the argument `floc`
@@ -2676,7 +2676,7 @@ class gamma_gen(rv_continuous):
 
         if floc is None or method.lower() == 'mm':
             # loc is not fixed.  Use the default fit method.
-            return super(gamma_gen, self).fit(data, *args, **kwds)
+            return super().fit(data, *args, **kwds)
 
         # We already have this value, so just pop it from kwds.
         kwds.pop('floc', None)
@@ -2790,7 +2790,7 @@ class erlang_gen(gamma_gen):
     # Trivial override of the fit method, so we can monkey-patch its
     # docstring.
     def fit(self, data, *args, **kwds):
-        return super(erlang_gen, self).fit(data, *args, **kwds)
+        return super().fit(data, *args, **kwds)
 
     if fit.__doc__:
         fit.__doc__ = (rv_continuous.fit.__doc__ +
@@ -3055,7 +3055,7 @@ class gumbel_r_gen(rv_continuous):
         # method. This scenario is not suitable for solving a system of
         # equations
         if floc is not None or fscale is not None:
-            return super(gumbel_r_gen, self).fit(data, *args, **kwds)
+            return super().fit(data, *args, **kwds)
 
         # rv_continuous provided guesses
         loc, scale = self._fitstart(data)
@@ -3530,7 +3530,7 @@ class invgauss_gen(rv_continuous):
         method = kwds.get('method', 'mle')
 
         if type(self) == wald_gen or method.lower() == 'mm':
-            return super(invgauss_gen, self).fit(data, *args, **kwds)
+            return super().fit(data, *args, **kwds)
 
         data, fshape_s, floc, fscale = _check_fit_input_parameters(self, data,
                                                                    args, kwds)
@@ -3547,7 +3547,7 @@ class invgauss_gen(rv_continuous):
           a `FitDataError`.
         '''
         if floc is None or fshape_s is not None:
-            return super(invgauss_gen, self).fit(data, *args, **kwds)
+            return super().fit(data, *args, **kwds)
         elif np.any(data - floc < 0):
             raise FitDataError("invgauss", lower=0, upper=np.inf)
         else:
@@ -4954,7 +4954,7 @@ class logistic_gen(rv_continuous):
         # method. This scenario is not suitable for solving a system of
         # equations
         if floc is not None or fscale is not None:
-            return super(logistic_gen, self).fit(data, *args, **kwds)
+            return super().fit(data, *args, **kwds)
 
         # rv_continuous provided guesses
         loc, scale = self._fitstart(data)
@@ -5176,7 +5176,7 @@ class lognorm_gen(rv_continuous):
         floc = kwds.get('floc', None)
         if floc is None:
             # fall back on the default fit method.
-            return super(lognorm_gen, self).fit(data, *args, **kwds)
+            return super().fit(data, *args, **kwds)
 
         f0 = (kwds.get('f0', None) or kwds.get('fs', None) or
               kwds.get('fix_s', None))
@@ -6284,7 +6284,7 @@ class pareto_gen(rv_continuous):
         parameters = _check_fit_input_parameters(self, data, args, kwds)
         data, fshape, floc, fscale = parameters
         if floc is None:
-            return super(pareto_gen, self).fit(data, **kwds)
+            return super().fit(data, **kwds)
         if np.any(data - floc < (fscale if fscale else 0)):
             raise FitDataError("pareto", lower=1, upper=np.inf)
         data = data - floc
@@ -9011,7 +9011,7 @@ class rv_histogram(rv_continuous):
         # Set support
         kwargs['a'] = self.a = self._hbins[0]
         kwargs['b'] = self.b = self._hbins[-1]
-        super(rv_histogram, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def _pdf(self, x):
         """
@@ -9048,7 +9048,7 @@ class rv_histogram(rv_continuous):
         """
         Set the histogram as additional constructor argument
         """
-        dct = super(rv_histogram, self)._updated_ctor_param()
+        dct = super()._updated_ctor_param()
         dct['histogram'] = self._histogram
         return dct
 

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -626,7 +626,7 @@ class rv_generic(object):
 
     """
     def __init__(self, seed=None):
-        super(rv_generic, self).__init__()
+        super().__init__()
 
         # figure out if _stats signature has 'moments' keyword
         sig = _getfullargspec(self._stats)
@@ -1688,7 +1688,7 @@ class rv_continuous(rv_generic):
                  badvalue=None, name=None, longname=None,
                  shapes=None, extradoc=None, seed=None):
 
-        super(rv_continuous, self).__init__(seed)
+        super().__init__(seed)
 
         # save the ctor parameters, cf generic freeze
         self._ctor_param = dict(
@@ -3021,16 +3021,16 @@ class rv_discrete(rv_generic):
 
         if values is not None:
             # dispatch to a subclass
-            return super(rv_discrete, cls).__new__(rv_sample)
+            return super().__new__(rv_sample)
         else:
             # business as usual
-            return super(rv_discrete, cls).__new__(cls)
+            return super().__new__(cls)
 
     def __init__(self, a=0, b=inf, name=None, badvalue=None,
                  moment_tol=1e-8, values=None, inc=1, longname=None,
                  shapes=None, extradoc=None, seed=None):
 
-        super(rv_discrete, self).__init__(seed)
+        super().__init__(seed)
 
         # cf generic freeze
         self._ctor_param = dict(
@@ -3188,7 +3188,7 @@ class rv_discrete(rv_generic):
 
         """
         kwargs['discrete'] = True
-        return super(rv_discrete, self).rvs(*args, **kwargs)
+        return super().rvs(*args, **kwargs)
 
     def pmf(self, k, *args, **kwds):
         """

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -3021,10 +3021,10 @@ class rv_discrete(rv_generic):
 
         if values is not None:
             # dispatch to a subclass
-            return super().__new__(rv_sample)
+            return super(rv_discrete, cls).__new__(rv_sample)
         else:
             # business as usual
-            return super().__new__(cls)
+            return super(rv_discrete, cls).__new__(cls)
 
     def __init__(self, a=0, b=inf, name=None, badvalue=None,
                  moment_tol=1e-8, values=None, inc=1, longname=None,

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -190,7 +190,7 @@ class multi_rv_generic(object):
 
     """
     def __init__(self, seed=None):
-        super(multi_rv_generic, self).__init__()
+        super().__init__()
         self._random_state = check_random_state(seed)
 
     @property
@@ -354,7 +354,7 @@ class multivariate_normal_gen(multi_rv_generic):
     """
 
     def __init__(self, seed=None):
-        super(multivariate_normal_gen, self).__init__(seed)
+        super().__init__(seed)
         self.__doc__ = doccer.docformat(self.__doc__, mvn_docdict_params)
 
     def __call__(self, mean=None, cov=1, allow_singular=False, seed=None):
@@ -934,7 +934,7 @@ class matrix_normal_gen(multi_rv_generic):
     """
 
     def __init__(self, seed=None):
-        super(matrix_normal_gen, self).__init__(seed)
+        super().__init__(seed)
         self.__doc__ = doccer.docformat(self.__doc__, matnorm_docdict_params)
 
     def __call__(self, mean=None, rowcov=1, colcov=1, seed=None):
@@ -1422,7 +1422,7 @@ class dirichlet_gen(multi_rv_generic):
     """
 
     def __init__(self, seed=None):
-        super(dirichlet_gen, self).__init__(seed)
+        super().__init__(seed)
         self.__doc__ = doccer.docformat(self.__doc__, dirichlet_docdict_params)
 
     def __call__(self, alpha, seed=None):
@@ -1751,7 +1751,7 @@ class wishart_gen(multi_rv_generic):
     """
 
     def __init__(self, seed=None):
-        super(wishart_gen, self).__init__(seed)
+        super().__init__(seed)
         self.__doc__ = doccer.docformat(self.__doc__, wishart_docdict_params)
 
     def __call__(self, df=None, scale=None, seed=None):
@@ -2483,7 +2483,7 @@ class invwishart_gen(wishart_gen):
     """
 
     def __init__(self, seed=None):
-        super(invwishart_gen, self).__init__(seed)
+        super().__init__(seed)
         self.__doc__ = doccer.docformat(self.__doc__, wishart_docdict_params)
 
     def __call__(self, df=None, scale=None, seed=None):
@@ -2731,8 +2731,7 @@ class invwishart_gen(wishart_gen):
         """
         random_state = self._get_random_state(random_state)
         # Get random draws A such that A ~ W(df, I)
-        A = super(invwishart_gen, self)._standard_rvs(n, shape, dim,
-                                                      df, random_state)
+        A = super()._standard_rvs(n, shape, dim, df, random_state)
 
         # Calculate SA = (CA)'^{-1} (CA)^{-1} ~ iW(df, scale)
         eye = np.eye(dim)
@@ -3018,7 +3017,7 @@ class multinomial_gen(multi_rv_generic):
     """  # noqa: E501
 
     def __init__(self, seed=None):
-        super(multinomial_gen, self).__init__(seed)
+        super().__init__(seed)
         self.__doc__ = \
             doccer.docformat(self.__doc__, multinomial_docdict_params)
 
@@ -3371,7 +3370,7 @@ class special_ortho_group_gen(multi_rv_generic):
     """
 
     def __init__(self, seed=None):
-        super(special_ortho_group_gen, self).__init__(seed)
+        super().__init__(seed)
         self.__doc__ = doccer.docformat(self.__doc__)
 
     def __call__(self, dim=None, seed=None):
@@ -3523,7 +3522,7 @@ class ortho_group_gen(multi_rv_generic):
     """
 
     def __init__(self, seed=None):
-        super(ortho_group_gen, self).__init__(seed)
+        super().__init__(seed)
         self.__doc__ = doccer.docformat(self.__doc__)
 
     def _process_parameters(self, dim):
@@ -3633,7 +3632,7 @@ class random_correlation_gen(multi_rv_generic):
     """
 
     def __init__(self, seed=None):
-        super(random_correlation_gen, self).__init__(seed)
+        super().__init__(seed)
         self.__doc__ = doccer.docformat(self.__doc__)
 
     def _process_parameters(self, eigs, tol):
@@ -3815,7 +3814,7 @@ class unitary_group_gen(multi_rv_generic):
     """
 
     def __init__(self, seed=None):
-        super(unitary_group_gen, self).__init__(seed)
+        super().__init__(seed)
         self.__doc__ = doccer.docformat(self.__doc__)
 
     def _process_parameters(self, dim):
@@ -3976,7 +3975,7 @@ class multivariate_t_gen(multi_rv_generic):
         seed : Random state.
 
         """
-        super(multivariate_t_gen, self).__init__(seed)
+        super().__init__(seed)
         self.__doc__ = doccer.docformat(self.__doc__, mvt_docdict_params)
         self._random_state = check_random_state(seed)
 
@@ -4442,7 +4441,7 @@ class multivariate_hypergeom_gen(multi_rv_generic):
            https://python.quantecon.org/_downloads/pdf/multi_hyper.pdf
     """
     def __init__(self, seed=None):
-        super(multivariate_hypergeom_gen, self).__init__(seed)
+        super().__init__(seed)
         self.__doc__ = doccer.docformat(self.__doc__, mhg_docdict_params)
 
     def __call__(self, m, n, seed=None):

--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -215,7 +215,7 @@ class _kde_subclass1(stats.gaussian_kde):
 class _kde_subclass2(stats.gaussian_kde):
     def __init__(self, dataset):
         self.covariance_factor = self.scotts_factor
-        super(_kde_subclass2, self).__init__(dataset)
+        super().__init__(dataset)
 
 
 class _kde_subclass3(stats.gaussian_kde):

--- a/setup.py
+++ b/setup.py
@@ -256,7 +256,7 @@ def get_build_ext_override():
             hooks = getattr(ext, '_pre_build_hook', ())
             _run_pre_build_hooks(hooks, (self, ext))
 
-            super(build_ext, self).build_extension(ext)
+            super().build_extension(ext)
 
         def __is_using_gnu_linker(self, ext):
             if not sys.platform.startswith('linux'):


### PR DESCRIPTION
There are two common ways to use the [`super` built-in](https://docs.python.org/3/library/functions.html#super):

1. Passing both the class and instance, e.g. `super(C, self)`, as was required for Python 2
2. Just using `super()` without arguments, as described by [PEP 3135](https://www.python.org/dev/peps/pep-3135/), adopted in 2007 for Python 3.0

Currently there is a mixture of the two forms; find them with `git grep "super([^)]"` or `git grep "super()"`. This PR refactors most of them to the PEP 3135 convention. This convention is cleaner and enforces the DRY (Don't Repeat Yourself) rule.

There are a few exceptions that should remain as they are (i.e. not touched by this PR):
1. [scipy/stats/_continuous_distns.py#L2788](https://github.com/scipy/scipy/blob/f679c65d641f6dbd5217516670ded71d60081076/scipy/stats/_continuous_distns.py#L2788)
2. [scipy/stats_distn_infrastructure.py#L3700](https://github.com/scipy/scipy/blob/f679c65d641f6dbd5217516670ded71d60081076/scipy/stats/_distn_infrastructure.py#L3700)

With both of these instances, `super(cls, self)`, the first argument *cls* is a different class to the parent class. There are a few other uses of `super()` used in methods outside classes that should also remain with arguments.