### PR TITLE
DOC, BUG: Fix error in heading remapping for custom `scipy.optimize:function` domain directive

### DIFF
--- a/ci/azure-travis-template.yaml
+++ b/ci/azure-travis-template.yaml
@@ -82,7 +82,7 @@ steps:
   - script: pip install pytest-cov coverage codecov
     displayName: 'Install coverage dependencies'
 - ${{ if eq(parameters.refguide_check, true) }}:
-  - script: pip install matplotlib sphinx==3.1 numpydoc==1.1 "Jinja2<=3.0.3"
+  - script: pip install matplotlib sphinx==3.1 numpydoc "Jinja2<=3.0.3"
     displayName: 'Install documentation dependencies'
   - script: sudo apt-get install -y wamerican-small
     displayName: 'Install word list (for csgraph tutorial)'

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -155,6 +155,7 @@ for key in (
         r"OpenSSL\.rand is deprecated",  # OpenSSL package in linkcheck
         r"Using or importing the ABCs from",  # 3.5 importlib._bootstrap
         r"'contextfunction' is renamed to 'pass_context'",  # Jinja
+        r"distutils Version",  # distutils
         ):
     warnings.filterwarnings(  # deal with other modules having bad imports
         'ignore', message=".*" + key, category=DeprecationWarning)

--- a/doc/source/scipyoptdoc.py
+++ b/doc/source/scipyoptdoc.py
@@ -135,10 +135,12 @@ def wrap_mangling_directive(base_directive):
             # Change "Options" to "Other Parameters", run numpydoc, reset
             new_lines = []
             for line in lines:
+                # Remap Options to the "Other Parameters" numpydoc section
+                # along with correct heading length
                 if line.strip() == 'Options':
                     line = "Other Parameters"
-                elif line.strip() == "-"*len('Options'):
-                    line = "-"*len("Other Parameters")
+                    new_lines.extend([line, "-"*len(line)])
+                    continue
                 new_lines.append(line)
             # use impl_name instead of name here to avoid duplicate refs
             mangle_docstrings(env.app, 'function', impl_name,

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -3,5 +3,5 @@
 Sphinx!=3.1.0, !=4.1.0
 pydata-sphinx-theme>=0.6.1
 sphinx-panels>=0.5.2
-numpydoc==1.1
+numpydoc
 matplotlib>2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ doc = [
     "pydata-sphinx-theme>=0.6.1",
     "sphinx-panels>=0.5.2",
     "matplotlib>2",
-    "numpydoc==1.1.0",
+    "numpydoc",
 ]
 dev = [
     "mypy",


### PR DESCRIPTION
There is a bug in `.. scipy.optimize::function` that causes the heading under the `Returns` section of the docstrings to be replaced with a heading with the wrong length. The numpydoc 1.2rc1 release candidate will raise a UserWarning when there is an incorrect header length. Because of the way the doc build is configured, this `UserWarning` is elevated to an exception that terminates the scipy doc build process, so this fix is necessary to build the scipy docs with numpydoc 1.2.

I also had to add an extra warnings filter for a distutils deprecation warning to get the docs to build locally. Not sure if this is the desired fix, but I thought I'd include it here just in case. I'm happy to drop 6ebf6e3 if there is a different preferred solution, or if it's preferred to be handled in a different PR.