### PR TITLE
MAINT: clarify deprecation warning spatial.transform.rotation

### DIFF
--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -25,8 +25,9 @@ def __getattr__(name):
             "scipy.spatial.transform.rotation is deprecated and has no attribute "
             f"{name}. Try looking in scipy.spatial instead.")
 
-    warnings.warn(f"Please use `{name}` from the `scipy.spatial` namespace, "
-                  "the `scipy.spatial.transform.rotation` namespace is deprecated.",
+    warnings.warn(f"Please use `{name}` from the `scipy.spatial.transform` "
+                  "namespace, the `scipy.spatial.transform.rotation` namespace"
+                  " is deprecated.",
                   category=DeprecationWarning, stacklevel=2)
 
     return getattr(_rotation, name)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #15572.

#### What does this implement/fix?
<!--Please explain your changes.-->

I suppose the previous message is technically correct, since Rotation is in the transform submodule of the spatial namespace, but the warning message is a bit vague since it's not entirely clear that it is the `.rotation` rather than `.transform.rotation` that is to be deprecated.

#### Additional information
<!--Any additional information you think is important.-->
Previous error message:
```
DeprecationWarning: Please use `Rotation` from the `scipy.spatial` namespace, the `scipy.spatial.transform.rotation` namespace is deprecated.
  from scipy.spatial.transform.rotation import Rotation
```

new warning message:
```
DeprecationWarning: Please use `Rotation` from the `scipy.spatial.transform` namespace, the `scipy.spatial.transform.rotation` namespace is deprecated.
  from scipy.spatial.transform.rotation import Rotation
```