### PR TITLE
MAINT: stats.mode: fix issues with `nan_policy='propagate'`

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -440,9 +440,10 @@ def mode(a, axis=0, nan_policy='propagate'):
     The mode of object arrays is calculated using `collections.Counter`, which
     treats NaNs with different binary representations as distinct.
 
-    The mode of arrays with other dtypes is calculated using `np.unique`, which
-    treats all NaNs - even those with different binary representations - as
-    equivalent.
+    The mode of arrays with other dtypes is calculated using `np.unique`.
+    In NumPy versions 1.21 and after, all NaNs - even those with different
+    binary representations - are treated as equivalent and counted as separate
+    instances of the same value.
 
     Examples
     --------

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -404,7 +404,7 @@ ModeResult = namedtuple('ModeResult', ('mode', 'count'))
 
 
 def mode(a, axis=0, nan_policy='propagate'):
-    """Return an array of the modal (most common) value in the passed array.
+    r"""Return an array of the modal (most common) value in the passed array.
 
     If there is more than one such value, only one is returned.
     The bin-count for the modal bins is also returned.
@@ -431,6 +431,19 @@ def mode(a, axis=0, nan_policy='propagate'):
     count : ndarray
         Array of counts for each mode.
 
+    Notes
+    -----
+    Input `a` is converted to an `np.ndarray` before taking the mode.
+    To avoid the possibility of unexpected conversions, convert `a` to an
+    `np.ndarray` of the desired type before using `mode`.
+
+    The mode of object arrays is calculated using `collections.Counter`, which
+    treats NaNs with different binary representations as distinct.
+
+    The mode of arrays with other dtypes is calculated using `np.unique`, which
+    treats all NaNs - even those with different binary representations - as
+    equivalent.
+
     Examples
     --------
     >>> a = np.array([[6, 8, 3, 0],
@@ -448,7 +461,6 @@ def mode(a, axis=0, nan_policy='propagate'):
     ModeResult(mode=3, count=3)
 
     """
-    a_orig = a
     a, axis = _chk_asarray(a, axis)
     if a.size == 0:
         return ModeResult(np.array([]), np.array([]))
@@ -458,11 +470,6 @@ def mode(a, axis=0, nan_policy='propagate'):
     if contains_nan and nan_policy == 'omit':
         a = ma.masked_invalid(a)
         return mstats_basic.mode(a, axis)
-
-    if contains_nan:
-        # When sequences are converted to numerical arrays, NumPy sometimes
-        # changes the binary representation of some NaNs. Avoid this.
-        a = np.asarray(a_orig, dtype=object)
 
     if a.dtype == object:
         def _mode1D(a):

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -29,7 +29,7 @@ References
 import warnings
 import math
 from math import gcd
-from collections import namedtuple
+from collections import namedtuple, Counter
 
 import numpy as np
 from numpy import array, asarray, ma
@@ -406,7 +406,7 @@ ModeResult = namedtuple('ModeResult', ('mode', 'count'))
 def mode(a, axis=0, nan_policy='propagate'):
     """Return an array of the modal (most common) value in the passed array.
 
-    If there is more than one such value, only the smallest is returned.
+    If there is more than one such value, only one is returned.
     The bin-count for the modal bins is also returned.
 
     Parameters
@@ -420,7 +420,7 @@ def mode(a, axis=0, nan_policy='propagate'):
         Defines how to handle when input contains nan.
         The following options are available (default is 'propagate'):
 
-          * 'propagate': returns nan
+          * 'propagate': treats nan as it would treat any other value
           * 'raise': throws an error
           * 'omit': performs the calculations ignoring nan values
 
@@ -448,6 +448,7 @@ def mode(a, axis=0, nan_policy='propagate'):
     ModeResult(mode=3, count=3)
 
     """
+    a_orig = a
     a, axis = _chk_asarray(a, axis)
     if a.size == 0:
         return ModeResult(np.array([]), np.array([]))
@@ -458,26 +459,20 @@ def mode(a, axis=0, nan_policy='propagate'):
         a = ma.masked_invalid(a)
         return mstats_basic.mode(a, axis)
 
-    if a.dtype == object and np.nan in set(a.ravel()):
-        # Fall back to a slower method since np.unique does not work with NaN
-        scores = set(np.ravel(a))  # get ALL unique values
-        testshape = list(a.shape)
-        testshape.pop(axis)
-        oldmostfreq = np.zeros(testshape, dtype=a.dtype)
-        oldcounts = np.zeros(testshape, dtype=int)
+    if contains_nan:
+        # When sequences are converted to numerical arrays, NumPy sometimes
+        # changes the binary representation of some NaNs. Avoid this.
+        a = np.asarray(a_orig, dtype=object)
 
-        for score in scores:
-            template = (a == score)
-            counts = np.sum(template, axis)
-            mostfrequent = np.where(counts > oldcounts, score, oldmostfreq)
-            oldcounts = np.maximum(counts, oldcounts)
-            oldmostfreq = mostfrequent
-
-        return ModeResult(mostfrequent[()], oldcounts[()])
-
-    def _mode1D(a):
-        vals, cnts = np.unique(a, return_counts=True)
-        return vals[cnts.argmax()], cnts.max()
+    if a.dtype == object:
+        def _mode1D(a):
+            cntr = Counter(a)
+            mode = max(cntr, key=lambda x: cntr[x])
+            return mode, cntr[mode]
+    else:
+        def _mode1D(a):
+            vals, cnts = np.unique(a, return_counts=True)
+            return vals[cnts.argmax()], cnts.max()
 
     # np.apply_along_axis will convert the _mode1D tuples to a numpy array,
     # casting types in the process.

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2276,8 +2276,9 @@ class TestMode:
         # mode should treat np.nan as it would any other object when
         # nan_policy='propagate'
         a = [2, np.nan, 1, np.nan]
-        res = stats.mode(a)
-        assert np.isnan(res.mode) and res.count == 2
+        if NumpyVersion(np.__version__) >= '1.21.0':
+            res = stats.mode(a)
+            assert np.isnan(res.mode) and res.count == 2
 
         # mode should work on object arrays. There were issues when
         # objects do not support comparison operations.

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2272,6 +2272,23 @@ class TestMode:
         np.testing.assert_array_equal(res.mode.shape, reference_shape)
         np.testing.assert_array_equal(res.count.shape, reference_shape)
 
+    def test_nan_policy_propagate_gh_9815(self):
+        # mode should treat np.nan as it would any other object when
+        # nan_policy='propagate'
+        a = [2, np.nan, 1, np.nan]
+        res = stats.mode(a)
+        assert np.isnan(res.mode) and res.count == 2
+
+        # mode should work on object arrays. There were issues when
+        # objects do not support comparison operations.
+        a = np.array(a, dtype='object')
+        res = stats.mode(a)
+        assert np.isnan(res.mode) and res.count == 2
+
+        a = np.array([10, True, 'hello', 10], dtype='object')
+        res = stats.mode(a)
+        assert_array_equal(res, (10, 2))
+
 
 class TestSEM:
 


### PR DESCRIPTION
#### Reference issue
closes gh-9815

#### What does this implement/fix?
Two issues were observed in gh-9815:
* `mode` with `nan_policy='propagate'` did not always produce the expected result when the input contained NaNs
* `mode` with `nan_policy='propagate'` encountered an error when the input was an object array containing types that could not be compared

This fixes these issues by replacing `mode`'s fall-back algorithm.

Now:
```python3
import numpy as np
from scipy import stats
stats.mode([np.nan, np.nan, np.nan, 1., 1., 2., 3., 3., 3., np.nan])  # ModeResult(mode=nan, count=4)
stats.mode(np.array([10, True, 'hello', 10], dtype='object'))  # ModeResult(mode=10, count=2)
```

#### Additional information
There are multiple binary representations of NaN. This PR does not attempt to treat all of them as the same value. However, it is careful to preserve the NaN representations of the user input so that they are compared as intended. This is important, because NumPy may alter the representation of NaNs in a sequence when converting it to a numerical array.

<details>

```python3
from collections import Counter
import numpy as np

a = [2, np.nan, 1, np.nan]
Counter(a)  # Counter({2: 1, nan: 2, 1: 1})
Counter(np.asarray(a, dtype=object))  #  Counter({2: 1, nan: 2, 1: 1})
Counter(np.asarray(a, dtype=float))  # Counter({2.0: 1, nan: 1, 1.0: 1, nan: 1})
```

</details>

It might be possible to treat different NaNs as the same, but we would probably have to change them to a sentinel value first (e.g. `a[np.isnan(a)] = 'a_sentinel_value_not_already_in_data'`). For object arrays, we'd have to loop through element-by-element (not just slice by slice) because `np.isnan` doesn't work on object arrays.  Do we want to do that? There was not consensus in gh-9815 on whether that was important or not, just that it was important to document. Either way, we'll explain it in a Notes section.