### PR TITLE
MAINT: Increase tolerance values to avoid test failures

### DIFF
--- a/scipy/sparse/linalg/eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/eigen/tests/test_svds.py
@@ -223,7 +223,7 @@ class SVDSCommonTests:
         rng = np.random.default_rng(0)
         A = rng.random((10, 10))
         res = svds(A, k=k, which=which, solver=self.solver, random_state=0)
-        _check_svds(A, k, *res, which=which, atol=2e-9)
+        _check_svds(A, k, *res, which=which, atol=8e-10)
 
     # loop instead of parametrize for simplicity
     def test_svds_parameter_tol(self):
@@ -252,7 +252,7 @@ class SVDSCommonTests:
         tols = [1e-4, 1e-2, 1e0]  # tolerance levels to check
         # for 'arpack' and 'propack', accuracies make discrete steps
         accuracies = {'propack': [1e-12, 1e-6, 1e-4],
-                      'arpack': [1e-14, 1e-10, 1e-10],
+                      'arpack': [5e-15, 1e-10, 1e-10],
                       'lobpcg': [1e-11, 1e-3, 10]}
 
         for tol, accuracy in zip(tols, accuracies[self.solver]):

--- a/scipy/sparse/linalg/eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/eigen/tests/test_svds.py
@@ -223,7 +223,7 @@ class SVDSCommonTests:
         rng = np.random.default_rng(0)
         A = rng.random((10, 10))
         res = svds(A, k=k, which=which, solver=self.solver, random_state=0)
-        _check_svds(A, k, *res, which=which, atol=2e-10)
+        _check_svds(A, k, *res, which=which, atol=2e-9)
 
     # loop instead of parametrize for simplicity
     def test_svds_parameter_tol(self):
@@ -252,7 +252,7 @@ class SVDSCommonTests:
         tols = [1e-4, 1e-2, 1e0]  # tolerance levels to check
         # for 'arpack' and 'propack', accuracies make discrete steps
         accuracies = {'propack': [1e-12, 1e-6, 1e-4],
-                      'arpack': [1e-15, 1e-10, 1e-10],
+                      'arpack': [1e-14, 1e-10, 1e-10],
                       'lobpcg': [1e-11, 1e-3, 10]}
 
         for tol, accuracy in zip(tols, accuracies[self.solver]):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
* https://github.com/rgommers/scipy/pull/68

<details>
<summary> 

1.  Failing tests on Linux(locally)</summary>

<p>

```py

=================================== FAILURES ===================================
___________________ Test_SVDS_ARPACK.test_svds_parameter_tol ___________________

self = <scipy.sparse.linalg.eigen.tests.test_svds.Test_SVDS_ARPACK object at 0x7f1a6284f1f0>

    def test_svds_parameter_tol(self):
        # check the effect of the `tol` parameter on solver accuracy by solving
        # the same problem with varying `tol` and comparing the eigenvalues
        # against ground truth computed
        n = 100  # matrix size
        k = 3    # number of eigenvalues to check
    
        # generate a random, sparse-ish matrix
        # effect isn't apparent for matrices that are too small
        rng = np.random.default_rng(0)
        A = rng.random((n, n))
        A[A > .1] = 0
        A = A @ A.T
    
        _, s, _ = svd(A)  # calculate ground truth
    
        # calculate the error as a function of `tol`
        A = csc_matrix(A)
    
        def err(tol):
            _, s2, _ = svds(A, k=k, v0=np.ones(n), solver=self.solver, tol=tol)
            return np.linalg.norm((s2 - s[k-1::-1])/s[k-1::-1])
    
        tols = [1e-4, 1e-2, 1e0]  # tolerance levels to check
        # for 'arpack' and 'propack', accuracies make discrete steps
        accuracies = {'propack': [1e-12, 1e-6, 1e-4],
                      'arpack': [1e-15, 1e-10, 1e-10],
                      'lobpcg': [1e-11, 1e-3, 10]}
    
        for tol, accuracy in zip(tols, accuracies[self.solver]):
            error = err(tol)
>           assert error < accuracy
E           assert 1.3722998529102833e-15 < 1e-15

A          = <100x100 sparse matrix of type '<class 'numpy.float64'>'
	with 6624 stored elements in Compressed Sparse Column format>
_          = array([[-0.06798121, -0.06969187, -0.1634784 , ..., -0.08870255,
        -0.08289897, -0.07725935],
       [-0.0130691...722,  0.12174589],
       [ 0.03737577,  0.07600953, -0.04798564, ..., -0.08283926,
        -0.04644228,  0.04356348]])
accuracies = {'arpack': [1e-15, 1e-10, 1e-10], 'lobpcg': [1e-11, 0.001, 10], 'propack': [1e-12, 1e-06, 0.0001]}
accuracy   = 1e-15
err        = <function SVDSCommonTests.test_svds_parameter_tol.<locals>.err at 0x7f1a63fddd30>
error      = 1.3722998529102833e-15
k          = 3
n          = 100
rng        = Generator(PCG64) at 0x7F1A628A54A0
s          = array([3.57532733e-01, 1.27553875e-01, 1.19870964e-01, 1.15829350e-01,
       1.12545658e-01, 1.09114116e-01, 1.028058...2.69065672e-04, 1.72149810e-04, 1.65442589e-04,
       7.44147686e-05, 3.32524683e-05, 2.12349114e-06, 1.50715281e-07])
self       = <scipy.sparse.linalg.eigen.tests.test_svds.Test_SVDS_ARPACK object at 0x7f1a6284f1f0>
tol        = 0.0001
tols       = [0.0001, 0.01, 1.0]

sparse/linalg/eigen/tests/test_svds.py:260: AssertionError
_____________ Test_SVDS_PROPACK.test_svds_parameter_k_which[LM-5] ______________

self = <scipy.sparse.linalg.eigen.tests.test_svds.Test_SVDS_PROPACK object at 0x7f1a627d4040>
k = 5, which = 'LM'

    @pytest.mark.parametrize("k", [3, 5])
    @pytest.mark.parametrize("which", ["LM", "SM"])
    def test_svds_parameter_k_which(self, k, which):
        # check that the `k` parameter sets the number of eigenvalues/
        # eigenvectors returned.
        # Also check that the `which` parameter sets whether the largest or
        # smallest eigenvalues are returned
        rng = np.random.default_rng(0)
        A = rng.random((10, 10))
        res = svds(A, k=k, which=which, solver=self.solver, random_state=0)
>       _check_svds(A, k, *res, which=which, atol=2e-10)

A          = array([[0.63696169, 0.26978671, 0.04097352, 0.01652764, 0.81327024,
        0.91275558, 0.60663578, 0.72949656, 0.5436..., 0.96792619, 0.0147063 , 0.86364009, 0.98119504,
        0.95721018, 0.14876401, 0.97262881, 0.88993556, 0.82237383]])
k          = 5
res        = (array([[-0.32771492,  0.4158033 , -0.53137496,  0.02426458,  0.31783075],
       [-0.39239685, -0.02251468, -0.063087...54 ,  0.21588656,  0.29722489,  0.31843038,
         0.31819307,  0.28881893,  0.46509902,  0.29898348,  0.31066731]]))
rng        = Generator(PCG64) at 0x7F1A63E8A900
self       = <scipy.sparse.linalg.eigen.tests.test_svds.Test_SVDS_PROPACK object at 0x7f1a627d4040>
which      = 'LM'

sparse/linalg/eigen/tests/test_svds.py:226: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

A = array([[0.63696169, 0.26978671, 0.04097352, 0.01652764, 0.81327024,
        0.91275558, 0.60663578, 0.72949656, 0.5436..., 0.96792619, 0.0147063 , 0.86364009, 0.98119504,
        0.95721018, 0.14876401, 0.97262881, 0.88993556, 0.82237383]])
k = 5
u = array([[-0.32771492,  0.4158033 , -0.53137496,  0.02426458,  0.31783075],
       [-0.39239685, -0.02251468, -0.0630873...84 , -0.12697327, -0.09277105,  0.34919585],
       [-0.26457914, -0.13503641, -0.15837359,  0.53003248,  0.42841613]])
s = array([0.90017941, 0.97420967, 1.26999904, 1.59849819, 5.71090105])
vh = array([[-0.42927645, -0.02385317,  0.21368543,  0.47797589, -0.42344063,
         0.30012128,  0.03406212,  0.19590089...554 ,  0.21588656,  0.29722489,  0.31843038,
         0.31819307,  0.28881893,  0.46509902,  0.29898348,  0.31066731]])
which = 'LM', check_usvh_A = False, check_svd = True, atol = 2e-10, rtol = 1e-07

    def _check_svds(A, k, u, s, vh, which="LM", check_usvh_A=False,
                    check_svd=True, atol=1e-10, rtol=1e-7):
        n, m = A.shape
    
        # Check shapes.
        assert_equal(u.shape, (n, k))
        assert_equal(s.shape, (k,))
        assert_equal(vh.shape, (k, m))
    
        # Check that the original matrix can be reconstituted.
        A_rebuilt = (u*s).dot(vh)
        assert_equal(A_rebuilt.shape, A.shape)
        if check_usvh_A:
            assert_allclose(A_rebuilt, A, atol=atol, rtol=rtol)
    
        # Check that u is a semi-orthogonal matrix.
        uh_u = np.dot(u.T.conj(), u)
        assert_equal(uh_u.shape, (k, k))
>       assert_allclose(uh_u, np.identity(k), atol=atol, rtol=rtol)
E       AssertionError: 
E       Not equal to tolerance rtol=1e-07, atol=2e-10
E       
E       Mismatched elements: 2 / 25 (8%)
E       Max absolute difference: 2.31723081e-10
E       Max relative difference: 4.01900735e-14
E        x: array([[ 1.000000e+00,  7.318203e-15,  6.765278e-15, -5.120791e-14,
E                3.459577e-11],
E              [ 7.318203e-15,  1.000000e+00,  5.997672e-16,  1.625355e-13,...
E        y: array([[1., 0., 0., 0., 0.],
E              [0., 1., 0., 0., 0.],
E              [0., 0., 1., 0., 0.],...

A          = array([[0.63696169, 0.26978671, 0.04097352, 0.01652764, 0.81327024,
        0.91275558, 0.60663578, 0.72949656, 0.5436..., 0.96792619, 0.0147063 , 0.86364009, 0.98119504,
        0.95721018, 0.14876401, 0.97262881, 0.88993556, 0.82237383]])
A_rebuilt  = array([[ 0.62664866,  0.26143156,  0.11583711,  0.10946253,  0.90237439,
         0.86426285,  0.54138144,  0.62698622...6753, -0.05990525,  0.81456418,  0.85739979,
         1.00404725,  0.21265842,  1.03219384,  0.92104378,  0.79572735]])
atol       = 2e-10
check_svd  = True
check_usvh_A = False
k          = 5
m          = 10
n          = 10
rtol       = 1e-07
s          = array([0.90017941, 0.97420967, 1.26999904, 1.59849819, 5.71090105])
u          = array([[-0.32771492,  0.4158033 , -0.53137496,  0.02426458,  0.31783075],
       [-0.39239685, -0.02251468, -0.0630873...84 , -0.12697327, -0.09277105,  0.34919585],
       [-0.26457914, -0.13503641, -0.15837359,  0.53003248,  0.42841613]])
uh_u       = array([[ 1.00000000e+00,  7.31820278e-15,  6.76527755e-15,
        -5.12079130e-14,  3.45957696e-11],
       [ 7.31820...8.10437847e-12],
       [ 3.45957696e-11, -2.31723081e-10, -1.26188968e-10,
        -8.10437847e-12,  1.00000000e+00]])
vh         = array([[-0.42927645, -0.02385317,  0.21368543,  0.47797589, -0.42344063,
         0.30012128,  0.03406212,  0.19590089...554 ,  0.21588656,  0.29722489,  0.31843038,
         0.31819307,  0.28881893,  0.46509902,  0.29898348,  0.31066731]])
which      = 'LM'

sparse/linalg/eigen/tests/test_svds.py:56: AssertionError
```
</p>
</details>

<details>
<summary>

2. Failing tests on [MACOS](https://github.com/rgommers/scipy/pull/68/checks?check_run_id=3752496432)
</summary>
<p>

```py
=================================== FAILURES ===================================
_____________ Test_SVDS_PROPACK.test_svds_parameter_k_which[LM-3] ______________
[gw0] darwin -- Python 3.9.7 /usr/local/miniconda/envs/scipy-dev/bin/python
lib/python3.9/site-packages/scipy/sparse/linalg/eigen/tests/test_svds.py:226: in test_svds_parameter_k_which
    _check_svds(A, k, *res, which=which, atol=2e-10)
        A          = array([[0.63696169, 0.26978671, 0.04097352, 0.01652764, 0.81327024,
        0.91275558, 0.60663578, 0.72949656, 0.5436..., 0.96792619, 0.0147063 , 0.86364009, 0.98119504,
        0.95721018, 0.14876401, 0.97262881, 0.88993556, 0.82237383]])
        k          = 3
        res        = (array([[-0.53137496,  0.02426458,  0.31783075],
       [-0.06308732, -0.593292  ,  0.2603729 ],
       [ 0.29852945, ...54 ,  0.21588656,  0.29722489,  0.31843038,
         0.31819307,  0.28881893,  0.46509902,  0.29898348,  0.31066731]]))
        rng        = Generator(PCG64) at 0x144AE4660
        self       = <scipy.sparse.linalg.eigen.tests.test_svds.Test_SVDS_PROPACK object at 0x14538c2b0>
        which      = 'LM'
lib/python3.9/site-packages/scipy/sparse/linalg/eigen/tests/test_svds.py:56: in _check_svds
    assert_allclose(uh_u, np.identity(k), atol=atol, rtol=rtol)
E   AssertionError: 
E   Not equal to tolerance rtol=1e-07, atol=2e-10
E   
E   Mismatched elements: 2 / 9 (22.2%)
E   Max absolute difference: 2.14588805e-10
E   Max relative difference: 6.86117829e-14
E    x: array([[ 1.000000e+00,  2.505357e-13, -2.145888e-10],
E          [ 2.505357e-13,  1.000000e+00, -1.378156e-11],
E          [-2.145888e-10, -1.378156e-11,  1.000000e+00]])
E    y: array([[1., 0., 0.],
E          [0., 1., 0.],
E          [0., 0., 1.]])
        A          = array([[0.63696169, 0.26978671, 0.04097352, 0.01652764, 0.81327024,
        0.91275558, 0.60663578, 0.72949656, 0.5436..., 0.96792619, 0.0147063 , 0.86364009, 0.98119504,
        0.95721018, 0.14876401, 0.97262881, 0.88993556, 0.82237383]])
        A_rebuilt  = array([[ 0.74737372,  0.38299487,  0.29278206,  0.27265922,  0.68903058,
         0.94608907,  0.38643623,  0.71353767...2225, -0.04600463,  0.92119575,  0.78526736,
         1.07770596,  0.27435433,  1.06951112,  0.85196693,  0.87499717]])
        atol       = 2e-10
        check_svd  = True
        check_usvh_A = False
        k          = 3
        m          = 10
        n          = 10
        rtol       = 1e-07
        s          = array([1.26999904, 1.59849819, 5.71090105])
        u          = array([[-0.53137496,  0.02426458,  0.31783075],
       [-0.06308732, -0.593292  ,  0.2603729 ],
       [ 0.29852945, -...826545 ,  0.38210697],
       [-0.12697327, -0.09277105,  0.34919585],
       [-0.15837359,  0.53003248,  0.42841613]])
        uh_u       = array([[ 1.00000000e+00,  2.50535703e-13, -2.14588805e-10],
       [ 2.50535703e-13,  1.00000000e+00, -1.37815592e-11],
       [-2.14588805e-10, -1.37815592e-11,  1.00000000e+00]])
        vh         = array([[-0.18671618,  0.10199068,  0.10934924,  0.41421103, -0.16640367,
        -0.53308201,  0.17728763,  0.19159265...554 ,  0.21588656,  0.29722489,  0.31843038,
         0.31819307,  0.28881893,  0.46509902,  0.29898348,  0.31066731]])
        which      = 'LM'
_____________ Test_SVDS_PROPACK.test_svds_parameter_k_which[LM-5] ______________
[gw0] darwin -- Python 3.9.7 /usr/local/miniconda/envs/scipy-dev/bin/python
lib/python3.9/site-packages/scipy/sparse/linalg/eigen/tests/test_svds.py:226: in test_svds_parameter_k_which
    _check_svds(A, k, *res, which=which, atol=2e-10)
        A          = array([[0.63696169, 0.26978671, 0.04097352, 0.01652764, 0.81327024,
        0.91275558, 0.60663578, 0.72949656, 0.5436..., 0.96792619, 0.0147063 , 0.86364009, 0.98119504,
        0.95721018, 0.14876401, 0.97262881, 0.88993556, 0.82237383]])
        k          = 5
        res        = (array([[-0.32771492,  0.4158033 , -0.53137496,  0.02426458,  0.31783075],
       [-0.39239685, -0.02251468, -0.063087...54 ,  0.21588656,  0.29722489,  0.31843038,
         0.31819307,  0.28881893,  0.46509902,  0.29898348,  0.31066731]]))
        rng        = Generator(PCG64) at 0x144AE49E0
        self       = <scipy.sparse.linalg.eigen.tests.test_svds.Test_SVDS_PROPACK object at 0x1453a0c10>
        which      = 'LM'
lib/python3.9/site-packages/scipy/sparse/linalg/eigen/tests/test_svds.py:56: in _check_svds
    assert_allclose(uh_u, np.identity(k), atol=atol, rtol=rtol)
E   AssertionError: 
E   Not equal to tolerance rtol=1e-07, atol=2e-10
E   
E   Mismatched elements: 4 / 25 (16%)
E   Max absolute difference: 3.94088727e-10
E   Max relative difference: 6.86117829e-14
E    x: array([[ 1.000000e+00,  1.357248e-14,  5.682954e-15, -9.137135e-14,
E            5.875646e-11],
E          [ 1.357248e-14,  1.000000e+00, -2.105954e-15,  2.722406e-13,...
E    y: array([[1., 0., 0., 0., 0.],
E          [0., 1., 0., 0., 0.],
E          [0., 0., 1., 0., 0.],...
        A          = array([[0.63696169, 0.26978671, 0.04097352, 0.01652764, 0.81327024,
        0.91275558, 0.60663578, 0.72949656, 0.5436..., 0.96792619, 0.0147063 , 0.86364009, 0.98119504,
        0.95721018, 0.14876401, 0.97262881, 0.88993556, 0.82237383]])
        A_rebuilt  = array([[ 0.62664866,  0.26143156,  0.11583711,  0.10946253,  0.90237439,
         0.86426285,  0.54138144,  0.62698622...6753, -0.05990525,  0.81456418,  0.85739979,
         1.00404725,  0.21265842,  1.03219384,  0.92104378,  0.79572735]])
        atol       = 2e-10
        check_svd  = True
        check_usvh_A = False
        k          = 5
        m          = 10
        n          = 10
        rtol       = 1e-07
        s          = array([0.90017941, 0.97420967, 1.26999904, 1.59849819, 5.71090105])
        u          = array([[-0.32771492,  0.4158033 , -0.53137496,  0.02426458,  0.31783075],
       [-0.39239685, -0.02251468, -0.0630873...84 , -0.12697327, -0.09277105,  0.34919585],
       [-0.26457914, -0.13503641, -0.15837359,  0.53003248,  0.42841613]])
        uh_u       = array([[ 1.00000000e+00,  1.35724765e-14,  5.68295411e-15,
        -9.13713549e-14,  5.87564580e-11],
       [ 1.35724...1.37815592e-11],
       [ 5.87564580e-11, -3.94088727e-10, -2.14588805e-10,
        -1.37815592e-11,  1.00000000e+00]])
        vh         = array([[-0.42927645, -0.02385317,  0.21368543,  0.47797589, -0.42344063,
         0.30012128,  0.03406212,  0.19590089...554 ,  0.21588656,  0.29722489,  0.31843038,
         0.31819307,  0.28881893,  0.46509902,  0.29898348,  0.31066731]])
        which      = 'LM'
```
</p>
</details>



cc @rgommers 