### PR TITLE
BLD: fix include order, Python.h before standard headers

### DIFF
--- a/scipy/_lib/src/_test_ccallback.c
+++ b/scipy/_lib/src/_test_ccallback.c
@@ -34,8 +34,8 @@
  *
  */
 
-#include <setjmp.h>
 #include <Python.h>
+#include <setjmp.h>
 
 #include "ccallback.h"
 

--- a/scipy/optimize/_trlib/trlib_eigen_inverse.c
+++ b/scipy/optimize/_trlib/trlib_eigen_inverse.c
@@ -22,8 +22,8 @@
  *
  */
 
-#include "trlib.h"
 #include "trlib_private.h"
+#include "trlib.h"
 
 #include "_c99compat.h"
 

--- a/scipy/optimize/_trlib/trlib_krylov.c
+++ b/scipy/optimize/_trlib/trlib_krylov.c
@@ -22,8 +22,8 @@
  *
  */
 
-#include "trlib.h"
 #include "trlib_private.h"
+#include "trlib.h"
 
 #include "_c99compat.h"
 

--- a/scipy/optimize/_trlib/trlib_leftmost.c
+++ b/scipy/optimize/_trlib/trlib_leftmost.c
@@ -22,8 +22,8 @@
  *
  */
 
-#include "trlib.h"
 #include "trlib_private.h"
+#include "trlib.h"
 
 #include "_c99compat.h"
 

--- a/scipy/optimize/_trlib/trlib_quadratic_zero.c
+++ b/scipy/optimize/_trlib/trlib_quadratic_zero.c
@@ -22,8 +22,8 @@
  *
  */
 
-#include "trlib.h"
 #include "trlib_private.h"
+#include "trlib.h"
 
 #include "_c99compat.h"
 

--- a/scipy/optimize/_trlib/trlib_tri_factor.c
+++ b/scipy/optimize/_trlib/trlib_tri_factor.c
@@ -22,8 +22,8 @@
  *
  */
 
-#include "trlib.h"
 #include "trlib_private.h"
+#include "trlib.h"
 
 #include "_c99compat.h"
 

--- a/scipy/spatial/src/distance_wrap.c
+++ b/scipy/spatial/src/distance_wrap.c
@@ -42,12 +42,13 @@
 #pragma GCC optimize("unroll-loops")
 #endif
 #endif
-#include <stdio.h>
-#include <math.h>
-#include <stdlib.h>
 #include <Python.h>
 #include <numpy/arrayobject.h>
 #include <numpy/npy_math.h>
+
+#include <stdio.h>
+#include <math.h>
+#include <stdlib.h>
 
 #include "distance_impl.h"
 

--- a/scipy/special/_cosine.c
+++ b/scipy/special/_cosine.c
@@ -14,9 +14,6 @@
  *  The ufuncs are used by the class scipy.stats.cosine_gen.
  */
 
-
-#include <numpy/npy_common.h>
-
 #include <stdio.h>
 #include <math.h>
 

--- a/scipy/special/_cosine.c
+++ b/scipy/special/_cosine.c
@@ -15,7 +15,7 @@
  */
 
 
-#include <Python.h>
+#include <numpy/npy_common.h>
 
 #include <stdio.h>
 #include <math.h>

--- a/scipy/special/_cosine.c
+++ b/scipy/special/_cosine.c
@@ -14,6 +14,9 @@
  *  The ufuncs are used by the class scipy.stats.cosine_gen.
  */
 
+
+#include <Python.h>
+
 #include <stdio.h>
 #include <math.h>
 

--- a/scipy/special/_ellip_harm_2.pyx
+++ b/scipy/special/_ellip_harm_2.pyx
@@ -1,10 +1,10 @@
+cdef extern from "Python.h":
+    object PyCapsule_New(void *pointer, char *name, void *destructor)
+
 import ctypes
 from libc.math cimport sqrt, fabs
 from libc.stdlib cimport free
 from numpy import nan
-
-cdef extern from "Python.h":
-    object PyCapsule_New(void *pointer, char *name, void *destructor)
 
 from scipy._lib._ccallback import LowLevelCallable
 from ._ellip_harm cimport ellip_harmonic, ellip_harm_eval, lame_coefficients

--- a/scipy/special/cephes/chbevl.c
+++ b/scipy/special/cephes/chbevl.c
@@ -57,8 +57,8 @@
  * Direct inquiries to 30 Frost Street, Cambridge, MA 02140
  */
 
-#include <stdio.h>
 #include "mconf.h"
+#include <stdio.h>
 
 double chbevl(double x, double array[], int n)
 {

--- a/scipy/special/cephes/polevl.h
+++ b/scipy/special/cephes/polevl.h
@@ -61,7 +61,6 @@
 #ifndef CEPHES_POLEV
 #define CEPHES_POLEV
 
-#include "cephes.h"
 #include <numpy/npy_common.h>
 
 static NPY_INLINE double polevl(double x, const double coef[], int N)

--- a/scipy/special/sf_error.c
+++ b/scipy/special/sf_error.c
@@ -1,7 +1,7 @@
+#include <Python.h>
+
 #include <stdlib.h>
 #include <stdarg.h>
-
-#include <Python.h>
 
 #include "sf_error.h"
 


### PR DESCRIPTION
Python.h must always come before any standard headers, or it may result in warnings like:
```
/opt/hostedtoolcache/Python/3.9.6/x64/include/python3.9/pytime.h:153:60: warning: ‘struct timespec’ declared inside parameter list will not be visible outside of this definition or declaration
  153 | PyAPI_FUNC(int) _PyTime_FromTimespec(_PyTime_t *tp, struct timespec *ts);
      |                                                            ^~~~~~~~
/opt/hostedtoolcache/Python/3.9.6/x64/include/python3.9/pytime.h:158:56: warning: ‘struct timespec’ declared inside parameter list will not be visible outside of this definition or declaration
  158 | PyAPI_FUNC(int) _PyTime_AsTimespec(_PyTime_t t, struct timespec *ts);
```

The warning may not show up for all build systems; it is visible in the Meson Linux CI job.
