### PR TITLE
MAINT: prepare for SciPy 1.8.0rc4

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,14 +8,10 @@
 	path = scipy/_lib/boost
 	url = https://github.com/scipy/boost-headers-only
 	shallow = true
-	active = false
-	ignore = all
 [submodule "scipy/sparse/linalg/_propack/PROPACK"]
 	path = scipy/sparse/linalg/_propack/PROPACK
 	url = https://github.com/scipy/PROPACK
 	shallow = true
-	active = false
-	ignore = all
 [submodule "scipy/_lib/unuran"]
 	path = scipy/_lib/unuran
 	url = https://github.com/scipy/unuran.git

--- a/doc/release/1.8.0-notes.rst
+++ b/doc/release/1.8.0-notes.rst
@@ -559,6 +559,7 @@ Issues closed for 1.8.0
 * `#15228 <https://github.com/scipy/scipy/issues/15228>`__: BUG: bounded L-BFGS-B doesn't work with a scalar.
 * `#15254 <https://github.com/scipy/scipy/issues/15254>`__: BUG: \`DeprecationWarning: distutils Version classes are deprecated\`
 * `#15267 <https://github.com/scipy/scipy/issues/15267>`__: Windows CI jobs have a build issue with Pythran 0.11
+* `#15276 <https://github.com/scipy/scipy/issues/15276>`__: Boost and PROPACK git submodules are too easy to commit changes...
 * `#15316 <https://github.com/scipy/scipy/issues/15316>`__: BUG: Failed to install scipy 1.7.x with pypy 3.7 in aarch64
 * `#15339 <https://github.com/scipy/scipy/issues/15339>`__: BUG: \`highs-ds\` returns memoryviews instead of np.arrays for...
 * `#15375 <https://github.com/scipy/scipy/issues/15375>`__: BUG: axis argument to scipy.stats.mode does not accept negative...
@@ -945,6 +946,7 @@ Pull requests for 1.8.0
 * `#15270 <https://github.com/scipy/scipy/pull/15270>`__: MAINT: rename \`moduleTNC\` extension back to \`_moduleTNC\`
 * `#15271 <https://github.com/scipy/scipy/pull/15271>`__: TST: slightly bump test tolerance for a new lobpcg test
 * `#15275 <https://github.com/scipy/scipy/pull/15275>`__: MAINT: Fix imports in \`signal._signaltools\`
+* `#15278 <https://github.com/scipy/scipy/pull/15278>`__: MAINT: remove non-default settings (except \`shallow\`) in \`.gitmodules\`
 * `#15288 <https://github.com/scipy/scipy/pull/15288>`__: BLD Respect the --skip-build flag in setup.py
 * `#15293 <https://github.com/scipy/scipy/pull/15293>`__: BUG: fix Hausdorff int overflow
 * `#15301 <https://github.com/scipy/scipy/pull/15301>`__: TST: update \`sparse.linalg\` tests for failures due to tolerances

--- a/doc/release/1.8.0-notes.rst
+++ b/doc/release/1.8.0-notes.rst
@@ -555,13 +555,13 @@ Issues closed for 1.8.0
 * `#15103 <https://github.com/scipy/scipy/issues/15103>`__: BUG: scipy.stats.chi.mean returns nan for large df due to use...
 * `#15186 <https://github.com/scipy/scipy/issues/15186>`__: Fix use of \`pytest.warns(None)\` for pytest 7.0.0
 * `#15206 <https://github.com/scipy/scipy/issues/15206>`__: BUG: Minor issue with suggestions in scipy.sparse DeprecationWarnings...
-* `#15210 <https://github.com/scipy/scipy/issues/15210>`__: BUG: A sparse matrix raises a ValueError when \`__rmul__\` with...
 * `#15224 <https://github.com/scipy/scipy/issues/15224>`__: BUG: 0th power of sparse array/matrix always returns the identity...
 * `#15228 <https://github.com/scipy/scipy/issues/15228>`__: BUG: bounded L-BFGS-B doesn't work with a scalar.
 * `#15254 <https://github.com/scipy/scipy/issues/15254>`__: BUG: \`DeprecationWarning: distutils Version classes are deprecated\`
 * `#15267 <https://github.com/scipy/scipy/issues/15267>`__: Windows CI jobs have a build issue with Pythran 0.11
 * `#15316 <https://github.com/scipy/scipy/issues/15316>`__: BUG: Failed to install scipy 1.7.x with pypy 3.7 in aarch64
 * `#15339 <https://github.com/scipy/scipy/issues/15339>`__: BUG: \`highs-ds\` returns memoryviews instead of np.arrays for...
+* `#15375 <https://github.com/scipy/scipy/issues/15375>`__: BUG: axis argument to scipy.stats.mode does not accept negative...
 
 ***********************
 Pull requests for 1.8.0
@@ -938,6 +938,7 @@ Pull requests for 1.8.0
 * `#15232 <https://github.com/scipy/scipy/pull/15232>`__: BUG: Add rmul for sparse arrays
 * `#15236 <https://github.com/scipy/scipy/pull/15236>`__: BLD: update setup.py for Python 3.10
 * `#15248 <https://github.com/scipy/scipy/pull/15248>`__: MAINT: 1.8.0rc2 backports
+* `#15249 <https://github.com/scipy/scipy/pull/15249>`__: FIX: PROPACK MKL compatibility
 * `#15253 <https://github.com/scipy/scipy/pull/15253>`__: BUG: special: fix \`stdtr\` and \`stdtrit\` for infinite df
 * `#15256 <https://github.com/scipy/scipy/pull/15256>`__: MAINT: use PEP440 vs. distutils
 * `#15268 <https://github.com/scipy/scipy/pull/15268>`__: CI: pin setuptools to 59.6.0 and Pythran to 0.10.0 for Windows...
@@ -958,4 +959,7 @@ Pull requests for 1.8.0
 * `#15341 <https://github.com/scipy/scipy/pull/15341>`__: BUG: \`highs-ds\` returns memoryviews instead of np.arrays for...
 * `#15397 <https://github.com/scipy/scipy/pull/15397>`__: BUG: ensured vendored pep440 is imported
 * `#15416 <https://github.com/scipy/scipy/pull/15416>`__: BUG: Fix PyUFunc for wasm targets
+* `#15418 <https://github.com/scipy/scipy/pull/15418>`__: MAINT: 1.8.0 rc3 backports round 1
+* `#15421 <https://github.com/scipy/scipy/pull/15421>`__: BUG: stats: mode: fix negative axis issue with np.moveaxis instead...
+* `#15432 <https://github.com/scipy/scipy/pull/15432>`__: MAINT: release branch PROPACK switch (default off)
 

--- a/scipy/sparse/linalg/_propack/setup.py
+++ b/scipy/sparse/linalg/_propack/setup.py
@@ -17,15 +17,23 @@ def check_propack_submodule():
 def configuration(parent_package='', top_path=None):
     from numpy.distutils.system_info import get_info, NotFoundError
     from numpy.distutils.misc_util import Configuration
-    config = Configuration('_propack', parent_package, top_path)
+    from scipy._build_utils import (gfortran_legacy_flag_hook,
+                                    get_g77_abi_wrappers,
+                                    needs_g77_abi_wrapper)
+
     lapack_opt = get_info('lapack_opt')
+    pre_build_hook = gfortran_legacy_flag_hook
+    f2py_options = None
+
     if not lapack_opt:
         raise NotFoundError('no lapack/blas resources found')
+
+    config = Configuration('_propack', parent_package, top_path)
 
     #  ------------------------------------------------------------
     #  Set up the libraries.
     #  We need a different python extension file for each, because
-    #  names resue between functions in the LAPACK extensions.  This
+    #  names reuse between functions in the LAPACK extensions.  This
     #  could probably be remedied with some work.
     #  NOTES: this might not longer apply now that we build without
     #         LAPACK extensions
@@ -38,30 +46,36 @@ def configuration(parent_package='', top_path=None):
     for prefix, directory in type_dict.items():
         propack_lib = f'_{prefix}propack'
 
-        # Need to use risc implementation for 32-bit machines
-        if _is_32bit:
-            src = list((pathlib.Path(
-                __file__).parent / 'PROPACK' / directory).glob('*.F'))
+        # Use risc msg implementation for 64-bit machines, pentium for 32-bit
+        src = list((pathlib.Path(
+            __file__).parent / 'PROPACK' / directory).glob('*.F'))
+        if _is_32bit():
+            # don't ask me why, 32-bit blows up without second.F
             src = [str(p) for p in src if 'risc' not in str(p)]
         else:
-            src = join('PROPACK', directory, '*.F')
+            src = [str(p) for p in src
+                   if 'pentium' not in str(p) and 'second' not in str(p)]
+
+        if not _is_32bit():
+            # don't ask me why, 32-bit blows up with this wrapper
+            src += get_g77_abi_wrappers(lapack_opt)
+
+        cmacros = [('_OPENMP',)]
+        if needs_g77_abi_wrapper(lapack_opt):
+            cmacros += [('SCIPY_USE_G77_CDOTC_WRAP', 1)]
 
         config.add_library(propack_lib,
                            sources=src,
-                           macros=[('_OPENMP',)])
-        config.add_extension(f'_{prefix}propack',
-                             sources=f'{prefix}propack.pyf',
-                             libraries=[propack_lib],
-                             extra_info=lapack_opt,
-                             undef_macros=['_OPENMP'])
-
-        # add required data files to run example matrix tests
-        path_list = ['PROPACK', directory, 'Examples']
-        config.add_data_files('.', join(*path_list, '*.coord'))
-        config.add_data_files('.', join(*path_list, '*.diag'))
-        config.add_data_files('.', join(*path_list, '*.rra'))
-        config.add_data_files('.', join(*path_list, '*.cua'))
-        config.add_data_files('.', join(*path_list, 'Output', '*.ascii'))
+                           macros=cmacros,
+                           depends=['setup.py'])
+        ext = config.add_extension(f'_{prefix}propack',
+                                   sources=f'{prefix}propack.pyf',
+                                   libraries=[propack_lib],
+                                   extra_info=lapack_opt,
+                                   undef_macros=['_OPENMP'],
+                                   f2py_options=f2py_options,
+                                   depends=['setup.py'] + src)
+        ext._pre_build_hook = pre_build_hook
 
     return config
 

--- a/scipy/sparse/linalg/tests/test_propack.py
+++ b/scipy/sparse/linalg/tests/test_propack.py
@@ -8,6 +8,9 @@ from pytest import raises as assert_raises
 from scipy.sparse.linalg._svdp import _svdp
 from scipy.sparse import csr_matrix, csc_matrix, coo_matrix
 
+if not os.environ.get("USE_PROPACK"):
+    pytestmark = pytest.mark.skip("USE_PROPACK not set")
+
 TOLS = {
     np.float32: 1e-4,
     np.float64: 1e-8,

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -442,8 +442,7 @@ def mode(a, axis=0, nan_policy='propagate'):
     # casting types in the process.
     # This recreates the results without that issue
     # View of a, rotated so the requested axis is last
-    in_dims = list(range(a.ndim))
-    a_view = np.transpose(a, in_dims[:axis] + in_dims[axis+1:] + [axis])
+    a_view = np.moveaxis(a, axis, -1)
 
     inds = np.ndindex(a_view.shape[:-1])
     modes = np.empty(a_view.shape[:-1], dtype=a.dtype)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2167,6 +2167,14 @@ class TestMode:
         assert_equal(vals[0], np.array([[10], [10], [20], [30], [30]]))
         assert_equal(vals[1], np.array([[2], [4], [3], [4], [3]]))
 
+    @pytest.mark.parametrize('axis', np.arange(-4, 0))
+    def test_negative_axes_gh_15375(self, axis):
+        np.random.seed(984213899)
+        a = np.random.rand(10, 11, 12, 13)
+        res0 = stats.mode(a, axis=a.ndim+axis)
+        res1 = stats.mode(a, axis=axis)
+        np.testing.assert_array_equal(res0, res1)
+
     def test_strings(self):
         data1 = ['rain', 'showers', 'showers']
         vals = stats.mode(data1)


### PR DESCRIPTION
* backport the two merged PRs with a backport label

* this needs to fix the remaining conda-forge PROPACK issues

* @mckib2 I don't see a submodule change here? was the maintenance branch already ahead of `main` in that regard? Not sure I fully trust current submodule settings/situation, so good to double check we have the right submodule commit in use here (seems to be the latest one you can get locally).

* cc @h-vetinari 

* I'm still slightly confused about how PROPACK related issues could remain at this point--my objective was to turn off (skip) *all* propack related tests in rc3 with the env variable--I still think some are not getting skipped properly as I noted in the rc3 backport PR