### PR TITLE
Fix typo in doc overview: "pandas" to "SciPy"

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -81,7 +81,7 @@ science, and engineering.
 
     Saw a typo in the documentation? Want to improve
     existing functionalities? The contributing guidelines will guide
-    you through the process of improving pandas.
+    you through the process of improving SciPy.
 
     +++
 


### PR DESCRIPTION
This is probably due to the fact that the guides have been taken from pandas.