### PR TITLE
MAINT: special: deprecate casting to integers behavior in `special.comb` when `exact=True`

### DIFF
--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -763,13 +763,6 @@ add_newdoc(
     >>> (binom(x, y), comb(x, y), comb(x, y, exact=True))
     (960566918219.9999, 960566918219.9999, 960566918220)
 
-    Note that if ``exact=True`` and ``legacy=True``, non-integer arguments to
-    `comb` will be truncated to integers, leading to inaccurate results.
-
-    >>> x, y = 3.9, 2.8
-    >>> (binom(x, y), comb(x, y), comb(x, y, exact=True, legacy=True))
-    (4.2071983565457955, 4.2071983565457955, 3)
-
     `binom` returns ``nan`` when ``x`` is a negative integer, but is otherwise
     defined for negative arguments. `comb` returns 0 whenever one of ``x`` or
     ``y`` is negative or ``x`` is less than ``y``.

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -763,11 +763,11 @@ add_newdoc(
     >>> (binom(x, y), comb(x, y), comb(x, y, exact=True))
     (960566918219.9999, 960566918219.9999, 960566918220)
 
-    Note that if ``exact=True``, non-integer arguments to  `comb` will be
-    truncated to integers, leading to inaccurate results.
+    Note that if ``exact=True`` and ``legacy=True``, non-integer arguments to
+    `comb` will be truncated to integers, leading to inaccurate results.
 
     >>> x, y = 3.9, 2.8
-    >>> (binom(x, y), comb(x, y), comb(x, y, exact=True))
+    >>> (binom(x, y), comb(x, y), comb(x, y, exact=True, legacy=True))
     (4.2071983565457955, 4.2071983565457955, 3)
 
     `binom` returns ``nan`` when ``x`` is a negative integer, but is otherwise

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2183,9 +2183,12 @@ def comb(N, k, exact=False, repetition=False, legacy=True):
         calculation being performed as if `exact` is False.
 
         .. deprecated:: 1.9.0
-            Non-integer arguments are deprecated when `exact=True` and
-            `legacy=True`. `legacy` will default to False in the second
-            release after SciPy 1.9.0.
+            Non-integer arguments are currently being cast to integers when
+            `exact=True`. This behaviour is deprecated and the default will
+            change to avoid the cast in SciPy 1.11.0. To opt into the future
+            behavior set `legacy=False`. If you want to keep the
+            argument-casting but silence this warning, cast your inputs
+            directly, e.g. ``comb(int(your_N), int(your_k), exact=True)``.
 
     Returns
     -------
@@ -2222,9 +2225,13 @@ def comb(N, k, exact=False, repetition=False, legacy=True):
         if int(N) != N or int(k) != k:
             if legacy:
                 warnings.warn(
-                    "Non-integer arguments are deprecated when exact=True "
-                    "and legacy=True. legacy will default to False in the "
-                    "second release after SciPy 1.9.0.",
+                    "Non-integer arguments are currently being cast to "
+                    "integers when exact=True. This behaviour is "
+                    "deprecated and the default will change to avoid the cast "
+                    "in SciPy 1.11.0. To opt into the future behavior set "
+                    "legacy=False. If you want to keep the argument-casting "
+                    "but silence this warning, cast your inputs directly, "
+                    "e.g. comb(int(your_N), int(your_k), exact=True).",
                     DeprecationWarning, stacklevel=2
                 )
             else:

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2172,15 +2172,17 @@ def comb(N, k, exact=False, repetition=False, legacy=True):
     k : int, ndarray
         Number of elements taken.
     exact : bool, optional
-        If `exact` is False, then floating point precision is used, otherwise
-        exact long integer is computed.
+        For integers, if `exact` is False, then floating point precision is
+        used, otherwise the result is computed exactly. For non-integers, if
+        `exact` is True, the inputs are currently cast to integers, though
+        this behavior is deprecated (see below).
     repetition : bool, optional
         If `repetition` is True, then the number of combinations with
         repetition is computed.
     legacy : bool, optional
-        If `legacy` is True and `exact` is True, then non-integral arguements
-        are cast to ints, otherwise non-integral arguements result in the
-        calculation being performed as if `exact` is False.
+        If `legacy` is True and `exact` is True, then non-integral arguments
+        are cast to ints; if `legacy` is False, the result for non-integral
+        arguments is unaffected by the value of `exact`.
 
         .. deprecated:: 1.9.0
             Non-integer arguments are currently being cast to integers when
@@ -2236,6 +2238,7 @@ def comb(N, k, exact=False, repetition=False, legacy=True):
                 )
             else:
                 return comb(N, k)
+        # _comb_int casts inputs to integers
         return _comb_int(N, k)
     else:
         k, N = asarray(k), asarray(N)

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2183,7 +2183,7 @@ def comb(N, k, exact=False, repetition=False):
     val : int, float, ndarray
         The total number of combinations.
 
-        .. deprecated:: 1.7.4
+        .. deprecated:: 1.9.0
             If ``exact=True`` then ``N`` and ``k`` are cast to integers which
             may lose precision if they are non-integers. This behaviour is
             deprecated.    

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2219,7 +2219,7 @@ def comb(N, k, exact=False, repetition=False):
             warnings.warn(
                 "Non-integer arguments are deprecated when exact=True; "
                 "note that arguments will be cast to integers (as before)",
-                DeprecationWarning,
+                DeprecationWarning, stacklevel=2
             )
         return _comb_int(N, k)
     else:

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2216,7 +2216,10 @@ def comb(N, k, exact=False, repetition=False):
         return comb(N + k - 1, k, exact)
     if exact:
         if int(N) != N or int(k) != k:
-            warnings.warn("Non-integer arguments when exact is True is deprecated.", DeprecationWarning)
+            warnings.warn(
+                "Non-integer arguments when exact is True are deprecated.",
+                DeprecationWarning,
+            )
         return _comb_int(N, k)
     else:
         k, N = asarray(k), asarray(N)

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2186,7 +2186,8 @@ def comb(N, k, exact=False, repetition=False):
         .. deprecated:: 1.9.0
             If ``exact=True`` then ``N`` and ``k`` are cast to integers which
             may lose precision if they are non-integers. This behaviour is
-            deprecated.
+            deprecated and will be removed in the second release after
+            SciPy 1.9.0.
 
     See Also
     --------
@@ -2217,8 +2218,9 @@ def comb(N, k, exact=False, repetition=False):
     if exact:
         if int(N) != N or int(k) != k:
             warnings.warn(
-                "Non-integer arguments are deprecated when exact=True; "
-                "note that arguments will be cast to integers (as before)",
+                "Non-integer arguments are deprecated when exact=True "
+                "and will be removed in the second release after "
+                "SciPy 1.9.0",
                 DeprecationWarning, stacklevel=2
             )
         return _comb_int(N, k)

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2186,8 +2186,8 @@ def comb(N, k, exact=False, repetition=False):
         .. deprecated:: 1.9.0
             If ``exact=True`` then ``N`` and ``k`` are cast to integers which
             may lose precision if they are non-integers. This behaviour is
-            deprecated and will be removed in the second release after
-            SciPy 1.9.0.
+            deprecated and comb will return NaN for integral inputs in the
+            second release after SciPy 1.9.0.
 
     See Also
     --------
@@ -2219,8 +2219,8 @@ def comb(N, k, exact=False, repetition=False):
         if int(N) != N or int(k) != k:
             warnings.warn(
                 "Non-integer arguments are deprecated when exact=True "
-                "and will be removed in the second release after "
-                "SciPy 1.9.0",
+                "and comb will return NaN for integral inputs in the "
+                "second release after SciPy 1.9.0",
                 DeprecationWarning, stacklevel=2
             )
         return _comb_int(N, k)

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2209,9 +2209,7 @@ def comb(N, k, exact=False, repetition=False):
     if repetition:
         return comb(N + k - 1, k, exact)
     if exact:
-        if not isscalar(N) or not isscalar(k):
-            raise ValueError("Arguements must be scalar.")
-        elif int(N) != N or int(k) != k:
+        if int(N) != N or int(k) != k:
             raise ValueError("Arguements must be integers when exact is True.")
         return _comb_int(N, k)
     else:

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2217,7 +2217,8 @@ def comb(N, k, exact=False, repetition=False):
     if exact:
         if int(N) != N or int(k) != k:
             warnings.warn(
-                "Non-integer arguments when exact is True are deprecated.",
+                "Non-integer arguments are deprecated when exact=True; "
+                "note that arguments will be cast to integers (as before)",
                 DeprecationWarning,
             )
         return _comb_int(N, k)

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2186,7 +2186,7 @@ def comb(N, k, exact=False, repetition=False):
         .. deprecated:: 1.9.0
             If ``exact=True`` then ``N`` and ``k`` are cast to integers which
             may lose precision if they are non-integers. This behaviour is
-            deprecated.    
+            deprecated.
 
     See Also
     --------

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2185,8 +2185,8 @@ def comb(N, k, exact=False, repetition=False):
 
         .. deprecated:: 1.9.0
             Non-integer arguments are deprecated when exact=True and comb
-            will return NaN for integral inputs in the second release after
-            SciPy 1.9.0.
+            will return NaN for non-integral inputs in the second release
+            after SciPy 1.9.0.
 
 
     See Also
@@ -2219,7 +2219,7 @@ def comb(N, k, exact=False, repetition=False):
         if int(N) != N or int(k) != k:
             warnings.warn(
                 "Non-integer arguments are deprecated when exact=True "
-                "and comb will return NaN for integral inputs in the "
+                "and comb will return NaN for non-integral inputs in the "
                 "second release after SciPy 1.9.0",
                 DeprecationWarning, stacklevel=2
             )

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2184,10 +2184,10 @@ def comb(N, k, exact=False, repetition=False):
         The total number of combinations.
 
         .. deprecated:: 1.9.0
-            If ``exact=True`` then ``N`` and ``k`` are cast to integers which
-            may lose precision if they are non-integers. This behaviour is
-            deprecated and comb will return NaN for integral inputs in the
-            second release after SciPy 1.9.0.
+            Non-integer arguments are deprecated when exact=True and comb
+            will return NaN for integral inputs in the second release after
+            SciPy 1.9.0.
+
 
     See Also
     --------

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -5,6 +5,7 @@
 import operator
 import numpy as np
 import math
+import warnings
 from numpy import (pi, asarray, floor, isscalar, iscomplex, real,
                    imag, sqrt, where, mgrid, sin, place, issubdtype,
                    extract, inexact, nan, zeros, sinc)
@@ -2182,6 +2183,11 @@ def comb(N, k, exact=False, repetition=False):
     val : int, float, ndarray
         The total number of combinations.
 
+        .. deprecated:: 1.7.4
+            If ``exact=True`` then ``N`` and ``k`` are cast to integers which
+            may lose precision if they are non-integers. This behaviour is
+            deprecated.    
+
     See Also
     --------
     binom : Binomial coefficient considered as a function of two real
@@ -2192,11 +2198,6 @@ def comb(N, k, exact=False, repetition=False):
     - Array arguments accepted only for exact=False case.
     - If N < 0, or k < 0, then 0 is returned.
     - If k > N and repetition=False, then 0 is returned.
-
-    Raises
-    ------
-    ValueError
-        Raised when `exact` is True and non-integer arguements are parsed.
 
     Examples
     --------
@@ -2215,7 +2216,7 @@ def comb(N, k, exact=False, repetition=False):
         return comb(N + k - 1, k, exact)
     if exact:
         if int(N) != N or int(k) != k:
-            raise ValueError("Arguements must be integers when exact is True.")
+            warnings.warn("Non-integer arguments when exact is True is deprecated.", DeprecationWarning)
         return _comb_int(N, k)
     else:
         k, N = asarray(k), asarray(N)

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2160,7 +2160,7 @@ def obl_cv_seq(m, n, c):
     return _specfun.segv(m, n, c, -1)[1][:maxL]
 
 
-def comb(N, k, exact=False, repetition=False):
+def comb(N, k, exact=False, repetition=False, legacy=True):
     """The number of combinations of N things taken k at a time.
 
     This is often expressed as "N choose k".
@@ -2177,17 +2177,20 @@ def comb(N, k, exact=False, repetition=False):
     repetition : bool, optional
         If `repetition` is True, then the number of combinations with
         repetition is computed.
+    legacy : bool, optional
+        If `legacy` is True and `exact` is True, then non-integral arguements
+        are cast to ints, otherwise non-integral arguements result in the
+        calculation being performed as if `exact` is False.
+
+        .. deprecated:: 1.9.0
+            Non-integer arguments are deprecated when `exact=True` and
+            `legacy=True`. `legacy` will default to False in the second
+            release after SciPy 1.9.0.
 
     Returns
     -------
     val : int, float, ndarray
         The total number of combinations.
-
-        .. deprecated:: 1.9.0
-            Non-integer arguments are deprecated when exact=True and comb
-            will return NaN for non-integral inputs in the second release
-            after SciPy 1.9.0.
-
 
     See Also
     --------
@@ -2214,15 +2217,18 @@ def comb(N, k, exact=False, repetition=False):
 
     """
     if repetition:
-        return comb(N + k - 1, k, exact)
+        return comb(N + k - 1, k, exact, legacy=legacy)
     if exact:
         if int(N) != N or int(k) != k:
-            warnings.warn(
-                "Non-integer arguments are deprecated when exact=True "
-                "and comb will return NaN for non-integral inputs in the "
-                "second release after SciPy 1.9.0",
-                DeprecationWarning, stacklevel=2
-            )
+            if legacy:
+                warnings.warn(
+                    "Non-integer arguments are deprecated when exact=True "
+                    "and legacy=True. legacy will default to False in the "
+                    "second release after SciPy 1.9.0.",
+                    DeprecationWarning, stacklevel=2
+                )
+            else:
+                return comb(N, k)
         return _comb_int(N, k)
     else:
         k, N = asarray(k), asarray(N)

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2193,6 +2193,11 @@ def comb(N, k, exact=False, repetition=False):
     - If N < 0, or k < 0, then 0 is returned.
     - If k > N and repetition=False, then 0 is returned.
 
+    Raises
+    ------
+    ValueError
+        Raised when `exact` is True and non-integer arguements are parsed.
+
     Examples
     --------
     >>> from scipy.special import comb

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2209,6 +2209,10 @@ def comb(N, k, exact=False, repetition=False):
     if repetition:
         return comb(N + k - 1, k, exact)
     if exact:
+        if not isscalar(N) or not isscalar(k):
+            raise ValueError("Arguements must be scalar.")
+        elif int(N) != N or int(k) != k:
+            raise ValueError("Arguements must be integers when exact is True.")
         return _comb_int(N, k)
     else:
         k, N = asarray(k), asarray(N)

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1323,12 +1323,26 @@ class TestCombinatorics:
             DeprecationWarning,
             match=r"Non-integer arguments are deprecated when exact=True",
         ):
-            special.comb(4.5, 3, exact=True)
+            assert_equal(
+                special.comb(4.5, 3, exact=True, legacy=True),
+                special.comb(4, 3, exact=True),
+            )
         with pytest.warns(
             DeprecationWarning,
             match=r"Non-integer arguments are deprecated when exact=True",
         ):
-            special.comb(4, 3.5, exact=True)
+            assert_equal(
+                special.comb(4, 3.5, exact=True, legacy=True),
+                special.comb(4, 3, exact=True),
+            )
+        assert_equal(
+            special.comb(4.5, 3, exact=True, legacy=False),
+            special.comb(4.5, 3),
+        )
+        assert_equal(
+            special.comb(4, 3.5, exact=True, legacy=False),
+            special.comb(4, 3.5),
+        )
 
     def test_comb_with_np_int64(self):
         n = 70

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1319,30 +1319,32 @@ class TestCombinatorics:
         expected = 100891344545564193334812497256
         assert_equal(special.comb(100, 50, exact=True), expected)
 
-        with pytest.warns(
-            DeprecationWarning,
-            match=r"Non-integer arguments are currently being cast to",
-        ):
-            assert_equal(
-                special.comb(4.5, 3, exact=True, legacy=True),
-                special.comb(4, 3, exact=True),
-            )
-        with pytest.warns(
-            DeprecationWarning,
-            match=r"Non-integer arguments are currently being cast to",
-        ):
-            assert_equal(
-                special.comb(4, 3.5, exact=True, legacy=True),
-                special.comb(4, 3, exact=True),
-            )
-        assert_equal(
-            special.comb(4.5, 3, exact=True, legacy=False),
-            special.comb(4.5, 3),
-        )
-        assert_equal(
-            special.comb(4, 3.5, exact=True, legacy=False),
-            special.comb(4, 3.5),
-        )
+    @pytest.mark.parametrize("repetition", [True, False])
+    @pytest.mark.parametrize("legacy", [True, False])
+    @pytest.mark.parametrize("k", [3.5, 3])
+    @pytest.mark.parametrize("N", [4.5, 4])
+    def test_comb_legacy(self, N, k, legacy, repetition):
+        # test is only relevant for exact=True
+        if legacy and (N != int(N) or k != int(k)):
+            with pytest.warns(
+                DeprecationWarning,
+                match=r"Non-integer arguments are currently being cast to",
+            ):
+                result = special.comb(N, k, exact=True, legacy=legacy,
+                                      repetition=repetition)
+        else:
+            result = special.comb(N, k, exact=True, legacy=legacy,
+                                  repetition=repetition)
+        if legacy:
+            # for exact=True and legacy=True, cast input arguments, else don't
+            if repetition:
+                N, k = int(N + k - 1), int(k)
+                repetition = False
+            else:
+                N, k = int(N), int(k)
+        # expected result is the same as with exact=False
+        expected = special.comb(N, k, legacy=legacy, repetition=repetition)
+        assert_equal(result, expected)
 
     def test_comb_with_np_int64(self):
         n = 70

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1319,8 +1319,8 @@ class TestCombinatorics:
         expected = 100891344545564193334812497256
         assert_equal(special.comb(100, 50, exact=True), expected)
 
-        assert_raises(ValueError, special.comb, 4.5, 3, True)
-        assert_raises(ValueError, special.comb, 4, 3.5, True)
+        assert_raises(DeprecationWarning, special.comb, 4.5, 3, True)
+        assert_raises(DeprecationWarning, special.comb, 4, 3.5, True)
 
     def test_comb_with_np_int64(self):
         n = 70

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1319,7 +1319,6 @@ class TestCombinatorics:
         expected = 100891344545564193334812497256
         assert_equal(special.comb(100, 50, exact=True), expected)
 
-        assert_raises(ValueError, special.comb, [3,4], [1,2], True)
         assert_raises(ValueError, special.comb, 4.5, 3, True)
         assert_raises(ValueError, special.comb, 4, 3.5, True)
 

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1321,12 +1321,12 @@ class TestCombinatorics:
 
         with pytest.warns(
             DeprecationWarning,
-            match="Non-integer arguments are deprecated when exact=True;.*",
+            match=r"Non-integer arguments are deprecated when exact=True",
         ):
             special.comb(4.5, 3, exact=True)
         with pytest.warns(
             DeprecationWarning,
-            match="Non-integer arguments are deprecated when exact=True;.*",
+            match=r"Non-integer arguments are deprecated when exact=True",
         ):
             special.comb(4, 3.5, exact=True)
 

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1319,8 +1319,16 @@ class TestCombinatorics:
         expected = 100891344545564193334812497256
         assert_equal(special.comb(100, 50, exact=True), expected)
 
-        assert_raises(DeprecationWarning, special.comb, 4.5, 3, True)
-        assert_raises(DeprecationWarning, special.comb, 4, 3.5, True)
+        with pytest.warns(
+            DeprecationWarning,
+            match="Non-integer arguments when exact is True are deprecated.",
+        ):
+            special.comb(4.5, 3, exact=True)
+        with pytest.warns(
+            DeprecationWarning,
+            match="Non-integer arguments when exact is True are deprecated.",
+        ):
+            special.comb(4, 3.5, exact=True)
 
     def test_comb_with_np_int64(self):
         n = 70

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1319,6 +1319,10 @@ class TestCombinatorics:
         expected = 100891344545564193334812497256
         assert_equal(special.comb(100, 50, exact=True), expected)
 
+        assert_raises(ValueError, special.comb, [3,4], [1,2], True)
+        assert_raises(ValueError, special.comb, 4.5, 3, True)
+        assert_raises(ValueError, special.comb, 4, 3.5, True)
+
     def test_comb_with_np_int64(self):
         n = 70
         k = 30

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1321,7 +1321,7 @@ class TestCombinatorics:
 
         with pytest.warns(
             DeprecationWarning,
-            match=r"Non-integer arguments are deprecated when exact=True",
+            match=r"Non-integer arguments are currently being cast to",
         ):
             assert_equal(
                 special.comb(4.5, 3, exact=True, legacy=True),
@@ -1329,7 +1329,7 @@ class TestCombinatorics:
             )
         with pytest.warns(
             DeprecationWarning,
-            match=r"Non-integer arguments are deprecated when exact=True",
+            match=r"Non-integer arguments are currently being cast to",
         ):
             assert_equal(
                 special.comb(4, 3.5, exact=True, legacy=True),

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1321,12 +1321,12 @@ class TestCombinatorics:
 
         with pytest.warns(
             DeprecationWarning,
-            match="Non-integer arguments when exact is True are deprecated.",
+            match="Non-integer arguments are deprecated when exact=True;.*",
         ):
             special.comb(4.5, 3, exact=True)
         with pytest.warns(
             DeprecationWarning,
-            match="Non-integer arguments when exact is True are deprecated.",
+            match="Non-integer arguments are deprecated when exact=True;.*",
         ):
             special.comb(4, 3.5, exact=True)
 

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1338,6 +1338,9 @@ class TestCombinatorics:
         if legacy:
             # for exact=True and legacy=True, cast input arguments, else don't
             if repetition:
+                # the casting in legacy mode happens AFTER transforming N & k,
+                # so rounding can change (e.g. both floats, but sum to int);
+                # hence we need to emulate the repetition-transformation here
                 N, k = int(N + k - 1), int(k)
                 repetition = False
             else:


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
#15351
#6501

#### What does this implement/fix?
<!--Please explain your changes.-->
Previously it was possible to make the answer less precise by setting `exact=True` (see #15351 ). For example:
```
>>> x, y = 3.9, 2.8
>>> (comb(x, y), comb(x, y, exact=True))
(4.2071983565457955, 3)
```
This pull request changes comb so that when `exact=True` and non integer arguments are parsed a `ValueError` is thrown. A test is also added for this. 
#### Additional information
<!--Any additional information you think is important.-->
