### PR TITLE
ENH: Port sqeuclidean and braycurtis to _distance_pybind

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -1778,8 +1778,8 @@ _METRIC_INFOS = [
         canonical_name='braycurtis',
         aka={'braycurtis'},
         dist_func=braycurtis,
-        cdist_func=CDistMetricWrapper('braycurtis'),
-        pdist_func=PDistMetricWrapper('braycurtis'),
+        cdist_func=_distance_pybind.cdist_braycurtis,
+        pdist_func=_distance_pybind.pdist_braycurtis,
     ),
     MetricInfo(
         canonical_name='canberra',
@@ -1923,8 +1923,8 @@ _METRIC_INFOS = [
         canonical_name='sqeuclidean',
         aka={'sqeuclidean', 'sqe', 'sqeuclid'},
         dist_func=sqeuclidean,
-        cdist_func=CDistMetricWrapper('sqeuclidean'),
-        pdist_func=PDistMetricWrapper('sqeuclidean'),
+        cdist_func=_distance_pybind.cdist_sqeuclidean,
+        pdist_func=_distance_pybind.pdist_sqeuclidean,
     ),
     MetricInfo(
         canonical_name='wminkowski',

--- a/scipy/spatial/src/distance_metrics.h
+++ b/scipy/spatial/src/distance_metrics.h
@@ -277,7 +277,8 @@ struct SquareEuclideanDistance {
 struct BraycurtisDistance {
     template <typename T>
     struct Acc {
-        T diff=0, sum=0;
+        Acc(): diff(0), sum(0) {}
+        T diff, sum;
     };
 
     template <typename T>

--- a/scipy/spatial/src/distance_metrics.h
+++ b/scipy/spatial/src/distance_metrics.h
@@ -46,14 +46,19 @@ struct ForceUnroll<1> {
     }
 };
 
-template <int ilp_factor=4, typename T,
+template <int ilp_factor=4,
+          typename T,
           typename TransformFunc,
           typename ProjectFunc = Identity,
           typename ReduceFunc = Plus>
 void transform_reduce_2d_(
     StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y,
-    const TransformFunc& map, const ProjectFunc& project = Identity{},
+    const TransformFunc& map,
+    const ProjectFunc& project = Identity{},
     const ReduceFunc& reduce = Plus{}) {
+    // Result type of calling map
+    using AccumulateType = typename std::decay<decltype(
+        map(std::declval<T>(), std::declval<T>()))>::type;
     intptr_t xs = x.strides[1], ys = y.strides[1];
 
     intptr_t i = 0;
@@ -66,7 +71,7 @@ void transform_reduce_2d_(
                 y_rows[k] = &y(i + k, 0);
             });
 
-            T dist[ilp_factor] = {0};
+            AccumulateType dist[ilp_factor] = {};
             for (intptr_t j = 0; j < x.shape[1]; ++j) {
                 ForceUnroll<ilp_factor>{}([&](int k) {
                     auto val = map(x_rows[k][j], y_rows[k][j]);
@@ -87,7 +92,7 @@ void transform_reduce_2d_(
                 y_rows[k] = &y(i + k, 0);
             });
 
-            T dist[ilp_factor] = {0};
+            AccumulateType dist[ilp_factor] = {};
             for (intptr_t j = 0; j < x.shape[1]; ++j) {
                 auto x_offset = j * xs;
                 auto y_offset = j * ys;
@@ -105,7 +110,7 @@ void transform_reduce_2d_(
     for (; i < x.shape[0]; ++i) {
         const T* x_row = &x(i, 0);
         const T* y_row = &y(i, 0);
-        T dist = 0;
+        AccumulateType dist = {};
         for (intptr_t j = 0; j < x.shape[1]; ++j) {
             auto val = map(x_row[j * xs], y_row[j * ys]);
             dist = reduce(dist, val);
@@ -125,6 +130,9 @@ void transform_reduce_2d_(
     const ReduceFunc& reduce = Plus{}) {
     intptr_t i = 0;
     intptr_t xs = x.strides[1], ys = y.strides[1], ws = w.strides[1];
+    // Result type of calling map
+    using AccumulateType = typename std::decay<decltype(
+        map(std::declval<T>(), std::declval<T>(), std::declval<T>()))>::type;
 
     for (; i + (ilp_factor - 1) < x.shape[0]; i += ilp_factor) {
         const T* x_rows[ilp_factor];
@@ -136,7 +144,7 @@ void transform_reduce_2d_(
             w_rows[k] = &w(i + k, 0);
         });
 
-        T dist[ilp_factor] = {0};
+        AccumulateType dist[ilp_factor] = {};
         for (intptr_t j = 0; j < x.shape[1]; ++j) {
             ForceUnroll<ilp_factor>{}([&](int k) {
                 auto val = map(x_rows[k][j * xs], y_rows[k][j * ys], w_rows[k][j * ws]);
@@ -152,7 +160,7 @@ void transform_reduce_2d_(
         const T* x_row = &x(i, 0);
         const T* y_row = &y(i, 0);
         const T* w_row = &w(i, 0);
-        T dist = 0;
+        AccumulateType dist = {};
         for (intptr_t j = 0; j < x.shape[1]; ++j) {
             auto val = map(x_row[j * xs], y_row[j * ys], w_row[j * ws]);
             dist = reduce(dist, val);
@@ -244,6 +252,71 @@ struct CityBlockDistance {
     void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y, StridedView2D<const T> w) const {
         transform_reduce_2d_(out, x, y, w, [](T x, T y, T w) INLINE_LAMBDA {
             return w * std::abs(x - y);
+        });
+    }
+};
+
+struct SquareEuclideanDistance {
+    template <typename T>
+    void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y) const {
+        transform_reduce_2d_(out, x, y, [](T x, T y) INLINE_LAMBDA {
+            auto diff = x - y;
+            return diff * diff;
+        });
+    }
+
+    template <typename T>
+    void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y, StridedView2D<const T> w) const {
+        transform_reduce_2d_(out, x, y, w, [](T x, T y, T w) INLINE_LAMBDA {
+            auto diff = x - y;
+            return w * diff * diff;
+        });
+    }
+};
+
+struct BraycurtisDistance {
+    template <typename T>
+    struct Acc {
+        T diff=0, sum=0;
+    };
+
+    template <typename T>
+    void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y) const {
+        // dist = abs(x - y).sum() / abs(x + y).sum()
+        transform_reduce_2d_<2>(out, x, y, [](T x, T y) INLINE_LAMBDA {
+            Acc<T> acc;
+            acc.diff = std::abs(x - y);
+            acc.sum = std::abs(x + y);
+            return acc;
+        },
+        [](const Acc<T>& acc) INLINE_LAMBDA {
+            return acc.diff / acc.sum;
+        },
+        [](const Acc<T>& a, const Acc<T>& b) INLINE_LAMBDA {
+            Acc<T> acc;
+            acc.diff = a.diff + b.diff;
+            acc.sum = a.sum + b.sum;
+            return acc;
+        });
+    }
+
+    template <typename T>
+    void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y, StridedView2D<const T> w) const {
+        // dist = (w * abs(x - y)).sum() / (w * abs(x + y)).sum()
+        transform_reduce_2d_(out, x, y, w, [](T x, T y, T w) INLINE_LAMBDA {
+            Acc<T> acc;
+            acc.diff = w * std::abs(x - y);
+            acc.sum = w * std::abs(x + y);
+            return acc;
+        },
+        [](const Acc<T>& acc) INLINE_LAMBDA {
+            return acc.diff / acc.sum;
+        },
+        [](const Acc<T>& a, const Acc<T>& b) INLINE_LAMBDA {
+            Acc<T> acc;
+            acc.diff = a.diff + b.diff;
+            acc.sum = a.sum + b.sum;
+            return acc;
         });
     }
 };

--- a/scipy/spatial/src/distance_pybind.cpp
+++ b/scipy/spatial/src/distance_pybind.cpp
@@ -570,6 +570,16 @@ PYBIND11_MODULE(_distance_pybind, m) {
               }
           },
           "x"_a, "w"_a=py::none(), "out"_a=py::none(), "p"_a=2.0);
+    m.def("pdist_sqeuclidean",
+          [](py::object x, py::object w, py::object out) {
+              return pdist(out, x, w, SquareEuclideanDistance{});
+          },
+          "x"_a, "w"_a=py::none(), "out"_a=py::none());
+    m.def("pdist_braycurtis",
+          [](py::object x, py::object w, py::object out) {
+              return pdist(out, x, w, BraycurtisDistance{});
+          },
+          "x"_a, "w"_a=py::none(), "out"_a=py::none());
     m.def("cdist_chebyshev",
           [](py::object x, py::object y, py::object w, py::object out) {
               return cdist(out, x, y, w, ChebyshevDistance{});
@@ -599,6 +609,16 @@ PYBIND11_MODULE(_distance_pybind, m) {
               }
           },
           "x"_a, "y"_a, "w"_a=py::none(), "out"_a=py::none(), "p"_a=2.0);
+    m.def("cdist_sqeuclidean",
+          [](py::object x, py::object y, py::object w, py::object out) {
+              return cdist(out, x, y, w, SquareEuclideanDistance{});
+          },
+          "x"_a, "y"_a, "w"_a=py::none(), "out"_a=py::none());
+    m.def("cdist_braycurtis",
+          [](py::object x, py::object y, py::object w, py::object out) {
+              return cdist(out, x, y, w, BraycurtisDistance{});
+          },
+          "x"_a, "y"_a, "w"_a=py::none(), "out"_a=py::none());
 }
 
 }  // namespace (anonymous)


### PR DESCRIPTION
#### What does this implement/fix?
This reimplements cdist/pdist for sqeuclidean and braycurtis metrics in the new C++ distance framework. 

#### Benchmarks
Benchmark results for me show improvement across the board.

On gcc:
```
       before           after         ratio
     [6d1d8403]       [e7ea3bf4]
     <master>         <distance-braycurtis-sqeuclidean>
-      17.7±0.2μs       16.8±0.1μs     0.95  spatial.Xdist.time_cdist(100, 'sqeuclidean')
-        1.04±0ms          779±9μs     0.75  spatial.Xdist.time_pdist(1000, 'braycurtis')
-     2.03±0.01ms      1.53±0.01ms     0.75  spatial.Xdist.time_cdist(1000, 'braycurtis')
-      14.1±0.1μs       10.5±0.1μs     0.74  spatial.Xdist.time_pdist(100, 'braycurtis')
-     25.7±0.08μs       18.2±0.2μs     0.71  spatial.Xdist.time_cdist(100, 'braycurtis')
-     3.76±0.02μs      2.04±0.01μs     0.54  spatial.Xdist.time_pdist(10, 'sqeuclidean')
-     3.79±0.04μs      2.00±0.04μs     0.53  spatial.Xdist.time_pdist(10, 'braycurtis')
-      4.71±0.1μs      2.27±0.02μs     0.48  spatial.Xdist.time_cdist(10, 'sqeuclidean')
-     4.78±0.09μs      2.18±0.03μs     0.46  spatial.Xdist.time_cdist(10, 'braycurtis')
-         320±3μs         2.43±0μs     0.01  spatial.XdistWeighted.time_pdist(10, 'sqeuclidean')
-         414±2μs      2.40±0.02μs     0.01  spatial.XdistWeighted.time_pdist(10, 'braycurtis')
-         709±7μs      2.63±0.03μs     0.00  spatial.XdistWeighted.time_cdist(10, 'sqeuclidean')
-        906±10μs      2.67±0.03μs     0.00  spatial.XdistWeighted.time_cdist(10, 'braycurtis')
-     1.32±0.02ms      3.07±0.02μs     0.00  spatial.XdistWeighted.time_pdist(20, 'sqeuclidean')
-     1.74±0.01ms      3.12±0.05μs     0.00  spatial.XdistWeighted.time_pdist(20, 'braycurtis')
-     2.80±0.03ms      3.62±0.08μs     0.00  spatial.XdistWeighted.time_cdist(20, 'sqeuclidean')
-     3.56±0.03ms       3.89±0.1μs     0.00  spatial.XdistWeighted.time_cdist(20, 'braycurtis')
-      34.1±0.3ms      15.5±0.06μs     0.00  spatial.XdistWeighted.time_pdist(100, 'sqeuclidean')
-      44.4±0.1ms       17.5±0.1μs     0.00  spatial.XdistWeighted.time_pdist(100, 'braycurtis')
-      68.7±0.2ms       26.9±0.3μs     0.00  spatial.XdistWeighted.time_cdist(100, 'sqeuclidean')
-      89.2±0.9ms         30.8±1μs     0.00  spatial.XdistWeighted.time_cdist(100, 'braycurtis')
```

On clang-10:
```
       before           after         ratio
     [6d1d8403]       [e7ea3bf4]
     <master>         <distance-braycurtis-sqeuclidean>
-     1.11±0.01ms      1.04±0.02ms     0.93  spatial.Xdist.time_cdist(1000, 'sqeuclidean')
-     23.8±0.07μs       22.1±0.2μs     0.93  spatial.Xdist.time_cdist(100, 'braycurtis')
-     16.2±0.02μs      13.6±0.07μs     0.84  spatial.Xdist.time_cdist(100, 'sqeuclidean')
-         651±5μs        541±0.9μs     0.83  spatial.Xdist.time_pdist(1000, 'sqeuclidean')
-      10.5±0.1μs      8.55±0.03μs     0.81  spatial.Xdist.time_pdist(100, 'sqeuclidean')
-     3.80±0.06μs      2.07±0.01μs     0.54  spatial.Xdist.time_pdist(10, 'braycurtis')
-      4.05±0.3μs      1.99±0.02μs     0.49  spatial.Xdist.time_pdist(10, 'sqeuclidean')
-     4.62±0.02μs      2.21±0.01μs     0.48  spatial.Xdist.time_cdist(10, 'braycurtis')
-     4.68±0.01μs      2.11±0.01μs     0.45  spatial.Xdist.time_cdist(10, 'sqeuclidean')
-       331±0.7μs      2.35±0.03μs     0.01  spatial.XdistWeighted.time_pdist(10, 'sqeuclidean')
-         417±2μs         2.44±0μs     0.01  spatial.XdistWeighted.time_pdist(10, 'braycurtis')
-         724±5μs      2.53±0.02μs     0.00  spatial.XdistWeighted.time_cdist(10, 'sqeuclidean')
-        909±10μs      2.61±0.03μs     0.00  spatial.XdistWeighted.time_cdist(10, 'braycurtis')
-     1.32±0.02ms      2.86±0.01μs     0.00  spatial.XdistWeighted.time_pdist(20, 'sqeuclidean')
-     1.71±0.01ms      3.08±0.02μs     0.00  spatial.XdistWeighted.time_pdist(20, 'braycurtis')
-     2.78±0.02ms      3.42±0.02μs     0.00  spatial.XdistWeighted.time_cdist(20, 'sqeuclidean')
-     3.64±0.06ms      3.65±0.01μs     0.00  spatial.XdistWeighted.time_cdist(20, 'braycurtis')
-      34.6±0.1ms       12.1±0.1μs     0.00  spatial.XdistWeighted.time_pdist(100, 'sqeuclidean')
-      44.5±0.8ms      15.5±0.04μs     0.00  spatial.XdistWeighted.time_pdist(100, 'braycurtis')
-        70.1±1ms       21.0±0.2μs     0.00  spatial.XdistWeighted.time_cdist(100, 'sqeuclidean')
-        89.1±2ms       26.5±0.1μs     0.00  spatial.XdistWeighted.time_cdist(100, 'braycurtis')
```