### PR TITLE
BENCH: Add more formats for sparse arithmetic

### DIFF
--- a/benchmarks/benchmarks/sparse.py
+++ b/benchmarks/benchmarks/sparse.py
@@ -4,10 +4,7 @@ Simple benchmarks for the sparse module
 import warnings
 import time
 import timeit
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
+import pickle
 
 import numpy
 import numpy as np
@@ -55,7 +52,7 @@ def poisson2d(N, dtype='d', format=None):
 class Arithmetic(Benchmark):
     param_names = ['format', 'XY', 'op']
     params = [
-        ['csr'],
+        ['csr', 'csc', 'coo', 'dia'],
         ['AA', 'AB', 'BA', 'BB'],
         ['__add__', '__sub__', 'multiply', '__mul__']
     ]


### PR DESCRIPTION
#### Reference issue
This will be useful for checking the speedup in gh-14004, and in general any optimization work done on sparse matrix arithmetic.

#### What does this implement/fix?
Adds CSC, COO, and DIA formats to the benchmarked sparse formats set.

#### Additional information
I also removed a Python 2 import fallback for `pickle`.

[ci skip] (only affects benchmark code)