### PR TITLE
BLD: put upper bound `setuptools<60.0` in conda environment yml files

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ channels:
   - conda-forge
 dependencies:
   - python
+  - setuptools<60.0
   - cython
   - compilers
   - numpy

--- a/environment_meson.yml
+++ b/environment_meson.yml
@@ -8,6 +8,7 @@ channels:
   - conda-forge
 dependencies:
   - python
+  - setuptools<60.0
   - cython
   - compilers
   - meson


### PR DESCRIPTION
This is hopefully the last place where we have to add this upper bound.

[ci skip]
