### PR TITLE
DOC: added Fermi-Dirac distribution by name

### DIFF
--- a/doc/source/tutorial/stats/continuous_genlogistic.rst
+++ b/doc/source/tutorial/stats/continuous_genlogistic.rst
@@ -5,7 +5,7 @@ Generalized Logistic Distribution
 =================================
 
 Has been used in the analysis of extreme values. There is one shape
-parameter :math:`c>0.` The support is :math:`x\geq0`.
+parameter :math:`c>0`. The support is :math:`x \in \mathcal{R}`.
 
 .. math::
    :nowrap:

--- a/doc/source/tutorial/stats/continuous_logistic.rst
+++ b/doc/source/tutorial/stats/continuous_logistic.rst
@@ -4,14 +4,20 @@
 Logistic (Sech-squared) Distribution
 ====================================
 
-A special case of the Generalized Logistic distribution with :math:`c=1.` Defined for :math:`x\geq0`
+A special case of the Generalized Logistic distribution with :math:`c=1`.
+The support is :math:`x \in \mathcal{R}`.
+
+This distribution function has a direct connection with the Fermi-Dirac
+distribution via its survival function. I.e. `scipy.stats.logistic.sf` is
+equivalent to the Fermi-Dirac distribution.
 
 .. math::
    :nowrap:
 
     \begin{eqnarray*} f\left(x\right) & = & \frac{\exp\left(-x\right)}{\left(1+\exp\left(-x\right)\right)^{2}}\\
     F\left(x\right) & = & \frac{1}{1+\exp\left(-x\right)}\\
-    G\left(q\right) & = & -\log\left(1/q-1\right)\end{eqnarray*}
+    G\left(q\right) & = & -\log\left(1/q-1\right)\\
+    S\left(x\right) & = & n_F(x)=\frac{1}{1+\exp\left(x\right)}\end{eqnarray*}
 
 .. math::
    :nowrap:

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -5160,6 +5160,9 @@ class logistic_gen(rv_continuous):
 
     `logistic` is a special case of `genlogistic` with ``c=1``.
 
+    Remark that the survival function (`sf`) is equal to the Fermi-Dirac
+    distribution describing fermionic statistics.
+
     %(after_notes)s
 
     %(example)s


### PR DESCRIPTION
This makes the documentation clearer about the association
of the logistic distribution equalling the Fermi-Dirac distribution
when using the survival function.

Also removed erroneous support limits for genlogistic and logistic.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

Documentation cleaning and enables physicists to recognize the Fermi-Dirac distribution.
Also, removed wrong support in `genlogistic` and `logistic`.

#### Additional information
<!--Any additional information you think is important.-->
