### PR TITLE
MAINT: Update vendored uarray, required for auto-dispatching

### DIFF
--- a/scipy/_lib/_uarray/__init__.py
+++ b/scipy/_lib/_uarray/__init__.py
@@ -1,5 +1,5 @@
 """
-.. note:
+.. note::
     If you are looking for overrides for NumPy-specific methods, see the
     documentation for :obj:`unumpy`. This page explains how to write
     back-ends and multimethods.

--- a/scipy/_lib/_uarray/__init__.py
+++ b/scipy/_lib/_uarray/__init__.py
@@ -1,10 +1,10 @@
 """
-.. note::
+.. note:
     If you are looking for overrides for NumPy-specific methods, see the
     documentation for :obj:`unumpy`. This page explains how to write
     back-ends and multimethods.
 
-``uarray`` is built around a back-end protocol and overridable multimethods.
+``uarray`` is built around a back-end protocol, and overridable multimethods.
 It is necessary to define multimethods for back-ends to be able to override them.
 See the documentation of :obj:`generate_multimethod` on how to write multimethods.
 
@@ -97,7 +97,7 @@ converted at all and it's up to the backend to handle that.
 ('override_me', (1, '2'), {})
 
 You also have the option to return ``NotImplemented``, in which case processing moves on
-to the next back-end, which, in this case, doesn't exist. The same applies to
+to the next back-end, which in this case, doesn't exist. The same applies to
 ``__ua_convert__``.
 
 >>> be.__ua_function__ = lambda *a, **kw: NotImplemented
@@ -105,7 +105,7 @@ to the next back-end, which, in this case, doesn't exist. The same applies to
 ...     overridden_me(1, "2")
 Traceback (most recent call last):
     ...
-uarray.backend.BackendNotImplementedError: ...
+uarray.BackendNotImplementedError: ...
 
 The last possibility is if we don't have ``__ua_convert__``, in which case the job is left
 up to ``__ua_function__``, but putting things back into arrays after conversion will not be
@@ -113,5 +113,7 @@ possible.
 """
 
 from ._backend import *
+from ._version import get_versions
 
-__version__ = '0.5.1+49.g4c3f1d7.scipy'
+__version__ = get_versions()["version"]
+del get_versions

--- a/scipy/_lib/_uarray/__init__.py
+++ b/scipy/_lib/_uarray/__init__.py
@@ -113,7 +113,5 @@ possible.
 """
 
 from ._backend import *
-from ._version import get_versions
 
-__version__ = get_versions()["version"]
-del get_versions
+__version__ = '0.8.2+14.gaf53966.scipy'

--- a/scipy/_lib/_uarray/_uarray_dispatch.cxx
+++ b/scipy/_lib/_uarray/_uarray_dispatch.cxx
@@ -1,13 +1,16 @@
+#include "small_dynamic_array.h"
+#include "vectorcall.h"
+
+#include <Python.h>
 
 #include <algorithm>
 #include <cstddef>
 #include <new>
+#include <stdexcept>
 #include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>
-
-#include <Python.h>
 
 
 namespace {
@@ -88,9 +91,17 @@ py_ref py_make_tuple(const Ts &... args) {
   return py_ref::steal(PyTuple_Pack(sizeof...(args), py_get(args)...));
 }
 
+py_ref py_bool(bool input) { return py_ref::ref(input ? Py_True : Py_False); }
+
+template <typename T, size_t N>
+constexpr size_t array_size(const T (&array)[N]) {
+  return N;
+}
+
 struct backend_options {
   py_ref backend;
-  bool coerce, only;
+  bool coerce = false;
+  bool only = false;
 
   bool operator==(const backend_options & other) const {
     return (
@@ -106,6 +117,7 @@ struct backend_options {
 struct global_backends {
   backend_options global;
   std::vector<py_ref> registered;
+  bool try_global_backend_last = false;
 };
 
 struct local_backends {
@@ -113,15 +125,19 @@ struct local_backends {
   std::vector<backend_options> preferred;
 };
 
+using global_state_t = std::unordered_map<std::string, global_backends>;
+using local_state_t = std::unordered_map<std::string, local_backends>;
 
 static py_ref BackendNotImplementedError;
-static std::unordered_map<std::string, global_backends> global_domain_map;
-thread_local std::unordered_map<std::string, local_backends> local_domain_map;
+static global_state_t global_domain_map;
+thread_local global_state_t * current_global_state = &global_domain_map;
+thread_local global_state_t thread_local_domain_map;
+thread_local local_state_t local_domain_map;
 
 /** Constant Python string identifiers
 
 Using these with PyObject_GetAttr is faster than PyObject_GetAttrString which
-has to create a new Python string internally.
+has to create a new python string internally.
  */
 struct {
   py_ref ua_convert;
@@ -151,9 +167,23 @@ struct {
   }
 } identifiers;
 
-std::string domain_to_string(PyObject * domain) {
+bool domain_validate(PyObject * domain) {
   if (!PyUnicode_Check(domain)) {
     PyErr_SetString(PyExc_TypeError, "__ua_domain__ must be a string");
+    return false;
+  }
+
+  auto size = PyUnicode_GetLength(domain);
+  if (size == 0) {
+    PyErr_SetString(PyExc_ValueError, "__ua_domain__ must be non-empty");
+    return false;
+  }
+
+  return true;
+}
+
+std::string domain_to_string(PyObject * domain) {
+  if (!domain_validate(domain)) {
     return {};
   }
 
@@ -170,44 +200,399 @@ std::string domain_to_string(PyObject * domain) {
   return std::string(str, size);
 }
 
-std::string backend_to_domain_string(PyObject * backend) {
+Py_ssize_t backend_get_num_domains(PyObject * backend) {
   auto domain =
       py_ref::steal(PyObject_GetAttr(backend, identifiers.ua_domain.get()));
   if (!domain)
-    return {};
+    return -1;
 
-  return domain_to_string(domain.get());
+  if (PyUnicode_Check(domain.get())) {
+    return 1;
+  }
+
+  if (!PySequence_Check(domain.get())) {
+    PyErr_SetString(
+        PyExc_TypeError,
+        "__ua_domain__ must be a string or sequence of strings");
+    return -1;
+  }
+
+  return PySequence_Size(domain.get());
 }
 
+enum class LoopReturn { Continue, Break, Error };
 
-/** Use to clean up Python references before the interpreter is finalized.
- *
- * This must be installed in a Python atexit handler. This prevents Py_DECREF
- * being called after the interpreter has already shut down.
- */
-PyObject * clear_all_globals(PyObject * /* self */, PyObject * /* args */) {
+template <typename Func>
+LoopReturn backend_for_each_domain(PyObject * backend, Func f) {
+  auto domain =
+      py_ref::steal(PyObject_GetAttr(backend, identifiers.ua_domain.get()));
+  if (!domain)
+    return LoopReturn::Error;
+
+  if (PyUnicode_Check(domain.get())) {
+    return f(domain.get());
+  }
+
+  if (!PySequence_Check(domain.get())) {
+    PyErr_SetString(
+        PyExc_TypeError,
+        "__ua_domain__ must be a string or sequence of strings");
+    return LoopReturn::Error;
+  }
+
+  auto size = PySequence_Size(domain.get());
+  if (size < 0)
+    return LoopReturn::Error;
+  if (size == 0) {
+    PyErr_SetString(PyExc_ValueError, "__ua_domain__ lists must be non-empty");
+    return LoopReturn::Error;
+  }
+
+  for (Py_ssize_t i = 0; i < size; ++i) {
+    auto dom = py_ref::steal(PySequence_GetItem(domain.get(), i));
+    if (!dom)
+      return LoopReturn::Error;
+
+    auto res = f(dom.get());
+    if (res != LoopReturn::Continue) {
+      return res;
+    }
+  }
+  return LoopReturn::Continue;
+}
+
+template <typename Func>
+LoopReturn backend_for_each_domain_string(PyObject * backend, Func f) {
+  return backend_for_each_domain(backend, [&](PyObject * domain) {
+    auto domain_string = domain_to_string(domain);
+    if (domain_string.empty()) {
+      return LoopReturn::Error;
+    }
+    return f(domain_string);
+  });
+}
+
+bool backend_validate_ua_domain(PyObject * backend) {
+  const auto res = backend_for_each_domain(backend, [&](PyObject * domain) {
+    return domain_validate(domain) ? LoopReturn::Continue : LoopReturn::Error;
+  });
+  return (res != LoopReturn::Error);
+}
+
+struct BackendState {
+  PyObject_HEAD
+  global_state_t globals;
+  local_state_t locals;
+  bool use_thread_local_globals = true;
+
+  static void dealloc(BackendState * self) {
+    self->~BackendState();
+    Py_TYPE(self)->tp_free(self);
+  }
+
+  static PyObject * new_(
+      PyTypeObject * type, PyObject * args, PyObject * kwargs) {
+    auto self = reinterpret_cast<BackendState *>(type->tp_alloc(type, 0));
+    if (self == nullptr)
+      return nullptr;
+
+    // Placement new
+    self = new (self) BackendState;
+    return reinterpret_cast<PyObject *>(self);
+  }
+
+  static PyObject * pickle_(BackendState * self) {
+    try {
+      py_ref py_global = BackendState::convert_py(self->globals);
+      py_ref py_locals = BackendState::convert_py(self->locals);
+      py_ref py_use_local_globals =
+          BackendState::convert_py(self->use_thread_local_globals);
+
+      return py_make_tuple(py_global, py_locals, py_use_local_globals)
+          .release();
+    } catch (std::runtime_error &) {
+      return nullptr;
+    }
+  }
+
+  static PyObject * unpickle_(PyObject * cls, PyObject * args) {
+    try {
+      PyObject *py_locals, *py_global;
+      py_ref ref =
+          py_ref::steal(Q_PyObject_Vectorcall(cls, nullptr, 0, nullptr));
+      BackendState * output = reinterpret_cast<BackendState *>(ref.get());
+      if (output == nullptr)
+        return nullptr;
+
+      int use_thread_local_globals;
+      if (!PyArg_ParseTuple(
+              args, "OOp", &py_global, &py_locals, &use_thread_local_globals))
+        return nullptr;
+      local_state_t locals = convert_local_state(py_locals);
+      global_state_t globals = convert_global_state(py_global);
+
+      output->locals = std::move(locals);
+      output->globals = std::move(globals);
+      output->use_thread_local_globals = use_thread_local_globals;
+
+      return ref.release();
+    } catch (std::invalid_argument &) {
+      return nullptr;
+    } catch (std::bad_alloc &) {
+      PyErr_NoMemory();
+      return nullptr;
+    }
+  }
+
+  template <typename T, typename Convertor>
+  static std::vector<T> convert_iter(
+      PyObject * input, Convertor item_convertor) {
+    std::vector<T> output;
+    py_ref iterator = py_ref::steal(PyObject_GetIter(input));
+    if (!iterator)
+      throw std::invalid_argument("");
+
+    py_ref item;
+    while ((item = py_ref::steal(PyIter_Next(iterator.get())))) {
+      output.push_back(item_convertor(item.get()));
+    }
+
+    if (PyErr_Occurred())
+      throw std::invalid_argument("");
+
+    return output;
+  }
+
+  template <
+      typename K, typename V, typename KeyConvertor, typename ValueConvertor>
+  static std::unordered_map<K, V> convert_dict(
+      PyObject * input, KeyConvertor key_convertor,
+      ValueConvertor value_convertor) {
+    std::unordered_map<K, V> output;
+
+    if (!PyDict_Check(input))
+      throw std::invalid_argument("");
+
+    PyObject *key, *value;
+    Py_ssize_t pos = 0;
+
+    while (PyDict_Next(input, &pos, &key, &value)) {
+      output[key_convertor(key)] = value_convertor(value);
+    }
+
+    if (PyErr_Occurred())
+      throw std::invalid_argument("");
+
+    return output;
+  }
+
+  static std::string convert_domain(PyObject * input) {
+    std::string output = domain_to_string(input);
+    if (output.empty())
+      throw std::invalid_argument("");
+
+    return output;
+  }
+
+  static backend_options convert_backend_options(PyObject * input) {
+    backend_options output;
+    int coerce, only;
+    PyObject * py_backend;
+    if (!PyArg_ParseTuple(input, "Opp", &py_backend, &coerce, &only))
+      throw std::invalid_argument("");
+
+    if (py_backend != Py_None) {
+      output.backend = py_ref::ref(py_backend);
+    }
+    output.coerce = coerce;
+    output.only = only;
+
+    return output;
+  }
+
+  static py_ref convert_backend(PyObject * input) { return py_ref::ref(input); }
+
+  static local_backends convert_local_backends(PyObject * input) {
+    PyObject *py_skipped, *py_preferred;
+    if (!PyArg_ParseTuple(input, "OO", &py_skipped, &py_preferred))
+      throw std::invalid_argument("");
+
+    local_backends output;
+    output.skipped =
+        convert_iter<py_ref>(py_skipped, BackendState::convert_backend);
+    output.preferred = convert_iter<backend_options>(
+        py_preferred, BackendState::convert_backend_options);
+
+    return output;
+  }
+
+  static global_backends convert_global_backends(PyObject * input) {
+    PyObject *py_global, *py_registered;
+    int try_global_backend_last;
+    if (!PyArg_ParseTuple(
+            input, "OOp", &py_global, &py_registered, &try_global_backend_last))
+      throw std::invalid_argument("");
+
+    global_backends output;
+    output.global = BackendState::convert_backend_options(py_global);
+    output.registered =
+        convert_iter<py_ref>(py_registered, BackendState::convert_backend);
+    output.try_global_backend_last = try_global_backend_last;
+
+    return output;
+  }
+
+  static global_state_t convert_global_state(PyObject * input) {
+    return convert_dict<std::string, global_backends>(
+        input, BackendState::convert_domain,
+        BackendState::convert_global_backends);
+  }
+
+  static local_state_t convert_local_state(PyObject * input) {
+    return convert_dict<std::string, local_backends>(
+        input, BackendState::convert_domain,
+        BackendState::convert_local_backends);
+  }
+
+  static py_ref convert_py(py_ref input) { return input; }
+
+  static py_ref convert_py(bool input) { return py_bool(input); }
+
+  static py_ref convert_py(backend_options input) {
+    if (!input.backend) {
+      input.backend = py_ref::ref(Py_None);
+    }
+    py_ref output = py_make_tuple(
+        input.backend, py_bool(input.coerce), py_bool(input.only));
+    if (!output)
+      throw std::runtime_error("");
+    return output;
+  }
+
+  static py_ref convert_py(const std::string & input) {
+    py_ref output =
+        py_ref::steal(PyUnicode_FromStringAndSize(input.c_str(), input.size()));
+    if (!output)
+      throw std::runtime_error("");
+    return output;
+  }
+
+  template <typename T>
+  static py_ref convert_py(const std::vector<T> & input) {
+    py_ref output = py_ref::steal(PyList_New(input.size()));
+
+    if (!output)
+      throw std::runtime_error("");
+
+    for (size_t i = 0; i < input.size(); i++) {
+      py_ref element = convert_py(input[i]);
+      PyList_SET_ITEM(output.get(), i, element.release());
+    }
+
+    return output;
+  }
+
+  static py_ref convert_py(const local_backends & input) {
+    py_ref py_skipped = BackendState::convert_py(input.skipped);
+    py_ref py_preferred = BackendState::convert_py(input.preferred);
+    py_ref output = py_make_tuple(py_skipped, py_preferred);
+
+    if (!output)
+      throw std::runtime_error("");
+
+    return output;
+  }
+
+  static py_ref convert_py(const global_backends & input) {
+    py_ref py_globals = BackendState::convert_py(input.global);
+    py_ref py_registered = BackendState::convert_py(input.registered);
+    py_ref output = py_make_tuple(
+        py_globals, py_registered, py_bool(input.try_global_backend_last));
+
+    if (!output)
+      throw std::runtime_error("");
+
+    return output;
+  }
+
+  template <typename K, typename V>
+  static py_ref convert_py(const std::unordered_map<K, V> & input) {
+    py_ref output = py_ref::steal(PyDict_New());
+
+    if (!output)
+      throw std::runtime_error("");
+
+    for (const auto & kv : input) {
+      py_ref py_key = convert_py(kv.first);
+      py_ref py_value = convert_py(kv.second);
+
+      if (PyDict_SetItem(output.get(), py_key.get(), py_value.get()) < 0) {
+        throw std::runtime_error("");
+      }
+    }
+
+    return output;
+  }
+};
+
+/** Clean up global python references when the module is finalized. */
+void globals_free(void * /* self */) {
   global_domain_map.clear();
   BackendNotImplementedError.reset();
   identifiers.clear();
-  Py_RETURN_NONE;
+}
+
+/** Allow GC to break reference cycles between the module and global backends.
+ *
+ * NOTE: local state and "thread local globals" can't be visited because we
+ * can't access locals from another thread. However, since those are only
+ * set through context managers they should always be unset before module
+ * cleanup.
+ */
+int globals_traverse(PyObject * self, visitproc visit, void * arg) {
+  for (const auto & kv : global_domain_map) {
+    const auto & globals = kv.second;
+    PyObject * backend = globals.global.backend.get();
+    Py_VISIT(backend);
+    for (const auto & reg : globals.registered) {
+      backend = reg.get();
+      Py_VISIT(backend);
+    }
+  }
+  return 0;
+}
+
+int globals_clear(PyObject * /* self */) {
+  global_domain_map.clear();
+  return 0;
 }
 
 PyObject * set_global_backend(PyObject * /* self */, PyObject * args) {
   PyObject * backend;
-  int only = false, coerce = false;
-  if (!PyArg_ParseTuple(args, "O|pp", &backend, &coerce, &only))
+  int only = false, coerce = false, try_last = false;
+  if (!PyArg_ParseTuple(args, "O|ppp", &backend, &coerce, &only, &try_last))
     return nullptr;
 
-  auto domain = backend_to_domain_string(backend);
-  if (domain.empty())
+  if (!backend_validate_ua_domain(backend)) {
+    return nullptr;
+  }
+
+  const auto res =
+      backend_for_each_domain_string(backend, [&](const std::string & domain) {
+        backend_options options;
+        options.backend = py_ref::ref(backend);
+        options.coerce = coerce;
+        options.only = only;
+
+        auto & domain_globals = (*current_global_state)[domain];
+        domain_globals.global = options;
+        domain_globals.try_global_backend_last = try_last;
+        return LoopReturn::Continue;
+      });
+
+  if (res == LoopReturn::Error)
     return nullptr;
 
-  backend_options options;
-  options.backend = py_ref::ref(backend);
-  options.coerce = coerce;
-  options.only = only;
-
-  global_domain_map[domain].global = options;
   Py_RETURN_NONE;
 }
 
@@ -216,21 +601,29 @@ PyObject * register_backend(PyObject * /* self */, PyObject * args) {
   if (!PyArg_ParseTuple(args, "O", &backend))
     return nullptr;
 
-  auto domain = backend_to_domain_string(backend);
-  if (domain.empty())
+  if (!backend_validate_ua_domain(backend)) {
+    return nullptr;
+  }
+
+  const auto ret =
+      backend_for_each_domain_string(backend, [&](const std::string & domain) {
+        (*current_global_state)[domain].registered.push_back(
+            py_ref::ref(backend));
+        return LoopReturn::Continue;
+      });
+  if (ret == LoopReturn::Error)
     return nullptr;
 
-  global_domain_map[domain].registered.push_back(py_ref::ref(backend));
   Py_RETURN_NONE;
 }
 
 void clear_single(const std::string & domain, bool registered, bool global) {
-  auto domain_globals = global_domain_map.find(domain);
-  if (domain_globals == global_domain_map.end())
+  auto domain_globals = current_global_state->find(domain);
+  if (domain_globals == current_global_state->end())
     return;
 
   if (registered && global) {
-    global_domain_map.erase(domain_globals);
+    current_global_state->erase(domain_globals);
     return;
   }
 
@@ -240,6 +633,7 @@ void clear_single(const std::string & domain, bool registered, bool global) {
 
   if (global) {
     domain_globals->second.global.backend.reset();
+    domain_globals->second.try_global_backend_last = false;
   }
 }
 
@@ -250,7 +644,7 @@ PyObject * clear_backends(PyObject * /* self */, PyObject * args) {
     return nullptr;
 
   if (domain == Py_None && registered && global) {
-    global_domain_map.clear();
+    current_global_state->clear();
     Py_RETURN_NONE;
   }
 
@@ -259,28 +653,51 @@ PyObject * clear_backends(PyObject * /* self */, PyObject * args) {
   Py_RETURN_NONE;
 }
 
-
 /** Common functionality of set_backend and skip_backend */
 template <typename T>
 class context_helper {
+public:
+  using BackendLists = SmallDynamicArray<std::vector<T> *>;
+  // using BackendLists = std::vector<std::vector<T> *>;
+private:
   T new_backend_;
-  std::vector<T> * backends_;
+  BackendLists backend_lists_;
 
 public:
   const T & get_backend() const { return new_backend_; }
 
-  context_helper(): backends_(nullptr) {}
+  context_helper() {}
+
+  bool init(BackendLists && backend_lists, T new_backend) {
+    static_assert(std::is_nothrow_move_assignable<BackendLists>::value, "");
+    backend_lists_ = std::move(backend_lists);
+    new_backend_ = std::move(new_backend);
+    return true;
+  }
 
   bool init(std::vector<T> & backends, T new_backend) {
-    backends_ = &backends;
+    try {
+      backend_lists_ = BackendLists(1, &backends);
+    } catch (std::bad_alloc &) {
+      PyErr_NoMemory();
+      return false;
+    }
     new_backend_ = std::move(new_backend);
     return true;
   }
 
   bool enter() {
+    auto first = backend_lists_.begin();
+    auto last = backend_lists_.end();
+    auto cur = first;
     try {
-      backends_->push_back(new_backend_);
+      for (; cur < last; ++cur) {
+        (*cur)->push_back(new_backend_);
+      }
     } catch (std::bad_alloc &) {
+      for (; first < cur; ++first) {
+        (*first)->pop_back();
+      }
       PyErr_NoMemory();
       return false;
     }
@@ -289,19 +706,26 @@ public:
 
   bool exit() {
     bool success = true;
-    if (backends_->empty()) {
-      PyErr_SetString(
-          PyExc_SystemExit, "__exit__ call has no matching __enter__");
-      return false;
-    }
-    if (backends_->back() != new_backend_) {
-      PyErr_SetString(
-          PyExc_RuntimeError, "Found invalid context state while in __exit__. "
-                              "__enter__ and __exit__ may be unmatched");
-      success = false;
+
+    for (auto * backends : backend_lists_) {
+      if (backends->empty()) {
+        PyErr_SetString(
+            PyExc_SystemExit, "__exit__ call has no matching __enter__");
+        success = false;
+        continue;
+      }
+
+      if (backends->back() != new_backend_) {
+        PyErr_SetString(
+            PyExc_RuntimeError,
+            "Found invalid context state while in __exit__. "
+            "__enter__ and __exit__ may be unmatched");
+        success = false;
+      }
+
+      backends->pop_back();
     }
 
-    backends_->pop_back();
     return success;
   }
 };
@@ -313,6 +737,7 @@ struct SetBackendContext {
   context_helper<backend_options> ctx_;
 
   static void dealloc(SetBackendContext * self) {
+    PyObject_GC_UnTrack(self);
     self->~SetBackendContext();
     Py_TYPE(self)->tp_free(self);
   }
@@ -339,17 +764,38 @@ struct SetBackendContext {
             args, kwargs, "O|pp", (char **)kwlist, &backend, &coerce, &only))
       return -1;
 
-    auto domain = backend_to_domain_string(backend);
-    if (domain.empty())
+    if (!backend_validate_ua_domain(backend)) {
       return -1;
-    backend_options opt;
-    opt.backend = py_ref::ref(backend);
-    opt.coerce = coerce;
-    opt.only = only;
+    }
+
+    auto num_domains = backend_get_num_domains(backend);
+    if (num_domains < 0) {
+      return -1;
+    }
 
     try {
-      if (!self->ctx_.init(local_domain_map[domain].preferred, std::move(opt)))
+      decltype(ctx_)::BackendLists backend_lists(num_domains);
+      int idx = 0;
+
+      const auto ret = backend_for_each_domain_string(
+          backend, [&](const std::string & domain) {
+            backend_lists[idx] = &local_domain_map[domain].preferred;
+            ++idx;
+            return LoopReturn::Continue;
+          });
+
+      if (ret == LoopReturn::Error) {
         return -1;
+      }
+
+      backend_options opt;
+      opt.backend = py_ref::ref(backend);
+      opt.coerce = coerce;
+      opt.only = only;
+
+      if (!self->ctx_.init(std::move(backend_lists), opt)) {
+        return -1;
+      }
     } catch (std::bad_alloc &) {
       PyErr_NoMemory();
       return -1;
@@ -374,6 +820,12 @@ struct SetBackendContext {
     Py_VISIT(self->ctx_.get_backend().backend.get());
     return 0;
   }
+
+  static PyObject * pickle_(SetBackendContext * self, PyObject * /*args*/) {
+    const backend_options & opt = self->ctx_.get_backend();
+    return py_make_tuple(opt.backend, py_bool(opt.coerce), py_bool(opt.only))
+        .release();
+  }
 };
 
 
@@ -383,6 +835,7 @@ struct SkipBackendContext {
   context_helper<py_ref> ctx_;
 
   static void dealloc(SkipBackendContext * self) {
+    PyObject_GC_UnTrack(self);
     self->~SkipBackendContext();
     Py_TYPE(self)->tp_free(self);
   }
@@ -407,14 +860,33 @@ struct SkipBackendContext {
             args, kwargs, "O", (char **)kwlist, &backend))
       return -1;
 
-    auto domain = backend_to_domain_string(backend);
-    if (domain.empty())
+    if (!backend_validate_ua_domain(backend)) {
       return -1;
+    }
+
+    auto num_domains = backend_get_num_domains(backend);
+    if (num_domains < 0) {
+      return -1;
+    }
 
     try {
-      if (!self->ctx_.init(
-              local_domain_map[domain].skipped, py_ref::ref(backend)))
+      decltype(ctx_)::BackendLists backend_lists(num_domains);
+      int idx = 0;
+
+      const auto ret = backend_for_each_domain_string(
+          backend, [&](const std::string & domain) {
+            backend_lists[idx] = &local_domain_map[domain].skipped;
+            ++idx;
+            return LoopReturn::Continue;
+          });
+
+      if (ret == LoopReturn::Error) {
         return -1;
+      }
+
+      if (!self->ctx_.init(std::move(backend_lists), py_ref::ref(backend))) {
+        return -1;
+      }
     } catch (std::bad_alloc &) {
       PyErr_NoMemory();
       return -1;
@@ -438,24 +910,40 @@ struct SkipBackendContext {
   static int traverse(SkipBackendContext * self, visitproc visit, void * arg) {
     Py_VISIT(self->ctx_.get_backend().get());
     return 0;
-    return 0;
+  }
+
+  static PyObject * pickle_(SkipBackendContext * self, PyObject * /*args*/) {
+    return py_make_tuple(self->ctx_.get_backend()).release();
   }
 };
 
-enum class LoopReturn { Continue, Break, Error };
+const local_backends & get_local_backends(const std::string & domain_key) {
+  static const local_backends null_local_backends;
+  auto itr = local_domain_map.find(domain_key);
+  if (itr == local_domain_map.end()) {
+    return null_local_backends;
+  }
+  return itr->second;
+}
+
+
+const global_backends & get_global_backends(const std::string & domain_key) {
+  static const global_backends null_global_backends;
+  const auto & cur_globals = *current_global_state;
+  auto itr = cur_globals.find(domain_key);
+  if (itr == cur_globals.end()) {
+    return null_global_backends;
+  }
+  return itr->second;
+}
 
 template <typename Callback>
-LoopReturn for_each_backend(const std::string & domain_key, Callback call) {
-  local_backends * locals = nullptr;
-  try {
-    locals = &local_domain_map[domain_key];
-  } catch (std::bad_alloc &) {
-    PyErr_NoMemory();
-    return LoopReturn::Error;
-  }
+LoopReturn for_each_backend_in_domain(
+    const std::string & domain_key, Callback call) {
+  const local_backends & locals = get_local_backends(domain_key);
 
-  auto & skip = locals->skipped;
-  auto & pref = locals->preferred;
+  auto & skip = locals.skipped;
+  auto & pref = locals.preferred;
 
   auto should_skip = [&](PyObject * backend) -> int {
     bool success = true;
@@ -486,22 +974,31 @@ LoopReturn for_each_backend(const std::string & domain_key, Callback call) {
       return ret;
 
     if (options.only || options.coerce)
-      return ret;
+      return LoopReturn::Break;
   }
 
-  auto & globals = global_domain_map[domain_key];
-  auto & global_options = globals.global;
-  int skip_current =
-      global_options.backend ? should_skip(global_options.backend.get()) : 1;
-  if (skip_current < 0)
-    return LoopReturn::Error;
-  if (!skip_current) {
-    ret = call(global_options.backend.get(), global_options.coerce);
+  auto & globals = get_global_backends(domain_key);
+  auto try_global_backend = [&] {
+    auto & options = globals.global;
+    if (!options.backend)
+      return LoopReturn::Continue;
+
+    int skip_current = should_skip(options.backend.get());
+    if (skip_current < 0)
+      return LoopReturn::Error;
+    if (skip_current > 0)
+      return LoopReturn::Continue;
+
+    return call(options.backend.get(), options.coerce);
+  };
+
+  if (!globals.try_global_backend_last) {
+    ret = try_global_backend();
     if (ret != LoopReturn::Continue)
       return ret;
 
-    if (global_options.only || global_options.coerce)
-      return ret;
+    if (globals.global.only || globals.global.coerce)
+      return LoopReturn::Break;
   }
 
   for (size_t i = 0; i < globals.registered.size(); ++i) {
@@ -516,7 +1013,29 @@ LoopReturn for_each_backend(const std::string & domain_key, Callback call) {
     if (ret != LoopReturn::Continue)
       return ret;
   }
-  return ret;
+
+  if (!globals.try_global_backend_last) {
+    return ret;
+  }
+  return try_global_backend();
+}
+
+template <typename Callback>
+LoopReturn for_each_backend(std::string domain, Callback call) {
+  do {
+    auto ret = for_each_backend_in_domain(domain, call);
+    if (ret != LoopReturn::Continue) {
+      return ret;
+    }
+
+    auto dot_pos = domain.rfind('.');
+    if (dot_pos == std::string::npos) {
+      return ret;
+    }
+
+    domain.resize(dot_pos);
+  } while (!domain.empty());
+  return LoopReturn::Continue;
 }
 
 struct py_func_args {
@@ -601,6 +1120,8 @@ struct Function {
   static int clear(Function * self);
   static PyObject * get_extractor(Function * self);
   static PyObject * get_replacer(Function * self);
+  static PyObject * get_domain(Function * self);
+  static PyObject * get_default(Function * self);
 };
 
 
@@ -649,11 +1170,8 @@ py_ref Function::canonicalize_kwargs(PyObject * kwargs) {
 
 py_func_args Function::replace_dispatchables(
     PyObject * backend, PyObject * args, PyObject * kwargs, PyObject * coerce) {
-  auto ua_convert =
-      py_ref::steal(PyObject_GetAttr(backend, identifiers.ua_convert.get()));
-
-  if (!ua_convert) {
-    PyErr_Clear();
+  auto has_ua_convert = PyObject_HasAttr(backend, identifiers.ua_convert.get());
+  if (!has_ua_convert) {
     return {py_ref::ref(args), py_ref::ref(kwargs)};
   }
 
@@ -662,9 +1180,10 @@ py_func_args Function::replace_dispatchables(
   if (!dispatchables)
     return {};
 
-  auto convert_args = py_make_tuple(dispatchables, coerce);
-  auto res = py_ref::steal(
-      PyObject_Call(ua_convert.get(), convert_args.get(), nullptr));
+  PyObject * convert_args[] = {backend, dispatchables.get(), coerce};
+  auto res = py_ref::steal(Q_PyObject_VectorcallMethod(
+      identifiers.ua_convert.get(), convert_args,
+      array_size(convert_args) | Q_PY_VECTORCALL_ARGUMENTS_OFFSET, nullptr));
   if (!res) {
     return {};
   }
@@ -677,12 +1196,11 @@ py_func_args Function::replace_dispatchables(
   if (!replaced_args)
     return {};
 
-  auto replacer_args = py_make_tuple(args, kwargs, replaced_args);
-  if (!replacer_args)
-    return {};
-
-  res = py_ref::steal(
-      PyObject_Call(replacer_.get(), replacer_args.get(), nullptr));
+  PyObject * replacer_args[] = {nullptr, args, kwargs, replaced_args.get()};
+  res = py_ref::steal(Q_PyObject_Vectorcall(
+      replacer_.get(), &replacer_args[1],
+      (array_size(replacer_args) - 1) | Q_PY_VECTORCALL_ARGUMENTS_OFFSET,
+      nullptr));
   if (!res)
     return {};
 
@@ -765,18 +1283,11 @@ PyObject * Function::call(PyObject * args_, PyObject * kwargs_) {
         if (new_args.args == nullptr)
           return LoopReturn::Error;
 
-        auto ua_function = py_ref::steal(
-            PyObject_GetAttr(backend, identifiers.ua_function.get()));
-        if (!ua_function)
-          return LoopReturn::Error;
-
-        auto ua_func_args = py_make_tuple(
-            reinterpret_cast<PyObject *>(this), new_args.args, new_args.kwargs);
-        if (!ua_func_args)
-          return LoopReturn::Error;
-
-        result = py_ref::steal(
-            PyObject_Call(ua_function.get(), ua_func_args.get(), nullptr));
+        PyObject * args[] = {backend, reinterpret_cast<PyObject *>(this),
+                             new_args.args.get(), new_args.kwargs.get()};
+        result = py_ref::steal(Q_PyObject_VectorcallMethod(
+            identifiers.ua_function.get(), args,
+            array_size(args) | Q_PY_VECTORCALL_ARGUMENTS_OFFSET, nullptr));
 
         // raise BackendNotImplemeted is equivalent to return NotImplemented
         if (!result &&
@@ -826,10 +1337,15 @@ PyObject * Function::call(PyObject * args_, PyObject * kwargs_) {
         return LoopReturn::Break; // Backend called successfully
       });
 
-  if (ret != LoopReturn::Continue)
+  if (ret == LoopReturn::Error)
+    return nullptr;
+
+  if (result && result != Py_NotImplemented)
     return result.release();
 
-  if (def_impl_ != Py_None) {
+  // Last resort, try calling default implementation directly
+  // Only call if no backend was marked only or coerce
+  if (ret == LoopReturn::Continue && def_impl_ != Py_None) {
     result =
         py_ref::steal(PyObject_Call(def_impl_.get(), args.get(), kwargs.get()));
     if (!result) {
@@ -916,57 +1432,221 @@ PyObject * Function::get_replacer(Function * self) {
   return self->replacer_.get();
 }
 
+PyObject * Function::get_default(Function * self) {
+  Py_INCREF(self->def_impl_.get());
+  return self->def_impl_.get();
+}
 
-// getset takes mutable char * in Python < 3.7
+PyObject * Function::get_domain(Function * self) {
+  return PyUnicode_FromStringAndSize(
+      self->domain_key_.c_str(), self->domain_key_.size());
+}
+
+
+PyMethodDef BackendState_Methods[] = {
+    {"_pickle", (PyCFunction)BackendState::pickle_, METH_NOARGS, nullptr},
+    {"_unpickle", (PyCFunction)BackendState::unpickle_,
+     METH_VARARGS | METH_CLASS, nullptr},
+    {NULL} /* Sentinel */
+};
+
+PyTypeObject BackendStateType = {
+    PyVarObject_HEAD_INIT(NULL, 0)     /* boilerplate */
+    "uarray._BackendState",            /* tp_name */
+    sizeof(BackendState),              /* tp_basicsize */
+    0,                                 /* tp_itemsize */
+    (destructor)BackendState::dealloc, /* tp_dealloc */
+    0,                                 /* tp_print */
+    0,                                 /* tp_getattr */
+    0,                                 /* tp_setattr */
+    0,                                 /* tp_reserved */
+    0,                                 /* tp_repr */
+    0,                                 /* tp_as_number */
+    0,                                 /* tp_as_sequence */
+    0,                                 /* tp_as_mapping */
+    0,                                 /* tp_hash  */
+    0,                                 /* tp_call */
+    0,                                 /* tp_str */
+    0,                                 /* tp_getattro */
+    0,                                 /* tp_setattro */
+    0,                                 /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT,                /* tp_flags */
+    0,                                 /* tp_doc */
+    0,                                 /* tp_traverse */
+    0,                                 /* tp_clear */
+    0,                                 /* tp_richcompare */
+    0,                                 /* tp_weaklistoffset */
+    0,                                 /* tp_iter */
+    0,                                 /* tp_iternext */
+    BackendState_Methods,              /* tp_methods */
+    0,                                 /* tp_members */
+    0,                                 /* tp_getset */
+    0,                                 /* tp_base */
+    0,                                 /* tp_dict */
+    0,                                 /* tp_descr_get */
+    0,                                 /* tp_descr_set */
+    0,                                 /* tp_dictoffset */
+    0,                                 /* tp_init */
+    0,                                 /* tp_alloc */
+    BackendState::new_,                /* tp_new */
+};
+
+PyObject * get_state(PyObject * /* self */, PyObject * /* args */) {
+  py_ref ref = py_ref::steal(Q_PyObject_Vectorcall(
+      reinterpret_cast<PyObject *>(&BackendStateType), nullptr, 0, nullptr));
+  BackendState * output = reinterpret_cast<BackendState *>(ref.get());
+
+  output->locals = local_domain_map;
+  output->use_thread_local_globals =
+      (current_global_state != &global_domain_map);
+  output->globals = *current_global_state;
+
+  return ref.release();
+}
+
+PyObject * set_state(PyObject * /* self */, PyObject * args) {
+  PyObject * arg;
+  int reset_allowed = false;
+  if (!PyArg_ParseTuple(args, "O|p", &arg, &reset_allowed))
+    return nullptr;
+
+  if (!PyObject_IsInstance(
+          arg, reinterpret_cast<PyObject *>(&BackendStateType))) {
+    PyErr_SetString(
+        PyExc_TypeError, "state must be a uarray._BackendState object.");
+    return nullptr;
+  }
+
+  BackendState * state = reinterpret_cast<BackendState *>(arg);
+  local_domain_map = state->locals;
+  bool use_thread_local_globals =
+      (!reset_allowed) || state->use_thread_local_globals;
+  current_global_state =
+      use_thread_local_globals ? &thread_local_domain_map : &global_domain_map;
+
+  if (use_thread_local_globals)
+    thread_local_domain_map = state->globals;
+  else
+    thread_local_domain_map.clear();
+
+
+  Py_RETURN_NONE;
+}
+
+PyObject * determine_backend(PyObject * /*self*/, PyObject * args) {
+  PyObject *domain_object, *dispatchables;
+  int coerce;
+  if (!PyArg_ParseTuple(
+          args, "OOp:determine_backend", &domain_object, &dispatchables,
+          &coerce))
+    return nullptr;
+
+  auto domain = domain_to_string(domain_object);
+  if (domain.empty())
+    return nullptr;
+
+  auto dispatchables_tuple = py_ref::steal(PySequence_Tuple(dispatchables));
+  if (!dispatchables_tuple)
+    return nullptr;
+
+  py_ref selected_backend;
+  auto result = for_each_backend_in_domain(
+      domain, [&](PyObject * backend, bool coerce_backend) {
+        auto has_ua_convert =
+            PyObject_HasAttr(backend, identifiers.ua_convert.get());
+
+        if (!has_ua_convert) {
+          // If no __ua_convert__, assume it won't accept the type
+          return LoopReturn::Continue;
+        }
+
+        PyObject * convert_args[] = {backend, dispatchables_tuple.get(),
+                                     (coerce && coerce_backend) ? Py_True
+                                                                : Py_False};
+
+        auto res = py_ref::steal(Q_PyObject_VectorcallMethod(
+            identifiers.ua_convert.get(), convert_args,
+            array_size(convert_args) | Q_PY_VECTORCALL_ARGUMENTS_OFFSET,
+            nullptr));
+        if (!res) {
+          return LoopReturn::Error;
+        }
+
+        if (res == Py_NotImplemented) {
+          return LoopReturn::Continue;
+        }
+
+        // __ua_convert__ succeeded, so select this backend
+        selected_backend = py_ref::ref(backend);
+        return LoopReturn::Break;
+      });
+
+  if (result != LoopReturn::Continue)
+    return selected_backend.release();
+
+  // All backends failed, raise an error
+  PyErr_SetString(
+      BackendNotImplementedError.get(),
+      "No backends could accept input of this type.");
+  return nullptr;
+}
+
+
+// getset takes mutable char * in python < 3.7
 static char dict__[] = "__dict__";
 static char arg_extractor[] = "arg_extractor";
 static char arg_replacer[] = "arg_replacer";
+static char default_[] = "default";
+static char domain[] = "domain";
 PyGetSetDef Function_getset[] = {
     {dict__, PyObject_GenericGetDict, PyObject_GenericSetDict},
     {arg_extractor, (getter)Function::get_extractor, NULL},
     {arg_replacer, (getter)Function::get_replacer, NULL},
+    {default_, (getter)Function::get_default, NULL},
+    {domain, (getter)Function::get_domain, NULL},
     {NULL} /* Sentinel */
 };
 
 PyTypeObject FunctionType = {
-    PyVarObject_HEAD_INIT(NULL, 0)             /* boilerplate */
-    "uarray._Function",                        /* tp_name */
-    sizeof(Function),                          /* tp_basicsize */
-    0,                                         /* tp_itemsize */
-    (destructor)Function::dealloc,             /* tp_dealloc */
-    0,                                         /* tp_print */
-    0,                                         /* tp_getattr */
-    0,                                         /* tp_setattr */
-    0,                                         /* tp_reserved */
-    (reprfunc)Function::repr,                  /* tp_repr */
-    0,                                         /* tp_as_number */
-    0,                                         /* tp_as_sequence */
-    0,                                         /* tp_as_mapping */
-    0,                                         /* tp_hash  */
-    (ternaryfunc)Function_call,                /* tp_call */
-    0,                                         /* tp_str */
-    PyObject_GenericGetAttr,                   /* tp_getattro */
-    PyObject_GenericSetAttr,                   /* tp_setattro */
-    0,                                         /* tp_as_buffer */
-    (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC), /* tp_flags */
-    0,                                         /* tp_doc */
-    (traverseproc)Function::traverse,          /* tp_traverse */
-    (inquiry)Function::clear,                  /* tp_clear */
-    0,                                         /* tp_richcompare */
-    0,                                         /* tp_weaklistoffset */
-    0,                                         /* tp_iter */
-    0,                                         /* tp_iternext */
-    0,                                         /* tp_methods */
-    0,                                         /* tp_members */
-    Function_getset,                           /* tp_getset */
-    0,                                         /* tp_base */
-    0,                                         /* tp_dict */
-    Function::descr_get,                       /* tp_descr_get */
-    0,                                         /* tp_descr_set */
-    offsetof(Function, dict_),                 /* tp_dictoffset */
-    (initproc)Function::init,                  /* tp_init */
-    0,                                         /* tp_alloc */
-    Function::new_,                            /* tp_new */
+    PyVarObject_HEAD_INIT(NULL, 0) /* boilerplate */
+    /* tp_name= */ "uarray._Function",
+    /* tp_basicsize= */ sizeof(Function),
+    /* tp_itemsize= */ 0,
+    /* tp_dealloc= */ (destructor)Function::dealloc,
+    /* tp_print= */ 0,
+    /* tp_getattr= */ 0,
+    /* tp_setattr= */ 0,
+    /* tp_reserved= */ 0,
+    /* tp_repr= */ (reprfunc)Function::repr,
+    /* tp_as_number= */ 0,
+    /* tp_as_sequence= */ 0,
+    /* tp_as_mapping= */ 0,
+    /* tp_hash= */ 0,
+    /* tp_call= */ (ternaryfunc)Function_call,
+    /* tp_str= */ 0,
+    /* tp_getattro= */ PyObject_GenericGetAttr,
+    /* tp_setattro= */ PyObject_GenericSetAttr,
+    /* tp_as_buffer= */ 0,
+    /* tp_flags= */
+    (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Q_Py_TPFLAGS_METHOD_DESCRIPTOR),
+    /* tp_doc= */ 0,
+    /* tp_traverse= */ (traverseproc)Function::traverse,
+    /* tp_clear= */ (inquiry)Function::clear,
+    /* tp_richcompare= */ 0,
+    /* tp_weaklistoffset= */ 0,
+    /* tp_iter= */ 0,
+    /* tp_iternext= */ 0,
+    /* tp_methods= */ 0,
+    /* tp_members= */ 0,
+    /* tp_getset= */ Function_getset,
+    /* tp_base= */ 0,
+    /* tp_dict= */ 0,
+    /* tp_descr_get= */ Function::descr_get,
+    /* tp_descr_set= */ 0,
+    /* tp_dictoffset= */ offsetof(Function, dict_),
+    /* tp_init= */ (initproc)Function::init,
+    /* tp_alloc= */ 0,
+    /* tp_new= */ Function::new_,
 };
 
 
@@ -974,6 +1654,7 @@ PyMethodDef SetBackendContext_Methods[] = {
     {"__enter__", (PyCFunction)SetBackendContext::enter__, METH_NOARGS,
      nullptr},
     {"__exit__", (PyCFunction)SetBackendContext::exit__, METH_VARARGS, nullptr},
+    {"_pickle", (PyCFunction)SetBackendContext::pickle_, METH_NOARGS, nullptr},
     {NULL} /* Sentinel */
 };
 
@@ -997,7 +1678,7 @@ PyTypeObject SetBackendContextType = {
     0,                                         /* tp_getattro */
     0,                                         /* tp_setattro */
     0,                                         /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,                        /* tp_flags */
+    (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC), /* tp_flags */
     0,                                         /* tp_doc */
     (traverseproc)SetBackendContext::traverse, /* tp_traverse */
     0,                                         /* tp_clear */
@@ -1024,6 +1705,7 @@ PyMethodDef SkipBackendContext_Methods[] = {
      nullptr},
     {"__exit__", (PyCFunction)SkipBackendContext::exit__, METH_VARARGS,
      nullptr},
+    {"_pickle", (PyCFunction)SkipBackendContext::pickle_, METH_NOARGS, nullptr},
     {NULL} /* Sentinel */
 };
 
@@ -1047,7 +1729,7 @@ PyTypeObject SkipBackendContextType = {
     0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,                         /* tp_flags */
+    (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC),  /* tp_flags */
     0,                                          /* tp_doc */
     (traverseproc)SkipBackendContext::traverse, /* tp_traverse */
     0,                                          /* tp_clear */
@@ -1072,14 +1754,22 @@ PyTypeObject SkipBackendContextType = {
 PyMethodDef method_defs[] = {
     {"set_global_backend", set_global_backend, METH_VARARGS, nullptr},
     {"register_backend", register_backend, METH_VARARGS, nullptr},
-    {"clear_all_globals", clear_all_globals, METH_NOARGS, nullptr},
     {"clear_backends", clear_backends, METH_VARARGS, nullptr},
+    {"determine_backend", determine_backend, METH_VARARGS, nullptr},
+    {"get_state", get_state, METH_NOARGS, nullptr},
+    {"set_state", set_state, METH_VARARGS, nullptr},
     {NULL} /* Sentinel */
 };
 
-PyModuleDef uarray_module = {
-    PyModuleDef_HEAD_INIT, "_uarray", nullptr, -1, method_defs,
-};
+PyModuleDef uarray_module = {PyModuleDef_HEAD_INIT,
+                             /* m_name= */ "uarray._uarray",
+                             /* m_doc= */ nullptr,
+                             /* m_size= */ -1,
+                             /* m_methods= */ method_defs,
+                             /* m_slots= */ nullptr,
+                             /* m_traverse= */ globals_traverse,
+                             /* m_clear= */ globals_clear,
+                             /* m_free= */ globals_free};
 
 } // namespace
 
@@ -1111,6 +1801,11 @@ extern "C" MODULE_EXPORT PyObject * PyInit__uarray(void) {
   Py_INCREF(&SkipBackendContextType);
   PyModule_AddObject(
       m.get(), "_SkipBackendContext", (PyObject *)&SkipBackendContextType);
+
+  if (PyType_Ready(&BackendStateType) < 0)
+    return nullptr;
+  Py_INCREF(&BackendStateType);
+  PyModule_AddObject(m.get(), "_BackendState", (PyObject *)&BackendStateType);
 
   BackendNotImplementedError = py_ref::steal(PyErr_NewExceptionWithDoc(
       "uarray.BackendNotImplementedError",

--- a/scipy/_lib/_uarray/scipychanges.patch
+++ b/scipy/_lib/_uarray/scipychanges.patch
@@ -1,13 +1,13 @@
 diff --git a/scipy/_lib/_uarray/__init__.py b/scipy/_lib/_uarray/__init__.py
-index b455bb8ad..b84928a24 100644
+index b3c395d0a..f837b0e9b 100644
 --- a/scipy/_lib/_uarray/__init__.py
 +++ b/scipy/_lib/_uarray/__init__.py
-@@ -112,7 +112,5 @@ possible.
+@@ -113,7 +113,5 @@ possible.
  """
-
+ 
  from ._backend import *
--from ._version import get_versions  # type: ignore
-
+-from ._version import get_versions
+ 
 -__version__ = get_versions()["version"]
 -del get_versions
-+__version__ = '0.5.1+49.g4c3f1d7.scipy'
++__version__ = '0.8.2+14.gaf53966.scipy'

--- a/scipy/_lib/_uarray/setup.py
+++ b/scipy/_lib/_uarray/setup.py
@@ -20,7 +20,7 @@ def configuration(parent_package='', top_path=None):
     config.add_data_files('LICENSE')
     ext = config.add_extension('_uarray',
                                sources=['_uarray_dispatch.cxx', 'vectorcall.cxx'],
-                               depends=['small_dynamic_array.h', 'vectorcall.h']
+                               depends=['small_dynamic_array.h', 'vectorcall.h'],
                                language='c++')
     ext._pre_build_hook = pre_build_hook
     return config

--- a/scipy/_lib/_uarray/setup.py
+++ b/scipy/_lib/_uarray/setup.py
@@ -19,7 +19,8 @@ def configuration(parent_package='', top_path=None):
     config = Configuration('_uarray', parent_package, top_path)
     config.add_data_files('LICENSE')
     ext = config.add_extension('_uarray',
-                               sources=['_uarray_dispatch.cxx'],
+                               sources=['_uarray_dispatch.cxx', 'vectorcall.cxx'],
+                               depends=['small_dynamic_array.h', 'vectorcall.h']
                                language='c++')
     ext._pre_build_hook = pre_build_hook
     return config

--- a/scipy/_lib/_uarray/small_dynamic_array.h
+++ b/scipy/_lib/_uarray/small_dynamic_array.h
@@ -222,7 +222,7 @@ public:
   }
 
   reference operator[](size_type idx) {
-    assert(0 < idx && idx < size);
+    assert(0 < idx && idx < size_);
     return begin()[idx];
   }
 };

--- a/scipy/_lib/_uarray/small_dynamic_array.h
+++ b/scipy/_lib/_uarray/small_dynamic_array.h
@@ -1,0 +1,228 @@
+#pragma once
+#include <cassert>
+#include <cstddef>
+#include <cstdlib>
+#include <memory>
+#include <new>
+#include <type_traits>
+
+
+/** Fixed size dynamic array with small buffer optimisation */
+template <typename T, ptrdiff_t SmallCapacity = 1>
+class SmallDynamicArray {
+  ptrdiff_t size_;
+  union {
+    T elements[SmallCapacity];
+    T * array;
+  } storage_;
+
+  bool is_small() const { return size_ <= SmallCapacity; }
+
+  void destroy_buffer(T * first, T * last) noexcept {
+    for (; first < last; ++first) {
+      first->~T();
+    }
+  }
+
+  void default_construct_buffer(T * first, T * last) noexcept(
+      std::is_nothrow_destructible<T>::value) {
+    auto cur = first;
+    try {
+      for (; cur < last; ++cur) {
+        new (cur) T(); // Placement new
+      }
+    } catch (...) {
+      // If construction failed, destroy already constructed values
+      destroy_buffer(first, cur);
+      throw;
+    }
+  }
+
+  void move_construct_buffer(T * first, T * last, T * d_first) noexcept(
+      std::is_nothrow_move_constructible<T>::value) {
+    T * d_cur = d_first;
+
+    try {
+      for (; first < last; ++first, ++d_cur) {
+        new (d_cur) T(std::move(*first)); // Placement new
+      }
+    } catch (...) {
+      destroy_buffer(d_first, d_cur);
+      throw;
+    }
+  }
+
+  void allocate() {
+    assert(size_ >= 0);
+    if (is_small())
+      return;
+
+    storage_.array = (T *)malloc(size_ * sizeof(T));
+    if (!storage_.array) {
+      throw std::bad_alloc();
+    }
+  }
+
+  void deallocate() noexcept {
+    if (!is_small()) {
+      free(storage_.array);
+    }
+  }
+
+public:
+  using value_type = T;
+  using iterator = value_type *;
+  using const_iterator = const value_type *;
+  using reference = value_type &;
+  using const_reference = const value_type &;
+  using size_type = ptrdiff_t;
+
+  SmallDynamicArray(): size_(0) {}
+
+  explicit SmallDynamicArray(size_t size): size_(size) {
+    allocate();
+    auto first = begin();
+    try {
+      default_construct_buffer(first, first + size_);
+    } catch (...) {
+      deallocate();
+      throw;
+    }
+  }
+
+  SmallDynamicArray(size_type size, const T & fill_value): size_(size) {
+    allocate();
+    try {
+      std::uninitialized_fill_n(begin(), size_, fill_value);
+    } catch (...) {
+      deallocate();
+      throw;
+    }
+  }
+
+  SmallDynamicArray(const SmallDynamicArray & copy): size_(copy.size_) {
+    allocate();
+    try {
+      std::uninitialized_copy_n(copy.begin(), size_, begin());
+    } catch (...) {
+      deallocate();
+      throw;
+    }
+  }
+
+  SmallDynamicArray(SmallDynamicArray && move) noexcept(
+      std::is_nothrow_move_constructible<T>::value)
+      : size_(move.size_) {
+    if (!move.is_small()) {
+      storage_.array = move.storage_.array;
+      move.storage_.array = nullptr;
+      move.storage_.size = 0;
+      return;
+    }
+
+    auto m_first = move.begin();
+    try {
+      move_construct_buffer(m_first, m_first + size_, begin());
+    } catch (...) {
+      destroy_buffer(m_first, m_first + size_);
+      move.size_ = 0;
+      size_ = 0;
+      throw;
+    }
+
+    destroy_buffer(&move.storage_.elements[0], &move.storage_.elements[size_]);
+    move.size_ = 0;
+  }
+
+  ~SmallDynamicArray() { clear(); }
+
+  SmallDynamicArray & operator=(const SmallDynamicArray & copy) {
+    if (&copy == this)
+      return *this;
+
+    clear();
+
+    size_ = copy.size;
+    try {
+      allocate();
+    } catch (...) {
+      size_ = 0;
+      throw;
+    }
+
+    try {
+      std::uninitialized_copy_n(copy.begin(), size_, begin());
+    } catch (...) {
+      deallocate();
+      size_ = 0;
+      throw;
+    }
+    return *this;
+  }
+
+  SmallDynamicArray & operator=(SmallDynamicArray && move) noexcept(
+      std::is_nothrow_move_constructible<T>::value) {
+    if (&move == this)
+      return *this;
+
+    if (!move.is_small()) {
+      storage_.array = move.storage_.array;
+      size_ = move.size_;
+      move.storage_.array = nullptr;
+      move.size_ = 0;
+      return *this;
+    }
+
+    clear();
+
+    size_ = move.size_;
+    auto m_first = move.begin();
+    try {
+      move_construct_buffer(m_first, m_first + size_, begin());
+    } catch (...) {
+      destroy_buffer(m_first, m_first + size_);
+      move.size_ = 0;
+      size_ = 0;
+      throw;
+    }
+
+    destroy_buffer(m_first, m_first + size_);
+    move.size_ = 0;
+    return *this;
+  }
+
+  void clear() noexcept(std::is_nothrow_destructible<T>::value) {
+    auto first = begin();
+    destroy_buffer(first, first + size_);
+    deallocate();
+    size_ = 0;
+  }
+
+  iterator begin() {
+    return is_small() ? &storage_.elements[0] : storage_.array;
+  }
+
+  const_iterator cbegin() const {
+    return is_small() ? &storage_.elements[0] : storage_.array;
+  }
+
+  iterator end() { return begin() + size_; }
+
+  const_iterator cend() const { return cbegin() + size_; }
+
+  const_iterator begin() const { return cbegin(); }
+
+  const_iterator end() const { return cend(); }
+
+  size_type size() const { return size_; }
+
+  const_reference operator[](size_type idx) const {
+    assert(0 < idx && idx < size_);
+    return begin()[idx];
+  }
+
+  reference operator[](size_type idx) {
+    assert(0 < idx && idx < size);
+    return begin()[idx];
+  }
+};

--- a/scipy/_lib/_uarray/small_dynamic_array.h
+++ b/scipy/_lib/_uarray/small_dynamic_array.h
@@ -217,12 +217,12 @@ public:
   size_type size() const { return size_; }
 
   const_reference operator[](size_type idx) const {
-    assert(0 < idx && idx < size_);
+    assert(0 <= idx && idx < size_);
     return begin()[idx];
   }
 
   reference operator[](size_type idx) {
-    assert(0 < idx && idx < size_);
+    assert(0 <= idx && idx < size_);
     return begin()[idx];
   }
 };

--- a/scipy/_lib/_uarray/vectorcall.cxx
+++ b/scipy/_lib/_uarray/vectorcall.cxx
@@ -1,0 +1,235 @@
+#include "vectorcall.h"
+
+#ifdef PYPY_VERSION
+
+/* PyPy doesn't have any support for Vectorcall/FastCall.
+ * These helpers are for translating to PyObject_Call. */
+
+static PyObject * build_arg_tuple(PyObject * const * args, Py_ssize_t nargs) {
+  PyObject * tuple = PyTuple_New(nargs);
+  if (!tuple) {
+    return NULL;
+  }
+
+  for (Py_ssize_t i = 0; i < nargs; ++i) {
+    Py_INCREF(args[i]); /* SET_ITEM steals a reference */
+    PyTuple_SET_ITEM(tuple, i, args[i]);
+  }
+  return tuple;
+}
+
+static PyObject * build_kwarg_dict(
+    PyObject * const * args, PyObject * names, Py_ssize_t nargs) {
+  PyObject * dict = PyDict_New();
+  if (!dict) {
+    return NULL;
+  }
+
+  for (Py_ssize_t i = 0; i < nargs; ++i) {
+    PyObject * key = PyTuple_GET_ITEM(names, i);
+    int success = PyDict_SetItem(dict, key, args[i]);
+    if (success == -1) {
+      Py_DECREF(dict);
+      return NULL;
+    }
+  }
+  return dict;
+}
+#elif (PY_VERSION_HEX < 0x03090000)
+// clang-format off
+
+static int is_method_descr(PyTypeObject* descr_tp) {
+    return (
+        (descr_tp->tp_flags & Q_Py_TPFLAGS_METHOD_DESCRIPTOR) != 0 ||
+        (descr_tp == &PyFunction_Type) ||
+        (descr_tp == &PyMethodDescr_Type));
+}
+
+/* The below code is derivative of CPython source, and is taken because
+_PyObject_GetMethod is not exported from shared objects.
+
+Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
+2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021 Python Software Foundation;
+All Rights Reserved
+*/
+
+/* Specialized version of _PyObject_GenericGetAttrWithDict
+   specifically for the LOAD_METHOD opcode.
+
+   Return 1 if a method is found, 0 if it's a regular attribute
+   from __dict__ or something returned by using a descriptor
+   protocol.
+
+   `method` will point to the resolved attribute or NULL.  In the
+   latter case, an error will be set.
+*/
+static int _PyObject_GetMethod(PyObject *obj, PyObject *name, PyObject **method)
+{
+    PyTypeObject *tp = Py_TYPE(obj);
+    PyObject *descr;
+    descrgetfunc f = NULL;
+    PyObject **dictptr, *dict;
+    PyObject *attr;
+    int meth_found = 0;
+
+    assert(*method == NULL);
+
+    if (Py_TYPE(obj)->tp_getattro != PyObject_GenericGetAttr
+            || !PyUnicode_Check(name)) {
+        *method = PyObject_GetAttr(obj, name);
+        return 0;
+    }
+
+    if (tp->tp_dict == NULL && PyType_Ready(tp) < 0)
+        return 0;
+
+    descr = _PyType_Lookup(tp, name);
+    if (descr != NULL) {
+        Py_INCREF(descr);
+        if (is_method_descr(Py_TYPE(descr))) {
+            meth_found = 1;
+        } else {
+            f = Py_TYPE(descr)->tp_descr_get;
+            if (f != NULL && PyDescr_IsData(descr)) {
+                *method = f(descr, obj, (PyObject *)Py_TYPE(obj));
+                Py_DECREF(descr);
+                return 0;
+            }
+        }
+    }
+
+    dictptr = _PyObject_GetDictPtr(obj);
+    if (dictptr != NULL && (dict = *dictptr) != NULL) {
+        Py_INCREF(dict);
+        attr = PyDict_GetItemWithError(dict, name);
+        if (attr != NULL) {
+            Py_INCREF(attr);
+            *method = attr;
+            Py_DECREF(dict);
+            Py_XDECREF(descr);
+            return 0;
+        }
+        else {
+            Py_DECREF(dict);
+            if (PyErr_Occurred()) {
+                Py_XDECREF(descr);
+                return 0;
+            }
+        }
+    }
+
+    if (meth_found) {
+        *method = descr;
+        return 1;
+    }
+
+    if (f != NULL) {
+        *method = f(descr, obj, (PyObject *)Py_TYPE(obj));
+        Py_DECREF(descr);
+        return 0;
+    }
+
+    if (descr != NULL) {
+        *method = descr;
+        return 0;
+    }
+
+    PyErr_Format(PyExc_AttributeError,
+                 "'%.50s' object has no attribute '%U'",
+                 tp->tp_name, name);
+    return 0;
+}
+
+// clang-format on
+#endif /* PYPY_VERSION */
+
+
+Py_ssize_t Q_PyVectorcall_NARGS(size_t n) {
+  return n & (~Q_PY_VECTORCALL_ARGUMENTS_OFFSET);
+}
+
+PyObject * Q_PyObject_Vectorcall(
+    PyObject * callable, PyObject * const * args, size_t nargsf,
+    PyObject * kwnames) {
+#ifdef PYPY_VERSION
+  PyObject * dict = NULL;
+  Py_ssize_t nargs = Q_PyVectorcall_NARGS(nargsf);
+  if (kwnames) {
+    Py_ssize_t nkwargs = PyTuple_GET_SIZE(kwnames);
+    dict = build_kwarg_dict(&args[nargs - nkwargs], kwnames, nkwargs);
+    if (!dict) {
+      return NULL;
+    }
+    nargs -= nkwargs;
+  }
+  PyObject * ret = Q_PyObject_VectorcallDict(callable, args, nargs, dict);
+  Py_XDECREF(dict);
+  return ret;
+#elif (PY_VERSION_HEX >= 0x03090000)
+  return PyObject_Vectorcall(callable, args, nargsf, kwnames);
+#elif (PY_VERSION_HEX >= 0x03080000)
+  return _PyObject_Vectorcall(callable, args, nargsf, kwnames);
+#else
+  Py_ssize_t nargs = Q_PyVectorcall_NARGS(nargsf);
+  return _PyObject_FastCallKeywords(
+      callable, (PyObject **)args, nargs, kwnames);
+#endif
+}
+
+PyObject * Q_PyObject_VectorcallDict(
+    PyObject * callable, PyObject * const * args, size_t nargsf,
+    PyObject * kwdict) {
+#ifdef PYPY_VERSION
+  Py_ssize_t nargs = Q_PyVectorcall_NARGS(nargsf);
+  PyObject * tuple = build_arg_tuple(args, nargs);
+  if (!tuple) {
+    return NULL;
+  }
+  PyObject * ret = PyObject_Call(callable, tuple, kwdict);
+  Py_DECREF(tuple);
+  return ret;
+#elif (PY_VERSION_HEX >= 0x03090000)
+  return PyObject_VectorcallDict(callable, args, nargsf, kwdict);
+#else
+  Py_ssize_t nargs = Q_PyVectorcall_NARGS(nargsf);
+  return _PyObject_FastCallDict(callable, (PyObject **)args, nargs, kwdict);
+#endif
+}
+
+PyObject * Q_PyObject_VectorcallMethod(
+    PyObject * name, PyObject * const * args, size_t nargsf,
+    PyObject * kwnames) {
+#ifdef PYPY_VERSION
+  PyObject * callable = PyObject_GetAttr(args[0], name);
+  if (!callable) {
+    return NULL;
+  }
+  PyObject * result =
+      Q_PyObject_Vectorcall(callable, &args[1], nargsf - 1, kwnames);
+  Py_DECREF(callable);
+  return result;
+#elif (PY_VERSION_HEX >= 0x03090000)
+  return PyObject_VectorcallMethod(name, args, nargsf, kwnames);
+#else
+  /* Private CPython code for CALL_METHOD opcode */
+  PyObject * callable = NULL;
+  int unbound = _PyObject_GetMethod(args[0], name, &callable);
+  if (callable == NULL) {
+    return NULL;
+  }
+
+  if (unbound) {
+    /* We must remove PY_VECTORCALL_ARGUMENTS_OFFSET since
+     * that would be interpreted as allowing to change args[-1] */
+    nargsf &= ~Q_PY_VECTORCALL_ARGUMENTS_OFFSET;
+  } else {
+    /* Skip "self". We can keep PY_VECTORCALL_ARGUMENTS_OFFSET since
+     * args[-1] in the onward call is args[0] here. */
+    args++;
+    nargsf--;
+  }
+  PyObject * result = Q_PyObject_Vectorcall(callable, args, nargsf, kwnames);
+  Py_DECREF(callable);
+  return result;
+#endif
+}

--- a/scipy/_lib/_uarray/vectorcall.h
+++ b/scipy/_lib/_uarray/vectorcall.h
@@ -1,0 +1,48 @@
+#pragma once
+#include <Python.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// True if python supports vectorcall on custom classes
+#define Q_HAS_VECTORCALL                                                       \
+  (!defined(PYPY_VERSION) && (PY_VERSION_HEX >= 0x03080000))
+
+#if !Q_HAS_VECTORCALL
+#  define Q_Py_TPFLAGS_HAVE_VECTORCALL 0
+#elif (PY_VERSION_HEX >= 0x03090000)
+#  define Q_Py_TPFLAGS_HAVE_VECTORCALL Py_TPFLAGS_HAVE_VECTORCALL
+#else
+#  define Q_Py_TPFLAGS_HAVE_VECTORCALL _Py_TPFLAGS_HAVE_VECTORCALL
+#endif
+
+#if !Q_HAS_VECTORCALL
+#  define Q_Py_TPFLAGS_METHOD_DESCRIPTOR 0
+#else
+#  define Q_Py_TPFLAGS_METHOD_DESCRIPTOR Py_TPFLAGS_METHOD_DESCRIPTOR
+#endif
+
+#if !Q_HAS_VECTORCALL
+#  define Q_PY_VECTORCALL_ARGUMENTS_OFFSET                                     \
+    ((size_t)1 << (8 * sizeof(size_t) - 1))
+#else
+#  define Q_PY_VECTORCALL_ARGUMENTS_OFFSET PY_VECTORCALL_ARGUMENTS_OFFSET
+#endif
+
+
+Py_ssize_t Q_PyVectorcall_NARGS(size_t n);
+
+PyObject * Q_PyObject_Vectorcall(
+    PyObject * callable, PyObject * const * args, size_t nargsf,
+    PyObject * kwnames);
+PyObject * Q_PyObject_VectorcallDict(
+    PyObject * callable, PyObject * const * args, size_t nargsf,
+    PyObject * kwdict);
+PyObject * Q_PyObject_VectorcallMethod(
+    PyObject * name, PyObject * const * args, size_t nargsf, PyObject * kwdict);
+
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/scipy/_lib/uarray.py
+++ b/scipy/_lib/uarray.py
@@ -16,7 +16,7 @@ except ImportError:
 else:
     from scipy._lib._pep440 import Version as _Version
 
-    _has_uarray = _Version(_uarray.__version__) >= _Version("0.5")
+    _has_uarray = _Version(_uarray.__version__) >= _Version("0.8")
     del _uarray
     del _Version
 


### PR DESCRIPTION
#### Reference issue
See #14266 

#### What does this implement/fix?

> 1. We need to update the vendored version of uarray used in SciPy. This is because the current uarray vendored version in SciPy doesn't support options like try_last=True which got added later in uarray #236.

The vendor uarray lib needed an update regardless of points 2 and 3 in the solution for #14266. It has now been almost two years since the last update was made. 

#### Additional information
This will also later enable us to help with automatically setting the global backend on import of the library if the discussion in #14266 is in favour of the proposal.

**Edit**: We also need to update the fft module [`fft._backend.py`](https://github.com/scipy/scipy/blob/master/scipy/fft/_backend.py) once this is good to go. I'll send a subsequent PR for that.

Looking forward to the feedback/review. Please let me know in case there is something I might have done wrong so that I can make the required changes.