### PR TITLE
DOC: signal: silence divide by zero warning in docstring example

### DIFF
--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -335,7 +335,8 @@ def bohman(M, sym=True):
     >>> plt.figure()
     >>> A = fft(window, 2048) / (len(window)/2.0)
     >>> freq = np.linspace(-0.5, 0.5, len(A))
-    >>> response = 20 * np.log10(np.abs(fftshift(A / abs(A).max())))
+    >>> with np.errstate(divide='ignore'):
+    >>>     response = 20 * np.log10(np.abs(fftshift(A / abs(A).max())))
     >>> plt.plot(freq, response)
     >>> plt.axis([-0.5, 0.5, -120, 0])
     >>> plt.title("Frequency response of the Bohman window")
@@ -1514,7 +1515,8 @@ def cosine(M, sym=True):
     >>> plt.figure()
     >>> A = fft(window, 2048) / (len(window)/2.0)
     >>> freq = np.linspace(-0.5, 0.5, len(A))
-    >>> response = 20 * np.log10(np.abs(fftshift(A / abs(A).max())))
+    >>> with np.errstate(divide='ignore'):
+    >>>     response = 20 * np.log10(np.abs(fftshift(A / abs(A).max())))
     >>> plt.plot(freq, response)
     >>> plt.axis([-0.5, 0.5, -120, 0])
     >>> plt.title("Frequency response of the cosine window")


### PR DESCRIPTION
[skip azp]
[skip actions]

#### Reference issue
gh-15327

#### What does this implement/fix?
Attempt to silence RuntimeWarning to avoid CircleCI failure.