### PR TITLE
MAINT: minor cleanups in usage of `compute_uv` keyword of `svd`

### DIFF
--- a/scipy/linalg/matfuncs.py
+++ b/scipy/linalg/matfuncs.py
@@ -646,7 +646,7 @@ def signm(A, disp=True):
 
     # Shifting to avoid zero eigenvalues. How to ensure that shifting does
     # not change the spectrum too much?
-    vals = svd(A, compute_uv=0)
+    vals = svd(A, compute_uv=False)
     max_sv = np.amax(vals)
     # min_nonzero_sv = vals[(vals>max_sv*errtol).tolist().count(1)-1]
     # c = 0.5/min_nonzero_sv

--- a/scipy/optimize/nonlin.py
+++ b/scipy/optimize/nonlin.py
@@ -868,7 +868,7 @@ class LowRankMatrix:
         D, R = qr(D, mode='economic')
         C = dot(C, R.T.conj())
 
-        U, S, WH = svd(C, full_matrices=False, compute_uv=True)
+        U, S, WH = svd(C, full_matrices=False)
 
         C = dot(C, inv(WH))
         D = dot(D, WH.T.conj())


### PR DESCRIPTION
Follow up of the discussion in https://github.com/data-apis/array-api/issues/214#issuecomment-878262647

I went on and looked at all the uses of `svd` within scipy and updated some that were not correct / presented some redundancy.

For reference, the only `svd` on a non-square matrix that did not use `full_matrices=False` and that I was not able to assess as incorrect was in https://github.com/scipy/scipy/blob/b62bd82f571f069bcf14d0f19c94da146db68441/scipy/optimize/_remove_redundancy.py#L400 and same a few lines afterwards. I believe that this is a proper use of `svd` with `full_matrices=True`. I wonder whether the algorithm could be implemented with a reduced SVD, that I do not know.

cc @rgommers 