### PR TITLE
Adapt dev.py to Windows install stages

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -478,9 +478,8 @@ def copy_openblas():
 
 
 def get_site_packages():
-    py_path = get_path('platlib')
-    return os.path.join(PATH_INSTALLED,
-                        runtests.get_path_suffix(py_path, 3))
+    plat_path = Path(get_path('platlib'))
+    return Path(PATH_INSTALLED) / plat_path.relative_to(sys.exec_prefix)
 
 
 def build_project(args):

--- a/dev.py
+++ b/dev.py
@@ -479,7 +479,7 @@ def copy_openblas():
 
 def get_site_packages():
     plat_path = Path(get_path('platlib'))
-    return Path(PATH_INSTALLED) / plat_path.relative_to(sys.exec_prefix)
+    return str(Path(PATH_INSTALLED) / plat_path.relative_to(sys.exec_prefix))
 
 
 def build_project(args):


### PR DESCRIPTION
Windows needs a copy of OpenBLAS DLL in `.libs`, and a `_distributor_init.py`
to match.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->