### PR TITLE
MAINT: stats: fix `trim1` `axis` behavior

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -3432,7 +3432,6 @@ def trim1(a, proportiontocut, tail='right', axis=0):
     instance, trimming 25% of the values from an array of 10 values will
     return an array of 8 values:
 
-
     >>> b = np.arange(10)
     >>> stats.trim1(b, 1/4).shape
     (8,)
@@ -3445,7 +3444,7 @@ def trim1(a, proportiontocut, tail='right', axis=0):
     >>> stats.trim1(d, 0.8, axis=0).shape
     (1, 10)
     >>> stats.trim1(d, 0.8, axis=1).shape
-    (2, 10)
+    (3, 2)
     >>> stats.trim1(d, 0.8, axis=None).shape
     (6,)
 
@@ -3471,7 +3470,9 @@ def trim1(a, proportiontocut, tail='right', axis=0):
 
     atmp = np.partition(a, (lowercut, uppercut - 1), axis)
 
-    return atmp[lowercut:uppercut]
+    sl = [slice(None)] * atmp.ndim
+    sl[axis] = slice(lowercut, uppercut)
+    return atmp[tuple(sl)]
 
 
 def trim_mean(a, proportiontocut, axis=0):

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -6001,6 +6001,18 @@ class TestTrim:
         assert_equal(stats.trim1([], 3/11., tail='left'), [])
         assert_equal(stats.trim1([], 4/6.), [])
 
+        # test axis
+        a = np.arange(24).reshape(6, 4)
+        ref = np.arange(4, 24).reshape(5, 4)  # first row trimmed
+
+        axis = 0
+        trimmed = stats.trim1(a, 0.2, tail='left', axis=axis)
+        assert_equal(np.sort(trimmed, axis=axis), ref)
+
+        axis = 1
+        trimmed = stats.trim1(a.T, 0.2, tail='left', axis=axis)
+        assert_equal(np.sort(trimmed, axis=axis), ref.T)
+
     def test_trimboth(self):
         a = np.arange(11)
         assert_equal(np.sort(stats.trimboth(a, 3/11.)), np.arange(3, 8))


### PR DESCRIPTION
#### Reference issue
gh-11148

#### What does this implement/fix?
gh-11148 revealed that `trim1`'s `axis` parameter wasn't working properly.

```
>>> import numpy as np
>>> from scipy import stats
>>> d = np.random.rand(3, 10)
>>> stats.trim1(d, 0.8, axis=0).shape  # 80% of rows trimmed
(1, 10)
>>> stats.trim1(d, 0.8, axis=1).shape  # 80% of columns trimmed?
(2, 10)
```

This PR borrows from `trimboth` the bit of code that is needed to correct the `axis` behavior. Now:
```python3
>>> stats.trim1(d, 0.8, axis=1).shape  # 80% of columns trimmed
(3, 2)
```