### PR TITLE
MAINT: CXXFLAGS for Pythran

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -343,6 +343,7 @@ stages:
             # directly for i686 mingw
             $env:NPY_DISTUTILS_APPEND_FLAGS = 1
             $env:CFLAGS = "-m32"
+            $env:CXXFLAGS = "-m32"
             $env:LDFLAGS = "-m32"
             refreshenv
         }


### PR DESCRIPTION
Attempt to fix `Main Windows Python37-32bit-fast` azure workflow.

Add `CXXFLAGS` for Pythran according to https://github.com/scipy/scipy/pull/14026#issuecomment-840751729