### PR TITLE
BUG: DOC: signal: fix need argument config and add missing doc link for `signal.get_window`

### DIFF
--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -702,8 +702,8 @@ def test_needs_params():
                    'general gaussian', 'general_gaussian',
                    'general gauss', 'general_gauss', 'ggs',
                    'dss', 'dpss',
-                   'chebwin', 'cheb', 'exponential', 'poisson', 'tukey',
-                   'tuk', 'dpss']:
+                   'chebwin', 'cheb',
+                   ]:
         assert_raises(ValueError, get_window, winstr, 7)
 
 
@@ -721,6 +721,10 @@ def test_not_needs_params():
                    'nuttall',
                    'parzen',
                    'taylor',
+                   'exponential',
+                   'poisson',
+                   'tukey',
+                   'tuk',
                    'triangle']:
         win = get_window(winstr, 7)
         assert_equal(len(win), 7)

--- a/scipy/signal/windows/windows.py
+++ b/scipy/signal/windows/windows.py
@@ -2018,7 +2018,7 @@ _win_equiv_raw = {
     ('chebwin', 'cheb'): (chebwin, True),
     ('cosine', 'halfcosine'): (cosine, False),
     ('dpss',): (dpss, True),
-    ('exponential', 'poisson'): (exponential, True),
+    ('exponential', 'poisson'): (exponential, False),
     ('flattop', 'flat', 'flt'): (flattop, False),
     ('gaussian', 'gauss', 'gss'): (gaussian, True),
     ('general gaussian', 'general_gaussian',
@@ -2030,7 +2030,7 @@ _win_equiv_raw = {
     ('parzen', 'parz', 'par'): (parzen, False),
     ('taylor', 'taylorwin'): (taylor, False),
     ('triangle', 'triang', 'tri'): (triang, False),
-    ('tukey', 'tuk'): (tukey, True),
+    ('tukey', 'tuk'): (tukey, False),
 }
 
 # Fill dict with all valid window name strings
@@ -2083,15 +2083,16 @@ def get_window(window, Nx, fftbins=True):
     - `~scipy.signal.windows.blackmanharris`
     - `~scipy.signal.windows.nuttall`
     - `~scipy.signal.windows.barthann`
+    - `~scipy.signal.windows.cosine`
+    - `~scipy.signal.windows.exponential`
+    - `~scipy.signal.windows.tukey`
+    - `~scipy.signal.windows.taylor`
     - `~scipy.signal.windows.kaiser` (needs beta)
     - `~scipy.signal.windows.gaussian` (needs standard deviation)
     - `~scipy.signal.windows.general_gaussian` (needs power, width)
     - `~scipy.signal.windows.dpss` (needs normalized half-bandwidth)
     - `~scipy.signal.windows.chebwin` (needs attenuation)
-    - `~scipy.signal.windows.exponential` (needs center, decay scale)
-    - `~scipy.signal.windows.tukey` (needs taper fraction)
-    - `~scipy.signal.windows.taylor` (needs number of constant sidelobes,
-      sidelobe level)
+
 
     If the window requires no parameters, then `window` can be a string.
 


### PR DESCRIPTION

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
fix #13158

#### What does this implement/fix?
<!--Please explain your changes.-->
I fixed need argument configs.
Current configs show [signal\.windows\.tukey](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.windows.tukey.html#scipy.signal.windows.tukey) and [signal\.windows\.exponential](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.windows.exponential.html#scipy.signal.windows.exponential) needs additional argument, but actually do not.
I fixed the test for the change.
Also, I added missing doc link of `windows.cosine` for `signal.get_window` note.
