### PR TITLE
replace `np.isclose` for pivot selection warning

### DIFF
--- a/scipy/optimize/_linprog_simplex.py
+++ b/scipy/optimize/_linprog_simplex.py
@@ -217,7 +217,7 @@ def _apply_pivot(T, basis, pivrow, pivcol, tol=1e-9):
             T[irow] = T[irow] - T[pivrow] * T[irow, pivcol]
 
     # The selected pivot should never lead to a pivot value less than the tol.
-    if np.isclose(pivval, tol, atol=0, rtol=1e4):
+    if np.abs(pivval) <= tol * 1e4:
         message = (
             "The pivot operation produces a pivot value of:{0: .1e}, "
             "which is only slightly greater than the specified "


### PR DESCRIPTION
#### Reference issue

Closes #14081

#### What does this implement/fix?

This replaces `numpy.isclose` in 

https://github.com/scipy/scipy/blob/0617428d9fb1d57fe8b0808291818e61b00efdbf/scipy/optimize/_linprog_simplex.py#L219-L229

since it relies on the asymmetric definition. Using `np.isclose(tol, pivval)` leads to a lot of false positives, since `rtol` is applied to the second argument.


The change communicates the intent better and might also be safer in edge-cases.


