### PR TITLE
MAINT: forward port 1.7.3 relnotes.

### DIFF
--- a/doc/release/1.7.3-notes.rst
+++ b/doc/release/1.7.3-notes.rst
@@ -1,0 +1,41 @@
+==========================
+SciPy 1.7.3 Release Notes
+==========================
+
+.. contents::
+
+SciPy 1.7.3 is a bug-fix release that provides binary wheels
+for MacOS arm64 with Python 3.8, 3.9, and 3.10. The MacOS arm64 wheels
+are only available for MacOS version 12.0 and greater, as explained
+in Issue 14688, linked below.
+
+Authors
+=======
+
+* Anirudh Dagar
+* Ralf Gommers
+* Tyler Reddy
+* Pamphile Roy
+* Olivier Grisel
+* Isuru Fernando
+
+A total of 6 people contributed to this release.
+People with a "+" by their names contributed a patch for the first time.
+This list of names is automatically generated, and may not be fully complete.
+
+Issues closed for 1.7.3
+-----------------------
+
+* `#13364 <https://github.com/scipy/scipy/issues/13364>`__: Segmentation fault on import of scipy.integrate on Apple M1 ARM...
+* `#14688 <https://github.com/scipy/scipy/issues/14688>`__: BUG: ARPACK's eigsh & OpenBLAS from Apple Silicon M1 (arm64)...
+* `#14991 <https://github.com/scipy/scipy/issues/14991>`__: four CI failures on pre-release job
+* `#15077 <https://github.com/scipy/scipy/issues/15077>`__: Remaining test failures for macOS arm64 wheel
+* `#15081 <https://github.com/scipy/scipy/issues/15081>`__: BUG: Segmentation fault caused by scipy.stats.qmc.qmc.update_discrepancy
+
+
+Pull requests for 1.7.3
+-----------------------
+
+* `#14990 <https://github.com/scipy/scipy/pull/14990>`__: BLD: update pyproject.toml for Python 3.10 changes
+* `#15086 <https://github.com/scipy/scipy/pull/15086>`__: BUG: out of bounds indexing in stats.qmc.update_discrepancy
+* `#15090 <https://github.com/scipy/scipy/pull/15090>`__: MAINT: skip a few failing tests in \`1.7.x\` for macOS arm64

--- a/doc/source/release.1.7.3.rst
+++ b/doc/source/release.1.7.3.rst
@@ -1,0 +1,1 @@
+.. include:: ../release/1.7.3-notes.rst

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -9,6 +9,7 @@ see the `commit logs <https://github.com/scipy/scipy/commits/>`_.
    :maxdepth: 1
 
    release.1.8.0
+   release.1.7.3
    release.1.7.2
    release.1.7.1
    release.1.7.0


### PR DESCRIPTION
Forward port SciPy `1.7.3` release notes after the release this morning.