### PR TITLE
DEP: deprecate private but non-underscored `signal.spline` namespace

### DIFF
--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -294,9 +294,13 @@ from .waveforms import *
 from ._max_len_seq import max_len_seq
 from ._upfirdn import upfirdn
 
-# The spline module (a C extension) provides:
-#     cspline2d, qspline2d, sepfir2d, symiirord1, symiirord2
-from .spline import *
+from ._spline import (
+ cspline2d,
+ qspline2d,
+ sepfir2d,
+ symiirorder1,
+ symiirorder2,
+)
 
 from .bsplines import *
 from .filter_design import *

--- a/scipy/signal/bsplines.py
+++ b/scipy/signal/bsplines.py
@@ -4,7 +4,7 @@ from numpy.core.umath import (sqrt, exp, greater, less, cos, add, sin,
                               less_equal, greater_equal)
 
 # From splinemodule.c
-from .spline import cspline2d, sepfir2d
+from ._spline import cspline2d, sepfir2d
 
 from scipy.special import comb
 from scipy._lib._util import float_factorial

--- a/scipy/signal/setup.py
+++ b/scipy/signal/setup.py
@@ -56,7 +56,7 @@ def configuration(parent_package='', top_path=None):
         '_upfirdn_apply', sources=['_upfirdn_apply.c'])
     spline_src = ['splinemodule.c', 'S_bspline_util.c', 'D_bspline_util.c',
                   'C_bspline_util.c', 'Z_bspline_util.c', 'bspline_util.c']
-    config.add_extension('spline', sources=spline_src, **numpy_nodepr_api)
+    config.add_extension('_spline', sources=spline_src, **numpy_nodepr_api)
 
     return config
 

--- a/scipy/signal/spline.py
+++ b/scipy/signal/spline.py
@@ -1,0 +1,26 @@
+# This file is not meant for public use and will be removed in the future
+# versions of SciPy. Use the `scipy.signal` namespace for importing the
+# functions included below.
+
+import warnings
+
+from . import _spline
+
+__all__ = ['cspline2d', 'qspline2d', 'sepfir2d', 'symiirorder1', 'symiirorder2']
+
+
+def __dir__():
+    return __all__
+
+
+def __getattr__(name):
+    if name not in __all__:
+        raise AttributeError(
+            f"scipy.signal.spline is deprecated and has no attribute {name}. "
+            "Try looking in scipy.signal instead.")
+
+    warnings.warn(f"Please use `{name}` from the `scipy.signal` namespace, "
+                  "the `scipy.signal.spline` namespace is deprecated.",
+                  category=DeprecationWarning, stacklevel=2)
+    return getattr(_spline, name)
+

--- a/scipy/signal/splinemodule.c
+++ b/scipy/signal/splinemodule.c
@@ -541,7 +541,7 @@ static struct PyMethodDef toolbox_module_methods[] = {
 /* Initialization function for the module */
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
-    "spline",
+    "_spline",
     NULL,
     -1,
     toolbox_module_methods,
@@ -551,7 +551,7 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
-PyObject *PyInit_spline(void)
+PyObject *PyInit__spline(void)
 {
     PyObject *m, *d, *s;
 

--- a/scipy/signal/tests/test_bsplines.py
+++ b/scipy/signal/tests/test_bsplines.py
@@ -254,3 +254,13 @@ def test_sepfir2d_invalid_image():
 
     with pytest.raises(ValueError, match="object of too small depth"):
         signal.sepfir2d(image[0], filt, filt)
+
+def test_cspline2d():
+    np.random.seed(181819142)
+    image = np.random.rand(71, 73)
+    ck = signal.cspline2d(image, 8.0)
+
+def test_qspline2d():
+    np.random.seed(181819143)
+    image = np.random.rand(71, 73)
+    qk = signal.qspline2d(image)


### PR DESCRIPTION
See gh-14360 for details. This shows the approach for a small namespace that clearly was and is private. 

I also noticed that some of these functions aren't even tested - let's ignore that for now (they probably should be deprecated outright, I'm not sure spline functionality in `signal` makes sense to begin with).