### PR TITLE
MAINT: signal: replace distutils templating with tempita

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -190,6 +190,9 @@ ignore_missing_imports = True
 [mypy-scipy.__config__]
 ignore_errors = True
 
+[mypy-scipy._build_utils.tempita]
+ignore_errors = True
+
 [mypy-scipy.signal.tests.test_signaltools]
 ignore_errors = True
 

--- a/scipy/_build_utils/tempita.py
+++ b/scipy/_build_utils/tempita.py
@@ -1,0 +1,32 @@
+import sys
+import os
+
+from Cython import Tempita as tempita
+# XXX: If this import ever fails (does it really?), vendor either
+# cython.tempita or numpy/npy_tempita.
+
+
+def process_tempita(fromfile):
+    """Process tempita templated file and write out the result.
+
+    The template file is expected to end in `.c.in` or `.pyx.in`:
+    E.g. processing `template.c.in` generates `template.c`.
+
+    """
+    if not fromfile.endswith('.in'):
+        raise ValueError("Unexpected extension: %s" % fromfile)
+
+    from_filename = tempita.Template.from_filename
+    template = from_filename(fromfile,
+                             encoding=sys.getdefaultencoding())    
+
+    content = template.substitute()
+
+    outfile = os.path.splitext(fromfile)[0]
+    with open(outfile, 'w') as f:
+        f.write(content)
+
+
+if __name__ == "__main__":
+    process_tempita(sys.argv[1])
+    

--- a/scipy/signal/correlate_nd.c.in
+++ b/scipy/signal/correlate_nd.c.in
@@ -105,32 +105,47 @@ clean_ax:
  * Implementation of the type-specific correlation 'kernels'
  */
 
-/**begin repeat
- * #fsuf = ubyte, byte, ushort, short, uint, int, ulong,
- *         long, ulonglong, longlong, float, double, longdouble#
- * #type = npy_ubyte, npy_byte, npy_ushort, short, npy_uint, int, npy_ulong,
- *         long, npy_ulonglong, npy_longlong, float, double, npy_longdouble#
- */
+{{py:
 
-static int _imp_correlate_nd_@fsuf@(PyArrayNeighborhoodIterObject *curx,
+INT_TYPES = ['npy_ubyte', 'npy_byte', 'npy_ushort', 'short', 'npy_uint', 'int',
+             'npy_ulong', 'long', 'npy_ulonglong', 'npy_longlong']
+INT_FSUFS = ['ubyte', 'byte', 'ushort', 'short', 'uint', 'int',
+             'ulong', 'long', 'ulonglong', 'longlong']
+
+
+REAL_TYPES = ['float', 'double', 'npy_longdouble']
+REAL_FSUFS = ['float', 'double', 'longdouble']
+
+ALL_TYPENUMS = ['UBYTE', 'BYTE', 'USHORT', 'SHORT', 'UINT', 'INT',
+                'ULONG', 'LONG', 'ULONGLONG', 'LONGLONG',
+                'FLOAT', 'DOUBLE', 'LONGDOUBLE',
+                'CFLOAT', 'CDOUBLE', 'CLONGDOUBLE']
+                
+CMPLX_FSUFS = ['cfloat', 'cdouble', 'clongdouble']
+
+}}
+
+
+{{for FSUF, TYPE in zip(INT_FSUFS + REAL_FSUFS, INT_TYPES + REAL_TYPES)}}
+static int _imp_correlate_nd_{{FSUF}}(PyArrayNeighborhoodIterObject *curx,
         PyArrayNeighborhoodIterObject *curneighx, PyArrayIterObject *ity,
         PyArrayIterObject *itz)
 {
     npy_intp i, j;
-    @type@ acc;
+    {{TYPE}} acc;
 
     for(i = 0; i < curx->size; ++i) {
         acc = 0;
         PyArrayNeighborhoodIter_Reset(curneighx);
         for(j = 0; j < curneighx->size; ++j) {
-            acc += *((@type@*)(curneighx->dataptr)) * *((@type@*)(ity->dataptr));
+            acc += *(({{TYPE}}*)(curneighx->dataptr)) * *(({{TYPE}}*)(ity->dataptr));
 
             PyArrayNeighborhoodIter_Next(curneighx);
             PyArray_ITER_NEXT(ity);
         }
         PyArrayNeighborhoodIter_Next(curx);
 
-        *((@type@*)(itz->dataptr)) = acc;
+        *(({{TYPE}}*)(itz->dataptr)) = acc;
         PyArray_ITER_NEXT(itz);
 
         PyArray_ITER_RESET(ity);
@@ -139,28 +154,28 @@ static int _imp_correlate_nd_@fsuf@(PyArrayNeighborhoodIterObject *curx,
     return 0;
 }
 
-/**end repeat**/
+{{endfor}}
 
-/**begin repeat
- * #fsuf = float, double, longdouble#
- * #type = float, double, npy_longdouble#
+
+/*
+ * Complex-valued kernels
  */
-
-static int _imp_correlate_nd_c@fsuf@(PyArrayNeighborhoodIterObject *curx,
+{{for FSUF, TYPE in zip(REAL_FSUFS, REAL_TYPES)}}
+static int _imp_correlate_nd_c{{FSUF}}(PyArrayNeighborhoodIterObject *curx,
         PyArrayNeighborhoodIterObject *curneighx, PyArrayIterObject *ity,
         PyArrayIterObject *itz)
 {
     npy_intp i, j;
-    @type@ racc, iacc;
-    @type@ *ptr1, *ptr2;
+    {{TYPE}} racc, iacc;
+    {{TYPE}} *ptr1, *ptr2;
 
     for(i = 0; i < curx->size; ++i) {
         racc = 0;
         iacc = 0;
         PyArrayNeighborhoodIter_Reset(curneighx);
         for(j = 0; j < curneighx->size; ++j) {
-            ptr1 = ((@type@*)(curneighx->dataptr));
-            ptr2 = ((@type@*)(ity->dataptr));
+            ptr1 = (({{TYPE}}*)(curneighx->dataptr));
+            ptr2 = (({{TYPE}}*)(ity->dataptr));
             racc += ptr1[0] * ptr2[0] + ptr1[1] * ptr2[1];
             iacc += ptr1[1] * ptr2[0] - ptr1[0] * ptr2[1];
 
@@ -169,8 +184,8 @@ static int _imp_correlate_nd_c@fsuf@(PyArrayNeighborhoodIterObject *curx,
         }
         PyArrayNeighborhoodIter_Next(curx);
 
-        ((@type@*)(itz->dataptr))[0] = racc;
-        ((@type@*)(itz->dataptr))[1] = iacc;
+        (({{TYPE}}*)(itz->dataptr))[0] = racc;
+        (({{TYPE}}*)(itz->dataptr))[1] = iacc;
         PyArray_ITER_NEXT(itz);
 
         PyArray_ITER_RESET(ity);
@@ -178,8 +193,8 @@ static int _imp_correlate_nd_c@fsuf@(PyArrayNeighborhoodIterObject *curx,
 
     return 0;
 }
+{{endfor}}
 
-/**end repeat**/
 
 static int _imp_correlate_nd_object(PyArrayNeighborhoodIterObject *curx,
         PyArrayNeighborhoodIterObject *curneighx, PyArrayIterObject *ity,
@@ -293,16 +308,12 @@ static int _correlate_nd_imp(PyArrayIterObject* itx, PyArrayIterObject *ity,
     }
 
     switch(typenum) {
-/**begin repeat
- * #TYPE = UBYTE, BYTE, USHORT, SHORT, UINT, INT, ULONG, LONG, ULONGLONG,
- *         LONGLONG, FLOAT, DOUBLE, LONGDOUBLE, CFLOAT, CDOUBLE, CLONGDOUBLE#
- * #type = ubyte, byte, ushort, short, uint, int, ulong, long, ulonglong,
- *         longlong, float, double, longdouble, cfloat, cdouble, clongdouble#
- */
-        case NPY_@TYPE@:
-            _imp_correlate_nd_@type@(curx, curneighx, ity, itz);
+
+        {{for TYPENUM, FSUF in zip(ALL_TYPENUMS, INT_FSUFS+REAL_FSUFS+CMPLX_FSUFS)}}
+        case NPY_{{TYPENUM}}:
+            _imp_correlate_nd_{{FSUF}}(curx, curneighx, ity, itz);
             break;
-/**end repeat**/
+        {{endfor}}
 
         /* The object array case does not worth being optimized, since most of
            the cost is numerical operations, not iterators moving in this case ? */

--- a/scipy/signal/lfilter.c.in
+++ b/scipy/signal/lfilter.c.in
@@ -9,24 +9,23 @@
 
 #include "sigtools.h"
 
-static void FLOAT_filt(char *b, char *a, char *x, char *y, char *Z,
+{{py:
+
+TNAMES = ['FLOAT', 'DOUBLE', 'EXTENDED']
+TYPES = ['float', 'double', 'npy_longdouble']
+
+}}
+
+
+{{for TNAME in TNAMES}}
+static void {{TNAME}}_filt(char *b, char *a, char *x, char *y, char *Z,
                        npy_intp len_b, npy_uintp len_x, npy_intp stride_X,
                        npy_intp stride_Y);
-static void DOUBLE_filt(char *b, char *a, char *x, char *y, char *Z,
+static void C{{TNAME}}_filt(char *b, char *a, char *x, char *y, char *Z,
                         npy_intp len_b, npy_uintp len_x, npy_intp stride_X,
                         npy_intp stride_Y);
-static void EXTENDED_filt(char *b, char *a, char *x, char *y, char *Z,
-                        npy_intp len_b, npy_uintp len_x, npy_intp stride_X,
-                        npy_intp stride_Y);
-static void CFLOAT_filt(char *b, char *a, char *x, char *y, char *Z,
-                        npy_intp len_b, npy_uintp len_x, npy_intp stride_X,
-                        npy_intp stride_Y);
-static void CDOUBLE_filt(char *b, char *a, char *x, char *y, char *Z,
-                         npy_intp len_b, npy_uintp len_x, npy_intp stride_X,
-                         npy_intp stride_Y);
-static void CEXTENDED_filt(char *b, char *a, char *x, char *y, char *Z,
-                         npy_intp len_b, npy_uintp len_x, npy_intp stride_X,
-                         npy_intp stride_Y);
+{{endfor}}
+
 static void OBJECT_filt(char *b, char *a, char *x, char *y, char *Z,
                         npy_intp len_b, npy_uintp len_x, npy_intp stride_X,
                         npy_intp stride_Y);
@@ -543,21 +542,19 @@ fail:
  *   dimension of an N-D array.                                  *
  *****************************************************************/
 
-/**begin repeat
- * #type = float, double, npy_longdouble#
- * #NAME = FLOAT, DOUBLE, EXTENDED#
- */
-static void @NAME@_filt(char *b, char *a, char *x, char *y, char *Z,
+
+{{for TNAME, TYPE in zip(TNAMES, TYPES)}}
+static void {{TNAME}}_filt(char *b, char *a, char *x, char *y, char *Z,
                        npy_intp len_b, npy_uintp len_x, npy_intp stride_X,
                        npy_intp stride_Y)
 {
     Py_BEGIN_ALLOW_THREADS
     char *ptr_x = x, *ptr_y = y;
-    @type@ *ptr_Z;
-    @type@ *ptr_b = (@type@*)b;
-    @type@ *ptr_a = (@type@*)a;
-    @type@ *xn, *yn;
-    const @type@ a0 = *((@type@ *) a);
+    {{TYPE}} *ptr_Z;
+    {{TYPE}} *ptr_b = ({{TYPE}}*)b;
+    {{TYPE}} *ptr_a = ({{TYPE}}*)a;
+    {{TYPE}} *xn, *yn;
+    const {{TYPE}} a0 = *(({{TYPE}} *) a);
     npy_intp n;
     npy_uintp k;
 
@@ -568,12 +565,12 @@ static void @NAME@_filt(char *b, char *a, char *x, char *y, char *Z,
     }
 
     for (k = 0; k < len_x; k++) {
-        ptr_b = (@type@ *) b;   /* Reset a and b pointers */
-        ptr_a = (@type@ *) a;
-        xn = (@type@ *) ptr_x;
-        yn = (@type@ *) ptr_y;
+        ptr_b = ({{TYPE}} *) b;   /* Reset a and b pointers */
+        ptr_a = ({{TYPE}} *) a;
+        xn = ({{TYPE}} *) ptr_x;
+        yn = ({{TYPE}} *) ptr_y;
         if (len_b > 1) {
-            ptr_Z = ((@type@ *) Z);
+            ptr_Z = (({{TYPE}} *) Z);
             *yn = *ptr_Z + *ptr_b  * *xn;   /* Calculate first delay (output) */
             ptr_b++;
             ptr_a++;
@@ -597,29 +594,30 @@ static void @NAME@_filt(char *b, char *a, char *x, char *y, char *Z,
     Py_END_ALLOW_THREADS
 }
 
-static void C@NAME@_filt(char *b, char *a, char *x, char *y, char *Z,
+
+static void C{{TNAME}}_filt(char *b, char *a, char *x, char *y, char *Z,
                         npy_intp len_b, npy_uintp len_x, npy_intp stride_X,
                         npy_intp stride_Y)
 {
     Py_BEGIN_ALLOW_THREADS
     char *ptr_x = x, *ptr_y = y;
-    @type@ *ptr_Z, *ptr_b;
-    @type@ *ptr_a;
-    @type@ *xn, *yn;
-    @type@ a0r = ((@type@ *) a)[0];
-    @type@ a0i = ((@type@ *) a)[1];
-    @type@ a0_mag, tmpr, tmpi;
+    {{TYPE}} *ptr_Z, *ptr_b;
+    {{TYPE}} *ptr_a;
+    {{TYPE}} *xn, *yn;
+    {{TYPE}} a0r = (({{TYPE}} *) a)[0];
+    {{TYPE}} a0i = (({{TYPE}} *) a)[1];
+    {{TYPE}} a0_mag, tmpr, tmpi;
     npy_intp n;
     npy_uintp k;
 
     a0_mag = a0r * a0r + a0i * a0i;
     for (k = 0; k < len_x; k++) {
-        ptr_b = (@type@ *) b;   /* Reset a and b pointers */
-        ptr_a = (@type@ *) a;
-        xn = (@type@ *) ptr_x;
-        yn = (@type@ *) ptr_y;
+        ptr_b = ({{TYPE}} *) b;   /* Reset a and b pointers */
+        ptr_a = ({{TYPE}} *) a;
+        xn = ({{TYPE}} *) ptr_x;
+        yn = ({{TYPE}} *) ptr_y;
         if (len_b > 1) {
-            ptr_Z = ((@type@ *) Z);
+            ptr_Z = (({{TYPE}} *) Z);
             tmpr = ptr_b[0] * a0r + ptr_b[1] * a0i;
             tmpi = ptr_b[1] * a0r - ptr_b[0] * a0i;
             /* Calculate first delay (output) */
@@ -666,7 +664,7 @@ static void C@NAME@_filt(char *b, char *a, char *x, char *y, char *Z,
     }
     Py_END_ALLOW_THREADS
 }
-/**end repeat**/
+{{endfor}}
 
 static void OBJECT_filt(char *b, char *a, char *x, char *y, char *Z,
                         npy_intp len_b, npy_uintp len_x, npy_intp stride_X,

--- a/scipy/signal/setup.py
+++ b/scipy/signal/setup.py
@@ -1,28 +1,7 @@
 from scipy._build_utils import numpy_nodepr_api
+from scipy._build_utils import tempita
 import os
 import sys
-
-def process_tempita(fromfile):
-    try:
-        try:
-            from Cython import Tempita as tempita
-        except ImportError:
-            import tempita
-    except ImportError:
-        raise Exception("Building requires tempita")
-
-    if not fromfile.endswith('c.in'):
-        raise ValueError("Unexpected extension: %s" % fromfile)
-
-    from_filename = tempita.Template.from_filename
-    template = from_filename(fromfile,
-                             encoding=sys.getdefaultencoding())    
-
-    content = template.substitute()
-
-    outfile = os.path.splitext(fromfile)[0]
-    with open(outfile, 'w') as f:
-        f.write(content)
 
 
 def configuration(parent_package='', top_path=None):
@@ -37,8 +16,8 @@ def configuration(parent_package='', top_path=None):
 
     # convert the *.c.in files : `lfilter.c.in -> lfilter.c` etc
     srcdir = os.path.join(os.getcwd(), 'scipy', 'signal')
-    process_tempita(os.path.join(srcdir, 'lfilter.c.in') )
-    process_tempita(os.path.join(srcdir, 'correlate_nd.c.in') )
+    tempita.process_tempita(os.path.join(srcdir, 'lfilter.c.in') )
+    tempita.process_tempita(os.path.join(srcdir, 'correlate_nd.c.in') )
 
     sigtools = config.add_extension('sigtools',
                          sources=['sigtoolsmodule.c', 'firfilter.c',

--- a/scipy/signal/setup.py
+++ b/scipy/signal/setup.py
@@ -38,11 +38,12 @@ def configuration(parent_package='', top_path=None):
     # convert the *.c.in files : `lfilter.c.in -> lfilter.c` etc
     srcdir = os.path.join(os.getcwd(), 'scipy', 'signal')
     process_tempita(os.path.join(srcdir, 'lfilter.c.in') )
+    process_tempita(os.path.join(srcdir, 'correlate_nd.c.in') )
 
     sigtools = config.add_extension('sigtools',
                          sources=['sigtoolsmodule.c', 'firfilter.c',
                                   'medianfilter.c', 'lfilter.c',
-                                  'correlate_nd.c.src'],
+                                  'correlate_nd.c'],
                          depends=['sigtools.h'],
                          include_dirs=['.'],
                          **numpy_nodepr_api)


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

gh-13930

#### What does this implement/fix?
<!--Please explain your changes.-->

Proof-of-concept / RFC: replace .c.src templating with tempita templating.

#### Additional information
<!--Any additional information you think is important.-->

This is only  a proof of concept. 

- [x] there is more distutils templating in `correlate_nd.c.src`
- [x] tempita invocation should be made more robust. The incantation in `signal/setup.py` is taken from `tools/cythonize.py`
- [x] if we go this way, do we keep autogenerated files under source control? In the current state of this PR, `lfilter.c` *is* under source control because 

```
$ git log scipy/signal/lfilter.c
commit aa1882ef55206d746bb3f840a1b33f886547e54b
Author: David Cournapeau <cournape@gmail.com>
Date:   Mon Apr 20 08:41:45 2009 +0000

    rename lfilter.c to a templated file.
``
