### PR TITLE
DOC: docstring fix for default of n param of interpolate.pade

### DIFF
--- a/scipy/interpolate/_pade.py
+++ b/scipy/interpolate/_pade.py
@@ -15,7 +15,7 @@ def pade(an, m, n=None):
         The order of the returned approximating polynomial `q`.
     n : int, optional
         The order of the returned approximating polynomial `p`. By default,
-        the order is ``len(an)-m``.
+        the order is ``len(an)-1-m``.
 
     Returns
     -------


### PR DESCRIPTION
Default param value of `n` of `pade` is missing -1 in docstring.

#### What does this implement/fix?

The docstring for parameter 'n' of the interpolate.pade function incorrectly is ``len(an)-n``.
It should be ``len(an)-1-n`` as can be seen in the implementation of the pade function.

I noticed this error when running the example lines in the online documentation. The default behavior does not correspond to the current live online documentation. But with this docstring fix (to made the actual code implementation) the default behavior I see would make sense.
