### PR TITLE
DOC: minor grammar fixes in minimize and KDTree.query

### DIFF
--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -96,7 +96,8 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
 
         where ``x`` is an array with shape (n,) and ``args`` is a tuple with
         the fixed parameters. If `jac` is a Boolean and is True, `fun` is
-        assumed to return and objective and gradient as an ``(f, g)`` tuple.
+        assumed to return a tuple ``(f, g)`` containing the objective
+        function and the gradient.
         Methods 'Newton-CG', 'trust-ncg', 'dogleg', 'trust-exact', and
         'trust-krylov' require that either a callable be supplied, or that
         `fun` return the objective and gradient.

--- a/scipy/spatial/kdtree.py
+++ b/scipy/spatial/kdtree.py
@@ -354,9 +354,9 @@ class KDTree(cKDTree):
             distance to the real kth nearest neighbor.
         p : float, 1<=p<=infinity, optional
             Which Minkowski p-norm to use.
-            1 is the sum-of-absolute-values "Manhattan" distance
-            2 is the usual Euclidean distance
-            infinity is the maximum-coordinate-difference distance
+            1 is the sum-of-absolute-values distance ("Manhattan" distance).
+            2 is the usual Euclidean distance.
+            infinity is the maximum-coordinate-difference distance.
             A large, finite p may cause a ValueError if overflow can occur.
         distance_upper_bound : nonnegative float, optional
             Return only neighbors within this distance. This is used to prune


### PR DESCRIPTION
Fixes a small typo in the minimize docs.

Fixes #13950.