### PR TITLE
CI: remove `pre_release_deps_source_dist` job from Azure CI config

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,21 +55,6 @@ stages:
   variables:
     AZURE_CI: 'true'
   jobs:
-  - job: pre_release_deps_source_dist
-    condition: eq(variables['System.PullRequest.TargetBranch'], 'master')
-    pool:
-      vmImage: 'ubuntu-18.04'
-    steps:
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '3.9'
-        addToPath: true
-        architecture: 'x64'
-    - template: ci/azure-travis-template.yaml
-      parameters:
-        test_mode: fast
-        numpy_spec: "--pre --upgrade --timeout=60 -i $(PRE_WHEELS) numpy"
-        other_spec: "--pre --upgrade --timeout=60"
   - job: coverage_full_tests
     pool:
       vmImage: 'ubuntu-18.04'


### PR DESCRIPTION
See gh-14732 for context. The similarly named job
`prerelease_deps_64bit_blas` covers what we remove here. There are
other jobs that test with 32-bit BLAS on Linux. The job we leave runs
the full test suite, the one that is removed here the fast test suite.

This cuts down on CI time and also on duplicate failures.

What I suspect is that, given the name of the job, it used to install from `sdist`. It does not do that anymore though, maybe that got lost in the TravisCI -> Azure move. Either way, we have too many CI jobs and this one is not very interesting.

[skip github]
