### PR TITLE
MAINT: github template for user questions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,7 +6,7 @@ contact_links:
     about: Please ask and answer usage questions on Stack Overflow
   - name: User Mailing list
     url: https://mail.python.org/mailman3/lists/scipy-user.python.org/
-    about: User related questions and announcements on the mailing list
+    about: User-related questions and announcements on the mailing list
   - name: Developer Mailing list
     url: https://mail.python.org/mailman3/lists/scipy-dev.python.org/
     about: Development discussions and announcements on the mailing list

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,15 @@
+blank_issues_enabled: true
+contact_links:
+    about: Ask questions and discuss with other scipy community members
+  - name: Stack Overflow
+    url: https://stackoverflow.com/questions/tagged/scipy
+    about: Please ask and answer usage questions on Stack Overflow
+  - name: User Mailing list
+    url: https://mail.python.org/mailman3/lists/scipy-user.python.org/
+    about: User related questions and announcements on the mailing list
+  - name: Developer Mailing list
+    url: https://mail.python.org/mailman3/lists/scipy-dev.python.org/
+    about: Development discussions and announcements on the mailing list
+  - name: Blank issue
+    url: https://github.com/scipy/scipy/issues/new
+    about: Please note that other templates should be used in most cases

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,5 @@
 blank_issues_enabled: true
 contact_links:
-    about: Ask questions and discuss with other scipy community members
   - name: Stack Overflow
     url: https://stackoverflow.com/questions/tagged/scipy
     about: Please ask and answer usage questions on Stack Overflow

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,9 +4,6 @@ contact_links:
   - name: Stack Overflow
     url: https://stackoverflow.com/questions/tagged/scipy
     about: Please ask and answer usage questions on Stack Overflow
-  - name: User Mailing list
-    url: https://mail.python.org/mailman3/lists/scipy-user.python.org/
-    about: User-related questions and announcements on the mailing list
   - name: Developer Mailing list
     url: https://mail.python.org/mailman3/lists/scipy-dev.python.org/
     about: Development discussions and announcements on the mailing list


### PR DESCRIPTION
I've seen this on scikit-learn's repo. We can put links instead of templates.

<img width="500" alt="Screenshot 2022-02-11 at 17 55 58" src="https://user-images.githubusercontent.com/23188539/153634539-47a192db-f1cf-42c1-9ecd-68862b81ce79.png">

I followed what they had, but we can as well add some links to our dev doc. Note that we have such link in our templates as well.