### PR TITLE
REL: prep for SciPy 1.7.2

### DIFF
--- a/doc/release/1.7.2-notes.rst
+++ b/doc/release/1.7.2-notes.rst
@@ -1,0 +1,20 @@
+==========================
+SciPy 1.7.2 Release Notes
+==========================
+
+.. contents::
+
+SciPy 1.7.2 is a bug-fix release with no new features
+compared to 1.7.1.
+
+Authors
+=======
+
+
+Issues closed for 1.7.2
+-----------------------
+
+
+Pull requests for 1.7.2
+-----------------------
+

--- a/doc/source/release.1.7.2.rst
+++ b/doc/source/release.1.7.2.rst
@@ -1,0 +1,1 @@
+.. include:: ../release/1.7.2-notes.rst

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -8,6 +8,7 @@ see the `commit logs <https://github.com/scipy/scipy/commits/>`_.
 .. toctree::
    :maxdepth: 1
 
+   release.1.7.2
    release.1.7.1
    release.1.7.0
    release.1.6.3

--- a/pavement.py
+++ b/pavement.py
@@ -69,10 +69,10 @@ except AttributeError:
 #-----------------------------------
 
 # Source of the release notes
-RELEASE = 'doc/release/1.7.1-notes.rst'
+RELEASE = 'doc/release/1.7.2-notes.rst'
 
 # Start/end of the log (from git)
-LOG_START = 'v1.7.0'
+LOG_START = 'v1.7.1'
 LOG_END = 'maintenance/1.7.x'
 
 

--- a/setup.py
+++ b/setup.py
@@ -56,8 +56,8 @@ Operating System :: MacOS
 
 MAJOR = 1
 MINOR = 7
-MICRO = 1
-ISRELEASED = True
+MICRO = 2
+ISRELEASED = False
 IS_RELEASE_BRANCH = True
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 


### PR DESCRIPTION
Prepare the maintenance branch for SciPy `1.7.2`.

I bumped the milestone for Mac M1 support to `1.7.2` for example, so such a release seems likely to happen at some point even if more bugs don't show up.