### PR TITLE
BLD: update pyproject.toml to not pin numpy for aarch64 + PyPy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ requires = [
 
     # numpy 1.19 was the first minor release to provide aarch64 wheels, but
     # wheels require fixes contained in numpy 1.19.2
-    "numpy==1.19.2; python_version=='3.8' and platform_machine=='aarch64'",
+    "numpy==1.19.2; python_version=='3.8' and platform_machine=='aarch64' and platform_python_implementation != 'PyPy'",
     # aarch64 for py39 is covered by default requirement below
 
     # arm64 on Darwin supports Python 3.8 and above requires numpy>=1.20.0


### PR DESCRIPTION
#### Reference issue
Closes: https://github.com/scipy/scipy/issues/15316

#### What does this implement/fix?
Add 'platform_python_implementation ' limit on `"numpy==1.19.2; python_version=='3.8' and platform_machine=='aarch64'",`

#### Additional information
Related: https://github.com/scipy/oldest-supported-numpy/pull/40
