### PR TITLE
MAINT: github labeler on file paths

### DIFF
--- a/.github/pr_path_labeler.yml
+++ b/.github/pr_path_labeler.yml
@@ -1,0 +1,46 @@
+# Labeler triggered by .github/workflows/labels.yml
+
+github:
+- any: [".github/**/*", "!.github/workflows"]
+
+CI:
+- any: ["**/*.yml", "**/*.yaml"]
+
+gitpod: **/*gitpod*
+
+Documentation:
+- any: ["**/*.rst", "**/*.md"]
+
+Benchmarks: benchmarks/**/*
+
+C/C++:
+- any: ["**/*.c", "**/*.cpp", "**/*.cxx", "**/*.h"]
+
+Cython:
+- **/*.pyx
+
+Fortran:
+- **/*.f
+
+scipy.cluster: scipy/cluster/**/*
+scipy.constants: scipy/constants/**/*
+scipy.fft: scipy/fft/**/*
+scipy.fftpack: scipy/fftpack/**/*
+scipy.integrate: scipy/integrate/**/*
+scipy.interpolate: scipy/interpolate/**/*
+scipy.io: scipy/io/**/*
+scipy._lib: scipy/_lib/**/*
+scipy.linalg: scipy/linalg/**/*
+scipy.misc: scipy/misc/**/*
+scipy.ndimage: scipy/ndimage/**/*
+scipy.odr: scipy/odr/**/*
+scipy.optimize: scipy/optimize/**/*
+scipy.signal: scipy/signal/**/*
+scipy.sparse:
+- any: ["scipy/sparse/**/*", "!scipy/sparse/csgraph/**/*", "!scipy/sparse/linalg/**/*"]
+scipy.sparse.csgraph: scipy/sparse/csgraph/**/*
+scipy.sparse.linalg: scipy/sparse/linalg/**/*
+scipy.spatial: scipy/spatial/**/*
+scipy.special: scipy/special/**/*
+scipy.stats: scipy/stats/**/*
+scipy.weave: scipy/weave/**/*

--- a/.github/pr_path_labeler.yml
+++ b/.github/pr_path_labeler.yml
@@ -1,26 +1,31 @@
 # Labeler triggered by .github/workflows/labels.yml
 
 github:
-- any: [".github/**/*", "!.github/workflows"]
+- any: [".github/**/*", "!.github/workflows/**/*"]
 
 CI:
-- any: ["**/*.yml", "**/*.yaml"]
+- any: ["**/*.yml"]
+- any: ["**/*.yaml"]
 
-gitpod: **/*gitpod*
+gitpod:
+- any: [".gitpod.yml"]
+- any: ["tools/docker_dev/gitpod.Dockerfile"]
 
 Documentation:
-- any: ["**/*.rst", "**/*.md"]
+- any: ["**/*.rst"]
+- any: ["**/*.md"]
 
 Benchmarks: benchmarks/**/*
 
 C/C++:
-- any: ["**/*.c", "**/*.cpp", "**/*.cxx", "**/*.h"]
+- any: ["**/*.c"]
+- any: ["**/*.cpp"]
+- any: ["**/*.cxx"]
+- any: ["**/*.h"]
 
-Cython:
-- **/*.pyx
+Cython: "**/*.pyx"
 
-Fortran:
-- **/*.f
+Fortran: "**/*.f"
 
 scipy.cluster: scipy/cluster/**/*
 scipy.constants: scipy/constants/**/*

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,16 @@
+# Triage PRs based on modified paths
+# Rely on .github/pr_path_labeler.yml
+# https://github.com/marketplace/actions/labeler
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage-on-file-paths:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v3
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        configuration-path: ".github/pr_path_labeler.yml"
+        sync-labels: true  # remove labels if file not modified anymore


### PR DESCRIPTION
Automatically label PRs based on file paths.

This needs a GitHub action (from GitHub). It's similar to what NumPy does. But they only look at the naming of the PR and not files.