### PR TITLE
BLD: remove dependency on libnpymath from `spatial._distance_wrap`

### DIFF
--- a/scipy/spatial/meson.build
+++ b/scipy/spatial/meson.build
@@ -85,7 +85,7 @@ _distance_wrap = py3.extension_module('_distance_wrap',
   'src/distance_wrap.c',
   c_args: numpy_nodepr_api,
   include_directories: [incdir_numpy, '../_lib'],
-  dependencies: [py3_dep, npymath_lib],
+  dependencies: [py3_dep],
   install: true,
   subdir: 'scipy/spatial'
 )

--- a/scipy/spatial/setup.py
+++ b/scipy/spatial/setup.py
@@ -88,7 +88,6 @@ def configuration(parent_package='', top_path=None):
                          include_dirs=[
                              get_numpy_include_dirs(),
                              join(dirname(dirname(__file__)), '_lib')],
-                         extra_info=get_misc_info("npymath"),
                          **numpy_nodepr_api)
 
     distance_pybind_includes = [

--- a/scipy/spatial/src/distance_impl.h
+++ b/scipy/spatial/src/distance_impl.h
@@ -594,7 +594,7 @@ pdist_cosine(const double *X, double *dm, const npy_intp num_rows,
             cosine = dot_product(u, v, num_cols) / (norms_buff[i] * norms_buff[j]);
             if (fabs(cosine) > 1.) {
                 /* Clip to correct rounding error. */
-                cosine = npy_copysign(1, cosine);
+                cosine = copysign(1, cosine);
             }
             *dm = 1. - cosine;
         }
@@ -791,7 +791,7 @@ cdist_cosine(const double *XA, const double *XB, double *dm, const npy_intp num_
             cosine = dot_product(u, v, num_cols) / (norms_buffA[i] * norms_buffB[j]);
             if (fabs(cosine) > 1.) {
                 /* Clip to correct rounding error. */
-                cosine = npy_copysign(1, cosine);
+                cosine = copysign(1, cosine);
             }
             *dm = 1. - cosine;
         }

--- a/scipy/spatial/src/distance_wrap.c
+++ b/scipy/spatial/src/distance_wrap.c
@@ -44,7 +44,6 @@
 #endif
 #include <Python.h>
 #include <numpy/arrayobject.h>
-#include <numpy/npy_math.h>
 
 #include <stdio.h>
 #include <math.h>


### PR DESCRIPTION
Now that we can rely on C99, let's see if we can reduce the number of places where we link in `libnpymath`.