### PR TITLE
MAINT: bump test tolerance in test_linprog

### DIFF
--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -2035,7 +2035,7 @@ class TestLinprogIPSpecific:
         res2 = linprog(c, A_ub=A, b_ub=b, method=self.method)  # default solver
         assert_allclose(res1.fun, res2.fun,
                         err_msg="linprog default solver unexpected result",
-                        rtol=1e-15, atol=1e-15)
+                        rtol=2e-15, atol=1e-15)
 
     def test_unbounded_below_no_presolve_original(self):
         # formerly caused segfault in TravisCI w/ "cholesky":True


### PR DESCRIPTION
Bump test tolerance in one of linprog tests. Otherwise it fails with 

```
$ python dev.py -t scipy/optimize/tests/test_linprog.py::TestLinprogIPSpecific::test_solver_select
ninja: Entering directory `build'
[2/2] Generating scipy/generate-config with a custom command
Build OK
Installing, see meson-install.log...
Installation OK
Running tests for scipy version:1.9.0.dev0+1463.e98bdfd, installed at:/home/br/repos/scipy/scipy/build-install/lib/python3.8/site-packages/scipy
================================= test session starts ==================================
platform linux -- Python 3.8.10, pytest-7.0.0, pluggy-1.0.0
rootdir: /home/br/repos/scipy/scipy, configfile: pytest.ini
collected 1 item                                                                       

scipy/optimize/tests/test_linprog.py F                                           [100%]

======================================= FAILURES =======================================
_______________________ TestLinprogIPSpecific.test_solver_select _______________________
scipy/optimize/tests/test_linprog.py:2036: in test_solver_select
    assert_allclose(res1.fun, res2.fun,
E   AssertionError: 
E   Not equal to tolerance rtol=1e-15, atol=1e-15
E   linprog default solver unexpected result
E   Mismatched elements: 1 / 1 (100%)
E   Max absolute difference: 7.10542736e-14
E   Max relative difference: 1.1093651e-15
E    x: array(-64.049494)
E    y: array(-64.049494)
```

As a factoid, the failure is observed on ubuntu focal with stock OpenBLAS and is not observed with netlib atlas (both `sudo apt`-installed).