### PR TITLE
DOC: stats: fix a header in `stats.sampling` tutorial

### DIFF
--- a/doc/source/tutorial/stats/sampling_dgt.rst
+++ b/doc/source/tutorial/stats/sampling_dgt.rst
@@ -2,6 +2,7 @@
 .. _sampling-dgt:
 
 Discrete Guide Table (DGT)
+==========================
 
 .. currentmodule:: scipy.stats.sampling
 


### PR DESCRIPTION
#### Reference issue

NA

#### What does this implement/fix?

This is a small PR that fixes `DiscreteGuideTable`'s tutorial header because it rendered incorrectly in the toc tree in `sampling` tutorial.

Previously:

![image](https://user-images.githubusercontent.com/43181252/144746079-03cc6ab4-5344-43f0-bdbd-5cf6daa19f79.png)

Now:

![image](https://user-images.githubusercontent.com/43181252/144746100-e1cd03a7-8430-4363-aee0-f85739c4d9ca.png)


#### Additional information
<!--Any additional information you think is important.-->
