### PR TITLE
BUG:signal: matching window dtype to input

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -3278,7 +3278,7 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0),
         max_rate = max(up, down)
         f_c = 1. / max_rate  # cutoff of FIR filter (rel. to Nyquist)
         half_len = 10 * max_rate  # reasonable cutoff for sinc-like function
-        h = firwin(2 * half_len + 1, f_c, window=window)
+        h = firwin(2 * half_len + 1, f_c, window=window).astype(x.dtype)  # match dtype of x
     h *= up
 
     # Zero-pad our filter to put the output samples at the center

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -3278,7 +3278,8 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0),
         max_rate = max(up, down)
         f_c = 1. / max_rate  # cutoff of FIR filter (rel. to Nyquist)
         half_len = 10 * max_rate  # reasonable cutoff for sinc-like function
-        h = firwin(2 * half_len + 1, f_c, window=window).astype(x.dtype)  # match dtype of x
+        h = firwin(2 * half_len + 1, f_c,
+                   window=window).astype(x.dtype)  # match dtype of x
     h *= up
 
     # Zero-pad our filter to put the output samples at the center

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1260,7 +1260,7 @@ class TestResample:
 
     @pytest.mark.parametrize('padtype', padtype_options)
     @pytest.mark.parametrize('dtype', [np.float32, np.float64])
-    def test_output_match_dtype(self, padtype):
+    def test_output_match_dtype(self, padtype, dtype):
         # Test that the dtype of x is preserved per issue #14733
         x = np.arange(10, dtype=dtype)
         y = signal.resample_poly(x, 1, 2, padtype=padtype)

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1258,6 +1258,14 @@ class TestResample:
         y = signal.resample_poly(x, 1, 2, window=h, padtype=padtype)
         assert(y.dtype == np.float32)
 
+    @pytest.mark.parametrize('padtype', padtype_options)
+    @pytest.mark.parametrize('dtype', [np.float32, np.float64])
+    def test_output_match_dtype(self, padtype):
+        # Test that the dtype of x is preserved per issue #14733
+        x = np.arange(10, dtype=dtype)
+        y = signal.resample_poly(x, 1, 2, padtype=padtype)
+        assert(y.dtype == x.dtype)
+
     @pytest.mark.parametrize(
         "method, ext, padtype",
         [("fft", False, None)]


### PR DESCRIPTION
#### Reference issue
Closes #14733 

#### What does this implement/fix?

When resample_poly constructs an FIR window, the window's dtype now matches that of the input signal to avoid accidental dtype promotion.

#### Additional information

I've left the other case, where the window is explicitly provided as a list/ndarray unchanged.  The current implementation resolves these by forcing through `np.array()` with no dtype specified.  I think it could also make sense to separate these two cases, where dtype is specified to match `x` when the window is a list, but leave it as is when window is given as an ndarray.  I'm happy to make that change too, but wanted to solicit input from the maintainers before doing it.
