### PR TITLE
Enable trust region methods to use a finite difference Hessian closes #13754

### DIFF
--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -108,16 +108,16 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
         obey any specified `bounds`.
     hess : {callable, '2-point', '3-point', 'cs', HessianUpdateStrategy}, optional
         Method for computing the Hessian matrix. Only for Newton-CG, dogleg,
-        trust-ncg,  trust-krylov, trust-exact and trust-constr. If it is
-        callable, it should return the  Hessian matrix:
+        trust-ncg, trust-krylov, trust-exact and trust-constr. If it is
+        callable, it should return the Hessian matrix:
 
             ``hess(x, *args) -> {LinearOperator, spmatrix, array}, (n, n)``
 
         where x is a (n,) ndarray and `args` is a tuple with the fixed
-        parameters. LinearOperator and sparse matrix returns are
-        allowed only for 'trust-constr' method. Alternatively, the keywords
+        parameters. LinearOperator and sparse matrix returns are only allowed
+        for 'trust-constr' method. Alternatively, the keywords
         {'2-point', '3-point', 'cs'} select a finite difference scheme
-        for numerical estimation. Or, objects implementing
+        for numerical estimation. Or, objects implementing the
         `HessianUpdateStrategy` interface can be used to approximate
         the Hessian. Available quasi-Newton methods implementing
         this interface are:
@@ -129,8 +129,8 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
         the Hessian cannot be estimated with options
         {'2-point', '3-point', 'cs'} and needs to be
         estimated using one of the quasi-Newton strategies.
-        Finite-difference options {'2-point', '3-point', 'cs'} and
-        `HessianUpdateStrategy` are available only for 'trust-constr' method.
+        'trust-exact' cannot use a finite-difference scheme, and must be used
+        with a callable returning an (n, n) array.
     hessp : callable, optional
         Hessian of objective function times an arbitrary vector p. Only for
         Newton-CG, trust-ncg, trust-krylov, trust-constr.

--- a/scipy/optimize/_trustregion.py
+++ b/scipy/optimize/_trustregion.py
@@ -5,7 +5,8 @@ import numpy as np
 import scipy.linalg
 from .optimize import (_check_unknown_options, _wrap_function, _status_message,
                        OptimizeResult, _prepare_scalar_function)
-
+from scipy.optimize._hessian_update_strategy import HessianUpdateStrategy
+from scipy.optimize._differentiable_functions import FD_METHODS
 __all__ = []
 
 
@@ -157,8 +158,25 @@ def _minimize_trust_region(fun, x0, args=(), jac=None, hess=None, hessp=None,
     sf = _prepare_scalar_function(fun, x0, jac=jac, hess=hess, args=args)
     fun = sf.fun
     jac = sf.grad
-    if hess is not None:
+    if callable(hess):
         hess = sf.hess
+    elif callable(hessp):
+        # this elif statement must come before examining whether hess
+        # is estimated by FD methods or a HessianUpdateStrategy
+        pass
+    elif (hess in FD_METHODS or isinstance(hess, HessianUpdateStrategy)):
+        # If the Hessian is being estimated by finite differences or a
+        # Hessian update strategy then ScalarFunction.hess returns a
+        # LinearOperator or a HessianUpdateStrategy. This enables the
+        # calculation/creation of a hessp. BUT you only want to do this
+        # if the user *hasn't* provided a callable(hessp) function.
+        hess = None
+        def hessp(x, p, *args):
+            return sf.hess(x).dot(p)
+    else:
+        raise ValueError('Either the Hessian or the Hessian-vector product '
+                         'is currently required for trust-region methods')
+
     # ScalarFunction doesn't represent hessp
     nhessp, hessp = _wrap_function(hessp, args)
 


### PR DESCRIPTION
Currently most trustregion methods (`trust-krylov`, `dogleg`, `trust-ncg`) have to have a callable `hess` or `hessp` in order to work.

However, it's possible for `hess` to be estimated by finite difference methods [in ScalarFunction](https://github.com/scipy/scipy/blob/master/scipy/optimize/_differentiable_functions.py#L187) if an analytical `grad` is provided. If this is the case then `ScalarFunction.hess(x)` will return a `LinearOperator` or a `HessianUpdateStrategy`. Either of those can be used to create a `hessp` function at runtime.

This PR allows those trustregion methods to proceed if `hessp is None` and `hess in ["2-point", "3-point", "cs"] or isinstance(hess, HessianUpdateStrategy)`.

See #13754 for more discussion.

@mgudorf