### PR TITLE
BUG: Divide by zero in yule dissimilarity of constant vectors

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -1296,7 +1296,11 @@ def yule(u, v, w=None):
     if w is not None:
         w = _validate_weights(w)
     (nff, nft, ntf, ntt) = _nbool_correspond_all(u, v, w=w)
-    return float(2.0 * ntf * nft / np.array(ntt * nff + ntf * nft))
+    half_R = ntf * nft
+    if half_R == 0:
+        return 0.0
+    else:
+        return float(2.0 * half_R / (ntt * nff + half_R))
 
 
 @np.deprecate(message="spatial.distance.matching is deprecated in scipy 1.0.0; "

--- a/scipy/spatial/src/distance_impl.h
+++ b/scipy/spatial/src/distance_impl.h
@@ -222,7 +222,11 @@ yule_distance_char(const char *u, const char *v, const npy_intp n)
         nft += (!x) & y;
     }
     nff = n - ntt - ntf - nft;
-    return (2. * ntf * nft) / ((double)ntt * nff + (double)ntf * nft);
+    double half_R = (double)ntf * nft;
+    if (half_R == 0.0) {
+        return 0.0;
+    }
+    return (2. * half_R) / ((double)ntt * nff + half_R);
 }
 
 static NPY_INLINE double

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -2129,3 +2129,15 @@ def test__validate_vector():
 
     x = [[1, 2], [3, 4]]
     assert_raises(ValueError, _validate_vector, x)
+
+def test_yule_all_same():
+    # Test yule avoids a divide by zero when exactly equal
+    x = np.ones((2, 6), dtype=bool)
+    d = wyule(x[0], x[0])
+    assert d == 0.0
+
+    d = pdist(x, 'yule')
+    assert_equal(d, [0.0])
+
+    d = cdist(x[:1], x[:1], 'yule')
+    assert_equal(d, [[0.0]])


### PR DESCRIPTION
#### Reference issue
Closes gh-13772

#### What does this implement/fix?
The divide by zero occurs when `(ntt * nff + ntf * nft) == 0` since all of these are non-negative, checking `ntf * nft == 0` is sufficient.