### PR TITLE
BUG: fix test fail in test_propack.py (loosen atol)

### DIFF
--- a/scipy/sparse/linalg/tests/test_propack.py
+++ b/scipy/sparse/linalg/tests/test_propack.py
@@ -115,7 +115,7 @@ def test_examples(precision, irl):
     # with BLIS, Netlib, and MKL+AVX512 - see
     # https://github.com/conda-forge/scipy-feedstock/pull/198#issuecomment-999180432
     atol = {
-        'single': 1.2e-4,
+        'single': 1.3e-4,
         'double': 1e-9,
         'complex8': 1e-3,
         'complex16': 1e-9,


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes gh-15700
#### What does this implement/fix?
<!--Please explain your changes.-->
Loosened atol from 1.2e-4 to 1.3e-4 to let test case pass
#### Additional information
<!--Any additional information you think is important.-->
