### PR TITLE
BUG: Fix alignment errors due to relaxed stride checking

### DIFF
--- a/scipy/spatial/src/distance_pybind.cpp
+++ b/scipy/spatial/src/distance_pybind.cpp
@@ -225,6 +225,13 @@ ArrayDescriptor get_descriptor(const py::array& arr) {
     const auto arr_strides = arr.strides();
     desc.strides.assign(arr_strides, arr_strides + ndim);
     for (intptr_t i = 0; i < ndim; ++i) {
+        if (arr_shape[i] <= 1) {
+            // Under NumPy's relaxed stride checking, dimensions with
+            // 1 or fewer elements are ignored.
+            desc.strides[i] = 0;
+            continue;
+        }
+
         if (desc.strides[i] % desc.element_size != 0) {
             std::stringstream msg;
             msg << "Arrays must be aligned to element size, but found stride of ";


### PR DESCRIPTION
#### Reference issue
Fixes errors in https://github.com/MacPython/scipy-wheels/pull/132

#### What does this implement/fix?
NumPy's relaxed stride checking explicitly ignores length-1 dimensions, so if we don't as well then there will be false-positives as we were seeing in the windows build with python 3.10.
https://github.com/numpy/numpy/blob/5cb560616abe44774d897a80970775d2a26bb03b/numpy/core/src/common/array_assign.c#L114-L118

