### PR TITLE
MAINT: build dependency updates

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Installing packages
         run: |      
           python3.8-dbg -c 'import sys; print("Python debug build:", hasattr(sys, "gettotalrefcount"))'
-          python3.8-dbg -m pip install --upgrade pip 'setuptools<58.5' wheel
+          python3.8-dbg -m pip install --upgrade pip setuptools wheel
           python3.8-dbg -m pip install --upgrade numpy cython pytest pytest-xdist pybind11
           python3.8-dbg -m pip install --upgrade mpmath gmpy2==2.1.0rc1 pythran threadpoolctl
           python3.8-dbg -m pip uninstall -y nose

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -172,7 +172,7 @@ stages:
             curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
             python3.8 get-pip.py && \
             pip3 --version && \
-            pip3 install 'setuptools<58.5' wheel --user && \
+            pip3 install setuptools wheel --user && \
             pip3 install numpy==1.17.3 cython==0.29.18 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath matplotlib==3.1.3 pythran --user && \
             apt-get -y install gcc-5 g++-5 gfortran-8 wget && \
             cd .. && \
@@ -243,7 +243,7 @@ stages:
         git submodule update --init
       displayName: 'Fetch submodules'
     - script: |
-        python -m pip install --upgrade pip "setuptools<50.0" wheel
+        python -m pip install --upgrade pip setuptools wheel
       displayName: 'Install tools'
     - powershell: |
         $pyversion = python -c "import sys; print(sys.version.split()[0])"

--- a/ci/azure-travis-template.yaml
+++ b/ci/azure-travis-template.yaml
@@ -64,7 +64,7 @@ steps:
   displayName: 'Add ccache to path'
 - script: >-
     pip install --upgrade ${{parameters.numpy_spec}} &&
-    pip install --upgrade pip==20.2.4 'setuptools<58.5' wheel &&
+    pip install --upgrade pip==20.2.4 setuptools wheel &&
     pip install ${{parameters.other_spec}}
     cython
     gmpy2==2.1.0rc1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@
 [build-system]
 requires = [
     "wheel",
-    "setuptools<58.5",
+    "setuptools",
     "Cython>=0.29.18",
     "pybind11>=2.4.3",
     "pythran>=0.9.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,11 @@ requires = [
     "numpy==1.20.0; python_version=='3.8' and platform_machine=='arm64' and platform_system=='Darwin'",
     "numpy==1.20.0; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Darwin'",
 
+    # Python 3.8 on s390x requires at least 1.17.5, see https://github.com/scipy/oldest-supported-numpy/issues/29
+    "numpy==1.17.5; python_version=='3.8' and platform_machine=='s390x' and platform_python_implementation != 'PyPy'",
+
     # default numpy requirements
-    "numpy==1.17.3; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'",
+    "numpy==1.17.3; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64' and platform_machine!='s390x' and platform_python_implementation != 'PyPy'",
     "numpy==1.19.3; python_version=='3.9' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_python_implementation != 'PyPy'",
     "numpy==1.21.4; python_version=='3.10' and platform_python_implementation != 'PyPy'",
 

--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -136,7 +136,7 @@ else:
     from scipy._lib import _pep440
     # In maintenance branch, change to np_maxversion N+3 if numpy is at N
     # See setup.py for more details
-    np_minversion = '1.16.5'
+    np_minversion = '1.17.3'
     np_maxversion = '9.9.99'
     if (_pep440.parse(__numpy_version__) < _pep440.Version(np_minversion) or
             _pep440.parse(__numpy_version__) >= _pep440.Version(np_maxversion)):


### PR DESCRIPTION
See commit messages for more details.

If unpinning `setuptools` works, we should update the upper bound in gh-15191 for `1.8.0`.