### PR TITLE
DOC: a small bug in docstring example of `lobpcg`

### DIFF
--- a/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
@@ -243,16 +243,16 @@ def lobpcg(
     >>> import numpy as np
     >>> from scipy.sparse import spdiags, issparse
     >>> from scipy.sparse.linalg import lobpcg, LinearOperator
-    
-    The marix size: 
-    
+
+    The marix size:
+
     >>> n = 100
     >>> vals = np.arange(1, n + 1)
-    
+
     The first mandatory input parameter, in this test
     a sparse 2D array representing the square matrix
     of the eigenvalue problem to solve:
-    
+
     >>> A = spdiags(vals, 0, n, n)
     >>> A.toarray()
     array([[  1.,   0.,   0., ...,   0.,   0.,   0.],
@@ -274,7 +274,7 @@ def lobpcg(
     >>> X = rng.normal(size=(n, 3))
 
     Constraints - an optional input parameter is a 2D array comprising
-    of column vectors that the eigenvectors must be orthogonal to: 
+    of column vectors that the eigenvectors must be orthogonal to:
 
     >>> Y = np.eye(n, 3)
 

--- a/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
@@ -260,10 +260,14 @@ def lobpcg(
     >>> Y = np.eye(n, 3)
 
     Initial guess for eigenvectors, should have linearly independent
-    columns. Column dimension = number of requested eigenvalues.
+    columns. One of mandatory input parameters, a 2D array with the
+    column dimension determining the number of requested eigenvalues.
+    If no initial approximations available, randomly oriented vectors
+    commonly work best, e.g., with components normally disrtibuted
+    around zero or uniformly distributed on the interval [-1 1].
 
     >>> rng = np.random.default_rng()
-    >>> X = rng.random((n, 3))
+    >>> X = rng.normal(size=(n, 3))
 
     Preconditioner in the inverse of A in this example:
 

--- a/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
@@ -243,8 +243,16 @@ def lobpcg(
     >>> import numpy as np
     >>> from scipy.sparse import spdiags, issparse
     >>> from scipy.sparse.linalg import lobpcg, LinearOperator
+    
+    The marix size: 
+    
     >>> n = 100
     >>> vals = np.arange(1, n + 1)
+    
+    The first mandatory input parameter, in this test
+    a sparse 2D array representing the square matrix
+    of the eigenvalue problem to solve:
+    
     >>> A = spdiags(vals, 0, n, n)
     >>> A.toarray()
     array([[  1.,   0.,   0., ...,   0.,   0.,   0.],
@@ -255,19 +263,20 @@ def lobpcg(
            [  0.,   0.,   0., ...,   0.,  99.,   0.],
            [  0.,   0.,   0., ...,   0.,   0., 100.]])
 
-    Constraints:
-
-    >>> Y = np.eye(n, 3)
-
     Initial guess for eigenvectors, should have linearly independent
-    columns. One of mandatory input parameters, a 2D array with the
-    column dimension determining the number of requested eigenvalues.
+    columns. The second mandatory input parameter, a 2D array with the
+    row dimension determining the number of requested eigenvalues.
     If no initial approximations available, randomly oriented vectors
     commonly work best, e.g., with components normally disrtibuted
     around zero or uniformly distributed on the interval [-1 1].
 
     >>> rng = np.random.default_rng()
     >>> X = rng.normal(size=(n, 3))
+
+    Constraints - an optional input parameter is a 2D array comprising
+    of column vectors that the eigenvectors must be orthogonal to: 
+
+    >>> Y = np.eye(n, 3)
 
     Preconditioner in the inverse of A in this example:
 

--- a/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
@@ -244,7 +244,7 @@ def lobpcg(
     >>> from scipy.sparse import spdiags, issparse
     >>> from scipy.sparse.linalg import lobpcg, LinearOperator
 
-    The marix size:
+    The square matrix size:
 
     >>> n = 100
     >>> vals = np.arange(1, n + 1)


### PR DESCRIPTION
Updating lobpcg docsting example and comments to underscore that components of the initial vectors better be on both sides of zero, rather than uniformly distributed on the interval `[0, 1]`

#### Reference issue
N/A, but see related #15152

#### What does this implement/fix?
Changes the components of the initial vectors in the docstring example from uniformly distributed on the interval `[0, 1]` to normal around zero, and updates the comment accordingly. 

#### Additional information
A trivial but important change not requiring unit tests. 

Common sense suggest that vectors with only positive components cover the positive quadrant only, not the whole vector space, are not so good to approximate eigenvectors. All examples in the original MATLAB/Octave code, written for the 2001 paper, https://github.com/lobpcg/blopex/blob/master/blopex_tools/matlab/lobpcg/lobpcg.m use randn, e.g., line 97.
