### PR TITLE
REL: filter out @ in authors name and add count

### DIFF
--- a/doc/source/dev/core-dev/newfeatures.rst.inc
+++ b/doc/source/dev/core-dev/newfeatures.rst.inc
@@ -1,6 +1,5 @@
 .. _deciding-on-new-features:
 
-========================
 Deciding on new features
 ========================
 The general decision rule to accept a proposed new feature has so far

--- a/tools/authors.py
+++ b/tools/authors.py
@@ -62,7 +62,7 @@ def main():
             names.update((name,))
 
         # Look for "thanks to" messages in the commit log
-        m = re.search(r'([Tt]hanks to|[Cc]ourtesy of) ([A-Z][A-Za-z]*? [A-Z][A-Za-z]*? [A-Z][A-Za-z]*|[A-Z][A-Za-z]*? [A-Z]\. [A-Z][A-Za-z]*|[A-Z][A-Za-z ]*? [A-Z][A-Za-z]*|[a-z0-9]+)($|\.| )', line)
+        m = re.search(r'([Tt]hanks to|[Cc]ourtesy of|Co-authored-by:) ([A-Z][A-Za-z]*? [A-Z][A-Za-z]*? [A-Z][A-Za-z]*|[A-Z][A-Za-z]*? [A-Z]\. [A-Z][A-Za-z]*|[A-Z][A-Za-z ]*? [A-Z][A-Za-z]*|[a-z0-9]+)($|\.| )', line)
         if m:
             name = m.group(2)
             if name not in (u'this',):
@@ -77,12 +77,12 @@ def main():
 
     # Find all authors before the named range
     for line in git.pipe('log', '--pretty=@@@%an@@@%n@@@%cn@@@%n%b',
-                         '%s' % (rev1,)):
+                         f'{rev1}'):
         analyze_line(line, all_authors)
 
     # Find authors in the named range
     for line in git.pipe('log', '--pretty=@@@%an@@@%n@@@%cn@@@%n%b',
-                         '%s..%s' % (rev1, rev2)):
+                         f'{rev1}..{rev2}'):
         analyze_line(line, authors, disp=options.debug)
 
     # Sort

--- a/tools/authors.py
+++ b/tools/authors.py
@@ -114,6 +114,10 @@ def main():
         # return for early exit so we only print new authors
         return
 
+    try:
+        authors.pop('GitHub')
+    except KeyError:
+        pass
     # Order by name. Could order by count with authors.most_common()
     authors = sorted(authors.items(), key=lambda i: name_key(i[0]))
 
@@ -127,8 +131,6 @@ Authors
     for author, count in authors:
         # remove @ if only GH handle is available
         author_clean = author.strip('@')
-        if author == 'GitHub':
-            continue
 
         if author in all_authors:
             stdout_b.write((f"* {author_clean} ({count})\n").encode('utf-8'))

--- a/tools/authors.py
+++ b/tools/authors.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
 # -*- encoding:utf-8 -*-
 """
-git-authors [OPTIONS] REV1..REV2
+List the authors who contributed within a given revision interval::
 
-List the authors who contributed within a given revision interval.
+    python tools/authors.py REV1..REV2
+
+`REVx` being a commit hash.
 
 To change the name mapping, edit .mailmap on the top-level of the
 repository.
@@ -122,10 +124,15 @@ Authors
 """)
 
     for author in authors:
+        # remove @ if only GH handle is available
+        author_clean = author.strip('@')
+        if author == 'GitHub':
+            continue
+
         if author in all_authors:
-            stdout_b.write(("* %s\n" % author).encode('utf-8'))
+            stdout_b.write(("* %s\n" % author_clean).encode('utf-8'))
         else:
-            stdout_b.write(("* %s +\n" % author).encode('utf-8'))
+            stdout_b.write(("* %s +\n" % author_clean).encode('utf-8'))
 
     stdout_b.write(("""
 A total of %(count)d people contributed to this release.


### PR DESCRIPTION
Closes #15543

Does the following:

* remove `@` if the name is being mapped to GitHub handle
* remove `GitHub` user automatically
* take into account co-authors
* add a count of commit per user (can remove if you don't like it, can also order by count instead of names, could also not show count when it's just 1 commit)
* (wrong title level while browsing the release page in the doc)

See bellow some example:


* `@` removed: `python tools/authors.py 9a504cd27ad..9cbbbba944`

```
# before this PR

* @endolith
* Andrew Annex +
* Nickolai Belakovski
* GitHub
* Xingyu Liu
* Cong Ma
* Tyler Reddy
* Leo C. Stein +
* Kai Striega
* Warren Weckesser

A total of 10 people contributed to this release.
```


```
# this PR

* endolith (1)
* Andrew Annex (1) +
* Nickolai Belakovski (1)
* Xingyu Liu (4)
* Cong Ma (2)
* Tyler Reddy (4)
* Leo C. Stein (4) +
* Kai Striega (18)
* Warren Weckesser (4)

A total of 9 people contributed to this release.
```


* `Co-authored-by:` accounted: `python tools/authors.py e7f5741df..b06254e5a08a`

```
# before this PR

* Gerrit Ansmann
* GitHub
* Ralf Gommers
* P. L. Lim

A total of 4 people contributed to this release.
```


```
# this PR

* Gerrit Ansmann (1)
* Ralf Gommers (1)
* P. L. Lim (1)
* Pamphile Roy (1)
* Albert Steppi (1)

A total of 5 people contributed to this release.
```
