### PR TITLE
BUG: spatial: improve dtype stability for all distance metrics

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -296,7 +296,7 @@ def _validate_seuclidean_kwargs(X, m, n, **kwargs):
 
 def _validate_vector(u, dtype=None):
 
-    if dtype is None:
+    if dtype is None and type(u) is np.ndarray:
         # Preserves float dtypes, but convert everything else to np.float64
         # for stability only when the dtype is not a subtype of inexact
         # or the dtype is not string.

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -302,7 +302,7 @@ def _validate_vector(u, dtype=None):
         # or the dtype is not string.
         if not (hasattr(u, "dtype") and
                 (np.issubdtype(u.dtype, np.inexact)
-                 or (u.dtype.kind == 'S'))):
+                 or (np.issubdtype(u.dtype, np.character)))):
             dtype = np.float64
 
     # XXX Is order='c' really necessary?

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -296,10 +296,11 @@ def _validate_seuclidean_kwargs(X, m, n, **kwargs):
 
 def _validate_vector(u, dtype=None):
 
-    if dtype is None and type(u) is np.ndarray:
+    if dtype is None:
         # Preserves float dtypes, but convert everything else to np.float64
         # for stability only when the dtype is not a subtype of inexact
         # or the dtype is not string.
+        u = np.asarray(u)
         if not (np.issubdtype(u.dtype, np.inexact)
                 or (np.issubdtype(u.dtype, np.character))):
             dtype = np.float64

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -295,7 +295,6 @@ def _validate_seuclidean_kwargs(X, m, n, **kwargs):
 
 
 def _validate_vector(u, dtype=None):
-
     # XXX Is order='c' really necessary?
     u = np.asarray(u, dtype=dtype, order='c')
     if u.ndim == 1:

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -300,9 +300,8 @@ def _validate_vector(u, dtype=None):
         # Preserves float dtypes, but convert everything else to np.float64
         # for stability only when the dtype is not a subtype of inexact
         # or the dtype is not string.
-        if not (hasattr(u, "dtype") and
-                (np.issubdtype(u.dtype, np.inexact)
-                 or (np.issubdtype(u.dtype, np.character)))):
+        if not (np.issubdtype(u.dtype, np.inexact)
+                or (np.issubdtype(u.dtype, np.character))):
             dtype = np.float64
 
     # XXX Is order='c' really necessary?

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -295,6 +295,16 @@ def _validate_seuclidean_kwargs(X, m, n, **kwargs):
 
 
 def _validate_vector(u, dtype=None):
+
+    if dtype is None:
+        # Preserves float dtypes, but convert everything else to np.float64
+        # for stability only when the dtype is not a subtype of inexact
+        # or the dtype is not string.
+        if not (hasattr(u, "dtype") and
+                (np.issubdtype(u.dtype, np.inexact)
+                 or (u.dtype.kind == 'S'))):
+            dtype = np.float64
+
     # XXX Is order='c' really necessary?
     u = np.asarray(u, dtype=dtype, order='c')
     if u.ndim == 1:
@@ -564,16 +574,8 @@ def sqeuclidean(u, v, w=None):
     1.0
 
     """
-    # Preserve float dtypes, but convert everything else to np.float64
-    # for stability.
-    utype, vtype = None, None
-    if not (hasattr(u, "dtype") and np.issubdtype(u.dtype, np.inexact)):
-        utype = np.float64
-    if not (hasattr(v, "dtype") and np.issubdtype(v.dtype, np.inexact)):
-        vtype = np.float64
-
-    u = _validate_vector(u, dtype=utype)
-    v = _validate_vector(v, dtype=vtype)
+    u = _validate_vector(u)
+    v = _validate_vector(v)
     u_v = u - v
     u_v_w = u_v  # only want weights applied once
     if w is not None:

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -296,15 +296,6 @@ def _validate_seuclidean_kwargs(X, m, n, **kwargs):
 
 def _validate_vector(u, dtype=None):
 
-    if dtype is None:
-        # Preserves float dtypes, but convert everything else to np.float64
-        # for stability only when the dtype is not a subtype of inexact
-        # or the dtype is not string.
-        u = np.asarray(u)
-        if not (np.issubdtype(u.dtype, np.inexact)
-                or (np.issubdtype(u.dtype, np.character))):
-            dtype = np.float64
-
     # XXX Is order='c' really necessary?
     u = np.asarray(u, dtype=dtype, order='c')
     if u.ndim == 1:
@@ -320,6 +311,19 @@ def _validate_vector(u, dtype=None):
         DeprecationWarning)
     return u
 
+
+def _validate_real_vector(u, dtype=None):
+
+    if dtype is None:
+        # Preserves float dtypes, but convert everything else to np.float64
+        # for stability only when the dtype is not a subtype of inexact
+        # or the dtype is not string.
+        u = np.asarray(u)
+        if not (np.issubdtype(u.dtype, np.inexact)
+                or (np.issubdtype(u.dtype, np.character))):
+            dtype = np.float64
+
+    return _validate_vector(u, dtype=dtype)
 
 def _validate_weights(w, dtype=np.double):
     w = _validate_vector(w, dtype=dtype)
@@ -478,8 +482,8 @@ def minkowski(u, v, p=2, w=None):
     1.0
 
     """
-    u = _validate_vector(u)
-    v = _validate_vector(v)
+    u = _validate_real_vector(u)
+    v = _validate_real_vector(v)
     if p <= 0:
         raise ValueError("p must be greater than 0")
     u_v = u - v
@@ -574,8 +578,8 @@ def sqeuclidean(u, v, w=None):
     1.0
 
     """
-    u = _validate_vector(u)
-    v = _validate_vector(v)
+    u = _validate_real_vector(u)
+    v = _validate_real_vector(v)
     u_v = u - v
     u_v_w = u_v  # only want weights applied once
     if w is not None:
@@ -617,8 +621,8 @@ def correlation(u, v, w=None, centered=True):
         The correlation distance between 1-D array `u` and `v`.
 
     """
-    u = _validate_vector(u)
-    v = _validate_vector(v)
+    u = _validate_real_vector(u)
+    v = _validate_real_vector(v)
     if w is not None:
         w = _validate_weights(w)
     if centered:
@@ -969,9 +973,9 @@ def seuclidean(u, v, V):
     3.1780497164141406
 
     """
-    u = _validate_vector(u)
-    v = _validate_vector(v)
-    V = _validate_vector(V, dtype=np.float64)
+    u = _validate_real_vector(u)
+    v = _validate_real_vector(v)
+    V = _validate_real_vector(V, dtype=np.float64)
     if V.shape[0] != u.shape[0] or u.shape[0] != v.shape[0]:
         raise TypeError('V must be a 1-D array of the same dimension '
                         'as u and v.')
@@ -1015,8 +1019,8 @@ def cityblock(u, v, w=None):
     1
 
     """
-    u = _validate_vector(u)
-    v = _validate_vector(v)
+    u = _validate_real_vector(u)
+    v = _validate_real_vector(v)
     l1_diff = abs(u - v)
     if w is not None:
         w = _validate_weights(w)
@@ -1063,8 +1067,8 @@ def mahalanobis(u, v, VI):
     1.7320508075688772
 
     """
-    u = _validate_vector(u)
-    v = _validate_vector(v)
+    u = _validate_real_vector(u)
+    v = _validate_real_vector(v)
     VI = np.atleast_2d(VI)
     delta = u - v
     m = np.dot(np.dot(delta, VI), delta)
@@ -1105,8 +1109,8 @@ def chebyshev(u, v, w=None):
     1
 
     """
-    u = _validate_vector(u)
-    v = _validate_vector(v)
+    u = _validate_real_vector(u)
+    v = _validate_real_vector(v)
     if w is not None:
         w = _validate_weights(w)
         has_weight = w > 0
@@ -1153,8 +1157,8 @@ def braycurtis(u, v, w=None):
     0.33333333333333331
 
     """
-    u = _validate_vector(u)
-    v = _validate_vector(v, dtype=np.float64)
+    u = _validate_real_vector(u)
+    v = _validate_real_vector(v, dtype=np.float64)
     l1_diff = abs(u - v)
     l1_sum = abs(u + v)
     if w is not None:
@@ -1204,8 +1208,8 @@ def canberra(u, v, w=None):
     1.0
 
     """
-    u = _validate_vector(u)
-    v = _validate_vector(v, dtype=np.float64)
+    u = _validate_real_vector(u)
+    v = _validate_real_vector(v, dtype=np.float64)
     if w is not None:
         w = _validate_weights(w)
     with np.errstate(invalid='ignore'):

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -1966,7 +1966,7 @@ def test_hamming_unequal_length():
     assert_raises(ValueError, whamming, x, y)
 
 
-def test_hamming_string_array():
+def test_hamming_string_array_and_list():
     # https://github.com/scikit-learn/scikit-learn/issues/4014
     a = np.array(['eggs', 'spam', 'spam', 'eggs', 'spam', 'spam', 'spam',
                   'spam', 'spam', 'spam', 'spam', 'eggs', 'eggs', 'spam',
@@ -1978,6 +1978,7 @@ def test_hamming_string_array():
                   dtype='|S4')
     desired = 0.45
     assert_allclose(whamming(a, b), desired)
+    assert_allclose(whamming(a.tolist(), b.tolist()), desired)
 
 
 def test_minkowski_w():
@@ -2187,7 +2188,7 @@ def test_jensenshannon():
                         [0.1402339, 0.0399106, 0.0201815])
 
 
-def test_dtype_distance_consistency():
+def test_dtype_array_distance_consistency():
     rnd = np.random.RandomState(1234)
     vi = np.eye(100)
     vo = np.ones(100)
@@ -2210,3 +2211,24 @@ def test_dtype_distance_consistency():
             else:
                 assert_almost_equal(metric(a, b),
                                     metric(a.astype(float), b.astype(float)))
+
+
+def test_dtype_list_distance_consistency():
+    ai = [0, 1, 2]
+    bi = [3, 4, 5]
+    af = [0.0, 1.0, 2.0]
+    bf = [3.0, 4.0, 5.0]
+    vi = np.eye(3)
+    vo = [1.0, 1.0, 1.0]
+
+    for metric in [cosine, euclidean, correlation, braycurtis,
+                   canberra, chebyshev, cityblock, jensenshannon,
+                   minkowski, sqeuclidean, mahalanobis,
+                   seuclidean]:
+        if metric == mahalanobis:
+            assert_almost_equal(metric(ai, bi, vi), metric(af, bf, vi))
+        elif metric == seuclidean:
+            assert_almost_equal(metric(ai, bi, vo), metric(af, bf, vo))
+        else:
+            assert_almost_equal(metric(ai, bi), metric(af, bf))
+

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -2231,4 +2231,3 @@ def test_dtype_list_distance_consistency():
             assert_almost_equal(metric(ai, bi, vo), metric(af, bf, vo))
         else:
             assert_almost_equal(metric(ai, bi), metric(af, bf))
-

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -2193,9 +2193,14 @@ def test_dtype_array_distance_consistency():
     vi = np.eye(100)
     vo = np.ones(100)
 
+    class C(np.ndarray):
+        pass
+
     for dtype in [np.int8, np.int16, np.int32, np.int64]:
         a = rnd.randint(100, size=100, dtype=dtype)
         b = rnd.randint(100, size=100, dtype=dtype)
+        c_arr_a = a.view(C)
+        c_arr_b = b.view(C)
 
         for metric in [cosine, euclidean, correlation, braycurtis, canberra,
                        chebyshev, cityblock, jensenshannon, minkowski,
@@ -2203,12 +2208,34 @@ def test_dtype_array_distance_consistency():
             if metric == mahalanobis:
                 assert_allclose(metric(a, b, vi),
                                 metric(a.astype(float), b.astype(float), vi))
+                assert_allclose(metric(a, b, vi),
+                                metric(c_arr_a, c_arr_b, vi))
+                assert_allclose(metric(a, b, vi),
+                                metric(c_arr_a.tolist(), c_arr_b.tolist(),
+                                       vi))
+                assert(isinstance(metric(a, b, vi),
+                                  type(metric(c_arr_a.tolist(),
+                                              c_arr_b.tolist(), vi))))
             elif metric == seuclidean:
                 assert_allclose(metric(a, b, vo),
                                 metric(a.astype(float), b.astype(float), vo))
+                assert_allclose(metric(a, b, vo), metric(c_arr_a, c_arr_b,
+                                                         vo))
+                assert_allclose(metric(a, b, vo),
+                                metric(c_arr_a.tolist(), c_arr_b.tolist(),
+                                       vo))
+                assert(isinstance(metric(a, b, vo),
+                                  type(metric(c_arr_a.tolist(),
+                                              c_arr_b.tolist(), vo))))
             else:
                 assert_allclose(metric(a, b),
                                 metric(a.astype(float), b.astype(float)))
+                assert_allclose(metric(a, b), metric(c_arr_a, c_arr_b))
+                assert_allclose(metric(a, b),
+                                metric(c_arr_a.tolist(), c_arr_b.tolist()))
+                assert(isinstance(metric(a, b),
+                                  type(metric(c_arr_a.tolist(),
+                                              c_arr_b.tolist()))))
 
 
 def test_dtype_list_distance_consistency():

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -2185,3 +2185,28 @@ def test_jensenshannon():
                         [0.1954288, 0.1447697, 0.1138377, 0.0927636])
     assert_almost_equal(jensenshannon(a, b, axis=1),
                         [0.1402339, 0.0399106, 0.0201815])
+
+
+def test_dtype_distance_consistency():
+    rnd = np.random.RandomState(1234)
+    vi = np.eye(100)
+    vo = np.ones(100)
+
+    for dtype in [np.int8, np.int16, np.int32, np.int64]:
+        a = rnd.randint(100, size=100, dtype=dtype)
+        b = rnd.randint(100, size=100, dtype=dtype)
+
+        for metric in [cosine, euclidean, correlation, braycurtis, canberra,
+                       chebyshev, cityblock, jensenshannon, minkowski,
+                       sqeuclidean, mahalanobis, seuclidean]:
+            if metric == mahalanobis:
+                assert_almost_equal(metric(a, b, vi),
+                                    metric(a.astype(float), b.astype(float),
+                                           vi))
+            elif metric == seuclidean:
+                assert_almost_equal(metric(a, b, vo),
+                                    metric(a.astype(float), b.astype(float),
+                                           vo))
+            else:
+                assert_almost_equal(metric(a, b),
+                                    metric(a.astype(float), b.astype(float)))

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -2201,16 +2201,14 @@ def test_dtype_array_distance_consistency():
                        chebyshev, cityblock, jensenshannon, minkowski,
                        sqeuclidean, mahalanobis, seuclidean]:
             if metric == mahalanobis:
-                assert_almost_equal(metric(a, b, vi),
-                                    metric(a.astype(float), b.astype(float),
-                                           vi))
+                assert_allclose(metric(a, b, vi),
+                                metric(a.astype(float), b.astype(float), vi))
             elif metric == seuclidean:
-                assert_almost_equal(metric(a, b, vo),
-                                    metric(a.astype(float), b.astype(float),
-                                           vo))
+                assert_allclose(metric(a, b, vo),
+                                metric(a.astype(float), b.astype(float), vo))
             else:
-                assert_almost_equal(metric(a, b),
-                                    metric(a.astype(float), b.astype(float)))
+                assert_allclose(metric(a, b),
+                                metric(a.astype(float), b.astype(float)))
 
 
 def test_dtype_list_distance_consistency():
@@ -2226,8 +2224,8 @@ def test_dtype_list_distance_consistency():
                    minkowski, sqeuclidean, mahalanobis,
                    seuclidean]:
         if metric == mahalanobis:
-            assert_almost_equal(metric(ai, bi, vi), metric(af, bf, vi))
+            assert_allclose(metric(ai, bi, vi), metric(af, bf, vi))
         elif metric == seuclidean:
-            assert_almost_equal(metric(ai, bi, vo), metric(af, bf, vo))
+            assert_allclose(metric(ai, bi, vo), metric(af, bf, vo))
         else:
-            assert_almost_equal(metric(ai, bi), metric(af, bf))
+            assert_allclose(metric(ai, bi), metric(af, bf))


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
fix #9961

#### What does this implement/fix?
<!--Please explain your changes.-->
As reported in #9961, current distance metric functions might have different results with different dtypes (integer vs float).
So, I moved the type conversion codes from `sqeuclidean` to `_validate_vector` in order to apply it for every distance metric.
I added a test for it.

