### PR TITLE
DOC: correct Voronoi docstring

### DIFF
--- a/scipy/spatial/qhull.pyx
+++ b/scipy/spatial/qhull.pyx
@@ -2497,7 +2497,7 @@ class Voronoi(_QhullUser):
     Parameters
     ----------
     points : ndarray of floats, shape (npoints, ndim)
-        Coordinates of points to construct a convex hull from
+        Coordinates of points to construct a Voronoi diagram from
     furthest_site : bool, optional
         Whether to compute a furthest-site Voronoi diagram. Default: False
     incremental : bool, optional


### PR DESCRIPTION
* the `Voronoi` class docstring refers to the construction
of the incorrect type of geometric diagram--likely a copy-paste
error from the `ConvexHull` docstring above