### PR TITLE
MAINT: simplify UNU.RAN api in stats

### DIFF
--- a/doc/source/tutorial/stats/sampling.rst
+++ b/doc/source/tutorial/stats/sampling.rst
@@ -163,7 +163,7 @@ which requires a PDF and its derivative w.r.t. ``x`` (i.e. the variate).
           required by some generators like the derivative of PDF for the
           TDR method. Relying on SciPy distributions might also reduce
           performance due to the vectorization of the methods like
-          ``pdf`` and ``cdf``. In both case, one can implement a
+          ``pdf`` and ``cdf``. In both cases, one can implement a
           custom distribution object that contains all the required
           methods and that is not vectorized as shown in the example
           above.

--- a/doc/source/tutorial/stats/sampling.rst
+++ b/doc/source/tutorial/stats/sampling.rst
@@ -82,10 +82,10 @@ different methods is shown in the table below.
 =====================================  ===============  ===============  ===========  ==============
 Methods for continuous distributions   Required Inputs  Optional Inputs  Setup Speed  Sampling Speed
 =====================================  ===============  ===============  ===========  ==============
-:class:`~TransformedDensityRejection`  pdf, dpdf        None             slow         fast
+:class:`~TransformedDensityRejection`  pdf, dpdf        none             slow         fast
 :class:`~NumericalInverseHermite`      cdf              pdf, dpdf        (very) slow  (very) fast
 :class:`~NumericalInversePolynomial`   pdf              cdf              (very) slow  (very) fast
-:class:`~NaiveRatioUniforms`           pdf              various          slow/fast    moderate
+:class:`~NaiveRatioUniforms`           pdf              none             slow/fast    moderate
 =====================================  ===============  ===============  ===========  ==============
 
 where
@@ -158,12 +158,15 @@ which requires a PDF and its derivative w.r.t. ``x`` (i.e. the variate).
           ``dpdf``, etc) need not be vectorized. They should
           accept and return floats.
 
-.. note:: One can also pass the SciPy distributions as arguments but it can
-          be slow due to validations and expensive NumPy operations.
-          Moreover, it doesn't always have all the information required
-          by some generators like derivative of PDF for TDR method. Also,
-          most of the distributions in SciPy provide a ``rvs`` method which
-          can be used instead.
+.. note:: One can also pass the SciPy distributions as arguments. However,
+          note that the object doesn't always have all the information
+          required by some generators like the derivative of PDF for the
+          TDR method. Relying on SciPy distributions might also reduce
+          performance due to the vectorization of the methods like
+          ``pdf`` and ``cdf``. In both case, one can implement a
+          custom distribution object that contains all the required
+          methods and that is not vectorized as shown in the example
+          above.
 
 In the above example, we have set up an object of the
 :class:`~TransformedDensityRejection` method to sample from a

--- a/doc/source/tutorial/stats/sampling_hinv.rst
+++ b/doc/source/tutorial/stats/sampling_hinv.rst
@@ -55,7 +55,7 @@ so the mesh of quantiles is refined as needed to reduce the maximum
 
 below the specified tolerance `u_resolution`. Refinement stops when the required
 tolerance is achieved or when the number of mesh intervals after the next
-refinement could exceed the maximum allowed number `max_intervals`.
+refinement could exceed the maximum allowed number of intervals (1000000).
 
     >>> from scipy.stats import NumericalInverseHermite
     >>> from scipy.stats import norm, genexpon

--- a/doc/source/tutorial/stats/sampling_hinv.rst
+++ b/doc/source/tutorial/stats/sampling_hinv.rst
@@ -55,7 +55,7 @@ so the mesh of quantiles is refined as needed to reduce the maximum
 
 below the specified tolerance `u_resolution`. Refinement stops when the required
 tolerance is achieved or when the number of mesh intervals after the next
-refinement could exceed the maximum allowed number of intervals (1000000).
+refinement could exceed the maximum allowed number of intervals (100000).
 
     >>> from scipy.stats import NumericalInverseHermite
     >>> from scipy.stats import norm, genexpon

--- a/doc/source/tutorial/stats/sampling_pinv.rst
+++ b/doc/source/tutorial/stats/sampling_pinv.rst
@@ -258,14 +258,8 @@ We can use this, for example, to check the maximum and mean absolute u-error:
 The approximate PPF method provided by the generator is much faster to
 evaluate than the exact PPF of the distribution.
 
-During setup, the CDF of the distribution is computed numerically but it is
-discarded once the setup is complete. To keep the approximated CDF, pass
-``keep_cdf=True`` during initialization:
-
-    >>> rng = NumericalInversePolynomial(dist, keep_cdf=True, random_state=urng)
-
-Now, the CDF can be evaluated by calling the
-:func:`~NumericalInversePolynomial.cdf` method:
+During setup, a table of CDF points is stored that can be used to approximate the
+CDF once the generator has been created:
 
     >>> rng.cdf(1.959963984540054)
     0.9750000000042454
@@ -286,7 +280,7 @@ distribution):
     >>> x_error.max() <= max_integration_error
     True
 
-A CDF table computed during setup is used to evaluate the CDF and only some
+The CDF table computed during setup is used to evaluate the CDF and only some
 further fine-tuning is required. This reduces the calls to the PDF but as the
 fine-tuning step uses the simple Gauss-Lobatto quadrature, the PDF is called
 several times, slowing down the computation.

--- a/doc/source/tutorial/stats/sampling_tdr.rst
+++ b/doc/source/tutorial/stats/sampling_tdr.rst
@@ -26,15 +26,7 @@ called T-concave. Currently the following transformations are implemented:
 In addition to the PDF, it also requires the derivative of the PDF w.r.t ``x``
 (i.e. the variate). These functions must be present as methods of a python
 object which can then be passed to the generators to instantiate their object.
-
-Three variants of this method are available:
-
-* GW: squeezes between construction points.
-* PS: squeezes proportional to hat function. (Default)
-* IA: same as variant PS but uses a composition method with
-  "immediate acceptance" in the region below the squeeze.
-
-This can be changed by passing a ``variant`` parameter.
+The variant that is implemented uses squeezes proportional to hat function ([1]_).
 
 An example of using this method is shown below:
 
@@ -132,13 +124,9 @@ To increase ``squeeze_hat_ratio``, pass ``max_squeeze_hat_ratio``:
 
     >>> dist = StandardNormal()
     >>> rng = TransformedDensityRejection(dist, max_squeeze_hat_ratio=0.999,
-    ...                                   max_intervals=1000, random_state=urng)
+    ...                                   random_state=urng)
     >>> rng.squeeze_hat_ratio
     0.999364900465214
-
-Note that we need to increase the ``max_intervals`` parameter when we want
-a higher ``squeeze_hat_ratio``. This is because more construction points are
-required to fit the distribution more tightly.
 
 Let's see how this affects the callbacks to the PDF method of the
 distribution:
@@ -166,7 +154,7 @@ distribution:
     >>> dist2 = StandardNormal()
     >>> # use the same stream of uniform random numbers
     >>> rng2 = TransformedDensityRejection(dist2, max_squeeze_hat_ratio=0.999,
-    ...                                    max_intervals=1000, random_state=urng2)
+    ...                                    random_state=urng2)
     >>> dist2.callbacks  # evaluations during setup
     467
     >>> dist2.callbacks = 0  # don't consider evaluations during setup
@@ -203,18 +191,13 @@ the number of construction points to use.
     >>> rng = TransformedDensityRejection(dist,
     ...                                   construction_points=[-5, 0, 5])
 
-It is also possible to change the variant of the method used by passing
-a ``variant`` parameter:
-
-    >>> rng = TransformedDensityRejection(dist, variant='ia')
-
 This method accepts many other set-up parameters. See the documentation for
 an exclusive list. More information of the parameters and the method can be
 found in `Section 5.3.16 of the UNU.RAN user manual
 <http://statmath.wu.ac.at/software/unuran/doc/unuran.html#TDR>`__.
 
 
-Please see [1]_, [2]_, and [3]_ for more details on this method.
+Please see [1]_ and [2]_ for more details on this method.
 
 
 References
@@ -226,5 +209,4 @@ References
 .. [2] Hörmann, Wolfgang. "A rejection technique for sampling from
        T-concave distributions." ACM Transactions on Mathematical
        Software (TOMS) 21.2 (1995): 182-193
-.. [3] W.R. Gilks and P. Wild (1992). Adaptive rejection sampling for
-       Gibbs sampling, Applied Statistics 41, pp. 337-348.
+

--- a/scipy/stats/_unuran/unuran_wrapper.pyi
+++ b/scipy/stats/_unuran/unuran_wrapper.pyi
@@ -42,11 +42,8 @@ class TransformedDensityRejection(Method):
                  domain: None | Tuple[float, float] = ...,
                  c: float = ...,
                  construction_points: int | npt.ArrayLike = ...,
-                 variant: str = ...,
                  use_dars: bool = ...,
                  max_squeeze_hat_ratio: float = ...,
-                 max_intervals: int = ...,
-                 guide_factor: float = ...,
                  random_state: SeedType = ...) -> None: ...
     @property
     def squeeze_hat_ratio(self) -> float: ...
@@ -111,7 +108,6 @@ class NumericalInverseHermite(Method):
                  u_resolution: float = ...,
                  construction_points: None | npt.ArrayLike = ...,
                  max_intervals: int = ...,
-                 guide_factor: float = ...,
                  random_state: SeedType = ...) -> None: ...
     @property
     def intervals(self) -> int: ...

--- a/scipy/stats/_unuran/unuran_wrapper.pyi
+++ b/scipy/stats/_unuran/unuran_wrapper.pyi
@@ -74,7 +74,6 @@ class NumericalInversePolynomial(Method):
                  domain: None | Tuple[float, float] = ...,
                  order: int = ...,
                  u_resolution: float = ...,
-                 max_intervals: int = ...,
                  keep_cdf: bool = ...,
                  random_state: SeedType = ...) -> None: ...
     @property
@@ -107,7 +106,6 @@ class NumericalInverseHermite(Method):
                  order: int= ...,
                  u_resolution: float = ...,
                  construction_points: None | npt.ArrayLike = ...,
-                 max_intervals: int = ...,
                  random_state: SeedType = ...) -> None: ...
     @property
     def intervals(self) -> int: ...

--- a/scipy/stats/_unuran/unuran_wrapper.pyi
+++ b/scipy/stats/_unuran/unuran_wrapper.pyi
@@ -36,9 +36,9 @@ class TDRDist(Protocol):
 class TransformedDensityRejection(Method):
     def __init__(self,
                  dist: TDRDist,
+                 *,
                  mode: None | float = ...,
                  center: None | float = ...,
-                 *,
                  domain: None | Tuple[float, float] = ...,
                  c: float = ...,
                  construction_points: int | npt.ArrayLike = ...,
@@ -68,9 +68,9 @@ class PINVDist(Protocol):
 class NumericalInversePolynomial(Method):
     def __init__(self,
                  dist: PINVDist,
+                 *,
                  mode: None | float = ...,
                  center: None | float = ...,
-                 *,
                  domain: None | Tuple[float, float] = ...,
                  order: int = ...,
                  u_resolution: float = ...,

--- a/scipy/stats/_unuran/unuran_wrapper.pyi
+++ b/scipy/stats/_unuran/unuran_wrapper.pyi
@@ -106,6 +106,7 @@ class NumericalInverseHermite(Method):
                  order: int= ...,
                  u_resolution: float = ...,
                  construction_points: None | npt.ArrayLike = ...,
+                 max_intervals: int = ...,
                  random_state: SeedType = ...) -> None: ...
     @property
     def intervals(self) -> int: ...

--- a/scipy/stats/_unuran/unuran_wrapper.pyi
+++ b/scipy/stats/_unuran/unuran_wrapper.pyi
@@ -74,7 +74,6 @@ class NumericalInversePolynomial(Method):
                  domain: None | Tuple[float, float] = ...,
                  order: int = ...,
                  u_resolution: float = ...,
-                 keep_cdf: bool = ...,
                  random_state: SeedType = ...) -> None: ...
     @property
     def intervals(self) -> int: ...

--- a/scipy/stats/_unuran/unuran_wrapper.pyx.templ
+++ b/scipy/stats/_unuran/unuran_wrapper.pyx.templ
@@ -974,7 +974,7 @@ UError = namedtuple('UError', ['max_error', 'mean_absolute_error'])
 
 cdef class NumericalInversePolynomial(Method):
     """
-    NumericalInversePolynomial(dist, *, mode=None, center=None, domain=None, order=5, u_resolution=1e-10, keep_cdf=False, random_state=None)
+    NumericalInversePolynomial(dist, *, mode=None, center=None, domain=None, order=5, u_resolution=1e-10, random_state=None)
 
     Polynomial interpolation based INVersion of CDF (PINV).
 
@@ -1057,12 +1057,6 @@ cdef class NumericalInversePolynomial(Method):
         is 2-32= 2.3e-10. Thus a value of 1.e-10 leads to an inversion algorithm that
         could be called exact. For most simulations slightly bigger values for the
         maximal error are enough as well. Default is 1e-10.
-    keep_cdf : bool, optional
-        If the PDF is given, then the CDF is computed numerically from the given PDF using
-        adaptive Gauss-Lobatto integration. Thus a table of CDF points is stored to keep
-        the number of evaluations of the PDF minimal. Usually this table is discarded when
-        the setup is completed. If ``keep_cdf`` is TRUE, then this table is kept and the
-        approximated CDF can be evaluated by calling the `cdf` method. Default is ``False``.
     random_state : {None, int, `numpy.random.Generator`,
                         `numpy.random.RandomState`}, optional
 
@@ -1183,7 +1177,6 @@ cdef class NumericalInversePolynomial(Method):
     >>> plt.title('Error between exact and approximated PPF (x-error)')
     >>> plt.show()
     """
-    cdef bint keep_cdf
 
     def __cinit__(self,
                   dist,
@@ -1193,7 +1186,6 @@ cdef class NumericalInversePolynomial(Method):
                   domain=None,
                   order=5,
                   u_resolution=1e-10,
-                  keep_cdf=False,
                   random_state=None):
         (domain, order, u_resolution) = self._validate_args(
             dist, domain, order, u_resolution
@@ -1206,10 +1198,8 @@ cdef class NumericalInversePolynomial(Method):
             'domain': domain,
             'order': order,
             'u_resolution': u_resolution,
-            'keep_cdf': keep_cdf,
             'random_state': random_state
         }
-        self.keep_cdf = keep_cdf
 
         cdef:
             unur_distr *distr
@@ -1248,7 +1238,8 @@ cdef class NumericalInversePolynomial(Method):
             # max_intervals is not part of the API. set it to the maximum
             # allowed value in UNU.RAN which is 1_000_000
             self._check_errorcode(unur_pinv_set_max_intervals(self.par, 1000000))
-            self._check_errorcode(unur_pinv_set_keepcdf(self.par, keep_cdf))
+            # always keep CDF in SciPy while UNU.RAN default is False
+            self._check_errorcode(unur_pinv_set_keepcdf(self.par, 1))
 
             self._set_rng(random_state)
         finally:
@@ -1297,8 +1288,6 @@ cdef class NumericalInversePolynomial(Method):
         cdf(x)
 
         Approximated cumulative distribution function of the given distribution.
-        Only available if ``keep_cdf`` was set to ``True`` when the instance was
-        created.
 
         Parameters
         ----------
@@ -1310,10 +1299,6 @@ cdef class NumericalInversePolynomial(Method):
         cdf : array_like
             Approximated cumulative distribution function evaluated at `x`.
         """
-        if not self.keep_cdf:
-            raise ValueError("CDF is not available. Initialize the generator "
-                             "again with `keep_cdf=True` to enable "
-                             "evaluation of (approximate) CDF.")
         x = np.asarray(x, dtype='d')
         oshape = x.shape
         x = x.ravel()

--- a/scipy/stats/_unuran/unuran_wrapper.pyx.templ
+++ b/scipy/stats/_unuran/unuran_wrapper.pyx.templ
@@ -974,7 +974,7 @@ UError = namedtuple('UError', ['max_error', 'mean_absolute_error'])
 
 cdef class NumericalInversePolynomial(Method):
     """
-    NumericalInversePolynomial(dist, mode=None, center=None, *, domain=None, order=5, u_resolution=1e-10, max_intervals=10000, keep_cdf=False, random_state=None)
+    NumericalInversePolynomial(dist, mode=None, center=None, *, domain=None, order=5, u_resolution=1e-10, keep_cdf=False, random_state=None)
 
     Polynomial interpolation based INVersion of CDF (PINV).
 
@@ -1057,9 +1057,6 @@ cdef class NumericalInversePolynomial(Method):
         is 2-32= 2.3e-10. Thus a value of 1.e-10 leads to an inversion algorithm that
         could be called exact. For most simulations slightly bigger values for the
         maximal error are enough as well. Default is 1e-10.
-    max_intervals : int, optional
-        Set maximum number of intervals. Must be in the range [100, 1000000].
-        Default is 10000.
     keep_cdf : bool, optional
         If the PDF is given, then the CDF is computed numerically from the given PDF using
         adaptive Gauss-Lobatto integration. Thus a table of CDF points is stored to keep
@@ -1196,11 +1193,10 @@ cdef class NumericalInversePolynomial(Method):
                   domain=None,
                   order=5,
                   u_resolution=1e-10,
-                  max_intervals=10000,
                   keep_cdf=False,
                   random_state=None):
-        (domain, order, u_resolution, max_intervals) = self._validate_args(
-            dist, domain, order, u_resolution, max_intervals
+        (domain, order, u_resolution) = self._validate_args(
+            dist, domain, order, u_resolution
         )
 
         # save all the arguments for pickling support
@@ -1210,7 +1206,6 @@ cdef class NumericalInversePolynomial(Method):
             'domain': domain,
             'order': order,
             'u_resolution': u_resolution,
-            'max_intervals': max_intervals,
             'keep_cdf': keep_cdf,
             'random_state': random_state
         }
@@ -1250,14 +1245,16 @@ cdef class NumericalInversePolynomial(Method):
 
             self._check_errorcode(unur_pinv_set_order(self.par, order))
             self._check_errorcode(unur_pinv_set_u_resolution(self.par, u_resolution))
-            self._check_errorcode(unur_pinv_set_max_intervals(self.par, max_intervals))
+            # max_intervals is not part of the API in SciPy
+            # set it to the highest allowed value in UNU.RAN (1e6)
+            self._check_errorcode(unur_pinv_set_max_intervals(self.par, 1000000))
             self._check_errorcode(unur_pinv_set_keepcdf(self.par, keep_cdf))
 
             self._set_rng(random_state)
         finally:
             _lock.release()
 
-    cdef object _validate_args(self, dist, domain, order, u_resolution, max_intervals):
+    cdef object _validate_args(self, dist, domain, order, u_resolution):
         domain = _validate_domain(domain, dist)
         # UNU.RAN raises warning and sets a default value. Prefer an error instead.
         if not (3 <= order <= 17 and int(order) == order):
@@ -1266,10 +1263,7 @@ cdef class NumericalInversePolynomial(Method):
         # it is not in the range [1.e-15, 1.e-5]. Prefer an error instead.
         if not (1e-15 <= u_resolution <= 1e-5):
             raise ValueError("`u_resolution` must be between 1e-15 and 1e-5.")
-        # UNU.RAN raises warning and sets a default value. Prefer an error instead.
-        if not (100 <= max_intervals <= 1000000 and int(max_intervals) == max_intervals):
-            raise ValueError("`max_intervals` must be an integer in the range [100, 1000000].")
-        return (domain, order, u_resolution, max_intervals)
+        return (domain, order, u_resolution)
 
     @property
     def intervals(self):
@@ -1417,7 +1411,7 @@ cdef class NumericalInversePolynomial(Method):
 
 cdef class NumericalInverseHermite(Method):
     """
-    NumericalInverseHermite(dist, *, domain=None, order=3, u_resolution=1e-12, construction_points=None, max_intervals=100000, random_state=None)
+    NumericalInverseHermite(dist, *, domain=None, order=3, u_resolution=1e-12, construction_points=None, random_state=None)
 
     Hermite interpolation based INVersion of CDF (HINV).
 
@@ -1482,9 +1476,6 @@ cdef class NumericalInverseHermite(Method):
         special design points for computing the Hermite interpolation to guarantee that the
         maximal u-error can not be bigger than desired. Such points are points where the
         density is not differentiable or has a local extremum.
-    max_intervals : int, default: ``100000``
-        Maximum number of intervals in the Hermite spline used to
-        approximate the percent point function. The default is 100000.
     random_state : {None, int, `numpy.random.Generator`,
                         `numpy.random.RandomState`}, optional
 
@@ -1521,7 +1512,8 @@ cdef class NumericalInverseHermite(Method):
 
     below the specified tolerance `u_resolution`. Refinement stops when the required
     tolerance is achieved or when the number of mesh intervals after the next
-    refinement could exceed the maximum allowed number `max_intervals`.
+    refinement could exceed the maximum allowed number of intervals, which is
+    one million.
 
     This method accepted a `tol` parameter to specify the maximum tolerable u-error
     but it has now been deprecated in the favor of `u_resolution`. `tol` will be
@@ -1672,9 +1664,8 @@ cdef class NumericalInverseHermite(Method):
                   u_resolution=1e-12,
                   tol=None,
                   construction_points=None,
-                  max_intervals=100000,
                   random_state=None):
-        domain, order, u_resolution = self._validate_args(dist, domain, order, max_intervals,
+        domain, order, u_resolution = self._validate_args(dist, domain, order,
                                                           u_resolution, tol, construction_points)
 
         # save all the arguments for pickling support
@@ -1684,7 +1675,6 @@ cdef class NumericalInverseHermite(Method):
             'order': order,
             'u_resolution': u_resolution,
             'tol': tol,
-            'max_intervals': max_intervals,
             'construction_points': construction_points,
             'random_state': random_state
         }
@@ -1717,21 +1707,19 @@ cdef class NumericalInverseHermite(Method):
 
             self._check_errorcode(unur_hinv_set_order(self.par, order))
             self._check_errorcode(unur_hinv_set_u_resolution(self.par, u_resolution))
-            self._check_errorcode(unur_hinv_set_max_intervals(self.par, max_intervals))
+            self._check_errorcode(unur_hinv_set_max_intervals(self.par, 1000000))
             self._check_errorcode(unur_hinv_set_cpoints(self.par, &self.construction_points_array[0],
                                                         len(self.construction_points_array)))
             self._set_rng(random_state)
         finally:
             _lock.release()
 
-    def _validate_args(self, dist, domain, order, max_intervals, u_resolution, tol,
+    def _validate_args(self, dist, domain, order, u_resolution, tol,
                        construction_points):
         domain = _validate_domain(domain, dist)
         # UNU.RAN raises warning and sets a default value. Prefer an error instead.
         if order not in {1, 3, 5}:
             raise ValueError("`order` must be either 1, 3, or 5.")
-        if int(max_intervals) != max_intervals or max_intervals <= 1:
-            raise ValueError("`max_intervals' must be an integer greater than 1.")
         if tol is not None:
             warnings.warn("`tol` has been deprecated and replaced with `u_resolution`. "
                           "It will be completely removed in a future release.",

--- a/scipy/stats/_unuran/unuran_wrapper.pyx.templ
+++ b/scipy/stats/_unuran/unuran_wrapper.pyx.templ
@@ -632,7 +632,7 @@ cdef class Method:
 
 cdef class TransformedDensityRejection(Method):
     r"""
-    TransformedDensityRejection(dist, mode=None, center=None, *, domain=None, c=-0.5, construction_points=30, variant="ps", use_dars=True, max_squeeze_hat_ratio=0.99, max_intervals=100, guide_factor=2, random_state=None)
+    TransformedDensityRejection(dist, mode=None, center=None, *, domain=None, c=-0.5, construction_points=30, use_dars=True, max_squeeze_hat_ratio=0.99, random_state=None)
 
     Transformed Density Rejection (TDR) Method.
 
@@ -688,15 +688,6 @@ cdef class TransformedDensityRejection(Method):
         If an integer, it defines the number of construction points. If it
         is array-like, the elements of the array are used as construction
         points. Default is 30.
-    variant : {'ps', 'gw', 'ia'}, optional
-        The variant to use. The default is 'ps'.
-        Three variants of this method are available:
-
-        * GW: squeezes between construction points, see [3]_.
-        * PS: squeezes proportional to hat function. (Default)
-        * IA: same as variant PS but uses a composition method with
-          "immediate acceptance" in the region below the squeeze.
-
     use_dars : bool, optional
         If True, "derandomized adaptive rejection sampling" (DARS) is used
         in setup. See [1]_ for the details of the DARS algorithm. Default
@@ -704,12 +695,6 @@ cdef class TransformedDensityRejection(Method):
     max_squeeze_hat_ratio : float, optional
         Set upper bound for the ratio (area below squeeze) / (area below hat).
         It must be a number between 0 and 1. Default is 0.99.
-    max_intervals : int, optional
-        Set maximum number of intervals. Default is 100.
-    guide_factor : float, optional
-        Set factor for relative size of the guide table for indexed search.
-        It must be greater than or equal to 0. When set to 0, then sequential
-        search is used. Default is 2.
     random_state : {None, int, `numpy.random.Generator`,
                         `numpy.random.RandomState`}, optional
 
@@ -802,13 +787,6 @@ cdef class TransformedDensityRejection(Method):
     >>> plt.title('Transformed Density Rejection Samples')
     >>> plt.legend()
     >>> plt.show()
-
-    To use the log transformation with 10 construction points and the
-    immediate acceptance variant of the method, do:
-
-    >>> rng = TransformedDensityRejection(dist, c=0., construction_points=10,
-    ...                                   variant='ia', random_state=urng)
-    >>> rvs = rng.rvs(1000)
     """
     cdef double[::1] construction_points_array
 
@@ -820,13 +798,10 @@ cdef class TransformedDensityRejection(Method):
                   domain=None,
                   c=-0.5,
                   construction_points=30,
-                  variant="ps",
                   use_dars=True,
                   max_squeeze_hat_ratio=0.99,
-                  max_intervals=100,
-                  guide_factor=2,
                   random_state=None):
-        (domain, c, construction_points, variant) = self._validate_args(dist, domain, c, construction_points, variant)
+        (domain, c, construction_points) = self._validate_args(dist, domain, c, construction_points)
 
         # save all the arguments for pickling support
         self._kwargs = {
@@ -836,11 +811,8 @@ cdef class TransformedDensityRejection(Method):
             'domain': domain,
             'c': c,
             'construction_points': construction_points,
-            'variant': variant,
             'use_dars': use_dars,
             'max_squeeze_hat_ratio': max_squeeze_hat_ratio,
-            'max_intervals': max_intervals,
-            'guide_factor': guide_factor,
             'random_state': random_state
         }
 
@@ -882,28 +854,24 @@ cdef class TransformedDensityRejection(Method):
                 self._check_errorcode(unur_tdr_set_cpoints(self.par, len(self.construction_points_array),
                                                            &self.construction_points_array[0]))
 
-            if variant == "ps":
-                self._check_errorcode(unur_tdr_set_variant_ps(self.par))
-            elif variant == "ia":
-                self._check_errorcode(unur_tdr_set_variant_ia(self.par))
-            elif variant == "gw":
-                self._check_errorcode(unur_tdr_set_variant_gw(self.par))
+            # PS variant is the default in UNU.RAN
+            self._check_errorcode(unur_tdr_set_variant_ps(self.par))
 
             self._check_errorcode(unur_tdr_set_usedars(self.par, use_dars))
             self._check_errorcode(unur_tdr_set_max_sqhratio(self.par, max_squeeze_hat_ratio))
-            self._check_errorcode(unur_tdr_set_max_intervals(self.par, max_intervals))
-            self._check_errorcode(unur_tdr_set_guidefactor(self.par, guide_factor))
+            # the parameter max_intervals is not part of the SciPy API
+            # UNU.RAN default is 100, we use a higher value to avoid problems
+            # if max_squeeze_hat_ratio is increased
+            self._check_errorcode(unur_tdr_set_max_intervals(self.par, 10000))
 
             self._set_rng(random_state)
         finally:
             _lock.release()
 
-    cdef object _validate_args(self, dist, domain, c, construction_points, variant):
+    cdef object _validate_args(self, dist, domain, c, construction_points):
         domain = _validate_domain(domain, dist)
         if c not in {-0.5, 0.}:
             raise ValueError("`c` must either be -0.5 or 0.")
-        if variant not in {"ps", "gw", "ia"}:
-            raise ValueError("Invalid option for the `variant`.")
         if not np.isscalar(construction_points):
             self.construction_points_array = np.ascontiguousarray(construction_points,
                                                                   dtype=np.float64)
@@ -916,7 +884,7 @@ cdef class TransformedDensityRejection(Method):
                 construction_points != int(construction_points)):
                 raise ValueError("`construction_points` must be a positive integer.")
 
-        return domain, c, construction_points, variant
+        return domain, c, construction_points
 
     @property
     def squeeze_hat_ratio(self):
@@ -949,9 +917,6 @@ cdef class TransformedDensityRejection(Method):
         ppf_hat(u)
 
         Evaluate the inverse of the CDF of the hat distribution at `u`.
-
-        This call does not work for variant IA (immediate acceptance).
-        In this case the hat CDF is evaluated as if variant PS is used.
 
         Parameters
         ----------
@@ -1452,7 +1417,7 @@ cdef class NumericalInversePolynomial(Method):
 
 cdef class NumericalInverseHermite(Method):
     """
-    NumericalInverseHermite(dist, *, domain=None, order=3, u_resolution=1e-12, construction_points=None, max_intervals=100000, guide_factor=1, random_state=None)
+    NumericalInverseHermite(dist, *, domain=None, order=3, u_resolution=1e-12, construction_points=None, max_intervals=100000, random_state=None)
 
     Hermite interpolation based INVersion of CDF (HINV).
 
@@ -1520,10 +1485,6 @@ cdef class NumericalInverseHermite(Method):
     max_intervals : int, default: ``100000``
         Maximum number of intervals in the Hermite spline used to
         approximate the percent point function. The default is 100000.
-    guide_factor : float, default: ``1``
-        Set factor for relative size of the guide table for indexed search.
-        It must be greater than or equal to 0. When set to 0, then sequential
-        search is used. Default is 1.
     random_state : {None, int, `numpy.random.Generator`,
                         `numpy.random.RandomState`}, optional
 
@@ -1712,7 +1673,6 @@ cdef class NumericalInverseHermite(Method):
                   tol=None,
                   construction_points=None,
                   max_intervals=100000,
-                  guide_factor=1,
                   random_state=None):
         domain, order, u_resolution = self._validate_args(dist, domain, order, max_intervals,
                                                           u_resolution, tol, construction_points)
@@ -1725,7 +1685,6 @@ cdef class NumericalInverseHermite(Method):
             'u_resolution': u_resolution,
             'tol': tol,
             'max_intervals': max_intervals,
-            'guide_factor': guide_factor,
             'construction_points': construction_points,
             'random_state': random_state
         }
@@ -1761,8 +1720,6 @@ cdef class NumericalInverseHermite(Method):
             self._check_errorcode(unur_hinv_set_max_intervals(self.par, max_intervals))
             self._check_errorcode(unur_hinv_set_cpoints(self.par, &self.construction_points_array[0],
                                                         len(self.construction_points_array)))
-            self._check_errorcode(unur_hinv_set_guidefactor(self.par, guide_factor))
-
             self._set_rng(random_state)
         finally:
             _lock.release()

--- a/scipy/stats/_unuran/unuran_wrapper.pyx.templ
+++ b/scipy/stats/_unuran/unuran_wrapper.pyx.templ
@@ -1245,8 +1245,8 @@ cdef class NumericalInversePolynomial(Method):
 
             self._check_errorcode(unur_pinv_set_order(self.par, order))
             self._check_errorcode(unur_pinv_set_u_resolution(self.par, u_resolution))
-            # max_intervals is not part of the API in SciPy
-            # set it to the highest allowed value in UNU.RAN (1e6)
+            # max_intervals is not part of the API. set it to the maximum
+            # allowed value in UNU.RAN which is 1_000_000
             self._check_errorcode(unur_pinv_set_max_intervals(self.par, 1000000))
             self._check_errorcode(unur_pinv_set_keepcdf(self.par, keep_cdf))
 
@@ -1513,7 +1513,7 @@ cdef class NumericalInverseHermite(Method):
     below the specified tolerance `u_resolution`. Refinement stops when the required
     tolerance is achieved or when the number of mesh intervals after the next
     refinement could exceed the maximum allowed number of intervals, which is
-    one million.
+    100000.
 
     This method accepted a `tol` parameter to specify the maximum tolerable u-error
     but it has now been deprecated in the favor of `u_resolution`. `tol` will be
@@ -1664,8 +1664,9 @@ cdef class NumericalInverseHermite(Method):
                   u_resolution=1e-12,
                   tol=None,
                   construction_points=None,
+                  max_intervals=100000,
                   random_state=None):
-        domain, order, u_resolution = self._validate_args(dist, domain, order,
+        domain, order, u_resolution = self._validate_args(dist, domain, order, max_intervals,
                                                           u_resolution, tol, construction_points)
 
         # save all the arguments for pickling support
@@ -1675,6 +1676,7 @@ cdef class NumericalInverseHermite(Method):
             'order': order,
             'u_resolution': u_resolution,
             'tol': tol,
+            'max_intervals': max_intervals,
             'construction_points': construction_points,
             'random_state': random_state
         }
@@ -1707,21 +1709,25 @@ cdef class NumericalInverseHermite(Method):
 
             self._check_errorcode(unur_hinv_set_order(self.par, order))
             self._check_errorcode(unur_hinv_set_u_resolution(self.par, u_resolution))
-            # max_intervals is not part of the API, set it to 1e6
-            # this is the default in UNU.RAN
-            self._check_errorcode(unur_hinv_set_max_intervals(self.par, 1000000))
+            self._check_errorcode(unur_hinv_set_max_intervals(self.par, max_intervals))
             self._check_errorcode(unur_hinv_set_cpoints(self.par, &self.construction_points_array[0],
                                                         len(self.construction_points_array)))
             self._set_rng(random_state)
         finally:
             _lock.release()
 
-    def _validate_args(self, dist, domain, order, u_resolution, tol,
+    def _validate_args(self, dist, domain, order, max_intervals, u_resolution, tol,
                        construction_points):
         domain = _validate_domain(domain, dist)
         # UNU.RAN raises warning and sets a default value. Prefer an error instead.
         if order not in {1, 3, 5}:
             raise ValueError("`order` must be either 1, 3, or 5.")
+        if int(max_intervals) != max_intervals or max_intervals <= 1:
+            raise ValueError("`max_intervals' must be an integer greater than 1.")
+        if max_intervals != 100000:
+            warnings.warn("`max_intervals` has been deprecated. "
+                          "It will be completely removed in a future release.",
+                          DeprecationWarning)
         if tol is not None:
             warnings.warn("`tol` has been deprecated and replaced with `u_resolution`. "
                           "It will be completely removed in a future release.",

--- a/scipy/stats/_unuran/unuran_wrapper.pyx.templ
+++ b/scipy/stats/_unuran/unuran_wrapper.pyx.templ
@@ -1707,6 +1707,8 @@ cdef class NumericalInverseHermite(Method):
 
             self._check_errorcode(unur_hinv_set_order(self.par, order))
             self._check_errorcode(unur_hinv_set_u_resolution(self.par, u_resolution))
+            # max_intervals is not part of the API, set it to 1e6
+            # this is the default in UNU.RAN
             self._check_errorcode(unur_hinv_set_max_intervals(self.par, 1000000))
             self._check_errorcode(unur_hinv_set_cpoints(self.par, &self.construction_points_array[0],
                                                         len(self.construction_points_array)))

--- a/scipy/stats/_unuran/unuran_wrapper.pyx.templ
+++ b/scipy/stats/_unuran/unuran_wrapper.pyx.templ
@@ -632,7 +632,7 @@ cdef class Method:
 
 cdef class TransformedDensityRejection(Method):
     r"""
-    TransformedDensityRejection(dist, mode=None, center=None, *, domain=None, c=-0.5, construction_points=30, use_dars=True, max_squeeze_hat_ratio=0.99, random_state=None)
+    TransformedDensityRejection(dist, *, mode=None, center=None, domain=None, c=-0.5, construction_points=30, use_dars=True, max_squeeze_hat_ratio=0.99, random_state=None)
 
     Transformed Density Rejection (TDR) Method.
 
@@ -792,9 +792,9 @@ cdef class TransformedDensityRejection(Method):
 
     def __cinit__(self,
                   dist,
+                  *,
                   mode=None,
                   center=None,
-                  *,
                   domain=None,
                   c=-0.5,
                   construction_points=30,
@@ -974,7 +974,7 @@ UError = namedtuple('UError', ['max_error', 'mean_absolute_error'])
 
 cdef class NumericalInversePolynomial(Method):
     """
-    NumericalInversePolynomial(dist, mode=None, center=None, *, domain=None, order=5, u_resolution=1e-10, keep_cdf=False, random_state=None)
+    NumericalInversePolynomial(dist, *, mode=None, center=None, domain=None, order=5, u_resolution=1e-10, keep_cdf=False, random_state=None)
 
     Polynomial interpolation based INVersion of CDF (PINV).
 
@@ -1187,9 +1187,9 @@ cdef class NumericalInversePolynomial(Method):
 
     def __cinit__(self,
                   dist,
+                  *,
                   mode=None,
                   center=None,
-                  *,
                   domain=None,
                   order=5,
                   u_resolution=1e-10,

--- a/scipy/stats/tests/test_sampling.py
+++ b/scipy/stats/tests/test_sampling.py
@@ -800,7 +800,6 @@ class TestNumericalInversePolynomial:
 
     bad_orders = [1, 4.5, 20, np.inf, np.nan]
     bad_u_resolution = [1e-20, 1e-1, np.inf, np.nan]
-    bad_max_intervals = [10, 10000000, 1000.5, np.inf, np.nan]
 
     @pytest.mark.parametrize("order", bad_orders)
     def test_bad_orders(self, order):
@@ -816,14 +815,6 @@ class TestNumericalInversePolynomial:
         with pytest.raises(ValueError, match=msg):
             NumericalInversePolynomial(StandardNormal(),
                                        u_resolution=u_resolution)
-
-    @pytest.mark.parametrize("max_intervals", bad_max_intervals)
-    def test_bad_max_intervals(self, max_intervals):
-        msg = (r"`max_intervals` must be an integer in the range "
-               r"\[100, 1000000\].")
-        with pytest.raises(ValueError, match=msg):
-            NumericalInversePolynomial(StandardNormal(),
-                                       max_intervals=max_intervals)
 
     def test_bad_args(self):
         dist = StandardNormal()
@@ -962,10 +953,6 @@ class TestNumericalInverseHermite:
         with pytest.raises(ValueError, match=match):
             stats.NumericalInverseHermite(StandardNormal(),
                                           u_resolution='ekki')
-
-        match = "`max_intervals' must be..."
-        with pytest.raises(ValueError, match=match):
-            stats.NumericalInverseHermite(StandardNormal(), max_intervals=-1)
 
         match = "`qmc_engine` must be an instance of..."
         with pytest.raises(ValueError, match=match):

--- a/scipy/stats/tests/test_sampling.py
+++ b/scipy/stats/tests/test_sampling.py
@@ -463,11 +463,6 @@ class TestTransformedDensityRejection:
         with pytest.raises(ValueError, match=msg):
             TransformedDensityRejection(StandardNormal(), c=-1.)
 
-    def test_bad_variant(self):
-        msg = r"Invalid option for the `variant`"
-        with pytest.raises(ValueError, match=msg):
-            TransformedDensityRejection(StandardNormal(), variant='foo')
-
     u = [np.linspace(0, 1, num=1000), [], [[]], [np.nan],
          [-np.inf, np.nan, np.inf], 0,
          [[np.nan, 0.5, 0.1], [0.2, 0.4, np.inf], [-2, 3, 4]]]
@@ -477,8 +472,7 @@ class TestTransformedDensityRejection:
         # Increase the `max_squeeze_hat_ratio` so the ppf_hat is more
         # accurate.
         rng = TransformedDensityRejection(StandardNormal(),
-                                          max_squeeze_hat_ratio=0.9999,
-                                          max_intervals=10000)
+                                          max_squeeze_hat_ratio=0.9999)
         # Older versions of NumPy throw RuntimeWarnings for comparisons
         # with nan.
         with suppress_warnings() as sup:

--- a/scipy/stats/tests/test_sampling.py
+++ b/scipy/stats/tests/test_sampling.py
@@ -771,8 +771,7 @@ class TestNumericalInversePolynomial:
     @pytest.mark.parametrize("x", x)
     def test_cdf(self, x):
         dist = StandardNormal()
-        rng = NumericalInversePolynomial(dist, keep_cdf=True,
-                                         u_resolution=1e-14)
+        rng = NumericalInversePolynomial(dist, u_resolution=1e-14)
         # Older versions of NumPy throw RuntimeWarnings for comparisons
         # with nan.
         with suppress_warnings() as sup:
@@ -819,9 +818,6 @@ class TestNumericalInversePolynomial:
     def test_bad_args(self):
         dist = StandardNormal()
         rng = NumericalInversePolynomial(dist)
-        msg = r"CDF is not available."
-        with pytest.raises(ValueError, match=msg):
-            rng.cdf([1, 2, 3])
         msg = r"`sample_size` must be greater than or equal to 1000."
         with pytest.raises(ValueError, match=msg):
             rng.u_error(10)

--- a/scipy/stats/tests/test_sampling.py
+++ b/scipy/stats/tests/test_sampling.py
@@ -954,6 +954,10 @@ class TestNumericalInverseHermite:
             stats.NumericalInverseHermite(StandardNormal(),
                                           u_resolution='ekki')
 
+        match = "`max_intervals' must be..."
+        with pytest.raises(ValueError, match=match):
+            stats.NumericalInverseHermite(StandardNormal(), max_intervals=-1)
+
         match = "`qmc_engine` must be an instance of..."
         with pytest.raises(ValueError, match=match):
             fni = stats.NumericalInverseHermite(StandardNormal())


### PR DESCRIPTION
#### Reference issue
gh-14830

#### What does this implement/fix?
- Remove a few parameters from `NumericalInverseHermite, NumericalInversePolinomial,TransformedDensityRejection`
- make all parameters but `dist`keyword only in `NumericalInversePolinomial, TransformedDensityRejection` to align the API to `...Hermite`
#### Additional information
...
