### PR TITLE
ENH: stats: add `axis` tuple and `nan_policy` to `kurtosis`

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -1083,6 +1083,9 @@ def skew(a, axis=0, bias=True, nan_policy='propagate'):
     return vals
 
 
+@_axis_nan_policy_factory(
+    lambda x: x, result_unpacker=lambda x: (x,), n_outputs=1
+)
 def kurtosis(a, axis=0, fisher=True, bias=True, nan_policy='propagate'):
     """Compute the kurtosis (Fisher or Pearson) of a dataset.
 

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -26,7 +26,8 @@ axis_nan_policy_cases = [
     (stats.wilcoxon, tuple(), dict(), 1, 2, True, None),
     (stats.gmean, tuple(), dict(), 1, 1, False, lambda x: (x,)),
     (stats.hmean, tuple(), dict(), 1, 1, False, lambda x: (x,)),
-    ]
+    (stats.kurtosis, tuple(), dict(), 1, 1, False, lambda x: (x,))
+]
 
 # If the message is one of those expected, put nans in
 # appropriate places of `statistics` and `pvalues`


### PR DESCRIPTION
#### Reference issue

gh-14651

#### What does this implement/fix?

Adds `_axis_nan_policy_factory` to `kurtosis`. `kurtosis` tests looked quite strong so I didn't add any special tests.
