### PR TITLE
MAINT: bump PYVER pavement.py

### DIFF
--- a/pavement.py
+++ b/pavement.py
@@ -81,7 +81,7 @@ LOG_END = 'master'
 #-------------------------------------------------------
 
 # Default Python version
-PYVER="3.6"
+PYVER="3.9"
 
 # Paver options object, holds all default dirs
 options(bootstrap=Bunch(bootstrap_dir="bootstrap"),


### PR DESCRIPTION
Fixes #13311

* bump the version of `PYVER` in `pavement.py` so that it
is one of our currently supported versions for the
release process

* as discussed in the issue, this is not super important, I chose
`3.9` so that we hopefully don't have to change this again before
we stop using this infrastructure