### PR TITLE
CI: fix Gitpod build by adding HiGHS submodule checkout

### DIFF
--- a/tools/docker_dev/gitpod.Dockerfile
+++ b/tools/docker_dev/gitpod.Dockerfile
@@ -40,6 +40,7 @@ WORKDIR ${WORKSPACE}
 RUN git submodule update --init --depth=1 -- scipy/_lib/boost
 RUN git submodule update --init --depth=1 -- scipy/sparse/linalg/_propack/PROPACK
 RUN git submodule update --init --depth=1 -- scipy/_lib/unuran
+RUN git submodule update --init --depth=1 -- scipy/_lib/highs
 RUN conda activate ${CONDA_ENV} && \
     python setup.py build_ext --inplace && \
     ccache -s


### PR DESCRIPTION
I considered removing the submodule-specific lines and just doing `git submodule update --init`, but that pulls in more so let's stay with the current method.