### PR TITLE
BUG: Fix root bracketing logic in Brent's method (issue #13737)

### DIFF
--- a/scipy/optimize/Zeros/brenth.c
+++ b/scipy/optimize/Zeros/brenth.c
@@ -4,7 +4,6 @@
 #include "zeros.h"
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
-#define SIGN(a) ((a) > 0. ? 1. : -1.)
 
 /*
  At the top of the loop the situation is the following:
@@ -50,7 +49,7 @@ brenth(callback_type f, double xa, double xb, double xtol, double rtol,
     fpre = (*f)(xpre,func_data);
     fcur = (*f)(xcur,func_data);
     solver_stats->funcalls = 2;
-    if (SIGN(fpre)*SIGN(fcur) > 0) {
+    if (fpre*fcur > 0) {
         solver_stats->error_num = SIGNERR;
         return 0.;
     }
@@ -65,7 +64,8 @@ brenth(callback_type f, double xa, double xb, double xtol, double rtol,
     solver_stats->iterations = 0;
     for (i = 0; i < iter; i++) {
         solver_stats->iterations++;
-        if (SIGN(fpre)*SIGN(fcur) < 0) {
+        if (fpre != 0 && fcur != 0 &&
+	    (signbit(fpre) != signbit(fcur))) {
             xblk = xpre;
             fblk = fpre;
             spre = scur = xcur - xpre;

--- a/scipy/optimize/Zeros/brenth.c
+++ b/scipy/optimize/Zeros/brenth.c
@@ -4,6 +4,7 @@
 #include "zeros.h"
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
+#define SIGN(a) ((a) > 0. ? 1. : -1.)
 
 /*
  At the top of the loop the situation is the following:
@@ -49,7 +50,7 @@ brenth(callback_type f, double xa, double xb, double xtol, double rtol,
     fpre = (*f)(xpre,func_data);
     fcur = (*f)(xcur,func_data);
     solver_stats->funcalls = 2;
-    if (fpre*fcur > 0) {
+    if (SIGN(fpre)*SIGN(fcur) > 0) {
         solver_stats->error_num = SIGNERR;
         return 0.;
     }
@@ -64,7 +65,7 @@ brenth(callback_type f, double xa, double xb, double xtol, double rtol,
     solver_stats->iterations = 0;
     for (i = 0; i < iter; i++) {
         solver_stats->iterations++;
-        if (fpre*fcur < 0) {
+        if (SIGN(fpre)*SIGN(fcur) < 0) {
             xblk = xpre;
             fblk = fpre;
             spre = scur = xcur - xpre;

--- a/scipy/optimize/Zeros/brentq.c
+++ b/scipy/optimize/Zeros/brentq.c
@@ -4,7 +4,6 @@
 #include "zeros.h"
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
-#define SIGN(a) ((a) > 0. ? 1. : -1.)
 
 /*
   At the top of the loop the situation is the following:
@@ -49,7 +48,7 @@ brentq(callback_type f, double xa, double xb, double xtol, double rtol,
     fpre = (*f)(xpre, func_data);
     fcur = (*f)(xcur, func_data);
     solver_stats->funcalls = 2;
-    if (SIGN(fpre)*SIGN(fcur) > 0) {
+    if (fpre*fcur > 0) {
         solver_stats->error_num = SIGNERR;
         return 0.;
     }
@@ -65,7 +64,8 @@ brentq(callback_type f, double xa, double xb, double xtol, double rtol,
     solver_stats->iterations = 0;
     for (i = 0; i < iter; i++) {
         solver_stats->iterations++;
-        if (SIGN(fpre)*SIGN(fcur) < 0) {
+        if (fpre != 0 && fcur != 0 &&
+	    (signbit(fpre) != signbit(fcur))) {
             xblk = xpre;
             fblk = fpre;
             spre = scur = xcur - xpre;

--- a/scipy/optimize/Zeros/brentq.c
+++ b/scipy/optimize/Zeros/brentq.c
@@ -4,6 +4,7 @@
 #include "zeros.h"
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
+#define SIGN(a) ((a) > 0. ? 1. : -1.)
 
 /*
   At the top of the loop the situation is the following:
@@ -48,7 +49,7 @@ brentq(callback_type f, double xa, double xb, double xtol, double rtol,
     fpre = (*f)(xpre, func_data);
     fcur = (*f)(xcur, func_data);
     solver_stats->funcalls = 2;
-    if (fpre*fcur > 0) {
+    if (SIGN(fpre)*SIGN(fcur) > 0) {
         solver_stats->error_num = SIGNERR;
         return 0.;
     }
@@ -64,7 +65,7 @@ brentq(callback_type f, double xa, double xb, double xtol, double rtol,
     solver_stats->iterations = 0;
     for (i = 0; i < iter; i++) {
         solver_stats->iterations++;
-        if (fpre*fcur < 0) {
+        if (SIGN(fpre)*SIGN(fcur) < 0) {
             xblk = xpre;
             fblk = fpre;
             spre = scur = xcur - xpre;

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -507,17 +507,14 @@ def test_brent_underflow_in_root_bracketing():
     # by checking f(a)*f(b) < 0 is not reliable when the product
     # underflows/overflows. (reported in issue# 13737)
 
-    xa = -400.0
-    xb = -350.0
-    rt = -400.0
-    underflow_scenario = (xa, xb, rt)
-    overflow_scenario = (-xa, -xb, -rt)
+    underflow_scenario = (-450.0, -350.0, -400.0)
+    overflow_scenario = (350.0, 450.0, 400.0)
 
     for a, b, root in [underflow_scenario, overflow_scenario]:
         c = np.exp(root)
         for method in [zeros.brenth, zeros.brentq]:
             res = method(lambda x: np.exp(x)-c, a, b)
-            assert_allclose(root, res, atol=1e-8)
+            assert_allclose(root, res)
 
 
 class TestRootResults:

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -502,6 +502,24 @@ def test_gh_5557():
         assert_allclose(0.6, res, atol=atol, rtol=rtol)
 
 
+def test_brent_underflow_in_root_bracketing():
+    # Tetsing if an interval [a,b] brackets a zero of a function
+    # by checking f(a)*f(b) < 0 is not reliable when the product
+    # underflows/overflows. (reported in issue# 13737)
+
+    xa = -400.0
+    xb = -350.0
+    rt = -400.0
+    underflow_scenario = (xa, xb, rt)
+    overflow_scenario = (-xa, -xb, -rt)
+
+    for a, b, root in [underflow_scenario, overflow_scenario]:
+        c = np.exp(root)
+        for method in [zeros.brenth, zeros.brentq]:
+            res = method(lambda x: np.exp(x)-c, a, b)
+            assert_allclose(root, res, atol=1e-8)
+
+
 class TestRootResults:
     def test_repr(self):
         r = zeros.RootResults(root=1.0,


### PR DESCRIPTION
The check, f(a)*f(b) < 0, to determine if the interval [a, b]
brackets a root, can fail when the product overflows/underflows.
The modified check is:
sgn(f(a))*sgn(f(b)) < 0, where sgn(x) denotes the sign of x.

Closes #13737