### PR TITLE
MAINT: remove brew update

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -71,7 +71,6 @@ jobs:
 
     - name: A few other packages
       run: |
-        brew update  # temporary needed until GiHub updates brew to 3.1.0
         brew install libmpc suitesparse swig
 
     - name: Install packages


### PR DESCRIPTION
Brew update is not required anymore as GitHub ships `brew >= 3.1.0` now.

This fixes the macos workflows errors.

xref https://github.com/actions/virtual-environments/issues/3165