### PR TITLE
ENH: optimize std in scipy.stats.binned_statistic

### DIFF
--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -583,7 +583,7 @@ def binned_statistic_dd(sample, values, statistic='mean',
             flatsum = np.bincount(binnumbers, values[vv])
             result[vv, a] = flatsum[a] / flatcount[a]
     elif statistic == 'std':
-        result.fill(0)
+        result.fill(np.nan)
         flatcount = np.bincount(binnumbers, None)
         a = flatcount.nonzero()
         for vv in builtins.range(Vdim):
@@ -631,8 +631,7 @@ def binned_statistic_dd(sample, values, statistic='mean',
             except Exception:
                 null = np.nan
         result.fill(null)
-        _calc_binned_statistic(Vdim, binnumbers, result, values, statistic,
-                               is_callable=True)
+        _calc_binned_statistic(Vdim, binnumbers, result, values, statistic)
 
     # Shape into a proper matrix
     result = result.reshape(np.append(Vdim, nbin))
@@ -654,19 +653,13 @@ def binned_statistic_dd(sample, values, statistic='mean',
     return BinnedStatisticddResult(result, edges, binnumbers)
 
 
-def _calc_binned_statistic(Vdim, bin_numbers, result, values, stat_func,
-                           is_callable=False):
+def _calc_binned_statistic(Vdim, bin_numbers, result, values, stat_func):
     unique_bin_numbers = np.unique(bin_numbers)
     for vv in builtins.range(Vdim):
         bin_map = _create_binned_data(bin_numbers, unique_bin_numbers,
                                       values, vv)
         for i in unique_bin_numbers:
-            # if the stat_func is callable, all results should be updated
-            # if the stat_func is np.std, calc std only when binned data is 2
-            # or more for speed up.
-            if is_callable or not (stat_func is np.std and
-                                   len(bin_map[i]) < 2):
-                result[vv, i] = stat_func(np.array(bin_map[i]))
+            result[vv, i] = stat_func(np.array(bin_map[i]))
 
 
 def _create_binned_data(bin_numbers, unique_bin_numbers, values, vv):

--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -584,7 +584,13 @@ def binned_statistic_dd(sample, values, statistic='mean',
             result[vv, a] = flatsum[a] / flatcount[a]
     elif statistic == 'std':
         result.fill(0)
-        _calc_binned_statistic(Vdim, binnumbers, result, values, np.std)
+        flatcount = np.bincount(binnumbers, None)
+        a = flatcount.nonzero()
+        for vv in builtins.range(Vdim):
+            flatsum = np.bincount(binnumbers, values[vv])
+            delta = values[vv] - flatsum[binnumbers] / flatcount[binnumbers]
+            std = np.sqrt(np.bincount(binnumbers, delta**2)[a] / flatcount[a])
+            result[vv, a] = std
     elif statistic == 'count':
         result.fill(0)
         flatcount = np.bincount(binnumbers, None)

--- a/scipy/stats/tests/test_binned_statistic.py
+++ b/scipy/stats/tests/test_binned_statistic.py
@@ -49,6 +49,16 @@ class TestBinnedStatistic:
 
         assert_allclose(stat1, stat2)
 
+    def test_empty_bins_std(self):
+        # tests that std returns gives nan for empty bins
+        x = self.x
+        u = self.u
+        print(binned_statistic(x, u, 'count', bins=1000))
+        stat1, edges1, bc = binned_statistic(x, u, 'std', bins=1000)
+        stat2, edges2, bc = binned_statistic(x, u, np.std, bins=1000)
+
+        assert_allclose(stat1, stat2)
+
     def test_non_finite_inputs_and_int_bins(self):
         # if either `values` or `sample` contain np.inf or np.nan throw
         # see issue gh-9010 for more


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### What does this implement/fix?
The current version of `scipy.stats.binned_statistic_dd` allows the following values for the statistic parameter:
['mean', 'median', 'count', 'sum', 'std', 'min', 'max'] (in addition to any callable)
Of these, sum, count, and mean are computed in a vectorized way while the rest are passed in a loop to the corresponding numpy functions which leads to much slower performance.

This PR aims to vectorize the `std` statistic calculation since it actually only requires knowledge of the `count`, and `mean` results (which as noted were already being done in a vectorized way).

Previously, I already addressed the `min`, `max`, and `median` in https://github.com/scipy/scipy/pull/14625 and just realized that `std` can be optimized as well. Taken together, these PR's can enable all of the "named" statistics to be calculated in a vectorized way with much better benchmark performance.

#### Additional information
Note: This also affects `binned_statistic` and `binned_statistic_2d`

On my machine, the benchmarks *before* this change:

            count                   574±4μs   
             sum                   556±0.2μs  
             mean                  618±0.2μs  
             min                  11.9±0.09ms 
             max                  12.3±0.08ms 
            median                 68.9±0.1ms 
             std                  4.12±0.01ms 
             <function std at 0x7f0d86328940>    47.1±0.3ms 

and *after*: (see `std`)

            count                   573±6μs   
             sum                   557±0.4μs  
             mean                   616±2μs   
             min                   11.8±0.1ms 
             max                  11.7±0.05ms 
            median                 67.4±0.3ms 
             std                   656±100μs  
             <function std at 0x7fbf29174940>    46.6±0.2ms 