### PR TITLE
BUG: stats: fix discrete `.isf` to work at boundaries when `loc != 0`

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -3414,13 +3414,16 @@ class rv_discrete(rv_generic):
         cond0 = self._argcheck(*args) & (loc == loc)
         cond1 = (q > 0) & (q < 1)
         cond2 = (q == 1) & cond0
+        cond3 = (q == 0) & cond0
         cond = cond0 & cond1
 
         # same problem as with ppf; copied from ppf and changed
         output = np.full(shape(cond), fill_value=self.badvalue, dtype='d')
         # output type 'd' to handle nin and inf
-        place(output, (q == 0)*(cond == cond), _b)
-        place(output, cond2, _a-1)
+        lower_bound = _a - 1 + loc
+        upper_bound = _b + loc
+        place(output, cond2*(cond == cond), lower_bound)
+        place(output, cond3*(cond == cond), upper_bound)
 
         # call place only if at least 1 valid argument
         if np.any(cond):

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -148,6 +148,31 @@ def test_ppf_with_loc(dist, args):
             )
 
 
+@pytest.mark.parametrize('dist, args', distdiscrete)
+def test_isf_with_loc(dist, args):
+    try:
+        distfn = getattr(stats, dist)
+    except TypeError:
+        distfn = dist
+    # check with a negative, no and positive relocation.
+    np.random.seed(1942349)
+    re_locs = [np.random.randint(-10, -1), 0, np.random.randint(1, 10)]
+    _a, _b = distfn.support(*args)
+    for loc in re_locs:
+        expected = _b + loc, _a - 1 + loc
+        res = distfn.isf(0., *args, loc=loc), distfn.isf(1., *args, loc=loc)
+        npt.assert_allclose(expected, res, rtol=1e-14)
+    # test broadcasting behaviour
+    re_locs = [np.random.randint(-10, -1, size=(5, 3)),
+               np.zeros((5, 3)),
+               np.random.randint(1, 10, size=(5, 3))]
+    _a, _b = distfn.support(*args)
+    for loc in re_locs:
+        expected = _b + loc, _a - 1 + loc
+        res = distfn.isf(0., *args, loc=loc), distfn.isf(1., *args, loc=loc)
+        npt.assert_allclose(expected, res, rtol=1e-14)
+
+
 def check_cdf_ppf(distfn, arg, supp, msg):
     # cdf is a step function, and ppf(q) = min{k : cdf(k) >= q, k integer}
     npt.assert_array_equal(distfn.ppf(distfn.cdf(supp, *arg), *arg),

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -161,7 +161,7 @@ def test_isf_with_loc(dist, args):
     for loc in re_locs:
         expected = _b + loc, _a - 1 + loc
         res = distfn.isf(0., *args, loc=loc), distfn.isf(1., *args, loc=loc)
-        npt.assert_allclose(expected, res, rtol=1e-14)
+        npt.assert_array_equal(expected, res)
     # test broadcasting behaviour
     re_locs = [np.random.randint(-10, -1, size=(5, 3)),
                np.zeros((5, 3)),
@@ -170,7 +170,7 @@ def test_isf_with_loc(dist, args):
     for loc in re_locs:
         expected = _b + loc, _a - 1 + loc
         res = distfn.isf(0., *args, loc=loc), distfn.isf(1., *args, loc=loc)
-        npt.assert_allclose(expected, res, rtol=1e-14)
+        npt.assert_array_equal(expected, res)
 
 
 def check_cdf_ppf(distfn, arg, supp, msg):


### PR DESCRIPTION
#### Reference issue

closes gh-14236

#### What does this implement/fix?

The `.isf` method of discrete distributions has been changed to incorporate location shift for quantiles `0` and `1` as explained in gh-14236. Appropriate tests have also been added. This PR closely resembles gh-11248.

#### Additional information

N/A