### PR TITLE
MAINT: prepare for SciPy 1.8.0 final

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,23 +7,14 @@
       </h1>
     </p>
 
-.. image:: https://img.shields.io/circleci/project/github/scipy/scipy/master.svg?label=CircleCI
-  :target: https://circleci.com/gh/scipy/scipy
-
-.. image:: https://dev.azure.com/scipy-org/SciPy/_apis/build/status/scipy.scipy?branchName=master
-  :target: https://dev.azure.com/scipy-org/SciPy/_build/latest?definitionId=1?branchName=master
-
-.. image:: https://github.com/scipy/scipy/workflows/macOS%20tests/badge.svg?branch=master
-  :target: https://github.com/scipy/scipy/actions?query=workflow%3A%22macOS+tests%22
+.. image:: https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A
+  :target: https://numfocus.org
 
 .. image:: https://img.shields.io/pypi/dm/scipy.svg?label=Pypi%20downloads
   :target: https://pypi.org/project/scipy/
 
 .. image:: https://img.shields.io/conda/dn/conda-forge/scipy.svg?label=Conda%20downloads
   :target: https://anaconda.org/conda-forge/scipy
-
-.. image:: https://codecov.io/gh/scipy/scipy/branch/master/graph/badge.svg
-  :target: https://codecov.io/gh/scipy/scipy
 
 .. image:: https://img.shields.io/badge/stackoverflow-Ask%20questions-blue.svg
   :target: https://stackoverflow.com/questions/tagged/scipy
@@ -38,7 +29,7 @@ ODE solvers, and more.
 
 - **Website:** https://scipy.org
 - **Documentation:** https://docs.scipy.org/
-- **Mailing list:** https://scipy.org/mailing-lists/
+- **Mailing list:** https://mail.python.org/mailman3/lists/scipy-dev.python.org/
 - **Source code:** https://github.com/scipy/scipy
 - **Contributing:** https://scipy.github.io/devdocs/dev/index.html
 - **Bug reports:** https://github.com/scipy/scipy/issues
@@ -83,6 +74,3 @@ comment on a relevant issue that is already open.
 If you are new to contributing to open source, `this
 guide <https://opensource.guide/how-to-contribute/>`__ helps explain why, what,
 and how to get involved.
-
-.. image:: https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A
-  :target: https://numfocus.org

--- a/doc/release/1.8.0-notes.rst
+++ b/doc/release/1.8.0-notes.rst
@@ -2,8 +2,6 @@
 SciPy 1.8.0 Release Notes
 =========================
 
-.. note:: Scipy 1.8.0 is not released yet!
-
 .. contents::
 
 SciPy 1.8.0 is the culmination of 6 months of hard work. It contains
@@ -563,6 +561,7 @@ Issues closed for 1.8.0
 * `#15316 <https://github.com/scipy/scipy/issues/15316>`__: BUG: Failed to install scipy 1.7.x with pypy 3.7 in aarch64
 * `#15339 <https://github.com/scipy/scipy/issues/15339>`__: BUG: \`highs-ds\` returns memoryviews instead of np.arrays for...
 * `#15375 <https://github.com/scipy/scipy/issues/15375>`__: BUG: axis argument to scipy.stats.mode does not accept negative...
+* `#15517 <https://github.com/scipy/scipy/issues/15517>`__: BUG: Link to mailing list seems broken
 
 ***********************
 Pull requests for 1.8.0
@@ -964,4 +963,5 @@ Pull requests for 1.8.0
 * `#15418 <https://github.com/scipy/scipy/pull/15418>`__: MAINT: 1.8.0 rc3 backports round 1
 * `#15421 <https://github.com/scipy/scipy/pull/15421>`__: BUG: stats: mode: fix negative axis issue with np.moveaxis instead...
 * `#15432 <https://github.com/scipy/scipy/pull/15432>`__: MAINT: release branch PROPACK switch (default off)
+* `#15515 <https://github.com/scipy/scipy/pull/15515>`__: MAINT: fix broken link and remove CI badges
 

--- a/doc/source/dev/gitwash/git_links.inc
+++ b/doc/source/dev/gitwash/git_links.inc
@@ -64,5 +64,5 @@
 .. _`NumPy mailing list`: https://numpy.org/community/
 .. _SciPy: https://www.scipy.org
 .. _`SciPy github`: https://github.com/scipy/scipy
-.. _`SciPy mailing list`: https://scipy.org/mailing-lists/
+.. _`SciPy mailing list`: https://mail.python.org/mailman3/lists/scipy-dev.python.org/
 .. _`SciPy repository`: https://github.com/scipy/scipy

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -15,7 +15,7 @@ SciPy documentation
 `Source Repository <https://github.com/scipy/scipy>`__ |
 `Issues & Ideas <https://github.com/scipy/scipy/issues>`__ |
 `Q&A Support <https://stackoverflow.com/questions/tagged/scipy>`__ |
-`Mailing List <https://scipy.org/mailing-lists>`__
+`Mailing List <https://mail.python.org/mailman3/lists/scipy-dev.python.org/>`__
 
 **SciPy** (pronounced "Sigh Pie") is an open-source software for mathematics,
 science, and engineering.


### PR DESCRIPTION
* backport gh-15515 (doc change only)
* update the docs to reflect that this not a release candidate anymore
* I haven't see any evidence that remaining conda-forge errors are related to SciPy proper anymore in: https://github.com/conda-forge/scipy-feedstock/pull/198
  * I think they'll need to disable Pythran for windows like we did; as of this evening, the MacOS errors I see over there are in some mambaforge config stuff that looks unrelated