### PR TITLE
MAINT: backports for 1.7.2, plus update Pythran min version to 0.9.12

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,3 +5,4 @@ omit =
     scipy/setup.py
     scipy/*/setup.py
     scipy/signal/_max_len_seq_inner.py
+disable_warnings = include-ignored

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -81,4 +81,5 @@ jobs:
 
     - name: Test SciPy
       run: |
+        export LIBRARY_PATH="$LIBRARY_PATH:/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib"
         SCIPY_USE_PYTHRAN=`test ${{ matrix.python-version }} != 3.9; echo $?` python -u runtests.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires = [
     "setuptools<58.0.0",
     "Cython>=0.29.18,<3.0",
     "pybind11>=2.4.3,<2.8.0",
-    "pythran>=0.9.11,<0.10.0",
+    "pythran>=0.9.12,<0.10.0",
 
     # NumPy dependencies - to update these, sync from
     # https://github.com/scipy/oldest-supported-numpy/, and then

--- a/scipy/cluster/_hierarchy.pyx
+++ b/scipy/cluster/_hierarchy.pyx
@@ -11,6 +11,7 @@ cdef extern from "numpy/npy_math.h":
 
 ctypedef unsigned char uchar
 
+np.import_array()
 
 # _hierarchy_distance_update.pxi includes the definition of linkage_distance_update
 # and the distance update functions for the supported linkage methods.

--- a/scipy/cluster/_optimal_leaf_ordering.pyx
+++ b/scipy/cluster/_optimal_leaf_ordering.pyx
@@ -32,6 +32,7 @@ from libc.stdlib cimport malloc, free
 
 from scipy.spatial.distance import squareform, is_valid_y, is_valid_dm
 
+np.import_array()
 
 @cython.profile(False)
 @cython.boundscheck(False)

--- a/scipy/fftpack/convolve.pyx
+++ b/scipy/fftpack/convolve.pyx
@@ -3,6 +3,8 @@ import numpy as np
 cimport numpy as np
 cimport cython
 
+np.import_array()
+
 __all__ = ['destroy_convolve_cache', 'convolve', 'convolve_z',
            'init_convolution_kernel']
 

--- a/scipy/interpolate/_bspl.pyx
+++ b/scipy/interpolate/_bspl.pyx
@@ -8,6 +8,8 @@ cimport numpy as cnp
 
 cimport cython
 
+cnp.import_array()
+
 cdef extern from "src/__fitpack.h":
     void _deBoor_D(const double *t, double x, int k, int ell, int m, double *result) nogil
 

--- a/scipy/io/matlab/mio_utils.pyx
+++ b/scipy/io/matlab/mio_utils.pyx
@@ -5,6 +5,8 @@
 import numpy as np
 cimport numpy as cnp
 
+cnp.import_array()
+
 
 cpdef object squeeze_element(cnp.ndarray arr):
     ''' Return squeezed element

--- a/scipy/ndimage/src/_cytest.pyx
+++ b/scipy/ndimage/src/_cytest.pyx
@@ -6,6 +6,7 @@ from cpython.pycapsule cimport (
 cimport numpy as np
 from numpy cimport npy_intp as intp
 
+np.import_array()
 
 cdef void _destructor(obj):
     cdef void *callback_data = PyCapsule_GetContext(obj)

--- a/scipy/optimize/_bglu_dense.pyx
+++ b/scipy/optimize/_bglu_dense.pyx
@@ -11,6 +11,8 @@ try:
 except ImportError:
     from time import clock as timer
 
+np.import_array()
+
 __all__ = ['LU', 'BGLU']
 
 @cython.boundscheck(False)

--- a/scipy/optimize/_group_columns.pyx
+++ b/scipy/optimize/_group_columns.pyx
@@ -10,6 +10,8 @@ import numpy as np
 cimport numpy as np
 from cpython cimport bool
 
+np.import_array()
+
 
 @cython.boundscheck(False)
 @cython.wraparound(False)

--- a/scipy/optimize/_highs/cython/src/_highs_wrapper.pyx
+++ b/scipy/optimize/_highs/cython/src/_highs_wrapper.pyx
@@ -64,6 +64,8 @@ from .HighsOptions cimport (
 )
 from .HighsModelUtils cimport utilPrimalDualStatusToString
 
+np.import_array()
+
 # options to reference for default values and bounds;
 # make a map to quickly lookup
 cdef HighsOptions _ref_opts

--- a/scipy/optimize/_trlib/_trlib.pyx
+++ b/scipy/optimize/_trlib/_trlib.pyx
@@ -6,6 +6,7 @@ cimport numpy as np
 
 from scipy._lib.messagestream cimport MessageStream
 
+np.import_array()
 
 class TRLIBQuadraticSubproblem(BaseQuadraticSubproblem):
 

--- a/scipy/signal/_max_len_seq_inner.pyx
+++ b/scipy/signal/_max_len_seq_inner.pyx
@@ -5,6 +5,7 @@ import numpy as np
 cimport numpy as np
 cimport cython
 
+np.import_array()
 
 # Fast inner loop of max_len_seq.
 @cython.cdivision(True)  # faster modulo

--- a/scipy/signal/_peak_finding_utils.pyx
+++ b/scipy/signal/_peak_finding_utils.pyx
@@ -11,6 +11,7 @@ import numpy as np
 cimport numpy as np
 from libc.math cimport ceil
 
+np.import_array()
 
 __all__ = ['_local_maxima_1d', '_select_by_peak_distance', '_peak_prominences',
            '_peak_widths']

--- a/scipy/signal/_sosfilt.pyx
+++ b/scipy/signal/_sosfilt.pyx
@@ -1,6 +1,8 @@
 cimport numpy as np
 cimport cython
 
+np.import_array()
+
 ctypedef fused DTYPE_floating_t:
     float
     float complex

--- a/scipy/signal/_spectral.pyx
+++ b/scipy/signal/_spectral.pyx
@@ -7,6 +7,8 @@ import numpy as np
 cimport numpy as np
 cimport cython
 
+np.import_array()
+
 __all__ = ['_lombscargle']
 
 

--- a/scipy/signal/_upfirdn_apply.pyx
+++ b/scipy/signal/_upfirdn_apply.pyx
@@ -40,6 +40,7 @@ from cython import bint  # boolean integer type
 from libc.stdlib cimport malloc, free
 from libc.string cimport memset
 
+np.import_array()
 
 ctypedef double complex double_complex
 ctypedef float complex float_complex

--- a/scipy/sparse/csgraph/_flow.pyx
+++ b/scipy/sparse/csgraph/_flow.pyx
@@ -7,6 +7,8 @@ cimport numpy as np
 
 include 'parameters.pxi'
 
+np.import_array()
+
 
 class MaximumFlowResult:
     """Represents the result of a maximum flow calculation.

--- a/scipy/sparse/csgraph/_matching.pyx
+++ b/scipy/sparse/csgraph/_matching.pyx
@@ -9,6 +9,8 @@ from numpy.math cimport INFINITY
 from scipy.sparse import (csr_matrix,
                           isspmatrix_coo, isspmatrix_csc, isspmatrix_csr)
 
+np.import_array()
+
 include "parameters.pxi"
 
 

--- a/scipy/sparse/csgraph/_min_spanning_tree.pyx
+++ b/scipy/sparse/csgraph/_min_spanning_tree.pyx
@@ -8,6 +8,8 @@ cimport cython
 from scipy.sparse import csr_matrix, isspmatrix_csc, isspmatrix
 from scipy.sparse.csgraph._validation import validate_graph
 
+np.import_array()
+
 include 'parameters.pxi'
 
 def minimum_spanning_tree(csgraph, overwrite=False):

--- a/scipy/sparse/csgraph/_reordering.pyx
+++ b/scipy/sparse/csgraph/_reordering.pyx
@@ -10,6 +10,7 @@ from scipy.sparse import (csc_matrix, csr_matrix, isspmatrix, isspmatrix_coo,
                           SparseEfficiencyWarning)
 from . import maximum_bipartite_matching
 
+np.import_array()
 
 include 'parameters.pxi'
 

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -22,6 +22,8 @@ cimport cython
 from libc.stdlib cimport malloc, free
 from numpy.math cimport INFINITY
 
+np.import_array()
+
 include 'parameters.pxi'
 
 

--- a/scipy/sparse/csgraph/_tools.pyx
+++ b/scipy/sparse/csgraph/_tools.pyx
@@ -11,6 +11,8 @@ cimport numpy as np
 from scipy.sparse import csr_matrix, isspmatrix,\
     isspmatrix_csr, isspmatrix_csc, isspmatrix_lil
 
+np.import_array()
+
 include 'parameters.pxi'
 
 def csgraph_from_masked(graph):

--- a/scipy/sparse/csgraph/_traversal.pyx
+++ b/scipy/sparse/csgraph/_traversal.pyx
@@ -15,6 +15,8 @@ from scipy.sparse.csgraph._tools import reconstruct_path
 cimport cython
 from libc cimport stdlib
 
+np.import_array()
+
 include 'parameters.pxi'
 
 def connected_components(csgraph, directed=True, connection='weak',

--- a/scipy/spatial/_hausdorff.pyx
+++ b/scipy/spatial/_hausdorff.pyx
@@ -15,6 +15,8 @@ cimport numpy as np
 cimport cython
 from libc.math cimport sqrt
 
+np.import_array()
+
 __all__ = ['directed_hausdorff']
 
 @cython.boundscheck(False)

--- a/scipy/spatial/_voronoi.pyx
+++ b/scipy/spatial/_voronoi.pyx
@@ -14,6 +14,8 @@ import numpy as np
 cimport numpy as np
 cimport cython
 
+np.import_array()
+
 __all__ = ['sort_vertices_of_regions']
 
 # array-filling placeholder that can never occur

--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -23,6 +23,8 @@ import threading
 import operator
 import warnings
 
+np.import_array()
+
 cdef extern from "<limits.h>":
     long LONG_MAX
 

--- a/scipy/spatial/qhull.pyx
+++ b/scipy/spatial/qhull.pyx
@@ -23,6 +23,8 @@ import os
 import sys
 import tempfile
 
+np.import_array()
+
 cdef extern from "numpy/npy_math.h":
     double nan "NPY_NAN"
 

--- a/scipy/spatial/src/distance_pybind.cpp
+++ b/scipy/spatial/src/distance_pybind.cpp
@@ -225,6 +225,13 @@ ArrayDescriptor get_descriptor(const py::array& arr) {
     const auto arr_strides = arr.strides();
     desc.strides.assign(arr_strides, arr_strides + ndim);
     for (intptr_t i = 0; i < ndim; ++i) {
+        if (arr_shape[i] <= 1) {
+            // Under NumPy's relaxed stride checking, dimensions with
+            // 1 or fewer elements are ignored.
+            desc.strides[i] = 0;
+            continue;
+        }
+
         if (desc.strides[i] % desc.element_size != 0) {
             throw std::runtime_error("Arrays must be aligned");
         }

--- a/scipy/spatial/transform/rotation.pyx
+++ b/scipy/spatial/transform/rotation.pyx
@@ -10,6 +10,8 @@ from cython.view cimport array
 from libc.math cimport sqrt, sin, cos, atan2, acos
 from numpy.math cimport PI as pi, NAN, isnan # avoid MSVC error
 
+np.import_array()
+
 # utilities for empty array initialization
 cdef inline double[:] _empty1(int n):
     return array(shape=(n,), itemsize=sizeof(double), format=b"d")

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -396,8 +396,8 @@ class multivariate_normal_gen(multi_rv_generic):
         cov = np.asarray(cov, dtype=float)
 
         if dim == 1:
-            mean.shape = (1,)
-            cov.shape = (1, 1)
+            mean = mean.reshape(1)
+            cov = cov.reshape(1, 1)
 
         if mean.ndim != 1 or mean.shape[0] != dim:
             raise ValueError("Array 'mean' must be a vector of length %d." %
@@ -4125,8 +4125,8 @@ class multivariate_t_gen(multi_rv_generic):
             dim = loc.size
 
         if dim == 1:
-            loc.shape = (1,)
-            shape.shape = (1, 1)
+            loc = loc.reshape(1)
+            shape = shape.reshape(1, 1)
 
         if loc.ndim != 1 or loc.shape[0] != dim:
             raise ValueError("Array 'loc' must be a vector of length %d." %

--- a/scipy/stats/_sobol.pyx
+++ b/scipy/stats/_sobol.pyx
@@ -6,6 +6,8 @@ cimport numpy as cnp
 import os
 import numpy as np
 
+cnp.import_array()
+
 # Parameters are linked to the direction numbers list.
 # See `initialize_direction_numbers` for more details.
 # Declared using DEF to be known at compilation time for ``poly`` et ``vinit``

--- a/scipy/stats/_stats.pyx
+++ b/scipy/stats/_stats.pyx
@@ -12,6 +12,7 @@ import numpy as np
 import scipy.stats, scipy.special
 cimport scipy.special.cython_special as cs
 
+np.import_array()
 
 cdef double von_mises_cdf_series(double k, double x, unsigned int p):
     cdef double s, c, sn, cn, R, V

--- a/scipy/stats/biasedurn.pyx.templ
+++ b/scipy/stats/biasedurn.pyx.templ
@@ -7,6 +7,8 @@ cimport numpy as np
 import numpy as np
 from libcpp.memory cimport unique_ptr
 
+np.import_array()
+
 IF not NPY_OLD:
     from numpy.random cimport bitgen_t
     from cpython.pycapsule cimport PyCapsule_GetPointer, PyCapsule_IsValid


### PR DESCRIPTION
These are the five backports that were in the queue, plus one commit specific to 1.7.x to update the minimum Pythran version we build with.

That version bump gets rid of the NetworkX dependency in Pythran, which was removed in 0.9.12. Closes gh-14335

This should also fix all CI failures on the 1.7.x branch.