### PR TITLE
improve docstrings for many scipy.special ufuncs

### DIFF
--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -75,7 +75,7 @@ add_newdoc("_cosine_invcdf",
 
 add_newdoc("sph_harm",
     r"""
-    sph_harm(m, n, theta, phi)
+    sph_harm(m, n, theta, phi, out=None)
 
     Compute spherical harmonics.
 
@@ -100,6 +100,8 @@ add_newdoc("sph_harm",
        Azimuthal (longitudinal) coordinate; must be in ``[0, 2*pi]``.
     phi : array_like
        Polar (colatitudinal) coordinate; must be in ``[0, pi]``.
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -256,7 +258,7 @@ add_newdoc("wrightomega",
 
 add_newdoc("agm",
     """
-    agm(a, b)
+    agm(a, b, out=None)
 
     Compute the arithmetic-geometric mean of `a` and `b`.
 
@@ -274,6 +276,8 @@ add_newdoc("agm",
         Real values only. If the values are both negative, the result
         is negative. If one value is negative and the other is positive,
         `nan` is returned.
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -311,7 +315,7 @@ add_newdoc("agm",
 
 add_newdoc("airy",
     r"""
-    airy(z)
+    airy(z, out=None)
 
     Airy functions and their derivatives.
 
@@ -319,6 +323,8 @@ add_newdoc("airy",
     ----------
     z : array_like
         Real or complex argument.
+    out : tuple of ndarray, optional
+        Optional output arrays for the function values
 
     Returns
     -------
@@ -384,7 +390,7 @@ add_newdoc("airy",
 
 add_newdoc("airye",
     """
-    airye(z)
+    airye(z, out=None)
 
     Exponentially scaled Airy functions and their derivatives.
 
@@ -399,6 +405,8 @@ add_newdoc("airye",
     ----------
     z : array_like
         Real or complex argument.
+    out : tuple of ndarray, optional
+        Optional output arrays for the function values
 
     Returns
     -------
@@ -462,7 +470,7 @@ add_newdoc("airye",
 
 add_newdoc("bdtr",
     r"""
-    bdtr(k, n, p)
+    bdtr(k, n, p, out=None)
 
     Binomial distribution cumulative distribution function.
 
@@ -479,6 +487,8 @@ add_newdoc("bdtr",
         Number of events (int).
     p : array_like
         Probability of success in a single event (float).
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -505,7 +515,7 @@ add_newdoc("bdtr",
 
 add_newdoc("bdtrc",
     r"""
-    bdtrc(k, n, p)
+    bdtrc(k, n, p, out=None)
 
     Binomial distribution survival function.
 
@@ -523,6 +533,8 @@ add_newdoc("bdtrc",
         Number of events (int)
     p : array_like
         Probability of success in a single event.
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -554,7 +566,7 @@ add_newdoc("bdtrc",
 
 add_newdoc("bdtri",
     r"""
-    bdtri(k, n, y)
+    bdtri(k, n, y, out=None)
 
     Inverse function to `bdtr` with respect to `p`.
 
@@ -571,6 +583,8 @@ add_newdoc("bdtri",
     y : array_like
         Cumulative probability (probability of `k` or fewer successes in `n`
         events).
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -599,7 +613,7 @@ add_newdoc("bdtri",
 
 add_newdoc("bdtrik",
     """
-    bdtrik(y, n, p)
+    bdtrik(y, n, p, out=None)
 
     Inverse function to `bdtr` with respect to `k`.
 
@@ -616,6 +630,8 @@ add_newdoc("bdtrik",
         Number of events (float).
     p : array_like
         Success probability (float).
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -649,7 +665,7 @@ add_newdoc("bdtrik",
 
 add_newdoc("bdtrin",
     """
-    bdtrin(k, y, p)
+    bdtrin(k, y, p, out=None)
 
     Inverse function to `bdtr` with respect to `n`.
 
@@ -666,6 +682,8 @@ add_newdoc("bdtrin",
         events).
     p : array_like
         Success probability (float).
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -699,7 +717,7 @@ add_newdoc("bdtrin",
 add_newdoc(
     "binom",
     r"""
-    binom(x, y)
+    binom(x, y, out=None)
 
     Binomial coefficient considered as a function of two real variables.
 
@@ -717,6 +735,8 @@ add_newdoc(
     ----------
     x, y: array_like
        Real arguments to :math:`\binom{x}{y}`.
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -790,7 +810,7 @@ add_newdoc(
 
 add_newdoc("btdtria",
     r"""
-    btdtria(p, b, x)
+    btdtria(p, b, x, out=None)
 
     Inverse of `btdtr` with respect to `a`.
 
@@ -809,6 +829,8 @@ add_newdoc("btdtria",
         Shape parameter (`b` > 0).
     x : array_like
         The quantile, in [0, 1].
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -843,7 +865,7 @@ add_newdoc("btdtria",
 
 add_newdoc("btdtrib",
     r"""
-    btdtria(a, p, x)
+    btdtria(a, p, x, out=None)
 
     Inverse of `btdtr` with respect to `b`.
 
@@ -862,6 +884,8 @@ add_newdoc("btdtrib",
         Cumulative probability, in [0, 1].
     x : array_like
         The quantile, in [0, 1].
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -1300,7 +1324,7 @@ add_newdoc("betaincinv",
 
 add_newdoc("betaln",
     """
-    betaln(a, b)
+    betaln(a, b, out=None)
 
     Natural logarithm of absolute value of beta function.
 
@@ -1328,7 +1352,7 @@ add_newdoc("betaln",
 
 add_newdoc("boxcox",
     """
-    boxcox(x, lmbda)
+    boxcox(x, lmbda, out=None)
 
     Compute the Box-Cox transformation.
 
@@ -1346,6 +1370,8 @@ add_newdoc("boxcox",
         Data to be transformed.
     lmbda : array_like
         Power parameter of the Box-Cox transform.
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -1368,7 +1394,7 @@ add_newdoc("boxcox",
 
 add_newdoc("boxcox1p",
     """
-    boxcox1p(x, lmbda)
+    boxcox1p(x, lmbda, out=None)
 
     Compute the Box-Cox transformation of 1 + `x`.
 
@@ -1386,6 +1412,8 @@ add_newdoc("boxcox1p",
         Data to be transformed.
     lmbda : array_like
         Power parameter of the Box-Cox transform.
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -1408,7 +1436,7 @@ add_newdoc("boxcox1p",
 
 add_newdoc("inv_boxcox",
     """
-    inv_boxcox(y, lmbda)
+    inv_boxcox(y, lmbda, out=None)
 
     Compute the inverse of the Box-Cox transformation.
 
@@ -1423,6 +1451,8 @@ add_newdoc("inv_boxcox",
         Data to be transformed.
     lmbda : array_like
         Power parameter of the Box-Cox transform.
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -1444,7 +1474,7 @@ add_newdoc("inv_boxcox",
 
 add_newdoc("inv_boxcox1p",
     """
-    inv_boxcox1p(y, lmbda)
+    inv_boxcox1p(y, lmbda, out=None)
 
     Compute the inverse of the Box-Cox transformation.
 
@@ -1459,6 +1489,8 @@ add_newdoc("inv_boxcox1p",
         Data to be transformed.
     lmbda : array_like
         Power parameter of the Box-Cox transform.
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -1480,7 +1512,7 @@ add_newdoc("inv_boxcox1p",
 
 add_newdoc("btdtr",
     r"""
-    btdtr(a, b, x)
+    btdtr(a, b, x, out=None)
 
     Cumulative distribution function of the beta distribution.
 
@@ -1500,6 +1532,8 @@ add_newdoc("btdtr",
         Shape parameter (b > 0).
     x : array_like
         Upper limit of integration, in [0, 1].
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -1527,7 +1561,7 @@ add_newdoc("btdtr",
 
 add_newdoc("btdtri",
     r"""
-    btdtri(a, b, p)
+    btdtri(a, b, p, out=None)
 
     The `p`-th quantile of the beta distribution.
 
@@ -1545,6 +1579,8 @@ add_newdoc("btdtri",
         Shape parameter (`b` > 0).
     p : array_like
         Cumulative probability, in [0, 1].
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -1572,7 +1608,7 @@ add_newdoc("btdtri",
 
 add_newdoc("cbrt",
     """
-    cbrt(x)
+    cbrt(x, out=None)
 
     Element-wise cube root of `x`.
 
@@ -1580,6 +1616,8 @@ add_newdoc("cbrt",
     ----------
     x : array_like
         `x` must contain real numbers.
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -1808,7 +1846,7 @@ add_newdoc("chdtriv",
 
 add_newdoc("chndtr",
     """
-    chndtr(x, df, nc)
+    chndtr(x, df, nc, out=None)
 
     Non-central chi square cumulative distribution function
 
@@ -1836,7 +1874,7 @@ add_newdoc("chndtr",
 
 add_newdoc("chndtrix",
     """
-    chndtrix(p, df, nc)
+    chndtrix(p, df, nc, out=None)
 
     Inverse to `chndtr` vs `x`
 
@@ -1866,7 +1904,7 @@ add_newdoc("chndtrix",
 
 add_newdoc("chndtridf",
     """
-    chndtridf(x, p, nc)
+    chndtridf(x, p, nc, out=None)
 
     Inverse to `chndtr` vs `df`
 
@@ -1894,7 +1932,7 @@ add_newdoc("chndtridf",
 
 add_newdoc("chndtrinc",
     """
-    chndtrinc(x, df, p)
+    chndtrinc(x, df, p, out=None)
 
     Inverse to `chndtr` vs `nc`
 
@@ -2032,7 +2070,7 @@ add_newdoc("cotdg",
 
 add_newdoc("dawsn",
     """
-    dawsn(x)
+    dawsn(x, out=None)
 
     Dawson's integral.
 
@@ -2044,6 +2082,8 @@ add_newdoc("dawsn",
     ----------
     x : array_like
         Function parameter.
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -2073,7 +2113,7 @@ add_newdoc("dawsn",
 
 add_newdoc("ellipe",
     r"""
-    ellipe(m)
+    ellipe(m, out=None)
 
     Complete elliptic integral of the second kind
 
@@ -2085,6 +2125,8 @@ add_newdoc("ellipe",
     ----------
     m : array_like
         Defines the parameter of the elliptic integral.
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -2166,7 +2208,7 @@ add_newdoc("ellipe",
 
 add_newdoc("ellipeinc",
     r"""
-    ellipeinc(phi, m)
+    ellipeinc(phi, m, out=None)
 
     Incomplete elliptic integral of the second kind
 
@@ -2178,9 +2220,10 @@ add_newdoc("ellipeinc",
     ----------
     phi : array_like
         amplitude of the elliptic integral.
-
     m : array_like
         parameter of the elliptic integral.
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -2231,7 +2274,7 @@ add_newdoc("ellipeinc",
 
 add_newdoc("ellipj",
     """
-    ellipj(u, m)
+    ellipj(u, m, out=None)
 
     Jacobian elliptic functions
 
@@ -2244,6 +2287,8 @@ add_newdoc("ellipj",
         Parameter.
     u : array_like
         Argument.
+    out : tuple of ndarray, optional
+        Optional output arrays for the function values
 
     Returns
     -------
@@ -2283,7 +2328,7 @@ add_newdoc("ellipj",
 
 add_newdoc("ellipkm1",
     """
-    ellipkm1(p)
+    ellipkm1(p, out=None)
 
     Complete elliptic integral of the first kind around `m` = 1
 
@@ -2297,6 +2342,8 @@ add_newdoc("ellipkm1",
     ----------
     p : array_like
         Defines the parameter of the elliptic integral as `m = 1 - p`.
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -2336,7 +2383,7 @@ add_newdoc("ellipkm1",
 
 add_newdoc("ellipk",
     r"""
-    ellipk(m)
+    ellipk(m, out=None)
 
     Complete elliptic integral of the first kind.
 
@@ -2348,6 +2395,8 @@ add_newdoc("ellipk",
     ----------
     m : array_like
         The parameter of the elliptic integral.
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -2391,7 +2440,7 @@ add_newdoc("ellipk",
 
 add_newdoc("ellipkinc",
     r"""
-    ellipkinc(phi, m)
+    ellipkinc(phi, m, out=None)
 
     Incomplete elliptic integral of the first kind
 
@@ -2405,9 +2454,10 @@ add_newdoc("ellipkinc",
     ----------
     phi : array_like
         amplitude of the elliptic integral
-
     m : array_like
         parameter of the elliptic integral
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -2454,7 +2504,7 @@ add_newdoc("ellipkinc",
 add_newdoc(
     "elliprc",
     r"""
-    elliprc(x, y)
+    elliprc(x, y, out=None)
 
     Degenerate symmetric elliptic integral.
 
@@ -2471,6 +2521,8 @@ add_newdoc(
     x, y : array_like
         Real or complex input parameters. `x` can be any number in the
         complex plane cut along the negative real axis. `y` must be non-zero.
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -2511,7 +2563,7 @@ add_newdoc(
 add_newdoc(
     "elliprd",
     r"""
-    elliprd(x, y, z)
+    elliprd(x, y, z, out=None)
 
     Symmetric elliptic integral of the second kind.
 
@@ -2529,6 +2581,8 @@ add_newdoc(
         Real or complex input parameters. `x` or `y` can be any number in the
         complex plane cut along the negative real axis, but at most one of them
         can be zero, while `z` must be non-zero.
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -2567,7 +2621,7 @@ add_newdoc(
 add_newdoc(
     "elliprf",
     r"""
-    elliprf(x, y, z)
+    elliprf(x, y, z, out=None)
 
     Completely-symmetric elliptic integral of the first kind.
 
@@ -2584,6 +2638,8 @@ add_newdoc(
         Real or complex input parameters. `x`, `y`, or `z` can be any number in
         the complex plane cut along the negative real axis, but at most one of
         them can be zero.
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -2621,7 +2677,7 @@ add_newdoc(
 add_newdoc(
     "elliprg",
     r"""
-    elliprg(x, y, z)
+    elliprg(x, y, z, out=None)
 
     Completely-symmetric elliptic integral of the second kind.
 
@@ -2639,6 +2695,8 @@ add_newdoc(
     x, y, z : array_like
         Real or complex input parameters. `x`, `y`, or `z` can be any number in
         the complex plane cut along the negative real axis.
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -2702,7 +2760,7 @@ add_newdoc(
 add_newdoc(
     "elliprj",
     r"""
-    elliprj(x, y, z, p)
+    elliprj(x, y, z, p, out=None)
 
     Symmetric elliptic integral of the third kind.
 
@@ -2725,6 +2783,8 @@ add_newdoc(
         the complex plane cut along the negative real axis (subject to further
         constraints, see Notes), and at most one of them can be zero. `p` must
         be non-zero.
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -2795,7 +2855,7 @@ add_newdoc(
 
 add_newdoc("entr",
     r"""
-    entr(x)
+    entr(x, out=None)
 
     Elementwise function for computing entropy.
 
@@ -2805,6 +2865,8 @@ add_newdoc("entr",
     ----------
     x : ndarray
         Input array.
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -2825,7 +2887,7 @@ add_newdoc("entr",
 
 add_newdoc("erf",
     """
-    erf(z)
+    erf(z, out=None)
 
     Returns the error function of complex argument.
 
@@ -2835,6 +2897,8 @@ add_newdoc("erf",
     ----------
     x : ndarray
         Input array.
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -3001,7 +3065,10 @@ add_newdoc("erfcx",
     """)
 
 add_newdoc("erfinv",
-    """Inverse of the error function.
+    """
+    erfinv(y, out=None)
+
+    Inverse of the error function.
 
     Computes the inverse of the error function.
 
@@ -3014,6 +3081,8 @@ add_newdoc("erfinv",
     ----------
     y : ndarray
         Argument at which to evaluate. Domain: [-1, 1]
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -3045,7 +3114,10 @@ add_newdoc("erfinv",
     """)
 
 add_newdoc("erfcinv",
-    """Inverse of the complementary error function.
+    """
+    erfcinv(y, out=None)
+
+    Inverse of the complementary error function.
 
     Computes the inverse of the complementary error function.
 
@@ -3060,6 +3132,8 @@ add_newdoc("erfcinv",
     ----------
     y : ndarray
         Argument at which to evaluate. Domain: [0, 2]
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -3121,6 +3195,8 @@ add_newdoc("eval_jacobi",
         Parameter
     x : array_like
         Points at which to evaluate the polynomial
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -3166,6 +3242,8 @@ add_newdoc("eval_sh_jacobi",
         Parameter
     q : float
         Parameter
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -3214,6 +3292,8 @@ add_newdoc("eval_gegenbauer",
         Parameter
     x : array_like
         Points at which to evaluate the Gegenbauer polynomial
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -3259,6 +3339,8 @@ add_newdoc("eval_chebyt",
         function.
     x : array_like
         Points at which to evaluate the Chebyshev polynomial
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -3311,6 +3393,8 @@ add_newdoc("eval_chebyu",
         function.
     x : array_like
         Points at which to evaluate the Chebyshev polynomial
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -3356,6 +3440,8 @@ add_newdoc("eval_chebys",
         determined via the relation to `eval_chebyu`.
     x : array_like
         Points at which to evaluate the Chebyshev polynomial
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -3413,6 +3499,8 @@ add_newdoc("eval_chebyc",
         determined via the relation to `eval_chebyt`.
     x : array_like
         Points at which to evaluate the Chebyshev polynomial
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -3471,6 +3559,8 @@ add_newdoc("eval_sh_chebyt",
         determined via the relation to `eval_chebyt`.
     x : array_like
         Points at which to evaluate the shifted Chebyshev polynomial
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -3516,6 +3606,8 @@ add_newdoc("eval_sh_chebyu",
         determined via the relation to `eval_chebyu`.
     x : array_like
         Points at which to evaluate the shifted Chebyshev polynomial
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -3561,6 +3653,8 @@ add_newdoc("eval_legendre",
         function.
     x : array_like
         Points at which to evaluate the Legendre polynomial
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -3641,6 +3735,8 @@ add_newdoc("eval_sh_legendre",
         determined via the relation to `eval_legendre`.
     x : array_like
         Points at which to evaluate the shifted Legendre polynomial
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -3692,6 +3788,8 @@ add_newdoc("eval_genlaguerre",
     x : array_like
         Points at which to evaluate the generalized Laguerre
         polynomial
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -3738,6 +3836,8 @@ add_newdoc("eval_laguerre",
         function.
     x : array_like
         Points at which to evaluate the Laguerre polynomial
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -3781,6 +3881,8 @@ add_newdoc("eval_hermite",
         Degree of the polynomial
     x : array_like
         Points at which to evaluate the Hermite polynomial
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -3825,6 +3927,8 @@ add_newdoc("eval_hermitenorm",
         Degree of the polynomial
     x : array_like
         Points at which to evaluate the Hermite polynomial
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -3929,7 +4033,7 @@ add_newdoc("exp1",
 
 add_newdoc("exp10",
     """
-    exp10(x)
+    exp10(x, out=None)
 
     Compute ``10**x`` element-wise.
 
@@ -3937,6 +4041,8 @@ add_newdoc("exp10",
     ----------
     x : array_like
         `x` must contain real numbers.
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -3958,7 +4064,7 @@ add_newdoc("exp10",
 
 add_newdoc("exp2",
     """
-    exp2(x)
+    exp2(x, out=None)
 
     Compute ``2**x`` element-wise.
 
@@ -3966,6 +4072,8 @@ add_newdoc("exp2",
     ----------
     x : array_like
         `x` must contain real numbers.
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -4074,7 +4182,7 @@ add_newdoc("expi",
 
 add_newdoc('expit',
     """
-    expit(x)
+    expit(x, out=None)
 
     Expit (a.k.a. logistic sigmoid) ufunc for ndarrays.
 
@@ -4086,6 +4194,8 @@ add_newdoc('expit',
     ----------
     x : ndarray
         The ndarray to apply expit to element-wise.
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -4133,7 +4243,7 @@ add_newdoc('expit',
 
 add_newdoc("expm1",
     """
-    expm1(x)
+    expm1(x, out=None)
 
     Compute ``exp(x) - 1``.
 
@@ -4146,6 +4256,8 @@ add_newdoc("expm1",
     ----------
     x : array_like
         `x` must contain real numbers.
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -4249,7 +4361,7 @@ add_newdoc("expn",
 
 add_newdoc("exprel",
     r"""
-    exprel(x)
+    exprel(x, out=None)
 
     Relative error exponential, ``(exp(x) - 1)/x``.
 
@@ -4262,6 +4374,8 @@ add_newdoc("exprel",
     ----------
     x : ndarray
         Input array.  `x` must contain real numbers.
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -4297,7 +4411,7 @@ add_newdoc("exprel",
 
 add_newdoc("fdtr",
     r"""
-    fdtr(dfn, dfd, x)
+    fdtr(dfn, dfd, x, out=None)
 
     F cumulative distribution function.
 
@@ -4323,6 +4437,8 @@ add_newdoc("fdtr",
         Second parameter (positive float).
     x : array_like
         Argument (nonnegative float).
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -4348,7 +4464,7 @@ add_newdoc("fdtr",
 
 add_newdoc("fdtrc",
     r"""
-    fdtrc(dfn, dfd, x)
+    fdtrc(dfn, dfd, x, out=None)
 
     F survival function.
 
@@ -4363,6 +4479,8 @@ add_newdoc("fdtrc",
         Second parameter (positive float).
     x : array_like
         Argument (nonnegative float).
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -4392,7 +4510,7 @@ add_newdoc("fdtrc",
 
 add_newdoc("fdtri",
     r"""
-    fdtri(dfn, dfd, p)
+    fdtri(dfn, dfd, p, out=None)
 
     The `p`-th quantile of the F-distribution.
 
@@ -4407,6 +4525,8 @@ add_newdoc("fdtri",
         Second parameter (positive float).
     p : array_like
         Cumulative probability, in [0, 1].
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -4440,7 +4560,7 @@ add_newdoc("fdtri",
 
 add_newdoc("fdtridfd",
     """
-    fdtridfd(dfn, p, x)
+    fdtridfd(dfn, p, x, out=None)
 
     Inverse to `fdtr` vs dfd
 
@@ -4454,6 +4574,8 @@ add_newdoc("fdtridfd",
         Cumulative probability, in [0, 1].
     x : array_like
         Argument (nonnegative float).
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -4468,7 +4590,7 @@ add_newdoc("fdtridfd",
 
 add_newdoc("fdtridfn",
     """
-    fdtridfn(p, dfd, x)
+    fdtridfn(p, dfd, x, out=None)
 
     Inverse to `fdtr` vs dfn
 
@@ -4483,6 +4605,8 @@ add_newdoc("fdtridfn",
         Second parameter (positive float).
     x : array_like
         Argument (nonnegative float).
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -4560,7 +4684,7 @@ add_newdoc("fresnel",
 
 add_newdoc("gamma",
     r"""
-    gamma(z)
+    gamma(z, out=None)
 
     gamma function.
 
@@ -4577,6 +4701,8 @@ add_newdoc("gamma",
     ----------
     z : array_like
         Real or complex valued argument
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -4635,7 +4761,7 @@ add_newdoc("gamma",
 
 add_newdoc("gammainc",
     r"""
-    gammainc(a, x)
+    gammainc(a, x, out=None)
 
     Regularized lower incomplete gamma function.
 
@@ -4653,6 +4779,8 @@ add_newdoc("gammainc",
         Positive parameter
     x : array_like
         Nonnegative argument
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -4702,7 +4830,7 @@ add_newdoc("gammainc",
 
 add_newdoc("gammaincc",
     r"""
-    gammaincc(a, x)
+    gammaincc(a, x, out=None)
 
     Regularized upper incomplete gamma function.
 
@@ -4720,6 +4848,8 @@ add_newdoc("gammaincc",
         Positive parameter
     x : array_like
         Nonnegative argument
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -4770,7 +4900,7 @@ add_newdoc("gammaincc",
 
 add_newdoc("gammainccinv",
     """
-    gammainccinv(a, y)
+    gammainccinv(a, y, out=None)
 
     Inverse of the regularized upper incomplete gamma function.
 
@@ -4786,6 +4916,8 @@ add_newdoc("gammainccinv",
         Positive parameter
     y : array_like
         Argument between 0 and 1, inclusive
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -4826,7 +4958,7 @@ add_newdoc("gammainccinv",
 
 add_newdoc("gammaincinv",
     """
-    gammaincinv(a, y)
+    gammaincinv(a, y, out=None)
 
     Inverse to the regularized lower incomplete gamma function.
 
@@ -4842,6 +4974,8 @@ add_newdoc("gammaincinv",
         Positive parameter
     y : array_like
         Parameter between 0 and 1, inclusive
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -4955,7 +5089,7 @@ add_newdoc("gammaln",
 
 add_newdoc("gammasgn",
     r"""
-    gammasgn(x)
+    gammasgn(x, out=None)
 
     Sign of the gamma function.
 
@@ -4977,6 +5111,8 @@ add_newdoc("gammasgn",
     ----------
     x : array_like
         Real argument
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -5025,7 +5161,7 @@ add_newdoc("gammasgn",
 
 add_newdoc("gdtr",
     r"""
-    gdtr(a, b, x)
+    gdtr(a, b, x, out=None)
 
     Gamma distribution cumulative distribution function.
 
@@ -5049,6 +5185,8 @@ add_newdoc("gdtr",
         :math:`\alpha` (float).
     x : array_like
         The quantile (upper limit of integration; float).
+    out : ndarray, optional
+        Optional output array for the function values
 
     See also
     --------
@@ -5076,7 +5214,7 @@ add_newdoc("gdtr",
 
 add_newdoc("gdtrc",
     r"""
-    gdtrc(a, b, x)
+    gdtrc(a, b, x, out=None)
 
     Gamma distribution survival function.
 
@@ -5099,6 +5237,8 @@ add_newdoc("gdtrc",
         :math:`\alpha` (float).
     x : array_like
         The quantile (lower limit of integration; float).
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -5334,7 +5474,7 @@ add_newdoc("gdtrix",
 
 add_newdoc("hankel1",
     r"""
-    hankel1(v, z)
+    hankel1(v, z, out=None)
 
     Hankel function of the first kind
 
@@ -5344,6 +5484,8 @@ add_newdoc("hankel1",
         Order (float).
     z : array_like
         Argument (float or complex).
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -5378,7 +5520,7 @@ add_newdoc("hankel1",
 
 add_newdoc("hankel1e",
     r"""
-    hankel1e(v, z)
+    hankel1e(v, z, out=None)
 
     Exponentially scaled Hankel function of the first kind
 
@@ -5392,6 +5534,8 @@ add_newdoc("hankel1e",
         Order (float).
     z : array_like
         Argument (float or complex).
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -5421,7 +5565,7 @@ add_newdoc("hankel1e",
 
 add_newdoc("hankel2",
     r"""
-    hankel2(v, z)
+    hankel2(v, z, out=None)
 
     Hankel function of the second kind
 
@@ -5431,6 +5575,8 @@ add_newdoc("hankel2",
         Order (float).
     z : array_like
         Argument (float or complex).
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -5464,7 +5610,7 @@ add_newdoc("hankel2",
 
 add_newdoc("hankel2e",
     r"""
-    hankel2e(v, z)
+    hankel2e(v, z, out=None)
 
     Exponentially scaled Hankel function of the second kind
 
@@ -5478,6 +5624,8 @@ add_newdoc("hankel2e",
         Order (float).
     z : array_like
         Argument (float or complex).
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -5508,7 +5656,7 @@ add_newdoc("hankel2e",
 
 add_newdoc("huber",
     r"""
-    huber(delta, r)
+    huber(delta, r, out=None)
 
     Huber loss function.
 
@@ -5520,6 +5668,8 @@ add_newdoc("huber",
         Input array, indicating the quadratic vs. linear loss changepoint.
     r : ndarray
         Input array, possibly representing residuals.
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -5673,7 +5823,7 @@ add_newdoc("hyp1f1",
 
 add_newdoc("hyp2f1",
     r"""
-    hyp2f1(a, b, c, z)
+    hyp2f1(a, b, c, z, out=None)
 
     Gauss hypergeometric function 2F1(a, b; c; z)
 
@@ -5683,6 +5833,8 @@ add_newdoc("hyp2f1",
         Arguments, should be real-valued.
     z : array_like
         Argument, real or complex.
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -5803,7 +5955,7 @@ add_newdoc("hyperu",
         Real-valued parameters
     x : array_like
         Real-valued argument
-    out : ndarray
+    out : ndarray, optional
         Optional output array for the function values
 
     Returns
@@ -5844,7 +5996,7 @@ add_newdoc("hyperu",
 
 add_newdoc("i0",
     r"""
-    i0(x)
+    i0(x, out=None)
 
     Modified Bessel function of order 0.
 
@@ -5859,6 +6011,8 @@ add_newdoc("i0",
     ----------
     x : array_like
         Argument (float)
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -5885,7 +6039,7 @@ add_newdoc("i0",
 
 add_newdoc("i0e",
     """
-    i0e(x)
+    i0e(x, out=None)
 
     Exponentially scaled modified Bessel function of order 0.
 
@@ -5897,6 +6051,8 @@ add_newdoc("i0e",
     ----------
     x : array_like
         Argument (float)
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -5926,7 +6082,7 @@ add_newdoc("i0e",
 
 add_newdoc("i1",
     r"""
-    i1(x)
+    i1(x, out=None)
 
     Modified Bessel function of order 1.
 
@@ -5942,6 +6098,8 @@ add_newdoc("i1",
     ----------
     x : array_like
         Argument (float)
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -5968,7 +6126,7 @@ add_newdoc("i1",
 
 add_newdoc("i1e",
     """
-    i1e(x)
+    i1e(x, out=None)
 
     Exponentially scaled modified Bessel function of order 1.
 
@@ -5980,6 +6138,8 @@ add_newdoc("i1e",
     ----------
     x : array_like
         Argument (float)
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -6074,7 +6234,7 @@ add_newdoc("it2j0y0",
 
 add_newdoc("it2struve0",
     r"""
-    it2struve0(x)
+    it2struve0(x, out=None)
 
     Integral related to the Struve function of order 0.
 
@@ -6089,6 +6249,8 @@ add_newdoc("it2struve0",
     ----------
     x : array_like
         Lower limit of integration.
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -6113,7 +6275,7 @@ add_newdoc("it2struve0",
 
 add_newdoc("itairy",
     """
-    itairy(x)
+    itairy(x, out=None)
 
     Integrals of Airy functions
 
@@ -6124,6 +6286,8 @@ add_newdoc("itairy",
 
     x : array_like
         Upper limit of integration (float).
+    out : tuple of ndarray, optional
+        Optional output arrays for the function values
 
     Returns
     -------
@@ -6213,7 +6377,7 @@ add_newdoc("itj0y0",
 
 add_newdoc("itmodstruve0",
     r"""
-    itmodstruve0(x)
+    itmodstruve0(x, out=None)
 
     Integral of the modified Struve function of order 0.
 
@@ -6224,6 +6388,8 @@ add_newdoc("itmodstruve0",
     ----------
     x : array_like
         Upper limit of integration (float).
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -6245,7 +6411,7 @@ add_newdoc("itmodstruve0",
 
 add_newdoc("itstruve0",
     r"""
-    itstruve0(x)
+    itstruve0(x, out=None)
 
     Integral of the Struve function of order 0.
 
@@ -6256,6 +6422,8 @@ add_newdoc("itstruve0",
     ----------
     x : array_like
         Upper limit of integration (float).
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -6281,7 +6449,7 @@ add_newdoc("itstruve0",
 
 add_newdoc("iv",
     r"""
-    iv(v, z)
+    iv(v, z, out=None)
 
     Modified Bessel function of the first kind of real order.
 
@@ -6292,10 +6460,12 @@ add_newdoc("iv",
         valued.
     z : array_like of float or complex
         Argument.
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
-    out : scalar or ndarray
+    scalar or ndarray
         Values of the modified Bessel function.
 
     Notes
@@ -6339,7 +6509,7 @@ add_newdoc("iv",
 
 add_newdoc("ive",
     r"""
-    ive(v, z)
+    ive(v, z, out=None)
 
     Exponentially scaled modified Bessel function of the first kind
 
@@ -6353,10 +6523,12 @@ add_newdoc("ive",
         Order.
     z : array_like of float or complex
         Argument.
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
-    out : scalar or ndarray
+    scalar or ndarray
         Values of the exponentially scaled modified Bessel function.
 
     Notes
@@ -6391,7 +6563,7 @@ add_newdoc("ive",
 
 add_newdoc("j0",
     r"""
-    j0(x)
+    j0(x, out=None)
 
     Bessel function of the first kind of order 0.
 
@@ -6399,6 +6571,8 @@ add_newdoc("j0",
     ----------
     x : array_like
         Argument (float).
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -6438,7 +6612,7 @@ add_newdoc("j0",
 
 add_newdoc("j1",
     """
-    j1(x)
+    j1(x, out=None)
 
     Bessel function of the first kind of order 1.
 
@@ -6446,6 +6620,8 @@ add_newdoc("j1",
     ----------
     x : array_like
         Argument (float).
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -6477,7 +6653,7 @@ add_newdoc("j1",
 
 add_newdoc("jn",
     """
-    jn(n, x)
+    jn(n, x, out=None)
 
     Bessel function of the first kind of integer order and real argument.
 
@@ -6487,6 +6663,8 @@ add_newdoc("jn",
         order of the Bessel function
     x : array_like
         argument of the Bessel function
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -6507,7 +6685,7 @@ add_newdoc("jn",
 
 add_newdoc("jv",
     r"""
-    jv(v, z)
+    jv(v, z, out=None)
 
     Bessel function of the first kind of real order and complex argument.
 
@@ -6517,6 +6695,8 @@ add_newdoc("jv",
         Order (float).
     z : array_like
         Argument (float or complex).
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -6559,7 +6739,7 @@ add_newdoc("jv",
 
 add_newdoc("jve",
     r"""
-    jve(v, z)
+    jve(v, z, out=None)
 
     Exponentially scaled Bessel function of order `v`.
 
@@ -6573,6 +6753,8 @@ add_newdoc("jve",
         Order (float).
     z : array_like
         Argument (float or complex).
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -6608,7 +6790,7 @@ add_newdoc("jve",
 
 add_newdoc("k0",
     r"""
-    k0(x)
+    k0(x, out=None)
 
     Modified Bessel function of the second kind of order 0, :math:`K_0`.
 
@@ -6619,6 +6801,8 @@ add_newdoc("k0",
     ----------
     x : array_like
         Argument (float).
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -6645,7 +6829,7 @@ add_newdoc("k0",
 
 add_newdoc("k0e",
     """
-    k0e(x)
+    k0e(x, out=None)
 
     Exponentially scaled modified Bessel function K of order 0
 
@@ -6657,6 +6841,8 @@ add_newdoc("k0e",
     ----------
     x : array_like
         Argument (float)
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -6684,7 +6870,7 @@ add_newdoc("k0e",
 
 add_newdoc("k1",
     """
-    k1(x)
+    k1(x, out=None)
 
     Modified Bessel function of the second kind of order 1, :math:`K_1(x)`.
 
@@ -6692,6 +6878,8 @@ add_newdoc("k1",
     ----------
     x : array_like
         Argument (float)
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -6718,7 +6906,7 @@ add_newdoc("k1",
 
 add_newdoc("k1e",
     """
-    k1e(x)
+    k1e(x, out=None)
 
     Exponentially scaled modified Bessel function K of order 1
 
@@ -6730,6 +6918,8 @@ add_newdoc("k1e",
     ----------
     x : array_like
         Argument (float)
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------
@@ -6838,9 +7028,16 @@ add_newdoc("keip",
 
 add_newdoc("kelvin",
     """
-    kelvin(x)
+    kelvin(x, out=None)
 
     Kelvin functions as complex numbers
+
+    Parameters
+    ----------
+    x : array_like
+        Argument
+    out : tuple of ndarray, optional
+        Optional output arrays for the function values
 
     Returns
     -------
@@ -6874,16 +7071,16 @@ add_newdoc("ker",
     out : ndarray, optional
         Optional output array for the function results.
 
+    Returns
+    -------
+    scalar or ndarray
+        Values of the Kelvin function.
+
     See Also
     --------
     kei : the corresponding imaginary part
     kerp : the derivative of ker
     kv : modified Bessel function of the second kind
-
-    Returns
-    -------
-    scalar or ndarray
-        Values of the Kelvin function.
 
     References
     ----------
@@ -6901,6 +7098,11 @@ add_newdoc("ker",
     array([ 0.28670621, -0.04166451, -0.06702923, -0.03617885])
     >>> sc.ker(x)
     array([ 0.28670621, -0.04166451, -0.06702923, -0.03617885])
+
+    References
+    ----------
+    .. [dlmf] NIST, Digital Library of Mathematical Functions,
+        https://dlmf.nist.gov/10.61
 
     """)
 
@@ -6986,7 +7188,7 @@ add_newdoc("kl_div",
 
 add_newdoc("kn",
     r"""
-    kn(n, x)
+    kn(n, x, out=None)
 
     Modified Bessel function of the second kind of integer order `n`
 
@@ -7002,10 +7204,12 @@ add_newdoc("kn",
         Order of Bessel functions (floats will truncate with a warning)
     x : array_like of float
         Argument at which to evaluate the Bessel functions
+    out : ndarray, optional
+        Optional output array for the function results.
 
     Returns
     -------
-    out : ndarray
+    scalar or ndarray
         Value of the Modified Bessel function of the second kind,
         :math:`K_n(x)`.
 
@@ -7050,7 +7254,7 @@ add_newdoc("kn",
 
 add_newdoc("kolmogi",
     """
-    kolmogi(p)
+    kolmogi(p, out=None)
 
     Inverse Survival Function of Kolmogorov distribution
 
@@ -7061,6 +7265,8 @@ add_newdoc("kolmogi",
     ----------
     p : float array_like
         Probability
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -7092,7 +7298,7 @@ add_newdoc("kolmogi",
 
 add_newdoc("kolmogorov",
     r"""
-    kolmogorov(y)
+    kolmogorov(y, out=None)
 
     Complementary cumulative distribution (Survival Function) function of
     Kolmogorov distribution.
@@ -7108,6 +7314,8 @@ add_newdoc("kolmogorov",
     y : float array_like
       Absolute deviation between the Empirical CDF (ECDF) and the target CDF,
       multiplied by sqrt(n).
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -7196,7 +7404,7 @@ add_newdoc("_kolmogp",
 
 add_newdoc("kv",
     r"""
-    kv(v, z)
+    kv(v, z, out=None)
 
     Modified Bessel function of the second kind of real order `v`
 
@@ -7218,6 +7426,8 @@ add_newdoc("kv",
         Order of Bessel functions
     z : array_like of complex
         Argument at which to evaluate the Bessel functions
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -7269,7 +7479,7 @@ add_newdoc("kv",
 
 add_newdoc("kve",
     r"""
-    kve(v, z)
+    kve(v, z, out=None)
 
     Exponentially scaled modified Bessel function of the second kind.
 
@@ -7285,6 +7495,8 @@ add_newdoc("kve",
         Order of Bessel functions
     z : array_like of complex
         Argument at which to evaluate the Bessel functions
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -7360,7 +7572,7 @@ add_newdoc("_log1pmx",
 
 add_newdoc('log_expit',
     """
-    log_expit(x)
+    log_expit(x, out=None)
 
     Logarithm of the logistic sigmoid function.
 
@@ -7375,6 +7587,8 @@ add_newdoc('log_expit',
     ----------
     x : array_like
         The values to apply ``log_expit`` to element-wise.
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -7424,7 +7638,7 @@ add_newdoc('log_expit',
 
 add_newdoc('logit',
     """
-    logit(x)
+    logit(x, out=None)
 
     Logit ufunc for ndarrays.
 
@@ -7436,6 +7650,8 @@ add_newdoc('logit',
     ----------
     x : ndarray
         The ndarray to apply logit to element-wise.
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -7483,7 +7699,7 @@ add_newdoc('logit',
 
 add_newdoc("lpmv",
     r"""
-    lpmv(m, v, x)
+    lpmv(m, v, x, out=None)
 
     Associated Legendre function of integer order and real degree.
 
@@ -7512,6 +7728,8 @@ add_newdoc("lpmv",
         Degree (float).
     x : array_like
         Argument (float). Must have ``|x| <= 1``.
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -7538,7 +7756,7 @@ add_newdoc("lpmv",
 
 add_newdoc("mathieu_a",
     """
-    mathieu_a(m, q)
+    mathieu_a(m, q, out=None)
 
     Characteristic value of even Mathieu functions
 
@@ -7548,6 +7766,8 @@ add_newdoc("mathieu_a",
         Order of the function
     q : array_like
         Parameter of the function
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -7563,7 +7783,7 @@ add_newdoc("mathieu_a",
 
 add_newdoc("mathieu_b",
     """
-    mathieu_b(m, q)
+    mathieu_b(m, q, out=None)
 
     Characteristic value of odd Mathieu functions
 
@@ -7573,6 +7793,8 @@ add_newdoc("mathieu_b",
         Order of the function
     q : array_like
         Parameter of the function
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -7588,7 +7810,7 @@ add_newdoc("mathieu_b",
 
 add_newdoc("mathieu_cem",
     """
-    mathieu_cem(m, q, x)
+    mathieu_cem(m, q, x, out=None)
 
     Even Mathieu function and its derivative
 
@@ -7604,6 +7826,8 @@ add_newdoc("mathieu_cem",
         Parameter of the function
     x : array_like
         Argument of the function, *given in degrees, not radians*
+    out : tuple of ndarray, optional
+        Optional output arrays for the function results
 
     Returns
     -------
@@ -7620,7 +7844,7 @@ add_newdoc("mathieu_cem",
 
 add_newdoc("mathieu_modcem1",
     """
-    mathieu_modcem1(m, q, x)
+    mathieu_modcem1(m, q, x, out=None)
 
     Even modified Mathieu function of the first kind and its derivative
 
@@ -7636,6 +7860,8 @@ add_newdoc("mathieu_modcem1",
         Parameter of the function
     x : array_like
         Argument of the function, *given in degrees, not radians*
+    out : tuple of ndarray, optional
+        Optional output arrays for the function results
 
     Returns
     -------
@@ -7652,7 +7878,7 @@ add_newdoc("mathieu_modcem1",
 
 add_newdoc("mathieu_modcem2",
     """
-    mathieu_modcem2(m, q, x)
+    mathieu_modcem2(m, q, x, out=None, out=None)
 
     Even modified Mathieu function of the second kind and its derivative
 
@@ -7668,6 +7894,8 @@ add_newdoc("mathieu_modcem2",
         Parameter of the function
     x : array_like
         Argument of the function, *given in degrees, not radians*
+    out : tuple of ndarray, optional
+        Optional output arrays for the function results
 
     Returns
     -------
@@ -7684,7 +7912,7 @@ add_newdoc("mathieu_modcem2",
 
 add_newdoc("mathieu_modsem1",
     """
-    mathieu_modsem1(m, q, x)
+    mathieu_modsem1(m, q, x, out=None)
 
     Odd modified Mathieu function of the first kind and its derivative
 
@@ -7700,6 +7928,8 @@ add_newdoc("mathieu_modsem1",
         Parameter of the function
     x : array_like
         Argument of the function, *given in degrees, not radians*
+    out : tuple of ndarray, optional
+        Optional output arrays for the function results
 
     Returns
     -------
@@ -7716,7 +7946,7 @@ add_newdoc("mathieu_modsem1",
 
 add_newdoc("mathieu_modsem2",
     """
-    mathieu_modsem2(m, q, x)
+    mathieu_modsem2(m, q, x, out=None)
 
     Odd modified Mathieu function of the second kind and its derivative
 
@@ -7732,6 +7962,8 @@ add_newdoc("mathieu_modsem2",
         Parameter of the function
     x : array_like
         Argument of the function, *given in degrees, not radians*
+    out : tuple of ndarray, optional
+        Optional output arrays for the function results
 
     Returns
     -------
@@ -7748,7 +7980,7 @@ add_newdoc("mathieu_modsem2",
 
 add_newdoc("mathieu_sem",
     """
-    mathieu_sem(m, q, x)
+    mathieu_sem(m, q, x, out=None)
 
     Odd Mathieu function and its derivative
 
@@ -7764,6 +7996,8 @@ add_newdoc("mathieu_sem",
         Parameter of the function
     x : array_like
         Argument of the function, *given in degrees, not radians*.
+    out : tuple of ndarray, optional
+        Optional output arrays for the function results
 
     Returns
     -------
@@ -7780,7 +8014,7 @@ add_newdoc("mathieu_sem",
 
 add_newdoc("modfresnelm",
     """
-    modfresnelm(x)
+    modfresnelm(x, out=None)
 
     Modified Fresnel negative integrals
 
@@ -7788,6 +8022,8 @@ add_newdoc("modfresnelm",
     ----------
     x : array_like
         Function argument
+    out : tuple of ndarray, optional
+        Optional output arrays for the function results
 
     Returns
     -------
@@ -7804,7 +8040,7 @@ add_newdoc("modfresnelm",
 
 add_newdoc("modfresnelp",
     """
-    modfresnelp(x)
+    modfresnelp(x, out=None)
 
     Modified Fresnel positive integrals
 
@@ -7812,6 +8048,8 @@ add_newdoc("modfresnelp",
     ----------
     x : array_like
         Function argument
+    out : tuple of ndarray, optional
+        Optional output arrays for the function results
 
     Returns
     -------
@@ -7828,7 +8066,7 @@ add_newdoc("modfresnelp",
 
 add_newdoc("modstruve",
     r"""
-    modstruve(v, x)
+    modstruve(v, x, out=None)
 
     Modified Struve function.
 
@@ -7847,6 +8085,8 @@ add_newdoc("modstruve",
     x : array_like
         Argument of the Struve function (float; must be positive unless `v` is
         an integer).
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -7876,7 +8116,7 @@ add_newdoc("modstruve",
 
 add_newdoc("nbdtr",
     r"""
-    nbdtr(k, n, p)
+    nbdtr(k, n, p, out=None)
 
     Negative binomial cumulative distribution function.
 
@@ -7899,6 +8139,8 @@ add_newdoc("nbdtr",
         The target number of successes (positive int).
     p : array_like
         Probability of success in a single event (float).
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -7932,7 +8174,7 @@ add_newdoc("nbdtr",
 
 add_newdoc("nbdtrc",
     r"""
-    nbdtrc(k, n, p)
+    nbdtrc(k, n, p, out=None)
 
     Negative binomial survival function.
 
@@ -7955,6 +8197,8 @@ add_newdoc("nbdtrc",
         The target number of successes (positive int).
     p : array_like
         Probability of success in a single event (float).
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -7983,7 +8227,7 @@ add_newdoc("nbdtrc",
 
 add_newdoc("nbdtri",
     """
-    nbdtri(k, n, y)
+    nbdtri(k, n, y, out=None)
 
     Inverse of `nbdtr` vs `p`.
 
@@ -7999,6 +8243,8 @@ add_newdoc("nbdtri",
         The target number of successes (positive int).
     y : array_like
         The probability of `k` or fewer failures before `n` successes (float).
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -8025,7 +8271,7 @@ add_newdoc("nbdtri",
 
 add_newdoc("nbdtrik",
     r"""
-    nbdtrik(y, n, p)
+    nbdtrik(y, n, p, out=None)
 
     Inverse of `nbdtr` vs `k`.
 
@@ -8041,6 +8287,8 @@ add_newdoc("nbdtrik",
         The target number of successes (positive int).
     p : array_like
         Probability of success in a single event (float).
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -8081,7 +8329,7 @@ add_newdoc("nbdtrik",
 
 add_newdoc("nbdtrin",
     r"""
-    nbdtrin(k, y, p)
+    nbdtrin(k, y, p, out=None)
 
     Inverse of `nbdtr` vs `n`.
 
@@ -8097,6 +8345,8 @@ add_newdoc("nbdtrin",
         The probability of `k` or fewer failures before `n` successes (float).
     p : array_like
         Probability of success in a single event (float).
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -8137,7 +8387,7 @@ add_newdoc("nbdtrin",
 
 add_newdoc("ncfdtr",
     r"""
-    ncfdtr(dfn, dfd, nc, f)
+    ncfdtr(dfn, dfd, nc, f, out=None)
 
     Cumulative distribution function of the non-central F distribution.
 
@@ -8161,6 +8411,8 @@ add_newdoc("ncfdtr",
         Noncentrality parameter.  Should be in range (0, 1e4).
     f : array_like
         Quantiles, i.e. the upper limit of integration.
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -8227,7 +8479,7 @@ add_newdoc("ncfdtr",
 
 add_newdoc("ncfdtri",
     """
-    ncfdtri(dfn, dfd, nc, p)
+    ncfdtri(dfn, dfd, nc, p, out=None)
 
     Inverse with respect to `f` of the CDF of the non-central F distribution.
 
@@ -8244,6 +8496,8 @@ add_newdoc("ncfdtri",
     p : array_like
         Value of the cumulative distribution function.  Must be in the
         range [0, 1].
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -8277,7 +8531,7 @@ add_newdoc("ncfdtri",
 
 add_newdoc("ncfdtridfd",
     """
-    ncfdtridfd(dfn, p, nc, f)
+    ncfdtridfd(dfn, p, nc, f, out=None)
 
     Calculate degrees of freedom (denominator) for the noncentral F-distribution.
 
@@ -8295,6 +8549,8 @@ add_newdoc("ncfdtridfd",
         Noncentrality parameter.  Should be in range (0, 1e4).
     f : array_like
         Quantiles, i.e., the upper limit of integration.
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -8335,7 +8591,7 @@ add_newdoc("ncfdtridfd",
 
 add_newdoc("ncfdtridfn",
     """
-    ncfdtridfn(p, dfd, nc, f)
+    ncfdtridfn(p, dfd, nc, f, out=None)
 
     Calculate degrees of freedom (numerator) for the noncentral F-distribution.
 
@@ -8353,6 +8609,8 @@ add_newdoc("ncfdtridfn",
         Noncentrality parameter.  Should be in range (0, 1e4).
     f : float
         Quantiles, i.e., the upper limit of integration.
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -8393,7 +8651,7 @@ add_newdoc("ncfdtridfn",
 
 add_newdoc("ncfdtrinc",
     """
-    ncfdtrinc(dfn, dfd, p, f)
+    ncfdtrinc(dfn, dfd, p, f, out=None)
 
     Calculate non-centrality parameter for non-central F distribution.
 
@@ -8411,6 +8669,8 @@ add_newdoc("ncfdtrinc",
         range [0, 1].
     f : array_like
         Quantiles, i.e., the upper limit of integration.
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -8444,7 +8704,7 @@ add_newdoc("ncfdtrinc",
 
 add_newdoc("nctdtr",
     """
-    nctdtr(df, nc, t)
+    nctdtr(df, nc, t, out=None)
 
     Cumulative distribution function of the non-central `t` distribution.
 
@@ -8456,6 +8716,8 @@ add_newdoc("nctdtr",
         Noncentrality parameter. Should be in range (-1e6, 1e6).
     t : array_like
         Quantiles, i.e., the upper limit of integration.
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -8493,7 +8755,7 @@ add_newdoc("nctdtr",
 
 add_newdoc("nctdtridf",
     """
-    nctdtridf(p, nc, t)
+    nctdtridf(p, nc, t, out=None)
 
     Calculate degrees of freedom for non-central t distribution.
 
@@ -8507,6 +8769,8 @@ add_newdoc("nctdtridf",
         Noncentrality parameter. Should be in range (-1e6, 1e6).
     t : array_like
         Quantiles, i.e., the upper limit of integration.
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -8524,7 +8788,7 @@ add_newdoc("nctdtridf",
 
 add_newdoc("nctdtrinc",
     """
-    nctdtrinc(df, p, t)
+    nctdtrinc(df, p, t, out=None)
 
     Calculate non-centrality parameter for non-central t distribution.
 
@@ -8538,6 +8802,8 @@ add_newdoc("nctdtrinc",
         CDF values, in range (0, 1].
     t : array_like
         Quantiles, i.e., the upper limit of integration.
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -8554,7 +8820,7 @@ add_newdoc("nctdtrinc",
 
 add_newdoc("nctdtrit",
     """
-    nctdtrit(df, nc, p)
+    nctdtrit(df, nc, p, out=None)
 
     Inverse cumulative distribution function of the non-central t distribution.
 
@@ -8568,6 +8834,8 @@ add_newdoc("nctdtrit",
         Noncentrality parameter. Should be in range (-1e6, 1e6).
     p : array_like
         CDF values, in range (0, 1].
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -8584,7 +8852,7 @@ add_newdoc("nctdtrit",
 
 add_newdoc("ndtr",
     r"""
-    ndtr(x)
+    ndtr(x, out=None)
 
     Gaussian cumulative distribution function.
 
@@ -8599,6 +8867,8 @@ add_newdoc("ndtr",
     ----------
     x : array_like, real or complex
         Argument
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -8614,7 +8884,7 @@ add_newdoc("ndtr",
 
 add_newdoc("nrdtrimn",
     """
-    nrdtrimn(p, x, std)
+    nrdtrimn(p, x, std, out=None)
 
     Calculate mean of normal distribution given other params.
 
@@ -8626,6 +8896,8 @@ add_newdoc("nrdtrimn",
         Quantiles, i.e. the upper limit of integration.
     std : array_like
         Standard deviation.
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -8640,7 +8912,7 @@ add_newdoc("nrdtrimn",
 
 add_newdoc("nrdtrisd",
     """
-    nrdtrisd(p, x, mn)
+    nrdtrisd(p, x, mn, out=None)
 
     Calculate standard deviation of normal distribution given other params.
 
@@ -8652,6 +8924,8 @@ add_newdoc("nrdtrisd",
         Quantiles, i.e. the upper limit of integration.
     mn : scalar or ndarray
         The mean of the normal distribution.
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -8666,7 +8940,7 @@ add_newdoc("nrdtrisd",
 
 add_newdoc("log_ndtr",
     """
-    log_ndtr(x)
+    log_ndtr(x, out=None)
 
     Logarithm of Gaussian cumulative distribution function.
 
@@ -8679,6 +8953,8 @@ add_newdoc("log_ndtr",
     ----------
     x : array_like, real or complex
         Argument
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -8696,7 +8972,7 @@ add_newdoc("log_ndtr",
 
 add_newdoc("ndtri",
     """
-    ndtri(y)
+    ndtri(y, out=None)
 
     Inverse of `ndtr` vs x
 
@@ -8708,6 +8984,8 @@ add_newdoc("ndtri",
     ----------
     p : array_like
         Probability
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -8722,7 +9000,7 @@ add_newdoc("ndtri",
 
 add_newdoc("obl_ang1",
     """
-    obl_ang1(m, n, c, x)
+    obl_ang1(m, n, c, x, out=None)
 
     Oblate spheroidal angular function of the first kind and its derivative
 
@@ -8740,6 +9018,8 @@ add_newdoc("obl_ang1",
         Spheroidal parameter
     x : array_like
         Parameter x (|x| < 1.0)
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -8756,7 +9036,7 @@ add_newdoc("obl_ang1",
 
 add_newdoc("obl_ang1_cv",
     """
-    obl_ang1_cv(m, n, c, cv, x)
+    obl_ang1_cv(m, n, c, cv, x, out=None)
 
     Oblate spheroidal angular function obl_ang1 for precomputed characteristic value
 
@@ -8777,6 +9057,8 @@ add_newdoc("obl_ang1_cv",
         Characteristic value
     x : array_like
         Parameter x (|x| < 1.0)
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -8793,7 +9075,7 @@ add_newdoc("obl_ang1_cv",
 
 add_newdoc("obl_cv",
     """
-    obl_cv(m, n, c)
+    obl_cv(m, n, c, out=None)
 
     Characteristic value of oblate spheroidal function
 
@@ -8808,6 +9090,8 @@ add_newdoc("obl_cv",
         Mode parameter n (>= m)
     c : array_like
         Spheroidal parameter
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -8818,7 +9102,7 @@ add_newdoc("obl_cv",
 
 add_newdoc("obl_rad1",
     """
-    obl_rad1(m, n, c, x)
+    obl_rad1(m, n, c, x, out=None)
 
     Oblate spheroidal radial function of the first kind and its derivative
 
@@ -8836,6 +9120,8 @@ add_newdoc("obl_rad1",
         Spheroidal parameter
     x : array_like
         Parameter x (|x| < 1.0)
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -8852,7 +9138,7 @@ add_newdoc("obl_rad1",
 
 add_newdoc("obl_rad1_cv",
     """
-    obl_rad1_cv(m, n, c, cv, x)
+    obl_rad1_cv(m, n, c, cv, x, out=None)
 
     Oblate spheroidal radial function obl_rad1 for precomputed characteristic value
 
@@ -8873,6 +9159,8 @@ add_newdoc("obl_rad1_cv",
         Characteristic value
     x : array_like
         Parameter x (|x| < 1.0)
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -8889,7 +9177,7 @@ add_newdoc("obl_rad1_cv",
 
 add_newdoc("obl_rad2",
     """
-    obl_rad2(m, n, c, x)
+    obl_rad2(m, n, c, x, out=None)
 
     Oblate spheroidal radial function of the second kind and its derivative.
 
@@ -8907,6 +9195,8 @@ add_newdoc("obl_rad2",
         Spheroidal parameter
     x : array_like
         Parameter x (|x| < 1.0)
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -8923,7 +9213,7 @@ add_newdoc("obl_rad2",
 
 add_newdoc("obl_rad2_cv",
     """
-    obl_rad2_cv(m, n, c, cv, x)
+    obl_rad2_cv(m, n, c, cv, x, out=None)
 
     Oblate spheroidal radial function obl_rad2 for precomputed characteristic value
 
@@ -8944,6 +9234,8 @@ add_newdoc("obl_rad2_cv",
         Characteristic value
     x : array_like
         Parameter x (|x| < 1.0)
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -8959,7 +9251,7 @@ add_newdoc("obl_rad2_cv",
 
 add_newdoc("pbdv",
     """
-    pbdv(v, x)
+    pbdv(v, x, out=None)
 
     Parabolic cylinder function D
 
@@ -8972,6 +9264,8 @@ add_newdoc("pbdv",
         Real parameter
     x : array_like
         Real argument
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -8983,12 +9277,21 @@ add_newdoc("pbdv",
 
 add_newdoc("pbvv",
     """
-    pbvv(v, x)
+    pbvv(v, x, out=None)
 
     Parabolic cylinder function V
 
     Returns the parabolic cylinder function Vv(x) in v and the
     derivative, Vv'(x) in vp.
+
+    Parameters
+    ----------
+    v : array_like
+        Real parameter
+    x : array_like
+        Real argument
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -9000,7 +9303,7 @@ add_newdoc("pbvv",
 
 add_newdoc("pbwa",
     r"""
-    pbwa(a, x)
+    pbwa(a, x, out=None)
 
     Parabolic cylinder function W.
 
@@ -9018,6 +9321,8 @@ add_newdoc("pbwa",
         Real parameter
     x : array_like
         Real argument
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -9061,7 +9366,7 @@ add_newdoc("pdtr",
         Number of occurrences (nonnegative, real)
     m : array_like
         Shape parameter (nonnegative, real)
-    out : ndarray
+    out : ndarray, optional
         Optional output array for the function results
 
     Returns
@@ -9112,7 +9417,7 @@ add_newdoc("pdtrc",
         Number of occurrences (nonnegative, real)
     m : array_like
         Shape parameter (nonnegative, real)
-    out : ndarray
+    out : ndarray, optional
         Optional output array for the function results
 
     Returns
@@ -9145,7 +9450,7 @@ add_newdoc("pdtri",
         Number of occurrences (nonnegative, real)
     y : array_like
         Probability
-    out : ndarray
+    out : ndarray, optional
         Optional output array for the function results
 
     Returns
@@ -9173,7 +9478,7 @@ add_newdoc("pdtrik",
         Shape parameter (nonnegative, real)
     p : array_like
         Probability
-    out : ndarray
+    out : ndarray, optional
         Optional output array for the function results
 
     Returns
@@ -9191,7 +9496,7 @@ add_newdoc("pdtrik",
 
 add_newdoc("poch",
     r"""
-    poch(z, m)
+    poch(z, m, out=None)
 
     Pochhammer symbol.
 
@@ -9213,6 +9518,8 @@ add_newdoc("poch",
     ----------
     z, m : array_like
         Real-valued arguments.
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -9252,7 +9559,7 @@ add_newdoc("poch",
 
 add_newdoc("pro_ang1",
     """
-    pro_ang1(m, n, c, x)
+    pro_ang1(m, n, c, x, out=None)
 
     Prolate spheroidal angular function of the first kind and its derivative
 
@@ -9270,6 +9577,8 @@ add_newdoc("pro_ang1",
         Spheroidal parameter
     x : array_like
         Real parameter (|x| < 1.0)
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -9281,7 +9590,7 @@ add_newdoc("pro_ang1",
 
 add_newdoc("pro_ang1_cv",
     """
-    pro_ang1_cv(m, n, c, cv, x)
+    pro_ang1_cv(m, n, c, cv, x, out=None)
 
     Prolate spheroidal angular function pro_ang1 for precomputed characteristic value
 
@@ -9302,6 +9611,8 @@ add_newdoc("pro_ang1_cv",
         Characteristic value
     x : array_like
         Real parameter (|x| < 1.0)
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -9313,7 +9624,7 @@ add_newdoc("pro_ang1_cv",
 
 add_newdoc("pro_cv",
     """
-    pro_cv(m, n, c)
+    pro_cv(m, n, c, out=None)
 
     Characteristic value of prolate spheroidal function
 
@@ -9328,6 +9639,8 @@ add_newdoc("pro_cv",
         Mode parameter n (>= m)
     c : array_like
         Spheroidal parameter
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -9337,7 +9650,7 @@ add_newdoc("pro_cv",
 
 add_newdoc("pro_rad1",
     """
-    pro_rad1(m, n, c, x)
+    pro_rad1(m, n, c, x, out=None)
 
     Prolate spheroidal radial function of the first kind and its derivative
 
@@ -9355,6 +9668,8 @@ add_newdoc("pro_rad1",
         Spheroidal parameter
     x : array_like
         Real parameter (|x| < 1.0)
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -9366,7 +9681,7 @@ add_newdoc("pro_rad1",
 
 add_newdoc("pro_rad1_cv",
     """
-    pro_rad1_cv(m, n, c, cv, x)
+    pro_rad1_cv(m, n, c, cv, x, out=None)
 
     Prolate spheroidal radial function pro_rad1 for precomputed characteristic value
 
@@ -9387,6 +9702,8 @@ add_newdoc("pro_rad1_cv",
         Characteristic value
     x : array_like
         Real parameter (|x| < 1.0)
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -9398,7 +9715,7 @@ add_newdoc("pro_rad1_cv",
 
 add_newdoc("pro_rad2",
     """
-    pro_rad2(m, n, c, x)
+    pro_rad2(m, n, c, x, out=None)
 
     Prolate spheroidal radial function of the second kind and its derivative
 
@@ -9418,6 +9735,8 @@ add_newdoc("pro_rad2",
         Characteristic value
     x : array_like
         Real parameter (|x| < 1.0)
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -9429,7 +9748,7 @@ add_newdoc("pro_rad2",
 
 add_newdoc("pro_rad2_cv",
     """
-    pro_rad2_cv(m, n, c, cv, x)
+    pro_rad2_cv(m, n, c, cv, x, out=None)
 
     Prolate spheroidal radial function pro_rad2 for precomputed characteristic value
 
@@ -9450,6 +9769,8 @@ add_newdoc("pro_rad2_cv",
         Characteristic value
     x : array_like
         Real parameter (|x| < 1.0)
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -9461,7 +9782,7 @@ add_newdoc("pro_rad2_cv",
 
 add_newdoc("pseudo_huber",
     r"""
-    pseudo_huber(delta, r)
+    pseudo_huber(delta, r, out=None)
 
     Pseudo-Huber loss function.
 
@@ -9473,6 +9794,8 @@ add_newdoc("pseudo_huber",
         Input array, indicating the soft quadratic vs. linear loss changepoint.
     r : array_like
         Input array, possibly representing residuals.
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -9767,6 +10090,8 @@ add_newdoc("shichi",
     x : array_like
         Real or complex points at which to compute the hyperbolic sine
         and cosine integrals.
+    out : tuple of ndarray, optional
+        Optional output arrays for the function results
 
     Returns
     -------
@@ -9820,6 +10145,8 @@ add_newdoc("sici",
     x : array_like
         Real or complex points at which to compute the sine and cosine
         integrals.
+    out : tuple of ndarray, optional
+        Optional output arrays for the function results
 
     Returns
     -------
@@ -9885,7 +10212,7 @@ add_newdoc("sindg",
 
 add_newdoc("smirnov",
     r"""
-    smirnov(n, d)
+    smirnov(n, d, out=None)
 
     Kolmogorov-Smirnov complementary cumulative distribution function
 
@@ -9902,6 +10229,8 @@ add_newdoc("smirnov",
       Number of samples
     d : float array_like
       Deviation between the Empirical CDF (ECDF) and the target CDF.
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -9983,7 +10312,7 @@ add_newdoc("smirnov",
 
 add_newdoc("smirnovi",
     """
-    smirnovi(n, p)
+    smirnovi(n, p, out=None)
 
     Inverse to `smirnov`
 
@@ -9996,6 +10325,8 @@ add_newdoc("smirnovi",
       Number of samples
     p : float array_like
         Probability
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -10054,6 +10385,8 @@ add_newdoc("spence",
     ----------
     z : array_like
         Points at which to evaluate Spence's function
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -10073,7 +10406,7 @@ add_newdoc("spence",
 
 add_newdoc("stdtr",
     """
-    stdtr(df, t)
+    stdtr(df, t, out=None)
 
     Student t distribution cumulative distribution function
 
@@ -10089,6 +10422,8 @@ add_newdoc("stdtr",
         Degrees of freedom
     t : array_like
         Upper bound of the integral
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -10103,7 +10438,7 @@ add_newdoc("stdtr",
 
 add_newdoc("stdtridf",
     """
-    stdtridf(p, t)
+    stdtridf(p, t, out=None)
 
     Inverse of `stdtr` vs df
 
@@ -10115,6 +10450,8 @@ add_newdoc("stdtridf",
         Probability
     t : array_like
         Upper bound of the integral
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -10129,7 +10466,7 @@ add_newdoc("stdtridf",
 
 add_newdoc("stdtrit",
     """
-    stdtrit(df, p)
+    stdtrit(df, p, out=None)
 
     Inverse of `stdtr` vs `t`
 
@@ -10141,6 +10478,8 @@ add_newdoc("stdtrit",
         Degrees of freedom
     p : array_like
         Probability
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -10156,7 +10495,7 @@ add_newdoc("stdtrit",
 
 add_newdoc("struve",
     r"""
-    struve(v, x)
+    struve(v, x, out=None)
 
     Struve function.
 
@@ -10175,6 +10514,8 @@ add_newdoc("struve",
     x : array_like
         Argument of the Struve function (float; must be positive unless `v` is
         an integer).
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -10241,7 +10582,7 @@ add_newdoc("tandg",
 
 add_newdoc("tklmbda",
     """
-    tklmbda(x, lmbda)
+    tklmbda(x, lmbda, out=None)
 
     Tukey-Lambda cumulative distribution function
 
@@ -10249,6 +10590,8 @@ add_newdoc("tklmbda",
     ----------
     x, lmbda : array_like
         Parameters
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -10258,7 +10601,7 @@ add_newdoc("tklmbda",
 
 add_newdoc("wofz",
     """
-    wofz(z)
+    wofz(z, out=None)
 
     Faddeeva function
 
@@ -10270,6 +10613,8 @@ add_newdoc("wofz",
     ----------
     z : array_like
         complex argument
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -10304,7 +10649,7 @@ add_newdoc("wofz",
 
 add_newdoc("xlogy",
     """
-    xlogy(x, y)
+    xlogy(x, y, out=None)
 
     Compute ``x*log(y)`` so that the result is 0 if ``x = 0``.
 
@@ -10314,6 +10659,8 @@ add_newdoc("xlogy",
         Multiplier
     y : array_like
         Argument
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -10329,7 +10676,7 @@ add_newdoc("xlogy",
 
 add_newdoc("xlog1py",
     """
-    xlog1py(x, y)
+    xlog1py(x, y, out=None)
 
     Compute ``x*log1p(y)`` so that the result is 0 if ``x = 0``.
 
@@ -10339,6 +10686,8 @@ add_newdoc("xlog1py",
         Multiplier
     y : array_like
         Argument
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -10354,7 +10703,7 @@ add_newdoc("xlog1py",
 
 add_newdoc("y0",
     r"""
-    y0(x)
+    y0(x, out=None)
 
     Bessel function of the second kind of order 0.
 
@@ -10362,6 +10711,8 @@ add_newdoc("y0",
     ----------
     x : array_like
         Argument (float).
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -10399,7 +10750,7 @@ add_newdoc("y0",
 
 add_newdoc("y1",
     """
-    y1(x)
+    y1(x, out=None)
 
     Bessel function of the second kind of order 1.
 
@@ -10407,6 +10758,8 @@ add_newdoc("y1",
     ----------
     x : array_like
         Argument (float).
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -10438,7 +10791,7 @@ add_newdoc("y1",
 
 add_newdoc("yn",
     r"""
-    yn(n, x)
+    yn(n, x, out=None)
 
     Bessel function of the second kind of integer order and real argument.
 
@@ -10448,6 +10801,8 @@ add_newdoc("yn",
         Order (integer).
     x : array_like
         Argument (float).
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -10474,7 +10829,7 @@ add_newdoc("yn",
 
 add_newdoc("yv",
     r"""
-    yv(v, z)
+    yv(v, z, out=None)
 
     Bessel function of the second kind of real order and complex argument.
 
@@ -10484,6 +10839,8 @@ add_newdoc("yv",
         Order (float).
     z : array_like
         Argument (float or complex).
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -10521,7 +10878,7 @@ add_newdoc("yv",
 
 add_newdoc("yve",
     r"""
-    yve(v, z)
+    yve(v, z, out=None)
 
     Exponentially scaled Bessel function of the second kind of real order.
 
@@ -10536,6 +10893,8 @@ add_newdoc("yve",
         Order (float).
     z : array_like
         Argument (float or complex).
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -10576,7 +10935,7 @@ add_newdoc("_zeta",
 
 add_newdoc("zetac",
     """
-    zetac(x)
+    zetac(x, out=None)
 
     Riemann zeta function minus 1.
 
@@ -10592,6 +10951,8 @@ add_newdoc("zetac",
     ----------
     x : array_like of float
         Values at which to compute zeta(x) - 1 (must be real).
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -10781,7 +11142,7 @@ add_newdoc("_cospi",
 
 add_newdoc("owens_t",
     """
-    owens_t(h, a)
+    owens_t(h, a, out=None)
 
     Owen's T Function.
 
@@ -10795,6 +11156,8 @@ add_newdoc("owens_t",
         Input value.
     a: array_like
         Input value.
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -10823,7 +11186,7 @@ add_newdoc("_factorial",
 
 add_newdoc("wright_bessel",
     r"""
-    wright_bessel(a, b, x)
+    wright_bessel(a, b, x, out=None)
 
     Wright's generalized Bessel function.
 
@@ -10841,6 +11204,8 @@ add_newdoc("wright_bessel",
         b >= 0
     x : array_like of float
         x >= 0
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------
@@ -10875,7 +11240,7 @@ add_newdoc("wright_bessel",
 
 add_newdoc("ndtri_exp",
     r"""
-    ndtri_exp(y)
+    ndtri_exp(y, out=None)
 
     Inverse of `log_ndtr` vs x. Allows for greater precision than
     `ndtri` composed with `numpy.exp` for very small values of y and for
@@ -10884,6 +11249,9 @@ add_newdoc("ndtri_exp",
     Parameters
     ----------
     y : array_like of float
+        Function argument
+    out : ndarray, optional
+        Optional output array for the function results
 
     Returns
     -------

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -42,7 +42,7 @@ add_newdoc("_cosine_cdf",
 
     Returns
     -------
-    float
+    scalar or ndarray
         The cosine distribution CDF evaluated at `x`.
 
     """)
@@ -68,7 +68,7 @@ add_newdoc("_cosine_invcdf",
 
     Returns
     -------
-    float
+    scalar or ndarray
         The inverse of the cosine distribution CDF evaluated at `p`.
 
     """)
@@ -103,7 +103,7 @@ add_newdoc("sph_harm",
 
     Returns
     -------
-    y_mn : complex float
+    y_mn : complex scalar or ndarray
        The harmonic :math:`Y^m_n` sampled at ``theta`` and ``phi``.
 
     Notes
@@ -222,7 +222,7 @@ add_newdoc("wrightomega",
 
     Returns
     -------
-    omega : ndarray
+    omega : scalar or ndarray
         Values of the Wright Omega function
 
     Notes
@@ -277,7 +277,7 @@ add_newdoc("agm",
 
     Returns
     -------
-    float
+    scalar or ndarray
         The arithmetic-geometric mean of `a` and `b`.
 
     Examples
@@ -322,7 +322,7 @@ add_newdoc("airy",
 
     Returns
     -------
-    Ai, Aip, Bi, Bip : ndarrays
+    Ai, Aip, Bi, Bip : 4-tuple of scalar or ndarray
         Airy functions Ai and Bi, and their derivatives Aip and Bip.
 
     Notes
@@ -402,7 +402,7 @@ add_newdoc("airye",
 
     Returns
     -------
-    eAi, eAip, eBi, eBip : array_like
+    eAi, eAip, eBi, eBip : 4-tuple of scalar or ndarray
         Exponentially scaled Airy functions eAi and eBi, and their derivatives
         eAip and eBip
 
@@ -482,7 +482,7 @@ add_newdoc("bdtr",
 
     Returns
     -------
-    y : ndarray
+    y : scalar or ndarray
         Probability of `floor(k)` or fewer successes in `n` independent events with
         success probabilities of `p`.
 
@@ -526,7 +526,7 @@ add_newdoc("bdtrc",
 
     Returns
     -------
-    y : ndarray
+    y : scalar or ndarray
         Probability of `floor(k) + 1` or more successes in `n` independent
         events with success probabilities of `p`.
 
@@ -574,7 +574,7 @@ add_newdoc("bdtri",
 
     Returns
     -------
-    p : ndarray
+    p : scalar or ndarray
         The event probability such that `bdtr(\lfloor k \rfloor, n, p) = y`.
 
     See also
@@ -619,7 +619,7 @@ add_newdoc("bdtrik",
 
     Returns
     -------
-    k : ndarray
+    k : scalar or ndarray
         The number of successes `k` such that `bdtr(k, n, p) = y`.
 
     See also
@@ -669,7 +669,7 @@ add_newdoc("bdtrin",
 
     Returns
     -------
-    n : ndarray
+    n : scalar or ndarray
         The number of events `n` such that `bdtr(k, n, p) = y`.
 
     See also
@@ -720,7 +720,7 @@ add_newdoc(
 
     Returns
     -------
-    array_like
+    scalar or ndarray
         Value of binomial coefficient.
 
     See Also
@@ -812,7 +812,7 @@ add_newdoc("btdtria",
 
     Returns
     -------
-    a : ndarray
+    a : scalar or ndarray
         The value of the shape parameter `a` such that `btdtr(a, b, x) = p`.
 
     See Also
@@ -865,7 +865,7 @@ add_newdoc("btdtrib",
 
     Returns
     -------
-    b : ndarray
+    b : scalar or ndarray
         The value of the shape parameter `b` such that `btdtr(a, b, x) = p`.
 
     See Also
@@ -1105,7 +1105,7 @@ add_newdoc("beta",
 
     Parameters
     ----------
-    a, b : array-like
+    a, b : array_like
         Real-valued arguments
     out : ndarray, optional
         Optional output array for the function result
@@ -1171,9 +1171,9 @@ add_newdoc("betainc",
 
     Parameters
     ----------
-    a, b : array-like
+    a, b : array_like
            Positive, real-valued parameters
-    x : array-like
+    x : array_like
         Real-valued such that :math:`0 \leq x \leq 1`,
         the upper limit of integration
     out : ndarray, optional
@@ -1181,7 +1181,7 @@ add_newdoc("betainc",
 
     Returns
     -------
-    array-like
+    scalar or ndarray
         Value of the incomplete beta function
 
     See Also
@@ -1257,16 +1257,16 @@ add_newdoc("betaincinv",
 
     Parameters
     ----------
-    a, b : array-like
+    a, b : array_like
         Positive, real-valued parameters
-    y : array-like
+    y : array_like
         Real-valued input
     out : ndarray, optional
         Optional output array for function values
 
     Returns
     -------
-    array-like
+    scalar or ndarray
         Value of the inverse of the incomplete beta function
 
     See Also
@@ -1305,6 +1305,25 @@ add_newdoc("betaln",
     Natural logarithm of absolute value of beta function.
 
     Computes ``ln(abs(beta(a, b)))``.
+
+    Parameters
+    ----------
+    a, b : array_like
+        Positive, real-valued parameters
+    out : ndarray, optional
+        Optional output array for function values
+
+    Returns
+    -------
+    scalar or ndarray
+        Value of the betaln function
+
+    See Also
+    --------
+    gamma : the gamma function
+    betainc :  the incomplete beta function
+    beta : the beta function
+
     """)
 
 add_newdoc("boxcox",
@@ -1330,7 +1349,7 @@ add_newdoc("boxcox",
 
     Returns
     -------
-    y : array
+    y : scalar or ndarray
         Transformed data.
 
     Notes
@@ -1370,7 +1389,7 @@ add_newdoc("boxcox1p",
 
     Returns
     -------
-    y : array
+    y : scalar or ndarray
         Transformed data.
 
     Notes
@@ -1407,7 +1426,7 @@ add_newdoc("inv_boxcox",
 
     Returns
     -------
-    x : array
+    x : scalar or ndarray
         Transformed data.
 
     Notes
@@ -1443,7 +1462,7 @@ add_newdoc("inv_boxcox1p",
 
     Returns
     -------
-    x : array
+    x : scalar or ndarray
         Transformed data.
 
     Notes
@@ -1484,7 +1503,7 @@ add_newdoc("btdtr",
 
     Returns
     -------
-    I : ndarray
+    I : scalar or ndarray
         Cumulative distribution function of the beta distribution with
         parameters `a` and `b` at `x`.
 
@@ -1529,7 +1548,7 @@ add_newdoc("btdtri",
 
     Returns
     -------
-    x : ndarray
+    x : scalar or ndarray
         The quantile corresponding to `p`.
 
     See Also
@@ -1564,7 +1583,7 @@ add_newdoc("cbrt",
 
     Returns
     -------
-    float
+    scalar or ndarray
         The cube root of each value in `x`.
 
     Examples
@@ -1793,6 +1812,26 @@ add_newdoc("chndtr",
 
     Non-central chi square cumulative distribution function
 
+    Parameters
+    ----------
+    x : array_like
+        Upper bound of the integral
+    df : array_like
+        Degrees of freedom
+    nc : array_like
+        Non-centrality parameter
+    out : ndarray, optional
+        Optional output array for the function results
+
+    Returns
+    -------
+    x : scalar or ndarray
+        Value of the non-central chi square cumulative distribution function.
+
+    See Also
+    --------
+    chndtrix, chndtridf, chndtrinc
+
     """)
 
 add_newdoc("chndtrix",
@@ -1800,6 +1839,29 @@ add_newdoc("chndtrix",
     chndtrix(p, df, nc)
 
     Inverse to `chndtr` vs `x`
+
+    Parameters
+    ----------
+    p : array_like
+        Probability
+    df : array_like
+        Degrees of freedom
+    nc : array_like
+        Non-centrality parameter
+    out : ndarray, optional
+        Optional output array for the function results
+
+    Returns
+    -------
+    x : scalar or ndarray
+        Value so that the probability a non-central Chi square random variable
+        with `df` degrees of freedom and non-centrality, `nc`, is greater than
+        `x` equals `p`.
+
+    See Also
+    --------
+    chndtr, chndtridf, chndtrinc
+
     """)
 
 add_newdoc("chndtridf",
@@ -1807,6 +1869,27 @@ add_newdoc("chndtridf",
     chndtridf(x, p, nc)
 
     Inverse to `chndtr` vs `df`
+
+    Parameters
+    ----------
+    x : array_like
+        Upper bound of the integral
+    p : array_like
+        Probability
+    nc : array_like
+        Non-centrality parameter
+    out : ndarray, optional
+        Optional output array for the function results
+
+    Returns
+    -------
+    df : scalar or ndarray
+        Degrees of freedom
+
+    See Also
+    --------
+    chndtr, chndtrix, chndtrinc
+
     """)
 
 add_newdoc("chndtrinc",
@@ -1814,6 +1897,28 @@ add_newdoc("chndtrinc",
     chndtrinc(x, df, p)
 
     Inverse to `chndtr` vs `nc`
+
+
+    Parameters
+    ----------
+    x : array_like
+        Upper bound of the integral
+    df : array_like
+        Degrees of freedom
+    p : array_like
+        Probability
+    out : ndarray, optional
+        Optional output array for the function results
+
+    Returns
+    -------
+    nc : scalar or ndarray
+        Non-centrality
+
+    See Also
+    --------
+    chndtr, chndtrix, chndtrinc
+
     """)
 
 add_newdoc("cosdg",
@@ -1935,6 +2040,16 @@ add_newdoc("dawsn",
 
         exp(-x**2) * integral(exp(t**2), t=0..x).
 
+    Parameters
+    ----------
+    x : array_like
+        Function parameter.
+
+    Returns
+    -------
+    y : scalar or ndarray
+        Value of the integral.
+
     See Also
     --------
     wofz, erf, erfc, erfcx, erfi
@@ -1973,7 +2088,7 @@ add_newdoc("ellipe",
 
     Returns
     -------
-    E : ndarray
+    E : scalar or ndarray
         Value of the elliptic integral.
 
     Notes
@@ -2069,7 +2184,7 @@ add_newdoc("ellipeinc",
 
     Returns
     -------
-    E : ndarray
+    E : scalar or ndarray
         Value of the elliptic integral.
 
     Notes
@@ -2132,7 +2247,7 @@ add_newdoc("ellipj",
 
     Returns
     -------
-    sn, cn, dn, ph : ndarrays
+    sn, cn, dn, ph : 4-tuple of scalar or ndarray
         The returned functions::
 
             sn(u|m), cn(u|m), dn(u|m)
@@ -2185,7 +2300,7 @@ add_newdoc("ellipkm1",
 
     Returns
     -------
-    K : ndarray
+    K : scalar or ndarray
         Value of the elliptic integral.
 
     Notes
@@ -2236,7 +2351,7 @@ add_newdoc("ellipk",
 
     Returns
     -------
-    K : array_like
+    K : scalar or ndarray
         Value of the elliptic integral.
 
     Notes
@@ -2296,7 +2411,7 @@ add_newdoc("ellipkinc",
 
     Returns
     -------
-    K : ndarray
+    K : scalar or ndarray
         Value of the elliptic integral
 
     Notes
@@ -2359,7 +2474,7 @@ add_newdoc(
 
     Returns
     -------
-    R : ndarray
+    R : scalar or ndarray
         Value of the integral. If `y` is real and negative, the Cauchy
         principal value is returned. If both of `x` and `y` are real, the
         return value is real. Otherwise, the return value is complex.
@@ -2417,7 +2532,7 @@ add_newdoc(
 
     Returns
     -------
-    R : ndarray
+    R : scalar or ndarray
         Value of the integral. If all of `x`, `y`, and `z` are real, the
         return value is real. Otherwise, the return value is complex.
 
@@ -2472,7 +2587,7 @@ add_newdoc(
 
     Returns
     -------
-    R : ndarray
+    R : scalar or ndarray
         Value of the integral. If all of `x`, `y`, and `z` are real, the return
         value is real. Otherwise, the return value is complex.
 
@@ -2527,7 +2642,7 @@ add_newdoc(
 
     Returns
     -------
-    R : ndarray
+    R : scalar or ndarray
         Value of the integral. If all of `x`, `y`, and `z` are real, the return
         value is real. Otherwise, the return value is complex.
 
@@ -2613,7 +2728,7 @@ add_newdoc(
 
     Returns
     -------
-    R : ndarray
+    R : scalar or ndarray
         Value of the integral. If all of `x`, `y`, `z`, and `p` are real, the
         return value is real. Otherwise, the return value is complex.
 
@@ -2693,7 +2808,7 @@ add_newdoc("entr",
 
     Returns
     -------
-    res : ndarray
+    res : scalar or ndarray
         The value of the elementwise entropy function at the given points `x`.
 
     See Also
@@ -2723,7 +2838,7 @@ add_newdoc("erf",
 
     Returns
     -------
-    res : ndarray
+    res : scalar or ndarray
         The values of the error function at the given points `x`.
 
     See Also
@@ -2902,7 +3017,7 @@ add_newdoc("erfinv",
 
     Returns
     -------
-    erfinv : ndarray
+    erfinv : scalar or ndarray
         The inverse of erf of y, element-wise)
 
     See Also
@@ -2948,7 +3063,7 @@ add_newdoc("erfcinv",
 
     Returns
     -------
-    erfcinv : ndarray
+    erfcinv : scalar or ndarray
         The inverse of erfc of y, element-wise
 
     See Also
@@ -3009,7 +3124,7 @@ add_newdoc("eval_jacobi",
 
     Returns
     -------
-    P : ndarray
+    P : scalar or ndarray
         Values of the Jacobi polynomial
 
     See Also
@@ -3054,7 +3169,7 @@ add_newdoc("eval_sh_jacobi",
 
     Returns
     -------
-    G : ndarray
+    G : scalar or ndarray
         Values of the shifted Jacobi polynomial.
 
     See Also
@@ -3102,7 +3217,7 @@ add_newdoc("eval_gegenbauer",
 
     Returns
     -------
-    C : ndarray
+    C : scalar or ndarray
         Values of the Gegenbauer polynomial
 
     See Also
@@ -3147,7 +3262,7 @@ add_newdoc("eval_chebyt",
 
     Returns
     -------
-    T : ndarray
+    T : scalar or ndarray
         Values of the Chebyshev polynomial
 
     See Also
@@ -3199,7 +3314,7 @@ add_newdoc("eval_chebyu",
 
     Returns
     -------
-    U : ndarray
+    U : scalar or ndarray
         Values of the Chebyshev polynomial
 
     See Also
@@ -3244,7 +3359,7 @@ add_newdoc("eval_chebys",
 
     Returns
     -------
-    S : ndarray
+    S : scalar or ndarray
         Values of the Chebyshev polynomial
 
     See Also
@@ -3301,7 +3416,7 @@ add_newdoc("eval_chebyc",
 
     Returns
     -------
-    C : ndarray
+    C : scalar or ndarray
         Values of the Chebyshev polynomial
 
     See Also
@@ -3359,7 +3474,7 @@ add_newdoc("eval_sh_chebyt",
 
     Returns
     -------
-    T : ndarray
+    T : scalar or ndarray
         Values of the shifted Chebyshev polynomial
 
     See Also
@@ -3404,7 +3519,7 @@ add_newdoc("eval_sh_chebyu",
 
     Returns
     -------
-    U : ndarray
+    U : scalar or ndarray
         Values of the shifted Chebyshev polynomial
 
     See Also
@@ -3449,7 +3564,7 @@ add_newdoc("eval_legendre",
 
     Returns
     -------
-    P : ndarray
+    P : scalar or ndarray
         Values of the Legendre polynomial
 
     See Also
@@ -3529,7 +3644,7 @@ add_newdoc("eval_sh_legendre",
 
     Returns
     -------
-    P : ndarray
+    P : scalar or ndarray
         Values of the shifted Legendre polynomial
 
     See Also
@@ -3580,7 +3695,7 @@ add_newdoc("eval_genlaguerre",
 
     Returns
     -------
-    L : ndarray
+    L : scalar or ndarray
         Values of the generalized Laguerre polynomial
 
     See Also
@@ -3626,7 +3741,7 @@ add_newdoc("eval_laguerre",
 
     Returns
     -------
-    L : ndarray
+    L : scalar or ndarray
         Values of the Laguerre polynomial
 
     See Also
@@ -3669,7 +3784,7 @@ add_newdoc("eval_hermite",
 
     Returns
     -------
-    H : ndarray
+    H : scalar or ndarray
         Values of the Hermite polynomial
 
     See Also
@@ -3713,7 +3828,7 @@ add_newdoc("eval_hermitenorm",
 
     Returns
     -------
-    He : ndarray
+    He : scalar or ndarray
         Values of the Hermite polynomial
 
     See Also
@@ -3752,7 +3867,7 @@ add_newdoc("exp1",
     ----------
     z: array_like
         Real or complex argument.
-    out: ndarray, optional
+    out : ndarray, optional
         Optional output array for the function results
 
     Returns
@@ -3825,7 +3940,7 @@ add_newdoc("exp10",
 
     Returns
     -------
-    float
+    scalar or ndarray
         ``10**x``, computed element-wise.
 
     Examples
@@ -3854,7 +3969,7 @@ add_newdoc("exp2",
 
     Returns
     -------
-    float
+    scalar or ndarray
         ``2**x``, computed element-wise.
 
     Examples
@@ -3890,9 +4005,9 @@ add_newdoc("expi",
 
     Parameters
     ----------
-    x: array_like
+    x : array_like
         Real or complex valued argument
-    out: ndarray, optional
+    out : ndarray, optional
         Optional output array for the function results
 
     Returns
@@ -3974,7 +4089,7 @@ add_newdoc('expit',
 
     Returns
     -------
-    out : ndarray
+    scalar or ndarray
         An ndarray of the same shape as x. Its entries
         are `expit` of the corresponding entry of x.
 
@@ -4034,7 +4149,7 @@ add_newdoc("expm1",
 
     Returns
     -------
-    float
+    scalar or ndarray
         ``exp(x) - 1`` computed element-wise.
 
     Examples
@@ -4078,11 +4193,11 @@ add_newdoc("expn",
 
     Parameters
     ----------
-    n: array_like
+    n : array_like
         Non-negative integers
-    x: array_like
+    x : array_like
         Real argument
-    out: ndarray, optional
+    out : ndarray, optional
         Optional output array for the function results
 
     Returns
@@ -4150,7 +4265,7 @@ add_newdoc("exprel",
 
     Returns
     -------
-    float
+    scalar or ndarray
         ``(exp(x) - 1)/x``, computed element-wise.
 
     See Also
@@ -4211,7 +4326,7 @@ add_newdoc("fdtr",
 
     Returns
     -------
-    y : ndarray
+    y : scalar or ndarray
         The CDF of the F-distribution with parameters `dfn` and `dfd` at `x`.
 
     Notes
@@ -4251,7 +4366,7 @@ add_newdoc("fdtrc",
 
     Returns
     -------
-    y : ndarray
+    y : scalar or ndarray
         The complemented F-distribution function with parameters `dfn` and
         `dfd` at `x`.
 
@@ -4295,7 +4410,7 @@ add_newdoc("fdtri",
 
     Returns
     -------
-    x : ndarray
+    x : scalar or ndarray
         The quantile corresponding to `p`.
 
     Notes
@@ -4330,6 +4445,25 @@ add_newdoc("fdtridfd",
     Inverse to `fdtr` vs dfd
 
     Finds the F density argument dfd such that ``fdtr(dfn, dfd, x) == p``.
+
+    Parameters
+    ----------
+    dfn : array_like
+        First parameter (positive float).
+    p : array_like
+        Cumulative probability, in [0, 1].
+    x : array_like
+        Argument (nonnegative float).
+
+    Returns
+    -------
+    dfd : scalar or ndarray
+        `dfd` such that ``fdtr(dfn, dfd, x) == p``.
+
+    See Also
+    --------
+    fdtr, fdtrc, fdtri, fdtridfn
+
     """)
 
 add_newdoc("fdtridfn",
@@ -4339,6 +4473,27 @@ add_newdoc("fdtridfn",
     Inverse to `fdtr` vs dfn
 
     finds the F density argument dfn such that ``fdtr(dfn, dfd, x) == p``.
+
+
+    Parameters
+    ----------
+    p : array_like
+        Cumulative probability, in [0, 1].
+    dfd : array_like
+        Second parameter (positive float).
+    x : array_like
+        Argument (nonnegative float).
+
+    Returns
+    -------
+    dfn : scalar or ndarray
+        `dfn` such that ``fdtr(dfn, dfd, x) == p``.
+
+    See Also
+    --------
+    fdtr, fdtrc, fdtri, fdtridfd
+
+
     """)
 
 add_newdoc("fresnel",
@@ -4901,7 +5056,7 @@ add_newdoc("gdtr",
 
     Returns
     -------
-    F : ndarray
+    F : scalar or ndarray
         The CDF of the gamma distribution with parameters `a` and `b`
         evaluated at `x`.
 
@@ -4947,7 +5102,7 @@ add_newdoc("gdtrc",
 
     Returns
     -------
-    F : ndarray
+    F : scalar or ndarray
         The survival function of the gamma distribution with parameters `a`
         and `b` evaluated at `x`.
 
@@ -4995,7 +5150,7 @@ add_newdoc("gdtria",
 
     Returns
     -------
-    a : ndarray
+    a : scalar or ndarray
         Values of the `a` parameter such that `p = gdtr(a, b, x)`.  `1/a`
         is the "scale" parameter of the gamma distribution.
 
@@ -5064,7 +5219,7 @@ add_newdoc("gdtrib",
 
     Returns
     -------
-    b : ndarray
+    b : scalar or ndarray
         Values of the `b` parameter such that `p = gdtr(a, b, x)`.  `b` is
         the "shape" parameter of the gamma distribution.
 
@@ -5135,7 +5290,7 @@ add_newdoc("gdtrix",
 
     Returns
     -------
-    x : ndarray
+    x : scalar or ndarray
         Values of the `x` parameter such that `p = gdtr(a, b, x)`.
 
     See Also
@@ -5192,7 +5347,8 @@ add_newdoc("hankel1",
 
     Returns
     -------
-    out : Values of the Hankel function of the first kind.
+    scalar or ndarray
+        Values of the Hankel function of the first kind.
 
     Notes
     -----
@@ -5239,7 +5395,7 @@ add_newdoc("hankel1e",
 
     Returns
     -------
-    out : ndarray
+    scalar or ndarray
         Values of the exponentially scaled Hankel function.
 
     Notes
@@ -5278,7 +5434,7 @@ add_newdoc("hankel2",
 
     Returns
     -------
-    out : ndarray
+    scalar or ndarray
         Values of the Hankel function of the second kind.
 
     Notes
@@ -5325,7 +5481,7 @@ add_newdoc("hankel2e",
 
     Returns
     -------
-    out : ndarray
+    scalar or ndarray
         Values of the exponentially scaled Hankel function of the second kind.
 
     Notes
@@ -5367,7 +5523,7 @@ add_newdoc("huber",
 
     Returns
     -------
-    res : ndarray
+    scalar or ndarray
         The computed Huber loss function values.
 
     Notes
@@ -5706,7 +5862,7 @@ add_newdoc("i0",
 
     Returns
     -------
-    I : ndarray
+    I : scalar or ndarray
         Value of the modified Bessel function of order 0 at `x`.
 
     Notes
@@ -5744,7 +5900,7 @@ add_newdoc("i0e",
 
     Returns
     -------
-    I : ndarray
+    I : scalar or ndarray
         Value of the exponentially scaled modified Bessel function of order 0
         at `x`.
 
@@ -5789,7 +5945,7 @@ add_newdoc("i1",
 
     Returns
     -------
-    I : ndarray
+    I : scalar or ndarray
         Value of the modified Bessel function of order 1 at `x`.
 
     Notes
@@ -5827,7 +5983,7 @@ add_newdoc("i1e",
 
     Returns
     -------
-    I : ndarray
+    I : scalar or ndarray
         Value of the exponentially scaled modified Bessel function of order 1
         at `x`.
 
@@ -5936,7 +6092,7 @@ add_newdoc("it2struve0",
 
     Returns
     -------
-    I : ndarray
+    I : scalar or ndarray
         The value of the integral.
 
     See also
@@ -5966,18 +6122,18 @@ add_newdoc("itairy",
     Parameters
     ----------
 
-    x: array_like
+    x : array_like
         Upper limit of integration (float).
 
     Returns
     -------
-    Apt
+    Apt : scalar or ndarray
         Integral of Ai(t) from 0 to x.
-    Bpt
+    Bpt : scalar or ndarray
         Integral of Bi(t) from 0 to x.
-    Ant
+    Ant : scalar or ndarray
         Integral of Ai(-t) from 0 to x.
-    Bnt
+    Bnt : scalar or ndarray
         Integral of Bi(-t) from 0 to x.
 
     Notes
@@ -6071,7 +6227,7 @@ add_newdoc("itmodstruve0",
 
     Returns
     -------
-    I : ndarray
+    I : scalar or ndarray
         The integral of :math:`L_0` from 0 to `x`.
 
     Notes
@@ -6103,7 +6259,7 @@ add_newdoc("itstruve0",
 
     Returns
     -------
-    I : ndarray
+    I : scalar or ndarray
         The integral of :math:`H_0` from 0 to `x`.
 
     See also
@@ -6139,7 +6295,7 @@ add_newdoc("iv",
 
     Returns
     -------
-    out : ndarray
+    out : scalar or ndarray
         Values of the modified Bessel function.
 
     Notes
@@ -6200,7 +6356,7 @@ add_newdoc("ive",
 
     Returns
     -------
-    out : ndarray
+    out : scalar or ndarray
         Values of the exponentially scaled modified Bessel function.
 
     Notes
@@ -6246,7 +6402,7 @@ add_newdoc("j0",
 
     Returns
     -------
-    J : ndarray
+    J : scalar or ndarray
         Value of the Bessel function of the first kind of order 0 at `x`.
 
     Notes
@@ -6293,7 +6449,7 @@ add_newdoc("j1",
 
     Returns
     -------
-    J : ndarray
+    J : scalar or ndarray
         Value of the Bessel function of the first kind of order 1 at `x`.
 
     Notes
@@ -6325,15 +6481,27 @@ add_newdoc("jn",
 
     Bessel function of the first kind of integer order and real argument.
 
-    Notes
-    -----
-    `jn` is an alias of `jv`.
-    Not to be confused with the spherical Bessel functions (see `spherical_jn`).
+    Parameters
+    ----------
+    n : array_like
+        order of the Bessel function
+    x : array_like
+        argument of the Bessel function
+
+    Returns
+    -------
+    scalar or ndarray
+        The value of the bessel function
 
     See also
     --------
     jv
     spherical_jn : spherical Bessel functions.
+
+    Notes
+    -----
+    `jn` is an alias of `jv`.
+    Not to be confused with the spherical Bessel functions (see `spherical_jn`).
 
     """)
 
@@ -6352,8 +6520,13 @@ add_newdoc("jv",
 
     Returns
     -------
-    J : ndarray
+    J : scalar or ndarray
         Value of the Bessel function, :math:`J_v(z)`.
+
+    See also
+    --------
+    jve : :math:`J_v` with leading exponential behavior stripped off.
+    spherical_jn : spherical Bessel functions.
 
     Notes
     -----
@@ -6376,11 +6549,6 @@ add_newdoc("jv",
     term is explicitly omitted for `v` values such that `v = floor(v)`.
 
     Not to be confused with the spherical Bessel functions (see `spherical_jn`).
-
-    See also
-    --------
-    jve : :math:`J_v` with leading exponential behavior stripped off.
-    spherical_jn : spherical Bessel functions.
 
     References
     ----------
@@ -6408,7 +6576,7 @@ add_newdoc("jve",
 
     Returns
     -------
-    J : ndarray
+    J : scalar or ndarray
         Value of the exponentially scaled Bessel function.
 
     Notes
@@ -6454,7 +6622,7 @@ add_newdoc("k0",
 
     Returns
     -------
-    K : ndarray
+    K : scalar or ndarray
         Value of the modified Bessel function :math:`K_0` at `x`.
 
     Notes
@@ -6492,7 +6660,7 @@ add_newdoc("k0e",
 
     Returns
     -------
-    K : ndarray
+    K : scalar or ndarray
         Value of the exponentially scaled modified Bessel function K of order
         0 at `x`.
 
@@ -6527,7 +6695,7 @@ add_newdoc("k1",
 
     Returns
     -------
-    K : ndarray
+    K : scalar or ndarray
         Value of the modified Bessel function K of order 1 at `x`.
 
     Notes
@@ -6565,7 +6733,7 @@ add_newdoc("k1e",
 
     Returns
     -------
-    K : ndarray
+    K : scalar or ndarray
         Value of the exponentially scaled modified Bessel function K of order
         1 at `x`.
 
@@ -6676,7 +6844,7 @@ add_newdoc("kelvin",
 
     Returns
     -------
-    Be, Ke, Bep, Kep
+    Be, Ke, Bep, Kep : 4-tuple of scalar or ndarray
         The tuple (Be, Ke, Bep, Kep) contains complex numbers
         representing the real and imaginary Kelvin functions and their
         derivatives evaluated at `x`.  For example, kelvin(x)[0].real =
@@ -6896,7 +7064,7 @@ add_newdoc("kolmogi",
 
     Returns
     -------
-    float
+    scalar or ndarray
         The value(s) of kolmogi(p)
 
     Notes
@@ -6943,7 +7111,7 @@ add_newdoc("kolmogorov",
 
     Returns
     -------
-    float
+    scalar or ndarray
         The value(s) of kolmogorov(y)
 
     Notes
@@ -7053,7 +7221,7 @@ add_newdoc("kv",
 
     Returns
     -------
-    out : ndarray
+    scalar or ndarray
         The results. Note that input must be of complex type to get complex
         output, e.g. ``kv(3, -2+0j)`` instead of ``kv(3, -2)``.
 
@@ -7120,7 +7288,7 @@ add_newdoc("kve",
 
     Returns
     -------
-    out : ndarray
+    scalar or ndarray
         The exponentially scaled modified Bessel function of the second kind.
 
     Notes
@@ -7210,7 +7378,7 @@ add_newdoc('log_expit',
 
     Returns
     -------
-    out : ndarray
+    out : scalar or ndarray
         The computed values, an ndarray of the same shape as ``x``.
 
     See Also
@@ -7271,7 +7439,7 @@ add_newdoc('logit',
 
     Returns
     -------
-    out : ndarray
+    scalar or ndarray
         An ndarray of the same shape as x. Its entries
         are logit of the corresponding entry of x.
 
@@ -7347,7 +7515,7 @@ add_newdoc("lpmv",
 
     Returns
     -------
-    pmv : ndarray
+    pmv : scalar or ndarray
         Value of the associated Legendre function.
 
     See Also
@@ -7374,8 +7542,23 @@ add_newdoc("mathieu_a",
 
     Characteristic value of even Mathieu functions
 
-    Returns the characteristic value for the even solution,
-    ``ce_m(z, q)``, of Mathieu's equation.
+    Parameters
+    ----------
+    m : array_like
+        Order of the function
+    q : array_like
+        Parameter of the function
+
+    Returns
+    -------
+    scalar or ndarray
+        Characteristic value for the even solution, ``ce_m(z, q)``, of
+        Mathieu's equation.
+
+    See Also
+    --------
+    mathieu_b, mathieu_cem, mathieu_sem
+
     """)
 
 add_newdoc("mathieu_b",
@@ -7384,8 +7567,23 @@ add_newdoc("mathieu_b",
 
     Characteristic value of odd Mathieu functions
 
-    Returns the characteristic value for the odd solution,
-    ``se_m(z, q)``, of Mathieu's equation.
+    Parameters
+    ----------
+    m : array_like
+        Order of the function
+    q : array_like
+        Parameter of the function
+
+    Returns
+    -------
+    scalar or ndarray
+        Characteristic value for the odd solution, ``se_m(z, q)``, of Mathieu's
+        equation.
+
+    See Also
+    --------
+    mathieu_a, mathieu_cem, mathieu_sem
+
     """)
 
 add_newdoc("mathieu_cem",
@@ -7400,19 +7598,24 @@ add_newdoc("mathieu_cem",
 
     Parameters
     ----------
-    m
+    m : array_like
         Order of the function
-    q
+    q : array_like
         Parameter of the function
-    x
+    x : array_like
         Argument of the function, *given in degrees, not radians*
 
     Returns
     -------
-    y
+    y : scalar or ndarray
         Value of the function
-    yp
+    yp : scalar or ndarray
         Value of the derivative vs x
+
+    See Also
+    --------
+    mathieu_a, mathieu_b, mathieu_sem
+
     """)
 
 add_newdoc("mathieu_modcem1",
@@ -7425,12 +7628,26 @@ add_newdoc("mathieu_modcem1",
     ``Mc1m(x, q)``, and its derivative at `x` for order `m` and parameter
     `q`.
 
+    Parameters
+    ----------
+    m : array_like
+        Order of the function
+    q : array_like
+        Parameter of the function
+    x : array_like
+        Argument of the function, *given in degrees, not radians*
+
     Returns
     -------
-    y
+    y : scalar or ndarray
         Value of the function
-    yp
+    yp : scalar or ndarray
         Value of the derivative vs x
+
+    See Also
+    --------
+    mathieu_modsem1
+
     """)
 
 add_newdoc("mathieu_modcem2",
@@ -7443,12 +7660,26 @@ add_newdoc("mathieu_modcem2",
     Mc2m(x, q), and its derivative at `x` (given in degrees) for order `m`
     and parameter `q`.
 
+    Parameters
+    ----------
+    m : array_like
+        Order of the function
+    q : array_like
+        Parameter of the function
+    x : array_like
+        Argument of the function, *given in degrees, not radians*
+
     Returns
     -------
-    y
+    y : scalar or ndarray
         Value of the function
-    yp
+    yp : scalar or ndarray
         Value of the derivative vs x
+
+    See Also
+    --------
+    mathieu_modsem2
+
     """)
 
 add_newdoc("mathieu_modsem1",
@@ -7461,12 +7692,26 @@ add_newdoc("mathieu_modsem1",
     Ms1m(x, q), and its derivative at `x` (given in degrees) for order `m`
     and parameter `q`.
 
+    Parameters
+    ----------
+    m : array_like
+        Order of the function
+    q : array_like
+        Parameter of the function
+    x : array_like
+        Argument of the function, *given in degrees, not radians*
+
     Returns
     -------
-    y
+    y : scalar or ndarray
         Value of the function
-    yp
+    yp : scalar or ndarray
         Value of the derivative vs x
+
+    See Also
+    --------
+    mathieu_modcem1
+
     """)
 
 add_newdoc("mathieu_modsem2",
@@ -7479,12 +7724,26 @@ add_newdoc("mathieu_modsem2",
     Ms2m(x, q), and its derivative at `x` (given in degrees) for order `m`
     and parameter q.
 
+    Parameters
+    ----------
+    m : array_like
+        Order of the function
+    q : array_like
+        Parameter of the function
+    x : array_like
+        Argument of the function, *given in degrees, not radians*
+
     Returns
     -------
-    y
+    y : scalar or ndarray
         Value of the function
-    yp
+    yp : scalar or ndarray
         Value of the derivative vs x
+
+    See Also
+    --------
+    mathieu_modcem2
+
     """)
 
 add_newdoc("mathieu_sem",
@@ -7499,19 +7758,24 @@ add_newdoc("mathieu_sem",
 
     Parameters
     ----------
-    m
+    m : array_like
         Order of the function
-    q
+    q : array_like
         Parameter of the function
-    x
+    x : array_like
         Argument of the function, *given in degrees, not radians*.
 
     Returns
     -------
-    y
+    y : scalar or ndarray
         Value of the function
-    yp
+    yp : scalar or ndarray
         Value of the derivative vs x
+
+    See Also
+    --------
+    mathieu_a, mathieu_b, mathieu_cem
+
     """)
 
 add_newdoc("modfresnelm",
@@ -7520,12 +7784,22 @@ add_newdoc("modfresnelm",
 
     Modified Fresnel negative integrals
 
+    Parameters
+    ----------
+    x : array_like
+        Function argument
+
     Returns
     -------
-    fm
+    fm : scalar or ndarray
         Integral ``F_-(x)``: ``integral(exp(-1j*t*t), t=x..inf)``
-    km
+    km : scalar or ndarray
         Integral ``K_-(x)``: ``1/sqrt(pi)*exp(1j*(x*x+pi/4))*fp``
+
+    See Also
+    --------
+    modfresnelp
+
     """)
 
 add_newdoc("modfresnelp",
@@ -7534,12 +7808,22 @@ add_newdoc("modfresnelp",
 
     Modified Fresnel positive integrals
 
+    Parameters
+    ----------
+    x : array_like
+        Function argument
+
     Returns
     -------
-    fp
+    fp : scalar or ndarray
         Integral ``F_+(x)``: ``integral(exp(1j*t*t), t=x..inf)``
-    kp
+    kp : scalar or ndarray
         Integral ``K_+(x)``: ``1/sqrt(pi)*exp(-1j*(x*x+pi/4))*fp``
+
+    See Also
+    --------
+    modfresnelm
+
     """)
 
 add_newdoc("modstruve",
@@ -7566,7 +7850,7 @@ add_newdoc("modstruve",
 
     Returns
     -------
-    L : ndarray
+    L : scalar or ndarray
         Value of the modified Struve function of order `v` at `x`.
 
     Notes
@@ -7618,7 +7902,7 @@ add_newdoc("nbdtr",
 
     Returns
     -------
-    F : ndarray
+    F : scalar or ndarray
         The probability of `k` or fewer failures before `n` successes in a
         sequence of events with individual success probability `p`.
 
@@ -7674,7 +7958,7 @@ add_newdoc("nbdtrc",
 
     Returns
     -------
-    F : ndarray
+    F : scalar or ndarray
         The probability of `k + 1` or more failures before `n` successes in a
         sequence of events with individual success probability `p`.
 
@@ -7718,7 +8002,7 @@ add_newdoc("nbdtri",
 
     Returns
     -------
-    p : ndarray
+    p : scalar or ndarray
         Probability of success in a single event (float) such that
         `nbdtr(k, n, p) = y`.
 
@@ -7760,7 +8044,7 @@ add_newdoc("nbdtrik",
 
     Returns
     -------
-    k : ndarray
+    k : scalar or ndarray
         The maximum number of allowed failures such that `nbdtr(k, n, p) = y`.
 
     See also
@@ -7816,7 +8100,7 @@ add_newdoc("nbdtrin",
 
     Returns
     -------
-    n : ndarray
+    n : scalar or ndarray
         The number of successes `n` such that `nbdtr(k, n, p) = y`.
 
     See also
@@ -7880,7 +8164,7 @@ add_newdoc("ncfdtr",
 
     Returns
     -------
-    cdf : float or ndarray
+    cdf : scalar or ndarray
         The calculated CDF.  If all inputs are scalar, the return will be a
         float.  Otherwise it will be an array.
 
@@ -7963,7 +8247,7 @@ add_newdoc("ncfdtri",
 
     Returns
     -------
-    f : float
+    f : scalar or ndarray
         Quantiles, i.e., the upper limit of integration.
 
     See Also
@@ -8014,7 +8298,7 @@ add_newdoc("ncfdtridfd",
 
     Returns
     -------
-    dfd : float
+    dfd : scalar or ndarray
         Degrees of freedom of the denominator sum of squares.
 
     See Also
@@ -8072,7 +8356,7 @@ add_newdoc("ncfdtridfn",
 
     Returns
     -------
-    dfn : float
+    dfn : scalar or ndarray
         Degrees of freedom of the numerator sum of squares.
 
     See Also
@@ -8130,7 +8414,7 @@ add_newdoc("ncfdtrinc",
 
     Returns
     -------
-    nc : float
+    nc : scalar or ndarray
         Noncentrality parameter.
 
     See Also
@@ -8175,7 +8459,7 @@ add_newdoc("nctdtr",
 
     Returns
     -------
-    cdf : float or ndarray
+    cdf : scalar or ndarray
         The calculated CDF. If all inputs are scalar, the return will be a
         float. Otherwise, it will be an array.
 
@@ -8224,6 +8508,18 @@ add_newdoc("nctdtridf",
     t : array_like
         Quantiles, i.e., the upper limit of integration.
 
+    Returns
+    -------
+    cdf : scalar or ndarray
+        The calculated CDF. If all inputs are scalar, the return will be a
+        float. Otherwise, it will be an array.
+
+    See Also
+    --------
+    nctdtr :  CDF of the non-central `t` distribution.
+    nctdtrit : Inverse CDF (iCDF) of the non-central t distribution.
+    nctdtrinc : Calculate non-centrality parameter, given CDF iCDF values.
+
     """)
 
 add_newdoc("nctdtrinc",
@@ -8243,6 +8539,17 @@ add_newdoc("nctdtrinc",
     t : array_like
         Quantiles, i.e., the upper limit of integration.
 
+    Returns
+    -------
+    nc : scalar or ndarray
+        Noncentrality parameter
+
+    See Also
+    --------
+    nctdtr :  CDF of the non-central `t` distribution.
+    nctdtrit : Inverse CDF (iCDF) of the non-central t distribution.
+    nctdtridf : Calculate degrees of freedom, given CDF and iCDF values.
+
     """)
 
 add_newdoc("nctdtrit",
@@ -8261,6 +8568,17 @@ add_newdoc("nctdtrit",
         Noncentrality parameter. Should be in range (-1e6, 1e6).
     p : array_like
         CDF values, in range (0, 1].
+
+    Returns
+    -------
+    t : scalar or ndarray
+        Quantiles
+
+    See Also
+    --------
+    nctdtr :  CDF of the non-central `t` distribution.
+    nctdtridf : Calculate degrees of freedom, given CDF and iCDF values.
+    nctdtrinc : Calculate non-centrality parameter, given CDF iCDF values.
 
     """)
 
@@ -8284,15 +8602,12 @@ add_newdoc("ndtr",
 
     Returns
     -------
-    ndarray
+    scalar or ndarray
         The value of the normal CDF evaluated at `x`
 
     See Also
     --------
-    erf
-    erfc
-    scipy.stats.norm
-    log_ndtr
+    erf, erfc, scipy.stats.norm, log_ndtr
 
     """)
 
@@ -8314,7 +8629,7 @@ add_newdoc("nrdtrimn",
 
     Returns
     -------
-    mn : float or ndarray
+    mn : scalar or ndarray
         The mean of the normal distribution.
 
     See Also
@@ -8335,12 +8650,12 @@ add_newdoc("nrdtrisd",
         CDF values, in range (0, 1].
     x : array_like
         Quantiles, i.e. the upper limit of integration.
-    mn : float or ndarray
+    mn : scalar or ndarray
         The mean of the normal distribution.
 
     Returns
     -------
-    std : array_like
+    std : scalar or ndarray
         Standard deviation.
 
     See Also
@@ -8367,7 +8682,7 @@ add_newdoc("log_ndtr",
 
     Returns
     -------
-    ndarray
+    scalar or ndarray
         The value of the log of the normal CDF evaluated at `x`
 
     See Also
@@ -8388,6 +8703,21 @@ add_newdoc("ndtri",
     Returns the argument x for which the area under the Gaussian
     probability density function (integrated from minus infinity to `x`)
     is equal to y.
+
+    Parameters
+    ----------
+    p : array_like
+        Probability
+
+    Returns
+    -------
+    x : scalar or ndarray
+        Value of x such that ``ndtr(x) == p``.
+
+    See Also
+    --------
+    ndtr
+
     """)
 
 add_newdoc("obl_ang1",
@@ -8400,12 +8730,28 @@ add_newdoc("obl_ang1",
     and its derivative (with respect to `x`) for mode parameters m>=0
     and n>=m, spheroidal parameter `c` and ``|x| < 1.0``.
 
+    Parameters
+    ----------
+    m : array_like
+        Mode parameter m (nonnegative)
+    n : array_like
+        Mode parameter n (>= m)
+    c : array_like
+        Spheroidal parameter
+    x : array_like
+        Parameter x (|x| < 1.0)
+
     Returns
     -------
-    s
+    s : scalar or ndarray
         Value of the function
-    sp
+    sp : scalar or ndarray
         Value of the derivative vs x
+
+    See Also
+    --------
+    obl_ang1_cv
+
     """)
 
 add_newdoc("obl_ang1_cv",
@@ -8419,12 +8765,30 @@ add_newdoc("obl_ang1_cv",
     and n>=m, spheroidal parameter `c` and ``|x| < 1.0``. Requires
     pre-computed characteristic value.
 
+    Parameters
+    ----------
+    m : array_like
+        Mode parameter m (nonnegative)
+    n : array_like
+        Mode parameter n (>= m)
+    c : array_like
+        Spheroidal parameter
+    cv : array_like
+        Characteristic value
+    x : array_like
+        Parameter x (|x| < 1.0)
+
     Returns
     -------
-    s
+    s : scalar or ndarray
         Value of the function
-    sp
+    sp : scalar or ndarray
         Value of the derivative vs x
+
+    See Also
+    --------
+    obl_ang1
+
     """)
 
 add_newdoc("obl_cv",
@@ -8435,6 +8799,21 @@ add_newdoc("obl_cv",
 
     Computes the characteristic value of oblate spheroidal wave
     functions of order `m`, `n` (n>=m) and spheroidal parameter `c`.
+
+    Parameters
+    ----------
+    m : array_like
+        Mode parameter m (nonnegative)
+    n : array_like
+        Mode parameter n (>= m)
+    c : array_like
+        Spheroidal parameter
+
+    Returns
+    -------
+    cv : scalar or ndarray
+        Characteristic value
+
     """)
 
 add_newdoc("obl_rad1",
@@ -8447,12 +8826,28 @@ add_newdoc("obl_rad1",
     and its derivative (with respect to `x`) for mode parameters m>=0
     and n>=m, spheroidal parameter `c` and ``|x| < 1.0``.
 
+    Parameters
+    ----------
+    m : array_like
+        Mode parameter m (nonnegative)
+    n : array_like
+        Mode parameter n (>= m)
+    c : array_like
+        Spheroidal parameter
+    x : array_like
+        Parameter x (|x| < 1.0)
+
     Returns
     -------
-    s
+    s : scalar or ndarray
         Value of the function
-    sp
+    sp : scalar or ndarray
         Value of the derivative vs x
+
+    See Also
+    --------
+    obl_rad1_cv
+
     """)
 
 add_newdoc("obl_rad1_cv",
@@ -8466,12 +8861,30 @@ add_newdoc("obl_rad1_cv",
     and n>=m, spheroidal parameter `c` and ``|x| < 1.0``. Requires
     pre-computed characteristic value.
 
+    Parameters
+    ----------
+    m : array_like
+        Mode parameter m (nonnegative)
+    n : array_like
+        Mode parameter n (>= m)
+    c : array_like
+        Spheroidal parameter
+    cv : array_like
+        Characteristic value
+    x : array_like
+        Parameter x (|x| < 1.0)
+
     Returns
     -------
-    s
+    s : scalar or ndarray
         Value of the function
-    sp
+    sp : scalar or ndarray
         Value of the derivative vs x
+
+    See Also
+    --------
+    obl_rad1
+
     """)
 
 add_newdoc("obl_rad2",
@@ -8484,12 +8897,28 @@ add_newdoc("obl_rad2",
     and its derivative (with respect to `x`) for mode parameters m>=0
     and n>=m, spheroidal parameter `c` and ``|x| < 1.0``.
 
+    Parameters
+    ----------
+    m : array_like
+        Mode parameter m (nonnegative)
+    n : array_like
+        Mode parameter n (>= m)
+    c : array_like
+        Spheroidal parameter
+    x : array_like
+        Parameter x (|x| < 1.0)
+
     Returns
     -------
-    s
+    s : scalar or ndarray
         Value of the function
-    sp
+    sp : scalar or ndarray
         Value of the derivative vs x
+
+    See Also
+    --------
+    obl_rad2_cv
+
     """)
 
 add_newdoc("obl_rad2_cv",
@@ -8503,12 +8932,29 @@ add_newdoc("obl_rad2_cv",
     and n>=m, spheroidal parameter `c` and ``|x| < 1.0``. Requires
     pre-computed characteristic value.
 
+    Parameters
+    ----------
+    m : array_like
+        Mode parameter m (nonnegative)
+    n : array_like
+        Mode parameter n (>= m)
+    c : array_like
+        Spheroidal parameter
+    cv : array_like
+        Characteristic value
+    x : array_like
+        Parameter x (|x| < 1.0)
+
     Returns
     -------
-    s
+    s : scalar or ndarray
         Value of the function
-    sp
+    sp : scalar or ndarray
         Value of the derivative vs x
+
+    See Also
+    --------
+    obl_rad2
     """)
 
 add_newdoc("pbdv",
@@ -8520,11 +8966,18 @@ add_newdoc("pbdv",
     Returns (d, dp) the parabolic cylinder function Dv(x) in d and the
     derivative, Dv'(x) in dp.
 
+    Parameters
+    ----------
+    v : array_like
+        Real parameter
+    x : array_like
+        Real argument
+
     Returns
     -------
-    d
+    d : scalar or ndarray
         Value of the function
-    dp
+    dp : scalar or ndarray
         Value of the derivative vs x
     """)
 
@@ -8539,9 +8992,9 @@ add_newdoc("pbvv",
 
     Returns
     -------
-    v
+    v : scalar or ndarray
         Value of the function
-    vp
+    vp : scalar or ndarray
         Value of the derivative vs x
     """)
 
@@ -8807,11 +9260,22 @@ add_newdoc("pro_ang1",
     and its derivative (with respect to `x`) for mode parameters m>=0
     and n>=m, spheroidal parameter `c` and ``|x| < 1.0``.
 
+    Parameters
+    ----------
+    m : array_like
+        Nonnegative mode parameter m
+    n : array_like
+        Mode parameter n (>= m)
+    c : array_like
+        Spheroidal parameter
+    x : array_like
+        Real parameter (|x| < 1.0)
+
     Returns
     -------
-    s
+    s : scalar or ndarray
         Value of the function
-    sp
+    sp : scalar or ndarray
         Value of the derivative vs x
     """)
 
@@ -8826,11 +9290,24 @@ add_newdoc("pro_ang1_cv",
     and n>=m, spheroidal parameter `c` and ``|x| < 1.0``. Requires
     pre-computed characteristic value.
 
+    Parameters
+    ----------
+    m : array_like
+        Nonnegative mode parameter m
+    n : array_like
+        Mode parameter n (>= m)
+    c : array_like
+        Spheroidal parameter
+    cv : array_like
+        Characteristic value
+    x : array_like
+        Real parameter (|x| < 1.0)
+
     Returns
     -------
-    s
+    s : scalar or ndarray
         Value of the function
-    sp
+    sp : scalar or ndarray
         Value of the derivative vs x
     """)
 
@@ -8842,6 +9319,20 @@ add_newdoc("pro_cv",
 
     Computes the characteristic value of prolate spheroidal wave
     functions of order `m`, `n` (n>=m) and spheroidal parameter `c`.
+
+    Parameters
+    ----------
+    m : array_like
+        Nonnegative mode parameter m
+    n : array_like
+        Mode parameter n (>= m)
+    c : array_like
+        Spheroidal parameter
+
+    Returns
+    -------
+    cv : scalar or ndarray
+        Characteristic value
     """)
 
 add_newdoc("pro_rad1",
@@ -8854,11 +9345,22 @@ add_newdoc("pro_rad1",
     and its derivative (with respect to `x`) for mode parameters m>=0
     and n>=m, spheroidal parameter `c` and ``|x| < 1.0``.
 
+    Parameters
+    ----------
+    m : array_like
+        Nonnegative mode parameter m
+    n : array_like
+        Mode parameter n (>= m)
+    c : array_like
+        Spheroidal parameter
+    x : array_like
+        Real parameter (|x| < 1.0)
+
     Returns
     -------
-    s
+    s : scalar or ndarray
         Value of the function
-    sp
+    sp : scalar or ndarray
         Value of the derivative vs x
     """)
 
@@ -8873,11 +9375,24 @@ add_newdoc("pro_rad1_cv",
     and n>=m, spheroidal parameter `c` and ``|x| < 1.0``. Requires
     pre-computed characteristic value.
 
+    Parameters
+    ----------
+    m : array_like
+        Nonnegative mode parameter m
+    n : array_like
+        Mode parameter n (>= m)
+    c : array_like
+        Spheroidal parameter
+    cv : array_like
+        Characteristic value
+    x : array_like
+        Real parameter (|x| < 1.0)
+
     Returns
     -------
-    s
+    s : scalar or ndarray
         Value of the function
-    sp
+    sp : scalar or ndarray
         Value of the derivative vs x
     """)
 
@@ -8891,11 +9406,24 @@ add_newdoc("pro_rad2",
     and its derivative (with respect to `x`) for mode parameters m>=0
     and n>=m, spheroidal parameter `c` and ``|x| < 1.0``.
 
+    Parameters
+    ----------
+    m : array_like
+        Nonnegative mode parameter m
+    n : array_like
+        Mode parameter n (>= m)
+    c : array_like
+        Spheroidal parameter
+    cv : array_like
+        Characteristic value
+    x : array_like
+        Real parameter (|x| < 1.0)
+
     Returns
     -------
-    s
+    s : scalar or ndarray
         Value of the function
-    sp
+    sp : scalar or ndarray
         Value of the derivative vs x
     """)
 
@@ -8910,11 +9438,24 @@ add_newdoc("pro_rad2_cv",
     and n>=m, spheroidal parameter `c` and ``|x| < 1.0``. Requires
     pre-computed characteristic value.
 
+    Parameters
+    ----------
+    m : array_like
+        Nonnegative mode parameter m
+    n : array_like
+        Mode parameter n (>= m)
+    c : array_like
+        Spheroidal parameter
+    cv : array_like
+        Characteristic value
+    x : array_like
+        Real parameter (|x| < 1.0)
+
     Returns
     -------
-    s
+    s : scalar or ndarray
         Value of the function
-    sp
+    sp : scalar or ndarray
         Value of the derivative vs x
     """)
 
@@ -8928,14 +9469,14 @@ add_newdoc("pseudo_huber",
 
     Parameters
     ----------
-    delta : ndarray
+    delta : array_like
         Input array, indicating the soft quadratic vs. linear loss changepoint.
-    r : ndarray
+    r : array_like
         Input array, possibly representing residuals.
 
     Returns
     -------
-    res : ndarray
+    res : scalar or ndarray
         The computed Pseudo-Huber loss function values.
 
     Notes
@@ -8963,7 +9504,7 @@ add_newdoc("psi",
 
     Returns
     -------
-    digamma : ndarray
+    digamma : scalar or ndarray
         Computed values of ``psi``.
 
     Notes
@@ -9229,9 +9770,9 @@ add_newdoc("shichi",
 
     Returns
     -------
-    si : ndarray
+    si : scalar or ndarray
         Hyperbolic sine integral at ``x``
-    ci : ndarray
+    ci : scalar or ndarray
         Hyperbolic cosine integral at ``x``
 
     Notes
@@ -9282,9 +9823,9 @@ add_newdoc("sici",
 
     Returns
     -------
-    si : ndarray
+    si : scalar or ndarray
         Sine integral at ``x``
-    ci : ndarray
+    ci : scalar or ndarray
         Cosine integral at ``x``
 
     Notes
@@ -9364,7 +9905,7 @@ add_newdoc("smirnov",
 
     Returns
     -------
-    float
+    scalar or ndarray
         The value(s) of smirnov(n, d), Prob(Dn+ >= d) (Also Prob(Dn- >= d))
 
     Notes
@@ -9458,7 +9999,7 @@ add_newdoc("smirnovi",
 
     Returns
     -------
-    float
+    scalar or ndarray
         The value(s) of smirnovi(n, p), the critical values.
 
     Notes
@@ -9516,7 +10057,7 @@ add_newdoc("spence",
 
     Returns
     -------
-    s : ndarray
+    s : scalar or ndarray
         Computed values of Spence's function
 
     Notes
@@ -9542,6 +10083,22 @@ add_newdoc("stdtr",
        gamma((df+1)/2)/(sqrt(df*pi)*gamma(df/2)) *
        integral((1+x**2/df)**(-df/2-1/2), x=-inf..t)
 
+    Parameters
+    ----------
+    df : array_like
+        Degrees of freedom
+    t : array_like
+        Upper bound of the integral
+
+    Returns
+    -------
+    scalar or ndarray
+        Value of the Student t CDF at t
+
+    See Also
+    --------
+    stdtridf : inverse of stdtr with respect to `df`
+    stdtrit : inverse of stdtr with respect to `t`
     """)
 
 add_newdoc("stdtridf",
@@ -9551,6 +10108,23 @@ add_newdoc("stdtridf",
     Inverse of `stdtr` vs df
 
     Returns the argument df such that stdtr(df, t) is equal to `p`.
+
+    Parameters
+    ----------
+    p : array_like
+        Probability
+    t : array_like
+        Upper bound of the integral
+
+    Returns
+    -------
+    df : scalar or ndarray
+        Value of `df` such that ``stdtr(df, t) == p``
+
+    See Also
+    --------
+    stdtr : Student t CDF
+    stdtrit : inverse of stdtr with respect to `t`
     """)
 
 add_newdoc("stdtrit",
@@ -9560,6 +10134,24 @@ add_newdoc("stdtrit",
     Inverse of `stdtr` vs `t`
 
     Returns the argument `t` such that stdtr(df, t) is equal to `p`.
+
+    Parameters
+    ----------
+    df : array_like
+        Degrees of freedom
+    p : array_like
+        Probability
+
+    Returns
+    -------
+    t : scalar or ndarray
+        Value of `t` such that ``stdtr(df, t) == p``
+
+    See Also
+    --------
+    stdtr : Student t CDF
+    stdtridf : inverse of stdtr with respect to `df`
+
     """)
 
 add_newdoc("struve",
@@ -9586,7 +10178,7 @@ add_newdoc("struve",
 
     Returns
     -------
-    H : ndarray
+    H : scalar or ndarray
         Value of the Struve function of order `v` at `x`.
 
     Notes
@@ -9653,6 +10245,15 @@ add_newdoc("tklmbda",
 
     Tukey-Lambda cumulative distribution function
 
+    Parameters
+    ----------
+    x, lmbda : array_like
+        Parameters
+
+    Returns
+    -------
+    cdf : scalar or ndarray
+        Value of the Tukey-Lambda CDF
     """)
 
 add_newdoc("wofz",
@@ -9664,6 +10265,16 @@ add_newdoc("wofz",
     Returns the value of the Faddeeva function for complex argument::
 
         exp(-z**2) * erfc(-i*z)
+
+    Parameters
+    ----------
+    z : array_like
+        complex argument
+
+    Returns
+    -------
+    scalar or ndarray
+        Value of the Faddeeva function
 
     See Also
     --------
@@ -9706,7 +10317,7 @@ add_newdoc("xlogy",
 
     Returns
     -------
-    z : array_like
+    z : scalar or ndarray
         Computed x*log(y)
 
     Notes
@@ -9731,7 +10342,7 @@ add_newdoc("xlog1py",
 
     Returns
     -------
-    z : array_like
+    z : scalar or ndarray
         Computed x*log1p(y)
 
     Notes
@@ -9754,7 +10365,7 @@ add_newdoc("y0",
 
     Returns
     -------
-    Y : ndarray
+    Y : scalar or ndarray
         Value of the Bessel function of the second kind of order 0 at `x`.
 
     Notes
@@ -9799,7 +10410,7 @@ add_newdoc("y1",
 
     Returns
     -------
-    Y : ndarray
+    Y : scalar or ndarray
         Value of the Bessel function of the second kind of order 1 at `x`.
 
     Notes
@@ -9840,7 +10451,7 @@ add_newdoc("yn",
 
     Returns
     -------
-    Y : ndarray
+    Y : scalar or ndarray
         Value of the Bessel function, :math:`Y_n(x)`.
 
     Notes
@@ -9876,7 +10487,7 @@ add_newdoc("yv",
 
     Returns
     -------
-    Y : ndarray
+    Y : scalar or ndarray
         Value of the Bessel function of the second kind, :math:`Y_v(x)`.
 
     Notes
@@ -9928,7 +10539,7 @@ add_newdoc("yve",
 
     Returns
     -------
-    Y : ndarray
+    Y : scalar or ndarray
         Value of the exponentially scaled Bessel function.
 
     Notes
@@ -9984,7 +10595,7 @@ add_newdoc("zetac",
 
     Returns
     -------
-    out : array_like
+    scalar or ndarray
         Values of zeta(x) - 1.
 
     See Also
@@ -10113,14 +10724,14 @@ add_newdoc("loggamma",
 
     Parameters
     ----------
-    z : array-like
+    z : array_like
         Values in the complex plain at which to compute ``loggamma``
     out : ndarray, optional
         Output array for computed values of ``loggamma``
 
     Returns
     -------
-    loggamma : ndarray
+    loggamma : scalar or ndarray
         Values of ``loggamma`` at z.
 
     Notes
@@ -10230,6 +10841,11 @@ add_newdoc("wright_bessel",
         b >= 0
     x : array_like of float
         x >= 0
+
+    Returns
+    -------
+    scalar or ndarray
+        Value of the Wright's generalized Bessel function
 
     Notes
     -----

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -221,6 +221,8 @@ add_newdoc("wrightomega",
     ----------
     z : array_like
         Points at which to evaluate the Wright Omega function
+    out : ndarray, optional
+        Optional output array for the function values
 
     Returns
     -------

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -3064,7 +3064,8 @@ add_newdoc("erfcx",
 
     """)
 
-add_newdoc("erfinv",
+add_newdoc(
+    "erfinv",
     """
     erfinv(y, out=None)
 
@@ -3113,7 +3114,8 @@ add_newdoc("erfinv",
 
     """)
 
-add_newdoc("erfcinv",
+add_newdoc(
+    "erfcinv",
     """
     erfcinv(y, out=None)
 
@@ -4588,7 +4590,8 @@ add_newdoc("fdtridfd",
 
     """)
 
-add_newdoc("fdtridfn",
+add_newdoc(
+    "fdtridfn",
     """
     fdtridfn(p, dfd, x, out=None)
 
@@ -6679,7 +6682,8 @@ add_newdoc("jn",
     Notes
     -----
     `jn` is an alias of `jv`.
-    Not to be confused with the spherical Bessel functions (see `spherical_jn`).
+    Not to be confused with the spherical Bessel functions (see
+    `spherical_jn`).
 
     """)
 

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -8605,22 +8605,22 @@ add_newdoc("pdtr",
     Parameters
     ----------
     k : array_like
-        Nonnegative real argument
+        Number of occurances (nonnegative, real)
     m : array_like
-        Nonnegative real shape parameter
+        Shape parameter (nonnegative, real)
     out : ndarray
         Optional output array for the function results
+
+    Returns
+    -------
+    scalar or ndarray
+        Values of the Poisson cumulative distribution function
 
     See Also
     --------
     pdtrc : Poisson survival function
     pdtrik : inverse of `pdtr` with respect to `k`
     pdtri : inverse of `pdtr` with respect to `m`
-
-    Returns
-    -------
-    scalar or ndarray
-        Values of the Poisson cumulative distribution function
 
     References
     ----------
@@ -8645,34 +8645,95 @@ add_newdoc("pdtr",
 
 add_newdoc("pdtrc",
     """
-    pdtrc(k, m)
+    pdtrc(k, m, out=None)
 
     Poisson survival function
 
     Returns the sum of the terms from k+1 to infinity of the Poisson
     distribution: sum(exp(-m) * m**j / j!, j=k+1..inf) = gammainc(
     k+1, m). Arguments must both be non-negative doubles.
+
+    Parameters
+    ----------
+    k : array_like
+        Number of occurances (nonnegative, real)
+    m : array_like
+        Shape parameter (nonnegative, real)
+    out : ndarray
+        Optional output array for the function results
+
+    Returns
+    -------
+    scalar or ndarray
+        Values of the Poisson survival function
+
+    See Also
+    --------
+    pdtr : Poisson cumulative distribution function
+    pdtrik : inverse of `pdtr` with respect to `k`
+    pdtri : inverse of `pdtr` with respect to `m`
+
     """)
 
 add_newdoc("pdtri",
     """
-    pdtri(k, y)
+    pdtri(k, y, out=None)
 
     Inverse to `pdtr` vs m
 
     Returns the Poisson variable `m` such that the sum from 0 to `k` of
     the Poisson density is equal to the given probability `y`:
-    calculated by gammaincinv(k+1, y). `k` must be a nonnegative
+    calculated by ``gammaincinv(k + 1, y)``. `k` must be a nonnegative
     integer and `y` between 0 and 1.
+
+    Parameters
+    ----------
+    k : array_like
+        Number of occurances (nonnegative, real)
+    y : array_like
+        Probability
+    out : ndarray
+        Optional output array for the function results
+
+    Returns
+    -------
+    scalar or ndarray
+        Values of the shape paramter `m` such that ``pdtr(k, m) = p``
+
+    See Also
+    --------
+    pdtr : Poisson cumulative distribution function
+    pdtrc : Poisson survival function
+    pdtrik : inverse of `pdtr` with respect to `k`
+
     """)
 
 add_newdoc("pdtrik",
     """
-    pdtrik(p, m)
+    pdtrik(p, m, out=None)
 
-    Inverse to `pdtr` vs k
+    Inverse to `pdtr` vs `m`.
 
-    Returns the quantile k such that ``pdtr(k, m) = p``
+    Parameters
+    ----------
+    m : array_like
+        Shape parameter (nonnegative, real)
+    p : array_like
+        Probability
+    out : ndarray
+        Optional output array for the function results
+
+    Returns
+    -------
+    scalar or ndarray
+        The number of occurances `k` such that ``pdtr(k, m) = p``
+
+    See Also
+    --------
+    pdtr : Poisson cumulative distribution function
+    pdtrc : Poisson survival function
+    pdtri : inverse of `pdtr` with respect to `m`
+
     """)
 
 add_newdoc("poch",

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -7103,11 +7103,6 @@ add_newdoc("ker",
     >>> sc.ker(x)
     array([ 0.28670621, -0.04166451, -0.06702923, -0.03617885])
 
-    References
-    ----------
-    .. [dlmf] NIST, Digital Library of Mathematical Functions,
-        https://dlmf.nist.gov/10.61
-
     """)
 
 add_newdoc("kerp",
@@ -9021,7 +9016,7 @@ add_newdoc("obl_ang1",
     c : array_like
         Spheroidal parameter
     x : array_like
-        Parameter x (|x| < 1.0)
+        Parameter x (``|x| < 1.0``)
     out : ndarray, optional
         Optional output array for the function results
 
@@ -9060,7 +9055,7 @@ add_newdoc("obl_ang1_cv",
     cv : array_like
         Characteristic value
     x : array_like
-        Parameter x (|x| < 1.0)
+        Parameter x (``|x| < 1.0``)
     out : ndarray, optional
         Optional output array for the function results
 
@@ -9123,7 +9118,7 @@ add_newdoc("obl_rad1",
     c : array_like
         Spheroidal parameter
     x : array_like
-        Parameter x (|x| < 1.0)
+        Parameter x (``|x| < 1.0``)
     out : ndarray, optional
         Optional output array for the function results
 
@@ -9162,7 +9157,7 @@ add_newdoc("obl_rad1_cv",
     cv : array_like
         Characteristic value
     x : array_like
-        Parameter x (|x| < 1.0)
+        Parameter x (``|x| < 1.0``)
     out : ndarray, optional
         Optional output array for the function results
 
@@ -9198,7 +9193,7 @@ add_newdoc("obl_rad2",
     c : array_like
         Spheroidal parameter
     x : array_like
-        Parameter x (|x| < 1.0)
+        Parameter x (``|x| < 1.0``)
     out : ndarray, optional
         Optional output array for the function results
 
@@ -9237,7 +9232,7 @@ add_newdoc("obl_rad2_cv",
     cv : array_like
         Characteristic value
     x : array_like
-        Parameter x (|x| < 1.0)
+        Parameter x (``|x| < 1.0``)
     out : ndarray, optional
         Optional output array for the function results
 
@@ -9580,7 +9575,7 @@ add_newdoc("pro_ang1",
     c : array_like
         Spheroidal parameter
     x : array_like
-        Real parameter (|x| < 1.0)
+        Real parameter (``|x| < 1.0``)
     out : ndarray, optional
         Optional output array for the function results
 
@@ -9614,7 +9609,7 @@ add_newdoc("pro_ang1_cv",
     cv : array_like
         Characteristic value
     x : array_like
-        Real parameter (|x| < 1.0)
+        Real parameter (``|x| < 1.0``)
     out : ndarray, optional
         Optional output array for the function results
 
@@ -9671,7 +9666,7 @@ add_newdoc("pro_rad1",
     c : array_like
         Spheroidal parameter
     x : array_like
-        Real parameter (|x| < 1.0)
+        Real parameter (``|x| < 1.0``)
     out : ndarray, optional
         Optional output array for the function results
 
@@ -9705,7 +9700,7 @@ add_newdoc("pro_rad1_cv",
     cv : array_like
         Characteristic value
     x : array_like
-        Real parameter (|x| < 1.0)
+        Real parameter (``|x| < 1.0``)
     out : ndarray, optional
         Optional output array for the function results
 
@@ -9738,7 +9733,7 @@ add_newdoc("pro_rad2",
     cv : array_like
         Characteristic value
     x : array_like
-        Real parameter (|x| < 1.0)
+        Real parameter (``|x| < 1.0``)
     out : ndarray, optional
         Optional output array for the function results
 
@@ -9772,7 +9767,7 @@ add_newdoc("pro_rad2_cv",
     cv : array_like
         Characteristic value
     x : array_like
-        Real parameter (|x| < 1.0)
+        Real parameter (``|x| < 1.0``)
     out : ndarray, optional
         Optional output array for the function results
 

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -4588,9 +4588,13 @@ add_newdoc("fdtridfd",
 
     See Also
     --------
-    fdtr, fdtrc, fdtri, fdtridfn
+    fdtr, fdtrc, fdtri
 
     """)
+
+'''
+commented out as fdtridfn seems to have bugs and is not in functions.json
+see: https://github.com/scipy/scipy/pull/15622#discussion_r811440983
 
 add_newdoc(
     "fdtridfn",
@@ -4624,6 +4628,7 @@ add_newdoc(
 
 
     """)
+'''
 
 add_newdoc("fresnel",
     r"""
@@ -7879,7 +7884,7 @@ add_newdoc("mathieu_modcem1",
 
 add_newdoc("mathieu_modcem2",
     """
-    mathieu_modcem2(m, q, x, out=None, out=None)
+    mathieu_modcem2(m, q, x, out=None)
 
     Even modified Mathieu function of the second kind and its derivative
 

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -8605,7 +8605,7 @@ add_newdoc("pdtr",
     Parameters
     ----------
     k : array_like
-        Number of occurances (nonnegative, real)
+        Number of occurrences (nonnegative, real)
     m : array_like
         Shape parameter (nonnegative, real)
     out : ndarray
@@ -8656,7 +8656,7 @@ add_newdoc("pdtrc",
     Parameters
     ----------
     k : array_like
-        Number of occurances (nonnegative, real)
+        Number of occurrences (nonnegative, real)
     m : array_like
         Shape parameter (nonnegative, real)
     out : ndarray
@@ -8689,7 +8689,7 @@ add_newdoc("pdtri",
     Parameters
     ----------
     k : array_like
-        Number of occurances (nonnegative, real)
+        Number of occurrences (nonnegative, real)
     y : array_like
         Probability
     out : ndarray
@@ -8726,7 +8726,7 @@ add_newdoc("pdtrik",
     Returns
     -------
     scalar or ndarray
-        The number of occurances `k` such that ``pdtr(k, m) = p``
+        The number of occurrences `k` such that ``pdtr(k, m) = p``
 
     See Also
     --------

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -7984,7 +7984,8 @@ add_newdoc("mathieu_modsem2",
 
     """)
 
-add_newdoc("mathieu_sem",
+add_newdoc(
+    "mathieu_sem",
     """
     mathieu_sem(m, q, x, out=None)
 


### PR DESCRIPTION
#### Reference issue
none

#### What does this implement/fix?
Expand docstrings for `scipy.special` functions related to Poisson distributions. `pdtr` was already pretty good, but the others did not have Parameters, Returns, or See Also sections.

#### Additional information
I think all functions in this file are `ufuncs` and have an `out` argument, although it is inconsistently documented for the `scipy.special` functions. Should we list it consistently for all functions in this file? (Technically ufuncs also have other kwargs like `where`, `order` and `dtype`, but I doubt we want to list all of them as most are pretty niche)

### Update: now expanded to
1.) add Parameters, Results and See Also sections to many other functions where they were missing
2.) document output type consistently
3.) list the optional `out` kwarg consistently
