### PR TITLE
BUG: stats: Fix a crash in stats.skew

### DIFF
--- a/scipy/stats/_mstats_basic.py
+++ b/scipy/stats/_mstats_basic.py
@@ -2561,6 +2561,7 @@ def skew(a, axis=0, bias=True):
         n = a.count(axis)
         can_correct = ~zero & (n > 2)
         if can_correct.any():
+            n = np.extract(can_correct, n)
             m2 = np.extract(can_correct, m2)
             m3 = np.extract(can_correct, m3)
             nval = ma.sqrt((n-1.0)*n)/(n-2.0)*m3/m2**1.5

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -668,6 +668,32 @@ class TestMoments:
         y = mstats.skew(self.testcase)
         assert_almost_equal(y,0.0,10)
 
+        # test that skew works on multidimensional masked arrays
+        correct_2d = ma.array(
+            np.array([0.6882870394455785, 0, 0.2665647526856708,
+                      0, -0.05211472114254485]),
+            mask=np.array([False, False, False, True, False], dtype=bool)
+        )
+        assert_array_almost_equal(mstats.skew(self.testcase_2d, 1), correct_2d)
+        for i, row in enumerate(self.testcase_2d):
+            assert_almost_equal(mstats.skew(row), correct_2d[i])
+
+        correct_2d_bias_corrected = ma.array(
+            np.array([1.685952043212545, 0.0, 0.3973712716070531, 0,
+                      -0.09026534484117164]),
+            mask=np.array([False, False, False, True, False], dtype=bool)
+        )
+        assert_array_almost_equal(mstats.skew(self.testcase_2d, 1, bias=False),
+                                  correct_2d_bias_corrected)
+        for i, row in enumerate(self.testcase_2d):
+            assert_almost_equal(mstats.skew(row, bias=False),
+                                correct_2d_bias_corrected[i])
+
+        # Check consistency between stats and mstats implementations
+        assert_array_almost_equal_nulp(mstats.skew(self.testcase_2d[2, :]),
+                                       stats.skew(self.testcase_2d[2, :]),
+                                       nulp=4)
+
     def test_kurtosis(self):
         # Set flags for axis = 0 and fisher=0 (Pearson's definition of kurtosis
         # for compatibility with Matlab)

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -674,7 +674,7 @@ class TestMoments:
                       0, -0.05211472114254485]),
             mask=np.array([False, False, False, True, False], dtype=bool)
         )
-        assert_array_almost_equal(mstats.skew(self.testcase_2d, 1), correct_2d)
+        assert_allclose(mstats.skew(self.testcase_2d, 1), correct_2d)
         for i, row in enumerate(self.testcase_2d):
             assert_almost_equal(mstats.skew(row), correct_2d[i])
 
@@ -683,16 +683,15 @@ class TestMoments:
                       -0.09026534484117164]),
             mask=np.array([False, False, False, True, False], dtype=bool)
         )
-        assert_array_almost_equal(mstats.skew(self.testcase_2d, 1, bias=False),
-                                  correct_2d_bias_corrected)
+        assert_allclose(mstats.skew(self.testcase_2d, 1, bias=False),
+                        correct_2d_bias_corrected)
         for i, row in enumerate(self.testcase_2d):
             assert_almost_equal(mstats.skew(row, bias=False),
                                 correct_2d_bias_corrected[i])
 
         # Check consistency between stats and mstats implementations
-        assert_array_almost_equal_nulp(mstats.skew(self.testcase_2d[2, :]),
-                                       stats.skew(self.testcase_2d[2, :]),
-                                       nulp=4)
+        assert_allclose(mstats.skew(self.testcase_2d[2, :]),
+                        stats.skew(self.testcase_2d[2, :]))
 
     def test_kurtosis(self):
         # Set flags for axis = 0 and fisher=0 (Pearson's definition of kurtosis


### PR DESCRIPTION
Reproducing code

```python
import numpy as np
from scipy.stats import skew

z = np.arange(12).reshape(4, 3).astype(float)
z[2:, 1] = np.nan

skew(z, bias=False, nan_policy='omit')
```

In scipy 1.7.1 this throws `ValueError: operands could not be broadcast together with shapes (3,) (2,)`