### PR TITLE
BLD: stats: don't include the generated Boost wrapper code in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -25,6 +25,7 @@ prune benchmarks/scipy
 prune scipy/special/tests/data/boost
 prune scipy/special/tests/data/gsl
 prune scipy/special/tests/data/local
+prune scipy/stats/_boost/src
 prune doc/build
 prune doc/source/generated
 prune */__pycache__


### PR DESCRIPTION
The `*.cxx` files contain an absolute path, which is coming from the
use of `src_dir` in `stats/_boost/setup.py`. That makes the generated
code non-portable. Which should be fine, as long as it's not included
in an sdist.

Should fix the failures with `1.7.0rc1` in https://github.com/conda-forge/scipy-feedstock/pull/169.