### PR TITLE
MAINT: disable include/source coverage warning.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,4 +5,4 @@ omit =
     scipy/setup.py
     scipy/*/setup.py
     scipy/signal/_max_len_seq_inner.py
-disable_warnings = --include is ignored because --source is set (include-ignored)
+disable_warnings = include-ignored

--- a/.coveragerc
+++ b/.coveragerc
@@ -5,3 +5,4 @@ omit =
     scipy/setup.py
     scipy/*/setup.py
     scipy/signal/_max_len_seq_inner.py
+disable_warnings = --include is ignored because --source is set (include-ignored)


### PR DESCRIPTION
Fixes #14802

Mitigate `coverage_full_tests` failure.

Starting with `coverage` 6, the warning `--include is ignored because --source is set (include-ignored)` is making the CI fail.

This PR just catches the warning.

#14653 will improve the coverage setup further. xref #14801