### PR TITLE
BUG: fix normalization of generalized eigenvectors

### DIFF
--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -97,7 +97,7 @@ def _geneig(a1, b1, left, right, overwrite_a, overwrite_b,
             vr = _make_complex_eigvecs(w, vr, t)
 
     # the eigenvectors returned by the lapack function are NOT normalized
-    for i in range(vr.shape[0]):
+    for i in range(vr.shape[1]):
         if right:
             vr[:, i] /= norm(vr[:, i])
         if left:

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -336,6 +336,15 @@ class TestEig:
                 A, B = matrices(omega=k*5./100)
                 self._check_gen_eig(A, B)
 
+    def test_gen_eig_normalization(self):
+        # issue #11550 (normalization of eigenvectors)
+        seed(0)
+        A = random(size=(4, 4))
+        B = random(size=(4, 4))
+        for left in [True, False]:
+            D, V = eig(A, B, right=not left, left=left)
+            assert_allclose([norm(V[:, k]) for k in range(4)], 1.0)
+
     def test_make_eigvals(self):
         # Step through all paths in _make_eigvals
         seed(1234)


### PR DESCRIPTION
#### Reference issue
Closes gh-11550

#### What does this implement/fix?
This ensures that the generalized left eigenvectors are normalized, as stated in the documentation.
