### PR TITLE
Improve error message for index dimension

### DIFF
--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -159,7 +159,7 @@ class IndexMixin:
             raise IndexError('invalid index') from e
 
         if x.ndim not in (1, 2):
-            raise IndexError('Index dimension must be <= 2')
+            raise IndexError('Index dimension must be 1 or 2')
 
         if x.size == 0:
             return x


### PR DESCRIPTION
#### ~~Reference issue~~

#### What does this implement/fix?
Since `x.ndim` can be `0`, but not accepted, this PR excludes the case explicitly in the error message.

#### Additional information
I have wasted some time trying to figure out why `x.ndim > 2` but it turns out that `x.ndim` was actually `0`.

I haven't checked for other places this change applies nor unittests which asserts on the error message.
