### PR TITLE
MAINT: Replace use of `pytest.warns(None)` with `warnings.catch_warnings`

### DIFF
--- a/scipy/fft/tests/test_fftlog.py
+++ b/scipy/fft/tests/test_fftlog.py
@@ -1,3 +1,4 @@
+import warnings
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest
@@ -108,13 +109,13 @@ def test_fht_special_cases():
 
     # case 1: xp in M, xm in M => well-defined transform
     mu, bias = -4.0, 1.0
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         fht(a, dln, mu, bias=bias)
         assert not record, 'fht warned about a well-defined transform'
 
     # case 2: xp not in M, xm in M => well-defined transform
     mu, bias = -2.5, 0.5
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         fht(a, dln, mu, bias=bias)
         assert not record, 'fht warned about a well-defined transform'
 

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -1,3 +1,4 @@
+import warnings
 import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 from pytest import raises as assert_raises
@@ -118,6 +119,7 @@ def test_undirected():
         for directed_in in (True, False):
             check(method, directed_in)
 
+
 def test_directed_sparse_zero():
     # test directed sparse graph with zero-weight edge and two connected components
     def check(method):
@@ -127,6 +129,7 @@ def test_directed_sparse_zero():
 
     for method in methods:
         check(method)
+
 
 def test_undirected_sparse_zero():
     def check(method, directed_in):
@@ -312,7 +315,7 @@ def test_buffer(method):
 
 
 def test_NaN_warnings():
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         shortest_path(np.array([[0, 1], [np.nan, 0]]))
     for r in record:
         assert r.category is not RuntimeWarning


### PR DESCRIPTION
The use of `pytest.warns(None)` is deprecated in pytest 7.0.0.
The alternative suggested by the deprecation warning, `pytest.warns()`,
does not match the old behavior.  In fact, `pytest.warns()` is intended
specifically to raise an error if the code in the context does not raise
the given warning, and in pytest 7.0.0rc1, the default warning used by
`pytest.warns()` is the generic `Warning` class.

This issue is discussed in the following pytest issues:

* https://github.com/pytest-dev/pytest/issues/9002
* https://github.com/pytest-dev/pytest/issues/9386

There, the recommended alternative is to use `warnings.catch_warnings`.
That is the change made here.

Closes gh-15186
