### PR TITLE
BLD: optimize: fix some warnings in moduleTNC and minpack.h

### DIFF
--- a/scipy/optimize/__minpack.h
+++ b/scipy/optimize/__minpack.h
@@ -255,7 +255,7 @@ static PyObject *minpack_hybrd(PyObject *dummy, PyObject *args) {
   int      allocated = 0;
   double   *wa = NULL;
 
-  STORE_VARS();    /* Define storage variables for global variables. */
+  STORE_VARS_NO_INFO();    /* Define storage variables for global variables. */
   
   if (!PyArg_ParseTuple(args, "OO|OidiiiddO", &fcn, &x0, &extra_args, &full_output, &xtol, &maxfev, &ml, &mu, &epsfcn, &factor, &o_diag)) return NULL;
 
@@ -464,7 +464,7 @@ static PyObject *minpack_lmdif(PyObject *dummy, PyObject *args) {
   int      allocated = 0;
   double   *wa = NULL;
 
-  STORE_VARS();
+  STORE_VARS_NO_INFO();
 
   if (!PyArg_ParseTuple(args, "OO|OidddiddO", &fcn, &x0, &extra_args, &full_output, &ftol, &xtol, &gtol, &maxfev, &epsfcn, &factor, &o_diag)) return NULL;
 

--- a/scipy/optimize/minpack.h
+++ b/scipy/optimize/minpack.h
@@ -36,6 +36,7 @@ the result tuple when the full_output argument is non-zero.
 #define PYERR2(errobj,message) {PyErr_Print(); PyErr_SetString(errobj, message); goto fail;}
 
 #define STORE_VARS() ccallback_t callback; int callback_inited = 0; jac_callback_info_t jac_callback_info;
+#define STORE_VARS_NO_INFO() ccallback_t callback; int callback_inited = 0;
 
 #define INIT_FUNC(fun,arg,errobj) do { /* Get extra arguments or set to zero length tuple */ \
   if (arg == NULL) { \

--- a/scipy/optimize/tnc/moduleTNC.c
+++ b/scipy/optimize/tnc/moduleTNC.c
@@ -23,8 +23,10 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-static char const rcsid[] =
-  "@(#) $Jeannot: moduleTNC.c,v 1.12 2005/01/28 18:27:31 js Exp $";
+/*
+ * static char const rcsid[] =
+ *   "@(#) $Jeannot: moduleTNC.c,v 1.12 2005/01/28 18:27:31 js Exp $";
+ */
 
 #include "Python.h"
 #include "numpy/arrayobject.h"


### PR DESCRIPTION
The warnings were:
```
[2/15] Compiling C object scipy/optimize/moduleTNC.cpython-39-x86_64-linux-gnu.so.p/tnc_moduleTNC.c.o
../scipy/optimize/tnc/moduleTNC.c:26:19: warning: 'rcsid' defined but not used [-Wunused-const-variable=]
   26 | static char const rcsid[] =
      |                   ^~~~~
[6/15] Compiling C object scipy/optimize/_minpack.cpython-39-x86_64-linux-gnu.so.p/_minpackmodule.c.o
In file included from ../scipy/optimize/_minpackmodule.c:5:
../scipy/optimize/__minpack.h: In function 'minpack_hybrd':
../scipy/optimize/minpack.h:38:89: warning: unused variable 'jac_callback_info' [-Wunused-variable]
   38 | #define STORE_VARS() ccallback_t callback; int callback_inited = 0; jac_callback_info_t jac_callback_info;
      |                                                                                         ^~~~~~~~~~~~~~~~~
../scipy/optimize/__minpack.h:258:3: note: in expansion of macro 'STORE_VARS'
  258 |   STORE_VARS();    /* Define storage variables for global variables. */
      |   ^~~~~~~~~~
../scipy/optimize/__minpack.h: In function 'minpack_lmdif':
../scipy/optimize/minpack.h:38:89: warning: unused variable 'jac_callback_info' [-Wunused-variable]
   38 | #define STORE_VARS() ccallback_t callback; int callback_inited = 0; jac_callback_info_t jac_callback_info;
      |                                                                                         ^~~~~~~~~~~~~~~~~
../scipy/optimize/__minpack.h:467:3: note: in expansion of macro 'STORE_VARS'
  467 |   STORE_VARS();
      |   ^~~~~~~~~~
```

Note that there's four usages of `STORE_VARS` and two of them did need `jac_callback_info`, so that cannot just be removed.