### PR TITLE
CI: remove matplotlib from 32-bit linux job, it fails to build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -172,7 +172,7 @@ stages:
             curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
             python3.8 get-pip.py && \
             pip3 --version && \
-            pip3 install setuptools==59.6.0 wheel numpy==1.18.5 cython==0.29.18 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath matplotlib==3.1.3 pythran==0.10.0 --user && \
+            pip3 install setuptools==59.6.0 wheel numpy==1.18.5 cython==0.29.18 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath pythran==0.10.0 --user && \
             apt-get -y install gcc-5 g++-5 gfortran-8 wget && \
             cd .. && \
             mkdir openblas && cd openblas && \


### PR DESCRIPTION
This was a pinned release, and building Matplotlib from source was working 3 days ago but no longer does. It looks like a bug in Pip 22.0 which was released 2 days ago.

We don't really need Matplotlib in this job, we only have a couple of tests that actually need Matplotlib and those get skipped if it's not installed. Building Matplotlib from source doesn't really make sense here. So let's not do that - will speed up CI a bit as well.

Closes gh-15498

[skip github]