### PR TITLE
use cython from the host python

### DIFF
--- a/tools/cythonize.py
+++ b/tools/cythonize.py
@@ -97,8 +97,10 @@ def process_pyx(fromfile, tofile, cwd):
     if tofile.endswith('.cxx'):
         flags += ['--cplus']
 
-    subprocess.check_call([sys.executable, '-m', 'cython'] + 
-                        flags + ["-o", tofile, fromfile], cwd=cwd)
+    out = subprocess.check_call([sys.executable, '-m', 'cython'] + 
+                        flags + ["-o", tofile, fromfile], cwd=cwd,
+                        universal_newlines=True)
+    print(out)
 
 def process_tempita_pyx(fromfile, tofile, cwd):
     try:

--- a/tools/cythonize.py
+++ b/tools/cythonize.py
@@ -103,7 +103,8 @@ def process_pyx(fromfile, tofile, cwd):
 
     try:
         try:
-            r = subprocess.call(['cython'] + flags + ["-o", tofile, fromfile], cwd=cwd)
+            r = subprocess.call([sys.executable, '-m', 'cython'] + 
+                                flags + ["-o", tofile, fromfile], cwd=cwd)
             if r != 0:
                 raise Exception('Cython failed')
         except OSError as e:


### PR DESCRIPTION
TL;DR: It turns out cythonizing the files will prefer a random cython on the bin path to one imported via python since the `subprocess.check` uses `['cython']` and not `[sys.executable', '-m', 'cython']`.

And now for the rest of the story:

In digging around why pypy3.7 + 1.7.0 crashes when calling
```
pypy runtests.py --python
>>> from scipy.stats import qmc
>>> sampler = qmc.Sobol(d=2, scramble=False)
```

I came across this oddity. Say I do not use a virtualenv, rather I have some python that I want to test locally with scipy. I install all the dependencies, and then start to build. The code that calls `cython` assumes the one I want to use is first on the `PATH`. But, since I am not using a virtualenv or a conda env, that might be any cython, not necessarily the one for my python.

It would seem safer to me to use the cython already in the python environment I am testing. Even more so since the checks just before this for the cython version.

This hasn't helped me find the problem with PyPy, but was a nice distraction.