### PR TITLE
BUG: Fixed an issue wherein `geometric_slerp` would return an incorrect shape/type for degenerate inputs

### DIFF
--- a/scipy/spatial/_geometric_slerp.py
+++ b/scipy/spatial/_geometric_slerp.py
@@ -193,7 +193,7 @@ def geometric_slerp(start,
 
     # Ensure that the output is broadcasted to the correct shape
     if np.array_equal(start, end):
-        shape = t.shape + start.shape
+        shape = (t.size,) + start.shape
         return np.full(shape, start)
 
     # for points that violate equation for n-sphere

--- a/scipy/spatial/_geometric_slerp.py
+++ b/scipy/spatial/_geometric_slerp.py
@@ -170,7 +170,6 @@ def geometric_slerp(start,
 
     start = np.asarray(start, dtype=np.float64)
     end = np.asarray(end, dtype=np.float64)
-    t = np.asarray(t, dtype=np.float64)
 
     if start.ndim != 1 or end.ndim != 1:
         raise ValueError("Start and end coordinates "
@@ -185,16 +184,8 @@ def geometric_slerp(start,
                          "both be in at least two-dimensional "
                          "space")
 
-    if t.size == 0:
-        return np.empty((0, start.size))
-
-    if t.min() < 0 or t.max() > 1:
-        raise ValueError("interpolation parameter must be in [0, 1]")
-
-    # Ensure that the output is broadcasted to the correct shape
     if np.array_equal(start, end):
-        shape = (t.size,) + start.shape
-        return np.full(shape, start)
+        return np.linspace(start, start, np.asarray(t).size)
 
     # for points that violate equation for n-sphere
     for coord in [start, end]:
@@ -217,6 +208,14 @@ def geometric_slerp(start,
         warnings.warn("start and end are antipodes"
                       " using the specified tolerance;"
                       " this may cause ambiguous slerp paths")
+
+    t = np.asarray(t, dtype=np.float64)
+
+    if t.size == 0:
+        return np.empty((0, start.size))
+
+    if t.min() < 0 or t.max() > 1:
+        raise ValueError("interpolation parameter must be in [0, 1]")
 
     if t.ndim == 0:
         return _geometric_slerp(start,

--- a/scipy/spatial/_geometric_slerp.py
+++ b/scipy/spatial/_geometric_slerp.py
@@ -170,6 +170,7 @@ def geometric_slerp(start,
 
     start = np.asarray(start, dtype=np.float64)
     end = np.asarray(end, dtype=np.float64)
+    t = np.asarray(t, dtype=np.float64)
 
     if start.ndim != 1 or end.ndim != 1:
         raise ValueError("Start and end coordinates "
@@ -184,8 +185,16 @@ def geometric_slerp(start,
                          "both be in at least two-dimensional "
                          "space")
 
+    if t.size == 0:
+        return np.empty((0, start.size))
+
+    if t.min() < 0 or t.max() > 1:
+        raise ValueError("interpolation parameter must be in [0, 1]")
+
+    # Ensure that the output is broadcasted to the correct shape
     if np.array_equal(start, end):
-        return [start] * np.asarray(t).size
+        shape = t.shape + start.shape
+        return np.full(shape, start)
 
     # for points that violate equation for n-sphere
     for coord in [start, end]:
@@ -208,14 +217,6 @@ def geometric_slerp(start,
         warnings.warn("start and end are antipodes"
                       " using the specified tolerance;"
                       " this may cause ambiguous slerp paths")
-
-    t = np.asarray(t, dtype=np.float64)
-
-    if t.size == 0:
-        return np.empty((0, start.size))
-
-    if t.min() < 0 or t.max() > 1:
-        raise ValueError("interpolation parameter must be in [0, 1]")
 
     if t.ndim == 0:
         return _geometric_slerp(start,

--- a/scipy/spatial/tests/test_slerp.py
+++ b/scipy/spatial/tests/test_slerp.py
@@ -363,15 +363,15 @@ class TestGeometricSlerp:
         np.linspace(0, 1, 5),
     ])
     def test_degenerate_input(self, start, t):
-        shape = t.shape + start.shape
+        shape = (t.size,) + start.shape
         expected = np.full(shape, start)
 
         actual = geometric_slerp(start=start, end=start, t=t)
         assert_allclose(actual, expected)
 
-        # Check that degenerate and non-degenerate inputs yield the same shape
+        # Check that degenerate and non-degenerate inputs yield the same size
         non_degenerate = geometric_slerp(start=start, end=start[::-1], t=t)
-        assert actual.shape == non_degenerate.shape
+        assert actual.size == non_degenerate.size
 
     @pytest.mark.parametrize('k', np.logspace(-10, -1, 10))
     def test_numerical_stability_pi(self, k):

--- a/scipy/spatial/tests/test_slerp.py
+++ b/scipy/spatial/tests/test_slerp.py
@@ -353,15 +353,25 @@ class TestGeometricSlerp:
     @pytest.mark.parametrize('start', [
         np.array([1, 0, 0]),
         np.array([0, 1]),
-        ])
-    def test_degenerate_input(self, start):
-        # handle start == end with repeated value
-        # like np.linspace
-        expected = [start] * 5
-        actual = geometric_slerp(start=start,
-                                 end=start,
-                                 t=np.linspace(0, 1, 5))
+    ])
+    @pytest.mark.parametrize('t', [
+        np.array(1),
+        np.array([1]),
+        np.array([[1]]),
+        np.array([[[1]]]),
+        np.array([]),
+        np.linspace(0, 1, 5),
+    ])
+    def test_degenerate_input(self, start, t):
+        shape = t.shape + start.shape
+        expected = np.full(shape, start)
+
+        actual = geometric_slerp(start=start, end=start, t=t)
         assert_allclose(actual, expected)
+
+        # Check that degenerate and non-degenerate inputs yield the same shape
+        non_degenerate = geometric_slerp(start=start, end=start[::-1], t=t)
+        assert actual.shape == non_degenerate.shape
 
     @pytest.mark.parametrize('k', np.logspace(-10, -1, 10))
     def test_numerical_stability_pi(self, k):


### PR DESCRIPTION
#### Reference issue
n.a.

#### What does this implement/fix?
Whenever the `start` and `end` parameters of `geometric_slerp` were degenerate, the function would previously return a list of length `t.size` filled with views of `start`.

There are a number of problems with this approach:
* It completely ignores the shape of `t`; this code-path thus ignores any broadcasting that would otherwise occur.
* All of a sudden a list is returned where one would expect an array.
* All list elements were, in fact, the very same array, potentially the same array the user previously passed as input. 
  This an excellent way for unexpected bugs to sneak into user code.

#### Additional information
The behavior prior to this PR:
``` python
In [1]: from scipy.spatial import geometric_slerp

In [2]: geometric_slerp([0, 1], [0, 1], t=[0, 0.5])  # degenerate `start` and `end`
Out[2]: [array([0., 1.]), array([0., 1.])]

In [3]: geometric_slerp([0, 1], [1, 0], t=[0, 0.5])  # non-degenerate
Out[3]:
array([[0.        , 1.        ],
       [0.70710678, 0.70710678]])
```