### PR TITLE
ENH: sparse.linalg: Add an useful nonzero initial guess option

### DIFF
--- a/scipy/sparse/linalg/isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/isolve/tests/test_iterative.py
@@ -520,6 +520,24 @@ def test_x0_working(solver):
     assert_(np.linalg.norm(A.dot(x) - b) <= 1e-6*np.linalg.norm(b))
 
 
+@pytest.mark.parametrize('solver', [cg, cgs, bicg, bicgstab, gmres, qmr, minres, lgmres, gcrotmk])
+def test_x0_equals_Mb(solver):
+    for case in params.cases:
+        if solver in case.skip:
+            continue
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning, ".*called without specifying.*")
+            A = case.A
+            b = case.b
+            x0 = ['Mb']
+            tol = 1e-8
+            x, info = solver(A, b, x0=x0, tol=tol)
+
+            assert_array_equal(x0, ['Mb'])  # ensure that x0 is not overwritten
+            assert_equal(info, 0)
+            assert_normclose(A.dot(x), b, tol=tol)
+
+
 #------------------------------------------------------------------------------
 
 class TestQMR:

--- a/scipy/sparse/linalg/isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/isolve/tests/test_iterative.py
@@ -520,7 +520,8 @@ def test_x0_working(solver):
     assert_(np.linalg.norm(A.dot(x) - b) <= 1e-6*np.linalg.norm(b))
 
 
-@pytest.mark.parametrize('solver', [cg, cgs, bicg, bicgstab, gmres, qmr, minres, lgmres, gcrotmk])
+@pytest.mark.parametrize('solver', [cg, cgs, bicg, bicgstab, gmres, qmr,
+                                    minres, lgmres, gcrotmk])
 def test_x0_equals_Mb(solver):
     for case in params.cases:
         if solver in case.skip:

--- a/scipy/sparse/linalg/isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/isolve/tests/test_iterative.py
@@ -529,11 +529,11 @@ def test_x0_equals_Mb(solver):
             sup.filter(DeprecationWarning, ".*called without specifying.*")
             A = case.A
             b = case.b
-            x0 = ['Mb']
+            x0 = 'Mb'
             tol = 1e-8
             x, info = solver(A, b, x0=x0, tol=tol)
 
-            assert_array_equal(x0, ['Mb'])  # ensure that x0 is not overwritten
+            assert_array_equal(x0, 'Mb')  # ensure that x0 is not overwritten
             assert_equal(info, 0)
             assert_normclose(A.dot(x), b, tol=tol)
 

--- a/scipy/sparse/linalg/isolve/utils.py
+++ b/scipy/sparse/linalg/isolve/utils.py
@@ -116,9 +116,10 @@ def make_system(A, M, x0, b):
     # set initial guess
     if x0 is None:
         x = zeros(N, dtype=xtype)
-    elif len(x0) == 1 and x0[0] == 'Mb':  # use nonzero initial guess ``M * b``
-        bCopy = b.copy()
-        x = M.matvec(bCopy)
+    elif isinstance(x0, str):  # use nonzero initial guess ``M * b``
+        if x0 == 'Mb':
+            bCopy = b.copy()
+            x = M.matvec(bCopy)
     else:
         x = array(x0, dtype=xtype)
         if not (x.shape == (N,1) or x.shape == (N,)):

--- a/scipy/sparse/linalg/isolve/utils.py
+++ b/scipy/sparse/linalg/isolve/utils.py
@@ -41,7 +41,7 @@ def make_system(A, M, x0, b):
         sparse or dense matrix (or any valid input to aslinearoperator)
     x0 : {array_like, None}
         initial guess to iterative method.
-        ``x0 = ['Mb']`` means using the nonzero initial guess ``M * b``.
+        ``x0 = 'Mb'`` means using the nonzero initial guess ``M * b``.
         Default is `None`, which means using the zero initial guess.
     b : array_like
         right hand side

--- a/scipy/sparse/linalg/isolve/utils.py
+++ b/scipy/sparse/linalg/isolve/utils.py
@@ -39,7 +39,7 @@ def make_system(A, M, x0, b):
     M : {LinearOperator, Nones}
         preconditioner
         sparse or dense matrix (or any valid input to aslinearoperator)
-    x0 : {array_like, None}
+    x0 : {array_like, str, None}
         initial guess to iterative method.
         ``x0 = 'Mb'`` means using the nonzero initial guess ``M * b``.
         Default is `None`, which means using the zero initial guess.

--- a/scipy/sparse/linalg/isolve/utils.py
+++ b/scipy/sparse/linalg/isolve/utils.py
@@ -91,15 +91,6 @@ def make_system(A, M, x0, b):
     b = asarray(b,dtype=xtype)  # make b the same type as x
     b = b.ravel()
 
-    if x0 is None:
-        x = zeros(N, dtype=xtype)
-    else:
-        x = array(x0, dtype=xtype)
-        if not (x.shape == (N,1) or x.shape == (N,)):
-            raise ValueError('shapes of A {} and x0 {} are incompatible'
-                            .format(A.shape, x.shape))
-        x = x.ravel()
-
     # process preconditioner
     if M is None:
         if hasattr(A_,'psolve'):
@@ -119,5 +110,18 @@ def make_system(A, M, x0, b):
         M = aslinearoperator(M)
         if A.shape != M.shape:
             raise ValueError('matrix and preconditioner have different shapes')
+
+    # set initial guess
+    if x0 is None:
+        x = zeros(N, dtype=xtype)
+    elif x0 is True:  # use nonzero initial guess ``M * b``
+        bCopy = b.copy()
+        x = M.matvec(bCopy)
+    else:
+        x = array(x0, dtype=xtype)
+        if not (x.shape == (N,1) or x.shape == (N,)):
+            raise ValueError('shapes of A {} and x0 {} are incompatible'
+                            .format(A.shape, x.shape))
+        x = x.ravel()
 
     return A, M, x, b, postprocess

--- a/scipy/sparse/linalg/isolve/utils.py
+++ b/scipy/sparse/linalg/isolve/utils.py
@@ -116,8 +116,8 @@ def make_system(A, M, x0, b):
     # set initial guess
     if x0 is None:
         x = zeros(N, dtype=xtype)
-    elif isinstance(x0, str):  # use nonzero initial guess ``M * b``
-        if x0 == 'Mb':
+    elif isinstance(x0, str):
+        if x0 == 'Mb':  # use nonzero initial guess ``M * b``
             bCopy = b.copy()
             x = M.matvec(bCopy)
     else:

--- a/scipy/sparse/linalg/isolve/utils.py
+++ b/scipy/sparse/linalg/isolve/utils.py
@@ -40,7 +40,9 @@ def make_system(A, M, x0, b):
         preconditioner
         sparse or dense matrix (or any valid input to aslinearoperator)
     x0 : {array_like, None}
-        initial guess to iterative method
+        initial guess to iterative method.
+        ``x0 = ['Mb']`` means using the nonzero initial guess ``M * b``.
+        Default is `None`, which means using the zero initial guess.
     b : array_like
         right hand side
 
@@ -114,14 +116,13 @@ def make_system(A, M, x0, b):
     # set initial guess
     if x0 is None:
         x = zeros(N, dtype=xtype)
-    elif x0 is True:  # use nonzero initial guess ``M * b``
+    elif len(x0) == 1 and x0[0] == 'Mb':  # use nonzero initial guess ``M * b``
         bCopy = b.copy()
         x = M.matvec(bCopy)
     else:
         x = array(x0, dtype=xtype)
         if not (x.shape == (N,1) or x.shape == (N,)):
-            raise ValueError('shapes of A {} and x0 {} are incompatible'
-                            .format(A.shape, x.shape))
+            raise ValueError(f'shapes of A {A.shape} and x0 {x.shape} are incompatible')
         x = x.ravel()
 
     return A, M, x, b, postprocess

--- a/scipy/sparse/linalg/isolve/utils.py
+++ b/scipy/sparse/linalg/isolve/utils.py
@@ -122,8 +122,9 @@ def make_system(A, M, x0, b):
             x = M.matvec(bCopy)
     else:
         x = array(x0, dtype=xtype)
-        if not (x.shape == (N,1) or x.shape == (N,)):
-            raise ValueError(f'shapes of A {A.shape} and x0 {x.shape} are incompatible')
+        if not (x.shape == (N, 1) or x.shape == (N,)):
+            raise ValueError(f'shapes of A {A.shape} and '
+                             f'x0 {x.shape} are incompatible')
         x = x.ravel()
 
     return A, M, x, b, postprocess


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
In this PR, an non-zero initial guess option is added, which allow us to apply preconditioner to right-hand side as initial guess of linear systems. The option can reduce iterative steps for some PDEs based on physical-field.

#### Additional information
<!--Any additional information you think is important.-->