### PR TITLE
BUG: Fixes failing benchmark test integrate.Quad.time_quad_cffi 

### DIFF
--- a/benchmarks/benchmarks/integrate.py
+++ b/benchmarks/benchmarks/integrate.py
@@ -111,4 +111,5 @@ class Quad(Benchmark):
         quad(self.f_ctypes, 0, np.pi)
 
     def time_quad_cffi(self):
-        quad(self.f_cffi, 0, np.pi)
+        if cffi is not None:
+            quad(self.f_cffi, 0, np.pi)


### PR DESCRIPTION
* References: #14667 

Works fine if `cffi` is not imported:

<details>
<summary> Result </summary>
<p>

```py
Running benchmarks for Scipy version 1.8.0.dev0+1529.461f198 at /home/smit/Smitlunagariya/scipy/installdir/lib/python3.9/site-packages/scipy/__init__.py
· No `environment_type` specified in asv.conf.json. This will be required in the future.
· Discovering benchmarks
· Running 1 total benchmarks (1 commits * 1 environments * 1 benchmarks)
[  0.00%] ·· Benchmarking existing-py_home_smit_anaconda3_envs_scipy-dev_bin_python
[ 50.00%] ··· Running (integrate.Quad.time_quad_cffi--).
[100.00%] ··· integrate.Quad.time_quad_cffi                              116±6ns
```

</p>
</details>
cc @rgommers 