### PR TITLE
MAINT: Modify to use new random API in benchmarks

### DIFF
--- a/benchmarks/benchmarks/interpolate.py
+++ b/benchmarks/benchmarks/interpolate.py
@@ -54,10 +54,10 @@ class Leaks(Benchmark):
 class BenchPPoly(Benchmark):
 
     def setup(self):
-        np.random.seed(1234)
+        rng = np.random.default_rng(1234)
         m, k = 55, 3
-        x = np.sort(np.random.random(m+1))
-        c = np.random.random((3, m))
+        x = np.sort(rng.random(m+1))
+        c = rng.random((3, m))
         self.pp = interpolate.PPoly(c, x)
 
         npts = 100

--- a/benchmarks/benchmarks/linalg.py
+++ b/benchmarks/benchmarks/linalg.py
@@ -148,22 +148,22 @@ class Lstsq(Benchmark):
             # skip: slow, and not useful to benchmark numpy
             raise NotImplementedError()
 
-        np.random.seed(1234)
+        rng = np.random.default_rng(1234)
         n = math.ceil(2./3. * size)
         k = math.ceil(1./2. * size)
         m = size
 
         if dtype is np.complex128:
-            A = ((10 * np.random.rand(m,k) - 5) +
-                 1j*(10 * np.random.rand(m,k) - 5))
-            temp = ((10 * np.random.rand(k,n) - 5) +
-                    1j*(10 * np.random.rand(k,n) - 5))
-            b = ((10 * np.random.rand(m,1) - 5) +
-                 1j*(10 * np.random.rand(m,1) - 5))
+            A = ((10 * rng.random((m,k)) - 5) +
+                 1j*(10 * rng.random((m,k)) - 5))
+            temp = ((10 * rng.random((k,n)) - 5) +
+                    1j*(10 * rng.random((k,n)) - 5))
+            b = ((10 * rng.random((m,1)) - 5) +
+                 1j*(10 * rng.random((m,1)) - 5))
         else:
-            A = (10 * np.random.rand(m,k) - 5)
-            temp = 10 * np.random.rand(k,n) - 5
-            b = 10 * np.random.rand(m,1) - 5
+            A = (10 * rng.random((m,k)) - 5)
+            temp = 10 * rng.random((k,n)) - 5
+            b = 10 * rng.random((m,1)) - 5
 
         self.A = A.dot(temp)
         self.b = b

--- a/benchmarks/benchmarks/signal.py
+++ b/benchmarks/benchmarks/signal.py
@@ -27,10 +27,10 @@ class Resample(Benchmark):
 class CalculateWindowedFFT(Benchmark):
 
     def setup(self):
-        np.random.seed(5678)
+        rng = np.random.default_rng(5678)
         # Create some long arrays for computation
-        x = np.random.randn(2**20)
-        y = np.random.randn(2**20)
+        x = rng.standard_normal(2**20)
+        y = rng.standard_normal(2**20)
         self.x = x
         self.y = y
 
@@ -58,12 +58,12 @@ class Convolve2D(Benchmark):
     ]
 
     def setup(self, mode, boundary):
-        np.random.seed(1234)
+        rng = np.random.default_rng(1234)
         # sample a bunch of pairs of 2d arrays
         pairs = []
         for ma, na, mb, nb in product((8, 13, 30, 36), repeat=4):
-            a = np.random.randn(ma, na)
-            b = np.random.randn(mb, nb)
+            a = rng.standard_normal((ma, na))
+            b = rng.standard_normal((mb, nb))
             pairs.append((a, b))
         self.pairs = pairs
 
@@ -91,11 +91,11 @@ class FFTConvolve(Benchmark):
     ]
 
     def setup(self, mode, size):
-        np.random.seed(1234)
+        rng = np.random.default_rng(1234)
         # sample a bunch of pairs of 2d arrays
         pairs = []
-        self.a = np.random.randn(size[0])
-        self.b = np.random.randn(size[1])
+        self.a = rng.standard_normal(size[0])
+        self.b = rng.standard_normal(size[1])
 
     def time_convolve2d(self, mode, size):
         signal.fftconvolve(self.a, self.b, mode=mode)
@@ -110,11 +110,11 @@ class OAConvolve(Benchmark):
     ]
 
     def setup(self, mode, size):
-        np.random.seed(1234)
+        rng = np.random.default_rng(1234)
         # sample a bunch of pairs of 2d arrays
         pairs = []
-        self.a = np.random.randn(size[0])
-        self.b = np.random.randn(size[1])
+        self.a = rng.standard_normal(size[0])
+        self.b = rng.standard_normal(size[1])
 
     def time_convolve2d(self, mode, size):
         signal.oaconvolve(self.a, self.b, mode=mode)
@@ -127,18 +127,18 @@ class Convolve(Benchmark):
     ]
 
     def setup(self, mode):
-        np.random.seed(1234)
+        rng = np.random.default_rng(1234)
         # sample a bunch of pairs of 2d arrays
         pairs = {'1d': [], '2d': []}
         for ma, nb in product((1, 2, 8, 13, 30, 36, 50, 75), repeat=2):
-            a = np.random.randn(ma)
-            b = np.random.randn(nb)
+            a = rng.standard_normal(ma)
+            b = rng.standard_normal(nb)
             pairs['1d'].append((a, b))
 
         for n_image in [256, 512, 1024]:
             for n_kernel in [3, 5, 7]:
-                x = np.random.randn(n_image, n_image)
-                h = np.random.randn(n_kernel, n_kernel)
+                x = rng.standard_normal((n_image, n_image))
+                h = rng.standard_normal((n_kernel, n_kernel))
                 pairs['2d'].append((x, h))
         self.pairs = pairs
 
@@ -200,13 +200,13 @@ class Upfirdn1D(Benchmark):
     ]
 
     def setup(self, up, down):
-        np.random.seed(1234)
+        rng = np.random.default_rng(1234)
         # sample a bunch of pairs of 2d arrays
         pairs = []
         for nfilt in [8, ]:
             for n in [32, 128, 512, 2048]:
-                h = np.random.randn(nfilt)
-                x = np.random.randn(n)
+                h = rng.standard_normal(nfilt)
+                x = rng.standard_normal(n)
                 pairs.append((h, x))
 
         self.pairs = pairs
@@ -225,13 +225,13 @@ class Upfirdn2D(Benchmark):
     ]
 
     def setup(self, up, down, axis):
-        np.random.seed(1234)
+        rng = np.random.default_rng(1234)
         # sample a bunch of pairs of 2d arrays
         pairs = []
         for nfilt in [8, ]:
             for n in [32, 128, 512]:
-                h = np.random.randn(nfilt)
-                x = np.random.randn(n, n)
+                h = rng.standard_normal(nfilt)
+                x = rng.standard_normal((n, n))
                 pairs.append((h, x))
 
         self.pairs = pairs

--- a/benchmarks/benchmarks/signal_filtering.py
+++ b/benchmarks/benchmarks/signal_filtering.py
@@ -90,8 +90,8 @@ class MedFilt2D(Benchmark):
     params = [[1, 2, 4]]
 
     def setup(self, threads):
-        np.random.seed(8176)
-        self.chunks = np.array_split(np.random.randn(250, 349), threads)
+        rng = np.random.default_rng(8176)
+        self.chunks = np.array_split(rng.standard_normal((250, 349)), threads)
 
     def _medfilt2d(self, threads):
         with ThreadPoolExecutor(max_workers=threads) as pool:

--- a/benchmarks/benchmarks/sparse.py
+++ b/benchmarks/benchmarks/sparse.py
@@ -143,16 +143,16 @@ class Matmul(Benchmark):
         C1 = 10
         C2 = 1000000
 
-        random.seed(0)
+        rng = np.random.default_rng(0)
 
-        i = random.randint(H1, size=C1)
-        j = random.randint(W1, size=C1)
-        data = random.rand(C1)
+        i = rng.integers(H1, size=C1)
+        j = rng.integers(W1, size=C1)
+        data = rng.random(C1)
         self.matrix1 = coo_matrix((data, (i, j)), shape=(H1, W1)).tocsr()
 
-        i = random.randint(H2, size=C2)
-        j = random.randint(W2, size=C2)
-        data = random.rand(C2)
+        i = rng.integers(H2, size=C2)
+        j = rng.integers(W2, size=C2)
+        data = rng.random(C2)
         self.matrix2 = coo_matrix((data, (i, j)), shape=(H2, W2)).tocsr()
 
     def time_large(self):

--- a/benchmarks/benchmarks/sparse_csgraph_djisktra.py
+++ b/benchmarks/benchmarks/sparse_csgraph_djisktra.py
@@ -16,7 +16,7 @@ class Dijkstra(Benchmark):
     param_names = ['n', 'min_only']
 
     def setup(self, n, min_only):
-        np.random.seed(1234)
+        rng = np.random.default_rng(1234)
         # make a random connectivity matrix
         data = scipy.sparse.rand(n, n, density=0.2, format='csc',
                                  random_state=42, dtype=np.bool_)
@@ -24,7 +24,7 @@ class Dijkstra(Benchmark):
         self.data = data
         # choose some random vertices
         v = np.arange(n)
-        np.random.shuffle(v)
+        rng.shuffle(v)
         self.indices = v[:int(n*.1)]
 
     def time_dijkstra_multi(self, n, min_only):

--- a/benchmarks/benchmarks/sparse_csgraph_matching.py
+++ b/benchmarks/benchmarks/sparse_csgraph_matching.py
@@ -18,8 +18,8 @@ class MaximumBipartiteMatching(Benchmark):
         # Create random sparse matrices. Note that we could use
         # scipy.sparse.rand for this purpose, but simply using np.random and
         # disregarding duplicates is quite a bit faster.
-        np.random.seed(42)
-        d = np.random.randint(0, n, size=(int(n*n*density), 2))
+        rng = np.random.default_rng(42)
+        d = rng.integers(0, n, size=(int(n*n*density), 2))
         graph = scipy.sparse.csr_matrix((np.ones(len(d)), (d[:, 0], d[:, 1])),
                                         shape=(n, n))
         self.graph = graph
@@ -31,29 +31,29 @@ class MaximumBipartiteMatching(Benchmark):
 # For benchmarking min_weight_full_bipartite_matching, we rely on some of
 # the classes defined in Burkard, Dell'Amico, Martello -- Assignment Problems,
 # 2009, Section 4.10.1.
-def random_uniform(shape):
-    return scipy.sparse.csr_matrix(np.random.uniform(1, 100, shape))
+def random_uniform(shape, rng):
+    return scipy.sparse.csr_matrix(rng.uniform(1, 100, shape))
 
 
-def random_uniform_sparse(shape):
-    return scipy.sparse.random(shape[0], shape[1], density=0.1, format='csr')
+def random_uniform_sparse(shape, rng):
+    return scipy.sparse.random(shape[0], shape[1], density=0.1, format='csr', random_state=rng)
 
 
-def random_uniform_integer(shape):
-    return scipy.sparse.csr_matrix(np.random.randint(1, 1000, shape))
+def random_uniform_integer(shape, rng):
+    return scipy.sparse.csr_matrix(rng.integers(1, 1000, shape))
 
 
-def random_geometric(shape):
-    P = np.random.randint(1, 1000, size=(shape[0], 2))
-    Q = np.random.randint(1, 1000, size=(shape[1], 2))
+def random_geometric(shape, rng):
+    P = rng.integers(1, 1000, size=(shape[0], 2))
+    Q = rng.integers(1, 1000, size=(shape[1], 2))
     return scipy.sparse.csr_matrix(cdist(P, Q, 'sqeuclidean'))
 
 
-def random_two_cost(shape):
-    return scipy.sparse.csr_matrix(np.random.choice((1, 1000000), shape))
+def random_two_cost(shape, rng):
+    return scipy.sparse.csr_matrix(rng.choice((1, 1000000), shape))
 
 
-def machol_wien(shape):
+def machol_wien(shape, rng):
     # Machol--Wien instances being harder than the other examples, we cut
     # down the size of the instance by 5.
     return scipy.sparse.csr_matrix(
@@ -71,7 +71,7 @@ class MinWeightFullBipartiteMatching(Benchmark):
     ]
 
     def setup(self, shape, input_type):
-        np.random.seed(42)
+        rng = np.random.default_rng(42)
         input_func = {'random_uniform': random_uniform,
                       'random_uniform_sparse': random_uniform_sparse,
                       'random_uniform_integer': random_uniform_integer,
@@ -79,7 +79,7 @@ class MinWeightFullBipartiteMatching(Benchmark):
                       'random_two_cost': random_two_cost,
                       'machol_wien': machol_wien}[input_type]
 
-        self.biadjacency_matrix = input_func(shape)
+        self.biadjacency_matrix = input_func(shape, rng)
 
     def time_evaluation(self, *args):
         min_weight_full_bipartite_matching(self.biadjacency_matrix)

--- a/benchmarks/benchmarks/sparse_linalg_expm.py
+++ b/benchmarks/benchmarks/sparse_linalg_expm.py
@@ -18,11 +18,11 @@ def random_sparse_csr(m, n, nnz_per_row):
     return M.tocsr()
 
 
-def random_sparse_csc(m, n, nnz_per_row):
+def random_sparse_csc(m, n, nnz_per_row, rng):
     # Copied from the scipy.sparse benchmark.
     rows = np.arange(m).repeat(nnz_per_row)
-    cols = np.random.randint(0, n, size=nnz_per_row*m)
-    vals = np.random.random_sample(m*nnz_per_row)
+    cols = rng.integers(0, n, size=nnz_per_row*m)
+    vals = rng.random(m*nnz_per_row)
     M = scipy.sparse.coo_matrix((vals, (rows, cols)), (m, n), dtype=float)
     # Use csc instead of csr, because sparse LU decomposition
     # raises a warning when I use csr.
@@ -53,14 +53,14 @@ class Expm(Benchmark):
     param_names = ['n', 'format']
 
     def setup(self, n, format):
-        np.random.seed(1234)
+        rng = np.random.default_rng(1234)
 
         # Let the number of nonzero entries per row
         # scale like the log of the order of the matrix.
         nnz_per_row = int(math.ceil(math.log(n)))
 
         # time the sampling of a random sparse matrix
-        self.A_sparse = random_sparse_csc(n, n, nnz_per_row)
+        self.A_sparse = random_sparse_csc(n, n, nnz_per_row, rng)
 
         # first format conversion
         self.A_dense = self.A_sparse.toarray()

--- a/benchmarks/benchmarks/sparse_linalg_onenormest.py
+++ b/benchmarks/benchmarks/sparse_linalg_onenormest.py
@@ -18,7 +18,7 @@ class BenchmarkOneNormEst(Benchmark):
     param_names = ['n', 'solver']
 
     def setup(self, n, solver):
-        np.random.seed(1234)
+        rng = np.random.default_rng(1234)
         nrepeats = 100
         shape = (int(n), int(n))
 
@@ -30,7 +30,7 @@ class BenchmarkOneNormEst(Benchmark):
             # Sample the matrices.
             self.matrices = []
             for i in range(nrepeats):
-                M = np.random.randn(*shape)
+                M = rng.standard_normal(shape)
                 self.matrices.append(M)
         else:
             max_nnz = 100000
@@ -38,7 +38,7 @@ class BenchmarkOneNormEst(Benchmark):
 
             self.matrices = []
             for i in range(nrepeats):
-                M = scipy.sparse.rand(shape[0], shape[1], min(max_nnz/(shape[0]*shape[1]), 1e-5))
+                M = scipy.sparse.rand(shape[0], shape[1], min(max_nnz/(shape[0]*shape[1]), 1e-5), random_state=rng)
                 self.matrices.append(M)
 
     def time_onenormest(self, n, solver):

--- a/benchmarks/benchmarks/sparse_linalg_solve.py
+++ b/benchmarks/benchmarks/sparse_linalg_solve.py
@@ -74,8 +74,8 @@ class Lgmres(Benchmark):
     param_names = ['n', 'm']
 
     def setup(self, n, m):
-        np.random.seed(1234)
-        self.A = sparse.eye(n, n) + sparse.rand(n, n, density=0.01)
+        rng = np.random.default_rng(1234)
+        self.A = sparse.eye(n, n) + sparse.rand(n, n, density=0.01, random_state=rng)
         self.b = np.ones(n)
 
     def time_inner(self, n, m):

--- a/benchmarks/benchmarks/spatial.py
+++ b/benchmarks/benchmarks/spatial.py
@@ -27,12 +27,12 @@ class Build(Benchmark):
         self.cls = KDTree if cls_name == 'KDTree' else cKDTree
         m, n, r = mnr
 
-        np.random.seed(1234)
-        self.data = np.concatenate((np.random.randn(n//2,m),
-                                    np.random.randn(n-n//2,m)+np.ones(m)))
+        rng = np.random.default_rng(1234)
+        self.data = np.concatenate((rng.standard_normal((n//2,m)),
+                                    rng.standard_normal((n-n//2,m))+np.ones(m)))
 
-        self.queries = np.concatenate((np.random.randn(r//2,m),
-                                       np.random.randn(r-r//2,m)+np.ones(m)))
+        self.queries = np.concatenate((rng.standard_normal((r//2,m)),
+                                       rng.standard_normal((r-r//2,m))+np.ones(m)))
 
     def time_build(self, mnr, cls_name):
         """
@@ -59,15 +59,15 @@ class PresortedDataSetup(Benchmark):
     def setup(self, mnr, balanced, order, radius):
         m, n, r = mnr
 
-        np.random.seed(1234)
+        rng = np.random.default_rng(1234)
         self.data = {
-            'random': np.random.uniform(size=(n, m)),
+            'random': rng.uniform(size=(n, m)),
             'sorted': np.repeat(np.arange(n, 0, -1)[:, np.newaxis],
                                 m,
                                 axis=1) / n
         }
 
-        self.queries = np.random.uniform(size=(r, m))
+        self.queries = rng.uniform(size=(r, m))
         self.T = cKDTree(self.data.get(order), balanced_tree=balanced)
 
 
@@ -120,10 +120,10 @@ class Query(LimitedParamBenchmark):
     def do_setup(self, mnr, p, boxsize, leafsize):
         m, n, r = mnr
 
-        np.random.seed(1234)
+        rng = np.random.default_rng(1234)
 
-        self.data = np.random.uniform(size=(n, m))
-        self.queries = np.random.uniform(size=(r, m))
+        self.data = rng.uniform(size=(n, m))
+        self.queries = rng.uniform(size=(r, m))
 
         self.T = cKDTree(self.data, leafsize=leafsize, boxsize=boxsize)
 
@@ -276,8 +276,8 @@ class CNeighbors(Benchmark):
 def generate_spherical_points(num_points):
     # generate uniform points on sphere
     # see: https://stackoverflow.com/a/23785326
-    np.random.seed(123)
-    points = np.random.normal(size=(num_points, 3))
+    rng = np.random.default_rng(123)
+    points = rng.normal(size=(num_points, 3))
     points /= np.linalg.norm(points, axis=1)[:, np.newaxis]
     return points
 
@@ -333,8 +333,8 @@ class Xdist(Benchmark):
     param_names = ['num_points', 'metric']
 
     def setup(self, num_points, metric):
-        np.random.seed(123)
-        self.points = np.random.random_sample((num_points, 3))
+        rng = np.random.default_rng(123)
+        self.points = rng.random((num_points, 3))
         self.metric = metric
         if metric == 'minkowski-P3':
             # p=2 is just the euclidean metric, try another p value as well
@@ -369,8 +369,8 @@ class XdistWeighted(Benchmark):
     param_names = ['num_points', 'metric']
 
     def setup(self, num_points, metric):
-        np.random.seed(123)
-        self.points = np.random.random_sample((num_points, 3))
+        rng = np.random.default_rng(123)
+        self.points = rng.random((num_points, 3))
         self.metric = metric
         if metric == 'minkowski-P3':
             # p=2 is just the euclidean metric, try another p value as well
@@ -395,8 +395,8 @@ class ConvexHullBench(Benchmark):
     param_names = ['num_points', 'incremental']
 
     def setup(self, num_points, incremental):
-        np.random.seed(123)
-        self.points = np.random.random_sample((num_points, 3))
+        rng = np.random.default_rng(123)
+        self.points = rng.random((num_points, 3))
 
     def time_convex_hull(self, num_points, incremental):
         """Time scipy.spatial.ConvexHull over a range of input data sizes
@@ -410,8 +410,8 @@ class VoronoiBench(Benchmark):
     param_names = ['num_points', 'furthest_site']
 
     def setup(self, num_points, furthest_site):
-        np.random.seed(123)
-        self.points = np.random.random_sample((num_points, 3))
+        rng = np.random.default_rng(123)
+        self.points = rng.random((num_points, 3))
 
     def time_voronoi_calculation(self, num_points, furthest_site):
         """Time conventional Voronoi diagram calculation."""
@@ -422,10 +422,9 @@ class Hausdorff(Benchmark):
     param_names = ['num_points']
 
     def setup(self, num_points):
-        np.random.seed(123)
-        self.points1 = np.random.random_sample((num_points, 3))
-        np.random.seed(71890)
-        self.points2 = np.random.random_sample((num_points, 3))
+        rng = np.random.default_rng(123)
+        self.points1 = rng.random((num_points, 3))
+        self.points2 = rng.random((num_points, 3))
 
     def time_directed_hausdorff(self, num_points):
         # time directed_hausdorff code in 3 D
@@ -454,8 +453,8 @@ class RotationBench(Benchmark):
     param_names = ['num_rotations']
 
     def setup(self, num_rotations):
-        np.random.seed(1234)
-        self.rotations = Rotation.random(num_rotations)
+        rng = np.random.default_rng(1234)
+        self.rotations = Rotation.random(num_rotations, random_state=rng)
 
     def time_matrix_conversion(self, num_rotations):
         '''Time converting rotation from and to matrices'''

--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -79,10 +79,10 @@ class Kendalltau(Benchmark):
 
 class InferentialStats(Benchmark):
     def setup(self):
-        np.random.seed(12345678)
-        self.a = stats.norm.rvs(loc=5, scale=10, size=500)
-        self.b = stats.norm.rvs(loc=8, scale=10, size=20)
-        self.c = stats.norm.rvs(loc=8, scale=20, size=20)
+        rng = np.random.default_rng(12345678)
+        self.a = stats.norm.rvs(loc=5, scale=10, size=500, random_state=rng)
+        self.b = stats.norm.rvs(loc=8, scale=10, size=20, random_state=rng)
+        self.c = stats.norm.rvs(loc=8, scale=20, size=20, random_state=rng)
 
     def time_ttest_ind_same_var(self):
         # test different sized sample with variances
@@ -195,8 +195,8 @@ class Distribution(Benchmark):
     ]
 
     def setup(self, distribution, properties):
-        np.random.seed(12345678)
-        self.x = np.random.rand(100)
+        rng = np.random.default_rng(12345678)
+        self.x = rng.random(100)
 
     def time_distribution(self, distribution, properties):
         if distribution == 'gamma':
@@ -238,8 +238,8 @@ class DescriptiveStats(Benchmark):
     ]
 
     def setup(self, n_levels):
-        np.random.seed(12345678)
-        self.levels = np.random.randint(n_levels, size=(1000, 10))
+        rng = np.random.default_rng(12345678)
+        self.levels = rng.integers(n_levels, size=(1000, 10))
 
     def time_mode(self, n_levels):
         stats.mode(self.levels, axis=0)
@@ -247,10 +247,10 @@ class DescriptiveStats(Benchmark):
 
 class GaussianKDE(Benchmark):
     def setup(self):
-        np.random.seed(12345678)
+        rng = np.random.default_rng(12345678)
         n = 2000
-        m1 = np.random.normal(size=n)
-        m2 = np.random.normal(scale=0.5, size=n)
+        m1 = rng.normal(size=n)
+        m2 = rng.normal(scale=0.5, size=n)
 
         xmin = m1.min()
         xmax = m1.max()
@@ -276,16 +276,16 @@ class GroupSampling(Benchmark):
     params = [[3, 10, 50, 200]]
 
     def setup(self, dim):
-        np.random.seed(12345678)
+        self.rng = np.random.default_rng(12345678)
 
     def time_unitary_group(self, dim):
-        stats.unitary_group.rvs(dim)
+        stats.unitary_group.rvs(dim, random_state=self.rng)
 
     def time_ortho_group(self, dim):
-        stats.ortho_group.rvs(dim)
+        stats.ortho_group.rvs(dim, random_state=self.rng)
 
     def time_special_ortho_group(self, dim):
-        stats.special_ortho_group.rvs(dim)
+        stats.special_ortho_group.rvs(dim, random_state=self.rng)
 
 
 class BinnedStatisticDD(Benchmark):
@@ -293,8 +293,8 @@ class BinnedStatisticDD(Benchmark):
     params = ["count", "sum", "mean", "min", "max", "median", "std", np.std]
 
     def setup(self, statistic):
-        np.random.seed(12345678)
-        self.inp = np.random.rand(9999).reshape(3, 3333) * 200
+        rng = np.random.default_rng(12345678)
+        self.inp = rng.random(9999).reshape(3, 3333) * 200
         self.subbin_x_edges = np.arange(0, 200, dtype=np.float32)
         self.subbin_y_edges = np.arange(0, 200, dtype=np.float64)
         self.ret = stats.binned_statistic_dd(
@@ -402,8 +402,8 @@ class BenchQMCDiscrepancy(Benchmark):
     ]
 
     def setup(self, method):
-        np.random.seed(1234)
-        sample = np.random.random_sample((1000, 10))
+        rng = np.random.default_rng(1234)
+        sample = rng.random((1000, 10))
         self.sample = sample
 
     def time_discrepancy(self, method):


### PR DESCRIPTION
#### What does this implement/fix?
https://github.com/scipy/scipy/pull/14018#discussion_r636858684
> I think modifying all `numpy.random` usage to the new API in a follow up PR would be nice. If we leave it as a mix or mostly old-style, others are going to copy that old style.
> There's a very minor issue that for some benchmarks, changing the exact set of random numbers that is generated may affect the timing. This can be detected by using --bench-compare, to see that the results didn't change significantly after making the change. In case there's one or two benchmarks where changed timings are significant, those could then be left as old-style.

<google-sheets-html-origin><!--td {border: 1px solid #ccc;}br {mso-data-placement:same-cell;}-->
Modified Benchmark | Time Change
-- | --
interpolate.BenchPPoly | not significant
linalg.Lstsq | not significant
signal_filtering.MedFilt2D | not significant
signal.CalculateWindowedFFT | not significant
signal.Convolve2D | not significant
signal.FFTConvolve | not significant
signal.OAConvolve | not significant
signal.Convolve | not significant
signal.Upfirdn1D | not significant
signal.Upfirdn2D | not significant
sparse_csgraph_djisktra.Dijkstra | not significant
sparse_csgraph_matching.MaximumBipartiteMatching | not significant
sparse_csgraph_matching.MinWeightFullBipartiteMatching | not significant
sparse_linalg_expm.Expm | not significant
sparse_linalg_onenormest.BenchmarkOneNormEst | not significant
sparse_linalg_solve.Lgmres | not significant
sparse.Matmul | not significant
spatial.Build | not significant
spatial.PresortedDataSetup | not significant
spatial.Query | not significant
spatial.SphericalVorSort | not significant
spatial.Xdist | not significant
spatial.XdistWeighted | not significant
spatial.ConvexHullBench | not significant
spatial.VoronoiBench | not significant
spatial.Hausdorff | not significant
spatial.RotationBench | not significant
stats.InferentialStats | not significant
stats.Distribution | not significant
stats.DescriptiveStats | not significant
stats.GaussianKDE | not significant
stats.GroupSampling | not significant
stats.BinnedStatisticDD | not significant
stats.BenchQMCDiscrepancy | not significant

</google-sheets-html-origin>

cc @rgommers @serge-sans-paille 