### PR TITLE
TST, BUG: fix rbf matrix value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,6 +147,7 @@ scipy/integrate/vodemodule.c
 scipy/integrate/_dop-f2pywrappers.f
 scipy/integrate/lsoda-f2pywrappers.f
 scipy/integrate/vode-f2pywrappers.f
+scipy/interpolate/_rbfinterp_pythran.cpp
 scipy/interpolate/_ppoly.c
 scipy/interpolate/_bspl.c
 scipy/interpolate/interpnd.c

--- a/scipy/interpolate/tests/test_rbfinterp.py
+++ b/scipy/interpolate/tests/test_rbfinterp.py
@@ -200,7 +200,7 @@ class _TestRBFInterpolator:
 
         y = _1d_test_function(x)
         ytrue = _1d_test_function(xitp)
-        yitp = self.build(x, y, epsilon=0.6, kernel=kernel)(xitp)
+        yitp = self.build(x, y, epsilon=5.0, kernel=kernel)(xitp)
 
         mse = np.mean((yitp - ytrue)**2)
         assert mse < 1.0e-4


### PR DESCRIPTION
Fixes #14158 ; this is basically the patch suggested by @treverhines 

* fix an ill-conditioned matrix causing regular test failures
on MacOS (locally) and on Windows (sporadically) for
`test_interpolation_misfit_1d()` with the `gaussian` and
`inverse_multiquadric` kernels, respectively

* I've tested the fix locally on MacOS to produce 20 failures
before (on `master`) and no failures after with a `pytest-repeat` run of
the problem test with:
`python runtests.py -v -t "scipy.interpolate.tests.test_rbfinterp::TestRBFInterpolatorNeighbors20::test_interpolation_misfit_1d" -- --count=20`

* so on my Mac master produces `20 failed, 140 passed in 1.54s` and this
feature branch produces `160 passed in 1.09s`

* I'm still fiddling with using `pytest-repeat` to probe the issue
on Windows, although if the fix is that decisive on MacOS for
one kernel we may have enough confidence to move forward with
such a small test-only patch anyway

* also, added a related file to `.gitignore`; I'm assuming
this is the normal way pythran names/generates CPP files