### PR TITLE
BUG: Fix Nelder-Mead logic when using a non-1D x0 and adapative

### DIFF
--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -671,6 +671,8 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
 
     fcalls, func = _wrap_function(func, args)
 
+    x0 = asfarray(x0).flatten()
+
     if adaptive:
         dim = float(len(x0))
         rho = 1
@@ -685,8 +687,6 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
 
     nonzdelt = 0.05
     zdelt = 0.00025
-
-    x0 = asfarray(x0).flatten()
 
     if bounds is not None:
         lower_bound, upper_bound = bounds.lb, bounds.ub


### PR DESCRIPTION
#### Reference issue
n.a.

#### What does this implement/fix?
In the Nelder-Mead minimizer, when providing a non 1D `x0` (e.g. `x0 = np.zeros((1,10))`) and using `adaptive = True`, in the if adaptive block the program would use the first dimension of `x0` instead of the actual number of element. With the previous example, it would mean using `dim = 1` instead of `dim = 10`.

By moving the flattening of `x0` before this block, we can work around this problem without further altering the logic flow of the program, as `x0` is not used anywhere else between the 2 positions.

#### Additional information
n.a.