### PR TITLE
DOC: badge with version of the doc in the navbar

### DIFF
--- a/doc/source/_static/scipy.css
+++ b/doc/source/_static/scipy.css
@@ -28,6 +28,12 @@
 	unicode-range: U+0028, U+0029;
 }
 
+/* Don't wrap version badge under logo */
+
+#navbar-start {
+  white-space: nowrap;
+}
+
 /* Taken from NumPy */
 
 @import url('https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,400;0,700;0,900;1,400;1,700;1,900&family=Open+Sans:ital,wght@0,400;0,600;1,400;1,600&display=swap');

--- a/doc/source/_templates/version.html
+++ b/doc/source/_templates/version.html
@@ -1,0 +1,5 @@
+<!-- This will display the version of the docs as a badge -->
+<a href="https://docs.scipy.org/doc/">
+    <img src="https://img.shields.io/badge/release-{{ version|replace("+", "%2B") }}-yellow?style=for-the-badge"
+         style="margin-left: 1em; width: 60%;">
+</a>

--- a/doc/source/_templates/version.html
+++ b/doc/source/_templates/version.html
@@ -12,6 +12,10 @@ Nat Methods 8, 441 (2011). https://doi.org/10.1038/nmeth.1618
         {# orange for dev #E69F00 #}
         <img src="https://img.shields.io/badge/release-{{ version|replace("+", "%2B") }}-E69F00?style=for-the-badge"
          style="margin-left: 1em; width: 60%;">
+    {% elif versionwarning %}
+        {# red for old #980F0F #}
+        <img src="https://img.shields.io/badge/release-{{ version|replace("+", "%2B") }}-980F0F?style=for-the-badge"
+         style="margin-left: 1em; width: 60%;">
     {% else %}
         {# green for stable #009E73 #}
         <img src="https://img.shields.io/badge/release-{{ version }}-009E73?style=for-the-badge"

--- a/doc/source/_templates/version.html
+++ b/doc/source/_templates/version.html
@@ -1,5 +1,20 @@
-<!-- This will display the version of the docs as a badge -->
+{# This will display the version of the docs as a badge
+
+Colors from:
+
+Wong, B. Points of view: Color blindness.
+Nat Methods 8, 441 (2011). https://doi.org/10.1038/nmeth.1618
+
+#}
+
 <a href="https://docs.scipy.org/doc/">
-    <img src="https://img.shields.io/badge/release-{{ version|replace("+", "%2B") }}-yellow?style=for-the-badge"
+    {% if "dev" in version %}
+        {# orange for dev #E69F00 #}
+        <img src="https://img.shields.io/badge/release-{{ version|replace("+", "%2B") }}-E69F00?style=for-the-badge"
          style="margin-left: 1em; width: 60%;">
+    {% else %}
+        {# green for stable #009E73 #}
+        <img src="https://img.shields.io/badge/release-{{ version }}-009E73?style=for-the-badge"
+         style="margin-left: 1em; width: 60%;">
+    {% endif %}
 </a>

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -148,6 +148,7 @@ for key in (
         r"'U' mode is deprecated",  # sphinx io
         r"OpenSSL\.rand is deprecated",  # OpenSSL package in linkcheck
         r"Using or importing the ABCs from",  # 3.5 importlib._bootstrap
+        r"'contextfunction' is renamed to 'pass_context'",  # Jinja
         ):
     warnings.filterwarnings(  # deal with other modules having bad imports
         'ignore', message=".*" + key, category=DeprecationWarning)
@@ -180,6 +181,7 @@ html_logo = '_static/scipyshiny_small.png'
 html_theme_options = {
   "logo_link": "index",
   "github_url": "https://github.com/scipy/scipy",
+  "navbar_start": ["navbar-logo", "version"],
 }
 
 if 'versionwarning' in tags:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -192,9 +192,14 @@ if 'versionwarning' in tags:
            'script.src = "/doc/_static/versionwarning.js";\n'
            'document.head.appendChild(script);');
     html_context = {
-        'VERSIONCHECK_JS': src
+        'VERSIONCHECK_JS': src,
+        'versionwarning': True
     }
     html_js_files = ['versioncheck.js']
+else:
+    html_context = {
+        'versionwarning': False
+    }
 
 html_title = "%s v%s Manual" % (project, version)
 html_static_path = ['_static']


### PR DESCRIPTION
Add a badge with the version information to the navbar between the logo and the sections. The badge is an hyperlink to the list of versions (https://docs.scipy.org/doc/).

The badge is responsive.

As discussed in #14128

<img width="400" alt="Screenshot 2021-05-25 at 15 27 44" src="https://user-images.githubusercontent.com/23188539/119506001-c9d20000-bd6d-11eb-91b1-e73e7fa1b63a.png">

<img width="1400" alt="Screenshot 2021-05-25 at 15 19 06" src="https://user-images.githubusercontent.com/23188539/119505870-ad35c800-bd6d-11eb-8887-fff0d4e4ff30.png">
<img width="1400" alt="119655356-c7cd7700-be29-11eb-96b2-6f9a4e254583" src="https://user-images.githubusercontent.com/23188539/119656944-9bb2f580-be2b-11eb-9cb8-162c9e3759d4.png">
<img width="1400" alt="Screenshot 2021-05-29 at 09 33 00" src="https://user-images.githubusercontent.com/23188539/120062145-e7021980-c060-11eb-9ef0-0a9559c1766d.png">
