### PR TITLE
ENH:linalg: expm overhaul and ndarray processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,6 +198,8 @@ scipy/linalg/cython_lapack.pyx
 scipy/linalg/src/id_dist/src/*_subr_*.f
 scipy/linalg/_matfuncs_sqrtm_triu.c
 scipy/linalg/_matfuncs_sqrtm_triu.cpp
+scipy/linalg/_matfuncs_expm.c
+scipy/linalg/_matfuncs_expm.pyx
 scipy/ndimage/src/_ni_label.c
 scipy/ndimage/src/_cytest.c
 scipy/optimize/_bglu_dense.c

--- a/benchmarks/benchmarks/linalg.py
+++ b/benchmarks/benchmarks/linalg.py
@@ -233,8 +233,6 @@ class SpecialMatrices(Benchmark):
     def time_toeplitz(self, size):
         sl.toeplitz(self.x)
 
-    def time_tri(self, size):
-        sl.tri(size)
 
 
 class GetFuncs(Benchmark):

--- a/benchmarks/benchmarks/linalg.py
+++ b/benchmarks/benchmarks/linalg.py
@@ -234,7 +234,6 @@ class SpecialMatrices(Benchmark):
         sl.toeplitz(self.x)
 
 
-
 class GetFuncs(Benchmark):
     def setup(self):
         self.x = np.eye(1)

--- a/benchmarks/benchmarks/sparse_linalg_expm.py
+++ b/benchmarks/benchmarks/sparse_linalg_expm.py
@@ -6,6 +6,7 @@ from .common import Benchmark, safe_import
 
 with safe_import():
     import scipy.linalg
+    from scipy.sparse.linalg import expm as sp_expm
     from scipy.sparse.linalg import expm_multiply
 
 
@@ -67,6 +68,6 @@ class Expm(Benchmark):
 
     def time_expm(self, n, format):
         if format == 'sparse':
-            scipy.linalg.expm(self.A_sparse)
+            sp_expm(self.A_sparse)
         elif format == 'dense':
             scipy.linalg.expm(self.A_dense)

--- a/scipy/linalg/_matfuncs.py
+++ b/scipy/linalg/_matfuncs.py
@@ -375,6 +375,8 @@ def expm(A):
 
 
 def _sinch(x):
+    if np.isscalar(x):
+        return 1. if x == 0. else np.sinh(x)/x
     m = x == 0.
     x[m] = 1.
     x[~m] = np.sinh(x[~m])/x[~m]

--- a/scipy/linalg/_matfuncs.py
+++ b/scipy/linalg/_matfuncs.py
@@ -295,20 +295,20 @@ def expm(A):
     # Explicit formula for 2x2 case, formula (2.2) in [1]
     # without Kahan's method numerical instabilities can occur.
     if a.shape[-2:] == (2, 2):
-        a1, a2, a3, a4 = (a[..., 0, 0],
-                          a[..., 0, 1],
-                          a[..., 1, 0],
-                          a[..., 1, 1])
+        a1, a2, a3, a4 = (a[..., [0], [0]],
+                          a[..., [0], [1]],
+                          a[..., [1], [0]],
+                          a[..., [1], [1]])
         mu = csqrt((a1-a4)**2 + 4*a2*a3)/2.
         eApD2 = np.exp((a1+a4)/2.)
         AmD2 = (a1 - a4)/2.
         coshMu = np.cosh(mu)
         sinchMu = _sinch(mu)
         eA = np.empty((a.shape), dtype=mu.dtype)
-        eA[..., 0, 0] = eApD2 * (coshMu + AmD2*sinchMu)
-        eA[..., 0, 1] = eApD2 * a2 * sinchMu
-        eA[..., 1, 0] = eApD2 * a3 * sinchMu
-        eA[..., 1, 1] = eApD2 * (coshMu - AmD2*sinchMu)
+        eA[..., [0], [0]] = eApD2 * (coshMu + AmD2*sinchMu)
+        eA[..., [0], [1]] = eApD2 * a2 * sinchMu
+        eA[..., [1], [0]] = eApD2 * a3 * sinchMu
+        eA[..., [1], [1]] = eApD2 * (coshMu - AmD2*sinchMu)
         if np.isrealobj(a):
             return eA.real
         return eA

--- a/scipy/linalg/_matfuncs.py
+++ b/scipy/linalg/_matfuncs.py
@@ -19,10 +19,9 @@ from ._expm_frechet import expm_frechet, expm_cond
 from ._matfuncs_sqrtm import sqrtm
 from ._matfuncs_expm import pick_pade_structure, pade_UV_calc
 
-__all__ = ['expm','cosm','sinm','tanm','coshm','sinhm',
-           'tanhm','logm','funm','signm','sqrtm',
-           'expm_frechet', 'expm_cond', 'fractional_matrix_power',
-           'khatri_rao']
+__all__ = ['expm', 'cosm', 'sinm', 'tanm', 'coshm', 'sinhm', 'tanhm', 'logm',
+           'funm', 'signm', 'sqrtm', 'fractional_matrix_power','expm_frechet',
+           'expm_cond', 'khatri_rao']
 
 eps = np.finfo('d').eps
 feps = np.finfo('f').eps
@@ -258,10 +257,10 @@ def expm(A):
     >>> expm(np.zeros((3, 2, 2)))
     array([[[1., 0.],
             [0., 1.]],
-
+    <BLANKLINE>
            [[1., 0.],
             [0., 1.]],
-
+    <BLANKLINE>
            [[1., 0.],
             [0., 1.]]])
 

--- a/scipy/linalg/_matfuncs.py
+++ b/scipy/linalg/_matfuncs.py
@@ -1,20 +1,15 @@
 #
 # Author: Travis Oliphant, March 2002
 #
-
-__all__ = ['expm','cosm','sinm','tanm','coshm','sinhm',
-           'tanhm','logm','funm','signm','sqrtm',
-           'expm_frechet', 'expm_cond', 'fractional_matrix_power',
-           'khatri_rao']
-
-from numpy import (Inf, dot, diag, prod, logical_not, ravel,
-        transpose, conjugate, absolute, amax, sign, isfinite, single)
-from numpy.lib.scimath import sqrt as csqrt
-import numpy as np
 from itertools import product
-from scipy.linalg import LinAlgError, bandwidth
+
+import numpy as np
+from numpy import (Inf, dot, diag, prod, logical_not, ravel, transpose,
+                   conjugate, absolute, amax, sign, isfinite)
+from numpy.lib.scimath import sqrt as csqrt
 
 # Local imports
+from scipy.linalg import LinAlgError, bandwidth
 from ._misc import norm
 from ._basic import solve, inv
 from ._special_matrices import triu
@@ -23,8 +18,14 @@ from ._decomp_schur import schur, rsf2csf
 from ._expm_frechet import expm_frechet, expm_cond
 from ._matfuncs_sqrtm import sqrtm
 from ._matfuncs_expm import pick_pade_structure, pade_UV_calc
-eps = np.finfo(float).eps
-feps = np.finfo(single).eps
+
+__all__ = ['expm','cosm','sinm','tanm','coshm','sinhm',
+           'tanhm','logm','funm','signm','sqrtm',
+           'expm_frechet', 'expm_cond', 'fractional_matrix_power',
+           'khatri_rao']
+
+eps = np.finfo('d').eps
+feps = np.finfo('f').eps
 
 _array_precision = {'i': 1, 'l': 1, 'f': 0, 'd': 1, 'F': 0, 'D': 1}
 
@@ -221,21 +222,21 @@ def expm(A):
     Returns
     -------
     eA : ndarray
-        The resulting matrix exponential with the same shape of A
+        The resulting matrix exponential with the same shape of ``A``
 
     Notes
     -----
-    Implements the algorithm given in [1], which is essentially a careful Pade
-    approximation and thus higher powers (up to eight) of the input are
-    computed. This has to be taken into account as it is not difficult to have
-    exponential growth leading to floating point overflows. For input with size
-    ``n``, the memory usage is in the worst case in the order of ``8*(n**2)``.
-    If the input data is not of single and double precision of real and complex
-    dtypes, it is copied to a new array. Same applies for noncontiguous inputs.
+    Implements the algorithm given in [1], which is essentially a Pade
+    approximation with a variable order that is decided based on the array
+    data.
+
+    For input with size ``n``, the memory usage is in the worst case in the
+    order of ``8*(n**2)``. If the input data is not of single and double
+    precision of real and complex dtypes, it is copied to a new array.
 
     For cases ``n >= 400``, the exact 1-norm computation cost, breaks even with
     1-norm estimation and from that point on the estimation scheme given in
-    [2] is used.
+    [2] is used to decide on the approximation order.
 
     References
     ----------
@@ -254,9 +255,15 @@ def expm(A):
 
     Matrix version of the formula exp(0) = 1:
 
-    >>> expm(np.zeros((2,2)))
-    array([[ 1.,  0.],
-           [ 0.,  1.]])
+    >>> expm(np.zeros((3, 2, 2)))
+    array([[[1., 0.],
+            [0., 1.]],
+
+           [[1., 0.],
+            [0., 1.]],
+
+           [[1., 0.],
+            [0., 1.]]])
 
     Euler's identity (exp(i*theta) = cos(theta) + i*sin(theta))
     applied to a matrix:

--- a/scipy/linalg/_matfuncs.py
+++ b/scipy/linalg/_matfuncs.py
@@ -20,7 +20,7 @@ from ._matfuncs_sqrtm import sqrtm
 from ._matfuncs_expm import pick_pade_structure, pade_UV_calc
 
 __all__ = ['expm', 'cosm', 'sinm', 'tanm', 'coshm', 'sinhm', 'tanhm', 'logm',
-           'funm', 'signm', 'sqrtm', 'fractional_matrix_power','expm_frechet',
+           'funm', 'signm', 'sqrtm', 'fractional_matrix_power', 'expm_frechet',
            'expm_cond', 'khatri_rao']
 
 eps = np.finfo('d').eps

--- a/scipy/linalg/_matfuncs_expm.pyi
+++ b/scipy/linalg/_matfuncs_expm.pyi
@@ -1,0 +1,6 @@
+from numpy.typing import NDArray
+from typing import Any, Tuple
+
+def pick_pade_structure(a: NDArray[Any]) -> Tuple[int, int]: ...
+
+def pade_UV_calc(Am: NDArray[Any], n: int, m: int) -> None: ...

--- a/scipy/linalg/_matfuncs_expm.pyx.in
+++ b/scipy/linalg/_matfuncs_expm.pyx.in
@@ -196,7 +196,7 @@ cdef pick_pade_structure_{{ pfx }}({{ tname }}[:, :, ::1] Am):
             return 5, s
 
         # m = 7
-        if n < 360:
+        if n < 400:
             {{ pfx }}gemm(cN, cN, &intn, &intn, &intn, &one, &Amv[2, 0, 0], &intn, &Amv[2, 0, 0], &intn, &zero, &Amv[4, 0, 0], &intn)
             d8 = norm1(Amv[4, :, :]) ** (1./8.)
         else:
@@ -216,7 +216,7 @@ cdef pick_pade_structure_{{ pfx }}({{ tname }}[:, :, ::1] Am):
 
         # m = 13
         # Scale-square
-        if n < 360:
+        if n < 400:
             {{ pfx }}gemm(cN, cN, &intn, &intn, &intn, &one, &Amv[3, 0, 0], &intn, &Amv[2, 0, 0], &intn, &zero, &Amv[4, 0, 0], &intn)
             d10 = norm1(Amv[4, :, :]) ** (1./10.)
         else:
@@ -264,7 +264,7 @@ cdef void pade_357_UV_calc_{{ pfx }}({{ tname }}[:, :, ::]Am, int n, int m) nogi
     cdef {{ prec }} two=2.0
     cdef {{ tname }} one = 1.0, zero = 0.0, neg_one = -1.0
     if not ipiv:
-        raise MemoryError('Internal function "pade_357_UV_calc_c" failed to allocate memory.')
+        raise MemoryError('Internal function "pade_357_UV_calc" failed to allocate memory.')
     try:
         # b[m] is always 1. hence skipped
         if m == 3:
@@ -286,7 +286,7 @@ cdef void pade_357_UV_calc_{{ pfx }}({{ tname }}[:, :, ::]Am, int n, int m) nogi
             b[5] = 1512.
             b[6] = 56.
         else:
-            raise ValueError(f'Internal function "pade_357_UV_calc_c" received an invalid value {m}')
+            raise ValueError(f'Internal function "pade_357_UV_calc" received an invalid value {m}')
 
         # Utilize the unused powers of Am as scratch memory
         if m == 3:
@@ -302,7 +302,7 @@ cdef void pade_357_UV_calc_{{ pfx }}({{ tname }}[:, :, ::]Am, int n, int m) nogi
             # U = Am[0] @ (b[5]*Am[2] + b[3]*Am[1] + b[1]*I_n)
             {{ pfx }}copy(&n2, &Am[1, 0, 0], &int_one, &Am[4, 0, 0], &int_one)
             {{ pfx }}scal(&n2, &b[3], &Am[4, 0, 0], &int_one)
-            {{ pfx }}axpy(&n2, &b[5], &Am[2, 0, 0], &int_one, &Am[4, 0, 0], &int_one)
+            {{ pfx }}axpy(&n2, &one, &Am[2, 0, 0], &int_one, &Am[4, 0, 0], &int_one)
             for i in range(n):
                 Am[4, i, i] = Am[4, i, i] + b[1]
             {{ pfx }}gemm(<char*>'N', <char*>'N', &n, &n, &n, &one, &Am[4, 0, 0], &n, &Am[0, 0, 0], &n, &zero, &Am[3, 0, 0], &n)
@@ -317,7 +317,7 @@ cdef void pade_357_UV_calc_{{ pfx }}({{ tname }}[:, :, ::]Am, int n, int m) nogi
             {{ pfx }}copy(&n2, &Am[1, 0, 0], &int_one, &Am[4, 0, 0], &int_one)
             {{ pfx }}scal(&n2, &b[3], &Am[4, 0, 0], &int_one)
             {{ pfx }}axpy(&n2, &b[5], &Am[2, 0, 0], &int_one, &Am[4, 0, 0], &int_one)
-            {{ pfx }}axpy(&n2, &b[7], &Am[3, 0, 0], &int_one, &Am[4, 0, 0], &int_one)
+            {{ pfx }}axpy(&n2, &one, &Am[3, 0, 0], &int_one, &Am[4, 0, 0], &int_one)
             for i in range(n):
                 Am[4, i, i] = Am[4, i, i] + b[1]
             # We ran out of space for dgemm; first compute V and then reuse space for U

--- a/scipy/linalg/_matfuncs_expm.pyx.in
+++ b/scipy/linalg/_matfuncs_expm.pyx.in
@@ -262,85 +262,87 @@ cdef void pade_357_UV_calc_{{ pfx }}({{ tname }}[:, :, ::]Am, int n, int m) nogi
     cdef {{ tname }} one = 1.0, zero = 0.0, neg_one = -1.0
     if not ipiv:
         raise MemoryError('Internal function "pade_357_UV_calc_c" failed to allocate memory.')
-    # b[m] is always 1. hence skipped
-    if m == 3:
-        b[0] = 120.
-        b[1] = 60.
-        b[2] = 12.
-    elif m == 5:
-        b[0] = 30240.
-        b[1] = 15120.
-        b[2] = 3360.
-        b[3] = 420.
-        b[4] = 30.
-    elif m == 7:
-        b[0] = 17297280.
-        b[1] = 8648640.
-        b[2] = 1995840.
-        b[3] = 277200.
-        b[4] = 25200.
-        b[5] = 1512.
-        b[6] = 56.
-    else:
-        raise ValueError(f'Internal function "pade_357_UV_calc_c" received an invalid value {m}')
+    try:
+        # b[m] is always 1. hence skipped
+        if m == 3:
+            b[0] = 120.
+            b[1] = 60.
+            b[2] = 12.
+        elif m == 5:
+            b[0] = 30240.
+            b[1] = 15120.
+            b[2] = 3360.
+            b[3] = 420.
+            b[4] = 30.
+        elif m == 7:
+            b[0] = 17297280.
+            b[1] = 8648640.
+            b[2] = 1995840.
+            b[3] = 277200.
+            b[4] = 25200.
+            b[5] = 1512.
+            b[6] = 56.
+        else:
+            raise ValueError(f'Internal function "pade_357_UV_calc_c" received an invalid value {m}')
 
-    # Utilize the unused powers of Am as scratch memory
-    if m == 3:
-        # U = Am[0] @ Am[1] + 60.*Am[0]
-        {{ pfx }}copy(&n2, &Am[0, 0, 0], &int_one, &Am[3, 0, 0], &int_one)
-        {{ pfx }}gemm(<char*>'N', <char*>'N', &n, &n, &n, &one, &Am[0, 0, 0], &n, &Am[1, 0, 0], &n, &b[1], &Am[3, 0, 0], &n)
-        # V = 12.*Am[1] + 120*I_n
-        {{ pfx }}scal(&n2, &b[2], &Am[1, 0, 0], &int_one)
+        # Utilize the unused powers of Am as scratch memory
+        if m == 3:
+            # U = Am[0] @ Am[1] + 60.*Am[0]
+            {{ pfx }}copy(&n2, &Am[0, 0, 0], &int_one, &Am[3, 0, 0], &int_one)
+            {{ pfx }}gemm(<char*>'N', <char*>'N', &n, &n, &n, &one, &Am[0, 0, 0], &n, &Am[1, 0, 0], &n, &b[1], &Am[3, 0, 0], &n)
+            # V = 12.*Am[1] + 120*I_n
+            {{ pfx }}scal(&n2, &b[2], &Am[1, 0, 0], &int_one)
+            for i in range(n):
+                Am[1, i, i] = Am[1, i, i] + b[0]
+
+        elif m == 5:
+            # U = Am[0] @ (b[5]*Am[2] + b[3]*Am[1] + b[1]*I_n)
+            {{ pfx }}copy(&n2, &Am[1, 0, 0], &int_one, &Am[4, 0, 0], &int_one)
+            {{ pfx }}scal(&n2, &b[3], &Am[4, 0, 0], &int_one)
+            {{ pfx }}axpy(&n2, &b[5], &Am[2, 0, 0], &int_one, &Am[4, 0, 0], &int_one)
+            for i in range(n):
+                Am[4, i, i] = Am[4, i, i] + b[1]
+            {{ pfx }}gemm(<char*>'N', <char*>'N', &n, &n, &n, &one, &Am[0, 0, 0], &n, &Am[4, 0, 0], &n, &zero, &Am[3, 0, 0], &n)
+            # V = b[4]*Am[2] + b[2]*Am[1] + b[0]*I_n
+            {{ pfx }}scal(&n2, &b[2], &Am[1, 0, 0], &int_one)
+            {{ pfx }}axpy(&n2, &b[4], &Am[2, 0, 0], &int_one, &Am[1, 0, 0], &int_one)
+            for i in range(n):
+                Am[1, i, i] = Am[1, i, i] + b[0]
+
+        else:
+            # U = Am[0] @ (b[7]*Am[3] + b[5]*Am[2] + b[3]*Am[1] + b[1]*I_n)
+            {{ pfx }}copy(&n2, &Am[1, 0, 0], &int_one, &Am[4, 0, 0], &int_one)
+            {{ pfx }}scal(&n2, &b[3], &Am[4, 0, 0], &int_one)
+            {{ pfx }}axpy(&n2, &b[5], &Am[2, 0, 0], &int_one, &Am[4, 0, 0], &int_one)
+            {{ pfx }}axpy(&n2, &b[7], &Am[3, 0, 0], &int_one, &Am[4, 0, 0], &int_one)
+            for i in range(n):
+                Am[4, i, i] = Am[4, i, i] + b[1]
+            # We ran out of space for dgemm; first compute V and then reuse space for U
+            # V = b[6]*Am[3] + b[4]*Am[2] + b[2]*Am[1] + b[0]*I_n
+            {{ pfx }}scal(&n2, &b[2], &Am[1, 0, 0], &int_one)
+            {{ pfx }}axpy(&n2, &b[4], &Am[2, 0, 0], &int_one, &Am[1, 0, 0], &int_one)
+            {{ pfx }}axpy(&n2, &b[6], &Am[3, 0, 0], &int_one, &Am[1, 0, 0], &int_one)
+            for i in range(n):
+                Am[1, i, i] = Am[1, i, i] + b[0]
+            # Now we can scratch A[2] or A[3]
+            {{ pfx }}gemm(<char*>'N', <char*>'N', &n, &n, &n, &one, &Am[0, 0, 0], &n, &Am[4, 0, 0], &n, &zero, &Am[3, 0, 0], &n)
+
+        # inv(V-U) (V+U) = inv(V-U) (V-U+2V) = I + 2 inv(V-U) U
+        {{ pfx }}axpy(&n2, &neg_one, &Am[3, 0, 0], &int_one, &Am[1, 0, 0], &int_one)
+
+        # Convert array layout for solving AX = B into Am[2]
+        swap_c_and_f_layout(&Am[3, 0, 0], &Am[2, 0, 0], n, n, n)
+
+        {{ pfx }}getrf( &n, &n, &Am[1, 0, 0], &n, &ipiv[0], &info )
+        {{ pfx }}getrs(<char*>'C', &n, &n, &Am[1, 0, 0], &n, &ipiv[0], &Am[2, 0, 0], &n, &info )
+        {{ sc }}scal(&n2, &two, &Am[2, 0, 0], &int_one)
         for i in range(n):
-            Am[1, i, i] = Am[1, i, i] + b[0]
+            Am[2, i, i] = Am[2, i, i] + 1.
 
-    elif m == 5:
-        # U = Am[0] @ (b[5]*Am[2] + b[3]*Am[1] + b[1]*I_n)
-        {{ pfx }}copy(&n2, &Am[1, 0, 0], &int_one, &Am[4, 0, 0], &int_one)
-        {{ pfx }}scal(&n2, &b[3], &Am[4, 0, 0], &int_one)
-        {{ pfx }}axpy(&n2, &b[5], &Am[2, 0, 0], &int_one, &Am[4, 0, 0], &int_one)
-        for i in range(n):
-            Am[4, i, i] = Am[4, i, i] + b[1]
-        {{ pfx }}gemm(<char*>'N', <char*>'N', &n, &n, &n, &one, &Am[0, 0, 0], &n, &Am[4, 0, 0], &n, &zero, &Am[3, 0, 0], &n)
-        # V = b[4]*Am[2] + b[2]*Am[1] + b[0]*I_n
-        {{ pfx }}scal(&n2, &b[2], &Am[1, 0, 0], &int_one)
-        {{ pfx }}axpy(&n2, &b[4], &Am[2, 0, 0], &int_one, &Am[1, 0, 0], &int_one)
-        for i in range(n):
-            Am[1, i, i] = Am[1, i, i] + b[0]
-
-    else:
-        # U = Am[0] @ (b[7]*Am[3] + b[5]*Am[2] + b[3]*Am[1] + b[1]*I_n)
-        {{ pfx }}copy(&n2, &Am[1, 0, 0], &int_one, &Am[4, 0, 0], &int_one)
-        {{ pfx }}scal(&n2, &b[3], &Am[4, 0, 0], &int_one)
-        {{ pfx }}axpy(&n2, &b[5], &Am[2, 0, 0], &int_one, &Am[4, 0, 0], &int_one)
-        {{ pfx }}axpy(&n2, &b[7], &Am[3, 0, 0], &int_one, &Am[4, 0, 0], &int_one)
-        for i in range(n):
-            Am[4, i, i] = Am[4, i, i] + b[1]
-        # We ran out of space for dgemm; first compute V and then reuse space for U
-        # V = b[6]*Am[3] + b[4]*Am[2] + b[2]*Am[1] + b[0]*I_n
-        {{ pfx }}scal(&n2, &b[2], &Am[1, 0, 0], &int_one)
-        {{ pfx }}axpy(&n2, &b[4], &Am[2, 0, 0], &int_one, &Am[1, 0, 0], &int_one)
-        {{ pfx }}axpy(&n2, &b[6], &Am[3, 0, 0], &int_one, &Am[1, 0, 0], &int_one)
-        for i in range(n):
-            Am[1, i, i] = Am[1, i, i] + b[0]
-        # Now we can scratch A[2] or A[3]
-        {{ pfx }}gemm(<char*>'N', <char*>'N', &n, &n, &n, &one, &Am[0, 0, 0], &n, &Am[4, 0, 0], &n, &zero, &Am[3, 0, 0], &n)
-
-    # inv(V-U) (V+U) = inv(V-U) (V-U+2V) = I + 2 inv(V-U) U
-    {{ pfx }}axpy(&n2, &neg_one, &Am[3, 0, 0], &int_one, &Am[1, 0, 0], &int_one)
-
-    # Convert array layout for solving AX = B into Am[2]
-    swap_c_and_f_layout(&Am[3, 0, 0], &Am[2, 0, 0], n, n, n)
-
-    {{ pfx }}getrf( &n, &n, &Am[1, 0, 0], &n, &ipiv[0], &info )
-    {{ pfx }}getrs(<char*>'C', &n, &n, &Am[1, 0, 0], &n, &ipiv[0], &Am[2, 0, 0], &n, &info )
-    {{ sc }}scal(&n2, &two, &Am[2, 0, 0], &int_one)
-    for i in range(n):
-        Am[2, i, i] = Am[2, i, i] + 1.
-
-    # Put it back in Am in C order
-    swap_c_and_f_layout(&Am[2, 0, 0], &Am[0, 0, 0], n, n, n)
-    free(ipiv)
+        # Put it back in Am in C order
+        swap_c_and_f_layout(&Am[2, 0, 0], &Am[0, 0, 0], n, n, n)
+    finally:
+        free(ipiv)
 
 
 {{endfor}}
@@ -480,7 +482,6 @@ cdef void pade_13_UV_calc_{{ pfx }}({{ tname }}[:, :, ::1]Am, int n) nogil:
 
         # Convert array layout for solving AX = B into work4
         swap_c_and_f_layout(work2, work4, n, n, n)
-        free(work2)
 
         {{ pfx }}getrf( &n, &n, &work3[0], &n, &ipiv[0], &info )
         {{ pfx }}getrs(<char*>'C', &n, &n, &work3[0], &n, &ipiv[0], &work4[0], &n, &info )
@@ -491,6 +492,7 @@ cdef void pade_13_UV_calc_{{ pfx }}({{ tname }}[:, :, ::1]Am, int n) nogil:
         swap_c_and_f_layout(work4, &Am[0, 0, 0], n, n, n)
     finally:
         free(ipiv)
+        free(work2)
         free(work3)
         free(work4)
 

--- a/scipy/linalg/_matfuncs_expm.pyx.in
+++ b/scipy/linalg/_matfuncs_expm.pyx.in
@@ -16,6 +16,9 @@ from scipy.linalg.cython_blas cimport (sgemm, saxpy, sscal, scopy, sgemv,
 
 __all__ = ['pick_pade_structure', 'pade_UV_calc']
 
+# See GH-14813
+cnp.import_array()
+
 ctypedef fused lapack_t:
     float
     double

--- a/scipy/linalg/_matfuncs_expm.pyx.in
+++ b/scipy/linalg/_matfuncs_expm.pyx.in
@@ -333,7 +333,7 @@ cdef void pade_357_UV_calc_{{ pfx }}({{ tname }}[:, :, ::]Am, int n, int m) nogi
         swap_c_and_f_layout(&Am[3, 0, 0], &Am[2, 0, 0], n, n, n)
 
         {{ pfx }}getrf( &n, &n, &Am[1, 0, 0], &n, &ipiv[0], &info )
-        {{ pfx }}getrs(<char*>'C', &n, &n, &Am[1, 0, 0], &n, &ipiv[0], &Am[2, 0, 0], &n, &info )
+        {{ pfx }}getrs(<char*>'T', &n, &n, &Am[1, 0, 0], &n, &ipiv[0], &Am[2, 0, 0], &n, &info )
         {{ sc }}scal(&n2, &two, &Am[2, 0, 0], &int_one)
         for i in range(n):
             Am[2, i, i] = Am[2, i, i] + 1.
@@ -397,7 +397,7 @@ cdef void pade_9_UV_calc_{{ pfx }}({{ tname }}[:, :, ::]Am, int n) nogil:
         swap_c_and_f_layout(&Am[3, 0, 0], &Am[2, 0, 0], n, n, n)
 
         {{ pfx }}getrf( &n, &n, &Am[1, 0, 0], &n, &ipiv[0], &info )
-        {{ pfx }}getrs(<char*>'C', &n, &n, &Am[1, 0, 0], &n, &ipiv[0], &Am[2, 0, 0], &n, &info)
+        {{ pfx }}getrs(<char*>'T', &n, &n, &Am[1, 0, 0], &n, &ipiv[0], &Am[2, 0, 0], &n, &info)
         {{ sc }}scal(&n2, &two, &Am[2, 0, 0], &int_one)
         for i in range(n):
             Am[2, i, i] = Am[2, i, i] + 1.
@@ -483,7 +483,7 @@ cdef void pade_13_UV_calc_{{ pfx }}({{ tname }}[:, :, ::1]Am, int n) nogil:
         swap_c_and_f_layout(work2, work4, n, n, n)
 
         {{ pfx }}getrf( &n, &n, &work3[0], &n, &ipiv[0], &info )
-        {{ pfx }}getrs(<char*>'C', &n, &n, &work3[0], &n, &ipiv[0], &work4[0], &n, &info )
+        {{ pfx }}getrs(<char*>'T', &n, &n, &work3[0], &n, &ipiv[0], &work4[0], &n, &info )
         {{ sc }}scal(&n2, &two, &work4[0], &int1)
         for i in range(n):
             work4[i*(n+1)] += 1.

--- a/scipy/linalg/_matfuncs_expm.pyx.in
+++ b/scipy/linalg/_matfuncs_expm.pyx.in
@@ -1,0 +1,722 @@
+# cython: language_level=3
+cimport cython
+cimport numpy as cnp
+import numpy as np
+import random
+import math
+from libc.stdlib cimport malloc, free
+from libc.math cimport fabs, ceil, log2, pow
+from scipy.linalg.cython_lapack cimport (sgetrf, sgetrs, dgetrf, dgetrs,
+                                         cgetrf, cgetrs, zgetrf, zgetrs)
+from scipy.linalg.cython_blas cimport (sgemm, saxpy, sscal, scopy, sgemv,
+                                       dgemm, daxpy, dscal, dcopy, dgemv,
+                                       cgemm, caxpy, cscal, ccopy, cgemv,
+                                       zgemm, zaxpy, zscal, zcopy, dgemv,
+                                       csscal, zdscal, idamax)
+
+__all__ = ['pick_pade_structure', 'pade_UV_calc']
+
+ctypedef fused lapack_t:
+    float
+    double
+    (float complex)
+    (double complex)
+
+ctypedef fused lapack_cz_t:
+    (float complex)
+    (double complex)
+
+ctypedef fused lapack_sd_t:
+    float
+    double
+
+{{py:
+# Tempita variables
+typenames = ['float', 'double', 'float complex', 'double complex']
+precision = ['float', 'double', 'float', 'double']
+prefixes = ['s', 'd', 'c', 'z']
+}}
+# ====================== swap_c_and_f_layout : s, d, c, z ====================
+@cython.cdivision(True)
+@cython.wraparound(False)
+@cython.boundscheck(False)
+@cython.initializedcheck(False)
+cdef void swap_c_and_f_layout(lapack_t *a, lapack_t *b, int r, int c, int n) nogil:
+    """Recursive matrix transposition for square arrays"""
+    cdef int i, j, ith_row, r2, c2
+    cdef lapack_t *bb=b
+    cdef lapack_t *aa=a
+    if r < 16:
+        for j in range(c):
+            ith_row = 0
+            for i in range(r):
+            # Basically b[i*n+j] = a[j*n+i] without index math
+                bb[ith_row] = aa[i]
+                ith_row += n
+            aa += n
+            bb += 1
+    else:
+        # If tall
+        if (r > c):
+            r2 = r//2
+            swap_c_and_f_layout(a, b, r2, c, n)
+            swap_c_and_f_layout(a + r2, b+(r2)*n, r-r2, c, n)
+        else:  # Nope
+            c2 = c//2
+            swap_c_and_f_layout(a, b, r, c2, n);
+            swap_c_and_f_layout(a+(c2)*n, b+c2, r, c-c2, n)
+# ============================================================================
+
+# ========================= norm1 : s, d, c, z ===============================
+# The generic abs() function is made nogil friendly in Cython 3.x (unreleased)
+@cython.wraparound(False)
+@cython.boundscheck(False)
+@cython.initializedcheck(False)
+cdef double norm1(lapack_t[:, ::1] A):
+    """
+    Fast 1-norm computation for C-contiguous square arrays.
+    Regardless of the dtype we work in double precision to prevent overflows
+    """
+    cdef Py_ssize_t n = A.shape[0]
+    cdef Py_ssize_t i, j
+    cdef int ind = 1, intn = <int>n
+    cdef double temp = 0.
+    cdef double complex temp_cz = 0.
+    cdef double temp_sd = 0.
+    cdef double *work = <double*> malloc(n*sizeof(double))
+    if not work:
+        raise MemoryError('Internal function "norm1" failed to allocate memory.')
+    try:
+        if lapack_t in lapack_cz_t:
+            for j in range(n):
+                temp_cz = A[0, j]
+                work[j] = abs(temp_cz)
+            for i in range(1, n):
+                for j in range(n):
+                    temp_cz = A[i, j]
+                    work[j] += abs(temp_cz)
+        else:
+            for j in range(n):
+                temp_sd = A[0, j]
+                work[j] = abs(temp_sd)
+            for i in range(1, n):
+                for j in range(n):
+                    temp_sd = A[i, j]
+                    work[j] += abs(temp_sd)
+
+        ind = idamax(&intn, &work[0], &ind)
+        temp = work[ind-1]
+        return temp
+    finally:
+        free(work)
+# ============================================================================
+
+# ========================= kth power norm : d ===============================
+@cython.wraparound(False)
+@cython.boundscheck(False)
+@cython.initializedcheck(False)
+cdef double kth_power_norm_d(double* A, double* v1, double* v2, Py_ssize_t n, int spins):
+    cdef int k, int_one = 1, intn = <int>n
+    cdef double one =1., zero = 0.
+    for k in range(spins):
+        dgemv(<char*>'C', &intn, &intn, &one, &A[0], &intn, &v1[0], &int_one, &zero, &v2[0], &int_one)
+        dcopy(&intn, &v2[0], &int_one, &v1[0], &int_one)
+    k = idamax(&intn, &v1[0], &int_one)
+    return v1[k-1]
+# ============================================================================
+
+# ====================== pick_pade_structure : s, d, c, z ====================
+{{for tname, pfx, dchar, dt in zip(typenames, prefixes, ['f', 'd', 'F', 'D'],
+                                   ['float32', 'float64', 'complex64', 'complex128'],
+                                  )}}
+@cython.cdivision(True)
+@cython.wraparound(False)
+@cython.boundscheck(False)
+@cython.initializedcheck(False)
+cdef pick_pade_structure_{{ pfx }}({{ tname }}[:, ::1] A):
+    cdef Py_ssize_t n = A.shape[0], i, j, k
+    cdef int lm = 0, s = 0, intn = <int>n, n2= intn*intn, int_one = 1
+    cdef cnp.ndarray[cnp.{{ dt }}_t, ndim=3] Am = np.empty((5, n, n), dtype='{{ dchar }}')
+    cdef {{ tname }}[:, :, ::1] Amv = Am
+    cdef:
+        {{ tname }} one = 1.0, zero = 0.0
+        double normA
+        double d4, d6, d8, d10
+        double eta0, eta1, eta2, eta3, eta4
+        double u = (2.)**({{if pfx in ['s', 'c']}}-24.{{else}}-53{{endif}})
+        double two_pow_s
+        double temp
+    cdef double *absA = <double*>malloc(n*n*sizeof(double))
+    cdef double *work = <double*>malloc(n*sizeof(double))
+    cdef double *work2 = <double*>malloc(n*sizeof(double))
+    if not work or not work2 or not absA:
+        raise MemoryError('Internal function "pick_pade_structure" failed to allocate memory.')
+    cdef double [5] theta
+    cdef double [5] coeff
+    cdef char* cN = 'N'
+
+    theta[0] = 1.495585217958292e-002
+    theta[1] = 2.539398330063230e-001
+    theta[2] = 9.504178996162932e-001
+    theta[3] = 2.097847961257068e+000
+    theta[4] = 4.250000000000000e+000
+    coeff[0] = u*100800.
+    coeff[1] = u*10059033600.
+    coeff[2] = u*4487938430976000.
+    coeff[3] = u*5914384781877411840000.
+    coeff[4] = u*113250775606021113483283660800000000.
+    try:
+        for j in range(n):
+            work[j] = 1.
+
+        {{ pfx }}copy(&n2, &A[0, 0], &int_one, &Amv[0, 0, 0], &int_one)
+        for i in range(n):
+            for j in range(n):
+                absA[i*n + j] = abs(A[i, j])
+
+        # First spin = normest(|A|, 1), increase m when spun more
+        normA = kth_power_norm_d(absA, work, work2, n, 1)
+        {{ pfx }}gemm(cN, cN, &intn, &intn, &intn, &one, &Amv[0, 0, 0], &intn, &Amv[0, 0, 0], &intn, &zero, &Amv[1, 0, 0], &intn)
+        {{ pfx }}gemm(cN, cN, &intn, &intn, &intn, &one, &Amv[1, 0, 0], &intn, &Amv[1, 0, 0], &intn, &zero, &Amv[2, 0, 0], &intn)
+        {{ pfx }}gemm(cN, cN, &intn, &intn, &intn, &one, &Amv[2, 0, 0], &intn, &Amv[1, 0, 0], &intn, &zero, &Amv[3, 0, 0], &intn)
+        d4 = norm1(Amv[2]) ** (1./4.)
+        d6 = norm1(Amv[3]) ** (1./6.)
+        eta0 = max(d4, d6)
+        eta1 = eta0
+
+        # m = 3
+        temp = kth_power_norm_d(absA, work, work2, n, 6)
+        lm = max(<int>ceil(log2(temp/normA/coeff[0])/6), 0)
+        if eta0 < theta[0] and lm == 0:
+            return Am, 3, s
+
+        # m = 5
+        temp = kth_power_norm_d(absA, work, work2, n, 4)
+        lm = max(<int>ceil(log2(temp/normA/coeff[1])/10), 0)
+        if eta1 < theta[1] and lm == 0:
+            return Am, 5, s
+
+        # m = 7
+        if n < 360:
+            {{ pfx }}gemm(cN, cN, &intn, &intn, &intn, &one, &Amv[2, 0, 0], &intn, &Amv[2, 0, 0], &intn, &zero, &Amv[4, 0, 0], &intn)
+            d8 = norm1(Amv[4, :, :]) ** (1./8.)
+        else:
+            d8  = _norm1est(Am[0], m=8) ** (1./8.)
+
+        eta2 = max(d6, d8)
+        temp = kth_power_norm_d(absA, work, work2, n, 4)
+        lm = max(<int>ceil(log2(temp/normA/coeff[2])/14), 0)
+        if eta2 < theta[2] and lm == 0:
+            return Am, 7, s
+
+        # m = 9
+        temp = kth_power_norm_d(absA, work, work2, n, 4)
+        lm = max(<int>ceil(log2(temp/normA/coeff[3])/18), 0)
+        if eta2 < theta[3] and lm == 0:
+            return Am, 9, s
+
+        # m = 13
+        # Scale-square
+        if n < 360:
+            {{ pfx }}gemm(cN, cN, &intn, &intn, &intn, &one, &Amv[3, 0, 0], &intn, &Amv[2, 0, 0], &intn, &zero, &Amv[4, 0, 0], &intn)
+            d10 = norm1(Amv[4, :, :]) ** (1./10.)
+        else:
+            d10  = _norm1est(Am[0], m=10) ** (1./10.)
+
+        eta3 = max(d8, d10)
+        eta4 = min(eta2, eta3)
+        s = max(<int>ceil(log2(eta4/theta[4])), 0)
+        if s != 0:
+            two_pow_s = 2.** (-s)
+            dscal(&n2, &two_pow_s, absA, &int_one)
+            # kth_power_norm has spun 19 times already
+            two_pow_s = 2.** ((-s)*19.)
+            for i in range(n):
+                work[i] *= two_pow_s
+            normA *= 2.**(-s)
+        temp = kth_power_norm_d(absA, work, work2, n, 8)
+        s += max(<int>ceil(log2(temp/normA/coeff[4])/26), 0)
+        return Am, 13, s
+    finally:
+        free(work)
+        free(work2)
+        free(absA)
+
+
+{{endfor}}
+# ============================================================================
+
+# ====================== pade_m_UV_calc : s, d, c, z =========================
+# Note: MSVC does not accept "Memview[i, j, k] += 1.+0.j" as a valid operation
+# and results with error "C2088: '+=': illegal for struct".
+# OCD is unbearable but we do explicit addition for that reason.
+{{for tname, pfx, prec, sc in zip(typenames, prefixes, precision, ['s', 'd', 'cs', 'zd'])}}
+@cython.wraparound(False)
+@cython.boundscheck(False)
+@cython.initializedcheck(False)
+cdef void pade_357_UV_calc_{{ pfx }}({{ tname }}[:, :, ::]Am, int n, int m) nogil:
+    cdef {{ tname }} b[7]
+    cdef int *ipiv = <int*>malloc(n*sizeof(int))
+    cdef int i, info, n2 = n*n, int_one = 1
+    cdef {{ prec }} two=2.0
+    cdef {{ tname }} one = 1.0, zero = 0.0, neg_one = -1.0
+    if not ipiv:
+        raise MemoryError('Internal function "pade_357_UV_calc_c" failed to allocate memory.')
+    # b[m] is always 1. hence skipped
+    if m == 3:
+        b[0] = 120.
+        b[1] = 60.
+        b[2] = 12.
+    elif m == 5:
+        b[0] = 30240.
+        b[1] = 15120.
+        b[2] = 3360.
+        b[3] = 420.
+        b[4] = 30.
+    elif m == 7:
+        b[0] = 17297280.
+        b[1] = 8648640.
+        b[2] = 1995840.
+        b[3] = 277200.
+        b[4] = 25200.
+        b[5] = 1512.
+        b[6] = 56.
+    else:
+        raise ValueError(f'Internal function "pade_357_UV_calc_c" received an invalid value {m}')
+
+    # Utilize the unused powers of Am as scratch memory
+    if m == 3:
+        # U = Am[0] @ Am[1] + 60.*Am[0]
+        {{ pfx }}copy(&n2, &Am[0, 0, 0], &int_one, &Am[3, 0, 0], &int_one)
+        {{ pfx }}gemm(<char*>'N', <char*>'N', &n, &n, &n, &one, &Am[0, 0, 0], &n, &Am[1, 0, 0], &n, &b[1], &Am[3, 0, 0], &n)
+        # V = 12.*Am[1] + 120*I_n
+        {{ pfx }}scal(&n2, &b[2], &Am[1, 0, 0], &int_one)
+        for i in range(n):
+            Am[1, i, i] = Am[1, i, i] + b[0]
+
+    elif m == 5:
+        # U = Am[0] @ (b[5]*Am[2] + b[3]*Am[1] + b[1]*I_n)
+        {{ pfx }}copy(&n2, &Am[1, 0, 0], &int_one, &Am[4, 0, 0], &int_one)
+        {{ pfx }}scal(&n2, &b[3], &Am[4, 0, 0], &int_one)
+        {{ pfx }}axpy(&n2, &b[5], &Am[2, 0, 0], &int_one, &Am[4, 0, 0], &int_one)
+        for i in range(n):
+            Am[4, i, i] = Am[4, i, i] + b[1]
+        {{ pfx }}gemm(<char*>'N', <char*>'N', &n, &n, &n, &one, &Am[0, 0, 0], &n, &Am[4, 0, 0], &n, &zero, &Am[3, 0, 0], &n)
+        # V = b[4]*Am[2] + b[2]*Am[1] + b[0]*I_n
+        {{ pfx }}scal(&n2, &b[2], &Am[1, 0, 0], &int_one)
+        {{ pfx }}axpy(&n2, &b[4], &Am[2, 0, 0], &int_one, &Am[1, 0, 0], &int_one)
+        for i in range(n):
+            Am[1, i, i] = Am[1, i, i] + b[0]
+
+    else:
+        # U = Am[0] @ (b[7]*Am[3] + b[5]*Am[2] + b[3]*Am[1] + b[1]*I_n)
+        {{ pfx }}copy(&n2, &Am[1, 0, 0], &int_one, &Am[4, 0, 0], &int_one)
+        {{ pfx }}scal(&n2, &b[3], &Am[4, 0, 0], &int_one)
+        {{ pfx }}axpy(&n2, &b[5], &Am[2, 0, 0], &int_one, &Am[4, 0, 0], &int_one)
+        {{ pfx }}axpy(&n2, &b[7], &Am[3, 0, 0], &int_one, &Am[4, 0, 0], &int_one)
+        for i in range(n):
+            Am[4, i, i] = Am[4, i, i] + b[1]
+        # We ran out of space for dgemm; first compute V and then reuse space for U
+        # V = b[6]*Am[3] + b[4]*Am[2] + b[2]*Am[1] + b[0]*I_n
+        {{ pfx }}scal(&n2, &b[2], &Am[1, 0, 0], &int_one)
+        {{ pfx }}axpy(&n2, &b[4], &Am[2, 0, 0], &int_one, &Am[1, 0, 0], &int_one)
+        {{ pfx }}axpy(&n2, &b[6], &Am[3, 0, 0], &int_one, &Am[1, 0, 0], &int_one)
+        for i in range(n):
+            Am[1, i, i] = Am[1, i, i] + b[0]
+        # Now we can scratch A[2] or A[3]
+        {{ pfx }}gemm(<char*>'N', <char*>'N', &n, &n, &n, &one, &Am[0, 0, 0], &n, &Am[4, 0, 0], &n, &zero, &Am[3, 0, 0], &n)
+
+    # inv(V-U) (V+U) = inv(V-U) (V-U+2V) = I + 2 inv(V-U) U
+    {{ pfx }}axpy(&n2, &neg_one, &Am[3, 0, 0], &int_one, &Am[1, 0, 0], &int_one)
+
+    # Convert array layout for solving AX = B into Am[2]
+    swap_c_and_f_layout(&Am[3, 0, 0], &Am[2, 0, 0], n, n, n)
+
+    {{ pfx }}getrf( &n, &n, &Am[1, 0, 0], &n, &ipiv[0], &info )
+    {{ pfx }}getrs(<char*>'C', &n, &n, &Am[1, 0, 0], &n, &ipiv[0], &Am[2, 0, 0], &n, &info )
+    {{ sc }}scal(&n2, &two, &Am[2, 0, 0], &int_one)
+    for i in range(n):
+        Am[2, i, i] = Am[2, i, i] + 1.
+
+    # Put it back in Am in C order
+    swap_c_and_f_layout(&Am[2, 0, 0], &Am[0, 0, 0], n, n, n)
+    free(ipiv)
+
+
+{{endfor}}
+{{for tname, pfx, sc in zip(typenames, prefixes,  ['s', 'd', 'cs', 'zd'])}}
+@cython.wraparound(False)
+@cython.boundscheck(False)
+@cython.initializedcheck(False)
+cdef void pade_9_UV_calc_{{ pfx }}({{ tname }}[:, :, ::]Am, int n) nogil:
+    cdef {{ tname }} b[9]
+    cdef {{ tname }} *work = <{{ tname }}*>malloc(n*n*sizeof({{ tname }}))
+    cdef int *ipiv = <int*>malloc(n*sizeof(int))
+    cdef int i, info, n2 = n*n, int_one = 1
+    cdef {{ tname }} one = 1.0, zero = 0.0, neg_one = -1.0
+    cdef {{if pfx in ['s', 'c']}}float{{else}}double{{endif}} two = 2.0
+
+    if not (work and ipiv):
+        raise MemoryError('Internal function "pade_9_UV_calc" failed to allocate memory.')
+    try:
+        # b[9] = 1. hence skipped
+        b[0] = 17643225600.
+        b[1] = 8821612800.
+        b[2] = 2075673600.
+        b[3] = 302702400.
+        b[4] = 30270240.
+        b[5] = 2162160.
+        b[6] = 110880.
+        b[7] = 3960.
+        b[8] = 90.
+
+        # Utilize the unused powers of Am as scratch memory
+        # U = Am[0] @ (b[9]*Am[4] + b[7]*Am[3] + b[5]*Am[2] + b[3]*Am[1] + b[1]*I_n)
+        {{ pfx }}copy(&n2, &Am[1, 0, 0], &int_one, &work[0], &int_one)
+        {{ pfx }}scal(&n2, &b[3], &work[0], &int_one)
+        {{ pfx }}axpy(&n2, &b[5], &Am[2, 0, 0], &int_one, &work[0], &int_one)
+        {{ pfx }}axpy(&n2, &b[7], &Am[3, 0, 0], &int_one, &work[0], &int_one)
+        {{ pfx }}axpy(&n2, &one, &Am[4, 0, 0], &int_one, &work[0], &int_one)
+        for i in range(n):
+            work[i*(n+1)] += b[1]
+        # V = b[8]*Am[4] + b[6]*Am[3] + b[4]*Am[2] + b[2]*Am[1] + b[0]*I_n
+        {{ pfx }}scal(&n2, &b[2], &Am[1, 0, 0], &int_one)
+        {{ pfx }}axpy(&n2, &b[4], &Am[2, 0, 0], &int_one, &Am[1, 0, 0], &int_one)
+        {{ pfx }}axpy(&n2, &b[6], &Am[3, 0, 0], &int_one, &Am[1, 0, 0], &int_one)
+        {{ pfx }}axpy(&n2, &b[8], &Am[4, 0, 0], &int_one, &Am[1, 0, 0], &int_one)
+        for i in range(n):
+            Am[1, i, i] = Am[1, i, i] + b[0]
+        # Now we can scratch A[2] or A[3]
+        {{ pfx }}gemm(<char*>'N', <char*>'N', &n, &n, &n, &one, &Am[0, 0, 0], &n, &work[0], &n, &zero, &Am[3, 0, 0], &n)
+
+        # inv(V-U) (V+U) = inv(V-U) (V-U+2V) = I + 2 inv(V-U) U
+        {{ pfx }}axpy(&n2, &neg_one, &Am[3, 0, 0], &int_one, &Am[1, 0, 0], &int_one)
+
+        # Convert array layout for solving AX = B into Am[2]
+        swap_c_and_f_layout(&Am[3, 0, 0], &Am[2, 0, 0], n, n, n)
+
+        {{ pfx }}getrf( &n, &n, &Am[1, 0, 0], &n, &ipiv[0], &info )
+        {{ pfx }}getrs(<char*>'C', &n, &n, &Am[1, 0, 0], &n, &ipiv[0], &Am[2, 0, 0], &n, &info)
+        {{ sc }}scal(&n2, &two, &Am[2, 0, 0], &int_one)
+        for i in range(n):
+            Am[2, i, i] = Am[2, i, i] + 1.
+
+        # Put it back in Am in C order
+        swap_c_and_f_layout(&Am[2, 0, 0], &Am[0, 0, 0], n, n, n)
+    finally:
+        free(work)
+        free(ipiv)
+
+
+{{endfor}}
+{{for tname, pfx, sc in zip(typenames, prefixes,  ['s', 'd', 'cs', 'zd'])}}
+@cython.wraparound(False)
+@cython.boundscheck(False)
+@cython.initializedcheck(False)
+cdef void pade_13_UV_calc_{{ pfx }}({{ tname }}[:, :, ::1]Am, int n) nogil:
+    cdef {{ tname }} *work2 = <{{ tname }}*>malloc(n*n*sizeof({{ tname }}))
+    cdef {{ tname }} *work3 = <{{ tname }}*>malloc(n*n*sizeof({{ tname }}))
+    cdef {{ tname }} *work4 = <{{ tname }}*>malloc(n*n*sizeof({{ tname }}))
+    cdef int *ipiv = <int*>malloc(n*sizeof(int))
+    cdef Py_ssize_t i, j, k
+    cdef int info, int1 = 1, n2 = n*n
+    cdef {{ tname }} one = 1.0, zero = 0.0, neg_one = -1.
+    cdef {{if pfx in ['s', 'c']}}float{{else}}double{{endif}} two = 2.0
+    cdef {{ tname }} b[14]
+    b[0] = 64764752532480000.
+    b[1] = 32382376266240000.
+    b[2] = 7771770303897600.
+    b[3] = 1187353796428800.
+    b[4] = 129060195264000.
+    b[5] = 10559470521600.
+    b[6] = 670442572800.
+    b[7] = 33522128640.
+    b[8] = 1323241920.
+    b[9] = 40840800.
+    b[10] = 960960.
+    b[11] = 16380.
+    b[12] = 182.
+    b[13] = 1.
+
+    if not (work2 and work3 and work4 and ipiv):
+        raise MemoryError('Internal function "pade_13_UV_calc" failed to allocate memory.')
+    try:
+        # U = Am[0] @ (Am[3] @ (b[13]*Am[3] + b[11]*Am[2] + b[9]*Am[1]) +
+        #              b[7]*Am[3] + b[5]*Am[2] + b[3]*Am[1] + b[1]*I_n)
+        # V = Am[3] @ (b[12]*Am[3] + b[10]*Am[2] + b[8]*Am[1]) +
+        #              b[6]*Am[3] + b[4]*Am[2] + b[2]*Am[1] + b[0]*I_n
+
+        {{ pfx }}copy(&n2, &Am[1, 0, 0], &int1, &work2[0], &int1)
+        {{ pfx }}scal(&n2, &b[9], &work2[0], &int1)
+        {{ pfx }}axpy(&n2, &b[11], &Am[2, 0, 0], &int1, &work2[0], &int1)
+        {{ pfx }}axpy(&n2, &b[13], &Am[3, 0, 0], &int1, &work2[0], &int1)
+
+        {{ pfx }}copy(&n2, &Am[1, 0, 0], &int1, &work3[0], &int1)
+        {{ pfx }}scal(&n2, &b[2], &work3[0], &int1)
+        {{ pfx }}axpy(&n2, &b[4], &Am[2, 0, 0], &int1, &work3[0], &int1)
+        {{ pfx }}axpy(&n2, &b[6], &Am[3, 0, 0], &int1, &work3[0], &int1)
+
+        {{ pfx }}copy(&n2, &Am[1, 0, 0], &int1, &work4[0], &int1)
+        {{ pfx }}scal(&n2, &b[8], &work4[0], &int1)
+        {{ pfx }}axpy(&n2, &b[10], &Am[2, 0, 0], &int1, &work4[0], &int1)
+        {{ pfx }}axpy(&n2, &b[12], &Am[3, 0, 0], &int1, &work4[0], &int1)
+
+        # Overwrite Am[1] as it is not used further
+        {{ pfx }}scal(&n2, &b[3], &Am[1, 0, 0], &int1)
+        {{ pfx }}axpy(&n2, &b[5], &Am[2, 0, 0], &int1, &Am[1, 0, 0], &int1)
+        {{ pfx }}axpy(&n2, &b[7], &Am[3, 0, 0], &int1, &Am[1, 0, 0], &int1)
+
+        for i in range(n):
+            Am[1, i, i] = Am[1, i, i] + b[1]
+            work3[i*(n+1)] += b[0]
+
+        # U = D @ (A @ B + C)
+        {{ pfx }}gemm(<char*>'N', <char*>'N', &n, &n, &n, &one, &work2[0], &n, &Am[3, 0, 0], &n, &one, &Am[1, 0, 0], &n)
+        {{ pfx }}gemm(<char*>'N', <char*>'N', &n, &n, &n, &one, &Am[1, 0, 0], &n, &Am[0, 0, 0], &n, &zero, &work2[0], &n)
+        # V = A @ B + C
+        {{ pfx }}gemm(<char*>'N', <char*>'N', &n, &n, &n, &one, &work4[0], &n, &Am[3, 0, 0], &n, &one, &work3[0], &n)
+        # inv(V-U) (V+U) = inv(V-U) (V-U+2V) = I + 2 inv(V-U) U
+        {{ pfx }}axpy(&n2, &neg_one, &work2[0], &int1, &work3[0], &int1)
+
+        # Convert array layout for solving AX = B into work4
+        swap_c_and_f_layout(work2, work4, n, n, n)
+        free(work2)
+
+        {{ pfx }}getrf( &n, &n, &work3[0], &n, &ipiv[0], &info )
+        {{ pfx }}getrs(<char*>'C', &n, &n, &work3[0], &n, &ipiv[0], &work4[0], &n, &info )
+        {{ sc }}scal(&n2, &two, &work4[0], &int1)
+        for i in range(n):
+            work4[i*(n+1)] += 1.
+        # Put it back in Am in C order
+        swap_c_and_f_layout(work4, &Am[0, 0, 0], n, n, n)
+    finally:
+        free(ipiv)
+        free(work3)
+        free(work4)
+
+
+{{endfor}}
+# ============================================================================
+
+# ====================== norm1est ============================================
+def _norm1est(A, m=1, t=2, max_iter=5):
+    """Compute a lower bound for the 1-norm of 2D matrix A or its powers
+
+    Parameters
+    ----------
+    A : ndarray
+        Input square array of shape (N, N).
+    m : int, optional
+        If it is different than one, then m-th power of the matrix norm is
+        computed.
+    t : int, optional
+        The number of columns of the internal matrix used in the iterations.
+    max_iter : int, optional
+        The number of total iterations to be performed. Problems that require
+        more than 5 iterations are rarely reported in practice.
+
+    Returns
+    -------
+    c : float
+        The resulting 1-norm condition number estimate of A.
+
+    Notes
+    -----
+    Implements a SciPy adaptation of Algorithm 2.4 of [1], and the original
+    Fortran code given in [2].
+
+    The algorithm involves randomized elements and hence if needed, the seed
+    of the Python built-in random module can be set for reproducible results.
+
+    References
+    ----------
+    .. [1] Nicholas J. Higham and Françoise Tisseur (2000),
+           "A Block Algorithm for Matrix 1-Norm Estimation,
+           with an Application to 1-Norm Pseudospectra."
+           SIAM J. Matrix Anal. Appl. Vol. 21, No. 4, pp. 1185-1201.
+
+    .. [2] Sheung Hun Cheng, Nicholas J. Higham (2001), "Implementation for
+           LAPACK of a Block Algorithm for Matrix 1-Norm Estimation",
+           NA Report 393
+
+    """
+    # Ref [1] skips parallel col test for complex inputs
+    real_A = np.isrealobj(A)
+    n = A.shape[0]
+    est_old = 0
+    ind_hist = []
+    S = np.zeros([n, 2*t], dtype=np.int8 if real_A else A.dtype)
+    Y = np.empty([n, t], dtype=A.dtype)
+    Y[:, 0] = A.sum(axis=1) / n
+
+    # Higham and Tisseur assigns random 1, -1 for initialization but they also
+    # mention that it is arbitrary. Hence instead we use e_j to already start
+    # the while loop. Also we don't use a temporary X but keep indices instead
+    if t > 1:
+        cols = random.sample(population=range(n), k=t-1)
+        Y[:, 1:t] = A[:, cols]
+        ind_hist += cols
+
+    for k in range(max_iter):
+        if m >= 1:
+            for _ in range(m-1):
+                Y = A @ Y
+
+        Y_sums = (np.abs(Y)).sum(axis=0)
+        best_j = np.argmax(Y_sums)
+        est = Y_sums[best_j]
+        if est <= est_old:  # (1)
+            est = est_old
+            break
+        # else:
+            # w = Y[:, best_j]
+        est_old = est
+        S[:, :t] = S[:, t:]
+        _custom_signum(Y, S[:, t:], not real_A)
+        if t > 1 and real_A:
+            # (2)
+            if ((S[:, t:].T @ S[:, :t]).max(axis=1) == n).all() and k > 0:
+                break
+            else:
+                # replaces S in-place
+                _replace_parallel_cols(S)
+
+        # (3)
+        Z = A.conj().T @ S
+        if m >= 1:
+            for _ in range(m-1):
+                Z = A.conj().T @ Z
+
+        Z_sums = (np.abs(Z)).sum(axis=1)
+        if np.argmax(Z_sums) == best_j:  # (4)
+            break
+        h_sorter = np.argsort(Z_sums)
+        if all([x in ind_hist for x in h_sorter[:t]]):  # (5)
+            break
+        else:
+            pick = random.choice(range(n))
+            for _ in range(t):
+                while pick in ind_hist:
+                    pick = random.choice(range(n))
+                ind_hist += [pick]
+
+            Y = A[:, ind_hist[-t:]]
+
+    # v = np.zeros_like(X[:, 0])  # just some equal size array
+    # v[best_j] = 1
+
+    return est  # , v, w
+
+
+def _replace_parallel_cols(S):
+    """Helper function for 1-norm condition number estimator.
+
+    This function is akin to ?LARPC function given in Cheng, Higham (see Ref
+    section of expm, [2]).
+
+    Parameters
+    ----------
+    S : ndarray
+        Working array of the current iteration
+    S_old : ndarray
+        Working array of the previous iteration. Pass None if only S exists.
+    rng : Generator
+        The random generator used inside the body of condition estimator
+
+    Returns
+    -------
+    None
+
+    """
+    n, t = S.shape
+    max_spin = math.ceil(n / t)
+
+    for col in range(t):
+        curr_col = t + col
+        n_it = 0
+        while round(np.abs(S[:, col] @ S[:, :curr_col]).max()) == n:
+            S[:, col] = random.choices([1, -1], k=n)
+            n_it += 1
+            if n_it > max_spin:
+                break
+
+    return
+
+
+def _custom_signum(M, sgnM, is_complex=False):
+    """Helper function for 1-norm condition number estimator.
+
+    This function is defined to comply with ref. [1] of condest. For reals,
+    nonnegative inputs are mapped to 1 and to -1 otherwise. For complex inputs
+    sgn(x) = x / ||x|| and sgn(0 + 0j) := 1.
+
+    Parameters
+    ----------
+    M : ndarray
+        Input array
+
+    sgnM : ndarray
+        Output array that will be overwritten
+
+    Returns
+    -------
+    sgnM : ndarray
+        The resulting sign(M) array.
+
+    """
+    if is_complex:
+        sgnM.fill(1.)
+        mask = M != 0.
+        sgnM[mask] = M[mask] / np.abs(M[mask])
+    else:
+        np.signbit(M, out=sgnM)
+
+
+@cython.initializedcheck(False)
+def pade_UV_calc(lapack_t[:, :, ::1]Am, int n, int m):
+    """Helper functions for expm to solve the final polynomial evaluation"""
+    if lapack_t is float:
+        if m in [3, 5, 7]:
+            pade_357_UV_calc_s(Am, n, m)
+        elif m == 9:
+            pade_9_UV_calc_s(Am, n)
+        else: 
+            pade_13_UV_calc_s(Am, n)
+    elif lapack_t is double:
+        if m in [3, 5, 7]:
+            pade_357_UV_calc_d(Am, n, m)
+        elif m == 9:
+            pade_9_UV_calc_d(Am, n)
+        else: 
+            pade_13_UV_calc_d(Am, n)
+    elif lapack_t is floatcomplex:
+        if m in [3, 5, 7]:
+            pade_357_UV_calc_c(Am, n, m)
+        elif m == 9:
+            pade_9_UV_calc_c(Am, n)
+        else: 
+            pade_13_UV_calc_c(Am, n)
+    elif lapack_t is doublecomplex:
+        if m in [3, 5, 7]:
+            pade_357_UV_calc_z(Am, n, m)
+        elif m == 9:
+            pade_9_UV_calc_z(Am, n)
+        else: 
+            pade_13_UV_calc_z(Am, n)
+    else:
+        raise ValueError('Internal function "pade_UV_calc" received an unsupported dtype')
+
+
+@cython.initializedcheck(False)
+def pick_pade_structure(lapack_t[:, ::1]A):
+    """Helper functions for expm to choose Pade approximation order"""
+    if lapack_t is float:
+        return pick_pade_structure_s(A)
+    elif lapack_t is double:
+        return pick_pade_structure_d(A)
+    elif lapack_t is floatcomplex:
+        return pick_pade_structure_c(A)
+    elif lapack_t is doublecomplex:
+        return pick_pade_structure_z(A)
+    else:
+        raise ValueError('Internal function "pick_pade_structure" received an unsupported dtype.')

--- a/scipy/linalg/_matfuncs_expm.pyx.in
+++ b/scipy/linalg/_matfuncs_expm.pyx.in
@@ -1,9 +1,9 @@
 # cython: language_level=3
 cimport cython
+import math
+import random
 cimport numpy as cnp
 import numpy as np
-import random
-import math
 from libc.stdlib cimport malloc, free
 from libc.math cimport fabs, ceil, log2, pow
 from scipy.linalg.cython_lapack cimport (sgetrf, sgetrs, dgetrf, dgetrs,
@@ -200,7 +200,7 @@ cdef pick_pade_structure_{{ pfx }}({{ tname }}[:, :, ::1] Am):
             {{ pfx }}gemm(cN, cN, &intn, &intn, &intn, &one, &Amv[2, 0, 0], &intn, &Amv[2, 0, 0], &intn, &zero, &Amv[4, 0, 0], &intn)
             d8 = norm1(Amv[4, :, :]) ** (1./8.)
         else:
-            d8  = _norm1est(Am[0], m=8) ** (1./8.)
+            d8  = _norm1est(np.asarray(Am[0]), m=8) ** (1./8.)
 
         eta2 = max(d6, d8)
         temp = kth_power_norm_d(absA, work, work2, n, 4)
@@ -220,7 +220,7 @@ cdef pick_pade_structure_{{ pfx }}({{ tname }}[:, :, ::1] Am):
             {{ pfx }}gemm(cN, cN, &intn, &intn, &intn, &one, &Amv[3, 0, 0], &intn, &Amv[2, 0, 0], &intn, &zero, &Amv[4, 0, 0], &intn)
             d10 = norm1(Amv[4, :, :]) ** (1./10.)
         else:
-            d10  = _norm1est(Am[0], m=10) ** (1./10.)
+            d10  = _norm1est(np.asarray(Am[0]), m=10) ** (1./10.)
 
         eta3 = max(d8, d10)
         eta4 = min(eta2, eta3)
@@ -500,8 +500,23 @@ cdef void pade_13_UV_calc_{{ pfx }}({{ tname }}[:, :, ::1]Am, int n) nogil:
 # ============================================================================
 
 # ====================== norm1est ============================================
+
 def _norm1est(A, m=1, t=2, max_iter=5):
-    """Compute a lower bound for the 1-norm of 2D matrix A or its powers
+    """Compute a lower bound for the 1-norm of 2D matrix A or its powers.
+
+    Computing the 1-norm of 8th or 10th power of a very large array is a very
+    wasteful computation if we explicitly compute the actual power. The
+    estimation exploits (in a nutshell) the following:
+
+        (A @ A @ ... A) @ <thin array> = (A @ (A @ (... @ (A @ <thin array>)))
+
+    And in fact all the rest is practically Ward's power method with ``t``
+    starting vectors, hence, thin array and smarter selection of those vectors.
+
+    Thus at some point ``expm`` which uses this function to scale-square, will
+    switch to estimating when ``np.abs(A).sum(axis=0).max()`` becomes slower
+    than the estimate (``linalg.norm`` is even slower). Currently the switch
+    is chosen to be ``n=400``.
 
     Parameters
     ----------
@@ -527,21 +542,21 @@ def _norm1est(A, m=1, t=2, max_iter=5):
     Fortran code given in [2].
 
     The algorithm involves randomized elements and hence if needed, the seed
-    of the Python built-in random module can be set for reproducible results.
+    of the Python built-in "random" module can be set for reproducible results.
 
     References
     ----------
-    .. [1] Nicholas J. Higham and Françoise Tisseur (2000),
-           "A Block Algorithm for Matrix 1-Norm Estimation,
-           with an Application to 1-Norm Pseudospectra."
-           SIAM J. Matrix Anal. Appl. Vol. 21, No. 4, pp. 1185-1201.
+    .. [1] Nicholas J. Higham and Francoise Tisseur (2000), "A Block Algorithm
+           for Matrix 1-Norm Estimation, with an Application to 1-Norm
+           Pseudospectra." SIAM J. Matrix Anal. Appl. 21(4):1185-1201,
+           :doi:`10.1137/S0895479899356080`
 
     .. [2] Sheung Hun Cheng, Nicholas J. Higham (2001), "Implementation for
            LAPACK of a Block Algorithm for Matrix 1-Norm Estimation",
            NA Report 393
 
     """
-    # Ref [1] skips parallel col test for complex inputs
+    # We skip parallel col test for complex inputs
     real_A = np.isrealobj(A)
     n = A.shape[0]
     est_old = 0
@@ -573,14 +588,27 @@ def _norm1est(A, m=1, t=2, max_iter=5):
             # w = Y[:, best_j]
         est_old = est
         S[:, :t] = S[:, t:]
-        _custom_signum(Y, S[:, t:], not real_A)
+        if real_A:
+            S[:, t:] = np.signbit(Y)
+        else:
+            S[:, t:].fill(1)
+            mask = Y != 0.
+            S[:, t:][mask] = Y[mask] / np.abs(Y[mask])
+
         if t > 1 and real_A:
             # (2)
             if ((S[:, t:].T @ S[:, :t]).max(axis=1) == n).all() and k > 0:
                 break
             else:
-                # replaces S in-place
-                _replace_parallel_cols(S)
+                max_spin = math.ceil(n / t)
+                for col in range(t):
+                    curr_col = t + col
+                    n_it = 0
+                    while round(np.abs(S[:, col] @ S[:, :curr_col]).max()) == n:
+                        S[:, col] = random.choices([1, -1], k=n)
+                        n_it += 1
+                        if n_it > max_spin:
+                            break
 
         # (3)
         Z = A.conj().T @ S
@@ -607,70 +635,6 @@ def _norm1est(A, m=1, t=2, max_iter=5):
     # v[best_j] = 1
 
     return est  # , v, w
-
-
-def _replace_parallel_cols(S):
-    """Helper function for 1-norm condition number estimator.
-
-    This function is akin to ?LARPC function given in Cheng, Higham (see Ref
-    section of expm, [2]).
-
-    Parameters
-    ----------
-    S : ndarray
-        Working array of the current iteration
-    S_old : ndarray
-        Working array of the previous iteration. Pass None if only S exists.
-    rng : Generator
-        The random generator used inside the body of condition estimator
-
-    Returns
-    -------
-    None
-
-    """
-    n, t = S.shape
-    max_spin = math.ceil(n / t)
-
-    for col in range(t):
-        curr_col = t + col
-        n_it = 0
-        while round(np.abs(S[:, col] @ S[:, :curr_col]).max()) == n:
-            S[:, col] = random.choices([1, -1], k=n)
-            n_it += 1
-            if n_it > max_spin:
-                break
-
-    return
-
-
-def _custom_signum(M, sgnM, is_complex=False):
-    """Helper function for 1-norm condition number estimator.
-
-    This function is defined to comply with ref. [1] of condest. For reals,
-    nonnegative inputs are mapped to 1 and to -1 otherwise. For complex inputs
-    sgn(x) = x / ||x|| and sgn(0 + 0j) := 1.
-
-    Parameters
-    ----------
-    M : ndarray
-        Input array
-
-    sgnM : ndarray
-        Output array that will be overwritten
-
-    Returns
-    -------
-    sgnM : ndarray
-        The resulting sign(M) array.
-
-    """
-    if is_complex:
-        sgnM.fill(1.)
-        mask = M != 0.
-        sgnM[mask] = M[mask] / np.abs(M[mask])
-    else:
-        np.signbit(M, out=sgnM)
 
 
 @cython.initializedcheck(False)

--- a/scipy/linalg/_matfuncs_expm.pyx.in
+++ b/scipy/linalg/_matfuncs_expm.pyx.in
@@ -249,6 +249,10 @@ cdef pick_pade_structure_{{ pfx }}({{ tname }}[:, :, ::1] Am):
 # Note: MSVC does not accept "Memview[i, j, k] += 1.+0.j" as a valid operation
 # and results with error "C2088: '+=': illegal for struct".
 # OCD is unbearable but we do explicit addition for that reason.
+
+# Note: gemm calls for A @ B is done via dgemm(.., B, .., A, ..) because arrays
+# are in C-contiguous memory layout. This also the reason why getrs has 'T' as
+# the argument for TRANSA.
 {{for tname, pfx, prec, sc in zip(typenames, prefixes, precision, ['s', 'd', 'cs', 'zd'])}}
 @cython.wraparound(False)
 @cython.boundscheck(False)
@@ -288,7 +292,7 @@ cdef void pade_357_UV_calc_{{ pfx }}({{ tname }}[:, :, ::]Am, int n, int m) nogi
         if m == 3:
             # U = Am[0] @ Am[1] + 60.*Am[0]
             {{ pfx }}copy(&n2, &Am[0, 0, 0], &int_one, &Am[3, 0, 0], &int_one)
-            {{ pfx }}gemm(<char*>'N', <char*>'N', &n, &n, &n, &one, &Am[0, 0, 0], &n, &Am[1, 0, 0], &n, &b[1], &Am[3, 0, 0], &n)
+            {{ pfx }}gemm(<char*>'N', <char*>'N', &n, &n, &n, &one, &Am[1, 0, 0], &n, &Am[0, 0, 0], &n, &b[1], &Am[3, 0, 0], &n)
             # V = 12.*Am[1] + 120*I_n
             {{ pfx }}scal(&n2, &b[2], &Am[1, 0, 0], &int_one)
             for i in range(n):
@@ -301,7 +305,7 @@ cdef void pade_357_UV_calc_{{ pfx }}({{ tname }}[:, :, ::]Am, int n, int m) nogi
             {{ pfx }}axpy(&n2, &b[5], &Am[2, 0, 0], &int_one, &Am[4, 0, 0], &int_one)
             for i in range(n):
                 Am[4, i, i] = Am[4, i, i] + b[1]
-            {{ pfx }}gemm(<char*>'N', <char*>'N', &n, &n, &n, &one, &Am[0, 0, 0], &n, &Am[4, 0, 0], &n, &zero, &Am[3, 0, 0], &n)
+            {{ pfx }}gemm(<char*>'N', <char*>'N', &n, &n, &n, &one, &Am[4, 0, 0], &n, &Am[0, 0, 0], &n, &zero, &Am[3, 0, 0], &n)
             # V = b[4]*Am[2] + b[2]*Am[1] + b[0]*I_n
             {{ pfx }}scal(&n2, &b[2], &Am[1, 0, 0], &int_one)
             {{ pfx }}axpy(&n2, &b[4], &Am[2, 0, 0], &int_one, &Am[1, 0, 0], &int_one)
@@ -324,7 +328,7 @@ cdef void pade_357_UV_calc_{{ pfx }}({{ tname }}[:, :, ::]Am, int n, int m) nogi
             for i in range(n):
                 Am[1, i, i] = Am[1, i, i] + b[0]
             # Now we can scratch A[2] or A[3]
-            {{ pfx }}gemm(<char*>'N', <char*>'N', &n, &n, &n, &one, &Am[0, 0, 0], &n, &Am[4, 0, 0], &n, &zero, &Am[3, 0, 0], &n)
+            {{ pfx }}gemm(<char*>'N', <char*>'N', &n, &n, &n, &one, &Am[4, 0, 0], &n, &Am[0, 0, 0], &n, &zero, &Am[3, 0, 0], &n)
 
         # inv(V-U) (V+U) = inv(V-U) (V-U+2V) = I + 2 inv(V-U) U
         {{ pfx }}axpy(&n2, &neg_one, &Am[3, 0, 0], &int_one, &Am[1, 0, 0], &int_one)
@@ -388,7 +392,7 @@ cdef void pade_9_UV_calc_{{ pfx }}({{ tname }}[:, :, ::]Am, int n) nogil:
         for i in range(n):
             Am[1, i, i] = Am[1, i, i] + b[0]
         # Now we can scratch A[2] or A[3]
-        {{ pfx }}gemm(<char*>'N', <char*>'N', &n, &n, &n, &one, &Am[0, 0, 0], &n, &work[0], &n, &zero, &Am[3, 0, 0], &n)
+        {{ pfx }}gemm(<char*>'N', <char*>'N', &n, &n, &n, &one, &work[0], &n, &Am[0, 0, 0], &n, &zero, &Am[3, 0, 0], &n)
 
         # inv(V-U) (V+U) = inv(V-U) (V-U+2V) = I + 2 inv(V-U) U
         {{ pfx }}axpy(&n2, &neg_one, &Am[3, 0, 0], &int_one, &Am[1, 0, 0], &int_one)

--- a/scipy/linalg/_matfuncs_expm.pyx.in
+++ b/scipy/linalg/_matfuncs_expm.pyx.in
@@ -133,10 +133,9 @@ cdef double kth_power_norm_d(double* A, double* v1, double* v2, Py_ssize_t n, in
 @cython.wraparound(False)
 @cython.boundscheck(False)
 @cython.initializedcheck(False)
-cdef pick_pade_structure_{{ pfx }}({{ tname }}[:, ::1] A):
-    cdef Py_ssize_t n = A.shape[0], i, j, k
+cdef pick_pade_structure_{{ pfx }}({{ tname }}[:, :, ::1] Am):
+    cdef Py_ssize_t n = Am.shape[1], i, j, k
     cdef int lm = 0, s = 0, intn = <int>n, n2= intn*intn, int_one = 1
-    cdef cnp.ndarray[cnp.{{ dt }}_t, ndim=3] Am = np.empty((5, n, n), dtype='{{ dchar }}')
     cdef {{ tname }}[:, :, ::1] Amv = Am
     cdef:
         {{ tname }} one = 1.0, zero = 0.0
@@ -169,10 +168,10 @@ cdef pick_pade_structure_{{ pfx }}({{ tname }}[:, ::1] A):
         for j in range(n):
             work[j] = 1.
 
-        {{ pfx }}copy(&n2, &A[0, 0], &int_one, &Amv[0, 0, 0], &int_one)
+        # {{ pfx }}copy(&n2, &A[0, 0], &int_one, &Amv[0, 0, 0], &int_one)
         for i in range(n):
             for j in range(n):
-                absA[i*n + j] = abs(A[i, j])
+                absA[i*n + j] = abs(Am[0, i, j])
 
         # First spin = normest(|A|, 1), increase m when spun more
         normA = kth_power_norm_d(absA, work, work2, n, 1)
@@ -188,13 +187,13 @@ cdef pick_pade_structure_{{ pfx }}({{ tname }}[:, ::1] A):
         temp = kth_power_norm_d(absA, work, work2, n, 6)
         lm = max(<int>ceil(log2(temp/normA/coeff[0])/6), 0)
         if eta0 < theta[0] and lm == 0:
-            return Am, 3, s
+            return 3, s
 
         # m = 5
         temp = kth_power_norm_d(absA, work, work2, n, 4)
         lm = max(<int>ceil(log2(temp/normA/coeff[1])/10), 0)
         if eta1 < theta[1] and lm == 0:
-            return Am, 5, s
+            return 5, s
 
         # m = 7
         if n < 360:
@@ -207,13 +206,13 @@ cdef pick_pade_structure_{{ pfx }}({{ tname }}[:, ::1] A):
         temp = kth_power_norm_d(absA, work, work2, n, 4)
         lm = max(<int>ceil(log2(temp/normA/coeff[2])/14), 0)
         if eta2 < theta[2] and lm == 0:
-            return Am, 7, s
+            return 7, s
 
         # m = 9
         temp = kth_power_norm_d(absA, work, work2, n, 4)
         lm = max(<int>ceil(log2(temp/normA/coeff[3])/18), 0)
         if eta2 < theta[3] and lm == 0:
-            return Am, 9, s
+            return 9, s
 
         # m = 13
         # Scale-square
@@ -236,7 +235,7 @@ cdef pick_pade_structure_{{ pfx }}({{ tname }}[:, ::1] A):
             normA *= 2.**(-s)
         temp = kth_power_norm_d(absA, work, work2, n, 8)
         s += max(<int>ceil(log2(temp/normA/coeff[4])/26), 0)
-        return Am, 13, s
+        return 13, s
     finally:
         free(work)
         free(work2)
@@ -710,7 +709,7 @@ def pade_UV_calc(lapack_t[:, :, ::1]Am, int n, int m):
 
 
 @cython.initializedcheck(False)
-def pick_pade_structure(lapack_t[:, ::1]A):
+def pick_pade_structure(lapack_t[:, :, ::1]A):
     """Helper functions for expm to choose Pade approximation order"""
     if lapack_t is float:
         return pick_pade_structure_s(A)

--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -244,6 +244,22 @@ py3.extension_module('_decomp_update',
   subdir: 'scipy/linalg'
 )
 
+# _matfuncs_expm:
+_matfuncs_expm_pyx = custom_target('_matfuncs_expm',
+  output: '_matfuncs_expm.pyx',
+  input: '_matfuncs_expm.pyx.in',
+  command: [py3, tempita, '@INPUT@', '-o', '@OUTDIR@']
+)
+
+py3.extension_module('_matfuncs_expm',
+  linalg_init_cython_gen.process(_matfuncs_expm_pyx),
+  c_args: cython_c_args,
+  include_directories: inc_np,
+  dependencies: py3_dep,
+  install: true,
+  subdir: 'scipy/linalg'
+)
+
 _cythonized_array_utils = py3.extension_module('_cythonized_array_utils',
   linalg_init_cython_gen.process('_cythonized_array_utils.pyx'),
   c_args: [cython_c_args, c_undefined_ok],

--- a/scipy/linalg/setup.py
+++ b/scipy/linalg/setup.py
@@ -152,6 +152,9 @@ def configuration(parent_package='', top_path=None):
     config.add_extension('_cythonized_array_utils',
                          sources=['_cythonized_array_utils.c'])
 
+    config.add_extension('_matfuncs_expm',
+                         sources=['_matfuncs_expm.c'])
+
     # Add any license files
     config.add_data_files('src/id_dist/doc/doc.tex')
     config.add_data_files('src/lapack_deprecations/LICENSE')

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -9,10 +9,8 @@ import functools
 
 import numpy as np
 from numpy import array, identity, dot, sqrt
-from numpy.testing import (
-        assert_array_equal, assert_array_less, assert_equal,
-        assert_array_almost_equal,
-        assert_allclose, assert_, assert_warns)
+from numpy.testing import (assert_array_almost_equal, assert_allclose, assert_,
+                           assert_array_less, assert_array_equal, assert_warns)
 import pytest
 
 import scipy.linalg
@@ -108,7 +106,7 @@ class TestLogM:
         A = _get_al_mohy_higham_2012_experiment_1()
         A_logm, info = logm(A, disp=False)
         A_round_trip = expm(A_logm)
-        assert_allclose(A_round_trip, A, rtol=1e-5, atol=1e-14)
+        assert_allclose(A_round_trip, A, rtol=5e-5, atol=1e-14)
 
     def test_al_mohy_higham_2012_experiment_1_funm_log(self):
         # The raw funm with np.log does not complete the round trip.
@@ -604,25 +602,8 @@ class TestExpM:
         assert_array_almost_equal(expm(a),[[1,0],[0,1]])
 
     def test_single_elt(self):
-        # See gh-5853
-        from scipy.sparse import csc_matrix
-
-        vOne = -2.02683397006j
-        vTwo = -2.12817566856j
-
-        mOne = csc_matrix([[vOne]], dtype='complex')
-        mTwo = csc_matrix([[vTwo]], dtype='complex')
-
-        outOne = expm(mOne)
-        outTwo = expm(mTwo)
-
-        assert_equal(type(outOne), type(mOne))
-        assert_equal(type(outTwo), type(mTwo))
-
-        assert_allclose(outOne[0, 0], complex(-0.44039415155949196,
-                                              -0.8978045395698304))
-        assert_allclose(outTwo[0, 0], complex(-0.52896401032626006,
-                                              -0.84864425749518878))
+        elt = expm(1)
+        assert_allclose(elt, np.array([[np.e]]))
 
     def test_empty_matrix_input(self):
         # handle gh-11082
@@ -713,8 +694,8 @@ class TestExpmFrechet:
             expected_expm = scipy.linalg.expm(A)
             expected_frechet = scipy.linalg.expm(M)[:n, n:]
             observed_expm, observed_frechet = expm_frechet(A, E)
-            assert_allclose(expected_expm, observed_expm)
-            assert_allclose(expected_frechet, observed_frechet)
+            assert_allclose(expected_expm, observed_expm, atol=5e-8)
+            assert_allclose(expected_frechet, observed_frechet, atol=1e-7)
 
     def test_problematic_matrix(self):
         # this test case uncovered a bug which has since been fixed

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -611,6 +611,38 @@ class TestExpM:
         result = expm(A)
         assert result.size == 0
 
+    def test_2x2_input(self):
+        E = np.e
+        a = array([[1, 4], [1, 1]])
+        aa = (E**4 + 1)/(2*E)
+        bb = (E**4 - 1)/E
+        assert_allclose(expm(a), array([[aa, bb], [bb/4, aa]]))
+        assert expm(a.astype(np.complex64)).dtype.char == 'F'
+        assert expm(a.astype(np.float32)).dtype.char == 'f'
+
+    def test_nx2x2_input(self):
+        E = np.e
+        # These are integer matrices with integer eigenvalues
+        a = np.array([[[1, 4], [1, 1]],
+                      [[1, 3], [1, -1]],
+                      [[1, 3], [4, 5]],
+                      [[1, 3], [5, 3]],
+                      [[4, 5], [-3, -4]]], order='F')
+        # Exact results are computed symbolically
+        a_res = np.array([
+                          [[(E**4+1)/(2*E), (E**4-1)/E],
+                           [(E**4-1)/4/E, (E**4+1)/(2*E)]],
+                          [[1/(4*E**2)+(3*E**2)/4, (3*E**2)/4-3/(4*E**2)],
+                           [E**2/4-1/(4*E**2), 3/(4*E**2)+E**2/4]],
+                          [[3/(4*E)+E**7/4, -3/(8*E)+(3*E**7)/8],
+                           [-1/(2*E)+E**7/2, 1/(4*E)+(3*E**7)/4]],
+                          [[5/(8*E**2)+(3*E**6)/8, -3/(8*E**2)+(3*E**6)/8],
+                           [-5/(8*E**2)+(5*E**6)/8, 3/(8*E**2)+(5*E**6)/8]],
+                          [[-3/(2*E)+(5*E)/2, -5/(2*E)+(5*E)/2],
+                           [3/(2*E)-(3*E)/2, 5/(2*E)-(3*E)/2]]
+                         ])
+        assert_allclose(expm(a), a_res)
+
 
 class TestExpmFrechet:
 

--- a/scipy/sparse/linalg/tests/test_expm_multiply.py
+++ b/scipy/sparse/linalg/tests/test_expm_multiply.py
@@ -6,6 +6,7 @@ from numpy.testing import (assert_allclose, assert_, assert_equal,
                            suppress_warnings)
 from scipy.sparse import SparseEfficiencyWarning
 import scipy.linalg
+from scipy.sparse.linalg import expm as sp_expm
 from scipy.sparse.linalg._expm_multiply import (_theta, _compute_p_max,
         _onenormest_matrix_power, expm_multiply, _expm_multiply_simple,
         _expm_multiply_interval)
@@ -63,7 +64,7 @@ class TestExpmActionSimple:
             A = scipy.linalg.inv(np.random.randn(n, n))
             B = np.random.randn(n, k)
             observed = expm_multiply(A, B)
-            expected = np.dot(scipy.linalg.expm(A), B)
+            expected = np.dot(sp_expm(A), B)
             assert_allclose(observed, expected)
 
     def test_matrix_vector_multiply(self):
@@ -74,7 +75,7 @@ class TestExpmActionSimple:
             A = scipy.linalg.inv(np.random.randn(n, n))
             v = np.random.randn(n)
             observed = expm_multiply(A, v)
-            expected = np.dot(scipy.linalg.expm(A), v)
+            expected = np.dot(sp_expm(A), v)
             assert_allclose(observed, expected)
 
     def test_scaled_expm_multiply(self):
@@ -88,7 +89,7 @@ class TestExpmActionSimple:
                     A = scipy.linalg.inv(np.random.randn(n, n))
                     B = np.random.randn(n, k)
                     observed = _expm_multiply_simple(A, B, t=t)
-                    expected = np.dot(scipy.linalg.expm(t*A), B)
+                    expected = np.dot(sp_expm(t*A), B)
                     assert_allclose(observed, expected)
 
     def test_scaled_expm_multiply_single_timepoint(self):
@@ -99,7 +100,7 @@ class TestExpmActionSimple:
         A = np.random.randn(n, n)
         B = np.random.randn(n, k)
         observed = _expm_multiply_simple(A, B, t=t)
-        expected = scipy.linalg.expm(t*A).dot(B)
+        expected = sp_expm(t*A).dot(B)
         assert_allclose(observed, expected)
 
     def test_sparse_expm_multiply(self):
@@ -115,8 +116,9 @@ class TestExpmActionSimple:
                 sup.filter(SparseEfficiencyWarning,
                            "splu requires CSC matrix format")
                 sup.filter(SparseEfficiencyWarning,
-                           "spsolve is more efficient when sparse b is in the CSC matrix format")
-                expected = scipy.linalg.expm(A).dot(B)
+                           "spsolve is more efficient when sparse b is in the"
+                           " CSC matrix format")
+                expected = sp_expm(A).dot(B)
             assert_allclose(observed, expected)
 
     def test_complex(self):
@@ -155,8 +157,7 @@ class TestExpmActionInterval:
                     sup.filter(SparseEfficiencyWarning,
                                "spsolve is more efficient when sparse b is in the CSC matrix format")
                     for solution, t in zip(X, samples):
-                        assert_allclose(solution,
-                                scipy.linalg.expm(t*A).dot(target))
+                        assert_allclose(solution, sp_expm(t*A).dot(target))
 
     def test_expm_multiply_interval_vector(self):
         np.random.seed(1234)
@@ -172,7 +173,7 @@ class TestExpmActionInterval:
                 samples = np.linspace(start=start, stop=stop,
                         num=num, endpoint=endpoint)
                 for solution, t in zip(X, samples):
-                    assert_allclose(solution, scipy.linalg.expm(t*A).dot(v))
+                    assert_allclose(solution, sp_expm(t*A).dot(v))
 
     def test_expm_multiply_interval_matrix(self):
         np.random.seed(1234)
@@ -189,7 +190,7 @@ class TestExpmActionInterval:
                     samples = np.linspace(start=start, stop=stop,
                             num=num, endpoint=endpoint)
                     for solution, t in zip(X, samples):
-                        assert_allclose(solution, scipy.linalg.expm(t*A).dot(B))
+                        assert_allclose(solution, sp_expm(t*A).dot(B))
 
     def test_sparse_expm_multiply_interval_dtypes(self):
         # Test A & B int
@@ -197,13 +198,13 @@ class TestExpmActionInterval:
         B = np.ones(5, dtype=int)
         Aexpm = scipy.sparse.diags(np.exp(np.arange(5)),format='csr')
         assert_allclose(expm_multiply(A,B,0,1)[-1], Aexpm.dot(B))
-    
+
         # Test A complex, B int
         A = scipy.sparse.diags(-1j*np.arange(5),format='csr', dtype=complex)
         B = np.ones(5, dtype=int)
         Aexpm = scipy.sparse.diags(np.exp(-1j*np.arange(5)),format='csr')
         assert_allclose(expm_multiply(A,B,0,1)[-1], Aexpm.dot(B))
-    
+
         # Test A int, B complex
         A = scipy.sparse.diags(np.arange(5),format='csr', dtype=int)
         B = np.full(5, 1j, dtype=complex)
@@ -243,7 +244,7 @@ class TestExpmActionInterval:
                 samples = np.linspace(start=start, stop=stop,
                         num=num, endpoint=endpoint)
                 for solution, t in zip(X, samples):
-                    assert_allclose(solution, scipy.linalg.expm(t*A).dot(B))
+                    assert_allclose(solution, sp_expm(t*A).dot(B))
                 nsuccesses += 1
         if not nsuccesses:
             msg = 'failed to find a status-' + str(target_status) + ' interval'


### PR DESCRIPTION
Closes #354
Closes #4897
Closes #12838 


#### What does this implement/fix?
This is a complete overhaul of the function `scipy.linalg.expm`. Two important properties are the performance increase and being able to handle ndarrays with `n>=2`. Moreover, diagonal and triangular matrices are recognized and treated as such. The existing tests pass with very tiny adjustments. 

If you can provide some benchmark feedback for the new and the old version, that'd be great. It doesn't have to be scientific, "yes it is fast" "no I don't see any difference" is also fine. 

![image](https://user-images.githubusercontent.com/1303842/142934691-996d8248-66cc-43d2-8e74-f39dc0a1a99e.png)

Produced via: 

```python
import perfplot
import numpy as np
from scipy.sparse.linalg import expm as EX
from scipy.linalg import expm


perfplot.show(
    setup=lambda n: -np.random.rand(n, n),
    kernels=[EX, expm],
    labels=["SciPy", "this PR"],
    n_range=[3*x for x in range(1, 30)],
    logx="auto",
    logy=True,
    equality_check=None,
    xlabel="input size (n)",
}
```


#### Additional information
There are some tests missing for the new functionality. I will try to add them asap.

#### Things left out
I ran out of steam at some point since the logic became too much for me to hold it in my head, but hermitian matrices through a Schur factorization can also benefit from some performance increases. At some point I hope I will come back to this. 
