### PR TITLE
MAINT: silence warning in odepackmodule.c

### DIFF
--- a/scipy/integrate/_odepackmodule.c
+++ b/scipy/integrate/_odepackmodule.c
@@ -513,7 +513,7 @@ odepack_odeint(PyObject *dummy, PyObject *args, PyObject *kwdict)
     long k, ntimes, crit_ind = 0;
     long allocated = 0, full_output = 0, numcrit = 0;
     long t0count;
-    double *yout, *yout_ptr, *tout_ptr, *tcrit;
+    double *yout, *yout_ptr, *tout_ptr, *tcrit = NULL;
     double *wa;
     static char *kwlist[] = {"fun", "y0", "t", "args", "Dfun", "col_deriv",
                              "ml", "mu", "full_output", "rtol", "atol", "tcrit",
@@ -639,9 +639,6 @@ odepack_odeint(PyObject *dummy, PyObject *args, PyObject *kwdict)
     }
     rtol = (double *) PyArray_DATA(ap_rtol);
     atol = (double *) PyArray_DATA(ap_atol);
-    if (o_tcrit != NULL) {
-        tcrit = (double *)(PyArray_DATA(ap_tcrit));
-    }
 
     /* Find size of working arrays*/
     if (compute_lrw_liw(&lrw, &liw, neq, jt, ml, mu, mxordn, mxords) < 0) {
@@ -696,6 +693,7 @@ odepack_odeint(PyObject *dummy, PyObject *args, PyObject *kwdict)
     if (o_tcrit != NULL) {
         /* There are critical points */
         itask = 4;
+        tcrit = (double *)(PyArray_DATA(ap_tcrit));
         rwork[0] = *tcrit;
     }
     while (k < ntimes && istate > 0) {    /* loop over desired times */

--- a/scipy/integrate/_odepackmodule.c
+++ b/scipy/integrate/_odepackmodule.c
@@ -700,9 +700,14 @@ odepack_odeint(PyObject *dummy, PyObject *args, PyObject *kwdict)
 
         tout_ptr = tout + k;
         /* Use tcrit if relevant */
-        if (itask == 4 && *tout_ptr > *(tcrit + crit_ind)) {
-            crit_ind++;
-            rwork[0] = *(tcrit+crit_ind);
+        if (itask == 4) {
+            if (!tcrit) {
+                PYERR(odepack_error, "Internal error - tcrit must be defined!");
+            }
+            if (*tout_ptr > *(tcrit + crit_ind)) {
+                crit_ind++;
+                rwork[0] = *(tcrit+crit_ind);
+            }
         }
         if (crit_ind >= numcrit) {
             itask = 1;  /* No more critical values */


### PR DESCRIPTION
The warning was:
```
../scipy/integrate/_odepackmodule.c: In function 'odepack_odeint':
../scipy/integrate/_odepackmodule.c:699:20: warning: 'tcrit' may be used uninitialized in this function [-Wmaybe-uninitialized]
  699 |         rwork[0] = *tcrit;
      |                    ^~~~~~
```

Also combines two if-clauses that did the same check but were weirdly
split, making the code harder to understand.

This fix is slightly obscure; it's not clear that subsequent calls
to LSODA inside the while-loop cannot set `itask=4`. And at that
point something will fail (it now will try using a NULL pointer
rather than an uninitialized one).

`itask=4` means that the ODE being solved has critical points.
Presumably that will be detected on the first call and not after
time-stepping, but that's hard to verify.