### PR TITLE
MAINT: stats: bootstrap: fix bug with `method="BCa"` when `statistic` returns Python float

### DIFF
--- a/scipy/stats/_bootstrap.py
+++ b/scipy/stats/_bootstrap.py
@@ -104,7 +104,7 @@ def _bca_interval(data, statistic, axis, alpha, theta_hat_b, batch):
     sample = data[0]  # only works with 1 sample statistics right now
 
     # calculate z0_hat
-    theta_hat = statistic(sample, axis=axis)[..., None]
+    theta_hat = np.asarray(statistic(sample, axis=axis))[..., None]
     percentile = _percentile_of_score(theta_hat_b, theta_hat, axis=-1)
     z0_hat = ndtri(percentile)
 

--- a/scipy/stats/tests/test_bootstrap.py
+++ b/scipy/stats/tests/test_bootstrap.py
@@ -369,6 +369,24 @@ def test_bootstrap_degenerate(method):
     assert_equal(res.standard_error, 0)
 
 
+@pytest.mark.parametrize("method", ["basic", "percentile", "BCa"])
+def test_bootstrap_gh15678(method):
+    # Check that gh-15678 is fixed: when statistic function returned a Python
+    # float, method="BCa" failed when trying to add a dimension to the float
+    rng = np.random.default_rng(354645618886684)
+    dist = stats.norm(loc=2, scale=4)
+    data = dist.rvs(size=100, random_state=rng)
+    data = (data,)
+    res = bootstrap(data, stats.skew, method=method, n_resamples=100,
+                    random_state=np.random.default_rng(9563))
+    # this always worked because np.apply_along_axis returns NumPy data type
+    ref = bootstrap(data, stats.skew, method=method, n_resamples=100,
+                    random_state=np.random.default_rng(9563), vectorized=False)
+    assert_allclose(res.confidence_interval, ref.confidence_interval)
+    assert_allclose(res.standard_error, ref.standard_error)
+    assert isinstance(res.standard_error, np.float64)
+
+
 def test_jackknife_resample():
     shape = 3, 4, 5, 6
     np.random.seed(0)


### PR DESCRIPTION
#### Reference issue
closes gh-15678

#### What does this implement/fix?
When `statistic` passed into `scipy.stats.bootstrap` returned a Python float, `method="BCa"` failed because it tried to add a dimension to the Python float. Fixed by calling `np.asarray` on value returned by `statistic` function before trying to add a dimension.
