### PR TITLE
MAINT: SciPy 1.7.0rc2 backports

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,8 +14,6 @@ include .coveragerc
 include site.cfg.example
 include tox.ini pytest.ini
 recursive-include tools *
-# Cached Cython signatures
-include cythonize.dat
 # Exclude what we don't want to include
 recursive-exclude scipy/linalg/src/id_dist/src *_subr_*.f
 prune benchmarks/env

--- a/doc/release/1.7.0-notes.rst
+++ b/doc/release/1.7.0-notes.rst
@@ -631,6 +631,8 @@ Issues closed for 1.7.0
 * `#14093 <https://github.com/scipy/scipy/issues/14093>`__: DOC: Inconsistency in the definition of default values in the...
 * `#14158 <https://github.com/scipy/scipy/issues/14158>`__: TST, BUG: test_rbfinterp.py -- test_interpolation_misfit_1d fails...
 * `#14170 <https://github.com/scipy/scipy/issues/14170>`__: TST: signal submodule test_filtfilt_gust failing on 32-bit amd64...
+* `#14194 <https://github.com/scipy/scipy/issues/14194>`__: MAINT: download-wheels.py missing import
+* `#14199 <https://github.com/scipy/scipy/issues/14199>`__: Generated sources for biasedurn extension are broken in 1.7.0rc1
 
 
 ***********************
@@ -1029,3 +1031,5 @@ Pull requests for 1.7.0
 * `#14171 <https://github.com/scipy/scipy/pull/14171>`__: TST: signal: Bump tolerances for a test of Gustafsson's...
 * `#14175 <https://github.com/scipy/scipy/pull/14175>`__: TST: stats: Loosen tolerance in some binomtest tests.
 * `#14182 <https://github.com/scipy/scipy/pull/14182>`__: MAINT: stats: Update ppcc_plot and ppcc_max docstring.
+* `#14195 <https://github.com/scipy/scipy/pull/14195>`__: MAINT: download-wheels missing import
+* `#14230 <https://github.com/scipy/scipy/pull/14230>`__: REL: stop shipping generated Cython sources in sdist

--- a/scipy/optimize/_highs/setup.py
+++ b/scipy/optimize/_highs/setup.py
@@ -7,6 +7,8 @@ Some CMake files are used to create source lists for compilation
 import pathlib
 from datetime import datetime
 import os
+from os.path import join
+
 
 def pre_build_hook(build_ext, ext):
     from scipy._build_utils.compiler_helper import get_cxx_std_flag
@@ -94,8 +96,8 @@ def configuration(parent_package='', top_path=None):
         'basiclu',
         sources=basiclu_sources,
         include_dirs=[
-            'src/',
-            'src/ipm/basiclu/include/',
+            'src',
+            join('src', 'ipm', 'basiclu', 'include'),
         ],
         language='c',
         macros=DEFINE_MACROS,
@@ -110,22 +112,19 @@ def configuration(parent_package='', top_path=None):
                      if pathlib.Path(s).parent.name != 'mip']
     ext = config.add_extension(
         '_highs_wrapper',
-        sources=['cython/src/_highs_wrapper.cxx'] + highs_sources + ipx_sources,
+        sources=[join('cython', 'src', '_highs_wrapper.cxx')] + \
+                highs_sources + ipx_sources,
         include_dirs=[
-
             # highs_wrapper
-            'cython/src/',
-            'src/',
-            'src/lp_data/',
-
+            'src',
+            join('cython', 'src'),
+            join('src', 'lp_data'),
             # highs
-            'src/',
-            'src/io/',
-            'src/ipm/ipx/include/',
-
+            join('src', 'io'),
+            join('src', 'ipm', 'ipx', 'include'),
             # IPX
-            'src/ipm/ipx/include/',
-            'src/ipm/basiclu/include/',
+            join('src', 'ipm', 'ipx', 'include'),
+            join('src', 'ipm', 'basiclu', 'include'),
         ],
         language='c++',
         libraries=['basiclu'],
@@ -138,13 +137,13 @@ def configuration(parent_package='', top_path=None):
     # Export constants and enums from HiGHS:
     ext = config.add_extension(
         '_highs_constants',
-        sources=['cython/src/_highs_constants.cxx'],
+        sources=[join('cython', 'src', '_highs_constants.cxx')],
         include_dirs=[
-            'cython/src/',
-            'src/',
-            'src/io/',
-            'src/lp_data/',
-            'src/simplex/',
+            'src',
+            join('cython', 'src'),
+            join('src', 'io'),
+            join('src', 'lp_data'),
+            join('src', 'simplex'),
         ],
         language='c++',
     )

--- a/scipy/optimize/cython_optimize/setup.py
+++ b/scipy/optimize/cython_optimize/setup.py
@@ -1,0 +1,13 @@
+
+def configuration(parent_package='', top_path=None):
+    from numpy.distutils.misc_util import Configuration
+    config = Configuration('cython_optimize', parent_package, top_path)
+
+    config.add_data_files('*.pxd')
+    config.add_extension('_zeros', sources='_zeros.c')
+    return config
+
+
+if __name__ == '__main__':
+    from numpy.distutils.core import setup
+    setup(**configuration(top_path='').todict())

--- a/scipy/optimize/setup.py
+++ b/scipy/optimize/setup.py
@@ -118,10 +118,6 @@ def configuration(parent_package='', top_path=None):
     # Cython optimize API for zeros functions
     config.add_subpackage('cython_optimize')
     config.add_data_files('cython_optimize.pxd')
-    config.add_data_files(os.path.join('cython_optimize', '*.pxd'))
-    config.add_extension(
-        'cython_optimize._zeros',
-        sources=[os.path.join('cython_optimize', '_zeros.c')])
 
     config.add_subpackage('_shgo_lib')
     config.add_data_dir('_shgo_lib')

--- a/scipy/optimize/setup.py
+++ b/scipy/optimize/setup.py
@@ -1,3 +1,4 @@
+import sys
 import os.path
 from os.path import join
 
@@ -123,7 +124,10 @@ def configuration(parent_package='', top_path=None):
     config.add_data_dir('_shgo_lib')
 
     # HiGHS linear programming libraries and extensions
-    config.add_subpackage('_highs')
+    if 'sdist' not in sys.argv:
+        # Avoid running this during sdist creation - it makes numpy.distutils
+        # create an empty cython/src top-level directory.
+        config.add_subpackage('_highs')
 
     config.add_data_dir('tests')
 

--- a/setup.py
+++ b/setup.py
@@ -606,9 +606,10 @@ def setup_package():
         cmdclass['build_ext'] = get_build_ext_override()
         cmdclass['build_clib'] = get_build_clib_override()
 
-        cwd = os.path.abspath(os.path.dirname(__file__))
-        if not os.path.exists(os.path.join(cwd, 'PKG-INFO')):
-            # Generate Cython sources, unless building from source release
+        if not 'sdist' in sys.argv:
+            # Generate Cython sources, unless we're creating an sdist
+            # Cython is a build dependency, and shipping generated .c files
+            # can cause problems (see gh-14199)
             generate_cython()
 
         metadata['configuration'] = configuration

--- a/tools/download-wheels.py
+++ b/tools/download-wheels.py
@@ -9,6 +9,7 @@ import re
 import shutil
 import argparse
 import urllib
+import urllib.request
 
 import urllib3
 from bs4 import BeautifulSoup


### PR DESCRIPTION
Backport:

- gh-14195
- gh-14230

The latter is particularly important--the `sdist` I built for `1.7.0rc1` was completely broken/non-portable.

Update release notes accordingly