### PR TITLE
ENH: optimize: add optional parameters of adaptive step size adjustment in `bashinhopping`.

### DIFF
--- a/scipy/optimize/_basinhopping.py
+++ b/scipy/optimize/_basinhopping.py
@@ -351,7 +351,7 @@ class Metropolis:
 def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
                  minimizer_kwargs=None, take_step=None, accept_test=None,
                  callback=None, interval=50, disp=False, niter_success=None,
-                 seed=None, *, accept_rate=0.5, factor=0.9):
+                 seed=None, *, target_accept_rate=0.5, stepwise_factor=0.9):
     """Find the global minimum of a function using the basin-hopping algorithm.
 
     Basin-hopping is a two-phase method that combines a global stepping
@@ -437,17 +437,17 @@ def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
         `take_step` and `accept_test`, and these functions use random
         number generation, then those functions are responsible for the state
         of their random number generator.
-    accept_rate : float, optional
+    target_accept_rate : float, optional
         The target acceptance rate that is used to adjust the `stepsize`.
         If the current acceptance rate is greater than the target,
         then the `stepsize` is increased. Otherwise, it is decreased.
-        Default is 0.5.
+        Range is (0, 1). Default is 0.5.
 
         .. versionadded:: 1.8.0
 
-    factor : float, optional
-        The `stepsize` is multiplied or divided by this factor upon each
-        update. Default is 0.9.
+    stepwise_factor : float, optional
+        The `stepsize` is multiplied or divided by this stepwise factor upon
+        each update. Range is (0, 1). Default is 0.9.
 
         .. versionadded:: 1.8.0
 
@@ -667,6 +667,11 @@ def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
     ...                    niter=10, accept_test=mybounds)
 
     """
+    if target_accept_rate <= 0. or target_accept_rate >= 1.:
+        raise ValueError('target_accept_rate has to be in range (0, 1)')
+    if stepwise_factor <= 0. or stepwise_factor >= 1.:
+        raise ValueError('stepwise_factor has to be in range (0, 1)')
+
     x0 = np.array(x0)
 
     # set up the np.random generator
@@ -685,18 +690,19 @@ def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
         # if take_step.stepsize exists then use AdaptiveStepsize to control
         # take_step.stepsize
         if hasattr(take_step, "stepsize"):
-            take_step_wrapped = AdaptiveStepsize(take_step, interval=interval,
-                                                 accept_rate=accept_rate,
-                                                 factor=factor,
-                                                 verbose=disp)
+            take_step_wrapped = AdaptiveStepsize(
+                take_step, interval=interval,
+                accept_rate=target_accept_rate,
+                factor=stepwise_factor,
+                verbose=disp)
         else:
             take_step_wrapped = take_step
     else:
         # use default
         displace = RandomDisplacement(stepsize=stepsize, random_gen=rng)
         take_step_wrapped = AdaptiveStepsize(displace, interval=interval,
-                                             accept_rate=accept_rate,
-                                             factor=factor,
+                                             accept_rate=target_accept_rate,
+                                             factor=stepwise_factor,
                                              verbose=disp)
 
     # set up accept tests

--- a/scipy/optimize/_basinhopping.py
+++ b/scipy/optimize/_basinhopping.py
@@ -438,13 +438,18 @@ def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
         number generation, then those functions are responsible for the state
         of their random number generator.
     accept_rate : float, optional
-        The target acceptance rate that is used to adjust the ``stepsize``.
+        The target acceptance rate that is used to adjust the `stepsize`.
         If the current acceptance rate is greater than the target,
-        then the ``stepsize`` is increased. Otherwise, it is decreased.
+        then the `stepsize` is increased. Otherwise, it is decreased.
         Default is 0.5.
+
+        .. versionadded:: 1.8.0
+
     factor : float, optional
-        The ``stepsize`` is multiplied or divided by this factor upon each
+        The `stepsize` is multiplied or divided by this factor upon each
         update. Default is 0.9.
+
+        .. versionadded:: 1.8.0
 
     Returns
     -------

--- a/scipy/optimize/_basinhopping.py
+++ b/scipy/optimize/_basinhopping.py
@@ -351,7 +351,7 @@ class Metropolis:
 def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
                  minimizer_kwargs=None, take_step=None, accept_test=None,
                  callback=None, interval=50, disp=False, niter_success=None,
-                 seed=None):
+                 seed=None, accept_rate=0.5, factor=0.9):
     """Find the global minimum of a function using the basin-hopping algorithm.
 
     Basin-hopping is a two-phase method that combines a global stepping
@@ -437,6 +437,14 @@ def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
         `take_step` and `accept_test`, and these functions use random
         number generation, then those functions are responsible for the state
         of their random number generator.
+    accept_rate : float, optional
+        The target acceptance rate that is used to adjust the ``stepsize``.
+        If the current acceptance rate is greater than the target,
+        then the ``stepsize`` is increased. Otherwise, it is decreased.
+        Default is 0.5.
+    factor : float, optional
+        The ``stepsize`` is multiplied or divided by this factor upon each
+        update. Default is 0.9.
 
     Returns
     -------
@@ -673,6 +681,8 @@ def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
         # take_step.stepsize
         if hasattr(take_step, "stepsize"):
             take_step_wrapped = AdaptiveStepsize(take_step, interval=interval,
+                                                 accept_rate=accept_rate,
+                                                 factor=factor,
                                                  verbose=disp)
         else:
             take_step_wrapped = take_step
@@ -680,6 +690,8 @@ def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
         # use default
         displace = RandomDisplacement(stepsize=stepsize, random_gen=rng)
         take_step_wrapped = AdaptiveStepsize(displace, interval=interval,
+                                             accept_rate=accept_rate,
+                                             factor=factor,
                                              verbose=disp)
 
     # set up accept tests

--- a/scipy/optimize/_basinhopping.py
+++ b/scipy/optimize/_basinhopping.py
@@ -351,7 +351,7 @@ class Metropolis:
 def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
                  minimizer_kwargs=None, take_step=None, accept_test=None,
                  callback=None, interval=50, disp=False, niter_success=None,
-                 seed=None, accept_rate=0.5, factor=0.9):
+                 seed=None, *, accept_rate=0.5, factor=0.9):
     """Find the global minimum of a function using the basin-hopping algorithm.
 
     Basin-hopping is a two-phase method that combines a global stepping

--- a/scipy/optimize/tests/test__basinhopping.py
+++ b/scipy/optimize/tests/test__basinhopping.py
@@ -134,6 +134,19 @@ class TestBasinHopping:
         assert_raises(TypeError, basinhopping, func2d, self.x0[i],
                       accept_test=1)
 
+    def test_input_validation(self):
+        msg = 'target_accept_rate has to be in range \\(0, 1\\)'
+        with assert_raises(ValueError, match=msg):
+            basinhopping(func1d, self.x0[0], target_accept_rate=0.)
+        with assert_raises(ValueError, match=msg):
+            basinhopping(func1d, self.x0[0], target_accept_rate=1.)
+
+        msg = 'stepwise_factor has to be in range \\(0, 1\\)'
+        with assert_raises(ValueError, match=msg):
+            basinhopping(func1d, self.x0[0], stepwise_factor=0.)
+        with assert_raises(ValueError, match=msg):
+            basinhopping(func1d, self.x0[0], stepwise_factor=1.)
+
     def test_1d_grad(self):
         # test 1-D minimizations with gradient
         i = 0


### PR DESCRIPTION

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Fix #8774

#### What does this implement/fix?
<!--Please explain your changes.-->
`optimize.bashinhopping` has adaptive step size adjustment using this class.
https://github.com/scipy/scipy/blob/0f91f0f5ce24445c548777cee1bb853d52b32849/scipy/optimize/_basinhopping.py#L181-L205
The `AdaptiveStepsize` class has optional parameters `accept_rate` and  `factor` to configure the behavior of adaptive step size adjustment.
However, scipy users cannot configure these parameters because `bashinhopping` does not have arguments to set these.
`bashinhopping` only provides an argument to set `intervel`.
So, I added the optional parameters `accept_rate` and  `factor` for `bashinhopping`.

