### PR TITLE
DOC: update Readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,7 @@ first issue" may be a good starting point.Have a look at `our contributing
 guide <http://scipy.github.io/devdocs/dev/hacking.html>`__.
 
 Writing code isn’t the only way to contribute to SciPy. You can also:
+
 - review pull requests
 - triage issues
 - develop tutorials, presentations, and other educational materials

--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,9 @@ SciPy
 .. image:: https://img.shields.io/badge/stackoverflow-Ask%20questions-blue.svg
   :target: https://stackoverflow.com/questions/tagged/scipy
 
+.. image:: https://img.shields.io/badge/DOI-10.1038%2Fs41592--019--0686--2-blue
+  :target: https://www.nature.com/articles/s41592-019-0686-2
+
 SciPy (pronounced "Sigh Pie") is an open-source software for mathematics,
 science, and engineering. It includes modules for statistics, optimization,
 integration, linear algebra, Fourier transforms, signal and image processing,

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
+.. image:: doc/source/_static/scipyshiny_small.png
+  :target: https://docs.scipy.org/doc/scipy/reference/
+
 SciPy
 =====
-
-.. image:: https://img.shields.io/travis/scipy/scipy/master.svg?label=Travis%20CI
-   :target: https://travis-ci.org/scipy/scipy/
 
 .. image:: https://img.shields.io/circleci/project/github/scipy/scipy/master.svg?label=CircleCI
   :target: https://circleci.com/gh/scipy/scipy
@@ -22,18 +22,23 @@ SciPy
 .. image:: https://codecov.io/gh/scipy/scipy/branch/master/graph/badge.svg
   :target: https://codecov.io/gh/scipy/scipy
 
-SciPy (pronounced "Sigh Pie") is open-source software for mathematics,
+.. image:: https://img.shields.io/badge/stackoverflow-Ask%20questions-blue.svg
+  :target: https://stackoverflow.com/questions/tagged/scipy
+
+SciPy (pronounced "Sigh Pie") is an open-source software for mathematics,
 science, and engineering. It includes modules for statistics, optimization,
 integration, linear algebra, Fourier transforms, signal and image processing,
 ODE solvers, and more.
 
-- **Website:** https://www.scipy.org/
+- **Website:** https://docs.scipy.org/doc/scipy/reference/
 - **Documentation:** https://docs.scipy.org/
 - **Mailing list:** https://scipy.org/scipylib/mailing-lists.html
 - **Source code:** https://github.com/scipy/scipy
+- **Contributing:** https://scipy.github.io/devdocs/dev/index.html
 - **Bug reports:** https://github.com/scipy/scipy/issues
 - **Code of Conduct:** https://scipy.github.io/devdocs/dev/conduct/code_of_conduct.html
 - **Report a security vulnerability:** https://tidelift.com/docs/security
+- **Citing in your work:** https://www.scipy.org/citing.html
 
 SciPy depends on NumPy, which provides convenient and fast
 N-dimensional array manipulation. SciPy is built to work with
@@ -47,9 +52,41 @@ SciPy a try!
 
 For the installation instructions, see INSTALL.rst.txt_.
 
-We appreciate and welcome contributions. If you would like to take part in
-SciPy development, take a look at the file CONTRIBUTING.rst_.
+
+Call for Contributions
+----------------------
+
+The SciPy project welcomes your expertise and enthusiasm!
+
+Small improvements or fixes are always appreciated; issues labeled as "good
+first issue" may be a good starting point. If you are considering larger
+contributions to the source code, please contact us through the [mailing
+list](https://scipy.org/scipylib/mailing-lists.html) first.
+Have a look at our contributing guide CONTRIBUTING.rst_.
+
+Writing code isn’t the only way to contribute to SciPy. You can also:
+- review pull requests
+- triage issues
+- develop tutorials, presentations, and other educational materials
+- maintain and improve [our website](https://github.com/scipy/scipy.org)
+- develop graphic design for our brand assets and promotional materials
+- translate website content
+- help with outreach and onboard new contributors
+- write grant proposals and help with other fundraising efforts
+
+If you’re unsure where to start or how your skills fit in, reach out! You can
+ask on the mailing list or here, on GitHub, by opening a new issue or leaving a
+comment on a relevant issue that is already open.
+
+Our preferred channels of communication are all public.
+
+If you are new to contributing to open source, [this
+guide](https://opensource.guide/how-to-contribute/) helps explain why, what,
+and how to successfully get involved.
 
 
 .. _CONTRIBUTING.rst:  https://github.com/scipy/scipy/blob/master/CONTRIBUTING.rst
 .. _INSTALL.rst.txt:   https://github.com/scipy/scipy/blob/master/INSTALL.rst.txt
+
+.. image:: https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A
+  :target: https://numfocus.org

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,7 @@
 .. image:: doc/source/_static/scipyshiny_small.png
   :target: https://docs.scipy.org/doc/scipy/reference/
+  :width: 50
+  :align: left
 
 SciPy
 =====
@@ -53,7 +55,8 @@ upon by some of the world's leading scientists and engineers. If you need to
 manipulate numbers on a computer and display or publish the results, give
 SciPy a try!
 
-For the installation instructions, see INSTALL.rst.txt_.
+For the installation instructions, see `our install
+guide <https://scipy.github.io/devdocs/getting_started.html#installation>`__.
 
 
 Call for Contributions
@@ -62,16 +65,14 @@ Call for Contributions
 The SciPy project welcomes your expertise and enthusiasm!
 
 Small improvements or fixes are always appreciated; issues labeled as "good
-first issue" may be a good starting point. If you are considering larger
-contributions to the source code, please contact us through the [mailing
-list](https://scipy.org/scipylib/mailing-lists.html) first.
-Have a look at our contributing guide CONTRIBUTING.rst_.
+first issue" may be a good starting point.Have a look at `our contributing
+guide <http://scipy.github.io/devdocs/dev/hacking.html>`__.
 
 Writing code isn’t the only way to contribute to SciPy. You can also:
 - review pull requests
 - triage issues
 - develop tutorials, presentations, and other educational materials
-- maintain and improve [our website](https://github.com/scipy/scipy.org)
+- maintain and improve `our website <https://github.com/scipy/scipy.org>`__
 - develop graphic design for our brand assets and promotional materials
 - translate website content
 - help with outreach and onboard new contributors
@@ -83,13 +84,9 @@ comment on a relevant issue that is already open.
 
 Our preferred channels of communication are all public.
 
-If you are new to contributing to open source, [this
-guide](https://opensource.guide/how-to-contribute/) helps explain why, what,
+If you are new to contributing to open source, `this
+guide <https://opensource.guide/how-to-contribute/>`__ helps explain why, what,
 and how to successfully get involved.
-
-
-.. _CONTRIBUTING.rst:  https://github.com/scipy/scipy/blob/master/CONTRIBUTING.rst
-.. _INSTALL.rst.txt:   https://github.com/scipy/scipy/blob/master/INSTALL.rst.txt
 
 .. image:: https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A
   :target: https://numfocus.org

--- a/README.rst
+++ b/README.rst
@@ -46,8 +46,7 @@ ODE solvers, and more.
 - **Report a security vulnerability:** https://tidelift.com/docs/security
 - **Citing in your work:** https://www.scipy.org/citing.html
 
-SciPy depends on NumPy, which provides convenient and fast
-N-dimensional array manipulation. SciPy is built to work with
+SciPy is built to work with
 NumPy arrays, and provides many user-friendly and efficient numerical routines,
 such as routines for numerical integration and optimization. Together, they
 run on all popular operating systems, are quick to install, and are free of
@@ -63,9 +62,7 @@ guide <https://scipy.github.io/devdocs/getting_started.html#installation>`__.
 Call for Contributions
 ----------------------
 
-The SciPy project welcomes your expertise and enthusiasm!
-
-Small improvements or fixes are always appreciated; issues labeled as "good
+We appreciate and welcome contributions. Small improvements or fixes are always appreciated; issues labeled as "good
 first issue" may be a good starting point. Have a look at `our contributing
 guide <http://scipy.github.io/devdocs/dev/hacking.html>`__.
 
@@ -76,19 +73,16 @@ Writing code isn’t the only way to contribute to SciPy. You can also:
 - develop tutorials, presentations, and other educational materials
 - maintain and improve `our website <https://github.com/scipy/scipy.org>`__
 - develop graphic design for our brand assets and promotional materials
-- translate website content
 - help with outreach and onboard new contributors
 - write grant proposals and help with other fundraising efforts
 
 If you’re unsure where to start or how your skills fit in, reach out! You can
-ask on the mailing list or here, on GitHub, by opening a new issue or leaving a
+ask on the mailing list or here, on GitHub, by leaving a
 comment on a relevant issue that is already open.
-
-Our preferred channels of communication are all public.
 
 If you are new to contributing to open source, `this
 guide <https://opensource.guide/how-to-contribute/>`__ helps explain why, what,
-and how to successfully get involved.
+and how to get involved.
 
 .. image:: https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A
   :target: https://numfocus.org

--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,11 @@
-.. image:: doc/source/_static/scipyshiny_small.png
-  :target: https://docs.scipy.org/doc/scipy/reference/
-  :width: 50
-  :align: left
+.. raw:: html
 
-SciPy
-=====
+    <p>
+      <h1>
+        <a href="https://docs.scipy.org/doc/scipy/reference/"><img valign="middle" src="doc/source/_static/scipyshiny_small.png" height="50" height="50" alt="SciPy logo"/></a>
+        SciPy
+      </h1>
+    </p>
 
 .. image:: https://img.shields.io/circleci/project/github/scipy/scipy/master.svg?label=CircleCI
   :target: https://circleci.com/gh/scipy/scipy
@@ -65,7 +66,7 @@ Call for Contributions
 The SciPy project welcomes your expertise and enthusiasm!
 
 Small improvements or fixes are always appreciated; issues labeled as "good
-first issue" may be a good starting point.Have a look at `our contributing
+first issue" may be a good starting point. Have a look at `our contributing
 guide <http://scipy.github.io/devdocs/dev/hacking.html>`__.
 
 Writing code isn’t the only way to contribute to SciPy. You can also:


### PR DESCRIPTION
Update the Readme to reflect NumPy's readme:

* SciPy logo
* NumFOCUS logo
* A more detailed contributing section (same as NumPy)

And extra things:
 
* A link to the articles for citation
* DOI badge with link to SciPy's article
* A StackOverflow badge to ask questions
* Remove travis badge

(See the proposed changes on my fork)