### PR TITLE
MAINT: make fit method of rv_continuous pickleable

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -5,6 +5,7 @@
 #
 import warnings
 from collections.abc import Iterable
+from functools import wraps
 import ctypes
 
 import numpy as np
@@ -54,13 +55,13 @@ def _remove_optimizer_parameters(kwds):
 def _call_super_mom(fun):
     # if fit method is overridden only for MLE and doesn't specify what to do
     # if method == 'mm', this decorator calls generic implementation
+    @wraps(fun)
     def wrapper(self, *args, **kwds):
         method = kwds.get('method', 'mle').lower()
         if method == 'mm':
             return super(type(self), self).fit(*args, **kwds)
         else:
             return fun(self, *args, **kwds)
-    wrapper.__name__ = fun.__name__
     return wrapper
 
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -60,6 +60,7 @@ def _call_super_mom(fun):
             return super(type(self), self).fit(*args, **kwds)
         else:
             return fun(self, *args, **kwds)
+    wrapper.__name__ = fun.__name__
     return wrapper
 
 

--- a/scipy/stats/tests/common_tests.py
+++ b/scipy/stats/tests/common_tests.py
@@ -302,6 +302,16 @@ def check_pickling(distfn, args):
     r1 = unpickled.rvs(size=8)
     npt.assert_equal(r0, r1)
 
+    # check pickling/unpickling of .fit method
+    fit_function = distfn.fit
+    pickled_fit_function = pickle.dumps(fit_function)
+    unpickled_fit_function = pickle.loads(pickled_fit_function)
+    
+    data = distfn.rvs(*args, size=8)
+    p0 = fit_function(data, *args)
+    p1 = unpickled_fit_function(data, *args)
+    npt.assert_equal(p0, p1)
+    
     # restore the random_state
     distfn.random_state = rndm
 

--- a/scipy/stats/tests/common_tests.py
+++ b/scipy/stats/tests/common_tests.py
@@ -308,8 +308,8 @@ def check_pickling(distfn, args):
     unpickled_fit_function = pickle.loads(pickled_fit_function)
     
     data = distfn.rvs(*args, size=8)
-    p0 = fit_function(data, *args)
-    p1 = unpickled_fit_function(data, *args)
+    p0 = fit_function(data)
+    p1 = unpickled_fit_function(data)
     npt.assert_equal(p0, p1)
     
     # restore the random_state

--- a/scipy/stats/tests/common_tests.py
+++ b/scipy/stats/tests/common_tests.py
@@ -307,11 +307,7 @@ def check_pickling(distfn, args):
         fit_function = distfn.fit
         pickled_fit_function = pickle.dumps(fit_function)
         unpickled_fit_function = pickle.loads(pickled_fit_function)
-
-        data = distfn.rvs(*args, size=8)
-        p0 = fit_function(data)
-        p1 = unpickled_fit_function(data)
-        npt.assert_equal(p0, p1)
+        assert fit_function.__name__ == unpickled_fit_function.__name__ == "fit"
     
     # restore the random_state
     distfn.random_state = rndm

--- a/scipy/stats/tests/common_tests.py
+++ b/scipy/stats/tests/common_tests.py
@@ -303,14 +303,15 @@ def check_pickling(distfn, args):
     npt.assert_equal(r0, r1)
 
     # check pickling/unpickling of .fit method
-    fit_function = distfn.fit
-    pickled_fit_function = pickle.dumps(fit_function)
-    unpickled_fit_function = pickle.loads(pickled_fit_function)
-    
-    data = distfn.rvs(*args, size=8)
-    p0 = fit_function(data)
-    p1 = unpickled_fit_function(data)
-    npt.assert_equal(p0, p1)
+    if hasattr(distfn, "fit"):
+        fit_function = distfn.fit
+        pickled_fit_function = pickle.dumps(fit_function)
+        unpickled_fit_function = pickle.loads(pickled_fit_function)
+
+        data = distfn.rvs(*args, size=8)
+        p0 = fit_function(data)
+        p1 = unpickled_fit_function(data)
+        npt.assert_equal(p0, p1)
     
     # restore the random_state
     distfn.random_state = rndm


### PR DESCRIPTION
Allows fit methods decorated with _call_super_mom to be pickleable.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes #14346

#### What does this implement/fix?
<!--Please explain your changes.-->

Makes `rv_continuous.fit` methods decorated with `_call_super_mom` pickleable

#### Additional information
<!--Any additional information you think is important.-->