### PR TITLE
MAINT: 1.8.0 backports for relnotes and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,6 +194,7 @@ scipy/linalg/cython_lapack.pxd
 scipy/linalg/cython_lapack.pyx
 scipy/linalg/src/id_dist/src/*_subr_*.f
 scipy/linalg/_matfuncs_sqrtm_triu.c
+scipy/linalg/_matfuncs_sqrtm_triu.cpp
 scipy/ndimage/src/_ni_label.c
 scipy/ndimage/src/_cytest.c
 scipy/optimize/_bglu_dense.c
@@ -206,6 +207,7 @@ scipy/optimize/__nnls/__nnlsmodule.c
 scipy/optimize/slsqp/_slsqpmodule.c
 scipy/optimize/_lsq/givens_elimination.c
 scipy/optimize/_trlib/_trlib.c
+scipy/optimize/tnc/moduleTNC.c
 scipy/signal/_peak_finding_utils.c
 scipy/signal/_spectral.c
 scipy/signal/_spectral.cpp

--- a/doc/release/1.8.0-notes.rst
+++ b/doc/release/1.8.0-notes.rst
@@ -26,8 +26,9 @@ For running on PyPy, PyPy3 6.0+ is required.
 Highlights of this release
 **************************
 
-- A sparse array API has been added for early testing and feedback; users
-  may expect backwards compatibility changes in future releases
+- A sparse array API has been added for early testing and feedback; this
+  work is ongoing, and users should expect minor API refinements over
+  the next few releases.
 - The sparse SVD library PROPACK is now vendored with SciPy, and an interface
   is exposed via `scipy.sparse.svds` with ``solver='PROPACK'``.
 - A new `scipy.stats.sampling` submodule that leverages the ``UNU.RAN`` C
@@ -114,9 +115,9 @@ Added the Chirp Z-transform and Zoom FFT available as `scipy.signal.CZT` and
 `scipy.sparse` improvements
 ===========================
 
-An array API has been added for early testing and feedback. This work is
-ongoing, and users may expect backwards compatibility changes in
-future releases. Please refer to the `scipy.sparse`
+An array API has been added for early testing and feedback; this
+work is ongoing, and users should expect minor API refinements over
+the next few releases. Please refer to the `scipy.sparse`
 docstring for more information.
 
 ``maximum_flow`` introduces optional keyword only argument, ``method``


### PR DESCRIPTION
- backport gh-15173
- try to reword the description of sparse arrays in the release notes--the description was originally copied from the wiki entry by @stefanv, then @rgommers wanted it reworded for early testing, then I adopted a suggestion similar to what @ev-br had for the wording, and now I'm trying again..