### PR TITLE
MAINT: fix broken link and remove CI badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,23 +7,14 @@
       </h1>
     </p>
 
-.. image:: https://img.shields.io/circleci/project/github/scipy/scipy/main.svg?label=CircleCI
-  :target: https://circleci.com/gh/scipy/scipy
-
-.. image:: https://dev.azure.com/scipy-org/SciPy/_apis/build/status/scipy.scipy?branchName=main
-  :target: https://dev.azure.com/scipy-org/SciPy/_build/latest?definitionId=1?branchName=main
-
-.. image:: https://github.com/scipy/scipy/workflows/macOS%20tests/badge.svg?branch=main
-  :target: https://github.com/scipy/scipy/actions?query=workflow%3A%22macOS+tests%22
+.. image:: https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A
+  :target: https://numfocus.org
 
 .. image:: https://img.shields.io/pypi/dm/scipy.svg?label=Pypi%20downloads
   :target: https://pypi.org/project/scipy/
 
 .. image:: https://img.shields.io/conda/dn/conda-forge/scipy.svg?label=Conda%20downloads
   :target: https://anaconda.org/conda-forge/scipy
-
-.. image:: https://codecov.io/gh/scipy/scipy/branch/main/graph/badge.svg
-  :target: https://codecov.io/gh/scipy/scipy
 
 .. image:: https://img.shields.io/badge/stackoverflow-Ask%20questions-blue.svg
   :target: https://stackoverflow.com/questions/tagged/scipy
@@ -38,7 +29,7 @@ ODE solvers, and more.
 
 - **Website:** https://scipy.org
 - **Documentation:** https://docs.scipy.org/
-- **Mailing list:** https://scipy.org/mailing-lists/
+- **Mailing list:** https://mail.python.org/mailman3/lists/scipy-dev.python.org/
 - **Source code:** https://github.com/scipy/scipy
 - **Contributing:** https://scipy.github.io/devdocs/dev/index.html
 - **Bug reports:** https://github.com/scipy/scipy/issues
@@ -83,6 +74,3 @@ comment on a relevant issue that is already open.
 If you are new to contributing to open source, `this
 guide <https://opensource.guide/how-to-contribute/>`__ helps explain why, what,
 and how to get involved.
-
-.. image:: https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A
-  :target: https://numfocus.org

--- a/doc/source/dev/gitwash/git_links.inc
+++ b/doc/source/dev/gitwash/git_links.inc
@@ -64,5 +64,5 @@
 .. _`NumPy mailing list`: https://numpy.org/community/
 .. _SciPy: https://www.scipy.org
 .. _`SciPy github`: https://github.com/scipy/scipy
-.. _`SciPy mailing list`: https://scipy.org/mailing-lists/
+.. _`SciPy mailing list`: https://mail.python.org/mailman3/lists/scipy-dev.python.org/
 .. _`SciPy repository`: https://github.com/scipy/scipy

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -15,7 +15,7 @@ SciPy documentation
 `Source Repository <https://github.com/scipy/scipy>`__ |
 `Issues & Ideas <https://github.com/scipy/scipy/issues>`__ |
 `Q&A Support <https://stackoverflow.com/questions/tagged/scipy>`__ |
-`Mailing List <https://scipy.org/mailing-lists>`__
+`Mailing List <https://mail.python.org/mailman3/lists/scipy-dev.python.org/>`__
 
 **SciPy** (pronounced "Sigh Pie") is an open-source software for mathematics,
 science, and engineering.


### PR DESCRIPTION
Mailing list URL has changed and removes CI badges (following NumPy). It does not give any real information and having it red sometimes is at most scary for untrained eyes although the releases are perfectly fine.