### PR TITLE
ENH: stats: add `rvs` method for `gennorm`

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -8397,7 +8397,8 @@ class gennorm_gen(rv_continuous):
            generalized Gaussian densities." Journal of Statistical
            Computation and Simulation 79.11 (2009): 1317-1329
 
-    .. [3] "Simulate data from a generalized Gaussian distribution",
+    .. [3] Wicklin, Rick. "Simulate data from a generalized Gaussian
+           distribution" in The DO Loop blog, September 21, 2016,
            https://blogs.sas.com/content/iml/2016/09/21/simulate-generalized-gaussian-sas.html
 
     %(example)s

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -8393,6 +8393,13 @@ class gennorm_gen(rv_continuous):
     .. [1] "Generalized normal distribution, Version 1",
            https://en.wikipedia.org/wiki/Generalized_normal_distribution#Version_1
 
+    .. [2] Nardon, Martina, and Paolo Pianca. "Simulation techniques for
+           generalized Gaussian densities." Journal of Statistical
+           Computation and Simulation 79.11 (2009): 1317-1329
+
+    .. [3] "Simulate data from a generalized Gaussian distribution",
+           https://blogs.sas.com/content/iml/2016/09/21/simulate-generalized-gaussian-sas.html
+
     %(example)s
 
     """
@@ -8425,6 +8432,17 @@ class gennorm_gen(rv_continuous):
 
     def _entropy(self, beta):
         return 1. / beta - np.log(.5 * beta) + sc.gammaln(1. / beta)
+
+    def _rvs(self, beta, size=None, random_state=None):
+        # see [2]_ for the algorithm
+        # see [3]_ for reference implementation in SAS
+        z = random_state.gamma(1/beta, size=size)
+        y = z ** (1/beta)
+        # convert y to array to ensure masking support
+        y = np.asarray(y)
+        mask = random_state.random(size=y.shape) < 0.5
+        y[mask] = -y[mask]
+        return y
 
 
 gennorm = gennorm_gen(name='gennorm')

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -318,7 +318,7 @@ def test_rvs_broadcast(dist, shape_args):
     shape_only = dist in ['argus', 'betaprime', 'dgamma', 'dweibull',
                           'exponnorm', 'genhyperbolic', 'geninvgauss',
                           'levy_stable', 'nct', 'norminvgauss', 'rice',
-                          'skewnorm', 'semicircular']
+                          'skewnorm', 'semicircular', 'gennorm']
 
     distfunc = getattr(stats, dist)
     loc = np.zeros(2)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -731,8 +731,8 @@ class TestGennorm:
         # beta = 2
         dist = stats.gennorm(2)
         rvs = dist.rvs(size=1000)
-        rvs_norm = stats.norm.rvs(size=1000)
-        assert stats.ks_2samp(rvs * (2)**(1/2), rvs_norm).pvalue > 0.1
+        rvs_norm = stats.norm.rvs(scale=1/2**0.5, size=1000)
+        assert stats.ks_2samp(rvs, rvs_norm).pvalue > 0.1
 
     def test_rvs_broadcasting(self):
         np.random.seed(0)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -717,6 +717,32 @@ class TestGennorm:
         pdf2 = stats.norm.pdf(points, scale=2**-.5)
         assert_almost_equal(pdf1, pdf2)
 
+    def test_rvs(self):
+        np.random.seed(0)
+        # 0 < beta < 1
+        dist = stats.gennorm(0.5)
+        rvs = dist.rvs(size=1000)
+        assert stats.kstest(rvs, dist.cdf).pvalue > 0.1
+        # beta = 1
+        dist = stats.gennorm(1)
+        rvs = dist.rvs(size=1000)
+        rvs_laplace = stats.laplace.rvs(size=1000)
+        assert stats.ks_2samp(rvs, rvs_laplace).pvalue > 0.1
+        # beta = 2
+        dist = stats.gennorm(2)
+        rvs = dist.rvs(size=1000)
+        rvs_norm = stats.norm.rvs(size=1000)
+        assert stats.ks_2samp(rvs * (2)**(1/2), rvs_norm).pvalue > 0.1
+
+    def test_rvs_broadcasting(self):
+        np.random.seed(0)
+        dist = stats.gennorm([[0.5, 1.], [2., 5.]])
+        rvs = dist.rvs(size=[1000, 2, 2])
+        assert stats.kstest(rvs[:, 0, 0], stats.gennorm(0.5).cdf)[1] > 0.1
+        assert stats.kstest(rvs[:, 0, 1], stats.gennorm(1.0).cdf)[1] > 0.1
+        assert stats.kstest(rvs[:, 1, 0], stats.gennorm(2.0).cdf)[1] > 0.1
+        assert stats.kstest(rvs[:, 1, 1], stats.gennorm(5.0).cdf)[1] > 0.1
+
 
 class TestHalfgennorm:
     def test_expon(self):


### PR DESCRIPTION
#### Reference issue

gh-10106

#### What does this implement/fix?

This PR adds a specialized random variate sampling method for the generalized normal distribution.
The algorithm has been proposed in: [Nardon and Pianca (2009)](https://www.tandfonline.com/doi/abs/10.1080/00949650802290912)
Reference implementation in SAS is available [here](https://blogs.sas.com/content/iml/2016/09/21/simulate-generalized-gaussian-sas.html).

This speeds up generation of random variates by a factor of 5-8 for small values of the parameter and 50x for large values.
The following benchmark measures time to generate 1 million samples from the distribution.

On `main`:

```
For beta = 0.25 : 832 ms ± 1.39 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
For beta = 0.45 : 1 s ± 372 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
For beta = 0.75 : 1.11 s ± 2.18 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
For beta = 1.0 : 559 ms ± 260 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
For beta = 1.5 : 5.24 s ± 12 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
For beta = 2.0 : 6.72 s ± 27 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
For beta = 3.0 : 6.64 s ± 13.5 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
For beta = 5.0 : 6.23 s ± 6.67 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
For beta = 8.0 : 5.95 s ± 21.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

After this PR:

```
For beta = 0.25 : 100 ms ± 125 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
For beta = 0.45 : 101 ms ± 264 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
For beta = 0.75 : 101 ms ± 158 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
For beta = 1.0 : 45.2 ms ± 66.7 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
For beta = 1.5 : 148 ms ± 80.1 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
For beta = 2.0 : 120 ms ± 202 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
For beta = 3.0 : 138 ms ± 417 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
For beta = 5.0 : 128 ms ± 439 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
For beta = 8.0 : 122 ms ± 156 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

#### Additional information

<details>

<summary>Code for generating the benchmark</summary>

```python
In [1]: import numpy as np

In [2]: from scipy.stats import gennorm

In [3]: rng = np.random.default_rng()

In [4]: params = [0.25, 0.45, 0.75, 1.0, 1.5, 2.0, 3.0, 5.0, 8.0]

In [5]: for param in params:
   ...:     dist = gennorm(param)
   ...:     print(f"For beta = {param} : ", end="")
   ...:     %timeit dist.rvs(size=1_000_000, random_state=rng)
```

</details>
