### PR TITLE
DOC: factorialk docstring inconsistent with code

### DIFF
--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2463,7 +2463,8 @@ def factorialk(n, k, exact=True):
     Parameters
     ----------
     n : int
-        Calculate multifactorial. If `n` < 0, the return value is 0.
+        Calculate multifactorial. If `n` < 1 - `k`, the return value is 0.
+        Otherwise if `n` <= 0, the return value is 1.
     k : int
         Order of multifactorial.
     exact : bool, optional

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2463,8 +2463,8 @@ def factorialk(n, k, exact=True):
     Parameters
     ----------
     n : int
-        Calculate multifactorial. If `n` < 1 - `k`, the return value is 0.
-        Otherwise if `n` <= 0, the return value is 1.
+        Calculate multifactorial. If ``n < 1 - k``, the return value is 0.
+        Otherwise if ``n <= 0``, the return value is 1.
     k : int
         Order of multifactorial.
     exact : bool, optional


### PR DESCRIPTION


<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #15589 
#### What does this implement/fix?
<!--Please explain your changes.-->
The docstring for scipy.special.factorialk states: Calculate multifactorial. If n < 0, the return value is 0. However the code actually returns 0 if n < 1 - k else 1 if n <= 0. This pull request changes the docstring to be consistent with the implementation. 
#### Additional information
<!--Any additional information you think is important.-->
