### PR TITLE
MAINT: Try to detect scipy path in `runtests.py` while not building

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Testing SciPy
         if: ${{ github.event_name == 'pull_request' }}
         run: |
-          python3.8-dbg -u runtests.py -g -j2 -m fast -- -rfEX --durations=10 2>&1 | tee runtests.log
+          python3.8-dbg -u runtests.py -n -g -j2 -m fast -- -rfEX --durations=10 2>&1 | tee runtests.log
           python3.8-dbg tools/validate_runtests_log.py fast < runtests.log
       - name: Dynamic symbol hiding check on Linux
         if: ${{ github.event_name == 'pull_request' }}
@@ -93,4 +93,4 @@ jobs:
 
     - name: Test SciPy
       run: |
-        python -u runtests.py -m fast
+        python -u runtests.py -n -m fast

--- a/dev.py
+++ b/dev.py
@@ -314,8 +314,10 @@ def main(argv):
             current_python_path = os.environ.get('PYTHONPATH', None)
             print("Unable to import {} from: {}".format(PROJECT_MODULE,
                                                        current_python_path))
-            from distutils.sysconfig import get_python_lib
-            site_dir = get_python_lib(prefix=PATH_INSTALLED, plat_specific=True)
+            from sysconfig import get_path
+            py_path = get_path('platlib')
+            site_dir = os.path.join(PATH_INSTALLED,
+                                    runtests.get_path_suffix(py_path, 3))
             print("Trying to import scipy from development installed path at:",
                   site_dir)
             sys.path.insert(0, site_dir)
@@ -462,8 +464,8 @@ def build_project(args):
         env['OPT'] = '-O0 -ggdb'
         env['FOPT'] = '-O0 -ggdb'
         if args.gcov:
-            import distutils.sysconfig
-            cvars = distutils.sysconfig.get_config_vars()
+            from sysconfig import get_config_vars
+            cvars = get_config_vars()
             env['OPT'] = '-O0 -ggdb'
             env['FOPT'] = '-O0 -ggdb'
             env['CC'] = env.get('CC', cvars['CC']) + ' --coverage'
@@ -480,8 +482,10 @@ def build_project(args):
     if not os.path.exists(os.path.join(build_dir, 'build.ninja')):
         setup_build(args, env)
 
-    from distutils.sysconfig import get_python_lib
-    site_dir = get_python_lib(prefix=PATH_INSTALLED, plat_specific=True)
+    from sysconfig import get_path
+    py_path = get_path('platlib')
+    site_dir = os.path.join(PATH_INSTALLED,
+                            runtests.get_path_suffix(py_path, 3))
 
     cmd = ["ninja", "-C", "build"]
     if args.parallel > 1:

--- a/runtests.py
+++ b/runtests.py
@@ -290,8 +290,33 @@ def main(argv):
     if args.build_only:
         sys.exit(0)
     else:
-        __import__(PROJECT_MODULE)
-        test = sys.modules[PROJECT_MODULE].test
+        # __import__(PROJECT_MODULE)
+        # test = sys.modules[PROJECT_MODULE].test
+        try:
+            __import__(PROJECT_MODULE)
+            test = sys.modules[PROJECT_MODULE].test
+            version = sys.modules[PROJECT_MODULE].__version__
+            mod_path = sys.modules[PROJECT_MODULE].__file__
+            mod_path = os.path.abspath(os.path.join(os.path.dirname(mod_path)))
+        except ImportError:
+            current_python_path = os.environ.get('PYTHONPATH', None)
+            print("Unable to import {} from: {}".format(PROJECT_MODULE,
+                                                       current_python_path))
+            dst_dir = os.path.join(ROOT_DIR, 'build', 'testenv')
+            from sysconfig import get_path
+            py_path = get_path('platlib')
+            site_dir = os.path.join(dst_dir, get_path_suffix(py_path, 3))
+            print("Trying to import scipy from development installed path at:",
+                  site_dir)
+            sys.path.insert(0, site_dir)
+            os.environ['PYTHONPATH'] = \
+                os.pathsep.join((site_dir, os.environ.get('PYTHONPATH', '')))
+            __import__(PROJECT_MODULE)
+            test = sys.modules[PROJECT_MODULE].test
+            version = sys.modules[PROJECT_MODULE].__version__
+            mod_path = sys.modules[PROJECT_MODULE].__file__
+            mod_path = os.path.abspath(os.path.join(os.path.dirname(mod_path)))
+
 
     if args.submodule:
         tests = [PROJECT_MODULE + "." + args.submodule]

--- a/runtests.py
+++ b/runtests.py
@@ -290,8 +290,6 @@ def main(argv):
     if args.build_only:
         sys.exit(0)
     else:
-        # __import__(PROJECT_MODULE)
-        # test = sys.modules[PROJECT_MODULE].test
         try:
             __import__(PROJECT_MODULE)
             test = sys.modules[PROJECT_MODULE].test

--- a/runtests.py
+++ b/runtests.py
@@ -301,7 +301,7 @@ def main(argv):
         except ImportError:
             current_python_path = os.environ.get('PYTHONPATH', None)
             print("Unable to import {} from: {}".format(PROJECT_MODULE,
-                                                       current_python_path))
+                                                        current_python_path))
             dst_dir = os.path.join(ROOT_DIR, 'build', 'testenv')
             from sysconfig import get_path
             py_path = get_path('platlib')
@@ -340,6 +340,8 @@ def main(argv):
     cwd = os.getcwd()
     try:
         os.chdir(test_dir)
+        print("Running tests for {} version:{}, installed at:{}".format(
+              PROJECT_MODULE, version, mod_path))
         result = test(args.mode,
                       verbose=args.verbose,
                       extra_argv=extra_argv,

--- a/runtests.py
+++ b/runtests.py
@@ -291,15 +291,10 @@ def main(argv):
         sys.exit(0)
     else:
         try:
-            __import__(PROJECT_MODULE)
-            test = sys.modules[PROJECT_MODULE].test
-            version = sys.modules[PROJECT_MODULE].__version__
-            mod_path = sys.modules[PROJECT_MODULE].__file__
-            mod_path = os.path.abspath(os.path.join(os.path.dirname(mod_path)))
+            test, version, mod_path = import_module()
         except ImportError:
-            current_python_path = os.environ.get('PYTHONPATH', None)
-            print("Unable to import {} from: {}".format(PROJECT_MODULE,
-                                                        current_python_path))
+            # this may fail when running with --no-build, so try to detect
+            # an installed scipy in a subdir inside a repo
             dst_dir = os.path.join(ROOT_DIR, 'build', 'testenv')
             from sysconfig import get_path
             py_path = get_path('platlib')
@@ -309,11 +304,7 @@ def main(argv):
             sys.path.insert(0, site_dir)
             os.environ['PYTHONPATH'] = \
                 os.pathsep.join((site_dir, os.environ.get('PYTHONPATH', '')))
-            __import__(PROJECT_MODULE)
-            test = sys.modules[PROJECT_MODULE].test
-            version = sys.modules[PROJECT_MODULE].__version__
-            mod_path = sys.modules[PROJECT_MODULE].__file__
-            mod_path = os.path.abspath(os.path.join(os.path.dirname(mod_path)))
+            test, version, mod_path = import_module()
 
 
     if args.submodule:
@@ -356,6 +347,18 @@ def main(argv):
         sys.exit(0)
     else:
         sys.exit(1)
+
+
+def import_module():
+    """
+    Function of import project module.
+    """
+    __import__(PROJECT_MODULE)
+    test = sys.modules[PROJECT_MODULE].test
+    version = sys.modules[PROJECT_MODULE].__version__
+    mod_path = sys.modules[PROJECT_MODULE].__file__
+    mod_path = os.path.abspath(os.path.join(os.path.dirname(mod_path)))
+    return test, version, mod_path
 
 
 def get_path_suffix(current_path, levels=3):


### PR DESCRIPTION
We don't need to use `export PYTHONPATH` and can test without building:
```
$ python runtests.py -n -s io
Unable to import scipy from: None
Trying to import scipy from development installed path at: /home/admin-pc/Smitlunagariya/scipy/build/testenv/lib/python3.10/site-packages
=============================================== test session starts ================================================
platform linux -- Python 3.10.0, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /home/admin-pc/Smitlunagariya/scipy, configfile: pytest.ini
plugins: cov-3.0.0, forked-1.4.0, xdist-2.5.0
collected 607 items                                                                                                

../testenv/lib/python3.10/site-packages/scipy/io/_harwell_boeing/tests/test_fortran_format.py ...........    [  1%]
../testenv/lib/python3.10/site-packages/scipy/io/_harwell_boeing/tests/test_hb.py ..                         [  2%]
../testenv/lib/python3.10/site-packages/scipy/io/arff/tests/test_arffread.py ...........................     [  6%]
../testenv/lib/python3.10/site-packages/scipy/io/matlab/tests/test_byteordercodes.py ..                      [  6%]
../testenv/lib/python3.10/site-packages/scipy/io/matlab/tests/test_mio.py .................................. [ 12%]
..................................                                                                           [ 18%]
../testenv/lib/python3.10/site-packages/scipy/io/matlab/tests/test_mio5_utils.py ......                      [ 19%]
../testenv/lib/python3.10/site-packages/scipy/io/matlab/tests/test_mio_funcs.py .                            [ 19%]
../testenv/lib/python3.10/site-packages/scipy/io/matlab/tests/test_mio_utils.py ..                           [ 19%]
../testenv/lib/python3.10/site-packages/scipy/io/matlab/tests/test_miobase.py .                              [ 19%]
../testenv/lib/python3.10/site-packages/scipy/io/matlab/tests/test_pathological.py ..                        [ 20%]
../testenv/lib/python3.10/site-packages/scipy/io/matlab/tests/test_streams.py ...........                    [ 21%]
../testenv/lib/python3.10/site-packages/scipy/io/tests/test_fortran.py ...........                           [ 23%]
../testenv/lib/python3.10/site-packages/scipy/io/tests/test_idl.py ......................................... [ 30%]
..........................                                                                                   [ 34%]
../testenv/lib/python3.10/site-packages/scipy/io/tests/test_mmio.py ........................................ [ 41%]
..................................                                                                           [ 46%]
../testenv/lib/python3.10/site-packages/scipy/io/tests/test_netcdf.py .........................              [ 51%]
../testenv/lib/python3.10/site-packages/scipy/io/tests/test_paths.py ...........                             [ 52%]
../testenv/lib/python3.10/site-packages/scipy/io/tests/test_wavfile.py ..................................... [ 58%]
............................................................................................................ [ 76%]
............................................................................................................ [ 94%]
.................................                                                                            [100%]

```

cc @rgommers 