### PR TITLE
MAINT: Fix a couple compiler warnings.

### DIFF
--- a/scipy/integrate/tests/_test_multivariate.c
+++ b/scipy/integrate/tests/_test_multivariate.c
@@ -67,7 +67,7 @@ static const routine_t routines[] = {
 static int create_pointers(PyObject *module)
 {
     PyObject *d, *obj = NULL;
-    int i;
+    size_t i;
 
     d = PyModule_GetDict(module);
     if (d == NULL) {

--- a/scipy/spatial/ckdtree/src/query_ball_tree.cxx
+++ b/scipy/spatial/ckdtree/src/query_ball_tree.cxx
@@ -209,7 +209,7 @@ query_ball_tree(const ckdtree *self, const ckdtree *other,
         {}
     }
 
-    for (size_t i = 0; i < self->n; ++i) {
+    for (ckdtree_intp_t i = 0; i < self->n; ++i) {
         std::sort(results[i].begin(), results[i].end());
     }
 


### PR DESCRIPTION
Fix these warnings:

```
gcc: scipy/integrate/tests/_test_multivariate.c
scipy/integrate/tests/_test_multivariate.c: In function ‘create_pointers’:
scipy/integrate/tests/_test_multivariate.c:77:19: warning: comparison of integer
 expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
   77 |     for (i = 0; i < sizeof(routines) / sizeof(routine_t); ++i) {
      |                   ^

scipy/spatial/ckdtree/src/query_ball_tree.cxx: In function ‘int query_ball_tree(const
 ckdtree*, const ckdtree*, double, double, double, std::vector<long int>*)’:
scipy/spatial/ckdtree/src/query_ball_tree.cxx:212:26: warning: comparison of integer
 expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘const
 npy_intp’ {aka ‘const long int’} [-Wsign-compare]
  212 |     for (size_t i = 0; i < self->n; ++i) {
      |                        ~~^~~~~~~~~
```