### PR TITLE
BLD: update setup.py for Python 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ maintainers = [
 # Note: Python and NumPy upper version bounds should be set correctly in
 # release branches, see:
 #     https://scipy.github.io/devdocs/dev/core-dev/index.html#version-ranges-for-numpy-and-other-dependencies
-requires-python = ">=3.8,<3.11"
+requires-python = ">=3.8"
 dependencies = [
     "numpy>=1.17.3",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ maintainers = [
 # Note: Python and NumPy upper version bounds should be set correctly in
 # release branches, see:
 #     https://scipy.github.io/devdocs/dev/core-dev/index.html#version-ranges-for-numpy-and-other-dependencies
-requires-python = ">=3.8"
+requires-python = ">=3.8,<3.11"
 dependencies = [
     "numpy>=1.17.3",
 ]

--- a/setup.py
+++ b/setup.py
@@ -543,7 +543,7 @@ def setup_package():
     np_minversion = '1.17.3'
     np_maxversion = '9.9.99'
     python_minversion = '3.8'
-    python_maxversion = '3.11'
+    python_maxversion = '3.10'
     if IS_RELEASE_BRANCH:
         req_np = 'numpy>={},<{}'.format(np_minversion, np_maxversion)
         req_py = '>={},<{}'.format(python_minversion, python_maxversion)

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ Programming Language :: Python
 Programming Language :: Python :: 3
 Programming Language :: Python :: 3.8
 Programming Language :: Python :: 3.9
+Programming Language :: Python :: 3.10
 Topic :: Software Development :: Libraries
 Topic :: Scientific/Engineering
 Operating System :: Microsoft :: Windows
@@ -542,7 +543,7 @@ def setup_package():
     np_minversion = '1.17.3'
     np_maxversion = '9.9.99'
     python_minversion = '3.8'
-    python_maxversion = '3.10'
+    python_maxversion = '3.11'
     if IS_RELEASE_BRANCH:
         req_np = 'numpy>={},<{}'.format(np_minversion, np_maxversion)
         req_py = '>={},<{}'.format(python_minversion, python_maxversion)


### PR DESCRIPTION
I noticed that `Python :: 3.10` doesn't appear under the programming language classifiers:
https://pypi.org/project/scipy/1.8.0rc1/

I am not sure how you handle backports, but this should also be applied to the 1.8 branch.