### PR TITLE
Don't put space after directive name.

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -315,7 +315,7 @@ def correlation_lags(in1_len, in2_len, mode='full'):
     Cross-correlation for continuous functions :math:`f` and :math:`g` is
     defined as:
 
-    .. math ::
+    .. math::
 
         \left ( f\star g \right )\left ( \tau \right )
         \triangleq \int_{t_0}^{t_0 +T}
@@ -326,7 +326,7 @@ def correlation_lags(in1_len, in2_len, mode='full'):
     Cross correlation for discrete functions :math:`f` and :math:`g` is
     defined as:
 
-    .. math ::
+    .. math::
         \left ( f\star g \right )\left [ n \right ]
         \triangleq \sum_{-\infty}^{\infty}
         \overline{f\left [ m \right ]}g\left [ m+n \right ]


### PR DESCRIPTION
This is non standard and not supported by all rst parsers,
it also screw up syntax highlighting of editors.

There is also about 2500 directives that don't use space in the
codebase, and those two are feeling alone.
