### PR TITLE
BUG: stats: fix broadcasting behavior of argsreduce

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -568,8 +568,9 @@ def argsreduce(cond, *args):
         newargs = [newargs, ]
 
     if np.all(cond):
-        # Nothing to do
-        return newargs
+        # broadcast arrays with cond
+        *newargs, cond = np.broadcast_arrays(*newargs, cond)
+        return [arg.ravel() for arg in newargs]
 
     s = cond.shape
     # np.extract returns flattened arrays, which are not broadcastable together

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -6054,6 +6054,17 @@ def test_support_broadcasting_gh13294_regression():
     assert b2.shape == ex_b2.shape
 
 
+def test_stats_broadcasting_gh14953_regression():
+    # test case in gh14953
+    loc = [0., 0.]
+    scale = [[1.], [2.]]
+    assert_equal(stats.norm.var(loc, scale), [[1., 1.], [4., 4.]])
+    # test some edge cases
+    loc = np.empty((0, ))
+    scale = np.empty((1, 0))
+    assert stats.norm.var(loc, scale).shape == (1, 0)
+
+
 # Check a few values of the cosine distribution's cdf, sf, ppf and
 # isf methods.  Expected values were computed with mpmath.
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -6057,8 +6057,8 @@ def test_support_broadcasting_gh13294_regression():
 def test_stats_broadcasting_gh14953_regression():
     # test case in gh14953
     loc = [0., 0.]
-    scale = [[1.], [2.]]
-    assert_equal(stats.norm.var(loc, scale), [[1., 1.], [4., 4.]])
+    scale = [[1.], [2.], [3.]]
+    assert_equal(stats.norm.var(loc, scale), [[1., 1.], [4., 4.], [9., 9.]])
     # test some edge cases
     loc = np.empty((0, ))
     scale = np.empty((1, 0))


### PR DESCRIPTION

#### Reference issue

closes #14953

#### What does this implement/fix?

`argsreduce` didn't broadcast the arrays when no invalid values were present in the given arguments. This led to wrong behaviour down the line for some methods of the distribution using it. This has been fixed and tests for one of the methods (`stats`) have been added.

#### Additional information

I am trying to add tests that check broadcasting behavior for other methods that use `argsreduce`. This would a nice candidate for testing with Hypothesis.