### PR TITLE
CI: remove labeler sync

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -13,4 +13,4 @@ jobs:
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: ".github/pr_path_labeler.yml"
-        sync-labels: true  # remove labels if file not modified anymore
+        sync-labels: false  # would remove labels if file not modified anymore


### PR DESCRIPTION
As seen here https://github.com/scipy/scipy/pull/14708#issuecomment-916167470 for instance, we don't want to have the synchronisation of labels for every commit.

[skip ci]
