### PR TITLE
DEP: Deprecate private but non-underscored ndimage.<module> namespace

### DIFF
--- a/scipy/ndimage/_interpolation.py
+++ b/scipy/ndimage/_interpolation.py
@@ -662,7 +662,7 @@ def shift(input, shift, output=None, order=3, mode='constant', cval=0.0,
                                      complex_output=complex_output)
     if complex_output:
         # import under different name to avoid confusion with shift parameter
-        from scipy.ndimage.interpolation import shift as _shift
+        from scipy.ndimage._interpolation import shift as _shift
 
         kwargs = dict(order=order, mode=mode, prefilter=prefilter)
         _shift(input.real, shift, output=output.real, cval=numpy.real(cval),
@@ -772,7 +772,7 @@ def zoom(input, zoom, output=None, order=3, mode='constant', cval=0.0,
                                      complex_output=complex_output)
     if complex_output:
         # import under different name to avoid confusion with zoom parameter
-        from scipy.ndimage.interpolation import zoom as _zoom
+        from scipy.ndimage._interpolation import zoom as _zoom
 
         kwargs = dict(order=order, mode=mode, prefilter=prefilter)
         _zoom(input.real, zoom, output=output.real, cval=numpy.real(cval),

--- a/scipy/ndimage/_interpolation.py
+++ b/scipy/ndimage/_interpolation.py
@@ -73,7 +73,7 @@ def spline_filter1d(input, order=3, axis=-1, output=numpy.float64,
 
     Notes
     -----
-    All functions in `ndimage.interpolation` do spline interpolation of
+    All of the interpolation functions in `ndimage` do spline interpolation of
     the input image. If using B-splines of `order > 1`, the input image
     values have to be converted to B-spline coefficients first, which is
     done by applying this 1-D filter sequentially along all

--- a/scipy/ndimage/_measurements.py
+++ b/scipy/ndimage/_measurements.py
@@ -33,7 +33,7 @@ import numpy as np
 from . import _ni_support
 from . import _ni_label
 from . import _nd_image
-from . import morphology
+from . import _morphology
 
 __all__ = ['label', 'find_objects', 'labeled_comprehension', 'sum', 'mean',
            'variance', 'standard_deviation', 'minimum', 'maximum', 'median',
@@ -177,7 +177,7 @@ def label(input, structure=None, output=None):
     if numpy.iscomplexobj(input):
         raise TypeError('Complex type not supported')
     if structure is None:
-        structure = morphology.generate_binary_structure(input.ndim, 1)
+        structure = _morphology.generate_binary_structure(input.ndim, 1)
     structure = numpy.asarray(structure, dtype=bool)
     if structure.ndim != input.ndim:
         raise RuntimeError('structure and input must have equal rank')
@@ -1370,7 +1370,7 @@ def center_of_mass(input, labels=None, index=None):
     ...               [0,1,1,0],
     ...               [0,1,1,0]))
     >>> from scipy import ndimage
-    >>> ndimage.measurements.center_of_mass(a)
+    >>> ndimage.center_of_mass(a)
     (2.0, 1.5)
 
     Calculation of multiple objects in an image
@@ -1381,7 +1381,7 @@ def center_of_mass(input, labels=None, index=None):
     ...               [0,0,1,1],
     ...               [0,0,1,1]))
     >>> lbl = ndimage.label(b)[0]
-    >>> ndimage.measurements.center_of_mass(b, lbl, [1,2])
+    >>> ndimage.center_of_mass(b, lbl, [1,2])
     [(0.33333333333333331, 1.3333333333333333), (3.5, 2.5)]
 
     Negative masses are also accepted, which can occur for example when
@@ -1391,14 +1391,14 @@ def center_of_mass(input, labels=None, index=None):
     ...               [0,-1,-1,0],
     ...               [0,1,-1,0],
     ...               [0,1,1,0]))
-    >>> ndimage.measurements.center_of_mass(c)
+    >>> ndimage.center_of_mass(c)
     (-4.0, 1.0)
 
     If there are division by zero issues, the function does not raise an
     error but rather issues a RuntimeWarning before returning inf and/or NaN.
 
     >>> d = np.array([-1, 1])
-    >>> ndimage.measurements.center_of_mass(d)
+    >>> ndimage.center_of_mass(d)
     (inf,)
     """
     normalizer = sum(input, labels, index)
@@ -1450,18 +1450,18 @@ def histogram(input, min, max, bins, labels=None, index=None):
     ...               [ 0.    ,  0.    ,  0.7181,  0.2787],
     ...               [ 0.    ,  0.    ,  0.6573,  0.3094]])
     >>> from scipy import ndimage
-    >>> ndimage.measurements.histogram(a, 0, 1, 10)
+    >>> ndimage.histogram(a, 0, 1, 10)
     array([13,  0,  2,  1,  0,  1,  1,  2,  0,  0])
 
     With labels and no indices, non-zero elements are counted:
 
     >>> lbl, nlbl = ndimage.label(a)
-    >>> ndimage.measurements.histogram(a, 0, 1, 10, lbl)
+    >>> ndimage.histogram(a, 0, 1, 10, lbl)
     array([0, 0, 2, 1, 0, 1, 1, 2, 0, 0])
 
     Indices can be used to count only certain objects:
 
-    >>> ndimage.measurements.histogram(a, 0, 1, 10, lbl, 2)
+    >>> ndimage.histogram(a, 0, 1, 10, lbl, 2)
     array([0, 0, 1, 1, 0, 0, 1, 1, 0, 0])
 
     """
@@ -1510,7 +1510,7 @@ def watershed_ift(input, markers, structure=None, output=None):
         raise TypeError('only 8 and 16 unsigned inputs are supported')
 
     if structure is None:
-        structure = morphology.generate_binary_structure(input.ndim, 1)
+        structure = _morphology.generate_binary_structure(input.ndim, 1)
     structure = numpy.asarray(structure, dtype=bool)
     if structure.ndim != input.ndim:
         raise RuntimeError('structure and input must have equal rank')

--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -1,3 +1,8 @@
+# This file is not meant for public use and will be removed in the future
+# versions of SciPy. Use the `scipy.ndimage` namespace for importing the
+# functions included below.
+
+import warnings
 from . import _filters
 
 
@@ -19,5 +24,9 @@ def __getattr__(name):
     if name not in __all__:
         raise AttributeError(
             f"scipy.ndimage.filters has no attribute {name}.")
+
+    warnings.warn(f"Please use `{name}` from the `scipy.ndimage` namespace, "
+                  "the `scipy.ndimage.filters` namespace is deprecated.",
+                  category=DeprecationWarning, stacklevel=2)
 
     return getattr(_filters, name)

--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -23,7 +23,8 @@ def __dir__():
 def __getattr__(name):
     if name not in __all__:
         raise AttributeError(
-            f"scipy.ndimage.filters has no attribute {name}.")
+            "scipy.ndimage.filters is deprecated and has no attribute "
+            f"{name}. Try looking in scipy.ndimage instead.")
 
     warnings.warn(f"Please use `{name}` from the `scipy.ndimage` namespace, "
                   "the `scipy.ndimage.filters` namespace is deprecated.",

--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -1,6 +1,6 @@
-# This file is not meant for public use and will be removed in the future
-# versions of SciPy. Use the `scipy.ndimage` namespace for importing the
-# functions included below.
+# This file is not meant for public use and will be removed in SciPy v2.0.0.
+# Use the `scipy.ndimage` namespace for importing the functions
+# included below.
 
 import warnings
 from . import _filters

--- a/scipy/ndimage/fourier.py
+++ b/scipy/ndimage/fourier.py
@@ -17,7 +17,8 @@ def __dir__():
 def __getattr__(name):
     if name not in __all__:
         raise AttributeError(
-            f"scipy.ndimage.fourier has no attribute {name}.")
+            "scipy.ndimage.fourier is deprecated and has no attribute "
+            f"{name}. Try looking in scipy.ndimage instead.")
 
     warnings.warn(f"Please use `{name}` from the `scipy.ndimage` namespace, "
                   "the `scipy.ndimage.fourier` namespace is deprecated.",

--- a/scipy/ndimage/fourier.py
+++ b/scipy/ndimage/fourier.py
@@ -1,3 +1,8 @@
+# This file is not meant for public use and will be removed in the future
+# versions of SciPy. Use the `scipy.ndimage` namespace for importing the
+# functions included below.
+
+import warnings
 from . import _fourier
 
 
@@ -13,5 +18,9 @@ def __getattr__(name):
     if name not in __all__:
         raise AttributeError(
             f"scipy.ndimage.fourier has no attribute {name}.")
+
+    warnings.warn(f"Please use `{name}` from the `scipy.ndimage` namespace, "
+                  "the `scipy.ndimage.fourier` namespace is deprecated.",
+                  category=DeprecationWarning, stacklevel=2)
 
     return getattr(_fourier, name)

--- a/scipy/ndimage/fourier.py
+++ b/scipy/ndimage/fourier.py
@@ -1,6 +1,6 @@
-# This file is not meant for public use and will be removed in the future
-# versions of SciPy. Use the `scipy.ndimage` namespace for importing the
-# functions included below.
+# This file is not meant for public use and will be removed in SciPy v2.0.0.
+# Use the `scipy.ndimage` namespace for importing the functions
+# included below.
 
 import warnings
 from . import _fourier

--- a/scipy/ndimage/interpolation.py
+++ b/scipy/ndimage/interpolation.py
@@ -1,6 +1,6 @@
-# This file is not meant for public use and will be removed in the future
-# versions of SciPy. Use the `scipy.ndimage` namespace for importing the
-# functions included below.
+# This file is not meant for public use and will be removed in SciPy v2.0.0.
+# Use the `scipy.ndimage` namespace for importing the functions
+# included below.
 
 import warnings
 from . import _interpolation

--- a/scipy/ndimage/interpolation.py
+++ b/scipy/ndimage/interpolation.py
@@ -18,7 +18,8 @@ def __dir__():
 def __getattr__(name):
     if name not in __all__:
         raise AttributeError(
-            f"scipy.ndimage.interpolation has no attribute {name}.")
+            "scipy.ndimage.interpolation is deprecated and has no attribute "
+            f"{name}. Try looking in scipy.ndimage instead.")
 
     warnings.warn(f"Please use `{name}` from the `scipy.ndimage` namespace, "
                   "the `scipy.ndimage.interpolation` namespace is deprecated.",

--- a/scipy/ndimage/interpolation.py
+++ b/scipy/ndimage/interpolation.py
@@ -1,3 +1,8 @@
+# This file is not meant for public use and will be removed in the future
+# versions of SciPy. Use the `scipy.ndimage` namespace for importing the
+# functions included below.
+
+import warnings
 from . import _interpolation
 
 
@@ -14,5 +19,9 @@ def __getattr__(name):
     if name not in __all__:
         raise AttributeError(
             f"scipy.ndimage.interpolation has no attribute {name}.")
+
+    warnings.warn(f"Please use `{name}` from the `scipy.ndimage` namespace, "
+                  "the `scipy.ndimage.interpolation` namespace is deprecated.",
+                  category=DeprecationWarning, stacklevel=2)
 
     return getattr(_interpolation, name)

--- a/scipy/ndimage/measurements.py
+++ b/scipy/ndimage/measurements.py
@@ -1,3 +1,8 @@
+# This file is not meant for public use and will be removed in the future
+# versions of SciPy. Use the `scipy.ndimage` namespace for importing the
+# functions included below.
+
+import warnings
 from . import _measurements
 
 
@@ -16,5 +21,9 @@ def __getattr__(name):
     if name not in __all__:
         raise AttributeError(
             f"scipy.ndimage.measurements has no attribute {name}.")
+
+    warnings.warn(f"Please use `{name}` from the `scipy.ndimage` namespace, "
+                  "the `scipy.ndimage.measurements` namespace is deprecated.",
+                  category=DeprecationWarning, stacklevel=2)
 
     return getattr(_measurements, name)

--- a/scipy/ndimage/measurements.py
+++ b/scipy/ndimage/measurements.py
@@ -1,6 +1,6 @@
-# This file is not meant for public use and will be removed in the future
-# versions of SciPy. Use the `scipy.ndimage` namespace for importing the
-# functions included below.
+# This file is not meant for public use and will be removed in SciPy v2.0.0.
+# Use the `scipy.ndimage` namespace for importing the functions
+# included below.
 
 import warnings
 from . import _measurements

--- a/scipy/ndimage/measurements.py
+++ b/scipy/ndimage/measurements.py
@@ -20,7 +20,8 @@ def __dir__():
 def __getattr__(name):
     if name not in __all__:
         raise AttributeError(
-            f"scipy.ndimage.measurements has no attribute {name}.")
+            "scipy.ndimage.measurements is deprecated and has no attribute "
+            f"{name}. Try looking in scipy.ndimage instead.")
 
     warnings.warn(f"Please use `{name}` from the `scipy.ndimage` namespace, "
                   "the `scipy.ndimage.measurements` namespace is deprecated.",

--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -23,7 +23,8 @@ def __dir__():
 def __getattr__(name):
     if name not in __all__:
         raise AttributeError(
-            f"scipy.ndimage.morphology has no attribute {name}.")
+            "scipy.ndimage.morphology is deprecated and has no attribute "
+            f"{name}. Try looking in scipy.ndimage instead.")
 
     warnings.warn(f"Please use `{name}` from the `scipy.ndimage` namespace, "
                   "the `scipy.ndimage.morphology` namespace is deprecated.",

--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -1,6 +1,6 @@
-# This file is not meant for public use and will be removed in the future
-# versions of SciPy. Use the `scipy.ndimage` namespace for importing the
-# functions included below.
+# This file is not meant for public use and will be removed in SciPy v2.0.0.
+# Use the `scipy.ndimage` namespace for importing the functions
+# included below.
 
 import warnings
 from . import _morphology

--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -1,3 +1,8 @@
+# This file is not meant for public use and will be removed in the future
+# versions of SciPy. Use the `scipy.ndimage` namespace for importing the
+# functions included below.
+
+import warnings
 from . import _morphology
 
 
@@ -19,5 +24,9 @@ def __getattr__(name):
     if name not in __all__:
         raise AttributeError(
             f"scipy.ndimage.morphology has no attribute {name}.")
+
+    warnings.warn(f"Please use `{name}` from the `scipy.ndimage` namespace, "
+                  "the `scipy.ndimage.morphology` namespace is deprecated.",
+                  category=DeprecationWarning, stacklevel=2)
 
     return getattr(_morphology, name)

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -1545,7 +1545,7 @@ def test_gh_5430():
     x = numpy.random.normal(size=(256, 256))
     perlin = numpy.zeros_like(x)
     for i in 2**numpy.arange(6):
-        perlin += ndimage.filters.gaussian_filter(x, i, mode="wrap") * i**2
+        perlin += ndimage.gaussian_filter(x, i, mode="wrap") * i**2
     # This also fixes gh-4106, show that the OPs example now runs.
     x = numpy.int64(21)
     ndimage._ni_support._normalize_sequence(x, 0)
@@ -1955,7 +1955,7 @@ def test_size_footprint_both_set():
 def test_byte_order_median():
     """Regression test for #413: median_filter does not handle bytes orders."""
     a = numpy.arange(9, dtype='<f4').reshape(3, 3)
-    ref = ndimage.filters.median_filter(a, (3, 3))
+    ref = ndimage.median_filter(a, (3, 3))
     b = numpy.arange(9, dtype='>f4').reshape(3, 3)
-    t = ndimage.filters.median_filter(b, (3, 3))
+    t = ndimage.median_filter(b, (3, 3))
     assert_array_almost_equal(ref, t)

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -18,7 +18,7 @@ from numpy import array, arange
 import numpy as np
 
 from scipy.fft import fft
-from scipy.ndimage.filters import correlate1d
+from scipy.ndimage import correlate1d
 from scipy.optimize import fmin, linear_sum_assignment
 from scipy import signal
 from scipy.signal import (

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -35,7 +35,7 @@ import numpy as np
 from numpy import array, asarray, ma
 
 from scipy.spatial.distance import cdist
-from scipy.ndimage import measurements
+from scipy.ndimage import _measurements
 from scipy._lib._util import (check_random_state, MapWrapper,
                               rng_integers, float_factorial)
 import scipy.special as special
@@ -5483,7 +5483,7 @@ def _threshold_mgc_map(stat_mgc_map, samp_size):
     # find the largest connected component of significant correlations
     sig_connect = stat_mgc_map > threshold
     if np.sum(sig_connect) > 0:
-        sig_connect, _ = measurements.label(sig_connect)
+        sig_connect, _ = _measurements.label(sig_connect)
         _, label_counts = np.unique(sig_connect, return_counts=True)
 
         # skip the first element in label_counts, as it is count(zeros)


### PR DESCRIPTION
#### Reference issue
See gh-14360 for details. Follows gh-14419 pattern.

#### What does this implement/fix?
Adds deprecation warning to private but non-underscored ndimage modules.

Also, I've noticed that our documentation examples show the use of this private namespace for example in the `center_of_mass` method. See [`center_of_mass` docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.center_of_mass.html#scipy.ndimage.center_of_mass).

Therefore, I've replaced any such instance in documentation or internal calls of `ndimage.<module>.<some_func>` to `ndimage.<some_func>` avoiding deprecation warnings in our own code.

#### Additional information

**Note: This PR is planned to be merged after #14356**. It will need a very minor change (replace `_<module>` with `_multimethods`) after that merge, which I'll do by rebasing again. I wanted to get this up early, for feedback, if any. Hence raising this WIP PR before #14356 actually lands.

**Edit 1:**
Ps. Technically can go ahead with this before #14356 as well (then I can rebase that PR), but let's wait for some time anyways. :)

**Edit 2:**
Q. What about places like [this](https://github.com/scipy/scipy/blob/053f3f54130f8b17c09540352a784f4c54a919df/scipy/ndimage/_interpolation.py#L76) in the docs where we mention the private namespace? Should we also re-phrase these? Small things like these could actually contribute towards someone using a deprecated namespace.

cc @rgommers 