### PR TITLE
MAINT: fix a tiny typo in signal/spectral.py

### DIFF
--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -1952,7 +1952,6 @@ def _triage_segments(window, nperseg, input_length):
     nperseg : int
         Length of each segment. If window is str or tuple, nperseg is set to
         256. If window is array_like, nperseg is set to the length of the
-        6
         window.
     """
     # parse window; if array like, then set nperseg = win.shape


### PR DESCRIPTION
Fix a simple typo by removing a misplaced "6".
