### PR TITLE
MAINT: `integrate.lsoda` missing in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,11 +142,11 @@ scipy/fftpack/convolve.c
 scipy/fftpack/src/dct.c
 scipy/fftpack/src/dst.c
 scipy/integrate/_dopmodule.c
-scipy/integrate/lsodamodule.c
-scipy/integrate/vodemodule.c
+scipy/integrate/_lsodamodule.c
+scipy/integrate/_vodemodule.c
 scipy/integrate/_dop-f2pywrappers.f
-scipy/integrate/lsoda-f2pywrappers.f
-scipy/integrate/vode-f2pywrappers.f
+scipy/integrate/_lsoda-f2pywrappers.f
+scipy/integrate/_vode-f2pywrappers.f
 scipy/interpolate/_rbfinterp_pythran.cpp
 scipy/interpolate/_ppoly.c
 scipy/interpolate/_bspl.c


### PR DESCRIPTION
Missing in `.gitignore` since the public/private PR I guess.