### PR TITLE
DOC: incorrect underline lenght in section.

### DIFF
--- a/scipy/optimize/_remove_redundancy.py
+++ b/scipy/optimize/_remove_redundancy.py
@@ -118,7 +118,7 @@ def _remove_redundancy_pivot_dense(A, rhs, true_rank=None):
         An array representing the right-hand side of a system of equations
 
     Returns
-    ----------
+    -------
     A : 2-D sparse matrix
         A matrix representing the left-hand side of a system of equations
     rhs : 1-D array


### PR DESCRIPTION
NumpyDoc emits a warning which clutters output.

[skip azp] [skip actions]

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->
<!-- 
#### Reference issue
<!--Example: Closes gh-WXYZ.-->
<!-- 
#### What does this implement/fix?
<!--Please explain your changes.-->
<!-- 
#### Additional information
<!--Any additional information you think is important.-->
