### PR TITLE
MAINT: sparse.linalg: Remove unnecessary operations

### DIFF
--- a/scipy/sparse/linalg/_isolve/utils.py
+++ b/scipy/sparse/linalg/_isolve/utils.py
@@ -66,23 +66,21 @@ def make_system(A, M, x0, b):
     A = aslinearoperator(A)
 
     if A.shape[0] != A.shape[1]:
-        raise ValueError('expected square matrix, but got shape=%s' % (A.shape,))
+        raise ValueError(f'expected square matrix, but got shape={(A.shape,)}')
 
     N = A.shape[0]
 
     b = asanyarray(b)
 
     if not (b.shape == (N,1) or b.shape == (N,)):
-        raise ValueError('shapes of A {} and b {} are incompatible'
-                         .format(A.shape, b.shape))
+        raise ValueError(f'shapes of A {A.shape} and b {b.shape} are '
+                         'incompatible')
 
     if b.dtype.char not in 'fdFD':
         b = b.astype('d')  # upcast non-FP types to double
 
     def postprocess(x):
-        if isinstance(b,matrix):
-            x = asmatrix(x)
-        return x.reshape(b.shape)
+        return x
 
     if hasattr(A,'dtype'):
         xtype = A.dtype.char


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
Removed the unnecessary condition statement related with the `numpy.matrix` type in `utils.py` because `b` is a `ndarray` after calling `make_system`, and the `reshape` operation  is also unnecessary.

#### Additional information
<!--Any additional information you think is important.-->
