### PR TITLE
BUG: stats: magnitude of Yates' correction <= abs(observed-expected) statistic

### DIFF
--- a/scipy/stats/contingency.py
+++ b/scipy/stats/contingency.py
@@ -287,7 +287,11 @@ def chi2_contingency(observed, correction=True, lambda_=None):
     else:
         if dof == 1 and correction:
             # Adjust `observed` according to Yates' correction for continuity.
-            observed = observed + 0.5 * np.sign(expected - observed)
+            # Magnitude of correction no bigger than difference; see gh-13875
+            diff = expected - observed
+            direction = np.sign(diff)
+            magnitude = np.minimum(0.5, np.abs(diff))
+            observed = observed + magnitude * direction
 
         chi2, p = power_divergence(observed, expected,
                                    ddof=observed.size - 1 - dof, axis=None,

--- a/scipy/stats/tests/test_contingency.py
+++ b/scipy/stats/tests/test_contingency.py
@@ -198,6 +198,14 @@ def test_chi2_contingency_bad_args():
     assert_raises(ValueError, chi2_contingency, obs)
 
 
+def test_chi2_contingency_yates_gh13875():
+    # Magnitude of Yates' continuity correction should not exceed difference
+    # between expected and observed value of the statistic; see gh-13875
+    observed = np.array([[1573, 3], [4, 0]])
+    p = chi2_contingency(observed)[1]
+    assert_allclose(p, 1, rtol=1e-12)
+
+
 def test_bad_association_args():
     # Invalid Test Statistic
     assert_raises(ValueError, association, [[1, 2], [3, 4]], "X")


### PR DESCRIPTION
#### Reference issue
gh-13875

#### What does this implement/fix?
I'm not really sure!
It does what @WarrenWeckesser said to do [here](https://github.com/scipy/scipy/issues/13875#issuecomment-821314590) to fix the bug reported [here](https://github.com/scipy/scipy/issues/13875#issue-859828403).

#### Additional information
Blindly following what I read in gh-13875; please correct me if I misread. 