### PR TITLE
DOC: Use constrained_layout in Lomb-Scargle example

### DIFF
--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -122,16 +122,15 @@ def lombscargle(x,
 
     Now make a plot of the input data:
 
-    >>> plt.subplot(2, 1, 1)
-    >>> plt.plot(x, y, 'b+')
-    >>> plt.xlabel('Time [s]')
+    >>> fig, (ax_t, ax_w) = plt.subplots(2, 1, constrained_layout=True)
+    >>> ax_t.plot(x, y, 'b+')
+    >>> ax_t.set_xlabel('Time [s]')
 
     Then plot the normalized periodogram:
 
-    >>> plt.subplot(2, 1, 2)
-    >>> plt.plot(w, pgram)
-    >>> plt.xlabel('Angular frequency [rad/s]')
-    >>> plt.ylabel('Normalized amplitude')
+    >>> ax_w.plot(w, pgram)
+    >>> ax_w.set_xlabel('Angular frequency [rad/s]')
+    >>> ax_w.set_ylabel('Normalized amplitude')
     >>> plt.show()
 
     """


### PR DESCRIPTION
The plot axes labels were overlapping

https://github.com/scipy/scipy/pull/15134#issuecomment-983301408

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
