### PR TITLE
BENCH: add benchmark for f_oneway

### DIFF
--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -43,10 +43,10 @@ class CorrelationFunctions(Benchmark):
 
 class ANOVAFunction(Benchmark):
     def setup(self):
-        np.random.seed(12345678)
-        self.a = np.random.rand(6,3) * 10
-        self.b = np.random.rand(6,3) * 10
-        self.c = np.random.rand(6,3) * 10
+        rng = np.random.default_rng(12345678)
+        self.a = rng.random((6,3)) * 10
+        self.b = rng.random((6,3)) * 10
+        self.c = rng.random((6,3)) * 10
     
     def time_f_oneway(self):
         statistic, pvalue = stats.f_oneway(self.a, self.b, self.c)

--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -41,6 +41,18 @@ class CorrelationFunctions(Benchmark):
         resBarnard = stats.barnard_exact(self.a, alternative=alternative)
 
 
+class ANOVAFunction(Benchmark):
+    def setup(self):
+        np.random.seed(12345678)
+        self.a = np.random.rand(6,3) * 10
+        self.b = np.random.rand(6,3) * 10
+        self.c = np.random.rand(6,3) * 10
+    
+    def time_f_oneway(self):
+        statistic, pvalue = stats.f_oneway(self.a, self.b, self.c)
+        statistic, pvalue = stats.f_oneway(self.a, self.b, self.c, axis=1)
+
+
 class Kendalltau(Benchmark):
     param_names = ['nan_policy','method','variant']
     params = [

--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -62,11 +62,11 @@ class Kendalltau(Benchmark):
     ]
 
     def setup(self, nan_policy, method, variant):
-        np.random.seed(12345678)
+        rng = np.random.default_rng(12345678)
         a = np.arange(200)
-        np.random.shuffle(a)
+        rng.shuffle(a)
         b = np.arange(200)
-        np.random.shuffle(b)
+        rng.shuffle(b)
         self.a = a
         self.b = b
 


### PR DESCRIPTION
#### What does this implement/fix?
Add benchmark for ANOVA Functions stats.f_oneway. The results on my local machine:

```
· Running 1 total benchmarks (1 commits * 1 environments * 1 benchmarks)
[  0.00%] ·· Benchmarking existing-py_Users_charlotte_anaconda3_envs_scipydev_bin_python
[ 50.00%] ··· Running (stats.ANOVAFunction.time_f_oneway--).
[100.00%] ··· stats.ANOVAFunction.time_f_oneway                        254±3μs
```