### PR TITLE
ENH: add radius to gaussian_filter1d and gaussian_filter

### DIFF
--- a/scipy/ndimage/_filters.py
+++ b/scipy/ndimage/_filters.py
@@ -209,7 +209,7 @@ def _gaussian_kernel1d(sigma, order, radius):
 
 @_ni_docstrings.docfiller
 def gaussian_filter1d(input, sigma, axis=-1, order=0, output=None,
-                      mode="reflect", cval=0.0, truncate=4.0):
+                      mode="reflect", cval=0.0, truncate=4.0, radius=None):
     """1-D Gaussian filter.
 
     Parameters
@@ -228,6 +228,10 @@ def gaussian_filter1d(input, sigma, axis=-1, order=0, output=None,
     truncate : float, optional
         Truncate the filter at this many standard deviations.
         Default is 4.0.
+    radius : None or int, optional
+        Radius of the Gaussian kernel. If specified, the size of
+        the kernel will be ``2*radius+1``, and `truncate` is ignored.
+        Default is None.
 
     Returns
     -------
@@ -257,6 +261,10 @@ def gaussian_filter1d(input, sigma, axis=-1, order=0, output=None,
     sd = float(sigma)
     # make the radius of the filter equal to truncate standard deviations
     lw = int(truncate * sd + 0.5)
+    if radius is not None:
+        lw = radius
+        if not isinstance(lw, int) or lw < 0:
+            raise ValueError('Radius must be a nonnegative integer.')
     # Since we are calling correlate, not convolve, revert the kernel
     weights = _gaussian_kernel1d(sigma, order, lw)[::-1]
     return correlate1d(input, weights, axis, output, mode, cval, 0)
@@ -264,7 +272,7 @@ def gaussian_filter1d(input, sigma, axis=-1, order=0, output=None,
 
 @_ni_docstrings.docfiller
 def gaussian_filter(input, sigma, order=0, output=None,
-                    mode="reflect", cval=0.0, truncate=4.0):
+                    mode="reflect", cval=0.0, truncate=4.0, radius=None):
     """Multidimensional Gaussian filter.
 
     Parameters
@@ -286,6 +294,10 @@ def gaussian_filter(input, sigma, order=0, output=None,
     truncate : float
         Truncate the filter at this many standard deviations.
         Default is 4.0.
+    radius : None or int, optional
+        Radius of the Gaussian kernel. If specified, the size of the kernel
+        for each axis will be ``2*radius+1``, and `truncate` is ignored.
+        Default is None.
 
     Returns
     -------
@@ -342,7 +354,7 @@ def gaussian_filter(input, sigma, order=0, output=None,
     if len(axes) > 0:
         for axis, sigma, order, mode in axes:
             gaussian_filter1d(input, sigma, axis, order, output,
-                              mode, cval, truncate)
+                              mode, cval, truncate, radius)
             input = output
     else:
         output[...] = input[...]

--- a/scipy/ndimage/_filters.py
+++ b/scipy/ndimage/_filters.py
@@ -209,7 +209,7 @@ def _gaussian_kernel1d(sigma, order, radius):
 
 @_ni_docstrings.docfiller
 def gaussian_filter1d(input, sigma, axis=-1, order=0, output=None,
-                      mode="reflect", cval=0.0, truncate=4.0, radius=None):
+                      mode="reflect", cval=0.0, truncate=4.0, *, radius=None):
     """1-D Gaussian filter.
 
     Parameters
@@ -230,7 +230,7 @@ def gaussian_filter1d(input, sigma, axis=-1, order=0, output=None,
         Default is 4.0.
     radius : None or int, optional
         Radius of the Gaussian kernel. If specified, the size of
-        the kernel will be ``2*radius+1``, and `truncate` is ignored.
+        the kernel will be ``2*radius + 1``, and `truncate` is ignored.
         Default is None.
 
     Returns
@@ -263,7 +263,7 @@ def gaussian_filter1d(input, sigma, axis=-1, order=0, output=None,
     lw = int(truncate * sd + 0.5)
     if radius is not None:
         lw = radius
-        if not isinstance(lw, int) or lw < 0:
+        if not isinstance(lw, numbers.Integral) or lw < 0:
             raise ValueError('Radius must be a nonnegative integer.')
     # Since we are calling correlate, not convolve, revert the kernel
     weights = _gaussian_kernel1d(sigma, order, lw)[::-1]
@@ -272,7 +272,7 @@ def gaussian_filter1d(input, sigma, axis=-1, order=0, output=None,
 
 @_ni_docstrings.docfiller
 def gaussian_filter(input, sigma, order=0, output=None,
-                    mode="reflect", cval=0.0, truncate=4.0, radius=None):
+                    mode="reflect", cval=0.0, truncate=4.0, *, radius=None):
     """Multidimensional Gaussian filter.
 
     Parameters
@@ -296,7 +296,7 @@ def gaussian_filter(input, sigma, order=0, output=None,
         Default is 4.0.
     radius : None or int, optional
         Radius of the Gaussian kernel. If specified, the size of the kernel
-        for each axis will be ``2*radius+1``, and `truncate` is ignored.
+        for each axis will be ``2*radius + 1``, and `truncate` is ignored.
         Default is None.
 
     Returns

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -1832,12 +1832,27 @@ def test_gaussian_radius():
     f2 = ndimage.gaussian_filter1d(x, sigma=2, radius=3)
     assert_equal(f1, f2)
 
-    # Test gaussian_filter
+    # Test gaussian_filter when sigma is a number.
     a = numpy.zeros((9, 9))
     a[4, 4] = 1
     f1 = ndimage.gaussian_filter(a, sigma=0.5, truncate=3.5)
     f2 = ndimage.gaussian_filter(a, sigma=0.5, radius=2)
     assert_equal(f1, f2)
+
+    # Test gaussian_filter when sigma is a sequence.
+    a = numpy.zeros((50, 50))
+    a[25, 25] = 1
+    f1 = ndimage.gaussian_filter(a, sigma=[0.5, 2.5], truncate=3.5)
+    f2 = ndimage.gaussian_filter(a, sigma=[0.5, 2.5], radius=[2, 9])
+    assert_equal(f1, f2)
+
+
+def test_gaussian_radius_invalid():
+    # radius must be a nonnegative integer
+    with assert_raises(ValueError):
+        ndimage.gaussian_filter1d(numpy.zeros(8), sigma=1, radius=-1)
+    with assert_raises(ValueError):
+        ndimage.gaussian_filter1d(numpy.zeros(8), sigma=1, radius=1.1)
 
 
 class TestThreading:

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -1821,6 +1821,25 @@ def test_gaussian_truncate():
     assert_equal(n, 15)
 
 
+def test_gaussian_radius():
+    # Test that Gaussian filters with radius argument produce the same
+    # results as the filters with corresponding truncate argument.
+    # radius = int(truncate * sigma + 0.5)
+    # Test gaussian_filter1d
+    x = numpy.zeros(7)
+    x[3] = 1
+    f1 = ndimage.gaussian_filter1d(x, sigma=2, truncate=1.5)
+    f2 = ndimage.gaussian_filter1d(x, sigma=2, radius=3)
+    assert_equal(f1, f2)
+
+    # Test gaussian_filter
+    a = numpy.zeros((9, 9))
+    a[4, 4] = 1
+    f1 = ndimage.gaussian_filter(a, sigma=0.5, truncate=3.5)
+    f2 = ndimage.gaussian_filter(a, sigma=0.5, radius=2)
+    assert_equal(f1, f2)
+
+
 class TestThreading:
     def check_func_thread(self, n, fun, args, out):
         from threading import Thread


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #11475
#### What does this implement/fix?
<!--Please explain your changes.-->
I added an optional `radius` argument to `gaussian_filter1d` and `gaussian_filter`. The default value is None. If `radius` is provided, the value of `truncate` will be ignored, and the kernel size of the filter will be 2*radius+1.

Tests were added to test filters with `radius` specified produce the same results as the filters using `truncate`.
#### Additional information
<!--Any additional information you think is important.-->
I agree with #11475 that it would be nice for user to have the option to directly specifiy the radius of the kernel. I have encountered this kind of usecase.