### PR TITLE
MAINT: stats: keep `entropy` importable from `scipy.stats.distributions`

### DIFF
--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -12,9 +12,10 @@ from . import _discrete_distns
 
 from ._continuous_distns import *
 from ._discrete_distns import *
+from ._entropy import entropy
 
 # For backwards compatibility e.g. pymc expects distributions.__all__.
-__all__ = ['rv_discrete', 'rv_continuous', 'rv_histogram']
+__all__ = ['rv_discrete', 'rv_continuous', 'rv_histogram', 'entropy']
 
 # Add only the distribution names, not the *_gen names.
 __all__ += _continuous_distns._distn_names

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -61,6 +61,21 @@ def check_vonmises_cdf_periodic(k, L, s, x):
     assert_almost_equal(vm.cdf(x) % 1, vm.cdf(x % (2*numpy.pi*s)) % 1)
 
 
+def test_distributions_submodule():
+    actual = set(scipy.stats.distributions.__all__)
+    continuous = [dist[0] for dist in distcont]    # continuous dist names
+    discrete = [dist[0] for dist in distdiscrete]  # discrete dist names
+    other = ['rv_discrete', 'rv_continuous', 'rv_histogram',
+             'entropy', 'trapz']
+    expected = continuous + discrete + other
+
+    # need to remove, e.g.,
+    # <scipy.stats._continuous_distns.trapezoid_gen at 0x1df83bbc688>
+    expected = set(filter(lambda s: not str(s).startswith('<'), expected))
+
+    assert actual == expected
+
+
 def test_vonmises_pdf_periodic():
     for k in [0.1, 1, 101]:
         for x in [0, 1, numpy.pi, 10, 100]:


### PR DESCRIPTION
#### Reference issue
gh-13787

#### What does this implement/fix?
The `entropy` function was removed from `_distn_infrastructure.py`, so it could no longer be imported from `scipy.stats.distributions`. This makes `entropy` importable from `scipy.stats.distributions` and adds a test to ensure backwards compatibility.