### PR TITLE
ENH: sparse.linalg: Use the faster "sqrt" from "math" and be consistent with both "lsqr.py" and "lsmr.py"

### DIFF
--- a/scipy/sparse/linalg/isolve/minres.py
+++ b/scipy/sparse/linalg/isolve/minres.py
@@ -1,5 +1,6 @@
-from numpy import sqrt, inner, zeros, inf, finfo
+from numpy import inner, zeros, inf, finfo
 from numpy.linalg import norm
+from math import sqrt
 
 from .utils import make_system
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
Replace "sqrt" from "numpy" with "sqrt" from "math" to be consistent with both "lsqr.py" and "lsmr.py".

#### Additional information
<!--Any additional information you think is important.-->