### PR TITLE
DOC: documents parameter `limit` for function `integrate.quad_vec`.

### DIFF
--- a/scipy/integrate/_quad_vec.py
+++ b/scipy/integrate/_quad_vec.py
@@ -122,6 +122,9 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, li
         Vector norm to use for error estimation.
     cache_size : int, optional
         Number of bytes to use for memoization.
+    limit : float or int, optional
+        An upper bound on the number of subintervals used in the adaptive
+        algorithm.
     workers : int or map-like callable, optional
         If `workers` is an integer, part of the computation is done in
         parallel subdivided to this many tasks (using


### PR DESCRIPTION
Description now aligns with that of `integrate.quad`. Closes #15415.

#### Reference issue
#15415

#### What does this implement/fix?
It documents the parameter `limit` for the function `integrate.quad_vec`.  
This documentation aligns with that of [`integrate.quad`](https://github.com/scipy/scipy/blob/ecb800f37bc6c6eb4f160cba34fec81932eaea70/scipy/integrate/_quadpack_py.py#L118-L120).
