### PR TITLE
ENH: Optimize sparse frobenius norm

### DIFF
--- a/scipy/sparse/linalg/_norm.py
+++ b/scipy/sparse/linalg/_norm.py
@@ -3,6 +3,7 @@
 """
 import numpy as np
 from scipy.sparse import issparse
+import scipy.sparse as sp
 
 from numpy import Inf, sqrt, abs
 
@@ -10,11 +11,8 @@ __all__ = ['norm']
 
 
 def _sparse_frobenius_norm(x):
-    if np.issubdtype(x.dtype, np.complexfloating):
-        sqnorm = abs(x).power(2).sum()
-    else:
-        sqnorm = x.power(2).sum()
-    return sqrt(sqnorm)
+    data = sp._sputils._todata(x)
+    return np.linalg.norm(data)
 
 
 def norm(x, ord=None, axis=None):


### PR DESCRIPTION
#### What does this implement/fix?
This optimizes `sparse.linalg.norm`'s default case. If possible, it will access the data array otherwise it creates a numpy array for just the values. With that array, we can just call `np.linalg.norm` for a fused square and sum with no overhead from copying around indices.

#### Benchmarks

I've benchmarked with `sp.random(10000, 10000)` which has 1 million nnz. In all cases it is significantly faster, with the best case being `_data_matrix` subclasses which have ~10-100x speedup and are almost as fast as calling `np.linalg.norm(s.data)` directly.

|  Sparse Format | Master (us) | This PR (us) |
|:--------------:|:-----------:|:------------:|
| None (ndarray) |      -      |     34.4     |
|       COO      |    3,300    |     35.6     |
|       CSR      |     949     |     36.7     |
|       BSR      |     943     |     48.0     |
|       DOK      |    87,500   |    20,400    |
|       LIL      |    10,000   |     5,410    |