### PR TITLE
MAINT: mypy: ignore mpmath imports in mypy.ini

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -63,6 +63,9 @@ ignore_missing_imports = True
 [mypy-pythran]
 ignore_missing_imports = True
 
+[mypy-mpmath]
+ignore_missing_imports = True
+
 #
 # Extension modules without stubs.
 #

--- a/scipy/signal/tests/mpsig.py
+++ b/scipy/signal/tests/mpsig.py
@@ -3,7 +3,7 @@ Some signal functions implemented using mpmath.
 """
 
 try:
-    import mpmath  # type: ignore[import]
+    import mpmath
 except ImportError:
     mpmath = None
 

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -23,7 +23,7 @@ from scipy.signal.filter_design import (_cplxreal, _cplxpair, _norm_factor,
                                         _bessel_poly, _bessel_zeros)
 
 try:
-    import mpmath  # type: ignore[import]
+    import mpmath
 except ImportError:
     mpmath = None
 

--- a/scipy/special/_mptestutils.py
+++ b/scipy/special/_mptestutils.py
@@ -9,7 +9,7 @@ import pytest
 from scipy.special._testutils import assert_func_equal
 
 try:
-    import mpmath  # type: ignore[import]
+    import mpmath
 except ImportError:
     pass
 

--- a/scipy/special/_precompute/cosine_cdf.py
+++ b/scipy/special/_precompute/cosine_cdf.py
@@ -1,5 +1,5 @@
 
-import mpmath  # type: ignore[import]
+import mpmath
 
 
 def f(x):

--- a/scipy/special/_precompute/gammainc_asy.py
+++ b/scipy/special/_precompute/gammainc_asy.py
@@ -12,7 +12,7 @@ import os
 from scipy.special._precompute.utils import lagrange_inversion
 
 try:
-    import mpmath as mp  # type: ignore[import]
+    import mpmath as mp
 except ImportError:
     pass
 

--- a/scipy/special/_precompute/gammainc_data.py
+++ b/scipy/special/_precompute/gammainc_data.py
@@ -25,7 +25,7 @@ from numpy import pi
 from scipy.special._mptestutils import mpf2float
 
 try:
-    import mpmath as mp  # type: ignore[import]
+    import mpmath as mp
 except ImportError:
     pass
 

--- a/scipy/special/_precompute/lambertw.py
+++ b/scipy/special/_precompute/lambertw.py
@@ -6,7 +6,7 @@ approximations.
 import numpy as np
 
 try:
-    import mpmath  # type: ignore[import]
+    import mpmath
     import matplotlib.pyplot as plt  # type: ignore[import]
 except ImportError:
     pass

--- a/scipy/special/_precompute/loggamma.py
+++ b/scipy/special/_precompute/loggamma.py
@@ -1,7 +1,7 @@
 """Precompute series coefficients for log-Gamma."""
 
 try:
-    import mpmath  # type: ignore[import]
+    import mpmath
 except ImportError:
     pass
 

--- a/scipy/special/_precompute/struve_convergence.py
+++ b/scipy/special/_precompute/struve_convergence.py
@@ -34,7 +34,7 @@ Black dashed line
 import numpy as np
 import matplotlib.pyplot as plt  # type: ignore[import]
 
-import mpmath  # type: ignore[import]
+import mpmath
 
 
 def err_metric(a, b, atol=1e-290):

--- a/scipy/special/_precompute/utils.py
+++ b/scipy/special/_precompute/utils.py
@@ -1,5 +1,5 @@
 try:
-    import mpmath as mp  # type: ignore[import]
+    import mpmath as mp
 except ImportError:
     pass
 

--- a/scipy/special/_precompute/wright_bessel_data.py
+++ b/scipy/special/_precompute/wright_bessel_data.py
@@ -12,7 +12,7 @@ import numpy as np
 from scipy.special._mptestutils import mpf2float
 
 try:
-    import mpmath as mp # type: ignore[import]
+    import mpmath as mp
 except ImportError:
     pass
 

--- a/scipy/special/_precompute/wrightomega.py
+++ b/scipy/special/_precompute/wrightomega.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 try:
-    import mpmath  # type: ignore[import]
+    import mpmath
 except ImportError:
     pass
 

--- a/scipy/special/_precompute/zetac.py
+++ b/scipy/special/_precompute/zetac.py
@@ -1,6 +1,6 @@
 """Compute the Taylor series for zeta(x) - 1 around x = 0."""
 try:
-    import mpmath  # type: ignore[import]
+    import mpmath
 except ImportError:
     pass
 

--- a/scipy/special/tests/test_cdflib.py
+++ b/scipy/special/tests/test_cdflib.py
@@ -32,7 +32,7 @@ from scipy.special._mptestutils import (
     Arg, IntArg, get_args, mpf2float, assert_mpmath_equal)
 
 try:
-    import mpmath  # type: ignore[import]
+    import mpmath
 except ImportError:
     mpmath = MissingModule('mpmath')
 

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -23,7 +23,7 @@ from scipy.special._ufuncs import (
     _igam_fac)
 
 try:
-    import mpmath  # type: ignore[import]
+    import mpmath
 except ImportError:
     mpmath = MissingModule('mpmath')
 

--- a/scipy/special/tests/test_precompute_gammainc.py
+++ b/scipy/special/tests/test_precompute_gammainc.py
@@ -14,7 +14,7 @@ except ImportError:
     sympy = MissingModule('sympy')
 
 try:
-    import mpmath as mp  # type: ignore[import]
+    import mpmath as mp
 except ImportError:
     mp = MissingModule('mpmath')
 

--- a/scipy/special/tests/test_precompute_utils.py
+++ b/scipy/special/tests/test_precompute_utils.py
@@ -10,7 +10,7 @@ except ImportError:
     sympy = MissingModule('sympy')
 
 try:
-    import mpmath as mp  # type: ignore[import]
+    import mpmath as mp
 except ImportError:
     mp = MissingModule('mpmath')
 


### PR DESCRIPTION
#### Reference issue

N/A

#### What does this implement/fix?

As discussed in https://github.com/scipy/scipy/pull/13721#discussion_r598389079 and also suggested on the mailing list: https://mail.python.org/pipermail/scipy-dev/2021-March/024635.html, this adds the `mpmath` import to `mypy.ini` file.

`mpmath` should be ignored in the `mypy.ini` file so that future PRs don't have to use the `type: ignore[import]` directive every time `mpmath` is imported.

#### Additional information
<!--Any additional information you think is important.-->