### PR TITLE
BUG: stats._unuran: fix remaining attribute lookup errors

### DIFF
--- a/scipy/stats/_unuran/unuran_wrapper.pyx.templ
+++ b/scipy/stats/_unuran/unuran_wrapper.pyx.templ
@@ -33,6 +33,8 @@ __all__ = ['UNURANError', 'TransformedDensityRejection', 'DiscreteAliasUrn',
 
 cdef extern from "Python.h":
     PyObject *PyErr_Occurred()
+    void PyErr_Fetch(PyObject **ptype, PyObject **pvalue, PyObject **ptraceback)
+    void PyErr_Restore(PyObject *type, PyObject *value, PyObject *traceback)
 
 
 # Internal API for handling Python callbacks.
@@ -465,8 +467,10 @@ cdef class Method:
             unur_gen *rng = self.rng
             size_t i
             size_t size = len(out)
+            PyObject *type, *value, *traceback
 
         has_callback_wrapper = (self._callback_wrapper is not None)
+        error = 0
 
         _lock.acquire()
         try:
@@ -478,12 +482,17 @@ cdef class Method:
             for i in range(size):
                 out[i] = unur_sample_cont(rng)
                 if PyErr_Occurred():
+                    error = 1
                     return
             msg = self._messages.get()
             if msg:
                 raise UNURANError(msg)
         finally:
+            if error:
+                PyErr_Fetch(&type, &value, &traceback)
             _lock.release()
+            if error:
+                PyErr_Restore(type, value, traceback)
             if has_callback_wrapper:
                 release_unuran_callback(&callback)
 
@@ -503,8 +512,10 @@ cdef class Method:
             unur_gen *rng = self.rng
             size_t i
             size_t size = len(out)
+            PyObject *type, *value, *traceback
 
         has_callback_wrapper = (self._callback_wrapper is not None)
+        error = 0
 
         _lock.acquire()
         try:
@@ -516,12 +527,17 @@ cdef class Method:
             for i in range(size):
                 out[i] = unur_sample_discr(rng)
                 if PyErr_Occurred():
+                    error = 1
                     return
             msg = self._messages.get()
             if msg:
                 raise UNURANError(msg)
         finally:
+            if error:
+                PyErr_Fetch(&type, &value, &traceback)
             _lock.release()
+            if error:
+                PyErr_Restore(type, value, traceback)
             if has_callback_wrapper:
                 release_unuran_callback(&callback)
 
@@ -1457,6 +1473,9 @@ cdef class NumericalInversePolynomial(Method):
         cdef:
             size_t i
             ccallback_t callback
+            PyObject *type, *value, *traceback
+
+        error = 0
 
         _lock.acquire()
         try:
@@ -1466,11 +1485,16 @@ cdef class NumericalInversePolynomial(Method):
             for i in range(N):
                 out[i] = unur_pinv_eval_approxcdf(self.rng, x[i])
                 if PyErr_Occurred():
+                    error = 1
                     return
                 if out[i] == UNUR_INFINITY or out[i] == -UNUR_INFINITY:
                     raise UNURANError(self._messages.get())
         finally:
+            if error:
+                PyErr_Fetch(&type, &value, &traceback)
             _lock.release()
+            if error:
+                PyErr_Restore(type, value, traceback)
             release_unuran_callback(&callback)
 
     def cdf(self, x):


### PR DESCRIPTION
#### Reference issue

Closes #14968
Follow-up of #15331

#### What does this implement/fix?

See https://github.com/scipy/scipy/issues/14968#issuecomment-1003592655

Cython looks up the `release` method (attribute) of the `_lock` variable when `_lock.release()` is called. Python doesn't allow ANY kind of attribute lookup when a live exception is set. So, this might lead to debug build crashes. This has been fixed by saving/restoring the error before/after calling `_lock.release()`.

#### Additional information
<!--Any additional information you think is important.-->
