### PR TITLE
CI: fix Azure job which uses pre-release wheels + Python 3.7

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,7 @@ stages:
     steps:
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: '3.7'
+        versionSpec: '3.9'
         addToPath: true
         architecture: 'x64'
     - template: ci/azure-travis-template.yaml


### PR DESCRIPTION
NumPy dropped 3.7 in its main branch, and 3.7 pre-release wheels
were all removed from the anaconda bucket.

Closes gh-14617