### PR TITLE
BUG:signal: Fix median bias in csd(..., average="median")

### DIFF
--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -586,12 +586,13 @@ def csd(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
         if Pxy.shape[-1] > 1:
             if average == 'median':
                 # np.median must be passed real arrays for the desired result
+                bias = _median_bias(Pxy.shape[-1])
                 if np.iscomplexobj(Pxy):
                     Pxy = (np.median(np.real(Pxy), axis=-1)
                            + 1j * np.median(np.imag(Pxy), axis=-1))
-                    Pxy /= _median_bias(Pxy.shape[-1])
                 else:
-                    Pxy = np.median(Pxy, axis=-1) / _median_bias(Pxy.shape[-1])
+                    Pxy = np.median(Pxy, axis=-1)
+                Pxy /= bias
             elif average == 'mean':
                 Pxy = Pxy.mean(axis=-1)
             else:

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -848,6 +848,23 @@ class TestCSD:
         assert_allclose(f, fodd)
         assert_allclose(f, feven)
 
+    def test_copied_data(self):
+        x = np.random.randn(64)
+        y = x.copy()
+
+        _, p_same = csd(x, x, nperseg=8, average='mean',
+                        return_onesided=False)
+        _, p_copied = csd(x, y, nperseg=8, average='mean',
+                          return_onesided=False)
+        assert_allclose(p_same, p_copied)
+
+        _, p_same = csd(x, x, nperseg=8, average='median',
+                        return_onesided=False)
+        _, p_copied = csd(x, y, nperseg=8, average='median',
+                          return_onesided=False)
+        assert_allclose(p_same, p_copied)
+
+
 class TestCoherence:
     def test_identical_input(self):
         x = np.random.randn(20)


### PR DESCRIPTION
This commit fixes the bug that wrongly computes _median_bias from the
number of frequency instead of the number of frames.
A test is added to check (at least) the same bias is applied for both
cases where `x is y`, and `x is not y`.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes #15601

#### What does this implement/fix?
<!--Please explain your changes.-->

The original CSD with `average='median'` returns results with incorrect scale when the return value is complex.
This PR fix this behavior and adds a test that calls `csd` 2 times with `x is y` setting and `x is not y`, but `x==y` setting.
The former expected to return real-valued array, where the latter expected to return complex-valued array (with zeroed imag-part).
This test fails if the scalefactor is wrongly applied depending on whether result is complex or not.

#### Additional information
<!--Any additional information you think is important.-->
