### PR TITLE
DEP: deprecate `spatial.distance.kulsinski`

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -808,7 +808,7 @@ def jaccard(u, v, w=None):
 
 
 @_deprecated(f"Kulsinski has been deprecated from scipy.spatial.distance,"
-             f"it is superseded by scipy.spatial.distance.kulczynski1")
+             f" it is superseded by scipy.spatial.distance.kulczynski1")
 def kulsinski(u, v, w=None):
     """
     Compute the Kulsinski dissimilarity between two boolean 1-D arrays.

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -807,8 +807,9 @@ def jaccard(u, v, w=None):
     return (a / b) if b != 0 else 0
 
 
-@_deprecated(f"Kulsinski has been deprecated from scipy.spatial.distance,"
-             f" it is superseded by scipy.spatial.distance.kulczynski1")
+@_deprecated("Kulsinski has been deprecated from scipy.spatial.distance"
+             " in SciPy 1.9.0 and it will be removed in SciPy 2.0."
+             " It is superseded by scipy.spatial.distance.kulczynski1.")
 def kulsinski(u, v, w=None):
     """
     Compute the Kulsinski dissimilarity between two boolean 1-D arrays.

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -124,6 +124,7 @@ from ..special import rel_entr
 
 from . import _distance_pybind
 
+from .._lib.deprecation import _deprecated
 
 def _copy_array_if_base_present(a):
     """Copy the array if its base points to a parent array."""
@@ -806,6 +807,8 @@ def jaccard(u, v, w=None):
     return (a / b) if b != 0 else 0
 
 
+@_deprecated(f"Kulsinski has been deprecated from scipy.spatial.distance,"
+             f"it is superseded by scipy.spatial.distance.kulczynski1")
 def kulsinski(u, v, w=None):
     """
     Compute the Kulsinski dissimilarity between two boolean 1-D arrays.


### PR DESCRIPTION

#### Reference issue
Closes #15125 

#### What does this implement/fix?

Deprecates a method

#### Additional information

I deprecated the method but was not able to find where the method was being used except for test. So I am creating a draft pull request.