### PR TITLE
DOC: Updated documentation for interp1d

### DIFF
--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -385,7 +385,8 @@ class interp1d(_Interpolator1D):
           ``x_new > x[-1]``. Anything that is not a 2-element tuple (e.g.,
           list or ndarray, regardless of shape) is taken to be a single
           array-like argument meant to be used for both bounds as
-          ``below, above = fill_value, fill_value``.
+          ``below, above = fill_value, fill_value``. Using a two-element tuple
+          or ndarray requires ``bounds_error=False``.
 
           .. versionadded:: 0.17.0
         - If "extrapolate", then points outside the data range will be


### PR DESCRIPTION
Included a line in the docstring for interp1d to make it clearer that in order to use any `fill_value` other than 'extrapolate' you must set `bounds_error=False`.

It is already mentioned under bounds_error, but it seems plenty of us missed this when reading the documentation, so I tried to make it clearer.

This was discussed in [gh-12707](https://github.com/scipy/scipy/issues/12707), but the issue was closed before a change was made. I think it is worth updating the documentation still.

