### PR TITLE
MAINT: add support for wheel DL proxy

### DIFF
--- a/tools/download-wheels.py
+++ b/tools/download-wheels.py
@@ -30,7 +30,11 @@ def get_wheel_names(version):
         The release version. For instance, "1.5.0".
 
     """
-    http = urllib3.PoolManager(cert_reqs='CERT_REQUIRED')
+    proxy = os.getenv('https_proxy')
+    if proxy is not None:
+        http = urllib3.ProxyManager(proxy)
+    else:
+        http = urllib3.PoolManager(cert_reqs='CERT_REQUIRED')
     tmpl = re.compile(rf"^.*{PREFIX}-{version}-.*\.whl$")
     index_url = f"{STAGING_URL}/files"
     index_html = http.request('GET', index_url)
@@ -52,7 +56,11 @@ def download_wheels(version, wheelhouse):
         Directory in which to download the wheels.
 
     """
-    http = urllib3.PoolManager(cert_reqs='CERT_REQUIRED')
+    proxy = os.getenv('https_proxy')
+    if proxy is not None:
+        http = urllib3.ProxyManager(proxy)
+    else:
+        http = urllib3.PoolManager(cert_reqs='CERT_REQUIRED')
     wheel_names = get_wheel_names(version)
 
     for i, wheel_name in enumerate(wheel_names):

--- a/tools/download-wheels.py
+++ b/tools/download-wheels.py
@@ -8,6 +8,7 @@ import os
 import re
 import shutil
 import argparse
+import urllib
 
 import urllib3
 from bs4 import BeautifulSoup
@@ -17,6 +18,20 @@ __version__ = '0.1'
 # Edit these for other projects.
 STAGING_URL = 'https://anaconda.org/multibuild-wheels-staging/scipy'
 PREFIX = 'scipy'
+
+def http_manager():
+    """
+    Return a urllib3 http request manager, leveraging
+    proxy settings when available.
+    """
+    proxy_dict = urllib.request.getproxies()
+    if 'http' in proxy_dict:
+        http = urllib3.ProxyManager(proxy_dict['http'])
+    elif 'all' in proxy_dict:
+        http = urllib3.ProxyManager(proxy_dict['all'])
+    else:
+        http = urllib3.PoolManager(cert_reqs='CERT_REQUIRED')
+    return http
 
 def get_wheel_names(version):
     """ Get wheel names from Anaconda HTML directory.
@@ -30,11 +45,7 @@ def get_wheel_names(version):
         The release version. For instance, "1.5.0".
 
     """
-    proxy = os.getenv('https_proxy')
-    if proxy is not None:
-        http = urllib3.ProxyManager(proxy)
-    else:
-        http = urllib3.PoolManager(cert_reqs='CERT_REQUIRED')
+    http = http_manager()
     tmpl = re.compile(rf"^.*{PREFIX}-{version}-.*\.whl$")
     index_url = f"{STAGING_URL}/files"
     index_html = http.request('GET', index_url)
@@ -56,11 +67,7 @@ def download_wheels(version, wheelhouse):
         Directory in which to download the wheels.
 
     """
-    proxy = os.getenv('https_proxy')
-    if proxy is not None:
-        http = urllib3.ProxyManager(proxy)
-    else:
-        http = urllib3.PoolManager(cert_reqs='CERT_REQUIRED')
+    http = http_manager()
     wheel_names = get_wheel_names(version)
 
     for i, wheel_name in enumerate(wheel_names):


### PR DESCRIPTION
* add support for downloading SciPy wheels from behind
a proxy during the release process, falling back to
the original behavior if a common proxy-related environment
variable is not defined

* this should only affect the release manager--prevents me
from having to make this change manually each time