### PR TITLE
DOC: fix doc build warning about arxiv role already being registered

### DIFF
--- a/doc/source/doi_role.py
+++ b/doc/source/doi_role.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
     doilinks
-    ~~~~~~~~~~~~~~~~~~~
+    ~~~~~~~~
     Extension to add links to DOIs. With this extension you can use e.g.
     :doi:`10.1016/S0022-2836(05)80360-2` in your documents. This will
     create a link to a DOI resolver
@@ -41,10 +41,10 @@ def arxiv_role(typ, rawtext, text, lineno, inliner, options={}, content=[]):
 
 
 def setup_link_role(app):
-    app.add_role('doi', doi_role)
-    app.add_role('DOI', doi_role)
-    app.add_role('arXiv', arxiv_role)
-    app.add_role('arxiv', arxiv_role)
+    app.add_role('doi', doi_role, override=True)
+    app.add_role('DOI', doi_role, override=True)
+    app.add_role('arXiv', arxiv_role, override=True)
+    app.add_role('arxiv', arxiv_role, override=True)
 
 
 def setup(app):


### PR DESCRIPTION
This warning is breaking the doc build on merges to master currently.

The `override` keyword used here makes sense anyway, and is supported in Sphinx >= 1.8