### PR TITLE
TST: update `sparse.linalg` tests for failures due to tolerances

### DIFF
--- a/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
@@ -222,7 +222,7 @@ def test_fiedler_large_12():
 def test_failure_to_run_iterations():
     """Check that the code exists gracefully without breaking. Issue #10974.
     """
-    rnd = np.random.RandomState(0)
+    rnd = np.random.RandomState(4120349)
     X = rnd.standard_normal((100, 10))
     A = X @ X.T
     Q = rnd.standard_normal((X.shape[0], 4))

--- a/scipy/sparse/linalg/_eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/_eigen/tests/test_svds.py
@@ -365,8 +365,8 @@ class SVDSCommonTests:
         # not necessarily identical - results
         res1a = svds(A, k, solver=self.solver, random_state=random_state)
         res2a = svds(A, k, solver=self.solver, random_state=random_state)
-        _check_svds(A, k, *res1a, rtol=1e-6)
-        _check_svds(A, k, *res2a, rtol=1e-6)
+        _check_svds(A, k, *res1a, atol=2e-10, rtol=1e-6)
+        _check_svds(A, k, *res2a, atol=2e-10, rtol=1e-6)
 
         message = "Arrays are not equal"
         with pytest.raises(AssertionError, match=message):

--- a/scipy/sparse/linalg/_isolve/tests/test_lsqr.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_lsqr.py
@@ -20,7 +20,12 @@ for jj in range(5):
 
 b = normal(size=n)
 
+# tolerance for atol/btol keywords of lsqr()
 tol = 2e-10
+# tolerances for testing the results of the lsqr() call with assert_allclose
+# These tolerances are a bit fragile - see discussion in gh-15301.
+atol_test = 4e-10
+rtol_test = 2e-8
 show = False
 maxit = None
 
@@ -31,7 +36,7 @@ def test_lsqr_basic():
     assert_array_equal(b_copy, b)
 
     svx = np.linalg.solve(G, b)
-    assert_allclose(xo, svx, atol=tol, rtol=tol)
+    assert_allclose(xo, svx, atol=atol_test, rtol=rtol_test)
 
     # Now the same but with damp > 0.
     # This is equivalent to solving the extented system:
@@ -44,7 +49,7 @@ def test_lsqr_basic():
     Gext = np.r_[G, damp * np.eye(G.shape[1])]
     bext = np.r_[b, np.zeros(G.shape[1])]
     svx, *_ = np.linalg.lstsq(Gext, bext, rcond=None)
-    assert_allclose(xo, svx, atol=tol, rtol=tol)
+    assert_allclose(xo, svx, atol=atol_test, rtol=rtol_test)
 
 
 def test_gh_2466():

--- a/scipy/sparse/linalg/_isolve/tests/test_lsqr.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_lsqr.py
@@ -20,12 +20,12 @@ for jj in range(5):
 
 b = normal(size=n)
 
-tol = 1e-10
+tol = 2e-10
 show = False
 maxit = None
 
 
-def test_basic():
+def test_lsqr_basic():
     b_copy = b.copy()
     xo, *_ = lsqr(G, b, show=show, atol=tol, btol=tol, iter_lim=maxit)
     assert_array_equal(b_copy, b)

--- a/scipy/sparse/linalg/tests/test_propack.py
+++ b/scipy/sparse/linalg/tests/test_propack.py
@@ -111,10 +111,13 @@ def test_svdp(ctor, precision, irl, which):
 @pytest.mark.parametrize('precision', _dtype_testing)
 @pytest.mark.parametrize('irl', (False, True))
 def test_examples(precision, irl):
+    # Note: atol for complex8 bumped from 1e-4 to 1e-3 because of test failures
+    # with BLIS, Netlib, and MKL+AVX512 - see
+    # https://github.com/conda-forge/scipy-feedstock/pull/198#issuecomment-999180432
     atol = {
-        'single': 1e-4,
+        'single': 1.2e-4,
         'double': 1e-9,
-        'complex8': 1e-4,
+        'complex8': 1e-3,
         'complex16': 1e-9,
     }[precision]
 


### PR DESCRIPTION
See https://github.com/conda-forge/scipy-feedstock/pull/198#issuecomment-999180432 for details of test failures. They are happening in multiple configs:
- (linux + x86 + blis/netlib) or (osx + netlib) or (win + blis/netlib): two failures in propack tests
- linux + x86 + MKL + AVX512: 2 failures
- osx + x86 + BLIS: 6 failures

This should solve most of them, the only one I decided not to fix with a tolerance bump is `test_x0_equals_Mb[bicgstab]`; that one gave an internal breakdown error code in `bicgstab`:
```
*                  -11: OMEGA  .ls.  BREAKTOL: S and T have become 
*                                         orthogonal relative to T'*T.
```
It can be skipped in conda-forge if desired; there's no good way to put in a skip for MKL+AVX512, and there's no clear way to fix the test.
