### PR TITLE
ENH: stats: add axis tuple support to _axis_nan_policy_factory decorators

### DIFF
--- a/scipy/stats/_axis_nan_policy.py
+++ b/scipy/stats/_axis_nan_policy.py
@@ -12,6 +12,84 @@ from scipy._lib._docscrape import FunctionDoc, Parameter
 import inspect
 
 
+def _broadcast_arrays(arrays, axis=None):
+    """
+    Broadcast shapes of arrays, ignoring incompatibility of specified axes
+    """
+    new_shapes = _broadcast_array_shapes(arrays, axis=axis)
+    if axis is None:
+        new_shapes = [new_shapes]*len(arrays)
+    return [np.broadcast_to(array, new_shape)
+            for array, new_shape in zip(arrays, new_shapes)]
+
+
+def _broadcast_array_shapes(arrays, axis=None):
+    """
+    Broadcast shapes of arrays, ignoring incompatibility of specified axes
+    """
+    shapes = [np.asarray(arr).shape for arr in arrays]
+    return _broadcast_shapes(shapes, axis)
+
+
+def _broadcast_shapes(shapes, axis=None):
+    """
+    Broadcast shapes, ignoring incompatibility of specified axes
+    """
+    if not shapes:
+        return shapes
+
+    # input validation
+    if axis is not None:
+        axis = np.atleast_1d(axis)
+        axis_int = axis.astype(int)
+        if not np.array_equal(axis_int, axis):
+            raise ValueError('`axis` must be an integer, a '
+                             'tuple of integers, or `None`.')
+        axis = axis_int
+
+    # First, ensure all shapes have same number of dimensions by prepending 1s.
+    n_dims = max([len(shape) for shape in shapes])
+    new_shapes = np.ones((len(shapes), n_dims), dtype=int)
+    for row, shape in zip(new_shapes, shapes):
+        row[len(row)-len(shape):] = shape  # can't use negative indices (-0:)
+
+    # Remove the shape elements of the axes to be ignored, but remember them.
+    if axis is not None:
+        axis[axis < 0] = n_dims + axis[axis < 0]
+        axis = np.sort(axis)
+        if axis[-1] >= n_dims or axis[0] < 0:
+            message = (f"`axis` is out of bounds "
+                       f"for array of dimension {n_dims}")
+            raise ValueError(message)
+
+        if len(np.unique(axis)) != len(axis):
+            raise ValueError("`axis` must contain only distinct elements")
+        removed_shapes = new_shapes[:, axis]
+        new_shapes = np.delete(new_shapes, axis, axis=1)
+
+    # If arrays are broadcastable, shape elements that are 1 may be replaced
+    # with a corresponding non-1 shape element. Assuming arrays are
+    # broadcastable, that final shape element can be found with:
+    new_shape = np.max(new_shapes, axis=0)
+    # except in case of an empty array:
+    new_shape *= new_shapes.all(axis=0)
+
+    # Among all arrays, there can only be one unique non-1 shape element.
+    # Therefore, if any non-1 shape element does not match what we found
+    # above, the arrays must not be broadcastable after all.
+    if np.any(~((new_shapes == 1) | (new_shapes == new_shape))):
+        raise ValueError("Array shapes are incompatible for broadcasting.")
+
+    if axis is not None:
+        # Add back the shape elements that were ignored
+        new_axis = axis - np.arange(len(axis))
+        new_shapes = [tuple(np.insert(new_shape, new_axis, removed_shape))
+                      for removed_shape in removed_shapes]
+        return new_shapes
+    else:
+        return tuple(new_shape)
+
+
 def _broadcast_array_shapes_remove_axis(arrays, axis=None):
     """
     Broadcast shapes of arrays, dropping specified axes
@@ -41,34 +119,15 @@ def _broadcast_shapes_remove_axis(shapes, axis=None):
     Same as _broadcast_array_shapes, but given a sequence
     of array shapes `shapes` instead of the arrays themselves.
     """
-    n_dims = max([len(shape) for shape in shapes])
-    new_shapes = np.ones((len(shapes), n_dims), dtype=int)
-    for row, shape in zip(new_shapes, shapes):
-        row[len(row)-len(shape):] = shape  # can't use negative indices (-0:)
-    if axis is not None:
-        new_shapes = np.delete(new_shapes, axis, axis=1)
-    new_shape = np.max(new_shapes, axis=0)
-    new_shape *= new_shapes.all(axis=0)
-    if np.any(~((new_shapes == 1) | (new_shapes == new_shape))):
-        raise ValueError("Array shapes are incompatible for broadcasting.")
-    return tuple(new_shape)
+    shapes = _broadcast_shapes(shapes, axis)
+    shape = np.delete(shapes[0], axis)
+    return tuple(shape)
 
 
-def _broadcast_concatenate(xs, axis):
+def _broadcast_concatenate(arrays, axis):
     """Concatenate arrays along an axis with broadcasting."""
-    # prepend 1s to array shapes as needed
-    ndim = max([x.ndim for x in xs])
-    xs = [x.reshape([1]*(ndim-x.ndim) + list(x.shape)) for x in xs]
-    # move the axis we're concatenating along to the end
-    xs = [np.swapaxes(x, axis, -1) for x in xs]
-    # determine final shape of all but the last axis
-    shape = _broadcast_array_shapes_remove_axis(xs, axis=-1)
-    # broadcast along all but the last axis
-    xs = [np.broadcast_to(x, shape + (x.shape[-1],)) for x in xs]
-    # concatenate along last axis
-    res = np.concatenate(xs, axis=-1)
-    # move the last axis back to where it was
-    res = np.swapaxes(res, axis, -1)
+    arrays = _broadcast_arrays(arrays, axis)
+    res = np.concatenate(arrays, axis=axis)
     return res
 
 
@@ -297,12 +356,18 @@ def _axis_nan_policy_factory(result_object, default_axis=0,
             # convert masked arrays to regular arrays with sentinel values
             samples, sentinel = _masked_arrays_2_sentinel_arrays(samples)
 
+            samples = _broadcast_arrays(samples, axis=axis)
+
+            # standardize to always work along last axis
             if axis is None:
                 samples = [sample.ravel() for sample in samples]
-                axis = 0
-            elif axis != int(axis):
-                raise ValueError('`axis` must be an integer')
-            axis = int(axis)
+            else:
+                axis = np.atleast_1d(axis)
+                samples = [np.moveaxis(sample, axis, range(-len(axis), 0))
+                           for sample in samples]
+                samples = [sample.reshape(sample.shape[:-len(axis)] + (-1,))
+                           for sample in samples]
+            axis = -1  # work over the last axis
 
             # if axis is not needed, just handle nan_policy and return
             ndims = np.array([sample.ndim for sample in samples])

--- a/scipy/stats/_axis_nan_policy.py
+++ b/scipy/stats/_axis_nan_policy.py
@@ -359,12 +359,11 @@ def _axis_nan_policy_factory(result_object, default_axis=0,
             # convert masked arrays to regular arrays with sentinel values
             samples, sentinel = _masked_arrays_2_sentinel_arrays(samples)
 
-            samples = _broadcast_arrays(samples, axis=axis)
-
             # standardize to always work along last axis
             if axis is None:
                 samples = [sample.ravel() for sample in samples]
             else:
+                samples = _broadcast_arrays(samples, axis=axis)
                 axis = np.atleast_1d(axis)
                 n_axes = len(axis)
                 # move all axes in `axis` to the end to be raveled

--- a/scipy/stats/_axis_nan_policy.py
+++ b/scipy/stats/_axis_nan_policy.py
@@ -74,7 +74,7 @@ def _broadcast_concatenate(xs, axis):
 
 # TODO: add support for `axis` tuples
 def _remove_nans(samples, paired):
-    "Remove nans from paired or unpaired samples"
+    "Remove nans from paired or unpaired 1D samples"
     # potential optimization: don't copy arrays that don't contain nans
     if not paired:
         return [sample[~np.isnan(sample)] for sample in samples]
@@ -86,6 +86,68 @@ def _remove_nans(samples, paired):
         nans = nans | np.isnan(sample)
     not_nans = ~nans
     return [sample[not_nans] for sample in samples]
+
+
+def _remove_sentinel(samples, paired, sentinel):
+    "Remove sentinel values from paired or unpaired 1D samples"
+    # could consolidate with `_remove_nans`, but it's not quite as simple as
+    # passing `sentinel=np.nan` because `(np.nan == np.nan) is False`
+
+    # potential optimization: don't copy arrays that don't contain sentinel
+    if not paired:
+        return [sample[sample != sentinel] for sample in samples]
+
+    # for paired samples, we need to remove the whole pair when any part
+    # has a nan
+    sentinels = (samples[0] == sentinel)
+    for sample in samples[1:]:
+        sentinels = sentinels | (sample == sentinel)
+    not_sentinels = ~sentinels
+    return [sample[not_sentinels] for sample in samples]
+
+
+def _masked_arrays_2_sentinel_arrays(samples):
+    # masked arrays in `samples` are converted to regular arrays, and values
+    # corresponding with masked elements ar replaced with a sentinel value
+
+    # return without modifying arrays if none have a mask
+    has_mask = False
+    for sample in samples:
+        mask = getattr(sample, 'mask', False)
+        has_mask = has_mask or np.any(mask)
+    if not has_mask:
+        return samples, None  # None means there is no sentinel value
+
+    # Choose a sentinel value. We can't use `np.nan`, because sentinel (masked)
+    # values are always omitted, but there are different nan policies.
+    for i in range(len(samples)):
+        # Things get more complicated if the arrays are of different types.
+        # We could have different sentinel values for each array, but
+        # the purpose of this code is convenience, not efficiency.
+        samples[i] = samples[i].astype(np.float64, copy=False)
+
+    max_possible, eps = np.finfo(np.float64).max, np.finfo(np.float64).eps
+
+    sentinel = max_possible
+    while sentinel > 0:
+        for sample in samples:
+            if np.any(sample == sentinel):
+                sentinel *= (1 - 2*eps)  # choose a new sentinel value
+                break
+        else: # when sentinel value is OK, break the while loop
+            break
+
+    # replace masked elements with sentinel value
+    out_samples = []
+    for sample in samples:
+        mask = getattr(sample, 'mask', False)
+        if np.any(mask):
+            mask = np.broadcast_to(mask, sample.shape)
+            sample = sample.data.copy()  # don't modify original array
+            sample[mask] = sentinel
+        out_samples.append(sample)
+
+    return out_samples, sentinel
 
 
 def _check_empty_inputs(samples, axis):
@@ -232,6 +294,9 @@ def _axis_nan_policy_factory(result_object, default_axis=0,
             nan_policy = kwds.pop('nan_policy', 'propagate')
             del args  # avoid the possibility of passing both `args` and `kwds`
 
+            # convert masked arrays to regular arrays with sentinel values
+            samples, sentinel = _masked_arrays_2_sentinel_arrays(samples)
+
             if axis is None:
                 samples = [sample.ravel() for sample in samples]
                 axis = 0
@@ -261,12 +326,14 @@ def _axis_nan_policy_factory(result_object, default_axis=0,
                     # consider passing in contains_nans
                     samples = _remove_nans(samples, paired)
 
-                # ideally, this is what the behavior would be, but some
-                # existing functions raise exceptions, so overriding it
-                # would break backward compatibility.
+                # ideally, this is what the behavior would be:
                 # if is_too_small(samples):
                 #     return result_object(np.nan, np.nan)
+                # but some existing functions raise exceptions, and changing
+                # behavior of those would break backward compatibility.
 
+                if sentinel:
+                    samples = _remove_sentinel(samples, paired, sentinel)
                 return hypotest_fun_in(*samples, **kwds)
 
             # check for empty input
@@ -289,7 +356,7 @@ def _axis_nan_policy_factory(result_object, default_axis=0,
             contains_nan, _ = (
                 scipy.stats._stats_py._contains_nan(x, nan_policy))
 
-            if vectorized and not contains_nan:
+            if vectorized and not contains_nan and not sentinel:
                 return hypotest_fun_in(*samples, axis=axis, **kwds)
 
             # Addresses nan_policy == "omit"
@@ -297,6 +364,8 @@ def _axis_nan_policy_factory(result_object, default_axis=0,
                 def hypotest_fun(x):
                     samples = np.split(x, split_indices)[:n_samp]
                     samples = _remove_nans(samples, paired)
+                    if sentinel:
+                        samples = _remove_sentinel(samples, paired, sentinel)
                     if is_too_small(samples):
                         return result_object(np.nan, np.nan)
                     return hypotest_fun_in(*samples, **kwds)
@@ -307,11 +376,19 @@ def _axis_nan_policy_factory(result_object, default_axis=0,
                     if np.isnan(x).any():
                         return result_object(np.nan, np.nan)
                     samples = np.split(x, split_indices)[:n_samp]
+                    if sentinel:
+                        samples = _remove_sentinel(samples, paired, sentinel)
+                    if is_too_small(samples):
+                        return result_object(np.nan, np.nan)
                     return hypotest_fun_in(*samples, **kwds)
 
             else:
                 def hypotest_fun(x):
                     samples = np.split(x, split_indices)[:n_samp]
+                    if sentinel:
+                        samples = _remove_sentinel(samples, paired, sentinel)
+                    if is_too_small(samples):
+                        return result_object(np.nan, np.nan)
                     return hypotest_fun_in(*samples, **kwds)
 
             x = np.moveaxis(x, axis, -1)

--- a/scipy/stats/_axis_nan_policy.py
+++ b/scipy/stats/_axis_nan_policy.py
@@ -121,7 +121,9 @@ def _broadcast_shapes_remove_axis(shapes, axis=None):
     of array shapes `shapes` instead of the arrays themselves.
     """
     shapes = _broadcast_shapes(shapes, axis)
-    shape = np.delete(shapes[0], axis)
+    shape = shapes[0]
+    if axis is not None:
+        shape = np.delete(shape, axis)
     return tuple(shape)
 
 

--- a/scipy/stats/_axis_nan_policy.py
+++ b/scipy/stats/_axis_nan_policy.py
@@ -12,6 +12,65 @@ from scipy._lib._docscrape import FunctionDoc, Parameter
 import inspect
 
 
+def _broadcast_arrays(arrays, axis=None):
+    """
+    Broadcast shapes of arrays, ignoring incompatibility of specified axes
+    """
+    new_shapes = _broadcast_array_shapes(arrays, axis=axis)
+    if axis is None:
+        new_shapes = [new_shapes]*len(arrays)
+    return [np.broadcast_to(array, new_shape)
+            for array, new_shape in zip(arrays, new_shapes)]
+
+
+def _broadcast_array_shapes(arrays, axis=None):
+    """
+    Broadcast shapes of arrays, ignoring incompatibility of specified axes
+    """
+    shapes = [np.asarray(arr).shape for arr in arrays]
+    return _broadcast_shapes(shapes, axis)
+
+
+def _broadcast_shapes(shapes, axis=None):
+    """
+    Broadcast shapes, ignoring incompatibility of specified axes
+    """
+    # First, ensure all shapes have same number of dimensions by prepending 1s.
+    n_dims = max([len(shape) for shape in shapes])
+    new_shapes = np.ones((len(shapes), n_dims), dtype=int)
+    for row, shape in zip(new_shapes, shapes):
+        row[len(row)-len(shape):] = shape  # can't use negative indices (-0:)
+
+    # Remove the shape elements of the axes to be ignored, but remember them.
+    if axis is not None:
+        axis = np.atleast_1d(axis)
+        axis[axis < 0] = n_dims + axis[axis < 0]
+        removed_shapes = new_shapes[:, axis]
+        new_shapes = np.delete(new_shapes, axis, axis=1)
+
+    # If arrays are broadcastable, shape elements that are 1 may be replaced
+    # with a corresponding non-1 shape element. Assuming arrays are
+    # broadcastable, that final shape element can be found with:
+    new_shape = np.max(new_shapes, axis=0)
+    # except in case of an empty array:
+    new_shape *= new_shapes.all(axis=0)
+
+    # Among all arrays, there can only be one unique non-1 shape element.
+    # Therefore, if any non-1 shape element does not match what we found
+    # above, the arrays must not be broadcastable after all.
+    if np.any(~((new_shapes == 1) | (new_shapes == new_shape))):
+        raise ValueError("Array shapes are incompatible for broadcasting.")
+
+    if axis is not None:
+        # Add back the shape elements that were ignored
+        new_axis = axis - np.arange(len(axis))
+        new_shapes = [tuple(np.insert(new_shape, new_axis, removed_shape))
+                      for removed_shape in removed_shapes]
+        return new_shapes
+    else:
+        return tuple(new_shape)
+
+
 def _broadcast_array_shapes_remove_axis(arrays, axis=None):
     """
     Broadcast shapes of arrays, dropping specified axes

--- a/scipy/stats/_axis_nan_policy.py
+++ b/scipy/stats/_axis_nan_policy.py
@@ -108,7 +108,7 @@ def _remove_sentinel(samples, paired, sentinel):
 
 def _masked_arrays_2_sentinel_arrays(samples):
     # masked arrays in `samples` are converted to regular arrays, and values
-    # corresponding with masked elements ar replaced with a sentinel value
+    # corresponding with masked elements are replaced with a sentinel value
 
     # return without modifying arrays if none have a mask
     has_mask = False
@@ -134,7 +134,7 @@ def _masked_arrays_2_sentinel_arrays(samples):
             if np.any(sample == sentinel):
                 sentinel *= (1 - 2*eps)  # choose a new sentinel value
                 break
-        else: # when sentinel value is OK, break the while loop
+        else:  # when sentinel value is OK, break the while loop
             break
 
     # replace masked elements with sentinel value

--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -13,6 +13,7 @@ from . import _wilcoxon_data
 import scipy.stats._bootstrap as _bootstrap
 from scipy._lib._util import check_random_state
 from ._hypotests_pythran import _Q, _P, _a_ij_Aij_Dij2
+from scipy.stats._axis_nan_policy import _broadcast_arrays
 
 __all__ = ['epps_singleton_2samp', 'cramervonmises', 'somersd',
            'barnard_exact', 'boschloo_exact', 'cramervonmises_2samp',
@@ -1408,65 +1409,6 @@ def cramervonmises_2samp(x, y, method='auto'):
 
 attributes = ('statistic', 'pvalue', 'null_distribution')
 PermutationTestResult = make_dataclass('PermutationTestResult', attributes)
-
-
-def _broadcast_arrays(arrays, axis=None):
-    """
-    Broadcast shapes of arrays, ignoring incompatibility of specified axes
-    """
-    new_shapes = _broadcast_array_shapes(arrays, axis=axis)
-    if axis is None:
-        new_shapes = [new_shapes]*len(arrays)
-    return [np.broadcast_to(array, new_shape)
-            for array, new_shape in zip(arrays, new_shapes)]
-
-
-def _broadcast_array_shapes(arrays, axis=None):
-    """
-    Broadcast shapes of arrays, ignoring incompatibility of specified axes
-    """
-    shapes = [np.asarray(arr).shape for arr in arrays]
-    return _broadcast_shapes(shapes, axis)
-
-
-def _broadcast_shapes(shapes, axis=None):
-    """
-    Broadcast shapes, ignoring incompatibility of specified axes
-    """
-    # First, ensure all shapes have same number of dimensions by prepending 1s.
-    n_dims = max([len(shape) for shape in shapes])
-    new_shapes = np.ones((len(shapes), n_dims), dtype=int)
-    for row, shape in zip(new_shapes, shapes):
-        row[len(row)-len(shape):] = shape  # can't use negative indices (-0:)
-
-    # Remove the shape elements of the axes to be ignored, but remember them.
-    if axis is not None:
-        axis = np.atleast_1d(axis)
-        axis[axis < 0] = n_dims + axis[axis < 0]
-        removed_shapes = new_shapes[:, axis]
-        new_shapes = np.delete(new_shapes, axis, axis=1)
-
-    # If arrays are broadcastable, shape elements that are 1 may be replaced
-    # with a corresponding non-1 shape element. Assuming arrays are
-    # broadcastable, that final shape element can be found with:
-    new_shape = np.max(new_shapes, axis=0)
-    # except in case of an empty array:
-    new_shape *= new_shapes.all(axis=0)
-
-    # Among all arrays, there can only be one unique non-1 shape element.
-    # Therefore, if any non-1 shape element does not match what we found
-    # above, the arrays must not be broadcastable after all.
-    if np.any(~((new_shapes == 1) | (new_shapes == new_shape))):
-        raise ValueError("Array shapes are incompatible for broadcasting.")
-
-    if axis is not None:
-        # Add back the shape elements that were ignored
-        new_axis = axis - np.arange(len(axis))
-        new_shapes = [tuple(np.insert(new_shape, new_axis, removed_shape))
-                      for removed_shape in removed_shapes]
-        return new_shapes
-    else:
-        return tuple(new_shape)
 
 
 def _all_partitions_concatenated(ns):

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -88,7 +88,7 @@ def _contains_nan(a, nan_policy='propagate'):
     try:
         # Calling np.sum to avoid creating a huge array into memory
         # e.g. np.isnan(a).any()
-        with np.errstate(invalid='ignore'):
+        with np.errstate(invalid='ignore', over='ignore'):
             contains_nan = np.isnan(np.sum(a))
     except TypeError:
         # This can happen when attempting to sum things which are not

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -4,7 +4,7 @@
 # that support `axis` and `nan_policy` and additional tests for some associated
 # functions in stats._util.
 
-from itertools import product, combinations_with_replacement
+from itertools import product, combinations_with_replacement, permutations
 import re
 import pickle
 import pytest
@@ -610,7 +610,7 @@ def test_masked_stat_1d():
     np.testing.assert_array_equal(res6, res)
 
 
-@pytest.mark.parametrize(("axis"), range(-2, 2))
+@pytest.mark.parametrize(("axis"), range(-3, 3))
 def test_masked_stat_3d(axis):
     # basic test of _axis_nan_policy_factory with 3D masked sample
     np.random.seed(0)
@@ -679,6 +679,7 @@ def test_mixed_mask_nan_1():
     np.testing.assert_array_equal(res3, res)
     np.testing.assert_array_equal(res4, res)
 
+
 def test_mixed_mask_nan_2():
     # targeted test of _axis_nan_policy_factory with 2D masked sample:
     # check for expected interaction between masks and nans
@@ -719,3 +720,61 @@ def test_mixed_mask_nan_2():
              np.nan, ref1.pvalue, ref2.pvalue]
     np.testing.assert_array_equal(res.statistic, stat_ref)
     np.testing.assert_array_equal(res.pvalue, p_ref)
+
+
+def test_axis_None_vs_tuple():
+    # `axis` `None` should be equivalent to tuple with all axes
+    shape = (3, 8, 9, 10)
+    rng = np.random.default_rng(0)
+    x = rng.random(shape)
+    res = stats.kruskal(*x, axis=None)
+    res2 = stats.kruskal(*x, axis=(0, 1, 2))
+    np.testing.assert_array_equal(res, res2)
+
+
+@pytest.mark.parametrize(("axis"),
+                         list(permutations(range(-3, 3), 2)) + [(-4, 1)])
+def test_other_axis_tuples(axis):
+    # Check that _axis_nan_policy_factory treates all `axis` tuples as expected
+    rng = np.random.default_rng(0)
+    shape_x = (4, 5, 6)
+    shape_y = (1, 6)
+    x = rng.random(shape_x)
+    y = rng.random(shape_y)
+    axis_original = axis
+
+    # convert axis elements to positive
+    axis = tuple([(i if i >=0 else 3 + i) for i in axis])
+    axis = sorted(axis)
+
+    if len(set(axis)) != len(axis):
+        message = "`axis` must contain only distinct elements"
+        with pytest.raises(ValueError, match=re.escape(message)):
+            stats.mannwhitneyu(x, y, axis=axis_original)
+        return
+
+    if axis[0] < 0 or axis[-1] > 2:
+        message = "`axis` is out of bounds for array of dimension 3"
+        with pytest.raises(ValueError, match=re.escape(message)):
+            stats.mannwhitneyu(x, y, axis=axis_original)
+        return
+
+    res = stats.mannwhitneyu(x, y, axis=axis_original)
+
+    # reference behavior
+    not_axis = {0, 1, 2} - set(axis)  # which axis is not part of `axis`
+    not_axis = next(iter(not_axis))  # take it out of the set
+
+    x2 = x
+    shape_y_broadcasted = [1, 1, 6]
+    shape_y_broadcasted[not_axis] = shape_x[not_axis]
+    y2 = np.broadcast_to(y, shape_y_broadcasted)
+
+    m = x2.shape[not_axis]
+    x2 = np.moveaxis(x2, axis, (1, 2))
+    y2 = np.moveaxis(y2, axis, (1, 2))
+    x2 = np.reshape(x2, (m, -1))
+    y2 = np.reshape(y2, (m, -1))
+    res2 = stats.mannwhitneyu(x2, y2, axis=1)
+
+    np.testing.assert_array_equal(res, res2)

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -576,11 +576,7 @@ def test_masked_array_2_sentinel_array():
 
 
 def test_masked_stat_1d():
-    # Adding support for masked arrays requires minimal modifications to the
-    # _axis_nan_policy decorator, so exhaustive tests for masked arrays
-    # (and all possible combinations of masked/non masked arrays with and
-    # without masked elements and nans) is not necessary. Instead, perform
-    # basic tests in 1D and 2D.
+    # basic test of _axis_nan_policy_factory with 1D masked sample
     males = [19, 22, 16, 29, 24]
     females = [20, 11, 17, 12]
     res = stats.mannwhitneyu(males, females)
@@ -594,7 +590,7 @@ def test_masked_stat_1d():
     females3 = [20, 11, 17, 1000, 12]
     mask3 = [False, False, False, True, False]
     females3 = np.ma.masked_array(females3, mask=mask3)
-    res3 =  stats.mannwhitneyu(males, females3)
+    res3 = stats.mannwhitneyu(males, females3)
     np.testing.assert_array_equal(res3, res)
 
     # same result when extra nan is omitted and additional element is masked
@@ -616,11 +612,7 @@ def test_masked_stat_1d():
 
 @pytest.mark.parametrize(("axis"), range(-2, 2))
 def test_masked_stat_3d(axis):
-    # Adding support for masked arrays requires minimal modifications to the
-    # _axis_nan_policy decorator, so exhaustive tests for masked arrays
-    # (and all possible combinations of masked/non masked arrays with and
-    # without masked elements and nans) is not necessary. Instead, perform
-    # basic tests in 1D and 2D.
+    # basic test of _axis_nan_policy_factory with 3D masked sample
     np.random.seed(0)
     a = np.random.rand(3, 4, 5)
     b = np.random.rand(4, 5)
@@ -639,3 +631,91 @@ def test_masked_stat_3d(axis):
     res = stats.kruskal(a_nans, b, c_nans, nan_policy='omit', axis=axis)
     res2 = stats.kruskal(a_masked, b, c_masked, axis=axis)
     np.testing.assert_array_equal(res, res2)
+
+
+def test_mixed_mask_nan_1():
+    # targeted test of _axis_nan_policy_factory with 2D masked sample:
+    # omitting samples with masks and nan_policy='omit' are equivalent
+    # also checks paired-sample sentinel value removal
+    m, n = 3, 20
+    axis = -1
+
+    np.random.seed(0)
+    a = np.random.rand(m, n)
+    b = np.random.rand(m, n)
+    mask_a1 = np.random.rand(m, n) < 0.2
+    mask_a2 = np.random.rand(m, n) < 0.1
+    mask_b1 = np.random.rand(m, n) < 0.15
+    mask_b2 = np.random.rand(m, n) < 0.15
+    mask_a1[2, :] = True
+
+    a_nans = a.copy()
+    b_nans = b.copy()
+    a_nans[mask_a1 | mask_a2] = np.nan
+    b_nans[mask_b1 | mask_b2] = np.nan
+
+    a_masked1 = np.ma.masked_array(a, mask=mask_a1)
+    b_masked1 = np.ma.masked_array(b, mask=mask_b1)
+    a_masked1[mask_a2] = np.nan
+    b_masked1[mask_b2] = np.nan
+
+    a_masked2 = np.ma.masked_array(a, mask=mask_a2)
+    b_masked2 = np.ma.masked_array(b, mask=mask_b2)
+    a_masked2[mask_a1] = np.nan
+    b_masked2[mask_b1] = np.nan
+
+    a_masked3 = np.ma.masked_array(a, mask=(mask_a1 | mask_a2))
+    b_masked3 = np.ma.masked_array(b, mask=(mask_b1 | mask_b2))
+
+    res = stats.wilcoxon(a_nans, b_nans, nan_policy='omit', axis=axis)
+    res1 = stats.wilcoxon(a_masked1, b_masked1, nan_policy='omit', axis=axis)
+    res2 = stats.wilcoxon(a_masked2, b_masked2, nan_policy='omit', axis=axis)
+    res3 = stats.wilcoxon(a_masked3, b_masked3, nan_policy='raise', axis=axis)
+    res4 = stats.wilcoxon(a_masked3, b_masked3,
+                          nan_policy='propagate', axis=axis)
+
+    np.testing.assert_array_equal(res1, res)
+    np.testing.assert_array_equal(res2, res)
+    np.testing.assert_array_equal(res3, res)
+    np.testing.assert_array_equal(res4, res)
+
+def test_mixed_mask_nan_2():
+    # targeted test of _axis_nan_policy_factory with 2D masked sample:
+    # check for expected interaction between masks and nans
+
+    # Cases here are
+    # [mixed nan/mask, all nans, all masked,
+    # unmasked nan, masked nan, unmasked non-nan]
+    a = [[1, np.nan, 2], [np.nan, np.nan, np.nan], [1, 2, 3],
+         [1, np.nan, 3], [1, np.nan, 3], [1, 2, 3]]
+    mask = [[1, 0, 1], [0, 0, 0], [1, 1, 1],
+            [0, 0, 0], [0, 1, 0], [0, 0, 0]]
+    a_masked = np.ma.masked_array(a, mask=mask)
+    b = [[4, 5, 6]]
+    ref1 = stats.ranksums([1, 3], [4, 5, 6])
+    ref2 = stats.ranksums([1, 2, 3], [4, 5, 6])
+
+    # nan_policy = 'omit'
+    # all elements are removed from first three rows
+    # middle element is removed from fourth and fifth rows
+    # no elements removed from last row
+    res = stats.ranksums(a_masked, b, nan_policy='omit', axis=-1)
+    stat_ref = [np.nan, np.nan, np.nan,
+                ref1.statistic, ref1.statistic, ref2.statistic]
+    p_ref = [np.nan, np.nan, np.nan,
+             ref1.pvalue, ref1.pvalue, ref2.pvalue]
+    np.testing.assert_array_equal(res.statistic, stat_ref)
+    np.testing.assert_array_equal(res.pvalue, p_ref)
+
+    # nan_policy = 'propagate'
+    # nans propagate in first, second, and fourth row
+    # all elements are removed by mask from third row
+    # middle element is removed from fifth row
+    # no elements removed from last row
+    res = stats.ranksums(a_masked, b, nan_policy='propagate', axis=-1)
+    stat_ref = [np.nan, np.nan, np.nan,
+                np.nan, ref1.statistic, ref2.statistic]
+    p_ref = [np.nan, np.nan, np.nan,
+             np.nan, ref1.pvalue, ref2.pvalue]
+    np.testing.assert_array_equal(res.statistic, stat_ref)
+    np.testing.assert_array_equal(res.pvalue, p_ref)

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -732,6 +732,24 @@ def test_axis_None_vs_tuple():
     np.testing.assert_array_equal(res, res2)
 
 
+def test_axis_None_vs_tuple_with_broadcasting():
+    # `axis` `None` should be equivalent to tuple with all axes,
+    # which should be equivalent to raveling the arrays before passing them
+    rng = np.random.default_rng(0)
+    x = rng.random((5, 1))
+    y = rng.random((1, 5))
+    x2, y2 = np.broadcast_arrays(x, y)
+
+    res0 = stats.mannwhitneyu(x.ravel(), y.ravel())
+    res1 = stats.mannwhitneyu(x, y, axis=None)
+    res2 = stats.mannwhitneyu(x, y, axis=(0, 1))
+    res3 = stats.mannwhitneyu(x2.ravel(), y2.ravel())
+
+    assert(res1 == res0)
+    assert(res2 == res0)
+    assert(res3 != res0)
+
+
 @pytest.mark.parametrize(("axis"),
                          list(permutations(range(-3, 3), 2)) + [(-4, 1)])
 def test_other_axis_tuples(axis):
@@ -744,7 +762,7 @@ def test_other_axis_tuples(axis):
     axis_original = axis
 
     # convert axis elements to positive
-    axis = tuple([(i if i >=0 else 3 + i) for i in axis])
+    axis = tuple([(i if i >= 0 else 3 + i) for i in axis])
     axis = sorted(axis)
 
     if len(set(axis)) != len(axis):


### PR DESCRIPTION
#### Reference issue
gh-14651 (checks the second box)

#### What does this implement/fix?
gh-13312 added `_axis_nan_policy_factory`, which returns a decorator that adds `axis` and `nan_policy` arguments to stats functions. With the additions in this PR, the decorators produced now support `axis` arguments that are tuples of integers. 

#### Additional information
This implements the steps discussed in [this comment](https://github.com/scipy/scipy/pull/15239#discussion_r771843179).
To facilitate review, I've left some self-review comments to explain the changes. Feel free to mark them resolved. 
I would also suggest viewing the changes in three separate steps.
* In 7c3af006474355cea4c5a506934727b5d8a8a4db, `_broadcast_arrays` and related functions are moved (verbatim) from `_hypotests.py` into `_axis_nan_policy.py`, a better permanent home
* In fddaf0635828b00837c0d0a038076612322c24d7, the `_broadcast...` functions are consolidated, so that the main logic is only in `_broadcast_arrays`
* The remaining commits (select 565d4fd1ab9c22610411f835c049cee8452ccba9 and 49939585656caeaff5c8ae80c4e547bede1dfafc) modify `_axis_nan_policy_factory` to support `axis` tuples and add tests.

<details>

![image](https://user-images.githubusercontent.com/6570539/146889859-ceeab66d-ed77-4c64-a3e2-563d339db522.png)

![image](https://user-images.githubusercontent.com/6570539/146889895-cb489a79-6994-469c-9aa1-de6c34030f77.png)

![image](https://user-images.githubusercontent.com/6570539/146890244-9c11b76a-396e-4d18-acb7-cef4b548f98e.png)

Selecting the last two commits in the last step will also select the first three commits (because of the merge commit).

</details>

This should be squash-merged; the commit history is messier than intended. 