### PR TITLE
CI: Improve concurrency to cancel running jobs on PR update

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,6 +10,10 @@ on:
       - main
       - maintenance/**
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   Python-38-dbg:
     name: Python 3.8-dbg

--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -18,6 +18,10 @@ env:
   CCACHE_DIR: "${{ github.workspace }}/.ccache"
   INSTALLDIR: "build-install"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test_meson:
     name: Meson build

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -10,6 +10,9 @@ on:
       - main
       - maintenance/**
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   test_macos:

--- a/.github/workflows/macos_meson.yml
+++ b/.github/workflows/macos_meson.yml
@@ -14,6 +14,10 @@ env:
   INSTALLDIR: "build-install"
   CCACHE_DIR: "${{ github.workspace }}/.ccache"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test_meson:
     name: Meson build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,6 +10,10 @@ on:
       - main
       - maintenance/**
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Meson Windows tests


### PR DESCRIPTION
#### What does this implement/fix?

Reference: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-a-fallback-value

This will cancel old running jobs on current PRs/branches where more commits have been made, thus saving resources and relieving some spots in the queue a bit faster.
