### PR TITLE
ENH: implement right multiplication of linear operators by arrays

### DIFF
--- a/scipy/sparse/linalg/interface.py
+++ b/scipy/sparse/linalg/interface.py
@@ -136,6 +136,7 @@ class LinearOperator:
     array([ 2.,  3.])
 
     """
+    __array_ufunc__ = None
 
     ndim = 2
 
@@ -437,8 +438,20 @@ class LinearOperator:
     def __rmul__(self, x):
         if np.isscalar(x):
             return _ScaledLinearOperator(self, x)
-        else:
+        elif isinstance(x, LinearOperator):
             return NotImplemented
+
+        x = np.asarray(x).T.conj()
+
+        if x.ndim == 1 or x.ndim == 2 and x.shape[1] == 1:
+            return self.rmatvec(x).T.conj()
+        elif x.ndim == 2:
+            return self.rmatmat(x).T.conj()
+        else:
+            raise ValueError(
+                'expected scalar, 1-d or 2-d array/matrix or LinearOperator,'
+                f' got {x}'
+            )
 
     def __pow__(self, p):
         if np.isscalar(p):

--- a/scipy/sparse/linalg/interface.py
+++ b/scipy/sparse/linalg/interface.py
@@ -441,12 +441,12 @@ class LinearOperator:
         elif isinstance(x, LinearOperator):
             return NotImplemented
 
-        x = np.asarray(x).T.conj()
+        x = np.asarray(x)
 
         if x.ndim == 1 or x.ndim == 2 and x.shape[1] == 1:
-            return self.rmatvec(x).T.conj()
+            return self.rmatvec(x.T.conj()).T.conj()
         elif x.ndim == 2:
-            return self.rmatmat(x).T.conj()
+            return self.rmatmat(x.T.conj()).T.conj()
         else:
             raise ValueError(
                 'expected scalar, 1-d or 2-d array/matrix or LinearOperator,'

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -455,4 +455,4 @@ def test_right_matmul():
     A = interface.aslinearoperator(X)
     assert_equal(A @ X, X @ A)
     with pytest.raises(ValueError, match="expected scalar, 1-d or 2-d array"):
-        None @ X
+        None @ A

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -448,3 +448,11 @@ def test_transpose_noconjugate():
 
     assert_equal(B.dot(v), Y.dot(v))
     assert_equal(B.T.dot(v), Y.T.dot(v))
+
+
+def test_right_matmul():
+    X = np.array([[1j, 2], [0, 2+1j]])
+    A = interface.aslinearoperator(X)
+    assert_equal(A @ X, X @ A)
+    with pytest.raises(ValueError, "expected scalar, 1-d or 2-d array"):
+        None @ X

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -454,5 +454,5 @@ def test_right_matmul():
     X = np.array([[1j, 2], [0, 2+1j]])
     A = interface.aslinearoperator(X)
     assert_equal(A @ X, X @ A)
-    with pytest.raises(ValueError, "expected scalar, 1-d or 2-d array"):
+    with pytest.raises(ValueError, match="expected scalar, 1-d or 2-d array"):
         None @ X


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue

N/A

#### What does this implement/fix?

Allows to multiply a linear operator by a numpy array from the left if the linear operator supports this.