### PR TITLE
BUG: special: Clean up some private namespaces and fix `special.__all__`

### DIFF
--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -8,12 +8,10 @@ import math
 from numpy import (pi, asarray, floor, isscalar, iscomplex, real,
                    imag, sqrt, where, mgrid, sin, place, issubdtype,
                    extract, inexact, nan, zeros, sinc)
-from . import _ufuncs as ufuncs
+from . import _ufuncs
 from ._ufuncs import (mathieu_a, mathieu_b, iv, jv, gamma,
-                      psi, hankel1, hankel2, yv, kv, ndtri,
-                      poch, binom, hyp0f1)
+                      psi, hankel1, hankel2, yv, kv, poch, binom)
 from . import _specfun
-from . import _orthogonal
 from ._comb import _comb_int
 
 
@@ -38,37 +36,27 @@ __all__ = [
     'fresnel_zeros',
     'fresnelc_zeros',
     'fresnels_zeros',
-    'gamma',
     'h1vp',
     'h2vp',
-    'hankel1',
-    'hankel2',
-    'hyp0f1',
-    'iv',
     'ivp',
     'jn_zeros',
     'jnjnp_zeros',
     'jnp_zeros',
     'jnyn_zeros',
-    'jv',
     'jvp',
     'kei_zeros',
     'keip_zeros',
     'kelvin_zeros',
     'ker_zeros',
     'kerp_zeros',
-    'kv',
     'kvp',
     'lmbda',
     'lpmn',
     'lpn',
     'lqmn',
     'lqn',
-    'mathieu_a',
-    'mathieu_b',
     'mathieu_even_coef',
     'mathieu_odd_coef',
-    'ndtri',
     'obl_cv_seq',
     'pbdn_seq',
     'pbdv_seq',
@@ -76,7 +64,6 @@ __all__ = [
     'perm',
     'polygamma',
     'pro_cv_seq',
-    'psi',
     'riccati_jn',
     'riccati_yn',
     'sinc',
@@ -85,7 +72,6 @@ __all__ = [
     'y1p_zeros',
     'yn_zeros',
     'ynp_zeros',
-    'yv',
     'yvp',
     'zeta'
 ]
@@ -1074,7 +1060,7 @@ def assoc_laguerre(x, n, k=0.0):
     reversed argument order ``(x, n, k=0.0) --> (n, k, x)``.
 
     """
-    return _orthogonal.eval_genlaguerre(n, k, x)
+    return _ufuncs.eval_genlaguerre(n, k, x)
 
 
 digamma = psi
@@ -1298,7 +1284,7 @@ def lpmn(m, n, z):
     if (m < 0):
         mp = -m
         mf, nf = mgrid[0:mp+1, 0:n+1]
-        with ufuncs.errstate(all='ignore'):
+        with _ufuncs.errstate(all='ignore'):
             if abs(z) < 1:
                 # Ferrer function; DLMF 14.9.3
                 fixarr = where(mf > nf, 0.0,
@@ -1381,7 +1367,7 @@ def clpmn(m, n, z, type=3):
     if (m < 0):
         mp = -m
         mf, nf = mgrid[0:mp+1, 0:n+1]
-        with ufuncs.errstate(all='ignore'):
+        with _ufuncs.errstate(all='ignore'):
             if type == 2:
                 fixarr = where(mf > nf, 0.0,
                                (-1)**mf * gamma(nf-mf+1) / gamma(nf+mf+1))
@@ -2398,7 +2384,7 @@ def factorial(n, exact=False):
                 out[np.isnan(n)] = n[np.isnan(n)]
             return out
     else:
-        out = ufuncs._factorial(n)
+        out = _ufuncs._factorial(n)
         return out
 
 
@@ -2575,6 +2561,6 @@ def zeta(x, q=None, out=None):
 
     """
     if q is None:
-        return ufuncs._riemann_zeta(x, out)
+        return _ufuncs._riemann_zeta(x, out)
     else:
-        return ufuncs._zeta(x, q, out)
+        return _ufuncs._zeta(x, q, out)

--- a/scipy/special/_orthogonal.py
+++ b/scipy/special/_orthogonal.py
@@ -83,8 +83,7 @@ from scipy.special import airy
 
 # Local imports.
 from . import _ufuncs
-from . import _ufuncs as cephes
-_gam = cephes.gamma
+_gam = _ufuncs.gamma
 # There is no .pyi file for _specfun
 from . import _specfun  # type: ignore
 
@@ -95,29 +94,22 @@ _polyfuns = ['legendre', 'chebyt', 'chebyu', 'chebyc', 'chebys',
 
 # Correspondence between new and old names of root functions
 _rootfuns_map = {'roots_legendre': 'p_roots',
-               'roots_chebyt': 't_roots',
-               'roots_chebyu': 'u_roots',
-               'roots_chebyc': 'c_roots',
-               'roots_chebys': 's_roots',
-               'roots_jacobi': 'j_roots',
-               'roots_laguerre': 'l_roots',
-               'roots_genlaguerre': 'la_roots',
-               'roots_hermite': 'h_roots',
-               'roots_hermitenorm': 'he_roots',
-               'roots_gegenbauer': 'cg_roots',
-               'roots_sh_legendre': 'ps_roots',
-               'roots_sh_chebyt': 'ts_roots',
-               'roots_sh_chebyu': 'us_roots',
-               'roots_sh_jacobi': 'js_roots'}
+                 'roots_chebyt': 't_roots',
+                 'roots_chebyu': 'u_roots',
+                 'roots_chebyc': 'c_roots',
+                 'roots_chebys': 's_roots',
+                 'roots_jacobi': 'j_roots',
+                 'roots_laguerre': 'l_roots',
+                 'roots_genlaguerre': 'la_roots',
+                 'roots_hermite': 'h_roots',
+                 'roots_hermitenorm': 'he_roots',
+                 'roots_gegenbauer': 'cg_roots',
+                 'roots_sh_legendre': 'ps_roots',
+                 'roots_sh_chebyt': 'ts_roots',
+                 'roots_sh_chebyu': 'us_roots',
+                 'roots_sh_jacobi': 'js_roots'}
 
-_evalfuns = ['eval_legendre', 'eval_chebyt', 'eval_chebyu',
-             'eval_chebyc', 'eval_chebys', 'eval_jacobi',
-             'eval_laguerre', 'eval_genlaguerre', 'eval_hermite',
-             'eval_hermitenorm', 'eval_gegenbauer',
-             'eval_sh_legendre', 'eval_sh_chebyt', 'eval_sh_chebyu',
-             'eval_sh_jacobi']
-
-__all__ = _polyfuns + list(_rootfuns_map.keys()) + _evalfuns + ['poch', 'binom']
+__all__ = _polyfuns + list(_rootfuns_map.keys())
 
 
 class orthopoly1d(np.poly1d):
@@ -263,7 +255,7 @@ def roots_jacobi(n, alpha, beta, mu=False):
     if alpha == beta:
         return roots_gegenbauer(m, alpha+0.5, mu)
 
-    mu0 = 2.0**(alpha+beta+1)*cephes.beta(alpha+1, beta+1)
+    mu0 = 2.0**(alpha+beta+1)*_ufuncs.beta(alpha+1, beta+1)
     a = alpha
     b = beta
     if a + b == 0.0:
@@ -275,9 +267,9 @@ def roots_jacobi(n, alpha, beta, mu=False):
     bn_func = lambda k: 2.0 / (2.0*k+a+b)*np.sqrt((k+a)*(k+b) / (2*k+a+b+1)) \
               * np.where(k == 1, 1.0, np.sqrt(k*(k+a+b) / (2.0*k+a+b-1)))
 
-    f = lambda n, x: cephes.eval_jacobi(n, a, b, x)
-    df = lambda n, x: 0.5 * (n + a + b + 1) \
-                      * cephes.eval_jacobi(n-1, a+1, b+1, x)
+    f = lambda n, x: _ufuncs.eval_jacobi(n, a, b, x)
+    df = lambda n, x: (0.5 * (n + a + b + 1)
+                       * _ufuncs.eval_jacobi(n-1, a+1, b+1, x))
     return _gen_roots_and_weights(m, mu0, an_func, bn_func, f, df, False, mu)
 
 
@@ -372,7 +364,7 @@ def jacobi(n, alpha, beta, monic=False):
     kn = _gam(2 * n + ab1) / 2.0**n / _gam(n + 1) / _gam(n + ab1)
     # here kn = coefficient on x^n term
     p = orthopoly1d(x, w, hn, kn, wfunc, (-1, 1), monic,
-                    lambda x: eval_jacobi(n, alpha, beta, x))
+                    lambda x: _ufuncs.eval_jacobi(n, alpha, beta, x))
     return p
 
 # Jacobi Polynomials shifted         G_n(p,q,x)
@@ -433,6 +425,7 @@ def roots_sh_jacobi(n, p1, q1, mu=False):
     else:
         return x, w
 
+
 def sh_jacobi(n, p, q, monic=False):
     r"""Shifted Jacobi polynomial.
 
@@ -483,7 +476,7 @@ def sh_jacobi(n, p, q, monic=False):
     # kn = 1.0 in standard form so monic is redundant. Kept for compatibility.
     kn = 1.0
     pp = orthopoly1d(x, w, hn, kn, wfunc=wfunc, limits=(0, 1), monic=monic,
-                     eval_func=lambda x: eval_sh_jacobi(n, p, q, x))
+                     eval_func=lambda x: _ufuncs.eval_sh_jacobi(n, p, q, x))
     return pp
 
 # Generalized Laguerre               L^(alpha)_n(x)
@@ -536,7 +529,7 @@ def roots_genlaguerre(n, alpha, mu=False):
     if alpha < -1:
         raise ValueError("alpha must be greater than -1.")
 
-    mu0 = cephes.gamma(alpha + 1)
+    mu0 = _ufuncs.gamma(alpha + 1)
 
     if m == 1:
         x = np.array([alpha+1.0], 'd')
@@ -548,9 +541,9 @@ def roots_genlaguerre(n, alpha, mu=False):
 
     an_func = lambda k: 2 * k + alpha + 1
     bn_func = lambda k: -np.sqrt(k * (k + alpha))
-    f = lambda n, x: cephes.eval_genlaguerre(n, alpha, x)
-    df = lambda n, x: (n*cephes.eval_genlaguerre(n, alpha, x)
-                     - (n + alpha)*cephes.eval_genlaguerre(n-1, alpha, x))/x
+    f = lambda n, x: _ufuncs.eval_genlaguerre(n, alpha, x)
+    df = lambda n, x: (n*_ufuncs.eval_genlaguerre(n, alpha, x)
+                       - (n + alpha)*_ufuncs.eval_genlaguerre(n-1, alpha, x))/x
     return _gen_roots_and_weights(m, mu0, an_func, bn_func, f, df, False, mu)
 
 
@@ -651,7 +644,7 @@ def genlaguerre(n, alpha, monic=False):
     hn = _gam(n + alpha + 1) / _gam(n + 1)
     kn = (-1)**n / _gam(n + 1)
     p = orthopoly1d(x, w, hn, kn, wfunc, (0, inf), monic,
-                    lambda x: eval_genlaguerre(n, alpha, x))
+                    lambda x: _ufuncs.eval_genlaguerre(n, alpha, x))
     return p
 
 # Laguerre                      L_n(x)
@@ -790,7 +783,7 @@ def laguerre(n, monic=False):
     hn = 1.0
     kn = (-1)**n / _gam(n + 1)
     p = orthopoly1d(x, w, hn, kn, lambda x: exp(-x), (0, inf), monic,
-                    lambda x: eval_laguerre(n, x))
+                    lambda x: _ufuncs.eval_laguerre(n, x))
     return p
 
 # Hermite  1                         H_n(x)
@@ -867,8 +860,8 @@ def roots_hermite(n, mu=False):
     if n <= 150:
         an_func = lambda k: 0.0*k
         bn_func = lambda k: np.sqrt(k/2.0)
-        f = cephes.eval_hermite
-        df = lambda n, x: 2.0 * n * cephes.eval_hermite(n-1, x)
+        f = _ufuncs.eval_hermite
+        df = lambda n, x: 2.0 * n * _ufuncs.eval_hermite(n-1, x)
         return _gen_roots_and_weights(m, mu0, an_func, bn_func, f, df, True, mu)
     else:
         nodes, weights = _roots_hermite_asy(m)
@@ -1305,7 +1298,7 @@ def hermite(n, monic=False):
     hn = 2**n * _gam(n + 1) * sqrt(pi)
     kn = 2**n
     p = orthopoly1d(x, w, hn, kn, wfunc, (-inf, inf), monic,
-                    lambda x: eval_hermite(n, x))
+                    lambda x: _ufuncs.eval_hermite(n, x))
     return p
 
 # Hermite  2                         He_n(x)
@@ -1371,8 +1364,8 @@ def roots_hermitenorm(n, mu=False):
     if n <= 150:
         an_func = lambda k: 0.0*k
         bn_func = lambda k: np.sqrt(k)
-        f = cephes.eval_hermitenorm
-        df = lambda n, x: n * cephes.eval_hermitenorm(n-1, x)
+        f = _ufuncs.eval_hermitenorm
+        df = lambda n, x: n * _ufuncs.eval_hermitenorm(n-1, x)
         return _gen_roots_and_weights(m, mu0, an_func, bn_func, f, df, True, mu)
     else:
         nodes, weights = _roots_hermite_asy(m)
@@ -1430,7 +1423,7 @@ def hermitenorm(n, monic=False):
     hn = sqrt(2 * pi) * _gam(n + 1)
     kn = 1.0
     p = orthopoly1d(x, w, hn, kn, wfunc=wfunc, limits=(-inf, inf), monic=monic,
-                    eval_func=lambda x: eval_hermitenorm(n, x))
+                    eval_func=lambda x: _ufuncs.eval_hermitenorm(n, x))
     return p
 
 # The remainder of the polynomials can be derived from the ones above.
@@ -1491,13 +1484,16 @@ def roots_gegenbauer(n, alpha, mu=False):
         # keep doing so.
         return roots_chebyt(n, mu)
 
-    mu0 = np.sqrt(np.pi) * cephes.gamma(alpha + 0.5) / cephes.gamma(alpha + 1)
+    mu0 = (np.sqrt(np.pi) * _ufuncs.gamma(alpha + 0.5)
+           / _ufuncs.gamma(alpha + 1))
     an_func = lambda k: 0.0 * k
     bn_func = lambda k: np.sqrt(k * (k + 2 * alpha - 1)
                         / (4 * (k + alpha) * (k + alpha - 1)))
-    f = lambda n, x: cephes.eval_gegenbauer(n, alpha, x)
-    df = lambda n, x: (-n*x*cephes.eval_gegenbauer(n, alpha, x)
-         + (n + 2*alpha - 1)*cephes.eval_gegenbauer(n-1, alpha, x))/(1-x**2)
+    f = lambda n, x: _ufuncs.eval_gegenbauer(n, alpha, x)
+    df = lambda n, x: ((-n*x*_ufuncs.eval_gegenbauer(n, alpha, x)
+                        + ((n + 2*alpha - 1)
+                           * _ufuncs.eval_gegenbauer(n - 1, alpha, x)))
+                       / (1 - x**2))
     return _gen_roots_and_weights(m, mu0, an_func, bn_func, f, df, True, mu)
 
 
@@ -1572,7 +1568,8 @@ def gegenbauer(n, alpha, monic=False):
     factor = (_gam(2*alpha + n) * _gam(alpha + 0.5) /
               _gam(2*alpha) / _gam(alpha + 0.5 + n))
     base._scale(factor)
-    base.__dict__['_eval_func'] = lambda x: eval_gegenbauer(float(n), alpha, x)
+    base.__dict__['_eval_func'] = lambda x: _ufuncs.eval_gegenbauer(float(n),
+                                                                    alpha, x)
     return base
 
 # Chebyshev of the first kind: T_n(x) =
@@ -1729,13 +1726,13 @@ def chebyt(n, monic=False):
     wfunc = lambda x: 1.0 / sqrt(1 - x * x)
     if n == 0:
         return orthopoly1d([], [], pi, 1.0, wfunc, (-1, 1), monic,
-                           lambda x: eval_chebyt(n, x))
+                           lambda x: _ufuncs.eval_chebyt(n, x))
     n1 = n
     x, w, mu = roots_chebyt(n1, mu=True)
     hn = pi / 2
     kn = 2**(n - 1)
     p = orthopoly1d(x, w, hn, kn, wfunc, (-1, 1), monic,
-                    lambda x: eval_chebyt(n, x))
+                    lambda x: _ufuncs.eval_chebyt(n, x))
     return p
 
 # Chebyshev of the second kind
@@ -1994,7 +1991,7 @@ def chebyc(n, monic=False):
                     limits=(-2, 2), monic=monic)
     if not monic:
         p._scale(2.0 / p(2))
-        p.__dict__['_eval_func'] = lambda x: eval_chebyc(n, x)
+        p.__dict__['_eval_func'] = lambda x: _ufuncs.eval_chebyc(n, x)
     return p
 
 # Chebyshev of the second kind       S_n(x)
@@ -2101,7 +2098,7 @@ def chebys(n, monic=False):
     if not monic:
         factor = (n + 1.0) / p(2)
         p._scale(factor)
-        p.__dict__['_eval_func'] = lambda x: eval_chebys(n, x)
+        p.__dict__['_eval_func'] = lambda x: _ufuncs.eval_chebys(n, x)
     return p
 
 # Shifted Chebyshev of the first kind     T^*_n(x)
@@ -2228,7 +2225,7 @@ def roots_sh_chebyu(n, mu=False):
     """
     x, w, m = roots_chebyu(n, True)
     x = (x + 1) / 2
-    m_us = cephes.beta(1.5, 1.5)
+    m_us = _ufuncs.beta(1.5, 1.5)
     w *= m_us / m
     if mu:
         return x, w, m_us
@@ -2386,9 +2383,9 @@ def roots_legendre(n, mu=False):
     mu0 = 2.0
     an_func = lambda k: 0.0 * k
     bn_func = lambda k: k * np.sqrt(1.0 / (4 * k * k - 1))
-    f = cephes.eval_legendre
-    df = lambda n, x: (-n*x*cephes.eval_legendre(n, x)
-                       + n*cephes.eval_legendre(n-1, x))/(1-x**2)
+    f = _ufuncs.eval_legendre
+    df = lambda n, x: (-n*x*_ufuncs.eval_legendre(n, x)
+                       + n*_ufuncs.eval_legendre(n-1, x))/(1-x**2)
     return _gen_roots_and_weights(m, mu0, an_func, bn_func, f, df, True, mu)
 
 
@@ -2443,7 +2440,8 @@ def legendre(n, monic=False):
     hn = 2.0 / (2 * n + 1)
     kn = _gam(2 * n + 1) / _gam(n + 1)**2 / 2.0**n
     p = orthopoly1d(x, w, hn, kn, wfunc=lambda x: 1.0, limits=(-1, 1),
-                    monic=monic, eval_func=lambda x: eval_legendre(n, x))
+                    monic=monic,
+                    eval_func=lambda x: _ufuncs.eval_legendre(n, x))
     return p
 
 # Shifted Legendre              P^*_n(x)
@@ -2495,6 +2493,7 @@ def roots_sh_legendre(n, mu=False):
     else:
         return x, w
 
+
 def sh_legendre(n, monic=False):
     r"""Shifted Legendre polynomial.
 
@@ -2526,31 +2525,14 @@ def sh_legendre(n, monic=False):
     wfunc = lambda x: 0.0 * x + 1.0
     if n == 0:
         return orthopoly1d([], [], 1.0, 1.0, wfunc, (0, 1), monic,
-                           lambda x: eval_sh_legendre(n, x))
+                           lambda x: _ufuncs.eval_sh_legendre(n, x))
     x, w = roots_sh_legendre(n)
     hn = 1.0 / (2 * n + 1.0)
     kn = _gam(2 * n + 1) / _gam(n + 1)**2
     p = orthopoly1d(x, w, hn, kn, wfunc, limits=(0, 1), monic=monic,
-                    eval_func=lambda x: eval_sh_legendre(n, x))
+                    eval_func=lambda x: _ufuncs.eval_sh_legendre(n, x))
     return p
 
-
-# -----------------------------------------------------------------------------
-# Code for backwards compatibility
-# -----------------------------------------------------------------------------
-
-# Import functions in case someone is still calling the orthogonal
-# module directly. (They shouldn't be; it's not in the public API).
-poch = cephes.poch
-
-# eval_chebyu, eval_sh_chebyt and eval_sh_chebyu: These functions are not
-# used in _orthogonal.py, they are not in _rootfuns_map, but their names
-# do appear in _evalfuns, so they must be kept.
-from ._ufuncs import (binom, eval_jacobi, eval_sh_jacobi, eval_gegenbauer,
-                      eval_chebyt, eval_chebyu, eval_chebys, eval_chebyc,
-                      eval_sh_chebyt, eval_sh_chebyu, eval_legendre,
-                      eval_sh_legendre, eval_genlaguerre, eval_laguerre,
-                      eval_hermite, eval_hermitenorm)
 
 # Make the old root function names an alias for the new ones
 _modattrs = globals()

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -4,6 +4,9 @@
 
 import warnings
 from . import _basic
+from ._ufuncs import (mathieu_a, mathieu_b, iv, jv, gamma,
+                      psi, hankel1, hankel2, yv, kv)
+
 
 __all__ = [  # noqa: F822
     'ai_zeros',

--- a/scipy/special/tests/test_orthogonal_eval.py
+++ b/scipy/special/tests/test_orthogonal_eval.py
@@ -2,6 +2,7 @@ import numpy as np
 from numpy.testing import assert_, assert_allclose
 import pytest
 
+from scipy.special import _ufuncs
 import scipy.special._orthogonal as orth
 from scipy.special._testutils import FuncData
 
@@ -10,23 +11,23 @@ def test_eval_chebyt():
     n = np.arange(0, 10000, 7)
     x = 2*np.random.rand() - 1
     v1 = np.cos(n*np.arccos(x))
-    v2 = orth.eval_chebyt(n, x)
+    v2 = _ufuncs.eval_chebyt(n, x)
     assert_(np.allclose(v1, v2, rtol=1e-15))
 
 
 def test_eval_genlaguerre_restriction():
     # check it returns nan for alpha <= -1
-    assert_(np.isnan(orth.eval_genlaguerre(0, -1, 0)))
-    assert_(np.isnan(orth.eval_genlaguerre(0.1, -1, 0)))
+    assert_(np.isnan(_ufuncs.eval_genlaguerre(0, -1, 0)))
+    assert_(np.isnan(_ufuncs.eval_genlaguerre(0.1, -1, 0)))
 
 
 def test_warnings():
     # ticket 1334
     with np.errstate(all='raise'):
         # these should raise no fp warnings
-        orth.eval_legendre(1, 0)
-        orth.eval_laguerre(1, 1)
-        orth.eval_gegenbauer(1, 1, 0)
+        _ufuncs.eval_legendre(1, 0)
+        _ufuncs.eval_laguerre(1, 1)
+        _ufuncs.eval_gegenbauer(1, 1, 0)
 
 
 class TestPolys:
@@ -69,68 +70,68 @@ class TestPolys:
             ds.check()
 
     def test_jacobi(self):
-        self.check_poly(orth.eval_jacobi, orth.jacobi,
-                   param_ranges=[(-0.99, 10), (-0.99, 10)], x_range=[-1, 1],
-                   rtol=1e-5)
+        self.check_poly(_ufuncs.eval_jacobi, orth.jacobi,
+                        param_ranges=[(-0.99, 10), (-0.99, 10)],
+                        x_range=[-1, 1], rtol=1e-5)
 
     def test_sh_jacobi(self):
-        self.check_poly(orth.eval_sh_jacobi, orth.sh_jacobi,
-                   param_ranges=[(1, 10), (0, 1)], x_range=[0, 1],
-                   rtol=1e-5)
+        self.check_poly(_ufuncs.eval_sh_jacobi, orth.sh_jacobi,
+                        param_ranges=[(1, 10), (0, 1)], x_range=[0, 1],
+                        rtol=1e-5)
 
     def test_gegenbauer(self):
-        self.check_poly(orth.eval_gegenbauer, orth.gegenbauer,
-                   param_ranges=[(-0.499, 10)], x_range=[-1, 1],
-                   rtol=1e-7)
+        self.check_poly(_ufuncs.eval_gegenbauer, orth.gegenbauer,
+                        param_ranges=[(-0.499, 10)], x_range=[-1, 1],
+                        rtol=1e-7)
 
     def test_chebyt(self):
-        self.check_poly(orth.eval_chebyt, orth.chebyt,
-                   param_ranges=[], x_range=[-1, 1])
+        self.check_poly(_ufuncs.eval_chebyt, orth.chebyt,
+                        param_ranges=[], x_range=[-1, 1])
 
     def test_chebyu(self):
-        self.check_poly(orth.eval_chebyu, orth.chebyu,
-                   param_ranges=[], x_range=[-1, 1])
+        self.check_poly(_ufuncs.eval_chebyu, orth.chebyu,
+                        param_ranges=[], x_range=[-1, 1])
 
     def test_chebys(self):
-        self.check_poly(orth.eval_chebys, orth.chebys,
-                   param_ranges=[], x_range=[-2, 2])
+        self.check_poly(_ufuncs.eval_chebys, orth.chebys,
+                        param_ranges=[], x_range=[-2, 2])
 
     def test_chebyc(self):
-        self.check_poly(orth.eval_chebyc, orth.chebyc,
-                   param_ranges=[], x_range=[-2, 2])
+        self.check_poly(_ufuncs.eval_chebyc, orth.chebyc,
+                        param_ranges=[], x_range=[-2, 2])
 
     def test_sh_chebyt(self):
         with np.errstate(all='ignore'):
-            self.check_poly(orth.eval_sh_chebyt, orth.sh_chebyt,
+            self.check_poly(_ufuncs.eval_sh_chebyt, orth.sh_chebyt,
                             param_ranges=[], x_range=[0, 1])
 
     def test_sh_chebyu(self):
-        self.check_poly(orth.eval_sh_chebyu, orth.sh_chebyu,
-                   param_ranges=[], x_range=[0, 1])
+        self.check_poly(_ufuncs.eval_sh_chebyu, orth.sh_chebyu,
+                        param_ranges=[], x_range=[0, 1])
 
     def test_legendre(self):
-        self.check_poly(orth.eval_legendre, orth.legendre,
-                   param_ranges=[], x_range=[-1, 1])
+        self.check_poly(_ufuncs.eval_legendre, orth.legendre,
+                        param_ranges=[], x_range=[-1, 1])
 
     def test_sh_legendre(self):
         with np.errstate(all='ignore'):
-            self.check_poly(orth.eval_sh_legendre, orth.sh_legendre,
+            self.check_poly(_ufuncs.eval_sh_legendre, orth.sh_legendre,
                             param_ranges=[], x_range=[0, 1])
 
     def test_genlaguerre(self):
-        self.check_poly(orth.eval_genlaguerre, orth.genlaguerre,
-                   param_ranges=[(-0.99, 10)], x_range=[0, 100])
+        self.check_poly(_ufuncs.eval_genlaguerre, orth.genlaguerre,
+                        param_ranges=[(-0.99, 10)], x_range=[0, 100])
 
     def test_laguerre(self):
-        self.check_poly(orth.eval_laguerre, orth.laguerre,
-                   param_ranges=[], x_range=[0, 100])
+        self.check_poly(_ufuncs.eval_laguerre, orth.laguerre,
+                        param_ranges=[], x_range=[0, 100])
 
     def test_hermite(self):
-        self.check_poly(orth.eval_hermite, orth.hermite,
-                   param_ranges=[], x_range=[-100, 100])
+        self.check_poly(_ufuncs.eval_hermite, orth.hermite,
+                        param_ranges=[], x_range=[-100, 100])
 
     def test_hermitenorm(self):
-        self.check_poly(orth.eval_hermitenorm, orth.hermitenorm,
+        self.check_poly(_ufuncs.eval_hermitenorm, orth.hermitenorm,
                         param_ranges=[], x_range=[-100, 100])
 
 
@@ -175,75 +176,76 @@ class TestRecurrence:
             ds.check()
 
     def test_jacobi(self):
-        self.check_poly(orth.eval_jacobi,
-                   param_ranges=[(-0.99, 10), (-0.99, 10)], x_range=[-1, 1])
+        self.check_poly(_ufuncs.eval_jacobi,
+                        param_ranges=[(-0.99, 10), (-0.99, 10)],
+                        x_range=[-1, 1])
 
     def test_sh_jacobi(self):
-        self.check_poly(orth.eval_sh_jacobi,
-                   param_ranges=[(1, 10), (0, 1)], x_range=[0, 1])
+        self.check_poly(_ufuncs.eval_sh_jacobi,
+                        param_ranges=[(1, 10), (0, 1)], x_range=[0, 1])
 
     def test_gegenbauer(self):
-        self.check_poly(orth.eval_gegenbauer,
-                   param_ranges=[(-0.499, 10)], x_range=[-1, 1])
+        self.check_poly(_ufuncs.eval_gegenbauer,
+                        param_ranges=[(-0.499, 10)], x_range=[-1, 1])
 
     def test_chebyt(self):
-        self.check_poly(orth.eval_chebyt,
-                   param_ranges=[], x_range=[-1, 1])
+        self.check_poly(_ufuncs.eval_chebyt,
+                        param_ranges=[], x_range=[-1, 1])
 
     def test_chebyu(self):
-        self.check_poly(orth.eval_chebyu,
-                   param_ranges=[], x_range=[-1, 1])
+        self.check_poly(_ufuncs.eval_chebyu,
+                        param_ranges=[], x_range=[-1, 1])
 
     def test_chebys(self):
-        self.check_poly(orth.eval_chebys,
-                   param_ranges=[], x_range=[-2, 2])
+        self.check_poly(_ufuncs.eval_chebys,
+                        param_ranges=[], x_range=[-2, 2])
 
     def test_chebyc(self):
-        self.check_poly(orth.eval_chebyc,
-                   param_ranges=[], x_range=[-2, 2])
+        self.check_poly(_ufuncs.eval_chebyc,
+                        param_ranges=[], x_range=[-2, 2])
 
     def test_sh_chebyt(self):
-        self.check_poly(orth.eval_sh_chebyt,
-                   param_ranges=[], x_range=[0, 1])
+        self.check_poly(_ufuncs.eval_sh_chebyt,
+                        param_ranges=[], x_range=[0, 1])
 
     def test_sh_chebyu(self):
-        self.check_poly(orth.eval_sh_chebyu,
-                   param_ranges=[], x_range=[0, 1])
+        self.check_poly(_ufuncs.eval_sh_chebyu,
+                        param_ranges=[], x_range=[0, 1])
 
     def test_legendre(self):
-        self.check_poly(orth.eval_legendre,
-                   param_ranges=[], x_range=[-1, 1])
+        self.check_poly(_ufuncs.eval_legendre,
+                        param_ranges=[], x_range=[-1, 1])
 
     def test_sh_legendre(self):
-        self.check_poly(orth.eval_sh_legendre,
-                   param_ranges=[], x_range=[0, 1])
+        self.check_poly(_ufuncs.eval_sh_legendre,
+                        param_ranges=[], x_range=[0, 1])
 
     def test_genlaguerre(self):
-        self.check_poly(orth.eval_genlaguerre,
-                   param_ranges=[(-0.99, 10)], x_range=[0, 100])
+        self.check_poly(_ufuncs.eval_genlaguerre,
+                        param_ranges=[(-0.99, 10)], x_range=[0, 100])
 
     def test_laguerre(self):
-        self.check_poly(orth.eval_laguerre,
-                   param_ranges=[], x_range=[0, 100])
+        self.check_poly(_ufuncs.eval_laguerre,
+                        param_ranges=[], x_range=[0, 100])
 
     def test_hermite(self):
-        v = orth.eval_hermite(70, 1.0)
+        v = _ufuncs.eval_hermite(70, 1.0)
         a = -1.457076485701412e60
-        assert_allclose(v,a)
+        assert_allclose(v, a)
 
 
 def test_hermite_domain():
     # Regression test for gh-11091.
-    assert np.isnan(orth.eval_hermite(-1, 1.0))
-    assert np.isnan(orth.eval_hermitenorm(-1, 1.0))
+    assert np.isnan(_ufuncs.eval_hermite(-1, 1.0))
+    assert np.isnan(_ufuncs.eval_hermitenorm(-1, 1.0))
 
 
 @pytest.mark.parametrize("n", [0, 1, 2])
 @pytest.mark.parametrize("x", [0, 1, np.nan])
 def test_hermite_nan(n, x):
     # Regression test for gh-11369.
-    assert np.isnan(orth.eval_hermite(n, x)) == np.any(np.isnan([n, x]))
-    assert np.isnan(orth.eval_hermitenorm(n, x)) == np.any(np.isnan([n, x]))
+    assert np.isnan(_ufuncs.eval_hermite(n, x)) == np.any(np.isnan([n, x]))
+    assert np.isnan(_ufuncs.eval_hermitenorm(n, x)) == np.any(np.isnan([n, x]))
 
 
 @pytest.mark.parametrize('n', [0, 1, 2, 3.2])
@@ -251,7 +253,7 @@ def test_hermite_nan(n, x):
 @pytest.mark.parametrize('x', [2, np.nan])
 def test_genlaguerre_nan(n, alpha, x):
     # Regression test for gh-11361.
-    nan_laguerre = np.isnan(orth.eval_genlaguerre(n, alpha, x))
+    nan_laguerre = np.isnan(_ufuncs.eval_genlaguerre(n, alpha, x))
     nan_arg = np.any(np.isnan([n, alpha, x]))
     assert nan_laguerre == nan_arg
 
@@ -261,6 +263,6 @@ def test_genlaguerre_nan(n, alpha, x):
 @pytest.mark.parametrize('x', [1e-6, 2, np.nan])
 def test_gegenbauer_nan(n, alpha, x):
     # Regression test for gh-11370.
-    nan_gegenbauer = np.isnan(orth.eval_gegenbauer(n, alpha, x))
+    nan_gegenbauer = np.isnan(_ufuncs.eval_gegenbauer(n, alpha, x))
     nan_arg = np.any(np.isnan([n, alpha, x]))
     assert nan_gegenbauer == nan_arg


### PR DESCRIPTION
Before this change, `scipy.special.__all__` contained duplicated names.

From both `_ufuncs` and `_basic`:
    'gamma', 'hankel1', 'hankel2', 'hyp0f1', 'iv', 'jv', 'kv',
    'mathieu_a', 'mathieu_b', 'ndtri', 'psi', 'yv'

From both `_ufuncs` and `_orthogonal`:
    'binom', 'eval_chebyc', 'eval_chebys', 'eval_chebyt', 'eval_chebyu',
    'eval_gegenbauer', 'eval_genlaguerre', 'eval_hermite', 'eval_hermitenorm',
    'eval_jacobi', 'eval_laguerre', 'eval_legendre', 'eval_sh_chebyt',
    'eval_sh_chebyu', 'eval_sh_jacobi', 'eval_sh_legendre', 'poch'

The duplicated names are all ufuncs, so the true source of these names
is the `_ufuncs` module.  The new modules `_basic` and `_orthogonal`
are private, so there is no need to populate their namespaces with
names from `_ufuncs`.  I've cleaned up these modules so that their
`__all__` lists contain only the functions that are actually defined
there.

We *do* need to maintain the names in the deprecated public modules
`basic` and `orthogonal`, so I added the appropriate imports in
`basic.py` to maintain backwards compatibility.

I undid a couple obfuscatory aliases of `_ufuncs`; it was aliased
as `ufuncs` in `_basic.py` and as `cephes` in `_orthogonal.py`.

I also made a few incidental PEP 8 white space changes.

