### PR TITLE
MAINT: move LSAP rectangular matrix handling into solver code

### DIFF
--- a/benchmarks/benchmarks/optimize_lap.py
+++ b/benchmarks/benchmarks/optimize_lap.py
@@ -31,11 +31,12 @@ def random_spatial(shape):
 class LinearAssignment(Benchmark):
 
     sizes = range(100, 401, 100)
-    param_names = ['shapes', 'cost_type']
-    params = [
-        [(i, i) for i in sizes] + [(i, 2 * i) for i in sizes],
-        ['uniform', 'spatial', 'logarithmic', 'integer', 'binary']
-    ]
+    shapes = [(i, i) for i in sizes]
+    shapes.extend([(i, 2 * i) for i in sizes])
+    shapes.extend([(2 * i, i) for i in sizes])
+    cost_types = ['uniform', 'spatial', 'logarithmic', 'integer', 'binary']
+    param_names = ['shape', 'cost_type']
+    params = [shapes, cost_types]
 
     def setup(self, shape, cost_type):
 

--- a/scipy/optimize/_lsap.py
+++ b/scipy/optimize/_lsap.py
@@ -97,12 +97,4 @@ def linear_sum_assignment(cost_matrix, maximize=False):
     if maximize:
         cost_matrix = -cost_matrix
 
-    cost_matrix = cost_matrix.astype(np.double)
-
-    # The algorithm expects more columns than rows in the cost matrix.
-    if cost_matrix.shape[1] < cost_matrix.shape[0]:
-        a, b = _lsap_module.calculate_assignment(cost_matrix.T)
-        indices = np.argsort(b)
-        return (b[indices], a[indices])
-    else:
-        return _lsap_module.calculate_assignment(cost_matrix)
+    return _lsap_module.calculate_assignment(cost_matrix.astype(np.double))

--- a/scipy/optimize/_lsap.py
+++ b/scipy/optimize/_lsap.py
@@ -97,4 +97,4 @@ def linear_sum_assignment(cost_matrix, maximize=False):
     if maximize:
         cost_matrix = -cost_matrix
 
-    return _lsap_module.calculate_assignment(cost_matrix.astype(np.double))
+    return _lsap_module.calculate_assignment(cost_matrix)

--- a/scipy/optimize/_lsap_module.c
+++ b/scipy/optimize/_lsap_module.c
@@ -28,7 +28,6 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <math.h>
 #include "numpy/arrayobject.h"
 #include "numpy/ndarraytypes.h"
 #include "rectangular_lsap/rectangular_lsap.h"
@@ -58,7 +57,7 @@ calculate_assignment(PyObject* self, PyObject* args)
 
     npy_intp num_rows = PyArray_DIM(obj_cont, 0);
     npy_intp num_cols = PyArray_DIM(obj_cont, 1);
-    npy_intp dim[1] = { num_rows };
+    npy_intp dim[1] = { num_rows < num_cols ? num_rows : num_cols };
     a = PyArray_SimpleNew(1, dim, NPY_INT64);
     if (!a)
         goto cleanup;
@@ -67,12 +66,10 @@ calculate_assignment(PyObject* self, PyObject* args)
     if (!b)
         goto cleanup;
 
-    int64_t* adata = PyArray_DATA((PyArrayObject*)a);
-    for (npy_intp i = 0; i < num_rows; i++)
-        adata[i] = i;
-
     int ret = solve_rectangular_linear_sum_assignment(
-      num_rows, num_cols, cost_matrix, PyArray_DATA((PyArrayObject*)b));
+      num_rows, num_cols, cost_matrix,
+      PyArray_DATA((PyArrayObject*)a),
+      PyArray_DATA((PyArrayObject*)b));
     if (ret == RECTANGULAR_LSAP_INFEASIBLE) {
         PyErr_SetString(PyExc_ValueError, "cost matrix is infeasible");
         goto cleanup;

--- a/scipy/optimize/rectangular_lsap/rectangular_lsap.cpp
+++ b/scipy/optimize/rectangular_lsap/rectangular_lsap.cpp
@@ -50,7 +50,7 @@ Author: PM Larsen
 template <typename T> std::vector<intptr_t> argsort_iter(const std::vector<T> &v)
 {
     std::vector<intptr_t> index(v.size());
-    iota(index.begin(), index.end(), 0);
+    std::iota(index.begin(), index.end(), 0);
     std::sort(index.begin(), index.end(), [&v](intptr_t i, intptr_t j)
               {return v[i] < v[j];});
     return index;

--- a/scipy/optimize/rectangular_lsap/rectangular_lsap.cpp
+++ b/scipy/optimize/rectangular_lsap/rectangular_lsap.cpp
@@ -40,10 +40,21 @@ pseudocode described in pages 1685-1686 of:
 Author: PM Larsen
 */
 
-#include <algorithm>
 #include <cmath>
-#include "rectangular_lsap.h"
 #include <vector>
+#include <numeric>
+#include <algorithm>
+#include "rectangular_lsap.h"
+
+
+template <typename T> std::vector<intptr_t> argsort_iter(const std::vector<T> &v)
+{
+    std::vector<intptr_t> index(v.size());
+    iota(index.begin(), index.end(), 0);
+    std::sort(index.begin(), index.end(), [&v](intptr_t i, intptr_t j)
+              {return v[i] < v[j];});
+    return index;
+}
 
 static intptr_t
 augmenting_path(intptr_t nc, std::vector<double>& cost, std::vector<double>& u,
@@ -117,13 +128,31 @@ augmenting_path(intptr_t nc, std::vector<double>& cost, std::vector<double>& u,
 }
 
 static int
-solve(intptr_t nr, intptr_t nc, double* input_cost, int64_t* output_col4row)
+solve(intptr_t nr, intptr_t nc, double* input_cost, int64_t* a, int64_t* b)
 {
+    // handle trivial inputs
+    if (nr == 0 || nc == 0) {
+        return 0;
+    }
+
+    std::vector<double> cost(input_cost, input_cost + nr * nc);
+
+    // tall rectangular cost matrix must be transposed
+    bool transpose = nc < nr;
+    if (transpose) {
+        for (intptr_t i = 0; i < nr; i++) {
+            for (intptr_t j = 0; j < nc; j++) {
+                cost[j * nr + i] = input_cost[i * nc + j];
+            }
+        }
+
+        std::swap(nr, nc);
+    }
+
     // build a non-negative cost matrix
-    std::vector<double> cost(nr * nc);
-    double minval = *std::min_element(input_cost, input_cost + nr * nc);
+    double minval = *std::min_element(cost.begin(), cost.end());
     for (intptr_t i = 0; i < nr * nc; i++) {
-        auto v = input_cost[i] - minval;
+        auto v = cost[i] - minval;
         cost[i] = v;
 
         // test for NaN and -inf entries
@@ -178,8 +207,19 @@ solve(intptr_t nr, intptr_t nc, double* input_cost, int64_t* output_col4row)
         }
     }
 
-    for (intptr_t i = 0; i < nr; i++) {
-        output_col4row[i] = col4row[i];
+    if (transpose) {
+        intptr_t i = 0;
+        for (auto v: argsort_iter(col4row)) {
+            a[i] = col4row[v];
+            b[i] = v;
+            i++;
+        }
+    }
+    else {
+        for (intptr_t i = 0; i < nr; i++) {
+            a[i] = i;
+            b[i] = col4row[i];
+        }
     }
 
     return 0;
@@ -191,9 +231,9 @@ extern "C" {
 
 int
 solve_rectangular_linear_sum_assignment(intptr_t nr, intptr_t nc, double* input_cost,
-                                        int64_t* col4row)
+                                        int64_t* a, int64_t* b)
 {
-    return solve(nr, nc, input_cost, col4row);
+    return solve(nr, nc, input_cost, a, b);
 }
 
 #ifdef __cplusplus

--- a/scipy/optimize/rectangular_lsap/rectangular_lsap.h
+++ b/scipy/optimize/rectangular_lsap/rectangular_lsap.h
@@ -41,7 +41,7 @@ extern "C" {
 #include <stdint.h>
 
 int solve_rectangular_linear_sum_assignment(intptr_t nr, intptr_t nc, double* input_cost,
-                                            int64_t* col4row);
+                                            int64_t* a, int64_t* b);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### What does this implement/fix?
<!--Please explain your changes.-->
The code for handling tall rectangular cost matrices is split up over `_lsap.py`, `_lsap_module.c`, and the solver code. Here I have moved it all into the solver code.

#### Additional information
I'm doing some maintenance on this module. I am keeping each PR small to make reviewing easier. 


@peterbell10 would you like to take a look again?