### PR TITLE
BUG: optimize: add a missing attribute of OptimizeResult in `basinhopping`

### DIFF
--- a/scipy/optimize/_basinhopping.py
+++ b/scipy/optimize/_basinhopping.py
@@ -734,6 +734,7 @@ def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
     res.fun = res.lowest_optimization_result.fun
     res.message = message
     res.nit = i + 1
+    res.success = res.lowest_optimization_result.success
     return res
 
 

--- a/scipy/optimize/tests/test__basinhopping.py
+++ b/scipy/optimize/tests/test__basinhopping.py
@@ -467,3 +467,12 @@ class Test_AdaptiveStepsize:
             self.takestep(x)
             self.takestep.report(False)
         assert_(self.ts.stepsize < self.stepsize)
+
+    def test_result_attributes(self):
+        result = basinhopping(lambda x: x ** 2, x0=1)
+        assert hasattr(result, "x")
+        assert hasattr(result, "success")
+        assert hasattr(result, "message")
+        assert hasattr(result, "fun")
+        assert hasattr(result, "nfev")
+        assert hasattr(result, "nit")

--- a/scipy/optimize/tests/test__basinhopping.py
+++ b/scipy/optimize/tests/test__basinhopping.py
@@ -467,12 +467,3 @@ class Test_AdaptiveStepsize:
             self.takestep(x)
             self.takestep.report(False)
         assert_(self.ts.stepsize < self.stepsize)
-
-    def test_result_attributes(self):
-        result = basinhopping(lambda x: x ** 2, x0=1)
-        assert hasattr(result, "x")
-        assert hasattr(result, "success")
-        assert hasattr(result, "message")
-        assert hasattr(result, "fun")
-        assert hasattr(result, "nfev")
-        assert hasattr(result, "nit")

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -2545,3 +2545,26 @@ def test_x_overwritten_user_function():
             hess = fquad_hess
         res = optimize.minimize(fquad, x0, method=meth, jac=jac, hess=hess)
         assert_allclose(res.x, np.arange(np.size(x0)), atol=2e-4)
+
+
+class TestGlobalOptimization:
+
+    def test_optimize_result_attributes(self):
+        def func(x):
+            return x ** 2
+
+        # Note that `brute` solver does not return `OptimizeResult`
+        results = [optimize.basinhopping(func, x0=1),
+                   optimize.differential_evolution(func, [(-4, 4)]),
+                   optimize.shgo(func, [(-4, 4)]),
+                   optimize.dual_annealing(func, [(-4, 4)]),
+                   ]
+
+        for result in results:
+            assert isinstance(result, optimize.OptimizeResult)
+            assert hasattr(result, "x")
+            assert hasattr(result, "success")
+            assert hasattr(result, "message")
+            assert hasattr(result, "fun")
+            assert hasattr(result, "nfev")
+            assert hasattr(result, "nit")


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Fix #4630
(Other issues reported in #4630 has been fixed in #14884)

#### What does this implement/fix?
<!--Please explain your changes.-->
https://github.com/scipy/scipy/issues/4630#issuecomment-570905172 reported that OptimizeResults of `basinhopping` is missing the `success` attribute.
So, I fixed it and added a test for it.

