### PR TITLE
BENCH: Add benchmark for cdist/pdist with weights

### DIFF
--- a/benchmarks/benchmarks/spatial.py
+++ b/benchmarks/benchmarks/spatial.py
@@ -359,6 +359,37 @@ class Xdist(Benchmark):
         distance.pdist(self.points, self.metric, **self.kwargs)
 
 
+class XdistWeighted(Benchmark):
+    params = (
+        [10, 20, 100],
+        ['euclidean', 'minkowski', 'cityblock', 'sqeuclidean', 'cosine',
+         'correlation', 'hamming', 'jaccard', 'chebyshev', 'canberra',
+         'braycurtis', 'yule', 'dice', 'kulsinski', 'rogerstanimoto',
+         'russellrao', 'sokalmichener', 'sokalsneath', 'minkowski-P3'])
+    param_names = ['num_points', 'metric']
+
+    def setup(self, num_points, metric):
+        np.random.seed(123)
+        self.points = np.random.random_sample((num_points, 3))
+        self.metric = metric
+        if metric == 'minkowski-P3':
+            # p=2 is just the euclidean metric, try another p value as well
+            self.kwargs = {'p': 3.0}
+            self.metric = 'minkowski'
+        else:
+            self.kwargs = {}
+        self.weights = np.ones(3)
+
+    def time_cdist(self, num_points, metric):
+        """Time scipy.spatial.distance.cdist for weighted distance metrics."""
+        distance.cdist(self.points, self.points, self.metric, w=self.weights,
+                       **self.kwargs)
+
+    def time_pdist(self, num_points, metric):
+        """Time scipy.spatial.distance.pdist for weighted distance metrics."""
+        distance.pdist(self.points, self.metric, w=self.weights, **self.kwargs)
+
+
 class ConvexHullBench(Benchmark):
     params = ([10, 100, 1000, 5000], [True, False])
     param_names = ['num_points', 'incremental']


### PR DESCRIPTION
### Reference issue
To track progress of #13629

#### What does this implement/fix?
This adds a benchmark for cdist/pdist with a weight vector supplied. It's very similar to the existing `Xdist` benchmark except that it only covers metrics that support weights and also uses smaller arrays because the current implementation is excruciatingly slow for 1000 elements. On my machine the slowest of these is around 200ms for 100 elements so 1000 elements would be ~20s per call.