### PR TITLE
BUG: ensure studentized_range pvalues are in the range [0, 1] by clipping the _cdf

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -9194,7 +9194,8 @@ class studentized_range_gen(rv_continuous):
             return integrate.nquad(llc, ranges=ranges, opts=opts)[0]
 
         ufunc = np.frompyfunc(_single_cdf, 3, 1)
-        return np.float64(ufunc(x, k, df))
+        # clip p-values to ensure they are in [0, 1].
+        return np.clip(np.float64(ufunc(x, k, df)), 0, 1)
 
 
 studentized_range = studentized_range_gen(name='studentized_range', a=0,

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -5235,6 +5235,13 @@ class TestStudentizedRange:
             k, df, _, _ = stats.studentized_range._fitstart([1, 2, 3])
         assert_(stats.studentized_range._argcheck(k, df))
 
+    def test_clipping(self):
+        # The result of this computation was -9.9253938401489e-14, but p-values
+        # should not be negative. The result from mpmath is 0.
+        q, k, v = 34.6413996195345746, 3, 339
+        p = stats.studentized_range.sf(q, k, v)
+        assert_equal(p, 0)
+
 
 def test_540_567():
     # test for nan returned in tickets 540, 567

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -5236,11 +5236,12 @@ class TestStudentizedRange:
         assert_(stats.studentized_range._argcheck(k, df))
 
     def test_clipping(self):
-        # The result of this computation was -9.9253938401489e-14, but p-values
-        # should not be negative. The result from mpmath is 0.
+        # The result of this computation was -9.9253938401489e-14 on some
+        # systems, but p-values should not be negative. The result from mpmath
+        # is 0.
         q, k, v = 34.6413996195345746, 3, 339
         p = stats.studentized_range.sf(q, k, v)
-        assert_equal(p, 0)
+        assert_equal(p >= 0, True)
 
 
 def test_540_567():

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -5236,11 +5236,12 @@ class TestStudentizedRange:
         assert_(stats.studentized_range._argcheck(k, df))
 
     def test_clipping(self):
-        # The result of this computation was -9.9253938401489e-14, but p-values
-        # should not be negative. The result from mpmath is 0.
+        # The result of this computation was -9.9253938401489e-14 on some
+        # systems. The result is very nearly zero, but should not be zero.
         q, k, v = 34.6413996195345746, 3, 339
         p = stats.studentized_range.sf(q, k, v)
-        assert_equal(p, 0)
+        assert_allclose(p, 0, atol=1e-10)
+        assert p >= 0
 
 
 def test_540_567():

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -5237,7 +5237,8 @@ class TestStudentizedRange:
 
     def test_clipping(self):
         # The result of this computation was -9.9253938401489e-14 on some
-        # systems. The result is very nearly zero, but should not be zero.
+        # systems. The correct result is very nearly zero, but should not be
+        # negative.
         q, k, v = 34.6413996195345746, 3, 339
         p = stats.studentized_range.sf(q, k, v)
         assert_allclose(p, 0, atol=1e-10)


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->
#### What does this implement/fix?
<!--Please explain your changes.-->

While [suggesting other python libraries](https://github.com/raphaelvallat/pingouin/pull/229) use SciPy's studentized range, it was observed that with some extreme parameters that you can get slightly negative values when it should be 0. Therefore we need to clip the `_cdf` to [0, 1]. 

#### Additional information
<!--Any additional information you think is important.-->
Take a look at [this notebook](https://colab.research.google.com/drive/1PlgjaDbBKGl67QPOY5BDO_VDRp4bCpJ4?usp=sharing) to see this behavior. 


<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->




I'm looking into the 1 [test failure](https://dev.azure.com/scipy-org/SciPy/_build/results?buildId=16372&view=logs&j=e3555eda-5afc-5d78-d2e9-cf9756f98375&t=220e105d-2d02-5073-9f3b-414490a3ddd5&l=1225) for clipping. It looks like the troublesome parameters selected don't give negative results on linux 32 bit systems. The other is a timeout issue.