### PR TITLE
Install Pythran from sources for python 3.10

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -81,7 +81,8 @@ jobs:
     - name: Install packages
       run: |
         pip install --user git+https://github.com/numpy/numpy.git
-        python3.10 -m pip install --user setuptools wheel cython pytest pybind11 pytest-xdist pythran
+        python3.10 -m pip install --user setuptools wheel cython pytest pybind11 pytest-xdist
+        pip install --user git+https://github.com/serge-sans-paille/pythran.git
         python3.10 -m pip install -r mypy_requirements.txt
 
     - name: Mypy


### PR DESCRIPTION
This should fix the CI error in https://github.com/scipy/scipy/pull/13595