### PR TITLE
DOC: optimize: fix sporadic linprog doctest failure

### DIFF
--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -582,7 +582,7 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
     ...               options={'maxiter': 4})
     >>> print(res)
         con: array([], dtype=float64)
-        fun: -21.35207150630407
+        fun: -21.35207150630407 # may vary
     message: 'The iteration limit was reached before the algorithm converged.'
         nit: 4
       slack: array([37.19406046,  0.5727398 ])


### PR DESCRIPTION
Addresses sporadic doctest failure mentioned in gh-14672.

```
==============
scipy.optimize
==============

scipy.optimize.linprog
----------------------

File "build/testenv/lib/python3.8/site-packages/scipy/optimize/_linprog.py", line 583, in linprog
Failed example:
    print(res)
Expected:
        con: array([], dtype=float64)
        fun: -21.35207150630407
    message: 'The iteration limit was reached before the algorithm converged.'
        nit: 4
      slack: array([37.19406046,  0.5727398 ])
     status: 1
    success: False
          x: array([ 9.4021973 , -2.98746855])
Got:
         con: array([], dtype=float64)
         fun: -21.352071506304075
     message: 'The iteration limit was reached before the algorithm converged.'
         nit: 4
       slack: array([37.19406046,  0.5727398 ])
      status: 1
     success: False
           x: array([ 9.4021973 , -2.98746855])
```