### PR TITLE
BUG: fix error message

### DIFF
--- a/scipy/sparse/linalg/_eigen/_svds.py
+++ b/scipy/sparse/linalg/_eigen/_svds.py
@@ -102,7 +102,7 @@ def _iv(A, k, ncv, tol, which, v0, maxiter,
 
         shape = (A.shape[0],) if solver == 'propack' else (min(A.shape),)
         if v0.shape != shape:
-            message = "`v0` must have shape {shape}."
+            message = f"`v0` must have shape {shape}."
             raise ValueError(message)
 
     # input validation/standardization for `maxiter`

--- a/scipy/sparse/linalg/_eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/_eigen/tests/test_svds.py
@@ -166,10 +166,10 @@ class SVDSCommonTests:
         if transpose:
             A = A.T
         k = 2
-        message = "`v0` must have shape"
 
         required_length = (A.shape[0] if self.solver == 'propack'
                            else min(A.shape))
+        message = f"`v0` must have shape \\({required_length},\\)."
         if n != required_length:
             with pytest.raises(ValueError, match=message):
                 svds(A, k=k, v0=v0, solver=self.solver)
@@ -177,7 +177,7 @@ class SVDSCommonTests:
     def test_svds_input_validation_v0_2(self):
         A = np.ones((10, 10))
         v0 = np.ones((1, 10))
-        message = "`v0` must have shape"
+        message = f"`v0` must have shape \\({A[0]},\\)."
         with pytest.raises(ValueError, match=message):
             svds(A, k=1, v0=v0, solver=self.solver)
 

--- a/scipy/sparse/linalg/_eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/_eigen/tests/test_svds.py
@@ -169,16 +169,16 @@ class SVDSCommonTests:
 
         required_length = (A.shape[0] if self.solver == 'propack'
                            else min(A.shape))
-        message = f"`v0` must have shape \\({required_length},\\)."
+        message = f"`v0` must have shape ({required_length},)."
         if n != required_length:
-            with pytest.raises(ValueError, match=message):
+            with pytest.raises(ValueError, match=re.escape(message)):
                 svds(A, k=k, v0=v0, solver=self.solver)
 
     def test_svds_input_validation_v0_2(self):
         A = np.ones((10, 10))
         v0 = np.ones((1, 10))
-        message = f"`v0` must have shape \\({A.shape[0]},\\)."
-        with pytest.raises(ValueError, match=message):
+        message = f"`v0` must have shape (10,)."
+        with pytest.raises(ValueError, match=re.escape(message)):
             svds(A, k=1, v0=v0, solver=self.solver)
 
     @pytest.mark.parametrize("v0", ("hi", 1, np.ones(10, dtype=int)))

--- a/scipy/sparse/linalg/_eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/_eigen/tests/test_svds.py
@@ -177,7 +177,7 @@ class SVDSCommonTests:
     def test_svds_input_validation_v0_2(self):
         A = np.ones((10, 10))
         v0 = np.ones((1, 10))
-        message = f"`v0` must have shape \\({A[0]},\\)."
+        message = f"`v0` must have shape \\({A.shape[0]},\\)."
         with pytest.raises(ValueError, match=message):
             svds(A, k=1, v0=v0, solver=self.solver)
 

--- a/scipy/sparse/linalg/_eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/_eigen/tests/test_svds.py
@@ -177,7 +177,7 @@ class SVDSCommonTests:
     def test_svds_input_validation_v0_2(self):
         A = np.ones((10, 10))
         v0 = np.ones((1, 10))
-        message = f"`v0` must have shape (10,)."
+        message = "`v0` must have shape (10,)."
         with pytest.raises(ValueError, match=re.escape(message)):
             svds(A, k=1, v0=v0, solver=self.solver)
 

--- a/scipy/sparse/linalg/_eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/_eigen/tests/test_svds.py
@@ -166,19 +166,19 @@ class SVDSCommonTests:
         if transpose:
             A = A.T
         k = 2
+        message = "`v0` must have shape"
 
         required_length = (A.shape[0] if self.solver == 'propack'
                            else min(A.shape))
-        message = f"`v0` must have shape ({required_length},)."
         if n != required_length:
-            with pytest.raises(ValueError, match=re.escape(message)):
+            with pytest.raises(ValueError, match=message):
                 svds(A, k=k, v0=v0, solver=self.solver)
 
     def test_svds_input_validation_v0_2(self):
         A = np.ones((10, 10))
         v0 = np.ones((1, 10))
-        message = "`v0` must have shape (10,)."
-        with pytest.raises(ValueError, match=re.escape(message)):
+        message = "`v0` must have shape"
+        with pytest.raises(ValueError, match=message):
             svds(A, k=1, v0=v0, solver=self.solver)
 
     @pytest.mark.parametrize("v0", ("hi", 1, np.ones(10, dtype=int)))


### PR DESCRIPTION
#### Reference issue

https://github.com/neurospin/pylearn-parsimony/issues/35

#### What does this implement/fix?

The error message requires literal string interpolation to fill the `{shape}`.