### PR TITLE
Set min length of the knot array for BSpline.design_matrix

### DIFF
--- a/scipy/interpolate/_bspl.pyx
+++ b/scipy/interpolate/_bspl.pyx
@@ -447,14 +447,13 @@ def _make_design_matrix(const double[::1] x,
         cnp.ndarray[long, ndim=1] col_ind = np.zeros(n * (k + 1), dtype=int)
     for i in range(n):
         ind = find_interval(t, k, x[i], k - 1, 0)
-        if ind <  k:
-            raise ValueError(f'Out of bounds w/ x = {x}.')
+        
         _deBoor_D(&t[0], x[i], k, ind, 0, &wrk[0])
 
         data[(k + 1) * i : (k + 1) * (i + 1)] = wrk[:k + 1]
         row_ind[(k + 1) * i : (k + 1) * (i + 1)] = i
         col_ind[(k + 1) * i : (k + 1) * (i + 1)] = np.arange(ind - k
-                                                            ,min(ind + 1, nt - k - 1)
+                                                            ,ind + 1
                                                             ,dtype=int)
 
-    return csr_matrix((data.base, (row_ind, col_ind)), (n, nt - k - 1))       
+    return csr_matrix((np.asarray(data), (row_ind, col_ind)), (n, nt - k - 1))       

--- a/scipy/interpolate/_bspl.pyx
+++ b/scipy/interpolate/_bspl.pyx
@@ -457,4 +457,4 @@ def _make_design_matrix(const double[::1] x,
                                                             ,min(ind + 1, nt - k - 1)
                                                             ,dtype=int)
 
-    return csr_matrix((data, (row_ind, col_ind)), (n, nt - k - 1))       
+    return csr_matrix((data.base, (row_ind, col_ind)), (n, nt - k - 1))       

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -363,8 +363,8 @@ class BSpline:
         at the certain point (first row - x[0], ..., last row - x[-1]).
 
         `nt` is a lenght of the vector of knots: as far as there are
-        `nt - k - 1` basis elements, `nt` should be not less than `k + 2`
-        to have at least one basis element.
+        `nt - k - 1` basis elements, `nt` should be not less than `2 * k + 2`
+        to have at least `k + 1` basis element.
 
         Out of bounds `x` raises a ValueError.
         """
@@ -375,12 +375,13 @@ class BSpline:
             raise ValueError(f"Expect t to be a 1-D sorted array_like, but "
                              f"got t={t}.")
         # There are `nt - k - 1` basis elemets in a BSpline built on the
-        # vector of knots with length `nt`, so to have at least one basis
-        # element we need to have at least `k + 2` elements in the vector
+        # vector of knots with length `nt`, so to have at least `k + 1` basis
+        # element we need to have at least `2 * k + 2` elements in the vector
         # of knots.
-        if len(t) <= k + 1:
+        if len(t) < 2 * k + 2:
             raise ValueError(f"Length t is not enough for k={k}.")
-        if (min(x) < t[k]) or (max(x) > t[-k]):
+        # Checks from `find_interval` function
+        if (min(x) < t[k]) or (max(x) > t[t.shape[0] - k - 1]):
             raise ValueError(f'Out of bounds w/ x = {x}.')
 
         return _bspl._make_design_matrix(x, t, k)

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -492,9 +492,10 @@ class TestBSpline:
 
     def test_design_matrix_t_shapes(self):
         # test for minimal possible `t` shape
-        t = [0., 1., 1., 1., 2.]
-        des_matr = BSpline.design_matrix(1., t, 3).toarray()
-        assert_allclose(des_matr, [[1.]], atol=1e-14)
+        t = [1., 1., 1., 2., 3., 4., 4., 4.]
+        des_matr = BSpline.design_matrix(2., t, 3).toarray()
+        assert_allclose(des_matr, [[0.25, 0.58333333, 0.16666667, 0.]],
+                                                            atol=1e-9)
 
     def test_design_matrix_asserts(self):
         np.random.seed(1234)

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -490,7 +490,6 @@ class TestBSpline:
                                                  k).toarray()
             assert_allclose(des_matr_csr @ bspl.c, yc, atol=1e-14)
 
-    @pytest.mark.xfail_on_32bit("Win32bit des_matr is nan")
     def test_design_matrix_t_shapes(self):
         # test for minimal possible `t` shape
         t = [0., 1., 1., 1., 2.]

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -494,8 +494,9 @@ class TestBSpline:
         # test for minimal possible `t` shape
         t = [1., 1., 1., 2., 3., 4., 4., 4.]
         des_matr = BSpline.design_matrix(2., t, 3).toarray()
-        assert_allclose(des_matr, [[0.25, 0.58333333, 0.16666667, 0.]],
-                                                            atol=1e-9)
+        assert_allclose(des_matr,
+                        [[0.25, 0.58333333, 0.16666667, 0.]],
+                        atol=1e-14)
 
     def test_design_matrix_asserts(self):
         np.random.seed(1234)

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -473,7 +473,7 @@ class TestBSpline:
         for k in range(2, 7):
             run_design_matrix_tests(n, k, "periodic")
 
-    def test_design_matrix_x_t_shapes(self):
+    def test_design_matrix_x_shapes(self):
         # test for different `x` shapes
         np.random.seed(1234)
         n = 10
@@ -490,6 +490,8 @@ class TestBSpline:
                                                  k).toarray()
             assert_allclose(des_matr_csr @ bspl.c, yc, atol=1e-14)
 
+    @pytest.mark.xfail_on_32bit("Win32bit des_matr is nan")
+    def test_design_matrix_t_shapes(self):
         # test for minimal possible `t` shape
         t = [0., 1., 1., 1., 2.]
         des_matr = BSpline.design_matrix(1., t, 3).toarray()


### PR DESCRIPTION
Quick fix of test for different `t` shapes in `design_matrix`.