### PR TITLE
CI: Add lint_diff docs & option to run only on specified files/dirs

### DIFF
--- a/doc/source/dev/contributor/pep8.rst
+++ b/doc/source/dev/contributor/pep8.rst
@@ -25,7 +25,7 @@ compliance before pushing your code:
 
    ::
 
-      flake8 scipy/optimize/linprog.py
+      flake8 scipy/optimize/_linprog.py
 
    The absence of output indicates that there are no PEP8 issues with
    the file. Unfortunately, there is also no output if you get the file
@@ -38,6 +38,22 @@ compliance before pushing your code:
    (``linprog2.py`` doesn’t exist.) To make sure you have the path
    right, consider introducing (and then removing) a small PEP8 issue in
    the target file, such as a line that is over 79 characters long.
+
+-  Before sending a Pull Request, we recommend running the lint tests only
+   for the changes you've made in your feature branch. This will mimic
+   the continuous integration linting checks setup on GitHub.
+   You can run the following in the SciPy root directory.
+
+   ::
+
+      python tools/lint_diff.py
+
+   If you want to run the diff based lint tests only for specific files
+   or directories, please consider using the ``--files`` option.
+
+   ::
+
+      python tools/lint_diff.py --files scipy/odr/models.py scipy/ndimage
 
 -  If you have existing code with a lot of PEP8 issues, consider using
    |autopep8|_ to automatically fix most of them.

--- a/doc/source/dev/contributor/pep8.rst
+++ b/doc/source/dev/contributor/pep8.rst
@@ -19,25 +19,8 @@ compliance before pushing your code:
    Editor |rarr| Advanced Settings. This can help you fix PEP8 issues as you
    write your code.
 
--  You can also perform checks using the |flake8|_ tool. After
-   installing ``flake8``, navigate to the SciPy root directory in a
-   console window and try:
-
-   ::
-
-      flake8 scipy/optimize/_linprog.py
-
-   The absence of output indicates that there are no PEP8 issues with
-   the file. Unfortunately, there is also no output if you get the file
-   path wrong:
-
-   ::
-
-      flake8 scipy/optimize/linprog2.py
-
-   (``linprog2.py`` doesn’t exist.) To make sure you have the path
-   right, consider introducing (and then removing) a small PEP8 issue in
-   the target file, such as a line that is over 79 characters long.
+-  SciPy makes use of special configuration files for linting with the
+   |flake8|_ tool.
 
 -  It is typically recommended to leave any existing style issues alone
    unless they are part of the code you're already modifying.
@@ -46,9 +29,9 @@ compliance before pushing your code:
    Before sending a Pull Request, we suggest running the lint tests only
    for the changes you've made in your feature branch. This will mimic
    the continuous integration linting checks setup on GitHub.
-   You can run the following check locally in the SciPy root directory
-   to ensure your Pull Request doesn't break the Continuous Integration
-   linting tests.
+   After installing ``flake8``, you can run the following check locally
+   in the SciPy root directory to ensure your Pull Request doesn't
+   break the Continuous Integration linting tests.
 
    ::
 

--- a/doc/source/dev/contributor/pep8.rst
+++ b/doc/source/dev/contributor/pep8.rst
@@ -39,10 +39,16 @@ compliance before pushing your code:
    right, consider introducing (and then removing) a small PEP8 issue in
    the target file, such as a line that is over 79 characters long.
 
--  Before sending a Pull Request, we recommend running the lint tests only
+-  It is typically recommended to leave any existing style issues alone
+   unless they are part of the code you're already modifying.
+   This practice ensures that the codebase is gradually cleaned up
+   without dedicating precious review time to style-only cleanups.
+   Before sending a Pull Request, we suggest running the lint tests only
    for the changes you've made in your feature branch. This will mimic
    the continuous integration linting checks setup on GitHub.
-   You can run the following in the SciPy root directory.
+   You can run the following check locally in the SciPy root directory
+   to ensure your Pull Request doesn't break the Continuous Integration
+   linting tests.
 
    ::
 
@@ -56,7 +62,8 @@ compliance before pushing your code:
       python tools/lint_diff.py --files scipy/odr/models.py scipy/ndimage
 
 -  If you have existing code with a lot of PEP8 issues, consider using
-   |autopep8|_ to automatically fix most of them.
+   |autopep8|_ to automatically fix them before incorporating the code into
+   SciPy.
 
 .. _PEP8: https://www.python.org/dev/peps/pep-0008/
 .. _enable Real-time code style analysis: https://stackoverflow.com/questions/51463223/how-to-use-pep8-module-using-spyder

--- a/tools/lint_diff.py
+++ b/tools/lint_diff.py
@@ -97,6 +97,8 @@ def main():
     rc, errors = run_flake8(diff)
     if errors:
         print(errors)
+    else:
+        print("No lint errors found.")
     sys.exit(rc)
 
 

--- a/tools/lint_diff.py
+++ b/tools/lint_diff.py
@@ -58,14 +58,17 @@ def find_diff(sha, files=None):
         for file_or_dir in files:
             msg = f"{file_or_dir} doesn't exist. Please provide a valid path."
             assert os.path.exists(file_or_dir), msg
+        res = subprocess.run(
+            ['git', 'diff', '--unified=0', sha, '--', *files],
+            stdout=subprocess.PIPE,
+            encoding='utf-8',
+        )
     else:
-        files = '*.py'
-
-    res = subprocess.run(
-        ['git', 'diff', '--unified=0', sha, '--', *files],
-        stdout=subprocess.PIPE,
-        encoding='utf-8',
-    )
+        res = subprocess.run(
+            ['git', 'diff', '--unified=0', sha, '--', '*.py'],
+            stdout=subprocess.PIPE,
+            encoding='utf-8',
+        )
     res.check_returncode()
     return res.stdout
 

--- a/tools/lint_diff.py
+++ b/tools/lint_diff.py
@@ -58,17 +58,13 @@ def find_diff(sha, files=None):
         for file_or_dir in files:
             msg = f"{file_or_dir} doesn't exist. Please provide a valid path."
             assert os.path.exists(file_or_dir), msg
-        res = subprocess.run(
-            ['git', 'diff', '--unified=0', sha, '--', *files],
-            stdout=subprocess.PIPE,
-            encoding='utf-8',
-        )
     else:
-        res = subprocess.run(
-            ['git', 'diff', '--unified=0', sha, '--', '*.py'],
-            stdout=subprocess.PIPE,
-            encoding='utf-8',
-        )
+        files = ['*.py']
+    res = subprocess.run(
+        ['git', 'diff', '--unified=0', sha, '--'] + files,
+        stdout=subprocess.PIPE,
+        encoding='utf-8'
+    )
     res.check_returncode()
     return res.stdout
 

--- a/tools/lint_diff.py
+++ b/tools/lint_diff.py
@@ -56,15 +56,13 @@ def find_diff(sha, files=None):
     """Find the diff since the given sha."""
     if files:
         for file_or_dir in files:
-            assert os.path.exists(file_or_dir), (f"{file_or_dir} doesn't "
-                                                 "exist. Please provide a "
-                                                 "valid path.")
-        files = ' '.join(files)
+            msg = f"{file_or_dir} doesn't exist. Please provide a valid path."
+            assert os.path.exists(file_or_dir), msg
     else:
         files = '*.py'
 
     res = subprocess.run(
-        ['git', 'diff', '--unified=0', sha, '--', files],
+        ['git', 'diff', '--unified=0', sha, '--', *files],
         stdout=subprocess.PIPE,
         encoding='utf-8',
     )


### PR DESCRIPTION
#### Reference issue
See https://github.com/scipy/scipy/pull/14456#discussion_r680292455

#### What does this implement/fix?
This adds documentation to run flake8 based checks locally which mimics the CI. CI is a little more strict for PRs (uses this [`lint_diff.ini`](https://github.com/scipy/scipy/blob/master/tools/lint_diff.ini) flake8 config) than the master branch (uses this [`tox.ini`](https://github.com/scipy/scipy/blob/master/tox.ini) flake8 config).

**Note: The CI behaviour should remain unaffected by this PR, this is only for local use.**

#### Additional Information
Earlier to test locally in your feature branch: 
```bash
python tools/lint_diff.py
```

Now you can pass in the specific files or directories or both if needed: 
```bash
python tools/lint_diff.py --files scipy/odr/models.py scipy/ndimage
```

cc @mdhaber @peterbell10 @rgommers 