### PR TITLE
Improved documentation on bartlett window on scipy.org

### DIFF
--- a/scipy/signal/windows/bartlett_doc
+++ b/scipy/signal/windows/bartlett_doc
@@ -1,0 +1,22 @@
+import numpy as np   
+import matplotlib.pyplot as plt
+from scipy import signal
+from scipy.fft import fft, fftshift
+
+
+
+window = signal.windows.bartlett(51)
+plt.plot(window)
+plt.title("Bartlett window")
+plt.ylabel("Amplitude")
+plt.xlabel("Sample")
+
+plt.figure()
+A = fft(window, 2048) / (len(window)/2.0)
+freq = np.linspace(-0.5, 0.5, len(A))
+response = 20 * np.log10(np.abs(fftshift(A / abs(A).max())))
+plt.plot(freq, response)
+plt.axis([-0.5, 0.5, -120, 0])
+plt.title("Frequency response of the Bartlett window")
+plt.ylabel("Normalized magnitude [dB]")
+plt.xlabel("Normalized frequency [cycles per sample]")


### PR DESCRIPTION
Improved documentation on bartlett window 
https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.windows.bartlett.html#scipy.signal.windows.bartlett
was missing 'import numpy as np'


