### PR TITLE
FIX:DEP: Allow better tolerance control for pinv and pinvh and deprecate pinv2

### DIFF
--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -15,7 +15,7 @@ from pytest import raises as assert_raises
 from scipy.linalg import (solve, inv, det, lstsq, pinv, pinv2, pinvh, norm,
                           solve_banded, solveh_banded, solve_triangular,
                           solve_circulant, circulant, LinAlgError, block_diag,
-                          matrix_balance, LinAlgWarning)
+                          matrix_balance, qr, LinAlgWarning)
 
 from scipy.linalg._testutils import assert_no_overwrite
 from scipy._lib._testutils import check_free_memory
@@ -1213,7 +1213,10 @@ class TestLstsq:
             assert_equal(s, np.empty((0,)))
 
 
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 class TestPinv:
+    def setup_method(self):
+        np.random.seed(1234)
 
     def test_simple_real(self):
         a = array([[1, 2, 3], [4, 5, 6], [7, 8, 10]], dtype=float)
@@ -1262,15 +1265,39 @@ class TestPinv:
         a_pinv2 = pinv2(a)
         assert_array_almost_equal(a_pinv, a_pinv2)
 
-    def test_tall_transposed(self):
-        a = random([10, 2])
-        a_pinv = pinv(a)
-        # The result will be transposed internally hence will be a C-layout
-        # instead of the typical LAPACK output with Fortran-layout
-        assert a_pinv.flags['C_CONTIGUOUS']
+    def test_atol_rtol(self):
+        n = 12
+        # get a random ortho matrix for shuffling
+        q, _ = qr(np.random.rand(n, n))
+        a_m = np.arange(35.0).reshape(7,5)
+        a = a_m.copy()
+        a[0,0] = 0.001
+        atol = 1e-5
+        rtol = 0.05
+        # svds of a_m is ~ [116.906, 4.234, tiny, tiny, tiny]
+        # svds of a is ~ [116.906, 4.234, 4.62959e-04, tiny, tiny]
+        # Just abs cutoff such that we arrive at a_modified
+        a_p = pinv(a_m, atol=atol, rtol=0.)
+        adiff1 = a @ a_p @ a - a
+        adiff2 = a_m @ a_p @ a_m - a_m
+        # Now adiff1 should be around atol value while adiff2 should be
+        # relatively tiny
+        assert_allclose(np.linalg.norm(adiff1), 5e-4, atol=5.e-4)
+        assert_allclose(np.linalg.norm(adiff2), 5e-14, atol=5.e-14)
+
+        # Now do the same but remove another sv ~4.234 via rtol
+        a_p = pinv(a_m, atol=atol, rtol=rtol)
+        adiff1 = a @ a_p @ a - a
+        adiff2 = a_m @ a_p @ a_m - a_m
+        assert_allclose(np.linalg.norm(adiff1), 4.233, rtol=0.01)
+        assert_allclose(np.linalg.norm(adiff2), 4.233, rtol=0.01)
 
 
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 class TestPinvSymmetric:
+
+    def setup_method(self):
+        np.random.seed(1234)
 
     def test_simple_real(self):
         a = array([[1, 2, 3], [4, 5, 6], [7, 8, 10]], dtype=float)
@@ -1302,20 +1329,35 @@ class TestPinvSymmetric:
         a_pinv = pinvh(a.tolist())
         assert_array_almost_equal(np.dot(a, a_pinv), np.eye(3))
 
+    def test_atol_rtol(self):
+        n = 12
+        # get a random ortho matrix for shuffling
+        q, _ = qr(np.random.rand(n, n))
+        a = np.diag([4, 3, 2, 1, 0.99e-4, 0.99e-5] + [0.99e-6]*(n-6))
+        a = q.T @ a @ q
+        a_m = np.diag([4, 3, 2, 1, 0.99e-4, 0.] + [0.]*(n-6))
+        a_m = q.T @ a_m @ q
+        atol = 1e-5
+        rtol = (4.01e-4 - 4e-5)/4
+        # Just abs cutoff such that we arrive at a_modified
+        a_p = pinvh(a, atol=atol, rtol=0.)
+        adiff1 = a @ a_p @ a - a
+        adiff2 = a_m @ a_p @ a_m - a_m
+        # Now adiff1 should dance around atol value since truncation
+        # while adiff2 should be relatively tiny
+        assert_allclose(norm(adiff1), atol, rtol=0.1)
+        assert_allclose(norm(adiff2), 1e-12, atol=1e-11)
 
-def test_pinv_pinv2_comparison():  # As reported in gh-8861
-    I_6 = np.eye(6)
-    Ts = np.diag([-1] * 4 + [-2], k=-1) + np.diag([-2] + [-1] * 4, k=1)
-    T = I_6 + Ts
-    A = 25 * (np.kron(I_6, T) + np.kron(Ts, I_6))
-
-    Ap, Ap2 = pinv(A), pinv2(A)
-
-    tol = 1e-11
-    assert_allclose(A @ Ap @ A - A, A @ Ap2 @ A - A, rtol=0., atol=tol)
-    assert_allclose(Ap @ A @ Ap - Ap, Ap2 @ A @ Ap2 - Ap2, rtol=0., atol=tol)
+        # Now do the same but through rtol cancelling atol value
+        a_p = pinvh(a, atol=atol, rtol=rtol)
+        adiff1 = a @ a_p @ a - a
+        adiff2 = a_m @ a_p @ a_m - a_m
+        # adiff1 and adiff2 should be elevated to ~1e-4 due to mismatch
+        assert_allclose(norm(adiff1), 1e-4, rtol=0.1)
+        assert_allclose(norm(adiff2), 1e-4, rtol=0.1)
 
 
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 @pytest.mark.parametrize('scale', (1e-20, 1., 1e20))
 @pytest.mark.parametrize('pinv_', (pinv, pinvh, pinv2))
 def test_auto_rcond(scale, pinv_):
@@ -1458,6 +1500,7 @@ class TestOverwrite:
     def test_pinv(self):
         assert_no_overwrite(pinv, [(3, 3)])
 
+    @pytest.mark.filterwarnings('ignore::DeprecationWarning')
     def test_pinv2(self):
         assert_no_overwrite(pinv2, [(3, 3)])
 


### PR DESCRIPTION

#### Reference issue
Closes #13704 
Xref: https://github.com/scikit-learn/scikit-learn/pull/19646

/cc @ogrisel 

#### What does this implement/fix?
Historically, pinv2 and pinv were using different solution methods however for a very long time already both use the same SVD based solvers. Hence duplicate code for no apparent reason in the namespace. Relevant mailing list discussion start is here : 
https://mail.python.org/pipermail/scipy-dev/2021-March/024627.html

Moreover, even more importantly, cond and rcond parameters of all pinv? functions were broken and were causing already problems elsewhere see above for scikit-learn issue.

Hopefully this PR will fix these. 