### PR TITLE
DOC: stats: fix multivariate_t docs pdf eqn

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -3879,7 +3879,7 @@ class multivariate_t_gen(multi_rv_generic):
     .. math::
 
         f(x) = \frac{\Gamma(\nu + p)/2}{\Gamma(\nu/2)\nu^{p/2}\pi^{p/2}|\Sigma|^{1/2}}
-               \exp\left[1 + \frac{1}{\nu} (\mathbf{x} - \boldsymbol{\mu})^{\top}
+               \left[1 + \frac{1}{\nu} (\mathbf{x} - \boldsymbol{\mu})^{\top}
                \boldsymbol{\Sigma}^{-1}
                (\mathbf{x} - \boldsymbol{\mu}) \right]^{-(\nu + p)/2},
 


### PR DESCRIPTION
The multivarite T distribution pdf math equation contained an extra `\exp` compared to https://en.wikipedia.org/wiki/Multivariate_t-distribution

closes #14608