### PR TITLE
ENH: optimize min max and median scipy.stats.binned_statistic

### DIFF
--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -598,13 +598,25 @@ def binned_statistic_dd(sample, values, statistic='mean',
             result[vv, a] = flatsum
     elif statistic == 'median':
         result.fill(np.nan)
-        _calc_binned_statistic(Vdim, binnumbers, result, values, np.median)
+        for vv in builtins.range(Vdim):
+            i = np.lexsort((values[vv], binnumbers))
+            _, j, counts = np.unique(binnumbers[i],
+                                     return_index=True, return_counts=True)
+            mid = j + (counts - 1) / 2
+            mid_a = values[vv, i][np.floor(mid).astype(int)]
+            mid_b = values[vv, i][np.ceil(mid).astype(int)]
+            medians = (mid_a + mid_b) / 2
+            result[vv, binnumbers[i][j]] = medians
     elif statistic == 'min':
         result.fill(np.nan)
-        _calc_binned_statistic(Vdim, binnumbers, result, values, np.min)
+        for vv in builtins.range(Vdim):
+            i = np.argsort(values[vv])[::-1]  # Reversed so the min is last
+            result[vv, binnumbers[i]] = values[vv, i]
     elif statistic == 'max':
         result.fill(np.nan)
-        _calc_binned_statistic(Vdim, binnumbers, result, values, np.max)
+        for vv in builtins.range(Vdim):
+            i = np.argsort(values[vv])
+            result[vv, binnumbers[i]] = values[vv, i]
     elif callable(statistic):
         with np.errstate(invalid='ignore'), suppress_warnings() as sup:
             sup.filter(RuntimeWarning)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### What does this implement/fix?
The current version of `scipy.stats.binned_statistic_dd` allows the following values for the `statistic` parameter:
['mean', 'median', 'count', 'sum', 'std', 'min', 'max'] (in addition to any callable)
Of these, `sum`, `count`, and `mean` are computed in a vectorized way while the rest are passed in a loop to the corresponding numpy functions which leads to much slower performance.

This PR implements an optimization where sorting the array allows vectorizing the `min`, `max`, and `median` statistics calculation and orders of magnitude improvements in the benchmarks for those three stats.

#### Additional information
Note: This also affects `binned_statistic` and `binned_statistic_2d`

On my machine, the benchmarks *before* this change:

            count                 1.48±0.02ms 
             sum                  1.46±0.01ms 
             mean                 1.62±0.02ms 
             min                   31.6±0.3ms 
             max                   30.9±0.6ms 
            median                  165±2ms   
             std                  10.00±0.2ms 
             <function std at 0x7fbe79411940>     114±3ms   

and *after*: (see `min`, `max`, and `median`)

            count                 1.56±0.06ms 
             sum                  1.52±0.05ms 
             mean                 1.70±0.07ms 
             min                  1.65±0.02ms 
             max                  1.63±0.02ms 
            median                2.24±0.03ms 
             std                   10.9±0.2ms 
             <function std at 0x7f7087727940>     126±2ms   
