### PR TITLE
MAINT: stats: remove unused 'type: ignore' comment

### DIFF
--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -889,7 +889,7 @@ class LatinHypercube(QMCEngine):
             samples = self.rng.uniform(size=(n, self.d))  # type: ignore[assignment]
 
         perms = np.tile(np.arange(1, n + 1), (self.d, 1))
-        for i in range(self.d):  # type: ignore[arg-type]
+        for i in range(self.d):
             self.rng.shuffle(perms[i, :])
         perms = perms.T
 


### PR DESCRIPTION
#### Reference issue
All recent PRs

#### What does this implement/fix?
Attempt to eliminate mypy complaint
```scipy/stats/_qmc.py:892: error: unused "type: ignore" comment```
in 
![image](https://user-images.githubusercontent.com/6570539/121768213-e9a94800-cb11-11eb-8cd4-e038dd7a8f1a.png)

#### Additional information
Anecdotes about mypy saving people time/trouble are welcome.