### PR TITLE
DOC: stats: remove 'Methods' section from `binomtest` docstring so Sphinx generates it?

### DIFF
--- a/scipy/stats/_binomtest.py
+++ b/scipy/stats/_binomtest.py
@@ -26,11 +26,6 @@ class BinomTestResult:
     proportion_estimate : float
         The estimate of the proportion of successes.
 
-    Methods
-    -------
-    proportion_ci :
-        Compute the confidence interval for the estimate of the proportion.
-
     """
     def __init__(self, k, n, alternative, pvalue, proportion_estimate):
         self.k = k

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -3850,6 +3850,15 @@ class multivariate_t_gen(multi_rv_generic):
     as a function to fix the location, shape matrix, and degrees of freedom
     parameters, returning a "frozen" multivariate t-distribution random.
 
+    Methods
+    -------
+    ``pdf(x, loc=None, shape=1, df=1, allow_singular=False)``
+        Probability density function.
+    ``logpdf(x, loc=None, shape=1, df=1, allow_singular=False)``
+        Log of the probability density function.
+    ``rvs(loc=None, shape=1, df=1, size=1, random_state=None)``
+        Draw random samples from a multivariate t-distribution.
+
     Parameters
     ----------
     x : array_like

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -3850,15 +3850,6 @@ class multivariate_t_gen(multi_rv_generic):
     as a function to fix the location, shape matrix, and degrees of freedom
     parameters, returning a "frozen" multivariate t-distribution random.
 
-    Methods
-    -------
-    ``pdf(x, loc=None, shape=1, df=1, allow_singular=False)``
-        Probability density function.
-    ``logpdf(x, loc=None, shape=1, df=1, allow_singular=False)``
-        Log of the probability density function.
-    ``rvs(loc=None, shape=1, df=1, size=1, random_state=None)``
-        Draw random samples from a multivariate t-distribution.
-
     Parameters
     ----------
     x : array_like


### PR DESCRIPTION
#### What does this implement/fix?
The `BinomTestResult` documentation does not link to documentation for the method `proportion_ci`.
![image](https://user-images.githubusercontent.com/6570539/124289989-c3226f80-db07-11eb-8239-f4723e8ec335.png)


This PR fixes that problem by removing the explicit "Methods" section from the docstring, making Sphinx [auto-generate a Methods section](https://32945-1460385-gh.circle-artifacts.com/0/html-scipyorg/reference/generated/scipy.stats._result_classes.BinomTestResult.html#scipy.stats._result_classes.BinomTestResult) 

![image](https://user-images.githubusercontent.com/6570539/124290134-f238e100-db07-11eb-9061-d8800e8e6d5a.png)

and link to [documentation for `proportion_ci`](https://32945-1460385-gh.circle-artifacts.com/0/html-scipyorg/reference/generated/scipy.stats._result_classes.BinomTestResult.proportion_ci.html#scipy.stats._result_classes.BinomTestResult.proportion_ci).

![image](https://user-images.githubusercontent.com/6570539/124290190-01b82a00-db08-11eb-9cd0-131e522517de.png)