### PR TITLE
ENH: optimize: milp: mixed integer linear programming

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -515,9 +515,6 @@ ignore_errors = True
 [mypy-scipy.optimize.minpack2]
 ignore_errors = True
 
-[mypy-scipy.optimize.tests.test_milp]
-ignore_errors = True
-
 [mypy-scipy.cluster.hierarchy]
 ignore_errors = True
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -515,6 +515,9 @@ ignore_errors = True
 [mypy-scipy.optimize.minpack2]
 ignore_errors = True
 
+[mypy-scipy.optimize.tests.test_milp]
+ignore_errors = True
+
 [mypy-scipy.cluster.hierarchy]
 ignore_errors = True
 

--- a/scipy/optimize/__init__.py
+++ b/scipy/optimize/__init__.py
@@ -239,10 +239,6 @@ Linear programming / MILP
    :toctree: generated/
 
    milp -- Mixed integer linear programming.
-
-.. autosummary::
-   :toctree: generated/
-
    linprog -- Unified interface for minimizers of linear programming problems.
 
 The `linprog` function supports the following methods:

--- a/scipy/optimize/__init__.py
+++ b/scipy/optimize/__init__.py
@@ -232,8 +232,13 @@ The `root` function supports the following methods:
    optimize.root-krylov
    optimize.root-dfsane
 
-Linear programming
-==================
+Linear programming / MILP
+=========================
+
+.. autosummary::
+   :toctree: generated/
+
+   milp -- Mixed integer linear programming.
 
 .. autosummary::
    :toctree: generated/
@@ -420,6 +425,7 @@ from ._hessian_update_strategy import HessianUpdateStrategy, BFGS, SR1
 from ._shgo import shgo
 from ._dual_annealing import dual_annealing
 from ._qap import quadratic_assignment
+from ._milp import milp
 
 # Deprecated namespaces, to be removed in v2.0.0
 from . import (

--- a/scipy/optimize/_milp.py
+++ b/scipy/optimize/_milp.py
@@ -331,6 +331,7 @@ def milp(c, *, integrality=None, bounds=None, constraints=None, options=None):
     >>> integrality = np.ones_like(c)
 
     We solve the problem like:
+
     >>> from scipy.optimize import milp
     >>> res = milp(c=c, constraints=constraints, integrality=integrality)
     >>> res.x
@@ -338,6 +339,7 @@ def milp(c, *, integrality=None, bounds=None, constraints=None, options=None):
 
     Note that had we solved the relaxed problem (without integrality
     constraints):
+
     >>> res = milp(c=c, constraints=constraints)  # OR:
     >>> # from scipy.optimize import linprog; res = linprog(c, A, b_u)
     >>> res.x

--- a/scipy/optimize/_milp.py
+++ b/scipy/optimize/_milp.py
@@ -1,7 +1,7 @@
 import warnings
 import numpy as np
 from scipy.sparse import csc_array, vstack
-from ._highs._highs_wrapper import _highs_wrapper
+from ._highs._highs_wrapper import _highs_wrapper  # type: ignore[import]
 from ._constraints import LinearConstraint, Bounds
 from ._optimize import OptimizeResult
 
@@ -106,7 +106,7 @@ def _milp_iv(c, integrality, bounds, constraints, options):
         raise ValueError(message)
 
     # constraints IV
-    if not constraints: # constraints is None, empty sequence, False, 0, etc.
+    if not constraints:
         constraints = [LinearConstraint(np.empty((0, c.size)),
                                         np.empty((0,)), np.empty((0,)))]
     A, b_l, b_u = _constraints_to_components(constraints)
@@ -204,22 +204,23 @@ def milp(c, *, integrality=None, bounds=None, constraints=None, options=None):
         precision, and the matrices of constraint coefficients are converted to
         instances of `scipy.sparse.csc_array`. The ``keep_feasible`` parameter
         of `LinearConstraint` objects is ignored.
+    options : dict, optional
+        A dictionary of solver options. The following keys
+        are recognized.
 
-    Options
-    -------
-    disp : bool (default: ``False``)
-        Set to ``True`` if indicators of optimization status are to be
-        printed to the console during optimization.
-    presolve : bool (default: ``True``)
-        Presolve attempts to identify trivial infeasibilities,
-        identify trivial unboundedness, and simplify the problem before
-        sending it to the main solver. It is generally recommended
-        to keep the default setting ``True``; set to ``False`` if
-        presolve is to be disabled.
-    time_limit : float
-        The maximum time in seconds allotted to solve the problem;
-        default is the largest possible value for a ``double`` on the
-        platform.
+        disp : bool (default: ``False``)
+            Set to ``True`` if indicators of optimization status are to be
+            printed to the console during optimization.
+        presolve : bool (default: ``True``)
+            Presolve attempts to identify trivial infeasibilities,
+            identify trivial unboundedness, and simplify the problem before
+            sending it to the main solver. It is generally recommended
+            to keep the default setting ``True``; set to ``False`` if
+            presolve is to be disabled.
+        time_limit : float
+            The maximum time in seconds allotted to solve the problem;
+            default is the largest possible value for a ``double`` on the
+            platform.
 
     Returns
     -------
@@ -340,7 +341,6 @@ def milp(c, *, integrality=None, bounds=None, constraints=None, options=None):
 
     highs_res = _highs_wrapper(c, indptr, indices, data, b_l, b_u,
                                lb, ub, integrality, options)
-
 
     res = {}
 

--- a/scipy/optimize/_milp.py
+++ b/scipy/optimize/_milp.py
@@ -220,7 +220,7 @@ def milp(c, *, integrality=None, bounds=None, constraints=None, options=None):
             identify trivial unboundedness, and simplify the problem before
             sending it to the main solver.
         time_limit : float, optional
-            The maximum time in seconds allotted to solve the problem.
+            The maximum number of seconds allotted to solve the problem.
             Default is no time limit.
 
     Returns

--- a/scipy/optimize/_milp.py
+++ b/scipy/optimize/_milp.py
@@ -20,8 +20,9 @@ def _constraints_to_components(constraints):
 
     We want to accept 1, 2, and 4 and reject 3 and 5.
     """
-    message = ("`constraints` must be a sequence of "
-               "`scipy.optimize.LinearConstraint` objects.")
+    message = ("`constraints` (or each element within `constraints`) must be "
+               "convertible into an instance of "
+               "`scipy.optimize.LinearConstraint`.")
     As = []
     b_ls = []
     b_us = []
@@ -93,7 +94,8 @@ def _milp_iv(c, integrality, bounds, constraints, options):
     if bounds is None:
         bounds = Bounds(0, np.inf)
     elif not isinstance(bounds, Bounds):
-        message = "`bounds` must be an instance of `scipy.optimize.Bounds`."
+        message = ("`bounds` must be convertible into an instance of "
+                   "`scipy.optimize.Bounds`.")
         try:
             bounds = Bounds(*bounds)
         except TypeError as exc:
@@ -111,7 +113,13 @@ def _milp_iv(c, integrality, bounds, constraints, options):
     if not constraints:
         constraints = [LinearConstraint(np.empty((0, c.size)),
                                         np.empty((0,)), np.empty((0,)))]
-    A, b_l, b_u = _constraints_to_components(constraints)
+    try:
+        A, b_l, b_u = _constraints_to_components(constraints)
+    except ValueError as exc:
+        message = ("`constraints` (or each element within `constraints`) must "
+                   "be convertible into an instance of "
+                   "`scipy.optimize.LinearConstraint`.")
+        raise ValueError(message) from exc
 
     if A.shape != (b_l.size, c.size):
         message = "The shape of `A` must be (len(b_l), len(c))."

--- a/scipy/optimize/_milp.py
+++ b/scipy/optimize/_milp.py
@@ -1,0 +1,359 @@
+import warnings
+import numpy as np
+from scipy.sparse import csc_array, vstack
+from ._highs._highs_wrapper import _highs_wrapper
+from ._constraints import LinearConstraint, Bounds
+from ._optimize import OptimizeResult
+
+
+def _constraints_to_components(constraints):
+    # convert sequence of constraints to a single set of components A, b_l, b_u
+
+    # `constraints` could be
+    # 1. A LinearConstraint
+    # 2. A tuple representing a LinearConstraint
+    # 3. An invalid object
+    # 4. A sequence of composed entirely of objects of type 1/2
+    # 5. A sequence containing at least one object of type 3
+    # We want to accept 1, 2, and 4 and reject 3 and 5
+
+    message = ("`constraints` must be a sequence of "
+               "`scipy.optimize.LinearConstraint` objects.")
+    As = []
+    b_ls = []
+    b_us = []
+
+    # Accept case 1 by standardizing as case 4
+    if isinstance(constraints, LinearConstraint):
+        constraints = [constraints]
+    else:
+        # Reject case 3
+        try:
+            iter(constraints)
+        except TypeError:
+            raise ValueError(message)
+
+        # Accept case 2 by standardizing as case 4
+        if len(constraints) == 3:
+            # argument could be a single tuple representing a LinearConstraint
+            try:
+                constraints = [LinearConstraint(*constraints)]
+            except TypeError:
+                # argument was not a tuple representing a LinearConstraint
+                pass
+
+    # Address cases 4/5
+    for constraint in constraints:
+        # if it's not a LinearConstraint or something that represents a
+        # LinearConstraint at this point, it's invalid
+        if not isinstance(constraint, LinearConstraint):
+            try:
+                constraint = LinearConstraint(*constraint)
+            except TypeError:
+                raise ValueError(message)
+        As.append(csc_array(constraint.A))
+        b_ls.append(np.atleast_1d(constraint.lb).astype(np.double))
+        b_us.append(np.atleast_1d(constraint.ub).astype(np.double))
+
+    if len(As) > 1:
+        A = vstack(As)
+        b_l = np.concatenate(b_ls)
+        b_u = np.concatenate(b_us)
+    else:  # avoid unnecessary copying
+        A = As[0]
+        b_l = b_ls[0]
+        b_u = b_us[0]
+
+    return A, b_l, b_u
+
+
+def _milp_iv(c, integrality, bounds, constraints, options):
+
+    # objective IV
+    c = np.atleast_1d(c).astype(np.double)
+    if c.ndim != 1:
+        message = "`c` must be a one-dimensional array."
+        raise ValueError(message)
+
+    # integrality IV
+    message = ("`integrality` must contain integers 0-3 and be broadcastable "
+               "to `c.shape`.")
+    if integrality is None:
+        integrality = 0
+    try:
+        integrality = np.broadcast_to(integrality, c.shape).astype(np.uint8)
+    except ValueError:
+        raise ValueError(message)
+    if integrality.min() < 0 or integrality.max() > 3:
+        raise ValueError(message)
+
+    # bounds IV
+    if bounds is None:
+        bounds = Bounds(0, np.inf)
+    elif not isinstance(bounds, Bounds):
+        message = "`bounds` must be an instance of `scipy.optimize.Bounds`."
+        try:
+            bounds = Bounds(*bounds)
+        except TypeError:
+            raise ValueError(message)
+
+    try:
+        lb = np.broadcast_to(bounds.lb, c.shape).astype(np.double)
+        ub = np.broadcast_to(bounds.ub, c.shape).astype(np.double)
+    except (ValueError, TypeError):
+        message = ("`bounds.lb` and `bounds.ub` must contain reals and "
+                   "be broadcastable to `c.shape`.")
+        raise ValueError(message)
+
+    # constraints IV
+    if not constraints: # constraints is None, empty sequence, False, 0, etc.
+        constraints = [LinearConstraint(np.empty((0, c.size)),
+                                        np.empty((0,)), np.empty((0,)))]
+    A, b_l, b_u = _constraints_to_components(constraints)
+
+    if A.shape != (b_l.size, c.size):
+        message = "The shape of `A` must be (len(b_l), len(c))."
+        raise ValueError(message)
+    indptr, indices, data = A.indptr, A.indices, A.data.astype(np.double)
+
+    # options IV
+    options = options or {}
+    supported_options = {'disp', 'presolve', 'time_limit'}
+    unsupported_options = set(options).difference(supported_options)
+    if unsupported_options:
+        message = (f"Unrecognized options detected: {unsupported_options}. "
+                   "These will be passed to HiGHS verbatim.")
+        warnings.warn(message, RuntimeWarning, stacklevel=3)
+    options_iv = {'log_to_console': options.get("disp", False)}
+    options_iv.update(options)
+
+    return c, integrality, lb, ub, indptr, indices, data, b_l, b_u, options_iv
+
+
+def milp(c, *, integrality=None, bounds=None, constraints=None, options=None):
+    r"""
+    Mixed-integer linear programming
+
+    Solves problems of the following form:
+
+    .. math::
+
+        \min_x \ & c^T x \\
+        \mbox{such that} \ & b_l \leq A x \leq b_u,\\
+        & l \leq x \leq u, \\
+        & x_i \in \mathbb{Z}, i \in X_i
+
+    where :math:`x` is a vector of decision variables;
+    :math:`c`, :math:`b_l`, :math:`b_u`, :math:`l`, and :math:`u` are vectors;
+    :math:`A` is a matrix, and :math:`X_i` is the set of indices of
+    decision variables that must be integral.
+
+    Alternatively, that's:
+
+    minimize::
+
+        c @ x
+
+    such that::
+
+        b_l <= A @ x <= b_u
+        l <= x <= u
+        Specified elements of x must be integers
+
+    By default, ``l = 0`` and ``u = np.inf`` unless specified with
+    ``bounds``.
+
+    Parameters
+    ----------
+    c : 1D array_like
+        The coefficients of the linear objective function to be minimized.
+        `c` is converted to a double precision array before the problem is
+        solved.
+    integrality : 1D array_like, optional
+        Indicates the type of integrality constraint on each decision variable.
+
+        ``0`` : Continuous variable; no integrality constraint.
+
+        ``1`` : Integer variable; decision variable must be an integer
+        within `bounds`.
+
+        ``2`` : Semi-continuous variable; decision variable must be within
+        `bounds` or take value ``0``.
+
+        ``3`` : Semi-integer variable; decision variable must be an integer
+        within `bounds` or take value ``0``.
+
+        By default, all variables are continuous. `integrality` is converted
+        to an array of integers before the problem is solved.
+    bounds : scipy.optimize.Bounds, optional
+        Bounds on the decision variables. Lower and upper bounds are converted
+        to double precision arrays before the problem is solved. The
+        ``keep_feasible`` parameter of the `Bounds` object is ignored. If
+        not specified, all decision variables are constrained to be
+        non-negative.
+    constraints : sequence of scipy.optimize.LinearConstraint, optional
+        Linear constraints of the optimization problem. Arguments may be
+        one of the following:
+
+        1. A single `LinearConstraint` object
+        2. A single tuple that can be converted to a `LinearConstraint` object
+           as ``LinearConstraint(*constraints)``
+        3. A sequence composed entirely of objects of type 1. and 2.
+
+        Before the problem is solved, all values are converted to double
+        precision, and the matrices of constraint coefficients are converted to
+        instances of `scipy.sparse.csc_array`. The ``keep_feasible`` parameter
+        of `LinearConstraint` objects is ignored.
+
+    Options
+    -------
+    disp : bool (default: ``False``)
+        Set to ``True`` if indicators of optimization status are to be
+        printed to the console during optimization.
+    presolve : bool (default: ``True``)
+        Presolve attempts to identify trivial infeasibilities,
+        identify trivial unboundedness, and simplify the problem before
+        sending it to the main solver. It is generally recommended
+        to keep the default setting ``True``; set to ``False`` if
+        presolve is to be disabled.
+    time_limit : float
+        The maximum time in seconds allotted to solve the problem;
+        default is the largest possible value for a ``double`` on the
+        platform.
+
+    Returns
+    -------
+    res : OptimizeResult
+        An instance of :class:`scipy.optimize.OptimizeResult`. The object
+        is guaranteed to have the following attributes.
+
+        status : int
+            An integer representing the exit status of the algorithm.
+
+            ``0`` : Optimal solution found.
+
+            ``1`` : Iteration or time limit reached.
+
+            ``2`` : Problem is infeasible.
+
+            ``3`` : Problem is unbounded.
+
+            ``4`` : Other; see message for details.
+
+        success : bool
+            True when an optimal solution is found, the problem is determined
+            to be infeasible, or the problem is determined to be unbounded.
+
+        message : str
+            A string descriptor of the exit status of the algorithm.
+
+        The following attributes will also be present, but the values may be
+        ``None``, depending on the solution status.
+
+        x : ndarray
+            The values of the decision variables that minimizes the
+            objective function while satisfying the constraints.
+        fun : float
+            The optimal value of the objective function ``c @ x``.
+        mip_node_count : int
+            The number of subproblems or "nodes" solved by the MILP solver.
+        mip_dual_bound : float
+            The MILP solver's final estimate of the lower bound on the optimal
+            solution.
+        mip_gap : float
+            The difference between the final objective function value and the
+            final dual bound.
+
+    Notes
+    -----
+    `milp` is a wrapper of the HiGHS linear optimization software [1]_.
+
+    References
+    ----------
+    .. [1] Huangfu, Q., Galabova, I., Feldmeier, M., and Hall, J. A. J.
+           "HiGHS - high performance software for linear optimization."
+           Accessed 12/25/2021 at https://www.maths.ed.ac.uk/hall/HiGHS/#guide
+    .. [2] Huangfu, Q. and Hall, J. A. J. "Parallelizing the dual revised
+           simplex method." Mathematical Programming Computation, 10 (1),
+           119-142, 2018. DOI: 10.1007/s12532-017-0130-5
+
+    Examples
+    --------
+    Consider the problem at
+    https://en.wikipedia.org/wiki/Integer_programming#Example, which is
+    expressed as a maximization problem of two variables. Since `milp` requires
+    that the problem be expressed as a minimization problem, the objective
+    function coefficients on the decision variables are:
+
+    >>> c = -np.array([0, 1])
+
+    Note the negative sign: we maximize the original objective function
+    by minimizing the negative of the objective function.
+
+    We collect the coefficients of the constraints into arrays like:
+
+    >>> A = np.array([[-1, 1], [3, 2], [2, 3]])
+    >>> b_u = np.array([1, 12, 12])
+    >>> b_l = np.full_like(b_u, -np.inf)
+
+    Because there is no lower limit on these constraints, we have defined a
+    variable ``b_l`` full of values representing negative infinity. This may
+    be unfamiliar to users of `scipy.optimize.linprog`, which only accepts
+    "less than" (or "upper bound") inequality constraints of the form
+    ``A_ub @ x <= b_u``. By accepting both ``b_l`` and ``b_u`` of constraints
+    ``b_l <= A_ub @ x <= b_u``, `milp` makes it easy to specify "greater than"
+    inequality constraints, "less than" inequality constraints, and equality
+    constraints concisely.
+
+    These arrays are collected into a single `LinearConstraint` object like:
+
+    >>> from scipy.optimize import LinearConstraint
+    >>> constraints = LinearConstraint(A, b_l, b_u)
+
+    The non-negativity bounds on the decision variables are enforced by
+    default, so we do not need to provide an argument for `bounds`.
+
+    Finally, the problem states that both decision variables must be integers:
+
+    >>> integrality = np.ones_like(c)
+
+    We solve the problem like:
+    >>> from scipy.optimize import milp
+    >>> res = milp(c=c, constraints=constraints, integrality=integrality)
+    >>> res.x
+    [1.0, 2.0]
+
+    Note that had we solved the relaxed problem (without integrality
+    constraints):
+    >>> res = milp(c=c, constraints=constraints)  # OR:
+    >>> # from scipy.optimize import linprog; res = linprog(c, A, b_u)
+    >>> res.x
+    [1.8, 2.8]
+
+    we would not have obtained the correct solution by rounding to the nearest
+    integers.
+
+    """
+
+    args_iv = _milp_iv(c, integrality, bounds, constraints, options)
+    c, integrality, lb, ub, indptr, indices, data, b_l, b_u, options = args_iv
+
+    highs_res = _highs_wrapper(c, indptr, indices, data, b_l, b_u,
+                               lb, ub, integrality, options)
+
+
+    res = {}
+
+    status_map = {7: 0, 13: 1, 8: 2, 10: 3}
+    res['status'] = status_map.get(highs_res.get('status', None), 4)
+    res['success'] = res['status'] in {0, 2, 3}
+    res['message'] = highs_res.get('message', 'No message provided by HiGHs')
+
+    x = highs_res.get('x', None)
+    res['x'] = np.array(x) if x is not None else None
+    res['fun'] = highs_res.get('fun', None)
+    res['mip_node_count'] = highs_res.get('mip_node_count', None)
+    res['mip_dual_bound'] = highs_res.get('mip_dual_bound', None)
+    res['mip_gap'] = highs_res.get('mip_gap', None)
+
+    return OptimizeResult(res)

--- a/scipy/optimize/_milp.py
+++ b/scipy/optimize/_milp.py
@@ -253,9 +253,7 @@ def milp(c, *, integrality=None, bounds=None, constraints=None, options=None):
             ``4`` : Other; see message for details.
 
         success : bool
-            ``True`` when an optimal solution is found, the problem is
-            determined to be infeasible, or the problem is determined
-            to be unbounded.
+            ``True`` when an optimal solution is found and ``False`` otherwise.
 
         message : str
             A string descriptor of the exit status of the algorithm.
@@ -364,7 +362,7 @@ def milp(c, *, integrality=None, bounds=None, constraints=None, options=None):
                                                      highs_message)
     res['status'] = status
     res['message'] = message
-    res['success'] = res['status'] in {0, 2, 3}
+    res['success'] = (status == 0)
     x = highs_res.get('x', None)
     res['x'] = np.array(x) if x is not None else None
     res['fun'] = highs_res.get('fun', None)

--- a/scipy/optimize/_milp.py
+++ b/scipy/optimize/_milp.py
@@ -185,6 +185,7 @@ def milp(c, *, integrality=None, bounds=None, constraints=None, options=None):
 
         By default, all variables are continuous. `integrality` is converted
         to an array of integers before the problem is solved.
+
     bounds : scipy.optimize.Bounds, optional
         Bounds on the decision variables. Lower and upper bounds are converted
         to double precision arrays before the problem is solved. The
@@ -205,8 +206,7 @@ def milp(c, *, integrality=None, bounds=None, constraints=None, options=None):
         instances of `scipy.sparse.csc_array`. The ``keep_feasible`` parameter
         of `LinearConstraint` objects is ignored.
     options : dict, optional
-        A dictionary of solver options. The following keys
-        are recognized.
+        A dictionary of solver options. The following keys are recognized.
 
         disp : bool (default: ``False``)
             Set to ``True`` if indicators of optimization status are to be
@@ -214,13 +214,10 @@ def milp(c, *, integrality=None, bounds=None, constraints=None, options=None):
         presolve : bool (default: ``True``)
             Presolve attempts to identify trivial infeasibilities,
             identify trivial unboundedness, and simplify the problem before
-            sending it to the main solver. It is generally recommended
-            to keep the default setting ``True``; set to ``False`` if
-            presolve is to be disabled.
-        time_limit : float
-            The maximum time in seconds allotted to solve the problem;
-            default is the largest possible value for a ``double`` on the
-            platform.
+            sending it to the main solver.
+        time_limit : float, optional
+            The maximum time in seconds allotted to solve the problem.
+            Default is no time limit.
 
     Returns
     -------
@@ -268,7 +265,9 @@ def milp(c, *, integrality=None, bounds=None, constraints=None, options=None):
 
     Notes
     -----
-    `milp` is a wrapper of the HiGHS linear optimization software [1]_.
+    `milp` is a wrapper of the HiGHS linear optimization software [1]_. The
+    algorithm is deterministic, and it typically finds the global optimum of
+    moderately challenging mixed-integer linear programs (when it exists).
 
     References
     ----------

--- a/scipy/optimize/_milp.py
+++ b/scipy/optimize/_milp.py
@@ -75,8 +75,9 @@ def _constraints_to_components(constraints):
 def _milp_iv(c, integrality, bounds, constraints, options):
     # objective IV
     c = np.atleast_1d(c).astype(np.double)
-    if c.ndim != 1:
-        message = "`c` must be a one-dimensional array."
+    if c.ndim != 1 or c.size == 0 or not np.all(np.isfinite(c)):
+        message = ("`c` must be a one-dimensional array of finite numbers "
+                   "with at least one element.")
         raise ValueError(message)
 
     # integrality IV

--- a/scipy/optimize/_milp.py
+++ b/scipy/optimize/_milp.py
@@ -242,8 +242,9 @@ def milp(c, *, integrality=None, bounds=None, constraints=None, options=None):
             ``4`` : Other; see message for details.
 
         success : bool
-            True when an optimal solution is found, the problem is determined
-            to be infeasible, or the problem is determined to be unbounded.
+            ``True`` when an optimal solution is found, the problem is
+            determined to be infeasible, or the problem is determined
+            to be unbounded.
 
         message : str
             A string descriptor of the exit status of the algorithm.
@@ -252,7 +253,7 @@ def milp(c, *, integrality=None, bounds=None, constraints=None, options=None):
         ``None``, depending on the solution status.
 
         x : ndarray
-            The values of the decision variables that minimizes the
+            The values of the decision variables that minimize the
             objective function while satisfying the constraints.
         fun : float
             The optimal value of the objective function ``c @ x``.
@@ -347,7 +348,7 @@ def milp(c, *, integrality=None, bounds=None, constraints=None, options=None):
     status_map = {7: 0, 13: 1, 8: 2, 10: 3}
     res['status'] = status_map.get(highs_res.get('status', None), 4)
     res['success'] = res['status'] in {0, 2, 3}
-    res['message'] = highs_res.get('message', 'No message provided by HiGHs')
+    res['message'] = highs_res.get('message', 'No message provided by HiGHS')
 
     x = highs_res.get('x', None)
     res['x'] = np.array(x) if x is not None else None

--- a/scipy/optimize/_milp.py
+++ b/scipy/optimize/_milp.py
@@ -4,6 +4,7 @@ from scipy.sparse import csc_array, vstack
 from ._highs._highs_wrapper import _highs_wrapper  # type: ignore[import]
 from ._constraints import LinearConstraint, Bounds
 from ._optimize import OptimizeResult
+from ._linprog_highs import _highs_to_scipy_status_message
 
 
 def _constraints_to_components(constraints):
@@ -347,11 +348,14 @@ def milp(c, *, integrality=None, bounds=None, constraints=None, options=None):
 
     res = {}
 
-    status_map = {7: 0, 13: 1, 8: 2, 10: 3}
-    res['status'] = status_map.get(highs_res.get('status', None), 4)
+    # Convert to scipy-style status and message
+    highs_status = highs_res.get('status', None)
+    highs_message = highs_res.get('message', None)
+    status, message = _highs_to_scipy_status_message(highs_status,
+                                                     highs_message)
+    res['status'] = status
+    res['message'] = message
     res['success'] = res['status'] in {0, 2, 3}
-    res['message'] = highs_res.get('message', 'No message provided by HiGHS')
-
     x = highs_res.get('x', None)
     res['x'] = np.array(x) if x is not None else None
     res['fun'] = highs_res.get('fun', None)

--- a/scipy/optimize/meson.build
+++ b/scipy/optimize/meson.build
@@ -290,6 +290,7 @@ py3.install_sources([
   '_linprog_simplex.py',
   '_linprog_util.py',
   '_lsap.py',
+  '_milp.py',
   '_minimize.py',
   '_minpack_py.py',
   '_nnls.py',

--- a/scipy/optimize/tests/meson.build
+++ b/scipy/optimize/tests/meson.build
@@ -23,6 +23,7 @@ py3.install_sources([
     'test_linprog.py',
     'test_lsq_common.py',
     'test_lsq_linear.py',
+    'test_milp.py',
     'test_minimize_constrained.py',
     'test_minpack.py',
     'test_nnls.py',

--- a/scipy/optimize/tests/test_milp.py
+++ b/scipy/optimize/tests/test_milp.py
@@ -37,7 +37,6 @@ def test_milp_iv():
     with pytest.raises(ValueError, match=message):
         milp([1, 2, 3], integrality = [1, 5, 3])
 
-
     message = "`lb`, `ub`, and `keep_feasible` must be broadcastable."
     with pytest.raises(ValueError, match=message):
         milp([1, 2, 3], bounds=([1, 2], [3, 4, 5]))
@@ -91,22 +90,22 @@ def test_result():
     assert res.status == 1
     assert not res.success
     assert isinstance(res.message, str)
-    assert (res.fun == res.mip_dual_bound == res.mip_gap
-            == res.mip_node_count == res.x == None)
+    assert (res.fun is res.mip_dual_bound is res.mip_gap
+            is res.mip_node_count is res.x is None)
 
     res = milp(1, bounds=(1, -1))
     assert res.status == 2
     assert res.success
     assert isinstance(res.message, str)
-    assert (res.fun == res.mip_dual_bound == res.mip_gap
-            == res.mip_node_count == res.x == None)
+    assert (res.fun is res.mip_dual_bound is res.mip_gap
+            is res.mip_node_count is res.x is None)
 
     res = milp(-1)
     assert res.status == 3
     assert res.success
     assert isinstance(res.message, str)
-    assert (res.fun == res.mip_dual_bound == res.mip_gap
-            == res.mip_node_count == res.x == None)
+    assert (res.fun is res.mip_dual_bound is res.mip_gap
+            is res.mip_node_count is res.x is None)
 
 def test_milp_optional_args():
     # check that arguments other than `c` are indeed optional
@@ -235,7 +234,7 @@ def test_milp_6():
     # source: https://www.mathworks.com/help/optim/ug/intlinprog.html
     # TODO: figure out why this intermittently segfaults!
     integrality = 1
-    A_eq = np.array([[22, 13, 26, 33, 21,  3, 14, 26],
+    A_eq = np.array([[22, 13, 26, 33, 21, 3, 14, 26],
                      [39, 16, 22, 28, 26, 30, 23, 24],
                      [18, 14, 29, 27, 30, 38, 26, 26],
                      [41, 26, 28, 36, 18, 38, 16, 26]])

--- a/scipy/optimize/tests/test_milp.py
+++ b/scipy/optimize/tests/test_milp.py
@@ -13,9 +13,13 @@ from scipy.optimize import milp, Bounds, LinearConstraint
 
 def test_milp_iv():
 
-    message = "`c` must be a one-dimensional array"
+    message = "`c` must be a one-dimensional array of finite numbers with"
     with pytest.raises(ValueError, match=message):
         milp(np.zeros((3, 4)))
+    with pytest.raises(ValueError, match=message):
+        milp([])
+    with pytest.raises(ValueError, match=message):
+        milp(None)
 
     message = "`bounds` must be convertible into an instance of..."
     with pytest.raises(ValueError, match=message):

--- a/scipy/optimize/tests/test_milp.py
+++ b/scipy/optimize/tests/test_milp.py
@@ -234,7 +234,6 @@ def test_milp_5():
 def test_milp_6():
     # solve a larger MIP with only equality constraints
     # source: https://www.mathworks.com/help/optim/ug/intlinprog.html
-    # TODO: figure out why this intermittently segfaults!
     integrality = 1
     A_eq = np.array([[22, 13, 26, 33, 21, 3, 14, 26],
                      [39, 16, 22, 28, 26, 30, 23, 24],

--- a/scipy/optimize/tests/test_milp.py
+++ b/scipy/optimize/tests/test_milp.py
@@ -17,17 +17,17 @@ def test_milp_iv():
     with pytest.raises(ValueError, match=message):
         milp(np.zeros((3, 4)))
 
-    message = "`bounds` must be an instance of..."
+    message = "`bounds` must be convertible into an instance of..."
     with pytest.raises(ValueError, match=message):
         milp(1, bounds=10)
 
-    message = "`constraints` must be a sequence of..."
-    with pytest.raises(ValueError, match=message):
+    message = "`constraints` (or each element within `constraints`) must be"
+    with pytest.raises(ValueError, match=re.escape(message)):
         milp(1, constraints=10)
-
-    message = "The shape of `A` must be (len(b_l), len(c))."
     with pytest.raises(ValueError, match=re.escape(message)):
         milp(np.zeros(3), constraints=([[1, 2, 3]], [2, 3], [2, 3]))
+
+    message = "The shape of `A` must be (len(b_l), len(c))."
     with pytest.raises(ValueError, match=re.escape(message)):
         milp(np.zeros(3), constraints=([[1, 2]], [2], [2]))
 

--- a/scipy/optimize/tests/test_milp.py
+++ b/scipy/optimize/tests/test_milp.py
@@ -52,6 +52,7 @@ def test_milp_iv():
         milp([1, 2, 3], bounds=([1, 2, 3], [set(), 4, 5]))
 
 
+@pytest.mark.xfail(strict=True, reason="Needs to be fixed in `_highs_wrapper`")
 def test_milp_options(capsys):
     message = "Unrecognized options detected: {'ekki'}..."
     options = {'ekki': True}
@@ -62,10 +63,6 @@ def test_milp_options(capsys):
     options = {"disp": True, "presolve": False, "time_limit": 0.05}
     res = milp(c=c, constraints=(A, b, b), bounds=(0, 1), integrality=1,
                options=options)
-
-    # This shows that captured.out tests work
-    # Need to pass this test when the following print statement is _removed_.
-    print("Time Limit Reached, Presolve is switched off")
 
     captured = capsys.readouterr()
     assert "Presolve is switched off" in captured.out

--- a/scipy/optimize/tests/test_milp.py
+++ b/scipy/optimize/tests/test_milp.py
@@ -33,9 +33,9 @@ def test_milp_iv():
     message = ("`integrality` must contain integers 0-3 and be broadcastable "
                "to `c.shape`.")
     with pytest.raises(ValueError, match=message):
-        milp([1, 2, 3], integrality = [1, 2])
+        milp([1, 2, 3], integrality=[1, 2])
     with pytest.raises(ValueError, match=message):
-        milp([1, 2, 3], integrality = [1, 5, 3])
+        milp([1, 2, 3], integrality=[1, 5, 3])
 
     message = "`lb`, `ub`, and `keep_feasible` must be broadcastable."
     with pytest.raises(ValueError, match=message):
@@ -50,6 +50,7 @@ def test_milp_iv():
         milp([1, 2, 3], bounds=([1, 2, 3], ["3+4", 4, 5]))
     with pytest.raises(ValueError, match=message):
         milp([1, 2, 3], bounds=([1, 2, 3], [set(), 4, 5]))
+
 
 def test_milp_options(capsys):
     message = "Unrecognized options detected: {'ekki'}..."
@@ -69,7 +70,7 @@ def test_milp_options(capsys):
     captured = capsys.readouterr()
     assert "Presolve is switched off" in captured.out
     assert "Time Limit Reached" in captured.out
-    assert res.success == False
+    assert res.success is False
 
 
 def test_result():
@@ -106,6 +107,7 @@ def test_result():
     assert isinstance(res.message, str)
     assert (res.fun is res.mip_dual_bound is res.mip_gap
             is res.mip_node_count is res.x is None)
+
 
 def test_milp_optional_args():
     # check that arguments other than `c` are indeed optional

--- a/scipy/optimize/tests/test_milp.py
+++ b/scipy/optimize/tests/test_milp.py
@@ -72,7 +72,7 @@ def test_milp_options(capsys):
     captured = capsys.readouterr()
     assert "Presolve is switched off" in captured.out
     assert "Time Limit Reached" in captured.out
-    assert res.success is False
+    assert not res.success
 
 
 def test_result():
@@ -100,7 +100,7 @@ def test_result():
 
     res = milp(1, bounds=(1, -1))
     assert res.status == 2
-    assert res.success
+    assert not res.success
     msg = "The problem is infeasible. (HiGHS Status 8:"
     assert res.message.startswith(msg)
     assert (res.fun is res.mip_dual_bound is res.mip_gap
@@ -108,7 +108,7 @@ def test_result():
 
     res = milp(-1)
     assert res.status == 3
-    assert res.success
+    assert not res.success
     msg = "The problem is unbounded. (HiGHS Status 10:"
     assert res.message.startswith(msg)
     assert (res.fun is res.mip_dual_bound is res.mip_gap

--- a/scipy/optimize/tests/test_milp.py
+++ b/scipy/optimize/tests/test_milp.py
@@ -1,11 +1,12 @@
 """
 Unit test for Mixed Integer Linear Programming
 """
-
 import re
+
 import numpy as np
-import pytest
 from numpy.testing import assert_allclose, assert_array_equal
+import pytest
+
 from .test_linprog import magic_square
 from scipy.optimize import milp, Bounds, LinearConstraint
 

--- a/scipy/optimize/tests/test_milp.py
+++ b/scipy/optimize/tests/test_milp.py
@@ -76,7 +76,8 @@ def test_result():
     res = milp(c=c, constraints=(A, b, b), bounds=(0, 1), integrality=1)
     assert res.status == 0
     assert res.success
-    assert isinstance(res.message, str)
+    msg = "Optimization terminated successfully. (HiGHS Status 7:"
+    assert res.message.startswith(msg)
     assert isinstance(res.x, np.ndarray)
     assert isinstance(res.fun, float)
     assert isinstance(res.mip_node_count, int)
@@ -88,21 +89,24 @@ def test_result():
                options={'time_limit': 0.05})
     assert res.status == 1
     assert not res.success
-    assert isinstance(res.message, str)
+    msg = "Time limit reached. (HiGHS Status 13:"
+    assert res.message.startswith(msg)
     assert (res.fun is res.mip_dual_bound is res.mip_gap
             is res.mip_node_count is res.x is None)
 
     res = milp(1, bounds=(1, -1))
     assert res.status == 2
     assert res.success
-    assert isinstance(res.message, str)
+    msg = "The problem is infeasible. (HiGHS Status 8:"
+    assert res.message.startswith(msg)
     assert (res.fun is res.mip_dual_bound is res.mip_gap
             is res.mip_node_count is res.x is None)
 
     res = milp(-1)
     assert res.status == 3
     assert res.success
-    assert isinstance(res.message, str)
+    msg = "The problem is unbounded. (HiGHS Status 10:"
+    assert res.message.startswith(msg)
     assert (res.fun is res.mip_dual_bound is res.mip_gap
             is res.mip_node_count is res.x is None)
 
@@ -180,13 +184,11 @@ def test_milp_3():
 
     # solve original problem
     res = milp(c=c, constraints=constraints, integrality=integrality)
-    assert res.message == 'Optimal'
     assert_allclose(res.fun, -2)
     assert_allclose(res.x, [1, 2])
 
     # solve relaxed problem
     res = milp(c=c, constraints=constraints)
-    assert res.message == 'Optimal'
     assert_allclose(res.fun, -2.8)
     assert_allclose(res.x, [1.8, 2.8])
 
@@ -204,7 +206,6 @@ def test_milp_4():
 
     res = milp(c, integrality=integrality, bounds=bounds,
                constraints=constraints)
-    assert res.message == 'Optimal'
     assert_allclose(res.fun, 59)
     assert_allclose(res.x, [6.5, 7])
 

--- a/scipy/optimize/tests/test_milp.py
+++ b/scipy/optimize/tests/test_milp.py
@@ -1,0 +1,247 @@
+"""
+Unit test for Mixed Integer Linear Programming
+"""
+
+import re
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose, assert_array_equal
+from .test_linprog import magic_square
+from scipy.optimize import milp, Bounds, LinearConstraint
+
+
+def test_milp_iv():
+
+    message = "`c` must be a one-dimensional array"
+    with pytest.raises(ValueError, match=message):
+        milp(np.zeros((3, 4)))
+
+    message = "`bounds` must be an instance of..."
+    with pytest.raises(ValueError, match=message):
+        milp(1, bounds=10)
+
+    message = "`constraints` must be a sequence of..."
+    with pytest.raises(ValueError, match=message):
+        milp(1, constraints=10)
+
+    message = "The shape of `A` must be (len(b_l), len(c))."
+    with pytest.raises(ValueError, match=re.escape(message)):
+        milp(np.zeros(3), constraints=([[1, 2, 3]], [2, 3], [2, 3]))
+    with pytest.raises(ValueError, match=re.escape(message)):
+        milp(np.zeros(3), constraints=([[1, 2]], [2], [2]))
+
+    message = ("`integrality` must contain integers 0-3 and be broadcastable "
+               "to `c.shape`.")
+    with pytest.raises(ValueError, match=message):
+        milp([1, 2, 3], integrality = [1, 2])
+    with pytest.raises(ValueError, match=message):
+        milp([1, 2, 3], integrality = [1, 5, 3])
+
+
+    message = "`lb`, `ub`, and `keep_feasible` must be broadcastable."
+    with pytest.raises(ValueError, match=message):
+        milp([1, 2, 3], bounds=([1, 2], [3, 4, 5]))
+    with pytest.raises(ValueError, match=message):
+        milp([1, 2, 3], bounds=([1, 2, 3], [4, 5]))
+
+    message = "`bounds.lb` and `bounds.ub` must contain reals and..."
+    with pytest.raises(ValueError, match=message):
+        milp([1, 2, 3], bounds=([1, 2], [3, 4]))
+    with pytest.raises(ValueError, match=message):
+        milp([1, 2, 3], bounds=([1, 2, 3], ["3+4", 4, 5]))
+    with pytest.raises(ValueError, match=message):
+        milp([1, 2, 3], bounds=([1, 2, 3], [set(), 4, 5]))
+
+def test_milp_options(capsys):
+    message = "Unrecognized options detected: {'ekki'}..."
+    options = {'ekki': True}
+    with pytest.warns(RuntimeWarning, match=message):
+        milp(1, options=options)
+
+    A, b, c, numbers, M = magic_square(3)
+    options = {"disp": True, "presolve": False, "time_limit": 0.05}
+    res = milp(c=c, constraints=(A, b, b), bounds=(0, 1), integrality=1,
+               options=options)
+
+    # This shows that captured.out tests work
+    # Need to pass this test when the following print statement is _removed_.
+    print("Time Limit Reached, Presolve is switched off")
+
+    captured = capsys.readouterr()
+    assert "Presolve is switched off" in captured.out
+    assert "Time Limit Reached" in captured.out
+    assert res.success == False
+
+
+def test_result():
+    A, b, c, numbers, M = magic_square(3)
+    res = milp(c=c, constraints=(A, b, b), bounds=(0, 1), integrality=1)
+    assert res.status == 0
+    assert res.success
+    assert isinstance(res.message, str)
+    assert isinstance(res.x, np.ndarray)
+    assert isinstance(res.fun, float)
+    assert isinstance(res.mip_node_count, int)
+    assert isinstance(res.mip_dual_bound, float)
+    assert isinstance(res.mip_gap, float)
+
+    A, b, c, numbers, M = magic_square(6)
+    res = milp(c=c*0, constraints=(A, b, b), bounds=(0, 1), integrality=1,
+               options={'time_limit': 0.05})
+    assert res.status == 1
+    assert not res.success
+    assert isinstance(res.message, str)
+    assert (res.fun == res.mip_dual_bound == res.mip_gap
+            == res.mip_node_count == res.x == None)
+
+    res = milp(1, bounds=(1, -1))
+    assert res.status == 2
+    assert res.success
+    assert isinstance(res.message, str)
+    assert (res.fun == res.mip_dual_bound == res.mip_gap
+            == res.mip_node_count == res.x == None)
+
+    res = milp(-1)
+    assert res.status == 3
+    assert res.success
+    assert isinstance(res.message, str)
+    assert (res.fun == res.mip_dual_bound == res.mip_gap
+            == res.mip_node_count == res.x == None)
+
+def test_milp_optional_args():
+    # check that arguments other than `c` are indeed optional
+    res = milp(1)
+    assert res.fun == 0
+    assert_array_equal(res.x, [0])
+
+
+def test_milp_1():
+    # solve magic square problem
+    n = 3
+    A, b, c, numbers, M = magic_square(n)
+    res = milp(c=c*0, constraints=(A, b, b), bounds=(0, 1), integrality=1)
+
+    # check that solution is a magic square
+    x = np.round(res.x)
+    s = (numbers.flatten() * x).reshape(n**2, n, n)
+    square = np.sum(s, axis=0)
+    np.testing.assert_allclose(square.sum(axis=0), M)
+    np.testing.assert_allclose(square.sum(axis=1), M)
+    np.testing.assert_allclose(np.diag(square).sum(), M)
+    np.testing.assert_allclose(np.diag(square[:, ::-1]).sum(), M)
+
+
+def test_milp_2():
+    # solve MIP with inequality constraints and all integer constraints
+    # source: slide 5,
+    # https://www.cs.upc.edu/~erodri/webpage/cps/theory/lp/milp/slides.pdf
+    # also check that `milp` accepts all valid ways of specifying constraints
+    c = -np.ones(2)
+    A = [[-2, 2], [-8, 10]]
+    b_l = [1, -np.inf]
+    b_u = [np.inf, 13]
+    linear_constraint = LinearConstraint(A, b_l, b_u)
+
+    # solve original problem
+    res1 = milp(c=c, constraints=(A, b_l, b_u), integrality=True)
+    res2 = milp(c=c, constraints=linear_constraint, integrality=True)
+    res3 = milp(c=c, constraints=[(A, b_l, b_u)], integrality=True)
+    res4 = milp(c=c, constraints=[linear_constraint], integrality=True)
+    res5 = milp(c=c, integrality=True,
+                constraints=[(A[:1], b_l[:1], b_u[:1]),
+                             (A[1:], b_l[1:], b_u[1:])])
+    res6 = milp(c=c, integrality=True,
+                constraints=[LinearConstraint(A[:1], b_l[:1], b_u[:1]),
+                             LinearConstraint(A[1:], b_l[1:], b_u[1:])])
+    res7 = milp(c=c, integrality=True,
+                constraints=[(A[:1], b_l[:1], b_u[:1]),
+                             LinearConstraint(A[1:], b_l[1:], b_u[1:])])
+    xs = np.array([res1.x, res2.x, res3.x, res4.x, res5.x, res6.x, res7.x])
+    funs = np.array([res1.fun, res2.fun, res3.fun,
+                     res4.fun, res5.fun, res6.fun, res7.fun])
+    np.testing.assert_allclose(xs, np.broadcast_to([1, 2], xs.shape))
+    np.testing.assert_allclose(funs, -3)
+
+    # solve relaxed problem
+    res = milp(c=c, constraints=(A, b_l, b_u))
+    np.testing.assert_allclose(res.x, [4, 4.5])
+    np.testing.assert_allclose(res.fun, -8.5)
+
+
+def test_milp_3():
+    # solve MIP with inequality constraints and all integer constraints
+    # source: https://en.wikipedia.org/wiki/Integer_programming#Example
+    c = [0, -1]
+    A = [[-1, 1], [3, 2], [2, 3]]
+    b_u = [1, 12, 12]
+    b_l = np.full_like(b_u, -np.inf)
+    constraints = LinearConstraint(A, b_l, b_u)
+
+    integrality = np.ones_like(c)
+
+    # solve original problem
+    res = milp(c=c, constraints=constraints, integrality=integrality)
+    assert res.message == 'Optimal'
+    assert_allclose(res.fun, -2)
+    assert_allclose(res.x, [1, 2])
+
+    # solve relaxed problem
+    res = milp(c=c, constraints=constraints)
+    assert res.message == 'Optimal'
+    assert_allclose(res.fun, -2.8)
+    assert_allclose(res.x, [1.8, 2.8])
+
+
+def test_milp_4():
+    # solve MIP with inequality constraints and only one integer constraint
+    # source: https://www.mathworks.com/help/optim/ug/intlinprog.html
+    c = [8, 1]
+    integrality = [0, 1]
+    A = [[1, 2], [-4, -1], [2, 1]]
+    b_l = [-14, -np.inf, -np.inf]
+    b_u = [np.inf, -33, 20]
+    constraints = LinearConstraint(A, b_l, b_u)
+    bounds = Bounds(-np.inf, np.inf)
+
+    res = milp(c, integrality=integrality, bounds=bounds,
+               constraints=constraints)
+    assert res.message == 'Optimal'
+    assert_allclose(res.fun, 59)
+    assert_allclose(res.x, [6.5, 7])
+
+
+def test_milp_5():
+    # solve MIP with inequality and equality constraints
+    # source: https://www.mathworks.com/help/optim/ug/intlinprog.html
+    c = [-3, -2, -1]
+    integrality = [0, 0, 1]
+    lb = [0, 0, 0]
+    ub = [np.inf, np.inf, 1]
+    bounds = Bounds(lb, ub)
+    A = [[1, 1, 1], [4, 2, 1]]
+    b_l = [-np.inf, 12]
+    b_u = [7, 12]
+    constraints = LinearConstraint(A, b_l, b_u)
+
+    res = milp(c, integrality=integrality, bounds=bounds,
+               constraints=constraints)
+    # there are multiple solutions
+    assert_allclose(res.fun, -12)
+
+
+@pytest.mark.slow
+def test_milp_6():
+    # solve a larger MIP with only equality constraints
+    # source: https://www.mathworks.com/help/optim/ug/intlinprog.html
+    # TODO: figure out why this intermittently segfaults!
+    integrality = 1
+    A_eq = np.array([[22, 13, 26, 33, 21,  3, 14, 26],
+                     [39, 16, 22, 28, 26, 30, 23, 24],
+                     [18, 14, 29, 27, 30, 38, 26, 26],
+                     [41, 26, 28, 36, 18, 38, 16, 26]])
+    b_eq = np.array([7872, 10466, 11322, 12058])
+    c = np.array([2, 10, 13, 17, 7, 5, 7, 3])
+
+    res = milp(c=c, constraints=(A_eq, b_eq, b_eq), integrality=integrality)
+
+    np.testing.assert_allclose(res.fun, 1854)


### PR DESCRIPTION
#### Reference issue
Closes gh-14455
gh-15294
gh-9269

#### What does this implement/fix?
In gh-15294, we exposed HiGHS MILP features by adding the `integrality` parameter to `linprog`. In gh-14455, however, the consensus was that MILP also deserved its own function. This PR adds a new `milp` function dedicated to mixed integer linear programming. 

#### Additional information
gh-15394 should merge first.