### PR TITLE
DOC: missing section for metrics

### DIFF
--- a/scipy/spatial/__init__.py
+++ b/scipy/spatial/__init__.py
@@ -19,6 +19,9 @@ Nearest-neighbor queries
    cKDTree     -- class for efficient nearest-neighbor queries (faster implementation)
    Rectangle
 
+Distance metrics
+================
+
 Distance metrics are contained in the :mod:`scipy.spatial.distance` submodule.
 
 Delaunay triangulation, convex hulls, and Voronoi diagrams


### PR DESCRIPTION
Small documentation fix to add a dedicated section for `spatial.metrics`.

Current state
<img width="400" alt="Screenshot 2022-02-07 at 17 39 26" src="https://user-images.githubusercontent.com/23188539/152831727-f7fff04e-4f13-4671-86bf-0617eae4dceb.png">

It looks like metrics are part of `Nearest-neighbor queries` which is wrong. And there is no entry in the TOC on the right.

This PR makes the section more prominent. It's a first step into improving this part of the doc.

<img width="400" alt="Screenshot 2022-02-07 at 18 34 24" src="https://user-images.githubusercontent.com/23188539/152841409-d0aa10f0-96f5-4a60-b039-63aeb1f211c5.png">


