### PR TITLE
ENH: Make `get_matfile_version` and other `io.matlab` objects public

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
           command: |
             . venv/bin/activate
             export SHELL=$(which bash)
-            python -u runtests.py -g -j2 --doc html-scipyorg --doc latex
+            python -u runtests.py -g --doc html-scipyorg --doc latex
             make -C doc/build/latex all-pdf LATEXOPTS="-file-line-error -halt-on-error"
             cp -f doc/build/latex/scipy-ref.pdf doc/build/html-scipyorg/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
           command: |
             . venv/bin/activate
             export SHELL=$(which bash)
-            python -u runtests.py -g --doc html-scipyorg --doc latex
+            python -u runtests.py -g -j2 --doc html-scipyorg --doc latex
             make -C doc/build/latex all-pdf LATEXOPTS="-file-line-error -halt-on-error"
             cp -f doc/build/latex/scipy-ref.pdf doc/build/html-scipyorg/
 

--- a/doc/API.rst.txt
+++ b/doc/API.rst.txt
@@ -106,6 +106,7 @@ change is made.
 * `scipy.io`
 
   - `scipy.io.arff`
+  - `scipy.io.matlab`
   - `scipy.io.wavfile`
 
 * `scipy.linalg`

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -37,7 +37,7 @@ help:
 	@echo "  show      to show the html-scipyorg output"
 
 clean:
-	-rm -rf build/* source/generated
+	-rm -rf build/* source/reference/generated
 
 
 #------------------------------------------------------------------------------
@@ -159,4 +159,3 @@ linkcheck: version-check
 
 show:
 	@python -c "import webbrowser; webbrowser.open_new_tab('file://$(PWD)/build/html-scipyorg/index.html')"
-

--- a/doc/source/_templates/autosummary/ndarray_subclass.rst
+++ b/doc/source/_templates/autosummary/ndarray_subclass.rst
@@ -5,5 +5,6 @@
 
 .. class:: {{ objname }}
 
-This is a thin wrapper around :class:`numpy.ndarray` that is not meant to
-be instantiated directly.
+This is an ndarray wrapper for a native MATLAB object. This class is not meant
+to be instantiated directly, but can be used for type checking
+:func:`scipy.io.loadmat` outputs.

--- a/doc/source/_templates/autosummary/ndarray_subclass.rst
+++ b/doc/source/_templates/autosummary/ndarray_subclass.rst
@@ -1,0 +1,9 @@
+{{ fullname }}
+{{ underline }}
+
+.. currentmodule:: {{ module }}
+
+.. class:: {{ objname }}
+
+This is a thin wrapper around :class:`numpy.ndarray` that is not meant to
+be instantiated directly.

--- a/doc/source/reference/io.matlab.rst
+++ b/doc/source/reference/io.matlab.rst
@@ -1,0 +1,6 @@
+:orphan:
+
+.. automodule:: scipy.io.matlab
+   :no-members:
+   :no-inherited-members:
+   :no-special-members:

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -1,6 +1,6 @@
 # Note: this should disappear at some point. For now, please keep it
 #       in sync with the doc dependencies in pyproject.toml
-Sphinx!=3.1.0, !=4.1.0
+Sphinx!=3.1.0, !=4.1.0, !=4.3.0
 pydata-sphinx-theme>=0.6.1
 sphinx-panels>=0.5.2
 matplotlib>2

--- a/mypy.ini
+++ b/mypy.ini
@@ -373,6 +373,9 @@ ignore_errors = True
 [mypy-scipy.io.arff._arffread]
 ignore_errors = True
 
+[mypy-scipy.io._matlab.tests.test_mio]
+ignore_errors = True
+
 [mypy-scipy.io._netcdf]
 ignore_errors = True
 

--- a/scipy/io/__init__.py
+++ b/scipy/io/__init__.py
@@ -109,9 +109,7 @@ Arff files (:mod:`scipy.io.arff`)
 
 """
 # matfile read and write
-from ._matlab import (loadmat, savemat, whosmat, byteordercodes,
-                      get_matfile_version, MatReadError, MatlabOpaque,
-                      MatlabFunction, MatWriteError)
+from ._matlab import loadmat, savemat, whosmat, byteordercodes
 
 # netCDF file support
 from ._netcdf import netcdf_file, netcdf_variable

--- a/scipy/io/__init__.py
+++ b/scipy/io/__init__.py
@@ -20,6 +20,7 @@ MATLAB® files
    loadmat - Read a MATLAB style mat file (version 4 through 7.1)
    savemat - Write a MATLAB style mat file (version 4 through 7.1)
    whosmat - List contents of a MATLAB style mat file (version 4 through 7.1)
+   get_matfile_version - Get the MATLAB file version
 
 IDL® files
 ==========
@@ -94,7 +95,8 @@ Arff files (:mod:`scipy.io.arff`)
 
 """
 # matfile read and write
-from ._matlab import loadmat, savemat, whosmat, byteordercodes
+from ._matlab import (loadmat, savemat, whosmat, byteordercodes,
+                      get_matfile_version)
 
 # netCDF file support
 from ._netcdf import netcdf_file, netcdf_variable

--- a/scipy/io/__init__.py
+++ b/scipy/io/__init__.py
@@ -111,7 +111,7 @@ from ._idl import readsav
 from ._harwell_boeing import hb_read, hb_write
 
 # Deprecated namespaces, to be removed in v2.0.0
-from . import arff, harwell_boeing, idl, matlab, mmio, netcdf, wavfile
+from . import arff, harwell_boeing, idl, mmio, netcdf, wavfile
 
 __all__ = [s for s in dir() if not s.startswith('_')]
 

--- a/scipy/io/__init__.py
+++ b/scipy/io/__init__.py
@@ -20,10 +20,24 @@ MATLAB® files
    loadmat - Read a MATLAB style mat file (version 4 through 7.1)
    savemat - Write a MATLAB style mat file (version 4 through 7.1)
    whosmat - List contents of a MATLAB style mat file (version 4 through 7.1)
+
+There are also utilities for lower-level access and triage:
+
+.. module:: scipy.io.matlab
+
+.. autosummary::
+   :toctree: generated/
+
    get_matfile_version - Get the MATLAB file version
+   MatReadError - Exception indicating a read issue
+   MatWriteError - Exception indicating a write issue
+   MatlabOpaque - Class for MATLAB opaque matrices
+   MatlabFunction - Class for MATLAB function objects
 
 IDL® files
 ==========
+
+.. module:: scipy.io
 
 .. autosummary::
    :toctree: generated/
@@ -96,7 +110,8 @@ Arff files (:mod:`scipy.io.arff`)
 """
 # matfile read and write
 from ._matlab import (loadmat, savemat, whosmat, byteordercodes,
-                      get_matfile_version)
+                      get_matfile_version, MatReadError, MatlabOpaque,
+                      MatlabFunction, MatWriteError)
 
 # netCDF file support
 from ._netcdf import netcdf_file, netcdf_variable

--- a/scipy/io/__init__.py
+++ b/scipy/io/__init__.py
@@ -21,23 +21,8 @@ MATLAB® files
    savemat - Write a MATLAB style mat file (version 4 through 7.1)
    whosmat - List contents of a MATLAB style mat file (version 4 through 7.1)
 
-There are also utilities for lower-level access and triage:
-
-.. module:: scipy.io.matlab
-
-.. autosummary::
-   :toctree: generated/
-
-   get_matfile_version - Get the MATLAB file version
-   MatReadError - Exception indicating a read issue
-   MatWriteError - Exception indicating a write issue
-   MatlabOpaque - Class for MATLAB opaque matrices
-   MatlabFunction - Class for MATLAB function objects
-
 IDL® files
 ==========
-
-.. module:: scipy.io
 
 .. autosummary::
    :toctree: generated/
@@ -107,6 +92,27 @@ Arff files (:mod:`scipy.io.arff`)
    ArffError
    ParseArffError
 
+MATLAB® file utilies (:mod:`scipy.io.matlab`)
+=============================================
+
+.. module:: scipy.io.matlab
+
+.. autosummary::
+   :toctree: generated/
+
+   matfile_version - Get the MATLAB file version
+   MatReadError - Exception indicating a read issue
+   MatReadWarning - Warning class for read issues
+   MatWriteError - Exception indicating a write issue
+   mat_struct - Class used when ``struct_as_record=False``
+
+.. autosummary::
+   :toctree: generated/
+   :template: autosummary/ndarray_subclass.rst
+   :nosignatures:
+
+   MatlabOpaque - Class for a MATLAB opaque matrix
+   MatlabFunction - Class for a MATLAB function object
 """
 # matfile read and write
 from ._matlab import loadmat, savemat, whosmat, byteordercodes

--- a/scipy/io/__init__.py
+++ b/scipy/io/__init__.py
@@ -21,6 +21,8 @@ MATLAB® files
    savemat - Write a MATLAB style mat file (version 4 through 7.1)
    whosmat - List contents of a MATLAB style mat file (version 4 through 7.1)
 
+For low-level MATLAB reading and writing utilities, see `scipy.io.matlab`.
+
 IDL® files
 ==========
 
@@ -91,31 +93,12 @@ Arff files (:mod:`scipy.io.arff`)
    MetaData
    ArffError
    ParseArffError
-
-MATLAB® file utilies (:mod:`scipy.io.matlab`)
-=============================================
-
-.. module:: scipy.io.matlab
-
-.. autosummary::
-   :toctree: generated/
-
-   matfile_version - Get the MATLAB file version
-   MatReadError - Exception indicating a read issue
-   MatReadWarning - Warning class for read issues
-   MatWriteError - Exception indicating a write issue
-   mat_struct - Class used when ``struct_as_record=False``
-
-.. autosummary::
-   :toctree: generated/
-   :template: autosummary/ndarray_subclass.rst
-   :nosignatures:
-
-   MatlabOpaque - Class for a MATLAB opaque matrix
-   MatlabFunction - Class for a MATLAB function object
 """
 # matfile read and write
 from ._matlab import loadmat, savemat, whosmat, byteordercodes
+
+# lower-level MATLAB utilities
+from . import matlab
 
 # netCDF file support
 from ._netcdf import netcdf_file, netcdf_variable

--- a/scipy/io/_matlab/__init__.py
+++ b/scipy/io/_matlab/__init__.py
@@ -10,12 +10,12 @@ Drive, Natick, MA 01760-2098, USA.
 # Matlab file read and write utilities
 from .mio import loadmat, savemat, whosmat
 from .mio5 import MatlabFunction
-from .mio5_params import MatlabOpaque, mat_struct
+from .mio5_params import MatlabObject, MatlabOpaque, mat_struct
 from .miobase import (matfile_version, MatReadError, MatReadWarning,
                       MatWriteError)
 from . import byteordercodes
 
-__all__ = ['loadmat', 'savemat', 'whosmat', 'byteordercodes',
+__all__ = ['loadmat', 'savemat', 'whosmat', 'byteordercodes', 'MatlabObject',
            'matfile_version', 'MatReadError', 'MatReadWarning',
            'MatWriteError', 'mat_struct', 'MatlabOpaque', 'MatlabFunction']
 

--- a/scipy/io/_matlab/__init__.py
+++ b/scipy/io/_matlab/__init__.py
@@ -9,9 +9,11 @@ Drive, Natick, MA 01760-2098, USA.
 """
 # Matlab file read and write utilities
 from .mio import loadmat, savemat, whosmat
+from .miobase import get_matfile_version
 from . import byteordercodes
 
-__all__ = ['loadmat', 'savemat', 'whosmat', 'byteordercodes']
+__all__ = ['loadmat', 'savemat', 'whosmat', 'byteordercodes',
+           'get_matfile_version']
 
 from scipy._lib._testutils import PytestTester
 test = PytestTester(__name__)

--- a/scipy/io/_matlab/__init__.py
+++ b/scipy/io/_matlab/__init__.py
@@ -9,7 +9,10 @@ Drive, Natick, MA 01760-2098, USA.
 """
 # Matlab file read and write utilities
 from .mio import loadmat, savemat, whosmat
-from .miobase import get_matfile_version
+from .mio5 import MatlabFunction
+from .mio5_params import MatlabOpaque
+from .miobase import (get_matfile_version, MatReadError, MatReadWarning,
+                      MatWriteError)
 from . import byteordercodes
 
 __all__ = ['loadmat', 'savemat', 'whosmat', 'byteordercodes',

--- a/scipy/io/_matlab/__init__.py
+++ b/scipy/io/_matlab/__init__.py
@@ -10,13 +10,14 @@ Drive, Natick, MA 01760-2098, USA.
 # Matlab file read and write utilities
 from .mio import loadmat, savemat, whosmat
 from .mio5 import MatlabFunction
-from .mio5_params import MatlabOpaque
-from .miobase import (get_matfile_version, MatReadError, MatReadWarning,
+from .mio5_params import MatlabOpaque, mat_struct
+from .miobase import (matfile_version, MatReadError, MatReadWarning,
                       MatWriteError)
 from . import byteordercodes
 
 __all__ = ['loadmat', 'savemat', 'whosmat', 'byteordercodes',
-           'get_matfile_version']
+           'matfile_version', 'MatReadError', 'MatReadWarning',
+           'MatWriteError', 'mat_struct', 'MatlabOpaque', 'MatlabFunction']
 
 from scipy._lib._testutils import PytestTester
 test = PytestTester(__name__)

--- a/scipy/io/_matlab/mio.py
+++ b/scipy/io/_matlab/mio.py
@@ -5,7 +5,7 @@ Module for reading and writing matlab (TM) .mat files
 
 from contextlib import contextmanager
 
-from .miobase import get_matfile_version, docfiller
+from .miobase import _get_matfile_version, docfiller
 from .mio4 import MatFile4Reader, MatFile4Writer
 from .mio5 import MatFile5Reader, MatFile5Writer
 
@@ -71,7 +71,7 @@ def mat_reader_factory(file_name, appendmat=True, **kwargs):
 
     """
     byte_stream, file_opened = _open_file(file_name, appendmat)
-    mjv, mnv = get_matfile_version(byte_stream)
+    mjv, mnv = _get_matfile_version(byte_stream)
     if mjv == 0:
         return MatFile4Reader(byte_stream, **kwargs), file_opened
     elif mjv == 1:
@@ -96,7 +96,7 @@ def loadmat(file_name, mdict=None, appendmat=True, **kwargs):
         Dictionary in which to insert matfile variables.
     appendmat : bool, optional
        True to append the .mat extension to the end of the given
-       filename, if not already present.
+       filename, if not already present. Default is True.
     byte_order : str or None, optional
        None by default, implying byte order guessed from mat
        file. Otherwise can be one of ('native', '=', 'little', '<',

--- a/scipy/io/_matlab/mio5_params.py
+++ b/scipy/io/_matlab/mio5_params.py
@@ -208,17 +208,21 @@ for _bytecode in '<>':
 
 
 class mat_struct:
-    ''' Placeholder for holding read data from structs
+    """Placeholder for holding read data from structs.
 
     We use instances of this class when the user passes False as a value to the
-    ``struct_as_record`` parameter of the :func:`scipy.io._matlab.loadmat`
-    function.
-    '''
+    ``struct_as_record`` parameter of the :func:`scipy.io.loadmat` function.
+    """
     pass
 
 
 class MatlabObject(np.ndarray):
-    ''' ndarray Subclass to contain matlab object '''
+    """Subclass of ndarray to signal this is a matlab object.
+
+    This is a simple subclass of :class:`numpy.ndarray` meant to be used
+    by :func:`scipy.io.loadmat` and should not be instantiated directly.
+    """
+
     def __new__(cls, input_array, classname=None):
         # Input array is an already formed ndarray instance
         # We first cast to be our class type
@@ -235,14 +239,24 @@ class MatlabObject(np.ndarray):
 
 
 class MatlabFunction(np.ndarray):
-    ''' Subclass to signal this is a matlab function '''
+    """Subclass for a MATLAB function.
+
+    This is a simple subclass of :class:`numpy.ndarray` meant to be used
+    by :func:`scipy.io.loadmat` and should not be directly instantiated.
+    """
+
     def __new__(cls, input_array):
         obj = np.asarray(input_array).view(cls)
         return obj
 
 
 class MatlabOpaque(np.ndarray):
-    ''' Subclass to signal this is a matlab opaque matrix '''
+    """Subclass for a MATLAB opaque matrix.
+
+    This is a simple subclass of :class:`numpy.ndarray` meant to be used
+    by :func:`scipy.io.loadmat` and should not be directly instantiated.
+    """
+
     def __new__(cls, input_array):
         obj = np.asarray(input_array).view(cls)
         return obj

--- a/scipy/io/_matlab/miobase.py
+++ b/scipy/io/_matlab/miobase.py
@@ -174,7 +174,7 @@ def read_dtype(mat_stream, a_dtype):
     return arr
 
 
-def get_matfile_version(fileobj):
+def get_matfile_version(file_name, appendmat=True):
     """
     Return major, minor tuple depending on apparent mat file type
 
@@ -186,8 +186,12 @@ def get_matfile_version(fileobj):
 
     Parameters
     ----------
-    fileobj : file_like
-        object implementing seek() and read()
+    file_name : str
+       Name of the mat file (do not need .mat extension if
+       appendmat==True). Can also pass open file-like object.
+    appendmat : bool, optional
+       True to append the .mat extension to the end of the given
+       filename, if not already present.
 
     Returns
     -------
@@ -207,6 +211,12 @@ def get_matfile_version(fileobj):
     -----
     Has the side effect of setting the file read pointer to 0
     """
+    from .mio import _open_file_context
+    with _open_file_context(file_name, appendmat=appendmat) as fileobj:
+        return _get_matfile_version(fileobj)
+
+
+def _get_matfile_version(fileobj):
     # Mat4 files have a zero somewhere in first 4 bytes
     fileobj.seek(0)
     mopt_bytes = fileobj.read(4)

--- a/scipy/io/_matlab/miobase.py
+++ b/scipy/io/_matlab/miobase.py
@@ -216,6 +216,9 @@ def matfile_version(file_name, *, appendmat=True):
         return _get_matfile_version(fileobj)
 
 
+get_matfile_version = matfile_version
+
+
 def _get_matfile_version(fileobj):
     # Mat4 files have a zero somewhere in first 4 bytes
     fileobj.seek(0)

--- a/scipy/io/_matlab/miobase.py
+++ b/scipy/io/_matlab/miobase.py
@@ -15,15 +15,15 @@ from . import byteordercodes as boc
 
 
 class MatReadError(Exception):
-    pass
+    """Exception indicating a read issue."""
 
 
 class MatWriteError(Exception):
-    pass
+    """Exception indicating a write issue."""
 
 
 class MatReadWarning(UserWarning):
-    pass
+    """Warning class for read issues."""
 
 
 doc_dict = \
@@ -34,7 +34,7 @@ doc_dict = \
      'append_arg':
          '''appendmat : bool, optional
    True to append the .mat extension to the end of the given
-   filename, if not already present.''',
+   filename, if not already present. Default is True.''',
      'load_args':
          '''byte_order : str or None, optional
    None by default, implying byte order guessed from mat
@@ -174,7 +174,7 @@ def read_dtype(mat_stream, a_dtype):
     return arr
 
 
-def get_matfile_version(file_name, appendmat=True):
+def matfile_version(file_name, *, appendmat=True):
     """
     Return major, minor tuple depending on apparent mat file type
 
@@ -191,7 +191,7 @@ def get_matfile_version(file_name, appendmat=True):
        appendmat==True). Can also pass open file-like object.
     appendmat : bool, optional
        True to append the .mat extension to the end of the given
-       filename, if not already present.
+       filename, if not already present. Default is True.
 
     Returns
     -------

--- a/scipy/io/_matlab/tests/test_mio.py
+++ b/scipy/io/_matlab/tests/test_mio.py
@@ -26,8 +26,8 @@ from numpy import array
 import scipy.sparse as SP
 
 import scipy.io._matlab.byteordercodes as boc
-from scipy.io._matlab.miobase (import matdims, MatWriteError, MatReadError,
-                               get_matfile_version)
+from scipy.io._matlab.miobase import (
+    matdims, MatWriteError, MatReadError, get_matfile_version)
 from scipy.io._matlab.mio import (mat_reader_factory, loadmat, savemat, whosmat)
 from scipy.io._matlab.mio5 import (MatlabObject, MatFile5Writer, MatFile5Reader,
                                   MatlabFunction, varmats_from_mat,

--- a/scipy/io/_matlab/tests/test_mio.py
+++ b/scipy/io/_matlab/tests/test_mio.py
@@ -1284,6 +1284,9 @@ def test_opaque():
 @pytest.mark.xfail
 def test_deprecation():
     """Test that access to previous attributes still works."""
+    # The mypy.ini [mypy-scipy.io._matlab.tests.test_mio] can be removed
+    # once these are fixed.
+
     # This should be accessible immediately from scipy.io import
     with pytest.deprecated_call(match=r'scipy\.io\.matlab instead'):
         scipy.io.matlab.mio5_params.MatlabOpaque  # noqa

--- a/scipy/io/_matlab/tests/test_mio.py
+++ b/scipy/io/_matlab/tests/test_mio.py
@@ -1286,7 +1286,7 @@ def test_deprecation():
     """Test that access to previous attributes still works."""
     # This should be accessible immediately from scipy.io import
     with pytest.deprecated_call(match=r'scipy\.io\.matlab instead'):
-        scipy.io.matlab.mio5_params.MatlabOpaque
+        scipy.io.matlab.mio5_params.MatlabOpaque  # noqa
     # these should be importable but warn as well
     with pytest.deprecated_call(match=r'scipy\.io\.matlab instead'):
-        from scipy.io.matlab.miobase import MatReadError
+        from scipy.io.matlab.miobase import MatReadError  # noqa

--- a/scipy/io/_matlab/tests/test_mio.py
+++ b/scipy/io/_matlab/tests/test_mio.py
@@ -27,7 +27,7 @@ import scipy.sparse as SP
 
 import scipy.io._matlab.byteordercodes as boc
 from scipy.io._matlab.miobase import (
-    matdims, MatWriteError, MatReadError, get_matfile_version)
+    matdims, MatWriteError, MatReadError, matfile_version)
 from scipy.io._matlab.mio import (mat_reader_factory, loadmat, savemat, whosmat)
 from scipy.io._matlab.mio5 import (MatlabObject, MatFile5Writer, MatFile5Reader,
                                   MatlabFunction, varmats_from_mat,
@@ -1259,7 +1259,7 @@ def test_simplify_cells():
     (2, '_7*_*', '.*hdf5.*'),
     (1, '8*_*', None),
 ])
-def test_get_matfile_version(version, filt, regex):
+def test_matfile_version(version, filt, regex):
     use_filt = pjoin(test_data_path, 'test*%s.mat' % filt)
     files = glob(use_filt)
     if regex is not None:
@@ -1267,5 +1267,5 @@ def test_get_matfile_version(version, filt, regex):
     assert len(files) > 0, \
         "No files for version %s using filter %s" % (version, filt)
     for file in files:
-        got_version = get_matfile_version(file)
+        got_version = matfile_version(file)
         assert got_version[0] == version

--- a/scipy/io/matlab.py
+++ b/scipy/io/matlab.py
@@ -6,6 +6,7 @@ import warnings
 from ._matlab import (loadmat, savemat, whosmat, byteordercodes,
                       matfile_version, MatReadError, MatReadWarning,
                       MatWriteError, MatlabOpaque, MatlabFunction, mat_struct)
+from . import _matlab
 
 
 __all__ = [  # noqa: F822

--- a/scipy/io/matlab.py
+++ b/scipy/io/matlab.py
@@ -4,11 +4,17 @@
 
 import warnings
 from . import _matlab
+from ._matlab import (loadmat, savemat, whosmat, byteordercodes,
+                      get_matfile_version, MatReadError, MatReadWarning,
+                      MatWriteError, MatlabOpaque, MatlabFunction)
 
 
 __all__ = [  # noqa: F822
-    'loadmat', 'savemat', 'whosmat', 'byteordercodes'
+    'loadmat', 'savemat', 'whosmat', 'byteordercodes', 'get_matfile_version',
+    'MatReadError', 'MatReadWarning', 'MatWriteError', 'MatlabOpaque',
+    'MatlabFunction',
 ]
+
 
 def __dir__():
     return __all__

--- a/scipy/io/matlab.py
+++ b/scipy/io/matlab.py
@@ -1,18 +1,17 @@
-# This file is not meant for public use and will be removed in SciPy v2.0.0.
-# Use the `scipy.io` namespace for importing the functions
-# included below.
+"""
+Module to read / write MATLAB .mat files.
+"""
 
 import warnings
-from . import _matlab
 from ._matlab import (loadmat, savemat, whosmat, byteordercodes,
-                      get_matfile_version, MatReadError, MatReadWarning,
-                      MatWriteError, MatlabOpaque, MatlabFunction)
+                      matfile_version, MatReadError, MatReadWarning,
+                      MatWriteError, MatlabOpaque, MatlabFunction, mat_struct)
 
 
 __all__ = [  # noqa: F822
-    'loadmat', 'savemat', 'whosmat', 'byteordercodes', 'get_matfile_version',
+    'loadmat', 'savemat', 'whosmat', 'byteordercodes', 'matfile_version',
     'MatReadError', 'MatReadWarning', 'MatWriteError', 'MatlabOpaque',
-    'MatlabFunction',
+    'MatlabFunction', 'mat_struct',
 ]
 
 

--- a/scipy/io/matlab.py
+++ b/scipy/io/matlab.py
@@ -1,18 +1,53 @@
 """
-Module to read / write MATLAB .mat files.
+MATLAB® file utilies (:mod:`scipy.io.matlab`)
+=============================================
+
+.. currentmodule:: scipy.io.matlab
+
+This submodule is meant to provide lower-level file utilies related to reading
+and writing MATLAB files.
+
+.. autosummary::
+   :toctree: generated/
+
+   matfile_version - Get the MATLAB file version
+   MatReadError - Exception indicating a read issue
+   MatReadWarning - Warning class for read issues
+   MatWriteError - Exception indicating a write issue
+   mat_struct - Class used when ``struct_as_record=False``
+
+.. autosummary::
+   :toctree: generated/
+   :template: autosummary/ndarray_subclass.rst
+   :nosignatures:
+
+   MatlabObject - Class for a MATLAB object
+   MatlabOpaque - Class for a MATLAB opaque matrix
+   MatlabFunction - Class for a MATLAB function object
+
+The following utilities that live in the :mod:`scipy.io`
+namespace also exist in this namespace:
+
+.. autosummary::
+   :toctree: generated/
+
+   loadmat - Read a MATLAB style mat file (version 4 through 7.1)
+   savemat - Write a MATLAB style mat file (version 4 through 7.1)
+   whosmat - List contents of a MATLAB style mat file (version 4 through 7.1)
 """
 
 import warnings
 from ._matlab import (loadmat, savemat, whosmat, byteordercodes,
                       matfile_version, MatReadError, MatReadWarning,
-                      MatWriteError, MatlabOpaque, MatlabFunction, mat_struct)
+                      MatWriteError, MatlabOpaque, MatlabFunction, mat_struct,
+                      MatlabObject)
 from . import _matlab
 
 
 __all__ = [  # noqa: F822
     'loadmat', 'savemat', 'whosmat', 'byteordercodes', 'matfile_version',
     'MatReadError', 'MatReadWarning', 'MatWriteError', 'MatlabOpaque',
-    'MatlabFunction', 'mat_struct',
+    'MatlabFunction', 'mat_struct', 'MatlabObject',
 ]
 
 

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -76,6 +76,7 @@ PUBLIC_SUBMODULES = [
     'interpolate',
     'io',
     'io.arff',
+    'io.matlab',
     'io.wavfile',
     'linalg',
     'linalg.blas',


### PR DESCRIPTION
After #14930 it became clear that some libraries like [pymatreader](https://gitlab.com/obob/pymatreader/-/blob/master/pymatreader/pymatreader.py#L34) were using get_matfile_version. This is a proposal to make it public as `scipy.io.get_matfile_version`. Open to other ideas for return value and name / parameters, but it seems okay to me as is.

While I was digging around in the tests I de-duplicated and modernized a little bit of the testing code that I thought I'd want to reuse, but it turns out I didn't. I kept it in there because it makes the code more DRY but I can remove it if people don't like it.