### PR TITLE
ENH: stats.contingency: Add the sparse option to crosstab.

### DIFF
--- a/scipy/stats/_crosstab.py
+++ b/scipy/stats/_crosstab.py
@@ -140,6 +140,7 @@ def crosstab(*args, levels=None, sparse=False):
     >>> count.A
     array([[2, 3, 0],
            [1, 0, 4]])
+
     """
     nargs = len(args)
     if nargs == 0:

--- a/scipy/stats/_crosstab.py
+++ b/scipy/stats/_crosstab.py
@@ -1,7 +1,8 @@
 import numpy as np
+from scipy.sparse import coo_matrix
 
 
-def crosstab(*args, levels=None):
+def crosstab(*args, levels=None, sparse=False):
     """
     Return table of counts for each possible unique combination in ``*args``.
 
@@ -26,6 +27,11 @@ def crosstab(*args, levels=None):
         does not occur in the corresponding sequence in `levels`, that value
         is ignored and not counted in the returned array `count`.  The default
         value of `levels` for ``args[i]`` is ``np.unique(args[i])``
+    sparse : bool, optional
+        If True, return a sparse matrix.  The matrix will be an instance of
+        the `scipy.sparse.coo_matrix` class.  Because SciPy's sparse matrices
+        must be 2-d, only two input sequences are allowed when `sparse` is
+        True.  Default is False.
 
     Returns
     -------
@@ -35,7 +41,7 @@ def crosstab(*args, levels=None):
         the corresponding dimensions of `count`.
         If `levels` was given, then if ``levels[i]`` is not None,
         ``elements[i]`` will hold the values given in ``levels[i]``.
-    count : numpy.ndarray
+    count : numpy.ndarray or scipy.sparse.coo_matrix
         Counts of the unique elements in ``zip(*args)``, stored in an array.
         Also known as a *contingency table* when ``len(args) > 1``.
 
@@ -124,6 +130,16 @@ def crosstab(*args, levels=None):
     array([[1, 1],
            [1, 4],
            [0, 3]])
+
+    Finally, let's repeat the first example, but return a sparse matrix:
+
+    >>> (avals, xvals), count = crosstab(a, x, sparse=True)
+    >>> count
+    <2x3 sparse matrix of type '<class 'numpy.int64'>'
+            with 4 stored elements in COOrdinate format>
+    >>> count.A
+    array([[2, 3, 0],
+           [1, 0, 4]])
     """
     nargs = len(args)
     if nargs == 0:
@@ -133,13 +149,14 @@ def crosstab(*args, levels=None):
     if not all(len(a) == len0 for a in args[1:]):
         raise ValueError("All input sequences must have the same length.")
 
+    if sparse and nargs != 2:
+        raise ValueError("When `sparse` is True, only two input sequences "
+                         "are allowed.")
+
     if levels is None:
         # Call np.unique with return_inverse=True on each argument.
-        actual_levels, inverses = zip(*[np.unique(a, return_inverse=True)
-                                        for a in args])
-        shape = [len(u) for u in actual_levels]
-        count = np.zeros(shape, dtype=int)
-        np.add.at(count, inverses, 1)
+        actual_levels, indices = zip(*[np.unique(a, return_inverse=True)
+                                       for a in args])
     else:
         # `levels` is not None...
         if len(levels) != nargs:
@@ -162,9 +179,15 @@ def crosstab(*args, levels=None):
             actual_levels.append(levels_list)
 
         mask_all = mask.all(axis=0)
+        indices = tuple(inv[:, mask_all])
+
+    if sparse:
+        count = coo_matrix((np.ones(len(indices[0]), dtype=int),
+                            (indices[0], indices[1])))
+        count.sum_duplicates()
+    else:
         shape = [len(u) for u in actual_levels]
         count = np.zeros(shape, dtype=int)
-        indices = tuple(inv[:, mask_all])
         np.add.at(count, indices, 1)
 
     return actual_levels, count

--- a/scipy/stats/tests/test_crosstab.py
+++ b/scipy/stats/tests/test_crosstab.py
@@ -1,19 +1,24 @@
+import pytest
 import numpy as np
 from numpy.testing import assert_array_equal
 from scipy.stats.contingency import crosstab
 
 
-def test_crosstab_basic():
+@pytest.mark.parametrize('sparse', [False, True])
+def test_crosstab_basic(sparse):
     a = [0, 0, 9, 9, 0, 0, 9]
     b = [2, 1, 3, 1, 2, 3, 3]
     expected_avals = [0, 9]
     expected_bvals = [1, 2, 3]
     expected_count = np.array([[1, 2, 1],
                                [1, 0, 2]])
-    (avals, bvals), count = crosstab(a, b)
+    (avals, bvals), count = crosstab(a, b, sparse=sparse)
     assert_array_equal(avals, expected_avals)
     assert_array_equal(bvals, expected_bvals)
-    assert_array_equal(count, expected_count)
+    if sparse:
+        assert_array_equal(count.A, expected_count)
+    else:
+        assert_array_equal(count, expected_count)
 
 
 def test_crosstab_basic_1d():
@@ -47,20 +52,26 @@ def test_crosstab_basic_3d():
     assert_array_equal(count, expected_count)
 
 
-def test_crosstab_levels():
+@pytest.mark.parametrize('sparse', [False, True])
+def test_crosstab_levels(sparse):
     a = [0, 0, 9, 9, 0, 0, 9]
     b = [1, 2, 3, 1, 2, 3, 3]
     expected_avals = [0, 9]
     expected_bvals = [0, 1, 2, 3]
     expected_count = np.array([[0, 1, 2, 1],
                                [0, 1, 0, 2]])
-    (avals, bvals), count = crosstab(a, b, levels=[None, [0, 1, 2, 3]])
+    (avals, bvals), count = crosstab(a, b, levels=[None, [0, 1, 2, 3]],
+                                     sparse=sparse)
     assert_array_equal(avals, expected_avals)
     assert_array_equal(bvals, expected_bvals)
-    assert_array_equal(count, expected_count)
+    if sparse:
+        assert_array_equal(count.A, expected_count)
+    else:
+        assert_array_equal(count, expected_count)
 
 
-def test_crosstab_extra_levels():
+@pytest.mark.parametrize('sparse', [False, True])
+def test_crosstab_extra_levels(sparse):
     # The pair of values (-1, 3) will be ignored, because we explicitly
     # request the counted `a` values to be [0, 9].
     a = [0, 0, 9, 9, 0, 0, 9, -1]
@@ -69,7 +80,11 @@ def test_crosstab_extra_levels():
     expected_bvals = [0, 1, 2, 3]
     expected_count = np.array([[0, 1, 2, 1],
                                [0, 1, 0, 2]])
-    (avals, bvals), count = crosstab(a, b, levels=[[0, 9], [0, 1, 2, 3]])
+    (avals, bvals), count = crosstab(a, b, levels=[[0, 9], [0, 1, 2, 3]],
+                                     sparse=sparse)
     assert_array_equal(avals, expected_avals)
     assert_array_equal(bvals, expected_bvals)
-    assert_array_equal(count, expected_count)
+    if sparse:
+        assert_array_equal(count.A, expected_count)
+    else:
+        assert_array_equal(count, expected_count)

--- a/scipy/stats/tests/test_crosstab.py
+++ b/scipy/stats/tests/test_crosstab.py
@@ -88,3 +88,23 @@ def test_crosstab_extra_levels(sparse):
         assert_array_equal(count.A, expected_count)
     else:
         assert_array_equal(count, expected_count)
+
+
+def test_validation_at_least_one():
+    with pytest.raises(TypeError, match='At least one'):
+        crosstab()
+
+
+def test_validation_same_lengths():
+    with pytest.raises(ValueError, match='must have the same length'):
+        crosstab([1, 2], [1, 2, 3, 4])
+
+
+def test_validation_sparse_only_two_args():
+    with pytest.raises(ValueError, match='only two input sequences'):
+        crosstab([0, 1, 1], [8, 8, 9], [1, 3, 3], sparse=True)
+
+
+def test_validation_len_levels_matches_args():
+    with pytest.raises(ValueError, match='number of input sequences'):
+        crosstab([0, 1, 1], [8, 8, 9], levels=([0, 1, 2, 3],))


### PR DESCRIPTION
This is a small enhancement to the [`crosstab`](http://scipy.github.io/devdocs/generated/scipy.stats.contingency.crosstab.html) function that was suggested by [@rlucas7 and @matthew-brett](https://github.com/scipy/scipy/pull/11352#discussion_r369915766) in the review of the PR that added `crosstab`.