### PR TITLE
[WIP]Feature/gitpod maintenance

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,13 +3,15 @@ name: Build Docker images
 on:
   push: 
     branches:
-      - master
+    - master
+    paths:
+    - 'tools/docker_dev/Dockerfile'
     tags:
       - '*'
 
 jobs: 
   build:
-    name: Build Docker image 
+    name: Build base Docker image 
     runs-on: ubuntu-latest
     environment: scipy-dev
     if: "github.repository_owner == 'scipy' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,13 +1,15 @@
-name: Build Docker images 
+name: Build Base Docker Image
 
 on:
   push: 
     branches:
     - master
+    - feature/*
     paths:
     - './tools/docker_dev/environment.yml'
     tags:
       - '*'
+  workflow_dispatch:
 
 jobs: 
   build:
@@ -53,4 +55,6 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
           tags: |
-            scipy/scipy-dev:${{ steps.getrefs.outputs.date }}-${{ steps.getrefs.outputs.branch}}-${{ steps.getrefs.outputs.sha8 }}, scipy/scipy-dev:latest
+            trallard/scipy-dev:${{ steps.getrefs.outputs.date }}-${{ steps.getrefs.outputs.branch}}-${{ steps.getrefs.outputs.sha8 }}, trallard/scipy-dev:latest
+      - name: Image digest 
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,7 @@ on:
     branches:
     - master
     paths:
-    - 'tools/docker_dev/Dockerfile'
+    - './tools/docker_dev/environment.yml'
     tags:
       - '*'
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,6 +32,12 @@ jobs:
         id: getrefs
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-buildx-
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -44,5 +50,7 @@ jobs:
           context: "./tools/docker_dev"
           file: "./tools/docker_dev/Dockerfile"
           push: ${{ github.event_name != 'pull_request' }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
           tags: |
             scipy/scipy-dev:${{ steps.getrefs.outputs.date }}-${{ steps.getrefs.outputs.branch}}-${{ steps.getrefs.outputs.sha8 }}, scipy/scipy-dev:latest

--- a/.github/workflows/gitpod.yml
+++ b/.github/workflows/gitpod.yml
@@ -4,8 +4,10 @@ on:
   push: 
     branches:
     - master
+    - feature/*
     tags:
       - '*'
+  workflow_dispatch:
 
 jobs:
   build:
@@ -51,4 +53,6 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
           tags: |
-            scipy/scipy-gitpod:${{ steps.getrefs.outputs.date }}-${{ steps.getrefs.outputs.branch}}-${{ steps.getrefs.outputs.sha8 }}, scipy/scipy-gitpod:latest
+            trallard/scipy-gitpod:${{ steps.getrefs.outputs.date }}-${{ steps.getrefs.outputs.branch}}-${{ steps.getrefs.outputs.sha8 }}, trallard/scipy-gitpod:latest
+      - name: Image digest 
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/gitpod.yml
+++ b/.github/workflows/gitpod.yml
@@ -1,0 +1,46 @@
+name: Build Gitpod Docker image
+
+on:
+  push: 
+    branches:
+    - master
+    tags:
+      - '*'
+
+jobs:
+  build:
+    name: Build Gitpod Docker image 
+    runs-on: ubuntu-latest
+    environment: scipy-dev
+    if: "github.repository_owner == 'scipy' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+      - name: Lint Docker 
+        uses: brpaz/hadolint-action@v1.2.1
+        with: 
+          dockerfile: ./tools/docker_dev/.gitpod.Dockerfile
+      - name: Get refs
+        shell: bash
+        run: |
+          export raw_branch=${GITHUB_REF#refs/heads/}
+          echo "::set-output name=branch::${raw_branch//\//-}"
+          echo "::set-output name=date::$(date +'%Y%m%d')"
+          echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
+        id: getrefs
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: "./tools/docker_dev"
+          file: "./tools/docker_dev/.gitpod.Dockerfile"
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            scipy/scipy-gitpod:${{ steps.getrefs.outputs.date }}-${{ steps.getrefs.outputs.branch}}-${{ steps.getrefs.outputs.sha8 }}, scipy/scipy-gitpod:latest

--- a/.github/workflows/gitpod.yml
+++ b/.github/workflows/gitpod.yml
@@ -30,6 +30,12 @@ jobs:
         id: getrefs
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-buildx-
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -39,8 +45,10 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
-          context: "./tools/docker_dev"
+          context: "."
           file: "./tools/docker_dev/.gitpod.Dockerfile"
           push: ${{ github.event_name != 'pull_request' }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
           tags: |
             scipy/scipy-gitpod:${{ steps.getrefs.outputs.date }}-${{ steps.getrefs.outputs.branch}}-${{ steps.getrefs.outputs.sha8 }}, scipy/scipy-gitpod:latest

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,22 +7,23 @@
 # With this configuration the prebuild will happen on push to master 
 # -------------------------------------------------------------------------
 
-image:
-  file: ./tools/docker_dev/.gitpod.Dockerfile
+image: scipy/scipy-gitpod:latest
 tasks:
-  - name: Prebuild Scipy & docs
+  - name: Prebuild Scipy docs
     prebuild: |
       conda activate scipydev
-      python setup.py build_ext --inplace
       git submodule update --init
       cd doc 
       make html-scipyorg
-      pip install sphinx-autobuild
+      mv /home/gitpod/build /workspace/scipy/build
     command: |
       conda activate scipydev
       conda develop .
   - name: Develop here
-    init: mkdir -p /workspace/scipy/.theia &&  cp /workspace/scipy/tools/docker_dev/settings.json /workspace/scipy/.theia/settings.json
+    init: |
+      mkdir -p /workspace/scipy/.theia 
+      cp /workspace/scipy/tools/docker_dev/settings.json /workspace/scipy/.theia/settings.json
+      cp /home/gitpod/build /workspace/scipy/build
     command: conda activate scipydev
 
 # --------------------------------------------------------

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,7 +7,7 @@
 # With this configuration the prebuild will happen on push to master 
 # -------------------------------------------------------------------------
 
-image: scipy/scipy-gitpod:latest
+image: trallard/scipy-gitpod:latest
 tasks:
   - name: Prebuild Scipy docs
     prebuild: |
@@ -15,10 +15,8 @@ tasks:
       git submodule update --init
       cd doc 
       make html-scipyorg
-      mv /home/gitpod/build /workspace/scipy/build
     command: |
       conda activate scipydev
-      conda develop .
   - name: Develop here
     init: |
       mkdir -p /workspace/scipy/.theia 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -39,6 +39,7 @@ vscode:
     - njpwerner.autodocstring@0.5.4:TKRAH5+nBrBnq+ysTYA86Q==
     - lextudio.restructuredtext@141.0.0:JobzqAU1ylF4bDdKqnrpOg==
     - ritwickdey.liveserver@5.6.1:5Mhl1RgVVDcIym163x8r+w==
+    - ms-python.python@2020.10.332292344:5ctthQ25Qni5/aAuOIUTYQ==
 
 # --------------------------------------------------------
 # using prebuilds for the container 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -9,20 +9,18 @@
 
 image: trallard/scipy-gitpod:latest
 tasks:
-  - name: Prebuild Scipy docs
+  - name: Prepare development
+    before: conda develop .
+    init: |
+      mkdir -p /workspace/scipy/.vscode 
+      cp /workspace/scipy/tools/docker_dev/settings.json /workspace/scipy/.vscode/settings.json
+      python setup.py build_ext --inplace
+    command: conda develop .
+  - name: Prebuild docs
     prebuild: |
-      conda activate scipydev
       git submodule update --init
       cd doc 
       make html-scipyorg
-    command: |
-      conda activate scipydev
-  - name: Develop here
-    init: |
-      mkdir -p /workspace/scipy/.theia 
-      cp /workspace/scipy/tools/docker_dev/settings.json /workspace/scipy/.theia/settings.json
-      cp /home/gitpod/build /workspace/scipy/build
-    command: conda activate scipydev
 
 # --------------------------------------------------------
 # exposing ports for liveserve

--- a/doc/source/dev/contributor/quickstart_docker.rst
+++ b/doc/source/dev/contributor/quickstart_docker.rst
@@ -110,9 +110,9 @@ container do not persist after you close it.
 
    as a prompt. Notice the ``(base)`` at the beginning, since we are using conda.
 
-#. Activate the ``scipydev`` conda environment::
+#. Activate the ``scipy-dev`` conda environment::
 
-      conda activate scipydev
+      conda activate scipy-dev
 
    this environment has all the dependencies you'll need to start using/building SciPy.
 

--- a/tools/docker_dev/.dockerignore
+++ b/tools/docker_dev/.dockerignore
@@ -1,0 +1,81 @@
+# Git
+.git
+.gitignore
+
+# CI
+.github/workflows/*
+
+# Docker
+docker-compose.yml
+.docker
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*/__pycache__/
+*/*/__pycache__/
+*/*/*/__pycache__/
+*.py[cod]
+*/*.py[cod]
+*/*/*.py[cod]
+*/*/*/*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Sphinx documentation
+doc/_build/
+
+# Virtual environment
+.env/
+.venv/
+venv/
+
+# Python mode for VIM
+.ropeproject
+*/.ropeproject
+*/*/.ropeproject
+*/*/*/.ropeproject
+
+# Vim swap files
+*.swp
+*/*.swp
+*/*/*.swp
+*/*/*/*.swp
+
+# VSCode 
+.vscode/*

--- a/tools/docker_dev/.gitpod.Dockerfile
+++ b/tools/docker_dev/.gitpod.Dockerfile
@@ -16,7 +16,7 @@ ENV HOME=/home/scipy \
 
 # -----------------------------------------------------------------------------
 # Change default shell - this avoids issues with Conda later - note we do need
-# login bash here as we are building SciPy inside Docker
+# login bash here as we are building SciPy inside
 # Fix DL4006
 SHELL ["/bin/bash","--login", "-o", "pipefail", "-c"]
 
@@ -27,7 +27,6 @@ RUN mkdir -p ${WORKSPACE}
 # Ensure the following happens in the workspace
 WORKDIR ${WORKSPACE}
 
-# deep clone as we only need to build the latest dev version from master
 RUN git clone https://github.com/scipy/scipy.git  --depth 1 --single-branch . && \
     conda activate scipydev && \
     python setup.py build_ext --inplace 
@@ -80,7 +79,7 @@ ENV LANG=en_US.UTF-8 \
     # ---- Gitpod user ----
     GP_USER=gitpod \
     GP_GROUP=gitpod \
-    UID=3333
+    UID=33333
 # ---- Directories needed ----
 ENV HOME=/home/gitpod \
     CONDA_DIR=/opt/conda \ 
@@ -102,10 +101,8 @@ RUN chmod a+rx /usr/local/bin/fix_permissions && \
     chmod a+rx /usr/local/bin/workspace_config && \
     workspace_config && \
     chown -R ${GP_USER}:${GP_GROUP} ${WORKSPACE} && \ 
-    # again, need to make sure this is user writable
     fix_permissions ${WORKSPACE}  
 
-# favour less privileged user
 USER ${GP_USER}
 
 # install Sphinx autobuild - needed for rst preview
@@ -115,5 +112,5 @@ RUN python -m pip install --no-cache-dir sphinx-autobuild && \
     fix_permissions ${CONDA_DIR}
 
 # Copy build directory from build stage - doing this to avoid issues
-# with how gitpod clones repos later it will end up in /home/gitpod/build
+# with how gitpod clones repos later
 COPY --chown=${GP_USER}:${GP_GROUP} --from=build ${WORKSPACE}/build/ ${HOME}/build/

--- a/tools/docker_dev/.gitpod.Dockerfile
+++ b/tools/docker_dev/.gitpod.Dockerfile
@@ -3,6 +3,9 @@
 # while reducing the build time
 ARG BASE_CONTAINER=scipy/scipy-dev:latest
 FROM ${BASE_CONTAINER}
+# -----------------------------------------------------------------------------
+
+USER root
 
 # -----------------------------------------------------------------------------
 # ---- OS dependencies ----
@@ -13,7 +16,6 @@ RUN apt-get update && \
     dirmngr \
     gpg-agent \
     git \
-    htop \
     jq \
     less \
     locales \
@@ -21,33 +23,38 @@ RUN apt-get update && \
     man-db \
     sudo \
     ssl-cert \
-    time \
-    zip \
-    unzip && \
+    time && \
     # this needs to be done after installing dirmngr
     apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0 && \ 
     apt-add-repository https://cli.github.com/packages && \ 
     apt-get install -yq --no-install-recommends \
-    gh \ 
-    && locale-gen en_US.UTF-8 \
-    && apt-get clean \
-    && rm -rf /var/cache/apt/* \
-    && rm -rf /var/lib/apt/lists/* \
-    && rm -rf /tmp/*
+    gh && \ 
+    locale-gen en_US.UTF-8 && \
+    apt-get clean && \
+    rm -rf /var/cache/apt/* &&\
+    rm -rf /var/lib/apt/lists/* &&\
+    rm -rf /tmp/*
 
 # -----------------------------------------------------------------------------
-# ---- Gitpod user ----
+# ---- ENV variables ----
 # by default we are using gitpod as user and group
 ENV LANG=en_US.UTF-8 \
-    HOME=/home/gitpod \
+    # ---- Gitpod user ----
     GP_USER=gitpod \
     GP_GROUP=gitpod \
+    UID=3333
+# ---- Directories needed ----
+ENV HOME=/home/gitpod \
     CONDA_DIR=/opt/conda \ 
-    WORKSPACE=/workspace/scipy/
+    WORKSPACE=/workspace/scipy/ 
 
+# -----------------------------------------------------------------------------
 # Change default shell - this avoids issues with Conda later
+# Fix DL4006
 SHELL ["/bin/bash","--login", "-o", "pipefail", "-c"]
 
+# -----------------------------------------------------------------------------
+# ---- Copy needed files ----
 # Copy multiple scripts - fix directory permissions and 
 # basic workspace configurations
 COPY ./tools/docker_dev/fix_permissions /usr/local/bin/fix_permissions
@@ -56,37 +63,41 @@ COPY ./tools/docker_dev/workspace_config /usr/local/bin/workspace_config
 RUN chmod a+rx /usr/local/bin/fix_permissions && \
     chmod a+rx /usr/local/bin/workspace_config
 
+# -----------------------------------------------------------------------------
+# ---- Create gitpod user and group: needed for permissions later ----
 # '-l': see https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user
-RUN useradd -l -u 33333 -G sudo -md "${HOME}" -s /bin/bash -p ${GP_GROUP} ${GP_USER} && \
+RUN echo "auth requisite pam_deny.so" >> /etc/pam.d/su && \
+    sed -i.bak -e 's/^%admin/#%admin/' /etc/sudoers && \
+    sed -i.bak -e 's/^%sudo/#%sudo/' /etc/sudoers && \
+    useradd -l -u ${UID} -G sudo -md "${HOME}" -s /bin/bash -p ${GP_GROUP} ${GP_USER} && \
     # passwordless sudo for users in the 'sudo' group
     sed -i.bkp -e 's/%sudo\s\+ALL=(ALL\(:ALL\)\?)\s\+ALL/%sudo ALL=NOPASSWD:ALL/g' /etc/sudoers && \
-    # ensuring we can use conda develop
-    chown -R ${GP_USER}:${GP_GROUP} ${CONDA_DIR} 
+    # transfer ownership to gitpod user 
+    chown -R ${GP_USER}:${GP_GROUP} ${CONDA_DIR} && \ 
+    fix_permissions ${CONDA_DIR} && \
+    mkdir -p ${WORKSPACE} && \
+    chown -R ${GP_USER}:${GP_GROUP} ${WORKSPACE} && \ 
+    fix_permissions ${WORKSPACE}  
 
-# Using root to fix permissions - make sure we change to 'gitpod' always
-USER root
+# workspace configs here
+RUN workspace_config 
 
-RUN mkdir -p ${WORKSPACE} && \ 
-    echo ". $CONDA_DIR/etc/profile.d/conda.sh" >> ~/.profile && \ 
-    conda init bash && \
-    # Making the directories human writable - this is needed to use `conda develop`
-    # $HOME is by default user writable
-    fix_permissions ${CONDA_DIR}/envs/scipydev/ && \
-    fix_permissions $CONDA_DIR && \
-    workspace_config 
-
-
+# Always favour the least-privileged user, in this case gitpod
+USER ${GP_USER}
+# -----------------------------------------------------------------------------
+# ---- Build Scipy here ----
 # Ensure the following happens in the workspace
 WORKDIR ${WORKSPACE}
+
 RUN git clone https://github.com/scipy/scipy.git  --depth 1 --single-branch . && \
     conda activate scipydev && \
     python setup.py build_ext --inplace && \
     conda develop . && \ 
-    python -m pip install --upgrade pip --no-cache-dir && \ 
-    python -m pip install sphinx-autobuild --no-cache-dir
-
-# Always favour the least-privileged user, in this case gitpod
-USER gitpod
+    python -m pip install --no-cache-dir sphinx-autobuild && \
+    rm -rf /tmp/* && \
+    # for good measure as we installed things
+    fix_permissions ${WORKSPACE} && \
+    fix_permissions ${CONDA_DIR}
 
 # Ensure we are in the correct directory
 WORKDIR ${WORKSPACE}

--- a/tools/docker_dev/Dockerfile
+++ b/tools/docker_dev/Dockerfile
@@ -1,5 +1,8 @@
 # 
 # Dockerfile for Scipy development 
+# Note this is also the base for the Gitpod Docker image, see: .gitpod.Dockerfile
+# This should only be updated through GitHub actions when there are changes made 
+# to the environment.yml file
 # 
 # Usage: 
 # -------

--- a/tools/docker_dev/Dockerfile
+++ b/tools/docker_dev/Dockerfile
@@ -1,8 +1,5 @@
 # 
 # Dockerfile for Scipy development 
-# Note this is also the base for the Gitpod Docker image, see: .gitpod.Dockerfile
-# This should only be updated through GitHub actions when there are changes made 
-# to the environment.yml file
 # 
 # Usage: 
 # -------
@@ -27,7 +24,8 @@
 # Ubuntu 20.04 (focal)
 # https://hub.docker.com/_/ubuntu/?tab=tags&name=focal
 # OS/ARCH: linux/amd64
-ARG BASE_CONTAINER=ubuntu:focal-20210325
+ARG ROOT_CONTAINER=ubuntu:focal-20210325
+ARG BASE_CONTAINER=${ROOT_CONTAINER}
 
 # hadolint ignore=DL3006 as base container is tagged
 FROM ${BASE_CONTAINER}
@@ -96,27 +94,22 @@ RUN apt-get update && \
 
 # Enable prompt color in the skeleton .bashrc
 # hadolint ignore=SC2016
-RUN sed -i 's/^#force_color_prompt=yes/force_color_prompt=yes/' /etc/skel/.bashrc && \
-    # Enable basic vim defaults in ~/.vimrc
-    echo "filetype plugin indent on" >> ~/.vimrc && \
-    echo "set colorcolumn=80" >> ~/.vimrc && \
-    echo "set number" >> ~/.vimrc && \
-    echo "syntax enable" >> ~/.vimrc
+RUN sed -i 's/^#force_color_prompt=yes/force_color_prompt=yes/' /etc/skel/.bashrc
 
 # -----------------------------------------------------------------------------
 # ---- Installing conda  ----
 RUN wget --quiet "https://github.com/conda-forge/miniforge/releases/download/${miniforge_version}/${miniforge_installer}" && \
     echo "${miniforge_checksum} *${miniforge_installer}" | sha256sum --check && \
-    /bin/bash "${miniforge_installer}" -f -b -p ${CONDA_DIR} && \
+    /bin/bash "${miniforge_installer}" -f -b -p $CONDA_DIR && \
     rm "${miniforge_installer}" && \
     # Conda configuration see https://conda.io/projects/conda/en/latest/configuration.html
-    echo "conda ${CONDA_VERSION}" >> ${CONDA_DIR}/conda-meta/pinned && \
+    echo "conda ${CONDA_VERSION}" >> $CONDA_DIR/conda-meta/pinned && \
     conda config --system --set auto_update_conda false && \
     conda config --system --set show_channel_urls true && \
     # This allows to change the Python version installed by passing the arg `PYTHON_VERSION` at build time
     # then version is added to conda-meta/pinned 
     if [ ! $PYTHON_VERSION = 'default' ]; then conda install --yes python=$PYTHON_VERSION; fi && \
-    conda list python | grep '^python ' | tr -s ' ' | cut -d '.' -f 1,2 | sed 's/$/.*/' >> ${CONDA_DIR}/conda-meta/pinned && \
+    conda list python | grep '^python ' | tr -s ' ' | cut -d '.' -f 1,2 | sed 's/$/.*/' >> $CONDA_DIR/conda-meta/pinned && \
     conda install --quiet --yes \
     "conda=${CONDA_VERSION}" \
     'pip' && \
@@ -124,10 +117,9 @@ RUN wget --quiet "https://github.com/conda-forge/miniforge/releases/download/${m
     conda clean --all -f -y 
 
 # make conda activate command available from /bin/bash (login and interactive)
-RUN echo ". ${CONDA_DIR}/etc/profile.d/conda.sh" >> ~/.profile && \ 
-    # Add call to conda init script see https://stackoverflow.com/a/58081608/4413446
-    echo 'eval "$(command conda shell.bash hook 2> /dev/null)"' >> /etc/skel/.bashrc && \
-    conda init bash && \
+RUN ln -s ${CONDA_DIR}/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
+    echo ". ${CONDA_DIR}/etc/profile.d/conda.sh" >> ~/.bashrc && \
+    echo "conda activate base" >> ~/.bashrc && \
     echo "conda activate scipydev" >> ~/.bashrc
 
 # -----------------------------------------------------------------------------
@@ -138,11 +130,9 @@ RUN echo ". ${CONDA_DIR}/etc/profile.d/conda.sh" >> ~/.profile && \
 COPY ./environment.yml /tmp/environment.yml
 
 RUN conda env create -f /tmp/environment.yml && \
-    # conda activate "${CONDA_ENV}" && \
-    conda clean --all -f -y  && \
-    rm -rf /tmp/* && \
-    find /opt/conda/ -follow -type f -name '*.a' -delete && \
-    find /opt/conda/ -follow -type f -name '*.js.map' -delete 
+    conda activate "${CONDA_ENV}" && \
+    conda clean --all -f -y && \
+    rm -rf /tmp/* 
 
 # -----------------------------------------------------------------------------
 # Create a Scipy directory inside /home/ 

--- a/tools/docker_dev/Dockerfile
+++ b/tools/docker_dev/Dockerfile
@@ -16,7 +16,7 @@
 # docker run --rm -it -v $(pwd):/home/scipy scipy:<image-tag>
 # 
 # Once the container is running, you'll need to activate the conda environment
-# conda activate scipydev
+# conda activate scipy-dev
 # 
 # And run the tests with
 # python runtests.py
@@ -66,7 +66,7 @@ ENV CONDA_DIR=/opt/conda \
 
 ENV CONDA_VERSION="${conda_version}" \
     MINIFORGE_VERSION="${miniforge_version}" \
-    CONDA_ENV=scipydev \
+    CONDA_ENV=scipy-dev \
     # ---- Gitpod user ----
     GP_USER=gitpod \
     GP_GROUP=gitpod \

--- a/tools/docker_dev/Dockerfile
+++ b/tools/docker_dev/Dockerfile
@@ -27,8 +27,7 @@
 # Ubuntu 20.04 (focal)
 # https://hub.docker.com/_/ubuntu/?tab=tags&name=focal
 # OS/ARCH: linux/amd64
-ARG ROOT_CONTAINER=ubuntu:focal-20201106@sha256:4e4bc990609ed865e07afc8427c30ffdddca5153fd4e82c20d8f0783a291e241
-ARG BASE_CONTAINER=${ROOT_CONTAINER}
+ARG BASE_CONTAINER=ubuntu:focal-20210325
 
 # hadolint ignore=DL3006 as base container is tagged
 FROM ${BASE_CONTAINER}
@@ -67,7 +66,7 @@ ARG PYTHON_VERSION=default
 ENV CONDA_DIR=/opt/conda \
     SHELL=/bin/bash 
 
-ENV PATH=$CONDA_DIR/bin:$PATH \
+ENV PATH=${CONDA_DIR}/bin:$PATH \
     CONDA_VERSION="${conda_version}" \
     MINIFORGE_VERSION="${miniforge_version}" \
     CONDA_ENV=scipydev \
@@ -98,13 +97,8 @@ RUN apt-get update && \
 # Enable prompt color in the skeleton .bashrc
 # hadolint ignore=SC2016
 RUN sed -i 's/^#force_color_prompt=yes/force_color_prompt=yes/' /etc/skel/.bashrc && \
-    # Add call to conda init script see https://stackoverflow.com/a/58081608/4413446
-    echo 'eval "$(command conda shell.bash hook 2> /dev/null)"' >> /etc/skel/.bashrc 
-
-# -----------------------------------------------------------------------------
-
-# Enable basic vim defaults in ~/.vimrc
-RUN echo "filetype plugin indent on" >> ~/.vimrc && \
+    # Enable basic vim defaults in ~/.vimrc
+    echo "filetype plugin indent on" >> ~/.vimrc && \
     echo "set colorcolumn=80" >> ~/.vimrc && \
     echo "set number" >> ~/.vimrc && \
     echo "syntax enable" >> ~/.vimrc
@@ -113,16 +107,16 @@ RUN echo "filetype plugin indent on" >> ~/.vimrc && \
 # ---- Installing conda  ----
 RUN wget --quiet "https://github.com/conda-forge/miniforge/releases/download/${miniforge_version}/${miniforge_installer}" && \
     echo "${miniforge_checksum} *${miniforge_installer}" | sha256sum --check && \
-    /bin/bash "${miniforge_installer}" -f -b -p $CONDA_DIR && \
+    /bin/bash "${miniforge_installer}" -f -b -p ${CONDA_DIR} && \
     rm "${miniforge_installer}" && \
     # Conda configuration see https://conda.io/projects/conda/en/latest/configuration.html
-    echo "conda ${CONDA_VERSION}" >> $CONDA_DIR/conda-meta/pinned && \
+    echo "conda ${CONDA_VERSION}" >> ${CONDA_DIR}/conda-meta/pinned && \
     conda config --system --set auto_update_conda false && \
     conda config --system --set show_channel_urls true && \
     # This allows to change the Python version installed by passing the arg `PYTHON_VERSION` at build time
     # then version is added to conda-meta/pinned 
     if [ ! $PYTHON_VERSION = 'default' ]; then conda install --yes python=$PYTHON_VERSION; fi && \
-    conda list python | grep '^python ' | tr -s ' ' | cut -d '.' -f 1,2 | sed 's/$/.*/' >> $CONDA_DIR/conda-meta/pinned && \
+    conda list python | grep '^python ' | tr -s ' ' | cut -d '.' -f 1,2 | sed 's/$/.*/' >> ${CONDA_DIR}/conda-meta/pinned && \
     conda install --quiet --yes \
     "conda=${CONDA_VERSION}" \
     'pip' && \
@@ -130,8 +124,11 @@ RUN wget --quiet "https://github.com/conda-forge/miniforge/releases/download/${m
     conda clean --all -f -y 
 
 # make conda activate command available from /bin/bash (login and interactive)
-RUN echo ". $CONDA_DIR/etc/profile.d/conda.sh" >> ~/.profile && \ 
-    conda init bash
+RUN echo ". ${CONDA_DIR}/etc/profile.d/conda.sh" >> ~/.profile && \ 
+    # Add call to conda init script see https://stackoverflow.com/a/58081608/4413446
+    echo 'eval "$(command conda shell.bash hook 2> /dev/null)"' >> /etc/skel/.bashrc && \
+    conda init bash && \
+    echo "conda activate scipydev" >> ~/.bashrc
 
 # -----------------------------------------------------------------------------
 # ---- Create conda environment ----
@@ -141,11 +138,14 @@ RUN echo ". $CONDA_DIR/etc/profile.d/conda.sh" >> ~/.profile && \
 COPY ./environment.yml /tmp/environment.yml
 
 RUN conda env create -f /tmp/environment.yml && \
-    conda activate "${CONDA_ENV}" && \
-    conda clean --all -f -y 
+    # conda activate "${CONDA_ENV}" && \
+    conda clean --all -f -y  && \
+    rm -rf /tmp/* && \
+    find /opt/conda/ -follow -type f -name '*.a' -delete && \
+    find /opt/conda/ -follow -type f -name '*.js.map' -delete 
 
 # -----------------------------------------------------------------------------
 # Create a Scipy directory inside /home/ 
 # this will be used to mount the local volume
-RUN mkdir $PROJECT_DIR
-WORKDIR $PROJECT_DIR
+RUN mkdir ${PROJECT_DIR}
+WORKDIR ${PROJECT_DIR}

--- a/tools/docker_dev/Dockerfile
+++ b/tools/docker_dev/Dockerfile
@@ -31,7 +31,7 @@ ARG BASE_CONTAINER=${ROOT_CONTAINER}
 FROM ${BASE_CONTAINER}
 
 # Change default shell - this avoids issues with Conda later
-SHELL ["/bin/bash","--login", "-o", "pipefail", "-c"]
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # -----------------------------------------------------------------------------
 # ---- Miniforge installer ----
@@ -64,11 +64,17 @@ ARG PYTHON_VERSION=default
 ENV CONDA_DIR=/opt/conda \
     SHELL=/bin/bash 
 
-ENV PATH=${CONDA_DIR}/bin:$PATH \
-    CONDA_VERSION="${conda_version}" \
+ENV CONDA_VERSION="${conda_version}" \
     MINIFORGE_VERSION="${miniforge_version}" \
     CONDA_ENV=scipydev \
-    PROJECT_DIR=/home/scipy
+    # ---- Gitpod user ----
+    GP_USER=gitpod \
+    GP_GROUP=gitpod \
+    UID=3333 
+
+ENV HOME="/home/${GP_USER}" \
+    PROJECT_DIR="${GP_HOME}/scipy"\
+    PATH=${CONDA_DIR}/bin:$PATH 
 
 # -----------------------------------------------------------------------------
 # ---- OS dependencies ----
@@ -82,13 +88,48 @@ RUN apt-get update && \
     git \
     libatlas-base-dev \
     software-properties-common \
+    sudo \
     vim \
     wget && \
     apt-get clean && \
     rm -rf /tmp/* && \
     rm -rf /var/lib/apt/lists/* && \
-    rm -rf /var/cache/apt/* && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/cache/apt/* 
+
+# -----------------------------------------------------------------------------
+# ---- Copy needed files ----
+# Copy multiple scripts - fix directory permissions and 
+# basic workspace configurations
+COPY ./workspace_config /usr/local/bin/workspace_config
+COPY ./fix_permissions /usr/local/bin/fix_permissions
+
+RUN chmod a+rx /usr/local/bin/workspace_config && \
+    chmod a+rx /usr/local/bin/fix_permissions 
+
+# -----------------------------------------------------------------------------
+# ---- Create gitpod user and group: needed for permissions later ----
+# '-l': see https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user
+RUN echo "auth requisite pam_deny.so" >> /etc/pam.d/su && \
+    sed -i.bak -e 's/^%admin/#%admin/' /etc/sudoers && \
+    sed -i.bak -e 's/^%sudo/#%sudo/' /etc/sudoers && \
+    # create /home/gitpod too for later use
+    useradd -l -u ${UID} -G sudo -md ${HOME} -s /bin/bash -p ${GP_GROUP} ${GP_USER} && \
+    # passwordless sudo for users in the 'sudo' group
+    sed -i.bkp -e 's/%sudo\s\+ALL=(ALL\(:ALL\)\?)\s\+ALL/%sudo ALL=NOPASSWD:ALL/g' /etc/sudoers && \
+    mkdir -p ${CONDA_DIR} && \
+    # transfer conda path ownership and ensure it is user writable
+    chown -R ${GP_USER}:${GP_GROUP} ${CONDA_DIR} && \
+    fix_permissions ${HOME} && \
+    fix_permissions ${CONDA_DIR} && \
+    workspace_config
+
+# Setup work directory for backward-compatibility
+RUN mkdir ${PROJECT_DIR} && \
+    fix_permissions ${HOME}
+
+USER ${GP_USER}
+
+WORKDIR /tmp
 
 # -----------------------------------------------------------------------------
 # ---- Installing conda  ----
@@ -108,16 +149,9 @@ RUN wget --quiet "https://github.com/conda-forge/miniforge/releases/download/${m
     "conda=${CONDA_VERSION}" \
     'pip' && \
     conda update --all --quiet --yes && \
-    conda clean --all -f -y 
+    conda clean --all -f -y && \
+    fix_permissions ${CONDA_DIR}
 
-# -----------------------------------------------------------------------------
-# ---- Copy needed files ----
-# Copy multiple scripts - fix directory permissions and 
-# basic workspace configurations
-COPY ./workspace_config /usr/local/bin/workspace_config
-
-RUN chmod a+rx /usr/local/bin/workspace_config && \
-    workspace_config 
 
 # -----------------------------------------------------------------------------
 # ---- Create conda environment ----
@@ -127,11 +161,12 @@ RUN chmod a+rx /usr/local/bin/workspace_config && \
 COPY ./environment.yml /tmp/environment.yml
 
 RUN conda env create -f /tmp/environment.yml && \
-    conda clean --all -f -y && \
-    rm -rf /tmp/* 
+    fix_permissions ${CONDA_DIR} &&\
+    conda clean --all -f -y 
 
 # -----------------------------------------------------------------------------
 # Create a Scipy directory inside /home/ 
 # this will be used to mount the local volume
-RUN mkdir ${PROJECT_DIR}
+# RUN mkdir ${PROJECT_DIR}
 WORKDIR ${PROJECT_DIR}
+USER ${GP_USER}

--- a/tools/docker_dev/Dockerfile
+++ b/tools/docker_dev/Dockerfile
@@ -70,7 +70,7 @@ ENV CONDA_VERSION="${conda_version}" \
     # ---- Gitpod user ----
     GP_USER=gitpod \
     GP_GROUP=gitpod \
-    UID=3333 
+    UID=33333
 
 ENV HOME="/home/${GP_USER}" \
     PROJECT_DIR="${GP_HOME}/scipy"\

--- a/tools/docker_dev/Dockerfile
+++ b/tools/docker_dev/Dockerfile
@@ -91,12 +91,6 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # -----------------------------------------------------------------------------
-
-# Enable prompt color in the skeleton .bashrc
-# hadolint ignore=SC2016
-RUN sed -i 's/^#force_color_prompt=yes/force_color_prompt=yes/' /etc/skel/.bashrc
-
-# -----------------------------------------------------------------------------
 # ---- Installing conda  ----
 RUN wget --quiet "https://github.com/conda-forge/miniforge/releases/download/${miniforge_version}/${miniforge_installer}" && \
     echo "${miniforge_checksum} *${miniforge_installer}" | sha256sum --check && \
@@ -116,11 +110,14 @@ RUN wget --quiet "https://github.com/conda-forge/miniforge/releases/download/${m
     conda update --all --quiet --yes && \
     conda clean --all -f -y 
 
-# make conda activate command available from /bin/bash (login and interactive)
-RUN ln -s ${CONDA_DIR}/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
-    echo ". ${CONDA_DIR}/etc/profile.d/conda.sh" >> ~/.bashrc && \
-    echo "conda activate base" >> ~/.bashrc && \
-    echo "conda activate scipydev" >> ~/.bashrc
+# -----------------------------------------------------------------------------
+# ---- Copy needed files ----
+# Copy multiple scripts - fix directory permissions and 
+# basic workspace configurations
+COPY ./workspace_config /usr/local/bin/workspace_config
+
+RUN chmod a+rx /usr/local/bin/workspace_config && \
+    workspace_config 
 
 # -----------------------------------------------------------------------------
 # ---- Create conda environment ----
@@ -130,7 +127,6 @@ RUN ln -s ${CONDA_DIR}/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
 COPY ./environment.yml /tmp/environment.yml
 
 RUN conda env create -f /tmp/environment.yml && \
-    conda activate "${CONDA_ENV}" && \
     conda clean --all -f -y && \
     rm -rf /tmp/* 
 

--- a/tools/docker_dev/environment.yml
+++ b/tools/docker_dev/environment.yml
@@ -1,6 +1,6 @@
 # Optional dependencies left out: mpmath, gmpy2, libsuitesparse, 
 # libgmp,libmpfr, libsuitesparse, libmpc, sparse, scikit-umfpack
-name: scipydev 
+name: scipy-dev 
 dependencies:
   - pytest=6.2.1
   - pybind11=2.6.1

--- a/tools/docker_dev/settings.json
+++ b/tools/docker_dev/settings.json
@@ -5,8 +5,6 @@
     "restructuredtext.updateOnTextChanged": "true",
     "restructuredtext.updateDelay": 300,
     "restructuredtext.linter.disabled": true,
-    // pythonPath is now deprecated so using python.defaultInterpreterPath 
-    "python.defaultInterpreterPath": "/opt/conda/envs/scipydev/bin/python",
-    "python.terminal.activateEnvironment": true,
-    "python.terminal.activateEnvInCurrentTerminal": true
+    "python.pythonPath": "/opt/conda/envs/scipydev/bin/python",
+    "python.condaPath": "/opt/conda/envs/scipydev/bin/conda"
 }

--- a/tools/docker_dev/settings.json
+++ b/tools/docker_dev/settings.json
@@ -5,6 +5,7 @@
     "restructuredtext.updateOnTextChanged": "true",
     "restructuredtext.updateDelay": 300,
     "restructuredtext.linter.disabled": true,
-    "python.pythonPath": "/opt/conda/envs/scipydev/bin/python",
-    "python.condaPath": "/opt/conda/envs/scipydev/bin/conda"
+    "python.pythonPath": "/opt/conda/envs/scipy-dev/bin/python",
+    "python.condaPath": "/opt/conda/envs/scipy-dev/bin/conda",
+    "terminal.integrated.inheritEnv": false
 }

--- a/tools/docker_dev/workspace_config
+++ b/tools/docker_dev/workspace_config
@@ -14,5 +14,10 @@ git config --global alias.type 'cat-file -t'
 git config --global alias.dump 'cat-file -p'
 
 # Vanity custom bash prompt - makes it more legible tbh
-echo "PS1='\[\e]0;\u \w\a\]\[\033[01;36m\]\u\[\033[m\] > \[\033[38;5;141m\]\w\[\033[m\] \\$ '"  >> ~/.bashrc
+echo "PS1='\[\e]0;\u \w\a\]\[\033[01;36m\]\u\[\033[m\] > \[\033[38;5;141m\]\w\[\033[m\] \\$ '" >>~/.bashrc
 
+# Add conda
+echo ". ${CONDA_DIR}/etc/profile.d/conda.sh" >>~/.profile
+
+# Add call to conda init script see https://stackoverflow.com/a/58081608/4413446
+echo 'eval "$(command conda shell.bash hook 2> /dev/null)"' >>/etc/skel/.bashrc

--- a/tools/docker_dev/workspace_config
+++ b/tools/docker_dev/workspace_config
@@ -22,9 +22,10 @@ echo "syntax enable" >>~/.vimrc
 echo "PS1='\[\e]0;\u \w\a\]\[\033[01;36m\]\u\[\033[m\] > \[\033[38;5;141m\]\w\[\033[m\] \\$ '" >>~/.bashrc
 
 # make conda activate command available from /bin/bash (login and interactive)
-ln -s ${CONDA_DIR}/etc/profile.d/conda.sh /etc/profile.d/conda.sh
+if [[ ! -f "/etc/profile.d/conda.sh" ]]; then
+    ln -s ${CONDA_DIR}/etc/profile.d/conda.sh /etc/profile.d/conda.sh
+fi
 echo ". ${CONDA_DIR}/etc/profile.d/conda.sh" >>~/.bashrc
-echo "conda activate base" >>~/.bashrc
 echo "conda activate scipydev" >>~/.bashrc
 
 # Enable prompt color in the skeleton .bashrc

--- a/tools/docker_dev/workspace_config
+++ b/tools/docker_dev/workspace_config
@@ -4,7 +4,6 @@
 set -e
 
 # Add git aliases
-
 git config --global alias.co checkout
 git config --global alias.ci commit
 git config --global alias.st status
@@ -13,11 +12,18 @@ git config --global alias.hist "log --pretty=format:'%h %ad | %s%d [%an]' --grap
 git config --global alias.type 'cat-file -t'
 git config --global alias.dump 'cat-file -p'
 
+# Enable basic vim defaults in ~/.vimrc
+echo "filetype plugin indent on" >>~/.vimrc
+echo "set colorcolumn=80" >>~/.vimrc
+echo "set number" >>~/.vimrc
+echo "syntax enable" >>~/.vimrc
+
 # Vanity custom bash prompt - makes it more legible tbh
 echo "PS1='\[\e]0;\u \w\a\]\[\033[01;36m\]\u\[\033[m\] > \[\033[38;5;141m\]\w\[\033[m\] \\$ '" >>~/.bashrc
 
-# Add conda
+# Add conda -- interactive login
 echo ". ${CONDA_DIR}/etc/profile.d/conda.sh" >>~/.profile
 
 # Add call to conda init script see https://stackoverflow.com/a/58081608/4413446
-echo 'eval "$(command conda shell.bash hook 2> /dev/null)"' >>/etc/skel/.bashrc
+# also for reference
+echo 'eval "$(command conda shell.bash hook 2> /dev/null)"' >>~/.bashrc

--- a/tools/docker_dev/workspace_config
+++ b/tools/docker_dev/workspace_config
@@ -18,12 +18,15 @@ echo "set colorcolumn=80" >>~/.vimrc
 echo "set number" >>~/.vimrc
 echo "syntax enable" >>~/.vimrc
 
-# Vanity custom bash prompt - makes it more legible tbh
+# Vanity custom bash prompt - makes it more legible
 echo "PS1='\[\e]0;\u \w\a\]\[\033[01;36m\]\u\[\033[m\] > \[\033[38;5;141m\]\w\[\033[m\] \\$ '" >>~/.bashrc
 
-# Add conda -- interactive login
-echo ". ${CONDA_DIR}/etc/profile.d/conda.sh" >>~/.profile
+# make conda activate command available from /bin/bash (login and interactive)
+ln -s ${CONDA_DIR}/etc/profile.d/conda.sh /etc/profile.d/conda.sh
+echo ". ${CONDA_DIR}/etc/profile.d/conda.sh" >>~/.bashrc
+echo "conda activate base" >>~/.bashrc
+echo "conda activate scipydev" >>~/.bashrc
 
-# Add call to conda init script see https://stackoverflow.com/a/58081608/4413446
-# also for reference
-echo 'eval "$(command conda shell.bash hook 2> /dev/null)"' >>~/.bashrc
+# Enable prompt color in the skeleton .bashrc
+# hadolint ignore=SC2016
+sed -i 's/^#force_color_prompt=yes/force_color_prompt=yes/' /etc/skel/.bashrc

--- a/tools/docker_dev/workspace_config
+++ b/tools/docker_dev/workspace_config
@@ -26,7 +26,7 @@ if [[ ! -f "/etc/profile.d/conda.sh" ]]; then
     ln -s ${CONDA_DIR}/etc/profile.d/conda.sh /etc/profile.d/conda.sh
 fi
 echo ". ${CONDA_DIR}/etc/profile.d/conda.sh" >>~/.bashrc
-echo "conda activate scipydev" >>~/.bashrc
+echo "conda activate scipy-dev" >>~/.bashrc
 
 # Enable prompt color in the skeleton .bashrc
 # hadolint ignore=SC2016


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Related to #13677 

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR tackles the issues mentioned in the above issue and makes improvements to the GitPod integration

**Editor**
- [x] Make sure the Python extension is installed -> since we are using our custom image
- [x] .theia/settings.json has 3 python settings that current give a warning -> removed deprecated settings

**Docker images**
- [x]  Add the gh cli (https://github.com/cli/cli) to the gitpod container
- [x] Build SciPy in the gitpod Docker image (with this the build takes approx 9 mins locally)
- [x] Reduce image size: now using multi-stage builds for the `gitpod` image resulting in:

  ```
  REPOSITORY        TAG            SIZE
  trallard          scipy-gitpod   2.59GB
  scipy/scipy-dev   latest         2.4GB
  ```

   which is a considerable shrink as opposed to the original ~5GB for the gitpod image.
- [x] Build Gitpod image nightly, push and use that for gitpod integration -> building on push to `master` atm
- [ ] on each new workspace startup, there's a popup "Sphinx preview not enabled". This is probably because a workspace opens with README.rst opened up in Theia by default. Would be nice to install a Sphinx extension, but I don't see one. TODO: install `sphinx-autobuild` in the Docker container -> there is a rst extension which allows the rendering of Sphinx docs 
  
**GitHub actions**
- [x] Cache image layers to reduce build times
- [x] Change update base Docker image to when changes are detected in `tools/docker_dev/environment.yml`
- [x] Add workflow to build and push the gitpod Docker image (`.github/workflows/docker.yml`)
- [ ] Change update base Docker image to monthly in `.github/workflows/docker.yml`

**Gitpod**
- [x] Replace the image being used in `gitpod.yaml` to the new image directly from DockerHub 
- [ ] ensuring that the most recent prebuild is picked when navigating to https://gitpod.io/#https://github.com/scipy/scipy. Right now it looks like after a merge to master, the previous prebuild is not picked up. See #13667 (comment) for details.
EDIT: asked for advice at https://community.gitpod.io/t/using-the-most-recent-prebuild-may-be-behind-head/2980
- [ ]  see if we can name scipy/scipy as upstream rather than origin, to match our contributor guide (the contributor's own fork is called origin). EDIT: may be a non-issue except for people who have commit rights, see second comment below.
- [ ]  the scipy and docs prebuilds work, and runtests.py does the right thing. however re-running make html for the docs doesn't, because conda develop . doesn't manage to include scipy in the list of installed packages. need to look into whether that can be improved.


#### Additional information
<!--Any additional information you think is important.-->