### PR TITLE
BUG: Fix chi2_contingency Yates' correction behavior

### DIFF
--- a/scipy/stats/contingency.py
+++ b/scipy/stats/contingency.py
@@ -287,7 +287,8 @@ def chi2_contingency(observed, correction=True, lambda_=None):
     else:
         if dof == 1 and correction:
             # Adjust `observed` according to Yates' correction for continuity.
-            observed = observed + 0.5 * np.sign(expected - observed)
+            yates = np.minimum(0.5, np.abs(expected - observed))
+            observed = observed + yates * np.sign(expected - observed)
 
         chi2, p = power_divergence(observed, expected,
                                    ddof=observed.size - 1 - dof, axis=None,

--- a/scipy/stats/tests/test_contingency.py
+++ b/scipy/stats/tests/test_contingency.py
@@ -166,6 +166,25 @@ def test_chi2_contingency_R():
     assert_approx_equal(p, 0.6442, significant=4)
     assert_equal(dof, 11)
 
+    # test Yates' correction (unbalanced case)
+    # > X <- matrix(c(1000, 10, 1, 0), ncol=2, nrow=2)
+    # > X
+    #     [,1] [,2]
+    # [1,] 1000    1
+    # [2,]   10    0
+    # > chisq.test(X)
+    #         Pearson's Chi-squared test with Yates' continuity correction
+    # data:  X
+    # X-squared = 5.163e-28, df = 1, p-value = 1
+
+    obs = np.array(
+        [[1000, 1],
+         [10, 0]]
+    )
+    chi2, p, dof, expected = chi2_contingency(obs, correction=True)
+    assert_approx_equal(p, 1.0, significant=2)
+    assert_allclose(chi2, 0.0)
+
 
 def test_chi2_contingency_g():
     c = np.array([[15, 60], [15, 90]])


### PR DESCRIPTION

#### Reference issue
Closes gh-13875

#### What does this implement/fix?
The current SciPy's implementation of Yates' correction shifts observed values toward expected by 0.5 (disregard of difference between observed and expected). Sometimes (see case mentioned in gh-13875) these shifts became very large and lead to unreliable results.
As it was noted [here ](https://stats.stackexchange.com/a/159779) and pointed out in the bottom of Wikipedia [page ](https://en.wikipedia.org/wiki/Yates%27s_correction_for_continuity) about Yates' correction, it is common approach to use [this formula ](https://wikimedia.org/api/rest_v1/media/math/render/svg/6ad077421e4665bb6a2db4ebc193674296930bdd) to handle that buggy behavior. Proposed approach (`yates = np.minimum(0.5, np.abs(expected - observed))`) is equivalent (explanation is [here ](https://stats.stackexchange.com/a/159779)) to this [formula](https://wikimedia.org/api/rest_v1/media/math/render/svg/6ad077421e4665bb6a2db4ebc193674296930bdd) and also implemented in R's chisq.test.
