### PR TITLE
BENCH: Add benchmarks for special.factorial/factorial2/factorialk

### DIFF
--- a/benchmarks/benchmarks/special.py
+++ b/benchmarks/benchmarks/special.py
@@ -160,4 +160,10 @@ class Factorial2(Benchmark):
 
 
 class FactorialK(Benchmark):
-    ...
+    @with_attributes(params=[(100, 1000), range(1, 10)],
+                     param_names=['n', 'k'])
+    def time_factorialk_exact_true_scalar_positive_int(self, n, k):
+        factorialk(n, k, exact=True)
+
+    def time_factorialk_exact_false_scalar_negative_int(self):
+        factorialk(-10000, 3, exact=True)

--- a/benchmarks/benchmarks/special.py
+++ b/benchmarks/benchmarks/special.py
@@ -150,6 +150,14 @@ class Factorial2(Benchmark):
     def time_factorial2_exact_false_array_negative_int(self):
         factorial2(self.negative_ints, exact=False)
 
+    @with_attributes(params=[(100, 1000, 2000)],
+                     param_names=['n'])
+    def time_factorial2_exact_true_scalar_positive_int(self, n):
+        factorial2(n, exact=True)
+
+    def time_factorial2_exact_true_scalar_negative_int(self):
+        factorial2(-10000, exact=True)
+
 
 class FactorialK(Benchmark):
     ...

--- a/benchmarks/benchmarks/special.py
+++ b/benchmarks/benchmarks/special.py
@@ -77,9 +77,9 @@ class Expn(Benchmark):
 
 class Factorial(Benchmark):
     def setup(self, *args):
-        self.positive_ints = np.arange(100, 1001, step=10, dtype=int)
+        self.positive_ints = np.arange(10, 111, step=20, dtype=int)
         self.negative_ints = -1 * self.positive_ints
-        self.positive_floats = np.linspace(100.2, 10000.8)
+        self.positive_floats = np.linspace(100.2, 1000.8, num=10)
         self.negative_floats = -1 * self.positive_floats
 
     @with_attributes(params=[(100, 1000, 10000)],
@@ -110,7 +110,7 @@ class Factorial(Benchmark):
     def time_factorial_exact_false_array_negative_float(self):
         factorial(self.negative_floats, exact=False)
 
-    @with_attributes(params=[(100, 1000, 5000)],
+    @with_attributes(params=[(100, 200, 400)],
                      param_names=['n'])
     def time_factorial_exact_true_scalar_positive_int(self, n):
         factorial(n, exact=True)
@@ -133,10 +133,10 @@ class Factorial(Benchmark):
 
 class Factorial2(Benchmark):
     def setup(self, *args):
-        self.positive_ints = np.arange(100, 1001, step=10, dtype=int)
+        self.positive_ints = np.arange(100, 201, step=20, dtype=int)
         self.negative_ints = -1 * self.positive_ints
 
-    @with_attributes(params=[(100, 1000, 2000)],
+    @with_attributes(params=[(100, 200, 400)],
                      param_names=['n'])
     def time_factorial2_exact_false_scalar_positive_int(self, n):
         factorial2(n, exact=False)
@@ -150,7 +150,7 @@ class Factorial2(Benchmark):
     def time_factorial2_exact_false_array_negative_int(self):
         factorial2(self.negative_ints, exact=False)
 
-    @with_attributes(params=[(100, 1000, 2000)],
+    @with_attributes(params=[(100, 200, 400)],
                      param_names=['n'])
     def time_factorial2_exact_true_scalar_positive_int(self, n):
         factorial2(n, exact=True)
@@ -160,7 +160,7 @@ class Factorial2(Benchmark):
 
 
 class FactorialK(Benchmark):
-    @with_attributes(params=[(100, 1000), range(1, 10)],
+    @with_attributes(params=[(100, 500), range(1, 10)],
                      param_names=['n', 'k'])
     def time_factorialk_exact_true_scalar_positive_int(self, n, k):
         factorialk(n, k, exact=True)

--- a/benchmarks/benchmarks/special.py
+++ b/benchmarks/benchmarks/special.py
@@ -3,7 +3,15 @@ import numpy as np
 from .common import Benchmark, with_attributes, safe_import
 
 with safe_import():
-    from scipy.special import ai_zeros, bi_zeros, erf, expn
+    from scipy.special import (
+        ai_zeros,
+        bi_zeros,
+        erf,
+        expn,
+        factorial,
+        factorial2,
+        factorialk,
+    )
 with safe_import():
     # wasn't always in scipy.special, so import separately
     from scipy.special import comb
@@ -65,3 +73,15 @@ class Expn(Benchmark):
 
     def time_expn_large_n(self):
         expn(self.n, self.x)
+
+
+class Factorial(Benchmark):
+    ...
+
+
+class Factorial2(Benchmark):
+    ...
+
+
+class FactorialK(Benchmark):
+    ...

--- a/benchmarks/benchmarks/special.py
+++ b/benchmarks/benchmarks/special.py
@@ -76,7 +76,39 @@ class Expn(Benchmark):
 
 
 class Factorial(Benchmark):
-    ...
+    def setup(self, *args):
+        self.positive_ints = np.arange(100, 1001, step=10, dtype=int)
+        self.negative_ints = -1 * self.positive_ints
+        self.positive_floats = np.linspace(100.2, 10000.8)
+        self.negative_floats = -1 * self.positive_floats
+
+    @with_attributes(params=[(100, 1000, 10000)],
+                     param_names=['n'])
+    def time_factorial_exact_false_scalar_positive_int(self, n):
+        factorial(n, exact=False)
+
+    def time_factorial_exact_false_scalar_negative_int(self):
+        factorial(-10000, exact=False)
+
+    @with_attributes(params=[(100.8, 1000.3, 10000.5)],
+                     param_names=['n'])
+    def time_factorial_exact_false_scalar_positive_float(self, n):
+        factorial(n, exact=False)
+
+    def time_factorial_exact_false_scalar_negative_float(self):
+        factorial(-10000.8, exact=False)
+
+    def time_factorial_exact_false_array_positive_int(self):
+        factorial(self.positive_ints, exact=False)
+
+    def time_factorial_exact_false_array_negative_int(self):
+        factorial(self.negative_ints, exact=False)
+
+    def time_factorial_exact_false_array_positive_float(self):
+        factorial(self.positive_floats, exact=False)
+
+    def time_factorial_exact_false_array_negative_float(self):
+        factorial(self.negative_floats, exact=False)
 
 
 class Factorial2(Benchmark):

--- a/benchmarks/benchmarks/special.py
+++ b/benchmarks/benchmarks/special.py
@@ -110,6 +110,26 @@ class Factorial(Benchmark):
     def time_factorial_exact_false_array_negative_float(self):
         factorial(self.negative_floats, exact=False)
 
+    @with_attributes(params=[(100, 1000, 10000)],
+                     param_names=['n'])
+    def time_factorial_exact_true_scalar_positive_int(self, n):
+        factorial(n, exact=True)
+
+    def time_factorial_exact_true_scalar_negative_int(self):
+        factorial(-10000, exact=True)
+
+    def time_factorial_exact_true_scalar_negative_float(self):
+        factorial(-10000.8, exact=True)
+
+    def time_factorial_exact_true_array_positive_int(self):
+        factorial(self.positive_ints, exact=True)
+
+    def time_factorial_exact_true_array_negative_int(self):
+        factorial(self.negative_ints, exact=True)
+
+    def time_factorial_exact_true_array_negative_float(self):
+        factorial(self.negative_floats, exact=True)
+
 
 class Factorial2(Benchmark):
     ...

--- a/benchmarks/benchmarks/special.py
+++ b/benchmarks/benchmarks/special.py
@@ -110,7 +110,7 @@ class Factorial(Benchmark):
     def time_factorial_exact_false_array_negative_float(self):
         factorial(self.negative_floats, exact=False)
 
-    @with_attributes(params=[(100, 1000, 10000)],
+    @with_attributes(params=[(100, 1000, 5000)],
                      param_names=['n'])
     def time_factorial_exact_true_scalar_positive_int(self, n):
         factorial(n, exact=True)
@@ -132,7 +132,23 @@ class Factorial(Benchmark):
 
 
 class Factorial2(Benchmark):
-    ...
+    def setup(self, *args):
+        self.positive_ints = np.arange(100, 1001, step=10, dtype=int)
+        self.negative_ints = -1 * self.positive_ints
+
+    @with_attributes(params=[(100, 1000, 2000)],
+                     param_names=['n'])
+    def time_factorial2_exact_false_scalar_positive_int(self, n):
+        factorial2(n, exact=False)
+
+    def time_factorial2_exact_false_scalar_negative_int(self):
+        factorial2(-10000, exact=False)
+
+    def time_factorial2_exact_false_array_positive_int(self):
+        factorial2(self.positive_ints, exact=False)
+
+    def time_factorial2_exact_false_array_negative_int(self):
+        factorial2(self.negative_ints, exact=False)
 
 
 class FactorialK(Benchmark):


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->
part of gh-15600
#### What does this implement/fix?
<!--Please explain your changes.-->
gh-15600 highlight a number of inconsistencies in special.factorial/factorial2/factorialk. As a first step to resolving them in would be useful to benchmark the existing functionality to ensure we are not making it worse. This pull request adds benchmarks for all the options in the table bellow that dont raise an exception or return nan.
![image](https://user-images.githubusercontent.com/60778417/155841990-c667fd5c-9f4b-4d27-88a0-0c2519ef8fcd.png)
(table courtesy of @h-vetinari )
#### Additional information
<!--Any additional information you think is important.-->
cc. @h-vetinari , @tupui , @tirthasheshpatel ,