### PR TITLE
BUG: Fixed an issue wherein `SphericalVoronoi` could raise for certain array-likes

### DIFF
--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -176,7 +176,7 @@ class SphericalVoronoi:
 
         self.radius = float(radius)
         self.points = np.array(points).astype(np.double)
-        self._dim = len(points[0])
+        self._dim = self.points.shape[1]
         if center is None:
             self.center = np.zeros(self._dim)
         else:

--- a/scipy/spatial/tests/test_spherical_voronoi.py
+++ b/scipy/spatial/tests/test_spherical_voronoi.py
@@ -128,6 +128,11 @@ class TestSphericalVoronoi:
         assert_array_equal(s4.center, center)
         assert_equal(s4.radius, radius)
 
+        # Test a non-sequence/-ndarray based array-like
+        s5 = SphericalVoronoi(memoryview(self.points))
+        assert_array_equal(s5.center, np.array([0, 0, 0]))
+        assert_equal(s5.radius, 1)
+
     def test_vertices_regions_translation_invariance(self):
         sv_origin = SphericalVoronoi(self.points)
         center = np.array([1, 1, 1])

--- a/scipy/spatial/tests/test_spherical_voronoi.py
+++ b/scipy/spatial/tests/test_spherical_voronoi.py
@@ -129,7 +129,7 @@ class TestSphericalVoronoi:
         assert_equal(s4.radius, radius)
 
         # Test a non-sequence/-ndarray based array-like
-        s5 = SphericalVoronoi(memoryview(self.points))
+        s5 = SphericalVoronoi(memoryview(self.points))  # type: ignore[arg-type]
         assert_array_equal(s5.center, np.array([0, 0, 0]))
         assert_equal(s5.radius, 1)
 


### PR DESCRIPTION
#### Reference issue
n.a.

#### What does this implement/fix?
`SphericalVoronoi` would previously assume that the passed `points` (a 2D array-like) would support `__getitem__`.
While this is true for majority of cases (_i.e._ ndarrays or nested sequences), this assumption does not necessarily 
hold true for others, including the likes of memoryviews or objects that only implement the `__array__` protocol.

Aforementioned issue has been resolved by removing the getitem operation on the `points` array-like,
instead extracting the relevant axis length from its corresponding ndarray.

#### Additional information
Prior to this PR:
``` python
In [1]: from scipy.spatial import SphericalVoronoi
   ...: import numpy as np

In [2]: points_array = np.array(
   ...:     [[0, 0, 1], [0, 0, -1], [1, 0, 0],
   ...:      [0, 1, 0], [0, -1, 0], [-1, 0, 0]]
   ...: )
   ...: points = memoryview(points_array)
   ...:

In [3]: SphericalVoronoi(points)
---------------------------------------------------------------------------
NotImplementedError                       Traceback (most recent call last)
<ipython-input-3-b5e197d36cd6> in <module>
----> 1 SphericalVoronoi(memoryview(points))

~\anaconda3\envs\CAT\lib\site-packages\scipy\spatial\_spherical_voronoi.py in __init__(self, points, radius, center, threshold)
    177         self.radius = float(radius)
    178         self.points = np.array(points).astype(np.double)
--> 179         self._dim = len(points[0])
    180         if center is None:
    181             self.center = np.zeros(self._dim)

NotImplementedError: multi-dimensional sub-views are not implemented
```