### PR TITLE
DOC: add required scipy version to kwarg

### DIFF
--- a/scipy/spatial/transform/rotation.pyx
+++ b/scipy/spatial/transform/rotation.pyx
@@ -789,6 +789,8 @@ cdef class Rotation:
             A single vector or a stack of vectors, where `rot_vec[i]` gives
             the ith rotation vector.
         degrees : bool, optional
+            *New Feature:* Added in v1.7.0
+        
             If True, then the given magnitudes are assumed to be in degrees.
             Default is False.
 

--- a/scipy/spatial/transform/rotation.pyx
+++ b/scipy/spatial/transform/rotation.pyx
@@ -788,11 +788,11 @@ cdef class Rotation:
         rotvec : array_like, shape (N, 3) or (3,)
             A single vector or a stack of vectors, where `rot_vec[i]` gives
             the ith rotation vector.
-        degrees : bool, optional
-            *New Feature:* Added in v1.7.0
-        
+        degrees : bool, optional        
             If True, then the given magnitudes are assumed to be in degrees.
             Default is False.
+
+            .. versionadded:: 1.7.0
 
         Returns
         -------

--- a/scipy/spatial/transform/rotation.pyx
+++ b/scipy/spatial/transform/rotation.pyx
@@ -788,7 +788,7 @@ cdef class Rotation:
         rotvec : array_like, shape (N, 3) or (3,)
             A single vector or a stack of vectors, where `rot_vec[i]` gives
             the ith rotation vector.
-        degrees : bool, optional        
+        degrees : bool, optional
             If True, then the given magnitudes are assumed to be in degrees.
             Default is False.
 


### PR DESCRIPTION
Closes: https://github.com/scipy/scipy/issues/14444

#### What does this implement/fix?
Improves the docstring by adding the minimum scipy version required to use a new kwarg.
