### PR TITLE
DOC: clarify `ndimage.center_of_mass` docstring

### DIFF
--- a/scipy/ndimage/measurements.py
+++ b/scipy/ndimage/measurements.py
@@ -1355,7 +1355,8 @@ def center_of_mass(input, labels=None, index=None):
         Only used with `index`. Dimensions must be the same as `input`.
     index : int or sequence of ints, optional
         Labels for which to calculate centers-of-mass. If not specified,
-        all labels greater than zero are used. Only used with `labels`.
+        the combined center of mass of all labels greater than zero
+        will be calculated. Only used with `labels`.
 
     Returns
     -------


### PR DESCRIPTION
The docstring previously made it seem that for `index=None` you would
get an array with a COM for every label. Instead you get a single COM averaged over
all nonzero labels.

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Fixes: GH-2358

#### What does this implement/fix?
Explains more explicitly what `index=None` implies

#### Additional information
<!--Any additional information you think is important.-->