### PR TITLE
DOC: Git:// protocol on github pending removal.

### DIFF
--- a/doc/source/dev/contributor/recommended_development_setup.rst
+++ b/doc/source/dev/contributor/recommended_development_setup.rst
@@ -23,7 +23,7 @@ account and then create your local repository via::
     $ git clone git@github.com:YOURUSERNAME/scipy.git scipy
     $ cd scipy
     $ git submodule update --init
-    $ git remote add upstream git://github.com/scipy/scipy.git
+    $ git remote add upstream https://github.com/scipy/scipy.git
 
 Second to code review pull requests it is helpful to have a local copy of the
 code changes in the pull request. The preferred method to bring a PR from the

--- a/doc/source/dev/gitwash/following_latest.rst
+++ b/doc/source/dev/gitwash/following_latest.rst
@@ -16,7 +16,7 @@ Get the local copy of the code
 
 From the command line::
 
-   git clone git://github.com/scipy/scipy.git
+   git clone https://github.com/scipy/scipy.git
 
 You now have a copy of the code tree in the new ``scipy`` directory.
 If this doesn't work you can try the alternative read-only url::


### PR DESCRIPTION
Today is a brownout day and git will later be removed unless properly
configured to use ssh.

https://github.blog/2021-09-01-improving-git-protocol-security-github/

Tell users to use https.