### PR TITLE
BUG: fix `stats.binned_statistic_dd` issue with values close to bin edge

### DIFF
--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -737,8 +737,9 @@ def _bin_numbers(sample, nbin, edges, dedges):
             raise ValueError('The smallest edge difference is numerically 0.')
         decimal = int(-np.log10(dedges_min)) + 6
         # Find which points are on the rightmost edge.
-        on_edge = np.where(np.around(sample[:, i], decimal) ==
-                           np.around(edges[i][-1], decimal))[0]
+        on_edge = np.where((sample[:, i] >= edges[i][-1]) &
+                           (np.around(sample[:, i], decimal) ==
+                            np.around(edges[i][-1], decimal)))[0]
         # Shift these points one bin to the left.
         sampBin[i][on_edge] -= 1
 

--- a/scipy/stats/tests/test_binned_statistic.py
+++ b/scipy/stats/tests/test_binned_statistic.py
@@ -515,3 +515,18 @@ class TestBinnedStatistic:
         X = np.array([0, 0.42358226], dtype=np.float32)
         stat, _, _ = binned_statistic(X, None, 'count', bins=5)
         assert_allclose(stat, np.array([1, 0, 0, 0, 1], dtype=np.float64))
+
+    def test_gh14332(self):
+        # Test the wrong output when the `sample` is close to bin edge
+        x = []
+        size = 20
+        for i in range(size):
+            x += [1-0.1**i]
+ 
+        bins = np.linspace(0,1,11)
+        sum1, edges1, bc = binned_statistic_dd(x, np.ones(len(x)),
+                                               bins=[bins], statistic='sum')
+        sum2, edges2 = np.histogram(x, bins=bins)
+
+        assert_allclose(sum1, sum2)
+        assert_allclose(edges1[0], edges2)


### PR DESCRIPTION
#### What does this implement/fix?
Fix https://github.com/scipy/scipy/issues/14332.

A potential concern: when the number is larger than 0.999999999999999999, `np.digitalize()` will put it to bin `10` rather than `9`. But this would not be a problem because it will also satisfy the condition `(sample[:, i] >= edges[i][-1]) `, namely, 0.999999999999999999>=1, then this point will be shifted from bin 10 to bin 9 later.
```
import numpy as np
arr = []
size = 8
for i in range(size):
    arr += [1-0.1**i]
bins = np.linspace(0,1,10)
a = 0.99999999999999999
arr +=[a]
print(a<1,a==1,a>1,a>=1)
print(np.digitize(arr,bins)) # [ 1  9  9  9  9  9  9  9 10]
```
