### PR TITLE
MAINT: Refactor `linalg.tests.test_interpolative::TestInterpolativeDecomposition::test_id`

### DIFF
--- a/scipy/linalg/tests/test_interpolative.py
+++ b/scipy/linalg/tests/test_interpolative.py
@@ -31,205 +31,139 @@ import numpy as np
 from scipy.linalg import hilbert, svdvals, norm
 from scipy.sparse.linalg import aslinearoperator
 from scipy.linalg.interpolative import interp_decomp
-import time
 import itertools
 
 from numpy.testing import (assert_, assert_allclose, assert_equal,
                            assert_array_equal)
+import pytest
 from pytest import raises as assert_raises
 
 
-def _debug_print(s):
-    if 0:
-        print(s)
+@pytest.fixture()
+def eps():
+    yield 1e-12
+
+
+@pytest.fixture(params=[np.float64, np.complex128])
+def A(request):
+    # construct Hilbert matrix
+    # set parameters
+    n = 300
+    yield hilbert(n).astype(request.param)
+
+
+@pytest.fixture()
+def L(A):
+    yield aslinearoperator(A)
+
+
+@pytest.fixture()
+def rank(A, eps):
+    S = np.linalg.svd(A, compute_uv=False)
+    try:
+        rank = np.nonzero(S < eps)[0][0]
+    except IndexError:
+        rank = A.shape[0]
+    return rank
 
 
 class TestInterpolativeDecomposition:
-    def test_id(self):
-        for dtype in [np.float64, np.complex128]:
-            self.check_id(dtype)
 
-    def check_id(self, dtype):
+    @pytest.mark.parametrize(
+        "rand,lin_op",
+        [(False, False), (True, False), (True, True)])
+    def test_real_id_fixed_precision(self, A, L, eps, rand, lin_op):
         # Test ID routines on a Hilbert matrix.
+        A_or_L = A if not lin_op else L
 
-        # set parameters
-        n = 300
-        eps = 1e-12
-
-        # construct Hilbert matrix
-        A = hilbert(n).astype(dtype)
-        if np.issubdtype(dtype, np.complexfloating):
-            A = A * (1 + 1j)
-        L = aslinearoperator(A)
-
-        # find rank
-        S = np.linalg.svd(A, compute_uv=False)
-        try:
-            rank = np.nonzero(S < eps)[0][0]
-        except IndexError:
-            rank = n
-
-        # print input summary
-        _debug_print("Hilbert matrix dimension:        %8i" % n)
-        _debug_print("Working precision:               %8.2e" % eps)
-        _debug_print("Rank to working precision:       %8i" % rank)
-
-        # set print format
-        fmt = "%8.2e (s) / %5s"
-
-        # test real ID routines
-        _debug_print("-----------------------------------------")
-        _debug_print("Real ID routines")
-        _debug_print("-----------------------------------------")
-
-        # fixed precision
-        _debug_print("Calling iddp_id / idzp_id  ...",)
-        t0 = time.time()
-        k, idx, proj = pymatrixid.interp_decomp(A, eps, rand=False)
-        t = time.time() - t0
+        k, idx, proj = pymatrixid.interp_decomp(A_or_L, eps, rand=rand)
         B = pymatrixid.reconstruct_matrix_from_id(A[:, idx[:k]], idx, proj)
-        _debug_print(fmt % (t, np.allclose(A, B, eps)))
         assert_allclose(A, B, rtol=eps, atol=1e-08)
 
-        _debug_print("Calling iddp_aid / idzp_aid ...",)
-        t0 = time.time()
-        k, idx, proj = pymatrixid.interp_decomp(A, eps)
-        t = time.time() - t0
-        B = pymatrixid.reconstruct_matrix_from_id(A[:, idx[:k]], idx, proj)
-        _debug_print(fmt % (t, np.allclose(A, B, eps)))
-        assert_allclose(A, B, rtol=eps, atol=1e-08)
-
-        _debug_print("Calling iddp_rid / idzp_rid ...",)
-        t0 = time.time()
-        k, idx, proj = pymatrixid.interp_decomp(L, eps)
-        t = time.time() - t0
-        B = pymatrixid.reconstruct_matrix_from_id(A[:, idx[:k]], idx, proj)
-        _debug_print(fmt % (t, np.allclose(A, B, eps)))
-        assert_allclose(A, B, rtol=eps, atol=1e-08)
-
-        # fixed rank
+    @pytest.mark.parametrize(
+        "rand,lin_op",
+        [(False, False), (True, False), (True, True)])
+    def test_real_id_fixed_rank(self, A, L, eps, rank, rand, lin_op):
         k = rank
+        A_or_L = A if not lin_op else L
 
-        _debug_print("Calling iddr_id / idzr_id  ...",)
-        t0 = time.time()
-        idx, proj = pymatrixid.interp_decomp(A, k, rand=False)
-        t = time.time() - t0
+        idx, proj = pymatrixid.interp_decomp(A_or_L, k, rand=rand)
         B = pymatrixid.reconstruct_matrix_from_id(A[:, idx[:k]], idx, proj)
-        _debug_print(fmt % (t, np.allclose(A, B, eps)))
         assert_allclose(A, B, rtol=eps, atol=1e-08)
 
-        _debug_print("Calling iddr_aid / idzr_aid ...",)
-        t0 = time.time()
-        idx, proj = pymatrixid.interp_decomp(A, k)
-        t = time.time() - t0
-        B = pymatrixid.reconstruct_matrix_from_id(A[:, idx[:k]], idx, proj)
-        _debug_print(fmt % (t, np.allclose(A, B, eps)))
-        assert_allclose(A, B, rtol=eps, atol=1e-08)
+    @pytest.mark.parametrize("rand,lin_op", [(False, False)])
+    def test_real_id_skel_and_interp_matrices(
+            self, A, L, eps, rank, rand, lin_op):
+        k = rank
+        A_or_L = A if not lin_op else L
 
-        _debug_print("Calling iddr_rid / idzr_rid ...",)
-        t0 = time.time()
-        idx, proj = pymatrixid.interp_decomp(L, k)
-        t = time.time() - t0
-        B = pymatrixid.reconstruct_matrix_from_id(A[:, idx[:k]], idx, proj)
-        _debug_print(fmt % (t, np.allclose(A, B, eps)))
-        assert_allclose(A, B, rtol=eps, atol=1e-08)
-
-        # check skeleton and interpolation matrices
-        idx, proj = pymatrixid.interp_decomp(A, k, rand=False)
+        idx, proj = pymatrixid.interp_decomp(A_or_L, k, rand=rand)
         P = pymatrixid.reconstruct_interp_matrix(idx, proj)
         B = pymatrixid.reconstruct_skel_matrix(A, k, idx)
-        assert_allclose(B, A[:,idx[:k]], rtol=eps, atol=1e-08)
+        assert_allclose(B, A[:, idx[:k]], rtol=eps, atol=1e-08)
         assert_allclose(B @ P, A, rtol=eps, atol=1e-08)
 
-        # test SVD routines
-        _debug_print("-----------------------------------------")
-        _debug_print("SVD routines")
-        _debug_print("-----------------------------------------")
+    @pytest.mark.parametrize(
+        "rand,lin_op",
+        [(False, False), (True, False), (True, True)])
+    def test_svd_fixed_precison(self, A, L, eps, rand, lin_op):
+        A_or_L = A if not lin_op else L
 
-        # fixed precision
-        _debug_print("Calling iddp_svd / idzp_svd ...",)
-        t0 = time.time()
-        U, S, V = pymatrixid.svd(A, eps, rand=False)
-        t = time.time() - t0
+        U, S, V = pymatrixid.svd(A_or_L, eps, rand=rand)
         B = U * S @ V.T.conj()
-        _debug_print(fmt % (t, np.allclose(A, B, eps)))
         assert_allclose(A, B, rtol=eps, atol=1e-08)
 
-        _debug_print("Calling iddp_asvd / idzp_asvd...",)
-        t0 = time.time()
-        U, S, V = pymatrixid.svd(A, eps)
-        t = time.time() - t0
+    @pytest.mark.parametrize(
+        "rand,lin_op",
+        [(False, False), (True, False), (True, True)])
+    def test_svd_fixed_rank(self, A, L, eps, rank, rand, lin_op):
+        k = rank
+        A_or_L = A if not lin_op else L
+
+        U, S, V = pymatrixid.svd(A_or_L, k, rand=rand)
         B = U * S @ V.T.conj()
-        _debug_print(fmt % (t, np.allclose(A, B, eps)))
         assert_allclose(A, B, rtol=eps, atol=1e-08)
 
-        _debug_print("Calling iddp_rsvd / idzp_rsvd...",)
-        t0 = time.time()
-        U, S, V = pymatrixid.svd(L, eps)
-        t = time.time() - t0
-        B = U * S @ V.T.conj()
-        _debug_print(fmt % (t, np.allclose(A, B, eps)))
-        assert_allclose(A, B, rtol=eps, atol=1e-08)
-
-        # fixed rank
+    def test_id_to_svd(self, A, eps, rank):
         k = rank
 
-        _debug_print("Calling iddr_svd / idzr_svd ...",)
-        t0 = time.time()
-        U, S, V = pymatrixid.svd(A, k, rand=False)
-        t = time.time() - t0
-        B = U * S @ V.T.conj()
-        _debug_print(fmt % (t, np.allclose(A, B, eps)))
-        assert_allclose(A, B, rtol=eps, atol=1e-08)
-
-        _debug_print("Calling iddr_asvd / idzr_asvd ...",)
-        t0 = time.time()
-        U, S, V = pymatrixid.svd(A, k)
-        t = time.time() - t0
-        B = U * S @ V.T.conj()
-        _debug_print(fmt % (t, np.allclose(A, B, eps)))
-        assert_allclose(A, B, rtol=eps, atol=1e-08)
-
-        _debug_print("Calling iddr_rsvd / idzr_rsvd ...",)
-        t0 = time.time()
-        U, S, V = pymatrixid.svd(L, k)
-        t = time.time() - t0
-        B = U * S @ V.T.conj()
-        _debug_print(fmt % (t, np.allclose(A, B, eps)))
-        assert_allclose(A, B, rtol=eps, atol=1e-08)
-
-        # ID to SVD
         idx, proj = pymatrixid.interp_decomp(A, k, rand=False)
-        Up, Sp, Vp = pymatrixid.id_to_svd(A[:, idx[:k]], idx, proj)
+        U, S, V = pymatrixid.id_to_svd(A[:, idx[:k]], idx, proj)
         B = U * S @ V.T.conj()
         assert_allclose(A, B, rtol=eps, atol=1e-08)
 
-        # Norm estimates
+    def test_estimate_spectral_norm(self, A):
         s = svdvals(A)
         norm_2_est = pymatrixid.estimate_spectral_norm(A)
         assert_allclose(norm_2_est, s[0], rtol=1e-6, atol=1e-8)
 
+    def test_estimate_spectral_norm_diff(self, A):
         B = A.copy()
-        B[:,0] *= 1.2
+        B[:, 0] *= 1.2
         s = svdvals(A - B)
         norm_2_est = pymatrixid.estimate_spectral_norm_diff(A, B)
         assert_allclose(norm_2_est, s[0], rtol=1e-6, atol=1e-8)
 
-        # Rank estimates
-        B = np.array([[1, 1, 0], [0, 0, 1], [0, 0, 1]], dtype=dtype)
+    def test_rank_estimates_array(self, A):
+        B = np.array([[1, 1, 0], [0, 0, 1], [0, 0, 1]], dtype=A.dtype)
+
         for M in [A, B]:
-            ML = aslinearoperator(M)
-
             rank_tol = 1e-9
-            rank_np = np.linalg.matrix_rank(M, norm(M, 2)*rank_tol)
+            rank_np = np.linalg.matrix_rank(M, norm(M, 2) * rank_tol)
             rank_est = pymatrixid.estimate_rank(M, rank_tol)
-            rank_est_2 = pymatrixid.estimate_rank(ML, rank_tol)
-
             assert_(rank_est >= rank_np)
             assert_(rank_est <= rank_np + 10)
 
-            assert_(rank_est_2 >= rank_np - 4)
-            assert_(rank_est_2 <= rank_np + 4)
+    def test_rank_estimates_lin_op(self, A):
+        B = np.array([[1, 1, 0], [0, 0, 1], [0, 0, 1]], dtype=A.dtype)
+
+        for M in [A, B]:
+            ML = aslinearoperator(M)
+            rank_tol = 1e-9
+            rank_np = np.linalg.matrix_rank(M, norm(M, 2) * rank_tol)
+            rank_est = pymatrixid.estimate_rank(ML, rank_tol)
+            assert_(rank_est >= rank_np - 4)
+            assert_(rank_est <= rank_np + 4)
 
     def test_rand(self):
         pymatrixid.seed('default')


### PR DESCRIPTION
This test was not very useful for seeing what was actually broken as it
could only fail once on the first issue. This commit refactors the
single test into numerous smaller tests, making use of `pytest` fixtures.
This aims to aid in debugging of test failures.

I believe, the test was actually broken in places before. For example, see [line 204](https://github.com/scipy/scipy/blob/e4b3e6eb372b8c1d875f2adf607630a31e2a609c/scipy/linalg/tests/test_interpolative.py#L204) of the original file.