### PR TITLE
BUG: optimize: fix max function call validation for `minimize` with Powell

### DIFF
--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -3190,11 +3190,13 @@ def _minimize_powell(func, x0, args=(), callback=None, bounds=None,
                 temp = fx - fx2
                 t -= delta*temp*temp
                 if t < 0.0:
-                    fval, x, direc1 = _linesearch_powell(func, x, direc1,
-                                                         tol=xtol * 100,
-                                                         lower_bound=lower_bound,
-                                                         upper_bound=upper_bound,
-                                                         fval=fval)
+                    fval, x, direc1 = _linesearch_powell(
+                        func, x, direc1,
+                        tol=xtol * 100,
+                        lower_bound=lower_bound,
+                        upper_bound=upper_bound,
+                        fval=fval
+                    )
                     if np.any(direc1):
                         direc[bigind] = direc[-1]
                         direc[-1] = direc1

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -475,6 +475,36 @@ def _wrap_scalar_function(function, args):
     return ncalls, function_wrapper
 
 
+class _MaxFuncCallError(RuntimeError):
+    pass
+
+
+def _wrap_scalar_function_with_validation(function, args, maxfun):
+    # wraps a minimizer function to count number of evaluations
+    # and to easily provide an args kwd.
+    ncalls = [0]
+    if function is None:
+        return ncalls, None
+
+    def function_wrapper(x, *wrapper_args):
+        if ncalls[0] >= maxfun:
+            raise _MaxFuncCallError()
+        ncalls[0] += 1
+        # A copy of x is sent to the user function (gh13740)
+        fx = function(np.copy(x), *(wrapper_args + args))
+        # Ideally, we'd like to a have a true scalar returned from f(x). For
+        # backwards-compatibility, also allow np.array([1.3]), np.array([[1.3]]) etc.
+        if not np.isscalar(fx):
+            try:
+                fx = np.asarray(fx).item()
+            except (TypeError, ValueError) as e:
+                raise ValueError("The user-provided objective function "
+                                 "must return a scalar value.") from e
+        return fx
+
+    return ncalls, function_wrapper
+
+
 def fmin(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None, maxfun=None,
          full_output=0, disp=1, retall=0, callback=None, initial_simplex=None):
     """
@@ -3062,9 +3092,7 @@ def _minimize_powell(func, x0, args=(), callback=None, bounds=None,
     _check_unknown_options(unknown_options)
     maxfun = maxfev
     retall = return_all
-    # we need to use a mutable object here that we can update in the
-    # wrapper function
-    fcalls, func = _wrap_scalar_function(func, args)
+
     x = asarray(x0).flatten()
     if retall:
         allvecs = [x]
@@ -3085,6 +3113,10 @@ def _minimize_powell(func, x0, args=(), callback=None, bounds=None,
             maxfun = N * 1000
         else:
             maxfun = np.inf
+
+    # we need to use a mutable object here that we can update in the
+    # wrapper function
+    fcalls, func = _wrap_scalar_function_with_validation(func, args, maxfun)
 
     if direc is None:
         direc = eye(N, dtype=float)
@@ -3113,57 +3145,60 @@ def _minimize_powell(func, x0, args=(), callback=None, bounds=None,
     iter = 0
     ilist = list(range(N))
     while True:
-        fx = fval
-        bigind = 0
-        delta = 0.0
-        for i in ilist:
-            direc1 = direc[i]
-            fx2 = fval
-            fval, x, direc1 = _linesearch_powell(func, x, direc1,
-                                                 tol=xtol * 100,
-                                                 lower_bound=lower_bound,
-                                                 upper_bound=upper_bound,
-                                                 fval=fval)
-            if (fx2 - fval) > delta:
-                delta = fx2 - fval
-                bigind = i
-        iter += 1
-        if callback is not None:
-            callback(x)
-        if retall:
-            allvecs.append(x)
-        bnd = ftol * (np.abs(fx) + np.abs(fval)) + 1e-20
-        if 2.0 * (fx - fval) <= bnd:
-            break
-        if fcalls[0] >= maxfun:
-            break
-        if iter >= maxiter:
-            break
-        if np.isnan(fx) and np.isnan(fval):
-            # Ended up in a nan-region: bail out
-            break
-
-        # Construct the extrapolated point
-        direc1 = x - x1
-        x2 = 2*x - x1
-        x1 = x.copy()
-        fx2 = squeeze(func(x2))
-
-        if (fx > fx2):
-            t = 2.0*(fx + fx2 - 2.0*fval)
-            temp = (fx - fval - delta)
-            t *= temp*temp
-            temp = fx - fx2
-            t -= delta*temp*temp
-            if t < 0.0:
+        try:
+            fx = fval
+            bigind = 0
+            delta = 0.0
+            for i in ilist:
+                direc1 = direc[i]
+                fx2 = fval
                 fval, x, direc1 = _linesearch_powell(func, x, direc1,
                                                      tol=xtol * 100,
                                                      lower_bound=lower_bound,
                                                      upper_bound=upper_bound,
                                                      fval=fval)
-                if np.any(direc1):
-                    direc[bigind] = direc[-1]
-                    direc[-1] = direc1
+                if (fx2 - fval) > delta:
+                    delta = fx2 - fval
+                    bigind = i
+            iter += 1
+            if callback is not None:
+                callback(x)
+            if retall:
+                allvecs.append(x)
+            bnd = ftol * (np.abs(fx) + np.abs(fval)) + 1e-20
+            if 2.0 * (fx - fval) <= bnd:
+                break
+            if fcalls[0] >= maxfun:
+                break
+            if iter >= maxiter:
+                break
+            if np.isnan(fx) and np.isnan(fval):
+                # Ended up in a nan-region: bail out
+                break
+
+            # Construct the extrapolated point
+            direc1 = x - x1
+            x2 = 2*x - x1
+            x1 = x.copy()
+            fx2 = squeeze(func(x2))
+
+            if (fx > fx2):
+                t = 2.0*(fx + fx2 - 2.0*fval)
+                temp = (fx - fval - delta)
+                t *= temp*temp
+                temp = fx - fx2
+                t -= delta*temp*temp
+                if t < 0.0:
+                    fval, x, direc1 = _linesearch_powell(func, x, direc1,
+                                                         tol=xtol * 100,
+                                                         lower_bound=lower_bound,
+                                                         upper_bound=upper_bound,
+                                                         fval=fval)
+                    if np.any(direc1):
+                        direc[bigind] = direc[-1]
+                        direc[-1] = direc1
+        except _MaxFuncCallError:
+            break
 
     warnflag = 0
     # out of bounds is more urgent than exceeding function evals or iters,

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -488,7 +488,7 @@ def _wrap_scalar_function_with_validation(function, args, maxfun):
 
     def function_wrapper(x, *wrapper_args):
         if ncalls[0] >= maxfun:
-            raise _MaxFuncCallError()
+            raise _MaxFuncCallError("Too many function calls")
         ncalls[0] += 1
         # A copy of x is sent to the user function (gh13740)
         fx = function(np.copy(x), *(wrapper_args + args))

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -493,7 +493,8 @@ def _wrap_scalar_function_with_validation(function, args, maxfun):
         # A copy of x is sent to the user function (gh13740)
         fx = function(np.copy(x), *(wrapper_args + args))
         # Ideally, we'd like to a have a true scalar returned from f(x). For
-        # backwards-compatibility, also allow np.array([1.3]), np.array([[1.3]]) etc.
+        # backwards-compatibility, also allow np.array([1.3]),
+        # np.array([[1.3]]) etc.
         if not np.isscalar(fx):
             try:
                 fx = np.asarray(fx).item()

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -535,7 +535,7 @@ def test_maxfev_test():
             result = optimize.minimize(cost, np.random.rand(10),
                                        method=method,
                                        options={'maxfev': imaxfev})
-            assert result["nfev"] == ifev
+            assert result["nfev"] == imaxfev
 
 
 def test_obj_func_returns_scalar():

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -542,11 +542,11 @@ def test_maxfev_test():
 
 def test_wrap_scalar_function_with_validation():
 
-    def func(x):
+    def func_(x):
         return x
 
     fcalls, func = optimize.optimize.\
-        _wrap_scalar_function_with_validation(func, np.asarray(1), 5)
+        _wrap_scalar_function_with_validation(func_, np.asarray(1), 5)
 
     for i in range(5):
         func(np.asarray(i))
@@ -555,6 +555,13 @@ def test_wrap_scalar_function_with_validation():
     msg = "Too many function calls"
     with assert_raises(optimize.optimize._MaxFuncCallError, match=msg):
         func(np.asarray(i))  # exceeded maximum function call
+
+    fcalls, func = optimize.optimize.\
+        _wrap_scalar_function_with_validation(func_, np.asarray(1), 5)
+
+    msg = "The user-provided objective function must return a scalar value."
+    with assert_raises(ValueError, match=msg):
+        func(np.array([1, 1]))
 
 
 def test_obj_func_returns_scalar():

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -525,6 +525,14 @@ class CheckOptimizeParameterized(CheckOptimize):
                          [-4.35700753e-07, -5.24869401e-01, 4.87527774e-01]],
                         atol=1e-6, rtol=1e-7)
 
+    def test_maxfev_test(self):
+
+        for method in ['Powell']:  # extend to more methods
+            result = optimize.minimize(self.func, self.startparams,
+                                       method=method,
+                                       options={'maxfev': 1})
+            assert result["nfev"] <= 1
+
 
 def test_obj_func_returns_scalar():
     match = ("The user-provided "

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -527,8 +527,9 @@ class CheckOptimizeParameterized(CheckOptimize):
 
 
 def test_maxfev_test():
+    rng = np.random.default_rng(271707100830272976862395227613146332411)
     def cost(x):
-        return np.random.rand(1) * 1000  # never converged problem
+        return rng.random(1) * 1000  # never converged problem
 
     for imaxfev in [1, 10, 50]:
         for method in ['Powell']:  # TODO: extend to more methods

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -540,6 +540,22 @@ def test_maxfev_test():
             assert result["nfev"] == imaxfev
 
 
+def test_wrap_scalar_function_with_validation():
+
+    def func(x):
+        return x
+
+    fcalls, func = optimize.optimize.\
+        _wrap_scalar_function_with_validation(func, np.asarray(1), 5)
+
+    for i in range(5):
+        func(np.asarray(i))
+        assert fcalls[0] == i+1
+
+    with assert_raises(optimize.optimize._MaxFuncCallError):
+        func(np.asarray(i))  # exceeded maximum function call
+
+
 def test_obj_func_returns_scalar():
     match = ("The user-provided "
              "objective function must "

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -533,7 +533,7 @@ def test_maxfev_test():
 
     for imaxfev in [1, 10, 50]:
         for method in ['Powell']:  # TODO: extend to more methods
-            result = optimize.minimize(cost, np.random.rand(10),
+            result = optimize.minimize(cost, rng.random(10),
                                        method=method,
                                        options={'maxfev': imaxfev})
             assert result["nfev"] == imaxfev

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -552,7 +552,8 @@ def test_wrap_scalar_function_with_validation():
         func(np.asarray(i))
         assert fcalls[0] == i+1
 
-    with assert_raises(optimize.optimize._MaxFuncCallError):
+    msg = "Too many function calls"
+    with assert_raises(optimize.optimize._MaxFuncCallError, match=msg):
         func(np.asarray(i))  # exceeded maximum function call
 
 

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -528,6 +528,7 @@ class CheckOptimizeParameterized(CheckOptimize):
 
 def test_maxfev_test():
     rng = np.random.default_rng(271707100830272976862395227613146332411)
+
     def cost(x):
         return rng.random(1) * 1000  # never converged problem
 

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -525,13 +525,17 @@ class CheckOptimizeParameterized(CheckOptimize):
                          [-4.35700753e-07, -5.24869401e-01, 4.87527774e-01]],
                         atol=1e-6, rtol=1e-7)
 
-    def test_maxfev_test(self):
 
-        for method in ['Powell']:  # extend to more methods
-            result = optimize.minimize(self.func, self.startparams,
+def test_maxfev_test():
+    def cost(X):
+        return np.random.rand(1) * 1000  # never converged problem
+
+    for ifev in [1, 10, 50]:
+        for method in ['Powell']:  # TODO: extend to more methods
+            result = optimize.minimize(cost, np.random.rand(10),
                                        method=method,
-                                       options={'maxfev': 1})
-            assert result["nfev"] <= 1
+                                       options={'maxfev': ifev})
+            assert result["nfev"] == ifev
 
 
 def test_obj_func_returns_scalar():

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -527,14 +527,14 @@ class CheckOptimizeParameterized(CheckOptimize):
 
 
 def test_maxfev_test():
-    def cost(X):
+    def cost(x):
         return np.random.rand(1) * 1000  # never converged problem
 
-    for ifev in [1, 10, 50]:
+    for imaxfev in [1, 10, 50]:
         for method in ['Powell']:  # TODO: extend to more methods
             result = optimize.minimize(cost, np.random.rand(10),
                                        method=method,
-                                       options={'maxfev': ifev})
+                                       options={'maxfev': imaxfev})
             assert result["nfev"] == ifev
 
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
fix a part of #12271

#### What does this implement/fix?
As reported in #12271, `minimize` with Powell method has an issue of max function call validation.
The reason for this issue is that `minimize_powell` check the max function call here once a loop:
https://github.com/scipy/scipy/blob/fbcfba22f2e4f89510f0bc1e24591a6b91204378/scipy/optimize/optimize.py#L3018-L3019
But, `_linesearch_powell` might evaluate the function multiple times.
To fix the issue, I create a new wrap function `_wrap_function_with_validation` which counts function evaluation and raises an exception when function evaluation reaches the maximum value.
We should check other methods have the same issue or not, but this PR only focuses on fixing the issue of Powell method.

