### PR TITLE
MAINT: sparse.linalg: Correct the criterion and iteration number to show in `tfqmr.py`

### DIFF
--- a/scipy/sparse/linalg/_isolve/tfqmr.py
+++ b/scipy/sparse/linalg/_isolve/tfqmr.py
@@ -145,7 +145,7 @@ def tfqmr(A, b, x0=None, tol=1e-5, maxiter=None, M=None,
         d = u + (theta**2 / alpha) * eta * d  # [1]-(5.5)
         # [1]-(5.2)
         theta = np.linalg.norm(w) / tau
-        c = np.sqrt(1. / (1 + theta**2))
+        c = 1. / np.hypot(1, abs(theta))
         tau *= theta * c
         # Calculate step and direction [1]-(5.4)
         eta = (c**2) * alpha
@@ -155,11 +155,11 @@ def tfqmr(A, b, x0=None, tol=1e-5, maxiter=None, M=None,
         if callback is not None:
             callback(x)
 
-        # Convergence criteron
-        if tau * np.sqrt(iter+1) < atol:
+        # Convergence criterion
+        if tau * np.sqrt(iter+2.) < atol:
             if (show):
                 print("TFQMR: Linear solve converged due to reach TOL "
-                      "iterations {}".format(iter+1))
+                      f"iterations {(iter+1+even)//2}")
             return (postprocess(x), 0)
 
         if (not even):
@@ -177,5 +177,5 @@ def tfqmr(A, b, x0=None, tol=1e-5, maxiter=None, M=None,
 
     if (show):
         print("TFQMR: Linear solve not converged due to reach MAXIT "
-              "iterations {}".format(iter+1))
-    return (postprocess(x), maxiter)
+              f"iterations {(maxiter+even)//2}")
+    return (postprocess(x), (maxiter+even)//2)

--- a/scipy/sparse/linalg/_isolve/tfqmr.py
+++ b/scipy/sparse/linalg/_isolve/tfqmr.py
@@ -110,6 +110,10 @@ def tfqmr(A, b, x0=None, tol=1e-5, maxiter=None, M=None,
     ndofs = A.shape[0]
     if maxiter is None:
         maxiter = min(10000, ndofs * 10)
+
+    # "loops" is twice as "maxiter"
+    loops = maxiter * 2
+
     if x0 is None:
         x0 = x.copy()
 
@@ -132,7 +136,7 @@ def tfqmr(A, b, x0=None, tol=1e-5, maxiter=None, M=None,
     else:
         atol = max(atol, tol * r0norm)
 
-    for iter in range(maxiter):
+    for iter in range(loops):
         even = iter % 2 == 0
         if (even):
             vtrstar = np.inner(rstar.conjugate(), v)
@@ -152,11 +156,13 @@ def tfqmr(A, b, x0=None, tol=1e-5, maxiter=None, M=None,
         z = M.matvec(d)
         x += eta * z
 
-        if callback is not None:
+        if (callback is not None) and (not even):
             callback(x)
 
         # Convergence criterion
         if tau * np.sqrt(iter+2.) < atol:
+            if (callback is not None) and (even):
+                callback(x)
             if (show):
                 print("TFQMR: Linear solve converged due to reach TOL "
                       f"iterations {(iter+1+even)//2}")
@@ -177,5 +183,5 @@ def tfqmr(A, b, x0=None, tol=1e-5, maxiter=None, M=None,
 
     if (show):
         print("TFQMR: Linear solve not converged due to reach MAXIT "
-              f"iterations {(maxiter+even)//2}")
-    return (postprocess(x), (maxiter+even)//2)
+              f"iterations {maxiter}")
+    return (postprocess(x), maxiter)


### PR DESCRIPTION
…w in `tfqmr.edp`

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
Corrected the convergence criterion (`tau * np.sqrt(even+1) < atol` is a better choice) and the iteration number to print to screen. The latter should be half of the number of the `for ` loops.
#### Additional information
<!--Any additional information you think is important.-->