### PR TITLE
DOC: Adding examples to docstrings in morphology: white_tophat, black_tophat

### DIFF
--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -1736,6 +1736,24 @@ def white_tophat(input, size=None, footprint=None, structure=None,
     output : ndarray
         Result of the filter of `input` with `structure`.
 
+    Examples
+    --------
+    Subtract gray background from a bright peak.
+
+    >>> from scipy.ndimage import generate_binary_structure, white_tophat
+    >>> square = generate_binary_structure(rank=2, connectivity=3)
+    >>> bright_on_gray = numpy.array([[2, 3, 3, 3, 2],
+    ...                               [3, 4, 5, 4, 3],
+    ...                               [3, 5, 9, 5, 3],
+    ...                               [3, 4, 5, 4, 3],
+    ...                               [2, 3, 3, 3, 2]])
+    >>> white_tophat(input=bright_on_gray, structure=square)
+    array([[0, 0, 0, 0, 0],
+           [0, 0, 1, 0, 0],
+           [0, 1, 5, 1, 0],
+           [0, 0, 1, 0, 0],
+           [0, 0, 0, 0, 0]])
+
     See also
     --------
     black_tophat
@@ -1794,6 +1812,24 @@ def black_tophat(input, size=None, footprint=None,
     black_tophat : ndarray
         Result of the filter of `input` with `structure`.
 
+    Examples
+    --------
+    Change dark peak to bright peak and subtract background.
+
+    >>> from scipy.ndimage import generate_binary_structure, black_tophat
+    >>> square = generate_binary_structure(rank=2, connectivity=3)
+    >>> dark_on_gray = numpy.array([[7, 6, 6, 6, 7],
+    ...                             [6, 5, 4, 5, 6],
+    ...                             [6, 4, 0, 4, 6],
+    ...                             [6, 5, 4, 5, 6],
+    ...                             [7, 6, 6, 6, 7]])
+    >>> black_tophat(input=dark_on_gray, structure=square)
+    array([[0, 0, 0, 0, 0],
+           [0, 0, 1, 0, 0],
+           [0, 1, 5, 1, 0],
+           [0, 0, 1, 0, 0],
+           [0, 0, 0, 0, 0]])
+
     See also
     --------
     white_tophat, grey_opening, grey_closing
@@ -1848,7 +1884,7 @@ def distance_transform_bf(input, metric="euclidean", sampling=None,
         Whether to calculate the feature transform.
         Default is False.
     distances : ndarray, optional
-        An output array to store the calculated distance transform, instead of 
+        An output array to store the calculated distance transform, instead of
         returning it.
         `return_distances` must be True.
         It must be the same shape as `input`, and of type float64 if `metric`

--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -1742,11 +1742,11 @@ def white_tophat(input, size=None, footprint=None, structure=None,
 
     >>> from scipy.ndimage import generate_binary_structure, white_tophat
     >>> square = generate_binary_structure(rank=2, connectivity=3)
-    >>> bright_on_gray = numpy.array([[2, 3, 3, 3, 2],
-    ...                               [3, 4, 5, 4, 3],
-    ...                               [3, 5, 9, 5, 3],
-    ...                               [3, 4, 5, 4, 3],
-    ...                               [2, 3, 3, 3, 2]])
+    >>> bright_on_gray = np.array([[2, 3, 3, 3, 2],
+    ...                            [3, 4, 5, 4, 3],
+    ...                            [3, 5, 9, 5, 3],
+    ...                            [3, 4, 5, 4, 3],
+    ...                            [2, 3, 3, 3, 2]])
     >>> white_tophat(input=bright_on_gray, structure=square)
     array([[0, 0, 0, 0, 0],
            [0, 0, 1, 0, 0],
@@ -1818,11 +1818,11 @@ def black_tophat(input, size=None, footprint=None,
 
     >>> from scipy.ndimage import generate_binary_structure, black_tophat
     >>> square = generate_binary_structure(rank=2, connectivity=3)
-    >>> dark_on_gray = numpy.array([[7, 6, 6, 6, 7],
-    ...                             [6, 5, 4, 5, 6],
-    ...                             [6, 4, 0, 4, 6],
-    ...                             [6, 5, 4, 5, 6],
-    ...                             [7, 6, 6, 6, 7]])
+    >>> dark_on_gray = np.array([[7, 6, 6, 6, 7],
+    ...                          [6, 5, 4, 5, 6],
+    ...                          [6, 4, 0, 4, 6],
+    ...                          [6, 5, 4, 5, 6],
+    ...                          [7, 6, 6, 6, 7]])
     >>> black_tophat(input=dark_on_gray, structure=square)
     array([[0, 0, 0, 0, 0],
            [0, 0, 1, 0, 0],


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Helps fixing #7168.

#### What does this implement/fix?
<!--Please explain your changes.-->
Adding docstrings to `morphology.white_tophat` and `morphology.black_tophat`.

#### Additional information
<!--Any additional information you think is important.-->
Examples adapted from [skimage0.9-white_tophat](https://scikit-image.org/docs/0.9.x/api/skimage.morphology.html#skimage.morphology.white_tophat) and [skimage0.9-black_tophat](https://scikit-image.org/docs/0.9.x/api/skimage.morphology.html#skimage.morphology.black_tophat).