### PR TITLE
REL: prep for SciPy 1.6.4

### DIFF
--- a/doc/release/1.6.4-notes.rst
+++ b/doc/release/1.6.4-notes.rst
@@ -1,0 +1,21 @@
+==========================
+SciPy 1.6.4 Release Notes
+==========================
+
+.. contents::
+
+SciPy 1.6.4 is a bug-fix release with no new features
+compared to 1.6.3.
+
+Authors
+=======
+
+
+Issues closed for 1.6.4
+-----------------------
+
+
+
+Pull requests for 1.6.4
+-----------------------
+

--- a/doc/source/release.1.6.4.rst
+++ b/doc/source/release.1.6.4.rst
@@ -1,0 +1,1 @@
+.. include:: ../release/1.6.4-notes.rst

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
    :maxdepth: 1
 
+   release.1.6.4
    release.1.6.3
    release.1.6.2
    release.1.6.1

--- a/pavement.py
+++ b/pavement.py
@@ -69,10 +69,10 @@ except AttributeError:
 #-----------------------------------
 
 # Source of the release notes
-RELEASE = 'doc/release/1.6.3-notes.rst'
+RELEASE = 'doc/release/1.6.4-notes.rst'
 
 # Start/end of the log (from git)
-LOG_START = 'v1.6.2'
+LOG_START = 'v1.6.3'
 LOG_END = 'maintenance/1.6.x'
 
 

--- a/setup.py
+++ b/setup.py
@@ -55,8 +55,8 @@ Operating System :: MacOS
 
 MAJOR = 1
 MINOR = 6
-MICRO = 3
-ISRELEASED = True
+MICRO = 4
+ISRELEASED = False
 IS_RELEASE_BRANCH = True
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 


### PR DESCRIPTION
Prepare for SciPy `1.6.4` just in case. Realistically, attention will probably start shifting to `1.7.0` planning soon though.