### PR TITLE
ENH: sparse.linalg: Use a more appropriate scalar for "count"

### DIFF
--- a/scipy/sparse/linalg/isolve/tests/demo_lgmres.py
+++ b/scipy/sparse/linalg/isolve/tests/demo_lgmres.py
@@ -17,12 +17,12 @@ f = mm.open('%s_rhs1.mtx.gz' % problem)
 b = np.array(io.mmread(f)).ravel()
 f.close()
 
-count = [0]
+count = 0
 
 
 def matvec(v):
-    count[0] += 1
-    sys.stderr.write('%d\r' % count[0])
+    count += 1
+    sys.stderr.write('%d\r' % count)
     return Am@v
 
 
@@ -33,26 +33,26 @@ M = 100
 print("MatrixMarket problem %s" % problem)
 print("Invert %d x %d matrix; nnz = %d" % (Am.shape[0], Am.shape[1], Am.nnz))
 
-count[0] = 0
+count = 0
 x0, info = la.gmres(A, b, restrt=M, tol=1e-14)
-count_0 = count[0]
+count_0 = count
 err0 = np.linalg.norm(Am@x0 - b) / np.linalg.norm(b)
 print("GMRES(%d):" % M, count_0, "matvecs, residual", err0)
 if info != 0:
     print("Didn't converge")
 
-count[0] = 0
+count = 0
 x1, info = la.lgmres(A, b, inner_m=M-6*2, outer_k=6, tol=1e-14)
-count_1 = count[0]
+count_1 = count
 err1 = np.linalg.norm(Am@x1 - b) / np.linalg.norm(b)
 print("LGMRES(%d,6) [same memory req.]:" % (M-2*6), count_1,
       "matvecs, residual:", err1)
 if info != 0:
     print("Didn't converge")
 
-count[0] = 0
+count = 0
 x2, info = la.lgmres(A, b, inner_m=M-6, outer_k=6, tol=1e-14)
-count_2 = count[0]
+count_2 = count
 err2 = np.linalg.norm(Am@x2 - b) / np.linalg.norm(b)
 print("LGMRES(%d,6) [same subspace size]:" % (M-6), count_2,
       "matvecs, residual:", err2)

--- a/scipy/sparse/linalg/isolve/tests/test_gcrotmk.py
+++ b/scipy/sparse/linalg/isolve/tests/test_gcrotmk.py
@@ -22,11 +22,11 @@ Am = csr_matrix(array([[-2,1,0,0,0,9],
                        [0,3,0,1,-2,1],
                        [1,0,0,0,1,-2]]))
 b = array([1,2,3,4,5,6])
-count = [0]
+count = 0
 
 
 def matvec(v):
-    count[0] += 1
+    count += 1
     return Am@v
 
 
@@ -34,11 +34,11 @@ A = LinearOperator(matvec=matvec, shape=Am.shape, dtype=Am.dtype)
 
 
 def do_solve(**kw):
-    count[0] = 0
+    count = 0
     with suppress_warnings() as sup:
         sup.filter(DeprecationWarning, ".*called without specifying.*")
         x0, flag = gcrotmk(A, b, x0=zeros(A.shape[0]), tol=1e-14, **kw)
-    count_0 = count[0]
+    count_0 = count
     assert_(allclose(A@x0, b, rtol=1e-12, atol=1e-12), norm(A@x0-b))
     return x0, count_0
 

--- a/scipy/sparse/linalg/isolve/tests/test_lgmres.py
+++ b/scipy/sparse/linalg/isolve/tests/test_lgmres.py
@@ -24,11 +24,11 @@ Am = csr_matrix(array([[-2, 1, 0, 0, 0, 9],
                        [0, 3, 0, 1, -2, 1],
                        [1, 0, 0, 0, 1, -2]]))
 b = array([1, 2, 3, 4, 5, 6])
-count = [0]
+count = 0
 
 
 def matvec(v):
-    count[0] += 1
+    count += 1
     return Am@v
 
 
@@ -36,12 +36,12 @@ A = LinearOperator(matvec=matvec, shape=Am.shape, dtype=Am.dtype)
 
 
 def do_solve(**kw):
-    count[0] = 0
+    count = 0
     with suppress_warnings() as sup:
         sup.filter(DeprecationWarning, ".*called without specifying.*")
         x0, flag = lgmres(A, b, x0=zeros(A.shape[0]),
                           inner_m=6, tol=1e-14, **kw)
-    count_0 = count[0]
+    count_0 = count
     assert_(allclose(A@x0, b, rtol=1e-12, atol=1e-12), norm(A@x0-b))
     return x0, count_0
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
Using the scalar type is more appropiate for calculating the calling count of SpMV. The above is only my opinion.

#### Additional information
<!--Any additional information you think is important.-->
