### PR TITLE
ENH: sparse.linalg: Add TFQMR algorithm for non-Hermitian sparse linear systems

### DIFF
--- a/scipy/sparse/linalg/__init__.py
+++ b/scipy/sparse/linalg/__init__.py
@@ -60,6 +60,7 @@ Iterative methods for linear equation systems:
    minres -- Use MINimum RESidual iteration to solve Ax = b
    qmr -- Use Quasi-Minimal Residual iteration to solve A x = b
    gcrotmk -- Solve a matrix equation using the GCROT(m,k) algorithm
+   tfqmr -- Use Transpose-Free Quasi-Minimal Residual iteration to solve A x = b
 
 Iterative methods for least-squares problems:
 

--- a/scipy/sparse/linalg/isolve/__init__.py
+++ b/scipy/sparse/linalg/isolve/__init__.py
@@ -7,6 +7,7 @@ from .lgmres import lgmres
 from .lsqr import lsqr
 from .lsmr import lsmr
 from ._gcrotmk import gcrotmk
+from .tfqmr import tfqmr
 
 __all__ = [s for s in dir() if not s.startswith('_')]
 

--- a/scipy/sparse/linalg/isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/isolve/tests/test_iterative.py
@@ -16,7 +16,7 @@ from scipy.linalg import norm
 from scipy.sparse import spdiags, csr_matrix, SparseEfficiencyWarning
 
 from scipy.sparse.linalg import LinearOperator, aslinearoperator
-from scipy.sparse.linalg.isolve import cg, cgs, bicg, bicgstab, gmres, qmr, minres, lgmres, gcrotmk
+from scipy.sparse.linalg.isolve import cg, cgs, bicg, bicgstab, gmres, qmr, minres, lgmres, gcrotmk, tfqmr
 
 # TODO check that method preserve shape and type
 # TODO test both preconditioner methods
@@ -46,7 +46,7 @@ class Case:
 class IterativeParams:
     def __init__(self):
         # list of tuples (solver, symmetric, positive_definite )
-        solvers = [cg, cgs, bicg, bicgstab, gmres, qmr, minres, lgmres, gcrotmk]
+        solvers = [cg, cgs, bicg, bicgstab, gmres, qmr, minres, lgmres, gcrotmk, tfqmr]
         sym_solvers = [minres, cg]
         posdef_solvers = [cg]
         real_solvers = [minres]
@@ -141,9 +141,9 @@ class IterativeParams:
         data[1,:] = -1
         A = spdiags(data, [0,-1], 10, 10, format='csr')
         self.cases.append(Case("nonsymposdef", A,
-                               skip=sym_solvers+[cgs, qmr, bicg]))
+                               skip=sym_solvers+[cgs, qmr, bicg, tfqmr]))
         self.cases.append(Case("nonsymposdef", A.astype('F'),
-                               skip=sym_solvers+[cgs, qmr, bicg]))
+                               skip=sym_solvers+[cgs, qmr, bicg, tfqmr]))
 
         # Symmetric, non-pd, hitting cgs/bicg/bicgstab/qmr breakdown
         A = np.array([[0, 0, 0, 0, 0, 1, -1, -0, -0, -0, -0],
@@ -161,7 +161,7 @@ class IterativeParams:
         assert (A == A.T).all()
         self.cases.append(Case("sym-nonpd", A, b,
                                skip=posdef_solvers,
-                               nonconvergence=[cgs,bicg,bicgstab,qmr]))
+                               nonconvergence=[cgs,bicg,bicgstab,qmr,tfqmr]))
 
 
 params = IterativeParams()
@@ -412,7 +412,7 @@ def test_atol(solver):
         assert_(err <= max(atol, atol2))
 
 
-@pytest.mark.parametrize("solver", [cg, cgs, bicg, bicgstab, gmres, qmr, minres, lgmres, gcrotmk])
+@pytest.mark.parametrize("solver", [cg, cgs, bicg, bicgstab, gmres, qmr, minres, lgmres, gcrotmk, tfqmr])
 def test_zero_rhs(solver):
     np.random.seed(1234)
     A = np.random.rand(10, 10)
@@ -457,7 +457,8 @@ def test_zero_rhs(solver):
     pytest.param(cgs, marks=pytest.mark.xfail),
     pytest.param(bicg, marks=pytest.mark.xfail),
     pytest.param(bicgstab, marks=pytest.mark.xfail),
-    pytest.param(gcrotmk, marks=pytest.mark.xfail)])
+    pytest.param(gcrotmk, marks=pytest.mark.xfail),
+    pytest.param(tfqmr, marks=pytest.mark.xfail)])
 def test_maxiter_worsening(solver):
     # Check error does not grow (boundlessly) with increasing maxiter.
     # This can occur due to the solvers hitting close to breakdown,
@@ -486,7 +487,7 @@ def test_maxiter_worsening(solver):
         assert_(error <= tol*best_error)
 
 
-@pytest.mark.parametrize("solver", [cg, cgs, bicg, bicgstab, gmres, qmr, minres, lgmres, gcrotmk])
+@pytest.mark.parametrize("solver", [cg, cgs, bicg, bicgstab, gmres, qmr, minres, lgmres, gcrotmk, tfqmr])
 def test_x0_working(solver):
     # Easy problem
     np.random.seed(1)

--- a/scipy/sparse/linalg/isolve/tfqmr.py
+++ b/scipy/sparse/linalg/isolve/tfqmr.py
@@ -94,10 +94,10 @@ def tfqmr(A, b, x0=None, tol=1e-5, maxiter=None, M=None,
 
     # Check data type
     dtype = A.dtype
-    if np.issubdtype(dtype, int):
+    if np.issubdtype(dtype, np.int64):
         dtype = float
         A = A.astype(dtype)
-        if np.issubdtype(b.dtype, int):
+        if np.issubdtype(b.dtype, np.int64):
             b = b.astype(dtype)
 
     A, M, x, b, postprocess = make_system(A, M, x0, b)

--- a/scipy/sparse/linalg/isolve/tfqmr.py
+++ b/scipy/sparse/linalg/isolve/tfqmr.py
@@ -130,7 +130,7 @@ def tfqmr(A, b, x0=None, tol=1e-5, maxiter=None, M=None,
     if atol is None:
         atol = tol * r0norm
     else:
-        atol = max(atol, tol*r0norm)
+        atol = max(atol, tol * r0norm)
 
     for iter in range(maxiter):
         even = iter%2 == 0
@@ -142,7 +142,7 @@ def tfqmr(A, b, x0=None, tol=1e-5, maxiter=None, M=None,
             alpha = rho / vtrstar
             uNext = u - alpha * v
         w -= alpha * uhat
-        d = u + (theta**2/alpha) * eta * d
+        d = u + (theta**2 / alpha) * eta * d
         theta = np.linalg.norm(w) / tau
         c = np.sqrt(1. / (1 + theta**2))
         tau *= theta * c

--- a/scipy/sparse/linalg/isolve/tfqmr.py
+++ b/scipy/sparse/linalg/isolve/tfqmr.py
@@ -1,0 +1,182 @@
+import warnings
+import numpy as np
+from .utils import make_system
+
+
+__all__ = ['tfqmr']
+
+
+def tfqmr(A, b, x0=None, tol=1e-5, maxiter=None, M=None,
+          callback=None, atol=None, view=False):
+    """
+    Use Transpose-Free Quasi-Minimal Residual iteration to solve ``Ax = b``.
+
+    Parameters
+    ----------
+    A : {sparse matrix, dense matrix, LinearOperator}
+        The real or complex N-by-N matrix of the linear system.
+        Alternatively, `A` can be a linear operator which can
+        produce ``Ax`` using, e.g.,
+        `scipy.sparse.linalg.LinearOperator`.
+    b : {array, matrix}
+        Right hand side of the linear system. Has shape (N,) or (N,1).
+    x0  : {array, matrix}
+        Starting guess for the solution.
+    tol, atol : float, optional
+        Tolerances for convergence, ``norm(residual) <= max(tol*norm(b-Ax0), atol)``.
+        The default for `tol` is 1.0e-5
+        The default for `atol` is ``tol * norm(b-Ax0)``.
+
+        .. warning::
+
+           The default value for `atol` will be changed in a future release.
+           For future compatibility, specify `atol` explicitly.
+    maxiter : int, optional
+        Maximum number of iterations.  Iteration will stop after maxiter
+        steps even if the specified tolerance has not been achieved.
+    M : {sparse matrix, dense matrix, LinearOperator}
+        Inverse of the preconditioner of A.  M should approximate the
+        inverse of A and be easy to solve for (see Notes).  Effective
+        preconditioning dramatically improves the rate of convergence,
+        which implies that fewer iterations are needed to reach a given
+        error tolerance.  By default, no preconditioner is used.
+    callback : function, optional
+        User-supplied function to call after each iteration.  It is called
+        as `callback(xk)`, where `xk` is the current solution vector.
+    view : bool, optional
+        Specify ``view = True`` to view the convergence, ``view = False`` is
+        to close the output of the convergence.
+        Default is `False`
+
+    Returns
+    -------
+    x : array or matrix
+        The converged solution.
+    info : int
+        Provides convergence information:
+
+            - 0  : successful exit
+            - >0 : convergence to tolerance not achieved, number of iterations
+            - <0 : illegal input or breakdown
+
+    Notes
+    -----
+    The Transpose-Free QMR algorithm is derived from the CGS algorithm.
+    However, unlike CGS, the convergence curves for the TFQMR method is
+    smoothed by computing a quasi minimization of the residual norm. The
+    implementation supports left preconditioner, and the "residual norm"
+    to compute in convergence criterion is actually an upper bound on the
+    actual residual norm ``||b - Axk||``.
+
+    References
+    ----------
+    .. [1] R. W. Freund, A Transpose-Free Quasi-Minimal Residual Algorithm for
+           Non-Hermitian Linear Systems, SIAM J. Sci. Comput., 14(2), 470-482,
+           1993.
+    .. [2] Y. Saad, Iterative Methods for Sparse Linear Systems, 2nd edition,
+           SIAM, Philadelphia, 2003.
+    .. [3] C. T. Kelley, Iterative Methods for Linear and Nonlinear Equations,
+           number 16 in Frontiers in Applied Mathematics, SIAM, Philadelphia,
+           1995.
+
+    Examples
+    --------
+    >>> from scipy.sparse import csc_matrix
+    >>> from scipy.sparse.linalg import tfqmr
+    >>> A = csc_matrix([[3, 2, 0], [1, -1, 0], [0, 5, 1]], dtype=float)
+    >>> b = np.array([2, 4, -1], dtype=float)
+    >>> x, exitCode = tfqmr(A, b)
+    >>> print(exitCode)            # 0 indicates successful convergence
+    0
+    >>> np.allclose(A.dot(x), b)
+    True
+    """
+
+    # Check data type
+    dtype = A.dtype
+    if dtype == int:
+        dtype = float
+        A = A.astype(dtype)
+        if b.dtype == int:
+            b = b.astype(dtype)
+
+    A, M, x, b, postprocess = make_system(A, M, x0, b)
+
+    # Check if the R.H.S is a zero vector
+    if np.linalg.norm(b) == 0.:
+        x = b.copy()
+        return (postprocess(x), 0)
+
+    ndofs = A.shape[0]
+    if maxiter is None:
+        maxiter = min(10000, ndofs*10)
+    if x0 is None:
+        x0 = x.copy()
+
+    u = r = b - A.matvec(x)
+    w = r.copy()
+    # Take rstar as r
+    rstar = r
+    v = M.matvec(A.matvec(r))
+    uhat = v
+    d = theta = eta = 0.
+    rho = np.inner(rstar.conjugate(), r)
+    rhoLast = rho
+    r0norm = np.sqrt(rho)
+    tau = r0norm
+    if r0norm == 0:
+        return (postprocess(x), 0)
+
+    if atol is None:
+        warnings.warn("scipy.sparse.linalg.tfqmr called without specifying `atol`. "
+                      "The default value will change in the future. To preserve "
+                      "current behavior, set ``atol=tol*r0norm``.",
+                      category=DeprecationWarning, stacklevel=2)
+        atol = tol * r0norm
+    else:
+        atol = max(atol, tol*r0norm)
+
+    for iter in range(maxiter):
+        even = iter%2 == 0
+        if (even):
+            vtrstar = np.inner(rstar.conjugate(), v)
+            # Check breakdown
+            if vtrstar == 0.:
+                return (postprocess(x), -1)
+            alpha = rho / vtrstar
+            uNext = u - alpha * v
+        w -= alpha * uhat
+        d = u + (theta**2/alpha) * eta * d
+        theta = np.linalg.norm(w) / tau
+        c = np.sqrt(1. / (1 + theta**2))
+        tau *= theta * c
+        eta = (c**2) * alpha
+        z = M.matvec(d)
+        x += eta * z
+
+        if callback is not None:
+            callback(x)
+
+        # Convergence criteron
+        if tau * np.sqrt(iter+1) < atol:
+            if (view):
+                print("TFQMR: Linear solve converged due to reach TOL "
+                      "iterations {}".format(iter+1))
+            return (postprocess(x), 0)
+
+        if (not even):
+            rho = np.inner(rstar.conjugate(), w)
+            beta = rho / rhoLast
+            u = w + beta * u
+            v = beta * uhat + (beta**2) * v
+            uhat = M.matvec(A.matvec(u))
+            v += uhat
+        else:
+            uhat = M.matvec(A.matvec(uNext))
+            u = uNext
+            rhoLast = rho
+
+    if (view):
+        print("TFQMR: Linear solve not converged due to reach MAXIT "
+              "iterations {}".format(iter+1))
+    return (postprocess(x), maxiter)

--- a/scipy/sparse/linalg/isolve/tfqmr.py
+++ b/scipy/sparse/linalg/isolve/tfqmr.py
@@ -115,7 +115,7 @@ def tfqmr(A, b, x0=None, tol=1e-5, maxiter=None, M=None,
 
     u = r = b - A.matvec(x)
     w = r.copy()
-    # Let rstar equals b - Ax0, that is rstar := r = b - Ax0 mathematically
+    # Take rstar as b - Ax0, that is rstar := r = b - Ax0 mathematically
     rstar = r
     v = M.matvec(A.matvec(r))
     uhat = v
@@ -140,12 +140,14 @@ def tfqmr(A, b, x0=None, tol=1e-5, maxiter=None, M=None,
             if vtrstar == 0.:
                 return (postprocess(x), -1)
             alpha = rho / vtrstar
-            uNext = u - alpha * v
-        w -= alpha * uhat
-        d = u + (theta**2 / alpha) * eta * d
+            uNext = u - alpha * v  # [1]-(5.6)
+        w -= alpha * uhat  # [1]-(5.8)
+        d = u + (theta**2 / alpha) * eta * d  # [1]-(5.5)
+        # [1]-(5.2)
         theta = np.linalg.norm(w) / tau
         c = np.sqrt(1. / (1 + theta**2))
         tau *= theta * c
+        # Calculate step and direction [1]-(5.4)
         eta = (c**2) * alpha
         z = M.matvec(d)
         x += eta * z
@@ -161,6 +163,7 @@ def tfqmr(A, b, x0=None, tol=1e-5, maxiter=None, M=None,
             return (postprocess(x), 0)
 
         if (not even):
+            # [1]-(5.7)
             rho = np.inner(rstar.conjugate(), w)
             beta = rho / rhoLast
             u = w + beta * u

--- a/scipy/sparse/linalg/isolve/tfqmr.py
+++ b/scipy/sparse/linalg/isolve/tfqmr.py
@@ -7,20 +7,20 @@ __all__ = ['tfqmr']
 
 
 def tfqmr(A, b, x0=None, tol=1e-5, maxiter=None, M=None,
-          callback=None, atol=None, view=False):
+          callback=None, atol=None, show=False):
     """
     Use Transpose-Free Quasi-Minimal Residual iteration to solve ``Ax = b``.
 
     Parameters
     ----------
-    A : {sparse matrix, dense matrix, LinearOperator}
+    A : {sparse matrix, ndarray, LinearOperator}
         The real or complex N-by-N matrix of the linear system.
         Alternatively, `A` can be a linear operator which can
         produce ``Ax`` using, e.g.,
         `scipy.sparse.linalg.LinearOperator`.
-    b : {array, matrix}
+    b : {ndarray}
         Right hand side of the linear system. Has shape (N,) or (N,1).
-    x0  : {array, matrix}
+    x0 : {ndarray}
         Starting guess for the solution.
     tol, atol : float, optional
         Tolerances for convergence, ``norm(residual) <= max(tol*norm(b-Ax0), atol)``.
@@ -34,7 +34,7 @@ def tfqmr(A, b, x0=None, tol=1e-5, maxiter=None, M=None,
     maxiter : int, optional
         Maximum number of iterations.  Iteration will stop after maxiter
         steps even if the specified tolerance has not been achieved.
-    M : {sparse matrix, dense matrix, LinearOperator}
+    M : {sparse matrix, ndarray, LinearOperator}
         Inverse of the preconditioner of A.  M should approximate the
         inverse of A and be easy to solve for (see Notes).  Effective
         preconditioning dramatically improves the rate of convergence,
@@ -43,14 +43,14 @@ def tfqmr(A, b, x0=None, tol=1e-5, maxiter=None, M=None,
     callback : function, optional
         User-supplied function to call after each iteration.  It is called
         as `callback(xk)`, where `xk` is the current solution vector.
-    view : bool, optional
-        Specify ``view = True`` to view the convergence, ``view = False`` is
+    show : bool, optional
+        Specify ``show = True`` to show the convergence, ``show = False`` is
         to close the output of the convergence.
         Default is `False`
 
     Returns
     -------
-    x : array or matrix
+    x : ndarray
         The converged solution.
     info : int
         Provides convergence information:
@@ -94,10 +94,10 @@ def tfqmr(A, b, x0=None, tol=1e-5, maxiter=None, M=None,
 
     # Check data type
     dtype = A.dtype
-    if dtype == int:
+    if np.issubdtype(dtype, int):
         dtype = float
         A = A.astype(dtype)
-        if b.dtype == int:
+        if np.issubdtype(b.dtype, int):
             b = b.astype(dtype)
 
     A, M, x, b, postprocess = make_system(A, M, x0, b)
@@ -128,10 +128,6 @@ def tfqmr(A, b, x0=None, tol=1e-5, maxiter=None, M=None,
         return (postprocess(x), 0)
 
     if atol is None:
-        warnings.warn("scipy.sparse.linalg.tfqmr called without specifying `atol`. "
-                      "The default value will change in the future. To preserve "
-                      "current behavior, set ``atol=tol*r0norm``.",
-                      category=DeprecationWarning, stacklevel=2)
         atol = tol * r0norm
     else:
         atol = max(atol, tol*r0norm)
@@ -159,7 +155,7 @@ def tfqmr(A, b, x0=None, tol=1e-5, maxiter=None, M=None,
 
         # Convergence criteron
         if tau * np.sqrt(iter+1) < atol:
-            if (view):
+            if (show):
                 print("TFQMR: Linear solve converged due to reach TOL "
                       "iterations {}".format(iter+1))
             return (postprocess(x), 0)
@@ -176,7 +172,7 @@ def tfqmr(A, b, x0=None, tol=1e-5, maxiter=None, M=None,
             u = uNext
             rhoLast = rho
 
-    if (view):
+    if (show):
         print("TFQMR: Linear solve not converged due to reach MAXIT "
               "iterations {}".format(iter+1))
     return (postprocess(x), maxiter)

--- a/scipy/sparse/linalg/isolve/tfqmr.py
+++ b/scipy/sparse/linalg/isolve/tfqmr.py
@@ -1,4 +1,3 @@
-import warnings
 import numpy as np
 from .utils import make_system
 
@@ -24,7 +23,7 @@ def tfqmr(A, b, x0=None, tol=1e-5, maxiter=None, M=None,
         Starting guess for the solution.
     tol, atol : float, optional
         Tolerances for convergence, ``norm(residual) <= max(tol*norm(b-Ax0), atol)``.
-        The default for `tol` is 1.0e-5
+        The default for `tol` is 1.0e-5.
         The default for `atol` is ``tol * norm(b-Ax0)``.
 
         .. warning::
@@ -34,6 +33,7 @@ def tfqmr(A, b, x0=None, tol=1e-5, maxiter=None, M=None,
     maxiter : int, optional
         Maximum number of iterations.  Iteration will stop after maxiter
         steps even if the specified tolerance has not been achieved.
+        Default is ``min(10000, ndofs * 10)``, where ``ndofs = A.shape[0]``.
     M : {sparse matrix, ndarray, LinearOperator}
         Inverse of the preconditioner of A.  M should approximate the
         inverse of A and be easy to solve for (see Notes).  Effective
@@ -46,7 +46,7 @@ def tfqmr(A, b, x0=None, tol=1e-5, maxiter=None, M=None,
     show : bool, optional
         Specify ``show = True`` to show the convergence, ``show = False`` is
         to close the output of the convergence.
-        Default is `False`
+        Default is `False`.
 
     Returns
     -------
@@ -97,8 +97,8 @@ def tfqmr(A, b, x0=None, tol=1e-5, maxiter=None, M=None,
     if np.issubdtype(dtype, np.int64):
         dtype = float
         A = A.astype(dtype)
-        if np.issubdtype(b.dtype, np.int64):
-            b = b.astype(dtype)
+    if np.issubdtype(b.dtype, np.int64):
+        b = b.astype(dtype)
 
     A, M, x, b, postprocess = make_system(A, M, x0, b)
 
@@ -109,13 +109,13 @@ def tfqmr(A, b, x0=None, tol=1e-5, maxiter=None, M=None,
 
     ndofs = A.shape[0]
     if maxiter is None:
-        maxiter = min(10000, ndofs*10)
+        maxiter = min(10000, ndofs * 10)
     if x0 is None:
         x0 = x.copy()
 
     u = r = b - A.matvec(x)
     w = r.copy()
-    # Take rstar as r
+    # Let rstar equals b - Ax0, that is rstar := r = b - Ax0 mathematically
     rstar = r
     v = M.matvec(A.matvec(r))
     uhat = v
@@ -133,7 +133,7 @@ def tfqmr(A, b, x0=None, tol=1e-5, maxiter=None, M=None,
         atol = max(atol, tol * r0norm)
 
     for iter in range(maxiter):
-        even = iter%2 == 0
+        even = iter % 2 == 0
         if (even):
             vtrstar = np.inner(rstar.conjugate(), v)
             # Check breakdown


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

<!--Please explain your changes.-->
This PR creates a new file `tfqmr.py` in the directory `scipy/sparse/linalg/isolve/` and adds the Transpose-Free Quasi-Minimal Residual (TFQMR) algorithm for solving general nonsingular non-Hermitian linear systems. Tests for the algorithm has been added to `test_iterative.py`

#### Additional information
<!--Any additional information you think is important.-->
The Transpose-Free QMR algorithm is derived from the CGS algorithm. However, unlike CGS, the convergence curves for the TFQMR method is smoothed by computing a quasi minimization. This leads to a smooth convergence history.

**References:**
[1] R. W. Freund, A Transpose-Free Quasi-Minimal Residual Algorithm for Non-Hermitian Linear Systems, SIAM J. Sci. Comput., 14(2), 470-482, 1993.
[2] Y. Saad, Iterative Methods for Sparse Linear Systems, 2nd edition, SIAM, Philadelphia, 2003.
[3] C. T. Kelley, Iterative Methods for Linear and Nonlinear Equations, number 16 in Frontiers in Applied Mathematics, SIAM, Philadelphia, 1995.





