### PR TITLE
BUG: Fix owens_t function when a tends to infinity

### DIFF
--- a/scipy/special/cephes/owens_t.c
+++ b/scipy/special/cephes/owens_t.c
@@ -333,7 +333,7 @@ double owens_t(double h, double a) {
 
     if (fabs_a == NPY_INFINITY) {
 	/* See page 13 in the paper */
-	result = owens_t_norm2(h);
+	result = 0.5 * owens_t_norm2(h);
     }
     else if (h == NPY_INFINITY) {
 	result = 0;

--- a/scipy/special/tests/test_owens_t.py
+++ b/scipy/special/tests/test_owens_t.py
@@ -35,7 +35,11 @@ def test_infs():
     assert_allclose(sc.owens_t(h, -a), -res, rtol=5e-14)
 
     h = 1
+    # Refer Owens T function definition in Wikipedia
+    # https://en.wikipedia.org/wiki/Owen%27s_T_function
     # Value approximated through Numerical Integration
+    # using scipy.integrate.quad
+    # quad(lambda x: 1/(2*pi)*(exp(-0.5*(1*1)*(1+x*x))/(1+x*x)), 0, inf)
     res = 0.07932762696572854
     assert_allclose(sc.owens_t(h, np.inf), res, rtol=5e-14)
     assert_allclose(sc.owens_t(h, -np.inf), -res, rtol=5e-14)

--- a/scipy/special/tests/test_owens_t.py
+++ b/scipy/special/tests/test_owens_t.py
@@ -28,8 +28,15 @@ def test_nans():
 
 
 def test_infs():
+    h, a = 0, np.inf
+    # T(0, a) = 1/2π * arctan(a)
+    res = 1/(2*np.pi) * np.arctan(a)
+    assert_allclose(sc.owens_t(h, a), res, rtol=5e-14)
+    assert_allclose(sc.owens_t(h, -a), -res, rtol=5e-14)
+
     h = 1
-    res = 0.5*sc.erfc(h/np.sqrt(2))
+    # Value approximated through Numerical Integration
+    res = 0.07932762696572854
     assert_allclose(sc.owens_t(h, np.inf), res, rtol=5e-14)
     assert_allclose(sc.owens_t(h, -np.inf), -res, rtol=5e-14)
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #15117 

#### What does this implement/fix?
<!--Please explain your changes.-->
Fixed owens_t(h, a) function giving wrong answers when a tends to infinity.

#### Additional information
<!--Any additional information you think is important.-->
Added and modified tests.
