### PR TITLE
MAINT: Remove `distutils` usage in `runtests.py` to fix deprecation warnings

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -33,9 +33,9 @@ jobs:
           mkdir builds
           cd builds
       - name: Installing packages
-        run: |      
+        run: |
           python3.8-dbg -c 'import sys; print("Python debug build:", hasattr(sys, "gettotalrefcount"))'
-          python3.8-dbg -m pip install --upgrade pip setuptools wheel
+          python3.8-dbg -m pip install --upgrade pip "setuptools<60.0" wheel
           python3.8-dbg -m pip install --upgrade numpy cython pytest pytest-xdist pybind11
           python3.8-dbg -m pip install --upgrade mpmath gmpy2==2.1.0rc1 pythran threadpoolctl
           python3.8-dbg -m pip uninstall -y nose
@@ -83,7 +83,7 @@ jobs:
       run: |
         which python
         pip install --user git+https://github.com/numpy/numpy.git
-        python -m pip install --user setuptools wheel cython pytest pybind11 pytest-xdist
+        python -m pip install --user "setuptools<60.0" wheel cython pytest pybind11 pytest-xdist
         pip install --user git+https://github.com/serge-sans-paille/pythran.git
         python -m pip install -r mypy_requirements.txt
 

--- a/runtests.py
+++ b/runtests.py
@@ -333,6 +333,21 @@ def main(argv):
         sys.exit(1)
 
 
+def get_path_suffix(current_path, levels=3):
+    """
+    This utility function is only needed for a single use further down,
+    in order to grab the last `levels` subdirs from the input path.
+    It'll always resolve to something like ``lib/python3.X/site-packages``.
+    Site-packages is actually 3 levels deep on all platforms, so this
+    function should suffice.
+    """
+    current_new = current_path
+    for i in range(levels):
+        current_new = os.path.dirname(current_new)
+
+    return os.path.relpath(current_path, current_new)
+
+
 def build_project(args):
     """
     Build a dev version of the project.
@@ -365,8 +380,8 @@ def build_project(args):
         env['OPT'] = '-O0 -ggdb'
         env['FOPT'] = '-O0 -ggdb'
         if args.gcov:
-            import distutils.sysconfig
-            cvars = distutils.sysconfig.get_config_vars()
+            from sysconfig import get_config_vars
+            cvars = get_config_vars()
             env['OPT'] = '-O0 -ggdb'
             env['FOPT'] = '-O0 -ggdb'
             env['CC'] = env.get('CC', cvars['CC']) + ' --coverage'
@@ -385,8 +400,10 @@ def build_project(args):
             '--single-version-externally-managed',
             '--record=' + dst_dir + 'tmp_install_log.txt']
 
-    from distutils.sysconfig import get_python_lib
-    site_dir = get_python_lib(prefix=dst_dir, plat_specific=True)
+    from sysconfig import get_path
+    py_path = get_path('platlib')
+    site_dir = os.path.join(dst_dir, get_path_suffix(py_path, 3))
+
     # easy_install won't install to a path that Python by default cannot see
     # and isn't on the PYTHONPATH. Plus, it has to exist.
     if not os.path.exists(site_dir):


### PR DESCRIPTION
The `distutils.sysconfig` module is deprecated and throws a warning:
```py
$ python runtests.py --build-only
scipy/runtests.py:394: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
  from distutils.sysconfig import get_python_lib
scipy/runtests.py:394: DeprecationWarning: The distutils.sysconfig module is deprecated, use sysconfig instead
  from distutils.sysconfig import get_python_lib
```
cc @rgommers 