### PR TITLE
Fix extent for scipy.signal.cwt example

### DIFF
--- a/scipy/signal/wavelets.py
+++ b/scipy/signal/wavelets.py
@@ -452,7 +452,7 @@ def cwt(data, wavelet, widths, dtype=None, **kwargs):
     >>> sig  = np.cos(2 * np.pi * 7 * t) + signal.gausspulse(t - 0.4, fc=2)
     >>> widths = np.arange(1, 31)
     >>> cwtmatr = signal.cwt(sig, signal.ricker, widths)
-    >>> plt.imshow(cwtmatr, extent=[-1, 1, 1, 31], cmap='PRGn', aspect='auto',
+    >>> plt.imshow(cwtmatr, extent=[-1, 1, 31, 1], cmap='PRGn', aspect='auto',
     ...            vmax=abs(cwtmatr).max(), vmin=-abs(cwtmatr).max())
     >>> plt.show()
     """


### PR DESCRIPTION
Extent is oriented [bottom, top] as opposed to array input data which is oriented [top, bottom]. This conveys the wrong message on how CWT actually works by misrepresenting the scales on y-axis (i.e they are in the wrong order)

This was fixed by me already in issue scipy#5150 but i guess it somehow missed being pulled into release - now i noticed so i just do this again