### PR TITLE
REL: prep for SciPy 1.8.1

### DIFF
--- a/doc/release/1.8.1-notes.rst
+++ b/doc/release/1.8.1-notes.rst
@@ -1,0 +1,19 @@
+==========================
+SciPy 1.8.1 Release Notes
+==========================
+
+.. contents::
+
+SciPy 1.8.1 is a bug-fix release with no new features
+compared to 1.8.0.
+
+Authors
+=======
+
+
+Issues closed for 1.8.1
+-----------------------
+
+
+Pull requests for 1.8.1
+-----------------------

--- a/doc/source/release.1.8.1.rst
+++ b/doc/source/release.1.8.1.rst
@@ -1,0 +1,1 @@
+.. include:: ../release/1.8.1-notes.rst

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -8,6 +8,7 @@ see the `commit logs <https://github.com/scipy/scipy/commits/>`_.
 .. toctree::
    :maxdepth: 1
 
+   release.1.8.1
    release.1.8.0
    release.1.7.3
    release.1.7.2

--- a/pavement.py
+++ b/pavement.py
@@ -68,10 +68,10 @@ except AttributeError:
 #-----------------------------------
 
 # Source of the release notes
-RELEASE = 'doc/release/1.8.0-notes.rst'
+RELEASE = 'doc/release/1.8.1-notes.rst'
 
 # Start/end of the log (from git)
-LOG_START = 'v1.7.0'
+LOG_START = 'v1.8.0'
 LOG_END = 'maintenance/1.8.x'
 
 

--- a/setup.py
+++ b/setup.py
@@ -56,8 +56,8 @@ Operating System :: MacOS
 
 MAJOR = 1
 MINOR = 8
-MICRO = 0
-ISRELEASED = True
+MICRO = 1
+ISRELEASED = False
 IS_RELEASE_BRANCH = True
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 


### PR DESCRIPTION
Prepare for SciPy `1.8.1`. Between `PROPACK` being default off due to issues (mostly, but perhaps not exclusively, on Windows) and a new attempt to deploy release docs with the new theme and a custom-modified `.htaccess` file on the docs server, pretty unlikely we'll avoid additional release in this series.