### PR TITLE
BUG: MultivariateNormalQMC with specific QMCEngine remove unneeded checks for d == 1

### DIFF
--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -1550,10 +1550,6 @@ class MultivariateNormalQMC(QMCEngine):
                 raise ValueError("Dimension of `engine` must be consistent"
                                  " with dimensions of mean and covariance.")
             self.engine = engine
-            if engine.d == 0:
-              raise ValueError("0 not valid")
-            if engine.d == 1:
-              raise ValueError("1 not valid")
         else:
             raise ValueError("`engine` must be an instance of "
                              "`scipy.stats.qmc.QMCEngine` or `None`.")

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -1545,11 +1545,15 @@ class MultivariateNormalQMC(QMCEngine):
             engine_dim = d
         if engine is None:
             self.engine = Sobol(d=engine_dim, scramble=True, seed=seed)  # type: QMCEngine
-        elif isinstance(engine, QMCEngine) and engine.d != 1:
+        elif isinstance(engine, QMCEngine):
             if engine.d != d:
                 raise ValueError("Dimension of `engine` must be consistent"
                                  " with dimensions of mean and covariance.")
             self.engine = engine
+            if engine.d == 0:
+              raise ValueError("0 not valid")
+            if engine.d == 1:
+              raise ValueError("1 not valid")
         else:
             raise ValueError("`engine` must be an instance of "
                              "`scipy.stats.qmc.QMCEngine` or `None`.")

--- a/scipy/stats/tests/test_qmc.py
+++ b/scipy/stats/tests/test_qmc.py
@@ -764,13 +764,13 @@ class TestMultivariateNormalQMCEngine(QMCEngineTests):
         pytest.skip("Not applicable: normal is not bounded.")
 
     def test_other_engine(self):
-        for dvalue in (0, 1, 2):
-            base_engine = qmc.Sobol(d=dvalue, scramble=False)
-            engine = qmc.MultivariateNormalQMC(mean=np.zeros(2),
+        for d in (0, 1, 2):
+            base_engine = qmc.Sobol(d=d, scramble=False)
+            engine = qmc.MultivariateNormalQMC(mean=np.zeros(d),
                                                engine=base_engine,
                                                inv_transform=True)
             samples = engine.random()
-            assert_equal(samples.shape, (1, 2))
+            assert_equal(samples.shape, (1, d))
 
 class TestNormalQMC:
     def test_NormalQMC(self):

--- a/scipy/stats/tests/test_qmc.py
+++ b/scipy/stats/tests/test_qmc.py
@@ -763,6 +763,14 @@ class TestMultivariateNormalQMCEngine(QMCEngineTests):
     def test_bounds(self, *args):
         pytest.skip("Not applicable: normal is not bounded.")
 
+    def test_other_engine(self):
+        for dvalue in (0, 1, 2):
+            base_engine = qmc.Sobol(d=dvalue, scramble=False)
+            engine = qmc.MultivariateNormalQMC(mean=np.zeros(2),
+                                               engine=base_engine,
+                                               inv_transform=True)
+            samples = engine.random()
+            assert_equal(samples.shape, (1, 2))
 
 class TestNormalQMC:
     def test_NormalQMC(self):


### PR DESCRIPTION
#### Reference issue
Addresses #14904

#### What does this implement/fix?
removes unneeded check for `d` which was throwing an exception

#### Additional information
#PyDataGlobal sprint

Thanks @rgommers & @melissawm for your assistance. 