### PR TITLE
CI: pin mypy to 0.902 and fix one CI failure

### DIFF
--- a/mypy_requirements.txt
+++ b/mypy_requirements.txt
@@ -1,4 +1,4 @@
 # Note: this should disappear at some point. For now, please keep it
 #       in sync with the dev dependencies in pyproject.toml
-mypy
+mypy==0.902
 typing_extensions

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -884,9 +884,9 @@ class LatinHypercube(QMCEngine):
 
         """
         if self.centered:
-            samples = 0.5
+            samples: np.ndarray | float = 0.5
         else:
-            samples = self.rng.uniform(size=(n, self.d))  # type: ignore[assignment]
+            samples = self.rng.uniform(size=(n, self.d))
 
         perms = np.tile(np.arange(1, n + 1), (self.d, 1))
         for i in range(self.d):


### PR DESCRIPTION
Newer mypy releases often come with new failures (because Mypy got smarter in this case, so the `#type: ignore` is no longer needed), so we want to pin the mypy version in CI.
