### PR TITLE
MAINT: DOC: analytics from analytics.scientific-python

### DIFF
--- a/doc/source/_templates/layout.html
+++ b/doc/source/_templates/layout.html
@@ -1,0 +1,17 @@
+{# Base layout for all pages
+
+## Analytics
+
+The service https://plausible.io is used to gather simple
+and privacy-friendly analytics for the site. The dashboard can be accessed
+at https://analytics.scientific-python.org/docs.scipy.org
+The Scientific-Python community is managing the account.
+
+#}
+
+{% extends "!layout.html" %}
+
+{% block extrahead %}
+    <script defer data-domain="docs.scipy.org" src="https://analytics.scientific-python.org/js/plausible.js"></script>
+    {{ super() }}
+{% endblock %}


### PR DESCRIPTION
Similar to what is done on the main website of the organization.

Add analytics to the documentation website. It will be a new dashboard and be accessible at https://analytics.scientific-python.org/docs.scipy.org

See https://github.com/scipy/scipy.org/issues/338 for more details.

I am not sure about the approach I choose to add the call to the script. There could be another preferred way.