### PR TITLE
CI: remove coverage usage from Windows jobs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -337,7 +337,7 @@ stages:
     - powershell: |
         $env:PATH = "C:\\ProgramData\\chocolatey\\lib\\mingw\\tools\\install\\mingw$(BITS)\\bin;" + $env:PATH
         $env:SCIPY_USE_PYTHRAN=$(SCIPY_USE_PYTHRAN)
-        python runtests.py -n --mode=$(TEST_MODE) -- -n 2 --junitxml=junit/test-results.xml --cov=scipy --cov-report=xml --cov-report=html --durations=10
+        python runtests.py -n --mode=$(TEST_MODE) -- -n 2 --junitxml=junit/test-results.xml --durations=10
       displayName: 'Run SciPy Test Suite'
     - task: PublishTestResults@2
       condition: succeededOrFailed()
@@ -345,8 +345,3 @@ stages:
         testResultsFiles: '**/test-*.xml'
         failTaskOnFailedTests: true
         testRunTitle: 'Publish test results for Python $(python.version)'
-    - task: PublishCodeCoverageResults@1
-      inputs:
-        codeCoverageTool: Cobertura
-        summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
-        reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'


### PR DESCRIPTION
We seem to be measuring coverage on all jobs, and it remains quite
flaky. It is not necessary to do this on all jobs. So to stop the
hangs in CI, let's remove them from the Windows jobs where this is
a regular occurrence.

If the root cause is found, it can be re-enabled (preferably on only
a single Windows job with the full test suite, and not on all jobs -
we've had too many problems for too little gain for too long here).

Closes gh-14914