### PR TITLE
MAINT: Removed redifinition of trace1 in spatial/qhull

### DIFF
--- a/scipy/spatial/qhull_misc.c
+++ b/scipy/spatial/qhull_misc.c
@@ -1,6 +1,5 @@
 #include "qhull_src/src/qhull_ra.h"
 
-#define trace1(args) {}
 
 /* This is a patched version of qhull_src/src/user_r.c:qh_new_qhull,
    with an additional "feaspoint" argument.


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Refer https://github.com/rgommers/scipy/pull/28#issuecomment-871204576

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->

cc @rgommers 