### PR TITLE
MAINT: changed needed after renaming `master` branch to `main`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
               echo "Merging $(cat merge.txt)";
               git remote add upstream https://github.com/scipy/scipy.git;
               git pull --ff-only upstream "refs/pull/$(cat merge.txt)/merge";
-              git fetch upstream master;
+              git fetch upstream main;
             fi
 
       - run:
@@ -128,7 +128,7 @@ jobs:
           destination: html-benchmarks
 
 # Upload build output to scipy/devdocs repository, using SSH deploy keys.
-# The keys are only available for builds on master branch.
+# The keys are only available for builds on main branch.
 # https://developer.github.com/guides/managing-deploy-keys/
 # https://circleci.com/docs/2.0/configuration-reference/#add_ssh_keys
 
@@ -179,4 +179,4 @@ workflows:
             - build_docs
           filters:
             branches:
-              only: master
+              only: main

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,11 +1,11 @@
 name: Build Base Docker Image
 
-# Triggered only if environment.yml in master changes
+# Triggered only if environment.yml in main changes
 # Pushes a Docker image with all dev dependencies to Docker Hub
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - 'environment.yml'
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -3,11 +3,11 @@ name: Linux Tests
 on:
   push:
     branches:
-      - master
+      - main
       - maintenance/**
   pull_request:
     branches:
-      - master
+      - main
       - maintenance/**
 
 jobs:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -36,7 +36,7 @@ jobs:
         # this is taken verbatim from the numpy azure pipeline setup.
         set -xe
         # same version of gfortran as the open-libs and numpy-wheel builds
-        curl -L https://github.com/MacPython/gfortran-install/raw/main/archives/gfortran-4.9.0-Mavericks.dmg -o gfortran.dmg
+        curl -L https://github.com/MacPython/gfortran-install/raw/master/archives/gfortran-4.9.0-Mavericks.dmg -o gfortran.dmg
         GFORTRAN_SHA256=$(shasum -a 256 gfortran.dmg)
         KNOWN_SHA256="d2d5ca5ba8332d63bbe23a07201c4a0a5d7e09ee56f0298a96775f928c3c4b30  gfortran.dmg"
         if [ "$GFORTRAN_SHA256" != "$KNOWN_SHA256" ]; then

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -3,11 +3,11 @@ name: macOS tests
 on:
   push:
     branches:
-      - master
+      - main
       - maintenance/**
   pull_request:
     branches:
-      - master
+      - main
       - maintenance/**
 
 
@@ -36,7 +36,7 @@ jobs:
         # this is taken verbatim from the numpy azure pipeline setup.
         set -xe
         # same version of gfortran as the open-libs and numpy-wheel builds
-        curl -L https://github.com/MacPython/gfortran-install/raw/master/archives/gfortran-4.9.0-Mavericks.dmg -o gfortran.dmg
+        curl -L https://github.com/MacPython/gfortran-install/raw/main/archives/gfortran-4.9.0-Mavericks.dmg -o gfortran.dmg
         GFORTRAN_SHA256=$(shasum -a 256 gfortran.dmg)
         KNOWN_SHA256="d2d5ca5ba8332d63bbe23a07201c4a0a5d7e09ee56f0298a96775f928c3c4b30  gfortran.dmg"
         if [ "$GFORTRAN_SHA256" != "$KNOWN_SHA256" ]; then

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -44,11 +44,11 @@ vscode:
 # --------------------------------------------------------
 # using prebuilds for the container - note: atm this only
 # works for the SciPy repo
-# With this configuration the prebuild will happen on push to master 
+# With this configuration the prebuild will happen on push to main 
 github:
   prebuilds:
-    # enable for master branch
-    master: true
+    # enable for main branch
+    main: true
     # enable for other branches (defaults to false) 
     branches: false 
     # enable for pull requests coming from this repo (defaults to true) 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -5,20 +5,20 @@ SciPy pull request guidelines
 Pull requests are always welcome, and the SciPy community appreciates
 any help you give. Note that a code of conduct applies to all spaces
 managed by the SciPy project, including issues and pull requests:
-https://github.com/scipy/scipy/blob/master/doc/source/dev/conduct/code_of_conduct.rst.
+https://github.com/scipy/scipy/blob/main/doc/source/dev/conduct/code_of_conduct.rst.
 
 When submitting a pull request, we ask you check the following:
 
 1. **Unit tests**, **documentation**, and **code style** are in order.
    For details, please read
-   https://github.com/scipy/scipy/blob/master/HACKING.rst.txt.
+   https://github.com/scipy/scipy/blob/main/HACKING.rst.txt.
 
    It's also OK to submit work in progress if you're unsure of what
    this exactly means, in which case you'll likely be asked to make
    some further changes.
 
 2. The contributed code will be **licensed under SciPy's license**,
-   https://github.com/scipy/scipy/blob/master/LICENSE.txt.
+   https://github.com/scipy/scipy/blob/main/LICENSE.txt.
    If you did not write the code yourself, you ensure the existing
    license is compatible and include the license information in the
    contributed files, or obtain a permission from the original

--- a/HACKING.rst.txt
+++ b/HACKING.rst.txt
@@ -117,7 +117,7 @@ the requirements outlined above.  In many cases the code review happens
 relatively quickly, but it's possible that it stalls.  If you have addressed
 all feedback already given, it's perfectly fine to ask on the mailing list
 again for review (after a reasonable amount of time, say a couple of weeks, has
-passed).  Once the review is completed, the PR is merged into the "master"
+passed).  Once the review is completed, the PR is merged into the "main"
 branch of SciPy.
 
 The above describes the requirements and process for adding code to SciPy.  It

--- a/README.rst
+++ b/README.rst
@@ -7,13 +7,13 @@
       </h1>
     </p>
 
-.. image:: https://img.shields.io/circleci/project/github/scipy/scipy/master.svg?label=CircleCI
+.. image:: https://img.shields.io/circleci/project/github/scipy/scipy/main.svg?label=CircleCI
   :target: https://circleci.com/gh/scipy/scipy
 
-.. image:: https://dev.azure.com/scipy-org/SciPy/_apis/build/status/scipy.scipy?branchName=master
-  :target: https://dev.azure.com/scipy-org/SciPy/_build/latest?definitionId=1?branchName=master
+.. image:: https://dev.azure.com/scipy-org/SciPy/_apis/build/status/scipy.scipy?branchName=main
+  :target: https://dev.azure.com/scipy-org/SciPy/_build/latest?definitionId=1?branchName=main
 
-.. image:: https://github.com/scipy/scipy/workflows/macOS%20tests/badge.svg?branch=master
+.. image:: https://github.com/scipy/scipy/workflows/macOS%20tests/badge.svg?branch=main
   :target: https://github.com/scipy/scipy/actions?query=workflow%3A%22macOS+tests%22
 
 .. image:: https://img.shields.io/pypi/dm/scipy.svg?label=Pypi%20downloads
@@ -22,7 +22,7 @@
 .. image:: https://img.shields.io/conda/dn/conda-forge/scipy.svg?label=Conda%20downloads
   :target: https://anaconda.org/conda-forge/scipy
 
-.. image:: https://codecov.io/gh/scipy/scipy/branch/master/graph/badge.svg
+.. image:: https://codecov.io/gh/scipy/scipy/branch/main/graph/badge.svg
   :target: https://codecov.io/gh/scipy/scipy
 
 .. image:: https://img.shields.io/badge/stackoverflow-Ask%20questions-blue.svg

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -299,7 +299,7 @@ stages:
     # are the primary providers of the SciPy wheels available
     # on PyPI, so we now regularly test that the version of
     # _distributor_init.py in our wheels repo is capable of
-    # loading the DLLs from a main branch wheel build
+    # loading the DLLs from a master branch wheel build
     - powershell: |
         git clone -n --depth 1 https://github.com/MacPython/scipy-wheels.git
         cd scipy-wheels

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ trigger:
   batch: False
   branches:
     include:
-      - master
+      - main
       - maintenance/*
   paths:
     include:
@@ -129,7 +129,7 @@ stages:
         numpy_spec: "numpy==1.18.5"
         use_wheel: true
   - job: Lint
-    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))  # skip for PR merges
+    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/main'))  # skip for PR merges
     pool:
       vmImage: 'ubuntu-20.04'
     steps:
@@ -156,7 +156,7 @@ stages:
       displayName: 'Run Lint Checks'
       failOnStderr: true
   - job: Linux_Python_38_32bit_full
-    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))  # skip for PR merges
+    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/main'))  # skip for PR merges
     pool:
       vmImage: 'ubuntu-20.04'
     steps:
@@ -196,7 +196,7 @@ stages:
         summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
         reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
   - job: Windows
-    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))  # skip for PR merges
+    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/main'))  # skip for PR merges
     pool:
       vmImage: 'windows-latest'
     variables:
@@ -299,7 +299,7 @@ stages:
     # are the primary providers of the SciPy wheels available
     # on PyPI, so we now regularly test that the version of
     # _distributor_init.py in our wheels repo is capable of
-    # loading the DLLs from a master branch wheel build
+    # loading the DLLs from a main branch wheel build
     - powershell: |
         git clone -n --depth 1 https://github.com/MacPython/scipy-wheels.git
         cd scipy-wheels

--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -23,7 +23,7 @@ result)::
 
 Compare change in benchmark results with another branch::
 
-    python runtests.py --bench-compare master sparse.Arithmetic
+    python runtests.py --bench-compare main sparse.Arithmetic
 
 Run benchmarks against the system-installed SciPy rather than rebuild::
 

--- a/ci/azure-travis-template.yaml
+++ b/ci/azure-travis-template.yaml
@@ -141,14 +141,14 @@ steps:
       COVERAGE: '--coverage --gcov'
     ${{ if or(eq(parameters.use_wheel, true), eq(parameters.use_sdist, true))}}:
       USE_WHEEL_BUILD: '--no-build'
-  # Only run tests on master for the coverage build
+  # Only run tests on main for the coverage build
   ${{ if eq(parameters.coverage, false) }}:
-    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))  # skip for PR merges
+    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/main'))  # skip for PR merges
   displayName: 'Run tests'
-- ${{ if and(ne(variables['Build.SourceBranch'], 'refs/heads/master'), eq(parameters.refguide_check, true)) }}:
+- ${{ if and(ne(variables['Build.SourceBranch'], 'refs/heads/main'), eq(parameters.refguide_check, true)) }}:
   - script: python runtests.py -g --refguide-check
     displayName: 'Refguide Check'
-- ${{ if and(ne(variables['Build.SourceBranch'], 'refs/heads/master'), eq(parameters.asv_check, true)) }}:
+- ${{ if and(ne(variables['Build.SourceBranch'], 'refs/heads/main'), eq(parameters.asv_check, true)) }}:
   - script: |
       set -euo pipefail
       cd benchmarks
@@ -157,7 +157,7 @@ steps:
       ! SCIPY_ALLOW_BENCH_IMPORT_ERRORS=0 python -masv check -E existing > /dev/null
 - script: ./tools/check_pyext_symbol_hiding.sh build
   displayName: "Check dynamic symbol hiding works"
-  condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
+  condition: ne(variables['Build.SourceBranch'], 'refs/heads/main')
   failOnStderr: true
 - ${{ if eq(parameters.coverage, true) }}:
   - script: |

--- a/dev.py
+++ b/dev.py
@@ -155,7 +155,7 @@ def main(argv):
     if args.pep8:
         # Lint the source using the configuration in tox.ini.
         os.system("flake8 scipy benchmarks/benchmarks")
-        # Lint just the diff since branching off of master using a
+        # Lint just the diff since branching off of main using a
         # stricter configuration.
         lint_diff = os.path.join(ROOT_DIR, 'tools', 'lint_diff.py')
         os.system(lint_diff)

--- a/doc/release/1.0.0-notes.rst
+++ b/doc/release/1.0.0-notes.rst
@@ -387,7 +387,7 @@ Other changes
 
 SciPy now has a formal governance structure.  It consists of a BDFL (Pauli
 Virtanen) and a Steering Committee.  See `the governance document
-<https://github.com/scipy/scipy/blob/master/doc/source/dev/governance/governance.rst>`_
+<https://github.com/scipy/scipy/blob/main/doc/source/dev/governance/governance.rst>`_
 for details.
 
 It is now possible to build SciPy on Windows with MSVC + gfortran!  Continuous

--- a/doc/release/1.9.0-notes.rst
+++ b/doc/release/1.9.0-notes.rst
@@ -15,7 +15,7 @@ optimizations. Before upgrading, we recommend that users check that
 their own code does not use deprecated SciPy functionality (to do so,
 run your code with ``python -Wd`` and check for ``DeprecationWarning`` s).
 Our development attention will now shift to bug-fix releases on the
-1.9.x branch, and on adding new features on the master branch.
+1.9.x branch, and on adding new features on the main branch.
 
 This release requires Python 3.8+ and NumPy 1.17.3 or greater.
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -501,7 +501,7 @@ def linkcode_resolve(domain, info):
             return "https://github.com/scipy/scipy/blob/%s/%s%s" % (
                 m.group(1), fn, linespec)
         elif 'dev' in scipy.__version__:
-            return "https://github.com/scipy/scipy/blob/master/%s%s" % (
+            return "https://github.com/scipy/scipy/blob/main/%s%s" % (
                 fn, linespec)
         else:
             return "https://github.com/scipy/scipy/blob/v%s/%s%s" % (

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -71,7 +71,7 @@ templates_path = ['_templates']
 # The suffix of source filenames.
 source_suffix = '.rst'
 
-# The master toctree document.
+# The main toctree document.
 master_doc = 'index'
 
 # General substitutions.
@@ -187,7 +187,7 @@ html_theme_options = {
 
 if 'versionwarning' in tags:
     # Specific to docs.scipy.org deployment.
-    # See https://github.com/scipy/docs.scipy.org/blob/master/_static/versionwarning.js_t
+    # See https://github.com/scipy/docs.scipy.org/blob/main/_static/versionwarning.js_t
     src = ('var script = document.createElement("script");\n'
            'script.type = "text/javascript";\n'
            'script.src = "/doc/_static/versionwarning.js";\n'

--- a/doc/source/dev/contributor/adding_new/new_stats_distribution.rst.inc
+++ b/doc/source/dev/contributor/adding_new/new_stats_distribution.rst.inc
@@ -54,9 +54,9 @@ Implementation
 #. Find an already existing distribution similar to ``Squirrel``.
    Use its code as a template for ``Squirrel``.
 #. Read the docstring for class ``rv_continuous`` in
-   `scipy/stats/_distn_infrastructure.py <https://github.com/scipy/scipy/blob/master/scipy/stats/_distn_infrastructure.py#L1378>`_.
+   `scipy/stats/_distn_infrastructure.py <https://github.com/scipy/scipy/blob/main/scipy/stats/_distn_infrastructure.py#L1378>`_.
 #. Write the new code for class ``squirrel_gen`` and insert it into
-   `scipy/stats/_continuous_distns.py <https://github.com/scipy/scipy/blob/master/scipy/stats/_continuous_distns.py>`_,
+   `scipy/stats/_continuous_distns.py <https://github.com/scipy/scipy/blob/main/scipy/stats/_continuous_distns.py>`_,
    which is in (mostly) alphabetical order by distribution name.
 #. Does the distribution have infinite support? If not, left and/or right
    endpoints ``a``, ``b`` need to be specified in the call to ``squirrel_gen(name='squirrel', a=?, b=?)``.
@@ -70,17 +70,17 @@ Implementation
 #. If ``squirrel_gen.rvs()`` is expensive to compute, consider implementing a
    specific ``squirrel_gen._rvs()``.
 #. Add the name to the listing in the docstring of
-   `scipy/stats/__init__.py <https://github.com/scipy/scipy/blob/master/scipy/stats/__init__.py>`_.
+   `scipy/stats/__init__.py <https://github.com/scipy/scipy/blob/main/scipy/stats/__init__.py>`_.
 #. Add the name and a good set of example shape parameters to the ``distcont``
    list in
-   `scipy/stats/_distr_params.py <https://github.com/scipy/scipy/blob/master/scipy/stats/_distr_params.py#L5>`_.
+   `scipy/stats/_distr_params.py <https://github.com/scipy/scipy/blob/main/scipy/stats/_distr_params.py#L5>`_.
    These shape parameters are used both for testing and automatic documentation generation.
 #. Add the name and an _invalid_ set of example shape parameters to the
    list in ``invdistcont``, also in
-   `_distr_params.py <https://github.com/scipy/scipy/blob/master/scipy/stats/_distr_params.py>`_.
+   `_distr_params.py <https://github.com/scipy/scipy/blob/main/scipy/stats/_distr_params.py>`_.
    These shape parameters are also used for testing.
 #. Add a ``TestSquirrel`` class and any specific tests to
-   `scipy/stats/tests/test_distributions.py <https://github.com/scipy/scipy/blob/master/scipy/stats/tests/test_distributions.py>`_.
+   `scipy/stats/tests/test_distributions.py <https://github.com/scipy/scipy/blob/main/scipy/stats/tests/test_distributions.py>`_.
 #. Run and pass(!) the tests.
 
 After Implementation
@@ -88,9 +88,9 @@ After Implementation
 
 #. Add a tutorial ``doc/source/tutorial/stats/continuous_squirrel.rst``
 #. Add it to the listing of continuous distributions in
-   `doc/source/tutorial/stats/continuous.rst <https://github.com/scipy/scipy/blob/master/doc/source/tutorial/stats/continuous.rst>`_.
+   `doc/source/tutorial/stats/continuous.rst <https://github.com/scipy/scipy/blob/main/doc/source/tutorial/stats/continuous.rst>`_.
 #. Update the ``number of continuous distributions`` in the example code in
-   `doc/source/tutorial/stats.rst <https://github.com/scipy/scipy/blob/master/doc/source/tutorial/stats.rst>`_.
+   `doc/source/tutorial/stats.rst <https://github.com/scipy/scipy/blob/main/doc/source/tutorial/stats.rst>`_.
 #. Build the documentation successfully.
 #. Submit a PR.
 

--- a/doc/source/dev/contributor/benchmarking.rst
+++ b/doc/source/dev/contributor/benchmarking.rst
@@ -173,12 +173,12 @@ check out the ``asv find`` command and the ``--quick``,
 .. _Benchmarking SciPy: https://youtu.be/edLQ8KRpupQ
 .. _airspeed velocity (asv) documentation: https://asv.readthedocs.io/en/stable/
 .. _airspeed velocity of an unladen scipy: https://pv.github.io/scipy-bench/
-.. _SciPy benchmarks readme: https://github.com/scipy/scipy/blob/master/benchmarks/README.rst
+.. _SciPy benchmarks readme: https://github.com/scipy/scipy/blob/main/benchmarks/README.rst
 .. _Klee-Minty hypercube problem: https://en.wikipedia.org/wiki/Klee%E2%80%93Minty_cube
 .. _KleeMinty.time_klee_minty: https://pv.github.io/scipy-bench/#optimize_linprog.KleeMinty.time_klee_minty
 
 .. |optimize-linprog-py| replace:: ``scipy/benchmarks/benchmarks/optimize_linprog.py``
-.. _optimize-linprog-py: https://github.com/scipy/scipy/blob/master/benchmarks/benchmarks/optimize_linprog.py
+.. _optimize-linprog-py: https://github.com/scipy/scipy/blob/main/benchmarks/benchmarks/optimize_linprog.py
 
 .. |7fa17f2369e0e5ad055b23cc1a5ee079f9e8ca32| replace:: ``7fa17f2369e0e5ad055b23cc1a5ee079f9e8ca32``
 .. _7fa17f2369e0e5ad055b23cc1a5ee079f9e8ca32: https://github.com/scipy/scipy/commit/7fa17f2369e0e5ad055b23cc1a5ee079f9e8ca32

--- a/doc/source/dev/contributor/benchmarking.rst
+++ b/doc/source/dev/contributor/benchmarking.rst
@@ -112,9 +112,9 @@ To run a benchmark defined in a class, such as ``KleeMinty`` from
    python runtests.py --bench optimize_linprog.KleeMinty
 
 To compare benchmark results between the active branch and another, such
-as ``master``::
+as ``main``::
 
-   python runtests.py --bench-compare master optimize_linprog.KleeMinty
+   python runtests.py --bench-compare main optimize_linprog.KleeMinty
 
 All of the commands above display the results in plain text in the
 console, and the results are not saved for comparison with future

--- a/doc/source/dev/contributor/cython.rst
+++ b/doc/source/dev/contributor/cython.rst
@@ -185,20 +185,20 @@ the alternative is many low-level operations in Python.
 .. _cimport: https://cython.readthedocs.io/en/latest/src/userguide/sharing_declarations.html
 
 .. |cdef| replace:: ``cdef``
-.. _cdef: https://github.com/scipy/scipy/blob/master/scipy/optimize/setup.py
+.. _cdef: https://github.com/scipy/scipy/blob/main/scipy/optimize/setup.py
 
 .. _Cython decorators: https://cython.readthedocs.io/en/latest/src/userguide/numpy_tutorial.html
 
 .. |linprog-rs| replace:: ``scipy.optimize._linprog_rs.py``
-.. _linprog-rs: https://github.com/scipy/scipy/blob/master/scipy/optimize/_linprog_rs.py
+.. _linprog-rs: https://github.com/scipy/scipy/blob/main/scipy/optimize/_linprog_rs.py
 
 .. |bglu-dense| replace:: ``/scipy/optimize/_bglu_dense.pyx``
-.. _bglu-dense: https://github.com/scipy/scipy/blob/master/scipy/optimize/_bglu_dense.pyx
+.. _bglu-dense: https://github.com/scipy/scipy/blob/main/scipy/optimize/_bglu_dense.pyx
 
 .. |distutils| replace:: ``numpy.distutils``
 .. _distutils: https://docs.scipy.org/doc/numpy/reference/distutils.html
 
 .. |optimize-setup| replace:: ``scipy/optimize/setup.py``
-.. _optimize-setup: https://github.com/scipy/scipy/blob/master/scipy/optimize/setup.py
+.. _optimize-setup: https://github.com/scipy/scipy/blob/main/scipy/optimize/setup.py
 
 .. _Cythonizing SciPy Code: https://youtu.be/K9bF7cjUJ7c

--- a/doc/source/dev/contributor/development_workflow.rst
+++ b/doc/source/dev/contributor/development_workflow.rst
@@ -308,7 +308,7 @@ Checklist before submitting a PR
 .. _the wiki: https://github.com/scipy/scipy/wiki
 
 .. |differential_evolution| replace:: ``differential_evolution``
-.. _differential_evolution: https://github.com/scipy/scipy/blob/master/scipy/optimize/_differentialevolution.py
+.. _differential_evolution: https://github.com/scipy/scipy/blob/main/scipy/optimize/_differentialevolution.py
 
 .. |setup.py| replace:: ``setup.py``
-.. _setup.py: https://github.com/scipy/scipy/blob/master/setup.py
+.. _setup.py: https://github.com/scipy/scipy/blob/main/setup.py

--- a/doc/source/dev/contributor/development_workflow.rst
+++ b/doc/source/dev/contributor/development_workflow.rst
@@ -81,30 +81,30 @@ commits from the ``upstream`` repository::
 
    git fetch upstream
 
-Then, create a new branch based on the master branch of the upstream
+Then, create a new branch based on the main branch of the upstream
 repository::
 
-   git checkout -b my-new-feature upstream/master
+   git checkout -b my-new-feature upstream/main
 
-Equivalently, you might want to keep the master branch of your own repository
+Equivalently, you might want to keep the main branch of your own repository
 up to date and create a new branch based on that::
 
-   git checkout master
-   git rebase upstream/master
+   git checkout main
+   git rebase upstream/main
    git checkout -b my-new-feature
 
 In order, these commands
 
-#. ensure that the ``master`` branch of your local repository is checked out,
+#. ensure that the ``main`` branch of your local repository is checked out,
 
-#. apply all the latest changes from the ``upstream/master`` (main SciPy
-   repository master branch) to your local ``master`` branch, and
+#. apply all the latest changes from the ``upstream/main`` (main SciPy
+   repository main branch) to your local ``main`` branch, and
 
-#. create and check out a new branch (``-b``) based on your local ``master``
+#. create and check out a new branch (``-b``) based on your local ``main``
    branch.
 
 In any case, it's important that your feature branch include the latest
-changes from the upstream master to help avoid
+changes from the upstream main to help avoid
 `merge conflicts <https://help.github.com/en/articles/resolving-a-merge-conflict-using-the-command-line>`_
 when it's time to submit a pull request.
 
@@ -211,7 +211,7 @@ In more detail
 
 It may be the case that while you were working on your edits, new commits have
 been added to ``upstream`` that affect your work. In this case, follow the
-:ref:`rebasing-on-master` instructions to apply those changes to your branch.
+:ref:`rebasing-on-main` instructions to apply those changes to your branch.
 
 .. _writing-the-commit-message:
 

--- a/doc/source/dev/contributor/meson.rst
+++ b/doc/source/dev/contributor/meson.rst
@@ -42,9 +42,9 @@ suite::
 Full details and explanation
 ============================
 
-To build SciPy, we need the SciPy ``master`` branch. Note that further work
+To build SciPy, we need the SciPy ``main`` branch. Note that further work
 on Meson integration is being done in the ``meson`` branch from ``@rgommers``'s
-fork. We stay with SciPy master here::
+fork. We stay with SciPy ``main`` here::
 
   git clone git@github.com:scipy/scipy.git
   git submodule update --init
@@ -102,7 +102,7 @@ running the tests should also work, for example::
 Current status (24 Dec '21) is that the full test suite passes on Linux, macOS
 and Windows with OpenBLAS, without any build warnings on Linux (with GCC 9 at
 least) and a moderate amount on the other platforms. There is CI (one job in
-SciPy master, and more on ``@rgommers``'s fork) to keep it that way.
+SciPy ``main``, and more on ``@rgommers``'s fork) to keep it that way.
 The current status is already good enough to work on both build related issues
 (e.g. build warnings, debugging some C/C++ extension) and on general SciPy
 development. It is already a much smoother/faster experience than

--- a/doc/source/dev/contributor/runtests.rst
+++ b/doc/source/dev/contributor/runtests.rst
@@ -126,7 +126,7 @@ They can be enabled by setting the environment variable ``SCIPY_XSLOW=1``
 before running the test suite.
 
 .. |runtests-py| replace:: ``runtests.py``
-.. _runtests-py: https://github.com/scipy/scipy/blob/master/runtests.py
+.. _runtests-py: https://github.com/scipy/scipy/blob/main/runtests.py
 
 .. |pytest-cov| replace:: ``pytest-cov``
 .. _pytest-cov: https://pypi.org/project/pytest-cov/
@@ -142,4 +142,4 @@ before running the test suite.
 .. _pytest: https://docs.pytest.org/en/latest/
 
 .. |test-linprog| replace:: ``scipy/optimize/tests/test_linprog.py``
-.. _test-linprog: https://github.com/scipy/scipy/blob/master/scipy/optimize/tests/test_linprog.py
+.. _test-linprog: https://github.com/scipy/scipy/blob/main/scipy/optimize/tests/test_linprog.py

--- a/doc/source/dev/core-dev/github.rst.inc
+++ b/doc/source/dev/core-dev/github.rst.inc
@@ -42,7 +42,7 @@ Dealing with pull requests
 
 - When merging contributions, a committer is responsible for ensuring that
   those meet the requirements outlined in `Contributing to SciPy
-  <https://github.com/scipy/scipy/blob/master/HACKING.rst.txt>`_. Also check
+  <https://github.com/scipy/scipy/blob/main/HACKING.rst.txt>`_. Also check
   that new features and backwards compatibility breaks were discussed on the
   scipy-dev mailing list.
 - New code goes in via a pull request (PR).

--- a/doc/source/dev/core-dev/github.rst.inc
+++ b/doc/source/dev/core-dev/github.rst.inc
@@ -68,7 +68,7 @@ Dealing with pull requests
 Backporting
 -----------
 All pull requests (whether they contain enhancements, bug fixes or something else),
-should be made against master.  Only bug fixes are candidates for backporting
+should be made against main.  Only bug fixes are candidates for backporting
 to a maintenance branch.  The backport strategy for SciPy is to (a) only backport
 fixes that are important, and (b) to only backport when it's reasonably sure
 that a new bugfix release on the relevant maintenance branch will be made.
@@ -77,10 +77,10 @@ Typically, the developer who merges an important bugfix adds the
 whether and when the backport is done.  After the backport is completed, the
 ``backport-candidate`` label has to be removed again.
 
-A good strategy for a backport pull request is to combine several master
+A good strategy for a backport pull request is to combine several main
 branch pull requests, to reduce the burden on continuous integration tests
 and to reduce the merge commit cluttering of maintenance branch history. It
-is generally best to have a single commit for each of the master branch pull
+is generally best to have a single commit for each of the main branch pull
 requests represented in the backport pull request. This way, history is clear
 and can be reverted in a straightforward manner if needed.
 

--- a/doc/source/dev/core-dev/releasing.rst.inc
+++ b/doc/source/dev/core-dev/releasing.rst.inc
@@ -12,7 +12,7 @@ SciPy version:
 #. Build all release artifacts (sources, installers, docs).
 #. Upload the release artifacts.
 #. Announce the release.
-#. Port relevant changes to release notes and build scripts to master.
+#. Port relevant changes to release notes and build scripts to main.
 
 In this guide we attempt to describe in detail how to perform each of the above
 steps.  In addition to those steps, which have to be performed by the release
@@ -44,7 +44,7 @@ Bug-fix versions don't need a beta or RC, and can be done much quicker.
 Ideally the final release is identical to the last RC, however there may be
 minor difference - it's up to the release manager to judge the risk of that.
 Typically, if compiled code or complex pure Python code changes then a new RC
-is needed, while a simple bug-fix that's backported from master doesn't require
+is needed, while a simple bug-fix that's backported from main doesn't require
 a new RC.
 
 To propose a schedule, send a list with estimated dates for branching and
@@ -62,13 +62,13 @@ release notes.
 Maintenance branches are named ``maintenance/<major>.<minor>.x`` (e.g. 0.19.x).
 To create one, simply push a branch with the correct name to the scipy repo.
 Immediately after, push a commit where you increment the version number on the
-master branch and add release notes for that new version.  Send an email to
+main branch and add release notes for that new version.  Send an email to
 scipy-dev to let people know that you've done this.
 
 
 Updating upper bounds of dependencies
 -------------------------------------
-In master we do not set upper bounds, because we want to test new releases or
+In main we do not set upper bounds, because we want to test new releases or
 development versions of dependencies there. In a maintenance branch however,
 the goal is to be able to create releases that stay working for years. Hence
 correct upper bounds must be set. The following places must be updated after
@@ -244,4 +244,4 @@ and test against their own code) and report issues on Github or scipy-dev.
 
 After the final release is done, port relevant changes to release notes, build
 scripts, author name mapping in ``tools/authors.py`` and any other changes that
-were only made on the maintenance branch to master.
+were only made on the maintenance branch to main.

--- a/doc/source/dev/gitwash/development_setup.rst
+++ b/doc/source/dev/gitwash/development_setup.rst
@@ -76,11 +76,11 @@ Clone your fork
    ``git branch -a`` to show you all branches.  You'll get something
    like::
 
-      * master
-      remotes/origin/master
+      * main
+      remotes/origin/main
 
-   This tells you that you are currently on the ``master`` branch, and
-   that you also have a ``remote`` connection to ``origin/master``.
+   This tells you that you are currently on the ``main`` branch, and
+   that you also have a ``remote`` connection to ``origin/main``.
    What remote repository is ``remote/origin``? Try ``git remote -v`` to
    see the URLs for the remote.  They will point to your github_ fork.
 
@@ -111,8 +111,8 @@ Just for your own satisfaction, show yourself that you now have a new
 To keep in sync with changes in SciPy, you want to set up your repository
 so it pulls from ``upstream`` by default.  This can be done with::
 
-   git config branch.master.remote upstream
-   git config branch.master.merge refs/heads/master
+   git config branch.main.remote upstream
+   git config branch.main.merge refs/heads/main
 
 Your config file should now look something like (from
 ``$ cat .git/config``)::
@@ -130,8 +130,8 @@ Your config file should now look something like (from
    [remote "upstream"]
            url = https://github.com/scipy/scipy.git
            fetch = +refs/heads/*:refs/remotes/upstream/*
-   [branch "master"]
+   [branch "main"]
            remote = upstream
-           merge = refs/heads/master
+           merge = refs/heads/main
 
 .. include:: git_links.inc

--- a/doc/source/dev/gitwash/dot2_dot3.rst
+++ b/doc/source/dev/gitwash/dot2_dot3.rst
@@ -5,22 +5,22 @@ Two and three dots in difference specs
 ======================================
 
 Imagine a series of commits A, B, C, D...  Imagine that there are two
-branches, *topic* and *master*.  You branched *topic* off *master* when
-*master* was at commit 'E'.  The graph of the commits looks like this::
+branches, *topic* and *main*.  You branched *topic* off *main* when
+*main* was at commit 'E'.  The graph of the commits looks like this::
 
 
         A---B---C topic
         /
-   D---E---F---G master
+   D---E---F---G main
 
 Then::
 
-   git diff master..topic
+   git diff main..topic
 
 will output the difference from G to C (i.e. with effects of F and G),
 while::
 
-   git diff master...topic
+   git diff main...topic
 
 would output just differences in the topic branch (i.e. only A, B, and
 C).

--- a/doc/source/dev/gitwash/git_links.inc
+++ b/doc/source/dev/gitwash/git_links.inc
@@ -47,7 +47,7 @@
 .. _ipython git workflow: https://mail.python.org/pipermail/ipython-dev/2010-October/005632.html
 .. _git parable: http://tom.preston-werner.com/2009/05/19/the-git-parable.html
 .. _git foundation: http://matthew-brett.github.com/pydagogue/foundation.html
-.. _numpy/master: https://github.com/numpy/numpy
+.. _numpy/main: https://github.com/numpy/numpy
 .. _git cherry-pick: https://www.kernel.org/pub/software/scm/git/docs/git-cherry-pick.html
 .. _git blame: https://www.kernel.org/pub/software/scm/git/docs/git-blame.html
 .. _this blog post: https://github.com/blog/612-introducing-github-compare-view

--- a/doc/source/dev/gitwash/useful_git.rst
+++ b/doc/source/dev/gitwash/useful_git.rst
@@ -4,10 +4,10 @@
 Git tips
 ========
 
-.. _rebasing-on-master:
+.. _rebasing-on-main:
 
-Rebasing on master
-------------------
+Rebasing on main
+----------------
 
 This updates your feature branch with changes from the upstream `SciPy
 github`_ repo. If you do not absolutely need to do this, try to avoid doing
@@ -22,8 +22,8 @@ Next, you need to update the feature branch::
    git checkout my-new-feature
    # make a backup in case you mess up
    git branch tmp my-new-feature
-   # rebase on upstream master branch
-   git rebase upstream/master
+   # rebase on upstream main branch
+   git rebase upstream/main
 
 If you have made changes to files that have changed also upstream,
 this may generate merge conflicts that you need to resolve. See
@@ -36,7 +36,7 @@ Finally, remove the backup branch upon a successful rebase::
 
 .. note::
 
-   Rebasing on master is preferred over merging upstream back to your
+   Rebasing on main is preferred over merging upstream back to your
    branch. Using ``git merge`` and ``git pull`` is discouraged when
    working on feature branches.
 
@@ -99,7 +99,7 @@ Suppose that the commit history looks like this::
     29001ed Add pre-nep for a copule of structured_array_extensions.
     ...
 
-and ``6ad92e5`` is the last commit in the ``master`` branch. Suppose we
+and ``6ad92e5`` is the last commit in the ``main`` branch. Suppose we
 want to make the following changes:
 
 * Rewrite the commit message for ``13d7934`` to something more sensible.
@@ -166,7 +166,7 @@ Deleting a branch on github_
 
 ::
 
-   git checkout master
+   git checkout main
    # delete branch locally
    git branch -D my-unwanted-branch
    # delete branch on github
@@ -225,25 +225,25 @@ Backporting
 -----------
 
 Backporting is the process of copying new feature/fixes committed in
-`scipy/master`_ back to stable release branches. To do this you make a branch
+`scipy/main`_ back to stable release branches. To do this you make a branch
 off the branch you are backporting to, cherry pick the commits you want from
-``scipy/master``, and then submit a pull request for the branch containing the
+``scipy/main``, and then submit a pull request for the branch containing the
 backport.
 
 1. First, you need to make the branch you will work on. This needs to be
-   based on the older version of SciPy (not master)::
+   based on the older version of SciPy (not main)::
 
     # Make a new branch based on scipy/maintenance/1.8.x,
     # backport-3324 is our new name for the branch.
     git checkout -b backport-3324 upstream/maintenance/1.8.x
 
-2. Now you need to apply the changes from master to this branch using
+2. Now you need to apply the changes from main to this branch using
    `git cherry-pick`_::
 
     # Update remote
     git fetch upstream
     # Check the commit log for commits to cherry pick
-    git log upstream/master
+    git log upstream/main
     # This pull request included commits aa7a047 to c098283 (inclusive)
     # so you use the .. syntax (for a range of commits), the ^ makes the
     # range inclusive.
@@ -254,7 +254,7 @@ backport.
 
 3. You might run into some conflicts cherry picking here. These are
    resolved the same way as merge/rebase conflicts. Except here you can
-   use `git blame`_ to see the difference between master and the
+   use `git blame`_ to see the difference between main and the
    backported branch to make sure nothing gets screwed up.
 
 4. Push the new branch to your Github repository::
@@ -262,8 +262,8 @@ backport.
     git push -u origin backport-3324
 
 5. Finally make a pull request using Github. Make sure it is against the
-   maintenance branch and not master, Github will usually suggest you
-   make the pull request against master.
+   maintenance branch and not main, Github will usually suggest you
+   make the pull request against main.
 
 .. _pushing-to-main:
 
@@ -273,7 +273,7 @@ Pushing changes to the main repo
 *This is only relevant if you have commit rights to the main SciPy repo.*
 
 When you have a set of "ready" changes in a feature branch ready for
-SciPy's ``master`` or ``maintenance`` branches, you can push
+SciPy's ``main`` or ``maintenance`` branches, you can push
 them to ``upstream`` as follows:
 
 1. First, merge or rebase on the target branch.
@@ -281,23 +281,23 @@ them to ``upstream`` as follows:
    a) Only a few, unrelated commits then prefer rebasing::
 
         git fetch upstream
-        git rebase upstream/master
+        git rebase upstream/main
 
-      See :ref:`rebasing-on-master`.
+      See :ref:`rebasing-on-main`.
 
    b) If all of the commits are related, create a merge commit::
 
         git fetch upstream
-        git merge --no-ff upstream/master
+        git merge --no-ff upstream/main
 
 2. Check that what you are going to push looks sensible::
 
-        git log -p upstream/master..
+        git log -p upstream/main..
         git log --oneline --graph
 
 3. Push to upstream::
 
-        git push upstream my-feature-branch:master
+        git push upstream my-feature-branch:main
 
 .. note::
 
@@ -305,6 +305,6 @@ them to ``upstream`` as follows:
     first that you're about to push the changes you want to the place you
     want.
 
-.. _scipy/master: https://github.com/scipy/scipy
+.. _scipy/main: https://github.com/scipy/scipy
 
 .. include:: git_links.inc

--- a/doc/source/dev/governance/people.rst
+++ b/doc/source/dev/governance/people.rst
@@ -52,4 +52,4 @@ None currently
 Document history
 ----------------
 
-https://github.com/scipy/scipy/commits/master/doc/source/dev/governance/people.rst
+https://github.com/scipy/scipy/commits/main/doc/source/dev/governance/people.rst

--- a/doc/source/dev/roadmap-detailed.rst
+++ b/doc/source/dev/roadmap-detailed.rst
@@ -61,7 +61,7 @@ Making this easier is a priority.
 
 Moving to the Meson build system
 ````````````````````````````````
-Support for the Meson build system was merged into SciPy master in Dec 2021.
+Support for the Meson build system was merged into SciPy main in Dec 2021.
 This significantly improves build performance, and will fix multiple issues
 (e.g., our issues with Windows compilers, cross-compilation support). The aim
 is to make it the default build system for SciPy 1.9.0, and then remove support

--- a/pavement.py
+++ b/pavement.py
@@ -72,7 +72,7 @@ RELEASE = 'doc/release/1.9.0-notes.rst'
 
 # Start/end of the log (from git)
 LOG_START = 'v1.8.0'
-LOG_END = 'master'
+LOG_END = 'main'
 
 
 #-------------------------------------------------------

--- a/runtests.py
+++ b/runtests.py
@@ -141,7 +141,7 @@ def main(argv):
     if args.pep8:
         # Lint the source using the configuration in tox.ini.
         os.system("flake8 scipy benchmarks/benchmarks")
-        # Lint just the diff since branching off of master using a
+        # Lint just the diff since branching off of main using a
         # stricter configuration.
         lint_diff = os.path.join(ROOT_DIR, 'tools', 'lint_diff.py')
         os.system(lint_diff)

--- a/tools/cythonize.py
+++ b/tools/cythonize.py
@@ -82,7 +82,7 @@ def process_pyx(fromfile, tofile, cwd):
 
         # Note: we only check lower bound, for upper bound we rely on pip
         # respecting pyproject.toml. Reason: we want to be able to build/test
-        # with more recent Cython locally or on master, upper bound is for
+        # with more recent Cython locally or on main, upper bound is for
         # sdist in a release.
         if _pep440.parse(cython_version) < _pep440.Version(min_required_version):
             raise Exception('Building SciPy requires Cython >= {}, found '

--- a/tools/lint_diff.py
+++ b/tools/lint_diff.py
@@ -41,9 +41,9 @@ def find_branch_point(branch):
 
     """
     branch_commits = rev_list('HEAD', 1000)
-    master_commits = set(rev_list(branch, 1000))
+    main_commits = set(rev_list(branch, 1000))
     for branch_commit in branch_commits:
-        if branch_commit in master_commits:
+        if branch_commit in main_commits:
             return branch_commit
 
     # If a branch split off over 1000 commits ago we will fail to find
@@ -82,7 +82,7 @@ def run_flake8(diff):
 
 def main():
     parser = ArgumentParser()
-    parser.add_argument("--branch", type=str, default='master',
+    parser.add_argument("--branch", type=str, default='main',
                         help="The branch to diff against")
     parser.add_argument("--files", type=str, nargs='+', default=None,
                         help="The files or directories to diff against")

--- a/tools/validate_runtests_log.py
+++ b/tools/validate_runtests_log.py
@@ -11,7 +11,7 @@ command, which (i) aborts the py process so that runtests.py does not finish,
 and (ii) the exit code is implementation-defined.
 
 Also check that the number of tests run is larger than some baseline number
-(taken from the state of the master branch at some random point in time.)
+(taken from the state of the main branch at some random point in time.)
 This probably could/should be made less brittle.
 
 """


### PR DESCRIPTION
This is for after @rgommers renames the master branch main.