### PR TITLE
BENCH: shorten svds benchmark that is timing out in CI

### DIFF
--- a/benchmarks/benchmarks/sparse_linalg_svds.py
+++ b/benchmarks/benchmarks/sparse_linalg_svds.py
@@ -10,7 +10,7 @@ class BenchSVDS(Benchmark):
     # Benchmark SVD using the MatrixMarket test matrices recommended by the
     # author of PROPACK at http://sun.stanford.edu/~rmunk/PROPACK/
     params = [
-        [20, 50, 100],  # consider instead [0.01, 0.05, 0.1] of size,
+        [25],
         ["abb313", "illc1033", "illc1850", "qh1484", "rbs480a", "tols4000",
          "well1033", "well1850", "west0479", "west2021"],
         ['arpack', 'lobpcg', 'propack']


### PR DESCRIPTION
This is a follow-up to gh-14433. On CircleCI this benchmark was timing out after 10 minutes. There's no reason this benchmark should be run with 3 different sizes always. This change makes the runtime ~6x shorter.

Note that a LOBPCG benchmark is failing, that should be addressed separately.

Result:
```
$ time python runtests.py --bench --no-build time_svds
Running benchmarks for Scipy version 1.8.0.dev0+1721.e4029e6 at /home/rgommers/code/scipy/scipy/__init__.py
· No `environment_type` specified in asv.conf.json. This will be required in the future.
· Discovering benchmarks
· Running 1 total benchmarks (1 commits * 1 environments * 1 benchmarks)
[  0.00%] ·· Benchmarking existing-py_home_rgommers_anaconda3_envs_scipy-dev_bin_python
[ 50.00%] ··· Running (sparse_linalg_svds.BenchSVDS.time_svds--).
[100.00%] ··· sparse_linalg_svds.BenchSVDS.time_svds                         1/30 failed
[100.00%] ··· ==== ========== ============= ============ =============
              --                               solver                 
              --------------- ----------------------------------------
               k    problem       arpack       lobpcg       propack   
              ==== ========== ============= ============ =============
               25    abb313     5.11±0.2ms   22.7±0.4ms    5.83±0.2ms 
               25   illc1033     22.7±1ms    34.6±0.7ms    30.1±0.4ms 
               25   illc1850    25.4±0.5ms    51.1±1ms     48.6±0.6ms 
               25    qh1484    7.19±0.06ms     failed     9.96±0.08ms 
               25   rbs480a    16.1±0.09ms   64.1±0.7ms    15.5±0.3ms 
               25   tols4000     72.0±2ms     174±1ms      42.2±0.5ms 
               25   well1033   7.43±0.08ms   29.2±0.3ms    13.9±0.2ms 
               25   well1850    16.6±0.3ms   52.5±0.6ms    25.5±0.5ms 
               25   west0479   4.59±0.07ms   36.3±0.5ms    7.03±0.2ms 
               25   west2021    10.1±0.2ms   91.9±0.7ms    12.2±0.2ms 
              ==== ========== ============= ============ =============
```