### PR TITLE
DOC: add examples/ update mstats doc of pearsonr in scipy.stats

### DIFF
--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -366,12 +366,6 @@ def pearsonr(x, y):
     distribution of the correlation coefficient.)  Like other correlation
     coefficients, this one varies between -1 and +1 with 0 implying no
     correlation. Correlations of -1 or +1 imply an exact linear relationship.
-    Positive correlations imply that as x increases, so does y. Negative
-    correlations imply that as x increases, y decreases.
-
-    The p-value roughly indicates the probability of an uncorrelated system
-    producing datasets that have a Pearson correlation at least as extreme
-    as the one computed from these datasets.
 
     Parameters
     ----------
@@ -413,13 +407,13 @@ def pearsonr(x, y):
         r = \frac{\sum (x - m_x) (y - m_y)}
                  {\sqrt{\sum (x - m_x)^2 \sum (y - m_y)^2}}
 
-    where :math:`m_x` is the mean of the vector :math:`x` and :math:`m_y` is
-    the mean of the vector :math:`y`.
+    where :math:`m_x` is the mean of the vector x and :math:`m_y` is
+    the mean of the vector y.
 
-    Under the assumption that :math:`x` and :math:`m_y` are drawn from
+    Under the assumption that x and y are drawn from
     independent normal distributions (so the population correlation coefficient
     is 0), the probability density function of the sample correlation
-    coefficient :math:`r` is ([1]_, [2]_):
+    coefficient r is ([1]_, [2]_):
 
     .. math::
 
@@ -434,11 +428,14 @@ def pearsonr(x, y):
 
         dist = scipy.stats.beta(n/2 - 1, n/2 - 1, loc=-1, scale=2)
 
-    The p-value returned by `pearsonr` is a two-sided p-value.  For a
+    The p-value returned by `pearsonr` is a two-sided p-value. The p-value
+    roughly indicates the probability of an uncorrelated system
+    producing datasets that have a Pearson correlation at least as extreme
+    as the one computed from these datasets. More precisely, for a
     given sample with correlation coefficient r, the p-value is
     the probability that abs(r') of a random sample x' and y' drawn from
     the population with zero correlation would be greater than or equal
-    to abs(r).  In terms of the object ``dist`` shown above, the p-value
+    to abs(r). In terms of the object ``dist`` shown above, the p-value
     for a given r and length n can be computed as::
 
         p = 2*dist.cdf(-abs(r))
@@ -476,9 +473,9 @@ def pearsonr(x, y):
     (-0.7426106572325057, 0.1505558088534455)
 
     It is important to keep in mind that no correlation does not imply
-    independence unless (X, Y) is Gaussian. Correlation can even be zero
+    independence unless (x, y) is Gaussian. Correlation can even be zero
     when there is a very simple dependence structure: if X follows a
-    standard normal distribution, let Y = abs(X). A simple check
+    standard normal distribution, let y = abs(x). A simple check
     confirms that the correlation is close to zero:
 
     >>> x = stats.norm.rvs(size=500)
@@ -486,27 +483,26 @@ def pearsonr(x, y):
     >>> mstats.pearsonr(x, y)
     (-0.016172891856853524, 0.7182823678751942) # may vary
 
-    Indeed, since the expectation of x is zero, cov(X, Y) = E(X*Y). This equals
-    EX*abs(X) which is zero by symmetry.
+    Indeed, since the expectation of x is zero, cov(x, y) = E[x*y]. This equals
+    E[x*abs(x)] which is zero by symmetry.
 
     If the relationship between x and y is non-linear, the correlation
     coefficient can be misleading. For example, if X has a standard normal
-    distribution, define Y = X if X < 0 and Y = 0 otherwise. A simple calculation
-    shows that corr(X, Y) = sqrt(2/Pi) = 0.797..., implying a high level of
-    correlation:
+    distribution, define y = x if x < 0 and y = 0 otherwise. A simple
+    calculation shows that corr(x, y) = sqrt(2/Pi) = 0.797..., implying
+    a high level of correlation:
 
     >>> y = np.where(x < 0, x, 0)
     >>> mstats.pearsonr(x, y)
     (0.8537091583771509, 3.183461621422181e-143) # may vary
 
-    This is unintuitive since there is no dependence of X and Y if X is larger
-    than zero which happens in about half of the cases if we sample X and Y.
+    This is unintuitive since there is no dependence of x and y if x is larger
+    than zero which happens in about half of the cases if we sample x and y.
 
-    There is linear dependance between X and Y in the sense that
-    Y = a + b*X + e, were a,b are constants and e is a random error term,
-    assumed to be independent of X. For simplicity, assume that X is standard
-    normal, a=0, b=1 and let e follow a normal distribution with mean zero
-    and standard deviation s>0.
+    There is a linear dependance between x and y if y = a + b*x + e, where
+    a,b are constants and e is a random error term, assumed to be independent
+    of x. For simplicity, assume that x is standard normal, a=0, b=1 and let
+    e follow a normal distribution with mean zero and standard deviation s>0.
 
     >>> s = 0.5
     >>> e = stats.norm.rvs(scale=s, size=500)

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -356,39 +356,171 @@ def msign(x):
 
 
 def pearsonr(x, y):
-    """
-    Calculates a Pearson correlation coefficient and the p-value for testing
-    non-correlation.
+    r"""
+    Pearson correlation coefficient and p-value for testing non-correlation.
 
-    The Pearson correlation coefficient measures the linear relationship
-    between two datasets. Strictly speaking, Pearson's correlation requires
-    that each dataset be normally distributed. Like other correlation
+    The Pearson correlation coefficient [1]_ measures the linear relationship
+    between two datasets.  The calculation of the p-value relies on the
+    assumption that each dataset is normally distributed.  (See Kowalski [3]_
+    for a discussion of the effects of non-normality of the input on the
+    distribution of the correlation coefficient.)  Like other correlation
     coefficients, this one varies between -1 and +1 with 0 implying no
-    correlation. Correlations of -1 or +1 imply an exact linear
-    relationship. Positive correlations imply that as `x` increases, so does
-    `y`. Negative correlations imply that as `x` increases, `y` decreases.
+    correlation. Correlations of -1 or +1 imply an exact linear relationship.
+    Positive correlations imply that as x increases, so does y. Negative
+    correlations imply that as x increases, y decreases.
 
     The p-value roughly indicates the probability of an uncorrelated system
     producing datasets that have a Pearson correlation at least as extreme
-    as the one computed from these datasets. The p-values are not entirely
-    reliable but are probably reasonable for datasets larger than 500 or so.
+    as the one computed from these datasets.
 
     Parameters
     ----------
-    x : 1-D array_like
-        Input
-    y : 1-D array_like
-        Input
+    x : (N,) array_like
+        Input array.
+    y : (N,) array_like
+        Input array.
 
     Returns
     -------
-    pearsonr : float
-        Pearson's correlation coefficient, 2-tailed p-value.
+    r : float
+        Pearson's correlation coefficient.
+    p-value : float
+        Two-tailed p-value.
+
+    Warns
+    -----
+    PearsonRConstantInputWarning
+        Raised if an input is a constant array.  The correlation coefficient
+        is not defined in this case, so ``np.nan`` is returned.
+
+    PearsonRNearConstantInputWarning
+        Raised if an input is "nearly" constant.  The array ``x`` is considered
+        nearly constant if ``norm(x - mean(x)) < 1e-13 * abs(mean(x))``.
+        Numerical errors in the calculation ``x - mean(x)`` in this case might
+        result in an inaccurate calculation of r.
+
+    See Also
+    --------
+    spearmanr : Spearman rank-order correlation coefficient.
+    kendalltau : Kendall's tau, a correlation measure for ordinal data.
+
+    Notes
+    -----
+    The correlation coefficient is calculated as follows:
+
+    .. math::
+
+        r = \frac{\sum (x - m_x) (y - m_y)}
+                 {\sqrt{\sum (x - m_x)^2 \sum (y - m_y)^2}}
+
+    where :math:`m_x` is the mean of the vector :math:`x` and :math:`m_y` is
+    the mean of the vector :math:`y`.
+
+    Under the assumption that :math:`x` and :math:`m_y` are drawn from
+    independent normal distributions (so the population correlation coefficient
+    is 0), the probability density function of the sample correlation
+    coefficient :math:`r` is ([1]_, [2]_):
+
+    .. math::
+
+        f(r) = \frac{{(1-r^2)}^{n/2-2}}{\mathrm{B}(\frac{1}{2},\frac{n}{2}-1)}
+
+    where n is the number of samples, and B is the beta function.  This
+    is sometimes referred to as the exact distribution of r.  This is
+    the distribution that is used in `pearsonr` to compute the p-value.
+    The distribution is a beta distribution on the interval [-1, 1],
+    with equal shape parameters a = b = n/2 - 1.  In terms of SciPy's
+    implementation of the beta distribution, the distribution of r is::
+
+        dist = scipy.stats.beta(n/2 - 1, n/2 - 1, loc=-1, scale=2)
+
+    The p-value returned by `pearsonr` is a two-sided p-value.  For a
+    given sample with correlation coefficient r, the p-value is
+    the probability that abs(r') of a random sample x' and y' drawn from
+    the population with zero correlation would be greater than or equal
+    to abs(r).  In terms of the object ``dist`` shown above, the p-value
+    for a given r and length n can be computed as::
+
+        p = 2*dist.cdf(-abs(r))
+
+    When n is 2, the above continuous distribution is not well-defined.
+    One can interpret the limit of the beta distribution as the shape
+    parameters a and b approach a = b = 0 as a discrete distribution with
+    equal probability masses at r = 1 and r = -1.  More directly, one
+    can observe that, given the data x = [x1, x2] and y = [y1, y2], and
+    assuming x1 != x2 and y1 != y2, the only possible values for r are 1
+    and -1.  Because abs(r') for any sample x' and y' with length 2 will
+    be 1, the two-sided p-value for a sample of length 2 is always 1.
 
     References
     ----------
-    http://www.statsoft.com/textbook/glosp.html#Pearson%20Correlation
+    .. [1] "Pearson correlation coefficient", Wikipedia,
+           https://en.wikipedia.org/wiki/Pearson_correlation_coefficient
+    .. [2] Student, "Probable error of a correlation coefficient",
+           Biometrika, Volume 6, Issue 2-3, 1 September 1908, pp. 302-310.
+    .. [3] C. J. Kowalski, "On the Effects of Non-Normality on the Distribution
+           of the Sample Product-Moment Correlation Coefficient"
+           Journal of the Royal Statistical Society. Series C (Applied
+           Statistics), Vol. 21, No. 1 (1972), pp. 1-12.
 
+    Examples
+    --------
+    >>> from scipy import stats
+    >>> from scipy.stats import mstats
+    >>> a = np.array([0, 0, 0, 1, 1, 1, 1])
+    >>> b = np.arange(7)
+    >>> mstats.pearsonr(a, b)
+    (0.8660254037844386, 0.011724811003954649)
+
+    >>> mstats.pearsonr([1, 2, 3, 4, 5], [10, 9, 2.5, 6, 4])
+    (-0.7426106572325057, 0.1505558088534455)
+
+    It is important to keep in mind that no correlation does not imply
+    independence unless (X, Y) is Gaussian. Correlation can even be zero
+    when there is a very simple dependence structure: if X follows a
+    standard normal distribution, let Y = abs(X). A simple check
+    confirms that the correlation is close to zero:
+
+    >>> x = stats.norm.rvs(size=500)
+    >>> y = np.abs(x)
+    >>> mstats.pearsonr(x, y)
+    (-0.016172891856853524, 0.7182823678751942) # may vary
+
+    Indeed, since the expectation of x is zero, cov(X, Y) = E(X*Y). This equals
+    EX*abs(X) which is zero by symmetry.
+
+    If the relationship between x and y is non-linear, the correlation
+    coefficient can be misleading. For example, if X has a standard normal
+    distribution, define Y = X if X < 0 and Y = 0 otherwise. A simple calculation
+    shows that corr(X, Y) = sqrt(2/Pi) = 0.797..., implying a high level of
+    correlation:
+
+    >>> y = np.where(x < 0, x, 0)
+    >>> mstats.pearsonr(x, y)
+    (0.8537091583771509, 3.183461621422181e-143) # may vary
+
+    This is unintuitive since there is no dependence of X and Y if X is larger
+    than zero which happens in about half of the cases if we sample X and Y.
+
+    There is linear dependance between X and Y in the sense that
+    Y = a + b*X + e, were a,b are constants and e is a random error term,
+    assumed to be independent of X. For simplicity, assume that X is standard
+    normal, a=0, b=1 and let e follow a normal distribution with mean zero
+    and standard deviation s>0.
+
+    >>> s = 0.5
+    >>> e = stats.norm.rvs(scale=s, size=500)
+    >>> y = x + e
+    >>> mstats.pearsonr(x, y)
+    (0.9029601878969703, 8.428978827629898e-185) # may vary
+
+    This should be close to the exact value given by
+
+    >>> 1/np.sqrt(1 + s**2)
+    0.8944271909999159
+
+    As expected, a large variance of the noise reduces the correlation, while
+    the correlation approaches one as the variance of the error goes to zero.
     """
     (x, y, n) = _chk_size(x, y)
     (x, y) = (x.ravel(), y.ravel())

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -464,42 +464,10 @@ def pearsonr(x, y):
     --------
     >>> from scipy import stats
     >>> from scipy.stats import mstats
-    >>> a = np.array([0, 0, 0, 1, 1, 1, 1])
-    >>> b = np.arange(7)
-    >>> mstats.pearsonr(a, b)
-    (0.8660254037844386, 0.011724811003954649)
-
     >>> mstats.pearsonr([1, 2, 3, 4, 5], [10, 9, 2.5, 6, 4])
     (-0.7426106572325057, 0.1505558088534455)
 
-    It is important to keep in mind that no correlation does not imply
-    independence unless (x, y) is Gaussian. Correlation can even be zero
-    when there is a very simple dependence structure: if X follows a
-    standard normal distribution, let y = abs(x). A simple check
-    confirms that the correlation is close to zero:
-
-    >>> x = stats.norm.rvs(size=500)
-    >>> y = np.abs(x)
-    >>> mstats.pearsonr(x, y)
-    (-0.016172891856853524, 0.7182823678751942) # may vary
-
-    Indeed, since the expectation of x is zero, cov(x, y) = E[x*y]. This equals
-    E[x*abs(x)] which is zero by symmetry.
-
-    If the relationship between x and y is non-linear, the correlation
-    coefficient can be misleading. For example, if X has a standard normal
-    distribution, define y = x if x < 0 and y = 0 otherwise. A simple
-    calculation shows that corr(x, y) = sqrt(2/Pi) = 0.797..., implying
-    a high level of correlation:
-
-    >>> y = np.where(x < 0, x, 0)
-    >>> mstats.pearsonr(x, y)
-    (0.8537091583771509, 3.183461621422181e-143) # may vary
-
-    This is unintuitive since there is no dependence of x and y if x is larger
-    than zero which happens in about half of the cases if we sample x and y.
-
-    There is a linear dependance between x and y if y = a + b*x + e, where
+    There is a linear dependence between x and y if y = a + b*x + e, where
     a,b are constants and e is a random error term, assumed to be independent
     of x. For simplicity, assume that x is standard normal, a=0, b=1 and let
     e follow a normal distribution with mean zero and standard deviation s>0.
@@ -515,8 +483,34 @@ def pearsonr(x, y):
     >>> 1/np.sqrt(1 + s**2)
     0.8944271909999159
 
-    As expected, a large variance of the noise reduces the correlation, while
-    the correlation approaches one as the variance of the error goes to zero.
+    For s=0.5, we observe a high level of correlation. In general, a large
+    variance of the noise reduces the correlation, while the correlation
+    approaches one as the variance of the error goes to zero.
+
+    It is important to keep in mind that no correlation does not imply
+    independence unless (x, y) is jointly normal. Correlation can even be zero
+    when there is a very simple dependence structure: if X follows a
+    standard normal distribution, let y = abs(x). Note that the correlation
+    between x and y is zero. Indeed, since the expectation of x is zero,
+    cov(x, y) = E[x*y]. By definition, this equals E[x*abs(x)] which is zero
+    by symmetry. The following lines of code illustrate this observation:
+
+    >>> x = stats.norm.rvs(size=500)
+    >>> y = np.abs(x)
+    >>> mstats.pearsonr(x, y)
+    (-0.016172891856853524, 0.7182823678751942) # may vary
+
+    A non-zero correlation coefficient can be misleading. For example, if X has
+    a standard normal distribution, define y = x if x < 0 and y = 0 otherwise.
+    A simple calculation shows that corr(x, y) = sqrt(2/Pi) = 0.797...,
+    implying a high level of correlation:
+
+    >>> y = np.where(x < 0, x, 0)
+    >>> mstats.pearsonr(x, y)
+    (0.8537091583771509, 3.183461621422181e-143) # may vary
+
+    This is unintuitive since there is no dependence of x and y if x is larger
+    than zero which happens in about half of the cases if we sample x and y.
     """
     (x, y, n) = _chk_size(x, y)
     (x, y) = (x.ravel(), y.ravel())

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3988,42 +3988,10 @@ def pearsonr(x, y):
     Examples
     --------
     >>> from scipy import stats
-    >>> a = np.array([0, 0, 0, 1, 1, 1, 1])
-    >>> b = np.arange(7)
-    >>> stats.pearsonr(a, b)
-    (0.8660254037844386, 0.011724811003954649)
-
     >>> stats.pearsonr([1, 2, 3, 4, 5], [10, 9, 2.5, 6, 4])
     (-0.7426106572325057, 0.1505558088534455)
 
-    It is important to keep in mind that no correlation does not imply
-    independence unless (x, y) is Gaussian. Correlation can even be zero
-    when there is a very simple dependence structure: if x follows a
-    standard normal distribution, let y = abs(x). A simple check
-    confirms that the correlation is close to zero:
-
-    >>> x = stats.norm.rvs(size=500)
-    >>> y = np.abs(x)
-    >>> stats.pearsonr(x, y)
-    (-0.016172891856853524, 0.7182823678751942) # may vary
-
-    Indeed, since the expectation of x is zero, cov(x, y) = E[x*y]. This equals
-    E[x*abs(x)] which is zero by symmetry.
-
-    If the relationship between x and y is non-linear, the correlation
-    coefficient can be misleading. For example, if x has a standard normal
-    distribution, define y = x if x < 0 and y = 0 otherwise. A simple
-    alculation shows that corr(x, y) = sqrt(2/Pi) = 0.797..., implying a
-    high level of correlation:
-
-    >>> y = np.where(x < 0, x, 0)
-    >>> stats.pearsonr(x, y)
-    (0.8537091583771509, 3.183461621422181e-143) # may vary
-
-    This is unintuitive since there is no dependence of x and y if x is larger
-    than zero which happens in about half of the cases if we sample x and y.
-
-    There is a linear dependance between x and y if y = a + b*x + e, where
+    There is a linear dependence between x and y if y = a + b*x + e, where
     a,b are constants and e is a random error term, assumed to be independent
     of x. For simplicity, assume that x is standard normal, a=0, b=1 and let
     e follow a normal distribution with mean zero and standard deviation s>0.
@@ -4039,8 +4007,34 @@ def pearsonr(x, y):
     >>> 1/np.sqrt(1 + s**2)
     0.8944271909999159
 
-    As expected, a large variance of the noise reduces the correlation, while
-    the correlation approaches one as the variance of the error goes to zero.
+    For s=0.5, we observe a high level of correlation. In general, a large
+    variance of the noise reduces the correlation, while the correlation
+    approaches one as the variance of the error goes to zero.
+
+    It is important to keep in mind that no correlation does not imply
+    independence unless (x, y) is jointly normal. Correlation can even be zero
+    when there is a very simple dependence structure: if X follows a
+    standard normal distribution, let y = abs(x). Note that the correlation
+    between x and y is zero. Indeed, since the expectation of x is zero,
+    cov(x, y) = E[x*y]. By definition, this equals E[x*abs(x)] which is zero
+    by symmetry. The following lines of code illustrate this observation:
+
+    >>> x = stats.norm.rvs(size=500)
+    >>> y = np.abs(x)
+    >>> stats.pearsonr(x, y)
+    (-0.016172891856853524, 0.7182823678751942) # may vary
+
+    A non-zero correlation coefficient can be misleading. For example, if X has
+    a standard normal distribution, define y = x if x < 0 and y = 0 otherwise.
+    A simple calculation shows that corr(x, y) = sqrt(2/Pi) = 0.797...,
+    implying a high level of correlation:
+
+    >>> y = np.where(x < 0, x, 0)
+    >>> stats.pearsonr(x, y)
+    (0.8537091583771509, 3.183461621422181e-143) # may vary
+
+    This is unintuitive since there is no dependence of x and y if x is larger
+    than zero which happens in about half of the cases if we sample x and y.
     """
     n = len(x)
     if n != len(y):

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3999,6 +3999,52 @@ def pearsonr(x, y):
     >>> stats.pearsonr([1, 2, 3, 4, 5], [10, 9, 2.5, 6, 4])
     (-0.7426106572325057, 0.1505558088534455)
 
+    It is important to keep in mind that no correlation does not imply
+    independence unless (X, Y) is Gaussian. Correlation can even be zero
+    when there is a very simple dependence structure: if X follows a
+    standard normal distribution, let Y = abs(X). A simple check
+    confirms that the correlation is close to zero:
+
+    >>> x = stats.norm.rvs(size=500)
+    >>> y = np.abs(x)
+    >>> stats.pearsonr(x, y)
+    (-0.016172891856853524, 0.7182823678751942) # may vary
+
+    Indeed, since the expectation of x is zero, cov(X, Y) = E(X*Y). This equals
+    EX*abs(X) which is zero by symmetry.
+
+    If the relationship between x and y is non-linear, the correlation
+    coefficient can be misleading. For example, if X has a standard normal
+    distribution, define Y = X if X < 0 and Y = 0 otherwise. A simple calculation
+    shows that corr(X, Y) = sqrt(2/Pi) = 0.797..., implying a high level of
+    correlation:
+
+    >>> y = np.where(x < 0, x, 0)
+    >>> stats.pearsonr(x, y)
+    (0.8537091583771509, 3.183461621422181e-143) # may vary
+
+    This is unintuitive since there is no dependence of X and Y if X is larger
+    than zero which happens in about half of the cases if we sample X and Y.
+
+    There is linear dependance between X and Y in the sense that
+    Y = a + b*X + e, were a,b are constants and e is a random error term,
+    assumed to be independent of X. For simplicity, assume that X is standard
+    normal, a=0, b=1 and let e follow a normal distribution with mean zero
+    and standard deviation s>0.
+
+    >>> s = 0.5
+    >>> e = stats.norm.rvs(scale=s, size=500)
+    >>> y = x + e
+    >>> stats.pearsonr(x, y)
+    (0.9029601878969703, 8.428978827629898e-185) # may vary
+
+    This should be close to the exact value given by
+
+    >>> 1/np.sqrt(1 + s**2)
+    0.8944271909999159
+
+    As expected, a large variance of the noise reduces the correlation, while
+    the correlation approaches one as the variance of the error goes to zero.
     """
     n = len(x)
     if n != len(y):

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3891,12 +3891,6 @@ def pearsonr(x, y):
     distribution of the correlation coefficient.)  Like other correlation
     coefficients, this one varies between -1 and +1 with 0 implying no
     correlation. Correlations of -1 or +1 imply an exact linear relationship.
-    Positive correlations imply that as x increases, so does y. Negative
-    correlations imply that as x increases, y decreases.
-
-    The p-value roughly indicates the probability of an uncorrelated system
-    producing datasets that have a Pearson correlation at least as extreme
-    as the one computed from these datasets.
 
     Parameters
     ----------
@@ -3938,13 +3932,13 @@ def pearsonr(x, y):
         r = \frac{\sum (x - m_x) (y - m_y)}
                  {\sqrt{\sum (x - m_x)^2 \sum (y - m_y)^2}}
 
-    where :math:`m_x` is the mean of the vector :math:`x` and :math:`m_y` is
-    the mean of the vector :math:`y`.
+    where :math:`m_x` is the mean of the vector x and :math:`m_y` is
+    the mean of the vector y.
 
-    Under the assumption that :math:`x` and :math:`m_y` are drawn from
+    Under the assumption that x and y are drawn from
     independent normal distributions (so the population correlation coefficient
     is 0), the probability density function of the sample correlation
-    coefficient :math:`r` is ([1]_, [2]_):
+    coefficient r is ([1]_, [2]_):
 
     .. math::
 
@@ -3959,11 +3953,14 @@ def pearsonr(x, y):
 
         dist = scipy.stats.beta(n/2 - 1, n/2 - 1, loc=-1, scale=2)
 
-    The p-value returned by `pearsonr` is a two-sided p-value.  For a
+    The p-value returned by `pearsonr` is a two-sided p-value. The p-value
+    roughly indicates the probability of an uncorrelated system
+    producing datasets that have a Pearson correlation at least as extreme
+    as the one computed from these datasets. More precisely, for a
     given sample with correlation coefficient r, the p-value is
     the probability that abs(r') of a random sample x' and y' drawn from
     the population with zero correlation would be greater than or equal
-    to abs(r).  In terms of the object ``dist`` shown above, the p-value
+    to abs(r). In terms of the object ``dist`` shown above, the p-value
     for a given r and length n can be computed as::
 
         p = 2*dist.cdf(-abs(r))
@@ -4000,9 +3997,9 @@ def pearsonr(x, y):
     (-0.7426106572325057, 0.1505558088534455)
 
     It is important to keep in mind that no correlation does not imply
-    independence unless (X, Y) is Gaussian. Correlation can even be zero
-    when there is a very simple dependence structure: if X follows a
-    standard normal distribution, let Y = abs(X). A simple check
+    independence unless (x, y) is Gaussian. Correlation can even be zero
+    when there is a very simple dependence structure: if x follows a
+    standard normal distribution, let y = abs(x). A simple check
     confirms that the correlation is close to zero:
 
     >>> x = stats.norm.rvs(size=500)
@@ -4010,27 +4007,26 @@ def pearsonr(x, y):
     >>> stats.pearsonr(x, y)
     (-0.016172891856853524, 0.7182823678751942) # may vary
 
-    Indeed, since the expectation of x is zero, cov(X, Y) = E(X*Y). This equals
-    EX*abs(X) which is zero by symmetry.
+    Indeed, since the expectation of x is zero, cov(x, y) = E[x*y]. This equals
+    E[x*abs(x)] which is zero by symmetry.
 
     If the relationship between x and y is non-linear, the correlation
-    coefficient can be misleading. For example, if X has a standard normal
-    distribution, define Y = X if X < 0 and Y = 0 otherwise. A simple calculation
-    shows that corr(X, Y) = sqrt(2/Pi) = 0.797..., implying a high level of
-    correlation:
+    coefficient can be misleading. For example, if x has a standard normal
+    distribution, define y = x if x < 0 and y = 0 otherwise. A simple
+    alculation shows that corr(x, y) = sqrt(2/Pi) = 0.797..., implying a
+    high level of correlation:
 
     >>> y = np.where(x < 0, x, 0)
     >>> stats.pearsonr(x, y)
     (0.8537091583771509, 3.183461621422181e-143) # may vary
 
-    This is unintuitive since there is no dependence of X and Y if X is larger
-    than zero which happens in about half of the cases if we sample X and Y.
+    This is unintuitive since there is no dependence of x and y if x is larger
+    than zero which happens in about half of the cases if we sample x and y.
 
-    There is linear dependance between X and Y in the sense that
-    Y = a + b*X + e, were a,b are constants and e is a random error term,
-    assumed to be independent of X. For simplicity, assume that X is standard
-    normal, a=0, b=1 and let e follow a normal distribution with mean zero
-    and standard deviation s>0.
+    There is a linear dependance between x and y if y = a + b*x + e, where
+    a,b are constants and e is a random error term, assumed to be independent
+    of x. For simplicity, assume that x is standard normal, a=0, b=1 and let
+    e follow a normal distribution with mean zero and standard deviation s>0.
 
     >>> s = 0.5
     >>> e = stats.norm.rvs(scale=s, size=500)


### PR DESCRIPTION
#### Reference issue
Closes #14235 (fix typo m_y -> y)

#### What does this implement/fix?
I added a few more examples for `pearsonr`, mainly to create awareness that the correlation coefficient can lead to unintuitive results if there is no linear relationship.

I also noted that the mstats docstring was outdated and simply copied the stats docstring.

