### PR TITLE
MAINT: _lib: add __dealloc__ to MessageStream

### DIFF
--- a/scipy/_lib/messagestream.pxd
+++ b/scipy/_lib/messagestream.pxd
@@ -8,3 +8,4 @@ cdef class MessageStream:
     cdef bint _removed
     cdef size_t _memstream_size
     cdef char *_memstream_ptr
+    cpdef close(self)

--- a/scipy/_lib/messagestream.pyx
+++ b/scipy/_lib/messagestream.pyx
@@ -88,3 +88,15 @@ cdef class MessageStream:
         if not self._removed:
             stdio.remove(self._filename)
             self._removed = 1
+
+    def __dealloc__(self):
+        if self.handle != NULL:
+            stdio.fclose(self.handle)
+            self.handle = NULL
+
+        if self._memstream_ptr != NULL:
+            stdlib.free(self._memstream_ptr)
+            self._memstream_ptr = NULL
+
+        if not self._removed:
+            stdio.remove(self._filename)

--- a/scipy/_lib/messagestream.pyx
+++ b/scipy/_lib/messagestream.pyx
@@ -40,7 +40,7 @@ cdef class MessageStream:
         if stdio.remove(self._filename) == 0:
             self._removed = 1
 
-    def __del__(self):
+    def __dealloc__(self):
         self.close()
 
     def get(self):
@@ -76,7 +76,7 @@ cdef class MessageStream:
     def clear(self):
         stdio.rewind(self.handle)
 
-    def close(self):
+    cpdef close(self):
         if self.handle != NULL:
             stdio.fclose(self.handle)
             self.handle = NULL
@@ -88,15 +88,3 @@ cdef class MessageStream:
         if not self._removed:
             stdio.remove(self._filename)
             self._removed = 1
-
-    def __dealloc__(self):
-        if self.handle != NULL:
-            stdio.fclose(self.handle)
-            self.handle = NULL
-
-        if self._memstream_ptr != NULL:
-            stdlib.free(self._memstream_ptr)
-            self._memstream_ptr = NULL
-
-        if not self._removed:
-            stdio.remove(self._filename)

--- a/scipy/_lib/messagestream.pyx
+++ b/scipy/_lib/messagestream.pyx
@@ -17,7 +17,7 @@ cdef class MessageStream:
     to a temporary file, residing in memory (if possible) or on disk.
     """
 
-    def __init__(self):
+    def __cinit__(self):
         # Try first in-memory files, if available
         self._memstream_ptr = NULL
         self.handle = messagestream_open_memstream(&self._memstream_ptr,


### PR DESCRIPTION
#### Reference issue

N/A

#### What does this implement/fix?

Extension class `MessageStream` doesn't implement a `__dealloc__` method which is required to free C level structures once the object goes out of scope. It is possible to do so with a call to the `close()` method but it is very inconvenient to call it every time one doesn't need the message stream anymore. Also, there could be a memory leak if one forgot to call the `close` method. Using `__dealloc__`, we can tell Cython to manage memory automatically for us.

#### Additional information

This is not in the public API but I was planning to use this in #14215 for error handling and it would help if this method was present.