### PR TITLE
MAINT: use 'yield from <expr>' (PEP 380)

### DIFF
--- a/scipy/fft/tests/test_helper.py
+++ b/scipy/fft/tests/test_helper.py
@@ -45,8 +45,7 @@ class TestNextFastLen:
         np.random.seed(1234)
 
         def nums():
-            for j in range(1, 1000):
-                yield j
+            yield from range(1, 1000)
             yield 2**5 * 3**5 * 4**5 + 1
 
         for n in nums():

--- a/scipy/sparse/csc.py
+++ b/scipy/sparse/csc.py
@@ -120,8 +120,7 @@ class csc_matrix(_cs_matrix):
     transpose.__doc__ = spmatrix.transpose.__doc__
 
     def __iter__(self):
-        for r in self.tocsr():
-            yield r
+        yield from self.tocsr()
 
     def tocsc(self, copy=False):
         if copy:

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -2504,16 +2504,14 @@ class TestBessel:
     def _cephes_vs_amos_points(self):
         """Yield points at which to compare Cephes implementation to AMOS"""
         # check several points, including large-amplitude ones
-        for v in [-120, -100.3, -20., -10., -1., -.5,
-                  0., 1., 12.49, 120., 301]:
-            for z in [-1300, -11, -10, -1, 1., 10., 200.5, 401., 600.5,
-                      700.6, 1300, 10003]:
-                yield v, z
+        v = [-120, -100.3, -20., -10., -1., -.5, 0., 1., 12.49, 120., 301]
+        z = [-1300, -11, -10, -1, 1., 10., 200.5, 401., 600.5, 700.6, 1300,
+             10003]
+        yield from itertools.product(v, z)
 
         # check half-integers; these are problematic points at least
         # for cephes/iv
-        for v in 0.5 + arange(-60, 60):
-            yield v, 3.5
+        yield from itertools.product(0.5 + arange(-60, 60), [3.5])
 
     def check_cephes_vs_amos(self, f1, f2, rtol=1e-11, atol=0, skip=None):
         for v, z in self._cephes_vs_amos_points():


### PR DESCRIPTION
This PR uses mostly simple cases of [PEP 380](https://www.python.org/dev/peps/pep-0380/) to rewrite:
```python
for v in g:
    yield v
```
into:
```python
yield from <expr>
```
which was a new feature in [Python 3.3](https://docs.python.org/3/whatsnew/3.3.html#pep-380).

For nested for loops, `itertools.product` is used to help form an expression.