### PR TITLE
DOC: Add thorough docstring for scipy.special.binom

### DIFF
--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -710,8 +710,8 @@ add_newdoc(
         \binom{x}{y} = \frac{\Gamma(x + 1)}{\Gamma(y + 1)\Gamma(x - y + 1)} =
             \frac{1}{(x + 1)\mathrm{B}(x - y + 1, y + 1)}
 
-    Where :math:`\Gamma` is the Gamma function and :math:`\mathrm{B}` is
-    the Beta function [1]_. See `gamma` and `beta`.
+    Where :math:`\Gamma` is the Gamma function (`gamma`) and :math:`\mathrm{B}`
+    is the Beta function (`beta`) [1]_.
 
     Parameters
     ----------
@@ -720,7 +720,7 @@ add_newdoc(
 
     Returns
     -------
-    ndarray
+    array_like
         Value of binomial coefficient.
 
     See Also
@@ -772,7 +772,7 @@ add_newdoc(
 
     `binom` returns ``nan`` when ``x`` is a negative integer, but is otherwise
     defined for negative arguments. `comb` returns 0 whenever one of ``x`` or
-    ``y`` is negative.
+    ``y`` is negative or ``x`` is less than ``y``.
 
     >>> x, y = -3, 2
     >>> (binom(x, y), comb(x, y), comb(x, y, exact=True))
@@ -781,6 +781,10 @@ add_newdoc(
     >>> x, y = -3.1, 2.2
     >>> (binom(x, y), comb(x, y), comb(x, y, exact=True))
     (18.714147876804432, 0.0, 0)
+
+    >>> x, y = 2.2, 3.1
+    >>> (binom(x, y), comb(x, y), comb(x, y, exact=True))
+    (0.037399983365134115, 0.0, 0)
     """
 )
 

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -697,15 +697,90 @@ add_newdoc("bdtrin",
     """)
 
 add_newdoc("binom",
-    """
-    binom(n, k)
+    r"""
+    binom(x, y)
 
-    Binomial coefficient
+    Binomial coefficient considered as a function of two real variables.
+
+    For real arguments, the binomial coefficient is defined as
+
+    .. math::
+
+        \binom{x}{y} = \frac{\Gamma(x + 1)}{\Gamma(y + 1)\Gamma(x - y + 1)} =
+            \frac{1}{(x + 1)\mathrm{B}(x - y + 1, y _ 1)}
+
+    Where :math:`\Gamma` is the Gamma function and :math:`\mathrm{B}` is
+    the Beta function [1]_. See `gamma` and `beta`.
+
+    Parameters
+    ----------
+    x, y: array_like
+       Real arguments to :math:`\binom{x}{y}`.
+
+    Returns
+    -------
+    ndarray
+        Value of binomial coefficient.
 
     See Also
     --------
     comb : The number of combinations of N things taken k at a time.
 
+    Notes
+    -----
+    The Gamma function has poles at non-positive integers and tends to either
+    positive or negative infinity depending on the direction on the real line
+    from which a pole is approached. When considered as a function of two real
+    variables, :math:`\binom{x}{y}` is thus undefined when `x` is a negative
+    integer.  `binom` returns ``nan`` when ``x`` is a negative integer. This
+    is the case even when ``x`` is a negative integer and ``y`` an integer,
+    contrary to the usual convention for defining :math:`\binom{n}{k}` when it
+    is considered as a function of two integer variables.
+
+    References
+    ----------
+    .. [1] https://en.wikipedia.org/wiki/Binomial_coefficient
+
+    Examples
+    --------
+    >>> from scipy.special import binom, comb
+
+    It's illustrative to see the ways in which `binom` differs from the
+    function `comb`. Below we compare `binom` and `comb` with and without
+    ``exact=True``.
+
+    For positive `x` and `y`, `comb` calls `binom` internally when
+    ``exact=False``. For small values `comb` with ``exact=True`` agrees
+    with `binom`.
+    
+    >>> x, y = 3, 2
+    >>> (binom(x, y), comb(x, y), comb(x, y, exact=True))
+    (3.0, 3.0, 3)
+
+    As expected, for larger values `comb` with ``exact=True`` no longer agrees
+    with `binom`.
+
+    >>> x, y = 43, 23
+    >>> (binom(x, y), comb(x, y), comb(x, y, exact=True))
+    (960566918219.9999, 960566918219.9999, 960566918220)
+
+    Note that if `comb` is passed non integer arguments when ``exact=True``,
+    these will be truncated to integers, leading to inaccurate results.
+
+    >>> x, y = 3.9, 2.8
+    >>> (binom(x, y), comb(x, y), comb(x, y, exact=True))
+    (4.2071983565457955, 4.2071983565457955, 3)
+
+    `binom` returns ``nan`` when ``x`` is a negative integer. `comb`
+    returns 0 whenever one of ``x`` or ``y`` is negative.
+
+    >>> x, y = -3, 2
+    >>> (binom(x, y), comb(x, y), comb(x, y, exact=True))
+    (nan, 0.0, 0)
+
+    >>> x, y = -3.1, 2.2
+    >>> (binom(x, y), comb(x, y), comb(x, y, exact=True))
+    (18.714147876804432, 0.0, 0)
     """)
 
 add_newdoc("btdtria",

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -707,7 +707,7 @@ add_newdoc("binom",
     .. math::
 
         \binom{x}{y} = \frac{\Gamma(x + 1)}{\Gamma(y + 1)\Gamma(x - y + 1)} =
-            \frac{1}{(x + 1)\mathrm{B}(x - y + 1, y _ 1)}
+            \frac{1}{(x + 1)\mathrm{B}(x - y + 1, y + 1)}
 
     Where :math:`\Gamma` is the Gamma function and :math:`\mathrm{B}` is
     the Beta function [1]_. See `gamma` and `beta`.

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -696,7 +696,8 @@ add_newdoc("bdtrin",
            Functions, Inverses, and Other Parameters.
     """)
 
-add_newdoc("binom",
+add_newdoc(
+    "binom",
     r"""
     binom(x, y)
 
@@ -743,8 +744,8 @@ add_newdoc("binom",
 
     Examples
     --------
-    The following examples illustrate the ways in which `binom` differs from the
-    function `comb`.
+    The following examples illustrate the ways in which `binom` differs from
+    the function `comb`.
 
     >>> from scipy.special import binom, comb
 
@@ -770,7 +771,7 @@ add_newdoc("binom",
     (4.2071983565457955, 4.2071983565457955, 3)
 
     `binom` returns ``nan`` when ``x`` is a negative integer, but is otherwise
-    defined for negative arguments. `comb` returns 0 whenever one of ``x`` or 
+    defined for negative arguments. `comb` returns 0 whenever one of ``x`` or
     ``y`` is negative.
 
     >>> x, y = -3, 2
@@ -780,7 +781,8 @@ add_newdoc("binom",
     >>> x, y = -3.1, 2.2
     >>> (binom(x, y), comb(x, y), comb(x, y, exact=True))
     (18.714147876804432, 0.0, 0)
-    """)
+    """
+)
 
 add_newdoc("btdtria",
     r"""

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -743,36 +743,35 @@ add_newdoc("binom",
 
     Examples
     --------
+    The following examples illustrate the ways in which `binom` differs from the
+    function `comb`.
+
     >>> from scipy.special import binom, comb
 
-    It's illustrative to see the ways in which `binom` differs from the
-    function `comb`. Below we compare `binom` and `comb` with and without
-    ``exact=True``.
+    When ``exact=False`` and ``x`` and ``y`` are both positive, `comb` calls
+    `binom` internally.
 
-    For positive `x` and `y`, `comb` calls `binom` internally when
-    ``exact=False``. For small values `comb` with ``exact=True`` agrees
-    with `binom`.
-    
     >>> x, y = 3, 2
     >>> (binom(x, y), comb(x, y), comb(x, y, exact=True))
     (3.0, 3.0, 3)
 
-    As expected, for larger values `comb` with ``exact=True`` no longer agrees
+    For larger values, `comb` with ``exact=True`` no longer agrees
     with `binom`.
 
     >>> x, y = 43, 23
     >>> (binom(x, y), comb(x, y), comb(x, y, exact=True))
     (960566918219.9999, 960566918219.9999, 960566918220)
 
-    Note that if `comb` is passed non integer arguments when ``exact=True``,
-    these will be truncated to integers, leading to inaccurate results.
+    Note that if ``exact=True``, non-integer arguments to  `comb` will be
+    truncated to integers, leading to inaccurate results.
 
     >>> x, y = 3.9, 2.8
     >>> (binom(x, y), comb(x, y), comb(x, y, exact=True))
     (4.2071983565457955, 4.2071983565457955, 3)
 
-    `binom` returns ``nan`` when ``x`` is a negative integer. `comb`
-    returns 0 whenever one of ``x`` or ``y`` is negative.
+    `binom` returns ``nan`` when ``x`` is a negative integer, but is generally
+    defined for negative arguments. `comb` returns 0 whenever one of ``x`` or 
+    ``y`` is negative.
 
     >>> x, y = -3, 2
     >>> (binom(x, y), comb(x, y), comb(x, y, exact=True))

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -769,7 +769,7 @@ add_newdoc("binom",
     >>> (binom(x, y), comb(x, y), comb(x, y, exact=True))
     (4.2071983565457955, 4.2071983565457955, 3)
 
-    `binom` returns ``nan`` when ``x`` is a negative integer, but is generally
+    `binom` returns ``nan`` when ``x`` is a negative integer, but is otherwise
     defined for negative arguments. `comb` returns 0 whenever one of ``x`` or 
     ``y`` is negative.
 

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2184,7 +2184,8 @@ def comb(N, k, exact=False, repetition=False):
 
     See Also
     --------
-    binom : Binomial coefficient considered as a function of two real variables.
+    binom : Binomial coefficient considered as a function of two real
+            variables.
 
     Notes
     -----

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2184,7 +2184,7 @@ def comb(N, k, exact=False, repetition=False):
 
     See Also
     --------
-    binom : Binomial coefficient ufunc
+    binom : Binomial coefficient considered as a function of two real variables.
 
     Notes
     -----


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes gh-15247
#### What does this implement/fix?
<!--Please explain your changes.-->
This PR fleshes out the docstring for `scipy.special.binom`. The current [docstring](https://github.com/scipy/scipy/blob/00758f96d8ff937b4447d646ae909ef31302aa59/scipy/special/_add_newdocs.py#L699-L709) is minimal and does not inform the user about how `binom` differs from `scipy.special.comb`. 

The updated docstring:
1. Specifies that `binom` is for computing the binomial coefficient considered as a function of two real values.
2. Gives the formula that generalizes the binomial coefficient to real values. 
3. Has a note explaining why `binom` differs from the usual convention for defining `\binom{n}{k}` for negative integer `n` and integer `k` when `\binom{n}{k}` is considered as a function of two integer values. This discrepancy was noted in gh-15213.
4. Has a number of examples illustrating how `binom` differs from `comb`.
<!--Any additional information you think is important.-->
I'd appreciate input on the updated docstring. Particularly on whether the **Notes** section is clear, whether any important information is missing, or whether the examples could be improved.