### PR TITLE
BLD: fix build warnings for scipy.special

### DIFF
--- a/scipy/special/_cython_special_custom.pxi
+++ b/scipy/special/_cython_special_custom.pxi
@@ -6,11 +6,13 @@ cpdef number_t spherical_jn(long n, number_t z, bint derivative=0) nogil:
     if derivative:
         if number_t is double:
             return _spherical_bessel.spherical_jn_d_real(n, z)
-        return _spherical_bessel.spherical_jn_d_complex(n, z)
+        else:
+            return _spherical_bessel.spherical_jn_d_complex(n, z)
 
     if number_t is double:
         return _spherical_bessel.spherical_jn_real(n, z)
-    return _spherical_bessel.spherical_jn_complex(n, z)
+    else:
+        return _spherical_bessel.spherical_jn_complex(n, z)
 
 
 cpdef number_t spherical_yn(long n, number_t z, bint derivative=0) nogil:
@@ -18,11 +20,13 @@ cpdef number_t spherical_yn(long n, number_t z, bint derivative=0) nogil:
     if derivative:
         if number_t is double:
             return _spherical_bessel.spherical_yn_d_real(n, z)
-        return _spherical_bessel.spherical_yn_d_complex(n, z)
+        else:
+            return _spherical_bessel.spherical_yn_d_complex(n, z)
 
     if number_t is double:
         return _spherical_bessel.spherical_yn_real(n, z)
-    return _spherical_bessel.spherical_yn_complex(n, z)
+    else:
+        return _spherical_bessel.spherical_yn_complex(n, z)
 
 
 cpdef number_t spherical_in(long n, number_t z, bint derivative=0) nogil:
@@ -30,11 +34,13 @@ cpdef number_t spherical_in(long n, number_t z, bint derivative=0) nogil:
     if derivative:
         if number_t is double:
             return _spherical_bessel.spherical_in_d_real(n, z)
-        return _spherical_bessel.spherical_in_d_complex(n, z)
+        else:
+            return _spherical_bessel.spherical_in_d_complex(n, z)
 
     if number_t is double:
         return _spherical_bessel.spherical_in_real(n, z)
-    return _spherical_bessel.spherical_in_complex(n, z)
+    else:
+        return _spherical_bessel.spherical_in_complex(n, z)
 
 
 cpdef number_t spherical_kn(long n, number_t z, bint derivative=0) nogil:
@@ -42,8 +48,10 @@ cpdef number_t spherical_kn(long n, number_t z, bint derivative=0) nogil:
     if derivative:
         if number_t is double:
             return _spherical_bessel.spherical_kn_d_real(n, z)
-        return _spherical_bessel.spherical_kn_d_complex(n, z)
+        else:
+            return _spherical_bessel.spherical_kn_d_complex(n, z)
 
     if number_t is double:
         return _spherical_bessel.spherical_kn_real(n, z)
-    return _spherical_bessel.spherical_kn_complex(n, z)
+    else:
+        return _spherical_bessel.spherical_kn_complex(n, z)

--- a/scipy/special/cephes/kolmogorov.c
+++ b/scipy/special/cephes/kolmogorov.c
@@ -257,8 +257,6 @@ _kolmogi(double psf, double pcdf)
     double x, t;
     double xmin = 0;
     double xmax = NPY_INFINITY;
-    double fmin = 1 - psf;
-    double fmax = pcdf - 1;
     int iterations;
     double a = xmin, b = xmax;
 


### PR DESCRIPTION
- fix some "unused variable" warnings for `special/cephes/`
- fix "unreachable code" warnings for `cython_special`