### PR TITLE
BUG: wrong value for Expn at x=0

### DIFF
--- a/scipy/special/cephes/expn.c
+++ b/scipy/special/cephes/expn.c
@@ -88,7 +88,7 @@ double expn(int n, double x)
     }
 
     if (x == 0.0) {
-	if (n < 2) {
+	if (n <= 1) {
 	    sf_error("expn", SF_ERROR_SINGULAR, NULL);
 	    return (NPY_INFINITY);
 	}


### PR DESCRIPTION
The current code returns inf for n<2 at x=0, while the value is only inf for n<=1.
 The range 1<n<2 has a finite value as well; see https://dlmf.nist.gov/8.19#E6.
