### PR TITLE
BLD: add setup.py for `stats/_levy_stable`

### DIFF
--- a/scipy/stats/_levy_stable/c_src/levyst.c
+++ b/scipy/stats/_levy_stable/c_src/levyst.c
@@ -14,6 +14,13 @@
 #include <stdlib.h>
 #include "levyst.h"
 
+/* M_PI et al. are not defined in math.h in C99, even with _USE_MATH_DEFINES */
+#ifndef M_PI_2
+# define M_PI_2  1.57079632679489661923  /* pi/2 */
+# define M_1_PI  0.31830988618379067154  /* 1/pi */
+# define M_2_PI  0.63661977236758134308  /* 2/pi */
+#endif
+
 double
 g_alpha_ne_one(struct nolan_precanned *sp, double theta)
 {

--- a/scipy/stats/_levy_stable/setup.py
+++ b/scipy/stats/_levy_stable/setup.py
@@ -1,0 +1,24 @@
+from os.path import join
+
+
+def configuration(parent_package='', top_path=None):
+    from numpy.distutils.misc_util import Configuration
+
+    config = Configuration('_levy_stable', parent_package, top_path)
+
+    config.add_library(
+        '_levyst',
+        sources=[join('c_src', 'levyst.c')],
+        headers=[join('c_src', 'levyst.h')]
+    )
+    config.add_extension(
+        'levyst',
+        libraries=['_levyst'],
+        sources=['levyst.c']
+    )
+    return config
+
+
+if __name__ == '__main__':
+    from numpy.distutils.core import setup
+    setup(**configuration(top_path='').todict())

--- a/scipy/stats/setup.py
+++ b/scipy/stats/setup.py
@@ -87,26 +87,17 @@ def configuration(parent_package='', top_path=None):
     )
     ext._pre_build_hook = pre_build_hook
 
-    # add unuran subumodule
+    # add unuran submodule
     config.add_subpackage('_unuran')
 
     # add boost stats distributions
     config.add_subpackage('_boost')
 
+    # add levy stable submodule
+    config.add_subpackage('_levy_stable')
+
     # Type stubs
     config.add_data_files('*.pyi')
-
-    # add levy stable module
-    config.add_data_files(join('_levy_stable', '*.py'))
-    config.add_library(
-        'levyst',
-        sources=[join('_levy_stable/c_src', 'levyst.c')],
-        headers=[join('_levy_stable/c_src', 'levyst.h')]
-    )
-    config.add_extension(
-        '_levy_stable.levyst',
-        libraries=['levyst'],
-        sources=[join('_levy_stable', 'levyst.c')])
 
     return config
 


### PR DESCRIPTION
Closes gh-15245

EDIT: the second commit also makes the usage of `M_PI_2` and other such symbols more robust (I need this for the Meson build).