### PR TITLE
Error in parameter checking  in cdfbin.f

### DIFF
--- a/scipy/special/cdflib/cdfbin.f
+++ b/scipy/special/cdflib/cdfbin.f
@@ -118,7 +118,7 @@ C     ..
 C     .. Intrinsic Functions ..
       INTRINSIC abs
 C     ..
-      IF (.NOT. ((which.LT.1).AND. (which.GT.4))) GO TO 30
+      IF (.NOT. ((which.LT.1).OR. (which.GT.4))) GO TO 30
       IF (.NOT. (which.LT.1)) GO TO 10
       bound = 1.0D0
       GO TO 20


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
I don't think there is a related issue yet.

#### What does this implement/fix?
<!--Please explain your changes.-->
Fixes an error in the logic of parameter checking for the ```which``` parameter in the CDFBIN subroutine.

#### Additional information
<!--Any additional information you think is important.-->
Someone clearly made a typo and when trying to check that the ```which``` parameter should not be smaller than 1 and not larger than 4, accidentally put 
```Fortran
(.NOT. ((which.LT.1).AND. (which.GT.4)))
```
which is always true instead of the correct expression
```Fortran
(.NOT. ((which.LT.1).OR. (which.GT.4)))
```
This is of not too much consequence as long as ```CDFBIN``` is called with legal ```which``` parameters in {1,2,3,4} but should nevertheless be corrected.
