### PR TITLE
BUG: Fix PyUFunc for wasm targets

### DIFF
--- a/scipy/stats/_boost/include/Templated_PyUFunc.hpp
+++ b/scipy/stats/_boost/include/Templated_PyUFunc.hpp
@@ -7,7 +7,7 @@
 // TODO: remove C++11 implementation when SciPy supports C++14 on all platforms
 #define USE_CPP14 (__cplusplus >= 201402L)
 
-#if USE_CPP14
+#if USE_CPP14 && !defined(__wasm32__) && !defined(__wasm64__)
 
 #include <type_traits>
 #include <utility>


### PR DESCRIPTION
In the Wasm ABI, the following code does not work:
```C
double func(double, double, double);
typedef double (*variadic_func)(...);

double bad_func(double a, double b, double c){
   variadic_func f = (variadic_func)func;
   return f(a, b, c);
}
```
It will fail at runtime with "indirect call signature mismatch" because `func`
has wasm type `(f64, f64, f64) -> f64`, whereas in Wasm32 ABI `variadic_func`
has type `i32 -> f64` (the `i32` is a `double *` which points to an array with
the three arguments).

Behind the `#if USE_CPP14` branch, there is code that makes this bad cast. By
changing the `#if USE_CPP14` to
`#if USE_CPP14 && !defined(__wasm32__) && !defined(__wasm64__)`
we get the working `#else` branch code when targeting Wasm.