### PR TITLE
CI: pin numpy to 1.21.5 in the Azure refguide check job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -83,7 +83,7 @@ stages:
     - template: ci/azure-travis-template.yaml
       parameters:
         test_mode: fast
-        numpy_spec: "--upgrade numpy"
+        numpy_spec: "numpy==1.21.5"
         refguide_check: true
         asv_check: true
         use_wheel: true


### PR DESCRIPTION
The `linalg.lapack` warnings is the problem outlined in gh-15327.
There is one other minor printing change in `integrate`.

Given that the lapack issues must be fixed upstream in `numpy.f2py`, we need to pin this job.

[skip github]
