### PR TITLE
MAINT: version bounds before 1.8.0rc1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,11 +9,11 @@
 
 [build-system]
 requires = [
-    "wheel",
-    "setuptools<58.5",
-    "Cython>=0.29.18",
-    "pybind11>=2.4.3",
-    "pythran>=0.9.12",
+    "wheel<0.38.0",
+    "setuptools<60.0.0",
+    "Cython>=0.29.18,<3.0",
+    "pybind11>=2.4.3,<2.9.0",
+    "pythran>=0.9.12,<0.11.0",
 
     # NumPy dependencies - to update these, sync from
     # https://github.com/scipy/oldest-supported-numpy/, and then
@@ -52,9 +52,9 @@ maintainers = [
 # Note: Python and NumPy upper version bounds should be set correctly in
 # release branches, see:
 #     https://scipy.github.io/devdocs/dev/core-dev/index.html#version-ranges-for-numpy-and-other-dependencies
-requires-python = ">=3.8"
+requires-python = ">=3.8,<3.11"
 dependencies = [
-    "numpy>=1.17.3",
+    "numpy>=1.17.3,<1.25.0",
 ]
 readme = "README.rst"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,11 @@ requires = [
     "numpy==1.20.0; python_version=='3.8' and platform_machine=='arm64' and platform_system=='Darwin'",
     "numpy==1.20.0; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Darwin'",
 
+    # Python 3.8 on s390x requires at least 1.17.5, see https://github.com/scipy/oldest-supported-numpy/issues/29
+    "numpy==1.17.5; python_version=='3.8' and platform_machine=='s390x' and platform_python_implementation != 'PyPy'",
+
     # default numpy requirements
-    "numpy==1.17.3; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'",
+    "numpy==1.17.3; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64' and platform_machine!='s390x' and platform_python_implementation != 'PyPy'",
     "numpy==1.19.3; python_version=='3.9' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_python_implementation != 'PyPy'",
     "numpy==1.21.4; python_version=='3.10' and platform_python_implementation != 'PyPy'",
 

--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -138,8 +138,8 @@ else:
     from scipy._lib import _pep440
     # In maintenance branch, change to np_maxversion N+3 if numpy is at N
     # See setup.py for more details
-    np_minversion = '1.16.5'
-    np_maxversion = '9.9.99'
+    np_minversion = '1.17.3'
+    np_maxversion = '1.25.0'
     if (_pep440.parse(__numpy_version__) < _pep440.Version(np_minversion) or
             _pep440.parse(__numpy_version__) >= _pep440.Version(np_maxversion)):
         import warnings

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ MAJOR = 1
 MINOR = 8
 MICRO = 0
 ISRELEASED = False
-IS_RELEASE_BRANCH = False
+IS_RELEASE_BRANCH = True
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
 
@@ -540,9 +540,9 @@ def setup_package():
     #            in N+1 will turn into errors in N+3
     # For Python versions, if releases is (e.g.) <=3.9.x, set bound to 3.10
     np_minversion = '1.17.3'
-    np_maxversion = '9.9.99'
+    np_maxversion = '1.25.0'
     python_minversion = '3.8'
-    python_maxversion = '3.10'
+    python_maxversion = '3.11'
     if IS_RELEASE_BRANCH:
         req_np = 'numpy>={},<{}'.format(np_minversion, np_maxversion)
         req_py = '>={},<{}'.format(python_minversion, python_maxversion)


### PR DESCRIPTION
* attempt to add upper version bounds
before 1.8.0rc1

@rgommers I usually depend on you to find my mistakes on the version bounds stuff.

For reference, for `maintenance/1.7.x` last time we did this for the bounds: https://github.com/scipy/scipy/pull/14145