### PR TITLE
DOC: "Options" is not a valid Numpydoc section header.

### DIFF
--- a/scipy/optimize/_linprog_doc.py
+++ b/scipy/optimize/_linprog_doc.py
@@ -81,8 +81,6 @@ def _linprog_highs_doc(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
         :ref:`'simplex' <optimize.linprog-simplex>` (legacy)
         are also available.
 
-    Options
-    -------
     maxiter : int
         The maximum number of iterations to perform in either phase.
         For :ref:`'highs-ipm' <optimize.linprog-highs-ipm>`, this does not
@@ -288,8 +286,6 @@ def _linprog_highs_ds_doc(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
         :ref:`'simplex' <optimize.linprog-simplex>` (legacy)
         are also available.
 
-    Options
-    -------
     maxiter : int
         The maximum number of iterations to perform in either phase.
         Default is the largest possible value for an ``int`` on the platform.
@@ -481,8 +477,6 @@ def _linprog_highs_ipm_doc(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
         :ref:`'simplex' <optimize.linprog-simplex>` (legacy)
         are also available.
 
-    Options
-    -------
     maxiter : int
         The maximum number of iterations to perform in either phase.
         For :ref:`'highs-ipm' <optimize.linprog-highs-ipm>`, this does not
@@ -662,8 +656,6 @@ def _linprog_ip_doc(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
     callback : callable, optional
         Callback function to be executed once per iteration.
 
-    Options
-    -------
     maxiter : int (default: 1000)
         The maximum number of iterations of the algorithm.
     disp : bool (default: False)
@@ -990,8 +982,6 @@ def _linprog_rs_doc(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
         'revised simplex' method, and can only be used if `x0` represents a
         basic feasible solution.
 
-    Options
-    -------
     maxiter : int (default: 5000)
        The maximum number of iterations to perform in either phase.
     disp : bool (default: False)
@@ -1166,8 +1156,6 @@ def _linprog_simplex_doc(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
     callback : callable, optional
         Callback function to be executed once per iteration.
 
-    Options
-    -------
     maxiter : int (default: 5000)
        The maximum number of iterations to perform in either phase.
     disp : bool (default: False)

--- a/scipy/optimize/_linprog_highs.py
+++ b/scipy/optimize/_linprog_highs.py
@@ -97,8 +97,6 @@ def _linprog_highs(lp, solver, time_limit=None, presolve=True,
     solver : "ipm" or "simplex" or None
         Which HiGHS solver to use.  If ``None``, "simplex" will be used.
 
-    Options
-    -------
     maxiter : int
         The maximum number of iterations to perform in either phase. For
         ``solver='ipm'``, this does not include the number of crossover

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -858,8 +858,6 @@ def _linprog_ip(c, c0, A, b, callback, postsolve_args, maxiter=1000, tol=1e-8,
         Data needed by _postsolve to convert the solution to the standard-form
         problem into the solution to the original problem.
 
-    Options
-    -------
     maxiter : int (default = 1000)
         The maximum number of iterations of the algorithm.
     tol : float (default = 1e-8)

--- a/scipy/optimize/_linprog_rs.py
+++ b/scipy/optimize/_linprog_rs.py
@@ -479,8 +479,6 @@ def _linprog_rs(c, c0, A, b, x0, callback, postsolve_args,
         Data needed by _postsolve to convert the solution to the standard-form
         problem into the solution to the original problem.
 
-    Options
-    -------
     maxiter : int
        The maximum number of iterations to perform in either phase.
     tol : float

--- a/scipy/optimize/_linprog_simplex.py
+++ b/scipy/optimize/_linprog_simplex.py
@@ -503,8 +503,6 @@ def _linprog_simplex(c, c0, A, b, callback, postsolve_args,
         Data needed by _postsolve to convert the solution to the standard-form
         problem into the solution to the original problem.
 
-    Options
-    -------
     maxiter : int
        The maximum number of iterations to perform.
     disp : bool

--- a/scipy/optimize/_qap.py
+++ b/scipy/optimize/_qap.py
@@ -273,8 +273,6 @@ def _quadratic_assignment_faq(A, B,
         documentation for 'faq'.
         :ref:`'2opt' <optimize.qap-2opt>` is also available.
 
-    Options
-    -------
     maximize : bool (default: False)
         Maximizes the objective function if ``True``.
     partial_match : 2-D array of integers, optional (default: None)
@@ -577,8 +575,6 @@ def _quadratic_assignment_2opt(A, B, maximize=False, rng=None,
         documentation for '2opt'.
         :ref:`'faq' <optimize.qap-faq>` is also available.
 
-    Options
-    -------
     maximize : bool (default: False)
         Maximizes the objective function if ``True``.
     rng : {None, int, `numpy.random.Generator`,


### PR DESCRIPTION
This does not appear to be in the numpydoc format description[1], nor is
it handled by the `Numpydoc` Package, as sections are  being parsed
differently [2] if they are actually named 'Parameters', 'Other Parameters',
'Attributes', or 'Methods'.

My guess is that in the functions, this modifies, 'Parameters', was
meant for mandatory, and Options for optional parameters, though both of
those should be in Parameters. They could also be put in "Other
Parameters" as well, though this other section is also rarely used.

While it does not affect sphinx rendering (much), this make it a harder
to process docs using NumpyDocs and in particular this caused issues in
one of my project [3] to improperly detect undocumented parameters. This
would also affect one of the improvement I'm planning for IPython/Jupyter
to understand and reder the NumpyDoc format in a more pleasant and
functional way.

1: https://numpydoc.readthedocs.io/en/latest/format.html
2: https://github.com/numpy/numpydoc/blob/6d7eaf70a19664aa43997c07c65bea0b7774c16a/numpydoc/docscrape.py#L401-L407
3: https://github.com/carreau/velin

