### PR TITLE
 BENCH: add benchmark for somersd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -280,6 +280,7 @@ scipy/stats/biasedurn.cxx
 scipy/stats/biasedurn.pyx
 scipy/stats/_sobol.c
 scipy/stats/_qmc_cy.cxx
+scipy/stats/_hypotests_pythran.cpp
 scipy/version.py
 scipy/special/_exprel.c
 scipy/optimize/_group_columns.c

--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -458,3 +458,17 @@ class DistanceFunctions(Benchmark):
         distance = stats.wasserstein_distance(
                  self.u_values, self.v_values, 
                  self.u_weights, self.v_weights)
+
+
+class Somersd(Benchmark):
+    param_names = ['n_size']
+    params = [
+        [10, 100]
+    ]
+    def setup(self, n_size):
+        rng = np.random.default_rng(12345678)
+        self.x = rng.choice(n_size, size=n_size)
+        self.y = rng.choice(n_size, size=n_size)
+
+    def time_somersd(self, n_size):
+        res = stats.somersd(self.x, self.y)


### PR DESCRIPTION

https://github.com/scipy/scipy/pull/14308#pullrequestreview-693414732
Since `_tau_b` doesn't seem to be a public function, I only added benchmark for `somersd`.

Before Pythran's speedup:
```
[100.00%] ··· ======== ==========
               n_size            
              -------- ----------
                 10     889±10μs 
                100     106±1ms  
              ======== ============
```
After Pythran's speedup(7x-20x faster):
```
[100.00%] ··· ======== ============
               n_size              
              -------- ------------
                 10      125±5μs   
                100     5.37±0.1ms 
              ======== ============
```

cc @rgommers @serge-sans-paille 
