### PR TITLE
ENH: stats: add masked array support to `_axis_nan_policy_factory` decorators

### DIFF
--- a/scipy/stats/_axis_nan_policy.py
+++ b/scipy/stats/_axis_nan_policy.py
@@ -74,7 +74,7 @@ def _broadcast_concatenate(xs, axis):
 
 # TODO: add support for `axis` tuples
 def _remove_nans(samples, paired):
-    "Remove nans from paired or unpaired samples"
+    "Remove nans from paired or unpaired 1D samples"
     # potential optimization: don't copy arrays that don't contain nans
     if not paired:
         return [sample[~np.isnan(sample)] for sample in samples]
@@ -86,6 +86,68 @@ def _remove_nans(samples, paired):
         nans = nans | np.isnan(sample)
     not_nans = ~nans
     return [sample[not_nans] for sample in samples]
+
+
+def _remove_sentinel(samples, paired, sentinel):
+    "Remove sentinel values from paired or unpaired 1D samples"
+    # could consolidate with `_remove_nans`, but it's not quite as simple as
+    # passing `sentinel=np.nan` because `(np.nan == np.nan) is False`
+
+    # potential optimization: don't copy arrays that don't contain sentinel
+    if not paired:
+        return [sample[sample != sentinel] for sample in samples]
+
+    # for paired samples, we need to remove the whole pair when any part
+    # has a nan
+    sentinels = (samples[0] == sentinel)
+    for sample in samples[1:]:
+        sentinels = sentinels | (sample == sentinel)
+    not_sentinels = ~sentinels
+    return [sample[not_sentinels] for sample in samples]
+
+
+def _masked_arrays_2_sentinel_arrays(samples):
+    # masked arrays in `samples` are converted to regular arrays, and values
+    # corresponding with masked elements ar replaced with a sentinel value
+
+    # return without modifying arrays if none have a mask
+    has_mask = False
+    for sample in samples:
+        mask = getattr(sample, 'mask', False)
+        has_mask = has_mask or np.any(mask)
+    if not has_mask:
+        return samples, None  # None means there is no sentinel value
+
+    # Choose a sentinel value. We can't use `np.nan`, because sentinel (masked)
+    # values are always omitted, but there are different nan policies.
+    for i in range(len(samples)):
+        # Things get more complicated if the arrays are of different types.
+        # We could have different sentinel values for each array, but
+        # the purpose of this code is convenience, not efficiency.
+        samples[i] = samples[i].astype(np.float64, copy=False)
+
+    max_possible, eps = np.finfo(np.float64).max, np.finfo(np.float64).eps
+
+    sentinel = max_possible
+    while sentinel > 0:
+        for sample in samples:
+            if np.any(sample == sentinel):
+                sentinel *= (1 - 2*eps)  # choose a new sentinel value
+                break
+        else: # when sentinel value is OK, break the while loop
+            break
+
+    # replace masked elements with sentinel value
+    out_samples = []
+    for sample in samples:
+        mask = getattr(sample, 'mask', False)
+        if np.any(mask):
+            mask = np.broadcast_to(mask, sample.shape)
+            sample = sample.data.copy()  # don't modify original array
+            sample[mask] = sentinel
+        out_samples.append(sample)
+
+    return out_samples, sentinel
 
 
 def _check_empty_inputs(samples, axis):
@@ -232,6 +294,9 @@ def _axis_nan_policy_factory(result_object, default_axis=0,
             nan_policy = kwds.pop('nan_policy', 'propagate')
             del args  # avoid the possibility of passing both `args` and `kwds`
 
+            # convert masked arrays to regular arrays with sentinel values
+            samples, sentinel = _masked_arrays_2_sentinel_arrays(samples)
+
             if axis is None:
                 samples = [sample.ravel() for sample in samples]
                 axis = 0
@@ -261,12 +326,14 @@ def _axis_nan_policy_factory(result_object, default_axis=0,
                     # consider passing in contains_nans
                     samples = _remove_nans(samples, paired)
 
-                # ideally, this is what the behavior would be, but some
-                # existing functions raise exceptions, so overriding it
-                # would break backward compatibility.
+                # ideally, this is what the behavior would be:
                 # if is_too_small(samples):
                 #     return result_object(np.nan, np.nan)
+                # but some existing functions raise exceptions, and changing
+                # behavior of those would break backward compatibility.
 
+                if sentinel:
+                    samples = _remove_sentinel(samples, paired, sentinel)
                 return hypotest_fun_in(*samples, **kwds)
 
             # check for empty input
@@ -289,7 +356,7 @@ def _axis_nan_policy_factory(result_object, default_axis=0,
             contains_nan, _ = (
                 scipy.stats._stats_py._contains_nan(x, nan_policy))
 
-            if vectorized and not contains_nan:
+            if vectorized and not contains_nan and not sentinel:
                 return hypotest_fun_in(*samples, axis=axis, **kwds)
 
             # Addresses nan_policy == "omit"
@@ -297,6 +364,8 @@ def _axis_nan_policy_factory(result_object, default_axis=0,
                 def hypotest_fun(x):
                     samples = np.split(x, split_indices)[:n_samp]
                     samples = _remove_nans(samples, paired)
+                    if sentinel:
+                        samples = _remove_sentinel(samples, paired, sentinel)
                     if is_too_small(samples):
                         return result_object(np.nan, np.nan)
                     return hypotest_fun_in(*samples, **kwds)
@@ -307,11 +376,19 @@ def _axis_nan_policy_factory(result_object, default_axis=0,
                     if np.isnan(x).any():
                         return result_object(np.nan, np.nan)
                     samples = np.split(x, split_indices)[:n_samp]
+                    if sentinel:
+                        samples = _remove_sentinel(samples, paired, sentinel)
+                    if is_too_small(samples):
+                        return result_object(np.nan, np.nan)
                     return hypotest_fun_in(*samples, **kwds)
 
             else:
                 def hypotest_fun(x):
                     samples = np.split(x, split_indices)[:n_samp]
+                    if sentinel:
+                        samples = _remove_sentinel(samples, paired, sentinel)
+                    if is_too_small(samples):
+                        return result_object(np.nan, np.nan)
                     return hypotest_fun_in(*samples, **kwds)
 
             x = np.moveaxis(x, axis, -1)

--- a/scipy/stats/_axis_nan_policy.py
+++ b/scipy/stats/_axis_nan_policy.py
@@ -108,7 +108,7 @@ def _remove_sentinel(samples, paired, sentinel):
 
 def _masked_arrays_2_sentinel_arrays(samples):
     # masked arrays in `samples` are converted to regular arrays, and values
-    # corresponding with masked elements ar replaced with a sentinel value
+    # corresponding with masked elements are replaced with a sentinel value
 
     # return without modifying arrays if none have a mask
     has_mask = False
@@ -134,7 +134,7 @@ def _masked_arrays_2_sentinel_arrays(samples):
             if np.any(sample == sentinel):
                 sentinel *= (1 - 2*eps)  # choose a new sentinel value
                 break
-        else: # when sentinel value is OK, break the while loop
+        else:  # when sentinel value is OK, break the while loop
             break
 
     # replace masked elements with sentinel value

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -88,7 +88,7 @@ def _contains_nan(a, nan_policy='propagate'):
     try:
         # Calling np.sum to avoid creating a huge array into memory
         # e.g. np.isnan(a).any()
-        with np.errstate(invalid='ignore'):
+        with np.errstate(invalid='ignore', over='ignore'):
             contains_nan = np.isnan(np.sum(a))
     except TypeError:
         # This can happen when attempting to sum things which are not

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -576,11 +576,7 @@ def test_masked_array_2_sentinel_array():
 
 
 def test_masked_stat_1d():
-    # Adding support for masked arrays requires minimal modifications to the
-    # _axis_nan_policy decorator, so exhaustive tests for masked arrays
-    # (and all possible combinations of masked/non masked arrays with and
-    # without masked elements and nans) is not necessary. Instead, perform
-    # basic tests in 1D and 2D.
+    # basic test of _axis_nan_policy_factory with 1D masked sample
     males = [19, 22, 16, 29, 24]
     females = [20, 11, 17, 12]
     res = stats.mannwhitneyu(males, females)
@@ -594,7 +590,7 @@ def test_masked_stat_1d():
     females3 = [20, 11, 17, 1000, 12]
     mask3 = [False, False, False, True, False]
     females3 = np.ma.masked_array(females3, mask=mask3)
-    res3 =  stats.mannwhitneyu(males, females3)
+    res3 = stats.mannwhitneyu(males, females3)
     np.testing.assert_array_equal(res3, res)
 
     # same result when extra nan is omitted and additional element is masked
@@ -616,11 +612,7 @@ def test_masked_stat_1d():
 
 @pytest.mark.parametrize(("axis"), range(-2, 2))
 def test_masked_stat_3d(axis):
-    # Adding support for masked arrays requires minimal modifications to the
-    # _axis_nan_policy decorator, so exhaustive tests for masked arrays
-    # (and all possible combinations of masked/non masked arrays with and
-    # without masked elements and nans) is not necessary. Instead, perform
-    # basic tests in 1D and 2D.
+    # basic test of _axis_nan_policy_factory with 3D masked sample
     np.random.seed(0)
     a = np.random.rand(3, 4, 5)
     b = np.random.rand(4, 5)
@@ -639,3 +631,91 @@ def test_masked_stat_3d(axis):
     res = stats.kruskal(a_nans, b, c_nans, nan_policy='omit', axis=axis)
     res2 = stats.kruskal(a_masked, b, c_masked, axis=axis)
     np.testing.assert_array_equal(res, res2)
+
+
+def test_mixed_mask_nan_1():
+    # targeted test of _axis_nan_policy_factory with 2D masked sample:
+    # omitting samples with masks and nan_policy='omit' are equivalent
+    # also checks paired-sample sentinel value removal
+    m, n = 3, 20
+    axis = -1
+
+    np.random.seed(0)
+    a = np.random.rand(m, n)
+    b = np.random.rand(m, n)
+    mask_a1 = np.random.rand(m, n) < 0.2
+    mask_a2 = np.random.rand(m, n) < 0.1
+    mask_b1 = np.random.rand(m, n) < 0.15
+    mask_b2 = np.random.rand(m, n) < 0.15
+    mask_a1[2, :] = True
+
+    a_nans = a.copy()
+    b_nans = b.copy()
+    a_nans[mask_a1 | mask_a2] = np.nan
+    b_nans[mask_b1 | mask_b2] = np.nan
+
+    a_masked1 = np.ma.masked_array(a, mask=mask_a1)
+    b_masked1 = np.ma.masked_array(b, mask=mask_b1)
+    a_masked1[mask_a2] = np.nan
+    b_masked1[mask_b2] = np.nan
+
+    a_masked2 = np.ma.masked_array(a, mask=mask_a2)
+    b_masked2 = np.ma.masked_array(b, mask=mask_b2)
+    a_masked2[mask_a1] = np.nan
+    b_masked2[mask_b1] = np.nan
+
+    a_masked3 = np.ma.masked_array(a, mask=(mask_a1 | mask_a2))
+    b_masked3 = np.ma.masked_array(b, mask=(mask_b1 | mask_b2))
+
+    res = stats.wilcoxon(a_nans, b_nans, nan_policy='omit', axis=axis)
+    res1 = stats.wilcoxon(a_masked1, b_masked1, nan_policy='omit', axis=axis)
+    res2 = stats.wilcoxon(a_masked2, b_masked2, nan_policy='omit', axis=axis)
+    res3 = stats.wilcoxon(a_masked3, b_masked3, nan_policy='raise', axis=axis)
+    res4 = stats.wilcoxon(a_masked3, b_masked3,
+                          nan_policy='propagate', axis=axis)
+
+    np.testing.assert_array_equal(res1, res)
+    np.testing.assert_array_equal(res2, res)
+    np.testing.assert_array_equal(res3, res)
+    np.testing.assert_array_equal(res4, res)
+
+def test_mixed_mask_nan_2():
+    # targeted test of _axis_nan_policy_factory with 2D masked sample:
+    # check for expected interaction between masks and nans
+
+    # Cases here are
+    # [mixed nan/mask, all nans, all masked,
+    # unmasked nan, masked nan, unmasked non-nan]
+    a = [[1, np.nan, 2], [np.nan, np.nan, np.nan], [1, 2, 3],
+         [1, np.nan, 3], [1, np.nan, 3], [1, 2, 3]]
+    mask = [[1, 0, 1], [0, 0, 0], [1, 1, 1],
+            [0, 0, 0], [0, 1, 0], [0, 0, 0]]
+    a_masked = np.ma.masked_array(a, mask=mask)
+    b = [[4, 5, 6]]
+    ref1 = stats.ranksums([1, 3], [4, 5, 6])
+    ref2 = stats.ranksums([1, 2, 3], [4, 5, 6])
+
+    # nan_policy = 'omit'
+    # all elements are removed from first three rows
+    # middle element is removed from fourth and fifth rows
+    # no elements removed from last row
+    res = stats.ranksums(a_masked, b, nan_policy='omit', axis=-1)
+    stat_ref = [np.nan, np.nan, np.nan,
+                ref1.statistic, ref1.statistic, ref2.statistic]
+    p_ref = [np.nan, np.nan, np.nan,
+             ref1.pvalue, ref1.pvalue, ref2.pvalue]
+    np.testing.assert_array_equal(res.statistic, stat_ref)
+    np.testing.assert_array_equal(res.pvalue, p_ref)
+
+    # nan_policy = 'propagate'
+    # nans propagate in first, second, and fourth row
+    # all elements are removed by mask from third row
+    # middle element is removed from fifth row
+    # no elements removed from last row
+    res = stats.ranksums(a_masked, b, nan_policy='propagate', axis=-1)
+    stat_ref = [np.nan, np.nan, np.nan,
+                np.nan, ref1.statistic, ref2.statistic]
+    p_ref = [np.nan, np.nan, np.nan,
+             np.nan, ref1.pvalue, ref2.pvalue]
+    np.testing.assert_array_equal(res.statistic, stat_ref)
+    np.testing.assert_array_equal(res.pvalue, p_ref)

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -679,6 +679,7 @@ def test_mixed_mask_nan_1():
     np.testing.assert_array_equal(res3, res)
     np.testing.assert_array_equal(res4, res)
 
+
 def test_mixed_mask_nan_2():
     # targeted test of _axis_nan_policy_factory with 2D masked sample:
     # check for expected interaction between masks and nans


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->
gh-14651 (checks the third box)

#### What does this implement/fix?
<!--Please explain your changes.-->
gh-13312 added `_axis_nan_policy_factory`, which returns a decorator that adds `axis` and `nan_policy` arguments to stats functions. With the additions in this PR, the decorators produced also add support for masked arrays. Initially, this will pave the way to apply the decorators to stats functions that already support masked arrays (e.g. `gmean`). Eventually, we may be able to use it to deprecate `scipy.stats.mstats`.

#### Additional information
<!--Any additional information you think is important.-->
We agreed on the approach taken by this PR (adding sentinel values to the data array) in gh-14657. I plan to explore a different option (separating the masked array into the data array and the mask) separately. If we decide to go in that direction, this can serve as a reference implementation to test against. The important part is to get the behavior correct; we can optimize efficiency later.
