### PR TITLE
DOC: optimize: add notes for max function evaluation constraint violation

### DIFF
--- a/scipy/optimize/_lbfgsb_py.py
+++ b/scipy/optimize/_lbfgsb_py.py
@@ -105,7 +105,9 @@ def fmin_l_bfgs_b(func, x0, fprime=None, args=(),
         If zero, then no output. If a positive number, then this over-rides
         `iprint` (i.e., `iprint` gets the value of `disp`).
     maxfun : int, optional
-        Maximum number of function evaluations.
+        Maximum number of function evaluations. Note that this function
+        may violate the limit because of evaluating gradients by numerical
+        differentiation.
     maxiter : int, optional
         Maximum number of iterations.
     callback : callable, optional

--- a/scipy/optimize/_tnc.py
+++ b/scipy/optimize/_tnc.py
@@ -147,7 +147,9 @@ def fmin_tnc(func, x0, fprime=None, args=(), approx_grad=0,
         max(1,min(50,n/2)). Defaults to -1.
     maxfun : int, optional
         Maximum number of function evaluation. If None, maxfun is
-        set to max(100, 10*len(x0)). Defaults to None.
+        set to max(100, 10*len(x0)). Defaults to None. Note that this function
+        may violate the limit because of evaluating gradients by numerical
+        differentiation.
     eta : float, optional
         Severity of the line search. If < 0 or > 1, set to 0.25.
         Defaults to -1.

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -534,7 +534,9 @@ def test_maxfev_test():
         return rng.random(1) * 1000  # never converged problem
 
     for imaxfev in [1, 10, 50]:
-        # TODO: extend to more methods
+        # "TNC" and "L-BFGS-B" also supports max function evaluation, but
+        # these may violate the limit because of evaluating gradients
+        # by numerical differentiation. See the discussion in PR #14805.
         for method in ['Powell', 'Nelder-Mead']:
             result = optimize.minimize(cost, rng.random(10),
                                        method=method,


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Fix #14818
Ref https://github.com/scipy/scipy/pull/14805#issuecomment-937413098

#### What does this implement/fix?
As discussed and reported in https://github.com/scipy/scipy/pull/14805#issuecomment-937413098 and #14818,
"TNC" and "L-BFGS-B" support max function evaluation constraint, but these may violate the limit because of evaluating gradients by numerical differentiation.
So, I improved the docs for clarifying the limitation.

