### PR TITLE
DOC: BLD: fix doc build version check, and improve build time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,11 +77,11 @@ jobs:
 
       - run:
           name: build docs
-          no_output_timeout: 20m
+          no_output_timeout: 25m
           command: |
             . venv/bin/activate
             export SHELL=$(which bash)
-            python -u runtests.py -g --doc html-scipyorg --doc latex
+            python -u runtests.py -g -j2 --doc html-scipyorg --doc latex
             make -C doc/build/latex all-pdf LATEXOPTS="-file-line-error -halt-on-error"
             cp -f doc/build/latex/scipy-ref.pdf doc/build/html-scipyorg/
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -56,7 +56,7 @@ UPLOAD_DIR=/srv/docs_scipy_org/doc/scipy-$(RELEASE)
 
 SCIPYVER:=$(shell $(PYTHON) -c "import scipy; print(scipy.version.git_revision[:10])" 2>/dev/null)
 GITVER ?= $(shell cd ..; $(PYTHON) -c "from setup import git_version; \
-				print(git_version()[:10])")
+				print(git_version()[0][:10])")
 
 version-check:
 ifeq "$(GITVER)" "Unknown"

--- a/doc/source/_templates/sidebar-nav-bs.html
+++ b/doc/source/_templates/sidebar-nav-bs.html
@@ -1,0 +1,9 @@
+<nav class="bd-links" id="bd-docs-nav" aria-label="Main navigation">
+  <div class="bd-toc-item active">
+    {% if pagename.startswith("reference") %}
+    {{ generate_nav_html("sidebar", maxdepth=4, collapse=True, includehidden=True, titles_only=True) }}
+    {% else %}
+    {{ generate_nav_html("sidebar", maxdepth=4, collapse=False, includehidden=True, titles_only=True) }}
+    {% endif %}
+  </div>
+</nav>

--- a/doc/source/_templates/sidebar-nav-bs.html
+++ b/doc/source/_templates/sidebar-nav-bs.html
@@ -3,7 +3,7 @@
     {% if pagename.startswith("reference") %}
     {{ generate_nav_html("sidebar", maxdepth=4, collapse=True, includehidden=True, titles_only=True) }}
     {% else %}
-    {{ generate_nav_html("sidebar", maxdepth=4, collapse=False, includehidden=True, titles_only=True) }}
+    {{ generate_nav_html("sidebar", maxdepth=4, collapse=True, includehidden=True, titles_only=True) }}
     {% endif %}
   </div>
 </nav>

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -239,7 +239,7 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
     >>> rng = np.random.default_rng()
     >>> x = rng.standard_normal(100)
     >>> a = np.arange(-50, 50)
-    >>> vec_res = optimize.newton(f, x, fprime=fder, args=(a, ))
+    >>> vec_res = optimize.newton(f, x, fprime=fder, args=(a, ), maxiter=200)
 
     The above is the equivalent of solving for each value in ``(x, a)``
     separately in a for-loop, just faster:


### PR DESCRIPTION
- The version check broke with gh-13882 changing `git_version()` in `setup.py`
- The doc build time fix is taken over from Pandas (xref gh-13843 - maybe fix it, but the `:orphan:` change may result in further improvements).

Locally this improves the build time from 63 min to 17 min --> 3.7x