### PR TITLE
FIX: raise Python OverflowError exception on Boost.Math error

### DIFF
--- a/scipy/stats/_boost/include/func_defs.hpp
+++ b/scipy/stats/_boost/include/func_defs.hpp
@@ -39,9 +39,11 @@ RealType
 boost::math::policies::user_overflow_error(const char* function, const char* message, const RealType& val) {
     std::string msg("Error in function ");
     msg += (boost::format(function) % typeid(RealType).name()).str() + ": ";
+    // From Boost docs: "overflow and underflow messages do not contain this %1% specifier
+    //                   (since the value of value is immaterial in these cases)."
     msg += message;
     PyErr_SetString(PyExc_OverflowError, msg.c_str());
-    return val;
+    return 0;
 }
 
 

--- a/scipy/stats/_boost/include/func_defs.hpp
+++ b/scipy/stats/_boost/include/func_defs.hpp
@@ -12,11 +12,12 @@ typedef boost::math::policies::policy<
     boost::math::policies::discrete_quantile<
         boost::math::policies::integer_round_up > > Policy;
 
-// Run user_error function when evaluation_errors are encountered
+// Run user_error function when evaluation_errors and overflow_errors are encountered
 typedef boost::math::policies::policy<
-    boost::math::policies::evaluation_error<
-        boost::math::policies::user_error> > user_error_policy;
+    boost::math::policies::evaluation_error<boost::math::policies::user_error>,
+    boost::math::policies::overflow_error<boost::math::policies::user_error> > user_error_policy;
 BOOST_MATH_DECLARE_SPECIAL_FUNCTIONS(user_error_policy)
+
 
 // Raise a RuntimeWarning making users aware that something went wrong during
 // evaluation of the function, but return the best guess
@@ -29,6 +30,17 @@ boost::math::policies::user_evaluation_error(const char* function, const char* m
     // required information, so don't call boost::format for now
     msg += message;
     PyErr_WarnEx(NULL, msg.c_str(), 1);
+    return val;
+}
+
+
+template <class RealType>
+RealType
+boost::math::policies::user_overflow_error(const char* function, const char* message, const RealType& val) {
+    std::string msg("Error in function ");
+    msg += (boost::format(function) % typeid(RealType).name()).str() + ": ";
+    msg += message;
+    PyErr_SetString(PyExc_OverflowError, msg.c_str());
     return val;
 }
 

--- a/scipy/stats/_boost/setup.py
+++ b/scipy/stats/_boost/setup.py
@@ -20,6 +20,7 @@ def configuration(parent_package='', top_path=None):
         # return nan instead of throwing
         ('BOOST_MATH_DOMAIN_ERROR_POLICY', 'ignore_error'),
         ('BOOST_MATH_EVALUATION_ERROR_POLICY', 'user_error'),
+        ('BOOST_MATH_OVERFLOW_ERROR_POLICY', 'user_error'),
     ]
     if sys.maxsize > 2**32:
         # 32-bit machines lose too much precision with no promotion,

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -3,6 +3,7 @@
 # Further enhancements and tests added by numerous SciPy developers.
 #
 import warnings
+from sys import float_info
 
 import numpy as np
 from numpy.random import RandomState
@@ -747,6 +748,10 @@ class TestBinomP:
 
         res = self.binom_test_func(51, 235, p=1/6, alternative='two-sided')
         assert_almost_equal(res, 0.0437479701823997)
+
+    def test_boost_overflow_raises(self):
+        # Boost.Math error policy should raise exceptions in Python
+        assert_raises(OverflowError, self.binom_test_func, 5.0, 6, p=float_info.min)
 
 
 class TestBinomTestP(TestBinomP):

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -3,7 +3,7 @@
 # Further enhancements and tests added by numerous SciPy developers.
 #
 import warnings
-from sys import float_info
+import sys
 
 import numpy as np
 from numpy.random import RandomState
@@ -749,9 +749,10 @@ class TestBinomP:
         res = self.binom_test_func(51, 235, p=1/6, alternative='two-sided')
         assert_almost_equal(res, 0.0437479701823997)
 
+    @pytest.mark.skipif(sys.maxsize <= 2**32, reason="32-bit does not overflow")
     def test_boost_overflow_raises(self):
         # Boost.Math error policy should raise exceptions in Python
-        assert_raises(OverflowError, self.binom_test_func, 5.0, 6, p=float_info.min)
+        assert_raises(OverflowError, self.binom_test_func, 5.0, 6, p=sys.float_info.min)
 
 
 class TestBinomTestP(TestBinomP):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes gh-14704

#### What does this implement/fix?
<!--Please explain your changes.-->

- Changes Boost.Math policy to throw Python `OverflowError` on C++ overflow exception

#### Additional information
<!--Any additional information you think is important.-->
