### PR TITLE
DOC: Update broken link to SuperLU library.

### DIFF
--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -290,7 +290,7 @@ def splu(A, permc_spec=None, diag_pivot_thresh=None,
 
     References
     ----------
-    .. [1] SuperLU http://crd.lbl.gov/~xiaoye/SuperLU/
+    .. [1] SuperLU https://portal.nersc.gov/project/sparse/superlu/
 
     Examples
     --------


### PR DESCRIPTION
Updates the broken link in the `References` section of the [splu docstring](https://scipy.github.io/devdocs/reference/generated/scipy.sparse.linalg.splu.html)