### PR TITLE
BUG: signal: fix get_window argument handling and add tests.

### DIFF
--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -707,6 +707,24 @@ def test_needs_params():
         assert_raises(ValueError, get_window, winstr, 7)
 
 
+def test_not_needs_params():
+    for winstr in ['barthann',
+                   'bartlett',
+                   'blackman',
+                   'blackmanharris',
+                   'bohman',
+                   'boxcar',
+                   'cosine',
+                   'flattop',
+                   'hamming',
+                   'hanning',
+                   'nuttall',
+                   'parzen',
+                   'taylor',
+                   'triangle']:
+        get_window(winstr, 7)  # should work without error
+
+
 def test_deprecation():
     if dep_hann.__doc__ is not None:  # can be None with `-OO` mode
         assert_('signal.hann is deprecated' in dep_hann.__doc__)

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -722,7 +722,8 @@ def test_not_needs_params():
                    'parzen',
                    'taylor',
                    'triangle']:
-        get_window(winstr, 7)  # should work without error
+        win = get_window(winstr, 7)
+        assert_equal(len(win), 7)
 
 
 def test_deprecation():

--- a/scipy/signal/windows/windows.py
+++ b/scipy/signal/windows/windows.py
@@ -2147,11 +2147,11 @@ def get_window(window, Nx, fftbins=True):
             raise ValueError("Unknown window type.") from e
 
         if winfunc is dpss:
-            params = (Nx,) + args + (None, sym)
+            params = (Nx,) + args + (None,)
         else:
-            params = (Nx,) + args + (sym,)
+            params = (Nx,) + args
     else:
         winfunc = kaiser
-        params = (Nx, beta, sym)
+        params = (Nx, beta)
 
-    return winfunc(*params)
+    return winfunc(*params, sym=sym)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
fix #13878 

#### What does this implement/fix?
<!--Please explain your changes.-->
I fixed `signal.get_window` argument handling.
Current code assume the optional argument `sym` is located at second argument, but [scipy\.signal\.windows\.taylor](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.windows.taylor.html#scipy.signal.windows.taylor) one does not, it is fifth argument.
So, I changed `sym` argument handling to optional argument handling.

Also, I added tests for `get_window` to check all window functions which needs only one argument works correctly.

