### PR TITLE
ENH: Annotate the array dtypes of `scipy.spatial.qhull`

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -2,6 +2,7 @@
 warn_redundant_casts = True
 warn_unused_ignores = True
 show_error_codes = True
+plugins = numpy.typing.mypy_plugin
 
 #
 # Typing tests is low priority, but enabling type checking on the

--- a/mypy.ini
+++ b/mypy.ini
@@ -509,9 +509,6 @@ ignore_errors = True
 [mypy-scipy.spatial.tests.test_kdtree]
 ignore_errors = True
 
-[mypy-scipy.spatial.tests.test_qhull]
-ignore_errors = True
-
 [mypy-scipy.integrate._ivp.bdf]
 ignore_errors = True
 

--- a/scipy/spatial/qhull.pyi
+++ b/scipy/spatial/qhull.pyi
@@ -125,6 +125,8 @@ class ConvexHull(_QhullUser):
     equations: np.ndarray
     coplanar: np.ndarray
     good: None | np.ndarray
+    volume: float
+    area: float
     nsimplex: int
 
     def __init__(

--- a/scipy/spatial/qhull.pyi
+++ b/scipy/spatial/qhull.pyi
@@ -5,7 +5,7 @@ Static type checking stub file for scipy/spatial/qhull.pyx
 from typing import List, Tuple, Any, Dict
 
 import numpy as np
-from numpy.typing import ArrayLike
+from numpy.typing import ArrayLike, NDArray
 from typing_extensions import final
 
 @final
@@ -20,16 +20,16 @@ class _Qhull:
     def __init__(
         self,
         mode_option: bytes,
-        points: np.ndarray,
+        points: NDArray[np.float64],
         options: None | bytes = ...,
         required_options: None | bytes = ...,
         furthest_site: bool = ...,
         incremental: bool = ...,
-        interior_point: None | np.ndarray = ...,
+        interior_point: None | NDArray[np.float64] = ...,
     ) -> None: ...
     def check_active(self) -> None: ...
     def close(self) -> None: ...
-    def get_points(self) -> np.ndarray: ...
+    def get_points(self) -> NDArray[np.float64]: ...
     def add_points(
         self,
         points: ArrayLike,
@@ -38,29 +38,38 @@ class _Qhull:
     def get_paraboloid_shift_scale(self) -> Tuple[float, float]: ...
     def volume_area(self) -> Tuple[float, float]: ...
     def triangulate(self) -> None: ...
-    def get_simplex_facet_array(self): ...
-    def get_hull_points(self) -> np.ndarray: ...
-    def get_hull_facets(self) -> Tuple[List[List[int]], np.ndarray]: ...
-    def get_voronoi_diagram(self) -> Tuple[
-        np.ndarray,
-        np.ndarray,
-        List[List[int]],
-        List[List[int]],
-        np.ndarray,
+    def get_simplex_facet_array(self) -> Tuple[
+        NDArray[np.intc],
+        NDArray[np.intc],
+        NDArray[np.float64],
+        NDArray[np.intc],
+        NDArray[np.intc],
     ]: ...
-    def get_extremes_2d(self) -> np.ndarray: ...
+    def get_hull_points(self) -> NDArray[np.float64]: ...
+    def get_hull_facets(self) -> Tuple[
+        List[List[int]],
+        NDArray[np.float64],
+    ]: ...
+    def get_voronoi_diagram(self) -> Tuple[
+        NDArray[np.float64],
+        NDArray[np.intc],
+        List[List[int]],
+        List[List[int]],
+        NDArray[np.intp],
+    ]: ...
+    def get_extremes_2d(self) -> NDArray[np.intc]: ...
 
 def _get_barycentric_transforms(
-    points: np.ndarray,
-    simplices: np.ndarray,
+    points: NDArray[np.float64],
+    simplices: NDArray[np.int_],
     eps: float
-) -> np.ndarray: ...
+) -> NDArray[np.float64]: ...
 
 class _QhullUser:
     ndim: int
     npoints: int
-    min_bound: np.ndarray
-    max_bound: np.ndarray
+    min_bound: NDArray[np.float64]
+    max_bound: NDArray[np.float64]
 
     def __init__(self, qhull: _Qhull, incremental: bool = ...) -> None: ...
     def close(self) -> None: ...
@@ -76,13 +85,13 @@ class Delaunay(_QhullUser):
     furthest_site: bool
     paraboloid_scale: float
     paraboloid_shift: float
-    simplices: np.ndarray
-    neighbors: np.ndarray
-    equations: np.ndarray
-    coplanar: np.ndarray
-    good: np.ndarray
+    simplices: NDArray[np.intc]
+    neighbors: NDArray[np.intc]
+    equations: NDArray[np.float64]
+    coplanar: NDArray[np.intc]
+    good: NDArray[np.intc]
     nsimplex: int
-    vertices: np.ndarray
+    vertices: NDArray[np.intc]
 
     def __init__(
         self,
@@ -98,33 +107,36 @@ class Delaunay(_QhullUser):
         restart: bool = ...
     ) -> None: ...
     @property
-    def points(self) -> np.ndarray: ...
+    def points(self) -> NDArray[np.float64]: ...
     @property
-    def transform(self) -> np.ndarray: ...
+    def transform(self) -> NDArray[np.float64]: ...
     @property
-    def vertex_to_simplex(self) -> np.ndarray: ...
+    def vertex_to_simplex(self) -> NDArray[np.intc]: ...
     @property
-    def vertex_neighbor_vertices(self) -> Tuple[np.ndarray, np.ndarray]: ...
+    def vertex_neighbor_vertices(self) -> Tuple[
+        NDArray[np.intc],
+        NDArray[np.intc],
+    ]: ...
     @property
-    def convex_hull(self) -> np.ndarray: ...
+    def convex_hull(self) -> NDArray[np.intc]: ...
     def find_simplex(
         self,
         xi: ArrayLike,
         bruteforce: bool = ...,
         tol: float = ...
-    ) -> np.ndarray: ...
-    def plane_distance(self, xi: ArrayLike) -> np.ndarray: ...
-    def lift_points(self, x: ArrayLike) -> np.ndarray: ...
+    ) -> NDArray[np.intc]: ...
+    def plane_distance(self, xi: ArrayLike) -> NDArray[np.float64]: ...
+    def lift_points(self, x: ArrayLike) -> NDArray[np.float64]: ...
 
-def tsearch(tri: Delaunay, xi: ArrayLike) -> np.ndarray: ...
+def tsearch(tri: Delaunay, xi: ArrayLike) -> NDArray[np.intc]: ...
 def _copy_docstr(dst: object, src: object) -> None: ...
 
 class ConvexHull(_QhullUser):
-    simplices: np.ndarray
-    neighbors: np.ndarray
-    equations: np.ndarray
-    coplanar: np.ndarray
-    good: None | np.ndarray
+    simplices: NDArray[np.intc]
+    neighbors: NDArray[np.intc]
+    equations: NDArray[np.float64]
+    coplanar: NDArray[np.intc]
+    good: None | NDArray[np.bool_]
     volume: float
     area: float
     nsimplex: int
@@ -139,16 +151,16 @@ class ConvexHull(_QhullUser):
     def add_points(self, points: ArrayLike,
                    restart: bool = ...) -> None: ...
     @property
-    def points(self) -> np.ndarray: ...
+    def points(self) -> NDArray[np.float64]: ...
     @property
-    def vertices(self) -> np.ndarray: ...
+    def vertices(self) -> NDArray[np.intc]: ...
 
 class Voronoi(_QhullUser):
-    vertices: np.ndarray
-    ridge_points: np.ndarray
+    vertices: NDArray[np.float64]
+    ridge_points: NDArray[np.intc]
     ridge_vertices: List[List[int]]
     regions: List[List[int]]
-    point_region: np.ndarray
+    point_region: NDArray[np.intp]
     furthest_site: bool
 
     def __init__(
@@ -165,18 +177,18 @@ class Voronoi(_QhullUser):
         restart: bool = ...
     ) -> None: ...
     @property
-    def points(self) -> np.ndarray: ...
+    def points(self) -> NDArray[np.float64]: ...
     @property
     def ridge_dict(self) -> Dict[Tuple[int, int], List[int]]: ...
 
 class HalfspaceIntersection(_QhullUser):
-    interior_point: np.ndarray
+    interior_point: NDArray[np.float64]
     dual_facets: List[List[int]]
-    dual_equations: np.ndarray
-    dual_points: np.ndarray
+    dual_equations: NDArray[np.float64]
+    dual_points: NDArray[np.float64]
     dual_volume: float
     dual_area: float
-    intersections: np.ndarray
+    intersections: NDArray[np.float64]
     ndim: int
     nineq: int
 
@@ -194,6 +206,6 @@ class HalfspaceIntersection(_QhullUser):
         restart: bool = ...
     ) -> None: ...
     @property
-    def halfspaces(self) -> np.ndarray: ...
+    def halfspaces(self) -> NDArray[np.float64]: ...
     @property
-    def dual_vertices(self) -> np.ndarray: ...
+    def dual_vertices(self) -> NDArray[np.int_]: ...


### PR DESCRIPTION
#### Reference issue
n.a.

#### What does this implement/fix?
With the release of numpy 1.21 earlier today, it is now possible to express the array dtype via PEP 484 type annotations. 

This PR does exactly that, annotating the array dtypes of all arrays mentioned in `scipy.spatial.qhull`.

#### Additional information
``` python
>>> from typing import TYPE_CHECKING

>>> import numpy as np
>>> from scipy.spatial import ConvexHull

>>> points = np.random.rand(30, 2)
>>> hull = ConvexHull(points)

>>> if TYPE_CHECKING:
...     # note: Revealed type is "numpy.ndarray[Any, numpy.dtype[numpy.floating[numpy.typing._64Bit]]]"
...     reveal_type(hull.points)

```