### PR TITLE
ENH, TYP: Add annotations for `scipy.constants`

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -358,9 +358,6 @@ ignore_errors = True
 [mypy-scipy.fft]
 ignore_errors = True
 
-[mypy-scipy.constants]
-ignore_errors = True
-
 [mypy-scipy.fft._helper]
 ignore_errors = True
 

--- a/scipy/constants/__init__.py
+++ b/scipy/constants/__init__.py
@@ -319,7 +319,7 @@ References
 # Modules contributed by BasSw (wegwerp@gmail.com)
 from ._codata import *
 from ._constants import *
-from ._codata import _obsolete_constants
+from ._codata import _obsolete_constants, physical_constants
 
 # Deprecated namespaces, to be removed in v2.0.0
 from . import codata, constants

--- a/scipy/constants/__init__.py
+++ b/scipy/constants/__init__.py
@@ -324,16 +324,17 @@ from ._codata import _obsolete_constants
 # Deprecated namespaces, to be removed in v2.0.0
 from . import codata, constants
 
-_constant_names = [(_k.lower(), _k, _v)
-                   for _k, _v in physical_constants.items()
-                   if _k not in _obsolete_constants]
+_constant_names_list = [(_k.lower(), _k, _v)
+                        for _k, _v in physical_constants.items()
+                        if _k not in _obsolete_constants]
 _constant_names = "\n".join(["``%s``%s  %s %s" % (_x[1], " "*(66-len(_x[1])),
                                                   _x[2][0], _x[2][1])
-                             for _x in sorted(_constant_names)])
+                             for _x in sorted(_constant_names_list)])
 if __doc__:
     __doc__ = __doc__ % dict(constant_names=_constant_names)
 
 del _constant_names
+del _constant_names_list
 
 __all__ = [s for s in dir() if not s.startswith('_')]
 

--- a/scipy/constants/_codata.py
+++ b/scipy/constants/_codata.py
@@ -1510,6 +1510,7 @@ def parse_constants_2002to2014(d: str) -> dict[str, tuple[float, str, float]]:
         constants[name] = (val, units, uncert)
     return constants
 
+
 def parse_constants_2018toXXXX(d: str) -> dict[str, tuple[float, str, float]]:
     constants = {}
     for line in d.split('\n'):

--- a/scipy/constants/_codata.py
+++ b/scipy/constants/_codata.py
@@ -4,6 +4,8 @@
 # Updated to 2014 values by Joseph Booker, 2015
 # Updated to 2018 values by Jakob Jakobson, 2019
 
+from __future__ import annotations
+
 """
 Fundamental Physical Constants
 ------------------------------
@@ -49,8 +51,11 @@ back to the 1800s. To search the bibliography, visit
 https://physics.nist.gov/cuu/Constants/
 
 """
+
 import warnings
 from math import pi, sqrt
+
+from typing import Any
 
 __all__ = ['physical_constants', 'value', 'unit', 'precision', 'find',
            'ConstantWarning']
@@ -1492,10 +1497,10 @@ W to Z mass ratio                                           0.881 53            
 
 # -----------------------------------------------------------------------------
 
-physical_constants = {}
+physical_constants: dict[str, tuple[float, str, float]] = {}
 
 
-def parse_constants_2002to2014(d):
+def parse_constants_2002to2014(d: str) -> dict[str, tuple[float, str, float]]:
     constants = {}
     for line in d.split('\n'):
         name = line[:55].rstrip()
@@ -1507,7 +1512,7 @@ def parse_constants_2002to2014(d):
         constants[name] = (val, units, uncert)
     return constants
 
-def parse_constants_2018toXXXX(d):
+def parse_constants_2018toXXXX(d: str) -> dict[str, tuple[float, str, float]]:
     constants = {}
     for line in d.split('\n'):
         name = line[:60].rstrip()
@@ -1563,13 +1568,13 @@ class ConstantWarning(DeprecationWarning):
     pass
 
 
-def _check_obsolete(key):
+def _check_obsolete(key: str) -> None:
     if key in _obsolete_constants and key not in _aliases:
         warnings.warn("Constant '%s' is not in current %s data set" % (
             key, _current_codata), ConstantWarning)
 
 
-def value(key):
+def value(key: str) -> float:
     """
     Value in physical_constants indexed by key
 
@@ -1594,7 +1599,7 @@ def value(key):
     return physical_constants[key][0]
 
 
-def unit(key):
+def unit(key: str) -> str:
     """
     Unit in physical_constants indexed by key
 
@@ -1619,7 +1624,7 @@ def unit(key):
     return physical_constants[key][1]
 
 
-def precision(key):
+def precision(key: str) -> float:
     """
     Relative precision in physical_constants indexed by key
 
@@ -1644,7 +1649,7 @@ def precision(key):
     return physical_constants[key][2] / physical_constants[key][0]
 
 
-def find(sub=None, disp=False):
+def find(sub: str | None = None, disp: bool = False) -> Any:
     """
     Return list of physical_constant keys containing a given string.
 
@@ -1705,7 +1710,7 @@ def find(sub=None, disp=False):
     else:
         return result
 
-    
+
 c = value('speed of light in vacuum')
 mu0 = value('vacuum mag. permeability')
 epsilon0 = value('vacuum electric permittivity')

--- a/scipy/constants/_codata.py
+++ b/scipy/constants/_codata.py
@@ -1504,10 +1504,8 @@ def parse_constants_2002to2014(d: str) -> dict[str, tuple[float, str, float]]:
     constants = {}
     for line in d.split('\n'):
         name = line[:55].rstrip()
-        val = line[55:77].replace(' ', '').replace('...', '')
-        val = float(val)
-        uncert = line[77:99].replace(' ', '').replace('(exact)', '0')
-        uncert = float(uncert)
+        val = float(line[55:77].replace(' ', '').replace('...', ''))
+        uncert = float(line[77:99].replace(' ', '').replace('(exact)', '0'))
         units = line[99:].rstrip()
         constants[name] = (val, units, uncert)
     return constants
@@ -1516,10 +1514,8 @@ def parse_constants_2018toXXXX(d: str) -> dict[str, tuple[float, str, float]]:
     constants = {}
     for line in d.split('\n'):
         name = line[:60].rstrip()
-        val = line[60:85].replace(' ', '').replace('...', '')
-        val = float(val)
-        uncert = line[85:110].replace(' ', '').replace('(exact)', '0')
-        uncert = float(uncert)
+        val = float(line[60:85].replace(' ', '').replace('...', ''))
+        uncert = float(line[85:110].replace(' ', '').replace('(exact)', '0'))
         units = line[110:].rstrip()
         constants[name] = (val, units, uncert)
     return constants

--- a/scipy/constants/_constants.py
+++ b/scipy/constants/_constants.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """
 Collection of physical constants and conversion factors.
 
@@ -8,14 +6,8 @@ print '10 mile per minute is', 10*mile/minute, 'm/s or', 10*mile/(minute*knot), 
 
 The list is not meant to be comprehensive, but just convenient for everyday use.
 """
-"""
-BasSw 2006
-physical constants: imported from CODATA
-unit conversion: see e.g., NIST special publication 811
-Use at own risk: double-check values before calculating your Mars orbit-insertion burn.
-Some constants exist in a few variants, which are marked with suffixes.
-The ones without any suffix should be the most common ones.
-"""
+
+from __future__ import annotations
 
 import math as _math
 from typing import TYPE_CHECKING, Any
@@ -26,6 +18,14 @@ import numpy as _np
 if TYPE_CHECKING:
     import numpy.typing as npt
 
+"""
+BasSw 2006
+physical constants: imported from CODATA
+unit conversion: see e.g., NIST special publication 811
+Use at own risk: double-check values before calculating your Mars orbit-insertion burn.
+Some constants exist in a few variants, which are marked with suffixes.
+The ones without any suffix should be the most common ones.
+"""
 
 __all__ = [
     'Avogadro', 'Boltzmann', 'Btu', 'Btu_IT', 'Btu_th', 'G',
@@ -220,7 +220,11 @@ kgf = kilogram_force = g  # * 1 kg
 # functions for conversions that are not linear
 
 
-def convert_temperature(val: npt.ArrayLike, old_scale: str, new_scale: str) -> Any:
+def convert_temperature(
+    val: npt.ArrayLike,
+    old_scale: str,
+    new_scale: str,
+) -> Any:
     """
     Convert from a temperature scale to another one among Celsius, Kelvin,
     Fahrenheit, and Rankine scales.

--- a/scipy/constants/_constants.py
+++ b/scipy/constants/_constants.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """
 Collection of physical constants and conversion factors.
 
@@ -16,8 +18,13 @@ The ones without any suffix should be the most common ones.
 """
 
 import math as _math
+from typing import TYPE_CHECKING, Any
+
 from ._codata import value as _cd
 import numpy as _np
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
 
 
 __all__ = [
@@ -213,7 +220,7 @@ kgf = kilogram_force = g  # * 1 kg
 # functions for conversions that are not linear
 
 
-def convert_temperature(val, old_scale, new_scale):
+def convert_temperature(val: npt.ArrayLike, old_scale: str, new_scale: str) -> Any:
     """
     Convert from a temperature scale to another one among Celsius, Kelvin,
     Fahrenheit, and Rankine scales.
@@ -285,7 +292,7 @@ def convert_temperature(val, old_scale, new_scale):
 # optics
 
 
-def lambda2nu(lambda_):
+def lambda2nu(lambda_: npt.ArrayLike) -> Any:
     """
     Convert wavelength to optical frequency
 
@@ -314,7 +321,7 @@ def lambda2nu(lambda_):
     return c / _np.asanyarray(lambda_)
 
 
-def nu2lambda(nu):
+def nu2lambda(nu: npt.ArrayLike) -> Any:
     """
     Convert optical frequency to wavelength.
 


### PR DESCRIPTION
#### What does this implement/fix?
This PR adds type annotations for the `scipy.constants` sub-package. 

Most functions were pretty straightforward to annotate here, but there are a couple of cases that woud require an overload to get right, _e.g._ `convert_temperature` which returns either an array or a scalar depending on the dimensionality of the input. As `@typing.overload` can give rise to quite a bit of visual clutter when used for inline annotations, I've neglected its usage and annotated the respective functions as returning `Any` for now (this decision is very much open to discussion).

#### Reference issue
n.a.