### PR TITLE
MAINT: special: Don't use macro for 'extern "C"' in strictly C++ files.

### DIFF
--- a/scipy/special/_faddeeva.cxx
+++ b/scipy/special/_faddeeva.cxx
@@ -4,7 +4,7 @@
 
 using namespace std;
 
-EXTERN_C_START
+extern "C" {
 
 npy_cdouble faddeeva_w(npy_cdouble zp)
 {
@@ -149,4 +149,4 @@ double faddeeva_voigt_profile(double x, double sigma, double gamma)
     return real(w) / sigma / SQRT_2PI;
 }
 
-EXTERN_C_END
+}  // extern "C"

--- a/scipy/special/_wright.cxx
+++ b/scipy/special/_wright.cxx
@@ -4,7 +4,7 @@
 
 using namespace std;
 
-EXTERN_C_START
+extern "C" {
 
 npy_cdouble wrightomega(npy_cdouble zp)
 {
@@ -18,4 +18,4 @@ double wrightomega_real(double x)
   return wright::wrightomega_real(x);
 }
 
-EXTERN_C_END
+}  // extern "C"

--- a/scipy/special/ellint_carlson_wrap.cxx
+++ b/scipy/special/ellint_carlson_wrap.cxx
@@ -1,24 +1,11 @@
 #include "ellint_carlson_wrap.hh"
-
-
-#undef _BEGIN_EXTERN_C
-#undef _END_EXTERN_C
-#ifdef __cplusplus
-#define _BEGIN_EXTERN_C	extern "C" {
-#define _END_EXTERN_C	}
-#else
-#define _BEGIN_EXTERN_C	/* nothing */
-#define _END_EXTERN_C	/* nothing */
-#endif
-
-
 #include "sf_error.h"
 
 
 static constexpr double ellip_rerr = 5e-16;
 
 
-_BEGIN_EXTERN_C
+extern "C" {
 
 
 double fellint_RC(double x, double y)
@@ -151,8 +138,4 @@ npy_cdouble cellint_RJ(npy_cdouble x, npy_cdouble y, npy_cdouble z, npy_cdouble 
 }
 
 
-_END_EXTERN_C
-
-
-#undef _BEGIN_EXTERN_C
-#undef _END_EXTERN_C
+}  // extern "C"


### PR DESCRIPTION
The files _faddeeva.cxx, _wright.cxx, and ellint_carlson_wrap.cxx
are strictly C++ files.  They cannot be compiled by a C compiler.
So there is no need for `extern "C" {}` to be hidden in a macro,
and the code is clearer without the use of the macros.
