### PR TITLE
ENH: spatial.distance.jaccard: raise `ValueError` for non-boolean arrays

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -864,7 +864,8 @@ def jaccard(u, v, w=None):
     u = _validate_vector(u)
     v = _validate_vector(v)
 
-    nonzero = np.bitwise_or(u.astype(bool), v.astype(bool))
+    nonzero = np.bitwise_or(u.astype(bool, copy=False),
+                            v.astype(bool, copy=False))
     unequal_nonzero = np.bitwise_and((u != v), nonzero)
     if w is not None:
         w = _validate_weights(w)

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -861,14 +861,12 @@ def jaccard(u, v, w=None):
     0.66666666666666663
 
     """
-    if np.isin(u, [0, 1]).all() == False or np.isin(v, [0, 1]).all() == False:
-        raise ValueError('u and v should be boolean 1-D arrays')
-        
     u = _validate_vector(u)
     v = _validate_vector(v)
 
-    nonzero = np.bitwise_or(u != 0, v != 0)
+    nonzero = np.bitwise_or(u.astype(bool), v.astype(bool))
     unequal_nonzero = np.bitwise_and((u != v), nonzero)
+    print(unequal_nonzero)
     if w is not None:
         w = _validate_weights(w)
         nonzero = w * nonzero

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -866,7 +866,6 @@ def jaccard(u, v, w=None):
 
     nonzero = np.bitwise_or(u.astype(bool), v.astype(bool))
     unequal_nonzero = np.bitwise_and((u != v), nonzero)
-    print(unequal_nonzero)
     if w is not None:
         w = _validate_weights(w)
         nonzero = w * nonzero

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -855,7 +855,7 @@ def jaccard(u, v, w=None):
     1.0
     >>> distance.jaccard([1, 0, 0], [1, 1, 0])
     0.5
-    >>> 
+    >>> distance.jaccard([1, 0, 0], [1, 2, 0])
     0.5
     >>> distance.jaccard([1, 0, 0], [1, 1, 1])
     0.66666666666666663

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -855,12 +855,15 @@ def jaccard(u, v, w=None):
     1.0
     >>> distance.jaccard([1, 0, 0], [1, 1, 0])
     0.5
-    >>> distance.jaccard([1, 0, 0], [1, 2, 0])
+    >>> 
     0.5
     >>> distance.jaccard([1, 0, 0], [1, 1, 1])
     0.66666666666666663
 
     """
+    if np.isin(u, [0, 1]).all() == False or np.isin(v, [0, 1]).all() == False:
+        raise ValueError('u and v should be boolean 1-D arrays')
+        
     u = _validate_vector(u)
     v = _validate_vector(v)
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #14304.
#### What does this implement/fix?
<!--Please explain your changes.-->

According to the description of the Jaccard distance, it should take only 1-D booleans arrays, plus according to https://github.com/scipy/scipy/issues/14304#issuecomment-869097423, we should add a `ValueError`, for the case we don't have booleans arrays.

<!--#### Additional information-->
<!--Any additional information you think is important.-->