### PR TITLE
TST: stats: mark very slow tests as `xslow`

### DIFF
--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -33,13 +33,18 @@ not for numerically exact results.
 
 DECIMAL = 5  # specify the precision of the tests  # increased from 0 to 5
 
-distslow = ['kstwo', 'genexpon', 'ksone', 'recipinvgauss', 'vonmises',
-            'kappa4', 'vonmises_line', 'gausshyper', 'norminvgauss',
-            'geninvgauss', 'genhyperbolic']
+# For skipping test_cont_basic
 # distslow are sorted by speed (very slow to slow)
+distslow = ['recipinvgauss', 'vonmises', 'kappa4', 'vonmises_line',
+            'gausshyper', 'norminvgauss', 'geninvgauss', 'genhyperbolic',
+            'truncnorm']
 
-distxslow = ['studentized_range']
 # distxslow are sorted by speed (very slow to slow)
+distxslow = ['studentized_range', 'kstwo', 'ksone', 'wrapcauchy', 'genexpon']
+
+# For skipping test_moments, which is already marked slow
+distxslow_test_moments = ['studentized_range', 'vonmises', 'vonmises_line',
+                          'ksone', 'kstwo', 'recipinvgauss', 'genexpon']
 
 # skip check_fit_args (test is slow)
 skip_fit_test_mle = ['exponpow', 'exponweib', 'gausshyper', 'genexpon',
@@ -248,13 +253,11 @@ def cases_test_moments():
         if distname == 'levy_stable':
             continue
 
-        if distname == 'studentized_range':
-            msg = ("studentized_range is far too slow for this test and it is "
-                   "redundant with test_distributions::TestStudentizedRange::"
-                   "test_moment_against_mp")
+        if distname in distxslow_test_moments:
             yield pytest.param(distname, arg, True, True, True, True,
-                               marks=pytest.mark.xslow(reason=msg))
+                               marks=pytest.mark.xslow(reason="too slow"))
             continue
+
         cond1 = distname not in fail_normalization
         cond2 = distname not in fail_higher
         cond3 = distname not in fail_loc_scale

--- a/scipy/stats/tests/test_fit.py
+++ b/scipy/stats/tests/test_fit.py
@@ -59,6 +59,7 @@ failing_fits = {"MM": mm_failing_fits + mm_slow_fits, "MLE": mle_failing_fits}
 # Don't run the fit test on these:
 skip_fit = [
     'erlang',  # Subclass of gamma, generates a warning.
+    'genhyperbolic',  # too slow
 ]
 
 

--- a/scipy/stats/tests/test_hypotests.py
+++ b/scipy/stats/tests/test_hypotests.py
@@ -1503,6 +1503,7 @@ class TestPermutationTest:
         assert res.statistic == res2.statistic
         assert_allclose(res.pvalue, res2.pvalue, atol=1e-2)
 
+    @pytest.mark.slow()
     def test_randomized_test_against_exact_samples(self):
         # check that the randomized and exact tests agree to reasonable
         # precision for permutation_type='samples'
@@ -1670,7 +1671,7 @@ class TestPermutationTest:
         assert_allclose(res.statistic, expected.statistic, rtol=self.rtol)
         assert_allclose(res.pvalue, expected.pvalue, rtol=self.rtol)
 
-    @pytest.mark.slow()
+    @pytest.mark.xslow()
     @pytest.mark.parametrize('axis', (-1, 2))
     def test_vectorized_nsamp_ptype_both(self, axis):
         # Test that permutation_test with permutation_type='independent' works
@@ -1816,7 +1817,7 @@ class TestPermutationTest:
 
         assert_allclose(res.pvalue, res2[1])
 
-    @pytest.mark.slow()
+    @pytest.mark.xslow()
     @pytest.mark.parametrize('axis', (-2, 1))
     def test_vectorized_nsamp_ptype_samples(self, axis):
         # Test that permutation_test with permutation_type='samples' works
@@ -1876,7 +1877,7 @@ class TestPermutationTest:
                   'expected_statistic': 32.5,
                   'expected_avg': 38.117647, 'expected_std': 5.172124}
 
-    @pytest.mark.slow()  # only the second case is slow, really
+    @pytest.mark.xslow()  # only the second case is slow, really
     @pytest.mark.parametrize('case', (tie_case_1, tie_case_2))
     def test_with_ties(self, case):
         """

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -452,7 +452,7 @@ class TestCorr:
             res = _mstats_basic._kendall_p_exact(nc[0], nc[1])
             assert_almost_equal(res, expected)
 
-    @pytest.mark.slow
+    @pytest.mark.xslow
     def test_kendall_p_exact_large(self):
         # Test for the exact method with large samples (n >= 171)
         # expected values generated using SymPy

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3867,6 +3867,7 @@ class TestKSTwoSamples:
         self._testOne(x, y, 'two-sided', 0.11292880151060758, 2.7755575615628914e-15, mode='asymp')
         self._testOne(x, y, 'two-sided', 0.11292880151060758, 2.7755575615628914e-15, mode='exact')
 
+    @pytest.mark.xslow
     def test_gh11184_bigger(self):
         # 10000, 10001, exact two-sided
         np.random.seed(123456)
@@ -3877,7 +3878,7 @@ class TestKSTwoSamples:
         self._testOne(x, y, 'greater', 0.10597913208679133, 2.7947433906389253e-41, mode='asymp')
         self._testOne(x, y, 'less', 0.09658002199780022, 2.7947433906389253e-41, mode='asymp')
 
-    @pytest.mark.slow
+    @pytest.mark.xslow
     def test_gh12999(self):
         np.random.seed(123456)
         for x in range(1000, 12000, 1000):
@@ -7126,7 +7127,7 @@ class TestMGCStat:
         assert_approx_equal(stat, obs_stat, significant=1)
         assert_approx_equal(pvalue, obs_pvalue, significant=1)
 
-    @pytest.mark.slow
+    @pytest.mark.xslow
     def test_twosamp(self):
         np.random.seed(12345678)
 


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Partially addresses gh-15233

#### What does this implement/fix?
Some CI builds are timing out. I think it's safe enough to xslow these tests to speed up the test suite.

#### Additional information
<!--Any additional information you think is important.-->

- I don't have any particular knowledge of `test_kendall_p_exact_large` (@Konrad0), `test_gh11184_bigger` (@pvanmulbregt?), or `test_twosamp` (@sampan501).  Please check whether they can be sped up or confirm that it's OK to mark them xslow.
- `ksone`, `kstwo`, and `genexpon` "promoted" from slow to xslow for `test_cont_basic`
- Somehow "wrapcauchy" wasn't even marked as slow for `test_cont_basic`, but it deserves to go straight to the xslow list.
- Added a list to skip `test_moments` for very slow distributions
- `test_vectorized_nsamp_ptype_samples`, `test_vectorized_nsamp_ptype_both`, and `test_with_ties` are good tests, but they are inherently slow. I made them about as small as I could. I think it's OK if they're not run on CI all the time, though.
-  It's ok to xslow `test_pdf_nolan_samples` now because it's getting modified in gh-9523. Thanks @steppi @ragibson!