### PR TITLE
DOC: mitigate newton optimization not converging.

### DIFF
--- a/scipy/optimize/_zeros_py.py
+++ b/scipy/optimize/_zeros_py.py
@@ -251,7 +251,8 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
     The above is the equivalent of solving for each value in ``(x, a)``
     separately in a for-loop, just faster:
 
-    >>> loop_res = [optimize.newton(f, x0, fprime=fder, args=(a0,))
+    >>> loop_res = [optimize.newton(f, x0, fprime=fder, args=(a0,),
+    ...                             maxiter=200)
     ...             for x0, a0 in zip(x, a)]
     >>> np.allclose(vec_res, loop_res)
     True
@@ -259,8 +260,7 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
     Plot the results found for all values of ``a``:
 
     >>> analytical_result = np.sign(a) * np.abs(a)**(1/3)
-    >>> fig = plt.figure()
-    >>> ax = fig.add_subplot(111)
+    >>> fig, ax = plt.subplots()
     >>> ax.plot(a, analytical_result, 'o')
     >>> ax.plot(a, vec_res, '.')
     >>> ax.set_xlabel('$a$')


### PR DESCRIPTION
Increase the max number of iterations in a `scipy.optimize.newton` doctest to 200 (following what is done in the same doc above).

This issue is not present all the time, there is some randomness for some reason.

As seen recently here for instance https://app.circleci.com/pipelines/github/scipy/scipy/9753/workflows/004fd8e0-44ee-4039-86f0-00b948968786/jobs/38550

```
/home/circleci/repo/build/testenv/lib/python3.8/site-packages/scipy/optimize/_zeros_py.py:docstring of scipy.optimize._zeros_py.newton:141: WARNING: Exception occurred in plotting scipy-optimize-newton-1
 from /home/circleci/repo/doc/source/reference/generated/scipy.optimize.newton.rst:
Traceback (most recent call last):
  File "/home/circleci/repo/venv/lib/python3.8/site-packages/matplotlib/sphinxext/plot_directive.py", line 484, in run_code
    exec(code, ns)
  File "<string>", line 42, in <module>
  File "<string>", line 42, in <listcomp>
  File "/home/circleci/repo/build/testenv/lib/python3.8/site-packages/scipy/optimize/_zeros_py.py", line 368, in newton
    raise RuntimeError(msg)
RuntimeError: Failed to converge after 50 iterations, value is 3.174805379995878.
```