### PR TITLE
MAINT: loosen mypy ignore in QMC

### DIFF
--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -526,7 +526,7 @@ def n_primes(n: IntNumber) -> List[int]:
     if len(primes) < n:
         big_number = 2000
         while 'Not enough primes':
-            primes = primes_from_2_to(big_number)[:n]  # type: ignore[misc]
+            primes = primes_from_2_to(big_number)[:n]  # type: ignore
             if len(primes) == n:
                 break
             big_number += 1000
@@ -1151,7 +1151,7 @@ class LatinHypercube(QMCEngine):
 
         oa_lhs_sample /= p
 
-        return oa_lhs_sample[:, :self.d]  # type: ignore[misc]
+        return oa_lhs_sample[:, :self.d]  # type: ignore
 
     def _random_cd(self, best_sample: np.ndarray) -> np.ndarray:
         """Optimal LHS on CD.


### PR DESCRIPTION
Nightly is failing on 

```
scipy/stats/_qmc.py:529: error: Incompatible types in assignment (expression has type "ndarray[Any, Any]", variable has type "List[int]")  [assignment]
30
scipy/stats/_qmc.py:1154: error: Invalid index type "Tuple[slice, slice]" for "ndarray[Any, dtype[floating[_64Bit]]]"; expected type "Union[SupportsIndex, _SupportsArray[dtype[Union[bool_, integer[Any]]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any]]]]], _NestedSequence[Union[bool, int]], Tuple[Union[SupportsIndex, _SupportsArray[dtype[Union[bool_, integer[Any]]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any]]]]], _NestedSequence[Union[bool, int]]], ...]]"  [index]
```

This PR loosen the ignore as we had trouble here in the past. Seems like the API is not stable on mypy/NumPy yet to really rely on that.

https://github.com/scipy/scipy/pull/14653/checks?check_run_id=3802509474