### PR TITLE
ENH: rebased version of gh-14279

### DIFF
--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -563,9 +563,6 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
     if meth == 'cobyla' and bounds is not None:
         warn('Method %s cannot handle bounds.' % method,
              RuntimeWarning)
-    # - callback
-    if (meth in ('cobyla',) and callback is not None):
-        warn('Method %s does not support callback.' % method, RuntimeWarning)
     # - return_all
     if (meth in ('l-bfgs-b', 'tnc', 'cobyla', 'slsqp') and
             options.get('return_all', False)):
@@ -687,7 +684,8 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
         res = _minimize_tnc(fun, x0, args, jac, bounds, callback=callback,
                             **options)
     elif meth == 'cobyla':
-        res = _minimize_cobyla(fun, x0, args, constraints, **options)
+        res = _minimize_cobyla(fun, x0, args, constraints, callback=callback,
+                                **options)
     elif meth == 'slsqp':
         res = _minimize_slsqp(fun, x0, args, jac, bounds,
                               constraints, callback=callback, **options)

--- a/scipy/optimize/cobyla/cobyla.pyf
+++ b/scipy/optimize/cobyla/cobyla.pyf
@@ -8,11 +8,16 @@ python module _cobyla__user__routines
             double precision intent(out) :: f
             double precision intent(in), dimension(m), depend(m) :: con
         end subroutine calcfc
+        subroutine callback(n,m,x)
+            integer intent(in,hide) :: n
+            integer intent(in,hide) :: m
+            double precision dimension(n),depend(n),intent(in) :: x
+        end subroutine callback
     end interface _cobyla_user_interface
 end python module _cobyla__user__routines
 python module _cobyla ! in 
     interface  ! in :__cobyla
-        subroutine minimize(calcfc,n,m,x,rhobeg,rhoend,iprint,maxfun,w,iact,dinfo)
+        subroutine minimize(calcfc,n,m,x,rhobeg,rhoend,iprint,maxfun,w,iact,dinfo,callback)
             fortranname cobyla
             use _cobyla__user__routines
             external calcfc
@@ -26,6 +31,7 @@ python module _cobyla ! in
             double precision dimension(n*(3*n+2*m+11)+4*m+6), intent(cache,hide),depend(n,m) :: w
             integer dimension(m + 1),intent(cache,hide),depend(m) :: iact
             double precision dimension(4), intent(in,out) :: dinfo
+            external callback
         end subroutine minimize
     end interface 
 end python module _cobyla

--- a/scipy/optimize/tests/test_cobyla.py
+++ b/scipy/optimize/tests/test_cobyla.py
@@ -40,7 +40,6 @@ class TestCobyla:
 
         callback = Callback()
 
-
         # Minimize with method='COBYLA'
         cons = ({'type': 'ineq', 'fun': self.con1},
                 {'type': 'ineq', 'fun': self.con2})

--- a/scipy/optimize/tests/test_cobyla.py
+++ b/scipy/optimize/tests/test_cobyla.py
@@ -1,7 +1,7 @@
 import math
 import numpy as np
 
-from numpy.testing import assert_allclose, assert_
+from numpy.testing import assert_allclose, assert_, assert_array_equal
 
 from scipy.optimize import fmin_cobyla, minimize
 
@@ -29,16 +29,32 @@ class TestCobyla:
         assert_allclose(x, self.solution, atol=1e-4)
 
     def test_minimize_simple(self):
+        class Callback:
+            def __init__(self):
+                self.n_calls = 0
+                self.last_x = None
+
+            def __call__(self, x):
+                self.n_calls += 1
+                self.last_x = x
+
+        callback = Callback()
+
+
         # Minimize with method='COBYLA'
         cons = ({'type': 'ineq', 'fun': self.con1},
                 {'type': 'ineq', 'fun': self.con2})
         sol = minimize(self.fun, self.x0, method='cobyla', constraints=cons,
-                       options=self.opts)
+                       callback=callback, options=self.opts)
         assert_allclose(sol.x, self.solution, atol=1e-4)
         assert_(sol.success, sol.message)
         assert_(sol.maxcv < 1e-5, sol)
         assert_(sol.nfev < 70, sol)
         assert_(sol.fun < self.fun(self.solution) + 1e-3, sol)
+        assert_(sol.nfev == callback.n_calls,
+                "Callback is not called exactly once for every function eval.")
+        assert_array_equal(sol.x, callback.last_x,
+                           "Last design vector sent to the callback is not equal to returned value.")
 
     def test_minimize_constraint_violation(self):
         np.random.seed(1234)

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -1110,10 +1110,6 @@ class TestOptimizeSimple(CheckOptimize):
         # Check that arrays passed to callbacks are not modified
         # inplace by the optimizer afterward
 
-        # cobyla doesn't have callback
-        if method == 'cobyla':
-            return
-
         if method in ('fmin_tnc', 'fmin_l_bfgs_b'):
             func = lambda x: (optimize.rosen(x), optimize.rosen_der(x))
         else:


### PR DESCRIPTION
Don't merge this yet--I'd like to give @daniel-de-vries another day or so to update their PR. However, the rebase was highly nontrivial after the namespace privatization work, so I'll open this now and maybe @tupui can give it a quick scan (two core devs seemed happy with it already, and code changes looked sensible to me too).

I believe if worst comes to worst, the script we have will still pick up the co-authorship on the commits for that contributor. I cannot force push to their `master` branch of their fork of SciPy, which they used for the PR.

I won't add the `1.8.0` milestone to this PR, but will leave it on the other one--if only to maintain an accurate count for myself..