### PR TITLE
BUG: special: fix `stdtr` and `stdtrit` for infinite df

### DIFF
--- a/scipy/special/cdf_wrappers.c
+++ b/scipy/special/cdf_wrappers.c
@@ -8,6 +8,7 @@
  */
 
 #include "cdf_wrappers.h"
+#include "cephes.h"
 
 #if defined(NO_APPEND_FORTRAN)
 #if defined(UPPERCASE_FORTRAN)
@@ -395,6 +396,11 @@ double cdft1_wrap(double df, double t){
   double q=0, p=0, bound=0;
   int status=10;
 
+  if (npy_isinf(df)) {
+    if (npy_isnan(t)) return NPY_NAN;
+    return ndtr(t);
+  }
+
   CDFLIB_CALL2(F_FUNC(cdft,CDFT), "stdtr",
                t, df,
                p, NO_RETURN_BOUND);
@@ -404,6 +410,11 @@ double cdft2_wrap(double df, double p){
   int which=2;
   double q=1.0-p, t=0, bound=0;
   int status=10;
+
+  if (npy_isinf(df)) {
+    if (npy_isnan(p)) return NPY_NAN;
+    return ndtri(p);
+  }
 
   CDFLIB_CALL2(F_FUNC(cdft,CDFT), "stdtrit",
                t, df,

--- a/scipy/special/tests/test_cdft_asymptotic.py
+++ b/scipy/special/tests/test_cdft_asymptotic.py
@@ -17,7 +17,7 @@ def test_stdtr_vs_R_large_df():
              0.84134474606842180044,
              0.84134474606854281475,
              0.84134474606854292578]
-    assert_allclose(res, res_R, rtol=1e-15)
+    assert_allclose(res, res_R, rtol=2e-15)
     # last value should also agree with ndtr
     assert_equal(res[3], ndtr(1.))
 

--- a/scipy/special/tests/test_cdft_asymptotic.py
+++ b/scipy/special/tests/test_cdft_asymptotic.py
@@ -1,0 +1,49 @@
+# gh-14777 regression tests
+# Test stdtr and stdtrit with infinite df and large values of df
+
+import numpy as np
+from numpy.testing import assert_allclose, assert_equal
+from scipy.special import stdtr, stdtrit, ndtr, ndtri
+
+
+def test_stdtr_vs_R_large_df():
+    df = [1e10, 1e12, 1e120, np.inf]
+    t = 1.
+    res = stdtr(df, t)
+    # R Code:
+    #   options(digits=20)
+    #   pt(1., c(1e10, 1e12, 1e120, Inf))
+    res_R = [0.84134474605644460343,
+             0.84134474606842180044,
+             0.84134474606854281475,
+             0.84134474606854292578]
+    assert_allclose(res, res_R, rtol=1e-15)
+    # last value should also agree with ndtr
+    assert_equal(res[3], ndtr(1.))
+
+
+def test_stdtrit_vs_R_large_df():
+    df = [1e10, 1e12, 1e120, np.inf]
+    p = 0.1
+    res = stdtrit(df, p)
+    # R Code:
+    #   options(digits=20)
+    #   qt(0.1, c(1e10, 1e12, 1e120, Inf))
+    res_R = [-1.2815515656292593150,
+             -1.2815515655454472466,
+             -1.2815515655446008125,
+             -1.2815515655446008125]
+    assert_allclose(res, res_R, rtol=1e-15)
+    # last value should also agree with ndtri
+    assert_equal(res[3], ndtri(0.1))
+
+
+def test_stdtr_stdtri_invalid():
+    # a mix of large and inf df with t/p equal to nan
+    df = [1e10, 1e12, 1e120, np.inf]
+    x = np.nan
+    res1 = stdtr(df, x)
+    res2 = stdtrit(df, x)
+    res_ex = 4*[np.nan]
+    assert_equal(res1, res_ex)
+    assert_equal(res2, res_ex)


### PR DESCRIPTION
#### Reference issue

Partially addresses gh-14777
Supersedes gh-14781

#### What does this implement/fix?

`stdtr` and `stdtrit` returned wrong results when infinite df was given.
This behavior has been fixed by branching to `ndtr` and `ndtri` respectively.
Tests comparing the result with R's `pt` and `qt` have also been added.

#### Additional information

This should fix the `cdf`, `ppf`, and `isf` methods of the t distribution. In a follow-up, I will fix `pdf`, `stats`, and `moment` which should close gh-14777
