### PR TITLE
ENH: port scipy.signal._arraytools to be Array API compatible

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -15,3 +15,4 @@ filterwarnings =
     ignore:'environmentfilter' is renamed to 'pass_environment'
     ignore:'contextfunction' is renamed to 'pass_context'
     ignore:.*The distutils.* is deprecated.*:DeprecationWarning
+    ignore:.*The numpy.array_api submodule is still experimental.*:UserWarning

--- a/scipy/_lib/_array_api_util.py
+++ b/scipy/_lib/_array_api_util.py
@@ -1,0 +1,65 @@
+"""Utility functions to use Python Array API compatible libraries.
+
+For the context about the Array API see:
+https://data-apis.org/array-api/latest/purpose_and_scope.html
+
+The SciPy use case of the Array API is described on the following page:
+https://data-apis.org/array-api/latest/use_cases.html#use-case-scipy
+"""
+
+import numpy as np
+
+from scipy._lib import _pep440
+
+_NUMPY_INCLUDES_ARRAY_API = _pep440.parse(np.__version__) >= _pep440.Version(
+    "1.22.0"
+)
+
+
+def _get_namespace(*arrays):
+    """
+    Returns the module that implements Array API compatible functions or NumPy.
+
+    Parameters
+    ----------
+    *arrays : sequence of array_like
+        Arrays to get the namespace from.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> x = np.arange(6)
+    >>> _get_namespace(x).__name__
+    'numpy'
+
+    >>> import numpy.array_api as xp
+    >>> x = xp.arange(6)
+    >>> _get_namespace(x).__name__
+    'numpy.array_api'
+    """
+    # `arrays` contains one or more arrays
+    # When there is no __array_namespace__,
+    # we will use assume the default (NumPy) namespace.
+    namespaces = {
+        x.__array_namespace__() if hasattr(x, "__array_namespace__") else np
+        for x in arrays
+    }
+
+    if len(namespaces) != 1:
+        raise ValueError(
+            f"Expected a single common namespace for array inputs, \
+              but got: {[n.__name__ for n in namespaces]}"
+        )
+
+    (xp,) = namespaces
+
+    return xp
+
+
+def _concatenate(arrays, axis):
+    """NumPy and Array API compatibility function for concatenating arrays."""
+    xp = _get_namespace(*arrays)
+    if xp is np:
+        return xp.concatenate(arrays, axis=axis)
+    else:
+        return xp.concat(arrays, axis=axis)

--- a/scipy/_lib/_array_api_util.py
+++ b/scipy/_lib/_array_api_util.py
@@ -20,6 +20,8 @@ def _get_namespace(*arrays):
     """
     Returns the module that implements Array API compatible functions or NumPy.
 
+    .. versionadded:: 1.9.0
+
     Parameters
     ----------
     *arrays : sequence of array_like

--- a/scipy/_lib/meson.build
+++ b/scipy/_lib/meson.build
@@ -90,6 +90,7 @@ py3.extension_module('messagestream',
 
 python_sources = [
   '__init__.py',
+  '_array_api_utils.py',
   '_bunch.py',
   '_ccallback.py',
   '_disjoint_set.py',

--- a/scipy/signal/_arraytools.py
+++ b/scipy/signal/_arraytools.py
@@ -3,6 +3,8 @@ Functions for acting on a axis of an array.
 """
 import numpy as np
 
+from scipy._lib._array_api_util import _concatenate, _get_namespace
+
 
 def axis_slice(a, start=None, stop=None, step=None, axis=-1):
     """Take a slice along axis 'axis' from 'a'.
@@ -97,10 +99,9 @@ def odd_ext(x, n, axis=-1):
     left_ext = axis_slice(x, start=n, stop=0, step=-1, axis=axis)
     right_end = axis_slice(x, start=-1, axis=axis)
     right_ext = axis_slice(x, start=-2, stop=-(n + 2), step=-1, axis=axis)
-    ext = np.concatenate((2 * left_end - left_ext,
-                          x,
-                          2 * right_end - right_ext),
-                         axis=axis)
+    ext = _concatenate(
+        (2 * left_end - left_ext, x, 2 * right_end - right_ext), axis=axis
+    )
     return ext
 
 
@@ -146,10 +147,7 @@ def even_ext(x, n, axis=-1):
                          % (n, x.shape[axis] - 1))
     left_ext = axis_slice(x, start=n, stop=0, step=-1, axis=axis)
     right_ext = axis_slice(x, start=-2, stop=-(n + 2), step=-1, axis=axis)
-    ext = np.concatenate((left_ext,
-                          x,
-                          right_ext),
-                         axis=axis)
+    ext = _concatenate((left_ext, x, right_ext), axis=axis)
     return ext
 
 
@@ -191,19 +189,17 @@ def const_ext(x, n, axis=-1):
     >>> plt.legend(loc='best')
     >>> plt.show()
     """
+    xp = _get_namespace(x)
     if n < 1:
         return x
     left_end = axis_slice(x, start=0, stop=1, axis=axis)
     ones_shape = [1] * x.ndim
     ones_shape[axis] = n
-    ones = np.ones(ones_shape, dtype=x.dtype)
+    ones = xp.ones(ones_shape, dtype=x.dtype)
     left_ext = ones * left_end
     right_end = axis_slice(x, start=-1, axis=axis)
     right_ext = ones * right_end
-    ext = np.concatenate((left_ext,
-                          x,
-                          right_ext),
-                         axis=axis)
+    ext = _concatenate((left_ext, x, right_ext), axis=axis)
     return ext
 
 
@@ -232,10 +228,11 @@ def zero_ext(x, n, axis=-1):
     array([[ 0,  0,  1,  2,  3,  4,  5,  0,  0],
            [ 0,  0,  0,  1,  4,  9, 16,  0,  0]])
     """
+    xp = _get_namespace(x)
     if n < 1:
         return x
     zeros_shape = list(x.shape)
     zeros_shape[axis] = n
-    zeros = np.zeros(zeros_shape, dtype=x.dtype)
-    ext = np.concatenate((zeros, x, zeros), axis=axis)
+    zeros = xp.zeros(zeros_shape, dtype=x.dtype)
+    ext = _concatenate((zeros, x, zeros), axis=axis)
     return ext

--- a/scipy/signal/tests/_utils.py
+++ b/scipy/signal/tests/_utils.py
@@ -1,0 +1,11 @@
+import pytest
+import numpy
+from scipy._lib._array_api_util import _NUMPY_INCLUDES_ARRAY_API
+
+
+if _NUMPY_INCLUDES_ARRAY_API:
+    import numpy.array_api
+
+pytest_enable_array_api = pytest.mark.parametrize(
+    "xp", [numpy, *((numpy.array_api,) if _NUMPY_INCLUDES_ARRAY_API else ())]
+)

--- a/scipy/signal/tests/test_array_tools.py
+++ b/scipy/signal/tests/test_array_tools.py
@@ -1,16 +1,17 @@
-import numpy as np
-
 from numpy.testing import assert_array_equal
 from pytest import raises as assert_raises
+import pytest
 
 from scipy.signal._arraytools import (axis_slice, axis_reverse,
      odd_ext, even_ext, const_ext, zero_ext)
 
+from scipy.signal.tests._utils import pytest_enable_array_api
 
+
+@pytest_enable_array_api
 class TestArrayTools:
-
-    def test_axis_slice(self):
-        a = np.arange(12).reshape(3, 4)
+    def test_axis_slice(self, xp):
+        a = xp.reshape(xp.arange(12), (3, 4))
 
         s = axis_slice(a, start=0, stop=1, axis=0)
         assert_array_equal(s, a[0:1, :])
@@ -30,8 +31,8 @@ class TestArrayTools:
         s = axis_slice(a, start=0, step=2, axis=1)
         assert_array_equal(s, a[:, ::2])
 
-    def test_axis_reverse(self):
-        a = np.arange(12).reshape(3, 4)
+    def test_axis_reverse(self, xp):
+        a = xp.reshape(xp.arange(12), (3, 4))
 
         r = axis_reverse(a, axis=0)
         assert_array_equal(r, a[::-1, :])
@@ -39,73 +40,103 @@ class TestArrayTools:
         r = axis_reverse(a, axis=1)
         assert_array_equal(r, a[:, ::-1])
 
-    def test_odd_ext(self):
-        a = np.array([[1, 2, 3, 4, 5],
-                      [9, 8, 7, 6, 5]])
+    def test_odd_ext(self, xp):
+        a = xp.asarray([[1, 2, 3, 4, 5], [9, 8, 7, 6, 5]])
 
         odd = odd_ext(a, 2, axis=1)
-        expected = np.array([[-1, 0, 1, 2, 3, 4, 5, 6, 7],
-                             [11, 10, 9, 8, 7, 6, 5, 4, 3]])
+        expected = xp.asarray(
+            [[-1, 0, 1, 2, 3, 4, 5, 6, 7], [11, 10, 9, 8, 7, 6, 5, 4, 3]]
+        )
         assert_array_equal(odd, expected)
 
         odd = odd_ext(a, 1, axis=0)
-        expected = np.array([[-7, -4, -1, 2, 5],
-                             [1, 2, 3, 4, 5],
-                             [9, 8, 7, 6, 5],
-                             [17, 14, 11, 8, 5]])
+        expected = xp.asarray(
+            [
+                [-7, -4, -1, 2, 5],
+                [1, 2, 3, 4, 5],
+                [9, 8, 7, 6, 5],
+                [17, 14, 11, 8, 5],
+            ]
+        )
         assert_array_equal(odd, expected)
 
         assert_raises(ValueError, odd_ext, a, 2, axis=0)
         assert_raises(ValueError, odd_ext, a, 5, axis=1)
 
-    def test_even_ext(self):
-        a = np.array([[1, 2, 3, 4, 5],
-                      [9, 8, 7, 6, 5]])
+    def test_even_ext(self, xp):
+        a = xp.asarray([[1, 2, 3, 4, 5], [9, 8, 7, 6, 5]])
 
         even = even_ext(a, 2, axis=1)
-        expected = np.array([[3, 2, 1, 2, 3, 4, 5, 4, 3],
-                             [7, 8, 9, 8, 7, 6, 5, 6, 7]])
+        expected = xp.asarray(
+            [[3, 2, 1, 2, 3, 4, 5, 4, 3], [7, 8, 9, 8, 7, 6, 5, 6, 7]]
+        )
         assert_array_equal(even, expected)
 
         even = even_ext(a, 1, axis=0)
-        expected = np.array([[9, 8, 7, 6, 5],
-                             [1, 2, 3, 4, 5],
-                             [9, 8, 7, 6, 5],
-                             [1, 2, 3, 4, 5]])
+        expected = xp.asarray(
+            [
+                [9, 8, 7, 6, 5],
+                [1, 2, 3, 4, 5],
+                [9, 8, 7, 6, 5],
+                [1, 2, 3, 4, 5],
+            ]
+        )
         assert_array_equal(even, expected)
 
         assert_raises(ValueError, even_ext, a, 2, axis=0)
         assert_raises(ValueError, even_ext, a, 5, axis=1)
 
-    def test_const_ext(self):
-        a = np.array([[1, 2, 3, 4, 5],
-                      [9, 8, 7, 6, 5]])
+    def test_const_ext(self, xp):
+        a = xp.asarray([[1, 2, 3, 4, 5], [9, 8, 7, 6, 5]])
 
         const = const_ext(a, 2, axis=1)
-        expected = np.array([[1, 1, 1, 2, 3, 4, 5, 5, 5],
-                             [9, 9, 9, 8, 7, 6, 5, 5, 5]])
+        expected = xp.asarray(
+            [[1, 1, 1, 2, 3, 4, 5, 5, 5], [9, 9, 9, 8, 7, 6, 5, 5, 5]]
+        )
         assert_array_equal(const, expected)
 
         const = const_ext(a, 1, axis=0)
-        expected = np.array([[1, 2, 3, 4, 5],
-                             [1, 2, 3, 4, 5],
-                             [9, 8, 7, 6, 5],
-                             [9, 8, 7, 6, 5]])
+        expected = xp.asarray(
+            [
+                [1, 2, 3, 4, 5],
+                [1, 2, 3, 4, 5],
+                [9, 8, 7, 6, 5],
+                [9, 8, 7, 6, 5],
+            ]
+        )
         assert_array_equal(const, expected)
 
-    def test_zero_ext(self):
-        a = np.array([[1, 2, 3, 4, 5],
-                      [9, 8, 7, 6, 5]])
+    def test_zero_ext(self, xp):
+        a = xp.asarray([[1, 2, 3, 4, 5], [9, 8, 7, 6, 5]])
 
         zero = zero_ext(a, 2, axis=1)
-        expected = np.array([[0, 0, 1, 2, 3, 4, 5, 0, 0],
-                             [0, 0, 9, 8, 7, 6, 5, 0, 0]])
+        expected = xp.asarray(
+            [[0, 0, 1, 2, 3, 4, 5, 0, 0], [0, 0, 9, 8, 7, 6, 5, 0, 0]]
+        )
         assert_array_equal(zero, expected)
 
         zero = zero_ext(a, 1, axis=0)
-        expected = np.array([[0, 0, 0, 0, 0],
-                             [1, 2, 3, 4, 5],
-                             [9, 8, 7, 6, 5],
-                             [0, 0, 0, 0, 0]])
+        expected = xp.asarray(
+            [
+                [0, 0, 0, 0, 0],
+                [1, 2, 3, 4, 5],
+                [9, 8, 7, 6, 5],
+                [0, 0, 0, 0, 0],
+            ]
+        )
         assert_array_equal(zero, expected)
 
+
+@pytest_enable_array_api
+class TestArrayToolsReturnTypes:
+    @pytest.mark.parametrize("func", [axis_slice, axis_reverse])
+    def test_type_axis_funcs(self, xp, func):
+        x = xp.asarray([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+        result = func(x)
+        assert type(x) == type(result)
+
+    @pytest.mark.parametrize("func", [odd_ext, even_ext, const_ext, zero_ext])
+    def test_type_ext_funcs(self, xp, func):
+        x = xp.asarray([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+        result = func(x, 2)
+        assert type(x) == type(result)


### PR DESCRIPTION
List of ported functions:
* odd_ext
* even_ext
* const_ext
* zero_ext

List of functions that were already working with Array API arrays:
* axis_slice
* axis_reverse

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Ref. https://github.com/scipy/scipy/issues/15354

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR makes functions from `scipy.signal._arraytools` accept and return arrays from Array API compatible libraries such as `numpy.array_api` and `cupy.array_api`. Only `numpy.array_api` is tested here.

cc: @AnirudhDagar, @rgommers, @czgdp1807   