### PR TITLE
DOC: interpolate: rbf has kwargs too.

### DIFF
--- a/scipy/interpolate/rbf.py
+++ b/scipy/interpolate/rbf.py
@@ -54,7 +54,7 @@ __all__ = ['Rbf']
 
 class Rbf:
     """
-    Rbf(*args)
+    Rbf(*args, **kwargs)
 
     A class for radial basis function interpolation of functions from
     N-D scattered data to an M-D domain.


### PR DESCRIPTION
A tiny fix for the [`Rbf`](http://scipy.github.io/devdocs/reference/generated/scipy.interpolate.Rbf.html#scipy.interpolate.Rbf) docstring.