### PR TITLE
ENH: differential_evolution vectorized kwd

### DIFF
--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -163,8 +163,9 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
         trial vectors can take advantage of continuous improvements in the best
         solution.
         With ``'deferred'``, the best solution vector is updated once per
-        generation. Only ``'deferred'`` is compatible with parallelization, and
-        the `workers` keyword can over-ride this option.
+        generation. Only ``'deferred'`` is compatible with parallelization or
+        vectorization, and the `workers` and `vectorized` keywords can
+        over-ride this option.
 
         .. versionadded:: 1.2.0
 
@@ -495,13 +496,14 @@ class DifferentialEvolutionSolver:
         where and `atol` and `tol` are the absolute and relative tolerance
         respectively.
     updating : {'immediate', 'deferred'}, optional
-        If `immediate` the best solution vector is continuously updated within
-        a single generation. This can lead to faster convergence as trial
-        vectors can take advantage of continuous improvements in the best
+        If ``'immediate'``, the best solution vector is continuously updated
+        within a single generation [4]_. This can lead to faster convergence as
+        trial vectors can take advantage of continuous improvements in the best
         solution.
-        With `deferred` the best solution vector is updated once per
-        generation. Only `deferred` is compatible with parallelization, and the
-        `workers` keyword can over-ride this option.
+        With ``'deferred'``, the best solution vector is updated once per
+        generation. Only ``'deferred'`` is compatible with parallelization or
+        vectorization, and the `workers` and `vectorized` keywords can
+        over-ride this option.
     workers : int or map-like callable, optional
         If `workers` is an int the population is subdivided into `workers`
         sections and evaluated in parallel

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -594,18 +594,18 @@ class DifferentialEvolutionSolver:
         if workers != 1 and updating == 'immediate':
             warnings.warn("differential_evolution: the 'workers' keyword has"
                           " overridden updating='immediate' to"
-                          " updating='deferred'", UserWarning)
+                          " updating='deferred'", UserWarning, stacklevel=2)
             self._updating = 'deferred'
 
         if vectorized and workers != 1:
             warnings.warn("differential_evolution: the 'workers' keyword"
-                          " overrides the 'vectorized' keyword")
+                          " overrides the 'vectorized' keyword", stacklevel=2)
             self.vectorized = vectorized = False
 
         if vectorized and updating == 'immediate':
             warnings.warn("differential_evolution: the 'vectorized' keyword"
                           " has overridden updating='immediate' to updating"
-                          "='deferred'", UserWarning)
+                          "='deferred'", UserWarning, stacklevel=2)
             self._updating = 'deferred'
 
         # an object with a map method.

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -584,9 +584,9 @@ class DifferentialEvolutionSolver:
             self._updating = 'deferred'
 
         if vectorized and workers != 1:
-                warnings.warn("differential_evolution: the 'workers' keyword"
-                              " overrides the 'vectorized' keyword")
-                self.vectorized = vectorized = False
+            warnings.warn("differential_evolution: the 'workers' keyword"
+                          " overrides the 'vectorized' keyword")
+            self.vectorized = vectorized = False
 
         if vectorized and updating == 'immediate':
             warnings.warn("differential_evolution: the 'vectorized' keyword"

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -339,9 +339,19 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
     ...     arg2 = 0.5 * (np.cos(2. * np.pi * x[0]) + np.cos(2. * np.pi * x[1]))
     ...     return -20. * np.exp(arg1) - np.exp(arg2) + 20. + np.e
     >>> bounds = [(-5, 5), (-5, 5)]
-    >>> result = differential_evolution(ackley, bounds)
-    >>> result.x, result.fun
-    (array([ 0.,  0.]), 4.4408920985006262e-16)
+    >>> result = differential_evolution(ackley, bounds, seed=1)
+    >>> result.x, result.fun, result.nfev
+    (array([0., 0.]), 4.440892098500626e-16, 3063)
+
+    The Ackley function is written in a vectorized manner, so the
+    ``'vectorized'`` keyword can be employed. Note the reduced number of
+    function evaluations.
+
+    >>> result = differential_evolution(
+    ...     ackley, bounds, vectorized=True, updating='deferred', seed=1
+    ... )
+    >>> result.x, result.fun, result.nfev
+    (array([0., 0.]), 4.440892098500626e-16, 190)
 
     References
     ----------

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -209,11 +209,12 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
         .. versionadded:: 1.9.0
 
     vectorized : bool, optional
-        If ``vectorized is True``, `func` is sent an `x` array of shape
-        ``(N, M)`` and is expected to return an array of shape ``(M,)``.
+        If ``vectorized is True``, `func` is sent an `x` array with
+        ``x.shape == (N, M)``, and is expected to return an array of shape
+        ``(M,)``.
         This option is an alternative to the parallelization offered by
         `workers`, and may help in optimization speed. This keyword is
-        ignored if the `workers` keyword has ``workers != 1``.
+        ignored if ``workers != 1``.
         This option will override the `updating` keyword to
         ``updating='deferred'``.
 
@@ -524,11 +525,12 @@ class DifferentialEvolutionSolver:
         If there are no integer values lying between the bounds then a
         `ValueError` is raised.
     vectorized : bool, optional
-        If ``vectorized is True``, `func` is sent an `x` array of shape
-        ``(N, M)`` and is expected to return an array of shape ``(M,)``.
+        If ``vectorized is True``, `func` is sent an `x` array with
+        ``x.shape == (N, M)``, and is expected to return an array of shape
+        ``(M,)``.
         This option is an alternative to the parallelization offered by
         `workers`, and may help in optimization speed. This keyword is
-        ignored if the `workers` keyword has ``workers != 1``.
+        ignored if ``workers != 1``.
         This option will override the `updating` keyword to
         ``updating='deferred'``.
     """

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -219,10 +219,13 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
         ``x.shape == (N, S)``, and return an array of shape ``(M, S)``, where
         `M` is the number of constraint components.
         This option is an alternative to the parallelization offered by
-        `workers`, and may help in optimization speed. This keyword is
-        ignored if ``workers != 1``.
+        `workers`, and may help in optimization speed by reducing interpreter
+        overhead from multiple function calls. This keyword is ignored if
+        ``workers != 1``.
         This option will override the `updating` keyword to
         ``updating='deferred'``.
+        See the notes section for further discussion on when to use
+        ``'vectorized'``, and when to use ``'workers'``.
 
         .. versionadded:: 1.9.0
 
@@ -276,6 +279,20 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
     convergence as trial vectors can immediately benefit from improved
     solutions. To use the original Storn and Price behaviour, updating the best
     solution once per iteration, set ``updating='deferred'``.
+    The ``'deferred'`` approach is compatible with both parallelization and
+    vectorization (``'workers'`` and ``'vectorized'`` keywords). These may
+    improve minimization speed by using computer resources more efficiently.
+    The ``'workers'`` distribute calculations over multiple processors. By
+    default the Python `multiprocessing` module is used, but other approaches
+    are also possible, such as the Message Passing Interface (MPI) used on
+    clusters [6]_ [7]_. The overhead from these approaches (creating new
+    Processes, etc) may be significant, meaning that computational speed
+    doesn't necessarily scale with the number of processors used.
+    Parallelization is best suited to computationally expensive objective
+    functions. If the objective function is less expensive, then
+    ``'vectorized'`` may aid by only calling the objective function once per
+    iteration, rather than multiple times for all the population members; the
+    interpreter overhead is reduced.
 
     .. versionadded:: 0.15.0
 
@@ -341,6 +358,8 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
            evolution algorithm. Proceedings of the 2002 Congress on
            Evolutionary Computation. CEC'02 (Cat. No. 02TH8600). Vol. 2. IEEE,
            2002.
+    .. [6] https://mpi4py.readthedocs.io/en/stable/
+    .. [7] https://schwimmbad.readthedocs.io/en/latest/
     """
 
     # using a context manager means that any created Pool objects are

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -193,6 +193,7 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
         Provides an initial guess to the minimization. Once the population has
         been initialized this vector replaces the first (best) member. This
         replacement is done even if `init` is given an initial population.
+        ``x0.shape == (N,)``.
 
         .. versionadded:: 1.7.0
 
@@ -515,6 +516,7 @@ class DifferentialEvolutionSolver:
         Provides an initial guess to the minimization. Once the population has
         been initialized this vector replaces the first (best) member. This
         replacement is done even if `init` is given an initial population.
+        ``x0.shape == (N,)``.
     integrality : 1-D array, optional
         For each decision variable, a boolean value indicating whether the
         decision variable is constrained to integer values. The array is
@@ -1120,8 +1122,8 @@ class DifferentialEvolutionSolver:
 
     def _constraint_violation_fn(self, x):
         """
-        Calculates total constraint violation for all the constraints, for a set of
-        solutions.
+        Calculates total constraint violation for all the constraints, for a
+        set of solutions.
 
         Parameters
         ----------

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -1214,7 +1214,7 @@ class DifferentialEvolutionSolver:
             # shortcut for no constraints
             return np.ones(num_members, bool), np.zeros((num_members, 1))
 
-        (S, N)
+        # (S, N)
         parameters_pop = self._scale_parameters(population)
 
         if self.vectorized:

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -660,9 +660,9 @@ class TestDifferentialEvolutionSolver:
         )
 
         # the following line is used in _calculate_population_feasibilities.
-        # _constraint_violation_fn returns an (1, C) array when
+        # _constraint_violation_fn returns an (1, M) array when
         # x.shape == (N,), i.e. a single solution. Therefore this list
-        # comprehension will should generate (M, 1, C) array.
+        # comprehension should generate (S, 1, M) array.
         constraint_violation = np.array([solver._constraint_violation_fn(x)
                                          for x in np.array(xs)])
         assert constraint_violation.shape == (3, 1, 3)
@@ -840,11 +840,11 @@ class TestDifferentialEvolutionSolver:
 
     def test_constraint_wrapper_violation(self):
         def cons_f(x):
-            # written in vectorised form to accept an array of (N, M)
-            # returning (C, M)
+            # written in vectorised form to accept an array of (N, S)
+            # returning (M, S)
             # where N is the number of parameters,
-            # M is the number of points to be examined,
-            # and C is the number of constraints
+            # S is the number of solution vectors to be examined,
+            # and M is the number of constraint components
             return np.array([x[0] ** 2 + x[1],
                              x[0] ** 2 - x[1]])
 
@@ -1379,7 +1379,7 @@ class TestDifferentialEvolutionSolver:
         def quadratic_vec(x):
             return np.sum(x**2, axis=0)
 
-        # A vectorized function needs to accept (len(x), M) and return (M,)
+        # A vectorized function needs to accept (len(x), S) and return (S,)
         with pytest.raises(RuntimeError, match='The vectorized function'):
             differential_evolution(quadratic, self.bounds,
                                    vectorized=True, updating='deferred')
@@ -1396,7 +1396,7 @@ class TestDifferentialEvolutionSolver:
                                    updating='deferred')
 
         def rosen_vec(x):
-            # accept an (len(x0), M) array, returning a (M,) array
+            # accept an (len(x0), S) array, returning a (S,) array
             v = 100 * (x[1:] - x[:-1]**2.0)**2.0
             v += (1 - x[:-1])**2.0
             return np.squeeze(v)
@@ -1423,7 +1423,7 @@ class TestDifferentialEvolutionSolver:
         nlc2 = NonlinearConstraint(constr_f2, (0.9, 0.5), (2.0, 2.0))
 
         def rosen_vec(x):
-            # accept an (len(x0), M) array, returning a (M,) array
+            # accept an (len(x0), S) array, returning a (S,) array
             v = 100 * (x[1:] - x[:-1]**2.0)**2.0
             v += (1 - x[:-1])**2.0
             return np.squeeze(v)

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -1396,7 +1396,7 @@ class TestDifferentialEvolutionSolver:
             return np.sum(x**2, axis=0)
 
         # A vectorized function needs to accept (len(x), S) and return (S,)
-        with pytest.raises(RuntimeError, 'The vectorized function'):
+        with pytest.raises(RuntimeError, match='The vectorized function'):
             differential_evolution(quadratic, self.bounds,
                                    vectorized=True, updating='deferred')
 

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -1396,7 +1396,7 @@ class TestDifferentialEvolutionSolver:
             return np.sum(x**2, axis=0)
 
         # A vectorized function needs to accept (len(x), S) and return (S,)
-        with pytest.raises(RuntimeError, test_constraint_violation_fn):
+        with pytest.raises(RuntimeError, 'The vectorized function'):
             differential_evolution(quadratic, self.bounds,
                                    vectorized=True, updating='deferred')
 

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -1411,11 +1411,11 @@ class TestDifferentialEvolutionSolver:
                                    vectorized=True, workers=map,
                                    updating='deferred')
 
+        ncalls = [0]
+
         def rosen_vec(x):
-            # accept an (len(x0), S) array, returning a (S,) array
-            v = 100 * (x[1:] - x[:-1]**2.0)**2.0
-            v += (1 - x[:-1])**2.0
-            return np.squeeze(v)
+            ncalls[0] += 1
+            return rosen(x)
 
         bounds = [(0, 10), (0, 10)]
         res1 = differential_evolution(rosen, bounds, updating='deferred',
@@ -1425,7 +1425,7 @@ class TestDifferentialEvolutionSolver:
 
         # the two minimisation runs should be functionally equivalent
         assert_allclose(res1.x, res2.x)
-        assert res1.nfev == res2.nfev
+        assert ncalls[0] == res2.nfev
         assert res1.nit == res2.nit
 
     def test_vectorized_constraints(self):

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -652,7 +652,7 @@ class TestDifferentialEvolutionSolver:
 
         for x, v in zip(xs, vs):
             cv = solver._constraint_violation_fn(np.array(x))
-            assert_almost_equal(cv, np.atleast_2d(v))
+            assert_allclose(cv, np.atleast_2d(v))
 
         # vectorized calculation of a series of solutions
         assert_allclose(
@@ -872,11 +872,11 @@ class TestDifferentialEvolutionSolver:
         vs = [(0, 0), (0, 0.1), (0.64, 0), (0.19, 0), (0.01, 1.14)]
 
         for x, v in zip(xs, vs):
-            assert_almost_equal(pc.violation(x), v)
+            assert_allclose(pc.violation(x), v)
 
         # now check that we can vectorize the constraint wrapper
-        np.testing.assert_almost_equal(pc.violation(np.array(xs).T),
-                                       np.array(vs).T)
+        assert_allclose(pc.violation(np.array(xs).T),
+                        np.array(vs).T)
         assert pc.fun(np.array(xs).T).shape == (2, len(xs))
         assert pc.violation(np.array(xs).T).shape == (2, len(xs))
         assert pc.num_constr == 2


### PR DESCRIPTION
Adds the `vectorized` keyword to `differential_evolution`. If `vectorized is True` then `func` is assumed to accept an `(M, len(x))` array and return a `(M,)` array.

`vectorized` is overriden by the `workers` kwd.

The first commit addresses the objective function itself. Further exploration is examining feasibility of vectorising the constraint functions. If vectorisation of the constraints is not possible I'll probably close the PR.