### PR TITLE
MAINT: Remove old, commented extract_diagonal

### DIFF
--- a/scipy/sparse/spfuncs.py
+++ b/scipy/sparse/spfuncs.py
@@ -11,24 +11,6 @@ from ._sparsetools import csr_count_blocks
 def extract_diagonal(A):
     raise NotImplementedError('use .diagonal() instead')
 
-#def extract_diagonal(A):
-#    """extract_diagonal(A) returns the main diagonal of A."""
-#    #TODO extract kth diagonal
-#    if isspmatrix_csr(A) or isspmatrix_csc(A):
-#        fn = getattr(sparsetools, A.format + "_diagonal")
-#        y = empty( min(A.shape), dtype=upcast(A.dtype) )
-#        fn(A.shape[0],A.shape[1],A.indptr,A.indices,A.data,y)
-#        return y
-#    elif isspmatrix_bsr(A):
-#        M,N = A.shape
-#        R,C = A.blocksize
-#        y = empty( min(M,N), dtype=upcast(A.dtype) )
-#        fn = sparsetools.bsr_diagonal(M//R, N//C, R, C, \
-#                A.indptr, A.indices, ravel(A.data), y)
-#        return y
-#    else:
-#        return extract_diagonal(csr_matrix(A))
-
 
 def estimate_blocksize(A,efficiency=0.7):
     """Attempt to determine the blocksize of a sparse matrix


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### What does this implement/fix?
<!--Please explain your changes.-->

This removes an old commented implementation of diagonal extraction which is not used anymore.