### PR TITLE
ENH: stats: add weights in harmonic mean

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -315,7 +315,7 @@ def hmean(a, axis=0, dtype=None, *, weights=None):
         the size of `a` along the given `axis`) or of the same shape as `a`.
         Default is None, which gives each value a weight of 1.0.
 
-    .. versionadded:: 1.9
+        .. versionadded:: 1.9
 
     Returns
     -------

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -292,7 +292,7 @@ def gmean(a, axis=0, dtype=None, weights=None):
     return np.exp(np.average(log_a, axis=axis, weights=weights))
 
 
-def hmean(a, axis=0, dtype=None, weights=None):
+def hmean(a, axis=0, dtype=None, *, weights=None):
     """Calculate the harmonic mean along the specified axis.
 
     That is:  n / (1/x1 + 1/x2 + ... + 1/xn)
@@ -314,6 +314,8 @@ def hmean(a, axis=0, dtype=None, weights=None):
         The weights array can either be 1-D (in which case its length must be
         the size of `a` along the given `axis`) or of the same shape as `a`.
         Default is None, which gives each value a weight of 1.0.
+
+    .. versionadded:: 1.9
 
     Returns
     -------
@@ -339,6 +341,8 @@ def hmean(a, axis=0, dtype=None, weights=None):
     ----------
     .. [1] "Weighted Harmonic Mean", *Wikipedia*,
            https://en.wikipedia.org/wiki/Harmonic_mean#Weighted_harmonic_mean
+    .. [2] Ferger, F., "The nature and use of the harmonic mean", Journal of
+           the American Statistical Association, vol. 26, pp. 36-40, 1931
 
     Examples
     --------

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -337,7 +337,8 @@ def hmean(a, axis=0, dtype=None, weights=None):
 
     References
     ----------
-    .. [1] "Weighted Harmonic Mean", *Wikipedia*, https://en.wikipedia.org/wiki/Harmonic_mean#Weighted_harmonic_mean
+    .. [1] "Weighted Harmonic Mean", *Wikipedia*,
+           https://en.wikipedia.org/wiki/Harmonic_mean#Weighted_harmonic_mean
 
     Examples
     --------

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -5461,8 +5461,8 @@ def check_equal_gmean(array_like, desired, axis=None, dtype=None, rtol=1e-7, wei
     assert_allclose(x, desired, rtol=rtol)
     assert_equal(x.dtype, dtype)
 
-def check_equal_hmean(array_like, desired, axis=None, dtype=None, rtol=1e-7):
-    x = stats.hmean(array_like, axis=axis, dtype=dtype)
+def check_equal_hmean(array_like, desired, axis=None, dtype=None, rtol=1e-7, weights=None):
+    x = stats.hmean(array_like, axis=axis, dtype=dtype, weights=weights)
     assert_allclose(x, desired, rtol=rtol)
     assert_equal(x.dtype, dtype)
 
@@ -5539,6 +5539,30 @@ class TestHarMean:
         a = [[10, 20, 30, 40], [50, 60, 70, 80], [90, 100, 110, 120]]
         desired = matrix([[19.2, 63.03939962, 103.80078637]]).T
         check_equal_hmean(matrix(a), desired, axis=1)
+
+    def test_weights_1d_list(self):
+        # Desired result from:
+        # https://www.hackmath.net/en/math-problem/35871
+        weights = [10, 5, 3]
+        a = [2, 10, 6]
+        desired = 3
+        check_equal_hmean(a, desired, weights=weights, rtol=1e-5)
+
+    def test_weights_1d_array(self):
+        # Desired result from:
+        # https://www.hackmath.net/en/math-problem/35871
+        a = np.array([2, 10, 6])
+        weights = np.array([10, 5, 3])
+        desired = 3
+        check_equal_hmean(a, desired, weights=weights, rtol=1e-5)
+
+    def test_weights_masked_1d_array(self):
+        # Desired result from:
+        # https://www.hackmath.net/en/math-problem/35871
+        a = np.array([2, 10, 6, 42])
+        weights = np.ma.array([10, 5, 3, 42], mask=[0, 0, 0, 1])
+        desired = 3
+        check_equal_hmean(a, desired, weights=weights, rtol=1e-5)
 
 
 class TestGeoMean:

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -5461,7 +5461,9 @@ def check_equal_gmean(array_like, desired, axis=None, dtype=None, rtol=1e-7, wei
     assert_allclose(x, desired, rtol=rtol)
     assert_equal(x.dtype, dtype)
 
-def check_equal_hmean(array_like, desired, axis=None, dtype=None, rtol=1e-7, weights=None):
+
+def check_equal_hmean(array_like, desired, axis=None, dtype=None, rtol=1e-7,
+                      weights=None):
     x = stats.hmean(array_like, axis=axis, dtype=dtype, weights=weights)
     assert_allclose(x, desired, rtol=rtol)
     assert_equal(x.dtype, dtype)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -5455,7 +5455,8 @@ def test_obrientransform():
     assert_array_almost_equal(result[0], expected, decimal=4)
 
 
-def check_equal_gmean(array_like, desired, axis=None, dtype=None, rtol=1e-7, weights=None):
+def check_equal_gmean(array_like, desired, axis=None, dtype=None, rtol=1e-7,
+                      weights=None):
     # Note this doesn't test when axis is not specified
     x = stats.gmean(array_like, axis=axis, dtype=dtype, weights=weights)
     assert_allclose(x, desired, rtol=rtol)
@@ -5550,13 +5551,13 @@ class TestHarMean:
         desired = 3
         check_equal_hmean(a, desired, weights=weights, rtol=1e-5)
 
-    def test_weights_1d_array(self):
+    def test_weights_2d_array(self):
         # Desired result from:
         # https://www.hackmath.net/en/math-problem/35871
-        a = np.array([2, 10, 6])
-        weights = np.array([10, 5, 3])
-        desired = 3
-        check_equal_hmean(a, desired, weights=weights, rtol=1e-5)
+        a = np.array([[2, 10, 6], [7, 7, 7]])
+        weights = np.array([[10, 5, 3], [1, 1, 1]])
+        desired = np.array([3, 7])
+        check_equal_hmean(a, desired, axis=1, weights=weights, rtol=1e-5)
 
     def test_weights_masked_1d_array(self):
         # Desired result from:

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -5551,7 +5551,15 @@ class TestHarMean:
         desired = 3
         check_equal_hmean(a, desired, weights=weights, rtol=1e-5)
 
-    def test_weights_2d_array(self):
+    def test_weights_2d_array_axis0(self):
+        # Desired result from:
+        # https://www.hackmath.net/en/math-problem/35871
+        a = np.array([[2, 5], [10, 5], [6, 5]])
+        weights = np.array([[10, 1], [5, 1], [3, 1]])
+        desired = np.array([3, 5])
+        check_equal_hmean(a, desired, axis=0, weights=weights, rtol=1e-5)
+
+    def test_weights_2d_array_axis1(self):
         # Desired result from:
         # https://www.hackmath.net/en/math-problem/35871
         a = np.array([[2, 10, 6], [7, 7, 7]])


### PR DESCRIPTION
#### What does this implement/fix?

Scipy supports weights for `gmean`, but not for `hmean`.

This PR aims to:
- add weights to hmean,
- complete doc,
- complete tests.

#### Additional information

https://en.wikipedia.org/wiki/Harmonic_mean#Weighted_harmonic_mean
