### PR TITLE
ENH: scipy.interpolate.BSpline from_power_basis

### DIFF
--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -706,6 +706,8 @@ class BSpline:
 
         Notes
         -----
+        .. versionadded:: 1.8.0
+
         Accepts only ``CubicSpline`` instances for now.
 
         The algorithm follows from differentiation
@@ -717,31 +719,33 @@ class BSpline:
             c_j = \sum_{m=0}^{k} \frac{(k-m)!}{k!}
                        c_{m,i} (-1)^{k-m} D^m p_{j,k}(x_i)
 
-        :math: `c_{m, i}` - a coefficient of CubicSpline,
-        :math: `D^m p_{j, k}(x_i)` - an m-th defivative of a dual polynomial
-        in ``x_i``.
+        :math:`c_{m, i}` - a coefficient of CubicSpline,
+        :math:`D^m p_{j, k}(x_i)` - an m-th defivative of a dual polynomial
+        in :math:`x_i`.
 
         ``k`` always equals 3 for now.
 
-        First ``n - 2`` coefficients are computed in ``x_i = x_j``, e.g.
+        First ``n - 2`` coefficients are computed in :math:`x_i = x_j`, e.g.
 
         .. math::
 
             c_1 = \sum_{m=0}^{k} \frac{(k-1)!}{k!} c_{m,1} D^m p_{j,3}(x_1)
 
-        Last ``nod + 2`` coefficients are computed ``in x[-2]``,
+        Last ``nod + 2`` coefficients are computed in ``x[-2]``,
         ``nod`` - number of derivatives at the ends.
 
-        For example, consider ``x = [0, 1, 2, 3, 4]``,
-        ``y = [1, 1, 1, 1, 1]`` and bc_type = ``natural``
+        For example, consider :math:`x = [0, 1, 2, 3, 4]`,
+        :math:`y = [1, 1, 1, 1, 1]` and bc_type = ``natural``
+
         The coefficients of CubicSpline in the power basis:
 
-        [[0, 0, 0, 0, 0],
-         [0, 0, 0, 0, 0],
-         [0, 0, 0, 0, 0],
-         [1, 1, 1, 1, 1]]
+        $[[0, 0, 0, 0, 0],\\$
+        $[0, 0, 0, 0, 0],\\$
+        $[0, 0, 0, 0, 0],\\$
+        $[1, 1, 1, 1, 1]]$
 
-        The knot vector ``t = [0, 0, 0, 0, 1, 2, 3, 4, 4, 4, 4]``
+        The knot vector: :math:`t = [0, 0, 0, 0, 1, 2, 3, 4, 4, 4, 4]`
+
         In this case
 
         .. math::
@@ -750,8 +754,6 @@ class BSpline:
 
         References
         ----------
-        .. versionadded:: 1.8.0
-
         .. [1] Tom Lyche and Knut Morken, Spline Methods, 2005, Section 3.1.2
 
         """

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -739,10 +739,8 @@ class BSpline:
 
         The coefficients of CubicSpline in the power basis:
 
-        $[[0, 0, 0, 0, 0],\\$
-        $[0, 0, 0, 0, 0],\\$
-        $[0, 0, 0, 0, 0],\\$
-        $[1, 1, 1, 1, 1]]$
+        :math:`[[0, 0, 0, 0, 0], [0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0], [1, 1, 1, 1, 1]]`
 
         The knot vector: :math:`t = [0, 0, 0, 0, 1, 2, 3, 4, 4, 4, 4]`
 

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -9,6 +9,8 @@ from . import _bspl
 from . import _fitpack_impl
 from . import _fitpack as _dierckx
 from scipy._lib._util import prod
+from scipy.special import poch
+from itertools import combinations
 
 __all__ = ["BSpline", "make_interp_spline", "make_lsq_spline"]
 
@@ -32,6 +34,32 @@ def _as_float_array(x, check_finite=False):
     if check_finite and not np.isfinite(x).all():
         raise ValueError("Array must not contain infs or nans.")
     return x
+
+
+def _dual_poly(j, k, t, y):
+    """
+    Dual polynomial of the B-spline B_{j,k,t} -
+    polynomial which is associated with B_{j,k,t}:
+    $p_{j,k}(y) = (y - t_{j+1})(y - t_{j+2})...(y - t_{j+k})$
+    """
+    if k == 0:
+        return 1
+    return np.prod([(y - t[j + i]) for i in range(1, k + 1)])
+
+
+def _diff_dual_poly(j, k, y, d, t):
+    """
+    d-th derivative of the dual polynomial $p_{j,k}(y)$
+    """
+    if d == 0:
+        return _dual_poly(j, k, t, y)
+    if d == k:
+        return poch(1, k)
+    comb = list(combinations(range(j + 1, j + k + 1), d))
+    res = 0
+    for i in range(len(comb) * len(comb[0])):
+        res += np.prod([(y - t[j + p]) for p in range(1, k + 1) if (j + p) not in comb[i//d]])
+    return res
 
 
 class BSpline:
@@ -87,6 +115,7 @@ class BSpline:
     integrate
     construct_fast
     design_matrix
+    from_power_basis
 
     Notes
     -----
@@ -648,6 +677,96 @@ class BSpline:
 
         integral *= sign
         return integral.reshape(ca.shape[1:])
+
+    @classmethod
+    def from_power_basis(cls, pp, bc_type='not-a-knot'):
+        r"""
+        Construct a polynomial in the B-spline basis
+        from a piecewise polynomial in the power basis.
+
+        For now, accepts ``CubicSpline`` instances only.
+
+        Parameters
+        ----------
+        pp : CubicSpline
+            A piecewise polynomial in the power basis, as created by CubicSpline
+        bc_type : string, optional
+            Boundary condition type as in CubicSpline:
+            one of the ``not-a-knot``, ``natural``, ``clamped``, or ``periodic``
+            ``bc_type`` is needed for composition a knot vector.
+
+        Returns
+        -------
+        b : BSpline object
+            A new instance representing the initial polynomial in the B-spline basis.
+
+        Notes
+        -----
+        The algorithm follows from differentiation the Marsden’s identity [1]:
+        each of coefficients of spline interpolation function in B-spline basis is
+        computed as follows:
+
+        .. math::
+
+            c_j = \sum_{m=0}^{k} \frac{(k-m)!}{k!} c_{m,i} (-1)^{k-m} D^m p_{j,k}(x_i)
+
+        :math: `c_{m, i}` - a coefficient of CubicSpline,
+        :math: `D^m p_{j, k}(x_i)` - an m-th defivative of a dual polynomial in ``x_i``.
+        ``k`` always equals 3 for now.
+
+        First ``n - 2`` coefficients are computed in ``x_i = x_j``, e.g.
+
+        .. math::
+
+            c_1 = \sum_{m=0}^{k} \frac{(k-1)!}{k!} c_{m,1} D^m p_{j,3}(x_1)
+
+        Last ``nod + 2`` coefficients are computed ``in x[-2]``,
+        ``nod`` - number of derivatives at the ends.
+
+        Examples
+        --------
+        Consider x = [0, 1, 2, 3, 4], y = [1, 1, 1, 1, 1] and bc_type = ``natural``
+        The coefficients of Cubic Spline in the power basis:
+
+        [[0, 0, 0, 0, 0],
+         [0, 0, 0, 0, 0],
+         [0, 0, 0, 0, 0],
+         [1, 1, 1, 1, 1]]
+
+        The knot vector t = [0, 0, 0, 0, 1, 2, 3, 4, 4, 4, 4]
+        In this case c[j] = 0!/k!*c_{3, i}*k! = c_{3, i} = 1 for j = 0, ..., 6
+
+        References
+        ----------
+        .. versionadded:: 1.8.0
+
+        .. [1] Tom Lyche and Knut Mørken, Spline Methods, 2005, Section 3.1.2
+
+        """
+        if not isinstance(pp, _cubic.CubicSpline):
+             raise NotImplementedError("Only CubicSpline objects are accepted for now.")
+        x = pp.x
+        coef = pp.c
+        k = pp.c.shape[0] - 1
+        n = x.shape[0]
+
+        if bc_type == 'not-a-knot':
+            t = np.r_[(x[0], )*(k + 1), x[2: -2], (x[-1], )*(k + 1)]
+        elif bc_type == 'natural' or bc_type == 'clamped':
+            t = np.r_[(x[0], )*k, x, (x[-1], )*k]
+        elif bc_type == 'periodic':
+            t = _periodic_knots(x, k)
+        else:
+            raise TypeError('Unknown boundary condition: %s' % bc_type)
+
+        nod = t.shape[0] - (n + k + 1)  # number of derivatives at the ends
+        c = np.zeros(n + nod, dtype=pp.c.dtype)
+        for m in range(k + 1):
+            for i in range(n - 2):
+                c[i] += poch(k + 1, -m) * coef[m, i] * np.power(-1, k - m) * _diff_dual_poly(i, k, x[i], m, t)
+            for j in range(n - 2, n + nod):
+                c[j] += poch(k + 1, -m) * coef[m, n - 2] * np.power(-1, k - m) * _diff_dual_poly(j, k, x[n - 2], m, t)
+        return cls.construct_fast(t, c, k, pp.extrapolate, pp.axis)
 
 
 #################################

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -709,7 +709,7 @@ class BSpline:
         Accepts only ``CubicSpline`` instances for now.
 
         The algorithm follows from differentiation
-        the Marsden’s identity [1]: each of coefficients of spline
+        the Marsden's identity [1]: each of coefficients of spline
         interpolation function in the B-spline basis is computed as follows:
 
         .. math::
@@ -752,7 +752,7 @@ class BSpline:
         ----------
         .. versionadded:: 1.8.0
 
-        .. [1] Tom Lyche and Knut Mørken, Spline Methods, 2005, Section 3.1.2
+        .. [1] Tom Lyche and Knut Morken, Spline Methods, 2005, Section 3.1.2
 
         """
         from ._cubic import CubicSpline

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -58,7 +58,7 @@ def _diff_dual_poly(j, k, y, d, t):
     comb = list(combinations(range(j + 1, j + k + 1), d))
     res = 0
     for i in range(len(comb) * len(comb[0])):
-        res += np.prod([(y - t[j + p]) for p in range(1, k + 1)\
+        res += np.prod([(y - t[j + p]) for p in range(1, k + 1)
                         if (j + p) not in comb[i//d]])
     return res
 
@@ -744,9 +744,9 @@ class BSpline:
         The knot vector ``t = [0, 0, 0, 0, 1, 2, 3, 4, 4, 4, 4]``
         In this case
 
-	    .. math::
+        .. math::
 
-	        c_j = \frac{0!}{k!} c_{3, i} k! = c_{3, i} = 1,~j = 0, ..., 6
+            c_j = \frac{0!}{k!} c_{3, i} k! = c_{3, i} = 1,~j = 0, ..., 6
 
         References
         ----------
@@ -757,8 +757,8 @@ class BSpline:
         """
         from ._cubic import CubicSpline
         if not isinstance(pp, CubicSpline):
-             raise NotImplementedError("Only CubicSpline objects are accepted"
-                                        "for now. Got %s instead." % type(pp))
+            raise NotImplementedError("Only CubicSpline objects are accepted"
+                                      "for now. Got %s instead." % type(pp))
         x = pp.x
         coef = pp.c
         k = pp.c.shape[0] - 1

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -516,7 +516,7 @@ class TestBSpline:
         with assert_raises(ValueError):
             BSpline.design_matrix(x, t, k)
 
-    @pytest.mark.parametrize('bc_type', ['natural', 'clamped',\
+    @pytest.mark.parametrize('bc_type', ['natural', 'clamped',
                                          'periodic', 'not-a-knot'])
     def test_from_power_basis(self, bc_type):
         np.random.seed(1234)
@@ -531,7 +531,7 @@ class TestBSpline:
         bspl_new = make_interp_spline(x, y, bc_type=bc_type)
         assert_allclose(bspl.c, bspl_new.c, atol=1e-15)
 
-    @pytest.mark.parametrize('bc_type', ['natural', 'clamped',\
+    @pytest.mark.parametrize('bc_type', ['natural', 'clamped',
                                          'periodic', 'not-a-knot'])
     def test_from_power_basis_complex(self, bc_type):
         np.random.seed(1234)
@@ -543,9 +543,9 @@ class TestBSpline:
         bspl = BSpline.from_power_basis(cb, bc_type=bc_type)
         bspl_new_real = make_interp_spline(x, y.real, bc_type=bc_type)
         bspl_new_imag = make_interp_spline(x, y.imag, bc_type=bc_type)
-        assert_equal(bspl.c.dtype, (bspl_new_real.c\
+        assert_equal(bspl.c.dtype, (bspl_new_real.c
                                     + 1j * bspl_new_imag.c).dtype)
-        assert_allclose(bspl.c, bspl_new_real.c\
+        assert_allclose(bspl.c, bspl_new_real.c
                         + 1j * bspl_new_imag.c, atol=1e-15)
 
     def test_from_power_basis_exmp(self):
@@ -563,7 +563,7 @@ class TestBSpline:
         '''
         x = np.array([0, 1, 2, 3, 4])
         y = np.array([1, 1, 1, 1, 1])
-        bspl = BSpline.from_power_basis(CubicSpline(x, y, bc_type='natural'),\
+        bspl = BSpline.from_power_basis(CubicSpline(x, y, bc_type='natural'),
                                         bc_type='natural')
         assert_allclose(bspl.c, [1, 1, 1, 1, 1, 1, 1], atol=1e-15)
 

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -551,12 +551,12 @@ class TestBSpline:
     def test_from_power_basis_exmp(self):
         '''
         For x = [0, 1, 2, 3, 4] and y = [1, 1, 1, 1, 1]
-        The coefficients of Cubic Spline in the power basis:
+        the coefficients of Cubic Spline in the power basis:
 
-        [[0, 0, 0, 0, 0],
-         [0, 0, 0, 0, 0],
-         [0, 0, 0, 0, 0],
-         [1, 1, 1, 1, 1]]
+        $[[0, 0, 0, 0, 0],\\$
+        $[0, 0, 0, 0, 0],\\$
+        $[0, 0, 0, 0, 0],\\$
+        $[1, 1, 1, 1, 1]]$
 
         It could be shown explicitly that coefficients of the interpolating
         function in B-spline basis are c = [1, 1, 1, 1, 1, 1, 1]

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -516,7 +516,8 @@ class TestBSpline:
         with assert_raises(ValueError):
             BSpline.design_matrix(x, t, k)
 
-    @pytest.mark.parametrize('bc_type', ['natural', 'clamped', 'periodic', 'not-a-knot'])
+    @pytest.mark.parametrize('bc_type', ['natural', 'clamped',\
+                                         'periodic', 'not-a-knot'])
     def test_from_power_basis(self, bc_type):
         np.random.seed(1234)
         x = np.sort(np.random.random(20))
@@ -530,7 +531,8 @@ class TestBSpline:
         bspl_new = make_interp_spline(x, y, bc_type=bc_type)
         assert_allclose(bspl.c, bspl_new.c, atol=1e-15)
 
-    @pytest.mark.parametrize('bc_type', ['natural', 'clamped', 'periodic', 'not-a-knot'])
+    @pytest.mark.parametrize('bc_type', ['natural', 'clamped',\
+                                         'periodic', 'not-a-knot'])
     def test_from_power_basis_complex(self, bc_type):
         np.random.seed(1234)
         x = np.sort(np.random.random(20))
@@ -541,8 +543,10 @@ class TestBSpline:
         bspl = BSpline.from_power_basis(cb, bc_type=bc_type)
         bspl_new_real = make_interp_spline(x, y.real, bc_type=bc_type)
         bspl_new_imag = make_interp_spline(x, y.imag, bc_type=bc_type)
-        assert_equal(bspl.c.dtype, (bspl_new_real.c + 1j * bspl_new_imag.c).dtype)
-        assert_allclose(bspl.c, bspl_new_real.c + 1j * bspl_new_imag.c, atol=1e-15)
+        assert_equal(bspl.c.dtype, (bspl_new_real.c\
+                                    + 1j * bspl_new_imag.c).dtype)
+        assert_allclose(bspl.c, bspl_new_real.c\
+                        + 1j * bspl_new_imag.c, atol=1e-15)
 
     def test_from_power_basis_exmp(self):
         '''
@@ -559,7 +563,8 @@ class TestBSpline:
         '''
         x = np.array([0, 1, 2, 3, 4])
         y = np.array([1, 1, 1, 1, 1])
-        bspl = BSpline.from_power_basis(CubicSpline(x, y, bc_type='natural'), bc_type='natural')
+        bspl = BSpline.from_power_basis(CubicSpline(x, y, bc_type='natural'),\
+                                        bc_type='natural')
         assert_allclose(bspl.c, [1, 1, 1, 1, 1, 1, 1], atol=1e-15)
 
 

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -516,6 +516,53 @@ class TestBSpline:
         with assert_raises(ValueError):
             BSpline.design_matrix(x, t, k)
 
+    @pytest.mark.parametrize('bc_type', ['natural', 'clamped', 'periodic', 'not-a-knot'])
+    def test_from_power_basis(self, bc_type):
+        np.random.seed(1234)
+        x = np.sort(np.random.random(20))
+        y = np.random.random(20)
+        if bc_type == 'periodic':
+            y[-1] = y[0]
+        cb = CubicSpline(x, y, bc_type=bc_type)
+        bspl = BSpline.from_power_basis(cb, bc_type=bc_type)
+        xx = np.linspace(0, 1, 20)
+        assert_allclose(cb(xx), bspl(xx), atol=1e-15)
+        bspl_new = make_interp_spline(x, y, bc_type=bc_type)
+        assert_allclose(bspl.c, bspl_new.c, atol=1e-15)
+
+    @pytest.mark.parametrize('bc_type', ['natural', 'clamped', 'periodic', 'not-a-knot'])
+    def test_from_power_basis_complex(self, bc_type):
+        np.random.seed(1234)
+        x = np.sort(np.random.random(20))
+        y = np.random.random(20) + np.random.random(20) * 1j
+        if bc_type == 'periodic':
+            y[-1] = y[0]
+        cb = CubicSpline(x, y, bc_type=bc_type)
+        bspl = BSpline.from_power_basis(cb, bc_type=bc_type)
+        bspl_new_real = make_interp_spline(x, y.real, bc_type=bc_type)
+        bspl_new_imag = make_interp_spline(x, y.imag, bc_type=bc_type)
+        assert_equal(bspl.c.dtype, (bspl_new_real.c + 1j * bspl_new_imag.c).dtype)
+        assert_allclose(bspl.c, bspl_new_real.c + 1j * bspl_new_imag.c, atol=1e-15)
+
+    def test_from_power_basis_exmp(self):
+        '''
+        For x = [0, 1, 2, 3, 4] and y = [1, 1, 1, 1, 1]
+        The coefficients of Cubic Spline in the power basis:
+
+        [[0, 0, 0, 0, 0],
+         [0, 0, 0, 0, 0],
+         [0, 0, 0, 0, 0],
+         [1, 1, 1, 1, 1]]
+
+        It could be shown explicitly that coefficients of the interpolating
+        function in B-spline basis are c = [1, 1, 1, 1, 1, 1, 1]
+        '''
+        x = np.array([0, 1, 2, 3, 4])
+        y = np.array([1, 1, 1, 1, 1])
+        bspl = BSpline.from_power_basis(CubicSpline(x, y, bc_type='natural'), bc_type='natural')
+        assert_allclose(bspl.c, [1, 1, 1, 1, 1, 1, 1], atol=1e-15)
+
+
 def test_knots_multiplicity():
     # Take a spline w/ random coefficients, throw in knots of varying
     # multiplicity.


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Solution for the task described in gh-6730

#### What does this implement/fix?
<!--Please explain your changes.-->
A new method from_cubic in BSpline class allows to convert a CubicSpline object to BSpline object.

#### Additional information
<!--Any additional information you think is important.-->
Knot vector for BSpline is constructed automatically depending on boundary condition of a CubicSpline object.