### PR TITLE
DOC:linalg: Clarify driver defaults in eigh

### DIFF
--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -313,6 +313,8 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
         Defines which LAPACK driver should be used. Valid options are "ev",
         "evd", "evr", "evx" for standard problems and "gv", "gvd", "gvx" for
         generalized (where b is not None) problems. See the Notes section.
+        The default for standard problems is "evr". For generalized problems,
+        "gvd" is used for full set, and "gvx" for subset requested cases.
     type : int, optional
         For the generalized problems, this keyword specifies the problem type
         to be solved for ``w`` and ``v`` (only takes 1, 2, 3 as possible


### PR DESCRIPTION
This is a reissue of #14874 to avoid the merge conflicts with #14872 

#### Reference issue
Closes #14873 


#### What does this implement/fix?
Added the missing default options to the eigh `driver` keyword docstring.

The CI has run already in #14874 hence will merge straightaway.