### PR TITLE
MAINT: fix maybe-uninitialized warnings in lbfgbf.f

### DIFF
--- a/scipy/optimize/lbfgsb_src/lbfgsb.f
+++ b/scipy/optimize/lbfgsb_src/lbfgsb.f
@@ -1415,6 +1415,8 @@ c       the derivative f1 and the vector p = W'd (for theta = 1).
       nfree = n + 1
       nbreak = 0
       ibkmin = 0
+      tl = 0
+      tu = 0
       bkmin = zero
       col2 = 2*col
       f1 = zero


### PR DESCRIPTION
These are harmless warnings, but it's useful to get rid of them.
The variables are defined only inside an if-block like:

    if (nbd(i) .le. 2) tl = x(i) - l(i)

and then used in another `if (nbd(i) .le. 2)` block elsewhere.
The compiler isn't able to verify that these are the same conditions.