### PR TITLE
WIP: DOC: Added examples in docstrings in scipy.special

### DIFF
--- a/scipy/special/_spherical_bessel.py
+++ b/scipy/special/_spherical_bessel.py
@@ -61,6 +61,7 @@ def spherical_jn(n, z, derivative=False):
     >>> plt.plot(x, spherical_jn(2, x), 'g', label='j_2')
     >>> plt.legend()
     >>> plt.show()
+
     """
     if derivative:
         return _spherical_jn_d(n, z)
@@ -115,7 +116,6 @@ def spherical_yn(n, z, derivative=False):
 
     Examples
     --------
-
     The first spherical Bessel functions of the second kind:
 
     >>> from scipy.special import spherical_yn
@@ -128,6 +128,7 @@ def spherical_yn(n, z, derivative=False):
     >>> plt.ylim(-1.5, 0.5)
     >>> plt.legend()
     >>> plt.show()
+
     """
     if derivative:
         return _spherical_yn_d(n, z)
@@ -180,7 +181,6 @@ def spherical_in(n, z, derivative=False):
 
     Examples
     --------
-
     The first modified spherical Bessel functions of the first kind:
 
     >>> from scipy.special import spherical_in
@@ -193,6 +193,7 @@ def spherical_in(n, z, derivative=False):
     >>> plt.ylim(-0.5, 3.5)
     >>> plt.legend()
     >>> plt.show()
+
     """
     if derivative:
         return _spherical_in_d(n, z)
@@ -245,7 +246,6 @@ def spherical_kn(n, z, derivative=False):
 
     Examples
     --------
-
     The first modified spherical Bessel functions of the second kind:
 
     >>> from scipy.special import spherical_kn
@@ -258,6 +258,7 @@ def spherical_kn(n, z, derivative=False):
     >>> plt.ylim(-0.5, 3.5)
     >>> plt.legend()
     >>> plt.show()
+    
     """
     if derivative:
         return _spherical_kn_d(n, z)

--- a/scipy/special/_spherical_bessel.py
+++ b/scipy/special/_spherical_bessel.py
@@ -47,6 +47,20 @@ def spherical_jn(n, z, derivative=False):
     .. [1] https://dlmf.nist.gov/10.47.E3
     .. [2] https://dlmf.nist.gov/10.51.E1
     .. [3] https://dlmf.nist.gov/10.51.E2
+
+    Examples
+    --------
+    The first spherical Bessel functions of the first kind:
+
+    >>> from scipy.special import spherical_jn
+    >>> import matplotlib.pyplot as plt
+    >>> import numpy as np
+    >>> x = np.arange(0., 20., 0.1)
+    >>> plt.plot(x, spherical_jn(0, x), 'b', label='j_0')
+    >>> plt.plot(x, spherical_jn(1, x), 'r', label='j_1')
+    >>> plt.plot(x, spherical_jn(2, x), 'g', label='j_2')
+    >>> plt.legend()
+    >>> plt.show()
     """
     if derivative:
         return _spherical_jn_d(n, z)
@@ -98,6 +112,22 @@ def spherical_yn(n, z, derivative=False):
     .. [1] https://dlmf.nist.gov/10.47.E4
     .. [2] https://dlmf.nist.gov/10.51.E1
     .. [3] https://dlmf.nist.gov/10.51.E2
+
+    Examples
+    --------
+
+    The first spherical Bessel functions of the second kind:
+
+    >>> from scipy.special import spherical_yn
+    >>> import matplotlib.pyplot as plt
+    >>> import numpy as np
+    >>> x = np.arange(0., 20., 0.1)
+    >>> plt.plot(x, spherical_yn(0, x), 'b', label='y_0')
+    >>> plt.plot(x, spherical_yn(1, x), 'r', label='y_1')
+    >>> plt.plot(x, spherical_yn(2, x), 'g', label='y_2')
+    >>> plt.ylim(-1.5, 0.5)
+    >>> plt.legend()
+    >>> plt.show()
     """
     if derivative:
         return _spherical_yn_d(n, z)
@@ -147,6 +177,22 @@ def spherical_in(n, z, derivative=False):
     ----------
     .. [1] https://dlmf.nist.gov/10.47.E7
     .. [2] https://dlmf.nist.gov/10.51.E5
+
+    Examples
+    --------
+
+    The first modified spherical Bessel functions of the first kind:
+
+    >>> from scipy.special import spherical_in
+    >>> import matplotlib.pyplot as plt
+    >>> import numpy as np
+    >>> x = np.arange(0., 4., 0.1)
+    >>> plt.plot(x, spherical_in(0, x), 'b', label='i_0')
+    >>> plt.plot(x, spherical_in(1, x), 'r', label='i_1')
+    >>> plt.plot(x, spherical_in(2, x), 'g', label='i_2')
+    >>> plt.ylim(-0.5, 3.5)
+    >>> plt.legend()
+    >>> plt.show()
     """
     if derivative:
         return _spherical_in_d(n, z)
@@ -196,6 +242,22 @@ def spherical_kn(n, z, derivative=False):
     ----------
     .. [1] https://dlmf.nist.gov/10.47.E9
     .. [2] https://dlmf.nist.gov/10.51.E5
+
+    Examples
+    --------
+
+    The first modified spherical Bessel functions of the second kind:
+
+    >>> from scipy.special import spherical_kn
+    >>> import matplotlib.pyplot as plt
+    >>> import numpy as np
+    >>> x = np.arange(0., 4., 0.1)
+    >>> plt.plot(x, spherical_kn(0, x), 'b', label='k_0')
+    >>> plt.plot(x, spherical_kn(1, x), 'r', label='k_1')
+    >>> plt.plot(x, spherical_kn(2, x), 'g', label='k_2')
+    >>> plt.ylim(-0.5, 3.5)
+    >>> plt.legend()
+    >>> plt.show()
     """
     if derivative:
         return _spherical_kn_d(n, z)

--- a/scipy/special/orthogonal.py
+++ b/scipy/special/orthogonal.py
@@ -317,6 +317,22 @@ def jacobi(n, alpha, beta, monic=False):
     :math:`P_n^{(\alpha, \beta)}` are orthogonal over :math:`[-1, 1]`
     with weight function :math:`(1 - x)^\alpha(1 + x)^\beta`.
 
+    Examples
+    --------
+    Jacobi polynomials P_n with alpha=1.5, beta=-0.5, n=1,2,3,4
+
+    >>> from scipy.special import jacobi
+    >>> import matplotlib.pyplot as plt
+    >>> import numpy as np
+    >>> x = np.arange(-1., 1., 0.05)
+    >>> plt.plot(x, jacobi(1, 1.5, -0.5)(x), label='P_1, alpha=1.5, beta=-0.5)')
+    >>> plt.plot(x, jacobi(2, 1.5, -0.5)(x), label='P_2, alpha=1.5, beta=-0.5)')
+    >>> plt.plot(x, jacobi(3, 1.5, -0.5)(x), label='P_3, alpha=1.5, beta=-0.5)')
+    >>> plt.plot(x, jacobi(4, 1.5, -0.5)(x), label='P_4, alpha=1.5, beta=-0.5)')
+    >>> plt.ylim(-1.5, 5.)
+    >>> plt.legend()
+    >>> plt.show()
+
     """
     if n < 0:
         raise ValueError("n must be nonnegative.")
@@ -427,6 +443,21 @@ def sh_jacobi(n, p, q, monic=False):
     For fixed :math:`p, q`, the polynomials :math:`G_n^{(p, q)}` are
     orthogonal over :math:`[0, 1]` with weight function :math:`(1 -
     x)^{p - q}x^{q - 1}`.
+
+    Examples
+    --------
+    Jacobi shifted polynomials G_n with p=1.5, q=0.5, n=1,2,3
+
+    >>> from scipy.special import sh_jacobi
+    >>> import matplotlib.pyplot as plt
+    >>> import numpy as np
+    >>> x = np.arange(-1., 1.5, 0.1)
+    >>> plt.plot(x, sh_jacobi(1, 1.5, 0.5)(x), label='G_1, p=1.5, q=0.5')
+    >>> plt.plot(x, sh_jacobi(2, 1.5, 0.5)(x), label='G_2, p=1.5, q=0.5')
+    >>> plt.plot(x, sh_jacobi(3, 1.5, 0.5)(x), label='G_3, p=1.5, q=0.5')
+    >>> plt.ylim(-1.5, 2.)
+    >>> plt.legend()
+    >>> plt.show()
 
     """
     if n < 0:
@@ -555,6 +586,21 @@ def genlaguerre(n, alpha, monic=False):
     --------
     laguerre : Laguerre polynomial.
 
+    Examples
+    --------
+    Generalized Laguerre polynomial L_3 with alpha=0, 1, 2
+
+    >>> from scipy.special import genlaguerre
+    >>> import matplotlib.pyplot as plt
+    >>> import numpy as np
+    >>> x = np.arange(-2., 10., 0.1)
+    >>> plt.plot(x, genlaguerre(3, 0)(x), label='L_3, alpha=0')
+    >>> plt.plot(x, genlaguerre(3, 1)(x), label='L_3, alpha=1')
+    >>> plt.plot(x, genlaguerre(3, 2)(x), label='L_3, alpha=2')
+    >>> plt.ylim(-5., 10.)
+    >>> plt.legend()
+    >>> plt.show()
+    
     """
     if alpha <= -1:
         raise ValueError("alpha must be > -1")

--- a/scipy/special/orthogonal.py
+++ b/scipy/special/orthogonal.py
@@ -1143,6 +1143,23 @@ def hermite(n, monic=False):
     The polynomials :math:`H_n` are orthogonal over :math:`(-\infty,
     \infty)` with weight function :math:`e^{-x^2}`.
 
+    Examples
+    --------
+    The first 10 Hermite numbers:
+
+    >>> from scipy.special import hermite
+    >>> hermite_numbers = [hermite(n)(0) for n in range(10)]
+    >>> hermite_numbers
+    [1.0, 0.0, -2.0, -0.0, 12.0, 0.0, -120.0, -0.0, 1680.0, 0.0]
+
+    The 4th-order Hermite polynomial:
+
+    >>> from scipy.special import hermite
+    >>> import matplotlib.pyplot as plt
+    >>> import numpy as np
+    >>> x = np.arange(-2., 2., 0.1)
+    >>> plt.plot(x, hermite(4)(x))
+
     """
     if n < 0:
         raise ValueError("n must be nonnegative.")

--- a/scipy/special/orthogonal.py
+++ b/scipy/special/orthogonal.py
@@ -1502,6 +1502,20 @@ def chebyt(n, monic=False):
     --------
     chebyu : Chebyshev polynomial of the second kind.
 
+    Examples
+    --------
+    Chebyshev polynomials t_2, t_3, t_4:
+
+    >>> from scipy.special import chebyt
+    >>> import matplotlib.pyplot as plt
+    >>> import numpy as np
+    >>> x = np.arange(-2., 2., 0.1)
+    >>> plt.plot(x, chebyt(2)(x), 'b', label='t_2')
+    >>> plt.plot(x, chebyt(3)(x), 'r', label='t_3')
+    >>> plt.plot(x, chebyt(4)(x), 'g', label='t_4')
+    >>> plt.ylim(-5., 5.)
+    >>> plt.legend()
+    >>> plt.show()
     """
     if n < 0:
         raise ValueError("n must be nonnegative.")
@@ -1606,6 +1620,20 @@ def chebyu(n, monic=False):
     --------
     chebyt : Chebyshev polynomial of the first kind.
 
+    Examples
+    --------
+    Chebyshev polynomials u_0, u_1, u_2:
+
+    >>> from scipy.special import chebyu
+    >>> import matplotlib.pyplot as plt
+    >>> import numpy as np
+    >>> x = np.arange(-2., 2., 0.1)
+    >>> plt.plot(x, chebyu(0)(x), 'b', label='u_0')
+    >>> plt.plot(x, chebyu(1)(x), 'r', label='u_1')
+    >>> plt.plot(x, chebyu(2)(x), 'g', label='u_2')
+    >>> plt.ylim(-5., 5.)
+    >>> plt.legend()
+    >>> plt.show()
     """
     base = jacobi(n, 0.5, 0.5, monic=monic)
     if monic:

--- a/scipy/special/orthogonal.py
+++ b/scipy/special/orthogonal.py
@@ -694,6 +694,21 @@ def laguerre(n, monic=False):
     The polynomials :math:`L_n` are orthogonal over :math:`[0,
     \infty)` with weight function :math:`e^{-x}`.
 
+    Examples
+    --------
+    The Laguerre polynomials are the special case alpha=0 of the generalized
+    Laguerre polynomials:
+    >>> from scipy.special import genlaguerre, laguerre
+    >>> import matplotlib.pyplot as plt
+    >>> fig, (ax1, ax2) = plt.subplots(2)
+    >>> ax1.plot(x, genlaguerre(3, 0)(x), label='L_3, alpha=0')
+    >>> ax1.set_ylim(-5., 10.)
+    >>> ax1.legend()
+    >>> ax2.plot(x, laguerre(3)(x), label='L_3')
+    >>> ax2.set_ylim(-5., 10.)
+    >>> ax2.legend()
+    >>> plt.show()
+
     """
     if n < 0:
         raise ValueError("n must be nonnegative.")


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Issue #7168 

#### What does this implement/fix?
<!--Please explain your changes.-->
The current docstring does not provide any example for the Hermite function in scipy.special. I added a couple.

UPDATE:
I decided to contribute some more. So far I added examples for:

- /scipy/special/orthogonal.py
jacobi
sh_jacobi
genlaguerre
laguerre
hermite
chebyt
chebyu

- /scipy/special/_spherical_bessel.py
spherical_jn
spherical_yn
spherical_in
spherical_kn

Suggestions and comments are always welcome. Work is in progress.

