### PR TITLE
DOC: stats.burr12: fix typo

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1019,7 +1019,7 @@ class burr12_gen(rv_continuous):
 
     Notes
     -----
-    The probability density function for `burr` is:
+    The probability density function for `burr12` is:
 
     .. math::
 


### PR DESCRIPTION
#### Reference issue
gh-14003

#### What does this implement/fix?
Obvious typo in `burr12` distribution documentation.

#### Additional information
Please consider double-checking recently-merged changes from gh-14003. I went ahead and corrected/merged that myself, but it would be good to have someone else looking since there was some confusion there.