### PR TITLE
DOC: stray backticks

### DIFF
--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -551,7 +551,7 @@ def dblquad(func, a, b, gfun, hfun, args=(), epsabs=1.49e-8, epsrel=1.49e-8):
         Extra arguments to pass to `func`.
     epsabs : float, optional
         Absolute tolerance passed directly to the inner 1-D quadrature
-        integration. Default is 1.49e-8. `dblquad`` tries to obtain
+        integration. Default is 1.49e-8. ``dblquad`` tries to obtain
         an accuracy of ``abs(i-result) <= max(epsabs, epsrel*abs(i))``
         where ``i`` = inner integral of ``func(y, x)`` from ``gfun(x)``
         to ``hfun(x)``, and ``result`` is the numerical approximation.

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -37,7 +37,7 @@ if trapezoid.__doc__:
 # Note: alias kept for backwards compatibility. Rename was done
 # because trapz is a slur in colloquial English (see gh-12924).
 def trapz(y, x=None, dx=1.0, axis=-1):
-    """`An alias of `trapezoid`.
+    """An alias of `trapezoid`.
 
     `trapz` is kept for backwards compatibility. For new code, prefer
     `trapezoid` instead.
@@ -288,7 +288,7 @@ def tupleset(t, i, value):
 # Note: alias kept for backwards compatibility. Rename was done
 # because cumtrapz is a slur in colloquial English (see gh-12924).
 def cumtrapz(y, x=None, dx=1.0, axis=-1, initial=None):
-    """`An alias of `cumulative_trapezoid`.
+    """An alias of `cumulative_trapezoid`.
 
     `cumtrapz` is kept for backwards compatibility. For new code, prefer
     `cumulative_trapezoid` instead.
@@ -422,7 +422,7 @@ def _basic_simpson(y, start, stop, x, dx, axis):
 # Note: alias kept for backwards compatibility. simps was renamed to simpson
 # because the former is a slur in colloquial English (see gh-12924).
 def simps(y, x=None, dx=1.0, axis=-1, even='avg'):
-    """`An alias of `simpson`.
+    """An alias of `simpson`.
 
     `simps` is kept for backwards compatibility. For new code, prefer
     `simpson` instead.


### PR DESCRIPTION
Some stray backticks.

Messing up rst parsing, and looks like got copied around... so better to remove them ? 

Also a mismatched pairs of backticks., technically i guess it could be single pair, as it's referring to self. Happy to change the other way arround.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->
<!--
#### Reference issue
<!--Example: Closes gh-WXYZ.-->
<!--
#### What does this implement/fix?
<!--Please explain your changes.-->
<!--
#### Additional information
<!--Any additional information you think is important.-->
