### PR TITLE
ENH: make `savgol_coeffs`, `savgol_filter` work for even window length

### DIFF
--- a/scipy/signal/_savitzky_golay.py
+++ b/scipy/signal/_savitzky_golay.py
@@ -13,7 +13,6 @@ def savgol_coeffs(window_length, polyorder, deriv=0, delta=1.0, pos=None,
     ----------
     window_length : int
         The length of the filter window (i.e., the number of coefficients).
-        `window_length` must be an odd positive integer.
     polyorder : int
         The order of the polynomial used to fit the samples.
         `polyorder` must be less than `window_length`.
@@ -44,6 +43,9 @@ def savgol_coeffs(window_length, polyorder, deriv=0, delta=1.0, pos=None,
     A. Savitzky, M. J. E. Golay, Smoothing and Differentiation of Data by
     Simplified Least Squares Procedures. Analytical Chemistry, 1964, 36 (8),
     pp 1627-1639.
+    Jianwen Luo, Kui Ying, and Jing Bai. 2005. Savitzky-Golay smoothing and
+    differentiation filter for even number data. Signal Process.
+    85, 7 (July 2005), 1429-1434. 
 
     See Also
     --------
@@ -69,6 +71,8 @@ def savgol_coeffs(window_length, polyorder, deriv=0, delta=1.0, pos=None,
     array([ 0.25714286,  0.37142857,  0.34285714,  0.17142857, -0.14285714])
     >>> savgol_coeffs(5, 2, pos=3, use='dot')
     array([-0.14285714,  0.17142857,  0.34285714,  0.37142857,  0.25714286])
+    >>> savgol_coeffs(4, 2, pos=3, deriv=1, use='dot')
+    array([0.45,  -0.85,  -0.65,  1.05])
 
     `x` contains data from the parabola x = t**2, sampled at
     t = -1, 0, 1, 2, 3.  `c` holds the coefficients that will compute the
@@ -98,11 +102,11 @@ def savgol_coeffs(window_length, polyorder, deriv=0, delta=1.0, pos=None,
 
     halflen, rem = divmod(window_length, 2)
 
-    if rem == 0:
-        raise ValueError("window_length must be odd.")
-
     if pos is None:
-        pos = halflen
+        if rem == 0:
+            pos = halflen - 0.5
+        else:
+            pos = halflen
 
     if not (0 <= pos < window_length):
         raise ValueError("pos must be nonnegative and less than "
@@ -120,6 +124,7 @@ def savgol_coeffs(window_length, polyorder, deriv=0, delta=1.0, pos=None,
     # from 0 to polyorder. (That is, A is a vandermonde matrix, but not
     # necessarily square.)
     x = np.arange(-pos, window_length - pos, dtype=float)
+
     if use == "conv":
         # Reverse so that result can be used in a convolution.
         x = x[::-1]
@@ -237,8 +242,8 @@ def savgol_filter(x, window_length, polyorder, deriv=0, delta=1.0,
         before filtering.
     window_length : int
         The length of the filter window (i.e., the number of coefficients).
-        `window_length` must be a positive odd integer. If `mode` is 'interp',
-        `window_length` must be less than or equal to the size of `x`.
+        If `mode` is 'interp', `window_length` must be less than or equal 
+        to the size of `x`.
     polyorder : int
         The order of the polynomial used to fit the samples.
         `polyorder` must be less than `window_length`.

--- a/scipy/signal/_savitzky_golay.py
+++ b/scipy/signal/_savitzky_golay.py
@@ -45,7 +45,7 @@ def savgol_coeffs(window_length, polyorder, deriv=0, delta=1.0, pos=None,
     pp 1627-1639.
     Jianwen Luo, Kui Ying, and Jing Bai. 2005. Savitzky-Golay smoothing and
     differentiation filter for even number data. Signal Process.
-    85, 7 (July 2005), 1429-1434. 
+    85, 7 (July 2005), 1429-1434.
 
     See Also
     --------
@@ -242,7 +242,7 @@ def savgol_filter(x, window_length, polyorder, deriv=0, delta=1.0,
         before filtering.
     window_length : int
         The length of the filter window (i.e., the number of coefficients).
-        If `mode` is 'interp', `window_length` must be less than or equal 
+        If `mode` is 'interp', `window_length` must be less than or equal
         to the size of `x`.
     polyorder : int
         The order of the polynomial used to fit the samples.

--- a/scipy/signal/tests/test_savitzky_golay.py
+++ b/scipy/signal/tests/test_savitzky_golay.py
@@ -157,6 +157,43 @@ def test_sg_coeffs_large():
     coeffs1 = savgol_coeffs(31, 9, deriv=1)
     assert_array_almost_equal(coeffs1, -coeffs1[::-1])
 
+#--------------------------------------------------------------------
+# savgol_coeffs tests for even window length
+#--------------------------------------------------------------------
+
+def test_sg_coeffs_even_window_length():
+    # Simple case - deriv=0, polyorder=0, 1
+    window_lengths = [4, 6, 8, 10, 12, 14, 16]
+    for length in window_lengths:
+        h_p_d = savgol_coeffs(length, 0, 0)
+        assert_allclose(h_p_d, 1/length)
+    
+    # Verify with closed forms
+    # deriv=1, polyorder=1, 2
+    def h_p_d_closed_form_1(k, m):
+        return 6*(k - 0.5)/((2*m + 1)*m*(2*m - 1))
+    
+    # deriv=2, polyorder=2
+    def h_p_d_closed_form_2(k, m):
+        numer = 15*(-4*m**2 + 1 + 12*(k - 0.5)**2)
+        denom = 4*(2*m + 1)*(m + 1)*m*(m - 1)*(2*m - 1)
+        return numer/denom
+    
+    for length in window_lengths:
+        m = length//2
+        expected_output = [h_p_d_closed_form_1(k, m)
+                            for k in range(-m + 1, m + 1)][::-1]
+        actual_output = savgol_coeffs(length, 1, 1)
+        assert_allclose(expected_output, actual_output)
+        actual_output = savgol_coeffs(length, 2, 1)
+        assert_allclose(expected_output, actual_output)
+
+        expected_output = [h_p_d_closed_form_2(k, m)
+                            for k in range(-m + 1, m + 1)][::-1]
+        actual_output = savgol_coeffs(length, 2, 2)
+        assert_allclose(expected_output, actual_output)
+        actual_output = savgol_coeffs(length, 3, 2)
+        assert_allclose(expected_output, actual_output)
 
 #--------------------------------------------------------------------
 # savgol_filter tests

--- a/scipy/signal/tests/test_savitzky_golay.py
+++ b/scipy/signal/tests/test_savitzky_golay.py
@@ -157,9 +157,10 @@ def test_sg_coeffs_large():
     coeffs1 = savgol_coeffs(31, 9, deriv=1)
     assert_array_almost_equal(coeffs1, -coeffs1[::-1])
 
-#--------------------------------------------------------------------
+# --------------------------------------------------------------------
 # savgol_coeffs tests for even window length
-#--------------------------------------------------------------------
+# --------------------------------------------------------------------
+
 
 def test_sg_coeffs_even_window_length():
     # Simple case - deriv=0, polyorder=0, 1
@@ -167,29 +168,29 @@ def test_sg_coeffs_even_window_length():
     for length in window_lengths:
         h_p_d = savgol_coeffs(length, 0, 0)
         assert_allclose(h_p_d, 1/length)
-    
+
     # Verify with closed forms
     # deriv=1, polyorder=1, 2
     def h_p_d_closed_form_1(k, m):
         return 6*(k - 0.5)/((2*m + 1)*m*(2*m - 1))
-    
+
     # deriv=2, polyorder=2
     def h_p_d_closed_form_2(k, m):
         numer = 15*(-4*m**2 + 1 + 12*(k - 0.5)**2)
         denom = 4*(2*m + 1)*(m + 1)*m*(m - 1)*(2*m - 1)
         return numer/denom
-    
+
     for length in window_lengths:
         m = length//2
         expected_output = [h_p_d_closed_form_1(k, m)
-                            for k in range(-m + 1, m + 1)][::-1]
+                           for k in range(-m + 1, m + 1)][::-1]
         actual_output = savgol_coeffs(length, 1, 1)
         assert_allclose(expected_output, actual_output)
         actual_output = savgol_coeffs(length, 2, 1)
         assert_allclose(expected_output, actual_output)
 
         expected_output = [h_p_d_closed_form_2(k, m)
-                            for k in range(-m + 1, m + 1)][::-1]
+                           for k in range(-m + 1, m + 1)][::-1]
         actual_output = savgol_coeffs(length, 2, 2)
         assert_allclose(expected_output, actual_output)
         actual_output = savgol_coeffs(length, 3, 2)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes https://github.com/scipy/scipy/issues/13898

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->

Please let me know if there are any examples to test `savgol_filter` on even window lengths.
I will updated documentation once I complete testing `savgol_filter`. `savgol_coeffs` work correctly with even window length.

Reference - https://www.researchgate.net/publication/220227041_Savitzky-Golay_smoothing_and_differentiation_filter_for_even_number_data
