### PR TITLE
[MRG] BUG: Avoid lobpcg failure when iterations can't continue 

### DIFF
--- a/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
@@ -467,10 +467,12 @@ def lobpcg(A, X,
                 activeBlockVectorBP = _as2d(blockVectorBP[:, activeMask])
 
         if activeBlockVectorR is None:
-            warnings.warn("Iteration '%s' failed." % iterationNumber
-                          "tolerance '%s' may be violated." % residualTolerance,
-                          UserWarning)
-            break
+            warnings.warn(
+                "Iteration %d failed not reaching tolerance %g."
+                % (iterationNumber, residualTolerance),
+                UserWarning,
+           )
+           break
         if M is not None:
             # Apply preconditioner T to the active residuals.
             activeBlockVectorR = M(activeBlockVectorR)
@@ -481,9 +483,11 @@ def lobpcg(A, X,
             _applyConstraints(activeBlockVectorR,
                               gramYBY, blockVectorBY, blockVectorY)
         if activeBlockVectorR is None:
-            warnings.warn("Iteration '%s' failed." % iterationNumber
-                          "tolerance '%s' may be violated." % residualTolerance,
-                          UserWarning)
+            warnings.warn(
+                "Iteration %d failed not reaching tolerance %g."
+                % (iterationNumber, residualTolerance),
+                UserWarning,
+            )
             break
 
         ##
@@ -503,9 +507,11 @@ def lobpcg(A, X,
         activeBlockVectorR, activeBlockVectorBR = aux
 
         if activeBlockVectorR is None:
-            warnings.warn("Iteration '%s' failed." % iterationNumber
-                          "tolerance '%s' may be violated." % residualTolerance,
-                          UserWarning)
+            warnings.warn(
+                "Iteration %d failed not reaching tolerance %g."
+                % (iterationNumber, residualTolerance),
+                UserWarning,
+            )
             break
         activeBlockVectorAR = A(activeBlockVectorR)
 

--- a/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
@@ -118,7 +118,7 @@ def _get_indx(_lambda, num, largest):
     """Get `num` indices into `_lambda` depending on `largest` option."""
     ii = np.argsort(_lambda)
     if largest:
-        ii = ii[: -num - 1 : -1]
+        ii = ii[:-num - 1:-1]
     else:
         ii = ii[:num]
 
@@ -646,8 +646,8 @@ def lobpcg(
         if B is not None:
             if not restart:
                 eigBlockVectorX = eigBlockVector[:sizeX]
-                eigBlockVectorR = eigBlockVector[sizeX : sizeX + currentBlockSize]
-                eigBlockVectorP = eigBlockVector[sizeX + currentBlockSize :]
+                eigBlockVectorR = eigBlockVector[sizeX: sizeX + currentBlockSize]
+                eigBlockVectorP = eigBlockVector[sizeX + currentBlockSize:]
 
                 pp = np.dot(activeBlockVectorR, eigBlockVectorR)
                 pp += np.dot(activeBlockVectorP, eigBlockVectorP)
@@ -679,8 +679,8 @@ def lobpcg(
         else:
             if not restart:
                 eigBlockVectorX = eigBlockVector[:sizeX]
-                eigBlockVectorR = eigBlockVector[sizeX : sizeX + currentBlockSize]
-                eigBlockVectorP = eigBlockVector[sizeX + currentBlockSize :]
+                eigBlockVectorR = eigBlockVector[sizeX: sizeX + currentBlockSize]
+                eigBlockVectorP = eigBlockVector[sizeX + currentBlockSize:]
 
                 pp = np.dot(activeBlockVectorR, eigBlockVectorR)
                 pp += np.dot(activeBlockVectorP, eigBlockVectorP)

--- a/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
@@ -19,12 +19,11 @@ References
 
 import warnings
 import numpy as np
-from scipy.linalg import (inv, eigh, cho_factor, cho_solve, cholesky,
-                          LinAlgError)
+from scipy.linalg import inv, eigh, cho_factor, cho_solve, cholesky, LinAlgError
 from scipy.sparse.linalg import aslinearoperator
 from numpy import block as bmat
 
-__all__ = ['lobpcg']
+__all__ = ["lobpcg"]
 
 
 def _report_nonhermitian(M, name):
@@ -39,9 +38,10 @@ def _report_nonhermitian(M, name):
     tol = 10 * np.finfo(M.dtype).eps
     tol = max(tol, tol * norm(M, 1))
     if nmd > tol:
-        print('matrix %s of the type %s is not sufficiently Hermitian:'
-              % (name, M.dtype))
-        print('condition: %.e < %e' % (nmd, tol))
+        print(
+            "matrix %s of the type %s is not sufficiently Hermitian:" % (name, M.dtype)
+        )
+        print("condition: %.e < %e" % (nmd, tol))
 
 
 def _as2d(ar):
@@ -67,7 +67,7 @@ def _makeOperator(operatorInput, expectedShape):
         operator = aslinearoperator(operatorInput)
 
     if operator.shape != expectedShape:
-        raise ValueError('operator has invalid shape')
+        raise ValueError("operator has invalid shape")
 
     return operator
 
@@ -81,7 +81,7 @@ def _applyConstraints(blockVectorV, factYBY, blockVectorBY, blockVectorY):
 
 def _b_orthonormalize(B, blockVectorV, blockVectorBV=None, retInvR=False):
     """B-orthonormalize the given block vector using Cholesky."""
-    normalization = blockVectorV.max(axis=0)+np.finfo(blockVectorV.dtype).eps
+    normalization = blockVectorV.max(axis=0) + np.finfo(blockVectorV.dtype).eps
     blockVectorV = blockVectorV / normalization
     if blockVectorBV is None:
         if B is not None:
@@ -103,7 +103,7 @@ def _b_orthonormalize(B, blockVectorV, blockVectorBV=None, retInvR=False):
         else:
             blockVectorBV = None
     except LinAlgError:
-        #raise ValueError('Cholesky has failed')
+        # raise ValueError('Cholesky has failed')
         blockVectorV = None
         blockVectorBV = None
         VBV = None
@@ -118,18 +118,26 @@ def _get_indx(_lambda, num, largest):
     """Get `num` indices into `_lambda` depending on `largest` option."""
     ii = np.argsort(_lambda)
     if largest:
-        ii = ii[:-num-1:-1]
+        ii = ii[: -num - 1 : -1]
     else:
         ii = ii[:num]
 
     return ii
 
 
-def lobpcg(A, X,
-           B=None, M=None, Y=None,
-           tol=None, maxiter=None,
-           largest=True, verbosityLevel=0,
-           retLambdaHistory=False, retResidualNormsHistory=False):
+def lobpcg(
+    A,
+    X,
+    B=None,
+    M=None,
+    Y=None,
+    tol=None,
+    maxiter=None,
+    largest=True,
+    verbosityLevel=0,
+    retLambdaHistory=False,
+    retResidualNormsHistory=False,
+):
     """Locally Optimal Block Preconditioned Conjugate Gradient Method (LOBPCG)
 
     LOBPCG is a preconditioned eigensolver for large symmetric positive
@@ -303,7 +311,7 @@ def lobpcg(A, X,
 
     # Block size.
     if len(blockVectorX.shape) != 2:
-        raise ValueError('expected rank-2 array for argument X')
+        raise ValueError("expected rank-2 array for argument X")
 
     n, sizeX = blockVectorX.shape
 
@@ -339,20 +347,20 @@ def lobpcg(A, X,
         sizeX = min(sizeX, n)
 
         if blockVectorY is not None:
-            raise NotImplementedError('The dense eigensolver '
-                                      'does not support constraints.')
+            raise NotImplementedError(
+                "The dense eigensolver " "does not support constraints."
+            )
 
         # Define the closed range of indices of eigenvalues to return.
         if largest:
-            eigvals = (n - sizeX, n-1)
+            eigvals = (n - sizeX, n - 1)
         else:
-            eigvals = (0, sizeX-1)
+            eigvals = (0, sizeX - 1)
 
         A_dense = A(np.eye(n, dtype=A.dtype))
         B_dense = None if B is None else B(np.eye(n, dtype=B.dtype))
 
-        vals, vecs = eigh(A_dense, B_dense, eigvals=eigvals,
-                          check_finite=False)
+        vals, vecs = eigh(A_dense, B_dense, eigvals=eigvals, check_finite=False)
         if largest:
             # Reverse order to be compatible with eigs() in 'LM' mode.
             vals = vals[::-1]
@@ -377,7 +385,7 @@ def lobpcg(A, X,
             # gramYBY is a Cholesky factor from now on...
             gramYBY = cho_factor(gramYBY)
         except LinAlgError as e:
-            raise ValueError('cannot handle linearly dependent constraints') from e
+            raise ValueError("cannot handle linearly dependent constraints") from e
 
         _applyConstraints(blockVectorX, gramYBY, blockVectorBY, blockVectorY)
 
@@ -424,7 +432,7 @@ def lobpcg(A, X,
     while iterationNumber < maxiter:
         iterationNumber += 1
         if verbosityLevel > 0:
-            print('iteration %d' % iterationNumber)
+            print("iteration %d" % iterationNumber)
 
         if B is not None:
             aux = blockVectorBX * _lambda[np.newaxis, :]
@@ -452,9 +460,9 @@ def lobpcg(A, X,
             break
 
         if verbosityLevel > 0:
-            print('current block size:', currentBlockSize)
-            print('eigenvalue:', _lambda)
-            print('residual norms:', residualNorms)
+            print("current block size:", currentBlockSize)
+            print("eigenvalue:", _lambda)
+            print("residual norms:", residualNorms)
         if verbosityLevel > 10:
             print(eigBlockVector)
 
@@ -471,8 +479,8 @@ def lobpcg(A, X,
                 "Iteration %d failed not reaching tolerance %g."
                 % (iterationNumber, residualTolerance),
                 UserWarning,
-           )
-           break
+            )
+            break
         if M is not None:
             # Apply preconditioner T to the active residuals.
             activeBlockVectorR = M(activeBlockVectorR)
@@ -480,8 +488,7 @@ def lobpcg(A, X,
         ##
         # Apply constraints to the preconditioned residuals.
         if blockVectorY is not None:
-            _applyConstraints(activeBlockVectorR,
-                              gramYBY, blockVectorBY, blockVectorY)
+            _applyConstraints(activeBlockVectorR, gramYBY, blockVectorBY, blockVectorY)
         if activeBlockVectorR is None:
             warnings.warn(
                 "Iteration %d failed not reaching tolerance %g."
@@ -493,13 +500,13 @@ def lobpcg(A, X,
         ##
         # B-orthogonalize the preconditioned residuals to X.
         if B is not None:
-            activeBlockVectorR = activeBlockVectorR - np.matmul(blockVectorX,
-                                 np.matmul(blockVectorBX.T.conj(),
-                                 activeBlockVectorR))
+            activeBlockVectorR = activeBlockVectorR - np.matmul(
+                blockVectorX, np.matmul(blockVectorBX.T.conj(), activeBlockVectorR)
+            )
         else:
-            activeBlockVectorR = activeBlockVectorR - np.matmul(blockVectorX,
-                                 np.matmul(blockVectorX.T.conj(),
-                                 activeBlockVectorR))
+            activeBlockVectorR = activeBlockVectorR - np.matmul(
+                blockVectorX, np.matmul(blockVectorX.T.conj(), activeBlockVectorR)
+            )
 
         ##
         # B-orthonormalize the preconditioned residuals.
@@ -517,8 +524,9 @@ def lobpcg(A, X,
 
         if iterationNumber > 0:
             if B is not None:
-                aux = _b_orthonormalize(B, activeBlockVectorP,
-                                        activeBlockVectorBP, retInvR=True)
+                aux = _b_orthonormalize(
+                    B, activeBlockVectorP, activeBlockVectorBP, retInvR=True
+                )
                 activeBlockVectorP, activeBlockVectorBP, invR, normal = aux
             else:
                 aux = _b_orthonormalize(B, activeBlockVectorP, retInvR=True)
@@ -535,9 +543,9 @@ def lobpcg(A, X,
         # Perform the Rayleigh Ritz Procedure:
         # Compute symmetric Gram matrices:
 
-        if activeBlockVectorAR.dtype == 'float32':
+        if activeBlockVectorAR.dtype == "float32":
             myeps = 1
-        elif activeBlockVectorR.dtype == 'float32':
+        elif activeBlockVectorR.dtype == "float32":
             myeps = 1e-4
         else:
             myeps = 1e-8
@@ -560,9 +568,9 @@ def lobpcg(A, X,
         gramRAR = np.dot(activeBlockVectorR.T.conj(), activeBlockVectorAR)
 
         if explicitGramFlag:
-            gramRAR = (gramRAR + gramRAR.T.conj())/2
+            gramRAR = (gramRAR + gramRAR.T.conj()) / 2
             gramXAX = np.dot(blockVectorX.T.conj(), blockVectorAX)
-            gramXAX = (gramXAX + gramXAX.T.conj())/2
+            gramXAX = (gramXAX + gramXAX.T.conj()) / 2
             gramXBX = np.dot(blockVectorX.T.conj(), blockVectorBX)
             gramRBR = np.dot(activeBlockVectorR.T.conj(), activeBlockVectorBR)
             gramXBR = np.dot(blockVectorX.T.conj(), activeBlockVectorBR)
@@ -574,12 +582,12 @@ def lobpcg(A, X,
 
         def _handle_gramA_gramB_verbosity(gramA, gramB):
             if verbosityLevel > 0:
-                _report_nonhermitian(gramA, 'gramA')
-                _report_nonhermitian(gramB, 'gramB')
+                _report_nonhermitian(gramA, "gramA")
+                _report_nonhermitian(gramB, "gramB")
             if verbosityLevel > 10:
                 # Note: not documented, but leave it in here for now
-                np.savetxt('gramA.txt', gramA)
-                np.savetxt('gramB.txt', gramB)
+                np.savetxt("gramA.txt", gramA)
+                np.savetxt("gramB.txt", gramB)
 
         if not restart:
             gramXAP = np.dot(blockVectorX.T.conj(), activeBlockVectorAP)
@@ -588,41 +596,44 @@ def lobpcg(A, X,
             gramXBP = np.dot(blockVectorX.T.conj(), activeBlockVectorBP)
             gramRBP = np.dot(activeBlockVectorR.T.conj(), activeBlockVectorBP)
             if explicitGramFlag:
-                gramPAP = (gramPAP + gramPAP.T.conj())/2
-                gramPBP = np.dot(activeBlockVectorP.T.conj(),
-                                 activeBlockVectorBP)
+                gramPAP = (gramPAP + gramPAP.T.conj()) / 2
+                gramPBP = np.dot(activeBlockVectorP.T.conj(), activeBlockVectorBP)
             else:
                 gramPBP = ident
 
-            gramA = bmat([[gramXAX, gramXAR, gramXAP],
-                          [gramXAR.T.conj(), gramRAR, gramRAP],
-                          [gramXAP.T.conj(), gramRAP.T.conj(), gramPAP]])
-            gramB = bmat([[gramXBX, gramXBR, gramXBP],
-                          [gramXBR.T.conj(), gramRBR, gramRBP],
-                          [gramXBP.T.conj(), gramRBP.T.conj(), gramPBP]])
+            gramA = bmat(
+                [
+                    [gramXAX, gramXAR, gramXAP],
+                    [gramXAR.T.conj(), gramRAR, gramRAP],
+                    [gramXAP.T.conj(), gramRAP.T.conj(), gramPAP],
+                ]
+            )
+            gramB = bmat(
+                [
+                    [gramXBX, gramXBR, gramXBP],
+                    [gramXBR.T.conj(), gramRBR, gramRBP],
+                    [gramXBP.T.conj(), gramRBP.T.conj(), gramPBP],
+                ]
+            )
 
             _handle_gramA_gramB_verbosity(gramA, gramB)
 
             try:
-                _lambda, eigBlockVector = eigh(gramA, gramB,
-                                               check_finite=False)
+                _lambda, eigBlockVector = eigh(gramA, gramB, check_finite=False)
             except LinAlgError:
                 # try again after dropping the direction vectors P from RR
                 restart = True
 
         if restart:
-            gramA = bmat([[gramXAX, gramXAR],
-                          [gramXAR.T.conj(), gramRAR]])
-            gramB = bmat([[gramXBX, gramXBR],
-                          [gramXBR.T.conj(), gramRBR]])
+            gramA = bmat([[gramXAX, gramXAR], [gramXAR.T.conj(), gramRAR]])
+            gramB = bmat([[gramXBX, gramXBR], [gramXBR.T.conj(), gramRBR]])
 
             _handle_gramA_gramB_verbosity(gramA, gramB)
 
             try:
-                _lambda, eigBlockVector = eigh(gramA, gramB,
-                                               check_finite=False)
+                _lambda, eigBlockVector = eigh(gramA, gramB, check_finite=False)
             except LinAlgError as e:
-                raise ValueError('eigh has failed in lobpcg iterations') from e
+                raise ValueError("eigh has failed in lobpcg iterations") from e
 
         ii = _get_indx(_lambda, sizeX, largest)
         if verbosityLevel > 10:
@@ -635,12 +646,12 @@ def lobpcg(A, X,
         lambdaHistory.append(_lambda)
 
         if verbosityLevel > 10:
-            print('lambda:', _lambda)
-#         # Normalize eigenvectors!
-#         aux = np.sum( eigBlockVector.conj() * eigBlockVector, 0 )
-#         eigVecNorms = np.sqrt( aux )
-#         eigBlockVector = eigBlockVector / eigVecNorms[np.newaxis, :]
-#         eigBlockVector, aux = _b_orthonormalize( B, eigBlockVector )
+            print("lambda:", _lambda)
+        #         # Normalize eigenvectors!
+        #         aux = np.sum( eigBlockVector.conj() * eigBlockVector, 0 )
+        #         eigVecNorms = np.sqrt( aux )
+        #         eigBlockVector = eigBlockVector / eigVecNorms[np.newaxis, :]
+        #         eigBlockVector, aux = _b_orthonormalize( B, eigBlockVector )
 
         if verbosityLevel > 10:
             print(eigBlockVector)
@@ -649,8 +660,8 @@ def lobpcg(A, X,
         if B is not None:
             if not restart:
                 eigBlockVectorX = eigBlockVector[:sizeX]
-                eigBlockVectorR = eigBlockVector[sizeX:sizeX+currentBlockSize]
-                eigBlockVectorP = eigBlockVector[sizeX+currentBlockSize:]
+                eigBlockVectorR = eigBlockVector[sizeX : sizeX + currentBlockSize]
+                eigBlockVectorP = eigBlockVector[sizeX + currentBlockSize :]
 
                 pp = np.dot(activeBlockVectorR, eigBlockVectorR)
                 pp += np.dot(activeBlockVectorP, eigBlockVectorP)
@@ -682,8 +693,8 @@ def lobpcg(A, X,
         else:
             if not restart:
                 eigBlockVectorX = eigBlockVector[:sizeX]
-                eigBlockVectorR = eigBlockVector[sizeX:sizeX+currentBlockSize]
-                eigBlockVectorP = eigBlockVector[sizeX+currentBlockSize:]
+                eigBlockVectorR = eigBlockVector[sizeX : sizeX + currentBlockSize]
+                eigBlockVectorP = eigBlockVector[sizeX + currentBlockSize :]
 
                 pp = np.dot(activeBlockVectorR, eigBlockVectorR)
                 pp += np.dot(activeBlockVectorP, eigBlockVectorP)
@@ -723,8 +734,8 @@ def lobpcg(A, X,
     # Computing the actual true residuals
 
     if verbosityLevel > 0:
-        print('final eigenvalue:', _lambda)
-        print('final residual norms:', residualNorms)
+        print("final eigenvalue:", _lambda)
+        print("final residual norms:", residualNorms)
 
     if retLambdaHistory:
         if retResidualNormsHistory:

--- a/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
@@ -510,9 +510,9 @@ def lobpcg(
 
         if activeBlockVectorR is None:
             warnings.warn(
-                "Iteration %d failed at tolerance %g not reaching %g."
-                % (iterationNumber, np.max(residualNorms), residualTolerance),
-                UserWarning,
+                f"Iteration {iterationNumber} failed at tolerance "
+                f"{np.max(residualNorms)} not reaching {residualTolerance}.",
+                UserWarning, stacklevel=3
             )
             break
         activeBlockVectorAR = A(activeBlockVectorR)

--- a/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
@@ -465,6 +465,8 @@ def lobpcg(A, X,
             if B is not None:
                 activeBlockVectorBP = _as2d(blockVectorBP[:, activeMask])
 
+        if activeBlockVectorR is None:
+            break
         if M is not None:
             # Apply preconditioner T to the active residuals.
             activeBlockVectorR = M(activeBlockVectorR)
@@ -474,6 +476,8 @@ def lobpcg(A, X,
         if blockVectorY is not None:
             _applyConstraints(activeBlockVectorR,
                               gramYBY, blockVectorBY, blockVectorY)
+        if activeBlockVectorR is None:
+            break
 
         ##
         # B-orthogonalize the preconditioned residuals to X.
@@ -491,6 +495,8 @@ def lobpcg(A, X,
         aux = _b_orthonormalize(B, activeBlockVectorR)
         activeBlockVectorR, activeBlockVectorBR = aux
 
+        if activeBlockVectorR is None:
+            break
         activeBlockVectorAR = A(activeBlockVectorR)
 
         if iterationNumber > 0:

--- a/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
@@ -19,7 +19,8 @@ References
 
 import warnings
 import numpy as np
-from scipy.linalg import inv, eigh, cho_factor, cho_solve, cholesky, LinAlgError
+from scipy.linalg import (inv, eigh, cho_factor, cho_solve,
+                          cholesky, LinAlgError)
 from scipy.sparse.linalg import aslinearoperator
 from numpy import block as bmat
 
@@ -39,7 +40,7 @@ def _report_nonhermitian(M, name):
     tol = max(tol, tol * norm(M, 1))
     if nmd > tol:
         print(
-            "matrix %s of the type %s is not sufficiently Hermitian:" % (name, M.dtype)
+            "matrix %s of the type %s is not Hermitian:"% (name, M.dtype)
         )
         print("condition: %.e < %e" % (nmd, tol))
 
@@ -360,7 +361,10 @@ def lobpcg(
         A_dense = A(np.eye(n, dtype=A.dtype))
         B_dense = None if B is None else B(np.eye(n, dtype=B.dtype))
 
-        vals, vecs = eigh(A_dense, B_dense, eigvals=eigvals, check_finite=False)
+        vals, vecs = eigh(A_dense,
+                          B_dense,
+                          eigvals=eigvals,
+                          check_finite=False)
         if largest:
             # Reverse order to be compatible with eigs() in 'LM' mode.
             vals = vals[::-1]
@@ -385,7 +389,7 @@ def lobpcg(
             # gramYBY is a Cholesky factor from now on...
             gramYBY = cho_factor(gramYBY)
         except LinAlgError as e:
-            raise ValueError("cannot handle linearly dependent constraints") from e
+            raise ValueError("linearly dependent constraints") from e
 
         _applyConstraints(blockVectorX, gramYBY, blockVectorBY, blockVectorY)
 
@@ -481,17 +485,22 @@ def lobpcg(
         ##
         # Apply constraints to the preconditioned residuals.
         if blockVectorY is not None:
-            _applyConstraints(activeBlockVectorR, gramYBY, blockVectorBY, blockVectorY)
+            _applyConstraints(activeBlockVectorR,
+                              gramYBY,
+                              blockVectorBY,
+                              blockVectorY)
 
         ##
         # B-orthogonalize the preconditioned residuals to X.
         if B is not None:
             activeBlockVectorR = activeBlockVectorR - np.matmul(
-                blockVectorX, np.matmul(blockVectorBX.T.conj(), activeBlockVectorR)
+                blockVectorX,
+                np.matmul(blockVectorBX.T.conj(), activeBlockVectorR)
             )
         else:
             activeBlockVectorR = activeBlockVectorR - np.matmul(
-                blockVectorX, np.matmul(blockVectorX.T.conj(), activeBlockVectorR)
+                blockVectorX,
+                np.matmul(blockVectorX.T.conj(), activeBlockVectorR)
             )
 
         ##
@@ -583,7 +592,8 @@ def lobpcg(
             gramRBP = np.dot(activeBlockVectorR.T.conj(), activeBlockVectorBP)
             if explicitGramFlag:
                 gramPAP = (gramPAP + gramPAP.T.conj()) / 2
-                gramPBP = np.dot(activeBlockVectorP.T.conj(), activeBlockVectorBP)
+                gramPBP = np.dot(activeBlockVectorP.T.conj(),
+                                 activeBlockVectorBP)
             else:
                 gramPBP = ident
 
@@ -605,7 +615,9 @@ def lobpcg(
             _handle_gramA_gramB_verbosity(gramA, gramB)
 
             try:
-                _lambda, eigBlockVector = eigh(gramA, gramB, check_finite=False)
+                _lambda, eigBlockVector = eigh(gramA,
+                                               gramB,
+                                               check_finite=False)
             except LinAlgError:
                 # try again after dropping the direction vectors P from RR
                 restart = True
@@ -617,7 +629,9 @@ def lobpcg(
             _handle_gramA_gramB_verbosity(gramA, gramB)
 
             try:
-                _lambda, eigBlockVector = eigh(gramA, gramB, check_finite=False)
+                _lambda, eigBlockVector = eigh(gramA,
+                                               gramB,
+                                               check_finite=False)
             except LinAlgError as e:
                 raise ValueError("eigh has failed in lobpcg iterations") from e
 
@@ -646,7 +660,8 @@ def lobpcg(
         if B is not None:
             if not restart:
                 eigBlockVectorX = eigBlockVector[:sizeX]
-                eigBlockVectorR = eigBlockVector[sizeX: sizeX + currentBlockSize]
+                eigBlockVectorR = eigBlockVector[sizeX:
+                                                 sizeX + currentBlockSize]
                 eigBlockVectorP = eigBlockVector[sizeX + currentBlockSize:]
 
                 pp = np.dot(activeBlockVectorR, eigBlockVectorR)
@@ -679,7 +694,8 @@ def lobpcg(
         else:
             if not restart:
                 eigBlockVectorX = eigBlockVector[:sizeX]
-                eigBlockVectorR = eigBlockVector[sizeX: sizeX + currentBlockSize]
+                eigBlockVectorR = eigBlockVector[sizeX:
+                                                 sizeX + currentBlockSize]
                 eigBlockVectorP = eigBlockVector[sizeX + currentBlockSize:]
 
                 pp = np.dot(activeBlockVectorR, eigBlockVectorR)

--- a/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
@@ -17,6 +17,7 @@ References
        https://github.com/lobpcg/blopex
 """
 
+import warnings
 import numpy as np
 from scipy.linalg import (inv, eigh, cho_factor, cho_solve, cholesky,
                           LinAlgError)
@@ -466,6 +467,9 @@ def lobpcg(A, X,
                 activeBlockVectorBP = _as2d(blockVectorBP[:, activeMask])
 
         if activeBlockVectorR is None:
+            warnings.warn("Iteration '%s' failed." % iterationNumber
+                          "tolerance '%s' may be violated." % residualTolerance,
+                          UserWarning)
             break
         if M is not None:
             # Apply preconditioner T to the active residuals.
@@ -477,6 +481,9 @@ def lobpcg(A, X,
             _applyConstraints(activeBlockVectorR,
                               gramYBY, blockVectorBY, blockVectorY)
         if activeBlockVectorR is None:
+            warnings.warn("Iteration '%s' failed." % iterationNumber
+                          "tolerance '%s' may be violated." % residualTolerance,
+                          UserWarning)
             break
 
         ##
@@ -496,6 +503,9 @@ def lobpcg(A, X,
         activeBlockVectorR, activeBlockVectorBR = aux
 
         if activeBlockVectorR is None:
+            warnings.warn("Iteration '%s' failed." % iterationNumber
+                          "tolerance '%s' may be violated." % residualTolerance,
+                          UserWarning)
             break
         activeBlockVectorAR = A(activeBlockVectorR)
 

--- a/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
@@ -474,13 +474,6 @@ def lobpcg(
             if B is not None:
                 activeBlockVectorBP = _as2d(blockVectorBP[:, activeMask])
 
-        if activeBlockVectorR is None:
-            warnings.warn(
-                "Iteration %d failed not reaching tolerance %g."
-                % (iterationNumber, residualTolerance),
-                UserWarning,
-            )
-            break
         if M is not None:
             # Apply preconditioner T to the active residuals.
             activeBlockVectorR = M(activeBlockVectorR)
@@ -489,13 +482,6 @@ def lobpcg(
         # Apply constraints to the preconditioned residuals.
         if blockVectorY is not None:
             _applyConstraints(activeBlockVectorR, gramYBY, blockVectorBY, blockVectorY)
-        if activeBlockVectorR is None:
-            warnings.warn(
-                "Iteration %d failed not reaching tolerance %g."
-                % (iterationNumber, residualTolerance),
-                UserWarning,
-            )
-            break
 
         ##
         # B-orthogonalize the preconditioned residuals to X.
@@ -515,8 +501,8 @@ def lobpcg(
 
         if activeBlockVectorR is None:
             warnings.warn(
-                "Iteration %d failed not reaching tolerance %g."
-                % (iterationNumber, residualTolerance),
+                "Iteration %d failed at tolerance %g not reaching %g."
+                % (iterationNumber, np.max(residualNorms), residualTolerance),
                 UserWarning,
             )
             break

--- a/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
@@ -40,7 +40,7 @@ def _report_nonhermitian(M, name):
     tol = max(tol, tol * norm(M, 1))
     if nmd > tol:
         print(
-            "matrix %s of the type %s is not Hermitian:"% (name, M.dtype)
+            "matrix %s of the type %s is not Hermitian:" % (name, M.dtype)
         )
         print("condition: %.e < %e" % (nmd, tol))
 

--- a/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
@@ -91,15 +91,15 @@ def _b_orthonormalize(B, blockVectorV, blockVectorBV=None, retInvR=False):
             blockVectorBV = blockVectorV  # Shared data!!!
     else:
         blockVectorBV = blockVectorBV / normalization
-    VBV = np.matmul(blockVectorV.T.conj(), blockVectorBV)
+    VBV = blockVectorV.T.conj() @ blockVectorBV
     try:
         # VBV is a Cholesky factor from now on...
         VBV = cholesky(VBV, overwrite_a=True)
         VBV = inv(VBV, overwrite_a=True)
-        blockVectorV = np.matmul(blockVectorV, VBV)
+        blockVectorV = blockVectorV @ VBV
         # blockVectorV = (cho_solve((VBV.T, True), blockVectorV.T)).T
         if B is not None:
-            blockVectorBV = np.matmul(blockVectorBV, VBV)
+            blockVectorBV = blockVectorBV @ VBV
             # blockVectorBV = (cho_solve((VBV.T, True), blockVectorBV.T)).T
         else:
             blockVectorBV = None
@@ -493,14 +493,14 @@ def lobpcg(
         ##
         # B-orthogonalize the preconditioned residuals to X.
         if B is not None:
-            activeBlockVectorR = activeBlockVectorR - np.matmul(
-                blockVectorX,
-                np.matmul(blockVectorBX.T.conj(), activeBlockVectorR)
+            activeBlockVectorR = activeBlockVectorR - (
+                blockVectorX @
+                (blockVectorBX.T.conj() @ activeBlockVectorR)
             )
         else:
-            activeBlockVectorR = activeBlockVectorR - np.matmul(
-                blockVectorX,
-                np.matmul(blockVectorX.T.conj(), activeBlockVectorR)
+            activeBlockVectorR = activeBlockVectorR - (
+                blockVectorX @
+                (blockVectorX.T.conj() @ activeBlockVectorR)
             )
 
         ##

--- a/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
@@ -736,8 +736,8 @@ def lobpcg(
     # Computing the actual true residuals
 
     if verbosityLevel > 0:
-        print("final eigenvalue:", _lambda)
-        print("final residual norms:", residualNorms)
+        print("Final eigenvalue(s):", _lambda)
+        print("Final residual norm(s):", residualNorms)
 
     if retLambdaHistory:
         if retResidualNormsHistory:

--- a/scipy/sparse/linalg/eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/tests/test_lobpcg.py
@@ -5,7 +5,8 @@ import platform
 
 import numpy as np
 from numpy.testing import (assert_almost_equal, assert_equal,
-                           assert_allclose, assert_array_less)
+                           assert_allclose, assert_array_less,
+                           suppress_warnings)
 
 import pytest
 
@@ -201,14 +202,16 @@ def test_fiedler_large_12():
     _check_fiedler(12, 2)
 
 
-def test_failure():
-    """Check that the code exists gracefully without failing. Issue #10974.
+def test_failure_to_run_iterations():
+    """Check that the code exists gracefully without breaking. Issue #10974.
     """
     X = np.random.randn(100, 10)
     A = X @ X.T
     Q = np.random.randn(X.shape[0], 4)
-    eigenvalues, _ = lobpcg(A, Q, maxiter=20)
-    assert(np.max(eigenvalues) > 0)
+    with suppress_warnings() as sup:
+        sup.filter(UserWarning, ".*failed not reaching.*")
+        eigenvalues, _ = lobpcg(A, Q, maxiter=20)
+        assert(np.max(eigenvalues) > 0)
 
 
 def test_hermitian():

--- a/scipy/sparse/linalg/eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/tests/test_lobpcg.py
@@ -201,6 +201,16 @@ def test_fiedler_large_12():
     _check_fiedler(12, 2)
 
 
+def test_failure():
+    """Check that the code exists gracefully without failing. Issue #10974.
+    """
+    X = np.random.randn(100, 10)
+    A = X @ X.T
+    Q = np.random.randn(X.shape[0], 4)
+    eigenvalues, _ = lobpcg(A, Q, maxiter=20)
+    assert(np.max(eigenvalues) > 0)
+
+
 def test_hermitian():
     """Check complex-value Hermitian cases.
     """

--- a/scipy/sparse/linalg/eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/tests/test_lobpcg.py
@@ -209,7 +209,7 @@ def test_failure_to_run_iterations():
     A = X @ X.T
     Q = np.random.randn(X.shape[0], 4)
     with suppress_warnings() as sup:
-        sup.filter(UserWarning, ".*failed not reaching.*")
+        sup.filter(UserWarning, ".*not reaching.*")
         eigenvalues, _ = lobpcg(A, Q, maxiter=20)
         assert(np.max(eigenvalues) > 0)
 


### PR DESCRIPTION
The LOBPCG algorithm iterates constructing new iterative approximations. In a few situations, the construction is mathematically impossible after some number (maybe as small as 1) of iterations, so the iterations can't continue, which is indicated by outputting `None` by one of the internal functions. When `None` goes as an input to the next function, which performs matrix-matrix multiplications, this results in that cryptic error. The fix checks for `None` and stops the iterations. The requested tolerance will not be met, but this will be fixed later in the next PR together with #14784. 

Adding a check to break the iteration loop to eliminate a possibility for the code to fail even if iterations can't continue. Instead of failing, the code now gracefully exists outputting the last computed approximation. 

The provided unit test checks the code failure in the example https://github.com/scipy/scipy/issues/10974#issuecomment-605666851 where the rank of the matrix is too small (10) for the block Krylov subspace to exist so that lobpcg runs out of space to continue iterations and fails with a cryptic error message if the block size is 4, although runs fine if the block size is 3. 

#### Reference issue
Closes #10974 also noticed in #14784

#### What does this implement/fix?
https://github.com/scipy/scipy/issues/10974#issuecomment-605666851 

#### Additional information
The checks failing appear to be unrelated to this PR, so it's ready to be reviewed and merged. 

