### PR TITLE
MAINT: CI: Rename 'Nightly CPython' job to 'NumPy main'

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -51,8 +51,8 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         run: ./tools/check_pyext_symbol_hiding.sh build
 
-  test_nightly:
-    name: Nightly CPython
+  test_numpy_main:
+    name: NumPy main
     if: "github.repository == 'scipy/scipy' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]') && !contains(github.ref, 'maintenance/') && !contains(github.base_ref, 'maintenance/')"
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
As far as I can tell, there are no "nightly" packages installed by this CI check. The distinguishing feature seems to be that it builds numpy from the main development branch of the numpy github repository.