### PR TITLE
MAINT: use `Rotation.Random` instead of manual generation

### DIFF
--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -695,7 +695,7 @@ def test_as_euler_degenerate_symmetric_axes():
 def test_inv():
     rnd = np.random.RandomState(0)
     n = 10
-    p = Rotation.from_quat(rnd.normal(size=(n, 4)))
+    p = Rotation.random(num=n, random_state=rnd)
     q = p.inv()
 
     p_mat = p.as_matrix()
@@ -712,7 +712,7 @@ def test_inv():
 
 def test_inv_single_rotation():
     rnd = np.random.RandomState(0)
-    p = Rotation.from_quat(rnd.normal(size=(4,)))
+    p = Rotation.random(random_state=rnd)
     q = p.inv()
 
     p_mat = p.as_matrix()
@@ -725,7 +725,7 @@ def test_inv_single_rotation():
     assert_array_almost_equal(res1, eye)
     assert_array_almost_equal(res2, eye)
 
-    x = Rotation.from_quat(rnd.normal(size=(1, 4)))
+    x = Rotation.random(num=1, random_state=rnd)
     y = x.inv()
 
     x_matrix = x.as_matrix()
@@ -1040,7 +1040,7 @@ def test_align_vectors_no_rotation():
 
 def test_align_vectors_no_noise():
     rnd = np.random.RandomState(0)
-    c = Rotation.from_quat(rnd.normal(size=4))
+    c = Rotation.random(random_state=rnd)
     b = rnd.normal(size=(5, 3))
     a = c.apply(b)
 
@@ -1078,7 +1078,7 @@ def test_align_vectors_scaled_weights():
 def test_align_vectors_noise():
     rnd = np.random.RandomState(0)
     n_vectors = 100
-    rot = Rotation.from_euler('xyz', rnd.normal(size=3))
+    rot = Rotation.random(random_state=rnd)
     vectors = rnd.normal(size=(n_vectors, 3))
     result = rot.apply(vectors)
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

Use Random.Rotation in the rotation tests rather than the old method of passing random variables into the from_* methods.