### PR TITLE
BUG: avoid large cython global variable in function

### DIFF
--- a/scipy/stats/_sobol.pyx
+++ b/scipy/stats/_sobol.pyx
@@ -91,11 +91,19 @@ def initialize_direction_numbers():
         np.savez_compressed("./_sobol_direction_numbers", vinit=vs, poly=poly)
 
     """
-    global is_initialized, poly, vinit
+    cdef int[:] dns_poly
+    cdef int[:, :] dns_vinit
+
+    global is_initialized
     if not is_initialized:
         dns = np.load(os.path.join(os.path.dirname(__file__), "_sobol_direction_numbers.npz"))
-        poly = dns["poly"]
-        vinit = dns["vinit"]
+        dns_poly = dns["poly"].astype(np.intc)
+        dns_vinit = dns["vinit"].astype(np.intc)
+        for i in range(MAXDIM):
+            poly[i] = dns_poly[i]
+        for i in range(MAXDIM):
+            for j in range(MAXDEG):
+                vinit[i][j] = dns_vinit[i, j]
         is_initialized = True
 
 


### PR DESCRIPTION
Fixes #14363, xref conda-forge/scipy-feedstock#176 

The v1.7.0 release added a very large statically allocated table `cdef int vinit[21201][18]` to `_sobol.pyx`. Then the table is lazily loaded via 

```
def initialize_direction_numbers():
    global vinit, ...
    if not is_initialized:
        ...
        vinit = data
```

As reported in cython/cython#4272, this leads to C code that has a second static allocation of `vinit` at the beginning of `initialize_direction_numbers`, which could overflow the stack. The solution here avoids the memory problem at the cost of element-by-element assignment, which is slower but avoids the possible crash.