### PR TITLE
BUG: stats: mode: fix negative axis issue with np.moveaxis instead of custom code

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -456,8 +456,7 @@ def mode(a, axis=0, nan_policy='propagate'):
     # casting types in the process.
     # This recreates the results without that issue
     # View of a, rotated so the requested axis is last
-    in_dims = list(range(a.ndim))
-    a_view = np.transpose(a, in_dims[:axis] + in_dims[axis+1:] + [axis])
+    a_view = np.moveaxis(a, axis, -1)
 
     inds = np.ndindex(a_view.shape[:-1])
     modes = np.empty(a_view.shape[:-1], dtype=a.dtype)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2167,6 +2167,14 @@ class TestMode:
         assert_equal(vals[0], np.array([[10], [10], [20], [30], [30]]))
         assert_equal(vals[1], np.array([[2], [4], [3], [4], [3]]))
 
+    @pytest.mark.parametrize('axis', np.arange(-4, 0))
+    def test_negative_axes_gh_15375(self, axis):
+        np.random.seed(984213899)
+        a = np.random.rand(10, 11, 12, 13)
+        res0 = stats.mode(a, axis=a.ndim+axis)
+        res1 = stats.mode(a, axis=axis)
+        np.testing.assert_array_equal(res0, res1)
+
     def test_strings(self):
         data1 = ['rain', 'showers', 'showers']
         vals = stats.mode(data1)


### PR DESCRIPTION
#### Reference issue
Closes gh-15375

#### What does this implement/fix?
`scipy.stats.mode` did not handle negative axes properly because custom code was used to do the job `np.moveaxis`. This fixes the bug by using `np.moveaxis`.

#### Additional information
I considered `axis = axis if axis >= 0 else a.ndim + axis`, but this is a stronger solution.