### PR TITLE
DOC: Correct `spatial.distance.jaccard()` documentation, see #12174

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -834,13 +834,13 @@ def jaccard(u, v, w=None):
 
     Notes
     -----
-    When both `u` and `v` lead to a `0/0` division i.e. there is no overlap
-    between the items in the vectors the returned distance is 0. See the
-    Wikipedia page on the Jaccard index [1]_, and this paper [2]_.
+    When both `u` and `v` lead to a `0/0` division (i.e. both vectors contain
+    only falsy values) the returned distance is `0`. See the Wikipedia page on
+    the Jaccard index [1]_, and this paper [2]_.
 
     .. versionchanged:: 1.2.0
         Previously, when `u` and `v` lead to a `0/0` division, the function
-        would return NaN. This was changed to return 0 instead.
+        would return NaN. This was changed to return `0` instead.
 
     References
     ----------

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -1145,17 +1145,22 @@ class TestPdist:
         Y_test1 = wpdist(X, 'jaccard')
         _assert_within_tol(Y_test1, Y_right, eps)
 
-    def test_pdist_djaccard_allzeros(self):
-        eps = 1e-08
-        Y = pdist(np.zeros((5, 3)), 'jaccard')
-        _assert_within_tol(np.zeros(10), Y, eps)
-
     def test_pdist_djaccard_random_nonC(self):
         eps = 1e-08
         X = np.float64(eo['pdist-boolean-inp'])
         Y_right = eo['pdist-jaccard']
         Y_test2 = wpdist(X, 'test_jaccard')
         _assert_within_tol(Y_test2, Y_right, eps)
+
+    def test_pdist_djaccard_allzeros(self):
+        eps = 1e-08
+        Y = pdist(np.zeros((5, 3)), 'jaccard')
+        _assert_within_tol(np.zeros(10), Y, eps)
+
+    def test_pdist_djaccard_allzeros_nonC(self):
+        eps = 1e-08
+        Y = pdist(np.zeros((5, 3)), 'test_jaccard')
+        _assert_within_tol(np.zeros(10), Y, eps)
 
     def test_pdist_jensenshannon_random(self):
         eps = 1e-08
@@ -1203,11 +1208,6 @@ class TestPdist:
         Y_right = eo['pdist-jensenshannon-iris']
         Y_test2 = pdist(X, 'test_jensenshannon')
         _assert_within_tol(Y_test2, Y_right, eps)
-
-    def test_pdist_djaccard_allzeros_nonC(self):
-        eps = 1e-08
-        Y = pdist(np.zeros((5, 3)), 'test_jaccard')
-        _assert_within_tol(np.zeros(10), Y, eps)
 
     def test_pdist_chebyshev_random(self):
         eps = 1e-08


### PR DESCRIPTION
#### Reference issue
Addresses #12174 

#### What does this implement/fix?
It corrects the documentation for `spatial.distance.jaccard()` to describe the behaviour when the underlying function is poorly defined. It also arranges the tests for this function more sensibly.

#### Additional information
There is potentially more work to be done cleaning up the naming of the tests, but that is more of a code maintenance issue than a documentation issue, therefore should be under a different PR.