### PR TITLE
MAINT:linalg: Rename func to "bandwidth"

### DIFF
--- a/scipy/linalg/__init__.py
+++ b/scipy/linalg/__init__.py
@@ -45,7 +45,7 @@ Basics
    orthogonal_procrustes - Solve an orthogonal Procrustes problem
    matrix_balance - Balance matrix entries with a similarity transformation
    subspace_angles - Compute the subspace angles between two matrices
-   get_array_bandwidth - Return the lower and upper bandwidth of an array
+   bandwidth - Return the lower and upper bandwidth of an array
    issymmetric - Check if a square 2D array is symmetric
    ishermitian - Check if a square 2D array is Hermitian
    LinAlgError

--- a/scipy/linalg/_cythonized_array_utils.pyi
+++ b/scipy/linalg/_cythonized_array_utils.pyi
@@ -1,7 +1,7 @@
 from numpy.typing import NDArray
 from typing import Any, Tuple
 
-def get_array_bandwidth(a: NDArray[Any]) -> Tuple[int, int]: ...
+def bandwidth(a: NDArray[Any]) -> Tuple[int, int]: ...
 
 def issymmetric(
     a: NDArray[Any],

--- a/scipy/linalg/_cythonized_array_utils.pyx
+++ b/scipy/linalg/_cythonized_array_utils.pyx
@@ -22,11 +22,11 @@ ctypedef fused np_complex_numeric_t:
     cnp.complex64_t
     cnp.complex128_t
 
-__all__ = ['get_array_bandwidth', 'issymmetric', 'ishermitian']
+__all__ = ['bandwidth', 'issymmetric', 'ishermitian']
 
 
 @cython.embedsignature(True)
-def get_array_bandwidth(a):
+def bandwidth(a):
     """Return the lower and upper bandwidth of a 2D numeric array.
 
     Parameters
@@ -66,13 +66,13 @@ def get_array_bandwidth(a):
 
     Examples
     --------
-    >>> from scipy.linalg import get_array_bandwidth
+    >>> from scipy.linalg import bandwidth
     >>> A = np.array([[3., 0., 0., 0., 0.],
     ...               [0., 4., 0., 0., 0.],
     ...               [0., 0., 5., 1., 0.],
     ...               [8., 0., 0., 6., 2.],
     ...               [0., 9., 0., 0., 7.]])
-    >>> get_array_bandwidth(A)
+    >>> bandwidth(A)
     (3, 1)
 
     """
@@ -83,17 +83,17 @@ def get_array_bandwidth(a):
         raise ValueError('Input array must be a 2D NumPy array.')
 
     if a.flags['C_CONTIGUOUS']:
-        l, u = get_array_bandwidth_c(a)
+        l, u = bandwidth_c(a)
     elif a.flags['F_CONTIGUOUS']:
-        u, l = get_array_bandwidth_c(a.T)
+        u, l = bandwidth_c(a.T)
     else:
-        l, u = get_array_bandwidth_noncontig(a)
+        l, u = bandwidth_noncontig(a)
 
     return l, u
 
 
 @cython.initializedcheck(False)
-def get_array_bandwidth_c(np_numeric_t[:, ::1]A):
+def bandwidth_c(np_numeric_t[:, ::1]A):
     cdef int l, u
     with nogil:
         l, u = band_check_internal_c(A)
@@ -101,7 +101,7 @@ def get_array_bandwidth_c(np_numeric_t[:, ::1]A):
 
 
 @cython.initializedcheck(False)
-def get_array_bandwidth_noncontig(np_numeric_t[:, :]A):
+def bandwidth_noncontig(np_numeric_t[:, :]A):
     cdef int l, u
     with nogil:
         l, u = band_check_internal_noncontig(A)

--- a/scipy/linalg/tests/test_cythonized_array_utils.py
+++ b/scipy/linalg/tests/test_cythonized_array_utils.py
@@ -1,31 +1,31 @@
 import numpy as np
-from scipy.linalg import get_array_bandwidth, issymmetric, ishermitian
+from scipy.linalg import bandwidth, issymmetric, ishermitian
 import pytest
 from pytest import raises
 
 
-def test_get_array_bandwidth_dtypes():
+def test_bandwidth_dtypes():
     n = 5
     for t in np.typecodes['All']:
         A = np.zeros([n, n], dtype=t)
         if t in 'eUVOMm':
-            raises(TypeError, get_array_bandwidth, A)
+            raises(TypeError, bandwidth, A)
         elif t == 'G':  # No-op test. On win these pass on others fail.
             pass
         else:
-            _ = get_array_bandwidth(A)
+            _ = bandwidth(A)
 
 
-def test_get_array_bandwidth_non2d_input():
+def test_bandwidth_non2d_input():
     A = np.array([1, 2, 3])
-    raises(ValueError, get_array_bandwidth, A)
+    raises(ValueError, bandwidth, A)
     A = np.array([[[1, 2, 3], [4, 5, 6]]])
-    raises(ValueError, get_array_bandwidth, A)
+    raises(ValueError, bandwidth, A)
 
 
 @pytest.mark.parametrize('T', [x for x in np.typecodes['All']
                                if x not in 'eGUVOMm'])
-def test_get_array_bandwidth_square_inputs(T):
+def test_bandwidth_square_inputs(T):
     n = 20
     k = 4
     R = np.zeros([n, n], dtype=T, order='F')
@@ -34,12 +34,12 @@ def test_get_array_bandwidth_square_inputs(T):
     R[[x for x in range(n-k)], [x for x in range(k, n)]] = 1
     R[[x for x in range(1, n)], [x for x in range(n-1)]] = 1
     R[[x for x in range(k, n)], [x for x in range(n-k)]] = 1
-    assert get_array_bandwidth(R) == (k, k)
+    assert bandwidth(R) == (k, k)
 
 
 @pytest.mark.parametrize('T', [x for x in np.typecodes['All']
                                if x not in 'eGUVOMm'])
-def test_get_array_bandwidth_rect_inputs(T):
+def test_bandwidth_rect_inputs(T):
     n, m = 10, 20
     k = 5
     R = np.zeros([n, m], dtype=T, order='F')
@@ -48,7 +48,7 @@ def test_get_array_bandwidth_rect_inputs(T):
     R[[x for x in range(n-k)], [x for x in range(k, n)]] = 1
     R[[x for x in range(1, n)], [x for x in range(n-1)]] = 1
     R[[x for x in range(k, n)], [x for x in range(n-k)]] = 1
-    assert get_array_bandwidth(R) == (k, k)
+    assert bandwidth(R) == (k, k)
 
 
 def test_issymetric_ishermitian_dtypes():


### PR DESCRIPTION

#### Reference issue
#14701

#### What does this implement/fix?
As discussed in the linked issue and on the mailing list the function `get_array_bandwidth` is renamed to `bandwidth`

