### PR TITLE
DOC: stats: remove `NumericalInverseHermite` from `scipy.stats` API docs

### DIFF
--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -386,7 +386,6 @@ Random variate generation / CDF Inversion
    :toctree: generated/
 
    rvs_ratio_uniforms
-   NumericalInverseHermite
 
 Circular statistical functions
 ------------------------------


### PR DESCRIPTION
#### Reference issue

follow-up of #15083 

#### What does this implement/fix?

`NumericalInverseHermite` has been shifted to `scipy.stats.sampling` and deprecated from `scipy.stats`. gh-15083 forgot to remove the entry of `NumericalInverseHermite` from `scipy.stats` API docs.