### PR TITLE
MAINT: sparse: Remove defunct function extract_diagonal

### DIFF
--- a/scipy/sparse/spfuncs.py
+++ b/scipy/sparse/spfuncs.py
@@ -8,10 +8,6 @@ from .csc import isspmatrix_csc
 from ._sparsetools import csr_count_blocks
 
 
-def extract_diagonal(A):
-    raise NotImplementedError('use .diagonal() instead')
-
-
 def estimate_blocksize(A,efficiency=0.7):
     """Attempt to determine the blocksize of a sparse matrix
 


### PR DESCRIPTION
The function has been

    def extract_diagonal(A):
        raise NotImplementedError('use .diagonal() instead')

for more than 13 years.  I think we can safely remove this now.
