### PR TITLE
WIP: TST: add tests for Pythran somersd

### DIFF
--- a/scipy/_lib/_testutils.py
+++ b/scipy/_lib/_testutils.py
@@ -6,6 +6,7 @@ Generic test utilities.
 import os
 import re
 import sys
+import numpy as np
 
 
 __all__ = ['PytestTester', 'check_free_memory']
@@ -69,6 +70,16 @@ class PytestTester:
             code = exc.code
 
         return (code == 0)
+
+
+class PythranFunc:
+    '''
+    Inherit from this class to generate a bunch of relevant test cases
+    '''
+    def __init__(self):
+        self.ALL_INTEGER = [np.int32, np.int64]
+        self.ALL_FLOAT = [np.float32, np.float64]
+        self.ALL_COMPLEX = [np.complex64, np.complex128]
 
 
 def _pytest_has_xdist():

--- a/scipy/_lib/_testutils.py
+++ b/scipy/_lib/_testutils.py
@@ -7,9 +7,10 @@ import os
 import re
 import sys
 import numpy as np
+from numpy.testing import assert_allclose
 
 
-__all__ = ['PytestTester', 'check_free_memory']
+__all__ = ['PytestTester', 'check_free_memory', '_TestPythranFunc']
 
 
 class FPUModeChangeWarning(RuntimeWarning):
@@ -72,14 +73,31 @@ class PytestTester:
         return (code == 0)
 
 
-class PythranFunc:
+class _TestPythranFunc:
     '''
     Inherit from this class to generate a bunch of relevant test cases
     '''
-    def __init__(self):
-        self.ALL_INTEGER = [np.int32, np.int64]
+    def setup_method(self):
+        self.ALL_INTEGER = [np.int8, np.int16, np.int32, np.int64]
         self.ALL_FLOAT = [np.float32, np.float64]
         self.ALL_COMPLEX = [np.complex64, np.complex128]
+        self.dtypes = []
+        self.arguments = []
+        self.index = []
+        self.expected = None
+    
+    def test_all_dtypes(self):
+        for dtype in self.dtypes:
+            tmp = self.arguments.copy()
+            for idx in self.index:
+                tmp[idx] = tmp[idx].astype(dtype)
+            self.pythranfunc(*tmp)
+    
+    def test_views(self):
+        tmp = self.arguments.copy()
+        for idx in self.index:
+            tmp[idx] = tmp[idx][::-1][::-1]
+        self.pythranfunc(*tmp)
 
 
 def _pytest_has_xdist():

--- a/scipy/stats/tests/test_hypotests.py
+++ b/scipy/stats/tests/test_hypotests.py
@@ -3,6 +3,7 @@ from __future__ import division, print_function, absolute_import
 from itertools import product
 
 import numpy as np
+from numpy.lib.index_tricks import nd_grid
 import pytest
 from numpy.testing import (assert_, assert_equal, assert_allclose,
                            assert_almost_equal)  # avoid new uses
@@ -16,6 +17,7 @@ from scipy.stats._hypotests import (epps_singleton_2samp, cramervonmises,
                                     boschloo_exact)
 from scipy.stats._mannwhitneyu import mannwhitneyu, _mwu_state
 from .common_tests import check_named_results
+from scipy._lib._testutils import _TestPythranFunc
 
 class TestEppsSingleton:
     def test_statistic_1(self):
@@ -613,40 +615,18 @@ class TestMannWhitneyU:
         assert_allclose(res, expected, rtol=1e-12)
 
 
-class TestSomersD:
-    def test_pythran_dtypes(self):
-        # test different dtypes
-        for dtype in [np.int32, np.int64, np.float32, np.float64]:
-            x = np.array([5, 2, 1, 3, 6, 4, 7, 8], dtype=dtype)
-            y = np.array([5, 2, 6, 3, 1, 8, 7, 4], dtype=dtype)
-            expected = (0.000000000000000, 1.000000000000000)
-            res = stats.somersd(x, y)
-            assert_allclose(res.statistic, expected[0], atol=1e-15)
-            assert_allclose(res.pvalue, expected[1], atol=1e-15)
+class TestSomersD(_TestPythranFunc):
+    def setup_method(self):
+        # self.dtypes = self.ALL_INTEGER + self.ALL_FLOAT
+        self.dtypes = [np.int8, np.int16, np.int32, np.int64, np.float32, np.float64]
+        self.arguments = [np.arange(10), np.arange(10)]
+        self.index = [0, 1]
+        self.expected = stats.somersd(*self.arguments)
 
-    def test_pythran_views(self):
-        table = np.array([[1, 2, 27, 25, 14, 7, 0], [1, 2, 7, 14, 18, 35, 12],
-                          [1, 2, 1, 3, 2, 7, 17]])[:, 2:]
-        expected = (0.6032766111513396, 1.0007091191074533e-27)
-        res = stats.somersd(table)
-        assert_allclose(res.statistic, expected[0], atol=1e-15)
-        assert_allclose(res.pvalue, expected[1], atol=1e-15)
-
-    def test_pythran_strided(self):
-        x = np.arange(10)[::2]
-        y = np.array([9, 7, 8, 6, 5, 3, 4, 2, 1, 0])[::2]
-        expected = (-1.000000000000000, 0)
-        res = stats.somersd(x, y)
-        assert_allclose(res.statistic, expected[0], atol=1e-15)
-        assert_allclose(res.pvalue, expected[1], atol=1e-15)
-
-    def test_pythran_keyword(self):
-        x = [5, 2, 1, 3, 6, 4, 7]
-        y = [5, 2, 6, 3, 1, 7, 4]
-        expected = (-0.142857142857140, 0.630326953157670)
-        res = stats.somersd(x, y=y)
-        assert_allclose(res.statistic, expected[0], atol=1e-15)
-        assert_allclose(res.pvalue, expected[1], atol=1e-15)
+    def pythranfunc(self, *args):
+        res = stats.somersd(*args)
+        assert_allclose(res.statistic, self.expected.statistic, atol=1e-15)
+        assert_allclose(res.pvalue, self.expected.pvalue, atol=1e-15)
 
     def test_like_kendalltau(self):
         # All tests correspond with one in test_stats.py `test_kendalltau`

--- a/scipy/stats/tests/test_hypotests.py
+++ b/scipy/stats/tests/test_hypotests.py
@@ -3,7 +3,6 @@ from __future__ import division, print_function, absolute_import
 from itertools import product
 
 import numpy as np
-from numpy.lib.index_tricks import nd_grid
 import pytest
 from numpy.testing import (assert_, assert_equal, assert_allclose,
                            assert_almost_equal)  # avoid new uses
@@ -617,14 +616,14 @@ class TestMannWhitneyU:
 
 class TestSomersD(_TestPythranFunc):
     def setup_method(self):
-        # self.dtypes = self.ALL_INTEGER + self.ALL_FLOAT
-        self.dtypes = [np.int8, np.int16, np.int32, np.int64, np.float32, np.float64]
+        self.dtypes = self.ALL_INTEGER + self.ALL_FLOAT
         self.arguments = [np.arange(10), np.arange(10)]
         self.index = [0, 1]
         self.expected = stats.somersd(*self.arguments)
+        self.func = stats.somersd
 
-    def pythranfunc(self, *args):
-        res = stats.somersd(*args)
+    def pythranfunc(self, *args, **kwargs):
+        res = stats.somersd(*args, **kwargs)
         assert_allclose(res.statistic, self.expected.statistic, atol=1e-15)
         assert_allclose(res.pvalue, self.expected.pvalue, atol=1e-15)
 

--- a/scipy/stats/tests/test_hypotests.py
+++ b/scipy/stats/tests/test_hypotests.py
@@ -1,7 +1,6 @@
 from __future__ import division, print_function, absolute_import
 
 from itertools import product
-from scipy.stats.contingency import expected_freq
 
 import numpy as np
 import pytest
@@ -17,7 +16,6 @@ from scipy.stats._hypotests import (epps_singleton_2samp, cramervonmises,
                                     boschloo_exact)
 from scipy.stats._mannwhitneyu import mannwhitneyu, _mwu_state
 from .common_tests import check_named_results
-from scipy._lib._testutils import PythranFunc
 
 class TestEppsSingleton:
     def test_statistic_1(self):
@@ -615,23 +613,20 @@ class TestMannWhitneyU:
         assert_allclose(res, expected, rtol=1e-12)
 
 
-class TestSomersD(PythranFunc):
-    def __init__(self):
-        super().__init__()
-        self.dtypes = self.ALL_INTEGER+self.ALL_FLOAT
-
+class TestSomersD:
     def test_pythran_dtypes(self):
         # test different dtypes
-        for dtype in self.dtypes:
+        for dtype in [np.int32, np.int64, np.float32, np.float64]:
             x = np.array([5, 2, 1, 3, 6, 4, 7, 8], dtype=dtype)
             y = np.array([5, 2, 6, 3, 1, 8, 7, 4], dtype=dtype)
             expected = (0.000000000000000, 1.000000000000000)
             res = stats.somersd(x, y)
             assert_allclose(res.statistic, expected[0], atol=1e-15)
             assert_allclose(res.pvalue, expected[1], atol=1e-15)
-        
+
     def test_pythran_views(self):
-        table = np.array([[1, 2, 27, 25, 14, 7, 0], [1, 2, 7, 14, 18, 35, 12], [1, 2, 1, 3, 2, 7, 17]])[:, 2:]
+        table = np.array([[1, 2, 27, 25, 14, 7, 0], [1, 2, 7, 14, 18, 35, 12],
+                          [1, 2, 1, 3, 2, 7, 17]])[:, 2:]
         expected = (0.6032766111513396, 1.0007091191074533e-27)
         res = stats.somersd(table)
         assert_allclose(res.statistic, expected[0], atol=1e-15)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
https://github.com/scipy/scipy/issues/14544

#### What does this implement/fix?
Take `somersd` as an example, firstly implement all the tests by hand. 

Hi @rgommers, thank you so much for your detailed suggestions! But I'm a little confused about :
>A size-1 array, and (if applicable for the function) a size-0 array
see BUG: RBFInterpolator fails when calling it with a slice of a (1, n) array #14420 for a relevant bug report for non-contiguous inputs and views.

Do you mean size-1 array is like (1, n), and size-0 array is like np.empty(shape=(0, 0)) ? Why would that be a potential problem to Pythran? I think https://github.com/scipy/scipy/issues/14420 is more a problem of views, not a problem of size-1 array..?

For your sketch, 
```
# in class TestMyFunc(PythranFunc)
def pythranfunc(self, x, ):
        "This function is called by the test machinery with various inputs for `x`"
        result = module.funcname(x, ...)  # this is the function call to test, e.g. `stats.somersd`
        expected = # exact result
        assert_allclose(result, expected, rtol=self.rtol, atol=self.atol)
```
How can `pythranfunc` be called by the test machinery with various inputs for `x`? I would expect there is a `_gen_types()` in `PythranFunc`, and in `pythranfunc`, I will call `_gen_types()` to generate different types of `x` and test them?

Also, how many types do you think we should cover...? Currently, there are:
```
        self.ALL_INTEGER = [np.int32, np.int64]
        self.ALL_FLOAT = [np.float32, np.float64]
        self.ALL_COMPLEX = [np.complex64, np.complex128]
```

cc @serge-sans-paille 