### PR TITLE
ENH: Speed up knot interval lookup for BSpline.design_matrix

### DIFF
--- a/scipy/interpolate/_bspl.pyx
+++ b/scipy/interpolate/_bspl.pyx
@@ -441,16 +441,17 @@ def _make_design_matrix(const double[::1] x,
         ..., last row - x[-1]).
     """
     cdef:
-        cnp.npy_intp i
+        cnp.npy_intp i, ind
         cnp.npy_intp n = x.shape[0]
         cnp.npy_intp nt = t.shape[0]
         double[::1] wrk = np.empty(2*k+2, dtype=float)
         double[::1] data = np.zeros(n * (k + 1), dtype=float)
         cnp.ndarray[long, ndim=1] row_ind = np.zeros(n * (k + 1), dtype=int)
         cnp.ndarray[long, ndim=1] col_ind = np.zeros(n * (k + 1), dtype=int)
+    ind = k
     for i in range(n):
-        ind = find_interval(t, k, x[i], k - 1, 0)
         
+        ind = find_interval(t, k, x[i], ind, 0)
         _deBoor_D(&t[0], x[i], k, ind, 0, &wrk[0])
 
         data[(k + 1) * i : (k + 1) * (i + 1)] = wrk[:k + 1]


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes gh-#14987
#### What does this implement/fix?
<!--Please explain your changes.-->
This PR speeds up the knot interval search when constructing the BSpline design matrix by updating the last knot interval each iteration. Now, the knot interval search no longer begins at the beginning of the knot array each iteration.
#### Additional information
<!--Any additional information you think is .-->
I'm not sure about the typing for `ind` and how Cython handles int vs intp typing. All other functions in scipy.interpolate._bspl.pyx use int when using the `find_interval` function, and I unfortunately don't have the internet bandwidth to download a compiler to test the compiled Cython. However, if tests fail, I can simply switch `ind` to int.