### PR TITLE
MAINT: remove the last deprecated `PyEval_*` usages

### DIFF
--- a/scipy/integrate/__quadpack.h
+++ b/scipy/integrate/__quadpack.h
@@ -309,7 +309,7 @@ double quad_thunk(double *x)
             goto done;
         }
 
-        res = PyEval_CallObject(callback->py_function, arglist);
+        res = PyObject_CallObject(callback->py_function, arglist);
         if (res == NULL) {
             error = 1;
             goto done;

--- a/scipy/integrate/_odepackmodule.c
+++ b/scipy/integrate/_odepackmodule.c
@@ -120,7 +120,7 @@ PyObject *call_odeint_user_function(PyObject *func, npy_intp n, double *x,
     }
 
     /* Call the Python function. */
-    result = PyEval_CallObject(func, arglist);
+    result = PyObject_CallObject(func, arglist);
     if (result == NULL) {
         goto fail;
     }


### PR DESCRIPTION
The only remaining ones, `PyEval_SaveThread` and `PyEval_RestoreThread`, are not deprecated and should stay.
