### PR TITLE
ENH: Add orthogonalize argument to DCT/DST

### DIFF
--- a/scipy/fft/_pocketfft/pypocketfft.cxx
+++ b/scipy/fft/_pocketfft/pypocketfft.cxx
@@ -231,7 +231,7 @@ py::array r2r_fftpack(const py::array &in, const py::object &axes_,
 
 template<typename T> py::array dct_internal(const py::array &in,
   const py::object &axes_, int type, int inorm, py::object &out_,
-  size_t nthreads)
+  size_t nthreads, bool ortho)
   {
   auto axes = makeaxes(in, axes_);
   auto dims(copy_shape(in));
@@ -244,7 +244,6 @@ template<typename T> py::array dct_internal(const py::array &in,
   py::gil_scoped_release release;
   T fct = (type==1) ? norm_fct<T>(inorm, dims, axes, 2, -1)
                     : norm_fct<T>(inorm, dims, axes, 2);
-  bool ortho = inorm == 1;
   pocketfft::dct(dims, s_in, s_out, axes, type, d_in, d_out, fct, ortho,
     nthreads);
   }
@@ -252,16 +251,20 @@ template<typename T> py::array dct_internal(const py::array &in,
   }
 
 py::array dct(const py::array &in, int type, const py::object &axes_,
-  int inorm, py::object &out_, size_t nthreads)
+  int inorm, py::object &out_, size_t nthreads, const py::object & ortho_obj)
   {
+  bool ortho=inorm==1;
+  if (!ortho_obj.is_none())
+    ortho=ortho_obj.cast<bool>();
+
   if ((type<1) || (type>4)) throw std::invalid_argument("invalid DCT type");
   DISPATCH(in, f64, f32, flong, dct_internal, (in, axes_, type, inorm, out_,
-    nthreads))
+    nthreads, ortho))
   }
 
 template<typename T> py::array dst_internal(const py::array &in,
   const py::object &axes_, int type, int inorm, py::object &out_,
-  size_t nthreads)
+  size_t nthreads, bool ortho)
   {
   auto axes = makeaxes(in, axes_);
   auto dims(copy_shape(in));
@@ -274,7 +277,6 @@ template<typename T> py::array dst_internal(const py::array &in,
   py::gil_scoped_release release;
   T fct = (type==1) ? norm_fct<T>(inorm, dims, axes, 2, 1)
                     : norm_fct<T>(inorm, dims, axes, 2);
-  bool ortho = inorm == 1;
   pocketfft::dst(dims, s_in, s_out, axes, type, d_in, d_out, fct, ortho,
     nthreads);
   }
@@ -282,11 +284,15 @@ template<typename T> py::array dst_internal(const py::array &in,
   }
 
 py::array dst(const py::array &in, int type, const py::object &axes_,
-  int inorm, py::object &out_, size_t nthreads)
+  int inorm, py::object &out_, size_t nthreads, const py::object &ortho_obj)
   {
+  bool ortho=inorm==1;
+  if (!ortho_obj.is_none())
+    ortho=ortho_obj.cast<bool>();
+
   if ((type<1) || (type>4)) throw std::invalid_argument("invalid DST type");
   DISPATCH(in, f64, f32, flong, dst_internal, (in, axes_, type, inorm,
-    out_, nthreads))
+    out_, nthreads, ortho))
   }
 
 template<typename T> py::array c2r_internal(const py::array &in,
@@ -622,7 +628,7 @@ axes : list of integers
 inorm : int
     Normalization type
       0 : no normalization
-      1 : make transform orthogonal and divide by sqrt(N)
+      1 : divide by sqrt(N)
       2 : divide by N
     where N is the product of n_i for every transformed axis i.
     n_i is 2*(<axis_length>-1 for type 1 and 2*<axis length>
@@ -640,6 +646,8 @@ out : numpy.ndarray (same shape and data type as `a`)
 nthreads : int
     Number of threads to use. If 0, use the system default (typically governed
     by the `OMP_NUM_THREADS` environment variable).
+ortho: bool
+    Orthogonalize transform (defaults to ``inorm==1``)
 
 Returns
 -------
@@ -661,7 +669,7 @@ axes : list of integers
 inorm : int
     Normalization type
       0 : no normalization
-      1 : make transform orthogonal and divide by sqrt(N)
+      1 : divide by sqrt(N)
       2 : divide by N
     where N is the product of n_i for every transformed axis i.
     n_i is 2*(<axis_length>+1 for type 1 and 2*<axis length>
@@ -678,6 +686,8 @@ out : numpy.ndarray (same shape and data type as `a`)
 nthreads : int
     Number of threads to use. If 0, use the system default (typically governed
     by the `OMP_NUM_THREADS` environment variable).
+ortho: bool
+    Orthogonalize transform (defaults to ``inorm==1``)
 
 Returns
 -------
@@ -721,9 +731,9 @@ PYBIND11_MODULE(pypocketfft, m)
   m.def("genuine_hartley", genuine_hartley, genuine_hartley_DS, "a"_a,
     "axes"_a=None, "inorm"_a=0, "out"_a=None, "nthreads"_a=1);
   m.def("dct", dct, dct_DS, "a"_a, "type"_a, "axes"_a=None, "inorm"_a=0,
-    "out"_a=None, "nthreads"_a=1);
+    "out"_a=None, "nthreads"_a=1, "ortho"_a=None);
   m.def("dst", dst, dst_DS, "a"_a, "type"_a, "axes"_a=None, "inorm"_a=0,
-    "out"_a=None, "nthreads"_a=1);
+    "out"_a=None, "nthreads"_a=1, "ortho"_a=None);
 
   static PyMethodDef good_size_meth[] =
     {{"good_size", (PyCFunction)good_size,

--- a/scipy/fft/_pocketfft/realtransforms.py
+++ b/scipy/fft/_pocketfft/realtransforms.py
@@ -6,7 +6,7 @@ import functools
 
 
 def _r2r(forward, transform, x, type=2, n=None, axis=-1, norm=None,
-         overwrite_x=False, workers=None):
+         overwrite_x=False, workers=None, orthogonalize=None):
     """Forward or backward 1-D DCT/DST
 
     Parameters
@@ -43,7 +43,7 @@ def _r2r(forward, transform, x, type=2, n=None, axis=-1, norm=None,
         transform(tmp.imag, type, (axis,), norm, out.imag, workers)
         return out
 
-    return transform(tmp, type, (axis,), norm, out, workers)
+    return transform(tmp, type, (axis,), norm, out, workers, orthogonalize)
 
 
 dct = functools.partial(_r2r, True, pfft.dct)
@@ -58,7 +58,7 @@ idst.__name__ = 'idst'
 
 
 def _r2rn(forward, transform, x, type=2, s=None, axes=None, norm=None,
-          overwrite_x=False, workers=None):
+          overwrite_x=False, workers=None, orthogonalize=None):
     """Forward or backward nd DCT/DST
 
     Parameters
@@ -96,7 +96,7 @@ def _r2rn(forward, transform, x, type=2, s=None, axes=None, norm=None,
         transform(tmp.imag, type, axes, norm, out.imag, workers)
         return out
 
-    return transform(tmp, type, axes, norm, out, workers)
+    return transform(tmp, type, axes, norm, out, workers, orthogonalize)
 
 
 dctn = functools.partial(_r2rn, True, pfft.dct)

--- a/scipy/fft/_realtransforms.py
+++ b/scipy/fft/_realtransforms.py
@@ -264,8 +264,7 @@ def idstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
 @_dispatch
 def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None,
         orthogonalize=None):
-    r"""
-    Return the Discrete Cosine Transform of arbitrary type sequence x.
+    r"""Return the Discrete Cosine Transform of arbitrary type sequence x.
 
     Parameters
     ----------
@@ -366,9 +365,9 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None,
 
        y_k = x_0 + 2 \sum_{n=1}^{N-1} x_n \cos\left(\frac{\pi(2k+1)n}{2N}\right)
 
-    If ``orthogonalize=True``, ``x[0]`` terms are multiplied by :math:`\sqrt{2}`
-    which, when combined with ``norm="ortho"``, makes the corresponding matrix
-    of coefficients orthonormal (``O @ O.T = np.eye(N)``).
+    If ``orthogonalize=True``, ``x[0]`` terms are multiplied by
+    :math:`\sqrt{2}` which, when combined with ``norm="ortho"``, makes the
+    corresponding matrix of coefficients orthonormal (``O @ O.T = np.eye(N)``).
 
     The (unnormalized) DCT-III is the inverse of the (unnormalized) DCT-II, up
     to a factor `2N`. The orthonormalized DCT-III is exactly the inverse of
@@ -383,8 +382,8 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None,
 
        y_k = 2 \sum_{n=0}^{N-1} x_n \cos\left(\frac{\pi(2k+1)(2n+1)}{4N} \right)
 
-    ``orthogonalize`` has no effect here, as the DCT-IV matrix is already orthogonal
-    up to a scale factor of ``2N``.
+    ``orthogonalize`` has no effect here, as the DCT-IV matrix is already
+    orthogonal up to a scale factor of ``2N``.
 
     References
     ----------

--- a/scipy/fft/_realtransforms.py
+++ b/scipy/fft/_realtransforms.py
@@ -7,7 +7,7 @@ __all__ = ['dct', 'idct', 'dst', 'idst', 'dctn', 'idctn', 'dstn', 'idstn']
 
 @_dispatch
 def dctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
-         workers=None):
+         workers=None, *, orthogonalize=None):
     """
     Return multidimensional Discrete Cosine Transform along the specified axes.
 
@@ -37,6 +37,11 @@ def dctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    orthogonalize : bool, optional
+        Whether to use the orthogonalized DCT variant (see Notes).
+        Defaults to ``True`` when ``norm=="ortho"`` and ``False`` otherwise.
+
+        .. versionadded:: 1.8.0
 
     Returns
     -------
@@ -66,7 +71,7 @@ def dctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
 
 @_dispatch
 def idctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
-          workers=None):
+          workers=None, orthogonalize=None):
     """
     Return multidimensional Inverse Discrete Cosine Transform along the specified axes.
 
@@ -96,6 +101,11 @@ def idctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    orthogonalize : bool, optional
+        Whether to use the orthogonalized IDCT variant (see Notes).
+        Defaults to ``True`` when ``norm=="ortho"`` and ``False`` otherwise.
+
+        .. versionadded:: 1.8.0
 
     Returns
     -------
@@ -125,7 +135,7 @@ def idctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
 
 @_dispatch
 def dstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
-         workers=None):
+         workers=None, orthogonalize=None):
     """
     Return multidimensional Discrete Sine Transform along the specified axes.
 
@@ -155,6 +165,11 @@ def dstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    orthogonalize : bool, optional
+        Whether to use the orthogonalized DST variant (see Notes).
+        Defaults to ``True`` when ``norm=="ortho"`` and ``False`` otherwise.
+
+        .. versionadded:: 1.8.0
 
     Returns
     -------
@@ -184,7 +199,7 @@ def dstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
 
 @_dispatch
 def idstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
-          workers=None):
+          workers=None, orthogonalize=None):
     """
     Return multidimensional Inverse Discrete Sine Transform along the specified axes.
 
@@ -214,6 +229,11 @@ def idstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    orthogonalize : bool, optional
+        Whether to use the orthogonalized IDST variant (see Notes).
+        Defaults to ``True`` when ``norm=="ortho"`` and ``False`` otherwise.
+
+        .. versionadded:: 1.8.0
 
     Returns
     -------
@@ -242,8 +262,10 @@ def idstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
 
 
 @_dispatch
-def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
-    r"""Return the Discrete Cosine Transform of arbitrary type sequence x.
+def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None,
+        orthogonalize=None):
+    r"""
+    Return the Discrete Cosine Transform of arbitrary type sequence x.
 
     Parameters
     ----------
@@ -266,6 +288,11 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    orthogonalize : bool, optional
+        Whether to use the orthogonalized DCT variant (see Notes).
+        Defaults to ``True`` when ``norm=="ortho"`` and ``False`` otherwise.
+
+        .. versionadded:: 1.8.0
 
     Returns
     -------
@@ -282,12 +309,13 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
     MATLAB ``dct(x)``.
 
     .. warning:: For ``type in {1, 2, 3}``, ``norm="ortho"`` breaks the direct
-                 correspondence with the direct Fourier transform.
+                 correspondence with the direct Fourier transform. To recover
+                 it you must specify ``orthogonalize=False``.
 
-    For ``norm="ortho"`` both the `dct` and `idct` are made orthogonal through
-    scaling by the same overall factor in both directions and for types 1, 2
-    and 3 the transform definition is modified to give orthogonality of the DCT
-    matrix (see below).
+    For ``norm="ortho"`` both the `dct` and `idct` are scaled by the same
+    overall factor in both directions. By default, the transform is also
+    orthogonalized which for types 1, 2 and 3 means the transform definition is
+    modified to give orthogonality of the DCT matrix (see below).
 
     For ``norm="backward"``, there is no scaling on `dct` and the `idct` is
     scaled by ``1/N`` where ``N`` is the "logical" size of the DCT. For
@@ -308,15 +336,10 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
        y_k = x_0 + (-1)^k x_{N-1} + 2 \sum_{n=1}^{N-2} x_n \cos\left(
        \frac{\pi k n}{N-1} \right)
 
-    If ``norm='ortho'``, ``x[0]`` and ``x[N-1]`` are multiplied by a scaling
-    factor of :math:`\sqrt{2}`, and ``y[k]`` is multiplied by a scaling factor
-    ``f``
-
-    .. math::
-
-        f = \begin{cases}
-         \frac{1}{2}\sqrt{\frac{1}{N-1}} & \text{if }k=0\text{ or }N-1, \\
-         \frac{1}{2}\sqrt{\frac{2}{N-1}} & \text{otherwise} \end{cases}
+    If ``orthogonalize=True``, ``x[0]`` and ``x[N-1]`` are multiplied by a
+    scaling factor of :math:`\sqrt{2}`, and ``y[0]`` and ``y[N-1]`` are divided
+    by :math:`\sqrt{2}`. When combined with ``norm="ortho"``, this makes the
+    corresponding matrix of coefficients orthonormal (``O @ O.T = np.eye(N)``).
 
     .. note::
        The DCT-I is only supported for input size > 1.
@@ -330,15 +353,9 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
 
        y_k = 2 \sum_{n=0}^{N-1} x_n \cos\left(\frac{\pi k(2n+1)}{2N} \right)
 
-    If ``norm="ortho"``, ``y[k]`` is multiplied by a scaling factor ``f``
-
-    .. math::
-       f = \begin{cases}
-       \sqrt{\frac{1}{4N}} & \text{if }k=0, \\
-       \sqrt{\frac{1}{2N}} & \text{otherwise} \end{cases}
-
-    which makes the corresponding matrix of coefficients orthonormal
-    (``O @ O.T = np.eye(N)``).
+    If ``orthogonalize=True``, ``y[0]`` is divided by :math:`\sqrt{2}` which,
+    when combined with ``norm="ortho"``, makes the corresponding matrix of
+    coefficients orthonormal (``O @ O.T = np.eye(N)``).
 
     **Type III**
 
@@ -349,12 +366,9 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
 
        y_k = x_0 + 2 \sum_{n=1}^{N-1} x_n \cos\left(\frac{\pi(2k+1)n}{2N}\right)
 
-    or, for ``norm="ortho"``
-
-    .. math::
-
-       y_k = \frac{x_0}{\sqrt{N}} + \sqrt{\frac{2}{N}} \sum_{n=1}^{N-1} x_n
-       \cos\left(\frac{\pi(2k+1)n}{2N}\right)
+    If ``orthogonalize=True``, ``x[0]`` terms are multiplied by :math:`\sqrt{2}`
+    which, when combined with ``norm="ortho"``, makes the corresponding matrix
+    of coefficients orthonormal (``O @ O.T = np.eye(N)``).
 
     The (unnormalized) DCT-III is the inverse of the (unnormalized) DCT-II, up
     to a factor `2N`. The orthonormalized DCT-III is exactly the inverse of
@@ -369,11 +383,8 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
 
        y_k = 2 \sum_{n=0}^{N-1} x_n \cos\left(\frac{\pi(2k+1)(2n+1)}{4N} \right)
 
-    If ``norm="ortho"``, ``y[k]`` is multiplied by a scaling factor ``f``
-
-    .. math::
-
-        f = \frac{1}{\sqrt{2N}}
+    ``orthogonalize`` has no effect here, as the DCT-IV matrix is already orthogonal
+    up to a scale factor of ``2N``.
 
     References
     ----------
@@ -402,7 +413,7 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
 
 @_dispatch
 def idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
-         workers=None):
+         workers=None, orthogonalize=None):
     """
     Return the Inverse Discrete Cosine Transform of an arbitrary type sequence.
 
@@ -427,6 +438,11 @@ def idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    orthogonalize : bool, optional
+        Whether to use the orthogonalized IDCT variant (see Notes).
+        Defaults to ``True`` when ``norm=="ortho"`` and ``False`` otherwise.
+
+        .. versionadded:: 1.8.0
 
     Returns
     -------
@@ -443,12 +459,14 @@ def idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
     MATLAB ``idct(x)``.
 
     .. warning:: For ``type in {1, 2, 3}``, ``norm="ortho"`` breaks the direct
-                 correspondence with the inverse direct Fourier transform.
+                 correspondence with the inverse direct Fourier transform. To
+                 recover it you must specify ``orthogonalize=False``.
 
-    For ``norm="ortho"`` both the `dct` and `idct` are made orthogonal
-    through scaling by the same overall factor in both directions and for types
-    1, 2 and 3 the transform definition is modified to give orthogonality of
-    the IDCT matrix (see `dct` for the full definitions).
+    For ``norm="ortho"`` both the `dct` and `idct` are scaled by the same
+    overall factor in both directions. By default, the transform is also
+    orthogonalized which for types 1, 2 and 3 means the transform definition is
+    modified to give orthogonality of the IDCT matrix (see `dct` for the full
+    definitions).
 
     'The' IDCT is the IDCT-II, which is the same as the normalized DCT-III.
 
@@ -473,8 +491,10 @@ def idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
 
 
 @_dispatch
-def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
-    r"""Return the Discrete Sine Transform of arbitrary type sequence x.
+def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None,
+        orthogonalize=None):
+    r"""
+    Return the Discrete Sine Transform of arbitrary type sequence x.
 
     Parameters
     ----------
@@ -497,6 +517,11 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    orthogonalize : bool, optional
+        Whether to use the orthogonalized DST variant (see Notes).
+        Defaults to ``True`` when ``norm=="ortho"`` and ``False`` otherwise.
+
+        .. versionadded:: 1.8.0
 
     Returns
     -------
@@ -510,12 +535,13 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
     Notes
     -----
     .. warning:: For ``type in {2, 3}``, ``norm="ortho"`` breaks the direct
-                 correspondence with the inverse direct Fourier transform.
+                 correspondence with the direct Fourier transform. To recover
+                 it you must specify ``orthogonalize=False``.
 
-    For ``norm="ortho"`` both the `dst` and `idst` are made orthogonal through
-    scaling by the same overall factor in both directions and for types 2 and
-    3 the transform definition is modified to give orthogonality of the DST
-    matrix (see below).
+    For ``norm="ortho"`` both the `dst` and `idst` are scaled by the same
+    overall factor in both directions. By default, the transform is also
+    orthogonalized which for types 2 and 3 means the transform definition is
+    modified to give orthogonality of the DST matrix (see below).
 
     For ``norm="backward"``, there is no scaling on the `dst` and the `idst` is
     scaled by ``1/N`` where ``N`` is the "logical" size of the DST.
@@ -538,6 +564,9 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
     The (unnormalized) DST-I is its own inverse, up to a factor :math:`2(N+1)`.
     The orthonormalized DST-I is exactly its own inverse.
 
+    ``orthogonalize`` has no effect here, as the DST-I matrix is already
+    orthogonal up to a scale factor of ``2N``.
+
     **Type II**
 
     There are several definitions of the DST-II; we use the following for
@@ -548,13 +577,9 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
 
         y_k = 2 \sum_{n=0}^{N-1} x_n \sin\left(\frac{\pi(k+1)(2n+1)}{2N}\right)
 
-    if ``norm='ortho'``, ``y[k]`` is multiplied by a scaling factor ``f``
-
-    .. math::
-
-        f = \begin{cases}
-        \sqrt{\frac{1}{4N}} & \text{if }k = 0, \\
-        \sqrt{\frac{1}{2N}} & \text{otherwise} \end{cases}
+    If ``orthogonalize=True``, ``y[0]`` is divided :math:`\sqrt{2}` which, when
+    combined with ``norm="ortho"``, makes the corresponding matrix of
+    coefficients orthonormal (``O @ O.T = np.eye(N)``).
 
     **Type III**
 
@@ -566,6 +591,10 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
 
         y_k = (-1)^k x_{N-1} + 2 \sum_{n=0}^{N-2} x_n \sin\left(
         \frac{\pi(2k+1)(n+1)}{2N}\right)
+
+    If ``orthogonalize=True``, ``x[0]`` is multiplied by :math:`\sqrt{2}`
+    which, when combined with ``norm="ortho"``, makes the corresponding matrix
+    of coefficients orthonormal (``O @ O.T = np.eye(N)``).
 
     The (unnormalized) DST-III is the inverse of the (unnormalized) DST-II, up
     to a factor :math:`2N`. The orthonormalized DST-III is exactly the inverse of the
@@ -581,6 +610,9 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
 
         y_k = 2 \sum_{n=0}^{N-1} x_n \sin\left(\frac{\pi(2k+1)(2n+1)}{4N}\right)
 
+    ``orthogonalize`` has no effect here, as the DST-IV matrix is already
+    orthogonal up to a scale factor of ``2N``.
+
     The (unnormalized) DST-IV is its own inverse, up to a factor :math:`2N`. The
     orthonormalized DST-IV is exactly its own inverse.
 
@@ -595,7 +627,7 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None):
 
 @_dispatch
 def idst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
-         workers=None):
+         workers=None, orthogonalize=None):
     """
     Return the Inverse Discrete Sine Transform of an arbitrary type sequence.
 
@@ -620,6 +652,11 @@ def idst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
         Maximum number of workers to use for parallel computation. If negative,
         the value wraps around from ``os.cpu_count()``.
         See :func:`~scipy.fft.fft` for more details.
+    orthogonalize : bool, optional
+        Whether to use the orthogonalized IDST variant (see Notes).
+        Defaults to ``True`` when ``norm=="ortho"`` and ``False`` otherwise.
+
+        .. versionadded:: 1.8.0
 
     Returns
     -------
@@ -635,10 +672,11 @@ def idst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
     .. warning:: For ``type in {2, 3}``, ``norm="ortho"`` breaks the direct
                  correspondence with the inverse direct Fourier transform.
 
-    For ``norm="ortho"`` both the `dst` and `idst` are made orthogonal through
-    scaling by the same overall factor in both directions and for types 2 and
-    3 the transform definition is modified to give orthogonality of the IDST
-    matrix (see below).
+    For ``norm="ortho"`` both the `dst` and `idst` are scaled by the same
+    overall factor in both directions. By default, the transform is also
+    orthogonalized which for types 2 and 3 means the transform definition is
+    modified to give orthogonality of the DST matrix (see `dst` for the full
+    definitions).
 
     'The' IDST is the IDST-II, which is the same as the normalized DST-III.
 

--- a/scipy/fft/tests/test_real_transforms.py
+++ b/scipy/fft/tests/test_real_transforms.py
@@ -77,7 +77,8 @@ def test_identity_1d_overwrite(forward, backward, type, dtype, axis, norm,
                          ])
 @pytest.mark.parametrize("norm", [None, 'backward', 'ortho', 'forward'])
 @pytest.mark.parametrize("orthogonalize", [False, True])
-def test_identity_nd(forward, backward, type, shape, axes, norm, orthogonalize):
+def test_identity_nd(forward, backward, type, shape, axes, norm,
+                     orthogonalize):
     # Test the identity f^-1(f(x)) == x
 
     x = np.random.random(shape)
@@ -164,15 +165,17 @@ def test_orthogonalize_default(func, type):
         b = func(x, type=type, norm=norm)
         assert_allclose(a, b)
 
+
 @pytest.mark.parametrize("norm", ["backward", "ortho", "forward"])
-@pytest.mark.parametrize("func, type",[
-    (dct, 4), (dst, 1), (dst, 4),])
+@pytest.mark.parametrize("func, type", [
+    (dct, 4), (dst, 1), (dst, 4)])
 def test_orthogonalize_noop(func, type, norm):
     # Transforms where orthogonalize is a no-op
     x = np.random.rand(100)
     y1 = func(x, type=type, norm=norm, orthogonalize=True)
     y2 = func(x, type=type, norm=norm, orthogonalize=False)
     assert_allclose(y1, y2)
+
 
 @pytest.mark.parametrize("norm", ["backward", "ortho", "forward"])
 def test_orthogonalize_dct1(norm):
@@ -189,6 +192,7 @@ def test_orthogonalize_dct1(norm):
     y2[-1] /= SQRT_2
     assert_allclose(y1, y2)
 
+
 @pytest.mark.parametrize("norm", ["backward", "ortho", "forward"])
 @pytest.mark.parametrize("func", [dct, dst])
 def test_orthogonalize_dcst2(func, norm):
@@ -198,6 +202,7 @@ def test_orthogonalize_dcst2(func, norm):
 
     y2[0] /= SQRT_2
     assert_allclose(y1, y2)
+
 
 @pytest.mark.parametrize("norm", ["backward", "ortho", "forward"])
 @pytest.mark.parametrize("func", [dct, dst])

--- a/scipy/fft/tests/test_real_transforms.py
+++ b/scipy/fft/tests/test_real_transforms.py
@@ -7,6 +7,9 @@ from scipy.fft import dct, idct, dctn, idctn, dst, idst, dstn, idstn
 import scipy.fft as fft
 from scipy import fftpack
 
+import math
+SQRT_2 = math.sqrt(2)
+
 # scipy.fft wraps the fftpack versions but with normalized inverse transforms.
 # So, the forward transforms and definitions are already thoroughly tested in
 # fftpack/test_real_transforms.py
@@ -17,19 +20,20 @@ from scipy import fftpack
 @pytest.mark.parametrize("n", [2, 3, 4, 5, 10, 16])
 @pytest.mark.parametrize("axis", [0, 1])
 @pytest.mark.parametrize("norm", [None, 'backward', 'ortho', 'forward'])
-def test_identity_1d(forward, backward, type, n, axis, norm):
+@pytest.mark.parametrize("orthogonalize", [False, True])
+def test_identity_1d(forward, backward, type, n, axis, norm, orthogonalize):
     # Test the identity f^-1(f(x)) == x
     x = np.random.rand(n, n)
 
-    y = forward(x, type, axis=axis, norm=norm)
-    z = backward(y, type, axis=axis, norm=norm)
+    y = forward(x, type, axis=axis, norm=norm, orthogonalize=orthogonalize)
+    z = backward(y, type, axis=axis, norm=norm, orthogonalize=orthogonalize)
     assert_allclose(z, x)
 
     pad = [(0, 0)] * 2
     pad[axis] = (0, 4)
 
     y2 = np.pad(y, pad, mode='edge')
-    z2 = backward(y2, type, n, axis, norm)
+    z2 = backward(y2, type, n, axis, norm, orthogonalize=orthogonalize)
     assert_allclose(z2, x)
 
 
@@ -72,7 +76,8 @@ def test_identity_1d_overwrite(forward, backward, type, dtype, axis, norm,
                              ((4, 5, 6), (0, 2)),
                          ])
 @pytest.mark.parametrize("norm", [None, 'backward', 'ortho', 'forward'])
-def test_identity_nd(forward, backward, type, shape, axes, norm):
+@pytest.mark.parametrize("orthogonalize", [False, True])
+def test_identity_nd(forward, backward, type, shape, axes, norm, orthogonalize):
     # Test the identity f^-1(f(x)) == x
 
     x = np.random.random(shape)
@@ -80,8 +85,8 @@ def test_identity_nd(forward, backward, type, shape, axes, norm):
     if axes is not None:
         shape = np.take(shape, axes)
 
-    y = forward(x, type, axes=axes, norm=norm)
-    z = backward(y, type, axes=axes, norm=norm)
+    y = forward(x, type, axes=axes, norm=norm, orthogonalize=orthogonalize)
+    z = backward(y, type, axes=axes, norm=norm, orthogonalize=orthogonalize)
     assert_allclose(z, x)
 
     if axes is None:
@@ -96,7 +101,7 @@ def test_identity_nd(forward, backward, type, shape, axes, norm):
             pad[a] = (0, 4)
 
     y2 = np.pad(y, pad, mode='edge')
-    z2 = backward(y2, type, shape, axes, norm)
+    z2 = backward(y2, type, shape, axes, norm, orthogonalize=orthogonalize)
     assert_allclose(z2, x)
 
 
@@ -142,3 +147,65 @@ def test_fftpack_equivalience(func, type, norm):
     fftpack_res = getattr(fftpack, func)(x, type, norm=norm)
 
     assert_allclose(fft_res, fftpack_res)
+
+
+@pytest.mark.parametrize("func", [dct, dst, dctn, dstn])
+@pytest.mark.parametrize("type", [1, 2, 3, 4])
+def test_orthogonalize_default(func, type):
+    # Test orthogonalize is the default when norm="ortho", but not otherwise
+    x = np.random.rand(100)
+
+    for norm, ortho in [
+            ("forward", False),
+            ("backward", False),
+            ("ortho", True),
+    ]:
+        a = func(x, type=type, norm=norm, orthogonalize=ortho)
+        b = func(x, type=type, norm=norm)
+        assert_allclose(a, b)
+
+@pytest.mark.parametrize("norm", ["backward", "ortho", "forward"])
+@pytest.mark.parametrize("func, type",[
+    (dct, 4), (dst, 1), (dst, 4),])
+def test_orthogonalize_noop(func, type, norm):
+    # Transforms where orthogonalize is a no-op
+    x = np.random.rand(100)
+    y1 = func(x, type=type, norm=norm, orthogonalize=True)
+    y2 = func(x, type=type, norm=norm, orthogonalize=False)
+    assert_allclose(y1, y2)
+
+@pytest.mark.parametrize("norm", ["backward", "ortho", "forward"])
+def test_orthogonalize_dct1(norm):
+    x = np.random.rand(100)
+
+    x2 = x.copy()
+    x2[0] *= SQRT_2
+    x2[-1] *= SQRT_2
+
+    y1 = dct(x, type=1, norm=norm, orthogonalize=True)
+    y2 = dct(x2, type=1, norm=norm, orthogonalize=False)
+
+    y2[0] /= SQRT_2
+    y2[-1] /= SQRT_2
+    assert_allclose(y1, y2)
+
+@pytest.mark.parametrize("norm", ["backward", "ortho", "forward"])
+@pytest.mark.parametrize("func", [dct, dst])
+def test_orthogonalize_dcst2(func, norm):
+    x = np.random.rand(100)
+    y1 = func(x, type=2, norm=norm, orthogonalize=True)
+    y2 = func(x, type=2, norm=norm, orthogonalize=False)
+
+    y2[0] /= SQRT_2
+    assert_allclose(y1, y2)
+
+@pytest.mark.parametrize("norm", ["backward", "ortho", "forward"])
+@pytest.mark.parametrize("func", [dct, dst])
+def test_orthogonalize_dcst3(func, norm):
+    x = np.random.rand(100)
+    x2 = x.copy()
+    x2[0] *= SQRT_2
+
+    y1 = func(x, type=3, norm=norm, orthogonalize=True)
+    y2 = func(x2, type=3, norm=norm, orthogonalize=False)
+    assert_allclose(y1, y2)


### PR DESCRIPTION
#### Reference issue
Ref gh-15033

#### What does this implement/fix?
This adds an `orthogonalize=None` parameter to the real transforms in `scipy.fft` which controls whether the modified definition of DCT/DST is used without changing the overall scaling. So for example, you can now call
```
dst(..., norm="ortho", orthogonalize=False)
```
for `1/sqrt(N)` scaling of the unmodified DST. Or,
```
dst(..., norm=None, orthogonalize=True)
```
for an unscaled variant of orthogonal DST. Neither of which were possible before.

For backward compatibility, `orthogonalize` defaults to true when `norm="ortho"` and false otherwise.
