### PR TITLE
CI: increase timeout for doc build CI job to 30 minutes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
 
       - run:
           name: build docs
-          no_output_timeout: 20m
+          no_output_timeout: 30m
           command: |
             . venv/bin/activate
             export SHELL=$(which bash)


### PR DESCRIPTION
Doc build takes around 20 minutes, and quite a few PRs have been timing out recently.

xref gh-13807