### PR TITLE
ENH: Orthogonal Latin Hypercube Sampling to QMC

### DIFF
--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -1028,6 +1028,7 @@ class LatinHypercube(QMCEngine):
             "random-cd": self._random_cd,
         }
 
+        self.optimization_method: Optional[Callable]
         if optimization is not None:
             try:
                 optimization = optimization.lower()  # type: ignore[assignment]
@@ -1119,7 +1120,8 @@ class LatinHypercube(QMCEngine):
         # following is making a scrambled OA into an OA-LHS
         oa_lhs_sample = np.zeros(shape=(n_row, n_col))
         lhs_engine = LatinHypercube(d=1, centered=self.centered,
-                                    orthogonal=False, seed=self.rng)
+                                    orthogonal=False,
+                                    seed=self.rng)  # type: QMCEngine
         for j in range(n_col):
             for k in range(p):
                 idx = np.where(oa_sample[:, j] == k)[0]
@@ -1130,7 +1132,7 @@ class LatinHypercube(QMCEngine):
 
         oa_lhs_sample /= p
 
-        return oa_lhs_sample[:, :self.d]
+        return oa_lhs_sample[:, :self.d]  # type: ignore[misc]
 
     def _random_cd(self, n: IntNumber = 1) -> np.ndarray:
         """Optimal LHS on CD.

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -938,19 +938,22 @@ class LatinHypercube(QMCEngine):
 
     :math:`A` is called an orthogonal array of strength :math:`t` if in each
     n-row-by-t-column submatrix of :math:`A`: all :math:`p^t` possible
-    distinct rows occur the same number of times,
-    with :math:`p` a prime number. The elements of :math:`A` are in the set
-    :math:`\{0, 1, ..., p\}`, also called symbols.
-
-    To create an orthogonal array based LHS, the array is randomized by
-    randomly permuting the symbol values on each column independently. Then,
-    on each column and for a given symbol value, a plain LHS is added. The
-    resulting matrix is finally divided by :math:`p`.
+    distinct rows occur the same number of times. The elements of :math:`A`
+    are in the set :math:`\{0, 1, ..., p-1\}`, also called symbols.
+    The constraint that `p` must be a prime number is to allow modular
+    arithmetic.
 
     Strength 1 (plain LHS) brings an advantage over strength 0 (MC) and
     strength 2 is a useful increment over strength 1. Going to strength 3 is
     a smaller increment and scrambled QMC like Sobol', Halton are more
     performant [7]_.
+
+    To create a LHS of strength 2, the orthogonal array :math:`A` is
+    randomized by randomly permuting the symbol values on each column
+    independently. It's the set of symbols which is permuted, not the
+    independent elements. Hence all 0 can becomes 2, 1 become 2, etc.
+    Then, on each column and for a given symbol value, a plain LHS of size
+    ``(p, 1)`` is added. The resulting matrix is finally divided by :math:`p`.
 
     References
     ----------

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -1120,9 +1120,7 @@ class LatinHypercube(QMCEngine):
 
         oa_lhs_sample /= self._p
 
-        idx = self.rng.permutation(n_col)[:self.d]
-        oa_lhs_sample = oa_lhs_sample[:, idx]
-        return oa_lhs_sample
+        return oa_lhs_sample[:, :self.d]
 
     def _random_cd(self, n: IntNumber = 1) -> np.ndarray:
         """Optimal LHS on CD.

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -1093,7 +1093,7 @@ class LatinHypercube(QMCEngine):
         primes = primes_from_2_to(p + 2)
         if p not in primes or n != n_row:
             raise ValueError(
-                "n is not the square of a prime number. Closest"
+                "n is not the square of a prime number. Close"
                 f" values are {primes[-2:]**2}"
             )
         if self.d > p + 1:

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -891,10 +891,6 @@ class LatinHypercube(QMCEngine):
     :math:`[0,1)^{d}`. Each univariate marginal distribution is stratified,
     placing exactly one point in :math:`[j/n, (j+1)/n)` for
     :math:`j=0,1,...,n-1`. They are still applicable when :math:`n << d`.
-    LHS is extremely effective on integrands that are nearly additive [2]_.
-    LHS on :math:`n` points never has more variance than plain MC on
-    :math:`n-1` points [3]_. There is a central limit theorem for LHS [4]_,
-    but not necessarily for optimized LHS.
 
     Parameters
     ----------
@@ -915,7 +911,9 @@ class LatinHypercube(QMCEngine):
         .. versionadded:: 1.8.0
 
     orthogonal_array_p : int, optional
-        Orthogonal array based LHS. `orthogonal_array_p` must be a prime.
+        Orthogonal array based LHS of strength 2 [7]_, [8]_.
+        `orthogonal_array_p` must be a prime. It also constrains
+        ``d <= orthogonal_array_p + 1`` and ``n = orthogonal_array_p**2``.
 
         .. versionadded:: 1.8.0
 
@@ -925,6 +923,23 @@ class LatinHypercube(QMCEngine):
         seeded with `seed`.
         If `seed` is already a ``Generator`` instance then that instance is
         used.
+
+    Notes
+    -----
+
+    LHS is extremely effective on integrands that are nearly additive [2]_.
+    LHS on :math:`n` points never has more variance than plain MC on
+    :math:`n-1` points [3]_. There is a central limit theorem for LHS [4]_,
+    but not necessarily for optimized LHS.
+
+    LHS is an orthogonal array of strength 1.
+    :math:`A` is called an orthogonal array of strength :math:`t` if in each
+    n-row-by-t-column submatrix of :math:`A`, all :math:`q^t` possible
+    distinct rows occur the same number of times.
+
+    Strength 1 (LHS) brings an advantage over strength 0 (MC) and strength 2
+    is a useful increment over strength 1. Going to strength 3 is a smaller
+    increment and scrambled QMC like Sobol', Halton are more performant [7]_.
 
     References
     ----------
@@ -942,6 +957,10 @@ class LatinHypercube(QMCEngine):
     .. [6] Damblin et al., "Numerical studies of space filling designs:
        optimization of Latin Hypercube Samples and subprojection properties."
        Journal of Simulation, 2013.
+    .. [7] A. B. Owen , "Orthogonal arrays for computer experiments,
+       integration and visualization." Statistica Sinica, 1992.
+    .. [8] B. Tang, "Orthogonal Array-Based Latin Hypercubes."
+       Journal of the American Statistical Association, 1993.
 
     Examples
     --------

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -1090,7 +1090,7 @@ class LatinHypercube(QMCEngine):
         n_row = p**2
         n_col = p + 1
 
-        primes = primes_from_2_to(p + 2)
+        primes = primes_from_2_to(p + 1)
         if p not in primes or n != n_row:
             raise ValueError(
                 "n is not the square of a prime number. Close"
@@ -1132,6 +1132,7 @@ class LatinHypercube(QMCEngine):
 
         oa_lhs_sample /= p
 
+        self.num_generated += n
         return oa_lhs_sample[:, :self.d]  # type: ignore[misc]
 
     def _random_cd(self, n: IntNumber = 1) -> np.ndarray:
@@ -1150,6 +1151,7 @@ class LatinHypercube(QMCEngine):
             return np.empty((n, self.d))
 
         best_sample = self.lhs_method(n=n)
+        # self.num_generated += n  # done when calling self.lhs_method
         best_disc = discrepancy(best_sample)
 
         if n == 1:
@@ -1179,7 +1181,6 @@ class LatinHypercube(QMCEngine):
             else:
                 n_nochange += 1
 
-        self.num_generated += n
         return best_sample
 
 

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -928,19 +928,22 @@ class LatinHypercube(QMCEngine):
     Notes
     -----
 
+    When LHS is used for integrating a function :math:`f` over :math:`n`,
     LHS is extremely effective on integrands that are nearly additive [2]_.
-    LHS on :math:`n` points never has more variance than plain MC on
-    :math:`n-1` points [3]_. There is a central limit theorem for LHS [4]_,
-    but not necessarily for optimized LHS.
+    With a LHS of :math:`n` points, the variance of the integral is always
+    lower than plain MC on :math:`n-1` points [3]_. There is a central limit
+    theorem for LHS on the mean and variance of the integral [4]_, but not
+    necessarily for optimized LHS due to the randomization.
 
-    LHS is an orthogonal array of strength 1.
     :math:`A` is called an orthogonal array of strength :math:`t` if in each
-    n-row-by-t-column submatrix of :math:`A`, all :math:`q^t` possible
-    distinct rows occur the same number of times.
+    n-row-by-t-column submatrix of :math:`A`: all :math:`p^t` possible
+    distinct rows occur the same number of times,
+    with :math:`p` a prime number.
 
-    Strength 1 (LHS) brings an advantage over strength 0 (MC) and strength 2
-    is a useful increment over strength 1. Going to strength 3 is a smaller
-    increment and scrambled QMC like Sobol', Halton are more performant [7]_.
+    Strength 1 (plain LHS) brings an advantage over strength 0 (MC) and
+    strength 2 is a useful increment over strength 1. Going to strength 3 is
+    a smaller increment and scrambled QMC like Sobol', Halton are more
+    performant [7]_.
 
     References
     ----------

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -940,7 +940,7 @@ class LatinHypercube(QMCEngine):
     n-row-by-t-column submatrix of :math:`A`: all :math:`p^t` possible
     distinct rows occur the same number of times. The elements of :math:`A`
     are in the set :math:`\{0, 1, ..., p-1\}`, also called symbols.
-    The constraint that `p` must be a prime number is to allow modular
+    The constraint that :math:`p` must be a prime number is to allow modular
     arithmetic.
 
     Strength 1 (plain LHS) brings an advantage over strength 0 (MC) and
@@ -949,11 +949,12 @@ class LatinHypercube(QMCEngine):
     performant [7]_.
 
     To create a LHS of strength 2, the orthogonal array :math:`A` is
-    randomized by randomly permuting the symbol values on each column
-    independently. It's the set of symbols which is permuted, not the
-    independent elements. Hence all 0 can becomes 2, 1 become 2, etc.
-    Then, on each column and for a given symbol value, a plain LHS of size
-    ``(p, 1)`` is added. The resulting matrix is finally divided by :math:`p`.
+    randomized by applying a random, bijective map of the set of symbols onto
+    itself. For example, in column 0, all 0s might become 2; in column 1,
+    all 0s might become 1, etc.
+    Then, for each column :math:`i` and symbol :math:`j`, we add a plain,
+    one-dimensional LHS of size :math:`p` to the subarray where
+    :math:`A^i = j`. The resulting matrix is finally divided by :math:`p`.
 
     References
     ----------
@@ -1144,7 +1145,7 @@ class LatinHypercube(QMCEngine):
                                     seed=self.rng)  # type: QMCEngine
         for j in range(n_col):
             for k in range(p):
-                idx = np.where(oa_sample[:, j] == k)[0]
+                idx = oa_sample[:, j] == k
                 lhs = lhs_engine.random(p).flatten()
                 oa_lhs_sample[:, j][idx] = lhs + oa_sample[:, j][idx]
 

--- a/scipy/stats/tests/test_qmc.py
+++ b/scipy/stats/tests/test_qmc.py
@@ -1,5 +1,6 @@
 import os
 from collections import Counter
+from itertools import combinations
 
 import pytest
 import numpy as np
@@ -554,6 +555,18 @@ class TestLHS(QMCEngineTests):
         assert np.any(sample != expected)
         assert_allclose(sorted_sample, expected, atol=0.5 / n)
         assert np.any(sample - expected > 0.5 / n)
+
+    @pytest.mark.parametrize("centered", [False, True])
+    def test_orthogonal_array(self, centered):
+        p = 5
+
+        engine = self.engine(d=3, scramble=False, centered=centered,
+                             orthogonal_array_p=p)
+        oa_lhs_sample = engine.random(25)
+        for i, j in combinations(range(engine.d), 2):
+            samples_2d = oa_lhs_sample[:, [i, j]]
+            assert np.all(np.unique((samples_2d * p).astype(int),
+                                    return_counts=True, axis=0)[1] == 1)
 
     def test_discrepancy_hierarchy(self):
         seed = np.random.RandomState(123456)

--- a/scipy/stats/tests/test_qmc.py
+++ b/scipy/stats/tests/test_qmc.py
@@ -549,6 +549,7 @@ class TestLHS(QMCEngineTests):
                              optimization=optimization)
         sample = engine.random(n=n)
         assert sample.shape == (n, d)
+        assert engine.num_generated == n
 
         sorted_sample = np.sort(sample, axis=0)
 
@@ -560,7 +561,7 @@ class TestLHS(QMCEngineTests):
     def test_orthogonal_array(self, centered):
         p = 5
 
-        engine = self.engine(d=3, scramble=False, centered=centered,
+        engine = self.engine(d=6, scramble=False, centered=centered,
                              orthogonal=True)
         oa_lhs_sample = engine.random(p**2)
         for i, j in combinations(range(engine.d), 2):

--- a/scipy/stats/tests/test_qmc.py
+++ b/scipy/stats/tests/test_qmc.py
@@ -540,13 +540,15 @@ class TestLHS(QMCEngineTests):
     @pytest.mark.parametrize("optimization", [None, "random-CD"])
     def test_sample_stratified(self, optimization, centered,
                                orthogonal):
+        seed = np.random.RandomState(123456)
         d, n = 4, 25
         expected1d = (np.arange(n) + 0.5) / n
         expected = np.broadcast_to(expected1d, (d, n)).T
 
-        engine = self.engine(d=d, scramble=False, centered=centered,
-                             orthogonal=orthogonal,
-                             optimization=optimization)
+        engine = qmc.LatinHypercube(d=d, centered=centered,
+                                    orthogonal=orthogonal,
+                                    optimization=optimization,
+                                    seed=seed)
         sample = engine.random(n=n)
         assert sample.shape == (n, d)
         assert engine.num_generated == n
@@ -559,10 +561,11 @@ class TestLHS(QMCEngineTests):
 
     @pytest.mark.parametrize("centered", [False, True])
     def test_orthogonal_array(self, centered):
+        seed = np.random.RandomState(123456)
         p = 5
 
-        engine = self.engine(d=6, scramble=False, centered=centered,
-                             orthogonal=True)
+        engine = qmc.LatinHypercube(d=6, centered=centered,
+                                    orthogonal=True, seed=seed)
         oa_lhs_sample = engine.random(p**2)
         for i, j in combinations(range(engine.d), 2):
             samples_2d = oa_lhs_sample[:, [i, j]]

--- a/scipy/stats/tests/test_qmc.py
+++ b/scipy/stats/tests/test_qmc.py
@@ -540,7 +540,9 @@ class TestLHS(QMCEngineTests):
     @pytest.mark.parametrize("optimization", [None, "random-CD"])
     def test_sample_stratified(self, optimization, centered, strength):
         seed = np.random.RandomState(123456)
-        d, n = 6, 25
+        p = 5
+        n = p**2
+        d = 6
         expected1d = (np.arange(n) + 0.5) / n
         expected = np.broadcast_to(expected1d, (d, n)).T
 
@@ -559,7 +561,6 @@ class TestLHS(QMCEngineTests):
         assert np.any(sample - expected > 0.5 / n)
 
         if strength == 2 and optimization is None:
-            p = d - 1
             unique_elements = np.arange(p)
             desired = set(product(unique_elements, unique_elements))
 


### PR DESCRIPTION
Closes #13659.

This introduces Orthogonal Array (OA) based LHS to `scipy.stats.qmc.LatinHypercube`.

An OA is characterized by its strength. Here strength is 2 which means that for any 2 columns of the OA each combination of row values is present twice. This constrains the number of sample as for this property to be true, you must sample an exact value.

`orthogonal_array_p` is given as an input parameter. It must be a prime number. Then `n=orthogonal_array_p**2` and `d <= orthogonal_array_p+1`. I added some input validation and documentation.

![oa_lhs](https://user-images.githubusercontent.com/23188539/128363315-d27e12be-b551-43c4-96ec-00a366438cd6.png)
