### PR TITLE
DOC: Remove link to alpha in scipy.stats.dirichlet

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -1295,7 +1295,7 @@ def _lnB(alpha):
 class dirichlet_gen(multi_rv_generic):
     r"""A Dirichlet random variable.
 
-    The `alpha` keyword specifies the concentration parameters of the
+    The ``alpha`` keyword specifies the concentration parameters of the
     distribution.
 
     .. versionadded:: 0.15.0

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -1338,7 +1338,7 @@ class dirichlet_gen(multi_rv_generic):
     .. math::
         \sum_{i=1}^{K} x_i = 1
 
-    where 0 < x_i < 1.
+    where :math:`0 < x_i < 1`.
 
     If the quantiles don't lie within the simplex, a ValueError is raised.
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes: #14190 
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
Removes link to alpha and add math styling to an equation.
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->