### PR TITLE
CI, MAINT: restrictions on pre-release CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -53,7 +53,7 @@ jobs:
 
   test_nightly:
     name: Nightly CPython
-    if: "github.repository == 'scipy/scipy' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]') && !contains(github.ref, 'maintenance/')"
+    if: "github.repository == 'scipy/scipy' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]') && !contains(github.ref, 'maintenance/') && !contains(github.base_ref, 'maintenance/')"
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,6 +56,7 @@ stages:
     AZURE_CI: 'true'
   jobs:
   - job: pre_release_deps_source_dist
+    condition: eq(System.PullRequest.TargetBranch, 'master')
     pool:
       vmImage: 'ubuntu-18.04'
     steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,7 +56,7 @@ stages:
     AZURE_CI: 'true'
   jobs:
   - job: pre_release_deps_source_dist
-    condition: eq(System.PullRequest.TargetBranch, 'master')
+    condition: eq(variables['System.PullRequest.TargetBranch'], 'master')
     pool:
       vmImage: 'ubuntu-18.04'
     steps:


### PR DESCRIPTION
* pre-release builds are currently causing a series of
CI test failures on both `master` and backport PRs (like
this one: https://github.com/scipy/scipy/pull/14148)

* for the specific case of `maintenance/` branch-targeted
backports, the changes suggested here aim to prevent
the pre-release checks from running on release branch PRs
on the basis that they will inevitably break in non-relevant
ways (unsupported Python versions, transient NumPy nightly
issues, etc.--I believe it may actually be latest NumPy
in this case since Python 3.7 pre-rel has similar failures
to Python 3.10)

* I'll probably try backporting this fix directly
in the above PR as the "real test" that the skips
actually work now..