### PR TITLE
 BENCH: add more benchmarks for inferential statistics tests

### DIFF
--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -1,5 +1,3 @@
-from operator import mod
-from scipy.stats.stats import mode
 import warnings
 
 import numpy as np

--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -98,24 +98,6 @@ class KS(Benchmark):
         stats.ks_2samp(self.a, self.b, alternative=alternative, mode=mode)
 
 
-class MannWhitneyU(Benchmark):
-    param_names = ['alternative', 'method']
-    params = [
-        ['two-sided', 'less', 'greater'],
-        ['auto', 'asymptotic', 'exact'],
-    ]
-
-    def setup(self, alternative, method):
-        rng = np.random.default_rng(0x2cedaefb4c66ab35f32d163376cc0c1b)
-        self.u1 = rng.uniform(-1, 1, 50)
-        self.u2 = rng.uniform(-0.5, 1.5, 100)
-
-    def time_mannwhitneyu(self, alternative, method):
-        stats.mannwhitneyu(self.u1, self.u2, 
-                           alternative=alternative, 
-                           method=method)
-
-
 class RankSums(Benchmark):
     param_names = ['alternative']
     params = [

--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -1,3 +1,5 @@
+from operator import mod
+from scipy.stats.stats import mode
 import warnings
 
 import numpy as np
@@ -77,12 +79,84 @@ class Kendalltau(Benchmark):
         tau, p_value = stats.kendalltau(self.a, self.b, nan_policy=nan_policy, method=method, variant=variant)
 
 
+class KS(Benchmark):
+    param_names = ['alternative', 'mode']
+    params = [
+        ['two-sided', 'less', 'greater'],
+        ['auto', 'exact', 'asymp'],
+    ]
+
+    def setup(self, alternative, mode):
+        rng = np.random.default_rng(12345678)
+        self.a = stats.norm.rvs(loc=5, scale=10, size=500, random_state=rng)
+        self.b = stats.norm.rvs(loc=8, scale=10, size=500, random_state=rng)                                           
+    
+    def time_ks_1samp(self, alternative, mode):
+        stats.ks_1samp(self.a, stats.norm.cdf, 
+                       alternative=alternative, mode=mode)
+
+    def time_ks_2samp(self, alternative, mode):
+        stats.ks_2samp(self.a, self.b, alternative=alternative, mode=mode)
+
+
+class MannWhitneyU(Benchmark):
+    param_names = ['alternative', 'method']
+    params = [
+        ['two-sided', 'less', 'greater'],
+        ['auto', 'asymptotic', 'exact'],
+    ]
+
+    def setup(self, alternative, method):
+        rng = np.random.default_rng(12345678)
+        self.u1 = rng.uniform(-1, 1, 50)
+        self.u2 = rng.uniform(-0.5, 1.5, 100)
+
+    def time_mannwhitneyu(self, alternative, method):
+        stats.mannwhitneyu(self.u1, self.u2, 
+                           alternative=alternative, 
+                           method=method)
+
+
+class RankSums(Benchmark):
+    param_names = ['alternative']
+    params = [
+        ['two-sided', 'less', 'greater']
+    ]
+
+    def setup(self, alternative):
+        rng = np.random.default_rng(12345678)
+        self.u1 = rng.uniform(-1, 1, 200)
+        self.u2 = rng.uniform(-0.5, 1.5, 300)
+
+    def time_ranksums(self, alternative):
+        stats.ranksums(self.u1, self.u2, alternative=alternative)
+
+
+class BrunnerMunzel(Benchmark):
+    param_names = ['alternative', 'nan_policy', 'distribution']
+    params = [
+        ['two-sided', 'less', 'greater'],
+        ['propagate', 'raise', 'omit'],
+        ['t', 'normal']
+    ]
+
+    def setup(self, alternative, nan_policy, distribution):
+        rng = np.random.default_rng(12345678)
+        self.u1 = rng.uniform(-1, 1, 200)
+        self.u2 = rng.uniform(-0.5, 1.5, 300)
+
+    def time_brunnermunzel(self, alternative, nan_policy, distribution):
+        stats.brunnermunzel(self.u1, self.u2, alternative=alternative, 
+                            distribution=distribution, nan_policy=nan_policy)
+
+
 class InferentialStats(Benchmark):
     def setup(self):
         rng = np.random.default_rng(12345678)
         self.a = stats.norm.rvs(loc=5, scale=10, size=500, random_state=rng)
-        self.b = stats.norm.rvs(loc=8, scale=10, size=20, random_state=rng)
-        self.c = stats.norm.rvs(loc=8, scale=20, size=20, random_state=rng)
+        self.b = stats.norm.rvs(loc=8, scale=10, size=500, random_state=rng)
+        self.c = stats.norm.rvs(loc=8, scale=20, size=500, random_state=rng)
+        self.chisq = rng.integers(1, 20, 500)
 
     def time_ttest_ind_same_var(self):
         # test different sized sample with variances
@@ -93,6 +167,18 @@ class InferentialStats(Benchmark):
         # test different sized sample with different variances
         stats.ttest_ind(self.a, self.c)
         stats.ttest_ind(self.a, self.c, equal_var=False)
+
+    def time_chisqure(self):
+        stats.chisquare(self.chisq)
+    
+    def time_friedmanchisquare(self):
+        stats.friedmanchisquare(self.a, self.b, self.c)
+    
+    def time_epps_singleton_2samp(self):
+        stats.epps_singleton_2samp(self.a, self.b)
+
+    def time_kruskal(self):
+        stats.mstats.kruskal(self.a, self.b)
 
 
 class DistributionsAll(Benchmark):

--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -86,7 +86,7 @@ class KS(Benchmark):
     ]
 
     def setup(self, alternative, mode):
-        rng = np.random.default_rng(12345678)
+        rng = np.random.default_rng(0x2e7c964ff9a5cd6be22014c09f1dbba9)
         self.a = stats.norm.rvs(loc=5, scale=10, size=500, random_state=rng)
         self.b = stats.norm.rvs(loc=8, scale=10, size=500, random_state=rng)                                           
     
@@ -106,7 +106,7 @@ class MannWhitneyU(Benchmark):
     ]
 
     def setup(self, alternative, method):
-        rng = np.random.default_rng(12345678)
+        rng = np.random.default_rng(0x2cedaefb4c66ab35f32d163376cc0c1b)
         self.u1 = rng.uniform(-1, 1, 50)
         self.u2 = rng.uniform(-0.5, 1.5, 100)
 
@@ -123,7 +123,7 @@ class RankSums(Benchmark):
     ]
 
     def setup(self, alternative):
-        rng = np.random.default_rng(12345678)
+        rng = np.random.default_rng(0xb6acd7192d6e5da0f68b5d8ab8ce7af2)
         self.u1 = rng.uniform(-1, 1, 200)
         self.u2 = rng.uniform(-0.5, 1.5, 300)
 
@@ -140,7 +140,7 @@ class BrunnerMunzel(Benchmark):
     ]
 
     def setup(self, alternative, nan_policy, distribution):
-        rng = np.random.default_rng(12345678)
+        rng = np.random.default_rng(0xb82c4db22b2818bdbc5dbe15ad7528fe)
         self.u1 = rng.uniform(-1, 1, 200)
         self.u2 = rng.uniform(-0.5, 1.5, 300)
 
@@ -151,7 +151,7 @@ class BrunnerMunzel(Benchmark):
 
 class InferentialStats(Benchmark):
     def setup(self):
-        rng = np.random.default_rng(12345678)
+        rng = np.random.default_rng(0x13d756fadb635ae7f5a8d39bbfb0c931)
         self.a = stats.norm.rvs(loc=5, scale=10, size=500, random_state=rng)
         self.b = stats.norm.rvs(loc=8, scale=10, size=500, random_state=rng)
         self.c = stats.norm.rvs(loc=8, scale=20, size=500, random_state=rng)

--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -74,8 +74,8 @@ class Kendalltau(Benchmark):
         self.b = b
 
     def time_kendalltau(self, nan_policy, method, variant):
-        tau, p_value = stats.kendalltau(self.a, self.b, nan_policy=nan_policy, 
-                                        method=method, variant=variant)
+        stats.kendalltau(self.a, self.b, nan_policy=nan_policy,
+                         method=method, variant=variant)
 
 
 class KS(Benchmark):
@@ -88,10 +88,10 @@ class KS(Benchmark):
     def setup(self, alternative, mode):
         rng = np.random.default_rng(0x2e7c964ff9a5cd6be22014c09f1dbba9)
         self.a = stats.norm.rvs(loc=5, scale=10, size=500, random_state=rng)
-        self.b = stats.norm.rvs(loc=8, scale=10, size=500, random_state=rng)                                           
-    
+        self.b = stats.norm.rvs(loc=8, scale=10, size=500, random_state=rng)
+
     def time_ks_1samp(self, alternative, mode):
-        stats.ks_1samp(self.a, stats.norm.cdf, 
+        stats.ks_1samp(self.a, stats.norm.cdf,
                        alternative=alternative, mode=mode)
 
     def time_ks_2samp(self, alternative, mode):
@@ -127,7 +127,7 @@ class BrunnerMunzel(Benchmark):
         self.u2 = rng.uniform(-0.5, 1.5, 300)
 
     def time_brunnermunzel(self, alternative, nan_policy, distribution):
-        stats.brunnermunzel(self.u1, self.u2, alternative=alternative, 
+        stats.brunnermunzel(self.u1, self.u2, alternative=alternative,
                             distribution=distribution, nan_policy=nan_policy)
 
 
@@ -151,10 +151,10 @@ class InferentialStats(Benchmark):
 
     def time_chisqure(self):
         stats.chisquare(self.chisq)
-    
+
     def time_friedmanchisquare(self):
         stats.friedmanchisquare(self.a, self.b, self.c)
-    
+
     def time_epps_singleton_2samp(self):
         stats.epps_singleton_2samp(self.a, self.b)
 

--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -76,7 +76,8 @@ class Kendalltau(Benchmark):
         self.b = b
 
     def time_kendalltau(self, nan_policy, method, variant):
-        tau, p_value = stats.kendalltau(self.a, self.b, nan_policy=nan_policy, method=method, variant=variant)
+        tau, p_value = stats.kendalltau(self.a, self.b, nan_policy=nan_policy, 
+                                        method=method, variant=variant)
 
 
 class KS(Benchmark):


### PR DESCRIPTION
#### What does this implement/fix?
Add more benchmarks for inferential statistic tests:

- KS test
- MannWhitneyU
- RankSums
- BrunnerMunzel
- chisqure
- friedmanchisquare
- epps_singleton_2samp
- kruskal

Seems MannWhitneyU(exact) and friedmanchisquare are very slow, will look into them.
cc @rgommers @serge-sans-paille 
```
[ 75.00%] ··· stats.KS.time_ks_1samp                                                                              ok
[ 75.00%] ··· ============= ========== ========== ==========
              --                          mode              
              ------------- --------------------------------
               alternative     auto      exact      asymp   
              ============= ========== ========== ==========
                two-sided    412±20μs   501±70μs   260±20μs 
                   less      327±40μs   374±60μs   272±10μs 
                 greater     535±70μs   501±20μs   661±20μs 
              ============= ========== ========== ==========

[100.00%] ··· stats.KS.time_ks_2samp                                                                              ok
[100.00%] ··· ============= ========== ========== ==========
              --                          mode              
              ------------- --------------------------------
               alternative     auto      exact      asymp   
              ============= ========== ========== ==========
                two-sided    317±30μs   287±30μs   538±20μs 
                   less      170±10μs   179±6μs    166±8μs  
                 greater     185±20μs   234±30μs   192±40μs 
              ============= ========== ========== ==========
```

```
[100.00%] ··· stats.MannWhitneyU.time_mannwhitneyu                                                                               ok
[100.00%] ··· ============= ========== ============ =============
              --                            method               
              ------------- -------------------------------------
               alternative     auto     asymptotic      exact    
              ============= ========== ============ =============
                two-sided    482±70μs    496±20μs     2.21±0.3ms 
                   less      503±10μs    462±20μs    2.03±0.09ms 
                 greater     581±50μs    509±80μs    4.60±0.01ms 
              ============= ========== ============ =============
```

```
[100.00%] ··· stats.RankSums.time_ranksums                                                                                       ok
[100.00%] ··· ============= ==========
               alternative            
              ------------- ----------
                two-sided    161±5μs  
                   less      174±10μs 
                 greater     169±7μs  
              ============= ==========
```

```
[100.00%] ··· ============= ============ =========== ==========
              --                              distribution     
              -------------------------- ----------------------
               alternative   nan_policy       t        normal  
              ============= ============ =========== ==========
                two-sided    propagate     364±30μs   365±10μs 
                two-sided      raise       394±40μs   435±50μs 
                two-sided       omit       379±10μs   382±30μs 
                   less      propagate     353±20μs   347±10μs 
                   less        raise       474±30μs   369±10μs 
                   less         omit       409±20μs   353±20μs 
                 greater     propagate     391±20μs   412±50μs 
                 greater       raise      402±100μs   411±20μs 
                 greater        omit       398±20μs   367±20μs 
              ============= ============ =========== ==========
```
```
[ 58.33%] ··· stats.InferentialStats.time_chisqure              111±10μs
[ 66.67%] ··· stats.InferentialStats.time_epps_singleton_2samp  638±20μs
[ 75.00%] ··· stats.InferentialStats.time_friedmanchisquare     26.9±1ms
[ 83.33%] ··· stats.InferentialStats.time_kruskal               752±40μs
```