### PR TITLE
MAINT: Ignore build generated files in ``scipy.stats``

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -273,9 +273,9 @@ scipy/special/cython_special.pyx
 scipy/special/_specfunmodule.c
 scipy/special/tests/data/*.npz
 scipy/stats/_rank.c
-scipy/stats/mvn-f2pywrappers.f
-scipy/stats/mvnmodule.c
-scipy/stats/statlibmodule.c
+scipy/stats/_mvn-f2pywrappers.f
+scipy/stats/_mvnmodule.c
+scipy/stats/_statlibmodule.c
 scipy/stats/vonmises_cython.c
 scipy/stats/_stats.c
 scipy/stats/_biasedurn.cxx

--- a/scipy/integrate/lsoda.py
+++ b/scipy/integrate/lsoda.py
@@ -22,5 +22,4 @@ def __getattr__(name):
                   "and will be removed in SciPy v2.0.0.",
                   category=DeprecationWarning, stacklevel=2)
 
-
     return getattr(_lsoda, name)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

The following files are generated on every build but aren't needed to be tracked,

scipy/stats/_mvn-f2pywrappers.f
scipy/stats/_mvnmodule.c
scipy/stats/_statlibmodule.c

Adding them to `.gitignore` to ease the workflow.

#### Additional information
<!--Any additional information you think is important.-->
