### PR TITLE
MAINT: Clean-up 'next = __next__'

### DIFF
--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -1226,8 +1226,6 @@ class DifferentialEvolutionSolver:
 
         return self.x, self.population_energies[0]
 
-    next = __next__
-
     def _scale_parameters(self, trial):
         """Scale from a number between 0 and 1 to parameters."""
         return self.__scale_arg1 + (trial - 0.5) * self.__scale_arg2


### PR DESCRIPTION
[PEP 3114](https://www.python.org/dev/peps/pep-3114/) renamed `iterator.next()` to `iterator.__next__()` for Python 3.0.

Backwards compatibility for Python 2 was provided for classes using `next = __next__`, but this can now be removed.

There is only one scipy class that had used this idiom, `DifferentialEvolutionSolver`.