### PR TITLE
DOC: Fix example for subset_by_index in eigh doc

### DIFF
--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -425,7 +425,7 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
     >>> eigh(A, eigvals_only=True, subset_by_value=[-np.inf, 10])
     array([6.69199443e-07, 9.11938152e+00])
 
-    Request the largest second eigenvalue and its eigenvector
+    Request the second smallest eigenvalue and its eigenvector
 
     >>> w, v = eigh(A, subset_by_index=[1, 1])
     >>> w


### PR DESCRIPTION
The main docstring correctly says:
To return only the second smallest to fifth smallest eigenvalues, ``[1, 4]`` is used.
But the example text is off from that.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
None

#### What does this implement/fix?
<!--Please explain your changes.-->
Small miswording in the example docstring.

#### Additional information
<!--Any additional information you think is important.-->
