### PR TITLE
DOC: fixed the link for fluiddyn's transonic vision in dev/roadmap.html.

### DIFF
--- a/doc/source/dev/roadmap.rst
+++ b/doc/source/dev/roadmap.rst
@@ -40,7 +40,7 @@ Enabling the use of an accelerator like Pythran, possibly via Transonic, and
 making it easier for users to use Numba's ``@njit`` in their code that relies
 on SciPy functionality would unlock a lot of performance gain.  That needs a
 strategy though, all solutions are still maturing (see for example
-`this overview <https://fluiddyn.bitbucket.io/transonic-vision.html>`__).
+`this overview <https://fluiddyn.netlify.app/transonic-vision.html>`__).
 
 Finally, many individual functions can be optimized for performance.
 ``scipy.optimize`` and ``scipy.interpolate`` functions are particularly often


### PR DESCRIPTION
#### Reference issue
Couldn't find a relevant issue.

#### What does this implement/fix?
This fixed a wrong link for fluiddyn's transonic vision in dev/roadmap.html.

#### Additional information
Extremely minor fix, no additional info.
