### PR TITLE
DOC: fix inconsistent number in scipy.sparse.csgraph documentation example

### DIFF
--- a/scipy/sparse/csgraph/__init__.py
+++ b/scipy/sparse/csgraph/__init__.py
@@ -140,7 +140,7 @@ and the two have unequal weights, then the smaller of the two is used.
 
 So for the same graph, when ``directed=False`` we get the graph::
 
-    (0)--1--(1)--2--(2)
+    (0)--1--(1)--3--(2)
 
 Note that a symmetric matrix will represent an undirected graph, regardless
 of whether the 'directed' keyword is set to True or False. In this case,


### PR DESCRIPTION
Docs say "If both edges are not null, and the two have unequal weights, then the smaller of the two is used." Yet a value outside of `{G[i, j], G[j, i]}`, is used.

#### What does this implement/fix?
Fixes an incorrect number in scipy.sparse.csgraph documentation.
