### PR TITLE
BUG: Reactivate conda environment in init

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,6 +2,8 @@
 # that even forks do have a usable freshly built SciPy
 # Might delegate this later to prebuild with Q2 improvements on gitpod
 # https://www.gitpod.io/docs/config-start-tasks/#configuring-the-terminal
+# please note that the conda env *must* be activated again for ccache to
+# work, else it fails with a very cryptic message
 # -------------------------------------------------------------------------
 
 image: scipy/scipy-gitpod:latest
@@ -10,14 +12,15 @@ tasks:
     init: |
       mkdir -p .vscode
       cp tools/docker_dev/settings.json .vscode/settings.json
+      conda activate scipy-dev
       python setup.py build_ext --inplace
-      echo "🛠 \e[35m\e[1m Completed rebuilding SciPy!! 🛠 "
+      echo "🛠 Completed rebuilding SciPy!! 🛠 "
       conda develop .
-      echo "📖 \e[35m\e[1m Building docs 📖 "
+      echo "📖 Building docs 📖 "
       git submodule update --init
       cd doc 
       make html-scipyorg
-      echo "✨ \e[35m\e[1m pre-build complete! You can close this terminal ✨ "
+      echo "✨ Pre-build complete! You can close this terminal ✨ "
   
 # --------------------------------------------------------
 # exposing ports for liveserve

--- a/tools/docker_dev/.gitpod.Dockerfile
+++ b/tools/docker_dev/.gitpod.Dockerfile
@@ -1,5 +1,5 @@
 # Doing a local shallow clone - keeps the container secure
-# and much slimmer than usins COPY directly
+# and much slimmer than using COPY directly or cloning a remote 
 ARG BASE_CONTAINER=scipy/scipy-dev:latest
 FROM ${BASE_CONTAINER} as clone
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
This is a quick fix to ensure that conda reactivates the environment in the prebuild

Even though `scipy-dev` should be activated by default the ccache settings do need to reactivate the environment (see Dockerfile for reference if needed)

Also removed colouring that was not being applied in the terminal but it is not needed at all 


#### Additional information
<!--Any additional information you think is important.-->

In good news the action for the gitpod dockerfile now works and  Gitpod will be fully operational and polished after this patch