### PR TITLE
Bug fix: dqc25f.f

### DIFF
--- a/scipy/integrate/quadpack/dqc25f.f
+++ b/scipy/integrate/quadpack/dqc25f.f
@@ -339,7 +339,7 @@ c
       do 150 j = 1,12
         resc24 = resc24+cheb24(k)*chebmo(m,k)
         ress24 = ress24+cheb24(k+1)*chebmo(m,k+1)
-        resabs = dabs(cheb24(k))+dabs(cheb24(k+1))
+        resabs = resabs+dabs(cheb24(k))+dabs(cheb24(k+1))
         k = k-2
   150 continue
       estc = dabs(resc24-resc12)


### PR DESCRIPTION
Variable "resabs" should be sum(abs(cheb24(:)))*dabs(hlgth), otherwise it doesn't make any sense.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
