### PR TITLE
DOC: Add note for interp1d for non-unique x-values

### DIFF
--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -409,6 +409,10 @@ class interp1d(_Interpolator1D):
 
     Input values `x` and `y` must be convertible to `float` values like
     `int` or `float`.
+    
+    If the values in `x` are not unique, the resulting behavior is
+    undefined and specific to the choice of `kind`, i.e., changing
+    `kind` will change the behavior for duplicates.
 
 
     Examples


### PR DESCRIPTION
Closes: #13744 

This PR adds a note to the docstring of `scipy.interpolate.interpolate1d` that points out inconsistencies between different interpolation methods (`kind`) in the presence of non-unique arguments (x-values). Ideally, this would be fixed by unifying the behavior; however, existing code depends on the current behavior (https://github.com/scipy/scipy/issues/13744#issuecomment-806438009).

I will also check some of the other interpolation functions. If you know other functions that may benefit from a similar note, please let me know and I'll add them to the PR.