### PR TITLE
ENH: stats: add axis, nan_policy, masked array support to kstat, kstatvar

### DIFF
--- a/scipy/stats/_axis_nan_policy.py
+++ b/scipy/stats/_axis_nan_policy.py
@@ -235,19 +235,24 @@ def _add_reduced_axes(res, reduced_axes, keepdims):
             if keepdims else res)
 
 
-# Standard docstring / signature entries for `axis` and `nan_policy`
+# Standard docstring / signature entries for `axis`, `nan_policy`, `keepdims`
 _name = 'axis'
-_type = "int or None, default: 0"
 _desc = (
     """If an int, the axis of the input along which to compute the statistic.
 The statistic of each axis-slice (e.g. row) of the input will appear in a
 corresponding element of the output.
 If ``None``, the input will be raveled before computing the statistic."""
     .split('\n'))
-_axis_parameter_doc = Parameter(_name, _type, _desc)
-_axis_parameter = inspect.Parameter(_name,
-                                    inspect.Parameter.KEYWORD_ONLY,
-                                    default=0)
+
+
+def _get_axis_params(default_axis=0, _name=_name, _desc=_desc):  # bind NOW
+    _type = f"int or None, default: {default_axis}"
+    _axis_parameter_doc = Parameter(_name, _type, _desc)
+    _axis_parameter = inspect.Parameter(_name,
+                                        inspect.Parameter.KEYWORD_ONLY,
+                                        default=default_axis)
+    return _axis_parameter_doc, _axis_parameter
+
 
 _name = 'nan_policy'
 _type = "{'propagate', 'omit', 'raise'}"
@@ -282,7 +287,7 @@ _keepdims_parameter = inspect.Parameter(_name,
 
 _standard_note_addition = (
     """\nBeginning in SciPy 1.9, ``np.matrix`` inputs (not recommended for new
-code) are converted to ``np.ndarray``s before the calculation is performed. In
+code) are converted to ``np.ndarray`` before the calculation is performed. In
 this case, the output will be a scalar or ``np.ndarray`` of appropriate shape
 rather than a 2D ``np.matrix``. Similarly, while masked elements of masked
 arrays are ignored, the output will be a scalar or ``np.ndarray`` rather than a
@@ -549,6 +554,7 @@ def _axis_nan_policy_factory(tuple_to_result, default_axis=0,
             res = _add_reduced_axes(res, reduced_axes, keepdims)
             return tuple_to_result(*res)
 
+        _axis_parameter_doc, _axis_parameter = _get_axis_params(default_axis)
         doc = FunctionDoc(axis_nan_policy_wrapper)
         parameter_names = [param.name for param in doc['Parameters']]
         if 'axis' in parameter_names:

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -211,6 +211,9 @@ def mvsdist(data):
     return mdist, vdist, sdist
 
 
+@_axis_nan_policy_factory(
+    lambda x: x, result_to_tuple=lambda x: (x,), n_outputs=1
+)
 def kstat(data, n=2):
     r"""
     Return the nth k-statistic (1<=n<=4 so far).
@@ -307,6 +310,9 @@ def kstat(data, n=2):
         raise ValueError("Should not be here.")
 
 
+@_axis_nan_policy_factory(
+    lambda x: x, result_to_tuple=lambda x: (x,), n_outputs=1
+)
 def kstatvar(data, n=2):
     r"""Return an unbiased estimator of the variance of the k-statistic.
 

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -212,7 +212,7 @@ def mvsdist(data):
 
 
 @_axis_nan_policy_factory(
-    lambda x: x, result_to_tuple=lambda x: (x,), n_outputs=1
+    lambda x: x, result_to_tuple=lambda x: (x,), n_outputs=1, default_axis=None
 )
 def kstat(data, n=2):
     r"""
@@ -311,7 +311,7 @@ def kstat(data, n=2):
 
 
 @_axis_nan_policy_factory(
-    lambda x: x, result_to_tuple=lambda x: (x,), n_outputs=1
+    lambda x: x, result_to_tuple=lambda x: (x,), n_outputs=1, default_axis=None
 )
 def kstatvar(data, n=2):
     r"""Return an unbiased estimator of the variance of the k-statistic.

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -28,6 +28,8 @@ axis_nan_policy_cases = [
     (stats.hmean, tuple(), dict(), 1, 1, False, lambda x: (x,)),
     (stats.kurtosis, tuple(), dict(), 1, 1, False, lambda x: (x,)),
     (stats.skew, tuple(), dict(), 1, 1, False, lambda x: (x,)),
+    (stats.kstat, tuple(), dict(), 1, 1, False, lambda x: (x,)),
+    (stats.kstatvar, tuple(), dict(), 1, 1, False, lambda x: (x,)),
 ]
 
 # If the message is one of those expected, put nans in
@@ -46,7 +48,8 @@ too_small_messages = {"The input contains nan",  # for nan_policy="raise"
                       "At least one observation is required",
                       "zero-size array to reduction operation maximum",
                       "`x` and `y` must be of nonzero size.",
-                      "The exact distribution of the Wilcoxon test"}
+                      "The exact distribution of the Wilcoxon test",
+                      "Data input must not be empty"}
 
 
 def _mixed_data_generator(n_samples, n_repetitions, axis, rng,

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -411,6 +411,21 @@ def test_keepdims(hypotest, args, kwds, n_samples, unpacker,
             assert_equal(rn, rn_base)
 
 
+@pytest.mark.parametrize(("fun", "nsamp"),
+                         [(stats.kstat, 1),
+                          (stats.kstatvar, 1)])
+def test_hypotest_back_compat_no_axis(fun, nsamp):
+    m, n = 8, 9
+
+    rng = np.random.default_rng(0)
+    x = rng.random((nsamp, m, n))
+    res = fun(*x)
+    res2 = fun(*x, _no_deco=True)
+    res3 = fun([xi.ravel() for xi in x])
+    assert_equal(res, res2)
+    assert_equal(res, res3)
+
+
 @pytest.mark.parametrize(("axis"), (0, 1, 2))
 def test_axis_nan_policy_decorated_positional_axis(axis):
     # Test for correct behavior of function decorated with


### PR DESCRIPTION
#### Reference issue
gh-14651

#### What does this implement/fix?
Adds support for `axis`, `nan_policy`, and `keepdims` parameters to `stats.kstat` and `kstatvar`.

#### Additional information
Previously, these functions didn't have `axis`, `nan_policy`, or masked array support, so I think it's a pretty clear win. 

At some point, someone could pretty easily provide native `axis` support to these functions for a speed boost, but the decorator is fine for now.

Currently, this maintains the default behavior when no axis is provided: default `axis=None`. At some point, we'll want to deprecate calling these without an explicit axis, then after the deprecation cycle, we can change the default axis to 0 and drop the deprecation warning. I think we should wait until the decorator is applied to more functions before we do that. That way all functions with changing default are on the same cycle.

_Note to reviewer: I suggest looking at the last commit separately. Its purpose is to render default axis properly in the documentation._