### PR TITLE
MAINT: Make solve_ivp slightly more strict wrt. t_span.

### DIFF
--- a/scipy/integrate/_ivp/ivp.py
+++ b/scipy/integrate/_ivp/ivp.py
@@ -505,7 +505,7 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
         raise ValueError("`method` must be one of {} or OdeSolver class."
                          .format(METHODS))
 
-    t0, tf = float(t_span[0]), float(t_span[1])
+    t0, tf = map(float, t_span)
 
     if args is not None:
         # Wrap the user's fun (and jac, if given) in lambdas to hide the


### PR DESCRIPTION
Previously, `len(t_span) > 2` would be silently ignored, which can lead
to confusing errors downstream if e.g. t_span and y0 were accidentally
inverted.  For example,
`solve_ivp(lambda t, y: -.5 * y, [2, 4, 8], [0, 10], t_eval=[0, 1, 2, 4, 10])`
(from the docstring examples, but inverting t_span and y0) would result
in "Values in `t_eval` are not within `t_span`".

Instead, add an implicit check that `len(t_span) == 2` (via unpacking);
the error for the above case is now "too many values to unpack" and
explicitly points to `t_span`.  (One could also add an explicit check,
but it's unclear whether it's worth it?)

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
