### PR TITLE
[BUG] Fix importing scipy.lib._pep440

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -138,16 +138,17 @@ def get_build_ext_override():
         try:
             import pythran
             from pythran.dist import PythranBuildExt
+        except ImportError:
+            BaseBuildExt = npy_build_ext
+        else:
             BaseBuildExt = PythranBuildExt[npy_build_ext]
-            importlib.import_module('scipy/_lib/_pep440')
+            _pep440 = importlib.import_module('scipy._lib._pep440')
             if _pep440.parse(pythran.__version__) < _pep440.Version('0.9.12'):
                 raise RuntimeError("The installed `pythran` is too old, >= "
                                    "0.9.12 is needed, {} detected. Please "
                                    "upgrade Pythran, or use `export "
                                    "SCIPY_USE_PYTHRAN=0`.".format(
                                    pythran.__version__))
-        except ImportError:
-            BaseBuildExt = npy_build_ext
     else:
         BaseBuildExt = npy_build_ext
 
@@ -251,7 +252,10 @@ def generate_cython():
         try:
             # Note, pip may not be installed or not have been used
             import pip
-            importlib.import_module('scipy/_lib/_pep440')
+        except (ImportError, ModuleNotFoundError):
+            raise RuntimeError("Running cythonize failed!")
+        else:
+            _pep440 = importlib.import_module('scipy._lib._pep440')
             if _pep440.parse(pip.__version__) < _pep440.Version('18.0.0'):
                 raise RuntimeError("Cython not found or too old. Possibly due "
                                    "to `pip` being too old, found version {}, "
@@ -259,8 +263,6 @@ def generate_cython():
                                    pip.__version__))
             else:
                 raise RuntimeError("Running cythonize failed!")
-        except (ImportError, ModuleNotFoundError):
-            raise RuntimeError("Running cythonize failed!")
 
 
 def parse_setuppy_commands():


### PR DESCRIPTION
- Change scipy/_lib/_pep440 to scipy._lib._pep440
- Do the second import in else clause to avoid errors like this
  in the future
- Set the imported module to a variable

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
