### PR TITLE
DOC: optimize hess and consistency

### DIFF
--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -120,7 +120,8 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
         or dogleg), the keywords {'2-point', '3-point', 'cs'} select a finite
         difference scheme for numerical estimation. Or, objects implementing
         the `HessianUpdateStrategy` interface can be used to approximate the
-        Hessian. Available quasi-Newton methods implementing this interface are:
+        Hessian. Available quasi-Newton methods implementing this interface
+        are:
 
             - `BFGS`;
             - `SR1`.

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -59,7 +59,7 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
         specify the function.
     x0 : ndarray, shape (n,)
         Initial guess. Array of real elements of size (n,),
-        where 'n' is the number of independent variables.
+        where ``n`` is the number of independent variables.
     args : tuple, optional
         Extra arguments passed to the objective function and its
         derivatives (`fun`, `jac` and `hess` functions).
@@ -84,7 +84,7 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
               see below for description.
 
         If not given, chosen to be one of ``BFGS``, ``L-BFGS-B``, ``SLSQP``,
-        depending if the problem has constraints or bounds.
+        depending on if the problem has constraints or bounds.
     jac : {callable,  '2-point', '3-point', 'cs', bool}, optional
         Method for computing the gradient vector. Only for CG, BFGS,
         Newton-CG, L-BFGS-B, TNC, SLSQP, dogleg, trust-ncg, trust-krylov,
@@ -114,14 +114,13 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
 
             ``hess(x, *args) -> {LinearOperator, spmatrix, array}, (n, n)``
 
-        where x is a (n,) ndarray and `args` is a tuple with the fixed
+        where ``x`` is a (n,) ndarray and ``args`` is a tuple with the fixed
         parameters. LinearOperator and sparse matrix returns are only allowed
-        for 'trust-constr' method. Alternatively, the keywords
-        {'2-point', '3-point', 'cs'} select a finite difference scheme
-        for numerical estimation. Or, objects implementing the
-        `HessianUpdateStrategy` interface can be used to approximate
-        the Hessian. Available quasi-Newton methods implementing
-        this interface are:
+        for 'trust-constr' method. Alternatively (not available for Newton-CG
+        or dogleg), the keywords {'2-point', '3-point', 'cs'} select a finite
+        difference scheme for numerical estimation. Or, objects implementing
+        the `HessianUpdateStrategy` interface can be used to approximate the
+        Hessian. Available quasi-Newton methods implementing this interface are:
 
             - `BFGS`;
             - `SR1`.
@@ -141,8 +140,8 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
 
             ``hessp(x, p, *args) ->  ndarray shape (n,)``
 
-        where x is a (n,) ndarray, p is an arbitrary vector with
-        dimension (n,) and `args` is a tuple with the fixed
+        where ``x`` is a (n,) ndarray, ``p`` is an arbitrary vector with
+        dimension (n,) and ``args`` is a tuple with the fixed
         parameters.
     bounds : sequence or `Bounds`, optional
         Bounds on variables for Nelder-Mead, L-BFGS-B, TNC, SLSQP, Powell, and
@@ -153,7 +152,7 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
                is used to specify no bound.
 
     constraints : {Constraint, dict} or List of {Constraint, dict}, optional
-        Constraints definition (only for COBYLA, SLSQP and trust-constr).
+        Constraints definition. Only for COBYLA, SLSQP and trust-constr.
 
         Constraints for 'trust-constr' are defined as a single object or a
         list of objects specifying constraints to the optimization problem.

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -84,7 +84,7 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
               see below for description.
 
         If not given, chosen to be one of ``BFGS``, ``L-BFGS-B``, ``SLSQP``,
-        depending on if the problem has constraints or bounds.
+        depending on whether or not the problem has constraints or bounds.
     jac : {callable,  '2-point', '3-point', 'cs', bool}, optional
         Method for computing the gradient vector. Only for CG, BFGS,
         Newton-CG, L-BFGS-B, TNC, SLSQP, dogleg, trust-ncg, trust-krylov,


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Close #14535 
#### What does this implement/fix?
<!--Please explain your changes.-->

- Clarify `hess` options for `scipy.optimize.minimize`
- Optimize documentation consistency & grammar

#### Additional information
<!--Any additional information you think is important.-->
Might require further work on error messages. Current tracebacks are not informative:
```python
# Newton-CG
TypeError: '<=' not supported between instances of 'int' and '_SumLinearOperator'

# dogleg
TypeError: 'NoneType' object is not callable
```
@tupui 