### PR TITLE
MAINT: update `stats.iqr` for deprecated `np.percentile` keyword

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -33,6 +33,7 @@ from collections import namedtuple
 
 import numpy as np
 from numpy import array, asarray, ma
+from numpy.lib import NumpyVersion
 
 from scipy.spatial.distance import cdist
 from scipy.ndimage import _measurements
@@ -2803,18 +2804,18 @@ def iqr(x, axis=None, rng=(25, 75), scale=1.0, nan_policy='propagate',
     rng : Two-element sequence containing floats in range of [0,100] optional
         Percentiles over which to compute the range. Each must be
         between 0 and 100, inclusive. The default is the true IQR:
-        `(25, 75)`. The order of the elements is not important.
+        ``(25, 75)``. The order of the elements is not important.
     scale : scalar or str, optional
         The numerical value of scale will be divided out of the final
         result. The following string values are recognized:
 
           * 'raw' : No scaling, just return the raw IQR.
-            **Deprecated!**  Use `scale=1` instead.
+            **Deprecated!**  Use ``scale=1`` instead.
           * 'normal' : Scale by
             :math:`2 \sqrt{2} erf^{-1}(\frac{1}{2}) \approx 1.349`.
 
-        The default is 1.0. The use of scale='raw' is deprecated.
-        Array-like scale is also allowed, as long
+        The default is 1.0. The use of ``scale='raw'`` is deprecated.
+        Array-like `scale` is also allowed, as long
         as it broadcasts correctly to the output such that
         ``out / scale`` is a valid operation. The output dimensions
         depend on the input array, `x`, the `axis` argument, and the
@@ -2826,22 +2827,24 @@ def iqr(x, axis=None, rng=(25, 75), scale=1.0, nan_policy='propagate',
           * 'propagate': returns nan
           * 'raise': throws an error
           * 'omit': performs the calculations ignoring nan values
-    interpolation : {'linear', 'lower', 'higher', 'midpoint',
-                     'nearest'}, optional
+    interpolation : str, optional
 
         Specifies the interpolation method to use when the percentile
-        boundaries lie between two data points `i` and `j`.
+        boundaries lie between two data points ``i`` and ``j``.
         The following options are available (default is 'linear'):
 
-          * 'linear': `i + (j - i) * fraction`, where `fraction` is the
-            fractional part of the index surrounded by `i` and `j`.
-          * 'lower': `i`.
-          * 'higher': `j`.
-          * 'nearest': `i` or `j` whichever is nearest.
-          * 'midpoint': `(i + j) / 2`.
+          * 'linear': ``i + (j - i)*fraction``, where ``fraction`` is the
+            fractional part of the index surrounded by ``i`` and ``j``.
+          * 'lower': ``i``.
+          * 'higher': ``j``.
+          * 'nearest': ``i`` or ``j`` whichever is nearest.
+          * 'midpoint': ``(i + j)/2``.
+
+        For NumPy >= 1.22.0, the additional options provided by the ``method``
+        keyword of `numpy.percentile` are also valid.
 
     keepdims : bool, optional
-        If this is set to `True`, the reduced axes are left in the
+        If this is set to True, the reduced axes are left in the
         result as dimensions with size one. With this option, the result
         will broadcast correctly against the original array `x`.
 
@@ -2856,27 +2859,6 @@ def iqr(x, axis=None, rng=(25, 75), scale=1.0, nan_policy='propagate',
     See Also
     --------
     numpy.std, numpy.var
-
-    Notes
-    -----
-    This function is heavily dependent on the version of `numpy` that is
-    installed. Versions greater than 1.11.0b3 are highly recommended, as they
-    include a number of enhancements and fixes to `numpy.percentile` and
-    `numpy.nanpercentile` that affect the operation of this function. The
-    following modifications apply:
-
-    Below 1.10.0 : `nan_policy` is poorly defined.
-        The default behavior of `numpy.percentile` is used for 'propagate'. This
-        is a hybrid of 'omit' and 'propagate' that mostly yields a skewed
-        version of 'omit' since NaNs are sorted to the end of the data. A
-        warning is raised if there are NaNs in the data.
-    Below 1.9.0: `numpy.nanpercentile` does not exist.
-        This means that `numpy.percentile` is used regardless of `nan_policy`
-        and a warning is issued. See previous item for a description of the
-        behavior.
-    Below 1.9.0: `keepdims` and `interpolation` are not supported.
-        The keywords get ignored with a warning if supplied with non-default
-        values. However, multiple axes are still supported.
 
     References
     ----------
@@ -2937,8 +2919,12 @@ def iqr(x, axis=None, rng=(25, 75), scale=1.0, nan_policy='propagate',
         raise ValueError("range must not contain NaNs")
 
     rng = sorted(rng)
-    pct = percentile_func(x, rng, axis=axis, interpolation=interpolation,
-                          keepdims=keepdims)
+    if NumpyVersion(np.__version__) >= '1.22.0':
+        pct = percentile_func(x, rng, axis=axis, method=interpolation,
+                              keepdims=keepdims)
+    else:
+        pct = percentile_func(x, rng, axis=axis, interpolation=interpolation,
+                              keepdims=keepdims)
     out = np.subtract(pct[1], pct[0])
 
     if scale != 1.0:

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2752,6 +2752,14 @@ class TestIQR:
         assert_equal(stats.iqr(x, rng=(25, 80), interpolation='midpoint'), 2.5)
         assert_equal(stats.iqr(y, interpolation='midpoint'), 2)
 
+        # Check all method= values new in numpy 1.22.0 are accepted
+        if NumpyVersion(np.__version__) >= '1.22.0':
+            for method in ('inverted_cdf', 'averaged_inverted_cdf',
+                           'closest_observation', 'interpolated_inverted_cdf',
+                           'hazen', 'weibull', 'median_unbiased',
+                           'normal_unbiased'):
+                stats.iqr(y, interpolation=method)
+
         assert_raises(ValueError, stats.iqr, x, interpolation='foobar')
 
     def test_keepdims(self):


### PR DESCRIPTION
Also clean up the docstring, and enable the new options added for the `method` keyword in numpy 1.22.0