### PR TITLE
MAINT: use dict built-in rather than OrderedDict

### DIFF
--- a/benchmarks/benchmarks/io_matlab.py
+++ b/benchmarks/benchmarks/io_matlab.py
@@ -2,7 +2,6 @@ from .common import set_mem_rlimit, run_monitored, get_mem_info
 
 import os
 import tempfile
-import collections
 from io import BytesIO
 
 import numpy as np
@@ -22,14 +21,14 @@ class MemUsage(Benchmark):
         return [list(self._get_sizes().keys()), [True, False]]
 
     def _get_sizes(self):
-        sizes = collections.OrderedDict([
-            ('1M', 1e6),
-            ('10M', 10e6),
-            ('100M', 100e6),
-            ('300M', 300e6),
-            # ('500M', 500e6),
-            # ('1000M', 1000e6),
-        ])
+        sizes = {
+            '1M': 1e6,
+            '10M': 10e6,
+            '100M': 100e6,
+            '300M': 300e6,
+            # '500M': 500e6,
+            # '1000M': 1000e6,
+        }
         return sizes
 
     def setup(self, size, compressed):

--- a/benchmarks/benchmarks/lsq_problems.py
+++ b/benchmarks/benchmarks/lsq_problems.py
@@ -1,6 +1,5 @@
 """Benchmark problems for nonlinear least squares."""
 
-from collections import OrderedDict
 import inspect
 import sys
 import numpy as np
@@ -469,11 +468,11 @@ def extract_lsq_problems():
 
     Returns
     -------
-    OrderedDict, str -> LSQBenchmarkProblem
+    dict, str -> LSQBenchmarkProblem
         The key is a problem name.
         The value is an instance of LSQBenchmarkProblem.
     """
-    problems = OrderedDict()
+    problems = {}
     for name, problem_class in inspect.getmembers(sys.modules[__name__],
                                                   inspect.isclass):
         if (name != "LSQBenchmarkProblem" and

--- a/benchmarks/benchmarks/optimize.py
+++ b/benchmarks/benchmarks/optimize.py
@@ -3,7 +3,7 @@ import time
 import inspect
 import json
 import traceback
-from collections import defaultdict, OrderedDict
+from collections import defaultdict
 
 import numpy as np
 
@@ -433,7 +433,7 @@ class BenchGlobal(Benchmark):
     """
     timeout = 300
 
-    _functions = OrderedDict([
+    _functions = dict([
         item for item in inspect.getmembers(gbf, inspect.isclass)
         if (issubclass(item[1], gbf.Benchmark) and
             item[0] not in ('Benchmark') and

--- a/scipy/_lib/_disjoint_set.py
+++ b/scipy/_lib/_disjoint_set.py
@@ -1,7 +1,6 @@
 """
 Disjoint set data structure
 """
-import collections
 
 
 class DisjointSet:
@@ -88,9 +87,8 @@ class DisjointSet:
         self._parents = {}
         # _nbrs is a circular linked list which links connected elements.
         self._nbrs = {}
-        # _indices tracks the element insertion order - OrderedDict is used to
-        # ensure correct ordering in `__iter__`.
-        self._indices = collections.OrderedDict()
+        # _indices tracks the element insertion order in `__iter__`.
+        self._indices = {}
         if elements is not None:
             for x in elements:
                 self.add(x)

--- a/scipy/cluster/tests/test_disjoint_set.py
+++ b/scipy/cluster/tests/test_disjoint_set.py
@@ -1,7 +1,6 @@
 import pytest
 from pytest import raises as assert_raises
 import numpy as np
-import collections
 from scipy.cluster.hierarchy import DisjointSet
 import string
 
@@ -24,8 +23,8 @@ def generate_random_token():
 
 
 def get_elements(n):
-    # OrderedDict is deterministic without difficulty of comparing numpy ints
-    elements = collections.OrderedDict()
+    # dict is deterministic without difficulty of comparing numpy ints
+    elements = {}
     for element in generate_random_token():
         if element not in elements:
             elements[element] = len(elements)

--- a/scipy/io/arff/arffread.py
+++ b/scipy/io/arff/arffread.py
@@ -1,7 +1,6 @@
 # Last Change: Mon Aug 20 08:00 PM 2007 J
 import re
 import datetime
-from collections import OrderedDict
 
 import numpy as np
 
@@ -682,9 +681,7 @@ class MetaData:
     """
     def __init__(self, rel, attr):
         self.name = rel
-
-        # We need the dictionary to be ordered
-        self._attributes = OrderedDict((a.name, a) for a in attr)
+        self._attributes = {a.name: a for a in attr}
 
     def __repr__(self):
         msg = ""

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -552,25 +552,18 @@ def test_use_small_element():
 
 
 def test_save_dict():
-    # Test that dict can be saved (as recarray), loaded as matstruct
-    dict_types = ((dict, False), (OrderedDict, True),)
+    # Test that both dict and OrderedDict can be saved (as recarray),
+    # loaded as matstruct, and preserve order
     ab_exp = np.array([[(1, 2)]], dtype=[('a', object), ('b', object)])
-    ba_exp = np.array([[(2, 1)]], dtype=[('b', object), ('a', object)])
-    for dict_type, is_ordered in dict_types:
-        # Initialize with tuples to keep order for OrderedDict
+    for dict_type in (dict, OrderedDict):
+        # Initialize with tuples to keep order
         d = dict_type([('a', 1), ('b', 2)])
         stream = BytesIO()
         savemat(stream, {'dict': d})
         stream.seek(0)
         vals = loadmat(stream)['dict']
-        assert_equal(set(vals.dtype.names), set(['a', 'b']))
-        if is_ordered:  # Input was ordered, output in ab order
-            assert_array_equal(vals, ab_exp)
-        else:  # Not ordered input, either order output
-            if vals.dtype.names[0] == 'a':
-                assert_array_equal(vals, ab_exp)
-            else:
-                assert_array_equal(vals, ba_exp)
+        assert_equal(vals.dtype.names, ('a', 'b'))
+        assert_array_equal(vals, ab_exp)
 
 
 def test_1d_shape():

--- a/scipy/io/netcdf.py
+++ b/scipy/io/netcdf.py
@@ -37,7 +37,6 @@ __all__ = ['netcdf_file', 'netcdf_variable']
 import warnings
 import weakref
 from operator import mul
-from collections import OrderedDict
 from platform import python_implementation
 
 import mmap as mm
@@ -262,8 +261,8 @@ class netcdf_file:
         self.version_byte = version
         self.maskandscale = maskandscale
 
-        self.dimensions = OrderedDict()
-        self.variables = OrderedDict()
+        self.dimensions = {}
+        self.variables = {}
 
         self._dims = []
         self._recs = 0
@@ -275,7 +274,7 @@ class netcdf_file:
             self._mm = mm.mmap(self.fp.fileno(), 0, access=mm.ACCESS_READ)
             self._mm_buf = np.frombuffer(self._mm, dtype=np.int8)
 
-        self._attributes = OrderedDict()
+        self._attributes = {}
 
         if mode in 'ra':
             self._read()
@@ -295,7 +294,7 @@ class netcdf_file:
             try:
                 self.flush()
             finally:
-                self.variables = OrderedDict()
+                self.variables = {}
                 if self._mm_buf is not None:
                     ref = weakref.ref(self._mm_buf)
                     self._mm_buf = None
@@ -634,7 +633,7 @@ class netcdf_file:
             raise ValueError("Unexpected header.")
         count = self._unpack_int()
 
-        attributes = OrderedDict()
+        attributes = {}
         for attr in range(count):
             name = asstr(self._unpack_string())
             attributes[name] = self._read_att_values()
@@ -865,7 +864,7 @@ class netcdf_variable:
         self.dimensions = dimensions
         self.maskandscale = maskandscale
 
-        self._attributes = attributes or OrderedDict()
+        self._attributes = attributes or {}
         for k, v in self._attributes.items():
             self.__dict__[k] = v
 


### PR DESCRIPTION
Since [Python 3.7](https://docs.python.org/3/whatsnew/3.7.html), the `dict` built-in is guaranteed to preserve insertion order. This means there is no real need to use `collections.OrderedDict` anymore.

One exception is `scipy/integrate/_quad_vec.py`, where `class LRUDict(collections.OrderedDict)` is kept. This class also make's use of `move_to_end`, which is a method of `collections.OrderedDict`.