### PR TITLE
DOC: interpolate: silence `sproot` tutorial failure on refguide_asv_check

### DIFF
--- a/doc/source/tutorial/interpolate.rst
+++ b/doc/source/tutorial/interpolate.rst
@@ -259,9 +259,9 @@ example that follows.
    Roots of spline
 
    >>> interpolate.sproot(tck)
-   array([3.1416])
+   array([3.1416])  # may vary
 
-   Notice that `sproot` failed to find an obvious solution at the edge of the
+   Notice that `sproot` may fail to find an obvious solution at the edge of the
    approximation interval, :math:`x = 0`. If we define the spline on a slightly
    larger interval, we recover both roots :math:`x = 0` and :math:`x = 2\pi`:
 

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -14,7 +14,6 @@ from warnings import warn
 
 import numpy as np
 
-
 # unconstrained minimization
 from ._optimize import (_minimize_neldermead, _minimize_powell, _minimize_cg,
                        _minimize_bfgs, _minimize_newtoncg,


### PR DESCRIPTION
#### Reference issue
gh-15327

#### What does this implement/fix?
Apparently, `sproot` may find the x=0 solution after all. Acknowledge that in the tutorial and avoid refguide failure.