### PR TITLE
BUG: fix two issues in the fblas signature files

### DIFF
--- a/scipy/linalg/fblas_l1.pyf.src
+++ b/scipy/linalg/fblas_l1.pyf.src
@@ -175,7 +175,7 @@ end subroutine <prefix2>rotm
 
 
 subroutine <prefix>swap(n,x,offx,incx,y,offy,incy)
-  ! Swap two arrays: x <-> y
+  ! Swap two arrays, `x` and `y`
 
   callstatement (*f2py_func)(&n,x+offx,&incx,y+offy,&incy)
   callprotoargument F_INT*,<ctype>*,F_INT*,<ctype>*,F_INT*

--- a/scipy/linalg/fblas_l3.pyf.src
+++ b/scipy/linalg/fblas_l3.pyf.src
@@ -147,7 +147,7 @@ subroutine <prefix6><sy,\0,\0,\0,he,he>r2k(n,k,alpha,a,b,beta,c,trans,lower,lda,
   integer depend(a, b, trans, ka, lda, kb, ldb), intent(hide), &
         check(trans ? lda==ldb: ka==kb) :: k = (trans ? lda : ka)
 
-end subroutine <prefix><sy,\0,\0,\0,he,he>r2k
+end subroutine <prefix6><sy,\0,\0,\0,he,he>r2k
 
 
 subroutine <prefix>trmm(m, n, k, alpha, a, b, lda, ldb, side, lower, trans_a, diag)


### PR DESCRIPTION
This gave the following warnings:
```
Mismatch in number of replacements (base <prefix=s,d,c,z>) for <__l1=->. Ignoring.
Mismatch in number of replacements (base <prefix6=s,d,c,z,c,z>) for <prefix=s,d,c,z>. Ignoring.
```

The first warning was harmless, that's due to a comment line in the signature file that is incorrectly captured by a regex.

The second one seems like a real bug. The diff in the generated .pyf file from the .src.pyf one is:
```
4277c4277
< end subroutine ssyr2k
---
> end subroutine prefixsyr2k
4313c4313
< end subroutine dsyr2k
---
> end subroutine prefixsyr2k
4349c4349
< end subroutine csyr2k
---
> end subroutine prefixsyr2k
4385c4385
< end subroutine zsyr2k
---
> end subroutine prefixsyr2k
4421c4421
< end subroutine cher2k
---
> end subroutine prefixher2k
4457c4457
< end subroutine zher2k
---
> end subroutine prefixher2k
```

I have no idea why the build didn't fail on this; `f2py` is probably just too forgiving. There are some `syr2k` issues that were closed, like gh-5917. So unclear if this fixes a hidden bug or not, but the fix must be a good thing regardless:)
