### PR TITLE
MAINT: remove support for Python 3.7 (hence NumPy 1.16)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,14 +5,14 @@ _defaults: &defaults
   docker:
     # CircleCI maintains a library of pre-built images
     # documented at https://circleci.com/docs/2.0/circleci-images/
-    - image: circleci/python:3.7.0
+    - image: cimg/python:3.8
   working_directory: ~/repo
 
 _debian: &debian
   name: install Debian dependencies
   command: |
     sudo apt-get update
-    sudo apt-get install libatlas-dev libatlas-base-dev liblapack-dev gfortran libgmp-dev libmpfr-dev libfreetype6-dev libpng-dev zlib1g zlib1g-dev texlive-fonts-recommended texlive-latex-recommended texlive-latex-extra texlive-generic-extra latexmk texlive-xetex fonts-freefont-otf
+    sudo apt-get install libatlas-base-dev liblapack-dev gfortran libgmp-dev libmpfr-dev libfreetype6-dev libpng-dev zlib1g zlib1g-dev texlive-fonts-recommended texlive-latex-recommended texlive-latex-extra texlive-plain-generic latexmk texlive-xetex fonts-freefont-otf
 
 jobs:
 # Build SciPy from source
@@ -115,7 +115,7 @@ jobs:
             . venv/bin/activate
             pip install --upgrade pip
             pip install pyfftw cffi pytest
-            export PYTHONPATH=$PWD/build/testenv/lib/python3.7/site-packages
+            export PYTHONPATH=$PWD/build/testenv/lib/python3.8/site-packages
             cd benchmarks
             asv machine --machine CircleCI
             export SCIPY_GLOBAL_BENCH_NUMTRIALS=1

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -11,8 +11,8 @@ on:
       - maintenance/**
 
 jobs:
-  Python-37-dbg:
-    name: Python 3.7-dbg
+  Python-38-dbg:
+    name: Python 3.8-dbg
     if: "github.repository == 'scipy/scipy' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
     runs-on: ubuntu-18.04
     steps:
@@ -22,9 +22,9 @@ jobs:
       - name: Configuring Test Environment
         run: |
           sudo apt-get update
-          sudo apt install python3.7-dbg python3.7-dev libatlas-base-dev liblapack-dev gfortran libgmp-dev libmpfr-dev libsuitesparse-dev ccache swig libmpc-dev
+          sudo apt install python3.8-dbg python3.8-dev libatlas-base-dev liblapack-dev gfortran libgmp-dev libmpfr-dev libsuitesparse-dev ccache swig libmpc-dev
           free -m
-          python3.7-dbg --version # just to check
+          python3.8-dbg --version # just to check
           export NPY_NUM_BUILD_JOBS=2
           uname -a
           df -h
@@ -34,19 +34,19 @@ jobs:
           cd builds
       - name: Installing packages
         run: |      
-          python3.7-dbg -c 'import sys; print("Python debug build:", hasattr(sys, "gettotalrefcount"))'
-          python3.7-dbg -m pip install --upgrade pip setuptools wheel
-          python3.7-dbg -m pip install --upgrade numpy cython pytest pytest-xdist pybind11
-          python3.7-dbg -m pip install --upgrade mpmath gmpy2 pythran
-          python3.7-dbg -m pip uninstall -y nose
+          python3.8-dbg -c 'import sys; print("Python debug build:", hasattr(sys, "gettotalrefcount"))'
+          python3.8-dbg -m pip install --upgrade pip setuptools wheel
+          python3.8-dbg -m pip install --upgrade numpy cython pytest pytest-xdist pybind11
+          python3.8-dbg -m pip install --upgrade mpmath gmpy2 pythran
+          python3.8-dbg -m pip uninstall -y nose
           cd ..
       - name: Building SciPy
-        run: python3.7-dbg -u runtests.py -g -j2 --build-only
+        run: python3.8-dbg -u runtests.py -g -j2 --build-only
       - name: Testing SciPy
         if: ${{ github.event_name == 'pull_request' }}
         run: |
-          python3.7-dbg -u runtests.py -g -j2 -m fast -- -rfEX --durations=10 2>&1 | tee runtests.log
-          python3.7-dbg tools/validate_runtests_log.py fast < runtests.log
+          python3.8-dbg -u runtests.py -g -j2 -m fast -- -rfEX --durations=10 2>&1 | tee runtests.log
+          python3.8-dbg tools/validate_runtests_log.py fast < runtests.log
       - name: Dynamic symbol hiding check on Linux
         if: ${{ github.event_name == 'pull_request' }}
         run: ./tools/check_pyext_symbol_hiding.sh build

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
         numpy-version: ['--upgrade numpy']
 
     steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,7 +36,7 @@ stages:
   jobs:
     - job: Skip
       pool:
-        vmImage: 'ubuntu-18.04'
+        vmImage: 'ubuntu-20.04'
       variables:
         DECODE_PERCENTS: 'false'
         RET: 'true'
@@ -76,7 +76,7 @@ stages:
     steps:
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: '3.7'
+        versionSpec: '3.8'
         addToPath: true
         architecture: 'x64'
     - template: ci/azure-travis-template.yaml
@@ -117,11 +117,11 @@ stages:
         use_wheel: true
   - job: source_distribution
     pool:
-      vmImage: 'ubuntu-18.04'
+      vmImage: 'ubuntu-20.04'
     steps:
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: '3.7'
+        versionSpec: '3.8'
         addToPath: true
         architecture: 'x64'
     - template: ci/azure-travis-template.yaml
@@ -148,18 +148,18 @@ stages:
       displayName: 'Install GCC 4.8'
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: '3.7'
+        versionSpec: '3.8'
         addToPath: true
         architecture: 'x64'
     - template: ci/azure-travis-template.yaml
       parameters:
         test_mode: fast
-        numpy_spec: "numpy==1.16.5"
+        numpy_spec: "numpy==1.17.3"
         use_wheel: true
   - job: Lint
     condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))  # skip for PR merges
     pool:
-      vmImage: 'ubuntu-18.04'
+      vmImage: 'ubuntu-20.04'
     steps:
     - task: UsePythonVersion@0
       inputs:
@@ -183,10 +183,10 @@ stages:
         tools/unicode-check.py
       displayName: 'Run Lint Checks'
       failOnStderr: true
-  - job: Linux_Python_37_32bit_full
+  - job: Linux_Python_38_32bit_full
     condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))  # skip for PR merges
     pool:
-      vmImage: 'ubuntu-16.04'
+      vmImage: 'ubuntu-20.04'
     steps:
     - script: |
         git submodule update --init
@@ -196,28 +196,28 @@ stages:
             docker pull i386/ubuntu:bionic
             docker run -v $(pwd):/scipy i386/ubuntu:bionic /usr/bin/linux32 /bin/bash -c "cd scipy && \
             apt-get -y update && \
-            apt-get -y install curl python3.7-dev python3.7 python3-distutils pkg-config libpng-dev libjpeg8-dev libfreetype6-dev && \
+            apt-get -y install curl python3.8-dev python3.8 python3-distutils pkg-config libpng-dev libjpeg8-dev libfreetype6-dev && \
             curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
-            python3.7 get-pip.py && \
+            python3.8 get-pip.py && \
             pip3 --version && \
-            pip3 install setuptools wheel numpy==1.16.6 cython==0.29.18 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath matplotlib==3.1.3 pythran --user && \
+            pip3 install setuptools wheel numpy==1.17.3 cython==0.29.18 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath matplotlib==3.1.3 pythran --user && \
             apt-get -y install gcc-5 g++-5 gfortran-8 wget && \
             cd .. && \
             mkdir openblas && cd openblas && \
-            target=\$(python3.7 ../scipy/tools/openblas_support.py) && \
+            target=\$(python3.8 ../scipy/tools/openblas_support.py) && \
             cp -r \$target/lib/* /usr/lib && \
             cp \$target/include/* /usr/include && \
             cd ../scipy && \
-            CC=gcc-5 CXX=g++-5 F77=gfortran-8 F90=gfortran-8 python3.7 setup.py install && \
-            python3.7 tools/openblas_support.py --check_version $(openblas_version) && \
-            CC=gcc-5 CXX=g++-5 F77=gfortran-8 F90=gfortran-8 python3.7 runtests.py --mode=full -- -n auto -s --junitxml=junit/test-results.xml --cov-config=.coveragerc --cov-report=xml --cov-report=html"
+            CC=gcc-5 CXX=g++-5 F77=gfortran-8 F90=gfortran-8 python3.8 setup.py install && \
+            python3.8 tools/openblas_support.py --check_version $(openblas_version) && \
+            CC=gcc-5 CXX=g++-5 F77=gfortran-8 F90=gfortran-8 python3.8 runtests.py --mode=full -- -n auto -s --junitxml=junit/test-results.xml --cov-config=.coveragerc --cov-report=xml --cov-report=html"
       displayName: 'Run 32-bit Ubuntu Docker Build / Tests'
     - task: PublishTestResults@2
       condition: succeededOrFailed()
       inputs:
         testResultsFiles: '**/test-*.xml'
         failTaskOnFailedTests: true
-        testRunTitle: 'Publish test results for Python 3.7-32 bit full Linux'
+        testRunTitle: 'Publish test results for Python 3.8-32 bit full Linux'
     - task: PublishCodeCoverageResults@1
       inputs:
         codeCoverageTool: Cobertura
@@ -234,14 +234,14 @@ stages:
     strategy:
       maxParallel: 4
       matrix:
-          Python37-32bit-fast:
-            PYTHON_VERSION: '3.7'
+          Python38-32bit-fast:
+            PYTHON_VERSION: '3.8'
             PYTHON_ARCH: 'x86'
             TEST_MODE: fast
             BITS: 32
             SCIPY_USE_PYTHRAN: 1
-          Python37-64bit-full:
-            PYTHON_VERSION: '3.7'
+          Python38-64bit-full:
+            PYTHON_VERSION: '3.8'
             PYTHON_ARCH: 'x64'
             TEST_MODE: full
             BITS: 64

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,7 +1,7 @@
 # Makefile for Sphinx documentation
 
 # If `python3` doesn't point to the Python you want to use (with Sphinx installed),
-# then you can use, e.g., `make html PYTHON=python3.7` to specify a Python executable
+# then you can use, e.g., `make html PYTHON=python3.9` to specify a Python executable
 PYTHON = python3
 
 # You can set these variables from the command line.

--- a/doc/source/dev/contributor/rendering_documentation.rst
+++ b/doc/source/dev/contributor/rendering_documentation.rst
@@ -37,7 +37,7 @@ To render the documentation on your own machine:
    `git submodules`_.
 #. Enter ``make html-scipyorg``. If you have multiple version of Python on
    your path, you can choose which version to use by appending
-   ``PYTHON=python3.7`` to this command, where ``python3.7`` is to be
+   ``PYTHON=python3.9`` to this command, where ``python3.9`` is to be
    replaced with the name of the Python you use for SciPy development.
    This uses the `Make build automation tool`_
    to execute the documentation build instructions from the ``Makefile``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ requires = [
 
     # numpy 1.19 was the first minor release to provide aarch64 wheels, but
     # wheels require fixes contained in numpy 1.19.2
-    "numpy==1.19.2; python_version=='3.7' and platform_machine=='aarch64'",
     "numpy==1.19.2; python_version=='3.8' and platform_machine=='aarch64'",
     # aarch64 for py39 is covered by default requirement below
 
@@ -31,12 +30,8 @@ requires = [
     "numpy==1.20.0; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Darwin'",
 
     # default numpy requirements
-    "numpy==1.16.5; python_version=='3.7' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'",
     "numpy==1.17.3; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'",
     "numpy==1.19.3; python_version=='3.9' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_python_implementation != 'PyPy'",
-
-    # First PyPy versions for which there are numpy wheels
-    "numpy==1.20.0; python_version=='3.7' and platform_python_implementation=='PyPy'",
 
     # For Python versions which aren't yet officially supported,
     # we specify an unpinned NumPy which allows source distributions
@@ -69,7 +64,6 @@ classifiers = [
     "Programming Language :: C",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Topic :: Software Development :: Libraries",

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,8 @@ import sysconfig
 from distutils.version import LooseVersion
 
 
-if sys.version_info[:2] < (3, 7):
-    raise RuntimeError("Python version >= 3.7 required.")
+if sys.version_info[:2] < (3, 8):
+    raise RuntimeError("Python version >= 3.8 required.")
 
 import builtins
 
@@ -41,7 +41,6 @@ License :: OSI Approved :: BSD License
 Programming Language :: C
 Programming Language :: Python
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
 Programming Language :: Python :: 3.9
 Topic :: Software Development :: Libraries
@@ -549,9 +548,9 @@ def setup_package():
     # Rationale: SciPy builds without deprecation warnings with N; deprecations
     #            in N+1 will turn into errors in N+3
     # For Python versions, if releases is (e.g.) <=3.9.x, set bound to 3.10
-    np_minversion = '1.16.5'
+    np_minversion = '1.17.3'
     np_maxversion = '9.9.99'
-    python_minversion = '3.7'
+    python_minversion = '3.8'
     python_maxversion = '3.10'
     if IS_RELEASE_BRANCH:
         req_np = 'numpy>={},<{}'.format(np_minversion, np_maxversion)

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -17,8 +17,8 @@
 #
 # docker run -it --rm -v $PWD/:/home/scipy scipy/scipy-dev /bin/bash
 #
-# The available Python executables are python3.7 and python3.8 (along with
-# pip3.7 and pip3.8.
+# The available Python executables are python3.8 (along with
+# pip3.8.
 # The image does not come bundled with cython/numpy/pytest/pybind11, those need to
 # be installed with pip before trying to build/run scipy.
 #
@@ -32,14 +32,7 @@
 # ubuntu focal has python 3.8 as default
 FROM ubuntu:focal
 
-# add deadsnakes ppa to install python 3.7
-RUN apt-get update && \
-    apt-get install -y software-properties-common && \
-    add-apt-repository ppa:deadsnakes/ppa
-
 RUN apt-get update && apt-get install -y \
-	python3.7 \
-	python3.7-dev \
 	python3-pip \
 	build-essential \
 	vim \
@@ -55,5 +48,5 @@ RUN apt-get update && apt-get install -y \
 	git
 
 
-# setup pips, pip3.7 and pip3.8
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3.7 get-pip.py && python3.8 get-pip.py && rm get-pip.py
+# setup pips and pip3.8
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3.8 get-pip.py && rm get-pip.py

--- a/tox.ini
+++ b/tox.ini
@@ -22,10 +22,10 @@
 #   tox -- -v
 
 # Tox assumes that you have appropriate Python interpreters already
-# installed and that they can be run as 'python3.6', 'python3.7', etc.
+# installed and that they can be run as 'python3.9', etc.
 
 [tox]
-envlist = py37,py38,py39
+envlist = py38,py39
 skipsdist=True
 
 [testenv]


### PR DESCRIPTION
We should be dropping Python 3.7 with the next release (1.8), hence NumPy 1.16 will not be supported and we will move to NumPy 1.17.3.

This PR touches the `setup.py`, `pyproject.toml`, CI, some other smaller things and some documentation.

Related to recent discussions and linked to #14649. Also in accordance with [NEP29](https://numpy.org/neps/nep-0029-deprecation_policy.html) (NumPy already dropped support for 3.7 on main). And see [here](https://devguide.python.org/#status-of-python-branches) for official Python support. There will be just 1 year of support of 3.7 for the next release if we don't migrate now.

I think I touched everything with these 2 PRs. Just not sure about the Dockerfile.