### PR TITLE
TST, MAINT: ignore np distutils dep

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -15,3 +15,4 @@ filterwarnings =
     ignore:'environmentfilter' is renamed to 'pass_environment'
     ignore:'contextfunction' is renamed to 'pass_context'
     ignore:.*The distutils.* is deprecated.*:DeprecationWarning
+    ignore:\s*.*numpy.distutils.*:DeprecationWarning


### PR DESCRIPTION
* ignore the deprecation warnings for `numpy.distutils`,
which cause a small number of failures/errors in our testsuite
(see: gh-15625
for example failures in our CI)

* I doubt we're going to forget that `numpy.distutils` is going
away with all the work happening on the switch over to `meson`,
etc.
