### PR TITLE
BLD: fix include order and build warnings for `optimize/_trlib`

### DIFF
--- a/scipy/optimize/_trlib/trlib_krylov.c
+++ b/scipy/optimize/_trlib/trlib_krylov.c
@@ -722,7 +722,6 @@ trlib_int_t trlib_krylov_min(
         if( ret < 10 && *outerstatus < 100 && convexify ) {
             // exit, check if we should convexify
             trlib_flt_t lam = fwork[7];
-            trlib_flt_t obj = fwork[8];
             if( lam > 1e-2*fmax(1.0, fwork[13]) && fwork[14] < 0.0 && fabs(fwork[14]) < 1e-8 * fwork[13]) { // do only if it seems to make sense based on eigenvalue estimation
                 // ask caller to compute objective value
                 *outerstatus = 200 + ret;
@@ -731,7 +730,6 @@ trlib_int_t trlib_krylov_min(
             }
         }
         if( *outerstatus > 200 && *outerstatus < 300 ) {
-            trlib_flt_t lam = fwork[7];
             trlib_flt_t obj = fwork[8];
             trlib_flt_t realobj = g_dot_g;
             if( fabs(obj - realobj) > fmax(1e-6, 1e-1*fabs(realobj)) || realobj > 0.0) {

--- a/scipy/optimize/_trlib/trlib_private.h
+++ b/scipy/optimize/_trlib/trlib_private.h
@@ -28,15 +28,15 @@
 /* #undef TRLIB_MEASURE_TIME */
 /* #undef TRLIB_MEASURE_SUBTIME */
 
+#include "numpy/arrayobject.h"
+#include "npy_cblas.h"
+
 #include "trlib.h"
 #include <math.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
-
-#include "numpy/arrayobject.h"
-#include "npy_cblas.h"
 
 // blas
 void BLAS_FUNC(daxpy)(CBLAS_INT *n, double *alpha, double *x, CBLAS_INT *incx, double *y, CBLAS_INT *incy);


### PR DESCRIPTION
`Python.h` must always be included before standard system headers, and numpy includes pull in `Python.h` so must come first too.

This was the cause of build warnings like (repeated quite a few times):
```
[10/17] Compiling C object scipy/optimize/_trlib/_trlib.cpython-39-x86_64-linux-gnu.so.p/trlib_krylov.c.o
In file included from /home/rgommers/anaconda3/envs/scipy-meson/include/python3.9/Python.h:85,
                 from /home/rgommers/anaconda3/envs/scipy-meson/lib/python3.9/site-packages/numpy/core/include/numpy/ndarrayobject.h:11,
                 from /home/rgommers/anaconda3/envs/scipy-meson/lib/python3.9/site-packages/numpy/core/include/numpy/arrayobject.h:4,
                 from ../scipy/optimize/_trlib/trlib_private.h:38,
                 from ../scipy/optimize/_trlib/trlib_krylov.c:26:
/home/rgommers/anaconda3/envs/scipy-meson/include/python3.9/pytime.h:153:60: warning: 'struct timespec' declared inside parameter list will not be visible outside of this definition or declaration
  153 | PyAPI_FUNC(int) _PyTime_FromTimespec(_PyTime_t *tp, struct timespec *ts);
      |                                                            ^~~~~~~~
/home/rgommers/anaconda3/envs/scipy-meson/include/python3.9/pytime.h:158:56: warning: 'struct timespec' declared inside parameter list will not be visible outside of this definition or declaration
  158 | PyAPI_FUNC(int) _PyTime_AsTimespec(_PyTime_t t, struct timespec *ts);
      |                                                        ^~~~~~~~
```

The unused variable warnings were:
```
../scipy/optimize/_trlib/trlib_krylov.c: In function 'trlib_krylov_min':
../scipy/optimize/_trlib/trlib_krylov.c:725:25: warning: unused variable 'obj' [-Wunused-variable]
  725 |             trlib_flt_t obj = fwork[8];
      |                         ^~~
../scipy/optimize/_trlib/trlib_krylov.c:734:25: warning: unused variable 'lam' [-Wunused-variable]
  734 |             trlib_flt_t lam = fwork[7];
      |                         ^~~
```