### PR TITLE
ENH: signal: Add Kaiser-Bessel derived window function

### DIFF
--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -472,8 +472,8 @@ class TestKaiserBesselDerived:
             windows.kaiser_bessel_derived(M + 1, beta=4.)
 
         # Assert ValueError for non-symmetric setting
-        msg = "Kaiser-Bessel Derived windows are only defined for " \
-              "symmetric shapes"
+        msg = ("Kaiser-Bessel Derived windows are only defined for "
+               "symmetric shapes")
         with assert_raises(ValueError, match=msg):
             windows.kaiser_bessel_derived(M + 1, beta=4., sym=False)
 

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -449,6 +449,11 @@ class TestKaiserBesselDerived:
         # Test for Princen-Bradley condition
         assert_allclose(w[:M // 2] ** 2 + w[-M // 2:] ** 2, 1.)
 
+        # Test actual values from other implementations
+        # M = 2:  sqrt(2) / 2
+        # M = 4:  0.518562710536, 0.855039598640
+        # M = 6:  0.436168993154, 0.707106781187, 0.899864772847
+        # Ref:https://github.com/scipy/scipy/pull/4747#issuecomment-172849418
         assert_allclose(windows.kaiser_bessel_derived(2, beta=np.pi / 2)[:1],
                         np.sqrt(2) / 2)
 

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -461,12 +461,16 @@ class TestKaiserBesselDerived:
     def test_exceptions(self):
         M = 100
         # Assert ValueError for odd window length
-        assert_raises(ValueError, windows.kaiser_bessel_derived,
-                      M + 1, beta=4.)
+        msg = "Kaiser-Bessel Derived windows are only defined for even " \
+              "number of points"
+        with assert_raises(ValueError, match=msg):
+            windows.kaiser_bessel_derived(M + 1, beta=4.)
 
         # Assert ValueError for non-symmetric setting
-        assert_raises(ValueError, windows.kaiser_bessel_derived,
-                      M, beta=4., sym=False)
+        msg = "Kaiser-Bessel Derived windows are only defined for " \
+              "symmetric shapes"
+        with assert_raises(ValueError, match=msg):
+            windows.kaiser_bessel_derived(M + 1, beta=4., sym=False)
 
 
 class TestNuttall:

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -466,8 +466,8 @@ class TestKaiserBesselDerived:
     def test_exceptions(self):
         M = 100
         # Assert ValueError for odd window length
-        msg = "Kaiser-Bessel Derived windows are only defined for even " \
-              "number of points"
+        msg = ("Kaiser-Bessel Derived windows are only defined for even "
+               "number of points")
         with assert_raises(ValueError, match=msg):
             windows.kaiser_bessel_derived(M + 1, beta=4.)
 

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -437,6 +437,37 @@ class TestKaiser:
                          0.5985765418119844])
 
 
+class TestKaiserBesselDerived:
+
+    def test_basic(self):
+        M = 100
+        w = windows.kaiser_bessel_derived(M, beta=4.0)
+        w2 = windows.get_window(('kaiser bessel derived', 4.0), M, fftbins=False)
+        assert_allclose(w, w2)
+
+        # Test for Princen-Bradley condition
+        assert_allclose(w[:M // 2] ** 2 + w[-M // 2:] ** 2, 1.)
+
+        assert_allclose(windows.kaiser_bessel_derived(2, beta=np.pi / 2)[:1],
+                        np.sqrt(2) / 2)
+
+        assert_allclose(windows.kaiser_bessel_derived(4, beta=np.pi / 2)[:2],
+                        [0.518562710536, 0.855039598640])
+
+        assert_allclose(windows.kaiser_bessel_derived(6, beta=np.pi / 2)[:3],
+                        [0.436168993154, 0.707106781187, 0.899864772847])
+
+    def test_exceptions(self):
+        M = 100
+        # Assert ValueError for odd window length
+        assert_raises(ValueError, windows.kaiser_bessel_derived,
+                      M + 1, beta=4.)
+
+        # Assert ValueError for non-symmetric setting
+        assert_raises(ValueError, windows.kaiser_bessel_derived,
+                      M, beta=4., sym=False)
+
+
 class TestNuttall:
 
     def test_basic(self):
@@ -711,7 +742,8 @@ def test_windowfunc_basics():
 
 
 def test_needs_params():
-    for winstr in ['kaiser', 'ksr', 'gaussian', 'gauss', 'gss',
+    for winstr in ['kaiser', 'ksr', 'kaiser_bessel_derived', 'kbd',
+                   'gaussian', 'gauss', 'gss',
                    'general gaussian', 'general_gaussian',
                    'general gauss', 'general_gauss', 'ggs',
                    'dss', 'dpss', 'general cosine', 'general_cosine',

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -442,7 +442,8 @@ class TestKaiserBesselDerived:
     def test_basic(self):
         M = 100
         w = windows.kaiser_bessel_derived(M, beta=4.0)
-        w2 = windows.get_window(('kaiser bessel derived', 4.0), M, fftbins=False)
+        w2 = windows.get_window(('kaiser bessel derived', 4.0),
+                                M, fftbins=False)
         assert_allclose(w, w2)
 
         # Test for Princen-Bradley condition

--- a/scipy/signal/windows/__init__.py
+++ b/scipy/signal/windows/__init__.py
@@ -46,6 +46,7 @@ from . import windows
 
 __all__ = ['boxcar', 'triang', 'parzen', 'bohman', 'blackman', 'nuttall',
            'blackmanharris', 'flattop', 'bartlett', 'hanning', 'barthann',
-           'hamming', 'kaiser', 'gaussian', 'general_gaussian', 'general_cosine',
-           'general_hamming', 'chebwin', 'cosine', 'hann',
-           'exponential', 'tukey', 'taylor', 'get_window', 'dpss']
+           'hamming', 'kaiser', 'kaiser_bessel_derived', 'gaussian',
+           'general_gaussian', 'general_cosine', 'general_hamming',
+           'chebwin', 'cosine', 'hann', 'exponential', 'tukey', 'taylor',
+           'get_window', 'dpss']

--- a/scipy/signal/windows/__init__.py
+++ b/scipy/signal/windows/__init__.py
@@ -9,33 +9,33 @@ The suite of window functions for filtering and spectral estimation.
 .. autosummary::
    :toctree: generated/
 
-   get_window        -- Return a window of a given length and type.
+   get_window              -- Return a window of a given length and type.
 
-   barthann          -- Bartlett-Hann window
-   bartlett          -- Bartlett window
-   blackman          -- Blackman window
-   blackmanharris    -- Minimum 4-term Blackman-Harris window
-   bohman            -- Bohman window
-   boxcar            -- Boxcar window
-   chebwin           -- Dolph-Chebyshev window
-   cosine            -- Cosine window
-   dpss              -- Discrete prolate spheroidal sequences
-   exponential       -- Exponential window
-   flattop           -- Flat top window
-   gaussian          -- Gaussian window
-   general_cosine    -- Generalized Cosine window
-   general_gaussian  -- Generalized Gaussian window
-   general_hamming   -- Generalized Hamming window
-   hamming           -- Hamming window
-   hann              -- Hann window
-   hanning           -- Hann window
-   kaiser            -- Kaiser window
-   kaiser_bessel_derived -- Kaiser-Bessel derived window
-   nuttall           -- Nuttall's minimum 4-term Blackman-Harris window
-   parzen            -- Parzen window
-   taylor            -- Taylor window
-   triang            -- Triangular window
-   tukey             -- Tukey window
+   barthann                -- Bartlett-Hann window
+   bartlett                -- Bartlett window
+   blackman                -- Blackman window
+   blackmanharris          -- Minimum 4-term Blackman-Harris window
+   bohman                  -- Bohman window
+   boxcar                  -- Boxcar window
+   chebwin                 -- Dolph-Chebyshev window
+   cosine                  -- Cosine window
+   dpss                    -- Discrete prolate spheroidal sequences
+   exponential             -- Exponential window
+   flattop                 -- Flat top window
+   gaussian                -- Gaussian window
+   general_cosine          -- Generalized Cosine window
+   general_gaussian        -- Generalized Gaussian window
+   general_hamming         -- Generalized Hamming window
+   hamming                 -- Hamming window
+   hann                    -- Hann window
+   hanning                 -- Hann window
+   kaiser                  -- Kaiser window
+   kaiser_bessel_derived   -- Kaiser-Bessel derived window
+   nuttall                 -- Nuttall's minimum 4-term Blackman-Harris window
+   parzen                  -- Parzen window
+   taylor                  -- Taylor window
+   triang                  -- Triangular window
+   tukey                   -- Tukey window
 
 """
 

--- a/scipy/signal/windows/__init__.py
+++ b/scipy/signal/windows/__init__.py
@@ -30,6 +30,7 @@ The suite of window functions for filtering and spectral estimation.
    hann              -- Hann window
    hanning           -- Hann window
    kaiser            -- Kaiser window
+   kaiser_bessel_derived -- Kaiser-Bessel derived window
    nuttall           -- Nuttall's minimum 4-term Blackman-Harris window
    parzen            -- Parzen window
    taylor            -- Taylor window

--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -1229,7 +1229,7 @@ def kaiser_bessel_derived(M, beta, *, sym=True):
         This parameter only exists to comply with the interface offered by
         the other window functions and to be callable by `get_window`.
         When True (default), generates a symmetric window, for use in filter
-        design. It will raise `ValueError` otherwise.
+        design.
 
     Returns
     -------

--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -1258,7 +1258,8 @@ def kaiser_bessel_derived(M, beta, sym=True):
     >>> import matplotlib.pyplot as plt
     >>> N = 100
     >>> for alpha in [0.64, 2.55, 7.64, 31.83]:
-    ...     plt.plot(signal.windows.kaiser_bessel_derived(N, alpha), label=f"{alpha=}")
+    ...     plt.plot(signal.windows.kaiser_bessel_derived(N, alpha),
+    ...             label=f"{alpha=}")
     >>> plt.legend()
     >>> plt.grid(True)
     >>> plt.title("Kaiser-Bessel derived window")

--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -1268,7 +1268,6 @@ def kaiser_bessel_derived(M, beta, *, sym=True):
     >>> plt.tight_layout()
     >>> plt.show()
     """
-
     if not sym:
         raise ValueError(
             "Kaiser-Bessel Derived windows are only defined for symmetric "

--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -1291,9 +1291,7 @@ def kaiser_bessel_derived(M, beta, *, sym=True):
     kaiser_window = kaiser(M // 2 + 1, beta)
     csum = np.cumsum(kaiser_window)
     half_window = np.sqrt(csum[:-1] / csum[-1])
-    w = np.zeros(M)
-    w[:M//2] = half_window
-    w[-M//2:] = half_window[::-1]
+    w = np.concatenate((half_window, half_window[::-1]), axis=0)
     return w
 
 

--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -1214,7 +1214,7 @@ def kaiser(M, beta, sym=True):
     return _truncate(w, needs_trunc)
 
 
-def kaiser_bessel_derived(M, beta, sym=True):
+def kaiser_bessel_derived(M, beta, *, sym=True):
     """Return a Kaiser-Bessel derived window.
 
     Parameters

--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -1256,17 +1256,18 @@ def kaiser_bessel_derived(M, beta, *, sym=True):
 
     >>> from scipy import signal
     >>> import matplotlib.pyplot as plt
+    >>> fig, ax = plt.subplots()
     >>> N = 100
     >>> for alpha in [0.64, 2.55, 7.64, 31.83]:
-    ...     plt.plot(signal.windows.kaiser_bessel_derived(N, alpha),
+    ...     ax.plot(signal.windows.kaiser_bessel_derived(N, alpha),
     ...             label=f"{alpha=}")
-    >>> plt.legend()
-    >>> plt.grid(True)
-    >>> plt.title("Kaiser-Bessel derived window")
-    >>> plt.ylabel("Amplitude")
-    >>> plt.xlabel("Sample")
-    >>> plt.tight_layout()
-    >>> plt.show()
+    >>> ax.grid(True)
+    >>> ax.set_title("Kaiser-Bessel derived window")
+    >>> ax.set_ylabel("Amplitude")
+    >>> ax.set_xlabel("Sample")
+    >>> fig.legend(loc="center")
+    >>> fig.tight_layout()
+    >>> fig.show()
     """
     if not sym:
         raise ValueError(

--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -1222,7 +1222,7 @@ def kaiser_bessel_derived(M, beta, *, sym=True):
     M : int
         Number of points in the output window. If zero or less, an empty
         array is returned. Note that this window is only defined for an even
-        number of points. It will raise `ValueError` otherwise.
+        number of points.
     beta : float
         Kaiser window shape parameter.
     sym : bool, optional

--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -1278,7 +1278,8 @@ def kaiser_bessel_derived(M, beta, *, sym=True):
     elif M % 2:
         raise ValueError(
             "Kaiser-Bessel Derived windows are only defined for even number "
-            "of points")
+            "of points"
+        )
 
     kaiser_window = kaiser(M // 2 + 1, beta)
     csum = np.cumsum(kaiser_window)

--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -1272,7 +1272,8 @@ def kaiser_bessel_derived(M, beta, *, sym=True):
     if not sym:
         raise ValueError(
             "Kaiser-Bessel Derived windows are only defined for symmetric "
-            "shapes")
+            "shapes"
+        )
     elif M < 1:
         return np.array([])
     elif M % 2:

--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -1236,6 +1236,10 @@ def kaiser_bessel_derived(M, beta, *, sym=True):
     w : ndarray
         The window, normalized to fulfil the Princen-Bradley condition.
 
+    See Also
+    --------
+    kaiser
+
     Notes
     -----
     It is designed to be suitable for use with the modified discrete cosine

--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -1263,14 +1263,17 @@ def kaiser_bessel_derived(M, beta, *, sym=True):
     >>> from scipy import signal
     >>> import matplotlib.pyplot as plt
     >>> fig, ax = plt.subplots()
-    >>> N = 100
+    >>> N = 50
     >>> for alpha in [0.64, 2.55, 7.64, 31.83]:
-    ...     ax.plot(signal.windows.kaiser_bessel_derived(N, alpha),
+    ...     ax.plot(signal.windows.kaiser_bessel_derived(2*N, np.pi*alpha),
     ...             label=f"{alpha=}")
     >>> ax.grid(True)
     >>> ax.set_title("Kaiser-Bessel derived window")
     >>> ax.set_ylabel("Amplitude")
     >>> ax.set_xlabel("Sample")
+    >>> ax.set_xticks([0, N, 2*N-1])
+    >>> ax.set_xticklabels(["0", "N", "2N+1"])
+    >>> ax.set_yticks([0.0, 0.2, 0.4, 0.6, 0.707, 0.8, 1.0])
     >>> fig.legend(loc="center")
     >>> fig.tight_layout()
     >>> fig.show()

--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -1250,13 +1250,15 @@ def kaiser_bessel_derived(M, beta, *, sym=True):
 
     References
     ----------
-    .. [1] Wikipedia, "Kaiser window",
+    .. [1] Bosi, Marina, and Richard E. Goldberg. Introduction to Digital
+           Audio Coding and Standards. Dordrecht: Kluwer, 2003.
+    .. [2] Wikipedia, "Kaiser window",
            https://en.wikipedia.org/wiki/Kaiser_window
 
     Examples
     --------
     Plot the Kaiser-Bessel derived window based on the wikipedia
-    reference [1]_:
+    reference [2]_:
 
     >>> from scipy import signal
     >>> import matplotlib.pyplot as plt

--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -1272,7 +1272,7 @@ def kaiser_bessel_derived(M, beta, *, sym=True):
     >>> ax.set_ylabel("Amplitude")
     >>> ax.set_xlabel("Sample")
     >>> ax.set_xticks([0, N, 2*N-1])
-    >>> ax.set_xticklabels(["0", "N", "2N+1"])
+    >>> ax.set_xticklabels(["0", "N", "2N+1"])  # doctest: +SKIP
     >>> ax.set_yticks([0.0, 0.2, 0.4, 0.6, 0.707, 0.8, 1.0])
     >>> fig.legend(loc="center")
     >>> fig.tight_layout()


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
PR #4747

#### What does this implement/fix?
<!--Please explain your changes.-->
About 6 years ago, the [Kaiser-Bessel derived windows](https://en.wikipedia.org/wiki/Kaiser_window#Kaiser%E2%80%93Bessel-derived_(KBD)_window) function was tried to be added in #4747.
However, it is staled now unfortunately despite the window being commonly used in audio signal processing and audio coding.
So, I added the Kaiser-Bessel derived window function again based on the PR #4747.
