### PR TITLE
BUG: ensured vendored pep440 is imported

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -139,7 +139,6 @@ def get_build_ext_override():
             import pythran
             from pythran.dist import PythranBuildExt
             BaseBuildExt = PythranBuildExt[npy_build_ext]
-            # Version check - a too old Pythran will give problems
             importlib.import_module('scipy/_lib/_pep440')
             if _pep440.parse(pythran.__version__) < _pep440.Version('0.9.12'):
                 raise RuntimeError("The installed `pythran` is too old, >= "
@@ -252,6 +251,7 @@ def generate_cython():
         try:
             # Note, pip may not be installed or not have been used
             import pip
+            importlib.import_module('scipy/_lib/_pep440')
             if _pep440.parse(pip.__version__) < _pep440.Version('18.0.0'):
                 raise RuntimeError("Cython not found or too old. Possibly due "
                                    "to `pip` being too old, found version {}, "


### PR DESCRIPTION
This imports the vendored pep440 at the top level
ensuring it is accessible regardless of order.

The problem would arize when Pythran is not importable,
which then skips any _pep440 imports.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

No current issue.

#### What does this implement/fix?
<!--Please explain your changes.-->

Ensured `_pep440` is accessible at the top level `setup.py`

#### Additional information
<!--Any additional information you think is important.-->

The problem would arise when `import pythran` triggered an `ImportError`, in which case the `_pep440` was never imported.
