### PR TITLE
ENH: added Fermi-Dirac distribution by name

### DIFF
--- a/doc/release/1.8.0-notes.rst
+++ b/doc/release/1.8.0-notes.rst
@@ -82,6 +82,10 @@ Sample statistics
 Statistical Distributions
 -------------------------
 
+Added the `fermi_dirac` distribution which is equivalent to the `logistic`.
+For physicists this is clearer since it belongs here. The Fermi-Dirac distribution
+is obtaining through the survival-function: `fermi_dirac.sf(x)`.
+
 
 Other
 -----

--- a/doc/source/tutorial/stats/continuous.rst
+++ b/doc/source/tutorial/stats/continuous.rst
@@ -228,6 +228,7 @@ Continuous Distributions in `scipy.stats`
    continuous_exponweib
    continuous_exponpow
    continuous_fatiguelife
+   continuous_fermi_dirac
    continuous_fisk
    continuous_foldcauchy
    continuous_foldnorm

--- a/doc/source/tutorial/stats/continuous_fermi_dirac.rst
+++ b/doc/source/tutorial/stats/continuous_fermi_dirac.rst
@@ -1,0 +1,34 @@
+
+.. _continuous-fermi-dirac:
+
+Fermi-Dirac Distribution
+========================
+
+Commonly used in physics for the relative occupation of spin-half particles. Physicist
+may recognize the Fermi-Dirac distribution as the survival function of this distribution.
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} f\left(x\right) & = & \frac{\exp\left(-x\right)}{\left(1+\exp\left(-x\right)\right)^{2}}\\
+    F\left(x\right) & = & \frac{1}{1+\exp\left(-x\right)}\\
+    G\left(q\right) & = & -\log\left(1/q-1\right)\\
+    S\left(x\right) & = & n_F = \frac{1}{1+\exp\left(x\right)}\end{eqnarray*}
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} \mu & = & \gamma+\psi_{0}\left(1\right)=0\\
+    \mu_{2} & = & \frac{\pi^{2}}{6}+\psi_{1}\left(1\right)=\frac{\pi^{2}}{3}\\
+    \gamma_{1} & = & \frac{\psi_{2}\left(1\right)+2\zeta\left(3\right)}{\mu_{2}^{3/2}}=0\\
+    \gamma_{2} & = & \frac{\left(\frac{\pi^{4}}{15}+\psi_{3}\left(1\right)\right)}{\mu_{2}^{2}}=\frac{6}{5}\\
+    m_{d} & = & \log1=0\\
+    m_{n} & = & -\log\left(2-1\right)=0\end{eqnarray*}
+
+where :math:`\psi_m` is the polygamma function :math:`\psi_m(z) = \frac{d^{m+1}}{dz^{m+1}} \log(\Gamma(z))`.
+
+.. math::
+
+     h\left[X\right]=1.
+
+Implementation: `scipy.stats.fermi_dirac`

--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -71,6 +71,7 @@ Continuous distributions
    exponpow          -- Exponential Power
    f                 -- F (Snecdor F)
    fatiguelife       -- Fatigue Life (Birnbaum-Saunders)
+   fermi_dirac       -- Fermi-Dirac
    fisk              -- Fisk
    foldcauchy        -- Folded Cauchy
    foldnorm          -- Folded Normal

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -5230,6 +5230,42 @@ class logistic_gen(rv_continuous):
 logistic = logistic_gen(name='logistic')
 
 
+class fermi_dirac_gen(logistic_gen):
+    r"""Fermi-Dirac continuous random variable.
+
+    %(before_notes)s
+
+    Notes
+    -----
+    The probability density function for `fermi_dirac` is:
+
+    .. math::
+
+        f(x) = \frac{\exp(-x)}
+                    {(1+\exp(-x))^2}
+
+    In physics it is better known through the survival function used as:
+
+    .. math::
+
+        S(x) = n_F(x) = \frac{1}{exp(x) + 1}
+
+    To use the physicists Fermi-Dirac distribution one should
+    use `fermi_dirac.sf`.
+
+    `fermi_dirac` is a special case of `genlogistic` with ``c=1``.
+
+    %(after_notes)s
+
+    %(example)s
+
+    """
+    pass
+
+
+fermi_dirac = fermi_dirac_gen(name='fermi_dirac')
+
+
 class loggamma_gen(rv_continuous):
     r"""A log gamma continuous random variable.
 

--- a/scipy/stats/_distr_params.py
+++ b/scipy/stats/_distr_params.py
@@ -27,6 +27,7 @@ distcont = [
     ['exponweib', (2.8923945291034436, 1.9505288745913174)],
     ['f', (29, 18)],
     ['fatiguelife', (29,)],   # correction numargs = 1
+    ['fermi_dirac', ()],
     ['fisk', (3.0857548622253179,)],
     ['foldcauchy', (4.7164673455831894,)],
     ['foldnorm', (1.9521253373555869,)],
@@ -191,6 +192,7 @@ invdistcont = [
     ['exponpow', (-1, )],
     ['f', (10, -10)],
     ['fatiguelife', (-1, )],
+    ['fermi_dirac', ()],
     ['fisk', (-1, )],
     ['foldcauchy', (-1, )],
     ['foldnorm', (-1, )],


### PR DESCRIPTION
The Fermi-Dirac distribution is heavily used in the field of
physics and it is obvious to retain this distribution function here.

It has been unclear to me whether the distribution should be named
differently since the actual Fermi-Dirac distribution as physicists
knows it is the survival function of the logistic distribution.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

It adds the Fermi-Dirac distribution such that physicists may find it naturally here.

#### Additional information
<!--Any additional information you think is important.-->

It may be very non-intuitive for physicists to use `fermi_dirac.sf` to actually get the Fermi-Dirac correct. As such the name is a bit misleading since it does not refer to the probability distribution function. However, I think that just by locating this very important distribution function by name outweighs this *weird* behaviour.
