### PR TITLE
Resolve conflict with pypy aarch64 (v1.7.x)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,8 @@ requires = [
 
     # numpy 1.19 was the first minor release to provide aarch64 wheels, but
     # wheels require fixes contained in numpy 1.19.2
-    "numpy==1.19.2; python_version=='3.7' and platform_machine=='aarch64'",
-    "numpy==1.19.2; python_version=='3.8' and platform_machine=='aarch64'",
+    "numpy==1.19.2; python_version=='3.7' and platform_machine=='aarch64' and platform_python_implementation != 'PyPy'",
+    "numpy==1.19.2; python_version=='3.8' and platform_machine=='aarch64' and platform_python_implementation != 'PyPy'",
     # aarch64 for py39 is covered by default requirement below
 
     # default numpy requirements


### PR DESCRIPTION
This is a patch for v1.7.x.

There are some conflict dependency when install scipy in pypy aarch64, this is just a patch to sync oldest-supported-numpy version. https://github.com/scipy/oldest-supported-numpy/pull/40

#### Reference issue
Closes: https://github.com/scipy/scipy/issues/15316

#### What does this implement/fix?
Resolve conflict with pypy aarch64

#### Additional information
Related: https://github.com/scipy/oldest-supported-numpy/pull/40
