### PR TITLE
BUG: bsplines: fixed issue #14525

### DIFF
--- a/scipy/signal/bsplines.py
+++ b/scipy/signal/bsplines.py
@@ -182,7 +182,7 @@ def bspline(x, n):
     True
 
     """
-    ax = -abs(asarray(x,dtype=float))
+    ax = -abs(asarray(x))
     # number of pieces on the left-side is (n+1)/2
     funclist, condfuncs = _bspline_piecefunctions(n)
     condlist = [func(ax) for func in condfuncs]

--- a/scipy/signal/bsplines.py
+++ b/scipy/signal/bsplines.py
@@ -182,7 +182,7 @@ def bspline(x, n):
     True
 
     """
-    ax = -abs(asarray(x))
+    ax = -abs(asarray(x,dtype=float))
     # number of pieces on the left-side is (n+1)/2
     funclist, condfuncs = _bspline_piecefunctions(n)
     condlist = [func(ax) for func in condfuncs]
@@ -280,7 +280,7 @@ def cubic(x):
     True
 
     """
-    ax = abs(asarray(x))
+    ax = abs(asarray(x,dtype=float))
     res = zeros_like(ax)
     cond1 = less(ax, 1)
     if cond1.any():
@@ -332,7 +332,7 @@ def quadratic(x):
     True
 
     """
-    ax = abs(asarray(x))
+    ax = abs(asarray(x,dtype=float))
     res = zeros_like(ax)
     cond1 = less(ax, 0.5)
     if cond1.any():

--- a/scipy/signal/bsplines.py
+++ b/scipy/signal/bsplines.py
@@ -182,7 +182,7 @@ def bspline(x, n):
     True
 
     """
-    ax = -abs(asarray(x,dtype=float))
+    ax = -abs(asarray(x))
     # number of pieces on the left-side is (n+1)/2
     funclist, condfuncs = _bspline_piecefunctions(n)
     condlist = [func(ax) for func in condfuncs]
@@ -280,7 +280,7 @@ def cubic(x):
     True
 
     """
-    ax = abs(asarray(x,dtype=float))
+    ax = abs(asarray(x))
     res = zeros_like(ax)
     cond1 = less(ax, 1)
     if cond1.any():
@@ -332,7 +332,7 @@ def quadratic(x):
     True
 
     """
-    ax = abs(asarray(x,dtype=float))
+    ax = abs(asarray(x))
     res = zeros_like(ax)
     cond1 = less(ax, 0.5)
     if cond1.any():

--- a/scipy/signal/bsplines.py
+++ b/scipy/signal/bsplines.py
@@ -186,7 +186,7 @@ def bspline(x, n):
     # number of pieces on the left-side is (n+1)/2
     funclist, condfuncs = _bspline_piecefunctions(n)
     condlist = [func(ax) for func in condfuncs]
-    return piecewise(ax, condlist, funclist)
+    return piecewise(ax.astype('float'), condlist, funclist)
 
 
 def gauss_spline(x, n):
@@ -281,7 +281,7 @@ def cubic(x):
 
     """
     ax = abs(asarray(x))
-    res = zeros_like(ax)
+    res = zeros_like(ax, dtype='float')
     cond1 = less(ax, 1)
     if cond1.any():
         ax1 = ax[cond1]
@@ -333,7 +333,7 @@ def quadratic(x):
 
     """
     ax = abs(asarray(x))
-    res = zeros_like(ax)
+    res = zeros_like(ax, dtype='float')
     cond1 = less(ax, 0.5)
     if cond1.any():
         ax1 = ax[cond1]

--- a/scipy/signal/tests/test_bsplines.py
+++ b/scipy/signal/tests/test_bsplines.py
@@ -10,12 +10,11 @@ from pytest import raises
 import scipy.signal.bsplines as bsp
 from scipy import signal
 
-
 class TestBSplines:
-    """Test behaviors of B-splines. Some of the values tested against were returned as of
-    SciPy 1.1.0 and are included for regression testing purposes. Others (at integer
-    points) are compared to theoretical expressions (cf. Unser, Aldroubi, Eden,
-    IEEE TSP 1993, Table 1)."""
+    """Test behaviors of B-splines. Some of the values tested against were 
+    returned as of SciPy 1.1.0 and are included for regression testing 
+    purposes. Others (at integer points) are compared to theoretical 
+    expressions (cf. Unser, Aldroubi, Eden, IEEE TSP 1993, Table 1)."""
 
     def test_spline_filter(self):
         np.random.seed(12457)
@@ -106,7 +105,7 @@ class TestBSplines:
 
     def test_bspline(self):
         np.random.seed(12458)
-        # Verify with theoretical results at integer points up to order 5 (see docstring)
+        # Verify with theoretical results at integer points up to order 5
         assert_allclose(bsp.bspline([-1, 0, 1], 0),
                         array([0, 1, 0]))
         assert_allclose(bsp.bspline([-1, 0, 1], 1),

--- a/scipy/signal/tests/test_bsplines.py
+++ b/scipy/signal/tests/test_bsplines.py
@@ -12,8 +12,10 @@ from scipy import signal
 
 
 class TestBSplines:
-    """Test behaviors of B-splines. The values tested against were returned as of
-    SciPy 1.1.0 and are included for regression testing purposes"""
+    """Test behaviors of B-splines. Some of the values tested against were returned as of
+    SciPy 1.1.0 and are included for regression testing purposes. Others (at integer
+    points) are compared to theoretical expressions (cf. Unser, Aldroubi, Eden,
+    IEEE TSP 1993, Table 1)."""
 
     def test_spline_filter(self):
         np.random.seed(12457)
@@ -104,6 +106,20 @@ class TestBSplines:
 
     def test_bspline(self):
         np.random.seed(12458)
+        # Verify with theoretical results at integer points up to order 5 (see docstring)
+        assert_allclose(bsp.bspline([-1, 0, 1], 0),
+                        array([0, 1, 0]))
+        assert_allclose(bsp.bspline([-1, 0, 1], 1),
+                        array([0, 1, 0]))
+        assert_allclose(bsp.bspline([-2, -1, 0, 1, 2], 2),
+                        array([0, 1, 6, 1, 0])/8.)
+        assert_allclose(bsp.bspline([-2, -1, 0, 1, 2], 3),
+                        array([0, 1, 4, 1, 0])/6.)
+        assert_allclose(bsp.bspline([-3, -2, -1, 0, 1, 2, 3], 4),
+                        array([0, 1, 76, 230, 76, 1, 0])/384.)
+        assert_allclose(bsp.bspline([-3, -2, -1, 0, 1, 2, 3], 5),
+                        array([0, 1, 26, 66, 26, 1, 0]) / 120.)
+        # Compare with SciPy 1.1.0
         assert_allclose(bsp.bspline(np.random.rand(1, 1), 2),
                         array([[0.73694695]]))
         data_array_complex = np.random.rand(4, 4) + np.random.rand(4, 4)*1j
@@ -129,7 +145,10 @@ class TestBSplines:
 
     def test_cubic(self):
         np.random.seed(12460)
-        assert_array_equal(bsp.cubic([0]), array([0]))
+        # Verify with theoretical results at integer points (see docstring)
+        assert_allclose(bsp.cubic([-2, -1, 0, 1, 2]),
+                        array([0, 1, 4, 1, 0])/6.)
+        # Compare with SciPy 1.1.0
         data_array_complex = np.random.rand(4, 4) + np.random.rand(4, 4)*1j
         data_array_complex = 1+1j-2*data_array_complex
         # scaling the magnitude by 10 makes the results close enough to zero,
@@ -144,7 +163,10 @@ class TestBSplines:
 
     def test_quadratic(self):
         np.random.seed(12461)
-        assert_array_equal(bsp.quadratic([0]), array([0]))
+        # Verify correct results at integer points
+        assert_allclose(bsp.quadratic([-2, -1, 0, 1, 2]),
+                        array([0, 1, 6, 1, 0])/8.)
+        # Compare with SciPy 1.1.0
         data_array_complex = np.random.rand(4, 4) + np.random.rand(4, 4)*1j
         # scaling the magnitude by 10 makes the results all zero,
         # so just make the elements have a mix of positive and negative


### PR DESCRIPTION
bspline, quadratic and cubic gave zero outputs for integer dtypes.

#### Reference issue
This fixes #14525 but does not find the logic flaw. 

#### What does this implement/fix?
Fixed through casting to float in the already present asarray.

#### Additional information
Could not set up the development environment properly on MacOS (problems with Blas and Lapack), so I could not really run tests. The change is minimal, however.