### PR TITLE
Fixed a typo in CubicSpline docstring

### DIFF
--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -548,7 +548,7 @@ class CubicSpline(CubicHermiteSpline):
 
     Notes
     -----
-    Parameters `bc_type` and ``interpolate`` work independently, i.e. the
+    Parameters `bc_type` and ``extrapolate`` work independently, i.e. the
     former controls only construction of a spline, and the latter only
     evaluation.
 


### PR DESCRIPTION

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

Original text in the note section of CubicSpline docstring:
"Parameters `bc_type` and ``interpolate`` work independently"

It should be a typo as I see. Note that CubicSpline does not have a parameter `interpolate`, but `extrapolate`.


#### Additional information
<!--Any additional information you think is important.-->
