### PR TITLE
MAINT: special: Updates for _cosine.c.

### DIFF
--- a/scipy/special/_cosine.c
+++ b/scipy/special/_cosine.c
@@ -14,14 +14,17 @@
  *  The ufuncs are used by the class scipy.stats.cosine_gen.
  */
 
-#include <stdio.h>
+#include "cephes/polevl.h"
 #include <math.h>
 
-#include "cephes/polevl.h"
-
-#if !defined(M_PI)
-#define M_PI 0x1.921fb54442d18p+1
-#endif
+// M_PI64 is the 64 bit floating point representation of π, e.g.
+//   >>> math.pi.hex()
+//   '0x1.921fb54442d18p+1'
+// It is used in the function cosine_cdf_pade_approx_at_neg_pi,
+// which depends on this value being the 64 bit representation.
+// Do not replace this with M_PI from math.h or NPY_PI from the
+// numpy header files.
+#define M_PI64 0x1.921fb54442d18p+1
 
 //
 // p and q (below) are the coefficients in the numerator and denominator
@@ -92,10 +95,10 @@ double cosine_cdf_pade_approx_at_neg_pi(double x)
                              0.020281047093125535,
                              1.0};
 
-    // M_PI is not exactly π.  In fact, float64(π - M_PI) is
+    // M_PI64 is not exactly π.  In fact, float64(π - M_PI64) is
     // 1.2246467991473532e-16.  h is supposed to be x + π, so to compute
     // h accurately, we write the calculation as:
-    h = (x + M_PI) + 1.2246467991473532e-16;
+    h = (x + M_PI64) + 1.2246467991473532e-16;
     h2 = h*h;
     h3 = h2*h;
     numer = h3*polevl(h2, numer_coeffs,


### PR DESCRIPTION
(1) In _cosine.c, change order of included headers.

polevl.h imports from numpy header files, which ultimately
include Python.h.  Python.h is supposed to be included before
other headers are included, so this changes moves the include
of polevl.h before that of <math.h>.

Also remove the inclusion of <stdio.h>, which is not used
in _cosine.c.

(2) Unconditionally define the macro M_PI64.

The code in the function cosine_cdf_pade_approx_at_neg_pi
requires a 64-bit approximation to pi.  So instead of
conditionally getting the definition from math.h, the macro
M_PI64 is defined in the file.

-----

This is the change that was removed from https://github.com/scipy/scipy/pull/14673 because of unexpected test failures triggered by moving the include statements in _cosine.c.

