### PR TITLE
FIX: Check for None before calling str methods

### DIFF
--- a/scipy/io/matlab/mio4.py
+++ b/scipy/io/matlab/mio4.py
@@ -388,7 +388,7 @@ class MatFile4Reader(MatFileReader):
         mdict = {}
         while not self.end_of_stream():
             hdr, next_position = self.read_var_header()
-            name = hdr.name.decode('latin1')
+            name = 'None' if hdr.name is None else hdr.name.decode('latin1')
             if variable_names is not None and name not in variable_names:
                 self.mat_stream.seek(next_position)
                 continue
@@ -408,7 +408,7 @@ class MatFile4Reader(MatFileReader):
         vars = []
         while not self.end_of_stream():
             hdr, next_position = self.read_var_header()
-            name = hdr.name.decode('latin1')
+            name = 'None' if hdr.name is None else hdr.name.decode('latin1')
             shape = self._matrix_reader.shape_from_header(hdr)
             info = mclass_info.get(hdr.mclass, 'unknown')
             vars.append((name, shape, info))

--- a/scipy/io/matlab/mio5.py
+++ b/scipy/io/matlab/mio5.py
@@ -310,7 +310,7 @@ class MatFile5Reader(MatFileReader):
         mdict['__globals__'] = []
         while not self.end_of_stream():
             hdr, next_position = self.read_var_header()
-            name = hdr.name.decode('latin1')
+            name = 'None' if hdr.name is None else hdr.name.decode('latin1')
             if name in mdict:
                 warnings.warn('Duplicate variable name "%s" in stream'
                               ' - replacing previous with new\n'
@@ -358,7 +358,7 @@ class MatFile5Reader(MatFileReader):
         vars = []
         while not self.end_of_stream():
             hdr, next_position = self.read_var_header()
-            name = hdr.name.decode('latin1')
+            name = 'None' if hdr.name is None else hdr.name.decode('latin1')
             if name == '':
                 # can only be a matlab 7 function workspace
                 name = '__function_workspace__'
@@ -429,7 +429,7 @@ def varmats_from_mat(file_obj):
     while not rdr.end_of_stream():
         start_position = next_position
         hdr, next_position = rdr.read_var_header()
-        name = hdr.name.decode('latin1')
+        name = 'None' if hdr.name is None else hdr.name.decode('latin1')
         # Read raw variable string
         file_obj.seek(start_position)
         byte_count = next_position - start_position

--- a/scipy/io/matlab/tests/test_mio_funcs.py
+++ b/scipy/io/matlab/tests/test_mio_funcs.py
@@ -16,7 +16,7 @@ def read_minimat_vars(rdr):
     i = 0
     while not rdr.end_of_stream():
         hdr, next_position = rdr.read_var_header()
-        name = hdr.name.decode('latin1')
+        name = 'None' if hdr.name is None else hdr.name.decode('latin1')
         if name == '':
             name = 'var_%d' % i
             i += 1


### PR DESCRIPTION
Resolves a rare issue when None is returned instead of a string.
Returns 'None' since that's what the old "numpy.compat.asstr"
implementation returned.

#### Reference issue
Closes #14271 