### PR TITLE
CI: pin pyparsing for doc build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,8 @@ jobs:
             pip install -r doc_requirements.txt
             pip install nose mpmath argparse Pillow asv pythran
             pip install pybind11
+            # temporary pin for gh-14911
+            pip install pyparsing==2.4.7
 
       - run:
           name: build SciPy


### PR DESCRIPTION
* temporary workaround for gh-14911 to see if
it gets CI doc build green again