### PR TITLE
MAINT: stats: silence mypy complaints

### DIFF
--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -888,14 +888,15 @@ class LatinHypercube(QMCEngine):
         else:
             samples = self.rng.uniform(size=(n, self.d))
 
-        perms = np.tile(np.arange(1, n + 1), (self.d, 1))
+        perms = np.tile(np.arange(1, n + 1),
+                        (self.d, 1))  # type: ignore[arg-type]
         for i in range(self.d):
             self.rng.shuffle(perms[i, :])
         perms = perms.T
 
         samples = (perms - samples) / n
         self.num_generated += n
-        return samples  # type: ignore[return-value]
+        return samples
 
 
 class Sobol(QMCEngine):


### PR DESCRIPTION
#### What does this implement/fix?
mypy is complaining in master (e.g. Nightly CPython in gh-14209, gh-14432):
```
scipy/stats/_qmc.py:891: error: Argument 2 to "tile" has incompatible type "Tuple[Union[int, integer[Any]], int]"; expected "Union[int, Sequence[int]]"  [arg-type]
scipy/stats/_qmc.py:898: error: unused "type: ignore" comment
Found 2 errors in 1 file (checked 699 source files)
Error: Process completed with exit code 1.
```
This ignores the complaint on line 891 and removes the ignore comment on line 898.
