### PR TITLE
BLD: fix build warnings for `stats/biasedurn`

### DIFF
--- a/scipy/stats/biasedurn/stoc3.cpp
+++ b/scipy/stats/biasedurn/stoc3.cpp
@@ -466,7 +466,8 @@ int32_t * source, double * weights, int32_t n, int colors) {
    if (n < 0 || colors < 0 || colors > MAXCOLORS) FatalError("Parameter out of range in function MultiWalleniusNCHyp");
    if (colors == 0) return;
    if (n == 0) {
-      for (i=0; i<colors; i++) destination[i] = 0; return;
+      for (i=0; i<colors; i++) destination[i] = 0;
+      return;
    }
 
    // check validity of array parameters
@@ -1078,7 +1079,8 @@ int32_t * source, double * weights, int32_t n, int colors) {
    if (n < 0 || colors < 0 || colors > MAXCOLORS) FatalError("Parameter out of range in function MultiFishersNCHyp");
    if (colors == 0) return;
    if (n == 0) {
-      for (i=0; i<colors; i++) destination[i] = 0; return;
+      for (i=0; i<colors; i++) destination[i] = 0;
+      return;
    }
 
    // check validity of array parameters


### PR DESCRIPTION
The warnings were:
```
[7/23] Compiling C++ object scipy/stats/biasedurn.cpython-39-x86_64-linux-gnu.so.p/biasedurn_stoc3.cpp.o
../scipy/stats/biasedurn/stoc3.cpp: In member function 'void StochasticLib3::MultiWalleniusNCHyp(int32_t*, int32_t*, double*, int32_t, int)':
../scipy/stats/biasedurn/stoc3.cpp:469:7: warning: this 'for' clause does not guard... [-Wmisleading-indentation]
  469 |       for (i=0; i<colors; i++) destination[i] = 0; return;
      |       ^~~
../scipy/stats/biasedurn/stoc3.cpp:469:52: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'for'
  469 |       for (i=0; i<colors; i++) destination[i] = 0; return;
      |                                                    ^~~~~~
../scipy/stats/biasedurn/stoc3.cpp: In member function 'void StochasticLib3::MultiFishersNCHyp(int32_t*, int32_t*, double*, int32_t, int)':
../scipy/stats/biasedurn/stoc3.cpp:1081:7: warning: this 'for' clause does not guard... [-Wmisleading-indentation]
 1081 |       for (i=0; i<colors; i++) destination[i] = 0; return;
      |       ^~~
../scipy/stats/biasedurn/stoc3.cpp:1081:52: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'for'
 1081 |       for (i=0; i<colors; i++) destination[i] = 0; return;
      |                                                    ^~~~~~
```
