### PR TITLE
ENH: interpolate: Make an improvement to support complete coefficients (the second way of #14773)

### DIFF
--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -75,7 +75,6 @@ def lagrange(x, w):
     ...          label=r"$3 x^2 - 2 x$", linestyle='-.')
     >>> plt.legend()
     >>> plt.show()
-
     """
 
     M = len(x)
@@ -88,6 +87,17 @@ def lagrange(x, w):
             fac = x[j]-x[k]
             pt *= poly1d([1.0, -x[k]])/fac
         p += pt
+    # Add the attribute 'coord' to a 'poly1d' object. which is initialized as 'p.coeffs'
+    p.coord = p.coeffs
+    diff = M - len(p.coeffs)
+    # If the number of interpolation points is greater than the number of
+    # polynomial coefficients, zeros will be filled in the later to ensure
+    # the size of the both is equal, that is the size of 'p.coord' is same
+    # as the size of 'x' and 'p.coord' equals 'p.coeffs' except for these
+    # zero fill-in
+    if diff > 0:
+        tmp = np.zeros(diff)
+        p.coord = np.append(tmp, p.coeffs)
     return p
 
 

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -87,7 +87,8 @@ def lagrange(x, w):
             fac = x[j]-x[k]
             pt *= poly1d([1.0, -x[k]])/fac
         p += pt
-    # Add the attribute 'coord' to a 'poly1d' object. which is initialized as 'p.coeffs'
+    # Add the attribute 'coord' to a 'poly1d' object. which is initialized
+    # as 'p.coeffs'
     p.coord = p.coeffs
     diff = M - len(p.coeffs)
     # If the number of interpolation points is greater than the number of

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -753,13 +753,26 @@ class TestInterp1D:
 
 
 class TestLagrange:
-
-    def test_lagrange(self):
-        p = poly1d([5,2,1,4,3])
+    # To test the case when the number of interpolation points equals
+    # the number of polynomial coefficients
+    def test_complete_coeffs(self):
+        p = poly1d([5, 2, 1, 4, 3])
         xs = np.arange(len(p.coeffs))
         ys = p(xs)
-        pl = lagrange(xs,ys)
-        assert_array_almost_equal(p.coeffs,pl.coeffs)
+        pl = lagrange(xs, ys)
+        assert_allclose(p.coeffs, pl.coeffs, atol=1e-14)
+        assert_allclose(pl.coeffs, pl.coord)
+
+    # To test the case when the number of interpolation points is greater than
+    # the number of polynomial coefficients
+    def test_reduced_coeffs(self):
+        a = np.array([0, 2, 1])
+        p = poly1d(a)
+        x = np.arange(len(a))
+        y = p(x)
+        pl = lagrange(x, y)
+        assert_allclose(p.coeffs, pl.coeffs, atol=1e-14)
+        assert_allclose(a, pl.coord, atol=1e-14)
 
 
 class TestAkima1DInterpolator:


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
To solve #14681 
The first implementation way: #14773 

#### What does this implement/fix?
<!--Please explain your changes.-->
Make some improvements with the function `lagrange` ( the second implementation way of #14773)

#### Additional information
<!--Any additional information you think is important.-->
Usage:
```python
from scipy.interpolate import lagrange

x = np.arange(3)
y = np.ones(3)
y *= 0.5
pl = lagrange(x, y, reduce=False)
print(f"Zero-filled coefficients: {pl.coord}")
print(f"Standard coefficients: {pl.coeffs}")

pl = lagrange(x, y, reduce=True)
print(f"Non-zero-filled coefficients: {pl.coord}")
print(f"Standard coefficients: {pl.coeffs}")
```