### PR TITLE
DOC: stats: fix random number generation subsection in stats docs

### DIFF
--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -371,7 +371,7 @@ Statistical distances
    energy_distance
 
 Random variate generation / CDF Inversion
-=========================================
+-----------------------------------------
 
 .. autosummary::
    :toctree: generated/


### PR DESCRIPTION
#### Reference issue

N/A

#### What does this implement/fix?

Fix the `Random variate generation / CDF Inversion` section in the API docs:

![image](https://user-images.githubusercontent.com/43181252/140399976-b06676b7-6891-4ce2-8f1f-e24c5bcadb6c.png)

#### Additional information

@tupui as discussed in #14703, this fixes the incorrect rendering of the `Random variate generation / CDF Inversion` section.