### PR TITLE
CI: reshuffle two Windows Azure CI jobs, and don't run 'full' on both

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -229,7 +229,7 @@ stages:
           Python39-64bit-fast:
             PYTHON_VERSION: '3.9'
             PYTHON_ARCH: 'x64'
-            TEST_MODE: full
+            TEST_MODE: fast
             BITS: 64
             SCIPY_USE_PYTHRAN: 0
     steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -218,16 +218,16 @@ stages:
             TEST_MODE: full
             BITS: 64
             SCIPY_USE_PYTHRAN: 0
-          Python39-64bit-full-ilp64:
-            PYTHON_VERSION: '3.9'
+          Python310-64bit-full-ilp64:
+            PYTHON_VERSION: '3.10'
             PYTHON_ARCH: 'x64'
             TEST_MODE: full
             NPY_USE_BLAS_ILP64: 1
             BITS: 64
             OPENBLAS64_: $(OPENBLAS)
             SCIPY_USE_PYTHRAN: 1
-          Python310-64bit-full:
-            PYTHON_VERSION: '3.10'
+          Python39-64bit-fast:
+            PYTHON_VERSION: '3.9'
             PYTHON_ARCH: 'x64'
             TEST_MODE: full
             BITS: 64


### PR DESCRIPTION
The Python 3.10 test was timing out a lot, and there's no reason to run the full test suite on all three 64-bit test jobs.
Python 3.9/3.10 are switched here to preserve the full test suite run on 3.10 with ILP64 BLAS. If 3.10 and 3.8 pass, then 3.9 full will be fine too.