### PR TITLE
ENH: add `order` parameter to specify quaternion format

### DIFF
--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -1179,6 +1179,9 @@ cdef class Rotation:
             'xyzw' (scalar last) or 'wxyz' (scalar first).
             Default is 'xyzw'.
 
+            .. versionadded:: 1.9.0
+
+
         Returns
         -------
         quat : `numpy.ndarray`, shape (4,) or (N, 4)

--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -580,7 +580,7 @@ cdef class Rotation:
         return self._quat.shape[0]
 
     @classmethod
-    def from_quat(cls, quat, order='xyzw'):
+    def from_quat(cls, quat, *, order='xyzw'):
         """Initialize from quaternions.
 
         3D rotations can be represented using unit-norm quaternions [1]_.

--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -595,6 +595,9 @@ cdef class Rotation:
             or 'wxyz' (scalar first).
             Default is 'xyzw'.
 
+            .. versionadded:: 1.9.0
+
+
         Returns
         -------
         rotation : `Rotation` instance

--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -1163,7 +1163,7 @@ cdef class Rotation:
         else:
             return cls(quat, normalize=False, copy=False)
 
-    def as_quat(self, order='xyzw'):
+    def as_quat(self, *, order='xyzw'):
         """Represent as quaternions.
 
         Rotations in 3 dimensions can be represented using unit norm

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -114,6 +114,22 @@ def test_as_matrix_from_square_input():
     assert_array_almost_equal(mat[3], np.eye(3))
 
 
+def test_quaternion_ordering_invalid_input():
+    x = np.array([0, 0, 0, 1])
+    with pytest.raises(ValueError, match="`order` must be 'xywz' or 'wxyz'"):
+        Rotation.from_quat(x, order='yzwx')
+
+    rot = Rotation.identity()
+    with pytest.raises(ValueError, match="`order` must be 'xywz' or 'wxyz'"):
+        rot.as_quat(order='yzwx')
+
+
+def test_quaternion_ordering_scalar_first():
+    x = Rotation.random(random_state=0).as_quat(order='wxyz')
+    rot = Rotation.from_quat(x, order='wxyz')
+    assert_array_almost_equal(x, rot.as_quat(order='wxyz'))
+
+
 def test_as_matrix_from_generic_input():
     quats = [
             [0, 0, 1, 1],

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -124,8 +124,9 @@ def test_quaternion_ordering_invalid_input():
         rot.as_quat(order='yzwx')
 
 
-def test_quaternion_ordering_scalar_first():
-    x = Rotation.random(random_state=0).as_quat(order='wxyz')
+@pytest.mark.parametrize("num", [None, 1])
+def test_quaternion_ordering_scalar_first(num):
+    x = Rotation.random(num=num, random_state=0).as_quat(order='wxyz')
     rot = Rotation.from_quat(x, order='wxyz')
     assert_array_almost_equal(x, rot.as_quat(order='wxyz'))
 

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -128,7 +128,7 @@ def test_quaternion_ordering_invalid_input():
 def test_quaternion_ordering_scalar_first(num):
     x = Rotation.random(num=num, random_state=0).as_quat(order='wxyz')
     rot = Rotation.from_quat(x, order='wxyz')
-    assert_array_almost_equal(x, rot.as_quat(order='wxyz'))
+    assert_allclose(x, rot.as_quat(order='wxyz'))
 
 
 def test_as_matrix_from_generic_input():


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #14548

#### What does this implement/fix?
<!--Please explain your changes.-->
Adds an `order` parameter for specifying the quaternion format, either scalar-last or scalar-first.