### PR TITLE
ENH: Set fft backend with try_last=True

### DIFF
--- a/scipy/fft/_backend.py
+++ b/scipy/fft/_backend.py
@@ -7,10 +7,9 @@ class _ScipyBackend:
 
     Notes
     -----
-    We use the domain ``numpy.scipy`` rather than ``scipy`` because in the
-    future, ``uarray`` will treat the domain as a hierarchy. This means the user
-    can install a single backend for ``numpy`` and have it implement
-    ``numpy.scipy.fft`` as well.
+    We use the domain ``numpy.scipy`` rather than ``scipy`` because ``uarray``
+    treats the domain as a hierarchy. This means the user can install a single
+    backend for ``numpy`` and have it implement ``numpy.scipy.fft`` as well.
     """
     __ua_domain__ = "numpy.scipy.fft"
 
@@ -44,7 +43,7 @@ def _backend_from_arg(backend):
 
 
 def set_global_backend(backend, coerce=False, only=False, try_last=False):
-    """Sets the global ndimage backend
+    """Sets the global fft backend
 
     This utility method replaces the default backend for permanent use. It
     will be tried in the list of backends automatically, unless the

--- a/scipy/fft/_backend.py
+++ b/scipy/fft/_backend.py
@@ -43,11 +43,13 @@ def _backend_from_arg(backend):
     return backend
 
 
-def set_global_backend(backend):
-    """Sets the global fft backend
+def set_global_backend(backend, coerce=False, only=False, try_last=False):
+    """Sets the global ndimage backend
 
-    The global backend has higher priority than registered backends, but lower
-    priority than context-specific backends set with `set_backend`.
+    This utility method replaces the default backend for permanent use. It
+    will be tried in the list of backends automatically, unless the
+    ``only`` flag is set on a backend. This will be the first tried
+    backend outside the :obj:`set_backend` context manager.
 
     Parameters
     ----------
@@ -55,6 +57,13 @@ def set_global_backend(backend):
         The backend to use.
         Can either be a ``str`` containing the name of a known backend
         {'scipy'} or an object that implements the uarray protocol.
+    coerce : bool
+        Whether to coerce input types when trying this backend.
+    only : bool
+        If ``True``, no more backends will be tried if this fails.
+        Implied by ``coerce=True``.
+    try_last : bool
+        If ``True``, the global backend is tried after registered backends.
 
     Raises
     ------
@@ -75,7 +84,7 @@ def set_global_backend(backend):
     array([1.+0.j])
     """
     backend = _backend_from_arg(backend)
-    ua.set_global_backend(backend)
+    ua.set_global_backend(backend, coerce=coerce, only=only, try_last=try_last)
 
 
 def register_backend(backend):
@@ -177,4 +186,4 @@ def skip_backend(backend):
     return ua.skip_backend(backend)
 
 
-set_global_backend('scipy')
+set_global_backend('scipy', try_last=True)


### PR DESCRIPTION
#### Reference issue
This is a follow up to the #14266 #14275 

#### What does this implement/fix?
Now that the vendored uarray version is updated, this enables the functionality to use `try_last=True` when setting the global default backend in `scipy.fft`.

The following is an example snippet of what is now possible.
```python
import numpy as np
import cupy as cp
import scipy.fft
import cupyx.scipy.fft as cu_fft

# Register the cupy backend at the start
scipy.fft.register_backend(cu_fft)

# Basic
y_numpy = scipy.fft.fft(np.arange(10))

####### Earlier #######
# scipy with cupy array
x = cp.arange(10)
y_cupy = scipy.fft.fft(x)  # this will now raise a `TypeError` and complain about not using the correct backend

####### After the PR #######
# scipy with cupy array
x = cp.arange(10)
y_cupy = scipy.fft.fft(x) # works, no need of the context manager. just register your backend once at the top
```

#### How is this different from auto-dispatch proposed in #14266?
With auto-dispatch the proposal is to take this one step further by completely removing the backend registration at the top as well and placing that inside the other library (cupy for this example) which automatically registers on import. It is still open for discussion, irrespective of the decision to go ahead with auto-dispatch or not, this is still needed as part of the ***Step 2*** mentioned in #14266.

cc @peterbell10 @rgommers 