### PR TITLE
BUG: correct the test loop in test_arpack.eval_evec

### DIFF
--- a/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
@@ -73,7 +73,7 @@ def _get_test_tolerance(type_char, mattype=None, D_type=None, which=None):
         tol = 30 * np.finfo(np.float32).eps
         rtol *= 5
 
-    if type_char in ('D','F')  and which in ('LM','SM','LA') and \
+    if type_char in ('D','F') and which in ('LM','SM','LA') and \
           D_type.name == "gen-hermitian-Mc":
         # missing case 2, and more, from PR 14798
         tol = 30 * np.finfo(np.float32).eps
@@ -272,7 +272,7 @@ def eval_evec(symmetric, d, typ, k, which, v0=None, sigma=None,
             ntries += 1
 
         if check_evecs:
-        # check eigenvectors
+            # check eigenvectors
             LHS = np.dot(a, evec)
             if general:
                 RHS = eigenvalues * np.dot(b, evec)

--- a/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
@@ -67,14 +67,14 @@ def _get_test_tolerance(type_char, mattype=None, D_type=None, which=None):
         # sparse in single precision: worse errors
         rtol *= 5
 
-    if mattype is np.asarray and type_char == 'F' and which == 'LA' \
-          and D_type.name == "gen-hermitian-Mc":
+    if (mattype is np.asarray and type_char == 'F' and which == 'LA'
+        and D_type.name == "gen-hermitian-Mc"):
         # missing case 1 from PR 14798
         tol = 30 * np.finfo(np.float32).eps
         rtol *= 5
 
-    if type_char in ('D','F') and which in ('LM','SM','LA') and \
-          D_type.name == "gen-hermitian-Mc":
+    if (type_char in ('D', 'F') and which in ('LM', 'SM', 'LA')
+        and D_type.name == "gen-hermitian-Mc"):
         # missing case 2, and more, from PR 14798
         tol = 30 * np.finfo(np.float32).eps
         rtol *= 7

--- a/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
@@ -251,22 +251,25 @@ def eval_evec(symmetric, d, typ, k, which, v0=None, sigma=None,
         eigenvalues = eigenvalues[ind]
         evec = evec[:, ind]
 
-        # check eigenvectors
-        LHS = np.dot(a, evec)
-        if general:
-            RHS = eigenvalues * np.dot(b, evec)
-        else:
-            RHS = eigenvalues * evec
-
-            assert_allclose(LHS, RHS, rtol=rtol, atol=atol, err_msg=err)
-
         try:
             # check eigenvalues
             assert_allclose_cc(eigenvalues, exact_eval, rtol=rtol, atol=atol,
                                err_msg=err)
-            break
+            check_evecs = True
         except AssertionError:
+            check_evecs = False
             ntries += 1
+
+        if check_evecs:
+        # check eigenvectors
+            LHS = np.dot(a, evec)
+            if general:
+                RHS = eigenvalues * np.dot(b, evec)
+            else:
+                RHS = eigenvalues * evec
+
+            assert_allclose(LHS, RHS, rtol=rtol, atol=atol, err_msg=err)
+            break
 
     # check eigenvalues
     assert_allclose_cc(eigenvalues, exact_eval, rtol=rtol, atol=atol, err_msg=err)

--- a/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
@@ -73,7 +73,7 @@ def _get_test_tolerance(type_char, mattype=None, D_type=None, which=None):
         tol = 30 * np.finfo(np.float32).eps
         rtol *= 5
 
-    if type_char == 'D'  and which in ('LM','SM','LA') and \
+    if type_char in ('D','F')  and which in ('LM','SM','LA') and \
           D_type.name == "gen-hermitian-Mc":
         # missing case 2, and more, from PR 14798
         tol = 30 * np.finfo(np.float32).eps

--- a/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
@@ -67,14 +67,20 @@ def _get_test_tolerance(type_char, mattype=None, D_type=None, which=None):
         # sparse in single precision: worse errors
         rtol *= 5
 
-    if (mattype is np.asarray and type_char == 'F' and which == 'LA'
-        and D_type.name == "gen-hermitian-Mc"):
+    if (
+        mattype is np.asarray
+        and type_char == 'F' and which == 'LA'
+        and D_type.name == "gen-hermitian-Mc"
+    ):
         # missing case 1 from PR 14798
         tol = 30 * np.finfo(np.float32).eps
         rtol *= 5
 
-    if (type_char in ('D', 'F') and which in ('LM', 'SM', 'LA')
-        and D_type.name == "gen-hermitian-Mc"):
+    if (
+        type_char in ('D', 'F')
+        and which in ('LM', 'SM', 'LA')
+        and D_type.name == "gen-hermitian-Mc"
+    ):
         # missing case 2, and more, from PR 14798
         tol = 30 * np.finfo(np.float32).eps
         rtol *= 7

--- a/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
@@ -28,7 +28,7 @@ from scipy._lib._gcutils import assert_deallocated, IS_PYPY
 _ndigits = {'f': 3, 'd': 11, 'F': 3, 'D': 11}
 
 
-def _get_test_tolerance(type_char, mattype=None):
+def _get_test_tolerance(type_char, mattype=None, D_type=None, which=None):
     """
     Return tolerance values suitable for a given test:
 
@@ -66,6 +66,14 @@ def _get_test_tolerance(type_char, mattype=None):
     if mattype is csr_matrix and type_char in ('f', 'F'):
         # sparse in single precision: worse errors
         rtol *= 5
+
+
+    if mattype is np.asarray and type_char == 'F' and which == 'LA' \
+          and D_type.name == "gen-hermitian-Mc":
+        # missing case from PR 14798
+        tol = 30 * np.finfo(np.float32).eps
+        rtol *= 5
+
 
     return tol, rtol, atol
 
@@ -223,8 +231,7 @@ def eval_evec(symmetric, d, typ, k, which, v0=None, sigma=None,
         kwargs['OPpart'] = OPpart
 
     # compute suitable tolerances
-    kwargs['tol'], rtol, atol = _get_test_tolerance(typ, mattype)
-
+    kwargs['tol'], rtol, atol = _get_test_tolerance(typ, mattype, d, which)
     # on rare occasions, ARPACK routines return results that are proper
     # eigenvalues and -vectors, but not necessarily the ones requested in
     # the parameter which. This is inherent to the Krylov methods, and

--- a/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
@@ -68,22 +68,16 @@ def _get_test_tolerance(type_char, mattype=None, D_type=None, which=None):
         rtol *= 5
 
     if (
-        mattype is np.asarray
-        and type_char == 'F' and which == 'LA'
+        which in ('LM', 'SM', 'LA')
         and D_type.name == "gen-hermitian-Mc"
     ):
-        # missing case 1 from PR 14798
-        tol = 30 * np.finfo(np.float32).eps
-        rtol *= 5
+        if type_char == 'F':
+            # missing case 1, 2, and more, from PR 14798
+            rtol *= 5
 
-    if (
-        type_char in ('D', 'F')
-        and which in ('LM', 'SM', 'LA')
-        and D_type.name == "gen-hermitian-Mc"
-    ):
-        # missing case 2, and more, from PR 14798
-        tol = 30 * np.finfo(np.float32).eps
-        rtol *= 7
+        if type_char == 'D':
+            # missing more cases, from PR 14798
+            rtol *= 7
 
     return tol, rtol, atol
 

--- a/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
@@ -67,13 +67,17 @@ def _get_test_tolerance(type_char, mattype=None, D_type=None, which=None):
         # sparse in single precision: worse errors
         rtol *= 5
 
-
     if mattype is np.asarray and type_char == 'F' and which == 'LA' \
           and D_type.name == "gen-hermitian-Mc":
-        # missing case from PR 14798
+        # missing case 1 from PR 14798
         tol = 30 * np.finfo(np.float32).eps
         rtol *= 5
 
+    if type_char == 'D'  and which in ('LM','SM','LA') and \
+          D_type.name == "gen-hermitian-Mc":
+        # missing case 2, and more, from PR 14798
+        tol = 30 * np.finfo(np.float32).eps
+        rtol *= 7
 
     return tol, rtol, atol
 


### PR DESCRIPTION
In scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py, eval_evec
one tests for correctness eigenpairs, in a loop,
which is meant to allow for an error (the
`k`-tuple of eigenpairs found differs from what's asked by `which`
argument) in Krylov subspaces method. Cf. comments there:

    # on rare occasions, ARPACK routines return results that are proper
    # eigenvalues and -vectors, but not necessarily the ones requested in
    # the parameter which. This is inherent to the Krylov methods, and
    # should not be treated as a failure. If such a rare situation
    # occurs, the calculation is tried again (but at most a few times).

One should 1st check whether one got correct eigenvalues, and try again
if they are not the wanted ones.
The current implementation does it backwards: it checks whether
the eigenpair works, without 1st checking for eigenvalues.

This commit corrects this programming error.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Requested by @rgommers  in review of gh-14786


#### Additional information
https://github.com/scipy/scipy/pull/14786#issuecomment-932793440
