### PR TITLE
ENH: make QhullError public

### DIFF
--- a/scipy/spatial/__init__.py
+++ b/scipy/spatial/__init__.py
@@ -92,7 +92,7 @@ Functions
    geometric_slerp
 
 Warnings / Errors used in :mod:`scipy.spatial`
---------------------------------------------
+----------------------------------------------
 .. autosummary::
    :toctree: generated/
    QhullError

--- a/scipy/spatial/__init__.py
+++ b/scipy/spatial/__init__.py
@@ -90,7 +90,7 @@ Functions
    minkowski_distance_p
    procrustes
    geometric_slerp
-   
+
 Warnings / Errors used in :mod:`scipy.spatial`
 --------------------------------------------
 .. autosummary::

--- a/scipy/spatial/__init__.py
+++ b/scipy/spatial/__init__.py
@@ -90,6 +90,12 @@ Functions
    minkowski_distance_p
    procrustes
    geometric_slerp
+   
+Warnings / Errors used in :mod:`scipy.spatial`
+--------------------------------------------
+.. autosummary::
+   :toctree: generated/
+   QhullError
 
 """
 

--- a/scipy/spatial/_qhull.pyi
+++ b/scipy/spatial/_qhull.pyi
@@ -8,6 +8,9 @@ import numpy as np
 from numpy.typing import ArrayLike, NDArray
 from typing_extensions import final
 
+class QhullError(RuntimeError):
+    ...
+    
 @final
 class _Qhull:
     # Read-only cython attribute that behaves, more or less, like a property

--- a/scipy/spatial/_qhull.pyx
+++ b/scipy/spatial/_qhull.pyx
@@ -28,7 +28,7 @@ np.import_array()
 cdef extern from "numpy/npy_math.h":
     double nan "NPY_NAN"
 
-__all__ = ['Delaunay', 'ConvexHull', 'Voronoi', 'HalfspaceIntersection', 'tsearch']
+__all__ = ['Delaunay', 'ConvexHull', 'QhullError', 'Voronoi', 'HalfspaceIntersection', 'tsearch']
 
 #------------------------------------------------------------------------------
 # Qhull interface


### PR DESCRIPTION
#### Reference issue
Closes #14999 

#### What does this implement/fix?
Makes `QhullError` public so it can be caught by users of Qhull.

#### Additional information
Came up in [scikit-image #5363](https://github.com/scikit-image/scikit-image/issues/5363) as part of `regionprops` calculations., see discussion [here](https://github.com/scikit-image/scikit-image/pull/6008#discussion_r744350997). 

