### PR TITLE
MAINT: fix deprecated Python C API usage in odr

### DIFF
--- a/scipy/odr/__odrpack.c
+++ b/scipy/odr/__odrpack.c
@@ -100,7 +100,7 @@ void fcn_callback(F_INT *n, F_INT *m, F_INT *np, F_INT *nq, F_INT *ldn, F_INT *l
           PYERR2(odr_error, "Function has not been initialized");
         }
 
-      if ((result = PyEval_CallObject(odr_global.fcn, arglist)) == NULL)
+      if ((result = PyObject_CallObject(odr_global.fcn, arglist)) == NULL)
         {
           if (PyErr_ExceptionMatches(odr_stop))
             {
@@ -136,7 +136,7 @@ void fcn_callback(F_INT *n, F_INT *m, F_INT *np, F_INT *nq, F_INT *ldn, F_INT *l
           PYERR2(odr_error, "Function has not been initialized");
         }
 
-      if ((result = PyEval_CallObject(odr_global.fjacb, arglist)) == NULL)
+      if ((result = PyObject_CallObject(odr_global.fjacb, arglist)) == NULL)
         {
           if (PyErr_ExceptionMatches(odr_stop))
             {
@@ -195,7 +195,7 @@ void fcn_callback(F_INT *n, F_INT *m, F_INT *np, F_INT *nq, F_INT *ldn, F_INT *l
           PYERR2(odr_error, "fjcad has not been initialized");
         }
 
-      if ((result = PyEval_CallObject(odr_global.fjacd, arglist)) == NULL)
+      if ((result = PyObject_CallObject(odr_global.fjacd, arglist)) == NULL)
         {
           if (PyErr_ExceptionMatches(odr_stop))
             {
@@ -1118,7 +1118,7 @@ PyObject *odr(PyObject * self, PyObject * args, PyObject * kwds)
         }
       if (PyArray_DIMS(work)[0] < lwork)
         {
-            printf("%ld " F_INT_FMT "\n", PyArray_DIMS(work)[0], lwork);
+          printf("%ld %lld\n", PyArray_DIMS(work)[0], (long long)lwork);
           PYERR(PyExc_ValueError, "work is too small");
         }
     }

--- a/scipy/odr/odrpack.h
+++ b/scipy/odr/odrpack.h
@@ -9,16 +9,12 @@
 
 #if NPY_BITSOF_SHORT == 64
 #define F_INT_PYFMT   "h"
-#define F_INT_FMT "%h"
 #elif NPY_BITSOF_INT == 64
 #define F_INT_PYFMT   "i"
-#define F_INT_FMT "%d"
 #elif NPY_BITSOF_LONG == 64
 #define F_INT_PYFMT   "l"
-#define F_INT_FMT "%ld"
 #elif NPY_BITSOF_LONGLONG == 64
 #define F_INT_PYFMT   "L"
-#define F_INT_FMT "%lld"
 #else
 #error No compatible 64-bit integer size. \
        Please contact NumPy maintainers and give detailed information about your \
@@ -29,7 +25,6 @@
 
 #define F_INT int
 #define F_INT_NPY NPY_INT
-#define F_INT_FMT NPY_INT_FMT
 #define F_INT_PYFMT   "i"
 
 #endif


### PR DESCRIPTION
`PyEval_*` is deprecated although not being removed apparently. Still, better to replace with the equivalent `PyObject_` call. See https://bugs.python.org/issue42181

The printf cleanup is fixing an annoying warning; using a format specifier like `%ld` or `%lld` that's hidden in a macro makes gcc
emit a warning that there are too many arguments (see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47781). So instead, upcast the integer with unknown size to the largest possible size, and use a fixed `%lld` specifier.