### PR TITLE
BUG: scipy.stats._unran: send only strings to include_dirs

### DIFF
--- a/scipy/stats/_unuran/setup.py
+++ b/scipy/stats/_unuran/setup.py
@@ -128,7 +128,7 @@ def configuration(parent_package="", top_path=None):
         "unuran_wrapper",
         sources=["unuran_wrapper.c"] + sources,
         libraries=[],
-        include_dirs=UNURAN_SOURCE_DIRS
+        include_dirs=[str(dir_.resolve()) for dir_ in UNURAN_SOURCE_DIRS]
         + [
             os.path.join(
                 os.path.dirname(__file__), "..", "..", "_lib", "src"


### PR DESCRIPTION
With python3.7, sending Path variables gives an error

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
This fixes the following error
```
Traceback (most recent call last):
  File "setup.py", line 631, in <module>
    setup_package()
  File "setup.py", line 627, in setup_package
    setup(**metadata)
  File "/opt/python/cp37-cp37m/lib/python3.7/site-packages/numpy/distutils/core.py", line 169, in setup
    return old_setup(**new_attr)
  File "/opt/python/cp37-cp37m/lib/python3.7/site-packages/setuptools/__init__.py", line 153, in setup
    return distutils.core.setup(**attrs)
  File "/opt/python/cp37-cp37m/lib/python3.7/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/opt/python/cp37-cp37m/lib/python3.7/distutils/dist.py", line 966, in run_commands
    self.run_command(cmd)
  File "/opt/python/cp37-cp37m/lib/python3.7/distutils/dist.py", line 985, in run_command
    cmd_obj.run()
  File "/opt/python/cp37-cp37m/lib/python3.7/site-packages/wheel/bdist_wheel.py", line 299, in run
    self.run_command('build')
  File "/opt/python/cp37-cp37m/lib/python3.7/distutils/cmd.py", line 313, in run_command
    self.distribution.run_command(command)
  File "/opt/python/cp37-cp37m/lib/python3.7/distutils/dist.py", line 985, in run_command
    cmd_obj.run()
  File "/opt/python/cp37-cp37m/lib/python3.7/site-packages/numpy/distutils/command/build.py", line 47, in run
    old_build.run(self)
    include_dirs = quote_args(include_dirs)
  File "/opt/python/cp37-cp37m/lib/python3.7/site-packages/numpy/distutils/misc_util.py", line 116, in quote_args
    if ' ' in a and a[0] not in '"\'':
TypeError: argument of type 'PosixPath' is not iterable
```

See https://dev.azure.com/numpy/numpy/_build/results?buildId=19182&view=logs&jobId=374573bd-7e87-5b54-007a-2f6e64e926bb&j=374573bd-7e87-5b54-007a-2f6e64e926bb&t=05610bf4-91f2-573f-bd2f-ea443fb7b964

cc @tirthasheshpatel, @rgommers 