### PR TITLE
MAINT: download-wheels missing import

### DIFF
--- a/tools/download-wheels.py
+++ b/tools/download-wheels.py
@@ -9,6 +9,7 @@ import re
 import shutil
 import argparse
 import urllib
+import urllib.request
 
 import urllib3
 from bs4 import BeautifulSoup


### PR DESCRIPTION
Fixes #14194 

* add a missing import in the `download-wheels.py` module
that we missed after adding proxy support there a few weeks
ago