### PR TITLE
DOC: Make code block an Item List

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -6576,7 +6576,7 @@ def power_divergence(f_obs, f_exp=None, ddof=0, axis=0, lambda_=None):
         is 1.  For convenience, `lambda_` may be assigned one of the following
         strings, in which case the corresponding numerical value is used:
 
-        * ``pearson`` (value 1)
+        * ``"pearson"`` (value 1)
             Pearson's chi-squared statistic. In this case, the function is
             equivalent to `chisquare`.
         * ``"log-likelihood"`` (value 0)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -6578,7 +6578,7 @@ def power_divergence(f_obs, f_exp=None, ddof=0, axis=0, lambda_=None):
         
         Pearson (value 1)
             Pearson's chi-squared statistic. In this case, the function is
-            equivalent to `chisquare`.
+            equivalent to `stats.chisquare`.
         Log-Likelihood (value 0)
             Log-likelihood ratio. Also known as the G-test [3]_.
         Freeman-Turkey (value -1/2)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -6574,20 +6574,20 @@ def power_divergence(f_obs, f_exp=None, ddof=0, axis=0, lambda_=None):
     lambda_ : float or str, optional
         The power in the Cressie-Read power divergence statistic.  The default
         is 1.  For convenience, `lambda_` may be assigned one of the following
-        strings, in which case the corresponding numerical value is used
+        strings, in which case the corresponding numerical value is used:
 
-        Pearson (value 1)
+        * ``pearson`` (value 1)
             Pearson's chi-squared statistic. In this case, the function is
             equivalent to `chisquare`.
-        Log-Likelihood (value 0)
+        * ``"log-likelihood"`` (value 0)
             Log-likelihood ratio. Also known as the G-test [3]_.
-        Freeman-Turkey (value -1/2)
+        * ``"freeman-tukey"`` (value -1/2)
             Freeman-Tukey statistic.
-        Mod-Log-Likelihood (value -1)
+        * ``"mod-log-likelihood"`` (value -1)
             Modified log-likelihood ratio.
-        Neyman (value -2)
+        * ``"neyman"`` (value -2)
             Neyman's statistic.
-        Cressie-Read (value 2/3)
+        * ``"cressie-read"`` (value 2/3)
             The power recommended in [5]_.
 
     Returns

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -6575,7 +6575,7 @@ def power_divergence(f_obs, f_exp=None, ddof=0, axis=0, lambda_=None):
         The power in the Cressie-Read power divergence statistic.  The default
         is 1.  For convenience, `lambda_` may be assigned one of the following
         strings, in which case the corresponding numerical value is used
-        
+
         Pearson (value 1)
             Pearson's chi-squared statistic. In this case, the function is
             equivalent to `chisquare`.

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -6574,18 +6574,21 @@ def power_divergence(f_obs, f_exp=None, ddof=0, axis=0, lambda_=None):
     lambda_ : float or str, optional
         The power in the Cressie-Read power divergence statistic.  The default
         is 1.  For convenience, `lambda_` may be assigned one of the following
-        strings, in which case the corresponding numerical value is used::
-
-            String              Value   Description
-            "pearson"             1     Pearson's chi-squared statistic.
-                                        In this case, the function is
-                                        equivalent to `stats.chisquare`.
-            "log-likelihood"      0     Log-likelihood ratio. Also known as
-                                        the G-test [3]_.
-            "freeman-tukey"      -1/2   Freeman-Tukey statistic.
-            "mod-log-likelihood" -1     Modified log-likelihood ratio.
-            "neyman"             -2     Neyman's statistic.
-            "cressie-read"        2/3   The power recommended in [5]_.
+        strings, in which case the corresponding numerical value is used
+        
+        Pearson (value 1)
+            Pearson's chi-squared statistic. In this case, the function is
+            equivalent to `stats.chisquare`.
+        Log-Likelihood (value 0)
+            Log-likelihood ratio. Also known as the G-test [3]_.
+        Freeman-Turkey (value -1/2)
+            Freeman-Tukey statistic.
+        Mod-Log-Likelihood (value -1)
+            Modified log-likelihood ratio.
+        Neyman (value -2)
+            Neyman's statistic.
+        Cressie-Read (value 2/3)
+            The power recommended in [5]_.
 
     Returns
     -------

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -6578,7 +6578,7 @@ def power_divergence(f_obs, f_exp=None, ddof=0, axis=0, lambda_=None):
         
         Pearson (value 1)
             Pearson's chi-squared statistic. In this case, the function is
-            equivalent to `stats.chisquare`.
+            equivalent to `chisquare`.
         Log-Likelihood (value 0)
             Log-likelihood ratio. Also known as the G-test [3]_.
         Freeman-Turkey (value -1/2)


### PR DESCRIPTION
Closes: https://github.com/scipy/scipy/issues/14277

The issue was that references were not rendered correctly. I decided to replace the code block with a definition list in response to @tupui 's comment https://github.com/scipy/scipy/issues/14277#issuecomment-867134453 .