### PR TITLE
BUG: Reference count leak in distance_pybind

### DIFF
--- a/scipy/spatial/src/distance_pybind.cpp
+++ b/scipy/spatial/src/distance_pybind.cpp
@@ -243,7 +243,7 @@ py::array_t<T> npy_asarray(const py::handle& obj, int flags = 0) {
     if (arr == nullptr) {
         throw py::error_already_set();
     }
-    return py::reinterpret_borrow<py::array_t<T>>(arr);
+    return py::reinterpret_steal<py::array_t<T>>(arr);
 }
 
 // Cast python object to NumPy array with unspecified dtype.
@@ -253,7 +253,7 @@ py::array npy_asarray(const py::handle& obj, int flags = 0) {
     if (arr == nullptr) {
         throw py::error_already_set();
     }
-    return py::reinterpret_borrow<py::array>(arr);
+    return py::reinterpret_steal<py::array>(arr);
 }
 
 template <typename scalar_t>

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -35,6 +35,7 @@
 import os.path
 
 from functools import wraps, partial
+import weakref
 
 import numpy as np
 import warnings
@@ -649,6 +650,28 @@ class TestCdist:
                 Y2 = cdist(X1_copy, X2_copy, metric, **kwargs)
                 # test that output is numerically equivalent
                 _assert_within_tol(Y1, Y2, eps, verbose > 2)
+
+    def test_cdist_refcount(self):
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning, "'wminkowski' metric is deprecated")
+            for metric in _METRICS_NAMES:
+                x1 = np.random.rand(10, 10)
+                x2 = np.random.rand(10, 10)
+
+                kwargs = dict()
+                if metric in ['minkowski', 'wminkowski']:
+                    kwargs['p'] = 1.23
+                    if metric == 'wminkowski':
+                        kwargs['w'] = 1.0 / x1.std(axis=0)
+
+                out = cdist(x1, x2, metric=metric, **kwargs)
+
+                # Check reference counts aren't messed up. If we only hold weak
+                # references, the arrays should be deallocated.
+                weak_refs = [weakref.ref(v) for v in (x1, x2, out)]
+                del x1, x2, out
+                assert all(weak_ref() is None for weak_ref in weak_refs)
+
 
 class TestPdist:
 


### PR DESCRIPTION
#### Reference issue
Fixes #14382

#### What does this implement/fix?
These `PyArray_FromAny` wrappers were using `reinterpret_borrow` which actually increments the refcount on the array, and in this case leaks the original reference. Instead, we need `reinterpret_steal` which just wraps the object without increasing the reference count, then the original reference is managed automatically.