### PR TITLE
BUG: fix convergence tolerance in `_lsq.check_termination`

### DIFF
--- a/scipy/optimize/_lsq/common.py
+++ b/scipy/optimize/_lsq/common.py
@@ -708,7 +708,7 @@ def left_multiply(J, d, copy=True):
 def check_termination(dF, F, dx_norm, x_norm, ratio, ftol, xtol):
     """Check termination condition for nonlinear least squares."""
     ftol_satisfied = dF < ftol * F and ratio > 0.25
-    xtol_satisfied = dx_norm < xtol * (xtol + x_norm)
+    xtol_satisfied = dx_norm < xtol * (1 + x_norm)
 
     if ftol_satisfied and xtol_satisfied:
         return 4

--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -316,7 +316,7 @@ class BaseMixin:
                 res = least_squares(
                     fun_rosenbrock_cropped, x0, jac, x_scale=x_scale,
                     tr_solver=tr_solver, method=self.method)
-                assert_allclose(res.cost, 0, atol=1e-14)
+                assert_allclose(res.cost, 0, atol=1e-13)
 
     def test_fun_wrong_dimensions(self):
         assert_raises(ValueError, least_squares, fun_wrong_dimensions,

--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -316,6 +316,7 @@ class BaseMixin:
                 res = least_squares(
                     fun_rosenbrock_cropped, x0, jac, x_scale=x_scale,
                     tr_solver=tr_solver, method=self.method)
+                assert res.nfev < 40
                 assert_allclose(res.cost, 0, atol=1e-13)
 
     def test_fun_wrong_dimensions(self):


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
The implemented convergence check is quite unusual and I believe this was not intended. This changes the tolerance check such that xtol is a canonical absolute + relative tolerance

#### Additional information
<!--Any additional information you think is important.-->