### PR TITLE
MAINT: special: Remove an unused variable from _poly_approx in _cosine.c

### DIFF
--- a/scipy/special/_cosine.c
+++ b/scipy/special/_cosine.c
@@ -207,7 +207,6 @@ double _poly_approx(double s)
 {
     double s2;
     double p;
-    double px;
     double coeffs[] = {1.1911667949082915e-08,
                        1.683039183039183e-07,
                        43.0/17248000,


### PR DESCRIPTION
Fixes this warning:

```
scipy/special/_cosine.c: In function ‘_poly_approx’:
scipy/special/_cosine.c:210:12: warning: unused variable ‘px’ [-Wunused-variable]
  210 |     double px;
      |            ^~
```