### PR TITLE
MAINT: Fix a couple build warnings.

### DIFF
--- a/scipy/special/cephes/kolmogorov.c
+++ b/scipy/special/cephes/kolmogorov.c
@@ -720,7 +720,7 @@ _smirnov(int n, double x)
     double cdf, sf, pdf;
 
     int bUseUpperSum;
-    int nxfl, nxceil, n1mxfl, n1mxceil;
+    int nxfl, n1mxfl, n1mxceil;
     ThreeProbs ret;
 
     if (!(n > 0 && x >= 0.0 && x <= 1.0)) {
@@ -737,7 +737,6 @@ _smirnov(int n, double x)
     }
 
     alpha = modNX(n, x, &nxfl, &nx);
-    nxceil = nxfl + (alpha == 0 ? 0: 1);
     n1mxfl = n - nxfl - (alpha == 0 ? 0 : 1);
     n1mxceil = n - nxfl;
     /*

--- a/scipy/stats/statlib/spearman.f
+++ b/scipy/stats/statlib/spearman.f
@@ -9,7 +9,7 @@ c
 c     Auxiliary function required: ALNORM = algorithm AS66
 c
       dimension l(6)
-      double precision zero, one, two, b, x, y, z, u, six,
+      double precision zero, one, two, b, x, y, u, six,
      $  c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12
       data zero, one, two, six /0.0d0, 1.0d0, 2.0d0, 6.0d0/
       data        c1,     c2,     c3,     c4,     c5,     c6,


### PR DESCRIPTION
When I build the main branch with gcc+gfortran 11 and check the combined stderr and stdout outputs, 3114 lines contain the word `warning` or `Warning`.  This PR fixes two of them :neutral_face:.

```
scipy/special/cephes/kolmogorov.c: In function ‘_smirnov’:
scipy/special/cephes/kolmogorov.c:723:15: warning: variable ‘nxceil’ set but not used [-Wunused-but-set-variable]
  723 |     int nxfl, nxceil, n1mxfl, n1mxceil;
      |               ^~~~~~
```

```
scipy/stats/statlib/spearman.f:12:49:

   12 |       double precision zero, one, two, b, x, y, z, u, six,
      |                                                 1
Warning: Unused variable ‘z’ declared at (1) [-Wunused-variable]
```
