### PR TITLE
ENH: sparse.linalg: Support the functionality of obtaining the initial residual norm through `callback`

### DIFF
--- a/scipy/sparse/linalg/_isolve/_gcrotmk.py
+++ b/scipy/sparse/linalg/_isolve/_gcrotmk.py
@@ -355,12 +355,12 @@ def gcrotmk(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
             x = axpy(u, x, x.shape[0], yc)
             r = axpy(c, r, r.shape[0], -yc)
 
+    # -- initial callback
+    if callback is not None:
+        callback(x)
+
     # GCROT main iteration
     for j_outer in range(maxiter):
-        # -- callback
-        if callback is not None:
-            callback(x)
-
         beta = nrm2(r)
 
         # -- check stopping condition
@@ -443,6 +443,10 @@ def gcrotmk(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
         gamma = dot(cx, r)
         r = axpy(cx, r, r.shape[0], -gamma)  # r -= gamma*cx
         x = axpy(ux, x, x.shape[0], gamma)  # x += gamma*ux
+
+        # -- callback
+        if callback is not None:
+            callback(x)
 
         # Truncate CU
         if truncate == 'oldest':

--- a/scipy/sparse/linalg/_isolve/iterative.py
+++ b/scipy/sparse/linalg/_isolve/iterative.py
@@ -173,6 +173,8 @@ def bicg(A, b, x0=None, tol=1e-5, maxiter=None, M=None, callback=None, atol=None
     info = 0
     ftflag = True
     iter_ = maxiter
+    if callback is not None:
+        callback(x)
     while True:
         olditer = iter_
         x, iter_, resid, info, ndx1, ndx2, sclr1, sclr2, ijob = \
@@ -245,6 +247,8 @@ def bicgstab(A, b, x0=None, tol=1e-5, maxiter=None, M=None, callback=None, atol=
     info = 0
     ftflag = True
     iter_ = maxiter
+    if callback is not None:
+        callback(x)
     while True:
         olditer = iter_
         x, iter_, resid, info, ndx1, ndx2, sclr1, sclr2, ijob = \
@@ -312,6 +316,8 @@ def cg(A, b, x0=None, tol=1e-5, maxiter=None, M=None, callback=None, atol=None):
     info = 0
     ftflag = True
     iter_ = maxiter
+    if callback is not None:
+        callback(x)
     while True:
         olditer = iter_
         x, iter_, resid, info, ndx1, ndx2, sclr1, sclr2, ijob = \
@@ -383,6 +389,8 @@ def cgs(A, b, x0=None, tol=1e-5, maxiter=None, M=None, callback=None, atol=None)
     info = 0
     ftflag = True
     iter_ = maxiter
+    if callback is not None:
+        callback(x)
     while True:
         olditer = iter_
         x, iter_, resid, info, ndx1, ndx2, sclr1, sclr2, ijob = \
@@ -773,6 +781,8 @@ def qmr(A, b, x0=None, tol=1e-5, maxiter=None, M1=None, M2=None, callback=None,
     info = 0
     ftflag = True
     iter_ = maxiter
+    if callback is not None:
+        callback(x)
     while True:
         olditer = iter_
         x, iter_, resid, info, ndx1, ndx2, sclr1, sclr2, ijob = \

--- a/scipy/sparse/linalg/_isolve/lgmres.py
+++ b/scipy/sparse/linalg/_isolve/lgmres.py
@@ -150,12 +150,12 @@ def lgmres(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
 
     ptol_max_factor = 1.0
 
+    # -- initial callback
+    if callback is not None:
+        callback(x)
+
     for k_outer in range(maxiter):
         r_outer = matvec(x) - b
-
-        # -- callback
-        if callback is not None:
-            callback(x)
 
         # -- determine input type routines
         if axpy is None:
@@ -229,6 +229,10 @@ def lgmres(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
 
         # -- Apply step
         x += dx
+
+        # -- callback
+        if callback is not None:
+            callback(x)
     else:
         # didn't converge ...
         return postprocess(x), maxiter

--- a/scipy/sparse/linalg/_isolve/minres.py
+++ b/scipy/sparse/linalg/_isolve/minres.py
@@ -192,6 +192,9 @@ def minres(A, b, x0=None, shift=0.0, tol=1e-5, maxiter=None,
     w2 = zeros(n, dtype=xtype)
     r2 = r1
 
+    if callback is not None:
+        callback(x)
+
     if show:
         print()
         print()

--- a/scipy/sparse/linalg/_isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_iterative.py
@@ -190,8 +190,18 @@ def check_maxiter(solver, case):
 
     x, info = solver(A, b, x0=x0, tol=tol, maxiter=1, callback=callback)
 
-    assert_equal(len(residuals), 1)
+    # Because GMRES includes inner and outer iterations and "callback" is
+    # called only when an outer iteration is performed, "len(residuals)"
+    # equals 1 when "maxiter" equals 1
+    assert_equal(len(residuals), 1 if solver is gmres else 2)
     assert_equal(info, 1)
+
+    # To test the first element of "residuals" is the initial residual norm
+    if solver is gmres:
+        residuals = []
+        x, info = solver(A, b, x0=x0, tol=tol, maxiter=2, callback=callback,
+                         callback_type='x')
+    assert_equal(residuals[0], norm(b - A@x0))
 
 
 def test_maxiter():

--- a/scipy/sparse/linalg/_isolve/tfqmr.py
+++ b/scipy/sparse/linalg/_isolve/tfqmr.py
@@ -132,6 +132,10 @@ def tfqmr(A, b, x0=None, tol=1e-5, maxiter=None, M=None,
     else:
         atol = max(atol, tol * r0norm)
 
+    if callback is not None:
+        callback(x)
+
+    # TFQMR iteration
     for iter in range(maxiter):
         even = iter % 2 == 0
         if (even):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Fixed #13936

#### What does this implement/fix?
<!--Please explain your changes.-->
We find the initial residual norm is lost when solving linear systems by Krylov methods and calling `callback ` to get residual norms. The PR supplements this information so that users can get a complete convergence history.

#### Additional information
<!--Any additional information you think is important.-->
