### PR TITLE
ENH: Changed return type of pearsonr to namedtuple

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -4061,10 +4061,10 @@ def pearsonr(x, y):
 
     Returns
     -------
-    r : float
-        Pearson's correlation coefficient.
-    p-value : float
-        Two-tailed p-value.
+    correlation : float
+       Pearson's correlation coefficient.
+    pvalue : float
+       Two-tailed p-value.
 
     Warns
     -----

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -4030,6 +4030,9 @@ class PearsonRNearConstantInputWarning(RuntimeWarning):
                    "correlation coefficent may be inaccurate.")
         self.args = (msg,)
 
+        
+PearsonrResult = namedtuple('PearsonrResult', ('correlation', 'pvalue'))
+
 
 def pearsonr(x, y):
     r"""
@@ -4212,7 +4215,7 @@ def pearsonr(x, y):
     ab = n/2 - 1
     prob = 2*special.btdtr(ab, ab, 0.5*(1 - abs(np.float64(r))))
 
-    return r, prob
+    return PearsonrResult(r, prob)
 
 
 def fisher_exact(table, alternative='two-sided'):

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -406,6 +406,11 @@ class TestCorrPearsonr:
         x = [1]
         y = [2]
         assert_raises(ValueError, stats.pearsonr, x, y)
+        
+    def test_pearsonr_result_attributes(self):
+        res = stats.pearsonr(X, X)
+        attributes = ('correlation', 'pvalue')
+        check_named_results(res, attributes)
 
 
 class TestFisherExact:


### PR DESCRIPTION
#### What does this implement/fix?
This change aims to make the return type of `stats.pearsonr` consistent with other stats functions such as `stats.spearmanr` which already return named tuples