### PR TITLE
TST, MAINT: hausdorff test cleanups

### DIFF
--- a/scipy/spatial/tests/test_hausdorff.py
+++ b/scipy/spatial/tests/test_hausdorff.py
@@ -1,8 +1,7 @@
 import numpy as np
-from numpy.testing import (assert_almost_equal,
+from numpy.testing import (assert_allclose,
                            assert_array_equal,
-                           assert_equal,
-                           assert_)
+                           assert_equal)
 import pytest
 from scipy.spatial.distance import directed_hausdorff
 from scipy.spatial import distance
@@ -36,7 +35,7 @@ class TestHausdorff:
 
         forward = directed_hausdorff(self.path_1, self.path_2)[0]
         reverse = directed_hausdorff(self.path_2, self.path_1)[0]
-        assert_(forward != reverse)
+        assert forward != reverse
 
     def test_brute_force_comparison_forward(self):
         # Ensure that the algorithm for directed_hausdorff gives the
@@ -46,7 +45,7 @@ class TestHausdorff:
         # brute force over rows:
         expected = max(np.amin(distance.cdist(self.path_1, self.path_2),
                                axis=1))
-        assert_almost_equal(actual, expected, decimal=9)
+        assert_allclose(actual, expected)
 
     def test_brute_force_comparison_reverse(self):
         # Ensure that the algorithm for directed_hausdorff gives the
@@ -56,13 +55,13 @@ class TestHausdorff:
         # brute force over columns:
         expected = max(np.amin(distance.cdist(self.path_1, self.path_2), 
                                axis=0))
-        assert_almost_equal(actual, expected, decimal=9)
+        assert_allclose(actual, expected)
 
     def test_degenerate_case(self):
         # The directed Hausdorff distance must be zero if both input
         # data arrays match.
         actual = directed_hausdorff(self.path_1, self.path_1)[0]
-        assert_almost_equal(actual, 0.0, decimal=9)
+        assert_allclose(actual, 0.0)
 
     def test_2d_data_forward(self):
         # Ensure that 2D data is handled properly for a simple case
@@ -72,7 +71,7 @@ class TestHausdorff:
         expected = max(np.amin(distance.cdist(self.path_1[..., :2],
                                               self.path_2[..., :2]),
                                axis=1))
-        assert_almost_equal(actual, expected, decimal=9)
+        assert_allclose(actual, expected)
 
     def test_4d_data_reverse(self):
         # Ensure that 4D data is handled properly for a simple case
@@ -81,7 +80,7 @@ class TestHausdorff:
         # brute force over columns:
         expected = max(np.amin(distance.cdist(self.path_1_4d, self.path_2_4d), 
                                axis=0))
-        assert_almost_equal(actual, expected, decimal=9)
+        assert_allclose(actual, expected)
 
     def test_indices(self):
         # Ensure that correct point indices are returned -- they should
@@ -145,6 +144,6 @@ class TestHausdorff:
         # verify fix for gh-11332
         actual = directed_hausdorff(u=A, v=B, seed=seed)
         # check distance
-        assert_almost_equal(actual[0], expected[0], decimal=9)
+        assert_allclose(actual[0], expected[0])
         # check indices
         assert actual[1:] == expected[1:]


### PR DESCRIPTION
* use `assert_allclose` instead of `assert_almost_equal`
for more consistent floating point comparisons per the
NumPy documentation:
https://numpy.org/doc/stable/reference/generated/numpy.testing.assert_almost_equal.html

* replace `assert_` with plain `assert` now that we use
`pytest` consistently

* this only came up because I've been translating the code and its unit
tests to a [`Rust` implementation](https://github.com/tylerjereddy/rusty_hausdorff/blob/main/src/lib.rs) to see how it performs (and if the promise of safe/convenient concurrency holds up well)
