### PR TITLE
BUG: Avoid C Preprocessor symbol in _hypotests_pythran.py.

### DIFF
--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -12,8 +12,8 @@ from scipy.special import gamma, kv, gammaln, comb, factorial
 from . import _wilcoxon_data
 import scipy.stats._bootstrap as _bootstrap
 from scipy._lib._util import check_random_state
-from ._hypotests_pythran import _Q, _a_ij_Aij_Dij2
-from ._hypotests_pythran import _concordant_pairs as _P
+from ._hypotests_pythran import _a_ij_Aij_Dij2
+from ._hypotests_pythran import _concordant_pairs as _P, _discordant_pairs as _Q
 from ._axis_nan_policy import _broadcast_arrays
 
 __all__ = ['epps_singleton_2samp', 'cramervonmises', 'somersd',

--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -12,7 +12,8 @@ from scipy.special import gamma, kv, gammaln, comb, factorial
 from . import _wilcoxon_data
 import scipy.stats._bootstrap as _bootstrap
 from scipy._lib._util import check_random_state
-from ._hypotests_pythran import _Q, _P, _a_ij_Aij_Dij2
+from ._hypotests_pythran import _Q, _a_ij_Aij_Dij2
+from ._hypotests_pythran import _concordant_pairs as _P
 from ._axis_nan_policy import _broadcast_arrays
 
 __all__ = ['epps_singleton_2samp', 'cramervonmises', 'somersd',

--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -13,7 +13,9 @@ from . import _wilcoxon_data
 import scipy.stats._bootstrap as _bootstrap
 from scipy._lib._util import check_random_state
 from ._hypotests_pythran import _a_ij_Aij_Dij2
-from ._hypotests_pythran import _concordant_pairs as _P, _discordant_pairs as _Q
+from ._hypotests_pythran import (
+    _concordant_pairs as _P, _discordant_pairs as _Q
+)
 from ._axis_nan_policy import _broadcast_arrays
 
 __all__ = ['epps_singleton_2samp', 'cramervonmises', 'somersd',

--- a/scipy/stats/_hypotests_pythran.py
+++ b/scipy/stats/_hypotests_pythran.py
@@ -14,9 +14,9 @@ def _Dij(A, i, j):
     # See `somersd` References [2] bottom of page 309
     return A[i+1:, :j].sum() + A[:i, j+1:].sum()
 
-#pythran export _P(float[:,:])
-#pythran export _P(int[:,:])
-def _P(A):
+#pythran export _concordant_pairs(float[:,:])
+#pythran export _concordant_pairs(int[:,:])
+def _concordant_pairs(A):
     """Twice the number of concordant pairs, excluding ties."""
     # See `somersd` References [2] bottom of page 309
     m, n = A.shape

--- a/scipy/stats/_hypotests_pythran.py
+++ b/scipy/stats/_hypotests_pythran.py
@@ -14,6 +14,7 @@ def _Dij(A, i, j):
     # See `somersd` References [2] bottom of page 309
     return A[i+1:, :j].sum() + A[:i, j+1:].sum()
 
+
 #pythran export _concordant_pairs(float[:,:])
 #pythran export _concordant_pairs(int[:,:])
 def _concordant_pairs(A):
@@ -26,6 +27,7 @@ def _concordant_pairs(A):
             count += A[i, j]*_Aij(A, i, j)
     return count
 
+
 #pythran export _discordant_pairs(float[:,:])
 #pythran export _discordant_pairs(int[:,:])
 def _discordant_pairs(A):
@@ -37,6 +39,7 @@ def _discordant_pairs(A):
         for j in range(n):
             count += A[i, j]*_Dij(A, i, j)
     return count
+
 
 #pythran export _a_ij_Aij_Dij2(float[:,:])
 #pythran export _a_ij_Aij_Dij2(int[:,:])

--- a/scipy/stats/_hypotests_pythran.py
+++ b/scipy/stats/_hypotests_pythran.py
@@ -26,9 +26,9 @@ def _concordant_pairs(A):
             count += A[i, j]*_Aij(A, i, j)
     return count
 
-#pythran export _Q(float[:,:])
-#pythran export _Q(int[:,:])
-def _Q(A):
+#pythran export _discordant_pairs(float[:,:])
+#pythran export _discordant_pairs(int[:,:])
+def _discordant_pairs(A):
     """Twice the number of discordant pairs, excluding ties."""
     # See `somersd` References [2] bottom of page 309
     m, n = A.shape

--- a/scipy/stats/_hypotests_pythran.py
+++ b/scipy/stats/_hypotests_pythran.py
@@ -15,8 +15,8 @@ def _Dij(A, i, j):
     return A[i+1:, :j].sum() + A[:i, j+1:].sum()
 
 
-#pythran export _concordant_pairs(float[:,:])
-#pythran export _concordant_pairs(int[:,:])
+# pythran export _concordant_pairs(float[:,:])
+# pythran export _concordant_pairs(int[:,:])
 def _concordant_pairs(A):
     """Twice the number of concordant pairs, excluding ties."""
     # See `somersd` References [2] bottom of page 309
@@ -28,8 +28,8 @@ def _concordant_pairs(A):
     return count
 
 
-#pythran export _discordant_pairs(float[:,:])
-#pythran export _discordant_pairs(int[:,:])
+# pythran export _discordant_pairs(float[:,:])
+# pythran export _discordant_pairs(int[:,:])
 def _discordant_pairs(A):
     """Twice the number of discordant pairs, excluding ties."""
     # See `somersd` References [2] bottom of page 309


### PR DESCRIPTION
`_P` is a C Preprocessor symbol on my platform, so compilation of this file fails with many errors, starting with syntax errors: expected identifier before numeric constant and continuing with undeclared variables.

Renaming this function to have a longer name avoids this problem.

[The GCC documentation for its C preprocessor](https://gcc.gnu.org/onlinedocs/gcc-11.2.0/cpp/System-specific-Predefined-Macros.html#System-specific-Predefined-Macros) suggests that symbols starting with an underscore and a capital letter will perform unreliably when compiled, as they are part of the C preprocessor reserved namespace.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
This avoids compiler errors such as
```C++
struct _P var1
```
```
Error: expected identifier before numeric constant
```
followed by many
```
Error: variable var1 undeclared in this scope.  Did you mean ...
```
#### Additional information
<!--Any additional information you think is important.-->
You will probably need to be on Cygwin to reproduce this bug.  To reach this bug instead of failing earlier, you may need to patch the Boost headers to allow use on Cygwin.