### PR TITLE
MAINT: Dont use parallel Sphinx

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
           command: |
             . venv/bin/activate
             export SHELL=$(which bash)
-            python -u runtests.py -g -j2 --doc html-scipyorg --doc latex
+            python -u runtests.py -g --doc html-scipyorg --doc latex
             make -C doc/build/latex all-pdf LATEXOPTS="-file-line-error -halt-on-error"
             cp -f doc/build/latex/scipy-ref.pdf doc/build/html-scipyorg/
 


### PR DESCRIPTION
Currently takes ~30 minutes to build on CircleCI. Let's see if a non-parallel build is comparable.