### PR TITLE
Fix incorrect error message in multivariate_normal

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -143,6 +143,10 @@ class _PSD:
         infinities or NaNs.
     allow_singular : bool, optional
         Whether to allow a singular matrix.  (Default: True)
+    check_symmetric : bool, optional
+        Whether to check symmetry of the matrix. Disabling may give a
+        performance gain, but may result in problems if the input is
+        asymmetric (Default: True)
 
     Notes
     -----
@@ -151,16 +155,15 @@ class _PSD:
     """
 
     def __init__(self, M, cond=None, rcond=None, lower=True,
-                 check_finite=True, allow_singular=True):
+                 check_finite=True, allow_singular=True, check_symmetric=True):
         # Compute the symmetric eigendecomposition.
         # Note that eigh takes care of array conversion, chkfinite,
         # and assertion that the matrix is square.
-        M = np.asarray(M)
+        if check_symmetric and not scipy.linalg.issymmetric(M):
+            raise ValueError('the input matrix must be symmetric')
         s, u = scipy.linalg.eigh(M, lower=lower, check_finite=check_finite)
 
         eps = _eigvalsh_to_eps(s, cond, rcond)
-        if not np.allclose(M, M.T, atol=1e-10):
-            raise ValueError('the input matrix must be symmetric')
         if np.min(s) < -eps:
             raise ValueError('the input matrix must be positive semidefinite')
         d = s[s > eps]

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -155,9 +155,12 @@ class _PSD:
         # Compute the symmetric eigendecomposition.
         # Note that eigh takes care of array conversion, chkfinite,
         # and assertion that the matrix is square.
+        M = np.asarray(M)
         s, u = scipy.linalg.eigh(M, lower=lower, check_finite=check_finite)
 
         eps = _eigvalsh_to_eps(s, cond, rcond)
+        if not np.allclose(M, M.T, atol=1e-10):
+            raise ValueError('the input matrix must be symmetric')
         if np.min(s) < -eps:
             raise ValueError('the input matrix must be positive semidefinite')
         d = s[s > eps]

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -159,7 +159,8 @@ class _PSD:
         # Compute the symmetric eigendecomposition.
         # Note that eigh takes care of array conversion, chkfinite,
         # and assertion that the matrix is square.
-        if check_symmetric and not scipy.linalg.issymmetric(M):
+        M = np.asarray(M)
+        if check_symmetric and not scipy.linalg.issymmetric(M, atol=1e-10):
             raise ValueError('the input matrix must be symmetric')
         s, u = scipy.linalg.eigh(M, lower=lower, check_finite=check_finite)
 

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -313,6 +313,11 @@ class TestMultivariateNormal:
         cov = [[1, 0], [0, -1]]
         assert_raises(ValueError, _PSD, cov)
 
+    def test_exception_symmetric_cov(self):
+        cov = [[1, 0], [1, 1]]
+        err_info = assert_raises(ValueError, _PSD, cov)
+        assert err_info.value.args[0] == 'the input matrix must be symmetric'
+
     def test_exception_singular_cov(self):
         np.random.seed(1234)
         x = np.random.randn(5)

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -315,8 +315,7 @@ class TestMultivariateNormal:
 
     def test_exception_symmetric_cov(self):
         cov = [[1, 0], [1, 1]]
-        err_info = assert_raises(ValueError, _PSD, cov)
-        assert err_info.value.args[0] == 'the input matrix must be symmetric'
+        assert_raises(ValueError, _PSD, cov)
 
     def test_exception_singular_cov(self):
         np.random.seed(1234)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #15508 

#### What does this implement/fix?
<!--Please explain your changes.-->
Modified _PSD class __init__ to check if input M matrix is symmetric and print an appropriate error message. Added the test for that too.

#### Additional information
<!--Any additional information you think is important.-->
