### PR TITLE
MAINT: restore access to deprecated private namespaces

### DIFF
--- a/scipy/constants/__init__.py
+++ b/scipy/constants/__init__.py
@@ -321,6 +321,9 @@ from ._codata import *
 from ._constants import *
 from ._codata import _obsolete_constants
 
+# Deprecated namespaces, to be removed in v2.0.0
+from . import codata, constants
+
 _constant_names = [(_k.lower(), _k, _v)
                    for _k, _v in physical_constants.items()
                    if _k not in _obsolete_constants]

--- a/scipy/fftpack/__init__.py
+++ b/scipy/fftpack/__init__.py
@@ -96,6 +96,9 @@ from ._pseudo_diffs import *
 from ._helper import *
 from ._realtransforms import *
 
+# Deprecated namespaces, to be removed in v2.0.0
+from . import basic, helper, pseudo_diffs, realtransforms
+
 from scipy._lib._testutils import PytestTester
 test = PytestTester(__name__)
 del PytestTester

--- a/scipy/integrate/__init__.py
+++ b/scipy/integrate/__init__.py
@@ -98,6 +98,9 @@ from ._ivp import (solve_ivp, OdeSolution, DenseOutput,
                    OdeSolver, RK23, RK45, DOP853, Radau, BDF, LSODA)
 from ._quad_vec import quad_vec
 
+# Deprecated namespaces, to be removed in v2.0.0
+from . import dop, lsoda, vode
+
 __all__ = [s for s in dir() if not s.startswith('_')]
 
 from scipy._lib._testutils import PytestTester

--- a/scipy/interpolate/__init__.py
+++ b/scipy/interpolate/__init__.py
@@ -183,6 +183,9 @@ from ._bsplines import *
 
 from ._pade import *
 
+# Deprecated namespaces, to be removed in v2.0.0
+from . import fitpack, fitpack2, interpolate, ndgriddata, polyint
+
 __all__ = [s for s in dir() if not s.startswith('_')]
 
 from scipy._lib._testutils import PytestTester

--- a/scipy/io/__init__.py
+++ b/scipy/io/__init__.py
@@ -106,6 +106,9 @@ from ._mmio import mminfo, mmread, mmwrite
 from ._idl import readsav
 from ._harwell_boeing import hb_read, hb_write
 
+# Deprecated namespaces, to be removed in v2.0.0
+from . import arff, harwell_boeing, idl, matlab, mmio, netcdf, wavfile
+
 __all__ = [s for s in dir() if not s.startswith('_')]
 
 from scipy._lib._testutils import PytestTester

--- a/scipy/linalg/__init__.py
+++ b/scipy/linalg/__init__.py
@@ -217,6 +217,12 @@ from ._decomp_update import *
 from ._sketches import *
 from ._decomp_cossin import *
 
+# Deprecated namespaces, to be removed in v2.0.0
+from . import (
+    decomp, decomp_cholesky, decomp_lu, decomp_qr, decomp_svd, decomp_schur,
+    basic, misc, special_matrices,
+)
+
 __all__ = [s for s in dir() if not s.startswith('_')]
 
 

--- a/scipy/misc/__init__.py
+++ b/scipy/misc/__init__.py
@@ -22,6 +22,9 @@ Various utilities that don't have another home.
 from ._common import *
 from . import _common
 
+# Deprecated namespaces, to be removed in v2.0.0
+from . import common, doccer
+
 __all__ = _common.__all__
 
 del _common

--- a/scipy/ndimage/__init__.py
+++ b/scipy/ndimage/__init__.py
@@ -153,13 +153,13 @@ from ._fourier import *  # noqa: F401 F403
 from ._interpolation import *  # noqa: F401 F403
 from ._measurements import *  # noqa: F401 F403
 from ._morphology import *  # noqa: F401 F403
+
+# Deprecated namespaces, to be removed in v2.0.0
 from . import filters  # noqa: F401
 from . import fourier  # noqa: F401
 from . import interpolation  # noqa: F401
 from . import measurements  # noqa: F401
 from . import morphology  # noqa: F401
-
-__version__ = '2.0'
 
 __all__ = [s for s in dir() if not s.startswith('_')]
 

--- a/scipy/odr/__init__.py
+++ b/scipy/odr/__init__.py
@@ -120,6 +120,9 @@ from ._odrpack import *
 from ._models import *
 from . import _add_newdocs
 
+# Deprecated namespaces, to be removed in v2.0.0
+from . import models, odrpack
+
 __all__ = [s for s in dir()
            if not (s.startswith('_') or s in ('odr_stop', 'odr_error'))]
 

--- a/scipy/optimize/__init__.py
+++ b/scipy/optimize/__init__.py
@@ -421,6 +421,12 @@ from ._shgo import shgo
 from ._dual_annealing import dual_annealing
 from ._qap import quadratic_assignment
 
+# Deprecated namespaces, to be removed in v2.0.0
+from . import (
+    cobyla, lbfgsb, linesearch, minpack, minpack2, moduleTNC, nonlin, optimize,
+    slsqp, tnc, zeros
+)
+
 __all__ = [s for s in dir() if not s.startswith('_')]
 
 from scipy._lib._testutils import PytestTester

--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -314,6 +314,11 @@ from ._wavelets import *
 from ._peak_finding import *
 from .windows import get_window  # keep this one in signal namespace
 
+# Deprecated namespaces, to be removed in v2.0.0
+from . import (
+    bsplines, filter_design, fir_filter_design, lti_conversion, ltisys,
+    spectral, signaltools, waveforms, wavelets,
+)
 
 # deal with * -> windows.* doc-only soft-deprecation
 deprecated_windows = ('boxcar', 'triang', 'parzen', 'bohman', 'blackman',
@@ -359,7 +364,6 @@ for name in deprecated_windows:
     locals()[name] = deco(name)
 
 del deprecated_windows, name, deco
-
 
 __all__ = [s for s in dir() if not s.startswith('_')]
 

--- a/scipy/signal/windows/__init__.py
+++ b/scipy/signal/windows/__init__.py
@@ -40,6 +40,9 @@ The suite of window functions for filtering and spectral estimation.
 
 from ._windows import *
 
+# Deprecated namespaces, to be removed in v2.0.0
+from . import windows
+
 __all__ = ['boxcar', 'triang', 'parzen', 'bohman', 'blackman', 'nuttall',
            'blackmanharris', 'flattop', 'bartlett', 'hanning', 'barthann',
            'hamming', 'kaiser', 'gaussian', 'general_gaussian', 'general_cosine',

--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -239,6 +239,12 @@ from ._matrix_io import *
 # For backward compatibility with v0.19.
 from . import csgraph
 
+# Deprecated namespaces, to be removed in v2.0.0
+from . import (
+    base, bsr, compressed, construct, coo, csc, csr, data, dia, dok, extract,
+    lil, sparsetools, sputils
+)
+
 __all__ = [s for s in dir() if not s.startswith('_')]
 
 # Filter PendingDeprecationWarning for np.matrix introduced with numpy 1.15

--- a/scipy/spatial/__init__.py
+++ b/scipy/spatial/__init__.py
@@ -107,6 +107,9 @@ from ._plotutils import *
 from ._procrustes import procrustes
 from ._geometric_slerp import geometric_slerp
 
+# Deprecated namespaces, to be removed in v2.0.0
+from . import ckdtree, kdtree, qhull
+
 __all__ = [s for s in dir() if not s.startswith('_')]
 __all__ += ['distance', 'transform']
 

--- a/scipy/spatial/transform/__init__.py
+++ b/scipy/spatial/transform/__init__.py
@@ -19,6 +19,9 @@ Rotations in 3 dimensions
 from ._rotation import Rotation, Slerp
 from ._rotation_spline import RotationSpline
 
+# Deprecated namespaces, to be removed in v2.0.0
+from . import rotation
+
 __all__ = ['Rotation', 'Slerp', 'RotationSpline']
 
 from scipy._lib._testutils import PytestTester

--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -665,6 +665,9 @@ from ._spherical_bessel import (
     spherical_kn
 )
 
+# Deprecated namespaces, to be removed in v2.0.0
+from . import add_newdocs, basic, orthogonal, specfun, sf_error, spfun_stats
+
 __all__ = _ufuncs.__all__ + _basic.__all__ + _orthogonal.__all__ + [
     'SpecialFunctionWarning',
     'SpecialFunctionError',

--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -465,6 +465,11 @@ from ._unuran import *  # noqa
 from ._page_trend_test import page_trend_test
 from ._mannwhitneyu import mannwhitneyu
 
+# Deprecated namespaces, to be removed in v2.0.0
+from . import (
+    biasedurn, kde, morestats, mstats_basic, mstats_extras, mvn, statlib, stats
+)
+
 __all__ = [s for s in dir() if not s.startswith("_")]  # Remove dunders.
 
 from scipy._lib._testutils import PytestTester


### PR DESCRIPTION
These all had compatibility shims for direct import (e.g.
`from scipy.io import arff`), but not for access like:

    from scipy import io
    io.arff.xxx

This restores that access. The changes in this commit don't trigger
a deprecation warning, however use of any object in the now-restored
namespaces will trigger such a warning.

FYI @Smit-create, @czgdp1807 