### PR TITLE
MAINT: improve validations and keyword only arguments for some parameters of QMC

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -483,7 +483,7 @@ def rng_integers(gen, low, high=None, size=None, dtype='int64',
         If provided, one above the largest (signed) integer to be drawn from
         the distribution (see above for behavior if high=None). If array-like,
         must contain integer values.
-    size : None
+    size : array-like of ints, optional
         Output shape. If the given shape is, e.g., (m, n, k), then m * n * k
         samples are drawn. Default is None, in which case a single value is
         returned.

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -9,6 +9,7 @@ import warnings
 import numpy as np
 
 import scipy.stats as stats
+from scipy._lib._util import rng_integers
 from scipy.stats._sobol import (
     initialize_v, _cscramble, _fill_p_cumulative, _draw, _fast_forward,
     _categorize, initialize_direction_numbers, _MAXDIM, _MAXBIT
@@ -994,19 +995,16 @@ class Sobol(QMCEngine):
 
     def _scramble(self):
         """Scramble the sequence."""
-        try:
-            rg_integers = self.rng.integers
-        except AttributeError:
-            rg_integers = self.rng.randint
         # Generate shift vector
         self._shift = np.dot(
-            rg_integers(2, size=(self.d, self.MAXBIT), dtype=int),
+            rng_integers(self.rng, 2, size=(self.d, self.MAXBIT), dtype=int),
             2 ** np.arange(self.MAXBIT, dtype=int),
         )
         self._quasi = self._shift.copy()
         # Generate lower triangular matrices (stacked across dimensions)
-        ltm = np.tril(rg_integers(2, size=(self.d, self.MAXBIT, self.MAXBIT),
-                                  dtype=int))
+        ltm = np.tril(rng_integers(self.rng, 2,
+                                   size=(self.d, self.MAXBIT, self.MAXBIT),
+                                   dtype=int))
         _cscramble(self.d, ltm, self._sv)
         self.num_generated = 0
 

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -839,19 +839,6 @@ class LatinHypercube(QMCEngine):
         self.num_generated += n
         return samples
 
-    def reset(self):
-        """Reset the engine to base state.
-
-        Returns
-        -------
-        engine : LatinHypercube
-            Engine reset to its base state.
-
-        """
-        self.__init__(d=self.d, centered=self.centered, seed=self.rng_seed)
-        self.num_generated = 0
-        return self
-
 
 class Sobol(QMCEngine):
     """Engine for generating (scrambled) Sobol' sequences.
@@ -1082,8 +1069,8 @@ class Sobol(QMCEngine):
             Engine reset to its base state.
 
         """
+        super().reset()
         self._quasi = self._shift.copy()
-        self.num_generated = 0
         return self
 
     def fast_forward(self, n):
@@ -1215,6 +1202,7 @@ class MultivariateNormalQMC(QMCEngine):
 
         """
         base_samples = self._standard_normal_samples(n)
+        self.num_generated += n
         return self._correlate(base_samples)
 
     def reset(self):
@@ -1226,6 +1214,7 @@ class MultivariateNormalQMC(QMCEngine):
             Engine reset to its base state.
 
         """
+        super().reset()
         self.engine.reset()
         return self
 
@@ -1310,6 +1299,8 @@ class MultinomialQMC(QMCEngine):
             raise ValueError("`engine` must be an instance of "
                              "`scipy.stats.qmc.QMCEngine` or `None`.")
 
+        super().__init__(d=1, seed=seed)
+
     def random(self, n=1):
         """Draw `n` QMC samples from the multinomial distribution.
 
@@ -1329,6 +1320,7 @@ class MultinomialQMC(QMCEngine):
         _fill_p_cumulative(np.array(self.pvals, dtype=float), p_cumulative)
         sample = np.zeros_like(self.pvals, dtype=int)
         _categorize(base_draws, p_cumulative, sample)
+        self.num_generated += n
         return sample
 
     def reset(self):
@@ -1340,5 +1332,6 @@ class MultinomialQMC(QMCEngine):
             Engine reset to its base state.
 
         """
+        super().reset()
         self.engine.reset()
         return self

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -65,7 +65,7 @@ def check_random_state(seed=None):
                          ' instance' % seed)
 
 
-def scale(sample, l_bounds, u_bounds, reverse=False):
+def scale(sample, l_bounds, u_bounds, *, reverse=False):
     r"""Sample scaling from unit hypercube to different bounds.
 
     To convert a sample from :math:`[0, 1)` to :math:`[a, b), b>a`,
@@ -148,7 +148,7 @@ def scale(sample, l_bounds, u_bounds, reverse=False):
         return (sample - lower) / (upper - lower)
 
 
-def discrepancy(sample, iterative=False, method="CD", workers=1):
+def discrepancy(sample, *, iterative=False, method="CD", workers=1):
     """Discrepancy of a given sample.
 
     Parameters
@@ -418,7 +418,7 @@ def n_primes(n):
     return primes
 
 
-def van_der_corput(n, base=2, start_index=0, scramble=False, seed=None):
+def van_der_corput(n, base=2, *, start_index=0, scramble=False, seed=None):
     """Van der Corput sequence.
 
     Pseudo-random number generator based on a b-adic expansion.
@@ -567,7 +567,7 @@ class QMCEngine(ABC):
     """
 
     @abstractmethod
-    def __init__(self, d, seed=None):
+    def __init__(self, d, *, seed=None):
         if not np.issubdtype(type(d), np.integer):
             raise ValueError('d must be an integer value')
 
@@ -707,7 +707,7 @@ class Halton(QMCEngine):
 
     """
 
-    def __init__(self, d, scramble=True, seed=None):
+    def __init__(self, d, *, scramble=True, seed=None):
         super().__init__(d=d, seed=seed)
         self.seed = seed
         self.base = n_primes(d)
@@ -729,7 +729,7 @@ class Halton(QMCEngine):
         """
         # Generate a sample using a Van der Corput sequence per dimension.
         # important to have ``type(bdim) == int`` for performance reason
-        sample = [van_der_corput(n, int(bdim), self.num_generated,
+        sample = [van_der_corput(n, int(bdim), start_index=self.num_generated,
                                  scramble=self.scramble,
                                  seed=copy.deepcopy(self.seed))
                   for bdim in self.base]
@@ -807,7 +807,7 @@ class LatinHypercube(QMCEngine):
 
     """
 
-    def __init__(self, d, centered=False, seed=None):
+    def __init__(self, d, *, centered=False, seed=None):
         super().__init__(d=d, seed=seed)
         self.centered = centered
 
@@ -958,7 +958,7 @@ class Sobol(QMCEngine):
     MAXDIM = _MAXDIM
     MAXBIT = _MAXBIT
 
-    def __init__(self, d, scramble=True, seed=None):
+    def __init__(self, d, *, scramble=True, seed=None):
         super().__init__(d=d, seed=seed)
         if d > self.MAXDIM:
             raise ValueError(
@@ -1132,7 +1132,7 @@ class MultivariateNormalQMC(QMCEngine):
 
     """
 
-    def __init__(self, mean, cov=None, cov_root=None, inv_transform=True,
+    def __init__(self, mean, cov=None, *, cov_root=None, inv_transform=True,
                  engine=None, seed=None):
         mean = np.array(mean, copy=False, ndmin=1)
         d = mean.shape[0]
@@ -1283,7 +1283,7 @@ class MultinomialQMC(QMCEngine):
 
     """
 
-    def __init__(self, pvals, engine=None, seed=None):
+    def __init__(self, pvals, *, engine=None, seed=None):
         self.pvals = np.array(pvals, copy=False, ndmin=1)
         if np.min(pvals) < 0:
             raise ValueError('Elements of pvals must be non-negative.')

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -1188,8 +1188,15 @@ class MultivariateNormalQMC(QMCEngine):
             engine_dim = d
         if engine is None:
             self.engine = Sobol(d=engine_dim, scramble=True, seed=seed)
-        else:
+        elif isinstance(engine, QMCEngine) and engine.d != 1:
+            if engine.d != d:
+                raise ValueError("Dimension of `engine` must be consistent"
+                                 " with dimensions of mean and covariance.")
             self.engine = engine
+        else:
+            raise ValueError("`engine` must be an instance of "
+                             "`scipy.stats.qmc.QMCEngine` or `None`.")
+
         self._mean = mean
         self._corr_matrix = cov_root
 
@@ -1294,8 +1301,14 @@ class MultinomialQMC(QMCEngine):
         if not np.isclose(np.sum(pvals), 1):
             raise ValueError('Elements of pvals must sum to 1.')
         if engine is None:
-            engine = Sobol(d=1, scramble=True, seed=seed)
-        self.engine = engine
+            self.engine = Sobol(d=1, scramble=True, seed=seed)
+        elif isinstance(engine, QMCEngine):
+            if engine.d != 1:
+                raise ValueError("Dimension of `engine` must be 1.")
+            self.engine = engine
+        else:
+            raise ValueError("`engine` must be an instance of "
+                             "`scipy.stats.qmc.QMCEngine` or `None`.")
 
     def random(self, n=1):
         """Draw `n` QMC samples from the multinomial distribution.

--- a/scipy/stats/_qmc.pyi
+++ b/scipy/stats/_qmc.pyi
@@ -35,7 +35,8 @@ def scale(
 
 
 def discrepancy(
-        sample: npt.ArrayLike, *, iterative: bool = ..., method: str = ...
+        sample: npt.ArrayLike, *, iterative: bool = ..., method: str = ...,
+        workers: _IntegerType = ...
 ) -> _FloatingType: ...
 
 

--- a/scipy/stats/_qmc.pyi
+++ b/scipy/stats/_qmc.pyi
@@ -30,12 +30,12 @@ def check_random_state(
 
 def scale(
         sample: npt.ArrayLike, l_bounds: npt.ArrayLike,
-        u_bounds: npt.ArrayLike, reverse: bool = ...
+        u_bounds: npt.ArrayLike, *, reverse: bool = ...
 ) -> np.ndarray: ...
 
 
 def discrepancy(
-        sample: npt.ArrayLike, iterative: bool = ..., method: str = ...
+        sample: npt.ArrayLike, *, iterative: bool = ..., method: str = ...
 ) -> _FloatingType: ...
 
 
@@ -52,7 +52,7 @@ def n_primes(n: _IntegerType) -> np.ndarray: ...
 
 
 def van_der_corput(
-        n: _IntegerType, base: _IntegerType = ...,
+        n: _IntegerType, base: _IntegerType = ..., *,
         start_index: _IntegerType = ..., scramble: bool = ...,
         seed: Optional[Union[_IntegerType, np.random.Generator]] = ...
 ) -> np.ndarray: ...
@@ -63,7 +63,7 @@ class QMCEngine(ABC):
     @abstractmethod
     def __init__(
             self,
-            d: _IntegerType,
+            d: _IntegerType, *,
             seed: Optional[Union[_IntegerType, np.random.Generator]] = ...
     ) -> None: ...
 
@@ -77,7 +77,7 @@ class QMCEngine(ABC):
 
 class Halton(QMCEngine):
     def __init__(
-            self, d: _IntegerType, scramble: bool = ...,
+            self, d: _IntegerType, *, scramble: bool = ...,
             seed: Optional[Union[_IntegerType, np.random.Generator]] = ...
     ) -> None: ...
 
@@ -86,7 +86,7 @@ class Halton(QMCEngine):
 
 class LatinHypercube(QMCEngine):
     def __init__(
-            self, d: _IntegerType, centered: bool = ...,
+            self, d: _IntegerType, *, centered: bool = ...,
             seed: Optional[Union[_IntegerType, np.random.Generator]] = ...
     ) -> None: ...
 
@@ -97,7 +97,7 @@ class LatinHypercube(QMCEngine):
 
 class Sobol(QMCEngine):
     def __init__(
-            self, d: _IntegerType, scramble: bool = ...,
+            self, d: _IntegerType, *, scramble: bool = ...,
             seed: Optional[Union[_IntegerType, np.random.Generator]] = ...
     ) -> None: ...
 
@@ -114,7 +114,7 @@ class Sobol(QMCEngine):
 
 class MultivariateNormalQMC(QMCEngine):
     def __init__(
-            self, mean: npt.ArrayLike, cov: Optional[npt.ArrayLike] = ...,
+            self, mean: npt.ArrayLike, cov: Optional[npt.ArrayLike] = ..., *,
             cov_root: Optional[npt.ArrayLike] = ...,
             inv_transform: bool = ...,
             engine: Optional[QMCEngine] = ...,
@@ -131,7 +131,7 @@ class MultivariateNormalQMC(QMCEngine):
 
 class MultinomialQMC(QMCEngine):
     def __init__(
-            self, pvals: npt.ArrayLike, engine: Optional[QMCEngine] = ...,
+            self, pvals: npt.ArrayLike, *, engine: Optional[QMCEngine] = ...,
             seed: Optional[Union[_IntegerType, np.random.Generator]] = ...
     ) -> None: ...
 

--- a/scipy/stats/tests/test_qmc.py
+++ b/scipy/stats/tests/test_qmc.py
@@ -611,9 +611,10 @@ class TestMultinomialQMC:
             qmc.MultinomialQMC(p)
 
         p = np.array([0.12, 0.26, 0.05, 0.35, 0.22])
+        seed = np.random.RandomState(12345)
         message = r"Dimension of `engine` must be 1."
         with pytest.raises(ValueError, match=message):
-            qmc.MultinomialQMC(p, engine=qmc.Sobol(d=2))
+            qmc.MultinomialQMC(p, engine=qmc.Sobol(d=2, seed=seed))
 
         message = r"`engine` must be an instance of..."
         with pytest.raises(ValueError, match=message):
@@ -803,27 +804,28 @@ class TestNormalQMC:
 class TestMultivariateNormalQMC:
 
     def test_validations(self):
+        seed = np.random.RandomState()
+
         message = r"Dimension of `engine` must be consistent"
         with pytest.raises(ValueError, match=message):
-            qmc.MultivariateNormalQMC([0], engine=qmc.Sobol(d=2))
+            qmc.MultivariateNormalQMC([0], engine=qmc.Sobol(d=2, seed=seed),
+                                      seed=seed)
 
         message = r"`engine` must be an instance of..."
         with pytest.raises(ValueError, match=message):
-            qmc.MultivariateNormalQMC([0, 0], engine=np.random.RandomState)
+            qmc.MultivariateNormalQMC([0, 0], engine=np.random.RandomState,
+                                      seed=seed)
 
         message = r"Covariance matrix not PSD."
         with pytest.raises(ValueError, match=message):
-            seed = np.random.RandomState(123456)
             qmc.MultivariateNormalQMC([0, 0], [[1, 2], [2, 1]], seed=seed)
 
         message = r"Covariance matrix is not symmetric."
         with pytest.raises(ValueError, match=message):
-            seed = np.random.RandomState(123456)
             qmc.MultivariateNormalQMC([0, 0], [[1, 0], [2, 1]], seed=seed)
 
         message = r"Dimension mismatch between mean and covariance."
         with pytest.raises(ValueError, match=message):
-            seed = np.random.RandomState(123456)
             qmc.MultivariateNormalQMC([0], [[1, 0], [0, 1]], seed=seed)
 
     def test_MultivariateNormalQMCNonPD(self):

--- a/scipy/stats/tests/test_qmc.py
+++ b/scipy/stats/tests/test_qmc.py
@@ -356,7 +356,7 @@ def test_subclassing_QMCEngine():
 
     # input validation
     with pytest.raises(ValueError, match=r"d must be an integer value"):
-            RandomEngine((2,), seed=seed)
+        RandomEngine((2,), seed=seed)  # noqa
 
 
 class QMCEngineTests:

--- a/scipy/stats/tests/test_qmc.py
+++ b/scipy/stats/tests/test_qmc.py
@@ -3,7 +3,7 @@ from collections import Counter
 
 import pytest
 import numpy as np
-from numpy.testing import (assert_allclose, assert_almost_equal, assert_,
+from numpy.testing import (assert_allclose, assert_almost_equal,
                            assert_equal, assert_array_almost_equal,
                            assert_array_equal)
 from scipy.stats import shapiro
@@ -404,8 +404,8 @@ class QMCEngineTests:
     def test_bounds(self, scramble):
         engine = self.engine(d=100, scramble=scramble)
         sample = engine.random(512)
-        assert_(np.all(sample >= 0))
-        assert_(np.all(sample <= 1))
+        assert np.all(sample >= 0)
+        assert np.all(sample <= 1)
 
     @pytest.mark.parametrize("scramble", scramble, ids=ids)
     def test_sample(self, scramble):
@@ -418,7 +418,9 @@ class QMCEngineTests:
 
     @pytest.mark.parametrize("scramble", scramble, ids=ids)
     def test_continuing(self, scramble):
-        ref_sample = self.reference(scramble=scramble)
+        engine = self.engine(d=2, scramble=scramble)
+        ref_sample = engine.random(n=8)
+
         engine = self.engine(d=2, scramble=scramble)
 
         n_half = len(ref_sample) // 2
@@ -440,7 +442,9 @@ class QMCEngineTests:
 
     @pytest.mark.parametrize("scramble", scramble, ids=ids)
     def test_fast_forward(self, scramble):
-        ref_sample = self.reference(scramble=scramble)
+        engine = self.engine(d=2, scramble=scramble)
+        ref_sample = engine.random(n=8)
+
         engine = self.engine(d=2, scramble=scramble)
 
         engine.fast_forward(4)
@@ -659,6 +663,23 @@ class TestMultinomialQMC:
         assert_array_equal(samples, samples_reset)
 
 
+def _wrapper_mv_qmc(*args, **kwargs):
+    d = kwargs.pop("d")
+    return qmc.MultivariateNormalQMC(mean=np.zeros(d), **kwargs)
+
+
+class TestMultivariateNormalQMCEngine(QMCEngineTests):
+    qmce = _wrapper_mv_qmc
+    can_scramble = False
+
+    def test_sample(self, *args):
+        pytest.skip("Not applicable: the value of reference sample is"
+                    " implementation dependent.")
+
+    def test_bounds(self, *args):
+        pytest.skip("Not applicable: normal is not bounded.")
+
+
 class TestNormalQMC:
     def test_NormalQMC(self):
         # d = 1
@@ -753,38 +774,30 @@ class TestNormalQMC:
         seed = np.random.RandomState(12345)
         engine = qmc.MultivariateNormalQMC(mean=np.zeros(2), seed=seed)
         samples = engine.random(n=256)
-        assert_(all(np.abs(samples.mean(axis=0)) < 1e-2))
-        assert_(all(np.abs(samples.std(axis=0) - 1) < 1e-2))
+        assert all(np.abs(samples.mean(axis=0)) < 1e-2)
+        assert all(np.abs(samples.std(axis=0) - 1) < 1e-2)
         # perform Shapiro-Wilk test for normality
         for i in (0, 1):
             _, pval = shapiro(samples[:, i])
-            assert_(pval > 0.9)
+            assert pval > 0.9
         # make sure samples are uncorrelated
         cov = np.cov(samples.transpose())
-        assert_(np.abs(cov[0, 1]) < 1e-2)
+        assert np.abs(cov[0, 1]) < 1e-2
 
     def test_NormalQMCShapiroInvTransform(self):
         seed = np.random.RandomState(12345)
         engine = qmc.MultivariateNormalQMC(
             mean=np.zeros(2), seed=seed, inv_transform=True)
         samples = engine.random(n=256)
-        assert_(all(np.abs(samples.mean(axis=0)) < 1e-2))
-        assert_(all(np.abs(samples.std(axis=0) - 1) < 1e-2))
+        assert all(np.abs(samples.mean(axis=0)) < 1e-2)
+        assert all(np.abs(samples.std(axis=0) - 1) < 1e-2)
         # perform Shapiro-Wilk test for normality
         for i in (0, 1):
             _, pval = shapiro(samples[:, i])
-            assert_(pval > 0.9)
+            assert pval > 0.9
         # make sure samples are uncorrelated
         cov = np.cov(samples.transpose())
-        assert_(np.abs(cov[0, 1]) < 1e-2)
-
-    def test_reset(self):
-        seed = np.random.RandomState(12345)
-        engine = qmc.MultivariateNormalQMC(mean=np.zeros(1), seed=seed)
-        samples = engine.random(2)
-        engine.reset()
-        samples_reset = engine.random(2)
-        assert_array_equal(samples, samples_reset)
+        assert np.abs(cov[0, 1]) < 1e-2
 
 
 class TestMultivariateNormalQMC:
@@ -947,15 +960,15 @@ class TestMultivariateNormalQMC:
             mean=[0, 0], cov=[[1, 0], [0, 1]], seed=seed
         )
         samples = engine.random(n=256)
-        assert_(all(np.abs(samples.mean(axis=0)) < 1e-2))
-        assert_(all(np.abs(samples.std(axis=0) - 1) < 1e-2))
+        assert all(np.abs(samples.mean(axis=0)) < 1e-2)
+        assert all(np.abs(samples.std(axis=0) - 1) < 1e-2)
         # perform Shapiro-Wilk test for normality
         for i in (0, 1):
             _, pval = shapiro(samples[:, i])
-            assert_(pval > 0.9)
+            assert pval > 0.9
         # make sure samples are uncorrelated
         cov = np.cov(samples.transpose())
-        assert_(np.abs(cov[0, 1]) < 1e-2)
+        assert np.abs(cov[0, 1]) < 1e-2
 
         # test the correlated, non-zero mean case
         seed = np.random.RandomState(12345)
@@ -963,15 +976,15 @@ class TestMultivariateNormalQMC:
             mean=[1.0, 2.0], cov=[[1.5, 0.5], [0.5, 1.5]], seed=seed
         )
         samples = engine.random(n=256)
-        assert_(all(np.abs(samples.mean(axis=0) - [1, 2]) < 1e-2))
-        assert_(all(np.abs(samples.std(axis=0) - np.sqrt(1.5)) < 1e-2))
+        assert all(np.abs(samples.mean(axis=0) - [1, 2]) < 1e-2)
+        assert all(np.abs(samples.std(axis=0) - np.sqrt(1.5)) < 1e-2)
         # perform Shapiro-Wilk test for normality
         for i in (0, 1):
             _, pval = shapiro(samples[:, i])
-            assert_(pval > 0.9)
+            assert pval > 0.9
         # check covariance
         cov = np.cov(samples.transpose())
-        assert_(np.abs(cov[0, 1] - 0.5) < 1e-2)
+        assert np.abs(cov[0, 1] - 0.5) < 1e-2
 
     def test_MultivariateNormalQMCShapiroInvTransform(self):
         # test the standard case
@@ -980,15 +993,15 @@ class TestMultivariateNormalQMC:
             mean=[0, 0], cov=[[1, 0], [0, 1]], seed=seed, inv_transform=True
         )
         samples = engine.random(n=256)
-        assert_(all(np.abs(samples.mean(axis=0)) < 1e-2))
-        assert_(all(np.abs(samples.std(axis=0) - 1) < 1e-2))
+        assert all(np.abs(samples.mean(axis=0)) < 1e-2)
+        assert all(np.abs(samples.std(axis=0) - 1) < 1e-2)
         # perform Shapiro-Wilk test for normality
         for i in (0, 1):
             _, pval = shapiro(samples[:, i])
-            assert_(pval > 0.9)
+            assert pval > 0.9
         # make sure samples are uncorrelated
         cov = np.cov(samples.transpose())
-        assert_(np.abs(cov[0, 1]) < 1e-2)
+        assert np.abs(cov[0, 1]) < 1e-2
 
         # test the correlated, non-zero mean case
         seed = np.random.RandomState(12345)
@@ -999,15 +1012,15 @@ class TestMultivariateNormalQMC:
             inv_transform=True,
         )
         samples = engine.random(n=256)
-        assert_(all(np.abs(samples.mean(axis=0) - [1, 2]) < 1e-2))
-        assert_(all(np.abs(samples.std(axis=0) - np.sqrt(1.5)) < 1e-2))
+        assert all(np.abs(samples.mean(axis=0) - [1, 2]) < 1e-2)
+        assert all(np.abs(samples.std(axis=0) - np.sqrt(1.5)) < 1e-2)
         # perform Shapiro-Wilk test for normality
         for i in (0, 1):
             _, pval = shapiro(samples[:, i])
-            assert_(pval > 0.9)
+            assert pval > 0.9
         # check covariance
         cov = np.cov(samples.transpose())
-        assert_(np.abs(cov[0, 1] - 0.5) < 1e-2)
+        assert np.abs(cov[0, 1] - 0.5) < 1e-2
 
     def test_MultivariateNormalQMCDegenerate(self):
         # X, Y iid standard Normal and Z = X + Y, random vector (X, Y, Z)
@@ -1018,17 +1031,16 @@ class TestMultivariateNormalQMC:
             seed=seed,
         )
         samples = engine.random(n=512)
-        assert_(all(np.abs(samples.mean(axis=0)) < 1e-2))
-        assert_(np.abs(np.std(samples[:, 0]) - 1) < 1e-2)
-        assert_(np.abs(np.std(samples[:, 1]) - 1) < 1e-2)
-        assert_(np.abs(np.std(samples[:, 2]) - np.sqrt(2)) < 1e-2)
+        assert all(np.abs(samples.mean(axis=0)) < 1e-2)
+        assert np.abs(np.std(samples[:, 0]) - 1) < 1e-2
+        assert np.abs(np.std(samples[:, 1]) - 1) < 1e-2
+        assert np.abs(np.std(samples[:, 2]) - np.sqrt(2)) < 1e-2
         for i in (0, 1, 2):
             _, pval = shapiro(samples[:, i])
-            assert_(pval > 0.8)
+            assert pval > 0.8
         cov = np.cov(samples.transpose())
-        assert_(np.abs(cov[0, 1]) < 1e-2)
-        assert_(np.abs(cov[0, 2] - 1) < 1e-2)
+        assert np.abs(cov[0, 1]) < 1e-2
+        assert np.abs(cov[0, 2] - 1) < 1e-2
         # check to see if X + Y = Z almost exactly
-        assert_(
-            all(np.abs(samples[:, 0] + samples[:, 1] - samples[:, 2]) < 1e-5)
-        )
+        assert all(np.abs(samples[:, 0] + samples[:, 1] - samples[:, 2])
+                   < 1e-5)


### PR DESCRIPTION
Adjust a few things based on recent new best practices and things saw in other PR:
* Keyword only arguments for things like `seed` (we still need to be sure before release about this name, cf the general talk about best practices, but not related to this PR)
* Validation of dimension for passing engine to `MultivariateNormalQMC`.
* Fix/clean some machinery such as `reset` and `num_generated`.
* Use `rng_integers` over custom handling.