### PR TITLE
TST: split combined LSAP input validation tests up

### DIFF
--- a/scipy/optimize/tests/test_linear_assignment.py
+++ b/scipy/optimize/tests/test_linear_assignment.py
@@ -16,30 +16,44 @@ from scipy.sparse.csgraph.tests.test_matching import (
 )
 
 
-def test_linear_sum_assignment_input_validation():
+def test_linear_sum_assignment_input_shape():
+    with pytest.raises(ValueError, match="expected a matrix"):
+        linear_sum_assignment([1, 2, 3])
 
-    assert_raises(ValueError, linear_sum_assignment, [1, 2, 3])
 
+def test_linear_sum_assignment_input_object():
     C = [[1, 2, 3], [4, 5, 6]]
     assert_array_equal(linear_sum_assignment(C),
                        linear_sum_assignment(np.asarray(C)))
     assert_array_equal(linear_sum_assignment(C),
                        linear_sum_assignment(matrix(C)))
 
+
+def test_linear_sum_assignment_input_bool():
     I = np.identity(3)
     assert_array_equal(linear_sum_assignment(I.astype(np.bool_)),
                        linear_sum_assignment(I))
-    assert_raises(ValueError, linear_sum_assignment, I.astype(str))
 
-    I[0][0] = np.nan
-    with pytest.raises(ValueError, match="contains invalid numeric entries"):
-        linear_sum_assignment(I)
 
+def test_linear_sum_assignment_input_string():
     I = np.identity(3)
-    I[1][1] = -np.inf
+    with pytest.raises(ValueError, match="expected a matrix containing"):
+        linear_sum_assignment(I.astype(str))
+
+
+def test_linear_sum_assignment_input_nan():
+    I = np.diag([np.nan, 1, 1])
     with pytest.raises(ValueError, match="contains invalid numeric entries"):
         linear_sum_assignment(I)
 
+
+def test_linear_sum_assignment_input_neginf():
+    I = np.diag([1, -np.inf, 1])
+    with pytest.raises(ValueError, match="contains invalid numeric entries"):
+        linear_sum_assignment(I)
+
+
+def test_linear_sum_assignment_input_inf():
     I = np.identity(3)
     I[:, 0] = np.inf
     with pytest.raises(ValueError, match="cost matrix is infeasible"):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### What does this implement/fix?
<!--Please explain your changes.-->

The input validation checks for the `optimize.linear_sum_assignment` module are all combined in a single test. This makes  development harder because the test output is not very fine grained.

Here I have split the tests up.