### PR TITLE
TST: fix `sparse.linalg.spsolve` test with singular input

### DIFF
--- a/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
@@ -211,10 +211,12 @@ class TestLinsolve:
         b = np.arange(20)
 
         try:
-            # should either raise a runtimeerror or return value
-            # appropriate for singular input
-            x = spsolve(A, b)
-            assert_(not np.isfinite(x).any())
+            # should either raise a runtime error or return value
+            # appropriate for singular input (which yields the warning)
+            with suppress_warnings() as sup:
+                sup.filter(MatrixRankWarning, "Matrix is exactly singular")
+                x = spsolve(A, b)
+            assert not np.isfinite(x).any()
         except RuntimeError:
             pass
 


### PR DESCRIPTION
That test triggered a RuntimeError, but with the Meson build it improves
to give a MatrixRankWarning instead. Because that wasn't silenced, the
test then failed. This commit fixes it.

Warning before the fix (xref gh-3312):
```
____________________________________ TestLinsolve.test_singular_gh_3312 _____________________________________
lib/python3.9/site-packages/scipy/sparse/linalg/tests/test_linsolve.py:216: in test_singular_gh_3312
    x = spsolve(A, b)
        A          = <20x20 sparse matrix of type '<class 'numpy.float64'>'
        with 4 stored elements in Compressed Sparse Column format>
        b          = array([ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,
       17, 18, 19])
        ij         = array([[17,  0],
       [17,  6],
       [17, 12],
       [10, 13]], dtype=int32)
        self       = <scipy.sparse.linalg.tests.test_linsolve.TestLinsolve object at 0x7fa2006ed4c0>
        v          = array([0.284213  , 0.94933781, 0.15767017, 0.38797296])
lib/python3.9/site-packages/scipy/sparse/linalg/dsolve/linsolve.py:206: in spsolve
    warn("Matrix is exactly singular", MatrixRankWarning)
E   scipy.sparse.linalg.dsolve.linsolve.MatrixRankWarning: Matrix is exactly singular
        A          = <20x20 sparse matrix of type '<class 'numpy.float64'>'
        with 4 stored elements in Compressed Sparse Column format>
        M          = 20
        N          = 20
        b          = array([ 0.,  1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9., 10., 11., 12.,
       13., 14., 15., 16., 17., 18., 19.])
        b_is_sparse = False
        b_is_vector = True
        flag       = 1
        info       = 3
        options    = {'ColPerm': None}
        permc_spec = None
        result_dtype = dtype('float64')
        use_umfpack = False
        x          = array([ 0.,  1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9., 10., 11., 12.,
       13., 14., 15., 16., 17., 18., 19.])
========================================== short test summary info ==========================================
FAILED lib/python3.9/site-packages/scipy/sparse/linalg/tests/test_linsolve.py::TestLinsolve::test_singular_gh_3312
```

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->