### PR TITLE
ENH: Use block structure in pade

### DIFF
--- a/scipy/interpolate/_pade.py
+++ b/scipy/interpolate/_pade.py
@@ -57,17 +57,13 @@ def pade(an, m, n=None):
     if m == 0:  # this is just the Taylor series
         return _Polynomial(an), _Polynomial([1])
     # first solve the Toeplitz system for q
-    trail_zeros = m - n - 1
-    if trail_zeros > 0:
-        top = r_[an[n+1::-1], zeros(trail_zeros)]
-    else:
-        top = an[n+1::-1][:m]
-    top = r_[an[n+1::-1][:m+1], [0]*(m-n-1)]  # first row might contain tailing zeros
+    # first row might contain tailing zeros
+    top = r_[an[n+1::-1][:m+1], [0]*(m-n-1)]
     an_mat = linalg.toeplitz(an[n+1:], top)
     # we set q[0] = 1 -> first column is -rhs
     q = r_[1.0, linalg.solve(an_mat[:, 1:], -an_mat[:, 0])]
-    # substitue `q` to get `p`
-    if m > 100:  # arbitrary threshold when to use dedicated toeplitz function
+    # substitute `q` to get `p`
+    if m > 100:  # arbitrary threshold when to use dedicated Toeplitz function
         p = linalg.matmul_toeplitz((an[:n+1], zeros(m+1)), q)
     else:
         p = linalg.toeplitz(an[:n+1], zeros(m+1)) @ q

--- a/scipy/interpolate/_pade.py
+++ b/scipy/interpolate/_pade.py
@@ -1,7 +1,9 @@
-from numpy import zeros, asarray, eye, poly1d, hstack, r_
+from numpy import zeros, asarray, eye, polynomial, hstack, r_
 from scipy import linalg
 
 __all__ = ["pade"]
+
+_Polynomial = polynomial.Polynomial
 
 
 def pade(an, m, n=None):
@@ -30,8 +32,7 @@ def pade(an, m, n=None):
     >>> e_exp = [1.0, 1.0, 1.0/2.0, 1.0/6.0, 1.0/24.0, 1.0/120.0]
     >>> p, q = pade(e_exp, 2)
 
-    >>> e_exp.reverse()
-    >>> e_poly = np.poly1d(e_exp)
+    >>> e_poly = np.polynomial.Polynomial(e_exp)
 
     Compare ``e_poly(x)`` and the Pade approximation ``p(x)/q(x)``
 
@@ -59,4 +60,4 @@ def pade(an, m, n=None):
     pq = linalg.solve(C, an)
     p = pq[:n+1]
     q = r_[1.0, pq[n+1:]]
-    return poly1d(p[::-1]), poly1d(q[::-1])
+    return _Polynomial(p), _Polynomial(q)

--- a/scipy/interpolate/_pade.py
+++ b/scipy/interpolate/_pade.py
@@ -3,6 +3,7 @@ from scipy import linalg
 
 __all__ = ["pade"]
 
+
 def pade(an, m, n=None):
     """
     Return Pade approximation to a polynomial as the ratio of two polynomials.
@@ -55,12 +56,11 @@ def pade(an, m, n=None):
     Akj = eye(N+1, n+1, dtype=an.dtype)
     Bkj = zeros((N+1, m), dtype=an.dtype)
     for row in range(1, m+1):
-        Bkj[row,:row] = -(an[:row])[::-1]
+        Bkj[row, :row] = -(an[:row])[::-1]
     for row in range(m+1, N+1):
-        Bkj[row,:] = -(an[row-m:row])[::-1]
+        Bkj[row, :] = -(an[row-m:row])[::-1]
     C = hstack((Akj, Bkj))
     pq = linalg.solve(C, an)
     p = pq[:n+1]
     q = r_[1.0, pq[n+1:]]
     return poly1d(p[::-1]), poly1d(q[::-1])
-

--- a/scipy/interpolate/_pade.py
+++ b/scipy/interpolate/_pade.py
@@ -54,11 +54,7 @@ def pade(an, m, n=None):
         raise ValueError("Order of q+p <m+n> must be smaller than len(an).")
     an = an[:N+1]
     Akj = eye(N+1, n+1, dtype=an.dtype)
-    Bkj = zeros((N+1, m), dtype=an.dtype)
-    for row in range(1, m+1):
-        Bkj[row, :row] = -(an[:row])[::-1]
-    for row in range(m+1, N+1):
-        Bkj[row, :] = -(an[row-m:row])[::-1]
+    Bkj = linalg.toeplitz(r_[0, -an[:-1]], zeros(m))
     C = hstack((Akj, Bkj))
     pq = linalg.solve(C, an)
     p = pq[:n+1]

--- a/scipy/interpolate/tests/test_pade.py
+++ b/scipy/interpolate/tests/test_pade.py
@@ -1,66 +1,66 @@
 from numpy.testing import (assert_array_equal, assert_array_almost_equal)
 from scipy.interpolate import pade
 
+
 def test_pade_trivial():
     nump, denomp = pade([1.0], 0)
-    assert_array_equal(nump.c, [1.0])
-    assert_array_equal(denomp.c, [1.0])
+    assert_array_equal(nump.coef, [1.0])
+    assert_array_equal(denomp.coef, [1.0])
 
     nump, denomp = pade([1.0], 0, 0)
-    assert_array_equal(nump.c, [1.0])
-    assert_array_equal(denomp.c, [1.0])
+    assert_array_equal(nump.coef, [1.0])
+    assert_array_equal(denomp.coef, [1.0])
 
 
 def test_pade_4term_exp():
     # First four Taylor coefficients of exp(x).
-    # Unlike poly1d, the first array element is the zero-order term.
     an = [1.0, 1.0, 0.5, 1.0/6]
 
     nump, denomp = pade(an, 0)
-    assert_array_almost_equal(nump.c, [1.0/6, 0.5, 1.0, 1.0])
-    assert_array_almost_equal(denomp.c, [1.0])
+    assert_array_almost_equal(nump.coef, an)
+    assert_array_almost_equal(denomp.coef, [1.0])
 
     nump, denomp = pade(an, 1)
-    assert_array_almost_equal(nump.c, [1.0/6, 2.0/3, 1.0])
-    assert_array_almost_equal(denomp.c, [-1.0/3, 1.0])
+    assert_array_almost_equal(nump.coef, [1.0, 2.0/3, 1.0/6])
+    assert_array_almost_equal(denomp.coef, [1.0, -1.0/3])
 
     nump, denomp = pade(an, 2)
-    assert_array_almost_equal(nump.c, [1.0/3, 1.0])
-    assert_array_almost_equal(denomp.c, [1.0/6, -2.0/3, 1.0])
+    assert_array_almost_equal(nump.coef, [1.0, 1.0/3])
+    assert_array_almost_equal(denomp.coef, [1.0, -2.0/3, 1.0/6])
 
     nump, denomp = pade(an, 3)
-    assert_array_almost_equal(nump.c, [1.0])
-    assert_array_almost_equal(denomp.c, [-1.0/6, 0.5, -1.0, 1.0])
+    assert_array_almost_equal(nump.coef, [1.0])
+    assert_array_almost_equal(denomp.coef, [1.0, -1.0, 0.5, -1.0/6])
 
     # Testing inclusion of optional parameter
     nump, denomp = pade(an, 0, 3)
-    assert_array_almost_equal(nump.c, [1.0/6, 0.5, 1.0, 1.0])
-    assert_array_almost_equal(denomp.c, [1.0])
+    assert_array_almost_equal(nump.coef, [1.0, 1.0, 0.5, 1.0/6])
+    assert_array_almost_equal(denomp.coef, [1.0])
 
     nump, denomp = pade(an, 1, 2)
-    assert_array_almost_equal(nump.c, [1.0/6, 2.0/3, 1.0])
-    assert_array_almost_equal(denomp.c, [-1.0/3, 1.0])
+    assert_array_almost_equal(nump.coef, [1.0, 2.0/3, 1.0/6])
+    assert_array_almost_equal(denomp.coef, [1.0, -1.0/3])
 
     nump, denomp = pade(an, 2, 1)
-    assert_array_almost_equal(nump.c, [1.0/3, 1.0])
-    assert_array_almost_equal(denomp.c, [1.0/6, -2.0/3, 1.0])
+    assert_array_almost_equal(nump.coef, [1.0, 1.0/3])
+    assert_array_almost_equal(denomp.coef, [1.0, -2.0/3, 1.0/6])
 
     nump, denomp = pade(an, 3, 0)
-    assert_array_almost_equal(nump.c, [1.0])
-    assert_array_almost_equal(denomp.c, [-1.0/6, 0.5, -1.0, 1.0])
+    assert_array_almost_equal(nump.coef, [1.0])
+    assert_array_almost_equal(denomp.coef, [1.0, -1.0, 0.5, -1.0/6])
 
     # Testing reducing array.
     nump, denomp = pade(an, 0, 2)
-    assert_array_almost_equal(nump.c, [0.5, 1.0, 1.0])
-    assert_array_almost_equal(denomp.c, [1.0])
+    assert_array_almost_equal(nump.coef, [1.0, 1.0, 0.5])
+    assert_array_almost_equal(denomp.coef, [1.0])
 
     nump, denomp = pade(an, 1, 1)
-    assert_array_almost_equal(nump.c, [1.0/2, 1.0])
-    assert_array_almost_equal(denomp.c, [-1.0/2, 1.0])
+    assert_array_almost_equal(nump.coef, [1.0, 1.0/2])
+    assert_array_almost_equal(denomp.coef, [1.0, -1.0/2])
 
     nump, denomp = pade(an, 2, 0)
-    assert_array_almost_equal(nump.c, [1.0])
-    assert_array_almost_equal(denomp.c, [1.0/2, -1.0, 1.0])
+    assert_array_almost_equal(nump.coef, [1.0])
+    assert_array_almost_equal(denomp.coef, [1.0, -1.0, 1.0/2])
 
 
 def test_pade_ints():
@@ -77,25 +77,26 @@ def test_pade_ints():
             nump_flt, denomp_flt = pade(an_flt, i, j)
 
             # Check that they are the same.
-            assert_array_equal(nump_int.c, nump_flt.c)
-            assert_array_equal(denomp_int.c, denomp_flt.c)
+            assert_array_equal(nump_int.coef, nump_flt.coef)
+            assert_array_equal(denomp_int.coef, denomp_flt.coef)
 
 
 def test_pade_complex():
     # Test sequence with known solutions - see page 6 of 10.1109/PESGM.2012.6344759.
     # Variable x is parameter - these tests will work with any complex number.
     x = 0.2 + 0.6j
-    an = [1.0, x, -x*x.conjugate(), x.conjugate()*(x**2) + x*(x.conjugate()**2),
-          -(x**3)*x.conjugate() - 3*(x*x.conjugate())**2 - x*(x.conjugate()**3)]
+    xc = x.conjugate()
+    an = [1.0, x, -x*xc, xc*(x**2) + x*(xc**2),
+          -(x**3)*xc - 3*(x*xc)**2 - x*(xc**3)]
 
     nump, denomp = pade(an, 1, 1)
-    assert_array_almost_equal(nump.c, [x + x.conjugate(), 1.0])
-    assert_array_almost_equal(denomp.c, [x.conjugate(), 1.0])
+    assert_array_almost_equal(nump.coef, [1.0, x + xc])
+    assert_array_almost_equal(denomp.coef, [1.0, xc])
 
     nump, denomp = pade(an, 1, 2)
-    assert_array_almost_equal(nump.c, [x**2, 2*x + x.conjugate(), 1.0])
-    assert_array_almost_equal(denomp.c, [x + x.conjugate(), 1.0])
+    assert_array_almost_equal(nump.coef, [1.0, 2*x + xc, x**2])
+    assert_array_almost_equal(denomp.coef, [1.0, x + xc])
 
     nump, denomp = pade(an, 2, 2)
-    assert_array_almost_equal(nump.c, [x**2 + x*x.conjugate() + x.conjugate()**2, 2*(x + x.conjugate()), 1.0])
-    assert_array_almost_equal(denomp.c, [x.conjugate()**2, x + 2*x.conjugate(), 1.0])
+    assert_array_almost_equal(nump.coef, [1.0, 2*(x + xc), x**2 + x*xc + xc**2])
+    assert_array_almost_equal(denomp.coef, [1.0, x + 2*xc, xc**2])

--- a/scipy/interpolate/tests/test_pade.py
+++ b/scipy/interpolate/tests/test_pade.py
@@ -98,5 +98,6 @@ def test_pade_complex():
     assert_array_almost_equal(denomp.coef, [1.0, x + xc])
 
     nump, denomp = pade(an, 2, 2)
-    assert_array_almost_equal(nump.coef, [1.0, 2*(x + xc), x**2 + x*xc + xc**2])
+    assert_array_almost_equal(nump.coef,
+                              [1.0, 2*(x + xc), x**2 + x*xc + xc**2])
     assert_array_almost_equal(denomp.coef, [1.0, x + 2*xc, xc**2])


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
None 

#### What does this implement/fix?
<!--Please explain your changes.-->
The Pade is solved as the matrix quation:

> [A, B] [p, q]^T = 0

The Matrix `A`, however, has the very simple block structure

> A = [I, 0]^T

so the matrix problem can be written in the block structure

> |I,  B_1| |p| = |0|
> |0, B_2| |q| = |0|

The new version of `pade` solves the second line of this matrix problem 

> B_2 q = 0

and substitutes the solution.
This is more stable for large degree of the denominator polynomial `q`.

I personally need this, to use `pade` for the Fourier-Pade transformation with many Fourier coefficients.

#### Additional information
<!--Any additional information you think is important.-->

Additionally, I did the following refactoring:

* use `Polynomial` instead of old `poly1d`