### PR TITLE
BUG: Fixes failing benchmark tests optimize_qap.QuadraticAssignment.track_score

### DIFF
--- a/benchmarks/benchmarks/optimize_qap.py
+++ b/benchmarks/benchmarks/optimize_qap.py
@@ -56,6 +56,6 @@ class QuadraticAssignment(Benchmark):
 
     def track_score(self, method, qap_prob):
         res = quadratic_assignment(self.A, self.B, self.method)
-        score = int(res['score'])
+        score = int(res['fun'])
         percent_diff = (score - self.opt_solution) / self.opt_solution
         return percent_diff


### PR DESCRIPTION
* References: #14667 
Now the benchmark test passes(apart from few timeouts)
<details>
<summary>Result</summary>
<p>

```py
$ python runtests.py -n --bench optimize_qap.QuadraticAssignment.track_score
Running benchmarks for Scipy version 1.8.0.dev0+1529.461f198 at /home/smit/Smitlunagariya/scipy/installdir/lib/python3.9/site-packages/scipy/__init__.py
· No `environment_type` specified in asv.conf.json. This will be required in the future.
· Discovering benchmarks
· Running 1 total benchmarks (1 commits * 1 environments * 1 benchmarks)
[  0.00%] ·· Benchmarking existing-py_home_smit_anaconda3_envs_scipy-dev_bin_python
[100.00%] ··· optimize_qap.QuadraticAssignment.track_score         11/244 failed
[100.00%] ··· ======== ============= =======================
               Method   QAP Problem                         
              -------- ------------- -----------------------
                faq        bur26a     0.0015191636860173918 
                faq        bur26b     0.0032463280399554514 
                faq        bur26c     0.0014717710914084648 
                faq        bur26d     0.0013247060824735522 
                faq        bur26e      0.002353681974293464 
                faq        bur26f     0.0006657775530903395 
                faq        bur26g      0.002757687622588605 
                faq        bur26h     0.0029304130442683674 
                faq        chr12a       2.463358458961474   
                faq        chr12b      0.07452268528022993  
                faq        chr12c       0.1731803513804231  
                faq        chr15a       1.0060630557801131  
                faq        chr15b      0.14042553191489363  
                faq        chr15c       0.7765151515151515  
                faq        chr18a      0.39124166516489456  
                faq        chr18b       0.1681877444589309  
                faq        chr20a       0.4470802919708029  
                faq        chr20b       0.3951261966927763  
                faq        chr20c      0.40263046245226985  
                faq        chr22a      0.36939571150097467  
                faq        chr22b       0.4068453341943817  
                faq        chr25a      0.46996838777660693  
                faq        els19       0.23730908404728923  
                faq        esc16a      0.029411764705882353 
                faq        esc16b       0.0958904109589041  
                faq        esc16c              0.05         
                faq        esc16d             2.875         
                faq        esc16e      0.07142857142857142  
                faq        esc16g      0.15384615384615385  
                faq        esc16h       0.5240963855421686  
                faq        esc16i              0.0          
                faq        esc16j              0.0          
                faq        esc32e              0.0          
                faq        esc32g       0.6666666666666666  
                faq        esc128             0.125         
                faq        had12       0.00847457627118644  
                faq        had14      0.0007342143906020558 
                faq        had16       0.004301075268817204 
                faq        had18       0.015677491601343786 
                faq        had20       0.009534816527015313 
                faq        kra30a      0.08683914510686164  
                faq        kra30b      0.03708160140013126  
                faq        kra32        0.0453318335208099  
                faq       lipa20a      0.024165082812924246 
                faq       lipa20b      0.14928349830107845  
                faq       lipa30a      0.025648808620427985 
                faq       lipa30b              0.0          
                faq       lipa40a      0.019373454245671887 
                faq       lipa40b              0.0          
                faq       lipa50a      0.015508994572657144 
                faq       lipa50b              0.0          
                faq       lipa60a      0.012591169393198903 
                faq       lipa60b              0.0          
                faq       lipa70a      0.011687431887131455 
                faq       lipa70b              0.0          
                faq       lipa80a      0.020979877169770334 
                faq       lipa90a      0.018137703463383524 
                faq       lipa90b              0.0          
                faq        nug12       0.03460207612456748  
                faq        nug14       0.05917159763313609  
                faq        nug16a      0.031055900621118012 
                faq        nug16b      0.03387096774193549  
                faq        nug17       0.006928406466512702 
                faq        nug18       0.021761658031088083 
                faq        nug20       0.021011673151750974 
                faq        nug21       0.014766201804757998 
                faq        nug22       0.03225806451612903  
                faq        nug24       0.020068807339449542 
                faq        nug25       0.013888888888888888 
                faq        nug27       0.032862055789071455 
                faq        nug28       0.024003097173828883 
                faq        nug30       0.027106466361854997 
                faq        rou12       0.04092931625963792  
                faq        rou15       0.048694277406058556 
                faq        rou20       0.025308674306223657 
                faq        scr12       0.35052531041069723  
                faq        scr15       0.07950723504106375  
                faq        scr20       0.09206580023629919  
                faq        sko42       0.015684290412345054 
                faq        sko49       0.012144017788420423 
                faq        sko56       0.012653084914968948 
                faq        sko64       0.012454121819456472 
                faq        sko72       0.006580536102390727 
                faq        sko81       0.010461768390514077 
                faq        sko90       0.017103190402825142 
                faq       sko100a      0.015394534282443651 
                faq       sko100b      0.011228799792059263 
                faq       sko100c      0.018557844476606567 
                faq       sko100d      0.011686366796812323 
                faq       sko100e      0.013623868588669125 
                faq       sko100f      0.015244638879196972 
                faq        ste36b      0.07935907141054757  
                faq        ste36c      0.05689789309767681  
                faq        tai12a      0.09026094396121488  
                faq        tai12b       0.2641991591267436  
                faq        tai15a      0.02360038535446944  
                faq        tai15b      0.007113418209290446 
                faq        tai17a      0.05872975852561548  
                faq        tai20a      0.04642336264467321  
                faq        tai20b      0.13753921134287356  
                faq        tai25a      0.044744254902095174 
                faq        tai25b      0.07031948591892696  
                faq        tai30a      0.04194272627170755  
                faq        tai30b       0.1328411233556051  
                faq        tai35a      0.03798510488430645  
                faq        tai40a      0.027578144659597306 
                faq        tai40b      0.10197142617667788  
                faq        tai50a      0.03731800220134624  
                faq        tai50b      0.039072249961633776 
                faq        tai60a       0.0326074436695614  
                faq        tai60b      0.06244725241542608  
                faq        tai64c       2.1755218952459363  
                faq        tai80a      0.019743711916216565 
                faq       tai100a      0.020805923638589418 
                faq       tai100b      0.05380669043443942  
                faq       tai150b      0.02760697068871638  
                faq       tai256c       1.2048086370620592  
                faq        tho30       0.035481805570376695 
                faq        tho40       0.01319662725140947  
                faq        tho150      0.014434557364584889 
                faq        wil50       0.008275975090134382 
                faq        wil100      0.006394714288853566 
                2opt       bur26a     0.0024003670759415994 
                2opt       bur26b     0.0031926329255298528 
                2opt       bur26c      0.002588083758461486 
                2opt       bur26d     0.0032748660442659095 
                2opt       bur26e      0.002800508420552977 
                2opt       bur26f     0.0001998919103003561 
                2opt       bur26g      0.006281992635886787 
                2opt       bur26h     0.0034543148859967616 
                2opt       chr12a              0.0          
                2opt       chr12b      0.46048039416957504  
                2opt       chr12c       0.5356758694872714  
                2opt       chr15a       0.717663702506063   
                2opt       chr15b      0.46783479349186485  
                2opt       chr15c       0.8659511784511784  
                2opt       chr18a       0.6658857451793115  
                2opt       chr18b       0.2907431551499348  
                2opt       chr20a       0.2874087591240876  
                2opt       chr20b       0.2898172323759791  
                2opt       chr20c       1.4119643614764532  
                2opt       chr22a      0.09096816114359974  
                2opt       chr22b      0.19276719405876655  
                2opt       chr25a       0.636986301369863   
                2opt       els19       0.22665127789331366  
                2opt       esc16a              0.0          
                2opt       esc16b              0.0          
                2opt       esc16c             0.0125        
                2opt       esc16d              0.0          
                2opt       esc16e      0.14285714285714285  
                2opt       esc16g      0.07692307692307693  
                2opt       esc16h              0.0          
                2opt       esc16i              0.0          
                2opt       esc16j              0.0          
                2opt       esc32e              0.0          
                2opt       esc32g              0.0          
                2opt       esc128             0.3125        
                2opt       had12       0.01937046004842615  
                2opt       had14       0.011013215859030838 
                2opt       had16       0.008064516129032258 
                2opt       had18       0.001866368047779022 
                2opt       had20       0.00722334585379948  
                2opt       kra30a      0.07637795275590552  
                2opt       kra30b      0.008422664624808576 
                2opt       kra32       0.047131608548931385 
                2opt      lipa20a      0.027423296225902796 
                2opt      lipa20b              0.0          
                2opt      lipa30a      0.02139930186674761  
                2opt      lipa30b      0.16129330498065061  
                2opt      lipa40a      0.013253852495402372 
                2opt      lipa40b      0.19335852667227607  
                2opt      lipa50a      0.013334836454994926 
                2opt      lipa50b      0.18324156120583948  
                2opt      lipa60a      0.011369359622451454 
                2opt      lipa60b      0.20231059050408015  
                2opt      lipa70a      0.010049777620688639 
                2opt      lipa70b       0.2084977841501564  
                2opt      lipa80a      0.00864156085230751  
                2opt      lipa90a      0.007586723234339905 
                2opt      lipa90b      0.21606306774916914  
                2opt       nug12       0.05536332179930796  
                2opt       nug14       0.05325443786982249  
                2opt       nug16a       0.0484472049689441  
                2opt       nug16b      0.05967741935483871  
                2opt       nug17       0.08314087759815242  
                2opt       nug18       0.03730569948186528  
                2opt       nug20       0.038910505836575876 
                2opt       nug21       0.018867924528301886 
                2opt       nug22       0.028921023359288096 
                2opt       nug24       0.02522935779816514  
                2opt       nug25       0.030982905982905984 
                2opt       nug27       0.04356132976690867  
                2opt       nug28       0.04607046070460705  
                2opt       nug30       0.02906596995427825  
                2opt       rou12       0.06591997554430895  
                2opt       rou15       0.06637305553202902  
                2opt       rou20       0.05352559949939492  
                2opt       scr12       0.05049347341610952  
                2opt       scr15       0.07235041063746578  
                2opt       scr20       0.08197764246114696  
                2opt       sko42       0.030736149759676194 
                2opt       sko49       0.04181989224322244  
                2opt       sko56       0.024725753090719137 
                2opt       sko64       0.019464720194647202 
                2opt       sko72       0.01249698140545762  
                2opt       sko81       0.016373986241455855 
                2opt       sko90       0.012688905430436062 
                2opt      sko100a             failed        
                2opt      sko100b             failed        
                2opt      sko100c             failed        
                2opt      sko100d             failed        
                2opt      sko100e             failed        
                2opt      sko100f             failed        
                2opt       ste36b      0.09954579863739592  
                2opt       ste36c      0.06280896844440723  
                2opt       tai12a      0.02083630400684443  
                2opt       tai12b       0.1853376637609219  
                2opt       tai15a      0.05476876155934613  
                2opt       tai15b     0.0048440201256178175 
                2opt       tai17a      0.030678389303229688 
                2opt       tai20a      0.03769819270429094  
                2opt       tai20b      0.018595729598319857 
                2opt       tai25a      0.05871376973003351  
                2opt       tai25b      0.15351807822544022  
                2opt       tai30a      0.03733583551595966  
                2opt       tai30b      0.042891951012466366 
                2opt       tai35a      0.05612712128231108  
                2opt       tai40a      0.05140330703293973  
                2opt       tai40b      0.010691221443267276 
                2opt       tai50a      0.05414922989327763  
                2opt       tai50b      0.09880168065439704  
                2opt       tai60a       0.043994958618988   
                2opt       tai60b      0.03663873633749289  
                2opt       tai64c      0.005508834394437715 
                2opt       tai80a      0.045191916785488666 
                2opt      tai100a      0.034471781120558515 
                2opt      tai100b             failed        
                2opt      tai150b             failed        
                2opt      tai256c             failed        
                2opt       tho30       0.028225376160495145 
                2opt       tho40       0.03294583312544696  
                2opt       tho150             failed        
                2opt       wil50       0.011840380203212061 
                2opt       wil100             failed        
              ======== ============= =======================

[100.00%] ···· For parameters: '2opt', 'sko100a'
               
               
               asv: benchmark timed out (timeout 60.0s)
               
               For parameters: '2opt', 'sko100b'
               
               
               asv: benchmark timed out (timeout 60.0s)
               
               For parameters: '2opt', 'sko100c'
               
               
               asv: benchmark timed out (timeout 60.0s)
               
               For parameters: '2opt', 'sko100d'
               
               
               asv: benchmark timed out (timeout 60.0s)
               
               For parameters: '2opt', 'sko100e'
               
               
               asv: benchmark timed out (timeout 60.0s)
               
               For parameters: '2opt', 'sko100f'
               
               
               asv: benchmark timed out (timeout 60.0s)
               
               For parameters: '2opt', 'tai100b'
               
               
               asv: benchmark timed out (timeout 60.0s)
               
               For parameters: '2opt', 'tai150b'
               
               
               asv: benchmark timed out (timeout 60.0s)
               
               For parameters: '2opt', 'tai256c'
               
               
               asv: benchmark timed out (timeout 60.0s)
               
               For parameters: '2opt', 'tho150'
               
               
               asv: benchmark timed out (timeout 60.0s)
               
               For parameters: '2opt', 'wil100'
               
               
               asv: benchmark timed out (timeout 60.0s)

```

</p>
</details>

cc @rgommers 