### PR TITLE
CI: simplify 32-bit Linux testing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -182,7 +182,7 @@ stages:
             cd ../scipy && \
             CC=gcc-5 CXX=g++-5 F77=gfortran-8 F90=gfortran-8 pip3 install . && \
             python3.8 tools/openblas_support.py --check_version $(openblas_version) && \
-            CC=gcc-5 CXX=g++-5 F77=gfortran-8 F90=gfortran-8 python3.8 runtests.py --mode=full -- -n auto -s --junitxml=junit/test-results.xml --cov-config=.coveragerc --cov-report=xml --cov-report=html"
+            python3.8 runtests.py -n --mode=full -- -n auto -s --junitxml=junit/test-results.xml --cov-config=.coveragerc --cov-report=xml --cov-report=html"
       displayName: 'Run 32-bit Ubuntu Docker Build / Tests'
     - task: PublishTestResults@2
       condition: succeededOrFailed()


### PR DESCRIPTION
* don't reinstall SciPy in the Azure 32-bit Linux
job after it has just been installed; use the `-n`
`runtests.py` flag; this only saves us about 8 seconds
per run, but still better to avoid wasting and the extra
code complexity in the CI

* there are still some more simplifications/warnings
to fix for this job, but this seems like an easy gain