### PR TITLE
ENH: stats: add `nnlf` method for discrete distributions

### DIFF
--- a/scipy/stats/tests/test_fit.py
+++ b/scipy/stats/tests/test_fit.py
@@ -140,3 +140,22 @@ def test_expon_fit():
     data = [0, 0, 0, 0, 2, 2, 2, 2]
     phat = stats.expon.fit(data, floc=0)
     assert_allclose(phat, [0, 1.0], atol=1e-3)
+
+
+@pytest.mark.parametrize("dist, params",
+                         [(stats.norm, (0.5, 2.5)), # loc, scale
+                          (stats.binom, (10, 0.3, 2))])  # n, p, loc
+def test_nnlf_and_related_methods(dist, params):
+    rng = np.random.default_rng(983459824)
+
+    if hasattr(dist, 'pdf'):
+        logpxf = dist.logpdf
+    else:
+        logpxf = dist.logpmf
+
+    x = dist.rvs(*params, size=100, random_state=rng)
+    ref = -logpxf(x, *params).sum()
+    res1 = dist.nnlf(params, x)
+    res2 = dist._penalized_nnlf(params, x)
+    assert_allclose(res1, ref)
+    assert_allclose(res2, ref)

--- a/scipy/stats/tests/test_fit.py
+++ b/scipy/stats/tests/test_fit.py
@@ -143,8 +143,8 @@ def test_expon_fit():
 
 
 @pytest.mark.parametrize("dist, params",
-                         [(stats.norm, (0.5, 2.5)), # loc, scale
-                          (stats.binom, (10, 0.3, 2))])  # n, p, loc
+                         [(stats.norm, (0.5, 2.5)),  # type: ignore[attr-defined] # noqa
+                          (stats.binom, (10, 0.3, 2))])  # type: ignore[attr-defined] # noqa
 def test_nnlf_and_related_methods(dist, params):
     rng = np.random.default_rng(983459824)
 


### PR DESCRIPTION
#### Reference issue
gh-15436

#### What does this implement/fix?
gh-15436 adds a `fit` function for discete distributions. It makes sense to share the negative log-likelihood function code between discrete and continuous distributions, so this PR moves those methods from `rv_continuous` to `rv_generic`.

#### Additional information
Need to check whether the documentation for `nnlf` renders correctly after this change.

`nnlf` seems like an erroneous acronym for Negative Log-Likelihood Function. I'd rather not fix it here, but separately, we could consider doc-deprecating `nnlf` and adding a method `nllf`, possibly modifying the interface to make it more consistent with the rest of `rv_generic` methods (e.g. separate shapes, `loc`, and `scale` instead of a tuple `theta`). We might also want to add more comprehensive tests for `nnlf` (or `nllf`) at some point; e.g., in `test_basic_continuous`/`test_basic_discrete`. I couldn't find any existing ones.