### PR TITLE
ENH: improve _sosfilt_float via Pythran

### DIFF
--- a/scipy/signal/_sosfilt_float.py
+++ b/scipy/signal/_sosfilt_float.py
@@ -1,0 +1,23 @@
+#pythran export _sosfilt_float(float[:, :], float[:, :], float[:, :, :])
+def _sosfilt_float(sos, x, zi):
+    # Modifies x and zi in place
+    n_signals = x.shape[0]
+    n_samples = x.shape[1]
+    n_sections = sos.shape[0]
+
+    for i in range(n_signals):
+        zi_slice = zi[i, :, :]
+        for n in range(n_samples):
+
+            x_cur = x[i, n]
+
+            for s in range(n_sections):
+                x_new = sos[s, 0] * x_cur + zi_slice[s, 0]
+                zi_slice[s, 0] = (sos[s, 1] * x_cur - sos[s, 4] * x_new
+                                  + zi_slice[s, 1])
+                zi_slice[s, 1] = sos[s, 2] * x_cur - sos[s, 5] * x_new
+                x_cur = x_new
+
+            x[i, n] = x_cur
+    return x, zi
+

--- a/scipy/signal/setup.py
+++ b/scipy/signal/setup.py
@@ -41,6 +41,13 @@ def configuration(parent_package='', top_path=None):
             sources=["scipy/signal/_spectral.py"],
             config=['compiler.blas=none'])
         config.ext_modules.append(ext)
+
+        ext = pythran.dist.PythranExtension(
+            'scipy.signal._sosfilt_float',
+            sources=["scipy/signal/_sosfilt_float.py"],
+            config=['compiler.blas=none'])
+        config.ext_modules.append(ext)
+        
     else:
         config.add_extension(
             '_spectral', sources=['_spectral.c'])

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2,6 +2,7 @@
 # 1999 -- 2002
 
 import operator
+import os
 import math
 import timeit
 from scipy.spatial import cKDTree
@@ -17,6 +18,7 @@ from ._arraytools import axis_slice, axis_reverse, odd_ext, even_ext, const_ext
 from .filter_design import cheby1, _validate_sos
 from .fir_filter_design import firwin
 from ._sosfilt import _sosfilt
+from ._sosfilt_float import _sosfilt_float
 import warnings
 
 
@@ -4225,7 +4227,10 @@ def sosfilt(sos, x, axis=-1, zi=None):
     x = np.array(x, dtype, order='C')  # make a copy, can modify in place
     zi = np.ascontiguousarray(np.reshape(zi, (-1, n_sections, 2)))
     sos = sos.astype(dtype, copy=False)
-    _sosfilt(sos, x, zi)
+    if sos.dtype is object or int(os.environ.get('SCIPY_USE_PYTHRAN', 0)):
+        _sosfilt(sos, x, zi)
+    else:
+        x, zi = _sosfilt_float(sos, x, zi)
     x.shape = x_shape
     x = np.moveaxis(x, -1, axis)
     if return_zi:


### PR DESCRIPTION
[ci skip]

Since Pythran performance is not much better than Cython's, and Pythran does not support `object type` `_sosfilt_object`, so we decided not to merge it.

![image](https://user-images.githubusercontent.com/38244988/126888931-046ade3f-34d3-42b6-baa7-e96e58b8f198.png)


cc @serge-sans-paille ,  I didn't simplify the loop in `_sosfilt_float` to `zi_slice[:,0] = sos[:,1] * x_cur - sos[:,4] ...` because it seems `x_cur` and `x_new` will be updated in the loop :) . cc @rgommers 



