### PR TITLE
MAINT: 1.7.0 backports before rc1

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -53,7 +53,7 @@ jobs:
 
   test_nightly:
     name: Nightly CPython
-    if: "github.repository == 'scipy/scipy' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]') && !contains(github.ref, 'maintenance/')"
+    if: "github.repository == 'scipy/scipy' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]') && !contains(github.ref, 'maintenance/') && !contains(github.base_ref, 'maintenance/')"
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -147,6 +147,7 @@ scipy/integrate/vodemodule.c
 scipy/integrate/_dop-f2pywrappers.f
 scipy/integrate/lsoda-f2pywrappers.f
 scipy/integrate/vode-f2pywrappers.f
+scipy/interpolate/_rbfinterp_pythran.cpp
 scipy/interpolate/_ppoly.c
 scipy/interpolate/_bspl.c
 scipy/interpolate/interpnd.c

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,6 +56,7 @@ stages:
     AZURE_CI: 'true'
   jobs:
   - job: pre_release_deps_source_dist
+    condition: eq(System.PullRequest.TargetBranch, 'master')
     pool:
       vmImage: 'ubuntu-18.04'
     steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,7 +56,7 @@ stages:
     AZURE_CI: 'true'
   jobs:
   - job: pre_release_deps_source_dist
-    condition: eq(System.PullRequest.TargetBranch, 'master')
+    condition: eq(variables['System.PullRequest.TargetBranch'], 'master')
     pool:
       vmImage: 'ubuntu-18.04'
     steps:

--- a/doc/release/1.7.0-notes.rst
+++ b/doc/release/1.7.0-notes.rst
@@ -629,6 +629,7 @@ Issues closed for 1.7.0
 * `#14048 <https://github.com/scipy/scipy/issues/14048>`__: DOC: missing git submodule information
 * `#14055 <https://github.com/scipy/scipy/issues/14055>`__: linalg.solve: Unclear error when using assume_a='her' with real...
 * `#14093 <https://github.com/scipy/scipy/issues/14093>`__: DOC: Inconsistency in the definition of default values in the...
+* `#14158 <https://github.com/scipy/scipy/issues/14158>`__: TST, BUG: test_rbfinterp.py -- test_interpolation_misfit_1d fails...
 
 
 ***********************
@@ -1022,3 +1023,5 @@ Pull requests for 1.7.0
 * `#14139 <https://github.com/scipy/scipy/pull/14139>`__: FIX/DOC: lsqr doctests print failure
 * `#14145 <https://github.com/scipy/scipy/pull/14145>`__: MAINT: 1.7.x version pins ("backport")
 * `#14146 <https://github.com/scipy/scipy/pull/14146>`__: MAINT: commit count if no tag
+* `#14164 <https://github.com/scipy/scipy/pull/14164>`__: TST, BUG: fix rbf matrix value
+* `#14166 <https://github.com/scipy/scipy/pull/14166>`__: CI, MAINT: restrictions on pre-release CI

--- a/doc/release/1.7.0-notes.rst
+++ b/doc/release/1.7.0-notes.rst
@@ -612,6 +612,7 @@ Issues closed for 1.7.0
 * `#13793 <https://github.com/scipy/scipy/issues/13793>`__: CI: CircleCI doc build failure
 * `#13840 <https://github.com/scipy/scipy/issues/13840>`__: manylinux1 builds are failing because of C99 usage in \`special/_cosine.c\`
 * `#13850 <https://github.com/scipy/scipy/issues/13850>`__: CI: Homebrew is failing due to bintray
+* `#13875 <https://github.com/scipy/scipy/issues/13875>`__: BUG: chi2_contingency with Yates correction
 * `#13878 <https://github.com/scipy/scipy/issues/13878>`__: BUG: \`signal.get_window\` argument handling issue
 * `#13880 <https://github.com/scipy/scipy/issues/13880>`__: Remove all usages of numpy.compat
 * `#13896 <https://github.com/scipy/scipy/issues/13896>`__: Boschloo's Test for More Powerful Hypothesis Testing of 2x2 Contingency...
@@ -931,6 +932,7 @@ Pull requests for 1.7.0
 * `#13910 <https://github.com/scipy/scipy/pull/13910>`__: DOC: update Readme
 * `#13911 <https://github.com/scipy/scipy/pull/13911>`__: MAINT: use dict built-in rather than OrderedDict
 * `#13920 <https://github.com/scipy/scipy/pull/13920>`__: BUG: Reactivate conda environment in init
+* `#13925 <https://github.com/scipy/scipy/pull/13925>`__: BUG: stats: magnitude of Yates' correction <= abs(observed-expected)...
 * `#13926 <https://github.com/scipy/scipy/pull/13926>`__: DOC: correct return type in disjoint_set.subsets docstring
 * `#13927 <https://github.com/scipy/scipy/pull/13927>`__: DOC/MAINT: Add copyright notice to qmc.primes_from_2_to
 * `#13928 <https://github.com/scipy/scipy/pull/13928>`__: BUG: DOC: signal: fix need argument config and add missing doc...
@@ -1011,9 +1013,12 @@ Pull requests for 1.7.0
 * `#14110 <https://github.com/scipy/scipy/pull/14110>`__: DOC: mailmap update
 * `#14113 <https://github.com/scipy/scipy/pull/14113>`__: ENH: stats: bootstrap: add \`paired\` parameter
 * `#14116 <https://github.com/scipy/scipy/pull/14116>`__: MAINT: fix deprecated Python C API usage in odr
+* `#14118 <https://github.com/scipy/scipy/pull/14118>`__: DOC: 1.7.0 release notes
 * `#14125 <https://github.com/scipy/scipy/pull/14125>`__: DOC: fix typo
 * `#14126 <https://github.com/scipy/scipy/pull/14126>`__: ENH: stats: bootstrap: add \`batch\` parameter to control batch...
 * `#14127 <https://github.com/scipy/scipy/pull/14127>`__: CI: upgrade pip in benchmarks CI run
 * `#14130 <https://github.com/scipy/scipy/pull/14130>`__: BUG: Fix trust-constr report TypeError if verbose is set to 2...
 * `#14133 <https://github.com/scipy/scipy/pull/14133>`__: MAINT: interpolate: raise NotImplementedError not ValueError
 * `#14139 <https://github.com/scipy/scipy/pull/14139>`__: FIX/DOC: lsqr doctests print failure
+* `#14145 <https://github.com/scipy/scipy/pull/14145>`__: MAINT: 1.7.x version pins ("backport")
+* `#14146 <https://github.com/scipy/scipy/pull/14146>`__: MAINT: commit count if no tag

--- a/scipy/interpolate/tests/test_rbfinterp.py
+++ b/scipy/interpolate/tests/test_rbfinterp.py
@@ -200,7 +200,7 @@ class _TestRBFInterpolator:
 
         y = _1d_test_function(x)
         ytrue = _1d_test_function(xitp)
-        yitp = self.build(x, y, epsilon=0.6, kernel=kernel)(xitp)
+        yitp = self.build(x, y, epsilon=5.0, kernel=kernel)(xitp)
 
         mse = np.mean((yitp - ytrue)**2)
         assert mse < 1.0e-4

--- a/scipy/stats/contingency.py
+++ b/scipy/stats/contingency.py
@@ -288,7 +288,11 @@ def chi2_contingency(observed, correction=True, lambda_=None):
     else:
         if dof == 1 and correction:
             # Adjust `observed` according to Yates' correction for continuity.
-            observed = observed + 0.5 * np.sign(expected - observed)
+            # Magnitude of correction no bigger than difference; see gh-13875
+            diff = expected - observed
+            direction = np.sign(diff)
+            magnitude = np.minimum(0.5, np.abs(diff))
+            observed = observed + magnitude * direction
 
         chi2, p = power_divergence(observed, expected,
                                    ddof=observed.size - 1 - dof, axis=None,

--- a/scipy/stats/tests/test_contingency.py
+++ b/scipy/stats/tests/test_contingency.py
@@ -201,6 +201,14 @@ def test_chi2_contingency_bad_args():
     assert_raises(ValueError, chi2_contingency, obs)
 
 
+def test_chi2_contingency_yates_gh13875():
+    # Magnitude of Yates' continuity correction should not exceed difference
+    # between expected and observed value of the statistic; see gh-13875
+    observed = np.array([[1573, 3], [4, 0]])
+    p = chi2_contingency(observed)[1]
+    assert_allclose(p, 1, rtol=1e-12)
+
+
 def test_bad_association_args():
     # Invalid Test Statistic
     assert_raises(ValueError, association, [[1, 2], [3, 4]], "X")

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ def git_version():
         out = _minimal_ext_cmd(['git', 'rev-list', 'HEAD', prev_version_tag,
                                 '--count'])
         COMMIT_COUNT = out.strip().decode('ascii')
+        COMMIT_COUNT = '0' if not COMMIT_COUNT else COMMIT_COUNT
     except OSError:
         GIT_REVISION = "Unknown"
         COMMIT_COUNT = "Unknown"


### PR DESCRIPTION
I'll update the release notes/re-milestone things when this is otherwise ready to merge. Because of the long weekend here in the US I may try to bump `rc1` forward slightly from Saturday to early-mid next week instead of trying to rush it tonight.

Currently included:

- gh-14146
- gh-14164
- gh-14166 (not yet merged to `master`)
- gh-13925