### PR TITLE
MAINT: two small fixes for implicit scalar-array-conversions

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -6655,7 +6655,7 @@ class pearson3_gen(rv_continuous):
         # close to this small.
         norm2pearson_transition = 0.000016
 
-        ans, x, skew = np.broadcast_arrays([1.0], x, skew)
+        ans, x, skew = np.broadcast_arrays(1.0, x, skew)
         ans = ans.copy()
 
         # mask is True where skew is small enough to use the normal approx.

--- a/scipy/stats/mstats_extras.py
+++ b/scipy/stats/mstats_extras.py
@@ -161,14 +161,15 @@ def hdquantiles_sd(data, prob=list([.25,.5,.75]), axis=None):
 
         vv = np.arange(n) / float(n-1)
         betacdf = beta.cdf
-        
+
         for (i,p) in enumerate(prob):
             _w = betacdf(vv, (n+1)*p, (n+1)*(1-p))
             w = _w[1:] - _w[:-1]
             mx_ = np.fromiter([w[:k] @ xsorted[:k] + w[k:] @ xsorted[k+1:]
                                for k in range(n)], dtype=float_)
-            mx_var = np.array(mx_.var(), copy=False, ndmin=1) * n / float(n-1)
-            hdsd[i] = float(n-1) * np.sqrt(np.diag(mx_var).diagonal() / float(n))
+            # mx_var = np.array(mx_.var(), copy=False, ndmin=1) * n / (n - 1)
+            # hdsd[i] = (n - 1) * np.sqrt(mx_var / n)
+            hdsd[i] = np.sqrt(mx_.var() * (n - 1))
         return hdsd
 
     # Initialization & checks


### PR DESCRIPTION
Last bit of #13864. Two small clean-ups.