### PR TITLE
BLD: add `-std=c99` flag to scipy.special extensions using cosine.c

### DIFF
--- a/scipy/special/_cosine.c
+++ b/scipy/special/_cosine.c
@@ -19,6 +19,9 @@
 
 #include "cephes/polevl.h"
 
+#if !defined(M_PI)
+#define M_PI 3.1415926535897932384626433832795028841971
+#endif
 
 //
 // p and q (below) are the coefficients in the numerator and denominator

--- a/scipy/special/_cosine.c
+++ b/scipy/special/_cosine.c
@@ -20,7 +20,7 @@
 #include "cephes/polevl.h"
 
 #if !defined(M_PI)
-#define M_PI 3.1415926535897932384626433832795028841971
+#define M_PI 0x1.921fb54442d18p+1
 #endif
 
 //

--- a/scipy/special/setup.py
+++ b/scipy/special/setup.py
@@ -4,13 +4,9 @@ from os.path import join, dirname
 from distutils.sysconfig import get_python_inc
 import subprocess
 import numpy
-from numpy.distutils.misc_util import get_numpy_include_dirs
+from numpy.distutils.misc_util import get_numpy_include_dirs, get_info
 
-try:
-    from numpy.distutils.misc_util import get_info
-except ImportError as e:
-    raise ValueError("numpy >= 1.4 is required (detected %s from %s)" %
-                     (numpy.__version__, numpy.__file__)) from e
+from scipy._build_utils.compiler_helper import set_c_flags_hook
 
 
 def configuration(parent_package='',top_path=None):
@@ -87,11 +83,12 @@ def configuration(parent_package='',top_path=None):
                        libraries=['sc_amos', 'sc_cephes', 'sc_mach',
                                   'sc_cdf', 'sc_specfun'],
                        define_macros=define_macros)
-    config.add_extension('_ufuncs',
-                         depends=ufuncs_dep,
-                         sources=ufuncs_src,
-                         extra_info=get_info("npymath"),
-                         **cfg)
+    _ufuncs = config.add_extension('_ufuncs',
+                                   depends=ufuncs_dep,
+                                   sources=ufuncs_src,
+                                   extra_info=get_info("npymath"),
+                                   **cfg)
+    _ufuncs._pre_build_hook = set_c_flags_hook
 
     # Extension _ufuncs_cxx
     ufuncs_cxx_src = ['_ufuncs_cxx.cxx', 'sf_error.c',
@@ -132,11 +129,12 @@ def configuration(parent_package='',top_path=None):
                        libraries=['sc_amos', 'sc_cephes', 'sc_mach',
                                   'sc_cdf', 'sc_specfun'],
                        define_macros=define_macros)
-    config.add_extension('cython_special',
-                         depends=cython_special_dep,
-                         sources=cython_special_src,
-                         extra_info=get_info("npymath"),
-                         **cfg)
+    cython_special = config.add_extension('cython_special',
+                                          depends=cython_special_dep,
+                                          sources=cython_special_src,
+                                          extra_info=get_info("npymath"),
+                                          **cfg)
+    cython_special._pre_build_hook = set_c_flags_hook
 
     # combinatorics
     config.add_extension('_comb',


### PR DESCRIPTION
This fixes the manylinux1 builds. Closes gh-13840

Also clean up an outdated try-catch.