### PR TITLE
MAINT: 1.7.1 backports (round 2)

### DIFF
--- a/doc/release/1.7.1-notes.rst
+++ b/doc/release/1.7.1-notes.rst
@@ -17,9 +17,10 @@ Authors
 * Matti Picus
 * Tyler Reddy
 * Pamphile Roy
+* Sebastian Wallkötter
 * Arthur Volant
 
-A total of 8 people contributed to this release.
+A total of 9 people contributed to this release.
 People with a "+" by their names contributed a patch for the first time.
 This list of names is automatically generated, and may not be fully complete.
 
@@ -33,6 +34,7 @@ Issues closed for 1.7.1
 * `#14363 <https://github.com/scipy/scipy/issues/14363>`__: Huge stack allocation in _sobol.pyx may cause stack overvflow
 * `#14382 <https://github.com/scipy/scipy/issues/14382>`__: Memory leak in \`scipy.spatial.distance\` for \`cdist\`
 * `#14396 <https://github.com/scipy/scipy/issues/14396>`__: BUG: Sphinx 4.1 breaks the banner's logo
+* `#14444 <https://github.com/scipy/scipy/issues/14444>`__: DOC/FEAT Rotation.from_rotvec documents a degrees argument which...
 
 Pull requests for 1.7.1
 -----------------------
@@ -47,4 +49,6 @@ Pull requests for 1.7.1
 * `#14384 <https://github.com/scipy/scipy/pull/14384>`__: BUG: Reference count leak in distance_pybind
 * `#14397 <https://github.com/scipy/scipy/pull/14397>`__: DOC/CI: do not allow sphinx 4.1.
 * `#14417 <https://github.com/scipy/scipy/pull/14417>`__: DOC/CI: pin sphinx to !=4.1.0
+* `#14460 <https://github.com/scipy/scipy/pull/14460>`__: DOC: add required scipy version to kwarg
+* `#14466 <https://github.com/scipy/scipy/pull/14466>`__: MAINT: 1.7.1 backports (round 1)
 

--- a/scipy/spatial/transform/rotation.pyx
+++ b/scipy/spatial/transform/rotation.pyx
@@ -792,6 +792,8 @@ cdef class Rotation:
             If True, then the given magnitudes are assumed to be in degrees.
             Default is False.
 
+            .. versionadded:: 1.7.0
+
         Returns
         -------
         rotation : `Rotation` instance


### PR DESCRIPTION
Backport gh-14460 (the last remaning merged backport candidate PR). I may try to do a release somewhat soon-ish for the `spatial` memory leak.