### PR TITLE
DOC: stats: implement suggestion for making pdf more readable

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -2976,22 +2976,21 @@ class genhyperbolic_gen(rv_continuous):
 
     .. math::
 
-        f(x, p, a, b) =
-            \frac{(a^2 - b^2)^{p/2}}
-            {\sqrt{2\pi}a^{p-0.5}
-            K_p\Big(\sqrt{a^2 - b^2}\Big)}
-            e^{bx} \times \frac{K_{p - 1/2}
-            (a \sqrt{1 + x^2})}
-            {(\sqrt{1 + x^2})^{1/2 - p}}
+        f(x, p, a, b) = g^p / (\sqrt{2\pi} a^k K_p(g))
+                        e^{bx} K_k (a h) h^k
 
-    for :math:`x, p \in ( - \infty; \infty)`,
-    :math:`|b| < a` if :math:`p \ge 0`,
-    :math:`|b| \le a` if :math:`p < 0`.
+    for :math:`x, p \in (-\infty; \infty)`,
+    :math:`|b| < a` if :math:`p \ge 0`, and
+    :math:`|b| \le a` if :math:`p < 0`, where
     :math:`K_{p}(.)` denotes the modified Bessel function of the second
-    kind and order :math:`p` (`scipy.special.kn`)
+    kind and order :math:`p` (`scipy.special.kn`),
+    :math:`g = \sqrt{a^2 - b^2}`,
+    :math:`h = \sqrt{1 + x^2}`, and
+    :math:`k = p - 1/2`.
 
-    `genhyperbolic` takes ``p`` as a tail parameter,
-    ``a`` as a shape parameter,
+    `genhyperbolic` takes
+    ``p`` as a tail parameter,
+    ``a`` as a shape parameter, and
     ``b`` as a skewness parameter.
 
     %(after_notes)s


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->
gh-13298

#### What does this implement/fix?
<!--Please explain your changes.-->
@ev-br [wrote ](https://github.com/scipy/scipy/pull/13298#pullrequestreview-638207522)
> Readability: define named variables for `p-1/2`, `a^2-b^2` etc. Also prefer X / Y to \frac{X}{Y}

This is an attempt to implement that suggestion. @ev-br if you have other suggestions, please push to this branch.

#### Additional information
<!--Any additional information you think is important.-->

[This gist](https://gist.github.com/mdhaber/46ede992f135a62c14b51a506a610267) confirms that the different forms are equivalent.