### PR TITLE
remove 'del fft'

### DIFF
--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -158,3 +158,4 @@ else:
 
     # This makes "from scipy import fft" return scipy.fft, not np.fft
     del fft
+    from . import fft


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?

`from scipy import fft` currently causes pylint to say: 
`E0611: No name 'fft' in module 'scipy' (no-name-in-module)`

Deleting numpy's fft in `__init__.py` without re-importing scipy's confuses pylint.

#### Additional information
<!--Any additional information you think is important.-->
