### PR TITLE
ENH: stats.sampling: add SROU method

### DIFF
--- a/benchmarks/benchmarks/stats_sampling.py
+++ b/benchmarks/benchmarks/stats_sampling.py
@@ -4,11 +4,16 @@ from .common import Benchmark, safe_import
 with safe_import():
     from scipy import stats
 with safe_import():
+    from scipy.stats import sampling
+with safe_import():
     from scipy import special
 
 
 # Beta distribution with a = 2, b = 3
 class contdist1:
+    def __init__(self):
+        self.mode = 1/3
+
     def pdf(self, x):
         return 12 * x * (1-x)**2
 
@@ -28,6 +33,9 @@ class contdist1:
 
 # Standard Normal Distribution
 class contdist2:
+    def __init__(self):
+        self.mode = 0
+
     def pdf(self, x):
         return 1./np.sqrt(2*np.pi) * np.exp(-0.5 * x*x)
 
@@ -46,6 +54,7 @@ class contdist2:
 class contdist3:
     def __init__(self, shift=0.):
         self.shift = shift
+        self.mode = shift
 
     def pdf(self, x):
         x -= self.shift
@@ -74,6 +83,9 @@ class contdist3:
 #          \  0        otherwise
 # Taken from UNU.RAN test suite (from file t_pinv.c)
 class contdist4:
+    def __init__(self):
+        self.mode = 0
+
     def pdf(self, x):
         return 0.05 + 0.45 * (1 + np.sin(2*np.pi*x))
 
@@ -98,6 +110,9 @@ class contdist4:
 #          \  0        otherwise
 # Taken from UNU.RAN test suite (from file t_pinv.c)
 class contdist5:
+    def __init__(self):
+        self.mode = 0
+
     def pdf(self, x):
         return 0.2 * (0.05 + 0.45 * (1 + np.sin(2*np.pi*x)))
 
@@ -130,21 +145,57 @@ class TransformedDensityRejection(Benchmark):
         with np.testing.suppress_warnings() as sup:
             sup.filter(RuntimeWarning)
             try:
-                self.rng = stats.TransformedDensityRejection(
+                self.rng = sampling.TransformedDensityRejection(
                     dist, c=c, random_state=self.urng
                 )
-            except stats.UNURANError:
+            except sampling.UNURANError:
                 # contdist3 is not T-concave for c=0. So, skip such test-cases
                 raise NotImplementedError(f"{dist} not T-concave for c={c}")
 
     def time_tdr_setup(self, dist, c):
         with np.testing.suppress_warnings() as sup:
             sup.filter(RuntimeWarning)
-            stats.TransformedDensityRejection(
+            sampling.TransformedDensityRejection(
                 dist, c=c, random_state=self.urng
             )
 
     def time_tdr_rvs(self, dist, c):
+        self.rng.rvs(100000)
+
+
+class SimpleRatioUniforms(Benchmark):
+
+    param_names = ['dist', 'cdf_at_mode']
+
+    params = [allcontdists, [0, 1]]
+
+    def setup(self, dist, cdf_at_mode):
+        self.urng = np.random.default_rng(0xfaad7df1c89e050200dbe258636b3265)
+        try:
+            if cdf_at_mode:
+                cdf_at_mode = dist.cdf(dist.mode)
+            else:
+                cdf_at_mode = None
+            self.rng = sampling.SimpleRatioUniforms(
+                dist, mode=dist.mode,
+                cdf_at_mode=cdf_at_mode,
+                random_state=self.urng
+            )
+        except sampling.UNURANError:
+            raise NotImplementedError("{dist} not T-concave")
+
+    def time_srou_setup(self, dist, cdf_at_mode):
+        if cdf_at_mode:
+            cdf_at_mode = dist.cdf(dist.mode)
+        else:
+            cdf_at_mode = None
+        sampling.SimpleRatioUniforms(
+            dist, mode=dist.mode,
+            cdf_at_mode=cdf_at_mode,
+            random_state=self.urng
+        )
+
+    def time_srou_rvs(self, dist, cdf_at_mode):
         self.rng.rvs(100000)
 
 
@@ -159,16 +210,16 @@ class NumericalInversePolynomial(Benchmark):
         with np.testing.suppress_warnings() as sup:
             sup.filter(RuntimeWarning)
             try:
-                self.rng = stats.NumericalInversePolynomial(
+                self.rng = sampling.NumericalInversePolynomial(
                     dist, random_state=self.urng
                 )
-            except stats.UNURANError:
+            except sampling.UNURANError:
                 raise NotImplementedError(f"setup failed for {dist}")
 
     def time_pinv_setup(self, dist):
         with np.testing.suppress_warnings() as sup:
             sup.filter(RuntimeWarning)
-            stats.NumericalInversePolynomial(
+            sampling.NumericalInversePolynomial(
                 dist, random_state=self.urng
             )
 
@@ -186,16 +237,16 @@ class NumericalInverseHermite(Benchmark):
         with np.testing.suppress_warnings() as sup:
             sup.filter(RuntimeWarning)
             try:
-                self.rng = stats.NumericalInverseHermite(
+                self.rng = sampling.NumericalInverseHermite(
                     dist, order=order, random_state=self.urng
                 )
-            except stats.UNURANError:
+            except sampling.UNURANError:
                 raise NotImplementedError(f"setup failed for {dist}")
 
     def time_hinv_setup(self, dist, order):
         with np.testing.suppress_warnings() as sup:
             sup.filter(RuntimeWarning)
-            stats.NumericalInverseHermite(
+            sampling.NumericalInverseHermite(
                 dist, order=order, random_state=self.urng
             )
 
@@ -222,10 +273,10 @@ class DiscreteAliasUrn(Benchmark):
         self.urng = np.random.default_rng(0x2fc9eb71cd5120352fa31b7a048aa867)
         x = np.arange(domain[0], domain[1] + 1)
         self.pv = dist.pmf(x, *params)
-        self.rng = stats.DiscreteAliasUrn(self.pv, random_state=self.urng)
+        self.rng = sampling.DiscreteAliasUrn(self.pv, random_state=self.urng)
 
     def time_dau_setup(self, distribution):
-        stats.DiscreteAliasUrn(self.pv, random_state=self.urng)
+        sampling.DiscreteAliasUrn(self.pv, random_state=self.urng)
 
     def time_dau_rvs(self, distribution):
         self.rng.rvs(100000)
@@ -250,10 +301,10 @@ class DiscreteGuideTable(Benchmark):
         self.urng = np.random.default_rng(0x2fc9eb71cd5120352fa31b7a048aa867)
         x = np.arange(domain[0], domain[1] + 1)
         self.pv = dist.pmf(x, *params)
-        self.rng = stats.DiscreteGuideTable(self.pv, random_state=self.urng)
+        self.rng = sampling.DiscreteGuideTable(self.pv, random_state=self.urng)
 
     def time_dgt_setup(self, distribution):
-        stats.DiscreteGuideTable(self.pv, random_state=self.urng)
+        sampling.DiscreteGuideTable(self.pv, random_state=self.urng)
 
     def time_dgt_rvs(self, distribution):
         self.rng.rvs(100000)

--- a/doc/source/tutorial/stats/sampling.rst
+++ b/doc/source/tutorial/stats/sampling.rst
@@ -85,6 +85,7 @@ Methods for continuous distributions   Required Inputs  Optional Inputs  Setup S
 :class:`~TransformedDensityRejection`  pdf, dpdf        none             slow         fast
 :class:`~NumericalInverseHermite`      cdf              pdf, dpdf        (very) slow  (very) fast
 :class:`~NumericalInversePolynomial`   pdf              cdf              (very) slow  (very) fast
+:class:`~SimpleRatioUniforms`          pdf              none             fast         slow
 =====================================  ===============  ===============  ===========  ==============
 
 where
@@ -293,6 +294,7 @@ Generators in :mod:`scipy.stats.sampling`
    sampling_pinv
    sampling_dgt
    sampling_hinv
+   sampling_srou
 
 
 References

--- a/doc/source/tutorial/stats/sampling_srou.rst
+++ b/doc/source/tutorial/stats/sampling_srou.rst
@@ -6,7 +6,7 @@ Simple Ratio-of-Uniforms (SROU)
 .. currentmodule:: scipy.stats.sampling
 
 * Required: PDF, area under PDF if different than 1
-* Optional: mode
+* Optional: mode, CDF at mode
 * Speed:
 
   * Set-up: fast
@@ -76,6 +76,34 @@ its histogram:
     >>> ax.set_title('Simple Ratio-of-Uniforms Samples')
     >>> ax.legend()
     >>> plt.show()
+
+The main advantage of the method is a fast setup. This can be beneficial if one
+repeatedly needs to generate small to moderate samples of a distribution with
+different shape parameters. In such a situation, the setup step of
+`sampling.NumericalInverseHermite` or `sampling.NumericalInversePolynomial` will
+lead to poor performance. As an example, assume we are interested to generate
+100 samples for the Gamma distribution with 1000 different shape parameters
+given by `np.arange(1.5, 5, 1000)`.
+
+    >>> import math
+    >>> class GammaDist:
+    ...     def __init__(self, p):
+    ...         self.p = p
+    ...     def pdf(self, x):
+    ...         return x**(self.p-1) * np.exp(-x)
+    ...
+    >>> urng = np.random.default_rng()
+    >>> p = np.arange(1.5, 5, 1000)
+    >>> res = np.empty((1000, 100))
+    >>> for i in range(1000):
+    ...     dist = GammaDist(p[i])
+    ...     rng = SimpleRatioUniforms(dist, mode=p[i]-1,
+    ...                               pdf_area=math.gamma(p[i]),
+    ...                               random_state=urng)
+    ...     with np.suppress_warnings() as sup:
+    ...         sup.filter(RuntimeWarning, "invalid value encountered in double_scalars")
+    ...         sup.filter(RuntimeWarning, "overflow encountered in exp")
+    ...         res[i] = rng.rvs(100)
 
 See [1]_, [2]_, and [3]_ for more details.
 

--- a/doc/source/tutorial/stats/sampling_srou.rst
+++ b/doc/source/tutorial/stats/sampling_srou.rst
@@ -5,7 +5,7 @@ Simple Ratio-of-Uniforms (SROU)
 
 .. currentmodule:: scipy.stats.sampling
 
-* Required: PDF, area under PDF
+* Required: PDF, area under PDF if different than 1
 * Optional: mode
 * Speed:
 
@@ -68,12 +68,13 @@ its histogram:
     >>> rvs = rng.rvs(1000)
     >>> x = np.linspace(rvs.min()-0.1, rvs.max()+0.1, 1000)
     >>> fx = 1/np.sqrt(2*np.pi) * dist.pdf(x)
-    >>> plt.plot(x, fx, 'r-', lw=2, label='true distribution')
-    >>> plt.hist(rvs, bins=10, density=True, alpha=0.8, label='random variates')
-    >>> plt.xlabel('x')
-    >>> plt.ylabel('PDF(x)')
-    >>> plt.title('Simple Ratio-of-Uniforms Samples')
-    >>> plt.legend()
+    >>> fig, ax = plt.subplots()
+    >>> ax.plot(x, fx, 'r-', lw=2, label='true distribution')
+    >>> ax.hist(rvs, bins=10, density=True, alpha=0.8, label='random variates')
+    >>> ax.set_xlabel('x')
+    >>> ax.set_ylabel('PDF(x)')
+    >>> ax.set_title('Simple Ratio-of-Uniforms Samples')
+    >>> ax.legend()
     >>> plt.show()
 
 See [1]_, [2]_, and [3]_ for more details.

--- a/scipy/stats/_unuran/unuran_wrapper.pyi
+++ b/scipy/stats/_unuran/unuran_wrapper.pyi
@@ -55,6 +55,26 @@ class TransformedDensityRejection(Method):
     def ppf_hat(self, u: npt.ArrayLike) -> np.ndarray: ...
 
 
+class SROUDist(Protocol):
+    @property
+    def pdf(self) -> Callable[..., float]: ...
+    @property
+    def support(self) -> Tuple[float, float]: ...
+
+
+class SimpleRatioUniforms(Method):
+    def __init__(self,
+                 dist: SROUDist,
+                 *,
+                 mode: None | float = ...,
+                 pdf_area: float = ...,
+                 domain: None | Tuple[float, float] = ...,
+                 r: float = ...,
+                 cdf_at_mode: float = ...,
+                 use_squeeze: bool = ...,
+                 random_state: SeedType = ...) -> None: ...
+
+
 UError = NamedTuple('UError', [('max_error', float),
                                ('mean_absolute_error', float)])
 

--- a/scipy/stats/_unuran/unuran_wrapper.pyi
+++ b/scipy/stats/_unuran/unuran_wrapper.pyi
@@ -69,9 +69,7 @@ class SimpleRatioUniforms(Method):
                  mode: None | float = ...,
                  pdf_area: float = ...,
                  domain: None | Tuple[float, float] = ...,
-                 r: float = ...,
                  cdf_at_mode: float = ...,
-                 use_squeeze: bool = ...,
                  random_state: SeedType = ...) -> None: ...
 
 

--- a/scipy/stats/_unuran/unuran_wrapper.pyx.templ
+++ b/scipy/stats/_unuran/unuran_wrapper.pyx.templ
@@ -976,7 +976,7 @@ cdef class SimpleRatioUniforms(Method):
     Simple Ratio-of-Uniforms (SROU) Method.
 
     SROU is based on the ratio-of-uniforms method that uses universal inequalities for constructing
-    a (universal) bounding rectangle. It works for T-concave distributions with T(x) = -1/sqrt(x).
+    a (universal) bounding rectangle. It works for T-concave distributions with ``T(x) = -1/sqrt(x)``.
 
     Parameters
     ----------
@@ -987,7 +987,8 @@ cdef class SimpleRatioUniforms(Method):
           expected to be: ``def pdf(self, x: float) -> float``. i.e.
           the PDF should accept a Python float and
           return a Python float. It doesn't need to integrate to 1 i.e.
-          the PDF doesn't need to be normalized.
+          the PDF doesn't need to be normalized. If not normalized, `pdf_area`
+          should be set to the area under the PDF.
 
     mode : float, optional
         (Exact) Mode of the distribution. When the mode is ``None``, a slow
@@ -1071,12 +1072,13 @@ cdef class SimpleRatioUniforms(Method):
     >>> import matplotlib.pyplot as plt
     >>> x = np.linspace(rvs.min()-0.1, rvs.max()+0.1, 1000)
     >>> fx = 1/np.sqrt(2*np.pi) * dist.pdf(x)
-    >>> plt.plot(x, fx, 'r-', lw=2, label='true distribution')
-    >>> plt.hist(rvs, bins=10, density=True, alpha=0.8, label='random variates')
-    >>> plt.xlabel('x')
-    >>> plt.ylabel('PDF(x)')
-    >>> plt.title('Simple Ratio-of-Uniforms Samples')
-    >>> plt.legend()
+    >>> fig, ax = plt.subplots()
+    >>> ax.plot(x, fx, 'r-', lw=2, label='true distribution')
+    >>> ax.hist(rvs, bins=10, density=True, alpha=0.8, label='random variates')
+    >>> ax.set_xlabel('x')
+    >>> ax.set_ylabel('PDF(x)')
+    >>> ax.set_title('Simple Ratio-of-Uniforms Samples')
+    >>> ax.legend()
     >>> plt.show()
     """
 

--- a/scipy/stats/_unuran/unuran_wrapper.pyx.templ
+++ b/scipy/stats/_unuran/unuran_wrapper.pyx.templ
@@ -969,6 +969,185 @@ cdef class TransformedDensityRejection(Method):
         return np.asarray(out).reshape(oshape)[()]
 
 
+cdef class SimpleRatioUniforms(Method):
+    r"""
+    SimpleRatioUniforms(dist, *, mode=None, pdf_area=1, domain=None, cdf_at_mode=None, random_state=None)
+
+    Simple Ratio-of-Uniforms (SROU) Method.
+
+    SROU is based on the ratio-of-uniforms method that uses universal inequalities for constructing
+    a (universal) bounding rectangle. It works for T-concave distributions with T(x) = -1/sqrt(x).
+
+    Parameters
+    ----------
+    dist : object
+        An instance of a class with ``pdf`` method.
+
+        * ``pdf``: PDF of the distribution. The signature of the PDF is
+          expected to be: ``def pdf(self, x: float) -> float``. i.e.
+          the PDF should accept a Python float and
+          return a Python float. It doesn't need to integrate to 1 i.e.
+          the PDF doesn't need to be normalized.
+
+    mode : float, optional
+        (Exact) Mode of the distribution. When the mode is ``None``, a slow
+        numerical routine is used to approximate it. Default is ``None``.
+    pdf_area : float, optional
+        Area under the PDF. Optionally, an upper bound to the area under
+        the PDF can be passed at the cost of increased rejection constant.
+        Default is 1.
+    domain : list or tuple of length 2, optional
+        The support of the distribution.
+        Default is ``None``. When ``None``:
+
+        * If a ``support`` method is provided by the distribution object
+          `dist`, it is used to set the domain of the distribution.
+        * Otherwise the support is assumed to be :math:`(-\infty, \infty)`.
+
+    cdf_at_mode : float, optional
+        CDF at the mode. It can be given to increase the performance of the
+        algorithm. The rejection constant is halfed when CDF at mode is given.
+        Default is ``None``.
+    random_state : {None, int, `numpy.random.Generator`,
+                        `numpy.random.RandomState`}, optional
+
+        A NumPy random number generator or seed for the underlying NumPy random
+        number generator used to generate the stream of uniform random numbers.
+        If `random_state` is None (or `np.random`), the `numpy.random.RandomState`
+        singleton is used.
+        If `random_state` is an int, a new ``RandomState`` instance is used,
+        seeded with `random_state`.
+        If `random_state` is already a ``Generator`` or ``RandomState`` instance then
+        that instance is used.
+
+    References
+    ----------
+    .. [1] UNU.RAN reference manual, Section 5.3.16,
+           "SROU - Simple Ratio-of-Uniforms method",
+           http://statmath.wu.ac.at/software/unuran/doc/unuran.html#SROU
+    .. [2] Leydold, Josef. "A simple universal generator for continuous and
+           discrete univariate T-concave distributions." ACM Transactions on
+           Mathematical Software (TOMS) 27.1 (2001): 66-82
+    .. [3] Leydold, Josef. "Short universal generators via generalized ratio-of-uniforms
+           method." Mathematics of Computation 72.243 (2003): 1453-1471
+
+    Examples
+    --------
+    >>> from scipy.stats.sampling import SimpleRatioUniforms
+
+    Suppose we have the normal distribution:
+
+    >>> class StdNorm:
+    ...     def pdf(self, x):
+    ...         return np.exp(-0.5 * x**2)
+
+    Notice that the PDF doesn't integrate to 1. We can either pass the exact
+    area under the PDF during initialization of the generator or an upper
+    bound to the exact area under the PDF. Also, it is recommended to pass
+    the mode of the distribution to speed up the setup:
+
+    >>> urng = np.random.default_rng()
+    >>> dist = StdNorm()
+    >>> rng = SimpleRatioUniforms(dist, mode=0,
+    ...                           pdf_area=np.sqrt(2*np.pi),
+    ...                           random_state=urng)
+
+    Now, we can use the `rvs` method to generate samples from the distribution:
+
+    >>> rvs = rng.rvs(10)
+
+    If the CDF at mode is avaialble, it can be set to improve the performace of `rvs`:
+
+    >>> from scipy.stats import norm
+    >>> rng = SimpleRatioUniforms(dist, mode=0,
+    ...                           pdf_area=np.sqrt(2*np.pi),
+    ...                           cdf_at_mode=norm.cdf(0),
+    ...                           random_state=urng)
+    >>> rvs = rng.rvs(1000)
+
+    We can check that the samples are from the given distribution by visualizing
+    its histogram:
+
+    >>> import matplotlib.pyplot as plt
+    >>> x = np.linspace(rvs.min()-0.1, rvs.max()+0.1, 1000)
+    >>> fx = 1/np.sqrt(2*np.pi) * dist.pdf(x)
+    >>> plt.plot(x, fx, 'r-', lw=2, label='true distribution')
+    >>> plt.hist(rvs, bins=10, density=True, alpha=0.8, label='random variates')
+    >>> plt.xlabel('x')
+    >>> plt.ylabel('PDF(x)')
+    >>> plt.title('Simple Ratio-of-Uniforms Samples')
+    >>> plt.legend()
+    >>> plt.show()
+    """
+
+    def __cinit__(self,
+                  dist,
+                  *,
+                  mode=None,
+                  pdf_area=1,
+                  domain=None,
+                  cdf_at_mode=None,
+                  random_state=None):
+        (domain, pdf_area) = self._validate_args(dist, domain, pdf_area)
+
+        # save all the arguments for pickling support
+        self._kwargs = {
+            'dist': dist,
+            'mode': mode,
+            'pdf_area': pdf_area,
+            'domain': domain,
+            'cdf_at_mode': cdf_at_mode,
+            'random_state': random_state
+        }
+
+        cdef:
+            unur_distr *distr
+            unur_par *par
+            unur_gen *rng
+
+        self.callbacks = _unpack_dist(dist, "cont", meths=["pdf"])
+        def _callback_wrapper(x, name):
+            return self.callbacks[name](x)
+        self._callback_wrapper = _callback_wrapper
+        self._messages = MessageStream()
+        _lock.acquire()
+        try:
+            unur_set_stream(self._messages.handle)
+
+            self.distr = unur_distr_cont_new()
+            if self.distr == NULL:
+                raise UNURANError(self._messages.get())
+            _pack_distr(self.distr, self.callbacks)
+
+            if mode is not None:
+                self._check_errorcode(unur_distr_cont_set_mode(self.distr, mode))
+            self._check_errorcode(unur_distr_cont_set_pdfarea(self.distr, pdf_area))
+
+            if domain is not None:
+                self._check_errorcode(unur_distr_cont_set_domain(self.distr, domain[0],
+                                                                 domain[1]))
+
+            self.par = unur_srou_new(self.distr)
+            if self.par == NULL:
+                raise UNURANError(self._messages.get())
+
+            if cdf_at_mode is not None:
+                self._check_errorcode(unur_srou_set_cdfatmode(self.par, cdf_at_mode))
+                # Always use squeeze when CDF at mode is given to improve performance
+                self._check_errorcode(unur_srou_set_usesqueeze(self.par, True))
+
+            self._set_rng(random_state)
+        finally:
+            _lock.release()
+
+    cdef object _validate_args(self, dist, domain, pdf_area):
+        # validate args
+        domain = _validate_domain(domain, dist)
+        if pdf_area < 0:
+            raise ValueError("`pdf_area` must be > 0")
+        return domain, pdf_area
+
+
 UError = namedtuple('UError', ['max_error', 'mean_absolute_error'])
 
 

--- a/scipy/stats/_unuran/unuran_wrapper.pyx.templ
+++ b/scipy/stats/_unuran/unuran_wrapper.pyx.templ
@@ -1121,11 +1121,11 @@ cdef class SimpleRatioUniforms(Method):
 
             if mode is not None:
                 self._check_errorcode(unur_distr_cont_set_mode(self.distr, mode))
-            self._check_errorcode(unur_distr_cont_set_pdfarea(self.distr, pdf_area))
 
             if domain is not None:
                 self._check_errorcode(unur_distr_cont_set_domain(self.distr, domain[0],
                                                                  domain[1]))
+            self._check_errorcode(unur_distr_cont_set_pdfarea(self.distr, pdf_area))
 
             self.par = unur_srou_new(self.distr)
             if self.par == NULL:

--- a/scipy/stats/_unuran/unuran_wrapper.pyx.templ
+++ b/scipy/stats/_unuran/unuran_wrapper.pyx.templ
@@ -975,8 +975,12 @@ cdef class SimpleRatioUniforms(Method):
 
     Simple Ratio-of-Uniforms (SROU) Method.
 
-    SROU is based on the ratio-of-uniforms method that uses universal inequalities for constructing
-    a (universal) bounding rectangle. It works for T-concave distributions with ``T(x) = -1/sqrt(x)``.
+    SROU is based on the ratio-of-uniforms method that uses universal inequalities for
+    constructing a (universal) bounding rectangle. It works for T-concave distributions
+    with ``T(x) = -1/sqrt(x)``. The main advantage of the method is a fast setup. This
+    can be beneficial if one repeatedly needs to generate small to moderate samples of
+    a distribution with different shape parameters. In such a situation, the setup step of
+    `NumericalInverseHermite` or `NumericalInversePolynomial` will lead to poor performance.
 
     Parameters
     ----------

--- a/scipy/stats/sampling.py
+++ b/scipy/stats/sampling.py
@@ -21,6 +21,7 @@ For continuous distributions
    NumericalInverseHermite
    NumericalInversePolynomial
    TransformedDensityRejection
+   SimpleRatioUniforms
 
 For discrete distributions
 --------------------------
@@ -45,5 +46,6 @@ from ._unuran.unuran_wrapper import (  # noqa: F401
     DiscreteGuideTable,
     NumericalInversePolynomial,
     NumericalInverseHermite,
+    SimpleRatioUniforms,
     UNURANError
 )

--- a/scipy/stats/tests/test_sampling.py
+++ b/scipy/stats/tests/test_sampling.py
@@ -13,6 +13,7 @@ from scipy.stats.sampling import (
     DiscreteGuideTable,
     NumericalInversePolynomial,
     NumericalInverseHermite,
+    SimpleRatioUniforms,
     UNURANError
 )
 from scipy import stats
@@ -43,7 +44,8 @@ all_methods = [
     ("DiscreteAliasUrn", {"dist": [0.02, 0.18, 0.8]}),
     ("DiscreteGuideTable", {"dist": [0.02, 0.18, 0.8]}),
     ("NumericalInversePolynomial", {"dist": StandardNormal()}),
-    ("NumericalInverseHermite", {"dist": StandardNormal()})
+    ("NumericalInverseHermite", {"dist": StandardNormal()}),
+    ("SimpleRatioUniforms", {"dist": StandardNormal(), "mode": 0})
 ]
 
 # Make sure an internal error occurs in UNU.RAN when invalid callbacks are
@@ -1238,16 +1240,52 @@ class TestDiscreteGuideTable:
             DiscreteGuideTable(stats.binom(10, 0.2), domain=domain)
 
 
-class Gamma:
-    def __init__(self, p):
-        self.p = p
+class TestSimpleRatioUniforms:
+    # pdf with piecewise linear function as transformed density
+    # with T = -1/sqrt with shift. Taken from UNU.RAN test suite
+    # (from file t_srou.c)
+    class dist:
+        def __init__(self, shift):
+            self.shift = shift
+            self.mode = shift
 
-    def pdf(self, x):
-        return x**(self.p - 1) * math.exp(-x)
+        def pdf(self, x):
+            x -= self.shift
+            y = 1. / (abs(x) + 1.)
+            return 0.5 * y * y
 
-    def cdf(self, x):
-        return stats.gamma.cdf(x, self.p)
+        def cdf(self, x):
+            x -= self.shift
+            if x <= 0.:
+                return 0.5 / (1. - x)
+            else:
+                return 1. - 0.5 / (1. + x)
 
-    @staticmethod
-    def support():
-        return 0, np.inf
+    dists = [dist(0.), dist(10000.)]
+
+    # exact mean and variance of the distributions in the list dists
+    mv1 = [0., np.inf]
+    mv2 = [10000., np.inf]
+    mvs = [mv1, mv2]
+
+    @pytest.mark.parametrize("dist, mv_ex",
+                             zip(dists, mvs))
+    def test_basic(self, dist, mv_ex):
+        rng = SimpleRatioUniforms(dist, mode=dist.mode, random_state=42)
+        check_cont_samples(rng, dist, mv_ex)
+        rng = SimpleRatioUniforms(dist, mode=dist.mode,
+                                  cdf_at_mode=dist.cdf(dist.mode),
+                                  random_state=42)
+        check_cont_samples(rng, dist, mv_ex)
+
+    # test domains with inf + nan in them. need to write a custom test for
+    # this because not all methods support infinite tails.
+    @pytest.mark.parametrize("domain, err, msg", inf_nan_domains)
+    def test_inf_nan_domains(self, domain, err, msg):
+        with pytest.raises(err, match=msg):
+            SimpleRatioUniforms(StandardNormal(), domain=domain)
+
+    def test_bad_args(self):
+        # pdf_area < 0
+        with pytest.raises(ValueError, match=r"`pdf_area` must be > 0"):
+            SimpleRatioUniforms(StandardNormal(), mode=0, pdf_area=-1)


### PR DESCRIPTION
#### Reference issue

gh-14600

#### What does this implement/fix?

This PR adds Simple Ratio-of-Uniforms method to sample random variates from
continuous distributions. It can be used for the varying-parameter case as it
has a fast setup but slow generation times. As no other methods in sampling
have a fast setup, this would be a nice addition. Basic documentation and a tutorial
have also been added.