### PR TITLE
BUG: Fix trust-constr report TypeError if verbose is set to 2 or 3

### DIFF
--- a/scipy/optimize/_trustregion_constr/report.py
+++ b/scipy/optimize/_trustregion_constr/report.py
@@ -19,11 +19,13 @@ class ReportBase:
 
     @classmethod
     def print_iteration(cls, *args):
-        # args[3] is obj func. It should really be a float. However,
-        # trust-constr typically provides a length 1 array. We have to coerce
-        # it to a float, otherwise the string format doesn't work.
+        # args[3] is obj func, and args[4] is tr-radius. They should really be
+        # floats. However, trust-constr typically provides a ndarray for these
+        # values. We have to coerce them to floats, otherwise the string
+        # formatting doesn't work.
         args = list(args)
         args[3] = float(args[3])
+        args[4] = float(args[4])
 
         iteration_format = ["{{:{}}}".format(x) for x in cls.ITERATION_FORMATS]
         fmt = "|" + "|".join(iteration_format) + "|"

--- a/scipy/optimize/_trustregion_constr/tests/test_report.py
+++ b/scipy/optimize/_trustregion_constr/tests/test_report.py
@@ -1,10 +1,32 @@
+import numpy as np
 from scipy.optimize import minimize, Bounds
 
 def test_gh10880():
-    # checks that verbose reporting works with trust-constr
+    # checks that verbose reporting works with trust-constr for
+    # bound-contrained problems
     bnds = Bounds(1, 2)
     opts = {'maxiter': 1000, 'verbose': 2}
-    minimize(lambda x: x**2, x0=2., method='trust-constr', bounds=bnds, options=opts)
+    minimize(lambda x: x**2, x0=2., method='trust-constr',
+             bounds=bnds, options=opts)
 
     opts = {'maxiter': 1000, 'verbose': 3}
-    minimize(lambda x: x**2, x0=2., method='trust-constr', bounds=bnds, options=opts)
+    minimize(lambda x: x**2, x0=2., method='trust-constr',
+             bounds=bnds, options=opts)
+
+def test_gh12922():
+    # checks that verbose reporting works with trust-constr for
+    # general constraints
+    def objective(x):
+        return np.array([(np.sum((x+1)**2))])
+
+    cons = {'type': 'ineq', 'fun': lambda x: -x[0]**2}
+    n = 25
+    x0 = np.linspace(-5, 5, n)
+
+    opts = {'maxiter': 1000, 'verbose': 2}
+    result = minimize(objective, x0=x0, method='trust-constr',
+                      constraints=cons, options=opts)
+
+    opts = {'maxiter': 1000, 'verbose': 3}
+    result = minimize(objective, x0=x0, method='trust-constr',
+                      constraints=cons, options=opts)


### PR DESCRIPTION
For certain combinations of objective function/constraints/starting points, setting verbose >= 2 in minimize with `trust-constr` results in a `TypeError` when reporting iteration information, because the trust region radius is returned as a ndarray. The reporting format expects a float.

Fixes #12922