### PR TITLE
TST: suppress jinja2 deprecation warning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -12,3 +12,5 @@ filterwarnings =
     once:the imp module is deprecated in favour of importlib.*:DeprecationWarning
     once:the imp module is deprecated in favour of importlib.*:PendingDeprecationWarning
     ignore:assertions not in test modules or plugins:pytest.PytestConfigWarning
+    ignore:'environmentfilter' is renamed to 'pass_environment'
+    ignore:'contextfunction' is renamed to 'pass_context'


### PR DESCRIPTION
This is triggered by Sphinx, which is imported during test discovery for
`doc/sphinxext/numpydoc/tests/test_numpydoc.py`,
and breaks running the test suite in a development branch.

Relevant part of the traceback:
```
____________ ERROR collecting doc/sphinxext/numpydoc/tests/test_numpydoc.py ____________
../scipy/doc/sphinxext/numpydoc/tests/test_numpydoc.py:3: in <module>
    from numpydoc.numpydoc import mangle_docstrings, _clean_text_signature

...

        __name__   = 'sphinx.jinja2glue'
        __package__ = 'sphinx'
        __spec__   = ModuleSpec(name='sphinx.jinja2glue', loader=<_frozen_importlib_external.SourceFileLoader object at 0x7f014be80070>, origin='/home/rgommers/anaconda3/envs/scipy-dev/lib/python3.8/site-packages/sphinx/jinja2glue.py')
        __warningregistry__ = {'version': 126}
        _slice_index = <function _slice_index at 0x7f014c001d30>
        _tobool    = <function _tobool at 0x7f014c001430>
        _todim     = <function _todim at 0x7f014c001ca0>
        _toint     = <function _toint at 0x7f014c001c10>
        accesskey  = <function accesskey at 0x7f014c001dc0>
        contextfunction = <function contextfunction at 0x7f014cfb8160>
        idgen      = <class 'sphinx.jinja2glue.idgen'>
        logging    = <module 'sphinx.util.logging' from '/home/rgommers/anaconda3/envs/scipy-dev/lib/python3.8/site-packages/sphinx/util/logging.py'>
        mtimes_of_files = <function mtimes_of_files at 0x7f014c9d28b0>
        open_if_exists = <function open_if_exists at 0x7f014cfb8670>
        path       = <module 'posixpath' from '/home/rgommers/anaconda3/envs/scipy-dev/lib/python3.8/posixpath.py'>
        pformat    = <function pformat at 0x7f015b839940>
../../anaconda3/envs/scipy-dev/lib/python3.8/site-packages/jinja2/utils.py:110: in contextfunction
    warnings.warn(
E   DeprecationWarning: 'contextfunction' is renamed to 'pass_context', the old name will be removed in Jinja 3.1.
```

EDIT: relevant package versions:
```
jinja2                    3.0.1              pyhd8ed1ab_0    conda-forge
numpydoc                  1.1.0                      py_1    conda-forge
sphinx                    3.5.4              pyh44b312d_0    conda-forge
```