### PR TITLE
optimize._linprog() sparse matrix input doc update/convert sparse parameters to dense for simplex methods

### DIFF
--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -207,13 +207,17 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
         The coefficients of the linear objective function to be minimized.
     A_ub : 2-D array, optional
         The inequality constraint matrix. Each row of ``A_ub`` specifies the
-        coefficients of a linear inequality constraint on ``x``.
+        coefficients of a linear inequality constraint on ``x``. Accepts sparse 
+        matrix. If method="simplex" or "revised simplex", tries to convert
+        sparse matrix to dense.
     b_ub : 1-D array, optional
         The inequality constraint vector. Each element represents an
         upper bound on the corresponding value of ``A_ub @ x``.
     A_eq : 2-D array, optional
         The equality constraint matrix. Each row of ``A_eq`` specifies the
-        coefficients of a linear equality constraint on ``x``.
+        coefficients of a linear equality constraint on ``x``.  Accepts sparse 
+        matrix. If method="simplex" or "revised simplex", tries to convert 
+        sparse matrix to dense.
     b_eq : 1-D array, optional
         The equality constraint vector. Each element of ``A_eq @ x`` must equal
         the corresponding element of ``b_eq``.
@@ -587,7 +591,11 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
     if x0 is not None and meth != "revised simplex":
         warning_message = "x0 is used only when method is 'revised simplex'. "
         warn(warning_message, OptimizeWarning)
-
+        
+    if 'simplex' in meth:
+        A_eq = A_eq.todense()
+        A_ub = A_ub.todense()
+        
     lp = _LPProblem(c, A_ub, b_ub, A_eq, b_eq, bounds, x0)
     lp, solver_options = _parse_linprog(lp, options, meth)
     tol = solver_options.get('tol', 1e-9)

--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -606,8 +606,7 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
         if sps.issparse(A_ub):
             warn(conversion_message.format('A_ub'), SparseEfficiencyWarning)
             A_ub = A_ub.toarray()        
-
-        
+ 
     lp = _LPProblem(c, A_ub, b_ub, A_eq, b_eq, bounds, x0)
     lp, solver_options = _parse_linprog(lp, options, meth)
     tol = solver_options.get('tol', 1e-9)

--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -605,7 +605,7 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
             A_eq = A_eq.toarray()
         if sps.issparse(A_ub):
             warn(conversion_message.format('A_ub'), SparseEfficiencyWarning)
-            A_ub = A_ub.toarray()        
+            A_ub = A_ub.toarray()       
 
     lp = _LPProblem(c, A_ub, b_ub, A_eq, b_eq, bounds, x0)
     lp, solver_options = _parse_linprog(lp, options, meth)

--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -593,12 +593,12 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
     if x0 is not None and meth != "revised simplex":
         warning_message = "x0 is used only when method is 'revised simplex'. "
         warn(warning_message, OptimizeWarning)
-        
-    # convert sparse matrices to dense array if a simplex method is used and warn
-    if meth in {'revised simplex', 'simplex'}:           
-        conversion_message = '''Converting sparse input {0} to dense array 
-        because a simplex method is used. May run out of memory if {0} is very 
-        large; consider HiGHS method instead.'''.replace('\n', '')
+
+    # convert sparse to dense array if a simplex method is used and warn
+    if meth in {'revised simplex', 'simplex'}:
+        conversion_message = '''Converting sparse input {0} to dense array
+        because a simplex method is used. May run out of memory if {0} is very
+        large; consider HiGHS method instead.'''.replace('\n', ' ')
         if sps.issparse(A_eq):
             # warn first before trying to convert so user knows where error is.
             warn(conversion_message.format('A_eq'), SparseEfficiencyWarning)
@@ -606,7 +606,7 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
         if sps.issparse(A_ub):
             warn(conversion_message.format('A_ub'), SparseEfficiencyWarning)
             A_ub = A_ub.toarray()        
- 
+
     lp = _LPProblem(c, A_ub, b_ub, A_eq, b_eq, bounds, x0)
     lp, solver_options = _parse_linprog(lp, options, meth)
     tol = solver_options.get('tol', 1e-9)

--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -605,7 +605,7 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
             A_eq = A_eq.toarray()
         if sps.issparse(A_ub):
             warn(conversion_message.format('A_ub'), SparseEfficiencyWarning)
-            A_ub = A_ub.toarray()       
+            A_ub = A_eq.toarray()
 
     lp = _LPProblem(c, A_ub, b_ub, A_eq, b_eq, bounds, x0)
     lp, solver_options = _parse_linprog(lp, options, meth)

--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -16,6 +16,7 @@ Functions
 """
 
 import numpy as np
+import scipy.sparse as sps
 
 from .optimize import OptimizeResult, OptimizeWarning
 from warnings import warn
@@ -207,17 +208,13 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
         The coefficients of the linear objective function to be minimized.
     A_ub : 2-D array, optional
         The inequality constraint matrix. Each row of ``A_ub`` specifies the
-        coefficients of a linear inequality constraint on ``x``. Accepts sparse 
-        matrix. If method="simplex" or "revised simplex", tries to convert
-        sparse matrix to dense.
+        coefficients of a linear inequality constraint on ``x``.
     b_ub : 1-D array, optional
         The inequality constraint vector. Each element represents an
         upper bound on the corresponding value of ``A_ub @ x``.
     A_eq : 2-D array, optional
         The equality constraint matrix. Each row of ``A_eq`` specifies the
-        coefficients of a linear equality constraint on ``x``.  Accepts sparse 
-        matrix. If method="simplex" or "revised simplex", tries to convert 
-        sparse matrix to dense.
+        coefficients of a linear equality constraint on ``x``.
     b_eq : 1-D array, optional
         The equality constraint vector. Each element of ``A_eq @ x`` must equal
         the corresponding element of ``b_eq``.
@@ -592,9 +589,12 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
         warning_message = "x0 is used only when method is 'revised simplex'. "
         warn(warning_message, OptimizeWarning)
         
-    if 'simplex' in meth:
-        A_eq = A_eq.todense()
-        A_ub = A_ub.todense()
+    if meth in {'revised simplex', 'simplex'}:
+        if sps.issparse(A_eq):
+            A_eq = A_eq.todense()
+        if sps.issparse(A_ub):
+            A_ub = A_ub.todense()
+        
         
     lp = _LPProblem(c, A_ub, b_ub, A_eq, b_eq, bounds, x0)
     lp, solver_options = _parse_linprog(lp, options, meth)

--- a/scipy/optimize/_linprog_doc.py
+++ b/scipy/optimize/_linprog_doc.py
@@ -51,15 +51,17 @@ def _linprog_highs_doc(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
     ----------
     c : 1-D array
         The coefficients of the linear objective function to be minimized.
-    A_ub : 2-D array, optional
+    A_ub : 2-D array or sparse matrix, optional
         The inequality constraint matrix. Each row of ``A_ub`` specifies the
-        coefficients of a linear inequality constraint on ``x``.
+        coefficients of a linear inequality constraint on ``x``. Converts 
+        input to dense array.
     b_ub : 1-D array, optional
         The inequality constraint vector. Each element represents an
         upper bound on the corresponding value of ``A_ub @ x``.
-    A_eq : 2-D array, optional
+    A_eq : 2-D array or sparse matrix, optional
         The equality constraint matrix. Each row of ``A_eq`` specifies the
-        coefficients of a linear equality constraint on ``x``.
+        coefficients of a linear equality constraint on ``x``. Converts 
+        input to dense array.
     b_eq : 1-D array, optional
         The equality constraint vector. Each element of ``A_eq @ x`` must equal
         the corresponding element of ``b_eq``.
@@ -307,15 +309,17 @@ def _linprog_highs_ds_doc(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
     ----------
     c : 1-D array
         The coefficients of the linear objective function to be minimized.
-    A_ub : 2-D array, optional
+    A_ub : 2-D array or sparse matrix, optional
         The inequality constraint matrix. Each row of ``A_ub`` specifies the
-        coefficients of a linear inequality constraint on ``x``.
-    b_ub : 1-D array, optional
+        coefficients of a linear inequality constraint on ``x``. Converts 
+        input to dense array.
+    b_ub : 1-D array or sparse matrix, optional
         The inequality constraint vector. Each element represents an
         upper bound on the corresponding value of ``A_ub @ x``.
     A_eq : 2-D array, optional
         The equality constraint matrix. Each row of ``A_eq`` specifies the
-        coefficients of a linear equality constraint on ``x``.
+        coefficients of a linear equality constraint on ``x``. Converts 
+        input to dense array.
     b_eq : 1-D array, optional
         The equality constraint vector. Each element of ``A_eq @ x`` must equal
         the corresponding element of ``b_eq``.
@@ -548,15 +552,17 @@ def _linprog_highs_ipm_doc(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
     ----------
     c : 1-D array
         The coefficients of the linear objective function to be minimized.
-    A_ub : 2-D array, optional
+    A_ub : 2-D array or sparse matrix, optional
         The inequality constraint matrix. Each row of ``A_ub`` specifies the
-        coefficients of a linear inequality constraint on ``x``.
-    b_ub : 1-D array, optional
+        coefficients of a linear inequality constraint on ``x``. Converts 
+        input to dense array.
+    b_ub : 1-D array or sparse matrix, optional
         The inequality constraint vector. Each element represents an
         upper bound on the corresponding value of ``A_ub @ x``.
     A_eq : 2-D array, optional
         The equality constraint matrix. Each row of ``A_eq`` specifies the
-        coefficients of a linear equality constraint on ``x``.
+        coefficients of a linear equality constraint on ``x``. Converts 
+        input to dense array.
     b_eq : 1-D array, optional
         The equality constraint vector. Each element of ``A_eq @ x`` must equal
         the corresponding element of ``b_eq``.
@@ -776,15 +782,17 @@ def _linprog_ip_doc(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
     ----------
     c : 1-D array
         The coefficients of the linear objective function to be minimized.
-    A_ub : 2-D array, optional
+    A_ub : 2-D array or sparse matrix, optional
         The inequality constraint matrix. Each row of ``A_ub`` specifies the
-        coefficients of a linear inequality constraint on ``x``.
+        coefficients of a linear inequality constraint on ``x``. Converts 
+        input to dense array.
     b_ub : 1-D array, optional
         The inequality constraint vector. Each element represents an
         upper bound on the corresponding value of ``A_ub @ x``.
-    A_eq : 2-D array, optional
+    A_eq : 2-D array or sparse matrix, optional
         The equality constraint matrix. Each row of ``A_eq`` specifies the
-        coefficients of a linear equality constraint on ``x``.
+        coefficients of a linear equality constraint on ``x``. Converts 
+        input to dense array.
     b_eq : 1-D array, optional
         The equality constraint vector. Each element of ``A_eq @ x`` must equal
         the corresponding element of ``b_eq``.
@@ -1099,15 +1107,17 @@ def _linprog_rs_doc(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
     ----------
     c : 1-D array
         The coefficients of the linear objective function to be minimized.
-    A_ub : 2-D array, optional
+    A_ub : 2-D array or sparse matrix, optional
         The inequality constraint matrix. Each row of ``A_ub`` specifies the
-        coefficients of a linear inequality constraint on ``x``.
+        coefficients of a linear inequality constraint on ``x``. Converts 
+        input to dense array.
     b_ub : 1-D array, optional
         The inequality constraint vector. Each element represents an
         upper bound on the corresponding value of ``A_ub @ x``.
-    A_eq : 2-D array, optional
+    A_eq : 2-D array or sparse matrix, optional
         The equality constraint matrix. Each row of ``A_eq`` specifies the
-        coefficients of a linear equality constraint on ``x``.
+        coefficients of a linear equality constraint on ``x``. Converts 
+        input to dense array.
     b_eq : 1-D array, optional
         The equality constraint vector. Each element of ``A_eq @ x`` must equal
         the corresponding element of ``b_eq``.
@@ -1280,15 +1290,17 @@ def _linprog_simplex_doc(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
     ----------
     c : 1-D array
         The coefficients of the linear objective function to be minimized.
-    A_ub : 2-D array, optional
+    A_ub : 2-D array or sparse matrix, optional
         The inequality constraint matrix. Each row of ``A_ub`` specifies the
-        coefficients of a linear inequality constraint on ``x``.
+        coefficients of a linear inequality constraint on ``x``. Converts 
+        input to dense array.
     b_ub : 1-D array, optional
         The inequality constraint vector. Each element represents an
         upper bound on the corresponding value of ``A_ub @ x``.
-    A_eq : 2-D array, optional
+    A_eq : 2-D array or sparse matrix, optional
         The equality constraint matrix. Each row of ``A_eq`` specifies the
-        coefficients of a linear equality constraint on ``x``.
+        coefficients of a linear equality constraint on ``x``. Converts 
+        input to dense array.
     b_eq : 1-D array, optional
         The equality constraint vector. Each element of ``A_eq @ x`` must equal
         the corresponding element of ``b_eq``.

--- a/scipy/optimize/_linprog_doc.py
+++ b/scipy/optimize/_linprog_doc.py
@@ -53,7 +53,7 @@ def _linprog_highs_doc(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
         The coefficients of the linear objective function to be minimized.
     A_ub : 2-D array or sparse matrix, optional
         The inequality constraint matrix. Each row of ``A_ub`` specifies the
-        coefficients of a linear inequality constraint on ``x``. 
+        coefficients of a linear inequality constraint on ``x``.
     b_ub : 1-D array, optional
         The inequality constraint vector. Each element represents an
         upper bound on the corresponding value of ``A_ub @ x``.
@@ -309,7 +309,7 @@ def _linprog_highs_ds_doc(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
         The coefficients of the linear objective function to be minimized.
     A_ub : 2-D array or sparse matrix, optional
         The inequality constraint matrix. Each row of ``A_ub`` specifies the
-        coefficients of a linear inequality constraint on ``x``. 
+        coefficients of a linear inequality constraint on ``x``.
     b_ub : 1-D array, optional
         The inequality constraint vector. Each element represents an
         upper bound on the corresponding value of ``A_ub @ x``.
@@ -550,7 +550,7 @@ def _linprog_highs_ipm_doc(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
         The coefficients of the linear objective function to be minimized.
     A_ub : 2-D array or sparse matrix, optional
         The inequality constraint matrix. Each row of ``A_ub`` specifies the
-        coefficients of a linear inequality constraint on ``x``. 
+        coefficients of a linear inequality constraint on ``x``.
     b_ub : 1-D array, optional
         The inequality constraint vector. Each element represents an
         upper bound on the corresponding value of ``A_ub @ x``.
@@ -778,13 +778,13 @@ def _linprog_ip_doc(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
         The coefficients of the linear objective function to be minimized.
     A_ub : 2-D array or sparse matrix, optional
         The inequality constraint matrix. Each row of ``A_ub`` specifies the
-        coefficients of a linear inequality constraint on ``x``. 
+        coefficients of a linear inequality constraint on ``x``.
     b_ub : 1-D array, optional
         The inequality constraint vector. Each element represents an
         upper bound on the corresponding value of ``A_ub @ x``.
     A_eq : 2-D array or sparse matrix, optional
         The equality constraint matrix. Each row of ``A_eq`` specifies the
-        coefficients of a linear equality constraint on ``x``. 
+        coefficients of a linear equality constraint on ``x``.
     b_eq : 1-D array, optional
         The equality constraint vector. Each element of ``A_eq @ x`` must equal
         the corresponding element of ``b_eq``.
@@ -1101,14 +1101,14 @@ def _linprog_rs_doc(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
         The coefficients of the linear objective function to be minimized.
     A_ub : 2-D array, optional
         The inequality constraint matrix. Each row of ``A_ub`` specifies the
-        coefficients of a linear inequality constraint on ``x``. If input is 
+        coefficients of a linear inequality constraint on ``x``. If input is
         sparse matrix, converts to dense array.
     b_ub : 1-D array, optional
         The inequality constraint vector. Each element represents an
         upper bound on the corresponding value of ``A_ub @ x``.
     A_eq : 2-D array, optional
         The equality constraint matrix. Each row of ``A_eq`` specifies the
-        coefficients of a linear equality constraint on ``x``. If input is 
+        coefficients of a linear equality constraint on ``x``. If input is
         sparse matrix, converts to dense array.
     b_eq : 1-D array, optional
         The equality constraint vector. Each element of ``A_eq @ x`` must equal
@@ -1284,14 +1284,14 @@ def _linprog_simplex_doc(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
         The coefficients of the linear objective function to be minimized.
     A_ub : 2-D array, optional
         The inequality constraint matrix. Each row of ``A_ub`` specifies the
-        coefficients of a linear inequality constraint on ``x``. If input is 
+        coefficients of a linear inequality constraint on ``x``. If input is
         sparse matrix, converts to dense array.
     b_ub : 1-D array, optional
         The inequality constraint vector. Each element represents an
         upper bound on the corresponding value of ``A_ub @ x``.
     A_eq : 2-D array, optional
         The equality constraint matrix. Each row of ``A_eq`` specifies the
-        coefficients of a linear equality constraint on ``x``. If input is 
+        coefficients of a linear equality constraint on ``x``. If input is
         sparse matrix, converts to dense array.
     b_eq : 1-D array, optional
         The equality constraint vector. Each element of ``A_eq @ x`` must equal

--- a/scipy/optimize/_linprog_doc.py
+++ b/scipy/optimize/_linprog_doc.py
@@ -53,15 +53,13 @@ def _linprog_highs_doc(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
         The coefficients of the linear objective function to be minimized.
     A_ub : 2-D array or sparse matrix, optional
         The inequality constraint matrix. Each row of ``A_ub`` specifies the
-        coefficients of a linear inequality constraint on ``x``. Converts 
-        input to dense array.
+        coefficients of a linear inequality constraint on ``x``. 
     b_ub : 1-D array, optional
         The inequality constraint vector. Each element represents an
         upper bound on the corresponding value of ``A_ub @ x``.
     A_eq : 2-D array or sparse matrix, optional
         The equality constraint matrix. Each row of ``A_eq`` specifies the
-        coefficients of a linear equality constraint on ``x``. Converts 
-        input to dense array.
+        coefficients of a linear equality constraint on ``x``.
     b_eq : 1-D array, optional
         The equality constraint vector. Each element of ``A_eq @ x`` must equal
         the corresponding element of ``b_eq``.
@@ -311,15 +309,13 @@ def _linprog_highs_ds_doc(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
         The coefficients of the linear objective function to be minimized.
     A_ub : 2-D array or sparse matrix, optional
         The inequality constraint matrix. Each row of ``A_ub`` specifies the
-        coefficients of a linear inequality constraint on ``x``. Converts 
-        input to dense array.
-    b_ub : 1-D array or sparse matrix, optional
+        coefficients of a linear inequality constraint on ``x``. 
+    b_ub : 1-D array, optional
         The inequality constraint vector. Each element represents an
         upper bound on the corresponding value of ``A_ub @ x``.
-    A_eq : 2-D array, optional
+    A_eq : 2-D array or sparse matrix, optional
         The equality constraint matrix. Each row of ``A_eq`` specifies the
-        coefficients of a linear equality constraint on ``x``. Converts 
-        input to dense array.
+        coefficients of a linear equality constraint on ``x``.
     b_eq : 1-D array, optional
         The equality constraint vector. Each element of ``A_eq @ x`` must equal
         the corresponding element of ``b_eq``.
@@ -554,15 +550,13 @@ def _linprog_highs_ipm_doc(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
         The coefficients of the linear objective function to be minimized.
     A_ub : 2-D array or sparse matrix, optional
         The inequality constraint matrix. Each row of ``A_ub`` specifies the
-        coefficients of a linear inequality constraint on ``x``. Converts 
-        input to dense array.
-    b_ub : 1-D array or sparse matrix, optional
+        coefficients of a linear inequality constraint on ``x``. 
+    b_ub : 1-D array, optional
         The inequality constraint vector. Each element represents an
         upper bound on the corresponding value of ``A_ub @ x``.
-    A_eq : 2-D array, optional
+    A_eq : 2-D array or sparse matrix, optional
         The equality constraint matrix. Each row of ``A_eq`` specifies the
-        coefficients of a linear equality constraint on ``x``. Converts 
-        input to dense array.
+        coefficients of a linear equality constraint on ``x``.
     b_eq : 1-D array, optional
         The equality constraint vector. Each element of ``A_eq @ x`` must equal
         the corresponding element of ``b_eq``.
@@ -784,15 +778,13 @@ def _linprog_ip_doc(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
         The coefficients of the linear objective function to be minimized.
     A_ub : 2-D array or sparse matrix, optional
         The inequality constraint matrix. Each row of ``A_ub`` specifies the
-        coefficients of a linear inequality constraint on ``x``. Converts 
-        input to dense array.
+        coefficients of a linear inequality constraint on ``x``. 
     b_ub : 1-D array, optional
         The inequality constraint vector. Each element represents an
         upper bound on the corresponding value of ``A_ub @ x``.
     A_eq : 2-D array or sparse matrix, optional
         The equality constraint matrix. Each row of ``A_eq`` specifies the
-        coefficients of a linear equality constraint on ``x``. Converts 
-        input to dense array.
+        coefficients of a linear equality constraint on ``x``. 
     b_eq : 1-D array, optional
         The equality constraint vector. Each element of ``A_eq @ x`` must equal
         the corresponding element of ``b_eq``.
@@ -1107,17 +1099,17 @@ def _linprog_rs_doc(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
     ----------
     c : 1-D array
         The coefficients of the linear objective function to be minimized.
-    A_ub : 2-D array or sparse matrix, optional
+    A_ub : 2-D array, optional
         The inequality constraint matrix. Each row of ``A_ub`` specifies the
-        coefficients of a linear inequality constraint on ``x``. Converts 
-        input to dense array.
+        coefficients of a linear inequality constraint on ``x``. If input is 
+        sparse matrix, converts to dense array.
     b_ub : 1-D array, optional
         The inequality constraint vector. Each element represents an
         upper bound on the corresponding value of ``A_ub @ x``.
-    A_eq : 2-D array or sparse matrix, optional
+    A_eq : 2-D array, optional
         The equality constraint matrix. Each row of ``A_eq`` specifies the
-        coefficients of a linear equality constraint on ``x``. Converts 
-        input to dense array.
+        coefficients of a linear equality constraint on ``x``. If input is 
+        sparse matrix, converts to dense array.
     b_eq : 1-D array, optional
         The equality constraint vector. Each element of ``A_eq @ x`` must equal
         the corresponding element of ``b_eq``.
@@ -1290,17 +1282,17 @@ def _linprog_simplex_doc(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
     ----------
     c : 1-D array
         The coefficients of the linear objective function to be minimized.
-    A_ub : 2-D array or sparse matrix, optional
+    A_ub : 2-D array, optional
         The inequality constraint matrix. Each row of ``A_ub`` specifies the
-        coefficients of a linear inequality constraint on ``x``. Converts 
-        input to dense array.
+        coefficients of a linear inequality constraint on ``x``. If input is 
+        sparse matrix, converts to dense array.
     b_ub : 1-D array, optional
         The inequality constraint vector. Each element represents an
         upper bound on the corresponding value of ``A_ub @ x``.
-    A_eq : 2-D array or sparse matrix, optional
+    A_eq : 2-D array, optional
         The equality constraint matrix. Each row of ``A_eq`` specifies the
-        coefficients of a linear equality constraint on ``x``. Converts 
-        input to dense array.
+        coefficients of a linear equality constraint on ``x``. If input is 
+        sparse matrix, converts to dense array.
     b_eq : 1-D array, optional
         The equality constraint vector. Each element of ``A_eq @ x`` must equal
         the corresponding element of ``b_eq``.

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -426,7 +426,7 @@ class LinprogCommonTests:
         assert_raises(ValueError, f, [1, 2], A_ub=np.zeros((1, 1, 3)), b_eq=1)
 
     def test_sparse_constraints(self):
-        
+
         def f(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None, bounds=None):
             linprog(c, A_ub, b_ub, A_eq, b_eq, bounds,
                     method=self.method, options=self.options)
@@ -441,10 +441,9 @@ class LinprogCommonTests:
         lb = x_valid - np.random.rand((n))
         bounds = np.column_stack((lb, ub))
         b_eq = A_eq * x_valid
-        
-        #gh-14488 - simplex methods now convert sparse matrix to dense array and give SparseEfficiencyWarning
-        if self.method in {'simplex', 'revised simplex'}:
-            
+
+        # simplex methods now convert sparse to dense array and warn gh-14448
+        if self.method in {'simplex', 'revised simplex'}:  
             with assert_warns(scipy.sparse.SparseEfficiencyWarning):
                 linprog(c=c, A_eq=A_eq, b_eq=b_eq, bounds=bounds,
                         method=self.method, options=self.options)

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -426,7 +426,7 @@ class LinprogCommonTests:
         assert_raises(ValueError, f, [1, 2], A_ub=np.zeros((1, 1, 3)), b_eq=1)
 
     def test_sparse_constraints(self):
-        # gh-13559: improve error message for sparse inputs when unsupported
+        
         def f(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None, bounds=None):
             linprog(c, A_ub, b_ub, A_eq, b_eq, bounds,
                     method=self.method, options=self.options)
@@ -441,15 +441,15 @@ class LinprogCommonTests:
         lb = x_valid - np.random.rand((n))
         bounds = np.column_stack((lb, ub))
         b_eq = A_eq * x_valid
-
+        
+        #gh-14488 - simplex methods now convert sparse matrix to dense array and give SparseEfficiencyWarning
         if self.method in {'simplex', 'revised simplex'}:
-            # simplex and revised simplex should raise error
-            with assert_raises(ValueError, match=f"Method '{self.method}' "
-                               "does not support sparse constraint matrices."):
+            
+            with assert_warns(scipy.sparse.SparseEfficiencyWarning):
                 linprog(c=c, A_eq=A_eq, b_eq=b_eq, bounds=bounds,
                         method=self.method, options=self.options)
         else:
-            # other methods should succeed
+            # other methods do not warn
             options = {**self.options}
             if self.method in {'interior-point'}:
                 options['sparse'] = True

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -443,7 +443,7 @@ class LinprogCommonTests:
         b_eq = A_eq * x_valid
 
         # simplex methods now convert sparse to dense array and warn gh-14448
-        if self.method in {'simplex', 'revised simplex'}:  
+        if self.method in {'simplex', 'revised simplex'}: 
             with assert_warns(scipy.sparse.SparseEfficiencyWarning):
                 linprog(c=c, A_eq=A_eq, b_eq=b_eq, bounds=bounds,
                         method=self.method, options=self.options)

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -443,7 +443,7 @@ class LinprogCommonTests:
         b_eq = A_eq * x_valid
 
         # simplex methods now convert sparse to dense array and warn gh-14448
-        if self.method in {'simplex', 'revised simplex'}: 
+        if self.method in {'simplex', 'revised simplex'}:
             with assert_warns(scipy.sparse.SparseEfficiencyWarning):
                 linprog(c=c, A_eq=A_eq, b_eq=b_eq, bounds=bounds,
                         method=self.method, options=self.options)


### PR DESCRIPTION

#### Reference issue
#14471 

#### What does this implement/fix?
ENH: optimize._linprog() will now try to convert sparse matrix to dense  for A_ub and A_eq parameters if method='simplex' or 'revised simplex', since they do not accept sparse matrices.

DOC: Added language to documentation for A_ub and A_eq parameters to reflect that they accept sparse matrix but will try to convert to dense if method='simplex' or 'revised simplex'.

