### PR TITLE
MAINT: Remove `distutils` usage

### DIFF
--- a/scipy/linalg/_generate_pyx.py
+++ b/scipy/linalg/_generate_pyx.py
@@ -8,6 +8,7 @@ all the BLAS/LAPACK routines that should be included in the wrappers.
 from collections import defaultdict
 from operator import itemgetter
 import os
+from stat import ST_MTIME
 import argparse
 
 
@@ -672,8 +673,24 @@ def filter_lines(lines):
     return func_sigs, sub_sigs, all_sigs
 
 
+def newer(source, target):
+    """
+    Return true if 'source' exists and is more recently modified than
+    'target', or if 'source' exists and 'target' doesn't.  Return false if
+    both exist and 'target' is the same age or younger than 'source'.
+    """
+    if not os.path.exists(source):
+        raise ValueError("file '%s' does not exist" % os.path.abspath(source))
+    if not os.path.exists(target):
+        return 1
+
+    mtime1 = os.stat(source)[ST_MTIME]
+    mtime2 = os.stat(target)[ST_MTIME]
+
+    return mtime1 > mtime2
+
+
 def all_newer(src_files, dst_files):
-    from distutils.dep_util import newer
     return all(os.path.exists(dst) and newer(dst, src)
                for dst in dst_files for src in src_files)
 

--- a/scipy/sparse/_generate_sparsetools.py
+++ b/scipy/sparse/_generate_sparsetools.py
@@ -20,7 +20,8 @@ See sparsetools.cxx for more details.
 """
 import optparse
 import os
-from distutils.dep_util import newer
+from stat import ST_MTIME
+
 
 #
 # List of all routines and their argument types.
@@ -193,6 +194,24 @@ static int get_thunk_case(int I_typenum, int T_typenum)
 #
 # Code generation
 #
+
+
+def newer(source, target):
+    """
+    Return true if 'source' exists and is more recently modified than
+    'target', or if 'source' exists and 'target' doesn't.  Return false if
+    both exist and 'target' is the same age or younger than 'source'.
+    """
+    if not os.path.exists(source):
+        raise ValueError("file '%s' does not exist" % os.path.abspath(source))
+    if not os.path.exists(target):
+        return 1
+
+    mtime1 = os.stat(source)[ST_MTIME]
+    mtime2 = os.stat(target)[ST_MTIME]
+
+    return mtime1 > mtime2
+
 
 def get_thunk_type_set():
     """

--- a/scipy/special/_generate_pyx.py
+++ b/scipy/special/_generate_pyx.py
@@ -225,6 +225,7 @@ class errstate:
 import itertools
 import json
 import os
+from stat import ST_MTIME
 import optparse
 import argparse
 import re
@@ -1440,8 +1441,24 @@ def unique(lst):
     return new_lst
 
 
+def newer(source, target):
+    """
+    Return true if 'source' exists and is more recently modified than
+    'target', or if 'source' exists and 'target' doesn't.  Return false if
+    both exist and 'target' is the same age or younger than 'source'.
+    """
+    if not os.path.exists(source):
+        raise ValueError("file '%s' does not exist" % os.path.abspath(source))
+    if not os.path.exists(target):
+        return 1
+
+    mtime1 = os.stat(source)[ST_MTIME]
+    mtime2 = os.stat(target)[ST_MTIME]
+
+    return mtime1 > mtime2
+
+
 def all_newer(src_files, dst_files):
-    from distutils.dep_util import newer
     return all(os.path.exists(dst) and newer(dst, src)
                for dst in dst_files for src in src_files)
 

--- a/scipy/special/utils/makenpz.py
+++ b/scipy/special/utils/makenpz.py
@@ -8,8 +8,24 @@ Build a npz containing all data files in the directory.
 import os
 import numpy as np
 import argparse
+from stat import ST_MTIME
 
-from distutils.util import newer  # type: ignore
+
+def newer(source, target):
+    """
+    Return true if 'source' exists and is more recently modified than
+    'target', or if 'source' exists and 'target' doesn't.  Return false if
+    both exist and 'target' is the same age or younger than 'source'.
+    """
+    if not os.path.exists(source):
+        raise ValueError("file '%s' does not exist" % os.path.abspath(source))
+    if not os.path.exists(target):
+        return 1
+
+    mtime1 = os.stat(source)[ST_MTIME]
+    mtime2 = os.stat(target)[ST_MTIME]
+
+    return mtime1 > mtime2
 
 
 def main():


### PR DESCRIPTION
Fixing a few `distutils` warnings like:
```py
/scipy/setup.py:123: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
  from distutils.command.sdist import sdist
```


cc @rgommers 