### PR TITLE
BUG: Segfaults due to invalid/out-of-bound sparse matrix constructor

### DIFF
--- a/scipy/sparse/bsr.py
+++ b/scipy/sparse/bsr.py
@@ -430,7 +430,7 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
 
         # TODO eliminate zeros
 
-        return bsr_matrix((data,indices,indptr),shape=(M,N),blocksize=(R,C), safety_check=False)
+        return bsr_matrix((data,indices,indptr),shape=(M,N),blocksize=(R,C), safety_check="never")
 
     ######################
     # Conversion methods #

--- a/scipy/sparse/bsr.py
+++ b/scipy/sparse/bsr.py
@@ -531,7 +531,7 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
 
         if self.nnz == 0:
             return bsr_matrix((N, M), blocksize=(C, R),
-                              dtype=self.dtype, copy=copy)
+                              dtype=self.dtype, copy=copy, safety_check=False)
 
         indptr = np.empty(N//C + 1, dtype=self.indptr.dtype)
         indices = np.empty(NBLK, dtype=self.indices.dtype)

--- a/scipy/sparse/bsr.py
+++ b/scipy/sparse/bsr.py
@@ -117,7 +117,7 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
     """
     format = 'bsr'
 
-    def __init__(self, arg1, shape=None, dtype=None, copy=False, blocksize=None):
+    def __init__(self, arg1, shape=None, dtype=None, copy=False, blocksize=None, safety_check=True):
         _data_matrix.__init__(self)
 
         if isspmatrix(arg1):
@@ -223,7 +223,10 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
         if dtype is not None:
             self.data = self.data.astype(dtype, copy=False)
 
-        self.check_format(full_check=False)
+        if isinstance(arg1, tuple):
+            self.check_format(full_check=safety_check)
+        else:
+            self.check_format(full_check=False)
 
     def check_format(self, full_check=True):
         """check whether the matrix format is valid
@@ -425,7 +428,7 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
 
         # TODO eliminate zeros
 
-        return bsr_matrix((data,indices,indptr),shape=(M,N),blocksize=(R,C))
+        return bsr_matrix((data,indices,indptr),shape=(M,N),blocksize=(R,C), safety_check=False)
 
     ######################
     # Conversion methods #
@@ -467,7 +470,7 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
                   indices,
                   data)
         from .csr import csr_matrix
-        return csr_matrix((data, indices, indptr), shape=self.shape)
+        return csr_matrix((data, indices, indptr), shape=self.shape, safety_check=False)
 
     tocsr.__doc__ = spmatrix.tocsr.__doc__
 
@@ -539,7 +542,7 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
                       indptr, indices, data.ravel())
 
         return bsr_matrix((data, indices, indptr),
-                          shape=(N, M), copy=copy)
+                          shape=(N, M), copy=copy, safety_check=False)
 
     transpose.__doc__ = spmatrix.transpose.__doc__
 
@@ -680,7 +683,7 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
 
         data = data.reshape(-1,R,C)
 
-        return self.__class__((data, indices, indptr), shape=self.shape)
+        return self.__class__((data, indices, indptr), shape=self.shape, safety_check=False)
 
     # needed by _data_matrix
     def _with_data(self,data,copy=True):
@@ -690,10 +693,10 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
         """
         if copy:
             return self.__class__((data,self.indices.copy(),self.indptr.copy()),
-                                   shape=self.shape,dtype=data.dtype)
+                                   shape=self.shape,dtype=data.dtype, safety_check=False)
         else:
             return self.__class__((data,self.indices,self.indptr),
-                                   shape=self.shape,dtype=data.dtype)
+                                   shape=self.shape,dtype=data.dtype, safety_check=False)
 
 #    # these functions are used by the parent class
 #    # to remove redudancy between bsc_matrix and bsr_matrix

--- a/scipy/sparse/bsr.py
+++ b/scipy/sparse/bsr.py
@@ -117,7 +117,7 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
     """
     format = 'bsr'
 
-    def __init__(self, arg1, shape=None, dtype=None, copy=False, blocksize=None, safety_check=True):
+    def __init__(self, arg1, shape=None, dtype=None, copy=False, blocksize=None, safety_check="auto"):
         _data_matrix.__init__(self)
 
         if isspmatrix(arg1):
@@ -223,10 +223,12 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
         if dtype is not None:
             self.data = self.data.astype(dtype, copy=False)
 
-        if isinstance(arg1, tuple):
-            self.check_format(full_check=safety_check)
-        else:
-            self.check_format(full_check=False)
+        perform_check = False
+        if isinstance(arg1, tuple) and safety_check == "auto":
+            perform_check = True
+        elif safety_check == "always":
+            perform_check = True
+        self.check_format(full_check=perform_check)
 
     def check_format(self, full_check=True):
         """check whether the matrix format is valid
@@ -470,7 +472,7 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
                   indices,
                   data)
         from .csr import csr_matrix
-        return csr_matrix((data, indices, indptr), shape=self.shape, safety_check=False)
+        return csr_matrix((data, indices, indptr), shape=self.shape, safety_check="never")
 
     tocsr.__doc__ = spmatrix.tocsr.__doc__
 
@@ -531,7 +533,7 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
 
         if self.nnz == 0:
             return bsr_matrix((N, M), blocksize=(C, R),
-                              dtype=self.dtype, copy=copy, safety_check=False)
+                              dtype=self.dtype, copy=copy, safety_check="never")
 
         indptr = np.empty(N//C + 1, dtype=self.indptr.dtype)
         indices = np.empty(NBLK, dtype=self.indices.dtype)
@@ -542,7 +544,7 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
                       indptr, indices, data.ravel())
 
         return bsr_matrix((data, indices, indptr),
-                          shape=(N, M), copy=copy, safety_check=False)
+                          shape=(N, M), copy=copy, safety_check="never")
 
     transpose.__doc__ = spmatrix.transpose.__doc__
 
@@ -683,7 +685,7 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
 
         data = data.reshape(-1,R,C)
 
-        return self.__class__((data, indices, indptr), shape=self.shape, safety_check=False)
+        return self.__class__((data, indices, indptr), shape=self.shape, safety_check="never")
 
     # needed by _data_matrix
     def _with_data(self,data,copy=True):
@@ -693,10 +695,10 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
         """
         if copy:
             return self.__class__((data,self.indices.copy(),self.indptr.copy()),
-                                   shape=self.shape,dtype=data.dtype, safety_check=False)
+                                   shape=self.shape,dtype=data.dtype, safety_check="never")
         else:
             return self.__class__((data,self.indices,self.indptr),
-                                   shape=self.shape,dtype=data.dtype, safety_check=False)
+                                   shape=self.shape,dtype=data.dtype, safety_check="never")
 
 #    # these functions are used by the parent class
 #    # to remove redudancy between bsc_matrix and bsr_matrix

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -24,7 +24,7 @@ from .sputils import (upcast, upcast_char, to_native, isdense, isshape,
 class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
     """base matrix class for compressed row- and column-oriented matrices"""
 
-    def __init__(self, arg1, shape=None, dtype=None, copy=False):
+    def __init__(self, arg1, shape=None, dtype=None, copy=False, safety_check=True):
         _data_matrix.__init__(self)
 
         if isspmatrix(arg1):
@@ -103,7 +103,12 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         if dtype is not None:
             self.data = self.data.astype(dtype, copy=False)
 
-        self.check_format(full_check=False)
+        if isinstance(arg1, tuple):
+            #this was either loaded from npz or constructed manually
+            self.check_format(full_check=safety_check)
+        else:
+            #under most conditions full_check is slow and not necessary
+            self.check_format(full_check=False)
 
     def getnnz(self, axis=None):
         if axis is None:

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -24,7 +24,7 @@ from .sputils import (upcast, upcast_char, to_native, isdense, isshape,
 class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
     """base matrix class for compressed row- and column-oriented matrices"""
 
-    def __init__(self, arg1, shape=None, dtype=None, copy=False, safety_check=True):
+    def __init__(self, arg1, shape=None, dtype=None, copy=False, safety_check="auto"):
         _data_matrix.__init__(self)
 
         if isspmatrix(arg1):
@@ -103,12 +103,13 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         if dtype is not None:
             self.data = self.data.astype(dtype, copy=False)
 
-        if isinstance(arg1, tuple):
+        perform_check = False
+        if isinstance(arg1, tuple) and safety_check == "auto":
             #this was either loaded from npz or constructed manually
-            self.check_format(full_check=safety_check)
-        else:
-            #under most conditions full_check is slow and not necessary
-            self.check_format(full_check=False)
+            perform_check = True
+        elif safety_check == "always":
+            perform_check = True
+        self.check_format(full_check=perform_check)
 
     def getnnz(self, axis=None):
         if axis is None:

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -322,7 +322,7 @@ def kron(A, B, format=None):
         data = A.data.repeat(B.size).reshape(-1,B.shape[0],B.shape[1])
         data = data * B
 
-        return bsr_matrix((data,A.indices,A.indptr), shape=output_shape)
+        return bsr_matrix((data,A.indices,A.indptr), shape=output_shape, safety_check=False)
     else:
         # use COO
         A = coo_matrix(A)
@@ -428,10 +428,10 @@ def _compressed_sparse_stack(blocks, axis):
     indptr[-1] = last_indptr
     if axis == 0:
         return csr_matrix((data, indices, indptr),
-                          shape=(sum_dim, constant_dim))
+                          shape=(sum_dim, constant_dim), safety_check=False)
     else:
         return csc_matrix((data, indices, indptr),
-                          shape=(constant_dim, sum_dim))
+                          shape=(constant_dim, sum_dim), safety_check=False)
 
 
 def hstack(blocks, format=None, dtype=None):

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -322,7 +322,7 @@ def kron(A, B, format=None):
         data = A.data.repeat(B.size).reshape(-1,B.shape[0],B.shape[1])
         data = data * B
 
-        return bsr_matrix((data,A.indices,A.indptr), shape=output_shape, safety_check=False)
+        return bsr_matrix((data,A.indices,A.indptr), shape=output_shape, safety_check="never")
     else:
         # use COO
         A = coo_matrix(A)
@@ -428,10 +428,10 @@ def _compressed_sparse_stack(blocks, axis):
     indptr[-1] = last_indptr
     if axis == 0:
         return csr_matrix((data, indices, indptr),
-                          shape=(sum_dim, constant_dim), safety_check=False)
+                          shape=(sum_dim, constant_dim), safety_check="never")
     else:
         return csc_matrix((data, indices, indptr),
-                          shape=(constant_dim, sum_dim), safety_check=False)
+                          shape=(constant_dim, sum_dim), safety_check="never")
 
 
 def hstack(blocks, format=None, dtype=None):

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -364,7 +364,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
             coo_tocsr(N, M, self.nnz, col, row, self.data,
                       indptr, indices, data)
 
-            x = csc_matrix((data, indices, indptr), shape=self.shape, safety_check=False)
+            x = csc_matrix((data, indices, indptr), shape=self.shape, safety_check="never")
             if not self.has_canonical_format:
                 x.sum_duplicates()
             return x
@@ -406,7 +406,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
             coo_tocsr(M, N, self.nnz, row, col, self.data,
                       indptr, indices, data)
 
-            x = csr_matrix((data, indices, indptr), shape=self.shape, safety_check=False)
+            x = csr_matrix((data, indices, indptr), shape=self.shape, safety_check="never")
             if not self.has_canonical_format:
                 x.sum_duplicates()
             return x

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -364,7 +364,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
             coo_tocsr(N, M, self.nnz, col, row, self.data,
                       indptr, indices, data)
 
-            x = csc_matrix((data, indices, indptr), shape=self.shape)
+            x = csc_matrix((data, indices, indptr), shape=self.shape, safety_check=False)
             if not self.has_canonical_format:
                 x.sum_duplicates()
             return x
@@ -406,7 +406,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
             coo_tocsr(M, N, self.nnz, row, col, self.data,
                       indptr, indices, data)
 
-            x = csr_matrix((data, indices, indptr), shape=self.shape)
+            x = csr_matrix((data, indices, indptr), shape=self.shape, safety_check=False)
             if not self.has_canonical_format:
                 x.sum_duplicates()
             return x

--- a/scipy/sparse/csc.py
+++ b/scipy/sparse/csc.py
@@ -147,7 +147,7 @@ class csc_matrix(_cs_matrix):
                   data)
 
         from .csr import csr_matrix
-        A = csr_matrix((data, indices, indptr), shape=self.shape, copy=False)
+        A = csr_matrix((data, indices, indptr), shape=self.shape, copy=False, safety_check=False)
         A.has_sorted_indices = True
         return A
 

--- a/scipy/sparse/csc.py
+++ b/scipy/sparse/csc.py
@@ -147,7 +147,7 @@ class csc_matrix(_cs_matrix):
                   data)
 
         from .csr import csr_matrix
-        A = csr_matrix((data, indices, indptr), shape=self.shape, copy=False, safety_check=False)
+        A = csr_matrix((data, indices, indptr), shape=self.shape, copy=False, safety_check="never")
         A.has_sorted_indices = True
         return A
 

--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -188,7 +188,7 @@ class csr_matrix(_cs_matrix):
                   data)
 
         from .csc import csc_matrix
-        A = csc_matrix((data, indices, indptr), shape=self.shape)
+        A = csc_matrix((data, indices, indptr), shape=self.shape, safety_check=False)
         A.has_sorted_indices = True
         return A
 
@@ -203,7 +203,7 @@ class csr_matrix(_cs_matrix):
 
         elif blocksize == (1,1):
             arg1 = (self.data.reshape(-1,1,1),self.indices,self.indptr)
-            return bsr_matrix(arg1, shape=self.shape, copy=copy)
+            return bsr_matrix(arg1, shape=self.shape, copy=copy, safety_check=False)
 
         else:
             R,C = blocksize
@@ -226,7 +226,7 @@ class csr_matrix(_cs_matrix):
                       self.data,
                       indptr, indices, data.ravel())
 
-            return bsr_matrix((data,indices,indptr), shape=self.shape)
+            return bsr_matrix((data,indices,indptr), shape=self.shape, safety_check=False)
 
     tobsr.__doc__ = spmatrix.tobsr.__doc__
 
@@ -245,7 +245,7 @@ class csr_matrix(_cs_matrix):
             indptr[1] = i1 - i0
             indices = self.indices[i0:i1]
             data = self.data[i0:i1]
-            yield csr_matrix((data, indices, indptr), shape=shape, copy=True)
+            yield csr_matrix((data, indices, indptr), shape=shape, copy=True, safety_check=False)
             i0 = i1
 
     def getrow(self, i):
@@ -261,7 +261,7 @@ class csr_matrix(_cs_matrix):
         indptr, indices, data = get_csr_submatrix(
             M, N, self.indptr, self.indices, self.data, i, i + 1, 0, N)
         return csr_matrix((data, indices, indptr), shape=(1, N),
-                          dtype=self.dtype, copy=False)
+                          dtype=self.dtype, copy=False, safety_check=False)
 
     def getcol(self, i):
         """Returns a copy of column i of the matrix, as a (m x 1)
@@ -276,7 +276,7 @@ class csr_matrix(_cs_matrix):
         indptr, indices, data = get_csr_submatrix(
             M, N, self.indptr, self.indices, self.data, 0, M, i, i + 1)
         return csr_matrix((data, indices, indptr), shape=(M, 1),
-                          dtype=self.dtype, copy=False)
+                          dtype=self.dtype, copy=False, safety_check=False)
 
     def _get_intXarray(self, row, col):
         return self.getrow(row)._minor_index_fancy(col)
@@ -312,7 +312,7 @@ class csr_matrix(_cs_matrix):
 
         shape = (1, max(0, int(np.ceil(float(stop - start) / stride))))
         return csr_matrix((row_data, row_indices, row_indptr), shape=shape,
-                          dtype=self.dtype, copy=False)
+                          dtype=self.dtype, copy=False, safety_check=False)
 
     def _get_sliceXint(self, row, col):
         if row.step in (1, None):

--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -142,7 +142,7 @@ class csr_matrix(_cs_matrix):
 
         from .csc import csc_matrix
         return csc_matrix((self.data, self.indices,
-                           self.indptr), shape=(N, M), copy=copy)
+                           self.indptr), shape=(N, M), copy=copy, safety_check=False)
 
     transpose.__doc__ = spmatrix.transpose.__doc__
 

--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -142,7 +142,7 @@ class csr_matrix(_cs_matrix):
 
         from .csc import csc_matrix
         return csc_matrix((self.data, self.indices,
-                           self.indptr), shape=(N, M), copy=copy, safety_check=False)
+                           self.indptr), shape=(N, M), copy=copy, safety_check="never")
 
     transpose.__doc__ = spmatrix.transpose.__doc__
 
@@ -188,7 +188,7 @@ class csr_matrix(_cs_matrix):
                   data)
 
         from .csc import csc_matrix
-        A = csc_matrix((data, indices, indptr), shape=self.shape, safety_check=False)
+        A = csc_matrix((data, indices, indptr), shape=self.shape, safety_check="never")
         A.has_sorted_indices = True
         return A
 
@@ -203,7 +203,7 @@ class csr_matrix(_cs_matrix):
 
         elif blocksize == (1,1):
             arg1 = (self.data.reshape(-1,1,1),self.indices,self.indptr)
-            return bsr_matrix(arg1, shape=self.shape, copy=copy, safety_check=False)
+            return bsr_matrix(arg1, shape=self.shape, copy=copy, safety_check="never")
 
         else:
             R,C = blocksize
@@ -226,7 +226,7 @@ class csr_matrix(_cs_matrix):
                       self.data,
                       indptr, indices, data.ravel())
 
-            return bsr_matrix((data,indices,indptr), shape=self.shape, safety_check=False)
+            return bsr_matrix((data,indices,indptr), shape=self.shape, safety_check="never")
 
     tobsr.__doc__ = spmatrix.tobsr.__doc__
 
@@ -245,7 +245,7 @@ class csr_matrix(_cs_matrix):
             indptr[1] = i1 - i0
             indices = self.indices[i0:i1]
             data = self.data[i0:i1]
-            yield csr_matrix((data, indices, indptr), shape=shape, copy=True, safety_check=False)
+            yield csr_matrix((data, indices, indptr), shape=shape, copy=True, safety_check="never")
             i0 = i1
 
     def getrow(self, i):
@@ -312,7 +312,7 @@ class csr_matrix(_cs_matrix):
 
         shape = (1, max(0, int(np.ceil(float(stop - start) / stride))))
         return csr_matrix((row_data, row_indices, row_indptr), shape=shape,
-                          dtype=self.dtype, copy=False, safety_check=False)
+                          dtype=self.dtype, copy=False, safety_check="never")
 
     def _get_sliceXint(self, row, col):
         if row.step in (1, None):

--- a/scipy/sparse/dia.py
+++ b/scipy/sparse/dia.py
@@ -389,7 +389,7 @@ class dia_matrix(_data_matrix):
         indices = row.T[mask.T].astype(idx_dtype, copy=False)
         data = self.data.T[mask.T]
         return csc_matrix((data, indices, indptr), shape=self.shape,
-                          dtype=self.dtype, safety_check=False)
+                          dtype=self.dtype, safety_check="never")
 
     tocsc.__doc__ = spmatrix.tocsc.__doc__
 

--- a/scipy/sparse/dia.py
+++ b/scipy/sparse/dia.py
@@ -389,7 +389,7 @@ class dia_matrix(_data_matrix):
         indices = row.T[mask.T].astype(idx_dtype, copy=False)
         data = self.data.T[mask.T]
         return csc_matrix((data, indices, indptr), shape=self.shape,
-                          dtype=self.dtype)
+                          dtype=self.dtype, safety_check=False)
 
     tocsc.__doc__ = spmatrix.tocsc.__doc__
 

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -451,7 +451,7 @@ class lil_matrix(spmatrix, IndexMixin):
 
         M, N = self.shape
         if M == 0 or N == 0:
-            return csr_matrix((M, N), dtype=self.dtype)
+            return csr_matrix((M, N), dtype=self.dtype, safety_check=False)
 
         # construct indptr array
         if M*N <= np.iinfo(np.int32).max:
@@ -478,7 +478,7 @@ class lil_matrix(spmatrix, IndexMixin):
         _csparsetools.lil_flatten_to_array(self.data, data)
 
         # init csr matrix
-        return csr_matrix((data, indices, indptr), shape=self.shape)
+        return csr_matrix((data, indices, indptr), shape=self.shape, safety_check=False)
 
     tocsr.__doc__ = spmatrix.tocsr.__doc__
 

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -451,7 +451,7 @@ class lil_matrix(spmatrix, IndexMixin):
 
         M, N = self.shape
         if M == 0 or N == 0:
-            return csr_matrix((M, N), dtype=self.dtype, safety_check=False)
+            return csr_matrix((M, N), dtype=self.dtype, safety_check="never")
 
         # construct indptr array
         if M*N <= np.iinfo(np.int32).max:
@@ -478,7 +478,7 @@ class lil_matrix(spmatrix, IndexMixin):
         _csparsetools.lil_flatten_to_array(self.data, data)
 
         # init csr matrix
-        return csr_matrix((data, indices, indptr), shape=self.shape, safety_check=False)
+        return csr_matrix((data, indices, indptr), shape=self.shape, safety_check="never")
 
     tocsr.__doc__ = spmatrix.tocsr.__doc__
 

--- a/scipy/sparse/tests/test_csc.py
+++ b/scipy/sparse/tests/test_csc.py
@@ -104,7 +104,7 @@ def test_invalid_csc_negative_indices():
         # negative indices are invalid
         indices = [-100, -555]
         indptr = [0, 1, 2]
-        shape = (2, 1000)
+        shape = (1000, 2)
         mat = csc_matrix((data, indices, indptr), shape=shape)
         #a = mat * mat.T #causes segfault if above constructor is called
 
@@ -115,9 +115,9 @@ def test_invalid_csc_out_of_bounds_indices():
         # out of bounds indices are invalid
         indices = [1001, 555]
         indptr = [0, 1, 2]
-        shape = (2, 1000)
+        shape = (1000, 2)
         mat = csc_matrix((data, indices, indptr), shape=shape)
-        #a = mat * mat.T #causes segfault if above constructor is called
+        #a = mat * mat.T #no segfault for some reason, but this is still invalid
 
 def test_invalid_csc_unordered_indptr():
     #see gh-8778 for more information
@@ -126,6 +126,6 @@ def test_invalid_csc_unordered_indptr():
         # indptr should be monotonically ascending
         indices = [1, 2]
         indptr = [0, 5, 1]
-        shape = (2, 1000)
+        shape = (1000, 2)
         mat = csc_matrix((data, indices, indptr), shape=shape)
         #a = mat * mat.T #causes segfault if above constructor is called

--- a/scipy/sparse/tests/test_csc.py
+++ b/scipy/sparse/tests/test_csc.py
@@ -96,3 +96,36 @@ def test_argmax_overflow(ax):
         ii, jj = np.max(idx), np.argmax(idx)
 
     assert A[ii, jj] == A[-2, -2]
+
+def test_invalid_csc_negative_indices():
+    #see gh-8778 for more information
+    with pytest.raises(Exception) as e:
+        data = [1.0, 1.0]
+        # negative indices are invalid
+        indices = [-100, -555]
+        indptr = [0, 1, 2]
+        shape = (2, 1000)
+        mat = csc_matrix((data, indices, indptr), shape=shape)
+        #a = mat * mat.T #causes segfault if above constructor is called
+
+def test_invalid_csc_out_of_bounds_indices():
+    #see gh-8778 for more information
+    with pytest.raises(Exception) as e:
+        data = [1.0, 1.0]
+        # out of bounds indices are invalid
+        indices = [1001, 555]
+        indptr = [0, 1, 2]
+        shape = (2, 1000)
+        mat = csc_matrix((data, indices, indptr), shape=shape)
+        #a = mat * mat.T #causes segfault if above constructor is called
+
+def test_invalid_csc_unordered_indptr():
+    #see gh-8778 for more information
+    with pytest.raises(Exception) as e:
+        data = [1.0, 1.0]
+        # indptr should be monotonically ascending
+        indices = [1, 2]
+        indptr = [0, 5, 1]
+        shape = (2, 1000)
+        mat = csc_matrix((data, indices, indptr), shape=shape)
+        #a = mat * mat.T #causes segfault if above constructor is called

--- a/scipy/sparse/tests/test_csr.py
+++ b/scipy/sparse/tests/test_csr.py
@@ -113,3 +113,35 @@ def test_csr_bool_indexing():
     assert (slice_list2 == slice_array2).all()
     assert (slice_list3 == slice_array3).all()
 
+def test_invalid_csr():
+    #see gh-8778 for more information
+    with pytest.raises(Exception) as e:
+        data = [1.0, 1.0]
+        # negative indices are invalid
+        indices = [-100, -555]
+        indptr = [0, 1, 2]
+        shape = (2, 1000)
+        mat = csr_matrix((data, indices, indptr), shape=shape)
+        #a = mat * mat.T #causes segfault if above constructor is called
+
+def test_invalid_csr2():
+    #see gh-8778 for more information
+    with pytest.raises(Exception) as e:
+        data = [1.0, 1.0]
+        # out of bounds indices are invalid
+        indices = [1001, 555]
+        indptr = [0, 1, 2]
+        shape = (2, 1000)
+        mat = csr_matrix((data, indices, indptr), shape=shape)
+        #a = mat * mat.T #causes segfault if above constructor is called
+
+def test_invalid_csr3():
+    #see gh-8778 for more information
+    with pytest.raises(Exception) as e:
+        data = [1.0, 1.0]
+        # out of bounds indices are invalid
+        indices = [1, 2]
+        indptr = [0, 5, 1]
+        shape = (2, 1000)
+        mat = csr_matrix((data, indices, indptr), shape=shape)
+        #a = mat * mat.T #causes segfault if above constructor is called

--- a/scipy/sparse/tests/test_csr.py
+++ b/scipy/sparse/tests/test_csr.py
@@ -113,7 +113,7 @@ def test_csr_bool_indexing():
     assert (slice_list2 == slice_array2).all()
     assert (slice_list3 == slice_array3).all()
 
-def test_invalid_csr():
+def test_invalid_csr_negative_indices():
     #see gh-8778 for more information
     with pytest.raises(Exception) as e:
         data = [1.0, 1.0]
@@ -124,7 +124,7 @@ def test_invalid_csr():
         mat = csr_matrix((data, indices, indptr), shape=shape)
         #a = mat * mat.T #causes segfault if above constructor is called
 
-def test_invalid_csr2():
+def test_invalid_csr_out_of_bounds_indices():
     #see gh-8778 for more information
     with pytest.raises(Exception) as e:
         data = [1.0, 1.0]
@@ -135,11 +135,11 @@ def test_invalid_csr2():
         mat = csr_matrix((data, indices, indptr), shape=shape)
         #a = mat * mat.T #causes segfault if above constructor is called
 
-def test_invalid_csr3():
+def test_invalid_csr_unordered_indptr():
     #see gh-8778 for more information
     with pytest.raises(Exception) as e:
         data = [1.0, 1.0]
-        # out of bounds indices are invalid
+        # indptr should be monotonically ascending
         indices = [1, 2]
         indptr = [0, 5, 1]
         shape = (2, 1000)


### PR DESCRIPTION
Closes #8778
Closes #9253

Note that this has performance implications for loading sparse matrices using scipy.sparse.load_npz or when constructing sparse matrices using the tuple constructor. Invalid sparse matrices likely lead to a segfault, and are a security concern due to a "write-what-where" vulnerability in which an attacker could form a sparse matrix that reads/writes any address relative to the matrix object in memory. Because it uses the tuple version of the constructor, this can occur when load_npz is called to load a sparse matrix from a file.

It is very unlikely anyone would exploit this vulnerability due to the small number of potential victims and the small chance that someone would load a sparse matrix npz file from a source they did not trust. Therefore disclosure is not a big issue. However, it is a huge pain to debug this bug when encountered accidentally.

This commit provides a compromise between security/stability and speed, performing a full check of the sparse matrix in conditions where an error is likely to occur (creating a new matrix or loading one from disk), and not during matrix operations. Users who require performance for these operations can turn off full_check option using the safety_check argument in the constructor.