### PR TITLE
MAINT: Remove wminkowski

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -49,7 +49,6 @@ functions. Use ``pdist`` for this purpose.
    minkowski        -- the Minkowski distance.
    seuclidean       -- the normalized Euclidean distance.
    sqeuclidean      -- the squared Euclidean distance.
-   wminkowski       -- (deprecated) alias of `minkowski`.
 
 Distance functions between two boolean vectors (representing sets) ``u`` and
 ``v``.  As in the case of numerical vectors, ``pdist`` is more efficient for
@@ -105,7 +104,6 @@ __all__ = [
     'sokalsneath',
     'sqeuclidean',
     'squareform',
-    'wminkowski',
     'yule'
 ]
 
@@ -321,20 +319,6 @@ def _validate_weights(w, dtype=np.double):
     return w
 
 
-@_deprecated(
-    msg="'wminkowski' metric is deprecated and will be removed in"
-        " SciPy 1.8.0, use 'minkowski' instead.")
-def _validate_wminkowski_kwargs(X, m, n, **kwargs):
-    w = kwargs.pop('w', None)
-    if w is None:
-        raise ValueError('weighted minkowski requires a weight '
-                         'vector `w` to be given.')
-    kwargs['w'] = _validate_weights(w)
-    if 'p' not in kwargs:
-        kwargs['p'] = 2.
-    return kwargs
-
-
 def directed_hausdorff(u, v, seed=0):
     """
     Compute the directed Hausdorff distance between two 2-D arrays.
@@ -502,62 +486,6 @@ def minkowski(u, v, p=2, w=None):
         u_v = root_w * u_v
     dist = norm(u_v, ord=p)
     return dist
-
-
-def wminkowski(u, v, p, w):
-    """
-    Compute the weighted Minkowski distance between two 1-D arrays.
-
-    The weighted Minkowski distance between `u` and `v`, defined as
-
-    .. math::
-
-       \\left(\\sum{(|w_i (u_i - v_i)|^p)}\\right)^{1/p}.
-
-    Parameters
-    ----------
-    u : (N,) array_like
-        Input array.
-    v : (N,) array_like
-        Input array.
-    p : scalar
-        The order of the norm of the difference :math:`{||u-v||}_p`.
-    w : (N,) array_like
-        The weight vector.
-
-    Returns
-    -------
-    wminkowski : double
-        The weighted Minkowski distance between vectors `u` and `v`.
-
-    Notes
-    -----
-    `wminkowski` is deprecated and will be removed in SciPy 1.8.0.
-    Use `minkowski` with the ``w`` argument instead.
-
-    Examples
-    --------
-    >>> from scipy.spatial import distance
-    >>> distance.wminkowski([1, 0, 0], [0, 1, 0], 1, np.ones(3))
-    2.0
-    >>> distance.wminkowski([1, 0, 0], [0, 1, 0], 2, np.ones(3))
-    1.4142135623730951
-    >>> distance.wminkowski([1, 0, 0], [0, 1, 0], 3, np.ones(3))
-    1.2599210498948732
-    >>> distance.wminkowski([1, 1, 0], [0, 1, 0], 1, np.ones(3))
-    1.0
-    >>> distance.wminkowski([1, 1, 0], [0, 1, 0], 2, np.ones(3))
-    1.0
-    >>> distance.wminkowski([1, 1, 0], [0, 1, 0], 3, np.ones(3))
-    1.0
-
-    """
-    warnings.warn(
-        message="scipy.distance.wminkowski is deprecated and will be removed "
-                "in SciPy 1.8.0, use scipy.distance.minkowski instead.",
-        category=DeprecationWarning)
-    w = _validate_weights(w)
-    return minkowski(u, v, p=p, w=w**p)
 
 
 def euclidean(u, v, w=None):
@@ -2010,16 +1938,6 @@ _METRIC_INFOS = [
         pdist_func=_distance_pybind.pdist_sqeuclidean,
     ),
     MetricInfo(
-        canonical_name='wminkowski',
-        aka={'wminkowski', 'wmi', 'wm', 'wpnorm'},
-        validator=_validate_wminkowski_kwargs,
-        dist_func=wminkowski,
-        cdist_func=CDistWeightedMetricWrapper(
-            'wminkowski', 'old_weighted_minkowski'),
-        pdist_func=PDistWeightedMetricWrapper(
-            'wminkowski', 'old_weighted_minkowski'),
-    ),
-    MetricInfo(
         canonical_name='yule',
         aka={'yule'},
         types=['bool'],
@@ -2275,15 +2193,7 @@ def pdist(X, metric='euclidean', *, out=None, **kwargs):
         Computes the Kulczynski 1 distance between each pair of
         boolean vectors. (see kulczynski1 function documentation)
 
-    24. ``Y = pdist(X, 'wminkowski', p=2, w=w)``
-
-        Computes the weighted Minkowski distance between each pair of
-        vectors. (see wminkowski function documentation)
-
-        'wminkowski' is deprecated and will be removed in SciPy 1.8.0.
-        Use 'minkowski' instead.
-
-    25. ``Y = pdist(X, f)``
+    24. ``Y = pdist(X, f)``
 
         Computes the distance between all pairs of vectors in X
         using the user supplied 2-arity function f. For example,
@@ -2724,7 +2634,7 @@ def cdist(XA, XB, metric='euclidean', *, out=None, **kwargs):
         'cosine', 'dice', 'euclidean', 'hamming', 'jaccard', 'jensenshannon',
         'kulsinski', 'kulczynski1', 'mahalanobis', 'matching', 'minkowski',
         'rogerstanimoto', 'russellrao', 'seuclidean', 'sokalmichener',
-        'sokalsneath', 'sqeuclidean', 'wminkowski', 'yule'.
+        'sokalsneath', 'sqeuclidean', 'yule'.
     **kwargs : dict, optional
         Extra arguments to `metric`: refer to each metric documentation for a
         list of all possible arguments.
@@ -2934,16 +2844,7 @@ def cdist(XA, XB, metric='euclidean', *, out=None, **kwargs):
         Computes the Sokal-Sneath distance between the vectors. (see
         `sokalsneath` function documentation)
 
-
-    23. ``Y = cdist(XA, XB, 'wminkowski', p=2., w=w)``
-
-        Computes the weighted Minkowski distance between the
-        vectors. (see `wminkowski` function documentation)
-
-        'wminkowski' is deprecated and will be removed in SciPy 1.8.0.
-        Use 'minkowski' instead.
-
-    24. ``Y = cdist(XA, XB, f)``
+    23. ``Y = cdist(XA, XB, f)``
 
         Computes the distance between all pairs of vectors in X
         using the user supplied 2-arity function f. For example,

--- a/scipy/spatial/src/distance_impl.h
+++ b/scipy/spatial/src/distance_impl.h
@@ -644,34 +644,6 @@ pdist_minkowski(const double *X, double *dm, npy_intp num_rows,
     return 0;
 }
 
-/* Old weighting type which is inconsistent with other distance metrics.
-   Remove in SciPy 1.8 along with wminkowski. */
-static NPY_INLINE int
-pdist_old_weighted_minkowski(const double *X, double *dm, npy_intp num_rows,
-                             const npy_intp num_cols, const double p, const double *w)
-{
-    npy_intp i, j;
-
-    // Covert from old style weights to new weights
-    double * new_weights = malloc(num_cols * sizeof(double));
-    if (!new_weights) {
-        return 1;
-    }
-    for (i = 0; i < num_cols; ++i) {
-        new_weights[i] = pow(w[i], p);
-    }
-
-    for (i = 0; i < num_rows; ++i) {
-        const double *u = X + (num_cols * i);
-        for (j = i + 1; j < num_rows; ++j, ++dm) {
-            const double *v = X + (num_cols * j);
-            *dm = weighted_minkowski_distance(u, v, num_cols, p, new_weights);
-        }
-    }
-    free(new_weights);
-    return 0;
-}
-
 static NPY_INLINE int
 pdist_weighted_minkowski(const double *X, double *dm, npy_intp num_rows,
                          const npy_intp num_cols, const double p, const double *w)
@@ -893,37 +865,6 @@ cdist_minkowski(const double *XA, const double *XB, double *dm,
             *dm = minkowski_distance(u, v, num_cols, p);
         }
     }
-    return 0;
-}
-
-/* Old weighting type which is inconsistent with other distance metrics.
-   Remove in SciPy 1.8 along with wminkowski. */
-static NPY_INLINE int
-cdist_old_weighted_minkowski(const double *XA, const double *XB, double *dm,
-                             const npy_intp num_rowsA, const npy_intp num_rowsB,
-                             const npy_intp num_cols, const double p,
-                             const double *w)
-{
-    npy_intp i, j;
-
-    // Covert from old style weights to new weights
-    double * new_weights = malloc(num_cols * sizeof(double));
-    if (!new_weights) {
-      return 1;
-    }
-
-    for (i = 0; i < num_cols; ++i) {
-      new_weights[i] = pow(w[i], p);
-    }
-
-    for (i = 0; i < num_rowsA; ++i) {
-        const double *u = XA + (num_cols * i);
-        for (j = 0; j < num_rowsB; ++j, ++dm) {
-            const double *v = XB + (num_cols * j);
-            *dm = weighted_minkowski_distance(u, v, num_cols, p, new_weights);
-        }
-    }
-    free(new_weights);
     return 0;
 }
 

--- a/scipy/spatial/src/distance_wrap.c
+++ b/scipy/spatial/src/distance_wrap.c
@@ -315,43 +315,6 @@ static PyObject *cdist_weighted_chebyshev_double_wrap(
   return Py_BuildValue("d", 0.0);
 }
 
-static PyObject *cdist_old_weighted_minkowski_double_wrap(
-  PyObject *self, PyObject *args, PyObject *kwargs)
-{
-  PyArrayObject *XA_, *XB_, *dm_, *w_;
-  int mA, mB, n;
-  double *dm;
-  const double *XA, *XB, *w;
-  double p;
-  static char *kwlist[] = {"XA", "XB", "dm", "p", "w", NULL};
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs,
-                                   "O!O!O!dO!:cdist_old_weighted_minkowski_double_wrap", kwlist,
-                                   &PyArray_Type, &XA_, &PyArray_Type, &XB_,
-                                   &PyArray_Type, &dm_,
-                                   &p,
-                                   &PyArray_Type, &w_)) {
-    return 0;
-  }
-  else {
-    int res;
-    NPY_BEGIN_ALLOW_THREADS;
-    XA = (const double*)PyArray_DATA(XA_);
-    XB = (const double*)PyArray_DATA(XB_);
-    w = (const double*)PyArray_DATA(w_);
-    dm = (double*)PyArray_DATA(dm_);
-    mA = PyArray_DIMS(XA_)[0];
-    mB = PyArray_DIMS(XB_)[0];
-    n = PyArray_DIMS(XA_)[1];
-    res = cdist_old_weighted_minkowski(XA, XB, dm, mA, mB, n, p, w);
-    NPY_END_ALLOW_THREADS;
-
-    if (res) {
-      return PyErr_NoMemory();
-    }
-  }
-  return Py_BuildValue("d", 0.0);
-}
-
 static PyObject *cdist_weighted_minkowski_double_wrap(
                             PyObject *self, PyObject *args, PyObject *kwargs)
 {
@@ -635,40 +598,6 @@ static PyObject *pdist_weighted_chebyshev_double_wrap(
   return Py_BuildValue("d", 0.0);
 }
 
-static PyObject *pdist_old_weighted_minkowski_double_wrap(
-  PyObject *self, PyObject *args, PyObject *kwargs)
-{
-  PyArrayObject *X_, *dm_, *w_;
-  int m, n;
-  double *dm, *X, *w;
-  double p;
-  static char *kwlist[] = {"X", "dm", "p", "w", NULL};
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs,
-                                   "O!O!dO!:pdist_weighted_minkowski_double_wrap", kwlist,
-                                   &PyArray_Type, &X_,
-                                   &PyArray_Type, &dm_,
-                                   &p,
-                                   &PyArray_Type, &w_)) {
-    return 0;
-  }
-  else {
-    int res;
-    NPY_BEGIN_ALLOW_THREADS;
-    X = (double*)PyArray_DATA(X_);
-    dm = (double*)PyArray_DATA(dm_);
-    w = (double*)PyArray_DATA(w_);
-    m = PyArray_DIMS(X_)[0];
-    n = PyArray_DIMS(X_)[1];
-
-    res = pdist_old_weighted_minkowski(X, dm, m, n, p, w);
-    NPY_END_ALLOW_THREADS;
-    if (res) {
-      return PyErr_NoMemory();
-    }
-  }
-  return Py_BuildValue("d", 0.0);
-}
-
 static PyObject *pdist_weighted_minkowski_double_wrap(
                             PyObject *self, PyObject *args, PyObject *kwargs)
 {
@@ -802,9 +731,6 @@ static PyMethodDef _distanceWrapMethods[] = {
   {"cdist_weighted_chebyshev_double_wrap",
    (PyCFunction) cdist_weighted_chebyshev_double_wrap,
    METH_VARARGS | METH_KEYWORDS},
-  {"cdist_old_weighted_minkowski_double_wrap",
-   (PyCFunction) cdist_old_weighted_minkowski_double_wrap,
-   METH_VARARGS | METH_KEYWORDS},
   {"cdist_weighted_minkowski_double_wrap",
    (PyCFunction) cdist_weighted_minkowski_double_wrap,
    METH_VARARGS | METH_KEYWORDS},
@@ -879,9 +805,6 @@ static PyMethodDef _distanceWrapMethods[] = {
    METH_VARARGS | METH_KEYWORDS},
   {"pdist_weighted_chebyshev_double_wrap",
    (PyCFunction) pdist_weighted_chebyshev_double_wrap,
-   METH_VARARGS | METH_KEYWORDS},
-  {"pdist_old_weighted_minkowski_double_wrap",
-   (PyCFunction) pdist_old_weighted_minkowski_double_wrap,
    METH_VARARGS | METH_KEYWORDS},
   {"pdist_weighted_minkowski_double_wrap",
    (PyCFunction) pdist_weighted_minkowski_double_wrap,

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -407,38 +407,36 @@ class TestCdist:
         X2 = [[7., 5., 8.], [7.5, 5.8, 8.4], [5.5, 5.8, 4.4]]
         kwargs = {'N0tV4l1D_p4raM': 3.14, "w":np.arange(3)}
         args = [3.14] * 200
-        with suppress_warnings() as w:
-            w.filter(DeprecationWarning)
-            for metric in _METRICS_NAMES:
-                assert_raises(TypeError, cdist, X1, X2,
-                              metric=metric, **kwargs)
-                assert_raises(TypeError, cdist, X1, X2,
-                              metric=eval(metric), **kwargs)
-                assert_raises(TypeError, cdist, X1, X2,
-                              metric="test_" + metric, **kwargs)
-                assert_raises(TypeError, cdist, X1, X2,
-                              metric=metric, *args)
-                assert_raises(TypeError, cdist, X1, X2,
-                              metric=eval(metric), *args)
-                assert_raises(TypeError, cdist, X1, X2,
-                              metric="test_" + metric, *args)
+        for metric in _METRICS_NAMES:
+            assert_raises(TypeError, cdist, X1, X2,
+                          metric=metric, **kwargs)
+            assert_raises(TypeError, cdist, X1, X2,
+                          metric=eval(metric), **kwargs)
+            assert_raises(TypeError, cdist, X1, X2,
+                          metric="test_" + metric, **kwargs)
+            assert_raises(TypeError, cdist, X1, X2,
+                          metric=metric, *args)
+            assert_raises(TypeError, cdist, X1, X2,
+                          metric=eval(metric), *args)
+            assert_raises(TypeError, cdist, X1, X2,
+                          metric="test_" + metric, *args)
 
-            assert_raises(TypeError, cdist, X1, X2, _my_metric)
-            assert_raises(TypeError, cdist, X1, X2, _my_metric, *args)
-            assert_raises(TypeError, cdist, X1, X2, _my_metric, **kwargs)
-            assert_raises(TypeError, cdist, X1, X2, _my_metric,
-                          kwarg=2.2, kwarg2=3.3)
-            assert_raises(TypeError, cdist, X1, X2, _my_metric, 1, 2, kwarg=2.2)
+        assert_raises(TypeError, cdist, X1, X2, _my_metric)
+        assert_raises(TypeError, cdist, X1, X2, _my_metric, *args)
+        assert_raises(TypeError, cdist, X1, X2, _my_metric, **kwargs)
+        assert_raises(TypeError, cdist, X1, X2, _my_metric,
+                      kwarg=2.2, kwarg2=3.3)
+        assert_raises(TypeError, cdist, X1, X2, _my_metric, 1, 2, kwarg=2.2)
 
-            assert_raises(TypeError, cdist, X1, X2, _my_metric, 1.1, 2.2, 3.3)
-            assert_raises(TypeError, cdist, X1, X2, _my_metric, 1.1, 2.2)
-            assert_raises(TypeError, cdist, X1, X2, _my_metric, 1.1)
-            assert_raises(TypeError, cdist, X1, X2, _my_metric, 1.1,
-                          kwarg=2.2, kwarg2=3.3)
+        assert_raises(TypeError, cdist, X1, X2, _my_metric, 1.1, 2.2, 3.3)
+        assert_raises(TypeError, cdist, X1, X2, _my_metric, 1.1, 2.2)
+        assert_raises(TypeError, cdist, X1, X2, _my_metric, 1.1)
+        assert_raises(TypeError, cdist, X1, X2, _my_metric, 1.1,
+                      kwarg=2.2, kwarg2=3.3)
 
-            # this should work
-            assert_allclose(cdist(X1, X2, metric=_my_metric,
-                                  arg=1.1, kwarg2=3.3), 5.4)
+        # this should work
+        assert_allclose(cdist(X1, X2, metric=_my_metric,
+                              arg=1.1, kwarg2=3.3), 5.4)
 
     def test_cdist_euclidean_random_unicode(self):
         eps = 1e-07
@@ -585,37 +583,35 @@ class TestCdist:
         X1 = eo['cdist-X1']
         X2 = eo['cdist-X2']
         out_r, out_c = X1.shape[0], X2.shape[0]
-        with suppress_warnings() as sup:
-            sup.filter(DeprecationWarning,
-                       message="'wminkowski' metric is deprecated")
-            for metric in _METRICS_NAMES:
-                kwargs = dict()
-                if metric == 'minkowski':
-                    kwargs['p'] = 1.23
-                out1 = np.empty((out_r, out_c), dtype=np.double)
-                Y1 = cdist(X1, X2, metric, **kwargs)
-                Y2 = cdist(X1, X2, metric, out=out1, **kwargs)
-                # test that output is numerically equivalent
-                _assert_within_tol(Y1, Y2, eps, verbose > 2)
-                # test that Y_test1 and out1 are the same object
-                assert_(Y2 is out1)
-                # test for incorrect shape
-                out2 = np.empty((out_r-1, out_c+1), dtype=np.double)
-                assert_raises(ValueError,
-                              cdist, X1, X2, metric, out=out2, **kwargs)
-                # test for C-contiguous order
-                out3 = np.empty(
-                    (2 * out_r, 2 * out_c), dtype=np.double)[::2, ::2]
-                out4 = np.empty((out_r, out_c), dtype=np.double, order='F')
-                assert_raises(ValueError,
-                              cdist, X1, X2, metric, out=out3, **kwargs)
-                assert_raises(ValueError,
-                              cdist, X1, X2, metric, out=out4, **kwargs)
 
-                # test for incorrect dtype
-                out5 = np.empty((out_r, out_c), dtype=np.int64)
-                assert_raises(ValueError,
-                              cdist, X1, X2, metric, out=out5, **kwargs)
+        for metric in _METRICS_NAMES:
+            kwargs = dict()
+            if metric == 'minkowski':
+                kwargs['p'] = 1.23
+            out1 = np.empty((out_r, out_c), dtype=np.double)
+            Y1 = cdist(X1, X2, metric, **kwargs)
+            Y2 = cdist(X1, X2, metric, out=out1, **kwargs)
+            # test that output is numerically equivalent
+            _assert_within_tol(Y1, Y2, eps, verbose > 2)
+            # test that Y_test1 and out1 are the same object
+            assert_(Y2 is out1)
+            # test for incorrect shape
+            out2 = np.empty((out_r-1, out_c+1), dtype=np.double)
+            assert_raises(ValueError,
+                          cdist, X1, X2, metric, out=out2, **kwargs)
+            # test for C-contiguous order
+            out3 = np.empty(
+                (2 * out_r, 2 * out_c), dtype=np.double)[::2, ::2]
+            out4 = np.empty((out_r, out_c), dtype=np.double, order='F')
+            assert_raises(ValueError,
+                          cdist, X1, X2, metric, out=out3, **kwargs)
+            assert_raises(ValueError,
+                          cdist, X1, X2, metric, out=out4, **kwargs)
+
+            # test for incorrect dtype
+            out5 = np.empty((out_r, out_c), dtype=np.int64)
+            assert_raises(ValueError,
+                          cdist, X1, X2, metric, out=out5, **kwargs)
 
     def test_striding(self):
         # test that striding is handled correct with calls to
@@ -635,35 +631,31 @@ class TestCdist:
         assert_(X1_copy.flags.c_contiguous)
         assert_(X2_copy.flags.c_contiguous)
 
-        with suppress_warnings() as sup:
-            sup.filter(DeprecationWarning, "'wminkowski' metric is deprecated")
-            for metric in _METRICS_NAMES:
-                kwargs = dict()
-                if metric == 'minkowski':
-                    kwargs['p'] = 1.23
-                Y1 = cdist(X1, X2, metric, **kwargs)
-                Y2 = cdist(X1_copy, X2_copy, metric, **kwargs)
-                # test that output is numerically equivalent
-                _assert_within_tol(Y1, Y2, eps, verbose > 2)
+        for metric in _METRICS_NAMES:
+            kwargs = dict()
+            if metric == 'minkowski':
+                kwargs['p'] = 1.23
+            Y1 = cdist(X1, X2, metric, **kwargs)
+            Y2 = cdist(X1_copy, X2_copy, metric, **kwargs)
+            # test that output is numerically equivalent
+            _assert_within_tol(Y1, Y2, eps, verbose > 2)
 
     def test_cdist_refcount(self):
-        with suppress_warnings() as sup:
-            sup.filter(DeprecationWarning, "'wminkowski' metric is deprecated")
-            for metric in _METRICS_NAMES:
-                x1 = np.random.rand(10, 10)
-                x2 = np.random.rand(10, 10)
+        for metric in _METRICS_NAMES:
+            x1 = np.random.rand(10, 10)
+            x2 = np.random.rand(10, 10)
 
-                kwargs = dict()
-                if metric == 'minkowski':
-                    kwargs['p'] = 1.23
+            kwargs = dict()
+            if metric == 'minkowski':
+                kwargs['p'] = 1.23
 
-                out = cdist(x1, x2, metric=metric, **kwargs)
+            out = cdist(x1, x2, metric=metric, **kwargs)
 
-                # Check reference counts aren't messed up. If we only hold weak
-                # references, the arrays should be deallocated.
-                weak_refs = [weakref.ref(v) for v in (x1, x2, out)]
-                del x1, x2, out
-                assert all(weak_ref() is None for weak_ref in weak_refs)
+            # Check reference counts aren't messed up. If we only hold weak
+            # references, the arrays should be deallocated.
+            weak_refs = [weakref.ref(v) for v in (x1, x2, out)]
+            del x1, x2, out
+            assert all(weak_ref() is None for weak_ref in weak_refs)
 
 
 class TestPdist:
@@ -685,35 +677,33 @@ class TestPdist:
         X1 = [[1., 2.], [1.2, 2.3], [2.2, 2.3]]
         kwargs = {'N0tV4l1D_p4raM': 3.14, "w":np.arange(2)}
         args = [3.14] * 200
-        with suppress_warnings() as w:
-            w.filter(DeprecationWarning)
-            for metric in _METRICS_NAMES:
-                assert_raises(TypeError, pdist, X1, metric=metric, **kwargs)
-                assert_raises(TypeError, pdist, X1,
-                              metric=eval(metric), **kwargs)
-                assert_raises(TypeError, pdist, X1,
-                              metric="test_" + metric, **kwargs)
-                assert_raises(TypeError, pdist, X1, metric=metric, *args)
-                assert_raises(TypeError, pdist, X1, metric=eval(metric), *args)
-                assert_raises(TypeError, pdist, X1,
-                              metric="test_" + metric, *args)
+        for metric in _METRICS_NAMES:
+            assert_raises(TypeError, pdist, X1, metric=metric, **kwargs)
+            assert_raises(TypeError, pdist, X1,
+                          metric=eval(metric), **kwargs)
+            assert_raises(TypeError, pdist, X1,
+                          metric="test_" + metric, **kwargs)
+            assert_raises(TypeError, pdist, X1, metric=metric, *args)
+            assert_raises(TypeError, pdist, X1, metric=eval(metric), *args)
+            assert_raises(TypeError, pdist, X1,
+                          metric="test_" + metric, *args)
 
-            assert_raises(TypeError, pdist, X1, _my_metric)
-            assert_raises(TypeError, pdist, X1, _my_metric, *args)
-            assert_raises(TypeError, pdist, X1, _my_metric, **kwargs)
-            assert_raises(TypeError, pdist, X1, _my_metric,
-                          kwarg=2.2, kwarg2=3.3)
-            assert_raises(TypeError, pdist, X1, _my_metric, 1, 2, kwarg=2.2)
+        assert_raises(TypeError, pdist, X1, _my_metric)
+        assert_raises(TypeError, pdist, X1, _my_metric, *args)
+        assert_raises(TypeError, pdist, X1, _my_metric, **kwargs)
+        assert_raises(TypeError, pdist, X1, _my_metric,
+                      kwarg=2.2, kwarg2=3.3)
+        assert_raises(TypeError, pdist, X1, _my_metric, 1, 2, kwarg=2.2)
 
-            assert_raises(TypeError, pdist, X1, _my_metric, 1.1, 2.2, 3.3)
-            assert_raises(TypeError, pdist, X1, _my_metric, 1.1, 2.2)
-            assert_raises(TypeError, pdist, X1, _my_metric, 1.1)
-            assert_raises(TypeError, pdist, X1, _my_metric, 1.1,
-                          kwarg=2.2, kwarg2=3.3)
+        assert_raises(TypeError, pdist, X1, _my_metric, 1.1, 2.2, 3.3)
+        assert_raises(TypeError, pdist, X1, _my_metric, 1.1, 2.2)
+        assert_raises(TypeError, pdist, X1, _my_metric, 1.1)
+        assert_raises(TypeError, pdist, X1, _my_metric, 1.1,
+                      kwarg=2.2, kwarg2=3.3)
 
-            # these should work
-            assert_allclose(pdist(X1, metric=_my_metric,
-                                  arg=1.1, kwarg2=3.3), 5.4)
+        # these should work
+        assert_allclose(pdist(X1, metric=_my_metric,
+                              arg=1.1, kwarg2=3.3), 5.4)
 
     def test_pdist_euclidean_random(self):
         eps = 1e-07
@@ -1487,28 +1477,26 @@ class TestPdist:
         eps = 1e-07
         X = eo['random-float32-data'][::5, ::2]
         out_size = int((X.shape[0] * (X.shape[0] - 1)) / 2)
-        with suppress_warnings() as sup:
-            sup.filter(DeprecationWarning, "'wminkowski' metric is deprecated")
-            for metric in _METRICS_NAMES:
-                kwargs = dict()
-                if metric == 'minkowski':
-                    kwargs['p'] = 1.23
-                out1 = np.empty(out_size, dtype=np.double)
-                Y_right = pdist(X, metric, **kwargs)
-                Y_test1 = pdist(X, metric, out=out1, **kwargs)
-                # test that output is numerically equivalent
-                _assert_within_tol(Y_test1, Y_right, eps)
-                # test that Y_test1 and out1 are the same object
-                assert_(Y_test1 is out1)
-                # test for incorrect shape
-                out2 = np.empty(out_size + 3, dtype=np.double)
-                assert_raises(ValueError, pdist, X, metric, out=out2, **kwargs)
-                # test for (C-)contiguous output
-                out3 = np.empty(2 * out_size, dtype=np.double)[::2]
-                assert_raises(ValueError, pdist, X, metric, out=out3, **kwargs)
-                # test for incorrect dtype
-                out5 = np.empty(out_size, dtype=np.int64)
-                assert_raises(ValueError, pdist, X, metric, out=out5, **kwargs)
+        for metric in _METRICS_NAMES:
+            kwargs = dict()
+            if metric == 'minkowski':
+                kwargs['p'] = 1.23
+            out1 = np.empty(out_size, dtype=np.double)
+            Y_right = pdist(X, metric, **kwargs)
+            Y_test1 = pdist(X, metric, out=out1, **kwargs)
+            # test that output is numerically equivalent
+            _assert_within_tol(Y_test1, Y_right, eps)
+            # test that Y_test1 and out1 are the same object
+            assert_(Y_test1 is out1)
+            # test for incorrect shape
+            out2 = np.empty(out_size + 3, dtype=np.double)
+            assert_raises(ValueError, pdist, X, metric, out=out2, **kwargs)
+            # test for (C-)contiguous output
+            out3 = np.empty(2 * out_size, dtype=np.double)[::2]
+            assert_raises(ValueError, pdist, X, metric, out=out3, **kwargs)
+            # test for incorrect dtype
+            out5 = np.empty(out_size, dtype=np.int64)
+            assert_raises(ValueError, pdist, X, metric, out=out5, **kwargs)
 
     def test_striding(self):
         # test that striding is handled correct with calls to
@@ -1521,17 +1509,14 @@ class TestPdist:
         assert_(not X.flags.c_contiguous)
         assert_(X_copy.flags.c_contiguous)
 
-        with suppress_warnings() as sup:
-            sup.filter(DeprecationWarning,
-                       message="'wminkowski' metric is deprecated")
-            for metric in _METRICS_NAMES:
-                kwargs = dict()
-                if metric == 'minkowski':
-                    kwargs['p'] = 1.23
-                Y1 = pdist(X, metric, **kwargs)
-                Y2 = pdist(X_copy, metric, **kwargs)
-                # test that output is numerically equivalent
-                _assert_within_tol(Y1, Y2, eps, verbose > 2)
+        for metric in _METRICS_NAMES:
+            kwargs = dict()
+            if metric == 'minkowski':
+                kwargs['p'] = 1.23
+            Y1 = pdist(X, metric, **kwargs)
+            Y2 = pdist(X_copy, metric, **kwargs)
+            # test that output is numerically equivalent
+            _assert_within_tol(Y1, Y2, eps, verbose > 2)
 
 class TestSomeDistanceFunctions:
 
@@ -2087,12 +2072,10 @@ def test_modifies_input():
                      [2.2, 2.3, 4.4],
                      [22.2, 23.3, 44.4]])
     X1_copy = X1.copy()
-    with suppress_warnings() as w:
-        w.filter(message="'wminkowski' metric is deprecated")
-        for metric in _METRICS_NAMES:
-            cdist(X1, X1, metric)
-            pdist(X1, metric)
-            assert_array_equal(X1, X1_copy)
+    for metric in _METRICS_NAMES:
+        cdist(X1, X1, metric)
+        pdist(X1, metric)
+        assert_array_equal(X1, X1_copy)
 
 
 def test_Xdist_deprecated_args():
@@ -2103,14 +2086,11 @@ def test_Xdist_deprecated_args():
                      [22.2, 23.3, 44.4]])
     weights = np.arange(3)
     for metric in _METRICS_NAMES:
-        with suppress_warnings() as w:
-            w.filter(DeprecationWarning,
-                    message="'wminkowski' metric is deprecated")
-            with pytest.raises(TypeError):
-                cdist(X1, X1, metric, 2.)
+        with pytest.raises(TypeError):
+            cdist(X1, X1, metric, 2.)
 
-            with pytest.raises(TypeError):
-                pdist(X1, metric, 2.)
+        with pytest.raises(TypeError):
+            pdist(X1, metric, 2.)
 
         for arg in ["p", "V", "VI"]:
             kwargs = {arg:"foo"}
@@ -2120,30 +2100,24 @@ def test_Xdist_deprecated_args():
             (arg == "p" and metric == "minkowski")):
                 continue
 
-            with suppress_warnings() as w:
-                w.filter(DeprecationWarning,
-                        message="'wminkowski' metric is deprecated")
-                with pytest.raises(TypeError):
-                    cdist(X1, X1, metric, **kwargs)
+            with pytest.raises(TypeError):
+                cdist(X1, X1, metric, **kwargs)
 
-                with pytest.raises(TypeError):
-                    pdist(X1, metric, **kwargs)
+            with pytest.raises(TypeError):
+                pdist(X1, metric, **kwargs)
 
 
 def test_Xdist_non_negative_weights():
     X = eo['random-float32-data'][::5, ::2]
     w = np.ones(X.shape[1])
     w[::5] = -w[::5]
-    with suppress_warnings() as sup:
-        sup.filter(DeprecationWarning,
-                   message="'wminkowski' metric is deprecated")
-        for metric in _METRICS_NAMES:
-            if metric in ['seuclidean', 'mahalanobis', 'jensenshannon']:
-                continue
+    for metric in _METRICS_NAMES:
+        if metric in ['seuclidean', 'mahalanobis', 'jensenshannon']:
+            continue
 
-            for m in [metric, eval(metric), "test_" + metric]:
-                assert_raises(ValueError, pdist, X, m, w=w)
-                assert_raises(ValueError, cdist, X, X, m, w=w)
+        for m in [metric, eval(metric), "test_" + metric]:
+            assert_raises(ValueError, pdist, X, m, w=w)
+            assert_raises(ValueError, cdist, X, X, m, w=w)
 
 
 def test__validate_vector():


### PR DESCRIPTION
Since @peterbell10's #12374, `wminkowski` has been scheduled for removal in 1.8 - let's do that.

~While I was add it, I saw a lot of loops over `_METRICS_NAMES` in `test_distance.py` that lent themselves well to parametrization.~ will appear in follow-up PR

I recommend to review the diff per commit (ideally) and ignoring whitespace changes (use ⚙️ in the diff view)