### PR TITLE
DEV: initialize all submodules in Gitpod Dockerfile

### DIFF
--- a/tools/docker_dev/gitpod.Dockerfile
+++ b/tools/docker_dev/gitpod.Dockerfile
@@ -37,7 +37,8 @@ WORKDIR ${WORKSPACE}
 
 # Build scipy to populate the cache used by ccache
 # Must re-activate conda to ensure the ccache flags are picked up
-RUN git submodule update --init
+RUN git submodule update --init --depth=1 -- scipy/_lib/boost
+RUN git submodule update --init --depth=1 -- scipy/_lib/unuran
 RUN conda activate ${CONDA_ENV} && \
     python setup.py build_ext --inplace && \
     ccache -s

--- a/tools/docker_dev/gitpod.Dockerfile
+++ b/tools/docker_dev/gitpod.Dockerfile
@@ -37,7 +37,7 @@ WORKDIR ${WORKSPACE}
 
 # Build scipy to populate the cache used by ccache
 # Must re-activate conda to ensure the ccache flags are picked up
-RUN git submodule update --init --depth=1 -- scipy/_lib/boost
+RUN git submodule update --init
 RUN conda activate ${CONDA_ENV} && \
     python setup.py build_ext --inplace && \
     ccache -s


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue

N/A

#### What does this implement/fix?

As pointed out in https://github.com/scipy/scipy/pull/14215#issuecomment-901215283, `gitpod` job failed on the CI after introducing UNU.RAN in scipy.stats. This was because the script only cloned boost instead of all the submodules under SciPy (see https://github.com/scipy/scipy/pull/14215#issuecomment-901222029 and https://github.com/scipy/scipy/pull/14215#issuecomment-901227775). Is there any reason to do so? If not, this fix should work.

#### Additional information

N/A