### PR TITLE
DOC: Correct the inconsistence definition of Default in class UnivariateSpline

### DIFF
--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -90,7 +90,7 @@ class UnivariateSpline:
         `bbox` is None, ``bbox=[x[0], x[-1]]``. Default is None.
     k : int, optional
         Degree of the smoothing spline.  Must be 1 <= `k` <= 5.
-        `k` = 3 is a cubic spline. Default is 3.
+        ``k = 3`` is a cubic spline. Default is 3.
     s : float or None, optional
         Positive smoothing factor used to choose the number of knots.  Number
         of knots will be increased until the smoothing condition is satisfied::

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -97,7 +97,7 @@ class UnivariateSpline:
 
             sum((w[i] * (y[i]-spl(x[i])))**2, axis=0) <= s
 
-        If s is None, ``s = len(w)`` which should be a good value if
+        If `s` is None, ``s = len(w)`` which should be a good value if
         ``1/w[i]`` is an estimate of the standard deviation of ``y[i]``.
         If 0, spline will interpolate through all data points. Default is None.
     ext : int or str, optional

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -83,7 +83,7 @@ class UnivariateSpline:
     y : (N,) array_like
         1-D array of dependent input data, of the same length as `x`.
     w : (N,) array_like, optional
-        Weights for spline fitting.  Must be positive.  If weights are None,
+        Weights for spline fitting.  Must be positive.  If `w` is None,
         weights are all equal. Default is None.
     bbox : (2,) array_like, optional
         2-sequence specifying the boundary of the approximation interval. If

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -87,7 +87,7 @@ class UnivariateSpline:
         weights are all equal. Default is None.
     bbox : (2,) array_like, optional
         2-sequence specifying the boundary of the approximation interval. If
-        bbox is None, ``bbox=[x[0], x[-1]]``. Default is None.
+        `bbox` is None, ``bbox=[x[0], x[-1]]``. Default is None.
     k : int, optional
         Degree of the smoothing spline.  Must be 1 <= `k` <= 5.
         `k` = 3 is a cubic spline. Default is 3.

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -83,23 +83,23 @@ class UnivariateSpline:
     y : (N,) array_like
         1-D array of dependent input data, of the same length as `x`.
     w : (N,) array_like, optional
-        Weights for spline fitting.  Must be positive.  If None (default),
-        weights are all equal.
+        Weights for spline fitting.  Must be positive.  If weights are None,
+        weights are all equal. Default is None.
     bbox : (2,) array_like, optional
         2-sequence specifying the boundary of the approximation interval. If
-        None (default), ``bbox=[x[0], x[-1]]``.
+        bbox is None, ``bbox=[x[0], x[-1]]``. Default is None.
     k : int, optional
         Degree of the smoothing spline.  Must be 1 <= `k` <= 5.
-        Default is `k` = 3, a cubic spline.
+        `k` = 3 is a cubic spline. Default is 3.
     s : float or None, optional
         Positive smoothing factor used to choose the number of knots.  Number
         of knots will be increased until the smoothing condition is satisfied::
 
             sum((w[i] * (y[i]-spl(x[i])))**2, axis=0) <= s
 
-        If None (default), ``s = len(w)`` which should be a good value if
+        If s is None, ``s = len(w)`` which should be a good value if
         ``1/w[i]`` is an estimate of the standard deviation of ``y[i]``.
-        If 0, spline will interpolate through all data points.
+        If 0, spline will interpolate through all data points. Default is None.
     ext : int or str, optional
         Controls the extrapolation mode for elements
         not in the interval defined by the knot sequence.
@@ -109,7 +109,7 @@ class UnivariateSpline:
         * if ext=2 or 'raise', raise a ValueError
         * if ext=3 of 'const', return the boundary value.
 
-        The default value is 0.
+        Default is 0.
 
     check_finite : bool, optional
         Whether to check that the input arrays contain only finite numbers.


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #14093

#### What does this implement/fix?

More consistency in the definition of the default values for the class `UnivariateSpline`
