### PR TITLE
substitute np.math.factorial with math.factorial

### DIFF
--- a/scipy/stats/_page_trend_test.py
+++ b/scipy/stats/_page_trend_test.py
@@ -1,5 +1,6 @@
 from itertools import permutations
 import numpy as np
+import math
 from ._continuous_distns import norm
 import scipy.stats
 from dataclasses import make_dataclass
@@ -435,7 +436,7 @@ class _PageL:
         # count occurences of each L value
         counts = np.histogram(Ls, np.arange(self.a-0.5, self.b+1.5))[0]
         # factorial(k) is number of possible permutations
-        return counts/np.math.factorial(self.k)
+        return counts/math.factorial(self.k)
 
     def pmf(self, l, n):
         '''Recursive function to evaluate p(l, k, n); see [5] Equation 1'''

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -34,6 +34,7 @@ import numpy as np
 from numpy import ndarray
 import numpy.ma as ma
 from numpy.ma import masked, nomask
+import math
 
 import itertools
 import warnings
@@ -544,9 +545,9 @@ def _kendall_p_exact(n, c):
     elif n == 2:
         prob = 1.0
     elif c == 0:
-        prob = 2.0/np.math.factorial(n) if n < 171 else 0.0
+        prob = 2.0/math.factorial(n) if n < 171 else 0.0
     elif c == 1:
-        prob = 2.0/np.math.factorial(n-1) if n < 172 else 0.0
+        prob = 2.0/math.factorial(n-1) if n < 172 else 0.0
     elif 4*c == n*(n-1):
         prob = 1.0
     elif n < 171:
@@ -556,7 +557,7 @@ def _kendall_p_exact(n, c):
             new = np.cumsum(new)
             if j <= c:
                 new[j:] -= new[:c+1-j]
-        prob = 2.0*np.sum(new)/np.math.factorial(n)
+        prob = 2.0*np.sum(new)/math.factorial(n)
     else:
         new = np.zeros(c+1)
         new[0:2] = 1.0


### PR DESCRIPTION
`np.math` is an alias of the stdlib `math` module that ends up in the numpy namespace by accident, @rgommers mentioned that we shouldn't be using it.  Here I removed the `np.` 