### PR TITLE
DOC: fix intersphinx links

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -234,10 +234,10 @@ mathjax_path = "scipy-mathjax/MathJax.js?config=scipy-mathjax"
 # Intersphinx configuration
 # -----------------------------------------------------------------------------
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/dev', None),
+    'python': ('https://docs.python.org/3', None),
     'numpy': ('https://numpy.org/devdocs', None),
     'neps': ('https://numpy.org/neps', None),
-    'matplotlib': ('https://matplotlib.org', None),
+    'matplotlib': ('https://matplotlib.org/stable', None),
     'asv': ('https://asv.readthedocs.io/en/stable/', None),
 }
 


### PR DESCRIPTION
Closes #15666

Fix intersphinx links. Also update the one for Python (as NumPy here).

Matplotlib has a new org website (beautiful) which is now at https://matplotlib.org/ while the doc lives at ex. https://matplotlib.org/stable