### PR TITLE
ENH: interpolate: Add the "coord" attribution to get non-reduced Lagrange coefficients

### DIFF
--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -100,7 +100,7 @@ class lagrange(poly1d):
         diff = self._M - len(self.coeffs)
         if diff > 0:
             tmp = np.zeros(diff)
-            self._coord = np.insert(self.coeffs, 0, tmp)
+            self._coord = np.append(tmp, self.coeffs)
         else:
             self._coord = self.coeffs
         return self._coord

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -753,13 +753,22 @@ class TestInterp1D:
 
 
 class TestLagrange:
-
     def test_lagrange(self):
-        p = poly1d([5,2,1,4,3])
+        p = poly1d([5, 2, 1, 4, 3])
         xs = np.arange(len(p.coeffs))
         ys = p(xs)
-        pl = lagrange(xs,ys)
-        assert_array_almost_equal(p.coeffs,pl.coeffs)
+        pl = lagrange(xs, ys)
+        assert_array_almost_equal(p.coeffs, pl.coeffs)
+        assert_array_equal(pl.coord, pl.coeffs)
+
+    def test_reduced_coeffs(self):
+        a = np.array([0, 2, 1])
+        p = poly1d(a)
+        x = np.arange(len(a))
+        y = p(x)
+        pl = lagrange(x, y)
+        assert_array_almost_equal(a, pl.coord)
+        assert_array_almost_equal(p.coeffs, pl.coeffs)
 
 
 class TestAkima1DInterpolator:


### PR DESCRIPTION
Add the "coord" attribution to get non-reduced Lagrange coefficients.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
To solve the issue #14681 

#### What does this implement/fix?
<!--Please explain your changes.-->
Added the `coord` attribution to support complete Lagrange interpolation coefficients (the solution of the issue #14681)

#### Additional information
<!--Any additional information you think is important.-->
Usage:
```python
import numpy as np
from scipy.interpolate import lagrange

x = np.array([0, 1, 2], dtype=float)
y = np.ones(3, dtype=float)
y *= 0.5
poly = lagrange(x, y)
# Check the reduced coefficients
print(f"Reduced coefficient: {poly.coeffs}")
# Check the complete coefficients
print(f"Complete coefficient: {poly.coord}")
```