### PR TITLE
CI: fix the matplotlib warning emitted during builing docs

### DIFF
--- a/doc/source/tutorial/special.rst
+++ b/doc/source/tutorial/special.rst
@@ -50,7 +50,8 @@ drum head anchored at the edge:
    >>> from mpl_toolkits.mplot3d import Axes3D
    >>> from matplotlib import cm
    >>> fig = plt.figure()
-   >>> ax = Axes3D(fig, rect=(0, 0.05, 0.95, 0.95))
+   >>> ax = Axes3D(fig, rect=(0, 0.05, 0.95, 0.95), auto_add_to_figure=False)
+   >>> fig.add_axes(ax)
    >>> ax.plot_surface(x, y, z, rstride=1, cstride=1, cmap='RdBu_r', vmin=-0.5, vmax=0.5)
    >>> ax.set_xlabel('X')
    >>> ax.set_ylabel('Y')

--- a/doc/source/tutorial/special.rst
+++ b/doc/source/tutorial/special.rst
@@ -51,7 +51,7 @@ drum head anchored at the edge:
    >>> from matplotlib import cm
    >>> fig = plt.figure()
    >>> ax = Axes3D(fig, rect=(0, 0.05, 0.95, 0.95), auto_add_to_figure=False)
-   >>> fig.add_axes(ax)
+   >>> ax = fig.add_axes(ax)
    >>> ax.plot_surface(x, y, z, rstride=1, cstride=1, cmap='RdBu_r', vmin=-0.5, vmax=0.5)
    >>> ax.set_xlabel('X')
    >>> ax.set_ylabel('Y')

--- a/doc/source/tutorial/special.rst
+++ b/doc/source/tutorial/special.rst
@@ -47,9 +47,8 @@ drum head anchored at the edge:
    >>> z = np.array([drumhead_height(1, 1, r, theta, 0.5) for r in radius])
 
    >>> import matplotlib.pyplot as plt
-   >>> from matplotlib import cm
    >>> fig = plt.figure()
-   >>> ax = fig.add_subplot(1, 1, 1, projection='3d')
+   >>> ax = fig.add_axes(rect=(0, 0.05, 0.95, 0.95), projection='3d')
    >>> ax.plot_surface(x, y, z, rstride=1, cstride=1, cmap='RdBu_r', vmin=-0.5, vmax=0.5)
    >>> ax.set_xlabel('X')
    >>> ax.set_ylabel('Y')

--- a/doc/source/tutorial/special.rst
+++ b/doc/source/tutorial/special.rst
@@ -47,11 +47,9 @@ drum head anchored at the edge:
    >>> z = np.array([drumhead_height(1, 1, r, theta, 0.5) for r in radius])
 
    >>> import matplotlib.pyplot as plt
-   >>> from mpl_toolkits.mplot3d import Axes3D
    >>> from matplotlib import cm
    >>> fig = plt.figure()
-   >>> ax = Axes3D(fig, rect=(0, 0.05, 0.95, 0.95), auto_add_to_figure=False)
-   >>> ax = fig.add_axes(ax)
+   >>> ax = fig.add_subplot(1, 1, 1, projection='3d')
    >>> ax.plot_surface(x, y, z, rstride=1, cstride=1, cmap='RdBu_r', vmin=-0.5, vmax=0.5)
    >>> ax.set_xlabel('X')
    >>> ax.set_ylabel('Y')


### PR DESCRIPTION
#### Reference issue

N/A

#### What does this implement/fix?

The doc build fails on master as `matplotlib>=3.4` deprecates adding 3D axes to the figure automatically:

```none
/home/circleci/repo/doc/source/tutorial/special.rst:37: WARNING: Exception occurred in plotting special-1
 from /home/circleci/repo/doc/source/tutorial/special.rst:
Traceback (most recent call last):
  File "/home/circleci/repo/venv/lib/python3.7/site-packages/matplotlib/sphinxext/plot_directive.py", line 483, in run_code
    exec(code, ns)
  File "<string>", line 15, in <module>
  File "/home/circleci/repo/venv/lib/python3.7/site-packages/mpl_toolkits/mplot3d/axes3d.py", line 147, in __init__
    "3.4", removal="3.6", message="Axes3D(fig) adding itself "
  File "/home/circleci/repo/venv/lib/python3.7/site-packages/matplotlib/_api/deprecation.py", line 118, in warn_deprecated
    warn_external(warning, category=MatplotlibDeprecationWarning)
  File "/home/circleci/repo/venv/lib/python3.7/site-packages/matplotlib/_api/__init__.py", line 213, in warn_external
    warnings.warn(message, category, stacklevel)
matplotlib._api.deprecation.MatplotlibDeprecationWarning: Axes3D(fig) adding itself to the figure is deprecated since 3.4. Pass the keyword argument auto_add_to_figure=False and use fig.add_axes(ax) to suppress this warning. The default value of auto_add_to_figure will change to False in mpl3.5 and True values will no longer work in 3.6.  This is consistent with other Axes classes.

```

This should fix the warning.