### PR TITLE
DOC/CI: pin sphinx to !=4.1.0

### DIFF
--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -1,6 +1,6 @@
 # Note: this should disappear at some point. For now, please keep it
 #       in sync with the doc dependencies in pyproject.toml
-Sphinx!=3.1.0, <4.1.0
+Sphinx!=3.1.0, !=4.1.0
 pydata-sphinx-theme>=0.6.1
 sphinx-panels>=0.5.2
 matplotlib>2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ test = [
     "scikit-umfpack",
 ]
 doc = [
-    "sphinx!=3.1.0, <4.1.0",
+    "sphinx!=3.1.0, !=4.1.0",
     "pydata-sphinx-theme>=0.6.1",
     "sphinx-panels>=0.5.2",
     "matplotlib>2",


### PR DESCRIPTION
This is a follow up of #14397

Sphinx 4.1.1 has been released with the necessary fix. They don't seem to yank versions, so for now we can just go with excluding this version.

[skip azp] [skip actions]
