### PR TITLE
MAINT: extra pythran annotation for i686 support

### DIFF
--- a/scipy/optimize/_group_columns.py
+++ b/scipy/optimize/_group_columns.py
@@ -54,6 +54,8 @@ def group_dense(m, n, A):
 
 #pythran export group_sparse(int, int, intc[], intc[])
 #pythran export group_sparse(int, int, int[], int[])
+#pythran export group_sparse(int, int, intc[::], intc[::])
+#pythran export group_sparse(int, int, int[::], int[::])
 def group_sparse(m, n, indices, indptr):
     groups = -np.ones(n, dtype=np.intp)
     current_group = 0

--- a/scipy/signal/_max_len_seq_inner.py
+++ b/scipy/signal/_max_len_seq_inner.py
@@ -4,6 +4,7 @@
 import numpy as np
 
 #pythran export _max_len_seq_inner(intp[], int8[], int, int, int8[])
+#pythran export _max_len_seq_inner(int[], int8[], int, int, int8[])
 
 # Fast inner loop of max_len_seq.
 def _max_len_seq_inner(taps, state, nbits, length, seq):


### PR DESCRIPTION
Bug spotted on Fedora, see https://src.fedoraproject.org/rpms/scipy/pull-request/22

The `int[::]` annotation is used to accept non-contiguous views.
