### PR TITLE
CI: Revert "CI: make sure Azure job step fails when building a SciPy wheel fails"

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -338,9 +338,10 @@ stages:
       displayName: 'Copy in _distributor_init.py'
       condition: and(succeeded(), eq(variables['PYTHON_VERSION'], '3.8'))
     - powershell: |
+        # The below lines ensure exit status of every line in this step is checked
+        Set-StrictMode -Version Latest
+        $global:erroractionpreference = 1
 
-        $ErrorActionPreference = 'Stop'
-        $PSDefaultParameterValues['*: ErrorAction']='Stop'
 
         If ($(BITS) -eq 32) {
             # 32-bit build requires careful adjustments

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -338,6 +338,10 @@ stages:
       displayName: 'Copy in _distributor_init.py'
       condition: and(succeeded(), eq(variables['PYTHON_VERSION'], '3.8'))
     - powershell: |
+
+        $ErrorActionPreference = 'Stop'
+        $PSDefaultParameterValues['*: ErrorAction']='Stop'
+
         If ($(BITS) -eq 32) {
             # 32-bit build requires careful adjustments
             # until Microsoft has a switch we can use

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -338,11 +338,6 @@ stages:
       displayName: 'Copy in _distributor_init.py'
       condition: and(succeeded(), eq(variables['PYTHON_VERSION'], '3.8'))
     - powershell: |
-      # The below 3 lines ensure exit status of every line in this step is checked
-      Set-StrictMode -Version Latest
-      $ErrorActionPreference = "Stop"
-      $PSDefaultParameterValues['*:ErrorAction']='Stop'
-
         If ($(BITS) -eq 32) {
             # 32-bit build requires careful adjustments
             # until Microsoft has a switch we can use


### PR DESCRIPTION
Reverts scipy/scipy#14492 and closes #14529

Seems like this is breaking Azure CI.

From the error reporting, I guess this line is the culprit `$PSDefaultParameterValues['*:ErrorAction']='Stop'`. 

~I think this needs a space after the colon, I will try.~ 