### PR TITLE
BUG: geometric_slerp t ndim guard

### DIFF
--- a/scipy/spatial/_geometric_slerp.py
+++ b/scipy/spatial/_geometric_slerp.py
@@ -52,8 +52,8 @@ def geometric_slerp(
     end : (n_dimensions, ) array-like
         Single n-dimensional input coordinate in a 1-D array-like
         object. `n` must be greater than 1.
-    t: float or (n_points,) array-like
-        A float or array-like of doubles representing interpolation
+    t: float or (n_points,) 1D array-like
+        A float or 1D array-like of doubles representing interpolation
         parameters, with values required in the inclusive interval
         between 0 and 1. A common approach is to generate the array
         with ``np.linspace(0, 1, n_pts)`` for linearly spaced points.
@@ -176,6 +176,11 @@ def geometric_slerp(
 
     start = np.asarray(start, dtype=np.float64)
     end = np.asarray(end, dtype=np.float64)
+    t = np.asarray(t)
+
+    if t.ndim > 1:
+        raise ValueError("The interpolation parameter "
+                         "value must be one dimensional.")
 
     if start.ndim != 1 or end.ndim != 1:
         raise ValueError("Start and end coordinates "
@@ -191,7 +196,7 @@ def geometric_slerp(
                          "space")
 
     if np.array_equal(start, end):
-        return np.linspace(start, start, np.asarray(t).size)
+        return np.linspace(start, start, t.size)
 
     # for points that violate equation for n-sphere
     for coord in [start, end]:


### PR DESCRIPTION
Fixes #14465, though we should make sure we agree on the acceptability of the backward compat break, which is discussed there in some detail.

* raise an exception when the interpolation parameter
provided to `geometric_slerp()` has more than 1 dimension,
to avoid inconsistent/incorrect results