### PR TITLE
BLD: fix confusing "import pip" failure that should be caught

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -360,7 +360,7 @@ def generate_cython():
                                    pip.__version__))
             else:
                 raise RuntimeError("Running cythonize failed!")
-        except ImportError:
+        except (ImportError, ModuleNotFoundError):
             raise RuntimeError("Running cythonize failed!")
 
 


### PR DESCRIPTION
Observed in the traceback of gh-14647. Not the root cause of that build issue, it's just confusing.