### PR TITLE
BUG: medfilt can access beyond the end of an array

### DIFF
--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1062,6 +1062,17 @@ class TestMedFilt:
         assert_equal(signal.medfilt(in_typed).dtype, dtype)
         assert_equal(signal.medfilt2d(in_typed).dtype, dtype)
 
+    @pytest.mark.parametrize('dtype', [np.bool_, np.cfloat, np.cdouble,
+                                       np.clongdouble, np.float16,])
+    def test_invalid_dtypes(self, dtype):
+        in_typed = np.array(self.IN, dtype=dtype)
+        with pytest.raises(ValueError, match="order_filterND"):
+            signal.medfilt(in_typed)
+
+        with pytest.raises(ValueError, match="order_filterND"):
+            signal.medfilt2d(in_typed)
+
+
     def test_none(self):
         # gh-1651, trac #1124. Ensure this does not segfault.
         with pytest.warns(UserWarning):


### PR DESCRIPTION
#### Reference issue
Should fix #14273 (don't have a local windows build to confirm though)

#### What does this implement/fix?
`compare_functions` is an array of size `NPY_NTYPES`. NumPy has since added new type codes for datetime, timedelta and float16. For these three types the code would access beyond the end of the array. If that static data happens to contain zeroes we are okay, if not it may interpret some random data as a function pointer and call it as if it were the comparison function.