### PR TITLE
ENH: `stats.qmc`: faster hypercube point comparison and scrambling doc

### DIFF
--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -253,10 +253,10 @@ def discrepancy(
     ----------
     .. [1] Fang et al. "Design and modeling for computer experiments".
        Computer Science and Data Analysis Series, 2006.
-    .. [2] Zhou Y.-D. et al. Mixture discrepancy for quasi-random point sets.
+    .. [2] Zhou Y.-D. et al. "Mixture discrepancy for quasi-random point sets."
        Journal of Complexity, 29 (3-4) , pp. 283-301, 2013.
     .. [3] T. T. Warnock. "Computational investigations of low discrepancy
-       point sets". Applications of Number Theory to Numerical
+       point sets." Applications of Number Theory to Numerical
        Analysis, Academic Press, pp. 319-343, 1972.
 
     Examples
@@ -579,7 +579,7 @@ def van_der_corput(
     References
     ----------
     .. [1] A. B. Owen. "A randomized Halton algorithm in R",
-       arXiv:1706.02808, 2017.
+       :arxiv:`1706.02808`, 2017.
 
     """
     if base < 2:
@@ -794,7 +794,7 @@ class Halton(QMCEngine):
        points in evaluating multi-dimensional integrals", Numerische
        Mathematik, 1960.
     .. [2] A. B. Owen. "A randomized Halton algorithm in R",
-       arXiv:1706.02808, 2017.
+       :arxiv:`1706.02808`, 2017.
 
     Examples
     --------
@@ -1218,7 +1218,7 @@ class Sobol(QMCEngine):
     d : int
         Dimensionality of the sequence. Max dimensionality is 21201.
     scramble : bool, optional
-        If True, use Owen scrambling. Otherwise no scrambling is done.
+        If True, use LMS+shift scrambling. Otherwise, no scrambling is done.
         Default is True.
     seed : {None, int, `numpy.random.Generator`}, optional
         If `seed` is None the `numpy.random.Generator` singleton is used.
@@ -1230,12 +1230,14 @@ class Sobol(QMCEngine):
     Notes
     -----
     Sobol' sequences [1]_ provide :math:`n=2^m` low discrepancy points in
-    :math:`[0,1)^{d}`. Scrambling them [2]_ makes them suitable for singular
+    :math:`[0,1)^{d}`. Scrambling them [3]_ makes them suitable for singular
     integrands, provides a means of error estimation, and can improve their
-    rate of convergence.
+    rate of convergence. The scrambling strategy which is implemented is a
+    (left) linear matrix scramble (LMS) followed by a digital random shift
+    (LMS+shift) [2]_.
 
     There are many versions of Sobol' sequences depending on their
-    'direction numbers'. This code uses direction numbers from [3]_. Hence,
+    'direction numbers'. This code uses direction numbers from [4]_. Hence,
     the maximum number of dimension is 21201. The direction numbers have been
     precomputed with search criterion 6 and can be retrieved at
     https://web.maths.unsw.edu.au/~fkuo/sobol/.
@@ -1244,7 +1246,7 @@ class Sobol(QMCEngine):
 
        Sobol' sequences are a quadrature rule and they lose their balance
        properties if one uses a sample size that is not a power of 2, or skips
-       the first point, or thins the sequence [4]_.
+       the first point, or thins the sequence [5]_.
 
        If :math:`n=2^m` points are not enough then one should take :math:`2^M`
        points for :math:`M>m`. When scrambling, the number R of independent
@@ -1256,19 +1258,18 @@ class Sobol(QMCEngine):
 
     References
     ----------
-    .. [1] I. M. Sobol. The distribution of points in a cube and the accurate
-       evaluation of integrals. Zh. Vychisl. Mat. i Mat. Phys., 7:784-802,
+    .. [1] I. M. Sobol', "The distribution of points in a cube and the accurate
+       evaluation of integrals." Zh. Vychisl. Mat. i Mat. Phys., 7:784-802,
        1967.
-
-    .. [2] Art B. Owen. Scrambling Sobol and Niederreiter-Xing points.
+    .. [2] J. Matousek, "On the L2-discrepancy for anchored boxes."
+       J. of Complexity 14, 527-556, 1998.
+    .. [3] Art B. Owen, "Scrambling Sobol and Niederreiter-Xing points."
        Journal of Complexity, 14(4):466-489, December 1998.
-
-    .. [3] S. Joe and F. Y. Kuo. Constructing sobol sequences with better
-       two-dimensional projections. SIAM Journal on Scientific Computing,
+    .. [4] S. Joe and F. Y. Kuo, "Constructing sobol sequences with better
+       two-dimensional projections." SIAM Journal on Scientific Computing,
        30(5):2635-2654, 2008.
-
-    .. [4] Art B. Owen. On dropping the first Sobol' point. arXiv 2008.08051,
-       2020.
+    .. [5] Art B. Owen, "On dropping the first Sobol' point."
+       :arxiv:`2008.08051`, 2020.
 
     Examples
     --------

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -164,7 +164,7 @@ def scale(
 
     if not reverse:
         # Checking that sample is within the hypercube
-        if not (np.all(sample >= 0) and np.all(sample <= 1)):
+        if not ((sample.max() <= 1.) and (sample.min() >= 0.)):
             raise ValueError('Sample is not in unit hypercube')
 
         return sample * (upper - lower) + lower
@@ -294,7 +294,7 @@ def discrepancy(
     if not sample.ndim == 2:
         raise ValueError("Sample is not a 2D array")
 
-    if not (np.all(sample >= 0) and np.all(sample <= 1)):
+    if not ((sample.max() <= 1.) and (sample.min() >= 0.)):
         raise ValueError("Sample is not in unit hypercube")
 
     workers = _validate_workers(workers)
@@ -357,7 +357,7 @@ def update_discrepancy(
     if not sample.ndim == 2:
         raise ValueError('Sample is not a 2D array')
 
-    if not (np.all(sample >= 0) and np.all(sample <= 1)):
+    if not ((sample.max() <= 1.) and (sample.min() >= 0.)):
         raise ValueError('Sample is not in unit hypercube')
 
     # Checking that x_new is within the hypercube and 1D

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -164,7 +164,7 @@ def scale(
 
     if not reverse:
         # Checking that sample is within the hypercube
-        if not ((sample.max() <= 1.) and (sample.min() >= 0.)):
+        if (sample.max() > 1.) or (sample.min() < 0.):
             raise ValueError('Sample is not in unit hypercube')
 
         return sample * (upper - lower) + lower
@@ -294,7 +294,7 @@ def discrepancy(
     if not sample.ndim == 2:
         raise ValueError("Sample is not a 2D array")
 
-    if not ((sample.max() <= 1.) and (sample.min() >= 0.)):
+    if (sample.max() > 1.) or (sample.min() < 0.):
         raise ValueError("Sample is not in unit hypercube")
 
     workers = _validate_workers(workers)
@@ -357,7 +357,7 @@ def update_discrepancy(
     if not sample.ndim == 2:
         raise ValueError('Sample is not a 2D array')
 
-    if not ((sample.max() <= 1.) and (sample.min() >= 0.)):
+    if (sample.max() > 1.) or (sample.min() < 0.):
         raise ValueError('Sample is not in unit hypercube')
 
     # Checking that x_new is within the hypercube and 1D

--- a/scipy/stats/qmc.py
+++ b/scipy/stats/qmc.py
@@ -160,61 +160,61 @@ numbers come from [27]_. It is extensible in dimension up to
 
 References
 ----------
-.. [1] Owen, Art B. "Monte Carlo Book: the Quasi-Monte Carlo parts." (2019).
-.. [2] Niederreiter, Harald. Random number generation and quasi-Monte Carlo
-   methods. Society for Industrial and Applied Mathematics, 1992.
+.. [1] Owen, Art B. "Monte Carlo Book: the Quasi-Monte Carlo parts." 2019.
+.. [2] Niederreiter, Harald. "Random number generation and quasi-Monte Carlo
+   methods." Society for Industrial and Applied Mathematics, 1992.
 .. [3] Dick, Josef, Frances Y. Kuo, and Ian H. Sloan. "High-dimensional
-   integration: the quasi-Monte Carlo way." Acta Numerica 22 (2013): 133.
+   integration: the quasi-Monte Carlo way." Acta Numerica no. 22: 133, 2013.
 .. [4] Aho, A. V., C. Aistleitner, T. Anderson, K. Appel, V. Arnol'd, N.
-   Aronszajn, D. Asotsky et al. "W. Chen et al.(eds.), A Panorama of
-   Discrepancy Theory (2014): 679. Sringer International Publishing,
-   Switzerland.
+   Aronszajn, D. Asotsky et al. "W. Chen et al.(eds.), "A Panorama of
+   Discrepancy Theory", Sringer International Publishing,
+   Switzerland: 679, 2014.
 .. [5] Hickernell, Fred J. "Koksma-Hlawka Inequality." Wiley StatsRef:
-   Statistics Reference Online (2014).
-.. [6] Owen, Art B. "On dropping the first Sobol' point." arXiv preprint
-   arXiv:2008.08051 (2020).
+   Statistics Reference Online, 2014.
+.. [6] Owen, Art B. "On dropping the first Sobol' point." :arxiv:`2008.08051`,
+   2020.
 .. [7] L'Ecuyer, Pierre, and Christiane Lemieux. "Recent advances in randomized
    quasi-Monte Carlo methods." In Modeling uncertainty, pp. 419-474. Springer,
    New York, NY, 2002.
 .. [8] DiCiccio, Thomas J., and Bradley Efron. "Bootstrap confidence
-   intervals." Statistical science (1996): 189-212.
-.. [9] Dimov, Ivan T. Monte Carlo methods for applied scientists. World
+   intervals." Statistical science: 189-212, 1996.
+.. [9] Dimov, Ivan T. "Monte Carlo methods for applied scientists." World
    Scientific, 2008.
-.. [10] Caflisch, Russel E., William J. Morokoff, and Art B. Owen. Valuation of
-   mortgage backed securities using Brownian bridges to reduce effective
-   dimension. Journal of Computational Finance, (1997): 1, no. 1 27-46.
+.. [10] Caflisch, Russel E., William J. Morokoff, and Art B. Owen. "Valuation
+   of mortgage backed securities using Brownian bridges to reduce effective
+   dimension." Journal of Computational Finance: no. 1 27-46, 1997.
 .. [11] Sloan, Ian H., and Henryk Wozniakowski. "When are quasi-Monte Carlo
    algorithms efficient for high dimensional integrals?." Journal of Complexity
    14, no. 1 (1998): 1-33.
-.. [12] Owen, Art B., and Daniel Rudolf "A strong law of large numbers for
+.. [12] Owen, Art B., and Daniel Rudolf, "A strong law of large numbers for
    scrambled net integration." SIAM Review, to appear.
 .. [13] Loh, Wei-Liem. "On the asymptotic distribution of scrambled net
-   quadrature." The Annals of Statistics 31, no. 4 (2003): 1282-1324.
-.. [14] Sloan, Ian H. and S. Joe. Lattice methods for multiple integration.
+   quadrature." The Annals of Statistics 31, no. 4: 1282-1324, 2003.
+.. [14] Sloan, Ian H. and S. Joe. "Lattice methods for multiple integration."
    Oxford University Press, 1994.
-.. [15] Dick, Josef, and Friedrich Pillichshammer. Digital nets and sequences:
-   discrepancy theory and quasi-Monte Carlo integration. Cambridge University
+.. [15] Dick, Josef, and Friedrich Pillichshammer. "Digital nets and sequences:
+   discrepancy theory and quasi-Monte Carlo integration." Cambridge University
    Press, 2010.
 .. [16] Dick, Josef, F. Kuo, Friedrich Pillichshammer, and I. Sloan.
    "Construction algorithms for polynomial lattice rules for multivariate
-   integration." Mathematics of computation 74, no. 252 (2005): 1895-1921.
+   integration." Mathematics of computation 74, no. 252: 1895-1921, 2005.
 .. [17] Sobol', Il'ya Meerovich. "On the distribution of points in a cube and
    the approximate evaluation of integrals." Zhurnal Vychislitel'noi Matematiki
-   i Matematicheskoi Fiziki 7, no. 4 (1967): 784-802.
+   i Matematicheskoi Fiziki 7, no. 4: 784-802, 1967.
 .. [18] Halton, John H. "On the efficiency of certain quasi-random sequences of
    points in evaluating multi-dimensional integrals." Numerische Mathematik 2,
-   no. 1 (1960): 84-90.
+   no. 1: 84-90, 1960.
 .. [19] Faure, Henri. "Discrepance de suites associees a un systeme de
-   numeration (en dimension s)." Acta arithmetica 41, no. 4 (1982): 337-351.
+   numeration (en dimension s)." Acta arithmetica 41, no. 4: 337-351, 1982.
 .. [20] Niederreiter, Harold, and Chaoping Xing. "Low-discrepancy sequences and
    global function fields with many rational places." Finite Fields and their
-   applications 2, no. 3 (1996): 241-273.
+   applications 2, no. 3: 241-273, 1996.
 .. [21] Hong, Hee Sun, and Fred J. Hickernell. "Algorithm 823: Implementing
    scrambled digital sequences." ACM Transactions on Mathematical Software
-   (TOMS) 29, no. 2 (2003): 95-109.
+   (TOMS) 29, no. 2: 95-109, 2003.
 .. [22] Dick, Josef. "Higher order scrambled digital nets achieve the optimal
    rate of the root mean square error for smooth integrands." The Annals of
-   Statistics 39, no. 3 (2011): 1372-1398.
+   Statistics 39, no. 3: 1372-1398, 2011.
 .. [23] Niederreiter, Harald. "Multidimensional numerical integration using
    pseudorandom numbers." In Stochastic Programming 84 Part I, pp. 17-38.
    Springer, Berlin, Heidelberg, 1986.
@@ -222,13 +222,13 @@ References
    Quadrature Rules." In Monte Carlo and Quasi-Monte Carlo Methods 2000,
    pp. 274-289. Springer, Berlin, Heidelberg, 2002.
 .. [25] Owen, Art B., and Seth D. Tribble. "A quasi-Monte Carlo Metropolis
-   algorithm." Proceedings of the National Academy of Sciences 102, no. 25
-   (2005): 8844-8849.
+   algorithm." Proceedings of the National Academy of Sciences 102,
+   no. 25: 8844-8849, 2005.
 .. [26] Chen, Su. "Consistency and convergence rate of Markov chain quasi Monte
    Carlo with examples." PhD diss., Stanford University, 2011.
 .. [27] Joe, Stephen, and Frances Y. Kuo. "Constructing Sobol sequences with
    better two-dimensional projections." SIAM Journal on Scientific Computing
-   30, no. 5 (2008): 2635-2654.
+   30, no. 5: 2635-2654, 2008.
 
 """
 from ._qmc import *

--- a/scipy/stats/tests/test_qmc.py
+++ b/scipy/stats/tests/test_qmc.py
@@ -4,11 +4,9 @@ from itertools import combinations, product
 
 import pytest
 import numpy as np
-from numpy.testing import (assert_allclose, assert_almost_equal,
-                           assert_equal, assert_array_almost_equal,
-                           assert_array_equal)
-from scipy.stats import shapiro
+from numpy.testing import assert_allclose, assert_equal, assert_array_equal
 
+from scipy.stats import shapiro
 from scipy.stats._sobol import _test_find_index
 from scipy.stats import qmc
 from scipy.stats._qmc import (van_der_corput, n_primes, primes_from_2_to,
@@ -333,33 +331,33 @@ class TestVDC:
         sample = van_der_corput(10)
         out = [0.0, 0.5, 0.25, 0.75, 0.125, 0.625,
                0.375, 0.875, 0.0625, 0.5625]
-        assert_almost_equal(sample, out)
+        assert_allclose(sample, out)
 
         sample = van_der_corput(10, workers=4)
-        assert_almost_equal(sample, out)
+        assert_allclose(sample, out)
 
         sample = van_der_corput(10, workers=8)
-        assert_almost_equal(sample, out)
+        assert_allclose(sample, out)
 
         sample = van_der_corput(7, start_index=3)
-        assert_almost_equal(sample, out[3:])
+        assert_allclose(sample, out[3:])
 
     def test_van_der_corput_scramble(self):
         seed = 338213789010180879520345496831675783177
         out = van_der_corput(10, scramble=True, seed=seed)
 
         sample = van_der_corput(7, start_index=3, scramble=True, seed=seed)
-        assert_almost_equal(sample, out[3:])
+        assert_allclose(sample, out[3:])
 
         sample = van_der_corput(
             7, start_index=3, scramble=True, seed=seed, workers=4
         )
-        assert_almost_equal(sample, out[3:])
+        assert_allclose(sample, out[3:])
 
         sample = van_der_corput(
             7, start_index=3, scramble=True, seed=seed, workers=8
         )
-        assert_almost_equal(sample, out[3:])
+        assert_allclose(sample, out[3:])
 
     def test_invalid_base_error(self):
         with pytest.raises(ValueError, match=r"'base' must be at least 2"):
@@ -457,7 +455,7 @@ class QMCEngineTests:
         engine = self.engine(d=2, scramble=scramble)
         sample = engine.random(n=len(ref_sample))
 
-        assert_almost_equal(sample, ref_sample, decimal=1)
+        assert_allclose(sample, ref_sample, atol=1e-1)
         assert engine.num_generated == len(ref_sample)
 
     @pytest.mark.parametrize("scramble", scramble, ids=ids)
@@ -471,7 +469,7 @@ class QMCEngineTests:
 
         _ = engine.random(n=n_half)
         sample = engine.random(n=n_half)
-        assert_almost_equal(sample, ref_sample[n_half:], decimal=1)
+        assert_allclose(sample, ref_sample[n_half:], atol=1e-1)
 
     @pytest.mark.parametrize("scramble", scramble, ids=ids)
     def test_reset(self, scramble):
@@ -494,7 +492,7 @@ class QMCEngineTests:
         engine.fast_forward(4)
         sample = engine.random(n=4)
 
-        assert_almost_equal(sample, ref_sample[4:], decimal=1)
+        assert_allclose(sample, ref_sample[4:], atol=1e-1)
 
         # alternate fast forwarding with sampling
         engine.reset()
@@ -504,10 +502,10 @@ class QMCEngineTests:
                 even_draws.append(engine.random())
             else:
                 engine.fast_forward(1)
-        assert_almost_equal(
+        assert_allclose(
             ref_sample[[i for i in range(8) if i % 2 == 0]],
             np.concatenate(even_draws),
-            decimal=5
+            atol=1e-5
         )
 
     @pytest.mark.parametrize("scramble", [True])
@@ -515,14 +513,14 @@ class QMCEngineTests:
         d = 50
         engine = self.engine(d=d, scramble=scramble)
         sample = engine.random(1024)
-        assert_array_almost_equal(
-            np.mean(sample, axis=0), np.repeat(0.5, d), decimal=2
+        assert_allclose(
+            np.mean(sample, axis=0), np.repeat(0.5, d), atol=1e-2
         )
-        assert_array_almost_equal(
-            np.percentile(sample, 25, axis=0), np.repeat(0.25, d), decimal=2
+        assert_allclose(
+            np.percentile(sample, 25, axis=0), np.repeat(0.25, d), atol=1e-2
         )
-        assert_array_almost_equal(
-            np.percentile(sample, 75, axis=0), np.repeat(0.75, d), decimal=2
+        assert_allclose(
+            np.percentile(sample, 75, axis=0), np.repeat(0.75, d), atol=1e-2
         )
 
 
@@ -726,7 +724,7 @@ class TestMultinomialQMC:
         p = np.array([0.12, 0.26, 0.05, 0.35, 0.22])
         engine = qmc.MultinomialQMC(p, seed=seed)
         draws = engine.random(8192)
-        assert_array_almost_equal(draws / np.sum(draws), p, decimal=4)
+        assert_allclose(draws / np.sum(draws), p, atol=1e-4)
 
     def test_FindIndex(self):
         p_cumulative = np.array([0.1, 0.4, 0.45, 0.6, 0.75, 0.9, 0.99, 1.0])
@@ -829,7 +827,7 @@ class TestNormalQMC:
         samples = engine.random(n=2)
         samples_expected = np.array([[0.446961, -1.243236],
                                      [-0.230754, 0.21354]])
-        assert_array_almost_equal(samples, samples_expected)
+        assert_allclose(samples, samples_expected, atol=1e-4)
 
         # test odd dimension
         seed = np.random.default_rng(274600237797326520096085022671371676017)
@@ -838,7 +836,7 @@ class TestNormalQMC:
         samples = engine.random(n=2)
         samples_expected = np.array([[0.446961, -1.243236, 0.324827],
                                      [-0.997875, 0.399134, 1.032234]])
-        assert_array_almost_equal(samples, samples_expected)
+        assert_allclose(samples, samples_expected, atol=1e-4)
 
     def test_NormalQMCSeededInvTransform(self):
         # test even dimension
@@ -848,7 +846,7 @@ class TestNormalQMC:
         samples = engine.random(n=2)
         samples_expected = np.array([[-0.804472, 0.384649],
                                      [0.396424, -0.117676]])
-        assert_array_almost_equal(samples, samples_expected)
+        assert_allclose(samples, samples_expected, atol=1e-4)
 
         # test odd dimension
         seed = np.random.default_rng(288527772707286126646493545351112463929)
@@ -857,7 +855,7 @@ class TestNormalQMC:
         samples = engine.random(n=2)
         samples_expected = np.array([[-0.804472, 0.384649, 1.583568],
                                      [0.165333, -2.266828, -1.655572]])
-        assert_array_almost_equal(samples, samples_expected)
+        assert_allclose(samples, samples_expected, atol=1e-4)
 
     def test_NormalQMCShapiro(self):
         rng = np.random.default_rng(13242)
@@ -980,7 +978,7 @@ class TestMultivariateNormalQMC:
         samples = engine.random(n=2)
         samples_expected = np.array([[0.479575, 0.934723],
                                      [1.712571, 0.172699]])
-        assert_array_almost_equal(samples, samples_expected)
+        assert_allclose(samples, samples_expected, atol=1e-4)
 
         # test odd dimension
         rng = np.random.default_rng(180182791534511062935571481899241825000)
@@ -991,7 +989,7 @@ class TestMultivariateNormalQMC:
         samples = engine.random(n=2)
         samples_expected = np.array([[2.463393, 2.252826, -0.886809],
                                      [1.252468, 0.029449, -1.126328]])
-        assert_array_almost_equal(samples, samples_expected)
+        assert_allclose(samples, samples_expected, atol=1e-4)
 
     def test_MultivariateNormalQMCSeededInvTransform(self):
         # test even dimension
@@ -1004,7 +1002,7 @@ class TestMultivariateNormalQMC:
         samples = engine.random(n=2)
         samples_expected = np.array([[-3.095968, -0.566545],
                                      [0.603154, 0.222434]])
-        assert_array_almost_equal(samples, samples_expected)
+        assert_allclose(samples, samples_expected, atol=1e-4)
 
         # test odd dimension
         rng = np.random.default_rng(224125808928297329711992996940871155974)
@@ -1016,7 +1014,7 @@ class TestMultivariateNormalQMC:
         samples = engine.random(n=2)
         samples_expected = np.array([[1.427248, -0.338187, -1.560687],
                                      [-0.357026, 1.662937, -0.29769]])
-        assert_array_almost_equal(samples, samples_expected)
+        assert_allclose(samples, samples_expected, atol=1e-4)
 
     def test_MultivariateNormalQMCShapiro(self):
         # test the standard case


### PR DESCRIPTION
Few minor things on QMC:

* Fix scrambling doc in Sobol'. It's not using Owen (NUS) but something from Matousek (LMS+shift). This came from a personal communication with Pierre L'Ecuyer.
* Faster (and clearer) point within hypercube check.
* Refactor usage of deprecated `assert_almost_equal` and `assert_array_almost_equal`.
* Uniformize a bit more the bibliography entries.