### PR TITLE
DOC: signal: fixed parameter 'order' for butter bandpass

### DIFF
--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -2942,9 +2942,10 @@ def butter(N, Wn, btype='low', analog=False, output='ba', fs=None):
     Parameters
     ----------
     N : int
-        The order of the filter. For bandpass filters, the resulting order
-        of the final sos matrix is 2*N, so N represents the number of
-        biquad sections of the desired system.
+        The order of the filter. For 'bandpass' and 'bandstop' filters,
+        the resulting order of the final second-order sections ('sos')
+        matrix is ``2*N``, with `N` the number of biquad sections
+        of the desired system.
     Wn : array_like
         The critical frequency or frequencies. For lowpass and highpass
         filters, Wn is a scalar; for bandpass and bandstop filters,

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -2942,7 +2942,9 @@ def butter(N, Wn, btype='low', analog=False, output='ba', fs=None):
     Parameters
     ----------
     N : int
-        The order of the filter.
+        The order of the filter. For bandpass filters, the resulting order
+        of the final sos matrix is 2*N, so N represents the number of
+        biquad sections of the desired system.
     Wn : array_like
         The critical frequency or frequencies. For lowpass and highpass
         filters, Wn is a scalar; for bandpass and bandstop filters,


### PR DESCRIPTION
Based on discussion [here](https://dsp.stackexchange.com/questions/81285/sos-matrices-order-does-not-correspond-to-given-parameter-when-designing-bandpa)

A given order should represent what the final system's order actually is, not twice that for bandpass filters. The current doc fix explains that a given order `N` for a butterworth bandpass will result in a sos-matrix of order 2*N.

Closes #15492 