### PR TITLE
ENH, BLD: Add configure option for blas/lapack libraries

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -16,6 +16,8 @@ project(
     'c_args=-Wno-unused-function -Wno-conversion -Wno-misleading-indentation -Wno-incompatible-pointer-types',
     'fortran_args=-Wno-conversion',
     'fortran_std=legacy',
+    'blas=openblas',
+    'lapack=openblas'
   ],
 )
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,4 @@
+option('blas', type: 'string', value: 'openblas',
+        description: 'option for BLAS library switching')
+option('lapack', type: 'string', value: 'openblas',
+        description: 'option for LAPACK library switching')

--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -44,11 +44,14 @@ fblas_module = custom_target('fblas_module',
   command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 )
 
+# Note: we're linking LAPACK on purpose here. For some routines (e.g., spmv)
+# the float/double routines are in BLAS while the complex routines are in
+# LAPACK - we have historically put these in `_fblas`.
 py3.extension_module('_fblas',
   [fblas_module, fortranobject_c, g77_abi_wrappers],
   c_args: numpy_nodepr_api,
   include_directories: [inc_np, inc_f2py],
-  dependencies: [py3_dep, blas],
+  dependencies: [py3_dep, blas, lapack],
   install: true,
   link_language: 'fortran',
   subdir: 'scipy/linalg'
@@ -205,7 +208,7 @@ cython_blas = py3.extension_module('cython_blas',
   c_args: cython_c_args,
   link_with: fwrappers,
   include_directories: inc_np,
-  dependencies: [py3_dep, blas],
+  dependencies: [py3_dep, blas, lapack],
   install: true,
   link_language: 'fortran',
   subdir: 'scipy/linalg'
@@ -220,7 +223,7 @@ cython_lapack = py3.extension_module('cython_lapack',
   c_args: cython_c_args,
   link_with: fwrappers,
   include_directories: inc_np,
-  dependencies: [py3_dep, blas],
+  dependencies: [py3_dep, blas, lapack],
   install: true,
   link_language: 'fortran',
   subdir: 'scipy/linalg'

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -108,12 +108,17 @@ numpy_nodepr_api = '-DNPY_NO_DEPRECATED_API=NPY_1_9_API_VERSION'
 
 
 # TODO: 64-bit BLAS and LAPACK
-blas = dependency('openblas')
-lapack = dependency('openblas')
+blas = dependency(get_option('blas'))
+lapack = dependency(get_option('lapack'))
 
-# TODO: deal with case where we do need the g77 ABI wrappers (see
-#       _build_utils/_fortran.py)
-g77_abi_wrappers = files('_build_utils' / 'src' / 'wrap_dummy_g77_abi.f')
+if blas.name() == 'mkl' or lapack.name() == 'mkl'
+  g77_abi_wrappers = files([
+    '_build_utils/src/wrap_g77_abi_f.f',
+    '_build_utils/src/wrap_g77_abi_c.c'
+    ])
+else
+  g77_abi_wrappers = files('_build_utils/src/wrap_dummy_g77_abi.f')
+endif
 
 generate_config = custom_target(
   'generate-config',

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -108,6 +108,14 @@ numpy_nodepr_api = '-DNPY_NO_DEPRECATED_API=NPY_1_9_API_VERSION'
 
 
 # TODO: 64-bit BLAS and LAPACK
+#
+# Note that this works as long as BLAS and LAPACK are detected properly via
+# pkg-config. By default we look for OpenBLAS, other libraries can be configured via
+# `meson configure -Dblas=blas -Dlapack=lapack` (example to build with Netlib
+# BLAS and LAPACK).
+# For MKL and for auto-detecting one of multiple libs, we'll need a custom
+# dependency in Meson (like is done for scalapack) - see
+# https://github.com/mesonbuild/meson/issues/2835
 blas = dependency(get_option('blas'))
 lapack = dependency(get_option('lapack'))
 

--- a/scipy/odr/meson.build
+++ b/scipy/odr/meson.build
@@ -8,16 +8,6 @@ odrpack = static_library('odrpack',
   fortran_args: '-Wno-conversion',  # silence "conversion from REAL(8) to INTEGER(4)"
 )
 
-# TODO: add support for multiple BLAS libraries!
-# Note that this works as is with conda (on Linx at least), because
-# openblas is detected properly via pkg-config. For multiple BLAS/LAPACK
-# libraries, we'll need a custom dependency in Meson (like is done for
-# scalapack).
-# conda: pkgconfig.variables('openblas')
-# https://github.com/mesonbuild/meson/issues/2835
-# TODO: 64-bit BLAS
-blas = dependency('openblas')
-
 py3.extension_module('__odrpack',
   '__odrpack.c',
   link_with: odrpack,

--- a/scipy/sparse/linalg/_dsolve/meson.build
+++ b/scipy/sparse/linalg/_dsolve/meson.build
@@ -201,7 +201,7 @@ _superlu = py3.extension_module('_superlu',
   c_args: numpy_nodepr_api,
   link_with: [superlu_lib],
   include_directories: [incdir_numpy, 'SuperLU/SRC'],
-  dependencies: [py3_dep, lapack],
+  dependencies: [py3_dep, blas, lapack],
   install: true,
   subdir: 'scipy/sparse/linalg/_dsolve'
 )


### PR DESCRIPTION
We can now switch blas/lapack libraries (after `meson setup`) in the following way:

```
$ cd build
$ meson configure # list all the options
$ meson configure -Dblas=mkl  # Change blas library
```
cc @rgommers