### PR TITLE
DOC: clarify SciPy compatibility with Python and NumPy.

### DIFF
--- a/doc/source/dev/toolchain.rst
+++ b/doc/source/dev/toolchain.rst
@@ -67,19 +67,23 @@ SciPy attempts to be compatible with at least the 4 previous releases of NumPy.
 In particular, SciPy cannot rely on features of just the latest NumPy, but
 needs to be written using what is common in all of those 4 releases. [1]_, [3]_.
 
-The table shows the NumPy versions suitable for each major Python version
-(for SciPy 1.3.x unless otherwise stated).
+The table shows the NumPy versions suitable for each major Python version.
 
-=================  ========================    ===========================
- Python             Minimum NumPy version       Maximum NumPy version
-=================  ========================    ===========================
-2.7 (SciPy 1.2)      1.8.2                      1.16.x
-3.5 (SciPy 1.4)      1.13.3                     1.18.x
-3.6 (SciPy 1.5)      1.14.5                     1.19.x
-3.7                  1.16.5                     >= 1.20.x
-3.8                  1.17.3                     >= 1.20.x
-3.9                  1.19.3                     >= 1.20.x
-=================  ========================    ===========================
+=================  ========================    =======================
+ SciPy version      Python versions             NumPy versions
+=================  ========================    =======================
+ 1.2                2.7, >=3.4, <=3.7           >=1.8.2, <= 1.16.x
+ 1.4                >=3.5, <=3.8                >=1.13.3, <= 1.17.3
+ 1.5                >=3.6, <=3.9                >=1.14.5, <= 1.19.3
+ 1.6                >=3.7, <=3.9                >=1.16.5, <= 1.20.x
+ 1.7.0/1            >=3.7, <3.10                >=1.16.5, <1.23.0
+ 1.7.2-x            >=3.7, <3.11                >=1.16.5, <1.24.0
+ 1.8                >=3.8, <3.11                >=1.17.3, <1.24.0
+=================  ========================    =======================
+
+In specific cases, such as a particular architecture, these requirements
+could vary. Please check the release notes and the meta-package
+``oldest-supported-numpy`` for more info. [18]_, [19]_.
 
 
 Compilers
@@ -351,3 +355,5 @@ References
 .. [15] https://github.com/MacPython/scipy-wheels
 .. [16] https://docs.microsoft.com/en-gb/cpp/windows/universal-crt-deployment
 .. [17] https://discuss.python.org/t/toolchain-upgrade-on-windows/6377/4
+.. [18] https://scipy.github.io/devdocs/release.html
+.. [19] https://github.com/scipy/oldest-supported-numpy


### PR DESCRIPTION
#### Reference issue
Closes #14585

#### What does this implement/fix?
Add clearer information in the toolchain documentation about which version of Python and NumPy each version of SciPy supports.

I tried to make this right, but might have missed something. Please double check before merging.

[skip azp] [skip actions]