### PR TITLE
`AttrDict` raises `AttributeError` on missing attributes, not `KeyError`.

### DIFF
--- a/scipy/io/_idl.py
+++ b/scipy/io/_idl.py
@@ -642,6 +642,14 @@ class AttrDict(dict):
         123
         >>> d('VARIABLE')
         123
+        >>> d['missing']
+        Traceback (most recent error last):
+        ...
+        KeyError: 'missing'
+        >>> d.missing
+        Traceback (most recent error last):
+        ...
+        AttributeError: 'AttrDict' object has no attribute 'missing'
     '''
 
     def __init__(self, init={}):
@@ -653,7 +661,13 @@ class AttrDict(dict):
     def __setitem__(self, key, value):
         return super().__setitem__(key.lower(), value)
 
-    __getattr__ = __getitem__
+    def __getattr__(self, name):
+        try:
+            return self.__getitem__(name)
+        except KeyError:
+            raise AttributeError(
+                f"'{type(self)}' object has no attribute '{name}'") from None
+
     __setattr__ = __setitem__
     __call__ = __getitem__
 

--- a/scipy/io/tests/test_idl.py
+++ b/scipy/io/tests/test_idl.py
@@ -1,12 +1,15 @@
 from os import path
 import warnings
 
-DATA_PATH = path.join(path.dirname(__file__), 'data')
-
 import numpy as np
 from numpy.testing import (assert_equal, assert_array_equal,
-    assert_, suppress_warnings)
+                           assert_, suppress_warnings)
+import pytest
+
 from scipy.io import readsav
+from scipy.io import _idl
+
+DATA_PATH = path.join(path.dirname(__file__), 'data')
 
 
 def object_array(*args):
@@ -435,3 +438,13 @@ def test_invalid_pointer():
     assert_(str(w[0].message) == ("Variable referenced by pointer not found in "
                                   "heap: variable will be set to None"))
     assert_identical(s['a'], np.array([None, None]))
+
+
+def test_attrdict():
+    d = _idl.AttrDict({'one': 1})
+    assert d['one'] == 1
+    assert d.one == 1
+    with pytest.raises(KeyError):
+        d['two']
+    with pytest.raises(AttributeError, match='has no attribute'):
+        d.two


### PR DESCRIPTION
Why? Consistency.

As noted in [the Python docs](https://docs.python.org/3/reference/datamodel.html#object.__getattr__), a custom `__getattr__` method should raise `AttributeError` when an attribute isn't present. However, the existing `scipy.io.idl.AttrDict` class sets `__getattr__ = __getitem__`, leading to a `KeyError` in this case.

The result is that these objects behave in unexpected ways; a concrete example where this came up is https://github.com/googlecolab/colabtools/issues/2472. This commit switches to instead raising an `AttributeError` in this situation.

* Before: [`KeyError`](https://user-images.githubusercontent.com/468559/144984611-a5b38e3e-fd25-4ae1-a29e-cb28808dca26.png)
* After: [`AttributeError`](https://user-images.githubusercontent.com/468559/144984626-95f7cc14-7b35-4afc-b7d6-0024125df013.png)
