### PR TITLE
Make Windows Python setup more standard

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,19 +16,15 @@ jobs:
     # Ensure (a) this doesn't run on forks by default, and
     #        (b) it does run with Act locally (`github` doesn't exist there)
     if: "github.repository != '' || github.repository == 'scipy/scipy'"
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+          architecture: 'x64'
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Choco python
-        uses: crazy-max/ghaction-chocolatey@v1
-        with:
-          args: install python --version=3.9.9 --no-progress
-      - name: set-python-path
-        run: |
-          # Install path, culled from output of Choco install above.
-          $py_dir = 'C:\hostedtoolcache\windows\Python\3.9.9\x64'
-          echo "$py_dir;$py_dir\Scripts;" >> $env:GITHUB_PATH
       - name: show-python-version
         run: |
           python --version


### PR DESCRIPTION
I was using my own Python install, because I was testing on a local
machine, but it's true that we should use the GHA Python setup tools for
this.

Thanks @tylerjereddy for the comment:
https://github.com/scipy/scipy/pull/15563#pullrequestreview-879741960

I agree too that the post-install is a little gruesome.  In fact we have
the same stuff implemented in Python in the `dev.py` script.  It might
be better to refactor that out into something in the `_build_tools`
directory, and run it as single Python command instead.  `dev.py`
could import the same code.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->