### PR TITLE
DOC: fix maximum_flow trivial example matrix

### DIFF
--- a/scipy/sparse/csgraph/_flow.pyx
+++ b/scipy/sparse/csgraph/_flow.pyx
@@ -147,7 +147,7 @@ def maximum_flow(csgraph, source, sink, *, method='dinic'):
     A less trivial example is given in [2]_, Chapter 26.1:
 
     >>> graph = csr_matrix([[0, 16, 13,  0,  0,  0],
-    ...                     [0, 10,  0, 12,  0,  0],
+    ...                     [0,  0, 10, 12,  0,  0],
     ...                     [0,  4,  0,  0, 14,  0],
     ...                     [0,  0,  9,  0,  0, 20],
     ...                     [0,  0,  0,  7,  0,  4],


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Reopening previously approved PR #14730 (closed due to incorrect revert from my end)
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
Fixes the matrix in the documentation example to match the referenced example in [[2]](https://web.ist.utl.pt/~fabio.ferreira/material/asa/clrs.pdf), Chapter 26.1 
<!--Please explain your changes.-->

#### Additional information
If this is not fixed, the maximum flow of erroneous example gives a residue graph with no flow from source to sink. 
<!--Any additional information you think is important.-->
