### PR TITLE
MAINT: sparse.linalg: Clear up unnecessary modules imported in `sparse/linalg/_isolve/utils.py`

### DIFF
--- a/scipy/sparse/linalg/_isolve/utils.py
+++ b/scipy/sparse/linalg/_isolve/utils.py
@@ -3,8 +3,7 @@ __docformat__ = "restructuredtext en"
 __all__ = []
 
 
-from numpy import asanyarray, asarray, array, matrix, zeros
-from scipy.sparse._sputils import asmatrix
+from numpy import asanyarray, asarray, array, zeros
 
 from scipy.sparse.linalg._interface import aslinearoperator, LinearOperator, \
      IdentityOperator


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
In `sparse/linalg/_isolve/utils.py`, both `numpy.matrix` and `asmatrix` are removed.

#### Additional information
<!--Any additional information you think is important.-->
