### PR TITLE
Make signal functions respect input dtype.

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -2285,7 +2285,7 @@ def hilbert(x, N=None, axis=-1):
         raise ValueError("N must be positive.")
 
     Xf = sp_fft.fft(x, N, axis=axis)
-    h = np.zeros(N)
+    h = np.zeros(N, dtype=Xf.dtype)
     if N % 2 == 0:
         h[0] = h[N // 2] = 1
         h[1:N // 2] = 2
@@ -2339,8 +2339,8 @@ def hilbert2(x, N=None):
                          "two positive integers")
 
     Xf = sp_fft.fft2(x, N, axes=(0, 1))
-    h1 = np.zeros(N[0], 'd')
-    h2 = np.zeros(N[1], 'd')
+    h1 = np.zeros(N[0], dtype=Xf.dtype)
+    h2 = np.zeros(N[1], dtype=Xf.dtype)
     for p in range(2):
         h = eval("h%d" % (p + 1))
         N1 = N[p]

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -3605,9 +3605,9 @@ def lfilter_zi(b, a):
 
     # Pad a or b with zeros so they are the same length.
     if len(a) < n:
-        a = np.r_[a, np.zeros(n - len(a))]
+        a = np.r_[a, np.zeros(n - len(a), dtype=a.dtype)]
     elif len(b) < n:
-        b = np.r_[b, np.zeros(n - len(b))]
+        b = np.r_[b, np.zeros(n - len(b), dtype=b.dtype)]
 
     IminusA = np.eye(n - 1, dtype=np.result_type(a, b)) - linalg.companion(a).T
     B = b[1:] - a[1:] * b[0]

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2646,6 +2646,11 @@ class TestHilbert:
                            9.444121133484362e-17 - 0.79252210110103j])
         assert_almost_equal(aan[0], a0hilb, 14, 'N regression')
 
+    @pytest.mark.parametrize('dtype', [np.float32, np.float64])
+    def test_hilbert_types(self, dtype):
+        in_typed = np.array(32, dtype=dtype)
+        assert_equal(np.real(signal.hilbert(in_typed)).dtype, dtype)
+
 
 class TestHilbert2:
 
@@ -2663,6 +2668,11 @@ class TestHilbert2:
         assert_raises(ValueError, hilbert2, x, N=0)
         assert_raises(ValueError, hilbert2, x, N=(2, 0))
         assert_raises(ValueError, hilbert2, x, N=(2,))
+
+    @pytest.mark.parametrize('dtype', [np.float32, np.float64])
+    def test_hilbert2_types(self, dtype):
+        in_typed = np.array(32, dtype=dtype)
+        assert_equal(np.real(signal.hilbert(in_typed)).dtype, dtype)
 
 
 class TestPartialFractionExpansion:

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2209,6 +2209,12 @@ class TestLFilterZI:
         zi2 = lfilter_zi(2*b, 2*a)
         assert_allclose(zi2, zi1, rtol=1e-12)
 
+    @pytest.mark.parametrize('dtype', [np.float32, np.float64])
+    def test_types(self, dtype):
+        b = np.zeros((8), dtype=dtype)
+        a = np.array([1], dtype=dtype)
+        assert_equal(np.real(signal.lfilter_zi(b, a)).dtype, dtype)
+
 
 class TestFiltFilt:
     filtfilt_kind = 'tf'

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2648,7 +2648,7 @@ class TestHilbert:
 
     @pytest.mark.parametrize('dtype', [np.float32, np.float64])
     def test_hilbert_types(self, dtype):
-        in_typed = np.array(32, dtype=dtype)
+        in_typed = np.zeros(32, dtype=dtype)
         assert_equal(np.real(signal.hilbert(in_typed)).dtype, dtype)
 
 
@@ -2671,8 +2671,8 @@ class TestHilbert2:
 
     @pytest.mark.parametrize('dtype', [np.float32, np.float64])
     def test_hilbert2_types(self, dtype):
-        in_typed = np.array(32, dtype=dtype)
-        assert_equal(np.real(signal.hilbert(in_typed)).dtype, dtype)
+        in_typed = np.zeros((2, 32), dtype=dtype)
+        assert_equal(np.real(signal.hilbert2(in_typed)).dtype, dtype)
 
 
 class TestPartialFractionExpansion:

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2654,7 +2654,7 @@ class TestHilbert:
 
     @pytest.mark.parametrize('dtype', [np.float32, np.float64])
     def test_hilbert_types(self, dtype):
-        in_typed = np.zeros(32, dtype=dtype)
+        in_typed = np.zeros(8, dtype=dtype)
         assert_equal(np.real(signal.hilbert(in_typed)).dtype, dtype)
 
 


### PR DESCRIPTION
This pull request ensures that the data type from the input and output are the same. This results in an expressive 35% speedup in single-precision Hilbert operations.

```
## Upstream
%timeit sc.hilbert(data64)
126 ms ± 284 us per loop (mean ‡ std. dev. of 7 runs, 10 Loops each)
%timeit sc.hilbert(data32)
101 ms ± 662 us per loop (mean ‡ std. dev. of 7 runs, 10 Loops each)
```

```
## Patch
In [5]: %timeit sc.hilbert (data64)
130 ms ± 259 us per loop (mean + std. dev. of 7 runs, 10 Loops each)
In [6]: %timeit sc.hilbert(data32)
75.6 ms ± 174 us per Loop (mean ‡ std. dev. of 7 runs, 10 Loops each)
```