### PR TITLE
BUG: stats: fix a bug in UNU.RAN error handler

### DIFF
--- a/scipy/stats/_unuran/unuran_callback.h
+++ b/scipy/stats/_unuran/unuran_callback.h
@@ -68,6 +68,9 @@ done:                                                                           
 void error_handler(const char *objid, const char *file, int line, const char *errortype, int unur_errno, const char *reason)
 {
     if ( unur_errno != UNUR_SUCCESS ) {
+        if (PyErr_Occurred()) {
+            return;
+        }
         FILE *LOG = unur_get_stream();
         char objid_[256], reason_[256];
         (objid == NULL || strcmp(objid, "") == 0) ? strcpy(objid_, "unknown") : strcpy(objid_, objid);


### PR DESCRIPTION
#### Reference issue

UNU.RAN error handler attempts to set a warning when a live exception could have been set.

<details>

<summary>For example, when a `KeyboardInterrupt` occurs</summary>

```python
>>> from scipy import stats
>>> from scipy.stats import sampling
>>> rng = sampling.SimpleRatioUniforms(stats.studentized_range(3,10))
^CTraceback (most recent call last):
  File "scipy/stats/unuran_wrapper.pyx", line 1141, in scipy.stats.unuran_wrapper.SimpleRatioUniforms.__cinit__._callback_wrapper
  File "scipy/stats/unuran_wrapper.pyx", line 266, in scipy.stats.unuran_wrapper._unpack_dist.wrap_dist.pdf
  File "/home/tirthasheshpatel/tensor_libs/scipy/build-2-install/lib/python3.9/site-packages/scipy/stats/_continuous_distns.py", line 9289, in _pdf
    return np.float64(ufunc(x, k, df))
  File "/home/tirthasheshpatel/tensor_libs/scipy/build-2-install/lib/python3.9/site-packages/scipy/stats/_continuous_distns.py", line 9286, in _single_pdf
    return integrate.nquad(llc, ranges=ranges, opts=opts)[0]
  File "/home/tirthasheshpatel/tensor_libs/scipy/build-2-install/lib/python3.9/site-packages/scipy/integrate/_quadpack_py.py", line 824, in nquad
    return _NQuad(func, ranges, opts, full_output).integrate(*args)
  File "/home/tirthasheshpatel/tensor_libs/scipy/build-2-install/lib/python3.9/site-packages/scipy/integrate/_quadpack_py.py", line 878, in integrate
    quad_r = quad(f, low, high, args=args, full_output=self.full_output,
  File "/home/tirthasheshpatel/tensor_libs/scipy/build-2-install/lib/python3.9/site-packages/scipy/integrate/_quadpack_py.py", line 351, in quad
    retval = _quad(func, a, b, args, full_output, epsabs, epsrel, limit,
  File "/home/tirthasheshpatel/tensor_libs/scipy/build-2-install/lib/python3.9/site-packages/scipy/integrate/_quadpack_py.py", line 465, in _quad
    return _quadpack._qagie(func,bound,infbounds,args,full_output,epsabs,epsrel,limit)
  File "/home/tirthasheshpatel/tensor_libs/scipy/build-2-install/lib/python3.9/site-packages/scipy/integrate/_quadpack_py.py", line 878, in integrate
    quad_r = quad(f, low, high, args=args, full_output=self.full_output,
  File "/home/tirthasheshpatel/tensor_libs/scipy/build-2-install/lib/python3.9/site-packages/scipy/integrate/_quadpack_py.py", line 351, in quad
    retval = _quad(func, a, b, args, full_output, epsabs, epsrel, limit,
  File "/home/tirthasheshpatel/tensor_libs/scipy/build-2-install/lib/python3.9/site-packages/scipy/integrate/_quadpack_py.py", line 465, in _quad
    return _quadpack._qagie(func,bound,infbounds,args,full_output,epsabs,epsrel,limit)
KeyboardInterrupt

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "scipy/stats/unuran_wrapper.pyx", line 1170, in scipy.stats.unuran_wrapper.SimpleRatioUniforms.__cinit__
SystemError: <class 'RuntimeWarning'> returned a result with an error set
```

</details>

#### What does this implement/fix?

This can be fixed by adding a PyErr_Occurred check before setting the warning in CPython.

#### Additional information
<!--Any additional information you think is important.-->
