### PR TITLE
DOC: add missing "regularized" to `gammainccinv` documentation

### DIFF
--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -4155,13 +4155,14 @@ add_newdoc("gammainccinv",
     """
     gammainccinv(a, y)
 
-    Inverse of the upper incomplete gamma function with respect to `x`
+    Inverse of the regularized upper incomplete gamma function with
+    respect to `x`
 
     Given an input :math:`y` between 0 and 1, returns :math:`x` such
-    that :math:`y = Q(a, x)`. Here :math:`Q` is the upper incomplete
-    gamma function; see `gammaincc`. This is well-defined because the
-    upper incomplete gamma function is monotonic as can be seen from
-    its definition in [dlmf]_.
+    that :math:`y = Q(a, x)`. Here :math:`Q` is the regularized upper
+    incomplete gamma function; see `gammaincc`. This is well-defined
+    because the upper incomplete gamma function is monotonic as can
+    be seen from its definition in [dlmf]_.
 
     Parameters
     ----------
@@ -4212,7 +4213,8 @@ add_newdoc("gammaincinv",
     """
     gammaincinv(a, y)
 
-    Inverse to the lower incomplete gamma function with respect to `x`.
+    Inverse to the regularized lower incomplete gamma function with
+    respect to `x`.
 
     Given an input :math:`y` between 0 and 1, returns :math:`x` such
     that :math:`y = P(a, x)`. Here :math:`P` is the regularized lower
@@ -4236,7 +4238,7 @@ add_newdoc("gammaincinv",
     --------
     gammainc : regularized lower incomplete gamma function
     gammaincc : regularized upper incomplete gamma function
-    gammainccinv : inverse of the regualizred upper incomplete gamma
+    gammainccinv : inverse of the regularized upper incomplete gamma
         function with respect to `x`
 
     References

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -4049,10 +4049,8 @@ add_newdoc("gammainc",
     See also
     --------
     gammaincc : regularized upper incomplete gamma function
-    gammaincinv : inverse of the regularized lower incomplete gamma
-        function with respect to `x`
-    gammainccinv : inverse of the regularized upper incomplete gamma
-        function with respect to `x`
+    gammaincinv : inverse of the regularized lower incomplete gamma function
+    gammainccinv : inverse of the regularized upper incomplete gamma function
 
     References
     ----------
@@ -4118,10 +4116,8 @@ add_newdoc("gammaincc",
     See also
     --------
     gammainc : regularized lower incomplete gamma function
-    gammaincinv : inverse of the regularized lower incomplete gamma
-        function with respect to `x`
-    gammainccinv : inverse to of the regularized upper incomplete
-        gamma function with respect to `x`
+    gammaincinv : inverse of the regularized lower incomplete gamma function
+    gammainccinv : inverse of the regularized upper incomplete gamma function
 
     References
     ----------
@@ -4155,8 +4151,7 @@ add_newdoc("gammainccinv",
     """
     gammainccinv(a, y)
 
-    Inverse of the regularized upper incomplete gamma function with
-    respect to `x`
+    Inverse of the regularized upper incomplete gamma function.
 
     Given an input :math:`y` between 0 and 1, returns :math:`x` such
     that :math:`y = Q(a, x)`. Here :math:`Q` is the regularized upper
@@ -4180,8 +4175,7 @@ add_newdoc("gammainccinv",
     --------
     gammaincc : regularized upper incomplete gamma function
     gammainc : regularized lower incomplete gamma function
-    gammaincinv : inverse of the regularized lower incomplete gamma
-        function with respect to `x`
+    gammaincinv : inverse of the regularized lower incomplete gamma function
 
     References
     ----------
@@ -4213,8 +4207,7 @@ add_newdoc("gammaincinv",
     """
     gammaincinv(a, y)
 
-    Inverse to the regularized lower incomplete gamma function with
-    respect to `x`.
+    Inverse to the regularized lower incomplete gamma function.
 
     Given an input :math:`y` between 0 and 1, returns :math:`x` such
     that :math:`y = P(a, x)`. Here :math:`P` is the regularized lower
@@ -4238,8 +4231,7 @@ add_newdoc("gammaincinv",
     --------
     gammainc : regularized lower incomplete gamma function
     gammaincc : regularized upper incomplete gamma function
-    gammainccinv : inverse of the regularized upper incomplete gamma
-        function with respect to `x`
+    gammainccinv : inverse of the regularized upper incomplete gamma function
 
     References
     ----------


### PR DESCRIPTION
#### Reference issue
None (I can make a separate issue if required)

#### What does this implement/fix?
The documentation of `gammainccinv` was incorrect: it mentioned it was the inverse of the upper gamma function without mentioning it was *regularized*.  This confused me a bit when looking for the correct method for one of my projects. This was introduced in #10690. Given `gammaincc` *is* regularized, and the following holds:

```python
gammainccinv(1, gammaincc(1, i)) == i
```

I conclude the documentation is incorrect and needs to be updated. In this PR I also fixed a related typo of the word "regularized" elsewhere (L4225).

Note the inverse of the *lower* gamma function (`gammaincinv`) does mentioned the regularization correctly:
https://github.com/scipy/scipy/blob/b6481610941b62d23bdd9a104840b58da35cac0b/scipy/special/_add_newdocs.py#L4218

#### Additional information
This is my first contribution so not fully familiar with the process, but I suspect this change does not affect test cases or documentation rendering in any way.
