### PR TITLE
TST: add a seed to the pickling test of RBFInterpolator

### DIFF
--- a/scipy/interpolate/tests/test_rbfinterp.py
+++ b/scipy/interpolate/tests/test_rbfinterp.py
@@ -362,7 +362,7 @@ class _TestRBFInterpolator:
     def test_pickleable(self):
         # Make sure we can pickle and unpickle the interpolant without any
         # changes in the behavior.
-        seq = Halton(1, scramble=False, seed=np.random.RandomState())
+        seq = Halton(1, scramble=False, seed=np.random.RandomState(2305982309))
 
         x = 3*seq.random(50)
         xitp = 3*seq.random(50)


### PR DESCRIPTION
xref gh-14732. This test is crashing most of the time in two CI jobs, but not always. This doesn't fix the root cause, but should make the test more reproducible.

[skip github]
