### PR TITLE
BUG: fix issue in lsqr.py introduced in a recent commit

### DIFF
--- a/scipy/sparse/linalg/isolve/lgmres.py
+++ b/scipy/sparse/linalg/isolve/lgmres.py
@@ -71,7 +71,7 @@ def lgmres(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
     store_outer_Av : bool, optional
         Whether LGMRES should store also A*v in addition to vectors `v`
         in the `outer_v` list. Default is True.
-    prepend_outer_v : bool, optional 
+    prepend_outer_v : bool, optional
         Whether to put outer_v augmentation vectors before Krylov iterates.
         In standard LGMRES, prepend_outer_v=False.
 
@@ -147,6 +147,7 @@ def lgmres(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
     if b_norm == 0:
         x = b
         return (postprocess(x), 0)
+
     ptol_max_factor = 1.0
 
     for k_outer in range(maxiter):

--- a/scipy/sparse/linalg/isolve/lsqr.py
+++ b/scipy/sparse/linalg/isolve/lsqr.py
@@ -369,9 +369,7 @@ def lsqr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
     # These satisfy  beta*u = b - A*x,  alfa*v = A'*u.
     u = b
     bnorm = np.linalg.norm(b)
-    if bnorm == 0:
-        x = b
-        return (postprocess(x), 0)
+
     if x0 is None:
         x = np.zeros(n)
         beta = bnorm.copy()


### PR DESCRIPTION
This came in in gh-14532 and was caught by a flake8 check.
The special-casing isn't needed here, because if `bnorm` is zero,
then `arnorm` is also zero and the early exit is already fine.

[skip github]