### PR TITLE
MAINT: update leftover Python and NumPy version from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,9 +51,9 @@ maintainers = [
 # Note: Python and NumPy upper version bounds should be set correctly in
 # release branches, see:
 #     https://scipy.github.io/devdocs/dev/core-dev/index.html#version-ranges-for-numpy-and-other-dependencies
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
-    "numpy>=1.16.5",
+    "numpy>=1.17.3",
 ]
 readme = "README.rst"
 classifiers = [


### PR DESCRIPTION
Some leftovers of Python 3.7 and NumPy 1.16.

[ci skip]