### PR TITLE
MAINT: static typing of entropy

### DIFF
--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -14,7 +14,11 @@ from typing import Optional, Union
 __all__ = ['entropy', 'differential_entropy']
 
 
-def entropy(pk, qk=None, base=None, axis=0):
+def entropy(pk: np.typing.ArrayLike,
+            qk: Optional[np.typing.ArrayLike] = None,
+            base: Optional[float] = None,
+            axis: int = 0
+            ) -> Union[np.number, np.ndarray]:
     """Calculate the entropy of a distribution for given probability values.
 
     If only probabilities `pk` are given, the entropy is calculated as
@@ -27,10 +31,10 @@ def entropy(pk, qk=None, base=None, axis=0):
 
     Parameters
     ----------
-    pk : sequence
+    pk : array_like
         Defines the (discrete) distribution. ``pk[i]`` is the (possibly
         unnormalized) probability of event ``i``.
-    qk : sequence, optional
+    qk : array_like, optional
         Sequence against which the relative entropy is computed. Should be in
         the same format as `pk`.
     base : float, optional
@@ -40,7 +44,7 @@ def entropy(pk, qk=None, base=None, axis=0):
 
     Returns
     -------
-    S : float
+    S : {float, array_like}
         The calculated entropy.
 
     Examples

--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -32,8 +32,9 @@ def entropy(pk: np.typing.ArrayLike,
     Parameters
     ----------
     pk : array_like
-        Defines the (discrete) distribution. ``pk[i]`` is the (possibly
-        unnormalized) probability of event ``i``.
+        Defines the (discrete) distribution. Along each axis-slice of ``pk``,
+        element ``i`` is the  (possibly unnormalized) probability of event
+        ``i``.
     qk : array_like, optional
         Sequence against which the relative entropy is computed. Should be in
         the same format as `pk`.


### PR DESCRIPTION
DOC: fix return type in entropy

maintenance: Add type hints for entropy function.
doc: return type of entropy is an ndarray if the argument pk isn't 1d.
This wasn't reflected in documentation, and was therefore misleading.
Additionally, the documentation now specifies pk and qk arguments as
array_like and not as sequences.
See #14680

Closes #14680

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->