### PR TITLE
ENH: make epsilon optional in optimize.approx_fprime.

### DIFF
--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -865,7 +865,7 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
     return result
 
 
-def approx_fprime(xk, f, epsilon, *args):
+def approx_fprime(xk, f, epsilon=_epsilon, *args):
     """Finite-difference approximation of the gradient of a scalar function.
 
     Parameters
@@ -877,11 +877,12 @@ def approx_fprime(xk, f, epsilon, *args):
         Should take `xk` as first argument, other arguments to `f` can be
         supplied in ``*args``. Should return a scalar, the value of the
         function at `xk`.
-    epsilon : array_like
+    epsilon : {float, array_like}, optional
         Increment to `xk` to use for determining the function gradient.
         If a scalar, uses the same finite difference delta for all partial
         derivatives. If an array, should contain one value per element of
-        `xk`.
+        `xk`. Defaults to ``sqrt(np.finfo(float).eps)``, which is approximately
+        1.49e-08.
     \\*args : args, optional
         Any other arguments that are to be passed to `f`.
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
N/A

#### What does this implement/fix?
<!--Please explain your changes.-->
Most functions in scipy.optimize which need to approximate a gradient
already default to an epsilon step of sqrt(finfo(float).eps); it makes
sense (and is a minor usability improvement) to use the same default in
approx_fprime as well.

#### Additional information
N/A