### PR TITLE
ENH: __setitem__ method for Rotation class

### DIFF
--- a/scipy/spatial/transform/rotation.pyx
+++ b/scipy/spatial/transform/rotation.pyx
@@ -2155,6 +2155,11 @@ cdef class Rotation:
         Raises
         ------
         TypeError if the instance was created as a single rotation.
+
+        Notes
+        -----
+
+        .. versionadded:: 1.8.0
         """
         if self._single:
             raise TypeError("Single rotation is not subscriptable.")

--- a/scipy/spatial/transform/rotation.pyx
+++ b/scipy/spatial/transform/rotation.pyx
@@ -2164,6 +2164,9 @@ cdef class Rotation:
         if self._single:
             raise TypeError("Single rotation is not subscriptable.")
 
+        if not isinstance(value, Rotation):
+            raise TypeError("value must be a Rotation object")
+
         quat = np.asarray(self._quat)
         quat[indexer] = value.as_quat()
         self._quat = quat

--- a/scipy/spatial/transform/rotation.pyx
+++ b/scipy/spatial/transform/rotation.pyx
@@ -2140,6 +2140,29 @@ cdef class Rotation:
 
         return self.__class__(np.asarray(self._quat)[indexer], normalize=False)
 
+    def __setitem__(self, indexer, value):
+        """Set rotation(s) at given index(es) from object.
+
+        Parameters
+        ----------
+        indexer : index, slice, or index array
+            Specifies which rotation(s) to replace. A single indexer must be
+            specified, i.e. as if indexing a 1 dimensional array or list.
+
+        value : `Rotation` instance
+            The rotations to set.
+
+        Raises
+        ------
+        TypeError if the instance was created as a single rotation.
+        """
+        if self._single:
+            raise TypeError("Single rotation is not subscriptable.")
+
+        quat = np.asarray(self._quat)
+        quat[indexer] = value.as_quat()
+        self._quat = quat
+
     @classmethod
     def identity(cls, num=None):
         """Get identity rotation(s).

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -978,6 +978,17 @@ def test_getitem():
     assert_allclose(r[:-1].as_matrix(), np.expand_dims(mat[0], axis=0), atol=1e-15)
 
 
+def test_getitem_single():
+    with pytest.raises(TypeError, match='not subscriptable'):
+        Rotation.identity()[0]
+
+
+def test_setitem_single():
+    r = Rotation.identity()
+    with pytest.raises(TypeError, match='not subscriptable'):
+        r[0] = Rotation.identity()
+
+
 def test_setitem_slice():
     rng = np.random.RandomState(seed=0)
     r1 = Rotation.random(10, random_state=rng)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -994,6 +994,12 @@ def test_setitem_integer():
     assert_equal(r1[1].as_quat(), r2.as_quat())
 
 
+def test_setitem_wrong_type():
+    r = Rotation.random(10, random_state=0)
+    with pytest.raises(TypeError, match='Rotation object'):
+        r[0] = 1
+
+
 def test_n_rotations():
     mat = np.empty((2, 3, 3))
     mat[0] = np.array([

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -978,6 +978,22 @@ def test_getitem():
     assert_allclose(r[:-1].as_matrix(), np.expand_dims(mat[0], axis=0), atol=1e-15)
 
 
+def test_setitem_slice():
+    rng = np.random.RandomState(seed=0)
+    r1 = Rotation.random(10, random_state=rng)
+    r2 = Rotation.random(5, random_state=rng)
+    r1[1:6] = r2
+    assert_equal(r1[1:6].as_quat(), r2.as_quat())
+
+
+def test_setitem_integer():
+    rng = np.random.RandomState(seed=0)
+    r1 = Rotation.random(10, random_state=rng)
+    r2 = Rotation.random(random_state=rng)
+    r1[1] = r2
+    assert_equal(r1[1].as_quat(), r2.as_quat())
+
+
 def test_n_rotations():
     mat = np.empty((2, 3, 3))
     mat[0] = np.array([


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Partially solves  #14122

#### What does this implement/fix?
<!--Please explain your changes.-->
This implements a `__setitem__` method for the `Rotation` class.


@nmayorov 