### PR TITLE
Improved documentation on barthann window 

### DIFF
--- a/scipy/signal/windows/barthann_doc
+++ b/scipy/signal/windows/barthann_doc
@@ -1,0 +1,20 @@
+import numpy as np
+from scipy import signal
+from scipy.fft import fft, fftshift
+import matplotlib.pyplot as plt
+
+window = signal.windows.barthann(51)
+plt.plot(window)
+plt.title("Bartlett-Hann window")
+plt.ylabel("Amplitude")
+plt.xlabel("Sample")
+
+plt.figure()
+A = fft(window, 2048) / (len(window)/2.0)
+freq = np.linspace(-0.5, 0.5, len(A))
+response = 20 * np.log10(np.abs(fftshift(A / abs(A).max())))
+plt.plot(freq, response)
+plt.axis([-0.5, 0.5, -120, 0])
+plt.title("Frequency response of the Bartlett-Hann window")
+plt.ylabel("Normalized magnitude [dB]")
+plt.xlabel("Normalized frequency [cycles per sample]")


### PR DESCRIPTION
Improved documentation on barthann window on scipy.org 
was missing 'import numpy as np'

All examples on scipy.org are missing 'import numpy as np' .. 
Might be obvious but still unnecessarily confusing for beginners. 


