### PR TITLE
REL: add PEP 621 (project metadata in pyproject.toml) support

### DIFF
--- a/doc/source/dev/core-dev/distributing.rst.inc
+++ b/doc/source/dev/core-dev/distributing.rst.inc
@@ -84,7 +84,7 @@ Version ranges for NumPy and other dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 For dependencies it's important to set lower and upper bounds on their
 versions. For *build-time* dependencies, they are specified in
-``pyproject.toml`` and the versions will _only_ apply to the SciPy build
+``pyproject.toml`` and the versions will *only* apply to the SciPy build
 itself. It's fine to specify either a range or a specific version for a
 dependency like ``wheel`` or ``setuptools``. For NumPy we have to worry
 about ABI compatibility too, hence we specify the version with ``==``
@@ -92,16 +92,16 @@ to the lowest supported version (because NumPy's ABI is backward but not
 forward compatible).
 
 For *run-time dependencies* (currently only ``numpy``), we specify the range
-of versions in ``install_requires`` in ``setup.py``. Getting the upper bound
-right is slightly tricky.  If we don't set any bound, a too-new version
-will be pulled in a few years down the line, and NumPy may have deprecated and
-removed some API that SciPy depended on by then. On the other hand if we set
-the upper bound to the newest already-released version, then as soon as a new
-NumPy version is released there will be no matching SciPy version that works
-with it. Given that NumPy and SciPy both release in a 6-monthly cadence and
-that features that get deprecated in NumPy should stay around for another two
-releases, we specify the upper bound as ``<1.xx+3.0`` (where ``xx`` is the
-minor version of the latest already-released NumPy.
+of versions in ``pyproject.toml`` and in ``install_requires`` in ``setup.py``.
+Getting the upper bound right is slightly tricky.  If we don't set any bound, a
+too-new version will be pulled in a few years down the line, and NumPy may have
+deprecated and removed some API that SciPy depended on by then. On the other
+hand if we set the upper bound to the newest already-released version, then as
+soon as a new NumPy version is released there will be no matching SciPy version
+that works with it. Given that NumPy and SciPy both release in a 6-monthly
+cadence and that features that get deprecated in NumPy should stay around for
+another two releases, we specify the upper bound as ``<1.xx+3.0`` (where ``xx``
+is the minor version of the latest already-released NumPy.
 
 
 .. _supported-py-numpy-versions:

--- a/doc/source/dev/core-dev/releasing.rst.inc
+++ b/doc/source/dev/core-dev/releasing.rst.inc
@@ -74,7 +74,8 @@ the goal is to be able to create releases that stay working for years. Hence
 correct upper bounds must be set. The following places must be updated after
 creating a maintenance branch:
 
-- ``pyproject.toml``: all build-time dependencies
+- ``pyproject.toml``: all build-time dependencies, as well as  supported Python
+                      and NumPy versions
 - ``setup.py``: supported Python and NumPy versions
 - ``scipy/__init__.py``: for NumPy version check
 

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -1,3 +1,5 @@
+# Note: this should disappear at some point. For now, please keep it
+#       in sync with the doc dependencies in pyproject.toml
 Sphinx!=3.1.0
 pydata-sphinx-theme>=0.6.1
 sphinx-panels>=0.5.2

--- a/mypy_requirements.txt
+++ b/mypy_requirements.txt
@@ -1,2 +1,4 @@
+# Note: this should disappear at some point. For now, please keep it
+#       in sync with the dev dependencies in pyproject.toml
 mypy
 typing_extensions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,70 @@ requires = [
     "numpy; python_version>='3.10'",
     "numpy; python_version>='3.8' and platform_python_implementation=='PyPy'",
 ]
+
+[project]
+name = "SciPy"
+license = {file = "LICENSE.txt"}
+
+maintainers = [
+    {name = "SciPy Developers", email = "scipy-dev@python.org"},
+]
+# Note: Python and NumPy upper version bounds should be set correctly in
+# release branches, see:
+#     https://scipy.github.io/devdocs/dev/core-dev/index.html#version-ranges-for-numpy-and-other-dependencies
+requires-python = ">=3.7"
+dependencies = [
+    "numpy>=1.16.5",
+]
+readme = "README.rst"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Science/Research",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: BSD License",
+    "Programming Language :: C",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: Scientific/Engineering",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: POSIX",
+    "Operating System :: Unix",
+    "Operating System :: MacOS",
+]
+dynamic = ['version', 'description']
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "pytest-cov",
+    "pytest-xdist",
+    "asv",
+    "mpmath",
+    "gmpy2",
+    "scikit-umfpack",
+]
+doc = [
+    "sphinx!=3.1.0",
+    "pydata-sphinx-theme>=0.6.1",
+    "sphinx-panels>=0.5.2",
+    "matplotlib>2",
+    "numpydoc==1.1.0",
+]
+dev = [
+    "mypy",
+    "typing_extensions",
+    "pycodestyle",
+    "flake8",
+]
+
+[project.urls]
+homepage = "https://scipy.org/"
+documentation = "https://docs.scipy.org/doc/scipy/reference/"
+source = "https://github.com/scipy/scipy"
+download = "https://github.com/scipy/scipy/releases"
+tracker = "https://github.com/scipy/scipy/issues"

--- a/setup.py
+++ b/setup.py
@@ -44,9 +44,10 @@ Programming Language :: Python :: 3
 Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
 Programming Language :: Python :: 3.9
-Topic :: Software Development
+Topic :: Software Development :: Libraries
 Topic :: Scientific/Engineering
 Operating System :: Microsoft :: Windows
+Operating System :: POSIX :: Linux
 Operating System :: POSIX
 Operating System :: Unix
 Operating System :: MacOS
@@ -533,7 +534,7 @@ def configuration(parent_package='', top_path=None):
 
 def setup_package():
     # In maintenance branch, change np_maxversion to N+3 if numpy is at N
-    # Update here and in scipy/__init__.py
+    # Update here, in pyproject.toml, and in scipy/__init__.py
     # Rationale: SciPy builds without deprecation warnings with N; deprecations
     #            in N+1 will turn into errors in N+3
     # For Python versions, if releases is (e.g.) <=3.9.x, set bound to 3.10
@@ -570,7 +571,6 @@ def setup_package():
         cmdclass=cmdclass,
         classifiers=[_f for _f in CLASSIFIERS.split('\n') if _f],
         platforms=["Windows", "Linux", "Solaris", "Mac OS-X", "Unix"],
-        test_suite='nose.collector',
         install_requires=[req_np],
         python_requires=req_py,
     )


### PR DESCRIPTION
Static metadata in a format that all packaging tools understand will be beneficial in the long term. PEP 621 (https://www.python.org/dev/peps/pep-0621/) became final last month, so let's support it.

`pip` doesn't have support yet it looks like, so can't really test. But this is all straightforward, should be correct (and can't break anything if CI passes). I based this on both the PEP itself and on [flit's implementation](https://github.com/takluyver/flit/blob/master/pyproject.toml).

@takluyver would you mind having a quick look at this? 