### PR TITLE
DOC: Misc numpydoc formatting.

### DIFF
--- a/scipy/_lib/_uarray/_backend.py
+++ b/scipy/_lib/_uarray/_backend.py
@@ -191,7 +191,7 @@ def generate_multimethod(
         return an (args, kwargs) pair with the dispatchables replaced inside the args/kwargs.
     domain : str
         A string value indicating the domain of this multimethod.
-    default: Optional[Callable], optional
+    default : Optional[Callable], optional
         The default implementation of this multimethod, where ``None`` (the default) specifies
         there is no default implementation.
 
@@ -554,16 +554,16 @@ def determine_backend(value, dispatch_type, *, domain, only=True, coerce=False):
     dispatch_type
         The dispatch type associated with ``value``, aka
         ":ref:`marking <MarkingGlossary>`".
-    domain: string
+    domain : string
         The domain to query for backends and set.
-    coerce: bool
+    coerce : bool
         Whether or not to allow coercion to the backend's types. Implies ``only``.
-    only: bool
+    only : bool
         Whether or not this should be the last backend to try.
 
     See Also
     --------
-    set_backend: For when you know which backend to set
+    set_backend : For when you know which backend to set
 
     Notes
     -----

--- a/scipy/constants/_constants.py
+++ b/scipy/constants/_constants.py
@@ -223,15 +223,13 @@ def convert_temperature(val, old_scale, new_scale):
     val : array_like
         Value(s) of the temperature(s) to be converted expressed in the
         original scale.
-
-    old_scale: str
+    old_scale : str
         Specifies as a string the original scale from which the temperature
         value(s) will be converted. Supported scales are Celsius ('Celsius',
         'celsius', 'C' or 'c'), Kelvin ('Kelvin', 'kelvin', 'K', 'k'),
         Fahrenheit ('Fahrenheit', 'fahrenheit', 'F' or 'f'), and Rankine
         ('Rankine', 'rankine', 'R', 'r').
-
-    new_scale: str
+    new_scale : str
         Specifies as a string the new scale to which the temperature
         value(s) will be converted. Supported scales are Celsius ('Celsius',
         'celsius', 'C' or 'c'), Kelvin ('Kelvin', 'kelvin', 'K', 'k'),

--- a/scipy/fft/_fftlog.py
+++ b/scipy/fft/_fftlog.py
@@ -271,7 +271,7 @@ def fhtoffset(dln, mu, initial=0.0, bias=0.0):
         Optimal offset of the uniform logarithmic spacing of the transform that
         fulfils a low-ringing condition.
 
-    See also
+    See Also
     --------
     fht : Definition of the fast Hankel transform.
 

--- a/scipy/fft/_pocketfft/realtransforms.py
+++ b/scipy/fft/_pocketfft/realtransforms.py
@@ -11,9 +11,9 @@ def _r2r(forward, transform, x, type=2, n=None, axis=-1, norm=None,
 
     Parameters
     ----------
-    forward: bool
+    forward : bool
         Transform direction (determines type and normalisation)
-    transform: {pypocketfft.dct, pypocketfft.dst}
+    transform : {pypocketfft.dct, pypocketfft.dst}
         The transform to perform
     """
     tmp = _asfarray(x)
@@ -63,9 +63,9 @@ def _r2rn(forward, transform, x, type=2, s=None, axes=None, norm=None,
 
     Parameters
     ----------
-    forward: bool
+    forward : bool
         Transform direction (determines type and normalisation)
-    transform: {pypocketfft.dct, pypocketfft.dst}
+    transform : {pypocketfft.dct, pypocketfft.dst}
         The transform to perform
     """
     tmp = _asfarray(x)

--- a/scipy/fftpack/_basic.py
+++ b/scipy/fftpack/_basic.py
@@ -403,7 +403,7 @@ def ifft2(x, shape=None, axes=(-2,-1), overwrite_x=False):
 
     See `ifft` for more information.
 
-    See also
+    See Also
     --------
     fft2, ifft
 

--- a/scipy/integrate/_bvp.py
+++ b/scipy/integrate/_bvp.py
@@ -218,12 +218,12 @@ def construct_global_jac(n, m, k, i_jac, j_jac, h, df_dy, df_dy_middle, df_dp,
         mesh nodes.
     df_dp : ndarray with shape (n, k, m) or None
         Jacobian of f with respect to p computed at the mesh nodes.
-    df_dp_middle: ndarray with shape (n, k, m - 1) or None
+    df_dp_middle : ndarray with shape (n, k, m - 1) or None
         Jacobian of f with respect to p computed at the middle between the
         mesh nodes.
     dbc_dya, dbc_dyb : ndarray, shape (n, n)
         Jacobian of bc with respect to ya and yb.
-    dbc_dp: ndarray with shape (n, k) or None
+    dbc_dp : ndarray with shape (n, k) or None
         Jacobian of bc with respect to p.
 
     Returns

--- a/scipy/integrate/_ivp/ivp.py
+++ b/scipy/integrate/_ivp/ivp.py
@@ -275,7 +275,7 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
         So if, for example, `fun` has the signature ``fun(t, y, a, b, c)``,
         then `jac` (if given) and any event functions must have the same
         signature, and `args` must be a tuple of length 3.
-    options
+    **options
         Options passed to a chosen solver. All options available for already
         implemented solvers are listed below.
     first_step : float or None, optional

--- a/scipy/integrate/_ode.py
+++ b/scipy/integrate/_ode.py
@@ -379,7 +379,7 @@ class ode:
         ----------
         name : str
             Name of the integrator.
-        integrator_params
+        **integrator_params
             Additional parameters for the integrator.
         """
         integrator = find_integrator(name)
@@ -672,7 +672,7 @@ class complex_ode(ode):
         ----------
         name : str
             Name of the integrator
-        integrator_params
+        **integrator_params
             Additional parameters for the integrator.
         """
         if name == 'zvode':

--- a/scipy/integrate/_odepack_py.py
+++ b/scipy/integrate/_odepack_py.py
@@ -78,7 +78,7 @@ def odeint(func, y0, t, args=(), Dfun=None, col_deriv=0, full_output=0,
         True if to return a dictionary of optional outputs as the second output
     printmessg : bool, optional
         Whether to print the convergence message
-    tfirst: bool, optional
+    tfirst : bool, optional
         If True, the first two arguments of `func` (and `Dfun`, if given)
         must ``t, y`` instead of the default ``y, t``.
 

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -568,7 +568,7 @@ def dblquad(func, a, b, gfun, hfun, args=(), epsabs=1.49e-8, epsrel=1.49e-8):
     abserr : float
         An estimate of the error.
 
-    See also
+    See Also
     --------
     quad : single integral
     tplquad : triple integral

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -759,7 +759,7 @@ def romberg(function, a, b, args=(), tol=1.48e-8, rtol=1.48e-8, show=False,
 
     Returns
     -------
-    results  : float
+    results : float
         Result of the integration.
 
     Other Parameters

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -427,7 +427,7 @@ class BSpline:
         ----------
         x : array_like
             points to evaluate the spline at.
-        nu: int, optional
+        nu : int, optional
             derivative to evaluate (default is 0).
         extrapolate : bool or 'periodic', optional
             whether to extrapolate based on the first and last intervals

--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -314,7 +314,7 @@ def pchip_interpolate(xi, yi, x, der=0, axis=0):
     ----------
     xi : array_like
         A sorted list of x-coordinates, of length N.
-    yi :  array_like
+    yi : array_like
         A 1-D array of real values. `yi`'s length along the interpolation
         axis must be equal to the length of `xi`. If N-D array, use axis
         parameter to select correct axis.

--- a/scipy/interpolate/_fitpack_py.py
+++ b/scipy/interpolate/_fitpack_py.py
@@ -467,7 +467,7 @@ def sproot(tck, mest=10):
     Manipulating the tck-tuples directly is not recommended. In new code,
     prefer using the `BSpline` objects.
 
-    See also
+    See Also
     --------
     splprep, splrep, splint, spalde, splev
     bisplrep, bisplev

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -2644,7 +2644,7 @@ def interpn(points, values, xi, method="linear", bounds_error=True,
     >>> print(interpn(points, values, point))
     [12.63]
 
-    See also
+    See Also
     --------
     NearestNDInterpolator : Nearest neighbor interpolation on unstructured
                             data in N dimensions

--- a/scipy/interpolate/_ndgriddata.py
+++ b/scipy/interpolate/_ndgriddata.py
@@ -98,7 +98,7 @@ class NearestNDInterpolator(NDInterpolatorBase):
 
         Parameters
         ----------
-        x1, x2, ... xn: array-like of float
+        x1, x2, ... xn : array-like of float
             Points where to interpolate data at.
             x1, x2, ... xn can be array-like of float with broadcastable shape.
             or x1 can be array-like of float with shape ``(..., ndim)``


### PR DESCRIPTION
This updates a couple of files and docstrings to properly follow
numpydoc.

You'll find:

 - space around colon in parameters.
 - 'See Also' is supposed to be uppercase `A`.
 - var-args/kwargs can and are supposed to have `*`.