### PR TITLE
MAINT: SciPy 1.6.3 backports

### DIFF
--- a/doc/release/1.6.3-notes.rst
+++ b/doc/release/1.6.3-notes.rst
@@ -10,11 +10,22 @@ compared to 1.6.2.
 Authors
 =======
 
+* Peter Bell
+* Tyler Reddy
+* 刘星雨 +
+
+A total of 3 people contributed to this release.
+People with a "+" by their names contributed a patch for the first time.
+This list of names is automatically generated, and may not be fully complete.
 
 Issues closed for 1.6.3
 -----------------------
+
+* `#13772 <https://github.com/scipy/scipy/issues/13772>`__: Divide by zero in distance.yule
 
 
 Pull requests for 1.6.3
 -----------------------
 
+* `#13773 <https://github.com/scipy/scipy/pull/13773>`__: BUG: Divide by zero in yule dissimilarity of constant vectors
+* `#13819 <https://github.com/scipy/scipy/pull/13819>`__: substitute np.math.factorial with math.factorial

--- a/doc/release/1.6.3-notes.rst
+++ b/doc/release/1.6.3-notes.rst
@@ -11,10 +11,12 @@ Authors
 =======
 
 * Peter Bell
+* Tirth Patel
 * Tyler Reddy
-* 刘星雨 +
+* Pamphile ROY +
+* Xingyu Liu +
 
-A total of 3 people contributed to this release.
+A total of 5 people contributed to this release.
 People with a "+" by their names contributed a patch for the first time.
 This list of names is automatically generated, and may not be fully complete.
 
@@ -22,10 +24,12 @@ Issues closed for 1.6.3
 -----------------------
 
 * `#13772 <https://github.com/scipy/scipy/issues/13772>`__: Divide by zero in distance.yule
-
+* `#13796 <https://github.com/scipy/scipy/issues/13796>`__: CI: prerelease_deps failures
 
 Pull requests for 1.6.3
 -----------------------
 
+* `#13755 <https://github.com/scipy/scipy/pull/13755>`__: CI: fix the matplotlib warning emitted during builing docs
 * `#13773 <https://github.com/scipy/scipy/pull/13773>`__: BUG: Divide by zero in yule dissimilarity of constant vectors
+* `#13799 <https://github.com/scipy/scipy/pull/13799>`__: CI/MAINT: deprecated np.typeDict
 * `#13819 <https://github.com/scipy/scipy/pull/13819>`__: substitute np.math.factorial with math.factorial

--- a/doc/source/tutorial/special.rst
+++ b/doc/source/tutorial/special.rst
@@ -47,10 +47,8 @@ drum head anchored at the edge:
    >>> z = np.array([drumhead_height(1, 1, r, theta, 0.5) for r in radius])
 
    >>> import matplotlib.pyplot as plt
-   >>> from mpl_toolkits.mplot3d import Axes3D
-   >>> from matplotlib import cm
    >>> fig = plt.figure()
-   >>> ax = Axes3D(fig, rect=(0, 0.05, 0.95, 0.95))
+   >>> ax = fig.add_axes(rect=(0, 0.05, 0.95, 0.95), projection='3d')
    >>> ax.plot_surface(x, y, z, rstride=1, cstride=1, cmap='RdBu_r', vmin=-0.5, vmax=0.5)
    >>> ax.set_xlabel('X')
    >>> ax.set_ylabel('Y')

--- a/scipy/ndimage/_ni_support.py
+++ b/scipy/ndimage/_ni_support.py
@@ -86,7 +86,7 @@ def _get_output(output, input, shape=None, complex_output=False):
             output = numpy.promote_types(output, numpy.complex64)
         output = numpy.zeros(shape, dtype=output)
     elif isinstance(output, str):
-        output = numpy.typeDict[output]
+        output = numpy.sctypeDict[output]
         if complex_output and numpy.dtype(output).kind != 'c':
             raise RuntimeError("output must have complex dtype")
         output = numpy.zeros(shape, dtype=output)

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -1344,7 +1344,11 @@ def yule(u, v, w=None):
     if w is not None:
         w = _validate_weights(w)
     (nff, nft, ntf, ntt) = _nbool_correspond_all(u, v, w=w)
-    return float(2.0 * ntf * nft / np.array(ntt * nff + ntf * nft))
+    half_R = ntf * nft
+    if half_R == 0:
+        return 0.0
+    else:
+        return float(2.0 * half_R / (ntt * nff + half_R))
 
 
 @np.deprecate(message="spatial.distance.matching is deprecated in scipy 1.0.0; "

--- a/scipy/spatial/src/distance_impl.h
+++ b/scipy/spatial/src/distance_impl.h
@@ -222,7 +222,11 @@ yule_distance_char(const char *u, const char *v, const npy_intp n)
         nft += (!x) & y;
     }
     nff = n - ntt - ntf - nft;
-    return (2. * ntf * nft) / ((double)ntt * nff + (double)ntf * nft);
+    double half_R = (double)ntf * nft;
+    if (half_R == 0.0) {
+        return 0.0;
+    }
+    return (2. * half_R) / ((double)ntt * nff + half_R);
 }
 
 static NPY_INLINE double

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -2130,3 +2130,15 @@ def test__validate_vector():
 
     x = [[1, 2], [3, 4]]
     assert_raises(ValueError, _validate_vector, x)
+
+def test_yule_all_same():
+    # Test yule avoids a divide by zero when exactly equal
+    x = np.ones((2, 6), dtype=bool)
+    d = wyule(x[0], x[0])
+    assert d == 0.0
+
+    d = pdist(x, 'yule')
+    assert_equal(d, [0.0])
+
+    d = cdist(x[:1], x[:1], 'yule')
+    assert_equal(d, [[0.0]])

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -34,6 +34,7 @@ import numpy as np
 from numpy import ndarray
 import numpy.ma as ma
 from numpy.ma import masked, nomask
+import math
 
 import itertools
 import warnings
@@ -544,9 +545,9 @@ def _kendall_p_exact(n, c):
     elif n == 2:
         prob = 1.0
     elif c == 0:
-        prob = 2.0/np.math.factorial(n) if n < 171 else 0.0
+        prob = 2.0/math.factorial(n) if n < 171 else 0.0
     elif c == 1:
-        prob = 2.0/np.math.factorial(n-1) if n < 172 else 0.0
+        prob = 2.0/math.factorial(n-1) if n < 172 else 0.0
     elif 4*c == n*(n-1):
         prob = 1.0
     elif n < 171:
@@ -556,7 +557,7 @@ def _kendall_p_exact(n, c):
             new = np.cumsum(new)
             if j <= c:
                 new[j:] -= new[:c+1-j]
-        prob = 2.0*np.sum(new)/np.math.factorial(n)
+        prob = 2.0*np.sum(new)/math.factorial(n)
     else:
         new = np.zeros(c+1)
         new[0:2] = 1.0


### PR DESCRIPTION
A few more bug fixes have gone in recently, but at the moment only these have labels for backporting and are included here:

- gh-13773
- gh-13819 (the patch ignores changes touching code that was added after branching in gh-12531 ; that feature doesn't exist in the maintenance branch)
