### PR TITLE
ENH: Add special.log_expit and use it in stats.logistic

### DIFF
--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -261,7 +261,8 @@ Raw statistical functions
    kolmogi      -- Inverse function to `kolmogorov`.
    tklmbda      -- Tukey-Lambda cumulative distribution function.
    logit        -- Logit ufunc for ndarrays.
-   expit        -- Expit ufunc for ndarrays.
+   expit        -- Logistic sigmoid function.
+   log_expit    -- Logarithm of the logistic sigmoid function.
    boxcox       -- Compute the Box-Cox transformation.
    boxcox1p     -- Compute the Box-Cox transformation of 1 + `x`.
    inv_boxcox   -- Compute the inverse of the Box-Cox transformation.

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -6707,6 +6707,70 @@ add_newdoc("_log1pmx",
     Internal function, do not use.
     """)
 
+add_newdoc('log_expit',
+    """
+    log_expit(x)
+
+    Logarithm of the logistic sigmoid function.
+
+    The SciPy implementation of the logistic sigmoid function is
+    `scipy.special.expit`, so this function is called ``log_expit``.
+
+    The function is mathematically equivalent to ``log(expit(x))``, but
+    is formulated to avoid loss of precision for inputs with large
+    (positive or negative) magnitude.
+
+    Parameters
+    ----------
+    x : array_like
+        The values to apply ``log_expit`` to element-wise.
+
+    Returns
+    -------
+    out : ndarray
+        The computed values, an ndarray of the same shape as ``x``.
+
+    See Also
+    --------
+    expit
+
+    Notes
+    -----
+    As a ufunc, ``log_expit`` takes a number of optional keyword arguments.
+    For more information see
+    `ufuncs <https://docs.scipy.org/doc/numpy/reference/ufuncs.html>`_
+
+    .. versionadded:: 1.8.0
+
+    Examples
+    --------
+    >>> from scipy.special import log_expit, expit
+
+    >>> log_expit([-3.0, 0.25, 2.5, 5.0])
+    array([-3.04858735, -0.57593942, -0.07888973, -0.00671535])
+
+    Large negative values:
+
+    >>> log_expit([-100, -500, -1000])
+    array([ -100.,  -500., -1000.])
+
+    Note that ``expit(-1000)`` returns 0, so the naive implementation
+    ``log(expit(-1000))`` return ``-inf``.
+
+    Large positive values:
+
+    >>> log_expit([29, 120, 400])
+    array([-2.54366565e-013, -7.66764807e-053, -1.91516960e-174])
+
+    Compare that to the naive implementation:
+
+    >>> np.log(expit([29, 120, 400]))
+    array([-2.54463117e-13,  0.00000000e+00,  0.00000000e+00])
+
+    The first value is accurate to only 3 digits, and the larger inputs
+    lose all precision and return 0.
+    """)
+
 add_newdoc('logit',
     """
     logit(x)

--- a/scipy/special/_logit.h
+++ b/scipy/special/_logit.h
@@ -1,7 +1,7 @@
 #ifndef _LOGIT_H_
 #define _LOGIT_H_
 
-#include<cmath>
+#include <cmath>
 
 template <typename T>
 inline T _logit(T x) {
@@ -10,9 +10,35 @@ inline T _logit(T x) {
 };
 
 
-template<typename T>
+template <typename T>
 inline T _expit(T x) {
     return 1 / (1 + std::exp(-x));
+};
+
+
+//
+// The logistic sigmoid function 'expit' is
+//
+//     S(x) = 1/(1 + exp(-x))     = exp(x)/(exp(x) + 1)
+//
+// so
+//
+// log S(x) = -log(1 + exp(-x))   = x - log(exp(x) + 1)
+//          = -log1p(exp(-x))     = x - log1p(exp(x))
+//
+// By using -log1p(exp(-x)) for x >= 0 and x - log1p(exp(x))
+// for x < 0, we extend the range of x values for which we
+// obtain accurate results (compared to the naive implementation
+// log(expit(x))).
+//
+template <typename T>
+inline T _log_expit(T x) {
+    if (x < 0.0) {
+        return x - std::log1p(std::exp(x));
+    }
+    else {
+        return -std::log1p(std::exp(-x));
+    }
 };
 
 
@@ -24,5 +50,8 @@ npy_float expitf(npy_float x) {return _expit(x);};
 npy_double expit(npy_double x) {return _expit(x);};
 npy_longdouble expitl(npy_longdouble x) {return _expit(x);};
 
+npy_float log_expitf(npy_float x) {return _log_expit(x);};
+npy_double log_expit(npy_double x) {return _log_expit(x);};
+npy_longdouble log_expitl(npy_longdouble x) {return _log_expit(x);};
 
 #endif

--- a/scipy/special/functions.json
+++ b/scipy/special/functions.json
@@ -914,6 +914,13 @@
             "log1p": "d->d"
         }
     },
+    "log_expit": {
+        "_logit.h++": {
+            "log_expit": "d->d",
+            "log_expitf": "f->f",
+            "log_expitl": "g->g"
+        }
+    },
     "log_ndtr": {
         "_faddeeva.h++": {
             "faddeeva_log_ndtr": "D->D"

--- a/scipy/special/setup.py
+++ b/scipy/special/setup.py
@@ -6,7 +6,8 @@ import subprocess
 import numpy
 from numpy.distutils.misc_util import get_numpy_include_dirs, get_info
 
-from scipy._build_utils.compiler_helper import set_c_flags_hook
+from scipy._build_utils.compiler_helper import (set_c_flags_hook,
+                                                set_cxx_flags_hook)
 
 
 def configuration(parent_package='',top_path=None):
@@ -96,12 +97,13 @@ def configuration(parent_package='',top_path=None):
                       '_wright.cxx', 'wright.cc']
     ufuncs_cxx_dep = (headers + ufuncs_cxx_src + cephes_src
                       + ['*.hh'])
-    config.add_extension('_ufuncs_cxx',
-                         sources=ufuncs_cxx_src,
-                         depends=ufuncs_cxx_dep,
-                         include_dirs=[curdir] + inc_dirs,
-                         define_macros=define_macros,
-                         extra_info=get_info("npymath"))
+    ufuncs_cxx_ext = config.add_extension('_ufuncs_cxx',
+                                          sources=ufuncs_cxx_src,
+                                          depends=ufuncs_cxx_dep,
+                                          include_dirs=[curdir] + inc_dirs,
+                                          define_macros=define_macros,
+                                          extra_info=get_info("npymath"))
+    ufuncs_cxx_ext._pre_build_hook = set_cxx_flags_hook
 
     cfg = combine_dict(lapack_opt, include_dirs=inc_dirs)
     config.add_extension('_ellip_harm_2',

--- a/scipy/special/setup.py
+++ b/scipy/special/setup.py
@@ -92,7 +92,7 @@ def configuration(parent_package='',top_path=None):
     _ufuncs._pre_build_hook = set_c_flags_hook
 
     # Extension _ufuncs_cxx
-    ufuncs_cxx_src = ['_ufuncs_cxx.cxx', 'sf_error.c',
+    ufuncs_cxx_src = ['_ufuncs_cxx.cxx', 'sf_error.cc',
                       '_faddeeva.cxx', 'Faddeeva.cc',
                       '_wright.cxx', 'wright.cc']
     ufuncs_cxx_dep = (headers + ufuncs_cxx_src + cephes_src

--- a/scipy/special/sf_error.cc
+++ b/scipy/special/sf_error.cc
@@ -1,0 +1,10 @@
+#include <Python.h>
+
+#include <stdlib.h>
+#include <stdarg.h>
+
+#include "sf_error.h"
+
+extern "C" {
+#include "sf_error.c"
+}

--- a/scipy/special/tests/test_cython_special.py
+++ b/scipy/special/tests/test_cython_special.py
@@ -185,6 +185,7 @@ PARAMS: List[Tuple[Callable, Callable, Tuple[str, ...], Optional[str]]] = [
     (special.kv, cython_special.kv, ('dd', 'dD'), None),
     (special.kve, cython_special.kve, ('dd', 'dD'), None),
     (special.log1p, cython_special.log1p, ('d', 'D'), None),
+    (special.log_expit, cython_special.log_expit, ('f', 'd', 'g'), None),
     (special.log_ndtr, cython_special.log_ndtr, ('d', 'D'), None),
     (special.ndtri_exp, cython_special.ndtri_exp, ('d',), None),
     (special.loggamma, cython_special.loggamma, ('D',), None),

--- a/scipy/special/tests/test_logit.py
+++ b/scipy/special/tests/test_logit.py
@@ -1,12 +1,12 @@
 import numpy as np
 from numpy.testing import (assert_equal, assert_almost_equal,
-        assert_allclose)
-from scipy.special import logit, expit
+                           assert_allclose)
+from scipy.special import logit, expit, log_expit
 
 
 class TestLogit:
     def check_logit_out(self, dtype, expected):
-        a = np.linspace(0,1,10)
+        a = np.linspace(0, 1, 10)
         a = np.array(a, dtype=dtype)
         with np.errstate(divide='ignore'):
             actual = logit(a)
@@ -41,7 +41,7 @@ class TestLogit:
 
 class TestExpit:
     def check_expit_out(self, dtype, expected):
-        a = np.linspace(-4,4,10)
+        a = np.linspace(-4, 4, 10)
         a = np.array(a, dtype=dtype)
         actual = expit(a)
         assert_almost_equal(actual, expected)
@@ -53,7 +53,7 @@ class TestExpit:
                             0.39068246, 0.60931754,
                             0.79139149, 0.9022274,
                             0.95734876, 0.98201376], dtype=np.float32)
-        self.check_expit_out('f4',expected)
+        self.check_expit_out('f4', expected)
 
     def test_float64(self):
         expected = np.array([0.01798621, 0.04265125,
@@ -71,3 +71,75 @@ class TestExpit:
                 assert_allclose(expit(-n), 0.0, atol=1e-20)
                 assert_equal(expit(n).dtype, dtype)
                 assert_equal(expit(-n).dtype, dtype)
+
+
+class TestLogExpit:
+
+    def test_large_negative(self):
+        x = np.array([-10000.0, -750.0, -500.0, -35.0])
+        y = log_expit(x)
+        assert_equal(y, x)
+
+    def test_large_positive(self):
+        x = np.array([750.0, 1000.0, 10000.0])
+        y = log_expit(x)
+        # y will contain -0.0, and -0.0 is used in the expected value,
+        # but assert_equal does not check the sign of zeros, and I don't
+        # think the sign is an essential part of the test (i.e. it would
+        # probably be OK if log_expit(1000) returned 0.0 instead of -0.0).
+        assert_equal(y, np.array([-0.0, -0.0, -0.0]))
+
+    def test_basic_float64(self):
+        x = np.array([-32, -20, -10, -3, -1, -0.1, -1e-9,
+                      0, 1e-9, 0.1, 1, 10, 100, 500, 710, 725, 735])
+        y = log_expit(x)
+        #
+        # Expected values were computed with mpmath:
+        #
+        #   import mpmath
+        #
+        #   mpmath.mp.dps = 100
+        #
+        #   def mp_log_expit(x):
+        #       return -mpmath.log1p(mpmath.exp(-x))
+        #
+        #   expected = [float(mp_log_expit(t)) for t in x]
+        #
+        expected = [-32.000000000000014, -20.000000002061153,
+                    -10.000045398899218, -3.048587351573742,
+                    -1.3132616875182228, -0.7443966600735709,
+                    -0.6931471810599453, -0.6931471805599453,
+                    -0.6931471800599454, -0.6443966600735709,
+                    -0.3132616875182228, -4.539889921686465e-05,
+                    -3.720075976020836e-44, -7.124576406741286e-218,
+                    -4.47628622567513e-309, -1.36930634e-315,
+                    -6.217e-320]
+
+        # When tested locally, only one value in y was not exactly equal to
+        # expected.  That was for x=1, and the y value differed from the
+        # expected by 1 ULP.  For this test, however, I'll use rtol=1e-15.
+        assert_allclose(y, expected, rtol=1e-15)
+
+    def test_basic_float32(self):
+        x = np.array([-32, -20, -10, -3, -1, -0.1, -1e-9,
+                      0, 1e-9, 0.1, 1, 10, 100], dtype=np.float32)
+        y = log_expit(x)
+        #
+        # Expected values were computed with mpmath:
+        #
+        #   import mpmath
+        #
+        #   mpmath.mp.dps = 100
+        #
+        #   def mp_log_expit(x):
+        #       return -mpmath.log1p(mpmath.exp(-x))
+        #
+        #   expected = [np.float32(mp_log_expit(t)) for t in x]
+        #
+        expected = np.array([-32.0, -20.0, -10.000046, -3.0485873,
+                             -1.3132616, -0.7443967, -0.6931472,
+                             -0.6931472, -0.6931472, -0.64439666,
+                             -0.3132617, -4.5398898e-05, -3.8e-44],
+                            dtype=np.float32)
+
+        assert_allclose(y, expected, rtol=5e-7)

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -5179,11 +5179,17 @@ class logistic_gen(rv_continuous):
     def _cdf(self, x):
         return sc.expit(x)
 
+    def _logcdf(self, x):
+        return sc.log_expit(x)
+
     def _ppf(self, q):
         return sc.logit(q)
 
     def _sf(self, x):
         return sc.expit(-x)
+
+    def _logsf(self, x):
+        return sc.log_expit(-x)
 
     def _isf(self, q):
         return -sc.logit(q)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1249,6 +1249,19 @@ class TestLogistic:
 
         _assert_less_or_close_loglike(stats.logistic, data, func)
 
+    @pytest.mark.parametrize('testlogcdf', [True, False])
+    def test_logcdfsf_tails(self, testlogcdf):
+        # Test either logcdf or logsf.  By symmetry, we can use the same
+        # expected values for both by switching the sign of x for logsf.
+        x = np.array([-10000, -800, 17, 50, 500])
+        if testlogcdf:
+            y = stats.logistic.logcdf(x)
+        else:
+            y = stats.logistic.logsf(-x)
+        # The expected values were computed with mpmath.
+        expected = [-10000.0, -800.0, -4.139937633089748e-08,
+                    -1.9287498479639178e-22, -7.124576406741286e-218]
+        assert_allclose(y, expected, rtol=2e-15)
 
 class TestLogser:
     def setup_method(self):


### PR DESCRIPTION
Add the function `special.log_expit` that computes the logarithm of the logistic sigmoid function.  The function improves the numerical behavior of the `logcdf` and `logsf` methods of `stats.logistic`, and could be used in downstream projects that implement logistic regression, such as the `Logit` class in `statsmodels`.