### PR TITLE
DEV: remove scikit-umfpack from environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -37,4 +37,3 @@ dependencies:
   # Some optional test dependencies
   - mpmath
   - gmpy2
-  - scikit-umfpack


### PR DESCRIPTION
This is a problematic optional dependency, because it in turn depends on SciPy. So this means that in a dev env you
get both a conda-installed SciPy and an inplace build. Which results in confusion often - so get rid of it.

`[ci skip]`