### PR TITLE
BUG: Fixes issue with clang.

### DIFF
--- a/scipy/special/_faddeeva.cxx
+++ b/scipy/special/_faddeeva.cxx
@@ -130,7 +130,7 @@ double faddeeva_voigt_profile(double x, double sigma, double gamma)
 
     if(sigma == 0){
         if (gamma == 0){
-            if (isnan(x))
+            if (std::isnan(x))
                 return x;
             if (x == 0)
                 return NPY_INFINITY;


### PR DESCRIPTION
I encountered this while building SciPy with Spack using the Clang compiler.

```
scipy/special/_faddeeva.cxx:133:17: error: call to 'isnan' is ambiguous
            if (isnan(x))
                ^~~~~
/usr/include/bits/mathcalls.h:235:19: note: candidate function
__MATHDECL_1 (int,isnan,, (_Mdouble_ __value)) __attribute__ ((__const__));
                  ^
/usr/tce/packages/gcc/gcc-4.9.3/lib64/gcc/x86_64-unknown-linux-gnu/4.9.3/../../../../include/c++/4.9.3/cmath:622:3: note: candidate function
  isnan(double __x)
```