### PR TITLE
BUG: sparse: fix a DIA.tocsc bug

### DIFF
--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -384,8 +384,9 @@ class dia_matrix(_data_matrix):
 
         idx_dtype = get_index_dtype(maxval=max(self.shape))
         indptr = np.zeros(num_cols + 1, dtype=idx_dtype)
-        indptr[1:offset_len+1] = np.cumsum(mask.sum(axis=0))
-        indptr[offset_len+1:] = indptr[offset_len]
+        indptr[1:offset_len+1] = np.cumsum(mask.sum(axis=0)[:num_cols])
+        if offset_len < num_cols:
+            indptr[offset_len+1:] = indptr[offset_len]
         indices = row.T[mask.T].astype(idx_dtype, copy=False)
         data = self.data.T[mask.T]
         return csc_matrix((data, indices, indptr), shape=self.shape,

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -4348,6 +4348,13 @@ class TestDIA(sparse_test_class(getset=False, slicing=False, slicing_assign=Fals
     def test_getnnz_axis(self):
         pass
 
+    def test_convert_gh14555(self):
+        # regression test for gh-14555
+        m = dia_matrix(([[1, 1, 0]], [-1]), shape=(4, 2))
+        expected = m.toarray()
+        assert_array_equal(m.tocsc().toarray(), expected)
+        assert_array_equal(m.tocsr().toarray(), expected)
+
 
 TestDIA.init_class()
 


### PR DESCRIPTION
#### Reference issue
Fixes gh-14551.

#### What does this implement/fix?
In some cases where a DIA-format sparse matrix has more `data` columns than actual columns, it was possible to attempt an out-of-bounds assignment. This PR ensures we assign at most `num_cols` entries to the CSC `indptr` array.