### PR TITLE
DOC: update diags parameter in `spdiags` docstring

### DIFF
--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -32,9 +32,9 @@ def spdiags(data, diags, m, n, format=None):
         Matrix diagonals stored row-wise
     diags : sequence of int or an int
         Diagonals to set:
-          - k = 0  the main diagonal
-          - k > 0  the kth upper diagonal
-          - k < 0  the kth lower diagonal
+        * k = 0  the main diagonal
+        * k > 0  the kth upper diagonal
+        * k < 0  the kth lower diagonal
     m, n : int
         Shape of the result
     format : str, optional

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -32,6 +32,7 @@ def spdiags(data, diags, m, n, format=None):
         Matrix diagonals stored row-wise
     diags : sequence of int or an int
         Diagonals to set:
+
         * k = 0  the main diagonal
         * k > 0  the kth upper diagonal
         * k < 0  the kth lower diagonal

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -29,14 +29,14 @@ def spdiags(data, diags, m, n, format=None):
     Parameters
     ----------
     data : array_like
-        matrix diagonals stored row-wise
+        Matrix diagonals stored row-wise
     diags : sequence of int or an int
         Diagonals to set:
           - k = 0  the main diagonal
           - k > 0  the kth upper diagonal
           - k < 0  the kth lower diagonal
     m, n : int
-        shape of the result
+        Shape of the result
     format : str, optional
         Format of the result. By default (format=None) an appropriate sparse
         matrix format is returned. This choice is subject to change.

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -30,10 +30,11 @@ def spdiags(data, diags, m, n, format=None):
     ----------
     data : array_like
         matrix diagonals stored row-wise
-    diags : diagonals to set
-        - k = 0  the main diagonal
-        - k > 0  the k-th upper diagonal
-        - k < 0  the k-th lower diagonal
+    diags : sequence of int or an int
+        Diagonals to set:
+          - k = 0  the main diagonal
+          - k > 0  the kth upper diagonal
+          - k < 0  the kth lower diagonal
     m, n : int
         shape of the result
     format : str, optional


### PR DESCRIPTION
The description of the `diags` parameter in the `spdiags` docstring seems to have crept up into the line that is supposed to describe the parameter type.