### PR TITLE
DOC: Fix Documentation rendering --refguide-check

### DIFF
--- a/doc/source/dev/contributor/runtests.rst
+++ b/doc/source/dev/contributor/runtests.rst
@@ -87,9 +87,9 @@ Other useful options include:
    docs are built only in the ``html-scipyorg`` format, but you can
    change this by appending the name of the desired format
    (e.g. ``--doc latex``).
-- ``--refguide-check`` to check whether the objects in a Scipy submodule's
-    ``__all__`` dict correspond to the objects included in the reference
-    guide. It also checks the validity of code samples in docstrings.
+-  ``--refguide-check`` to check whether the objects in a Scipy submodule's
+   ``__all__`` dict correspond to the objects included in the reference
+   guide. It also checks the validity of code samples in docstrings.
 - ``--bench`` to run all benchmarks. See :ref:`benchmarking-with-asv`.
 - ``--pep8`` to perform pep8 check.
 - ``--mypy`` to run *mypy* on the codebase.

--- a/doc/source/dev/contributor/runtests.rst
+++ b/doc/source/dev/contributor/runtests.rst
@@ -90,9 +90,9 @@ Other useful options include:
 -  ``--refguide-check`` to check whether the objects in a Scipy submodule's
    ``__all__`` dict correspond to the objects included in the reference
    guide. It also checks the validity of code samples in docstrings.
-- ``--bench`` to run all benchmarks. See :ref:`benchmarking-with-asv`.
-- ``--pep8`` to perform pep8 check.
-- ``--mypy`` to run *mypy* on the codebase.
+-  ``--bench`` to run all benchmarks. See :ref:`benchmarking-with-asv`.
+-  ``--pep8`` to perform pep8 check.
+-  ``--mypy`` to run *mypy* on the codebase.
 -  ``-n`` or ``--no-build`` to prevent SciPy from updating the build
    before testing
 -  ``-j`` or ``--parallel`` *n* to engage *n* cores when building SciPy;


### PR DESCRIPTION
#### Reference issue
None

#### What does this implement/fix?
Current docs rendering is slightly broken for `refguide-check` as seen in the attached screenshot below or this [link](https://scipy.github.io/devdocs/dev/contributor/runtests.html). This PR fixes the spacing.

![image](https://user-images.githubusercontent.com/23621655/141053567-59940284-37d2-43ca-b3e4-dafa473c823a.png)

