### PR TITLE
MAINT: refactor "for ... in range(len(" statements

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -104,8 +104,7 @@ def _lazyselect(condlist, choicelist, arrays, default=0):
     arrays = np.broadcast_arrays(*arrays)
     tcode = np.mintypecode([a.dtype.char for a in arrays])
     out = np.full(np.shape(arrays[0]), fill_value=default, dtype=tcode)
-    for index in range(len(condlist)):
-        func, cond = choicelist[index], condlist[index]
+    for func, cond in zip(choicelist, condlist):
         if np.all(cond is False):
             continue
         cond, _ = np.broadcast_arrays(cond, arrays[0])

--- a/scipy/fft/_pocketfft/tests/test_basic.py
+++ b/scipy/fft/_pocketfft/tests/test_basic.py
@@ -77,14 +77,14 @@ def direct_idft(x):
 
 def direct_dftn(x):
     x = asarray(x)
-    for axis in range(len(x.shape)):
+    for axis in range(x.ndim):
         x = fft(x, axis=axis)
     return x
 
 
 def direct_idftn(x):
     x = asarray(x)
-    for axis in range(len(x.shape)):
+    for axis in range(x.ndim):
         x = ifft(x, axis=axis)
     return x
 

--- a/scipy/fftpack/tests/test_real_transforms.py
+++ b/scipy/fftpack/tests/test_real_transforms.py
@@ -223,9 +223,9 @@ class _TestDCTBase:
 class _TestDCTIBase(_TestDCTBase):
     def test_definition_ortho(self):
         # Test orthornomal mode.
-        for i in range(len(X)):
-            x = np.array(X[i], dtype=self.rdt)
-            dt = np.result_type(np.float32, self.rdt)
+        dt = np.result_type(np.float32, self.rdt)
+        for xr in X:
+            x = np.array(xr, dtype=self.rdt)
             y = dct(x, norm='ortho', type=1)
             y2 = naive_dct1(x, norm='ortho')
             assert_equal(y.dtype, dt)
@@ -234,11 +234,9 @@ class _TestDCTIBase(_TestDCTBase):
 class _TestDCTIIBase(_TestDCTBase):
     def test_definition_matlab(self):
         # Test correspondence with MATLAB (orthornomal mode).
-        for i in range(len(X)):
-            dt = np.result_type(np.float32, self.rdt)
-            x = np.array(X[i], dtype=dt)
-
-            yr = Y[i]
+        dt = np.result_type(np.float32, self.rdt)
+        for xr, yr in zip(X, Y):
+            x = np.array(xr, dtype=dt)
             y = dct(x, norm="ortho", type=2)
             assert_equal(y.dtype, dt)
             assert_array_almost_equal(y, yr, decimal=self.dec)
@@ -247,9 +245,9 @@ class _TestDCTIIBase(_TestDCTBase):
 class _TestDCTIIIBase(_TestDCTBase):
     def test_definition_ortho(self):
         # Test orthornomal mode.
-        for i in range(len(X)):
-            x = np.array(X[i], dtype=self.rdt)
-            dt = np.result_type(np.float32, self.rdt)
+        dt = np.result_type(np.float32, self.rdt)
+        for xr in X:
+            x = np.array(xr, dtype=self.rdt)
             y = dct(x, norm='ortho', type=2)
             xi = dct(y, norm="ortho", type=3)
             assert_equal(xi.dtype, dt)
@@ -258,9 +256,9 @@ class _TestDCTIIIBase(_TestDCTBase):
 class _TestDCTIVBase(_TestDCTBase):
     def test_definition_ortho(self):
         # Test orthornomal mode.
-        for i in range(len(X)):
-            x = np.array(X[i], dtype=self.rdt)
-            dt = np.result_type(np.float32, self.rdt)
+        dt = np.result_type(np.float32, self.rdt)
+        for xr in X:
+            x = np.array(xr, dtype=self.rdt)
             y = dct(x, norm='ortho', type=4)
             y2 = naive_dct4(x, norm='ortho')
             assert_equal(y.dtype, dt)
@@ -478,9 +476,9 @@ class _TestDSTBase:
 class _TestDSTIBase(_TestDSTBase):
     def test_definition_ortho(self):
         # Test orthornomal mode.
-        for i in range(len(X)):
-            x = np.array(X[i], dtype=self.rdt)
-            dt = np.result_type(np.float32, self.rdt)
+        dt = np.result_type(np.float32, self.rdt)
+        for xr in X:
+            x = np.array(xr, dtype=self.rdt)
             y = dst(x, norm='ortho', type=1)
             y2 = naive_dst1(x, norm='ortho')
             assert_equal(y.dtype, dt)
@@ -489,9 +487,9 @@ class _TestDSTIBase(_TestDSTBase):
 class _TestDSTIVBase(_TestDSTBase):
     def test_definition_ortho(self):
         # Test orthornomal mode.
-        for i in range(len(X)):
-            x = np.array(X[i], dtype=self.rdt)
-            dt = np.result_type(np.float32, self.rdt)
+        dt = np.result_type(np.float32, self.rdt)
+        for xr in X:
+            x = np.array(xr, dtype=self.rdt)
             y = dst(x, norm='ortho', type=4)
             y2 = naive_dst4(x, norm='ortho')
             assert_equal(y.dtype, dt)

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -1926,13 +1926,13 @@ class RectSphereBivariateSpline(SphereBivariateSpline):
 
     >>> fig2 = plt.figure()
     >>> s = [3e9, 2e9, 1e9, 1e8]
-    >>> for ii in range(len(s)):
-    ...     lut = RectSphereBivariateSpline(lats, lons, data, s=s[ii])
+    >>> for idx, sval in enumerate(s, 1):
+    ...     lut = RectSphereBivariateSpline(lats, lons, data, s=sval)
     ...     data_interp = lut.ev(new_lats.ravel(),
     ...                          new_lons.ravel()).reshape((360, 180)).T
-    ...     ax = fig2.add_subplot(2, 2, ii+1)
+    ...     ax = fig2.add_subplot(2, 2, idx)
     ...     ax.imshow(data_interp, interpolation='nearest')
-    ...     ax.set_title("s = %g" % s[ii])
+    ...     ax.set_title(f"s = {sval:g}")
     >>> plt.show()
 
     """

--- a/scipy/linalg/flinalg.py
+++ b/scipy/linalg/flinalg.py
@@ -28,8 +28,8 @@ def get_flinalg_funcs(names,arrays=(),debug=0):
     """Return optimal available _flinalg function objects with
     names. Arrays are used to determine optimal prefix."""
     ordering = []
-    for i in range(len(arrays)):
-        t = arrays[i].dtype.char
+    for i, ar in enumerate(arrays):
+        t = ar.dtype.char
         if t not in _type_conv:
             t = 'd'
         ordering.append((t,i))

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -3785,8 +3785,8 @@ def main():
     print("\nMinimizing the Rosenbrock function of order 3\n")
     print(" Algorithm \t\t\t       Seconds")
     print("===========\t\t\t      =========")
-    for k in range(len(algor)):
-        print(algor[k], "\t -- ", times[k])
+    for alg, tme in zip(algor, times):
+        print(alg, "\t -- ", tme)
 
 
 if __name__ == "__main__":

--- a/scipy/optimize/tests/test_hessian_update_strategy.py
+++ b/scipy/optimize/tests/test_hessian_update_strategy.py
@@ -111,9 +111,7 @@ class TestHessianUpdateStrategy(TestCase):
         delta_grad = [grad_list[i+1]-grad_list[i]
                       for i in range(len(grad_list)-1)]
         # Check curvature condition
-        for i in range(len(delta_x)):
-            s = delta_x[i]
-            y = delta_grad[i]
+        for s, y in zip(delta_x, delta_grad):
             if np.dot(s, y) <= 0:
                 raise ArithmeticError()
         # Define QuasiNewton update
@@ -124,15 +122,13 @@ class TestHessianUpdateStrategy(TestCase):
             hess.initialize(len(x_list[0]), 'hess')
             inv_hess.initialize(len(x_list[0]), 'inv_hess')
             # Compare the hessian and its inverse
-            for i in range(len(delta_x)):
-                s = delta_x[i]
-                y = delta_grad[i]
+            for s, y in zip(delta_x, delta_grad):
                 hess.update(s, y)
                 inv_hess.update(s, y)
                 B = hess.get_matrix()
                 H = inv_hess.get_matrix()
                 assert_array_almost_equal(np.linalg.inv(B), H, decimal=10)
-            B_true = prob.hess(x_list[i+1])
+            B_true = prob.hess(x_list[len(delta_x)])
             assert_array_less(norm(B - B_true)/norm(B_true), 0.1)
 
     def test_SR1_skip_update(self):

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1467,11 +1467,10 @@ def order_filter(a, domain, rank):
 
     """
     domain = np.asarray(domain)
-    size = domain.shape
-    for k in range(len(size)):
-        if (size[k] % 2) != 1:
+    for dimsize in domain.shape:
+        if (dimsize % 2) != 1:
             raise ValueError("Each dimension of domain argument "
-                             " should have an odd number of elements.")
+                             "should have an odd number of elements.")
     return sigtools._order_filterND(a, domain, rank)
 
 

--- a/scipy/special/_precompute/utils.py
+++ b/scipy/special/_precompute/utils.py
@@ -26,7 +26,7 @@ def lagrange_inversion(a):
 
     """
     n = len(a)
-    f = sum(a[i]*x**i for i in range(len(a)))
+    f = sum(a[i]*x**i for i in range(n))
     h = (x/f).series(x, 0, n).removeO()
     hpower = [h**0]
     for k in range(n):

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -8011,8 +8011,8 @@ def friedmanchisquare(*args):
 
     # Handle ties
     ties = 0
-    for i in range(len(data)):
-        replist, repnum = find_repeats(array(data[i]))
+    for d in data:
+        replist, repnum = find_repeats(array(d))
         for t in repnum:
             ties += t * (t*t - 1)
     c = 1 - ties / (k*(k*k - 1)*n)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1563,18 +1563,18 @@ def test_weightedtau_vs_quadratic():
     # Trivial quadratic implementation, all parameters mandatory
     def wkq(x, y, rank, weigher, add):
         tot = conc = disc = u = v = 0
-        for i in range(len(x)):
-            for j in range(len(x)):
-                w = weigher(rank[i]) + weigher(rank[j]) if add else weigher(rank[i]) * weigher(rank[j])
-                tot += w
-                if x[i] == x[j]:
-                    u += w
-                if y[i] == y[j]:
-                    v += w
-                if x[i] < x[j] and y[i] < y[j] or x[i] > x[j] and y[i] > y[j]:
-                    conc += w
-                elif x[i] < x[j] and y[i] > y[j] or x[i] > x[j] and y[i] < y[j]:
-                    disc += w
+        for (i, j) in product(range(len(x)), range(len(x))):
+            w = weigher(rank[i]) + weigher(rank[j]) if add \
+                else weigher(rank[i]) * weigher(rank[j])
+            tot += w
+            if x[i] == x[j]:
+                u += w
+            if y[i] == y[j]:
+                v += w
+            if x[i] < x[j] and y[i] < y[j] or x[i] > x[j] and y[i] > y[j]:
+                conc += w
+            elif x[i] < x[j] and y[i] > y[j] or x[i] > x[j] and y[i] < y[j]:
+                disc += w
         return (conc - disc) / np.sqrt(tot - u) / np.sqrt(tot - v)
 
     np.random.seed(42)


### PR DESCRIPTION
Refactor `for i in range(len(items))` to `for item in items`, which is generally regarded to be more Pythonic.

Cases were identified using `git grep " in range(len("`, although not all cases are suitable for refactoring.