### PR TITLE
MAINT: stats: deprecate non-numeric array support in stats.mode

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -445,7 +445,7 @@ def mode(a, axis=0, nan_policy='propagate'):
         in the second release after SciPy 1.9.0. `pandas.DataFrame.mode`_ can
         be used instead.
 
-        .. _pandas.DataFrame.mode: <https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.mode.html>  # noqa: E501
+        .. _pandas.DataFrame.mode: https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.mode.html
 
     The mode of arrays with other dtypes is calculated using `np.unique`.
     In NumPy versions 1.21 and after, all NaNs - even those with different
@@ -468,7 +468,7 @@ def mode(a, axis=0, nan_policy='propagate'):
     >>> stats.mode(a, axis=None)
     ModeResult(mode=3, count=3)
 
-    """
+    """  # noqa: E501
     a, axis = _chk_asarray(a, axis)
     if a.size == 0:
         return ModeResult(np.array([]), np.array([]))

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -442,9 +442,10 @@ def mode(a, axis=0, nan_policy='propagate'):
 
     .. deprecated:: 1.9.0
         Support for non-numeric arrays has been deprecated and will be removed
-        in the second release after SciPy 1.9.0.
-        `pandas.DataFrame.mode <https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.mode.html>`_  # noqa: E501
-        can be used instead.
+        in the second release after SciPy 1.9.0. `pandas.DataFrame.mode`_ can
+        be used instead.
+
+        .. _pandas.DataFrame.mode: <https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.mode.html>  # noqa: E501
 
     The mode of arrays with other dtypes is calculated using `np.unique`.
     In NumPy versions 1.21 and after, all NaNs - even those with different

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -440,6 +440,12 @@ def mode(a, axis=0, nan_policy='propagate'):
     The mode of object arrays is calculated using `collections.Counter`, which
     treats NaNs with different binary representations as distinct.
 
+    .. deprecated:: 1.9.0
+        Support for object arrays has been deprecated and will be removed in
+        the second release after SciPy 1.9.0.
+        `pandas.DataFrame.mode <https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.mode.html>`_  # noqa: E501
+        can be used instead.
+
     The mode of arrays with other dtypes is calculated using `np.unique`.
     In NumPy versions 1.21 and after, all NaNs - even those with different
     binary representations - are treated as equivalent and counted as separate
@@ -471,6 +477,13 @@ def mode(a, axis=0, nan_policy='propagate'):
     if contains_nan and nan_policy == 'omit':
         a = ma.masked_invalid(a)
         return mstats_basic.mode(a, axis)
+
+    if a.dtype.kind not in 'uifc':
+        warnings.warn("Support for non-numeric arrays has been deprecated "
+                      "and will be removed in the second release after "
+                      "1.9.0. `pandas.DataFrame.mode` can be used instead, "
+                      "see https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.mode.html.",  # noqa: E501
+                      DeprecationWarning, stacklevel=2)
 
     if a.dtype == object:
         def _mode1D(a):

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -443,7 +443,7 @@ def mode(a, axis=0, nan_policy='propagate'):
     .. deprecated:: 1.9.0
         Support for object arrays has been deprecated and will be removed in
         the second release after SciPy 1.9.0.
-        `pandas.DataFrame.mode <https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.mode.html>`_  # noqa: E501
+        `pandas.DataFrame.mode <https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.mode.html>`_
         can be used instead.
 
     The mode of arrays with other dtypes is calculated using `np.unique`.

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -443,7 +443,7 @@ def mode(a, axis=0, nan_policy='propagate'):
     .. deprecated:: 1.9.0
         Support for object arrays has been deprecated and will be removed in
         the second release after SciPy 1.9.0.
-        `pandas.DataFrame.mode <https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.mode.html>`_
+        `pandas.DataFrame.mode <https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.mode.html>`_  # noqa: E501
         can be used instead.
 
     The mode of arrays with other dtypes is calculated using `np.unique`.

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -441,8 +441,8 @@ def mode(a, axis=0, nan_policy='propagate'):
     treats NaNs with different binary representations as distinct.
 
     .. deprecated:: 1.9.0
-        Support for object arrays has been deprecated and will be removed in
-        the second release after SciPy 1.9.0.
+        Support for non-numeric arrays has been deprecated and will be removed
+        in the second release after SciPy 1.9.0.
         `pandas.DataFrame.mode <https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.mode.html>`_  # noqa: E501
         can be used instead.
 
@@ -478,7 +478,7 @@ def mode(a, axis=0, nan_policy='propagate'):
         a = ma.masked_invalid(a)
         return mstats_basic.mode(a, axis)
 
-    if a.dtype.kind not in 'uifc':
+    if not np.issubdtype(a.dtype, np.number):
         warnings.warn("Support for non-numeric arrays has been deprecated "
                       "and will be removed in the second release after "
                       "1.9.0. `pandas.DataFrame.mode` can be used instead, "

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2178,7 +2178,10 @@ class TestMode:
 
     def test_strings(self):
         data1 = ['rain', 'showers', 'showers']
-        vals = stats.mode(data1)
+        with pytest.warns(DeprecationWarning,
+                          match=r"Support for non-numeric arrays has been "
+                                r"deprecated"):
+            vals = stats.mode(data1)
         assert_equal(vals[0], 'showers')
         assert_equal(vals[1], 2)
 
@@ -2186,7 +2189,10 @@ class TestMode:
         objects = [10, True, np.nan, 'hello', 10]
         arr = np.empty((5,), dtype=object)
         arr[:] = objects
-        vals = stats.mode(arr)
+        with pytest.warns(DeprecationWarning,
+                          match=r"Support for non-numeric arrays has been "
+                                r"deprecated"):
+            vals = stats.mode(arr)
         assert_equal(vals[0], 10)
         assert_equal(vals[1], 2)
 
@@ -2214,7 +2220,10 @@ class TestMode:
         arr[:] = points
         assert_(len(set(points)) == 4)
         assert_equal(np.unique(arr).shape, (4,))
-        vals = stats.mode(arr)
+        with pytest.warns(DeprecationWarning,
+                          match=r"Support for non-numeric arrays has been "
+                                r"deprecated"):
+            vals = stats.mode(arr)
 
         assert_equal(vals[0], Point(2))
         assert_equal(vals[1], 4)
@@ -2252,13 +2261,19 @@ class TestMode:
         # regression test for gh-9645: `mode` fails for object arrays w/ndim > 1
         data = [['Oxidation'], ['Oxidation'], ['Polymerization'], ['Reduction']]
         ar = np.array(data, dtype=object)
-        m = stats.mode(ar, axis=0)
+        with pytest.warns(DeprecationWarning,
+                          match=r"Support for non-numeric arrays has been "
+                                r"deprecated"):
+            m = stats.mode(ar, axis=0)
         assert np.all(m.mode == 'Oxidation') and m.mode.shape == (1,)
         assert np.all(m.count == 2) and m.count.shape == (1,)
 
         data1 = data + [[np.nan]]
         ar1 = np.array(data1, dtype=object)
-        m = stats.mode(ar1, axis=0)
+        with pytest.warns(DeprecationWarning,
+                          match=r"Support for non-numeric arrays has been "
+                                r"deprecated"):
+            m = stats.mode(ar1, axis=0)
         assert np.all(m.mode == 'Oxidation') and m.mode.shape == (1,)
         assert np.all(m.count == 2) and m.count.shape == (1,)
 
@@ -2267,7 +2282,13 @@ class TestMode:
     def test_mode_shape_gh_9955(self, axis, dtype):
         rng = np.random.default_rng(984213899)
         a = rng.uniform(size=(3, 4, 5)).astype(dtype)
-        res = stats.mode(a, axis=axis)
+        if dtype == 'object':
+            with pytest.warns(DeprecationWarning,
+                              match=r"Support for non-numeric arrays has "
+                                    r"been deprecated"):
+                res = stats.mode(a, axis=axis)
+        else:
+            res = stats.mode(a, axis=axis)
         reference_shape = list(a.shape)
         reference_shape.pop(axis)
         np.testing.assert_array_equal(res.mode.shape, reference_shape)
@@ -2284,11 +2305,17 @@ class TestMode:
         # mode should work on object arrays. There were issues when
         # objects do not support comparison operations.
         a = np.array(a, dtype='object')
-        res = stats.mode(a)
+        with pytest.warns(DeprecationWarning,
+                          match=r"Support for non-numeric arrays has been "
+                                r"deprecated"):
+            res = stats.mode(a)
         assert np.isnan(res.mode) and res.count == 2
 
         a = np.array([10, True, 'hello', 10], dtype='object')
-        res = stats.mode(a)
+        with pytest.warns(DeprecationWarning,
+                          match=r"Support for non-numeric arrays has been "
+                                r"deprecated"):
+            res = stats.mode(a)
         assert_array_equal(res, (10, 2))
 
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2132,6 +2132,9 @@ class TestItemfreq:
 
 
 class TestMode:
+
+    deprecation_msg = r"Support for non-numeric arrays has been deprecated"
+
     def test_empty(self):
         vals, counts = stats.mode([])
         assert_equal(vals, np.array([]))
@@ -2178,9 +2181,7 @@ class TestMode:
 
     def test_strings(self):
         data1 = ['rain', 'showers', 'showers']
-        with pytest.warns(DeprecationWarning,
-                          match=r"Support for non-numeric arrays has been "
-                                r"deprecated"):
+        with pytest.warns(DeprecationWarning, match=self.deprecation_msg):
             vals = stats.mode(data1)
         assert_equal(vals[0], 'showers')
         assert_equal(vals[1], 2)
@@ -2189,9 +2190,7 @@ class TestMode:
         objects = [10, True, np.nan, 'hello', 10]
         arr = np.empty((5,), dtype=object)
         arr[:] = objects
-        with pytest.warns(DeprecationWarning,
-                          match=r"Support for non-numeric arrays has been "
-                                r"deprecated"):
+        with pytest.warns(DeprecationWarning, match=self.deprecation_msg):
             vals = stats.mode(arr)
         assert_equal(vals[0], 10)
         assert_equal(vals[1], 2)
@@ -2220,9 +2219,7 @@ class TestMode:
         arr[:] = points
         assert_(len(set(points)) == 4)
         assert_equal(np.unique(arr).shape, (4,))
-        with pytest.warns(DeprecationWarning,
-                          match=r"Support for non-numeric arrays has been "
-                                r"deprecated"):
+        with pytest.warns(DeprecationWarning, match=self.deprecation_msg):
             vals = stats.mode(arr)
 
         assert_equal(vals[0], Point(2))
@@ -2261,18 +2258,14 @@ class TestMode:
         # regression test for gh-9645: `mode` fails for object arrays w/ndim > 1
         data = [['Oxidation'], ['Oxidation'], ['Polymerization'], ['Reduction']]
         ar = np.array(data, dtype=object)
-        with pytest.warns(DeprecationWarning,
-                          match=r"Support for non-numeric arrays has been "
-                                r"deprecated"):
+        with pytest.warns(DeprecationWarning, match=self.deprecation_msg):
             m = stats.mode(ar, axis=0)
         assert np.all(m.mode == 'Oxidation') and m.mode.shape == (1,)
         assert np.all(m.count == 2) and m.count.shape == (1,)
 
         data1 = data + [[np.nan]]
         ar1 = np.array(data1, dtype=object)
-        with pytest.warns(DeprecationWarning,
-                          match=r"Support for non-numeric arrays has been "
-                                r"deprecated"):
+        with pytest.warns(DeprecationWarning, match=self.deprecation_msg):
             m = stats.mode(ar1, axis=0)
         assert np.all(m.mode == 'Oxidation') and m.mode.shape == (1,)
         assert np.all(m.count == 2) and m.count.shape == (1,)
@@ -2283,9 +2276,7 @@ class TestMode:
         rng = np.random.default_rng(984213899)
         a = rng.uniform(size=(3, 4, 5)).astype(dtype)
         if dtype == 'object':
-            with pytest.warns(DeprecationWarning,
-                              match=r"Support for non-numeric arrays has "
-                                    r"been deprecated"):
+            with pytest.warns(DeprecationWarning, match=self.deprecation_msg):
                 res = stats.mode(a, axis=axis)
         else:
             res = stats.mode(a, axis=axis)
@@ -2305,16 +2296,12 @@ class TestMode:
         # mode should work on object arrays. There were issues when
         # objects do not support comparison operations.
         a = np.array(a, dtype='object')
-        with pytest.warns(DeprecationWarning,
-                          match=r"Support for non-numeric arrays has been "
-                                r"deprecated"):
+        with pytest.warns(DeprecationWarning, match=self.deprecation_msg):
             res = stats.mode(a)
         assert np.isnan(res.mode) and res.count == 2
 
         a = np.array([10, True, 'hello', 10], dtype='object')
-        with pytest.warns(DeprecationWarning,
-                          match=r"Support for non-numeric arrays has been "
-                                r"deprecated"):
+        with pytest.warns(DeprecationWarning, match=self.deprecation_msg):
             res = stats.mode(a)
         assert_array_equal(res, (10, 2))
 


### PR DESCRIPTION
#### Reference issue

closes gh-15551

#### What does this implement/fix?

Deprecate support for non-numeric arrays in `stats.mode`. With these changes, only unsigned integers, integers, floating points, and complex data types will be supported. Support for all other data types will be dropped. The deprecation warning uses similar wording as in gh-15512 since we still don't know the version number after 1.9 (gh-15528).

#### Additional information

@mdhaber I think `_axis_nan_policy_factory` will still have problems with complex data type since it can't be safely converted to float64. Do you think we should support complex? IMO, yes because complex is still "numeric". Would adding support for complex be troublesome? I guess not, we can just find the common dtype among inputs and convert the output before returning.