### PR TITLE
MAINT: stats: Some flake8-driven clean up.

### DIFF
--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -639,12 +639,14 @@ def _calc_binned_statistic(Vdim, bin_numbers, result, values, stat_func,
                            is_callable=False):
     unique_bin_numbers = np.unique(bin_numbers)
     for vv in builtins.range(Vdim):
-        bin_map = _create_binned_data(bin_numbers, unique_bin_numbers, values, vv)
+        bin_map = _create_binned_data(bin_numbers, unique_bin_numbers,
+                                      values, vv)
         for i in unique_bin_numbers:
             # if the stat_func is callable, all results should be updated
             # if the stat_func is np.std, calc std only when binned data is 2
             # or more for speed up.
-            if is_callable or not (stat_func is np.std and len(bin_map[i]) < 2):
+            if is_callable or not (stat_func is np.std and
+                                   len(bin_map[i]) < 2):
                 result[vv, i] = stat_func(np.array(bin_map[i]))
 
 
@@ -695,13 +697,15 @@ def _bin_edges(sample, bins=None, range=None):
             smax[i] = smax[i] + .5
 
     # Preserve sample floating point precision in bin edges
-    edges_dtype = sample.dtype if np.issubdtype(sample.dtype, np.floating) else float
+    edges_dtype = (sample.dtype if np.issubdtype(sample.dtype, np.floating)
+                   else float)
 
     # Create edge arrays
     for i in builtins.range(Ndim):
         if np.isscalar(bins[i]):
             nbin[i] = bins[i] + 2  # +2 for outlier bins
-            edges[i] = np.linspace(smin[i], smax[i], nbin[i] - 1, dtype=edges_dtype)
+            edges[i] = np.linspace(smin[i], smax[i], nbin[i] - 1,
+                                   dtype=edges_dtype)
         else:
             edges[i] = np.asarray(bins[i], edges_dtype)
             nbin[i] = len(edges[i]) + 1  # +1 for outlier bins

--- a/scipy/stats/_binomtest.py
+++ b/scipy/stats/_binomtest.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from math import sqrt
 import numpy as np
 from scipy._lib._util import _validate_int

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -5876,8 +5876,7 @@ class nakagami_gen(rv_continuous):
         if args is None:
             args = (1.0,) * self.numargs
         # Analytical justified estimates
-        # see: https://docs.scipy.org/doc/scipy/reference/tutorial/stats/
-        #      continuous_nakagami.html
+        # see: https://docs.scipy.org/doc/scipy/reference/tutorial/stats/continuous_nakagami.html
         loc = np.min(data)
         scale = np.sqrt(np.sum((data - loc)**2) / len(data))
         return args + (loc, scale)

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -24,8 +24,7 @@ from ._tukeylambda_stats import (tukeylambda_variance as _tlvar,
                                  tukeylambda_kurtosis as _tlkurt)
 from ._distn_infrastructure import (
     get_distribution_names, _kurtosis, _ncx2_cdf, _ncx2_log_pdf, _ncx2_pdf,
-    rv_continuous, _skew, _get_fixed_fit_value, _check_shape,
-    _fit_determine_optimizer)
+    rv_continuous, _skew, _get_fixed_fit_value, _check_shape)
 from ._ksstats import kolmogn, kolmognp, kolmogni
 from ._constants import (_XMIN, _EULER, _ZETA3,
                          _SQRT_2_OVER_PI, _LOG_SQRT_2_OVER_PI)
@@ -50,7 +49,7 @@ def _remove_optimizer_parameters(kwds):
         raise TypeError("Unknown arguments: %s." % kwds)
 
 def _call_super_mom(fun):
-    # if fit method is overridden only for MLE and doens't specify what to do
+    # if fit method is overridden only for MLE and doesn't specify what to do
     # if method == 'mm', this decorator calls generic implementation
     def wrapper(self, *args, **kwds):
         method = kwds.get('method', 'mle').lower()
@@ -1935,7 +1934,7 @@ class f_gen(rv_continuous):
         n = 1.0 * dfn
         m = 1.0 * dfd
         lPx = (m/2 * np.log(m) + n/2 * np.log(n) + sc.xlogy(n/2 - 1, x)
-                   - (((n+m)/2) * np.log(m + n*x) + sc.betaln(n/2, m/2)))
+               - (((n+m)/2) * np.log(m + n*x) + sc.betaln(n/2, m/2)))
         return lPx
 
     def _cdf(self, x, dfn, dfd):
@@ -3637,7 +3636,8 @@ class geninvgauss_gen(rv_continuous):
         def _cdf_single(x, *args):
             p, b = args
             user_data = np.array([p, b], float).ctypes.data_as(ctypes.c_void_p)
-            llc = LowLevelCallable.from_cython(_stats, '_geninvgauss_pdf', user_data)
+            llc = LowLevelCallable.from_cython(_stats, '_geninvgauss_pdf',
+                                               user_data)
 
             return integrate.quad(llc, _a, x)[0]
 
@@ -3696,7 +3696,8 @@ class geninvgauss_gen(rv_continuous):
                 # would cause an IndexError.
                 idx = tuple((it.multi_index[j] if not bc[j] else slice(None))
                             for j in range(-len(size), 0))
-                out[idx] = self._rvs_scalar(it[0], it[1], numsamples, random_state).reshape(shp)
+                out[idx] = self._rvs_scalar(it[0], it[1], numsamples,
+                                            random_state).reshape(shp)
                 it.iternext()
 
         if size == ():
@@ -3935,7 +3936,8 @@ class norminvgauss_gen(rv_continuous):
         # normal and V is invgauss(mu=1/sqrt(a**2 - b**2))
         gamma = np.sqrt(a**2 - b**2)
         ig = invgauss.rvs(mu=1/gamma, size=size, random_state=random_state)
-        return b * ig + np.sqrt(ig) * norm.rvs(size=size, random_state=random_state)
+        return b * ig + np.sqrt(ig) * norm.rvs(size=size,
+                                               random_state=random_state)
 
     def _stats(self, a, b):
         gamma = np.sqrt(a**2 - b**2)
@@ -5771,7 +5773,8 @@ class moyal_gen(rv_continuous):
 
     """
     def _rvs(self, size=None, random_state=None):
-        u1 = gamma.rvs(a = 0.5, scale = 2, size=size, random_state=random_state)
+        u1 = gamma.rvs(a=0.5, scale=2, size=size,
+                       random_state=random_state)
         return -np.log(u1)
 
     def _pdf(self, x):
@@ -5873,7 +5876,8 @@ class nakagami_gen(rv_continuous):
         if args is None:
             args = (1.0,) * self.numargs
         # Analytical justified estimates
-        # see: https://docs.scipy.org/doc/scipy/reference/tutorial/stats/continuous_nakagami.html
+        # see: https://docs.scipy.org/doc/scipy/reference/tutorial/stats/
+        #      continuous_nakagami.html
         loc = np.min(data)
         scale = np.sqrt(np.sum((data - loc)**2) / len(data))
         return args + (loc, scale)
@@ -6085,14 +6089,14 @@ class t_gen(rv_continuous):
         #                sqrt(pi*df) * gamma(df/2) * (1+x**2/df)**((df+1)/2)
         r = np.asarray(df*1.0)
         Px = (np.exp(sc.gammaln((r+1)/2)-sc.gammaln(r/2))
-                  / (np.sqrt(r*np.pi)*(1+(x**2)/r)**((r+1)/2)))
+              / (np.sqrt(r*np.pi)*(1+(x**2)/r)**((r+1)/2)))
 
         return Px
 
     def _logpdf(self, x, df):
         r = df*1.0
-        lPx = (sc.gammaln((r+1)/2)-sc.gammaln(r/2)
-                   - (0.5*np.log(r*np.pi) + (r+1)/2*np.log(1+(x**2)/r)))
+        lPx = (sc.gammaln((r+1)/2) - sc.gammaln(r/2)
+               - (0.5*np.log(r*np.pi) + (r+1)/2*np.log(1+(x**2)/r)))
         return lPx
 
     def _cdf(self, x, df):
@@ -6170,13 +6174,14 @@ class nct_gen(rv_continuous):
         ncx2 = nc*nc*x2
         fac1 = n + x2
         trm1 = (n/2.*np.log(n) + sc.gammaln(n+1)
-                    - (n*np.log(2)+nc*nc/2.+(n/2.)*np.log(fac1)+sc.gammaln(n/2.)))
+                - (n*np.log(2) + nc*nc/2 + (n/2)*np.log(fac1)
+                   + sc.gammaln(n/2)))
         Px = np.exp(trm1)
         valF = ncx2 / (2*fac1)
-        trm1 =  (np.sqrt(2)*nc*x*sc.hyp1f1(n/2+1, 1.5, valF)
-                         / np.asarray(fac1*sc.gamma((n+1)/2)))
+        trm1 = (np.sqrt(2)*nc*x*sc.hyp1f1(n/2+1, 1.5, valF)
+                / np.asarray(fac1*sc.gamma((n+1)/2)))
         trm2 = (sc.hyp1f1((n+1)/2, 0.5, valF)
-                        / np.asarray(np.sqrt(fac1)*sc.gamma(n/2+1)))
+                / np.asarray(np.sqrt(fac1)*sc.gamma(n/2+1)))
         Px *= trm1+trm2
         return Px
 
@@ -7500,6 +7505,7 @@ truncexpon = truncexpon_gen(a=0.0, name='truncexpon')
 TRUNCNORM_TAIL_X = 30
 TRUNCNORM_MAX_BRENT_ITERS = 40
 
+
 def _truncnorm_get_delta_scalar(a, b):
     if (a > TRUNCNORM_TAIL_X) or (b < -TRUNCNORM_TAIL_X):
         return 0
@@ -7509,6 +7515,7 @@ def _truncnorm_get_delta_scalar(a, b):
         delta = _norm_cdf(b) - _norm_cdf(a)
     delta = max(delta, 0)
     return delta
+
 
 def _truncnorm_get_delta(a, b):
     if np.isscalar(a) and np.isscalar(b):
@@ -7526,6 +7533,7 @@ def _truncnorm_get_delta(a, b):
         np.place(delta, condb, _norm_cdf(b[condb]) - _norm_cdf(a[condb]))
     delta[delta < 0] = 0
     return delta
+
 
 def _truncnorm_get_logdelta_scalar(a, b):
     if (a <= TRUNCNORM_TAIL_X) and (b >= -TRUNCNORM_TAIL_X):
@@ -7614,7 +7622,8 @@ def _truncnorm_logcdf_scalar(x, a, b):
             delta = _truncnorm_get_delta_scalar(a, b)
             if delta > 0:
                 np.place(out, cond_inner,
-                         np.log((_norm_cdf(x[cond_inner]) - _norm_cdf(a)) / delta))
+                         np.log((_norm_cdf(x[cond_inner]) - _norm_cdf(a))
+                                / delta))
             else:
                 with np.errstate(divide='ignore'):
                     if a < 0:
@@ -7627,8 +7636,9 @@ def _truncnorm_logcdf_scalar(x, a, b):
                         sla = _norm_logsf(a)
                         slb = _norm_logsf(b)
                         np.place(out, cond_inner,
-                                 np.log1p(-np.exp(_norm_logsf(x[cond_inner]) - sla))
-                                - np.log1p(-np.exp(slb - sla)))
+                                 np.log1p(-np.exp(_norm_logsf(x[cond_inner])
+                                                  - sla))
+                                 - np.log1p(-np.exp(slb - sla)))
         return (out[0] if (shp == ()) else out)
 
 
@@ -7656,7 +7666,8 @@ def _truncnorm_cdf_scalar(x, a, b):
             else:
                 with np.errstate(divide='ignore'):
                     np.place(out, cond_inner,
-                             np.exp(_truncnorm_logcdf_scalar(x[cond_inner], a, b)))
+                             np.exp(_truncnorm_logcdf_scalar(x[cond_inner],
+                                                             a, b)))
         return (out[0] if (shp == ()) else out)
 
 
@@ -7680,14 +7691,17 @@ def _truncnorm_logsf_scalar(x, a, b):
         if np.any(cond_inner):
             delta = _truncnorm_get_delta_scalar(a, b)
             if delta > 0:
-                np.place(out, cond_inner, np.log((_norm_sf(x[cond_inner]) - _norm_sf(b)) / delta))
+                np.place(out, cond_inner,
+                         np.log((_norm_sf(x[cond_inner]) - _norm_sf(b))
+                                / delta))
             else:
                 with np.errstate(divide='ignore'):
                     if b < 0:
                         nla, nlb = _norm_logcdf(a), _norm_logcdf(b)
                         np.place(out, cond_inner,
-                                 np.log1p(-np.exp(_norm_logcdf(x[cond_inner]) - nlb))
-                               - np.log1p(-np.exp(nla - nlb)))
+                                 np.log1p(-np.exp(_norm_logcdf(x[cond_inner])
+                                                  - nlb))
+                                 - np.log1p(-np.exp(nla - nlb)))
                     else:
                         sla, slb = _norm_logsf(a), _norm_logsf(b)
                         tab = np.log1p(-np.exp(slb - sla))
@@ -7717,18 +7731,23 @@ def _truncnorm_sf_scalar(x, a, b):
         if np.any(cond_inner):
             delta = _truncnorm_get_delta_scalar(a, b)
             if delta > 0:
-                np.place(out, cond_inner, (_norm_sf(x[cond_inner]) - _norm_sf(b)) / delta)
+                np.place(out, cond_inner,
+                         (_norm_sf(x[cond_inner]) - _norm_sf(b)) / delta)
             else:
-                np.place(out, cond_inner, np.exp(_truncnorm_logsf_scalar(x[cond_inner], a, b)))
+                np.place(out, cond_inner,
+                         np.exp(_truncnorm_logsf_scalar(x[cond_inner], a, b)))
         return (out[0] if (shp == ()) else out)
 
 
 def _norm_logcdfprime(z):
     # derivative of special.log_ndtr (See special/cephes/ndtr.c)
     # Differentiate formula for log Phi(z)_truncnorm_ppf
-    # log Phi(z) = -z^2/2 - log(-z) - log(2pi)/2 + log(1 + sum (-1)^n (2n-1)!! / z^(2n))
-    # Convergence of series is slow for |z| < 10, but can use d(log Phi(z))/dz = dPhi(z)/dz / Phi(z)
-    # Just take the first 10 terms because that is sufficient for use in _norm_ilogcdf
+    # log Phi(z) = -z^2/2 - log(-z) - log(2pi)/2
+    #              + log(1 + sum (-1)^n (2n-1)!! / z^(2n))
+    # Convergence of series is slow for |z| < 10, but can use
+    #     d(log Phi(z))/dz = dPhi(z)/dz / Phi(z)
+    # Just take the first 10 terms because that is sufficient for use
+    # in _norm_ilogcdf
     assert np.all(z <= -10)
     lhs = -z - 1/z
     denom_cons = 1/z**2
@@ -7744,6 +7763,7 @@ def _norm_logcdfprime(z):
         numerator_total += term * (2 * i) / z
         sign = -sign
     return lhs - numerator_total / (1 + denom_total)
+
 
 def _norm_ilogcdf(y):
     """Inverse function to _norm_logcdf==sc.log_ndtr."""
@@ -7777,7 +7797,8 @@ def _truncnorm_ppf_scalar(q, a, b):
                          _norm_isf(qinner * sb + sa * (1.0 - qinner)))
             else:
                 na, nb = _norm_cdf(a), _norm_cdf(b)
-                np.place(out, cond_inner, _norm_ppf(qinner * nb + na * (1.0 - qinner)))
+                np.place(out, cond_inner,
+                         _norm_ppf(qinner * nb + na * (1.0 - qinner)))
         elif np.isinf(b):
             np.place(out, cond_inner,
                      -_norm_ilogcdf(np.log1p(-qinner) + _norm_logsf(a)))
@@ -7786,7 +7807,10 @@ def _truncnorm_ppf_scalar(q, a, b):
                      _norm_ilogcdf(np.log(q) + _norm_logcdf(b)))
         else:
             if b < 0:
-                # Solve norm_logcdf(x) = norm_logcdf(a) + log1p(q * (expm1(norm_logcdf(b)  - norm_logcdf(a)))
+                # Solve
+                # norm_logcdf(x)
+                #      = norm_logcdf(a) + log1p(q * (expm1(norm_logcdf(b)
+                #                                    - norm_logcdf(a)))
                 #      = nla + log1p(q * expm1(nlb - nla))
                 #      = nlb + log(q) + log1p((1-q) * exp(nla - nlb)/q)
                 def _f_cdf(x, c):
@@ -7799,10 +7823,14 @@ def _truncnorm_ppf_scalar(q, a, b):
                     one_minus_q = (1 - q)[cond_inner]
                     values += np.log1p(one_minus_q * C / q[cond_inner])
                 x = [optimize.zeros.brentq(_f_cdf, a, b, args=(c,),
-                                           maxiter=TRUNCNORM_MAX_BRENT_ITERS)for c in values]
+                                           maxiter=TRUNCNORM_MAX_BRENT_ITERS)
+                     for c in values]
                 np.place(out, cond_inner, x)
             else:
-                # Solve norm_logsf(x) = norm_logsf(b) + log1p((1-q) * (expm1(norm_logsf(a)  - norm_logsf(b)))
+                # Solve
+                # norm_logsf(x)
+                #      = norm_logsf(b) + log1p((1-q) * (expm1(norm_logsf(a)
+                #                                       - norm_logsf(b)))
                 #      = slb + log1p((1-q)[cond_inner] * expm1(sla - slb))
                 #      = sla + log(1-q) + log1p(q * np.exp(slb - sla)/(1-q))
                 def _f_sf(x, c):
@@ -7815,7 +7843,8 @@ def _truncnorm_ppf_scalar(q, a, b):
                 if C:
                     values += np.log1p(q[cond_inner] * C / one_minus_q)
                 x = [optimize.zeros.brentq(_f_sf, a, b, args=(c,),
-                                             maxiter=TRUNCNORM_MAX_BRENT_ITERS) for c in values]
+                                           maxiter=TRUNCNORM_MAX_BRENT_ITERS)
+                     for c in values]
                 np.place(out, cond_inner, x)
         out[out < a] = a
         out[out > b] = b
@@ -7856,7 +7885,8 @@ class truncnorm_gen(rv_continuous):
         if a.size == 1 and b.size == 1:
             return _truncnorm_pdf_scalar(x, a.item(), b.item())
         it = np.nditer([x, a, b, None], [],
-                    [['readonly'], ['readonly'], ['readonly'], ['writeonly','allocate']])
+                       [['readonly'], ['readonly'], ['readonly'],
+                        ['writeonly', 'allocate']])
         for (_x, _a, _b, _ld) in it:
             _ld[...] = _truncnorm_pdf_scalar(_x, _a, _b)
         return it.operands[3]
@@ -7868,7 +7898,8 @@ class truncnorm_gen(rv_continuous):
         if a.size == 1 and b.size == 1:
             return _truncnorm_logpdf_scalar(x, a.item(), b.item())
         it = np.nditer([x, a, b, None], [],
-                    [['readonly'], ['readonly'], ['readonly'], ['writeonly','allocate']])
+                       [['readonly'], ['readonly'], ['readonly'],
+                        ['writeonly', 'allocate']])
         for (_x, _a, _b, _ld) in it:
             _ld[...] = _truncnorm_logpdf_scalar(_x, _a, _b)
         return it.operands[3]
@@ -7881,7 +7912,8 @@ class truncnorm_gen(rv_continuous):
             return _truncnorm_cdf_scalar(x, a.item(), b.item())
         out = None
         it = np.nditer([x, a, b, out], [],
-                       [['readonly'], ['readonly'], ['readonly'], ['writeonly', 'allocate']])
+                       [['readonly'], ['readonly'], ['readonly'],
+                        ['writeonly', 'allocate']])
         for (_x, _a, _b, _p) in it:
             _p[...] = _truncnorm_cdf_scalar(_x, _a, _b)
         return it.operands[3]
@@ -7893,7 +7925,8 @@ class truncnorm_gen(rv_continuous):
         if a.size == 1 and b.size == 1:
             return _truncnorm_logcdf_scalar(x, a.item(), b.item())
         it = np.nditer([x, a, b, None], [],
-                       [['readonly'], ['readonly'], ['readonly'], ['writeonly', 'allocate']])
+                       [['readonly'], ['readonly'], ['readonly'],
+                        ['writeonly', 'allocate']])
         for (_x, _a, _b, _p) in it:
             _p[...] = _truncnorm_logcdf_scalar(_x, _a, _b)
         return it.operands[3]
@@ -7906,7 +7939,8 @@ class truncnorm_gen(rv_continuous):
             return _truncnorm_sf_scalar(x, a.item(), b.item())
         out = None
         it = np.nditer([x, a, b, out], [],
-                       [['readonly'], ['readonly'], ['readonly'], ['writeonly', 'allocate']])
+                       [['readonly'], ['readonly'], ['readonly'],
+                        ['writeonly', 'allocate']])
         for (_x, _a, _b, _p) in it:
             _p[...] = _truncnorm_sf_scalar(_x, _a, _b)
         return it.operands[3]
@@ -7919,7 +7953,8 @@ class truncnorm_gen(rv_continuous):
             return _truncnorm_logsf_scalar(x, a.item(), b.item())
         out = None
         it = np.nditer([x, a, b, out], [],
-                       [['readonly'], ['readonly'], ['readonly'], ['writeonly', 'allocate']])
+                       [['readonly'], ['readonly'], ['readonly'],
+                        ['writeonly', 'allocate']])
         for (_x, _a, _b, _p) in it:
             _p[...] = _truncnorm_logsf_scalar(_x, _a, _b)
         return it.operands[3]
@@ -7933,7 +7968,8 @@ class truncnorm_gen(rv_continuous):
 
         out = None
         it = np.nditer([q, a, b, out], [],
-                       [['readonly'], ['readonly'], ['readonly'], ['writeonly', 'allocate']])
+                       [['readonly'], ['readonly'], ['readonly'],
+                        ['writeonly', 'allocate']])
         for (_q, _a, _b, _x) in it:
             _x[...] = _truncnorm_ppf_scalar(_q, _a, _b)
         return it.operands[3]
@@ -7995,7 +8031,8 @@ class truncnorm_gen(rv_continuous):
         if np.isscalar(a) and np.isscalar(b):
             out = self._rvs_scalar(a, b, size, random_state=random_state)
         elif a.size == 1 and b.size == 1:
-            out = self._rvs_scalar(a.item(), b.item(), size, random_state=random_state)
+            out = self._rvs_scalar(a.item(), b.item(), size,
+                                   random_state=random_state)
         else:
             # When this method is called, size will be a (possibly empty)
             # tuple of integers.  It will not be None; if `size=None` is passed
@@ -8036,7 +8073,8 @@ class truncnorm_gen(rv_continuous):
                 # would cause an IndexError.
                 idx = tuple((it.multi_index[j] if not bc[j] else slice(None))
                             for j in range(-len(size), 0))
-                out[idx] = self._rvs_scalar(it[0], it[1], numsamples, random_state).reshape(shp)
+                out[idx] = self._rvs_scalar(it[0], it[1], numsamples,
+                                            random_state).reshape(shp)
                 it.iternext()
 
         if size == ():

--- a/scipy/stats/_generate_pyx.py
+++ b/scipy/stats/_generate_pyx.py
@@ -1,5 +1,6 @@
 import pathlib
 
+
 def isNPY_OLD():
     '''
     A new random C API was added in 1.18 and became stable in 1.19.

--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -146,6 +146,7 @@ class CramerVonMisesResult:
         return (f"{self.__class__.__name__}(statistic={self.statistic}, "
                 f"pvalue={self.pvalue})")
 
+
 def _psi1_mod(x):
     """
     psi1 is defined in equation 1.10 in Csorgo, S. and Faraway, J. (1996).
@@ -1033,7 +1034,7 @@ def _pval_cvm_2samp_exact(s, nx, ny):
     """
     Compute the exact p-value of the Cramer-von Mises two-sample test
     for a given value s (float) of the test statistic by enumerating
-    all possible combinations. nx and ny are the sizes of the samples.    
+    all possible combinations. nx and ny are the sizes of the samples.
     """
     z = np.arange(1, nx+ny+1)
     rangex = np.arange(1, nx+1)
@@ -1045,7 +1046,7 @@ def _pval_cvm_2samp_exact(s, nx, ny):
     # note that the acutal values of the samples are irrelevant
     # once the ranks of the elements of x are fixed, the
     # ranks of the elements in the second sample
-    # that z = 1, ..., nx+ny contains all possible ranks for a loop over all 
+    # that z = 1, ..., nx+ny contains all possible ranks for a loop over all
     for c in combinations(z, nx):
         x = np.array(c)
         # the ranks of the second sample y are given by the set z - x
@@ -1152,7 +1153,7 @@ def cramervonmises_2samp(x, y, method='auto'):
 
     The p-value based on the asymptotic distribution is a good approximation
     even though the sample size is small.
-    
+
     >>> res = stats.cramervonmises_2samp(x, y, method='asymptotic')
     >>> res.statistic, res.pvalue
     (0.2655677655677655, 0.17974247316290415)

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -1036,7 +1036,8 @@ class Sobol(QMCEngine):
         )
         self._quasi = self._shift.copy()
         # Generate lower triangular matrices (stacked across dimensions)
-        ltm = np.tril(rg_integers(2, size=(self.d, self.MAXBIT, self.MAXBIT), dtype=int))
+        ltm = np.tril(rg_integers(2, size=(self.d, self.MAXBIT, self.MAXBIT),
+                                  dtype=int))
         _cscramble(self.d, ltm, self._sv)
         self.num_generated = 0
 

--- a/scipy/stats/tests/test_binned_statistic.py
+++ b/scipy/stats/tests/test_binned_statistic.py
@@ -487,7 +487,7 @@ class TestBinnedStatistic:
         bins = (bins, bins, bins)
         with assert_raises(ValueError, match='difference is numerically 0'):
             binned_statistic_dd(x, v, 'mean', bins=bins)
-    
+
     def test_dd_range_errors(self):
         # Test that descriptive exceptions are raised as appropriate for bad
         # values of the `range` argument. (See gh-12996)

--- a/scipy/stats/tests/test_hypotests.py
+++ b/scipy/stats/tests/test_hypotests.py
@@ -622,7 +622,6 @@ class TestCvm_2samp:
         assert_equal(r1.statistic, r2.statistic)
         assert_allclose(r1.pvalue, r2.pvalue, atol=1e-2)
 
-    #@pytest.mark.slow
     def test_method_auto(self):
         x = np.arange(10)
         y = [0.5, 4.7, 13.1]

--- a/scipy/stats/tests/test_qmc.py
+++ b/scipy/stats/tests/test_qmc.py
@@ -10,8 +10,7 @@ from scipy.stats import shapiro
 from scipy.stats._sobol import _test_find_index
 from scipy.stats import qmc
 from scipy.stats._qmc import (van_der_corput, n_primes, primes_from_2_to,
-                              update_discrepancy,
-                              QMCEngine, check_random_state)
+                              update_discrepancy, QMCEngine)
 
 
 class TestUtils:
@@ -181,7 +180,7 @@ class TestUtils:
             disc2 = np.sum(np.sum(np.prod(1
                                           + 1/2*np.abs(xij - 0.5)
                                           + 1/2*np.abs(xkj - 0.5)
-                                          - 1/2*np.abs(xij - xkj), axis = 2),
+                                          - 1/2*np.abs(xij - xkj), axis=2),
                                   axis=0))
             return (13/12)**s - 2/n * disc1 + 1/n**2*disc2
 
@@ -191,7 +190,7 @@ class TestUtils:
             xkj = x[:, None, :]
             disc = np.sum(np.sum(np.prod(3/2
                                          - np.abs(xij - xkj)
-                                         + np.abs(xij - xkj)**2, axis = 2),
+                                         + np.abs(xij - xkj)**2, axis=2),
                                  axis=0))
             return -(4/3)**s + 1/n**2 * disc
 
@@ -208,7 +207,7 @@ class TestUtils:
                                           - 1/4*np.abs(xkj - 0.5)
                                           - 3/4*np.abs(xij - xkj)
                                           + 1/2*np.abs(xij - xkj)**2,
-                                          axis = 2), axis=0))
+                                          axis=2), axis=0))
             return (19/12)**s - 2/n * disc1 + 1/n**2*disc2
 
         def disc_star_l2(x):
@@ -463,7 +462,8 @@ class TestLHS(QMCEngineTests):
         pytest.skip("Not applicable: not a sequence.")
 
     def test_sample(self, *args):
-        pytest.skip("Not applicable: the value of reference sample is implementation dependent.")
+        pytest.skip("Not applicable: the value of reference sample is"
+                    " implementation dependent.")
 
     def test_sample_stratified(self):
         d, n = 4, 20


### PR DESCRIPTION
When I do Python development, I occasionally spot-check my code by running it through `flake8`.  This catches PEP-8 issues, and other coding issues such as unused imports.  When I do SciPy development, I temporarily remove `tox.ini` and use `flake8` to check that my changes don't introduce new PEP-8 issue or other easily missed coding issues.  That can be a pain, because many of the SciPy files contain PEP-8 violations that `flake8` will complain about.  Our policy has been to avoid the big clean up that would be required to fix all those; instead, we live with them, and try to ensure that we don't make it worse in newly added code.

So this PR is not an attempt at a massive clean up of old code.  I'm pretty sure all the changes here are on code that was added or modified in the last 14 months or so.  It is mostly PEP-8 whitespace and line-length fixes, but there are a couple unused imports in there too.

I encourage all reviewers to keep an eye out for PEP-8 conformance when reviewing PRs.  We can't rely on the checks in CI to catch everything.