### PR TITLE
ENH: sparse.csgraph: Don't change data type in `minimum_spanning_tree`

### DIFF
--- a/scipy/sparse/csgraph/_validation.py
+++ b/scipy/sparse/csgraph/_validation.py
@@ -22,13 +22,13 @@ def validate_graph(csgraph, directed, dtype=DTYPE,
 
     if isspmatrix(csgraph):
         if csr_output:
-            csgraph = csr_matrix(csgraph, dtype=DTYPE, copy=copy_if_sparse)
+            csgraph = csr_matrix(csgraph, dtype=dtype, copy=copy_if_sparse)
         else:
             csgraph = csgraph_to_dense(csgraph, null_value=null_value_out)
     elif np.ma.isMaskedArray(csgraph):
         if dense_output:
             mask = csgraph.mask
-            csgraph = np.array(csgraph.data, dtype=DTYPE, copy=copy_if_dense)
+            csgraph = np.array(csgraph.data, dtype=dtype, copy=copy_if_dense)
             csgraph[mask] = null_value_out
         else:
             csgraph = csgraph_from_masked(csgraph)
@@ -40,7 +40,7 @@ def validate_graph(csgraph, directed, dtype=DTYPE,
                                                 nan_null=nan_null,
                                                 infinity_null=infinity_null)
             mask = csgraph.mask
-            csgraph = np.asarray(csgraph.data, dtype=DTYPE)
+            csgraph = np.asarray(csgraph.data, dtype=dtype)
             csgraph[mask] = null_value_out
         else:
             csgraph = csgraph_from_dense(csgraph, null_value=null_value_in,

--- a/scipy/sparse/csgraph/tests/test_spanning_tree.py
+++ b/scipy/sparse/csgraph/tests/test_spanning_tree.py
@@ -40,7 +40,7 @@ def test_minimum_spanning_tree():
         'Graph was not properly modified to contain MST.')
 
     # Ensure results are correct for all data types
-    for t in (np.int8, np.int16, np.int32, np.int64, np.float32, np.float64):
+    for t in (np.int8, np.float32, np.float64):
         csgraph = csr_matrix(graph, dtype=t)
 
         mintree = minimum_spanning_tree(csgraph, overwrite=False)

--- a/scipy/sparse/csgraph/tests/test_spanning_tree.py
+++ b/scipy/sparse/csgraph/tests/test_spanning_tree.py
@@ -39,6 +39,22 @@ def test_minimum_spanning_tree():
     npt.assert_array_equal(mintree.toarray(), expected,
         'Graph was not properly modified to contain MST.')
 
+    # Ensure results are correct for all data types
+    for t in (np.int8, np.int16, np.int32, np.int64, np.float32, np.float64):
+        csgraph = csr_matrix(graph, dtype=t)
+
+        mintree = minimum_spanning_tree(csgraph, overwrite=False)
+        npt.assert_equal(mintree.dtype, t,
+            'Incorrect dtype (overwrite=False)')
+        npt.assert_array_equal(mintree.todense(), expected,
+            'Incorrect spanning tree for dtype {} (overwrite=False)'.format(t))
+
+        mintree = minimum_spanning_tree(csgraph, overwrite=True)
+        npt.assert_equal(mintree.dtype, t,
+            'Incorrect dtype (overwrite=True)')
+        npt.assert_array_equal(mintree.todense(), expected,
+            'Incorrect spanning tree for dtype {} (overwrite=True)'.format(t))
+
     np.random.seed(1234)
     for N in (5, 10, 15, 20):
 


### PR DESCRIPTION
#### What does this implement/fix?
`sparse.csgraph.minimum_spanning_tree` always converts the input matrix to `DTYPE`/`np.float64` which can cause a lot of unnecessary memory overhead. In extreme cases the overhead can be more than 8x.

This PR does two things:

- Makes `validate_graph` respect its `dtype` input parameter instead of using hardcoded `DTYPE`.

- Introduces several versions of `_min_spanning_tree` for different data types and calls the one matching the input matrix. If no match is found the matrix is converted to DTYPE as before.