### PR TITLE
MAINT: add invalid='ignore' to np.errstate block in PchipInterpolator

### DIFF
--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -285,7 +285,7 @@ class PchipInterpolator(CubicHermiteSpline):
 
         # values where division by zero occurs will be excluded
         # by 'condition' afterwards
-        with np.errstate(divide='ignore'):
+        with np.errstate(divide='ignore', invalid='ignore'):
             whmean = (w1/mk[:-1] + w2/mk[1:]) / (w1 + w2)
 
         dk = np.zeros_like(y)


### PR DESCRIPTION
…ings in cases where denominator is complex 0 (0+0j)

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
https://github.com/scipy/scipy/issues/14140

#### What does this implement/fix?
Eliminates a nuisance warning when interpolating with PchipInterpolator over complex values.

#### Additional information
<!--Any additional information you think is important.-->