### PR TITLE
ENH: stats: somersd: add alternative parameter

### DIFF
--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -467,7 +467,7 @@ def _tau_b(A):
     return tau, p
 
 
-def _somers_d(A):
+def _somers_d(A, alternative='two-sided'):
     """Calculate Somers' D and p-value from contingency table."""
     # See [3] page 1740
 
@@ -484,10 +484,11 @@ def _somers_d(A):
     d = (PA - QA)/(NA2 - Sri2)
 
     S = _a_ij_Aij_Dij2(A) - (PA-QA)**2/NA
-    if S == 0:  # Avoid divide by zero
-        return d, 0
-    Z = (PA - QA)/(4*(S))**0.5
-    p = 2*norm.sf(abs(Z))  # 2-sided p-value
+
+    with np.errstate(divide='ignore'):
+        Z = (PA - QA)/(4*(S))**0.5
+
+    _, p = scipy.stats.stats._normtest_finish(Z, alternative)
 
     return d, p
 
@@ -496,7 +497,7 @@ SomersDResult = make_dataclass("SomersDResult",
                                ("statistic", "pvalue", "table"))
 
 
-def somersd(x, y=None):
+def somersd(x, y=None, alternative='two-sided'):
     r"""Calculates Somers' D, an asymmetric measure of ordinal association.
 
     Like Kendall's :math:`\tau`, Somers' :math:`D` is a measure of the
@@ -530,10 +531,16 @@ def somersd(x, y=None):
     x: array_like
         1D array of rankings, treated as the (row) independent variable.
         Alternatively, a 2D contingency table.
-    y: array_like
+    y: array_like, optional
         If `x` is a 1D array of rankings, `y` is a 1D array of rankings of the
         same length, treated as the (column) dependent variable.
         If `x` is 2D, `y` is ignored.
+    alternative : {'two-sided', 'less', 'greater'}, optional
+        Defines the alternative hypothesis. Default is 'two-sided'.
+        The following options are available:
+        * 'two-sided': the rank correlation is nonzero
+        * 'less': the rank correlation is negative (less than zero)
+        * 'greater':  the rank correlation is positive (greater than zero)
 
     Returns
     -------
@@ -543,7 +550,7 @@ def somersd(x, y=None):
             correlation : float
                The Somers' :math:`D` statistic.
             pvalue : float
-               The two-sided p-value for a hypothesis test whose null
+               The p-value for a hypothesis test whose null
                hypothesis is an absence of association, :math:`D=0`.
                See notes for more information.
             table : 2D array
@@ -663,7 +670,7 @@ def somersd(x, y=None):
         table = x
     else:
         raise ValueError("x must be either a 1D or 2D array")
-    d, p = _somers_d(table)
+    d, p = _somers_d(table, alternative)
     return SomersDResult(d, p, table)
 
 
@@ -682,7 +689,7 @@ def _all_partitions(nx, ny):
         y = z[mask]
         yield x, y
 
-        
+
 def _compute_log_combinations(n):
     """Compute all log combination of C(n, k)."""
     gammaln_arr = gammaln(np.arange(n + 1) + 1)
@@ -1028,8 +1035,8 @@ def boschloo_exact(table, alternative="two-sided", n=32):
     - :math:`H_0 : p_1 = p_2` versus :math:`H_1 : p_1 \neq p_2`,
       with `alternative` = "two-sided" (default one)
 
-    Boschloo's exact test uses the p-value of Fisher's exact test as a 
-    statistic, and Boschloo's p-value is the probability under the null 
+    Boschloo's exact test uses the p-value of Fisher's exact test as a
+    statistic, and Boschloo's p-value is the probability under the null
     hypothesis of observing such an extreme value of this statistic.
 
     Boschloo's and Barnard's are both more powerful than Fisher's exact

--- a/scipy/stats/tests/test_hypotests.py
+++ b/scipy/stats/tests/test_hypotests.py
@@ -858,6 +858,70 @@ class TestSomersD:
         res = stats.somersd(x, y)
         assert_equal(res.table, np.eye(10))
 
+    def test_somersd_alternative(self):
+        # Test alternative parameter, asymptotic method (due to tie)
+
+        # Based on scipy.stats.test_stats.TestCorrSpearman2::test_alternative
+        x1 = [1, 2, 3, 4, 5]
+        x2 = [5, 6, 7, 8, 7]
+
+        # strong positive correlation
+        expected = stats.somersd(x1, x2, alternative="two-sided")
+        assert expected.statistic > 0
+
+        # rank correlation > 0 -> large "less" p-value
+        res = stats.somersd(x1, x2, alternative="less")
+        assert_equal(res.statistic, expected.statistic)
+        assert_allclose(res.pvalue, 1 - (expected.pvalue / 2))
+
+        # rank correlation > 0 -> small "greater" p-value
+        res = stats.somersd(x1, x2, alternative="greater")
+        assert_equal(res.statistic, expected.statistic)
+        assert_allclose(res.pvalue, expected.pvalue / 2)
+
+        # reverse the direction of rank correlation
+        x2.reverse()
+
+        # strong negative correlation
+        expected = stats.somersd(x1, x2, alternative="two-sided")
+        assert expected.statistic < 0
+
+        # rank correlation < 0 -> large "greater" p-value
+        res = stats.somersd(x1, x2, alternative="greater")
+        assert_equal(res.statistic, expected.statistic)
+        assert_allclose(res.pvalue, 1 - (expected.pvalue / 2))
+
+        # rank correlation < 0 -> small "less" p-value
+        res = stats.somersd(x1, x2, alternative="less")
+        assert_equal(res.statistic, expected.statistic)
+        assert_allclose(res.pvalue, expected.pvalue / 2)
+
+        with pytest.raises(ValueError, match="alternative must be 'less'..."):
+            stats.somersd(x1, x2, alternative="ekki-ekki")
+
+    def test_somersd_perfect_correlation(self):
+        # Before the addition of `alternative`, perfect correlation was
+        # treated as a special case. Now it is treated like any other case, but
+        # make sure there are no divide by zero warnings or associated errors
+
+        x1 = np.arange(10)
+        x2 = x1
+
+        # perfect correlation -> small "two-sided" p-value (0)
+        res = stats.somersd(x1, x2, alternative="two-sided")
+        assert res.statistic == 1
+        assert res.pvalue == 0
+
+        # rank correlation > 0 -> large "less" p-value (1)
+        res = stats.somersd(x1, x2, alternative="less")
+        assert res.statistic == 1
+        assert res.pvalue == 1
+
+        # rank correlation > 0 -> small "greater" p-value (0)
+        res = stats.somersd(x1, x2, alternative="greater")
+        assert res.statistic == 1
+        assert res.pvalue == 0
+
 
 class TestBarnardExact:
     """Some tests to show that barnard_exact() works correctly."""

--- a/scipy/stats/tests/test_hypotests.py
+++ b/scipy/stats/tests/test_hypotests.py
@@ -899,28 +899,30 @@ class TestSomersD:
         with pytest.raises(ValueError, match="alternative must be 'less'..."):
             stats.somersd(x1, x2, alternative="ekki-ekki")
 
-    def test_somersd_perfect_correlation(self):
+    @pytest.mark.parametrize("positive_correlation", (False, True))
+    def test_somersd_perfect_correlation(self, positive_correlation):
         # Before the addition of `alternative`, perfect correlation was
         # treated as a special case. Now it is treated like any other case, but
         # make sure there are no divide by zero warnings or associated errors
 
         x1 = np.arange(10)
-        x2 = x1
+        x2 = x1 if positive_correlation else np.flip(x1)
+        expected_statistic = 1 if positive_correlation else -1
 
         # perfect correlation -> small "two-sided" p-value (0)
         res = stats.somersd(x1, x2, alternative="two-sided")
-        assert res.statistic == 1
+        assert res.statistic == expected_statistic
         assert res.pvalue == 0
 
         # rank correlation > 0 -> large "less" p-value (1)
         res = stats.somersd(x1, x2, alternative="less")
-        assert res.statistic == 1
-        assert res.pvalue == 1
+        assert res.statistic == expected_statistic
+        assert res.pvalue == (1 if positive_correlation else 0)
 
         # rank correlation > 0 -> small "greater" p-value (0)
         res = stats.somersd(x1, x2, alternative="greater")
-        assert res.statistic == 1
-        assert res.pvalue == 0
+        assert res.statistic == expected_statistic
+        assert res.pvalue == (0 if positive_correlation else 1)
 
 
 class TestBarnardExact:


### PR DESCRIPTION
#### Reference issue
gh-12506
gh-12801
gh-14209

#### What does this implement/fix?
This PR adds an `alternative` parameter to `somersd`. The asymptotic implementation and tests closely follow the example of gh-12801 (for `spearmanr`), lightly adapted to `somserd`. 

gh-14209 does the same for `kendalltau`. Let's get that polished and merged, apply any changes from that one to this one, and then this should be very straightforward.