### PR TITLE
REL: Bump `LICENSE.txt` to 2022

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2001-2002 Enthought, Inc.  2003-2019, SciPy Developers.
+Copyright (c) 2001-2002 Enthought, Inc. 2003-2022, SciPy Developers.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
closes #15282 

#### What does this implement/fix?
<!--Please explain your changes.-->
This commit bumps the license to 2022.

#### Additional information
<!--Any additional information you think is important.-->
I've bumped the license directly to 2022 rather than creating a two PRs for 2021 and 2022. I've noticed that there are some other files where this occurs (e.g. `stats_py.py`). I don't know whether these need to be updated individually each year or if they are covered by the overarching license.