### PR TITLE
MAINT: stats: mode: mode is a reduction operation; should consume an axis

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -376,7 +376,7 @@ def hmean(a, axis=0, dtype=None, *, weights=None):
 ModeResult = namedtuple('ModeResult', ('mode', 'count'))
 
 
-def mode(a, axis=0, nan_policy='propagate'):
+def mode(a, axis=0, nan_policy='propagate', *, keepdims=None):
     """Return an array of the modal (most common) value in the passed array.
 
     If there is more than one such value, only the smallest is returned.
@@ -396,6 +396,13 @@ def mode(a, axis=0, nan_policy='propagate'):
           * 'propagate': returns nan
           * 'raise': throws an error
           * 'omit': performs the calculations ignoring nan values
+    keepdims : bool, optional
+        If this is set to True, the axes which are reduced are left in the
+        result as dimensions with size one. With this option, the result will
+        broadcast correctly against the input array. Beginning in SciPy 1.9.0,
+        the default behavior is to remove the reduced dimensions, consistent
+        with other NumPy and scipy.stats reduction functions, and this
+        option will be removed in a future release.
 
     Returns
     -------
@@ -413,14 +420,24 @@ def mode(a, axis=0, nan_policy='propagate'):
     ...               [4, 7, 5, 9]])
     >>> from scipy import stats
     >>> stats.mode(a)
-    ModeResult(mode=array([[3, 1, 0, 0]]), count=array([[1, 1, 1, 1]]))
+    ModeResult(mode=array([3, 1, 0, 0]), count=array([1, 1, 1, 1]))
 
     To get mode of whole array, specify ``axis=None``:
 
     >>> stats.mode(a, axis=None)
-    ModeResult(mode=array([3]), count=array([3]))
+    ModeResult(mode=3, count=3)
 
     """
+    message = ("In SciPy 1.8.0 and before, the default behavior of `mode` was "
+               "equivalent to `keepdims=True, but this was inconsistent with "
+               "other NumPy and `scipy.stats` reduction functions. Parameter "
+               "`keepdims` was added in SciPy 1.9.0 to ameliorate the change "
+               "in default behavior. Nonetheless, use of this parameter is "
+               "deprecated, and like other reduction functions, `mode` will "
+               "always consume dimension `axis` in a future release.")
+    if keepdims is not None:
+        warnings.warn(message, DeprecationWarning, stacklevel=2)
+
     a, axis = _chk_asarray(a, axis)
     if a.size == 0:
         return ModeResult(np.array([]), np.array([]))
@@ -446,6 +463,10 @@ def mode(a, axis=0, nan_policy='propagate'):
             oldcounts = np.maximum(counts, oldcounts)
             oldmostfreq = mostfrequent
 
+        if keepdims:
+            mostfrequent = np.expand_dims(mostfrequent, axis)
+            oldcounts = np.expand_dims(oldcounts, axis)
+
         return ModeResult(mostfrequent[()], oldcounts[()])
 
     def _mode1D(a):
@@ -463,6 +484,10 @@ def mode(a, axis=0, nan_policy='propagate'):
     counts = np.empty(a_view.shape[:-1], dtype=np.int_)
     for ind in inds:
         modes[ind], counts[ind] = _mode1D(a_view[ind])
+
+    if keepdims:
+        modes = np.expand_dims(modes, axis)
+        counts = np.expand_dims(counts, axis)
     return ModeResult(modes[()], counts[()])
 
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -376,7 +376,7 @@ def hmean(a, axis=0, dtype=None, *, weights=None):
 ModeResult = namedtuple('ModeResult', ('mode', 'count'))
 
 
-def mode(a, axis=0, nan_policy='propagate', *, keepdims=None):
+def mode(a, axis=0, nan_policy='propagate'):
     """Return an array of the modal (most common) value in the passed array.
 
     If there is more than one such value, only the smallest is returned.
@@ -396,13 +396,6 @@ def mode(a, axis=0, nan_policy='propagate', *, keepdims=None):
           * 'propagate': returns nan
           * 'raise': throws an error
           * 'omit': performs the calculations ignoring nan values
-    keepdims : bool, optional
-        If this is set to True, the axes which are reduced are left in the
-        result as dimensions with size one. With this option, the result will
-        broadcast correctly against the input array. Beginning in SciPy 1.9.0,
-        the default behavior is to remove the reduced dimensions, consistent
-        with other NumPy and scipy.stats reduction functions, and this
-        option will be removed in a future release.
 
     Returns
     -------
@@ -428,16 +421,6 @@ def mode(a, axis=0, nan_policy='propagate', *, keepdims=None):
     ModeResult(mode=3, count=3)
 
     """
-    message = ("In SciPy 1.8.0 and before, the default behavior of `mode` was "
-               "equivalent to `keepdims=True, but this was inconsistent with "
-               "other NumPy and `scipy.stats` reduction functions. Parameter "
-               "`keepdims` was added in SciPy 1.9.0 to ameliorate the change "
-               "in default behavior. Nonetheless, use of this parameter is "
-               "deprecated, and like other reduction functions, `mode` will "
-               "always consume dimension `axis` in a future release.")
-    if keepdims is not None:
-        warnings.warn(message, DeprecationWarning, stacklevel=2)
-
     a, axis = _chk_asarray(a, axis)
     if a.size == 0:
         return ModeResult(np.array([]), np.array([]))
@@ -463,10 +446,6 @@ def mode(a, axis=0, nan_policy='propagate', *, keepdims=None):
             oldcounts = np.maximum(counts, oldcounts)
             oldmostfreq = mostfrequent
 
-        if keepdims:
-            mostfrequent = np.expand_dims(mostfrequent, axis)
-            oldcounts = np.expand_dims(oldcounts, axis)
-
         return ModeResult(mostfrequent[()], oldcounts[()])
 
     def _mode1D(a):
@@ -485,9 +464,6 @@ def mode(a, axis=0, nan_policy='propagate', *, keepdims=None):
     for ind in inds:
         modes[ind], counts[ind] = _mode1D(a_view[ind])
 
-    if keepdims:
-        modes = np.expand_dims(modes, axis)
-        counts = np.expand_dims(counts, axis)
     return ModeResult(modes[()], counts[()])
 
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -435,18 +435,18 @@ def mode(a, axis=0, nan_policy='propagate'):
         # Fall back to a slower method since np.unique does not work with NaN
         scores = set(np.ravel(a))  # get ALL unique values
         testshape = list(a.shape)
-        testshape[axis] = 1
+        testshape.pop(axis)
         oldmostfreq = np.zeros(testshape, dtype=a.dtype)
         oldcounts = np.zeros(testshape, dtype=int)
 
         for score in scores:
             template = (a == score)
-            counts = np.sum(template, axis, keepdims=True)
+            counts = np.sum(template, axis)
             mostfrequent = np.where(counts > oldcounts, score, oldmostfreq)
             oldcounts = np.maximum(counts, oldcounts)
             oldmostfreq = mostfrequent
 
-        return ModeResult(mostfrequent, oldcounts)
+        return ModeResult(mostfrequent[()], oldcounts[()])
 
     def _mode1D(a):
         vals, cnts = np.unique(a, return_counts=True)
@@ -463,9 +463,7 @@ def mode(a, axis=0, nan_policy='propagate'):
     counts = np.empty(a_view.shape[:-1], dtype=np.int_)
     for ind in inds:
         modes[ind], counts[ind] = _mode1D(a_view[ind])
-    newshape = list(a.shape)
-    newshape[axis] = 1
-    return ModeResult(modes.reshape(newshape), counts.reshape(newshape))
+    return ModeResult(modes[()], counts[()])
 
 
 def _mask_to_limits(a, limits, inclusive):

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2265,7 +2265,7 @@ class TestMode:
     @pytest.mark.parametrize('dtype', [np.float64, 'object'])
     def test_mode_shape_gh_9955(self, axis, dtype):
         rng = np.random.default_rng(984213899)
-        a = rng.uniform(size=(3, 4, 5)).astype(dtype)
+        a = rng.random(size=(3, 4, 5), dtype=dtype)
         res = stats.mode(a, axis=axis)
         reference_shape = list(a.shape)
         reference_shape.pop(axis)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2264,13 +2264,27 @@ class TestMode:
     @pytest.mark.parametrize('axis', np.arange(-3, 3))
     @pytest.mark.parametrize('dtype', [np.float64, 'object'])
     def test_mode_shape_gh_9955(self, axis, dtype):
-        np.random.seed(984213899)
-        a = np.random.rand(3, 4, 5).astype(dtype)
+        rng = np.random.default_rng(984213899)
+        a = rng.uniform(size=(3, 4, 5)).astype(dtype)
         res = stats.mode(a, axis=axis)
         reference_shape = list(a.shape)
         reference_shape.pop(axis)
         np.testing.assert_array_equal(res.mode.shape, reference_shape)
         np.testing.assert_array_equal(res.count.shape, reference_shape)
+
+    @pytest.mark.parametrize('axis', np.arange(-3, 3))
+    def test_keepdims_gh_9955(self, axis):
+        rng = np.random.default_rng(984213899)
+        a = rng.uniform(size=(3, 4, 5))
+        res0 = stats.mode(a, axis=axis)
+        with pytest.warns(DeprecationWarning):
+            res1 = stats.mode(a, axis=axis, keepdims=True)
+        reference_shape = list(a.shape)
+        reference_shape[axis] = 1
+        np.testing.assert_array_equal(res1.mode.shape, reference_shape)
+        np.testing.assert_array_equal(res1.count.shape, reference_shape)
+        np.testing.assert_array_equal(np.squeeze(res1.mode), res0.mode)
+        np.testing.assert_array_equal(np.squeeze(res1.count), res0.count)
 
 
 class TestSEM:

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2265,7 +2265,7 @@ class TestMode:
     @pytest.mark.parametrize('dtype', [np.float64, 'object'])
     def test_mode_shape_gh_9955(self, axis, dtype):
         rng = np.random.default_rng(984213899)
-        a = rng.random(size=(3, 4, 5), dtype=dtype)
+        a = rng.uniform(size=(3, 4, 5)).astype(dtype)
         res = stats.mode(a, axis=axis)
         reference_shape = list(a.shape)
         reference_shape.pop(axis)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2144,8 +2144,8 @@ class TestMode:
     def test_basic(self):
         data1 = [3, 5, 1, 10, 23, 3, 2, 6, 8, 6, 10, 6]
         vals = stats.mode(data1)
-        assert_equal(vals[0][0], 6)
-        assert_equal(vals[1][0], 3)
+        assert_equal(vals[0], 6)
+        assert_equal(vals[1], 3)
 
     def test_axes(self):
         data1 = [10, 10, 30, 40]
@@ -2156,16 +2156,16 @@ class TestMode:
         arr = np.array([data1, data2, data3, data4, data5])
 
         vals = stats.mode(arr, axis=None)
-        assert_equal(vals[0], np.array([30]))
-        assert_equal(vals[1], np.array([8]))
+        assert_equal(vals[0], np.array(30))
+        assert_equal(vals[1], np.array(8))
 
         vals = stats.mode(arr, axis=0)
-        assert_equal(vals[0], np.array([[10, 10, 30, 30]]))
-        assert_equal(vals[1], np.array([[2, 3, 3, 2]]))
+        assert_equal(vals[0], np.array([10, 10, 30, 30]))
+        assert_equal(vals[1], np.array([2, 3, 3, 2]))
 
         vals = stats.mode(arr, axis=1)
-        assert_equal(vals[0], np.array([[10], [10], [20], [30], [30]]))
-        assert_equal(vals[1], np.array([[2], [4], [3], [4], [3]]))
+        assert_equal(vals[0], np.array([10, 10, 20, 30, 30]))
+        assert_equal(vals[1], np.array([2, 4, 3, 4, 3]))
 
     @pytest.mark.parametrize('axis', np.arange(-4, 0))
     def test_negative_axes_gh_15375(self, axis):
@@ -2178,16 +2178,16 @@ class TestMode:
     def test_strings(self):
         data1 = ['rain', 'showers', 'showers']
         vals = stats.mode(data1)
-        assert_equal(vals[0][0], 'showers')
-        assert_equal(vals[1][0], 2)
+        assert_equal(vals[0], 'showers')
+        assert_equal(vals[1], 2)
 
     def test_mixed_objects(self):
         objects = [10, True, np.nan, 'hello', 10]
         arr = np.empty((5,), dtype=object)
         arr[:] = objects
         vals = stats.mode(arr)
-        assert_equal(vals[0][0], 10)
-        assert_equal(vals[1][0], 2)
+        assert_equal(vals[0], 10)
+        assert_equal(vals[1], 2)
 
     def test_objects(self):
         # Python objects must be sortable (le + eq) and have ne defined
@@ -2215,8 +2215,8 @@ class TestMode:
         assert_equal(np.unique(arr).shape, (4,))
         vals = stats.mode(arr)
 
-        assert_equal(vals[0][0], Point(2))
-        assert_equal(vals[1][0], 4)
+        assert_equal(vals[0], Point(2))
+        assert_equal(vals[1], 4)
 
     def test_mode_result_attributes(self):
         data1 = [3, 5, 1, 10, 23, 3, 2, 6, 8, 6, 10, 6]
@@ -2245,21 +2245,32 @@ class TestMode:
     ])
     def test_smallest_equal(self, data):
         result = stats.mode(data, nan_policy='omit')
-        assert_equal(result[0][0], 1)
+        assert_equal(result[0], 1)
 
     def test_obj_arrays_ndim(self):
         # regression test for gh-9645: `mode` fails for object arrays w/ndim > 1
         data = [['Oxidation'], ['Oxidation'], ['Polymerization'], ['Reduction']]
         ar = np.array(data, dtype=object)
         m = stats.mode(ar, axis=0)
-        assert np.all(m.mode == 'Oxidation') and m.mode.shape == (1, 1)
-        assert np.all(m.count == 2) and m.count.shape == (1, 1)
+        assert np.all(m.mode == 'Oxidation') and m.mode.shape == (1,)
+        assert np.all(m.count == 2) and m.count.shape == (1,)
 
         data1 = data + [[np.nan]]
         ar1 = np.array(data1, dtype=object)
         m = stats.mode(ar1, axis=0)
-        assert np.all(m.mode == 'Oxidation') and m.mode.shape == (1, 1)
-        assert np.all(m.count == 2) and m.count.shape == (1, 1)
+        assert np.all(m.mode == 'Oxidation') and m.mode.shape == (1,)
+        assert np.all(m.count == 2) and m.count.shape == (1,)
+
+    @pytest.mark.parametrize('axis', np.arange(-3, 3))
+    @pytest.mark.parametrize('dtype', [np.float64, 'object'])
+    def test_mode_shape_gh_9955(self, axis, dtype):
+        np.random.seed(984213899)
+        a = np.random.rand(3, 4, 5).astype(dtype)
+        res = stats.mode(a, axis=axis)
+        reference_shape = list(a.shape)
+        reference_shape.pop(axis)
+        np.testing.assert_array_equal(res.mode.shape, reference_shape)
+        np.testing.assert_array_equal(res.count.shape, reference_shape)
 
 
 class TestSEM:

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2272,20 +2272,6 @@ class TestMode:
         np.testing.assert_array_equal(res.mode.shape, reference_shape)
         np.testing.assert_array_equal(res.count.shape, reference_shape)
 
-    @pytest.mark.parametrize('axis', np.arange(-3, 3))
-    def test_keepdims_gh_9955(self, axis):
-        rng = np.random.default_rng(984213899)
-        a = rng.uniform(size=(3, 4, 5))
-        res0 = stats.mode(a, axis=axis)
-        with pytest.warns(DeprecationWarning):
-            res1 = stats.mode(a, axis=axis, keepdims=True)
-        reference_shape = list(a.shape)
-        reference_shape[axis] = 1
-        np.testing.assert_array_equal(res1.mode.shape, reference_shape)
-        np.testing.assert_array_equal(res1.count.shape, reference_shape)
-        np.testing.assert_array_equal(np.squeeze(res1.mode), res0.mode)
-        np.testing.assert_array_equal(np.squeeze(res1.count), res0.count)
-
 
 class TestSEM:
 


### PR DESCRIPTION
#### Reference issue
https://github.com/scipy/scipy/issues/9955#issuecomment-474166442

#### What does this implement/fix?
As noted in the issue linked above, `mode` is a reduction operation like many other `scipy.stats` (e.g. `skew`) and `np` (e.g. `mean`) functions, and therefore, it should follow the convention of consuming the axis it operates over. The authors took steps to ensure that did not happen, but I assume that was before there was a clear convention to follow. This PR fixes that.

#### Additional information
Current behavior:
```
>>> import numpy as np
>>> from scipy import stats
>>> x = np.random.rand(3, 4, 5)

>>> np.mean(x, axis=1).shape
(3, 5)

>>> stats.skew(x, axis=1).shape
(3, 5)

>>> stats.mode(x, axis=1).mode.shape
(3, 1, 5)
```
With this PR, the output shape of `mode` is `(3, 5)`, too.

This is a bug fix, but a backward-compatibility break nonetheless. To mitigate that, I could add `keep_dims=True` as a keyword-only argument and deprecate its use and behavior, explaining that the argument and `keep_dims=True` behavior would be removed in a future release.  Thoughts?