### PR TITLE
TST: parametrize test_ldl_type_size_combinations

### DIFF
--- a/scipy/linalg/tests/test_decomp_ldl.py
+++ b/scipy/linalg/tests/test_decomp_ldl.py
@@ -5,6 +5,7 @@ from numpy import (array, eye, zeros, empty_like, empty, tril_indices_from,
                    complex64, complex128)
 from numpy.random import rand, randint, seed
 from scipy.linalg import ldl
+import pytest
 from pytest import raises as assert_raises, warns
 from numpy import ComplexWarning
 
@@ -90,46 +91,47 @@ def test_permutations():
         assert_(not any(l[p, :][u_ind]), 'Spin {} failed'.format(_))
 
 
-def test_ldl_type_size_combinations():
+@pytest.mark.parametrize("dtype", [float32, float64])
+@pytest.mark.parametrize("n", [30, 750])
+def test_ldl_type_size_combinations_real(n, dtype):
     seed(1234)
-    sizes = [30, 750]
-    real_dtypes = [float32, float64]
-    complex_dtypes = [complex64, complex128]
+    msg = ("Failed for size: {}, dtype: {}".format(n, dtype))
 
-    for n, dtype in itertools.product(sizes, real_dtypes):
-        msg = ("Failed for size: {}, dtype: {}".format(n, dtype))
+    x = rand(n, n).astype(dtype)
+    x = x + x.T
+    x += eye(n, dtype=dtype)*dtype(randint(5, 1e6))
 
-        x = rand(n, n).astype(dtype)
-        x = x + x.T
-        x += eye(n, dtype=dtype)*dtype(randint(5, 1e6))
+    l, d1, p = ldl(x)
+    u, d2, p = ldl(x, lower=0)
+    rtol = 1e-4 if dtype is float32 else 1e-10
+    assert_allclose(l.dot(d1).dot(l.T), x, rtol=rtol, err_msg=msg)
+    assert_allclose(u.dot(d2).dot(u.T), x, rtol=rtol, err_msg=msg)
 
-        l, d1, p = ldl(x)
-        u, d2, p = ldl(x, lower=0)
-        rtol = 1e-4 if dtype is float32 else 1e-10
-        assert_allclose(l.dot(d1).dot(l.T), x, rtol=rtol, err_msg=msg)
-        assert_allclose(u.dot(d2).dot(u.T), x, rtol=rtol, err_msg=msg)
 
-    for n, dtype in itertools.product(sizes, complex_dtypes):
-        msg1 = ("Her failed for size: {}, dtype: {}".format(n, dtype))
-        msg2 = ("Sym failed for size: {}, dtype: {}".format(n, dtype))
+@pytest.mark.parametrize("dtype", [complex64, complex128])
+@pytest.mark.parametrize("n", [30, 750])
+def test_ldl_type_size_combinations_complex(n, dtype):
+    seed(1234)
+    msg1 = ("Her failed for size: {}, dtype: {}".format(n, dtype))
+    msg2 = ("Sym failed for size: {}, dtype: {}".format(n, dtype))
 
-        # Complex hermitian upper/lower
-        x = (rand(n, n)+1j*rand(n, n)).astype(dtype)
-        x = x+x.conj().T
-        x += eye(n, dtype=dtype)*dtype(randint(5, 1e6))
+    # Complex hermitian upper/lower
+    x = (rand(n, n)+1j*rand(n, n)).astype(dtype)
+    x = x+x.conj().T
+    x += eye(n, dtype=dtype)*dtype(randint(5, 1e6))
 
-        l, d1, p = ldl(x)
-        u, d2, p = ldl(x, lower=0)
-        rtol = 1e-4 if dtype is complex64 else 1e-10
-        assert_allclose(l.dot(d1).dot(l.conj().T), x, rtol=rtol, err_msg=msg1)
-        assert_allclose(u.dot(d2).dot(u.conj().T), x, rtol=rtol, err_msg=msg1)
+    l, d1, p = ldl(x)
+    u, d2, p = ldl(x, lower=0)
+    rtol = 1e-4 if dtype is complex64 else 1e-10
+    assert_allclose(l.dot(d1).dot(l.conj().T), x, rtol=rtol, err_msg=msg1)
+    assert_allclose(u.dot(d2).dot(u.conj().T), x, rtol=rtol, err_msg=msg1)
 
-        # Complex symmetric upper/lower
-        x = (rand(n, n)+1j*rand(n, n)).astype(dtype)
-        x = x+x.T
-        x += eye(n, dtype=dtype)*dtype(randint(5, 1e6))
+    # Complex symmetric upper/lower
+    x = (rand(n, n)+1j*rand(n, n)).astype(dtype)
+    x = x+x.T
+    x += eye(n, dtype=dtype)*dtype(randint(5, 1e6))
 
-        l, d1, p = ldl(x, hermitian=0)
-        u, d2, p = ldl(x, lower=0, hermitian=0)
-        assert_allclose(l.dot(d1).dot(l.T), x, rtol=rtol, err_msg=msg2)
-        assert_allclose(u.dot(d2).dot(u.T), x, rtol=rtol, err_msg=msg2)
+    l, d1, p = ldl(x, hermitian=0)
+    u, d2, p = ldl(x, lower=0, hermitian=0)
+    assert_allclose(l.dot(d1).dot(l.T), x, rtol=rtol, err_msg=msg2)
+    assert_allclose(u.dot(d2).dot(u.T), x, rtol=rtol, err_msg=msg2)

--- a/scipy/linalg/tests/test_decomp_ldl.py
+++ b/scipy/linalg/tests/test_decomp_ldl.py
@@ -92,7 +92,7 @@ def test_permutations():
 
 
 @pytest.mark.parametrize("dtype", [float32, float64])
-@pytest.mark.parametrize("n", [30, 750])
+@pytest.mark.parametrize("n", [30, 150])
 def test_ldl_type_size_combinations_real(n, dtype):
     seed(1234)
     msg = ("Failed for size: {}, dtype: {}".format(n, dtype))
@@ -109,7 +109,7 @@ def test_ldl_type_size_combinations_real(n, dtype):
 
 
 @pytest.mark.parametrize("dtype", [complex64, complex128])
-@pytest.mark.parametrize("n", [30, 750])
+@pytest.mark.parametrize("n", [30, 150])
 def test_ldl_type_size_combinations_complex(n, dtype):
     seed(1234)
     msg1 = ("Her failed for size: {}, dtype: {}".format(n, dtype))


### PR DESCRIPTION
This test is a prime example of something that should be parametrized - it's long, contains a loop, and figuring out where a failure _actually_ comes from is onerous.

Additionally, `test_ldl_type_size_combinations` is one of the longest-running test in conda-forge CI, especially in emulation (for cross-compiled packages). This is problematic because with some bad luck, the machines are slow enough that this test takes longer than our individual test timeout of 20min and then fails the CI, Happily this also happens to be defused completely by breaking up the test into (16) pieces through parametrization.

If viewed without whitespace changes (use ⚙️ in changes tab), the commit is even smaller:

<details>

```diff
diff --git a/scipy/linalg/tests/test_decomp_ldl.py b/scipy/linalg/tests/test_decomp_ldl.py
index ce6b7c05f..99642c785 100644
--- a/scipy/linalg/tests/test_decomp_ldl.py
+++ b/scipy/linalg/tests/test_decomp_ldl.py
@@ -5,6 +5,7 @@ from numpy import (array, eye, zeros, empty_like, empty, tril_indices_from,
                    complex64, complex128)
 from numpy.random import rand, randint, seed
 from scipy.linalg import ldl
+import pytest
 from pytest import raises as assert_raises, warns
 from numpy import ComplexWarning

@@ -90,13 +90,10 @@ def test_permutations():
         assert_(not any(l[p, :][u_ind]), 'Spin {} failed'.format(_))


-def test_ldl_type_size_combinations():
+@pytest.mark.parametrize("dtype", [float32, float64])
+@pytest.mark.parametrize("n", [30, 750])
+def test_ldl_type_size_combinations_real(n, dtype):
     seed(1234)
-    sizes = [30, 750]
-    real_dtypes = [float32, float64]
-    complex_dtypes = [complex64, complex128]
-
-    for n, dtype in itertools.product(sizes, real_dtypes):
     msg = ("Failed for size: {}, dtype: {}".format(n, dtype))

     x = rand(n, n).astype(dtype)
@@ -109,7 +106,11 @@ def test_ldl_type_size_combinations():
     assert_allclose(l.dot(d1).dot(l.T), x, rtol=rtol, err_msg=msg)
     assert_allclose(u.dot(d2).dot(u.T), x, rtol=rtol, err_msg=msg)

-    for n, dtype in itertools.product(sizes, complex_dtypes):
+
+@pytest.mark.parametrize("dtype", [complex64, complex128])
+@pytest.mark.parametrize("n", [30, 750])
+def test_ldl_type_size_combinations_real(n, dtype):
+    seed(1234)
     msg1 = ("Her failed for size: {}, dtype: {}".format(n, dtype))
     msg2 = ("Sym failed for size: {}, dtype: {}".format(n, dtype))
```

</details>