### PR TITLE
DOC: update toolchain.rst

### DIFF
--- a/doc/source/dev/toolchain.rst
+++ b/doc/source/dev/toolchain.rst
@@ -46,7 +46,7 @@ Python Versions
 ^^^^^^^^^^^^^^^
 
 SciPy is compatible with several versions of Python.  When dropping support for
-older Python versions, SciPy takes guidance from NEP 29 [10]_.  Python 2.7
+older Python versions, SciPy takes guidance from NEP 29 [1]_.  Python 2.7
 support was dropped starting from SciPy 1.3.
 
 ================  =======================================================================
@@ -65,7 +65,7 @@ NumPy
 SciPy depends on NumPy but releases of SciPy are not tied to releases of NumPy.
 SciPy attempts to be compatible with at least the 4 previous releases of NumPy.
 In particular, SciPy cannot rely on features of just the latest NumPy, but
-needs to be written using what is common in all of those 4 releases [3]_.
+needs to be written using what is common in all of those 4 releases [2]_.
 
 The table shows the NumPy versions suitable for each major Python version.
 
@@ -82,8 +82,8 @@ The table shows the NumPy versions suitable for each major Python version.
 =================  ========================    =======================
 
 In specific cases, such as a particular architecture, these requirements
-could vary. Please check the release notes and the meta-package
-``oldest-supported-numpy`` for more info. [18]_, [19]_.
+could vary. Please check the release notes [3]_ and the meta-package
+``oldest-supported-numpy`` for more info [4]_.
 
 
 Compilers
@@ -103,16 +103,16 @@ Official Builds
 Currently, SciPy wheels are being built as follows:
 
 ================  ========================  ===========================  ==============================
- Platform          Azure Base Image [14]_    Compilers                    Comment
+ Platform          Azure Base Image [5]_     Compilers                    Comment
 ================  ========================  ===========================  ==============================
 Linux (nightly)    ``ubuntu-18.04``          GCC 6.5                      See ``azure-pipelines.yml``
-Linux (release)    ``ubuntu-18.04``          GCC 7.5                      Built in separate repo [15]_
-OSX                ``macOS-10.15``           LLVM 12.0.0                  Built in separate repo [15]_
+Linux (release)    ``ubuntu-18.04``          GCC 7.5                      Built in separate repo [6]_
+OSX                ``macOS-10.15``           LLVM 12.0.0                  Built in separate repo [6]_
 Windows            ``windows-latest``        Visual Studio 2019 (16.11)   See ``azure-pipelines.yml``
 ================  ========================  ===========================  ==============================
 
 Note that the OSX wheels additionally vendor gfortran 4.9,
-see submodule ``gfortran-install`` in [15]_.
+see submodule ``gfortran-install`` in [6]_.
 
 
 C Compilers
@@ -124,10 +124,10 @@ there was a long-standing restriction that Windows builds of SciPy had to use
 the same version of the Microsoft Visual C++ compiler as were used for CPython
 itself, for reasons of ABI-compatibility [7]_, [8]_.
 
-With the introduction of the "Universal C Runtime" [16]_ since the release of
+With the introduction of the "Universal C Runtime" [9]_ since the release of
 Visual Studio 2015, this restriction has been lifted. For more context, see the
 explanations by Steve Dower (member of the CPython-on-Windows core developers)
-on this topic [17]_.
+on this topic [10]_.
 
 The use of MS Visual Studio 9.0 (which doesn't have support for C99)
 to build Python 2.7 has meant that C code in SciPy has had to conform
@@ -136,16 +136,16 @@ With the dropping of Python 2.7 for SciPy 1.3.x, the C90 restriction is no
 longer imposed by compilers.
 
 In terms of C language standards, it's relevant to note that C11 has optional
-features [12]_ (e.g. atomics, threading), some of which (VLAs & complex types)
+features [11]_ (e.g. atomics, threading), some of which (VLAs & complex types)
 were mandatory in the C99 standard. C17 (occasionally called C18) can be
 considered a bug fix for C11, so generally, C11 may be skipped entirely.
 
 SciPy has been restricted in the use of more advanced language features by the
 available compiler support, and Microsoft in particular has taken very long to
 achieve conformance to C99/C11/C17, however starting from MS Visual Studio 16.8,
-C11/C17 is supported [11]_ (though without the C11 optional features).
+C11/C17 is supported [12]_ (though without the C11 optional features).
 C99 ``<complex.h>`` would be particularly interesting for scipy;
-MSVC conformance for this is being tracked here [5]_.
+MSVC conformance for this is being tracked here [13]_.
 
 Therefore, using C features beyond C90 was only possible insofar there was support on
 windows; however, as of as of the end of 2021, a sufficiently recent compiler is used.
@@ -187,20 +187,20 @@ CPython) has been recent enough to support even C++17.
 Since the official builds (see above) use a pretty recent version of LLVM,
 the bottleneck for C++ support is therefore the oldest supported GCC version,
 where scipy has been constrained mainly by the version in the oldest supported
-manylinx versions & images [20]_.
+manylinx versions & images [14]_.
 
 At the end of 2021 (with the final removal of ``manylinux1`` wheels), scipy
 now has a minimum GCC requirement of GCC 6.3, which has full C++14 support
-[4]_. This corresponds to the lowest present GCC version in relevant manylinux
+[15]_. This corresponds to the lowest present GCC version in relevant manylinux
 versions - somewhat surprisingly, it is not the oldest remaining
 ``manylinux2010`` that is the most restrictive (due to the ABI-compatible
 "RHEL Dev Toolset" backports, it has GCC 8.3), but actually ``manylinux_2_24``
-that only comes with GCC 6.3 [21]_.
+that only comes with GCC 6.3 [16]_.
 
 C++17 _language_ support will require GCC >= 7 (released May 2017). As of the
 end of 2021, support for the entirety of the C++17 standard library has not yet
 been completed across all compilers; similarly, support for C++20 and C++23
-is still under heavy development. [4]_
+is still under heavy development. [15]_
 
 Fortran Compilers
 ~~~~~~~~~~~~~~~~~
@@ -227,7 +227,7 @@ is a build dependency (currently with the possibility to opt out).
 OpenMP support
 ^^^^^^^^^^^^^^
 
-For various reasons [13]_, SciPy cannot be distributed with built-in OpenMP support.
+For various reasons [17]_, SciPy cannot be distributed with built-in OpenMP support.
 When using the optional Pythran support, OpenMP-enabled parallel code can be
 generated when building from source.
 
@@ -325,20 +325,20 @@ making and distributing a SciPy release.
 References
 ----------
 
-.. [3] https://numpy.org/doc/stable/release.html
-.. [4] https://en.cppreference.com/w/cpp/compiler_support
-.. [5] https://developercommunity.visualstudio.com/t/Support-for-C99-Complex-numbers/1409049?space=8&q=complex
+.. [1] https://numpy.org/neps/nep-0029-deprecation_policy.html
+.. [2] https://numpy.org/doc/stable/release.html
+.. [3] https://scipy.github.io/devdocs/release.html
+.. [4] https://github.com/scipy/oldest-supported-numpy
+.. [5] https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted
+.. [6] https://github.com/MacPython/scipy-wheels
 .. [7] https://pythondev.readthedocs.io/windows.html#python-and-visual-studio-version-matrix
 .. [8] https://en.wikipedia.org/wiki/Microsoft_Visual_C%2B%2B#Internal_version_numbering
-.. [10] https://numpy.org/neps/nep-0029-deprecation_policy.html
-.. [11] https://devblogs.microsoft.com/cppblog/c11-and-c17-standard-support-arriving-in-msvc/
-.. [12] https://en.wikipedia.org/wiki/C11_%28C_standard_revision%29#Optional_features
-.. [13] https://github.com/scipy/scipy/issues/10239
-.. [14] https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted
-.. [15] https://github.com/MacPython/scipy-wheels
-.. [16] https://docs.microsoft.com/en-gb/cpp/windows/universal-crt-deployment
-.. [17] https://discuss.python.org/t/toolchain-upgrade-on-windows/6377/4
-.. [18] https://scipy.github.io/devdocs/release.html
-.. [19] https://github.com/scipy/oldest-supported-numpy
-.. [20] https://github.com/mayeut/pep600_compliance
-.. [21] https://github.com/pypa/manylinux/issues/1012
+.. [9] https://docs.microsoft.com/en-gb/cpp/windows/universal-crt-deployment
+.. [10] https://discuss.python.org/t/toolchain-upgrade-on-windows/6377/4
+.. [11] https://en.wikipedia.org/wiki/C11_%28C_standard_revision%29#Optional_features
+.. [12] https://devblogs.microsoft.com/cppblog/c11-and-c17-standard-support-arriving-in-msvc/
+.. [13] https://developercommunity.visualstudio.com/t/Support-for-C99-Complex-numbers/1409049?space=8&q=complex
+.. [14] https://github.com/mayeut/pep600_compliance
+.. [15] https://en.cppreference.com/w/cpp/compiler_support
+.. [16] https://github.com/pypa/manylinux/issues/1012
+.. [17] https://github.com/scipy/scipy/issues/10239

--- a/doc/source/dev/toolchain.rst
+++ b/doc/source/dev/toolchain.rst
@@ -57,6 +57,7 @@ available in release 1.2.x, which is a long-term support release [1]_, [2]_.
  2019              Py3.5+ (but Py2.7-specific code not removed)
  2020              Py3.6+ (removal of Py2.7-specific code permitted)
  2021              Py3.7+
+ 2022              Py3.8+
 ================  =======================================================================
 
 NumPy
@@ -91,7 +92,7 @@ Compilers
 
 Building SciPy requires compilers for C, C++, Fortran, as well as the
 python transpilers Cython and Pythran (the latter is an opt-out dependency
-as of version 1.7.0).
+starting from version 1.7.0).
 
 To maintain compatibility with a large number of platforms & setups, especially
 where using the official wheels (or other distribution channels like Anaconda
@@ -107,11 +108,12 @@ Currently, SciPy wheels are being built as follows:
 ================  ========================  ===========================  ==============================
 Linux (nightly)    ``ubuntu-18.04``          GCC 4.8                      See ``azure-pipelines.yml``
 Linux (release)    ``ubuntu-18.04``          GCC 7.5                      Built in separate repo [15]_
-OSX                ``macOS-10.14``           LLVM 11.0                    Built in separate repo [15]_
-Windows            ``VS2017-Win2016``        Visual Studio 2017 (15.9)    See ``azure-pipelines.yml``
+OSX                ``macOS-10.15``           LLVM 12.0.0                  Built in separate repo [15]_
+Windows            ``windows-latest``        Visual Studio 2019 (16.11)   See ``azure-pipelines.yml``
 ================  ========================  ===========================  ==============================
 
-Note that the OSX wheels additionally vendor gfortran 4.8, see [15]_.
+Note that the OSX wheels additionally vendor gfortran 4.9,
+see submodule ``gfortran-install`` in [15]_.
 
 
 C Compilers
@@ -223,17 +225,11 @@ flang     A recent version
 ======== ==================
 
 
-Cython Compiler
-~~~~~~~~~~~~~~~
+Cython & Pythran
+~~~~~~~~~~~~~~~~
 
-SciPy always requires a recent Cython compiler.
-
-======== ============ ===============
- Tool    Tool Version  SciPy version
-======== ============ ===============
-Cython     >= 0.29.13  1.4.1
-Cython     >= 0.29.18  1.5.0
-======== ============ ===============
+SciPy always requires a recent Cython compiler. Since 1.7, pythran
+is a build dependency (currently with the possibility to opt out).
 
 
 OpenMP support

--- a/doc/source/dev/toolchain.rst
+++ b/doc/source/dev/toolchain.rst
@@ -106,7 +106,7 @@ Currently, SciPy wheels are being built as follows:
 ================  ========================  ===========================  ==============================
  Platform          Azure Base Image [14]_    Compilers                    Comment
 ================  ========================  ===========================  ==============================
-Linux (nightly)    ``ubuntu-18.04``          GCC 4.8                      See ``azure-pipelines.yml``
+Linux (nightly)    ``ubuntu-18.04``          GCC 6.5                      See ``azure-pipelines.yml``
 Linux (release)    ``ubuntu-18.04``          GCC 7.5                      Built in separate repo [15]_
 OSX                ``macOS-10.15``           LLVM 12.0.0                  Built in separate repo [15]_
 Windows            ``windows-latest``        Visual Studio 2019 (16.11)   See ``azure-pipelines.yml``
@@ -134,8 +134,7 @@ The use of MS Visual Studio 9.0 (which doesn't have support for C99)
 to build Python 2.7 has meant that C code in SciPy has had to conform
 to the earlier C90 standard for the language and standard library.
 With the dropping of Python 2.7 for SciPy 1.3.x, the C90 restriction is no
-longer imposed by compilers. For GCC version < 5, an explicit ``-std=c99``
-may have to be added by the user if C99 features are used in SciPy code.
+longer imposed by compilers.
 
 In terms of C language standards, it's relevant to note that C11 has optional
 features [12]_ (e.g. atomics, threading), some of which (VLAs & complex types)
@@ -182,13 +181,27 @@ attempting to predict adoption timelines for newer standards.
 ================  =======================================================================
 
 Since dropping support for Python 2.7, C++11 can be used
-universally. For C++14, Windows is not a restriction anymore since Visual
-Studio 15.9 (<-> _MSC_VER 19.16, see [8]_), has full support (same for C++17),
-see [4]_. Using C++14 requires bumping the GCC minimal requirement to 5.x
-(released April 2015), whereas C++17 _language_ support will require
-GCC >= 7 [4]_. As of the end of 2021, support for the entirety of the
-C++17 standard library has not yet been completed across all compilers;
-similarly, support for C++20 and C++23 is still under heavy development.
+universally, and since dropping Python 3.6, the Visual Studio version
+(that had previously been stuck with 14.0 due to ABI compatibility with
+CPython) has been recent enough to support even C++17.
+
+Since the official builds (see above) use a pretty recent version of LLVM,
+the bottleneck for C++ support is therefore the oldest supported GCC version,
+where scipy has been constrained mainly by the version in the oldest supported
+manylinx versions & images [20]_.
+
+At the end of 2021 (with the final removal of ``manylinux1`` wheels), scipy
+now has a minimum GCC requirement of GCC 6.3, which has full C++14 support
+[4]_. This corresponds to the lowest present GCC version in relevant manylinux
+versions - somewhat surprisingly, it is not the oldest remaining
+``manylinux2010`` that is the most restrictive (due to the ABI-compatible
+"RHEL Dev Toolset" backports, it has GCC 8.3), but actually ``manylinux_2_24``
+that only comes with GCC 6.3 [21]_.
+
+C++17 _language_ support will require GCC >= 7 (released May 2017). As of the
+end of 2021, support for the entirety of the C++17 standard library has not yet
+been completed across all compilers; similarly, support for C++20 and C++23
+is still under heavy development. [4]_
 
 Fortran Compilers
 ~~~~~~~~~~~~~~~~~
@@ -332,3 +345,5 @@ References
 .. [17] https://discuss.python.org/t/toolchain-upgrade-on-windows/6377/4
 .. [18] https://scipy.github.io/devdocs/release.html
 .. [19] https://github.com/scipy/oldest-supported-numpy
+.. [20] https://github.com/mayeut/pep600_compliance
+.. [21] https://github.com/pypa/manylinux/issues/1012

--- a/doc/source/dev/toolchain.rst
+++ b/doc/source/dev/toolchain.rst
@@ -130,7 +130,7 @@ Visual Studio 2015, this restriction has been lifted. For more context, see the
 explanations by Steve Dower (member of the CPython-on-Windows core developers)
 on this topic [17]_.
 
-The use of MS Visual Studio 9.0 (which doesn't have support C99)
+The use of MS Visual Studio 9.0 (which doesn't have support for C99)
 to build Python 2.7 has meant that C code in SciPy has had to conform
 to the earlier C90 standard for the language and standard library.
 With the dropping of Python 2.7 for SciPy 1.3.x, the C90 restriction is no
@@ -146,69 +146,49 @@ SciPy has been restricted in the use of more advanced language features by the
 available compiler support, and Microsoft in particular has taken very long to
 achieve conformance to C99/C11/C17, however starting from MS Visual Studio 16.8,
 C11/C17 is supported [11]_ (though without the C11 optional features).
+C99 ``<complex.h>`` would be particularly interesting for scipy;
+MSVC conformance for this is being tracked here [5]_.
 
-Therefore, using C features beyond C90 is contingent upon updating the windows
-toolchain for SciPy, as well as checking compiler support for the desired feature
-across all minimally supported compiler versions. In short:
+Therefore, using C features beyond C90 was only possible insofar there was support on
+windows; however, as of as of the end of 2021, a sufficiently recent compiler is used.
+This is because GCC & LLVM support all relevant C11 features with the oldest currently
+used versions, and C17 is just a bugfix for C11, as mentioned above. In short:
 
-===================   ==============   =============================================
-CPython               MS Visual C++    C Standard
-===================   ==============   =============================================
-2.7, 3.0, 3.1, 3.2       9.0           C90
-3.3, 3.4                10.0           C90 & some of C99
-3.5, 3.6                14.0           C90 & most of C99
-3.7, 3.8, 3.9           15.7           Dependent on MSVC version used to build SciPy
-===================   ==============   =============================================
+================  =======================================================================
+ Date              C Standard
+================  =======================================================================
+ <= 2018           C90
+ 2019              C90 for old code, may consider C99 for new
+ 2020              C99 (no ``<complex.h>``, ``<stdatomic.h>``, ``<threads.h>`` & VLAs)
+ 2021              C17 (no ``<complex.h>``, ``<stdatomic.h>``, ``<threads.h>`` & VLAs)
+ ?                 C23, ``<complex.h>``, ``<stdatomic.h>``, ...
+================  =======================================================================
 
 
-C and C++ Language Standards
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+C++ Language Standards
+~~~~~~~~~~~~~~~~~~~~~~
 
-C and C++ language standards for SciPy are generally guidelines
+C++ language standards for SciPy are generally guidelines
 rather than official decisions. This is particularly true of
 attempting to predict adoption timelines for newer standards.
 
 ================  =======================================================================
- Date              C/C++ Standard
+ Date              C++ Standard
 ================  =======================================================================
- <= 2018           C90
- 2019              C90 for old code, may consider C99 for new
- 2020              C99
+ <= 2019           C++03
  2020              C++11
  2021              C++14
- ?                 C11, C17, C++17, C++20
+ ?                 C++17, C++20, C++23
 ================  =======================================================================
 
-For C, C11/C17 support will be available as soon as the ``vmImage`` for
-building SciPy is upgraded to ``windows-2019`` (which is compatible with
-currently supported CPython versions and "just" needs to be executed). This is
-because GCC & LLVM support all relevant C11 features with the oldest currently
-used versions, and C17 is just a bugfix for C11, as mentioned above.
-
-On the C++ side, since dropping support for Python 2.7, C++11 can be used
+Since dropping support for Python 2.7, C++11 can be used
 universally. For C++14, Windows is not a restriction anymore since Visual
 Studio 15.9 (<-> _MSC_VER 19.16, see [8]_), has full support (same for C++17),
-see [4]_. However, using C++14 still requires bumping the GCC minimal
-requirement to 5.x and C++17 will require GCC >= 7 [4]_.
-Compiler support for C++20 is still under heavy development.
-
-.. note::
-
-    Developer Note: Some C99 features would be useful for scientific
-    programming, in particular better support of IEEE 754 [5]_.
-    SciPy has a small include file ``scipy/_lib/_c99compat.h`` which
-    provides access to a few functions. Use in conjunction
-    with ``<numpy/npy_math.h>``.
-
-    ========================================= ========================================================
-     Feature                                  Workaround
-    ========================================= ========================================================
-    ``isnan()``, ``isinf()``, ``isfinite()``  Use ``sc_isnan()``, ``sc_isinf()``, ``sc_isfinite()``
-    ``NAN``                                   Use ``NPY_NAN`` (it is *almost* equivalent)
-    inline functions                          Make static functions and place in an include .h file
-    mid-block variable declarations           Declare variables at the top of the block
-    ========================================= ========================================================
-
+see [4]_. Using C++14 requires bumping the GCC minimal requirement to 5.x
+(released April 2015), whereas C++17 _language_ support will require
+GCC >= 7 [4]_. As of the end of 2021, support for the entirety of the
+C++17 standard library has not yet been completed across all compilers;
+similarly, support for C++20 and C++23 is still under heavy development.
 
 Fortran Compilers
 ~~~~~~~~~~~~~~~~~
@@ -337,7 +317,7 @@ References
 .. [2] https://python3statement.org
 .. [3] https://docs.scipy.org/doc/numpy/release.html
 .. [4] https://en.cppreference.com/w/cpp/compiler_support
-.. [5] https://en.wikipedia.org/wiki/IEEE_754-1985
+.. [5] https://developercommunity.visualstudio.com/t/Support-for-C99-Complex-numbers/1409049?space=8&q=complex
 .. [6] https://blogs.msdn.microsoft.com/vcblog/2013/07/19/c99-library-support-in-visual-studio-2013/
 .. [7] https://pythondev.readthedocs.io/windows.html#python-and-visual-studio-version-matrix
 .. [8] https://en.wikipedia.org/wiki/Microsoft_Visual_C%2B%2B#Internal_version_numbering

--- a/doc/source/dev/toolchain.rst
+++ b/doc/source/dev/toolchain.rst
@@ -250,7 +250,6 @@ OpenBLAS, ATLAS, MKL, BLIS, and reference Netlib libraries are known to work.
 =============== =====================================================
 LAPACK           3.4.1
 BLAS             A recent version of OpenBLAS, MKL or ATLAS.
-                 The Accelerate BLAS is no longer supported.
 =============== =====================================================
 
 

--- a/doc/source/dev/toolchain.rst
+++ b/doc/source/dev/toolchain.rst
@@ -47,8 +47,7 @@ Python Versions
 
 SciPy is compatible with several versions of Python.  When dropping support for
 older Python versions, SciPy takes guidance from NEP 29 [10]_.  Python 2.7
-support was dropped for SciPy releases numbered 1.3 and above but is still
-available in release 1.2.x, which is a long-term support release [1]_, [2]_.
+support was dropped starting from SciPy 1.3.
 
 ================  =======================================================================
  Date             Pythons supported
@@ -66,7 +65,7 @@ NumPy
 SciPy depends on NumPy but releases of SciPy are not tied to releases of NumPy.
 SciPy attempts to be compatible with at least the 4 previous releases of NumPy.
 In particular, SciPy cannot rely on features of just the latest NumPy, but
-needs to be written using what is common in all of those 4 releases. [1]_, [3]_.
+needs to be written using what is common in all of those 4 releases [3]_.
 
 The table shows the NumPy versions suitable for each major Python version.
 
@@ -123,7 +122,7 @@ SciPy is compatible with most modern C compilers (in particular ``clang``).
 In addition to concerns about compatibility with non-standard platforms,
 there was a long-standing restriction that Windows builds of SciPy had to use
 the same version of the Microsoft Visual C++ compiler as were used for CPython
-itself, for reasons of ABI-compatibility [6]_, [7]_, [8]_, [9]_.
+itself, for reasons of ABI-compatibility [7]_, [8]_.
 
 With the introduction of the "Universal C Runtime" [16]_ since the release of
 Visual Studio 2015, this restriction has been lifted. For more context, see the
@@ -326,15 +325,11 @@ making and distributing a SciPy release.
 References
 ----------
 
-.. [1] https://docs.scipy.org/doc/scipy/reference/release.1.2.0.html
-.. [2] https://python3statement.org
-.. [3] https://docs.scipy.org/doc/numpy/release.html
+.. [3] https://numpy.org/doc/stable/release.html
 .. [4] https://en.cppreference.com/w/cpp/compiler_support
 .. [5] https://developercommunity.visualstudio.com/t/Support-for-C99-Complex-numbers/1409049?space=8&q=complex
-.. [6] https://blogs.msdn.microsoft.com/vcblog/2013/07/19/c99-library-support-in-visual-studio-2013/
 .. [7] https://pythondev.readthedocs.io/windows.html#python-and-visual-studio-version-matrix
 .. [8] https://en.wikipedia.org/wiki/Microsoft_Visual_C%2B%2B#Internal_version_numbering
-.. [9] https://wiki.python.org/moin/WindowsCompilers
 .. [10] https://numpy.org/neps/nep-0029-deprecation_policy.html
 .. [11] https://devblogs.microsoft.com/cppblog/c11-and-c17-standard-support-arriving-in-msvc/
 .. [12] https://en.wikipedia.org/wiki/C11_%28C_standard_revision%29#Optional_features

--- a/doc/source/dev/toolchain.rst
+++ b/doc/source/dev/toolchain.rst
@@ -144,7 +144,7 @@ SciPy has been restricted in the use of more advanced language features by the
 available compiler support, and Microsoft in particular has taken very long to
 achieve conformance to C99/C11/C17, however starting from MS Visual Studio 16.8,
 C11/C17 is supported [12]_ (though without the C11 optional features).
-C99 ``<complex.h>`` would be particularly interesting for scipy;
+C99 ``<complex.h>`` would be particularly interesting for SciPy;
 MSVC conformance for this is being tracked here [13]_.
 
 Therefore, using C features beyond C90 was only possible insofar there was support on
@@ -186,10 +186,10 @@ CPython) has been recent enough to support even C++17.
 
 Since the official builds (see above) use a pretty recent version of LLVM,
 the bottleneck for C++ support is therefore the oldest supported GCC version,
-where scipy has been constrained mainly by the version in the oldest supported
-manylinx versions & images [14]_.
+where SciPy has been constrained mainly by the version in the oldest supported
+manylinux versions & images [14]_.
 
-At the end of 2021 (with the final removal of ``manylinux1`` wheels), scipy
+At the end of 2021 (with the final removal of ``manylinux1`` wheels), SciPy
 now has a minimum GCC requirement of GCC 6.3, which has full C++14 support
 [15]_. This corresponds to the lowest present GCC version in relevant manylinux
 versions - somewhat surprisingly, it is not the oldest remaining
@@ -220,7 +220,7 @@ flang     A recent version
 Cython & Pythran
 ~~~~~~~~~~~~~~~~
 
-SciPy always requires a recent Cython compiler. Since 1.7, pythran
+SciPy always requires a recent Cython compiler. Since 1.7, Pythran
 is a build dependency (currently with the possibility to opt out).
 
 
@@ -242,6 +242,7 @@ OpenBLAS, ATLAS, MKL, BLIS, and reference Netlib libraries are known to work.
 =============== =====================================================
 LAPACK           3.4.1
 BLAS             A recent version of OpenBLAS, MKL or ATLAS.
+                 The Accelerate BLAS library is no longer supported.
 =============== =====================================================
 
 


### PR DESCRIPTION
## TL;DR: As of extremely recently, scipy code may use C++14 and C17! :)

Updating the description of the current build infrastructure, as well as some changes that I had been mulling (e.g. removing the redundancy in the C conformance).

Crucially, #14832 also finally unlocked C17 due to using a recent enough MSVC compiler. 🥳