### PR TITLE
MAINT: use PEP440 vs. distutils

### DIFF
--- a/scipy/_build_utils/_fortran.py
+++ b/scipy/_build_utils/_fortran.py
@@ -127,7 +127,7 @@ def gfortran_legacy_flag_hook(cmd, ext):
     Pre-build hook to add dd gfortran legacy flag -fallow-argument-mismatch
     """
     from .compiler_helper import try_add_flag
-    from distutils.version import LooseVersion
+    from scipy._lib import _pep440
 
     if isinstance(ext, dict):
         # build_clib
@@ -142,7 +142,8 @@ def gfortran_legacy_flag_hook(cmd, ext):
         if compiler is None:
             continue
 
-        if compiler.compiler_type == "gnu95" and compiler.version >= LooseVersion("10"):
+        if (compiler.compiler_type == "gnu95" and
+        _pep440.parse(str(compiler.version)) >= _pep440.Version("10")):
             try_add_flag(args, compiler, "-fallow-argument-mismatch")
 
 

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -3,11 +3,11 @@ import os
 import pytest
 import warnings
 
-from distutils.version import LooseVersion
 import numpy as np
 import numpy.testing as npt
 from scipy._lib._fpumode import get_fpu_mode
 from scipy._lib._testutils import FPUModeChangeWarning
+from scipy._lib import _pep440
 
 
 def pytest_configure(config):
@@ -20,7 +20,7 @@ def pytest_configure(config):
 
 
 def _get_mark(item, name):
-    if LooseVersion(pytest.__version__) >= LooseVersion("3.6.0"):
+    if _pep440.parse(pytest.__version__) >= _pep440.Version("3.6.0"):
         mark = item.get_closest_marker(name)
     else:
         mark = item.get_marker(name)

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -1,6 +1,6 @@
 import warnings
 
-from distutils.version import LooseVersion
+from scipy._lib import _pep440
 import numpy as np
 from numpy.testing import (assert_array_almost_equal,
                            assert_array_equal, assert_array_less,
@@ -30,7 +30,7 @@ except ImportError:
 
 def mpmath_check(min_ver):
     return pytest.mark.skipif(mpmath is None or
-                              LooseVersion(mpmath.__version__) < LooseVersion(min_ver),
+                              _pep440.parse(mpmath.__version__) < _pep440.Version(min_ver),
                               reason="mpmath version >= %s required" % min_ver)
 
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -23,7 +23,7 @@ import operator
 import platform
 import itertools
 import sys
-from distutils.version import LooseVersion
+from scipy._lib import _pep440
 
 import numpy as np
 from numpy import (arange, zeros, array, dot, asarray,
@@ -4821,7 +4821,7 @@ def cases_64bit():
                 if bool(msg):
                     marks += [pytest.mark.skip(reason=msg)]
 
-                if LooseVersion(pytest.__version__) >= LooseVersion("3.6.0"):
+                if _pep440.parse(pytest.__version__) >= _pep440.Version("3.6.0"):
                     markers = getattr(method, 'pytestmark', [])
                     for mark in markers:
                         if mark.name in ('skipif', 'skip', 'xfail', 'xslow'):

--- a/scipy/special/_testutils.py
+++ b/scipy/special/_testutils.py
@@ -1,7 +1,7 @@
 import os
 import functools
 import operator
-from distutils.version import LooseVersion
+from scipy._lib import _pep440
 
 import numpy as np
 from numpy.testing import assert_
@@ -24,7 +24,7 @@ class MissingModule:
 def check_version(module, min_ver):
     if type(module) == MissingModule:
         return pytest.mark.skip(reason="{} is not installed".format(module.name))
-    return pytest.mark.skipif(LooseVersion(module.__version__) < LooseVersion(min_ver),
+    return pytest.mark.skipif(_pep440.parse(module.__version__) < _pep440.Version(min_ver),
                               reason="{} version >= {} required".format(module.__name__, min_ver))
 
 

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -8,7 +8,7 @@ from numpy import pi
 import pytest
 import itertools
 
-from distutils.version import LooseVersion
+from scipy._lib import _pep440
 
 import scipy.special as sc
 from scipy.special._testutils import (
@@ -1720,7 +1720,7 @@ class TestSystematic:
                                "systems and gh-8095 for another bad "
                                "point"))
     def test_rf(self):
-        if LooseVersion(mpmath.__version__) >= LooseVersion("1.0.0"):
+        if _pep440.parse(mpmath.__version__) >= _pep440.Version("1.0.0"):
             # no workarounds needed
             mppoch = mpmath.rf
         else:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ import subprocess
 import textwrap
 import warnings
 import sysconfig
-from distutils.version import LooseVersion
+import importlib
 
 
 if sys.version_info[:2] < (3, 8):
@@ -234,7 +234,8 @@ def get_build_ext_override():
             from pythran.dist import PythranBuildExt
             BaseBuildExt = PythranBuildExt[npy_build_ext]
             # Version check - a too old Pythran will give problems
-            if LooseVersion(pythran.__version__) < LooseVersion('0.9.12'):
+            importlib.import_module('scipy/_lib/_pep440')
+            if _pep440.parse(pythran.__version__) < _pep440.Version('0.9.12'):
                 raise RuntimeError("The installed `pythran` is too old, >= "
                                    "0.9.12 is needed, {} detected. Please "
                                    "upgrade Pythran, or use `export "
@@ -345,7 +346,7 @@ def generate_cython():
         try:
             # Note, pip may not be installed or not have been used
             import pip
-            if LooseVersion(pip.__version__) < LooseVersion('18.0.0'):
+            if _pep440.parse(pip.__version__) < _pep440.Version('18.0.0'):
                 raise RuntimeError("Cython not found or too old. Possibly due "
                                    "to `pip` being too old, found version {}, "
                                    "needed is >= 18.0.0.".format(

--- a/tools/cythonize.py
+++ b/tools/cythonize.py
@@ -53,7 +53,7 @@ DEFAULT_ROOT = 'scipy'
 def process_pyx(fromfile, tofile, cwd):
     try:
         from Cython.Compiler.Version import version as cython_version
-        from distutils.version import LooseVersion
+        from scipy._lib import _pep440
 
         # Try to find pyproject.toml
         pyproject_toml = join(dirname(__file__), '..', 'pyproject.toml')
@@ -84,7 +84,7 @@ def process_pyx(fromfile, tofile, cwd):
         # respecting pyproject.toml. Reason: we want to be able to build/test
         # with more recent Cython locally or on master, upper bound is for
         # sdist in a release.
-        if LooseVersion(cython_version) < LooseVersion(min_required_version):
+        if _pep440.parse(cython_version) < _pep440.Version(min_required_version):
             raise Exception('Building SciPy requires Cython >= {}, found '
                             '{}'.format(min_required_version, cython_version))
 


### PR DESCRIPTION
Fixes #15254 (eventually)

* version checking in a PEP440-compliant manner is
more robust than using `distutils` for this purpose

* replace accordingly, mostly because the latest `setuptools`
has finally deprecated i.e., `LooseVersion`

* I think the debate about whether we should use an external
package like `packaging` for this can be deferred since we
already vendor `scipy/_lib/_pep440.py` which says at the top:

```
The LooseVersion and StrictVersion classes that distutils provides don't
work; they don't recognize anything like alpha/beta/rc/dev versions.
```

* that's a bit harsh for some of our purposes, but the CI is failing
with `LooseVersion` now

* may need to be combined with i.e., gh-15255 from Smit as well -- cleaning out the `distutils` stuff touches several places of course