### PR TITLE
ENH: Annotate array dtypes in `scipy.spatial.ckdtree` and `distance`

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -506,9 +506,6 @@ ignore_errors = True
 [mypy-scipy.spatial.tests.test__plotutils]
 ignore_errors = True
 
-[mypy-scipy.spatial.tests.test_kdtree]
-ignore_errors = True
-
 [mypy-scipy.integrate._ivp.bdf]
 ignore_errors = True
 

--- a/scipy/spatial/ckdtree.pyi
+++ b/scipy/spatial/ckdtree.pyi
@@ -35,7 +35,10 @@ _ArrayLike0D = Union[
     bytes,
     np.generic,
 ]
-_WeightType = Union[npt.ArrayLike, Tuple[npt.ArrayLike, npt.ArrayLike]]
+_WeightType = Union[
+    npt.ArrayLike,
+    Tuple[Optional[npt.ArrayLike], Optional[npt.ArrayLike]],
+]
 
 class cKDTreeNode:
     @property
@@ -165,7 +168,7 @@ class cKDTree(Generic[_BoxType]):
         other: cKDTree,
         r: _ArrayLike0D,
         p: float = ...,
-        weights: None = ...,
+        weights: None | Tuple[None, None] = ...,
         cumulative: bool = ...,
     ) -> int: ...
     @overload
@@ -183,7 +186,7 @@ class cKDTree(Generic[_BoxType]):
         other: cKDTree,
         r: npt.ArrayLike,
         p: float = ...,
-        weights: None = ...,
+        weights: None | Tuple[None, None] = ...,
         cumulative: bool = ...,
     ) -> npt.NDArray[np.intp]: ...
     @overload

--- a/scipy/spatial/ckdtree.pyi
+++ b/scipy/spatial/ckdtree.pyi
@@ -22,7 +22,7 @@ else:
     from typing_extensions import Literal
 
 # TODO: Replace `ndarray` with a 1D float64 array when possible
-_BoxType = TypeVar("_BoxType", None, np.ndarray)
+_BoxType = TypeVar("_BoxType", None, npt.NDArray[np.float64])
 
 # Copied from `numpy.typing._scalar_like._ScalarLike`
 # TODO: Expand with 0D arrays once we have shape support
@@ -39,9 +39,9 @@ _WeightType = Union[npt.ArrayLike, Tuple[npt.ArrayLike, npt.ArrayLike]]
 
 class cKDTreeNode:
     @property
-    def data_points(self) -> np.ndarray: ...
+    def data_points(self) -> npt.NDArray[np.float64]: ...
     @property
-    def indices(self) -> np.ndarray: ...
+    def indices(self) -> npt.NDArray[np.intp]: ...
 
     # These are read-only attributes in cython, which behave like properties
     @property
@@ -75,13 +75,13 @@ class cKDTree(Generic[_BoxType]):
 
     # These are read-only attributes in cython, which behave like properties
     @property
-    def data(self) -> np.ndarray: ...
+    def data(self) -> npt.NDArray[np.float64]: ...
     @property
-    def maxes(self) -> np.ndarray: ...
+    def maxes(self) -> npt.NDArray[np.float64]: ...
     @property
-    def mins(self) -> np.ndarray: ...
+    def mins(self) -> npt.NDArray[np.float64]: ...
     @property
-    def indices(self) -> np.ndarray: ...
+    def indices(self) -> npt.NDArray[np.float64]: ...
     @property
     def boxsize(self) -> _BoxType: ...
 
@@ -107,7 +107,7 @@ class cKDTree(Generic[_BoxType]):
         copy_data: bool = ...,
         balanced_tree: bool = ...,
         boxsize: npt.ArrayLike = ...,
-    ) -> cKDTree[np.ndarray]: ...
+    ) -> cKDTree[npt.NDArray[np.float64]]: ...
 
     # TODO: returns a 2-tuple of scalars if `x.ndim == 1` and `k == 1`,
     # returns a 2-tuple of arrays otherwise
@@ -157,7 +157,7 @@ class cKDTree(Generic[_BoxType]):
         p: float = ...,
         eps: float = ...,
         output_type: Literal["ndarray"] = ...,
-    ) -> np.ndarray: ...
+    ) -> npt.NDArray[np.intp]: ...
 
     @overload
     def count_neighbors(  # type: ignore[misc]
@@ -178,14 +178,23 @@ class cKDTree(Generic[_BoxType]):
         cumulative: bool = ...,
     ) -> np.float64: ...
     @overload
+    def count_neighbors(  # type: ignore[misc]
+        self,
+        other: cKDTree,
+        r: npt.ArrayLike,
+        p: float = ...,
+        weights: None = ...,
+        cumulative: bool = ...,
+    ) -> npt.NDArray[np.intp]: ...
+    @overload
     def count_neighbors(
         self,
         other: cKDTree,
         r: npt.ArrayLike,
         p: float = ...,
-        weights: Optional[_WeightType] = ...,
+        weights: _WeightType = ...,
         cumulative: bool = ...,
-    ) -> np.ndarray: ...
+    ) -> npt.NDArray[np.float64]: ...
 
     @overload
     def sparse_distance_matrix(  # type: ignore[misc]
@@ -218,4 +227,4 @@ class cKDTree(Generic[_BoxType]):
         max_distance: float,
         p: float = ...,
         output_type: Literal["ndarray"] = ...,
-    ) -> np.ndarray: ...
+    ) -> npt.NDArray[np.void]: ...

--- a/scipy/spatial/distance.pyi
+++ b/scipy/spatial/distance.pyi
@@ -2,7 +2,7 @@ import sys
 from typing import overload, Optional, Any, Union, Tuple, SupportsFloat
 
 import numpy as np
-from numpy.typing import ArrayLike
+from numpy.typing import ArrayLike, NDArray
 
 if sys.version_info >= (3, 8):
     from typing import Literal, Protocol, SupportsIndex
@@ -18,12 +18,12 @@ else:
 
 class _MetricCallback1(Protocol):
     def __call__(
-        self, __XA: np.ndarray, __XB: np.ndarray
+        self, __XA: NDArray[Any], __XB: NDArray[Any]
     ) -> _FloatValue: ...
 
 class _MetricCallback2(Protocol):
     def __call__(
-        self, __XA: np.ndarray, __XB: np.ndarray, **kwargs: Any
+        self, __XA: NDArray[Any], __XB: NDArray[Any], **kwargs: Any
     ) -> _FloatValue: ...
 
 # TODO: Use a single protocol with a parameter specification variable
@@ -67,27 +67,28 @@ def canberra(
 ) -> np.float64: ...
 
 # TODO: Add `metric`-specific overloads
+# Returns a float64 or float128 array, depending on the input dtype
 @overload
 def cdist(
     XA: ArrayLike,
     XB: ArrayLike,
     metric: _MetricKind = ...,
     *,
-    out: Optional[np.ndarray] = ...,
+    out: None | NDArray[np.floating[Any]] = ...,
     p: float = ...,
     w: Optional[ArrayLike] = ...,
     V: Optional[ArrayLike] = ...,
     VI: Optional[ArrayLike] = ...,
-) -> np.ndarray: ...
+) -> NDArray[np.floating[Any]]: ...
 @overload
 def cdist(
     XA: ArrayLike,
     XB: ArrayLike,
     metric: _MetricCallback,
     *,
-    out: Optional[np.ndarray] = ...,
+    out: None | NDArray[np.floating[Any]] = ...,
     **kwargs: Any,
-) -> np.ndarray: ...
+) -> NDArray[np.floating[Any]]: ...
 
 # TODO: Wait for dtype support; the return type is
 # dependent on the input arrays dtype
@@ -173,20 +174,20 @@ def pdist(
     X: ArrayLike,
     metric: _MetricKind = ...,
     *,
-    out: Optional[np.ndarray] = ...,
+    out: None | NDArray[np.floating[Any]] = ...,
     p: float = ...,
     w: Optional[ArrayLike] = ...,
     V: Optional[ArrayLike] = ...,
     VI: Optional[ArrayLike] = ...,
-) -> np.ndarray: ...
+) -> NDArray[np.floating[Any]]: ...
 @overload
 def pdist(
     X: ArrayLike,
     metric: _MetricCallback,
     *,
-    out: Optional[np.ndarray] = ...,
+    out: None | NDArray[np.floating[Any]] = ...,
     **kwargs: Any,
-) -> np.ndarray: ...
+) -> NDArray[np.floating[Any]]: ...
 
 def seuclidean(
     u: ArrayLike, v: ArrayLike, V: ArrayLike
@@ -208,7 +209,7 @@ def squareform(
     X: ArrayLike,
     force: Literal["no", "tomatrix", "tovector"] = ...,
     checks: bool = ...,
-) -> np.ndarray: ...
+) -> NDArray[Any]: ...
 
 def rogerstanimoto(
     u: ArrayLike, v: ArrayLike, w: Optional[ArrayLike] = ...

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -873,7 +873,7 @@ def test_kdtree_build_modes(kdtree_type):
 def test_kdtree_pickle(kdtree_type):
     # test if it is possible to pickle a KDTree
     try:
-        import cPickle as pickle
+        import cPickle as pickle  # type: ignore[import]
     except ImportError:
         import pickle
     np.random.seed(0)


### PR DESCRIPTION
#### Reference issue

Follow up on https://github.com/scipy/scipy/pull/14281.

#### What does this implement/fix?

This PR adds type annotations for the array dtypes in `scipy.spatial.ckdtree` and `scipy.spatial.distance`.

There were a few cases (_e.g._ `squareform`) were the array dtype is entirely dependent on the passed
array-like. In these cases the dtype is left unspecified (_i.e._ `typing.Any`), as inferring the dtype of an array-like 
is a somewhat non-trivial and tedious process.

#### Additional information
``` python
>>> from typing import TYPE_CHECKING

>>> import numpy as np
>>> from scipy.spatial.distance import cdist

>>> coords = np.random.rand(30, 2)
>>> out = cdist(coords, coords)

>>> if TYPE_CHECKING:
...     # note: Revealed type is "numpy.ndarray[Any, numpy.dtype[numpy.floating[Any]]]"
...     reveal_type(out)

```