### PR TITLE
MAINT: Translation of hyp2f1 for complex numbers into Cython, part 2

### DIFF
--- a/scipy/special/_hyp2f1.pxd
+++ b/scipy/special/_hyp2f1.pxd
@@ -239,7 +239,7 @@ cdef inline double complex hyp2f1_series(
     double complex
     """
     cdef:
-        int k
+        uint64_t k
         double complex term = 1 + 0j
         double complex previous = 0 + 0j
         double complex result = 1 + 0j

--- a/scipy/special/_hyp2f1.pxd
+++ b/scipy/special/_hyp2f1.pxd
@@ -224,7 +224,7 @@ cdef inline double complex hyp2f1_series(
     b : double
     c : double
     z : double complex
-    max_degree : int
+    max_degree : uint64_t
         Maximum degree of terms before truncating.
     early_stop : bint
     rtol : double

--- a/scipy/special/_hyp2f1.pxd
+++ b/scipy/special/_hyp2f1.pxd
@@ -117,7 +117,6 @@ cdef inline double complex hyp2f1_complex(
     if fabs(1 - z.real) < EPS and z.imag == 0 and c - a - b < 0:
         return NPY_INFINITY + 0.0j
     # Gauss's Summation Theorem for z = 1; c - a - b > 0 (DLMF 15.4.20).
-    # Fallback to Fortran original. To be translated to Cython later.
     if z == 1.0 and c - a - b > 0:
         result = Gamma(c) * Gamma(c - a - b)
         result /= Gamma(c - a) * Gamma(c - b)

--- a/scipy/special/tests/test_hyp2f1.py
+++ b/scipy/special/tests/test_hyp2f1.py
@@ -212,7 +212,6 @@ class TestHyp2f1:
                     expected=1.3396562400934e117 + 0j,
                     rtol=1e-12,
                 ),
-                marks=pytest.mark.xfail(reason="overflow"),
             ),
             pytest.param(
                 Hyp2f1TestCase(
@@ -233,7 +232,6 @@ class TestHyp2f1:
                     expected=-1.3113641413099326e-56 + 0j,
                     rtol=1e-12,
                 ),
-                marks=pytest.mark.xfail(reason="underflow"),
             ),
         ],
     )
@@ -287,7 +285,6 @@ class TestHyp2f1:
                     expected=45143784.46783885 + 0j,
                     rtol=1e-7,
                 ),
-                marks=pytest.mark.xfail,
             ),
         ],
     )

--- a/scipy/special/tests/test_hyp2f1.py
+++ b/scipy/special/tests/test_hyp2f1.py
@@ -5,6 +5,7 @@ the implementation of mp_hyp2f1 below, which modifies mpmath's hyp2f1 to
 return the same branch as scipy's on the standard branch cut.
 """
 
+import sys
 import pytest
 import numpy as np
 from typing import NamedTuple
@@ -284,6 +285,10 @@ class TestHyp2f1:
                     z=-1 + 0j,
                     expected=45143784.46783885 + 0j,
                     rtol=1e-7,
+                    marks=pytest.mark.xfail(
+                        condition=sys.maxsize < 2**32,
+                        reason="Fails on 32 bit.",
+                    )
                 ),
             ),
         ],

--- a/scipy/special/tests/test_hyp2f1.py
+++ b/scipy/special/tests/test_hyp2f1.py
@@ -285,11 +285,11 @@ class TestHyp2f1:
                     z=-1 + 0j,
                     expected=45143784.46783885 + 0j,
                     rtol=1e-7,
-                    marks=pytest.mark.xfail(
-                        condition=sys.maxsize < 2**32,
-                        reason="Fails on 32 bit.",
-                    )
                 ),
+                marks=pytest.mark.xfail(
+                    condition=sys.maxsize < 2**32,
+                    reason="Fails on 32 bit.",
+                )
             ),
         ],
     )


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
This PR does not close any issues known to me.
#### What does this implement/fix?
<!--Please explain your changes.-->
This PR is the third in an ongoing project to translate the Gaussian hypergeometric function (exposed through `scipy.special.hyp2f1`) into Cython. To recap: the original Fortran implementation has many defects but the difficulty of working with and reviewing many lines of dense and sparsely documented Fortran 77 code has thwarted previous efforts to correct them. The goal is to move parts of the implementation in Cython piece by piece while correcting the defects until at last a solid and maintainable implementation is completed.

This PR handles the following cases

1. Unital argument for c - a - b > 0 through [DLMF 15.4.20](https://dlmf.nist.gov/15.4#E20).
2. z = -1 and c = 1 + a - b through [DLMF 15.4.26](https://dlmf.nist.gov/15.4#E26).
3. c - a or c - b a negative integer by applying an Euler hypegeometric transformation [DLMF 15.8.1](https://dlmf.nist.gov/15.8#E1) after which the computation reduces to evaluation of a polynomial.
4. Re(z) >= 0 and |z| < 0.9 through the Maclaurin series for hyp2f1.

For cases 1 and 2, where the function can be evaluated as a ratio of products of gamma functions, the behavior has been updated to compute with logs and then exponentiate if an underflow or overflow occurs with the standard method.

We've also updated the `max_degree` argument of `hyp2f1_series` to be a uint64. This gets rid of platform dependent behavior for the cases where computation reduces to polynomial evaluation.  

 
#### Additional information
<!--Any additional information you think is important.-->