### PR TITLE
CI: make sure CI stays on VS2019 unless changed explicitly 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -198,7 +198,7 @@ stages:
   - job: Windows
     condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/main'))  # skip for PR merges
     pool:
-      vmImage: 'windows-latest'
+      vmImage: 'windows-2019'
     variables:
       # OPENBLAS64_ variable has same value
       # but only needed for ILP64 build below

--- a/doc/source/dev/toolchain.rst
+++ b/doc/source/dev/toolchain.rst
@@ -107,7 +107,7 @@ Currently, SciPy wheels are being built as follows:
 Linux (nightly)    ``ubuntu-18.04``          GCC 6.5                      See ``azure-pipelines.yml``
 Linux (release)    ``ubuntu-18.04``          GCC 7.5                      Built in separate repo [6]_
 OSX                ``macOS-10.15``           LLVM 12.0.0                  Built in separate repo [6]_
-Windows            ``windows-latest``        Visual Studio 2019 (16.11)   See ``azure-pipelines.yml``
+Windows            ``windows-2019``          Visual Studio 2019 (16.11)   See ``azure-pipelines.yml``
 ================  ========================  ===========================  ==============================
 
 Note that the OSX wheels additionally vendor gfortran 4.9,


### PR DESCRIPTION
To avoid the deprecation warnings on azure for the old windows images, #14832 moved to `windows-latest`. This is [currently](https://github.com/actions/virtual-environments#available-environments) equivalent to `windows-2019` (bringing visual studio 2019, and corresponding toolset), but will presumably change to `windows-2022` at some point in the future.

Such a change of compiler version should be made consciously for the scipy CI (rather than imposed by what azure does), because the compiler version used for windows effectively defines the lower bound of support (as otherwise, changes that break on older compilers will not be caught in CI).

CC @tylerjereddy @rgommers 

PS. numpy did the same: https://github.com/numpy/numpy/pull/20524