### PR TITLE
BUG: Make chi2_contingency with Yates' correction compliant with R implementation of the test

### DIFF
--- a/scipy/stats/contingency.py
+++ b/scipy/stats/contingency.py
@@ -287,7 +287,10 @@ def chi2_contingency(observed, correction=True, lambda_=None):
     else:
         if dof == 1 and correction:
             # Adjust `observed` according to Yates' correction for continuity.
-            observed = observed + 0.5 * np.sign(expected - observed)
+            # Implementation is compliant with R's one
+            # https://github.com/wch/r-source/blob/trunk/src/library/stats/R/chisq.test.R
+            yates = np.minimum(0.5, np.abs(expected - observed))
+            observed = observed + yates * np.sign(expected - observed)
 
         chi2, p = power_divergence(observed, expected,
                                    ddof=observed.size - 1 - dof, axis=None,

--- a/scipy/stats/tests/test_contingency.py
+++ b/scipy/stats/tests/test_contingency.py
@@ -166,6 +166,25 @@ def test_chi2_contingency_R():
     assert_approx_equal(p, 0.6442, significant=4)
     assert_equal(dof, 11)
 
+    # test Yates' correction (unbalanced case)
+    # > X <- matrix(c(1000, 10, 1, 0), ncol=2, nrow=2)
+    # > X
+    #     [,1] [,2]
+    # [1,] 1000    1
+    # [2,]   10    0
+    # > chisq.test(X)
+    #         Pearson's Chi-squared test with Yates' continuity correction
+    # data:  X
+    # X-squared = 5.163e-28, df = 1, p-value = 1
+
+    obs = np.array(
+        [[1000, 1],
+         [10, 0]]
+    )
+    chi2, p, dof, expected = chi2_contingency(obs, correction=True)
+    assert_approx_equal(p, 1.0, significant=2)
+    assert_allclose(chi2, 0.0)
+
 
 def test_chi2_contingency_g():
     c = np.array([[15, 60], [15, 90]])


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes gh-#13875

#### What does this implement/fix?
As it is described in #13875, in some cases Yates' correction in `chi2_contingency` could lead to significant
decreasing of p-value (i.e. buggy behavior); R's corresponding method `chisq.test` deal with the problem in a different way: it tweaks absolute value of Yates' correction according to the difference between observed and expected tables. This pull request make  `chi2_contingency` (with Yates' correction) behavior the same as `chisq.test` in R. 
