### PR TITLE
Doc: Fix typo in documentation of spence function.

### DIFF
--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -8890,7 +8890,7 @@ add_newdoc("spence",
     It is defined to be
 
     .. math::
-      \int_0^z \frac{\log(t)}{1 - t}dt
+      \int_1^z \frac{\log(t)}{1 - t}dt
 
     for complex :math:`z`, where the contour of integration is taken
     to avoid the branch cut of the logarithm. Spence's function is


### PR DESCRIPTION


<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
#13628
#### What does this implement/fix?
<!--Please explain your changes.-->
earlier, doc incorrectly mentioned integration limits of spence function as 0 to z whereas implementation used limits 1 to z.
now, doc correctly mentions the integration limits 1 to z.
#### Additional information
<!--Any additional information you think is important.-->