### PR TITLE
CI: use https protocol for git in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
             echo ${CI_PULL_REQUEST//*pull\//} | tee merge.txt
             if [[ $(cat merge.txt) != "" ]]; then
               echo "Merging $(cat merge.txt)";
-              git remote add upstream git://github.com/scipy/scipy.git;
+              git remote add upstream https://github.com/scipy/scipy.git;
               git pull --ff-only upstream "refs/pull/$(cat merge.txt)/merge";
               git fetch upstream master;
             fi


### PR DESCRIPTION
GitHub is no longer supports the `git` protocol:

https://github.blog/2021-09-01-improving-git-protocol-security-github/
