### PR TITLE
DOC: Corrected docstring of ndimage.sum_labels

### DIFF
--- a/scipy/ndimage/_measurements.py
+++ b/scipy/ndimage/_measurements.py
@@ -619,11 +619,11 @@ def sum_labels(input, labels=None, index=None):
     >>> from scipy import ndimage
     >>> input =  [0,1,2,3]
     >>> labels = [1,1,2,2]
-    >>> ndimage.sum(input, labels, index=[1,2])
+    >>> ndimage.sum_labels(input, labels, index=[1,2])
     [1.0, 5.0]
-    >>> ndimage.sum(input, labels, index=1)
+    >>> ndimage.sum_labels(input, labels, index=1)
     1
-    >>> ndimage.sum(input, labels)
+    >>> ndimage.sum_labels(input, labels)
     6
 
 


### PR DESCRIPTION
The example in the docstring of the function [`ndimage.sum_labels`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.sum_labels.html#scipy.ndimage.sum_labels) still used `ndimage.sum` instead of `ndimage.sum_labels`, which is confusing. I simply adjusted the documentation to refer to the correct name.
