### PR TITLE
MAINT: LBFGSB err msg on MAXLS changed closes #11718

### DIFF
--- a/scipy/optimize/lbfgsb_src/lbfgsb.f
+++ b/scipy/optimize/lbfgsb_src/lbfgsb.f
@@ -2900,7 +2900,7 @@ c     ************
      +'   may possibly be caused by a bad search direction.')
  9018 format (/,' The triangular system is singular.')
  9019 format (/,
-     +' Line search cannot locate an adequate point after 20 function',/
+     +' Line search cannot locate an adequate point after MAXLS function',/
      +,'  and gradient evaluations.  Previous x, f and g restored.',/,
      +' Possible causes: 1 error in function or gradient evaluation;',/,
      +'                  2 rounding error dominate computation.')

--- a/scipy/optimize/lbfgsb_src/lbfgsb.f
+++ b/scipy/optimize/lbfgsb_src/lbfgsb.f
@@ -2900,8 +2900,9 @@ c     ************
      +'   may possibly be caused by a bad search direction.')
  9018 format (/,' The triangular system is singular.')
  9019 format (/,
-     +' Line search cannot locate an adequate point after MAXLS function',/
-     +,'  and gradient evaluations.  Previous x, f and g restored.',/,
+     +' Line search cannot locate an adequate point after MAXLS',/
+     +,'  function and gradient evaluations.',/
+     +,'  Previous x, f and g restored.',/,
      +' Possible causes: 1 error in function or gradient evaluation;',/,
      +'                  2 rounding error dominate computation.')
 


### PR DESCRIPTION
#11718 reports that if the maximum number of line search iterations is reached then the following message is *always* given:
```
Line search cannot locate an adequate point after 20 function
  and gradient evaluations.  Previous x, f and g restored.
 Possible causes: 1 error in function or gradient evaluation;
                  2 rounding error dominate computation.
```

Thus, if you set the maximum number of line search iterations to 40 then the error message will be wrong. This PR takes the quick and dirty route of changing the message to:
```
Line search cannot locate an adequate point after MAXLS function
```

I don't know how to do Fortran string interpolation, but it doesn't strike me as particularly important to do that.
