### PR TITLE
Make 0th power of a sparse array/matrix return the identity with the same dtype

### DIFF
--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -717,7 +717,7 @@ class spmatrix:
 
             if other == 0:
                 from ._construct import eye
-                E = eye(M)
+                E = eye(M, dtype=self.dtype)
                 if self._is_array:
                     from ._arrays import dia_array
                     E = dia_array(E)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1569,19 +1569,11 @@ class _TestCommon:
         A = array([[1, 0, 2, 0], [0, 3, 4, 0], [0, 5, 0, 0], [0, 6, 7, 8]])
         B = self.spmatrix(A)
 
-        def check(dtype, exponent):
-            A1 = array(A, dtype=dtype)
-            B1 = self.spmatrix(A1)
-
-            ret_sp = B1**exponent
-            ret_np = np.linalg.matrix_power(A1, exponent)
-
+        for exponent in [0,1,2,3]:
+            ret_sp = B**exponent
+            ret_np = np.linalg.matrix_power(A, exponent)
             assert_array_equal(ret_sp.toarray(), ret_np)
             assert_equal(ret_sp.dtype, ret_np.dtype)
-
-        for dtype in self.checked_dtypes:
-            for exponent in [0,1,2,3]:
-                check(dtype, exponent)
 
         # invalid exponents
         for exponent in [-1, 2.2, 1 + 3j]:

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1569,11 +1569,19 @@ class _TestCommon:
         A = array([[1, 0, 2, 0], [0, 3, 4, 0], [0, 5, 0, 0], [0, 6, 7, 8]])
         B = self.spmatrix(A)
 
-        for exponent in [0,1,2,3]:
-            assert_array_equal(
-                (B**exponent).toarray(),
-                np.linalg.matrix_power(A, exponent)
-            )
+        def check(dtype, exponent):
+            A1 = array(A, dtype=dtype)
+            B1 = self.spmatrix(A1)
+
+            ret_sp = B1**exponent
+            ret_np = np.linalg.matrix_power(A1, exponent)
+
+            assert_array_equal(ret_sp.toarray(), ret_np)
+            assert_equal(ret_sp.dtype, ret_np.dtype)
+
+        for dtype in self.checked_dtypes:
+            for exponent in [0,1,2,3]:
+                check(dtype, exponent)
 
         # invalid exponents
         for exponent in [-1, 2.2, 1 + 3j]:


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
gh-15224

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR fixes `spmatrix.__pow__` to return the identity of the same dtype with `self` for 0th power.

#### Additional information
<!--Any additional information you think is important.-->
N/A