### PR TITLE
MAINT: QMCEngine d input validation

### DIFF
--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -567,7 +567,7 @@ class QMCEngine(ABC):
 
     @abstractmethod
     def __init__(self, d, seed=None):
-        if not isinstance(d, int):
+        if not np.issubdtype(type(d), np.integer):
             raise ValueError('d must be an integer value')
 
         self.d = d

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -567,6 +567,9 @@ class QMCEngine(ABC):
 
     @abstractmethod
     def __init__(self, d, seed=None):
+        if not isinstance(d, int):
+            raise ValueError('d must be an integer value')
+
         self.d = d
         self.rng = check_random_state(seed)
         self.rng_seed = copy.deepcopy(seed)
@@ -968,11 +971,11 @@ class Sobol(QMCEngine):
     MAXBIT = _MAXBIT
 
     def __init__(self, d, scramble=True, seed=None):
+        super().__init__(d=d, seed=seed)
         if d > self.MAXDIM:
             raise ValueError(
                 "Maximum supported dimensionality is {}.".format(self.MAXDIM)
             )
-        super().__init__(d=d, seed=seed)
 
         # initialize direction numbers
         initialize_direction_numbers()

--- a/scipy/stats/tests/test_qmc.py
+++ b/scipy/stats/tests/test_qmc.py
@@ -354,6 +354,10 @@ def test_subclassing_QMCEngine():
     assert_equal(sample_2, sample_2_test)
     assert engine.num_generated == 12
 
+    # input validation
+    with pytest.raises(ValueError, match=r"d must be an integer value"):
+            RandomEngine((2,), seed=seed)
+
 
 class QMCEngineTests:
     """Generic tests for QMC engines."""
@@ -574,9 +578,10 @@ class TestSobol(QMCEngineTests):
             engine.random_base2(2)
 
     def test_raise(self):
+        seed = np.random.RandomState(12345)
         with pytest.raises(ValueError, match=r"Maximum supported "
                                              r"dimensionality"):
-            qmc.Sobol(qmc.Sobol.MAXDIM + 1)
+            qmc.Sobol(qmc.Sobol.MAXDIM + 1, seed=seed)
 
     def test_high_dim(self):
         seed = np.random.RandomState(12345)


### PR DESCRIPTION
As pointed out in #13319, `d` is not checked when instantiating `QMCEngine`.