### PR TITLE
MAINT: Clear scipy namespace of entries better imported from elsewhere

### DIFF
--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -56,7 +56,13 @@ Utility tools
  __numpy_version__ --- Numpy version string
 
 """
-__all__ = ['test']
+
+
+def __dir__():
+    return ['test']
+
+
+__all__ = __dir__()
 
 from numpy import show_config as show_numpy_config
 if show_numpy_config is None:


### PR DESCRIPTION
SciPy currently exposes the whole `numpy` and `scimath` namespace.  Although these entries raise a deprecation warning when used, they still appear in auto-complete.

This PR cleans up the namespace so that those functions are no longer visible (even though they are still there).
