### PR TITLE
MAINT: SciPy 1.7.2 prep/backports

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -194,7 +194,7 @@ stages:
       displayName: 'Fetch submodules'
     - script: |
             docker pull i386/ubuntu:bionic
-            docker run -v $(pwd):/scipy i386/ubuntu:bionic /bin/bash -c "cd scipy && \
+            docker run -v $(pwd):/scipy i386/ubuntu:bionic /usr/bin/linux32 /bin/bash -c "cd scipy && \
             apt-get -y update && \
             apt-get -y install curl python3.7-dev python3.7 python3-distutils pkg-config libpng-dev libjpeg8-dev libfreetype6-dev && \
             curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
     include:
     - '*'  # must quote since "*" is a YAML reserved character; we want a string
 
-# the version of OpenBLAS used is currently 0.3.15
+# the version of OpenBLAS used is currently 0.3.17
 # and should be updated to match scipy-wheels as appropriate
 variables:
     openblas_version: 0.3.17

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,10 +18,10 @@ pr:
     include:
     - '*'  # must quote since "*" is a YAML reserved character; we want a string
 
-# the version of OpenBLAS used is currently 0.3.8.dev
+# the version of OpenBLAS used is currently 0.3.15
 # and should be updated to match scipy-wheels as appropriate
 variables:
-    openblas_version: 0.3.9
+    openblas_version: 0.3.17
     pre_wheels: https://pypi.anaconda.org/scipy-wheels-nightly/simple
     CCACHE_DIR: $(Pipeline.Workspace)/ccache
     SCIPY_AVAILABLE_MEM: 3G
@@ -201,16 +201,16 @@ stages:
             python3.7 get-pip.py && \
             pip3 --version && \
             pip3 install setuptools wheel numpy==1.16.6 cython==0.29.18 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath matplotlib==3.1.3 pythran --user && \
-            apt-get -y install gcc-5 g++-5 gfortran-5 wget && \
+            apt-get -y install gcc-5 g++-5 gfortran-8 wget && \
             cd .. && \
             mkdir openblas && cd openblas && \
             target=\$(python3.7 ../scipy/tools/openblas_support.py) && \
             cp -r \$target/lib/* /usr/lib && \
             cp \$target/include/* /usr/include && \
             cd ../scipy && \
-            CC=gcc-5 CXX=g++-5 F77=gfortran-5 F90=gfortran-5 python3.7 setup.py install && \
+            CC=gcc-5 CXX=g++-5 F77=gfortran-8 F90=gfortran-8 python3.7 setup.py install && \
             python3.7 tools/openblas_support.py --check_version $(openblas_version) && \
-            CC=gcc-5 CXX=g++-5 F77=gfortran-5 F90=gfortran-5 python3.7 runtests.py --mode=full -- -n auto -s --junitxml=junit/test-results.xml --cov-config=.coveragerc --cov-report=xml --cov-report=html"
+            CC=gcc-5 CXX=g++-5 F77=gfortran-8 F90=gfortran-8 python3.7 runtests.py --mode=full -- -n auto -s --junitxml=junit/test-results.xml --cov-config=.coveragerc --cov-report=xml --cov-report=html"
       displayName: 'Run 32-bit Ubuntu Docker Build / Tests'
     - task: PublishTestResults@2
       condition: succeededOrFailed()
@@ -300,9 +300,8 @@ stages:
         clang-cl.exe --version
       displayName: 'clang-cl version'
     - powershell: |
-        # wheels appear to use mingw64 version 6.3.0, but 6.4.0
-        # is the closest match available from choco package manager
-        choco install -y mingw --forcex86 --force --version=6.4.0
+        # wheels must use same version
+        choco install -y mingw --forcex86 --force --version=7.3.0
       displayName: 'Install 32-bit mingw for 32-bit builds'
       condition: and(succeeded(), eq(variables['BITS'], 32))
     - script: >-

--- a/doc/release/1.7.2-notes.rst
+++ b/doc/release/1.7.2-notes.rst
@@ -12,13 +12,18 @@ version of OpenBLAS, 0.3.17.
 Authors
 =======
 
+* Isuru Fernando
 * Ralf Gommers
 * Matt Haberland
 * Nicholas McKibben
 * Judah Rand +
 * Tyler Reddy
+* Pamphile Roy
+* Charles Harris
+* Matti Picus
+* Hugo van Kemenade
 
-A total of 5 people contributed to this release.
+A total of 10 people contributed to this release.
 People with a "+" by their names contributed a patch for the first time.
 This list of names is automatically generated, and may not be fully complete.
 
@@ -37,7 +42,9 @@ Pull requests for 1.7.2
 * `#14207 <https://github.com/scipy/scipy/pull/14207>`__: DOC: stats: remove 'Methods' section from \`binomtest\` docstring...
 * `#14316 <https://github.com/scipy/scipy/pull/14316>`__: MAINT: Update \`openblas_support.py\` to support Apple Silicon
 * `#14323 <https://github.com/scipy/scipy/pull/14323>`__: BUG: Speed up sparse compressed indexing with very many rows
+* `#14333 <https://github.com/scipy/scipy/pull/14333>`__: MAINT: Use /usr/bin/linux32 so that sysconfig.get_platform()...
 * `#14478 <https://github.com/scipy/scipy/pull/14478>`__: BUG: geometric_slerp t ndim guard
+* `#14605 <https://github.com/scipy/scipy/pull/14605>`__: MAINT: Skip some interpolative decomposition tests
 * `#14616 <https://github.com/scipy/scipy/pull/14616>`__: REL: update build dependency versions in pyproject.toml for 1.7.2
 * `#14618 <https://github.com/scipy/scipy/pull/14618>`__: FIX: raise RuntimeWarning when Boost evaluation_error is encountered
 * `#14672 <https://github.com/scipy/scipy/pull/14672>`__: BLD: add \`zip_safe=False\` to the \`setup()\` call

--- a/doc/release/1.7.2-notes.rst
+++ b/doc/release/1.7.2-notes.rst
@@ -5,16 +5,39 @@ SciPy 1.7.2 Release Notes
 .. contents::
 
 SciPy 1.7.2 is a bug-fix release with no new features
-compared to 1.7.1.
+compared to 1.7.1. Notably, the release includes wheels
+for Python 3.10, and wheels are now built with a newer
+version of OpenBLAS, 0.3.17.
 
 Authors
 =======
 
+* Ralf Gommers
+* Matt Haberland
+* Nicholas McKibben
+* Judah Rand +
+* Tyler Reddy
+
+A total of 5 people contributed to this release.
+People with a "+" by their names contributed a patch for the first time.
+This list of names is automatically generated, and may not be fully complete.
 
 Issues closed for 1.7.2
 -----------------------
 
+* `#6019 <https://github.com/scipy/scipy/issues/6019>`__: minimize_scalar doesn't seem to honor "disp" option
+* `#14321 <https://github.com/scipy/scipy/issues/14321>`__: BUG: Indexing of CSR matrices with many rows is much slower than...
+* `#14465 <https://github.com/scipy/scipy/issues/14465>`__: BUG: n-d interpolation parameter provided to geometric_slerp
+* `#14599 <https://github.com/scipy/scipy/issues/14599>`__: SciPy 1.7 builds as zipped egg, ruining imports
+* `#14606 <https://github.com/scipy/scipy/issues/14606>`__: BUG: crash / core dump when calling scipy.stats.beta.ppf with...
 
 Pull requests for 1.7.2
 -----------------------
 
+* `#14207 <https://github.com/scipy/scipy/pull/14207>`__: DOC: stats: remove 'Methods' section from \`binomtest\` docstring...
+* `#14316 <https://github.com/scipy/scipy/pull/14316>`__: MAINT: Update \`openblas_support.py\` to support Apple Silicon
+* `#14323 <https://github.com/scipy/scipy/pull/14323>`__: BUG: Speed up sparse compressed indexing with very many rows
+* `#14478 <https://github.com/scipy/scipy/pull/14478>`__: BUG: geometric_slerp t ndim guard
+* `#14616 <https://github.com/scipy/scipy/pull/14616>`__: REL: update build dependency versions in pyproject.toml for 1.7.2
+* `#14618 <https://github.com/scipy/scipy/pull/14618>`__: FIX: raise RuntimeWarning when Boost evaluation_error is encountered
+* `#14672 <https://github.com/scipy/scipy/pull/14672>`__: BLD: add \`zip_safe=False\` to the \`setup()\` call

--- a/scipy/linalg/interpolative.py
+++ b/scipy/linalg/interpolative.py
@@ -388,7 +388,8 @@ import sys
 
 _DTYPE_ERROR = ValueError("invalid input dtype (input must be float64 or complex128)")
 _TYPE_ERROR = TypeError("invalid input type (must be array or LinearOperator)")
-_32BIT_ERROR = ValueError("interpolative decomposition on 32-bit systems with complex128 is buggy")
+_32BIT_ERROR = ValueError("interpolative decomposition on 32-bit systems "
+                          "with complex128 is buggy")
 _IS_32BIT = (sys.maxsize < 2**32)
 
 

--- a/scipy/linalg/interpolative.py
+++ b/scipy/linalg/interpolative.py
@@ -384,9 +384,12 @@ backend routine.
 
 import scipy.linalg._interpolative_backend as backend
 import numpy as np
+import sys
 
 _DTYPE_ERROR = ValueError("invalid input dtype (input must be float64 or complex128)")
 _TYPE_ERROR = TypeError("invalid input type (must be array or LinearOperator)")
+_32BIT_ERROR = ValueError("interpolative decomposition on 32-bit systems with complex128 is buggy")
+_IS_32BIT = (sys.maxsize < 2**32)
 
 
 def _is_real(A):
@@ -547,6 +550,8 @@ def interp_decomp(A, eps_or_k, rand=True):
                 if real:
                     k, idx, proj = backend.iddp_aid(eps, A)
                 else:
+                    if _IS_32BIT:
+                        raise _32BIT_ERROR
                     k, idx, proj = backend.idzp_aid(eps, A)
             else:
                 if real:
@@ -560,6 +565,8 @@ def interp_decomp(A, eps_or_k, rand=True):
                 if real:
                     idx, proj = backend.iddr_aid(A, k)
                 else:
+                    if _IS_32BIT:
+                        raise _32BIT_ERROR
                     idx, proj = backend.idzr_aid(A, k)
             else:
                 if real:
@@ -575,6 +582,8 @@ def interp_decomp(A, eps_or_k, rand=True):
             if real:
                 k, idx, proj = backend.iddp_rid(eps, m, n, matveca)
             else:
+                if _IS_32BIT:
+                    raise _32BIT_ERROR
                 k, idx, proj = backend.idzp_rid(eps, m, n, matveca)
             return k, idx - 1, proj
         else:
@@ -582,6 +591,8 @@ def interp_decomp(A, eps_or_k, rand=True):
             if real:
                 idx, proj = backend.iddr_rid(m, n, matveca, k)
             else:
+                if _IS_32BIT:
+                    raise _32BIT_ERROR
                 idx, proj = backend.idzr_rid(m, n, matveca, k)
             return idx - 1, proj
     else:
@@ -875,6 +886,8 @@ def svd(A, eps_or_k, rand=True):
                 if real:
                     U, V, S = backend.iddp_asvd(eps, A)
                 else:
+                    if _IS_32BIT:
+                        raise _32BIT_ERROR
                     U, V, S = backend.idzp_asvd(eps, A)
             else:
                 if real:
@@ -890,6 +903,8 @@ def svd(A, eps_or_k, rand=True):
                 if real:
                     U, V, S = backend.iddr_asvd(A, k)
                 else:
+                    if _IS_32BIT:
+                        raise _32BIT_ERROR
                     U, V, S = backend.idzr_asvd(A, k)
             else:
                 if real:
@@ -905,12 +920,16 @@ def svd(A, eps_or_k, rand=True):
             if real:
                 U, V, S = backend.iddp_rsvd(eps, m, n, matveca, matvec)
             else:
+                if _IS_32BIT:
+                    raise _32BIT_ERROR
                 U, V, S = backend.idzp_rsvd(eps, m, n, matveca, matvec)
         else:
             k = int(eps_or_k)
             if real:
                 U, V, S = backend.iddr_rsvd(m, n, matveca, matvec, k)
             else:
+                if _IS_32BIT:
+                    raise _32BIT_ERROR
                 U, V, S = backend.idzr_rsvd(m, n, matveca, matvec, k)
     else:
         raise _TYPE_ERROR

--- a/scipy/linalg/tests/test_interpolative.py
+++ b/scipy/linalg/tests/test_interpolative.py
@@ -31,204 +31,139 @@ import numpy as np
 from scipy.linalg import hilbert, svdvals, norm
 from scipy.sparse.linalg import aslinearoperator
 from scipy.linalg.interpolative import interp_decomp
-import time
 import itertools
 
-from numpy.testing import assert_, assert_allclose
+from numpy.testing import (assert_, assert_allclose, assert_equal,
+                           assert_array_equal)
+import pytest
 from pytest import raises as assert_raises
 
 
-def _debug_print(s):
-    if 0:
-        print(s)
+@pytest.fixture()
+def eps():
+    yield 1e-12
+
+
+@pytest.fixture(params=[np.float64, np.complex128])
+def A(request):
+    # construct Hilbert matrix
+    # set parameters
+    n = 300
+    yield hilbert(n).astype(request.param)
+
+
+@pytest.fixture()
+def L(A):
+    yield aslinearoperator(A)
+
+
+@pytest.fixture()
+def rank(A, eps):
+    S = np.linalg.svd(A, compute_uv=False)
+    try:
+        rank = np.nonzero(S < eps)[0][0]
+    except IndexError:
+        rank = A.shape[0]
+    return rank
 
 
 class TestInterpolativeDecomposition:
-    def test_id(self):
-        for dtype in [np.float64, np.complex128]:
-            self.check_id(dtype)
 
-    def check_id(self, dtype):
+    @pytest.mark.parametrize(
+        "rand,lin_op",
+        [(False, False), (True, False), (True, True)])
+    def test_real_id_fixed_precision(self, A, L, eps, rand, lin_op):
         # Test ID routines on a Hilbert matrix.
+        A_or_L = A if not lin_op else L
 
-        # set parameters
-        n = 300
-        eps = 1e-12
-
-        # construct Hilbert matrix
-        A = hilbert(n).astype(dtype)
-        if np.issubdtype(dtype, np.complexfloating):
-            A = A * (1 + 1j)
-        L = aslinearoperator(A)
-
-        # find rank
-        S = np.linalg.svd(A, compute_uv=False)
-        try:
-            rank = np.nonzero(S < eps)[0][0]
-        except IndexError:
-            rank = n
-
-        # print input summary
-        _debug_print("Hilbert matrix dimension:        %8i" % n)
-        _debug_print("Working precision:               %8.2e" % eps)
-        _debug_print("Rank to working precision:       %8i" % rank)
-
-        # set print format
-        fmt = "%8.2e (s) / %5s"
-
-        # test real ID routines
-        _debug_print("-----------------------------------------")
-        _debug_print("Real ID routines")
-        _debug_print("-----------------------------------------")
-
-        # fixed precision
-        _debug_print("Calling iddp_id / idzp_id  ...",)
-        t0 = time.time()
-        k, idx, proj = pymatrixid.interp_decomp(A, eps, rand=False)
-        t = time.time() - t0
+        k, idx, proj = pymatrixid.interp_decomp(A_or_L, eps, rand=rand)
         B = pymatrixid.reconstruct_matrix_from_id(A[:, idx[:k]], idx, proj)
-        _debug_print(fmt % (t, np.allclose(A, B, eps)))
-        assert_(np.allclose(A, B, eps))
+        assert_allclose(A, B, rtol=eps, atol=1e-08)
 
-        _debug_print("Calling iddp_aid / idzp_aid ...",)
-        t0 = time.time()
-        k, idx, proj = pymatrixid.interp_decomp(A, eps)
-        t = time.time() - t0
-        B = pymatrixid.reconstruct_matrix_from_id(A[:, idx[:k]], idx, proj)
-        _debug_print(fmt % (t, np.allclose(A, B, eps)))
-        assert_(np.allclose(A, B, eps))
-
-        _debug_print("Calling iddp_rid / idzp_rid ...",)
-        t0 = time.time()
-        k, idx, proj = pymatrixid.interp_decomp(L, eps)
-        t = time.time() - t0
-        B = pymatrixid.reconstruct_matrix_from_id(A[:, idx[:k]], idx, proj)
-        _debug_print(fmt % (t, np.allclose(A, B, eps)))
-        assert_(np.allclose(A, B, eps))
-
-        # fixed rank
+    @pytest.mark.parametrize(
+        "rand,lin_op",
+        [(False, False), (True, False), (True, True)])
+    def test_real_id_fixed_rank(self, A, L, eps, rank, rand, lin_op):
         k = rank
+        A_or_L = A if not lin_op else L
 
-        _debug_print("Calling iddr_id / idzr_id  ...",)
-        t0 = time.time()
-        idx, proj = pymatrixid.interp_decomp(A, k, rand=False)
-        t = time.time() - t0
+        idx, proj = pymatrixid.interp_decomp(A_or_L, k, rand=rand)
         B = pymatrixid.reconstruct_matrix_from_id(A[:, idx[:k]], idx, proj)
-        _debug_print(fmt % (t, np.allclose(A, B, eps)))
-        assert_(np.allclose(A, B, eps))
+        assert_allclose(A, B, rtol=eps, atol=1e-08)
 
-        _debug_print("Calling iddr_aid / idzr_aid ...",)
-        t0 = time.time()
-        idx, proj = pymatrixid.interp_decomp(A, k)
-        t = time.time() - t0
-        B = pymatrixid.reconstruct_matrix_from_id(A[:, idx[:k]], idx, proj)
-        _debug_print(fmt % (t, np.allclose(A, B, eps)))
-        assert_(np.allclose(A, B, eps))
+    @pytest.mark.parametrize("rand,lin_op", [(False, False)])
+    def test_real_id_skel_and_interp_matrices(
+            self, A, L, eps, rank, rand, lin_op):
+        k = rank
+        A_or_L = A if not lin_op else L
 
-        _debug_print("Calling iddr_rid / idzr_rid ...",)
-        t0 = time.time()
-        idx, proj = pymatrixid.interp_decomp(L, k)
-        t = time.time() - t0
-        B = pymatrixid.reconstruct_matrix_from_id(A[:, idx[:k]], idx, proj)
-        _debug_print(fmt % (t, np.allclose(A, B, eps)))
-        assert_(np.allclose(A, B, eps))
-
-        # check skeleton and interpolation matrices
-        idx, proj = pymatrixid.interp_decomp(A, k, rand=False)
+        idx, proj = pymatrixid.interp_decomp(A_or_L, k, rand=rand)
         P = pymatrixid.reconstruct_interp_matrix(idx, proj)
         B = pymatrixid.reconstruct_skel_matrix(A, k, idx)
-        assert_(np.allclose(B, A[:,idx[:k]], eps))
-        assert_(np.allclose(B.dot(P), A, eps))
+        assert_allclose(B, A[:, idx[:k]], rtol=eps, atol=1e-08)
+        assert_allclose(B @ P, A, rtol=eps, atol=1e-08)
 
-        # test SVD routines
-        _debug_print("-----------------------------------------")
-        _debug_print("SVD routines")
-        _debug_print("-----------------------------------------")
+    @pytest.mark.parametrize(
+        "rand,lin_op",
+        [(False, False), (True, False), (True, True)])
+    def test_svd_fixed_precison(self, A, L, eps, rand, lin_op):
+        A_or_L = A if not lin_op else L
 
-        # fixed precision
-        _debug_print("Calling iddp_svd / idzp_svd ...",)
-        t0 = time.time()
-        U, S, V = pymatrixid.svd(A, eps, rand=False)
-        t = time.time() - t0
-        B = np.dot(U, np.dot(np.diag(S), V.T.conj()))
-        _debug_print(fmt % (t, np.allclose(A, B, eps)))
-        assert_(np.allclose(A, B, eps))
+        U, S, V = pymatrixid.svd(A_or_L, eps, rand=rand)
+        B = U * S @ V.T.conj()
+        assert_allclose(A, B, rtol=eps, atol=1e-08)
 
-        _debug_print("Calling iddp_asvd / idzp_asvd...",)
-        t0 = time.time()
-        U, S, V = pymatrixid.svd(A, eps)
-        t = time.time() - t0
-        B = np.dot(U, np.dot(np.diag(S), V.T.conj()))
-        _debug_print(fmt % (t, np.allclose(A, B, eps)))
-        assert_(np.allclose(A, B, eps))
+    @pytest.mark.parametrize(
+        "rand,lin_op",
+        [(False, False), (True, False), (True, True)])
+    def test_svd_fixed_rank(self, A, L, eps, rank, rand, lin_op):
+        k = rank
+        A_or_L = A if not lin_op else L
 
-        _debug_print("Calling iddp_rsvd / idzp_rsvd...",)
-        t0 = time.time()
-        U, S, V = pymatrixid.svd(L, eps)
-        t = time.time() - t0
-        B = np.dot(U, np.dot(np.diag(S), V.T.conj()))
-        _debug_print(fmt % (t, np.allclose(A, B, eps)))
-        assert_(np.allclose(A, B, eps))
+        U, S, V = pymatrixid.svd(A_or_L, k, rand=rand)
+        B = U * S @ V.T.conj()
+        assert_allclose(A, B, rtol=eps, atol=1e-08)
 
-        # fixed rank
+    def test_id_to_svd(self, A, eps, rank):
         k = rank
 
-        _debug_print("Calling iddr_svd / idzr_svd ...",)
-        t0 = time.time()
-        U, S, V = pymatrixid.svd(A, k, rand=False)
-        t = time.time() - t0
-        B = np.dot(U, np.dot(np.diag(S), V.T.conj()))
-        _debug_print(fmt % (t, np.allclose(A, B, eps)))
-        assert_(np.allclose(A, B, eps))
-
-        _debug_print("Calling iddr_asvd / idzr_asvd ...",)
-        t0 = time.time()
-        U, S, V = pymatrixid.svd(A, k)
-        t = time.time() - t0
-        B = np.dot(U, np.dot(np.diag(S), V.T.conj()))
-        _debug_print(fmt % (t, np.allclose(A, B, eps)))
-        assert_(np.allclose(A, B, eps))
-
-        _debug_print("Calling iddr_rsvd / idzr_rsvd ...",)
-        t0 = time.time()
-        U, S, V = pymatrixid.svd(L, k)
-        t = time.time() - t0
-        B = np.dot(U, np.dot(np.diag(S), V.T.conj()))
-        _debug_print(fmt % (t, np.allclose(A, B, eps)))
-        assert_(np.allclose(A, B, eps))
-
-        # ID to SVD
         idx, proj = pymatrixid.interp_decomp(A, k, rand=False)
-        Up, Sp, Vp = pymatrixid.id_to_svd(A[:, idx[:k]], idx, proj)
-        B = U.dot(np.diag(S).dot(V.T.conj()))
-        assert_(np.allclose(A, B, eps))
+        U, S, V = pymatrixid.id_to_svd(A[:, idx[:k]], idx, proj)
+        B = U * S @ V.T.conj()
+        assert_allclose(A, B, rtol=eps, atol=1e-08)
 
-        # Norm estimates
+    def test_estimate_spectral_norm(self, A):
         s = svdvals(A)
         norm_2_est = pymatrixid.estimate_spectral_norm(A)
         assert_(np.allclose(norm_2_est, s[0], 1e-6))
 
+    def test_estimate_spectral_norm_diff(self, A):
         B = A.copy()
-        B[:,0] *= 1.2
+        B[:, 0] *= 1.2
         s = svdvals(A - B)
         norm_2_est = pymatrixid.estimate_spectral_norm_diff(A, B)
         assert_(np.allclose(norm_2_est, s[0], 1e-6))
 
-        # Rank estimates
-        B = np.array([[1, 1, 0], [0, 0, 1], [0, 0, 1]], dtype=dtype)
+    def test_rank_estimates_array(self, A):
+        B = np.array([[1, 1, 0], [0, 0, 1], [0, 0, 1]], dtype=A.dtype)
+
         for M in [A, B]:
-            ML = aslinearoperator(M)
-
             rank_tol = 1e-9
-            rank_np = np.linalg.matrix_rank(M, norm(M, 2)*rank_tol)
+            rank_np = np.linalg.matrix_rank(M, norm(M, 2) * rank_tol)
             rank_est = pymatrixid.estimate_rank(M, rank_tol)
-            rank_est_2 = pymatrixid.estimate_rank(ML, rank_tol)
-
             assert_(rank_est >= rank_np)
             assert_(rank_est <= rank_np + 10)
 
-            assert_(rank_est_2 >= rank_np - 4)
-            assert_(rank_est_2 <= rank_np + 4)
+    def test_rank_estimates_lin_op(self, A):
+        B = np.array([[1, 1, 0], [0, 0, 1], [0, 0, 1]], dtype=A.dtype)
+
+        for M in [A, B]:
+            ML = aslinearoperator(M)
+            rank_tol = 1e-9
+            rank_np = np.linalg.matrix_rank(M, norm(M, 2) * rank_tol)
+            rank_est = pymatrixid.estimate_rank(ML, rank_tol)
+            assert_(rank_est >= rank_np - 4)
+            assert_(rank_est <= rank_np + 4)
 
     def test_rand(self):
         pymatrixid.seed('default')

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -686,10 +686,10 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         if M == 0:
             return self.__class__(new_shape)
 
-        row_nnz = np.diff(self.indptr)
+        row_nnz = self.indptr[indices + 1] - self.indptr[indices]
         idx_dtype = self.indices.dtype
         res_indptr = np.zeros(M+1, dtype=idx_dtype)
-        np.cumsum(row_nnz[idx], out=res_indptr[1:])
+        np.cumsum(row_nnz, out=res_indptr[1:])
 
         nnz = res_indptr[-1]
         res_indices = np.empty(nnz, dtype=idx_dtype)
@@ -713,10 +713,18 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         if M == 0:
             return self.__class__(new_shape)
 
-        row_nnz = np.diff(self.indptr)
+        # Work out what slices are needed for `row_nnz`
+        # start,stop can be -1, only if step is negative
+        start0, stop0 = start, stop
+        if stop == -1 and start >= 0:
+            stop0 = None
+        start1, stop1 = start + 1, stop + 1
+
+        row_nnz = self.indptr[start1:stop1:step] - \
+            self.indptr[start0:stop0:step]
         idx_dtype = self.indices.dtype
         res_indptr = np.zeros(M+1, dtype=idx_dtype)
-        np.cumsum(row_nnz[idx], out=res_indptr[1:])
+        np.cumsum(row_nnz, out=res_indptr[1:])
 
         if step == 1:
             all_idx = slice(self.indptr[start], self.indptr[stop])

--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -310,7 +310,7 @@ class csr_matrix(_cs_matrix):
             row_data = row_data[::-1]
             row_indices = abs(row_indices[::-1])
 
-        shape = (1, int(np.ceil(float(stop - start) / stride)))
+        shape = (1, max(0, int(np.ceil(float(stop - start) / stride))))
         return csr_matrix((row_data, row_indices, row_indptr), shape=shape,
                           dtype=self.dtype, copy=False)
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -21,6 +21,7 @@ import contextlib
 import functools
 import operator
 import platform
+import itertools
 import sys
 from distutils.version import LooseVersion
 
@@ -2474,6 +2475,19 @@ class _TestSlicing:
         for i, a in enumerate(slices):
             for j, b in enumerate(slices):
                 check_2(a, b)
+
+        # Check out of bounds etc. systematically
+        extra_slices = []
+        for a, b, c in itertools.product(*([(None, 0, 1, 2, 5, 15,
+                                             -1, -2, 5, -15)]*3)):
+            if c == 0:
+                continue
+            extra_slices.append(slice(a, b, c))
+
+        for a in extra_slices:
+            check_2(a, a)
+            check_2(a, -2)
+            check_2(-2, a)
 
     def test_ellipsis_slicing(self):
         b = asmatrix(arange(50).reshape(5,10))

--- a/scipy/spatial/_geometric_slerp.py
+++ b/scipy/spatial/_geometric_slerp.py
@@ -46,8 +46,8 @@ def geometric_slerp(start,
     end : (n_dimensions, ) array-like
         Single n-dimensional input coordinate in a 1-D array-like
         object. `n` must be greater than 1.
-    t: float or (n_points,) array-like
-        A float or array-like of doubles representing interpolation
+    t: float or (n_points,) 1D array-like
+        A float or 1D array-like of doubles representing interpolation
         parameters, with values required in the inclusive interval
         between 0 and 1. A common approach is to generate the array
         with ``np.linspace(0, 1, n_pts)`` for linearly spaced points.
@@ -170,6 +170,11 @@ def geometric_slerp(start,
 
     start = np.asarray(start, dtype=np.float64)
     end = np.asarray(end, dtype=np.float64)
+    t = np.asarray(t)
+
+    if t.ndim > 1:
+        raise ValueError("The interpolation parameter "
+                         "value must be one dimensional.")
 
     if start.ndim != 1 or end.ndim != 1:
         raise ValueError("Start and end coordinates "
@@ -185,7 +190,7 @@ def geometric_slerp(start,
                          "space")
 
     if np.array_equal(start, end):
-        return [start] * np.asarray(t).size
+        return np.linspace(start, start, t.size)
 
     # for points that violate equation for n-sphere
     for coord in [start, end]:

--- a/scipy/spatial/tests/test_slerp.py
+++ b/scipy/spatial/tests/test_slerp.py
@@ -353,15 +353,31 @@ class TestGeometricSlerp:
     @pytest.mark.parametrize('start', [
         np.array([1, 0, 0]),
         np.array([0, 1]),
-        ])
-    def test_degenerate_input(self, start):
-        # handle start == end with repeated value
-        # like np.linspace
-        expected = [start] * 5
-        actual = geometric_slerp(start=start,
-                                 end=start,
-                                 t=np.linspace(0, 1, 5))
-        assert_allclose(actual, expected)
+    ])
+    @pytest.mark.parametrize('t', [
+        np.array(1),
+        np.array([1]),
+        np.array([[1]]),
+        np.array([[[1]]]),
+        np.array([]),
+        np.linspace(0, 1, 5),
+    ])
+    def test_degenerate_input(self, start, t):
+        if np.asarray(t).ndim > 1:
+            with pytest.raises(ValueError):
+                geometric_slerp(start=start, end=start, t=t)
+        else:
+
+            shape = (t.size,) + start.shape
+            expected = np.full(shape, start)
+
+            actual = geometric_slerp(start=start, end=start, t=t)
+            assert_allclose(actual, expected)
+
+            # Check that degenerate and non-degenerate
+            # inputs yield the same size
+            non_degenerate = geometric_slerp(start=start, end=start[::-1], t=t)
+            assert actual.size == non_degenerate.size
 
     @pytest.mark.parametrize('k', np.logspace(-10, -1, 10))
     def test_numerical_stability_pi(self, k):
@@ -381,3 +397,22 @@ class TestGeometricSlerp:
             norms = np.linalg.norm(result, axis=1)
             error = np.max(np.abs(norms - 1))
             assert error < 4e-15
+
+    @pytest.mark.parametrize('t', [
+     [[0, 0.5]],
+     [[[[[[[[[0, 0.5]]]]]]]]],
+    ])
+    def test_interpolation_param_ndim(self, t):
+        # regression test for gh-14465
+        arr1 = np.array([0, 1])
+        arr2 = np.array([1, 0])
+
+        with pytest.raises(ValueError):
+            geometric_slerp(start=arr1,
+                            end=arr2,
+                            t=t)
+
+        with pytest.raises(ValueError):
+            geometric_slerp(start=arr1,
+                            end=arr1,
+                            t=t)

--- a/scipy/stats/_binomtest.py
+++ b/scipy/stats/_binomtest.py
@@ -26,11 +26,6 @@ class BinomTestResult:
     proportion_estimate : float
         The estimate of the proportion of successes.
 
-    Methods
-    -------
-    proportion_ci :
-        Compute the confidence interval for the estimate of the proportion.
-
     """
     def __init__(self, k, n, alternative, pvalue, proportion_estimate):
         self.k = k

--- a/scipy/stats/_boost/setup.py
+++ b/scipy/stats/_boost/setup.py
@@ -19,6 +19,7 @@ def configuration(parent_package='', top_path=None):
     DEFINES = [
         # return nan instead of throwing
         ('BOOST_MATH_DOMAIN_ERROR_POLICY', 'ignore_error'),
+        ('BOOST_MATH_EVALUATION_ERROR_POLICY', 'user_error'),
     ]
     if sys.maxsize > 2**32:
         # 32-bit machines lose too much precision with no promotion,

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -3850,6 +3850,15 @@ class multivariate_t_gen(multi_rv_generic):
     as a function to fix the location, shape matrix, and degrees of freedom
     parameters, returning a "frozen" multivariate t-distribution random.
 
+    Methods
+    -------
+    ``pdf(x, loc=None, shape=1, df=1, allow_singular=False)``
+        Probability density function.
+    ``logpdf(x, loc=None, shape=1, df=1, allow_singular=False)``
+        Log of the probability density function.
+    ``rvs(loc=None, shape=1, df=1, size=1, random_state=None)``
+        Draw random samples from a multivariate t-distribution.
+
     Parameters
     ----------
     x : array_like

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -3850,15 +3850,6 @@ class multivariate_t_gen(multi_rv_generic):
     as a function to fix the location, shape matrix, and degrees of freedom
     parameters, returning a "frozen" multivariate t-distribution random.
 
-    Methods
-    -------
-    ``pdf(x, loc=None, shape=1, df=1, allow_singular=False)``
-        Probability density function.
-    ``logpdf(x, loc=None, shape=1, df=1, allow_singular=False)``
-        Log of the probability density function.
-    ``rvs(loc=None, shape=1, df=1, size=1, random_state=None)``
-        Draw random samples from a multivariate t-distribution.
-
     Parameters
     ----------
     x : array_like

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2890,6 +2890,11 @@ class TestBeta:
         a, b = 0.2, 3
         assert_equal(stats.beta.pdf(0, a, b), np.inf)
 
+    def test_boost_eval_issue_14606(self):
+        q, a, b = 0.995, 1.0e11, 1.0e13
+        with pytest.warns(RuntimeWarning):
+            stats.beta.ppf(q, a, b)
+
 
 class TestBetaPrime:
     def test_logpdf(self):

--- a/setup.py
+++ b/setup.py
@@ -582,6 +582,7 @@ def setup_package():
         platforms=["Windows", "Linux", "Solaris", "Mac OS-X", "Unix"],
         install_requires=[req_np],
         python_requires=req_py,
+        zip_safe=False,
     )
 
     if "--force" in sys.argv:

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -1,57 +1,48 @@
-import os
-import sys
 import glob
-import shutil
-import textwrap
+import os
 import platform
-import hashlib
+import sysconfig
+import sys
+import shutil
+import tarfile
+import textwrap
+import zipfile
 
 from tempfile import mkstemp, gettempdir
 from urllib.request import urlopen, Request
 from urllib.error import HTTPError
-import zipfile
-import tarfile
 
-OPENBLAS_V = 'v0.3.9'
-OPENBLAS_LONG = 'v0.3.9'
-BASE_LOC = ''
-ANACONDA = 'https://anaconda.org/multibuild-wheels-staging/openblas-libs'
-ARCHITECTURES = ['', 'windows', 'darwin', 'aarch64', 'x86', 'ppc64le', 's390x']
-sha256_vals = {
-'openblas64_-v0.3.9-macosx_10_9_x86_64-gf_1becaaa.tar.gz':
-'53f606a7da75d390287f1c51b2af7866b8fe7553a26d2474f827daf0e5c8a886',
-'openblas64_-v0.3.9-manylinux1_x86_64.tar.gz':
-'6fe5b1e2a4baa16833724bcc94a80b22e9c99fc1b9a2ddbce4f1f82a8002d906',
-'openblas64_-v0.3.9-win_amd64-gcc_7_1_0.zip':
-'15d24a66c5b22cc7b3120e831658f491c7a063804c33813235044a6f8b56686d',
-'openblas-v0.3.9-macosx_10_9_x86_64-gf_1becaaa.tar.gz': 
-'8221397b9cfb8cb22f3efb7f228ef901e13f9fd89c7d7d0cb7b8a79b0610bf33',
-'openblas-v0.3.9-manylinux1_i686.tar.gz': 
-'31abf8eccb697a320a998ce0f59045edc964602f815d78690c5a23839819261c',
-'openblas-v0.3.9-manylinux1_x86_64.tar.gz':
-'d9c39acbafae9b1daef19c2738ec938109a59e9322f93eb9a3c50869d220deff',
-'openblas-v0.3.9-win32-gcc_7_1_0.zip':
-'69a7dc265e8a8e45b358637d11cb1710ce88c4456634c7ce37d429b1d9bc9aaa',
-'openblas-v0.3.9-win_amd64-gcc_7_1_0.zip': 
-'0cea06f4a2afebaa6255854f73f237802fc6b58eaeb1a8b1c22d87cc399e0d48',
-'openblas-v0.3.9-manylinux2014_aarch64.tar.gz':
-'10d5ef5e9e19af5c199b59a17f43763e0c85ecf13cbc8f2d91e076f7847cdb5e'
-}
-
+OPENBLAS_V = '0.3.17'
+OPENBLAS_LONG = 'v0.3.17'
+BASE_LOC = 'https://anaconda.org/multibuild-wheels-staging/openblas-libs'
+BASEURL = f'{BASE_LOC}/{OPENBLAS_LONG}/download'
+SUPPORTED_PLATFORMS = [
+    'linux-aarch64',
+    'linux-x86_64',
+    'linux-i686',
+    'linux-ppc64le',
+    'linux-s390x',
+    'win-amd64',
+    'win-32',
+    'macosx-x86_64',
+    'macosx-arm64',
+]
 IS_32BIT = sys.maxsize < 2**32
-def get_arch():
-    if platform.system() == 'Windows':
-        ret = 'windows'
-    elif platform.system() == 'Darwin':
-        ret = 'darwin'
-    else:
-        ret = platform.uname().machine
-        # What do 32 bit machines report?
-        # If they are a docker, they report x86_64 or i686
-        if 'x86' in ret or ret == 'i686':
-            ret = 'x86'
-    assert ret in ARCHITECTURES
-    return ret
+
+
+def get_plat():
+    plat = sysconfig.get_platform()
+    plat_split = plat.split("-")
+    arch = plat_split[-1]
+    if arch == "win32":
+        plat = "win-32"
+    elif arch in ["universal2", "intel"]:
+        plat = f"macosx-{platform.uname().machine}"
+    elif len(plat_split) > 2:
+        plat = f"{plat_split[0]}-{arch}"
+    assert plat in SUPPORTED_PLATFORMS,  f'invalid platform {plat}'
+    return plat
+
 
 def get_ilp64():
     if os.environ.get("NPY_USE_BLAS_ILP64", "0") == "0":
@@ -60,57 +51,65 @@ def get_ilp64():
         raise RuntimeError("NPY_USE_BLAS_ILP64 set on 32-bit arch")
     return "64_"
 
-def download_openblas(target, arch, ilp64):
+
+def get_manylinux(arch):
+    if arch in ('x86_64', 'i686'):
+        default = '2010'
+    else:
+        default = '2014'
+    ret = os.environ.get("MB_ML_VER", default)
+    # XXX For PEP 600 this can be a glibc version
+    assert ret in ('1', '2010', '2014', '_2_24'), f'invalid MB_ML_VER {ret}'
+    return ret
+
+
+def download_openblas(target, plat, ilp64):
+    osname, arch = plat.split("-")
     fnsuffix = {None: "", "64_": "64_"}[ilp64]
     filename = ''
-    if arch in ('aarch64', 'ppc64le', 's390x'):
-        suffix = f'manylinux2014_{arch}.tar.gz'
-        filename = f'{ANACONDA}/{OPENBLAS_LONG}/download/openblas{fnsuffix}-{OPENBLAS_LONG}-{suffix}'
+    headers = {'User-Agent':
+               ('Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 ; '
+                '(KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.3')}
+    suffix = None
+    if osname == "linux":
+        ml_ver = get_manylinux(arch)
+        suffix = f'manylinux{ml_ver}_{arch}.tar.gz'
         typ = 'tar.gz'
-        typ = 'tar.gz'
-    elif arch == 'darwin':
+    elif plat == 'macosx-x86_64':
         suffix = 'macosx_10_9_x86_64-gf_1becaaa.tar.gz'
-        filename = f'{ANACONDA}/{OPENBLAS_LONG}/download/openblas{fnsuffix}-{OPENBLAS_LONG}-{suffix}'
         typ = 'tar.gz'
-    elif arch == 'windows':
-        if IS_32BIT:
-            suffix = 'win32-gcc_7_1_0.zip'
+    elif plat == 'macosx-arm64':
+        suffix = 'macosx_11_0_arm64-gf_f26990f.tar.gz'
+        typ = 'tar.gz'
+    elif osname == 'win':
+        if plat == "win-32":
+            suffix = 'win32-gcc_8_1_0.zip'
         else:
-            suffix = 'win_amd64-gcc_7_1_0.zip'
-        filename = f'{ANACONDA}/{OPENBLAS_LONG}/download/openblas{fnsuffix}-{OPENBLAS_LONG}-{suffix}'
+            suffix = 'win_amd64-gcc_8_1_0.zip'
         typ = 'zip'
-    elif 'x86' in arch:
-        if IS_32BIT:
-            suffix = 'manylinux1_i686.tar.gz'
-        else:
-            suffix = 'manylinux1_x86_64.tar.gz'
-        filename = f'{ANACONDA}/{OPENBLAS_LONG}/download/openblas{fnsuffix}-{OPENBLAS_LONG}-{suffix}'
-        typ = 'tar.gz'
-    if not filename:
-        return None
-    print("Downloading:", filename, file=sys.stderr)
-    try:
-        with open(target, 'wb') as fid:
-            # anaconda.org download location guards against
-            # scraping so trick it with a fake browser header
-            # see: https://medium.com/@speedforcerun/python-crawler-http-error-403-forbidden-1623ae9ba0f
-            headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.3'}
-            req = Request(url=filename, headers=headers)
-            fid.write(urlopen(req).read())
-        with open(target, 'rb') as binary_to_check:
-            data = binary_to_check.read()
-            sha256_returned = hashlib.sha256(data).hexdigest()
-            sha256_expected = sha256_vals[os.path.basename(filename)]
-            if sha256_returned != sha256_expected:
-                raise ValueError('sha256 hash mismatch for downloaded OpenBLAS')
 
-    except HTTPError as e:
-        print(f'Could not download "{filename}"')
-        print(f'Error message: {e}')
+    if not suffix:
         return None
+    filename = f'{BASEURL}/openblas{fnsuffix}-{OPENBLAS_LONG}-{suffix}'
+    req = Request(url=filename, headers=headers)
+    try:
+        response = urlopen(req)
+    except HTTPError:
+        print(f'Could not download "{filename}"', file=sys.stderr)
+        raise
+    length = response.getheader('content-length')
+    if response.status != 200:
+        print(f'Could not download "{filename}"', file=sys.stderr)
+        return None
+    print(f"Downloading {length} from {filename}", file=sys.stderr)
+    data = response.read()
+    print("Saving to file", file=sys.stderr)
+    with open(target, 'wb') as fid:
+        fid.write(data)
     return typ
 
-def setup_openblas(arch=get_arch(), ilp64=get_ilp64()):
+
+def setup_openblas(plat=get_plat(), ilp64=get_ilp64()):
     '''
     Download and setup an openblas library for building. If successful,
     the configuration script will find it automatically.
@@ -122,33 +121,39 @@ def setup_openblas(arch=get_arch(), ilp64=get_ilp64()):
         To determine success, do ``os.path.exists(msg)``
     '''
     _, tmp = mkstemp()
-    if not arch:
-        raise ValueError('unknown architecture')
-    typ = download_openblas(tmp, arch, ilp64)
+    if not plat:
+        raise ValueError('unknown platform')
+    typ = download_openblas(tmp, plat, ilp64)
     if not typ:
         return ''
-    if arch == 'windows':
+    osname, arch = plat.split("-")
+    if osname == 'win':
         if not typ == 'zip':
-            return 'expecting to download zipfile on windows, not %s' % str(typ)
+            return f'expecting to download zipfile on windows, not {typ}'
         return unpack_windows_zip(tmp)
     else:
         if not typ == 'tar.gz':
             return 'expecting to download tar.gz, not %s' % str(typ)
         return unpack_targz(tmp)
 
+
 def unpack_windows_zip(fname):
     with zipfile.ZipFile(fname, 'r') as zf:
         # Get the openblas.a file, but not openblas.dll.a nor openblas.dev.a
         lib = [x for x in zf.namelist() if OPENBLAS_LONG in x and
-                  x.endswith('a') and not x.endswith('dll.a') and
-                  not x.endswith('dev.a')]
+               x.endswith('a') and not x.endswith('dll.a') and
+               not x.endswith('dev.a')]
         if not lib:
             return 'could not find libopenblas_%s*.a ' \
                     'in downloaded zipfile' % OPENBLAS_LONG
-        target = os.path.join(gettempdir(), 'openblas.a')
+        if get_ilp64() is None:
+            target = os.path.join(gettempdir(), 'openblas.a')
+        else:
+            target = os.path.join(gettempdir(), 'openblas64_.a')
         with open(target, 'wb') as fid:
             fid.write(zf.read(lib[0]))
     return target
+
 
 def unpack_targz(fname):
     target = os.path.join(gettempdir(), 'openblas')
@@ -159,6 +164,7 @@ def unpack_targz(fname):
         prefix = os.path.commonpath(zf.getnames())
         extract_tarfile_to(zf, target, prefix)
         return target
+
 
 def extract_tarfile_to(tarfileobj, target_path, archive_path):
     """Extract TarFile contents under archive_path/ to target_path/"""
@@ -183,6 +189,7 @@ def extract_tarfile_to(tarfileobj, target_path, archive_path):
 
     tarfileobj.extractall(target_path, members=get_members())
 
+
 def make_init(dirname):
     '''
     Create a _distributor_init.py file for OpenBlas
@@ -196,12 +203,12 @@ def make_init(dirname):
             and is created as part of the scripts that build the wheel.
             '''
             import os
-            from ctypes import WinDLL
             import glob
             if os.name == 'nt':
                 # convention for storing / loading the DLL from
                 # numpy/.libs/, if present
                 try:
+                    from ctypes import WinDLL
                     basedir = os.path.dirname(__file__)
                 except:
                     pass
@@ -210,43 +217,61 @@ def make_init(dirname):
                     DLL_filenames = []
                     if os.path.isdir(libs_dir):
                         for filename in glob.glob(os.path.join(libs_dir,
-                                                             '*openblas*dll')):
+                                                               '*openblas*dll')):
                             # NOTE: would it change behavior to load ALL
                             # DLLs at this path vs. the name restriction?
                             WinDLL(os.path.abspath(filename))
                             DLL_filenames.append(filename)
-                if len(DLL_filenames) > 1:
-                    import warnings
-                    warnings.warn("loaded more than 1 DLL from .libs:\\n%s" %
-                              "\\n".join(DLL_filenames),
-                              stacklevel=1)
+                    if len(DLL_filenames) > 1:
+                        import warnings
+                        warnings.warn("loaded more than 1 DLL from .libs:"
+                                      "\\n%s" % "\\n".join(DLL_filenames),
+                                      stacklevel=1)
     """))
 
-def test_setup(arches):
+
+def test_setup(plats):
     '''
     Make sure all the downloadable files exist and can be opened
     '''
     def items():
-        for arch in arches:
-            yield arch, None
-            if arch in ('x86', 'darwin', 'windows'):
-                yield arch, '64_'
+        """ yields all combinations of arch, ilp64
+        """
+        for plat in plats:
+            yield plat, None
+            osname, arch = plat.split("-")
+            if arch not in ('i686', 'arm64', '32'):
+                yield plat, '64_'
+            if osname == "linux" and arch in ('i686', 'x86_64'):
+                oldval = os.environ.get('MB_ML_VER', None)
+                os.environ['MB_ML_VER'] = '1'
+                yield plat, None
+                # Once we create x86_64 and i686 manylinux2014 wheels...
+                # os.environ['MB_ML_VER'] = '2014'
+                # yield arch, None, False
+                if oldval:
+                    os.environ['MB_ML_VER'] = oldval
+                else:
+                    os.environ.pop('MB_ML_VER')
 
-    for arch, ilp64 in items():
-        if arch == '':
+    errs = []
+    for plat, ilp64 in items():
+        osname, _ = plat.split("-")
+        if plat not in plats:
             continue
-
         target = None
         try:
             try:
-                target = setup_openblas(arch, ilp64)
-            except Exception:
-                print(f'Could not setup {arch}')
-                raise
+                target = setup_openblas(plat, ilp64)
+            except Exception as e:
+                print(f'Could not setup {plat} with ilp64 {ilp64}, ')
+                print(e)
+                errs.append(e)
+                continue
             if not target:
-                raise RuntimeError(f'Could not setup {arch}')
+                raise RuntimeError(f'Could not setup {plat}')
             print(target)
-            if arch == 'windows':
+            if osname == 'win':
                 if not target.endswith('.a'):
                     raise RuntimeError("Not .a extracted!")
             else:
@@ -259,6 +284,9 @@ def test_setup(arches):
                     os.unlink(target)
                 else:
                     shutil.rmtree(target)
+    if errs:
+        raise errs[0]
+
 
 def test_version(expected_version, ilp64=get_ilp64()):
     """
@@ -277,12 +305,11 @@ def test_version(expected_version, ilp64=get_ilp64()):
     get_config.restype = ctypes.c_char_p
     res = get_config()
     print('OpenBLAS get_config returned', str(res))
-    check_str = b'OpenBLAS %s' % expected_version[0].encode()
-    assert check_str in res
-
-    if 'dev' not in expected_version[0]:
-        assert b'dev' not in res
-
+    if not expected_version:
+        expected_version = OPENBLAS_V
+    check_str = b'OpenBLAS %s' % expected_version.encode()
+    print(check_str)
+    assert check_str in res, f'{expected_version} not found in {res}'
     if ilp64:
         assert b"USE64BITINT" in res
     else:
@@ -295,16 +322,18 @@ if __name__ == '__main__':
         description='Download and expand an OpenBLAS archive for this '
                     'architecture')
     parser.add_argument('--test', nargs='*', default=None,
-        help='Test different architectures. "all", or any of %s' % ARCHITECTURES)
-    parser.add_argument('--check_version', nargs=1, default=None,
-        help='Check provided OpenBLAS version string against available OpenBLAS')
+                        help='Test different architectures. "all", or any of '
+                             f'{SUPPORTED_PLATFORMS}')
+    parser.add_argument('--check_version', nargs='?', default='',
+                        help='Check provided OpenBLAS version string '
+                             'against available OpenBLAS')
     args = parser.parse_args()
-    if args.check_version is not None:
+    if args.check_version != '':
         test_version(args.check_version)
     elif args.test is None:
         print(setup_openblas())
     else:
         if len(args.test) == 0 or 'all' in args.test:
-            test_setup(ARCHITECTURES)
+            test_setup(SUPPORTED_PLATFORMS)
         else:
             test_setup(args.test)


### PR DESCRIPTION
With Python 3.10 coming out early next week, backport PRs with the appropriate label, update release notes, and see where we are with the CI, etc.

Backports included so far:
- gh-14207
- gh-14316
- gh-14323
- gh-14478
- gh-14618
- gh-14672
- gh-14333
- gh-14605