### PR TITLE
Make bounds test for shgo stronger

### DIFF
--- a/scipy/optimize/tests/test__shgo.py
+++ b/scipy/optimize/tests/test__shgo.py
@@ -652,7 +652,7 @@ class TestShgoArguments:
     def test_18_bounds_class(self):
         # test that new and old bounds yield same result
         def f(x):
-            return np.square(x).sum()
+            return numpy.square(x).sum()
 
         lb = [-6., 1., -5.]
         ub = [-1., 3., 5.]

--- a/scipy/optimize/tests/test__shgo.py
+++ b/scipy/optimize/tests/test__shgo.py
@@ -665,7 +665,7 @@ class TestShgoArguments:
         assert res_new_bounds.nfev == res_old_bounds.nfev
         assert res_new_bounds.message == res_old_bounds.message
         assert res_new_bounds.success == res_old_bounds.success
-        x_opt = numpy.array([-1., 1., 0])
+        x_opt = numpy.array([-1., 1., 0.])
         numpy.testing.assert_allclose(res_new_bounds.x, x_opt)
         numpy.testing.assert_allclose(res_new_bounds.x,
                                       res_old_bounds.x)

--- a/scipy/optimize/tests/test__shgo.py
+++ b/scipy/optimize/tests/test__shgo.py
@@ -652,9 +652,10 @@ class TestShgoArguments:
     def test_18_bounds_class(self):
         # test that new and old bounds yield same result
         def f(x):
-            return x[0] ** 2 + x[1] ** 2
-        lb = [-6., -6.]
-        ub = [0., 0.]
+            return np.square(x).sum()
+
+        lb = [-6., 1., -5.]
+        ub = [-1., 3., 5.]
         bounds_old = list(zip(lb, ub))
         bounds_new = Bounds(lb, ub)
 

--- a/scipy/optimize/tests/test__shgo.py
+++ b/scipy/optimize/tests/test__shgo.py
@@ -665,6 +665,8 @@ class TestShgoArguments:
         assert res_new_bounds.nfev == res_old_bounds.nfev
         assert res_new_bounds.message == res_old_bounds.message
         assert res_new_bounds.success == res_old_bounds.success
+        x_opt = numpy.array([-1., 1., 0])
+        numpy.testing.assert_allclose(res_new_bounds.x, x_opt)
         numpy.testing.assert_allclose(res_new_bounds.x,
                                       res_old_bounds.x)
 


### PR DESCRIPTION
#### Reference issue
In #15455 it was mentioned that the current test for the bounds class is not really strong. It can be improved by changing the bounds so that the global minimum does not lie within the feasible region anymore. This way any effect of the bounds on the solution can be thoroughly tested.

#### Additional information
A very similar test was applied in #15453 for ``dual_annealing``
