### PR TITLE
BUG: integrate: fix implementation of adaptive stepsize control

### DIFF
--- a/scipy/integrate/_ivp/rk.py
+++ b/scipy/integrate/_ivp/rk.py
@@ -153,9 +153,6 @@ class RungeKutta(OdeSolver):
                     factor = min(MAX_FACTOR,
                                  SAFETY * error_norm ** self.error_exponent)
 
-                if step_rejected:
-                    factor = min(1, factor)
-
                 h_abs *= factor
 
                 step_accepted = True


### PR DESCRIPTION
remove unnecessary step_reject

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
According to the textbook **Hairer, Nørsett, Wanner (2008) Solving Ordinary Differential Equations I Nonstiff Problems** (4.13)
It is unnecessary to introduce further step size reduction when the proposed step is accepted beyond the formula (4.13).

#### Additional information
<!--Any additional information you think is important.-->