### PR TITLE
MAINT: Removed deprecated NumPy C api from `sparse`

### DIFF
--- a/scipy/sparse/setup.py
+++ b/scipy/sparse/setup.py
@@ -43,7 +43,7 @@ def configuration(parent_package='',top_path=None):
                'util.h']
     depends = [os.path.join('sparsetools', hdr) for hdr in depends],
     sparsetools = config.add_extension('_sparsetools',
-                         define_macros=[('__STDC_FORMAT_MACROS', 1)],
+                         define_macros=[('__STDC_FORMAT_MACROS', 1)] + numpy_nodepr_api['define_macros'],
                          depends=depends,
                          include_dirs=['sparsetools'],
                          sources=[os.path.join('sparsetools', 'sparsetools.cxx'),
@@ -51,8 +51,7 @@ def configuration(parent_package='',top_path=None):
                                   os.path.join('sparsetools', 'csc.cxx'),
                                   os.path.join('sparsetools', 'bsr.cxx'),
                                   os.path.join('sparsetools', 'other.cxx'),
-                                  get_sparsetools_sources],
-                         **numpy_nodepr_api
+                                  get_sparsetools_sources]
                          )
     sparsetools._pre_build_hook = set_cxx_flags_hook
 

--- a/scipy/sparse/setup.py
+++ b/scipy/sparse/setup.py
@@ -6,7 +6,7 @@ import subprocess
 def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
     from scipy._build_utils.compiler_helper import set_cxx_flags_hook
-
+    from scipy._build_utils import numpy_nodepr_api
     config = Configuration('sparse',parent_package,top_path)
 
     config.add_data_dir('tests')
@@ -51,7 +51,8 @@ def configuration(parent_package='',top_path=None):
                                   os.path.join('sparsetools', 'csc.cxx'),
                                   os.path.join('sparsetools', 'bsr.cxx'),
                                   os.path.join('sparsetools', 'other.cxx'),
-                                  get_sparsetools_sources]
+                                  get_sparsetools_sources],
+                         **numpy_nodepr_api
                          )
     sparsetools._pre_build_hook = set_cxx_flags_hook
 

--- a/scipy/sparse/sparsetools/sparsetools.cxx
+++ b/scipy/sparse/sparsetools/sparsetools.cxx
@@ -136,7 +136,6 @@ call_thunk(char ret_spec, const char *spec, thunk_t *thunk, PyObject *args)
         int n_supported_typenums;
         int cur_typenum;
         PyObject *arg;
-        PyArray_Descr *dtype;
 
         if (j >= MAX_ARGS) {
             PyErr_SetString(PyExc_ValueError,
@@ -215,9 +214,9 @@ call_thunk(char ret_spec, const char *spec, thunk_t *thunk, PyObject *args)
         }
 
         /* Find a compatible supported data type */
-        dtype = PyArray_DESCR(arg_arrays[j]);
+
         for (k = 0; k < n_supported_typenums; ++k) {
-            if (PyArray_CanCastSafely(dtype->type_num, supported_typenums[k]) &&
+            if (PyArray_CanCastSafely(PyArray_TYPE((PyArrayObject *)arg_arrays[j]), supported_typenums[k]) &&
                 (cur_typenum == -1 || PyArray_CanCastSafely(cur_typenum, supported_typenums[k])))
             {
                 cur_typenum = supported_typenums[k];
@@ -311,10 +310,10 @@ call_thunk(char ret_spec, const char *spec, thunk_t *thunk, PyObject *args)
 
             /* Cast if necessary */
             arg = arg_arrays[j];
-            if (PyArray_EquivTypenums(PyArray_DESCR(arg)->type_num, cur_typenum)) {
+            if (PyArray_EquivTypenums(PyArray_TYPE((PyArrayObject *)arg), cur_typenum)) {
                 /* No cast needed. */
             }
-            else if (!is_output[j] || PyArray_CanCastSafely(cur_typenum, PyArray_DESCR(arg)->type_num)) {
+            else if (!is_output[j] || PyArray_CanCastSafely(cur_typenum, PyArray_TYPE((PyArrayObject *)arg))) {
                 /* Cast needed. Output arrays require safe cast back. */
                 arg_arrays[j] = c_array_from_object(arg, cur_typenum, is_output[j]);
                 Py_DECREF(arg);
@@ -331,11 +330,11 @@ call_thunk(char ret_spec, const char *spec, thunk_t *thunk, PyObject *args)
         }
 
         /* Grab value */
-        arg_list[j] = PyArray_DATA(arg_arrays[j]);
+        arg_list[j] = PyArray_DATA((PyArrayObject *)arg_arrays[j]);
 
         /* Find maximum array size */
-        if (PyArray_SIZE(arg_arrays[j]) > max_array_size) {
-            max_array_size = PyArray_SIZE(arg_arrays[j]);
+        if (PyArray_SIZE((PyArrayObject *)arg_arrays[j]) > max_array_size) {
+            max_array_size = PyArray_SIZE((PyArrayObject *)arg_arrays[j]);
         }
     }
 
@@ -502,7 +501,7 @@ static PyObject *array_from_std_vector_and_free(int typenum, void *p)
         npy_intp length = v->size();                            \
         PyObject *obj = PyArray_SimpleNew(1, &length, typenum); \
         if (length > 0) {                                       \
-            memcpy(PyArray_DATA(obj), &((*v)[0]),               \
+            memcpy(PyArray_DATA((PyArrayObject *)obj), &((*v)[0]), \
                    sizeof(ctype)*length);                       \
         }                                                       \
         delete v;                                               \
@@ -522,17 +521,17 @@ static PyObject *c_array_from_object(PyObject *obj, int typenum, int is_output)
 {
     if (!is_output) {
         if (typenum == -1) {
-            return PyArray_FROM_OF(obj, NPY_C_CONTIGUOUS|NPY_NOTSWAPPED);
+            return PyArray_FROM_OF(obj, NPY_ARRAY_C_CONTIGUOUS|NPY_ARRAY_NOTSWAPPED);
         }
         else {
-            return PyArray_FROM_OTF(obj, typenum, NPY_C_CONTIGUOUS|NPY_NOTSWAPPED);
+            return PyArray_FROM_OTF(obj, typenum, NPY_ARRAY_C_CONTIGUOUS|NPY_ARRAY_NOTSWAPPED);
         }
     }
     else {
         #ifdef HAVE_WRITEBACKIFCOPY
-            int flags = NPY_C_CONTIGUOUS|NPY_WRITEABLE|NPY_ARRAY_WRITEBACKIFCOPY|NPY_NOTSWAPPED;
+            int flags = NPY_ARRAY_C_CONTIGUOUS|NPY_ARRAY_WRITEABLE|NPY_ARRAY_WRITEBACKIFCOPY|NPY_ARRAY_NOTSWAPPED;
         #else
-            int flags = NPY_C_CONTIGUOUS|NPY_WRITEABLE|NPY_UPDATEIFCOPY|NPY_NOTSWAPPED;
+            int flags = NPY_ARRAY_C_CONTIGUOUS|NPY_ARRAY_WRITEABLE|NPY_UPDATEIFCOPY|NPY_ARRAY_NOTSWAPPED;
         #endif
         if (typenum == -1) {
             return PyArray_FROM_OF(obj, flags);


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
* References: https://github.com/rgommers/scipy/issues/30
* Using `numpy_nodepr_api` and removing `Wno-cpp` flags

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
cc @rgommers 