### PR TITLE
ENH: Rotation.concatenate

### DIFF
--- a/scipy/spatial/transform/rotation.pyx
+++ b/scipy/spatial/transform/rotation.pyx
@@ -1586,6 +1586,10 @@ cdef class Rotation:
         -------
         concatenated : `Rotation` instance
             The concatenated rotations.
+
+        Notes
+        -----
+        .. versionadded:: 1.8.0
         """
         quats = []
         for rotation in rotations:

--- a/scipy/spatial/transform/rotation.pyx
+++ b/scipy/spatial/transform/rotation.pyx
@@ -1591,7 +1591,7 @@ cdef class Rotation:
         -----
         .. versionadded:: 1.8.0
         """
-        if not all([isinstance(x, Rotation) for x in rotations]):
+        if not all(isinstance(x, Rotation) for x in rotations):
             raise TypeError("input must contain Rotation objects only")
 
         quats = np.concatenate([np.atleast_2d(x.as_quat()) for x in rotations])

--- a/scipy/spatial/transform/rotation.pyx
+++ b/scipy/spatial/transform/rotation.pyx
@@ -333,6 +333,7 @@ cdef class Rotation:
     as_rotvec
     as_mrp
     as_euler
+    concatenate
     apply
     __mul__
     inv
@@ -1571,6 +1572,29 @@ cdef class Rotation:
             return np.asarray(mrps[0])
         else:
             return np.asarray(mrps)
+
+    @classmethod
+    def concatenate(cls, rotations):
+        """Concatenate a sequence of `Rotation` objects.
+
+        Parameters
+        ----------
+        rotations : sequence of `Rotation` objects
+            The rotations to concatenate.
+
+        Returns
+        -------
+        concatenated : `Rotation` instance
+            The concatenated rotations.
+        """
+        quats = []
+        for rotation in rotations:
+            if not isinstance(rotation, Rotation):
+                raise TypeError("input must contain Rotation objects only")
+            quats.extend(np.atleast_2d(rotation.as_quat()))
+
+        # normalization can change the data, so we leave it out here
+        return cls(quats, normalize=False)
 
     def apply(self, vectors, inverse=False):
         """Apply this rotation to a set of vectors.

--- a/scipy/spatial/transform/rotation.pyx
+++ b/scipy/spatial/transform/rotation.pyx
@@ -1591,13 +1591,10 @@ cdef class Rotation:
         -----
         .. versionadded:: 1.8.0
         """
-        quats = []
-        for rotation in rotations:
-            if not isinstance(rotation, Rotation):
-                raise TypeError("input must contain Rotation objects only")
-            quats.extend(np.atleast_2d(rotation.as_quat()))
+        if not all([isinstance(x, Rotation) for x in rotations]):
+            raise TypeError("input must contain Rotation objects only")
 
-        # normalization can change the data, so we leave it out here
+        quats = np.concatenate([np.atleast_2d(x.as_quat()) for x in rotations])
         return cls(quats, normalize=False)
 
     def apply(self, vectors, inverse=False):

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -1298,3 +1298,11 @@ def test_as_euler_contiguous():
     assert all(i >= 0 for i in e1.strides)
     assert all(i >= 0 for i in e2.strides)
 
+
+def test_concatenate():
+    rotation = Rotation.random(10, random_state=0)
+    sizes = [1, 2, 3, 1, 3]
+    starts = [0] + list(np.cumsum(sizes))
+    split = [rotation[i:i + n] for i, n in zip(starts, sizes)]
+    result = Rotation.concatenate(split)
+    assert_equal(rotation.as_quat(), result.as_quat())

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -1306,3 +1306,8 @@ def test_concatenate():
     split = [rotation[i:i + n] for i, n in zip(starts, sizes)]
     result = Rotation.concatenate(split)
     assert_equal(rotation.as_quat(), result.as_quat())
+
+
+def test_concatenate_wrong_type():
+    with pytest.raises(TypeError, match='Rotation objects only'):
+        Rotation.concatenate([Rotation.identity(), 1, None])


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #14340

#### What does this implement/fix?
<!--Please explain your changes.-->
This adds a `concatenate` method similar to `np.concatenate` but for `Rotation` objects.

@nmayorov what do you think?