### PR TITLE
CI: Lint with flake8 instead of pyflakes + pycodestyle 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -168,16 +168,12 @@ stages:
         architecture: 'x64'
     - script: >-
         python -m pip install
-        pycodestyle==2.5.0
-        pyflakes==2.3.1
+        flake8==3.9.2
       displayName: 'Install tools'
       failOnStderr: false
     - script: |
         set -euo pipefail
-        PYFLAKES_NODOCTEST=1 pyflakes scipy benchmarks/benchmarks 2>&1 | grep -E -v 'unable to detect undefined names|assigned to but never used|imported but unused|redefinition of unused|may be undefined, or defined from star imports|syntax error in type comment .ignore.import.' > test.out || true
-        cat test.out
-        test \! -s test.out
-        pycodestyle scipy benchmarks/benchmarks
+        flake8 scipy benchmarks/benchmarks
         # for Travis CI we used to do: git fetch --unshallow
         # but apparently Azure clones are not as shallow
         # so does not appear to be needed to fetch maintenance

--- a/benchmarks/benchmarks/fft_basic.py
+++ b/benchmarks/benchmarks/fft_basic.py
@@ -23,7 +23,7 @@ with safe_import() as exc:
     pyfftw.interfaces.cache.enable()
     has_pyfftw = True
 if exc.error:
-    pyfftw_fft = {}
+    pyfftw_fft = {}  # noqa: F811
     has_pyfftw = False
 
 

--- a/benchmarks/benchmarks/integrate.py
+++ b/benchmarks/benchmarks/integrate.py
@@ -18,7 +18,7 @@ if exc.error:
 with safe_import() as exc:
     import cffi
 if exc.error:
-    cffi = None
+    cffi = None  # noqa: F811
 
 with safe_import():
     from scipy.integrate import solve_bvp

--- a/environment.yml
+++ b/environment.yml
@@ -32,7 +32,6 @@ dependencies:
   - pydata-sphinx-theme
   - sphinx-panels
   # For linting
-  - pycodestyle
   - flake8
   # Some optional test dependencies
   - mpmath

--- a/runtests.py
+++ b/runtests.py
@@ -130,7 +130,7 @@ def main(argv):
     parser.add_argument("args", metavar="ARGS", default=[], nargs=REMAINDER,
                         help="Arguments to pass to Nose, Python or shell")
     parser.add_argument("--pep8", action="store_true", default=False,
-                        help="Perform pep8 check with pycodestyle.")
+                        help="Perform pep8 check with flake8.")
     parser.add_argument("--mypy", action="store_true", default=False,
                         help="Run mypy on the codebase")
     parser.add_argument("--doc", action="append", nargs="?",
@@ -139,7 +139,7 @@ def main(argv):
 
     if args.pep8:
         # Lint the source using the configuration in tox.ini.
-        os.system("pycodestyle scipy benchmarks/benchmarks")
+        os.system("flake8 scipy benchmarks/benchmarks")
         # Lint just the diff since branching off of master using a
         # stricter configuration.
         lint_diff = os.path.join(ROOT_DIR, 'tools', 'lint_diff.py')

--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -294,7 +294,7 @@ from .waveforms import *
 from ._max_len_seq import max_len_seq
 from ._upfirdn import upfirdn
 
-from ._spline import (
+from ._spline import (  # noqa: F401
  cspline2d,
  qspline2d,
  sepfir2d,

--- a/scipy/signal/spline.py
+++ b/scipy/signal/spline.py
@@ -6,7 +6,8 @@ import warnings
 
 from . import _spline
 
-__all__ = ['cspline2d', 'qspline2d', 'sepfir2d', 'symiirorder1', 'symiirorder2']
+__all__ = ['cspline2d', 'qspline2d', 'sepfir2d', 'symiirorder1',  # noqa: F822
+           'symiirorder2']  # noqa: F822
 
 
 def __dir__():
@@ -23,4 +24,3 @@ def __getattr__(name):
                   "the `scipy.signal.spline` namespace is deprecated.",
                   category=DeprecationWarning, stacklevel=2)
     return getattr(_spline, name)
-

--- a/scipy/signal/spline.py
+++ b/scipy/signal/spline.py
@@ -6,8 +6,8 @@ import warnings
 
 from . import _spline
 
-__all__ = ['cspline2d', 'qspline2d', 'sepfir2d', 'symiirorder1',  # noqa: F822
-           'symiirorder2']  # noqa: F822
+__all__ = [  # noqa: F822
+    'cspline2d', 'qspline2d', 'sepfir2d', 'symiirorder1', 'symiirorder2']
 
 
 def __dir__():

--- a/scipy/signal/tests/test_bsplines.py
+++ b/scipy/signal/tests/test_bsplines.py
@@ -255,12 +255,14 @@ def test_sepfir2d_invalid_image():
     with pytest.raises(ValueError, match="object of too small depth"):
         signal.sepfir2d(image[0], filt, filt)
 
+
 def test_cspline2d():
     np.random.seed(181819142)
     image = np.random.rand(71, 73)
-    ck = signal.cspline2d(image, 8.0)
+    signal.cspline2d(image, 8.0)
+
 
 def test_qspline2d():
     np.random.seed(181819143)
     image = np.random.rand(71, 73)
-    qk = signal.qspline2d(image)
+    signal.qspline2d(image)

--- a/scipy/stats/tests/test_discrete_distns.py
+++ b/scipy/stats/tests/test_discrete_distns.py
@@ -6,7 +6,6 @@ from scipy.stats import (betabinom, hypergeom, nhypergeom, bernoulli,
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal, assert_allclose
 from scipy.special import binom as special_binom
-import pytest
 from scipy.optimize import root_scalar
 from scipy.integrate import quad
 

--- a/tools/lint_diff.py
+++ b/tools/lint_diff.py
@@ -63,10 +63,10 @@ def find_diff(sha):
     return res.stdout
 
 
-def run_pycodestyle(diff):
-    """Run pycodestyle on the given diff."""
+def run_flake8(diff):
+    """Run flake8 on the given diff."""
     res = subprocess.run(
-        ['pycodestyle', '--diff', '--config', CONFIG],
+        ['flake8', '--diff', '--config', CONFIG],
         input=diff,
         stdout=subprocess.PIPE,
         encoding='utf-8',
@@ -82,7 +82,7 @@ def main():
 
     branch_point = find_branch_point(args.branch)
     diff = find_diff(branch_point)
-    rc, errors = run_pycodestyle(diff)
+    rc, errors = run_flake8(diff)
     if errors:
         print(errors)
     sys.exit(rc)

--- a/tox.ini
+++ b/tox.ini
@@ -43,3 +43,10 @@ max_line_length = 79
 statistics = True
 ignore = E121,E122,E123,E125,E126,E127,E128,E226,E231,E251,E265,E266,E302,E402,E501,E712,E721,E731,E741,W291,W293,W391,W503,W504
 exclude = scipy/__config__.py
+
+[flake8]
+max_line_length = 79
+ignore = E121,E122,E123,E125,E126,E127,E128,E226,E231,E251,E265,E266,E302,E402,E501,E712,E721,E731,E741,
+         W291,W293,W391,W503,W504,
+         F401,F403,F405,F841
+exclude = scipy/__config__.py


### PR DESCRIPTION
#### Reference issue
Related: https://github.com/scipy/scipy/pull/14419#issuecomment-885038708

#### What does this implement/fix?
`pyflakes`  doesn't respect `noqa` comments, so AFAIK you either enable a check globally or not at all. `flake8` doesn't have this issue, so lets move to that.