### PR TITLE
BUG: stats: Fix spurious warnings generated by several distributions.

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -1864,7 +1864,9 @@ class rv_continuous(rv_generic):
 
     # Could also define any of these
     def _logpdf(self, x, *args):
-        return log(self._pdf(x, *args))
+        p = self._pdf(x, *args)
+        with np.errstate(divide='ignore'):
+            return log(p)
 
     def _cdf_single(self, x, *args):
         _a, _b = self._get_support(*args)

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -551,23 +551,12 @@ def check_pdf_logpdf_at_endpoints(distfn, args, msg):
     points = np.array([0, 1])
     vals = distfn.ppf(points, *args)
     vals = vals[np.isfinite(vals)]
-    with npt.suppress_warnings() as sup:
-        # Several distributions incur divide by zero or encounter invalid values when computing
-        # the pdf or logpdf at the endpoints.
-        suppress_messsages = [
-            "divide by zero encountered in true_divide",  # multiple distributions
-            "divide by zero encountered in log",  # multiple distributions
-            "invalid value encountered in add",  # genextreme
-            ]
-        for msg in suppress_messsages:
-            sup.filter(category=RuntimeWarning, message=msg)
-
-        pdf = distfn.pdf(vals, *args)
-        logpdf = distfn.logpdf(vals, *args)
-        pdf = pdf[(pdf != 0) & np.isfinite(pdf)]
-        logpdf = logpdf[np.isfinite(logpdf)]
-        msg += " - logpdf-log(pdf) relationship"
-        npt.assert_almost_equal(np.log(pdf), logpdf, decimal=7, err_msg=msg)
+    pdf = distfn.pdf(vals, *args)
+    logpdf = distfn.logpdf(vals, *args)
+    pdf = pdf[(pdf != 0) & np.isfinite(pdf)]
+    logpdf = logpdf[np.isfinite(logpdf)]
+    msg += " - logpdf-log(pdf) relationship"
+    npt.assert_almost_equal(np.log(pdf), logpdf, decimal=7, err_msg=msg)
 
 
 def check_sf_logsf(distfn, args, msg):


### PR DESCRIPTION
Make a few small changes to ensure that spurious warnings such as
`RuntimeWarning: divide by zero encountered in log1p` and
`RuntimeWarning: invalid value encountered in subtract` are not
generated when a distribution's pdf and logpdf methods are
evaluated at the endpoints of its support.

Closes gh-15195.

I didn't add any new tests.  These changes are tested by the removal of the suppression of warnings in the function `check_pdf_logpdf_at_endpoints` in `test_continous_basic.py`.