### PR TITLE
[MRG] ENH: bypass `LinearOperator` in `lobpcg` for small-size cases

### DIFF
--- a/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
@@ -343,10 +343,6 @@ def lobpcg(
                 aux += "%d constraint\n\n" % sizeY
         print(aux)
 
-    A = _makeOperator(A, (n, n))
-    B = _makeOperator(B, (n, n))
-    M = _makeOperator(M, (n, n))
-
     if (n - sizeY) < (5 * sizeX):
         warnings.warn(
             f"The problem size {n} minus the constraints size {sizeY} "
@@ -368,8 +364,15 @@ def lobpcg(
         else:
             eigvals = (0, sizeX - 1)
 
-        A_dense = A(np.eye(n, dtype=A.dtype))
-        B_dense = None if B is None else B(np.eye(n, dtype=B.dtype))
+        if isinstance(A, LinearOperator):
+            A_dense = A(np.eye(n, dtype=A.dtype))
+        else:
+            A_dense =np.asarray_chkfinite(A)
+
+        if isinstance(A, LinearOperator):
+            B_dense = None if B is None else B(np.eye(n, dtype=B.dtype))
+        else:
+            A_dense =np.asarray_chkfinite(A)
 
         vals, vecs = eigh(A_dense,
                           B_dense,
@@ -384,6 +387,10 @@ def lobpcg(
 
     if (residualTolerance is None) or (residualTolerance <= 0.0):
         residualTolerance = np.sqrt(1e-15) * n
+
+    A = _makeOperator(A, (n, n))
+    B = _makeOperator(B, (n, n))
+    M = _makeOperator(M, (n, n))
 
     # Apply constraints to X.
     if blockVectorY is not None:

--- a/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
@@ -21,7 +21,7 @@ import warnings
 import numpy as np
 from scipy.linalg import (inv, eigh, cho_factor, cho_solve,
                           cholesky, LinAlgError)
-from scipy.sparse.linalg import aslinearoperator
+from scipy.sparse.linalg import LinearOperator, aslinearoperator
 from numpy import block as bmat
 
 __all__ = ["lobpcg"]

--- a/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
@@ -367,12 +367,12 @@ def lobpcg(
         if isinstance(A, LinearOperator):
             A_dense = A(np.eye(n, dtype=A.dtype))
         else:
-            A_dense =np.asarray_chkfinite(A)
+            A_dense = np.asarray_chkfinite(A)
 
         if isinstance(A, LinearOperator):
             B_dense = None if B is None else B(np.eye(n, dtype=B.dtype))
         else:
-            A_dense =np.asarray_chkfinite(A)
+            A_dense = np.asarray_chkfinite(A)
 
         vals, vecs = eigh(A_dense,
                           B_dense,

--- a/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
@@ -16,6 +16,8 @@ References
 .. [3] A. V. Knyazev's C and MATLAB implementations:
        https://github.com/lobpcg/blopex
 """
+# Author: Andrew Knyazev <Andrew.Knyazev@ucdenver.edu>
+#         Robert Cimrman.
 
 import warnings
 import numpy as np

--- a/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
@@ -368,7 +368,7 @@ def lobpcg(
         if isinstance(A, LinearOperator):
             A = A(np.eye(n, dtype=A.dtype))
         elif isspmatrix(A):
-            A = np.toarray(A)
+            A = A.toarray()
         else:
             A = np.asarray(A)
 
@@ -376,7 +376,7 @@ def lobpcg(
             if isinstance(B, LinearOperator):
                 B = B(np.eye(n, dtype=B.dtype))
             elif isspmatrix(B):
-                B = np.toarray(B)
+                B = B.toarray()
             else:
                 B = np.asarray(B)
 

--- a/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
@@ -22,6 +22,7 @@ import numpy as np
 from scipy.linalg import (inv, eigh, cho_factor, cho_solve,
                           cholesky, LinAlgError)
 from scipy.sparse.linalg import LinearOperator, aslinearoperator
+from scipy.sparse import isspmatrix
 from numpy import block as bmat
 
 __all__ = ["lobpcg"]
@@ -366,12 +367,16 @@ def lobpcg(
 
         if isinstance(A, LinearOperator):
             A = A(np.eye(n, dtype=A.dtype))
+        elif isspmatrix(A):
+            A = np.toarray(A)
         else:
             A = np.asarray(A)
 
         if B is not None:
             if isinstance(B, LinearOperator):
                 B = B(np.eye(n, dtype=B.dtype))
+            elif isspmatrix(B):
+                B = np.toarray(B)
             else:
                 B = np.asarray(B)
 

--- a/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
@@ -17,7 +17,7 @@ References
        https://github.com/lobpcg/blopex
 """
 # Author: Andrew Knyazev <Andrew.Knyazev@ucdenver.edu>
-#         Robert Cimrman <https://github.com/rc>
+#         Robert Cimrman <cimrman3@ntc.zcu.cz>
 
 import warnings
 import numpy as np
@@ -214,7 +214,7 @@ def lobpcg(
     The convergence speed depends basically on two factors:
 
     1. Relative separation of the seeking eigenvalues from the rest
-       of the eigenvalues. One can vary ``m`` to improve the absolute
+       of the eigenvalues. One can vary ``k`` to improve the absolute
        separation and use proper preconditioning to shrink the spectral spread.
        For example, a rod vibration test problem (under tests
        directory) is ill-conditioned for large ``n``, so convergence will be

--- a/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
@@ -365,17 +365,18 @@ def lobpcg(
             eigvals = (0, sizeX - 1)
 
         if isinstance(A, LinearOperator):
-            A_dense = A(np.eye(n, dtype=A.dtype))
+            A = A(np.eye(n, dtype=A.dtype))
         else:
-            A_dense = np.asarray_chkfinite(A)
+            A = np.asarray_chkfinite(A)
 
-        if isinstance(A, LinearOperator):
-            B_dense = None if B is None else B(np.eye(n, dtype=B.dtype))
-        else:
-            A_dense = np.asarray_chkfinite(A)
+        if B is not None:
+            if isinstance(B, LinearOperator):
+                B = B(np.eye(n, dtype=B.dtype))
+            else:
+                B = np.asarray_chkfinite(B)
 
-        vals, vecs = eigh(A_dense,
-                          B_dense,
+        vals, vecs = eigh(A,
+                          B,
                           eigvals=eigvals,
                           check_finite=False)
         if largest:

--- a/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
@@ -17,7 +17,7 @@ References
        https://github.com/lobpcg/blopex
 """
 # Author: Andrew Knyazev <Andrew.Knyazev@ucdenver.edu>
-#         Robert Cimrman.
+#         Robert Cimrman <https://github.com/rc>
 
 import warnings
 import numpy as np

--- a/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
@@ -367,13 +367,13 @@ def lobpcg(
         if isinstance(A, LinearOperator):
             A = A(np.eye(n, dtype=A.dtype))
         else:
-            A = np.asarray_chkfinite(A)
+            A = np.asarray(A)
 
         if B is not None:
             if isinstance(B, LinearOperator):
                 B = B(np.eye(n, dtype=B.dtype))
             else:
-                B = np.asarray_chkfinite(B)
+                B = np.asarray(B)
 
         vals, vecs = eigh(A,
                           B,

--- a/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
@@ -193,33 +193,36 @@ def lobpcg(
     the return tuple has the following format
     ``(lambda, V, lambda history, residual norms history)``.
 
-    In the following ``n`` denotes the matrix size and ``m`` the number
+    In the following ``n`` denotes the matrix size and ``k`` the number
     of required eigenvalues (smallest or largest).
 
-    The LOBPCG code internally solves eigenproblems of the size ``3m`` on every
-    iteration by calling the "standard" dense eigensolver, so if ``m`` is not
+    The LOBPCG code internally solves eigenproblems of the size ``3k`` on every
+    iteration by calling the "standard" dense eigensolver, so if ``k`` is not
     small enough compared to ``n``, it does not make sense to call the LOBPCG
     code, but rather one should use the "standard" eigensolver, e.g. numpy or
     scipy function in this case.
-    If one calls the LOBPCG algorithm for ``5m > n``, it will most likely break
+    If one calls the LOBPCG algorithm for ``5k > n``, it will most likely break
     internally, so the code tries to call the standard function instead.
 
     It is not that ``n`` should be large for the LOBPCG to work, but rather the
-    ratio ``n / m`` should be large. It you call LOBPCG with ``m=1``
+    ratio ``k / m`` should be large. It you call LOBPCG with ``k=1``
     and ``n=10``, it works though ``n`` is small. The method is intended
-    for extremely large ``n / m``.
+    for extremely large ``n / k``.
 
     The convergence speed depends basically on two factors:
 
-    1. How well relatively separated the seeking eigenvalues are from the rest
-       of the eigenvalues. One can try to vary ``m`` to make this better.
-
-    2. How well conditioned the problem is. This can be changed by using proper
-       preconditioning. For example, a rod vibration test problem (under tests
+    1. Relative separation of the seeking eigenvalues from the rest
+       of the eigenvalues. One can vary ``m`` to improve the absolute
+       separation and use proper preconditioning to shrink the spectral spread.
+       For example, a rod vibration test problem (under tests
        directory) is ill-conditioned for large ``n``, so convergence will be
        slow, unless efficient preconditioning is used. For this specific
        problem, a good simple preconditioner function would be a linear solve
-       for `A`, which is easy to code since A is tridiagonal.
+       for ``A``, which is easy to code since ``A`` is tridiagonal.
+
+    2. Quality of the initial approximations ``X`` to the seeking eigenvectors.
+       Randomly distributed around the origin vectors work well if no better
+       choice is known.
 
     References
     ----------

--- a/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
@@ -166,7 +166,7 @@ def test_diagonal(n, m, m_excluded):
 
     # Require that the returned eigenvectors be in the orthogonal complement
     # of the first few standard basis vectors.
-    if m_size > 0:
+    if m_excluded > 0:
         Y = np.eye(n, m_excluded)
     else:
         Y = None

--- a/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
@@ -1,7 +1,7 @@
 """ Test functions for the sparse.linalg._eigen.lobpcg module
 """
 # Author: Andrew Knyazev <Andrew.Knyazev@ucdenver.edu>
-#         Robert Cimrman <https://github.com/rc>
+#         Robert Cimrman <cimrman3@ntc.zcu.cz>
 #         Nils Wagner
 
 import itertools

--- a/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
@@ -160,7 +160,7 @@ def test_diagonal():
 
     # Pick random initial vectors.
     rnd = np.random.RandomState(0)
-    X = rng.normal(size=(n, m))
+    X = rnd.normal(size=(n, m))
 
     # Require that the returned eigenvectors be in the orthogonal complement
     # of the first few standard basis vectors.

--- a/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
@@ -129,16 +129,20 @@ def test_diagonal():
     vals = np.arange(1, n+1, dtype=float)
     A_s = diags([vals], [0], (n, n))
     A_a = A_s.toarray()
+
     def A_f(x):
         return A_s @ x
+
     A_lo = LinearOperator(matvec=A_f,
                           matmat=A_f,
                           shape=(n, n), dtype=float)
 
     B_a = eye(n)
     B_s = csr_matrix(B_a)
+
     def B_f(x):
         return B_a @ x
+
     B_lo = LinearOperator(matvec=B_f,
                           matmat=B_f,
                           shape=(n, n), dtype=float)
@@ -146,14 +150,17 @@ def test_diagonal():
     # Let the preconditioner M be the inverse of A.
     M_s = diags([1./vals], [0], (n, n))
     M_a = M_s.toarray()
+
     def M_f(x):
         return M_s @ x
+
     M_lo = LinearOperator(matvec=M_f,
                           matmat=M_f,
                           shape=(n, n), dtype=float)
 
     # Pick random initial vectors.
-    X = rnd.random((n, m))
+    rnd = np.random.RandomState(0)
+    X = rng.normal(size=(n, m))
 
     # Require that the returned eigenvectors be in the orthogonal complement
     # of the first few standard basis vectors.
@@ -166,8 +173,9 @@ def test_diagonal():
                 eigvals, vecs = lobpcg(A, X, B, M=M, Y=Y,
                                        maxiter=40, largest=False)
 
-    assert_allclose(eigvals, np.arange(1+m_excluded, 1+m_excluded+m))
-    _check_eigen(A, eigvals, vecs, rtol=1e-3, atol=1e-3)
+                assert_allclose(eigvals, np.arange(1+m_excluded,
+                                                   1+m_excluded+m))
+                _check_eigen(A, eigvals, vecs, rtol=1e-3, atol=1e-3)
 
 
 def _check_eigen(M, w, V, rtol=1e-8, atol=1e-14):

--- a/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
@@ -114,12 +114,13 @@ def test_regression():
     w, _ = lobpcg(A, X)
     assert_allclose(w, [1])
 
+
 @pytest.mark.filterwarnings("ignore:The problem size")
 @pytest.mark.parametrize('n, m, m_excluded', [(100, 4, 3), (4, 2, 0)])
 def test_diagonal(n, m, m_excluded):
-    """Test ``m-m_excluded`` eigenvalues and eigenvectors of
+    """Test ``m - m_excluded`` eigenvalues and eigenvectors of
     diagonal matrices of the size ``n`` varying matrix formats:
-    dense array, spare matrix, ``LinearOperator`` for both
+    dense array, spare matrix, and ``LinearOperator`` for both
     matrixes in the generalized eigenvalue problem ``Av = cBv``
     and for the preconditioner.
     """

--- a/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
@@ -136,7 +136,7 @@ def test_diagonal():
                           shape=(n, n), dtype=float)
 
     B_a = eye(n)
-    B_s = csr_matrix(B)
+    B_s = csr_matrix(B_a)
     def B_f(x):
         return B_a @ x
     B_lo = LinearOperator(matvec=B_f,

--- a/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
@@ -114,13 +114,16 @@ def test_regression():
     w, _ = lobpcg(A, X)
     assert_allclose(w, [1])
 
-
-def test_diagonal():
-    """Check for diagonal matrices.
+@pytest.mark.filterwarnings("ignore:The problem size")
+@pytest.mark.parametrize('n, m, m_excluded', [(100, 4, 3), (4, 2, 0)])
+def test_diagonal(n, m, m_excluded):
+    """Test ``m-m_excluded`` eigenvalues and eigenvectors of
+    diagonal matrices of the size ``n`` varying matrix formats:
+    dense array, spare matrix, ``LinearOperator`` for both
+    matrixes in the generalized eigenvalue problem ``Av = cBv``
+    and for the preconditioner.
     """
     rnd = np.random.RandomState(0)
-    n = 100
-    m = 4
 
     # Define the generalized eigenvalue problem Av = cBv
     # where (c, v) is a generalized eigenpair,
@@ -159,13 +162,14 @@ def test_diagonal():
                           shape=(n, n), dtype=float)
 
     # Pick random initial vectors.
-    rnd = np.random.RandomState(0)
     X = rnd.normal(size=(n, m))
 
     # Require that the returned eigenvectors be in the orthogonal complement
     # of the first few standard basis vectors.
-    m_excluded = 3
-    Y = np.eye(n, m_excluded)
+    if m_size > 0:
+        Y = np.eye(n, m_excluded)
+    else:
+        Y = None
 
     for A in [A_a, A_s, A_lo]:
         for B in [B_a, B_s, B_lo]:

--- a/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
@@ -1,6 +1,8 @@
 """ Test functions for the sparse.linalg._eigen.lobpcg module
 """
 # Author: Andrew Knyazev <Andrew.Knyazev@ucdenver.edu>
+#         Robert Cimrman
+#         Nils Wagner
 
 import itertools
 import platform

--- a/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
@@ -1,5 +1,7 @@
 """ Test functions for the sparse.linalg._eigen.lobpcg module
 """
+# Author: Andrew Knyazev <Andrew.Knyazev@ucdenver.edu>
+
 import itertools
 import platform
 import sys

--- a/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
@@ -1,7 +1,7 @@
 """ Test functions for the sparse.linalg._eigen.lobpcg module
 """
 # Author: Andrew Knyazev <Andrew.Knyazev@ucdenver.edu>
-#         Robert Cimrman
+#         Robert Cimrman <https://github.com/rc>
 #         Nils Wagner
 
 import itertools


### PR DESCRIPTION
bypass `LinearOperator` if `(n - sizeY) < (5 * sizeX)` in `lobpcg`

#### Reference issue
Closes #10983

#### What does this implement/fix?
Even if the original input matrices were given as arrays, each of them is first turned into a `LinearOperator`. When `lobpcg` is requested to compute > 20% of eigenvalues, it simply switches to `eigh`, but before that needs to recover the arrays back, which is a dramatic waste.

Unless original input matrices were given as `LinearOperator`, avoid the conversion when computing > 20% of eigenvalues and call `eigh` directly on the original arrays.

#### Additional information
No additional unit tests required. 