### PR TITLE
BUG: scipy.sparse.linalg.spsolve: fix memory error caused from overflowing signed 32-bit int input to doubleCalloc

### DIFF
--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/dgstrs.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/dgstrs.c
@@ -143,9 +143,9 @@ dgstrs (trans_t trans, SuperMatrix *L, SuperMatrix *U,
     }
 
     n = L->nrow;
-    work = doubleCalloc(n * nrhs);
+    work = doubleCalloc((size_t)n * (size_t)nrhs);
     if ( !work ) ABORT("Malloc fails for local work[].");
-    soln = doubleMalloc(n);
+    soln = doubleMalloc((size_t)n);
     if ( !soln ) ABORT("Malloc fails for local soln[].");
 
     Bmat = Bstore->nzval;
@@ -158,7 +158,7 @@ dgstrs (trans_t trans, SuperMatrix *L, SuperMatrix *U,
     if ( trans == NOTRANS ) {
 	/* Permute right hand sides to form Pr*B */
 	for (i = 0; i < nrhs; i++) {
-	    rhs_work = &Bmat[i*ldb];
+	    rhs_work = &Bmat[(size_t)i * (size_t)ldb];
 	    for (k = 0; k < n; k++) soln[perm_r[k]] = rhs_work[k];
 	    for (k = 0; k < n; k++) rhs_work[k] = soln[k];
 	}
@@ -176,7 +176,7 @@ dgstrs (trans_t trans, SuperMatrix *L, SuperMatrix *U,
 	    
 	    if ( nsupc == 1 ) {
 		for (j = 0; j < nrhs; j++) {
-		    rhs_work = &Bmat[j*ldb];
+		    rhs_work = &Bmat[(size_t)j * (size_t)ldb];
 	    	    luptr = L_NZ_START(fsupc);
 		    for (iptr=istart+1; iptr < L_SUB_START(fsupc+1); iptr++){
 			irow = L_SUB(iptr);
@@ -206,8 +206,8 @@ dgstrs (trans_t trans, SuperMatrix *L, SuperMatrix *U,
 			&beta, &work[0], &n );
 #endif
 		for (j = 0; j < nrhs; j++) {
-		    rhs_work = &Bmat[j*ldb];
-		    work_col = &work[j*n];
+		    rhs_work = &Bmat[(size_t)j * (size_t)ldb];
+		    work_col = &work[(size_t)j * (size_t)n];
 		    iptr = istart + nsupc;
 		    for (i = 0; i < nrow; i++) {
 			irow = L_SUB(iptr);
@@ -218,7 +218,7 @@ dgstrs (trans_t trans, SuperMatrix *L, SuperMatrix *U,
 		}
 #else		
 		for (j = 0; j < nrhs; j++) {
-		    rhs_work = &Bmat[j*ldb];
+		    rhs_work = &Bmat[(size_t)j * (size_t)ldb];
 		    dlsolve (nsupr, nsupc, &Lval[luptr], &rhs_work[fsupc]);
 		    dmatvec (nsupr, nrow, nsupc, &Lval[luptr+nsupc],
 			    &rhs_work[fsupc], &work[0] );
@@ -272,12 +272,12 @@ dgstrs (trans_t trans, SuperMatrix *L, SuperMatrix *U,
 #endif
 #else		
 		for (j = 0; j < nrhs; j++)
-		    dusolve ( nsupr, nsupc, &Lval[luptr], &Bmat[fsupc+j*ldb] );
+		    dusolve ( nsupr, nsupc, &Lval[luptr], &Bmat[(size_t)fsupc + (size_t)j * (size_t)ldb] );
 #endif		
 	    }
 
 	    for (j = 0; j < nrhs; ++j) {
-		rhs_work = &Bmat[j*ldb];
+		rhs_work = &Bmat[(size_t)j * (size_t)ldb];
 		for (jcol = fsupc; jcol < fsupc + nsupc; jcol++) {
 		    solve_ops += 2*(U_NZ_START(jcol+1) - U_NZ_START(jcol));
 		    for (i = U_NZ_START(jcol); i < U_NZ_START(jcol+1); i++ ){
@@ -296,7 +296,7 @@ dgstrs (trans_t trans, SuperMatrix *L, SuperMatrix *U,
 
 	/* Compute the final solution X := Pc*X. */
 	for (i = 0; i < nrhs; i++) {
-	    rhs_work = &Bmat[i*ldb];
+	    rhs_work = &Bmat[(size_t)i * (size_t)ldb];
 	    for (k = 0; k < n; k++) soln[k] = rhs_work[perm_c[k]];
 	    for (k = 0; k < n; k++) rhs_work[k] = soln[k];
 	}
@@ -306,7 +306,7 @@ dgstrs (trans_t trans, SuperMatrix *L, SuperMatrix *U,
     } else { /* Solve A'*X=B or CONJ(A)*X=B */
 	/* Permute right hand sides to form Pc'*B. */
 	for (i = 0; i < nrhs; i++) {
-	    rhs_work = &Bmat[i*ldb];
+	    rhs_work = &Bmat[(size_t)i * (size_t)ldb];
 	    for (k = 0; k < n; k++) soln[perm_c[k]] = rhs_work[k];
 	    for (k = 0; k < n; k++) rhs_work[k] = soln[k];
 	}
@@ -315,15 +315,15 @@ dgstrs (trans_t trans, SuperMatrix *L, SuperMatrix *U,
 	for (k = 0; k < nrhs; ++k) {
 	    
 	    /* Multiply by inv(U'). */
-	    sp_dtrsv("U", "T", "N", L, U, &Bmat[k*ldb], stat, info);
+	    sp_dtrsv("U", "T", "N", L, U, &Bmat[(size_t)k * (size_t)ldb], stat, info);
 	    
 	    /* Multiply by inv(L'). */
-	    sp_dtrsv("L", "T", "U", L, U, &Bmat[k*ldb], stat, info);
+	    sp_dtrsv("L", "T", "U", L, U, &Bmat[(size_t)k * (size_t)ldb], stat, info);
 	    
 	}
 	/* Compute the final solution X := Pr'*X (=inv(Pr)*X) */
 	for (i = 0; i < nrhs; i++) {
-	    rhs_work = &Bmat[i*ldb];
+	    rhs_work = &Bmat[(size_t)i * (size_t)ldb];
 	    for (k = 0; k < n; k++) soln[k] = rhs_work[perm_r[k]];
 	    for (k = 0; k < n; k++) rhs_work[k] = soln[k];
 	}

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/dmemory.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/dmemory.c
@@ -672,22 +672,22 @@ dallocateA(int n, int nnz, double **a, int **asub, int **xa)
 }
 
 
-double *doubleMalloc(int n)
+double *doubleMalloc(size_t n)
 {
     double *buf;
-    buf = (double *) SUPERLU_MALLOC((size_t)n * sizeof(double)); 
+    buf = (double *) SUPERLU_MALLOC(n * (size_t) sizeof(double));
     if ( !buf ) {
 	ABORT("SUPERLU_MALLOC failed for buf in doubleMalloc()\n");
     }
     return (buf);
 }
 
-double *doubleCalloc(int n)
+double *doubleCalloc(size_t n)
 {
     double *buf;
-    register int i;
+    register size_t i;
     double zero = 0.0;
-    buf = (double *) SUPERLU_MALLOC((size_t)n * sizeof(double));
+    buf = (double *) SUPERLU_MALLOC(n * (size_t) sizeof(double));
     if ( !buf ) {
 	ABORT("SUPERLU_MALLOC failed for buf in doubleCalloc()\n");
     }

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/slu_ddefs.h
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/slu_ddefs.h
@@ -241,8 +241,8 @@ extern void    dSetRWork (int, int, double *, double **, double **);
 extern void    dLUWorkFree (int *, double *, GlobalLU_t *);
 extern int     dLUMemXpand (int, int, MemType, int *, GlobalLU_t *);
 
-extern double  *doubleMalloc(int);
-extern double  *doubleCalloc(int);
+extern double  *doubleMalloc(size_t);
+extern double  *doubleCalloc(size_t);
 extern int     dmemory_usage(const int, const int, const int, const int);
 extern int     dQuerySpace (SuperMatrix *, SuperMatrix *, mem_usage_t *);
 extern int     ilu_dQuerySpace (SuperMatrix *, SuperMatrix *, mem_usage_t *);


### PR DESCRIPTION
BUG: For big linear systems **AX = B** such as when the right hand side B is of size 46679 x 46680 containing doubles, `spsolve(A, B)` gets stuck in a runtime memory error that looks like below:
```
Python(8835,0x10eafadc0) malloc: can't allocate region
:*** mach_vm_map(size=18446744065245585408, flags: 100) failed (error code=3)
Python(8835,0x10eafadc0) malloc: *** set a breakpoint in malloc_error_break to debug
Traceback (most recent call last):
  File "sparse_solve.py", line 14, in <module>
    x = spsolve(A, B)
  File "/Users/liviofetahu/sesco-llc/matricez/env/lib/python3.8/site-packages/scipy-1.8.0.dev0+1921.c30fefc-py3.8-macosx-10.15-x86_64.egg/scipy/sparse/linalg/dsolve/linsolve.py", line 204, in spsolve
    x, info = _superlu.gssv(N, A.nnz, A.data, A.indices, A.indptr,
RuntimeError: SUPERLU_MALLOC failed for buf in doubleCalloc()
 at line 693 in file scipy/sparse/linalg/dsolve/SuperLU/SRC/dmemory.c
```
which is caused by the Python **spsolve** function making a call to `x, info = _superlu.gssv(N, A.nnz, A.data, A.indices, A.indptr, b, flag, options=options)` where the **_superlu** module is implemented in C and exposed to Python through the low level Python C Extension Modules API.
**Py_gssv** in C calls **gssv** (inner-ly), and **gssv** in turn calls **dgstrs**, with this last one calling `doubleCalloc(n * nrhs)` where `int n = L->nrow` and `int nrhs = B->ncol`. Finally, **doubleCalloc** makes a call to the **SUPERLU_MALLOC** macro
```
buf = (double*) SUPERLU_MALLOC((size_t)n * sizeof(double));
if( !buf ) {
	ABORT("SUPERLU_MALLOC failed for buf in doubleCalloc()\n");
}
```
with the macro being defined as the `void* superlu_python_module_malloc(size_t size)` function that sets some member `mem_ptr = malloc(size);` and returns _nullptr_ if malloc returns _nullptr_ (meaning that the system wasn’t able to return a valid pointer to usable contiguous memory because it couldn’t allocate it), so **buf** in **doubleCalloc** is a null pointer and **doubleCalloc** aborts with the failure message explained above -- all this due to `(L->nrow * B->ncol)` exceeding the maximum value of a _signed 32-bit int_.

Fixes #14984