### PR TITLE
BUG: out of bounds indexing in stats.qmc.update_discrepancy

### DIFF
--- a/scipy/stats/_qmc_cy.pyx
+++ b/scipy/stats/_qmc_cy.pyx
@@ -252,15 +252,15 @@ cdef double c_update_discrepancy(double[::1] x_new_view,
                                  double initial_disc):
     cdef:
         Py_ssize_t n = sample_view.shape[0] + 1
-        Py_ssize_t xnew_nlines = x_new_view.shape[0]
+        Py_ssize_t d = sample_view.shape[1]
         Py_ssize_t i = 0, j = 0, k = 0
         double prod = 1, tmp_sum= 0
         double  disc1 = 0, disc2 = 0, disc3 = 0
-        double[::1] abs_ = np.zeros(n, dtype=np.float64)
+        double[::1] abs_ = np.empty(d, dtype=np.float64)
 
 
     # derivation from P.T. Roy (@tupui)
-    for i in range(xnew_nlines):
+    for i in range(d):
         abs_[i] = fabs(x_new_view[i] - 0.5)
         prod *= (
             1 + 0.5 * abs_[i]
@@ -271,7 +271,7 @@ cdef double c_update_discrepancy(double[::1] x_new_view,
 
     prod = 1
     for i in range(n - 1):
-        for j in range(xnew_nlines):
+        for j in range(d):
             prod *= (
                 1 + 0.5 * abs_[j]
                 + 0.5 * fabs(sample_view[i, j] - 0.5)
@@ -282,7 +282,7 @@ cdef double c_update_discrepancy(double[::1] x_new_view,
 
     disc2 *= 2 / pow(n, 2)
 
-    for i in range(xnew_nlines):
+    for i in range(d):
         prod *= 1 + abs_[i]
 
     disc3 = 1 / pow(n, 2) * prod

--- a/scipy/stats/tests/test_qmc.py
+++ b/scipy/stats/tests/test_qmc.py
@@ -180,14 +180,24 @@ class TestUtils:
             qmc.discrepancy(sample, workers=-2)
 
     def test_update_discrepancy(self):
+        # From Fang et al. Design and modeling for computer experiments, 2006
         space_1 = np.array([[1, 3], [2, 6], [3, 2], [4, 5], [5, 1], [6, 4]])
         space_1 = (2.0 * space_1 - 1.0) / (2.0 * 6.0)
 
         disc_init = qmc.discrepancy(space_1[:-1], iterative=True)
-        disc_iter = update_discrepancy(space_1[-1], space_1[:-1],
-                                       disc_init)
+        disc_iter = update_discrepancy(space_1[-1], space_1[:-1], disc_init)
 
         assert_allclose(disc_iter, 0.0081, atol=1e-4)
+
+        # n<d
+        rng = np.random.default_rng(241557431858162136881731220526394276199)
+        space_1 = rng.random((4, 10))
+
+        disc_ref = qmc.discrepancy(space_1)
+        disc_init = qmc.discrepancy(space_1[:-1], iterative=True)
+        disc_iter = update_discrepancy(space_1[-1], space_1[:-1], disc_init)
+
+        assert_allclose(disc_iter, disc_ref, atol=1e-4)
 
         # errors
         with pytest.raises(ValueError, match=r"Sample is not in unit "


### PR DESCRIPTION
Closes #15081

`abs_` was of size `n` although it should have been of size `d`. This causes an issue when `n<d`.

cc @99991