### PR TITLE
TST: optimize: skip test_network_flow_limited_capacity w/ UMFPACK due to numerical issues on some platforms

### DIFF
--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -1780,6 +1780,9 @@ if has_umfpack:
         def test_bug_10466(self):
             pytest.skip("Autoscale doesn't fix everything, and that's OK.")
 
+        def test_network_flow_limited_capacity(self):
+            pytest.skip("Failing due to numerical issues on some platforms.")
+
 
 class TestLinprogIPSparse(LinprogIPTests):
     options = {"sparse": True, "cholesky": False, "sym_pos": False}


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->
gh-13885

#### What does this implement/fix?
<!--Please explain your changes.-->
Temporary fix for gh-13885, in case that is causing trouble. 

We can leave that issue open, but I'm not sure if it will be solved immediately. It sounds like another manifestation of the numerical issues in the algorithm caused when the matrices are not full row rank.  In this case:
```python3
import numpy as np
n, p = -1, 1
A_eq = [[n, n, 0, 0, 0],
        [p, 0, n, n, 0],
        [0, p, p, 0, n],
        [0, 0, 0, p, p]]
print(np.linalg.matrix_rank(A_eq))
```
gives 3, which is less than the number of rows (4). 

Those warnings suppressed in the test are raised by the solver when a matrix that is not full row rank is encountered. We try to remove redundant rows in preprocessing, but that is not perfect, unfortunately. 

_Update: seems that redundant rows are being removed properly. These are numerical issues as solution is approached, another tendency of the algorithm in its straightforward implementation. Looks like the matrix `M` in `_get_delta` goes numerically singular on all platforms, but with UMFPACK we actually get infinities because an element of `z` goes to zero. In this case, we could add a check for `nans` in `u` and `v` in [this line](https://github.com/scipy/scipy/blob/fae1239a90f6f783d3277ca3d4bc534311cf68b0/scipy/optimize/_linprog_ip.py#L267), but it doesn't fix the problem; just identifies the problem a little earlier. I don't see an easy fix._

Perhaps we should change the default method to HiGHS now? It is typically even more reliable than `interior-point`, and it is much faster. Making it the default reduces the changce that users will run into problems like gh-13885.