### PR TITLE
MAINT: interpolate: raise NotImplementedError not ValueError

### DIFF
--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -1039,8 +1039,8 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
     k = operator.index(k)
 
     if bc_type == 'periodic' and t is not None:
-        raise ValueError("For periodic case t is constructed automatically "
-                         "and can not be passed manually")
+        raise NotImplementedError("For periodic case t is constructed "
+                         "automatically and can not be passed manually")
 
     # come up with a sensible knot vector, if needed
     if t is None:


### PR DESCRIPTION
A follow-up to gh-13701 : constructing periodic splines with given knots is not implemented, thus raise `NotImplementedError` instead of a `ValueError`.

Am marking this for the 1.7.0 milestone since the functionality is new in 1.7.0 (so back compat is not a concern).