### PR TITLE
BUG: sparse: fix DIA.setdiag issue

### DIFF
--- a/scipy/sparse/dia.py
+++ b/scipy/sparse/dia.py
@@ -276,13 +276,18 @@ class dia_matrix(_data_matrix):
             # allow also longer sequences
             values = values[:n]
 
+        data_rows, data_cols = self.data.shape
         if k in self.offsets:
+            if max_index > data_cols:
+                data = np.zeros((data_rows, max_index), dtype=self.data.dtype)
+                data[:, :data_cols] = self.data
+                self.data = data
             self.data[self.offsets == k, min_index:max_index] = values
         else:
             self.offsets = np.append(self.offsets, self.offsets.dtype.type(k))
-            m = max(max_index, self.data.shape[1])
-            data = np.zeros((self.data.shape[0]+1, m), dtype=self.data.dtype)
-            data[:-1,:self.data.shape[1]] = self.data
+            m = max(max_index, data_cols)
+            data = np.zeros((data_rows + 1, m), dtype=self.data.dtype)
+            data[:-1, :data_cols] = self.data
             data[-1, min_index:max_index] = values
             self.data = data
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -843,6 +843,7 @@ class _TestCommon:
     def test_setdiag(self):
         # simple test cases
         m = self.spmatrix(np.eye(3))
+        m2 = self.spmatrix((4, 4))
         values = [3, 2, 1]
         with suppress_warnings() as sup:
             sup.filter(SparseEfficiencyWarning,
@@ -862,6 +863,13 @@ class _TestCommon:
             assert_array_equal(m.A[0,2], 9)
             m.setdiag((9,), k=-2)
             assert_array_equal(m.A[2,0], 9)
+            # test short values on an empty matrix
+            m2.setdiag([1], k=2)
+            assert_array_equal(m2.A[0], [0, 0, 1, 0])
+            # test overwriting that same diagonal
+            m2.setdiag([1, 1], k=2)
+            assert_array_equal(m2.A[:2], [[0, 0, 1, 0],
+                                          [0, 0, 0, 1]])
 
     def test_nonzero(self):
         A = array([[1, 0, 1],[0, 1, 1],[0, 0, 1]])


### PR DESCRIPTION
#### Reference issue
Issue was identified in gh-14004.

#### What does this implement/fix?
When DIA.setdiag() gets a short values array, it only stores the minimum needed to represent the matrix. This can lead to errors later when trying to assign a full-length values array to the same diagonal, as the offset already exists but the backing data isn't large enough.