### PR TITLE
DOC: fix toarray/todense docstring

### DIFF
--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -840,7 +840,7 @@ class spmatrix:
         order : {'C', 'F'}, optional
             Whether to store multi-dimensional data in C (row-major)
             or Fortran (column-major) order in memory. The default
-            is 'None', indicating the NumPy default of C-ordered.
+            is 'None', which provides no ordering guarantees.
             Cannot be specified in conjunction with the `out`
             argument.
 
@@ -872,7 +872,7 @@ class spmatrix:
         order : {'C', 'F'}, optional
             Whether to store multidimensional data in C (row-major)
             or Fortran (column-major) order in memory. The default
-            is 'None', indicating the NumPy default of C-ordered.
+            is 'None', which provides no ordering guarantees.
             Cannot be specified in conjunction with the `out`
             argument.
 


### PR DESCRIPTION
#### Reference issue
Closes gh-10497

#### What does this implement/fix?

As discussed in the issue, the `spmatrix.toarray` and `spmatrix.todense` docstring incorrectly claims that the default order is C. This PR removes the order guarantee from the docstring.