### PR TITLE
MAINT: ScalarFunction remember best_x

### DIFF
--- a/scipy/optimize/_differentiable_functions.py
+++ b/scipy/optimize/_differentiable_functions.py
@@ -113,8 +113,8 @@ class ScalarFunction:
         self.g_updated = False
         self.H_updated = False
 
-        self._best_x = None
-        self._best_f = np.inf
+        self._lowest_x = None
+        self._lowest_f = np.inf
 
         finite_diff_options = {}
         if grad in FD_METHODS:
@@ -145,9 +145,9 @@ class ScalarFunction:
                         "must return a scalar value."
                     ) from e
 
-            if fx < self._best_f:
-                self._best_x = np.copy(x)
-                self._best_f = fx
+            if fx < self._lowest_f:
+                self._lowest_x = x
+                self._lowest_f = fx
 
             return fx
 

--- a/scipy/optimize/_differentiable_functions.py
+++ b/scipy/optimize/_differentiable_functions.py
@@ -113,6 +113,9 @@ class ScalarFunction:
         self.g_updated = False
         self.H_updated = False
 
+        self._best_x = None
+        self._best_f = np.inf
+
         finite_diff_options = {}
         if grad in FD_METHODS:
             finite_diff_options["method"] = grad
@@ -141,6 +144,11 @@ class ScalarFunction:
                         "The user-provided objective function "
                         "must return a scalar value."
                     ) from e
+
+            if fx < self._best_f:
+                self._best_x = np.copy(x)
+                self._best_f = fx
+
             return fx
 
         def update_fun():

--- a/scipy/optimize/tests/test_differentiable_functions.py
+++ b/scipy/optimize/tests/test_differentiable_functions.py
@@ -9,6 +9,7 @@ from scipy.optimize._differentiable_functions import (ScalarFunction,
                                                       VectorFunction,
                                                       LinearVectorFunction,
                                                       IdentityVectorFunction)
+from scipy.optimize import rosen, rosen_der, rosen_hess
 from scipy.optimize._hessian_update_strategy import BFGS
 
 
@@ -339,6 +340,27 @@ class TestScalarFunction(TestCase):
         assert_equal(sf.fun(x), 14.0)
         assert_equal(sf.x, np.array([1., 2., 3.]))
         assert x is not sf.x
+
+    def test_lowest_x(self):
+        # ScalarFunction should remember the lowest func(x) visited.
+        x0 = np.array([2, 3, 4])
+        sf = ScalarFunction(rosen, x0, (), rosen_der, rosen_hess,
+                            None, None)
+        sf.fun([1, 1, 1])
+        sf.fun(x0)
+        sf.fun([1.01, 1, 1.0])
+        sf.grad([1.01, 1, 1.0])
+        assert_equal(sf._lowest_f, 0.0)
+        assert_equal(sf._lowest_x, [1.0, 1.0, 1.0])
+
+        sf = ScalarFunction(rosen, x0, (), '2-point', rosen_hess,
+                            None, (-np.inf, np.inf))
+        sf.fun([1, 1, 1])
+        sf.fun(x0)
+        sf.fun([1.01, 1, 1.0])
+        sf.grad([1.01, 1, 1.0])
+        assert_equal(sf._lowest_f, 0.0)
+        assert_equal(sf._lowest_x, [1.0, 1.0, 1.0])
 
 
 class ExVectorialFunction:


### PR DESCRIPTION
This PR makes `optimize._differentiable_functions.ScalarFunction` remember the `x` value for which `fun(x)` has the lowest value. This will come in handy for PRs related to #15089.