### PR TITLE
MAINT: filter RuntimeWarnings in stats functions

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -618,10 +618,17 @@ class beta_gen(rv_continuous):
         return _boost._beta_sf(x, a, b)
 
     def _isf(self, x, a, b):
-        return _boost._beta_isf(x, a, b)
+        with warnings.catch_warnings():
+            # See gh-14901
+            message = "overflow encountered in _beta_isf"
+            warnings.filterwarnings('ignore', message=message)
+            return _boost._beta_isf(x, a, b)
 
     def _ppf(self, q, a, b):
-        return _boost._beta_ppf(q, a, b)
+        with warnings.catch_warnings():
+            message = "overflow encountered in _beta_ppf"
+            warnings.filterwarnings('ignore', message=message)
+            return _boost._beta_ppf(q, a, b)
 
     def _stats(self, a, b):
         return(

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -3,6 +3,8 @@
 #          SciPy Developers 2004-2011
 #
 from functools import partial
+import warnings
+
 from scipy import special
 from scipy.special import entr, logsumexp, betaln, gammaln as gamln, zeta
 from scipy._lib._util import _lazywhere, rng_integers
@@ -333,10 +335,17 @@ class nbinom_gen(rv_discrete):
         return _boost._nbinom_sf(k, n, p)
 
     def _isf(self, x, n, p):
-        return _boost._nbinom_isf(x, n, p)
+        with warnings.catch_warnings():
+            # See gh-14901
+            message = "overflow encountered in _nbinom_isf"
+            warnings.filterwarnings('ignore', message=message)
+            return _boost._nbinom_isf(x, n, p)
 
     def _ppf(self, q, n, p):
-        return _boost._nbinom_ppf(q, n, p)
+        with warnings.catch_warnings():
+            message = "overflow encountered in _nbinom_ppf"
+            warnings.filterwarnings('ignore', message=message)
+            return _boost._nbinom_ppf(q, n, p)
 
     def _stats(self, n, p):
         return(

--- a/scipy/stats/tests/test_discrete_distns.py
+++ b/scipy/stats/tests/test_discrete_distns.py
@@ -4,7 +4,9 @@ from scipy.stats import (betabinom, hypergeom, nhypergeom, bernoulli,
                          nchypergeom_fisher, nchypergeom_wallenius, randint)
 
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_equal, assert_allclose
+from numpy.testing import (
+    assert_almost_equal, assert_equal, assert_allclose, suppress_warnings
+)
 from scipy.special import binom as special_binom
 from scipy.optimize import root_scalar
 from scipy.integrate import quad
@@ -415,8 +417,11 @@ class TestNCH():
 
             return root_scalar(fun, bracket=(xl, xu)).root
 
-        assert_allclose(nchypergeom_wallenius.mean(N, m1, n, w),
-                        mean(N, m1, n, w), rtol=2e-2)
+        with suppress_warnings() as sup:
+            sup.filter(RuntimeWarning,
+                       message="invalid value encountered in mean")
+            assert_allclose(nchypergeom_wallenius.mean(N, m1, n, w),
+                            mean(N, m1, n, w), rtol=2e-2)
 
         @np.vectorize
         def variance(N, m1, n, w):
@@ -426,8 +431,14 @@ class TestNCH():
             b = (n-u)*(u + m2 - n)
             return N*a*b / ((N-1) * (m1*b + m2*a))
 
-        assert_allclose(nchypergeom_wallenius.stats(N, m1, n, w, moments='v'),
-                        variance(N, m1, n, w), rtol=5e-2)
+        with suppress_warnings() as sup:
+            sup.filter(RuntimeWarning,
+                       message="invalid value encountered in mean")
+            assert_allclose(
+                nchypergeom_wallenius.stats(N, m1, n, w, moments='v'),
+                variance(N, m1, n, w),
+                rtol=5e-2
+            )
 
         @np.vectorize
         def pmf(x, N, m1, n, w):


### PR DESCRIPTION
Fixes test suite failures on macOS 12, arm64.

See gh-14901 for details. The failures on x86-64 may not be identical, and this doesn't close the issue completely - it would be nice if we could fix the root cause, rather than just silence the warnings like this.