### PR TITLE
CI: upgrade pip in benchmarks CI run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,6 +113,7 @@ jobs:
           name: run asv
           command: |
             . venv/bin/activate
+            pip install --upgrade pip
             pip install pyfftw cffi pytest
             export PYTHONPATH=$PWD/build/testenv/lib/python3.7/site-packages
             cd benchmarks


### PR DESCRIPTION
A merge to master CI run just failed with:
```
  Could not find a version that satisfies the requirement
  pluggy<1.0.0a1,>=0.12 (from pytest) (from versions: )

  No matching distribution found for pluggy<1.0.0a1,>=0.12 (from pytest)
  You are using pip version 10.0.1, however version 21.1.2 is available.
```