### PR TITLE
ENH: Add args argument for callable in quad_vec

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -401,6 +401,18 @@ def getfullargspec_no_self(func):
                        kwdefaults or None, annotations)
 
 
+class _FunctionWrapper:
+    """
+    Object to wrap user's function, allowing picklability
+    """
+    def __init__(self, f, args):
+        self.f = f
+        self.args = [] if args is None else args
+
+    def __call__(self, x):
+        return self.f(x, *self.args)
+
+
 class MapWrapper:
     """
     Parallelisation wrapper for working with map-like callables, such as

--- a/scipy/integrate/_quad_vec.py
+++ b/scipy/integrate/_quad_vec.py
@@ -102,7 +102,8 @@ class _Bunch:
 
 
 def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, limit=10000,
-             workers=1, points=None, quadrature=None, full_output=False, args=()):
+             workers=1, points=None, quadrature=None, full_output=False,
+             args=()):
     r"""Adaptive integration of a vector-valued function.
 
     Parameters

--- a/scipy/integrate/_quad_vec.py
+++ b/scipy/integrate/_quad_vec.py
@@ -103,7 +103,7 @@ class _Bunch:
 
 def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, limit=10000,
              workers=1, points=None, quadrature=None, full_output=False,
-             args=()):
+             *, args=()):
     r"""Adaptive integration of a vector-valued function.
 
     Parameters

--- a/scipy/integrate/_quad_vec.py
+++ b/scipy/integrate/_quad_vec.py
@@ -102,7 +102,7 @@ class _Bunch:
 
 
 def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, limit=10000,
-             workers=1, points=None, quadrature=None, full_output=False):
+             workers=1, points=None, quadrature=None, full_output=False, args=()):
     r"""Adaptive integration of a vector-valued function.
 
     Parameters
@@ -140,6 +140,8 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, li
         Default: 'gk21' for finite intervals and 'gk15' for (semi-)infinite
     full_output : bool, optional
         Return an additional ``info`` dictionary.
+    args : tuple, optional
+        Extra arguments to pass to function, if any.
 
     Returns
     -------
@@ -214,6 +216,12 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, li
     """
     a = float(a)
     b = float(b)
+
+    if args:
+        if not isinstance(args, tuple):
+            args = (args,)
+        _f = f
+        f = lambda x: _f(x, *args)
 
     # Use simple transformations to deal with integrals over infinite
     # intervals.

--- a/scipy/integrate/_quad_vec.py
+++ b/scipy/integrate/_quad_vec.py
@@ -101,6 +101,18 @@ class _Bunch:
                                              for k in self.__keys))
 
 
+class _FunctionWrapper:
+    """
+    Object to wrap user function, allowing picklability
+    """
+    def __init__(self, f, args):
+        self.f = f
+        self.args = args
+
+    def __call__(self, x):
+        return self.f(x, *self.args)
+
+
 def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, limit=10000,
              workers=1, points=None, quadrature=None, full_output=False,
              *, args=()):
@@ -221,8 +233,9 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, li
     if args:
         if not isinstance(args, tuple):
             args = (args,)
-        _f = f
-        f = lambda x: _f(x, *args)
+
+        # create a wrapped function to allow the use of map and Pool.map
+        f = _FunctionWrapper(f, args)
 
     # Use simple transformations to deal with integrals over infinite
     # intervals.

--- a/scipy/integrate/_quad_vec.py
+++ b/scipy/integrate/_quad_vec.py
@@ -144,6 +144,8 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, li
     args : tuple, optional
         Extra arguments to pass to function, if any.
 
+        .. versionadded:: 1.8.0
+
     Returns
     -------
     res : {float, array-like}

--- a/scipy/integrate/_quad_vec.py
+++ b/scipy/integrate/_quad_vec.py
@@ -6,7 +6,7 @@ import functools
 
 import numpy as np
 
-from scipy._lib._util import MapWrapper
+from scipy._lib._util import MapWrapper, _FunctionWrapper
 
 
 class LRUDict(collections.OrderedDict):
@@ -99,18 +99,6 @@ class _Bunch:
     def __repr__(self):
         return "_Bunch({})".format(", ".join("{}={}".format(k, repr(self.__dict__[k]))
                                              for k in self.__keys))
-
-
-class _FunctionWrapper:
-    """
-    Object to wrap user function, allowing picklability
-    """
-    def __init__(self, f, args):
-        self.f = f
-        self.args = args
-
-    def __call__(self, x):
-        return self.f(x, *self.args)
 
 
 def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, limit=10000,

--- a/scipy/integrate/tests/test__quad_vec.py
+++ b/scipy/integrate/tests/test__quad_vec.py
@@ -87,6 +87,15 @@ def test_quad_vec_simple_inf(quadrature):
     assert_allclose(res, exact, rtol=0, atol=max(epsabs, 1.5 * err))
 
 
+def test_quad_vec_args():
+    f = lambda x, a: x * (x + a) * np.arange(3)
+    a = 2
+    exact = np.array([0, 4/3, 8/3])
+
+    res, err = quad_vec(f, 0, 1, args=(a,))
+    assert_allclose(res, exact, rtol=0, atol=1e-4)
+
+
 def _lorenzian(x):
     return 1 / (1 + x**2)
 
@@ -102,6 +111,25 @@ def test_quad_vec_pool():
         f = lambda x: 1 / (1 + x**2)
         res, err = quad_vec(f, -np.inf, np.inf, norm='max', epsabs=1e-4, workers=pool.map)
         assert_allclose(res, np.pi, rtol=0, atol=1e-4)
+
+
+def _func_with_args(x, a):
+    return x * (x + a) * np.arange(3)
+
+
+def test_quad_vec_pool_args():
+    from multiprocessing.dummy import Pool
+
+    f = _func_with_args
+    a = 2
+    exact = np.array([0, 4/3, 8/3])
+
+    res, err = quad_vec(f, 0, 1, args=(a,), workers=4)
+    assert_allclose(res, exact, rtol=0, atol=1e-4)
+
+    with Pool(10) as pool:
+        res, err = quad_vec(f, 0, 1, args=(a,), workers=pool.map)
+        assert_allclose(res, exact, rtol=0, atol=1e-4)
 
 
 @quadrature_params

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -7,7 +7,7 @@ import warnings
 import numpy as np
 from scipy.optimize import OptimizeResult, minimize
 from scipy.optimize.optimize import _status_message
-from scipy._lib._util import check_random_state, MapWrapper
+from scipy._lib._util import check_random_state, MapWrapper, _FunctionWrapper
 
 from scipy.optimize._constraints import (Bounds, new_bounds_to_old,
                                          NonlinearConstraint, LinearConstraint)
@@ -1332,18 +1332,6 @@ class DifferentialEvolutionSolver:
         self.random_number_generator.shuffle(idxs)
         idxs = idxs[:number_samples]
         return idxs
-
-
-class _FunctionWrapper:
-    """
-    Object to wrap user cost function, allowing picklability
-    """
-    def __init__(self, f, args):
-        self.f = f
-        self.args = [] if args is None else args
-
-    def __call__(self, x):
-        return self.f(x, *self.args)
 
 
 class _ConstraintWrapper:


### PR DESCRIPTION
#### Reference issue
Fixes #14412 

#### What does this implement/fix?
Provision to provide arguments for the callable function we wish to integrate with `scipy.integrate.quad_vec`.

#### Additional information
`scipy.integrate.quadrature` and `scipy.integrate.quad` both provide this argument. So it makes sense that it should be available in `quad_vec`.

Since `quad_vec` was added later, this got skipped somehow. Although when I dug up to find a good reason, I found the `args` argument to pass extra arguments was actually supported in the initial commit [here from PR #9642](https://github.com/scipy/scipy/pull/9642/commits/f48e866f9c6356423c0d648a5b015c373abf04ba), but got removed in the following [commit](https://github.com/scipy/scipy/pull/9642/commits/9fe95612b81a196887ac2bf60b890a717ee11feb) when the decision (see [comment #9642](https://github.com/scipy/scipy/pull/9642#issuecomment-451122360)) to make `quad_vec` a public function was taken.