### PR TITLE
ENH: use Pythran to speedup somersd and _tau_b

### DIFF
--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -9,7 +9,7 @@ from . import distributions
 from ._continuous_distns import chi2, norm
 from scipy.special import gamma, kv, gammaln
 from . import _wilcoxon_data
-from ._hypotests_pythran import _Q_pythran, _P_pythran, _a_ij_Aij_Dij2_pythran
+from ._hypotests_pythran import _Q, _P, _a_ij_Aij_Dij2
 
 __all__ = ['epps_singleton_2samp', 'cramervonmises', 'somersd',
            'barnard_exact', 'boschloo_exact', 'cramervonmises_2samp']
@@ -405,15 +405,15 @@ def _tau_b(A):
         return np.nan, np.nan
 
     NA = A.sum()
-    PA = _P_pythran(A)
-    QA = _Q_pythran(A)
+    PA = _P(A)
+    QA = _Q(A)
     Sri2 = (A.sum(axis=1)**2).sum()
     Scj2 = (A.sum(axis=0)**2).sum()
     denominator = (NA**2 - Sri2)*(NA**2 - Scj2)
 
     tau = (PA-QA)/(denominator)**0.5
 
-    numerator = 4*(_a_ij_Aij_Dij2_pythran(A) - (PA - QA)**2 / NA)
+    numerator = 4*(_a_ij_Aij_Dij2(A) - (PA - QA)**2 / NA)
     s02_tau_b = numerator/denominator
     if s02_tau_b == 0:  # Avoid divide by zero
         return tau, 0
@@ -433,13 +433,13 @@ def _somers_d(A):
 
     NA = A.sum()
     NA2 = NA**2
-    PA = _P_pythran(A)
-    QA = _Q_pythran(A)
+    PA = _P(A)
+    QA = _Q(A)
     Sri2 = (A.sum(axis=1)**2).sum()
 
     d = (PA - QA)/(NA2 - Sri2)
 
-    S = _a_ij_Aij_Dij2_pythran(A) - (PA-QA)**2/NA
+    S = _a_ij_Aij_Dij2(A) - (PA-QA)**2/NA
     if S == 0:  # Avoid divide by zero
         return d, 0
     Z = (PA - QA)/(4*(S))**0.5

--- a/scipy/stats/_hypotests_pythran.py
+++ b/scipy/stats/_hypotests_pythran.py
@@ -1,0 +1,49 @@
+#pythran export _Aij_pythran(float[:,:], int, int)
+#pythran export _Aij_pythran(int[:,:], int, int)
+def _Aij_pythran(A, i, j):
+    """Sum of upper-left and lower right blocks of contingency table."""
+    # See [2] bottom of page 309
+    return A[:i, :j].sum() + A[i+1:, j+1:].sum()
+
+#pythran export _Dij_pythran(float[:,:], int, int)
+#pythran export _Dij_pythran(int[:,:], int, int)
+def _Dij_pythran(A, i, j):
+    """Sum of lower-left and upper-right blocks of contingency table."""
+    # See [2] bottom of page 309
+    return A[i+1:, :j].sum() + A[:i, j+1:].sum()
+
+#pythran export _P_pythran(float[:,:])
+#pythran export _P_pythran(int[:,:])
+def _P_pythran(A):
+    """Twice the number of concordant pairs, excluding ties."""
+    # See [2] bottom of page 309
+    m, n = A.shape
+    count = 0
+    for i in range(m):
+        for j in range(n):
+            count += A[i, j]*_Aij_pythran(A, i, j)
+    return count
+
+#pythran export _Q_pythran(float[:,:])
+#pythran export _Q_pythran(int[:,:])
+def _Q_pythran(A):
+    """Twice the number of discordant pairs, excluding ties."""
+    # See [2] bottom of page 309
+    m, n = A.shape
+    count = 0
+    for i in range(m):
+        for j in range(n):
+            count += A[i, j]*_Dij_pythran(A, i, j)
+    return count
+
+#pythran export _a_ij_Aij_Dij2_pythran(float[:,:])
+#pythran export _a_ij_Aij_Dij2_pythran(int[:,:])
+def _a_ij_Aij_Dij2_pythran(A):
+    """A term that appears in the ASE of Kendall's tau and Somers' D."""
+    # See [2] section 4: Modified ASEs to test the null hypothesis...
+    m, n = A.shape
+    count = 0
+    for i in range(m):
+        for j in range(n):
+            count += A[i, j]*(_Aij_pythran(A, i, j) - _Dij_pythran(A, i, j))**2
+    return count

--- a/scipy/stats/_hypotests_pythran.py
+++ b/scipy/stats/_hypotests_pythran.py
@@ -2,21 +2,21 @@
 #pythran export _Aij_pythran(int[:,:], int, int)
 def _Aij_pythran(A, i, j):
     """Sum of upper-left and lower right blocks of contingency table."""
-    # See [2] bottom of page 309
+    # See `somersd` References [2] bottom of page 309
     return A[:i, :j].sum() + A[i+1:, j+1:].sum()
 
 #pythran export _Dij_pythran(float[:,:], int, int)
 #pythran export _Dij_pythran(int[:,:], int, int)
 def _Dij_pythran(A, i, j):
     """Sum of lower-left and upper-right blocks of contingency table."""
-    # See [2] bottom of page 309
+    # See `somersd` References [2] bottom of page 309
     return A[i+1:, :j].sum() + A[:i, j+1:].sum()
 
 #pythran export _P_pythran(float[:,:])
 #pythran export _P_pythran(int[:,:])
 def _P_pythran(A):
     """Twice the number of concordant pairs, excluding ties."""
-    # See [2] bottom of page 309
+    # See `somersd` References [2] bottom of page 309
     m, n = A.shape
     count = 0
     for i in range(m):
@@ -28,7 +28,7 @@ def _P_pythran(A):
 #pythran export _Q_pythran(int[:,:])
 def _Q_pythran(A):
     """Twice the number of discordant pairs, excluding ties."""
-    # See [2] bottom of page 309
+    # See `somersd` References [2] bottom of page 309
     m, n = A.shape
     count = 0
     for i in range(m):
@@ -40,7 +40,7 @@ def _Q_pythran(A):
 #pythran export _a_ij_Aij_Dij2_pythran(int[:,:])
 def _a_ij_Aij_Dij2_pythran(A):
     """A term that appears in the ASE of Kendall's tau and Somers' D."""
-    # See [2] section 4: Modified ASEs to test the null hypothesis...
+    # See `somersd` References [2] section 4: Modified ASEs to test the null hypothesis...
     m, n = A.shape
     count = 0
     for i in range(m):

--- a/scipy/stats/_hypotests_pythran.py
+++ b/scipy/stats/_hypotests_pythran.py
@@ -1,49 +1,49 @@
-#pythran export _Aij_pythran(float[:,:], int, int)
-#pythran export _Aij_pythran(int[:,:], int, int)
-def _Aij_pythran(A, i, j):
+#pythran export _Aij(float[:,:], int, int)
+#pythran export _Aij(int[:,:], int, int)
+def _Aij(A, i, j):
     """Sum of upper-left and lower right blocks of contingency table."""
     # See `somersd` References [2] bottom of page 309
     return A[:i, :j].sum() + A[i+1:, j+1:].sum()
 
-#pythran export _Dij_pythran(float[:,:], int, int)
-#pythran export _Dij_pythran(int[:,:], int, int)
-def _Dij_pythran(A, i, j):
+#pythran export _Dij(float[:,:], int, int)
+#pythran export _Dij(int[:,:], int, int)
+def _Dij(A, i, j):
     """Sum of lower-left and upper-right blocks of contingency table."""
     # See `somersd` References [2] bottom of page 309
     return A[i+1:, :j].sum() + A[:i, j+1:].sum()
 
-#pythran export _P_pythran(float[:,:])
-#pythran export _P_pythran(int[:,:])
-def _P_pythran(A):
+#pythran export _P(float[:,:])
+#pythran export _P(int[:,:])
+def _P(A):
     """Twice the number of concordant pairs, excluding ties."""
     # See `somersd` References [2] bottom of page 309
     m, n = A.shape
     count = 0
     for i in range(m):
         for j in range(n):
-            count += A[i, j]*_Aij_pythran(A, i, j)
+            count += A[i, j]*_Aij(A, i, j)
     return count
 
-#pythran export _Q_pythran(float[:,:])
-#pythran export _Q_pythran(int[:,:])
-def _Q_pythran(A):
+#pythran export _Q(float[:,:])
+#pythran export _Q(int[:,:])
+def _Q(A):
     """Twice the number of discordant pairs, excluding ties."""
     # See `somersd` References [2] bottom of page 309
     m, n = A.shape
     count = 0
     for i in range(m):
         for j in range(n):
-            count += A[i, j]*_Dij_pythran(A, i, j)
+            count += A[i, j]*_Dij(A, i, j)
     return count
 
-#pythran export _a_ij_Aij_Dij2_pythran(float[:,:])
-#pythran export _a_ij_Aij_Dij2_pythran(int[:,:])
-def _a_ij_Aij_Dij2_pythran(A):
+#pythran export _a_ij_Aij_Dij2(float[:,:])
+#pythran export _a_ij_Aij_Dij2(int[:,:])
+def _a_ij_Aij_Dij2(A):
     """A term that appears in the ASE of Kendall's tau and Somers' D."""
     # See `somersd` References [2] section 4: Modified ASEs to test the null hypothesis...
     m, n = A.shape
     count = 0
     for i in range(m):
         for j in range(n):
-            count += A[i, j]*(_Aij_pythran(A, i, j) - _Dij_pythran(A, i, j))**2
+            count += A[i, j]*(_Aij(A, i, j) - _Dij(A, i, j))**2
     return count

--- a/scipy/stats/setup.py
+++ b/scipy/stats/setup.py
@@ -1,3 +1,4 @@
+import os
 from os.path import join
 
 from numpy.distutils.misc_util import get_info
@@ -45,6 +46,14 @@ def configuration(parent_package='', top_path=None):
     ext = config.add_extension('_qmc_cy',
                                sources=['_qmc_cy.cxx'])
     ext._pre_build_hook = set_cxx_flags_hook
+
+    if int(os.environ.get('SCIPY_USE_PYTHRAN', 1)):
+        import pythran
+        ext = pythran.dist.PythranExtension(
+            'scipy.stats._hypotests_pythran',
+            sources=["scipy/stats/_hypotests_pythran.py"],
+            config=['compiler.blas=none'])
+        config.ext_modules.append(ext)
 
     # add BiasedUrn module
     config.add_data_files('biasedurn.pxd')


### PR DESCRIPTION
Use Pythran to speedup somersd and _tau_b, 4x~20x faster than the original version. cc @rgommers @serge-sans-paille 



  | Pythran version | Python version
-- | -- | --
somersd small (f1) | 0.108254081 | 0.457638957
somersd large (f2) | 0.497433675 | 11.13540973
_tau_b small (f3) | 0.107982646 | 0.410471312
_tau_b large (f4) | 0.47962526 | 10.10672088



```
from scipy.stats import somersd
from scipy.stats._hypotests import _tau_b
from timeit import timeit
import numpy as np


table = [[27, 25, 14, 7, 0], [7, 14, 18, 35, 12], [1, 3, 2, 7, 17]]
rng = np.random.default_rng(123)

a = np.empty((5,100))
for i in range(5):
    a[i, :] = rng.choice(200, size=100)


f1 = lambda: somersd(table)
f2 = lambda: somersd(a)
print(timeit(f1, number=1000))
print(timeit(f2, number=1000))

f3 = lambda: _tau_b(np.array(table))
f4 = lambda: _tau_b(a)
print(timeit(f3, number=1000))
print(timeit(f4, number=1000))
```
