### PR TITLE
ENH: sparse.linalg: The solution is zero when R.H.S. is zero

### DIFF
--- a/scipy/sparse/linalg/isolve/_gcrotmk.py
+++ b/scipy/sparse/linalg/isolve/_gcrotmk.py
@@ -292,6 +292,9 @@ def gcrotmk(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
     axpy, dot, scal, nrm2 = get_blas_funcs(['axpy', 'dot', 'scal', 'nrm2'], (x, r))
 
     b_norm = nrm2(b)
+    if b_norm == 0:
+        x = b
+        return (postprocess(x), 0)
 
     if discard_C:
         CU[:] = [(None, u) for c, u in CU]

--- a/scipy/sparse/linalg/isolve/lgmres.py
+++ b/scipy/sparse/linalg/isolve/lgmres.py
@@ -143,7 +143,11 @@ def lgmres(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
     axpy, dot, scal = None, None, None
     nrm2 = get_blas_funcs('nrm2', [b])
 
+    m, n = A.shape
     b_norm = nrm2(b)
+    if b_norm == 0:
+        x = b
+        return (postprocess(x), 0)
     ptol_max_factor = 1.0
 
     for k_outer in range(maxiter):

--- a/scipy/sparse/linalg/isolve/lgmres.py
+++ b/scipy/sparse/linalg/isolve/lgmres.py
@@ -143,7 +143,6 @@ def lgmres(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
     axpy, dot, scal = None, None, None
     nrm2 = get_blas_funcs('nrm2', [b])
 
-    m, n = A.shape
     b_norm = nrm2(b)
     if b_norm == 0:
         x = b

--- a/scipy/sparse/linalg/isolve/lsmr.py
+++ b/scipy/sparse/linalg/isolve/lsmr.py
@@ -301,6 +301,10 @@ def lsmr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
             print(msg[0])
         return x, istop, itn, normr, normar, normA, condA, normx
 
+    if normb == 0:
+        x = b
+        return x, istop, itn, normr, normar, normA, condA, normx
+
     if show:
         print(' ')
         print(hdg1, hdg2)

--- a/scipy/sparse/linalg/isolve/lsqr.py
+++ b/scipy/sparse/linalg/isolve/lsqr.py
@@ -369,6 +369,9 @@ def lsqr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
     # These satisfy  beta*u = b - A*x,  alfa*v = A'*u.
     u = b
     bnorm = np.linalg.norm(b)
+    if bnorm == 0:
+        x = b
+        return (postprocess(x), 0)
     if x0 is None:
         x = np.zeros(n)
         beta = bnorm.copy()

--- a/scipy/sparse/linalg/isolve/minres.py
+++ b/scipy/sparse/linalg/isolve/minres.py
@@ -137,6 +137,11 @@ def minres(A, b, x0=None, shift=0.0, tol=1e-5, maxiter=None,
     elif beta1 == 0:
         return (postprocess(x), 0)
 
+    bnorm = norm(b)
+    if bnorm == 0:
+        x = b
+        return (postprocess(x), 0)
+
     beta1 = sqrt(beta1)
 
     if check:


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
Update some files in `sparse.linalg.isolve` so that the solution of the algebraic systems is zero when R.H.S equals zero.

#### Additional information
<!--Any additional information you think is important.-->