### PR TITLE
DOC: stats.mstats: mannwhitneyu: the returned statistic is the minimum of the two statistics

### DIFF
--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -1163,7 +1163,7 @@ def mannwhitneyu(x,y, use_continuity=True):
     Returns
     -------
     statistic : float
-        The Mann-Whitney statistics
+        The minimum of the Mann-Whitney statistics
     pvalue : float
         Approximate p-value assuming a normal distribution.
 


### PR DESCRIPTION
#### Reference issue
Closes gh-5933
gh-14105 notes that the p-value is a two-sided p-value

#### What does this implement/fix?
This updates the `stats.mstats.mannwhitneyu` documentation to state that the statistic returned is the minimum of the statistics associated with the two samples.
