### PR TITLE
MAINT: sparse.linalg: Move the test function of GMRES to the appropriate location and remove test-independent code

### DIFF
--- a/scipy/sparse/linalg/_isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_iterative.py
@@ -346,19 +346,6 @@ def test_precond_inverse(case):
             check_precond_inverse(solver, case)
 
 
-def test_gmres_basic():
-    A = np.vander(np.arange(10) + 1)[:, ::-1]
-    b = np.zeros(10)
-    b[0] = 1
-    np.linalg.solve(A, b)
-
-    with suppress_warnings() as sup:
-        sup.filter(DeprecationWarning, ".*called without specifying.*")
-        x_gm, err = gmres(A, b, restart=5, maxiter=1)
-
-    assert_allclose(x_gm[0], 0.359, rtol=1e-2)
-
-
 def test_reentrancy():
     non_reentrant = [cg, cgs, bicg, bicgstab, gmres, qmr]
     reentrant = [lgmres, minres, gcrotmk]
@@ -590,6 +577,17 @@ class TestQMR:
 
 
 class TestGMRES:
+    def test_basic(self):
+        A = np.vander(np.arange(10) + 1)[:, ::-1]
+        b = np.zeros(10)
+        b[0] = 1
+
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning, ".*called without specifying.*")
+            x_gm, err = gmres(A, b, restart=5, maxiter=1)
+
+        assert_allclose(x_gm[0], 0.359, rtol=1e-2)
+
     def test_callback(self):
 
         def store_residual(r, rvec):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
The original `test_gmres_basic()` should have been the test function/method of the class `TestGMRES`. In this PR, moving the definition of `test_gmres_basic` into `TestGMRES` and renaming as `test_basic`. The `np.linalg.solve(A, b)` is removed because this line of code has nothing to do with the GMRES test.

#### Additional information
<!--Any additional information you think is important.-->
