### PR TITLE
ENH: signal: add cross cyclic spectral density

### DIFF
--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -276,6 +276,7 @@ Spectral analysis
    coherence      -- Compute the magnitude squared coherence, using Welch's method.
    spectrogram    -- Compute the spectrogram (legacy).
    lombscargle    -- Computes the Lomb-Scargle periodogram.
+   cyclic_sd      -- Computes the cross cyclic spectral density.
    vectorstrength -- Computes the vector strength.
    ShortTimeFFT   -- Interface for calculating the \
                      :ref:`Short Time Fourier Transform <tutorial_stft>` and \

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -1701,11 +1701,11 @@ def cyclic_sd(x, y, /, *, fs=16., alpha=4., sym=True, window='hann',
         to a Hann window.
     nperseg : int, optional
         Length of each segment. Defaults to None, but if window is str or
-        tuple, is set to 256, and if window is array_like, is set to the
-        length of the window.
+        tuple, is set to the min of 256 and length of inpus, and if window is
+        array_like, is set to the length of the window.
     noverlap : int, optional
         Number of points to overlap between segments. If `None`,
-        ``noverlap = nperseg // 2``. Defaults to `None`.
+        ``noverlap = 3 * nperseg // 4``. Defaults to `None`.
     nfft : int, optional
         Length of the FFT used, if a zero padded FFT is desired. If
         `None`, the FFT length is `nperseg`. Defaults to `None`.

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -1756,7 +1756,10 @@ def cyclic_sd(x, y, *, fs=16., fc=4., sym=True, window='hann', nperseg=None,
 
     References
     ----------
-    .. [1] J. Antoni, "Cyclic Spectral Analysis in Practice", Mech Syst Signal
+    .. [1] W. Gardner, "Measurement of spectral correlation", IEEE Trans
+           Acoust. vol. 34, pp. 1111-1123, 1986.
+
+    .. [2] J. Antoni, "Cyclic Spectral Analysis in Practice", Mech Syst Signal
            Process. vol. 21, pp. 597-630, 2007.
 
     Examples

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -1703,7 +1703,7 @@ def cyclic_sd(x, y, /, *, fs=16., alpha=4., sym=True, window='hann',
         Length of each segment. Defaults to None, but if window is str or
         tuple, is set to 256, and if window is array_like, is set to the
         length of the window.
-    noverlap: int, optional
+    noverlap : int, optional
         Number of points to overlap between segments. If `None`,
         ``noverlap = nperseg // 2``. Defaults to `None`.
     nfft : int, optional
@@ -1819,23 +1819,21 @@ def cyclic_sd(x, y, /, *, fs=16., alpha=4., sym=True, window='hann',
         raise ValueError('Cyclic frequency must be inferior to Nyquist '
                          'frequency, got %s' % (alpha,))
 
-    # to avoid leakage, noverlap >= nperseg//4*3, cf Boustany2005
-    if (noverlap is None) and (nperseg is None):
-        nperseg = 256
-        noverlap = nperseg // 4 * 3
-    elif noverlap is None:
-        noverlap = nperseg // 4 * 3
-    else:
-        raise ValueError('If nperseg is defined, noverlap must be defined too')
+    # to avoid leakage, noverlap >= 3/4*nperseg, see Boustany2005
+    if (nperseg is None) and (noverlap is None):
+        nperseg = min(256, x.shape[axis])
+        noverlap = int(3 * nperseg / 4)
+    elif (nperseg is not None) and (noverlap is None):
+        raise ValueError('In case nperseg is defined, set noverlap')
 
-    if (noverlap < nperseg // 4 * 3):
+    if (noverlap < 3 * nperseg // 4):
         warnings.warn('To avoid leakage, overlap should be larger than 75%')
 
     if sym:
-        y = y * np.exp(-1j * np.pi * (alpha / fs) * np.arange(y.shape[-1]))
-        x = x * np.exp(1j * np.pi * (alpha / fs) * np.arange(x.shape[-1]))
+        y = y * np.exp(-1j * np.pi * (alpha / fs) * np.arange(y.shape[axis]))
+        x = x * np.exp(1j * np.pi * (alpha / fs) * np.arange(x.shape[axis]))
     else:
-        x = x * np.exp(2j * np.pi * (alpha / fs) * np.arange(x.shape[-1]))
+        x = x * np.exp(2j * np.pi * (alpha / fs) * np.arange(x.shape[axis]))
 
     freqs, Pxy = csd(x, y, fs=fs, window=window, nperseg=nperseg,
                      noverlap=noverlap, nfft=nfft, detrend=detrend,

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -1801,7 +1801,7 @@ def cyclic_sd(x, y, /, *, fs=16., alpha=4., sym=True, window='hann',
     >>> alphas = np.arange(1, 70)
     >>> scd = np.empty((freqs.size, alphas.size), dtype=np.complex64)
     >>> for i, alpha in enumerate(alphas):
-    >>>     scd[:, i] = cyclic_sd(x, x, fs=fs, alpha=alpha)[1]
+    ...     scd[:, i] = cyclic_sd(x, x, fs=fs, alpha=alpha)[1]
 
     The modulation is expected to occur at frequency f_sig.
 

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -1794,16 +1794,16 @@ def cyclic_sd(x, y, *, fs=16., alpha=4., sym=True, window='hann', nperseg=None,
     >>> ax.set_xlim([0, 0.05])
     >>> ax.set_ylim([-10, 10])
     >>> ax.set(xlabel="Time (in s)", ylabel="Amplitude")
-    >>> ax.legend()
+    >>> ax.legend(loc='upper right')
     >>> plt.show()
 
     >>> freqs = cyclic_sd(x=x, y=x, fs=fs, alpha=0)[0]
-    >>> alphas = np.arange(1, 100)
+    >>> alphas = np.arange(1, 70)
     >>> scd = np.empty((freqs.size, alphas.size), dtype=np.complex64)
     >>> for i, alpha in enumerate(alphas):
     >>>     scd[:, i] = cyclic_sd(x=x, y=x, fs=fs, alpha=alpha)[1]
 
-    The modulation is expected to occur twice the frequency f_sig, ie 56 Hz.
+    The modulation is expected to occur at frequency f_sig.
 
     >>> foi = (freqs >= 0) & (freqs <= 2000)
     >>> scd, freqs = scd[foi], freqs[foi]

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -1741,19 +1741,8 @@ def cyclic_sd(x, y, /, *, fs=16., alpha=4., sym=True, window='hann',
 
     Notes
     -----
-    Use analytic signal to avoid correlation between positive and negative
-    frequencies.
-
     By convention, Pxy is computed with the conjugate FFT of X
     multiplied by the FFT of Y.
-
-    If the input series differ in length, the shorter series will be
-    zero-padded to match.
-
-    An appropriate amount of overlap will depend on the choice of window
-    and on your requirements. It is recommended to use nfft = 2*nperseg and
-    noverlap = 2/3*nperseg with a Hann window, or noverlap = 1/2*nperseg with a
-    half-sine window.
 
     .. versionadded:: 1.12
 

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -1771,6 +1771,7 @@ def cyclic_sd(x, y, /, *, fs=16., alpha=4., sym=True, window='hann',
 
     Examples
     --------
+    >>> import numpy as np
     >>> from scipy.signal import cyclic_sd
     >>> import matplotlib.pyplot as plt
     >>> rng = np.random.default_rng()

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -1938,8 +1938,8 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
                       None: None}
 
     if boundary not in boundary_funcs:
-        raise ValueError("Unknown boundary option '{}', must be one of: {}"
-                         .format(boundary, list(boundary_funcs.keys())))
+        raise ValueError(f"Unknown boundary option '{boundary}', "
+                         f"must be one of: {list(boundary_funcs.keys())}")
 
     # If x and y are the same object we can save ourselves some computation.
     same_data = y is x

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -1816,18 +1816,18 @@ def cyclic_sd(x, y, /, *, fs=16., alpha=4., sym=True, window='hann',
     """
 
     if alpha > fs / 2:
-        raise ValueError('Cyclic frequency must be inferior to Nyquist '
-                         f'frequency, got {alpha}')
+        raise ValueError("Cyclic frequency must be inferior to Nyquist "
+                         f"frequency, got {alpha}")
 
     # to avoid leakage, noverlap >= 3/4*nperseg, see Boustany2005
     if (nperseg is None) and (noverlap is None):
         nperseg = min(256, x.shape[axis])
         noverlap = int(3 * nperseg / 4)
     elif (nperseg is not None) and (noverlap is None):
-        raise ValueError('In case nperseg is defined, set noverlap')
+        raise ValueError("In case nperseg is defined, set noverlap")
 
     if (noverlap < 3 * nperseg // 4):
-        warnings.warn('To avoid leakage, overlap should be larger than 75%',
+        warnings.warn("To avoid leakage, overlap should be larger than 75%",
                       stacklevel=2)
 
     if sym:

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -1713,6 +1713,9 @@ def cyclic_sd(x, y, *, fs=16., fc=4., sym=True, window='hann', nperseg=None,
         function. If it is a function, it takes a segment and returns a
         detrended segment. If `detrend` is `False`, no detrending is
         done. Defaults to 'constant'.
+    return_onesided : bool, optional
+        If `True`, return a one-sided spectrum for real data. If
+        `False` return a two-sided spectrum.
     scaling : { 'density', 'spectrum' }, optional
         Selects between computing the cross cyclic spectral density ('density')
         where `Pxy` has units of V**2/Hz and computing the cross cyclic
@@ -1782,7 +1785,7 @@ def cyclic_sd(x, y, *, fs=16., fc=4., sym=True, window='hann', nperseg=None,
 
     freqs, Pxy = csd(x, y, fs=fs, window=window, nperseg=nperseg,
                      noverlap=noverlap, nfft=nfft, detrend=detrend,
-                     return_onesided=False, scaling=scaling,
+                     return_onesided=return_onesided, scaling=scaling,
                      axis=axis, average=average)
 
     return freqs, Pxy

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -1672,8 +1672,7 @@ def coherence(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
 
 def cyclic_sd(x, y, *, fs=16., alpha=4., sym=True, window='hann', nperseg=None,
               noverlap=None, nfft=None, detrend='constant',
-              return_onesided=True, scaling='density', axis=-1,
-              average='mean'):
+              scaling='density', axis=-1, average='mean'):
     r"""
     Estimate the cross cyclic spectral density, Pxy, using Welch's method.
 
@@ -1714,9 +1713,6 @@ def cyclic_sd(x, y, *, fs=16., alpha=4., sym=True, window='hann', nperseg=None,
         function. If it is a function, it takes a segment and returns a
         detrended segment. If `detrend` is `False`, no detrending is
         done. Defaults to 'constant'.
-    return_onesided : bool, optional
-        If `True`, return a one-sided spectrum for real data. If
-        `False` return a two-sided spectrum.
     scaling : { 'density', 'spectrum' }, optional
         Selects between computing the cross cyclic spectral density ('density')
         where `Pxy` has units of V**2/Hz and computing the cross cyclic
@@ -1756,7 +1752,7 @@ def cyclic_sd(x, y, *, fs=16., alpha=4., sym=True, window='hann', nperseg=None,
     noverlap = 2/3*nperseg with a Hann window, or noverlap = 1/2*nperseg with a
     half-sine window.
 
-    .. versionadded:: 1.9
+    .. versionadded:: 1.11
 
     References
     ----------
@@ -1827,7 +1823,7 @@ def cyclic_sd(x, y, *, fs=16., alpha=4., sym=True, window='hann', nperseg=None,
 
     freqs, Pxy = csd(x, y, fs=fs, window=window, nperseg=nperseg,
                      noverlap=noverlap, nfft=nfft, detrend=detrend,
-                     return_onesided=return_onesided, scaling=scaling,
+                     return_onesided=False, scaling=scaling,
                      axis=axis, average=average)
 
     return freqs, Pxy

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -1672,8 +1672,8 @@ def coherence(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
     return freqs, Cxy
 
 
-def cyclic_sd(x, y, *, fs=16., alpha=4., sym=True, window='hann', nperseg=None,
-              noverlap=None, nfft=None, detrend='constant',
+def cyclic_sd(x, y, /, *, fs=16., alpha=4., sym=True, window='hann',
+              nperseg=None, noverlap=None, nfft=None, detrend='constant',
               scaling='density', axis=-1, average='mean'):
     r"""
     Estimate the cross cyclic spectral density, Pxy, using Welch's method.
@@ -1755,7 +1755,7 @@ def cyclic_sd(x, y, *, fs=16., alpha=4., sym=True, window='hann', nperseg=None,
     noverlap = 2/3*nperseg with a Hann window, or noverlap = 1/2*nperseg with a
     half-sine window.
 
-    .. versionadded:: 1.11
+    .. versionadded:: 1.12
 
     References
     ----------
@@ -1797,11 +1797,11 @@ def cyclic_sd(x, y, *, fs=16., alpha=4., sym=True, window='hann', nperseg=None,
     >>> ax.legend(loc='upper right')
     >>> plt.show()
 
-    >>> freqs = cyclic_sd(x=x, y=x, fs=fs, alpha=0)[0]
+    >>> freqs = cyclic_sd(x, x, fs=fs, alpha=0)[0]
     >>> alphas = np.arange(1, 70)
     >>> scd = np.empty((freqs.size, alphas.size), dtype=np.complex64)
     >>> for i, alpha in enumerate(alphas):
-    >>>     scd[:, i] = cyclic_sd(x=x, y=x, fs=fs, alpha=alpha)[1]
+    >>>     scd[:, i] = cyclic_sd(x, x, fs=fs, alpha=alpha)[1]
 
     The modulation is expected to occur at frequency f_sig.
 

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -9,8 +9,10 @@ from ._arraytools import const_ext, even_ext, odd_ext, zero_ext
 import warnings
 
 
-__all__ = ['periodogram', 'welch', 'lombscargle', 'csd', 'coherence',
-           'spectrogram', 'stft', 'istft', 'check_COLA', 'check_NOLA']
+__all__ = [
+    'periodogram', 'welch', 'lombscargle', 'csd', 'coherence', 'cyclic_sd',
+    'spectrogram', 'stft', 'istft', 'check_COLA', 'check_NOLA'
+]
 
 
 def lombscargle(x,
@@ -1756,11 +1758,12 @@ def cyclic_sd(x, y, *, fs=16., alpha=4., sym=True, window='hann', nperseg=None,
 
     References
     ----------
-    .. [1] W. Gardner, "Measurement of spectral correlation", IEEE Trans
-           Acoust. vol. 34, pp. 1111-1123, 1986.
-
-    .. [2] J. Antoni, "Cyclic Spectral Analysis in Practice", Mech Syst Signal
-           Process. vol. 21, pp. 597-630, 2007.
+    .. [1] "Spectral correlation density", *Wikipedia*,
+           https://en.wikipedia.org/wiki/Spectral_correlation_density
+    .. [2] W. Gardner, "Measurement of spectral correlation", IEEE Trans
+           Acoust. vol. 34, pp. 1111-1123, 1986
+    .. [3] J. Antoni, "Cyclic Spectral Analysis in Practice", Mech Syst Signal
+           Process. vol. 21, pp. 597-630, 2007
 
     Examples
     --------

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -1781,7 +1781,7 @@ def cyclic_sd(x, y, *, fs=16., alpha=4., sym=True, window='hann', nperseg=None,
     >>> n_times, fs = 1e5, 1e4
     >>> f_carrier, f_sig = 1214, 28
     >>> time = np.arange(n_times) / fs
-    >>> sig = np.sin(2*np.pi*f_carrier*time) * np.sin(2*np.pi*f_sig*time)
+    >>> sig = np.sin(2*np.pi*f_carrier*time) * (1 + np.sin(2*np.pi*f_sig*time))
 
     Add a noise.
 
@@ -1792,6 +1792,7 @@ def cyclic_sd(x, y, *, fs=16., alpha=4., sym=True, window='hann', nperseg=None,
     >>> ax.plot(time, x, label='signal+noise')
     >>> ax.plot(time, sig, label='signal')
     >>> ax.set_xlim([0, 0.05])
+    >>> ax.set_ylim([-10, 10])
     >>> ax.set(xlabel="Time (in s)", ylabel="Amplitude")
     >>> ax.legend()
     >>> plt.show()

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -1817,7 +1817,7 @@ def cyclic_sd(x, y, /, *, fs=16., alpha=4., sym=True, window='hann',
 
     if alpha > fs / 2:
         raise ValueError('Cyclic frequency must be inferior to Nyquist '
-                         'frequency, got %s' % (alpha,))
+                         f'frequency, got {alpha}')
 
     # to avoid leakage, noverlap >= 3/4*nperseg, see Boustany2005
     if (nperseg is None) and (noverlap is None):
@@ -1827,7 +1827,8 @@ def cyclic_sd(x, y, /, *, fs=16., alpha=4., sym=True, window='hann',
         raise ValueError('In case nperseg is defined, set noverlap')
 
     if (noverlap < 3 * nperseg // 4):
-        warnings.warn('To avoid leakage, overlap should be larger than 75%')
+        warnings.warn('To avoid leakage, overlap should be larger than 75%',
+                      stacklevel=2)
 
     if sym:
         y = y * np.exp(-1j * np.pi * (alpha / fs) * np.arange(y.shape[axis]))

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -5,7 +5,7 @@
 from scipy._lib.deprecation import _sub_module_deprecation
 
 __all__ = [  # noqa: F822
-    'periodogram', 'welch', 'lombscargle', 'csd', 'coherence',
+    'periodogram', 'welch', 'lombscargle', 'csd', 'coherence', 'cyclic_sd',
     'spectrogram', 'stft', 'istft', 'check_COLA', 'check_NOLA',
     'sp_fft', 'get_window', 'const_ext', 'even_ext',
     'odd_ext', 'zero_ext'

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -921,13 +921,13 @@ class TestCyclicSd:
         rs = np.random.RandomState(526057773)
         x = rs.standard_normal(50)
 
-        fs, nperseg = 1, 15
+        fs, nperseg = 1, 16
         f = fftfreq(nperseg, 1/fs)
 
-        f1, _ = cyclic_sd(x, x, fs=fs, alpha=0.5, nperseg=nperseg, noverlap=10)
+        f1, _ = cyclic_sd(x, x, fs=fs, alpha=0.5, nperseg=nperseg, noverlap=12)
         assert_allclose(f, f1)
         cyclic_sd(x, x, fs=fs, alpha=0.4, sym=False, nperseg=nperseg,
-                  noverlap=10, nfft=nperseg, detrend=False, scaling='spectrum',
+                  noverlap=12, nfft=nperseg, detrend=False, scaling='spectrum',
                   average='median')
 
         with pytest.raises(ValueError, match='Cyclic frequency must be'):

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -11,7 +11,7 @@ from scipy import signal
 from scipy.fft import fftfreq, rfftfreq, fft, irfft
 from scipy.integrate import trapezoid
 from scipy.signal import (periodogram, welch, lombscargle, coherence,
-                          spectrogram, check_COLA, check_NOLA)
+                          cyclic_sd, spectrogram, check_COLA, check_NOLA)
 from scipy.signal.windows import hann
 from scipy.signal._spectral_py import _spectral_helper
 
@@ -916,6 +916,15 @@ class TestCoherence:
         assert_allclose(f, f1)
         assert_allclose(C, C1)
 
+class TestCyclicSd:
+    def test_identical_input(self):
+        x = np.random.randn(50)
+
+        fs, nperseg = 1, 15
+        f = fftfreq(nperseg, 1/fs)
+        f1, _ = cyclic_sd(x, x, fs=fs, alpha=0.5, nperseg=nperseg)
+
+        assert_allclose(f, f1)
 
 class TestSpectrogram:
     def test_average_all_segments(self):

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -932,6 +932,9 @@ class TestCyclicSd:
         with pytest.raises(ValueError, match='Cyclic frequency must be'):
             cyclic_sd(x, x, fs=fs, alpha=fs)
 
+        with pytest.raises(ValueError, match='In case nperseg is defined,'):
+            cyclic_sd(x, x, fs=fs, alpha=0.4, nperseg=10)
+
 class TestSpectrogram:
     def test_average_all_segments(self):
         x = np.random.randn(1024)

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -928,7 +928,7 @@ class TestCyclicSd:
         assert_array_equal(Pxx.shape, (nperseg,))
 
         cyclic_sd(x, x, fs=fs, alpha=0.4, sym=False, nperseg=nperseg,
-                  noverlap=noverlap, nfft=nperseg, windows='hamming',
+                  noverlap=noverlap, nfft=nperseg, window='hamming',
                   detrend=False, scaling='spectrum', average='median')
 
         with pytest.raises(ValueError, match='Cyclic frequency must be'):

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -929,7 +929,8 @@ class TestCyclicSd:
                   noverlap=10, nfft=nperseg, detrend=False, scaling='spectrum',
                   average='median')
 
-        assert_raises(ValueError, cyclic_sd, x, x, fs=fs, alpha=fs)
+        with pytest.raises(ValueError, match='Cyclic frequency must be'):
+            cyclic_sd(x, x, fs=fs, alpha=fs)
 
 class TestSpectrogram:
     def test_average_all_segments(self):

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -924,7 +924,7 @@ class TestCyclicSd:
         fs, nperseg = 1, 15
         f = fftfreq(nperseg, 1/fs)
 
-        f1, _ = cyclic_sd(x, x, fs=fs, alpha=0.5, sym=True)
+        f1, _ = cyclic_sd(x, x, fs=fs, alpha=0.5, nperseg=nperseg, noverlap=10)
         assert_allclose(f, f1)
         cyclic_sd(x, x, fs=fs, alpha=0.4, sym=False, nperseg=nperseg,
                   noverlap=10, nfft=nperseg, detrend=False, scaling='spectrum',
@@ -934,7 +934,7 @@ class TestCyclicSd:
             cyclic_sd(x, x, fs=fs, alpha=fs)
 
         with pytest.raises(ValueError, match='In case nperseg is defined,'):
-            cyclic_sd(x, x, fs=fs, alpha=0.4, nperseg=10)
+            cyclic_sd(x, x, fs=fs, alpha=0.3, nperseg=10)
 
 class TestSpectrogram:
     def test_average_all_segments(self):

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -923,11 +923,13 @@ class TestCyclicSd:
         fs, nperseg = 1, 15
         f = fftfreq(nperseg, 1/fs)
 
-        f1, _ = cyclic_sd(x, x, fs=fs, alpha=0.5, nperseg=nperseg, sym=True)
+        f1, _ = cyclic_sd(x, x, fs=fs, alpha=0.5, sym=True)
         assert_allclose(f, f1)
-        cyclic_sd(x, x, fs=fs, alpha=0.5, nperseg=nperseg, sym=False)
+        cyclic_sd(x, x, fs=fs, alpha=0.4, sym=False, nperseg=nperseg,
+                  noverlap=10, nfft=nperseg, detrend=False, scaling='spectrum',
+                  average='median')
 
-        assert_raises(ValueError, cyclic_sd, x, x, fs, fs)
+        assert_raises(ValueError, cyclic_sd, x, x, fs=fs, alpha=fs)
 
 class TestSpectrogram:
     def test_average_all_segments(self):

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -918,7 +918,8 @@ class TestCoherence:
 
 class TestCyclicSd:
     def test_identical_input(self):
-        x = np.random.randn(50)
+        rs = np.random.RandomState(526057773)
+        x = rs.standard_normal(50)
 
         fs, nperseg = 1, 15
         f = fftfreq(nperseg, 1/fs)

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -922,9 +922,12 @@ class TestCyclicSd:
 
         fs, nperseg = 1, 15
         f = fftfreq(nperseg, 1/fs)
-        f1, _ = cyclic_sd(x, x, fs=fs, alpha=0.5, nperseg=nperseg)
 
+        f1, _ = cyclic_sd(x, x, fs=fs, alpha=0.5, nperseg=nperseg, sym=True)
         assert_allclose(f, f1)
+        cyclic_sd(x, x, fs=fs, alpha=0.5, nperseg=nperseg, sym=False)
+
+        assert_raises(ValueError, cyclic_sd, x, x, fs, fs)
 
 class TestSpectrogram:
     def test_average_all_segments(self):


### PR DESCRIPTION
#### Reference issue

Closes #14783.

#### What does this implement/fix?

Function `cyclic_sd` computes the cross-cyclic spectral density, using `csd` 
https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.csd.html

https://en.wikipedia.org/wiki/Spectral_correlation_density

- [x] code and doc
- [x] example
- [x] test

#### Additional information

##### Function name

I don't know how to choose the function name.
"cross-cyclic spectral density" should be naturally abbreviated into "csd", 
but this name is already used for "cross-power spectral density".
Ideally, "cross-power spectral density" should have been abbreviated into "cpsd", 
and "cross-cyclic spectral density" into "ccsd"...

##### Example

Example of documentation computes cyclic spectral density of a signal at `f_sig`=28 Hz resulting from amplitude modulation, using a carrier frequency. Then, a noise is added.
![dev_cyclic_fig11](https://github.com/scipy/scipy/assets/5346669/ade15b08-d29c-4850-8c4c-db4191175bb4)


The modulation is expected to occur twice at frequency `f_sig`.
![dev_cyclic_fig12](https://github.com/scipy/scipy/assets/5346669/ba1caa7d-fd83-4012-b7db-9e1ce5544d32)
