### PR TITLE
BLD: if boost submodule content is missing, error out early

### DIFF
--- a/scipy/_lib/setup.py
+++ b/scipy/_lib/setup.py
@@ -1,4 +1,13 @@
 import os
+import pathlib
+
+
+def check_boost_submodule():
+    from scipy._lib._boost_utils import _boost_dir
+
+    if not os.path.exists(_boost_dir(ret_path=True) / 'README.md'):
+        raise RuntimeError("Missing the `boost` submodule! Run `git submodule "
+                           "update --init` to fix this.")
 
 
 def build_clib_pre_build_hook(cmd, ext):
@@ -12,6 +21,8 @@ def build_clib_pre_build_hook(cmd, ext):
 def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
     from scipy._lib._boost_utils import _boost_dir
+
+    check_boost_submodule()
 
     config = Configuration('_lib', parent_package, top_path)
     config.add_data_files('tests/*.py')


### PR DESCRIPTION
This is much better than failing with a cryptic error halfway through the build.