### PR TITLE
BLD Respect the --skip-build flag in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -581,6 +581,8 @@ def setup_package():
     if "--force" in sys.argv:
         run_build = True
         sys.argv.remove('--force')
+    elif "--skip-build" in sys.argv:
+        run_build = False
     else:
         # Raise errors for unsupported commands, improve help output, etc.
         run_build = check_setuppy_command()


### PR DESCRIPTION
`setup.py install` is supposed to accept a `--skip-build` flag which skips building the
package and just installs the already built package.

Pyodide needs ``--skip-build`` in order to cross compile to wasm: Pyodide first runs
`setup.py build` with wrappers around the compiler and related tools to record what
the normal build process is, then replays the compiler commands with fixes to cross
compile to wasm. We then need to install the package into our native cross compiler
Python as if it were a native copy of scipy so we can use it as a build-time dependency
for other packages.