### PR TITLE
BUG: stats: fix shape handing in multivariate_t.rvs

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -4081,7 +4081,7 @@ class multivariate_t_gen(multi_rv_generic):
             x = rng.chisquare(df, size=size) / df
 
         z = rng.multivariate_normal(np.zeros(dim), shape, size=size)
-        samples = loc + z / np.sqrt(x)[:, None]
+        samples = loc + z / np.sqrt(x)[..., None]
         return _squeeze_output(samples)
 
     def _process_quantiles(self, x, dim):

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -1870,6 +1870,14 @@ class TestMultivariateT:
         args = dict(loc=[0,0], shape=[[0,0],[0,1]], df=1, allow_singular=False)
         assert_raises(np.linalg.LinAlgError, multivariate_t, **args)
 
+    @pytest.mark.parametrize("size", [(10, 3), (5, 6, 4, 3)])
+    @pytest.mark.parametrize("dim", [2, 3, 4, 5])
+    @pytest.mark.parametrize("df", [1., 2., np.inf])
+    def test_rvs(self, size, dim, df):
+        dist = multivariate_t(np.zeros(dim), np.eye(dim), df)
+        rvs = dist.rvs(size=size)
+        assert rvs.shape == size + (dim, )
+
 
 class TestMultivariateHypergeom:
     @pytest.mark.parametrize(


### PR DESCRIPTION
#### Reference issue

closes gh-14189

#### What does this implement/fix?

``multivariate_t.rvs`` method failed when non-scalar size was passed as described in gh-14189. This behavior has been fixed now and appropriate tests have been added:

```py
>>> from scipy.stats import multivariate_t
>>> multivariate_t.rvs(loc=[0., 0.], shape=[[1., 0.], [0., 1.]], size=(10, 3)).shape
(10, 3, 2)
>>> multivariate_t.rvs(loc=[0., 0.], shape=[[1., 0.], [0., 1.]], size=(5, 4, 3)).shape
(5, 4, 3, 2)
```

#### Additional information

I think that the shape handling of many multivariate distributions that use `_squeeze_output` before returning is also broken and needs to be fixed. It might be out of scope for this PR so I haven't touched that behavior here.