### PR TITLE
MAINT: fix type-narrowing addition in sparse.construct.bmat

### DIFF
--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -682,7 +682,7 @@ def bmat(blocks, format=None, dtype=None):
         idx = slice(nnz, nnz + B.nnz)
         data[idx] = B.data
         np.add(B.row, row_offsets[i], out=row[idx], dtype=idx_dtype)
-        np.add(B.col, col_offsets[i], out=col[idx], dtype=idx_dtype)
+        np.add(B.col, col_offsets[j], out=col[idx], dtype=idx_dtype)
         nnz += B.nnz
 
     return coo_matrix((data, (row, col)), shape=shape).asformat(format)

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -681,8 +681,8 @@ def bmat(blocks, format=None, dtype=None):
         B = blocks[i, j]
         idx = slice(nnz, nnz + B.nnz)
         data[idx] = B.data
-        row[idx] = B.row + row_offsets[i]
-        col[idx] = B.col + col_offsets[j]
+        np.add(B.row, row_offsets[i], out=row[idx], dtype=idx_dtype)
+        np.add(B.col, col_offsets[i], out=col[idx], dtype=idx_dtype)
         nnz += B.nnz
 
     return coo_matrix((data, (row, col)), shape=shape).asformat(format)


### PR DESCRIPTION
Brought up in issue #14623

Note I have *not* added a unit test for this as the to catch the overflow in the situation described in the issue requires >20GB of RAM. If there is some suggestion as to how such a large test could be incorporated (basically directly from the mwe in the issue), please advise.