### PR TITLE
ENH: Rewrite minkowski metric in C++ with pybind11

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -123,6 +123,8 @@ from . import _hausdorff
 from ..linalg import norm
 from ..special import rel_entr
 
+from . import _distance_pybind
+
 
 def _copy_array_if_base_present(a):
     """Copy the array if its base points to a parent array."""
@@ -1747,6 +1749,8 @@ class MetricInfo:
     # X (pdist) and XA (cdist) are used to choose the type. if there is no
     # match the first type is used. Default double
     types: List[str] = dataclasses.field(default_factory=lambda: ['double'])
+    # true if out array must be C-contiguous
+    requires_contiguous_out: bool = True
 
 
 # Registry of implemented metrics:
@@ -1856,10 +1860,9 @@ _METRIC_INFOS = [
         aka={'minkowski', 'mi', 'm', 'pnorm'},
         validator=_validate_minkowski_kwargs,
         dist_func=minkowski,
-        cdist_func=CDistWeightedMetricWrapper(
-            'minkowski', 'weighted_minkowski'),
-        pdist_func=PDistWeightedMetricWrapper(
-            'minkowski', 'weighted_minkowski'),
+        cdist_func=_distance_pybind.cdist_minkowski,
+        pdist_func=_distance_pybind.pdist_minkowski,
+        requires_contiguous_out=False,
     ),
     MetricInfo(
         canonical_name='rogerstanimoto',

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -1773,18 +1773,17 @@ _METRIC_INFOS = [
         canonical_name='chebyshev',
         aka={'chebychev', 'chebyshev', 'cheby', 'cheb', 'ch'},
         dist_func=chebyshev,
-        validator=_validate_weight_with_size,
-        cdist_func=CDistWeightedMetricWrapper(
-            'chebyshev', 'weighted_chebyshev'),
-        pdist_func=PDistWeightedMetricWrapper(
-            'chebyshev', 'weighted_chebyshev'),
+        cdist_func=_distance_pybind.cdist_chebyshev,
+        pdist_func=_distance_pybind.pdist_chebyshev,
+        requires_contiguous_out=False,
     ),
     MetricInfo(
         canonical_name='cityblock',
         aka={'cityblock', 'cblock', 'cb', 'c'},
         dist_func=cityblock,
-        cdist_func=CDistMetricWrapper('cityblock'),
-        pdist_func=PDistMetricWrapper('cityblock'),
+        cdist_func=_distance_pybind.cdist_cityblock,
+        pdist_func=_distance_pybind.pdist_cityblock,
+        requires_contiguous_out=False,
     ),
     MetricInfo(
         canonical_name='correlation',
@@ -1812,8 +1811,9 @@ _METRIC_INFOS = [
         canonical_name='euclidean',
         aka={'euclidean', 'euclid', 'eu', 'e'},
         dist_func=euclidean,
-        cdist_func=CDistMetricWrapper('euclidean'),
-        pdist_func=PDistMetricWrapper('euclidean'),
+        cdist_func=_distance_pybind.cdist_euclidean,
+        pdist_func=_distance_pybind.pdist_euclidean,
+        requires_contiguous_out=False,
     ),
     MetricInfo(
         canonical_name='hamming',

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -1775,7 +1775,6 @@ _METRIC_INFOS = [
         dist_func=chebyshev,
         cdist_func=_distance_pybind.cdist_chebyshev,
         pdist_func=_distance_pybind.pdist_chebyshev,
-        requires_contiguous_out=False,
     ),
     MetricInfo(
         canonical_name='cityblock',
@@ -1783,7 +1782,6 @@ _METRIC_INFOS = [
         dist_func=cityblock,
         cdist_func=_distance_pybind.cdist_cityblock,
         pdist_func=_distance_pybind.pdist_cityblock,
-        requires_contiguous_out=False,
     ),
     MetricInfo(
         canonical_name='correlation',
@@ -1813,7 +1811,6 @@ _METRIC_INFOS = [
         dist_func=euclidean,
         cdist_func=_distance_pybind.cdist_euclidean,
         pdist_func=_distance_pybind.pdist_euclidean,
-        requires_contiguous_out=False,
     ),
     MetricInfo(
         canonical_name='hamming',
@@ -1862,7 +1859,6 @@ _METRIC_INFOS = [
         dist_func=minkowski,
         cdist_func=_distance_pybind.cdist_minkowski,
         pdist_func=_distance_pybind.pdist_minkowski,
-        requires_contiguous_out=False,
     ),
     MetricInfo(
         canonical_name='rogerstanimoto',

--- a/scipy/spatial/setup.py
+++ b/scipy/spatial/setup.py
@@ -2,13 +2,28 @@ from os.path import join, dirname
 import glob
 
 
+def pre_build_hook(build_ext, ext):
+    from scipy._build_utils.compiler_helper import (
+        set_cxx_flags_hook, try_add_flag, try_compile, has_flag)
+    cc = build_ext._cxx_compiler
+    args = ext.extra_compile_args
+
+    set_cxx_flags_hook(build_ext, ext)
+
+    if cc.compiler_type == 'msvc':
+        args.append('/EHsc')
+    else:
+        # Don't export library symbols
+        try_add_flag(args, cc, '-fvisibility=hidden')
+
 def configuration(parent_package='', top_path=None):
     from numpy.distutils.misc_util import Configuration, get_numpy_include_dirs
     from numpy.distutils.misc_util import get_info as get_misc_info
     from scipy._build_utils.system_info import get_info
-    from scipy._build_utils import combine_dict, uses_blas64
+    from scipy._build_utils import combine_dict, uses_blas64, numpy_nodepr_api
     from scipy._build_utils.compiler_helper import set_cxx_flags_hook
     from distutils.sysconfig import get_python_inc
+    import pybind11
 
     config = Configuration('spatial', parent_package, top_path)
 
@@ -74,6 +89,20 @@ def configuration(parent_package='', top_path=None):
                              get_numpy_include_dirs(),
                              join(dirname(dirname(__file__)), '_lib')],
                          extra_info=get_misc_info("npymath"))
+
+    distance_pybind_includes = [
+        pybind11.get_include(True),
+        pybind11.get_include(False),
+        get_numpy_include_dirs()]
+    ext = config.add_extension('_distance_pybind',
+                               sources=[join('src', 'distance_pybind.cpp')],
+                               depends=[join('src', 'function_ref.h'),
+                                        join('src', 'views.h'),
+                                        join('src', 'distance_metrics.h')],
+                               include_dirs=distance_pybind_includes,
+                               language='c++',
+                               **numpy_nodepr_api)
+    ext._pre_build_hook = pre_build_hook
 
     config.add_extension('_voronoi',
                          sources=['_voronoi.c'])

--- a/scipy/spatial/setup.py
+++ b/scipy/spatial/setup.py
@@ -11,6 +11,7 @@ def pre_build_hook(build_ext, ext):
     set_cxx_flags_hook(build_ext, ext)
 
     if cc.compiler_type == 'msvc':
+        # Ignore "structured exceptions" which are non-standard MSVC extensions
         args.append('/EHsc')
     else:
         # Don't export library symbols

--- a/scipy/spatial/src/distance_metrics.h
+++ b/scipy/spatial/src/distance_metrics.h
@@ -6,7 +6,7 @@
 #ifdef __GNUC__
 #define ALWAYS_INLINE inline __attribute__((always_inline))
 #define INLINE_LAMBDA __attribute__((always_inline))
-#elif defined(MSC_VER)
+#elif defined(_MSC_VER)
 #define ALWAYS_INLINE __forceinline
 #define INLINE_LAMBDA
 #else

--- a/scipy/spatial/src/distance_metrics.h
+++ b/scipy/spatial/src/distance_metrics.h
@@ -3,42 +3,103 @@
 #include <cmath>
 #include "views.h"
 
+#ifdef __GNUC__
+#define ALWAYS_INLINE inline __attribute__((always_inline))
+#define INLINE_LAMBDA __attribute__((always_inline))
+#elif defined(MSC_VER)
+#define ALWAYS_INLINE __forceinline
+#define INLINE_LAMBDA
+#else
+#define ALWAYS_INLINE inline
+#define INLINE_LAMBDA
+#endif
+
 struct Identity {
     template <typename T>
-    T operator() (T && val) const {
+    ALWAYS_INLINE T operator() (T && val) const {
         return std::forward<T>(val);
+    }
+};
+
+struct Plus {
+    template <typename T>
+    ALWAYS_INLINE T operator()(T a, T b) const {
+        return a + b;
+    }
+};
+
+// Helper to force a fixed bound loop to be completely unrolled
+template <int unroll>
+struct ForceUnroll{
+    template <typename Func>
+    ALWAYS_INLINE void operator()(const Func& f) const {
+        ForceUnroll<unroll - 1>{}(f);
+        f(unroll - 1);
+    }
+};
+
+template <>
+struct ForceUnroll<1> {
+    template <typename Func>
+    ALWAYS_INLINE void operator()(const Func& f) const {
+        f(0);
     }
 };
 
 template <int ilp_factor=4, typename T,
           typename TransformFunc,
           typename ProjectFunc = Identity,
-          typename ReduceFunc = std::plus<>>
+          typename ReduceFunc = Plus>
 void transform_reduce_2d_(
     StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y,
     const TransformFunc& map, const ProjectFunc& project = Identity{},
-    const ReduceFunc& reduce = std::plus<>{}) {
+    const ReduceFunc& reduce = Plus{}) {
     intptr_t xs = x.strides[1], ys = y.strides[1];
 
     intptr_t i = 0;
-    for (; i + (ilp_factor - 1) < x.shape[0]; i += ilp_factor) {
-        const T* x_rows[ilp_factor];
-        const T* y_rows[ilp_factor];
-        for (int k = 0; k < ilp_factor; ++k) {
-            x_rows[k] = &x(i + k, 0);
-            y_rows[k] = &y(i + k, 0);
-        }
+    if (xs == 1 && ys == 1) {
+        for (; i + (ilp_factor - 1) < x.shape[0]; i += ilp_factor) {
+            const T* x_rows[ilp_factor];
+            const T* y_rows[ilp_factor];
+            ForceUnroll<ilp_factor>{}([&](int k) {
+                x_rows[k] = &x(i + k, 0);
+                y_rows[k] = &y(i + k, 0);
+            });
 
-        T dist[ilp_factor] = {0};
-        for (intptr_t j = 0; j < x.shape[1]; ++j) {
-            for (int k = 0; k < ilp_factor; ++k) {
-                auto val = map(x_rows[k][j * xs], y_rows[k][j * ys]);
-                dist[k] = reduce(dist[k], val);
+            T dist[ilp_factor] = {0};
+            for (intptr_t j = 0; j < x.shape[1]; ++j) {
+                ForceUnroll<ilp_factor>{}([&](int k) {
+                    auto val = map(x_rows[k][j], y_rows[k][j]);
+                    dist[k] = reduce(dist[k], val);
+                });
             }
-        }
 
-        for (int k = 0; k < ilp_factor; ++k) {
-            out(i + k, 0) = project(dist[k]);
+            ForceUnroll<ilp_factor>{}([&](int k) {
+                out(i + k, 0) = project(dist[k]);
+            });
+        }
+    } else {
+        for (; i + (ilp_factor - 1) < x.shape[0]; i += ilp_factor) {
+            const T* x_rows[ilp_factor];
+            const T* y_rows[ilp_factor];
+            ForceUnroll<ilp_factor>{}([&](int k) {
+                x_rows[k] = &x(i + k, 0);
+                y_rows[k] = &y(i + k, 0);
+            });
+
+            T dist[ilp_factor] = {0};
+            for (intptr_t j = 0; j < x.shape[1]; ++j) {
+                auto x_offset = j * xs;
+                auto y_offset = j * ys;
+                ForceUnroll<ilp_factor>{}([&](int k) {
+                    auto val = map(x_rows[k][x_offset], y_rows[k][y_offset]);
+                    dist[k] = reduce(dist[k], val);
+                });
+            }
+
+            ForceUnroll<ilp_factor>{}([&](int k) {
+                out(i + k, 0) = project(dist[k]);
+            });
         }
     }
     for (; i < x.shape[0]; ++i) {
@@ -55,13 +116,13 @@ void transform_reduce_2d_(
 
 template <int ilp_factor=2, typename T,
           typename TransformFunc,
-          typename ProjectFunc=Identity,
-          typename ReduceFunc = std::plus<>>
+          typename ProjectFunc = Identity,
+          typename ReduceFunc = Plus>
 void transform_reduce_2d_(
     StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y,
     StridedView2D<const T> w, const TransformFunc& map,
     const ProjectFunc& project = Identity{},
-    const ReduceFunc& reduce = std::plus<>{}) {
+    const ReduceFunc& reduce = Plus{}) {
     intptr_t i = 0;
     intptr_t xs = x.strides[1], ys = y.strides[1], ws = w.strides[1];
 
@@ -69,23 +130,23 @@ void transform_reduce_2d_(
         const T* x_rows[ilp_factor];
         const T* y_rows[ilp_factor];
         const T* w_rows[ilp_factor];
-        for (int k = 0; k < ilp_factor; ++k) {
+        ForceUnroll<ilp_factor>{}([&](int k) {
             x_rows[k] = &x(i + k, 0);
             y_rows[k] = &y(i + k, 0);
             w_rows[k] = &w(i + k, 0);
-        }
+        });
 
         T dist[ilp_factor] = {0};
         for (intptr_t j = 0; j < x.shape[1]; ++j) {
-            for (int k = 0; k < ilp_factor; ++k) {
+            ForceUnroll<ilp_factor>{}([&](int k) {
                 auto val = map(x_rows[k][j * xs], y_rows[k][j * ys], w_rows[k][j * ws]);
                 dist[k] = reduce(dist[k], val);
-            }
+            });
         }
 
-        for (int k = 0; k < ilp_factor; ++k) {
+        ForceUnroll<ilp_factor>{}([&](int k) {
             out(i + k, 0) = project(dist[k]);
-        }
+        });
     }
     for (; i < x.shape[0]; ++i) {
         const T* x_row = &x(i, 0);
@@ -107,7 +168,7 @@ struct MinkowskiDistance {
     void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y) const {
         const T p = static_cast<T>(p_);
         const T invp = static_cast<T>(1.0 / p_);
-        transform_reduce_2d_(out, x, y, [p](T x, T y) {
+        transform_reduce_2d_(out, x, y, [p](T x, T y) INLINE_LAMBDA {
             auto diff = std::abs(x - y);
             return std::pow(diff, p);
         },
@@ -118,7 +179,7 @@ struct MinkowskiDistance {
     void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y, StridedView2D<const T> w) const {
         const T p = static_cast<T>(p_);
         const T invp = static_cast<T>(1.0 / p_);
-        transform_reduce_2d_(out, x, y, w, [p](T x, T y, T w) {
+        transform_reduce_2d_(out, x, y, w, [p](T x, T y, T w) INLINE_LAMBDA {
             auto diff = std::abs(x - y);
             return w * std::pow(diff, p);
         },
@@ -129,7 +190,7 @@ struct MinkowskiDistance {
 struct EuclideanDistance {
     template <typename T>
     void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y) const {
-        transform_reduce_2d_(out, x, y, [](T x, T y) {
+        transform_reduce_2d_(out, x, y, [](T x, T y) INLINE_LAMBDA {
             auto diff = std::abs(x - y);
             return diff * diff;
         },
@@ -138,7 +199,7 @@ struct EuclideanDistance {
 
     template <typename T>
     void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y, StridedView2D<const T> w) const {
-        transform_reduce_2d_(out, x, y, w, [](T x, T y, T w) {
+        transform_reduce_2d_(out, x, y, w, [](T x, T y, T w) INLINE_LAMBDA {
             auto diff = std::abs(x - y);
             return w * (diff * diff);
         },
@@ -149,7 +210,7 @@ struct EuclideanDistance {
 struct ChebyshevDistance {
     template <typename T>
     void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y) const {
-        transform_reduce_2d_(out, x, y, [](T x, T y) {
+        transform_reduce_2d_(out, x, y, [](T x, T y) INLINE_LAMBDA {
             return std::abs(x - y);
         },
         Identity{},
@@ -174,14 +235,14 @@ struct ChebyshevDistance {
 struct CityBlockDistance {
     template <typename T>
     void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y) const {
-        transform_reduce_2d_(out, x, y, [](T x, T y) {
+        transform_reduce_2d_<2>(out, x, y, [](T x, T y) INLINE_LAMBDA {
             return std::abs(x - y);
         });
     }
 
     template <typename T>
     void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y, StridedView2D<const T> w) const {
-        transform_reduce_2d_(out, x, y, w, [](T x, T y, T w) {
+        transform_reduce_2d_(out, x, y, w, [](T x, T y, T w) INLINE_LAMBDA {
             return w * std::abs(x - y);
         });
     }

--- a/scipy/spatial/src/distance_metrics.h
+++ b/scipy/spatial/src/distance_metrics.h
@@ -1,0 +1,116 @@
+#pragma once
+
+#include <cmath>
+#include "views.h"
+
+struct MinkowskiDistance {
+    double p_;
+
+    template <typename T>
+    void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y) const {
+        T p = p_;
+        for (int64_t i = 0; i < x.shape[0]; ++i) {
+            T p_dist = 0;
+            for (int64_t j = 0; j < x.shape[1]; ++j) {
+                auto diff = std::abs(x(i, j) - y(i, j));
+                p_dist += std::pow(diff, p);
+            }
+            out(i, 0) = std::pow(p_dist, 1 / p);
+        }
+    }
+
+    template <typename T>
+    void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y, StridedView2D<const T> w) const {
+        T p = p_;
+        for (int64_t i = 0; i < x.shape[0]; ++i) {
+            T p_dist = 0;
+            for (int64_t j = 0; j < x.shape[1]; ++j) {
+                auto diff = std::abs(x(i, j) - y(i, j));
+                p_dist += w(i, j) * std::pow(diff, p);
+            }
+            out(i, 0) = std::pow(p_dist, 1 / p);
+        }
+    }
+};
+
+struct EuclideanDistance {
+    template <typename T>
+    void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y) const {
+        for (int64_t i = 0; i < x.shape[0]; ++i) {
+            T sqdist = 0;
+            for (int64_t j = 0; j < x.shape[1]; ++j) {
+                auto diff = std::abs(x(i, j) - y(i, j));
+                sqdist += diff * diff;
+            }
+            out(i, 0) = std::sqrt(sqdist);
+        }
+    }
+
+    template <typename T>
+    void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y, StridedView2D<const T> w) const {
+        for (int64_t i = 0; i < x.shape[0]; ++i) {
+            T sqdist = 0;
+            for (int64_t j = 0; j < x.shape[1]; ++j) {
+                auto diff = std::abs(x(i, j) - y(i, j));
+                sqdist += w(i, j) * (diff * diff);
+            }
+            out(i, 0) = std::sqrt(sqdist);
+        }
+    }
+};
+
+struct ChebyshevDistance {
+    template <typename T>
+    void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y) const {
+        for (int64_t i = 0; i < x.shape[0]; ++i) {
+            T dist = 0;
+            for (int64_t j = 0; j < x.shape[1]; ++j) {
+                auto diff = std::abs(x(i, j) - y(i, j));
+                if (diff > dist) {
+                    dist = diff;
+                }
+            }
+            out(i, 0) = dist;
+        }
+    }
+
+    template <typename T>
+    void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y, StridedView2D<const T> w) const {
+        for (int64_t i = 0; i < x.shape[0]; ++i) {
+            T dist = 0;
+            for (int64_t j = 0; j < x.shape[1]; ++j) {
+                auto diff = std::abs(x(i, j) - y(i, j));
+                if (w(i, j) > 0 && diff > dist) {
+                    dist = diff;
+                }
+            }
+            out(i, 0) = dist;
+        }
+    }
+};
+
+struct CityBlockDistance {
+    template <typename T>
+    void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y) const {
+        for (int64_t i = 0; i < x.shape[0]; ++i) {
+            T dist = 0;
+            for (int64_t j = 0; j < x.shape[1]; ++j) {
+                auto diff = std::abs(x(i, j) - y(i, j));
+                dist += diff;
+            }
+            out(i, 0) = dist;
+        }
+    }
+
+    template <typename T>
+    void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y, StridedView2D<const T> w) const {
+        for (int64_t i = 0; i < x.shape[0]; ++i) {
+            T dist = 0;
+            for (int64_t j = 0; j < x.shape[1]; ++j) {
+                auto diff = std::abs(x(i, j) - y(i, j));
+                dist += w(i, j) * diff;
+            }
+            out(i, 0) = dist;
+        }
+    }
+};

--- a/scipy/spatial/src/distance_metrics.h
+++ b/scipy/spatial/src/distance_metrics.h
@@ -92,13 +92,25 @@ struct ChebyshevDistance {
 struct CityBlockDistance {
     template <typename T>
     void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y) const {
-        for (int64_t i = 0; i < x.shape[0]; ++i) {
-            T dist = 0;
-            for (int64_t j = 0; j < x.shape[1]; ++j) {
-                auto diff = std::abs(x(i, j) - y(i, j));
-                dist += diff;
+        if (x.strides[1] == 1 && y.strides[1] == 1) {
+            for (int64_t i = 0; i < x.shape[0]; ++i) {
+                const T* x_data = x.data + i * x.strides[0];
+                const T* y_data = y.data + i * y.strides[0];
+
+                T dist = 0;
+                for (int64_t j = 0; j < x.shape[1]; ++j) {
+                    dist += std::abs(x_data[j] - y_data[j]);
+                }
+                out(i, 0) = dist;
             }
-            out(i, 0) = dist;
+        } else {
+            for (int64_t i = 0; i < x.shape[0]; ++i) {
+                T dist = 0;
+                for (int64_t j = 0; j < x.shape[1]; ++j) {
+                    dist += std::abs(x(i, j) - y(i, j));
+                }
+                out(i, 0) = dist;
+            }
         }
     }
 

--- a/scipy/spatial/src/distance_metrics.h
+++ b/scipy/spatial/src/distance_metrics.h
@@ -3,75 +3,157 @@
 #include <cmath>
 #include "views.h"
 
+struct Identity {
+    template <typename T>
+    T operator() (T && val) const {
+        return std::forward<T>(val);
+    }
+};
+
+template <int ilp_factor=4, typename T,
+          typename TransformFunc,
+          typename ProjectFunc = Identity,
+          typename ReduceFunc = std::plus<>>
+void transform_reduce_2d_(
+    StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y,
+    const TransformFunc& map, const ProjectFunc& project = Identity{},
+    const ReduceFunc& reduce = std::plus<>{}) {
+    intptr_t xs = x.strides[1], ys = y.strides[1];
+
+    intptr_t i = 0;
+    for (; i + (ilp_factor - 1) < x.shape[0]; i += ilp_factor) {
+        const T* x_rows[ilp_factor];
+        const T* y_rows[ilp_factor];
+        for (int k = 0; k < ilp_factor; ++k) {
+            x_rows[k] = &x(i + k, 0);
+            y_rows[k] = &y(i + k, 0);
+        }
+
+        T dist[ilp_factor] = {0};
+        for (intptr_t j = 0; j < x.shape[1]; ++j) {
+            for (int k = 0; k < ilp_factor; ++k) {
+                auto val = map(x_rows[k][j * xs], y_rows[k][j * ys]);
+                dist[k] = reduce(dist[k], val);
+            }
+        }
+
+        for (int k = 0; k < ilp_factor; ++k) {
+            out(i + k, 0) = project(dist[k]);
+        }
+    }
+    for (; i < x.shape[0]; ++i) {
+        const T* x_row = &x(i, 0);
+        const T* y_row = &y(i, 0);
+        T dist = 0;
+        for (intptr_t j = 0; j < x.shape[1]; ++j) {
+            auto val = map(x_row[j * xs], y_row[j * ys]);
+            dist = reduce(dist, val);
+        }
+        out(i, 0) = project(dist);
+    }
+}
+
+template <int ilp_factor=2, typename T,
+          typename TransformFunc,
+          typename ProjectFunc=Identity,
+          typename ReduceFunc = std::plus<>>
+void transform_reduce_2d_(
+    StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y,
+    StridedView2D<const T> w, const TransformFunc& map,
+    const ProjectFunc& project = Identity{},
+    const ReduceFunc& reduce = std::plus<>{}) {
+    intptr_t i = 0;
+    intptr_t xs = x.strides[1], ys = y.strides[1], ws = w.strides[1];
+
+    for (; i + (ilp_factor - 1) < x.shape[0]; i += ilp_factor) {
+        const T* x_rows[ilp_factor];
+        const T* y_rows[ilp_factor];
+        const T* w_rows[ilp_factor];
+        for (int k = 0; k < ilp_factor; ++k) {
+            x_rows[k] = &x(i + k, 0);
+            y_rows[k] = &y(i + k, 0);
+            w_rows[k] = &w(i + k, 0);
+        }
+
+        T dist[ilp_factor] = {0};
+        for (intptr_t j = 0; j < x.shape[1]; ++j) {
+            for (int k = 0; k < ilp_factor; ++k) {
+                auto val = map(x_rows[k][j * xs], y_rows[k][j * ys], w_rows[k][j * ws]);
+                dist[k] = reduce(dist[k], val);
+            }
+        }
+
+        for (int k = 0; k < ilp_factor; ++k) {
+            out(i + k, 0) = project(dist[k]);
+        }
+    }
+    for (; i < x.shape[0]; ++i) {
+        const T* x_row = &x(i, 0);
+        const T* y_row = &y(i, 0);
+        const T* w_row = &w(i, 0);
+        T dist = 0;
+        for (intptr_t j = 0; j < x.shape[1]; ++j) {
+            auto val = map(x_row[j * xs], y_row[j * ys], w_row[j * ws]);
+            dist = reduce(dist, val);
+        }
+        out(i, 0) = project(dist);
+    }
+}
+
 struct MinkowskiDistance {
     double p_;
 
     template <typename T>
     void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y) const {
-        T p = p_;
-        for (intptr_t i = 0; i < x.shape[0]; ++i) {
-            T p_dist = 0;
-            for (intptr_t j = 0; j < x.shape[1]; ++j) {
-                auto diff = std::abs(x(i, j) - y(i, j));
-                p_dist += std::pow(diff, p);
-            }
-            out(i, 0) = std::pow(p_dist, 1 / p);
-        }
+        const T p = static_cast<T>(p_);
+        const T invp = static_cast<T>(1.0 / p_);
+        transform_reduce_2d_(out, x, y, [p](T x, T y) {
+            auto diff = std::abs(x - y);
+            return std::pow(diff, p);
+        },
+        [invp](T x) { return std::pow(x, invp); });
     }
 
     template <typename T>
     void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y, StridedView2D<const T> w) const {
-        T p = p_;
-        for (intptr_t i = 0; i < x.shape[0]; ++i) {
-            T p_dist = 0;
-            for (intptr_t j = 0; j < x.shape[1]; ++j) {
-                auto diff = std::abs(x(i, j) - y(i, j));
-                p_dist += w(i, j) * std::pow(diff, p);
-            }
-            out(i, 0) = std::pow(p_dist, 1 / p);
-        }
+        const T p = static_cast<T>(p_);
+        const T invp = static_cast<T>(1.0 / p_);
+        transform_reduce_2d_(out, x, y, w, [p](T x, T y, T w) {
+            auto diff = std::abs(x - y);
+            return w * std::pow(diff, p);
+        },
+        [invp](T x) { return std::pow(x, invp); });
     }
 };
 
 struct EuclideanDistance {
     template <typename T>
     void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y) const {
-        for (intptr_t i = 0; i < x.shape[0]; ++i) {
-            T sqdist = 0;
-            for (intptr_t j = 0; j < x.shape[1]; ++j) {
-                auto diff = std::abs(x(i, j) - y(i, j));
-                sqdist += diff * diff;
-            }
-            out(i, 0) = std::sqrt(sqdist);
-        }
+        transform_reduce_2d_(out, x, y, [](T x, T y) {
+            auto diff = std::abs(x - y);
+            return diff * diff;
+        },
+        [](T x) { return std::sqrt(x); });
     }
 
     template <typename T>
     void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y, StridedView2D<const T> w) const {
-        for (intptr_t i = 0; i < x.shape[0]; ++i) {
-            T sqdist = 0;
-            for (intptr_t j = 0; j < x.shape[1]; ++j) {
-                auto diff = std::abs(x(i, j) - y(i, j));
-                sqdist += w(i, j) * (diff * diff);
-            }
-            out(i, 0) = std::sqrt(sqdist);
-        }
+        transform_reduce_2d_(out, x, y, w, [](T x, T y, T w) {
+            auto diff = std::abs(x - y);
+            return w * (diff * diff);
+        },
+        [](T x) { return std::sqrt(x); });
     }
 };
 
 struct ChebyshevDistance {
     template <typename T>
     void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y) const {
-        for (intptr_t i = 0; i < x.shape[0]; ++i) {
-            T dist = 0;
-            for (intptr_t j = 0; j < x.shape[1]; ++j) {
-                auto diff = std::abs(x(i, j) - y(i, j));
-                if (diff > dist) {
-                    dist = diff;
-                }
-            }
-            out(i, 0) = dist;
-        }
+        transform_reduce_2d_(out, x, y, [](T x, T y) {
+            return std::abs(x - y);
+        },
+        Identity{},
+        [](T x, T y) { return std::max(x, y); });
     }
 
     template <typename T>
@@ -92,37 +174,15 @@ struct ChebyshevDistance {
 struct CityBlockDistance {
     template <typename T>
     void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y) const {
-        if (x.strides[1] == 1 && y.strides[1] == 1) {
-            for (intptr_t i = 0; i < x.shape[0]; ++i) {
-                const T* x_data = x.data + i * x.strides[0];
-                const T* y_data = y.data + i * y.strides[0];
-
-                T dist = 0;
-                for (intptr_t j = 0; j < x.shape[1]; ++j) {
-                    dist += std::abs(x_data[j] - y_data[j]);
-                }
-                out(i, 0) = dist;
-            }
-        } else {
-            for (intptr_t i = 0; i < x.shape[0]; ++i) {
-                T dist = 0;
-                for (intptr_t j = 0; j < x.shape[1]; ++j) {
-                    dist += std::abs(x(i, j) - y(i, j));
-                }
-                out(i, 0) = dist;
-            }
-        }
+        transform_reduce_2d_(out, x, y, [](T x, T y) {
+            return std::abs(x - y);
+        });
     }
 
     template <typename T>
     void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y, StridedView2D<const T> w) const {
-        for (intptr_t i = 0; i < x.shape[0]; ++i) {
-            T dist = 0;
-            for (intptr_t j = 0; j < x.shape[1]; ++j) {
-                auto diff = std::abs(x(i, j) - y(i, j));
-                dist += w(i, j) * diff;
-            }
-            out(i, 0) = dist;
-        }
+        transform_reduce_2d_(out, x, y, w, [](T x, T y, T w) {
+            return w * std::abs(x - y);
+        });
     }
 };

--- a/scipy/spatial/src/distance_metrics.h
+++ b/scipy/spatial/src/distance_metrics.h
@@ -9,9 +9,9 @@ struct MinkowskiDistance {
     template <typename T>
     void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y) const {
         T p = p_;
-        for (int64_t i = 0; i < x.shape[0]; ++i) {
+        for (intptr_t i = 0; i < x.shape[0]; ++i) {
             T p_dist = 0;
-            for (int64_t j = 0; j < x.shape[1]; ++j) {
+            for (intptr_t j = 0; j < x.shape[1]; ++j) {
                 auto diff = std::abs(x(i, j) - y(i, j));
                 p_dist += std::pow(diff, p);
             }
@@ -22,9 +22,9 @@ struct MinkowskiDistance {
     template <typename T>
     void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y, StridedView2D<const T> w) const {
         T p = p_;
-        for (int64_t i = 0; i < x.shape[0]; ++i) {
+        for (intptr_t i = 0; i < x.shape[0]; ++i) {
             T p_dist = 0;
-            for (int64_t j = 0; j < x.shape[1]; ++j) {
+            for (intptr_t j = 0; j < x.shape[1]; ++j) {
                 auto diff = std::abs(x(i, j) - y(i, j));
                 p_dist += w(i, j) * std::pow(diff, p);
             }
@@ -36,9 +36,9 @@ struct MinkowskiDistance {
 struct EuclideanDistance {
     template <typename T>
     void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y) const {
-        for (int64_t i = 0; i < x.shape[0]; ++i) {
+        for (intptr_t i = 0; i < x.shape[0]; ++i) {
             T sqdist = 0;
-            for (int64_t j = 0; j < x.shape[1]; ++j) {
+            for (intptr_t j = 0; j < x.shape[1]; ++j) {
                 auto diff = std::abs(x(i, j) - y(i, j));
                 sqdist += diff * diff;
             }
@@ -48,9 +48,9 @@ struct EuclideanDistance {
 
     template <typename T>
     void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y, StridedView2D<const T> w) const {
-        for (int64_t i = 0; i < x.shape[0]; ++i) {
+        for (intptr_t i = 0; i < x.shape[0]; ++i) {
             T sqdist = 0;
-            for (int64_t j = 0; j < x.shape[1]; ++j) {
+            for (intptr_t j = 0; j < x.shape[1]; ++j) {
                 auto diff = std::abs(x(i, j) - y(i, j));
                 sqdist += w(i, j) * (diff * diff);
             }
@@ -62,9 +62,9 @@ struct EuclideanDistance {
 struct ChebyshevDistance {
     template <typename T>
     void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y) const {
-        for (int64_t i = 0; i < x.shape[0]; ++i) {
+        for (intptr_t i = 0; i < x.shape[0]; ++i) {
             T dist = 0;
-            for (int64_t j = 0; j < x.shape[1]; ++j) {
+            for (intptr_t j = 0; j < x.shape[1]; ++j) {
                 auto diff = std::abs(x(i, j) - y(i, j));
                 if (diff > dist) {
                     dist = diff;
@@ -76,9 +76,9 @@ struct ChebyshevDistance {
 
     template <typename T>
     void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y, StridedView2D<const T> w) const {
-        for (int64_t i = 0; i < x.shape[0]; ++i) {
+        for (intptr_t i = 0; i < x.shape[0]; ++i) {
             T dist = 0;
-            for (int64_t j = 0; j < x.shape[1]; ++j) {
+            for (intptr_t j = 0; j < x.shape[1]; ++j) {
                 auto diff = std::abs(x(i, j) - y(i, j));
                 if (w(i, j) > 0 && diff > dist) {
                     dist = diff;
@@ -93,20 +93,20 @@ struct CityBlockDistance {
     template <typename T>
     void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y) const {
         if (x.strides[1] == 1 && y.strides[1] == 1) {
-            for (int64_t i = 0; i < x.shape[0]; ++i) {
+            for (intptr_t i = 0; i < x.shape[0]; ++i) {
                 const T* x_data = x.data + i * x.strides[0];
                 const T* y_data = y.data + i * y.strides[0];
 
                 T dist = 0;
-                for (int64_t j = 0; j < x.shape[1]; ++j) {
+                for (intptr_t j = 0; j < x.shape[1]; ++j) {
                     dist += std::abs(x_data[j] - y_data[j]);
                 }
                 out(i, 0) = dist;
             }
         } else {
-            for (int64_t i = 0; i < x.shape[0]; ++i) {
+            for (intptr_t i = 0; i < x.shape[0]; ++i) {
                 T dist = 0;
-                for (int64_t j = 0; j < x.shape[1]; ++j) {
+                for (intptr_t j = 0; j < x.shape[1]; ++j) {
                     dist += std::abs(x(i, j) - y(i, j));
                 }
                 out(i, 0) = dist;
@@ -116,9 +116,9 @@ struct CityBlockDistance {
 
     template <typename T>
     void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y, StridedView2D<const T> w) const {
-        for (int64_t i = 0; i < x.shape[0]; ++i) {
+        for (intptr_t i = 0; i < x.shape[0]; ++i) {
             T dist = 0;
-            for (int64_t j = 0; j < x.shape[1]; ++j) {
+            for (intptr_t j = 0; j < x.shape[1]; ++j) {
                 auto diff = std::abs(x(i, j) - y(i, j));
                 dist += w(i, j) * diff;
             }

--- a/scipy/spatial/src/distance_pybind.cpp
+++ b/scipy/spatial/src/distance_pybind.cpp
@@ -343,13 +343,13 @@ py::array cdist_weighted(
 }
 
 py::dtype npy_promote_types(const py::dtype& type1, const py::dtype& type2) {
-    // TODO: Casts away const, but think NumPy API should allow const here?
-    PyArray_Descr* descr = PyArray_PromoteTypes((PyArray_Descr*)type1.ptr(),
-                                                (PyArray_Descr*)type2.ptr());
+    PyArray_Descr* descr = PyArray_PromoteTypes(
+        reinterpret_cast<PyArray_Descr*>(type1.ptr()),
+        reinterpret_cast<PyArray_Descr*>(type2.ptr()));
     if (descr == nullptr) {
         throw py::error_already_set();
     }
-    return py::reinterpret_borrow<py::dtype>((PyObject*) descr);
+    return py::reinterpret_steal<py::dtype>(reinterpret_cast<PyObject*>(descr));
 }
 
 template <typename Container>

--- a/scipy/spatial/src/distance_pybind.cpp
+++ b/scipy/spatial/src/distance_pybind.cpp
@@ -531,6 +531,21 @@ PYBIND11_MODULE(_distance_pybind, m) {
         throw py::error_already_set();
     }
     using namespace pybind11::literals;
+    m.def("pdist_chebyshev",
+          [](py::object x, py::object w, py::object out) {
+              return pdist(out, x, w, ChebyshevDistance{});
+          },
+          "x"_a, "w"_a=py::none(), "out"_a=py::none());
+    m.def("pdist_cityblock",
+          [](py::object x, py::object w, py::object out) {
+              return pdist(out, x, w, CityBlockDistance{});
+          },
+          "x"_a, "w"_a=py::none(), "out"_a=py::none());
+    m.def("pdist_euclidean",
+          [](py::object x, py::object w, py::object out) {
+              return pdist(out, x, w, EuclideanDistance{});
+          },
+          "x"_a, "w"_a=py::none(), "out"_a=py::none());
     m.def("pdist_minkowski",
           [](py::object x, py::object w, py::object out, double p) {
               if (p == 1.0) {
@@ -544,6 +559,21 @@ PYBIND11_MODULE(_distance_pybind, m) {
               }
           },
           "x"_a, "w"_a=py::none(), "out"_a=py::none(), "p"_a=2.0);
+    m.def("cdist_chebyshev",
+          [](py::object x, py::object y, py::object w, py::object out) {
+              return cdist(out, x, y, w, ChebyshevDistance{});
+          },
+          "x"_a, "y"_a, "w"_a=py::none(), "out"_a=py::none());
+    m.def("cdist_cityblock",
+          [](py::object x, py::object y, py::object w, py::object out) {
+              return cdist(out, x, y, w, CityBlockDistance{});
+          },
+          "x"_a, "y"_a, "w"_a=py::none(), "out"_a=py::none());
+    m.def("cdist_euclidean",
+          [](py::object x, py::object y, py::object w, py::object out) {
+              return cdist(out, x, y, w, EuclideanDistance{});
+          },
+          "x"_a, "y"_a, "w"_a=py::none(), "out"_a=py::none());
     m.def("cdist_minkowski",
           [](py::object x, py::object y, py::object w, py::object out,
              double p) {

--- a/scipy/spatial/src/distance_pybind.cpp
+++ b/scipy/spatial/src/distance_pybind.cpp
@@ -1,0 +1,563 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <numpy/arrayobject.h>
+#include <cmath>
+#include <cassert>
+
+#include "function_ref.h"
+#include "views.h"
+#include "distance_metrics.h"
+
+#include <sstream>
+#include <string>
+
+namespace py = pybind11;
+
+namespace {
+
+template <typename T>
+using DistanceFunc = FunctionRef<
+    void(StridedView2D<T>, StridedView2D<const T>, StridedView2D<const T>)>;
+
+template <typename T>
+using WeightedDistanceFunc = FunctionRef<
+    void(StridedView2D<T>, StridedView2D<const T>,
+         StridedView2D<const T>, StridedView2D<const T>)>;
+
+// Validate weights are >= 0
+template <typename T>
+void validate_weights(const ArrayDescriptor& w, const T* w_data) {
+    intptr_t idx[NPY_MAXDIMS] = {0};
+    if (w.ndim > NPY_MAXDIMS) {
+        throw std::invalid_argument("Too many dimensions");
+    }
+
+    intptr_t numiter = 1;
+    for (intptr_t ax = 0; ax < w.ndim - 1; ++ax) {
+        numiter *= w.shape[ax];
+    }
+
+    bool is_valid = true;
+    const T* row_ptr = w_data;
+    const auto inner_size = w.shape[w.ndim - 1];
+    const auto stride = w.strides[w.ndim - 1];
+
+    while (is_valid && numiter > 0) {
+        for (intptr_t i = 0; i < inner_size; ++i) {
+            if (row_ptr[i * stride] < 0) {
+                is_valid = false;
+            }
+        }
+
+        for (intptr_t ax = w.ndim - 2; ax >= 0; --ax) {
+            ++idx[ax];
+            row_ptr += w.strides[ax];
+            if (idx[ax] < w.shape[ax]) {
+                break;
+            }
+            idx[ax] = 0;
+            row_ptr -= w.shape[ax] * w.strides[ax];
+        }
+        --numiter;
+    }
+
+    if (!is_valid) {
+        throw std::invalid_argument("Input weights should be all non-negative");
+    }
+}
+
+template <typename T>
+void pdist_impl(ArrayDescriptor out, T* out_data,
+                ArrayDescriptor x, const T* in_data,
+                DistanceFunc<T> f) {
+    const int64_t num_rows = x.shape[0], num_cols = x.shape[1];
+
+    StridedView2D<T> out_view;
+    out_view.strides = {out.strides[0], 0};
+    out_view.shape = {x.shape[0] - 1, x.shape[1]};
+    out_view.data = out_data;
+
+    StridedView2D<const T> x_view;
+    x_view.strides = {x.strides[0], x.strides[1]};
+    x_view.shape = {out_view.shape[0], num_cols};
+    x_view.data = in_data + x.strides[0];
+
+    StridedView2D<const T> y_view;
+    y_view.strides = {0, x.strides[1]};
+    y_view.shape = {out_view.shape[0], num_cols};
+    y_view.data = in_data;
+
+    for (int64_t i = 0; i < num_rows - 1; ++i) {
+        f(out_view, x_view, y_view);
+
+        out_view.data += out_view.shape[0] * out_view.strides[0];
+        out_view.shape[0] -= 1;
+        x_view.shape[0] = y_view.shape[0] = out_view.shape[0];
+        x_view.data += x.strides[0];
+        y_view.data += x.strides[0];
+    }
+}
+
+template <typename T>
+void pdist_weighted_impl(ArrayDescriptor out, T* out_data,
+                         ArrayDescriptor x, const T* x_data,
+                         ArrayDescriptor w, const T* w_data,
+                         WeightedDistanceFunc<T> f) {
+    if (x.ndim != 2) {
+        throw std::invalid_argument("x must be 2-dimensional");
+    }
+
+    const int64_t num_rows = x.shape[0], num_cols = x.shape[1];
+
+    StridedView2D<T> out_view;
+    out_view.strides = {out.strides[0], 0};
+    out_view.shape = {x.shape[0] - 1, x.shape[1]};
+    out_view.data = out_data;
+
+    StridedView2D<const T> w_view;
+    w_view.strides = {0, w.strides[0]};
+    w_view.data = w_data;
+
+    StridedView2D<const T> x_view;
+    x_view.strides = {x.strides[0], x.strides[1]};
+    x_view.shape = out_view.shape;
+    x_view.data = x_data + x.strides[0];
+
+    StridedView2D<const T> y_view;
+    y_view.strides = {0, x.strides[1]};
+    y_view.shape = out_view.shape;
+    y_view.data = x_data;
+
+    for (int64_t i = 0; i < num_rows - 1; ++i) {
+        f(out_view, x_view, y_view, w_view);
+
+        out_view.data += out_view.shape[0] * out_view.strides[0];
+        out_view.shape[0] -= 1;
+        x_view.shape[0] = y_view.shape[0] = w_view.shape[0] = out_view.shape[0];
+        x_view.data += x.strides[0];
+        y_view.data += x.strides[0];
+    }
+}
+
+template <typename T>
+void cdist_impl(ArrayDescriptor out, T* out_data,
+                ArrayDescriptor x, const T* x_data,
+                ArrayDescriptor y, const T* y_data,
+                DistanceFunc<T> f) {
+
+    const auto num_rowsX = x.shape[0];
+    const auto num_rowsY = y.shape[0];
+    const auto num_cols = x.shape[1];
+
+    StridedView2D<T> out_view;
+    out_view.strides = {out.strides[1], 0};
+    out_view.shape = {num_rowsY, num_cols};
+    out_view.data = out_data;
+
+    StridedView2D<const T> x_view;
+    x_view.strides = {0, x.strides[1]};
+    x_view.shape = {num_rowsY, num_cols};
+    x_view.data = x_data;
+
+    StridedView2D<const T> y_view;
+    y_view.strides = {y.strides[0], y.strides[1]};
+    y_view.shape = {out_view.shape[0], num_cols};
+    y_view.data = y_data;
+
+    for (int64_t i = 0; i < num_rowsX; ++i) {
+        f(out_view, x_view, y_view);
+
+        out_view.data += out.strides[0];
+        x_view.data += x.strides[0];
+    }
+}
+
+template <typename T>
+void cdist_weighted_impl(ArrayDescriptor out, T* out_data,
+                         ArrayDescriptor x, const T* x_data,
+                         ArrayDescriptor y, const T* y_data,
+                         ArrayDescriptor w, const T* w_data,
+                         WeightedDistanceFunc<T> f) {
+
+    const auto num_rowsX = x.shape[0];
+    const auto num_rowsY = y.shape[0];
+    const auto num_cols = x.shape[1];
+
+    StridedView2D<T> out_view;
+    out_view.strides = {out.strides[1], 0};
+    out_view.shape = {num_rowsY, num_cols};
+    out_view.data = out_data;
+
+    StridedView2D<const T> x_view;
+    x_view.strides = {0, x.strides[1]};
+    x_view.shape = {num_rowsY, num_cols};
+    x_view.data = x_data;
+
+    StridedView2D<const T> y_view;
+    y_view.strides = {y.strides[0], y.strides[1]};
+    y_view.shape = {num_rowsY, num_cols};
+    y_view.data = y_data;
+
+    StridedView2D<const T> w_view;
+    w_view.strides = {0, w.strides[0]};
+    w_view.shape = {num_rowsY, num_cols};
+    w_view.data = w_data;
+
+    for (int64_t i = 0; i < num_rowsX; ++i) {
+        f(out_view, x_view, y_view, w_view);
+
+        out_view.data += out.strides[0];
+        x_view.data += x.strides[0];
+    }
+}
+
+ArrayDescriptor get_descriptor(const py::array& arr) {
+    const auto ndim = arr.ndim();
+    ArrayDescriptor desc(ndim);
+
+    const auto arr_shape = arr.shape();
+    desc.shape.assign(arr_shape, arr_shape + ndim);
+
+    desc.element_size = arr.itemsize();
+    const auto arr_strides = arr.strides();
+    desc.strides.assign(arr_strides, arr_strides + ndim);
+    for (int64_t i = 0; i < ndim; ++i) {
+        if (desc.strides[i] % desc.element_size != 0) {
+            throw std::runtime_error("Arrays must be aligned");
+        }
+        desc.strides[i] /= desc.element_size;
+    }
+    return desc;
+}
+
+template <typename T>
+py::array_t<T> npy_asarray(const py::handle& obj, int flags = 0) {
+    auto descr = reinterpret_cast<PyArray_Descr*>(
+        py::dtype::of<T>().release().ptr());
+    auto* arr = PyArray_FromAny(obj.ptr(), descr, 0, 0, flags, nullptr);
+    if (arr == nullptr) {
+        throw py::error_already_set();
+    }
+    return py::reinterpret_borrow<py::array_t<T>>(arr);
+}
+
+py::array npy_asarray(const py::handle& obj, int flags = 0) {
+    auto* arr = PyArray_FromAny(obj.ptr(), nullptr, 0, 0, flags, nullptr);
+    if (arr == nullptr) {
+        throw py::error_already_set();
+    }
+    return py::reinterpret_borrow<py::array>(arr);
+}
+
+template <typename scalar_t>
+py::array pdist_unweighted(const py::array& out_obj, const py::array& x_obj,
+                           DistanceFunc<scalar_t> f) {
+    auto x = npy_asarray<scalar_t>(x_obj,
+                                   NPY_ARRAY_ALIGNED | NPY_ARRAY_NOTSWAPPED);
+    auto out = py::cast<py::array_t<scalar_t>>(out_obj);
+    auto out_desc = get_descriptor(out);
+    auto out_data = out.mutable_data();
+    auto x_desc = get_descriptor(x);
+    auto x_data = x.data();
+    {
+        py::gil_scoped_release guard;
+        pdist_impl(out_desc, out_data, x_desc, x_data, f);
+    }
+    return out;
+}
+
+template <typename scalar_t>
+py::array pdist_weighted(
+        const py::array& out_obj, const py::array& x_obj,
+        const py::array& w_obj, WeightedDistanceFunc<scalar_t> f) {
+    auto x = npy_asarray<scalar_t>(x_obj,
+                                   NPY_ARRAY_ALIGNED | NPY_ARRAY_NOTSWAPPED);
+    auto w = npy_asarray<scalar_t>(w_obj,
+                                   NPY_ARRAY_ALIGNED | NPY_ARRAY_NOTSWAPPED);
+    auto out = py::cast<py::array_t<scalar_t>>(out_obj);
+    auto out_desc = get_descriptor(out);
+    auto out_data = out.mutable_data();
+    auto x_desc = get_descriptor(x);
+    auto x_data = x.data();
+    auto w_desc = get_descriptor(w);
+    auto w_data = w.data();
+    {
+        py::gil_scoped_release guard;
+        validate_weights(w_desc, w_data);
+        pdist_weighted_impl(
+            out_desc, out_data, x_desc, x_data, w_desc, w_data, f);
+    }
+    return out;
+}
+
+template <typename scalar_t>
+py::array cdist_unweighted(const py::array& out_obj, const py::array& x_obj,
+                           const py::array& y_obj, DistanceFunc<scalar_t> f) {
+    auto x = npy_asarray<scalar_t>(x_obj,
+                                 NPY_ARRAY_ALIGNED | NPY_ARRAY_NOTSWAPPED);
+    auto y = npy_asarray<scalar_t>(y_obj,
+                                 NPY_ARRAY_ALIGNED | NPY_ARRAY_NOTSWAPPED);
+    auto out = py::cast<py::array_t<scalar_t>>(out_obj);
+
+    auto out_desc = get_descriptor(out);
+    auto out_data = out.mutable_data();
+    auto x_desc = get_descriptor(x);
+    auto x_data = x.data();
+    auto y_desc = get_descriptor(y);
+    auto y_data = y.data();
+    {
+        py::gil_scoped_release guard;
+        cdist_impl(out_desc, out_data, x_desc, x_data, y_desc, y_data, f);
+    }
+    return out;
+}
+
+template <typename scalar_t>
+py::array cdist_weighted(
+        const py::array& out_obj, const py::array& x_obj,
+        const py::array& y_obj, const py::array& w_obj,
+        WeightedDistanceFunc<scalar_t> f) {
+    auto x = npy_asarray<scalar_t>(x_obj,
+                                 NPY_ARRAY_ALIGNED | NPY_ARRAY_NOTSWAPPED);
+    auto y = npy_asarray<scalar_t>(y_obj,
+                                 NPY_ARRAY_ALIGNED | NPY_ARRAY_NOTSWAPPED);
+    auto w = npy_asarray<scalar_t>(w_obj,
+                                 NPY_ARRAY_ALIGNED | NPY_ARRAY_NOTSWAPPED);
+    auto out = py::cast<py::array_t<scalar_t>>(out_obj);
+
+    auto out_desc = get_descriptor(out);
+    auto out_data = out.mutable_data();
+    auto x_desc = get_descriptor(x);
+    auto x_data = x.data();
+    auto y_desc = get_descriptor(y);
+    auto y_data = y.data();
+    auto w_desc = get_descriptor(w);
+    auto w_data = w.data();
+    {
+        py::gil_scoped_release guard;
+        validate_weights(w_desc, w_data);
+        cdist_weighted_impl(
+            out_desc, out_data, x_desc, x_data, y_desc, y_data, w_desc, w_data, f);
+    }
+    return out;
+}
+
+py::dtype npy_promote_types(const py::dtype& type1, const py::dtype& type2) {
+    // TODO: Casts away const, but think NumPy API should allow const here?
+    PyArray_Descr* descr = PyArray_PromoteTypes((PyArray_Descr*)type1.ptr(),
+                                                (PyArray_Descr*)type2.ptr());
+    if (descr == nullptr) {
+        throw py::error_already_set();
+    }
+    return py::reinterpret_borrow<py::dtype>((PyObject*) descr);
+}
+
+template <typename Container>
+py::array prepare_out_argument(const py::object& obj, const py::dtype& dtype,
+                               const Container& out_shape) {
+    if (obj.is_none()) {
+        return py::array(dtype, out_shape);
+    }
+
+    if (!py::isinstance<py::array>(obj)) {
+        throw py::type_error("out argument must be an ndarray");
+    }
+
+    py::array out = py::cast<py::array>(obj);
+    const auto ndim = out.ndim();
+    const auto shape = out.shape();
+
+    if (ndim != out_shape.size() ||
+        !std::equal(shape, shape + ndim, out_shape.begin())) {
+        throw std::invalid_argument("Output array has incorrect shape.");
+    }
+    if (out.dtype().not_equal(dtype)) {
+        const py::handle& handle = dtype;
+        throw std::invalid_argument("wrong out dtype, expected " +
+                                    std::string(py::str(handle)));
+    }
+    auto pao = reinterpret_cast<PyArrayObject*>(out.ptr());
+    if (!PyArray_ISBEHAVED(pao)) {
+        throw std::invalid_argument(
+            "out array must be aligned, writable and native byte order");
+    }
+    return out;
+}
+
+py::array prepare_single_weight(const py::object& obj, int64_t len) {
+    py::array weight = npy_asarray(obj);
+    if (weight.ndim() != 1) {
+        throw std::invalid_argument("Weights must be a vector (ndim = 1)");
+    } else if (weight.shape(0) != len) {
+        std::stringstream msg;
+        msg << "Weights must have same size as input vector. ";
+        msg << weight.shape(0) << " vs. " << len << ".";
+        throw std::invalid_argument(msg.str());
+    }
+    return weight;
+}
+
+py::dtype common_type(py::dtype type) {
+    return std::move(type);
+}
+
+template <typename... Args>
+py::dtype common_type(const py::dtype& type1, const py::dtype& type2,
+                      const Args&... tail) {
+    return common_type(npy_promote_types(type1, type2), tail...);
+}
+
+int dtype_num(const py::dtype& dtype) {
+    return reinterpret_cast<const PyArray_Descr*>(
+        dtype.ptr())->type_num;
+}
+
+py::dtype promote_type_real(const py::dtype& dtype) {
+    switch (dtype.kind()) {
+    case 'b':
+    case 'i':
+    case 'u': {
+        // Promote integral and boolean types to double
+        return py::dtype::template of<double>();
+    }
+    case 'f': {
+        if (dtype_num(dtype) == NPY_LONGDOUBLE) {
+            return dtype;
+        } else {
+            // TODO: Allow float32 output
+            return py::dtype::template of<double>();
+        }
+    }
+
+    default: {
+        return dtype;
+    }
+    }
+}
+
+#define DISPATCH_DTYPE(dtype, func)                                     \
+    do {                                                                \
+        const py::dtype& type_obj = dtype;                              \
+        switch (dtype_num(type_obj)) {                                  \
+        case NPY_HALF:                                                  \
+        case NPY_FLOAT: /* TODO: Enable scalar_t=float dispatch */      \
+        case NPY_DOUBLE: {                                              \
+            using scalar_t = double;                                    \
+            func();                                                     \
+            break;                                                      \
+        }                                                               \
+        case NPY_LONGDOUBLE: {                                          \
+            using scalar_t = long double;                               \
+            func();                                                     \
+            break;                                                      \
+        }                                                               \
+        default: {                                                      \
+            const py::handle& handle = type_obj;                        \
+            throw std::invalid_argument(                                \
+                "Unsupported dtype " + std::string(py::str(handle)));   \
+        }                                                               \
+        }                                                               \
+    } while (0)
+
+template <typename Func>
+py::array pdist(const py::object& out_obj, const py::object& x_obj,
+                const py::object& w_obj, Func&& f) {
+    auto x = npy_asarray(x_obj);
+    if (x.ndim() != 2) {
+        throw std::invalid_argument("x must be 2-dimensional");
+    }
+
+    const int64_t m = x.shape(1);
+    const int64_t n = x.shape(0);
+    std::array<int64_t, 1> out_shape{{(n * (n - 1)) / 2}};
+    if (w_obj.is_none()) {
+        auto dtype = promote_type_real(x.dtype());
+        auto out = prepare_out_argument(out_obj, dtype, out_shape);
+        DISPATCH_DTYPE(dtype, [&]{
+            pdist_unweighted<scalar_t>(out, x, f);
+        });
+        return out;
+    }
+
+    auto w = prepare_single_weight(w_obj, m);
+    auto dtype = promote_type_real(common_type(x.dtype(), w.dtype()));
+    auto out = prepare_out_argument(out_obj, dtype, out_shape);
+    DISPATCH_DTYPE(dtype, [&]{
+        pdist_weighted<scalar_t>(out, x, w, f);
+    });
+    return out;
+}
+
+template <typename Func>
+py::array cdist(const py::object& out_obj, const py::object& x_obj,
+                const py::object& y_obj, const py::object& w_obj, Func&& f) {
+    auto x = npy_asarray(x_obj);
+    auto y = npy_asarray(y_obj);
+    if (x.ndim() != 2) {
+        throw std::invalid_argument("XA must be a 2-dimensional array.");
+    }
+    if (y.ndim() != 2) {
+        throw std::invalid_argument("XB must be a 2-dimensional array.");
+    }
+    const int64_t m = x.shape(1);
+    if (m != y.shape(1)) {
+        throw std::invalid_argument(
+            "XA and XB must have the same number of columns "
+            "(i.e. feature dimension).");
+    }
+
+    std::array<int64_t, 2> out_shape{{x.shape(0), y.shape(0)}};
+    if (w_obj.is_none()) {
+        auto dtype = promote_type_real(common_type(x.dtype(), y.dtype()));
+        auto out = prepare_out_argument(out_obj, dtype, out_shape);
+        DISPATCH_DTYPE(dtype, [&]{
+            cdist_unweighted<scalar_t>(out, x, y, f);
+        });
+        return out;
+    }
+
+    auto w = prepare_single_weight(w_obj, m);
+    auto dtype = promote_type_real(
+        common_type(x.dtype(), y.dtype(), w.dtype()));
+    auto out = prepare_out_argument(out_obj, dtype, out_shape);
+    DISPATCH_DTYPE(dtype, [&]{
+        cdist_weighted<scalar_t>(out, x, y, w, f);
+    });
+    return out;
+}
+
+PYBIND11_MODULE(_distance_pybind, m) {
+    if (_import_array() != 0) {
+        throw py::error_already_set();
+    }
+    using namespace pybind11::literals;
+    m.def("pdist_minkowski",
+          [](py::object x, py::object w, py::object out, double p) {
+              if (p == 1.0) {
+                  return pdist(out, x, w, CityBlockDistance{});
+              } else if (p == 2.0) {
+                  return pdist(out, x, w, EuclideanDistance{});
+              } else if (std::isinf(p)) {
+                  return pdist(out, x, w, ChebyshevDistance{});
+              } else {
+                  return pdist(out, x, w, MinkowskiDistance{p});
+              }
+          },
+          "x"_a, "w"_a=py::none(), "out"_a=py::none(), "p"_a=2.0);
+    m.def("cdist_minkowski",
+          [](py::object x, py::object y, py::object w, py::object out,
+             double p) {
+              if (p == 1.0) {
+                  return cdist(out, x, y, w, CityBlockDistance{});
+              } else if (p == 2.0) {
+                  return cdist(out, x, y, w, EuclideanDistance{});
+              } else if (std::isinf(p)) {
+                  return cdist(out, x, y, w, ChebyshevDistance{});
+              } else {
+                  return cdist(out, x, y, w, MinkowskiDistance{p});
+              }
+          },
+          "x"_a, "y"_a, "w"_a=py::none(), "out"_a=py::none(), "p"_a=2.0);
+}
+
+}  // namespace (anonymous)

--- a/scipy/spatial/src/distance_pybind.cpp
+++ b/scipy/spatial/src/distance_pybind.cpp
@@ -438,7 +438,8 @@ py::dtype promote_type_real(const py::dtype& dtype) {
     }
 }
 
-#define DISPATCH_DTYPE(dtype, func)                                     \
+// From a NumPy dtype, run "expression" with scalar_t aliasing the C++ type
+#define DISPATCH_DTYPE(dtype, expression)                               \
     do {                                                                \
         const py::dtype& type_obj = dtype;                              \
         switch (dtype_num(type_obj)) {                                  \
@@ -446,12 +447,12 @@ py::dtype promote_type_real(const py::dtype& dtype) {
         case NPY_FLOAT: /* TODO: Enable scalar_t=float dispatch */      \
         case NPY_DOUBLE: {                                              \
             using scalar_t = double;                                    \
-            func();                                                     \
+            expression();                                               \
             break;                                                      \
         }                                                               \
         case NPY_LONGDOUBLE: {                                          \
             using scalar_t = long double;                               \
-            func();                                                     \
+            expression();                                               \
             break;                                                      \
         }                                                               \
         default: {                                                      \

--- a/scipy/spatial/src/function_ref.h
+++ b/scipy/spatial/src/function_ref.h
@@ -1,0 +1,41 @@
+#pragma once
+#include <type_traits>
+
+// Type-erased reference to a function object.
+template <class Signature>
+class FunctionRef;
+
+template <class Ret, class... Args>
+class FunctionRef<Ret(Args...)> {
+public:
+    template <class FunctionObject,
+        typename std::enable_if<  // Don't disable the default copy constructor
+            !std::is_same<typename std::decay<FunctionObject>::type, FunctionRef>::value,
+        int>::type = 0
+    >
+    FunctionRef(FunctionObject && a_FunctionObject) {
+        data_ = &a_FunctionObject;
+        call_function_ = &ObjectFunctionCaller<FunctionObject>;
+    }
+
+    Ret operator () (Args... args) {
+        return call_function_(data_, std::forward<Args>(args)...);
+    }
+
+private:
+
+    template <class ObjectType>
+    static Ret ObjectFunctionCaller(void * callable, Args...  args) {
+        // Convert opaque reference to the concrete type.
+        using ObjectPtr = typename std::add_pointer<ObjectType>::type;
+        auto & Object = *static_cast<ObjectPtr>(callable);
+
+        // Forward the call down to the object.
+        return Object(std::forward<Args>(args)...);
+    }
+
+    using CallFunction = Ret(*)(void *, Args...);
+
+    void* data_;
+    CallFunction call_function_;
+};

--- a/scipy/spatial/src/views.h
+++ b/scipy/spatial/src/views.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <vector>
+#include <array>
+#include <cstdint>
+
+struct ArrayDescriptor {
+    ArrayDescriptor(int64_t ndim):
+        ndim(ndim), shape(ndim, 1), strides(ndim, 0) {
+    }
+
+    int64_t ndim;
+    int64_t element_size;
+    std::vector<int64_t> shape, strides;
+};
+
+template <typename T>
+struct StridedView2D {
+    std::array<int64_t, 2> shape;
+    std::array<int64_t, 2> strides;
+    T* data;
+
+    T& operator()(int64_t i, int64_t j) {
+        return data[i * strides[0] + j * strides[1]];
+    }
+};

--- a/scipy/spatial/src/views.h
+++ b/scipy/spatial/src/views.h
@@ -5,22 +5,22 @@
 #include <cstdint>
 
 struct ArrayDescriptor {
-    ArrayDescriptor(int64_t ndim):
+    ArrayDescriptor(intptr_t ndim):
         ndim(ndim), shape(ndim, 1), strides(ndim, 0) {
     }
 
-    int64_t ndim;
-    int64_t element_size;
-    std::vector<int64_t> shape, strides;
+    intptr_t ndim;
+    intptr_t element_size;
+    std::vector<intptr_t> shape, strides;
 };
 
 template <typename T>
 struct StridedView2D {
-    std::array<int64_t, 2> shape;
-    std::array<int64_t, 2> strides;
+    std::array<intptr_t, 2> shape;
+    std::array<intptr_t, 2> strides;
     T* data;
 
-    T& operator()(int64_t i, int64_t j) {
+    T& operator()(intptr_t i, intptr_t j) {
         return data[i * strides[0] + j * strides[1]];
     }
 };

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -110,21 +110,6 @@ _ytdist = squareform(_tdist)
 eo = {}
 
 
-# if enabled, equivalent to pytest.raises otherwise is a no-op
-class RaisesIf:
-    def __init__(self, enabled, *args, **kwargs):
-        self.enabled = enabled
-        self.context = pytest.raises(*args, **kwargs)
-
-    def __enter__(self):
-        if self.enabled:
-            self.context.__enter__()
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        if self.enabled:
-            return self.context.__exit__(exc_type, exc_val, exc_tb)
-
-
 def load_testing_files():
     for fn in _filenames:
         name = fn.replace(".txt", "").replace("-ml", "")
@@ -623,19 +608,11 @@ class TestCdist:
                 # test for C-contiguous order
                 out3 = np.empty(
                     (2 * out_r, 2 * out_c), dtype=np.double)[::2, ::2]
-                output_contiguous = _METRICS[metric].requires_contiguous_out
-                with RaisesIf(output_contiguous, ValueError,
-                              match="Output array must be C-contiguous"):
-                    Y3 = cdist(X1, X2, metric, out=out3, **kwargs)
-                    assert Y3 is out3
-                    _assert_within_tol(Y1, Y3, eps, verbose > 2)
-
                 out4 = np.empty((out_r, out_c), dtype=np.double, order='F')
-                with RaisesIf(output_contiguous, ValueError,
-                              match="Output array must be C-contiguous"):
-                    Y4 = cdist(X1, X2, metric, out=out4, **kwargs)
-                    assert Y4 is out4
-                    _assert_within_tol(Y1, Y4, eps, verbose > 2)
+                assert_raises(ValueError,
+                              cdist, X1, X2, metric, out=out3, **kwargs)
+                assert_raises(ValueError,
+                              cdist, X1, X2, metric, out=out4, **kwargs)
 
                 # test for incorrect dtype
                 out5 = np.empty((out_r, out_c), dtype=np.int64)
@@ -1515,13 +1492,7 @@ class TestPdist:
                 assert_raises(ValueError, pdist, X, metric, out=out2, **kwargs)
                 # test for (C-)contiguous output
                 out3 = np.empty(2 * out_size, dtype=np.double)[::2]
-                output_contiguous = _METRICS[metric].requires_contiguous_out
-                with RaisesIf(output_contiguous, ValueError,
-                              match="Output array must be C-contiguous"):
-                    Y_test3 = pdist(X, metric, out=out3, **kwargs)
-                    assert Y_test3 is out3
-                    _assert_within_tol(Y_right, Y_test3, eps, verbose > 2)
-
+                assert_raises(ValueError, pdist, X, metric, out=out3, **kwargs)
                 # test for incorrect dtype
                 out5 = np.empty(out_size, dtype=np.int64)
                 assert_raises(ValueError, pdist, X, metric, out=out5, **kwargs)


### PR DESCRIPTION
#### Reference issue
https://github.com/scipy/scipy/issues/13629#issuecomment-790831819

#### What does this implement/fix?
This implements a framework for `pdist` and `cdist` in C++ using pybind11 and demonstrates it with `minkowski` and related metrics (`chebyshev`, `cityblock` and `euclidean`).  The code supports weights, strided arrays, out arguments, type promotion and also adds `long double` support.

While there's a lot of new code here, most of it is metric-independant. To add a new metric, you only need to do 3 things:
1. Create a class in `distance_metrics.h` that implements the metric with and without weights.
2. Register `pdist` and `cdist` bindings in `distance_pybind.cpp`, e.g.
```cpp
    m.def("pdist_euclidean",
          [](py::object x, py::object w, py::object out) {
              return pdist(out, x, w, EuclideanDistance{});
          },
          "x"_a, "w"_a=py::none(), "out"_a=py::none());
```
3. Update the `MetricInfo` object in `distance.py`


#### Benchmark results

All metrics changed here have improved in performance. Both in terms of fixed overhead and in terms of calculation time. Weighted metrics in particular show 1000x speedup on large inputs, going from milliseconds to microseconds.

```
       before           after         ratio
     [9acb9368]       [8f10dc4f]
     <master>         <distance-rework>
-        47.2±2μs       44.6±0.3μs     0.95  spatial.Xdist.time_cdist(10, 'mahalanobis')
-     1.82±0.03ms      1.73±0.03ms     0.95  spatial.XdistWeighted.time_cdist(10, 'sokalsneath')
-      23.9±0.1μs       22.4±0.3μs     0.93  spatial.Xdist.time_cdist(100, 'euclidean')
-         164±7ms        153±0.6ms     0.93  spatial.XdistWeighted.time_cdist(100, 'canberra')
-      24.2±0.2μs       22.4±0.2μs     0.93  spatial.Xdist.time_cdist(100, 'minkowski')
-         658±4μs          606±1μs     0.92  spatial.Xdist.time_pdist(1000, 'cityblock')
-        1.30±0ms      1.18±0.02ms     0.91  spatial.Xdist.time_cdist(1000, 'cityblock')
-      11.6±0.1μs       10.4±0.1μs     0.89  spatial.Xdist.time_pdist(100, 'chebyshev')
-      19.9±0.1μs      17.5±0.02μs     0.88  spatial.Xdist.time_cdist(100, 'chebyshev')
-      10.4±0.1μs      8.73±0.02μs     0.84  spatial.Xdist.time_pdist(100, 'cityblock')
-      17.8±0.1μs      14.6±0.09μs     0.82  spatial.Xdist.time_cdist(100, 'cityblock')
-      29.6±0.3μs      22.6±0.03μs     0.76  spatial.XdistWeighted.time_cdist(20, 'minkowski-P3')
-     20.7±0.09μs       15.3±0.2μs     0.74  spatial.XdistWeighted.time_pdist(100, 'chebyshev')
-      36.2±0.3μs      26.5±0.09μs     0.73  spatial.XdistWeighted.time_cdist(100, 'chebyshev')
-     9.88±0.02μs       6.88±0.1μs     0.70  spatial.Xdist.time_cdist(10, 'minkowski-P3')
-     6.60±0.09μs      4.42±0.06μs     0.67  spatial.Xdist.time_pdist(10, 'minkowski-P3')
-      19.2±0.4μs       12.5±0.1μs     0.65  spatial.XdistWeighted.time_pdist(20, 'minkowski-P3')
-     3.78±0.04μs      2.02±0.01μs     0.54  spatial.Xdist.time_pdist(10, 'euclidean')
-     3.76±0.02μs      1.95±0.01μs     0.52  spatial.Xdist.time_pdist(10, 'cityblock')
-     3.83±0.06μs      1.98±0.02μs     0.52  spatial.Xdist.time_pdist(10, 'chebyshev')
-     4.04±0.01μs      2.07±0.02μs     0.51  spatial.Xdist.time_pdist(10, 'minkowski')
-     14.5±0.05μs      7.33±0.02μs     0.50  spatial.XdistWeighted.time_cdist(10, 'minkowski-P3')
-     4.64±0.01μs      2.20±0.04μs     0.47  spatial.Xdist.time_cdist(10, 'euclidean')
-     5.01±0.01μs      2.23±0.02μs     0.44  spatial.Xdist.time_cdist(10, 'minkowski')
-     4.75±0.01μs         2.09±0μs     0.44  spatial.Xdist.time_cdist(10, 'chebyshev')
-     4.70±0.04μs      2.05±0.02μs     0.44  spatial.Xdist.time_cdist(10, 'cityblock')
-      11.6±0.1μs      4.83±0.04μs     0.42  spatial.XdistWeighted.time_pdist(10, 'minkowski-P3')
-     10.5±0.04μs      3.50±0.03μs     0.33  spatial.XdistWeighted.time_cdist(20, 'chebyshev')
-     9.26±0.03μs      2.98±0.06μs     0.32  spatial.XdistWeighted.time_pdist(20, 'chebyshev')
-     8.82±0.02μs      2.37±0.03μs     0.27  spatial.XdistWeighted.time_pdist(10, 'chebyshev')
-     9.76±0.01μs      2.55±0.02μs     0.26  spatial.XdistWeighted.time_cdist(10, 'chebyshev')
-     11.3±0.04μs      2.46±0.01μs     0.22  spatial.XdistWeighted.time_pdist(10, 'minkowski')
-     14.4±0.03μs      2.67±0.01μs     0.19  spatial.XdistWeighted.time_cdist(10, 'minkowski')
-     18.6±0.05μs      3.08±0.02μs     0.17  spatial.XdistWeighted.time_pdist(20, 'minkowski')
-      28.4±0.1μs      3.67±0.02μs     0.13  spatial.XdistWeighted.time_cdist(20, 'minkowski')
-       257±0.5μs       15.6±0.2μs     0.06  spatial.XdistWeighted.time_pdist(100, 'minkowski')
-         499±3μs      27.6±0.04μs     0.06  spatial.XdistWeighted.time_cdist(100, 'minkowski')
-       320±0.8μs      2.37±0.04μs     0.01  spatial.XdistWeighted.time_pdist(10, 'cityblock')
-        404±10μs      2.42±0.04μs     0.01  spatial.XdistWeighted.time_pdist(10, 'euclidean')
-         698±4μs      2.53±0.02μs     0.00  spatial.XdistWeighted.time_cdist(10, 'cityblock')
-         855±7μs      2.62±0.01μs     0.00  spatial.XdistWeighted.time_cdist(10, 'euclidean')
-     1.29±0.01ms      2.92±0.01μs     0.00  spatial.XdistWeighted.time_pdist(20, 'cityblock')
-     1.58±0.01ms      3.08±0.01μs     0.00  spatial.XdistWeighted.time_pdist(20, 'euclidean')
-     2.76±0.02ms      3.38±0.03μs     0.00  spatial.XdistWeighted.time_cdist(20, 'cityblock')
-     3.40±0.05ms      3.64±0.01μs     0.00  spatial.XdistWeighted.time_cdist(20, 'euclidean')
-     32.8±0.07ms      13.1±0.02μs     0.00  spatial.XdistWeighted.time_pdist(100, 'cityblock')
-      40.5±0.3ms      15.4±0.07μs     0.00  spatial.XdistWeighted.time_pdist(100, 'euclidean')
-      84.2±0.1ms      27.5±0.07μs     0.00  spatial.XdistWeighted.time_cdist(100, 'euclidean')
-      68.2±0.3ms      22.2±0.04μs     0.00  spatial.XdistWeighted.time_cdist(100, 'cityblock')

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
```
