### PR TITLE
DOC: Add method details/reference to `scipy.integrate.dblquad`  and `scipy.integrate.tplquad`

### DIFF
--- a/scipy/integrate/quadpack.py
+++ b/scipy/integrate/quadpack.py
@@ -529,8 +529,9 @@ def _quad_weight(func,a,b,args,full_output,epsabs,epsrel,limlst,limit,maxp1,weig
 
 def dblquad(func, a, b, gfun, hfun, args=(), epsabs=1.49e-8, epsrel=1.49e-8):
     """
-    Compute a double integral.
+    Compute a double(deinite) integral.
 
+    Wraps `nquad` to compute double integral.
     Return the double (definite) integral of ``func(y, x)`` from ``x = a..b``
     and ``y = gfun(x)..hfun(x)``.
 
@@ -607,6 +608,7 @@ def tplquad(func, a, b, gfun, hfun, qfun, rfun, args=(), epsabs=1.49e-8,
     """
     Compute a triple (definite) integral.
 
+    Wraps `nquad` to compute triple integral.
     Return the triple integral of ``func(z, y, x)`` from ``x = a..b``,
     ``y = gfun(x)..hfun(x)``, and ``z = qfun(x,y)..rfun(x,y)``.
 
@@ -769,7 +771,7 @@ def nquad(func, ranges, args=None, opts=None, full_output=False):
     See Also
     --------
     quad : 1-D numerical integration
-    dblquad, tplquad : double and triple integrals
+    dblquad, tplquad : double and triple integrals (wrap `nquad`)
     fixed_quad : fixed-order Gaussian quadrature
     quadrature : adaptive Gaussian quadrature
 

--- a/scipy/integrate/quadpack.py
+++ b/scipy/integrate/quadpack.py
@@ -529,7 +529,7 @@ def _quad_weight(func,a,b,args,full_output,epsabs,epsrel,limlst,limit,maxp1,weig
 
 def dblquad(func, a, b, gfun, hfun, args=(), epsabs=1.49e-8, epsrel=1.49e-8):
     """
-    Compute a double(deinite) integral.
+    Compute a double (definite) integral.
 
     Wraps `nquad` to compute double integral.
     Return the double (definite) integral of ``func(y, x)`` from ``x = a..b``


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #13872

#### What does this implement/fix?
Add method details/reference to the documentation of  `scipy.integrate.dblquad`  and `scipy.integrate.tplquad`

#### Additional information
Both `scipy.integrate.dblquad`  and `scipy.integrate.tplquad` wrap `scipy.integrate.nquad` to perform double and triple integration (definite) respectively. This was previously unclear, [see here](https://github.com/scipy/scipy/issues/13872)
<!--Any additional information you think is important.-->