### PR TITLE
ENH: stats: bootstrap: add `batch` parameter to control batch size

### DIFF
--- a/scipy/stats/_bootstrap.py
+++ b/scipy/stats/_bootstrap.py
@@ -200,6 +200,11 @@ def bootstrap(data, statistic, *, axis=0, confidence_level=0.95,
     n_resamples : int, optional
         The number of resamples performed to form the bootstrap distribution
         of the statistic. The default is ``9999``.
+    batch : int or None, optional
+        The number of resamples to process in each vectorized call to
+        `statistic`. Memory usage is O(`batch`*``n``), where ``n`` is the
+        sample size. Default is ``None``, in which case ``batch = n_resamples``
+        (or ``batch = max(n_resamples, n)`` for ``method='BCa'``).
     method : str in {'percentile', 'basic', 'bca'}, optional
         Whether to return the 'percentile' bootstrap confidence interval
         (``'percentile'``), the 'reverse' or the bias-corrected and accelerated

--- a/scipy/stats/_bootstrap.py
+++ b/scipy/stats/_bootstrap.py
@@ -113,7 +113,7 @@ def _bootstrap_iv(data, statistic, vectorized, paired, axis, confidence_level,
                   n_resamples, batch, method, random_state):
     """Input validation and standardization for `bootstrap`."""
 
-    if not isinstance(vectorized, bool):
+    if vectorized not in {True, False}:
         raise ValueError("`vectorized` must be `True` or `False`.")
 
     if not vectorized:
@@ -141,7 +141,7 @@ def _bootstrap_iv(data, statistic, vectorized, paired, axis, confidence_level,
         sample = np.moveaxis(sample, axis_int, -1)
         data_iv.append(sample)
 
-    if not isinstance(paired, bool):
+    if paired not in {True, False}:
         raise ValueError("`paired` must be `True` or `False`.")
 
     if paired:
@@ -240,33 +240,32 @@ def bootstrap(data, statistic, *, vectorized=True, paired=False, axis=0,
         If `vectorized` is set ``False``, `statistic` will not be passed
         keyword argument `axis`, and is assumed to calculate the statistic
         only for 1D samples.
-    paired : bool, optional
+    paired : bool, default: ``False``
         Whether the statistic treats corresponding elements of the samples
-        in `data` as paired. The default is ``False``.
-    axis : int, optional
+        in `data` as paired.
+    axis : int, default: ``0``
         The axis of the samples in `data` along which the `statistic` is
-        calculated. The default is ``0``.
-    confidence_level : float, optional
+        calculated.
+    confidence_level : float, default: ``0.95``
         The confidence level of the confidence interval.
-        The default is ``0.95``.
-    n_resamples : int, optional
+    n_resamples : int, default: ``9999``
         The number of resamples performed to form the bootstrap distribution
-        of the statistic. The default is ``9999``.
-    batch : int or None, optional
+        of the statistic.
+    batch : int, optional
         The number of resamples to process in each vectorized call to
         `statistic`. Memory usage is O(`batch`*``n``), where ``n`` is the
         sample size. Default is ``None``, in which case ``batch = n_resamples``
         (or ``batch = max(n_resamples, n)`` for ``method='BCa'``).
-    method : str in {'percentile', 'basic', 'bca'}, optional
+    method : {'percentile', 'basic', 'bca'}, default: ``'BCa'``
         Whether to return the 'percentile' bootstrap confidence interval
         (``'percentile'``), the 'reverse' or the bias-corrected and accelerated
-        bootstrap confidence interval (``'BCa'``). The default is ``'BCa'``.
+        bootstrap confidence interval (``'BCa'``).
         Note that only ``'percentile'`` and ``'basic'`` support multi-sample
         statistics at this time.
     random_state : {None, int, `numpy.random.Generator`,
                     `numpy.random.RandomState`}, optional
 
-        If `seed` is None (or `np.random`), the `numpy.random.RandomState`
+        If `seed` is ``None`` (or `np.random`), the `numpy.random.RandomState`
         singleton is used.
         If `seed` is an int, a new ``RandomState`` instance is used,
         seeded with `seed`.

--- a/scipy/stats/tests/test_bootstrap.py
+++ b/scipy/stats/tests/test_bootstrap.py
@@ -212,7 +212,6 @@ tests_against_itself_1samp = {"basic": 1780,
                               "BCa": 1784}
 
 
-@pytest.mark.xfail_on_32bit("Uses too much memory")
 @pytest.mark.parametrize("method, expected",
                          tests_against_itself_1samp.items())
 def test_bootstrap_against_itself_1samp(method, expected):
@@ -223,20 +222,21 @@ def test_bootstrap_against_itself_1samp(method, expected):
     np.random.seed(0)
 
     n = 100  # size of sample
-    n_resamples = 1000  # number of bootstrap resamples used to form each CI
+    n_resamples = 999  # number of bootstrap resamples used to form each CI
     confidence_level = 0.9
 
     # The true mean is 5
     dist = stats.norm(loc=5, scale=1)
     stat_true = dist.mean()
 
-    # Do the same thing 1000 times. (The code is fully vectorized.)
+    # Do the same thing 2000 times. (The code is fully vectorized.)
     n_replications = 2000
     data = dist.rvs(size=(n_replications, n))
     res = bootstrap((data,),
                     statistic=np.mean,
                     confidence_level=confidence_level,
                     n_resamples=n_resamples,
+                    batch=50,
                     method=method,
                     axis=-1)
     ci = res.confidence_interval
@@ -251,11 +251,10 @@ def test_bootstrap_against_itself_1samp(method, expected):
     assert pvalue > 0.1
 
 
-tests_against_itself_2samp = {"basic": 888,
-                              "percentile": 886}
+tests_against_itself_2samp = {"basic": 892,
+                              "percentile": 890}
 
 
-@pytest.mark.xfail_on_32bit("Uses too much memory")
 @pytest.mark.parametrize("method, expected",
                          tests_against_itself_2samp.items())
 def test_bootstrap_against_itself_2samp(method, expected):
@@ -267,7 +266,7 @@ def test_bootstrap_against_itself_2samp(method, expected):
 
     n1 = 100  # size of sample 1
     n2 = 120  # size of sample 2
-    n_resamples = 1000  # number of bootstrap resamples used to form each CI
+    n_resamples = 999  # number of bootstrap resamples used to form each CI
     confidence_level = 0.9
 
     # The statistic we're interested in is the difference in means
@@ -289,6 +288,7 @@ def test_bootstrap_against_itself_2samp(method, expected):
                     statistic=my_stat,
                     confidence_level=confidence_level,
                     n_resamples=n_resamples,
+                    batch=50,
                     method=method,
                     axis=-1)
     ci = res.confidence_interval
@@ -343,10 +343,12 @@ def test_bootstrap_vectorized_1samp(method, axis):
 
     np.random.seed(0)
     x = np.random.rand(4, 5)
-    res1 = bootstrap((x,), statistic, vectorized=True,
-                     axis=axis, n_resamples=100, method=method, random_state=0)
-    res2 = bootstrap((x,), statistic_1d, vectorized=False,
-                     axis=axis, n_resamples=100, method=method, random_state=0)
+    res1 = bootstrap((x,), statistic, vectorized=True, axis=axis,
+                     n_resamples=100, batch=None, method=method,
+                     random_state=0)
+    res2 = bootstrap((x,), statistic_1d, vectorized=False, axis=axis,
+                     n_resamples=100, batch=10, method=method,
+                     random_state=0)
     assert_allclose(res1.confidence_interval, res2.confidence_interval)
     assert_allclose(res1.standard_error, res2.standard_error)
 


### PR DESCRIPTION
#### Reference issue
gh-13371

#### What does this implement/fix?
This adds one of the enhancements planned for the new bootstrap function:
The new parameter `batch` controls the batch size in which resamples are processed in vectorized calls to `statistic`.