### PR TITLE
BENCH: add benchmark for Kendalltau

### DIFF
--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -50,6 +50,7 @@ class Kendalltau(Benchmark):
     ]
 
     def setup(self, nan_policy, method, variant):
+        np.random.seed(12345678)
         a = np.arange(200)
         np.random.shuffle(a)
         b = np.arange(200)

--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -1,7 +1,6 @@
 import warnings
 
 import numpy as np
-import random
 from .common import Benchmark, safe_import, is_xslow
 
 with safe_import():
@@ -51,15 +50,15 @@ class Kendalltau(Benchmark):
     ]
 
     def setup(self, nan_policy, method, variant):
-        a = [x for x in range(0, 200)]
-        random.shuffle(a)
-        b = [x for x in range(0, 200)]
-        random.shuffle(b)
+        a = np.arange(200)
+        np.random.shuffle(a)
+        b = np.arange(200)
+        np.random.shuffle(b)
         self.a = a
         self.b = b
 
     def time_kendalltau(self, nan_policy, method, variant):
-        tau, p_value = stats.kendalltau(self.a, self.b, nan_policy = nan_policy, method = method, variant = variant)
+        tau, p_value = stats.kendalltau(self.a, self.b, nan_policy=nan_policy, method=method, variant=variant)
 
 
 class InferentialStats(Benchmark):

--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -1,6 +1,7 @@
 import warnings
 
 import numpy as np
+import random
 from .common import Benchmark, safe_import, is_xslow
 
 with safe_import():
@@ -39,6 +40,26 @@ class CorrelationFunctions(Benchmark):
 
     def time_barnard_exact(self, alternative):
         resBarnard = stats.barnard_exact(self.a, alternative=alternative)
+
+
+class Kendalltau(Benchmark):
+    param_names = ['nan_policy','method','variant']
+    params = [
+        ['propagate', 'raise', 'omit'],
+        ['auto', 'asymptotic', 'exact'],
+        ['b', 'c']
+    ]
+
+    def setup(self, nan_policy, method, variant):
+        a = [x for x in range(0, 200)]
+        random.shuffle(a)
+        b = [x for x in range(0, 200)]
+        random.shuffle(b)
+        self.a = a
+        self.b = b
+
+    def time_kendalltau(self, nan_policy, method, variant):
+        tau, p_value = stats.kendalltau(self.a, self.b, nan_policy = nan_policy, method = method, variant = variant)
 
 
 class InferentialStats(Benchmark):


### PR DESCRIPTION
#### What does this implement/fix?
Add benchmark for stats.kendalltau. The results on my local machine:


```
(scipydev) charlotte@CHARLOTLIU-MB0 scipy % python runtests.py --bench stats.Kendalltau
Building, see build.log...
Build OK (0:00:08.047040 elapsed)
Running benchmarks for Scipy version 1.7.0.dev0+f679c65 at /Users/charlotte/Desktop/internship/gsoc/scipy/build/testenv/lib/python3.8/site-packages/scipy/__init__.py
· No `environment_type` specified in asv.conf.json. This will be required in the future.
· Discovering benchmarks
· Running 1 total benchmarks (1 commits * 1 environments * 1 benchmarks)
[  0.00%] ·· Benchmarking existing-py_Users_charlotte_anaconda3_envs_scipydev_bin_python
[ 50.00%] ··· Running (stats.Kendalltau.time_kendalltau--).
[100.00%] ··· stats.Kendalltau.time_kendalltau                                                       ok
[100.00%] ··· ============ ============ ============= =============
              --                                  variant          
              ------------------------- ---------------------------
               nan_policy     method          b             c      
              ============ ============ ============= =============
               propagate       auto        209±10μs      250±8μs   
               propagate    asymptotic     202±10μs      257±20μs  
               propagate      exact       9.01±0.4ms   8.68±0.09ms 
                 raise         auto        199±3μs       236±2μs   
                 raise      asymptotic     198±2μs       238±6μs   
                 raise        exact      8.61±0.05ms   8.62±0.05ms 
                  omit         auto        199±7μs       238±6μs   
                  omit      asymptotic     199±3μs       231±4μs   
                  omit        exact      8.60±0.04ms   8.66±0.09ms 
              ============ ============ ============= =============
```