### PR TITLE
DOC: update pip_quickstart (submodules)

### DIFF
--- a/doc/source/dev/contributor/quickstart_pip.rst
+++ b/doc/source/dev/contributor/quickstart_pip.rst
@@ -111,8 +111,13 @@ Inside the ``scipy-dev`` environment, install the python-level dependencies::
 Note that when the virtual environment is active, the system-wide names ``pip3``
 and ``python3`` are aliased to ``pip`` and ``python``, respectively.
 
-Now that you have all needed dependencies, navigate to the directory where
-you cloned the source code into, and build SciPy (this takes a while)::
+Now that you have all external dependencies, navigate to the directory where
+you cloned the source code into. Download the submodules::
+
+    git submodule init
+    git submodule update
+
+And build SciPy (this takes a while)::
 
     python setup.py build
 

--- a/doc/source/dev/contributor/quickstart_pip.rst
+++ b/doc/source/dev/contributor/quickstart_pip.rst
@@ -114,8 +114,7 @@ and ``python3`` are aliased to ``pip`` and ``python``, respectively.
 Now that you have all external dependencies, navigate to the directory where
 you cloned the source code into. Download the submodules::
 
-    git submodule init
-    git submodule update
+    git submodule update --init
 
 And build SciPy (this takes a while)::
 


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

https://github.com/scipy/scipy.org/issues/436

#### What does this implement/fix?
<!--Please explain your changes.-->

Update the pip quickstart instructions: we now need to init/update submodules.

#### Additional information
<!--Any additional information you think is important.-->

Verified on a clean virtualenv install locally.