### PR TITLE
MAINT: Add missing imports in deprecated modules

### DIFF
--- a/scipy/_lib/tests/test_public_api.py
+++ b/scipy/_lib/tests/test_public_api.py
@@ -191,6 +191,7 @@ PRIVATE_BUT_PRESENT_MODULES = [
     'scipy.sparse.linalg.isolve',
     'scipy.sparse.linalg.matfuncs',
     'scipy.sparse.sparsetools',
+    'scipy.sparse.spfuncs',
     'scipy.sparse.sputils',
     'scipy.spatial.ckdtree',
     'scipy.spatial.kdtree',

--- a/scipy/_lib/tests/test_public_api.py
+++ b/scipy/_lib/tests/test_public_api.py
@@ -103,6 +103,8 @@ PRIVATE_BUT_PRESENT_MODULES = [
     'scipy.fftpack.helper',
     'scipy.fftpack.pseudo_diffs',
     'scipy.fftpack.realtransforms',
+    'scipy.integrate.odepack',
+    'scipy.integrate.quadpack',
     'scipy.integrate.dop',
     'scipy.integrate.lsoda',
     'scipy.integrate.vode',

--- a/scipy/constants/codata.py
+++ b/scipy/constants/codata.py
@@ -7,7 +7,11 @@ from . import _codata
 
 __all__ = [  # noqa: F822
     'physical_constants', 'value', 'unit', 'precision', 'find',
-    'ConstantWarning'
+    'ConstantWarning', 'txt2002', 'txt2006', 'txt2010', 'txt2014',
+    'txt2018', 'parse_constants_2002to2014',
+    'parse_constants_2018toXXXX', 'k', 'c', 'mu0', 'epsilon0',
+    'exact_values', 'key', 'val', 'v'
+
 ]
 
 

--- a/scipy/fftpack/pseudo_diffs.py
+++ b/scipy/fftpack/pseudo_diffs.py
@@ -7,9 +7,9 @@ from . import _pseudo_diffs
 
 __all__ = [  # noqa: F822
     'diff',
-    'tilbert','itilbert','hilbert','ihilbert',
-    'cs_diff','cc_diff','sc_diff','ss_diff',
-    'shift'
+    'tilbert', 'itilbert', 'hilbert', 'ihilbert',
+    'cs_diff', 'cc_diff', 'sc_diff', 'ss_diff',
+    'shift', 'iscomplexobj', 'convolve'
 ]
 
 

--- a/scipy/integrate/__init__.py
+++ b/scipy/integrate/__init__.py
@@ -99,7 +99,7 @@ from ._ivp import (solve_ivp, OdeSolution, DenseOutput,
 from ._quad_vec import quad_vec
 
 # Deprecated namespaces, to be removed in v2.0.0
-from . import dop, lsoda, vode
+from . import dop, lsoda, vode, odepack, quadpack
 
 __all__ = [s for s in dir() if not s.startswith('_')]
 

--- a/scipy/integrate/odepack.py
+++ b/scipy/integrate/odepack.py
@@ -1,0 +1,25 @@
+# This file is not meant for public use and will be removed in SciPy v2.0.0.
+# Use the `scipy.integrate` namespace for importing the functions
+# included below.
+
+import warnings
+from . import _odepack_py
+
+__all__ = ['odeint', 'ODEintWarning']  # noqa: F822
+
+
+def __dir__():
+    return __all__
+
+
+def __getattr__(name):
+    if name not in __all__:
+        raise AttributeError(
+            "scipy.integrate.odepack is deprecated and has no attribute "
+            f"{name}. Try looking in scipy.integrate instead.")
+
+    warnings.warn(f"Please use `{name}` from the `scipy.integrate` namespace, "
+                  "the `scipy.integrate.odepack` namespace is deprecated.",
+                  category=DeprecationWarning, stacklevel=2)
+
+    return getattr(_odepack_py, name)

--- a/scipy/integrate/quadpack.py
+++ b/scipy/integrate/quadpack.py
@@ -1,0 +1,28 @@
+# This file is not meant for public use and will be removed in SciPy v2.0.0.
+# Use the `scipy.integrate` namespace for importing the functions
+# included below.
+
+import warnings
+from . import _quadpack_py
+
+__all__ = [  # noqa: F822
+    'quad', 'dblquad', 'tplquad', 'nquad', 'quad_explain',
+    'IntegrationWarning', 'error'
+]
+
+
+def __dir__():
+    return __all__
+
+
+def __getattr__(name):
+    if name not in __all__:
+        raise AttributeError(
+            "scipy.integrate.quadpack is deprecated and has no attribute "
+            f"{name}. Try looking in scipy.integrate instead.")
+
+    warnings.warn(f"Please use `{name}` from the `scipy.integrate` namespace, "
+                  "the `scipy.integrate.quadpack` namespace is deprecated.",
+                  category=DeprecationWarning, stacklevel=2)
+
+    return getattr(_quadpack_py, name)

--- a/scipy/interpolate/__init__.py
+++ b/scipy/interpolate/__init__.py
@@ -184,7 +184,7 @@ from ._bsplines import *
 from ._pade import *
 
 # Deprecated namespaces, to be removed in v2.0.0
-from . import fitpack, fitpack2, interpolate, ndgriddata, polyint
+from . import fitpack, fitpack2, interpolate, ndgriddata, polyint, rbf
 
 __all__ = [s for s in dir() if not s.startswith('_')]
 

--- a/scipy/io/_harwell_boeing/__init__.py
+++ b/scipy/io/_harwell_boeing/__init__.py
@@ -3,10 +3,13 @@ from .hb import (MalformedHeader, hb_read, hb_write, HBInfo,
 from ._fortran_format_parser import (FortranFormatParser, IntFormat,
                                     ExpFormat, BadFortranFormat)
 
+# Deprecated namespaces, to be removed in v2.0.0
+from . import hb
+
 __all__ = [
     'MalformedHeader', 'hb_read', 'hb_write', 'HBInfo',
     'HBFile', 'HBMatrixType', 'FortranFormatParser', 'IntFormat',
-    'ExpFormat', 'BadFortranFormat'
+    'ExpFormat', 'BadFortranFormat', 'hb'
 ]
 
 from scipy._lib._testutils import PytestTester

--- a/scipy/io/arff/__init__.py
+++ b/scipy/io/arff/__init__.py
@@ -18,7 +18,10 @@ for more details about the ARFF format and available datasets.
 from ._arffread import *
 from . import _arffread
 
-__all__ = _arffread.__all__
+# Deprecated namespaces, to be removed in v2.0.0
+from .import arffread
+
+__all__ = _arffread.__all__ + ['arffread']
 
 from scipy._lib._testutils import PytestTester
 test = PytestTester(__name__)

--- a/scipy/io/arff/arffread.py
+++ b/scipy/io/arff/arffread.py
@@ -6,7 +6,16 @@ import warnings
 from . import _arffread
 
 __all__ = [  # noqa: F822
-    'MetaData', 'loadarff', 'ArffError', 'ParseArffError'
+    'MetaData', 'loadarff', 'ArffError', 'ParseArffError',
+    'r_meta', 'r_comment', 'r_empty', 'r_headerline',
+    'r_datameta', 'r_relation', 'r_attribute', 'r_nominal',
+    'r_date', 'r_comattrval', 'r_wcomattrval', 'Attribute',
+    'NominalAttribute', 'NumericAttribute', 'StringAttribute',
+    'DateAttribute', 'RelationalAttribute', 'to_attribute',
+    'csv_sniffer_has_bug_last_field', 'workaround_csv_sniffer_bug_last_field',
+    'split_data_line', 'tokenize_attribute', 'tokenize_single_comma',
+    'tokenize_single_wcomma', 'read_relational_attribute', 'read_header',
+    'basic_stats', 'print_attribute', 'test_weka'
 ]
 
 

--- a/scipy/io/harwell_boeing.py
+++ b/scipy/io/harwell_boeing.py
@@ -8,7 +8,7 @@ from . import _harwell_boeing
 __all__ = [  # noqa: F822
     'MalformedHeader', 'hb_read', 'hb_write', 'HBInfo',
     'HBFile', 'HBMatrixType', 'FortranFormatParser', 'IntFormat',
-    'ExpFormat', 'BadFortranFormat'
+    'ExpFormat', 'BadFortranFormat', 'hb'
 ]
 
 

--- a/scipy/io/idl.py
+++ b/scipy/io/idl.py
@@ -6,7 +6,10 @@ import warnings
 from . import _idl
 
 
-__all__ = ['readsav']  # noqa: F822
+__all__ = [  # noqa: F822
+    'readsav', 'DTYPE_DICT', 'RECTYPE_DICT', 'STRUCT_DICT',
+    'Pointer', 'ObjectPointer', 'AttrDict'
+]
 
 
 def __dir__():

--- a/scipy/io/matlab/__init__.py
+++ b/scipy/io/matlab/__init__.py
@@ -49,7 +49,8 @@ from ._miobase import (matfile_version, MatReadError, MatReadWarning,
                       MatWriteError)
 
 # Deprecated namespaces, to be removed in v2.0.0
-from .import mio, mio5, mio5_params, mio4, byteordercodes, miobase
+from .import (mio, mio5, mio5_params, mio4, byteordercodes,
+            miobase, mio_utils, streams, mio5_utils)
 
 __all__ = [
     'loadmat', 'savemat', 'whosmat', 'MatlabObject',

--- a/scipy/io/matlab/mio.py
+++ b/scipy/io/matlab/mio.py
@@ -6,8 +6,11 @@ import warnings
 from . import _mio
 
 
-__all__ = ['mat_reader_factory', 'loadmat', 'savemat', 'whosmat']  # noqa: F822
-
+__all__ = [  # noqa: F822
+    'mat_reader_factory', 'loadmat', 'savemat', 'whosmat',
+    'contextmanager', 'get_matfile_version', 'docfiller',
+    'MatFile4Reader', 'MatFile4Writer', 'MatFile5Reader', 'MatFile5Writer'
+]
 
 def __dir__():
     return __all__

--- a/scipy/io/matlab/mio4.py
+++ b/scipy/io/matlab/mio4.py
@@ -11,7 +11,9 @@ __all__ = [  # noqa: F822
     'VarHeader4', 'VarReader4', 'VarWriter4', 'arr_to_2d', 'mclass_info',
     'mdtypes_template', 'miDOUBLE', 'miINT16', 'miINT32', 'miSINGLE',
     'miUINT16', 'miUINT8', 'mxCHAR_CLASS', 'mxFULL_CLASS', 'mxSPARSE_CLASS',
-    'np_to_mtypes', 'order_codes'
+    'np_to_mtypes', 'order_codes', 'MatFileReader', 'docfiller',
+    'matdims', 'read_dtype', 'convert_dtypes', 'arr_to_chars',
+    'arr_dtype_number', 'squeeze_element', 'chars_to_strings'
 ]
 
 def __dir__():

--- a/scipy/io/matlab/mio5.py
+++ b/scipy/io/matlab/mio5.py
@@ -11,7 +11,16 @@ __all__ = [  # noqa: F822
     'VarHeader4', 'VarReader4', 'VarWriter4', 'arr_to_2d', 'mclass_info',
     'mdtypes_template', 'miDOUBLE', 'miINT16', 'miINT32', 'miSINGLE',
     'miUINT16', 'miUINT8', 'mxCHAR_CLASS', 'mxFULL_CLASS', 'mxSPARSE_CLASS',
-    'np_to_mtypes', 'order_codes'
+    'np_to_mtypes', 'order_codes', 'BytesIO', 'native_code',
+    'swapped_code', 'MatFileReader', 'docfiller', 'matdims',
+    'read_dtype', 'arr_to_chars', 'arr_dtype_number', 'MatWriteError',
+    'MatReadError', 'MatReadWarning', 'VarReader5', 'MatlabObject',
+    'MatlabFunction', 'MDTYPES', 'NP_TO_MTYPES', 'NP_TO_MXTYPES',
+    'miCOMPRESSED', 'miMATRIX', 'miINT8', 'miUTF8', 'miUINT32',
+    'mxCELL_CLASS', 'mxSTRUCT_CLASS', 'mxOBJECT_CLASS', 'mxDOUBLE_CLASS',
+    'mat_struct', 'ZlibInputStream', 'MatFile5Reader', 'varmats_from_mat',
+    'EmptyStructMarker', 'to_writeable', 'NDT_FILE_HDR', 'NDT_TAG_FULL',
+    'NDT_TAG_SMALL', 'NDT_ARRAY_FLAGS', 'VarWriter5', 'MatFile5Writer'
 ]
 
 def __dir__():

--- a/scipy/io/matlab/mio5_params.py
+++ b/scipy/io/matlab/mio5_params.py
@@ -17,7 +17,7 @@ __all__ = [  # noqa: F822
     'mxINT64_CLASS', 'mxINT8_CLASS', 'mxOBJECT_CLASS',
     'mxOBJECT_CLASS_FROM_MATRIX_H', 'mxOPAQUE_CLASS', 'mxSINGLE_CLASS',
     'mxSPARSE_CLASS', 'mxSTRUCT_CLASS', 'mxUINT16_CLASS', 'mxUINT32_CLASS',
-    'mxUINT64_CLASS', 'mxUINT8_CLASS'
+    'mxUINT64_CLASS', 'mxUINT8_CLASS', 'convert_dtypes'
 ]
 
 def __dir__():

--- a/scipy/io/matlab/mio5_utils.py
+++ b/scipy/io/matlab/mio5_utils.py
@@ -8,7 +8,7 @@ from . import _mio5_utils
 
 __all__ = [  # noqa: F822
     'VarHeader5', 'VarReader5', 'byteswap_u4', 'chars_to_strings',
-    'csc_matrix', 'mio5p', 'miob', 'pycopy', 'swapped_code'
+    'csc_matrix', 'mio5p', 'miob', 'pycopy', 'swapped_code', 'squeeze_element'
 ]
 
 def __dir__():

--- a/scipy/io/matlab/miobase.py
+++ b/scipy/io/matlab/miobase.py
@@ -11,7 +11,7 @@ __all__ = [  # noqa: F822
     'MatVarReader', 'MatWriteError', 'arr_dtype_number',
     'arr_to_chars', 'convert_dtypes', 'doc_dict',
     'docfiller', 'get_matfile_version',
-    'matdims', 'read_dtype'
+    'matdims', 'read_dtype', 'doccer', 'boc'
 ]
 
 def __dir__():

--- a/scipy/io/mmio.py
+++ b/scipy/io/mmio.py
@@ -6,7 +6,8 @@ import warnings
 from . import _mmio
 
 __all__ = [  # noqa: F822
-    'mminfo', 'mmread', 'mmwrite', 'MMFile'
+    'mminfo', 'mmread', 'mmwrite', 'MMFile',
+    'coo_matrix', 'isspmatrix', 'asstr'
 ]
 
 

--- a/scipy/io/netcdf.py
+++ b/scipy/io/netcdf.py
@@ -6,7 +6,13 @@ import warnings
 from . import _netcdf
 
 __all__ = [  # noqa: F822
-    'netcdf_file', 'netcdf_variable'
+    'netcdf_file', 'netcdf_variable',
+    'array', 'LITTLE_ENDIAN', 'IS_PYPY', 'ABSENT', 'ZERO',
+    'NC_BYTE', 'NC_CHAR', 'NC_SHORT', 'NC_INT', 'NC_FLOAT',
+    'NC_DOUBLE', 'NC_DIMENSION', 'NC_VARIABLE', 'NC_ATTRIBUTE',
+    'FILL_BYTE', 'FILL_CHAR', 'FILL_SHORT', 'FILL_INT', 'FILL_FLOAT',
+    'FILL_DOUBLE', 'TYPEMAP', 'FILLMAP', 'REVERSE', 'NetCDFFile',
+    'NetCDFVariable'
 ]
 
 

--- a/scipy/linalg/__init__.py
+++ b/scipy/linalg/__init__.py
@@ -220,7 +220,7 @@ from ._decomp_cossin import *
 # Deprecated namespaces, to be removed in v2.0.0
 from . import (
     decomp, decomp_cholesky, decomp_lu, decomp_qr, decomp_svd, decomp_schur,
-    basic, misc, special_matrices,
+    basic, misc, special_matrices, flinalg, matfuncs
 )
 
 __all__ = [s for s in dir() if not s.startswith('_')]

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -8,7 +8,9 @@ from . import _basic
 __all__ = [  # noqa: F822
     'solve', 'solve_triangular', 'solveh_banded', 'solve_banded',
     'solve_toeplitz', 'solve_circulant', 'inv', 'det', 'lstsq',
-    'pinv', 'pinv2', 'pinvh', 'matrix_balance', 'matmul_toeplitz'
+    'pinv', 'pinv2', 'pinvh', 'matrix_balance', 'matmul_toeplitz',
+    'atleast_1d', 'atleast_2d', 'get_flinalg_funcs', 'get_lapack_funcs',
+    'LinAlgError', 'LinAlgWarning', 'decomp', 'decomp_svd', 'levinson'
 ]
 
 

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -8,7 +8,10 @@ from . import _decomp
 __all__ = [  # noqa: F822
     'eig', 'eigvals', 'eigh', 'eigvalsh',
     'eig_banded', 'eigvals_banded',
-    'eigh_tridiagonal', 'eigvalsh_tridiagonal', 'hessenberg', 'cdf2rdf'
+    'eigh_tridiagonal', 'eigvalsh_tridiagonal', 'hessenberg', 'cdf2rdf',
+    'array', 'isfinite', 'inexact', 'nonzero', 'iscomplexobj', 'cast',
+    'flatnonzero', 'argsort', 'iscomplex', 'einsum', 'eye', 'inf',
+    'LinAlgError', 'norm', 'get_lapack_funcs'
 ]
 
 

--- a/scipy/linalg/decomp_cholesky.py
+++ b/scipy/linalg/decomp_cholesky.py
@@ -7,7 +7,8 @@ from . import _decomp_cholesky
 
 __all__ = [  # noqa: F822
     'cholesky', 'cho_factor', 'cho_solve', 'cholesky_banded',
-    'cho_solve_banded'
+    'cho_solve_banded', 'asarray_chkfinite', 'atleast_2d',
+    'LinAlgError', 'get_lapack_funcs'
 ]
 
 

--- a/scipy/linalg/decomp_lu.py
+++ b/scipy/linalg/decomp_lu.py
@@ -5,7 +5,12 @@
 import warnings
 from . import _decomp_lu
 
-__all__ = ['lu', 'lu_solve', 'lu_factor']  # noqa: F822
+__all__ = [  # noqa: F822
+    'lu', 'lu_solve', 'lu_factor',
+    'asarray_chkfinite', 'LinAlgWarning', 'get_lapack_funcs',
+    'get_flinalg_funcs'
+
+]
 
 
 def __dir__():

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -5,7 +5,9 @@
 import warnings
 from . import _decomp_qr
 
-__all__ = ['qr', 'qr_multiply', 'rq']  # noqa: F822
+__all__ = [  # noqa: F822
+    'qr', 'qr_multiply', 'rq', 'get_lapack_funcs', 'safecall'
+]
 
 
 def __dir__():

--- a/scipy/linalg/decomp_schur.py
+++ b/scipy/linalg/decomp_schur.py
@@ -5,7 +5,10 @@
 import warnings
 from . import _decomp_schur
 
-__all__ = ['schur', 'rsf2csf']  # noqa: F822
+__all__ = [  # noqa: F822
+    'schur', 'rsf2csf', 'asarray_chkfinite', 'single', 'array', 'norm',
+    'LinAlgError', 'get_lapack_funcs', 'eigvals', 'eps', 'feps'
+]
 
 
 def __dir__():

--- a/scipy/linalg/decomp_svd.py
+++ b/scipy/linalg/decomp_svd.py
@@ -6,7 +6,8 @@ import warnings
 from . import _decomp_svd
 
 __all__ = [  # noqa: F822
-    'svd', 'svdvals', 'diagsvd', 'orth', 'subspace_angles', 'null_space'
+    'svd', 'svdvals', 'diagsvd', 'orth', 'subspace_angles', 'null_space',
+    'LinAlgError', 'get_lapack_funcs'
 ]
 
 

--- a/scipy/linalg/flinalg.py
+++ b/scipy/linalg/flinalg.py
@@ -3,7 +3,7 @@
 import warnings
 from . import _flinalg_py
 
-__all__ = ['get_flinalg_funcs']  # noqa: F822
+__all__ = ['get_flinalg_funcs', 'has_column_major_storage']  # noqa: F822
 
 
 def __dir__():

--- a/scipy/linalg/matfuncs.py
+++ b/scipy/linalg/matfuncs.py
@@ -6,10 +6,12 @@ import warnings
 from . import _matfuncs
 
 __all__ = [  # noqa: F822
-    'expm','cosm','sinm','tanm','coshm','sinhm',
-    'tanhm','logm','funm','signm','sqrtm',
+    'expm', 'cosm', 'sinm', 'tanm', 'coshm', 'sinhm',
+    'tanhm', 'logm', 'funm', 'signm', 'sqrtm',
     'expm_frechet', 'expm_cond', 'fractional_matrix_power',
-    'khatri_rao'
+    'khatri_rao', 'prod', 'logical_not', 'ravel', 'transpose',
+    'conjugate', 'absolute', 'amax', 'sign', 'isfinite', 'single',
+    'norm', 'solve', 'inv', 'triu', 'svd', 'schur', 'rsf2csf', 'eps', 'feps'
 ]
 
 

--- a/scipy/linalg/misc.py
+++ b/scipy/linalg/misc.py
@@ -5,7 +5,10 @@
 import warnings
 from . import _misc
 
-__all__ = ['LinAlgError', 'LinAlgWarning', 'norm']  # noqa: F822
+__all__ = [  # noqa: F822
+    'LinAlgError', 'LinAlgWarning', 'norm', 'get_blas_funcs',
+    'get_lapack_funcs'
+]
 
 
 def __dir__():

--- a/scipy/linalg/special_matrices.py
+++ b/scipy/linalg/special_matrices.py
@@ -9,7 +9,7 @@ __all__ = [  # noqa: F822
     'tri', 'tril', 'triu', 'toeplitz', 'circulant', 'hankel',
     'hadamard', 'leslie', 'kron', 'block_diag', 'companion',
     'helmert', 'hilbert', 'invhilbert', 'pascal', 'invpascal', 'dft',
-    'fiedler', 'fiedler_companion', 'convolution_matrix'
+    'fiedler', 'fiedler_companion', 'convolution_matrix', 'as_strided'
 ]
 
 

--- a/scipy/misc/common.py
+++ b/scipy/misc/common.py
@@ -8,7 +8,7 @@ from . import _common
 
 __all__ = [  # noqa: F822
     'central_diff_weights', 'derivative', 'ascent', 'face',
-    'electrocardiogram'
+    'electrocardiogram', 'arange', 'newaxis', 'hstack', 'prod', 'array', 'load'
 ]
 
 

--- a/scipy/misc/doccer.py
+++ b/scipy/misc/doccer.py
@@ -7,7 +7,8 @@ from . import _doccer
 
 __all__ = [  # noqa: F822
     'docformat', 'inherit_docstring_from', 'indentcount_lines',
-    'filldoc', 'unindent_dict', 'unindent_string'
+    'filldoc', 'unindent_dict', 'unindent_string', 'extend_notes_in_docstring',
+    'replace_notes_in_docstring'
 ]
 
 

--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -6,14 +6,16 @@ import warnings
 from . import _filters
 
 
-__all__ = ['correlate1d', 'convolve1d', 'gaussian_filter1d',  # noqa: F822
-           'gaussian_filter', 'prewitt', 'sobel', 'generic_laplace',
-           'laplace', 'gaussian_laplace', 'generic_gradient_magnitude',
-           'gaussian_gradient_magnitude', 'correlate', 'convolve',
-           'uniform_filter1d', 'uniform_filter', 'minimum_filter1d',
-           'maximum_filter1d', 'minimum_filter', 'maximum_filter',
-           'rank_filter', 'median_filter', 'percentile_filter',
-           'generic_filter1d', 'generic_filter']
+__all__ = [  # noqa: F822
+    'correlate1d', 'convolve1d', 'gaussian_filter1d',
+    'gaussian_filter', 'prewitt', 'sobel', 'generic_laplace',
+    'laplace', 'gaussian_laplace', 'generic_gradient_magnitude',
+    'gaussian_gradient_magnitude', 'correlate', 'convolve',
+    'uniform_filter1d', 'uniform_filter', 'minimum_filter1d',
+    'maximum_filter1d', 'minimum_filter', 'maximum_filter',
+    'rank_filter', 'median_filter', 'percentile_filter',
+    'generic_filter1d', 'generic_filter', 'normalize_axis_index'
+]
 
 
 def __dir__():

--- a/scipy/ndimage/fourier.py
+++ b/scipy/ndimage/fourier.py
@@ -6,8 +6,10 @@ import warnings
 from . import _fourier
 
 
-__all__ = ['fourier_gaussian', 'fourier_uniform',  # noqa: F822
-           'fourier_ellipsoid', 'fourier_shift']
+__all__ = [  # noqa: F822
+    'fourier_gaussian', 'fourier_uniform',
+    'fourier_ellipsoid', 'fourier_shift', 'normalize_axis_index'
+]
 
 
 def __dir__():

--- a/scipy/ndimage/interpolation.py
+++ b/scipy/ndimage/interpolation.py
@@ -6,9 +6,12 @@ import warnings
 from . import _interpolation
 
 
-__all__ = ['spline_filter1d', 'spline_filter',  # noqa: F822
-           'geometric_transform', 'map_coordinates',
-           'affine_transform', 'shift', 'zoom', 'rotate']
+__all__ = [  # noqa: F822
+    'spline_filter1d', 'spline_filter',
+    'geometric_transform', 'map_coordinates',
+    'affine_transform', 'shift', 'zoom', 'rotate',
+    'normalize_axis_index', 'docfiller'
+]
 
 
 def __dir__():

--- a/scipy/ndimage/measurements.py
+++ b/scipy/ndimage/measurements.py
@@ -6,11 +6,13 @@ import warnings
 from . import _measurements
 
 
-__all__ = ['label', 'find_objects', 'labeled_comprehension',  # noqa: F822
-           'sum', 'mean', 'variance', 'standard_deviation',
-           'minimum', 'maximum', 'median', 'minimum_position',
-           'maximum_position', 'extrema', 'center_of_mass',
-           'histogram', 'watershed_ift', 'sum_labels']
+__all__ = [  # noqa: F822
+    'label', 'find_objects', 'labeled_comprehension',
+    'sum', 'mean', 'variance', 'standard_deviation',
+    'minimum', 'maximum', 'median', 'minimum_position',
+    'maximum_position', 'extrema', 'center_of_mass',
+    'histogram', 'watershed_ift', 'sum_labels', 'morphology'
+]
 
 
 def __dir__():

--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -6,14 +6,16 @@ import warnings
 from . import _morphology
 
 
-__all__ = ['iterate_structure', 'generate_binary_structure',  # noqa: F822
-           'binary_erosion', 'binary_dilation', 'binary_opening',
-           'binary_closing', 'binary_hit_or_miss', 'binary_propagation',
-           'binary_fill_holes', 'grey_erosion', 'grey_dilation',
-           'grey_opening', 'grey_closing', 'morphological_gradient',
-           'morphological_laplace', 'white_tophat', 'black_tophat',
-           'distance_transform_bf', 'distance_transform_cdt',
-           'distance_transform_edt']
+__all__ = [  # noqa: F822
+    'iterate_structure', 'generate_binary_structure',
+    'binary_erosion', 'binary_dilation', 'binary_opening',
+    'binary_closing', 'binary_hit_or_miss', 'binary_propagation',
+    'binary_fill_holes', 'grey_erosion', 'grey_dilation',
+    'grey_opening', 'grey_closing', 'morphological_gradient',
+    'morphological_laplace', 'white_tophat', 'black_tophat',
+    'distance_transform_bf', 'distance_transform_cdt',
+    'distance_transform_edt', 'filters'
+]
 
 
 def __dir__():

--- a/scipy/optimize/cobyla.py
+++ b/scipy/optimize/cobyla.py
@@ -15,6 +15,8 @@ __all__ = [  # noqa: F822
     'synchronized',
 ]
 
+def __dir__():
+    return __all__
 
 def __getattr__(name):
     if name not in __all__:

--- a/scipy/optimize/lbfgsb.py
+++ b/scipy/optimize/lbfgsb.py
@@ -20,6 +20,10 @@ __all__ = [  # noqa: F822
 ]
 
 
+def __dir__():
+    return __all__
+
+
 def __getattr__(name):
     if name not in __all__:
         raise AttributeError(

--- a/scipy/optimize/linesearch.py
+++ b/scipy/optimize/linesearch.py
@@ -21,6 +21,10 @@ __all__ = [  # noqa: F822
 ]
 
 
+def __dir__():
+    return __all__
+
+
 def __getattr__(name):
     if name not in __all__:
         raise AttributeError(

--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -43,6 +43,10 @@ __all__ = [  # noqa: F822
 ]
 
 
+def __dir__():
+    return __all__
+
+
 def __getattr__(name):
     if name not in __all__:
         raise AttributeError(

--- a/scipy/optimize/minpack2.py
+++ b/scipy/optimize/minpack2.py
@@ -12,6 +12,10 @@ __all__ = [  # noqa: F822
 ]
 
 
+def __dir__():
+    return __all__
+
+
 def __getattr__(name):
     if name not in __all__:
         raise AttributeError(

--- a/scipy/optimize/moduleTNC.py
+++ b/scipy/optimize/moduleTNC.py
@@ -11,6 +11,10 @@ __all__ = [  # noqa: F822
 ]
 
 
+def __dir__():
+    return __all__
+
+
 def __getattr__(name):
     if name not in __all__:
         raise AttributeError(

--- a/scipy/optimize/nonlin.py
+++ b/scipy/optimize/nonlin.py
@@ -48,6 +48,10 @@ __all__ = [  # noqa: F822
 ]
 
 
+def __dir__():
+    return __all__
+
+
 def __getattr__(name):
     if name not in __all__:
         raise AttributeError(

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -57,6 +57,10 @@ __all__ = [  # noqa: F822
 ]
 
 
+def __dir__():
+    return __all__
+
+
 def __getattr__(name):
     if name not in __all__:
         raise AttributeError(

--- a/scipy/optimize/slsqp.py
+++ b/scipy/optimize/slsqp.py
@@ -29,6 +29,10 @@ __all__ = [  # noqa: F822
 ]
 
 
+def __dir__():
+    return __all__
+
+
 def __getattr__(name):
     if name not in __all__:
         raise AttributeError(

--- a/scipy/optimize/tnc.py
+++ b/scipy/optimize/tnc.py
@@ -36,6 +36,10 @@ __all__ = [  # noqa: F822
 ]
 
 
+def __dir__():
+    return __all__
+
+
 def __getattr__(name):
     if name not in __all__:
         raise AttributeError(

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -27,6 +27,10 @@ __all__ = [  # noqa: F822
 ]
 
 
+def __dir__():
+    return __all__
+
+
 def __getattr__(name):
     if name not in __all__:
         raise AttributeError(

--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -317,7 +317,7 @@ from .windows import get_window  # keep this one in signal namespace
 # Deprecated namespaces, to be removed in v2.0.0
 from . import (
     bsplines, filter_design, fir_filter_design, lti_conversion, ltisys,
-    spectral, signaltools, waveforms, wavelets,
+    spectral, signaltools, waveforms, wavelets, spline
 )
 
 # deal with * -> windows.* doc-only soft-deprecation

--- a/scipy/signal/bsplines.py
+++ b/scipy/signal/bsplines.py
@@ -7,7 +7,11 @@ from . import _bsplines
 
 __all__ = [  # noqa: F822
     'spline_filter', 'bspline', 'gauss_spline', 'cubic', 'quadratic',
-    'cspline1d', 'qspline1d', 'cspline1d_eval', 'qspline1d_eval'
+    'cspline1d', 'qspline1d', 'cspline1d_eval', 'qspline1d_eval',
+    'logical_and', 'zeros_like', 'piecewise', 'array', 'arctan2',
+    'tan', 'arange', 'floor', 'exp', 'greater', 'less', 'add',
+    'less_equal', 'greater_equal', 'cspline2d', 'sepfir2d', 'comb',
+    'float_factorial'
 ]
 
 

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -15,7 +15,13 @@ __all__ = [  # noqa: F822
     'tf2sos', 'sos2tf', 'zpk2sos', 'sos2zpk', 'group_delay',
     'sosfreqz', 'iirnotch', 'iirpeak', 'bilinear_zpk',
     'lp2lp_zpk', 'lp2hp_zpk', 'lp2bp_zpk', 'lp2bs_zpk',
-    'gammatone', 'iircomb'
+    'gammatone', 'iircomb',
+    'atleast_1d', 'poly', 'polyval', 'roots', 'resize', 'absolute',
+    'logspace', 'tan', 'log10', 'arctan', 'arcsinh', 'exp', 'arccosh',
+    'ceil', 'conjugate', 'append', 'prod', 'full', 'array', 'mintypecode',
+    'npp_polyval', 'polyvalfromroots', 'optimize', 'sp_fft', 'comb',
+    'float_factorial', 'root_scalar', 'abs', 'maxflat', 'yulewalk',
+    'EPSILON', 'filter_dict', 'band_dict', 'bessel_norms'
 ]
 
 

--- a/scipy/signal/fir_filter_design.py
+++ b/scipy/signal/fir_filter_design.py
@@ -9,7 +9,10 @@ from . import _fir_filter_design
 
 __all__ = [  # noqa: F822
     'kaiser_beta', 'kaiser_atten', 'kaiserord',
-    'firwin', 'firwin2', 'remez', 'firls', 'minimum_phase'
+    'firwin', 'firwin2', 'remez', 'firls', 'minimum_phase',
+    'ceil', 'log', 'irfft', 'fft', 'ifft', 'sinc', 'toeplitz',
+    'hankel', 'solve', 'LinAlgError', 'LinAlgWarning', 'lstsq'
+
 ]
 
 

--- a/scipy/signal/lti_conversion.py
+++ b/scipy/signal/lti_conversion.py
@@ -8,7 +8,8 @@ from . import _lti_conversion
 
 __all__ = [  # noqa: F822
     'tf2ss', 'abcd_normalize', 'ss2tf', 'zpk2ss', 'ss2zpk',
-    'cont2discrete'
+    'cont2discrete','eye', 'atleast_2d',
+    'poly', 'prod', 'array', 'outer', 'linalg', 'tf2zpk', 'zpk2tf', 'normalize'
 ]
 
 

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -9,7 +9,15 @@ __all__ = [  # noqa: F822
     'lti', 'dlti', 'TransferFunction', 'ZerosPolesGain', 'StateSpace',
     'lsim', 'lsim2', 'impulse', 'impulse2', 'step', 'step2', 'bode',
     'freqresp', 'place_poles', 'dlsim', 'dstep', 'dimpulse',
-    'dfreqresp', 'dbode'
+    'dfreqresp', 'dbode', 's_qr', 'integrate', 'interpolate', 'linalg',
+    'interp1d', 'tf2zpk', 'zpk2tf', 'normalize', 'freqs',
+    'freqz', 'freqs_zpk', 'freqz_zpk', 'tf2ss', 'abcd_normalize',
+    'ss2tf', 'zpk2ss', 'ss2zpk', 'cont2discrete', 'atleast_1d',
+    'atleast_2d', 'squeeze', 'transpose', 'zeros_like', 'linspace',
+    'nan_to_num', 'LinearTimeInvariant', 'TransferFunctionContinuous',
+    'TransferFunctionDiscrete', 'ZerosPolesGainContinuous',
+    'ZerosPolesGainDiscrete', 'StateSpaceContinuous',
+    'StateSpaceDiscrete', 'Bunch'
 ]
 
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -13,7 +13,10 @@ __all__ = [  # noqa: F822
     'cmplx_sort', 'unique_roots', 'invres', 'invresz', 'residue',
     'residuez', 'resample', 'resample_poly', 'detrend',
     'lfilter_zi', 'sosfilt_zi', 'sosfiltfilt', 'choose_conv_method',
-    'filtfilt', 'decimate', 'vectorstrength'
+    'filtfilt', 'decimate', 'vectorstrength',
+    'timeit', 'cKDTree', 'sigtools', 'dlti', 'upfirdn', 'linalg',
+    'sp_fft', 'lambertw', 'get_window', 'axis_slice', 'axis_reverse',
+    'odd_ext', 'even_ext', 'const_ext', 'cheby1', 'firwin'
 ]
 
 

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -9,7 +9,9 @@ from . import _spectral_py
 
 __all__ = [  # noqa: F822
     'periodogram', 'welch', 'lombscargle', 'csd', 'coherence',
-    'spectrogram', 'stft', 'istft', 'check_COLA', 'check_NOLA'
+    'spectrogram', 'stft', 'istft', 'check_COLA', 'check_NOLA',
+    'sp_fft', 'signaltools', 'get_window', 'const_ext', 'even_ext',
+    'odd_ext', 'zero_ext'
 ]
 
 

--- a/scipy/signal/waveforms.py
+++ b/scipy/signal/waveforms.py
@@ -7,7 +7,8 @@ from . import _waveforms
 
 __all__ = [  # noqa: F822
     'sawtooth', 'square', 'gausspulse', 'chirp', 'sweep_poly',
-    'unit_impulse'
+    'unit_impulse', 'place', 'nan', 'mod', 'extract', 'log', 'exp',
+    'polyval', 'polyint'
 ]
 
 

--- a/scipy/signal/wavelets.py
+++ b/scipy/signal/wavelets.py
@@ -6,7 +6,8 @@ import warnings
 from . import _wavelets
 
 __all__ = [  # noqa: F822
-    'daub', 'qmf', 'cascade', 'morlet', 'ricker', 'morlet2', 'cwt'
+    'daub', 'qmf', 'cascade', 'morlet', 'ricker', 'morlet2', 'cwt',
+    'eig', 'comb', 'convolve'
 ]
 
 

--- a/scipy/signal/windows/windows.py
+++ b/scipy/signal/windows/windows.py
@@ -10,7 +10,8 @@ __all__ = [  # noqa: F822
     'blackmanharris', 'flattop', 'bartlett', 'hanning', 'barthann',
     'hamming', 'kaiser', 'gaussian', 'general_cosine',
     'general_gaussian', 'general_hamming', 'chebwin', 'cosine',
-    'hann', 'exponential', 'tukey', 'taylor', 'dpss', 'get_window'
+    'hann', 'exponential', 'tukey', 'taylor', 'dpss', 'get_window',
+    'linalg', 'sp_fft', 'k', 'v', 'key'
 ]
 
 

--- a/scipy/sparse/linalg/dsolve.py
+++ b/scipy/sparse/linalg/dsolve.py
@@ -9,7 +9,7 @@ from . import _dsolve
 __all__ = [  # noqa: F822
     'MatrixRankWarning', 'SuperLU', 'factorized',
     'spilu', 'splu', 'spsolve',
-    'spsolve_triangular', 'use_solver'
+    'spsolve_triangular', 'use_solver', 'linsolve', 'test'
 ]
 
 dsolve_modules = ['linsolve']

--- a/scipy/sparse/linalg/eigen.py
+++ b/scipy/sparse/linalg/eigen.py
@@ -8,7 +8,7 @@ from . import _eigen
 
 __all__ = [  # noqa: F822
     'ArpackError', 'ArpackNoConvergence',
-    'eigs', 'eigsh', 'lobpcg', 'svds'
+    'eigs', 'eigsh', 'lobpcg', 'svds', 'arpack', 'test'
 ]
 
 eigen_modules = ['arpack']

--- a/scipy/sparse/linalg/interface.py
+++ b/scipy/sparse/linalg/interface.py
@@ -6,7 +6,11 @@ import warnings
 from . import _interface
 
 
-__all__ = ['LinearOperator', 'aslinearoperator']  # noqa: F822
+__all__ = [  # noqa: F822
+    'LinearOperator', 'aslinearoperator',
+    'isspmatrix', 'isshape', 'isintlike', 'asmatrix',
+    'is_pydata_spmatrix', 'MatrixLinearOperator', 'IdentityOperator'
+]
 
 
 def __dir__():

--- a/scipy/sparse/linalg/isolve.py
+++ b/scipy/sparse/linalg/isolve.py
@@ -9,7 +9,7 @@ from . import _isolve
 __all__ = [  # noqa: F822
     'bicg', 'bicgstab', 'cg', 'cgs', 'gcrotmk', 'gmres',
     'lgmres', 'lsmr', 'lsqr',
-    'minres', 'qmr', 'tfqmr'
+    'minres', 'qmr', 'tfqmr', 'utils', 'iterative', 'test'
 ]
 
 

--- a/scipy/sparse/linalg/matfuncs.py
+++ b/scipy/sparse/linalg/matfuncs.py
@@ -6,7 +6,11 @@ import warnings
 from . import _matfuncs
 
 
-__all__ = ['expm', 'inv']  # noqa: F822
+__all__ = [  # noqa: F822
+    'expm', 'inv', 'float_factorial', 'solve', 'solve_triangular',
+    'isspmatrix', 'spsolve', 'is_pydata_spmatrix', 'LinearOperator',
+    'UPPER_TRIANGULAR', 'MatrixPowerOperator', 'ProductOperator'
+]
 
 
 def __dir__():

--- a/scipy/sparse/spfuncs.py
+++ b/scipy/sparse/spfuncs.py
@@ -1,0 +1,29 @@
+# This file is not meant for public use and will be removed in SciPy v2.0.0.
+# Use the `scipy.sparse` namespace for importing the functions
+# included below.
+
+import warnings
+from . import _spfuncs
+
+
+__all__ = [  # noqa: F822
+    'isspmatrix_csr', 'csr_matrix', 'isspmatrix_csc', 'csr_count_blocks',
+    'estimate_blocksize', 'count_blocks'
+]
+
+
+def __dir__():
+    return __all__
+
+
+def __getattr__(name):
+    if name not in __all__:
+        raise AttributeError(
+            "scipy.sparse.spfuncs is deprecated and has no attribute "
+            f"{name}. Try looking in scipy.sparse instead.")
+
+    warnings.warn(f"Please use `{name}` from the `scipy.sparse` namespace, "
+                  "the `scipy.sparse.spfuncs` namespace is deprecated.",
+                  category=DeprecationWarning, stacklevel=2)
+
+    return getattr(_spfuncs, name)

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -3,7 +3,7 @@
 import warnings
 from . import _add_newdocs
 
-__all__ = ['get', 'add_newdoc']  # noqa: F822
+__all__ = ['get', 'add_newdoc', 'Dict', 'docdict']  # noqa: F822
 
 
 def __dir__():

--- a/scipy/special/orthogonal.py
+++ b/scipy/special/orthogonal.py
@@ -36,7 +36,11 @@ _evalfuns = ['eval_legendre', 'eval_chebyt', 'eval_chebyu',
              'eval_sh_jacobi']
 
 __all__ = _polyfuns + list(_rootfuns_map.keys()) + _evalfuns + [  # noqa: F822
-    'poch', 'binom'
+    'poch', 'binom', 'exp', 'inf', 'floor', 'around', 'hstack', 'arange',
+    'linalg', 'airy', 'cephes', 'specfun', 'orthopoly1d', 'newfun',
+    'oldfun', 'p_roots', 't_roots', 'u_roots', 'c_roots', 's_roots',
+    'j_roots', 'l_roots', 'la_roots', 'h_roots', 'he_roots', 'cg_roots',
+    'ps_roots', 'ts_roots', 'us_roots', 'js_roots'
 ]
 
 

--- a/scipy/special/spfun_stats.py
+++ b/scipy/special/spfun_stats.py
@@ -5,7 +5,7 @@
 import warnings
 from . import _spfun_stats
 
-__all__ = ['multigammaln']  # noqa: F822
+__all__ = ['multigammaln', 'loggam']  # noqa: F822
 
 
 def __dir__():

--- a/scipy/stats/kde.py
+++ b/scipy/stats/kde.py
@@ -6,7 +6,12 @@ import warnings
 from . import _kde
 
 
-__all__ = ['gaussian_kde']  # noqa: F822
+__all__ = [  # noqa: F822
+    'gaussian_kde', 'linalg', 'logsumexp', 'check_random_state',
+    'atleast_2d', 'reshape', 'newaxis', 'exp', 'ravel', 'power',
+    'atleast_1d', 'squeeze', 'sum', 'transpose', 'cov', 'mvn',
+    'gaussian_kernel_estimate'
+]
 
 
 def __dir__():

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -14,7 +14,14 @@ __all__ = [  # noqa: F822
     'fligner', 'mood', 'wilcoxon', 'median_test',
     'circmean', 'circvar', 'circstd', 'anderson_ksamp',
     'yeojohnson_llf', 'yeojohnson', 'yeojohnson_normmax',
-    'yeojohnson_normplot'
+    'yeojohnson_normplot', 'annotations', 'namedtuple', 'isscalar', 'log',
+    'around', 'unique', 'arange', 'sort', 'amin', 'amax', 'atleast_1d',
+    'array', 'compress', 'exp', 'ravel', 'count_nonzero', 'arctan2',
+    'hypot', 'optimize', 'statlib', 'stats', 'find_repeats',
+    'chi2_contingency', 'distributions', 'rv_generic', 'Mean',
+    'Variance', 'Std_dev', 'ShapiroResult', 'AndersonResult',
+    'Anderson_ksampResult', 'AnsariResult', 'BartlettResult',
+    'LeveneResult', 'FlignerResult', 'WilcoxonResult'
 ]
 
 

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -29,7 +29,15 @@ __all__ = [  # noqa: F822
     'ttest_ind','ttest_rel','tvar',
     'variation',
     'winsorize',
-    'brunnermunzel',
+    'brunnermunzel', 'ma', 'masked', 'nomask', 'namedtuple',
+    'distributions', 'stats_linregress', 'stats_LinregressResult',
+    'stats_theilslopes', 'stats_siegelslopes', 'ModeResult',
+    'SpearmanrResult', 'KendalltauResult', 'PointbiserialrResult',
+    'Ttest_1sampResult', 'Ttest_indResult', 'Ttest_relResult',
+    'MannwhitneyuResult', 'KruskalResult', 'trimdoc', 'trim1',
+    'DescribeResult', 'stde_median', 'SkewtestResult', 'KurtosistestResult',
+    'NormaltestResult', 'F_onewayResult', 'FriedmanchisquareResult',
+    'BrunnerMunzelResult'
 ]
 
 

--- a/scipy/stats/mstats_extras.py
+++ b/scipy/stats/mstats_extras.py
@@ -12,7 +12,8 @@ __all__ = [  # noqa: F822
     'idealfourths',
     'median_cihs','mjci','mquantiles_cimj',
     'rsh',
-    'trimmed_mean_ci'
+    'trimmed_mean_ci', 'float_', 'int_', 'ma', 'MaskedArray', 'mstats',
+    'norm', 'beta', 't', 'binom'
 ]
 
 

--- a/scipy/stats/mvn.py
+++ b/scipy/stats/mvn.py
@@ -9,7 +9,8 @@ from . import _mvn  # type: ignore
 __all__ = [  # noqa: F822
     'mvnun',
     'mvnun_weighted',
-    'mvndst'
+    'mvndst',
+    'dkblck'
 ]
 
 

--- a/scipy/stats/statlib.py
+++ b/scipy/stats/statlib.py
@@ -8,7 +8,8 @@ from . import _statlib  # type: ignore
 
 __all__ = [  # noqa: F822
     'swilk',
-    'gscale'
+    'gscale',
+    'prho'
 ]
 
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -29,7 +29,19 @@ __all__ = [  # noqa: F822
     'tiecorrect', 'ranksums', 'kruskal', 'friedmanchisquare',
     'rankdata',
     'combine_pvalues', 'wasserstein_distance', 'energy_distance',
-    'brunnermunzel', 'alexandergovern'
+    'brunnermunzel', 'alexandergovern', 'gcd', 'namedtuple', 'array',
+    'ma', 'cdist', 'measurements', 'check_random_state', 'MapWrapper',
+    'rng_integers', 'float_factorial', 'linalg', 'distributions',
+    'mstats_basic', 'make_dataclass', 'ModeResult', 'DescribeResult',
+    'SkewtestResult', 'KurtosistestResult', 'NormaltestResult',
+    'Jarque_beraResult', 'HistogramResult', 'CumfreqResult',
+    'RelfreqResult', 'SigmaclipResult', 'F_onewayResult',
+    'AlexanderGovernResult', 'AlexanderGovernConstantInputWarning',
+    'SpearmanrResult', 'PointbiserialrResult', 'KendalltauResult',
+    'WeightedTauResult', 'MGCResult', 'Ttest_1sampResult', 'Ttest_indResult',
+    'Ttest_relResult', 'Power_divergenceResult', 'KstestResult',
+    'Ks_2sampResult', 'RanksumsResult', 'KruskalResult',
+    'FriedmanchisquareResult', 'BrunnerMunzelResult', 'RepeatedResults'
 ]
 
 


### PR DESCRIPTION
* See details at: https://github.com/scipy/scipy/issues/14360#issuecomment-980322121


Tracking the fixed modules:
 - [x] cluster
 - [x] constants
 - [x] fft
 - [x] fftpack
 - [x] integrate
 - [x] interpolate
 - [x] io (skipped `io.byteordercodes` since it should be `io.matlab.byteordercodes`(and that too is deprecated))
 - [x] linalg
 - [x] misc
 - [x] ndimage
 - [x] odr
 - [x] optimize
 - [x] signal
 - [x] sparse
 - [x] sparse.csgraph
 - [x] sparse.linalg
 - [x] spatial
 - [x] special
 - [x] stats

cc @rgommers 