### PR TITLE
ENH: signal: make `get_window` supports `general_cosine` and `general_hamming` window functions.

### DIFF
--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -643,6 +643,19 @@ class TestGetWindow:
         with assert_raises(ValueError, match='must have the same length'):
             resample(sig, len(sig) * osfactor, window=win)
 
+    def test_general_cosine(self):
+        assert_allclose(get_window(('general_cosine', [0.5, 0.3, 0.2]), 4),
+                        [0.4, 0.3, 1, 0.3])
+        assert_allclose(get_window(('general_cosine', [0.5, 0.3, 0.2]), 4,
+                                   fftbins=False),
+                        [0.4, 0.55, 0.55, 0.4])
+
+    def test_general_hamming(self):
+        assert_allclose(get_window(('general_hamming', 0.7), 5),
+                        [0.4, 0.6072949, 0.9427051, 0.9427051, 0.6072949])
+        assert_allclose(get_window(('general_hamming', 0.7), 5, fftbins=False),
+                        [0.4, 0.7, 1.0, 0.7, 0.4])
+
 
 def test_windowfunc_basics():
     for window_name, params in window_funcs:
@@ -701,8 +714,8 @@ def test_needs_params():
     for winstr in ['kaiser', 'ksr', 'gaussian', 'gauss', 'gss',
                    'general gaussian', 'general_gaussian',
                    'general gauss', 'general_gauss', 'ggs',
-                   'dss', 'dpss',
-                   'chebwin', 'cheb',
+                   'dss', 'dpss', 'general cosine', 'general_cosine',
+                   'chebwin', 'cheb', 'general hamming', 'general_hamming',
                    ]:
         assert_raises(ValueError, get_window, winstr, 7)
 

--- a/scipy/signal/windows/windows.py
+++ b/scipy/signal/windows/windows.py
@@ -2021,8 +2021,10 @@ _win_equiv_raw = {
     ('exponential', 'poisson'): (exponential, False),
     ('flattop', 'flat', 'flt'): (flattop, False),
     ('gaussian', 'gauss', 'gss'): (gaussian, True),
+    ('general cosine', 'general_cosine'): (general_cosine, True),
     ('general gaussian', 'general_gaussian',
         'general gauss', 'general_gauss', 'ggs'): (general_gaussian, True),
+    ('general hamming', 'general_hamming'): (general_hamming, True),
     ('hamming', 'hamm', 'ham'): (hamming, False),
     ('hanning', 'hann', 'han'): (hann, False),
     ('kaiser', 'ksr'): (kaiser, True),
@@ -2089,7 +2091,9 @@ def get_window(window, Nx, fftbins=True):
     - `~scipy.signal.windows.taylor`
     - `~scipy.signal.windows.kaiser` (needs beta)
     - `~scipy.signal.windows.gaussian` (needs standard deviation)
+    - `~scipy.signal.windows.general_cosine` (needs weighting coefficients)
     - `~scipy.signal.windows.general_gaussian` (needs power, width)
+    - `~scipy.signal.windows.general_hamming` (needs window coefficient)
     - `~scipy.signal.windows.dpss` (needs normalized half-bandwidth)
     - `~scipy.signal.windows.chebwin` (needs attenuation)
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
fix #13933 

#### What does this implement/fix?
<!--Please explain your changes.-->
I implemented `get_window` supporting `general_cosine` and `general_hamming` window functions.
I also added tests and doc links for these.
