### PR TITLE
ENH: integrality constraints for differential_evolution

### DIFF
--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -200,8 +200,6 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
         broadcast to ``(len(x),)``.
         If any decision variables are constrained to be integral, they will not
         be changed during polishing.
-        The solution vectors are passed to the objective function as
-        ``func(np.round(x[integrality]))``.
         Only integer values lying between the lower and upper bounds are used.
         If there are no integer values lying between the bounds then a
         `ValueError` is raised.
@@ -508,11 +506,9 @@ class DifferentialEvolutionSolver:
         broadcast to ``(len(x),)``.
         If any decision variables are constrained to be integral, they will not
         be changed during polishing.
-        The solution vectors are passed to the objective function as
-        ``func(np.round(x[integrality]))``.
         Only integer values lying between the lower and upper bounds are used.
         If there are no integer values lying between the bounds then a
-        `ValueError` is raised. 
+        `ValueError` is raised.
     """
 
     # Dispatch of mutation strategy method (binomial or exponential).
@@ -628,12 +624,6 @@ class DifferentialEvolutionSolver:
         # Which parameters are going to be integers?
         if np.any(integrality):
             # # user has provided a truth value for integer constraints
-            # if polish:
-            #     message = ("Polishing is incompatible with integrality"
-            #                " constraints; `polish` will be ignored.")
-            #     self.polish = False
-            #     warnings.warn(message, OptimizeWarning)
-
             integrality = np.broadcast_to(
                 integrality,
                 self.parameter_count

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -198,8 +198,8 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
         For each decision variable, a boolean value indicating whether the
         decision variable is constrained to integer values. The array is
         broadcast to ``(len(x),)``.
-        If any decision variables are constrained to be integral, polishing
-        will switched off (e.g. ``polish=False``).
+        If any decision variables are constrained to be integral, they will not
+        be changed during polishing.
         The solution vectors are passed to the objective function as
         ``func(np.round(x[integrality]))``.
         Only integer values lying between the lower and upper bounds are used.
@@ -504,9 +504,15 @@ class DifferentialEvolutionSolver:
         replacement is done even if `init` is given an initial population.
     integrality : 1-D array, optional
         For each decision variable, a boolean value indicating whether the
-        decision variable is constrained to integer values. If any decision
-        variables are constrained to be integral, polishing will not be
-        performed (e.g. ``polish=False``).
+        decision variable is constrained to integer values. The array is
+        broadcast to ``(len(x),)``.
+        If any decision variables are constrained to be integral, they will not
+        be changed during polishing.
+        The solution vectors are passed to the objective function as
+        ``func(np.round(x[integrality]))``.
+        Only integer values lying between the lower and upper bounds are used.
+        If there are no integer values lying between the bounds then a
+        `ValueError` is raised. 
     """
 
     # Dispatch of mutation strategy method (binomial or exponential).
@@ -943,8 +949,7 @@ class DifferentialEvolutionSolver:
             message=status_message,
             success=(warning_flag is not True))
 
-        if (self.polish and
-                (np.count_nonzero(self.integrality) != self.parameter_count)):
+        if self.polish and not np.all(self.integrality):
             # can't polish if all the parameters are integers
             if np.any(self.integrality):
                 # set the lower/upper bounds equal so that any integrality

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -5,7 +5,7 @@ Added by Andrew Nelson 2014
 import warnings
 
 import numpy as np
-from scipy.optimize import OptimizeResult, minimize, OptimizeWarning
+from scipy.optimize import OptimizeResult, minimize
 from scipy.optimize._optimize import _status_message
 from scipy._lib._util import check_random_state, MapWrapper, _FunctionWrapper
 

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -648,7 +648,7 @@ class DifferentialEvolutionSolver:
                                  " have any possible integer values between"
                                  " the lower/upper bounds.")
             self.limits[0, self.integrality] = (
-                    lb[self.integrality] - (0.5 + _MACHEPS)
+                    lb[self.integrality] - (0.5 - _MACHEPS)
             )
             self.limits[1, self.integrality] = (
                     ub[self.integrality] + (0.5 - _MACHEPS)

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -621,12 +621,12 @@ class DifferentialEvolutionSolver:
 
         # Which parameters are going to be integers?
         if np.any(integrality):
-            # user has provided a truth value for integer constraints
-            if polish:
-                message = ("Polishing is incompatible with integrality"
-                           " constraints; `polish` will be ignored.")
-                self.polish = False
-                warnings.warn(message, OptimizeWarning)
+            # # user has provided a truth value for integer constraints
+            # if polish:
+            #     message = ("Polishing is incompatible with integrality"
+            #                " constraints; `polish` will be ignored.")
+            #     self.polish = False
+            #     warnings.warn(message, OptimizeWarning)
 
             integrality = np.broadcast_to(
                 integrality,
@@ -944,6 +944,13 @@ class DifferentialEvolutionSolver:
             success=(warning_flag is not True))
 
         if self.polish:
+            if np.any(self.integrality):
+                # set the lower/upper bounds equal so that any integrality
+                # constraints work.
+                limits, integrality = self.limits, self.integrality
+                limits[0, integrality] = DE_result.x[integrality]
+                limits[1, integrality] = DE_result.x[integrality]
+
             polish_method = 'L-BFGS-B'
 
             if self._wrapped_constraints:

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -944,8 +944,7 @@ class DifferentialEvolutionSolver:
             success=(warning_flag is not True))
 
         if (self.polish and
-                (np.count_nonzero(self.integrality) != self.parameter_count)
-        ):
+                (np.count_nonzero(self.integrality) != self.parameter_count)):
             # can't polish if all the parameters are integers
             if np.any(self.integrality):
                 # set the lower/upper bounds equal so that any integrality

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -943,7 +943,10 @@ class DifferentialEvolutionSolver:
             message=status_message,
             success=(warning_flag is not True))
 
-        if self.polish:
+        if (self.polish and
+                (np.count_nonzero(self.integrality) != self.parameter_count)
+        ):
+            # can't polish if all the parameters are integers
             if np.any(self.integrality):
                 # set the lower/upper bounds equal so that any integrality
                 # constraints work.

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -6,7 +6,7 @@ import platform
 
 from scipy.optimize._differentialevolution import (DifferentialEvolutionSolver,
                                                    _ConstraintWrapper)
-from scipy.optimize import differential_evolution, OptimizeWarning
+from scipy.optimize import differential_evolution
 from scipy.optimize._constraints import (Bounds, NonlinearConstraint,
                                          LinearConstraint)
 from scipy.optimize import rosen, minimize
@@ -1275,14 +1275,17 @@ class TestDifferentialEvolutionSolver:
 
         # compare the DE derived solution to an LBFGSB solution (that doesn't
         # have to find the integral values). Note we're setting x0 to be the
-        # output from the first DE result, thereby making the polishing step and
-        # this minimisation pretty much equivalent.
-        LBFGSB = minimize(func2, res2.x[1], args=(5, dist, x), bounds=[(0, 0.95)])
+        # output from the first DE result, thereby making the polishing step
+        # and this minimisation pretty much equivalent.
+        LBFGSB = minimize(func2, res2.x[1], args=(5, dist, x),
+                          bounds=[(0, 0.95)])
         assert_allclose(res2.x[1], LBFGSB.x)
         assert res2.fun <= res.fun
 
     def test_integrality_limits(self):
-        f = lambda x: x
+        def f(x):
+            return x
+
         integrality = [True, False, True]
         bounds = [(0.2, 1.1), (0.9, 2.2), (3.3, 4.9)]
 
@@ -1298,7 +1301,7 @@ class TestDifferentialEvolutionSolver:
         assert_allclose(solver.limits[0], [0.5, 0.9, 3.5])
         assert_allclose(solver.limits[1], [1.5, 2.2, 4.5])
         assert_equal(solver.integrality, [True, False, True])
-        assert solver.polish == False
+        assert solver.polish is False
 
         bounds = [(-1.2, -0.9), (0.9, 2.2), (-10.3, 4.1)]
         solver = DifferentialEvolutionSolver(f, bounds=bounds, polish=False,

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -1309,6 +1309,13 @@ class TestDifferentialEvolutionSolver:
         assert_allclose(solver.limits[0], [-1.5, 0.9, -10.5])
         assert_allclose(solver.limits[1], [-0.5, 2.2, 4.5])
 
+        # A lower bound of -1.2 is converted to
+        # np.nextafter(np.ceil(-1.2) - 0.5, np.inf)
+        # with a similar process to the upper bound. Check that the
+        # conversions work
+        assert_allclose(np.round(solver.limits[0]), [-1.0, 1.0, -10.0])
+        assert_allclose(np.round(solver.limits[1]), [-1.0, 2.0, 4.0])
+
         bounds = [(-10.2, -8.1), (0.9, 2.2), (-10.9, -9.9999)]
         solver = DifferentialEvolutionSolver(f, bounds=bounds, polish=False,
                                              integrality=integrality)

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -1266,8 +1266,8 @@ class TestDifferentialEvolutionSolver:
 
         # check that we can still use integrality constraints with polishing
         res2 = differential_evolution(func, bounds, args=(dist, x),
-                                     integrality=integrality, polish=True,
-                                     seed=rng)
+                                      integrality=integrality, polish=True,
+                                      seed=rng)
 
         def func2(p, *args):
             n, dist, x = args

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -1268,6 +1268,7 @@ class TestDifferentialEvolutionSolver:
         res2 = differential_evolution(func, bounds, args=(dist, x),
                                      integrality=integrality, polish=True,
                                      seed=rng)
+
         def func2(p, *args):
             n, dist, x = args
             return func(np.array([n, p[0]]), dist, x)
@@ -1313,5 +1314,5 @@ class TestDifferentialEvolutionSolver:
 
         bounds = [(-10.2, -10.1), (0.9, 2.2), (-10.9, -9.9999)]
         with pytest.raises(ValueError, match='One of the integrality'):
-           DifferentialEvolutionSolver(f, bounds=bounds, polish=False,
-                                       integrality=integrality)
+            DifferentialEvolutionSolver(f, bounds=bounds, polish=False,
+                                        integrality=integrality)


### PR DESCRIPTION
Inspired by #15389. Makes it easier (and more obvious) to perform a minimisation with integrality constraints. By passing an `integrality` array parameter one can specify which parameters in the objective function should be considered as integers.

@mdhaber @mckib2 