### PR TITLE
BLD: change section name in site.cfg.example from ALL to DEFAULT

### DIFF
--- a/site.cfg.example
+++ b/site.cfg.example
@@ -83,7 +83,7 @@
 # This is a good place to add general library and include directories like
 # /usr/local/{lib,include}
 #
-#[ALL]
+#[DEFAULT]
 #library_dirs = /usr/local/lib
 #include_dirs = /usr/local/include
 #


### PR DESCRIPTION
ALL is not meant for general use (although it does seem to work), as documented in the docstring of `numpy.distutils.system_info`.

Closes gh-14746

[ci skip]