### PR TITLE
BLD: bump Pythran version to 0.9.12

### DIFF
--- a/doc/source/building/windows.rst
+++ b/doc/source/building/windows.rst
@@ -379,7 +379,7 @@ Now install the dependencies that we need to build and test SciPy.
 
 .. code:: shell
 
-    python -m pip install wheel setuptools numpy>=1.16.5 Cython>=0.29.18 pybind11>=2.4.3 pythran>=0.9.11 pytest pytest-xdist
+    python -m pip install wheel setuptools numpy>=1.16.5 Cython>=0.29.18 pybind11>=2.4.3 pythran>=0.9.12 pytest pytest-xdist
 
 .. note::
 

--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - openblas
   - libblas=*=*openblas  # helps avoid pulling in MKL
   - pybind11
-  - pythran>=0.9.11
+  - pythran>=0.9.12
   - conda-build  # to allow `conda develop .`
   # For testing and benchmarking
   - pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires = [
     "setuptools",
     "Cython>=0.29.18",
     "pybind11>=2.4.3",
-    "pythran>=0.9.11",
+    "pythran>=0.9.12",
 
     # NumPy dependencies - to update these, sync from
     # https://github.com/scipy/oldest-supported-numpy/, and then


### PR DESCRIPTION
Follow-up to gh-14694.