### PR TITLE
CI/MAINT: deprecated np.typeDict

### DIFF
--- a/scipy/ndimage/_ni_support.py
+++ b/scipy/ndimage/_ni_support.py
@@ -86,7 +86,7 @@ def _get_output(output, input, shape=None, complex_output=False):
             output = numpy.promote_types(output, numpy.complex64)
         output = numpy.zeros(shape, dtype=output)
     elif isinstance(output, str):
-        output = numpy.typeDict[output]
+        output = numpy.sctypeDict[output]
         if complex_output and numpy.dtype(output).kind != 'c':
             raise RuntimeError("output must have complex dtype")
         output = numpy.zeros(shape, dtype=output)


### PR DESCRIPTION
Change deprecated `np.typeDict` to `np.sctypeDict`.

Closes #13796