### PR TITLE
MAINT: fix typos principle -> principal

### DIFF
--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -3801,7 +3801,7 @@ add_newdoc("expi",
 
         Ei(x) = \int_{-\infty}^x \frac{e^t}{t} dt.
 
-    For :math:`x > 0` the integral is understood as a Cauchy principle
+    For :math:`x > 0` the integral is understood as a Cauchy principal
     value.
 
     It is extended to the complex plane by analytic continuation of
@@ -9073,7 +9073,7 @@ add_newdoc("shichi",
       \gamma + \log(x) + \int_0^x \frac{\cosh{t} - 1}{t} dt
 
     where :math:`\gamma` is Euler's constant and :math:`\log` is the
-    principle branch of the logarithm.
+    principal branch of the logarithm.
 
     Parameters
     ----------
@@ -9126,7 +9126,7 @@ add_newdoc("sici",
       \gamma + \log(x) + \int_0^x \frac{\cos{t} - 1}{t}dt
 
     where :math:`\gamma` is Euler's constant and :math:`\log` is the
-    principle branch of the logarithm.
+    principal branch of the logarithm.
 
     Parameters
     ----------

--- a/scipy/special/_precompute/lambertw.py
+++ b/scipy/special/_precompute/lambertw.py
@@ -1,4 +1,4 @@
-"""Compute a Pade approximation for the principle branch of the
+"""Compute a Pade approximation for the principal branch of the
 Lambert W function around 0 and compare it to various other
 approximations.
 


### PR DESCRIPTION
Fix "principle (branch|value)" into "principal (branch|value)" in several places.

[skip ci] because this concerns only doc strings
