### PR TITLE
BLD: ensure incrementing dev version strings

### DIFF
--- a/scipy/_build_utils/tests/test_scipy_version.py
+++ b/scipy/_build_utils/tests/test_scipy_version.py
@@ -9,7 +9,7 @@ def test_valid_scipy_version():
     # nonsense). See NumPy issue gh-6431 for an issue caused by an invalid
     # version.
     version_pattern = r"^[0-9]+\.[0-9]+\.[0-9]+(|a[0-9]|b[0-9]|rc[0-9])"
-    dev_suffix = r"(\.dev0\+([0-9a-f]{7}|Unknown))"
+    dev_suffix = r"(\.dev0\+.+([0-9a-f]{7}|Unknown))"
     if scipy.version.release:
         res = re.match(version_pattern, scipy.__version__)
     else:


### PR DESCRIPTION
Together with no longer changing the file name of the generated wheels for dev versions in scipy-wheels, this will resolve: 
https://github.com/MacPython/scipy-wheels/issues/114

The version string will be something like: `scipy-1.7.0.dev0+25389.adbc57d`. The `part after `.dev0+` is the total commit count, which will keep increasing; the last part is the commit hash (like before).

Testing locally with most recent pip resolves this, an install like this should succeed:
```
pip install scipy --pre --find-links ~/code/scipy/dist/scipy/ --no-index --no-deps
```
and the `METADATA` file inside the wheel has a matching version string.

When this is merged, I'll send a follow up PR to `scipy-wheels`.