### PR TITLE
CI: add `cffi` in the benchmark CI job, and in environment.yml

### DIFF
--- a/ci/azure-travis-template.yaml
+++ b/ci/azure-travis-template.yaml
@@ -70,6 +70,7 @@ steps:
     gmpy2
     mpmath
     pythran
+    cffi
     pybind11
     pytest
     pytest-xdist

--- a/environment.yml
+++ b/environment.yml
@@ -36,3 +36,4 @@ dependencies:
   # Some optional test dependencies
   - mpmath
   - gmpy2
+  - cffi

--- a/scipy/_lib/_ccallback.py
+++ b/scipy/_lib/_ccallback.py
@@ -1,3 +1,5 @@
+from numpy.testing import suppress_warnings
+
 from . import _ccallback_c
 
 import ctypes
@@ -16,7 +18,10 @@ def _import_cffi():
         return
 
     try:
-        import cffi
+        with suppress_warnings() as sup:
+            sup.filter(RuntimeWarning, "parsing methods must have")
+            import cffi
+
         ffi = cffi.FFI()
         CData = ffi.CData
     except ImportError:

--- a/scipy/_lib/tests/test_ccallback.py
+++ b/scipy/_lib/tests/test_ccallback.py
@@ -1,4 +1,4 @@
-from numpy.testing import assert_equal, assert_
+from numpy.testing import assert_equal, assert_, suppress_warnings
 from pytest import raises as assert_raises
 
 import time
@@ -10,7 +10,10 @@ from scipy._lib import _test_ccallback
 from scipy._lib._ccallback import LowLevelCallable
 
 try:
-    import cffi
+    with suppress_warnings() as sup:
+        sup.filter(RuntimeWarning, "parsing methods must have")
+        import cffi
+
     HAVE_CFFI = True
 except ImportError:
     HAVE_CFFI = False


### PR DESCRIPTION
There is an `integrate` benchmark which uses cffi, and cffi is supported in `_lib/ccallback.py` (no tests for that).

This is a follow-up to gh-14690 (FYI @Smit-create).
