### PR TITLE
MAINT: Clean up `type: ignore` comments related to third-party packages

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -87,6 +87,9 @@ jobs:
         pip install --user git+https://github.com/serge-sans-paille/pythran.git
         python -m pip install -r mypy_requirements.txt
 
+        # Packages that are only needed for their annotations
+        python -m pip install --user types-psutil pybind11 sphinx
+
     - name: Mypy
       run: |
         python -u runtests.py --mypy

--- a/mypy.ini
+++ b/mypy.ini
@@ -34,9 +34,6 @@ ignore_missing_imports = True
 # Third party dependencies that don't have types.
 #
 
-[mypy-pytest]
-ignore_missing_imports = True
-
 [mypy-sksparse]
 ignore_missing_imports = True
 
@@ -53,12 +50,6 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 
 [mypy-uarray]
-ignore_missing_imports = True
-
-[mypy-psutil]
-ignore_missing_imports = True
-
-[mypy-pybind11]
 ignore_missing_imports = True
 
 [mypy-pythran]

--- a/mypy.ini
+++ b/mypy.ini
@@ -64,6 +64,12 @@ ignore_missing_imports = True
 [mypy-threadpoolctl]
 ignore_missing_imports = True
 
+[mypy-sympy.*]
+ignore_missing_imports = True
+
+[mypy-matplotlib.*]
+ignore_missing_imports = True
+
 #
 # Extension modules without stubs.
 #

--- a/mypy_requirements.txt
+++ b/mypy_requirements.txt
@@ -1,4 +1,4 @@
 # Note: this should disappear at some point. For now, please keep it
 #       in sync with the dev dependencies in pyproject.toml
-mypy==0.902
+mypy==0.931
 typing_extensions

--- a/mypy_requirements.txt
+++ b/mypy_requirements.txt
@@ -2,9 +2,3 @@
 #       in sync with the dev dependencies in pyproject.toml
 mypy==0.931
 typing_extensions
-
-# Third-party packages with relevant type annotations
-sphinx
-pybind11
-pytest
-types-psutil

--- a/mypy_requirements.txt
+++ b/mypy_requirements.txt
@@ -2,3 +2,9 @@
 #       in sync with the dev dependencies in pyproject.toml
 mypy==0.931
 typing_extensions
+
+# Third-party packages with relevant type annotations
+sphinx
+pybind11
+pytest
+types-psutil

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,10 +99,6 @@ doc = [
 dev = [
     "mypy",
     "typing_extensions",
-    "sphinx",
-    "pybind11",
-    "pytest",
-    "types-psutil",
     "pycodestyle",
     "flake8",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,10 @@ doc = [
 dev = [
     "mypy",
     "typing_extensions",
+    "sphinx",
+    "pybind11",
+    "pytest",
+    "types-psutil",
     "pycodestyle",
     "flake8",
 ]

--- a/scipy/_lib/_docscrape.py
+++ b/scipy/_lib/_docscrape.py
@@ -607,7 +607,7 @@ class ClassDoc(NumpyDocString):
         self._cls = cls
 
         if 'sphinx' in sys.modules:
-            from sphinx.ext.autodoc import ALL  # type: ignore[import]
+            from sphinx.ext.autodoc import ALL
         else:
             ALL = object()
 

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -54,11 +54,11 @@ from . import hierarchy_test_data
 # Matplotlib is not a scipy dependency but is optionally used in dendrogram, so
 # check if it's available
 try:
-    import matplotlib  # type: ignore[import]
+    import matplotlib
     # and set the backend to be Agg (no gui)
     matplotlib.use('Agg')
     # before importing pyplot
-    import matplotlib.pyplot as plt  # type: ignore[import]
+    import matplotlib.pyplot as plt
     have_matplotlib = True
 except Exception:
     have_matplotlib = False

--- a/scipy/interpolate/_interpnd_info.py
+++ b/scipy/interpolate/_interpnd_info.py
@@ -3,7 +3,7 @@ Here we perform some symbolic computations required for the N-D
 interpolation routines in `interpnd.pyx`.
 
 """
-from sympy import symbols, binomial, Matrix  # type: ignore[import]
+from sympy import symbols, binomial, Matrix
 
 
 def _estimate_gradients_2d_global():

--- a/scipy/optimize/_shgo_lib/triangulation.py
+++ b/scipy/optimize/_shgo_lib/triangulation.py
@@ -369,7 +369,7 @@ class Complex:
 
              To plot a single simplex S in a set C, use e.g., [C[0]]
         """
-        from matplotlib import pyplot  # type: ignore[import]
+        from matplotlib import pyplot
         if self.dim == 2:
             pyplot.figure()
             for C in self.H:

--- a/scipy/spatial/_plotutils.py
+++ b/scipy/spatial/_plotutils.py
@@ -6,7 +6,7 @@ __all__ = ['delaunay_plot_2d', 'convex_hull_plot_2d', 'voronoi_plot_2d']
 
 @_decorator
 def _held_figure(func, obj, ax=None, **kw):
-    import matplotlib.pyplot as plt  # type: ignore[import]
+    import matplotlib.pyplot as plt
 
     if ax is None:
         fig = plt.figure()
@@ -133,7 +133,7 @@ def convex_hull_plot_2d(hull, ax=None):
     >>> plt.show()
 
     """
-    from matplotlib.collections import LineCollection  # type: ignore[import]
+    from matplotlib.collections import LineCollection
 
     if hull.points.shape[1] != 2:
         raise ValueError("Convex hull is not 2-D")

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -872,10 +872,7 @@ def test_kdtree_build_modes(kdtree_type):
 
 def test_kdtree_pickle(kdtree_type):
     # test if it is possible to pickle a KDTree
-    try:
-        import cPickle as pickle  # type: ignore[import]
-    except ImportError:
-        import pickle
+    import pickle
     np.random.seed(0)
     n = 50
     k = 4
@@ -889,10 +886,7 @@ def test_kdtree_pickle(kdtree_type):
 
 def test_kdtree_pickle_boxsize(kdtree_type):
     # test if it is possible to pickle a periodic KDTree
-    try:
-        import cPickle as pickle
-    except ImportError:
-        import pickle
+    import pickle
     np.random.seed(0)
     n = 50
     k = 4

--- a/scipy/special/_precompute/expn_asy.py
+++ b/scipy/special/_precompute/expn_asy.py
@@ -10,7 +10,7 @@ Sources
 import os
 
 try:
-    import sympy  # type: ignore[import]
+    import sympy
     from sympy import Poly
     x = sympy.symbols('x')
 except ImportError:

--- a/scipy/special/_precompute/lambertw.py
+++ b/scipy/special/_precompute/lambertw.py
@@ -7,7 +7,7 @@ import numpy as np
 
 try:
     import mpmath
-    import matplotlib.pyplot as plt  # type: ignore[import]
+    import matplotlib.pyplot as plt
 except ImportError:
     pass
 

--- a/scipy/special/_precompute/struve_convergence.py
+++ b/scipy/special/_precompute/struve_convergence.py
@@ -32,7 +32,7 @@ Black dashed line
 
 """
 import numpy as np
-import matplotlib.pyplot as plt  # type: ignore[import]
+import matplotlib.pyplot as plt
 
 import mpmath
 

--- a/scipy/special/_precompute/utils.py
+++ b/scipy/special/_precompute/utils.py
@@ -4,7 +4,7 @@ except ImportError:
     pass
 
 try:
-    from sympy.abc import x  # type: ignore[import]
+    from sympy.abc import x
 except ImportError:
     pass
 

--- a/scipy/special/_precompute/wright_bessel.py
+++ b/scipy/special/_precompute/wright_bessel.py
@@ -10,10 +10,10 @@ from scipy.optimize import minimize_scalar, curve_fit
 from time import time
 
 try:
-    import sympy  # type: ignore[import]
+    import sympy
     from sympy import EulerGamma, Rational, S, Sum, \
         factorial, gamma, gammasimp, pi, polygamma, symbols, zeta
-    from sympy.polys.polyfuncs import horner  # type: ignore[import]
+    from sympy.polys.polyfuncs import horner
 except ImportError:
     pass
 

--- a/scipy/special/tests/test_precompute_expn_asy.py
+++ b/scipy/special/tests/test_precompute_expn_asy.py
@@ -4,7 +4,7 @@ from scipy.special._testutils import check_version, MissingModule
 from scipy.special._precompute.expn_asy import generate_A
 
 try:
-    import sympy  # type: ignore[import]
+    import sympy
     from sympy import Poly
 except ImportError:
     sympy = MissingModule("sympy")

--- a/scipy/special/tests/test_precompute_gammainc.py
+++ b/scipy/special/tests/test_precompute_gammainc.py
@@ -9,7 +9,7 @@ from scipy.special._precompute.gammainc_asy import (
 from scipy.special._precompute.gammainc_data import gammainc, gammaincc
 
 try:
-    import sympy  # type: ignore[import]
+    import sympy
 except ImportError:
     sympy = MissingModule('sympy')
 

--- a/scipy/special/tests/test_precompute_utils.py
+++ b/scipy/special/tests/test_precompute_utils.py
@@ -5,7 +5,7 @@ from scipy.special._mptestutils import mp_assert_allclose
 from scipy.special._precompute.utils import lagrange_inversion
 
 try:
-    import sympy  # type: ignore[import]
+    import sympy
 except ImportError:
     sympy = MissingModule('sympy')
 

--- a/scipy/stats/_fit.py
+++ b/scipy/stats/_fit.py
@@ -127,13 +127,13 @@ class FitResult:
             The matplotlib Axes object on which the plot was drawn.
         """
         try:
-            from matplotlib.ticker import MaxNLocator  # type: ignore[import]
+            from matplotlib.ticker import MaxNLocator
         except ModuleNotFoundError as exc:
             message = "matplotlib must be installed to use method `plot`."
             raise ValueError(message) from exc
 
         if ax is None:
-            import matplotlib.pyplot as plt  # type: ignore[import]
+            import matplotlib.pyplot as plt
             ax = plt.gca()
 
         fit_params = np.atleast_1d(self.params)

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -22,9 +22,9 @@ from scipy.stats._binomtest import _binary_search_for_binom_tst
 # Matplotlib is not a scipy dependency but is optionally used in probplot, so
 # check if it's available
 try:
-    import matplotlib  # type: ignore[import]
+    import matplotlib
     matplotlib.rcParams['backend'] = 'Agg'
-    import matplotlib.pyplot as plt  # type: ignore[import]
+    import matplotlib.pyplot as plt
     have_matplotlib = True
 except Exception:
     have_matplotlib = False


### PR DESCRIPTION
Currently a number of `# type: ignore[import]` comments are scattered throughout the codebase due to third-party packages that lack type annotations. As they provide a reasonable amount of visual clutter, this PR attempts to remove them and deal with the fallout using one of two approaches:
* Installing the third party package. Note that this option is only viable if the package in question distributes type annotations (or has a matching stub-only package, _e.g._ `types-psutil`).
* Globally enabling the `ignore_missing_imports` option for the package in mypy.ini.