### PR TITLE
DOC: Fix Wikipedia bootstrap link

### DIFF
--- a/scipy/stats/_bootstrap.py
+++ b/scipy/stats/_bootstrap.py
@@ -293,7 +293,7 @@ def bootstrap(data, statistic, *, vectorized=True, paired=False, axis=0,
     .. [2] Nathaniel E. Helwig, "Bootstrap Confidence Intervals",
        http://users.stat.umn.edu/~helwig/notes/bootci-Notes.pdf
     .. [3] Bootstrapping (statistics), Wikipedia,
-       https://en.wikipedia.org/wiki/Bootstrapping_(statistics)
+       https://en.wikipedia.org/wiki/Bootstrapping_%28statistics%29
 
     Examples
     --------


### PR DESCRIPTION
I noticed that the link in the [documentation](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.bootstrap.html) to the Wikipedia page on statistical bootstrapping was not pointing to the right place. Seems like this is a general issue with reStructuredText when the hyperlink contains parentheses. Citation [[12]](https://docs.scipy.org/doc/scipy/dev/toolchain.html?highlight=wikipedia#id35) in the toolchain roadmap would have the same problem, but the parentheses were switched for their unicode equivalents (%28 and %29). I've simply applied that same fix to the hyperlink for statistical bootstrapping and this has fixed the issue when I build the documentation locally.

This is my first PR to `scipy` so I hope I've got the PR and commit format done correctly :crossed_fingers:. Thank you to the entire development team for creating this amazing open-source software.