### PR TITLE
DOC: clarify meaning of rvalue in stats.linregress

### DIFF
--- a/scipy/stats/_stats_mstats_common.py
+++ b/scipy/stats/_stats_mstats_common.py
@@ -47,7 +47,7 @@ def linregress(x, y=None, alternative='two-sided'):
             Intercept of the regression line.
         rvalue : float
             The Pearson correlation coefficient. The square of ``rvalue``
-            is the coefficient of determination.
+            is equal to the coefficient of determination.
         pvalue : float
             The p-value for a hypothesis test whose null hypothesis is
             that the slope is zero, using Wald Test with t-distribution of

--- a/scipy/stats/_stats_mstats_common.py
+++ b/scipy/stats/_stats_mstats_common.py
@@ -46,7 +46,8 @@ def linregress(x, y=None, alternative='two-sided'):
         intercept : float
             Intercept of the regression line.
         rvalue : float
-            Correlation coefficient.
+            The Pearson correlation coefficient. The square of ``rvalue``
+            is the coefficient of determination.
         pvalue : float
             The p-value for a hypothesis test whose null hypothesis is
             that the slope is zero, using Wald Test with t-distribution of


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes gh-14416.

#### What does this implement/fix?
<!--Please explain your changes.-->
Rewrote the description of the output value `rvalue` in `scipy.stats.linregress` to clarify that it is the Pearson correlation coefficient. Although "correlation coefficient" usually refers to the Pearson coefficient, it can refer to other quantities too, and it wasn't obvious to me from reading the documentation.

#### Additional information
<!--Any additional information you think is important.-->