### PR TITLE
BUG: Fix dual_annealing bounds test

### DIFF
--- a/scipy/optimize/tests/test__dual_annealing.py
+++ b/scipy/optimize/tests/test__dual_annealing.py
@@ -362,6 +362,6 @@ class TestDualAnnealing:
 
         # test that found minima, function evaluations and iterations match
         assert_allclose(ret_bounds_class.x, ret_bounds_list.x, atol=1e-8)
-        assert_allclose(ret_bounds_class.x, np.arange(-2, 3), atol=1e-8)
+        assert_allclose(ret_bounds_class.x, np.arange(-2, 3), atol=1e-7)
         assert_allclose(ret_bounds_list.fun, ret_bounds_class.fun, atol=1e-9)
         assert ret_bounds_list.nfev == ret_bounds_class.nfev


### PR DESCRIPTION
#### Reference issue
Closes #15670 
Only change is to increase tolerance for finding the global optimum at the boundary of the feasible space from 1e-8 to 1e-7.