### PR TITLE
Fix unuran builds for older compilers

### DIFF
--- a/scipy/stats/_unuran/setup.py
+++ b/scipy/stats/_unuran/setup.py
@@ -105,7 +105,8 @@ def configuration(parent_package="", top_path=None):
         ("STDC_HEADERS", "1"),
         ("UNUR_ENABLE_INFO", "1"),
         ("VERSION", '"%s"' % UNURAN_VERSION),
-        ("HAVE_CONFIG_H", "1")
+        ("HAVE_CONFIG_H", "1"),
+        ("_ISOC99_SOURCE", "1"),
     ]
 
     UNURAN_DIRS = [


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->

cc @tirthasheshpatel, @chrisb83, @rgommers 

Otherwise builds fail with undefiend symbol `isfinite`.
See https://dev.azure.com/numpy/numpy/_build/results?buildId=19164&view=results