### PR TITLE
DOC: More docstring reformatting.

### DIFF
--- a/scipy/_lib/_uarray/_backend.py
+++ b/scipy/_lib/_uarray/_backend.py
@@ -110,8 +110,7 @@ def get_state():
 
     See Also
     --------
-    set_state
-        Sets the state returned by this function.
+    set_state : Sets the state returned by this function.
     """
     return _uarray.get_state()
 
@@ -123,10 +122,8 @@ def reset_state():
 
     See Also
     --------
-    set_state
-        Context manager that sets the backend state.
-    get_state
-        Gets a state to be set by this context manager.
+    set_state : Context manager that sets the backend state.
+    get_state : Gets a state to be set by this context manager.
     """
     with set_state(get_state()):
         yield
@@ -139,8 +136,7 @@ def set_state(state):
 
     See Also
     --------
-    get_state
-        Gets a state to be set by this context manager.
+    get_state : Gets a state to be set by this context manager.
     """
     old_state = get_state()
     _uarray.set_state(state)
@@ -161,8 +157,7 @@ def create_multimethod(*args, **kwargs):
 
     See Also
     --------
-    generate_multimethod
-        Generates a multimethod.
+    generate_multimethod : Generates a multimethod.
     """
 
     def wrapper(a):
@@ -230,7 +225,7 @@ def generate_multimethod(
 
     See Also
     --------
-    uarray
+    uarray :
         See the module documentation for how to override the method by creating backends.
     """
     kw_defaults, arg_defaults, opts = get_defaults(argument_extractor)
@@ -261,8 +256,8 @@ def set_backend(backend, coerce=False, only=False):
 
     See Also
     --------
-    skip_backend: A context manager that allows skipping of backends.
-    set_global_backend: Set a single, global backend for a domain.
+    skip_backend : A context manager that allows skipping of backends.
+    set_global_backend : Set a single, global backend for a domain.
     """
     try:
         return backend.__ua_cache__["set", coerce, only]
@@ -289,8 +284,8 @@ def skip_backend(backend):
 
     See Also
     --------
-    set_backend: A context manager that allows setting of backends.
-    set_global_backend: Set a single, global backend for a domain.
+    set_backend : A context manager that allows setting of backends.
+    set_global_backend : Set a single, global backend for a domain.
     """
     try:
         return backend.__ua_cache__["skip"]
@@ -351,8 +346,8 @@ def set_global_backend(backend, coerce=False, only=False, *, try_last=False):
 
     See Also
     --------
-    set_backend: A context manager that allows setting of backends.
-    skip_backend: A context manager that allows skipping of backends.
+    set_backend : A context manager that allows setting of backends.
+    skip_backend : A context manager that allows skipping of backends.
     """
     _uarray.set_global_backend(backend, coerce, only, try_last)
 
@@ -567,14 +562,12 @@ def determine_backend(value, dispatch_type, *, domain, only=True, coerce=False):
 
     Notes
     -----
-
     Support is determined by the ``__ua_convert__`` protocol. Backends not
     supporting the type must return ``NotImplemented`` from their
     ``__ua_convert__`` if they don't support input of that type.
 
     Examples
     --------
-
     Suppose we have two backends ``BackendA`` and ``BackendB`` each supporting
     different types, ``TypeA`` and ``TypeB``. Neither supporting the other type:
 
@@ -626,33 +619,31 @@ def determine_backend_multi(
 
     Parameters
     ----------
-    dispatchables: Sequence[Union[uarray.Dispatchable, Any]]
+    dispatchables : Sequence[Union[uarray.Dispatchable, Any]]
         The dispatchables that must be supported
-    domain: string
+    domain : string
         The domain to query for backends and set.
-    coerce: bool
+    coerce : bool
         Whether or not to allow coercion to the backend's types. Implies ``only``.
-    only: bool
+    only : bool
         Whether or not this should be the last backend to try.
-    dispatch_type: Optional[Any]
+    dispatch_type : Optional[Any]
         The default dispatch type associated with ``dispatchables``, aka
         ":ref:`marking <MarkingGlossary>`".
 
     See Also
     --------
-    determine_backend: For a single dispatch value
-    set_backend: For when you know which backend to set
+    determine_backend : For a single dispatch value
+    set_backend : For when you know which backend to set
 
     Notes
     -----
-
     Support is determined by the ``__ua_convert__`` protocol. Backends not
     supporting the type must return ``NotImplemented`` from their
     ``__ua_convert__`` if they don't support input of that type.
 
     Examples
     --------
-
     :func:`determine_backend` allows the backend to be set from a single
     object. :func:`determine_backend_multi` allows multiple objects to be
     checked simultaneously for support in the backend. Suppose we have a

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -1610,8 +1610,10 @@ def cophenet(Z, Y=None):
 
     See Also
     --------
-    linkage : for a description of what a linkage matrix is.
-    scipy.spatial.distance.squareform : transforming condensed matrices into square ones.
+    linkage :
+        for a description of what a linkage matrix is.
+    scipy.spatial.distance.squareform :
+        transforming condensed matrices into square ones.
 
     Examples
     --------

--- a/scipy/fft/_basic.py
+++ b/scipy/fft/_basic.py
@@ -86,7 +86,6 @@ def fft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
 
     Notes
     -----
-
     FFT (Fast Fourier Transform) refers to a way the discrete Fourier Transform
     (DFT) can be calculated efficiently, by using symmetries in the calculated
     terms. The symmetry is highest when `n` is a power of 2, and the transform
@@ -1391,7 +1390,6 @@ def hfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
 
     Notes
     -----
-
     For a 1-D signal ``x`` to have a real spectrum, it must satisfy
     the Hermitian property::
 
@@ -1547,7 +1545,6 @@ def ihfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
 
     Notes
     -----
-
     The transform for real input is performed over the last transformation
     axis, as by `ihfft`, then the transform over the remaining axes is
     performed as by `ifftn`. The order of the output is the positive part of

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -646,20 +646,19 @@ def tplquad(func, a, b, gfun, hfun, qfun, rfun, args=(), epsabs=1.49e-8,
 
     See Also
     --------
-    quad: Adaptive quadrature using QUADPACK
-    quadrature: Adaptive Gaussian quadrature
-    fixed_quad: Fixed-order Gaussian quadrature
-    dblquad: Double integrals
+    quad : Adaptive quadrature using QUADPACK
+    quadrature : Adaptive Gaussian quadrature
+    fixed_quad : Fixed-order Gaussian quadrature
+    dblquad : Double integrals
     nquad : N-dimensional integrals
-    romb: Integrators for sampled data
-    simpson: Integrators for sampled data
-    ode: ODE integrators
-    odeint: ODE integrators
-    scipy.special: For coefficients and roots of orthogonal polynomials
+    romb : Integrators for sampled data
+    simpson : Integrators for sampled data
+    ode : ODE integrators
+    odeint : ODE integrators
+    scipy.special : For coefficients and roots of orthogonal polynomials
 
     Examples
     --------
-
     Compute the triple integral of ``x * y * z``, over ``x`` ranging
     from 1 to 2, ``y`` ranging from 2 to 3, ``z`` ranging from 0 to 1.
 

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -109,7 +109,6 @@ def fixed_quad(func, a, b, args=(), n=5):
     none : None
         Statically returned value of None
 
-
     See Also
     --------
     quad : adaptive quadrature using QUADPACK
@@ -232,18 +231,18 @@ def quadrature(func, a, b, args=(), tol=1.49e-8, rtol=1.49e-8, maxiter=50,
     err : float
         Difference between last two estimates of the integral.
 
-    See also
+    See Also
     --------
-    romberg: adaptive Romberg quadrature
-    fixed_quad: fixed-order Gaussian quadrature
-    quad: adaptive quadrature using QUADPACK
-    dblquad: double integrals
-    tplquad: triple integrals
-    romb: integrator for sampled data
-    simpson: integrator for sampled data
-    cumulative_trapezoid: cumulative integration for sampled data
-    ode: ODE integrator
-    odeint: ODE integrator
+    romberg : adaptive Romberg quadrature
+    fixed_quad : fixed-order Gaussian quadrature
+    quad : adaptive quadrature using QUADPACK
+    dblquad : double integrals
+    tplquad : triple integrals
+    romb : integrator for sampled data
+    simpson : integrator for sampled data
+    cumulative_trapezoid : cumulative integration for sampled data
+    ode : ODE integrator
+    odeint : ODE integrator
 
     Examples
     --------
@@ -329,15 +328,15 @@ def cumulative_trapezoid(y, x=None, dx=1.0, axis=-1, initial=None):
     See Also
     --------
     numpy.cumsum, numpy.cumprod
-    quad: adaptive quadrature using QUADPACK
-    romberg: adaptive Romberg quadrature
-    quadrature: adaptive Gaussian quadrature
-    fixed_quad: fixed-order Gaussian quadrature
-    dblquad: double integrals
-    tplquad: triple integrals
-    romb: integrators for sampled data
-    ode: ODE integrators
-    odeint: ODE integrators
+    quad : adaptive quadrature using QUADPACK
+    romberg : adaptive Romberg quadrature
+    quadrature : adaptive Gaussian quadrature
+    fixed_quad : fixed-order Gaussian quadrature
+    dblquad : double integrals
+    tplquad : triple integrals
+    romb : integrators for sampled data
+    ode : ODE integrators
+    odeint : ODE integrators
 
     Examples
     --------
@@ -464,16 +463,16 @@ def simpson(y, x=None, dx=1.0, axis=-1, even='avg'):
 
     See Also
     --------
-    quad: adaptive quadrature using QUADPACK
-    romberg: adaptive Romberg quadrature
-    quadrature: adaptive Gaussian quadrature
-    fixed_quad: fixed-order Gaussian quadrature
-    dblquad: double integrals
-    tplquad: triple integrals
-    romb: integrators for sampled data
-    cumulative_trapezoid: cumulative integration for sampled data
-    ode: ODE integrators
-    odeint: ODE integrators
+    quad : adaptive quadrature using QUADPACK
+    romberg : adaptive Romberg quadrature
+    quadrature : adaptive Gaussian quadrature
+    fixed_quad : fixed-order Gaussian quadrature
+    dblquad : double integrals
+    tplquad : triple integrals
+    romb : integrators for sampled data
+    cumulative_trapezoid : cumulative integration for sampled data
+    ode : ODE integrators
+    odeint : ODE integrators
 
     Notes
     -----
@@ -578,7 +577,7 @@ def romb(y, dx=1.0, axis=-1, show=False):
     romb : ndarray
         The integrated result for `axis`.
 
-    See also
+    See Also
     --------
     quad : adaptive quadrature using QUADPACK
     romberg : adaptive Romberg quadrature

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -1405,7 +1405,6 @@ def make_lsq_spline(x, y, t, k=3, w=None, axis=0, check_finite=True):
 
     Notes
     -----
-
     The number of data points must be larger than the spline degree `k`.
 
     Knots `t` must satisfy the Schoenberg-Whitney conditions,

--- a/scipy/interpolate/_fitpack_impl.py
+++ b/scipy/interpolate/_fitpack_impl.py
@@ -687,7 +687,7 @@ def sproot(tck, mest=10):
     zeros : ndarray
         An array giving the roots of the spline.
 
-    See also
+    See Also
     --------
     splprep, splrep, splint, spalde, splev
     bisplrep, bisplev

--- a/scipy/interpolate/_ndgriddata.py
+++ b/scipy/interpolate/_ndgriddata.py
@@ -219,7 +219,7 @@ def griddata(points, values, xi, method='linear', fill_value=np.nan,
     >>> plt.gcf().set_size_inches(6, 6)
     >>> plt.show()
 
-    See also
+    See Also
     --------
     LinearNDInterpolator :
         Piecewise linear interpolant in N dimensions.

--- a/scipy/io/matlab/_mio4.py
+++ b/scipy/io/matlab/_mio4.py
@@ -469,7 +469,7 @@ class VarWriter4:
         name : str
             name of variable
         shape : sequence
-           Shape of array as it will be read in matlab
+            Shape of array as it will be read in matlab
         P : int, optional
             code for mat4 data type, one of ``miDOUBLE, miSINGLE, miINT32,
             miINT16, miUINT16, miUINT8``

--- a/scipy/io/matlab/_mio5.py
+++ b/scipy/io/matlab/_mio5.py
@@ -208,7 +208,7 @@ class MatFile5Reader(MatFileReader):
 
     def guess_byte_order(self):
         ''' Guess byte order.
-        Sets stream pointer to 0 '''
+        Sets stream pointer to 0'''
         self.mat_stream.seek(126)
         mi = self.mat_stream.read(2)
         self.mat_stream.seek(0)

--- a/scipy/io/tests/test_netcdf.py
+++ b/scipy/io/tests/test_netcdf.py
@@ -53,9 +53,9 @@ def assert_mask_matches(arr, expected_mask):
 
     Parameters
     ----------
-    arr: ndarray or MaskedArray
+    arr : ndarray or MaskedArray
         Array to test.
-    expected_mask: array_like of booleans
+    expected_mask : array_like of booleans
         A list giving the expected mask.
     '''
 

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1261,7 +1261,7 @@ def pinv(a, atol=None, rtol=None, return_rank=False, check_finite=True,
 
         .. versionadded:: 1.7.0
 
-    rtol: float, optional
+    rtol : float, optional
         Relative threshold term, default value is ``max(M, N) * eps`` where
         ``eps`` is the machine precision value of the datatype of ``a``.
 
@@ -1414,12 +1414,13 @@ def pinvh(a, atol=None, rtol=None, lower=True, return_rank=False,
     ----------
     a : (N, N) array_like
         Real symmetric or complex hermetian matrix to be pseudo-inverted
-    atol: float, optional
+
+    atol : float, optional
         Absolute threshold term, default value is 0.
 
         .. versionadded:: 1.7.0
 
-    rtol: float, optional
+    rtol : float, optional
         Relative threshold term, default value is ``N * eps`` where
         ``eps`` is the machine precision value of the datatype of ``a``.
 
@@ -1563,7 +1564,6 @@ def matrix_balance(A, permute=True, scale=True, separate=False,
 
     Notes
     -----
-
     This algorithm is particularly useful for eigenvalue and matrix
     decompositions and in many cases it is already called by various
     LAPACK routines.

--- a/scipy/linalg/_decomp_cholesky.py
+++ b/scipy/linalg/_decomp_cholesky.py
@@ -254,8 +254,9 @@ def cholesky_banded(ab, overwrite_ab=False, lower=False, check_finite=True):
 
     See Also
     --------
-    cho_solve_banded : Solve a linear set equations, given the Cholesky factorization
-                of a banded Hermitian.
+    cho_solve_banded :
+        Solve a linear set equations, given the Cholesky factorization
+        of a banded Hermitian.
 
     Examples
     --------

--- a/scipy/ndimage/_filters.py
+++ b/scipy/ndimage/_filters.py
@@ -1372,7 +1372,7 @@ def median_filter(input, size=None, footprint=None, output=None,
     median_filter : ndarray
         Filtered array. Has the same shape as `input`.
 
-    See also
+    See Also
     --------
     scipy.signal.medfilt2d
 

--- a/scipy/ndimage/_measurements.py
+++ b/scipy/ndimage/_measurements.py
@@ -610,7 +610,7 @@ def sum_labels(input, labels=None, index=None):
         by `labels` with the same shape as `index`. If 'index' is None or scalar,
         a scalar is returned.
 
-    See also
+    See Also
     --------
     mean, median
 
@@ -656,7 +656,7 @@ def mean(input, labels=None, index=None):
         Sequence of same length as `index`, with the mean of the different
         regions labeled by the labels in `index`.
 
-    See also
+    See Also
     --------
     variance, standard_deviation, minimum, maximum, sum, label
 
@@ -931,7 +931,7 @@ def minimum(input, labels=None, index=None):
         and the minimal value of elements where `labels` is greater than zero
         if `index` is None.
 
-    See also
+    See Also
     --------
     label, maximum, median, minimum_position, extrema, sum, mean, variance,
     standard_deviation
@@ -993,7 +993,7 @@ def maximum(input, labels=None, index=None):
         and the maximal value of elements where `labels` is greater than zero
         if `index` is None.
 
-    See also
+    See Also
     --------
     label, minimum, median, maximum_position, extrema, sum, mean, variance,
     standard_deviation
@@ -1072,7 +1072,7 @@ def median(input, labels=None, index=None):
         and the median value of elements where `labels` is greater than zero
         if `index` is None.
 
-    See also
+    See Also
     --------
     label, minimum, maximum, extrema, sum, mean, variance, standard_deviation
 
@@ -1138,7 +1138,7 @@ def minimum_position(input, labels=None, index=None):
         If `index` or `labels` are not specified, a tuple of ints is
         returned specifying the location of the first minimal value of `input`.
 
-    See also
+    See Also
     --------
     label, minimum, median, maximum_position, extrema, sum, mean, variance,
     standard_deviation


### PR DESCRIPTION
This try to autoformat the DocStrings a bit more, in particular focus on
the See Also sections, that for proper parsing are better with an
uppercase A. Also unlike in parameters sections when the dee also are a
definition list it is recommended to put a colon at the end of the line,
with space before colon. So this tries to do that, and when it can try
to fit it in one line (total length < 80 chars).

There is also some normalisations of having no spaces after headers,
and some normalisation of always having 4 spaces indent in rst.
