### PR TITLE
MAINT: benchmarks: Update out of date instructions for safe benchmark imports

### DIFF
--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -53,10 +53,10 @@ Some things to consider:
 
 - When importing things from SciPy on the top of the test files, do it as::
 
-      try:
+      from .common import safe_import
+
+      with safe_import():
           from scipy.sparse.linalg import onenormest
-      except ImportError:
-          pass
 
   The benchmark files need to be importable also when benchmarking old versions
   of SciPy. The benchmarks themselves don't need any guarding against missing


### PR DESCRIPTION
gh-8779 added `safe_import()` to `benchmarks/benchmarks/common.py` as a way to guard against failed imports however the benchmark readme (https://github.com/scipy/scipy/blob/main/benchmarks/README.rst#writing-benchmarks) has not been updated to reflect this and still recommends using  try except block. This pull request changes the old recommendation
```
try:
    from scipy.sparse.linalg import onenormest
except ImportError:
    pass
```
to use `safe_import()` instead
```
from .common import safe_import

with safe_import():
    from scipy.sparse.linalg import onenormes
```