### PR TITLE
REL: stop shipping generated Cython sources in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,8 +14,6 @@ include .coveragerc
 include site.cfg.example
 include tox.ini pytest.ini
 recursive-include tools *
-# Cached Cython signatures
-include cythonize.dat
 # Exclude what we don't want to include
 recursive-exclude scipy/linalg/src/id_dist/src *_subr_*.f
 prune benchmarks/env

--- a/scipy/optimize/_highs/setup.py
+++ b/scipy/optimize/_highs/setup.py
@@ -7,6 +7,8 @@ Some CMake files are used to create source lists for compilation
 import pathlib
 from datetime import datetime
 import os
+from os.path import join
+
 
 def pre_build_hook(build_ext, ext):
     from scipy._build_utils.compiler_helper import get_cxx_std_flag
@@ -94,8 +96,8 @@ def configuration(parent_package='', top_path=None):
         'basiclu',
         sources=basiclu_sources,
         include_dirs=[
-            'src/',
-            'src/ipm/basiclu/include/',
+            'src',
+            join('src', 'ipm', 'basiclu', 'include'),
         ],
         language='c',
         macros=DEFINE_MACROS,
@@ -110,22 +112,19 @@ def configuration(parent_package='', top_path=None):
                      if pathlib.Path(s).parent.name != 'mip']
     ext = config.add_extension(
         '_highs_wrapper',
-        sources=['cython/src/_highs_wrapper.cxx'] + highs_sources + ipx_sources,
+        sources=[join('cython', 'src', '_highs_wrapper.cxx')] + \
+                highs_sources + ipx_sources,
         include_dirs=[
-
             # highs_wrapper
-            'cython/src/',
-            'src/',
-            'src/lp_data/',
-
+            'src',
+            join('cython', 'src'),
+            join('src', 'lp_data'),
             # highs
-            'src/',
-            'src/io/',
-            'src/ipm/ipx/include/',
-
+            join('src', 'io'),
+            join('src', 'ipm', 'ipx', 'include'),
             # IPX
-            'src/ipm/ipx/include/',
-            'src/ipm/basiclu/include/',
+            join('src', 'ipm', 'ipx', 'include'),
+            join('src', 'ipm', 'basiclu', 'include'),
         ],
         language='c++',
         libraries=['basiclu'],
@@ -138,13 +137,13 @@ def configuration(parent_package='', top_path=None):
     # Export constants and enums from HiGHS:
     ext = config.add_extension(
         '_highs_constants',
-        sources=['cython/src/_highs_constants.cxx'],
+        sources=[join('cython', 'src', '_highs_constants.cxx')],
         include_dirs=[
-            'cython/src/',
-            'src/',
-            'src/io/',
-            'src/lp_data/',
-            'src/simplex/',
+            'src',
+            join('cython', 'src'),
+            join('src', 'io'),
+            join('src', 'lp_data'),
+            join('src', 'simplex'),
         ],
         language='c++',
     )

--- a/scipy/optimize/cython_optimize/setup.py
+++ b/scipy/optimize/cython_optimize/setup.py
@@ -1,0 +1,13 @@
+
+def configuration(parent_package='', top_path=None):
+    from numpy.distutils.misc_util import Configuration
+    config = Configuration('cython_optimize', parent_package, top_path)
+
+    config.add_data_files('*.pxd')
+    config.add_extension('_zeros', sources='_zeros.c')
+    return config
+
+
+if __name__ == '__main__':
+    from numpy.distutils.core import setup
+    setup(**configuration(top_path='').todict())

--- a/scipy/optimize/setup.py
+++ b/scipy/optimize/setup.py
@@ -118,10 +118,6 @@ def configuration(parent_package='', top_path=None):
     # Cython optimize API for zeros functions
     config.add_subpackage('cython_optimize')
     config.add_data_files('cython_optimize.pxd')
-    config.add_data_files(os.path.join('cython_optimize', '*.pxd'))
-    config.add_extension(
-        'cython_optimize._zeros',
-        sources=[os.path.join('cython_optimize', '_zeros.c')])
 
     config.add_subpackage('_shgo_lib')
     config.add_data_dir('_shgo_lib')

--- a/scipy/optimize/setup.py
+++ b/scipy/optimize/setup.py
@@ -1,3 +1,4 @@
+import sys
 import os.path
 from os.path import join
 
@@ -123,7 +124,10 @@ def configuration(parent_package='', top_path=None):
     config.add_data_dir('_shgo_lib')
 
     # HiGHS linear programming libraries and extensions
-    config.add_subpackage('_highs')
+    if 'sdist' not in sys.argv:
+        # Avoid running this during sdist creation - it makes numpy.distutils
+        # create an empty cython/src top-level directory.
+        config.add_subpackage('_highs')
 
     config.add_data_dir('tests')
 

--- a/setup.py
+++ b/setup.py
@@ -606,9 +606,10 @@ def setup_package():
         cmdclass['build_ext'] = get_build_ext_override()
         cmdclass['build_clib'] = get_build_clib_override()
 
-        cwd = os.path.abspath(os.path.dirname(__file__))
-        if not os.path.exists(os.path.join(cwd, 'PKG-INFO')):
-            # Generate Cython sources, unless building from source release
+        if not 'sdist' in sys.argv:
+            # Generate Cython sources, unless we're creating an sdist
+            # Cython is a build dependency, and shipping generated .c files
+            # can cause problems (see gh-14199)
             generate_cython()
 
         metadata['configuration'] = configuration


### PR DESCRIPTION
This supercedes gh-14196, and closes gh-14199.

The `*.cxx` files for Boost contain an absolute path, which is coming from the use of `src_dir` in `stats/_boost/setup.py`. That makes the generated code non-portable.

Should fix the failures with `1.7.0rc1` in https://github.com/conda-forge/scipy-feedstock/pull/169.

Generated sources now also contain NumPy-version-dependent code (e.g. to use the numpy.random Cython API for >= 1.19.0), which is another good reason to stop shipping generated sources.

The Cython build dependency was already specified correctly in `pyproject.toml`.

Note that `python setup.py sdist` will generate some noise for Cython sources, like:
```
non-existing path in 'scipy/spatial': 'ckdtree.cxx'
```
This is coming from numpy.distutils, which sees `config.add_extension(somefile.c)` while `somefile.c` doesn't exist. This is harmless.

