### PR TITLE
ENH: Dinic's algorithm for maximum_flow

### DIFF
--- a/scipy/sparse/csgraph/_flow.pyx
+++ b/scipy/sparse/csgraph/_flow.pyx
@@ -47,17 +47,16 @@ def maximum_flow(csgraph, source, sink, *, method='edmonds_karp'):
         The source vertex from which the flow flows.
     sink : int
         The sink vertex to which the flow flows.
-    
-    .. versionadded:: 1.8.0
-
-    method: str
+    method: {‘edmonds_karp’, ‘dinic’}, optional
         The method/algorithm to be used for computing the maximum flow.
         Following methods are supported,
 
-            * 'edmonds_karp': Edmonds Karp algorithm in [1].
-            * 'dinic': Dinic's algorithm in [4].
+            * 'edmonds_karp': Edmonds Karp algorithm in [1]_.
+            * 'dinic': Dinic's algorithm in [4]_.
 
-        Optional, by default, 'edmonds_karp'.
+        Default is 'edmonds_karp'.
+
+        .. versionadded:: 1.8.0
 
     Returns
     -------
@@ -240,7 +239,7 @@ def maximum_flow(csgraph, source, sink, *, method='edmonds_karp'):
     rev_edge_ptr, tails = _make_edge_pointers(m)
     if method == 'edmonds_karp':
         residual = _edmonds_karp(m.indptr, tails, m.indices,
-                                m.data, rev_edge_ptr, source, sink)
+                                 m.data, rev_edge_ptr, source, sink)
     elif method == 'dinic':
         residual = _dinic(m.indptr, tails, m.indices,
                           m.data, rev_edge_ptr, source, sink)
@@ -443,7 +442,7 @@ cdef bint _build_level_graph(
     Parameters
     ----------
     edge_ptr : memoryview of length :math:`|V| + 1`
-        For a given vertex v, the edges whose tail is ``v`` are those between
+        For a given vertex ``v``, the edges whose tail is ``v`` are those between
         ``edge_ptr[v]`` and ``edge_ptr[v + 1] - 1``.
     source : int
         The source vertex.
@@ -510,7 +509,7 @@ cdef ITYPE_t _augment_paths(
     Parameters
     ----------
     edge_ptr : memoryview of length :math:`|V| + 1`
-        For a given vertex v, the edges whose tail is ``v`` are those between
+        For a given vertex ``v``, the edges whose tail is ``v`` are those between
         ``edge_ptr[v]`` and ``edge_ptr[v + 1] - 1``.
     current : int
         The current node in the path.
@@ -581,7 +580,7 @@ cdef ITYPE_t[:] _dinic(
     Parameters
     ----------
     edge_ptr : memoryview of length :math:`|V| + 1`
-        For a given vertex v, the edges whose tail is ``v`` are those between
+        For a given vertex ``v``, the edges whose tail is ``v`` are those between
         ``edge_ptr[v]`` and ``edge_ptr[v + 1] - 1``.
     tails : memoryview of length :math:`|E|`
         For a given edge ``e``, ``tails[e]`` is the tail vertex of ``e``.

--- a/scipy/sparse/csgraph/_flow.pyx
+++ b/scipy/sparse/csgraph/_flow.pyx
@@ -610,19 +610,17 @@ cdef ITYPE_t[:] _dinic(
     cdef ITYPE_t ITYPE_MAX = np.iinfo(ITYPE).max
 
     cdef ITYPE_t[:] levels, progress
-    cdef ITYPE_t[:] neg_ones = np.full(n_verts, -1, dtype=ITYPE)
     cdef ITYPE_t[:] q = np.empty(n_verts, dtype=ITYPE)
     cdef ITYPE_t[:] flows = np.zeros(n_edges, dtype=ITYPE)
     cdef ITYPE_t flow
 
     cdef ITYPE_t max_flow = 0
-    cdef ITYPE_t i = 0
-    while i < 100:
-        levels = neg_ones
+    while True:
+        levels = np.full(n_verts, -1, dtype=ITYPE)
         if not _build_level_graph(edge_ptr, source, sink,
                                  capacities, heads, levels, q):
             break
-        progress = neg_ones
+        progress = np.full(n_verts, -1, dtype=ITYPE)
         while True:
             flow = _augment_paths(edge_ptr, source, sink, 
                                  progress, levels, capacities,
@@ -631,5 +629,4 @@ cdef ITYPE_t[:] _dinic(
                 max_flow += flow
             else:
                 break
-        i += 1
     return flows

--- a/scipy/sparse/csgraph/_flow.pyx
+++ b/scipy/sparse/csgraph/_flow.pyx
@@ -87,9 +87,12 @@ def maximum_flow(csgraph, source, sink, *, method='edmonds_karp'):
     By the max-flow min-cut theorem, the maximal value of the flow is also the
     total weight of the edges in a minimum cut.
 
-    To solve the problem, we use the Edmonds--Karp algorithm. [1]_ This
-    particular implementation strives to exploit sparsity. Its time complexity
-    is :math:`O(VE^2)` and its space complexity is :math:`O(E)`.
+    To solve the problem, we provide Edmonds--Karp [1]_ and Dinic's algorithm [4]_. 
+    The implementation of former strives to exploit sparsity. Its time complexity
+    is :math:`O(VE^2)` and its space complexity is :math:`O(E)`. The latter 
+    achieves its performance by building level graphs and finding blocking flows
+    in them.  Its time complexity is :math:`O(V^2E)` and its space complexity is 
+    :math:`O(E)`.
 
     The maximum flow problem is usually defined with real valued capacities,
     but we require that all capacities are integral to ensure convergence. When

--- a/scipy/sparse/csgraph/_flow.pyx
+++ b/scipy/sparse/csgraph/_flow.pyx
@@ -47,7 +47,7 @@ def maximum_flow(csgraph, source, sink, *, method='edmonds_karp'):
         The source vertex from which the flow flows.
     sink : int
         The sink vertex to which the flow flows.
-    method: {‘edmonds_karp’, ‘dinic’}, optional
+    method: {'edmonds_karp', 'dinic'}, optional
         The method/algorithm to be used for computing the maximum flow.
         Following methods are supported,
 

--- a/scipy/sparse/csgraph/_flow.pyx
+++ b/scipy/sparse/csgraph/_flow.pyx
@@ -427,7 +427,7 @@ cdef bint build_level_graph(
 
     cdef ITYPE_t[:] q = np.empty(n_verts, dtype=ITYPE)
 
-    cdef ITYPE_t cur, start, end, dst_vertex
+    cdef ITYPE_t cur, start, end, dst_vertex, e
 
     q[0] = source
     start = 0
@@ -467,7 +467,8 @@ cdef ITYPE_t augment_paths(
     if current == sink:
         return flow
     
-    cdef ITYPE_t dst_vertex, result_flow
+    cdef ITYPE_t dst_vertex, result_flow, e
+    
     if progress[current] == -1:
         progress[current] = edge_ptr[current]
     while progress[current] < edge_ptr[current + 1]:

--- a/scipy/sparse/csgraph/_flow.pyx
+++ b/scipy/sparse/csgraph/_flow.pyx
@@ -26,7 +26,7 @@ class MaximumFlowResult:
         self.residual = residual
 
     def __repr__(self):
-        return 'MaximumFlowResult with value of %d' % self.flow_value 
+        return 'MaximumFlowResult with value of %d' % self.flow_value
 
 
 def maximum_flow(csgraph, source, sink, *, method='dinic'):
@@ -87,11 +87,12 @@ def maximum_flow(csgraph, source, sink, *, method='dinic'):
     By the max-flow min-cut theorem, the maximal value of the flow is also the
     total weight of the edges in a minimum cut.
 
-    To solve the problem, we provide Edmonds--Karp [1]_ and Dinic's algorithm [4]_. 
-    The implementation of former strives to exploit sparsity. Its time complexity
-    is :math:`O(|V|\,|E|^2)` and its space complexity is :math:`O(|E|)`. The latter 
-    achieves its performance by building level graphs and finding blocking flows
-    in them.  Its time complexity is :math:`O(|V|^2\,|E|)` and its space complexity is 
+    To solve the problem, we provide Edmonds--Karp [1]_ and Dinic's algorithm
+    [4]_. The implementation of both algorithms strive to exploit sparsity.
+    The time complexity of the former :math:`O(|V|\,|E|^2)` and its space
+    complexity is :math:`O(|E|)`. The latter achieves its performance by
+    building level graphs and finding blocking flows in them. Its time
+    complexity is :math:`O(|V|^2\,|E|)` and its space complexity is
     :math:`O(|E|)`.
 
     The maximum flow problem is usually defined with real valued capacities,
@@ -112,9 +113,10 @@ def maximum_flow(csgraph, source, sink, *, method='dinic'):
     .. [2] Cormen, T. H. and Leiserson, C. E. and Rivest, R. L. and Stein C.
            Introduction to Algorithms. Second Edition. 2001. MIT Press.
     .. [3] https://en.wikipedia.org/wiki/Graph_cuts_in_computer_vision
-    .. [4] Dinic, Efim A. 
+    .. [4] Dinic, Efim A.
            Algorithm for solution of a problem of maximum flow in networks with
-           power estimation. In Soviet Math. Doklady, vol. 11, pp. 1277-1280. 1970.
+           power estimation. In Soviet Math. Doklady, vol. 11, pp. 1277-1280.
+           1970.
 
     Examples
     --------
@@ -433,21 +435,21 @@ cdef ITYPE_t[:] _edmonds_karp(
     return flow
 
 cdef bint _build_level_graph(
-        const ITYPE_t[:] edge_ptr, # IN
-        const ITYPE_t source, # IN
-        const ITYPE_t sink, # IN
-        const ITYPE_t[:] capacities, # IN
-        const ITYPE_t[:] heads, # IN
-        ITYPE_t[:] levels, # IN/OUT
-        ITYPE_t[:] q, # IN/OUT
-    ) nogil:
+        const ITYPE_t[:] edge_ptr,  # IN
+        const ITYPE_t source,  # IN
+        const ITYPE_t sink,  # IN
+        const ITYPE_t[:] capacities,  # IN
+        const ITYPE_t[:] heads,  # IN
+        ITYPE_t[:] levels,  # IN/OUT
+        ITYPE_t[:] q,  # IN/OUT
+        ) nogil:
     """Builds layered graph from input graph using breadth first search.
 
     Parameters
     ----------
     edge_ptr : memoryview of length :math:`|V| + 1`
-        For a given vertex ``v``, the edges whose tail is ``v`` are those between
-        ``edge_ptr[v]`` and ``edge_ptr[v + 1] - 1``.
+        For a given vertex ``v``, the edges whose tail is ``v`` are
+        those between ``edge_ptr[v]`` and ``edge_ptr[v + 1] - 1``.
     source : int
         The source vertex.
     sink : int
@@ -457,10 +459,10 @@ cdef bint _build_level_graph(
     heads : memoryview of length :math:`|E|`
         For a given edge ``e``, ``heads[e]`` is the head vertex of ``e``.
     levels: memoryview of length :math:`|E|`
-        For a given vertex ``v``, ``levels[v]`` is the level of ``v`` in 
+        For a given vertex ``v``, ``levels[v]`` is the level of ``v`` in
         the layered graph of input graph.
     q : memoryview of length :math:`|E|`
-        Queue to be used in breadth first search. Passed to avoid repeated 
+        Queue to be used in breadth first search. Passed to avoid repeated
         queue creation inside this function.
 
     Returns
@@ -493,30 +495,30 @@ cdef bint _build_level_graph(
     return 0
 
 cdef ITYPE_t _augment_paths(
-        const ITYPE_t[:] edge_ptr, # IN
-        const ITYPE_t current, # IN
-        const ITYPE_t sink, # IN
-        const ITYPE_t[:] levels, # IN
-        const ITYPE_t[:] heads, # IN
-        const ITYPE_t[:] rev_edge_ptr, # IN
-        ITYPE_t[:] capacities, # IN/OUT
-        ITYPE_t[:] progress, # IN
-        ITYPE_t[:] flows, # OUT
-        ITYPE_t flow # OUT
-    ) nogil:
+        const ITYPE_t[:] edge_ptr,  # IN
+        const ITYPE_t current,  # IN
+        const ITYPE_t sink,  # IN
+        const ITYPE_t[:] levels,  # IN
+        const ITYPE_t[:] heads,  # IN
+        const ITYPE_t[:] rev_edge_ptr,  # IN
+        ITYPE_t[:] capacities,  # IN/OUT
+        ITYPE_t[:] progress,  # IN
+        ITYPE_t[:] flows,  # OUT
+        ITYPE_t flow  # OUT
+        ) nogil:
     """Computes blocking flow in layered graph using depth first search.
 
     Parameters
     ----------
     edge_ptr : memoryview of length :math:`|V| + 1`
-        For a given vertex ``v``, the edges whose tail is ``v`` are those between
-        ``edge_ptr[v]`` and ``edge_ptr[v + 1] - 1``.
+        For a given vertex ``v``, the edges whose tail is ``v`` are
+        those between ``edge_ptr[v]`` and ``edge_ptr[v + 1] - 1``.
     current : int
         The current node in the path.
     sink : int
         The sink vertex.
     levels: memoryview of length :math:`|E|`
-        For a given vertex ``v``, ``levels[v]`` is the level of ``v`` in 
+        For a given vertex ``v``, ``levels[v]`` is the level of ``v`` in
         the layered graph of input graph.
     heads : memoryview of length :math:`|E|`
         For a given edge ``e``, ``heads[e]`` is the head vertex of ``e``.
@@ -536,21 +538,19 @@ cdef ITYPE_t _augment_paths(
     Returns
     -------
     result_flow : int
-        The blocking flow in the layered graph.
+        An arbitrary flow in the layered graph.
 
     """
     if current == sink:
         return flow
-    
+
     cdef ITYPE_t dst_vertex, result_flow, e
 
-    if progress[current] == -1:
-        progress[current] = edge_ptr[current]
     while progress[current] < edge_ptr[current + 1]:
         e = progress[current]
         dst_vertex = heads[e]
-        if (capacities[e] > 0 and 
-            levels[dst_vertex] == levels[current] + 1):
+        if (capacities[e] > 0 and
+                levels[dst_vertex] == levels[current] + 1):
             result_flow = _augment_paths(edge_ptr, dst_vertex, sink,
                                          levels, heads, rev_edge_ptr,
                                          capacities, progress, flows,
@@ -579,8 +579,8 @@ cdef ITYPE_t[:] _dinic(
     Parameters
     ----------
     edge_ptr : memoryview of length :math:`|V| + 1`
-        For a given vertex ``v``, the edges whose tail is ``v`` are those between
-        ``edge_ptr[v]`` and ``edge_ptr[v + 1] - 1``.
+        For a given vertex ``v``, the edges whose tail is ``v`` are
+        those between ``edge_ptr[v]`` and ``edge_ptr[v + 1] - 1``.
     heads : memoryview of length :math:`|E|`
         For a given edge ``e``, ``heads[e]`` is the head vertex of ``e``.
     capacities : memoryview of length :math:`|E|`
@@ -603,28 +603,24 @@ cdef ITYPE_t[:] _dinic(
     cdef ITYPE_t n_edges = capacities.shape[0]
     cdef ITYPE_t ITYPE_MAX = np.iinfo(ITYPE).max
 
-    cdef ITYPE_t[:] levels = np.full(n_verts, -1, dtype=ITYPE)
-    cdef ITYPE_t[:] progress = np.full(n_verts, -1, dtype=ITYPE)
+    cdef ITYPE_t[:] levels = np.empty(n_verts, dtype=ITYPE)
+    cdef ITYPE_t[:] progress = np.empty(n_verts, dtype=ITYPE)
     cdef ITYPE_t[:] q = np.empty(n_verts, dtype=ITYPE)
     cdef ITYPE_t[:] flows = np.zeros(n_edges, dtype=ITYPE)
     cdef ITYPE_t flow
 
-    cdef ITYPE_t max_flow = 0
     while True:
         for i in range(n_verts):
             levels[i] = -1
         if not _build_level_graph(edge_ptr, source, sink,
-                                 capacities, heads, levels, q):
+                                  capacities, heads, levels, q):
             break
         for i in range(n_verts):
-            progress[i] = -1
-        while True:
+            progress[i] = edge_ptr[i]
+        flow = 1
+        while flow:
             flow = _augment_paths(edge_ptr, source, sink,
-                                 levels, heads, rev_edge_ptr,
-                                 capacities, progress, flows,
-                                 ITYPE_MAX)
-            if flow:
-                max_flow += flow
-            else:
-                break
+                                  levels, heads, rev_edge_ptr,
+                                  capacities, progress, flows,
+                                  ITYPE_MAX)
     return flows

--- a/scipy/sparse/csgraph/_flow.pyx
+++ b/scipy/sparse/csgraph/_flow.pyx
@@ -436,7 +436,6 @@ cdef bint build_level_graph(
 
     while start != end:
         cur = q[start]
-        # print(cur, sink)
         start += 1
         if start == n_verts:
             start = 0
@@ -444,7 +443,6 @@ cdef bint build_level_graph(
             return 1
         for e in range(edge_ptr[cur], edge_ptr[cur + 1]):
             dst_vertex = heads[e]
-            # print(capacities[e], heads[e], cur, dst_vertex)
             if capacities[e] > 0 and levels[dst_vertex] == -1:
                 levels[dst_vertex] = levels[cur] + 1
                 q[end] = dst_vertex
@@ -466,7 +464,6 @@ cdef ITYPE_t augment_paths(
         ITYPE_t[:] flows,
         ITYPE_t[:] rev_edge_ptr,
         ITYPE_t flow):
-    # print(current)
     if current == sink:
         return flow
     
@@ -476,9 +473,6 @@ cdef ITYPE_t augment_paths(
     while progress[current] < edge_ptr[current + 1]:
         e = progress[current]
         dst_vertex = heads[e]
-        # print(dst_vertex)
-        # if progress[current] == dst_vertex:
-            # print(current, sink)
         if (capacities[e] > 0 and 
             levels[dst_vertex] == levels[current] + 1):
             result_flow = augment_paths(edge_ptr, dst_vertex, sink,
@@ -515,7 +509,6 @@ cdef ITYPE_t[:] _dinic(
     cdef ITYPE_t max_flow = 0
     cdef ITYPE_t i = 0
     while i < 100:
-        # print("Iteration:", i)
         levels = np.full(n_verts, -1, dtype=ITYPE)
         if not build_level_graph(edge_ptr, source, sink,
                                  capacities, heads, levels):
@@ -526,10 +519,8 @@ cdef ITYPE_t[:] _dinic(
                                  progress, levels, capacities,
                                  heads, flows, rev_edge_ptr, ITYPE_MAX)
             if flow:
-                print(flow)
                 max_flow += flow
             else:
                 break
         i += 1
-    # print(max_flow)
     return flows

--- a/scipy/sparse/csgraph/_flow.pyx
+++ b/scipy/sparse/csgraph/_flow.pyx
@@ -244,8 +244,8 @@ def maximum_flow(csgraph, source, sink, *, method='dinic'):
         residual = _edmonds_karp(m.indptr, tails, m.indices,
                                  m.data, rev_edge_ptr, source, sink)
     elif method == 'dinic':
-        residual = _dinic(m.indptr, tails, m.indices,
-                          m.data, rev_edge_ptr, source, sink)
+        residual = _dinic(m.indptr, m.indices, m.data, rev_edge_ptr,
+                          source, sink)
     else:
         raise ValueError('{} method is not supported yet.'.format(method))
     residual_array = np.asarray(residual)
@@ -482,8 +482,6 @@ cdef bint _build_level_graph(
     while start != end:
         cur = q[start]
         start += 1
-        if start == n_verts:
-            start = 0
         if cur == sink:
             return 1
         for e in range(edge_ptr[cur], edge_ptr[cur + 1]):
@@ -492,8 +490,6 @@ cdef bint _build_level_graph(
                 levels[dst_vertex] = levels[cur] + 1
                 q[end] = dst_vertex
                 end += 1
-                if end == n_verts:
-                    end = 0
     return 0
 
 cdef ITYPE_t _augment_paths(
@@ -570,7 +566,6 @@ cdef ITYPE_t _augment_paths(
 
 cdef ITYPE_t[:] _dinic(
         ITYPE_t[:] edge_ptr,
-        ITYPE_t[:] tails,
         ITYPE_t[:] heads,
         ITYPE_t[:] capacities,
         ITYPE_t[:] rev_edge_ptr,
@@ -586,8 +581,6 @@ cdef ITYPE_t[:] _dinic(
     edge_ptr : memoryview of length :math:`|V| + 1`
         For a given vertex ``v``, the edges whose tail is ``v`` are those between
         ``edge_ptr[v]`` and ``edge_ptr[v + 1] - 1``.
-    tails : memoryview of length :math:`|E|`
-        For a given edge ``e``, ``tails[e]`` is the tail vertex of ``e``.
     heads : memoryview of length :math:`|E|`
         For a given edge ``e``, ``heads[e]`` is the head vertex of ``e``.
     capacities : memoryview of length :math:`|E|`

--- a/scipy/sparse/csgraph/_flow.pyx
+++ b/scipy/sparse/csgraph/_flow.pyx
@@ -487,6 +487,7 @@ cdef ITYPE_t augment_paths(
                                         min(flow, capacities[e]))
             if result_flow:
                 capacities[e] -= result_flow
+                capacities[rev_edge_ptr[e]] += result_flow
                 flows[e] += result_flow
                 flows[rev_edge_ptr[e]] -= result_flow
                 return result_flow
@@ -525,7 +526,7 @@ cdef ITYPE_t[:] _dinic(
                                  progress, levels, capacities,
                                  heads, flows, rev_edge_ptr, ITYPE_MAX)
             if flow:
-                # print()
+                print(flow)
                 max_flow += flow
             else:
                 break

--- a/scipy/sparse/csgraph/_flow.pyx
+++ b/scipy/sparse/csgraph/_flow.pyx
@@ -29,7 +29,7 @@ class MaximumFlowResult:
         return 'MaximumFlowResult with value of %d' % self.flow_value 
 
 
-def maximum_flow(csgraph, source, sink, *, method='edmonds_karp'):
+def maximum_flow(csgraph, source, sink, *, method='dinic'):
     r"""
     maximum_flow(csgraph, source, sink)
 
@@ -54,7 +54,7 @@ def maximum_flow(csgraph, source, sink, *, method='edmonds_karp'):
             * 'edmonds_karp': Edmonds Karp algorithm in [1]_.
             * 'dinic': Dinic's algorithm in [4]_.
 
-        Default is 'edmonds_karp'.
+        Default is 'dinic'.
 
         .. versionadded:: 1.8.0
 

--- a/scipy/sparse/csgraph/_flow.pyx
+++ b/scipy/sparse/csgraph/_flow.pyx
@@ -89,10 +89,10 @@ def maximum_flow(csgraph, source, sink, *, method='dinic'):
 
     To solve the problem, we provide Edmonds--Karp [1]_ and Dinic's algorithm [4]_. 
     The implementation of former strives to exploit sparsity. Its time complexity
-    is :math:`O(VE^2)` and its space complexity is :math:`O(E)`. The latter 
+    is :math:`O(|V|\,|E|^2)` and its space complexity is :math:`O(|E|)`. The latter 
     achieves its performance by building level graphs and finding blocking flows
-    in them.  Its time complexity is :math:`O(V^2E)` and its space complexity is 
-    :math:`O(E)`.
+    in them.  Its time complexity is :math:`O(|V|^2\,|E|)` and its space complexity is 
+    :math:`O(|E|)`.
 
     The maximum flow problem is usually defined with real valued capacities,
     but we require that all capacities are integral to ensure convergence. When
@@ -130,7 +130,7 @@ def maximum_flow(csgraph, source, sink, *, method='dinic'):
     >>> graph = csr_matrix([[0, 5], [0, 0]])
     >>> maximum_flow(graph, 0, 1).flow_value
     5
-    >>> maximum_flow(graph, 0, 1, method='dinic').flow_value
+    >>> maximum_flow(graph, 0, 1, method='edmonds_karp').flow_value
     5
 
     If, on the other hand, there is a bottleneck between source and sink, that
@@ -439,7 +439,8 @@ cdef bint _build_level_graph(
         const ITYPE_t[:] capacities, # IN
         const ITYPE_t[:] heads, # IN
         ITYPE_t[:] levels, # IN/OUT
-        ITYPE_t[:] q) nogil:
+        ITYPE_t[:] q, # IN/OUT
+    ) nogil:
     """Builds layered graph from input graph using breadth first search.
 
     Parameters
@@ -465,7 +466,7 @@ cdef bint _build_level_graph(
     Returns
     -------
     bool:
-        ``True`` if the layered graph creation was successfull,
+        ``True`` if the layered graph creation was successful,
         otherwise ``False``.
 
     """

--- a/scipy/sparse/csgraph/_flow.pyx
+++ b/scipy/sparse/csgraph/_flow.pyx
@@ -109,9 +109,9 @@ def maximum_flow(csgraph, source, sink, *, method='edmonds_karp'):
     .. [2] Cormen, T. H. and Leiserson, C. E. and Rivest, R. L. and Stein C.
            Introduction to Algorithms. Second Edition. 2001. MIT Press.
     .. [3] https://en.wikipedia.org/wiki/Graph_cuts_in_computer_vision
-    .. [4] Dinic, E.A. (1970).
-           Algorithm for solution of a problem of maximal flow in a network with
-           power estimation.
+    .. [4] Dinic, Efim A. 
+           Algorithm for solution of a problem of maximum flow in networks with
+           power estimation. In Soviet Math. Doklady, vol. 11, pp. 1277-1280. 1970.
 
     Examples
     --------

--- a/scipy/sparse/csgraph/tests/test_flow.py
+++ b/scipy/sparse/csgraph/tests/test_flow.py
@@ -11,28 +11,28 @@ def test_raises_on_dense_input():
     with pytest.raises(TypeError):
         graph = np.array([[0, 1], [0, 0]])
         maximum_flow(graph, 0, 1)
-        maximum_flow(graph, 0, 1, method='dinic')
+        maximum_flow(graph, 0, 1, method='edmonds_karp')
 
 
 def test_raises_on_csc_input():
     with pytest.raises(TypeError):
         graph = csc_matrix([[0, 1], [0, 0]])
         maximum_flow(graph, 0, 1)
-        maximum_flow(graph, 0, 1, method='dinic')
+        maximum_flow(graph, 0, 1, method='edmonds_karp')
 
 
 def test_raises_on_floating_point_input():
     with pytest.raises(ValueError):
         graph = csr_matrix([[0, 1.5], [0, 0]], dtype=np.float64)
         maximum_flow(graph, 0, 1)
-        maximum_flow(graph, 0, 1, method='dinic')
+        maximum_flow(graph, 0, 1, method='edmonds_karp')
 
 
 def test_raises_when_source_is_sink():
     with pytest.raises(ValueError):
         graph = csr_matrix([[0, 1], [0, 0]])
         maximum_flow(graph, 0, 0)
-        maximum_flow(graph, 0, 0, method='dinic')
+        maximum_flow(graph, 0, 0, method='edmonds_karp')
 
 
 @pytest.mark.parametrize('method', methods)

--- a/scipy/sparse/csgraph/tests/test_flow.py
+++ b/scipy/sparse/csgraph/tests/test_flow.py
@@ -5,66 +5,76 @@ import pytest
 from scipy.sparse import csr_matrix, csc_matrix
 from scipy.sparse.csgraph import maximum_flow
 
+methods = ['edmonds_karp', 'dinic']
 
 def test_raises_on_dense_input():
     with pytest.raises(TypeError):
         graph = np.array([[0, 1], [0, 0]])
         maximum_flow(graph, 0, 1)
+        maximum_flow(graph, 0, 1, method='dinic')
 
 
 def test_raises_on_csc_input():
     with pytest.raises(TypeError):
         graph = csc_matrix([[0, 1], [0, 0]])
         maximum_flow(graph, 0, 1)
+        maximum_flow(graph, 0, 1, method='dinic')
 
 
 def test_raises_on_floating_point_input():
     with pytest.raises(ValueError):
         graph = csr_matrix([[0, 1.5], [0, 0]], dtype=np.float64)
         maximum_flow(graph, 0, 1)
+        maximum_flow(graph, 0, 1, method='dinic')
 
 
 def test_raises_when_source_is_sink():
     with pytest.raises(ValueError):
         graph = csr_matrix([[0, 1], [0, 0]])
         maximum_flow(graph, 0, 0)
+        maximum_flow(graph, 0, 0, method='dinic')
 
 
+@pytest.mark.parametrize('method', methods)
 @pytest.mark.parametrize('source', [-1, 2, 3])
-def test_raises_when_source_is_out_of_bounds(source):
+def test_raises_when_source_is_out_of_bounds(source, method):
     with pytest.raises(ValueError):
         graph = csr_matrix([[0, 1], [0, 0]])
-        maximum_flow(graph, source, 1)
+        maximum_flow(graph, source, 1, method=method)
 
 
+@pytest.mark.parametrize('method', methods)
 @pytest.mark.parametrize('sink', [-1, 2, 3])
-def test_raises_when_sink_is_out_of_bounds(sink):
+def test_raises_when_sink_is_out_of_bounds(sink, method):
     with pytest.raises(ValueError):
         graph = csr_matrix([[0, 1], [0, 0]])
-        maximum_flow(graph, 0, sink)
+        maximum_flow(graph, 0, sink, method=method)
 
 
-def test_simple_graph():
+@pytest.mark.parametrize('method', methods)
+def test_simple_graph(method):
     # This graph looks as follows:
     #     (0) --5--> (1)
     graph = csr_matrix([[0, 5], [0, 0]])
-    res = maximum_flow(graph, 0, 1)
+    res = maximum_flow(graph, 0, 1, method=method)
     assert res.flow_value == 5
     expected_residual = np.array([[0, 5], [-5, 0]])
     assert_array_equal(res.residual.toarray(), expected_residual)
 
 
-def test_bottle_neck_graph():
+@pytest.mark.parametrize('method', methods)
+def test_bottle_neck_graph(method):
     # This graph cannot use the full capacity between 0 and 1:
     #     (0) --5--> (1) --3--> (2)
     graph = csr_matrix([[0, 5, 0], [0, 0, 3], [0, 0, 0]])
-    res = maximum_flow(graph, 0, 2)
+    res = maximum_flow(graph, 0, 2, method=method)
     assert res.flow_value == 3
     expected_residual = np.array([[0, 3, 0], [-3, 0, 3], [0, -3, 0]])
     assert_array_equal(res.residual.toarray(), expected_residual)
 
 
-def test_backwards_flow():
+@pytest.mark.parametrize('method', methods)
+def test_backwards_flow(method):
     # This example causes backwards flow between vertices 3 and 4,
     # and so this test ensures that we handle that accordingly. See
     #     https://stackoverflow.com/q/38843963/5085211
@@ -77,7 +87,7 @@ def test_backwards_flow():
                         [0, 0, 0, 0, 0, 0, 10, 0],
                         [0, 0, 0, 0, 0, 0, 0, 10],
                         [0, 0, 0, 0, 0, 0, 0, 0]])
-    res = maximum_flow(graph, 0, 7)
+    res = maximum_flow(graph, 0, 7, method=method)
     assert res.flow_value == 20
     expected_residual = np.array([[0, 10, 0, 0, 10, 0, 0, 0],
                                   [-10, 0, 10, 0, 0, 0, 0, 0],
@@ -90,7 +100,8 @@ def test_backwards_flow():
     assert_array_equal(res.residual.toarray(), expected_residual)
 
 
-def test_example_from_clrs_chapter_26_1():
+@pytest.mark.parametrize('method', methods)
+def test_example_from_clrs_chapter_26_1(method):
     # See page 659 in CLRS second edition, but note that the maximum flow
     # we find is slightly different than the one in CLRS; we push a flow of
     # 12 to v_1 instead of v_2.
@@ -100,7 +111,7 @@ def test_example_from_clrs_chapter_26_1():
                         [0, 0, 9, 0, 0, 20],
                         [0, 0, 0, 7, 0, 4],
                         [0, 0, 0, 0, 0, 0]])
-    res = maximum_flow(graph, 0, 5)
+    res = maximum_flow(graph, 0, 5, method=method)
     assert res.flow_value == 23
     expected_residual = np.array([[0, 12, 11, 0, 0, 0],
                                   [-12, 0, 0, 12, 0, 0],
@@ -111,14 +122,15 @@ def test_example_from_clrs_chapter_26_1():
     assert_array_equal(res.residual.toarray(), expected_residual)
 
 
-def test_disconnected_graph():
+@pytest.mark.parametrize('method', methods)
+def test_disconnected_graph(method):
     # This tests the following disconnected graph:
     #     (0) --5--> (1)    (2) --3--> (3)
     graph = csr_matrix([[0, 5, 0, 0],
                         [0, 0, 0, 0],
                         [0, 0, 9, 3],
                         [0, 0, 0, 0]])
-    res = maximum_flow(graph, 0, 3)
+    res = maximum_flow(graph, 0, 3, method=method)
     assert res.flow_value == 0
     expected_residual = np.zeros((4, 4), dtype=np.int32)
     assert_array_equal(res.residual.toarray(), expected_residual)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
https://github.com/scipy/scipy/issues/13402

#### What does this implement/fix?
<!--Please explain your changes.-->
I have implemented Dinic's algorithm in `_flow.pyx` as discussed in gh-13402.

#### Additional information
<!--Any additional information you think is important.-->
Benchmark
**Code**
```python
from scipy.sparse import csr_matrix
from scipy.sparse.csgraph import maximum_flow
import maxflow
import numpy as np, scipy, timeit, functools
from tabulate import tabulate

def maxflow_dinic(graph):
    solver = maxflow.Solver()
    solver.load_graph(graph, 'dinic')
    solver.solve('dinic', 0, 999)

def maxflow_edmonds_karp(graph):
    solver = maxflow.Solver()
    solver.load_graph(graph, 'edmonds_karp')
    solver.solve('edmonds_karp', 0, 999)

def scipy_edmonds_karp(graph):
    maximum_flow(graph, 0, 999, method='edmonds_karp')

def scipy_dinic(graph):
    maximum_flow(graph, 0, 999, method='dinic')

p_m = u" \u00B1 "
mu = u" \u03BC "
sigma = u" \u03C3 "
results = []
densities = [0.1, 0.3, 0.5, 0.9]
for density in densities:
    result = [density]
    result.append('Dinic')
    A = (scipy.sparse.rand(1000, 1000, density, format='csr')*100).astype(np.uint32)
    t = timeit.Timer(functools.partial(scipy_dinic, A))
    times = t.repeat(5, 1)
    result.append(str(np.mean(times).round(3)) + p_m + str(np.std(times).round(3)))

    t = timeit.Timer(functools.partial(maxflow_dinic, A))
    times = t.repeat(5, 1)
    result.append(str(np.mean(times).round(3)) + p_m + str(np.std(times).round(3)))
    results.append(result)

    result = [density]
    result.append('Edmonds Karp')
    t = timeit.Timer(functools.partial(scipy_edmonds_karp, A))
    times = t.repeat(5, 1)
    result.append(str(np.mean(times).round(3)) + p_m + str(np.std(times).round(3)))

    t = timeit.Timer(functools.partial(maxflow_edmonds_karp, A))
    times = t.repeat(5, 1)
    result.append(str(np.mean(times).round(3)) + p_m + str(np.std(times).round(3)))
    results.append(result)

print(tabulate(results, headers=[
    'Density', 'Algorithm',
    mu + p_m + sigma + '  (SciPy)',
    mu + p_m + sigma + ' (MaxFlow)'],
    tablefmt='github'), end="\n\n")
```

**Results**

|   Density | Algorithm    |  μ  ±  σ   (SciPy)   |  μ  ±  σ  (MaxFlow)   |
|-----------|--------------|----------------------|-----------------------|
|       0.1 | Dinic        | 0.042 ± 0.002        | 0.015 ± 0.0           |
|       0.1 | Edmonds Karp | 0.057 ± 0.001        | 0.073 ± 0.0           |
|       0.3 | Dinic        | 0.129 ± 0.002        | 0.066 ± 0.004         |
|       0.3 | Edmonds Karp | 0.201 ± 0.004        | 0.607 ± 0.003         |
|       0.5 | Dinic        | 0.193 ± 0.002        | 0.096 ± 0.002         |
|       0.5 | Edmonds Karp | 0.43 ± 0.003         | 1.656 ± 0.002         |
|       0.9 | Dinic        | 0.225 ± 0.001        | 0.099 ± 0.006         |
|       0.9 | Edmonds Karp | 0.977 ± 0.005        | 3.004 ± 0.036         |

`MaxFlow` in the above table refers to https://github.com/touqir14/MaxFlow 
The code has also been ported from the above repository. The improvement in SciPy ranges from ~1.35x to ~4.34x.

ping @jjerphan @fuglede @rgommers Please review.