### PR TITLE
MAINT: Fix use-after-free bug in Py_FindObjects

### DIFF
--- a/scipy/ndimage/src/nd_image.c
+++ b/scipy/ndimage/src/nd_image.c
@@ -928,7 +928,6 @@ static PyObject *Py_FindObjects(PyObject *obj, PyObject *args)
     Py_XDECREF(slc);
     free(regions);
     if (PyErr_Occurred()) {
-        Py_XDECREF(result);
         return NULL;
     } else {
         return result;


### PR DESCRIPTION
#### Reference issue
Closes gh-14713. See the issue for more details.

#### What does this implement/fix?
Remove the extra reference decrement which is not needed and may cause the ref count to become negative in case of a memory error (though that's not likely).

cc @tupui @Snape3058
