### PR TITLE
BUG: Fix TypeError in `stats._discrete_distns`

### DIFF
--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -1535,7 +1535,7 @@ class _nchypergeom_gen(rv_discrete):
             return urn.moments()
 
         m, v = _moments1(M, n, N, odds) if ("m" in moments
-                                            or "v" in moments) else None
+                                            or "v" in moments) else (None, None)
         s, k = None, None
         return m, v, s, k
 


### PR DESCRIPTION
* References: #14667  


<details>
<summary> Error traceback </summary>
<p>

```py
For parameters: 'nchypergeom_fisher', 'stats_s'
               Traceback (most recent call last):
                 File "/home/smit/anaconda3/envs/scipy-dev/lib/python3.9/site-packages/asv/benchmark.py", line 1184, in main_run_server
                   main_run(run_args)
                 File "/home/smit/anaconda3/envs/scipy-dev/lib/python3.9/site-packages/asv/benchmark.py", line 1058, in main_run
                   result = benchmark.do_run()
                 File "/home/smit/anaconda3/envs/scipy-dev/lib/python3.9/site-packages/asv/benchmark.py", line 537, in do_run
                   return self.run(*self._current_params)
                 File "/home/smit/anaconda3/envs/scipy-dev/lib/python3.9/site-packages/asv/benchmark.py", line 627, in run
                   samples, number = self.benchmark_timing(timer, min_repeat, max_repeat,
                 File "/home/smit/anaconda3/envs/scipy-dev/lib/python3.9/site-packages/asv/benchmark.py", line 663, in benchmark_timing
                   timing = timer.timeit(number)
                 File "/home/smit/anaconda3/envs/scipy-dev/lib/python3.9/timeit.py", line 177, in timeit
                   timing = self.inner(it, self.timer)
                 File "<timeit-src>", line 6, in inner
                 File "/home/smit/anaconda3/envs/scipy-dev/lib/python3.9/site-packages/asv/benchmark.py", line 599, in <lambda>
                   func = lambda: self.func(*param)
                 File "/home/smit/Smitlunagariya/scipy/benchmarks/benchmarks/stats.py", line 182, in time_distribution
                   self.method(*self.args, **self.kwds)
                 File "/home/smit/Smitlunagariya/scipy/installdir/lib/python3.9/site-packages/scipy/stats/_distn_infrastructure.py", line 1149, in stats
                   mu, mu2, g1, g2 = self._stats(*goodargs,
                 File "/home/smit/Smitlunagariya/scipy/installdir/lib/python3.9/site-packages/scipy/stats/_discrete_distns.py", line 1537, in _stats
                   m, v = _moments1(M, n, N, odds) if ("m" in moments
               TypeError: cannot unpack non-iterable NoneType object
```

</p>
</details>

After fixing:

```py
$ python runtests.py -n --bench stats.DistributionsAll.time_distribution
Running benchmarks for Scipy version 1.8.0.dev0+1529.461f198 at /home/smit/Smitlunagariya/scipy/installdir/lib/python3.9/site-packages/scipy/__init__.py
· No `environment_type` specified in asv.conf.json. This will be required in the future.
· Discovering benchmarks
· Running 1 total benchmarks (1 commits * 1 environments * 1 benchmarks)
[  0.00%] ·· Benchmarking existing-py_home_smit_anaconda3_envs_scipy-dev_bin_python
[ 50.00%] ··· Running (stats.DistributionsAll.time_distribution--).
[100.00%] ··· stats.DistributionsAll.time_distribution             4/2074 failed (4 timeouts)
```

cc @rgommers 