### PR TITLE
DOC: mailmap update

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -38,7 +38,9 @@
 @yanxun827 <yanxun827@gmail.com> yanxun827 <yanxun827@gmail.com>
 @ybeltukov <ybeltukov@gmail.com> ybeltukov <ybeltukov@gmail.com>
 @ziejcow <jan.gwinner@gmail.com>ziejcow <jan.gwinner@gmail.com>
+ADmitri <admitri42@gmail.com> ADmitri <ADmitri42@gmail.com>
 Aditya Vijaykumar <vijaykumar.aditya@gmail.com> adivijaykumar <vijaykumar.aditya@gmail.com>
+akahard2dj <akahard2dj@naver.com> akahard2dj@naver.com <@mrgoodbYtes@1>
 Akash Goel <goelakas@amazon.com> Goel <goelakas@amazon.com>
 Aldrian Obaja <> ubuntu <>
 Alex Griffing <argriffi@ncsu.edu> alex <argriffi@ncsu.edu>
@@ -57,15 +59,24 @@ Anreas Weh <andreas.weh@web.de> DerWeh <andreas.weh@web.de>
 Andreea Georgescu <ageorgescu@ucla.edu> Andreea_G <ageorgescu@ucla.edu>
 Andriy Gelman <andriy.gelman@gmail.com> talih0 <andriy.gelman@gmail.com>
 Andrew Fowlie <andrew.j.fowlie@googlemail.com> andrew <andrew.j.fowlie@googlemail.com>
+Andrew Fowlie <andrew.j.fowlie@googlemail.com> Andrew Fowlie <andrewfowlie@users.noreply.github.com>
 Andrew Knyazev <42650045+lobpcg@users.noreply.github.com> lobpcg <42650045+lobpcg@users.noreply.github.com>
+Andrew Knyazev <42650045+lobpcg@users.noreply.github.com> Andrew Knyazev <andrew.knyazev@ucdenver.edu>
 Andrew Nelson <andyfaff@gmail.com> Andrew Nelson <andrew@Andrews-MacBook-Pro.local>
 Andrew Nelson <andyfaff@gmail.com> Andrew Nelson <anz@d121131.ncnr.nist.gov>
 Andrew Sczesnak <andrewscz@gmail.com> polyatail <andrewscz@gmail.com>
+Angeline G. Burrell <angeline.burrell@nrl.navy.mil> Angeline Burrell <aburrell@users.noreply.github.com>
+Angeline G. Burrell <angeline.burrell@nrl.navy.mil> Angeline Burrell <angeline.burrell@nrl.navy.mil>
 Anne Archibald <peridot.faceted@gmail.com> aarchiba <peridot.faceted@gmail.com>
 Anne Archibald <peridot.faceted@gmail.com> Anne Archibald <archibald@astron.nl>
 Antonio Horta Ribeiro <antonior92@gmail.com> antonio <antonior92@gmail.com>
+Antonio Horta Ribeiro <antonior92@gmail.com> Antonio H Ribeiro <antonior92@gmail.com>
 Ariel Rokem <arokem@gmail.com> ariel.rokem <ariel.rokem@localhost>
+Arno Onken <arno.onken@iit.it> Arno Onken <asnelt@users.noreply.github.com>
+Arthur Volant <arthurvolant@gmail.com> Arthur <37664438+V0lantis@users.noreply.github.com>
 Ashwin Pathak <ashwinpathak20nov1996@gmail.com> ashwinpathak20 <ashwinpathak20nov1996@gmail.com>
+Ashwin Pathak <ashwinpathak20nov1996@gmail.com> ashwinpathak20nov1996 <ashwinpathak20nov1996@gmail.com>
+Atsushi Sakai <asakai.amsl+github@gmail.com> Atsushi Sakai <example@co.jp>
 Balint Pato <balintp@google.com> balopat <balintp@google.com>
 Behzad Nouri <behzadnouri@gmail.com> behzad nouri <behzadnouri@gmail.com>
 Benjamin Root <> weathergod <>
@@ -76,6 +87,7 @@ Bharat Raghunathan <bharatraghunthan9767@gmail.com> Bharat123rox <bharatraghunth
 Bharat Raghunathan <bharatraghunthan9767@gmail.com> Bharat123Rox <bharatraghunthan9767@gmail.com>
 Bhavika Tekwani <bhavicka.7992@gmail.com> bhavikat <bhavicka.7992@gmail.com>
 Blair Azzopardi <blairuk@gmail.com> bsdz <blairuk@gmail.com>
+Blair Azzopardi <blairuk@gmail.com> Blair Azzopardi <bsdz@users.noreply.github.com>
 Brandon David <brandon.david@zoho.com> brandondavid <brandon.david@zoho.com>
 Brett R. Murphy <bmurphy@enthought.com> brettrmurphy <bmurphy@enthought.com>
 Brian Hawthorne <brian.hawthorne@localhost> brian.hawthorne <brian.hawthorne@localhost>
@@ -91,15 +103,19 @@ Chris Lasher <> gotgenes <>
 Christian Clauss <cclauss@me.com> cclauss <cclauss@me.com>
 Christoph Baumgarten <christoph.baumgarten@gmail.com> chrisb83 <33071866+chrisb83@users.noreply.github.com>
 Christoph Baumgarten <christoph.baumgarten@gmail.com> chrisb83 <christoph.baumgarten@gmail.com>
+Christoph Baumgarten <christoph.baumgarten@gmail.com> Christoph Baumgarten <33071866+chrisb83@users.noreply.github.com>
 Christoph Gohlke <cgohlke@uci.edu> cgohlke <cgohlke@uci.edu>
 Christoph Gohlke <cgohlke@uci.edu> Christolph Gohlke <>
 Christoph Gohlke <cgohlke@uci.edu> cgholke <>
 Christoph Gohlke <cgohlke@uci.edu> cgohlke <cjgohlke@gmail.com>
+Christoph Gohlke <cgohlke@uci.edu> Christoph Gohlke <cjgohlke@gmail.com>
 Christopher Kuster <ckuster@carrollu.edu> ckuster <ckuster@carrollu.edu>
+CJ Carey <perimosocordiae@gmail.com> CJ Carey <cjcarey@google.com>
 Clemens Novak <clemens@familie-novak.net> cnovak <clemens@familie-novak.net>
 Clemens Novak <clemens@familie-novak.net> Clemens <clemens@familie-novak.net>
 Collin RM Stocks <> Collin Stocks <>
 Collin Tokheim <collintokheim@gmail.com> ctokheim <collintokheim@gmail.com>
+Cong Ma <cong.ma@obspm.fr> Cong Ma <cong.ma@uct.ac.za>
 Daan Wynen <black.puppydog@gmx.de> Daan Wynen <black-puppydog@users.noreply.github.com>
 Damian Eads <damian.eads@localhost> damian.eads <damian.eads@localhost>
 David Ellis <ducksual@gmail.com> davidcellis <ducksual@gmail.com>
@@ -131,6 +147,7 @@ Diana Sukhoverkhova <diana.suhoverhova@mail.ru> Diana <diana.suhoverhova@mail.ru
 Dieter Werthmüller <dieter@werthmuller.org> Dieter Werthmüller <mail@werthmuller.org>
 Dieter Werthmüller <dieter@werthmuller.org> Dieter Werthmüller <prisae@users.noreply.github.com>
 Dieter Werthmüller <dieter@werthmuller.org> prisae <dieter@werthmuller.org>
+Dima Pasechnik <dimpase@gmail.com> Dima Pasechnik <dima@pasechnik.info>
 Dmitrey Kroshko <dmitrey.kroshko@localhost> dmitrey.kroshko <dmitrey.kroshko@localhost>
 Domen Gorjup <domen_gorjup@hotmail.com> domengorjup <domen_gorjup@hotmail.com>
 Dávid Bodnár <david.bodnar@st.ovgu.de> bdvd <david.bodnar@st.ovgu.de>
@@ -145,18 +162,25 @@ Eric Soroos <eric-github@soroos.net> wiredfool <eric-github@soroos.net>
 Evgeni Burovski <evgeny.burovskiy@gmail.com> Zhenya <evgeni@burovski.me>
 Evgeni Burovski <evgeny.burovskiy@gmail.com> Evgeni Burovski <evgeni@burovski.me>
 Fabian Pedregosa <fabian@fseoane.net> Fabian Pedregosa <fabian.pedregosa@inria.fr>
+Fabian Pedregosa <fabian@fseoane.net> Fabian Pedregosa <pedregosa@google.com>
+Fabian Rost <fabian.rost@tu-dresden.de> Fabian Rost <fabrost@pks.mpg.de>
 Felix Berkenkamp <befelix@ethz.ch> Felix <befelix@ethz.ch>
 Felix Berkenkamp <befelix@ethz.ch> Felix Berkenkamp <fberkenkamp@gmail.com>
 Florian Wilhelm <Florian.Wilhelm@gmail.com> Florian Wilhelm <Florian.Wilhelm@blue-yonder.com>
 François Boulogne <fboulogne sciunto org> François Boulogne <fboulogne at april dot org>
 François Boulogne <fboulogne sciunto org> François Boulogne <fboulogne@sciunto.org>
+François Boulogne <fboulogne sciunto org> François Boulogne <devel@sciunto.org>
+François Magimel <magimel.francois@gmail.com> François Magimel <francois.magimel@etu.enseeiht.fr>
 Franz Forstmayr <forstmayr.franz@gmail.com> FranzForstmayr <franz.forstmayr@rosenberger.com>
+Franz Forstmayr <forstmayr.franz@gmail.com> FranzForstmayr <forstmayr.franz@gmail.com>
+Franz Forstmayr <forstmayr.franz@gmail.com> Franz Forstmayr <franz.forstmayr@rosenberger.com>
 Franziska Horn <cod3licious@users.noreply.github.com> cod3licious <cod3licious@users.noreply.github.com>
 Fukumu Tsutsumi <levelfourslv@gmail.com> levelfour <levelfourslv@gmail.com>
 G Young <gfyoung17@gmail.com> gfyoung <gfyoung17@gmail.com>
 G Young <gfyoung17@gmail.com> gfyoung <gfyoung@mit.edu>
 Garrett Reynolds <garrettreynolds5@gmail.com> Garrett-R <garrettreynolds5@gmail.com>
 Gaël Varoquaux <gael.varoquaux@normalesup.org> Gael varoquaux <gael.varoquaux@normalesup.org>
+Geordie McBain <gdmcbain@protonmail.com> G. D. McBain <gdmcbain@protonmail.com>
 Gina Helfrich <Dr-G@users.noreply.github.com> Gina <Dr-G@users.noreply.github.com>
 Giorgio Patrini <giorgio.patrini@anu.edu.au> giorgiop <giorgio.patrini@anu.edu.au>
 Giorgio Patrini <giorgio.patrini@anu.edu.au> giorgiop <giorgio.patrini@nicta.com.au>
@@ -165,6 +189,7 @@ Gregory R. Lee <grlee77@gmail.com> Gregory Lee <grlee77@gmail.com>
 Golnaz Irannejad <golnazirannejad@gmail.com> golnazir <golnazirannejad@gmail.com>
 Guillaume Horel <thrasibule@users.noreply.github.com> Thrasibule <thrasibule@users.noreply.github.com>
 Guo Fei <<guofei9987@foxmail.com> Guofei <<guofei9987@foxmail.com>
+Hameer Abbasi <einstein.edison@gmail.com> Hameer Abbasi <hameerabbasi@yahoo.com>
 Han Genuit <> 87 <>
 Han Genuit <> Han <>
 Harshal Prakash Patankar <pharshalp@gmail.com> pharshalp <pharshalp@gmail.com>
@@ -177,12 +202,12 @@ Henry Lin <hlin117@gmail.com> hlin117 <hlin117@gmail.com>
 Hiroki IKEDA <ikeda_hiroki@icloud.com> IKEDA Hiroki <ikeda_hiroki@icloud.com>
 Hugo van Kemenade <hugovk@users.noreply.github.com> Hugo <hugovk@users.noreply.github.com>
 Huize Wang <huizew@gmail.com> Huize <huizew@gmail.com>
+Huize Wang <huizew@gmail.com> Huize Wang <huizew@users.noreply.github.com>
 Max Silbiger <hollowaytape@retro-type.com> hollowaytape <hollowaytape@retro-type.com>
 Ion Elberdin <ionelberdin@gmail.com> Ion <ionelberdin@gmail.com>
 Ilhan Polat <ilhanpolat@gmail.com> ilayn <ilhanpolat@gmail.com>
 Irvin Probst <irvin.probst@ensta-bretagne.fr> I--P <irvin.probst@ensta-bretagne.fr>
 Jacob Carey <jacobcvt12@gmail.com> Jacob Carey <Jacobcvt12@users.noreply.github.com>
-Jakob Jakobson <43045863+jakobjakobson13@users.noreply.github.com> jakobjakobson13 <43045863+jakobjakobson13@users.noreply.github.com>
 Jacob Vanderplas <jakevdp@gmail.com> Jake VanderPlas <jakevdp@gmail.com>
 Jacob Vanderplas <jakevdp@gmail.com> Jake Vanderplas <jakevdp@gmail.com>
 Jacob Vanderplas <jakevdp@gmail.com> Jake Vanderplas <jakevdp@yahoo.com>
@@ -190,30 +215,48 @@ Jacob Vanderplas <jakevdp@gmail.com> Jake Vanderplas <vanderplas@astro.washingto
 Jacob Vanderplas <jakevdp@gmail.com> Jacob Vanderplas <jakevdp@yahoo.com>
 Jaime Fernandez del Rio <jaime.frio@gmail.com> jaimefrio <jaime.frio@gmail.com>
 Jaime Fernandez del Rio <jaime.frio@gmail.com> Jaime <jaime.frio@gmail.com>
-Jaime Fernandez del Rio <jaimefrio@google.com> Jaime Fernandez <jaimefrio@google.com>
+Jaime Fernandez del Rio <jaime.frio@gmail.com> Jaime Fernandez <jaimefrio@google.com>
+Jaime Fernandez del Rio <jaime.frio@gmail.com> Jaime Fernandez del Rio <jaimefrio@google.com>
+Jaime Fernandez del Rio <jaime.frio@gmail.com> Jaime Fernandez <jaime.frio@gmail.com>
+Jaime Fernandez del Rio <jaime.frio@gmail.com> Jaime Fernandez <jaime@Jaimes-iMac.local>
+Jakob Jakobson <43045863+jakobjakobson13@users.noreply.github.com> Jakob Jakobson <31574479+JakobJakobson@users.noreply.github.com>
+Jakob Jakobson <43045863+jakobjakobson13@users.noreply.github.com> jakobjakobson13 <43045863+jakobjakobson13@users.noreply.github.com>
 Jakub Dyczek <34447984+JDkuba@users.noreply.github.com> JDkuba <34447984+JDkuba@users.noreply.github.com>
 James T. Webber <jamestwebber@gmail.com> jamestwebber <jamestwebber@gmail.com>
+James T. Webber <jamestwebber@gmail.com> James Webber <jamestwebber@users.noreply.github.com>
+James T. Webber <jamestwebber@gmail.com> James Webber <j@meswebber.com>
+Jan Schlüter <jan.schlueter@ofai.at> Jan Schlueter <jan.schlueter@ofai.at>
+Jan Schlüter <jan.schlueter@ofai.at> Jan Schlüter <github@jan-schlueter.de>
 Jan Soedingrekso <jan.soedingrekso@tu-dortmund.de> sudojan <jan.soedingrekso@tu-dortmund.de>
 Jan Vleeshouwers <j.m.vleeshouwers@tue.nl> janvle <j.m.vleeshouwers@tue.nl>
 Jan Vleeshouwers <j.m.vleeshouwers@tue.nl> Vleeshouwers <j.m.vleeshouwers@tue.nl>
 Janani Padmanabhan <jenny.stone125@gmail.com> janani <janani@janani-Vostro-3446.(none)>
 Janani Padmanabhan <jenny.stone125@gmail.com> Janani <jenny.stone125@gmail.com>
+Jarrod Millman <jarrod.millman@gmail.com> Jarrod Millman <millman@berkeley.edu>
 Jean-François B. <jfbu@free.fr> jfbu <jfbu@free.fr>
+Jean-François B. <jfbu@free.fr> Jean-François B <jfbu@free.fr>
 Jeff Armstrong <jeff@approximatrix.com> ArmstrongJ <approximatrix@gmail.com>
 Jeff Armstrong <jeff@approximatrix.com> Jeff Armstrong <jeff@approximatrix.com>
 Jesse Engel <jesse.engel@gmail.com> jesseengel <jesse.engel@gmail.com>
+Jesse Livezey <jesse.livezey@gmail.com> Jesse Livezey <jlivezey@lbl.gov>
 Jin-Guo Liu <cacate0129@gmail.com> GiggleLiu <cacate0129@gmail.com>
-J.L. Lanfranchi <jllanfranchi@users.noreply.github.com> J. L. Lanfranchi <jllanfranchi@users.noreply.github.com>
+J.L. Lanfranchi <jll1062@phys.psu.edu> J. L. Lanfranchi <jllanfranchi@users.noreply.github.com>
+J.L. Lanfranchi <jll1062@phys.psu.edu> J.L. Lanfranchi <jllanfranchi@users.noreply.github.com>
 Joe Driscoll <32208193+jwd0023@users.noreply.github.com> jwd0023 <jwd0023@auburn.edu>
 Joel Nothman <joel.nothman@gmail.com> jnothman <jnothman@student.usyd.edu.au>
 Joel Nothman <joel.nothman@gmail.com> Joel Nothman <jnothman@student.usyd.edu.au>
+Johannes Kulick <jkkulick@amazon.de> Johannes Kulick <kulick@hildensia.de>
 Johannes Schmitz <johannes.schmitz1@gmail.com> johschmitz <johannes.schmitz1@gmail.com>
 Jona Sassenhagen <jona.sassenhagen@gmail.com> jona-sassenhagen <jona.sassenhagen@gmail.com>
 Jonathan Conroy <jonathanconroy14@gmail.com> jonathanconroy <jonathanconroy14@gmail.com>
 Jonathan Sutton <j.sutton.mail@gmail.com> suttonje <j.sutton.mail@gmail.com>
-Jonathan Sutton <fcs@oil.ornl.gov> SUTTON Jonathan [fcs] <fcs@oil.ornl.gov>
+Jonathan Sutton <j.sutton.mail@gmail.com> SUTTON Jonathan [fcs] <fcs@oil.ornl.gov>
+Jonathan Sutton <j.sutton.mail@gmail.com> Jonathan Sutton <fcs@oil.ornl.gov> 
+Jonathan Sutton <j.sutton.mail@gmail.com> Jonathan Sutton <fcs@dell-hwqwz12>
+Jonathan Sutton <j.sutton.mail@gmail.com> Jonathan Sutton <fcs@oil.ornl.gov>
 Jonathan Tammo Siebert <siebertjonathan@aim.com> jotasi <siebertjonathan@aim.com>
 Jonathan Taylor <jonathan.taylor@localhost> jonathan.taylor <jonathan.taylor@localhost>
+Jordão Bragantini <jordao.bragantini@gmail.com> Jordão Bragantini <jordao.bragantini@czbiohub.org>
 Joris Vankerschaver <joris.vankerschaver@gmail.com> Joris Vankerschaver <jvankerschaver@enthought.com>
 Joscha Reimer <jor@informatik.uni-kiel.de> jor <jor@informatik.uni-kiel.de>
 Josef Perktold <josef.pktd@gmail.com> josef-pktd <josef.pktd@gmail.com>
@@ -227,10 +270,16 @@ Josh Lawrence <josh.k.lawrence@gmail.com> wa03 <josh.k.lawrence@gmail.com>
 Josh Lefler <jlefty94@gmail.com> jlefty <jlefty94@gmail.com>
 Josh Wilson <person142@users.noreply.github.com> Josh <person142@users.noreply.github.com>
 Josue Melka <yoch.melka@gmail.com> yoch <yoch.melka@gmail.com>
+Juan M. Bello-Rivas <jmbr@superadditive.com> Juan M. Bello-Rivas <jmbr@users.noreply.github.com>
+Juan Nunez-Iglesias <juan.nunez-iglesias@monash.edu> Juan Nunez-Iglesias <juan.n@unimelb.edu.au>
+Juan Nunez-Iglesias <juan.nunez-iglesias@monash.edu> Juan Nunez-Iglesias <jni.soma@gmail.com>
 Juha Remes <jremes@outlook.com> newman101 <jremes@outlook.com>
+Julien Jerphanion <git@jjerphan.xyz> Julien Jerphanion (@jjerphan) <git@jjerphan.xyz>
 Kai Striega <kaistriega@gmail.com> kai-striega <kaistriega@gmail.com>
 Kai Striega <kaistriega@gmail.com> Kai <kaistriega@gmail.com>
 Kai Striega <kaistriega@gmail.com> kai <kaistriega@gmail.com>
+Kai Striega <kaistriega@gmail.com> kai-striega <kaistriega+github@gmail.com>
+Kai Striega <kaistriega@gmail.com> Kai Striega <kaistriega+github@gmail.com>
 Kat Huang <kat@aya.yale.edu> kat <kat@aya.yale.edu>
 Kentaro Yamamoto <38549987+yamaken1343@users.noreply.github.com> yamaken <38549987+yamaken1343@users.noreply.github.com>
 Klaus Sembritzki <klausem@gmail.com> klaus <klausem@gmail.com>
@@ -242,6 +291,8 @@ Lars Buitinck <larsmans@gmail.com> Lars Buitinck <larsmans@users.noreply.github.
 Lars Buitinck <larsmans@gmail.com> Lars Buitinck <l.buitinck@esciencecenter.nl>
 Lars Buitinck <larsmans@gmail.com> Lars Buitinck <L.J.Buitinck@uva.nl>
 Lars G <lagru@mailbox.org> Lars G <lagru@users.noreply.github.com>
+Lars G <lagru@mailbox.org> Lars Grueter <lagru@mailbox.org>
+Lars G <lagru@mailbox.org> Lars Grüter <lagru@users.noreply.github.com>
 Lei Ma <emptymalei@qq.com> OctoMiao <emptymalei@qq.com>
 Levi John Wolf <levi.john.wolf@gmail.com> ljwolf <levi.john.wolf@gmail.com>
 Liam Damewood <damewood@physics.ucdavis.edu> ldamewood <damewood@physics.ucdavis.edu>
@@ -250,12 +301,15 @@ Lindsey Hiltner <lindsey.hiltner@gmail.com> L. Hiltner <lhilt@users.noreply.gith
 Lindsey Hiltner <lindsey.hiltner@gmail.com> L Hiltner <lhilt@users.noreply.github.com>
 Lijun Wang <szcfweiya@gmail.com> szcf-weiya <szcfweiya@gmail.com>
 Lorenzo Luengo <> loluengo <>
+Lucas Roberts <rlucas7@vt.edu> Lucas Roberts <rlucas7@users.noreply.github.com>
 Lucía Cheung <cheunglucia@gmail.com> ludcila <cheunglucia@gmail.com>
 Luke Zoltan Kelley <lkelley@cfa.harvard.edu> lzkelley <lkelley@cfa.harvard.edu>
 Maja Gwozdz <maja.k.gwozdz@gmail.com> mkg33 <maja.k.gwozdz@gmail.com>
+Maja Gwozdz <maja.k.gwozdz@gmail.com> Maja Gwóźdź <maja.k.gwozdz@gmail.com>
 Mak Sze Chun <makszechun@gmail.com> makbigc <makszechun@gmail.com>
 Malayaja Chutani <42006125+malch2@users.noreply.github.com> malch2 <42006125+malch2@users.noreply.github.com>
 Malte Esders <git@maltimore.info> Maltimore <git@maltimore.info>
+Mandeep Singh <mandeep.singh@zomato.com> Mandeep Singh <daxlab@users.noreply.github.com>
 M.J. Nichol <mjnichol@alumni.uwaterloo.ca> voyager6868 <mjnichol@alumni.uwaterloo.ca>
 Maniteja Nandana <manitejanmt@gmail.com> maniteja123 <manitejanmt@gmail.com>
 Marc Honnorat <marc.honnorat@gmail.com> honnorat <marc.honnorat@gmail.com>
@@ -278,6 +332,7 @@ Max Bolingbroke <batterseapower@hotmail.com> DSG User <>
 Max Bolingbroke <batterseapower@hotmail.com> Max Bolingbroke <Max.Bolingbroke@gsacapital.com>
 Michael Benfield <mike.benfield@gmail.com> mikebenfield <mike.benfield@gmail.com>
 Michael Droettboom <> mdroe <>
+Michael Dunphy <Michael.Dunphy@dfo-mpo.gc.ca> Michael Dunphy <mdunphy@users.noreply.github.com>
 Michael Hirsch <scienceopen@noreply.github.com> michael <scienceopen@noreply.github.com>
 Michael Hirsch <scienceopen@noreply.github.com> Michael Hirsch <scienceopen@users.noreply.github.com>
 Michael James Bedford <SunsetOrange@users.noreply.github.com> Michael <SunsetOrange@users.noreply.github.com>
@@ -291,15 +346,21 @@ Nathan Woods <woodscn@lanl.gov> Nathan Woods <charlesnwoods@gmail.com>
 Nathan Woods <woodscn@lanl.gov> Nathan Woods <woodscn@pn1504346.lanl.gov>
 Neil Girdhar <mistersheik@gmail.com> Neil <mistersheik@gmail.com>
 Nicholas McKibben <nicholas.bgp@gmail.com> mckib2 <nicholas.bgp@gmail.com>
+Nicky van Foreest <vanforeest@gmail.com> Nicky van Foreest <ndvanforeest@users.noreply.github.com>
 Nicola Montecchio <nicola.montecchio@gmail.com> nicola montecchio <nicola.montecchio@gmail.com>
 Nikolai Nowaczyk <mail@nikno.de> Nikolai <mail@nikno.de>
 Nikolas Moya <nikolasmoya@gmail.com> nmoya <nikolasmoya@gmail.com>
 Nikolay Mayorov <nikolay.mayorov@zoho.com> Nikolay Mayorov <n59_ru@hotmail.com>
 Nikolay Mayorov <nikolay.mayorov@zoho.com> Nikolay Mayorov <nmayorov@users.noreply.github.com>
 Noel Kippers <n.kippers@catawiki.nl> RothNRK <n.kippers@catawiki.nl>
+Noel Kippers <n.kippers@catawiki.nl> Noel Kippers <RothNRK@users.noreply.github.com>
+Oleksandr Pavlyk <oleksandr.pavlyk@intel.com> Oleksandr Pavlyk <oleksandr-pavlyk@users.noreply.github.com>
 Orestis Floros <orestisf1993@gmail.com> Orestis <orestisf1993@gmail.com>
 Pablo Winant <pablo.winant@gmail.com> pablo.winant@gmail.com <Pablo Winant>
+Pamphile Roy <roy.pamphile@gmail.com> Pamphile ROY <proy@bongfish.com>
+Pamphile Roy <roy.pamphile@gmail.com> Pamphile ROY <roy.pamphile@gmail.com>
 Patrick Snape <patricksnape@gmail.com> patricksnape <patricksnape@gmail.com>
+Paul Kienzle <pkienzle@gmail.com> Paul Kienzle <pkienzle@nist.gov>
 Paul van Mulbregt <pvanmulbregt@users.noreply.github.com> pvanmulbregt <pvanmulbregt@users.noreply.github.com>
 Peadar Coyle <peadarcoyle@googlemail.com> springcoil <peadarcoyle@googlemail.com>
 Pedro López-Adeva Fernández-Layos <plopezadeva@gmail.com> plafl <plopezadeva@gmail.com>
@@ -314,9 +375,15 @@ Peter Lysakovski <30794408+Lskvk@users.noreply.github.com> Lskvk <30794408+Lskvk
 Peter Mahler Larsen <pete.mahler.larsen@gmail.com> pmla <pete.mahler.larsen@gmail.com>
 Peter Mahler Larsen <pete.mahler.larsen@gmail.com> Peter <peter.mahler.larsen@gmail.com>
 Peter Mahler Larsen <pete.mahler.larsen@gmail.com> Peter Larsen <peter.mahler.larsen@gmail.com>
+Peter Mahler Larsen <pete.mahler.larsen@gmail.com> pmla <peter.mahler.larsen@gmail.com>
 Peyton Murray <peynmurray@gmail.com> pdmurray <peynmurray@gmail.com>
+Peyton Murray <peynmurray@gmail.com> Peyton Murray <peytonmurray@gmail.com>
+Philip DeBoer <philip.deboer@gmail.com> Philip DeBoer <philip_deboer@scotiacapital.com>
 Phillip Weinberg <weinbe58@bu.edu> weinbe58 <weinbe58@bu.edu>
+Pierre de Buyl <pdebuyl@pdebuyl.be> Pierre de Buyl <pdebuyl@ulb.ac.be>
 Pierre GM <pierregm@localhost> pierregm <pierregm@localhost>
+Poom Chiarawongse <eight1911@gmail.com> Poom Chiarawongse <tchiarawongs@gmail.com>
+Poom Chiarawongse <eight1911@gmail.com> poom <eight1911@gmail.com>
 Radoslaw Guzinski <radoslaw.guzinski@esa.int> radosuav <rmgu@dhi-gras.com>
 Radoslaw Guzinski <radoslaw.guzinski@esa.int> radosuav <radoslaw.guzinski@esa.int>
 Ralf Gommers <ralf.gommers@gmail.com> rgommers <ralf.gommers@googlemail.com>
@@ -325,13 +392,17 @@ Raphael Wettinger <ra@phael.org> raphael <ra@phael.org>
 Raphael Wettinger <ra@phael.org> raphaelw <raphael.wettinger@googlemail.com>
 Reidar Kind <53039431+reidarkind@users.noreply.github.com> reidarkind <53039431+reidarkind@users.noreply.github.com>
 Renee Otten <reneeotten@users.noreply.github.com> reneeotten <reneeotten@users.noreply.github.com>
+Richard Gowers <richardjgowers@gmail.com> richardjgowers <richardjgowers@gmail.com>
 Rick Paris <rick.paris@mlb.com> rparis <rick.paris@mlb.com>
 Rob Falck <robfalck@gmail.com> rob.falck <rob.falck@localhost>
 Robert David Grant <rgrant@enthought.com> Robert David Grant <robert.david.grant@gmail.com>
 Robert Kern <rkern@enthought.com> Robert Kern <robert.kern@gmail.com>
+Robert Uhl <robert.uhl@rwth-aachen.de> Robert Uhl <62612220+robertuhl@users.noreply.github.com>
 Roman Mirochnik <roman.mirochnik@hpe.com> mirochni <roman.mirochnik@hpe.com>
 Rupak Das <dr10ru@yahoo.co.in> Rupak <dr10ru@yahoo.co.in>
+Ruslan Yevdokymov <evruslan17@gmail.com> Ruslan Yevdokymov <38809160+ruslanye@users.noreply.github.com>
 Sam Lewis <sam.vr.lewis@gmail.com> Sam Lewis <samvrlewis@users.noreply.github.com>
+Sam McCormack <sampmccormack@gmail.com> Sam McCormack <TheGreatCabbage@users.noreply.github.com>
 Sam Mason <sam@samason.uk> Sam Mason <sam.mason@warwick.ac.uk>
 Samuel Wallan <44255917+swallan@users.noreply.github.com> swallan <44255917+swallan@users.noreply.github.com>
 Samuel Wallan <44255917+swallan@users.noreply.github.com> Sam Wallan <44255917+swallan@users.noreply.github.com>
@@ -347,9 +418,12 @@ Sebastian Pucilowski <smopucilowski@gmail.com> Sebastian Pucilowski <smopucilows
 Sebastian Skoupý <sebastian.skoupy@gmail.com> Sebascn <sebastian.skoupy@gmail.com>
 Skipper Seabold <jsseabold@gmail.com> skip <skip@localhost>
 Shinya SUZUKI <sshinya@bio.titech.ac.jp> Shinya SUZUKI <minasitawakou@gmail.com>
+Sourav Singh <souravsingh@users.noreply.github.com> Sourav Singh <4314261+souravsingh@users.noreply.github.com>
 Srikiran <srikiran@dhcp-v233-179.pv.reshsg.uci.edu> sriki18 <sriki18@users.noreply.github.com>
 Stefan Endres <stefan.c.endres@gmail.com> stefan-endres <stefan.c.endres@gmail.com>
+Stefan Endres <stefan.c.endres@gmail.com> Stefan Endres <Stefan.C.Endres@gmail.com>
 Stefan Peterson <stefan.peterson@rubico.com> sjpet <stefan.peterson@rubico.com>
+Stefan Peterson <stefan.peterson@rubico.com> Stefan Peterson <sjpet@users.noreply.github.com>
 Stefan van der Walt <stefanv@berkeley.edu> Stefan van der Walt <sjvdwalt@gmail.com>
 Stefan van der Walt <stefanv@berkeley.edu> Stefan van der Walt <stefan@sun.ac.za>
 Steve Richardson <arichar6@gmail.com> arichar6 <arichar6@gmail.com>
@@ -358,26 +432,36 @@ Sturla Molden <sturla@molden.no> Sturla Molden <sturlamolden@users.noreply.githu
 Sturla Molden <sturla@molden.no> unknown <sturlamo@PK-FYS-1121C.uio.no>
 Sumit Binnani <sumitbinnani.developer@gmail.com> sumitbinnani <sumitbinnani.developer@gmail.com>
 Sylvain Bellemare <sbellem@gmail.com> Sylvain Bellemare <sylvain.bellemare@ezeep.com>
+Sylvain Gubian <sylvain.gubian@pmi.com> Sylvain Gubian <Sylvain.Gubian@pmi.com>
 Sytse Knypstra <S.Knypstra@rug.nl> SytseK <S.Knypstra@rug.nl>
 Takuya Oshima <oshima@eng.niigata-u.ac.jp> Takuya OSHIMA <oshima@eng.niigata-u.ac.jp>
 Terry Jones <terry@fluidinfo.com> terrycojones <terry@fluidinfo.com>
+Thomas Kluyver <takowl@gmail.com> Thomas Kluyver <thomas@kluyver.me.uk>
 Thouis (Ray) Jones <thouis@gmail.com> Thouis (Ray) Jones <thouis@seas.harvard.edu>
 Tiago M.D. Pereira <tiagomdp@gmail.com> tiagopereira <tiagomdp@gmail.com>
 Tim Cera <tim@cerazone.net> timcera <tim@cerazone.net>
 Tim Leslie <tim.leslie@gmail.com> Tim Leslie <timl@breakawayconsulting.com.au>
+Tobias Megies <megies@geophysik.uni-muenchen.de> Tobias Megies <megies@users.noreply.github.com>
 Tobias Schmidt <royalts@gmail.com> RoyalTS <royalts@gmail.com>
 Todd Goodall <beyondmetis@gmail.com> Todd <beyondmetis@gmail.com>
+Todd Jennings <toddrjen@gmail.com> Todd <toddrjen@gmail.com>
 Tom Waite <tom.waite@localhost> tom.waite <tom.waite@localhost>
 Tom Donoghue <tdonoghue@ucsd.edu> TomDonoghue <tdonoghue@ucsd.edu>
 Tony S. Yu <tsyu80@gmail.com> tonysyu <tsyu80@gmail.com>
 Tony S. Yu <tsyu80@gmail.com> Tony S Yu <tsyu80@gmail.com>
+Toshiki Kataoka <tos.lunar@gmail.com> Toshiki Kataoka <kataoka@preferred.jp>
+Toshiki Kataoka <tos.lunar@gmail.com> tosh1ki <tosh1ki@yahoo.co.jp>
 Travis Oliphant <teoliphant@gmail.com> Travis E. Oliphant <teoliphant@gmail.com>
 Travis Oliphant <teoliphant@gmail.com> Travis Oliphant <oliphant@enthought.com>
 Uwe Schmitt <uwe.schmitt@localhost> uwe.schmitt <uwe.schmitt@localhost>
 Vicky Close <vicky.r.close@gmail.com> vickyclose <vicky.r.close@gmail.com>
+Vladyslav Rachek <wsw.raczek@gmail.com> Vladyslav Rachek <36896640+erheron@users.noreply.github.com>
 Warren Weckesser <warren.weckesser@gmail.com> warren.weckesser <warren.weckesser@localhost>
 Warren Weckesser <warren.weckesser@gmail.com> Warren Weckesser <warren.weckesser@enthought.com>
 Warren Weckesser <warren.weckesser@gmail.com> Warren Weckesser <warren.weckesser@localhost>
 Wendy Liu <ilostwaldo@gmail.com> dellsystem <ilostwaldo@gmail.com>
+Will Tirone <will.tirone1@gmail.com> WillTirone <42592742+WillTirone@users.noreply.github.com>
+Xingyu Liu <38244988+charlotte12l@users.noreply.github.com> 刘星雨 <liuxingyu.12@bytedance.com>
 Yu Feng <rainwoodman@gmail.com> Yu Feng <yfeng1@waterfall.dyn.berkeley.edu>
 Yves-Rémi Van Eycke <yves-remi@hotmail.com> vanpact <yves-remi@hotmail.com>
+Zé Vinícius <jvmirca@gmail.com> Ze Vinicius <jvmirca@gmail.com>


### PR DESCRIPTION
* reduce author name degeneracy produced by
`git log --format="%aN <%aE>" | sort -u`
to reduce the likelihood of duplicate authors
listed by release scripts

* the mapping adjustments mostly try to follow
common sense; a few basic rules I tried to follow
were:

  * favor a canonical name if it is already listed
in the mailmap file
  * for duplicate names where one lacks accents, use
the name with accents on the basis that it may
better reflect the native language of the name (unless
a non-accented name was already mapped)
  * in a small number of cases the native characters were
not used because of a preference previously expressed by
the contributor