### PR TITLE
DOC: correct return type in disjoint_set.subsets docstring

### DIFF
--- a/scipy/_lib/_disjoint_set.py
+++ b/scipy/_lib/_disjoint_set.py
@@ -215,7 +215,7 @@ class DisjointSet:
 
         Returns
         -------
-        result : set
+        result : list
             Subsets in the disjoint set.
         """
         result = []


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### What does this implement/fix?
<!--Please explain your changes.-->
The docstring of the `scipy.cluster.hierarchy.disjoint_set.subsets` method states that the return value is a set. It is in fact a list, but I think that an iterator would be more in the spirit of modern python.

I have changed the return type to an iterator and updated the docstring. This is a breaking change, albeit a small one in a new module - @rgommers could you advise?