### PR TITLE
Fixed doc for gaussian_kde (kde.factor description)

### DIFF
--- a/scipy/stats/kde.py
+++ b/scipy/stats/kde.py
@@ -76,8 +76,9 @@ class gaussian_kde:
 
         .. versionadded:: 1.2.0
     factor : float
-        The bandwidth factor, obtained from `kde.covariance_factor`, with which
-        the covariance matrix is multiplied.
+        The bandwidth factor, obtained from `kde.covariance_factor`. The square
+        of `kde.factor` multiplies the covariance matrix of the data in the kde
+        estimation.
     covariance : ndarray
         The covariance matrix of `dataset`, scaled by the calculated bandwidth
         (`kde.factor`).


### PR DESCRIPTION
#### Reference issue

[gh-14217](https://github.com/scipy/scipy/issues/14217)

#### What does this implement/fix?

This fixes the doc description of the `factor` attribute in `stats.gaussian_kde`. 

#### Additional information

Here is the code in `stats.gaussian_kde`, where `factor` is assigned and used. Its square multiplies the **data** covariance matrix, to get the covariance of the Gaussian distributions used to construct the Gaussian mixture giving the kde.
```python
    def _compute_covariance(self):
        """Computes the covariance matrix for each Gaussian kernel using
        covariance_factor().
        """
        self.factor = self.covariance_factor()
        # Cache covariance and inverse covariance of the data
        if not hasattr(self, '_data_inv_cov'):
            self._data_covariance = atleast_2d(cov(self.dataset, rowvar=1,
                                               bias=False,
                                               aweights=self.weights))
            self._data_inv_cov = linalg.inv(self._data_covariance)

        self.covariance = self._data_covariance * self.factor**2
        self.inv_cov = self._data_inv_cov / self.factor**2
        L = linalg.cholesky(self.covariance*2*pi)
        self.log_det = 2*np.log(np.diag(L)).sum()
```
The documentation currently reports that it is `factor` to multiply the covariance, not `factor**2`.