### PR TITLE
MAINT: 1.7.x version pins ("backport")

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,10 +10,10 @@
 [build-system]
 requires = [
     "wheel<0.37.0",
-    "setuptools",
+    "setuptools<58.0.0",
     "Cython>=0.29.18,<3.0",
     "pybind11>=2.4.3,<2.7.0",
-    "pythran>=0.9.11",
+    "pythran==0.9.11",
 
     # NumPy dependencies - to update these, sync from
     # https://github.com/scipy/oldest-supported-numpy/, and then
@@ -22,25 +22,20 @@ requires = [
 
     # numpy 1.19 was the first minor release to provide aarch64 wheels, but
     # wheels require fixes contained in numpy 1.19.2
-    "numpy==1.19.2; python_version=='3.6' and platform_machine=='aarch64'",
     "numpy==1.19.2; python_version=='3.7' and platform_machine=='aarch64'",
+    "numpy==1.19.2; python_version=='3.8' and platform_machine=='aarch64'",
+    # aarch64 for py39 is covered by default requirement below
 
     # default numpy requirements
-    "numpy==1.16.5; python_version=='3.6' and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'",
     "numpy==1.16.5; python_version=='3.7' and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'",
     "numpy==1.17.3; python_version=='3.8' and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'",
     "numpy==1.19.3; python_version=='3.9' and platform_python_implementation != 'PyPy'",
 
     # First PyPy versions for which there are numpy wheels
-    "numpy==1.19.0; python_version=='3.6' and platform_python_implementation=='PyPy'",
     "numpy==1.20.0; python_version=='3.7' and platform_python_implementation=='PyPy'",
-
-    # For Python versions which aren't yet officially supported,
-    # we specify an unpinned NumPy which allows source distributions
-    # to be used and allows wheels to be used as soon as they
-    # become available.
-    "numpy; python_version>='3.10'",
-    "numpy; python_version>='3.8' and platform_python_implementation=='PyPy'",
+    # Unpinned NumPy version in case PyPy catches up with supported Python versions
+    "numpy; python_version=='3.8' and platform_python_implementation=='PyPy'",
+    "numpy; python_version=='3.9' and platform_python_implementation=='PyPy'",
 ]
 
 [project]
@@ -53,9 +48,9 @@ maintainers = [
 # Note: Python and NumPy upper version bounds should be set correctly in
 # release branches, see:
 #     https://scipy.github.io/devdocs/dev/core-dev/index.html#version-ranges-for-numpy-and-other-dependencies
-requires-python = ">=3.7"
+requires-python = ">=3.7,<3.10"
 dependencies = [
-    "numpy>=1.16.5",
+    "numpy>=1.16.5,<1.23.0",
 ]
 readme = "README.rst"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,10 @@
 
 [build-system]
 requires = [
-    "wheel",
+    "wheel<0.37.0",
     "setuptools",
-    "Cython>=0.29.18",
-    "pybind11>=2.4.3",
+    "Cython>=0.29.18,<3.0",
+    "pybind11>=2.4.3,<2.7.0",
     "pythran>=0.9.11",
 
     # NumPy dependencies - to update these, sync from

--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -139,7 +139,7 @@ else:
     # In maintenance branch, change to np_maxversion N+3 if numpy is at N
     # See setup.py for more details
     np_minversion = '1.16.5'
-    np_maxversion = '9.9.99'
+    np_maxversion = '1.23.0'
     if (_pep440.parse(__numpy_version__) < _pep440.Version(np_minversion) or
             _pep440.parse(__numpy_version__) >= _pep440.Version(np_maxversion)):
         import warnings

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ MAJOR = 1
 MINOR = 7
 MICRO = 0
 ISRELEASED = False
-IS_RELEASE_BRANCH = False
+IS_RELEASE_BRANCH = True
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
 
@@ -547,7 +547,7 @@ def setup_package():
     #            in N+1 will turn into errors in N+3
     # For Python versions, if releases is (e.g.) <=3.9.x, set bound to 3.10
     np_minversion = '1.16.5'
-    np_maxversion = '9.9.99'
+    np_maxversion = '1.23.0'
     python_minversion = '3.7'
     python_maxversion = '3.10'
     if IS_RELEASE_BRANCH:


### PR DESCRIPTION
@rgommers Chances are this isn't quite right yet--it mostly borrows from the changes in the previous release branch, so maybe some versions can be slightly higher..