### PR TITLE
MAINT: Remove unused variable warnings

### DIFF
--- a/scipy/_build_utils/src/wrap_g77_abi_f.f
+++ b/scipy/_build_utils/src/wrap_g77_abi_f.f
@@ -36,7 +36,6 @@
 
       COMPLEX FUNCTION WCLADIV( X, Y )
       COMPLEX            X, Y
-      COMPLEX            Z
       EXTERNAL SLADIV
       INTRINSIC          AIMAG, CMPLX, REAL
       REAL               ZI, ZR
@@ -47,7 +46,6 @@
 
       DOUBLE COMPLEX FUNCTION WZLADIV( X, Y )
       DOUBLE COMPLEX     X, Y
-      DOUBLE COMPLEX     Z
       EXTERNAL DLADIV
       INTRINSIC          DBLE, DCMPLX, DIMAG
       DOUBLE PRECISION   ZI, ZR


### PR DESCRIPTION
Fixes following warnings:
```
../scipy/_build_utils/src/wrap_g77_abi_f.f:39:26:

   39 |       COMPLEX            Z
      |                          1
Warning: Unused variable 'z' declared at (1) [-Wunused-variable]
../scipy/_build_utils/src/wrap_g77_abi_f.f:50:26:

   50 |       DOUBLE COMPLEX     Z
      |                          1
Warning: Unused variable 'z' declared at (1) [-Wunused-variable]
```
cc @rgommers 
