### PR TITLE
MAINT: sparse.linalg: `bnorm` only calculate once

### DIFF
--- a/scipy/sparse/linalg/_isolve/tests/demo_lgmres.py
+++ b/scipy/sparse/linalg/_isolve/tests/demo_lgmres.py
@@ -17,6 +17,7 @@ f = mm.open(f'{problem}_rhs1.mtx.gz')
 b = np.array(io.mmread(f)).ravel()
 f.close()
 
+bnorm = np.linalg.norm(b)
 count = [0]
 
 
@@ -36,25 +37,25 @@ print(f"Invert {Am.shape[0]} x {Am.shape[1]} matrix; nnz = {Am.nnz}")
 count[0] = 0
 x0, info = la.gmres(A, b, restrt=M, tol=1e-14)
 count_0 = count[0]
-err0 = np.linalg.norm(Am@x0 - b) / np.linalg.norm(b)
-print(f"GMRES({M}): {count_0} matvecs, residual {err0}")
+err0 = np.linalg.norm(Am@x0 - b) / bnorm
+print(f"GMRES({M}): {count_0} matvecs, relative residual: {err0}")
 if info != 0:
     print("Didn't converge")
 
 count[0] = 0
 x1, info = la.lgmres(A, b, inner_m=M-6*2, outer_k=6, tol=1e-14)
 count_1 = count[0]
-err1 = np.linalg.norm(Am@x1 - b) / np.linalg.norm(b)
+err1 = np.linalg.norm(Am@x1 - b) / bnorm
 print(f"LGMRES({M - 2*6}, 6) [same memory req.]: {count_1} "
-      f"matvecs, residual: {err1}")
+      f"matvecs, relative residual: {err1}")
 if info != 0:
     print("Didn't converge")
 
 count[0] = 0
 x2, info = la.lgmres(A, b, inner_m=M-6, outer_k=6, tol=1e-14)
 count_2 = count[0]
-err2 = np.linalg.norm(Am@x2 - b) / np.linalg.norm(b)
+err2 = np.linalg.norm(Am@x2 - b) / bnorm
 print(f"LGMRES({M - 6}, 6) [same subspace size]: {count_2} "
-      f"matvecs, residual: {err2}")
+      f"matvecs, relative residual: {err2}")
 if info != 0:
     print("Didn't converge")


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
For a given right-hand side `b`, `np.linalg.norm(b)` only need to be calculated once in `demo_lgmres.py`. In addition, relative residual is specified.

#### Additional information
<!--Any additional information you think is important.-->
