### PR TITLE
Add an array API to scipy.sparse

### DIFF
--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -16,6 +16,14 @@ Sparse matrix classes
 .. autosummary::
    :toctree: generated/
 
+   bsr_array - Block Sparse Row array
+   coo_array - A sparse array in COOrdinate format
+   csc_array - Compressed Sparse Column array
+   csr_array - Compressed Sparse Row array
+   dia_array - Sparse array with DIAgonal storage
+   dok_array - Dictionary Of Keys based sparse array
+   lil_array - Row-based list of lists sparse array
+
    bsr_matrix - Block Sparse Row matrix
    coo_matrix - A sparse matrix in COOrdinate format
    csc_matrix - Compressed Sparse Column matrix

--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -5,13 +5,38 @@ Sparse matrices (:mod:`scipy.sparse`)
 
 .. currentmodule:: scipy.sparse
 
-SciPy 2-D sparse matrix package for numeric data.
+SciPy 2-D sparse array package for numeric data.
+
+.. note::
+
+   This package is switching to an array interface, compatible with
+   NumPy arrays, from the older matrix interface.  We recommend that
+   you use the array objects (`bsr_array`, `coo_array`, etc.) for
+   all new work.
+
+   When using the array interface, please note that:
+
+   - ``x * y`` no longer performs matrix multiplication, but
+     element-wise multiplication (just like with NumPy arrays).  To
+     make code work with both arrays and matrices, use ``x @ y`` for
+     matrix multiplication.
+   - Operations such as `sum`, that used to produce dense matrices, now
+     produce arrays, whose multiplication behavior differs similarly.
+   - Sparse arrays currently must be two-dimensional.  This also means
+     that all *slicing* operations on these objects must produce
+     two-dimensional results, or they will result in an error. This
+     will be addressed in a future version.
+
+   The construction utilities (`eye`, `kron`, `random`, `diags`, etc.)
+   have not yet been ported, but their results can be wrapped into arrays::
+
+     A = csr_array(eye(3))
 
 Contents
 ========
 
-Sparse matrix classes
----------------------
+Sparse array classes
+--------------------
 
 .. autosummary::
    :toctree: generated/
@@ -23,6 +48,12 @@ Sparse matrix classes
    dia_array - Sparse array with DIAgonal storage
    dok_array - Dictionary Of Keys based sparse array
    lil_array - Row-based list of lists sparse array
+
+Sparse matrix classes
+---------------------
+
+.. autosummary::
+   :toctree: generated/
 
    bsr_matrix - Block Sparse Row matrix
    coo_matrix - A sparse matrix in COOrdinate format

--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -236,6 +236,10 @@ from ._construct import *
 from ._extract import *
 from ._matrix_io import *
 
+from ._arrays import (
+    csr_array, csc_array, lil_array, dok_array, coo_array, dia_array, bsr_array
+)
+
 # For backward compatibility with v0.19.
 from . import csgraph
 

--- a/scipy/sparse/_arrays.py
+++ b/scipy/sparse/_arrays.py
@@ -48,6 +48,9 @@ class _sparray:
 
 
 def _matrix_doc_to_array(docstr):
+    # For opimized builds with stripped docstrings
+    if docstr is None:
+        return None
     return docstr.replace('matrix', 'array').replace('matrices', 'arrays')
 
 

--- a/scipy/sparse/_arrays.py
+++ b/scipy/sparse/_arrays.py
@@ -1,0 +1,75 @@
+from functools import wraps
+
+from ._bsr import bsr_matrix
+from ._coo import coo_matrix
+from ._csc import csc_matrix
+from ._csr import csr_matrix
+from ._dia import dia_matrix
+from ._dok import dok_matrix
+from ._lil import lil_matrix
+
+from . import sputils
+
+
+class sparray:
+    _is_array = True
+
+    @property
+    def _bsr_container(self):
+        return bsr_array
+
+    @property
+    def _coo_container(self):
+        return coo_array
+
+    @property
+    def _csc_container(self):
+        return csc_array
+
+    @property
+    def _csr_container(self):
+        return csr_array
+
+    @property
+    def _dia_container(self):
+        return dia_array
+
+    @property
+    def _dok_container(self):
+        return dok_array
+
+    @property
+    def _lil_container(self):
+        return lil_array
+
+    # Restore elementwise multiplication
+    def __mul__(self, *args, **kwargs):
+        return self.multiply(*args, **kwargs)
+
+
+class bsr_array(sparray, bsr_matrix):
+    pass
+
+
+class coo_array(sparray, coo_matrix):
+    pass
+
+
+class csc_array(sparray, csc_matrix):
+    pass
+
+
+class csr_array(sparray, csr_matrix):
+    pass
+
+
+class dia_array(sparray, dia_matrix):
+    pass
+
+
+class dok_array(sparray, dok_matrix):
+    pass
+
+
+class lil_array(sparray, lil_matrix):
+    pass

--- a/scipy/sparse/_arrays.py
+++ b/scipy/sparse/_arrays.py
@@ -7,7 +7,11 @@ from ._dok import dok_matrix
 from ._lil import lil_matrix
 
 
-class sparray:
+class _sparray:
+    """This class provides a base class for all sparse arrays.
+
+    It cannot be instantiated.  Most of the work is provided by subclasses.
+    """
     _is_array = True
 
     @property
@@ -43,29 +47,40 @@ class sparray:
         return self.multiply(*args, **kwargs)
 
 
-class bsr_array(sparray, bsr_matrix):
+def _matrix_doc_to_array(docstr):
+    return docstr.replace('matrix', 'array').replace('matrices', 'arrays')
+
+
+class bsr_array(_sparray, bsr_matrix):
     pass
+bsr_array.__doc__ = _matrix_doc_to_array(bsr_matrix.__doc__)
 
 
-class coo_array(sparray, coo_matrix):
+class coo_array(_sparray, coo_matrix):
     pass
+coo_array.__doc__ = _matrix_doc_to_array(coo_matrix.__doc__)
 
 
-class csc_array(sparray, csc_matrix):
+class csc_array(_sparray, csc_matrix):
     pass
+csc_array.__doc__ = _matrix_doc_to_array(csc_matrix.__doc__)
 
 
-class csr_array(sparray, csr_matrix):
+class csr_array(_sparray, csr_matrix):
     pass
+csr_array.__doc__ = _matrix_doc_to_array(csr_matrix.__doc__)
 
 
-class dia_array(sparray, dia_matrix):
+class dia_array(_sparray, dia_matrix):
     pass
+dia_array.__doc__ = _matrix_doc_to_array(dia_matrix.__doc__)
 
 
-class dok_array(sparray, dok_matrix):
+class dok_array(_sparray, dok_matrix):
     pass
+dok_array.__doc__ = _matrix_doc_to_array(dok_matrix.__doc__)
 
 
-class lil_array(sparray, lil_matrix):
+class lil_array(_sparray, lil_matrix):
     pass
+lil_array.__doc__ = _matrix_doc_to_array(lil_matrix.__doc__)

--- a/scipy/sparse/_arrays.py
+++ b/scipy/sparse/_arrays.py
@@ -1,5 +1,3 @@
-from functools import wraps
-
 from ._bsr import bsr_matrix
 from ._coo import coo_matrix
 from ._csc import csc_matrix
@@ -7,8 +5,6 @@ from ._csr import csr_matrix
 from ._dia import dia_matrix
 from ._dok import dok_matrix
 from ._lil import lil_matrix
-
-from . import sputils
 
 
 class sparray:

--- a/scipy/sparse/_arrays.py
+++ b/scipy/sparse/_arrays.py
@@ -53,34 +53,36 @@ def _matrix_doc_to_array(docstr):
 
 class bsr_array(_sparray, bsr_matrix):
     pass
-bsr_array.__doc__ = _matrix_doc_to_array(bsr_matrix.__doc__)
 
 
 class coo_array(_sparray, coo_matrix):
     pass
-coo_array.__doc__ = _matrix_doc_to_array(coo_matrix.__doc__)
 
 
 class csc_array(_sparray, csc_matrix):
     pass
-csc_array.__doc__ = _matrix_doc_to_array(csc_matrix.__doc__)
 
 
 class csr_array(_sparray, csr_matrix):
     pass
-csr_array.__doc__ = _matrix_doc_to_array(csr_matrix.__doc__)
 
 
 class dia_array(_sparray, dia_matrix):
     pass
-dia_array.__doc__ = _matrix_doc_to_array(dia_matrix.__doc__)
 
 
 class dok_array(_sparray, dok_matrix):
     pass
-dok_array.__doc__ = _matrix_doc_to_array(dok_matrix.__doc__)
 
 
 class lil_array(_sparray, lil_matrix):
     pass
+
+
+bsr_array.__doc__ = _matrix_doc_to_array(bsr_matrix.__doc__)
+coo_array.__doc__ = _matrix_doc_to_array(coo_matrix.__doc__)
+csc_array.__doc__ = _matrix_doc_to_array(csc_matrix.__doc__)
+csr_array.__doc__ = _matrix_doc_to_array(csr_matrix.__doc__)
+dia_array.__doc__ = _matrix_doc_to_array(dia_matrix.__doc__)
+dok_array.__doc__ = _matrix_doc_to_array(dok_matrix.__doc__)
 lil_array.__doc__ = _matrix_doc_to_array(lil_matrix.__doc__)

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -595,7 +595,7 @@ class spmatrix:
     def _mul_sparse_matrix(self, other):
         return self.tocsr()._mul_sparse_matrix(other)
 
-    def _rmul_dispatcher(self, other):
+    def _rmul_dispatch(self, other):
         if isscalarlike(other):
             return self._mul_dispatch(other)
         else:
@@ -607,7 +607,7 @@ class spmatrix:
             return (self.transpose() @ tr).transpose()
 
     def __rmul__(self, other):  # other * self
-        return self._rmul_dispatcher(other)
+        return self._rmul_dispatch(other)
 
     #######################
     # matmul (@) operator #
@@ -623,7 +623,7 @@ class spmatrix:
         if isscalarlike(other):
             raise ValueError("Scalar operands are not allowed, "
                              "use '*' instead")
-        return self._rmul_dispatcher(other)
+        return self._rmul_dispatch(other)
 
     ####################
     # Other Arithmetic #

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -1101,7 +1101,7 @@ class spmatrix:
         if out is not None and out.shape != ret.shape:
             raise ValueError("dimensions do not match")
 
-        return ret.sum(axis=(), dtype=dtype, out=out)
+        return ret.sum(axis=(axis), dtype=dtype, out=out)
 
     def mean(self, axis=None, dtype=None, out=None):
         """

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -1,9 +1,11 @@
 """Base class for sparse matrices"""
+from warnings import warn
+
 import numpy as np
 
-from ._sputils import (isdense, isscalarlike, isintlike,
-                       get_sum_dtype, validateaxis, check_reshape_kwargs,
-                       check_shape, asmatrix)
+from ._sputils import (asmatrix, check_reshape_kwargs, check_shape,
+                       get_sum_dtype, isdense, isintlike, isscalarlike,
+                       matrix, validateaxis)
 
 __all__ = ['spmatrix', 'isspmatrix', 'issparse',
            'SparseWarning', 'SparseEfficiencyWarning']
@@ -62,6 +64,43 @@ class spmatrix:
 
     __array_priority__ = 10.1
     ndim = 2
+
+    @property
+    def _bsr_container(self):
+        from ._bsr import bsr_matrix
+        return bsr_matrix
+
+    @property
+    def _coo_container(self):
+        from ._coo import coo_matrix
+        return coo_matrix
+
+    @property
+    def _csc_container(self):
+        from ._csc import csc_matrix
+        return csc_matrix
+
+    @property
+    def _csr_container(self):
+        from ._csr import csr_matrix
+        return csr_matrix
+
+    @property
+    def _dia_container(self):
+        from ._dia import dia_matrix
+        return dia_matrix
+
+    @property
+    def _dok_container(self):
+        from ._dok import dok_matrix
+        return dok_matrix
+
+    @property
+    def _lil_container(self):
+        from ._lil import lil_matrix
+        return lil_matrix
+
+    _is_array = False
 
     def __init__(self, maxprint=MAXPRINT):
         self._shape = None
@@ -184,6 +223,20 @@ class spmatrix:
         else:
             return self
 
+    @classmethod
+    def _ascontainer(cls, X, **kwargs):
+        if cls._is_array:
+            return np.asarray(X, **kwargs)
+        else:
+            return asmatrix(X, **kwargs)
+
+    @classmethod
+    def _container(cls, X, **kwargs):
+        if cls._is_array:
+            return np.array(X, **kwargs)
+        else:
+            return matrix(X, **kwargs)
+
     def asfptype(self):
         """Upcast matrix to a floating point format (if necessary)"""
 
@@ -251,7 +304,8 @@ class spmatrix:
 
     def __repr__(self):
         _, format_name = _formats[self.getformat()]
-        return "<%dx%d sparse matrix of type '%s'\n" \
+        sparse_cls = 'array' if self._is_array else 'matrix'
+        return f"<%dx%d sparse {sparse_cls} of type '%s'\n" \
                "\twith %d stored elements in %s format>" % \
                (self.shape + (self.dtype.type, self.nnz, format_name))
 
@@ -356,7 +410,7 @@ class spmatrix:
         array([ 1, -3, -1], dtype=int64)
 
         """
-        return self * other
+        return self @ other
 
     def power(self, n, dtype=None):
         """Element-wise power."""
@@ -450,7 +504,7 @@ class spmatrix:
         else:
             return NotImplemented
 
-    def __mul__(self, other):
+    def _mul_dispatch(self, other):
         """interpret other and call one of the following
 
         self._mul_scalar()
@@ -500,7 +554,7 @@ class spmatrix:
             result = self._mul_vector(np.ravel(other))
 
             if isinstance(other, np.matrix):
-                result = asmatrix(result)
+                result = self._ascontainer(result)
 
             if other.ndim == 2 and other.shape[1] == 1:
                 # If 'other' was an (nx1) column vector, reshape the result
@@ -518,12 +572,15 @@ class spmatrix:
             result = self._mul_multivector(np.asarray(other))
 
             if isinstance(other, np.matrix):
-                result = asmatrix(result)
+                result = self._ascontainer(result)
 
             return result
 
         else:
             raise ValueError('could not interpret dimensions')
+
+    def __mul__(self, other):
+        return self._mul_dispatch(other)
 
     # by default, use CSR for __mul__ handlers
     def _mul_scalar(self, other):
@@ -538,16 +595,19 @@ class spmatrix:
     def _mul_sparse_matrix(self, other):
         return self.tocsr()._mul_sparse_matrix(other)
 
-    def __rmul__(self, other):  # other * self
+    def _rmul_dispatcher(self, other):
         if isscalarlike(other):
-            return self.__mul__(other)
+            return self._mul_dispatch(other)
         else:
             # Don't use asarray unless we have to
             try:
                 tr = other.transpose()
             except AttributeError:
                 tr = np.asarray(other).transpose()
-            return (self.transpose() * tr).transpose()
+            return (self.transpose() @ tr).transpose()
+
+    def __rmul__(self, other):  # other * self
+        return self._rmul_dispatcher(other)
 
     #######################
     # matmul (@) operator #
@@ -557,13 +617,13 @@ class spmatrix:
         if isscalarlike(other):
             raise ValueError("Scalar operands are not allowed, "
                              "use '*' instead")
-        return self.__mul__(other)
+        return self._mul_dispatch(other)
 
     def __rmatmul__(self, other):
         if isscalarlike(other):
             raise ValueError("Scalar operands are not allowed, "
                              "use '*' instead")
-        return self.__rmul__(other)
+        return self._rmul_dispatcher(other)
 
     ####################
     # Other Arithmetic #
@@ -656,15 +716,15 @@ class spmatrix:
 
             if other == 0:
                 from ._construct import eye
-                return eye(self.shape[0], dtype=self.dtype)
+                return eye(self.shape[0], dtype=self.dtype, _array=self._is_array)
             elif other == 1:
                 return self.copy()
             else:
                 tmp = self.__pow__(other//2)
                 if (other % 2):
-                    return self * tmp * tmp
+                    return self @ tmp @ tmp
                 else:
-                    return tmp * tmp
+                    return tmp @ tmp
         elif isscalarlike(other):
             raise ValueError('exponent must be an integer')
         else:
@@ -672,10 +732,14 @@ class spmatrix:
 
     def __getattr__(self, attr):
         if attr == 'A':
+            if self._is_array:
+                warn(np.VisibleDeprecationWarning("Please use `.todense()` instead"))
             return self.toarray()
         elif attr == 'T':
             return self.transpose()
         elif attr == 'H':
+            if self._is_array:
+                warn(np.VisibleDeprecationWarning("Please use `.conj().T` instead"))
             return self.getH()
         elif attr == 'real':
             return self._real()
@@ -790,9 +854,9 @@ class spmatrix:
             j += n
         if j < 0 or j >= n:
             raise IndexError("index out of bounds")
-        col_selector = csc_matrix(([1], [[j], [0]]),
-                                  shape=(n, 1), dtype=self.dtype)
-        return self * col_selector
+        col_selector = self._csc_container(([1], [[j], [0]]),
+                                           shape=(n, 1), dtype=self.dtype)
+        return self @ col_selector
 
     def getrow(self, i):
         """Returns a copy of row i of the matrix, as a (1 x n) sparse
@@ -807,9 +871,9 @@ class spmatrix:
             i += m
         if i < 0 or i >= m:
             raise IndexError("index out of bounds")
-        row_selector = csr_matrix(([1], [[0], [i]]),
-                                  shape=(1, m), dtype=self.dtype)
-        return row_selector * self
+        row_selector = self._csr_container(([1], [[0], [i]]),
+                                           shape=(1, m), dtype=self.dtype)
+        return row_selector @ self
 
     # The following dunder methods cannot be implemented.
     #
@@ -861,7 +925,7 @@ class spmatrix:
             with the appropriate values and returned wrapped in a
             `numpy.matrix` object that shares the same memory.
         """
-        return asmatrix(self.toarray(order=order, out=out))
+        return self._ascontainer(self.toarray(order=order, out=out))
 
     def toarray(self, order=None, out=None):
         """
@@ -1015,9 +1079,9 @@ class spmatrix:
 
         if axis is None:
             # sum over rows and columns
-            return (self * asmatrix(np.ones(
-                (n, 1), dtype=res_dtype))).sum(
-                dtype=dtype, out=out)
+            return (
+                self @ self._ascontainer(np.ones((n, 1), dtype=res_dtype))
+            ).sum(dtype=dtype, out=out)
 
         if axis < 0:
             axis += 2
@@ -1025,12 +1089,14 @@ class spmatrix:
         # axis = 0 or 1 now
         if axis == 0:
             # sum over columns
-            ret = asmatrix(np.ones(
-                (1, m), dtype=res_dtype)) * self
+            ret = self._ascontainer(
+                np.ones((1, m), dtype=res_dtype)
+            ) @ self
         else:
             # sum over rows
-            ret = self * asmatrix(
-                np.ones((n, 1), dtype=res_dtype))
+            ret = self @ self._ascontainer(
+                np.ones((n, 1), dtype=res_dtype)
+            )
 
         if out is not None and out.shape != ret.shape:
             raise ValueError("dimensions do not match")

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -858,7 +858,6 @@ class spmatrix:
         # Spmatrix subclasses should override this method for efficiency.
         # Post-multiply by a (n x 1) column vector 'a' containing all zeros
         # except for a_j = 1
-        from ._csc import csc_matrix
         n = self.shape[1]
         if j < 0:
             j += n
@@ -875,7 +874,6 @@ class spmatrix:
         # Spmatrix subclasses should override this method for efficiency.
         # Pre-multiply by a (1 x m) row vector 'a' containing all zeros
         # except for a_i = 1
-        from ._csr import csr_matrix
         m = self.shape[0]
         if i < 0:
             i += m

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -717,13 +717,12 @@ class spmatrix:
 
             if other == 0:
                 from ._construct import eye
-                E = np.ones(self.shape[0])
+                E = eye(M)
                 if self._is_array:
                     from ._arrays import dia_array
-                    return dia_array((E, 0), shape=(M, M))
-                else:
-                    from ._dia import dia_matrix
-                    return dia_matrix((E, 0), shape=(M, M))
+                    E = dia_array(E)
+                return E
+
             elif other == 1:
                 return self.copy()
             else:

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -1112,7 +1112,7 @@ class spmatrix:
         if out is not None and out.shape != ret.shape:
             raise ValueError("dimensions do not match")
 
-        return ret.sum(axis=(axis), dtype=dtype, out=out)
+        return ret.sum(axis=axis, dtype=dtype, out=out)
 
     def mean(self, axis=None, dtype=None, out=None):
         """

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -706,7 +706,8 @@ class spmatrix:
         return NotImplemented
 
     def __pow__(self, other):
-        if self.shape[0] != self.shape[1]:
+        M, N = self.shape[0], self.shape[1]
+        if M != N:
             raise TypeError('matrix is not square')
 
         if isintlike(other):
@@ -716,9 +717,13 @@ class spmatrix:
 
             if other == 0:
                 from ._construct import eye
-                return eye(
-                    self.shape[0], dtype=self.dtype, _array=self._is_array
-                )
+                E = np.ones(self.shape[0])
+                if self._is_array:
+                    from ._arrays import dia_array
+                    return dia_array((E, 0), shape=(M, M))
+                else:
+                    from ._dia import dia_matrix
+                    return dia_matrix((E, 0), shape=(M, M))
             elif other == 1:
                 return self.copy()
             else:

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -716,7 +716,9 @@ class spmatrix:
 
             if other == 0:
                 from ._construct import eye
-                return eye(self.shape[0], dtype=self.dtype, _array=self._is_array)
+                return eye(
+                    self.shape[0], dtype=self.dtype, _array=self._is_array
+                )
             elif other == 1:
                 return self.copy()
             else:
@@ -733,13 +735,17 @@ class spmatrix:
     def __getattr__(self, attr):
         if attr == 'A':
             if self._is_array:
-                warn(np.VisibleDeprecationWarning("Please use `.todense()` instead"))
+                warn(np.VisibleDeprecationWarning(
+                    "Please use `.todense()` instead"
+                ))
             return self.toarray()
         elif attr == 'T':
             return self.transpose()
         elif attr == 'H':
             if self._is_array:
-                warn(np.VisibleDeprecationWarning("Please use `.conj().T` instead"))
+                warn(np.VisibleDeprecationWarning(
+                    "Please use `.conj().T` instead"
+                ))
             return self.getH()
         elif attr == 'real':
             return self._real()

--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -155,7 +155,7 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
                 # (data,(row,col)) format
                 from ._coo import coo_matrix
                 self._set_self(
-                    coo_matrix(arg1, dtype=dtype, shape=shape).tobsr(
+                    self._coo_container(arg1, dtype=dtype, shape=shape).tobsr(
                         blocksize=blocksize
                     )
                 )
@@ -196,7 +196,9 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
                 raise ValueError("unrecognized form for"
                         " %s_matrix constructor" % self.format) from e
             from ._coo import coo_matrix
-            arg1 = coo_matrix(arg1, dtype=dtype).tobsr(blocksize=blocksize)
+            arg1 = self._coo_container(
+                arg1, dtype=dtype
+            ).tobsr(blocksize=blocksize)
             self._set_self(arg1)
 
         if shape is not None:
@@ -425,7 +427,9 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
 
         # TODO eliminate zeros
 
-        return bsr_matrix((data,indices,indptr),shape=(M,N),blocksize=(R,C))
+        return self._bsr_container(
+            (data,indices,indptr), shape=(M,N), blocksize=(R,C)
+        )
 
     ######################
     # Conversion methods #
@@ -466,8 +470,7 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
                   indptr,
                   indices,
                   data)
-        from ._csr import csr_matrix
-        return csr_matrix((data, indices, indptr), shape=self.shape)
+        return self._csr_container((data, indices, indptr), shape=self.shape)
 
     tocsr.__doc__ = spmatrix.tocsr.__doc__
 
@@ -508,8 +511,7 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
         if copy:
             data = data.copy()
 
-        from ._coo import coo_matrix
-        return coo_matrix((data,(row,col)), shape=self.shape)
+        return self._coo_container((data,(row,col)), shape=self.shape)
 
     def toarray(self, order=None, out=None):
         return self.tocoo(copy=False).toarray(order=order, out=out)
@@ -527,8 +529,8 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
         NBLK = self.nnz//(R*C)
 
         if self.nnz == 0:
-            return bsr_matrix((N, M), blocksize=(C, R),
-                              dtype=self.dtype, copy=copy)
+            return self._bsr_container((N, M), blocksize=(C, R),
+                                       dtype=self.dtype, copy=copy)
 
         indptr = np.empty(N//C + 1, dtype=self.indptr.dtype)
         indices = np.empty(NBLK, dtype=self.indices.dtype)
@@ -538,8 +540,8 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
                       self.indptr, self.indices, self.data.ravel(),
                       indptr, indices, data.ravel())
 
-        return bsr_matrix((data, indices, indptr),
-                          shape=(N, M), copy=copy)
+        return self._bsr_container((data, indices, indptr),
+                                   shape=(N, M), copy=copy)
 
     transpose.__doc__ = spmatrix.transpose.__doc__
 
@@ -726,4 +728,5 @@ def isspmatrix_bsr(x):
     >>> isspmatrix_bsr(csr_matrix([[5]]))
     False
     """
-    return isinstance(x, bsr_matrix)
+    from ._arrays import bsr_array
+    return isinstance(x, bsr_matrix) or isinstance(x, bsr_array)

--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -153,7 +153,6 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
 
             elif len(arg1) == 2:
                 # (data,(row,col)) format
-                from ._coo import coo_matrix
                 self._set_self(
                     self._coo_container(arg1, dtype=dtype, shape=shape).tobsr(
                         blocksize=blocksize
@@ -195,7 +194,6 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
             except Exception as e:
                 raise ValueError("unrecognized form for"
                         " %s_matrix constructor" % self.format) from e
-            from ._coo import coo_matrix
             arg1 = self._coo_container(
                 arg1, dtype=dtype
             ).tobsr(blocksize=blocksize)

--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -428,7 +428,7 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
         # TODO eliminate zeros
 
         return self._bsr_container(
-            (data,indices,indptr), shape=(M,N), blocksize=(R,C)
+            (data, indices, indptr), shape=(M, N), blocksize=(R, C)
         )
 
     ######################
@@ -511,7 +511,9 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
         if copy:
             data = data.copy()
 
-        return self._coo_container((data,(row,col)), shape=self.shape)
+        return self._coo_container(
+            (data, (row, col)), shape=self.shape
+        )
 
     def toarray(self, order=None, out=None):
         return self.tocoo(copy=False).toarray(order=order, out=out)

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -15,9 +15,9 @@ from ._sparsetools import (get_csr_submatrix, csr_sample_offsets, csr_todense,
                            csr_column_index1, csr_column_index2)
 from ._index import IndexMixin
 from ._sputils import (upcast, upcast_char, to_native, isdense, isshape,
-                      getdtype, isscalarlike, isintlike, get_index_dtype,
-                      downcast_intp_index, get_sum_dtype, check_shape,
-                      matrix, asmatrix, is_pydata_spmatrix)
+                       getdtype, isscalarlike, isintlike, get_index_dtype,
+                       downcast_intp_index, get_sum_dtype, check_shape,
+                       is_pydata_spmatrix)
 
 
 class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -9,7 +9,6 @@ from scipy._lib._util import _prune_array
 
 from ._base import spmatrix, isspmatrix, SparseEfficiencyWarning
 from ._data import _data_matrix, _minmax_mixin
-from ._dia import dia_matrix
 from . import _sparsetools
 from ._sparsetools import (get_csr_submatrix, csr_sample_offsets, csr_todense,
                            csr_sample_values, csr_row_index, csr_row_slice,
@@ -50,9 +49,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             else:
                 if len(arg1) == 2:
                     # (data, ij) format
-                    from ._coo import coo_matrix
-                    other = self.__class__(coo_matrix(arg1, shape=shape,
-                                                      dtype=dtype))
+                    other = self.__class__(self._coo_container(arg1, shape=shape,
+                                                               dtype=dtype))
                     self._set_self(other)
                 elif len(arg1) == 3:
                     # (data, indices, indptr) format
@@ -82,8 +80,9 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             except Exception as e:
                 raise ValueError("unrecognized {}_matrix constructor usage"
                                  "".format(self.format)) from e
-            from ._coo import coo_matrix
-            self._set_self(self.__class__(coo_matrix(arg1, dtype=dtype)))
+            self._set_self(self.__class__(
+                self._coo_container(arg1, dtype=dtype)
+            ))
 
         # Read matrix dimensions given, if any
         if shape is not None:
@@ -354,7 +353,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         M, N = self._swap(self.shape)
         y = result if result.flags.c_contiguous else result.T
         csr_todense(M, N, self.indptr, self.indices, self.data, y)
-        return matrix(result, copy=False)
+        return self._container(result, copy=False)
 
     def _add_sparse(self, other):
         return self._binopt(other, '_plus_')
@@ -386,23 +385,23 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                 return other._mul_sparse_matrix(self.tocsc())
             # Row vector times matrix. other is a row.
             elif other.shape[0] == 1 and self.shape[1] == other.shape[1]:
-                other = dia_matrix((other.toarray().ravel(), [0]),
-                                   shape=(other.shape[1], other.shape[1]))
+                other = self._dia_container((other.toarray().ravel(), [0]),
+                                            shape=(other.shape[1], other.shape[1]))
                 return self._mul_sparse_matrix(other)
             # self is a row.
             elif self.shape[0] == 1 and self.shape[1] == other.shape[1]:
-                copy = dia_matrix((self.toarray().ravel(), [0]),
-                                  shape=(self.shape[1], self.shape[1]))
+                copy = self._dia_container((self.toarray().ravel(), [0]),
+                                           shape=(self.shape[1], self.shape[1]))
                 return other._mul_sparse_matrix(copy)
             # Column vector times matrix. other is a column.
             elif other.shape[1] == 1 and self.shape[0] == other.shape[0]:
-                other = dia_matrix((other.toarray().ravel(), [0]),
-                                   shape=(other.shape[0], other.shape[0]))
+                other = self._dia_container((other.toarray().ravel(), [0]),
+                                            shape=(other.shape[0], other.shape[0]))
                 return other._mul_sparse_matrix(self)
             # self is a column.
             elif self.shape[1] == 1 and self.shape[0] == other.shape[0]:
-                copy = dia_matrix((self.toarray().ravel(), [0]),
-                                  shape=(self.shape[0], self.shape[0]))
+                copy = self._dia_container((self.toarray().ravel(), [0]),
+                                           shape=(self.shape[0], self.shape[0]))
                 return copy._mul_sparse_matrix(other)
             else:
                 raise ValueError("inconsistent shapes")
@@ -420,7 +419,6 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         elif self.shape == (1, 1):
             return np.multiply(self.toarray()[0, 0], other)
 
-        from ._coo import coo_matrix
         ret = self.tocoo()
         # Matching shapes.
         if self.shape == other.shape:
@@ -435,9 +433,9 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                 raise ValueError("inconsistent shapes")
             row = np.repeat(np.arange(other.shape[0]), len(ret.row))
             col = np.tile(ret.col, other.shape[0])
-            return coo_matrix((data.view(np.ndarray).ravel(), (row, col)),
-                              shape=(other.shape[0], self.shape[1]),
-                              copy=False)
+            return self._coo_container((data.view(np.ndarray).ravel(), (row, col)),
+                                       shape=(other.shape[0], self.shape[1]),
+                                       copy=False)
         # Sparse column vector times...
         elif self.shape[1] == 1:
             if other.shape[0] == 1:  # Dense row vector.
@@ -448,9 +446,9 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                 raise ValueError("inconsistent shapes")
             row = np.repeat(ret.row, other.shape[1])
             col = np.tile(np.arange(other.shape[1]), len(ret.col))
-            return coo_matrix((data.view(np.ndarray).ravel(), (row, col)),
-                              shape=(self.shape[0], other.shape[1]),
-                              copy=False)
+            return self._coo_container((data.view(np.ndarray).ravel(), (row, col)),
+                                       shape=(self.shape[0], other.shape[1]),
+                                       copy=False)
         # Sparse matrix times dense row vector.
         elif other.shape[0] == 1 and self.shape[1] == other.shape[1]:
             data = np.multiply(ret.data, other[:, ret.col].ravel())
@@ -599,7 +597,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
             major_index, value = self._minor_reduce(np.add)
             ret[major_index] = value
-            ret = asmatrix(ret)
+            ret = self._ascontainer(ret)
             if axis % 2 == 1:
                 ret = ret.T
 
@@ -666,7 +664,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         csr_sample_values(M, N, self.indptr, self.indices, self.data,
                           major.size, major.ravel(), minor.ravel(), val)
         if major.ndim == 1:
-            return asmatrix(val)
+            return self._ascontainer(val)
         return self.__class__(val.reshape(major.shape))
 
     def _get_columnXarray(self, row, col):
@@ -1027,9 +1025,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         _sparsetools.expandptr(major_dim, self.indptr, major_indices)
         row, col = self._swap((major_indices, minor_indices))
 
-        from ._coo import coo_matrix
-        return coo_matrix((self.data, (row, col)), self.shape, copy=copy,
-                          dtype=self.dtype)
+        return self._coo_container((self.data, (row, col)), self.shape, copy=copy,
+                                   dtype=self.dtype)
 
     tocoo.__doc__ = spmatrix.tocoo.__doc__
 
@@ -1277,7 +1274,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             out[row, col] = 0
             r = r.tocoo()
             out[r.row, r.col] = r.data
-            out = matrix(out)
+            out = self._container(out)
         else:
             # integers types go with nan <-> 0
             out = r

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -49,8 +49,9 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             else:
                 if len(arg1) == 2:
                     # (data, ij) format
-                    other = self.__class__(self._coo_container(arg1, shape=shape,
-                                                               dtype=dtype))
+                    other = self.__class__(
+                        self._coo_container(arg1, shape=shape, dtype=dtype)
+                    )
                     self._set_self(other)
                 elif len(arg1) == 3:
                     # (data, indices, indptr) format
@@ -385,23 +386,31 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                 return other._mul_sparse_matrix(self.tocsc())
             # Row vector times matrix. other is a row.
             elif other.shape[0] == 1 and self.shape[1] == other.shape[1]:
-                other = self._dia_container((other.toarray().ravel(), [0]),
-                                            shape=(other.shape[1], other.shape[1]))
+                other = self._dia_container(
+                    (other.toarray().ravel(), [0]),
+                    shape=(other.shape[1], other.shape[1])
+                )
                 return self._mul_sparse_matrix(other)
             # self is a row.
             elif self.shape[0] == 1 and self.shape[1] == other.shape[1]:
-                copy = self._dia_container((self.toarray().ravel(), [0]),
-                                           shape=(self.shape[1], self.shape[1]))
+                copy = self._dia_container(
+                    (self.toarray().ravel(), [0]),
+                    shape=(self.shape[1], self.shape[1])
+                )
                 return other._mul_sparse_matrix(copy)
             # Column vector times matrix. other is a column.
             elif other.shape[1] == 1 and self.shape[0] == other.shape[0]:
-                other = self._dia_container((other.toarray().ravel(), [0]),
-                                            shape=(other.shape[0], other.shape[0]))
+                other = self._dia_container(
+                    (other.toarray().ravel(), [0]),
+                    shape=(other.shape[0], other.shape[0])
+                )
                 return other._mul_sparse_matrix(self)
             # self is a column.
             elif self.shape[1] == 1 and self.shape[0] == other.shape[0]:
-                copy = self._dia_container((self.toarray().ravel(), [0]),
-                                           shape=(self.shape[0], self.shape[0]))
+                copy = self._dia_container(
+                    (self.toarray().ravel(), [0]),
+                    shape=(self.shape[0], self.shape[0])
+                )
                 return copy._mul_sparse_matrix(other)
             else:
                 raise ValueError("inconsistent shapes")
@@ -433,9 +442,11 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                 raise ValueError("inconsistent shapes")
             row = np.repeat(np.arange(other.shape[0]), len(ret.row))
             col = np.tile(ret.col, other.shape[0])
-            return self._coo_container((data.view(np.ndarray).ravel(), (row, col)),
-                                       shape=(other.shape[0], self.shape[1]),
-                                       copy=False)
+            return self._coo_container(
+                (data.view(np.ndarray).ravel(), (row, col)),
+                shape=(other.shape[0], self.shape[1]),
+                copy=False
+            )
         # Sparse column vector times...
         elif self.shape[1] == 1:
             if other.shape[0] == 1:  # Dense row vector.
@@ -446,9 +457,11 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                 raise ValueError("inconsistent shapes")
             row = np.repeat(ret.row, other.shape[1])
             col = np.tile(np.arange(other.shape[1]), len(ret.col))
-            return self._coo_container((data.view(np.ndarray).ravel(), (row, col)),
-                                       shape=(self.shape[0], other.shape[1]),
-                                       copy=False)
+            return self._coo_container(
+                (data.view(np.ndarray).ravel(), (row, col)),
+                shape=(self.shape[0], other.shape[1]),
+                copy=False
+            )
         # Sparse matrix times dense row vector.
         elif other.shape[0] == 1 and self.shape[1] == other.shape[1]:
             data = np.multiply(ret.data, other[:, ret.col].ravel())
@@ -1025,8 +1038,10 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         _sparsetools.expandptr(major_dim, self.indptr, major_indices)
         row, col = self._swap((major_indices, minor_indices))
 
-        return self._coo_container((self.data, (row, col)), self.shape, copy=copy,
-                                   dtype=self.dtype)
+        return self._coo_container(
+            (self.data, (row, col)), self.shape, copy=copy,
+            dtype=self.dtype
+        )
 
     tocoo.__doc__ = spmatrix.tocoo.__doc__
 

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -20,10 +20,12 @@ from ._bsr import bsr_matrix
 from ._coo import coo_matrix
 from ._dia import dia_matrix
 
+from ._arrays import coo_array, csr_array, csc_array, dia_array
+
 from ._base import issparse
 
 
-def spdiags(data, diags, m, n, format=None):
+def spdiags(data, diags, m, n, format=None, _array=False):
     """
     Return a sparse matrix from diagonals.
 
@@ -60,7 +62,10 @@ def spdiags(data, diags, m, n, format=None):
            [0, 0, 3, 4]])
 
     """
-    return dia_matrix((data, diags), shape=(m,n)).asformat(format)
+    if _array:
+        return dia_array((data, diags), shape=(m,n)).asformat(format)
+    else:
+        return dia_matrix((data, diags), shape=(m,n)).asformat(format)
 
 
 def diags(diagonals, offsets=0, shape=None, format=None, dtype=None):
@@ -219,7 +224,7 @@ def identity(n, dtype='d', format=None):
     return eye(n, n, dtype=dtype, format=format)
 
 
-def eye(m, n=None, k=0, dtype=float, format=None):
+def eye(m, n=None, k=0, dtype=float, format=None, _array=False):
     """Sparse matrix with ones on diagonal
 
     Returns a sparse (m x n) matrix where the kth diagonal
@@ -261,17 +266,23 @@ def eye(m, n=None, k=0, dtype=float, format=None):
             indptr = np.arange(n+1, dtype=idx_dtype)
             indices = np.arange(n, dtype=idx_dtype)
             data = np.ones(n, dtype=dtype)
-            cls = {'csr': csr_matrix, 'csc': csc_matrix}[format]
+            if _array:
+                cls = {'csr': csr_array, 'csc': csc_array}[format]
+            else:
+                cls = {'csr': csr_matrix, 'csc': csc_matrix}[format]
             return cls((data,indices,indptr),(n,n))
         elif format == 'coo':
             idx_dtype = get_index_dtype(maxval=n)
             row = np.arange(n, dtype=idx_dtype)
             col = np.arange(n, dtype=idx_dtype)
             data = np.ones(n, dtype=dtype)
-            return coo_matrix((data,(row,col)),(n,n))
+            if _array:
+                return coo_array((data,(row,col)),(n,n))
+            else:
+                return coo_matrix((data,(row,col)),(n,n))
 
     diags = np.ones((1, max(0, min(m + k, n))), dtype=dtype)
-    return spdiags(diags, k, m, n).asformat(format)
+    return spdiags(diags, k, m, n, _array=_array).asformat(format)
 
 
 def kron(A, B, format=None):

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -63,9 +63,9 @@ def spdiags(data, diags, m, n, format=None, _array=False):
 
     """
     if _array:
-        return dia_array((data, diags), shape=(m,n)).asformat(format)
+        return dia_array((data, diags), shape=(m, n)).asformat(format)
     else:
-        return dia_matrix((data, diags), shape=(m,n)).asformat(format)
+        return dia_matrix((data, diags), shape=(m, n)).asformat(format)
 
 
 def diags(diagonals, offsets=0, shape=None, format=None, dtype=None):
@@ -277,9 +277,9 @@ def eye(m, n=None, k=0, dtype=float, format=None, _array=False):
             col = np.arange(n, dtype=idx_dtype)
             data = np.ones(n, dtype=dtype)
             if _array:
-                return coo_array((data,(row,col)),(n,n))
+                return coo_array((data, (row, col)), (n, n))
             else:
-                return coo_matrix((data,(row,col)),(n,n))
+                return coo_matrix((data, (row, col)), (n, n))
 
     diags = np.ones((1, max(0, min(m + k, n))), dtype=dtype)
     return spdiags(diags, k, m, n, _array=_array).asformat(format)

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -20,12 +20,10 @@ from ._bsr import bsr_matrix
 from ._coo import coo_matrix
 from ._dia import dia_matrix
 
-from ._arrays import coo_array, csr_array, csc_array, dia_array
-
 from ._base import issparse
 
 
-def spdiags(data, diags, m, n, format=None, _array=False):
+def spdiags(data, diags, m, n, format=None):
     """
     Return a sparse matrix from diagonals.
 
@@ -62,10 +60,7 @@ def spdiags(data, diags, m, n, format=None, _array=False):
            [0, 0, 3, 4]])
 
     """
-    if _array:
-        return dia_array((data, diags), shape=(m, n)).asformat(format)
-    else:
-        return dia_matrix((data, diags), shape=(m, n)).asformat(format)
+    return dia_matrix((data, diags), shape=(m, n)).asformat(format)
 
 
 def diags(diagonals, offsets=0, shape=None, format=None, dtype=None):
@@ -224,7 +219,7 @@ def identity(n, dtype='d', format=None):
     return eye(n, n, dtype=dtype, format=format)
 
 
-def eye(m, n=None, k=0, dtype=float, format=None, _array=False):
+def eye(m, n=None, k=0, dtype=float, format=None):
     """Sparse matrix with ones on diagonal
 
     Returns a sparse (m x n) matrix where the kth diagonal
@@ -266,23 +261,17 @@ def eye(m, n=None, k=0, dtype=float, format=None, _array=False):
             indptr = np.arange(n+1, dtype=idx_dtype)
             indices = np.arange(n, dtype=idx_dtype)
             data = np.ones(n, dtype=dtype)
-            if _array:
-                cls = {'csr': csr_array, 'csc': csc_array}[format]
-            else:
-                cls = {'csr': csr_matrix, 'csc': csc_matrix}[format]
+            cls = {'csr': csr_matrix, 'csc': csc_matrix}[format]
             return cls((data,indices,indptr),(n,n))
         elif format == 'coo':
             idx_dtype = get_index_dtype(maxval=n)
             row = np.arange(n, dtype=idx_dtype)
             col = np.arange(n, dtype=idx_dtype)
             data = np.ones(n, dtype=dtype)
-            if _array:
-                return coo_array((data, (row, col)), (n, n))
-            else:
-                return coo_matrix((data, (row, col)), (n, n))
+            return coo_matrix((data, (row, col)), (n, n))
 
     diags = np.ones((1, max(0, min(m + k, n))), dtype=dtype)
-    return spdiags(diags, k, m, n, _array=_array).asformat(format)
+    return spdiags(diags, k, m, n).asformat(format)
 
 
 def kron(A, B, format=None):

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -434,7 +434,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
             data = np.zeros((len(diags), self.col.max()+1), dtype=self.dtype)
             data[diag_idx, self.col] = self.data
 
-        return self._dia_container((data,diags), shape=self.shape)
+        return self._dia_container((data, diags), shape=self.shape)
 
     todia.__doc__ = spmatrix.todia.__doc__
 

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -231,8 +231,8 @@ class coo_matrix(_data_matrix, _minmax_mixin):
         else:
             new_data = self.data
 
-        return coo_matrix((new_data, (new_row, new_col)),
-                          shape=shape, copy=False)
+        return self.__class__((new_data, (new_row, new_col)),
+                              shape=shape, copy=False)
 
     reshape.__doc__ = spmatrix.reshape.__doc__
 
@@ -295,8 +295,8 @@ class coo_matrix(_data_matrix, _minmax_mixin):
                               "dimensions is the only logical permutation."))
 
         M, N = self.shape
-        return coo_matrix((self.data, (self.col, self.row)),
-                          shape=(N, M), copy=copy)
+        return self.__class__((self.data, (self.col, self.row)),
+                              shape=(N, M), copy=copy)
 
     transpose.__doc__ = spmatrix.transpose.__doc__
 
@@ -347,9 +347,8 @@ class coo_matrix(_data_matrix, _minmax_mixin):
                [0, 0, 0, 1]])
 
         """
-        from ._csc import csc_matrix
         if self.nnz == 0:
-            return csc_matrix(self.shape, dtype=self.dtype)
+            return self._csc_container(self.shape, dtype=self.dtype)
         else:
             M,N = self.shape
             idx_dtype = get_index_dtype((self.col, self.row),
@@ -364,7 +363,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
             coo_tocsr(N, M, self.nnz, col, row, self.data,
                       indptr, indices, data)
 
-            x = csc_matrix((data, indices, indptr), shape=self.shape)
+            x = self._csc_container((data, indices, indptr), shape=self.shape)
             if not self.has_canonical_format:
                 x.sum_duplicates()
             return x
@@ -389,9 +388,8 @@ class coo_matrix(_data_matrix, _minmax_mixin):
                [0, 0, 0, 1]])
 
         """
-        from ._csr import csr_matrix
         if self.nnz == 0:
-            return csr_matrix(self.shape, dtype=self.dtype)
+            return self._csr_container(self.shape, dtype=self.dtype)
         else:
             M,N = self.shape
             idx_dtype = get_index_dtype((self.row, self.col),
@@ -406,7 +404,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
             coo_tocsr(M, N, self.nnz, row, col, self.data,
                       indptr, indices, data)
 
-            x = csr_matrix((data, indices, indptr), shape=self.shape)
+            x = self._csr_container((data, indices, indptr), shape=self.shape)
             if not self.has_canonical_format:
                 x.sum_duplicates()
             return x
@@ -420,8 +418,6 @@ class coo_matrix(_data_matrix, _minmax_mixin):
     tocoo.__doc__ = spmatrix.tocoo.__doc__
 
     def todia(self, copy=False):
-        from ._dia import dia_matrix
-
         self.sum_duplicates()
         ks = self.col - self.row  # the diagonal for each nonzero
         diags, diag_idx = np.unique(ks, return_inverse=True)
@@ -438,15 +434,13 @@ class coo_matrix(_data_matrix, _minmax_mixin):
             data = np.zeros((len(diags), self.col.max()+1), dtype=self.dtype)
             data[diag_idx, self.col] = self.data
 
-        return dia_matrix((data,diags), shape=self.shape)
+        return self._dia_container((data,diags), shape=self.shape)
 
     todia.__doc__ = spmatrix.todia.__doc__
 
     def todok(self, copy=False):
-        from ._dok import dok_matrix
-
         self.sum_duplicates()
-        dok = dok_matrix((self.shape), dtype=self.dtype)
+        dok = self._dok_container((self.shape), dtype=self.dtype)
         dok._update(zip(zip(self.row,self.col),self.data))
 
         return dok
@@ -517,10 +511,10 @@ class coo_matrix(_data_matrix, _minmax_mixin):
         (i.e. .row and .col) are copied.
         """
         if copy:
-            return coo_matrix((data, (self.row.copy(), self.col.copy())),
+            return self.__class__((data, (self.row.copy(), self.col.copy())),
                                    shape=self.shape, dtype=data.dtype)
         else:
-            return coo_matrix((data, (self.row, self.col)),
+            return self.__class__((data, (self.row, self.col)),
                                    shape=self.shape, dtype=data.dtype)
 
     def sum_duplicates(self):
@@ -575,7 +569,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
         M, N = self.shape
         coo_todense(M, N, self.nnz, self.row, self.col, self.data,
                     result.ravel('A'), fortran)
-        return matrix(result, copy=False)
+        return self._container(result, copy=False)
 
     def _mul_vector(self, other):
         #output array
@@ -615,4 +609,5 @@ def isspmatrix_coo(x):
     >>> isspmatrix_coo(csr_matrix([[5]]))
     False
     """
-    return isinstance(x, coo_matrix)
+    from ._arrays import coo_array
+    return isinstance(x, coo_matrix) or isinstance(x, coo_array)

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -14,7 +14,7 @@ from ._base import isspmatrix, SparseEfficiencyWarning, spmatrix
 from ._data import _data_matrix, _minmax_mixin
 from ._sputils import (upcast, upcast_char, to_native, isshape, getdtype,
                        getdata, get_index_dtype, downcast_intp_index,
-                       check_shape, check_reshape_kwargs, matrix)
+                       check_shape, check_reshape_kwargs)
 
 import operator
 

--- a/scipy/sparse/_csc.py
+++ b/scipy/sparse/_csc.py
@@ -113,9 +113,8 @@ class csc_matrix(_cs_matrix):
 
         M, N = self.shape
 
-        from ._csr import csr_matrix
-        return csr_matrix((self.data, self.indices,
-                           self.indptr), (N, M), copy=copy)
+        return self._csr_container((self.data, self.indices,
+                                    self.indptr), (N, M), copy=copy)
 
     transpose.__doc__ = spmatrix.transpose.__doc__
 
@@ -146,8 +145,10 @@ class csc_matrix(_cs_matrix):
                   indices,
                   data)
 
-        from ._csr import csr_matrix
-        A = csr_matrix((data, indices, indptr), shape=self.shape, copy=False)
+        A = self._csr_container(
+            (data, indices, indptr),
+            shape=self.shape, copy=False
+        )
         A.has_sorted_indices = True
         return A
 
@@ -255,4 +256,5 @@ def isspmatrix_csc(x):
     >>> isspmatrix_csc(csr_matrix([[5]]))
     False
     """
-    return isinstance(x, csc_matrix)
+    from ._arrays import csc_array
+    return isinstance(x, csc_matrix) or isinstance(x, csc_array)

--- a/scipy/sparse/_csr.py
+++ b/scipy/sparse/_csr.py
@@ -145,7 +145,7 @@ class csr_matrix(_cs_matrix):
     transpose.__doc__ = spmatrix.transpose.__doc__
 
     def tolil(self, copy=False):
-        lil = self._lil_container(self.shape,dtype=self.dtype)
+        lil = self._lil_container(self.shape, dtype=self.dtype)
 
         self.sum_duplicates()
         ptr,ind,dat = self.indptr,self.indices,self.data
@@ -220,7 +220,9 @@ class csr_matrix(_cs_matrix):
                       self.data,
                       indptr, indices, data.ravel())
 
-            return self._bsr_container((data,indices,indptr), shape=self.shape)
+            return self._bsr_container(
+                (data, indices, indptr), shape=self.shape
+            )
 
     tobsr.__doc__ = spmatrix.tobsr.__doc__
 
@@ -239,7 +241,9 @@ class csr_matrix(_cs_matrix):
             indptr[1] = i1 - i0
             indices = self.indices[i0:i1]
             data = self.data[i0:i1]
-            yield self.__class__((data, indices, indptr), shape=shape, copy=True)
+            yield self.__class__(
+                (data, indices, indptr), shape=shape, copy=True
+            )
             i0 = i1
 
     def getrow(self, i):

--- a/scipy/sparse/_csr.py
+++ b/scipy/sparse/_csr.py
@@ -139,16 +139,13 @@ class csr_matrix(_cs_matrix):
                               "dimensions is the only logical permutation."))
 
         M, N = self.shape
-
-        from ._csc import csc_matrix
-        return csc_matrix((self.data, self.indices,
-                           self.indptr), shape=(N, M), copy=copy)
+        return self._csc_container((self.data, self.indices,
+                                    self.indptr), shape=(N, M), copy=copy)
 
     transpose.__doc__ = spmatrix.transpose.__doc__
 
     def tolil(self, copy=False):
-        from ._lil import lil_matrix
-        lil = lil_matrix(self.shape,dtype=self.dtype)
+        lil = self._lil_container(self.shape,dtype=self.dtype)
 
         self.sum_duplicates()
         ptr,ind,dat = self.indptr,self.indices,self.data
@@ -187,23 +184,20 @@ class csr_matrix(_cs_matrix):
                   indices,
                   data)
 
-        from ._csc import csc_matrix
-        A = csc_matrix((data, indices, indptr), shape=self.shape)
+        A = self._csc_container((data, indices, indptr), shape=self.shape)
         A.has_sorted_indices = True
         return A
 
     tocsc.__doc__ = spmatrix.tocsc.__doc__
 
     def tobsr(self, blocksize=None, copy=True):
-        from ._bsr import bsr_matrix
-
         if blocksize is None:
             from ._spfuncs import estimate_blocksize
             return self.tobsr(blocksize=estimate_blocksize(self))
 
         elif blocksize == (1,1):
             arg1 = (self.data.reshape(-1,1,1),self.indices,self.indptr)
-            return bsr_matrix(arg1, shape=self.shape, copy=copy)
+            return self._bsr_container(arg1, shape=self.shape, copy=copy)
 
         else:
             R,C = blocksize
@@ -226,7 +220,7 @@ class csr_matrix(_cs_matrix):
                       self.data,
                       indptr, indices, data.ravel())
 
-            return bsr_matrix((data,indices,indptr), shape=self.shape)
+            return self._bsr_container((data,indices,indptr), shape=self.shape)
 
     tobsr.__doc__ = spmatrix.tobsr.__doc__
 
@@ -245,7 +239,7 @@ class csr_matrix(_cs_matrix):
             indptr[1] = i1 - i0
             indices = self.indices[i0:i1]
             data = self.data[i0:i1]
-            yield csr_matrix((data, indices, indptr), shape=shape, copy=True)
+            yield self.__class__((data, indices, indptr), shape=shape, copy=True)
             i0 = i1
 
     def getrow(self, i):
@@ -260,8 +254,8 @@ class csr_matrix(_cs_matrix):
             raise IndexError('index (%d) out of range' % i)
         indptr, indices, data = get_csr_submatrix(
             M, N, self.indptr, self.indices, self.data, i, i + 1, 0, N)
-        return csr_matrix((data, indices, indptr), shape=(1, N),
-                          dtype=self.dtype, copy=False)
+        return self.__class__((data, indices, indptr), shape=(1, N),
+                              dtype=self.dtype, copy=False)
 
     def getcol(self, i):
         """Returns a copy of column i of the matrix, as a (m x 1)
@@ -275,8 +269,8 @@ class csr_matrix(_cs_matrix):
             raise IndexError('index (%d) out of range' % i)
         indptr, indices, data = get_csr_submatrix(
             M, N, self.indptr, self.indices, self.data, 0, M, i, i + 1)
-        return csr_matrix((data, indices, indptr), shape=(M, 1),
-                          dtype=self.dtype, copy=False)
+        return self.__class__((data, indices, indptr), shape=(M, 1),
+                              dtype=self.dtype, copy=False)
 
     def _get_intXarray(self, row, col):
         return self.getrow(row)._minor_index_fancy(col)
@@ -311,8 +305,8 @@ class csr_matrix(_cs_matrix):
             row_indices = abs(row_indices[::-1])
 
         shape = (1, max(0, int(np.ceil(float(stop - start) / stride))))
-        return csr_matrix((row_data, row_indices, row_indptr), shape=shape,
-                          dtype=self.dtype, copy=False)
+        return self.__class__((row_data, row_indices, row_indptr), shape=shape,
+                              dtype=self.dtype, copy=False)
 
     def _get_sliceXint(self, row, col):
         if row.step in (1, None):
@@ -355,4 +349,5 @@ def isspmatrix_csr(x):
     >>> isspmatrix_csr(csc_matrix([[5]]))
     False
     """
-    return isinstance(x, csr_matrix)
+    from ._arrays import csr_array
+    return isinstance(x, csr_matrix) or isinstance(x, csr_array)

--- a/scipy/sparse/_data.py
+++ b/scipy/sparse/_data.py
@@ -177,7 +177,6 @@ class _minmax_mixin:
         major_index = np.compress(mask, major_index)
         value = np.compress(mask, value)
 
-        from . import coo_matrix
         if axis == 0:
             return self._coo_container(
                 (value, (np.zeros(len(value)), major_index)),

--- a/scipy/sparse/_data.py
+++ b/scipy/sparse/_data.py
@@ -179,11 +179,11 @@ class _minmax_mixin:
 
         from . import coo_matrix
         if axis == 0:
-            return coo_matrix((value, (np.zeros(len(value)), major_index)),
-                              dtype=self.dtype, shape=(1, M))
+            return self._coo_container((value, (np.zeros(len(value)), major_index)),
+                                       dtype=self.dtype, shape=(1, M))
         else:
-            return coo_matrix((value, (major_index, np.zeros(len(value)))),
-                              dtype=self.dtype, shape=(M, 1))
+            return self._coo_container((value, (major_index, np.zeros(len(value)))),
+                                       dtype=self.dtype, shape=(M, 1))
 
     def _min_or_max(self, axis, out, min_or_max):
         if out is not None:

--- a/scipy/sparse/_data.py
+++ b/scipy/sparse/_data.py
@@ -179,11 +179,15 @@ class _minmax_mixin:
 
         from . import coo_matrix
         if axis == 0:
-            return self._coo_container((value, (np.zeros(len(value)), major_index)),
-                                       dtype=self.dtype, shape=(1, M))
+            return self._coo_container(
+                (value, (np.zeros(len(value)), major_index)),
+                dtype=self.dtype, shape=(1, M)
+            )
         else:
-            return self._coo_container((value, (major_index, np.zeros(len(value)))),
-                                       dtype=self.dtype, shape=(M, 1))
+            return self._coo_container(
+                (value, (major_index, np.zeros(len(value)))),
+                dtype=self.dtype, shape=(M, 1)
+            )
 
     def _min_or_max(self, axis, out, min_or_max):
         if out is not None:

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -214,7 +214,7 @@ class dia_matrix(_data_matrix):
             ret = self._ascontainer(res, dtype=res_dtype)
 
         else:
-            row_sums = np.zeros(num_rows, dtype=res_dtype)
+            row_sums = np.zeros((num_rows, 1), dtype=res_dtype)
             one = np.ones(num_cols, dtype=res_dtype)
             dia_matvec(num_rows, num_cols, len(self.offsets),
                        self.data.shape[1], self.offsets, self.data, one, row_sums)
@@ -223,9 +223,6 @@ class dia_matrix(_data_matrix):
 
             if axis is None:
                 return row_sums.sum(dtype=dtype, out=out)
-
-            if axis is not None:
-                row_sums = row_sums.T
 
             ret = self._ascontainer(row_sums.sum(axis=axis))
 

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -403,7 +403,9 @@ class dia_matrix(_data_matrix):
         col = np.tile(offset_inds, num_offsets)[mask.ravel()]
         data = self.data[mask]
 
-        A = self._coo_container((data,(row,col)), shape=self.shape, dtype=self.dtype)
+        A = self._coo_container(
+            (data, (row, col)), shape=self.shape, dtype=self.dtype
+        )
         A.has_canonical_format = True
         return A
 
@@ -415,9 +417,13 @@ class dia_matrix(_data_matrix):
         but with different data.  By default the structure arrays are copied.
         """
         if copy:
-            return self._dia_container((data, self.offsets.copy()), shape=self.shape)
+            return self._dia_container(
+                (data, self.offsets.copy()), shape=self.shape
+            )
         else:
-            return self._dia_container((data,self.offsets), shape=self.shape)
+            return self._dia_container(
+                (data, self.offsets), shape=self.shape
+            )
 
     def resize(self, *shape):
         shape = check_shape(shape)

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -9,7 +9,7 @@ import numpy as np
 from ._base import isspmatrix, _formats, spmatrix
 from ._data import _data_matrix
 from ._sputils import (isshape, upcast_char, getdtype, get_index_dtype,
-                       get_sum_dtype, validateaxis, check_shape, matrix)
+                       get_sum_dtype, validateaxis, check_shape)
 from ._sparsetools import dia_matvec
 
 
@@ -364,7 +364,6 @@ class dia_matrix(_data_matrix):
     diagonal.__doc__ = spmatrix.diagonal.__doc__
 
     def tocsc(self, copy=False):
-        from ._csc import csc_matrix
         if self.nnz == 0:
             return self._csc_container(self.shape, dtype=self.dtype)
 

--- a/scipy/sparse/_dok.py
+++ b/scipy/sparse/_dok.py
@@ -388,7 +388,6 @@ class dok_matrix(spmatrix, IndexMixin, dict):
     copy.__doc__ = spmatrix.copy.__doc__
 
     def tocoo(self, copy=False):
-        from ._coo import coo_matrix
         if self.nnz == 0:
             return self._coo_container(self.shape, dtype=self.dtype)
 

--- a/scipy/sparse/_dok.py
+++ b/scipy/sparse/_dok.py
@@ -186,9 +186,11 @@ class dok_matrix(spmatrix, IndexMixin, dict):
         return newdok
 
     def _get_intXarray(self, row, col):
+        col = col.squeeze()
         return self._get_columnXarray([row], col)
 
     def _get_arrayXint(self, row, col):
+        row = row.squeeze()
         return self._get_columnXarray(row, [col])
 
     def _get_sliceXarray(self, row, col):

--- a/scipy/sparse/_dok.py
+++ b/scipy/sparse/_dok.py
@@ -100,8 +100,7 @@ class dok_matrix(spmatrix, IndexMixin, dict):
             if len(arg1.shape) != 2:
                 raise TypeError('Expected rank <=2 dense array or matrix.')
 
-            from ._coo import coo_matrix
-            d = coo_matrix(arg1, dtype=dtype).todok()
+            d = self._coo_container(arg1, dtype=dtype).todok()
             dict.update(self, d)
             self._shape = check_shape(arg1.shape)
             self.dtype = d.dtype
@@ -174,7 +173,7 @@ class dok_matrix(spmatrix, IndexMixin, dict):
             # O(nr*nc) path: loop over <row x col>
             return self._get_columnXarray(row_range, col_range)
         # O(nnz) path: loop over entries of self
-        newdok = dok_matrix(shape, dtype=self.dtype)
+        newdok = self._dok_container(shape, dtype=self.dtype)
         for key in self.keys():
             i, ri = divmod(int(key[0]) - row_start, row_step)
             if ri != 0 or i < 0 or i >= shape[0]:
@@ -202,7 +201,7 @@ class dok_matrix(spmatrix, IndexMixin, dict):
 
     def _get_columnXarray(self, row, col):
         # outer indexing
-        newdok = dok_matrix((len(row), len(col)), dtype=self.dtype)
+        newdok = self._dok_container((len(row), len(col)), dtype=self.dtype)
 
         for i, r in enumerate(row):
             for j, c in enumerate(col):
@@ -214,7 +213,7 @@ class dok_matrix(spmatrix, IndexMixin, dict):
     def _get_arrayXarray(self, row, col):
         # inner indexing
         i, j = map(np.atleast_2d, np.broadcast_arrays(row, col))
-        newdok = dok_matrix(i.shape, dtype=self.dtype)
+        newdok = self._dok_container(i.shape, dtype=self.dtype)
 
         for key in itertools.product(range(i.shape[0]), range(i.shape[1])):
             v = dict.get(self, (i[key], j[key]), 0)
@@ -244,7 +243,7 @@ class dok_matrix(spmatrix, IndexMixin, dict):
     def __add__(self, other):
         if isscalarlike(other):
             res_dtype = upcast_scalar(self.dtype, other)
-            new = dok_matrix(self.shape, dtype=res_dtype)
+            new = self._dok_container(self.shape, dtype=res_dtype)
             # Add this scalar to every element.
             M, N = self.shape
             for key in itertools.product(range(M), range(N)):
@@ -258,7 +257,7 @@ class dok_matrix(spmatrix, IndexMixin, dict):
             # We could alternatively set the dimensions to the largest of
             # the two matrices to be summed.  Would this be a good idea?
             res_dtype = upcast(self.dtype, other.dtype)
-            new = dok_matrix(self.shape, dtype=res_dtype)
+            new = self._dok_container(self.shape, dtype=res_dtype)
             dict.update(new, self)
             with np.errstate(over='ignore'):
                 dict.update(new,
@@ -274,7 +273,7 @@ class dok_matrix(spmatrix, IndexMixin, dict):
 
     def __radd__(self, other):
         if isscalarlike(other):
-            new = dok_matrix(self.shape, dtype=self.dtype)
+            new = self._dok_container(self.shape, dtype=self.dtype)
             M, N = self.shape
             for key in itertools.product(range(M), range(N)):
                 aij = dict.get(self, (key), 0) + other
@@ -283,7 +282,7 @@ class dok_matrix(spmatrix, IndexMixin, dict):
         elif isspmatrix_dok(other):
             if other.shape != self.shape:
                 raise ValueError("Matrix dimensions are not equal.")
-            new = dok_matrix(self.shape, dtype=self.dtype)
+            new = self._dok_container(self.shape, dtype=self.dtype)
             dict.update(new, self)
             dict.update(new,
                        ((k, self[k] + other[k]) for k in other.keys()))
@@ -300,14 +299,14 @@ class dok_matrix(spmatrix, IndexMixin, dict):
         if self.dtype.kind == 'b':
             raise NotImplementedError('Negating a sparse boolean matrix is not'
                                       ' supported.')
-        new = dok_matrix(self.shape, dtype=self.dtype)
+        new = self._dok_container(self.shape, dtype=self.dtype)
         dict.update(new, ((k, -self[k]) for k in self.keys()))
         return new
 
     def _mul_scalar(self, other):
         res_dtype = upcast_scalar(self.dtype, other)
         # Multiply this scalar by every element.
-        new = dok_matrix(self.shape, dtype=res_dtype)
+        new = self._dok_container(self.shape, dtype=res_dtype)
         dict.update(new, ((k, v * other) for k, v in self.items()))
         return new
 
@@ -336,7 +335,7 @@ class dok_matrix(spmatrix, IndexMixin, dict):
     def __truediv__(self, other):
         if isscalarlike(other):
             res_dtype = upcast_scalar(self.dtype, other)
-            new = dok_matrix(self.shape, dtype=res_dtype)
+            new = self._dok_container(self.shape, dtype=res_dtype)
             dict.update(new, ((k, v / other) for k, v in self.items()))
             return new
         return self.tocsr() / other
@@ -364,7 +363,7 @@ class dok_matrix(spmatrix, IndexMixin, dict):
                              "dimensions is the only logical permutation.")
 
         M, N = self.shape
-        new = dok_matrix((N, M), dtype=self.dtype, copy=copy)
+        new = self._dok_container((N, M), dtype=self.dtype, copy=copy)
         dict.update(new, (((right, left), val)
                           for (left, right), val in self.items()))
         return new
@@ -374,13 +373,13 @@ class dok_matrix(spmatrix, IndexMixin, dict):
     def conjtransp(self):
         """Return the conjugate transpose."""
         M, N = self.shape
-        new = dok_matrix((N, M), dtype=self.dtype)
+        new = self._dok_container((N, M), dtype=self.dtype)
         dict.update(new, (((right, left), np.conj(val))
                           for (left, right), val in self.items()))
         return new
 
     def copy(self):
-        new = dok_matrix(self.shape, dtype=self.dtype)
+        new = self._dok_container(self.shape, dtype=self.dtype)
         dict.update(new, self)
         return new
 
@@ -389,13 +388,13 @@ class dok_matrix(spmatrix, IndexMixin, dict):
     def tocoo(self, copy=False):
         from ._coo import coo_matrix
         if self.nnz == 0:
-            return coo_matrix(self.shape, dtype=self.dtype)
+            return self._coo_container(self.shape, dtype=self.dtype)
 
         idx_dtype = get_index_dtype(maxval=max(self.shape))
         data = np.fromiter(self.values(), dtype=self.dtype, count=self.nnz)
         row = np.fromiter((i for i, _ in self.keys()), dtype=idx_dtype, count=self.nnz)
         col = np.fromiter((j for _, j in self.keys()), dtype=idx_dtype, count=self.nnz)
-        A = coo_matrix((data, (row, col)), shape=self.shape, dtype=self.dtype)
+        A = self._coo_container((data, (row, col)), shape=self.shape, dtype=self.dtype)
         A.has_canonical_format = True
         return A
 
@@ -450,4 +449,5 @@ def isspmatrix_dok(x):
     >>> isspmatrix_dok(csr_matrix([[5]]))
     False
     """
-    return isinstance(x, dok_matrix)
+    from ._arrays import dok_array
+    return isinstance(x, dok_matrix) or isinstance(x, dok_array)

--- a/scipy/sparse/_dok.py
+++ b/scipy/sparse/_dok.py
@@ -394,7 +394,9 @@ class dok_matrix(spmatrix, IndexMixin, dict):
         data = np.fromiter(self.values(), dtype=self.dtype, count=self.nnz)
         row = np.fromiter((i for i, _ in self.keys()), dtype=idx_dtype, count=self.nnz)
         col = np.fromiter((j for _, j in self.keys()), dtype=idx_dtype, count=self.nnz)
-        A = self._coo_container((data, (row, col)), shape=self.shape, dtype=self.dtype)
+        A = self._coo_container(
+            (data, (row, col)), shape=self.shape, dtype=self.dtype
+        )
         A.has_canonical_format = True
         return A
 

--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -31,9 +31,13 @@ class IndexMixin:
     """
     def __getitem__(self, key):
         row, col = self._validate_indices(key)
+
         def vector(data):
             if self._is_array:
-                return data.todense().squeeze()
+                raise NotImplementedError(
+                    'We have not yet implemented 1D sparse slices; '
+                    'please index using explicit indices, e.g. `x[:, [0]]`'
+                )
             else:
                 return data
 
@@ -44,7 +48,7 @@ class IndexMixin:
             elif isinstance(col, slice):
                 return vector(self._get_intXslice(row, col))
             elif col.ndim == 1:
-                return vector(self._get_intXarray(row, col))
+                return self._get_intXarray(row, col)
             raise IndexError('index results in >2 dimensions')
         elif isinstance(row, slice):
             if isinstance(col, INT_TYPES):
@@ -58,12 +62,12 @@ class IndexMixin:
             raise IndexError('index results in >2 dimensions')
         elif row.ndim == 1:
             if isinstance(col, INT_TYPES):
-                return vector(self._get_arrayXint(row, col))
+                return self._get_arrayXint(row, col)
             elif isinstance(col, slice):
                 return self._get_arrayXslice(row, col)
         else:  # row.ndim == 2
             if isinstance(col, INT_TYPES):
-                return vector(self._get_arrayXint(row, col))
+                return self._get_arrayXint(row, col)
             elif isinstance(col, slice):
                 raise IndexError('index results in >2 dimensions')
             elif row.shape[1] == 1 and (col.ndim == 1 or col.shape[0] == 1):

--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -31,18 +31,24 @@ class IndexMixin:
     """
     def __getitem__(self, key):
         row, col = self._validate_indices(key)
+        def vector(data):
+            if self._is_array:
+                return data.todense().squeeze()
+            else:
+                return data
+
         # Dispatch to specialized methods.
         if isinstance(row, INT_TYPES):
             if isinstance(col, INT_TYPES):
                 return self._get_intXint(row, col)
             elif isinstance(col, slice):
-                return self._get_intXslice(row, col)
+                return vector(self._get_intXslice(row, col))
             elif col.ndim == 1:
-                return self._get_intXarray(row, col)
+                return vector(self._get_intXarray(row, col))
             raise IndexError('index results in >2 dimensions')
         elif isinstance(row, slice):
             if isinstance(col, INT_TYPES):
-                return self._get_sliceXint(row, col)
+                return vector(self._get_sliceXint(row, col))
             elif isinstance(col, slice):
                 if row == slice(None) and row == col:
                     return self.copy()
@@ -52,12 +58,12 @@ class IndexMixin:
             raise IndexError('index results in >2 dimensions')
         elif row.ndim == 1:
             if isinstance(col, INT_TYPES):
-                return self._get_arrayXint(row, col)
+                return vector(self._get_arrayXint(row, col))
             elif isinstance(col, slice):
                 return self._get_arrayXslice(row, col)
         else:  # row.ndim == 2
             if isinstance(col, INT_TYPES):
-                return self._get_arrayXint(row, col)
+                return vector(self._get_arrayXint(row, col))
             elif isinstance(col, slice):
                 raise IndexError('index results in >2 dimensions')
             elif row.shape[1] == 1 and (col.ndim == 1 or col.shape[0] == 1):

--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -170,7 +170,6 @@ class IndexMixin:
         return row, col
 
     def _asindices(self, idx, length):
-
         """Convert `idx` to a valid index for an axis with a given length.
 
         Subclasses that need special validation can override this method.

--- a/scipy/sparse/_lil.py
+++ b/scipy/sparse/_lil.py
@@ -231,6 +231,7 @@ class lil_matrix(spmatrix, IndexMixin):
         return self._get_row_ranges(row, slice(col, col+1))
 
     def _get_arrayXint(self, row, col):
+        row = row.squeeze()
         return self._get_row_ranges(row, slice(col, col+1))
 
     def _get_intXslice(self, row, col):

--- a/scipy/sparse/_lil.py
+++ b/scipy/sparse/_lil.py
@@ -116,12 +116,11 @@ class lil_matrix(spmatrix, IndexMixin):
         else:
             # assume A is dense
             try:
-                A = asmatrix(arg1)
+                A = self._ascontainer(arg1)
             except TypeError as e:
                 raise TypeError('unsupported matrix type') from e
             else:
-                from ._csr import csr_matrix
-                A = csr_matrix(A, dtype=dtype).tolil()
+                A = self._csr_container(A, dtype=dtype).tolil()
 
                 self._shape = check_shape(A.shape)
                 self.dtype = A.dtype
@@ -184,7 +183,7 @@ class lil_matrix(spmatrix, IndexMixin):
     def getrowview(self, i):
         """Returns a view of the 'i'th row (without copying).
         """
-        new = lil_matrix((1, self.shape[1]), dtype=self.dtype)
+        new = self._lil_container((1, self.shape[1]), dtype=self.dtype)
         new.rows[0] = self.rows[i]
         new.data[0] = self.data[i]
         return new
@@ -197,7 +196,7 @@ class lil_matrix(spmatrix, IndexMixin):
             i += M
         if i < 0 or i >= M:
             raise IndexError('row index out of bounds')
-        new = lil_matrix((1, N), dtype=self.dtype)
+        new = self._lil_container((1, N), dtype=self.dtype)
         new.rows[0] = self.rows[i][:]
         new.data[0] = self.data[i][:]
         return new
@@ -260,7 +259,7 @@ class lil_matrix(spmatrix, IndexMixin):
     def _get_arrayXarray(self, row, col):
         # inner indexing
         i, j = map(np.atleast_2d, _prepare_index_for_memoryview(row, col))
-        new = lil_matrix(i.shape, dtype=self.dtype)
+        new = self._lil_container(i.shape, dtype=self.dtype)
         _csparsetools.lil_fancy_get(self.shape[0], self.shape[1],
                                     self.rows, self.data,
                                     new.rows, new.data,
@@ -286,7 +285,7 @@ class lil_matrix(spmatrix, IndexMixin):
         j_start, j_stop, j_stride = col_slice.indices(self.shape[1])
         col_range = range(j_start, j_stop, j_stride)
         nj = len(col_range)
-        new = lil_matrix((len(rows), nj), dtype=self.dtype)
+        new = self._lil_container((len(rows), nj), dtype=self.dtype)
 
         _csparsetools.lil_get_row_ranges(self.shape[0], self.shape[1],
                                          self.rows, self.data,
@@ -311,7 +310,7 @@ class lil_matrix(spmatrix, IndexMixin):
         if (x.shape == self.shape and
                 isinstance(row, slice) and row == slice(None) and
                 isinstance(col, slice) and col == slice(None)):
-            x = lil_matrix(x, dtype=self.dtype)
+            x = self._lil_container(x, dtype=self.dtype)
             self.rows = x.rows
             self.data = x.data
             return
@@ -335,7 +334,7 @@ class lil_matrix(spmatrix, IndexMixin):
     def _mul_scalar(self, other):
         if other == 0:
             # Multiply by zero: return the zero matrix
-            new = lil_matrix(self.shape, dtype=self.dtype)
+            new = self._lil_container(self.shape, dtype=self.dtype)
         else:
             res_dtype = upcast_scalar(self.dtype, other)
 
@@ -358,7 +357,7 @@ class lil_matrix(spmatrix, IndexMixin):
 
     def copy(self):
         M, N = self.shape
-        new = lil_matrix(self.shape, dtype=self.dtype)
+        new = self._lil_container(self.shape, dtype=self.dtype)
         # This is ~14x faster than calling deepcopy() on rows and data.
         _csparsetools.lil_get_row_ranges(M, N, self.rows, self.data,
                                          new.rows, new.data, range(M),
@@ -378,7 +377,7 @@ class lil_matrix(spmatrix, IndexMixin):
             else:
                 return self
 
-        new = lil_matrix(shape, dtype=self.dtype)
+        new = self._lil_container(shape, dtype=self.dtype)
 
         if order == 'C':
             ncols = self.shape[1]
@@ -447,11 +446,9 @@ class lil_matrix(spmatrix, IndexMixin):
     tolil.__doc__ = spmatrix.tolil.__doc__
 
     def tocsr(self, copy=False):
-        from ._csr import csr_matrix
-
         M, N = self.shape
         if M == 0 or N == 0:
-            return csr_matrix((M, N), dtype=self.dtype)
+            return self._csr_container((M, N), dtype=self.dtype)
 
         # construct indptr array
         if M*N <= np.iinfo(np.int32).max:
@@ -478,7 +475,7 @@ class lil_matrix(spmatrix, IndexMixin):
         _csparsetools.lil_flatten_to_array(self.data, data)
 
         # init csr matrix
-        return csr_matrix((data, indices, indptr), shape=self.shape)
+        return self._csr_container((data, indices, indptr), shape=self.shape)
 
     tocsr.__doc__ = spmatrix.tocsr.__doc__
 
@@ -547,4 +544,5 @@ def isspmatrix_lil(x):
     >>> isspmatrix_lil(csr_matrix([[5]]))
     False
     """
-    return isinstance(x, lil_matrix)
+    from ._arrays import lil_array
+    return isinstance(x, lil_matrix) or isinstance(x, lil_array)

--- a/scipy/sparse/_lil.py
+++ b/scipy/sparse/_lil.py
@@ -12,8 +12,7 @@ import numpy as np
 from ._base import spmatrix, isspmatrix
 from ._index import IndexMixin, INT_TYPES, _broadcast_arrays
 from ._sputils import (getdtype, isshape, isscalarlike, upcast_scalar,
-                       get_index_dtype, check_shape, check_reshape_kwargs,
-                       asmatrix)
+                       get_index_dtype, check_shape, check_reshape_kwargs)
 from . import _csparsetools
 
 

--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -292,7 +292,7 @@ def check_shape(args, current_shape=None):
     if current_shape is None:
         if len(new_shape) != 2:
             raise ValueError('shape must be a 2-tuple of positive integers')
-        elif new_shape[0] < 0 or new_shape[1] < 0:
+        elif not all(d >= 0 for d in new_shape):
             raise ValueError("'shape' elements cannot be negative")
 
     else:

--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -292,7 +292,7 @@ def check_shape(args, current_shape=None):
     if current_shape is None:
         if len(new_shape) != 2:
             raise ValueError('shape must be a 2-tuple of positive integers')
-        elif not all(d >= 0 for d in new_shape):
+        elif any(d < 0 for d in new_shape):
             raise ValueError("'shape' elements cannot be negative")
 
     else:

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -222,6 +222,10 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
             row_segs = []
             col_segs = []
             for j in range(b.shape[1]):
+                # TODO: replace this with
+                # bj = b[:, j].toarray().ravel()
+                # once 1D sparse arrays are supported.
+                # That is a slightly faster code path.
                 bj = b[:, [j]].toarray().ravel()
                 xj = Afactsolve(bj)
                 w = np.flatnonzero(xj)

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -222,7 +222,7 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
             row_segs = []
             col_segs = []
             for j in range(b.shape[1]):
-                bj = b[:, j].toarray().ravel()
+                bj = b[:, [j]].toarray().ravel()
                 xj = Afactsolve(bj)
                 w = np.flatnonzero(xj)
                 segment_length = w.shape[0]

--- a/scipy/sparse/tests/test_array_api.py
+++ b/scipy/sparse/tests/test_array_api.py
@@ -123,6 +123,9 @@ def test_getrow_getcol(A):
 
 @parametrize_sparrays
 def test_docstr(A):
+    if A.__doc__ is None:
+        return
+
     docstr = A.__doc__.lower()
     for phrase in ('matrix', 'matrices'):
         assert phrase not in docstr

--- a/scipy/sparse/tests/test_array_api.py
+++ b/scipy/sparse/tests/test_array_api.py
@@ -1,5 +1,3 @@
-import importlib
-
 import pytest
 import numpy as np
 import scipy.sparse
@@ -31,21 +29,25 @@ parametrize_square_sparrays = pytest.mark.parametrize(
     "B", square_sparrays, ids=sparray_types
 )
 
+
 @parametrize_sparrays
 def test_sum(A):
-    assert not isinstance(A.sum(axis=0), np.matrix), "Expected array, got matrix"
+    assert not isinstance(A.sum(axis=0), np.matrix), \
+        "Expected array, got matrix"
     assert A.sum(axis=0).shape == (4,)
     assert A.sum(axis=1).shape == (3,)
 
 
 @parametrize_sparrays
 def test_mean(A):
-    assert not isinstance(A.mean(axis=1), np.matrix), "Expected array, got matrix"
+    assert not isinstance(A.mean(axis=1), np.matrix), \
+        "Expected array, got matrix"
 
 
 @parametrize_sparrays
 def test_todense(A):
-    assert not isinstance(A.todense(), np.matrix), "Expected array, got matrix"
+    assert not isinstance(A.todense(), np.matrix), \
+        "Expected array, got matrix"
 
 
 @parametrize_sparrays
@@ -111,3 +113,9 @@ def test_no_A_attr(A):
 def test_no_H_attr(A):
     with pytest.warns(np.VisibleDeprecationWarning):
         A.H
+
+
+@parametrize_sparrays
+def test_getrow_getcol(A):
+    assert A.getcol(0)._is_array
+    assert A.getrow(0)._is_array

--- a/scipy/sparse/tests/test_array_api.py
+++ b/scipy/sparse/tests/test_array_api.py
@@ -1,0 +1,107 @@
+import importlib
+
+import pytest
+import numpy as np
+import scipy.sparse
+
+sparray_types = ('bsr', 'coo', 'csc', 'csr', 'dia', 'dok', 'lil')
+
+sparray_classes = [
+    getattr(scipy.sparse, f'{T}_array') for T in sparray_types
+]
+
+A = np.array([
+    [0, 1, 2, 0],
+    [2, 0, 0, 3],
+    [1, 4, 0, 0]
+])
+
+B = np.array([
+    [0, 1],
+    [2, 0]
+])
+
+sparrays = [sparray(A) for sparray in sparray_classes]
+square_sparrays = [sparray(B) for sparray in sparray_classes]
+
+parametrize_sparrays = pytest.mark.parametrize(
+    "A", sparrays, ids=sparray_types
+)
+parametrize_square_sparrays = pytest.mark.parametrize(
+    "B", square_sparrays, ids=sparray_types
+)
+
+@parametrize_sparrays
+def test_sum(A):
+    assert not isinstance(A.sum(axis=0), np.matrix), "Expected array, got matrix"
+
+
+@parametrize_sparrays
+def test_mean(A):
+    assert not isinstance(A.mean(axis=1), np.matrix), "Expected array, got matrix"
+
+
+@parametrize_sparrays
+def test_todense(A):
+    assert not isinstance(A.todense(), np.matrix), "Expected array, got matrix"
+
+
+@parametrize_sparrays
+def test_indexing(A):
+    if A.__class__.__name__[:3] in ('dia', 'coo', 'bsr'):
+        return
+    assert A[1, :].shape == (4,)
+    assert A[:, 1].shape == (3,)
+    assert isinstance(A[0], np.ndarray), "Expected sparse array, got sparse matrix"
+
+    assert isinstance(A[1, [1, 2]], np.ndarray), "Expected ndarray, got sparse array"
+    assert A[:, [1, 2]]._is_array, "Expected sparse array, got something else"
+
+
+@parametrize_sparrays
+def test_dense_addition(A):
+    X = np.random.random(A.shape)
+    assert not isinstance(A + X, np.matrix), "Expected array, got matrix"
+
+
+@parametrize_sparrays
+def test_sparse_addition(A):
+    assert (A + A)._is_array, "Expected array, got matrix"
+
+
+@parametrize_sparrays
+def test_elementwise_mul(A):
+    assert np.all((A * A).todense() == A.power(2).todense())
+
+
+@parametrize_sparrays
+def test_matmul(A):
+    assert np.all((A @ A.T).todense() == A.dot(A.T).todense())
+
+
+@parametrize_square_sparrays
+def test_pow(B):
+    assert (B**0)._is_array, "Expected array, got matrix"
+    assert (B**2)._is_array, "Expected array, got matrix"
+
+
+@parametrize_sparrays
+def test_sparse_divide(A):
+    assert isinstance(A / A, np.ndarray)
+
+
+@parametrize_sparrays
+def test_dense_divide(A):
+    assert (A / 2)._is_array, "Expected array, got matrix"
+
+
+@parametrize_sparrays
+def test_no_A_attr(A):
+    with pytest.warns(np.VisibleDeprecationWarning):
+        A.A
+
+
+@parametrize_sparrays
+def test_no_H_attr(A):
+    with pytest.warns(np.VisibleDeprecationWarning):
+        A.H

--- a/scipy/sparse/tests/test_array_api.py
+++ b/scipy/sparse/tests/test_array_api.py
@@ -75,8 +75,15 @@ def test_indexing(A):
     with pytest.raises(NotImplementedError):
         A[:, 1]
 
+    with pytest.raises(NotImplementedError):
+        A[1, [1, 2]]
+
+    with pytest.raises(NotImplementedError):
+        A[[1, 2], 1]
+
     assert A[[0]]._is_array, "Expected sparse array, got sparse matrix"
-    assert A[1, [1, 2]]._is_array, "Expected ndarray, got sparse array"
+    assert A[1, [[1, 2]]]._is_array, "Expected ndarray, got sparse array"
+    assert A[[[1, 2]], 1]._is_array, "Expected ndarray, got sparse array"
     assert A[:, [1, 2]]._is_array, "Expected sparse array, got something else"
 
 

--- a/scipy/sparse/tests/test_array_api.py
+++ b/scipy/sparse/tests/test_array_api.py
@@ -34,6 +34,8 @@ parametrize_square_sparrays = pytest.mark.parametrize(
 @parametrize_sparrays
 def test_sum(A):
     assert not isinstance(A.sum(axis=0), np.matrix), "Expected array, got matrix"
+    assert A.sum(axis=0).shape == (4,)
+    assert A.sum(axis=1).shape == (3,)
 
 
 @parametrize_sparrays

--- a/scipy/sparse/tests/test_array_api.py
+++ b/scipy/sparse/tests/test_array_api.py
@@ -119,3 +119,10 @@ def test_no_H_attr(A):
 def test_getrow_getcol(A):
     assert A.getcol(0)._is_array
     assert A.getrow(0)._is_array
+
+
+@parametrize_sparrays
+def test_docstr(A):
+    docstr = A.__doc__.lower()
+    for phrase in ('matrix', 'matrices'):
+        assert phrase not in docstr

--- a/scipy/sparse/tests/test_array_api.py
+++ b/scipy/sparse/tests/test_array_api.py
@@ -50,11 +50,15 @@ def test_todense(A):
 def test_indexing(A):
     if A.__class__.__name__[:3] in ('dia', 'coo', 'bsr'):
         return
-    assert A[1, :].shape == (4,)
-    assert A[:, 1].shape == (3,)
-    assert isinstance(A[0], np.ndarray), "Expected sparse array, got sparse matrix"
 
-    assert isinstance(A[1, [1, 2]], np.ndarray), "Expected ndarray, got sparse array"
+    with pytest.raises(NotImplementedError):
+        A[1, :]
+
+    with pytest.raises(NotImplementedError):
+        A[:, 1]
+
+    assert A[[0]]._is_array, "Expected sparse array, got sparse matrix"
+    assert A[1, [1, 2]]._is_array, "Expected ndarray, got sparse array"
     assert A[:, [1, 2]]._is_array, "Expected sparse array, got something else"
 
 


### PR DESCRIPTION
This PR adds matching array classes for the bsr, coo, csc, csr, dia, dok, and lil matrices,
as a thin layer on top of the existing sparse matrix implementation.

For each of the new sparse array classes, we restore element-wise
multiplication.  In the existing implementation, we switch to using the `@` operator
(instead of `*`, which behaves differently for arrays and matrices).

The existing matrix implementation often explicitly creates matrices
or sparse matrices.  To address that, we attach to each sparse array /
matrix various container attributes (`_coo_container`,
`_lil_container`, etc.).  These map to `_coo_matrix` and `_lil_matrix`
for sparse matrices, and to `_coo_array` and `_lil_array` for sparse
arrays.  Thus, the implementation can be agnostic of the container type.

For the same reason `_ascontainer` and `_container` methods are
introduced, which map to `asmatrix`/`matrix` and `asarray`/`array`
respectively.

---

One implementation detail I would like to improve is the detection of sparse arrays and matrices.  For now, that is done using `if "matrix" in self.__class__.__name__`, but that could be a problem if the user subclasses from these.

The test suite contains the failure modes I anticipated, but can be expanded to provide more thorough coverage of all basic operations.

---

Closes #7462
Closes #8162
Closes #14497