### PR TITLE
ENH: optionally pass population, energies to differential evolution callback

### DIFF
--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -255,6 +255,34 @@ class TestDifferentialEvolutionSolver:
         result = differential_evolution(rosen, bounds, callback=callback_evaluates_false)
         assert result.success
 
+    def test_callback_args(self):
+        # test that callback arguments obey full_population parameter
+        bounds = [(0, 2), (0, 2), (0, 2)]
+
+        def simple_callback(xk, convergence=0.):
+            # xk should be a 1D-array and same size as bounds
+            assert isinstance(xk, np.ndarray)
+            assert xk.shape == (len(bounds),)
+
+            return
+
+        result = differential_evolution(rosen, bounds, maxiter=1, callback=simple_callback)
+
+        def full_callback(xk, convergence=0.):
+            # xk should be tuple of len 2
+            assert len(xk) == 2
+
+            # test for correct type and size of population and energies
+            population, energies = xk
+            assert isinstance(population, np.ndarray)
+            assert isinstance(energies, np.ndarray)
+            assert population.shape == (len(bounds)*5, len(bounds))  # popsize=5
+            assert energies.shape == (len(bounds)*5,)  # popsize=5
+
+            return
+
+        result = differential_evolution(rosen, bounds, maxiter=1, callback=full_callback, full_population=True, popsize=5)
+
     def test_args_tuple_is_passed(self):
         # test that the args tuple is passed to the cost function properly.
         bounds = [(-10, 10)]


### PR DESCRIPTION
Adds `full_population` parameter (defaults to False) to `differential_evolution` that allows a tuple (scaled population, energies) to be passed as the first argument to the callback function instead of just `x0`.

Also added unit tests.

Note this is an optional feature and does not really change the callback function signature. The callback still has the form `callback(xk, convergence)` but when `full_population=True`, all the user needs to do is unpack the 2-tuple passed as `xk`. Additionally the original meaning of `xk`, the best parameter `x0`, call be attained by just accessing the first row in the population array.

There has been some discussion/attempts at this in the past (#6878, #6890, #6905, #6923), so this feature appears to be wanted, but so far none of the solutions have been satisfactory since they break backwards-compatibility. That is why I propose this method which is opt-in and still uses the same 2-argument callback function.

Also toyed around with the idea of stacking the population and energy arrays into a single array so that `xk` would be a single array in either case. Also not totally sold on the name of the parameter (`full_population`). Happy to discuss the best path forward.