### PR TITLE
MAINT: more backporting/doc updating for 1.7.2

### DIFF
--- a/doc/release/1.7.2-notes.rst
+++ b/doc/release/1.7.2-notes.rst
@@ -7,23 +7,30 @@ SciPy 1.7.2 Release Notes
 SciPy 1.7.2 is a bug-fix release with no new features
 compared to 1.7.1. Notably, the release includes wheels
 for Python 3.10, and wheels are now built with a newer
-version of OpenBLAS, 0.3.17.
+version of OpenBLAS, 0.3.17. Python 3.10 wheels are provided
+for MacOS x86_64 (thin, not universal2 or arm64 at this time),
+and Windows/Linux 64-bit. Many wheels are now built with newer
+versions of manylinux, which may require newer versions of pip.
 
 Authors
 =======
 
+* Peter Bell
+* da-woods +
 * Isuru Fernando
 * Ralf Gommers
 * Matt Haberland
 * Nicholas McKibben
+* Ilhan Polat
 * Judah Rand +
 * Tyler Reddy
 * Pamphile Roy
 * Charles Harris
 * Matti Picus
 * Hugo van Kemenade
+* Jacob Vanderplas
 
-A total of 10 people contributed to this release.
+A total of 14 people contributed to this release.
 People with a "+" by their names contributed a patch for the first time.
 This list of names is automatically generated, and may not be fully complete.
 
@@ -35,6 +42,10 @@ Issues closed for 1.7.2
 * `#14465 <https://github.com/scipy/scipy/issues/14465>`__: BUG: n-d interpolation parameter provided to geometric_slerp
 * `#14599 <https://github.com/scipy/scipy/issues/14599>`__: SciPy 1.7 builds as zipped egg, ruining imports
 * `#14606 <https://github.com/scipy/scipy/issues/14606>`__: BUG: crash / core dump when calling scipy.stats.beta.ppf with...
+* `#14732 <https://github.com/scipy/scipy/issues/14732>`__: CI, TST: pre-release failures for scipy/interpolate/tests/test_rbfinterp.py
+* `#14802 <https://github.com/scipy/scipy/issues/14802>`__: CI: Azure Main coverage job failure
+* `#14829 <https://github.com/scipy/scipy/issues/14829>`__: macOS CI failing with \`ld: library not found for -lSystem\`
+* `#14887 <https://github.com/scipy/scipy/issues/14887>`__: BUG: scipy.stats.multivariate_normal.logpdf mutates some inputs
 
 Pull requests for 1.7.2
 -----------------------
@@ -48,3 +59,12 @@ Pull requests for 1.7.2
 * `#14616 <https://github.com/scipy/scipy/pull/14616>`__: REL: update build dependency versions in pyproject.toml for 1.7.2
 * `#14618 <https://github.com/scipy/scipy/pull/14618>`__: FIX: raise RuntimeWarning when Boost evaluation_error is encountered
 * `#14672 <https://github.com/scipy/scipy/pull/14672>`__: BLD: add \`zip_safe=False\` to the \`setup()\` call
+* `#14791 <https://github.com/scipy/scipy/pull/14791>`__: MAINT: SciPy 1.7.2 prep/backports
+* `#14803 <https://github.com/scipy/scipy/pull/14803>`__: MAINT: disable include/source coverage warning.
+* `#14813 <https://github.com/scipy/scipy/pull/14813>`__: Added missing np.import_array()
+* `#14831 <https://github.com/scipy/scipy/pull/14831>`__: CI: Add stdlib to LD_LIBRARY_PATH
+* `#14893 <https://github.com/scipy/scipy/pull/14893>`__: BUG: Fix alignment errors due to relaxed stride checking
+* `#14897 <https://github.com/scipy/scipy/pull/14897>`__: BUG: avoid mutating inputs in multivariate distributions
+* `#14921 <https://github.com/scipy/scipy/pull/14921>`__: MAINT: "backport" 3.10 support
+* `#14937 <https://github.com/scipy/scipy/pull/14937>`__: MAINT: backports for 1.7.2, plus update Pythran min version to...
+* `#14938 <https://github.com/scipy/scipy/pull/14938>`__: TST: silence test failures on macOS for \`beta.ppf\` overflow

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -7,6 +7,7 @@ import sys
 import pickle
 import os
 import json
+import platform
 
 from numpy.testing import (assert_equal, assert_array_equal,
                            assert_almost_equal, assert_array_almost_equal,
@@ -36,6 +37,10 @@ from itertools import product
 
 # python -OO strips docstrings
 DOCSTRINGS_STRIPPED = sys.flags.optimize > 1
+
+# Failing on macOS 11, Intel CPUs. See gh-14901
+MACOS_INTEL = (sys.platform == 'darwin') and (platform.machine() == 'x86_64')
+
 
 # distributions to skip while testing the fix for the support method
 # introduced in gh-13294. These distributions are skipped as they
@@ -2840,6 +2845,7 @@ class TestBeta:
         x = [0.1, 0.5, 0.6]
         assert_raises(ValueError, stats.beta.fit, x, fa=0.5, fix_a=0.5)
 
+    @pytest.mark.skipif(MACOS_INTEL, reason="Overflow, see gh-14901")
     def test_issue_12635(self):
         # Confirm that Boost's beta distribution resolves gh-12635.
         # Check against R:
@@ -2851,6 +2857,7 @@ class TestBeta:
         p, a, b = 0.9999999999997369, 75.0, 66334470.0
         assert_allclose(stats.beta.ppf(p, a, b), 2.343620802982393e-06)
 
+    @pytest.mark.skipif(MACOS_INTEL, reason="Overflow, see gh-14901")
     def test_issue_12794(self):
         # Confirm that Boost's beta distribution resolves gh-12794.
         # Check against R.
@@ -2868,6 +2875,7 @@ class TestBeta:
         res = stats.beta.sf(inv, count_list + 1, 100000 - count_list)
         assert_allclose(res, p)
 
+    @pytest.mark.skipif(MACOS_INTEL, reason="Overflow, see gh-14901")
     def test_issue_12796(self):
         # Confirm that Boost's beta distribution succeeds in the case
         # of gh-12796


### PR DESCRIPTION
Backport gh-14938 (PR has already been relabeled/re-milestoned) and update the release notes to cover the last several backport PRs.

I've tried to add a blurb explaining what is going on with `3.10` support, hopefully not too confusing...

https://github.com/MacPython/scipy-wheels/pull/135 has been updated following the upstream NumPy release and multibuild updates, fingers crossed.