### PR TITLE
MAINT: check for negative weights in `Rotation.align_vectors`

### DIFF
--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -2361,6 +2361,8 @@ cdef class Rotation:
                                  "equal to number of input vectors, got "
                                  "{} values and {} vectors.".format(
                                     weights.shape[0], b.shape[0]))
+            if (weights < 0).any():
+                raise ValueError("`weights` may not contain negative values")
 
         B = np.einsum('ji,jk->ik', weights[:, None] * a, b)
         u, s, vh = np.linalg.svd(B)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -1139,6 +1139,10 @@ def test_align_vectors_invalid_input():
                        match="Expected `weights` to have number of values"):
         Rotation.align_vectors([[1, 2, 3]], [[1, 2, 3]], weights=[1, 2])
 
+    with pytest.raises(ValueError,
+                       match="`weights` may not contain negative values"):
+        Rotation.align_vectors([[1, 2, 3]], [[1, 2, 3]], weights=[-1])
+
 
 def test_random_rotation_shape():
     rnd = np.random.RandomState(0)


### PR DESCRIPTION
Negative weights should not be permitted in `Rotation.align_vectors`.
Here I have added a check for this.
