### PR TITLE
MAINT: 1.7.3 backports/doc updates

### DIFF
--- a/doc/release/1.7.3-notes.rst
+++ b/doc/release/1.7.3-notes.rst
@@ -5,8 +5,9 @@ SciPy 1.7.3 Release Notes
 .. contents::
 
 SciPy 1.7.3 is a bug-fix release that provides binary wheels
-for MacOS arm64 with Python 3.8, 3.9, and 3.10. Note that a small
-number of test failures have been skipped for these new wheels.
+for MacOS arm64 with Python 3.8, 3.9, and 3.10. The MacOS arm64 wheels
+are only available for MacOS version 12.0 and greater, as explained
+in Issue 14688, linked below.
 
 Authors
 =======
@@ -16,8 +17,9 @@ Authors
 * Tyler Reddy
 * Pamphile Roy
 * Olivier Grisel
+* Isuru Fernando
 
-A total of 5 people contributed to this release.
+A total of 6 people contributed to this release.
 People with a "+" by their names contributed a patch for the first time.
 This list of names is automatically generated, and may not be fully complete.
 

--- a/doc/release/1.7.3-notes.rst
+++ b/doc/release/1.7.3-notes.rst
@@ -1,0 +1,37 @@
+==========================
+SciPy 1.7.3 Release Notes
+==========================
+
+.. contents::
+
+SciPy 1.7.3 is a bug-fix release that provides binary wheels
+for MacOS arm64 with Python 3.8, 3.9, and 3.10. Note that a small
+number of test failures have been skipped for these new wheels.
+
+Authors
+=======
+
+* Anirudh Dagar
+* Ralf Gommers
+* Tyler Reddy
+* Pamphile Roy
+* Olivier Grisel
+
+A total of 5 people contributed to this release.
+People with a "+" by their names contributed a patch for the first time.
+This list of names is automatically generated, and may not be fully complete.
+
+Issues closed for 1.7.3
+-----------------------
+
+* `#13364 <https://github.com/scipy/scipy/issues/13364>`__: Segmentation fault on import of scipy.integrate on Apple M1 ARM...
+* `#14688 <https://github.com/scipy/scipy/issues/14688>`__: BUG: ARPACK's eigsh & OpenBLAS from Apple Silicon M1 (arm64)...
+* `#14991 <https://github.com/scipy/scipy/issues/14991>`__: four CI failures on pre-release job
+* `#15081 <https://github.com/scipy/scipy/issues/15081>`__: BUG: Segmentation fault caused by scipy.stats.qmc.qmc.update_discrepancy
+
+
+Pull requests for 1.7.3
+-----------------------
+
+* `#14990 <https://github.com/scipy/scipy/pull/14990>`__: BLD: update pyproject.toml for Python 3.10 changes
+* `#15086 <https://github.com/scipy/scipy/pull/15086>`__: BUG: out of bounds indexing in stats.qmc.update_discrepancy

--- a/doc/release/1.7.3-notes.rst
+++ b/doc/release/1.7.3-notes.rst
@@ -29,6 +29,7 @@ Issues closed for 1.7.3
 * `#13364 <https://github.com/scipy/scipy/issues/13364>`__: Segmentation fault on import of scipy.integrate on Apple M1 ARM...
 * `#14688 <https://github.com/scipy/scipy/issues/14688>`__: BUG: ARPACK's eigsh & OpenBLAS from Apple Silicon M1 (arm64)...
 * `#14991 <https://github.com/scipy/scipy/issues/14991>`__: four CI failures on pre-release job
+* `#15077 <https://github.com/scipy/scipy/issues/15077>`__: Remaining test failures for macOS arm64 wheel
 * `#15081 <https://github.com/scipy/scipy/issues/15081>`__: BUG: Segmentation fault caused by scipy.stats.qmc.qmc.update_discrepancy
 
 
@@ -37,3 +38,4 @@ Pull requests for 1.7.3
 
 * `#14990 <https://github.com/scipy/scipy/pull/14990>`__: BLD: update pyproject.toml for Python 3.10 changes
 * `#15086 <https://github.com/scipy/scipy/pull/15086>`__: BUG: out of bounds indexing in stats.qmc.update_discrepancy
+* `#15090 <https://github.com/scipy/scipy/pull/15090>`__: MAINT: skip a few failing tests in \`1.7.x\` for macOS arm64

--- a/doc/source/release.1.7.3.rst
+++ b/doc/source/release.1.7.3.rst
@@ -1,0 +1,1 @@
+.. include:: ../release/1.7.3-notes.rst

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -8,6 +8,7 @@ see the `commit logs <https://github.com/scipy/scipy/commits/>`_.
 .. toctree::
    :maxdepth: 1
 
+   release.1.7.3
    release.1.7.2
    release.1.7.1
    release.1.7.0

--- a/pavement.py
+++ b/pavement.py
@@ -69,10 +69,10 @@ except AttributeError:
 #-----------------------------------
 
 # Source of the release notes
-RELEASE = 'doc/release/1.7.2-notes.rst'
+RELEASE = 'doc/release/1.7.3-notes.rst'
 
 # Start/end of the log (from git)
-LOG_START = 'v1.7.1'
+LOG_START = 'v1.7.2'
 LOG_END = 'maintenance/1.7.x'
 
 

--- a/scipy/stats/_qmc_cy.pyx
+++ b/scipy/stats/_qmc_cy.pyx
@@ -246,15 +246,15 @@ cdef double c_update_discrepancy(double[::1] x_new_view,
                                  double initial_disc):
     cdef:
         Py_ssize_t n = sample_view.shape[0] + 1
-        Py_ssize_t xnew_nlines = x_new_view.shape[0]
+        Py_ssize_t d = sample_view.shape[1]
         Py_ssize_t i = 0, j = 0, k = 0
         double prod = 1, tmp_sum= 0
         double  disc1 = 0, disc2 = 0, disc3 = 0
-        double[::1] abs_ = np.zeros(n, dtype=np.float64)
+        double[::1] abs_ = np.empty(d, dtype=np.float64)
 
 
     # derivation from P.T. Roy (@tupui)
-    for i in range(xnew_nlines):
+    for i in range(d):
         abs_[i] = fabs(x_new_view[i] - 0.5)
         prod *= (
             1 + 0.5 * abs_[i]
@@ -265,7 +265,7 @@ cdef double c_update_discrepancy(double[::1] x_new_view,
 
     prod = 1
     for i in range(n - 1):
-        for j in range(xnew_nlines):
+        for j in range(d):
             prod *= (
                 1 + 0.5 * abs_[j]
                 + 0.5 * fabs(sample_view[i, j] - 0.5)
@@ -276,7 +276,7 @@ cdef double c_update_discrepancy(double[::1] x_new_view,
 
     disc2 *= 2 / pow(n, 2)
 
-    for i in range(xnew_nlines):
+    for i in range(d):
         prod *= 1 + abs_[i]
 
     disc3 = 1 / pow(n, 2) * prod

--- a/scipy/stats/tests/test_qmc.py
+++ b/scipy/stats/tests/test_qmc.py
@@ -178,14 +178,24 @@ class TestUtils:
             qmc.discrepancy(sample, workers=-2)
 
     def test_update_discrepancy(self):
+        # From Fang et al. Design and modeling for computer experiments, 2006
         space_1 = np.array([[1, 3], [2, 6], [3, 2], [4, 5], [5, 1], [6, 4]])
         space_1 = (2.0 * space_1 - 1.0) / (2.0 * 6.0)
 
         disc_init = qmc.discrepancy(space_1[:-1], iterative=True)
-        disc_iter = update_discrepancy(space_1[-1], space_1[:-1],
-                                       disc_init)
+        disc_iter = update_discrepancy(space_1[-1], space_1[:-1], disc_init)
 
         assert_allclose(disc_iter, 0.0081, atol=1e-4)
+
+        # n<d
+        rng = np.random.default_rng(241557431858162136881731220526394276199)
+        space_1 = rng.random((4, 10))
+
+        disc_ref = qmc.discrepancy(space_1)
+        disc_init = qmc.discrepancy(space_1[:-1], iterative=True)
+        disc_iter = update_discrepancy(space_1[-1], space_1[:-1], disc_init)
+
+        assert_allclose(disc_iter, disc_ref, atol=1e-4)
 
         # errors
         with pytest.raises(ValueError, match=r"Sample is not in unit "

--- a/scipy/stats/tests/test_qmc.py
+++ b/scipy/stats/tests/test_qmc.py
@@ -12,6 +12,7 @@ from scipy.stats._sobol import _test_find_index
 from scipy.stats import qmc
 from scipy.stats._qmc import (van_der_corput, n_primes, primes_from_2_to,
                               update_discrepancy, QMCEngine)
+from scipy._lib._pep440 import Version
 
 
 class TestUtils:
@@ -177,6 +178,8 @@ class TestUtils:
         with pytest.raises(ValueError, match="Invalid number of workers..."):
             qmc.discrepancy(sample, workers=-2)
 
+    @pytest.mark.skipif(Version(np.__version__) < Version('1.17'),
+                        reason='default_rng not available for numpy, < 1.17')
     def test_update_discrepancy(self):
         # From Fang et al. Design and modeling for computer experiments, 2006
         space_1 = np.array([[1, 3], [2, 6], [3, 2], [4, 5], [5, 1], [6, 4]])


### PR DESCRIPTION
* add early draft of the release notes for SciPy `1.7.3.`--I'm not actually sure how many problematic tests are going to be skipped, but I've left a sentence in there about test skipping for the `arm64` thin wheels
* I've manually added an author or two based on assistance with M1 wheels work that would not get picked up by our script--feel free to suggest others if appropriate
* there's really very little in the area of backports here at the moment--most of the magic was in the wheels repo, and I think we may get some test skips added from Ralf for this maintenance branch for which I'd then update this PR