### PR TITLE
BUG: ensure wavelet has an odd number of pixels (fixes #13962)

### DIFF
--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -837,12 +837,12 @@ class TestFindPeaksCwt:
         # when window_size is too large
         test_data[250:320] -= 1
 
-        found_locs = find_peaks_cwt(test_data, widths, gap_thresh=2, min_snr=3,
+        found_locs = find_peaks_cwt(test_data, widths, gap_thresh=2, min_snr=20,
                                     min_length=None, window_size=None)
         with pytest.raises(AssertionError):
             assert found_locs.size == act_locs.size
 
-        found_locs = find_peaks_cwt(test_data, widths, gap_thresh=2, min_snr=3,
+        found_locs = find_peaks_cwt(test_data, widths, gap_thresh=2, min_snr=20,
                                     min_length=None, window_size=20)
         assert found_locs.size == act_locs.size
 

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -856,4 +856,4 @@ class TestFindPeaksCwt:
         widths = 1
         found_locs = find_peaks_cwt(test_data, widths)
 
-        np.testing.assert_equal(found_locs, 32)
+        np.testing.assert_equal(found_locs, np.argmax(test_data))

--- a/scipy/signal/wavelets.py
+++ b/scipy/signal/wavelets.py
@@ -467,8 +467,9 @@ def cwt(data, wavelet, widths, dtype=None, **kwargs):
 
     output = np.empty((len(widths), len(data)), dtype=dtype)
     for ind, width in enumerate(widths):
+        N = np.min([10 * width, len(data)])
         # Force N to be odd to avoid shifting the peak
-        N = int(np.min([10 * width, len(data)])) // 2 * 2 + 1
+        N += 1 - N % 2
         # the conditional block below and the window_size
         # kwarg pop above may be removed eventually; these
         # are shims for 32-bit arch + NumPy <= 1.14.5 to

--- a/scipy/signal/wavelets.py
+++ b/scipy/signal/wavelets.py
@@ -467,7 +467,8 @@ def cwt(data, wavelet, widths, dtype=None, **kwargs):
 
     output = np.empty((len(widths), len(data)), dtype=dtype)
     for ind, width in enumerate(widths):
-        N = np.min([10 * width, len(data)])
+        # Force N to be odd to avoid shifting the peak
+        N = int(np.min([10 * width, len(data)])) // 2 * 2 + 1
         # the conditional block below and the window_size
         # kwarg pop above may be removed eventually; these
         # are shims for 32-bit arch + NumPy <= 1.14.5 to


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #13962 

#### What does this implement/fix?
<!--Please explain your changes.-->
This forces the convolution kernel to have an odd number of pixels, thereby preventing a shift in the location of the peak when convolve() is called.

#### Additional information
<!--Any additional information you think is important.-->