### PR TITLE
BLD: update minimum Pythran version to 0.10.0 for SciPy 1.8.0

### DIFF
--- a/doc/source/building/windows.rst
+++ b/doc/source/building/windows.rst
@@ -379,7 +379,7 @@ Now install the dependencies that we need to build and test SciPy.
 
 .. code:: shell
 
-    python -m pip install wheel setuptools numpy>=1.16.5 Cython>=0.29.18 pybind11>=2.4.3 pythran>=0.9.12 pytest pytest-xdist
+    python -m pip install wheel setuptools numpy>=1.16.5 Cython>=0.29.18 pybind11>=2.4.3 pythran>=0.10.0 pytest pytest-xdist
 
 .. note::
 

--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - openblas
   - libblas=*=*openblas  # helps avoid pulling in MKL
   - pybind11
-  - pythran>=0.9.12
+  - pythran>=0.10.0
   - conda-build  # to allow `conda develop .`
   # For testing and benchmarking
   - pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires = [
     "setuptools<60.0.0",
     "Cython>=0.29.18,<3.0",
     "pybind11>=2.4.3,<2.9.0",
-    "pythran>=0.9.12,<0.11.0",
+    "pythran>=0.10.0,<0.11.0",
 
     # NumPy dependencies - to update these, sync from
     # https://github.com/scipy/oldest-supported-numpy/, and then

--- a/setup.py
+++ b/setup.py
@@ -234,9 +234,9 @@ def get_build_ext_override():
             from pythran.dist import PythranBuildExt
             BaseBuildExt = PythranBuildExt[npy_build_ext]
             # Version check - a too old Pythran will give problems
-            if LooseVersion(pythran.__version__) < LooseVersion('0.9.12'):
+            if LooseVersion(pythran.__version__) < LooseVersion('0.10.0'):
                 raise RuntimeError("The installed `pythran` is too old, >= "
-                                   "0.9.12 is needed, {} detected. Please "
+                                   "0.10.0 is needed, {} detected. Please "
                                    "upgrade Pythran, or use `export "
                                    "SCIPY_USE_PYTHRAN=0`.".format(
                                    pythran.__version__))


### PR DESCRIPTION
This fixes a problem with RBFInterpolator, which needed a change in Pythran which landed in Pythran 0.10.0

This shouldn't change anything for from-source builds, because we the way the requirement is written means we're already defaulting to the highest version number below 0.11.0

Closes gh-14420