### PR TITLE
CI: fix the failing job on linux.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -33,7 +33,8 @@ jobs:
       - name: Installing packages
         run: |      
           python3.7-dbg -c 'import sys; print("Python debug build:", hasattr(sys, "gettotalrefcount"))'
-          python3.7-dbg -m pip install --upgrade pip setuptools wheel cython pytest pytest-xdist argparse pybind11
+          python3.7-dbg -m pip install --upgrade pip setuptools wheel
+          python3.7-dbg -m pip install --upgrade cython pytest pytest-xdist argparse pybind11
           python3.7-dbg -m pip install --upgrade mpmath gmpy2 pythran
           python3.7-dbg -m pip install --upgrade --no-cache-dir numpy
           python3.7-dbg -m pip uninstall -y nose

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,7 +34,7 @@ jobs:
         run: |      
           python3.7-dbg -c 'import sys; print("Python debug build:", hasattr(sys, "gettotalrefcount"))'
           python3.7-dbg -m pip install --upgrade pip setuptools wheel
-          python3.7-dbg -m pip install --upgrade cython pytest pytest-xdist argparse pybind11
+          python3.7-dbg -m pip install --upgrade cython pytest pytest-xdist pybind11
           python3.7-dbg -m pip install --upgrade mpmath gmpy2 pythran
           python3.7-dbg -m pip install --upgrade --no-cache-dir numpy
           python3.7-dbg -m pip uninstall -y nose


### PR DESCRIPTION
#### Reference issue

N/A

#### What does this implement/fix?

I think the job on Linux failed as `cython` was not able to find the `setuptools` package. So, I changed the script to first upgrade `setuptools` and then upgrade `cython` and other packages. Works on my master: https://github.com/tirthasheshpatel/scipy/runs/2350445370

#### Additional information

N/A