### PR TITLE
MAINT/TST: Fix tests failing with the nightly build of numpy.

### DIFF
--- a/scipy/cluster/tests/test_disjoint_set.py
+++ b/scipy/cluster/tests/test_disjoint_set.py
@@ -11,6 +11,7 @@ def generate_random_token():
     tokens += list(np.arange(k, dtype=float))
     tokens += list(string.ascii_letters)
     tokens += [None for i in range(k)]
+    tokens = np.array(tokens, dtype=object)
     rng = np.random.RandomState(seed=0)
 
     while 1:

--- a/scipy/stats/tests/test_contingency.py
+++ b/scipy/stats/tests/test_contingency.py
@@ -1,6 +1,7 @@
 import numpy as np
 from numpy.testing import (assert_equal, assert_array_equal,
-         assert_array_almost_equal, assert_approx_equal, assert_allclose)
+                           assert_array_almost_equal, assert_approx_equal,
+                           assert_allclose)
 import pytest
 from pytest import raises as assert_raises
 from scipy.special import xlogy
@@ -169,10 +170,12 @@ def test_chi2_contingency_R():
 
 def test_chi2_contingency_g():
     c = np.array([[15, 60], [15, 90]])
-    g, p, dof, e = chi2_contingency(c, lambda_='log-likelihood', correction=False)
+    g, p, dof, e = chi2_contingency(c, lambda_='log-likelihood',
+                                    correction=False)
     assert_allclose(g, 2*xlogy(c, c/e).sum())
 
-    g, p, dof, e = chi2_contingency(c, lambda_='log-likelihood', correction=True)
+    g, p, dof, e = chi2_contingency(c, lambda_='log-likelihood',
+                                    correction=True)
     c_corr = c + np.array([[-0.5, 0.5], [0.5, -0.5]])
     assert_allclose(g, 2*xlogy(c_corr, c_corr/e).sum())
 
@@ -206,7 +209,8 @@ def test_bad_association_args():
     # chi2_contingency exception
     assert_raises(ValueError, association, [[-1, 10], [1, 2]], 'cramer')
     # Invalid Array Item Data Type
-    assert_raises(ValueError, association, [[1, 2], ["dd", 4]], 'cramer')
+    assert_raises(ValueError, association,
+                  np.array([[1, 2], ["dd", 4]], dtype=object), 'cramer')
 
 
 @pytest.mark.parametrize('stat, expected',


### PR DESCRIPTION
In the nightly build of numpy, a call such as
`rng.choice([1, 2.0, 'foo', None])` generates a warning:

    In [47]: rng.choice([1, 2.0, 'foo', None])
    [...]/bin/ipython:1: FutureWarning: Promotion of numbers and bools
    to strings is deprecated. In the future, code such as
    `np.concatenate((['string'], [0]))` will raise an error, while
    `np.asarray(['string', 0])` will return an array with `dtype=object`.
    To avoid the warning while retaining a string result use `dtype='U'`
    (or 'S').  To get an array of Python objects use `dtype=object`.
    (Warning added in NumPy 1.21)

    Out[47]: 2.0

Such a call is made in the function generate_random_token() in
scipy/cluster/tests/test_disjoint_set.py.  The warning causes
the unit tests to fail.

The fix is to make the argument to `choice()` an array of objects,
similar to the use of an object array in this call that does not
generate a warning:

    In [48]: rng.choice(np.array([1, 2.0, 'foo', None], dtype=object))
    Out[48]: 1

