### PR TITLE
Workflow : Add nightly release of NumPy in linux workflows

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,9 +34,8 @@ jobs:
         run: |      
           python3.7-dbg -c 'import sys; print("Python debug build:", hasattr(sys, "gettotalrefcount"))'
           python3.7-dbg -m pip install --upgrade pip setuptools wheel
-          python3.7-dbg -m pip install --upgrade cython pytest pytest-xdist pybind11
+          python3.7-dbg -m pip install --upgrade numpy cython pytest pytest-xdist pybind11
           python3.7-dbg -m pip install --upgrade mpmath gmpy2 pythran
-          python3.7-dbg -m pip install --upgrade --no-cache-dir -i https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
           python3.7-dbg -m pip uninstall -y nose
           cd ..
       - name: Building SciPy

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -75,7 +75,7 @@ jobs:
     - name: Install packages
       run: |
         python3.9 -m pip install --user -i https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
-        python3.9 -m pip install --user setuptools wheel cython pytest pytest-xdist pybind11 pytest-xdist pythran
+        python3.9 -m pip install --user setuptools wheel cython pytest pybind11 pytest-xdist pythran
         python3.9 -m pip install -r mypy_requirements.txt
 
     - name: Mypy

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -36,7 +36,7 @@ jobs:
           python3.7-dbg -m pip install --upgrade pip setuptools wheel
           python3.7-dbg -m pip install --upgrade cython pytest pytest-xdist pybind11
           python3.7-dbg -m pip install --upgrade mpmath gmpy2 pythran
-          python3.7-dbg -m pip install --upgrade --no-cache-dir numpy
+          python3.7-dbg -m pip install --upgrade --no-cache-dir -i https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
           python3.7-dbg -m pip uninstall -y nose
           cd ..
       - name: Building SciPy
@@ -75,7 +75,8 @@ jobs:
 
     - name: Install packages
       run: |
-        python3.9 -m pip install --user numpy setuptools wheel cython pytest pytest-xdist pybind11 pytest-xdist pythran
+        python3.9 -m pip install --user -i https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
+        python3.9 -m pip install --user setuptools wheel cython pytest pytest-xdist pybind11 pytest-xdist pythran
         python3.9 -m pip install -r mypy_requirements.txt
 
     - name: Mypy

--- a/scipy/fft/_pocketfft/tests/test_real_transforms.py
+++ b/scipy/fft/_pocketfft/tests/test_real_transforms.py
@@ -1,4 +1,12 @@
 from os.path import join, dirname
+from typing import (
+    Dict,
+    Tuple,
+    TYPE_CHECKING,
+    Union,
+    Type
+ )
+from functools import partial
 
 import numpy as np
 from numpy.testing import (
@@ -194,8 +202,17 @@ def test_complex(transform, dtype):
     assert_array_almost_equal(x, y)
 
 
+if TYPE_CHECKING:
+    Numbers = Union[Type[np.double], Type[np.float32], Type[int]]
+    DecMapType = Dict[
+        Tuple[
+            partial, Numbers, int
+        ],
+        int
+    ]
+
 # map (tranform, dtype, type) -> decimal
-dec_map = {
+dec_map: DecMapType = {
     # DCT
     (dct, np.double, 1): 13,
     (dct, np.float32, 1): 6,

--- a/scipy/fft/_pocketfft/tests/test_real_transforms.py
+++ b/scipy/fft/_pocketfft/tests/test_real_transforms.py
@@ -1,12 +1,5 @@
 from os.path import join, dirname
-from typing import (
-    Dict,
-    Tuple,
-    TYPE_CHECKING,
-    Union,
-    Type
- )
-from functools import partial
+from typing import Callable, Dict, Tuple, Union, Type
 
 import numpy as np
 from numpy.testing import (
@@ -202,14 +195,10 @@ def test_complex(transform, dtype):
     assert_array_almost_equal(x, y)
 
 
-if TYPE_CHECKING:
-    Numbers = Union[Type[np.double], Type[np.float32], Type[int]]
-    DecMapType = Dict[
-        Tuple[
-            partial, Numbers, int
-        ],
-        int
-    ]
+DecMapType = Dict[
+    Tuple[Callable[..., np.ndarray], Union[Type[np.floating], Type[int]], int],
+    int,
+]
 
 # map (tranform, dtype, type) -> decimal
 dec_map: DecMapType = {

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -1,5 +1,4 @@
 import itertools
-from typing import Union
 import warnings
 
 import numpy as np
@@ -23,9 +22,9 @@ from scipy.linalg._testutils import assert_no_overwrite
 from scipy._lib._testutils import check_free_memory
 from scipy.linalg.blas import HAS_ILP64
 
-REAL_DTYPES = Union[np.float32, np.float64, np.longdouble]
-COMPLEX_DTYPES = Union[np.complex64, np.complex128, np.clongdouble]
-DTYPES = Union[REAL_DTYPES, COMPLEX_DTYPES]
+REAL_DTYPES = (np.float32, np.float64, np.longdouble)
+COMPLEX_DTYPES = (np.complex64, np.complex128, np.clongdouble)
+DTYPES = REAL_DTYPES + COMPLEX_DTYPES
 
 
 def _eps_cast(dtyp):

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -1,5 +1,7 @@
-import warnings
 import itertools
+from typing import Union
+import warnings
+
 import numpy as np
 from numpy import (arange, array, dot, zeros, identity, conjugate, transpose,
                    float32)
@@ -21,9 +23,9 @@ from scipy.linalg._testutils import assert_no_overwrite
 from scipy._lib._testutils import check_free_memory
 from scipy.linalg.blas import HAS_ILP64
 
-REAL_DTYPES = [np.float32, np.float64, np.longdouble]
-COMPLEX_DTYPES = [np.complex64, np.complex128, np.clongdouble]
-DTYPES = REAL_DTYPES + COMPLEX_DTYPES
+REAL_DTYPES = Union[np.float32, np.float64, np.longdouble]
+COMPLEX_DTYPES = Union[np.complex64, np.complex128, np.clongdouble]
+DTYPES = Union[REAL_DTYPES, COMPLEX_DTYPES]
 
 
 def _eps_cast(dtyp):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Since some of the PRs are relating on very recent NumPy's changes (as for #13833), we need to pull the NumPy Nightly Release when doing our workflows

#### What does this implement/fix?
<!--Please explain your changes.-->
This fetch the Nightly Numpy Release rather than the latest release of Numpy, in order to have the latest changes. 
Right now, it it just implemented on the Linux's workflow, as I don't know if it is necessary to have it everywhere. If some more experienced reviewer believe we need it in every workflow, I'll change it right away.
