### PR TITLE
MAINT: replace IOError alias with OSError or other appropriate type

### DIFF
--- a/scipy/_lib/messagestream.pyx
+++ b/scipy/_lib/messagestream.pyx
@@ -33,7 +33,7 @@ cdef class MessageStream:
         self.handle = stdio.fopen(self._filename, "wb+")
         if self.handle == NULL:
             stdio.remove(self._filename)
-            raise IOError("Failed to open file {0}".format(self._filename))
+            raise OSError(f"Failed to open file {self._filename}")
         self._removed = 0
 
         # Use a posix-style deleted file, if possible
@@ -65,7 +65,7 @@ cdef class MessageStream:
                 stdio.rewind(self.handle)
                 nread = stdio.fread(buf, 1, pos, self.handle)
                 if nread != <size_t>pos:
-                    raise IOError("failed to read messages from buffer")
+                    raise OSError("failed to read messages from buffer")
 
                 obj = PyBytes_FromStringAndSize(buf, nread)
             finally:

--- a/scipy/io/_fortran.py
+++ b/scipy/io/_fortran.py
@@ -10,7 +10,7 @@ import numpy as np
 __all__ = ['FortranFile', 'FortranEOFError', 'FortranFormattingError']
 
 
-class FortranEOFError(TypeError, IOError):
+class FortranEOFError(TypeError, OSError):
     """Indicates that the file ended properly.
 
     This error descends from TypeError because the code used to raise
@@ -21,7 +21,7 @@ class FortranEOFError(TypeError, IOError):
     pass
 
 
-class FortranFormattingError(TypeError, IOError):
+class FortranFormattingError(TypeError, OSError):
     """Indicates that the file ended mid-record.
 
     Descends from TypeError for backward compatibility.
@@ -282,8 +282,8 @@ class FortranFile:
 
         second_size = self._read_size()
         if first_size != second_size:
-            raise IOError('Sizes do not agree in the header and footer for '
-                          'this record - check header dtype')
+            raise ValueError('Sizes do not agree in the header and footer for '
+                             'this record - check header dtype')
 
         # Unpack result
         if len(dtypes) == 1:

--- a/scipy/io/arff/arffread.py
+++ b/scipy/io/arff/arffread.py
@@ -51,7 +51,7 @@ r_wcomattrval = re.compile(r"(\S+)\s+(..+$)")
 # ------------------------
 
 
-class ArffError(IOError):
+class ArffError(OSError):
     pass
 
 

--- a/scipy/io/harwell_boeing/hb.py
+++ b/scipy/io/harwell_boeing/hb.py
@@ -436,7 +436,7 @@ class HBFile:
         if hb_info is None:
             self._hb_info = HBInfo.from_file(file)
         else:
-            #raise IOError("file %s is not writable, and hb_info "
+            #raise OSError("file %s is not writable, and hb_info "
             #              "was given." % file)
             self._hb_info = hb_info
 

--- a/scipy/io/matlab/mio.py
+++ b/scipy/io/matlab/mio.py
@@ -37,14 +37,14 @@ def _open_file(file_like, appendmat, mode='rb'):
 
     try:
         return open(file_like, mode), True
-    except IOError as e:
+    except OSError as e:
         # Probably "not found"
         if isinstance(file_like, str):
             if appendmat and not file_like.endswith('.mat'):
                 file_like += '.mat'
             return open(file_like, mode), True
         else:
-            raise IOError(
+            raise OSError(
                 'Reader needs file name or open file-like object'
             ) from e
 

--- a/scipy/io/matlab/streams.pyx
+++ b/scipy/io/matlab/streams.pyx
@@ -62,7 +62,7 @@ cdef class GenericStream:
             count += read_size
 
         if count != n:
-            raise IOError('could not read bytes')
+            raise OSError('could not read bytes')
         return 0
 
     cdef object read_string(self, size_t n, void **pp, int copy=True):
@@ -70,7 +70,7 @@ cdef class GenericStream:
         if copy != True:
             data = self.fobj.read(n)
             if PyBytes_Size(data) != n:
-                raise IOError('could not read bytes')
+                raise OSError('could not read bytes')
             pp[0] = <void*>PyBytes_AS_STRING(data)
             return data
 
@@ -164,7 +164,7 @@ cdef class ZlibInputStream(GenericStream):
         self._total_position += count
 
         if count != n:
-            raise IOError('could not read bytes')
+            raise OSError('could not read bytes')
 
         return 0
 
@@ -187,7 +187,7 @@ cdef class ZlibInputStream(GenericStream):
 
     cpdef long int tell(self) except -1:
         if self._total_position == -1:
-            raise IOError("Invalid file position.")
+            raise OSError("Invalid file position.")
         return self._total_position
 
     cpdef int seek(self, long int offset, int whence=0) except -1:
@@ -197,12 +197,12 @@ cdef class ZlibInputStream(GenericStream):
         elif whence == 0:
             new_pos = offset
         elif whence == 2:
-            raise IOError("Zlib stream cannot seek from file end")
+            raise OSError("Zlib stream cannot seek from file end")
         else:
             raise ValueError("Invalid value for whence")
 
         if new_pos < self._total_position:
-            raise IOError("Zlib stream cannot seek backwards")
+            raise OSError("Zlib stream cannot seek backwards")
 
         while self._total_position < new_pos:
             self._fill_buffer()

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -1223,8 +1223,8 @@ def test_save_unicode_field(tmpdir):
 
 def test_filenotfound():
     # Check the correct error is thrown
-    assert_raises(IOError, loadmat, "NotExistentFile00.mat")
-    assert_raises(IOError, loadmat, "NotExistentFile00")
+    assert_raises(OSError, loadmat, "NotExistentFile00.mat")
+    assert_raises(OSError, loadmat, "NotExistentFile00")
 
 
 def test_simplify_cells():

--- a/scipy/io/matlab/tests/test_mio5_utils.py
+++ b/scipy/io/matlab/tests/test_mio5_utils.py
@@ -92,7 +92,7 @@ def test_read_tag():
     r = _make_readerlike(str_io)
     c_reader = m5u.VarReader5(r)
     # This works for StringIO but _not_ cStringIO
-    assert_raises(IOError, c_reader.read_tag)
+    assert_raises(OSError, c_reader.read_tag)
     # bad SDE
     tag = _make_tag('i4', 1, mio5p.miINT32, sde=True)
     tag['byte_count'] = 5

--- a/scipy/io/matlab/tests/test_streams.py
+++ b/scipy/io/matlab/tests/test_streams.py
@@ -75,14 +75,14 @@ def test_read():
             assert_equal(res, b'a\x00st')
             res = _read_into(st, 4)
             assert_equal(res, b'ring')
-            assert_raises(IOError, _read_into, st, 2)
+            assert_raises(OSError, _read_into, st, 2)
             # read alloc
             st.seek(0)
             res = _read_string(st, 4)
             assert_equal(res, b'a\x00st')
             res = _read_string(st, 4)
             assert_equal(res, b'ring')
-            assert_raises(IOError, _read_string, st, 2)
+            assert_raises(OSError, _read_string, st, 2)
 
 
 class TestZlibInputStream:
@@ -127,7 +127,7 @@ class TestZlibInputStream:
         stream.read(len(data))
         assert_equal(compressed_stream.tell(), len(compressed_data))
 
-        assert_raises(IOError, stream.read, 1)
+        assert_raises(OSError, stream.read, 1)
 
     def test_read_bad_checksum(self):
         data = np.random.randint(0, 256, 10).astype(np.uint8).tobytes()
@@ -164,12 +164,12 @@ class TestZlibInputStream:
         d3 = stream.read(11)
         assert_equal(d3, data[p:p+11])
 
-        assert_raises(IOError, stream.seek, 10, 2)
-        assert_raises(IOError, stream.seek, -1, 1)
+        assert_raises(OSError, stream.seek, 10, 2)
+        assert_raises(OSError, stream.seek, -1, 1)
         assert_raises(ValueError, stream.seek, 1, 123)
 
         stream.seek(10000, 1)
-        assert_raises(IOError, stream.read, 12)
+        assert_raises(OSError, stream.read, 12)
 
     def test_seek_bad_checksum(self):
         data = np.random.randint(0, 256, 10).astype(np.uint8).tobytes()

--- a/scipy/sparse/_matrix_io.py
+++ b/scipy/sparse/_matrix_io.py
@@ -88,7 +88,7 @@ def load_npz(file):
 
     Raises
     ------
-    IOError
+    OSError
         If the input file does not exist or cannot be read.
 
     See Also

--- a/scipy/special/utils/makenpz.py
+++ b/scipy/special/utils/makenpz.py
@@ -44,7 +44,7 @@ def main():
                 changed = set(old_data.keys()) != set(key for key, _ in files)
             finally:
                 old_data.close()
-        except (IOError, OSError):
+        except OSError:
             # corrupted file
             changed = True
 

--- a/tools/cythonize.py
+++ b/tools/cythonize.py
@@ -47,12 +47,6 @@ from os.path import dirname, join
 HASH_FILE = 'cythonize.dat'
 DEFAULT_ROOT = 'scipy'
 
-# WindowsError is not defined on unix systems
-try:
-    WindowsError
-except NameError:
-    WindowsError = None
-
 #
 # Rules
 #


### PR DESCRIPTION
Since Python 3.3,  IO and OS exceptions were re-worked as per [PEP 3151](https://www.python.org/dev/peps/pep-3151/). The new main base class is [OSError](https://docs.python.org/3/library/exceptions.html#OSError), with several other exceptions merged, including IOError (i.e. `assert IOError is OSError`).

This PR changes the old IOError alias to OSError, with a few exceptions noted in-line.