### PR TITLE
MAINT: stats: Update ppcc_plot and ppcc_max docstring.

### DIFF
--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -679,9 +679,9 @@ def ppcc_max(x, brack=(0.0, 1.0), dist='tukeylambda'):
 
     >>> from scipy import stats
     >>> import matplotlib.pyplot as plt
-    >>> rng = np.random.default_rng(1234567)
+    >>> rng = np.random.default_rng()
     >>> c = 2.5
-    >>> x = stats.weibull_min.rvs(c, scale=4, size=500, random_state=rng)
+    >>> x = stats.weibull_min.rvs(c, scale=4, size=2000, random_state=rng)
 
     Generate the PPCC plot for this data with the Weibull distribution.
 
@@ -693,8 +693,6 @@ def ppcc_max(x, brack=(0.0, 1.0), dist='tukeylambda'):
     point in the PPCC graph.
 
     >>> cmax = stats.ppcc_max(x, brack=(c/2, 2*c), dist='weibull_min')
-    >>> print(cmax)
-    2.4937451834924382
     >>> ax.axvline(cmax, color='r')
     >>> plt.show()
 
@@ -773,9 +771,9 @@ def ppcc_plot(x, a, b, dist='tukeylambda', plot=None, N=80):
 
     >>> from scipy import stats
     >>> import matplotlib.pyplot as plt
-    >>> rng = np.random.default_rng(1234567)
+    >>> rng = np.random.default_rng()
     >>> c = 2.5
-    >>> x = stats.weibull_min.rvs(c, scale=4, size=500, random_state=rng)
+    >>> x = stats.weibull_min.rvs(c, scale=4, size=2000, random_state=rng)
 
     Take a look at the histogram of the data.
 

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -630,11 +630,11 @@ def probplot(x, sparams=(), dist='norm', fit=True, plot=None, rvalue=False):
 def ppcc_max(x, brack=(0.0, 1.0), dist='tukeylambda'):
     """Calculate the shape parameter that maximizes the PPCC.
 
-    The probability plot correlation coefficient (PPCC) plot can be used to
-    determine the optimal shape parameter for a one-parameter family of
-    distributions.  ppcc_max returns the shape parameter that would maximize the
-    probability plot correlation coefficient for the given data to a
-    one-parameter family of distributions.
+    The probability plot correlation coefficient (PPCC) plot can be used
+    to determine the optimal shape parameter for a one-parameter family
+    of distributions. ``ppcc_max`` returns the shape parameter that would
+    maximize the probability plot correlation coefficient for the given
+    data to a one-parameter family of distributions.
 
     Parameters
     ----------
@@ -667,37 +667,35 @@ def ppcc_max(x, brack=(0.0, 1.0), dist='tukeylambda'):
 
     References
     ----------
-    .. [1] J.J. Filliben, "The Probability Plot Correlation Coefficient Test for
-           Normality", Technometrics, Vol. 17, pp. 111-117, 1975.
-
-    .. [2] https://www.itl.nist.gov/div898/handbook/eda/section3/ppccplot.htm
+    .. [1] J.J. Filliben, "The Probability Plot Correlation Coefficient Test
+           for Normality", Technometrics, Vol. 17, pp. 111-117, 1975.
+    .. [2] Engineering Statistics Handbook, NIST/SEMATEC,
+           https://www.itl.nist.gov/div898/handbook/eda/section3/ppccplot.htm
 
     Examples
     --------
-    First we generate some random data from a Tukey-Lambda distribution,
-    with shape parameter -0.7:
+    First we generate some random data from a Weibull distribution
+    with shape parameter 2.5:
 
     >>> from scipy import stats
-    >>> x = stats.tukeylambda.rvs(-0.7, loc=2, scale=0.5, size=10000,
-    ...                           random_state=1234567) + 1e4
-
-    Now we explore this data with a PPCC plot as well as the related
-    probability plot and Box-Cox normplot.  A red line is drawn where we
-    expect the PPCC value to be maximal (at the shape parameter -0.7 used
-    above):
-
     >>> import matplotlib.pyplot as plt
-    >>> fig = plt.figure(figsize=(8, 6))
-    >>> ax = fig.add_subplot(111)
-    >>> res = stats.ppcc_plot(x, -5, 5, plot=ax)
+    >>> rng = np.random.default_rng(1234567)
+    >>> c = 2.5
+    >>> x = stats.weibull_min.rvs(c, scale=4, size=500, random_state=rng)
 
-    We calculate the value where the shape should reach its maximum and a red
-    line is drawn there. The line should coincide with the highest point in the
-    ppcc_plot.
+    Generate the PPCC plot for this data with the Weibull distribution.
 
-    >>> max = stats.ppcc_max(x)
-    >>> ax.vlines(max, 0, 1, colors='r', label='Expected shape value')
+    >>> fig, ax = plt.subplots(figsize=(8, 6))
+    >>> res = stats.ppcc_plot(x, c/2, 2*c, dist='weibull_min', plot=ax)
 
+    We calculate the value where the shape should reach its maximum and a
+    red line is drawn there. The line should coincide with the highest
+    point in the PPCC graph.
+
+    >>> cmax = stats.ppcc_max(x, brack=(c/2, 2*c), dist='weibull_min')
+    >>> print(cmax)
+    2.4937451834924382
+    >>> ax.axvline(cmax, color='r')
     >>> plt.show()
 
     """
@@ -770,28 +768,35 @@ def ppcc_plot(x, a, b, dist='tukeylambda', plot=None, N=80):
 
     Examples
     --------
-    First we generate some random data from a Tukey-Lambda distribution,
-    with shape parameter -0.7:
+    First we generate some random data from a Weibull distribution
+    with shape parameter 2.5, and plot the histogram of the data:
 
     >>> from scipy import stats
     >>> import matplotlib.pyplot as plt
-    >>> rng = np.random.default_rng()
-    >>> x = stats.tukeylambda.rvs(-0.7, loc=2, scale=0.5,
-    ...                           size=10000, random_state=rng) + 1e4
+    >>> rng = np.random.default_rng(1234567)
+    >>> c = 2.5
+    >>> x = stats.weibull_min.rvs(c, scale=4, size=500, random_state=rng)
+
+    Take a look at the histogram of the data.
+
+    >>> fig1, ax = plt.subplots(figsize=(9, 4))
+    >>> ax.hist(x, bins=50)
+    >>> ax.set_title('Histogram of x')
+    >>> plt.show()
 
     Now we explore this data with a PPCC plot as well as the related
     probability plot and Box-Cox normplot.  A red line is drawn where we
-    expect the PPCC value to be maximal (at the shape parameter -0.7 used
-    above):
+    expect the PPCC value to be maximal (at the shape parameter ``c``
+    used above):
 
-    >>> fig = plt.figure(figsize=(12, 4))
-    >>> ax1 = fig.add_subplot(131)
-    >>> ax2 = fig.add_subplot(132)
-    >>> ax3 = fig.add_subplot(133)
+    >>> fig2 = plt.figure(figsize=(12, 4))
+    >>> ax1 = fig2.add_subplot(1, 3, 1)
+    >>> ax2 = fig2.add_subplot(1, 3, 2)
+    >>> ax3 = fig2.add_subplot(1, 3, 3)
     >>> res = stats.probplot(x, plot=ax1)
-    >>> res = stats.boxcox_normplot(x, -5, 5, plot=ax2)
-    >>> res = stats.ppcc_plot(x, -5, 5, plot=ax3)
-    >>> ax3.vlines(-0.7, 0, 1, colors='r', label='Expected shape value')
+    >>> res = stats.boxcox_normplot(x, -4, 4, plot=ax2)
+    >>> res = stats.ppcc_plot(x, c/2, 2*c, dist='weibull_min', plot=ax3)
+    >>> ax3.axvline(c, color='r')
     >>> plt.show()
 
     """


### PR DESCRIPTION
* Use weibull_min instead of tukeylambda to generate
  the sample data.  This generates nicer plots in the
  ppcc_plot docstring, and ensures that boxcox_normplot
  is given valid data.
* Reduce the size of random sample from 10000 to 500; the
  smaller sample demonstrates the functions just as well
  as the larger sample.
* Add a histogram to the ppcc_plot example.
* Remove text from the ppcc_max docstring that was
  probably copy-pasted from the ppcc_plot docstring.
* Do some additional copy-editing of the docstrings.

This will fix the problem that @tylerjereddy reported in https://github.com/scipy/scipy/pull/14181.