### PR TITLE
MAINT: Fix imports in `signal._signaltools`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,6 +209,7 @@ scipy/optimize/slsqp/_slsqpmodule.c
 scipy/optimize/_lsq/givens_elimination.c
 scipy/optimize/_trlib/_trlib.c
 scipy/optimize/tnc/moduleTNC.c
+scipy/optimize/tnc/_moduleTNC.c
 scipy/signal/_peak_finding_utils.c
 scipy/signal/_spectral.c
 scipy/signal/_spectral.cpp

--- a/scipy/signal/_fir_filter_design.py
+++ b/scipy/signal/_fir_filter_design.py
@@ -459,7 +459,7 @@ def firwin(numtaps, cutoff, width=None, window='hamming', pass_zero=True,
         h -= left * sinc(left * m)
 
     # Get and apply the window function.
-    from ._signaltools import get_window
+    from .windows import get_window
     win = get_window(window, numtaps, fftbins=False)
     h *= win
 
@@ -667,7 +667,7 @@ def firwin2(numtaps, freq, gain, nfreqs=None, window='hamming', nyq=None,
 
     if window is not None:
         # Create the window to apply to the filter coefficients.
-        from ._signaltools import get_window
+        from .windows import get_window
         wind = get_window(window, numtaps, fftbins=False)
     else:
         wind = 1

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -5,7 +5,8 @@ import operator
 import math
 import timeit
 from scipy.spatial import cKDTree
-from . import _sigtools, dlti
+from . import _sigtools
+from ._ltisys import dlti
 from ._upfirdn import upfirdn, _output_len, _upfirdn_modes
 from scipy import linalg, fft as sp_fft
 from scipy.fft._helper import _init_nd_shape_and_axes


### PR DESCRIPTION
I don't know why the following line does not fail on the master when there is no module named `dlti`( which is actually a class defined in `_ltisys.py`)
This same line raised an import error when I was working on https://github.com/rgommers/scipy/pull/101.
https://github.com/scipy/scipy/blob/bdefc817a8b821005c003111dc801e3d4931394e/scipy/signal/_signaltools.py#L8

cc @rgommers 