### PR TITLE
Small test fixes for pypy + win + mmap

### DIFF
--- a/scipy/io/tests/test_netcdf.py
+++ b/scipy/io/tests/test_netcdf.py
@@ -133,7 +133,8 @@ def test_read_write_files():
 
     finally:
         if IS_PYPY:
-            # windows cannot remove a dead file held by a mmap but not collected in PyPy
+            # windows cannot remove a dead file held by a mmap
+            # that has not been collected in PyPy
             break_cycles()
             break_cycles()
         os.chdir(cwd)

--- a/scipy/io/tests/test_netcdf.py
+++ b/scipy/io/tests/test_netcdf.py
@@ -10,10 +10,10 @@ from contextlib import contextmanager
 
 import numpy as np
 from numpy.testing import (assert_, assert_allclose, assert_equal,
-                           suppress_warnings)
+                           break_cycles, suppress_warnings, IS_PYPY)
 from pytest import raises as assert_raises
 
-from scipy.io.netcdf import netcdf_file, IS_PYPY
+from scipy.io.netcdf import netcdf_file
 from scipy._lib._tmpdirs import in_tempdir
 
 TEST_DATA_PATH = pjoin(dirname(__file__), 'data')
@@ -131,12 +131,13 @@ def test_read_write_files():
             check_simple(f)
             assert_equal(f.variables['app_var'][:], 42)
 
-    except:  # noqa: E722
+    finally:
+        if IS_PYPY:
+            # windows cannot remove a dead file held by a mmap but not collected in PyPy
+            break_cycles()
+            break_cycles()
         os.chdir(cwd)
         shutil.rmtree(tmpdir)
-        raise
-    os.chdir(cwd)
-    shutil.rmtree(tmpdir)
 
 
 def test_read_write_sio():

--- a/scipy/io/tests/test_wavfile.py
+++ b/scipy/io/tests/test_wavfile.py
@@ -4,7 +4,7 @@ from io import BytesIO
 
 import numpy as np
 from numpy.testing import (assert_equal, assert_, assert_array_equal,
-                           suppress_warnings)
+                           break_cycles, suppress_warnings, IS_PYPY)
 import pytest
 from pytest import raises, warns
 
@@ -408,3 +408,9 @@ def test_write_roundtrip(realfile, mmap, rate, channels, dt_str, tmpdir):
     else:
         with pytest.raises(ValueError, match='read-only'):
             data2[0] = 0
+
+    if realfile and mmap and IS_PYPY and sys.platform == 'win32':
+        # windows cannot remove a dead file held by a mmap but not collected in PyPy;
+        # since the same filename gets reused in this test over and over, clean it up
+        break_cycles()
+        break_cycles()

--- a/scipy/io/tests/test_wavfile.py
+++ b/scipy/io/tests/test_wavfile.py
@@ -410,7 +410,7 @@ def test_write_roundtrip(realfile, mmap, rate, channels, dt_str, tmpdir):
             data2[0] = 0
 
     if realfile and mmap and IS_PYPY and sys.platform == 'win32':
-        # windows cannot remove a dead file held by a mmap but not collected in PyPy;
-        # since the same filename gets reused in this test over and over, clean it up
+        # windows cannot remove a dead file held by a mmap but not collected
+        # in PyPy; since the filename gets reused in this test, clean this up
         break_cycles()
         break_cycles()

--- a/scipy/io/tests/test_wavfile.py
+++ b/scipy/io/tests/test_wavfile.py
@@ -370,7 +370,18 @@ def test_read_inconsistent_header():
                 wavfile.read(fp, mmap=mmap)
 
 
-def _check_roundtrip(realfile, rate, dtype, channels, tmpdir):
+# signed 8-bit integer PCM is not allowed
+# unsigned > 8-bit integer PCM is not allowed
+# 8- or 16-bit float PCM is not expected
+# g and q are platform-dependent, so not included
+@pytest.mark.parametrize("dt_str", ["<i2", "<i4", "<i8", "<f4", "<f8",
+                                    ">i2", ">i4", ">i8", ">f4", ">f8", '|u1'])
+@pytest.mark.parametrize("channels", [1, 2, 5])
+@pytest.mark.parametrize("rate", [8000, 32000])
+@pytest.mark.parametrize("mmap", [False, True])
+@pytest.mark.parametrize("realfile", [False, True])
+def test_write_roundtrip(realfile, mmap, rate, channels, dt_str, tmpdir):
+    dtype = np.dtype(dt_str)
     if realfile:
         tmpfile = str(tmpdir.join('temp.wav'))
     else:
@@ -386,30 +397,14 @@ def _check_roundtrip(realfile, rate, dtype, channels, tmpdir):
 
     wavfile.write(tmpfile, rate, data)
 
-    for mmap in [False, True]:
-        rate2, data2 = wavfile.read(tmpfile, mmap=mmap)
+    rate2, data2 = wavfile.read(tmpfile, mmap=mmap)
 
-        assert_equal(rate, rate2)
-        assert_(data2.dtype.byteorder in ('<', '=', '|'), msg=data2.dtype)
-        assert_array_equal(data, data2)
-        # also test writing (gh-12176)
-        if realfile:
+    assert_equal(rate, rate2)
+    assert_(data2.dtype.byteorder in ('<', '=', '|'), msg=data2.dtype)
+    assert_array_equal(data, data2)
+    # also test writing (gh-12176)
+    if realfile:
+        data2[0] = 0
+    else:
+        with pytest.raises(ValueError, match='read-only'):
             data2[0] = 0
-        else:
-            with pytest.raises(ValueError, match='read-only'):
-                data2[0] = 0
-
-
-def test_write_roundtrip(tmpdir):
-    for realfile in (False, True):
-        # signed 8-bit integer PCM is not allowed
-        # unsigned > 8-bit integer PCM is not allowed
-        # 8- or 16-bit float PCM is not expected
-        # g and q are platform-dependent, so not included
-        for dt_str in {'|u1',
-                       '<i2', '<i4', '<i8', '<f4', '<f8',
-                       '>i2', '>i4', '>i8', '>f4', '>f8'}:
-            for rate in (8000, 32000):
-                for channels in (1, 2, 5):
-                    dt = np.dtype(dt_str)
-                    _check_roundtrip(realfile, rate, dt, channels, tmpdir)


### PR DESCRIPTION
Came up in the context of https://github.com/conda-forge/scipy-feedstock/pull/180: 

```
=========================== short test summary info ===========================
FAILED io/tests/test_netcdf.py::test_read_write_files - PermissionError: [Win...
FAILED io/tests/test_wavfile.py::test_write_roundtrip - OSError: [Errno 22] I...
= 2 failed, 32019 passed, 2572 skipped, 104 xfailed, 11 xpassed, 41 warnings in 2113.66s (0:35:13) =
```

@mattip [suggested](https://github.com/conda-forge/scipy-feedstock/pull/180#issuecomment-893607024) to follow the approach he chose in https://github.com/numpy/numpy/pull/16974, and now the test suite passes.

While I was at it, I decided to parametrize `test_wavfile.test_write_roundtrip`, because a) it's perfect for it b) I wanted it to be easier to reason about where to put the `break_cycles()`.