### PR TITLE
MAINT, DOC: optimize: Make the input validation explanation clear for `optimize.leastsq` and add a test.

### DIFF
--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -411,8 +411,8 @@ def leastsq(func, x0, args=(), Dfun=None, full_output=0,
     m = shape[0]
 
     if n > m:
-        raise TypeError('Improper input: func input vector length N=%s must '
-                        'not exceed func output vector length M=%s' % (n, m))
+        raise TypeError(f"Improper input: func input vector length N={n} must"
+                        f" not exceed func output vector length M={m}")
 
     if epsfcn is None:
         epsfcn = finfo(dtype).eps

--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -290,8 +290,8 @@ def leastsq(func, x0, args=(), Dfun=None, full_output=0,
     Parameters
     ----------
     func : callable
-        Should take at least one (possibly length N vector) argument and
-        returns M floating point numbers. It must not return NaNs or
+        Should take at least one (possibly length ``N`` vector) argument and
+        returns ``M`` floating point numbers. It must not return NaNs or
         fitting might fail. M must be greater than or equal to N (M >= N).
     x0 : ndarray
         The starting estimate for the minimization.

--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -292,7 +292,7 @@ def leastsq(func, x0, args=(), Dfun=None, full_output=0,
     func : callable
         Should take at least one (possibly length N vector) argument and
         returns M floating point numbers. It must not return NaNs or
-        fitting might fail.
+        fitting might fail. M must be greater than or equal to N (M >= N).
     x0 : ndarray
         The starting estimate for the minimization.
     args : tuple, optional
@@ -411,7 +411,8 @@ def leastsq(func, x0, args=(), Dfun=None, full_output=0,
     m = shape[0]
 
     if n > m:
-        raise TypeError('Improper input: N=%s must not exceed M=%s' % (n, m))
+        raise TypeError('Improper input: func input vector length N=%s must '
+                        'not exceed func output vector length M=%s' % (n, m))
 
     if epsfcn is None:
         epsfcn = finfo(dtype).eps

--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -292,7 +292,7 @@ def leastsq(func, x0, args=(), Dfun=None, full_output=0,
     func : callable
         Should take at least one (possibly length ``N`` vector) argument and
         returns ``M`` floating point numbers. It must not return NaNs or
-        fitting might fail. M must be greater than or equal to N (M >= N).
+        fitting might fail. ``M`` must be greater than or equal to ``N``.
     x0 : ndarray
         The starting estimate for the minimization.
     args : tuple, optional

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -390,6 +390,15 @@ class TestLeastSq:
     def test_concurrent_with_gradient(self):
         return sequence_parallel([self.test_basic_with_gradient] * 10)
 
+    def test_func_input_output_length_check(self):
+
+        def func(x):
+            return 2 * (x[0] - 3) ** 2 + 1
+
+        with assert_raises(TypeError,
+                           match='Improper input: func input vector length N='):
+            optimize.leastsq(func, x0=[0, 1])
+
 
 class TestCurveFit:
     def setup_method(self):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Ref: #13969

#### What does this implement/fix?
<!--Please explain your changes.-->
`optimize.leastsq` validates input vector and output vector length here:
https://github.com/scipy/scipy/blob/4ec4ab8d6ccc1cdb34b84fdcb66fde2cc0210dbf/scipy/optimize/minpack.py#L413-L415
But, the error msg does not explain what is `N` and `M`.

`optimize.leastsq` docstring explains meanings of N and M here:
https://github.com/scipy/scipy/blob/4ec4ab8d6ccc1cdb34b84fdcb66fde2cc0210dbf/scipy/optimize/minpack.py#L293-L295
But, it does not explain the input validation.

So, I improved the error msg and the docstring to explain each other.
Also, a test for this validation is missing, so I added it.
