### PR TITLE
ENH: optimize: improvements to `LinearConstraint` class

### DIFF
--- a/scipy/optimize/_constraints.py
+++ b/scipy/optimize/_constraints.py
@@ -188,7 +188,7 @@ class LinearConstraint:
 
         When all elements of ``sl`` and ``sb`` are positive, all elements of
         the constraint are satisfied; a negative element in ``sl`` or ``sb``
-        indicates that the corresponding element the constraint is not
+        indicates that the corresponding element of the constraint is not
         satisfied.
 
         Parameters

--- a/scipy/optimize/_constraints.py
+++ b/scipy/optimize/_constraints.py
@@ -133,21 +133,23 @@ class LinearConstraint:
     ----------
     A : {array_like, sparse matrix}, shape (m, n)
         Matrix defining the constraint.
-    lb, ub : array_like
-        Lower and upper bounds on the constraint. Each array must have the
+    lb, ub : array_like, optional
+        Lower and upper limits on the constraint. Each array must have the
         shape (m,) or be a scalar, in the latter case a bound will be the same
         for all components of the constraint. Use ``np.inf`` with an
         appropriate sign to specify a one-sided constraint.
         Set components of `lb` and `ub` equal to represent an equality
         constraint. Note that you can mix constraints of different types:
         interval, one-sided or equality, by setting different components of
-        `lb` and `ub` as  necessary.
+        `lb` and `ub` as  necessary. Defaults to ``lb = -np.inf``
+        and ``ub = np.inf`` (no limits).
     keep_feasible : array_like of bool, optional
         Whether to keep the constraint components feasible throughout
         iterations. A single value set this property for all components.
         Default is False. Has no effect for equality constraints.
     """
-    def __init__(self, A, lb, ub, keep_feasible=False):
+
+    def __init__(self, A, lb=-np.inf, ub=np.inf, keep_feasible=False):
         self.A = A
         self.lb = lb
         self.ub = ub

--- a/scipy/optimize/_constraints.py
+++ b/scipy/optimize/_constraints.py
@@ -173,6 +173,36 @@ class LinearConstraint:
         self.keep_feasible = np.atleast_1d(keep_feasible).astype(bool)
         self._input_validation()
 
+    def residual(self, x):
+        """
+        Calculate the residual between the constraint function and the limits
+
+        For a linear constraint of the form::
+
+            lb <= A@x <= ub
+
+        the lower and upper residuals between ``A@x`` and the limits are values
+        ``sl`` and ``sb`` such that::
+
+            lb + sl == A@x == ub - sb
+
+        When all elements of ``sl`` and ``sb`` are positive, all elements of
+        the constraint are satisfied; a negative element in ``sl`` or ``sb``
+        indicates that the corresponding element the constraint is not
+        satisfied.
+
+        Parameters
+        ----------
+        x: array_like
+            Vector of independent variables
+
+        Returns
+        -------
+        sl, sb : array-like
+            The lower and upper residuals
+        """
+        return self.A@x - self.lb, self.ub - self.A@x
+
 
 class Bounds:
     """Bounds constraint on the variables.

--- a/scipy/optimize/tests/test_constraints.py
+++ b/scipy/optimize/tests/test_constraints.py
@@ -226,3 +226,9 @@ class TestLinearConstraint:
         message = "`A` must have exactly two dimensions."
         with pytest.raises(ValueError, match=message):
             LinearConstraint(A)
+
+    def test_residual(self):
+        A = np.eye(2)
+        lc = LinearConstraint(A, -2, 4)
+        x0 = [-1, 2]
+        np.testing.assert_allclose(lc.residual(x0), ([1, 4], [5, 2]))

--- a/scipy/optimize/tests/test_constraints.py
+++ b/scipy/optimize/tests/test_constraints.py
@@ -206,3 +206,12 @@ class TestBounds:
         bounds = Bounds(-2, 4)
         x0 = [-1, 2]
         np.testing.assert_allclose(bounds.residual(x0), ([1, 4], [5, 2]))
+
+
+class TestLinearConstraint:
+    def test_defaults(self):
+        A = np.eye(4)
+        lc = LinearConstraint(A)
+        lc2 = LinearConstraint(A, -np.inf, np.inf)
+        assert lc.lb == lc2.lb
+        assert lc.ub == lc2.ub

--- a/scipy/optimize/tests/test_constraints.py
+++ b/scipy/optimize/tests/test_constraints.py
@@ -213,5 +213,16 @@ class TestLinearConstraint:
         A = np.eye(4)
         lc = LinearConstraint(A)
         lc2 = LinearConstraint(A, -np.inf, np.inf)
-        assert lc.lb == lc2.lb
-        assert lc.ub == lc2.ub
+        assert_array_equal(lc.lb, lc2.lb)
+        assert_array_equal(lc.ub, lc2.ub)
+
+    def test_input_validation(self):
+        A = np.eye(4)
+        message = "`lb`, `ub`, and `keep_feasible` must be broadcastable"
+        with pytest.raises(ValueError, match=message):
+            LinearConstraint(A, [1, 2], [1, 2, 3])
+
+        A = np.empty((4, 3, 5))
+        message = "`A` must have exactly two dimensions."
+        with pytest.raises(ValueError, match=message):
+            LinearConstraint(A)


### PR DESCRIPTION
#### What does this implement/fix?
The motivation for this PR is a WIP `milp` function for mixed-integer linear programming, which will accept `LinearConstraint` objects. 
Rather than making sure that the `LinearConstraint` objects are valid in `milp`, it makes sense to add input validation to the `LinearConstraint` class. I also wanted to add some other features to the class for user convenience.
 
The first commit adds default values for `lb` and `ub`
The second commit adds input validation
The third commit adds a `residual` method that computes the distance from an input `x` to the constraint limits

#### Additional information
This is a follow-up to gh-15297. It would be good to merge this before gh-15460, as the `milp` input validation can then rely on these improvements to the `LinearConstraint` input validation.
