### PR TITLE
BUG/ENH: more stable recursion for 2-sample ks test exact p-values

### DIFF
--- a/scipy/stats/_hypotests_pythran.py
+++ b/scipy/stats/_hypotests_pythran.py
@@ -77,7 +77,7 @@ def _compute_outer_prob_inside_method(m, n, g, h):
     to (m, n) which satisfy |x/m - y/n| < h / lcm(m, n).
     The paths make steps of size +1 in either positive x or positive y
     directions.
-    We are, however, interested in 1 - proportion to computs p-values,
+    We are, however, interested in 1 - proportion to computes p-values,
     so we change the recursion to compute 1 - p directly while staying
     within the "inside method" a described by Hodges.
 
@@ -120,7 +120,7 @@ def _compute_outer_prob_inside_method(m, n, g, h):
     # Instead we rescale based on the magnitude of the right most term in
     # the column and keep track of an exponent separately and apply
     # it at the end of the calculation.  Similarly when multiplying by
-    # the binomial coefficint
+    # the binomial coefficient
     dtype = np.float64
     A = np.ones(lenA, dtype=dtype)
     # Initialize the first column

--- a/scipy/stats/_hypotests_pythran.py
+++ b/scipy/stats/_hypotests_pythran.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 #pythran export _Aij(float[:,:], int, int)
 #pythran export _Aij(int[:,:], int, int)
 def _Aij(A, i, j):
@@ -47,3 +49,100 @@ def _a_ij_Aij_Dij2(A):
         for j in range(n):
             count += A[i, j]*(_Aij(A, i, j) - _Dij(A, i, j))**2
     return count
+
+
+#pythran export _compute_outer_prob_inside_method(int64, int64, int64, int64)
+def _compute_outer_prob_inside_method(m, n, g, h):
+    """
+    Count the proportion of paths that do not stay strictly inside two
+    diagonal lines.
+
+    Parameters
+    ----------
+    m : integer
+        m > 0
+    n : integer
+        n > 0
+    g : integer
+        g is greatest common divisor of m and n
+    h : integer
+        0 <= h <= lcm(m,n)
+
+    Returns
+    -------
+    p : float
+        The proportion of paths that do not stay inside the two lines.
+
+    The classical algorithm counts the integer lattice paths from (0, 0)
+    to (m, n) which satisfy |x/m - y/n| < h / lcm(m, n).
+    The paths make steps of size +1 in either positive x or positive y
+    directions.
+    We are, however, interested in 1 - proportion to computs p-values,
+    so we change the recursion to compute 1 - p directly while staying
+    within the "inside method" a described by Hodges.
+
+    We generally follow Hodges' treatment of Drion/Gnedenko/Korolyuk.
+    Hodges, J.L. Jr.,
+    "The Significance Probability of the Smirnov Two-Sample Test,"
+    Arkiv fiur Matematik, 3, No. 43 (1958), 469-86.
+
+    For the recursion for 1-p see
+    Viehmann, T.: "Numerically more stable computation of the p-values
+    for the two-sample Kolmogorov-Smirnov test," arXiv: 2102.08037
+
+    """
+    # Probability is symmetrical in m, n.  Computation below uses m >= n.
+    if m < n:
+        m, n = n, m
+    mg = m // g
+    ng = n // g
+
+    # Count the integer lattice paths from (0, 0) to (m, n) which satisfy
+    # |nx/g - my/g| < h.
+    # Compute matrix A such that:
+    #  A(x, 0) = A(0, y) = 1
+    #  A(x, y) = A(x, y-1) + A(x-1, y), for x,y>=1, except that
+    #  A(x, y) = 0 if |x/m - y/n|>= h
+    # Probability is A(m, n)/binom(m+n, n)
+    # Optimizations exist for m==n, m==n*p.
+    # Only need to preserve a single column of A, and only a
+    # sliding window of it.
+    # minj keeps track of the slide.
+    minj, maxj = 0, min(int(np.ceil(h / mg)), n + 1)
+    curlen = maxj - minj
+    # Make a vector long enough to hold maximum window needed.
+    lenA = min(2 * maxj + 2, n + 1)
+    # This is an integer calculation, but the entries are essentially
+    # binomial coefficients, hence grow quickly.
+    # Scaling after each column is computed avoids dividing by a
+    # large binomial coefficient at the end, but is not sufficient to avoid
+    # the large dyanamic range which appears during the calculation.
+    # Instead we rescale based on the magnitude of the right most term in
+    # the column and keep track of an exponent separately and apply
+    # it at the end of the calculation.  Similarly when multiplying by
+    # the binomial coefficint
+    dtype = np.float64
+    A = np.ones(lenA, dtype=dtype)
+    # Initialize the first column
+    A[minj:maxj] = 0.0
+    for i in range(1, m + 1):
+        # Generate the next column.
+        # First calculate the sliding window
+        lastminj, lastlen = minj, curlen
+        minj = max(int(np.floor((ng * i - h) / mg)) + 1, 0)
+        minj = min(minj, n)
+        maxj = min(int(np.ceil((ng * i + h) / mg)), n + 1)
+        if maxj <= minj:
+            return 1.0
+        # Now fill in the values. We cannot use cumsum, unfortunately.
+        val = 0.0 if minj == 0 else 1.0
+        for jj in range(maxj - minj):
+            j = jj + minj
+            val = (A[jj + minj - lastminj] * i + val * j) / (i + j)
+            A[jj] = val
+        curlen = maxj - minj
+        if lastlen > curlen:
+            # Set some carried-over elements to 1
+            A[maxj - minj:maxj - minj + (lastlen - curlen)] = 1
+
+    return A[maxj - minj - 1]

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -48,6 +48,7 @@ from ._stats import (_kendall_dis, _toint64, _weightedrankedtau,
                      _local_correlations)
 from dataclasses import make_dataclass
 from ._hypotests import _all_partitions
+from ._hypotests_pythran import _compute_outer_prob_inside_method
 from ._axis_nan_policy import (_axis_nan_policy_factory,
                                _broadcast_concatenate)
 
@@ -7085,109 +7086,6 @@ def ks_1samp(x, cdf, args=(), alternative='two-sided', mode='auto'):
 Ks_2sampResult = KstestResult
 
 
-def _compute_prob_inside_method(m, n, g, h):
-    """
-    Count the proportion of paths that stay strictly inside two diagonal lines.
-
-    Parameters
-    ----------
-    m : integer
-        m > 0
-    n : integer
-        n > 0
-    g : integer
-        g is greatest common divisor of m and n
-    h : integer
-        0 <= h <= lcm(m,n)
-
-    Returns
-    -------
-    p : float
-        The proportion of paths that stay inside the two lines.
-
-    Count the integer lattice paths from (0, 0) to (m, n) which satisfy
-    |x/m - y/n| < h / lcm(m, n).
-    The paths make steps of size +1 in either positive x or positive y
-    directions.
-
-    We generally follow Hodges' treatment of Drion/Gnedenko/Korolyuk.
-    Hodges, J.L. Jr.,
-    "The Significance Probability of the Smirnov Two-Sample Test,"
-    Arkiv fiur Matematik, 3, No. 43 (1958), 469-86.
-
-    """
-    # Probability is symmetrical in m, n.  Computation below uses m >= n.
-    if m < n:
-        m, n = n, m
-    mg = m // g
-    ng = n // g
-
-    # Count the integer lattice paths from (0, 0) to (m, n) which satisfy
-    # |nx/g - my/g| < h.
-    # Compute matrix A such that:
-    #  A(x, 0) = A(0, y) = 1
-    #  A(x, y) = A(x, y-1) + A(x-1, y), for x,y>=1, except that
-    #  A(x, y) = 0 if |x/m - y/n|>= h
-    # Probability is A(m, n)/binom(m+n, n)
-    # Optimizations exist for m==n, m==n*p.
-    # Only need to preserve a single column of A, and only a
-    # sliding window of it.
-    # minj keeps track of the slide.
-    minj, maxj = 0, min(int(np.ceil(h / mg)), n + 1)
-    curlen = maxj - minj
-    # Make a vector long enough to hold maximum window needed.
-    lenA = min(2 * maxj + 2, n + 1)
-    # This is an integer calculation, but the entries are essentially
-    # binomial coefficients, hence grow quickly.
-    # Scaling after each column is computed avoids dividing by a
-    # large binomial coefficient at the end, but is not sufficient to avoid
-    # the large dyanamic range which appears during the calculation.
-    # Instead we rescale based on the magnitude of the right most term in
-    # the column and keep track of an exponent separately and apply
-    # it at the end of the calculation.  Similarly when multiplying by
-    # the binomial coefficint
-    dtype = np.float64
-    A = np.zeros(lenA, dtype=dtype)
-    # Initialize the first column
-    A[minj:maxj] = 1
-    expnt = 0
-    for i in range(1, m + 1):
-        # Generate the next column.
-        # First calculate the sliding window
-        lastminj, lastlen = minj, curlen
-        minj = max(int(np.floor((ng * i - h) / mg)) + 1, 0)
-        minj = min(minj, n)
-        maxj = min(int(np.ceil((ng * i + h) / mg)), n + 1)
-        if maxj <= minj:
-            return 0
-        # Now fill in the values
-        A[0:maxj - minj] = np.cumsum(A[minj - lastminj:maxj - lastminj])
-        curlen = maxj - minj
-        if lastlen > curlen:
-            # Set some carried-over elements to 0
-            A[maxj - minj:maxj - minj + (lastlen - curlen)] = 0
-        # Rescale if the right most value is over 2**900
-        val = A[maxj - minj - 1]
-        _, valexpt = math.frexp(val)
-        if valexpt > 900:
-            # Scaling to bring down to about 2**800 appears
-            # sufficient for sizes under 10000.
-            valexpt -= 800
-            A = np.ldexp(A, -valexpt)
-            expnt += valexpt
-
-    val = A[maxj - minj - 1]
-    # Now divide by the binomial (m+n)!/m!/n!
-    for i in range(1, n + 1):
-        val = (val * i) / (m + i)
-        _, valexpt = math.frexp(val)
-        if valexpt < -128:
-            val = np.ldexp(val, -valexpt)
-            expnt += valexpt
-    # Finally scale if needed.
-    return np.ldexp(val, expnt)
-
-
 def _compute_prob_outside_square(n, h):
     """
     Compute the proportion of paths that pass outside the two diagonal lines.
@@ -7333,7 +7231,7 @@ def _attempt_exact_2kssamp(n1, n2, g, d, alternative):
             if n1 == n2:
                 prob = _compute_prob_outside_square(n1, h)
             else:
-                prob = 1 - _compute_prob_inside_method(n1, n2, g, h)
+                prob = _compute_outer_prob_inside_method(n1, n2, g, h)
         else:
             if n1 == n2:
                 # prob = binom(2n, n-h) / binom(2n, n)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3886,7 +3886,6 @@ class TestKSTwoSamples:
         self._testOne(x, y, 'greater', 0.10597913208679133, 2.7947433906389253e-41, mode='asymp')
         self._testOne(x, y, 'less', 0.09658002199780022, 2.7947433906389253e-41, mode='asymp')
 
-    @pytest.mark.slow
     def test_gh12999(self):
         for x in range(1000, 12000, 1000):
             vals1 = np.random.normal(size=(x))

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -16,7 +16,8 @@ from numpy.testing import (assert_, assert_equal,
                            assert_almost_equal, assert_array_almost_equal,
                            assert_array_equal, assert_approx_equal,
                            assert_allclose, assert_warns, suppress_warnings,
-                           assert_string_equal)
+                           assert_string_equal,
+                           assert_array_less)
 import pytest
 from pytest import raises as assert_raises
 import numpy.ma.testutils as mat
@@ -3886,6 +3887,17 @@ class TestKSTwoSamples:
         self._testOne(x, y, 'less', 0.09658002199780022, 2.7947433906389253e-41, mode='asymp')
 
     @pytest.mark.slow
+    def test_gh12999(self):
+        for x in range(1000, 12000, 1000):
+            vals1 = np.random.normal(size=(x))
+            vals2 = np.random.normal(size=(x + 10), loc=0.5)
+            exact = stats.ks_2samp(vals1, vals2, mode='exact').pvalue
+            asymp = stats.ks_2samp(vals1, vals2, mode='asymp').pvalue
+            # these two p-values should be in line with each other
+            assert_array_less(exact, 3 * asymp)
+            assert_array_less(asymp, 3 * exact)
+
+    @pytest.mark.slow
     def testLargeBoth(self):
         # 10000, 11000
         n1, n2 = 10000, 11000
@@ -3912,9 +3924,12 @@ class TestKSTwoSamples:
     @pytest.mark.slow
     def test_some_code_paths(self):
         # Check that some code paths are executed
-        from scipy.stats.stats import _count_paths_outside_method, _compute_prob_inside_method
+        from scipy.stats.stats import (
+            _count_paths_outside_method,
+            _compute_outer_prob_inside_method
+        )
 
-        _compute_prob_inside_method(1, 1, 1, 1)
+        _compute_outer_prob_inside_method(1, 1, 1, 1)
         _count_paths_outside_method(1000, 1, 1, 1001)
 
         assert_raises(FloatingPointError, _count_paths_outside_method, 1100, 1099, 1, 1)


### PR DESCRIPTION
Fixes: #12999

So this follows @mdhaber's in #12999 request to leave the code structure as is.
However, in the test sent by @sigallev (which I adapted into a test), this is about 30x slower on my laptop. I think we can recover quite a bit of that by moving into cython/pythran/ whatever (I used [numba before](https://github.com/TorchDrift/TorchDrift/blob/bda529a7a26c1a9b14d8d878a75122ece22b95d6/torchdrift/detectors/ks.py#L25), but note that I'm computing with < instead of <=).

I also have a test variant that reproduces the classic algorithm using Python's `fractions`, but I didn't include this here and instead stuck to the "should be in the same ballpark as asymp" heuristic of the issue.

I think it might be worth integrating improving speed instead of keeping the structure as close to the old one as possible.