### PR TITLE
ENH: optimize: Add TFQMR method to approximate the inverse of the Jacobian in "Newton-Krylov" and "root"

### DIFF
--- a/scipy/optimize/_nonlin.py
+++ b/scipy/optimize/_nonlin.py
@@ -1320,8 +1320,8 @@ class KrylovJacobian(Jacobian):
     %(params_basic)s
     rdiff : float, optional
         Relative step size to use in numerical differentiation.
-    method : {'lgmres', 'gmres', 'bicgstab', 'cgs', 'minres'} or function
-        Krylov method to use to approximate the Jacobian.
+    method : {'lgmres', 'gmres', 'bicgstab', 'cgs', 'minres', 'tfqmr'} or
+        function Krylov method to use to approximate the Jacobian.
         Can be a string, or a function implementing the same interface as
         the iterative solvers in `scipy.sparse.linalg`.
 
@@ -1416,6 +1416,7 @@ class KrylovJacobian(Jacobian):
             lgmres=scipy.sparse.linalg.lgmres,
             cgs=scipy.sparse.linalg.cgs,
             minres=scipy.sparse.linalg.minres,
+            tfqmr=scipy.sparse.linalg.tfqmr,
             ).get(method, method)
 
         self.method_kw = dict(maxiter=inner_maxiter, M=self.preconditioner)

--- a/scipy/optimize/_root.py
+++ b/scipy/optimize/_root.py
@@ -684,8 +684,8 @@ def _root_krylov_doc():
 
         rdiff : float, optional
             Relative step size to use in numerical differentiation.
-        method : {'lgmres', 'gmres', 'bicgstab', 'cgs', 'minres'} or function
-            Krylov method to use to approximate the Jacobian.
+        method : {'lgmres', 'gmres', 'bicgstab', 'cgs', 'minres', 'tfqmr'} or
+            function Krylov method to use to approximate the Jacobian.
             Can be a string, or a function implementing the same
             interface as the iterative solvers in
             `scipy.sparse.linalg`.

--- a/scipy/optimize/tests/test_nonlin.py
+++ b/scipy/optimize/tests/test_nonlin.py
@@ -2,7 +2,7 @@
 Author: Ondrej Certik
 May 2007
 """
-from numpy.testing import assert_
+from numpy.testing import assert_, suppress_warnings
 import pytest
 
 from scipy.optimize import _nonlin as nonlin, root
@@ -34,6 +34,8 @@ def F(x):
 
 F.xin = [1,1,1,1,1]
 F.KNOWN_BAD = {}
+F.JAC_KSP_BAD = {}
+F.ROOT_JAC_KSP_BAD = {}
 
 
 def F2(x):
@@ -43,6 +45,8 @@ def F2(x):
 F2.xin = [1,2,3,4,5,6]
 F2.KNOWN_BAD = {'linearmixing': nonlin.linearmixing,
                 'excitingmixing': nonlin.excitingmixing}
+F2.JAC_KSP_BAD = {}
+F2.ROOT_JAC_KSP_BAD = {}
 
 
 def F2_lucky(x):
@@ -51,6 +55,8 @@ def F2_lucky(x):
 
 F2_lucky.xin = [0,0,0,0,0,0]
 F2_lucky.KNOWN_BAD = {}
+F2_lucky.JAC_KSP_BAD = {}
+F2_lucky.ROOT_JAC_KSP_BAD = {}
 
 
 def F3(x):
@@ -61,6 +67,8 @@ def F3(x):
 
 F3.xin = [1,2,3]
 F3.KNOWN_BAD = {}
+F3.JAC_KSP_BAD = {}
+F3.ROOT_JAC_KSP_BAD = {}
 
 
 def F4_powell(x):
@@ -72,6 +80,8 @@ F4_powell.xin = [-1, -2]
 F4_powell.KNOWN_BAD = {'linearmixing': nonlin.linearmixing,
                        'excitingmixing': nonlin.excitingmixing,
                        'diagbroyden': nonlin.diagbroyden}
+F4_powell.JAC_KSP_BAD = {'minres'}
+F4_powell.ROOT_JAC_KSP_BAD = {'gmres', 'bicgstab', 'cgs', 'minres', 'tfqmr'}
 
 
 def F5(x):
@@ -82,6 +92,8 @@ F5.xin = [2., 0, 2, 0]
 F5.KNOWN_BAD = {'excitingmixing': nonlin.excitingmixing,
                 'linearmixing': nonlin.linearmixing,
                 'diagbroyden': nonlin.diagbroyden}
+F5.JAC_KSP_BAD = {'cgs', 'minres'}
+F5.ROOT_JAC_KSP_BAD = {'minres'}
 
 
 def F6(x):
@@ -97,6 +109,8 @@ F6.xin = [-0.5, 1.4]
 F6.KNOWN_BAD = {'excitingmixing': nonlin.excitingmixing,
                 'linearmixing': nonlin.linearmixing,
                 'diagbroyden': nonlin.diagbroyden}
+F6.JAC_KSP_BAD = {}
+F6.ROOT_JAC_KSP_BAD = {}
 
 
 #-------------------------------------------------------------------------------
@@ -114,12 +128,34 @@ class TestNonlin:
     """
 
     def _check_nonlin_func(self, f, func, f_tol=1e-2):
+        if func == SOLVERS['krylov']:
+            # Test all methods mentioned in the class "KrylovJacobian"
+            for method in ['gmres', 'bicgstab', 'cgs', 'minres', 'tfqmr']:
+                if method in f.JAC_KSP_BAD:
+                    continue
+                with suppress_warnings() as sup:
+                    sup.filter(DeprecationWarning,
+                            ".*called without specifying")
+                    x = func(f, f.xin, method=method, line_search=None,
+                             f_tol=f_tol, maxiter=200, verbose=0)
+                assert_(np.absolute(f(x)).max() < f_tol)
         x = func(f, f.xin, f_tol=f_tol, maxiter=200, verbose=0)
         assert_(np.absolute(f(x)).max() < f_tol)
 
     def _check_root(self, f, method, f_tol=1e-2):
+        if method == 'krylov':
+            for jac_method in ['gmres', 'bicgstab', 'cgs', 'minres', 'tfqmr']:
+                if jac_method in f.ROOT_JAC_KSP_BAD:
+                    continue
+                with suppress_warnings() as sup:
+                    sup.filter(DeprecationWarning,
+                            ".*called without specifying")
+                    res = root(f, f.xin, method=method,
+                            options={'ftol': f_tol, 'maxiter': 200, 'disp': 0,
+                                     'jac_options':{'method':jac_method}})
+                assert_(np.absolute(res.fun).max() < f_tol)
         res = root(f, f.xin, method=method,
-                   options={'ftol': f_tol, 'maxiter': 200, 'disp': 0})
+                options={'ftol': f_tol, 'maxiter': 200, 'disp': 0})
         assert_(np.absolute(res.fun).max() < f_tol)
 
     @pytest.mark.xfail
@@ -135,7 +171,9 @@ class TestNonlin:
                     continue
                 self._check_nonlin_func(f, func)
 
-    def test_tol_norm_called(self):
+    @pytest.mark.parametrize("method", ['lgmres', 'gmres', 'bicgstab', 'cgs',
+                                        'minres', 'tfqmr'])
+    def test_tol_norm_called(self, method):
         # Check that supplying tol_norm keyword to nonlin_solve works
         self._tol_norm_used = False
 
@@ -143,8 +181,10 @@ class TestNonlin:
             self._tol_norm_used = True
             return np.absolute(x).max()
 
-        nonlin.newton_krylov(F, F.xin, f_tol=1e-2, maxiter=200, verbose=0,
-             tol_norm=local_norm_func)
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning, ".*called without specifying")
+            nonlin.newton_krylov(F, F.xin, method=method, f_tol=1e-2,
+                    maxiter=200, verbose=0, tol_norm=local_norm_func)
         assert_(self._tol_norm_used)
 
     def test_problem_root(self):

--- a/scipy/optimize/tests/test_nonlin.py
+++ b/scipy/optimize/tests/test_nonlin.py
@@ -135,7 +135,7 @@ class TestNonlin:
                     continue
                 with suppress_warnings() as sup:
                     sup.filter(DeprecationWarning,
-                            ".*called without specifying")
+                               ".*called without specifying")
                     x = func(f, f.xin, method=method, line_search=None,
                              f_tol=f_tol, maxiter=200, verbose=0)
                 assert_(np.absolute(f(x)).max() < f_tol)
@@ -149,13 +149,14 @@ class TestNonlin:
                     continue
                 with suppress_warnings() as sup:
                     sup.filter(DeprecationWarning,
-                            ".*called without specifying")
+                               ".*called without specifying")
                     res = root(f, f.xin, method=method,
-                            options={'ftol': f_tol, 'maxiter': 200, 'disp': 0,
-                                     'jac_options':{'method':jac_method}})
+                               options={'ftol': f_tol, 'maxiter': 200,
+                                        'disp': 0,
+                                        'jac_options': {'method': jac_method}})
                 assert_(np.absolute(res.fun).max() < f_tol)
         res = root(f, f.xin, method=method,
-                options={'ftol': f_tol, 'maxiter': 200, 'disp': 0})
+                   options={'ftol': f_tol, 'maxiter': 200, 'disp': 0})
         assert_(np.absolute(res.fun).max() < f_tol)
 
     @pytest.mark.xfail
@@ -184,7 +185,8 @@ class TestNonlin:
         with suppress_warnings() as sup:
             sup.filter(DeprecationWarning, ".*called without specifying")
             nonlin.newton_krylov(F, F.xin, method=method, f_tol=1e-2,
-                    maxiter=200, verbose=0, tol_norm=local_norm_func)
+                                 maxiter=200, verbose=0,
+                                 tol_norm=local_norm_func)
         assert_(self._tol_norm_used)
 
     def test_problem_root(self):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
In this PR, just like GMRES etc., TFQMR method can be used to approximate the inverse of the Jacobian in the process of solving nonlinear equations using Newton-Krylov method and finding root.

#### Additional information
<!--Any additional information you think is important.-->
