### PR TITLE
REL: fix doc upload path, remove "not yet released" line for 1.7.0

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -89,7 +89,7 @@ doc-dist: html-scipyorg html
 	-test -d build/htmlhelp || make htmlhelp-build
 	-rm -rf build/dist
 	mkdir -p build/dist
-	cp -r build/html-scipyorg build/dist/reference
+	cp -r build/html-scipyorg build/dist
 	touch build/dist/index.html
 	(cd build/html && zip -9qr ../dist/scipy-html.zip .)
 	cp build/latex/scipy-ref.pdf build/dist

--- a/doc/release/1.7.0-notes.rst
+++ b/doc/release/1.7.0-notes.rst
@@ -2,8 +2,6 @@
 SciPy 1.7.0 Release Notes
 ==========================
 
-.. note:: Scipy 1.7.0 is not released yet!
-
 .. contents::
 
 SciPy 1.7.0 is the culmination of 6 months of hard work. It contains
@@ -33,7 +31,7 @@ Highlights of this release
   improvements for long-standing weaknesses in `scipy.stats`
 - `scipy.stats` has six new distributions, eight new (or overhauled)
   hypothesis tests, a new function for bootstrapping, a class that enables
-  fast random variate sampling and percentile point function evaluation, 
+  fast random variate sampling and percentile point function evaluation,
   and many other enhancements.
 - ``cdist`` and ``pdist`` distance calculations are faster for several metrics,
   especially weighted cases, thanks to a rewrite to a new C++ backend framework


### PR DESCRIPTION
Closes gh-14267

`[ci skip]`