### PR TITLE
MAINT: sparse.linalg: Using more concise and user-friendly f-string with the demo file of LGMRES

### DIFF
--- a/scipy/sparse/linalg/_isolve/tests/demo_lgmres.py
+++ b/scipy/sparse/linalg/_isolve/tests/demo_lgmres.py
@@ -9,11 +9,11 @@ problem = "SPARSKIT/drivcav/e05r0200"
 #problem = "misc/hamm/add32"
 
 mm = np.lib._datasource.Repository('https://math.nist.gov/pub/MatrixMarket2/')
-f = mm.open('%s.mtx.gz' % problem)
+f = mm.open(f'{problem}.mtx.gz')
 Am = io.mmread(f).tocsr()
 f.close()
 
-f = mm.open('%s_rhs1.mtx.gz' % problem)
+f = mm.open(f'{problem}_rhs1.mtx.gz')
 b = np.array(io.mmread(f)).ravel()
 f.close()
 
@@ -22,7 +22,7 @@ count = [0]
 
 def matvec(v):
     count[0] += 1
-    sys.stderr.write('%d\r' % count[0])
+    sys.stderr.write(f"{count[0]}\r")
     return Am@v
 
 
@@ -31,13 +31,13 @@ A = la.LinearOperator(matvec=matvec, shape=Am.shape, dtype=Am.dtype)
 M = 100
 
 print("MatrixMarket problem %s" % problem)
-print("Invert %d x %d matrix; nnz = %d" % (Am.shape[0], Am.shape[1], Am.nnz))
+print(f"Invert {Am.shape[0]} x {Am.shape[1]} matrix; nnz = {Am.nnz}")
 
 count[0] = 0
 x0, info = la.gmres(A, b, restrt=M, tol=1e-14)
 count_0 = count[0]
 err0 = np.linalg.norm(Am@x0 - b) / np.linalg.norm(b)
-print("GMRES(%d):" % M, count_0, "matvecs, residual", err0)
+print(f"GMRES({M}): {count_0} matvecs, residual {err0}")
 if info != 0:
     print("Didn't converge")
 
@@ -45,8 +45,8 @@ count[0] = 0
 x1, info = la.lgmres(A, b, inner_m=M-6*2, outer_k=6, tol=1e-14)
 count_1 = count[0]
 err1 = np.linalg.norm(Am@x1 - b) / np.linalg.norm(b)
-print("LGMRES(%d,6) [same memory req.]:" % (M-2*6), count_1,
-      "matvecs, residual:", err1)
+print(f"LGMRES({M - 2*6}, 6) [same memory req.]: {count_1} "
+      f"matvecs, residual: {err1}")
 if info != 0:
     print("Didn't converge")
 
@@ -54,7 +54,7 @@ count[0] = 0
 x2, info = la.lgmres(A, b, inner_m=M-6, outer_k=6, tol=1e-14)
 count_2 = count[0]
 err2 = np.linalg.norm(Am@x2 - b) / np.linalg.norm(b)
-print("LGMRES(%d,6) [same subspace size]:" % (M-6), count_2,
-      "matvecs, residual:", err2)
+print(f"LGMRES({M - 6}, 6) [same subspace size]: {count_2} "
+      f"matvecs, residual: {err2}")
 if info != 0:
     print("Didn't converge")


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
I think the demo file needs to shows the user the most concise and user-friendly expression so far, and the strings in the original demo always feels like cubersome C-string. So I changed the original string expression into the f-string. Just my feeling and opinion.

#### Additional information
<!--Any additional information you think is important.-->
