### PR TITLE
MAINT: remove version pinning on gmpy2

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -37,7 +37,7 @@ jobs:
           python3.8-dbg -c 'import sys; print("Python debug build:", hasattr(sys, "gettotalrefcount"))'
           python3.8-dbg -m pip install --upgrade pip "setuptools<60.0" wheel
           python3.8-dbg -m pip install --upgrade numpy cython pytest pytest-xdist pybind11
-          python3.8-dbg -m pip install --upgrade mpmath gmpy2==2.1.0rc1 pythran threadpoolctl
+          python3.8-dbg -m pip install --upgrade mpmath gmpy2 pythran threadpoolctl
           python3.8-dbg -m pip uninstall -y nose
           cd ..
       - name: Building SciPy

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -77,7 +77,7 @@ jobs:
     - name: Install packages
       run: |
         pip install ${{ matrix.numpy-version }}
-        pip install setuptools==59.8.0 wheel cython pytest pytest-xdist pybind11 pytest-xdist mpmath gmpy2==2.1.0rc1 pythran
+        pip install setuptools==59.8.0 wheel cython pytest pytest-xdist pybind11 pytest-xdist mpmath gmpy2 pythran
 
     - name: Test SciPy
       run: |

--- a/ci/azure-travis-template.yaml
+++ b/ci/azure-travis-template.yaml
@@ -67,7 +67,7 @@ steps:
     pip install --upgrade pip==20.2.4 setuptools wheel &&
     pip install ${{parameters.other_spec}}
     cython
-    gmpy2==2.1.0rc1
+    gmpy2
     threadpoolctl
     mpmath
     pythran

--- a/environment.yml
+++ b/environment.yml
@@ -36,5 +36,5 @@ dependencies:
   - flake8
   # Some optional test dependencies
   - mpmath
-  - gmpy2=2.1.0rc1
+  - gmpy2
   - threadpoolctl

--- a/environment_meson.yml
+++ b/environment_meson.yml
@@ -38,5 +38,5 @@ dependencies:
   - flake8
   # Some optional test dependencies
   - mpmath
-  - gmpy2=2.1.0rc1
+  - gmpy2
   - threadpoolctl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ test = [
     "pytest-xdist",
     "asv",
     "mpmath",
-    "gmpy2==2.1.0rc1",
+    "gmpy2",
     "threadpoolctl",
     "scikit-umfpack",
 ]


### PR DESCRIPTION
gmpy2 was set to a RC due to a bug in the previous old stable release. Now that gmpy2 2.1.2 got released, the pinning is not necessary anymore.