### PR TITLE
CI: azure: Fix handling of 'skip azp'.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,7 +42,7 @@ stages:
         RET: 'true'
       steps:
       - bash: |
-          git_log=`git log --max-count=1 --skip=1 --pretty=format:"%B"`
+          git_log=`git log --max-count=1 --skip=1 --pretty=format:"%B" | tr "\n" " "`
           echo "##vso[task.setvariable variable=log]$git_log"
       - bash: echo "##vso[task.setvariable variable=RET]false"
         condition: or(contains(variables.log, '[skip azp]'), contains(variables.log, '[azp skip]'), contains(variables.log, '[skip ci]'), contains(variables.log, '[ci skip]'))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,7 +42,7 @@ stages:
         RET: 'true'
       steps:
       - bash: |
-          git_log=`git log --max-count=1 --skip=1 --pretty=format:"%s"`
+          git_log=`git log --max-count=1 --skip=1 --pretty=format:"%B"`
           echo "##vso[task.setvariable variable=log]$git_log"
       - bash: echo "##vso[task.setvariable variable=RET]false"
         condition: or(contains(variables.log, '[skip azp]'), contains(variables.log, '[azp skip]'), contains(variables.log, '[skip ci]'), contains(variables.log, '[ci skip]'))

--- a/doc/source/dev/contributor/continuous_integration.rst
+++ b/doc/source/dev/contributor/continuous_integration.rst
@@ -85,5 +85,5 @@ just updated a ``.rst`` file in the documentation and ask to skip Azure and
 GitHub Actions' workflows::
 
     DOC: improve QMCEngine examples.
-    [skip azp] [skip actions]
 
+    [skip azp] [skip actions]


### PR DESCRIPTION
Print the git log with format `%B` instead of `%s`
to get the full commit message (subject and body).
