### PR TITLE
DOC: Add inline comment in Hausdorff distance calculation

### DIFF
--- a/scipy/spatial/_hausdorff.pyx
+++ b/scipy/spatial/_hausdorff.pyx
@@ -58,8 +58,13 @@ def directed_hausdorff(double[:,::1] ar1, double[:,::1] ar2, seed=0):
                 i_store = i
                 j_store = j
 
-        # always true on first iteration of for-j loop, after that only
-        # if d >= cmax
+        # Note: The reference paper by A. A. Taha and A. Hanbury has this line
+        # (Algorithm 2, line 16) as:
+        #
+        # if cmin > cmax:
+        #
+        # That logic is incorrect, as cmin could still be np.inf if breaking early.
+        # The logic here accounts for that case.
         if cmin >= cmax and d >= cmax:
             cmax = cmin
             i_ret = i_store


### PR DESCRIPTION
#### What does this implement/fix?

Comparing the logic in the implementation of this function to the referenced literature I found a discrepancy between the two. It wasn't initially clear to me whether this was a bug, or an error in the paper. I've convinced myself that the error lies in the paper, so I've added a comment to the code to explain the discrepancy and save some time for the next person who bumps into this :-)

The paper in question can be found [here](https://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=7053955).
