### PR TITLE
CI: pin setuptools to 59.6.0 and Pythran to 0.10.0 for Windows and 32-bit Linux jobs on Azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -172,7 +172,7 @@ stages:
             curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
             python3.8 get-pip.py && \
             pip3 --version && \
-            pip3 install setuptools==59.6.0 wheel numpy==1.17.3 cython==0.29.18 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath matplotlib==3.1.3 pythran --user && \
+            pip3 install setuptools==59.6.0 wheel numpy==1.17.3 cython==0.29.18 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath matplotlib==3.1.3 pythran==0.10.0 --user && \
             apt-get -y install gcc-5 g++-5 gfortran-8 wget && \
             cd .. && \
             mkdir openblas && cd openblas && \
@@ -284,7 +284,7 @@ stages:
         numpy==1.21.4
         Pillow
         pybind11
-        pythran
+        pythran==0.10.0
         pytest
         pytest-cov
         pytest-env

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -180,7 +180,7 @@ stages:
             cp -r \$target/lib/* /usr/lib && \
             cp \$target/include/* /usr/include && \
             cd ../scipy && \
-            CC=gcc-5 CXX=g++-5 F77=gfortran-8 F90=gfortran-8 python3.8 setup.py install && \
+            CC=gcc-5 CXX=g++-5 F77=gfortran-8 F90=gfortran-8 pip3 install . && \
             python3.8 tools/openblas_support.py --check_version $(openblas_version) && \
             CC=gcc-5 CXX=g++-5 F77=gfortran-8 F90=gfortran-8 python3.8 runtests.py --mode=full -- -n auto -s --junitxml=junit/test-results.xml --cov-config=.coveragerc --cov-report=xml --cov-report=html"
       displayName: 'Run 32-bit Ubuntu Docker Build / Tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -172,8 +172,7 @@ stages:
             curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
             python3.8 get-pip.py && \
             pip3 --version && \
-            pip3 install setuptools wheel --user && \
-            pip3 install numpy==1.17.3 cython==0.29.18 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath matplotlib==3.1.3 pythran --user && \
+            pip3 install setuptools==59.6.0 wheel numpy==1.17.3 cython==0.29.18 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath matplotlib==3.1.3 pythran --user && \
             apt-get -y install gcc-5 g++-5 gfortran-8 wget && \
             cd .. && \
             mkdir openblas && cd openblas && \
@@ -243,7 +242,7 @@ stages:
         git submodule update --init
       displayName: 'Fetch submodules'
     - script: |
-        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --upgrade pip "setuptools==59.6.0" wheel
       displayName: 'Install tools'
     - powershell: |
         $pyversion = python -c "import sys; print(sys.version.split()[0])"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -326,6 +326,7 @@ stages:
             refreshenv
         }
         $env:PATH = "C:\\ProgramData\\chocolatey\\lib\\mingw\\tools\\install\\mingw$(BITS)\\bin;" + $env:PATH
+        $env:SCIPY_USE_PYTHRAN=0
 
         mkdir dist
         pip wheel --no-build-isolation -v -v -v --wheel-dir=dist .


### PR DESCRIPTION
This fixes the Windows build failures with Pythran 0.11. Closes gh-15267

It also fixes the failure of the 32-bit Linux build (no separate issue opened for that one), which looks like:

```
Adding scipy 1.9.0.dev0+unknown.unknown to easy-install.pth file

Installed /usr/lib/python3.8/site-packages/scipy-1.9.0.dev0+unknown.unknown-py3.8-linux-i686.egg
Processing dependencies for scipy==1.9.0.dev0+unknown.unknown
Searching for numpy==1.17.3
Best match: numpy 1.17.3
Adding numpy 1.17.3 to easy-install.pth file
Installing f2py script to /usr/bin
Installing f2py3 script to /usr/bin
Installing f2py3.8 script to /usr/bin

Using /root/.local/lib/python3.8/site-packages
Finished processing dependencies for scipy==1.9.0.dev0+unknown.unknown
Running from SciPy source directory.
/root/.local/lib/python3.8/site-packages/numpy/distutils/system_info.py:782: UserWarning: Specified path /root/.local/include/python3.8 is invalid.
  return self.get_paths(self.section, key)
/root/.local/lib/python3.8/site-packages/numpy/distutils/system_info.py:782: UserWarning: Specified path /usr/local/include/python3.8 is invalid.
  return self.get_paths(self.section, key)
/usr/local/lib/python3.8/dist-packages/setuptools/dist.py:493: UserWarning: Normalizing '1.9.0.dev0+Unknown.Unknown' to '1.9.0.dev0+unknown.unknown'
  warnings.warn(tmpl.format(**locals()))
/usr/local/lib/python3.8/dist-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
  warnings.warn(
/usr/local/lib/python3.8/dist-packages/setuptools/command/easy_install.py:156: EasyInstallDeprecationWarning: easy_install command is deprecated. Use build and pip and other standards-based tools.
  warnings.warn(
/usr/local/lib/python3.8/dist-packages/setuptools/command/egg_info.py:624: SetuptoolsDeprecationWarning: Custom 'build_py' does not implement 'get_data_files_without_manifest'.
Please extend command classes from setuptools instead of distutils.
  warnings.warn(
Traceback (most recent call last):
  File "tools/openblas_support.py", line 332, in <module>
    test_version(args.check_version)
  File "tools/openblas_support.py", line 296, in test_version
    import scipy
ModuleNotFoundError: No module named 'scipy'
```

