### PR TITLE
ENH: stats: add `alternative` to masked normality tests

### DIFF
--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -2515,24 +2515,33 @@ def stde_median(data, axis=None):
 SkewtestResult = namedtuple('SkewtestResult', ('statistic', 'pvalue'))
 
 
-def skewtest(a, axis=0):
+def skewtest(a, axis=0, alternative='two-sided'):
     """
     Tests whether the skew is different from the normal distribution.
 
     Parameters
     ----------
-    a : array
+    a : array_like
         The data to be tested
     axis : int or None, optional
        Axis along which statistics are calculated. Default is 0.
        If None, compute over the whole array `a`.
+    alternative : {'two-sided', 'less', 'greater'}, optional
+        Defines the alternative hypothesis.
+        The following options are available (default is 'two-sided'):
+
+          * 'two-sided'
+          * 'less': one-sided
+          * 'greater': one-sided
+
+        .. versionadded:: 1.7.0
 
     Returns
     -------
-    statistic : float
+    statistic : array_like
         The computed z-score for this test.
-    pvalue : float
-        a 2-sided p-value for the hypothesis test
+    pvalue : array_like
+        A p-value for the hypothesis test
 
     Notes
     -----
@@ -2540,6 +2549,9 @@ def skewtest(a, axis=0):
 
     """
     a, axis = _chk_asarray(a, axis)
+    if alternative not in {'two-sided', 'less', 'greater'}:
+        raise ValueError("alternative must be "
+                         "'less', 'greater' or 'two-sided'")
     if axis is None:
         a = a.ravel()
         axis = 0
@@ -2558,30 +2570,39 @@ def skewtest(a, axis=0):
     y = ma.where(y == 0, 1, y)
     Z = delta*ma.log(y/alpha + ma.sqrt((y/alpha)**2+1))
 
-    return SkewtestResult(Z, 2 * distributions.norm.sf(np.abs(Z)))
+    return SkewtestResult(*scipy.stats.stats._normtest_finish(Z, alternative))
 
 
 KurtosistestResult = namedtuple('KurtosistestResult', ('statistic', 'pvalue'))
 
 
-def kurtosistest(a, axis=0):
+def kurtosistest(a, axis=0, alternative='two-sided'):
     """
     Tests whether a dataset has normal kurtosis
 
     Parameters
     ----------
-    a : array
+    a : array_like
         array of the sample data
     axis : int or None, optional
        Axis along which to compute test. Default is 0. If None,
        compute over the whole array `a`.
+    alternative : {'two-sided', 'less', 'greater'}, optional
+        Defines the alternative hypothesis.
+        The following options are available (default is 'two-sided'):
+
+          * 'two-sided'
+          * 'less': one-sided
+          * 'greater': one-sided
+
+        .. versionadded:: 1.7.0
 
     Returns
     -------
-    statistic : float
+    statistic : array_like
         The computed z-score for this test.
-    pvalue : float
-        The 2-sided p-value for the hypothesis test
+    pvalue : array_like
+        The p-value for the hypothesis test
 
     Notes
     -----
@@ -2589,6 +2610,9 @@ def kurtosistest(a, axis=0):
 
     """
     a, axis = _chk_asarray(a, axis)
+    if alternative not in {'two-sided', 'less', 'greater'}:
+        raise ValueError("alternative must be "
+                         "'less', 'greater' or 'two-sided'")
     n = a.count(axis=axis)
     if np.min(n) < 5:
         raise ValueError(
@@ -2618,7 +2642,9 @@ def kurtosistest(a, axis=0):
                         -ma.power(-(1-2.0/A)/denom, 1/3.0))
     Z = (term1 - term2) / np.sqrt(2/(9.0*A))
 
-    return KurtosistestResult(Z, 2 * distributions.norm.sf(np.abs(Z)))
+    return KurtosistestResult(
+        *scipy.stats.stats._normtest_finish(Z, alternative)
+    )
 
 
 NormaltestResult = namedtuple('NormaltestResult', ('statistic', 'pvalue'))

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -2527,12 +2527,15 @@ def skewtest(a, axis=0, alternative='two-sided'):
        Axis along which statistics are calculated. Default is 0.
        If None, compute over the whole array `a`.
     alternative : {'two-sided', 'less', 'greater'}, optional
-        Defines the alternative hypothesis.
-        The following options are available (default is 'two-sided'):
+        Defines the alternative hypothesis. Default is 'two-sided'.
+        The following options are available:
 
-          * 'two-sided'
-          * 'less': one-sided
-          * 'greater': one-sided
+        * 'two-sided': the skewness of the distribution underlying the sample
+          is different from that of the normal distribution (i.e. 0)
+        * 'less': the skewness of the distribution underlying the sample
+          is less than that of the normal distribution
+        * 'greater': the skewness of the distribution underlying the sample
+          is greater than that of the normal distribution
 
         .. versionadded:: 1.7.0
 
@@ -2549,9 +2552,6 @@ def skewtest(a, axis=0, alternative='two-sided'):
 
     """
     a, axis = _chk_asarray(a, axis)
-    if alternative not in {'two-sided', 'less', 'greater'}:
-        raise ValueError("alternative must be "
-                         "'less', 'greater' or 'two-sided'")
     if axis is None:
         a = a.ravel()
         axis = 0
@@ -2591,9 +2591,12 @@ def kurtosistest(a, axis=0, alternative='two-sided'):
         Defines the alternative hypothesis.
         The following options are available (default is 'two-sided'):
 
-          * 'two-sided'
-          * 'less': one-sided
-          * 'greater': one-sided
+        * 'two-sided': the kurtosis of the distribution underlying the sample
+          is different from that of the normal distribution
+        * 'less': the kurtosis of the distribution underlying the sample
+          is less than that of the normal distribution
+        * 'greater': the kurtosis of the distribution underlying the sample
+          is greater than that of the normal distribution
 
         .. versionadded:: 1.7.0
 
@@ -2610,9 +2613,6 @@ def kurtosistest(a, axis=0, alternative='two-sided'):
 
     """
     a, axis = _chk_asarray(a, axis)
-    if alternative not in {'two-sided', 'less', 'greater'}:
-        raise ValueError("alternative must be "
-                         "'less', 'greater' or 'two-sided'")
     n = a.count(axis=axis)
     if np.min(n) < 5:
         raise ValueError(

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1422,12 +1422,8 @@ def skewtest(a, axis=0, nan_policy='propagate', alternative='two-sided'):
     contains_nan, nan_policy = _contains_nan(a, nan_policy)
 
     if contains_nan and nan_policy == 'omit':
-        if alternative != 'two-sided':
-            raise ValueError("nan-containing/masked inputs with "
-                             "nan_policy='omit' are currently not "
-                             "supported by one-sided alternatives.")
         a = ma.masked_invalid(a)
-        return mstats_basic.skewtest(a, axis)
+        return mstats_basic.skewtest(a, axis, alternative)
 
     if axis is None:
         a = np.ravel(a)
@@ -1525,12 +1521,8 @@ def kurtosistest(a, axis=0, nan_policy='propagate', alternative='two-sided'):
     contains_nan, nan_policy = _contains_nan(a, nan_policy)
 
     if contains_nan and nan_policy == 'omit':
-        if alternative != 'two-sided':
-            raise ValueError("nan-containing/masked inputs with "
-                             "nan_policy='omit' are currently not "
-                             "supported by one-sided alternatives.")
         a = ma.masked_invalid(a)
-        return mstats_basic.kurtosistest(a, axis)
+        return mstats_basic.kurtosistest(a, axis, alternative)
 
     n = a.shape[axis]
     if n < 5:

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -974,6 +974,16 @@ class TestNormalitytests():
         assert_allclose(z, z_ex, atol=1e-12)
         assert_allclose(p, p_ex, atol=1e-12)
 
+    def test_bad_alternative(self):
+        x = stats.norm.rvs(size=20, random_state=123)
+        msg = r"alternative must be 'less', 'greater' or 'two-sided'"
+
+        with pytest.raises(ValueError, match=msg):
+            mstats.skewtest(x, alternative='error')
+
+        with pytest.raises(ValueError, match=msg):
+            mstats.kurtosistest(x, alternative='error')
+
 
 class TestFOneway():
     def test_result_attributes(self):

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -961,6 +961,19 @@ class TestNormalitytests():
         x = np.hstack([np.full(c, i) for i, c in enumerate(counts)])
         assert_equal(mstats.kurtosistest(x)[1] < 0.01, True)
 
+    @pytest.mark.parametrize("test", ["skewtest", "kurtosistest"])
+    @pytest.mark.parametrize("alternative", ["less", "greater"])
+    def test_alternative(self, test, alternative):
+        x = stats.norm.rvs(loc=10, scale=2.5, size=20, random_state=123)
+
+        stats_test = getattr(stats, test)
+        mstats_test = getattr(mstats, test)
+
+        z_ex, p_ex = stats_test(x, alternative=alternative)
+        z, p = mstats_test(x, alternative=alternative)
+        assert_allclose(z, z_ex, atol=1e-12)
+        assert_allclose(p, p_ex, atol=1e-12)
+
 
 class TestFOneway():
     def test_result_attributes(self):

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -964,12 +964,20 @@ class TestNormalitytests():
     @pytest.mark.parametrize("test", ["skewtest", "kurtosistest"])
     @pytest.mark.parametrize("alternative", ["less", "greater"])
     def test_alternative(self, test, alternative):
-        x = stats.norm.rvs(loc=10, scale=2.5, size=20, random_state=123)
+        x = stats.norm.rvs(loc=10, scale=2.5, size=30, random_state=123)
 
         stats_test = getattr(stats, test)
         mstats_test = getattr(mstats, test)
 
         z_ex, p_ex = stats_test(x, alternative=alternative)
+        z, p = mstats_test(x, alternative=alternative)
+        assert_allclose(z, z_ex, atol=1e-12)
+        assert_allclose(p, p_ex, atol=1e-12)
+
+        # test with masked arrays
+        x[1:5] = np.nan
+        x = np.ma.masked_array(x, mask=np.isnan(x))
+        z_ex, p_ex = stats_test(x.compressed(), alternative=alternative)
         z, p = mstats_test(x, alternative=alternative)
         assert_allclose(z, z_ex, atol=1e-12)
         assert_allclose(p, p_ex, atol=1e-12)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4629,13 +4629,19 @@ def test_normalitytests():
     expected = (1.0184643553962129, 0.30845733195153502)
     assert_array_almost_equal(stats.skewtest(x, nan_policy='omit'), expected)
 
+    # test alternative with nan_policy='omit'
+    a1[10:100] = np.nan
+    z, p = stats.skewtest(a1, nan_policy='omit')
+    zl, pl = stats.skewtest(a1, nan_policy='omit', alternative='less')
+    zg, pg = stats.skewtest(a1, nan_policy='omit', alternative='greater')
+    assert_allclose(zl, z, atol=1e-15)
+    assert_allclose(zg, z, atol=1e-15)
+    assert_allclose(pl, 1 - p/2, atol=1e-15)
+    assert_allclose(pg, p/2, atol=1e-15)
+
     with np.errstate(all='ignore'):
         assert_raises(ValueError, stats.skewtest, x, nan_policy='raise')
     assert_raises(ValueError, stats.skewtest, x, nan_policy='foobar')
-    assert_raises(ValueError, stats.skewtest, x, nan_policy='omit',
-                  alternative='less')
-    assert_raises(ValueError, stats.skewtest, x, nan_policy='omit',
-                  alternative='greater')
     assert_raises(ValueError, stats.skewtest, list(range(8)),
                   alternative='foobar')
 
@@ -4648,12 +4654,20 @@ def test_normalitytests():
     assert_array_almost_equal(stats.kurtosistest(x, nan_policy='omit'),
                               expected)
 
+    # test alternative with nan_policy='omit'
+    a2[10:20] = np.nan
+    z, p = stats.kurtosistest(a2[:100], nan_policy='omit')
+    zl, pl = stats.kurtosistest(a2[:100], nan_policy='omit',
+                                alternative='less')
+    zg, pg = stats.kurtosistest(a2[:100], nan_policy='omit',
+                                alternative='greater')
+    assert_allclose(zl, z, atol=1e-15)
+    assert_allclose(zg, z, atol=1e-15)
+    assert_allclose(pl, 1 - p/2, atol=1e-15)
+    assert_allclose(pg, p/2, atol=1e-15)
+
     assert_raises(ValueError, stats.kurtosistest, x, nan_policy='raise')
     assert_raises(ValueError, stats.kurtosistest, x, nan_policy='foobar')
-    assert_raises(ValueError, stats.kurtosistest, x, nan_policy='omit',
-                  alternative='less')
-    assert_raises(ValueError, stats.kurtosistest, x, nan_policy='omit',
-                  alternative='greater')
     assert_raises(ValueError, stats.kurtosistest, list(range(20)),
                   alternative='foobar')
 


### PR DESCRIPTION
#### Reference issue

Addresses gh-12506.
gh-13549 added the alternative parameter to some normality tests but forgot to add it to the masked version. This is a continuation of that work.

#### What does this implement/fix?

`skewtest` and `kurtosistest` were missing an `alternative` parameter
in their masked version. It has been added and tested now.

#### Additional information

N/A