### PR TITLE
DOC, MAINT: fix links to wrapped functions and SciPy's distributions

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -20,8 +20,8 @@ needs_sphinx = '2.0'
 # ua._Function should not be treated as an attribute
 from sphinx.util import inspect
 import scipy._lib.uarray as ua
-from scipy.stats._distn_infrastructure import rv_generic
-from scipy.stats._multivariate import multi_rv_generic
+from scipy.stats._distn_infrastructure import rv_generic  # noqa: E402
+from scipy.stats._multivariate import multi_rv_generic  # noqa: E402
 old_isdesc = inspect.isdescriptor
 inspect.isdescriptor = (lambda obj: old_isdesc(obj)
                         and not isinstance(obj, ua._Function))

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -473,7 +473,7 @@ def linkcode_resolve(domain, info):
             return None
 
     # Use the original function object if it is wrapped.
-    obj = obj.__wrapped__ if hasattr(obj, "__wrapped__") else obj
+    obj = getattr(obj, "__wrapped__", obj)
     # SciPy's distributions are instances of *_gen. Point to this
     # class since it contains the implementation of all the methods.
     if isinstance(obj, (rv_generic, multi_rv_generic)):

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -20,6 +20,8 @@ needs_sphinx = '2.0'
 # ua._Function should not be treated as an attribute
 from sphinx.util import inspect
 import scipy._lib.uarray as ua
+from scipy.stats._distn_infrastructure import rv_generic
+from scipy.stats._multivariate import multi_rv_generic
 old_isdesc = inspect.isdescriptor
 inspect.isdescriptor = (lambda obj: old_isdesc(obj)
                         and not isinstance(obj, ua._Function))
@@ -470,6 +472,12 @@ def linkcode_resolve(domain, info):
         except Exception:
             return None
 
+    # Use the original function object if it is wrapped.
+    obj = obj.__wrapped__ if hasattr(obj, "__wrapped__") else obj
+    # SciPy's distributions are instances of *_gen. Point to this
+    # class since it contains the implementation of all the methods.
+    if isinstance(obj, (rv_generic, multi_rv_generic)):
+        obj = obj.__class__
     try:
         fn = inspect.getsourcefile(obj)
     except Exception:


### PR DESCRIPTION
#### Reference issue

fixes #15636 

#### What does this implement/fix?

Fix sources to functions that are wrapped using `functools.wraps` and add sources to the `*_gen` class for SciPy distributions.

#### Additional information

Cython and CPython functions generally don't have source code information so it isn't possible to link to their source.