### PR TITLE
BLD: update NumPy to >=1.18.5, setuptools to <60.0

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -77,7 +77,7 @@ jobs:
     - name: Install packages
       run: |
         pip install ${{ matrix.numpy-version }}
-        pip install setuptools wheel cython pytest pytest-xdist pybind11 pytest-xdist mpmath gmpy2==2.1.0rc1 pythran
+        pip install setuptools==59.8.0 wheel cython pytest pytest-xdist pybind11 pytest-xdist mpmath gmpy2==2.1.0rc1 pythran
 
     - name: Test SciPy
       run: |

--- a/INSTALL.rst.txt
+++ b/INSTALL.rst.txt
@@ -31,17 +31,17 @@ PREREQUISITES
 
 SciPy requires the following software installed for your platform:
 
-1) Python__ >= 3.7
+1) Python__ >= 3.8
 
 __ https://www.python.org
 
-2) NumPy__ >= 1.16.5
+2) NumPy__ >= 1.18.5
 
 __ https://www.numpy.org/
 
 If building from source, SciPy also requires:
 
-3) setuptools__
+3) setuptools__ < 60.0
 
 __ https://github.com/pypa/setuptools
 
@@ -53,9 +53,7 @@ __ https://github.com/pybind/pybind11
 
 __ http://www.sphinx-doc.org/
 
-6) If you want to build SciPy master or other unreleased version from source
-   (Cython-generated C sources are included in official releases):
-   Cython__ >= 0.29.18
+6) Cython__ >= 0.29.18
 
 __ http://cython.org/
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -126,7 +126,7 @@ stages:
     - template: ci/azure-travis-template.yaml
       parameters:
         test_mode: fast
-        numpy_spec: "numpy==1.17.3"
+        numpy_spec: "numpy==1.18.5"
         use_wheel: true
   - job: Lint
     condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))  # skip for PR merges
@@ -172,7 +172,7 @@ stages:
             curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
             python3.8 get-pip.py && \
             pip3 --version && \
-            pip3 install setuptools==59.6.0 wheel numpy==1.17.3 cython==0.29.18 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath matplotlib==3.1.3 pythran==0.10.0 --user && \
+            pip3 install setuptools==59.6.0 wheel numpy==1.18.5 cython==0.29.18 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath matplotlib==3.1.3 pythran==0.10.0 --user && \
             apt-get -y install gcc-5 g++-5 gfortran-8 wget && \
             cd .. && \
             mkdir openblas && cd openblas && \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@
 [build-system]
 requires = [
     "wheel",
-    "setuptools",
+    "setuptools<60.0",  # do not increase, 60.0 enables vendored distutils
     "Cython>=0.29.18",
     "pybind11>=2.4.3",
     "pythran>=0.9.12",
@@ -29,11 +29,8 @@ requires = [
     "numpy==1.20.0; python_version=='3.8' and platform_machine=='arm64' and platform_system=='Darwin'",
     "numpy==1.20.0; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Darwin'",
 
-    # Python 3.8 on s390x requires at least 1.17.5, see https://github.com/scipy/oldest-supported-numpy/issues/29
-    "numpy==1.17.5; python_version=='3.8' and platform_machine=='s390x' and platform_python_implementation != 'PyPy'",
-
     # default numpy requirements
-    "numpy==1.17.3; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64' and platform_machine!='s390x' and platform_python_implementation != 'PyPy'",
+    "numpy==1.18.5; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'",
     "numpy==1.19.3; python_version=='3.9' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_python_implementation != 'PyPy'",
     "numpy==1.21.4; python_version=='3.10' and platform_python_implementation != 'PyPy'",
 
@@ -57,7 +54,7 @@ maintainers = [
 #     https://scipy.github.io/devdocs/dev/core-dev/index.html#version-ranges-for-numpy-and-other-dependencies
 requires-python = ">=3.8"
 dependencies = [
-    "numpy>=1.17.3",
+    "numpy>=1.18.5",
 ]
 readme = "README.rst"
 classifiers = [

--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -136,7 +136,7 @@ else:
     from scipy._lib import _pep440
     # In maintenance branch, change to np_maxversion N+3 if numpy is at N
     # See setup.py for more details
-    np_minversion = '1.17.3'
+    np_minversion = '1.18.5'
     np_maxversion = '9.9.99'
     if (_pep440.parse(__numpy_version__) < _pep440.Version(np_minversion) or
             _pep440.parse(__numpy_version__) >= _pep440.Version(np_maxversion)):

--- a/setup.py
+++ b/setup.py
@@ -541,7 +541,7 @@ def setup_package():
     # Rationale: SciPy builds without deprecation warnings with N; deprecations
     #            in N+1 will turn into errors in N+3
     # For Python versions, if releases is (e.g.) <=3.9.x, set bound to 3.10
-    np_minversion = '1.17.3'
+    np_minversion = '1.18.5'
     np_maxversion = '9.9.99'
     python_minversion = '3.8'
     python_maxversion = '3.10'


### PR DESCRIPTION
For NumPy, this is a regular bump after 1.8.x was branched (still slightly on the conservative side w.r.t. NEP 29).

For setuptools, we do not want the vendored `distutils` that setuptools re-enabled in 60.0. Given that we are dropping support for this build system, it's not very likely we'll ever need `>=60.0`. This also fixes a CI failure we're seeing on 32-bit Linux:

  `AttributeError: module '_distutils_hack' has no attribute 'ensure_shim'`