### PR TITLE
MAINT: interpolate: Declare type for a Cython indexing variable.

### DIFF
--- a/scipy/interpolate/_bspl.pyx
+++ b/scipy/interpolate/_bspl.pyx
@@ -439,6 +439,7 @@ def _make_design_matrix(const double[::1] x,
         ..., last row - x[-1]).
     """
     cdef:
+        cnp.npy_intp i
         cnp.npy_intp n = x.shape[0]
         cnp.npy_intp nt = t.shape[0]
         double[::1] wrk = np.empty(2*k+2, dtype=float)


### PR DESCRIPTION
Fixes the build warning:

warning: _bspl.pyx:449:36: Index should be typed for more efficient access
