### PR TITLE
REL: fix small issue in pavement.py for release note writing

### DIFF
--- a/pavement.py
+++ b/pavement.py
@@ -38,12 +38,14 @@ import paver.path
 from paver.easy import options, Bunch, task, needs, dry, sh, cmdopts
 
 sys.path.insert(0, os.path.dirname(__file__))
+sys.path.insert(1, os.path.join(os.path.dirname(__file__), 'tools'))
 try:
-    version_utils = __import__("tools").version_utils
+    version_utils = __import__("version_utils")
     FULLVERSION = version_utils.VERSION
     # This is duplicated from setup.py
     if os.path.exists('.git'):
-        GIT_REVISION = version_utils.git_version()
+        GIT_REVISION, _ = version_utils.git_version(
+                os.path.join(os.path.dirname(__file__), '..'))
     else:
         GIT_REVISION = "Unknown"
 
@@ -53,6 +55,7 @@ try:
         else:
             FULLVERSION += '.dev0+' + GIT_REVISION[:7]
 finally:
+    sys.path.pop(1)
     sys.path.pop(0)
 
 try:


### PR DESCRIPTION
This snuck in with the move to Meson. It needs further cleanup, we'll get rid of this whole file at some point. Right now this is just the minimum fix to get past an error.

Disabled CI because there's nothing useful to test here; tested locally that I get `release/README.tmp` with correct contents. Merging straight away to unblock further work on this.

[ci skip]
