### PR TITLE
Rephrase collection of libraries that use PyData-Sphinx

### DIFF
--- a/doc/release/1.7.0-notes.rst
+++ b/doc/release/1.7.0-notes.rst
@@ -28,7 +28,7 @@ Highlights of this release
 
 - A new submodule for quasi-Monte Carlo, `scipy.stats.qmc`, was added
 - The documentation design was updated to use the same PyData-Sphinx theme as
-  other NumFOCUS packages like NumPy.
+  NumPy and other ecosystem libraries.
 - We now vendor and leverage the Boost C++ library to enable numerous
   improvements for long-standing weaknesses in `scipy.stats`
 - `scipy.stats` has six new distributions, eight new (or overhauled)


### PR DESCRIPTION
NumFOCUS is not the binding factor here, so replacing it with "ecosystem".