### PR TITLE
ENH: stats: add `axis` tuple and `nan_policy` to `skew`

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -1006,6 +1006,9 @@ def _moment(a, moment, axis, *, mean=None):
         return np.mean(s, axis)
 
 
+@_axis_nan_policy_factory(
+    lambda x: x, result_unpacker=lambda x: (x,), n_outputs=1
+)
 def skew(a, axis=0, bias=True, nan_policy='propagate'):
     r"""Compute the sample skewness of a data set.
 

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -26,7 +26,8 @@ axis_nan_policy_cases = [
     (stats.wilcoxon, tuple(), dict(), 1, 2, True, None),
     (stats.gmean, tuple(), dict(), 1, 1, False, lambda x: (x,)),
     (stats.hmean, tuple(), dict(), 1, 1, False, lambda x: (x,)),
-    (stats.kurtosis, tuple(), dict(), 1, 1, False, lambda x: (x,))
+    (stats.kurtosis, tuple(), dict(), 1, 1, False, lambda x: (x,)),
+    (stats.skew, tuple(), dict(), 1, 1, False, lambda x: (x,)),
 ]
 
 # If the message is one of those expected, put nans in

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -1737,8 +1737,8 @@ class TestCompareWithStats:
                 r = stats.skewtest(x)
                 rm = stats.mstats.skewtest(xm)
 
-                assert_equal(r[0][0], rm[0][0])
-                assert_equal(r[0][1], rm[0][1])
+                assert_allclose(r[0][0], rm[0][0], rtol=2e-15)
+                assert_allclose(r[0][1], rm[0][1], rtol=1e-15)
 
     def test_normaltest(self):
         with np.errstate(over='raise'), suppress_warnings() as sup:


### PR DESCRIPTION
#### Reference issue

gh-14651

#### What does this implement/fix?

Adds `_axis_nan_policy_factory` to `skew`. `skew` tests looked quite strong so I didn't add any special tests.

#### Additional information

I wrote an additional test with Hypothesis to tests for various edge cases and confirm the results are consistent. It passed for both `kurtosis` and `skew` (sorry, it's a little ugly right now because I was playing around and it was too much work to simplify). 

<details>

<summary>Additional tests with Hypothesis</summary>

```py
import numpy as np
import pytest
import hypothesis
from hypothesis import strategies as st
from hypothesis.extra import numpy as npst
from scipy import stats
from scipy.stats.tests.test_axis_nan_policy import axis_nan_policy_cases

# Writing more comprehensive tests with Hypothesis.
# The below tests check if functions using axis_nan_policy work for kurtosis and skew
# inputs with nans, masks, nans and masks, etc.
@hypothesis.given(data=st.data())
@hypothesis.seed(123)
@hypothesis.settings(max_examples=100, deadline=None)
@pytest.mark.parametrize("function, args, kwds, num_samples, num_outputs, paired, unpacker_function", axis_nan_policy_cases[7:])
def test_axis_nan_policy_with_hypothesis(function, args, kwds, num_samples, num_outputs, paired, unpacker_function, data):
    shapes = data.draw(npst.mutually_broadcastable_shapes(num_shapes=num_samples,
                                                          max_dims=6,
                                                          max_side=3))
    if len(shapes.result_shape) >= 1:
        axes = data.draw(npst.valid_tuple_axes(ndim=len(shapes.result_shape), min_size=1))
    else:
        axes = None

    samples = []
    nan_samples = []
    masked_samples = []
    nan_masked_samples = []

    for i in range(num_samples):
        sample = data.draw(npst.arrays(dtype=float, shape=shapes.input_shapes[i]))
        mask1 = np.random.rand(*sample.shape) < 0.2
        mask2 = np.random.rand(*sample.shape) < 0.15
        nan_sample = sample.copy()
        nan_sample[mask1|mask2] = np.nan
        masked_sample = np.ma.masked_array(sample, mask=mask1|mask2)
        nan_masked_sample = sample.copy()
        nan_masked_sample[mask1] = np.nan
        nan_masked_sample = np.ma.masked_array(nan_masked_sample, mask=mask2)
        samples.append(sample)
        nan_samples.append(nan_sample)
        masked_samples.append(masked_sample)
        nan_masked_samples.append(nan_masked_sample)

    with np.errstate(all='ignore'):
        with np.testing.suppress_warnings() as sup:
            sup.filter(RuntimeWarning)

            res_expected = function(*samples, *args, **kwds, _no_deco=True)
            res = function(*samples, *args, **kwds)
            np.testing.assert_allclose(res, res_expected)

            res1 = function(*nan_samples, *args, **kwds, axis=axes, nan_policy='omit')
            res2 = function(*masked_samples, *args, **kwds, axis=axes, nan_policy='omit')
            res3 = function(*nan_masked_samples, *args, **kwds, axis=axes, nan_policy='omit')
            np.testing.assert_allclose(res1, res2)
            np.testing.assert_allclose(res1, res3)
```

... or I didn't simplify because I got a little lazy 🙃

</details>
