### PR TITLE
BUG: fix refguide-check namedtuple handling

### DIFF
--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -490,6 +490,22 @@ CHECK_NAMESPACE = {
       'Inf': np.inf,}
 
 
+def try_convert_namedtuple(got):
+    # suppose that "got" is smth like MoodResult(statistic=10, pvalue=0.1).
+    # Then convert it to the tuple (10, 0.1), so that can later compare tuples.
+    num = sum(symb == '=' for symb in got)
+    if num == 0:
+        # not a nameduple, bail out
+        return got
+    regex = (r'[\w\d_]+\(' +
+             ', '.join([r'[\w\d_]+=(.+)']*num) +
+             r'\)')
+    grp = re.findall(regex, got.replace('\n', ' '))
+    # fold it back to a tuple
+    got_again = '(' + ', '.join(grp[0]) + ')'
+    return got_again
+
+
 class DTRunner(doctest.DocTestRunner):
     DIVIDER = "\n"
 
@@ -595,6 +611,14 @@ class Checker(doctest.OutputChecker):
                 s_got = ", ".join(s_got[1:-1].split())
                 return self.check_output(s_want, s_got, optionflags)
 
+            if "=" not in want and "=" not in got:
+                # if we're here, want and got cannot be eval-ed (hence cannot
+                # be converted to numpy objects), they are not namedtuples
+                # (those must have at least one '=' sign).
+                # Thus they should have compared equal with vanilla doctest.
+                # Since they did not, it's an error.
+                return False
+
             if not self.parse_namedtuples:
                 return False
             # suppose that "want"  is a tuple, and "got" is smth like
@@ -602,16 +626,10 @@ class Checker(doctest.OutputChecker):
             # Then convert the latter to the tuple (10, 0.1),
             # and then compare the tuples.
             try:
-                num = len(a_want)
-                regex = (r'[\w\d_]+\(' +
-                         ', '.join([r'[\w\d_]+=(.+)']*num) +
-                         r'\)')
-                grp = re.findall(regex, got.replace('\n', ' '))
-                if len(grp) > 1:  # no more than one for now
-                    return False
-                # fold it back to a tuple
-                got_again = '(' + ', '.join(grp[0]) + ')'
-                return self.check_output(want, got_again, optionflags)
+
+                got_again = try_convert_namedtuple(got)
+                want_again = try_convert_namedtuple(want)
+                return self.check_output(want_again, got_again, optionflags)
             except Exception:
                 return False
 

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -493,7 +493,7 @@ CHECK_NAMESPACE = {
 def try_convert_namedtuple(got):
     # suppose that "got" is smth like MoodResult(statistic=10, pvalue=0.1).
     # Then convert it to the tuple (10, 0.1), so that can later compare tuples.
-    num = sum(symb == '=' for symb in got)
+    num = got.count('=')
     if num == 0:
         # not a nameduple, bail out
         return got
@@ -626,12 +626,13 @@ class Checker(doctest.OutputChecker):
             # Then convert the latter to the tuple (10, 0.1),
             # and then compare the tuples.
             try:
-
                 got_again = try_convert_namedtuple(got)
                 want_again = try_convert_namedtuple(want)
-                return self.check_output(want_again, got_again, optionflags)
             except Exception:
                 return False
+            else:
+                return self.check_output(want_again, got_again, optionflags)
+
 
         # ... and defer to numpy
         try:


### PR DESCRIPTION
Handle scipy.stats namedtyple *Result type classes, e.g. `ConfidenceInterval(low=0.9950085825848624, high=0.9971212407917498)` which can show up in both expected and actual doctest output.  Here "handle" means convert these into tuples of numeric values and compare those.

Previously, refuide-check only handled the cases where the expected output was given as a tuple. Otherwise, it defaulted to comparing strings.
With this change, fiddling with least-significant digits should not be necessary anymore.

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

closes gh-14282

