### PR TITLE
ENH: iPython extension for interactive object representation

### DIFF
--- a/scipy/ipython/distributions.py
+++ b/scipy/ipython/distributions.py
@@ -1,0 +1,41 @@
+from IPython.core.pylabtools import print_figure
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def _repr_png_(distribution):
+
+    name = distribution.dist.name
+    title = (f"{name}(args={distribution.args}, kwargs={distribution.kwds}),"
+             " N=1000")
+
+    fig, ax = plt.subplots()
+
+    # PDF
+    x = np.linspace(distribution.ppf(0.01),
+                    distribution.ppf(0.99), 100)
+    pdf = distribution.pdf(x)
+    ax.plot(x, pdf, '-', lw=5, alpha=0.6)
+
+    # Empirical PDF
+    sample = distribution.rvs(size=1000)
+    ax.hist(sample, density=True, histtype="stepfilled", alpha=0.2)
+    delta = np.max(pdf) * 5e-2
+    ax.plot(sample[:100], -delta - delta * np.random.random(100), "+k")
+
+    ax.set_title(title)
+    ax.set_ylabel(r"$f$")
+    ax.set_xlabel(r"$x$")
+
+    data = print_figure(fig, "png")
+
+    # We MUST close the figure, otherwise IPython's display machinery
+    # will pick it up and send it as output, resulting in a double display
+    plt.close(fig)
+    return data
+
+
+def load_ipython_extension(ipython):
+    png_f = ipython.display_formatter.formatters["image/png"]
+    png_f.for_type_by_name("scipy.stats._distn_infrastructure",
+                           "rv_frozen", _repr_png_)


### PR DESCRIPTION
I propose to add one (or more ) extension to enable rich object representations in iPython.

This was discussed on the mailing list here:
https://mail.python.org/pipermail/scipy-dev/2021-May/024772.html

The current PR adds an extension which adds a display method rendering a PNG when calling a frozen distribution. It just shows the PDF, but I could add the CDF as well, or something else depending on wishes. It can be used as followed:

```python
%load_ext scipy.ipython.distributions
from scipy.stats import norm
norm(loc=3, scale=2)
```

![Unknown](https://user-images.githubusercontent.com/23188539/117708351-fe6f8480-b1cf-11eb-9483-27918cfd2b37.png)

The same logic could be used in more modules. I have a few ideas for QMC to represent a sample for instance. Also an optimization result could show the search. Or just adding some latex equations in some places could make things prettier. Etc.

For now I created a new module `scipy.ipython` to store these in order to keep the current classes free from these extensions. I am also not sure how to test these. If we continue, I would add some doc somewhere (and I could include this in some tutorial or make a new one).

cc @rkern @Carreau 