### PR TITLE
BUG/DOC/TST: combine_pvalues: fix Tippett and Pearson

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8112,6 +8112,12 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
     These methods are intended only for use to combine p-values from hypothesis
     tests based upon continuous distributions.
 
+    Each method assumes that under the null hypothesis, the p-values were
+    generated independently and uniformly at random in the interval [0, 1].  A
+    test statistic (different for each method) is computed and a combined
+    p-value is calculated based upon the distribution of this test statistic
+    under the null hypothesis.
+    
     Parameters
     ----------
     pvalues : array_like, 1-D

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8161,7 +8161,7 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
       This method emphasises small p-values.
       Note that the test statistic used internally and returned by this method
       is :math:`-2\\sum_i \log(p_i)` for numerical reasons.
-    * Pearson's method uses :math:`\\left( \\prod_i (1-p_i) \\right)^{-1}` [2]_.
+    * Pearson's method uses :math:`\\prod_i \\frac{1}{1-p_i}` [2]_.
       It thus emphasises large p-values.
       Note that the test statistic used internally and returned by this method
       is :math:`-2\\sum_i \log(1-p_i)` for numerical reasons.

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8171,7 +8171,7 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
     * Stouffer's method [5]_ uses Z-scores and the statistic:
       :math:`\\sum_i \\Phi^{-1} (p_i)`, where :math:`\\Phi` is the CDF of the
       standard normal distribution. The advantage of this method is that it is
-      straightforward to introduce weights, which can make Stouffer's method more 
+      straightforward to introduce weights, which can make Stouffer's method more
       powerful than Fisher's method when the p-values are from studies of different
       size [6]_ [7]_.
     * Tippett's method uses the smallest p-value as a statistic.

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8160,8 +8160,12 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
       uses the product of individual p-values: :math:`\\prod_i p_i`.
       (Mind that this product is not the combined p-value.)
       This method emphasises small p-values.
+      Note that the test statistic used internally and returned by this method
+      is :math:`-2\\sum_i \log(p_i)` for numerical reasons.
     * Pearson's method uses :math:`\\left \\prod_i (1-p_i) \\right)^{-1}` [2]_.
       It thus emphasises large p-values.
+      Note that the test statistic used internally and returned by this method
+      is :math:`-2\\sum_i \log(1-p_i)` for numerical reasons.
     * Mudholkar and George compromise between Fisher's and Pearson's method by
       averaging their statistics [4]_. Their method emphasises extreme p-values,
       both close to 1 and 0.

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8212,7 +8212,7 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
         pval = distributions.chi2.sf(statistic, 2 * len(pvalues))
     elif method == 'pearson':
         statistic = -2 * np.sum(np.log1p(-pvalues))
-        pval = 1-distributions.chi2.sf(statistic, 2 * len(pvalues))
+        pval = distributions.chi2.cdf(statistic, 2 * len(pvalues))
     elif method == 'mudholkar_george':
         normalizing_factor = np.sqrt(3/len(pvalues))/np.pi
         statistic = -np.sum(np.log(pvalues)) + np.sum(np.log1p(-pvalues))

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8145,35 +8145,35 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
     uniform distribution on the interval [0,1]. If this function is applied to
     tests with a discrete statistics such as any rank test or contingency-table
     test, it will yield systematically wrong results, e.g. Fisher's method will
-    systematically overestimate the p-value [1]_. This problem becomes less severe
-    for large sample sizes when the discrete distributions become approximately
-    continuous.
+    systematically overestimate the p-value [1]_. This problem becomes less
+    severe for large sample sizes when the discrete distributions become
+    approximately continuous.
 
-    The differences between the methods can be best illustrated by their statistics
-    and what aspects of a combination of p-values they emphasise when considering
-    significance [2]_. For example, methods emphasising large p-values are more 
-    sensitive to strong false and true negatives; conversely methods focussing on
-    small p-values are sensitive to positives.
+    The differences between the methods can be best illustrated by their
+    statistics and what aspects of a combination of p-values they emphasise
+    when considering significance [2]_. For example, methods emphasising large
+    p-values are more sensitive to strong false and true negatives; conversely
+    methods focussing on small p-values are sensitive to positives.
 
     * Fisher's method (also known as Fisher's combined probability test) [3]_
       uses the product of individual p-values: :math:`\\prod_i p_i`.
       (Mind that this product is not the combined p-value.)
       This method emphasises small p-values.
       Note that the test statistic used internally and returned by this method
-      is :math:`-2\\sum_i \log(p_i)` for numerical reasons.
+      is :math:`-2\\sum_i \\log(p_i)` for numerical reasons.
     * Pearson's method uses :math:`\\prod_i \\frac{1}{1-p_i}` [2]_.
       It thus emphasises large p-values.
       Note that the test statistic used internally and returned by this method
-      is :math:`-2\\sum_i \log(1-p_i)` for numerical reasons.
+      is :math:`-2\\sum_i \\log(1-p_i)` for numerical reasons.
     * Mudholkar and George compromise between Fisher's and Pearson's method by
-      averaging their statistics [4]_. Their method emphasises extreme p-values,
-      both close to 1 and 0.
+      averaging their statistics [4]_. Their method emphasises extreme
+      p-values, both close to 1 and 0.
     * Stouffer's method [5]_ uses Z-scores and the statistic:
       :math:`\\sum_i \\Phi^{-1} (p_i)`, where :math:`\\Phi` is the CDF of the
       standard normal distribution. The advantage of this method is that it is
-      straightforward to introduce weights, which can make Stouffer's method more
-      powerful than Fisher's method when the p-values are from studies of different
-      size [6]_ [7]_.
+      straightforward to introduce weights, which can make Stouffer's method
+      more powerful than Fisher's method when the p-values are from studies
+      of different size [6]_ [7]_.
     * Tippett's method uses the smallest p-value as a statistic.
       (Mind that this minimum is not the combined p-value.)
 
@@ -8185,8 +8185,9 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
 
     References
     ----------
-    .. [1] Kincaid, W. M., "The Combination of Tests Based on Discrete Distributions."
-           Journal of the American Statistical Association 57, no. 297 (1962), 10-19.
+    .. [1] Kincaid, W. M., "The Combination of Tests Based on Discrete
+           Distributions." Journal of the American Statistical Association 57,
+           no. 297 (1962), 10-19.
     .. [2] Heard, N. and Rubin-Delanchey, P. "Choosing between methods of
            combining p-values."  Biometrika 105.1 (2018): 239-246.
     .. [3] https://en.wikipedia.org/wiki/Fisher%27s_method

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8112,9 +8112,9 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
     These methods are intended only for combining p-values from hypothesis
     tests based upon continuous distributions.
 
-    Each method assumes that under the null hypothesis, the p-values were
-    generated independently and uniformly at random in the interval [0, 1].  A
-    test statistic (different for each method) is computed and a combined
+    Each method assumes that under the null hypothesis, the p-values are
+    sampled independently and uniformly from the interval [0, 1]. A test
+    statistic (different for each method) is computed and a combined
     p-value is calculated based upon the distribution of this test statistic
     under the null hypothesis.
 
@@ -8127,17 +8127,13 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
 
         Name of method to use to combine p-values.
 
-        The available methods are listed below (default 'fisher'). The
-        quantities listed are the test statistics associated with the methods.
+        The available methods are (see Notes for details):
 
-        * 'fisher': Fisher's method (Fisher's combined probability test), the
-          sum of the logarithm of the p-values
-        * 'pearson': Pearson's method (similar to Fisher's but uses sum of the
-          complement of the p-values inside the logarithms)
-        * 'tippett': Tippett's method (minimum of p-values)
+        * 'fisher': Fisher's method (Fisher's combined probability test)
+        * 'pearson': Pearson's method
+        * 'mudholkar_george': Mudholkar's and George's method
+        * 'tippett': Tippett's method
         * 'stouffer': Stouffer's Z-score method
-        * 'mudholkar_george': the difference of Fisher's and Pearson's methods
-          divided by 2
     weights : array_like, 1-D, optional
         Optional array of weights used only for Stouffer's Z-score method.
 
@@ -8150,14 +8146,11 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
 
     Notes
     -----
-    All methods assume tests based on continuous distributions, i.e., the
-    distribution of p-values under the null hypothesis must be the continuous
-    uniform distribution on the interval [0,1]. If this function is applied to
-    tests with a discrete statistics such as any rank test or contingency-table
-    test, it will yield systematically wrong results, e.g. Fisher's method will
-    systematically overestimate the p-value [1]_. This problem becomes less
-    severe for large sample sizes when the discrete distributions become
-    approximately continuous.
+    If this function is applied to tests with a discrete statistics such as
+    any rank test or contingency-table test, it will yield systematically
+    wrong results, e.g. Fisher's method will systematically overestimate the
+    p-value [1]_. This problem becomes less severe for large sample sizes
+    when the discrete distributions become approximately continuous.
 
     The differences between the methods can be best illustrated by their
     statistics and what aspects of a combination of p-values they emphasise
@@ -8165,16 +8158,14 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
     p-values are more sensitive to strong false and true negatives; conversely
     methods focussing on small p-values are sensitive to positives.
 
-    * Fisher's method (also known as Fisher's combined probability test) [3]_
-      uses the product of individual p-values: :math:`\\prod_i p_i`.
-      (Mind that this product is not the combined p-value.)
-      This method emphasises small p-values.
-      Note that the test statistic used internally and returned by this method
-      is :math:`-2\\sum_i \\log(p_i)` for numerical reasons.
-    * Pearson's method uses :math:`\\prod_i \\frac{1}{1-p_i}` [2]_.
+    * The statistics of Fisher's method (also known as Fisher's combined
+      probability test) [3]_ is :math:`-2\\sum_i \\log(p_i)`, which is
+      equivalent (as a test statistics) to the product of individual p-values:
+      :math:`\\prod_i p_i`. Under the null hypothesis, this statistics follows
+      a :math:`\\chi^2` distribution. This method emphasises small p-values.
+    * Pearson's method uses :math:`-2\\sum_i\\log(1-p_i)`, which is equivalent
+      to :math:`-\\prod_i \\frac{1}{1-p_i}` [2]_.
       It thus emphasises large p-values.
-      Note that the test statistic used internally and returned by this method
-      is :math:`-2\\sum_i \\log(1-p_i)` for numerical reasons.
     * Mudholkar and George compromise between Fisher's and Pearson's method by
       averaging their statistics [4]_. Their method emphasises extreme
       p-values, both close to 1 and 0.

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8212,7 +8212,7 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
         pval = distributions.chi2.sf(statistic, 2 * len(pvalues))
     elif method == 'pearson':
         statistic = -2 * np.sum(np.log1p(-pvalues))
-        pval = distributions.chi2.sf(statistic, 2 * len(pvalues))
+        pval = 1-distributions.chi2.sf(statistic, 2 * len(pvalues))
     elif method == 'mudholkar_george':
         normalizing_factor = np.sqrt(3/len(pvalues))/np.pi
         statistic = -np.sum(np.log(pvalues)) + np.sum(np.log1p(-pvalues))
@@ -8222,7 +8222,7 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
                                   * approx_factor, nu)
     elif method == 'tippett':
         statistic = np.min(pvalues)
-        pval = distributions.beta.sf(statistic, 1, len(pvalues))
+        pval = distributions.beta.cdf(statistic, 1, len(pvalues))
     elif method == 'stouffer':
         if weights is None:
             weights = np.ones_like(pvalues)

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8235,8 +8235,8 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
 
     else:
         raise ValueError(
-            "Invalid method '%s'. Options are 'fisher', 'pearson', \
-            'mudholkar_george', 'tippett', 'or 'stouffer'", method)
+            "Invalid method '%s'. Valid methods are 'fisher', 'pearson', \
+            'mudholkar_george', 'tippett', and 'stouffer'", method)
 
     return (statistic, pval)
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8126,7 +8126,9 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
     method : {'fisher', 'pearson', 'tippett', 'stouffer', 'mudholkar_george'}
 
         Name of method to use to combine p-values.
-        The following methods are available (default is 'fisher'):
+        
+        The available methods are listed below (default 'fisher'). The
+        quantities listed are the test statistics associated with the methods.
 
         * 'fisher': Fisher's method (Fisher's combined probability test), the
           sum of the logarithm of the p-values

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8115,7 +8115,7 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
     pvalues : array_like, 1-D
         Array of p-values assumed to come from independent tests based on
         continuous distributions.
-    method : {'fisher', 'pearson', 'tippett', 'stouffer', 'mudholkar_george'}, optional
+    method : {'fisher', 'pearson', 'tippett', 'stouffer', 'mudholkar_george'}
 
         Name of method to use to combine p-values.
         The following methods are available (default is 'fisher'):

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8107,12 +8107,14 @@ def brunnermunzel(x, y, alternative="two-sided", distribution="t",
 
 def combine_pvalues(pvalues, method='fisher', weights=None):
     """
-    Combine p-values from independent tests bearing upon the same hypothesis.
+    Combine p-values from independent tests that bear upon the same hypothesis
+    and are based on continuous distributions.
 
     Parameters
     ----------
     pvalues : array_like, 1-D
-        Array of p-values assumed to come from independent tests.
+        Array of p-values assumed to come from independent tests based on
+        continuous distributions.
     method : {'fisher', 'pearson', 'tippett', 'stouffer',
               'mudholkar_george'}, optional
 
@@ -8139,6 +8141,15 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
 
     Notes
     -----
+    All methods assume tests based on continuous distributions, i.e., the
+    distribution of p-values under the null hypothesis must be the continuous
+    uniform distribution on the interval [0,1]. If this function is applied to
+    tests with a discrete statistics such as any rank test or contingency-table
+    test, it will yield systematically wrong results, e.g. Fisher's method will
+    systematically overestimate the p-value [8]_. This problem becomes less severe
+    for large sample sizes when the discrete distributions become approximately
+    continuous.
+
     Fisher's method (also known as Fisher's combined probability test) [1]_ uses
     a chi-squared statistic to compute a combined p-value. The closely related
     Stouffer's Z-score method [2]_ uses Z-scores rather than p-values. The
@@ -8177,6 +8188,7 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
            for combining probabilities in meta-analysis." Journal of
            Evolutionary Biology 24, no. 8 (2011): 1836-1841.
     .. [7] https://en.wikipedia.org/wiki/Extensions_of_Fisher%27s_method
+	.. [8] Kincaid, W. M., "The Combination of Tests Based on Discrete Distributions." Journal of the American Statistical Association 57, no. 297 (1962), 10-19.
 
     """
     pvalues = np.asarray(pvalues)

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8169,7 +8169,7 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
       averaging their statistics [4]_. Their method emphasises extreme p-values,
       both close to 1 and 0.
     * Stouffer's method [5]_ uses Z-scores and the statistic:
-	  :math:`\\sum_i \\Phi^{-1} (p_i)`, where :math:`\\Phi` is the CDF of the
+      :math:`\\sum_i \\Phi^{-1} (p_i)`, where :math:`\\Phi` is the CDF of the
       standard normal distribution. The advantage of this method is that it is
       straightforward to introduce weights, which can make Stouffer's method more 
       powerful than Fisher's method when the p-values are from studies of different

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8239,8 +8239,9 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
 
     else:
         raise ValueError(
-            "Invalid method '%s'. Valid methods are 'fisher', 'pearson', \
-            'mudholkar_george', 'tippett', and 'stouffer'", method)
+            f"Invalid method {method!r}. Valid methods are 'fisher', 'pearson', "
+            "'mudholkar_george', 'tippett', and 'stouffer'"
+        )
 
     return (statistic, pval)
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8109,7 +8109,7 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
     """
     Combine p-values from independent tests that bear upon the same hypothesis.
     
-    These methods are intended only for use to combine p-values from hypothesis
+    These methods are intended only for combining p-values from hypothesis
     tests based upon continuous distributions.
 
     Each method assumes that under the null hypothesis, the p-values were

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8239,8 +8239,8 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
 
     else:
         raise ValueError(
-            f"Invalid method {method!r}. Valid methods are 'fisher', 'pearson', "
-            "'mudholkar_george', 'tippett', and 'stouffer'"
+            f"Invalid method {method!r}. Valid methods are 'fisher', "
+            "'pearson', 'mudholkar_george', 'tippett', and 'stouffer'"
         )
 
     return (statistic, pval)

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8108,7 +8108,7 @@ def brunnermunzel(x, y, alternative="two-sided", distribution="t",
 def combine_pvalues(pvalues, method='fisher', weights=None):
     """
     Combine p-values from independent tests that bear upon the same hypothesis.
-    
+
     These methods are intended only for combining p-values from hypothesis
     tests based upon continuous distributions.
 
@@ -8117,7 +8117,7 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
     test statistic (different for each method) is computed and a combined
     p-value is calculated based upon the distribution of this test statistic
     under the null hypothesis.
-    
+
     Parameters
     ----------
     pvalues : array_like, 1-D
@@ -8126,7 +8126,7 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
     method : {'fisher', 'pearson', 'tippett', 'stouffer', 'mudholkar_george'}
 
         Name of method to use to combine p-values.
-        
+
         The available methods are listed below (default 'fisher'). The
         quantities listed are the test statistics associated with the methods.
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8164,7 +8164,7 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
       :math:`\\prod_i p_i`. Under the null hypothesis, this statistics follows
       a :math:`\\chi^2` distribution. This method emphasises small p-values.
     * Pearson's method uses :math:`-2\\sum_i\\log(1-p_i)`, which is equivalent
-      to :math:`-\\prod_i \\frac{1}{1-p_i}` [2]_.
+      to :math:`\\prod_i \\frac{1}{1-p_i}` [2]_.
       It thus emphasises large p-values.
     * Mudholkar and George compromise between Fisher's and Pearson's method by
       averaging their statistics [4]_. Their method emphasises extreme
@@ -8212,8 +8212,8 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
         statistic = -2 * np.sum(np.log(pvalues))
         pval = distributions.chi2.sf(statistic, 2 * len(pvalues))
     elif method == 'pearson':
-        statistic = -2 * np.sum(np.log1p(-pvalues))
-        pval = distributions.chi2.cdf(statistic, 2 * len(pvalues))
+        statistic = 2 * np.sum(np.log1p(-pvalues))
+        pval = distributions.chi2.cdf(-statistic, 2 * len(pvalues))
     elif method == 'mudholkar_george':
         normalizing_factor = np.sqrt(3/len(pvalues))/np.pi
         statistic = -np.sum(np.log(pvalues)) + np.sum(np.log1p(-pvalues))

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8146,49 +8146,57 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
     uniform distribution on the interval [0,1]. If this function is applied to
     tests with a discrete statistics such as any rank test or contingency-table
     test, it will yield systematically wrong results, e.g. Fisher's method will
-    systematically overestimate the p-value [8]_. This problem becomes less severe
+    systematically overestimate the p-value [1]_. This problem becomes less severe
     for large sample sizes when the discrete distributions become approximately
     continuous.
 
-    Fisher's method (also known as Fisher's combined probability test) [1]_ uses
-    a chi-squared statistic to compute a combined p-value. The closely related
-    Stouffer's Z-score method [2]_ uses Z-scores rather than p-values. The
-    advantage of Stouffer's method is that it is straightforward to introduce
-    weights, which can make Stouffer's method more powerful than Fisher's
-    method when the p-values are from studies of different size [6]_ [7]_.
-    The Pearson's method uses :math:`log(1-p_i)` inside the sum whereas Fisher's
-    method uses :math:`log(p_i)` [4]_. For Fisher's and Pearson's method, the
-    sum of the logarithms is multiplied by -2 in the implementation. This
-    quantity has a chi-square distribution that determines the p-value. The
-    `mudholkar_george` method is the difference of the Fisher's and Pearson's
-    test statistics, each of which include the -2 factor [4]_. However, the
-    `mudholkar_george` method does not include these -2 factors. The test
-    statistic of `mudholkar_george` is the sum of logisitic random variables and
-    equation 3.6 in [3]_ is used to approximate the p-value based on Student's
-    t-distribution.
+    The differences between the methods can be best illustrated by their statistics
+    and what aspects of a combination of p-values they emphasise when considering
+    significance [2]_. For example, methods emphasising large p-values are more 
+    sensitive to strong false and true negatives; conversely methods focussing on
+    small p-values are sensitive to positives.
+
+    * Fisher's method (also known as Fisher's combined probability test) [3]_
+      uses the product of individual p-values: :math:`\\prod_i p_i`.
+      (Mind that this product is not the combined p-value.)
+      This method emphasises small p-values.
+    * Pearson's method uses :math:`\\left \\prod_i (1-p_i) \\right)^{-1}` [2]_.
+      It thus emphasises large p-values.
+    * Mudholkar and George compromise between Fisher's and Pearson's method by
+      averaging their statistics [4]_. Their method emphasises extreme p-values,
+      both close to 1 and 0.
+    * Stouffer's method [5]_ uses Z-scores and the statistic:
+      :math:`\\sum_i \\Phi^{-1} (p_i)`, where `\\Phi` is the CDF of the
+      standard normal distribution. The advantage of this method is that it is
+      straightforward to introduce weights, which can make Stouffer's method more 
+      powerful than Fisher's method when the p-values are from studies of different
+      size [6]_ [7]_.
+    * Tippett's method uses the smallest p-value as a statistic.
+      (Mind that this minimum is not the combined p-value.)
 
     Fisher's method may be extended to combine p-values from dependent tests
-    [5]_. Extensions such as Brown's method and Kost's method are not currently
+    [8]_. Extensions such as Brown's method and Kost's method are not currently
     implemented.
 
     .. versionadded:: 0.15.0
 
     References
     ----------
-    .. [1] https://en.wikipedia.org/wiki/Fisher%27s_method
-    .. [2] https://en.wikipedia.org/wiki/Fisher%27s_method#Relation_to_Stouffer.27s_Z-score_method
-    .. [3] George, E. O., and G. S. Mudholkar. "On the convolution of logistic
-           random variables." Metrika 30.1 (1983): 1-13.
-    .. [4] Heard, N. and Rubin-Delanchey, P. "Choosing between methods of
+    .. [1] Kincaid, W. M., "The Combination of Tests Based on Discrete Distributions."
+           Journal of the American Statistical Association 57, no. 297 (1962), 10-19.
+    .. [2] Heard, N. and Rubin-Delanchey, P. "Choosing between methods of
            combining p-values."  Biometrika 105.1 (2018): 239-246.
-    .. [5] Whitlock, M. C. "Combining probability from independent tests: the
+    .. [3] https://en.wikipedia.org/wiki/Fisher%27s_method
+    .. [4] George, E. O., and G. S. Mudholkar. "On the convolution of logistic
+           random variables." Metrika 30.1 (1983): 1-13.
+    .. [5] https://en.wikipedia.org/wiki/Fisher%27s_method#Relation_to_Stouffer.27s_Z-score_method
+    .. [6] Whitlock, M. C. "Combining probability from independent tests: the
            weighted Z-method is superior to Fisher's approach." Journal of
            Evolutionary Biology 18, no. 5 (2005): 1368-1373.
-    .. [6] Zaykin, Dmitri V. "Optimally weighted Z-test is a powerful method
+    .. [7] Zaykin, Dmitri V. "Optimally weighted Z-test is a powerful method
            for combining probabilities in meta-analysis." Journal of
            Evolutionary Biology 24, no. 8 (2011): 1836-1841.
-    .. [7] https://en.wikipedia.org/wiki/Extensions_of_Fisher%27s_method
-	.. [8] Kincaid, W. M., "The Combination of Tests Based on Discrete Distributions." Journal of the American Statistical Association 57, no. 297 (1962), 10-19.
+    .. [8] https://en.wikipedia.org/wiki/Extensions_of_Fisher%27s_method
 
     """
     pvalues = np.asarray(pvalues)

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8162,7 +8162,7 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
       This method emphasises small p-values.
       Note that the test statistic used internally and returned by this method
       is :math:`-2\\sum_i \log(p_i)` for numerical reasons.
-    * Pearson's method uses :math:`\\left \\prod_i (1-p_i) \\right)^{-1}` [2]_.
+    * Pearson's method uses :math:`\\left( \\prod_i (1-p_i) \\right)^{-1}` [2]_.
       It thus emphasises large p-values.
       Note that the test statistic used internally and returned by this method
       is :math:`-2\\sum_i \log(1-p_i)` for numerical reasons.
@@ -8170,7 +8170,7 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
       averaging their statistics [4]_. Their method emphasises extreme p-values,
       both close to 1 and 0.
     * Stouffer's method [5]_ uses Z-scores and the statistic:
-      :math:`\\sum_i \\Phi^{-1} (p_i)`, where `\\Phi` is the CDF of the
+	  :math:`\\sum_i \\Phi^{-1} (p_i)`, where :math:`\\Phi` is the CDF of the
       standard normal distribution. The advantage of this method is that it is
       straightforward to introduce weights, which can make Stouffer's method more 
       powerful than Fisher's method when the p-values are from studies of different

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8115,20 +8115,19 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
     pvalues : array_like, 1-D
         Array of p-values assumed to come from independent tests based on
         continuous distributions.
-    method : {'fisher', 'pearson', 'tippett', 'stouffer',
-              'mudholkar_george'}, optional
+    method : {'fisher', 'pearson', 'tippett', 'stouffer', 'mudholkar_george'}, optional
 
         Name of method to use to combine p-values.
         The following methods are available (default is 'fisher'):
 
-          * 'fisher': Fisher's method (Fisher's combined probability test), the
-            sum of the logarithm of the p-values
-          * 'pearson': Pearson's method (similar to Fisher's but uses sum of the
-            complement of the p-values inside the logarithms)
-          * 'tippett': Tippett's method (minimum of p-values)
-          * 'stouffer': Stouffer's Z-score method
-          * 'mudholkar_george': the difference of Fisher's and Pearson's methods
-            divided by 2
+        * 'fisher': Fisher's method (Fisher's combined probability test), the
+          sum of the logarithm of the p-values
+        * 'pearson': Pearson's method (similar to Fisher's but uses sum of the
+          complement of the p-values inside the logarithms)
+        * 'tippett': Tippett's method (minimum of p-values)
+        * 'stouffer': Stouffer's Z-score method
+        * 'mudholkar_george': the difference of Fisher's and Pearson's methods
+          divided by 2
     weights : array_like, 1-D, optional
         Optional array of weights used only for Stouffer's Z-score method.
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8107,8 +8107,10 @@ def brunnermunzel(x, y, alternative="two-sided", distribution="t",
 
 def combine_pvalues(pvalues, method='fisher', weights=None):
     """
-    Combine p-values from independent tests that bear upon the same hypothesis
-    and are based on continuous distributions.
+    Combine p-values from independent tests that bear upon the same hypothesis.
+    
+    These methods are intended only for use to combine p-values from hypothesis
+    tests based upon continuous distributions.
 
     Parameters
     ----------

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -6620,8 +6620,8 @@ class TestCombinePvalues:
         "method",
         ["fisher", "pearson", "tippett", "stouffer", "mudholkar_george"],
     )
-    def test_monotony(self, variant, method):
-        # Test that result increases monotonously with respect to input.
+    def test_monotonicity(self, variant, method):
+        # Test that result increases monotonically with respect to input.
         changing_values = np.linspace(0.1, 0.9, 10)
         rng = np.random.default_rng(278448169958891062669391462690811630763)
         pvalues = rng.random(7)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -6608,12 +6608,11 @@ class TestCombinePvalues:
         Z, p = stats.combine_pvalues([.1, .1, .1], method='mudholkar_george')
         assert_approx_equal(p, 0.019462, significant=4)
 
-    def test_mudholkar_george_equal_fisher_minus_pearson(self):
+    def test_mudholkar_george_equal_fisher_pearson_average(self):
         Z, p = stats.combine_pvalues([.01, .2, .3], method='mudholkar_george')
         Z_f, p_f = stats.combine_pvalues([.01, .2, .3], method='fisher')
         Z_p, p_p = stats.combine_pvalues([.01, .2, .3], method='pearson')
-        # 0.5 here is because logistic = log(u) - log(1-u), i.e. no 2 factors
-        assert_approx_equal(0.5 * (Z_f-Z_p), Z, significant=4)
+        assert_approx_equal(0.5 * (Z_f+Z_p), Z, significant=4)
 
     @pytest.mark.parametrize("variant", ["single", "all", "random"])
     @pytest.mark.parametrize(

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -6616,9 +6616,10 @@ class TestCombinePvalues:
         assert_approx_equal(0.5 * (Z_f-Z_p), Z, significant=4)
 
     @pytest.mark.parametrize("variant", ["single", "all"])
-    @pytest.mark.parametrize("method",
-                             ["fisher", "pearson", "tippett",
-                              "stouffer", "mudholkar_george"])
+    @pytest.mark.parametrize(
+        "method",
+        ["fisher", "pearson", "tippett", "stouffer", "mudholkar_george"],
+    )
     def test_monotony(self, variant, method):
         # Test that result increases monotonously with respect to input.
         changing_values = np.linspace(0.1, 0.9, 10)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -6622,7 +6622,8 @@ class TestCombinePvalues:
     def test_monotony(self, variant, method):
         # Test that result increases monotonously with respect to input.
         changing_values = np.linspace(0.1, 0.9, 10)
-        pvalues = np.random.random(7)
+        rng = np.random.default_rng(278448169958891062669391462690811630763)
+        pvalues = rng.random(7)
         combined_pvalues = []
         for changing_value in changing_values:
             if variant == "single":

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -6615,6 +6615,21 @@ class TestCombinePvalues:
         # 0.5 here is because logistic = log(u) - log(1-u), i.e. no 2 factors
         assert_approx_equal(0.5 * (Z_f-Z_p), Z, significant=4)
 
+    def test_monotony_all(self):
+        # Test that result increases monotonously with respect to input.
+        changing_values = np.linspace(0.1,0.9,10)
+        for method in ["fisher","pearson","tippett","stouffer","mudholkar_george"]:
+            for variant in ["single","all"]:
+                pvalues = np.random.random(7)
+                combined_pvalues = []
+                for changing_value in changing_values:
+                    if variant=="single":
+                        pvalues[0] = changing_value
+                    else:
+                        pvalues = np.full(7,changing_value)
+                    combined_p = stats.combine_pvalues(pvalues, method=method)[1]
+                    combined_pvalues.append(combined_p)
+                assert np.all(np.diff(combined_pvalues)>=0)
 
 class TestCdfDistanceValidation:
     """

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -6615,22 +6615,23 @@ class TestCombinePvalues:
         # 0.5 here is because logistic = log(u) - log(1-u), i.e. no 2 factors
         assert_approx_equal(0.5 * (Z_f-Z_p), Z, significant=4)
 
-    @pytest.mark.parametrize("variant", ["single","all"])
+    @pytest.mark.parametrize("variant", ["single", "all"])
     @pytest.mark.parametrize("method",
-            ["fisher","pearson","tippett","stouffer","mudholkar_george"])
-    def test_monotony(self,variant,method):
+                             ["fisher", "pearson", "tippett",
+                                 "stouffer", "mudholkar_george"])
+    def test_monotony(self, variant, method):
         # Test that result increases monotonously with respect to input.
-        changing_values = np.linspace(0.1,0.9,10)
+        changing_values = np.linspace(0.1, 0.9, 10)
         pvalues = np.random.random(7)
         combined_pvalues = []
         for changing_value in changing_values:
-            if variant=="single":
+            if variant == "single":
                 pvalues[0] = changing_value
             else:
-                pvalues = np.full(7,changing_value)
+                pvalues = np.full(7, changing_value)
             combined_p = stats.combine_pvalues(pvalues, method=method)[1]
             combined_pvalues.append(combined_p)
-        assert np.all(np.diff(combined_pvalues)>=0)
+        assert np.all(np.diff(combined_pvalues) >= 0)
 
 class TestCdfDistanceValidation:
     """

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -6618,7 +6618,7 @@ class TestCombinePvalues:
     @pytest.mark.parametrize("variant", ["single", "all"])
     @pytest.mark.parametrize("method",
                              ["fisher", "pearson", "tippett",
-                                 "stouffer", "mudholkar_george"])
+                              "stouffer", "mudholkar_george"])
     def test_monotony(self, variant, method):
         # Test that result increases monotonously with respect to input.
         changing_values = np.linspace(0.1, 0.9, 10)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -6618,7 +6618,7 @@ class TestCombinePvalues:
     @pytest.mark.parametrize("variant", ["single","all"])
     @pytest.mark.parametrize("method",
             ["fisher","pearson","tippett","stouffer","mudholkar_george"])
-    def test_monotony_all(self,variant,method):
+    def test_monotony(self,variant,method):
         # Test that result increases monotonously with respect to input.
         changing_values = np.linspace(0.1,0.9,10)
         pvalues = np.random.random(7)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -6615,21 +6615,22 @@ class TestCombinePvalues:
         # 0.5 here is because logistic = log(u) - log(1-u), i.e. no 2 factors
         assert_approx_equal(0.5 * (Z_f-Z_p), Z, significant=4)
 
-    def test_monotony_all(self):
+    @pytest.mark.parametrize("variant", ["single","all"])
+    @pytest.mark.parametrize("method",
+            ["fisher","pearson","tippett","stouffer","mudholkar_george"])
+    def test_monotony_all(self,variant,method):
         # Test that result increases monotonously with respect to input.
         changing_values = np.linspace(0.1,0.9,10)
-        for method in ["fisher","pearson","tippett","stouffer","mudholkar_george"]:
-            for variant in ["single","all"]:
-                pvalues = np.random.random(7)
-                combined_pvalues = []
-                for changing_value in changing_values:
-                    if variant=="single":
-                        pvalues[0] = changing_value
-                    else:
-                        pvalues = np.full(7,changing_value)
-                    combined_p = stats.combine_pvalues(pvalues, method=method)[1]
-                    combined_pvalues.append(combined_p)
-                assert np.all(np.diff(combined_pvalues)>=0)
+        pvalues = np.random.random(7)
+        combined_pvalues = []
+        for changing_value in changing_values:
+            if variant=="single":
+                pvalues[0] = changing_value
+            else:
+                pvalues = np.full(7,changing_value)
+            combined_p = stats.combine_pvalues(pvalues, method=method)[1]
+            combined_pvalues.append(combined_p)
+        assert np.all(np.diff(combined_pvalues)>=0)
 
 class TestCdfDistanceValidation:
     """

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -6598,11 +6598,11 @@ class TestCombinePvalues:
 
     def test_pearson(self):
         Z, p = stats.combine_pvalues([.01, .2, .3], method='pearson')
-        assert_approx_equal(p, 0.97787, significant=4)
+        assert_approx_equal(p, 0.02213, significant=4)
 
     def test_tippett(self):
         Z, p = stats.combine_pvalues([.01, .2, .3], method='tippett')
-        assert_approx_equal(p, 0.970299, significant=4)
+        assert_approx_equal(p, 0.0297, significant=4)
 
     def test_mudholkar_george(self):
         Z, p = stats.combine_pvalues([.1, .1, .1], method='mudholkar_george')


### PR DESCRIPTION
#### Reference issue
Closes #15373.

#### What does this implement/fix?
* Fixes #15373 and includes test for monotony as described therein.
* Includes warnings in documentation that this can only be applied to continuous tests.
* Better explain the different methods in the documentation, removing technical details that I doubt to be useful to any reader.
* Minor formatting fixes to documentation.

#### Additional information
I am currently in the process of writing a Monte Carlo-based [module](https://github.com/BPSB/combine-p-values-discrete) for combining _p_ values (mainly of discrete tests): I used this to further test all methods.
