### PR TITLE
TST: modify flaky test for constrained minimization

### DIFF
--- a/scipy/optimize/_trustregion_constr/tests/test_report.py
+++ b/scipy/optimize/_trustregion_constr/tests/test_report.py
@@ -17,7 +17,7 @@ def test_gh12922():
     # checks that verbose reporting works with trust-constr for
     # general constraints
     def objective(x):
-        return np.array([(np.sum((x+1)**2))])
+        return np.array([(np.sum((x+1)**4))])
 
     cons = {'type': 'ineq', 'fun': lambda x: -x[0]**2}
     n = 25


### PR DESCRIPTION
Was failing with:
```
lib/python3.9/site-packages/scipy/optimize/_hessian_update_strategy.py:182: in update
    warn('delta_grad == 0.0. Check if the approximated '
E   UserWarning: delta_grad == 0.0. Check if the approximated function is linear. If the function is linear better results can be obtained by defining the Hessian as zero instead of using quasi-Newton approximations.
```

Follow-up to gh-12922, where the `grad_delta==0` warning was observed,
but apparently the fix was a little unstable (seeing it in CI of the
Meson build on my fork).