### PR TITLE
CI: temporary asv pin

### DIFF
--- a/ci/azure-travis-template.yaml
+++ b/ci/azure-travis-template.yaml
@@ -87,7 +87,7 @@ steps:
   - script: sudo apt-get install -y wamerican-small
     displayName: 'Install word list (for csgraph tutorial)'
 - ${{ if eq(parameters.asv_check, true) }}:
-  - script: pip install "asv>=0.4.1"
+  - script: pip install "asv==0.4.2"
     displayName: 'Install asv'
 - script: pip uninstall -y nose
   displayName: 'Uninstall Nose'


### PR DESCRIPTION
* temporarily pin the version of `asv` used by
Azure CI until gh-15535 can be investigated in
more detail