### PR TITLE
MAINT: "backport" 3.10 support

### DIFF
--- a/doc/source/dev/toolchain.rst
+++ b/doc/source/dev/toolchain.rst
@@ -79,6 +79,7 @@ The table shows the NumPy versions suitable for each major Python version
 3.7                  1.16.5                     >= 1.20.x
 3.8                  1.17.3                     >= 1.20.x
 3.9                  1.19.3                     >= 1.20.x
+3.10                 1.21.3                     >= 1.21.x
 =================  ========================    ===========================
 
 
@@ -151,7 +152,7 @@ CPython               MS Visual C++    C Standard
 2.7, 3.0, 3.1, 3.2       9.0           C90
 3.3, 3.4                10.0           C90 & some of C99
 3.5, 3.6                14.0           C90 & most of C99
-3.7, 3.8, 3.9           15.7           Dependent on MSVC version used to build SciPy
+3.7, 3.8, 3.9, 3.10     15.7           Dependent on MSVC version used to build SciPy
 ===================   ==============   =============================================
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ requires = [
     "numpy==1.16.5; python_version=='3.7' and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'",
     "numpy==1.17.3; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_python_implementation != 'PyPy'",
     "numpy==1.19.3; python_version=='3.9' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_python_implementation != 'PyPy'",
-    "numpy==1.21.2; python_version=='3.10' and platform_python_implementation != 'PyPy'",
+    "numpy==1.21.3; python_version=='3.10' and platform_python_implementation != 'PyPy'",
 
     # First PyPy versions for which there are numpy wheels
     "numpy==1.20.0; python_version=='3.7' and platform_python_implementation=='PyPy'",
@@ -49,7 +49,7 @@ maintainers = [
 # Note: Python and NumPy upper version bounds should be set correctly in
 # release branches, see:
 #     https://scipy.github.io/devdocs/dev/core-dev/index.html#version-ranges-for-numpy-and-other-dependencies
-requires-python = ">=3.7,<3.10"
+requires-python = ">=3.7,<3.11"
 dependencies = [
     "numpy>=1.16.5,<1.24.0",
 ]

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ Programming Language :: Python :: 3
 Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
 Programming Language :: Python :: 3.9
+Programming Language :: Python :: 3.10
 Topic :: Software Development :: Libraries
 Topic :: Scientific/Engineering
 Operating System :: Microsoft :: Windows

--- a/setup.py
+++ b/setup.py
@@ -550,7 +550,7 @@ def setup_package():
     np_minversion = '1.16.5'
     np_maxversion = '1.23.0'
     python_minversion = '3.7'
-    python_maxversion = '3.10'
+    python_maxversion = '3.11'
     if IS_RELEASE_BRANCH:
         req_np = 'numpy>={},<{}'.format(np_minversion, np_maxversion)
         req_py = '>={},<{}'.format(python_minversion, python_maxversion)


### PR DESCRIPTION
* changes related to enabling Python `3.10` support
on the `maintenance/1.7.x` branch based on failures
in the wheels repo here:
https://github.com/MacPython/scipy-wheels/pull/135