### PR TITLE
ENH: Make dual_annealing work with Bounds class

### DIFF
--- a/scipy/optimize/_dual_annealing.py
+++ b/scipy/optimize/_dual_annealing.py
@@ -14,7 +14,8 @@ from scipy.optimize import OptimizeResult
 from scipy.optimize import minimize
 from scipy.special import gammaln
 from scipy._lib._util import check_random_state
-
+from scipy.optimize import Bounds
+from scipy.optimize._constraints import new_bounds_to_old
 
 __all__ = ['dual_annealing']
 
@@ -448,9 +449,13 @@ def dual_annealing(func, bounds, args=(), maxiter=1000,
         ``f(x, *args)``, where ``x`` is the argument in the form of a 1-D array
         and ``args`` is a  tuple of any additional fixed parameters needed to
         completely specify the function.
-    bounds : sequence, shape (n, 2)
-        Bounds for variables.  ``(min, max)`` pairs for each element in ``x``,
-        defining bounds for the objective function parameter.
+    bounds : sequence or `Bounds`
+        Bounds for variables. There are two ways to specify the bounds:
+        1. Instance of `Bounds` class.
+        2. ``(min, max)`` pairs for each element in ``x``, defining the finite
+        lower and upper bounds for the optimizing argument of `func`. It is
+        required to have ``len(bounds) == len(x)``. ``len(bounds)`` is used
+        to determine the number of parameters in ``x``.
     args : tuple, optional
         Any additional fixed parameters needed to completely specify the
         objective function.
@@ -613,7 +618,12 @@ def dual_annealing(func, bounds, args=(), maxiter=1000,
     >>> ret.fun
     0.000000
 
-    """  # noqa: E501
+    """ 
+    
+    if isinstance(bounds, Bounds):
+        bounds = new_bounds_to_old(bounds.lb, bounds.ub, len(bounds.lb))
+    
+    # noqa: E501
     if x0 is not None and not len(x0) == len(bounds):
         raise ValueError('Bounds size does not match x0')
 

--- a/scipy/optimize/_dual_annealing.py
+++ b/scipy/optimize/_dual_annealing.py
@@ -451,8 +451,8 @@ def dual_annealing(func, bounds, args=(), maxiter=1000,
     bounds : sequence or `Bounds`
         Bounds for variables. There are two ways to specify the bounds:
 
-            1. Instance of `Bounds` class.
-            2. Sequence of ``(min, max)`` pairs for each element in `x`.
+        1. Instance of `Bounds` class.
+        2. Sequence of ``(min, max)`` pairs for each element in `x`.
 
     args : tuple, optional
         Any additional fixed parameters needed to completely specify the

--- a/scipy/optimize/_dual_annealing.py
+++ b/scipy/optimize/_dual_annealing.py
@@ -618,11 +618,11 @@ def dual_annealing(func, bounds, args=(), maxiter=1000,
     >>> ret.fun
     0.000000
 
-    """ 
-    
+    """
+
     if isinstance(bounds, Bounds):
         bounds = new_bounds_to_old(bounds.lb, bounds.ub, len(bounds.lb))
-    
+
     # noqa: E501
     if x0 is not None and not len(x0) == len(bounds):
         raise ValueError('Bounds size does not match x0')

--- a/scipy/optimize/_dual_annealing.py
+++ b/scipy/optimize/_dual_annealing.py
@@ -11,10 +11,9 @@ import warnings
 
 import numpy as np
 from scipy.optimize import OptimizeResult
-from scipy.optimize import minimize
+from scipy.optimize import minimize, Bounds
 from scipy.special import gammaln
 from scipy._lib._util import check_random_state
-from scipy.optimize import Bounds
 from scipy.optimize._constraints import new_bounds_to_old
 
 __all__ = ['dual_annealing']
@@ -451,11 +450,10 @@ def dual_annealing(func, bounds, args=(), maxiter=1000,
         completely specify the function.
     bounds : sequence or `Bounds`
         Bounds for variables. There are two ways to specify the bounds:
-        1. Instance of `Bounds` class.
-        2. ``(min, max)`` pairs for each element in ``x``, defining the finite
-        lower and upper bounds for the optimizing argument of `func`. It is
-        required to have ``len(bounds) == len(x)``. ``len(bounds)`` is used
-        to determine the number of parameters in ``x``.
+
+            1. Instance of `Bounds` class.
+            2. Sequence of ``(min, max)`` pairs for each element in `x`.
+
     args : tuple, optional
         Any additional fixed parameters needed to completely specify the
         objective function.

--- a/scipy/optimize/tests/test__dual_annealing.py
+++ b/scipy/optimize/tests/test__dual_annealing.py
@@ -340,7 +340,9 @@ class TestDualAnnealing:
         assert_allclose(rate, accept_rate)
 
     def test_bounds_class(self):
-        func = lambda x: np.sum(x * x - 10 * np.cos(2 * np.pi * x)) + 10 * np.size(x)
+        def func(x):
+            f = np.sum(x * x - 10 * np.cos(2 * np.pi * x)) + 10 * np.size(x)
+            return f
         lw = [-5.12] * 10
         up = [5.12] * 10
         bounds = Bounds(lw, up)

--- a/scipy/optimize/tests/test__dual_annealing.py
+++ b/scipy/optimize/tests/test__dual_annealing.py
@@ -345,10 +345,11 @@ class TestDualAnnealing:
         lw = [-5.12] * 10
         up = [5.12] * 10
         bounds = Bounds(lw, up)
-        ret = dual_annealing(func, bounds=bounds, seed=1234)
-        assert_allclose(ret.x,
-                        [-4.26437714e-09, -3.91699361e-09, -1.86149218e-09,
-                         -3.97165720e-09, -6.29151648e-09, -6.53145322e-09,
-                         -3.93616815e-09, -6.55623025e-09, -6.05775280e-09,
-                         -5.00668935e-09], atol=4e-8)
-        assert_allclose(ret.fun, 0.000000, atol=5e-13)
+        ret_bounds_class = dual_annealing(func, bounds=bounds, seed=1234)
+
+        bounds_old = list(zip(lw, up))
+        ret_bounds_list = dual_annealing(func, bounds=bounds_old, seed=1234)
+        assert_allclose(ret_bounds_list.x, ret_bounds_class.x, atol=1e-7)
+
+        assert_allclose(ret_bounds_list.fun, ret_bounds_class.fun, atol=1e-7)
+        assert_allclose(ret_bounds_list.fun, 0.000000, atol=5e-13)

--- a/scipy/optimize/tests/test__dual_annealing.py
+++ b/scipy/optimize/tests/test__dual_annealing.py
@@ -6,6 +6,8 @@
 Unit tests for the dual annealing global optimizer
 """
 from scipy.optimize import dual_annealing
+from scipy.optimize import Bounds
+
 from scipy.optimize._dual_annealing import EnergyState
 from scipy.optimize._dual_annealing import LocalSearchWrapper
 from scipy.optimize._dual_annealing import ObjectiveFunWrapper
@@ -336,3 +338,16 @@ class TestDualAnnealing:
         rate = 0 if pqv <= 0 else np.exp(np.log(pqv) / (1 - accept_param))
 
         assert_allclose(rate, accept_rate)
+
+    def test_bounds_class(self):
+        func = lambda x: np.sum(x * x - 10 * np.cos(2 * np.pi * x)) + 10 * np.size(x)
+        lw = [-5.12] * 10
+        up = [5.12] * 10
+        bounds = Bounds(lw, up)
+        ret = dual_annealing(func, bounds=bounds, seed=1234)
+        assert_allclose(ret.x,
+                        [-4.26437714e-09, -3.91699361e-09, -1.86149218e-09,
+                         -3.97165720e-09, -6.29151648e-09, -6.53145322e-09,
+                         -3.93616815e-09, -6.55623025e-09, -6.05775280e-09,
+                         -5.00668935e-09], atol=4e-8)
+        assert_allclose(ret.fun, 0.000000, atol=5e-13)

--- a/scipy/optimize/tests/test__dual_annealing.py
+++ b/scipy/optimize/tests/test__dual_annealing.py
@@ -339,17 +339,27 @@ class TestDualAnnealing:
         assert_allclose(rate, accept_rate)
 
     def test_bounds_class(self):
+        # test that result does not depend on the bounds type
         def func(x):
             f = np.sum(x * x - 10 * np.cos(2 * np.pi * x)) + 10 * np.size(x)
             return f
         lw = [-5.12] * 10
         up = [5.12] * 10
+
+        # set upper bound to global minimum for a few dimensions
+        up[0] = 0.0
+        up[1] = 0.0
+        up[2] = 0.0
+
+        # run optimizations
         bounds = Bounds(lw, up)
         ret_bounds_class = dual_annealing(func, bounds=bounds, seed=1234)
 
         bounds_old = list(zip(lw, up))
         ret_bounds_list = dual_annealing(func, bounds=bounds_old, seed=1234)
-        assert_allclose(ret_bounds_list.x, ret_bounds_class.x, atol=1e-7)
 
-        assert_allclose(ret_bounds_list.fun, ret_bounds_class.fun, atol=1e-7)
-        assert_allclose(ret_bounds_list.fun, 0.000000, atol=5e-13)
+        # test that found minima, function evaluations and iterations match
+        assert_allclose(ret_bounds_list.x, ret_bounds_class.x, atol=1e-9)
+        assert_allclose(ret_bounds_list.fun, ret_bounds_class.fun, atol=1e-9)
+        assert ret_bounds_list.nfev == ret_bounds_class.nfev
+        assert ret_bounds_list.nit == ret_bounds_class.nit

--- a/scipy/optimize/tests/test__dual_annealing.py
+++ b/scipy/optimize/tests/test__dual_annealing.py
@@ -361,7 +361,8 @@ class TestDualAnnealing:
         ret_bounds_list = dual_annealing(func, bounds=bounds_old, seed=1234)
 
         # test that found minima, function evaluations and iterations match
-        assert_allclose(ret_bounds_list.x, ret_bounds_class.x, atol=1e-9)
+        assert_allclose(ret_bounds_class.x, ret_bounds_list.x, atol=1e-8)
+        assert_allclose(ret_bounds_class.x, np.arange(-2, 3), atol=1e-8)
         assert_allclose(ret_bounds_list.fun, ret_bounds_class.fun, atol=1e-9)
         assert ret_bounds_list.nfev == ret_bounds_class.nfev
         assert ret_bounds_list.nit == ret_bounds_class.nit

--- a/scipy/optimize/tests/test__dual_annealing.py
+++ b/scipy/optimize/tests/test__dual_annealing.py
@@ -343,13 +343,15 @@ class TestDualAnnealing:
         def func(x):
             f = np.sum(x * x - 10 * np.cos(2 * np.pi * x)) + 10 * np.size(x)
             return f
-        lw = [-5.12] * 10
-        up = [5.12] * 10
+        lw = [-5.12] * 5
+        up = [5.12] * 5
 
-        # set upper bound to global minimum for a few dimensions
-        up[0] = 0.0
-        up[1] = 0.0
-        up[2] = 0.0
+        # Unbounded global minimum is all zeros. Most bounds below will force
+        # a DV away from unbounded minimum and be active at solution.
+        up[0] = -2.0
+        up[1] = -1.0
+        lw[3] = 1.0
+        lw[4] = 2.0
 
         # run optimizations
         bounds = Bounds(lw, up)

--- a/scipy/optimize/tests/test__dual_annealing.py
+++ b/scipy/optimize/tests/test__dual_annealing.py
@@ -365,4 +365,3 @@ class TestDualAnnealing:
         assert_allclose(ret_bounds_class.x, np.arange(-2, 3), atol=1e-8)
         assert_allclose(ret_bounds_list.fun, ret_bounds_class.fun, atol=1e-9)
         assert ret_bounds_list.nfev == ret_bounds_class.nfev
-        assert ret_bounds_list.nit == ret_bounds_class.nit

--- a/scipy/optimize/tests/test__dual_annealing.py
+++ b/scipy/optimize/tests/test__dual_annealing.py
@@ -5,8 +5,7 @@
 """
 Unit tests for the dual annealing global optimizer
 """
-from scipy.optimize import dual_annealing
-from scipy.optimize import Bounds
+from scipy.optimize import dual_annealing, Bounds
 
 from scipy.optimize._dual_annealing import EnergyState
 from scipy.optimize._dual_annealing import LocalSearchWrapper


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue

#### What does this implement/fix?
All of scipy's global optimizers should support the Bounds class to have similar APIs. Currently, only differential_evolution supports it. I would like to add this step by step for each optimizer.

#### Additional information

