### PR TITLE
ENH: sparse.linalg: make `aslinearoperator` accept array_like

### DIFF
--- a/scipy/sparse/linalg/interface.py
+++ b/scipy/sparse/linalg/interface.py
@@ -822,8 +822,4 @@ def aslinearoperator(A):
 
         else:
             A = np.atleast_2d(np.asarray(A))
-            if not (np.issubdtype(A.dtype, np.number)
-                    or np.issubdtype(A.dtype, np.bool_)):
-                message = f"Linear operations not defined for type {A.dtype}"
-                raise TypeError(message)
             return MatrixLinearOperator(A)

--- a/scipy/sparse/linalg/interface.py
+++ b/scipy/sparse/linalg/interface.py
@@ -774,7 +774,7 @@ def aslinearoperator(A):
     """Return A as a LinearOperator.
 
     'A' may be any of the following types:
-     - ndarray
+     - array_like
      - matrix
      - sparse matrix (e.g. csr_matrix, lil_matrix, etc.)
      - LinearOperator
@@ -799,8 +799,6 @@ def aslinearoperator(A):
         return A
 
     elif isinstance(A, np.ndarray) or isinstance(A, np.matrix):
-        if A.ndim > 2:
-            raise ValueError('array must have ndim <= 2')
         A = np.atleast_2d(np.asarray(A))
         return MatrixLinearOperator(A)
 
@@ -823,4 +821,9 @@ def aslinearoperator(A):
                                   rmatmat=rmatmat, dtype=dtype)
 
         else:
-            raise TypeError('type not understood')
+            A = np.atleast_2d(np.asarray(A))
+            if not (np.issubdtype(A.dtype, np.number)
+                    or np.issubdtype(A.dtype, np.bool_)):
+                message = f"Linear operations not defined for type {A.dtype}"
+                raise TypeError(message)
+            return MatrixLinearOperator(A)

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -456,12 +456,6 @@ def test_aslinearoperator_input_validation_shape():
     with pytest.raises(ValueError, match=re.escape(message)):
         interface.aslinearoperator(np.ones((3, 4, 5)))
 
-@pytest.mark.parametrize("A", (["ekki", 'ni'], object, {1: 2}))
-def test_aslinearoperator_input_validation_type(A):
-    message = "Linear operations not defined for type"
-    with pytest.raises(TypeError, match=message):
-        interface.aslinearoperator(A)
-
 @pytest.mark.parametrize("dtype", [int, bool, float, complex])
 def test_aslinearoperator_input_array_like(dtype):
     A = np.eye(2, dtype=dtype)


### PR DESCRIPTION
#### What does this implement/fix?
Currently, `aslinearoperator` accepts ndarrays, but not other array-like objects (e.g. lists). This PR would make it more flexible. 

Note that the first commit would have restricted that to numeric or bool dtypes to avoid accepting strings and more general objects. Would that be preferred?

(The motivation for this is the work on adding PROPACK to `svds`. I'm improving the input validation for `svds` and testing to make sure it works with reasonable input data types. As I was testing, this behavior stood out as unusual, so I thought I'd propose this.)