### PR TITLE
ENH: numpy masked_arrays in refguide-check

### DIFF
--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -477,6 +477,7 @@ CHECK_NAMESPACE = {
       # recognize numpy repr's
       'array': np.array,
       'matrix': np.matrix,
+      'masked_array': np.ma.masked_array,
       'int64': np.int64,
       'uint64': np.uint64,
       'int8': np.int8,
@@ -609,6 +610,14 @@ class Checker(doctest.OutputChecker):
             if cond:
                 s_want = ", ".join(s_want[1:-1].split())
                 s_got = ", ".join(s_got[1:-1].split())
+                return self.check_output(s_want, s_got, optionflags)
+
+            # maybe we are dealing with masked arrays?
+            # their repr uses '--' for masked values and this is invalid syntax.
+            # If so, replace '--' by nans (they are masked anyway) and retry
+            if 'masked_array' in want or 'masked_array' in got:
+                s_want = want.replace('--', 'nan')
+                s_got = got.replace('--', 'nan')
                 return self.check_output(s_want, s_got, optionflags)
 
             if "=" not in want and "=" not in got:


### PR DESCRIPTION
Try handling numpy masked arrays in refguide-check. The is supposed to fix the issue seen at https://github.com/scipy/scipy/pull/14748#discussion_r711771773, where the crux --- I believe --- is that

```
masked_array(
      data=[[ --, 1.0, 2.0,  --],
            [ --,  --,  --, 1.0],
            [ --,  --,  --, 3.0],
            [ --,  --,  --,  --]],
      mask=[[ True, False, False,  True],
            [ True,  True,  True, False],
            [ True,  True,  True, False],
            [ True,  True,  True,  True]],
 fill_value=1e+20)
```

fails to `eval` because of `"--"` symbols and thus refguide-check falls back to the vanilla doctest. 

This fix is not tested, so really a proper test would be to run it on gh-14748 @tupui @dayyass 

P.S. The fact that refguide-check CI job passes on this PR is irrelevant, it was passing on master as well.