### PR TITLE
ENH: Poisson Disk sampling for QMC

### DIFF
--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -1684,6 +1684,8 @@ class PoissonDisk(QMCEngine):
             QMC sample.
 
         """
+        if n == 0 or self.d == 0:
+            return np.empty((n, self.d))
 
         def in_limits(sample: np.ndarray) -> bool:
             return (sample.max() <= 1.) and (sample.min() >= 0.)

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -1655,6 +1655,7 @@ class PoissonDisk(QMCEngine):
     Examples
     --------
     Generate a 2D sample using a `radius` of 0.2.
+
     >>> import matplotlib.pyplot as plt
     >>> from matplotlib.collections import PatchCollection
     >>> from scipy.stats import qmc
@@ -1668,6 +1669,7 @@ class PoissonDisk(QMCEngine):
     `radius`. ``radius/2`` is used to visualy have non-intersecting circle.
     If two samples are exactly at `radius` from each other, then their circle
     of radius ``radius/2`` will touch.
+
     >>> fig, ax = plt.subplots()
     >>> _ = ax.scatter(sample[:, 0], sample[:, 1])
     >>> circles = [plt.Circle((xi, yi), radius=radius/2, fill=False)

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -1610,9 +1610,8 @@ class PoissonDisk(QMCEngine):
         final sample. Default is "volume".
 
         * ``volume``: original Bridson algorithm as described in [1]_.
-          new candidates are sampled within the hypersphere.
+          New candidates are sampled *within* the hypersphere.
         * ``surface``: only sample the surface of the hypersphere.
-
     candidates : int
         Number of candidates to sample per iteration. More candidates result
         in a denser sampling as more candidates can be accepted per iteration.
@@ -1625,7 +1624,6 @@ class PoissonDisk(QMCEngine):
 
     Notes
     -----
-
     Poisson disk sampling is an iterative sampling strategy. Starting from
     a seed sample, ``n`` `candidates` are sampled in the hypersphere
     surrounding the seed. Candidates bellow a certain `radius` or outside the
@@ -1666,7 +1664,7 @@ class PoissonDisk(QMCEngine):
     >>> sample = engine.random(20)
 
     Visualizing the 2D sample and showing that no points are closer than
-    `radius`. ``radius/2`` is used to visualy have non-intersecting circle.
+    `radius`. ``radius/2`` is used to visualize non-intersecting circles.
     If two samples are exactly at `radius` from each other, then their circle
     of radius ``radius/2`` will touch.
 
@@ -1683,7 +1681,7 @@ class PoissonDisk(QMCEngine):
     Such visualization can be seen as circle packing: how many circle can
     we put in the space. It is a np-hard problem. The method `fill_space`
     can be used to add samples until no more samples can be added. This is
-    a hard problem parameters might need to be adjusted manually. Beware of
+    a hard problem and parameters may need to be adjusted manually. Beware of
     the dimension: as the dimensionality increases, the number of samples
     required to fill the space increases exponentially
     (curse-of-dimensionality).

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -1756,7 +1756,7 @@ class PoissonDisk(QMCEngine):
             self.sample_grid[tuple(indices)] = candidate
             curr_sample.append(candidate)
 
-        curr_sample = []
+        curr_sample: List[np.ndarray] = []
 
         if len(self.sample_pool) == 0:
             # the pool is being initialized with a single random sample
@@ -1768,7 +1768,7 @@ class PoissonDisk(QMCEngine):
         # exhaust sample pool to have up to n sample
         while len(self.sample_pool) and num_drawn < n:
             # select a sample from the available pool
-            idx_center = self.rng.integers(len(self.sample_pool))
+            idx_center = rng_integers(self.rng, len(self.sample_pool))
             center = self.sample_pool[idx_center]
             del self.sample_pool[idx_center]
 
@@ -1803,19 +1803,21 @@ class PoissonDisk(QMCEngine):
         return self
 
     def _hypersphere_volume_sample(
-        self, center: np.ndarray, radius: float, k: int = 1
+        self, center: np.ndarray, radius: DecimalNumber, k: int = 1
     ) -> np.ndarray:
         """Uniform sampling within hypersphere."""
         # should remove samples within r/2
         x = self.rng.standard_normal(size=(k, self.d))
         ssq = np.sum(x**2, axis=1)
         fr = radius * gammainc(self.d/2, ssq/2)**(1/self.d) / np.sqrt(ssq)
-        fr_tiled = np.tile(fr.reshape(k, 1), (1, self.d))
+        fr_tiled = np.tile(
+            fr.reshape(-1, 1), (1, self.d)  # type: ignore[arg-type]
+        )
         p = center + np.multiply(x, fr_tiled)
         return p
 
     def _hypersphere_surface_sample(
-        self, center: np.ndarray, radius: float, k: int = 1
+        self, center: np.ndarray, radius: DecimalNumber, k: int = 1
     ) -> np.ndarray:
         """Uniform sampling on the hypersphere's surface."""
         vec = self.rng.standard_normal(size=(k, self.d))

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -1681,8 +1681,11 @@ class PoissonDisk(QMCEngine):
         # sample to generate per iteration in the hypersphere around center
         self.k = 30
 
-        self.cell_size = self.radius / np.sqrt(self.d)
-        self.grid_size = (np.ceil(np.ones(self.d)/self.cell_size)).astype(int)
+        with np.errstate(divide='ignore'):
+            self.cell_size = self.radius / np.sqrt(self.d)
+            self.grid_size = (
+                np.ceil(np.ones(self.d) / self.cell_size)
+            ).astype(int)
 
         self._initialize_grid_pool()
 

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -1648,7 +1648,7 @@ class PoissonDisk(QMCEngine):
     ----------
     .. [1] Robert Bridson, "Fast Poisson Disk Sampling in Arbitrary
        Dimensions." SIGGRAPH, 2007.
-    .. [2] `StackOverflow <https://stackoverflow.com/questions/66047540>`_.
+    .. [2] `StackOverflow <https://stackoverflow.com/questions/66047540>`__.
 
     Examples
     --------

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -1786,13 +1786,16 @@ class PoissonDisk(QMCEngine):
 
             a = [slice(ind_min[i], ind_max[i]) for i in range(self.d)]
 
-            if np.any(
-                np.sum(
-                    np.square(candidate - self.sample_grid[tuple(a)]),
-                    axis=self.d
-                ) < self.radius_squared
-            ):
-                return True
+            # guards against: invalid value encountered in less as we are
+            # comparing with nan and returns False. Which is wanted.
+            with np.errstate(invalid='ignore'):
+                if np.any(
+                    np.sum(
+                        np.square(candidate - self.sample_grid[tuple(a)]),
+                        axis=self.d
+                    ) < self.radius_squared
+                ):
+                    return True
 
             return False
 

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -1645,6 +1645,33 @@ class PoissonDisk(QMCEngine):
        Dimensions." SIGGRAPH, 2007.
     .. [2] `StackOverflow <https://stackoverflow.com/questions/66047540>`_.
 
+    Examples
+    --------
+    Generate a 2D sample using a `radius` of 0.2.
+    >>> import matplotlib.pyplot as plt
+    >>> from matplotlib.collections import PatchCollection
+    >>> from scipy.stats import qmc
+    >>>
+    >>> rng = np.random.default_rng()
+    >>> radius = 0.2
+    >>> engine = qmc.PoissonDisk(d=2, radius=0.2, seed=rng)
+    >>> sample = engine.random(20)
+
+    Visualizing the 2D sample and showing that no points are closer than
+    `radius`. ``radius/2`` is used to visualy have non-intersecting circle.
+    If two samples are exactly at `radius` from each other, then their circle
+    of radius ``radius/2`` will touch.
+    >>> fig, ax = plt.subplots()
+    >>> _ = ax.scatter(sample[:, 0], sample[:, 1])
+    >>> circles = [plt.Circle((xi, yi), radius=radius/2, fill=False)
+    ...            for xi, yi in sample]
+    >>> collection = PatchCollection(circles, match_original=True)
+    >>> ax.add_collection(collection)
+    >>>
+    >>> ax.set(aspect='equal', xlabel=r'$x_1$', ylabel=r'$x_2$',
+    ...        xlim=[0, 1], ylim=[0, 1])
+    >>> plt.show()
+
     """
 
     def __init__(

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -1633,7 +1633,7 @@ class PoissonDisk(QMCEngine):
 
     The maximum number of point that a sample can contain is directly linked
     to the `radius`. As the dimension of the space increases, a higher radius
-    spread the points further and help overcome the curse-of-dimensionality.
+    spreads the points further and help overcome the curse of dimensionality.
 
     .. warning::
 

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -47,7 +47,7 @@ from ._qmc_cy import (
 
 
 __all__ = ['scale', 'discrepancy', 'update_discrepancy',
-           'QMCEngine', 'Sobol', 'Halton', 'LatinHypercube', 'PoissonDisc',
+           'QMCEngine', 'Sobol', 'Halton', 'LatinHypercube', 'PoissonDisk',
            'MultinomialQMC', 'MultivariateNormalQMC']
 
 
@@ -1596,7 +1596,7 @@ class Sobol(QMCEngine):
         return self
 
 
-class PoissonDisc(QMCEngine):
+class PoissonDisk(QMCEngine):
     """Poisson disk sampling.
 
     Parameters
@@ -1657,7 +1657,7 @@ class PoissonDisc(QMCEngine):
             raise ValueError(message) from exc
 
         # size of the sphere from which the samples are drawn relative to the
-        # size of a disc (radius)
+        # size of a disk (radius)
         # for the surface sampler, all new points are almost exactly 1 radius
         # away from at least one existing sample +eps to avoid rejection
         self.radius_factor = 2 if hypersphere == "volume" else 1.001

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -1603,6 +1603,8 @@ class PoissonDisk(QMCEngine):
     ----------
     d : int
         Dimension of the parameter space.
+    radius : float
+        Minimal distance to keep between points when sampling new candidates.
     hypersphere : {"volume", "surface"}, optional
         Sampling strategy to generate potential candidates to be added in the
         final sample. Default is "volume".
@@ -1621,7 +1623,19 @@ class PoissonDisk(QMCEngine):
     Notes
     -----
 
-    Taken from [2]_ by P. Zun, written consent given on 31.03.2021
+    Poisson disk sampling is an iterative sampling strategy. Starting from
+    a seed sample, candidates are sampled in the hypersphere surrounding the
+    seed. Candidates bellow a certain `radius` or outside of the domain are
+    rejected. New samples are added in a pool of sample seed. The process
+    stops when the pool is empty or when the number of required samples is
+    reached.
+
+    .. warning::
+
+       The algorithm is more suitable for low dimensions and sampling size
+       due to its iterative nature and memory requirements.
+
+    Some code taken from [2]_ by P. Zun, written consent given on 31.03.2021
     by the original author, Shamis, for free use in SciPy under
     the 3-clause BSD.
 
@@ -1686,6 +1700,9 @@ class PoissonDisk(QMCEngine):
 
     def random(self, n: IntNumber = 1) -> np.ndarray:
         """Draw `n` in the interval ``[0, 1]``.
+
+        Note that it can return fewer samples if the space is full.
+        See the note section of the class.
 
         Parameters
         ----------

--- a/scipy/stats/qmc.py
+++ b/scipy/stats/qmc.py
@@ -23,6 +23,7 @@ Engines
    Sobol
    Halton
    LatinHypercube
+   PoissonDisk
    MultinomialQMC
    MultivariateNormalQMC
 

--- a/scipy/stats/tests/test_qmc.py
+++ b/scipy/stats/tests/test_qmc.py
@@ -817,13 +817,23 @@ class TestPoisson(QMCEngineTests):
         radii = (high - low) * rng.random(10) + low
 
         dimensions = [1, 2, 3, 4]
+        hypersphere_methods = ["volume", "surface"]
 
-        for d, radius in product(dimensions, radii):
-            engine = self.qmce(d=2, radius=radius, seed=rng)
+        gen = product(dimensions, radii, hypersphere_methods)
+
+        for d, radius, hypersphere in gen:
+            engine = self.qmce(
+                d=2, radius=radius, hypersphere=hypersphere, seed=rng
+            )
             sample = engine.random(ns)
 
             assert len(sample) <= ns
             assert l2_norm(sample) >= radius
+
+    def test_raises(self):
+        message = r"'toto' is not a valid hypersphere sampling"
+        with pytest.raises(ValueError, match=message):
+            qmc.PoissonDisk(1, hypersphere="toto")
 
 
 class TestMultinomialQMC:

--- a/scipy/stats/tests/test_qmc.py
+++ b/scipy/stats/tests/test_qmc.py
@@ -790,6 +790,25 @@ class TestPoisson(QMCEngineTests):
         pytest.skip("Not applicable: the value of reference sample is"
                     " implementation dependent.")
 
+    def test_continuing(self, *args):
+        # can continue a sampling, but will not preserve the same order
+        # because candidates are lost, so we will not select the same center
+        radius = 0.05
+        ns = 6
+        engine = self.engine(d=2, radius=radius, scramble=False)
+
+        sample_init = engine.random(n=ns)
+        assert len(sample_init) <= ns
+        assert l2_norm(sample_init) >= radius
+
+        sample_continued = engine.random(n=ns)
+        assert len(sample_continued) <= ns
+        assert l2_norm(sample_continued) >= radius
+
+        sample = np.concatenate([sample_init, sample_continued], axis=0)
+        assert len(sample) <= ns * 2
+        assert l2_norm(sample) >= radius
+
     def test_mindist(self):
         rng = np.random.default_rng(132074951149370773672162394161442690287)
         ns = 100
@@ -803,7 +822,7 @@ class TestPoisson(QMCEngineTests):
             engine = self.qmce(d=2, radius=radius, seed=rng)
             sample = engine.random(ns)
 
-            assert len(sample) <= ns, (engine.num_generated, len(sample))
+            assert len(sample) <= ns
             assert l2_norm(sample) >= radius
 
 

--- a/scipy/stats/tests/test_qmc.py
+++ b/scipy/stats/tests/test_qmc.py
@@ -780,11 +780,11 @@ class TestPoisson(QMCEngineTests):
     qmce = qmc.PoissonDisk
     can_scramble = False
 
-    def test_continuing(self, *args):
-        pytest.skip("Not implemented.")
+    def test_bounds(self, *args):
+        pytest.skip("Too costly in memory.")
 
     def test_fast_forward(self, *args):
-        pytest.skip("Not implemented.")
+        pytest.skip("Not applicable: recursive process.")
 
     def test_sample(self, *args):
         pytest.skip("Not applicable: the value of reference sample is"
@@ -800,7 +800,7 @@ class TestPoisson(QMCEngineTests):
         dimensions = [1, 2, 3, 4]
 
         for d, radius in product(dimensions, radii):
-            engine = self.qmce(d=2, radius=radius)
+            engine = self.qmce(d=2, radius=radius, seed=rng)
             sample = engine.random(ns)
 
             assert len(sample) <= ns, (engine.num_generated, len(sample))

--- a/scipy/stats/tests/test_qmc.py
+++ b/scipy/stats/tests/test_qmc.py
@@ -791,14 +791,20 @@ class TestPoisson(QMCEngineTests):
                     " implementation dependent.")
 
     def test_mindist(self):
-        radius = 0.05
+        rng = np.random.default_rng(132074951149370773672162394161442690287)
         ns = 100
 
-        engine = self.qmce(d=2, radius=radius)
-        sample = engine.random(ns)
+        low, high = 0.01, 0.1
+        radii = (high - low) * rng.random(10) + low
 
-        assert len(sample) <= ns, (engine.num_generated, len(sample))
-        assert l2_norm(sample) >= radius
+        dimensions = [1, 2, 3, 4]
+
+        for d, radius in product(dimensions, radii):
+            engine = self.qmce(d=2, radius=radius)
+            sample = engine.random(ns)
+
+            assert len(sample) <= ns, (engine.num_generated, len(sample))
+            assert l2_norm(sample) >= radius
 
 
 class TestMultinomialQMC:

--- a/scipy/stats/tests/test_qmc.py
+++ b/scipy/stats/tests/test_qmc.py
@@ -830,6 +830,14 @@ class TestPoisson(QMCEngineTests):
             assert len(sample) <= ns
             assert l2_norm(sample) >= radius
 
+    def test_fill_space(self):
+        radius = 0.2
+        engine = self.qmce(d=2, radius=radius)
+
+        sample = engine.fill_space()
+        # circle packing problem is np complex
+        assert l2_norm(sample) >= radius
+
     def test_raises(self):
         message = r"'toto' is not a valid hypersphere sampling"
         with pytest.raises(ValueError, match=message):

--- a/scipy/stats/tests/test_qmc.py
+++ b/scipy/stats/tests/test_qmc.py
@@ -775,6 +775,32 @@ class TestSobol(QMCEngineTests):
         sample = engine.random(8)
         assert_array_equal(self.unscramble_nd, sample)
 
+
+class TestPoisson(QMCEngineTests):
+    qmce = qmc.PoissonDisc
+    can_scramble = False
+
+    def test_continuing(self, *args):
+        pytest.skip("Not implemented.")
+
+    def test_fast_forward(self, *args):
+        pytest.skip("Not implemented.")
+
+    def test_sample(self, *args):
+        pytest.skip("Not applicable: the value of reference sample is"
+                    " implementation dependent.")
+
+    def test_mindist(self):
+        radius = 0.05
+        ns = 100
+
+        engine = self.qmce(d=2, radius=radius)
+        sample = engine.random(ns)
+
+        assert len(sample) <= ns, (engine.num_generated, len(sample))
+        assert l2_norm(sample) >= radius
+
+
 class TestMultinomialQMC:
     def test_validations(self):
         # negative Ps
@@ -1181,10 +1207,6 @@ class TestMultivariateNormalQMC:
 
 class TestLloyd:
     def test_lloyd(self):
-        # mindist
-        def l2_norm(sample):
-            return distance.pdist(sample).min()
-
         # quite sensible seed as it can go up before going further down
         rng = np.random.RandomState(1809831)
         sample = rng.uniform(0, 1, size=(128, 2))
@@ -1237,3 +1259,8 @@ class TestLloyd:
         with pytest.raises(ValueError, match=msg):
             sample = [[-1.1, 0], [0.1, 0.4], [1, 2]]
             lloyd_centroidal_voronoi_tessellation(sample)
+
+
+# mindist
+def l2_norm(sample):
+    return distance.pdist(sample).min()

--- a/scipy/stats/tests/test_qmc.py
+++ b/scipy/stats/tests/test_qmc.py
@@ -777,7 +777,7 @@ class TestSobol(QMCEngineTests):
 
 
 class TestPoisson(QMCEngineTests):
-    qmce = qmc.PoissonDisc
+    qmce = qmc.PoissonDisk
     can_scramble = False
 
     def test_continuing(self, *args):


### PR DESCRIPTION
#### Reference issue
Adding Poisson Disk sampling to QMC #13912

#### What does this implement/fix?

Poisson disk sampling in arbitrary dimensions using Bridson's algorithm, implemented using ``numpy`` and ``scipy``.
Generates so-called "blue noise" that prevents clustering by ensuring each two points are at least ``radius`` apart.
https://www.cs.ubc.ca/~rbridson/docs/bridson-siggraph07-poissondisk.pdf

<details>

```python
import matplotlib.pyplot as plt
from matplotlib.collections import PatchCollection
from scipy.stats import qmc


rng = np.random.default_rng()
radius = 0.2
engine = qmc.PoissonDisk(d=2, radius=0.2, seed=rng)
sample = engine.random(20)

fig, ax = plt.subplots()
_ = ax.scatter(sample[:, 0], sample[:, 1])
circles = [plt.Circle((xi, yi), radius=radius/2, fill=False)
           for xi, yi in sample]
collection = PatchCollection(circles, match_original=True)
ax.add_collection(collection)
_ = ax.set(aspect='equal', xlabel=r'$x_1$', ylabel=r'$x_2$',
           xlim=[0, 1], ylim=[0, 1])
plt.show()
```
</details>

![poissonDisk](https://user-images.githubusercontent.com/23188539/169402582-5331019f-9093-4456-8a40-94c900de6c9c.png)

