### PR TITLE
ENH: sparse.linalg: Fixed the issue that the initial guess "x0" is changed by "lsmr"

### DIFF
--- a/scipy/sparse/linalg/isolve/lsmr.py
+++ b/scipy/sparse/linalg/isolve/lsmr.py
@@ -239,7 +239,7 @@ def lsmr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
         x = zeros(n, dtype)
         beta = normb.copy()
     else:
-        x = atleast_1d(x0)
+        x = atleast_1d(x0.copy())
         u = u - A.matvec(x)
         beta = norm(u)
 

--- a/scipy/sparse/linalg/isolve/tests/test_lsmr.py
+++ b/scipy/sparse/linalg/isolve/tests/test_lsmr.py
@@ -128,11 +128,18 @@ class TestLSMR:
 class TestLSMRReturns:
     def setup_method(self):
         self.n = 10
-        self.A = lowerBidiagonalMatrix(20,self.n)
-        self.xtrue = transpose(arange(self.n,0,-1))
+        self.A = lowerBidiagonalMatrix(20, self.n)
+        self.xtrue = transpose(arange(self.n, 0, -1))
         self.Afun = aslinearoperator(self.A)
         self.b = self.Afun.matvec(self.xtrue)
-        self.returnValues = lsmr(self.A,self.b)
+        self.x0 = ones(self.n)
+        self.x00 = self.x0.copy()
+        self.returnValues = lsmr(self.A, self.b)
+        self.returnValuesX0 = lsmr(self.A, self.b, x0=self.x0)
+
+    def test_unchanged_x0(self):
+        x, istop, itn, normr, normar, normA, condA, normx = self.returnValuesX0
+        assert_allclose(self.x00, self.x0)
 
     def testNormr(self):
         x, istop, itn, normr, normar, normA, condA, normx = self.returnValues


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
The initial guess shouldn't have been changed when users calling `lsmr`, the PR fixed the issue. Meanwhile, a few PEP8 errors are also fixed.

#### Additional information
<!--Any additional information you think is important.-->
