### PR TITLE
BUG: freeze setuptools build deps to workaround pypa/setuptools#2849

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Installing packages
         run: |      
           python3.8-dbg -c 'import sys; print("Python debug build:", hasattr(sys, "gettotalrefcount"))'
-          python3.8-dbg -m pip install --upgrade pip setuptools wheel
+          python3.8-dbg -m pip install --upgrade pip 'setuptools<58.5' wheel
           python3.8-dbg -m pip install --upgrade numpy cython pytest pytest-xdist pybind11
           python3.8-dbg -m pip install --upgrade mpmath gmpy2 pythran
           python3.8-dbg -m pip uninstall -y nose
@@ -72,7 +72,7 @@ jobs:
         sudo apt install -y --no-install-recommends python3.10-dev python3.10-distutils python3.10-venv
         # GitHub doesn't provide a pip interface with py3.10 yet. Therefore, install it manually :
         curl -O https://bootstrap.pypa.io/get-pip.py && python3.10 get-pip.py && rm get-pip.py
-        python3.10 -m pip install --upgrade pip setuptools
+        python3.10 -m pip install --upgrade pip 'setuptools<58.5'
 
     - name: Install other build dependencies
       run: |
@@ -81,7 +81,7 @@ jobs:
     - name: Install packages
       run: |
         pip install --user git+https://github.com/numpy/numpy.git
-        python3.10 -m pip install --user setuptools wheel cython pytest pybind11 pytest-xdist
+        python3.10 -m pip install --user 'setuptools<58.5' wheel cython pytest pybind11 pytest-xdist
         pip install --user git+https://github.com/serge-sans-paille/pythran.git
         python3.10 -m pip install -r mypy_requirements.txt
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -77,7 +77,7 @@ jobs:
     - name: Install packages
       run: |
         pip install ${{ matrix.numpy-version }}
-        pip install setuptools wheel cython pytest pytest-xdist pybind11 pytest-xdist mpmath gmpy2 pythran
+        pip install 'setuptools<58.5' wheel cython pytest pytest-xdist pybind11 pytest-xdist mpmath gmpy2 pythran
 
     - name: Test SciPy
       run: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -185,7 +185,7 @@ stages:
             curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
             python3.8 get-pip.py && \
             pip3 --version && \
-            pip3 install setuptools wheel numpy==1.17.3 cython==0.29.18 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath matplotlib==3.1.3 pythran --user && \
+            pip3 install 'setuptools<58.5' wheel numpy==1.17.3 cython==0.29.18 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath matplotlib==3.1.3 pythran --user && \
             apt-get -y install gcc-5 g++-5 gfortran-8 wget && \
             cd .. && \
             mkdir openblas && cd openblas && \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -185,7 +185,8 @@ stages:
             curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
             python3.8 get-pip.py && \
             pip3 --version && \
-            pip3 install 'setuptools<58.5' wheel numpy==1.17.3 cython==0.29.18 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath matplotlib==3.1.3 pythran --user && \
+            pip3 install 'setuptools<58.5' wheel --user && \
+            pip3 install numpy==1.17.3 cython==0.29.18 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath matplotlib==3.1.3 pythran --user && \
             apt-get -y install gcc-5 g++-5 gfortran-8 wget && \
             cd .. && \
             mkdir openblas && cd openblas && \

--- a/ci/azure-travis-template.yaml
+++ b/ci/azure-travis-template.yaml
@@ -64,7 +64,7 @@ steps:
   displayName: 'Add ccache to path'
 - script: >-
     pip install --upgrade ${{parameters.numpy_spec}} &&
-    pip install --upgrade pip==20.2.4 setuptools wheel &&
+    pip install --upgrade pip==20.2.4 'setuptools<58.5' wheel &&
     pip install ${{parameters.other_spec}}
     cython
     gmpy2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@
 [build-system]
 requires = [
     "wheel",
-    "setuptools",
+    "setuptools<58.5",
     "Cython>=0.29.18",
     "pybind11>=2.4.3",
     "pythran>=0.9.12",


### PR DESCRIPTION
xref pypa/setuptools#2849

As seen in [recent](https://dev.azure.com/scipy-org/SciPy/_build/results?buildId=14690&view=logs&jobId=ede89041-5e8e-5201-ce5c-f68c2cbf02dd&j=ede89041-5e8e-5201-ce5c-f68c2cbf02dd&t=d29e43e0-51b0-592c-77cf-c2635d71df89) CI jobs, dependency installation is failing with
```
    AttributeError: get_data_files_without_manifest
```