### PR TITLE
ENH: add NaiveRatioUniforms from UNU.RAN to scipy.stats

### DIFF
--- a/doc/source/tutorial/stats/plots/nrou_plot1.py
+++ b/doc/source/tutorial/stats/plots/nrou_plot1.py
@@ -1,0 +1,37 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from scipy import special as sc
+import math
+
+
+def u_bound(x, p, center):
+    if x < 0:
+        return 0
+    return (x - center) * x**((p-1)/2) * math.exp(-x/2)
+
+# bounding rectangle for Gamma(p) shifted by center
+def rectangle(p, center):
+    h = (p+1+center)/2
+    k = np.sqrt(h**2 - center*(p-1))
+    u_min, u_max = u_bound(h-k, p, center), u_bound(h+k, p, center)
+    v_max = math.sqrt((p-1)**(p-1) * math.exp(-(p-1)))
+    return u_min, u_max, v_max
+
+ps = np.arange(1.0, 2.5, 0.1)
+reject_const, reject_const_shift = [], []
+for p in ps:
+    # no shift (center=0)
+    u_min, u_max, v_max = rectangle(p, 0)
+    reject_const.append(2*v_max*(u_max - u_min) / sc.gamma(p))
+    # mode shift (center=p-1)
+    u_min, u_max, v_max = rectangle(p, p-1)
+    reject_const_shift.append(2*v_max*(u_max - u_min) / sc.gamma(p))
+
+fig = plt.figure()
+ax = fig.add_subplot(111)
+ax.plot(ps, reject_const, 'o', label='center=0')
+ax.plot(ps, reject_const_shift, 'o', label='center=mode')
+plt.xlabel('Shape parameter p of the Gamma distribution')
+plt.title('NROU rejection constants for the Gamma distribution')
+plt.legend()
+plt.show()

--- a/doc/source/tutorial/stats/plots/nrou_plot1.py
+++ b/doc/source/tutorial/stats/plots/nrou_plot1.py
@@ -9,6 +9,7 @@ def u_bound(x, p, center):
         return 0
     return (x - center) * x**((p-1)/2) * math.exp(-x/2)
 
+
 # bounding rectangle for Gamma(p) shifted by center
 def rectangle(p, center):
     h = (p+1+center)/2
@@ -16,6 +17,7 @@ def rectangle(p, center):
     u_min, u_max = u_bound(h-k, p, center), u_bound(h+k, p, center)
     v_max = math.sqrt((p-1)**(p-1) * math.exp(-(p-1)))
     return u_min, u_max, v_max
+
 
 ps = np.arange(1.0, 2.5, 0.1)
 reject_const, reject_const_shift = [], []

--- a/doc/source/tutorial/stats/plots/nrou_plot2.py
+++ b/doc/source/tutorial/stats/plots/nrou_plot2.py
@@ -1,0 +1,50 @@
+import numpy as np
+from scipy import stats
+from scipy import special as sc
+import matplotlib.pyplot as plt
+import math
+
+
+class Gamma:
+    def __init__(self, p):
+        self.p = p
+
+    def pdf(self, x):
+        if x < 0:
+            return 0.0
+        return x**(self.p - 1) * math.exp(-x)
+
+    @staticmethod
+    def support():
+        return 0, np.inf
+
+def u_bound(x, p, center):
+    if x < 0:
+        return 0
+    return (x - center) * x**((p-1)/2) * math.exp(-x/2)
+
+# bounding rectangle for Gamma(p) shifted by center
+def rectangle(p, center):
+    h = (p+1+center)/2
+    k = np.sqrt(h**2 - center*(p-1))
+    u_min, u_max = u_bound(h-k, p, center), u_bound(h+k, p, center)
+    v_max = math.sqrt((p-1)**(p-1) * math.exp(-(p-1)))
+    return u_min, u_max, v_max
+
+urng = np.random.default_rng()
+p = 2.2
+dist = Gamma(p)
+u_min, u_max, v_max = rectangle(p, p-1)
+rng = stats.NaiveRatioUniforms(dist, center=p-1, v_max=v_max,
+                               u_min=u_min, u_max=u_max, random_state=urng)
+rvs = rng.rvs(1000)
+x = np.linspace(rvs.min()-0.1, rvs.max()+0.1, num=500)
+fx = stats.gamma.pdf(x, p)
+fig = plt.figure()
+ax = fig.add_subplot(111)
+ax.plot(x, fx, "r-", label=" Gamma({}) pdf".format(p))
+ax.hist(rvs, bins=30, density=True, alpha=0.8, label="rvs")
+plt.xlabel("x")
+plt.title("Samples drawn using NROU method with mode shift.")
+plt.legend()
+plt.show()

--- a/doc/source/tutorial/stats/plots/nrou_plot2.py
+++ b/doc/source/tutorial/stats/plots/nrou_plot2.py
@@ -1,6 +1,5 @@
 import numpy as np
 from scipy import stats
-from scipy import special as sc
 import matplotlib.pyplot as plt
 import math
 
@@ -18,10 +17,12 @@ class Gamma:
     def support():
         return 0, np.inf
 
+
 def u_bound(x, p, center):
     if x < 0:
         return 0
     return (x - center) * x**((p-1)/2) * math.exp(-x/2)
+
 
 # bounding rectangle for Gamma(p) shifted by center
 def rectangle(p, center):
@@ -30,6 +31,7 @@ def rectangle(p, center):
     u_min, u_max = u_bound(h-k, p, center), u_bound(h+k, p, center)
     v_max = math.sqrt((p-1)**(p-1) * math.exp(-(p-1)))
     return u_min, u_max, v_max
+
 
 urng = np.random.default_rng()
 p = 2.2

--- a/doc/source/tutorial/stats/sampling.rst
+++ b/doc/source/tutorial/stats/sampling.rst
@@ -85,6 +85,7 @@ Methods for continuous distributions   Required Inputs  Optional Inputs  Setup S
 :class:`~TransformedDensityRejection`  pdf, dpdf        None             slow         fast
 :class:`~NumericalInverseHermite`      cdf              None             (very) slow  (very) fast
 :class:`~NumericalInversePolynomial`   pdf              cdf              (very) slow  (very) fast
+:class:`~NaiveRatioUniforms`           pdf              various          slow/fast    moderate
 =====================================  ===============  ===============  ===========  ==============
 
 where
@@ -286,6 +287,7 @@ Generators in :mod:`scipy.stats`
    sampling_tdr
    sampling_dau
    sampling_pinv
+   sampling_nrou
 
 
 References

--- a/doc/source/tutorial/stats/sampling_nrou.rst
+++ b/doc/source/tutorial/stats/sampling_nrou.rst
@@ -41,13 +41,13 @@ One can generate (U, V) uniformly on R and return
 verified.
 
 The algorithm is not changed if one replaces the pdf by a function
-that is proportional to it, e.g., by dropping unneccessary normalization
+that is proportional to it, e.g., by dropping unnecessary normalization
 factors.
 
 Intuitively, the method works well if A fills up most of the
 enclosing rectangle such that the probability is high that (U, V)
 lies in A whenever it lies in R as the number of required
-iterations becomes too large otherwise. To be more precise, note that
+iterations become too large otherwise. To be more precise, note that
 the expected number of iterations to draw (U, V) uniformly
 distributed on R such that (U, V) is also in A is given by
 the ratio ``area(R) / area(A) = 2 * v_max * (u_max - u_min) / area(pdf)``,

--- a/doc/source/tutorial/stats/sampling_nrou.rst
+++ b/doc/source/tutorial/stats/sampling_nrou.rst
@@ -155,8 +155,6 @@ account the normalization constant of the Gamma density):
 We can see that it becomes advantageous to apply the mode shift once as the
 mode moves further away from zero:
 
-.. plot::
-
     >>> import matplotlib.pyplot as plt
     >>> fig = plt.figure()
     >>> ax = fig.add_subplot(111)
@@ -167,10 +165,12 @@ mode moves further away from zero:
     >>> plt.legend()
     >>> plt.show()
 
+.. plot:: tutorial/stats/plots/nrou_plot1.py
+   :align: center
+   :include-source: 0
+
 To conclude this example, we generate random variates for ``Gamma(2.2)`` by
 applying NROU with mode shift and create a histogram:
-
-.. plot::
 
     >>> from scipy import stats
     >>> p = 2.2
@@ -189,6 +189,10 @@ applying NROU with mode shift and create a histogram:
     >>> plt.title("Samples drawn using NROU method with mode shift.")
     >>> plt.legend()
     >>> plt.show()
+
+.. plot:: tutorial/stats/plots/nrou_plot2.py
+   :align: center
+   :include-source: 0
 
 Finally, we remark that the parameter ``r`` can be used to transform the
 density. In general, it is recommended to use ``r=1`` for computational

--- a/doc/source/tutorial/stats/sampling_nrou.rst
+++ b/doc/source/tutorial/stats/sampling_nrou.rst
@@ -1,0 +1,118 @@
+
+.. _sampling-nrou:
+
+Naive Ratio-Of-Uniforms (NROU) Method
+=====================================
+
+.. currentmodule:: scipy.stats
+
+* Required: PDF
+* Optional: mode, center, bounding rectangle for acceptance region
+* Speed:
+
+  * Set-up: fast (if the bounding rectangle is known), otherwise slow
+  * Sampling: moderate
+
+NROU is an implementation of the (generalized) ratio-of-uniforms method which
+uses (minimal) bounding rectangles. It uses a positive control parameter r for
+adjusting the algorithm to the given distribution to improve performance and/or
+to make this method applicable. Larger values of r increase the class of
+distributions for which the method works at the expense of a higher
+rejection constant. For computational reasons r=1 should be used if possible.
+Moreover, this implementation uses the center of the distribution. 
+
+If ``r==1``, the method works as follows: for a given ``pdf`` and a constant
+`center`, define the set
+``A = {(u, v) : 0 < v <= sqrt(pdf(u/v + center))}``.
+If ``(U, V)`` is a random vector uniformly distributed over ``A``,
+then ``U/V + center`` follows a distribution according to ``pdf``.
+
+Typical choices of `center` are zero or the mode of `pdf`. The set ``A``
+is a subset of the rectangle ``R = [u_min, u_max] x [0, v_max]`` where
+
+* ``v_max = sup_x sqrt(pdf(x))``
+* ``u_min = inf_x (x - center) sqrt(pdf(x))``
+* ``u_max = sup_x (x - center) sqrt(pdf(x))``
+
+In particular, these values are finite if ``pdf`` is bounded and
+``x**2 * pdf(x)`` is bounded (i.e. subquadratic tails).
+One can generate ``(U, V)`` uniformly on ``R`` and return
+``U/V + center`` if ``(U, V)`` are also in ``A`` which can be directly
+verified.
+
+The algorithm is not changed if one replaces ``pdf`` by ``k * pdf`` for any
+constant k > 0. Thus, it is often convenient to work with a function
+that is proportional to the probability density function by dropping
+unneccessary normalization factors.
+
+Intuitively, the method works well if ``A`` fills up most of the
+enclosing rectangle such that the probability is high that ``(U, V)``
+lies in ``A`` whenever it lies in ``R`` as the number of required
+iterations becomes too large otherwise. To be more precise, note that
+the expected number of iterations to draw ``(U, V)`` uniformly
+distributed on ``R`` such that ``(U, V)`` is also in ``A`` is given by
+the ratio ``area(R) / area(A) = 2 * v_max * (u_max - u_min) / area(pdf)``,
+where ``area(pdf)`` is the integral of ``pdf`` (which is equal to one if the
+probability density function is used but can take on other values if a
+function proportional to the density is used). The equality holds since
+the area of ``A`` is equal to ``0.5 * area(pdf)`` (Theorem 7.1 in [4]_).
+
+In the general case, the acceptance region is defined as
+``A = {(u, v) : 0 < v <= (pdf(u/v**r + center))**(1/(r+1))}`` and the
+bounding rectangle is given by
+
+* ``v_max = sup_x pdf(x)**(1/(r+1))``
+* ``u_min = inf_x (x - center) (pdf(x))**(r/(r+1))``
+* ``u_max = sup_x (x - center) (pdf(x))**(r/(r+1))``
+
+Note that the orginal method is a special case with ``r=1``. The sampling
+then works as follows:
+
+* Generate ``(U,V)`` uniformly in ``[u_min, u_max] x [0, v_max]``
+* Set ``X = U/V**r + center``
+* If ``V**(r+1) <= pdf(X)``, return ``X``
+* Else try again
+
+An example of using this method is shown below:
+
+    >>> import numpy as np
+    >>> from scipy.stats import NaiveRatioUniforms
+    >>>
+    >>> class StandardNormal:
+    ...     def pdf(self, x):
+    ...         # note that the normalization constant is not required
+    ...         return np.exp(-0.5 * x*x) 
+    >>> dist = StandardNormal()
+    >>> u_bound = np.sqrt(dist.pdf(np.sqrt(2))) * np.sqrt(2)
+    >>> urng = np.random.default_rng()
+    >>> rng = NaiveRatioUniforms(dist, v_max=1, u_min=-u_bound,
+                                 u_max=u_bound, random_state=urng)
+    >>> rng.rvs()
+    -0.5677819961248616
+
+In the above example, we have used the NROU method to sample from the standard
+normal distribution. Note that we dropped the normalization constant while
+computing the PDF. This usually helps speed up the sampling stage. Also, note
+that the PDF doesn't need to be vectorized. It should accept and return a
+scalar.
+
+
+TODO: show mode shift, r != 0
+
+Please see [1]_, [2]_, [3]_ and [4]_ for more details on this method.
+
+
+References
+----------
+
+.. [1] UNU.RAN reference manual, Section 5.3.11,
+       "NROU - Naive Ratio-Of-Uniforms method",
+       http://statmath.wu.ac.at/software/unuran/doc/unuran.html#NROU
+.. [2] W. Hörmann, J. Leydold and G. Derflinger (2004). Automatic
+       Nonuniform Random Variate Generation, Springer, Berlin.
+.. [3] A.J. Kinderman and J.F. Monahan, "Computer Generation of Random
+       Variables Using the Ratio of Uniform Deviates",
+       ACM Transactions on Mathematical Software, 3(3), p. 257--260, 1977.
+.. [4] L. Devroye, "Non-Uniform Random Variate Generation",
+       Springer-Verlag, 1986.
+

--- a/doc/source/tutorial/stats/sampling_nrou.rst
+++ b/doc/source/tutorial/stats/sampling_nrou.rst
@@ -21,41 +21,40 @@ the class of distributions for which the method works at the expense of a higher
 rejection constant. For computational reasons r=1 should be used if possible.
 Moreover, this implementation uses the center of the distribution. 
 
-If ``r==1``, the method works as follows: for a given ``pdf`` and a constant
-`center`, define the set
+If ``r==1``, the method works as follows: for a given pdf and a constant
+``center``, define the set
 ``A = {(u, v) : 0 < v <= sqrt(pdf(u/v + center))}``.
-If ``(U, V)`` is a random vector uniformly distributed over ``A``,
-then ``U/V + center`` follows a distribution according to ``pdf``.
+If (U, V) is a random vector uniformly distributed over A,
+then ``U/V + center`` follows a distribution according to the pdf.
 
-Typical choices of `center` are zero or the mode of `pdf`. The set ``A``
+Typical choices of ``center`` are zero or the mode of the pdf. The set A
 is a subset of the rectangle ``R = [u_min, u_max] x [0, v_max]`` where
 
 * ``v_max = sup_x sqrt(pdf(x))``
 * ``u_min = inf_x (x - center) sqrt(pdf(x))``
 * ``u_max = sup_x (x - center) sqrt(pdf(x))``
 
-In particular, these values are finite if ``pdf`` is bounded and
+In particular, these values are finite if pdf is bounded and
 ``x**2 * pdf(x)`` is bounded (i.e. subquadratic tails).
-One can generate ``(U, V)`` uniformly on ``R`` and return
-``U/V + center`` if ``(U, V)`` are also in ``A`` which can be directly
+One can generate (U, V) uniformly on R and return
+``U/V + center`` if (U, V) are also in A which can be directly
 verified.
 
-The algorithm is not changed if one replaces ``pdf`` by ``k * pdf`` for any
-constant k > 0. Thus, it is often convenient to work with a function
-that is proportional to the probability density function by dropping
-unneccessary normalization factors.
+The algorithm is not changed if one replaces the pdf by a function
+that is proportional to it, e.g., by dropping unneccessary normalization
+factors.
 
-Intuitively, the method works well if ``A`` fills up most of the
-enclosing rectangle such that the probability is high that ``(U, V)``
-lies in ``A`` whenever it lies in ``R`` as the number of required
+Intuitively, the method works well if A fills up most of the
+enclosing rectangle such that the probability is high that (U, V)
+lies in A whenever it lies in R as the number of required
 iterations becomes too large otherwise. To be more precise, note that
-the expected number of iterations to draw ``(U, V)`` uniformly
-distributed on ``R`` such that ``(U, V)`` is also in ``A`` is given by
+the expected number of iterations to draw (U, V) uniformly
+distributed on R such that (U, V) is also in A is given by
 the ratio ``area(R) / area(A) = 2 * v_max * (u_max - u_min) / area(pdf)``,
-where ``area(pdf)`` is the integral of ``pdf`` (which is equal to one if the
+where ``area(pdf)`` is the integral of the pdf (which is equal to one if the
 probability density function is used but can take on other values if a
 function proportional to the density is used). The equality holds since
-the area of ``A`` is equal to ``0.5 * area(pdf)`` (Theorem 7.1 in [4]_).
+the area of A is equal to ``0.5 * area(pdf)`` (Theorem 7.1 in [4]_).
 
 In the general case, the acceptance region is defined as
 ``A = {(u, v) : 0 < v <= (pdf(u/v**r + center))**(1/(r+1))}`` and the

--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -376,6 +376,7 @@ Random variate generation / CDF Inversion
    :toctree: generated/
 
    rvs_ratio_uniforms
+   NaiveRatioUniforms
    NumericalInverseHermite
    NumericalInversePolynomial
    TransformedDensityRejection

--- a/scipy/stats/_unuran/__init__.py
+++ b/scipy/stats/_unuran/__init__.py
@@ -2,5 +2,6 @@ from .unuran_wrapper import (  # noqa: F401
     TransformedDensityRejection,
     DiscreteAliasUrn,
     NumericalInversePolynomial,
+    NaiveRatioUniforms,
     UNURANError
 )

--- a/scipy/stats/_unuran/unuran_wrapper.pyi
+++ b/scipy/stats/_unuran/unuran_wrapper.pyi
@@ -102,8 +102,8 @@ class NROUDist(Protocol):
 class NaiveRatioUniforms(Method):
     def __init__(self,
                  dist: NROUDist,
-                 center: None | float = ...,
                  *,
+                 center: float = ...,
                  domain: None | Tuple[float, float] = ...,
                  r: float = ...,
                  u_min: None | float = ...,

--- a/scipy/stats/_unuran/unuran_wrapper.pyi
+++ b/scipy/stats/_unuran/unuran_wrapper.pyi
@@ -92,6 +92,26 @@ class NumericalInversePolynomial(Method):
     def u_error(self, sample_size: int = ...) -> UError: ...
 
 
+class NROUDist(Protocol):
+    @property
+    def pdf(self) -> Callable[..., float]: ...
+    @property
+    def support(self) -> Tuple[float, float]: ...
+
+
+class NaiveRatioUniforms(Method):
+    def __init__(self,
+                 dist: NROUDist,
+                 center: None | float = ...,
+                 *,
+                 domain: None | Tuple[float, float] = ...,
+                 r: float = ...,
+                 u_min: None | float = ...,
+                 u_max: None | float = ...,
+                 v_max: None | float = ...,
+                 random_state: SeedType = ...) -> None: ...
+
+
 class DAUDist(Protocol):
     @property
     def pmf(self) -> Callable[..., float]: ...

--- a/scipy/stats/_unuran/unuran_wrapper.pyx.templ
+++ b/scipy/stats/_unuran/unuran_wrapper.pyx.templ
@@ -1613,3 +1613,246 @@ cdef class DiscreteAliasUrn(Method):
             pv_view = _validate_pv(dist)
 
         return pv_view, domain
+
+
+cdef class NaiveRatioUniforms(Method):
+    r"""
+    NaiveRatioUniforms(dist, center=0, *, domain=None, r=1.0, u_min=None, u_max=None, v_max=None, random_state=None)
+
+    Naive Ratio-Of-Uniforms (NROU) Method.
+
+    ...
+
+    Parameters
+    ----------
+    dist : object
+        An instance of a class with ``pdf`` method.
+
+        * ``pdf``: PDF of the distribution. The signature of the PDF is
+          expected to be: ``def pdf(self, x: float) -> float``. i.e.
+          the PDF should accept a Python float and the parameters and
+          return a Python float. It doesn't need to integrate to 1 i.e.
+          the PDF doesn't need to be normalized.
+
+    center : float, optional
+        Approximate location of the mode or the mean of the distribution.
+        This location provides some information about the main part of the
+        PDF and is used to avoid numerical problems. Default is ``None``.
+
+    domain : list or tuple of length 2, optional
+        The support of the distribution.
+        Default is ``None``. When ``None``:
+
+        * If a ``support`` method is provided by the distribution object
+          `dist`, it is used to set the domain of the distribution.
+        * Otherwise the support is assumed to be :math:`(-\infty, \infty)`.
+
+    r : float, optional
+        Set parameter ``r > 0`` for generalized Ratio-Of-Uniforms method.
+        The default is 1.0.
+
+    u_min: float
+        Sets the left boundary of the bounding rectangle, see details under
+        Notes. If necessary, consider computing the bound numerically using
+        methods in `scipy.optimize`. Important: The bound has to be
+        provided for ``dist.pdf(x - center)``.
+
+    u_max: float
+        Sets the right boundary of the bounding rectangle. Sets the left
+        boundary of the bounding rectangle, see details under
+        Notes. If necessary, consider computing the bound numerically using
+        methods in `scipy.optimize`. Important: The bound has to be
+        provided for ``dist.pdf(x - center)``.
+
+    v_max: float
+        Sets the upper boundary of the bounding rectangle. If the mode of the
+        pdf is known, it can be easily computed, see Notes for details.
+        Otherwise consider computing the bound numerically using
+        methods in `scipy.optimize`.
+
+    random_state : {None, int, `numpy.random.Generator`,
+                        `numpy.random.RandomState`}, optional
+
+        A NumPy random number generator or seed for the underlying NumPy random
+        number generator used to generate the stream of uniform random numbers.
+        If `random_state` is None (or `np.random`), the `numpy.random.RandomState`
+        singleton is used.
+        If `random_state` is an int, a new ``RandomState`` instance is used,
+        seeded with `random_state`.
+        If `random_state` is already a ``Generator`` or ``RandomState`` instance
+        then that instance is used.
+
+    Notes
+    -----
+
+    NROU is an implementation of the (generalized) ratio-of-uniforms method
+    which uses (minimal) bounding rectangles. It uses a positive control
+    parameter `r` for adjusting the algorithm to the given distribution to
+    improve performance and/or to make this method applicable. Larger values
+    of `r` increase the class of distributions for which the method works at
+    the expense of a higher rejection constant. For computational reasons,
+    ``r=1`` should be used if possible.
+
+    If ``r==1``, the method works as follows: for a given `pdf` and a constant
+    `center`, define the set
+    ``A = {(u, v) : 0 < v <= sqrt(pdf(u/v + center))}``.
+    If `(U, V)` is a random vector uniformly distributed over `A`,
+    then `U/V + center` follows a distribution according to `pdf`.
+
+    Typical choices of `center` are zero or the mode of `pdf`. The set `A` is a
+    subset of the rectangle ``R = [u_min, u_max] x [0, v_max]`` where
+
+    - ``v_max = sup_x sqrt(pdf(x))``
+    - ``u_min = inf_x (x - center) sqrt(pdf(x))``
+    - ``u_max = sup_x (x - center) sqrt(pdf(x))``
+
+    In particular, these values are finite if `pdf` is bounded and
+    ``x**2 * pdf(x)`` is bounded (i.e. subquadratic tails).
+    One can generate `(U, V)` uniformly on `R` and return
+    `U/V + center` if `(U, V)` are also in `A` which can be directly
+    verified.
+
+    The algorithm is not changed if one replaces `pdf` by k * `pdf` for any
+    constant k > 0. Thus, it is often convenient to work with a function
+    that is proportional to the probability density function by dropping
+    unneccessary normalization factors.
+
+    Intuitively, the method works well if `A` fills up most of the
+    enclosing rectangle such that the probability is high that `(U, V)`
+    lies in `A` whenever it lies in `R` as the number of required
+    iterations becomes too large otherwise. To be more precise, note that
+    the expected number of iterations to draw `(U, V)` uniformly
+    distributed on `R` such that `(U, V)` is also in `A` is given by
+    the ratio ``area(R) / area(A) = 2 * v_max * (u_max - u_min) / area(pdf)``,
+    where `area(pdf)` is the integral of `pdf` (which is equal to one if the
+    probability density function is used but can take on other values if a
+    function proportional to the density is used). The equality holds since
+    the area of `A` is equal to 0.5 * area(pdf) (Theorem 7.1 in [4]_).
+
+    In the general case, the acceptance region is defined as
+    ``A = {(u, v) : 0 < v <= (pdf(u/v**r + center))**(1/(r+1))}`` and the
+    bounding rectangle is given by
+
+    - ``v_max = sup_x pdf(x)**(1/(r+1))``
+    - ``u_min = inf_x (x - center) (pdf(x))**(r/(r+1))``
+    - ``u_max = sup_x (x - center) (pdf(x))**(r/(r+1))``
+
+    References
+    ----------
+    .. [1] UNU.RAN reference manual, Section 5.3.11,
+           "NROU - Naive Ratio-Of-Uniforms method",
+           http://statmath.wu.ac.at/software/unuran/doc/unuran.html#NROU
+    .. [2] W. Hörmann, J. Leydold and G. Derflinger (2004). Automatic
+           Nonuniform Random Variate Generation, Springer, Berlin.
+    .. [3] A.J. Kinderman and J.F. Monahan, "Computer Generation of Random
+           Variables Using the Ratio of Uniform Deviates",
+           ACM Transactions on Mathematical Software, 3(3), p. 257--260, 1977.
+    .. [4] L. Devroye, "Non-Uniform Random Variate Generation",
+           Springer-Verlag, 1986.
+
+    Examples
+    --------
+    >>> import math
+    >>> from scipy.stats import NaiveRatioUniforms
+
+    Suppose we want to generate normally distributed random variables.
+    It is easy to compute the bounding rectangle explicitly in that case.
+    Note that we drop the normalization factor of the density. Since the mode
+    of the distribution is located at zero, there is no need to change the
+    default value of the parameter `center`.
+
+    >>> urng = np.random.default_rng()
+    >>> class MyDist:
+    ...     def pdf(self, x):
+    ...         return math.exp(-0.5*x*x)
+    >>> dist = MyDist()
+    >>> u_bound = np.sqrt(dist.pdf(np.sqrt(2))) * np.sqrt(2)
+    >>> v_max = np.sqrt(dist.pdf(0))
+    >>> rng = NaiveRatioUniforms(dist, u_min=-u_bound, u_max=u_bound,
+    ...                          v_max=v_max, random_state=urng)
+
+    Once we have created the generator, we can draw samples of the normal
+    distribution:
+
+    >>> import matplotlib.pyplot as plt
+    >>> rvs = rng.rvs(1000)
+    >>> x = np.linspace(rvs.min()-0.1, rvs.max()+0.1, 100)
+    >>> fx = dist.pdf(x) / np.sqrt(2*np.pi)
+    >>> plt.plot(x, fx, 'r-', lw=2, label='normal pdf')
+    >>> plt.hist(rvs, bins=20, density=True, alpha=0.8, label='random variates')
+    >>> plt.xlabel('x')
+    >>> plt.legend()
+    >>> plt.show()
+
+    """
+
+    def __cinit__(self,
+                  dist,
+                  center=0.0,
+                  *,
+                  domain=None,
+                  r=1.0,
+                  u_min,
+                  u_max,
+                  v_max,
+                  random_state=None):
+        (domain, r, u_min, u_max, v_max) = self._validate_args( dist, domain, r, u_min, u_max, v_max)
+
+        # save all the arguments for pickling support
+        self._kwargs = {
+            'dist': dist,
+            'center': center,
+            'domain': domain,
+            'r': r,
+            'u_min': u_min,
+            'u_max': u_max,
+            'v_max': v_max,
+            'random_state': random_state
+        }
+
+        cdef:
+            unur_distr *distr
+            unur_par *par
+            unur_gen *rng
+
+        self.callbacks = _unpack_dist(dist, "cont", meths=["pdf"])
+        def _callback_wrapper(x, name):
+            return self.callbacks[name](x)
+        self._callback_wrapper = _callback_wrapper
+        self._messages = MessageStream()
+        _lock.acquire()
+        try:
+            unur_set_stream(self._messages.handle)
+
+            self.distr = unur_distr_cont_new()
+            if self.distr == NULL:
+                raise UNURANError(self._messages.get())
+            _pack_distr(self.distr, self.callbacks)
+
+            self._check_errorcode(unur_distr_cont_set_center(self.distr, center))
+            if domain is not None:
+                self._check_errorcode(unur_distr_cont_set_domain(self.distr, domain[0],
+                                                                 domain[1]))
+
+            self.par = unur_nrou_new(self.distr)
+            if self.par == NULL:
+                raise UNURANError(self._messages.get())
+            self._check_errorcode(unur_nrou_set_r(self.par, r))
+
+            self._check_errorcode(unur_nrou_set_u(self.par, u_min, u_max))
+            self._check_errorcode(unur_nrou_set_v(self.par, v_max))
+
+            self._set_rng(random_state)
+        finally:
+            _lock.release()
+
+    cdef object _validate_args(self, dist, domain, r, u_min, u_max, v_max):
+        domain = _validate_domain(domain, dist)
+        if r <= 0:
+            raise ValueError("`r` must be positive.")
+        if v_max <= 0:
+            raise ValueError("`v_max` must be positive.")
+        if u_min >= u_max:
+            raise ValueError("`u_min` must be smaller than `u_max`.")
+
+        return domain, r, u_min, u_max, v_max

--- a/scipy/stats/_unuran/unuran_wrapper.pyx.templ
+++ b/scipy/stats/_unuran/unuran_wrapper.pyx.templ
@@ -1702,41 +1702,40 @@ cdef class NaiveRatioUniforms(Method):
     Notes
     -----
 
-    If ``r==1``, the method works as follows: for a given `pdf` and a constant
+    If ``r==1``, the method works as follows: for a given pdf and a constant
     `center`, define the set
     ``A = {(u, v) : 0 < v <= sqrt(pdf(u/v + center))}``.
-    If `(U, V)` is a random vector uniformly distributed over `A`,
-    then `U/V + center` follows a distribution according to `pdf`.
+    If (U, V) is a random vector uniformly distributed over A,
+    then ``U/V + center`` follows a distribution according to ``dist.pdf``.
 
-    Typical choices of `center` are zero or the mode of `pdf`. The set `A` is a
+    Typical choices of `center` are zero or the mode of pdf. The set A is a
     subset of the rectangle ``R = [u_min, u_max] x [0, v_max]`` where
 
     - ``v_max = sup_x sqrt(pdf(x))``
     - ``u_min = inf_x (x - center) sqrt(pdf(x))``
     - ``u_max = sup_x (x - center) sqrt(pdf(x))``
 
-    In particular, these values are finite if `pdf` is bounded and
+    In particular, these values are finite if the pdf is bounded and
     ``x**2 * pdf(x)`` is bounded (i.e. subquadratic tails).
-    One can generate `(U, V)` uniformly on `R` and return
-    `U/V + center` if `(U, V)` are also in `A` which can be directly
+    One can generate (U, V) uniformly on R and return
+    ``U/V + center`` if (U, V) are also in A which can be directly
     verified.
 
-    The algorithm is not changed if one replaces `pdf` by k * `pdf` for any
-    constant k > 0. Thus, it is often convenient to work with a function
-    that is proportional to the probability density function by dropping
+    The algorithm is not changed if one replaces the pdf by a function
+    that is proportional to it, e.g., by dropping
     unneccessary normalization factors.
 
-    Intuitively, the method works well if `A` fills up most of the
-    enclosing rectangle such that the probability is high that `(U, V)`
-    lies in `A` whenever it lies in `R` as the number of required
+    Intuitively, the method works well if A fills up most of the
+    enclosing rectangle such that the probability is high that (U, V)
+    lies in A whenever it lies in R as the number of required
     iterations becomes too large otherwise. To be more precise, note that
-    the expected number of iterations to draw `(U, V)` uniformly
-    distributed on `R` such that `(U, V)` is also in `A` is given by
+    the expected number of iterations to draw (U, V) uniformly
+    distributed on R such that (U, V) is also in A is given by
     the ratio ``area(R) / area(A) = 2 * v_max * (u_max - u_min) / area(pdf)``,
-    where `area(pdf)` is the integral of `pdf` (which is equal to one if the
-    probability density function is used but can take on other values if a
-    function proportional to the density is used). The equality holds since
-    the area of `A` is equal to 0.5 * area(pdf) (Theorem 7.1 in [4]_).
+    where ``area(pdf)`` is the integral of the pdf (which is equal to one if
+    the true pdf is used but can take on other values if a
+    function proportional to the true pdf is used). The equality holds since
+    the area of A is equal to ``0.5 * area(pdf)`` (Theorem 7.1 in [4]_).
 
     In the general case, the acceptance region is defined as
     ``A = {(u, v) : 0 < v <= (pdf(u/v**r + center))**(1/(r+1))}`` and the

--- a/scipy/stats/_unuran/unuran_wrapper.pyx.templ
+++ b/scipy/stats/_unuran/unuran_wrapper.pyx.templ
@@ -21,6 +21,7 @@ from collections import namedtuple
 import numpy as np
 from scipy.stats._distn_infrastructure import argsreduce
 from scipy._lib._util import check_random_state
+import warnings
 
 
 __all__ = ['UNURANError', 'TransformedDensityRejection', 'DiscreteAliasUrn',
@@ -573,7 +574,7 @@ cdef class TransformedDensityRejection(Method):
 
         * ``pdf``: PDF of the distribution. The signature of the PDF is
           expected to be: ``def pdf(self, x: float) -> float``. i.e.
-          the PDF should accept a Python float and the parameters and
+          the PDF should accept a Python float and
           return a Python float. It doesn't need to integrate to 1 i.e.
           the PDF doesn't need to be normalized.
         * ``dpdf``: Derivative of the PDF w.r.t x (i.e. the variate). Must
@@ -981,9 +982,9 @@ cdef class NumericalInversePolynomial(Method):
         An instance of a class with a ``pdf`` and optionally a ``cdf`` method.
 
         * ``pdf``: PDF of the distribution. The signature of the PDF is expected to be:
-          ``def pdf(self, x: float) -> float``. i.e. the PDF should accept a Python
-          float and return a Python float. It doesn't need to integrate to 1 i.e. the
-          PDF doesn't need to be normalized.
+          ``def pdf(self, x: float) -> float``, i.e., the PDF should accept a Python
+          float and return a Python float. It doesn't need to integrate to 1,
+          i.e., the PDF doesn't need to be normalized.
         * ``cdf``: CDF of the distribution. This method is optional. If provided, it
           enables the calculation of "u-error". See `u_error`. Must have the same
           signature as the PDF.
@@ -1617,7 +1618,7 @@ cdef class DiscreteAliasUrn(Method):
 
 cdef class NaiveRatioUniforms(Method):
     r"""
-    NaiveRatioUniforms(dist, center=0, *, domain=None, r=1.0, u_min=None, u_max=None, v_max=None, random_state=None)
+    NaiveRatioUniforms(dist, *, center=0, domain=None, r=1.0, u_min=None, u_max=None, v_max=None, random_state=None)
 
     Naive Ratio-Of-Uniforms (NROU) Method.
 
@@ -1635,9 +1636,9 @@ cdef class NaiveRatioUniforms(Method):
         An instance of a class with ``pdf`` method.
 
         * ``pdf``: PDF of the distribution. The signature of the PDF is
-          expected to be: ``def pdf(self, x: float) -> float``. i.e.
-          the PDF should accept a Python float and the parameters and
-          return a Python float. It doesn't need to integrate to 1 i.e.
+          expected to be: ``def pdf(self, x: float) -> float``, i.e.,
+          the PDF should accept a Python float and return a Python float.
+          It doesn't need to integrate to 1, i.e.,
           the PDF doesn't need to be normalized.
 
     center : float, optional
@@ -1657,24 +1658,34 @@ cdef class NaiveRatioUniforms(Method):
         Set parameter ``r > 0`` for generalized Ratio-Of-Uniforms method.
         The default is 1.0.
 
-    u_min: float
+    u_min: float, optional
         Sets the left boundary of the bounding rectangle, see details under
         Notes. If necessary, consider computing the bound numerically using
         methods in `scipy.optimize`. Important: The bound has to be
-        provided for ``dist.pdf(x - center)``.
+        provided for ``dist.pdf(x - center)``. If ``None``, a numerical
+        routine will be used to find the bound. This routine can fail,
+        especially when the rectangle is not bounded. Note: If either `u_min`
+        or `u_max` is ``None``, both values are computed numerically.
+        The default is ``None``.
 
-    u_max: float
+    u_max: float, optional
         Sets the right boundary of the bounding rectangle. Sets the left
         boundary of the bounding rectangle, see details under
         Notes. If necessary, consider computing the bound numerically using
         methods in `scipy.optimize`. Important: The bound has to be
-        provided for ``dist.pdf(x - center)``.
+        provided for ``dist.pdf(x - center)``. If ``None``, a numerical
+        routine will be used to find the bound. This routine can fail,
+        especially when the rectangle is not bounded. Note: If either `u_min`
+        or `u_max` is ``None``, both values are computed numerically.
+        The default is ``None``.
 
-    v_max: float
+    v_max: float, optional
         Sets the upper boundary of the bounding rectangle. If the mode of the
         pdf is known, it can be easily computed, see Notes for details.
         Otherwise consider computing the bound numerically using
-        methods in `scipy.optimize`.
+        methods in `scipy.optimize`. If ``None``, a numerical routine will be
+        used to find the bound. This routine can fail, especially when the
+        rectangle is not bounded. The default is ``None``.
 
     random_state : {None, int, `numpy.random.Generator`,
                         `numpy.random.RandomState`}, optional
@@ -1735,6 +1746,9 @@ cdef class NaiveRatioUniforms(Method):
     - ``u_min = inf_x (x - center) (pdf(x))**(r/(r+1))``
     - ``u_max = sup_x (x - center) (pdf(x))**(r/(r+1))``
 
+    The rejection constant is given by
+    ``(r+1) * v_max * (u_max - u_min) / area(pdf)`` in the general case.
+
     References
     ----------
     .. [1] UNU.RAN reference manual, Section 5.3.11,
@@ -1792,11 +1806,11 @@ cdef class NaiveRatioUniforms(Method):
                   *,
                   domain=None,
                   r=1.0,
-                  u_min,
-                  u_max,
-                  v_max,
+                  u_min=None,
+                  u_max=None,
+                  v_max=None,
                   random_state=None):
-        (domain, r, u_min, u_max, v_max) = self._validate_args( dist, domain, r, u_min, u_max, v_max)
+        (domain, r, u_min, u_max, v_max) = self._validate_args(dist, domain, r, u_min, u_max, v_max)
 
         # save all the arguments for pickling support
         self._kwargs = {
@@ -1839,8 +1853,10 @@ cdef class NaiveRatioUniforms(Method):
                 raise UNURANError(self._messages.get())
             self._check_errorcode(unur_nrou_set_r(self.par, r))
 
-            self._check_errorcode(unur_nrou_set_u(self.par, u_min, u_max))
-            self._check_errorcode(unur_nrou_set_v(self.par, v_max))
+            if (u_min is not None) and (u_max is not None):
+                self._check_errorcode(unur_nrou_set_u(self.par, u_min, u_max))
+            if v_max is not None:
+                self._check_errorcode(unur_nrou_set_v(self.par, v_max))
 
             self._set_rng(random_state)
         finally:
@@ -1848,11 +1864,26 @@ cdef class NaiveRatioUniforms(Method):
 
     cdef object _validate_args(self, dist, domain, r, u_min, u_max, v_max):
         domain = _validate_domain(domain, dist)
+        # if one of u_min / u_max is None, set the other to None as well
+        # the reason is that the numerical routine to find the bounds can only
+        # be used for both bounds at the same time
+        warn = False
+        if (u_min is None) and (u_max is not None):
+            u_max = None
+            warn = True
+        if (u_min is not None) and (u_max is None):
+            u_min = None
+            warn = True
+        if warn:
+            msg = ("Only of the values of u_min and u_max is None. "
+                   "The value that is not None is ignored and both values "
+                   "will be computed numerically.")
+            warnings.warn(msg, RuntimeWarning)
         if r <= 0:
             raise ValueError("`r` must be positive.")
-        if v_max <= 0:
+        if (v_max is not None) and (v_max <= 0):
             raise ValueError("`v_max` must be positive.")
-        if u_min >= u_max:
+        if (u_min is not None) and (u_max is not None) and (u_min >= u_max):
             raise ValueError("`u_min` must be smaller than `u_max`.")
 
         return domain, r, u_min, u_max, v_max

--- a/scipy/stats/_unuran/unuran_wrapper.pyx.templ
+++ b/scipy/stats/_unuran/unuran_wrapper.pyx.templ
@@ -1723,12 +1723,12 @@ cdef class NaiveRatioUniforms(Method):
 
     The algorithm is not changed if one replaces the pdf by a function
     that is proportional to it, e.g., by dropping
-    unneccessary normalization factors.
+    unnecessary normalization factors.
 
     Intuitively, the method works well if A fills up most of the
     enclosing rectangle such that the probability is high that (U, V)
     lies in A whenever it lies in R as the number of required
-    iterations becomes too large otherwise. To be more precise, note that
+    iterations become too large otherwise. To be more precise, note that
     the expected number of iterations to draw (U, V) uniformly
     distributed on R such that (U, V) is also in A is given by
     the ratio ``area(R) / area(A) = 2 * v_max * (u_max - u_min) / area(pdf)``,
@@ -1872,7 +1872,6 @@ cdef class NaiveRatioUniforms(Method):
         # if one of u_min / u_max is None, set the other to None as well
         # the reason is that the numerical routine to find the bounds can only
         # be used for both bounds at the same time
-        warn = False
         if (u_min is None) ^ (u_max is None):
             u_min, u_max = None, None
             msg = ("Only one of the values of u_min and u_max is None. "

--- a/scipy/stats/_unuran/unuran_wrapper.pyx.templ
+++ b/scipy/stats/_unuran/unuran_wrapper.pyx.templ
@@ -1621,7 +1621,13 @@ cdef class NaiveRatioUniforms(Method):
 
     Naive Ratio-Of-Uniforms (NROU) Method.
 
-    ...
+    NROU is an implementation of the (generalized) ratio-of-uniforms method
+    which uses (minimal) bounding rectangles ([3]_, [5]_). It uses a positive
+    control parameter `r` for adjusting the algorithm to the given distribution
+    to improve performance and/or to make this method applicable. Larger values
+    of `r` increase the class of distributions for which the method works at
+    the expense of a higher rejection constant. For computational reasons,
+    ``r=1`` should be used if possible.
 
     Parameters
     ----------
@@ -1685,14 +1691,6 @@ cdef class NaiveRatioUniforms(Method):
     Notes
     -----
 
-    NROU is an implementation of the (generalized) ratio-of-uniforms method
-    which uses (minimal) bounding rectangles. It uses a positive control
-    parameter `r` for adjusting the algorithm to the given distribution to
-    improve performance and/or to make this method applicable. Larger values
-    of `r` increase the class of distributions for which the method works at
-    the expense of a higher rejection constant. For computational reasons,
-    ``r=1`` should be used if possible.
-
     If ``r==1``, the method works as follows: for a given `pdf` and a constant
     `center`, define the set
     ``A = {(u, v) : 0 < v <= sqrt(pdf(u/v + center))}``.
@@ -1749,10 +1747,12 @@ cdef class NaiveRatioUniforms(Method):
            ACM Transactions on Mathematical Software, 3(3), p. 257--260, 1977.
     .. [4] L. Devroye, "Non-Uniform Random Variate Generation",
            Springer-Verlag, 1986.
+    .. [5] J. C. Wakefield, A. E. Gelfand, and A. F. M. Smith. "Efficient
+           generation of random variates via the ratio-of-uniforms method."
+           Statistics and Computing 1.2, p. 129--133, 1991.
 
     Examples
     --------
-    >>> import math
     >>> from scipy.stats import NaiveRatioUniforms
 
     Suppose we want to generate normally distributed random variables.
@@ -1764,7 +1764,7 @@ cdef class NaiveRatioUniforms(Method):
     >>> urng = np.random.default_rng()
     >>> class MyDist:
     ...     def pdf(self, x):
-    ...         return math.exp(-0.5*x*x)
+    ...         return np.exp(-0.5*x*x)
     >>> dist = MyDist()
     >>> u_bound = np.sqrt(dist.pdf(np.sqrt(2))) * np.sqrt(2)
     >>> v_max = np.sqrt(dist.pdf(0))

--- a/scipy/stats/_unuran/unuran_wrapper.pyx.templ
+++ b/scipy/stats/_unuran/unuran_wrapper.pyx.templ
@@ -1749,6 +1749,12 @@ cdef class NaiveRatioUniforms(Method):
     The rejection constant is given by
     ``(r+1) * v_max * (u_max - u_min) / area(pdf)`` in the general case.
 
+    Note that in the current implementation, the speed of this generation
+    method is reduced by the fact that the pdf of `dist` needs to be called
+    from C for each random variate that is simulated even if the pdf is
+    vectorized (to simulate N random variates, the average number of
+    evaluations of the pdf is N times the rejection constant).
+
     References
     ----------
     .. [1] UNU.RAN reference manual, Section 5.3.11,
@@ -1802,8 +1808,8 @@ cdef class NaiveRatioUniforms(Method):
 
     def __cinit__(self,
                   dist,
-                  center=0.0,
                   *,
+                  center=0.0,
                   domain=None,
                   r=1.0,
                   u_min=None,
@@ -1868,17 +1874,13 @@ cdef class NaiveRatioUniforms(Method):
         # the reason is that the numerical routine to find the bounds can only
         # be used for both bounds at the same time
         warn = False
-        if (u_min is None) and (u_max is not None):
-            u_max = None
-            warn = True
-        if (u_min is not None) and (u_max is None):
-            u_min = None
-            warn = True
-        if warn:
-            msg = ("Only of the values of u_min and u_max is None. "
+        if (u_min is None) ^ (u_max is None):
+            u_min, u_max = None, None
+            msg = ("Only one of the values of u_min and u_max is None. "
                    "The value that is not None is ignored and both values "
                    "will be computed numerically.")
             warnings.warn(msg, RuntimeWarning)
+
         if r <= 0:
             raise ValueError("`r` must be positive.")
         if (v_max is not None) and (v_max <= 0):

--- a/scipy/stats/tests/test_sampling.py
+++ b/scipy/stats/tests/test_sampling.py
@@ -907,15 +907,32 @@ class TestNaiveRatioUniforms:
                                  v_max=v_max, random_state=357)
         check_cont_samples(rng, dist, (p, p))
 
+    def test_setup_no_bounds(self):
+        dist = StandardNormal()
+        u_bound = np.exp(-0.5) * np.sqrt(2)
+        v_max = 1.0
+
+        # no bound
+        rng = NaiveRatioUniforms(dist, random_state=7303)
+        check_cont_samples(rng, dist, (0, 1))
+        # just v_max
+        rng = NaiveRatioUniforms(dist, v_max=v_max, random_state=7303)
+        check_cont_samples(rng, dist, (0, 1))
+        # just one u-bound is missing
+        msg = 'Only of the values of u_min and u_max is None.'
+        with pytest.warns(RuntimeWarning, match=msg):
+            rng = NaiveRatioUniforms(dist, u_max=u_bound, random_state=7303)
+            check_cont_samples(rng, dist, (0, 1))
+
     def test_exceptions(self):
         dist = StandardNormal()
-        # need vmin < vmax
+        # need u_min < u_max
         msg = r"`u_min` must be smaller than `u_max`."
         with pytest.raises(ValueError, match=msg):
             NaiveRatioUniforms(dist, v_max=1, u_min=3, u_max=1)
         with pytest.raises(ValueError, match=msg):
             NaiveRatioUniforms(dist, v_max=1, u_min=1, u_max=1)
-        # need umax > 0
+        # need v_max > 0
         msg = r'`v_max` must be positive.'
         with pytest.raises(ValueError, match=msg):
             NaiveRatioUniforms(dist, v_max=-1, u_min=1, u_max=3)

--- a/scipy/stats/tests/test_sampling.py
+++ b/scipy/stats/tests/test_sampling.py
@@ -846,8 +846,6 @@ class Gamma:
         self.p = p
 
     def pdf(self, x):
-        if x < 0:
-            return 0.0
         return x**(self.p - 1) * math.exp(-x)
 
     def cdf(self, x):

--- a/scipy/stats/tests/test_sampling.py
+++ b/scipy/stats/tests/test_sampling.py
@@ -919,7 +919,7 @@ class TestNaiveRatioUniforms:
         rng = NaiveRatioUniforms(dist, v_max=v_max, random_state=7303)
         check_cont_samples(rng, dist, (0, 1))
         # just one u-bound is missing
-        msg = 'Only of the values of u_min and u_max is None.'
+        msg = 'Only one of the values of u_min and u_max is None.'
         with pytest.warns(RuntimeWarning, match=msg):
             rng = NaiveRatioUniforms(dist, u_max=u_bound, random_state=7303)
             check_cont_samples(rng, dist, (0, 1))

--- a/scipy/stats/tests/test_sampling.py
+++ b/scipy/stats/tests/test_sampling.py
@@ -1,4 +1,5 @@
 from functools import partial
+import math
 import threading
 import pickle
 import pytest
@@ -840,19 +841,27 @@ class TestNumericalInversePolynomial:
             rng.u_error()
 
 
+class Gamma:
+    def __init__(self, p):
+        self.p = p
+
+    def pdf(self, x):
+        if x < 0:
+            return 0.0
+        return x**(self.p - 1) * math.exp(-x)
+
+    def cdf(self, x):
+        return stats.gamma.cdf(x, self.p)
+
+    @staticmethod
+    def support():
+        return 0, np.inf
+
+
 class TestNaiveRatioUniforms:
 
-    def test_rv_generation(self):
-        # use KS test to check distribution of rvs
-        # normal distribution
-        dist = StandardNormal()
-        u = np.sqrt(dist.pdf(np.sqrt(2))) * np.sqrt(2)
-        v_max = np.sqrt(dist.pdf(0))
-        rng = NaiveRatioUniforms(dist, u_min=-u, u_max=u, v_max=v_max,
-                                 random_state=3756)
-        check_cont_samples(rng, dist, (0, 1))
-        # assert cramervonmises(rvs, 'norm').pvalue > 0.1
-
+    def test_rv_generation_default(self):
+        # use default settings (r=1, center=0)
         # exponential distribution
         class Exponential():
             def pdf(self, x):
@@ -866,6 +875,37 @@ class TestNaiveRatioUniforms:
                                  random_state=76525)
 
         check_cont_samples(rng, dist, (1, 1))
+
+    @pytest.mark.parametrize("r", [0.36, 1.0, 1.43])
+    def test_rv_generation_r(self, r):
+        # test different values of r
+        # note: u_max, u_min are attained at the points -/+ sqrt((r+1)/r)
+        dist = StandardNormal()
+        y = np.sqrt((r+1)/r)
+        u = (dist.pdf(y))**(r/(r+1)) * y
+        v_max = (dist.pdf(0))**(1/(r+1))
+        rng = NaiveRatioUniforms(dist, r=r, u_min=-u, u_max=u, v_max=v_max,
+                                 random_state=7303)
+        check_cont_samples(rng, dist, (0, 1))
+
+    @pytest.mark.parametrize("p", [1.5, 2.83])
+    def test_rv_generation_mode_shift(self, p):
+        # test mode shift with Gamma(p) distribution, mode=p-1
+        # note: the pdf is bounded only if p >= 1
+        # note: u_max, u_min can be computed explicitly
+        def u_bound(x, p, m):
+            if x < 0:
+                return 0
+            return (x - m) * x**((p-1)/2) * math.exp(-x/2)
+        dist = Gamma(p)
+        m = p-1
+        h = (p+1+m)/2
+        k = np.sqrt(h**2 - m*(p-1))
+        u_min, u_max = u_bound(h-k, p, m), u_bound(h+k, p, m)
+        v_max = np.sqrt(dist.pdf(m))
+        rng = NaiveRatioUniforms(dist, center=m, u_min=u_min, u_max=u_max,
+                                 v_max=v_max, random_state=357)
+        check_cont_samples(rng, dist, (p, p))
 
     def test_exceptions(self):
         dist = StandardNormal()


### PR DESCRIPTION
#### Reference issue
gh-14600

#### What does this implement/fix?
add NaiveRatioUniforms from UNU.RAN

this will replace `stats.rvs_ratio_uniforms` (a separate PR to deprecate that function will be submitted once this PR is merged)

#### Additional information

In line with `stats.rvs_ratio_uniforms`, the bounding rectangle has to be specified. One could make it optional and then UNU.RAN would try to find the boundaries numerically. I think it is better to ask users to compute the boundaries using `scipy.optimize` outside of this method to keep the interface simpler (for example, `mode` is not needed) and avoid additional test cases.

The tutorial still needs a bit more work: I will demonstrate how to use `r` and a mode shift (parameter `center`). The related test cases are already implemented, so I mainly need to explain the approach.

- [x] update tutorial
- [x] add benchmarks

Some general feedback on the approach that @tirthasheshpatel  implemented to wrap UNU.RAN: I found it very easy to use. Especially the functionality in `test_sampling.py` is very nice, e.g., to check invalid PDFs, domains etc


