### PR TITLE
MAINT: stats: fix docstring link in `logistic`

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -5160,7 +5160,7 @@ class logistic_gen(rv_continuous):
 
     `logistic` is a special case of `genlogistic` with ``c=1``.
 
-    Remark that the survival function (`sf`) is equal to the Fermi-Dirac
+    Remark that the survival function (``sf``) is equal to the Fermi-Dirac
     distribution describing fermionic statistics.
 
     %(after_notes)s


### PR DESCRIPTION
Use double backticks in stats.logistic docstring to fix the doc build (and stop CIrcleCI "uh-oh"-ing)