### PR TITLE
BUG: sparse.linalg: Fix deprecation warnings.

### DIFF
--- a/scipy/sparse/linalg/dsolve.py
+++ b/scipy/sparse/linalg/dsolve.py
@@ -25,8 +25,14 @@ def __getattr__(name):
             "scipy.sparse.linalg.dsolve is deprecated and has no attribute "
             f"{name}. Try looking in scipy.sparse.linalg instead.")
 
-    warnings.warn(f"Please use `{name}` from the `scipy.sparse.linalg` namespace, "
-                  "the `scipy.sparse.linalg.dsolve` namespace is deprecated.",
-                  category=DeprecationWarning, stacklevel=2)
+    if name in dsolve_modules:
+        msg = (f'The module `scipy.sparse.linalg.dsolve.{name}` is '
+               'deprecated. All public names must be imported directly from '
+               'the `scipy.sparse.linalg` namespace.')
+    else:
+        msg = (f"Please use `{name}` from the `scipy.sparse.linalg` namespace,"
+               " the `scipy.sparse.linalg.eigen` namespace is deprecated.")
+
+    warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
 
     return getattr(_dsolve, name)

--- a/scipy/sparse/linalg/eigen.py
+++ b/scipy/sparse/linalg/eigen.py
@@ -13,6 +13,7 @@ __all__ = [  # noqa: F822
 
 eigen_modules = ['arpack']
 
+
 def __dir__():
     return __all__
 
@@ -23,8 +24,14 @@ def __getattr__(name):
             "scipy.sparse.linalg.eigen is deprecated and has no attribute "
             f"{name}. Try looking in scipy.sparse.linalg instead.")
 
-    warnings.warn(f"Please use `{name}` from the `scipy.sparse.linalg` namespace, "
-                  "the `scipy.sparse.linalg.eigen` namespace is deprecated.",
-                  category=DeprecationWarning, stacklevel=2)
+    if name in eigen_modules:
+        msg = (f'The module `scipy.sparse.linalg.eigen.{name}` is '
+               'deprecated. All public names must be imported directly from '
+               'the `scipy.sparse.linalg` namespace.')
+    else:
+        msg = (f"Please use `{name}` from the `scipy.sparse.linalg` namespace,"
+               " the `scipy.sparse.linalg.eigen` namespace is deprecated.")
+
+    warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
 
     return getattr(_eigen, name)


### PR DESCRIPTION
Attempting to use `scipy.sparse.linalg.eigen.arpack` or
`scipy.sparse.linalg.dsolve.linsolve` resulted in an incorrect
warning message.

Closes gh-15206.
