### PR TITLE
WIP, CI: Azure Windows failure catch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -327,11 +327,13 @@ jobs:
           pip install $_.FullName
       }
     displayName: 'Build SciPy'
+    failOnStderr: true
   - powershell: |
       $env:PATH = "C:\\ProgramData\\chocolatey\\lib\\mingw\\tools\\install\\mingw$(BITS)\\bin;" + $env:PATH
       $env:SCIPY_USE_PYTHRAN=$(SCIPY_USE_PYTHRAN)
       python runtests.py -n --mode=$(TEST_MODE) -- -n 2 -rsx --junitxml=junit/test-results.xml --cov=scipy --cov-report=xml --cov-report=html --durations=10
     displayName: 'Run SciPy Test Suite'
+    condition: succeeded()
   - task: PublishTestResults@2
     condition: succeededOrFailed()
     inputs:


### PR DESCRIPTION
* try to prevent Azure from masking a failure
in the Windows `Build SciPy` stage by adding
`failOnStderr: true`, which we already have sprinkled
in other places in our Azure CI config (unfortunately,
sometimes writing to stderr is "normal" for some stages,
but hopefully not this one -- we will see when it runs)

* also added the requirement that all previous jobs in the
dependency graph succeed before `Run SciPy Test Suite`
stage is allowed to run (to reduce likelihood that it appears
to be a failure at that stage when previous stage(s) fail)

* see discussion:
https://github.com/scipy/scipy/issues/13464#issuecomment-808007208
