### PR TITLE
MAINT: allow multiplication sign `×`

### DIFF
--- a/tools/unicode-check.py
+++ b/tools/unicode-check.py
@@ -11,7 +11,7 @@ import argparse
 # allow in the source code.
 box_drawing_chars = set(chr(cp) for cp in range(0x2500, 0x2580))
 allowed = (set(['®', 'é', 'ê', 'ó', 'ö', 'ő', 'ü',
-                'λ', 'π', 'ω', '∫', '≠', '≥']) |
+                'λ', 'π', 'ω', '∫', '≠', '≥', '×']) |
            box_drawing_chars)
 
 


### PR DESCRIPTION
#### What does this implement/fix?
I'm seeing lint a check failure in master (e.g. gh-15605)
```
/usr/bin/bash --noprofile --norc /home/vsts/work/_temp/edbdfc6a-7b08-4535-a913-c1462a3b789c.sh
No lint errors found.
scipy/stats/tests/test_stats.py (no explicit encoding; utf-8 assumed)
... line 6669, position 30: character '×', code point U+00D7
##[error]Bash exited with code '1'.
Finishing: Run Lint Checks
```
It seems reasonable to allow the multiplication sign in documentation, especially with the hesitation to use LaTeX, so this adds it as an allowed character.

#### Additional information
Surprisingly, this failure did not show up in gh-15452 where the offending character was added. Do failures from `tools/unicode_check.py` not show up when there are failures from `tools/lint_diff.py`?  