### PR TITLE
ENH: stats: add `friston` and `nichols` methods to `combine_pvalues`

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8157,8 +8157,8 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
           * 'stouffer': Stouffer's Z-score method
           * 'mudholkar_george': the difference of Fisher's and Pearson's methods
             divided by 2
-          * 'friston': Friston's method (maximum of p-values to the power of the
-            number of p-values)
+          * 'friston': Friston's method (maximum of p-values to the power of
+            the number of p-values)
           * 'nichols': Nichols' method (maximum of p-values)
     weights : array_like, 1-D, optional
         Optional array of weights used only for Stouffer's Z-score method.
@@ -8213,8 +8213,8 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
            for combining probabilities in meta-analysis." Journal of
            Evolutionary Biology 24, no. 8 (2011): 1836-1841.
     .. [7] https://en.wikipedia.org/wiki/Extensions_of_Fisher%27s_method
-    .. [8] Nichols, T., et al. "Valid conjunction inference with the minimum statistic."
-           Neuroimage 25, no. 3 (2005): 653-60.
+    .. [8] Nichols, T., et al. "Valid conjunction inference with the minimum
+           statistic." Neuroimage 25, no. 3 (2005): 653-60.
     .. [9] Friston, K.J., et al. "Multisubject fMRI studies and conjunction
            analyses." Neuroimage 10, no. 4 (1999): 385-96.
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -6615,6 +6615,14 @@ class TestCombinePvalues:
         # 0.5 here is because logistic = log(u) - log(1-u), i.e. no 2 factors
         assert_approx_equal(0.5 * (Z_f-Z_p), Z, significant=4)
 
+    def test_friston(self):
+        Z, p = stats.combine_pvalues([.01, .2, .3], method='friston')
+        assert_approx_equal(p, 0.027, significant=4)
+
+    def test_nichols(self):
+        Z, p = stats.combine_pvalues([.01, .2, .3], method='nichols')
+        assert_approx_equal(p, 0.3, significant=4)
+
 
 class TestCdfDistanceValidation:
     """


### PR DESCRIPTION
#### Reference issue
Closes #15481

#### What does this implement/fix?
This commit adds two new methods to combine p-values derived from
multiple independent tests of the same hypothesis. Citations of
literature have been added to the doc string and the methods are
covered by new tests. See #15481.

