### PR TITLE
MAINT: pin setuptools in azure template

### DIFF
--- a/ci/azure-travis-template.yaml
+++ b/ci/azure-travis-template.yaml
@@ -64,7 +64,7 @@ steps:
   displayName: 'Add ccache to path'
 - script: >-
     pip install --upgrade ${{parameters.numpy_spec}} &&
-    pip install --upgrade pip==20.2.4 setuptools wheel &&
+    pip install --upgrade pip==20.2.4 setuptools==59.6.0 wheel &&
     pip install ${{parameters.other_spec}}
     cython
     gmpy2


### PR DESCRIPTION
Setuptool causing issues on azure with Python 3.8 job. The template version is not pinning hence we see the latest being installed although we specify something else in the job.

Ex. https://dev.azure.com/scipy-org/SciPy/_build/results?buildId=16304&view=logs&jobId=e3555eda-5afc-5d78-d2e9-cf9756f98375&j=e3555eda-5afc-5d78-d2e9-cf9756f98375&t=220e105d-2d02-5073-9f3b-414490a3ddd5

```python-stacktrace
RuntimeError: Setuptools version is '60.6.0', version < '60.0.0' is required. See pyproject.toml
```