### PR TITLE
ENH: add d2 statistical function

### DIFF
--- a/scipy/stats/d2.py
+++ b/scipy/stats/d2.py
@@ -1,8 +1,9 @@
 from scipy.stats import norm
+from scipy.integrate import quad
 import numpy as np
 
 
-def d2(n=2):
+def d2(n=2, method="exact"):
     """
     Computes the d2 statistic used for measuring
     relative range standard deviation approximation.
@@ -14,25 +15,42 @@ def d2(n=2):
     R / d2 where R is the range of the data (max - min)
     and d2 is computed as below.
 
+    See also:
+    https://v8doc.sas.com/sashtml/qc/chapc/sect9.htm
+
     :param n:
         Number of distributions considered for computing
         d2. All are normal with mean=0 and std=1.
+    :param method:
+        Optional. Method to use. Default "exact".
+            - "exact" computes the exact infinite integral.
+            - "random" uses normal distributions generated
+              on the fly to compute d2.
     :return:
         d2:
             the expectation value [that is, average here]
             of the ranges of the distributions
     """
-    x = {}
-    # slots to fill with normally distributed samples
-    for i in range(n):
-        x[i] = norm.rvs(size=100000, loc=0, scale=1)
+    if method == "exact":
+        def f(x, n):
+            return 1 - (1 - norm.cdf(x)) ** n - (norm.cdf(x)) ** n
 
-    x = np.vstack([x[i] for i in x])
+        d2 = quad(f, -np.inf, np.inf, args=(n))[0]
+        return d2
 
-    maxs = np.amax(x, axis=0)
-    mins = np.amin(x, axis=0)
+    elif method == "random":
+        x = {}
+        # slots to fill with normally distributed samples
+        for i in range(n):
+            x[i] = norm.rvs(size=100000, loc=0, scale=1)
 
-    r = maxs - mins
+        x = np.vstack([x[i] for i in x])
 
-    d2 = np.average(r)
-    return d2
+        maxs = np.amax(x, axis=0)
+        mins = np.amin(x, axis=0)
+
+        r = maxs - mins
+
+        d2 = np.average(r)
+        return d2
+

--- a/scipy/stats/d2.py
+++ b/scipy/stats/d2.py
@@ -1,0 +1,38 @@
+from scipy.stats import norm
+import numpy as np
+
+
+def d2(n=2):
+    """
+    Computes the d2 statistic used for measuring
+    relative range standard deviation approximation.
+
+    The d2 statistic is often found in statistical process
+    control tables.
+
+    That is, standard deviation can be approximated by
+    R / d2 where R is the range of the data (max - min)
+    and d2 is computed as below.
+
+    :param n:
+        Number of distributions considered for computing
+        d2. All are normal with mean=0 and std=1.
+    :return:
+        d2:
+            the expectation value [that is, average here]
+            of the ranges of the distributions
+    """
+    x = {}
+    # slots to fill with normally distributed samples
+    for i in range(n):
+        x[i] = norm.rvs(size=100000, loc=0, scale=1)
+
+    x = np.vstack([x[i] for i in x])
+
+    maxs = np.amax(x, axis=0)
+    mins = np.amin(x, axis=0)
+
+    r = maxs - mins
+
+    d2 = np.average(r)
+    return d2

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -73,7 +73,7 @@ __all__ = ['find_repeats', 'gmean', 'hmean', 'mode', 'tmean', 'tvar',
            'tiecorrect', 'ranksums', 'kruskal', 'friedmanchisquare',
            'rankdata',
            'combine_pvalues', 'wasserstein_distance', 'energy_distance',
-           'brunnermunzel', 'alexandergovern']
+           'brunnermunzel', 'alexandergovern', 'd2']
 
 
 def _contains_nan(a, nan_policy='propagate'):


### PR DESCRIPTION
First PR to scipy. Made issue here: #14604

I ran tests locally, and got some errors:

```
ERROR scipy/interpolate/tests/test_rbfinterp.py - AttributeError: module 'scipy.stats.stats' has no attribute 'd2'
```
and similar. Probably not placing the files/functions in the right place or some such.

#### Reference issue
#14604

#### What does this implement/fix?
Adds a function to calculate[ the d2 statistic](https://v8doc.sas.com/sashtml/qc/chapc/sect9.htm) which is used to estimate standard deviation of normally distributed datasets with knowledge of only the range (max-min) and number of samples

#### Additional information
<!--Any additional information you think is important.-->