### PR TITLE
TST: slightly bump test tolerance for a new lobpcg test

### DIFF
--- a/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
@@ -315,7 +315,7 @@ def test_tolerance_float32():
     X = rnd.standard_normal((n, m))
     X = X.astype(np.float32)
     eigvals, _ = lobpcg(A, X, tol=1e-5, maxiter=50, verbosityLevel=0)
-    assert_allclose(eigvals, -np.arange(1, 1 + m), atol=1e-5)
+    assert_allclose(eigvals, -np.arange(1, 1 + m), atol=1.5e-5)
 
 
 def test_random_initial_float32():


### PR DESCRIPTION
This was failing in the Meson build due to slightly different build flags:
```
scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py:318: in test_tolerance_float32
    assert_allclose(eigvals, -np.arange(1, 1 + m), atol=1e-5)
E   AssertionError:
E   Not equal to tolerance rtol=1e-07, atol=1e-05
E
E   Mismatched elements: 1 / 3 (33.3%)
E   Max absolute difference: 1.31130219e-05
E   Max relative difference: 4.37100728e-06
E    x: array([-1.      , -2.000001, -2.999987], dtype=float32)
E    y: array([-1, -2, -3])
```

Cc @lobpcg for visibility