### PR TITLE
BUG, TST: stats: fix RuntimeWarnings and add tests for the support method

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -1486,7 +1486,7 @@ class rv_generic:
         args, loc, scale = self._parse_args(*args, **kwargs)
         arrs = np.broadcast_arrays(*args, loc, scale)
         args, loc, scale = arrs[:-2], arrs[-2], arrs[-1]
-        cond = self._argcheck(*args) & (scale > 0) & (loc == loc)
+        cond = self._argcheck(*args) & (scale > 0) & ~np.isnan(loc)
         _a, _b = self._get_support(*args)
         # another `broadcast_arrays` call is required because
         # `_get_support` doesn't respect the shape of input

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -1486,7 +1486,7 @@ class rv_generic:
         args, loc, scale = self._parse_args(*args, **kwargs)
         arrs = np.broadcast_arrays(*args, loc, scale)
         args, loc, scale = arrs[:-2], arrs[-2], arrs[-1]
-        cond = self._argcheck(*args) & (scale > 0) & ~np.isnan(loc)
+        cond = (self._argcheck(*args) & (scale > 0) & ~np.isnan(loc))
         _a, _b = self._get_support(*args)
         # another `broadcast_arrays` call is required because
         # `_get_support` doesn't respect the shape of input

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -6080,7 +6080,11 @@ def test_support_broadcasting_gh13294_regression(distname, args):
         (4*[np.nan],) if isinstance(dist, stats.rv_discrete)
         else ([np.nan, 0, 0, 1], [3, np.nan, 0, -1])
     )
-    a0, b0 = dist.support(*args, *array_loc_scale)
+    with np.testing.suppress_warnings() as sup:
+        # on windows, numpy throws RuntimeWarning when using
+        # comparison operators on arrays with NaN values
+        sup.filter(RuntimeWarning, "invalid value encountered in greater")
+        a0, b0 = dist.support(*args, *array_loc_scale)
     ex_a0 = np.array(4*[np.nan])
     ex_b0 = np.array(4*[np.nan])
     assert_equal(a0, ex_a0)
@@ -6092,7 +6096,11 @@ def test_support_broadcasting_gh13294_regression(distname, args):
         ([],) if isinstance(dist, stats.rv_discrete)
         else ([], [])
     )
-    a1, b1 = dist.support(*args, *empty_loc_scale)
+    with np.testing.suppress_warnings() as sup:
+        # on windows, numpy throws RuntimeWarning when using
+        # comparison operators on arrays with NaN values
+        sup.filter(RuntimeWarning, "invalid value encountered in greater")
+        a1, b1 = dist.support(*args, *empty_loc_scale)
     ex_a1, ex_b1 = np.array([]), np.array([])
     assert_equal(a1, ex_a1)
     assert_equal(b1, ex_b1)
@@ -6118,7 +6126,11 @@ def test_support_broadcasting_gh13294_regression(distname, args):
              4*[np.nan]]
         )
 
-        a2, b2 = dist.support(*args, *broadcast_loc_scale)
+        with np.testing.suppress_warnings() as sup:
+            # on windows, numpy throws RuntimeWarning when using
+            # comparison operators on arrays with NaN values
+            sup.filter(RuntimeWarning, "invalid value encountered in greater")
+            a2, b2 = dist.support(*args, *broadcast_loc_scale)
         assert_equal(a2, ex_a2)
         assert_equal(b2, ex_b2)
         assert a2.shape == ex_a2.shape


### PR DESCRIPTION
#### Reference issue

closes gh-13504

#### What does this implement/fix?

The support method sometimes raised warnings when invalid inputs were given. This behavior has been fixed and a more comprehensive test suite for the support method has been added.

#### Additional information

In gh-13504,

> Add tests for distribution `support` (and possibly other) method(s) with array inputs.

Are there any specific methods missing tests with array inputs? I think most of them have been tested for specific distributions but can't find many test that check all the methods of all the distributions with valid and invalid array inputs in `scipy.stats`.