### PR TITLE
ENH: scipy.interpolate.BSpline from_cubic

### DIFF
--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -8,7 +8,8 @@ from scipy.linalg import (get_lapack_funcs, LinAlgError,
 from . import _bspl
 from . import _fitpack_impl
 from . import _fitpack as _dierckx
-from scipy._lib._util import prod
+from scipy._lib._util import prod, float_factorial
+from itertools import combinations
 
 __all__ = ["BSpline", "make_interp_spline", "make_lsq_spline"]
 
@@ -32,6 +33,44 @@ def _as_float_array(x, check_finite=False):
     if check_finite and not np.isfinite(x).all():
         raise ValueError("Array must not contain infs or nans.")
     return x
+
+def _find_left(t, x, k):
+    """
+    Returns the first index of ``t`` at which
+    ``t[i] <= x < t[i + 1]`` == True.
+    If such index can not be found returns the last index that
+    stands for the last element in initial vector of points
+    ``n + k - 2``.
+    """
+    nt = len(t)
+    for i in range(nt - 1):
+        if (t[i] <= x and t[i + 1] > x):
+            return i
+    return nt - k - 2
+
+def _dual_poly(j, k, t, y):
+    """
+    Dual polynomial of the B-spline B_{j,k,t} -
+    polynomial which is associated with B_{j,k,t}:
+    p_{j,k}(y) = (y - t_{j+1})(y - t_{j+2})...(y - t_{j+k})
+    """
+    if k == 0:
+        return 1
+    return np.prod([(y - t[j + i]) for i in range(1, k + 1)])
+
+def _diff_dual_poly(j, k, y, d, t):
+    """
+    d-th derivative of the dual polynomial p_{j,k}(y)
+    """
+    if d == 0:
+        return _dual_poly(j, k, t, y)
+    if d == k:
+        return float_factorial(k)
+    comb = list(combinations(range(j + 1, j + k + 1), d))
+    res = 0
+    for i in range(len(comb) * len(comb[0])):
+        res += np.prod([(y - t[j + p]) for p in range(1, k + 1) if (j + p) not in comb[i//d]])
+    return res
 
 
 class BSpline:
@@ -86,6 +125,7 @@ class BSpline:
     antiderivative
     integrate
     construct_fast
+    from_cubic
 
     Notes
     -----
@@ -560,6 +600,71 @@ class BSpline:
 
         integral *= sign
         return integral.reshape(ca.shape[1:])
+
+    @classmethod
+    def from_cubic(cls, cb, axis=0, bc_type='natural', extrapolate=None):
+        """
+        Construct a polynomial in the B-spline basis
+        from a piecewise polynomial in the power basis.
+
+        Parameters
+        ----------
+        cb : CubicSpline
+            A piecewise polynomial in the power basis, as created by CubicSpline
+        axis : int, optional
+            Axis along which y is assumed to be varying. Meaning that for x[i] the
+            corresponding values are np.take(y, i, axis=axis). Default is 0.
+        bc_type : string, optional
+            Boundary condition type as in CubicSpline
+        extrapolate: {bool, ‘periodic’, None}, optional
+            If bool, determines whether to extrapolate to out-of-bounds points based
+            on first and last intervals, or to return NaNs. If ‘periodic’, periodic
+            extrapolation is used. If None (default), extrapolate is set to ‘periodic’
+            for bc_type='periodic' and to True otherwise.
+
+        Returns
+        -------
+        b : BSpline object
+            A new instance representing the initial polynomial in the B-spline basis.
+
+        Notes
+        -----
+        The algorithm follows from differentiation the Marsden’s identity [1].
+        bc_type == 'not-a-knot' is not implemented yet.
+
+        References
+        ----------
+        .. [1] Tom Lyche and Knut Mørken, Spline Methods, 2005, Section 3.1.2
+
+        """
+        x = cb.x
+        coef = cb.c
+        k = cb.c.shape[0] - 1
+        n = x.shape[0]
+        t = np.zeros(n + 2 * k)
+
+        if bc_type == 'natural' or bc_type == 'clamped':
+            t[k: -k] = x
+            for i in range(1, k + 1):
+                t[k - i] = x[0]
+                t[n + k + i - 1] = x[-1]
+        elif bc_type == 'periodic':
+            t = _periodic_knots(x, k)
+
+        c = np.zeros(n + 2, )
+        for i in range(n - 2):
+            mu = _find_left(t, x[i], k)
+            for m in range(k + 1):
+                c[mu - k] += coef[m, i] * np.power(-1, k - m) * _diff_dual_poly(mu - k, k, x[i], m, t) * \
+                             float_factorial(k - m) / float_factorial(k)
+
+        mu = _find_left(t, x[-2], k)
+        for m in range(k + 1):
+            for j in range(mu - k, mu + 1):
+                c[j] += coef[m, n - 2] * np.power(-1, k - m) * _diff_dual_poly(j, k, x[n - 2], m, t) * \
+                        float_factorial(k - m) / float_factorial(k)
+
+        return cls.construct_fast(t, c, k, extrapolate, axis)
 
 
 #################################

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -430,6 +430,30 @@ class TestBSpline:
         spl1 = BSpline(t, c[1], k)
         assert_equal(spl(2.5), [spl0(2.5), spl1(2.5)])
 
+    @pytest.mark.parametrize('bc_type', ['natural', 'clamped', 'periodic'])
+    def test_from_cubic(self, bc_type):
+        np.random.seed(1234)
+        x = np.sort(np.random.random(20))
+        y = np.random.random(20)
+        cb = CubicSpline(x, y, bc_type=bc_type)
+        bspl = BSpline.from_cubic(cb, bc_type=bc_type)
+        bspl_new = make_interp_spline(x, y, bc_type=bc_type)
+        assert_allclose(bspl.c, bspl_new.c)
+
+    def test_from_cubic_exmp(self):
+        '''
+        For x = [0, 1, 2, 3, 4] and y = [1, 1, 1, 1, 1]
+        the coefficients of Cubic Spline:
+        [[0, 0, 0, 0, 0],
+         [0, 0, 0, 0, 0],
+         [0, 0, 0, 0, 0],
+         [1, 1, 1, 1, 1]]
+        '''
+        x = np.array([0, 1, 2, 3, 4])
+        y = np.array([1, 1, 1, 1, 1])
+        bspl = BSpline.from_cubic(CubicSpline(x, y))
+        assert_allclose(bspl.c, [1, 1, 1, 1, 1, 1, 1])
+
 
 def test_knots_multiplicity():
     # Take a spline w/ random coefficients, throw in knots of varying


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Solution for the task described in gh-6730

#### What does this implement/fix?
<!--Please explain your changes.-->
A new method ``from_cubic`` in ``BSpline`` class allows to convert a CubicSpline object to BSpline object.
 
#### Additional information
<!--Any additional information you think is important.-->
Knot vector for ``BSpline`` is constructed automatically depending on boundary condition of a ``CubicSpline`` object.