### PR TITLE
Faster restarted GMRES

### DIFF
--- a/scipy/sparse/linalg/isolve/iterative.py
+++ b/scipy/sparse/linalg/isolve/iterative.py
@@ -916,9 +916,9 @@ def _gmres_mgs(A, b, x0=None, restart=None, tol=1e-5, maxiter=None, M=None,
     maxOuterIter = maxiter
     if x0 is None:
         x0 = x.copy()
-    if restrt is None:
-        restrt = 20
-    m = min(restrt, ndofs)
+    if restart is None:
+        restart = 20
+    m = min(restart, ndofs)
 
     # Define orthonormal basis
     V = np.zeros((m+1, ndofs), dtype=dtype)

--- a/scipy/sparse/linalg/isolve/iterative.py
+++ b/scipy/sparse/linalg/isolve/iterative.py
@@ -839,7 +839,7 @@ def _gmres_mgs(A, b, x0=None, restart=None, tol=1e-5, maxiter=None, M=None,
         The real or complex N-by-N matrix of the linear system.
         Alternatively, `A` can be a linear operator which can
         produce ``Ax`` using, e.g.,
-        ``scipy.sparse.linalg.LinearOperator``.
+        `scipy.sparse.linalg.LinearOperator`.
     b : {array, matrix}
         Right hand side of the linear system. Has shape (N,) or (N,1).
 

--- a/scipy/sparse/linalg/isolve/iterative.py
+++ b/scipy/sparse/linalg/isolve/iterative.py
@@ -882,7 +882,7 @@ def _gmres_mgs(A, b, x0=None, restart=None, tol=1e-5, maxiter=None, M=None,
 
     Notes
     -----
-    A preconditioner, P, is chosen such that P is close to A but easy to solve
+    A preconditioner ``P`` is chosen such that ``P`` is close to `A` but easy to solve
     for. The preconditioner parameter required by this routine is
     ``M = P^-1``. The inverse should preferably not be calculated
     explicitly.  Rather, use the following template to produce M::

--- a/scipy/sparse/linalg/isolve/iterative.py
+++ b/scipy/sparse/linalg/isolve/iterative.py
@@ -854,15 +854,15 @@ def _gmres_mgs(A, b, x0=None, restart=None, tol=1e-5, maxiter=None, M=None, call
 
     Other parameters
     ----------------
-    x0: {array, matrix}
+    x0 : {array, matrix}
         Starting guess for the solution (a vector of zeros by default).
-    restart: int, optional
+    restart : int, optional
         Number of iterations between restarts. Larger values increase
         iteration cost, but may be necessary for convergence.
         Default is 30.
-    tol: float, optional
+    tol : float, optional
         Tolerances for convergence, ``norm(residual) <= tol*norm(b)``.
-    maxiter: int, optional
+    maxiter : int, optional
         Maximum number of iterations (restart cycles).  Iteration will stop
         after maxiter steps even if the specified tolerance has not been
         achieved.

--- a/scipy/sparse/linalg/isolve/iterative.py
+++ b/scipy/sparse/linalg/isolve/iterative.py
@@ -430,7 +430,7 @@ def cgs(A, b, x0=None, tol=1e-5, maxiter=None, M=None, callback=None, atol=None)
 
 @non_reentrant()
 def gmres(A, b, x0=None, tol=1e-5, restart=None, maxiter=None, M=None, callback=None,
-          restrt=None, atol=None, callback_type=None, orth=None):
+          restrt=None, atol=None, callback_type=None, *, orth=None):
     """
     Use Generalized Minimal RESidual iteration to solve ``Ax = b``.
 

--- a/scipy/sparse/linalg/isolve/iterative.py
+++ b/scipy/sparse/linalg/isolve/iterative.py
@@ -533,8 +533,7 @@ def gmres(A, b, x0=None, tol=1e-5, restart=None, maxiter=None, M=None, callback=
                                  callback=callback, restrt=restrt)
             return x, info
         else:
-            warnings.warn("The option 'atol' was deprecated with 'orth == \'mgs\''",
-                          category=DeprecationWarning)
+            raise ValueError("The option 'atol' is not used in the case of 'orth == \'mgs\''")
 
     # Change 'restrt' keyword to 'restart'
     if restrt is None:

--- a/scipy/sparse/linalg/isolve/iterative.py
+++ b/scipy/sparse/linalg/isolve/iterative.py
@@ -949,6 +949,7 @@ def _gmres_mgs(A, b, x0=None, restart=None, tol=1e-5, maxiter=None, M=None, call
 
         # Inner iterations
         for k in range(m):
+            # Modified Gram-Schmidt orthogonalization
             v = A.matvec(V[k])
             w = M.matvec(v)
             Hn[0:k+1, k] = V[0:k+1].conjugate().dot(w)
@@ -973,13 +974,10 @@ def _gmres_mgs(A, b, x0=None, restart=None, tol=1e-5, maxiter=None, M=None, call
             for i in range(k):
                 tmp0 = rot[0, i] * Hn[i, k] + rot[1, i] * Hn[i+1, k]
                 tmp1 = -rot[1, i] * Hn[i, k] + rot[0, i] * Hn[i+1, k]
-                Hn[i, k] = tmp0
-                Hn[i+1, k] = tmp1
+                Hn[i, k], Hn[i+1, k] = tmp0, tmp1
             sq = np.sqrt(Hn[k+1, k]**2 + Hn[k, k]**2)
-            rot[0, k] = Hn[k, k] / sq
-            rot[1, k] = Hn[k+1, k] / sq
-            Hn[k, k] = sq
-            Hn[k+1, k] = 0.
+            rot[0:2, k] = Hn[k:k+2, k] / sq
+            Hn[k, k], Hn[k+1, k] = sq, 0.
             g[k+1] = -rot[1, k] * g[k]
             g[k] *= rot[0, k]
 

--- a/scipy/sparse/linalg/isolve/iterative.py
+++ b/scipy/sparse/linalg/isolve/iterative.py
@@ -875,8 +875,6 @@ def _gmres_mgs(A, b, x0=None, restart=None, tol=1e-5, maxiter=None, M=None,
         error tolerance.  By default, no preconditioner is used.
     callback : function
         User-supplied function to call after each iteration.
-    restrt : int, optional
-        DEPRECATED - use `restart` instead.
 
     See Also
     --------

--- a/scipy/sparse/linalg/isolve/iterative.py
+++ b/scipy/sparse/linalg/isolve/iterative.py
@@ -827,9 +827,11 @@ def qmr(A, b, x0=None, tol=1e-5, maxiter=None, M1=None, M2=None, callback=None,
     return postprocess(x), info
 
 
-def _gmres_mgs(A, b, x0=None, restart=None, tol=1e-5, maxiter=None, M=None, callback=None, restrt=None):
+def _gmres_mgs(A, b, x0=None, restart=None, tol=1e-5, maxiter=None, M=None,
+               callback=None, restrt=None):
     """
-    Use Restarted Generalized Minimal RESidual based on modified Gram-Schmidt iteration to solve ``Ax = b``.
+    Use Restarted Generalized Minimal RESidual based on modified Gram-Schmidt
+    iteration to solve ``Ax = b``.
 
     Parameters
     ----------

--- a/scipy/sparse/linalg/isolve/iterative.py
+++ b/scipy/sparse/linalg/isolve/iterative.py
@@ -528,12 +528,10 @@ def gmres(A, b, x0=None, tol=1e-5, restart=None, maxiter=None, M=None, callback=
 
     # Faster restarted GMRES based on modified Gram-Schmidt orthogonalization
     if orth == 'mgs':
-        if atol is None:
-            x, info = _gmres_mgs(A, b, x0=x0, restart=restart, tol=tol, maxiter=maxiter, M=M, 
-                                 callback=callback, restrt=restrt)
-            return x, info
-        else:
-            raise ValueError("The option 'atol' is not used in the case of 'orth == \'mgs\''")
+        x, info = _gmres_mgs(A, b, x0=x0, restart=restart, tol=tol, maxiter=maxiter, M=M,
+                             callback=callback, restrt=restrt, atol=atol,
+                             callback_type=callback_type)
+        return x, info
 
     # Change 'restrt' keyword to 'restart'
     if restrt is None:
@@ -828,14 +826,14 @@ def qmr(A, b, x0=None, tol=1e-5, maxiter=None, M1=None, M2=None, callback=None,
 
 
 def _gmres_mgs(A, b, x0=None, restart=None, tol=1e-5, maxiter=None, M=None,
-               callback=None, restrt=None):
+               callback=None, restrt=None, atol=None, callback_type=None):
     """
     Use Restarted Generalized Minimal RESidual based on modified Gram-Schmidt
     iteration to solve ``Ax = b``.
 
     Parameters
     ----------
-    A : {sparse matrix, dense matrix, LinearOperator}
+    A : {array_like, LinearOperator}
         The real or complex N-by-N matrix of the linear system.
         Alternatively, `A` can be a linear operator which can
         produce ``Ax`` using, e.g.,
@@ -863,6 +861,7 @@ def _gmres_mgs(A, b, x0=None, restart=None, tol=1e-5, maxiter=None, M=None,
         Default is 30.
     tol : float, optional
         Tolerances for convergence, ``norm(residual) <= tol*norm(b)``.
+        Default is 1.0e-5.
     maxiter : int, optional
         Maximum number of iterations (restart cycles).  Iteration will stop
         after maxiter steps even if the specified tolerance has not been

--- a/scipy/sparse/linalg/isolve/iterative.py
+++ b/scipy/sparse/linalg/isolve/iterative.py
@@ -885,12 +885,13 @@ def _gmres_mgs(A, b, x0=None, restart=None, tol=1e-5, maxiter=None, M=None,
     A preconditioner ``P`` is chosen such that ``P`` is close to `A` but easy to solve
     for. The preconditioner parameter required by this routine is
     ``M = P^-1``. The inverse should preferably not be calculated
-    explicitly.  Rather, use the following template to produce M::
+    explicitly.  Rather, use the following template to produce ``M``:
 
-      # Construct a linear operator that computes P^-1 * x.
-      import scipy.sparse.linalg as spla
-      M_x = lambda x: spla.spsolve(P, x)
-      M = spla.LinearOperator((n, n), M_x)
+    >>> # Construct a linear operator that computes P^-1 * x.
+    >>> import scipy.sparse.linalg as spla
+    >>> M_x = lambda x: spla.spsolve(P, x)
+    >>> M = spla.LinearOperator((n, n), M_x)
+
     """
 
     # Change 'restrt' keyword to 'restart'

--- a/scipy/sparse/linalg/isolve/iterative.py
+++ b/scipy/sparse/linalg/isolve/iterative.py
@@ -837,7 +837,7 @@ def _gmres_mgs(A, b, x0=None, restart=None, tol=1e-5, maxiter=None, M=None,
     ----------
     A : {sparse matrix, dense matrix, LinearOperator}
         The real or complex N-by-N matrix of the linear system.
-        Alternatively, ``A`` can be a linear operator which can
+        Alternatively, `A` can be a linear operator which can
         produce ``Ax`` using, e.g.,
         ``scipy.sparse.linalg.LinearOperator``.
     b : {array, matrix}

--- a/scipy/sparse/linalg/isolve/iterative.py
+++ b/scipy/sparse/linalg/isolve/iterative.py
@@ -894,12 +894,6 @@ def _gmres_mgs(A, b, x0=None, restart=None, tol=1e-5, maxiter=None, M=None,
 
     """
 
-    # Change 'restrt' keyword to 'restart'
-    if restrt is None:
-        restrt = restart
-    elif restart is not None:
-        raise ValueError("Cannot specifiy both restart and restrt keywords. "
-                         "Preferably use 'restart' only.")
 
     # Check data type
     dtype = A.dtype


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Yousef Saad, Iterative Methods for Sparse Linear Systems, Second Edition, SIAM, 2003.

#### What does this implement/fix?
<!--Please explain your changes.-->
A faster implementation with restarted GMRES

#### Additional information
<!--Any additional information you think is important.-->
Using the keyword `orth = 'mgs'` to open the faster implementation of the algorithm