### PR TITLE
ENH: Support jac=True option for constraints in `scipy.optimize.minimize`

### DIFF
--- a/scipy/optimize/_constraints.py
+++ b/scipy/optimize/_constraints.py
@@ -42,14 +42,16 @@ class NonlinearConstraint:
         constraint. Note that you can mix constraints of different types:
         interval, one-sided or equality, by setting different components of
         `lb` and `ub` as  necessary.
-    jac : {callable,  '2-point', '3-point', 'cs'}, optional
+    jac : {callable,  '2-point', '3-point', 'cs', bool}, optional
         Method of computing the Jacobian matrix (an m-by-n matrix,
         where element (i, j) is the partial derivative of f[i] with
         respect to x[j]).  The keywords {'2-point', '3-point',
         'cs'} select a finite difference scheme for the numerical estimation.
         A callable must have the following signature:
         ``jac(x) -> {ndarray, sparse matrix}, shape (m, n)``.
-        Default is '2-point'.
+        Default is '2-point'. If `jac` is a Boolean and is True, `fun` is 
+        assumed to return a tuple ``(c, J)`` containing the evaluated constraint 
+        c and Jacobian J function and the gradient.
     hess : {callable, '2-point', '3-point', 'cs', HessianUpdateStrategy, None}, optional
         Method for computing the Hessian matrix. The keywords
         {'2-point', '3-point', 'cs'} select a finite difference scheme for
@@ -358,7 +360,7 @@ def new_constraint_to_old(con, x0):
                  "are ignored by this method.", OptimizeWarning)
 
         fun = con.fun
-        if callable(con.jac):
+        if callable(con.jac) or con.jac is True:
             jac = con.jac
         else:
             jac = None
@@ -469,7 +471,7 @@ def old_constraint_to_new(ic, con):
     if 'args' in con:
         args = con['args']
         fun = lambda x: con['fun'](x, *args)
-        if 'jac' in con:
+        if 'jac' in con and callable(con['jac']):
             jac = lambda x: con['jac'](x, *args)
     else:
         fun = con['fun']

--- a/scipy/optimize/_differentiable_functions.py
+++ b/scipy/optimize/_differentiable_functions.py
@@ -346,7 +346,7 @@ class VectorFunction:
                              "strategies.")
 
         if jac is True:
-            from scipy.optimize.optimize import MemoizeJac # no circular import
+            from scipy.optimize.optimize import MemoizeJac  # no circular import
             # constr fun returns (value, jac)
             fun = MemoizeJac(fun)
             jac = fun.derivative

--- a/scipy/optimize/_differentiable_functions.py
+++ b/scipy/optimize/_differentiable_functions.py
@@ -299,8 +299,8 @@ class VectorFunction:
     def __init__(self, fun, x0, jac, hess,
                  finite_diff_rel_step, finite_diff_jac_sparsity,
                  finite_diff_bounds, sparse_jacobian):
-        if not callable(jac) and jac not in FD_METHODS:
-            raise ValueError("`jac` must be either callable or one of {}."
+        if not callable(jac) and jac not in FD_METHODS and jac is not True:
+            raise ValueError("`jac` must be either callable, True or one of {}."
                              .format(FD_METHODS))
 
         if not (callable(hess) or hess in FD_METHODS
@@ -344,6 +344,12 @@ class VectorFunction:
                              "finite-differences, we require the Hessian to "
                              "be estimated using one of the quasi-Newton "
                              "strategies.")
+
+        if jac is True:
+            from scipy.optimize.optimize import MemoizeJac # no circular import
+            # constr fun returns (value, jac)
+            fun = MemoizeJac(fun)
+            jac = fun.derivative
 
         # Function evaluation
         def fun_wrapped(x):

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -169,8 +169,11 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
                 Constraint type: 'eq' for equality, 'ineq' for inequality.
             fun : callable
                 The function defining the constraint.
-            jac : callable, optional
-                The Jacobian of `fun` (only for SLSQP).
+            jac : {callable, bool} optional
+                The Jacobian of `fun` (only for SLSQP). If `jac` is a Boolean 
+                and is True, `fun` is assumed to return a tuple ``(c, J)`` 
+                containing the evaluated constraint c and Jacobian J
+                function and the gradient.
             args : sequence, optional
                 Extra arguments to be passed to the function and Jacobian.
 

--- a/scipy/optimize/tests/test_minimize_constrained.py
+++ b/scipy/optimize/tests/test_minimize_constrained.py
@@ -508,6 +508,20 @@ class TestTrustRegionConstr(TestCase):
                     if result.status in (0, 3):
                         raise RuntimeError("Invalid termination condition.")
 
+    def test_constraint_jac_true(self):
+        def fun(x):
+            return (x - 1) ** 2
+        def con_fun_and_jac(x):
+            # constraint: 0.25 * (x - 1) ** 2 >= -1.0
+            con_value = 0.25 * ( x - 1) ** 2 + 1.0
+            con_jac = 0.5 * (x - 1)
+            return con_value, con_jac
+        bounds = [(-2, 2)]
+        con = {'type': 'ineq', 'fun': con_fun_and_jac, 'jac': True}
+        res = minimize(fun, x0=[-1.5], bounds=bounds, constraints=(con,), 
+                       method='trust-constr') 
+        assert_array_almost_equal(res.x, 1, decimal=5)
+
     def test_default_jac_and_hess(self):
         def fun(x):
             return (x - 1) ** 2

--- a/scipy/optimize/tests/test_slsqp.py
+++ b/scipy/optimize/tests/test_slsqp.py
@@ -135,6 +135,14 @@ class TestSLSQP:
                        jac=True, method='SLSQP', options=self.opts)
         assert_(res['success'], res['message'])
         assert_allclose(res.x, [2, 1])
+    
+    def test_minimize_unbounded_con_combined(self):
+        # Minimize, method='SLSQP': unbounded, combined constraint and Jacobian
+        # constraint: 2*x*y + 2*x - x**2 - 2*y**2 >= 0
+        con = {'type': 'ineq', 'fun': self.fun_and_jac, 'jac': True}
+        res = minimize(self.fun_and_jac, [-1.0, 1.0], args=(-1.0, ),
+                       jac=True, constraints=(con,), method='SLSQP', 
+                       options=self.opts)
 
     def test_minimize_equality_approximated(self):
         # Minimize with method='SLSQP': equality constraint, approx. jacobian.


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### What does this implement/fix?

This PR adds support for a `jac=True` option for `scipy.optimize.minimize` constraints (NonlinearConstraint objects and dictionary constraints), see #13842.