### PR TITLE
MAINT: add a CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,54 @@
+# The purpose of this file is to trigger review requests when PRs touch
+# particular files. Those reviews are not mandatory, however it's often useful
+# to have an expert pinged who is interested in only one part of SciPy and
+# doesn't follow general development.
+#
+# Note that only GitHub handles (whether individuals or teams) with commit
+# rights should be added to this file.
+# See https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+# for more details about how CODEOWNERS works.
+
+# Each line is a file pattern followed by one or more owners.
+
+.github/CODEOWNERS  @rgommers @larsoner
+
+# Build related files
+pyproject.toml  @rgommers
+setup.py  @rgommers @larsoner
+pavement.py  @tylerjereddy
+environment.yml  @rgommers
+
+# SciPy submodules (please keep in alphabetical order)
+scipy/fft/*  @peterbell10
+scipy/fftpack/*  @peterbell10
+scipy/linalg/*  @larsoner @ilayn
+scipy/interpolate/*  @ev-br
+scipy/optimize/*  @andyfaff
+scipy/signal/*  @larsoner @ilayn
+scipy/sparse/*  @perimosocordiae
+scipy/spatial/*  @tylerjereddy @peterbell10
+scipy/special/*  @person142
+scipy/stats/_distn_infrastructure  @andyfaff @ev-br
+scipy/stats/*distr*.py  @ev-br
+scipy/stats/_continuous_distns  @andyfaff
+scipy/stats/_hypothesis.py  @tupui
+scipy/stats/*qmc.*  @tupui
+scipy/stats/*sobol*  @tupui
+
+# Testing infrastructure
+ci/*  @larsoner @andyfaff
+tools/refguide_check.py  @ev-br
+tools/*  @larsoner @rgommers
+runtests.py  @larsoner
+pytest.ini  @larsoner
+tox.ini  @larsoner
+codecov.yml  @larsoner
+.coveragerc  @larsoner
+benchmarks/asv.conf.json  @larsoner
+
+# CI config
+.circleci/*  @larsoner
+.github/*  @larsoner @andyfaff
+azure-pipelines.yml  @larsoner
+.travis.yml  @larsoner
+


### PR DESCRIPTION
As discussed initially in https://mail.python.org/pipermail/scipy-dev/2021-February/024582.html

Note that testing this on a fork is difficult, because review requests aren't triggered for the person who opened the PR, and reviewers must have commit rights (which they typically don't have on a fork). Here is a useful trick to test whether the syntax is correct, by using `.gitignore` (which obeys the same syntax) instead:
http://www.benjaminoakes.com/git/2018/08/10/Testing-changes-to-GitHub-CODEOWNERS/

I propose that everyone who wants to be added to some file(s) or submodule(s) adds a comment here, and I'll incorporate them all at once, before merging this PR to avoid some churn. We can leave this open for a week or so.

`[ci skip]`