### PR TITLE
DOC: Add examples to documentation for `scipy.special.ellipr{c,d,f,g,j}`

### DIFF
--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -2397,7 +2397,6 @@ add_newdoc(
     Basic homogeneity property:
 
     >>> from scipy.special import elliprc
-    >>> from numpy import sqrt
 
     >>> x = 1.2 + 3.4j
     >>> y = 5.
@@ -2405,7 +2404,7 @@ add_newdoc(
     >>> elliprc(scale*x, scale*y)
     (0.5484493976710874-0.4169557678995833j)
 
-    >>> elliprc(x, y)/sqrt(scale)
+    >>> elliprc(x, y)/np.sqrt(scale)
     (0.5484493976710874-0.41695576789958333j)
 
     When the two arguments coincide, the integral is particularly
@@ -2415,7 +2414,7 @@ add_newdoc(
     >>> elliprc(x, x)
     (0.4299173120614631-0.3041729818745595j)
 
-    >>> 1/sqrt(x)
+    >>> 1/np.sqrt(x)
     (0.4299173120614631-0.30417298187455954j)
 
     Another simple case: the first argument vanishes:
@@ -2424,22 +2423,19 @@ add_newdoc(
     >>> elliprc(0, y)
     (0.6753125346116815-0.47779380263880866j)
 
-    >>> from numpy import pi
-    >>> pi/2/sqrt(y)
+    >>> np.pi/2/np.sqrt(y)
     (0.6753125346116815-0.4777938026388088j)
 
     When `x` and `y` are both positive, we can express
     :math:`R_C(x,y)` in terms of more elementary functions.  For the
     case :math:`0 \le x < y`,
 
-    >>> from numpy import arctan, log
-
     >>> x = 3.2
     >>> y = 6.
     >>> elliprc(x, y)
     0.44942991498453444
 
-    >>> arctan(sqrt((y-x)/x))/sqrt(y-x)
+    >>> np.arctan(np.sqrt((y-x)/x))/np.sqrt(y-x)
     0.44942991498453433
 
     And for the case :math:`0 \le y < x`,
@@ -2449,7 +2445,7 @@ add_newdoc(
     >>> elliprc(x,y)
     0.4989837501576147
 
-    >>> log((sqrt(x)+sqrt(x-y))/sqrt(y))/sqrt(x-y)
+    >>> np.log((np.sqrt(x)+np.sqrt(x-y))/np.sqrt(y))/np.sqrt(x-y)
     0.49898375015761476
 
     """)
@@ -2514,7 +2510,6 @@ add_newdoc(
     Basic homogeneity property:
 
     >>> from scipy.special import elliprd
-    >>> from numpy import power
 
     >>> x = 1.2 + 3.4j
     >>> y = 5.
@@ -2523,7 +2518,7 @@ add_newdoc(
     >>> elliprd(scale*x, scale*y, scale*z)
     (-0.03703043835680379-0.24500934665683802j)
 
-    >>> elliprd(x, y, z)*power(scale, -1.5)
+    >>> elliprd(x, y, z)*np.power(scale, -1.5)
     (-0.0370304383568038-0.24500934665683805j)
 
     All three arguments coincide:
@@ -2532,7 +2527,7 @@ add_newdoc(
     >>> elliprd(x, x, x)
     (-0.03986825876151896-0.14051741840449586j)
 
-    >>> power(x, -1.5)
+    >>> np.power(x, -1.5)
     (-0.03986825876151894-0.14051741840449583j)
 
     The so-called "second lemniscate constant":
@@ -2541,8 +2536,7 @@ add_newdoc(
     0.5990701173677961
 
     >>> from scipy.special import gamma
-    >>> from numpy import sqrt, pi
-    >>> gamma(0.75)**2/sqrt(2*pi)
+    >>> gamma(0.75)**2/np.sqrt(2*np.pi)
     0.5990701173677959
 
     """)
@@ -2605,7 +2599,6 @@ add_newdoc(
     Basic homogeneity property:
 
     >>> from scipy.special import elliprf
-    >>> from numpy import sqrt
 
     >>> x = 1.2 + 3.4j
     >>> y = 5.
@@ -2614,7 +2607,7 @@ add_newdoc(
     >>> elliprf(scale*x, scale*y, scale*z)
     (0.5328051227278146-0.4008623567957094j)
 
-    >>> elliprf(x, y, z)/sqrt(scale)
+    >>> elliprf(x, y, z)/np.sqrt(scale)
     (0.5328051227278147-0.4008623567957095j)
 
     All three arguments coincide:
@@ -2623,7 +2616,7 @@ add_newdoc(
     >>> elliprf(x, x, x)
     (0.42991731206146316-0.30417298187455954j)
 
-    >>> 1/sqrt(x)
+    >>> 1/np.sqrt(x)
     (0.4299173120614631-0.30417298187455954j)
 
     The so-called "first lemniscate constant":
@@ -2632,8 +2625,7 @@ add_newdoc(
     1.3110287771460598
 
     >>> from scipy.special import gamma
-    >>> from numpy import pi
-    >>> gamma(0.25)**2/(4*sqrt(2*pi))
+    >>> gamma(0.25)**2/(4*np.sqrt(2*np.pi))
     1.3110287771460598
 
     """)
@@ -2707,7 +2699,6 @@ add_newdoc(
     Basic homogeneity property:
 
     >>> from scipy.special import elliprg
-    >>> from numpy import sqrt, pi
 
     >>> x = 1.2 + 3.4j
     >>> y = 5.
@@ -2716,7 +2707,7 @@ add_newdoc(
     >>> elliprg(scale*x, scale*y, scale*z)
     (1.195936862005246+0.8470988320464167j)
 
-    >>> elliprg(x, y, z)*sqrt(scale)
+    >>> elliprg(x, y, z)*np.sqrt(scale)
     (1.195936862005246+0.8470988320464165j)
 
     Simplifications:
@@ -2724,13 +2715,13 @@ add_newdoc(
     >>> elliprg(0, y, y)
     1.756203682760182
 
-    >>> 0.25*pi*sqrt(y)
+    >>> 0.25*np.pi*np.sqrt(y)
     1.7562036827601817
 
     >>> elliprg(0, 0, z)
     1.224744871391589
 
-    >>> 0.5*sqrt(z)
+    >>> 0.5*np.sqrt(z)
     1.224744871391589
 
     The surface area of a triaxial ellipsoid with semiaxes ``a``, ``b``, and
@@ -2846,7 +2837,6 @@ add_newdoc(
     Basic homogeneity property:
 
     >>> from scipy.special import elliprj
-    >>> from numpy import power
 
     >>> x = 1.2 + 3.4j
     >>> y = 5.
@@ -2856,7 +2846,7 @@ add_newdoc(
     >>> elliprj(scale*x, scale*y, scale*z, scale*p)
     (0.10834905565679157+0.19694950747103812j)
 
-    >>> elliprj(x, y, z, p)*power(scale, -1.5)
+    >>> elliprj(x, y, z, p)*np.power(scale, -1.5)
     (0.10834905565679556+0.19694950747103854j)
 
     Reduction to simpler elliptic integral:
@@ -2873,7 +2863,7 @@ add_newdoc(
     >>> elliprj(x, x, x, x)
     (-0.03986825876151896-0.14051741840449586j)
 
-    >>> power(x, -1.5)
+    >>> np.power(x, -1.5)
     (-0.03986825876151894-0.14051741840449583j)
 
     """)

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -2391,6 +2391,67 @@ add_newdoc(
            integrals," Numer. Algorithm, vol. 10, no. 1, pp. 13-26, 1995.
            https://arxiv.org/abs/math/9409227
            https://doi.org/10.1007/BF02198293
+
+    Examples
+    --------
+    Basic homogeneity property:
+
+    >>> from scipy.special import elliprc
+    >>> from numpy import sqrt
+
+    >>> x = 1.2 + 3.4j
+    >>> y = 5.
+    >>> scale = 0.3 + 0.4j
+    >>> elliprc(scale*x, scale*y)
+    (0.5484493976710874-0.4169557678995833j)
+
+    >>> elliprc(x, y)/sqrt(scale)
+    (0.5484493976710874-0.41695576789958333j)
+
+    When the two arguments coincide, the integral is particularly
+    simple:
+
+    >>> x = 1.2 + 3.4j
+    >>> elliprc(x, x)
+    (0.4299173120614631-0.3041729818745595j)
+
+    >>> 1/sqrt(x)
+    (0.4299173120614631-0.30417298187455954j)
+
+    Another simple case: the first argument vanishes:
+
+    >>> y = 1.2 + 3.4j
+    >>> elliprc(0, y)
+    (0.6753125346116815-0.47779380263880866j)
+
+    >>> from numpy import pi
+    >>> pi/2/sqrt(y)
+    (0.6753125346116815-0.4777938026388088j)
+
+    When `x` and `y` are both positive, we can express
+    :math:`R_C(x,y)` in terms of more elementary functions.  For the
+    case :math:`0 \le x < y`,
+
+    >>> from numpy import arctan, log
+
+    >>> x = 3.2
+    >>> y = 6.
+    >>> elliprc(x, y)
+    0.44942991498453444
+
+    >>> arctan(sqrt((y-x)/x))/sqrt(y-x)
+    0.44942991498453433
+
+    And for the case :math:`0 \le y < x`,
+
+    >>> x = 6.
+    >>> y = 3.2
+    >>> elliprc(x,y)
+    0.4989837501576147
+
+    >>> log((sqrt(x)+sqrt(x-y))/sqrt(y))/sqrt(x-y)
+    0.49898375015761476
+
     """)
 
 add_newdoc(
@@ -2447,6 +2508,43 @@ add_newdoc(
            integrals," Numer. Algorithm, vol. 10, no. 1, pp. 13-26, 1995.
            https://arxiv.org/abs/math/9409227
            https://doi.org/10.1007/BF02198293
+
+    Examples
+    --------
+    Basic homogeneity property:
+
+    >>> from scipy.special import elliprd
+    >>> from numpy import power
+
+    >>> x = 1.2 + 3.4j
+    >>> y = 5.
+    >>> z = 6.
+    >>> scale = 0.3 + 0.4j
+    >>> elliprd(scale*x, scale*y, scale*z)
+    (-0.03703043835680379-0.24500934665683802j)
+
+    >>> elliprd(x, y, z)*power(scale, -1.5)
+    (-0.0370304383568038-0.24500934665683805j)
+
+    All three arguments coincide:
+
+    >>> x = 1.2 + 3.4j
+    >>> elliprd(x, x, x)
+    (-0.03986825876151896-0.14051741840449586j)
+
+    >>> power(x, -1.5)
+    (-0.03986825876151894-0.14051741840449583j)
+
+    The so-called "second lemniscate constant":
+
+    >>> elliprd(0, 2, 1)/3
+    0.5990701173677961
+
+    >>> from scipy.special import gamma
+    >>> from numpy import sqrt, pi
+    >>> gamma(0.75)**2/sqrt(2*pi)
+    0.5990701173677959
+
     """)
 
 add_newdoc(
@@ -2501,6 +2599,43 @@ add_newdoc(
            integrals," Numer. Algorithm, vol. 10, no. 1, pp. 13-26, 1995.
            https://arxiv.org/abs/math/9409227
            https://doi.org/10.1007/BF02198293
+
+    Examples
+    --------
+    Basic homogeneity property:
+
+    >>> from scipy.special import elliprf
+    >>> from numpy import sqrt
+
+    >>> x = 1.2 + 3.4j
+    >>> y = 5.
+    >>> z = 6.
+    >>> scale = 0.3 + 0.4j
+    >>> elliprf(scale*x, scale*y, scale*z)
+    (0.5328051227278146-0.4008623567957094j)
+
+    >>> elliprf(x, y, z)/sqrt(scale)
+    (0.5328051227278147-0.4008623567957095j)
+
+    All three arguments coincide:
+
+    >>> x = 1.2 + 3.4j
+    >>> elliprf(x, x, x)
+    (0.42991731206146316-0.30417298187455954j)
+
+    >>> 1/sqrt(x)
+    (0.4299173120614631-0.30417298187455954j)
+
+    The so-called "first lemniscate constant":
+
+    >>> elliprf(0, 1, 2)
+    1.3110287771460598
+
+    >>> from scipy.special import gamma
+    >>> from numpy import pi
+    >>> gamma(0.25)**2/(4*sqrt(2*pi))
+    1.3110287771460598
+
     """)
 
 add_newdoc(
@@ -2569,6 +2704,35 @@ add_newdoc(
 
     Examples
     --------
+    Basic homogeneity property:
+
+    >>> from scipy.special import elliprg
+    >>> from numpy import sqrt, pi
+
+    >>> x = 1.2 + 3.4j
+    >>> y = 5.
+    >>> z = 6.
+    >>> scale = 0.3 + 0.4j
+    >>> elliprg(scale*x, scale*y, scale*z)
+    (1.195936862005246+0.8470988320464167j)
+
+    >>> elliprg(x, y, z)*sqrt(scale)
+    (1.195936862005246+0.8470988320464165j)
+
+    Simplifications:
+
+    >>> elliprg(0, y, y)
+    1.756203682760182
+
+    >>> 0.25*pi*sqrt(y)
+    1.7562036827601817
+
+    >>> elliprg(0, 0, z)
+    1.224744871391589
+
+    >>> 0.5*sqrt(z)
+    1.224744871391589
+
     The surface area of a triaxial ellipsoid with semiaxes ``a``, ``b``, and
     ``c`` is given by
 
@@ -2676,6 +2840,42 @@ add_newdoc(
            pp. 288-303, 1994.
            https://arxiv.org/abs/math/9310223
            https://doi.org/10.1137/S0036141092228477
+
+    Examples
+    --------
+    Basic homogeneity property:
+
+    >>> from scipy.special import elliprj
+    >>> from numpy import power
+
+    >>> x = 1.2 + 3.4j
+    >>> y = 5.
+    >>> z = 6.
+    >>> p = 7.
+    >>> scale = 0.3 - 0.4j
+    >>> elliprj(scale*x, scale*y, scale*z, scale*p)
+    (0.10834905565679157+0.19694950747103812j)
+
+    >>> elliprj(x, y, z, p)*power(scale, -1.5)
+    (0.10834905565679556+0.19694950747103854j)
+
+    Reduction to simpler elliptic integral:
+
+    >>> elliprj(x, y, z, z)
+    (0.08288462362195129-0.028376809745123258j)
+
+    >>> from scipy.special import elliprd
+    >>> elliprd(x, y, z)
+    (0.08288462362195136-0.028376809745123296j)
+
+    All arguments coincide:
+
+    >>> elliprj(x, x, x, x)
+    (-0.03986825876151896-0.14051741840449586j)
+
+    >>> power(x, -1.5)
+    (-0.03986825876151894-0.14051741840449583j)
+
     """)
 
 add_newdoc("entr",


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Examples were missing from several of the special functions `ellipr{c,d,f,j}`, as pointed out by @WarrenWeckesser at https://github.com/scipy/scipy/pull/15135#issuecomment-988182407 .

#### What does this implement/fix?
<!--Please explain your changes.-->

Some simple (and some less simple) examples of usage and properties in `Examples` sections of docstrings for these 5 functions.

#### Additional information
<!--Any additional information you think is important.-->
