### PR TITLE
ENH: set empty array norm to zero.

### DIFF
--- a/scipy/linalg/misc.py
+++ b/scipy/linalg/misc.py
@@ -29,7 +29,7 @@ def norm(a, ord=None, axis=None, keepdims=False, check_finite=True):
         Input array. If `axis` is None, `a` must be 1-D or 2-D, unless `ord`
         is None. If both `axis` and `ord` are None, the 2-norm of
         ``a.ravel`` will be returned.
-    ord : {int, float, inf, -inf, 'fro', 'nuc', None}, optional
+    ord : {int, inf, -inf, 'fro', 'nuc', None}, optional
         Order of the norm (see table under ``Notes``). inf means NumPy's
         `inf` object.
     axis : {int, 2-tuple of ints, None}, optional

--- a/scipy/linalg/misc.py
+++ b/scipy/linalg/misc.py
@@ -18,15 +18,16 @@ def norm(a, ord=None, axis=None, keepdims=False, check_finite=True):
     """
     Matrix or vector norm.
 
-    This function is able to return one of seven different matrix norms,
+    This function is able to return one of eight different matrix norms,
     or one of an infinite number of vector norms (described below), depending
-    on the value of the ``ord`` parameter.
+    on the value of the ``ord`` parameter. For tensors with rank different from
+    1 or 2, only `ord=None` is supported.
 
     Parameters
     ----------
     a : (M,) or (M, N) array_like
         Input array. If `axis` is None, `a` must be 1D or 2D.
-    ord : {int, float, inf, -inf, 'fro', 'nuc'}, optional
+    ord : {int, float, inf, -inf, 'fro', 'nuc', None}, optional
         Order of the norm (see table under ``Notes``). inf means NumPy's
         `inf` object
     axis : {int, 2-tuple of ints, None}, optional
@@ -82,6 +83,9 @@ def norm(a, ord=None, axis=None, keepdims=False, check_finite=True):
 
     Both the Frobenius and nuclear norm orders are only defined for
     matrices and raise a ValueError when x.ndim != 2.
+
+    `ord=None` is supported for any array shape and returns the 2-norm
+    of the flattened array.
 
     References
     ----------

--- a/scipy/linalg/misc.py
+++ b/scipy/linalg/misc.py
@@ -146,7 +146,6 @@ def norm(a, ord=None, axis=None, keepdims=False, check_finite=True):
     else:
         a = np.asarray(a)
 
-    # Only use optimized norms if axis and keepdims are not specified.
     if a.size and a.dtype.char in 'fdFD' and axis is None and not keepdims:
 
         if ord in (None, 2) and (a.ndim == 1):

--- a/scipy/linalg/misc.py
+++ b/scipy/linalg/misc.py
@@ -26,7 +26,7 @@ def norm(a, ord=None, axis=None, keepdims=False, check_finite=True):
     ----------
     a : (M,) or (M, N) array_like
         Input array. If `axis` is None, `a` must be 1D or 2D.
-    ord : {non-zero int, inf, -inf, 'fro'}, optional
+    ord : {int, float, inf, -inf, 'fro', 'nuc'}, optional
         Order of the norm (see table under ``Notes``). inf means NumPy's
         `inf` object
     axis : {int, 2-tuple of ints, None}, optional
@@ -63,6 +63,7 @@ def norm(a, ord=None, axis=None, keepdims=False, check_finite=True):
     =====  ============================  ==========================
     None   Frobenius norm                2-norm
     'fro'  Frobenius norm                --
+    'nuc'  nuclear norm                  --
     inf    max(sum(abs(x), axis=1))      max(abs(x))
     -inf   min(sum(abs(x), axis=1))      min(abs(x))
     0      --                            sum(x != 0)
@@ -76,6 +77,11 @@ def norm(a, ord=None, axis=None, keepdims=False, check_finite=True):
     The Frobenius norm is given by [1]_:
 
         :math:`||A||_F = [\\sum_{i,j} abs(a_{i,j})^2]^{1/2}`
+
+    The nuclear norm is the sum of the singular values.
+
+    Both the Frobenius and nuclear norm orders are only defined for
+    matrices and raise a ValueError when x.ndim != 2.
 
     The ``axis`` and ``keepdims`` arguments are passed directly to
     ``numpy.linalg.norm`` and are only usable if they are supported

--- a/scipy/linalg/misc.py
+++ b/scipy/linalg/misc.py
@@ -176,14 +176,8 @@ def norm(a, ord=None, axis=None, keepdims=False, check_finite=True):
                 lange = get_lapack_funcs('lange', dtype=a.dtype, ilp64='preferred')
                 return lange(*lange_args)
 
-    # Filter out the axis and keepdims arguments if they aren't used so they
-    # are never inadvertently passed to a version of numpy that doesn't
-    # support them.
-    if axis is not None:
-        if keepdims:
-            return np.linalg.norm(a, ord=ord, axis=axis, keepdims=keepdims)
-        return np.linalg.norm(a, ord=ord, axis=axis)
-    return np.linalg.norm(a, ord=ord)
+    # fall back to numpy in every other case
+    return np.linalg.norm(a, ord=ord, axis=axis, keepdims=keepdims)
 
 
 def _datacopied(arr, original):

--- a/scipy/linalg/misc.py
+++ b/scipy/linalg/misc.py
@@ -31,7 +31,7 @@ def norm(a, ord=None, axis=None, keepdims=False, check_finite=True):
         ``a.ravel`` will be returned.
     ord : {int, float, inf, -inf, 'fro', 'nuc', None}, optional
         Order of the norm (see table under ``Notes``). inf means NumPy's
-        `inf` object
+        `inf` object.
     axis : {int, 2-tuple of ints, None}, optional
         If `axis` is an integer, it specifies the axis of `a` along which to
         compute the vector norms.  If `axis` is a 2-tuple, it specifies the
@@ -56,8 +56,7 @@ def norm(a, ord=None, axis=None, keepdims=False, check_finite=True):
     -----
     For values of ``ord <= 0``, the result is, strictly speaking, not a
     mathematical 'norm', but it may still be useful for various numerical
-    purposes. Empty array norm is set to 0.0 unless ``ord < 0``, where an
-    error is raised.
+    purposes.
 
     The following norms can be calculated:
 

--- a/scipy/linalg/misc.py
+++ b/scipy/linalg/misc.py
@@ -53,7 +53,8 @@ def norm(a, ord=None, axis=None, keepdims=False, check_finite=True):
     -----
     For values of ``ord <= 0``, the result is, strictly speaking, not a
     mathematical 'norm', but it may still be useful for various numerical
-    purposes.
+    purposes. Empty array norm is set to 0.0  unless ``ord <= 0``, where an
+    error is raised.
 
     The following norms can be calculated:
 
@@ -140,6 +141,13 @@ def norm(a, ord=None, axis=None, keepdims=False, check_finite=True):
         a = np.asarray_chkfinite(a)
     else:
         a = np.asarray(a)
+
+    # define empty array norm as 0.0 for ord > 0
+    if a.size == 0:
+        if ord in (None, "fro") or ord > 0:
+            return 0.0
+        else:
+            raise ValueError("Empty array norm is ill-defined for ord <= 0")
 
     # Only use optimized norms if axis and keepdims are not specified.
     if a.dtype.char in 'fdFD' and axis is None and not keepdims:

--- a/scipy/linalg/misc.py
+++ b/scipy/linalg/misc.py
@@ -156,7 +156,7 @@ def norm(a, ord=None, axis=None, keepdims=False, check_finite=True):
             nrm2 = get_blas_funcs('nrm2', dtype=a.dtype, ilp64='preferred')
             return nrm2(a)
 
-        if a.ndim == 2 and axis is None and not keepdims:
+        if a.ndim == 2:
             # Use lapack for a couple fast matrix norms.
             # For some reason the *lange frobenius norm is slow.
             lange_args = None

--- a/scipy/linalg/misc.py
+++ b/scipy/linalg/misc.py
@@ -148,15 +148,8 @@ def norm(a, ord=None, axis=None, keepdims=False, check_finite=True):
     else:
         a = np.asarray(a)
 
-    # define empty array norm as 0.0 for ord > 0
-    if a.size == 0:
-        if ord in (None, "fro") or ord > 0:
-            return 0.0
-        else:
-            raise ValueError("Empty array norm is ill-defined for ord <= 0")
-
     # Only use optimized norms if axis and keepdims are not specified.
-    if a.dtype.char in 'fdFD' and axis is None and not keepdims:
+    if a.size and a.dtype.char in 'fdFD' and axis is None and not keepdims:
 
         if ord in (None, 2) and (a.ndim == 1):
             # use blas for fast and stable euclidean norm

--- a/scipy/linalg/misc.py
+++ b/scipy/linalg/misc.py
@@ -26,7 +26,7 @@ def norm(a, ord=None, axis=None, keepdims=False, check_finite=True):
     Parameters
     ----------
     a : array_like
-        Input array.  If `axis` is None, `a` must be 1-D or 2-D, unless `ord`
+        Input array. If `axis` is None, `a` must be 1-D or 2-D, unless `ord`
         is None. If both `axis` and `ord` are None, the 2-norm of
         ``a.ravel`` will be returned.
     ord : {int, float, inf, -inf, 'fro', 'nuc', None}, optional
@@ -34,13 +34,13 @@ def norm(a, ord=None, axis=None, keepdims=False, check_finite=True):
         `inf` object.
     axis : {int, 2-tuple of ints, None}, optional
         If `axis` is an integer, it specifies the axis of `a` along which to
-        compute the vector norms.  If `axis` is a 2-tuple, it specifies the
+        compute the vector norms. If `axis` is a 2-tuple, it specifies the
         axes that hold 2-D matrices, and the matrix norms of these matrices
-        are computed.  If `axis` is None then either a vector norm (when `a`
+        are computed. If `axis` is None then either a vector norm (when `a`
         is 1-D) or a matrix norm (when `a` is 2-D) is returned.
     keepdims : bool, optional
         If this is set to True, the axes which are normed over are left in the
-        result as dimensions with size one.  With this option the result will
+        result as dimensions with size one. With this option the result will
         broadcast correctly against the original `a`.
     check_finite : bool, optional
         Whether to check that the input matrix contains only finite numbers.

--- a/scipy/linalg/misc.py
+++ b/scipy/linalg/misc.py
@@ -65,14 +65,14 @@ def norm(a, ord=None, axis=None, keepdims=False, check_finite=True):
     None   Frobenius norm                2-norm
     'fro'  Frobenius norm                --
     'nuc'  nuclear norm                  --
-    inf    max(sum(abs(x), axis=1))      max(abs(x))
-    -inf   min(sum(abs(x), axis=1))      min(abs(x))
-    0      --                            sum(x != 0)
-    1      max(sum(abs(x), axis=0))      as below
-    -1     min(sum(abs(x), axis=0))      as below
+    inf    max(sum(abs(a), axis=1))      max(abs(a))
+    -inf   min(sum(abs(a), axis=1))      min(abs(a))
+    0      --                            sum(a != 0)
+    1      max(sum(abs(a), axis=0))      as below
+    -1     min(sum(abs(a), axis=0))      as below
     2      2-norm (largest sing. value)  as below
     -2     smallest singular value       as below
-    other  --                            sum(abs(x)**ord)**(1./ord)
+    other  --                            sum(abs(a)**ord)**(1./ord)
     =====  ============================  ==========================
 
     The Frobenius norm is given by [1]_:
@@ -82,7 +82,7 @@ def norm(a, ord=None, axis=None, keepdims=False, check_finite=True):
     The nuclear norm is the sum of the singular values.
 
     Both the Frobenius and nuclear norm orders are only defined for
-    matrices and raise a ValueError when x.ndim != 2.
+    matrices and raise a ValueError when `a.ndim != 2`.
 
     `ord=None` is supported for any array shape and returns the 2-norm
     of the flattened array.

--- a/scipy/linalg/misc.py
+++ b/scipy/linalg/misc.py
@@ -83,10 +83,6 @@ def norm(a, ord=None, axis=None, keepdims=False, check_finite=True):
     Both the Frobenius and nuclear norm orders are only defined for
     matrices and raise a ValueError when x.ndim != 2.
 
-    The ``axis`` and ``keepdims`` arguments are passed directly to
-    ``numpy.linalg.norm`` and are only usable if they are supported
-    by the version of numpy in use.
-
     References
     ----------
     .. [1] G. H. Golub and C. F. Van Loan, *Matrix Computations*,

--- a/scipy/linalg/misc.py
+++ b/scipy/linalg/misc.py
@@ -83,7 +83,7 @@ def norm(a, ord=None, axis=None, keepdims=False, check_finite=True):
     The nuclear norm is the sum of the singular values.
 
     Both the Frobenius and nuclear norm orders are only defined for
-    matrices and raise a ValueError when `a.ndim != 2`.
+    matrices.
 
     References
     ----------

--- a/scipy/linalg/misc.py
+++ b/scipy/linalg/misc.py
@@ -53,7 +53,7 @@ def norm(a, ord=None, axis=None, keepdims=False, check_finite=True):
     -----
     For values of ``ord <= 0``, the result is, strictly speaking, not a
     mathematical 'norm', but it may still be useful for various numerical
-    purposes. Empty array norm is set to 0.0  unless ``ord <= 0``, where an
+    purposes. Empty array norm is set to 0.0 unless ``ord < 0``, where an
     error is raised.
 
     The following norms can be calculated:

--- a/scipy/linalg/misc.py
+++ b/scipy/linalg/misc.py
@@ -25,8 +25,10 @@ def norm(a, ord=None, axis=None, keepdims=False, check_finite=True):
 
     Parameters
     ----------
-    a : (M,) or (M, N) array_like
-        Input array. If `axis` is None, `a` must be 1D or 2D.
+    a : array_like
+        Input array.  If `axis` is None, `a` must be 1-D or 2-D, unless `ord`
+        is None. If both `axis` and `ord` are None, the 2-norm of
+        ``a.ravel`` will be returned.
     ord : {int, float, inf, -inf, 'fro', 'nuc', None}, optional
         Order of the norm (see table under ``Notes``). inf means NumPy's
         `inf` object
@@ -83,9 +85,6 @@ def norm(a, ord=None, axis=None, keepdims=False, check_finite=True):
 
     Both the Frobenius and nuclear norm orders are only defined for
     matrices and raise a ValueError when `a.ndim != 2`.
-
-    `ord=None` is supported for any array shape and returns the 2-norm
-    of the flattened array.
 
     References
     ----------

--- a/scipy/linalg/tests/test_misc.py
+++ b/scipy/linalg/tests/test_misc.py
@@ -1,0 +1,4 @@
+from scipy.linalg import norm
+
+def test_norm():
+    assert norm([]) == 0.0

--- a/scipy/linalg/tests/test_misc.py
+++ b/scipy/linalg/tests/test_misc.py
@@ -1,4 +1,5 @@
 from scipy.linalg import norm
 
+
 def test_norm():
     assert norm([]) == 0.0


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
closes #12534

#### What does this implement/fix?
For `ord=None`, scipy.linalg.norm crashes when a 0-size array is given as input with a very confusing message:
```
In [1]: scipy.linalg.norm([])                                                                                                                     
---------------------------------------------------------------------------
error                                     Traceback (most recent call last)
<ipython-input-1-07a65e21029c> in <module>
----> 1 scipy.linalg.norm([])

~/Library/miniconda3/lib/python3.7/site-packages/scipy/linalg/misc.py in norm(a, ord, axis, keepdims, check_finite)
    148             # use blas for fast and stable euclidean norm
    149             nrm2 = get_blas_funcs('nrm2', dtype=a.dtype)
--> 150             return nrm2(a)
    151 
    152         if a.ndim == 2 and axis is None and not keepdims:

error: (offx>=0 && offx<len(x)) failed for 2nd keyword offx: dnrm2:offx=0
```

The easy solution is to set the norm of an empty array to 0. This is already the case for `numpy.linalg.norm` for `ord=fro`. However, for `ord<=0`, the result is not a mathematical norm and is hard to define for empty arrays. Here I propose to raise an error in such cases.
#### Additional information
<!--Any additional information you think is important.-->