### PR TITLE
TST: test DCT and DST for given dtype

### DIFF
--- a/scipy/fft/tests/test_real_transforms.py
+++ b/scipy/fft/tests/test_real_transforms.py
@@ -47,7 +47,7 @@ def test_identity_1d(forward, backward, type, n, axis, norm, orthogonalize):
 def test_identity_1d_overwrite(forward, backward, type, dtype, axis, norm,
                                overwrite_x):
     # Test the identity f^-1(f(x)) == x
-    x = np.random.rand(7, 8)
+    x = np.random.rand(7, 8).astype(dtype)
     x_orig = x.copy()
 
     y = forward(x, type, axis=axis, norm=norm, overwrite_x=overwrite_x)


### PR DESCRIPTION
#### What does this implement/fix?
<!--Please explain your changes.-->
The test of DCT and DST is parametrized, giving different data types,
this variable is, however, never used.

This changes the input data to the according data type the same way `test_identity_nd_overwrite` does.

#### Additional information
<!--Any additional information you think is important.-->
