### PR TITLE
DOC: remove kendall's tau-c from roadmap (done)

### DIFF
--- a/doc/source/dev/roadmap-detailed.rst
+++ b/doc/source/dev/roadmap-detailed.rst
@@ -403,7 +403,6 @@ The following improvements will help SciPy better serve this role.
 
   - Alexander-Govern test
   - Somers' D
-  - Kendall's tau-c
   - Page's L-test
   - Tukey-Kramer test
   - Dunnett's test


### PR DESCRIPTION
Kendall's tau-c was added in https://github.com/scipy/scipy/pull/9361

Also, that PR title should probably be renamed:

```diff
-ENH: Add Kendall's tau-a and tau-c variants to scipy.stats.kendalltau()
+ENH: Add Kendall's tau-c variant to scipy.stats.kendalltau()
```

because Kendall's tau-a was (unfortunately) removed prior to merging: https://github.com/scipy/scipy/pull/9361#issuecomment-673864938
