### PR TITLE
CI, MAINT: pin Cython for azure pre-rel

### DIFF
--- a/ci/azure-travis-template.yaml
+++ b/ci/azure-travis-template.yaml
@@ -66,7 +66,7 @@ steps:
     pip install --upgrade ${{parameters.numpy_spec}} &&
     pip install --upgrade pip==20.2.4 setuptools wheel &&
     pip install ${{parameters.other_spec}}
-    cython
+    "cython<3.0a5"
     gmpy2
     mpmath
     pythran


### PR DESCRIPTION
* for about 3 weeks pre-release CI has been failing as described
in gh-14732

* I bisected the pre-release versions of Cython `3.x` that are
available on PyPI locally and found that the first version to
reproduce a sefault for the command below is `3.0a5`

`python runtests.py -t "scipy/interpolate/tests/test_rbfinterp.py" -- -n 2`

* so, pin the max Cython version to `<3.0a5` for now (pip should still
install stable release when `--pre` is not used in other Azure CI
entries)

* obviously this is just a workaround--I'll open an upstream issue
to see if there are any suspicions about a possible bug or something
else we might do differently to avoid the segfault