### PR TITLE
ENH: stats: bootstrap: add `paired` parameter

### DIFF
--- a/scipy/stats/_bootstrap.py
+++ b/scipy/stats/_bootstrap.py
@@ -358,7 +358,7 @@ def bootstrap(data, statistic, *, paired=False, axis=0, confidence_level=0.95,
     ...     x, y = z[:n], z[n:]
     ...     return pearsonr(x, y)[0]
     >>> def my_vectorized_statistic(x, y, axis):
-    ...     z = np.concatenate([x, y])
+    ...     z = np.hstack([x, y])
     ...     return np.apply_along_axis(my_statistic, axis, z)
 
     We call `bootstrap` using `paired=True`.

--- a/scipy/stats/_bootstrap.py
+++ b/scipy/stats/_bootstrap.py
@@ -405,4 +405,4 @@ def bootstrap(data, statistic, *, paired=False, axis=0, confidence_level=0.95,
         ci_l, ci_u = 2*theta_hat - ci_u, 2*theta_hat - ci_l
 
     return BootstrapResult(confidence_interval=ConfidenceInterval(ci_l, ci_u),
-                           standard_error=np.std(theta_hat_b, ddof=1))
+                           standard_error=np.std(theta_hat_b, ddof=1, axis=-1))

--- a/scipy/stats/_bootstrap.py
+++ b/scipy/stats/_bootstrap.py
@@ -128,13 +128,13 @@ def _bootstrap_iv(data, statistic, vectorized, paired, axis, confidence_level,
     data_iv = []
     for sample in data:
         sample = np.atleast_1d(sample)
-        if sample.shape[axis] <= 1:
+        if sample.shape[axis_int] <= 1:
             raise ValueError("each sample in `data` must contain two or more "
                              "observations along `axis`.")
         sample = np.moveaxis(sample, axis_int, -1)
         data_iv.append(sample)
 
-    if paired is not True and paired is not False:
+    if not isinstance(paired, bool):
         raise ValueError("`paired` must be `True` or `False`.")
 
     if paired:
@@ -151,9 +151,7 @@ def _bootstrap_iv(data, statistic, vectorized, paired, axis, confidence_level,
             data = [sample[..., i] for sample in data]
             return unpaired_statistic(*data, axis=axis)
 
-        data_iv = [np.arange(n),]
-
-    # should we try: statistic(data, axis=axis) here?
+        data_iv = [np.arange(n)]
 
     confidence_level_float = float(confidence_level)
 

--- a/scipy/stats/tests/test_bootstrap.py
+++ b/scipy/stats/tests/test_bootstrap.py
@@ -60,13 +60,14 @@ def test_bootstrap_iv():
 
 @pytest.mark.parametrize("method", ['basic', 'percentile', 'BCa'])
 def test_bootstrap_paired(method):
+    # test that `paired` works as expected
     np.random.seed(0)
     n = 100
     x = np.random.rand(n)
     y = np.random.rand(n)
 
     def my_statistic(x, y, axis=-1):
-        return x.mean(axis=axis) - y.mean(axis=axis)
+        return ((x-y)**2).mean(axis=axis)
 
     def my_paired_statistic(i, axis=-1):
         a = x[i]
@@ -81,6 +82,44 @@ def test_bootstrap_paired(method):
     assert_allclose(res1.confidence_interval, res2.confidence_interval)
     assert_allclose(res1.standard_error, res2.standard_error)
 
+@pytest.mark.parametrize("method", ['basic', 'percentile', 'BCa'])
+@pytest.mark.parametrize("axis", [0, 1, 2])
+@pytest.mark.parametrize("paired", [True, False])
+def test_bootstrap_vectorized(method, axis, paired):
+    # test that paired is vectorized as expected: when samples are tiled,
+    # CI and standard_error of each axis-slice is the same as those of the
+    # original 1d sample
+
+    if not paired and method=='BCa':
+        # should re-assess when BCa is extended
+        pytest.xfail(reason="BCa currently for 1-sample statistics only")
+    np.random.seed(0)
+
+    def my_statistic(x, y, z, axis=-1):
+        return x.mean(axis=axis) + y.mean(axis=axis) + z.mean(axis=axis)
+
+    shape = 10, 11, 12
+    n_samples = shape[axis]
+
+    x = np.random.rand(n_samples)
+    y = np.random.rand(n_samples)
+    z = np.random.rand(n_samples)
+    res1 = bootstrap((x, y, z), my_statistic, paired=paired, method=method,
+                     random_state=0, axis=0, n_resamples=100)
+
+    reshape = [1, 1, 1]
+    reshape[axis] = n_samples
+    x = np.broadcast_to(x.reshape(reshape), shape)
+    y = np.broadcast_to(y.reshape(reshape), shape)
+    z = np.broadcast_to(z.reshape(reshape), shape)
+    res2 = bootstrap((x, y, z), my_statistic, paired=paired, method=method,
+                     random_state=0, axis=axis, n_resamples=100)
+
+    assert_allclose(res2.confidence_interval.low,
+                    res1.confidence_interval.low)
+    assert_allclose(res2.confidence_interval.high,
+                    res1.confidence_interval.high)
+    assert_allclose(res2.standard_error, res1.standard_error)
 
 @pytest.mark.parametrize("method", ['basic', 'percentile', 'BCa'])
 def test_bootstrap_against_theory(method):


### PR DESCRIPTION
#### Reference issue
gh-13371

#### What does this implement/fix?
This adds one of the enhancements planned for the new bootstrap function:
When the new parameter `paired` is set True, the statistic is treated as a paired-sample statistic