### PR TITLE
DOC: adjust deprecation messages to specify version 1.11.0

### DIFF
--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -407,8 +407,7 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
     programming solvers in SciPy, especially for large, sparse problems;
     which of these two is faster is problem-dependent.
     The other solvers (`'interior-point'`, `'revised simplex'`, and
-    `'simplex'`) are legacy methods and will be removed in the second release
-    after SciPy 1.9.0.
+    `'simplex'`) are legacy methods and will be removed in SciPy 1.11.0.
 
     Method *highs-ds* is a wrapper of the C++ high performance dual
     revised simplex implementation (HSOL) [13]_, [14]_. Method *highs-ipm*
@@ -604,9 +603,9 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
         sol['success'] = sol['status'] == 0
         return OptimizeResult(sol)
 
-    warn(f"`method='{meth}'` is deprecated and will be removed in the second "
-         "release after SciPy 1.9.0. Please use one of the HiGHS solvers (e.g."
-         " `method='highs'`) in new code.", DeprecationWarning, stacklevel=2)
+    warn(f"`method='{meth}'` is deprecated and will be removed in SciPy "
+         "1.11.0. Please use one of the HiGHS solvers (e.g. "
+         "`method='highs'`) in new code.", DeprecationWarning, stacklevel=2)
 
     iteration = 0
     complete = False  # will become True if solved in presolve

--- a/scipy/optimize/_linprog_doc.py
+++ b/scipy/optimize/_linprog_doc.py
@@ -760,8 +760,8 @@ def _linprog_ip_doc(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
     [4]_.
 
     .. deprecated:: 1.9.0
-        `method='interior-point'` will be removed in the second release after
-        1.9.0. It is replaced by `method='highs'` because the latter is
+        `method='interior-point'` will be removed in SciPy 1.11.0.
+        It is replaced by `method='highs'` because the latter is
         faster and more robust.
 
     Linear programming solves problems of the following form:
@@ -1088,8 +1088,8 @@ def _linprog_rs_doc(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
     equality and inequality constraints using the revised simplex method.
 
     .. deprecated:: 1.9.0
-        `method='revised simplex'` will be removed in the second release after
-        1.9.0. It is replaced by `method='highs'` because the latter is
+        `method='revised simplex'` will be removed in SciPy 1.11.0.
+        It is replaced by `method='highs'` because the latter is
         faster and more robust.
 
     Linear programming solves problems of the following form:
@@ -1274,8 +1274,8 @@ def _linprog_simplex_doc(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
     equality and inequality constraints using the tableau-based simplex method.
 
     .. deprecated:: 1.9.0
-        `method='simplex'` will be removed in the second release after
-        1.9.0. It is replaced by `method='highs'` because the latter is
+        `method='simplex'` will be removed in SciPy 1.11.0.
+        It is replaced by `method='highs'` because the latter is
         faster and more robust.
 
     Linear programming solves problems of the following form:

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -1261,7 +1261,7 @@ class rv_generic:
         .. deprecated:: 1.9.0
            Parameter `n` is replaced by parameter `order` to avoid name
            collisions with the shape parameter `n` of several distributions.
-           Parameter `n` will be removed in the second release after 1.9.0.
+           Parameter `n` will be removed in SciPy 1.11.0.
 
         Parameters
         ----------
@@ -1530,8 +1530,7 @@ class rv_generic:
         .. deprecated:: 1.9.0
            Parameter `alpha` is replaced by parameter `confidence` to avoid
            name collisions with the shape parameter `alpha` of some
-           distributions. Parameter `alpha` will be removed in the second
-           release after 1.9.0.
+           distributions. Parameter `alpha` will be removed in SciPy 1.11.0.
 
         Parameters
         ----------


### PR DESCRIPTION
#### Reference issue
gh-15528
gh-15512
gh-13490

#### What does this implement/fix?
The decision in gh-15528 was to number SciPy versions after 1.9 as 1.1x for the foreseeable future. With that resolved, we can clarify the wording of the deprecation messages that spurred the discussion.

@h-vetinari 
