### PR TITLE
DOC: update OptimizeResult notes

### DIFF
--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -111,10 +111,10 @@ class OptimizeResult(dict):
 
     Notes
     -----
-    There may be additional attributes not listed above depending of the
-    specific solver. Since this class is essentially a subclass of dict
-    with attribute accessors, one can see which attributes are available
-    using the `keys()` method.
+    OptimizeResult may have additional attributes not listed here depending
+    on the specific solver being used. Since this class is essentially a
+    subclass of dict with attribute accessors, one can see which
+    attributes are available using the `keys()` method.
     """
 
     def __getattr__(self, name):

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -111,10 +111,10 @@ class OptimizeResult(dict):
 
     Notes
     -----
-    OptimizeResult may have additional attributes not listed here depending
+    `OptimizeResult` may have additional attributes not listed here depending
     on the specific solver being used. Since this class is essentially a
     subclass of dict with attribute accessors, one can see which
-    attributes are available using the `keys()` method.
+    attributes are available using the `OptimizeResult.keys` method.
     """
 
     def __getattr__(self, name):


### PR DESCRIPTION
Closes: https://github.com/scipy/scipy/issues/14683

Does two things:
- Address the problem of `Notes` being placed before `Attributes`
- Edit the spelling in the first sentence.