### PR TITLE
WIP: ENH: improve _count_paths_outside_method via pythran

### DIFF
--- a/scipy/stats/_count_paths_outside_method_pythran.py
+++ b/scipy/stats/_count_paths_outside_method_pythran.py
@@ -1,0 +1,44 @@
+import scipy.special as special
+import numpy as np
+
+
+#pythran export _count_paths_outside_method(int, int, int, int)
+def _count_paths_outside_method(m, n, g, h):
+    if m < n:
+        m, n = n, m
+    mg = m // g
+    ng = n // g
+
+    # Not every x needs to be considered.
+    # xj holds the list of x values to be checked.
+    # Wherever n*x/m + ng*h crosses an integer
+    lxj = n + (mg-h)//mg
+    xj = [(h + mg * j + ng-1)//ng for j in range(lxj)]
+    # B is an array just holding a few values of B(x,y), the ones needed.
+    # B[j] == B(x_j, j)
+    if lxj == 0:
+        return np.round(special.binom(m + n, n))
+    B = np.zeros(lxj)
+    B[0] = 1
+    # Compute the B(x, y) terms
+    # The binomial coefficient is an integer, but special.binom()
+    # may return a float. Round it to the nearest integer.
+    for j in range(1, lxj):
+        Bj = np.round(special.binom(xj[j] + j, j))
+        if not np.isfinite(Bj):
+            raise FloatingPointError()
+        for i in range(j):
+            bin = np.round(special.binom(xj[j] - xj[i] + j - i, j-i))
+            Bj -= bin * B[i]
+        B[j] = Bj
+        if not np.isfinite(Bj):
+            raise FloatingPointError()
+    # Compute the number of path extensions...
+    num_paths = 0
+    for j in range(lxj):
+        bin = np.round(special.binom((m-xj[j]) + (n - j), n-j))
+        term = B[j] * bin
+        if not np.isfinite(term):
+            raise FloatingPointError()
+        num_paths += term
+    return np.round(num_paths)

--- a/scipy/stats/setup.py
+++ b/scipy/stats/setup.py
@@ -1,3 +1,4 @@
+import os
 from os.path import join
 
 from numpy.distutils.misc_util import get_info
@@ -77,6 +78,15 @@ def configuration(parent_package='', top_path=None):
         depends=['biasedurn/stocR.h'],
     )
     ext._pre_build_hook = pre_build_hook
+
+    if int(os.environ.get('SCIPY_USE_PYTHRAN', 1)):
+        from pythran.dist import PythranExtension
+        ext = PythranExtension(
+            'scipy.stats._count_paths_outside_method_pythran',
+            sources=['scipy/stats/_count_paths_outside_method_pythran.py'],
+            config=['compiler.blas=none']
+            )
+        config.ext_modules.append(ext)
 
     # add boost stats distributions
     config.add_subpackage('_boost')


### PR DESCRIPTION
Could speed up `stats.ks_2samp(rvs1, rvs2, alternative='less', mode='exact')` >20x times on my computer if went well with Pythran master

```
from scipy import stats
import numpy as np
from timeit import timeit

print(stats.__file__)
rng = np.random.default_rng(1234)
n1 = 200
n2 = 300

rvs1 = stats.norm.rvs(size=n1, loc=0., scale=1, random_state=rng)
rvs2 = stats.norm.rvs(size=n2, loc=0.5, scale=1.5, random_state=rng)
stats.ks_2samp(rvs1, rvs2, alternative='less', mode='exact')
```