### PR TITLE
DOC: interpolate:  improve `RectBivariateSpline` doc

### DIFF
--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -1285,11 +1285,13 @@ class RectBivariateSpline(BivariateSpline):
     ----------
     x,y : array_like
         1-D arrays of coordinates in strictly ascending order.
+        Evaluated points outside the data range will be extrapolated.
     z : array_like
         2-D array of data with shape (x.size,y.size).
     bbox : array_like, optional
         Sequence of length 4 specifying the boundary of the rectangular
-        approximation domain.  By default,
+        approximation domain, which means the start and end spline knots of
+        each dimension are set by these values. By default,
         ``bbox=[min(x), max(x), min(y), max(y)]``.
     kx, ky : ints, optional
         Degrees of the bivariate spline. Default is 3.


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Fix #9944

#### What does this implement/fix?
<!--Please explain your changes.-->
I improved 2 points for [`RectBivariateSpline`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.RectBivariateSpline.html#scipy.interpolate.RectBivariateSpline) doc.
1. Add an explanation that the evaluated points outside the data range will be extrapolated to fix #9944.
2. Add an explanation that the `bbox` values are used for the first and last spline knots based on the [StackOverflow comment](https://stackoverflow.com/a/45909136/8387766).

