### PR TITLE
DOC: stats: add UNU.RAN references in the tutorial

### DIFF
--- a/doc/source/tutorial/stats/sampling.rst
+++ b/doc/source/tutorial/stats/sampling.rst
@@ -105,6 +105,8 @@ where
 * pmf: probability mass function
 
 
+For more details on the generators implemented in UNU.RAN, please refer to [2]_ and [3]_.
+
 Basic concepts of the Interface
 -------------------------------
 
@@ -289,3 +291,9 @@ References
 
 .. [1] Von Neumann, John. "13. various techniques used in connection with
        random digits." Appl. Math Ser 12.36-38 (1951): 3.
+
+.. [2] UNU.RAN User Manual, https://statmath.wu.ac.at/unuran/doc/unuran.html
+
+.. [3] Leydold, Josef, Wolfgang Hörmann, and Halis Sak. "An R Interface to
+       the UNU.RAN Library for Universal Random Variate Generators.",
+       https://cran.r-project.org/web/packages/Runuran/vignettes/Runuran.pdf


### PR DESCRIPTION
#### Reference issue

NA

#### What does this implement/fix?

This is a small PR that adds UNU.RAN user manual and their R vignette to the list of references. These are heavily referred to while writing the tutorial so it would be nice to credit the authors of both the documents.

#### Additional information

NA