### PR TITLE
BUG: fix Hausdorff int overflow

### DIFF
--- a/scipy/spatial/_hausdorff.pyx
+++ b/scipy/spatial/_hausdorff.pyx
@@ -23,11 +23,11 @@ __all__ = ['directed_hausdorff']
 def directed_hausdorff(double[:,::1] ar1, double[:,::1] ar2, seed=0):
 
     cdef double cmax, cmin, d = 0
-    cdef int N1 = ar1.shape[0]
-    cdef int N2 = ar2.shape[0]
+    cdef Py_ssize_t N1 = ar1.shape[0]
+    cdef Py_ssize_t N2 = ar2.shape[0]
     cdef int data_dims = ar1.shape[1]
-    cdef int i, j, k
-    cdef unsigned int i_store = 0, j_store = 0, i_ret = 0, j_ret = 0
+    cdef Py_ssize_t i, j, k
+    cdef Py_ssize_t i_store = 0, j_store = 0, i_ret = 0, j_ret = 0
     cdef np.ndarray[np.int64_t, ndim=1, mode='c'] resort1, resort2
 
     # shuffling the points in each array generally increases the likelihood of

--- a/scipy/spatial/tests/test_hausdorff.py
+++ b/scipy/spatial/tests/test_hausdorff.py
@@ -147,3 +147,17 @@ class TestHausdorff:
         assert_allclose(actual[0], expected[0])
         # check indices
         assert actual[1:] == expected[1:]
+
+
+@pytest.mark.xslow
+def test_massive_arr_overflow():
+    # on 64-bit systems we should be able to
+    # handle arrays that exceed the indexing
+    # size of a 32-bit signed integer
+    size = int(3e9)
+    arr1 = np.zeros(shape=(size, 2))
+    arr2 = np.zeros(shape=(3, 2))
+    arr1[size - 1] = [5, 5]
+    actual = directed_hausdorff(u=arr1, v=arr2)
+    assert_allclose(actual[0], 7.0710678118654755)
+    assert_allclose(actual[1], size - 1)


### PR DESCRIPTION
* add a fix and regression test for operating
on arrays that have sizes exceeding the 32-bit
signed integer limit; it was also weird to have
variables with different types storing identical
values

* the test is marked `xslow` because it takes
more than seven minutes on a machine with 128 GB
memory (the failure before the fix is nearly instant,
however)

* the Cython indexing types are discussed by Warren
and Tim Peters here:
https://stackoverflow.com/questions/20987390/cython-why-when-is-it-preferable-to-use-py-ssize-t-for-indexing

* the parallel Rust implementation already uses the
language appropriate indexing `usize` type there:
https://github.com/tylerjereddy/rusty_hausdorff/blob/main/src/lib.rs#L128