### PR TITLE
BUG: diffev maxfun can be reached partway through population

### DIFF
--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -956,8 +956,10 @@ class DifferentialEvolutionSolver:
             right-padded with np.inf. Has shape ``(np.size(population, 0),)``
         """
         num_members = np.size(population, 0)
+        # these are the number of function evals left to stay under the
+        # maxfun budget
         nfevs = min(num_members,
-                    self.maxfun - num_members)
+                    self.maxfun - self._nfev)
 
         energies = np.full(num_members, np.inf)
 

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -346,23 +346,25 @@ class TestDifferentialEvolutionSolver:
         assert_equal(result.nfev, 41)
         assert_equal(result.success, False)
         assert_equal(result.message,
-                         'Maximum number of function evaluations has '
-                              'been exceeded.')
+                     'Maximum number of function evaluations has '
+                     'been exceeded.')
 
         # now repeat for updating='deferred version
+        # 47 function evaluations is not a multiple of the population size,
+        # so maxfun is reached partway through a population evaluation.
         solver = DifferentialEvolutionSolver(rosen,
                                              self.bounds,
                                              popsize=5,
                                              polish=False,
-                                             maxfun=40,
+                                             maxfun=47,
                                              updating='deferred')
         result = solver.solve()
 
-        assert_equal(result.nfev, 40)
+        assert_equal(result.nfev, 47)
         assert_equal(result.success, False)
         assert_equal(result.message,
-                         'Maximum number of function evaluations has '
-                              'been reached.')
+                     'Maximum number of function evaluations has '
+                     'been reached.')
 
     def test_quadratic(self):
         # test the quadratic function from object


### PR DESCRIPTION
If maxfun is reached partway through a population evaluation then `differential_evolution` should only use the remaining budget, and leave the remaining members unevaluated.