### PR TITLE
TST: silence RuntimeWarning from `np.det` in `signal.place_poles` test

### DIFF
--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -44,8 +44,8 @@ class TestPlacePoles:
         """
         fsf = place_poles(A, B, P, **kwargs)
         expected, _ = np.linalg.eig(A - np.dot(B, fsf.gain_matrix))
-        _assert_poles_close(expected,fsf.requested_poles)
-        _assert_poles_close(expected,fsf.computed_poles)
+        _assert_poles_close(expected, fsf.requested_poles)
+        _assert_poles_close(expected, fsf.computed_poles)
         _assert_poles_close(P,fsf.requested_poles)
         return fsf
 
@@ -75,18 +75,28 @@ class TestPlacePoles:
         # Test complex pole placement on a linearized car model, taken from L.
         # Jaulin, Automatique pour la robotique, Cours et Exercices, iSTE
         # editions p 184/185
-        A = np.array([0,7,0,0,0,0,0,7/3.,0,0,0,0,0,0,0,0]).reshape(4,4)
-        B = np.array([0,0,0,0,1,0,0,1]).reshape(4,2)
+        A = np.array([[0, 7, 0, 0],
+                      [0, 0, 0, 7/3.],
+                      [0, 0, 0, 0],
+                      [0, 0, 0, 0]])
+        B = np.array([[0, 0],
+                      [0, 0],
+                      [1, 0],
+                      [0, 1]])
         # Test complex poles on YT
         P = np.array([-3, -1, -2-1j, -2+1j])
-        self._check(A, B, P)
+        # on macOS arm64 this can lead to a RuntimeWarning invalid
+        # value in divide, so suppress it for now
+        with np.errstate(divide='ignore', invalid='ignore'):
+            self._check(A, B, P)
 
         # Try to reach the specific case in _YT_complex where two singular
         # values are almost equal. This is to improve code coverage but I
         # have no way to be sure this code is really reached
 
         P = [0-1e-6j,0+1e-6j,-10,10]
-        self._check(A, B, P, maxiter=1000)
+        with np.errstate(divide='ignore', invalid='ignore'):
+            self._check(A, B, P, maxiter=1000)
 
         # Try to reach the specific case in _YT_complex where the rank two
         # update yields two null vectors. This test was found via Monte Carlo.
@@ -116,7 +126,8 @@ class TestPlacePoles:
         big_B[:6,:5] = B
 
         P = [-10,-20,-30,40,50,60,70,-20-5j,-20+5j,5+3j,5-3j]
-        self._check(big_A, big_B, P)
+        with np.errstate(divide='ignore', invalid='ignore'):
+            self._check(big_A, big_B, P)
 
         #check with only complex poles and only real poles
         P = [-10,-20,-30,-40,-50,-60,-70,-80,-90,-100]
@@ -131,12 +142,14 @@ class TestPlacePoles:
                       0,0,0,5,0,0,0,0,9]).reshape(5,5)
         B = np.array([0,0,0,0,1,0,0,1,2,3]).reshape(5,2)
         P = np.array([-2, -3+1j, -3-1j, -1+1j, -1-1j])
-        place_poles(A, B, P)
+        with np.errstate(divide='ignore', invalid='ignore'):
+            place_poles(A, B, P)
 
         # same test with an odd number of real poles > 1
         # this is another specific case of YT
         P = np.array([-2, -3, -4, -1+1j, -1-1j])
-        self._check(A, B, P)
+        with np.errstate(divide='ignore', invalid='ignore'):
+            self._check(A, B, P)
 
     def test_tricky_B(self):
         # check we handle as we should the 1 column B matrices and


### PR DESCRIPTION
This test was raising because of the emitted "divide by zero" warnings
on macOS 12.1 on arm64 hardware. Full traceback:

<details>

```
_____________________________________________________________________ TestPlacePoles.test_complex ______________________________________________________________________
scipy/signal/tests/test_ltisys.py:82: in test_complex
    self._check(A, B, P)
        A          = array([[0.        , 7.        , 0.        , 0.        ],
       [0.        , 0.        , 0.        , 2.33333333],
       [0.        , 0.        , 0.        , 0.        ],
       [0.        , 0.        , 0.        , 0.        ]])
        B          = array([[0, 0],
       [0, 0],
       [1, 0],
       [0, 1]])
        P          = array([-3.+0.j, -1.+0.j, -2.-1.j, -2.+1.j])
        self       = <scipy.signal.tests.test_ltisys.TestPlacePoles object at 0x134263b50>
scipy/signal/tests/test_ltisys.py:45: in _check
    fsf = place_poles(A, B, P, **kwargs)
        A          = array([[0.        , 7.        , 0.        , 0.        ],
       [0.        , 0.        , 0.        , 2.33333333],
       [0.        , 0.        , 0.        , 0.        ],
       [0.        , 0.        , 0.        , 0.        ]])
        B          = array([[0, 0],
       [0, 0],
       [1, 0],
       [0, 1]])
        P          = array([-3.+0.j, -1.+0.j, -2.-1.j, -2.+1.j])
        kwargs     = {}
        self       = <scipy.signal.tests.test_ltisys.TestPlacePoles object at 0x134263b50>
scipy/signal/_ltisys.py:3348: in place_poles
    stop, cur_rtol, nb_iter = update_loop(ker_pole, transfer_matrix,
        A          = array([[0.        , 7.        , 0.        , 0.        ],
       [0.        , 0.        , 0.        , 2.33333333],
       [0.        , 0.        , 0.        , 0.        ],
       [0.        , 0.        , 0.        , 0.        ]])
        B          = array([[0, 0],
       [0, 0],
       [1, 0],
       [0, 1]])
        Q          = array([[-0.27216553-1.36082763e-01j,  0.16000261+2.13336816e-01j,
         0.        +0.00000000e+00j,  0.79653151+4.4...     +0.00000000e+00j, -0.96001567+2.77555756e-17j,
         0.        +0.00000000e+00j,  0.25632374-1.12552418e-01j]])
        _          = array([[7.34846923+0.j        , 1.90515869+0.95257934j],
       [0.        +0.j        , 2.43051587+0.j        ],
       [0.        +0.j        , 0.        +0.j        ],
       [0.        +0.j        , 0.        +0.j        ]])
        cur_rtol   = 0
        j          = 3
        ker_pole   = [array([[ 0.        +0.j,  0.81997603+0.j],
       [ 0.        +0.j, -0.3514183 +0.j],
       [ 1.        +0.j,  0.   ...       [ 1.        +0.j        ,  0.        +0.j        ],
       [ 0.        +0.j        ,  0.25632374-0.11255242j]])]
        ker_pole_j = array([[ 0.        +0.j        ,  0.79653151+0.44925663j],
       [ 0.        +0.j        , -0.29175995-0.01456882j],
       [ 1.        +0.j        ,  0.        +0.j        ],
       [ 0.        +0.j        ,  0.25632374-0.11255242j]])
        maxiter    = 30
        method     = 'YT'
        nb_iter    = 0
        pole_space_j = array([[-2.        -1.j,  0.        +0.j],
       [-7.        +0.j, -2.        -1.j],
       [ 0.        +0.j,  0.        +0.j],
       [ 0.        +0.j, -2.33333333+0.j]])
        poles      = array([-3.+0.j, -1.+0.j, -2.-1.j, -2.+1.j])
        rankB      = 2
        rtol       = 0.001
        skip_conjugate = False
        transfer_matrix = array([[ 0.57981061+0.j,  0.69871782+0.j,  0.56323283+0.j,
         0.31767241+0.j],
       [-0.24849026+0.j, -0.09981...78+0.j,
         0.        +0.j],
       [ 0.31948748+0.j,  0.04277864+0.j,  0.18124825+0.j,
        -0.07958658+0.j]])
        transfer_matrix_j = array([[ 0.56323283,  0.31767241],
       [-0.20630544, -0.01030171],
       [ 0.70710678,  0.        ],
       [ 0.18124825, -0.07958658]])
        u          = array([[ 0.,  0., -1.,  0.],
       [-0.,  0.,  0., -1.],
       [-1., -0.,  0.,  0.],
       [-0., -1.,  0.,  0.]])
        u0         = array([[ 0.,  0.],
       [-0.,  0.],
       [-1., -0.],
       [-0., -1.]])
        u1         = array([[-1.,  0.],
       [ 0., -1.],
       [ 0.,  0.],
       [ 0.,  0.]])
        update_loop = <function _YT_loop at 0x125931280>
        z          = array([[-1.,  0.],
       [ 0., -1.]])
scipy/signal/_ltisys.py:2989: in _YT_loop
    det_transfer_matrixb = np.abs(np.linalg.det(transfer_matrix))
        B          = array([[0, 0],
       [0, 0],
       [1, 0],
       [0, 1]])
        hnb        = 1
        i          = 1
        ker_pole   = [array([[ 0.        +0.j,  0.81997603+0.j],
       [ 0.        +0.j, -0.3514183 +0.j],
       [ 1.        +0.j,  0.   ...       [ 1.        +0.j        ,  0.        +0.j        ],
       [ 0.        +0.j        ,  0.25632374-0.11255242j]])]
        maxiter    = 30
        nb_real    = 2
        nb_try     = 0
        poles      = array([-3.+0.j, -1.+0.j, -2.-1.j, -2.+1.j])
        r_comp     = array([3])
        r_j        = array([], dtype=int64)
        r_p        = array([1])
        rtol       = 0.001
        stop       = False
        transfer_matrix = array([[ 0.57981061+0.j,  0.69871782+0.j,  0.56323283+0.j,
         0.31767241+0.j],
       [-0.24849026+0.j, -0.09981...78+0.j,
         0.        +0.j],
       [ 0.31948748+0.j,  0.04277864+0.j,  0.18124825+0.j,
        -0.07958658+0.j]])
        update_order = array([[1, 0],
       [2, 3],
       [0, 1],
       [2, 3],
       [2, 3],
       [2, 3],
       [0, 1],
       [2, 3]])
<__array_function__ internals>:5: in det
    ???
        args       = (array([[ 0.57981061+0.j,  0.69871782+0.j,  0.56323283+0.j,
         0.31767241+0.j],
       [-0.24849026+0.j, -0.0998...+0.j,
         0.        +0.j],
       [ 0.31948748+0.j,  0.04277864+0.j,  0.18124825+0.j,
        -0.07958658+0.j]]),)
        kwargs     = {}
        relevant_args = (array([[ 0.57981061+0.j,  0.69871782+0.j,  0.56323283+0.j,
         0.31767241+0.j],
       [-0.24849026+0.j, -0.0998...+0.j,
         0.        +0.j],
       [ 0.31948748+0.j,  0.04277864+0.j,  0.18124825+0.j,
        -0.07958658+0.j]]),)
/Users/rgommers/mambaforge/envs/scipy-meson/lib/python3.9/site-packages/numpy/linalg/linalg.py:2158: in det
    r = _umath_linalg.det(a, signature=signature)
E   RuntimeWarning: divide by zero encountered in det
        a          = array([[ 0.57981061+0.j,  0.69871782+0.j,  0.56323283+0.j,
         0.31767241+0.j],
       [-0.24849026+0.j, -0.09981...78+0.j,
         0.        +0.j],
       [ 0.31948748+0.j,  0.04277864+0.j,  0.18124825+0.j,
        -0.07958658+0.j]])
        result_t   = <class 'numpy.complex128'>
        signature  = 'D->D'
        t          = <class 'numpy.complex128'>
```

</details>