### PR TITLE
BLD: add `zip_safe=False` to the `setup()` call

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -583,6 +583,7 @@ def setup_package():
         platforms=["Windows", "Linux", "Solaris", "Mac OS-X", "Unix"],
         install_requires=[req_np],
         python_requires=req_py,
+        zip_safe=False,
     )
 
     if "--force" in sys.argv:


### PR DESCRIPTION
Closes gh-14599