### PR TITLE
TST:sparse.linalg: Use the more convenient "assert_normclose" in "test_minres.py"

### DIFF
--- a/scipy/sparse/linalg/isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/isolve/tests/test_iterative.py
@@ -206,8 +206,8 @@ def test_maxiter():
 
 def assert_normclose(a, b, tol=1e-8):
     residual = norm(a - b)
-    tolerance = tol*norm(b)
-    msg = "residual (%g) not smaller than tolerance %g" % (residual, tolerance)
+    tolerance = tol * norm(b)
+    msg = f"residual ({residual}) not smaller than tolerance ({tolerance})"
     assert_(residual < tolerance, msg=msg)
 
 

--- a/scipy/sparse/linalg/isolve/tests/test_minres.py
+++ b/scipy/sparse/linalg/isolve/tests/test_minres.py
@@ -70,7 +70,7 @@ def test_minres_non_default_x0():
     b = np.random.randn(5)
     c = np.random.randn(5)
     x = minres(a, b, x0=c, tol=tol)[0]
-    assert norm(a.dot(x) - b) < tol
+    assert_normclose(a.dot(x), b, tol=tol)
 
 
 def test_minres_precond_non_default_x0():
@@ -83,7 +83,7 @@ def test_minres_precond_non_default_x0():
     m = np.random.randn(5, 5)
     m = np.dot(m, m.T)
     x = minres(a, b, M=m, x0=c, tol=tol)[0]
-    assert norm(a.dot(x) - b) < tol
+    assert_normclose(a.dot(x), b, tol=tol)
 
 
 def test_minres_precond_exact_x0():
@@ -95,4 +95,4 @@ def test_minres_precond_exact_x0():
     m = np.random.randn(10, 10)
     m = np.dot(m, m.T)
     x = minres(a, b, M=m, x0=c, tol=tol)[0]
-    assert norm(a.dot(x) - b) < tol
+    assert_normclose(a.dot(x), b, tol=tol)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
A bug fix: the convergence condition should be `||b - Ax|| < tol * ||b||`, where `tol` is the tolerance of relative residual in MINRES algorithm. 

#### Additional information
<!--Any additional information you think is important.-->
