### PR TITLE
BENCH: Add missing pythran dependency

### DIFF
--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -40,6 +40,7 @@
         "numpy": [],
         "Cython": ["0.29.21"],
         "pytest": [],
+        "pythran": [],
         "pybind11": [],
     },
 


### PR DESCRIPTION
#### What does this implement/fix?
Running a comparison benchmark, e.g. `python runtests.py --bench-compare master` fails because `pythran` isn't listed as a benchmark dependency.