### PR TITLE
TST: relax test tolerances for BinomTest

### DIFF
--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -696,48 +696,51 @@ class TestBinomTest:
         # These tests work on all OS's but fail on
         # Linux_Python_37_32bit_full due to numerical issues caused
         # by large inputs.
+        rtol = 5e-13  # aarch64 observed rtol: 3.5e-13
         res = stats.binomtest(10079999, 21000000, 0.48)
-        assert_allclose(res.pvalue, 0.979042561004596, rtol=1e-15)
+        assert_allclose(res.pvalue, 0.979042561004596, rtol=rtol)
         res = stats.binomtest(10079990, 21000000, 0.48)
-        assert_allclose(res.pvalue, 0.9785298857599378, rtol=1e-15)
+        assert_allclose(res.pvalue, 0.9785298857599378, rtol=rtol)
         res = stats.binomtest(10080009, 21000000, 0.48)
-        assert_allclose(res.pvalue, 0.9786038762958954, rtol=1e-15)
+        assert_allclose(res.pvalue, 0.9786038762958954, rtol=rtol)
         res = stats.binomtest(10080017, 21000000, 0.48)
-        assert_allclose(res.pvalue, 0.9778567637538729, rtol=1e-15)
+        assert_allclose(res.pvalue, 0.9778567637538729, rtol=rtol)
 
     @pytest.mark.xfail_on_32bit("The large inputs make these tests "
                                 "sensitive to machine epsilon level")
     def test_two_sided_pvalues2(self):
+        rtol = 1e-14  # no aarch64 failure with 1e-15, preemptive bump
         res = stats.binomtest(9, n=21, p=0.48)
-        assert_allclose(res.pvalue, 0.6689672431938848, rtol=1e-15)
+        assert_allclose(res.pvalue, 0.6689672431938848, rtol=rtol)
         res = stats.binomtest(4, 21, 0.48)
-        assert_allclose(res.pvalue, 0.008139563452105921, rtol=1e-15)
+        assert_allclose(res.pvalue, 0.008139563452105921, rtol=rtol)
         res = stats.binomtest(11, 21, 0.48)
-        assert_allclose(res.pvalue, 0.8278629664608201, rtol=1e-15)
+        assert_allclose(res.pvalue, 0.8278629664608201, rtol=rtol)
         res = stats.binomtest(7, 21, 0.48)
-        assert_allclose(res.pvalue, 0.19667729017182273, rtol=1e-15)
+        assert_allclose(res.pvalue, 0.19667729017182273, rtol=rtol)
         res = stats.binomtest(3, 10, .5)
-        assert_allclose(res.pvalue, 0.3437499999999999, rtol=1e-15)
+        assert_allclose(res.pvalue, 0.3437499999999999, rtol=rtol)
         res = stats.binomtest(2, 2, .4)
-        assert_allclose(res.pvalue, 0.16000000000000003, rtol=1e-15)
+        assert_allclose(res.pvalue, 0.16000000000000003, rtol=rtol)
         res = stats.binomtest(2, 4, .3)
-        assert_allclose(res.pvalue, 0.5883999999999999, rtol=1e-15)
+        assert_allclose(res.pvalue, 0.5883999999999999, rtol=rtol)
 
     @pytest.mark.xfail_on_32bit("The large inputs make these tests "
                                 "sensitive to machine epsilon level")
     def test_edge_cases(self):
+        rtol = 1e-14  # aarch64 observed rtol: 1.33e-15
         res = stats.binomtest(484, 967, 0.5)
-        assert_allclose(res.pvalue, 0.999999999998212, rtol=1e-15)
+        assert_allclose(res.pvalue, 0.999999999998212, rtol=rtol)
         res = stats.binomtest(3, 47, 3/47)
-        assert_allclose(res.pvalue, 0.9999999999999998, rtol=1e-15)
+        assert_allclose(res.pvalue, 0.9999999999999998, rtol=rtol)
         res = stats.binomtest(13, 46, 13/46)
-        assert_allclose(res.pvalue, 0.9999999999999987, rtol=1e-15)
+        assert_allclose(res.pvalue, 0.9999999999999987, rtol=rtol)
         res = stats.binomtest(15, 44, 15/44)
-        assert_allclose(res.pvalue, 0.9999999999999989, rtol=1e-15)
+        assert_allclose(res.pvalue, 0.9999999999999989, rtol=rtol)
         res = stats.binomtest(7, 13, 0.5)
-        assert_allclose(res.pvalue, 0.9999999999999999, rtol=1e-15)
+        assert_allclose(res.pvalue, 0.9999999999999999, rtol=rtol)
         res = stats.binomtest(6, 11, 0.5)
-        assert_allclose(res.pvalue, 0.9999999999999997, rtol=1e-15)
+        assert_allclose(res.pvalue, 0.9999999999999997, rtol=rtol)
 
     def test_binary_srch_for_binom_tst(self):
         # Test that old behavior of binomtest is maintained


### PR DESCRIPTION
These rtol values were unnecessarily tight and caused these failures
on aarch64 on the scipy-wheels CI:

```
____________________ TestBinomTest.test_two_sided_pvalues1 _____________________
[gw2] linux -- Python 3.9.2 /venv/bin/python
/venv/lib/python3.9/site-packages/scipy/stats/tests/test_morestats.py:700: in test_two_sided_pvalues1
    assert_allclose(res.pvalue, 0.979042561004596, rtol=1e-15)
E   AssertionError:
E   Not equal to tolerance rtol=1e-15, atol=0
E
E   Mismatched elements: 1 / 1 (100%)
E   Max absolute difference: 3.5005332e-13
E   Max relative difference: 3.5754658e-13
E    x: array(0.979043)
E    y: array(0.979043)

        res        = BinomTestResult(k=10079999, n=21000000, alternative='two-sided', proportion_estimate=0.4799999523809524, pvalue=0.9790425610042459)
        self       = <scipy.stats.tests.test_morestats.TestBinomTest object at 0xffff6e2bf100>

________________________ TestBinomTest.test_edge_cases _________________________
[gw2] linux -- Python 3.9.2 /venv/bin/python
/venv/lib/python3.9/site-packages/scipy/stats/tests/test_morestats.py:730: in test_edge_cases
    assert_allclose(res.pvalue, 0.999999999998212, rtol=1e-15)
E   AssertionError:
E   Not equal to tolerance rtol=1e-15, atol=0
E
E   Mismatched elements: 1 / 1 (100%)
E   Max absolute difference: 1.33226763e-15
E   Max relative difference: 1.33226763e-15
E    x: array(1.)
E    y: array(1.)

        res        = BinomTestResult(k=484, n=967, alternative='two-sided', proportion_estimate=0.500517063081696, pvalue=0.9999999999982133)
        self       = <scipy.stats.tests.test_morestats.TestBinomTest object at 0xffff6e2ce5e0>
```

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->