### PR TITLE
DOC: fixes typo in equation for Poisson cumulative distribution function (scipy.special.pdtr)

### DIFF
--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -8129,7 +8129,7 @@ add_newdoc("pdtr",
 
     .. math::
 
-       \exp(-m) \sum_{j = 0}^{\lfloor{k}\rfloor} \frac{m^j}{m!}.
+       \exp(-m) \sum_{j = 0}^{\lfloor{k}\rfloor} \frac{m^j}{j!}.
 
     Parameters
     ----------


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
none

#### What does this implement/fix?
Fixes a typo in the doc string equation for the Poisson cumulative distribution function (scipy.special.pdtr) in which the denominator was incorrectly specified as the event rate "m" rather than the number of events "j" for the CDF. 

The C version of the equation has the correct denominator (https://github.com/scipy/scipy/blob/701ffcc8a6f04509d115aac5e5681c538b5265a2/scipy/special/cephes/pdtr.c#L21-L25) 

#### Additional information
It looks like this was just a typo from https://github.com/scipy/scipy/commit/9b23ba26419282e889d861f336623f1723f38a44, the commit diff shows the original docstring had the correct equation 
