### PR TITLE
DOC: show how to use solve_ivp with one arg

### DIFF
--- a/scipy/integrate/_ivp/ivp.py
+++ b/scipy/integrate/_ivp/ivp.py
@@ -483,7 +483,7 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
     ...
 
     We pass in the parameter values a=1.5, b=1, c=3 and d=1 with the `args`
-    argument.
+    argument. (If you have only one argument, use args=(1.5,) or args=[1.5])
 
     >>> sol = solve_ivp(lotkavolterra, [0, 15], [10, 5], args=(1.5, 1, 3, 1),
     ...                 dense_output=True)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes issue in stackoverflow https://stackoverflow.com/questions/53262552/cant-integrate-with-dblquad

#### What does this implement/fix?
Tell user, that if they have only one argument, they cannot simply use tuple. Because in python (a) != (a,)

#### Additional information
<!--Any additional information you think is important.-->