### PR TITLE
MAINT: Improve cdist alignment error message

### DIFF
--- a/scipy/spatial/src/distance_pybind.cpp
+++ b/scipy/spatial/src/distance_pybind.cpp
@@ -226,7 +226,10 @@ ArrayDescriptor get_descriptor(const py::array& arr) {
     desc.strides.assign(arr_strides, arr_strides + ndim);
     for (intptr_t i = 0; i < ndim; ++i) {
         if (desc.strides[i] % desc.element_size != 0) {
-            throw std::runtime_error("Arrays must be aligned");
+            std::stringstream msg;
+            msg << "Arrays must be aligned to element size, but found stride of ";
+            msg << desc.strides[i] << " bytes for elements of size " << desc.element_size;
+            throw std::runtime_error(msg.str());
         }
         desc.strides[i] /= desc.element_size;
     }


### PR DESCRIPTION
#### Reference issue
This should help to debug MacPython/scipy-wheels#132

#### What does this implement/fix?
This has the error message include the offending stride so we can hopefully see why the check is failing.

cc @tupui 

