### PR TITLE
BUG: stats: Fix handling of support endpoints in two distributions.

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1350,6 +1350,12 @@ class cosine_gen(rv_continuous):
         # cosine.pdf(x) = 1/(2*pi) * (1+cos(x))
         return 1.0/2/np.pi*(1+np.cos(x))
 
+    def _logpdf(self, x):
+        c = np.cos(x)
+        return _lazywhere(c != -1, (c,),
+                          lambda c: np.log1p(c) - np.log(2*np.pi),
+                          fillvalue=-np.inf)
+
     def _cdf(self, x):
         return scu._cosine_cdf(x)
 
@@ -2876,7 +2882,10 @@ class gengamma_gen(rv_continuous):
         return np.exp(self._logpdf(x, a, c))
 
     def _logpdf(self, x, a, c):
-        return np.log(abs(c)) + sc.xlogy(c*a - 1, x) - x**c - sc.gammaln(a)
+        return _lazywhere((x != 0) | (c > 0), (x, c),
+                          lambda x, c: (np.log(abs(c)) + sc.xlogy(c*a - 1, x)
+                                        - x**c - sc.gammaln(a)),
+                          fillvalue=-np.inf)
 
     def _cdf(self, x, a, c):
         xc = x**c

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -557,9 +557,8 @@ def check_pdf_logpdf_at_endpoints(distfn, args, msg):
         suppress_messsages = [
             "divide by zero encountered in true_divide",  # multiple distributions
             "divide by zero encountered in log",  # multiple distributions
-            "divide by zero encountered in power",  # gengamma
             "invalid value encountered in add",  # genextreme
-            "invalid value encountered in subtract",  # gengamma
+            "invalid value encountered in subtract",
             "invalid value encountered in multiply"  # recipinvgauss
             ]
         for msg in suppress_messsages:

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -4871,6 +4871,15 @@ def test_gengamma_edge():
     p = stats.gengamma.pdf(0, 1, 1)
     assert_equal(p, 1.0)
 
+
+def test_gengamma_endpoint_with_neg_c():
+    p = stats.gengamma.pdf(0, 1, -1)
+    assert p == 0.0
+    logp = stats.gengamma.logpdf(0, 1, -1)
+    assert logp == -np.inf
+
+
+def test_gengamma_munp():
     # Regression tests for gh-4724.
     p = stats.gengamma._munp(-2, 200, 1.)
     assert_almost_equal(p, 1./199/198)
@@ -6124,6 +6133,11 @@ def test_cosine_cdf_sf(x, expected):
 def test_cosine_ppf_isf(p, expected):
     assert_allclose(stats.cosine.ppf(p), expected)
     assert_allclose(stats.cosine.isf(p), -expected)
+
+
+def test_cosine_logpdf_endpoints():
+    logp = stats.cosine.logpdf([-np.pi, np.pi])
+    assert_equal(logp, [-np.inf, -np.inf])
 
 
 def test_distr_params_lists():


### PR DESCRIPTION
* `cosine.logpdf(-np.pi)` and `cosine.logpdf(np.pi)` would generate
  `RuntimeWarning: divide by zero encountered in log`
* With `c < 0`, `gengamma.pdf(0, a, c)` and `gengamma.logpdf(0, a, c)`
  would raise RuntimeWarnings and return nan.
