### PR TITLE
ENH: spatial.cKDTree: Add multi-thread build

### DIFF
--- a/scipy/spatial/_ckdtree.pyx
+++ b/scipy/spatial/_ckdtree.pyx
@@ -74,7 +74,8 @@ cdef extern from "ckdtree_decl.h":
                          np.float64_t *maxes,
                          np.float64_t *mins,
                          int _median,
-                         int _compact) nogil except +
+                         int _compact,
+                         int _workers) nogil except +
 
     int build_weights(ckdtree *self,
                          np.float64_t *node_weights,
@@ -417,7 +418,7 @@ cdef np.intp_t get_num_workers(workers: object, kwargs: dict) except -1:
 cdef class cKDTree:
     """
     cKDTree(data, leafsize=16, compact_nodes=True, copy_data=False,
-            balanced_tree=True, boxsize=None)
+            balanced_tree=True, boxsize=None, *, workers=1)
 
     kd-tree for quick nearest-neighbor lookup
 
@@ -461,6 +462,9 @@ cdef class cKDTree:
         is the boxsize along i-th dimension. The input data shall be wrapped
         into :math:`[0, L_i)`. A ValueError is raised if any of the data is
         outside of this bound.
+    workers : int, optional
+        Number of workers to use for parallel build. If -1 is given all
+        CPU threads are used. Default is 1.
 
     Notes
     -----
@@ -550,14 +554,14 @@ cdef class cKDTree:
         self.cself.tree_buffer = NULL
 
     def __init__(cKDTree self, data, np.intp_t leafsize=16, compact_nodes=True,
-            copy_data=False, balanced_tree=True, boxsize=None):
+            copy_data=False, balanced_tree=True, boxsize=None, *, workers=1):
 
         cdef:
             np.float64_t [::1] tmpmaxes, tmpmins
             np.float64_t *ptmpmaxes
             np.float64_t *ptmpmins
             ckdtree *cself = self.cself
-            int compact, median
+            int compact, median, build_workers
 
         self._python_tree = None
 
@@ -604,6 +608,18 @@ cdef class cKDTree:
         compact = 1 if compact_nodes else 0
         median = 1 if balanced_tree else 0
 
+        if workers == -1:
+            build_workers = os.cpu_count()
+            if build_workers is None:
+                raise NotImplementedError(
+                    "Cannot determine the number of cpus using os.cpu_count(), "
+                    "cannot use -1 for the number of workers"
+                )
+        elif workers > 0:
+            build_workers = workers
+        else:
+            raise ValueError(f'Invalid number of workers {workers}, must be -1 or > 0')
+
         cself.tree_buffer = new vector[ckdtreenode]()
 
         tmpmaxes = np.copy(self.maxes)
@@ -612,7 +628,7 @@ cdef class cKDTree:
         ptmpmaxes = &tmpmaxes[0]
         ptmpmins = &tmpmins[0]
         with nogil:
-            build_ckdtree(cself, 0, cself.n, ptmpmaxes, ptmpmins, median, compact)
+            build_ckdtree(cself, 0, cself.n, ptmpmaxes, ptmpmins, median, compact, build_workers)
 
         # set up the tree structure pointers
         self._post_init()

--- a/scipy/spatial/_kdtree.py
+++ b/scipy/spatial/_kdtree.py
@@ -222,6 +222,9 @@ class KDTree(cKDTree):
         is the boxsize along i-th dimension. The input data shall be wrapped
         into :math:`[0, L_i)`. A ValueError is raised if any of the data is
         outside of this bound.
+    workers : int, optional
+        Number of workers to use for parallel build. If -1 is given all
+        CPU threads are used. Default is 1.
 
     Notes
     -----
@@ -334,14 +337,14 @@ class KDTree(cKDTree):
         return self._tree
 
     def __init__(self, data, leafsize=10, compact_nodes=True, copy_data=False,
-                 balanced_tree=True, boxsize=None):
+                 balanced_tree=True, boxsize=None, *, workers=1):
         data = np.asarray(data)
         if data.dtype.kind == 'c':
             raise TypeError("KDTree does not work with complex data")
 
         # Note KDTree has different default leafsize from cKDTree
         super().__init__(data, leafsize, compact_nodes, copy_data,
-                         balanced_tree, boxsize)
+                         balanced_tree, boxsize, workers=workers)
 
     def query(
             self, x, k=1, eps=0, p=2, distance_upper_bound=np.inf, workers=1):

--- a/scipy/spatial/ckdtree/src/build.cxx
+++ b/scipy/spatial/ckdtree/src/build.cxx
@@ -12,42 +12,25 @@
 #include <typeinfo>
 #include <stdexcept>
 #include <ios>
+#include <future>
+#include <list>
 
 #define tree_buffer_root(buf) (&(buf)[0][0])
 
-static ckdtree_intp_t
-build(ckdtree *self, ckdtree_intp_t start_idx, intptr_t end_idx,
-      double *maxes, double *mins,
-      const int _median, const int _compact)
+static ckdtree_intp_t split_and_partition(ckdtree *self,
+    ckdtree_intp_t start_idx, ckdtree_intp_t end_idx, double *maxes, double *mins,
+    const int _median, const int _compact, ckdtreenode* node)
 {
-
     const ckdtree_intp_t m = self->m;
     const double *data = self->raw_data;
     ckdtree_intp_t *indices = (intptr_t *)(self->raw_indices);
 
-    ckdtreenode new_node, *n, *root;
-    ckdtree_intp_t node_index, _less, _greater;
-    ckdtree_intp_t i, j, p, d;
-    double size, split, minval, maxval;
+    ckdtree_intp_t p;
+    double split;
 
-    /* put a new node into the node stack */
-    self->tree_buffer->push_back(new_node);
-    node_index = self->tree_buffer->size() - 1;
-    root = tree_buffer_root(self->tree_buffer);
-    n = root + node_index;
-    memset(n, 0, sizeof(n[0]));
+    std::vector<double> tmpminmax;
 
-    n->start_idx = start_idx;
-    n->end_idx = end_idx;
-    n->children = end_idx - start_idx;
-
-    if (end_idx-start_idx <= self->leafsize) {
-        /* below brute force limit, return leafnode */
-        n->split_dim = -1;
-        return node_index;
-    }
-    else {
-
+    while (true) {
         if (CKDTREE_LIKELY(_compact)) {
             /* Recompute hyperrectangle bounds. This should lead to a more
              * compact kd-tree but comes at the expense of larger construction
@@ -56,13 +39,13 @@ build(ckdtree *self, ckdtree_intp_t start_idx, intptr_t end_idx,
              */
             const double *tmp_data_point;
             tmp_data_point = data + indices[start_idx] * m;
-            for(i=0; i<m; ++i) {
+            for(ckdtree_intp_t i=0; i<m; ++i) {
                 maxes[i] = tmp_data_point[i];
                 mins[i] = tmp_data_point[i];
             }
-            for (j = start_idx + 1; j < end_idx; ++j) {
+            for (ckdtree_intp_t j = start_idx + 1; j < end_idx; ++j) {
                 tmp_data_point = data + indices[j] * m;
-                for(i=0; i<m; ++i) {
+                for(ckdtree_intp_t i=0; i<m; ++i) {
                     double tmp = tmp_data_point[i];
                     maxes[i] = maxes[i] > tmp ? maxes[i] : tmp;
                     mins[i] = mins[i] < tmp ? mins[i] : tmp;
@@ -71,22 +54,22 @@ build(ckdtree *self, ckdtree_intp_t start_idx, intptr_t end_idx,
         }
 
         /* split on the dimension with largest spread */
-        d = 0;
-        size = 0;
-        for (i=0; i<m; ++i) {
+        ckdtree_intp_t d = 0;
+        double size = 0;
+        for (ckdtree_intp_t i=0; i<m; ++i) {
             if (maxes[i] - mins[i] > size) {
                 d = i;
                 size = maxes[i] - mins[i];
             }
         }
-        maxval = maxes[d];
-        minval = mins[d];
+        const double maxval = maxes[d];
+        const double minval = mins[d];
         if (maxval == minval) {
             /* all points are identical; warn user?
              * return leafnode
              */
-            n->split_dim = -1;
-            return node_index;
+            node->split_dim = -1;
+            return -1;
         }
 
         /* construct new inner node */
@@ -142,62 +125,257 @@ build(ckdtree *self, ckdtree_intp_t start_idx, intptr_t end_idx,
         if (CKDTREE_UNLIKELY(p == start_idx || p == end_idx)) {
             // All children are equal in this dimenion, try again with new bounds
             assert(!_compact);
-            self->tree_buffer->pop_back();
-            std::vector<double> tmp_bounds(2 * m);
-            double* tmp_mins = &tmp_bounds[0];
-            std::copy_n(mins, m, tmp_mins);
-            double* tmp_maxes = &tmp_bounds[m];
-            std::copy_n(maxes, m, tmp_maxes);
+
+            if (tmpminmax.empty())
+            {
+                tmpminmax.resize(2*m);
+                std::copy_n(mins, m, tmpminmax.begin());
+                std::copy_n(maxes, m, tmpminmax.begin()+m);
+                mins = tmpminmax.data();
+                maxes = tmpminmax.data()+m;
+            }
 
             const auto fixed_val = data[indices[start_idx]*m + d];
-            tmp_mins[d] = fixed_val;
-            tmp_maxes[d] = fixed_val;
-
-            return build(self, start_idx, end_idx, tmp_maxes, tmp_mins, _median, _compact);
+            mins[d] = fixed_val;
+            maxes[d] = fixed_val;
+            continue;
         }
 
+        node->split = split;
+        node->split_dim = d;
+        return p;
+    }
+}
+
+inline void init_ckdtreenode(ckdtreenode& node, ckdtree_intp_t start_idx, intptr_t end_idx)
+{
+    node.split_dim = -1;
+    node.children = end_idx - start_idx;
+    node.split = 0.;
+    node.start_idx = start_idx;
+    node.end_idx = end_idx;
+    node.less = node.greater = nullptr;
+    node._less = node._greater = 0;
+}
+
+static ckdtree_intp_t
+build(ckdtree *self, ckdtree_intp_t start_idx, intptr_t end_idx,
+      double *maxes, double *mins,
+      const int _median, const int _compact,
+      std::vector<ckdtreenode>& buf)
+{
+    /* put a new node into the node stack */
+    const ckdtree_intp_t node_index = buf.size();
+    ckdtree_intp_t _less, _greater = 0;
+    buf.emplace_back();
+    ckdtreenode *node = &buf.back();
+    init_ckdtreenode(*node, start_idx, end_idx);
+
+    if (end_idx-start_idx <= self->leafsize) {
+        /* below brute force limit, return leafnode */
+        node->split_dim = -1;
+        return node_index;
+    }
+    else {
+
+        const ckdtree_intp_t p = split_and_partition(self, start_idx, end_idx, maxes, mins, _median, _compact, node);
+        if(p < 0)
+            return node_index; // split_and_partition decided to have a leaf node
+
+        const double split = node->split;
+        const ckdtree_intp_t d = node->split_dim;
+
         if (CKDTREE_LIKELY(_compact)) {
-            _less = build(self, start_idx, p, maxes, mins, _median, _compact);
-            _greater = build(self, p, end_idx, maxes, mins, _median, _compact);
+            _less = build(self, start_idx, p, maxes, mins, _median, _compact, buf);
+            _greater = build(self, p, end_idx, maxes, mins, _median, _compact, buf);
         }
         else
         {
-            std::vector<double> tmp(m);
-            double *mids = &tmp[0];
+            std::vector<double> mids(self->m);
 
-            for (i=0; i<m; ++i) mids[i] = maxes[i];
+            std::copy_n(maxes, mids.size(), mids.begin());
             mids[d] = split;
-            _less = build(self, start_idx, p, mids, mins, _median, _compact);
+            _less = build(self, start_idx, p, mids.data(), mins, _median, _compact, buf);
 
-            for (i=0; i<m; ++i) mids[i] = mins[i];
+            std::copy_n(mins, mids.size(), mids.begin());
             mids[d] = split;
-            _greater = build(self, p, end_idx, maxes, mids, _median, _compact);
+            _greater = build(self, p, end_idx, maxes, mids.data(), _median, _compact, buf);
         }
 
-        /* recompute n because std::vector can
-         * reallocate its internal buffer
-         */
-        root = tree_buffer_root(self->tree_buffer);
-        n = root + node_index;
+        node = &buf[node_index];
         /* fill in entries */
-        n->_less = _less;
-        n->_greater = _greater;
-        n->less = root + _less;
-        n->greater = root + _greater;
-        n->split_dim = d;
-        n->split = split;
+        node->_less = _less;
+        node->less = buf.data() + node->_less;
+        node->_greater = _greater;
+        node->greater = buf.data() + node->_greater;
 
         return node_index;
     }
 }
 
+static ckdtree_intp_t
+build(ckdtree *self, ckdtree_intp_t start_idx, intptr_t end_idx,
+    double *maxes, double *mins,
+    const int _median, const int _compact,
+    std::list<std::vector<ckdtreenode>>* buflist, int workers);
 
+struct build_worker {
+
+    std::list<std::vector<ckdtreenode>> buflist_;
+    std::vector<double> mins_, maxes_;
+    std::future<ckdtree_intp_t> future_;
+
+    ckdtree_intp_t run(ckdtree *self, ckdtree_intp_t start_idx, intptr_t end_idx,
+          const double *maxes, const double *mins,
+          const int _median, const int _compact,
+          int workers)
+    {
+        const int subworkers = workers/2;
+        assert(subworkers > 0);
+
+        mins_.resize(self->m);
+        std::copy_n(mins, mins_.size(), mins_.begin());
+        maxes_.resize(self->m);
+        std::copy_n(maxes, maxes_.size(), maxes_.begin());
+
+        future_ = std::async(std::launch::async, [&]() {
+                return build(
+                    self, start_idx, end_idx, maxes_.data(), mins_.data(), _median, _compact,
+                    &buflist_, subworkers);
+            });
+
+        return subworkers;
+    }
+
+    operator bool() const { return future_.valid(); }
+    void wait() { future_.wait(); }
+    std::list<std::vector<ckdtreenode>>& buflist() { return buflist_; }
+};
+
+static ckdtree_intp_t
+build(ckdtree *self, ckdtree_intp_t start_idx, intptr_t end_idx,
+      double *maxes, double *mins,
+      const int _median, const int _compact,
+      std::list<std::vector<ckdtreenode>>* buflist, int workers)
+{
+    buflist->emplace_back();
+    std::vector<ckdtreenode>& buf = buflist->front();
+    buf.reserve((end_idx-start_idx)/self->leafsize/workers);
+
+    if (workers == 1)
+        return build(self, start_idx, end_idx, maxes, mins, _median, _compact, buf);
+
+    /* put a new node into the node stack */
+    const ckdtree_intp_t node_index = buf.size();
+    ckdtree_intp_t _less;
+    buf.emplace_back();
+    ckdtreenode *node = &buf.back();
+    init_ckdtreenode(*node, start_idx, end_idx);
+
+    if (end_idx-start_idx <= self->leafsize) {
+        /* below brute force limit, return leafnode */
+        node->split_dim = -1;
+        return node_index;
+    }
+    else {
+
+        const ckdtree_intp_t p = split_and_partition(self, start_idx, end_idx, maxes, mins,
+            _median, _compact, node);
+        if(p < 0)
+            return node_index; // split_and_partition decided to have a leaf node
+
+        const double split = node->split;
+        const ckdtree_intp_t d = node->split_dim;
+
+        // try to put this on its own cache line to avoid false sharing with the child thread
+        alignas(64) build_worker worker;
+
+        if (CKDTREE_LIKELY(_compact)) {
+            workers -= worker.run(self, p, end_idx, maxes, mins, _median, _compact, workers);
+            _less = build(self, start_idx, p, maxes, mins, _median, _compact, buflist, workers);
+        }
+        else
+        {
+            std::vector<double> mids(self->m);
+
+            std::copy_n(mins, mids.size(), mids.begin());
+            mids[d] = split;
+            workers -= worker.run(self, p, end_idx, maxes, mids.data(), _median, _compact, workers);
+
+            std::copy_n(maxes, mids.size(), mids.begin());
+            mids[d] = split;
+            _less = build(self, start_idx, p, mids.data(), mins, _median, _compact, buflist, workers);
+        }
+
+        node = &buf[node_index];
+        /* fill in entries */
+        node->_less = _less;
+
+        ckdtree_intp_t _greater = 0;
+        for(const auto& b : *buflist)
+            _greater += b.size();
+        worker.wait();
+        buflist->splice(buflist->end(), worker.buflist());
+        node->_greater = _greater;
+
+        return node_index;
+    }
+}
 
 int build_ckdtree(ckdtree *self, ckdtree_intp_t start_idx, intptr_t end_idx,
-              double *maxes, double *mins, int _median, int _compact)
+              double *maxes, double *mins, int _median, int _compact, int _workers)
 
 {
-    build(self, start_idx, end_idx, maxes, mins, _median, _compact);
+    if(_workers == 1) {
+        self->tree_buffer->reserve((end_idx-start_idx)/self->leafsize);
+        // build tree sequentially
+        build(self, start_idx, end_idx, maxes, mins, _median, _compact, *self->tree_buffer);
+    }
+    else {
+        std::list<std::vector<ckdtreenode>> buflist;
+        // build tree with sections collected in buflist
+        build(self, start_idx, end_idx, maxes, mins, _median, _compact, &buflist, _workers);
+
+        {
+            // count the number of nodes we got
+            ckdtree_intp_t tree_size = 0;
+            for(const auto& b : buflist) {
+                tree_size += b.size();
+            }
+            self->tree_buffer->resize(tree_size);
+        }
+
+        // merge sections from buflist in self->tree_buffer and update pointers and indices
+        std::vector<std::future<void>> futures;
+        futures.reserve(_workers-1);
+        auto buflistLast = buflist.end();
+        buflistLast--;
+
+        auto insertBuf = [self](int offset, std::vector<ckdtreenode>* b) -> void {
+                auto s = self->tree_buffer->begin()+offset;
+                for(const auto& a : *b) {
+                    *s = a;
+                    s->_less += offset;
+                    s->_greater += offset;
+                    s->less = self->tree_buffer->data() + s->_less;
+                    s->greater = self->tree_buffer->data() + s->_greater;
+                    ++s;
+                }
+                // std::copy(b->cbegin(), b->cend(), self->tree_buffer->begin()+offset);
+            };
+        ckdtree_intp_t offset = 0;
+        for(auto b = buflist.begin(); b != buflistLast; ++b) {
+            futures.push_back(std::async(std::launch::async, insertBuf, offset, &*b));
+            offset += b->size();
+        }
+        insertBuf(offset, &*buflistLast);
+
+        // wait for threads for clarity, the destructor would take care of this anyway...
+        for(auto& f : futures) {
+            f.wait();
+        }
+    }
+
     return 0;
 }
 

--- a/scipy/spatial/ckdtree/src/build.cxx
+++ b/scipy/spatial/ckdtree/src/build.cxx
@@ -238,7 +238,7 @@ struct build_worker {
         maxes_.resize(self->m);
         std::copy_n(maxes, maxes_.size(), maxes_.begin());
 
-        future_ = std::async(std::launch::async, [&]() {
+        future_ = std::async(std::launch::async, [=]() {
                 return build(
                     self, start_idx, end_idx, maxes_.data(), mins_.data(), _median, _compact,
                     &buflist_, subworkers);

--- a/scipy/spatial/ckdtree/src/ckdtree_decl.h
+++ b/scipy/spatial/ckdtree/src/ckdtree_decl.h
@@ -53,7 +53,7 @@ struct ckdtree {
 
 int
 build_ckdtree(ckdtree *self, ckdtree_intp_t start_idx, intptr_t end_idx,
-              double *maxes, double *mins, int _median, int _compact);
+              double *maxes, double *mins, int _median, int _compact, int _workers);
 
 int
 build_weights (ckdtree *self, double *node_weights, double *weights);

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -1504,3 +1504,17 @@ def test_kdtree_count_neighbors_weighted(kdtree_class):
     expect = [np.sum(weights[(prev_radius < dist) & (dist <= radius)])
               for prev_radius, radius in zip(itertools.chain([0], r[:-1]), r)]
     assert_allclose(nAB, expect)
+
+
+def test_ckdtree_parallel_build():
+    np.random.seed(1234)
+
+    for dim in range(1, 5):
+        data = np.random.random((12345, dim))
+
+        # sequential reference
+        tree = cKDTree(data, leafsize=3, workers=1)
+
+        for workers in range(2, 4):
+            ptree = cKDTree(data, leafsize=3, workers=workers)
+            assert_array_equal(tree.tree.indices, ptree.tree.indices)


### PR DESCRIPTION
This PR adds threading to the build phase `KDTree`/`cKDTree`. With large number of points (>~100M) the single-core build time grows into tens of minutes. Considering the memory requirements at this scale, this also means lots of cores sitting idle.

#### Reference issue
N/A

#### What does this implement/fix?
`cKDTree`'s `build()` function is changed to spawn worker threads at each recursion level up to a maximum number of workers controlled by the user through the optional `build_workers` argument to `cKDTree.__init__()`.
* The parallelism is implemented such, that the resulting tree is identical to the one from previous sequential implementation.
* The code uses C++11 threads. (I did not find any documentation or examples in the source as to what threading model is preferred in SciPy C++ code,so I chose the standard way. Should be supported even by GCC 4.8)
* There is no dynamic load balancing to keep the code simple. Dynamic balancing would probably not improve performance enough to be worth the added complexity.
* Performance limitations: Maximum speedup on Zen2 and SkyLake is between 4 and 5x with diminishing returns above ~four threads:
  * mainly due to memory bandwidth limitations
  * load imbalances
  * the top level sort has to done by one thread; C++17 parallel STL would help out here.
  * Ahmdal's law also hits at some point with ~5% of the sequential time spend in the setup before `build_ckdtree()` is called.
  * ![scaling D=10](https://user-images.githubusercontent.com/19977047/127145078-87d6f9de-1d3f-41df-b935-d23072957aab.png) 

#### Additional information
I did no find a C++ style guide for SciPy, so I tried to follow the style in the present code.