### PR TITLE
MAINT: prevent overwriting of x in minimize

### DIFF
--- a/scipy/optimize/_trustregion.py
+++ b/scipy/optimize/_trustregion.py
@@ -3,7 +3,7 @@ import math
 
 import numpy as np
 import scipy.linalg
-from .optimize import (_check_unknown_options, wrap_function, _status_message,
+from .optimize import (_check_unknown_options, _wrap_function, _status_message,
                        OptimizeResult, _prepare_scalar_function)
 
 __all__ = []
@@ -160,7 +160,7 @@ def _minimize_trust_region(fun, x0, args=(), jac=None, hess=None, hessp=None,
     if hess is not None:
         hess = sf.hess
     # ScalarFunction doesn't represent hessp
-    nhessp, hessp = wrap_function(hessp, args)
+    nhessp, hessp = _wrap_function(hessp, args)
 
     # limit the number of iterations
     if maxiter is None:

--- a/scipy/optimize/cobyla.py
+++ b/scipy/optimize/cobyla.py
@@ -249,7 +249,7 @@ def _minimize_cobyla(fun, x0, args=(), constraints=(),
     m = sum(cons_lengths)
 
     def calcfc(x, con):
-        f = fun(x, *args)
+        f = fun(np.copy(x), *args)
         i = 0
         for size, c in izip(cons_lengths, constraints):
             con[i: i + size] = c['fun'](x, *c['args'])

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -459,9 +459,9 @@ def _wrap_function(function, args):
     if function is None:
         return ncalls, None
 
-    def function_wrapper(x):
+    def function_wrapper(x, *wrapper_args):
         ncalls[0] += 1
-        return function(np.copy(x), *args)
+        return function(np.copy(x), *(wrapper_args + args))
 
     return ncalls, function_wrapper
 

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -451,14 +451,17 @@ def rosen_hess_prod(x, p):
     return Hp
 
 
-def wrap_function(function, args):
+def _wrap_function(function, args):
+    # wraps a minimizer function to count number of evaluations
+    # and to easily provide an args kwd.
+    # A copy of x is sent to the user function (gh13740)
     ncalls = [0]
     if function is None:
         return ncalls, None
 
-    def function_wrapper(*wrapper_args):
+    def function_wrapper(x):
         ncalls[0] += 1
-        return function(*(wrapper_args + args))
+        return function(np.copy(x), *args)
 
     return ncalls, function_wrapper
 
@@ -657,7 +660,7 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
     maxfun = maxfev
     retall = return_all
 
-    fcalls, func = wrap_function(func, args)
+    fcalls, func = _wrap_function(func, args)
 
     if adaptive:
         dim = float(len(x0))
@@ -2907,7 +2910,7 @@ def _minimize_powell(func, x0, args=(), callback=None, bounds=None,
     retall = return_all
     # we need to use a mutable object here that we can update in the
     # wrapper function
-    fcalls, func = wrap_function(func, args)
+    fcalls, func = _wrap_function(func, args)
     x = asarray(x0).flatten()
     if retall:
         allvecs = [x]

--- a/scipy/optimize/tests/test_differentiable_functions.py
+++ b/scipy/optimize/tests/test_differentiable_functions.py
@@ -326,6 +326,20 @@ class TestScalarFunction(TestCase):
         assert_equal(f2, 14.0)
         assert x is not sf.x
 
+        # gh13740 x is changed in user function
+        def ff(x):
+            x *= x    # overwrite x
+            return np.sum(x)
+
+        x = np.array([1., 2., 3.])
+        sf = ScalarFunction(
+            ff, x, (), '3-point', lambda x: x, None, (-np.inf, np.inf)
+        )
+        assert x is not sf.x
+        assert_equal(sf.fun(x), 14.0)
+        assert_equal(sf.x, np.array([1., 2., 3.]))
+        assert x is not sf.x
+
 
 class ExVectorialFunction:
 

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -2236,8 +2236,13 @@ def test_x_overwritten_user_function():
 
     fquad_hess = lambda x: np.eye(np.size(x)) * 2.0
 
-    meth_jac = ['newton-cg', 'dogleg', 'trust-ncg', 'trust-exact', 'trust-krylov']
-    meth_hess = ['dogleg', 'trust-ncg', 'trust-exact', 'trust-krylov']
+    meth_jac = [
+        'newton-cg', 'dogleg', 'trust-ncg', 'trust-exact',
+        'trust-krylov', 'trust-constr'
+    ]
+    meth_hess = [
+        'dogleg', 'trust-ncg', 'trust-exact', 'trust-krylov', 'trust-constr'
+    ]
 
     x0 = np.ones(5) * 1.5
 

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -2216,3 +2216,37 @@ def test_bounds_with_list():
     optimize.minimize(
         optimize.rosen, x0=np.array([9, 9]), method='Powell', bounds=bounds
     )
+
+
+def test_x_overwritten_user_function():
+    # if the user overwrites the x-array in the user function it's likely
+    # that the minimizer stops working properly.
+    # gh13740
+    def fquad(x):
+        a = np.arange(np.size(x))
+        x -= a
+        x *= x
+        return np.sum(x)
+
+    def fquad_jac(x):
+        a = np.arange(np.size(x))
+        x *= 2
+        x -= 2 * a
+        return x
+
+    fquad_hess = lambda x: np.eye(np.size(x)) * 2.0
+
+    meth_jac = ['newton-cg', 'dogleg', 'trust-ncg', 'trust-exact', 'trust-krylov']
+    meth_hess = ['dogleg', 'trust-ncg', 'trust-exact', 'trust-krylov']
+
+    x0 = np.ones(5) * 1.5
+
+    for meth in MINIMIZE_METHODS:
+        jac = None
+        hess = None
+        if meth in meth_jac:
+            jac = fquad_jac
+        if meth in meth_hess:
+            hess = fquad_hess
+        res = minimize(fquad, x0, method=meth, jac=jac, hess=hess)
+        assert_allclose(res.x, np.arange(np.size(x0)))

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -2248,5 +2248,5 @@ def test_x_overwritten_user_function():
             jac = fquad_jac
         if meth in meth_hess:
             hess = fquad_hess
-        res = minimize(fquad, x0, method=meth, jac=jac, hess=hess)
-        assert_allclose(res.x, np.arange(np.size(x0)))
+        res = optimize.minimize(fquad, x0, method=meth, jac=jac, hess=hess)
+        assert_allclose(res.x, np.arange(np.size(x0)), atol=2e-4)


### PR DESCRIPTION
Closes #13740.

In that issue the user function was overwriting the `x` vector it was supplied with. This means that `x` and `fun(x)` are no longer in the correct functional relationship within the minimizer. This would break most of the methods in `minimize`. This PR copies `x` before it's sent to the user function. It will add overhead, the only alternative is to post a big notice saying don't overwrite `x` in your user function because it will break the minimizer functionality.

Luckily, now that most, if not all, minimizers use `ScalarFunction` it's just a case of making the changes to one file.