### PR TITLE
MAINT: stats: Fix unused imports and a few other issues related to imports.

### DIFF
--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -4,10 +4,10 @@ import warnings
 from collections import namedtuple
 
 import numpy as np
-from numpy import (isscalar, r_, log, around, unique, asarray,
-                   zeros, arange, sort, amin, amax, any, atleast_1d,
-                   sqrt, ceil, floor, array, compress,
-                   pi, exp, ravel, count_nonzero, sin, cos, arctan2, hypot)
+from numpy import (isscalar, r_, log, around, unique, asarray, zeros,
+                   arange, sort, amin, amax, atleast_1d, sqrt, array,
+                   compress, pi, exp, ravel, count_nonzero, sin, cos,
+                   arctan2, hypot)
 
 from scipy import optimize
 from scipy import special
@@ -18,7 +18,6 @@ from .contingency import chi2_contingency
 from . import distributions
 from ._distn_infrastructure import rv_generic
 from ._hypotests import _get_wilcoxon_distr
-from .stats import _normtest_finish
 
 
 __all__ = ['mvsdist',
@@ -1058,7 +1057,7 @@ def boxcox(x, lmbda=None, alpha=None, optimizer=None):
     if np.all(x == x[0]):
         raise ValueError("Data must not be constant.")
 
-    if any(x <= 0):
+    if np.any(x <= 0):
         raise ValueError("Data must be positive.")
 
     if lmbda is not None:  # single transformation
@@ -2103,7 +2102,7 @@ def anderson_ksamp(samples, midrank=True):
                          "observation")
 
     n = np.array([sample.size for sample in samples])
-    if any(n == 0):
+    if np.any(n == 0):
         raise ValueError("anderson_ksamp encountered sample without "
                          "observations")
 

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -43,7 +43,6 @@ from collections import namedtuple
 from . import distributions
 import scipy.special as special
 import scipy.stats.stats
-from scipy._lib._util import float_factorial
 
 from ._stats_mstats_common import (
         _find_repeats,

--- a/scipy/stats/tests/common_tests.py
+++ b/scipy/stats/tests/common_tests.py
@@ -2,7 +2,7 @@ import pickle
 
 import numpy as np
 import numpy.testing as npt
-from numpy.testing import assert_allclose, assert_equal, suppress_warnings
+from numpy.testing import assert_allclose, assert_equal
 from pytest import raises as assert_raises
 
 import numpy.ma.testutils as ma_npt

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -15,7 +15,7 @@ from .common_tests import (check_normalization, check_moment, check_mean_expect,
                            check_random_state_property,
                            check_meth_dtype, check_ppf_dtype, check_cmplx_deriv,
                            check_pickling, check_rvs_broadcast, check_freezing)
-from scipy.stats._distr_params import distcont, invdistcont
+from scipy.stats._distr_params import distcont
 
 """
 Test all continuous distributions.

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -26,7 +26,7 @@ from scipy.stats._distn_infrastructure import argsreduce
 import scipy.stats.distributions
 
 from scipy.special import xlogy, polygamma, entr
-from .test_continuous_basic import distcont, invdistcont
+from scipy.stats._distr_params import distcont, invdistcont
 from .test_discrete_basic import distdiscrete, invdistdiscrete
 from scipy.stats._continuous_distns import FitDataError
 from scipy.optimize import root, fmin


### PR DESCRIPTION
* morestats.py
  * Remove unused imports of `floor` and `ceil`.
  * Don't shadow the builtin function `any`; use `np.any` instead.
  * Remove duplicated import of `_normtest_finish`.
* mstats_basic.py
  * Remove unused import of `float_factorial`.
* tests/common_tests.py
  * Remove unused import of `suppress_warnings`.
* tests/test_continuous_basic.py
  * Removed unused import of `invdistcont`.
* tests/test_distributions.py
  * Import `distcont` and `invdistcont` directly from
    `scipy.stats._distr_params` instead of from `test_continuous_basic`.
