### PR TITLE
Fix behavior of binary morphology with output=input when iterations=1

### DIFF
--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -252,7 +252,6 @@ def _binary_erosion(input, structure, iterations, mask, output,
     if iterations == 1:
         _nd_image.binary_erosion(input, structure, mask, output,
                                  border_value, origin, invert, cit, 0)
-        return output
     elif cit and not brute_force:
         changed, coordinate_list = _nd_image.binary_erosion(
             input, structure, mask, output,

--- a/scipy/ndimage/tests/test_morphology.py
+++ b/scipy/ndimage/tests/test_morphology.py
@@ -2344,7 +2344,7 @@ def test_binary_closing_noninteger_brute_force_passes_when_true():
 @pytest.mark.parametrize('brute_force', [False, True])
 def test_binary_input_as_output(function, iterations, brute_force):
     rstate = numpy.random.RandomState(123)
-    data = rstate.random_integers(low=0, high=2, size=100, dtype=bool)
+    data = rstate.randint(low=0, high=2, size=100).astype(bool)
     ndi_func = getattr(ndimage, function)
 
     # input data is not modified
@@ -2359,7 +2359,7 @@ def test_binary_input_as_output(function, iterations, brute_force):
 
 def test_binary_hit_or_miss_input_as_output():
     rstate = numpy.random.RandomState(123)
-    data = rstate.random_integers(low=0, high=2, size=100, dtype=bool)
+    data = rstate.randint(low=0, high=2, size=100).astype(bool)
 
     # input data is not modified
     data_orig = data.copy()

--- a/scipy/ndimage/tests/test_morphology.py
+++ b/scipy/ndimage/tests/test_morphology.py
@@ -2343,8 +2343,8 @@ def test_binary_closing_noninteger_brute_force_passes_when_true():
 @pytest.mark.parametrize('iterations', [1, 5])
 @pytest.mark.parametrize('brute_force', [False, True])
 def test_binary_input_as_output(function, iterations, brute_force):
-    rng = numpy.random.default_rng(123)
-    data = rng.integers(low=0, high=2, size=100, dtype=bool)
+    rstate = numpy.random.RandomState(123)
+    data = rstate.random_integers(low=0, high=2, size=100, dtype=bool)
     ndi_func = getattr(ndimage, function)
 
     # input data is not modified
@@ -2358,8 +2358,8 @@ def test_binary_input_as_output(function, iterations, brute_force):
 
 
 def test_binary_hit_or_miss_input_as_output():
-    rng = numpy.random.default_rng(123)
-    data = rng.integers(low=0, high=2, size=100, dtype=bool)
+    rstate = numpy.random.RandomState(123)
+    data = rstate.random_integers(low=0, high=2, size=100, dtype=bool)
 
     # input data is not modified
     data_orig = data.copy()

--- a/scipy/ndimage/tests/test_morphology.py
+++ b/scipy/ndimage/tests/test_morphology.py
@@ -2334,3 +2334,38 @@ def test_binary_closing_noninteger_brute_force_passes_when_true():
     assert ndimage.binary_erosion(
         data, iterations=2, brute_force=0.0
     ) == ndimage.binary_erosion(data, iterations=2, brute_force=bool(0.0))
+
+
+@pytest.mark.parametrize(
+    'function',
+    ['binary_erosion', 'binary_dilation', 'binary_opening', 'binary_closing'],
+)
+@pytest.mark.parametrize('iterations', [1, 5])
+@pytest.mark.parametrize('brute_force', [False, True])
+def test_binary_input_as_output(function, iterations, brute_force):
+    rng = numpy.random.default_rng(123)
+    data = rng.integers(low=0, high=2, size=100, dtype=bool)
+    ndi_func = getattr(ndimage, function)
+
+    # input data is not modified
+    data_orig = data.copy()
+    expected = ndi_func(data, brute_force=brute_force, iterations=iterations)
+    assert_array_equal(data, data_orig)
+
+    # data should now contain the expected result
+    ndi_func(data, brute_force=brute_force, iterations=iterations, output=data)
+    assert_array_equal(expected, data)
+
+
+def test_binary_hit_or_miss_input_as_output():
+    rng = numpy.random.default_rng(123)
+    data = rng.integers(low=0, high=2, size=100, dtype=bool)
+
+    # input data is not modified
+    data_orig = data.copy()
+    expected = ndimage.binary_hit_or_miss(data)
+    assert_array_equal(data, data_orig)
+
+    # data should now contain the expected result
+    ndimage.binary_hit_or_miss(data, output=data)
+    assert_array_equal(expected, data)


### PR DESCRIPTION

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
None

#### What does this implement/fix?
This one line fix corrects the behavior of `binary_erosion`, `binary_dilation` and `binary_fill_holes` when called in the following style:

```Python
binary_erosion(image, output=image)
```
The test cases added here do not pass for all parameter combinations without the change made here.

#### Additional information

An internal temporary array is made in this case since in-place erosion is not supported in the underlying C code. There was a fast return path that resulted in the output of the temporary array not being copied back to `output` when iterations=1. Specifically, the code path needs to reach these lines before returning:
https://github.com/scipy/scipy/blob/5fba81b49065cd929dbd8df64a43a4d57fe0c21e/scipy/ndimage/morphology.py#L287-L289

