### PR TITLE
DOC: stats: update interval and moment method signatures

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -93,8 +93,8 @@ isf(q, %(shapes)s, loc=0, scale=1)
     Inverse survival function (inverse of ``sf``).
 """
 _doc_moment = """\
-moment(n, %(shapes)s, loc=0, scale=1)
-    Non-central moment of order n
+moment(order, %(shapes)s, loc=0, scale=1)
+    Non-central moment of the specified order.
 """
 _doc_stats = """\
 stats(%(shapes)s, loc=0, scale=1, moments='mv')
@@ -135,9 +135,8 @@ std(%(shapes)s, loc=0, scale=1)
     Standard deviation of the distribution.
 """
 _doc_interval = """\
-interval(alpha, %(shapes)s, loc=0, scale=1)
-    Endpoints of the range that contains fraction alpha [0, 1] of the
-    distribution
+interval(confidence, %(shapes)s, loc=0, scale=1)
+    Confidence interval with equal areas around the median.
 """
 _doc_allmethods = ''.join([docheaders['methods'], _doc_rvs, _doc_pdf,
                            _doc_logpdf, _doc_cdf, _doc_logcdf, _doc_sf,


### PR DESCRIPTION
#### Reference issue
Closes gh-5982

#### What does this implement/fix?
gh-13490 fixed keyword collision between distribution shape parameters and method parameters, but the signatures that appear in the distribution documentation weren't updated. E.g. in `levy_stable`:
![image](https://user-images.githubusercontent.com/6570539/154664577-5187668d-0d0a-4025-a1a3-5a036686e3e5.png)

This fixes that. (In this case, the first argument of the `interval` method is now `confidence`.)