### PR TITLE
STY: sparse: remove extra blank line to fix lint failure in master

### DIFF
--- a/scipy/sparse/_arrays.py
+++ b/scipy/sparse/_arrays.py
@@ -50,7 +50,6 @@ class _sparray:
         return self.multiply(*args, **kwargs)
 
 
-
 def _matrix_doc_to_array(docstr):
     # For opimized builds with stripped docstrings
     if docstr is None:


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->
gh-15234

#### What does this implement/fix?
<!--Please explain your changes.-->
Lint check is failing in master (e.g. see CI failure in gh-15234):
```
scipy/sparse/_arrays.py:54:1: E303 too many blank lines (3)
```
This should fix that.