### PR TITLE
BUG: special: Fix loss of precision in pseudo_huber when r/delta is small.

### DIFF
--- a/scipy/special/_convex_analysis.pxd
+++ b/scipy/special/_convex_analysis.pxd
@@ -3,7 +3,7 @@ cdef extern from "numpy/npy_math.h":
     double nan "NPY_NAN"
     double inf "NPY_INFINITY"
 
-from libc.math cimport log, sqrt, fabs
+from libc.math cimport log, fabs, expm1, log1p
 
 cdef inline double entr(double x) nogil:
     if npy_isnan(x):
@@ -52,4 +52,8 @@ cdef inline double pseudo_huber(double delta, double r) nogil:
     else:
         u = delta
         v = r / delta
-        return u*u*(sqrt(1 + v*v) - 1)
+        # The formula is u*u*(sqrt(1 + v*v) - 1), but to maintain
+        # precision with small v, we use
+        #   sqrt(1 + v*v) - 1  =  exp(0.5*log(1 + v*v)) - 1
+        #                      =  expm1(0.5*log1p(v*v))
+        return u*u*expm1(0.5*log1p(v*v))

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -3600,3 +3600,16 @@ def test_pseudo_huber():
     z = np.array(np.random.randn(10, 2).tolist() + [[0, 0.5], [0.5, 0]])
     w = np.vectorize(xfunc, otypes=[np.float64])(z[:,0], z[:,1])
     assert_func_equal(special.pseudo_huber, w, z, rtol=1e-13, atol=1e-13)
+
+
+def test_pseudo_huber_small_r():
+    delta = 1.0
+    r = 1e-18
+    y = special.pseudo_huber(delta, r)
+    # expected computed with mpmath:
+    #     import mpmath
+    #     mpmath.mp.dps = 200
+    #     r = mpmath.mpf(1e-18)
+    #     expected = float(mpmath.sqrt(1 + r**2) - 1)
+    expected = 5.0000000000000005e-37
+    assert_allclose(y, expected, rtol=1e-13)


### PR DESCRIPTION
An example of the problem (included as a unit test) is `pseudo_huber(1.0, 1e-18)`.  Before this change, the function returned 0.  The correct value is 5.0000000000000005e-37.