### PR TITLE
MAINT: Prepare cdist/pdist for C++ rework

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -191,21 +191,18 @@ def _nbool_correspond_ft_tf(u, v, w=None):
 
 
 def _validate_cdist_input(XA, XB, mA, mB, n, metric_info, **kwargs):
-    if metric_info is not None:
-        # get supported types
-        types = metric_info.types
-        # choose best type
-        typ = types[types.index(XA.dtype)] if XA.dtype in types else types[0]
-        # validate data
-        XA = _convert_to_type(XA, out_type=typ)
-        XB = _convert_to_type(XB, out_type=typ)
+    # get supported types
+    types = metric_info.types
+    # choose best type
+    typ = types[types.index(XA.dtype)] if XA.dtype in types else types[0]
+    # validate data
+    XA = _convert_to_type(XA, out_type=typ)
+    XB = _convert_to_type(XB, out_type=typ)
 
-        # validate kwargs
-        _validate_kwargs = metric_info.validator
-        if _validate_kwargs:
-            kwargs = _validate_kwargs((XA, XB), mA + mB, n, **kwargs)
-    else:
-        typ = None
+    # validate kwargs
+    _validate_kwargs = metric_info.validator
+    if _validate_kwargs:
+        kwargs = _validate_kwargs((XA, XB), mA + mB, n, **kwargs)
     return XA, XB, typ, kwargs
 
 
@@ -263,20 +260,17 @@ def _validate_minkowski_kwargs(X, m, n, **kwargs):
 
 
 def _validate_pdist_input(X, m, n, metric_info, **kwargs):
-    if metric_info is not None:
-        # get supported types
-        types = metric_info.types
-        # choose best type
-        typ = types[types.index(X.dtype)] if X.dtype in types else types[0]
-        # validate data
-        X = _convert_to_type(X, out_type=typ)
+    # get supported types
+    types = metric_info.types
+    # choose best type
+    typ = types[types.index(X.dtype)] if X.dtype in types else types[0]
+    # validate data
+    X = _convert_to_type(X, out_type=typ)
 
-        # validate kwargs
-        _validate_kwargs = metric_info.validator
-        if _validate_kwargs:
-            kwargs = _validate_kwargs(X, m, n, **kwargs)
-    else:
-        typ = None
+    # validate kwargs
+    _validate_kwargs = metric_info.validator
+    if _validate_kwargs:
+        kwargs = _validate_kwargs(X, m, n, **kwargs)
     return X, typ, kwargs
 
 

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -209,6 +209,19 @@ def _validate_cdist_input(XA, XB, mA, mB, n, metric_info, **kwargs):
     return XA, XB, typ, kwargs
 
 
+def _validate_weight_with_size(X, m, n, **kwargs):
+    w = kwargs.pop('w', None)
+    if w is None:
+        return kwargs
+
+    if w.ndim != 1 or w.shape[0] != n:
+        raise ValueError("Weights must have same size as input vector. "
+                         f"{w.shape[0]} vs. {n}")
+
+    kwargs['w'] = _validate_weights(w)
+    return kwargs
+
+
 def _validate_hamming_kwargs(X, m, n, **kwargs):
     w = kwargs.get('w', np.ones((n,), dtype='double'))
 
@@ -239,9 +252,7 @@ def _validate_mahalanobis_kwargs(X, m, n, **kwargs):
 
 
 def _validate_minkowski_kwargs(X, m, n, **kwargs):
-    w = kwargs.pop('w', None)
-    if w is not None:
-        kwargs['w'] = _validate_weights(w)
+    kwargs = _validate_weight_with_size(X, m, n, **kwargs)
     if 'p' not in kwargs:
         kwargs['p'] = 2.
     else:
@@ -1764,6 +1775,7 @@ _METRIC_INFOS = [
         canonical_name='chebyshev',
         aka={'chebychev', 'chebyshev', 'cheby', 'cheb', 'ch'},
         dist_func=chebyshev,
+        validator=_validate_weight_with_size,
         cdist_func=CDistWeightedMetricWrapper(
             'chebyshev', 'weighted_chebyshev'),
         pdist_func=PDistWeightedMetricWrapper(

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -203,7 +203,7 @@ def _validate_cdist_input(XA, XB, mA, mB, n, metric_info, **kwargs):
         # validate kwargs
         _validate_kwargs = metric_info.validator
         if _validate_kwargs:
-            kwargs = _validate_kwargs(np.vstack([XA, XB]), mA + mB, n, **kwargs)
+            kwargs = _validate_kwargs((XA, XB), mA + mB, n, **kwargs)
     else:
         typ = None
     return XA, XB, typ, kwargs
@@ -230,7 +230,9 @@ def _validate_mahalanobis_kwargs(X, m, n, **kwargs):
                              "singular. For observations with %d "
                              "dimensions, at least %d observations "
                              "are required." % (m, n, n + 1))
-        CV = np.atleast_2d(np.cov(X.astype(np.double).T))
+        if isinstance(X, tuple):
+            X = np.vstack(X)
+        CV = np.atleast_2d(np.cov(X.astype(np.double, copy=False).T))
         VI = np.linalg.inv(CV).T.copy()
     kwargs["VI"] = _convert_to_double(VI)
     return kwargs
@@ -270,7 +272,9 @@ def _validate_pdist_input(X, m, n, metric_info, **kwargs):
 def _validate_seuclidean_kwargs(X, m, n, **kwargs):
     V = kwargs.pop('V', None)
     if V is None:
-        V = np.var(X.astype(np.double), axis=0, ddof=1)
+        if isinstance(X, tuple):
+            X = np.vstack(X)
+        V = np.var(X.astype(np.double, copy=False), axis=0, ddof=1)
     else:
         V = np.asarray(V, order='c')
         if len(V.shape) != 1:


### PR DESCRIPTION
#### Reference issue
Related to https://github.com/scipy/scipy/issues/13629#issuecomment-790831819

#### What does this implement/fix?
In preparation for rewriting the C++ implementations for `cdist`/`pdist`, I have taken the logic that's closely tied to the current C implementations and moved it from `cdist`/`pdist` into the per-metric `MetricInfo` object. This means I can incrementally update `cdist`/`pdist` one metric at a time in future PRs. 

#### Additional information

Benchmark changes (including weighted benchmarks in #13785):
```python
       before           after         ratio
     [7dcdeffe]       [4769878d]
     <master>         <xdist-python-rework>
+     4.68±0.02μs      5.15±0.05μs     1.10  spatial.Xdist.time_cdist(10, 'chebyshev')
+     2.55±0.01ms      2.80±0.01ms     1.10  spatial.XdistWeighted.time_pdist(20, 'jaccard')
+     5.22±0.04μs       5.62±0.1μs     1.08  spatial.Xdist.time_cdist(10, 'rogerstanimoto')
+     4.62±0.06μs      4.97±0.03μs     1.08  spatial.Xdist.time_cdist(10, 'sqeuclidean')
+     4.83±0.06μs      5.16±0.01μs     1.07  spatial.Xdist.time_cdist(10, 'cosine')
+      5.26±0.1μs      5.62±0.04μs     1.07  spatial.Xdist.time_cdist(10, 'kulsinski')
+     5.34±0.06μs      5.67±0.02μs     1.06  spatial.Xdist.time_cdist(10, 'yule')
+     4.96±0.04μs      5.23±0.03μs     1.05  spatial.Xdist.time_cdist(10, 'jaccard')
-      11.4±0.1μs      10.8±0.05μs     0.95  spatial.Xdist.time_pdist(100, 'sqeuclidean')
-      11.4±0.3μs       10.8±0.1μs     0.95  spatial.Xdist.time_pdist(100, 'cityblock')
-     4.66±0.02ms      4.41±0.01ms     0.95  spatial.XdistWeighted.time_pdist(20, 'dice')
-      3.83±0.1ms      3.60±0.01ms     0.94  spatial.XdistWeighted.time_pdist(20, 'canberra')
-     4.48±0.06μs       4.14±0.1μs     0.92  spatial.Xdist.time_pdist(10, 'jaccard')
-     5.94±0.09μs      5.46±0.01μs     0.92  spatial.Xdist.time_pdist(10, 'jensenshannon')
-      40.0±0.4μs       36.8±0.6μs     0.92  spatial.Xdist.time_cdist(100, 'hamming')
-      21.7±0.7μs      19.9±0.07μs     0.92  spatial.Xdist.time_pdist(10, 'seuclidean')
-      4.45±0.1μs      4.02±0.03μs     0.91  spatial.Xdist.time_pdist(10, 'chebyshev')
-     4.47±0.01μs      4.04±0.04μs     0.90  spatial.Xdist.time_pdist(10, 'cityblock')
-     4.60±0.07μs      4.13±0.05μs     0.90  spatial.Xdist.time_pdist(10, 'russellrao')
-        16.5±1μs       14.8±0.9μs     0.90  spatial.XdistWeighted.time_cdist(20, 'hamming')
-      4.73±0.3μs      4.22±0.07μs     0.89  spatial.Xdist.time_pdist(10, 'kulsinski')
-     4.48±0.01μs      4.00±0.01μs     0.89  spatial.Xdist.time_pdist(10, 'euclidean')
-     4.65±0.03μs      4.12±0.06μs     0.89  spatial.Xdist.time_pdist(10, 'sokalsneath')
-     4.49±0.06μs      3.97±0.01μs     0.89  spatial.Xdist.time_pdist(10, 'canberra')
-      4.48±0.2μs      3.96±0.04μs     0.88  spatial.Xdist.time_pdist(10, 'sqeuclidean')
-      4.86±0.6μs      4.25±0.02μs     0.87  spatial.Xdist.time_pdist(10, 'dice')
-     18.4±0.06μs      15.8±0.07μs     0.86  spatial.XdistWeighted.time_cdist(10, 'minkowski')
-      19.1±0.9μs       16.3±0.1μs     0.85  spatial.XdistWeighted.time_cdist(10, 'minkowski-P3')
-      15.1±0.4μs       12.8±0.5μs     0.85  spatial.Xdist.time_cdist(10, 'hamming')
-      12.3±0.2μs      10.3±0.06μs     0.83  spatial.Xdist.time_cdist(10, 'minkowski-P3')
-      5.10±0.5μs       4.20±0.1μs     0.82  spatial.Xdist.time_pdist(10, 'yule')
-      15.6±0.2μs      12.5±0.04μs     0.80  spatial.XdistWeighted.time_cdist(10, 'hamming')
-     7.53±0.07μs       5.49±0.2μs     0.73  spatial.Xdist.time_cdist(10, 'minkowski')
-         504±1μs       10.5±0.2μs     0.02  spatial.XdistWeighted.time_pdist(10, 'chebyshev')
-     1.09±0.05ms       11.8±0.5μs     0.01  spatial.XdistWeighted.time_cdist(10, 'chebyshev')
-     2.04±0.02ms      11.0±0.09μs     0.01  spatial.XdistWeighted.time_pdist(20, 'chebyshev')
-     4.31±0.06ms       12.6±0.2μs     0.00  spatial.XdistWeighted.time_cdist(20, 'chebyshev')
-      53.1±0.2ms       23.6±0.6μs     0.00  spatial.XdistWeighted.time_pdist(100, 'chebyshev')
-       107±0.4ms       39.0±0.8μs     0.00  spatial.XdistWeighted.time_cdist(100, 'chebyshev')
```

Summary: Overhead for small sizes has changed +/- .5 us for some metrics, but more improved than regressed. Weighted chebyshev also improved massively because the weighted kernels existed but weren't actually called before.