### PR TITLE
MAINT:BLD: Open file in text mode for tempita

### DIFF
--- a/tools/cythonize.py
+++ b/tools/cythonize.py
@@ -122,14 +122,13 @@ def process_tempita_pyx(fromfile, tofile, cwd):
     except ImportError as e:
         raise Exception('Building SciPy requires Tempita: '
                         'pip install --user Tempita') from e
-    from_filename = tempita.Template.from_filename
-    template = from_filename(os.path.join(cwd, fromfile),
-                             encoding=sys.getdefaultencoding())
-    pyxcontent = template.substitute()
-    assert fromfile.endswith('.pyx.in')
-    pyxfile = fromfile[:-len('.pyx.in')] + '.pyx'
-    with open(os.path.join(cwd, pyxfile), "w") as f:
-        f.write(pyxcontent)
+    with open(os.path.join(cwd, fromfile), mode='r') as f_in:
+        template = f_in.read()
+        pyxcontent = tempita.sub(template)
+        assert fromfile.endswith('.pyx.in')
+        pyxfile = fromfile[:-len('.in')]
+        with open(os.path.join(cwd, pyxfile), "w", encoding='utf8') as f_out:
+            f_out.write(pyxcontent)
     process_pyx(pyxfile, tofile, cwd)
 
 


### PR DESCRIPTION
This is probably from the Python 2 days. But currently after tempita processing pyx files are practically double newlined causing all kinds of strange linter and refguide_check issues mainly because it starts opening the file in byte mode (due to internal `tempita.Tempita.from_file` mechanism) and then all can happen in the decoding which I have encountered. 

As an example you can check `scipy/linalg/_decomp_update.pyx` (or any pyx file for that matter) after the build. 

In the pyx.in file the header 

```
"""
Routines for updating QR decompositions

.. versionadded:: 0.16.0

"""
#
# Copyright (C) 2014 Eric Moore
#
# A few references for Updating QR factorizations:
#
# 1, 2, and 3 cover updates to full decompositons (q is square) and 4 and 5
# cover updates to thin (economic) decompositions (r is square). Reference 3
# additionally covers updating complete orthogonal factorizations and cholesky
# decompositions (i.e. updating R alone).
```

in the resulting pyx file 

```
"""

Routines for updating QR decompositions



.. versionadded:: 0.16.0



"""

#

# Copyright (C) 2014 Eric Moore

#

# A few references for Updating QR factorizations:

#

# 1, 2, and 3 cover updates to full decompositons (q is square) and 4 and 5

# cover updates to thin (economic) decompositions (r is square). Reference 3

# additionally covers updating complete orthogonal factorizations and cholesky

# decompositions (i.e. updating R alone).

#
```
Hence I propose opening files in text mode (which we control anyways). 