### PR TITLE
MAINT: Remove `np.rollaxis` usage with `np.moveaxis` and `.T`

### DIFF
--- a/scipy/integrate/_bvp.py
+++ b/scipy/integrate/_bvp.py
@@ -594,7 +594,7 @@ def create_spline(y, yp, x, h):
     c[1] = (slope - yp[:, :-1]) / h - t
     c[2] = yp[:, :-1]
     c[3] = y[:, :-1]
-    c = np.rollaxis(c, 1)
+    c = np.moveaxis(c, 1, 0)
 
     return PPoly(c, x, extrapolate=True, axis=1)
 

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -224,7 +224,7 @@ class BSpline:
             # and axis !=0 means that we have c.shape (..., n, ...)
             #                                               ^
             #                                              axis
-            self.c = np.rollaxis(self.c, axis)
+            self.c = np.moveaxis(self.c, axis, 0)
 
         if k < 0:
             raise ValueError("Spline order cannot be negative.")
@@ -1236,7 +1236,7 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
     x = _as_float_array(x, check_finite)
     y = _as_float_array(y, check_finite)
 
-    y = np.rollaxis(y, axis)    # now internally interp axis is zero
+    y = np.moveaxis(y, axis, 0)    # now internally interp axis is zero
 
     if bc_type == 'periodic' and not np.allclose(y[0], y[-1], atol=1e-15):
         raise ValueError("First and last points does not match while "
@@ -1475,7 +1475,7 @@ def make_lsq_spline(x, y, t, k=3, w=None, axis=0, check_finite=True):
 
     axis = normalize_axis_index(axis, y.ndim)
 
-    y = np.rollaxis(y, axis)    # now internally interp axis is zero
+    y = np.moveaxis(y, axis, 0)    # now internally interp axis is zero
 
     if x.ndim != 1 or np.any(x[1:] - x[:-1] <= 0):
         raise ValueError("Expect x to be a 1-D sorted array_like.")

--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -15,7 +15,7 @@ def prepare_input(x, y, axis, dydx=None):
     """Prepare input for cubic spline interpolators.
 
     All data are converted to numpy arrays and checked for correctness.
-    Axes equal to `axis` of arrays `y` and `dydx` are rolled to be the 0th
+    Axes equal to `axis` of arrays `y` and `dydx` are moved to be the 0th
     axis. The value of `axis` is converted to lie in
     [0, number of dimensions of `y`).
     """
@@ -60,9 +60,9 @@ def prepare_input(x, y, axis, dydx=None):
     if np.any(dx <= 0):
         raise ValueError("`x` must be strictly increasing sequence.")
 
-    y = np.rollaxis(y, axis)
+    y = np.moveaxis(y, axis, 0)
     if dydx is not None:
-        dydx = np.rollaxis(dydx, axis)
+        dydx = np.moveaxis(dydx, axis, 0)
 
     return x, dx, y, axis, dydx
 

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -755,14 +755,14 @@ class _PPolyBase:
 
         self.axis = axis
         if axis != 0:
-            # roll the interpolation axis to be the first one in self.c
+            # move the interpolation axis to be the first one in self.c
             # More specifically, the target shape for self.c is (k, m, ...),
             # and axis !=0 means that we have c.shape (..., k, m, ...)
             #                                               ^
             #                                              axis
             # So we roll two of them.
-            self.c = np.rollaxis(self.c, axis+1)
-            self.c = np.rollaxis(self.c, axis+1)
+            self.c = np.moveaxis(self.c, axis+1, 0)
+            self.c = np.moveaxis(self.c, axis+1, 0)
 
         if self.x.ndim != 1:
             raise ValueError("x must be 1-dimensional")

--- a/scipy/interpolate/polyint.py
+++ b/scipy/interpolate/polyint.py
@@ -102,7 +102,7 @@ class _Interpolator1D:
         return y
 
     def _reshape_yi(self, yi, check=False):
-        yi = np.rollaxis(np.asarray(yi), self._y_axis)
+        yi = np.moveaxis(np.asarray(yi), self._y_axis, 0)
         if check and yi.shape[1:] != self._y_extra_shape:
             ok_shape = "%r + (N,) + %r" % (self._y_extra_shape[-self._y_axis:],
                                            self._y_extra_shape[:-self._y_axis])

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -206,7 +206,7 @@ class TestKrogh:
         Pi = [KroghInterpolator(xs,ys[:,i]) for i in range(ys.shape[1])]
         test_xs = np.linspace(-1,3,100)
         assert_almost_equal(P(test_xs),
-                np.asarray([p(test_xs) for p in Pi]).T)
+                            np.asarray([p(test_xs) for p in Pi]).T)
         assert_almost_equal(P.derivatives(test_xs),
                 np.transpose(np.asarray([p.derivatives(test_xs) for p in Pi]),
                     (1,2,0)))
@@ -326,7 +326,7 @@ class TestBarycentric:
         Pi = [BI(xs, ys[:, i]) for i in range(ys.shape[1])]
         test_xs = np.linspace(-1, 3, 100)
         assert_almost_equal(P(test_xs),
-                np.asarray([p(test_xs) for p in Pi]).T)
+                            np.asarray([p(test_xs) for p in Pi]).T)
 
     def test_shapes_scalarvalue(self):
         P = BarycentricInterpolator(self.xs, self.ys)

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -206,7 +206,7 @@ class TestKrogh:
         Pi = [KroghInterpolator(xs,ys[:,i]) for i in range(ys.shape[1])]
         test_xs = np.linspace(-1,3,100)
         assert_almost_equal(P(test_xs),
-                np.rollaxis(np.asarray([p(test_xs) for p in Pi]),-1))
+                np.asarray([p(test_xs) for p in Pi]).T)
         assert_almost_equal(P.derivatives(test_xs),
                 np.transpose(np.asarray([p.derivatives(test_xs) for p in Pi]),
                     (1,2,0)))
@@ -326,7 +326,7 @@ class TestBarycentric:
         Pi = [BI(xs, ys[:, i]) for i in range(ys.shape[1])]
         test_xs = np.linspace(-1, 3, 100)
         assert_almost_equal(P(test_xs),
-                np.rollaxis(np.asarray([p(test_xs) for p in Pi]), -1))
+                np.asarray([p(test_xs) for p in Pi]).T)
 
     def test_shapes_scalarvalue(self):
         P = BarycentricInterpolator(self.xs, self.ys)

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -855,7 +855,7 @@ def solve_circulant(c, b, singular='raise', tol=None,
         raise ValueError('Shapes of c {} and b {} are incompatible'
                          .format(c.shape, b.shape))
 
-    fc = np.fft.fft(np.rollaxis(c, caxis, c.ndim), axis=-1)
+    fc = np.fft.fft(np.moveaxis(c, caxis, -1), axis=-1)
     abs_fc = np.abs(fc)
     if tol is None:
         # This is the same tolerance as used in np.linalg.matrix_rank.
@@ -875,7 +875,7 @@ def solve_circulant(c, b, singular='raise', tol=None,
             # division fb/fc below.
             fc[near_zeros] = 1
 
-    fb = np.fft.fft(np.rollaxis(b, baxis, b.ndim), axis=-1)
+    fb = np.fft.fft(np.moveaxis(b, baxis, -1), axis=-1)
 
     q = fb / fc
 
@@ -892,7 +892,7 @@ def solve_circulant(c, b, singular='raise', tol=None,
     if not (np.iscomplexobj(c) or np.iscomplexobj(b)):
         x = x.real
     if outaxis != -1:
-        x = np.rollaxis(x, -1, outaxis)
+        x = np.moveaxis(x, -1, outaxis)
     return x
 
 

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -1625,7 +1625,7 @@ class TestSolveCirculant:
 
         x = solve_circulant(c, b, baxis=1, outaxis=-1)
         assert_equal(x.shape, (2, 3, 4))
-        assert_allclose(np.rollaxis(x, -1), expected)
+        assert_allclose(np.moveaxis(x, -1, 0), expected)
 
         # np.swapaxes(c, 1, 2) has shape (2, 4, 1); b.T has shape (4, 3).
         x = solve_circulant(np.swapaxes(c, 1, 2), b.T, caxis=1)

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -463,8 +463,8 @@ def freqz(b, a=1, worN=512, whole=False, plot=None, fs=2*pi, include_nyquist=Fal
             if b.ndim > 1:
                 # Last axis of h has length 1, so drop it.
                 h = h[..., 0]
-                # Rotate the first axis of h to the end.
-                h = np.rollaxis(h, 0, h.ndim)
+                # Move the first axis of h to the end.
+                h = np.moveaxis(h, 0, -1)
     else:
         w = atleast_1d(worN)
         del worN

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -1451,7 +1451,7 @@ def istft(Zxx, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
         if time_axis != Zxx.ndim-1:
             if freq_axis < time_axis:
                 time_axis -= 1
-            x = np.rollaxis(x, -1, time_axis)
+            x = np.moveaxis(x, -1, time_axis)
 
     time = np.arange(x.shape[0])/float(fs)
     return time, x
@@ -1714,14 +1714,14 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
     else:
         if x.size == 0 or y.size == 0:
             outshape = outershape + (min([x.shape[axis], y.shape[axis]]),)
-            emptyout = np.rollaxis(np.empty(outshape), -1, axis)
+            emptyout = np.moveaxis(np.empty(outshape), -1, axis)
             return emptyout, emptyout, emptyout
 
     if x.ndim > 1:
         if axis != -1:
-            x = np.rollaxis(x, axis, len(x.shape))
+            x = np.moveaxis(x, axis, -1)
             if not same_data and y.ndim > 1:
-                y = np.rollaxis(y, axis, len(y.shape))
+                y = np.moveaxis(y, axis, -1)
 
     # Check if x and y are the same length, zero-pad if necessary
     if not same_data:
@@ -1791,9 +1791,9 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
         # Wrap this function so that it receives a shape that it could
         # reasonably expect to receive.
         def detrend_func(d):
-            d = np.rollaxis(d, -1, axis)
+            d = np.moveaxis(d, -1, axis)
             d = detrend(d)
-            return np.rollaxis(d, axis, len(d.shape))
+            return np.moveaxis(d, axis, -1)
     else:
         detrend_func = detrend
 
@@ -1866,7 +1866,7 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
         axis -= 1
 
     # Roll frequency axis back to axis where the data came from
-    result = np.rollaxis(result, -1, axis)
+    result = np.moveaxis(result, -1, axis)
 
     return freqs, time, result
 

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -748,9 +748,9 @@ class TestFFTConvolve:
         b = b[:, :, None, None, None]
         expected = expected[:, :, None, None, None]
 
-        a = np.rollaxis(a.swapaxes(0, 2), 1, 5)
-        b = np.rollaxis(b.swapaxes(0, 2), 1, 5)
-        expected = np.rollaxis(expected.swapaxes(0, 2), 1, 5)
+        a = np.moveaxis(a.swapaxes(0, 2), 1, 4)
+        b = np.moveaxis(b.swapaxes(0, 2), 1, 4)
+        expected = np.moveaxis(expected.swapaxes(0, 2), 1, 4)
 
         # use 1 for dimension 2 in a and 3 in b to test broadcasting
         a = np.tile(a, [2, 1, 3, 1, 1])

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -329,7 +329,7 @@ class TestWelch:
     def test_detrend_external_nd_0(self):
         x = np.arange(20, dtype=np.float64) + 0.04
         x = x.reshape((2,1,10))
-        x = np.rollaxis(x, 2, 0)
+        x = np.moveaxis(x, 2, 0)
         f, p = welch(x, nperseg=10, axis=0,
                      detrend=lambda seg: signal.detrend(seg, axis=0, type='l'))
         assert_allclose(p, np.zeros_like(p), atol=1e-15)
@@ -669,7 +669,7 @@ class TestCSD:
     def test_detrend_external_nd_0(self):
         x = np.arange(20, dtype=np.float64) + 0.04
         x = x.reshape((2,1,10))
-        x = np.rollaxis(x, 2, 0)
+        x = np.moveaxis(x, 2, 0)
         f, p = csd(x, x, nperseg=10, axis=0,
                    detrend=lambda seg: signal.detrend(seg, axis=0, type='l'))
         assert_allclose(p, np.zeros_like(p), atol=1e-15)

--- a/scipy/spatial/transform/rotation.pyx
+++ b/scipy/spatial/transform/rotation.pyx
@@ -2020,7 +2020,7 @@ cdef class Rotation:
                     np.einsum('ix,j,kx', lv, ps, rv) -
                     np.einsum('ix,jx,k', lv, pv, rs) -
                     np.einsum('xyz,ix,jy,kz', e, lv, pv, rv))
-        qs = np.reshape(np.rollaxis(qs, 1), (qs.shape[1], -1))
+        qs = np.reshape(np.moveaxis(qs, 1, 0), (qs.shape[1], -1))
 
         # Find best indices from scalar components
         max_ind = np.argmax(np.reshape(qs, (len(qs), -1)), axis=1)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -847,7 +847,7 @@ def test_reduction_scalar_calculation():
         for j, pj in enumerate(p):
             for k, rk in enumerate(r):
                 scalars[i, j, k] = np.abs((li * pj * rk).as_quat()[3])
-    scalars = np.reshape(np.rollaxis(scalars, 1), (scalars.shape[1], -1))
+    scalars = np.reshape(np.moveaxis(scalars, 1, 0), (scalars.shape[1], -1))
 
     max_ind = np.argmax(np.reshape(scalars, (len(p), -1)), axis=1)
     left_best_check = max_ind // len(r)

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -1039,7 +1039,7 @@ class matrix_normal_gen(multi_rv_generic):
 
         """
         numrows, numcols = dims
-        roll_dev = np.rollaxis(X-mean, axis=-1, start=0)
+        roll_dev = np.moveaxis(X-mean, -1, 0)
         scale_dev = np.tensordot(col_prec_rt.T,
                                  np.dot(roll_dev, row_prec_rt), 1)
         maha = np.sum(np.sum(np.square(scale_dev), axis=-1), axis=0)
@@ -1124,7 +1124,7 @@ class matrix_normal_gen(multi_rv_generic):
         random_state = self._get_random_state(random_state)
         std_norm = random_state.standard_normal(size=(dims[1], size, dims[0]))
         roll_rvs = np.tensordot(colchol, np.dot(std_norm, rowchol.T), 1)
-        out = np.rollaxis(roll_rvs.T, axis=1, start=0) + mean[np.newaxis, :, :]
+        out = np.moveaxis(roll_rvs.T, 1, 0) + mean[np.newaxis, :, :]
         if size == 1:
             out = out.reshape(mean.shape)
         return out

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -2949,7 +2949,7 @@ def mood(x, y, axis=0, alternative="two-sided"):
 
     xy = np.concatenate((x, y), axis=axis)
     if axis != 0:
-        xy = np.rollaxis(xy, axis)
+        xy = np.moveaxis(xy, axis, 0)
 
     xy = xy.reshape(xy.shape[0], -1)
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4808,9 +4808,9 @@ def test_ttest_ind_with_uneq_var():
     assert_array_almost_equal(np.abs(p), pr)
     assert_equal(t.shape, (2, 3))
 
-    t,p = stats.ttest_ind(np.moveaxis(rvs1_3D, 2, 0),
-                                      np.moveaxis(rvs2_3D, 2, 0),
-                                      axis=2, equal_var=False)
+    t, p = stats.ttest_ind(np.moveaxis(rvs1_3D, 2, 0),
+                           np.moveaxis(rvs2_3D, 2, 0),
+                           axis=2, equal_var=False)
     assert_array_almost_equal(np.abs(t), np.abs(tr))
     assert_array_almost_equal(np.abs(p), pr)
     assert_equal(t.shape, (3, 2))

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2670,7 +2670,7 @@ class TestIQR:
         q = stats.iqr(o)
 
         assert_equal(stats.iqr(x, axis=(0, 1)), q)
-        x = np.rollaxis(x, -1, 0)               # x.shape = (10, 71, 23)
+        x = np.moveaxis(x, -1, 0)               # x.shape = (10, 71, 23)
         assert_equal(stats.iqr(x, axis=(2, 1)), q)
         x = x.swapaxes(0, 1)                    # x.shape = (71, 10, 23)
         assert_equal(stats.iqr(x, axis=(0, 2)), q)
@@ -3997,7 +3997,8 @@ def test_ttest_rel():
     assert_array_almost_equal(np.abs(p), pr)
     assert_equal(t.shape, (2, 3))
 
-    t, p = stats.ttest_rel(np.rollaxis(rvs1_3D, 2), np.rollaxis(rvs2_3D, 2),
+    t, p = stats.ttest_rel(np.moveaxis(rvs1_3D, 2, 0),
+                           np.moveaxis(rvs2_3D, 2, 0),
                            axis=2)
     assert_array_almost_equal(np.abs(t), tr)
     assert_array_almost_equal(np.abs(p), pr)
@@ -4179,7 +4180,8 @@ def test_ttest_ind():
     assert_array_almost_equal(np.abs(p), pr)
     assert_equal(t.shape, (2, 3))
 
-    t, p = stats.ttest_ind(np.rollaxis(rvs1_3D, 2), np.rollaxis(rvs2_3D, 2),
+    t, p = stats.ttest_ind(np.moveaxis(rvs1_3D, 2, 0),
+                           np.moveaxis(rvs2_3D, 2, 0),
                            axis=2)
     assert_array_almost_equal(np.abs(t), np.abs(tr))
     assert_array_almost_equal(np.abs(p), pr)
@@ -4806,13 +4808,14 @@ def test_ttest_ind_with_uneq_var():
     assert_array_almost_equal(np.abs(p), pr)
     assert_equal(t.shape, (2, 3))
 
-    t,p = stats.ttest_ind(np.rollaxis(rvs1_3D,2), np.rollaxis(rvs2_3D,2),
-                                   axis=2, equal_var=False)
+    t,p = stats.ttest_ind(np.moveaxis(rvs1_3D, 2, 0),
+                                      np.moveaxis(rvs2_3D, 2, 0),
+                                      axis=2, equal_var=False)
     assert_array_almost_equal(np.abs(t), np.abs(tr))
     assert_array_almost_equal(np.abs(p), pr)
     assert_equal(t.shape, (3, 2))
-    args = _desc_stats(np.rollaxis(rvs1_3D, 2),
-                       np.rollaxis(rvs2_3D, 2), axis=2)
+    args = _desc_stats(np.moveaxis(rvs1_3D, 2, 0),
+                       np.moveaxis(rvs2_3D, 2, 0), axis=2)
     t, p = stats.ttest_ind_from_stats(*args, equal_var=False)
     assert_array_almost_equal(np.abs(t), np.abs(tr))
     assert_array_almost_equal(np.abs(p), pr)
@@ -5966,7 +5969,7 @@ class TestTrim:
         a = np.random.randint(20, size=(5, 6, 4, 7))
         for axis in [0, 1, 2, 3, -1]:
             res1 = stats.trim_mean(a, 2/6., axis=axis)
-            res2 = stats.trim_mean(np.rollaxis(a, axis), 2/6.)
+            res2 = stats.trim_mean(np.moveaxis(a, axis, 0), 2/6.)
             assert_equal(res1, res2)
 
         res1 = stats.trim_mean(a, 2/6., axis=None)


### PR DESCRIPTION
#### Reference issue
Closes gh-14491

#### What does this implement/fix?
Refactor all the `np.rollaxis` instances in the codebase.
Also see [np.rollaxis documentation](https://numpy.org/doc/stable/reference/generated/numpy.rollaxis.html).

#### Additional information
Discussion about `np.moveaxis` not as performant as `np.rollaxis` is probably something practically negligible in the changes made here. These functions include operations that take at least an order of magnitude more in total to run making the performance effect of changing to `moveaxis` from `rollaxis` pointless.