### PR TITLE
ENH: optimize: linprog: improve HiGHS status/message handling

### DIFF
--- a/scipy/optimize/_linprog_highs.py
+++ b/scipy/optimize/_linprog_highs.py
@@ -75,8 +75,8 @@ def _highs_to_scipy_status_message(highs_status, highs_message):
         MODEL_STATUS_REACHED_ITERATION_LIMIT: (1, "Iteration limit reached. "),
         MODEL_STATUS_INFEASIBLE: (2, "The problem is infeasible. "),
         MODEL_STATUS_UNBOUNDED: (3, "The problem is unbounded. "),
-        MODEL_STATUS_UNBOUNDED_OR_INFEASIBLE: (4,
-            "The problem is unbounded or infeasible. ")}
+        MODEL_STATUS_UNBOUNDED_OR_INFEASIBLE: (4, "The problem is unbounded "
+                                               "or infeasible. ")}
     unrecognized = (4, "The HiGHS status code was not recognized. ")
     scipy_status, scipy_message = (
         scipy_statuses_messages.get(highs_status, unrecognized))

--- a/scipy/optimize/_linprog_highs.py
+++ b/scipy/optimize/_linprog_highs.py
@@ -57,9 +57,10 @@ from scipy.sparse import csc_matrix, vstack, issparse
 
 
 def _highs_to_scipy_status_message(highs_status, highs_message):
+    """Converts HiGHS status number/message to SciPy status number/message"""
 
     scipy_statuses_messages = {
-        None: (4, "HiGHS did not provide a status code."),
+        None: (4, "HiGHS did not provide a status code. "),
         MODEL_STATUS_NOTSET: (4, ""),
         MODEL_STATUS_LOAD_ERROR: (4, ""),
         MODEL_STATUS_MODEL_ERROR: (2, ""),
@@ -69,37 +70,18 @@ def _highs_to_scipy_status_message(highs_status, highs_message):
         MODEL_STATUS_MODEL_EMPTY: (4, ""),
         MODEL_STATUS_RDOVUB: (4, ""),
         MODEL_STATUS_REACHED_OBJECTIVE_TARGET: (4, ""),
-        MODEL_STATUS_OPTIMAL: (
-            0,
-            "Optimization terminated successfully. ",
-        ),
-        MODEL_STATUS_REACHED_TIME_LIMIT: (
-            1,
-            "Time limit reached. ",
-        ),
-        MODEL_STATUS_REACHED_ITERATION_LIMIT: (
-            1,
-            "Iteration limit reached. ",
-        ),
-        MODEL_STATUS_INFEASIBLE: (
-            2,
-            "The problem is infeasible. ",
-        ),
-        MODEL_STATUS_UNBOUNDED: (
-            3,
-            "The problem is unbounded. ",
-        ),
-        MODEL_STATUS_UNBOUNDED_OR_INFEASIBLE: (
-            4,
-            "The problem is unbounded or infeasible. ",
-        ),
-    }
-    unrecognized = "The HiGHS status code was not recognized. "
+        MODEL_STATUS_OPTIMAL: (0, "Optimization terminated successfully. "),
+        MODEL_STATUS_REACHED_TIME_LIMIT: (1, "Time limit reached. "),
+        MODEL_STATUS_REACHED_ITERATION_LIMIT: (1, "Iteration limit reached. "),
+        MODEL_STATUS_INFEASIBLE: (2, "The problem is infeasible. "),
+        MODEL_STATUS_UNBOUNDED: (3, "The problem is unbounded. "),
+        MODEL_STATUS_UNBOUNDED_OR_INFEASIBLE: (4,
+            "The problem is unbounded or infeasible. ")}
+    unrecognized = (4, "The HiGHS status code was not recognized. ")
     scipy_status, scipy_message = (
-        scipy_statuses_messages.get(highs_status, unrecognized)
-        )
+        scipy_statuses_messages.get(highs_status, unrecognized))
     scipy_message = (f"{scipy_message}"
-                     "(HiGHS Status {highs_status}: {highs_message})")
+                     f"(HiGHS Status {highs_status}: {highs_message})")
     return scipy_status, scipy_message
 
 

--- a/scipy/optimize/_linprog_highs.py
+++ b/scipy/optimize/_linprog_highs.py
@@ -56,6 +56,53 @@ from ._highs._highs_constants import (
 from scipy.sparse import csc_matrix, vstack, issparse
 
 
+def _highs_to_scipy_status_message(highs_status, highs_message):
+
+    scipy_statuses_messages = {
+        None: (4, "HiGHS did not provide a status code."),
+        MODEL_STATUS_NOTSET: (4, ""),
+        MODEL_STATUS_LOAD_ERROR: (4, ""),
+        MODEL_STATUS_MODEL_ERROR: (2, ""),
+        MODEL_STATUS_PRESOLVE_ERROR: (4, ""),
+        MODEL_STATUS_SOLVE_ERROR: (4, ""),
+        MODEL_STATUS_POSTSOLVE_ERROR: (4, ""),
+        MODEL_STATUS_MODEL_EMPTY: (4, ""),
+        MODEL_STATUS_RDOVUB: (4, ""),
+        MODEL_STATUS_REACHED_OBJECTIVE_TARGET: (4, ""),
+        MODEL_STATUS_OPTIMAL: (
+            0,
+            "Optimization terminated successfully. ",
+        ),
+        MODEL_STATUS_REACHED_TIME_LIMIT: (
+            1,
+            "Time limit reached. ",
+        ),
+        MODEL_STATUS_REACHED_ITERATION_LIMIT: (
+            1,
+            "Iteration limit reached. ",
+        ),
+        MODEL_STATUS_INFEASIBLE: (
+            2,
+            "The problem is infeasible. ",
+        ),
+        MODEL_STATUS_UNBOUNDED: (
+            3,
+            "The problem is unbounded. ",
+        ),
+        MODEL_STATUS_UNBOUNDED_OR_INFEASIBLE: (
+            4,
+            "The problem is unbounded or infeasible. ",
+        ),
+    }
+    unrecognized = "The HiGHS status code was not recognized. "
+    scipy_status, scipy_message = (
+        scipy_statuses_messages.get(highs_status, unrecognized)
+        )
+    scipy_message = (f"{scipy_message}"
+                     "(HiGHS Status {highs_status}: {highs_message})")
+    return scipy_status, scipy_message
+
+
 def _replace_inf(x):
     # Replace `np.inf` with CONST_INF
     infs = np.isinf(x)
@@ -284,77 +331,6 @@ def _linprog_highs(lp, solver, time_limit=None, presolve=True,
                  HIGHS_SIMPLEX_DUAL_EDGE_WEIGHT_STRATEGY_STEEPEST_EDGE,
                  None: None})
 
-    statuses = {
-        MODEL_STATUS_NOTSET: (
-            4,
-            f'HiGHS Status Code {MODEL_STATUS_NOTSET}: HighsModelStatusNOTSET',
-        ),
-        MODEL_STATUS_LOAD_ERROR: (
-            4,
-            f'HiGHS Status Code {MODEL_STATUS_LOAD_ERROR}: '
-            'HighsModelStatusLOAD_ERROR',
-        ),
-        MODEL_STATUS_MODEL_ERROR: (
-            2,
-            f'HiGHS Status Code {MODEL_STATUS_MODEL_ERROR}: '
-            'HighsModelStatusMODEL_ERROR',
-        ),
-        MODEL_STATUS_PRESOLVE_ERROR: (
-            4,
-            f'HiGHS Status Code {MODEL_STATUS_PRESOLVE_ERROR}: '
-            'HighsModelStatusPRESOLVE_ERROR',
-        ),
-        MODEL_STATUS_SOLVE_ERROR: (
-            4,
-            f'HiGHS Status Code {MODEL_STATUS_SOLVE_ERROR}: '
-            'HighsModelStatusSOLVE_ERROR',
-        ),
-        MODEL_STATUS_POSTSOLVE_ERROR: (
-            4,
-            f'HiGHS Status Code {MODEL_STATUS_POSTSOLVE_ERROR}: '
-            'HighsModelStatusPOSTSOLVE_ERROR',
-        ),
-        MODEL_STATUS_MODEL_EMPTY: (
-            4,
-            f'HiGHS Status Code {MODEL_STATUS_MODEL_EMPTY}: '
-            'HighsModelStatusMODEL_EMPTY',
-        ),
-        MODEL_STATUS_RDOVUB: (
-            4,
-            f'HiGHS Status Code {MODEL_STATUS_RDOVUB}: '
-            'HighsModelStatusREACHED_DUAL_OBJECTIVE_VALUE_UPPER_BOUND',
-        ),
-        MODEL_STATUS_REACHED_OBJECTIVE_TARGET: (
-            4,
-            f'HiGHS Status Code {MODEL_STATUS_REACHED_OBJECTIVE_TARGET}: '
-            'HighsModelStatusREACHED_OBJECTIVE_TARGET',
-        ),
-        MODEL_STATUS_INFEASIBLE: (
-            2,
-            "The problem is infeasible.",
-        ),
-        MODEL_STATUS_UNBOUNDED: (
-            3,
-            "The problem is unbounded.",
-        ),
-        MODEL_STATUS_UNBOUNDED_OR_INFEASIBLE: (
-            4,
-            "The problem is unbounded or infeasible.",
-        ),
-        MODEL_STATUS_OPTIMAL: (
-            0,
-            "Optimization terminated successfully.",
-        ),
-        MODEL_STATUS_REACHED_TIME_LIMIT: (
-            1,
-            "Time limit reached.",
-        ),
-        MODEL_STATUS_REACHED_ITERATION_LIMIT: (
-            1,
-            "Iteration limit reached.",
-        ),
-    }
-
     c, A_ub, b_ub, A_eq, b_eq, bounds, x0, integrality = lp
 
     lb, ub = bounds.T.copy()  # separate bounds, copy->C-cntgs
@@ -430,7 +406,10 @@ def _linprog_highs(lp, solver, time_limit=None, presolve=True,
     solvers = {"ipm": "highs-ipm", "simplex": "highs-ds", None: "highs-ds"}
 
     # Convert to scipy-style status and message
-    status, message = statuses[res['status']]
+    highs_status = res.get('status', None)
+    highs_message = res.get('message', None)
+    status, message = _highs_to_scipy_status_message(highs_status,
+                                                     highs_message)
 
     x = np.array(res['x']) if 'x' in res else None
     sol = {'x': x,

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -289,11 +289,11 @@ def test_choose_solver():
     _assert_success(res, desired_fun=-18.0, desired_x=[2, 6])
 
 
-def test_highs_status_message(self):
+def test_highs_status_message():
     res = linprog(1, method='highs')
-    msg = "Optimization terminated successfully. (HiGHS Status 7:..."
+    msg = "Optimization terminated successfully. (HiGHS Status 7:"
     assert res.status == 0
-    assert res.message == msg
+    assert res.message.startswith(msg)
 
     A, b, c, numbers, M = magic_square(6)
     bounds = [(0, 1)] * len(c)
@@ -301,26 +301,37 @@ def test_highs_status_message(self):
     options = {"time_limit": 0.1}
     res = linprog(c=c, A_eq=A, b_eq=b, bounds=bounds, method='highs',
                   options=options, integrality=integrality)
-    msg = "Time limit reached.  (HiGHS Status 7:..."
+    msg = "Time limit reached. (HiGHS Status 13:"
     assert res.status == 1
-    assert res.message == msg
+    assert res.message.startswith(msg)
 
     options = {"maxiter": 10}
-    res = linprog(c=c, A_eq=A, b_eq=b, bounds=bounds, method='highs',
-                  options=options, integrality=integrality)
-    msg = "Iteration limit reached.  (HiGHS Status 7:..."
+    res = linprog(c=c, A_eq=A, b_eq=b, bounds=bounds, method='highs-ds',
+                  options=options)
+    msg = "Iteration limit reached. (HiGHS Status 14:"
     assert res.status == 1
-    assert res.message == msg
+    assert res.message.startswith(msg)
 
     res = linprog(1, bounds=(1, -1), method='highs')
-    msg = "The problem is infeasible. (HiGHS Status 7:..."
+    msg = "The problem is infeasible. (HiGHS Status 8:"
     assert res.status == 2
-    assert res.message == msg
+    assert res.message.startswith(msg)
 
     res = linprog(-1, method='highs')
-    msg = "The problem is unbounded. (HiGHS Status 7:..."
+    msg = "The problem is unbounded. (HiGHS Status 10:"
     assert res.status == 3
-    assert res.message == msg
+    assert res.message.startswith(msg)
+
+    from scipy.optimize._linprog_highs import _highs_to_scipy_status_message
+    status, message = _highs_to_scipy_status_message(58, "Hello!")
+    msg = "The HiGHS status code was not recognized. (HiGHS Status 58:"
+    assert status == 4
+    assert message.startswith(msg)
+
+    status, message = _highs_to_scipy_status_message(None, None)
+    msg = "HiGHS did not provide a status code. (HiGHS Status None: None)"
+    assert status == 4
+    assert message.startswith(msg)
 
 
 A_ub = None

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -1238,7 +1238,9 @@ class LinprogCommonTests:
         assert_(res.success)
         assert_(res.nit)
         assert_(not res.status)
-        assert_(res.message == "Optimization terminated successfully.")
+        if 'highs' not in self.method:
+            # HiGHS status/message tested separately
+            assert_(res.message == "Optimization terminated successfully.")
         assert_allclose(c @ res.x, res.fun)
         assert_allclose(b_eq - A_eq @ res.x, res.con, atol=1e-11)
         assert_allclose(b_ub - A_ub @ res.x, res.slack, atol=1e-11)

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -289,6 +289,40 @@ def test_choose_solver():
     _assert_success(res, desired_fun=-18.0, desired_x=[2, 6])
 
 
+def test_highs_status_message(self):
+    res = linprog(1, method='highs')
+    msg = "Optimization terminated successfully. (HiGHS Status 7:..."
+    assert res.status == 0
+    assert res.message == msg
+
+    A, b, c, numbers, M = magic_square(6)
+    bounds = [(0, 1)] * len(c)
+    integrality = [1] * len(c)
+    options = {"time_limit": 0.1}
+    res = linprog(c=c, A_eq=A, b_eq=b, bounds=bounds, method='highs',
+                  options=options, integrality=integrality)
+    msg = "Time limit reached.  (HiGHS Status 7:..."
+    assert res.status == 1
+    assert res.message == msg
+
+    options = {"maxiter": 10}
+    res = linprog(c=c, A_eq=A, b_eq=b, bounds=bounds, method='highs',
+                  options=options, integrality=integrality)
+    msg = "Iteration limit reached.  (HiGHS Status 7:..."
+    assert res.status == 1
+    assert res.message == msg
+
+    res = linprog(1, bounds=(1, -1), method='highs')
+    msg = "The problem is infeasible. (HiGHS Status 7:..."
+    assert res.status == 2
+    assert res.message == msg
+
+    res = linprog(-1, method='highs')
+    msg = "The problem is unbounded. (HiGHS Status 7:..."
+    assert res.status == 3
+    assert res.message == msg
+
+
 A_ub = None
 b_ub = None
 A_eq = None


### PR DESCRIPTION
#### Reference issue
gh-15460

#### What does this implement/fix?
As discussed [here](https://github.com/scipy/scipy/pull/15460#pullrequestreview-860522995), this refactors and improves the status code / message handling of `linprog` with `method='highs'`. A new private function `_highs_to_scipy_status_message" maps HiGHS status codes to their SciPy equivalents, and now the complete HiGHS code and message is appended to the SciPy message, e.g.
```python3
from scipy.optimize import linprog
res = linprog(1, method='highs')
res.status  # 0
res.message  # 'Optimization terminated successfully. (HiGHS Status 7: Optimal)'