### PR TITLE
ENH: Pythran implementation of _cdf_distance

### DIFF
--- a/scipy/stats/_cdf_distance_1d.py
+++ b/scipy/stats/_cdf_distance_1d.py
@@ -61,8 +61,8 @@ def _cdf_distance_1d(p, u_values, v_values, u_weights=None, v_weights=None):
 
     # Get the respective positions of the values of u and v among the values of
     # both distributions.
-    u_cdf_indices = np.searchsorted(u_values[u_sorter],all_values[:-1],'right')
-    v_cdf_indices = np.searchsorted(v_values[v_sorter],all_values[:-1],'right')
+    u_cdf_indices = np.searchsorted(u_values[u_sorter], all_values[:-1], 'right')
+    v_cdf_indices = np.searchsorted(v_values[v_sorter], all_values[:-1], 'right')
 
     # Calculate the CDFs of u and v using their weights, if specified.
     if u_weights is None:

--- a/scipy/stats/_cdf_distance_1d.py
+++ b/scipy/stats/_cdf_distance_1d.py
@@ -2,6 +2,8 @@ import numpy as np
 
 #pythran export _cdf_distance_1d(int, float[:], float[:])
 #pythran export _cdf_distance_1d(int, float[:], float[:], None, None)
+#pythran export _cdf_distance_1d(int, float[:], float[:], None, float[:])
+#pythran export _cdf_distance_1d(int, float[:], float[:], float[:], None)
 #pythran export _cdf_distance_1d(int, float[:], float[:], float[:], float[:])
 def _cdf_distance_1d(p, u_values, v_values, u_weights=None, v_weights=None):
     r"""

--- a/scipy/stats/_cdf_distance_1d.py
+++ b/scipy/stats/_cdf_distance_1d.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 #pythran export _cdf_distance_1d(int, float[:], float[:])
+#pythran export _cdf_distance_1d(int, float[:], float[:], None, None)
 #pythran export _cdf_distance_1d(int, float[:], float[:], float[:], float[:])
 def _cdf_distance_1d(p, u_values, v_values, u_weights=None, v_weights=None):
     r"""

--- a/scipy/stats/_cdf_distance_1d.py
+++ b/scipy/stats/_cdf_distance_1d.py
@@ -1,0 +1,87 @@
+import numpy as np
+
+#pythran export _cdf_distance_1d(int, float[:], float[:])
+#pythran export _cdf_distance_1d(int, float[:], float[:], float[:], float[:])
+def _cdf_distance_1d(p, u_values, v_values, u_weights=None, v_weights=None):
+    r"""
+    Compute, between two one-dimensional distributions :math:`u` and
+    :math:`v`, whose respective CDFs are :math:`U` and :math:`V`, the
+    statistical distance that is defined as:
+
+    .. math::
+
+        l_p(u, v) = \left( \int_{-\infty}^{+\infty} |U-V|^p \right)^{1/p}
+
+    p is a positive parameter; p = 1 gives the Wasserstein distance, p = 2
+    gives the energy distance.
+
+    Parameters
+    ----------
+    u_values, v_values : array_like
+        Values observed in the (empirical) distribution.
+    u_weights, v_weights : array_like, optional
+        Weight for each value. If unspecified, each value is assigned the same
+        weight.
+        `u_weights` (resp. `v_weights`) must have the same length as
+        `u_values` (resp. `v_values`). If the weight sum differs from 1, it
+        must still be positive and finite so that the weights can be normalized
+        to sum to 1.
+
+    Returns
+    -------
+    distance : float
+        The computed distance between the distributions.
+
+    Notes
+    -----
+    The input distributions can be empirical, therefore coming from samples
+    whose values are effectively inputs of the function, or they can be seen as
+    generalized functions, in which case they are weighted sums of Dirac delta
+    functions located at the specified values.
+
+    References
+    ----------
+    .. [1] Bellemare, Danihelka, Dabney, Mohamed, Lakshminarayanan, Hoyer,
+           Munos "The Cramer Distance as a Solution to Biased Wasserstein
+           Gradients" (2017). :arXiv:`1705.10743`.
+
+    """
+
+    u_sorter = np.argsort(u_values)
+    v_sorter = np.argsort(v_values)
+
+    all_values = np.concatenate((u_values, v_values))
+    all_values = np.sort(all_values, kind='mergesort')
+
+    # Compute the differences between pairs of successive values of u and v.
+    deltas = np.diff(all_values)
+
+    # Get the respective positions of the values of u and v among the values of
+    # both distributions.
+    u_cdf_indices = np.searchsorted(u_values[u_sorter],all_values[:-1],'right')
+    v_cdf_indices = np.searchsorted(v_values[v_sorter],all_values[:-1],'right')
+
+    # Calculate the CDFs of u and v using their weights, if specified.
+    if u_weights is None:
+        u_cdf = u_cdf_indices / u_values.size
+    else:
+        u_sorted_cumweights = np.concatenate(([0],
+                                              np.cumsum(u_weights[u_sorter])))
+        u_cdf = u_sorted_cumweights[u_cdf_indices] / u_sorted_cumweights[-1]
+
+    if v_weights is None:
+        v_cdf = v_cdf_indices / v_values.size
+    else:
+        v_sorted_cumweights = np.concatenate(([0],
+                                              np.cumsum(v_weights[v_sorter])))
+        v_cdf = v_sorted_cumweights[v_cdf_indices] / v_sorted_cumweights[-1]
+
+    # Compute the value of the integral based on the CDFs.
+    # If p = 1 or p = 2, we avoid using np.power, which introduces an overhead
+    # of about 15%.
+    if p == 1:
+        return np.sum(np.multiply(np.abs(u_cdf - v_cdf), deltas))
+    if p == 2:
+        return np.sqrt(np.sum(np.multiply(np.square(u_cdf - v_cdf), deltas)))
+    return np.power(np.sum(np.multiply(np.power(np.abs(u_cdf - v_cdf), p),
+                                       deltas)), 1/p)

--- a/scipy/stats/setup.py
+++ b/scipy/stats/setup.py
@@ -1,3 +1,4 @@
+import os
 from os.path import join
 from platform import system
 
@@ -82,6 +83,15 @@ def configuration(parent_package='', top_path=None):
 
     # Type stubs
     config.add_data_files('*.pyi')
+
+    # add _cdf_distance_1d module
+    if int(os.environ.get('SCIPY_USE_PYTHRAN', 1)):
+        import pythran
+        ext = pythran.dist.PythranExtension(
+            'scipy.stats._cdf_distance_1d',
+            sources=["scipy/stats/_cdf_distance_1d.py"],
+            config=['compiler.blas=none'])
+        config.ext_modules.append(ext)
 
     return config
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -47,6 +47,7 @@ from ._stats_mstats_common import (_find_repeats, linregress, theilslopes,
                                    siegelslopes)
 from ._stats import (_kendall_dis, _toint64, _weightedrankedtau,
                      _local_correlations)
+from ._cdf_distance_1d import _cdf_distance_1d
 from dataclasses import make_dataclass
 
 
@@ -8322,44 +8323,8 @@ def _cdf_distance(p, u_values, v_values, u_weights=None, v_weights=None):
     u_values, u_weights = _validate_distribution(u_values, u_weights)
     v_values, v_weights = _validate_distribution(v_values, v_weights)
 
-    u_sorter = np.argsort(u_values)
-    v_sorter = np.argsort(v_values)
-
-    all_values = np.concatenate((u_values, v_values))
-    all_values.sort(kind='mergesort')
-
-    # Compute the differences between pairs of successive values of u and v.
-    deltas = np.diff(all_values)
-
-    # Get the respective positions of the values of u and v among the values of
-    # both distributions.
-    u_cdf_indices = u_values[u_sorter].searchsorted(all_values[:-1], 'right')
-    v_cdf_indices = v_values[v_sorter].searchsorted(all_values[:-1], 'right')
-
-    # Calculate the CDFs of u and v using their weights, if specified.
-    if u_weights is None:
-        u_cdf = u_cdf_indices / u_values.size
-    else:
-        u_sorted_cumweights = np.concatenate(([0],
-                                              np.cumsum(u_weights[u_sorter])))
-        u_cdf = u_sorted_cumweights[u_cdf_indices] / u_sorted_cumweights[-1]
-
-    if v_weights is None:
-        v_cdf = v_cdf_indices / v_values.size
-    else:
-        v_sorted_cumweights = np.concatenate(([0],
-                                              np.cumsum(v_weights[v_sorter])))
-        v_cdf = v_sorted_cumweights[v_cdf_indices] / v_sorted_cumweights[-1]
-
-    # Compute the value of the integral based on the CDFs.
-    # If p = 1 or p = 2, we avoid using np.power, which introduces an overhead
-    # of about 15%.
-    if p == 1:
-        return np.sum(np.multiply(np.abs(u_cdf - v_cdf), deltas))
-    if p == 2:
-        return np.sqrt(np.sum(np.multiply(np.square(u_cdf - v_cdf), deltas)))
-    return np.power(np.sum(np.multiply(np.power(np.abs(u_cdf - v_cdf), p),
-                                       deltas)), 1/p)
+    return _cdf_distance_1d(p, u_values, v_values,
+                                      u_weights, v_weights)
 
 
 def _validate_distribution(values, weights):


### PR DESCRIPTION
#### What does this implement/fix?
Pythran implementation of _cdf_distance.

```
u_values, v_values = [0.7, 7.4, 2.4, 6.8], [1.4, 8. ] 
u_weights, v_weights = [2.1, 4.2, 7.4, 8. ], [7.6, 8.8]

u_values = np.asarray(u_values, dtype=float)
u_weights = np.asarray(u_weights, dtype=float)

v_values = np.asarray(v_values, dtype=float)
v_weights = np.asarray(v_weights, dtype=float)
```

The Pythran version:
```
%timeit -n 100 -r 3 _pythran_cdf_distance(1,u_values, v_values, u_weights, v_weights)
23.4 µs ± 8.47 µs per loop (mean ± std. dev. of 3 runs, 100 loops each)
```
The original version:
```
%timeit -n 100 -r 3 _orig_cdf_distance(1,u_values, v_values, u_weights, v_weights )
74.4 µs ± 23.9 µs per loop (mean ± std. dev. of 3 runs, 100 loops each)
```

3x speedup with a small array input.

#### I also rewrote some parts to support Pythran compilation

Rewrote `u_values[u_sorter].searchsort` to `np.searchsort` to avoid Pythran `AssertionError: Function path is chained attributes and name.`

Rewrote `all_values.sort(kind='mergesort')` to `np.sort(all_values, kind='mergesort')` to avoid Pythran compliation error.

cc @rgommers @serge-sans-paille 

