### PR TITLE
MAINT: interpolate: csr_matrix -> csr_array

### DIFF
--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -10,7 +10,7 @@ from . import _fitpack_impl
 from . import _fitpack as _dierckx
 from scipy._lib._util import prod
 from scipy.special import poch
-from scipy.sparse import csr_matrix
+from scipy.sparse import csr_array
 from itertools import combinations
 
 __all__ = ["BSpline", "make_interp_spline", "make_lsq_spline"]
@@ -333,7 +333,7 @@ class BSpline:
     @classmethod
     def design_matrix(cls, x, t, k):
         """
-        Returns a design matrix in CSR format.
+        Returns a design matrix as a CSR format sparse array.
 
         Parameters
         ----------
@@ -346,7 +346,7 @@ class BSpline:
 
         Returns
         -------
-        design_matrix : `csr_matrix` object
+        design_matrix : `csr_array` object
             Sparse matrix in CSR format where in each row all the basis
             elements are evaluated at the certain point (first row - x[0],
             ..., last row - x[-1]).
@@ -417,7 +417,7 @@ class BSpline:
 
         n, nt = x.shape[0], t.shape[0]
         data, idx = _bspl._make_design_matrix(x, t, k)
-        return csr_matrix((data, idx), (n, nt - k - 1))
+        return csr_array((data, idx), (n, nt - k - 1))
 
     def __call__(self, x, nu=0, extrapolate=None):
         """


### PR DESCRIPTION
Return `csr_array` objects instead of `csr_matrix` from `BSpline.design_marix` method.

The main question is if this should go to 1.8.x or 1.9.x : the method is new in 1.8.0, so it makes sense to tweak the return type right away to avoid even thinking about backcompat down the line (however mild it will be). 
On the other hand, this is directly user-facing, and AFAIU the idea is to try the `_array` classes first before making a general recommendation. 
So I'm deferring the decision to @tylerjereddy and @rgommers .