### PR TITLE
ENH: scipy.interpolate b-splines (design_matrix)

### DIFF
--- a/scipy/interpolate/_bspl.pyx
+++ b/scipy/interpolate/_bspl.pyx
@@ -419,8 +419,7 @@ def _norm_eq_lsq(const double[::1] x,
 def _make_design_matrix(const double[::1] x,
                 const double[::1] t,
                 int k,
-                kind='dense',
-                bint extrapolate=False):
+                kind):
     '''
     Returns a design matrix for BSpline object in "dense" or "CSR" formats.
     
@@ -432,38 +431,22 @@ def _make_design_matrix(const double[::1] x,
         Vector of knots.
     k : int
         The maximum degree of spline.
-    kind : "CSR" or "dense", optional
-        Default is ``"dense"`` .
-        * ``"dense"`` : Returns dense matrix.
+    kind : "CSR", optional
+        Default is ``"CSR"`` .
         * ``"CSR"`` : Returns sparse matrix in CSR.
-    extrapolate : int, optional
-        Whether to extrapolate to ouf-of-bounds points, or to return NaNs.
-        Default is False.  
+
     Returns
     -------
-    2-D array, shape(n, nt - k - 1) or sparse matrix in CSR.
+    Sparse matrix in CSR.
     '''
     n = len(x)
     nt = len(t)
-    if kind == 'dense':
-        data = np.zeros((n, nt - k - 1), dtype=float)
-        for i in range(n):
-            ind = find_interval(t, k, x[i], k - 1, extrapolate)
-            vals = evaluate_all_bspl(t, k, x[i], ind)
-            # special check due to periodic boundary conditions:
-            # the shape of vector of B-splines evaluated at ``x[-1]``
-            # should be reduced by 1
-            if (ind == nt - k - 1):
-                data[i, ind - k: ind + 1] = vals[:-1]
-            else:
-                data[i, ind - k: ind + 1] = vals
-        return data
-    elif kind == 'CSR':
+    if kind == 'CSR':
         data = np.zeros(n * (k + 1), dtype=float)
         row_ind = np.zeros(n * (k + 1), dtype=int)
         col_ind = np.zeros(n * (k + 1), dtype=int)
         for i in range(n):
-            ind = find_interval(t, k, x[i], k - 1, extrapolate)
+            ind = find_interval(t, k, x[i], k - 1, 0)
             vals = evaluate_all_bspl(t, k, x[i], ind)
             # special check due to periodic boundary conditions:
             # the shape of vector of B-splines evaluated at ``x[-1]``
@@ -478,4 +461,4 @@ def _make_design_matrix(const double[::1] x,
                 col_ind[(k + 1) * i : (k + 1) * (i + 1)] = [i for i in range(ind - k, ind + 1)]
         return csr_matrix((data, (row_ind, col_ind)), [n, nt - k - 1])
     else:
-        raise ValueError(f"Unknown ``kind``: {kind}")                        
+        raise ValueError(f"Unknown ``kind``: {kind}")              

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -298,12 +298,12 @@ class BSpline:
         c = np.zeros_like(t)
         c[k] = 1.
         return cls.construct_fast(t, c, k, extrapolate)
-    
+
     @classmethod
     def design_matrix(cls, x, t, k):
         """
         Returns a design matrix in CSR format.
-        
+
         Parameters
         ----------
         x : array_like, shape (n,)
@@ -312,7 +312,7 @@ class BSpline:
             Sorted 1D array of knots.
         k : int
             B-spline degree.
- 
+
         Returns
         -------
         design_matrix : `csr_matrix` object
@@ -362,20 +362,22 @@ class BSpline:
         In each row of the design matrix all the basis elemets are evaluated
         at the certain point (first row - x[0], ..., last row - x[-1]).
 
-        `nt` is a lenght of the vector of knots: as far as there are `nt - k - 1`
-        basis elements, `nt` should be not less than `k + 2` to have at least one
-        basis element.
+        `nt` is a lenght of the vector of knots: as far as there are
+        `nt - k - 1` basis elements, `nt` should be not less than `k + 2`
+        to have at least one basis element.
 
         Out of bounds `x` raises a ValueError.
         """
         x = _as_float_array(x, True)
         t = _as_float_array(t, True)
-        
+
         if t.ndim != 1 or np.any(t[1:] < t[:-1]):
-            raise ValueError(f"Expect t to be a 1-D sorted array_like, but got t={t}.")
-        # There are `nt - k - 1` basis elemets in a BSpline built on the vector
-        # of knots with length `nt`, so to have at least one basis element we need
-        # to have at least `k + 2` elements in the vector of knots.
+            raise ValueError(f"Expect t to be a 1-D sorted array_like, but "
+                                "got t={t}.")
+        # There are `nt - k - 1` basis elemets in a BSpline built on the
+        # vector of knots with length `nt`, so to have at least one basis
+        # element we need to have at least `k + 2` elements in the vector
+        # of knots.
         if len(t) <= k + 1:
             raise ValueError(f"Length t is not enough for k={k}.")
         if (min(x) < t[k]) or (max(x) > t[-k]):

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -302,13 +302,13 @@ class BSpline:
     @classmethod
     def design_matrix(cls, x, t, k):
         """
-        Returns a design matrix for BSpline object in "dense" or "CSR" formats.
+        Returns a design matrix in CSR format.
         
         Parameters
         ----------
         x : array_like, shape (n,)
             Points to evaluate the spline at.
-        t : array_like, shape (n,)
+        t : array_like, shape (nt,)
             Sorted 1D array of knots.
         k : int
             B-spline degree.
@@ -343,7 +343,7 @@ class BSpline:
         [0. , 0. , 0.5, 0.5, 0. ],
         [0. , 0. , 0. , 0.5, 0.5]]
 
-        Comparing with method introduced in gh-6730
+        This result is equivalent to ones created in the sparse format
         >>> c = np.eye(len(t) - k - 1)
         >>> design_matrix_gh = BSpline(t, c, k)(x)
         >>> np.allclose(design_matrix, design_matrix_gh, atol=1e-14)
@@ -352,6 +352,12 @@ class BSpline:
         Notes
         -----
         versionadded:: 1.8.0
+
+        In each row of the design matrix all the basis elemets are evaluated
+        at the certain point (first row - x[0], ..., last row - x[-1]).
+
+        For now extrapolate option is not added (if `x` is out of boundaries
+        ValueError is raised).
         """
         x = _as_float_array(x, True)
         t = _as_float_array(t, True)

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -373,7 +373,7 @@ class BSpline:
 
         if t.ndim != 1 or np.any(t[1:] < t[:-1]):
             raise ValueError(f"Expect t to be a 1-D sorted array_like, but "
-                                "got t={t}.")
+                             f"got t={t}.")
         # There are `nt - k - 1` basis elemets in a BSpline built on the
         # vector of knots with length `nt`, so to have at least one basis
         # element we need to have at least `k + 2` elements in the vector

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -315,11 +315,15 @@ class BSpline:
  
         Returns
         -------
-        Sparse matrix in CSR format.
+        design_matrix : `csr_matrix` object
+            Sparse matrix in CSR format where in each row all the basis
+            elemets are evaluated at the certain point (first row - x[0],
+            ..., last row - x[-1]).
 
         Examples
         --------
         Construct a design matrix for a B-spline
+
         >>> from scipy.interpolate import make_interp_spline, BSpline
         >>> x = np.linspace(0, np.pi * 2, 4)
         >>> y = np.sin(x)
@@ -333,6 +337,7 @@ class BSpline:
         [0.        , 0.        , 0.        , 1.        ]]
 
         Construct a design matrix for some vector of knots
+
         >>> k = 2
         >>> t = [-1, 0, 1, 2, 3, 4, 5, 6]
         >>> x = [1, 2, 3, 4]
@@ -343,7 +348,8 @@ class BSpline:
         [0. , 0. , 0.5, 0.5, 0. ],
         [0. , 0. , 0. , 0.5, 0.5]]
 
-        This result is equivalent to ones created in the sparse format
+        This result is equivalent to the one created in the sparse format
+
         >>> c = np.eye(len(t) - k - 1)
         >>> design_matrix_gh = BSpline(t, c, k)(x)
         >>> np.allclose(design_matrix, design_matrix_gh, atol=1e-14)
@@ -351,23 +357,29 @@ class BSpline:
 
         Notes
         -----
-        versionadded:: 1.8.0
+        .. versionadded:: 1.8.0
 
         In each row of the design matrix all the basis elemets are evaluated
         at the certain point (first row - x[0], ..., last row - x[-1]).
 
-        For now extrapolate option is not added (if `x` is out of boundaries
-        ValueError is raised).
+        `nt` is a lenght of the vector of knots: as far as there are `nt - k - 1`
+        basis elements, `nt` should be not less than `k + 2` to have at least one
+        basis element.
+
+        Out of bounds `x` raises a ValueError.
         """
         x = _as_float_array(x, True)
         t = _as_float_array(t, True)
         
         if t.ndim != 1 or np.any(t[1:] < t[:-1]):
-            raise ValueError("Expect t to be a 1-D sorted array_like.")
-        if len(t) < k:
+            raise ValueError(f"Expect t to be a 1-D sorted array_like, but got t={t}.")
+        # There are `nt - k - 1` basis elemets in a BSpline built on the vector
+        # of knots with length `nt`, so to have at least one basis element we need
+        # to have at least `k + 2` elements in the vector of knots.
+        if len(t) <= k + 1:
             raise ValueError(f"Length t is not enough for k={k}.")
         if (min(x) < t[k]) or (max(x) > t[-k]):
-            raise ValueError('Out of bounds w/ x = %s.' % x)
+            raise ValueError(f'Out of bounds w/ x = {x}.')
 
         return _bspl._make_design_matrix(x, t, k)
 

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -300,25 +300,22 @@ class BSpline:
         return cls.construct_fast(t, c, k, extrapolate)
     
     @classmethod
-    def design_matrix(cls, x, t, k, kind="CSR"):
-        '''
+    def design_matrix(cls, x, t, k):
+        """
         Returns a design matrix for BSpline object in "dense" or "CSR" formats.
         
         Parameters
         ----------
-        x : 1-D array, shape(n,)
-            Values of x - coordinate of a given set of points (n >= 1).   
-        t : 1-D array, shape(nt,)
-            Vector of knots.
+        x : array_like, shape (n,)
+            Points to evaluate the spline at.
+        t : array_like, shape (n,)
+            Sorted 1D array of knots.
         k : int
-            The maximum degree of spline.
-        kind : "CSR", optional
-            Default is ``"CSR"`` .
-            * ``"CSR"`` : Returns sparse matrix in CSR.
+            B-spline degree.
  
         Returns
         -------
-        Sparse matrix in CSR.
+        Sparse matrix in CSR format.
 
         Examples
         --------
@@ -328,7 +325,7 @@ class BSpline:
         >>> y = np.sin(x)
         >>> k = 3
         >>> bspl = make_interp_spline(x, y, k=k)
-        >>> design_matrix = BSpline.design_matrix(x, bspl.t, k, kind="CSR")
+        >>> design_matrix = bspl.design_matrix(x, bspl.t, k)
         >>> design_matrix.toarray()
         [[1.        , 0.        , 0.        , 0.        ],
         [0.2962963 , 0.44444444, 0.22222222, 0.03703704],
@@ -339,7 +336,7 @@ class BSpline:
         >>> k = 2
         >>> t = [-1, 0, 1, 2, 3, 4, 5, 6]
         >>> x = [1, 2, 3, 4]
-        >>> design_matrix = BSpline.design_matrix(x, t, k, kind="CSR").toarray()
+        >>> design_matrix = BSpline.design_matrix(x, t, k).toarray()
         >>> design_matrix
         [[0.5, 0.5, 0. , 0. , 0. ],
         [0. , 0.5, 0.5, 0. , 0. ],
@@ -355,18 +352,18 @@ class BSpline:
         Notes
         -----
         versionadded:: 1.8.0
-        '''
+        """
         x = _as_float_array(x, True)
         t = _as_float_array(t, True)
         
         if t.ndim != 1 or np.any(t[1:] < t[:-1]):
             raise ValueError("Expect t to be a 1-D sorted array_like.")
-        if  len(t) < k:
+        if len(t) < k:
             raise ValueError(f"Length t is not enough for k={k}.")
         if (min(x) < t[k]) or (max(x) > t[-k]):
             raise ValueError('Out of bounds w/ x = %s.' % x)
 
-        return _bspl._make_design_matrix(x, t, k, kind)
+        return _bspl._make_design_matrix(x, t, k)
 
     def __call__(self, x, nu=0, extrapolate=None):
         """

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -442,6 +442,7 @@ class TestBSpline:
             To avoid repetition of the code the following function is
             provided.
             '''
+            np.random.seed(1234)
             x = np.sort(np.random.random_sample(n) * 40 - 20)
             y = np.random.random_sample(n) * 40 - 20
             if bc_type == "periodic":
@@ -457,7 +458,6 @@ class TestBSpline:
             assert_allclose(des_matr_csr @ bspl.c, y, atol=1e-14)
             assert_allclose(des_matr_def, des_matr_csr, atol=1e-14)
 
-        np.random.seed(1234)
         # "clamped" and "natural" work only with `k = 3`
         n = 11
         k = 3
@@ -497,7 +497,8 @@ class TestBSpline:
         x = np.sort(np.random.random_sample(n) * 40 - 20)
         y = np.random.random_sample(n) * 40 - 20
         bspl = make_interp_spline(x, y, k=k)
-        # invalid vector of knots
+        # invalid vector of knots (should a 1D non-descending array_like)
+        # here the actual vector of knots is reversed, so it is invalid
         with assert_raises(ValueError):
             des_test = BSpline.design_matrix(x, bspl.t[::-1], k)
         k = 2

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -505,7 +505,7 @@ class TestBSpline:
         # invalid vector of knots (should be a 1D non-descending array)
         # here the actual vector of knots is reversed, so it is invalid
         with assert_raises(ValueError):
-            des_test = BSpline.design_matrix(x, bspl.t[::-1], k)
+            BSpline.design_matrix(x, bspl.t[::-1], k)
         k = 2
         t = [0., 1., 2., 3., 4., 5.]
         x = [1., 2., 3., 4.]

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -453,8 +453,7 @@ class TestBSpline:
             des_matr_def = BSpline(bspl.t, c, k)(x)
             des_matr_csr = BSpline.design_matrix(x, 
                                                  bspl.t,
-                                                 k, 
-                                                 kind="CSR").toarray()
+                                                 k).toarray()
             assert_allclose(des_matr_csr @ bspl.c, y, atol=1e-14)
             assert_allclose(des_matr_def, des_matr_csr, atol=1e-14)
 
@@ -488,8 +487,7 @@ class TestBSpline:
             yc = y[:i]
             des_matr_csr = BSpline.design_matrix(xc,
                                                  bspl.t,
-                                                 k, 
-                                                 kind='CSR').toarray()
+                                                 k).toarray()
             assert_allclose(des_matr_csr @ bspl.c, yc, atol=1e-14)
         
     def test_design_matrix_asserts(self):
@@ -499,9 +497,6 @@ class TestBSpline:
         x = np.sort(np.random.random_sample(n) * 40 - 20)
         y = np.random.random_sample(n) * 40 - 20
         bspl = make_interp_spline(x, y, k=k)
-        # unknown `kind`
-        with assert_raises(ValueError):
-            des_test = BSpline.design_matrix(x, bspl.t, k, kind="Some kind")
         # invalid vector of knots
         with assert_raises(ValueError):
             des_test = BSpline.design_matrix(x, bspl.t[::-1], k)

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -473,7 +473,7 @@ class TestBSpline:
         for k in range(2, 7):
             run_design_matrix_tests(n, k, "periodic")
     
-    def test_design_matrix_x_shapes(self):
+    def test_design_matrix_x_t_shapes(self):
         # test for different `x` shapes
         np.random.seed(1234)
         n = 10
@@ -490,6 +490,11 @@ class TestBSpline:
                                                  k).toarray()
             assert_allclose(des_matr_csr @ bspl.c, yc, atol=1e-14)
         
+        # test for minimal possible `t` shape
+        t = [0., 1., 1., 1., 2.]
+        des_matr = BSpline.design_matrix(1., t, 3).toarray()
+        assert_allclose(des_matr, [[1.]], atol=1e-14)
+        
     def test_design_matrix_asserts(self):
         np.random.seed(1234)
         n = 10
@@ -497,7 +502,7 @@ class TestBSpline:
         x = np.sort(np.random.random_sample(n) * 40 - 20)
         y = np.random.random_sample(n) * 40 - 20
         bspl = make_interp_spline(x, y, k=k)
-        # invalid vector of knots (should a 1D non-descending array_like)
+        # invalid vector of knots (should be a 1D non-descending array)
         # here the actual vector of knots is reversed, so it is invalid
         with assert_raises(ValueError):
             des_test = BSpline.design_matrix(x, bspl.t[::-1], k)

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -429,7 +429,7 @@ class TestBSpline:
         spl0 = BSpline(t, c[0], k)
         spl1 = BSpline(t, c[1], k)
         assert_equal(spl(2.5), [spl0(2.5), spl1(2.5)])
-    
+
     def test_design_matrix_bc_types(self):
         '''
         Splines with different boundary conditions are built on different
@@ -447,12 +447,12 @@ class TestBSpline:
             y = np.random.random_sample(n) * 40 - 20
             if bc_type == "periodic":
                 y[0] = y[-1]
-       
+
             bspl = make_interp_spline(x, y, k=k, bc_type=bc_type)
 
             c = np.eye(len(bspl.t) - k - 1)
             des_matr_def = BSpline(bspl.t, c, k)(x)
-            des_matr_csr = BSpline.design_matrix(x, 
+            des_matr_csr = BSpline.design_matrix(x,
                                                  bspl.t,
                                                  k).toarray()
             assert_allclose(des_matr_csr @ bspl.c, y, atol=1e-14)
@@ -463,7 +463,7 @@ class TestBSpline:
         k = 3
         for bc in ["clamped", "natural"]:
             run_design_matrix_tests(n, k, bc)
-        
+
         # "not-a-knot" works with odd `k`
         for k in range(3, 8, 2):
             run_design_matrix_tests(n, k, "not-a-knot")
@@ -472,7 +472,7 @@ class TestBSpline:
         n = 5  # smaller `n` to test `k > n` case
         for k in range(2, 7):
             run_design_matrix_tests(n, k, "periodic")
-    
+
     def test_design_matrix_x_t_shapes(self):
         # test for different `x` shapes
         np.random.seed(1234)
@@ -489,12 +489,12 @@ class TestBSpline:
                                                  bspl.t,
                                                  k).toarray()
             assert_allclose(des_matr_csr @ bspl.c, yc, atol=1e-14)
-        
+
         # test for minimal possible `t` shape
         t = [0., 1., 1., 1., 2.]
         des_matr = BSpline.design_matrix(1., t, 3).toarray()
         assert_allclose(des_matr, [[1.]], atol=1e-14)
-        
+
     def test_design_matrix_asserts(self):
         np.random.seed(1234)
         n = 10
@@ -511,7 +511,7 @@ class TestBSpline:
         x = [1., 2., 3., 4.]
         # out of bounds
         with assert_raises(ValueError):
-            des_test = BSpline.design_matrix(x, t, k)
+            BSpline.design_matrix(x, t, k)
 
 def test_knots_multiplicity():
     # Take a spline w/ random coefficients, throw in knots of varying


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Resolves an issue described in gh-6730 (inconvenience of creating a design matrix) mentioned by @lorentzenchr
#### What does this implement/fix?
<!--Please explain your changes.-->
A new method `design_matrix` in `BSpline` class was implemented. Matrix can be returned in 2 kinds: dense and CSR.
#### Additional information
Now instead of using some tricks to get a design matrix you can get it from the method:
`BSpline.design_matrix(x_test)`