### PR TITLE
ENH: interpolate: add new methods for RegularGridInterpolator.

### DIFF
--- a/doc/source/tutorial/interpolate.rst
+++ b/doc/source/tutorial/interpolate.rst
@@ -21,6 +21,9 @@ for data in 1, 2, and higher dimensions:
   Object-oriented interface for the underlying routines is also
   available.
 
+- :class:`RegularGridInterpolator` provides several interpolation methods
+  on a regular grid in arbitrary (N) dimensions,
+
 - Functions for 1- and 2-D (smoothed) cubic-spline
   interpolation, based on the FORTRAN library FITPACK. They are both
   procedural and object-oriented interfaces for the FITPACK library.
@@ -143,6 +146,60 @@ that do not form a regular grid.
     >>> plt.title('Cubic')
     >>> plt.gcf().set_size_inches(6, 6)
     >>> plt.show()
+
+
+.. _tutorial-interpolate_regular_grid_interpolator:
+
+Multivariate data interpolation on a regular grid  (:class:`RegularGridInterpolator`)
+======================================================================================
+
+Suppose you have n-dimensional data on a regular grid, and you want to interpolate it.
+In such a case, :class:`RegularGridInterpolator` can be useful.
+The following example demonstrates its use, and compares the interpolation results
+using each method.
+
+.. plot::
+
+   >>> import matplotlib.pyplot as plt
+   >>> from scipy.interpolate import RegularGridInterpolator
+
+   Suppose we want to interpolate this 2-D function.
+
+   >>> def F(u, v):
+   ...     return u * np.cos(u * v) + v * np.sin(u * v)
+
+   Suppose we only know some data on a regular grid.
+
+   >>> fit_points = [np.linspace(0, 3, 8), np.linspace(0, 3, 8)]
+   >>> values = F(*np.meshgrid(*fit_points, indexing='ij'))
+
+   Creating test points and true values for evaluations.
+
+   >>> ut, vt = np.meshgrid(np.linspace(0, 3, 80), np.linspace(0, 3, 80), indexing='ij')
+   >>> true_values = F(ut, vt)
+   >>> test_points = np.array([ut.ravel(), vt.ravel()]).T
+
+   We can creat interpolator and interpolate test points using each method.
+
+   >>> interp = RegularGridInterpolator(fit_points, values)
+   >>> fig, axes = plt.subplots(2, 3, figsize=(10, 6))
+   >>> axes = axes.ravel()
+   >>> fig_index = 0
+   >>> for method in ['linear', 'nearest', 'slinear', 'cubic', 'quintic']:
+   ...     im = interp(test_points, method=method).reshape(80, 80)
+   ...     axes[fig_index].imshow(im)
+   ...     axes[fig_index].set_title(method)
+   ...     fig_index += 1
+   >>> axes[fig_index].imshow(true_values)
+   >>> axes[fig_index].set_title("True values")
+   >>> [axi.set_axis_off() for axi in axes.ravel()]  # all axis off
+   >>> fig.tight_layout()
+   >>> fig.show()
+
+   As expected, the higher degree spline interpolations are closest to the
+   true values, though are more expensive to compute than with `linear`
+   or `nearest`. The `slinear` interpolation also matches the `linear`
+   interpolation.
 
 
 Spline interpolation

--- a/doc/source/tutorial/interpolate.rst
+++ b/doc/source/tutorial/interpolate.rst
@@ -189,10 +189,10 @@ using each method.
    ...     im = interp(test_points, method=method).reshape(80, 80)
    ...     axes[fig_index].imshow(im)
    ...     axes[fig_index].set_title(method)
+   ...     axes[fig_index].axis("off")
    ...     fig_index += 1
    >>> axes[fig_index].imshow(true_values)
    >>> axes[fig_index].set_title("True values")
-   >>> [axi.set_axis_off() for axi in axes.ravel()]  # all axis off
    >>> fig.tight_layout()
    >>> fig.show()
 

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -2432,7 +2432,8 @@ class RegularGridInterpolator:
     which is indeed a close approximation to
     ``[f(2.1, 6.2, 8.3), f(3.3, 5.2, 7.1)]``.
 
-    Other examples are given :ref:`in the tutorial <tutorial-interpolate_regular_grid_interpolator>`.
+    Other examples are given
+    :ref:`in the tutorial <tutorial-interpolate_regular_grid_interpolator>`.
 
     See also
     --------

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -2467,8 +2467,8 @@ class RegularGridInterpolator:
         if method not in self.ALL_METHODS:
             raise ValueError("Method '%s' is not defined" % method)
         elif method in self.SPLINE_METHODS:
-            self._validate_input(points, method)
-            self._validate_input(values, method)
+            self._validate_not_complex(points, method)
+            self._validate_not_complex(values, method)
             self._validate_grid_dimensions(points, method)
         self.method = method
         self.bounds_error = bounds_error
@@ -2553,9 +2553,9 @@ class RegularGridInterpolator:
                                             norm_distances,
                                             out_of_bounds)
         elif method in self.SPLINE_METHODS:
+            self._validate_not_complex(xi, method)
             if is_method_changed:
                 self._validate_grid_dimensions(self.grid, method)
-                self._validate_input(xi, method)
             result = self._evaluate_spline(self.values.T, xi,
                                            self.SPLINE_DEGREE_MAP[method])
 
@@ -2585,8 +2585,8 @@ class RegularGridInterpolator:
         return self.values[tuple(idx_res)]
 
     @staticmethod
-    def _validate_input(input, method):
-        if np.iscomplexobj(input):
+    def _validate_not_complex(input_value, method):
+        if np.iscomplexobj(input_value):
             raise ValueError(f"method {method} does not support complex "
                              f"values. Use 'linear' or 'nearest'.")
 

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -2458,15 +2458,15 @@ class RegularGridInterpolator:
     # this class is based on code originally programmed by Johannes Buchner,
     # see https://github.com/JohannesBuchner/regulargrid
 
-    SPLINE_DEGREE_MAP = {"slinear": 1, "cubic": 3, "quintic": 5, }
-    SPLINE_METHODS = list(SPLINE_DEGREE_MAP.keys())
-    ALL_METHODS = ["linear", "nearest"] + SPLINE_METHODS
+    _SPLINE_DEGREE_MAP = {"slinear": 1, "cubic": 3, "quintic": 5, }
+    _SPLINE_METHODS = list(_SPLINE_DEGREE_MAP.keys())
+    _ALL_METHODS = ["linear", "nearest"] + _SPLINE_METHODS
 
     def __init__(self, points, values, method="linear", bounds_error=True,
                  fill_value=np.nan):
-        if method not in self.ALL_METHODS:
+        if method not in self._ALL_METHODS:
             raise ValueError("Method '%s' is not defined" % method)
-        elif method in self.SPLINE_METHODS:
+        elif method in self._SPLINE_METHODS:
             self._validate_not_complex(points, method)
             self._validate_not_complex(values, method)
             self._validate_grid_dimensions(points, method)
@@ -2523,7 +2523,7 @@ class RegularGridInterpolator:
         """
         is_method_changed = self.method != method
         method = self.method if method is None else method
-        if method not in self.ALL_METHODS:
+        if method not in self._ALL_METHODS:
             raise ValueError("Method '%s' is not defined" % method)
 
         ndim = len(self.grid)
@@ -2552,12 +2552,12 @@ class RegularGridInterpolator:
             result = self._evaluate_nearest(indices,
                                             norm_distances,
                                             out_of_bounds)
-        elif method in self.SPLINE_METHODS:
+        elif method in self._SPLINE_METHODS:
             self._validate_not_complex(xi, method)
             if is_method_changed:
                 self._validate_grid_dimensions(self.grid, method)
             result = self._evaluate_spline(self.values.T, xi,
-                                           self.SPLINE_DEGREE_MAP[method])
+                                           self._SPLINE_DEGREE_MAP[method])
 
         if not self.bounds_error and self.fill_value is not None:
             result[out_of_bounds] = self.fill_value
@@ -2591,7 +2591,7 @@ class RegularGridInterpolator:
                              f"values. Use 'linear' or 'nearest'.")
 
     def _validate_grid_dimensions(self, points, method):
-        k = self.SPLINE_DEGREE_MAP[method]
+        k = self._SPLINE_DEGREE_MAP[method]
         for i, point in enumerate(points):
             ndim = len(np.atleast_1d(point))
             if ndim <= k:

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -2490,12 +2490,12 @@ class TestRegularGridInterpolator:
         assert_allclose(v1, v2)
 
     def test_complex(self):
-        points, values = self._get_sample_4d()
+        points, values = self._get_sample_4d_3()
         values = values - 2j*values
         sample = np.asarray([[0.1, 0.1, 1., .9], [0.2, 0.1, .45, .8],
                              [0.5, 0.5, .5, .5]])
 
-        for method in ['linear', 'nearest']:
+        for method in ['linear', 'nearest', "slinear", "cubic", "quintic"]:
             interp = RegularGridInterpolator(points, values,
                                              method=method)
             rinterp = RegularGridInterpolator(points, values.real,
@@ -2506,26 +2506,6 @@ class TestRegularGridInterpolator:
             v1 = interp(sample)
             v2 = rinterp(sample) + 1j*iinterp(sample)
             assert_allclose(v1, v2)
-
-    def test_complex_exception(self):
-        points, values = self._get_sample_4d_3()
-        points = np.asarray(points)
-        sample = np.asarray(
-            [[0.1, 0.1, 1., .9], [0.2, 0.1, .45, .8], [0.5, 0.5, .5, .5]])
-        points_comp = points - 2j * points
-        values_comp = values - 2j * values
-        sample_comp = sample - 2j * sample
-
-        match = "does not support complex value."
-        for method in ['slinear', 'cubic', 'quintic']:
-            with pytest.raises(ValueError, match=match):
-                RegularGridInterpolator(points_comp, values, method=method)
-            with pytest.raises(ValueError, match=match):
-                RegularGridInterpolator(points, values_comp, method=method)
-
-            interp = RegularGridInterpolator(points, values, method=method)
-            with pytest.raises(ValueError, match=match):
-                interp(sample_comp)
 
     def test_linear_xi1d(self):
         points, values = self._get_sample_4d_2()


### PR DESCRIPTION
Co-authored-by: Tristan Hearn <tristanhearn@gmail.com>

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
PR #7903

#### What does this implement/fix?
<!--Please explain your changes.-->
PR #7903 tried to add new spline methods for `RegularGridInterpolator`. 
It seems very useful, but it is stalled now.
So, I picked up minimum code changes from PR #7903 to add new spline methods for `RegularGridInterpolator`.

These are different points from #7903
- Focusing on adding new spline methods.
- Not including gradient calculation.
- Not including spline_dim_error option argument.
- Move interpolation comparison examples to the interpolate tutorial.
- add simple tests
