### PR TITLE
Fix return data type of ascent

### DIFF
--- a/scipy/misc/_common.py
+++ b/scipy/misc/_common.py
@@ -178,10 +178,11 @@ def ascent():
     """
     import pickle
     import os
+    import numpy as np
     fname = os.path.join(os.path.dirname(__file__),'ascent.dat')
     with open(fname, 'rb') as f:
         ascent = array(pickle.load(f))
-    return ascent
+    return ascent.astype(np.uint8)
 
 
 def face(gray=False):

--- a/scipy/misc/_common.py
+++ b/scipy/misc/_common.py
@@ -178,10 +178,10 @@ def ascent():
     """
     import pickle
     import os
-    import numpy as np
+
     fname = os.path.join(os.path.dirname(__file__),'ascent.dat')
     with open(fname, 'rb') as f:
-        ascent = np.array(pickle.load(f), dtype=np.uint8)
+        ascent = array(pickle.load(f), dtype='uint8')
     return ascent
 
 

--- a/scipy/misc/_common.py
+++ b/scipy/misc/_common.py
@@ -181,8 +181,8 @@ def ascent():
     import numpy as np
     fname = os.path.join(os.path.dirname(__file__),'ascent.dat')
     with open(fname, 'rb') as f:
-        ascent = array(pickle.load(f))
-    return ascent.astype(np.uint8)
+        ascent = np.array(pickle.load(f), dtype=np.uint8)
+    return ascent
 
 
 def face(gray=False):


### PR DESCRIPTION
The ascent function returns a data type int64. However, the minimum and maximum values of the image array are 0 and 255, respectively. The data type should be uint8.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
