### PR TITLE
BUG: Speed up sparse compressed indexing with very many rows

### DIFF
--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -686,10 +686,10 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         if M == 0:
             return self.__class__(new_shape)
 
-        row_nnz = np.diff(self.indptr)
+        row_nnz = self.indptr[indices + 1] - self.indptr[indices]
         idx_dtype = self.indices.dtype
         res_indptr = np.zeros(M+1, dtype=idx_dtype)
-        np.cumsum(row_nnz[idx], out=res_indptr[1:])
+        np.cumsum(row_nnz, out=res_indptr[1:])
 
         nnz = res_indptr[-1]
         res_indices = np.empty(nnz, dtype=idx_dtype)
@@ -713,10 +713,11 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         if M == 0:
             return self.__class__(new_shape)
 
-        row_nnz = np.diff(self.indptr)
+        indices = np.arange(start, stop, step)
+        row_nnz = self.indptr[indices + 1] - self.indptr[indices]
         idx_dtype = self.indices.dtype
         res_indptr = np.zeros(M+1, dtype=idx_dtype)
-        np.cumsum(row_nnz[idx], out=res_indptr[1:])
+        np.cumsum(row_nnz, out=res_indptr[1:])
 
         if step == 1:
             all_idx = slice(self.indptr[start], self.indptr[stop])

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -715,13 +715,13 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
         # Work out what slices are needed for `row_nnz`
         # start,stop can be -1, only if step is negative
+        start0, stop0 = start, stop
         if stop == -1 and start >= 0:
-            idx0 = slice(start, None, step)
-        else:
-            idx0 = slice(start, stop, step)
-        idx1 = slice(start + 1, stop + 1, step)
+            stop0 = None
+        start1, stop1 = start + 1, stop + 1
 
-        row_nnz = self.indptr[idx1] - self.indptr[idx0]
+        row_nnz = self.indptr[start1:stop1:step] - \
+            self.indptr[start0:stop0:step]
         idx_dtype = self.indices.dtype
         res_indptr = np.zeros(M+1, dtype=idx_dtype)
         np.cumsum(row_nnz, out=res_indptr[1:])

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -713,8 +713,13 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         if M == 0:
             return self.__class__(new_shape)
 
-        indices = np.arange(start, stop, step)
-        row_nnz = self.indptr[indices + 1] - self.indptr[indices]
+        # Work out what slices are needed for `row_nnz`
+        start2 = None if start == -1 else start
+        stop2 = None if stop == -1 else stop
+        start3 = None if start2 is None else start2 + 1
+        stop3 = None if stop2 is None else stop2 + 1
+
+        row_nnz = self.indptr[start3:stop3:step] - self.indptr[start2:stop2:step]
         idx_dtype = self.indices.dtype
         res_indptr = np.zeros(M+1, dtype=idx_dtype)
         np.cumsum(row_nnz, out=res_indptr[1:])

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -714,12 +714,14 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             return self.__class__(new_shape)
 
         # Work out what slices are needed for `row_nnz`
-        start2 = None if start == -1 else start
-        stop2 = None if stop == -1 else stop
-        start3 = None if start2 is None else start2 + 1
-        stop3 = None if stop2 is None else stop2 + 1
+        # start,stop can be -1, only if step is negative
+        if stop == -1 and start >= 0:
+            idx0 = slice(start, None, step)
+        else:
+            idx0 = slice(start, stop, step)
+        idx1 = slice(start + 1, stop + 1, step)
 
-        row_nnz = self.indptr[start3:stop3:step] - self.indptr[start2:stop2:step]
+        row_nnz = self.indptr[idx1] - self.indptr[idx0]
         idx_dtype = self.indices.dtype
         res_indptr = np.zeros(M+1, dtype=idx_dtype)
         np.cumsum(row_nnz, out=res_indptr[1:])

--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -310,7 +310,7 @@ class csr_matrix(_cs_matrix):
             row_data = row_data[::-1]
             row_indices = abs(row_indices[::-1])
 
-        shape = (1, int(np.ceil(float(stop - start) / stride)))
+        shape = (1, max(0, int(np.ceil(float(stop - start) / stride))))
         return csr_matrix((row_data, row_indices, row_indptr), shape=shape,
                           dtype=self.dtype, copy=False)
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -21,6 +21,7 @@ import contextlib
 import functools
 import operator
 import platform
+import itertools
 import sys
 from distutils.version import LooseVersion
 
@@ -2474,6 +2475,19 @@ class _TestSlicing:
         for i, a in enumerate(slices):
             for j, b in enumerate(slices):
                 check_2(a, b)
+
+        # Check out of bounds etc. systematically
+        extra_slices = []
+        for a, b, c in itertools.product(*([(None, 0, 1, 2, 5, 15,
+                                             -1, -2, 5, -15)]*3)):
+            if c == 0:
+                continue
+            extra_slices.append(slice(a, b, c))
+
+        for a in extra_slices:
+            check_2(a, a)
+            check_2(a, -2)
+            check_2(-2, a)
 
     def test_ellipsis_slicing(self):
         b = asmatrix(arange(50).reshape(5,10))


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
See https://github.com/scipy/scipy/issues/14321

#### What does this implement/fix?
<!--Please explain your changes.-->
Remove unnecessary use of `np.diff`

Only a subset of the result of the diff was used which resulted in
poor scaling with very many rows.

#### Additional information
<!--Any additional information you think is important.-->