### PR TITLE
BUG: sparse: Fix DIA.diagonal bug and add a regression test

### DIFF
--- a/scipy/sparse/dia.py
+++ b/scipy/sparse/dia.py
@@ -323,10 +323,16 @@ class dia_matrix(_data_matrix):
         if k <= -rows or k >= cols:
             return np.empty(0, dtype=self.data.dtype)
         idx, = np.nonzero(self.offsets == k)
-        first_col, last_col = max(0, k), min(rows + k, cols)
+        first_col = max(0, k)
+        last_col = min(rows + k, cols)
+        result_size = last_col - first_col
         if idx.size == 0:
-            return np.zeros(last_col - first_col, dtype=self.data.dtype)
-        return self.data[idx[0], first_col:last_col]
+            return np.zeros(result_size, dtype=self.data.dtype)
+        result = self.data[idx[0], first_col:last_col]
+        padding = result_size - len(result)
+        if padding > 0:
+            result = np.pad(result, (0, padding), mode='constant')
+        return result
 
     diagonal.__doc__ = spmatrix.diagonal.__doc__
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -714,6 +714,7 @@ class _TestCommon:
         mats.append([[1],[0],[2]])
         mats.append([[0,1],[0,2],[0,3]])
         mats.append([[0,0,1],[0,0,2],[0,3,0]])
+        mats.append([[1,0],[0,0]])
 
         mats.append(kron(mats[0],[[1,2]]))
         mats.append(kron(mats[0],[[1],[2]]))


### PR DESCRIPTION
#### Reference issue
Fixes gh-13997.

#### What does this implement/fix?
We weren't accounting for the case where the DIA `data` array has fewer columns than the length of the desired output diagonal. In these (apparently fairly rare) cases, we need to pad the resulting array with zeros to make up for this deficit.
