### PR TITLE
CI: switch one macOS CI job from distutils to meson

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,4 +1,4 @@
-name: macOS tests
+name: macOS tests (setup.py)
 
 on:
   push:
@@ -19,7 +19,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        python-version: ["3.8", "3.10"]
+        python-version: ["3.8"]
         numpy-version: ['--upgrade numpy']
 
     steps:

--- a/.github/workflows/macos_meson.yml
+++ b/.github/workflows/macos_meson.yml
@@ -94,6 +94,13 @@ jobs:
       run: |
         conda activate scipy-meson
         python -m pip install meson==0.61.1
+        # Python.org installers still use 10.9, so let's use that too. Note
+        # that scikit-learn already changed to 10.13 in Jan 2021, so increasing
+        # this number in the future (if needed) should not be a problem.
+        # Conda-forge is still at 10.9, see:
+        # https://conda-forge.org/docs/maintainer/knowledge_base.html#requiring-newer-macos-sdks
+        export MACOSX_DEPLOYMENT_TARGET=10.9
+        export MACOSX_SDK_VERSION=10.9
         CC="ccache $CC" python dev.py -j 2 --build-only
 
     - name: Test SciPy

--- a/.github/workflows/macos_meson.yml
+++ b/.github/workflows/macos_meson.yml
@@ -1,0 +1,109 @@
+name: macOS tests (meson)
+
+on:
+  push:
+    branches:
+      - main
+      - maintenance/**
+  pull_request:
+    branches:
+      - main
+      - maintenance/**
+
+env:
+  INSTALLDIR: "installdir"
+  CCACHE_DIR: "${{ github.workspace }}/.ccache"
+
+jobs:
+  test_meson:
+    name: Meson build
+    # If using act to run CI locally the github object does not exist and the usual skipping should not be enforced
+    if: "github.repository != '' || github.repository == 'scipy/scipy' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install Ccache
+      run: |
+        brew install ccache
+
+    - name:  Prepare compiler cache
+      id:    prep-ccache
+      shell: bash -l {0}
+      run: |
+        mkdir -p "${CCACHE_DIR}"
+        echo "::set-output name=dir::$CCACHE_DIR"
+        NOW=$(date -u +"%F-%T")
+        echo "::set-output name=timestamp::${NOW}"
+
+    - name: Setup compiler cache
+      uses:  actions/cache@v2
+      id:    cache-ccache
+      # Reference: https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
+      # NOTE: The caching strategy is modeled in a way that it will always have
+      # a unique cache key for each workflow run (even if the same workflow is
+      # run multiple times). The restore keys are not unique and for a partial
+      # match, they will return the most recently created cache entry,
+      # according to the GitHub Action Docs.
+      with:
+        path: ${{ steps.prep-ccache.outputs.dir }}
+        key:  ${{ github.workflow }}-${{ matrix.python-version }}-ccache-macos-${{ steps.prep-ccache.outputs.timestamp }}
+        # This evaluates to `macOS Tests-3.10-ccache-macos-` which is not
+        # unique. As the CI matrix is expanded, this will need to be updated to
+        # be unique so that the cache is not restored from a different job altogether.
+        restore-keys: |
+          ${{ github.workflow }}-${{ matrix.python-version }}-ccache-macos-
+
+    - name: Setup Conda
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+        mamba-version: "*"
+        channels: conda-forge
+        channel-priority: true
+        activate-environment: scipy-meson
+        use-only-tar-bz2: true
+
+    - name: Cache conda
+      uses: actions/cache@v2
+      env:
+        # Increase this value to reset cache if environment_meson.yml has not changed
+        CACHE_NUMBER: 0
+      with:
+        path: /usr/local/miniconda/envs/scipy-meson
+        key:
+          ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('environment_meson.yml') }}
+      id: envcache
+
+    - name: Update Conda Environment
+      run: mamba env update -n scipy-meson -f environment_meson.yml
+
+    - name: Build and Install SciPy
+      shell: bash -l {0}
+      run: |
+        conda activate scipy-meson
+        python -m pip install meson==0.61.1
+        CC="ccache $CC" python dev.py -j 2 --build-only
+
+    - name: Test SciPy
+      shell: bash -l {0}
+      run: |
+        conda activate scipy-meson
+        export OMP_NUM_THREADS=2
+        python dev.py -n -j 2
+
+    - name: Ccache statistics
+      shell: bash -l {0}
+      run: |
+        ccache -s

--- a/environment_meson.yml
+++ b/environment_meson.yml
@@ -19,6 +19,7 @@ dependencies:
   - libblas=*=*openblas  # helps avoid pulling in MKL
   - pybind11
   - pythran>=0.9.12
+  - conda-build
   # For testing and benchmarking
   - pytest
   - pytest-cov

--- a/scipy/optimize/meson.build
+++ b/scipy/optimize/meson.build
@@ -45,22 +45,11 @@ _minpack = py3.extension_module('_minpack',
   subdir: 'scipy/optimize'
 )
 
-cpp_args = []
-link_args = []
-if host_machine.system() == 'darwin'
-  if compiler.has_argument('-mmacosx-version-min=10.9')
-    cpp_args = ['-mmacosx-version-min=10.9']
-    link_args = ['-mmacosx-version-min=10.9']
-  endif
-endif
-
 rectangular_lasp = static_library('rectangular_lasp',
   [
     'rectangular_lsap/rectangular_lsap.h',
     'rectangular_lsap/rectangular_lsap.cpp'
   ],
-  cpp_args: cpp_args,
-  link_args: link_args
 )
 
 py3.extension_module('_lsap_module',


### PR DESCRIPTION
This should be a little faster, and test something different - the two macOS jobs that we have now were basically identical. This job has been stable for a little while, so it's good to have it in the main repo now. 

Also important to point out: it's our first CI job using `conda-forge`, which is a nice addition. The rough comparison of timings:
- `setup.py` based job: 39-48 min
- `meson` based job: 29-41 min

The meson job takes 3-4 extra for installing with `mamba` (more needs to be downloaded, like Python itself), but builds a few minutes faster on a cold cache (and >5 min for rebuilds due to ccache), and the tests run >5 min faster as well because it's optimized for 2 cores, unlike the `runtests.py` based CI job.