### PR TITLE
DOC: Conform to numpydoc + uniformity.

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -23,7 +23,6 @@ def _lazywhere(cond, arrays, f, fillvalue=None, f2=None):
 
     Examples
     --------
-
     >>> a, b = np.array([1, 2, 3, 4]), np.array([5, 6, 7, 8])
     >>> def f(a, b):
     ...     return a*b
@@ -472,27 +471,27 @@ def rng_integers(gen, low, high=None, size=None, dtype='int64',
 
     Parameters
     ----------
-    gen: {None, np.random.RandomState, np.random.Generator}
+    gen : {None, np.random.RandomState, np.random.Generator}
         Random number generator. If None, then the np.random.RandomState
         singleton is used.
-    low: int or array-like of ints
+    low : int or array-like of ints
         Lowest (signed) integers to be drawn from the distribution (unless
         high=None, in which case this parameter is 0 and this value is used
         for high).
-    high: int or array-like of ints
+    high : int or array-like of ints
         If provided, one above the largest (signed) integer to be drawn from
         the distribution (see above for behavior if high=None). If array-like,
         must contain integer values.
-    size: None
+    size : None
         Output shape. If the given shape is, e.g., (m, n, k), then m * n * k
         samples are drawn. Default is None, in which case a single value is
         returned.
-    dtype: {str, dtype}, optional
+    dtype : {str, dtype}, optional
         Desired dtype of the result. All dtypes are determined by their name,
         i.e., 'int64', 'int', etc, so byteorder is not available and a specific
         precision may have different C types depending on the platform.
         The default value is np.int_.
-    endpoint: bool, optional
+    endpoint : bool, optional
         If True, sample from the interval [low, high] instead of the default
         [low, high) Defaults to False.
 

--- a/scipy/_lib/doccer.py
+++ b/scipy/_lib/doccer.py
@@ -255,11 +255,11 @@ def doc_replace(obj, oldval, newval):
 
     Parameters
     ----------
-    obj: object
+    obj : object
         The object to take the docstring from.
-    oldval: string
+    oldval : string
         The string to replace from the original docstring.
-    newval: string
+    newval : string
         The string to replace ``oldval`` with.
     """
     # __doc__ may be None for optimized Python (-OO)

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -221,7 +221,7 @@ def single(y):
 
     See Also
     --------
-    linkage: for advanced creation of hierarchical clusterings.
+    linkage : for advanced creation of hierarchical clusterings.
     scipy.spatial.distance.pdist : pairwise distance metrics
 
     Examples
@@ -301,7 +301,7 @@ def complete(y):
 
     See Also
     --------
-    linkage: for advanced creation of hierarchical clusterings.
+    linkage : for advanced creation of hierarchical clusterings.
     scipy.spatial.distance.pdist : pairwise distance metrics
 
     Examples
@@ -382,7 +382,7 @@ def average(y):
 
     See Also
     --------
-    linkage: for advanced creation of hierarchical clusterings.
+    linkage : for advanced creation of hierarchical clusterings.
     scipy.spatial.distance.pdist : pairwise distance metrics
 
     Examples
@@ -569,7 +569,7 @@ def centroid(y):
 
     See Also
     --------
-    linkage: for advanced creation of hierarchical clusterings.
+    linkage : for advanced creation of hierarchical clusterings.
     scipy.spatial.distance.pdist : pairwise distance metrics
 
     Examples
@@ -671,7 +671,7 @@ def median(y):
 
     See Also
     --------
-    linkage: for advanced creation of hierarchical clusterings.
+    linkage : for advanced creation of hierarchical clusterings.
     scipy.spatial.distance.pdist : pairwise distance metrics
 
     Examples
@@ -770,7 +770,7 @@ def ward(y):
 
     See Also
     --------
-    linkage: for advanced creation of hierarchical clusterings.
+    linkage : for advanced creation of hierarchical clusterings.
     scipy.spatial.distance.pdist : pairwise distance metrics
 
     Examples
@@ -1608,8 +1608,8 @@ def cophenet(Z, Y=None):
 
     See Also
     --------
-    linkage: for a description of what a linkage matrix is.
-    scipy.spatial.distance.squareform: transforming condensed matrices into square ones.
+    linkage : for a description of what a linkage matrix is.
+    scipy.spatial.distance.squareform : transforming condensed matrices into square ones.
 
     Examples
     --------
@@ -1809,8 +1809,8 @@ def from_mlab_linkage(Z):
 
     See Also
     --------
-    linkage: for a description of what a linkage matrix is.
-    to_mlab_linkage: transform from SciPy to MATLAB format.
+    linkage : for a description of what a linkage matrix is.
+    to_mlab_linkage : transform from SciPy to MATLAB format.
 
     Examples
     --------
@@ -1899,8 +1899,8 @@ def to_mlab_linkage(Z):
 
     See Also
     --------
-    linkage: for a description of what a linkage matrix is.
-    from_mlab_linkage: transform from Matlab to SciPy format.
+    linkage : for a description of what a linkage matrix is.
+    from_mlab_linkage : transform from Matlab to SciPy format.
 
     Examples
     --------
@@ -1981,7 +1981,7 @@ def is_monotonic(Z):
 
     See Also
     --------
-    linkage: for a description of what a linkage matrix is.
+    linkage : for a description of what a linkage matrix is.
 
     Examples
     --------
@@ -2058,14 +2058,14 @@ def is_valid_im(R, warning=False, throw=False, name=None):
     R : ndarray
         The inconsistency matrix to check for validity.
     warning : bool, optional
-         When True, issues a Python warning if the linkage
-         matrix passed is invalid.
+        When True, issues a Python warning if the linkage
+        matrix passed is invalid.
     throw : bool, optional
-         When True, throws a Python exception if the linkage
-         matrix passed is invalid.
+        When True, throws a Python exception if the linkage
+        matrix passed is invalid.
     name : str, optional
-         This string refers to the variable name of the invalid
-         linkage matrix.
+        This string refers to the variable name of the invalid
+        linkage matrix.
 
     Returns
     -------
@@ -2074,8 +2074,8 @@ def is_valid_im(R, warning=False, throw=False, name=None):
 
     See Also
     --------
-    linkage: for a description of what a linkage matrix is.
-    inconsistent: for the creation of a inconsistency matrix.
+    linkage : for a description of what a linkage matrix is.
+    inconsistent : for the creation of a inconsistency matrix.
 
     Examples
     --------
@@ -2389,7 +2389,7 @@ def correspond(Z, Y):
 
     See Also
     --------
-    linkage: for a description of what a linkage matrix is.
+    linkage : for a description of what a linkage matrix is.
 
     Examples
     --------
@@ -2480,7 +2480,6 @@ def fcluster(Z, t, criterion='inconsistent', depth=2, R=None, monocrit=None):
 
                   MI = maxinconsts(Z, R)
                   fcluster(Z, t=3, criterion='maxclust_monocrit', monocrit=MI)
-
     depth : int, optional
         The maximum depth to perform the inconsistency calculation.
         It has no meaning for the other criteria. Default is 2.
@@ -2726,7 +2725,7 @@ def leaves_list(Z):
 
     See Also
     --------
-    dendrogram: for information about dendrogram structure.
+    dendrogram : for information about dendrogram structure.
 
     Examples
     --------
@@ -3491,17 +3490,16 @@ def _dendrogram_calculate_info(Z, p, truncate_mode,
     Returns
     -------
     A tuple (left, w, h, md), where:
+        * left is the independent variable coordinate of the center of the
+          the U of the subtree
 
-      * left is the independent variable coordinate of the center of the
-        the U of the subtree
+        * w is the amount of space used for the subtree (in independent
+          variable units)
 
-      * w is the amount of space used for the subtree (in independent
-        variable units)
+        * h is the height of the subtree in dependent variable units
 
-      * h is the height of the subtree in dependent variable units
-
-      * md is the ``max(Z[*,2]``) for all nodes ``*`` below and including
-        the target node.
+        * md is the ``max(Z[*,2]``) for all nodes ``*`` below and including
+          the target node.
 
     """
     if n == 0:
@@ -3706,8 +3704,8 @@ def is_isomorphic(T1, T2):
 
     See Also
     --------
-    linkage: for a description of what a linkage matrix is.
-    fcluster: for the creation of flat cluster assignments.
+    linkage : for a description of what a linkage matrix is.
+    fcluster : for the creation of flat cluster assignments.
 
     Examples
     --------
@@ -3803,8 +3801,8 @@ def maxdists(Z):
 
     See Also
     --------
-    linkage: for a description of what a linkage matrix is.
-    is_monotonic: for testing for monotonicity of a linkage matrix.
+    linkage : for a description of what a linkage matrix is.
+    is_monotonic : for testing for monotonicity of a linkage matrix.
 
     Examples
     --------
@@ -3885,8 +3883,8 @@ def maxinconsts(Z, R):
 
     See Also
     --------
-    linkage: for a description of what a linkage matrix is.
-    inconsistent: for the creation of a inconsistency matrix.
+    linkage : for a description of what a linkage matrix is.
+    inconsistent : for the creation of a inconsistency matrix.
 
     Examples
     --------
@@ -3981,8 +3979,8 @@ def maxRstat(Z, R, i):
 
     See Also
     --------
-    linkage: for a description of what a linkage matrix is.
-    inconsistent: for the creation of a inconsistency matrix.
+    linkage : for a description of what a linkage matrix is.
+    inconsistent : for the creation of a inconsistency matrix.
 
     Examples
     --------
@@ -4094,7 +4092,6 @@ def leaders(Z, T):
         leader of flat cluster with id M[j]. If ``i < n``, ``i``
         corresponds to an original observation, otherwise it
         corresponds to a non-singleton cluster.
-
     M : ndarray
         The leader linkage node id's stored as a k-element 1-D array, where
         ``k`` is the number of flat clusters found in ``T``. This allows the
@@ -4105,7 +4102,7 @@ def leaders(Z, T):
 
     See Also
     --------
-    fcluster: for the creation of flat cluster assignments.
+    fcluster : for the creation of flat cluster assignments.
 
     Examples
     --------
@@ -4133,7 +4130,6 @@ def leaders(Z, T):
            [16.        , 17.        ,  5.77350269,  6.        ],
            [18.        , 19.        ,  5.77350269,  6.        ],
            [20.        , 21.        ,  8.16496581, 12.        ]])
-
 
     >>> T = fcluster(Z, 3, criterion='distance')
     >>> T


### PR DESCRIPTION
This update a couple of docstring to math numpydoc syntax.
For parameter and return types, space before colon is important for
numpydoc to properly find the parameter name and type.

Try to consistently indent 4 spaces in RST.

Try to be consistent and spacing between sections and parameters.

