### PR TITLE
DEV: meson: allow specifying build directory and install prefix

### DIFF
--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -16,7 +16,7 @@ on:
 
 env:
   CCACHE_DIR: "${{ github.workspace }}/.ccache"
-  INSTALLDIR: "installdir"
+  INSTALLDIR: "build-install"
 
 jobs:
   test_meson:

--- a/.github/workflows/macos_meson.yml
+++ b/.github/workflows/macos_meson.yml
@@ -11,7 +11,7 @@ on:
       - maintenance/**
 
 env:
-  INSTALLDIR: "installdir"
+  INSTALLDIR: "build-install"
   CCACHE_DIR: "${{ github.workspace }}/.ccache"
 
 jobs:

--- a/dev.py
+++ b/dev.py
@@ -414,7 +414,7 @@ def setup_build(args, env):
         if len(os.listdir(build_dir)):
             raise RuntimeError("Can't build into non-empty directory "
                                f"'{str(build_dir.absolute())}'")
-    else:
+    if os.path.exists(build_dir):
         build_options_file = (build_dir / "meson-info"
                               / "intro-buildoptions.json")
         with open(build_options_file) as f:

--- a/dev.py
+++ b/dev.py
@@ -409,6 +409,7 @@ def setup_build(args, env):
     """
     cmd = ["meson", "setup", args.build_dir, "--prefix", PATH_INSTALLED]
     build_dir = Path(args.build_dir)
+    run_dir = os.getcwd()
     if build_dir.exists() and not (build_dir / 'meson-info').exists():
         if list(build_dir.iterdir()):
             raise RuntimeError("Can't build into non-empty directory "
@@ -424,13 +425,14 @@ def setup_build(args, env):
                 installdir = option["value"]
                 break
         if installdir != PATH_INSTALLED:
-            cmd += ["--reconfigure"]
+            run_dir = os.path.join(run_dir, build_dir)
+            cmd = ["meson", "--reconfigure", "--prefix", PATH_INSTALLED]
         else:
             return
     if args.werror:
         cmd += ["--werror"]
     # Setting up meson build
-    ret = subprocess.call(cmd, env=env, cwd=ROOT_DIR)
+    ret = subprocess.call(cmd, env=env, cwd=run_dir)
     if ret == 0:
         print("Meson build setup OK")
     else:

--- a/dev.py
+++ b/dev.py
@@ -69,7 +69,7 @@ import subprocess
 import time
 import datetime
 import importlib.util
-import json
+import json  # noqa: E402
 from sysconfig import get_path
 
 try:

--- a/dev.py
+++ b/dev.py
@@ -409,7 +409,12 @@ def setup_build(args, env):
     """
     cmd = ["meson", "setup", args.build_dir, "--prefix", PATH_INSTALLED]
     build_dir = Path(args.build_dir)
-    if os.path.exists(build_dir / 'build.ninja'):
+    if (os.path.exists(build_dir) and not os.path.exists(build_dir
+                                                         / 'meson-info')):
+        if len(os.listdir(build_dir)):
+            raise RuntimeError("Can't build into non-empty directory "
+                               f"'{str(build_dir.absolute())}'")
+    else:
         build_options_file = (build_dir / "meson-info"
                               / "intro-buildoptions.json")
         with open(build_options_file) as f:
@@ -439,6 +444,12 @@ def install_project(args):
     """
     Installs the project after building.
     """
+    if os.path.exists(PATH_INSTALLED):
+        installdir = get_site_packages()
+        non_empty = len(os.listdir(PATH_INSTALLED))
+        if non_empty and not os.path.exists(installdir):
+            raise RuntimeError("Can't install in non-empty directory: "
+                               f"'{PATH_INSTALLED}'")
     cmd = ["meson", "install", "-C", args.build_dir]
     log_filename = os.path.join(ROOT_DIR, 'meson-install.log')
     start_time = datetime.datetime.now()

--- a/dev.py
+++ b/dev.py
@@ -409,11 +409,10 @@ def setup_build(args, env):
     """
     cmd = ["meson", "setup", args.build_dir, "--prefix", PATH_INSTALLED]
     build_dir = Path(args.build_dir)
-    if (os.path.exists(build_dir) and not os.path.exists(build_dir
-                                                         / 'meson-info')):
-        if len(os.listdir(build_dir)):
+    if build_dir.exists() and not (build_dir / 'meson-info').exists():
+        if list(build_dir.iterdir()):
             raise RuntimeError("Can't build into non-empty directory "
-                               f"'{str(build_dir.absolute())}'")
+                               f"'{build_dir.absolute()}'")
     if os.path.exists(build_dir):
         build_options_file = (build_dir / "meson-info"
                               / "intro-buildoptions.json")


### PR DESCRIPTION
#### Reference issue

NA

#### What does this implement/fix?

Allow specifying the build directory and install prefix when building with meson using `dev.py`. I like to have separate build and install folders when working with debug builds and builds with different versions of Python/NumPy. It would be nice to be able to specify the paths using `dev.py`. These changes allow such options:

```
python dev.py --build-dir builddir --install-prefix installdir --build-only -j12
```

#### Additional information

NA