### PR TITLE
DEP: Remove usage of numpy.compat

### DIFF
--- a/scipy/io/idl.py
+++ b/scipy/io/idl.py
@@ -31,7 +31,6 @@ __all__ = ['readsav']
 
 import struct
 import numpy as np
-from numpy.compat import asstr
 import tempfile
 import zlib
 import warnings
@@ -160,9 +159,8 @@ def _read_string(f):
     '''Read a string'''
     length = _read_long(f)
     if length > 0:
-        chars = _read_bytes(f, length)
+        chars = _read_bytes(f, length).decode('latin1')
         _align_32(f)
-        chars = asstr(chars)
     else:
         chars = ''
     return chars

--- a/scipy/io/matlab/mio4.py
+++ b/scipy/io/matlab/mio4.py
@@ -4,7 +4,6 @@ import sys
 import warnings
 
 import numpy as np
-from numpy.compat import asbytes, asstr
 
 import scipy.sparse
 
@@ -389,7 +388,7 @@ class MatFile4Reader(MatFileReader):
         mdict = {}
         while not self.end_of_stream():
             hdr, next_position = self.read_var_header()
-            name = asstr(hdr.name)
+            name = hdr.name.decode('latin1')
             if variable_names is not None and name not in variable_names:
                 self.mat_stream.seek(next_position)
                 continue
@@ -409,7 +408,7 @@ class MatFile4Reader(MatFileReader):
         vars = []
         while not self.end_of_stream():
             hdr, next_position = self.read_var_header()
-            name = asstr(hdr.name)
+            name = hdr.name.decode('latin1')
             shape = self._matrix_reader.shape_from_header(hdr)
             info = mclass_info.get(hdr.mclass, 'unknown')
             vars.append((name, shape, info))
@@ -483,7 +482,8 @@ class VarWriter4:
         header['imagf'] = imagf
         header['namlen'] = len(name) + 1
         self.write_bytes(header)
-        self.write_string(asbytes(name + '\0'))
+        data = name + '\0'
+        self.write_string(data.encode('latin1'))
 
     def write(self, arr, name):
         ''' Write matrix `arr`, with name `name`

--- a/scipy/io/matlab/mio5.py
+++ b/scipy/io/matlab/mio5.py
@@ -81,7 +81,6 @@ from io import BytesIO
 import warnings
 
 import numpy as np
-from numpy.compat import asbytes, asstr
 
 import scipy.sparse
 
@@ -311,7 +310,7 @@ class MatFile5Reader(MatFileReader):
         mdict['__globals__'] = []
         while not self.end_of_stream():
             hdr, next_position = self.read_var_header()
-            name = asstr(hdr.name)
+            name = hdr.name.decode('latin1')
             if name in mdict:
                 warnings.warn('Duplicate variable name "%s" in stream'
                               ' - replacing previous with new\n'
@@ -359,7 +358,7 @@ class MatFile5Reader(MatFileReader):
         vars = []
         while not self.end_of_stream():
             hdr, next_position = self.read_var_header()
-            name = asstr(hdr.name)
+            name = hdr.name.decode('latin1')
             if name == '':
                 # can only be a matlab 7 function workspace
                 name = '__function_workspace__'
@@ -430,7 +429,7 @@ def varmats_from_mat(file_obj):
     while not rdr.end_of_stream():
         start_position = next_position
         hdr, next_position = rdr.read_var_header()
-        name = asstr(hdr.name)
+        name = hdr.name.decode('latin1')
         # Read raw variable string
         file_obj.seek(start_position)
         byte_count = next_position - start_position
@@ -882,7 +881,7 @@ class MatFile5Writer:
             if self.do_compression:
                 stream = BytesIO()
                 self._matrix_writer.file_stream = stream
-                self._matrix_writer.write_top(var, asbytes(name), is_global)
+                self._matrix_writer.write_top(var, name.encode('latin1'), is_global)
                 out_str = zlib.compress(stream.getvalue())
                 tag = np.empty((), NDT_TAG_FULL)
                 tag['mdtype'] = miCOMPRESSED
@@ -890,4 +889,4 @@ class MatFile5Writer:
                 self.file_stream.write(tag.tobytes())
                 self.file_stream.write(out_str)
             else:  # not compressing
-                self._matrix_writer.write_top(var, asbytes(name), is_global)
+                self._matrix_writer.write_top(var, name.encode('latin1'), is_global)

--- a/scipy/io/matlab/mio5_utils.pyx
+++ b/scipy/io/matlab/mio5_utils.pyx
@@ -25,10 +25,11 @@ from cpython cimport Py_INCREF, Py_DECREF
 from cpython cimport PyObject
 
 cdef extern from "Python.h":
+    unicode PyUnicode_FromString(const char *u)
     ctypedef struct PyTypeObject:
         pass
 
-from cpython cimport PyBytes_Size, PyBytes_FromString
+from cpython cimport PyBytes_Size
 
 import numpy as np
 cimport numpy as cnp
@@ -917,7 +918,7 @@ cdef class VarReader5:
             char *n_ptr = names
             int j, dup_no
         for i in range(n_names):
-            name = PyBytes_FromString(n_ptr).decode('latin1')
+            name = PyUnicode_FromString(n_ptr)
             # Check if this is a duplicate field, rename if so
             dup_no = 0
             for j in range(i):

--- a/scipy/io/matlab/mio5_utils.pyx
+++ b/scipy/io/matlab/mio5_utils.pyx
@@ -31,7 +31,6 @@ cdef extern from "Python.h":
 from cpython cimport PyBytes_Size, PyBytes_FromString
 
 import numpy as np
-from numpy.compat import asbytes, asstr
 cimport numpy as cnp
 
 cdef extern from "numpy/arrayobject.h":
@@ -718,7 +717,7 @@ cdef class VarReader5:
         elif mc == mxSTRUCT_CLASS:
             arr = self.read_struct(header)
         elif mc == mxOBJECT_CLASS: # like structs, but with classname
-            classname = asstr(self.read_int8_string())
+            classname = self.read_int8_string().decode('latin1')
             arr = self.read_struct(header)
             arr = mio5p.MatlabObject(arr, classname)
         elif mc == mxFUNCTION_CLASS: # just a matrix of struct type
@@ -918,7 +917,7 @@ cdef class VarReader5:
             char *n_ptr = names
             int j, dup_no
         for i in range(n_names):
-            name = asstr(PyBytes_FromString(n_ptr))
+            name = PyBytes_FromString(n_ptr).decode('latin1')
             # Check if this is a duplicate field, rename if so
             dup_no = 0
             for j in range(i):

--- a/scipy/io/matlab/tests/test_mio_funcs.py
+++ b/scipy/io/matlab/tests/test_mio_funcs.py
@@ -5,8 +5,6 @@ of mat file.
 import os.path
 import io
 
-from numpy.compat import asstr
-
 from scipy.io.matlab.mio5 import MatFile5Reader
 
 test_data_path = os.path.join(os.path.dirname(__file__), 'data')
@@ -18,7 +16,7 @@ def read_minimat_vars(rdr):
     i = 0
     while not rdr.end_of_stream():
         hdr, next_position = rdr.read_var_header()
-        name = asstr(hdr.name)
+        name = hdr.name.decode('latin1')
         if name == '':
             name = 'var_%d' % i
             i += 1

--- a/scipy/io/netcdf.py
+++ b/scipy/io/netcdf.py
@@ -42,7 +42,6 @@ from platform import python_implementation
 import mmap as mm
 
 import numpy as np
-from numpy.compat import asbytes, asstr
 from numpy import frombuffer, dtype, empty, array, asarray
 from numpy import little_endian as LITTLE_ENDIAN
 from functools import reduce
@@ -486,7 +485,7 @@ class netcdf_file:
         self._write_att_array(var._attributes)
 
         nc_type = REVERSE[var.typecode(), var.itemsize()]
-        self.fp.write(asbytes(nc_type))
+        self.fp.write(nc_type)
 
         if not var.isrec:
             vsize = var.data.size * var.data.itemsize
@@ -579,7 +578,7 @@ class netcdf_file:
 
         values = asarray(values, dtype=dtype_)
 
-        self.fp.write(asbytes(nc_type))
+        self.fp.write(nc_type)
 
         if values.dtype.char == 'S':
             nelems = values.itemsize
@@ -618,7 +617,7 @@ class netcdf_file:
         count = self._unpack_int()
 
         for dim in range(count):
-            name = asstr(self._unpack_string())
+            name = self._unpack_string().decode('latin1')
             length = self._unpack_int() or None  # None for record dimension
             self.dimensions[name] = length
             self._dims.append(name)  # preserve order
@@ -635,7 +634,7 @@ class netcdf_file:
 
         attributes = {}
         for attr in range(count):
-            name = asstr(self._unpack_string())
+            name = self._unpack_string().decode('latin1')
             attributes[name] = self._read_att_values()
         return attributes
 
@@ -726,7 +725,7 @@ class netcdf_file:
                 self.variables[var].__dict__['data'] = rec_array[var]
 
     def _read_var(self):
-        name = asstr(self._unpack_string())
+        name = self._unpack_string().decode('latin1')
         dimensions = []
         shape = []
         dims = self._unpack_int()
@@ -791,7 +790,7 @@ class netcdf_file:
     def _pack_string(self, s):
         count = len(s)
         self._pack_int(count)
-        self.fp.write(asbytes(s))
+        self.fp.write(s.encode('latin1'))
         self.fp.write(b'\x00' * (-count % 4))  # pad
 
     def _unpack_string(self):

--- a/scipy/linalg/tests/test_build.py
+++ b/scipy/linalg/tests/test_build.py
@@ -4,7 +4,6 @@ import re
 
 import pytest
 from numpy.testing import assert_
-from numpy.compat import asbytes
 
 from scipy.linalg import _flapack as flapack
 
@@ -32,7 +31,8 @@ class FindDependenciesLdd:
     def grep_dependencies(self, file, deps):
         stdout = self.get_dependencies(file)
 
-        rdeps = dict([(asbytes(dep), re.compile(asbytes(dep))) for dep in deps])
+        rdeps = dict([( dep.encode('latin1'), 
+                        re.compile(dep.encode('latin1'))) for dep in deps])
         founds = []
         for l in stdout.splitlines():
             for k, v in rdeps.items():

--- a/scipy/spatial/qhull.pyx
+++ b/scipy/spatial/qhull.pyx
@@ -19,7 +19,6 @@ from . cimport setlist
 from libc cimport stdlib
 from scipy._lib.messagestream cimport MessageStream
 
-from numpy.compat import asbytes
 import os
 import sys
 import tempfile
@@ -1834,7 +1833,7 @@ class Delaunay(_QhullUser):
             if points.shape[1] >= 5:
                 qhull_options += b" Qx"
         else:
-            qhull_options = asbytes(qhull_options)
+            qhull_options = qhull_options.encode('latin1')
 
         # Run qhull
         qhull = _Qhull(b"d", points, qhull_options, required_options=b"Qt",
@@ -2429,7 +2428,7 @@ class ConvexHull(_QhullUser):
             if points.shape[1] >= 5:
                 qhull_options += b"Qx"
         else:
-            qhull_options = asbytes(qhull_options)
+            qhull_options = qhull_options.encode('latin1')
 
         # Run qhull
         qhull = _Qhull(b"i", points, qhull_options, required_options=b"Qt",
@@ -2608,7 +2607,7 @@ class Voronoi(_QhullUser):
             if points.shape[1] >= 5:
                 qhull_options += b" Qx"
         else:
-            qhull_options = asbytes(qhull_options)
+            qhull_options = qhull_options.encode('latin1')
 
         # Run qhull
         qhull = _Qhull(b"v", points, qhull_options, furthest_site=furthest_site,
@@ -2805,7 +2804,7 @@ class HalfspaceIntersection(_QhullUser):
             if halfspaces.shape[1] >= 6:
                 qhull_options += b"Qx"
         else:
-            qhull_options = asbytes(qhull_options)
+            qhull_options = qhull_options.encode('latin1')
 
         # Run qhull
         mode_option = "H"


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
#13880 

#### What does this implement/fix?
<!--Please explain your changes.-->
Removes the usage of `numpy.compat` library and uses `str.encode('latin1')` and `bytes.decode('latin1')` functions instead.

#### Additional information
<!--Any additional information you think is important.-->
I tried to trace the type of variables that were passed to `numpy.compat.asstr` and `numpy.compat.asbytes` functions and applied `str.encode('latin1')` and `bytes.decode('latin1')` functions instead on suitable types. The build passes all the tests.