### PR TITLE
MAINT: interpolate: speed up the RBFInterpolator evaluation with high dimensional interpolants

### DIFF
--- a/scipy/interpolate/_rbfinterp.py
+++ b/scipy/interpolate/_rbfinterp.py
@@ -8,7 +8,9 @@ from scipy.spatial import KDTree
 from scipy.special import comb
 from scipy.linalg.lapack import dgesv  # type: ignore[attr-defined]
 
-from ._rbfinterp_pythran import _build_system, _evaluate, _polynomial_matrix
+from ._rbfinterp_pythran import (_build_system,
+                                 _build_evaluation_coefficients,
+                                 _polynomial_matrix)
 
 
 __all__ = ["RBFInterpolator"]
@@ -435,12 +437,24 @@ class RBFInterpolator:
             for i in range(0, nx, chunksize):
                 # I had to use copy() here because pythran doesnt seem to
                 # accept views
-                vec = _evaluate(x[i:i + chunksize, :], y, self.kernel,
-                                self.epsilon, self.powers, shift, scale)
+                vec = _build_evaluation_coefficients(
+                    x[i:i + chunksize, :],
+                    y,
+                    self.kernel,
+                    self.epsilon,
+                    self.powers,
+                    shift,
+                    scale)
                 out[i:i + chunksize, :] = np.dot(vec, coeffs)
         else:
-            vec = _evaluate(x, y, self.kernel, self.epsilon, self.powers,
-                            shift, scale)
+            vec = _build_evaluation_coefficients(
+                x,
+                y,
+                self.kernel,
+                self.epsilon,
+                self.powers,
+                shift,
+                scale)
             out = np.dot(vec, coeffs)
         return out
 

--- a/scipy/interpolate/_rbfinterp.py
+++ b/scipy/interpolate/_rbfinterp.py
@@ -399,7 +399,7 @@ class RBFInterpolator:
             memory_budget=None
     ):
         """
-        Evaluate the interpolation why controlling memory consumption.
+        Evaluate the interpolation while controlling memory consumption.
         We chunk the input if we need more memory than specified.
 
         Parameters
@@ -408,7 +408,7 @@ class RBFInterpolator:
             array of points on which to evaluate
         y: (P, N) float ndarray
             array of points on which we know function values
-        shift: (N, ) array
+        shift: (N, ) ndarray
             Domain shift used to create the polynomial matrix.
         scale : (N,) float ndarray
             Domain scaling used to create the polynomial matrix.

--- a/scipy/interpolate/_rbfinterp.py
+++ b/scipy/interpolate/_rbfinterp.py
@@ -417,7 +417,7 @@ class RBFInterpolator:
                 x, self.y, self.kernel, self.epsilon, self.powers, self._shift,
                 self._scale, self._coeffs
                 )
-            out = np.dot(vec, self._coeff)
+            out = np.dot(vec, self._coeffs)
 
         else:
             # Get the indices of the k nearest observation points to each

--- a/scipy/interpolate/_rbfinterp.py
+++ b/scipy/interpolate/_rbfinterp.py
@@ -466,9 +466,14 @@ class RBFInterpolator:
         if ndim != self.y.shape[1]:
             raise ValueError("Expected the second axis of `x` to have length "
                              f"{self.y.shape[1]}.")
-        # how many floats in memory we already occupy
-        # We use that as a limit for chunking the evaluation
-        memory_budget = x.size + self.y.size + self.d.size
+
+        # Our memory budget for storing RBF coefficients is
+        # based on how many floats in memory we already occupy
+        # If this number is below 1e6 we just use 1e6
+        # This memory budget is used to decide how we chunk
+        # the inputs
+        memory_budget = max(x.size + self.y.size + self.d.size, 1000000)
+
         if self.neighbors is None:
             out = self._chunk_evaluator(
                 x,

--- a/scipy/interpolate/_rbfinterp.py
+++ b/scipy/interpolate/_rbfinterp.py
@@ -412,7 +412,7 @@ class RBFInterpolator:
             Domain shift used to create the polynomial matrix.
         scale : (N,) float ndarray
             Domain scaling used to create the polynomial matrix.
-        coeffs: (Q, P+R) float ndarray
+        coeffs: (P+R, S) float ndarray
             Coefficients in front of basis functions
         memory_budget: int
             Total amount of memory (in units of sizeof(float)) we wish

--- a/scipy/interpolate/_rbfinterp.py
+++ b/scipy/interpolate/_rbfinterp.py
@@ -456,7 +456,7 @@ class RBFInterpolator:
                     xnbr, ynbr, self.kernel, self.epsilon, self.powers, shift,
                     scale, coeffs
                     )
-                out[xidx] = np.dot(vec, self.coeffs)
+                out[xidx] = np.dot(vec, coeffs)
 
 
         out = out.view(self.d_dtype)

--- a/scipy/interpolate/_rbfinterp.py
+++ b/scipy/interpolate/_rbfinterp.py
@@ -422,7 +422,7 @@ class RBFInterpolator:
 
         Returns
         -------
-        (Q, ) float ndarray
+        (Q, S) float ndarray
         Interpolated array
         """
         nx, ndim = x.shape
@@ -435,8 +435,6 @@ class RBFInterpolator:
         if chunksize <= nx:
             out = np.empty((nx, self.d.shape[1]), dtype=float)
             for i in range(0, nx, chunksize):
-                # I had to use copy() here because pythran doesnt seem to
-                # accept views
                 vec = _build_evaluation_coefficients(
                     x[i:i + chunksize, :],
                     y,

--- a/scipy/interpolate/_rbfinterp.py
+++ b/scipy/interpolate/_rbfinterp.py
@@ -436,12 +436,11 @@ class RBFInterpolator:
                 # I had to use copy() here because pythran doesnt seem to
                 # accept views
                 vec = _evaluate(x[i:i + chunksize, :].copy(), y, self.kernel,
-                                self.epsilon, self.powers, shift, scale,
-                                coeffs[i:i + chunksize, :].copy())
+                                self.epsilon, self.powers, shift, scale)
                 out[i:i + chunksize, :] = np.dot(vec, coeffs)
         else:
             vec = _evaluate(x, y, self.kernel, self.epsilon, self.powers,
-                            shift, scale, coeffs)
+                            shift, scale)
             out = np.dot(vec, coeffs)
         return out
 

--- a/scipy/interpolate/_rbfinterp.py
+++ b/scipy/interpolate/_rbfinterp.py
@@ -413,10 +413,11 @@ class RBFInterpolator:
                 )
 
         if self.neighbors is None:
-            out = _evaluate(
+            vec = _evaluate(
                 x, self.y, self.kernel, self.epsilon, self.powers, self._shift,
                 self._scale, self._coeffs
                 )
+            out = np.dot(vec, self._coeff)
 
         else:
             # Get the indices of the k nearest observation points to each
@@ -451,11 +452,12 @@ class RBFInterpolator:
                 shift, scale, coeffs = _build_and_solve_system(
                     ynbr, dnbr, snbr, self.kernel, self.epsilon, self.powers,
                     )
-
-                out[xidx] = _evaluate(
+                vec = _evaluate(
                     xnbr, ynbr, self.kernel, self.epsilon, self.powers, shift,
                     scale, coeffs
                     )
+                out[xidx] = np.dot(vec, self.coeffs)
+
 
         out = out.view(self.d_dtype)
         out = out.reshape((nx,) + self.d_shape)

--- a/scipy/interpolate/_rbfinterp.py
+++ b/scipy/interpolate/_rbfinterp.py
@@ -435,7 +435,7 @@ class RBFInterpolator:
             for i in range(0, nx, chunksize):
                 # I had to use copy() here because pythran doesnt seem to
                 # accept views
-                vec = _evaluate(x[i:i + chunksize, :].copy(), y, self.kernel,
+                vec = _evaluate(x[i:i + chunksize, :], y, self.kernel,
                                 self.epsilon, self.powers, shift, scale)
                 out[i:i + chunksize, :] = np.dot(vec, coeffs)
         else:

--- a/scipy/interpolate/_rbfinterp.py
+++ b/scipy/interpolate/_rbfinterp.py
@@ -395,7 +395,31 @@ class RBFInterpolator:
                           coeffs,
                           memory_budget=None):
         """
-        Evaluate interpolation in chunks to save some memory
+        Evaluate the interpolation why controlling memory consumption.
+        We chunk the input if we need more memory than specified.
+
+        Parameters
+        ----------
+        x : (Q, N) float ndarray
+            array of points on which to evaluate
+        y: (P, N) float ndarray
+            array of points on which we know function values
+        shift: (N, ) array
+            Domain shift used to create the polynomial matrix.
+        scale : (N,) float ndarray
+            Domain scaling used to create the polynomial matrix.
+        coeffs: (Q, P+R) float ndarray
+            Coefficients in front of basis functions
+        memory_budget: int
+            Total amount of memory (in units of sizeof(float)) we wish
+            to devote for storing the array of coefficients for
+            interpolated points. If we need more memory than that, we
+            chunk the input.
+
+        Returns
+        -------
+        (Q, ) float ndarray
+        Interpolated array
         """
         nx, ndim = x.shape
         if self.neighbors is None:
@@ -441,7 +465,8 @@ class RBFInterpolator:
         if ndim != self.y.shape[1]:
             raise ValueError("Expected the second axis of `x` to have length "
                              f"{self.y.shape[1]}.")
-        # how many floats in memory we already have
+        # how many floats in memory we already occupy
+        # We use that as a limit for chunking the evaluation
         memory_budget = x.size + self.y.size + self.d.size
         if self.neighbors is None:
             out = self.__chunk_evaluator(x,

--- a/scipy/interpolate/_rbfinterp.py
+++ b/scipy/interpolate/_rbfinterp.py
@@ -396,7 +396,7 @@ class RBFInterpolator:
             shift,
             scale,
             coeffs,
-            memory_budget=None
+            memory_budget=1000000
     ):
         """
         Evaluate the interpolation while controlling memory consumption.

--- a/scipy/interpolate/_rbfinterp.py
+++ b/scipy/interpolate/_rbfinterp.py
@@ -10,16 +10,26 @@ from scipy.linalg.lapack import dgesv  # type: ignore[attr-defined]
 
 from ._rbfinterp_pythran import _build_system, _evaluate, _polynomial_matrix
 
+
 __all__ = ["RBFInterpolator"]
+
 
 # These RBFs are implemented.
 _AVAILABLE = {
-    "linear", "thin_plate_spline", "cubic", "quintic", "multiquadric",
-    "inverse_multiquadric", "inverse_quadratic", "gaussian"
-}
+    "linear",
+    "thin_plate_spline",
+    "cubic",
+    "quintic",
+    "multiquadric",
+    "inverse_multiquadric",
+    "inverse_quadratic",
+    "gaussian"
+    }
+
 
 # The shape parameter does not need to be specified when using these RBFs.
 _SCALE_INVARIANT = {"linear", "thin_plate_spline", "cubic", "quintic"}
+
 
 # For RBFs that are conditionally positive definite of order m, the interpolant
 # should include polynomial terms with degree >= m - 1. Define the minimum
@@ -32,7 +42,7 @@ _NAME_TO_MIN_DEGREE = {
     "thin_plate_spline": 1,
     "cubic": 1,
     "quintic": 2
-}
+    }
 
 
 def _monomial_powers(ndim, degree):
@@ -95,8 +105,9 @@ def _build_and_solve_system(y, d, smoothing, kernel, epsilon, powers):
         Domain scaling used to create the polynomial matrix.
 
     """
-    lhs, rhs, shift, scale = _build_system(y, d, smoothing, kernel, epsilon,
-                                           powers)
+    lhs, rhs, shift, scale = _build_system(
+        y, d, smoothing, kernel, epsilon, powers
+        )
     _, _, coeffs, info = dgesv(lhs, rhs, overwrite_a=True, overwrite_b=True)
     if info < 0:
         raise ValueError(f"The {-info}-th argument had an illegal value.")
@@ -104,12 +115,14 @@ def _build_and_solve_system(y, d, smoothing, kernel, epsilon, powers):
         msg = "Singular matrix."
         nmonos = powers.shape[0]
         if nmonos > 0:
-            pmat = _polynomial_matrix((y - shift) / scale, powers)
+            pmat = _polynomial_matrix((y - shift)/scale, powers)
             rank = np.linalg.matrix_rank(pmat)
             if rank < nmonos:
-                msg = ("Singular matrix. The matrix of monomials evaluated at "
-                       "the data point coordinates does not have full column "
-                       f"rank ({rank}/{nmonos}).")
+                msg = (
+                    "Singular matrix. The matrix of monomials evaluated at "
+                    "the data point coordinates does not have full column "
+                    f"rank ({rank}/{nmonos})."
+                    )
 
         raise LinAlgError(msg)
 
@@ -265,9 +278,8 @@ class RBFInterpolator:
     >>> plt.show()
 
     """
-    def __init__(self,
-                 y,
-                 d,
+
+    def __init__(self, y, d,
                  neighbors=None,
                  smoothing=0.0,
                  kernel="thin_plate_spline",
@@ -283,7 +295,8 @@ class RBFInterpolator:
         d = np.asarray(d, dtype=d_dtype, order="C")
         if d.shape[0] != ny:
             raise ValueError(
-                f"Expected the first axis of `d` to have length {ny}.")
+                f"Expected the first axis of `d` to have length {ny}."
+                )
 
         d_shape = d.shape[1:]
         d = d.reshape((ny, -1))
@@ -296,10 +309,11 @@ class RBFInterpolator:
             smoothing = np.full(ny, smoothing, dtype=float)
         else:
             smoothing = np.asarray(smoothing, dtype=float, order="C")
-            if smoothing.shape != (ny, ):
+            if smoothing.shape != (ny,):
                 raise ValueError(
                     "Expected `smoothing` to be a scalar or have shape "
-                    f"({ny},).")
+                    f"({ny},)."
+                    )
 
         kernel = kernel.lower()
         if kernel not in _AVAILABLE:
@@ -311,7 +325,8 @@ class RBFInterpolator:
             else:
                 raise ValueError(
                     "`epsilon` must be specified if `kernel` is not one of "
-                    f"{_SCALE_INVARIANT}.")
+                    f"{_SCALE_INVARIANT}."
+                    )
         else:
             epsilon = float(epsilon)
 
@@ -327,7 +342,9 @@ class RBFInterpolator:
                     f"`degree` should not be below {min_degree} when `kernel` "
                     f"is '{kernel}'. The interpolant may not be uniquely "
                     "solvable, and the smoothing parameter may have an "
-                    "unintuitive effect.", UserWarning)
+                    "unintuitive effect.",
+                    UserWarning
+                    )
 
         if neighbors is None:
             nobs = ny
@@ -345,11 +362,12 @@ class RBFInterpolator:
             raise ValueError(
                 f"At least {powers.shape[0]} data points are required when "
                 f"`degree` is {degree} and the number of dimensions is {ndim}."
-            )
+                )
 
         if neighbors is None:
             shift, scale, coeffs = _build_and_solve_system(
-                y, d, smoothing, kernel, epsilon, powers)
+                y, d, smoothing, kernel, epsilon, powers
+                )
 
             # Make these attributes private since they do not always exist.
             self._shift = shift

--- a/scipy/interpolate/_rbfinterp.py
+++ b/scipy/interpolate/_rbfinterp.py
@@ -387,13 +387,15 @@ class RBFInterpolator:
         self.epsilon = epsilon
         self.powers = powers
 
-    def __chunk_evaluator(self,
-                          x,
-                          y,
-                          shift,
-                          scale,
-                          coeffs,
-                          memory_budget=None):
+    def _chunk_evaluator(
+            self,
+            x,
+            y,
+            shift,
+            scale,
+            coeffs,
+            memory_budget=None
+    ):
         """
         Evaluate the interpolation why controlling memory consumption.
         We chunk the input if we need more memory than specified.
@@ -431,7 +433,7 @@ class RBFInterpolator:
         if chunksize <= nx:
             out = np.empty((nx, self.d.shape[1]), dtype=float)
             for i in range(0, nx, chunksize):
-                # i had to use copy() here because pythran doesnt seem to
+                # I had to use copy() here because pythran doesnt seem to
                 # accept views
                 vec = _evaluate(x[i:i + chunksize, :].copy(), y, self.kernel,
                                 self.epsilon, self.powers, shift, scale,
@@ -469,12 +471,13 @@ class RBFInterpolator:
         # We use that as a limit for chunking the evaluation
         memory_budget = x.size + self.y.size + self.d.size
         if self.neighbors is None:
-            out = self.__chunk_evaluator(x,
-                                         self.y,
-                                         self._shift,
-                                         self._scale,
-                                         self._coeffs,
-                                         memory_budget=memory_budget)
+            out = self._chunk_evaluator(
+                x,
+                self.y,
+                self._shift,
+                self._scale,
+                self._coeffs,
+                memory_budget=memory_budget)
         else:
             # Get the indices of the k nearest observation points to each
             # evaluation point.
@@ -513,12 +516,13 @@ class RBFInterpolator:
                     self.epsilon,
                     self.powers,
                 )
-                out[xidx] = self.__chunk_evaluator(xnbr,
-                                                   ynbr,
-                                                   shift,
-                                                   scale,
-                                                   coeffs,
-                                                   memory_budget=memory_budget)
+                out[xidx] = self._chunk_evaluator(
+                    xnbr,
+                    ynbr,
+                    shift,
+                    scale,
+                    coeffs,
+                    memory_budget=memory_budget)
 
         out = out.view(self.d_dtype)
         out = out.reshape((nx, ) + self.d_shape)

--- a/scipy/interpolate/_rbfinterp_pythran.py
+++ b/scipy/interpolate/_rbfinterp_pythran.py
@@ -164,15 +164,17 @@ def _build_system(y, d, smoothing, kernel, epsilon, powers):
     return lhs, rhs, shift, scale
 
 
-# pythran export _evaluate(float[:, :],
+# pythran export _build_evaluation_coefficients(float[:, :],
 #                          float[:, :],
 #                          str,
 #                          float,
 #                          int[:, :],
 #                          float[:],
 #                          float[:])
-def _evaluate(x, y, kernel, epsilon, powers, shift, scale):
-    """Evaluate the RBF interpolants at `x`.
+def _build_evaluation_coefficients(x, y, kernel, epsilon, powers,
+                                   shift, scale):
+    """Construct the coefficients needed to evaluate
+    the RBF.
 
     Parameters
     ----------

--- a/scipy/interpolate/_rbfinterp_pythran.py
+++ b/scipy/interpolate/_rbfinterp_pythran.py
@@ -170,9 +170,8 @@ def _build_system(y, d, smoothing, kernel, epsilon, powers):
 #                          float,
 #                          int[:, :],
 #                          float[:],
-#                          float[:],
-#                          float[:, :])
-def _evaluate(x, y, kernel, epsilon, powers, shift, scale, coeffs):
+#                          float[:])
+def _evaluate(x, y, kernel, epsilon, powers, shift, scale):
     """Evaluate the RBF interpolants at `x`.
 
     Parameters
@@ -191,8 +190,6 @@ def _evaluate(x, y, kernel, epsilon, powers, shift, scale, coeffs):
         Shifts the polynomial domain for numerical stability.
     scale : (N,) float ndarray
         Scales the polynomial domain for numerical stability.
-    coeffs : (P + R, S) float ndarray
-        Coefficients for each RBF and monomial.
 
     Returns
     -------

--- a/scipy/interpolate/_rbfinterp_pythran.py
+++ b/scipy/interpolate/_rbfinterp_pythran.py
@@ -173,7 +173,7 @@ def _build_system(y, d, smoothing, kernel, epsilon, powers):
 #                          float[:],
 #                          float[:, :])
 def _evaluate(x, y, kernel, epsilon, powers, shift, scale, coeffs):
-    """Evaluate the RBF interpolant at `x`.
+    """Evaluate the RBF interpolants at `x`.
 
     Parameters
     ----------
@@ -196,13 +196,12 @@ def _evaluate(x, y, kernel, epsilon, powers, shift, scale, coeffs):
 
     Returns
     -------
-    (Q, S) float ndarray
+    (Q, P + R) float ndarray
 
     """
     q = x.shape[0]
     p = y.shape[0]
     r = powers.shape[0]
-    s = coeffs.shape[1]
     kernel_func = NAME_TO_FUNC[kernel]
 
     yeps = y*epsilon

--- a/scipy/interpolate/_rbfinterp_pythran.py
+++ b/scipy/interpolate/_rbfinterp_pythran.py
@@ -209,17 +209,10 @@ def _evaluate(x, y, kernel, epsilon, powers, shift, scale, coeffs):
     xeps = x*epsilon
     xhat = (x - shift)/scale
 
-    out = np.zeros((q, s), dtype=float)
-    vec = np.empty((p + r,), dtype=float)
+    vec = np.empty((q, p + r), dtype=float)
     for i in range(q):
-        kernel_vector(xeps[i], yeps, kernel_func, vec[:p])
-        polynomial_vector(xhat[i], powers, vec[p:])
-        # Compute the dot product between coeffs and vec. Do not use np.dot
-        # because that introduces build complications with BLAS (see
-        # https://github.com/serge-sans-paille/pythran/issues/1346)
-        for j in range(s):
-            for k in range(p + r):
-                out[i, j] += coeffs[k, j]*vec[k]
+        kernel_vector(xeps[i], yeps, kernel_func, vec[i, :p])
+        polynomial_vector(xhat[i], powers, vec[i, p:])
 
-    return out
+    return vec
 

--- a/scipy/interpolate/tests/test_rbfinterp.py
+++ b/scipy/interpolate/tests/test_rbfinterp.py
@@ -154,6 +154,30 @@ class _TestRBFInterpolator:
 
         assert_allclose(yitp1, yitp2, atol=1e-8)
 
+    def test_chunking(self):
+        # If the observed data comes from a polynomial, then the interpolant
+        # should be able to reproduce the polynomial exactly, provided that
+        # `degree` is sufficiently high.
+        rng = np.random.RandomState(0)
+        seq = Halton(2, scramble=False, seed=rng)
+        degree = 3
+
+        largeN = 1000000 + 33
+        # this is large to check that chunking of the RBFInterpolator is tested
+        x = seq.random(50)
+        xitp = seq.random(largeN)
+
+        P = _vandermonde(x, degree)
+        Pitp = _vandermonde(xitp, degree)
+
+        poly_coeffs = rng.normal(0.0, 1.0, P.shape[1])
+
+        y = P.dot(poly_coeffs)
+        yitp1 = Pitp.dot(poly_coeffs)
+        yitp2 = self.build(x, y, degree=degree)(xitp)
+
+        assert_allclose(yitp1, yitp2, atol=1e-8)
+
     def test_vector_data(self):
         # Make sure interpolating a vector field is the same as interpolating
         # each component separately.


### PR DESCRIPTION
#### Reference issue
Closes: #15150 

#### What does this implement/fix?
This moves out the matrix multiplication out of pythran code and instead uses np.dot which is noticeably faster
due to blas. Because this code structure may potentially lead to more memory use, the evaluation is being split into chunks if needed.

The speed up is small for low dimensional interpolants (<10%), but reaches almost factor of 40  for interpolants with 4000 dimensions.

#### Additional information
The performance comparison. 
Here is the comparison of the time required to evaluate the model vs number of dimensions of the interpolant (4,40,400,4000).
The first number is the performance of hand-coded Rbf() evaluation. The second one is the performance of RBFInterpolator. 
Performance of patched code:
```
Ndim TimeRbf TimeRBFInterpolator
4 0.071  0.088
40 0.076  0.086
400 0.128  0.1430
4000 0.592  0.604
```
Performance of original code: 
```
Ndim TimeRbf TimeRBFInterpolator
4 0.071 0.098
40 0.076 0.320
400 0.128 2.605
4000 0.576 27.779
```
This is the code doing the testing (executed using 
`
env OMP_NUM_THREADS=1  python test.py 
`)

The code that does testing:

```python
import numpy as np
import scipy.interpolate
import time

rstate = np.random.default_rng(44)


def doit(nx, neval=1000, ndim=2, npt=6000):
    # initial point distribution
    xs = rstate.normal(size=(ndim, npt))
    xgrid = np.arange(nx)
    data = (xgrid[None, :] * xs[0][:, None]**2 + xs[-1][:, None]**2)

    # number of points
    xnew = rstate.normal(size=(ndim, neval))

    # use the old interface on 1d data to get coefficients to apply for the
    # to the 4000d data vectors
    RR = scipy.interpolate.Rbf(*([_ for _ in xs] + [data[:, 0]]))
    coeffs = scipy.linalg.solve(RR.A, data)
    t1 = time.time()
    r = RR._call_norm(xnew, RR.xi)
    pred0 = np.dot(RR._function(r), coeffs)
    t20 = time.time()

    # use the new interface
    RR = scipy.interpolate.RBFInterpolator(xs.T, data)
    t21 = time.time()
    pred1 = RR(xnew.T)
    t3 = time.time()

    return (t20 - t1, t3 - t21)


print('Ndim TimeRbf TimeRBFInterpolator')
for i in [4, 40, 400, 4000]:
    res = doit(i)
    print('%d %.3f %.3f' % (i, res[0], res[1]))
```