### PR TITLE
ENH: stats: kendalltau: add alternative parameter

### DIFF
--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -564,18 +564,18 @@ def _kendall_p_exact(n, c, alternative='two-sided'):
         raise ValueError(f'c ({c}) must satisfy 0 <= 4c <= n(n-1) = {n*(n-1)}.')
     elif n == 1:
         prob = 1.0
-        p_mass_at_statistic = 1
+        p_mass_at_c = 1
     elif n == 2:
         prob = 1.0
-        p_mass_at_statistic = 0.5
+        p_mass_at_c = 0.5
     elif c == 0:
         prob = 2.0/math.factorial(n) if n < 171 else 0.0
-        p_mass_at_statistic = prob/2
+        p_mass_at_c = prob/2
     elif c == 1:
         prob = 2.0/math.factorial(n-1) if n < 172 else 0.0
-        p_mass_at_statistic = (n-1)/math.factorial(n)
+        p_mass_at_c = (n-1)/math.factorial(n)
     elif 4*c == n*(n-1) and alternative == 'two-sided':
-        # I'm sure there's a simple formula for p_mass_at_statistic in this
+        # I'm sure there's a simple formula for p_mass_at_c in this
         # case, but I don't know it. Use generic formula for one-sided p-value.
         prob = 1.0
     elif n < 171:
@@ -586,7 +586,7 @@ def _kendall_p_exact(n, c, alternative='two-sided'):
             if j <= c:
                 new[j:] -= new[:c+1-j]
         prob = 2.0*np.sum(new)/math.factorial(n)
-        p_mass_at_statistic = new[-1]/math.factorial(n)
+        p_mass_at_c = new[-1]/math.factorial(n)
     else:
         new = np.zeros(c+1)
         new[0:2] = 1.0
@@ -595,7 +595,7 @@ def _kendall_p_exact(n, c, alternative='two-sided'):
             if j <= c:
                 new[j:] -= new[:c+1-j]
         prob = np.sum(new)
-        p_mass_at_statistic = new[-1]/2
+        p_mass_at_c = new[-1]/2
 
     if alternative != 'two-sided':
         # if the alternative hypothesis and alternative agree,
@@ -603,7 +603,7 @@ def _kendall_p_exact(n, c, alternative='two-sided'):
         if in_right_tail == alternative_greater:
             prob /= 2
         else:
-            prob = 1 - prob/2 + p_mass_at_statistic
+            prob = 1 - prob/2 + p_mass_at_c
 
     prob = np.clip(prob, 0, 1)
 
@@ -648,9 +648,9 @@ def kendalltau(x, y, use_ties=True, use_missing=False, method='auto',
     Returns
     -------
     correlation : float
-        Kendall tau
+        The Kendall tau statistic
     pvalue : float
-        p-value
+        The p-value
 
     References
     ----------

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -543,21 +543,40 @@ def spearmanr(x, y=None, use_ties=True, axis=None, nan_policy='propagate',
         return SpearmanrResult(rs, prob)
 
 
-def _kendall_p_exact(n, c):
-    # Exact p-value, see Maurice G. Kendall, "Rank Correlation Methods" (4th Edition), Charles Griffin & Co., 1970.
+def _kendall_p_exact(n, c, alternative='two-sided'):
+
+    # Use the fact that distribution is symmetric: always calculate a CDF in
+    # the left tail.
+    # This will be the one-sided p-value if `c` is on the side of
+    # the null distribution predicted by the alternative hypothesis.
+    # The two-sided p-value will be twice this value.
+    # If `c` is on the other side of the null distribution, we'll need to
+    # take the complement and add back the probability mass at `c`.
+    in_right_tail = (c >= (n*(n-1))//2 - c)
+    alternative_greater = (alternative == 'greater')
+    c = int(min(c, (n*(n-1))//2 - c))
+
+    # Exact p-value, see Maurice G. Kendall, "Rank Correlation Methods"
+    # (4th Edition), Charles Griffin & Co., 1970.
     if n <= 0:
         raise ValueError(f'n ({n}) must be positive')
     elif c < 0 or 4*c > n*(n-1):
         raise ValueError(f'c ({c}) must satisfy 0 <= 4c <= n(n-1) = {n*(n-1)}.')
     elif n == 1:
         prob = 1.0
+        p_mass_at_statistic = 1
     elif n == 2:
         prob = 1.0
+        p_mass_at_statistic = 0.5
     elif c == 0:
         prob = 2.0/math.factorial(n) if n < 171 else 0.0
+        p_mass_at_statistic = prob/2
     elif c == 1:
         prob = 2.0/math.factorial(n-1) if n < 172 else 0.0
-    elif 4*c == n*(n-1):
+        p_mass_at_statistic = (n-1)/math.factorial(n)
+    elif 4*c == n*(n-1) and alternative == 'two-sided':
+        # I'm sure there's a simple formula for p_mass_at_statistic in this
+        # case, but I don't know it. Use generic formula for one-sided p-value.
         prob = 1.0
     elif n < 171:
         new = np.zeros(c+1)
@@ -567,6 +586,7 @@ def _kendall_p_exact(n, c):
             if j <= c:
                 new[j:] -= new[:c+1-j]
         prob = 2.0*np.sum(new)/math.factorial(n)
+        p_mass_at_statistic = new[-1]/math.factorial(n)
     else:
         new = np.zeros(c+1)
         new[0:2] = 1.0
@@ -575,14 +595,26 @@ def _kendall_p_exact(n, c):
             if j <= c:
                 new[j:] -= new[:c+1-j]
         prob = np.sum(new)
+        p_mass_at_statistic = new[-1]/2
 
-    return np.clip(prob, 0, 1)
+    if alternative != 'two-sided':
+        # if the alternative hypothesis and alternative agree,
+        # one-sided p-value is half the two-sided p-value
+        if in_right_tail == alternative_greater:
+            prob /= 2
+        else:
+            prob = 1 - prob/2 + p_mass_at_statistic
+
+    prob = np.clip(prob, 0, 1)
+
+    return prob
 
 
 KendalltauResult = namedtuple('KendalltauResult', ('correlation', 'pvalue'))
 
 
-def kendalltau(x, y, use_ties=True, use_missing=False, method='auto'):
+def kendalltau(x, y, use_ties=True, use_missing=False, method='auto',
+               alternative='two-sided'):
     """
     Computes Kendall's rank correlation tau on two variables *x* and *y*.
 
@@ -605,13 +637,20 @@ def kendalltau(x, y, use_ties=True, use_missing=False, method='auto'):
         time may grow and the result may lose some precision.
         'auto' is the default and selects the appropriate
         method based on a trade-off between speed and accuracy.
+    alternative : {'two-sided', 'less', 'greater'}, optional
+        Defines the alternative hypothesis. Default is 'two-sided'.
+        The following options are available:
+
+        * 'two-sided': the rank correlation is nonzero
+        * 'less': the rank correlation is negative (less than zero)
+        * 'greater':  the rank correlation is positive (greater than zero)
 
     Returns
     -------
     correlation : float
         Kendall tau
     pvalue : float
-        Approximate 2-side p-value.
+        p-value
 
     References
     ----------
@@ -661,7 +700,7 @@ def kendalltau(x, y, use_ties=True, use_missing=False, method='auto'):
             method = 'asymptotic'
 
     if not xties and not yties and method == 'exact':
-        prob = _kendall_p_exact(n, int(min(C, (n*(n-1))//2-C)))
+        prob = _kendall_p_exact(n, C, alternative)
 
     elif method == 'asymptotic':
         var_s = n*(n-1)*(2*n+5)
@@ -685,7 +724,7 @@ def kendalltau(x, y, use_ties=True, use_missing=False, method='auto'):
         var_s /= 18.
         var_s += (v1 + v2)
         z = (C-D)/np.sqrt(var_s)
-        prob = special.erfc(abs(z)/np.sqrt(2))
+        _, prob = scipy.stats.stats._normtest_finish(z, alternative)
     else:
         raise ValueError("Unknown method "+str(method)+" specified, please "
                          "use auto, exact or asymptotic.")

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -4741,8 +4741,8 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate',
             return mstats_basic.kendalltau(x, y, method=method, use_ties=True,
                                            alternative=alternative)
         else:
-            message = ("`nan_policy='omit' is currently compatible only with "
-                       "`variant='b'.")
+            message = ("nan_policy='omit' is currently compatible only with "
+                       "variant='b'.")
             raise ValueError(message)
 
     if initial_lexsort is not None:  # deprecate to drop!

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -4737,11 +4737,12 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate',
     elif contains_nan and nan_policy == 'omit':
         x = ma.masked_invalid(x)
         y = ma.masked_invalid(y)
-        if variant == 'b' and alternative == 'two-sided':
-            return mstats_basic.kendalltau(x, y, method=method, use_ties=True)
+        if variant == 'b':
+            return mstats_basic.kendalltau(x, y, method=method, use_ties=True,
+                                           alternative=alternative)
         else:
             message = ("`nan_policy='omit' is currently compatible only with "
-                       "`variant='b' and `alternative='two-sided'`.")
+                       "`variant='b'.")
             raise ValueError(message)
 
     if initial_lexsort is not None:  # deprecate to drop!
@@ -4806,7 +4807,7 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate',
             method = 'asymptotic'
 
     if xtie == 0 and ytie == 0 and method == 'exact':
-        pvalue = mstats_basic._kendall_p_exact(size, min(dis, tot-dis))
+        pvalue = mstats_basic._kendall_p_exact(size, tot-dis, alternative)
     elif method == 'asymptotic':
         # con_minus_dis is approx normally distributed with this variance [3]_
         m = size * (size - 1.)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -4665,7 +4665,7 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate',
     correlation : float
        The tau statistic.
     pvalue : float
-       The two-sided p-value for a hypothesis test whose null hypothesis is
+       The p-value for a hypothesis test whose null hypothesis is
        an absence of association, tau = 0.
 
     See Also
@@ -5965,7 +5965,7 @@ def ttest_ind(a, b, axis=0, equal_var=True, nan_policy='propagate',
     statistic : float or array
         The calculated t-statistic.
     pvalue : float or array
-        The two-tailed p-value.
+        The p-value.
 
     Notes
     -----
@@ -6305,7 +6305,7 @@ def _permutation_ttest(a, b, permutations, axis=0, equal_var=True,
     statistic : float or array
         The calculated t-statistic.
     pvalue : float or array
-        The two-tailed p-value.
+        The p-value.
 
     """
     random_state = check_random_state(random_state)

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -407,6 +407,37 @@ class TestCorr:
         assert_almost_equal(output['seasonal p-value'].round(2),
                             [0.18,0.53,0.20,0.04])
 
+    @pytest.mark.parametrize("method", ("exact", "asymptotic"))
+    @pytest.mark.parametrize("alternative", ("two-sided", "greater", "less"))
+    def test_kendalltau_mstats_vs_stats(self, method, alternative):
+        # Test that mstats.kendalltau and stats.kendalltau with
+        # nan_policy='omit' matches behavior of stats.kendalltau
+        # Accuracy of the alternatives is tested in stats/tests/test_stats.py
+
+        np.random.seed(0)
+        n = 50
+        x = np.random.rand(n)
+        y = np.random.rand(n)
+        mask = np.random.rand(n) > 0.5
+
+        x_masked = ma.array(x, mask=mask)
+        y_masked = ma.array(y, mask=mask)
+        res_masked = mstats.kendalltau(
+            x_masked, y_masked, method=method, alternative=alternative)
+
+        x_compressed = x_masked.compressed()
+        y_compressed = y_masked.compressed()
+        res_compressed = stats.kendalltau(
+            x_compressed, y_compressed, method=method, alternative=alternative)
+
+        x[mask] = np.nan
+        y[mask] = np.nan
+        res_nan = stats.kendalltau(
+            x, y, method=method, nan_policy='omit', alternative=alternative)
+
+        assert_allclose(res_masked, res_compressed)
+        assert_allclose(res_nan, res_compressed)
+
     def test_kendall_p_exact_medium(self):
         # Test for the exact method with medium samples (some n >= 171)
         # expected values generated using SymPy

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1314,57 +1314,66 @@ class TestKendallTauAlternative:
         res_expected = stat_expected, p_expected
         assert_allclose(res, res_expected)
 
-    @pytest.mark.parametrize("alternative, p_expected, rev",
-        list(zip(alternatives, p_n1, [False]*3)) +
-        list(zip(alternatives, reversed(p_n1), [True]*3)))
+    case_R_n1 = (list(zip(alternatives, p_n1, [False]*3))
+                 + list(zip(alternatives, reversed(p_n1), [True]*3)))
+
+    @pytest.mark.parametrize("alternative, p_expected, rev", case_R_n1)
     def test_against_R_n1(self, alternative, p_expected, rev):
         x, y = [1], [2]
         stat_expected = np.nan
         self.exact_test(x, y, alternative, rev, stat_expected, p_expected)
 
-    @pytest.mark.parametrize("alternative, p_expected, rev",
-        list(zip(alternatives, p_n2, [False]*3)) +
-        list(zip(alternatives, reversed(p_n2), [True]*3)))
+    case_R_n2 = (list(zip(alternatives, p_n2, [False]*3))
+                 + list(zip(alternatives, reversed(p_n2), [True]*3)))
+
+    @pytest.mark.parametrize("alternative, p_expected, rev", case_R_n2)
     def test_against_R_n2(self, alternative, p_expected, rev):
         x, y = [1, 2], [3, 4]
         stat_expected = 0.9999999999999998
         self.exact_test(x, y, alternative, rev, stat_expected, p_expected)
 
-    @pytest.mark.parametrize("alternative, p_expected, rev",
-        list(zip(alternatives, p_c0, [False]*3)) +
-        list(zip(alternatives, reversed(p_c0), [True]*3)))
+    case_R_c0 = (list(zip(alternatives, p_c0, [False]*3))
+                 + list(zip(alternatives, reversed(p_c0), [True]*3)))
+
+    @pytest.mark.parametrize("alternative, p_expected, rev", case_R_c0)
     def test_against_R_c0(self, alternative, p_expected, rev):
         x, y = [1, 2, 3], [1, 2, 3]
         stat_expected = 1
         self.exact_test(x, y, alternative, rev, stat_expected, p_expected)
 
-    @pytest.mark.parametrize("alternative, p_expected, rev",
-        list(zip(alternatives, p_c1, [False]*3)) +
-        list(zip(alternatives, reversed(p_c1), [True]*3)))
+    case_R_c1 = (list(zip(alternatives, p_c1, [False]*3))
+                 + list(zip(alternatives, reversed(p_c1), [True]*3)))
+
+    @pytest.mark.parametrize("alternative, p_expected, rev", case_R_c1)
     def test_against_R_c1(self, alternative, p_expected, rev):
         x, y = [1, 2, 3, 4], [1, 2, 4, 3]
         stat_expected = 0.6666666666666667
         self.exact_test(x, y, alternative, rev, stat_expected, p_expected)
 
-    @pytest.mark.parametrize("alternative, p_expected, rev",
-        list(zip(alternatives, p_no_correlation, [False]*3)) +
-        list(zip(alternatives, reversed(p_no_correlation), [True]*3)))
+    case_R_no_corr = (list(zip(alternatives, p_no_correlation, [False]*3))
+                      + list(zip(alternatives, reversed(p_no_correlation),
+                                 [True]*3)))
+
+    @pytest.mark.parametrize("alternative, p_expected, rev", case_R_no_corr)
     def test_against_R_no_correlation(self, alternative, p_expected, rev):
         x, y = [1, 2, 3, 4, 5], [1, 5, 4, 2, 3]
         stat_expected = 0
         self.exact_test(x, y, alternative, rev, stat_expected, p_expected)
 
-    @pytest.mark.parametrize("alternative, p_expected, rev",
-        list(zip(alternatives, p_no_correlationb, [False]*3)) +
-        list(zip(alternatives, reversed(p_no_correlationb), [True]*3)))
+    case_no_cor_b = (list(zip(alternatives, p_no_correlationb, [False]*3))
+                     + list(zip(alternatives, reversed(p_no_correlationb),
+                                [True]*3)))
+
+    @pytest.mark.parametrize("alternative, p_expected, rev", case_no_cor_b)
     def test_against_R_no_correlationb(self, alternative, p_expected, rev):
         x, y = [1, 2, 3, 4, 5, 6, 7, 8], [8, 6, 1, 3, 2, 5, 4, 7]
         stat_expected = 0
         self.exact_test(x, y, alternative, rev, stat_expected, p_expected)
 
-    @pytest.mark.parametrize("alternative, p_expected, rev",
-        list(zip(alternatives, p_n_lt_171, [False]*3)) +
-        list(zip(alternatives, reversed(p_n_lt_171), [True]*3)))
+    case_R_lt_171 = (list(zip(alternatives, p_n_lt_171, [False]*3))
+                     + list(zip(alternatives, reversed(p_n_lt_171), [True]*3)))
+
+    @pytest.mark.parametrize("alternative, p_expected, rev", case_R_lt_171)
     def test_against_R_lt_171(self, alternative, p_expected, rev):
         # Data from Hollander & Wolfe (1973), p. 187f.
         # Used from https://rdrr.io/r/stats/cor.test.html
@@ -1373,9 +1382,11 @@ class TestKendallTauAlternative:
         stat_expected = 0.4444444444444445
         self.exact_test(x, y, alternative, rev, stat_expected, p_expected)
 
-    @pytest.mark.parametrize("alternative, p_expected, rev",
-        list(zip(alternatives, p_n_lt_171b, [False]*3)) +
-        list(zip(alternatives, reversed(p_n_lt_171b), [True]*3)))
+    case_R_lt_171b = (list(zip(alternatives, p_n_lt_171b, [False]*3))
+                      + list(zip(alternatives, reversed(p_n_lt_171b),
+                                 [True]*3)))
+
+    @pytest.mark.parametrize("alternative, p_expected, rev", case_R_lt_171b)
     def test_against_R_lt_171b(self, alternative, p_expected, rev):
         np.random.seed(0)
         x = np.random.rand(100)
@@ -1383,9 +1394,11 @@ class TestKendallTauAlternative:
         stat_expected = -0.04686868686868687
         self.exact_test(x, y, alternative, rev, stat_expected, p_expected)
 
-    @pytest.mark.parametrize("alternative, p_expected, rev",
-        list(zip(alternatives, p_n_lt_171c, [False]*3)) +
-        list(zip(alternatives, reversed(p_n_lt_171c), [True]*3)))
+    case_R_lt_171c = (list(zip(alternatives, p_n_lt_171c, [False]*3))
+                      + list(zip(alternatives, reversed(p_n_lt_171c),
+                                 [True]*3)))
+
+    @pytest.mark.parametrize("alternative, p_expected, rev", case_R_lt_171c)
     def test_against_R_lt_171c(self, alternative, p_expected, rev):
         np.random.seed(0)
         x = np.random.rand(170)
@@ -1393,8 +1406,10 @@ class TestKendallTauAlternative:
         stat_expected = 0.1115906717716673
         self.exact_test(x, y, alternative, rev, stat_expected, p_expected)
 
-    @pytest.mark.parametrize("alternative, rev",
-        list(zip(alternatives, [False]*3)) + list(zip(alternatives, [True]*3)))
+    case_R_gt_171 = (list(zip(alternatives, [False]*3)) +
+                     list(zip(alternatives, [True]*3)))
+
+    @pytest.mark.parametrize("alternative, rev", case_R_gt_171)
     def test_against_R_gt_171(self, alternative, rev):
         np.random.seed(0)
         x = np.random.rand(400)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1300,6 +1300,8 @@ class TestKendallTauAlternative:
     p_n2 = [1, 1, 0.5]
     p_c0 = [1, 0.3333333333333, 0.1666666666667]
     p_c1 = [0.9583333333333, 0.3333333333333, 0.1666666666667]
+    p_no_correlation = [0.5916666666667, 1, 0.5916666666667]
+    p_no_correlationb = [0.5475694444444, 1, 0.5475694444444]
     p_n_lt_171 = [0.9624118165785, 0.1194389329806, 0.0597194664903]
     p_n_lt_171b = [0.246236925303, 0.4924738506059, 0.755634083327]
     p_n_lt_171c = [0.9847475308925, 0.03071385306533, 0.01535692653267]
@@ -1342,6 +1344,22 @@ class TestKendallTauAlternative:
     def test_against_R_c1(self, alternative, p_expected, rev):
         x, y = [1, 2, 3, 4], [1, 2, 4, 3]
         stat_expected = 0.6666666666666667
+        self.exact_test(x, y, alternative, rev, stat_expected, p_expected)
+
+    @pytest.mark.parametrize("alternative, p_expected, rev",
+        list(zip(alternatives, p_no_correlation, [False]*3)) +
+        list(zip(alternatives, reversed(p_no_correlation), [True]*3)))
+    def test_against_R_no_correlation(self, alternative, p_expected, rev):
+        x, y = [1, 2, 3, 4, 5], [1, 5, 4, 2, 3]
+        stat_expected = 0
+        self.exact_test(x, y, alternative, rev, stat_expected, p_expected)
+
+    @pytest.mark.parametrize("alternative, p_expected, rev",
+        list(zip(alternatives, p_no_correlationb, [False]*3)) +
+        list(zip(alternatives, reversed(p_no_correlationb), [True]*3)))
+    def test_against_R_no_correlationb(self, alternative, p_expected, rev):
+        x, y = [1, 2, 3, 4, 5, 6, 7, 8], [8, 6, 1, 3, 2, 5, 4, 7]
+        stat_expected = 0
         self.exact_test(x, y, alternative, rev, stat_expected, p_expected)
 
     @pytest.mark.parametrize("alternative, p_expected, rev",

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1259,7 +1259,7 @@ class TestKendallTauAlternative:
         assert_equal(res[0], expected[0])
         assert_allclose(res[1], 1 - (expected[1] / 2))
 
-        # rank correlation > 0 -> small "less" p-value
+        # rank correlation > 0 -> small "greater" p-value
         res = stats.kendalltau(x1, x2, alternative="greater")
         assert_equal(res[0], expected[0])
         assert_allclose(res[1], expected[1] / 2)
@@ -1271,12 +1271,12 @@ class TestKendallTauAlternative:
         expected = stats.kendalltau(x1, x2, alternative="two-sided")
         assert expected[0] < 0
 
-        # rank correlation > 0 -> large "greater" p-value
+        # rank correlation < 0 -> large "greater" p-value
         res = stats.kendalltau(x1, x2, alternative="greater")
         assert_equal(res[0], expected[0])
         assert_allclose(res[1], 1 - (expected[1] / 2))
 
-        # rank correlation > 0 -> small "less" p-value
+        # rank correlation < 0 -> small "less" p-value
         res = stats.kendalltau(x1, x2, alternative="less")
         assert_equal(res[0], expected[0])
         assert_allclose(res[1], expected[1] / 2)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1406,11 +1406,11 @@ class TestKendallTauAlternative:
         stat_expected = 0.1115906717716673
         self.exact_test(x, y, alternative, rev, stat_expected, p_expected)
 
-    case_R_gt_171 = (list(zip(alternatives, [False]*3)) +
-                     list(zip(alternatives, [True]*3)))
+    case_gt_171 = (list(zip(alternatives, [False]*3)) +
+                   list(zip(alternatives, [True]*3)))
 
-    @pytest.mark.parametrize("alternative, rev", case_R_gt_171)
-    def test_against_R_gt_171(self, alternative, rev):
+    @pytest.mark.parametrize("alternative, rev", case_gt_171)
+    def test_gt_171(self, alternative, rev):
         np.random.seed(0)
         x = np.random.rand(400)
         y = np.random.rand(400)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1242,82 +1242,185 @@ def test_kendalltau_nan_2nd_arg():
     assert_allclose(r1.correlation, r2.correlation, atol=1e-15)
 
 
-def test_kendalltau_alternative():
-    # Test alternative parameter
+class TestKendallTauAlternative:
+    def test_kendalltau_alternative_asymptotic(self):
+        # Test alternative parameter, asymptotic method (due to tie)
 
-    # Simple test - Based on TestCorrSpearman2::test_alternative
-    x1 = [1, 2, 3, 4, 5]
-    x2 = [5, 6, 7, 8, 7]
+        # Based on TestCorrSpearman2::test_alternative
+        x1 = [1, 2, 3, 4, 5]
+        x2 = [5, 6, 7, 8, 7]
 
-    # strong positive correlation
-    expected = stats.kendalltau(x1, x2, alternative="two-sided")
-    assert expected[0] > 0
+        # strong positive correlation
+        expected = stats.kendalltau(x1, x2, alternative="two-sided")
+        assert expected[0] > 0
 
-    # rank correlation > 0 -> large "less" p-value
-    res = stats.kendalltau(x1, x2, alternative="less")
-    assert_equal(res[0], expected[0])
-    assert_allclose(res[1], 1 - (expected[1] / 2))
+        # rank correlation > 0 -> large "less" p-value
+        res = stats.kendalltau(x1, x2, alternative="less")
+        assert_equal(res[0], expected[0])
+        assert_allclose(res[1], 1 - (expected[1] / 2))
 
-    # rank correlation > 0 -> small "less" p-value
-    res = stats.kendalltau(x1, x2, alternative="greater")
-    assert_equal(res[0], expected[0])
-    assert_allclose(res[1], expected[1] / 2)
+        # rank correlation > 0 -> small "less" p-value
+        res = stats.kendalltau(x1, x2, alternative="greater")
+        assert_equal(res[0], expected[0])
+        assert_allclose(res[1], expected[1] / 2)
 
-    # reverse the direction of rank correlation
-    x2.reverse()
+        # reverse the direction of rank correlation
+        x2.reverse()
 
-    # strong negative correlation
-    expected = stats.kendalltau(x1, x2, alternative="two-sided")
-    assert expected[0] < 0
+        # strong negative correlation
+        expected = stats.kendalltau(x1, x2, alternative="two-sided")
+        assert expected[0] < 0
 
-    # rank correlation > 0 -> large "greater" p-value
-    res = stats.kendalltau(x1, x2, alternative="greater")
-    assert_equal(res[0], expected[0])
-    assert_allclose(res[1], 1 - (expected[1] / 2))
+        # rank correlation > 0 -> large "greater" p-value
+        res = stats.kendalltau(x1, x2, alternative="greater")
+        assert_equal(res[0], expected[0])
+        assert_allclose(res[1], 1 - (expected[1] / 2))
 
-    # rank correlation > 0 -> small "less" p-value
-    res = stats.kendalltau(x1, x2, alternative="less")
-    assert_equal(res[0], expected[0])
-    assert_allclose(res[1], expected[1] / 2)
+        # rank correlation > 0 -> small "less" p-value
+        res = stats.kendalltau(x1, x2, alternative="less")
+        assert_equal(res[0], expected[0])
+        assert_allclose(res[1], expected[1] / 2)
 
-    with pytest.raises(ValueError, match="alternative must be 'less'..."):
-        stats.kendalltau(x1, x2, alternative="ekki-ekki")
+        with pytest.raises(ValueError, match="alternative must be 'less'..."):
+            stats.kendalltau(x1, x2, alternative="ekki-ekki")
 
+    # There are a lot of special cases considered in the calculation of the
+    # exact p-value, so we test each separately. We also need to test
+    # separately when the observed statistic is in the left tail vs the right
+    # tail because the code leverages symmetry of the null distribution; to
+    # do that we use the same test case but negate one of the samples.
+    # Reference values computed using R cor.test, e.g.
+    # options(digits=16)
+    # x <- c(44.4, 45.9, 41.9, 53.3, 44.7, 44.1, 50.7, 45.2, 60.1)
+    # y <- c( 2.6,  3.1,  2.5,  5.0,  3.6,  4.0,  5.2,  2.8,  3.8)
+    # cor.test(x, y, method = "kendall", alternative = "g")
 
-@pytest.mark.parametrize("alternative", ('two-sided', 'less', 'greater'))
-def test_kendalltau_alternative_nan_policy(alternative):
-    # Test nan policies
-    x1 = [1, 2, 3, 4, 5]
-    x2 = [5, 6, 7, 8, 7]
-    x1nan = x1 + [np.nan]
-    x2nan = x2 + [np.nan]
+    alternatives = ('less', 'two-sided', 'greater')
+    p_n1 = [np.nan, np.nan, np.nan]
+    p_n2 = [1, 1, 0.5]
+    p_c0 = [1, 0.3333333333333, 0.1666666666667]
+    p_c1 = [0.9583333333333, 0.3333333333333, 0.1666666666667]
+    p_n_lt_171 = [0.9624118165785, 0.1194389329806, 0.0597194664903]
+    p_n_lt_171b = [0.246236925303, 0.4924738506059, 0.755634083327]
+    p_n_lt_171c = [0.9847475308925, 0.03071385306533, 0.01535692653267]
 
-    # test nan_policy="propagate"
-    assert_array_equal(stats.kendalltau(x1nan, x2nan), (np.nan, np.nan))
+    def exact_test(self, x, y, alternative, rev, stat_expected, p_expected):
+        if rev:
+            y = -np.asarray(y)
+            stat_expected *= -1
+        res = stats.kendalltau(x, y, method='exact', alternative=alternative)
+        res_expected = stat_expected, p_expected
+        assert_allclose(res, res_expected)
 
-    # test nan_policy="omit"
-    if alternative == 'two-sided':
-        res_actual = stats.kendalltau(x1nan, x2nan, nan_policy='omit',
-                                      alternative=alternative)
-        res_expected = stats.kendalltau(x1, x2, alternative=alternative)
+    @pytest.mark.parametrize("alternative, p_expected, rev",
+        list(zip(alternatives, p_n1, [False]*3)) +
+        list(zip(alternatives, reversed(p_n1), [True]*3)))
+    def test_against_R_n1(self, alternative, p_expected, rev):
+        x, y = [1], [2]
+        stat_expected = np.nan
+        self.exact_test(x, y, alternative, rev, stat_expected, p_expected)
+
+    @pytest.mark.parametrize("alternative, p_expected, rev",
+        list(zip(alternatives, p_n2, [False]*3)) +
+        list(zip(alternatives, reversed(p_n2), [True]*3)))
+    def test_against_R_n2(self, alternative, p_expected, rev):
+        x, y = [1, 2], [3, 4]
+        stat_expected = 0.9999999999999998
+        self.exact_test(x, y, alternative, rev, stat_expected, p_expected)
+
+    @pytest.mark.parametrize("alternative, p_expected, rev",
+        list(zip(alternatives, p_c0, [False]*3)) +
+        list(zip(alternatives, reversed(p_c0), [True]*3)))
+    def test_against_R_c0(self, alternative, p_expected, rev):
+        x, y = [1, 2, 3], [1, 2, 3]
+        stat_expected = 1
+        self.exact_test(x, y, alternative, rev, stat_expected, p_expected)
+
+    @pytest.mark.parametrize("alternative, p_expected, rev",
+        list(zip(alternatives, p_c1, [False]*3)) +
+        list(zip(alternatives, reversed(p_c1), [True]*3)))
+    def test_against_R_c1(self, alternative, p_expected, rev):
+        x, y = [1, 2, 3, 4], [1, 2, 4, 3]
+        stat_expected = 0.6666666666666667
+        self.exact_test(x, y, alternative, rev, stat_expected, p_expected)
+
+    @pytest.mark.parametrize("alternative, p_expected, rev",
+        list(zip(alternatives, p_n_lt_171, [False]*3)) +
+        list(zip(alternatives, reversed(p_n_lt_171), [True]*3)))
+    def test_against_R_lt_171(self, alternative, p_expected, rev):
+        # Data from Hollander & Wolfe (1973), p. 187f.
+        # Used from https://rdrr.io/r/stats/cor.test.html
+        x = [44.4, 45.9, 41.9, 53.3, 44.7, 44.1, 50.7, 45.2, 60.1]
+        y = [2.6, 3.1, 2.5, 5.0, 3.6, 4.0, 5.2, 2.8, 3.8]
+        stat_expected = 0.4444444444444445
+        self.exact_test(x, y, alternative, rev, stat_expected, p_expected)
+
+    @pytest.mark.parametrize("alternative, p_expected, rev",
+        list(zip(alternatives, p_n_lt_171b, [False]*3)) +
+        list(zip(alternatives, reversed(p_n_lt_171b), [True]*3)))
+    def test_against_R_lt_171b(self, alternative, p_expected, rev):
+        np.random.seed(0)
+        x = np.random.rand(100)
+        y = np.random.rand(100)
+        stat_expected = -0.04686868686868687
+        self.exact_test(x, y, alternative, rev, stat_expected, p_expected)
+
+    @pytest.mark.parametrize("alternative, p_expected, rev",
+        list(zip(alternatives, p_n_lt_171c, [False]*3)) +
+        list(zip(alternatives, reversed(p_n_lt_171c), [True]*3)))
+    def test_against_R_lt_171c(self, alternative, p_expected, rev):
+        np.random.seed(0)
+        x = np.random.rand(170)
+        y = np.random.rand(170)
+        stat_expected = 0.1115906717716673
+        self.exact_test(x, y, alternative, rev, stat_expected, p_expected)
+
+    @pytest.mark.parametrize("alternative, rev",
+        list(zip(alternatives, [False]*3)) + list(zip(alternatives, [True]*3)))
+    def test_against_R_gt_171(self, alternative, rev):
+        np.random.seed(0)
+        x = np.random.rand(400)
+        y = np.random.rand(400)
+        res0 = stats.kendalltau(x, y, method='exact',
+                                alternative=alternative)
+        res1 = stats.kendalltau(x, y, method='asymptotic',
+                                alternative=alternative)
+        assert_equal(res0[0], res1[0])
+        assert_allclose(res0[1], res1[1], rtol=1e-3)
+
+    @pytest.mark.parametrize("method", ('exact', 'asymptotic'))
+    @pytest.mark.parametrize("alternative", ('two-sided', 'less', 'greater'))
+    def test_nan_policy(self, method, alternative):
+        # Test nan policies
+        x1 = [1, 2, 3, 4, 5]
+        x2 = [5, 6, 7, 8, 9]
+        x1nan = x1 + [np.nan]
+        x2nan = x2 + [np.nan]
+
+        # test nan_policy="propagate"
+        res_actual = stats.kendalltau(x1nan, x2nan,
+                                      method=method, alternative=alternative)
+        res_expected = (np.nan, np.nan)
         assert_allclose(res_actual, res_expected)
-    else:
-        message = "`nan_policy='omit' is currently compatible only with"
+
+        # test nan_policy="omit"
+        res_actual = stats.kendalltau(x1nan, x2nan, nan_policy='omit',
+                                      method=method, alternative=alternative)
+        res_expected = stats.kendalltau(x1, x2, method=method,
+                                        alternative=alternative)
+        assert_allclose(res_actual, res_expected)
+
+        # test nan_policy="raise"
+        message = 'The input contains nan values'
         with pytest.raises(ValueError, match=message):
-            stats.kendalltau(x1nan, x2nan, nan_policy='omit',
-                             alternative=alternative)
+            stats.kendalltau(x1nan, x2nan, nan_policy='raise',
+                             method=method, alternative=alternative)
 
-    # test nan_policy="raise"
-    message = 'The input contains nan values'
-    with pytest.raises(ValueError, match=message):
-        stats.kendalltau(x1nan, x2nan, nan_policy='raise',
-                         alternative=alternative)
-
-    # test invalid nan_policy
-    message = "nan_policy must be one of..."
-    with pytest.raises(ValueError, match=message):
-        stats.kendalltau(x1nan, x2nan, nan_policy='ekki-ekki',
-                         alternative=alternative)
+        # test invalid nan_policy
+        message = "nan_policy must be one of..."
+        with pytest.raises(ValueError, match=message):
+            stats.kendalltau(x1nan, x2nan, nan_policy='ekki-ekki',
+                             method=method, alternative=alternative)
 
 
 def test_weightedtau():


### PR DESCRIPTION
#### Reference issue
gh-12506
gh-12801

#### What does this implement/fix?
This PR adds an `alternative` parameter to `kendalltau`. The asymptotic implementation and tests closely follow the example of gh-12801 (for `spearmanr`), lightly adapted to `kendalltau`. The exact implementation is more involved because of all the special cases in the calculation of the p-value.