### PR TITLE
ENH: Support Bounds class in shgo

### DIFF
--- a/scipy/optimize/_shgo.py
+++ b/scipy/optimize/_shgo.py
@@ -7,7 +7,8 @@ import time
 import logging
 import warnings
 from scipy import spatial
-from scipy.optimize import OptimizeResult, minimize
+from scipy.optimize import OptimizeResult, minimize, Bounds
+from scipy.optimize._constraints import new_bounds_to_old
 from ._optimize import _wrap_scalar_function
 from scipy.optimize._shgo_lib.triangulation import Complex
 
@@ -410,6 +411,11 @@ def shgo(func, bounds, args=(), constraints=None, n=None, iters=1,
     (-5.062616992290714e-14, -2.9594104944408173e-12, 0.0)
 
     """
+
+    # if necessary, convert bounds class to old bounds
+    if isinstance(bounds, Bounds):
+        bounds = new_bounds_to_old(Bounds.lb, Bounds.ub, len(Bounds.lb))
+
     # Initiate SHGO class
     shc = SHGO(func, bounds, args=args, constraints=constraints, n=n,
                iters=iters, callback=callback,

--- a/scipy/optimize/_shgo.py
+++ b/scipy/optimize/_shgo.py
@@ -413,7 +413,7 @@ def shgo(func, bounds, args=(), constraints=None, n=None, iters=1,
 
     # if necessary, convert bounds class to old bounds
     if isinstance(bounds, Bounds):
-        bounds = new_bounds_to_old(Bounds.lb, Bounds.ub, len(Bounds.lb))
+        bounds = new_bounds_to_old(bounds.lb, bounds.ub, len(bounds.lb))
 
     # Initiate SHGO class
     shc = SHGO(func, bounds, args=args, constraints=constraints, n=n,

--- a/scipy/optimize/_shgo.py
+++ b/scipy/optimize/_shgo.py
@@ -31,13 +31,12 @@ def shgo(func, bounds, args=(), constraints=None, n=None, iters=1,
         ``f(x, *args)``, where ``x`` is the argument in the form of a 1-D array
         and ``args`` is a tuple of any additional fixed parameters needed to
         completely specify the function.
-    bounds : sequence
-        Bounds for variables.  ``(min, max)`` pairs for each element in ``x``,
-        defining the lower and upper bounds for the optimizing argument of
-        `func`. It is required to have ``len(bounds) == len(x)``.
-        ``len(bounds)`` is used to determine the number of parameters in ``x``.
-        Use ``None`` for one of min or max when there is no bound in that
-        direction. By default bounds are ``(None, None)``.
+    bounds : sequence or `Bounds`
+        Bounds for variables. There are two ways to specify the bounds:
+
+        1. Instance of `Bounds` class.
+        2. Sequence of ``(min, max)`` pairs for each element in `x`.
+
     args : tuple, optional
         Any additional fixed parameters needed to completely specify the
         objective function.

--- a/scipy/optimize/tests/test__shgo.py
+++ b/scipy/optimize/tests/test__shgo.py
@@ -651,13 +651,15 @@ class TestShgoArguments:
 
     def test_18_bounds_class(self):
         # test that new and old bounds yield same result
+        def f(x):
+            return x[0] ** 2 + x[1] ** 2
         lb = [-6., -6.]
-        ub = [1., 1.]
+        ub = [0., 0.]
         bounds_old = list(zip(lb, ub))
         bounds_new = Bounds(lb, ub)
 
-        res_old_bounds = shgo(StructTest1.f, bounds_old)
-        res_new_bounds = shgo(StructTest1.f, bounds_new)
+        res_old_bounds = shgo(f, bounds_old)
+        res_new_bounds = shgo(f, bounds_new)
 
         assert res_new_bounds.nfev == res_old_bounds.nfev
         assert res_new_bounds.message == res_old_bounds.message

--- a/scipy/optimize/tests/test__shgo.py
+++ b/scipy/optimize/tests/test__shgo.py
@@ -665,7 +665,7 @@ class TestShgoArguments:
         assert res_new_bounds.message == res_old_bounds.message
         assert res_new_bounds.success == res_old_bounds.success
         numpy.testing.assert_allclose(res_new_bounds.x,
-                                        res_old_bounds.x)
+                                      res_old_bounds.x)
 
 
 # Failure test functions

--- a/scipy/optimize/tests/test__shgo.py
+++ b/scipy/optimize/tests/test__shgo.py
@@ -2,7 +2,7 @@ import logging
 import numpy
 import pytest
 from pytest import raises as assert_raises, warns
-from scipy.optimize import shgo
+from scipy.optimize import shgo, Bounds
 from scipy.optimize._shgo import SHGO
 
 
@@ -648,6 +648,23 @@ class TestShgoArguments:
             return numpy.random.uniform(size=(n,d))
 
         run_test(test1_1, n=30, sampling_method=sample)
+
+    def test_18_bounds_class(self):
+        # test that new and old bounds yield same result
+        lb = [-6., -6.]
+        ub = [1., 1.]
+        bounds_old = list(zip(lb, ub))
+        bounds_new = Bounds(lb, ub)
+
+        res_old_bounds = shgo(StructTest1.f, bounds_old)
+        res_new_bounds = shgo(StructTest1.f, bounds_new)
+
+        assert res_new_bounds.nfev == res_old_bounds.nfev
+        assert res_new_bounds.message == res_old_bounds.message
+        assert res_new_bounds.success == res_old_bounds.success
+        numpy.testing.assert_allclose(res_new_bounds.x,
+                                        res_old_bounds.x)
+
 
 # Failure test functions
 class TestShgoFailures:


### PR DESCRIPTION
#### Reference issue

#### What does this implement/fix?
Adds support for the Bounds class to the global optimizer shgo for a more uniform API across scipy.optimize.

#### Additional information
