### PR TITLE
MAINT: fix missing LowLevelCallable in `dir(scipy)`

### DIFF
--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -59,7 +59,7 @@ Utility tools
 
 
 def __dir__():
-    return ['test']
+    return ['LowLevelCallable', 'test']
 
 
 __all__ = __dir__()


### PR DESCRIPTION
This was missed in gh-14086