### PR TITLE
Fix typos in bspline docs (and comments)

### DIFF
--- a/scipy/interpolate/_bspl.pyx
+++ b/scipy/interpolate/_bspl.pyx
@@ -149,7 +149,7 @@ def evaluate_spline(const double[::1] t,
                 continue
 
             # Evaluate (k+1) b-splines which are non-zero on the interval.
-            # on return, first k+1 elemets of work are B_{m-k},..., B_{m}
+            # on return, first k+1 elements of work are B_{m-k},..., B_{m}
             _deBoor_D(&t[0], xval, k, interval, nu, &work[0])
 
             # Form linear combinations
@@ -435,7 +435,7 @@ def _make_design_matrix(const double[::1] x,
     -------
     design_matrix : `csr_matrix` object
         Sparse matrix in CSR format where in each row all the basis
-        elemets are evaluated at the certain point (first row - x[0],
+        elements are evaluated at the certain point (first row - x[0],
         ..., last row - x[-1]).
     """
     cdef:

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -347,7 +347,7 @@ class BSpline:
         -------
         design_matrix : `csr_matrix` object
             Sparse matrix in CSR format where in each row all the basis
-            elemets are evaluated at the certain point (first row - x[0],
+            elements are evaluated at the certain point (first row - x[0],
             ..., last row - x[-1]).
 
         Examples
@@ -389,7 +389,7 @@ class BSpline:
         -----
         .. versionadded:: 1.8.0
 
-        In each row of the design matrix all the basis elemets are evaluated
+        In each row of the design matrix all the basis elements are evaluated
         at the certain point (first row - x[0], ..., last row - x[-1]).
 
         `nt` is a lenght of the vector of knots: as far as there are
@@ -404,7 +404,7 @@ class BSpline:
         if t.ndim != 1 or np.any(t[1:] < t[:-1]):
             raise ValueError(f"Expect t to be a 1-D sorted array_like, but "
                              f"got t={t}.")
-        # There are `nt - k - 1` basis elemets in a BSpline built on the
+        # There are `nt - k - 1` basis elements in a BSpline built on the
         # vector of knots with length `nt`, so to have at least `k + 1` basis
         # element we need to have at least `2 * k + 2` elements in the vector
         # of knots.


### PR DESCRIPTION
#### Reference issue
n/a

#### What does this implement/fix?
<!--Please explain your changes.-->
I was perusing the new documentation on [`BSpline.design_matrix`](https://scipy.github.io/devdocs/reference/generated/scipy.interpolate.BSpline.design_matrix.html) and caught some minor typos -- my find-and-replace also found a few typos in comments.


#### Additional information
<!--Any additional information you think is important.-->
