### PR TITLE
ENH: sparse.linalg: Add Conjugate Residual (CR) type methods for various systems

### DIFF
--- a/benchmarks/benchmarks/sparse_linalg_solve.py
+++ b/benchmarks/benchmarks/sparse_linalg_solve.py
@@ -8,7 +8,7 @@ from .common import Benchmark, safe_import
 
 with safe_import():
     from scipy import linalg, sparse
-    from scipy.sparse.linalg import cg, minres, gmres, tfqmr, spsolve
+    from scipy.sparse.linalg import cg, minres, gmres, tfqmr, cr, spsolve
 with safe_import():
     from scipy.sparse.linalg import lgmres
 with safe_import():
@@ -34,10 +34,10 @@ class Bench(Benchmark):
     params = [
         [4, 6, 10, 16, 25, 40, 64, 100],
         ['dense', 'spsolve', 'cg', 'minres', 'gmres', 'lgmres', 'gcrotmk',
-         'tfqmr']
+         'tfqmr', 'cr']
     ]
     mapping = {'spsolve': spsolve, 'cg': cg, 'minres': minres, 'gmres': gmres,
-               'lgmres': lgmres, 'gcrotmk': gcrotmk, 'tfqmr': tfqmr}
+               'lgmres': lgmres, 'gcrotmk': gcrotmk, 'tfqmr': tfqmr, 'cr': cr}
     param_names = ['(n,n)', 'solver']
 
     def setup(self, n, solver):

--- a/scipy/sparse/linalg/__init__.py
+++ b/scipy/sparse/linalg/__init__.py
@@ -61,6 +61,7 @@ Iterative methods for linear equation systems:
    qmr -- Use Quasi-Minimal Residual iteration to solve A x = b
    gcrotmk -- Solve a matrix equation using the GCROT(m,k) algorithm
    tfqmr -- Use Transpose-Free Quasi-Minimal Residual iteration to solve A x = b
+   cr -- Use Conjugate Residual iteration to solve A x = b
 
 Iterative methods for least-squares problems:
 

--- a/scipy/sparse/linalg/_isolve/__init__.py
+++ b/scipy/sparse/linalg/_isolve/__init__.py
@@ -8,11 +8,12 @@ from .lsqr import lsqr
 from .lsmr import lsmr
 from ._gcrotmk import gcrotmk
 from .tfqmr import tfqmr
+from .cr import cr
 
 __all__ = [
     'bicg', 'bicgstab', 'cg', 'cgs', 'gcrotmk', 'gmres',
     'lgmres', 'lsmr', 'lsqr',
-    'minres', 'qmr', 'tfqmr'
+    'minres', 'qmr', 'tfqmr', 'cr',
 ]
 
 from scipy._lib._testutils import PytestTester

--- a/scipy/sparse/linalg/_isolve/cr.py
+++ b/scipy/sparse/linalg/_isolve/cr.py
@@ -1,0 +1,192 @@
+import numpy as np
+from .utils import make_system
+
+
+__all__ = ['cr']
+
+
+def cr(A, b, x0=None, tol=1e-5, maxiter=None, M=None,
+       callback=None, atol=None, dtol=1e+5, show=False):
+    """
+    Use Conjugate Residual (CR) iteration to solve ``Ax = b``.
+    CR is structurally similar to Conjugate Gradient method,
+    but mathematically equivalent to MINRES and the system can
+    be symmetric indefinite or Hermitian.
+
+    Parameters
+    ----------
+    A : {sparse matrix, ndarray, LinearOperator}
+        The N-by-N Hermitian matrix of the linear system.
+        Alternatively, `A` can be a linear operator which can
+        produce ``Ax`` using, e.g.,
+        `scipy.sparse.linalg.LinearOperator`.
+    b : {ndarray}
+        Right hand side of the linear system. Has shape (N,) or (N,1).
+    x0 : {ndarray}
+        Starting guess for the solution.
+    tol, atol : float, optional
+        Tolerances for convergence, ``norm(residual) <= max(tol*norm(b),
+        atol)``.
+        The default for `tol` is 1.0e-5.
+        The default for `atol` is ``tol * norm(b)``.
+    dtol : float, optional
+        Tolerance for divergence, ``norm(residual) > dtol * norm(b)``.
+        The default for `dtol` is 1.0e+5.
+    maxiter : int, optional
+        Maximum number of iterations.  Iteration will stop after maxiter
+        steps even if the specified tolerance has not been achieved.
+        Default is ``min(10000, n * 10)``, where ``n = A.shape[0]``.
+    M : {sparse matrix, ndarray, LinearOperator}
+        Inverse of the preconditioner of A.  M should approximate the
+        inverse of A and be easy to solve for (see Notes).  Effective
+        preconditioning dramatically improves the rate of convergence,
+        which implies that fewer iterations are needed to reach a given
+        error tolerance.  By default, no preconditioner is used.
+    callback : function, optional
+        User-supplied function to call after each iteration.  It is called
+        as `callback(xk)`, where `xk` is the current solution vector.
+    show : bool, optional
+        Specify ``show = True`` to show the convergence, ``show = False`` is
+        to close the output of the convergence.
+        Default is `False`.
+
+    Returns
+    -------
+    x : ndarray
+        The converged solution.
+    info : int
+        Provides convergence information:
+
+            - 0  : successful exit
+            - >0 : convergence to tolerance not achieved, number of iterations
+            - <0 : illegal input or breakdown
+
+    References
+    ----------
+    .. [1] Y. Saad, Iterative Methods for Sparse Linear Systems, 2nd edition,
+           SIAM, Philadelphia, 2003.
+    .. [2] G. H. Golub, C. F. van Loan, Matrix Computations, 3rd ed., The Johns
+           Hopkins University Press, Baltimore and London, 1996.
+
+    Examples
+    --------
+    >>> from scipy.sparse import csc_matrix
+    >>> from scipy.sparse.linalg import cr
+    >>> A = csc_matrix([[2, -1, 0], [-1, 2, -1], [0, -1, 2]], dtype=float)
+    >>> b = np.ones(3, dtype=float)
+    >>> x, exitCode = cr(A, b)
+    >>> print(exitCode)            # 0 indicates successful convergence
+    0
+    >>> np.allclose(A.dot(x), b)
+    True
+    """
+
+    # Check data type
+    dtype = A.dtype
+    if np.issubdtype(dtype, np.int64):
+        dtype = float
+        A = A.astype(dtype)
+    if np.issubdtype(b.dtype, np.int64):
+        b = b.astype(dtype)
+
+    A, M, x, b, postprocess = make_system(A, M, x0, b)
+
+    n = A.shape[0]
+    if maxiter is None:
+        maxiter = min(10000, n * 10)
+
+    # Check if the R.H.S is a zero vector
+    bnorm = np.linalg.norm(b)
+    if bnorm == 0.:
+        x = np.zeros(n, dtype=dtype)
+        if (show):
+            print("CR: Linear solve converged due to zero right-hand side "
+                  "iterations 0")
+        return (postprocess(x), 0)
+
+    # Check if the initial guess is a zero vector
+    if np.linalg.norm(x) == 0.:
+        r = b.copy()
+        rnorm = bnorm
+    else:
+        r = b - A.matvec(x)
+        rnorm = np.linalg.norm(r)
+
+    # Check if the residual norm is zero
+    if rnorm == 0.:
+        if (show):
+            print("CR: Linear solve converged due to zero residual "
+                  "iterations 0")
+        return (postprocess(x), 0)
+
+    if atol is None:
+        atol = tol * bnorm
+    else:
+        atol = max(atol, tol * bnorm)
+
+    beta = 0.
+    alpha = 0.
+
+    Mr = M.matvec(r)
+    AMr = A.matvec(Mr)
+    # p is a search direction
+    p = Mr.copy()
+    Ap = A.matvec(p)
+    for iter in range(maxiter):
+        MAp = M.matvec(Ap)
+
+        # Check breakdown
+        MApTAp = np.inner(MAp.conjugate(), Ap)
+        if (MApTAp != 0.):
+            # Compute step size on the search direction `p`
+            alpha = np.inner(Mr.conjugate(), AMr) / MApTAp
+        else:
+            if (show):
+                print("CR: Linear solve not converged due to BREAKDOWN "
+                      f"iterations {iter+1}")
+            return (postprocess(x), -1)
+
+        # Obtain the solution of each iteration
+        x += alpha * p
+
+        if callback is not None:
+            callback(x)
+
+        # Convergence criterion
+        r = r - alpha * Ap
+        rnorm = np.linalg.norm(r)
+        if rnorm < atol:
+            if (show):
+                print("CR: Linear solve converged due to reach TOL "
+                      f"iterations {iter+1}")
+            return (postprocess(x), 0)
+        if rnorm > dtol * bnorm:
+            if (show):
+                print("CR: Linear solve not converged due to reach "
+                      f"DIVERGENCE TOL iterations {iter+1}")
+                return (postprocess(x), iter+1)
+
+        # Compute Mr and AMr
+        Mr_old = Mr.copy()
+        AMr_old = AMr.copy()
+        Mr -= alpha * MAp
+        AMr = A.matvec(Mr)
+
+        # Check breakdown
+        MrTAMr_old = np.inner(Mr_old.conjugate(), AMr_old)
+        if (MrTAMr_old != 0.):
+            beta = np.inner(Mr.conjugate(), AMr) / MrTAMr_old
+        else:
+            if (show):
+                print("CR: Linear solve not converged due to BREAKDOWN "
+                      f"iterations {iter+1}")
+            return (postprocess(x), -1)
+
+        # Update the search direction
+        p = Mr + beta * p
+        Ap = AMr + beta * Ap
+
+    if (show):
+        print("CR: Linear solve not converged due to reach MAXIT "
+              f"iterations {maxiter}")
+    return (postprocess(x), maxiter)

--- a/scipy/sparse/linalg/_isolve/meson.build
+++ b/scipy/sparse/linalg/_isolve/meson.build
@@ -96,6 +96,7 @@ py3.install_sources([
     'lsqr.py',
     'minres.py',
     'tfqmr.py',
+    'cr.py',
     'utils.py',
   ],
   pure: false,

--- a/scipy/sparse/linalg/_isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_iterative.py
@@ -16,7 +16,8 @@ from scipy.linalg import norm
 from scipy.sparse import spdiags, csr_matrix, SparseEfficiencyWarning, kronsum
 
 from scipy.sparse.linalg import LinearOperator, aslinearoperator
-from scipy.sparse.linalg._isolve import cg, cgs, bicg, bicgstab, gmres, qmr, minres, lgmres, gcrotmk, tfqmr
+from scipy.sparse.linalg._isolve import cg, cgs, bicg, bicgstab, gmres, qmr, \
+                                        minres, lgmres, gcrotmk, tfqmr, cr
 
 # TODO check that method preserve shape and type
 # TODO test both preconditioner methods
@@ -45,15 +46,16 @@ class Case:
 
 class IterativeParams:
     def __init__(self):
-        # list of tuples (solver, symmetric, positive_definite )
-        solvers = [cg, cgs, bicg, bicgstab, gmres, qmr, minres, lgmres, gcrotmk, tfqmr]
-        sym_solvers = [minres, cg]
+        # list of tuples (solver, symmetric, positive_definite)
+        solvers = [cg, cgs, bicg, bicgstab, gmres, qmr, minres, lgmres,
+                   gcrotmk, tfqmr, cr]
+        sym_solvers = [minres, cg, cr]
         posdef_solvers = [cg]
         real_solvers = [minres]
 
         self.solvers = solvers
 
-        # list of tuples (A, symmetric, positive_definite )
+        # list of tuples (A, symmetric, positive_definite)
         self.cases = []
 
         # Symmetric and Positive Definite
@@ -154,7 +156,7 @@ class IterativeParams:
         self.cases.append(Case("nonsymposdef", A.astype('F'),
                                skip=sym_solvers+[cgs, qmr, bicg, tfqmr]))
 
-        # Symmetric, non-pd, hitting cgs/bicg/bicgstab/qmr breakdown
+        # Symmetric, non-pd, hitting cgs/bicg/bicgstab/qmr/tfqmr/cr breakdown
         A = np.array([[0, 0, 0, 0, 0, 1, -1, -0, -0, -0, -0],
                       [0, 0, 0, 0, 0, 2, -0, -1, -0, -0, -0],
                       [0, 0, 0, 0, 0, 2, -0, -0, -1, -0, -0],
@@ -170,7 +172,8 @@ class IterativeParams:
         assert (A == A.T).all()
         self.cases.append(Case("sym-nonpd", A, b,
                                skip=posdef_solvers,
-                               nonconvergence=[cgs,bicg,bicgstab,qmr,tfqmr]))
+                               nonconvergence=[cgs, bicg, bicgstab, qmr, tfqmr,
+                                               cr]))
 
 
 params = IterativeParams()
@@ -348,7 +351,7 @@ def test_precond_inverse(case):
 
 def test_reentrancy():
     non_reentrant = [cg, cgs, bicg, bicgstab, gmres, qmr]
-    reentrant = [lgmres, minres, gcrotmk]
+    reentrant = [lgmres, minres, gcrotmk, cr]
     for solver in reentrant + non_reentrant:
         with suppress_warnings() as sup:
             sup.filter(DeprecationWarning, ".*called without specifying.*")
@@ -412,7 +415,8 @@ def test_atol(solver):
         assert_(err <= max(atol, atol2))
 
 
-@pytest.mark.parametrize("solver", [cg, cgs, bicg, bicgstab, gmres, qmr, minres, lgmres, gcrotmk, tfqmr])
+@pytest.mark.parametrize("solver", [cg, cgs, bicg, bicgstab, gmres, qmr,
+                                    minres, lgmres, gcrotmk, tfqmr, cr])
 def test_zero_rhs(solver):
     np.random.seed(1234)
     A = np.random.rand(10, 10)
@@ -451,7 +455,7 @@ def test_zero_rhs(solver):
     pytest.param(gmres, marks=pytest.mark.xfail(platform.machine() == 'aarch64'
                                                 and sys.version_info[1] == 9,
                                                 reason="gh-13019")),
-    qmr,
+    qmr, cr,
     pytest.param(lgmres, marks=pytest.mark.xfail(platform.machine() == 'ppc64le',
                                                  reason="fails on ppc64le")),
     pytest.param(cgs, marks=pytest.mark.xfail),
@@ -487,7 +491,8 @@ def test_maxiter_worsening(solver):
         assert_(error <= tol*best_error)
 
 
-@pytest.mark.parametrize("solver", [cg, cgs, bicg, bicgstab, gmres, qmr, minres, lgmres, gcrotmk, tfqmr])
+@pytest.mark.parametrize("solver", [cg, cgs, bicg, bicgstab, gmres, qmr,
+                                    minres, lgmres, gcrotmk, tfqmr, cr])
 def test_x0_working(solver):
     # Easy problem
     np.random.seed(1)
@@ -512,7 +517,7 @@ def test_x0_working(solver):
 
 
 @pytest.mark.parametrize('solver', [cg, cgs, bicg, bicgstab, gmres, qmr,
-                                    minres, lgmres, gcrotmk])
+                                    minres, lgmres, gcrotmk, cr])
 def test_x0_equals_Mb(solver):
     for case in params.cases:
         if solver in case.skip:


### PR DESCRIPTION
Conjugate Residual (CR) type methods for various systems

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
 In this PR, we implemented the Conjugate Residual (CR) method for symmetric indefinite or Hermitian systems , which is similar to Conjugate Gradient (CG) formally but equivalent to Minimal Residual (MINRES) mathematically. Compared with CG (for symmetic positive-definite problems), CR exhibits typically similar convergence, and compared with MINRES (for symmetric indefinite problems), CR has almost the same the number of iterative steps but less computation in each iteration, which means higher computational efficiency (CPU time).

#### References
[1] Y. Saad, Iterative Methods for Sparse Linear Systems, 2nd edition, SIAM, Philadelphia, 2003.
[2] G. H. Golub, C. F. van Loan, Matrix Computations, 3rd ed., The Johns Hopkins University Press, Baltimore and London, 1996.

#### Additional information
<!--Any additional information you think is important.-->
Conjugate Residual (CR) type methods include traditional CR, Bi-CR and Generalized CR (GCR) etc. we intend to implement the traditional CR method for Hermitian problems firstly, and then implement Bi-CR and GCR for asymmetric problems respectively.