### PR TITLE
MAINT: move LSAP input validation into lsap_module

### DIFF
--- a/scipy/optimize/_lsap.py
+++ b/scipy/optimize/_lsap.py
@@ -84,14 +84,4 @@ def linear_sum_assignment(cost_matrix, maximize=False):
     >>> cost[row_ind, col_ind].sum()
     5
     """
-    cost_matrix = np.asarray(cost_matrix)
-    if cost_matrix.ndim != 2:
-        raise ValueError("expected a matrix (2-D array), got a %r array"
-                         % (cost_matrix.shape,))
-
-    if not (np.issubdtype(cost_matrix.dtype, np.number) or
-            cost_matrix.dtype == np.dtype(np.bool_)):
-        raise ValueError("expected a matrix containing numerical entries, got %s"
-                         % (cost_matrix.dtype,))
-
     return _lsap_module.calculate_assignment(cost_matrix, maximize)

--- a/scipy/optimize/_lsap_module.c
+++ b/scipy/optimize/_lsap_module.c
@@ -44,10 +44,16 @@ calculate_assignment(PyObject* self, PyObject* args)
         return NULL;
 
     PyArrayObject* obj_cont =
-      (PyArrayObject*)PyArray_ContiguousFromAny(obj_cost, NPY_DOUBLE, 2, 2);
+      (PyArrayObject*)PyArray_ContiguousFromAny(obj_cost, NPY_DOUBLE, 0, 0);
     if (!obj_cont) {
-        PyErr_SetString(PyExc_TypeError, "invalid cost matrix object");
         return NULL;
+    }
+
+    if (PyArray_NDIM(obj_cont) != 2) {
+        PyErr_Format(PyExc_ValueError,
+                     "expected a matrix (2-D array), got a %d array",
+                     PyArray_NDIM(obj_cont));
+        goto cleanup;
     }
 
     double* cost_matrix = (double*)PyArray_DATA(obj_cont);

--- a/scipy/optimize/tests/test_linear_assignment.py
+++ b/scipy/optimize/tests/test_linear_assignment.py
@@ -37,7 +37,7 @@ def test_linear_sum_assignment_input_bool():
 
 def test_linear_sum_assignment_input_string():
     I = np.identity(3)
-    with pytest.raises(ValueError, match="expected a matrix containing"):
+    with pytest.raises(TypeError, match="Cannot cast array data"):
         linear_sum_assignment(I.astype(str))
 
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### What does this implement/fix?
<!--Please explain your changes.-->
For small cost matrices, input validation in `linear_sum_assignment` is a significant overhead. Here I have moved the input validation into the `optimize._lsap_module`.

Other changes:

- ~I have changed the exceptions from `ValueError` to `TypeError`. I think these are more appropriate.~
- ~I have changed the exception string from `expected a matrix (2-D array), got a %r array` to `cost matrix must be 2D`. The `PyErr_SetString` only accepts `const char*` input.~
- Checking for `str` input is handled by `PyArray_ContiguousFromAny`. This raises a `TypeError` with the message `Cannot cast array data from dtype('<U32') to dtype('float64') according to the rule 'safe'`.

#### Additional information
<!--Any additional information you think is important.-->
The `_lsap.py` module only contains the docstring now. Can we move the docstring into the `_lsap_module.c` file? If so we can remove the `_lsap.py` file altogether.