### PR TITLE
MAINT: Use matmul binary operator in scipy.sparse.linalg

### DIFF
--- a/scipy/sparse/linalg/dsolve/__init__.py
+++ b/scipy/sparse/linalg/dsolve/__init__.py
@@ -27,27 +27,27 @@ Example session::
     >>> a = a.astype('F')
     >>> x = spsolve(a, b)
     >>> print(x)
-    >>> print("Error: ", a*x-b)
+    >>> print("Error: ", a@x-b)
     >>>
     >>> print("Solve: double precision complex:")
     >>> use_solver( useUmfpack = True )
     >>> a = a.astype('D')
     >>> x = spsolve(a, b)
     >>> print(x)
-    >>> print("Error: ", a*x-b)
+    >>> print("Error: ", a@x-b)
     >>>
     >>> print("Solve: double precision:")
     >>> a = a.astype('d')
     >>> x = spsolve(a, b)
     >>> print(x)
-    >>> print("Error: ", a*x-b)
+    >>> print("Error: ", a@x-b)
     >>>
     >>> print("Solve: single precision:")
     >>> use_solver( useUmfpack = False )
     >>> a = a.astype('f')
     >>> x = spsolve(a, b.astype('f'))
     >>> print(x)
-    >>> print("Error: ", a*x-b)
+    >>> print("Error: ", a@x-b)
 
 """
 

--- a/scipy/sparse/linalg/dsolve/_add_newdocs.py
+++ b/scipy/sparse/linalg/dsolve/_add_newdocs.py
@@ -6,7 +6,7 @@ add_newdoc('scipy.sparse.linalg.dsolve._superlu', 'SuperLU',
 
     Factorization is represented as::
 
-        Pr * A * Pc = L * U
+        Pr @ A @ Pc = L @ U
 
     To construct these `SuperLU` objects, call the `splu` and `spilu`
     functions.
@@ -74,7 +74,7 @@ add_newdoc('scipy.sparse.linalg.dsolve._superlu', 'SuperLU',
 
     We can reassemble the original matrix:
 
-    >>> (Pr.T * (lu.L * lu.U) * Pc.T).A
+    >>> (Pr.T @ (lu.L @ lu.U) @ Pc.T).A
     array([[ 1.,  2.,  0.,  4.],
            [ 1.,  0.,  0.,  1.],
            [ 1.,  0.,  2.,  1.],
@@ -94,9 +94,9 @@ add_newdoc('scipy.sparse.linalg.dsolve._superlu', 'SuperLU', ('solve',
     trans : {'N', 'T', 'H'}, optional
         Type of system to solve::
 
-            'N':   A   * x == rhs  (default)
-            'T':   A^T * x == rhs
-            'H':   A^H * x == rhs
+            'N':   A   @ x == rhs  (default)
+            'T':   A^T @ x == rhs
+            'H':   A^H @ x == rhs
 
         i.e., normal, transposed, and hermitian conjugate.
 

--- a/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
@@ -236,7 +236,7 @@ class TestLinsolve:
 
                 x = spsolve(Asp,b)
 
-                assert_(norm(b - Asp*x) < 10 * cond_A * eps)
+                assert_(norm(b - Asp@x) < 10 * cond_A * eps)
 
     def test_bvector_smoketest(self):
         Adense = array([[0., 1., 1.],
@@ -245,7 +245,7 @@ class TestLinsolve:
         As = csc_matrix(Adense)
         random.seed(1234)
         x = random.randn(3)
-        b = As*x
+        b = As@x
         x2 = spsolve(As, b)
 
         assert_array_almost_equal(x, x2)
@@ -486,7 +486,7 @@ class TestSplu:
         # Check that splu works at all
         def check(A, b, x, msg=""):
             eps = np.finfo(A.dtype).eps
-            r = A * x
+            r = A @ x
             assert_(abs(r - b).max() < 1e3*eps, msg)
 
         self._smoketest(splu, check, np.float32)
@@ -502,7 +502,7 @@ class TestSplu:
         errors = []
 
         def check(A, b, x, msg=""):
-            r = A * x
+            r = A @ x
             err = abs(r - b).max()
             assert_(err < 1e-2, msg)
             if b.dtype in (np.float64, np.complex128):
@@ -681,7 +681,7 @@ class TestSplu:
 
             Ad = A.toarray()
             lhs = Pr.dot(Ad).dot(Pc)
-            rhs = (lu.L * lu.U).toarray()
+            rhs = (lu.L @ lu.U).toarray()
 
             eps = np.finfo(dtype).eps
 

--- a/scipy/sparse/linalg/eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/arpack.py
@@ -1099,10 +1099,10 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
     """
     Find k eigenvalues and eigenvectors of the square matrix A.
 
-    Solves ``A * x[i] = w[i] * x[i]``, the standard eigenvalue problem
+    Solves ``A @ x[i] = w[i] * x[i]``, the standard eigenvalue problem
     for w[i] eigenvalues with corresponding eigenvectors x[i].
 
-    If M is specified, solves ``A * x[i] = w[i] * M * x[i]``, the
+    If M is specified, solves ``A @ x[i] = w[i] * M @ x[i]``, the
     generalized eigenvalue problem for w[i] eigenvalues
     with corresponding eigenvectors x[i]
 
@@ -1110,16 +1110,16 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
     ----------
     A : ndarray, sparse matrix or LinearOperator
         An array, sparse matrix, or LinearOperator representing
-        the operation ``A * x``, where A is a real or complex square matrix.
+        the operation ``A @ x``, where A is a real or complex square matrix.
     k : int, optional
         The number of eigenvalues and eigenvectors desired.
         `k` must be smaller than N-1. It is not possible to compute all
         eigenvectors of a matrix.
     M : ndarray, sparse matrix or LinearOperator, optional
         An array, sparse matrix, or LinearOperator representing
-        the operation M*x for the generalized eigenvalue problem
+        the operation M@x for the generalized eigenvalue problem
 
-            A * x = w * M * x.
+            A @ x = w * M @ x.
 
         M must represent a real symmetric matrix if A is real, and must
         represent a complex Hermitian matrix if A is complex. For best
@@ -1131,20 +1131,20 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
             If sigma is specified, M is positive semi-definite
 
         If sigma is None, eigs requires an operator to compute the solution
-        of the linear equation ``M * x = b``.  This is done internally via a
+        of the linear equation ``M @ x = b``.  This is done internally via a
         (sparse) LU decomposition for an explicit matrix M, or via an
         iterative solver for a general linear operator.  Alternatively,
         the user can supply the matrix or operator Minv, which gives
-        ``x = Minv * b = M^-1 * b``.
+        ``x = Minv @ b = M^-1 @ b``.
     sigma : real or complex, optional
         Find eigenvalues near sigma using shift-invert mode.  This requires
         an operator to compute the solution of the linear system
-        ``[A - sigma * M] * x = b``, where M is the identity matrix if
+        ``[A - sigma * M] @ x = b``, where M is the identity matrix if
         unspecified. This is computed internally via a (sparse) LU
         decomposition for explicit matrices A & M, or via an iterative
         solver if either A or M is a general linear operator.
         Alternatively, the user can supply the matrix or operator OPinv,
-        which gives ``x = OPinv * b = [A - sigma * M]^-1 * b``.
+        which gives ``x = OPinv @ b = [A - sigma * M]^-1 @ b``.
         For a real matrix A, shift-invert can either be done in imaginary
         mode or real mode, specified by the parameter OPpart ('r' or 'i').
         Note that when sigma is specified, the keyword 'which' (below)
@@ -1354,10 +1354,10 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
     Find k eigenvalues and eigenvectors of the real symmetric square matrix
     or complex Hermitian matrix A.
 
-    Solves ``A * x[i] = w[i] * x[i]``, the standard eigenvalue problem for
+    Solves ``A @ x[i] = w[i] * x[i]``, the standard eigenvalue problem for
     w[i] eigenvalues with corresponding eigenvectors x[i].
 
-    If M is specified, solves ``A * x[i] = w[i] * M * x[i]``, the
+    If M is specified, solves ``A @ x[i] = w[i] * M @ x[i]``, the
     generalized eigenvalue problem for w[i] eigenvalues
     with corresponding eigenvectors x[i].
 
@@ -1368,7 +1368,7 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
     Parameters
     ----------
     A : ndarray, sparse matrix or LinearOperator
-        A square operator representing the operation ``A * x``, where ``A`` is
+        A square operator representing the operation ``A @ x``, where ``A`` is
         real symmetric or complex Hermitian. For buckling mode (see below)
         ``A`` must additionally be positive-definite.
     k : int, optional
@@ -1489,10 +1489,10 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
         Specify strategy to use for shift-invert mode.  This argument applies
         only for real-valued A and sigma != None.  For shift-invert mode,
         ARPACK internally solves the eigenvalue problem
-        ``OP * x'[i] = w'[i] * B * x'[i]``
+        ``OP @ x'[i] = w'[i] * B @ x'[i]``
         and transforms the resulting Ritz vectors x'[i] and Ritz values w'[i]
         into the desired eigenvectors and eigenvalues of the problem
-        ``A * x[i] = w[i] * M * x[i]``.
+        ``A @ x[i] = w[i] * M @ x[i]``.
         The modes are as follows:
 
             'normal' :

--- a/scipy/sparse/linalg/isolve/_gcrotmk.py
+++ b/scipy/sparse/linalg/isolve/_gcrotmk.py
@@ -141,7 +141,7 @@ def _fgmres(matvec, v0, m, atol, lpsolve=None, rpsolve=None, cs=(), outer_v=(),
 
         # Arnoldi LSQ problem
 
-        # Add new column to H=Q*R, padding other columns with zeros
+        # Add new column to H=Q@R, padding other columns with zeros
         Q2 = np.zeros((j+2, j+2), dtype=Q.dtype, order='F')
         Q2[:j+1,:j+1] = Q
         Q2[j+1,j+1] = 1

--- a/scipy/sparse/linalg/isolve/iterative.py
+++ b/scipy/sparse/linalg/isolve/iterative.py
@@ -506,7 +506,7 @@ def gmres(A, b, x0=None, tol=1e-5, restart=None, maxiter=None, M=None, callback=
     ``M = P^-1``. The inverse should preferably not be calculated
     explicitly.  Rather, use the following template to produce M::
 
-      # Construct a linear operator that computes P^-1 * x.
+      # Construct a linear operator that computes P^-1 @ x.
       import scipy.sparse.linalg as spla
       M_x = lambda x: spla.spsolve(P, x)
       M = spla.LinearOperator((n, n), M_x)
@@ -706,7 +706,7 @@ def qmr(A, b, x0=None, tol=1e-5, maxiter=None, M1=None, M2=None, callback=None,
         Left preconditioner for A.
     M2 : {sparse matrix, ndarray, LinearOperator}
         Right preconditioner for A. Used together with the left
-        preconditioner M1.  The matrix M1*A*M2 should have better
+        preconditioner M1.  The matrix M1@A@M2 should have better
         conditioned than A alone.
     callback : function
         User-supplied function to call after each iteration.  It is called

--- a/scipy/sparse/linalg/isolve/lgmres.py
+++ b/scipy/sparse/linalg/isolve/lgmres.py
@@ -69,7 +69,7 @@ def lgmres(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
         to pass "guess" vectors in and out of the algorithm when solving
         similar problems.
     store_outer_Av : bool, optional
-        Whether LGMRES should store also A*v in addition to vectors `v`
+        Whether LGMRES should store also A@v in addition to vectors `v`
         in the `outer_v` list. Default is True.
     prepend_outer_v : bool, optional
         Whether to put outer_v augmentation vectors before Krylov iterates.

--- a/scipy/sparse/linalg/isolve/lsmr.py
+++ b/scipy/sparse/linalg/isolve/lsmr.py
@@ -101,7 +101,7 @@ def lsmr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
 
           istop   = 0 means x=0 is a solution.  If x0 was given, then x=x0 is a
                       solution.
-                  = 1 means x is an approximate solution to A*x = B,
+                  = 1 means x is an approximate solution to A@x = B,
                       according to atol and btol.
                   = 2 means x approximately solves the least-squares problem
                       according to atol.
@@ -321,8 +321,8 @@ def lsmr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
 
         # Perform the next step of the bidiagonalization to obtain the
         # next  beta, u, alpha, v.  These satisfy the relations
-        #         beta*u  =  a*v   -  alpha*u,
-        #        alpha*v  =  A'*u  -  beta*v.
+        #         beta*u  =  A@v   -  alpha*u,
+        #        alpha*v  =  A'@u  -  beta*v.
 
         u *= -alpha
         u += A.matvec(v)

--- a/scipy/sparse/linalg/isolve/lsqr.py
+++ b/scipy/sparse/linalg/isolve/lsqr.py
@@ -106,13 +106,13 @@ def lsqr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
 
     ::
 
-      1. Unsymmetric equations --    solve  A*x = b
+      1. Unsymmetric equations --    solve  Ax = b
 
-      2. Linear least squares  --    solve  A*x = b
+      2. Linear least squares  --    solve  Ax = b
                                      in the least-squares sense
 
-      3. Damped least squares  --    solve  (   A    )*x = ( b )
-                                            ( damp*I )     ( 0 )
+      3. Damped least squares  --    solve  (   A    )x = ( b )
+                                            ( damp*I )    ( 0 )
                                      in the least-squares sense
 
     Parameters
@@ -183,7 +183,7 @@ def lsqr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
     acond : float
         Estimate of ``cond(Abar)``.
     arnorm : float
-        Estimate of ``norm(A'*r - damp^2*x)``.
+        Estimate of ``norm(A'@r - damp^2*x)``.
     xnorm : float
         ``norm(x)``
     var : ndarray of float
@@ -223,27 +223,27 @@ def lsqr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
     If some initial estimate ``x0`` is known and if ``damp == 0``,
     one could proceed as follows:
 
-      1. Compute a residual vector ``r0 = b - A*x0``.
-      2. Use LSQR to solve the system  ``A*dx = r0``.
+      1. Compute a residual vector ``r0 = b - A@x0``.
+      2. Use LSQR to solve the system  ``A@dx = r0``.
       3. Add the correction dx to obtain a final solution ``x = x0 + dx``.
 
     This requires that ``x0`` be available before and after the call
     to LSQR.  To judge the benefits, suppose LSQR takes k1 iterations
-    to solve A*x = b and k2 iterations to solve A*dx = r0.
+    to solve A@x = b and k2 iterations to solve A@dx = r0.
     If x0 is "good", norm(r0) will be smaller than norm(b).
     If the same stopping tolerances atol and btol are used for each
     system, k1 and k2 will be similar, but the final solution x0 + dx
     should be more accurate.  The only way to reduce the total work
     is to use a larger stopping tolerance for the second system.
-    If some value btol is suitable for A*x = b, the larger value
-    btol*norm(b)/norm(r0)  should be suitable for A*dx = r0.
+    If some value btol is suitable for A@x = b, the larger value
+    btol*norm(b)/norm(r0)  should be suitable for A@dx = r0.
 
     Preconditioning is another way to reduce the number of iterations.
-    If it is possible to solve a related system ``M*x = b``
+    If it is possible to solve a related system ``M@x = b``
     efficiently, where M approximates A in some helpful way (e.g. M -
     A has low rank or its elements are small relative to those of A),
-    LSQR may converge more rapidly on the system ``A*M(inverse)*z =
-    b``, after which x can be recovered by solving M*x = z.
+    LSQR may converge more rapidly on the system ``A@M(inverse)@z =
+    b``, after which x can be recovered by solving M@x = z.
 
     If A is symmetric, LSQR should not be used!
 
@@ -366,7 +366,7 @@ def lsqr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
     sn2 = 0
 
     # Set up the first vectors u and v for the bidiagonalization.
-    # These satisfy  beta*u = b - A*x,  alfa*v = A'*u.
+    # These satisfy  beta*u = b - A@x,  alfa*v = A'@u.
     u = b
     bnorm = np.linalg.norm(b)
 
@@ -422,8 +422,8 @@ def lsqr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
         itn = itn + 1
         # Perform the next step of the bidiagonalization to obtain the
         # next  beta, u, alfa, v. These satisfy the relations
-        #     beta*u  =  a*v   -  alfa*u,
-        #     alfa*v  =  A'*u  -  beta*v.
+        #     beta*u  =  a@v   -  alfa*u,
+        #     alfa*v  =  A'@u  -  beta*v.
         u = A.matvec(v) - alfa * u
         beta = np.linalg.norm(u)
 

--- a/scipy/sparse/linalg/isolve/minres.py
+++ b/scipy/sparse/linalg/isolve/minres.py
@@ -127,7 +127,7 @@ def minres(A, b, x0=None, shift=0.0, tol=1e-5, maxiter=None,
     # y  =  beta1 P' v1,  where  P = C**(-1).
     # v is really P' v1.
 
-    r1 = b - A*x
+    r1 = b - A@x
     y = psolve(r1)
 
     beta1 = inner(r1, y)
@@ -370,7 +370,7 @@ if __name__ == '__main__':
     residuals = []
 
     def cb(x):
-        residuals.append(norm(b - A*x))
+        residuals.append(norm(b - A@x))
 
     # A = poisson((10,),format='csr')
     A = spdiags([arange(1,n+1,dtype=float)], [0], n, n, format='csr')

--- a/scipy/sparse/linalg/isolve/minres.py
+++ b/scipy/sparse/linalg/isolve/minres.py
@@ -12,7 +12,7 @@ def minres(A, b, x0=None, shift=0.0, tol=1e-5, maxiter=None,
     """
     Use MINimum RESidual iteration to solve Ax=b
 
-    MINRES minimizes norm(A*x - b) for a real symmetric matrix A.  Unlike
+    MINRES minimizes norm(Ax - b) for a real symmetric matrix A.  Unlike
     the Conjugate Gradient method, A can be indefinite or singular.
 
     If shift != 0 then the method solves (A - shift*I)x = b
@@ -279,7 +279,7 @@ def minres(A, b, x0=None, shift=0.0, tol=1e-5, maxiter=None,
 
         # Estimate  cond(A).
         # In this version we look at the diagonals of  R  in the
-        # factorization of the lower Hessenberg matrix,  Q * H = R,
+        # factorization of the lower Hessenberg matrix,  Q @ H = R,
         # where H is the tridiagonal matrix from Lanczos with one
         # extra row, beta(k+1) e_k^T.
 

--- a/scipy/sparse/linalg/isolve/tests/demo_lgmres.py
+++ b/scipy/sparse/linalg/isolve/tests/demo_lgmres.py
@@ -8,7 +8,7 @@ problem = "SPARSKIT/drivcav/e05r0200"
 #problem = "Harwell-Boeing/sherman/sherman1"
 #problem = "misc/hamm/add32"
 
-mm = np.lib._datasource.Repository('ftp://math.nist.gov/pub/MatrixMarket2/')
+mm = np.lib._datasource.Repository('https://math.nist.gov/pub/MatrixMarket2/')
 f = mm.open('%s.mtx.gz' % problem)
 Am = io.mmread(f).tocsr()
 f.close()
@@ -23,7 +23,7 @@ count = [0]
 def matvec(v):
     count[0] += 1
     sys.stderr.write('%d\r' % count[0])
-    return Am*v
+    return Am@v
 
 
 A = la.LinearOperator(matvec=matvec, shape=Am.shape, dtype=Am.dtype)
@@ -36,7 +36,7 @@ print("Invert %d x %d matrix; nnz = %d" % (Am.shape[0], Am.shape[1], Am.nnz))
 count[0] = 0
 x0, info = la.gmres(A, b, restrt=M, tol=1e-14)
 count_0 = count[0]
-err0 = np.linalg.norm(Am*x0 - b) / np.linalg.norm(b)
+err0 = np.linalg.norm(Am@x0 - b) / np.linalg.norm(b)
 print("GMRES(%d):" % M, count_0, "matvecs, residual", err0)
 if info != 0:
     print("Didn't converge")
@@ -44,7 +44,7 @@ if info != 0:
 count[0] = 0
 x1, info = la.lgmres(A, b, inner_m=M-6*2, outer_k=6, tol=1e-14)
 count_1 = count[0]
-err1 = np.linalg.norm(Am*x1 - b) / np.linalg.norm(b)
+err1 = np.linalg.norm(Am@x1 - b) / np.linalg.norm(b)
 print("LGMRES(%d,6) [same memory req.]:" % (M-2*6), count_1,
       "matvecs, residual:", err1)
 if info != 0:
@@ -53,7 +53,7 @@ if info != 0:
 count[0] = 0
 x2, info = la.lgmres(A, b, inner_m=M-6, outer_k=6, tol=1e-14)
 count_2 = count[0]
-err2 = np.linalg.norm(Am*x2 - b) / np.linalg.norm(b)
+err2 = np.linalg.norm(Am@x2 - b) / np.linalg.norm(b)
 print("LGMRES(%d,6) [same subspace size]:" % (M-6), count_2,
       "matvecs, residual:", err2)
 if info != 0:

--- a/scipy/sparse/linalg/isolve/tests/test_gcrotmk.py
+++ b/scipy/sparse/linalg/isolve/tests/test_gcrotmk.py
@@ -27,7 +27,7 @@ count = [0]
 
 def matvec(v):
     count[0] += 1
-    return Am*v
+    return Am@v
 
 
 A = LinearOperator(matvec=matvec, shape=Am.shape, dtype=Am.dtype)
@@ -39,7 +39,7 @@ def do_solve(**kw):
         sup.filter(DeprecationWarning, ".*called without specifying.*")
         x0, flag = gcrotmk(A, b, x0=zeros(A.shape[0]), tol=1e-14, **kw)
     count_0 = count[0]
-    assert_(allclose(A*x0, b, rtol=1e-12, atol=1e-12), norm(A*x0-b))
+    assert_(allclose(A@x0, b, rtol=1e-12, atol=1e-12), norm(A@x0-b))
     return x0, count_0
 
 

--- a/scipy/sparse/linalg/isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/isolve/tests/test_iterative.py
@@ -273,7 +273,7 @@ def check_precond_dummy(solver, case):
 
     x, info = solver(A, b, x0=x0, tol=tol)
     assert_equal(info,0)
-    assert_normclose(A*x, b, tol=tol)
+    assert_normclose(A@x, b, tol=tol)
 
 
 def test_precond_dummy():
@@ -582,7 +582,7 @@ class TestQMR:
             x,info = qmr(A, b, tol=1e-8, maxiter=15, M1=M1, M2=M2)
 
         assert_equal(info,0)
-        assert_normclose(A*x, b, tol=1e-8)
+        assert_normclose(A@x, b, tol=1e-8)
 
 
 class TestGMRES:

--- a/scipy/sparse/linalg/isolve/tests/test_lgmres.py
+++ b/scipy/sparse/linalg/isolve/tests/test_lgmres.py
@@ -29,7 +29,7 @@ count = [0]
 
 def matvec(v):
     count[0] += 1
-    return Am*v
+    return Am@v
 
 
 A = LinearOperator(matvec=matvec, shape=Am.shape, dtype=Am.dtype)
@@ -42,7 +42,7 @@ def do_solve(**kw):
         x0, flag = lgmres(A, b, x0=zeros(A.shape[0]),
                           inner_m=6, tol=1e-14, **kw)
     count_0 = count[0]
-    assert_(allclose(A*x0, b, rtol=1e-12, atol=1e-12), norm(A*x0-b))
+    assert_(allclose(A@x0, b, rtol=1e-12, atol=1e-12), norm(A@x0-b))
     return x0, count_0
 
 

--- a/scipy/sparse/linalg/isolve/tests/test_lsqr.py
+++ b/scipy/sparse/linalg/isolve/tests/test_lsqr.py
@@ -70,7 +70,7 @@ def test_well_conditioned_problems():
             rng = np.random.RandomState(seed + 10)
             beta = rng.rand(n)
             beta[beta == 0] = 0.00001  # ensure that all the betas are not null
-            b = A_sparse * beta[:, np.newaxis]
+            b = A_sparse @ beta[:, np.newaxis]
             output = lsqr(A_sparse, b, show=show)
 
             # Check that the termination condition corresponds to an approximate

--- a/scipy/sparse/linalg/isolve/tests/test_lsqr.py
+++ b/scipy/sparse/linalg/isolve/tests/test_lsqr.py
@@ -35,7 +35,7 @@ def test_basic():
 
     # Now the same but with damp > 0.
     # This is equivalent to solving the extented system:
-    # ( G      ) * x = ( b )
+    # ( G      ) @ x = ( b )
     # ( damp*I )       ( 0 )
     damp = 1.5
     xo, *_ = lsqr(

--- a/scipy/sparse/linalg/isolve/utils.py
+++ b/scipy/sparse/linalg/isolve/utils.py
@@ -41,7 +41,7 @@ def make_system(A, M, x0, b):
         sparse or dense matrix (or any valid input to aslinearoperator)
     x0 : {array_like, str, None}
         initial guess to iterative method.
-        ``x0 = 'Mb'`` means using the nonzero initial guess ``M * b``.
+        ``x0 = 'Mb'`` means using the nonzero initial guess ``M @ b``.
         Default is `None`, which means using the zero initial guess.
     b : array_like
         right hand side
@@ -117,7 +117,7 @@ def make_system(A, M, x0, b):
     if x0 is None:
         x = zeros(N, dtype=xtype)
     elif isinstance(x0, str):
-        if x0 == 'Mb':  # use nonzero initial guess ``M * b``
+        if x0 == 'Mb':  # use nonzero initial guess ``M @ b``
             bCopy = b.copy()
             x = M.matvec(bCopy)
     else:


### PR DESCRIPTION
I've reviewed all of the instances of multiplication (`*`) in the scipy.sparse.linalg package and replaced the instances where it represents matrix multiplication (based on the types of the operands) with the `@` operator. The behavior should be unchanged and the code should be slightly more readable.

There were also instances in non-executed parts of the source, like docstrings and comments. For the most part I changed these instances as well, but that may lead to more discussion. I don't want the doc/comment changes to be a blocker, so if that's contentions I'm happy to split out all the `DOC:` commits.

This longer term goal is to aid in the adoption of the sparse array interface, #14822 