### PR TITLE
MAINT: copy discrete dist dict

### DIFF
--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -1707,7 +1707,7 @@ nchypergeom_wallenius = nchypergeom_wallenius_gen(
 
 
 # Collect names of classes and objects in this module.
-pairs = list(globals().items())
+pairs = list(globals().copy().items())
 _distn_names, _distn_gen_names = get_distribution_names(pairs, rv_discrete)
 
 __all__ = _distn_names + _distn_gen_names


### PR DESCRIPTION
In response to https://stackoverflow.com/questions/68911221/python-runtimeerror-dictionary-changed-size-during-iteration-popping-out-rand.

The problem is almost identical (I think) to that observed in #11479, except that it's for discrete distns rather than continuous. I've therefore tried to apply the same 'fix' here, except that there's no easy way to test it.