### PR TITLE
DOC: stats: add weights in formulas and examples for gmean and hmean

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -221,10 +221,21 @@ def _broadcast_shapes_with_dropped_axis(a, b, axis):
         lambda x: x, n_samples=1, n_outputs=1, too_small=0, paired=True,
         result_unpacker=lambda x: (x,), kwd_samples=['weights'])
 def gmean(a, axis=0, dtype=None, weights=None):
-    """Compute the geometric mean along the specified axis.
+    """Compute the weighted geometric mean along the specified axis.
 
-    Return the geometric average of the array elements.
-    That is:  n-th root of (x1 * x2 * ... * xn)
+    The weighted geometric mean of the array :math:`a_i` associated to weights
+    :math:`w_i` is:
+
+    .. math::
+
+        \exp \left( \frac{ \sum_{i=1}^n w_i \log a_i }{ \sum_{i=1}^n w_i }
+        \right) \, ,
+
+    and, with equal weights, it falls backs to:
+
+    .. math::
+
+        \sqrt[n]{ \prod_{i=1}^n a_i } \, .
 
     Parameters
     ----------
@@ -262,7 +273,8 @@ def gmean(a, axis=0, dtype=None, weights=None):
 
     References
     ----------
-    .. [1] "Weighted Geometric Mean", *Wikipedia*, https://en.wikipedia.org/wiki/Weighted_geometric_mean.
+    .. [1] "Weighted Geometric Mean", *Wikipedia*,
+           https://en.wikipedia.org/wiki/Weighted_geometric_mean.
 
     Examples
     --------
@@ -271,6 +283,8 @@ def gmean(a, axis=0, dtype=None, weights=None):
     2.0
     >>> gmean([1, 2, 3, 4, 5, 6, 7])
     3.3800151591412964
+    >>> gmean([1, 4, 7], weights=[3, 1, 3])
+    3.6254165153852687
 
     """
     if not isinstance(a, np.ndarray):
@@ -295,9 +309,20 @@ def gmean(a, axis=0, dtype=None, weights=None):
         lambda x: x, n_samples=1, n_outputs=1, too_small=0, paired=True,
         result_unpacker=lambda x: (x,), kwd_samples=['weights'])
 def hmean(a, axis=0, dtype=None, *, weights=None):
-    """Calculate the harmonic mean along the specified axis.
+    """Calculate the weighted harmonic mean along the specified axis.
 
-    That is:  n / (1/x1 + 1/x2 + ... + 1/xn)
+    The weighted harmonic mean of the array :math:`a_i` associated to weights
+    :math:`w_i` is:
+
+    .. math::
+
+        \frac{ \sum_{i=1}^n w_i }{ \sum_{i=1}^n \frac{w_i}{a_i} } \, ,
+
+    and, with equal weights, it falls backs to:
+
+    .. math::
+
+        \frac{ n }{ \sum_{i=1}^n \frac{1}{a_i} } \, .
 
     Parameters
     ----------
@@ -350,6 +375,8 @@ def hmean(a, axis=0, dtype=None, *, weights=None):
     1.6000000000000001
     >>> hmean([1, 2, 3, 4, 5, 6, 7])
     2.6997245179063363
+    >>> hmean([1, 4, 7], weights=[3, 1, 3])
+    1.9029126213592233
 
     """
     if not isinstance(a, np.ndarray):

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -231,7 +231,7 @@ def gmean(a, axis=0, dtype=None, weights=None):
         \exp \left( \frac{ \sum_{i=1}^n w_i \ln a_i }{ \sum_{i=1}^n w_i }
                    \right) \, ,
 
-    and, with equal weights, it falls backs to:
+    and, with equal weights, it gives:
 
     .. math::
 
@@ -318,7 +318,7 @@ def hmean(a, axis=0, dtype=None, *, weights=None):
 
         \frac{ \sum_{i=1}^n w_i }{ \sum_{i=1}^n \frac{w_i}{a_i} } \, ,
 
-    and, with equal weights, it falls backs to:
+    and, with equal weights, it gives:
 
     .. math::
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -221,7 +221,7 @@ def _broadcast_shapes_with_dropped_axis(a, b, axis):
         lambda x: x, n_samples=1, n_outputs=1, too_small=0, paired=True,
         result_unpacker=lambda x: (x,), kwd_samples=['weights'])
 def gmean(a, axis=0, dtype=None, weights=None):
-    """Compute the weighted geometric mean along the specified axis.
+    r"""Compute the weighted geometric mean along the specified axis.
 
     The weighted geometric mean of the array :math:`a_i` associated to weights
     :math:`w_i` is:
@@ -229,7 +229,7 @@ def gmean(a, axis=0, dtype=None, weights=None):
     .. math::
 
         \exp \left( \frac{ \sum_{i=1}^n w_i \log a_i }{ \sum_{i=1}^n w_i }
-        \right) \, ,
+                   \right) \, ,
 
     and, with equal weights, it falls backs to:
 
@@ -284,7 +284,7 @@ def gmean(a, axis=0, dtype=None, weights=None):
     >>> gmean([1, 2, 3, 4, 5, 6, 7])
     3.3800151591412964
     >>> gmean([1, 4, 7], weights=[3, 1, 3])
-    3.6254165153852687
+    2.80668351922014
 
     """
     if not isinstance(a, np.ndarray):
@@ -309,7 +309,7 @@ def gmean(a, axis=0, dtype=None, weights=None):
         lambda x: x, n_samples=1, n_outputs=1, too_small=0, paired=True,
         result_unpacker=lambda x: (x,), kwd_samples=['weights'])
 def hmean(a, axis=0, dtype=None, *, weights=None):
-    """Calculate the weighted harmonic mean along the specified axis.
+    r"""Calculate the weighted harmonic mean along the specified axis.
 
     The weighted harmonic mean of the array :math:`a_i` associated to weights
     :math:`w_i` is:

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -228,7 +228,7 @@ def gmean(a, axis=0, dtype=None, weights=None):
 
     .. math::
 
-        \exp \left( \frac{ \sum_{i=1}^n w_i \log a_i }{ \sum_{i=1}^n w_i }
+        \exp \left( \frac{ \sum_{i=1}^n w_i \ln a_i }{ \sum_{i=1}^n w_i }
                    \right) \, ,
 
     and, with equal weights, it falls backs to:


### PR DESCRIPTION
#### Reference issue

As raised by https://github.com/scipy/scipy/pull/15347#pullrequestreview-844052975, it lacks the weights in the formulas and examples of gmean and hmean.

#### What does this implement/fix?

Complete formulas and examples with weights.

#### Additional information

https://en.wikipedia.org/wiki/Weighted_geometric_mean

https://en.wikipedia.org/wiki/Harmonic_mean#Weighted_harmonic_mean
