### PR TITLE
MAINT: commit count if no tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ def git_version():
         out = _minimal_ext_cmd(['git', 'rev-list', 'HEAD', prev_version_tag,
                                 '--count'])
         COMMIT_COUNT = out.strip().decode('ascii')
+        COMMIT_COUNT = '0' if not COMMIT_COUNT else COMMIT_COUNT
     except OSError:
         GIT_REVISION = "Unknown"
         COMMIT_COUNT = "Unknown"


### PR DESCRIPTION
Commit count is empty is the tag of the version does not exist.

This makes the CI fail as the the version metadata becomes invalid: `1.8.0.dev0+.8b5e5c8`

This PR would produce: `1.8.0.dev0+0.8b5e5c8`
 
Discussed here #14144