### PR TITLE
BLD: sync openblas with NumPy and update to 0.3.17

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -196,7 +196,7 @@ stages:
             docker pull i386/ubuntu:bionic
             docker run -v $(pwd):/scipy i386/ubuntu:bionic /usr/bin/linux32 /bin/bash -c "cd scipy && \
             apt-get -y update && \
-            apt-get -y install curl python3.7-dev python3.7 python3-distutils pkg-config libpng-dev libjpeg8-dev libfreetype6-dev && \
+            apt-get -y install curl python3.7-dev python3.7 python3-distutils pkg-config libpng-dev libjpeg8-dev libfreetype6-dev libgfortran5 && \
             curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
             python3.7 get-pip.py && \
             pip3 --version && \
@@ -300,9 +300,8 @@ stages:
         clang-cl.exe --version
       displayName: 'clang-cl version'
     - powershell: |
-        # wheels appear to use mingw64 version 6.3.0, but 6.4.0
-        # is the closest match available from choco package manager
-        choco install -y mingw --forcex86 --force --version=6.4.0
+        # wheels need to use this version too
+        choco install -y mingw --forcex86 --force --version=7.3.0
       displayName: 'Install 32-bit mingw for 32-bit builds'
       condition: and(succeeded(), eq(variables['BITS'], 32))
     - script: >-

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -1,5 +1,4 @@
 import glob
-import hashlib
 import os
 import platform
 import sysconfig
@@ -105,7 +104,6 @@ def download_openblas(target, plat, ilp64):
     print(f"Downloading {length} from {filename}", file=sys.stderr)
     data = response.read()
     # Verify hash
-    key = os.path.basename(filename)
     print("Saving to file", file=sys.stderr)
     with open(target, 'wb') as fid:
         fid.write(data)

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -1,57 +1,49 @@
-import os
-import sys
 import glob
-import shutil
-import textwrap
-import platform
 import hashlib
+import os
+import platform
+import sysconfig
+import sys
+import shutil
+import tarfile
+import textwrap
+import zipfile
 
 from tempfile import mkstemp, gettempdir
 from urllib.request import urlopen, Request
 from urllib.error import HTTPError
-import zipfile
-import tarfile
 
-OPENBLAS_V = 'v0.3.9'
-OPENBLAS_LONG = 'v0.3.9'
-BASE_LOC = ''
-ANACONDA = 'https://anaconda.org/multibuild-wheels-staging/openblas-libs'
-ARCHITECTURES = ['', 'windows', 'darwin', 'aarch64', 'x86', 'ppc64le', 's390x']
-sha256_vals = {
-'openblas64_-v0.3.9-macosx_10_9_x86_64-gf_1becaaa.tar.gz':
-'53f606a7da75d390287f1c51b2af7866b8fe7553a26d2474f827daf0e5c8a886',
-'openblas64_-v0.3.9-manylinux1_x86_64.tar.gz':
-'6fe5b1e2a4baa16833724bcc94a80b22e9c99fc1b9a2ddbce4f1f82a8002d906',
-'openblas64_-v0.3.9-win_amd64-gcc_7_1_0.zip':
-'15d24a66c5b22cc7b3120e831658f491c7a063804c33813235044a6f8b56686d',
-'openblas-v0.3.9-macosx_10_9_x86_64-gf_1becaaa.tar.gz': 
-'8221397b9cfb8cb22f3efb7f228ef901e13f9fd89c7d7d0cb7b8a79b0610bf33',
-'openblas-v0.3.9-manylinux1_i686.tar.gz': 
-'31abf8eccb697a320a998ce0f59045edc964602f815d78690c5a23839819261c',
-'openblas-v0.3.9-manylinux1_x86_64.tar.gz':
-'d9c39acbafae9b1daef19c2738ec938109a59e9322f93eb9a3c50869d220deff',
-'openblas-v0.3.9-win32-gcc_7_1_0.zip':
-'69a7dc265e8a8e45b358637d11cb1710ce88c4456634c7ce37d429b1d9bc9aaa',
-'openblas-v0.3.9-win_amd64-gcc_7_1_0.zip': 
-'0cea06f4a2afebaa6255854f73f237802fc6b58eaeb1a8b1c22d87cc399e0d48',
-'openblas-v0.3.9-manylinux2014_aarch64.tar.gz':
-'10d5ef5e9e19af5c199b59a17f43763e0c85ecf13cbc8f2d91e076f7847cdb5e'
-}
-
+OPENBLAS_V = '0.3.17'
+OPENBLAS_LONG = 'v0.3.17'
+BASE_LOC = 'https://anaconda.org/multibuild-wheels-staging/openblas-libs'
+BASEURL = f'{BASE_LOC}/{OPENBLAS_LONG}/download'
+SUPPORTED_PLATFORMS = [
+    'linux-aarch64',
+    'linux-x86_64',
+    'linux-i686',
+    'linux-ppc64le',
+    'linux-s390x',
+    'win-amd64',
+    'win-32',
+    'macosx-x86_64',
+    'macosx-arm64',
+]
 IS_32BIT = sys.maxsize < 2**32
-def get_arch():
-    if platform.system() == 'Windows':
-        ret = 'windows'
-    elif platform.system() == 'Darwin':
-        ret = 'darwin'
-    else:
-        ret = platform.uname().machine
-        # What do 32 bit machines report?
-        # If they are a docker, they report x86_64 or i686
-        if 'x86' in ret or ret == 'i686':
-            ret = 'x86'
-    assert ret in ARCHITECTURES
-    return ret
+
+
+def get_plat():
+    plat = sysconfig.get_platform()
+    plat_split = plat.split("-")
+    arch = plat_split[-1]
+    if arch == "win32":
+        plat = "win-32"
+    elif arch in ["universal2", "intel"]:
+        plat = f"macosx-{platform.uname().machine}"
+    elif len(plat_split) > 2:
+        plat = f"{plat_split[0]}-{arch}"
+    assert plat in SUPPORTED_PLATFORMS,  f'invalid platform {plat}'
+    return plat
+
 
 def get_ilp64():
     if os.environ.get("NPY_USE_BLAS_ILP64", "0") == "0":
@@ -60,57 +52,67 @@ def get_ilp64():
         raise RuntimeError("NPY_USE_BLAS_ILP64 set on 32-bit arch")
     return "64_"
 
-def download_openblas(target, arch, ilp64):
+
+def get_manylinux(arch):
+    if arch in ('x86_64', 'i686'):
+        default = '2010'
+    else:
+        default = '2014'
+    ret = os.environ.get("MB_ML_VER", default)
+    # XXX For PEP 600 this can be a glibc version
+    assert ret in ('1', '2010', '2014', '_2_24'), f'invalid MB_ML_VER {ret}'
+    return ret
+
+
+def download_openblas(target, plat, ilp64):
+    osname, arch = plat.split("-")
     fnsuffix = {None: "", "64_": "64_"}[ilp64]
     filename = ''
-    if arch in ('aarch64', 'ppc64le', 's390x'):
-        suffix = f'manylinux2014_{arch}.tar.gz'
-        filename = f'{ANACONDA}/{OPENBLAS_LONG}/download/openblas{fnsuffix}-{OPENBLAS_LONG}-{suffix}'
+    headers = {'User-Agent':
+               ('Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 ; '
+                '(KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.3')}
+    suffix = None
+    if osname == "linux":
+        ml_ver = get_manylinux(arch)
+        suffix = f'manylinux{ml_ver}_{arch}.tar.gz'
         typ = 'tar.gz'
-        typ = 'tar.gz'
-    elif arch == 'darwin':
+    elif plat == 'macosx-x86_64':
         suffix = 'macosx_10_9_x86_64-gf_1becaaa.tar.gz'
-        filename = f'{ANACONDA}/{OPENBLAS_LONG}/download/openblas{fnsuffix}-{OPENBLAS_LONG}-{suffix}'
         typ = 'tar.gz'
-    elif arch == 'windows':
-        if IS_32BIT:
-            suffix = 'win32-gcc_7_1_0.zip'
+    elif plat == 'macosx-arm64':
+        suffix = 'macosx_11_0_arm64-gf_f26990f.tar.gz'
+        typ = 'tar.gz'
+    elif osname == 'win':
+        if plat == "win-32":
+            suffix = 'win32-gcc_8_1_0.zip'
         else:
-            suffix = 'win_amd64-gcc_7_1_0.zip'
-        filename = f'{ANACONDA}/{OPENBLAS_LONG}/download/openblas{fnsuffix}-{OPENBLAS_LONG}-{suffix}'
+            suffix = 'win_amd64-gcc_8_1_0.zip'
         typ = 'zip'
-    elif 'x86' in arch:
-        if IS_32BIT:
-            suffix = 'manylinux1_i686.tar.gz'
-        else:
-            suffix = 'manylinux1_x86_64.tar.gz'
-        filename = f'{ANACONDA}/{OPENBLAS_LONG}/download/openblas{fnsuffix}-{OPENBLAS_LONG}-{suffix}'
-        typ = 'tar.gz'
-    if not filename:
-        return None
-    print("Downloading:", filename, file=sys.stderr)
-    try:
-        with open(target, 'wb') as fid:
-            # anaconda.org download location guards against
-            # scraping so trick it with a fake browser header
-            # see: https://medium.com/@speedforcerun/python-crawler-http-error-403-forbidden-1623ae9ba0f
-            headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.3'}
-            req = Request(url=filename, headers=headers)
-            fid.write(urlopen(req).read())
-        with open(target, 'rb') as binary_to_check:
-            data = binary_to_check.read()
-            sha256_returned = hashlib.sha256(data).hexdigest()
-            sha256_expected = sha256_vals[os.path.basename(filename)]
-            if sha256_returned != sha256_expected:
-                raise ValueError('sha256 hash mismatch for downloaded OpenBLAS')
 
-    except HTTPError as e:
-        print(f'Could not download "{filename}"')
-        print(f'Error message: {e}')
+    if not suffix:
         return None
+    filename = f'{BASEURL}/openblas{fnsuffix}-{OPENBLAS_LONG}-{suffix}'
+    req = Request(url=filename, headers=headers)
+    try:
+        response = urlopen(req)
+    except HTTPError:
+        print(f'Could not download "{filename}"', file=sys.stderr)
+        raise
+    length = response.getheader('content-length')
+    if response.status != 200:
+        print(f'Could not download "{filename}"', file=sys.stderr)
+        return None
+    print(f"Downloading {length} from {filename}", file=sys.stderr)
+    data = response.read()
+    # Verify hash
+    key = os.path.basename(filename)
+    print("Saving to file", file=sys.stderr)
+    with open(target, 'wb') as fid:
+        fid.write(data)
     return typ
 
-def setup_openblas(arch=get_arch(), ilp64=get_ilp64()):
+
+def setup_openblas(plat=get_plat(), ilp64=get_ilp64()):
     '''
     Download and setup an openblas library for building. If successful,
     the configuration script will find it automatically.
@@ -122,33 +124,39 @@ def setup_openblas(arch=get_arch(), ilp64=get_ilp64()):
         To determine success, do ``os.path.exists(msg)``
     '''
     _, tmp = mkstemp()
-    if not arch:
-        raise ValueError('unknown architecture')
-    typ = download_openblas(tmp, arch, ilp64)
+    if not plat:
+        raise ValueError('unknown platform')
+    typ = download_openblas(tmp, plat, ilp64)
     if not typ:
         return ''
-    if arch == 'windows':
+    osname, arch = plat.split("-")
+    if osname == 'win':
         if not typ == 'zip':
-            return 'expecting to download zipfile on windows, not %s' % str(typ)
+            return f'expecting to download zipfile on windows, not {typ}'
         return unpack_windows_zip(tmp)
     else:
         if not typ == 'tar.gz':
             return 'expecting to download tar.gz, not %s' % str(typ)
         return unpack_targz(tmp)
 
+
 def unpack_windows_zip(fname):
     with zipfile.ZipFile(fname, 'r') as zf:
         # Get the openblas.a file, but not openblas.dll.a nor openblas.dev.a
         lib = [x for x in zf.namelist() if OPENBLAS_LONG in x and
-                  x.endswith('a') and not x.endswith('dll.a') and
-                  not x.endswith('dev.a')]
+               x.endswith('a') and not x.endswith('dll.a') and
+               not x.endswith('dev.a')]
         if not lib:
             return 'could not find libopenblas_%s*.a ' \
                     'in downloaded zipfile' % OPENBLAS_LONG
-        target = os.path.join(gettempdir(), 'openblas.a')
+        if get_ilp64() is None:
+            target = os.path.join(gettempdir(), 'openblas.a')
+        else:
+            target = os.path.join(gettempdir(), 'openblas64_.a')
         with open(target, 'wb') as fid:
             fid.write(zf.read(lib[0]))
     return target
+
 
 def unpack_targz(fname):
     target = os.path.join(gettempdir(), 'openblas')
@@ -159,6 +167,7 @@ def unpack_targz(fname):
         prefix = os.path.commonpath(zf.getnames())
         extract_tarfile_to(zf, target, prefix)
         return target
+
 
 def extract_tarfile_to(tarfileobj, target_path, archive_path):
     """Extract TarFile contents under archive_path/ to target_path/"""
@@ -183,6 +192,7 @@ def extract_tarfile_to(tarfileobj, target_path, archive_path):
 
     tarfileobj.extractall(target_path, members=get_members())
 
+
 def make_init(dirname):
     '''
     Create a _distributor_init.py file for OpenBlas
@@ -196,12 +206,12 @@ def make_init(dirname):
             and is created as part of the scripts that build the wheel.
             '''
             import os
-            from ctypes import WinDLL
             import glob
             if os.name == 'nt':
                 # convention for storing / loading the DLL from
                 # numpy/.libs/, if present
                 try:
+                    from ctypes import WinDLL
                     basedir = os.path.dirname(__file__)
                 except:
                     pass
@@ -210,43 +220,61 @@ def make_init(dirname):
                     DLL_filenames = []
                     if os.path.isdir(libs_dir):
                         for filename in glob.glob(os.path.join(libs_dir,
-                                                             '*openblas*dll')):
+                                                               '*openblas*dll')):
                             # NOTE: would it change behavior to load ALL
                             # DLLs at this path vs. the name restriction?
                             WinDLL(os.path.abspath(filename))
                             DLL_filenames.append(filename)
-                if len(DLL_filenames) > 1:
-                    import warnings
-                    warnings.warn("loaded more than 1 DLL from .libs:\\n%s" %
-                              "\\n".join(DLL_filenames),
-                              stacklevel=1)
+                    if len(DLL_filenames) > 1:
+                        import warnings
+                        warnings.warn("loaded more than 1 DLL from .libs:"
+                                      "\\n%s" % "\\n".join(DLL_filenames),
+                                      stacklevel=1)
     """))
 
-def test_setup(arches):
+
+def test_setup(plats):
     '''
     Make sure all the downloadable files exist and can be opened
     '''
     def items():
-        for arch in arches:
-            yield arch, None
-            if arch in ('x86', 'darwin', 'windows'):
-                yield arch, '64_'
+        """ yields all combinations of arch, ilp64
+        """
+        for plat in plats:
+            yield plat, None
+            osname, arch = plat.split("-")
+            if arch not in ('i686', 'arm64', '32'):
+                yield plat, '64_'
+            if osname == "linux" and arch in ('i686', 'x86_64'):
+                oldval = os.environ.get('MB_ML_VER', None)
+                os.environ['MB_ML_VER'] = '1'
+                yield plat, None
+                # Once we create x86_64 and i686 manylinux2014 wheels...
+                # os.environ['MB_ML_VER'] = '2014'
+                # yield arch, None, False
+                if oldval:
+                    os.environ['MB_ML_VER'] = oldval
+                else:
+                    os.environ.pop('MB_ML_VER')
 
-    for arch, ilp64 in items():
-        if arch == '':
+    errs = []
+    for plat, ilp64 in items():
+        osname, _ = plat.split("-")
+        if plat not in plats:
             continue
-
         target = None
         try:
             try:
-                target = setup_openblas(arch, ilp64)
-            except Exception:
-                print(f'Could not setup {arch}')
-                raise
+                target = setup_openblas(plat, ilp64)
+            except Exception as e:
+                print(f'Could not setup {plat} with ilp64 {ilp64}, ')
+                print(e)
+                errs.append(e)
+                continue
             if not target:
-                raise RuntimeError(f'Could not setup {arch}')
+                raise RuntimeError(f'Could not setup {plat}')
             print(target)
-            if arch == 'windows':
+            if osname == 'win':
                 if not target.endswith('.a'):
                     raise RuntimeError("Not .a extracted!")
             else:
@@ -259,6 +287,9 @@ def test_setup(arches):
                     os.unlink(target)
                 else:
                     shutil.rmtree(target)
+    if errs:
+        raise errs[0]
+
 
 def test_version(expected_version, ilp64=get_ilp64()):
     """
@@ -277,12 +308,13 @@ def test_version(expected_version, ilp64=get_ilp64()):
     get_config.restype = ctypes.c_char_p
     res = get_config()
     print('OpenBLAS get_config returned', str(res))
-    check_str = b'OpenBLAS %s' % expected_version[0].encode()
-    assert check_str in res
-
+    if not expected_version:
+        expected_version = OPENBLAS_V
+    check_str = b'OpenBLAS %s' % expected_version.encode()
+    print(check_str)
+    assert check_str in res, f'{expected_version} not found in {res}'
     if 'dev' not in expected_version[0]:
         assert b'dev' not in res
-
     if ilp64:
         assert b"USE64BITINT" in res
     else:
@@ -295,16 +327,18 @@ if __name__ == '__main__':
         description='Download and expand an OpenBLAS archive for this '
                     'architecture')
     parser.add_argument('--test', nargs='*', default=None,
-        help='Test different architectures. "all", or any of %s' % ARCHITECTURES)
-    parser.add_argument('--check_version', nargs=1, default=None,
-        help='Check provided OpenBLAS version string against available OpenBLAS')
+                        help='Test different architectures. "all", or any of '
+                             f'{SUPPORTED_PLATFORMS}')
+    parser.add_argument('--check_version', nargs='?', default='',
+                        help='Check provided OpenBLAS version string '
+                             'against available OpenBLAS')
     args = parser.parse_args()
-    if args.check_version is not None:
+    if args.check_version != '':
         test_version(args.check_version)
     elif args.test is None:
         print(setup_openblas())
     else:
         if len(args.test) == 0 or 'all' in args.test:
-            test_setup(ARCHITECTURES)
+            test_setup(SUPPORTED_PLATFORMS)
         else:
             test_setup(args.test)


### PR DESCRIPTION
The version of OpenBLAS in SciPy has been 0.3.9 where NumPy advanced to 0.3.17. I copied the file from NumPy HEAD with some tweaks to the `test_version` function.