### PR TITLE
MAINT: report more accurate coverage results

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,4 +5,4 @@ omit =
     scipy/setup.py
     scipy/*/setup.py
     scipy/signal/_max_len_seq_inner.py
-disable_warnings = include-ignored
+    **/tests/**

--- a/scipy/_lib/_testutils.py
+++ b/scipy/_lib/_testutils.py
@@ -31,7 +31,6 @@ class PytestTester:
         import pytest
 
         module = sys.modules[self.module_name]
-        module_path = os.path.abspath(module.__path__[0])
 
         pytest_args = ['--showlocals', '--tb=short']
 
@@ -45,7 +44,7 @@ class PytestTester:
             pytest_args += ["-" + "v"*(int(verbose)-1)]
 
         if coverage:
-            pytest_args += ["--cov=" + module_path]
+            pytest_args += ["--cov"]
 
         if label == "fast":
             pytest_args += ["-m", "not slow"]


### PR DESCRIPTION
#### Reference issue

NA

#### What does this implement/fix?

The coverage results are significantly off because tests and a lot of third-party C/C++/FORTRAN libraries are checked for coverage. It would be nice to have a better idea of how much actual code is covered by tests. This is helpful because it:

- Makes it easier to discover untested code.
- Helps estimate how much does the pull request affect the overall coverage.
- Might help discover misplaced files (e.g. build utilities `_unuran_utils.py` and `_boost_utils.py` are misplaced under the `_lib` module while they should ideally be under `_build_utils`.)

One of the concerns might be the maintenance cost incurred by this: I think it should be fairly low because special files that need no testing (like code generators) either follow a common naming convention (e.g. `_generate_pyx`) or are rarely added so no new exemptions should be necessary in the future. Let me know if you think this is worth doing.

Apart from tests, we should also ignore:

- third-party C/C++/FORTRAN code/libraries: In most cases, we don't need to track how much third-party code is called by tests in SciPy. Most of these libraries are well-tested.
- code generators (e.g. `_generare_pyx.py`)
- maybe also exclude private modules (`_build_utils`)
- some files that have 0% coverage (data files, build utilities, etc). See the full coverage log below.

I will work more on this if others agree this is useful.

#### Additional information

<details>

<summary>Full coverage log</summary>

Module | statements | missing | excluded | branches | partial | coverage
-- | -- | -- | -- | -- | -- | --
Total | 63374 | 8666 | 0 | 24231 | 3078 | 84%
scipy/_build_utils/compiler_helper.py | 77 | 77 | 0 | 30 | 0 | 0%
scipy/_build_utils/tempita.py | 14 | 14 | 0 | 4 | 0 | 0%
scipy/_lib/_boost_utils.py | 5 | 5 | 0 | 0 | 0 | 0%
scipy/_lib/_unuran_utils.py | 5 | 5 | 0 | 0 | 0 | 0%
scipy/fft/_debug_backends.py | 13 | 13 | 0 | 0 | 0 | 0%
scipy/interpolate/_rbfinterp_pythran.py | 85 | 85 | 0 | 22 | 0 | 0%
scipy/interpolate/interpnd_info.py | 17 | 17 | 0 | 2 | 0 | 0%
scipy/linalg/_cython_signature_generator.py | 52 | 52 | 0 | 28 | 0 | 0%
scipy/linalg/_generate_pyx.py | 183 | 183 | 0 | 82 | 0 | 0%
scipy/optimize/_group_columns.py | 57 | 57 | 0 | 36 | 0 | 0%
scipy/signal/_spectral.py | 32 | 32 | 0 | 8 | 0 | 0%
scipy/signal/spline.py | 10 | 10 | 0 | 2 | 0 | 0%
scipy/sparse/generate_sparsetools.py | 132 | 132 | 0 | 54 | 0 | 0%
scipy/sparse/linalg/eigen/_svds_doc.py | 4 | 4 | 0 | 0 | 0 | 0%
scipy/sparse/sparsetools.py | 10 | 10 | 0 | 0 | 0 | 0%
scipy/special/_generate_pyx.py | 750 | 750 | 0 | 310 | 0 | 0%
scipy/special/_precompute/cosine_cdf.py | 10 | 10 | 0 | 4 | 0 | 0%
scipy/special/_precompute/hyp2f1_data.py | 95 | 95 | 0 | 40 | 0 | 0%
scipy/special/_precompute/lambertw.py | 48 | 48 | 0 | 10 | 0 | 0%
scipy/special/_precompute/loggamma.py | 30 | 30 | 0 | 10 | 0 | 0%
scipy/special/_precompute/struve_convergence.py | 58 | 58 | 0 | 8 | 0 | 0%
scipy/special/_precompute/wright_bessel.py | 178 | 178 | 0 | 52 | 0 | 0%
scipy/special/_precompute/wright_bessel_data.py | 82 | 82 | 0 | 14 | 0 | 0%
scipy/special/_precompute/wrightomega.py | 29 | 29 | 0 | 6 | 0 | 0%
scipy/special/_precompute/zetac.py | 19 | 19 | 0 | 6 | 0 | 0%
scipy/special/add_newdocs.py | 263 | 263 | 0 | 0 | 0 | 0%
scipy/special/basic.py | 3 | 3 | 0 | 0 | 0 | 0%
scipy/stats/_generate_pyx.py | 28 | 28 | 0 | 4 | 0 | 0%
scipy/stats/_hypotests_pythran.py | 25 | 25 | 0 | 12 | 0 | 0%
scipy/stats/_result_classes.py | 4 | 4 | 0 | 0 | 0 | 0%
scipy/_build_utils/system_info.py | 124 | 116 | 0 | 64 | 1 | 5%
scipy/_build_utils/_fortran.py | 189 | 167 | 0 | 72 | 0 | 8%
scipy/sparse/linalg/eigen/_svds.py | 97 | 84 | 0 | 36 | 0 | 10%
scipy/stats/_wilcoxon_data.py | 29 | 24 | 0 | 12 | 0 | 12%
scipy/special/_precompute/expn_asy.py | 31 | 22 | 0 | 12 | 1 | 23%
scipy/special/_precompute/utils.py | 20 | 13 | 0 | 8 | 0 | 25%
scipy/__config__.py | 40 | 26 | 0 | 18 | 1 | 26%
scipy/special/_precompute/gammainc_data.py | 63 | 43 | 0 | 10 | 1 | 29%
scipy/special/_precompute/gammainc_asy.py | 66 | 42 | 0 | 26 | 1 | 34%
scipy/ndimage/filters.py | 10 | 5 | 0 | 2 | 0 | 42%
scipy/ndimage/fourier.py | 10 | 5 | 0 | 2 | 0 | 42%
scipy/ndimage/interpolation.py | 10 | 5 | 0 | 2 | 0 | 42%
scipy/ndimage/measurements.py | 10 | 5 | 0 | 2 | 0 | 42%
scipy/ndimage/morphology.py | 10 | 5 | 0 | 2 | 0 | 42%
scipy/_lib/_testutils.py | 76 | 37 | 0 | 30 | 5 | 43%
scipy/misc/common.py | 72 | 33 | 0 | 34 | 6 | 44%
scipy/_lib/_uarray/_backend.py | 163 | 80 | 0 | 35 | 3 | 47%
scipy/special/_mptestutils.py | 287 | 133 | 0 | 104 | 27 | 51%
scipy/_lib/decorator.py | 235 | 101 | 0 | 100 | 19 | 53%
scipy/optimize/_linprog_doc.py | 13 | 6 | 0 | 0 | 0 | 54%
scipy/signal/waveforms.py | 118 | 55 | 0 | 48 | 8 | 55%
scipy/_build_utils/__init__.py | 18 | 8 | 0 | 0 | 0 | 56%
scipy/_lib/uarray.py | 14 | 6 | 0 | 2 | 1 | 56%
scipy/fft/_basic.py | 64 | 23 | 0 | 2 | 0 | 62%
scipy/optimize/_linprog.py | 96 | 35 | 0 | 34 | 2 | 62%
scipy/odr/odrpack.py | 353 | 109 | 0 | 198 | 35 | 63%
scipy/_lib/_docscrape.py | 441 | 126 | 0 | 214 | 48 | 64%
scipy/ndimage/_fourier.py | 71 | 17 | 0 | 30 | 7 | 64%
scipy/sparse/csgraph/_validation.py | 30 | 9 | 0 | 18 | 5 | 67%
scipy/sparse/linalg/isolve/lsqr.py | 205 | 60 | 0 | 76 | 15 | 67%
scipy/_lib/_pep440.py | 198 | 55 | 0 | 88 | 7 | 69%
scipy/integrate/quadpack.py | 198 | 51 | 0 | 106 | 12 | 69%
scipy/special/_basic.py | 523 | 129 | 0 | 250 | 86 | 70%
scipy/fft/_realtransforms.py | 28 | 8 | 0 | 0 | 0 | 71%
scipy/optimize/_shgo_lib/triangulation.py | 359 | 86 | 0 | 142 | 11 | 71%
scipy/sparse/linalg/dsolve/linsolve.py | 207 | 55 | 0 | 104 | 18 | 71%
scipy/interpolate/_fitpack_impl.py | 413 | 96 | 0 | 230 | 64 | 72%
scipy/optimize/_root_scalar.py | 123 | 29 | 0 | 68 | 16 | 73%
scipy/optimize/nonlin.py | 629 | 137 | 0 | 250 | 36 | 73%
scipy/fft/_backend.py | 33 | 8 | 0 | 6 | 2 | 74%
scipy/io/harwell_boeing/hb.py | 264 | 50 | 0 | 88 | 32 | 74%
scipy/_lib/deprecation.py | 44 | 7 | 0 | 12 | 7 | 75%
scipy/optimize/_lsq/lsq_linear.py | 81 | 17 | 0 | 56 | 17 | 75%
scipy/stats/mstats_extras.py | 157 | 33 | 0 | 42 | 7 | 75%
scipy/io/arff/arffread.py | 373 | 87 | 0 | 135 | 17 | 76%
scipy/io/idl.py | 426 | 88 | 0 | 236 | 28 | 76%
scipy/optimize/_trustregion_krylov.py | 11 | 2 | 0 | 6 | 2 | 76%
scipy/_lib/_ccallback.py | 98 | 20 | 0 | 38 | 7 | 77%
scipy/linalg/matfuncs.py | 138 | 26 | 0 | 46 | 8 | 77%
scipy/linalg/decomp_cholesky.py | 71 | 12 | 0 | 32 | 11 | 78%
scipy/linalg/lapack.py | 76 | 11 | 0 | 30 | 6 | 78%
scipy/optimize/tnc.py | 96 | 20 | 0 | 34 | 7 | 78%
scipy/sparse/linalg/isolve/minres.py | 202 | 43 | 0 | 78 | 15 | 78%
scipy/io/mmio.py | 459 | 87 | 0 | 279 | 28 | 79%
scipy/optimize/_hessian_update_strategy.py | 133 | 24 | 0 | 50 | 7 | 79%
scipy/optimize/_nnls.py | 20 | 3 | 0 | 8 | 3 | 79%
scipy/optimize/_tstutils.py | 205 | 33 | 0 | 52 | 7 | 79%
scipy/sparse/linalg/isolve/lsmr.py | 184 | 37 | 0 | 56 | 9 | 79%
scipy/conftest.py | 35 | 5 | 0 | 10 | 4 | 80%
scipy/integrate/_quadrature.py | 326 | 55 | 0 | 108 | 21 | 80%
scipy/linalg/decomp_lu.py | 47 | 7 | 0 | 22 | 7 | 80%
scipy/optimize/cobyla.py | 81 | 12 | 0 | 32 | 7 | 80%
scipy/linalg/_decomp_polar.py | 15 | 2 | 0 | 6 | 2 | 81%
scipy/cluster/hierarchy.py | 788 | 117 | 0 | 388 | 80 | 82%
scipy/io/harwell_boeing/_fortran_format_parser.py | 163 | 25 | 0 | 52 | 4 | 82%
scipy/ndimage/_interpolation.py | 268 | 40 | 0 | 127 | 30 | 82%
scipy/optimize/_lsq/trf_linear.py | 143 | 20 | 0 | 50 | 10 | 82%
scipy/optimize/_root.py | 88 | 15 | 0 | 34 | 5 | 82%
scipy/optimize/_trustregion_constr/projections.py | 163 | 27 | 0 | 44 | 6 | 82%
scipy/optimize/slsqp.py | 193 | 38 | 0 | 82 | 8 | 82%
scipy/sparse/linalg/eigen/arpack/arpack.py | 638 | 89 | 0 | 348 | 85 | 82%
scipy/stats/kde.py | 180 | 25 | 0 | 62 | 15 | 82%
scipy/__init__.py | 61 | 9 | 0 | 14 | 4 | 83%
scipy/fftpack/pseudo_diffs.py | 211 | 26 | 0 | 106 | 15 | 83%
scipy/interpolate/fitpack2.py | 450 | 63 | 0 | 210 | 31 | 83%
scipy/interpolate/rbf.py | 97 | 11 | 0 | 46 | 9 | 83%
scipy/linalg/_decomp_qz.py | 119 | 14 | 0 | 54 | 15 | 83%
scipy/linalg/flinalg.py | 29 | 4 | 0 | 12 | 1 | 83%
scipy/spatial/_plotutils.py | 77 | 9 | 0 | 26 | 7 | 83%
scipy/interpolate/_pade.py | 26 | 3 | 0 | 12 | 3 | 84%
scipy/io/_fortran.py | 78 | 10 | 0 | 44 | 10 | 84%
scipy/optimize/_basinhopping.py | 222 | 33 | 0 | 80 | 13 | 84%
scipy/optimize/minpack.py | 283 | 42 | 0 | 124 | 20 | 84%
scipy/sparse/linalg/isolve/utils.py | 55 | 7 | 0 | 28 | 6 | 84%
scipy/linalg/_interpolative_backend.py | 285 | 27 | 0 | 46 | 21 | 85%
scipy/linalg/_solvers.py | 215 | 21 | 0 | 90 | 26 | 85%
scipy/linalg/basic.py | 418 | 47 | 0 | 210 | 46 | 85%
scipy/optimize/_dual_annealing.py | 283 | 31 | 0 | 108 | 15 | 85%
scipy/optimize/_trustregion.py | 153 | 20 | 0 | 62 | 10 | 85%
scipy/optimize/zeros.py | 464 | 55 | 0 | 200 | 41 | 85%
scipy/sparse/bsr.py | 319 | 34 | 0 | 112 | 17 | 85%
scipy/special/_testutils.py | 180 | 25 | 0 | 80 | 10 | 85%
scipy/_lib/_util.py | 204 | 28 | 0 | 102 | 9 | 86%
scipy/linalg/decomp_schur.py | 102 | 10 | 0 | 66 | 13 | 86%
scipy/optimize/_spectral.py | 105 | 9 | 0 | 32 | 10 | 86%
scipy/stats/mstats_basic.py | 968 | 98 | 0 | 380 | 61 | 86%
scipy/integrate/odepack.py | 31 | 4 | 0 | 14 | 2 | 87%
scipy/linalg/_procrustes.py | 17 | 2 | 0 | 6 | 1 | 87%
scipy/ndimage/_measurements.py | 318 | 33 | 0 | 156 | 24 | 87%
scipy/ndimage/_morphology.py | 413 | 44 | 0 | 234 | 37 | 87%
scipy/optimize/optimize.py | 1352 | 163 | 0 | 560 | 66 | 87%
scipy/signal/_arraytools.py | 48 | 4 | 0 | 12 | 4 | 87%
scipy/signal/lti_conversion.py | 159 | 17 | 0 | 64 | 11 | 87%
scipy/sparse/linalg/_onenormest.py | 198 | 20 | 0 | 95 | 12 | 87%
scipy/sparse/linalg/interface.py | 346 | 30 | 0 | 116 | 30 | 87%
scipy/stats/_ksstats.py | 308 | 33 | 0 | 134 | 22 | 87%
scipy/_lib/doccer.py | 96 | 10 | 0 | 40 | 7 | 88%
scipy/cluster/vq.py | 152 | 15 | 0 | 54 | 10 | 88%
scipy/fft/_helper.py | 8 | 1 | 0 | 0 | 0 | 88%
scipy/fftpack/helper.py | 18 | 2 | 0 | 6 | 1 | 88%
scipy/integrate/_ode.py | 509 | 51 | 0 | 156 | 29 | 88%
scipy/interpolate/interpolate.py | 926 | 88 | 0 | 439 | 62 | 88%
scipy/linalg/decomp_svd.py | 86 | 7 | 0 | 34 | 5 | 88%
scipy/optimize/_lsq/common.py | 294 | 27 | 0 | 88 | 5 | 88%
scipy/optimize/_minimize.py | 169 | 19 | 0 | 132 | 12 | 88%
scipy/signal/_savitzky_golay.py | 80 | 7 | 0 | 34 | 7 | 88%
scipy/sparse/_index.py | 248 | 34 | 0 | 144 | 7 | 88%
scipy/sparse/base.py | 454 | 48 | 0 | 196 | 22 | 88%
scipy/stats/_stats_mstats_common.py | 111 | 10 | 0 | 44 | 8 | 88%
scipy/linalg/decomp.py | 385 | 32 | 0 | 200 | 20 | 89%
scipy/misc/doccer.py | 27 | 3 | 0 | 0 | 0 | 89%
scipy/optimize/_lsq/trf.py | 287 | 22 | 0 | 106 | 21 | 89%
scipy/optimize/_trustregion_ncg.py | 50 | 4 | 0 | 14 | 3 | 89%
scipy/sparse/_matrix_io.py | 37 | 4 | 0 | 16 | 2 | 89%
scipy/sparse/data.py | 183 | 16 | 0 | 72 | 8 | 89%
scipy/sparse/dok.py | 273 | 27 | 0 | 116 | 9 | 89%
scipy/sparse/linalg/_expm_multiply.py | 254 | 20 | 0 | 119 | 21 | 89%
scipy/sparse/linalg/eigen/lobpcg/lobpcg.py | 322 | 31 | 0 | 130 | 17 | 89%
scipy/sparse/linalg/isolve/tfqmr.py | 69 | 6 | 0 | 30 | 5 | 89%
scipy/sparse/linalg/matfuncs.py | 357 | 26 | 0 | 150 | 24 | 89%
scipy/sparse/spfuncs.py | 45 | 4 | 0 | 28 | 4 | 89%
scipy/sparse/sputils.py | 173 | 15 | 0 | 92 | 9 | 89%
scipy/special/spfun_stats.py | 13 | 1 | 0 | 6 | 1 | 89%
scipy/stats/_continuous_distns.py | 3524 | 279 | 0 | 684 | 89 | 89%
scipy/io/matlab/mio5.py | 398 | 29 | 0 | 140 | 15 | 90%
scipy/linalg/_matfuncs_inv_ssq.py | 350 | 30 | 0 | 170 | 20 | 90%
scipy/ndimage/_filters.py | 462 | 36 | 0 | 220 | 34 | 90%
scipy/signal/ltisys.py | 916 | 70 | 0 | 364 | 49 | 90%
scipy/signal/spectral.py | 364 | 29 | 0 | 228 | 22 | 90%
scipy/spatial/distance.py | 661 | 44 | 0 | 256 | 35 | 90%
scipy/version.py | 8 | 0 | 0 | 2 | 1 | 90%
scipy/constants/codata.py | 100 | 7 | 0 | 40 | 3 | 91%
scipy/interpolate/_bsplines.py | 402 | 25 | 0 | 163 | 25 | 91%
scipy/interpolate/ndgriddata.py | 46 | 3 | 0 | 18 | 3 | 91%
scipy/interpolate/polyint.py | 203 | 11 | 0 | 64 | 8 | 91%
scipy/io/matlab/mio4.py | 279 | 14 | 0 | 86 | 18 | 91%
scipy/linalg/_expm_frechet.py | 152 | 8 | 0 | 36 | 8 | 91%
scipy/linalg/blas.py | 102 | 7 | 0 | 42 | 4 | 91%
scipy/linalg/interpolative.py | 180 | 14 | 0 | 118 | 13 | 91%
scipy/optimize/_constraints.py | 183 | 13 | 0 | 80 | 7 | 91%
scipy/optimize/_differentiable_functions.py | 359 | 29 | 0 | 102 | 14 | 91%
scipy/optimize/_linprog_ip.py | 252 | 20 | 0 | 72 | 9 | 91%
scipy/optimize/_lsq/bvls.py | 117 | 6 | 0 | 30 | 7 | 91%
scipy/signal/__init__.py | 43 | 2 | 0 | 12 | 3 | 91%
scipy/signal/filter_design.py | 1252 | 82 | 0 | 512 | 60 | 91%
scipy/signal/wavelets.py | 141 | 8 | 0 | 52 | 8 | 91%
scipy/sparse/compressed.py | 743 | 46 | 0 | 286 | 34 | 91%
scipy/spatial/kdtree.py | 152 | 11 | 0 | 42 | 4 | 91%
scipy/io/matlab/mio.py | 64 | 3 | 0 | 24 | 4 | 92%
scipy/io/matlab/miobase.py | 107 | 9 | 0 | 28 | 2 | 92%
scipy/linalg/_matfuncs_sqrtm.py | 76 | 4 | 0 | 28 | 4 | 92%
scipy/linalg/decomp_qr.py | 129 | 8 | 0 | 70 | 8 | 92%
scipy/optimize/_trustregion_constr/minimize_trustregion_constr.py | 174 | 9 | 0 | 100 | 13 | 92%
scipy/signal/signaltools.py | 1176 | 77 | 0 | 591 | 60 | 92%
scipy/sparse/coo.py | 293 | 16 | 0 | 102 | 14 | 92%
scipy/sparse/lil.py | 290 | 21 | 0 | 112 | 10 | 92%
scipy/stats/_multivariate.py | 1254 | 66 | 0 | 374 | 54 | 92%
scipy/stats/_relative_risk.py | 57 | 3 | 0 | 22 | 3 | 92%
scipy/integrate/_bvp.py | 377 | 17 | 0 | 126 | 12 | 93%
scipy/integrate/_ivp/base.py | 98 | 6 | 0 | 28 | 3 | 93%
scipy/integrate/_ivp/lsoda.py | 57 | 2 | 0 | 14 | 3 | 93%
scipy/integrate/_quad_vec.py | 264 | 15 | 0 | 100 | 7 | 93%
scipy/interpolate/fitpack.py | 64 | 4 | 0 | 22 | 2 | 93%
scipy/io/matlab/byteordercodes.py | 18 | 1 | 0 | 10 | 1 | 93%
scipy/linalg/_decomp_cossin.py | 81 | 4 | 0 | 32 | 4 | 93%
scipy/optimize/_linprog_rs.py | 195 | 12 | 0 | 48 | 6 | 93%
scipy/optimize/_numdiff.py | 274 | 11 | 0 | 106 | 14 | 93%
scipy/optimize/_remove_redundancy.py | 173 | 10 | 0 | 42 | 2 | 93%
scipy/optimize/_trustregion_constr/qp_subproblem.py | 214 | 11 | 0 | 78 | 7 | 93%
scipy/optimize/_trustregion_constr/tr_interior_point.py | 147 | 5 | 0 | 20 | 6 | 93%
scipy/sparse/dia.py | 244 | 12 | 0 | 76 | 8 | 93%
scipy/sparse/linalg/isolve/lgmres.py | 67 | 4 | 0 | 32 | 3 | 93%
scipy/stats/_binned_statistic.py | 170 | 9 | 0 | 78 | 8 | 93%
scipy/stats/_binomtest.py | 120 | 8 | 0 | 68 | 3 | 93%
scipy/stats/_distn_infrastructure.py | 1490 | 81 | 0 | 503 | 45 | 93%
scipy/stats/_hypotests.py | 330 | 22 | 0 | 100 | 5 | 93%
scipy/stats/stats.py | 1923 | 105 | 0 | 831 | 77 | 93%
scipy/integrate/_ivp/common.py | 213 | 9 | 0 | 62 | 6 | 94%
scipy/io/netcdf.py | 481 | 20 | 0 | 162 | 19 | 94%
scipy/linalg/misc.py | 37 | 2 | 0 | 26 | 2 | 94%
scipy/ndimage/_ni_support.py | 51 | 3 | 0 | 36 | 2 | 94%
scipy/optimize/_lsq/least_squares.py | 255 | 12 | 0 | 140 | 11 | 94%
scipy/optimize/_trustregion_constr/canonical_constraint.py | 253 | 12 | 0 | 54 | 6 | 94%
scipy/sparse/construct.py | 246 | 12 | 0 | 104 | 8 | 94%
scipy/special/orthogonal.py | 520 | 23 | 0 | 260 | 22 | 94%
scipy/stats/morestats.py | 873 | 50 | 0 | 391 | 25 | 94%
scipy/_lib/_bunch.py | 72 | 3 | 0 | 30 | 2 | 95%
scipy/_lib/_gcutils.py | 31 | 1 | 0 | 8 | 1 | 95%
scipy/constants/__init__.py | 12 | 0 | 0 | 8 | 1 | 95%
scipy/fft/_pocketfft/realtransforms.py | 64 | 2 | 0 | 22 | 2 | 95%
scipy/fftpack/basic.py | 21 | 1 | 0 | 0 | 0 | 95%
scipy/linalg/special_matrices.py | 246 | 9 | 0 | 124 | 8 | 95%
scipy/optimize/_linprog_util.py | 486 | 20 | 0 | 202 | 16 | 95%
scipy/optimize/_lsq/dogbox.py | 147 | 4 | 0 | 42 | 5 | 95%
scipy/optimize/lbfgsb.py | 133 | 4 | 0 | 50 | 5 | 95%
scipy/sparse/csr.py | 133 | 5 | 0 | 34 | 4 | 95%
scipy/sparse/linalg/isolve/iterative.py | 420 | 10 | 0 | 212 | 22 | 95%
scipy/integrate/_ivp/bdf.py | 244 | 6 | 0 | 64 | 6 | 96%
scipy/integrate/_ivp/ivp.py | 161 | 5 | 0 | 94 | 5 | 96%
scipy/integrate/_ivp/radau.py | 261 | 6 | 0 | 70 | 6 | 96%
scipy/io/matlab/mio5_params.py | 76 | 3 | 0 | 6 | 0 | 96%
scipy/io/wavfile.py | 478 | 13 | 0 | 106 | 13 | 96%
scipy/optimize/_differentialevolution.py | 382 | 9 | 0 | 144 | 12 | 96%
scipy/optimize/_shgo.py | 610 | 6 | 0 | 274 | 25 | 96%
scipy/optimize/_trustregion_dogleg.py | 39 | 1 | 0 | 12 | 1 | 96%
scipy/optimize/linesearch.py | 301 | 9 | 0 | 94 | 8 | 96%
scipy/sparse/csc.py | 85 | 2 | 0 | 16 | 2 | 96%
scipy/special/_logsumexp.py | 47 | 1 | 0 | 20 | 2 | 96%
scipy/stats/_qmc.py | 394 | 13 | 0 | 136 | 6 | 96%
scipy/stats/_rvs_sampling.py | 126 | 3 | 0 | 34 | 4 | 96%
scipy/_lib/_threadsafety.py | 32 | 0 | 0 | 4 | 1 | 97%
scipy/constants/constants.py | 141 | 2 | 0 | 16 | 2 | 97%
scipy/interpolate/_rbfinterp.py | 121 | 2 | 0 | 54 | 4 | 97%
scipy/linalg/_decomp_ldl.py | 84 | 2 | 0 | 34 | 2 | 97%
scipy/odr/models.py | 90 | 1 | 0 | 4 | 2 | 97%
scipy/optimize/_trustregion_exact.py | 138 | 3 | 0 | 36 | 3 | 97%
scipy/sparse/linalg/_norm.py | 69 | 2 | 0 | 46 | 2 | 97%
scipy/spatial/_geometric_slerp.py | 52 | 1 | 0 | 26 | 1 | 97%
scipy/spatial/transform/_rotation_groups.py | 56 | 1 | 0 | 20 | 1 | 97%
scipy/stats/_axis_nan_policy.py | 153 | 4 | 0 | 87 | 4 | 97%
scipy/stats/_mannwhitneyu.py | 117 | 2 | 0 | 38 | 3 | 97%
scipy/_lib/_disjoint_set.py | 65 | 1 | 0 | 22 | 1 | 98%
scipy/signal/_peak_finding.py | 223 | 2 | 0 | 108 | 4 | 98%
scipy/signal/bsplines.py | 200 | 3 | 0 | 66 | 3 | 98%
scipy/signal/fir_filter_design.py | 270 | 3 | 0 | 142 | 6 | 98%
scipy/sparse/linalg/isolve/_gcrotmk.py | 190 | 2 | 0 | 98 | 4 | 98%
scipy/spatial/transform/_rotation_spline.py | 178 | 2 | 0 | 28 | 2 | 98%
scipy/stats/_entropy.py | 88 | 1 | 0 | 22 | 1 | 98%
scipy/stats/_page_trend_test.py | 96 | 1 | 0 | 36 | 1 | 98%
scipy/integrate/_ivp/rk.py | 191 | 1 | 0 | 34 | 1 | 99%
scipy/interpolate/_cubic.py | 260 | 2 | 0 | 92 | 2 | 99%
scipy/optimize/_linprog_simplex.py | 107 | 1 | 0 | 47 | 1 | 99%
scipy/optimize/_qap.py | 204 | 1 | 0 | 92 | 3 | 99%
scipy/signal/windows/windows.py | 299 | 2 | 0 | 110 | 2 | 99%
scipy/stats/_bootstrap.py | 146 | 1 | 0 | 48 | 1 | 99%
scipy/stats/_discrete_distns.py | 588 | 1 | 0 | 44 | 2 | 99%
scipy/_distributor_init.py | 0 | 0 | 0 | 0 | 0 | 100%
scipy/_lib/__init__.py | 3 | 0 | 0 | 0 | 0 | 100%
scipy/_lib/_tmpdirs.py | 26 | 0 | 0 | 2 | 0 | 100%
scipy/_lib/_uarray/__init__.py | 2 | 0 | 0 | 0 | 0 | 100%
scipy/cluster/__init__.py | 5 | 0 | 0 | 0 | 0 | 100%
scipy/fft/__init__.py | 11 | 0 | 0 | 0 | 0 | 100%
scipy/fft/_fftlog.py | 76 | 0 | 0 | 16 | 0 | 100%
scipy/fft/_pocketfft/__init__.py | 6 | 0 | 0 | 0 | 0 | 100%
scipy/fft/_pocketfft/basic.py | 156 | 0 | 0 | 58 | 0 | 100%
scipy/fft/_pocketfft/helper.py | 107 | 0 | 0 | 58 | 0 | 100%
scipy/fftpack/__init__.py | 8 | 0 | 0 | 0 | 0 | 100%
scipy/fftpack/realtransforms.py | 28 | 0 | 0 | 0 | 0 | 100%
scipy/integrate/__init__.py | 11 | 0 | 0 | 2 | 0 | 100%
scipy/integrate/_ivp/__init__.py | 7 | 0 | 0 | 0 | 0 | 100%
scipy/integrate/_ivp/dop853_coefficients.py | 152 | 0 | 0 | 0 | 0 | 100%
scipy/interpolate/__init__.py | 15 | 0 | 0 | 2 | 0 | 100%
scipy/io/__init__.py | 11 | 0 | 0 | 2 | 0 | 100%
scipy/io/arff/__init__.py | 6 | 0 | 0 | 0 | 0 | 100%
scipy/io/harwell_boeing/__init__.py | 1 | 0 | 0 | 0 | 0 | 100%
scipy/io/matlab/__init__.py | 6 | 0 | 0 | 0 | 0 | 100%
scipy/linalg/__init__.py | 24 | 0 | 0 | 2 | 0 | 100%
scipy/linalg/_sketches.py | 14 | 0 | 0 | 0 | 0 | 100%
scipy/linalg/_testutils.py | 39 | 0 | 0 | 18 | 0 | 100%
scipy/misc/__init__.py | 9 | 0 | 0 | 0 | 0 | 100%
scipy/ndimage/__init__.py | 15 | 0 | 0 | 2 | 0 | 100%
scipy/ndimage/_ni_docstrings.py | 19 | 0 | 0 | 0 | 0 | 100%
scipy/odr/__init__.py | 7 | 0 | 0 | 2 | 0 | 100%
scipy/odr/_add_newdocs.py | 3 | 0 | 0 | 0 | 0 | 100%
scipy/optimize/__init__.py | 26 | 0 | 0 | 2 | 0 | 100%
scipy/optimize/_highs/__init__.py | 0 | 0 | 0 | 0 | 0 | 100%
scipy/optimize/_linprog_highs.py | 64 | 0 | 0 | 10 | 0 | 100%
scipy/optimize/_lsap.py | 4 | 0 | 0 | 0 | 0 | 100%
scipy/optimize/_lsq/__init__.py | 3 | 0 | 0 | 0 | 0 | 100%
scipy/optimize/_shgo_lib/__init__.py | 0 | 0 | 0 | 0 | 0 | 100%
scipy/optimize/_trlib/__init__.py | 6 | 0 | 0 | 0 | 0 | 100%
scipy/optimize/_trustregion_constr/__init__.py | 2 | 0 | 0 | 0 | 0 | 100%
scipy/optimize/_trustregion_constr/equality_constrained_sqp.py | 104 | 0 | 0 | 24 | 0 | 100%
scipy/optimize/_trustregion_constr/report.py | 32 | 0 | 0 | 6 | 0 | 100%
scipy/optimize/cython_optimize/__init__.py | 0 | 0 | 0 | 0 | 0 | 100%
scipy/signal/_max_len_seq.py | 31 | 0 | 0 | 16 | 0 | 100%
scipy/signal/_upfirdn.py | 41 | 0 | 0 | 4 | 0 | 100%
scipy/signal/windows/__init__.py | 2 | 0 | 0 | 0 | 0 | 100%
scipy/sparse/__init__.py | 18 | 0 | 0 | 2 | 0 | 100%
scipy/sparse/csgraph/__init__.py | 13 | 0 | 0 | 0 | 0 | 100%
scipy/sparse/csgraph/_laplacian.py | 50 | 0 | 0 | 14 | 0 | 100%
scipy/sparse/extract.py | 21 | 0 | 0 | 0 | 0 | 100%
scipy/sparse/linalg/__init__.py | 12 | 0 | 0 | 2 | 0 | 100%
scipy/sparse/linalg/dsolve/__init__.py | 7 | 0 | 0 | 2 | 0 | 100%
scipy/sparse/linalg/dsolve/_add_newdocs.py | 9 | 0 | 0 | 0 | 0 | 100%
scipy/sparse/linalg/eigen/__init__.py | 7 | 0 | 0 | 2 | 0 | 100%
scipy/sparse/linalg/eigen/arpack/__init__.py | 1 | 0 | 0 | 0 | 0 | 100%
scipy/sparse/linalg/eigen/lobpcg/__init__.py | 5 | 0 | 0 | 2 | 0 | 100%
scipy/sparse/linalg/isolve/__init__.py | 11 | 0 | 0 | 2 | 0 | 100%
scipy/spatial/__init__.py | 13 | 0 | 0 | 2 | 0 | 100%
scipy/spatial/_procrustes.py | 24 | 0 | 0 | 8 | 0 | 100%
scipy/spatial/_spherical_voronoi.py | 81 | 0 | 0 | 24 | 0 | 100%
scipy/spatial/transform/__init__.py | 6 | 0 | 0 | 0 | 0 | 100%
scipy/special/__init__.py | 16 | 0 | 0 | 0 | 0 | 100%
scipy/special/_ellip_harm.py | 15 | 0 | 0 | 0 | 0 | 100%
scipy/special/_lambertw.py | 3 | 0 | 0 | 0 | 0 | 100%
scipy/special/_precompute/__init__.py | 0 | 0 | 0 | 0 | 0 | 100%
scipy/special/_spherical_bessel.py | 17 | 0 | 0 | 8 | 0 | 100%
scipy/special/sf_error.py | 6 | 0 | 0 | 0 | 0 | 100%
scipy/stats/__init__.py | 22 | 0 | 0 | 2 | 0 | 100%
scipy/stats/_boost/__init__.py | 4 | 0 | 0 | 0 | 0 | 100%
scipy/stats/_common.py | 3 | 0 | 0 | 0 | 0 | 100%
scipy/stats/_constants.py | 9 | 0 | 0 | 0 | 0 | 100%
scipy/stats/_crosstab.py | 37 | 0 | 0 | 23 | 0 | 100%
scipy/stats/_distr_params.py | 5 | 0 | 0 | 0 | 0 | 100%
scipy/stats/_tukeylambda_stats.py | 53 | 0 | 0 | 8 | 0 | 100%
scipy/stats/_unuran/__init__.py | 1 | 0 | 0 | 0 | 0 | 100%
scipy/stats/contingency.py | 58 | 0 | 0 | 24 | 0 | 100%
scipy/stats/distributions.py | 9 | 0 | 0 | 0 | 0 | 100%
scipy/stats/mstats.py | 3 | 0 | 0 | 0 | 0 | 100%
scipy/stats/qmc.py | 2 | 0 | 0 | 0 | 0 | 100%

</div>

</details>