### PR TITLE
ENH: stats: Implement _sf and _isf for the chi distribution.

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1228,8 +1228,14 @@ class chi_gen(rv_continuous):
     def _cdf(self, x, df):
         return sc.gammainc(.5*df, .5*x**2)
 
+    def _sf(self, x, df):
+        return sc.gammaincc(.5*df, .5*x**2)
+
     def _ppf(self, q, df):
         return np.sqrt(2*sc.gammaincinv(.5*df, q))
+
+    def _isf(self, q, df):
+        return np.sqrt(2*sc.gammainccinv(.5*df, q))
 
     def _stats(self, df):
         mu = np.sqrt(2)*sc.gamma(df/2.0+0.5)/sc.gamma(df/2.0)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -289,6 +289,21 @@ class TestBradford:
         assert_allclose(x, xx)
 
 
+class TestChi:
+
+    # "Exact" value of chi.sf(10, 4), as computed by Wolfram Alpha with
+    #     1 - CDF[ChiDistribution[4], 10]
+    CHI_SF_10_4 = 9.83662422461598e-21
+
+    def test_sf(self):
+        s = stats.chi.sf(10, 4)
+        assert_allclose(s, self.CHI_SF_10_4, rtol=1e-15)
+
+    def test_isf(self):
+        x = stats.chi.isf(self.CHI_SF_10_4, 4)
+        assert_allclose(x, 10, rtol=1e-15)
+
+
 class TestNBinom:
     def setup_method(self):
         np.random.seed(1234)


### PR DESCRIPTION
Simple implementations of `_sf` and `_isf` for the `chi` distribution.

Before:
```
In [32]: chi.sf(10, 4)
Out[32]: 0.0

In [33]: chi.isf(1e-22, 4)
Out[33]: inf
```
After:
```
In [26]: chi.sf(10, 4)
Out[26]: 9.836624224615988e-21

In [27]: chi.isf(1e-22, 4)
Out[27]: 10.457191680765618
```
