### PR TITLE
ENH: `scipy.stats.qmc.Sobol`: allow 32 or 64 bit computation

### DIFF
--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -503,11 +503,11 @@ class BenchQMCSobol(Benchmark):
 
     def setup(self, d, base2):
         self.rng = np.random.default_rng(168525179735951991038384544)
-        stats.qmc.Sobol(1)  # make it load direction numbers
+        stats.qmc.Sobol(1, bits=32)  # make it load direction numbers
 
     def time_sobol(self, d, base2):
         # scrambling is happening at init only, not worth checking
-        seq = stats.qmc.Sobol(d, scramble=False, seed=self.rng)
+        seq = stats.qmc.Sobol(d, scramble=False, bits=32, seed=self.rng)
         seq.random_base2(base2)
 
 

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -1223,7 +1223,8 @@ class Sobol(QMCEngine):
     bits : int, optional
         Number of bits of the generator. Control the maximum number of points
         that can be generated, which is ``2**bits``. Maximal value is 64.
-        It also conditions the return type to be either 32 or 64 bits arrays.
+        It also conditions the return dtype to be either ``np.float32``
+        or ``np.float64``.
         Default is None and use 30 bits for backward compatibility.
     seed : {None, int, `numpy.random.Generator`}, optional
         If `seed` is None the `numpy.random.Generator` singleton is used.

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -1223,9 +1223,10 @@ class Sobol(QMCEngine):
     bits : int, optional
         Number of bits of the generator. Control the maximum number of points
         that can be generated, which is ``2**bits``. Maximal value is 64.
-        It also conditions the return dtype to be either ``np.float32``
-        or ``np.float64``.
-        Default is None and use 30 bits for backward compatibility.
+        It also conditions the return dtype to be either ``np.float32`` (for
+        ``0 <= bits <= 32``) or ``np.float64``.
+        Default is None, which for backward compatibility, corresponds to 30
+        and the return dtype is ``np.float64``.
     seed : {None, int, `numpy.random.Generator`}, optional
         If `seed` is None the `numpy.random.Generator` singleton is used.
         If `seed` is an int, a new ``Generator`` instance is used,
@@ -1343,6 +1344,7 @@ class Sobol(QMCEngine):
 
         if self.bits is None:
             self.bits = 30
+            self.dtype_f = np.float64
 
         if self.bits <= 32:
             self.dtype_i = np.uint32
@@ -1385,7 +1387,10 @@ class Sobol(QMCEngine):
         ltm = np.tril(rng_integers(self.rng, 2,
                                    size=(self.d, self.bits, self.bits),
                                    dtype=self.dtype_i))
-        _cscramble(dim=self.d, bits=self.bits, ltm=ltm, sv=self._sv)  # type: ignore[arg-type]
+        _cscramble(
+            dim=self.d, bits=self.bits,  # type: ignore[arg-type]
+            ltm=ltm, sv=self._sv
+        )
 
     def random(self, n: IntNumber = 1) -> np.ndarray:
         """Draw next point(s) in the Sobol' sequence.
@@ -1431,7 +1436,9 @@ class Sobol(QMCEngine):
                     scale=self._scale, sv=self._sv, quasi=self._quasi,
                     sample=sample
                 )
-                sample = np.concatenate([self._first_point, sample])[:n]  # type: ignore[misc]
+                sample = np.concatenate(
+                    [self._first_point, sample]
+                )[:n]  # type: ignore[misc]
         else:
             _draw(
                 n=n, num_gen=self.num_generated - 1, dim=self.d,

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -1224,7 +1224,7 @@ class Sobol(QMCEngine):
         Number of bits of the generator. Control the maximum number of points
         that can be generated, which is ``2**bits``. Maximal value is 64.
         It does not correspond to the return type, which is always
-        ``np.float64`` to prevent points to repeat themselves.
+        ``np.float64`` to prevent points from repeating themselves.
         Default is None, which for backward compatibility, corresponds to 30.
     seed : {None, int, `numpy.random.Generator`}, optional
         If `seed` is None the `numpy.random.Generator` singleton is used.

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -30,7 +30,7 @@ import scipy.stats as stats
 from scipy._lib._util import rng_integers
 from ._sobol import (
     _initialize_v, _cscramble, _fill_p_cumulative, _draw, _fast_forward,
-    _categorize, _initialize_direction_numbers, _MAXDIM
+    _categorize, _MAXDIM
 )
 from ._qmc_cy import (
     _cy_wrapper_centered_discrepancy,
@@ -1335,6 +1335,8 @@ class Sobol(QMCEngine):
             )
 
         self.bits = bits
+        self.dtype_i: type
+        self.dtype_f: type
         if self.bits <= 32:
             self.dtype_i = np.uint32
             self.dtype_f = np.float32
@@ -1391,7 +1393,7 @@ class Sobol(QMCEngine):
             Sobol' sample.
 
         """
-        sample = np.empty((n, self.d), dtype=self.dtype_f)
+        sample: np.ndarray = np.empty((n, self.d), dtype=self.dtype_f)
 
         if n == 0:
             return sample

--- a/scipy/stats/_sobol.pyi
+++ b/scipy/stats/_sobol.pyi
@@ -44,8 +44,6 @@ def _categorize(
     result: np.ndarray
     ) -> None: ...
 
-def _initialize_direction_numbers() -> None: ...
-
 _MAXDIM: Literal[21201]
 _MAXDEG: Literal[18]
 

--- a/scipy/stats/_sobol.pyx
+++ b/scipy/stats/_sobol.pyx
@@ -22,11 +22,6 @@ ctypedef fused uint_32_64:
     cnp.uint64_t
 
 
-ctypedef fused float_32_64:
-    cnp.float32_t
-    cnp.float64_t
-
-
 # Needed to be accessed with python
 cdef extern from *:
     """
@@ -300,16 +295,15 @@ def _draw(
     n,
     num_gen,
     const int dim,
-    scale,
+    const cnp.float64_t scale,
     uint_32_64[:, ::1] sv,
     uint_32_64[::1] quasi,
-    float_32_64[:, ::1] sample
+    cnp.float64_t[:, ::1] sample
 ):
     # necessary wrapper to guide Cython for n, num_gen and scale
     cdef uint_32_64 n_ = n
     cdef uint_32_64 num_gen_ = num_gen
-    cdef float_32_64 scale_ = scale
-    draw(n_, num_gen_, dim, scale_, sv, quasi, sample)
+    draw(n_, num_gen_, dim, scale, sv, quasi, sample)
 
 
 @cython.boundscheck(False)
@@ -318,10 +312,10 @@ cdef void draw(
     const uint_32_64 n,
     const uint_32_64 num_gen,
     const int dim,
-    const float_32_64 scale,
+    const cnp.float64_t scale,
     uint_32_64[:, ::1] sv,
     uint_32_64[::1] quasi,
-    float_32_64[:, ::1] sample
+    cnp.float64_t[:, ::1] sample
 ) nogil:
     cdef int j, l
     cdef uint_32_64 num_gen_loc = num_gen

--- a/scipy/stats/_sobol.pyx
+++ b/scipy/stats/_sobol.pyx
@@ -17,6 +17,16 @@ DEF MAXDIM = 21201  # max number of dimensions
 DEF MAXDEG = 18  # max polynomial degree
 
 
+ctypedef fused uint_32_64:
+    cnp.uint32_t
+    cnp.uint64_t
+
+
+ctypedef fused float_32_64:
+    cnp.float32_t
+    cnp.float64_t
+
+
 # Needed to be accessed with python
 cdef extern from *:
     """
@@ -29,13 +39,32 @@ cdef extern from *:
 _MAXDIM = MAXDIM_DEFINE
 _MAXDEG = MAXDEG_DEFINE
 
-cdef cnp.uint64_t poly[MAXDIM]
-cdef cnp.uint64_t vinit[MAXDIM][MAXDEG]
-
-cdef bint is_initialized = False
+_poly_dict = {}
+_vinit_dict = {}
 
 
-def _initialize_direction_numbers():
+def get_poly_vinit(kind, dtype):
+
+    if kind == 'poly':
+        poly_vinit = _poly_dict.get(dtype)
+    else:
+        poly_vinit = _vinit_dict.get(dtype)
+
+    if poly_vinit is None:
+        _poly_dict[dtype] = np.empty((MAXDIM,), dtype=dtype)
+        _vinit_dict[dtype] = np.empty((MAXDIM, MAXDEG), dtype=dtype)
+
+        _initialize_direction_numbers(_poly_dict[dtype], _vinit_dict[dtype], dtype)
+
+        if kind == 'poly':
+            poly_vinit = _poly_dict.get(dtype)
+        else:
+            poly_vinit = _vinit_dict.get(dtype)
+
+    return poly_vinit
+
+
+def _initialize_direction_numbers(poly, vinit, dtype):
     """Load direction numbers.
 
     Direction numbers obtained using the search criterion D(6)
@@ -88,28 +117,22 @@ def _initialize_direction_numbers():
         np.savez_compressed("./_sobol_direction_numbers", vinit=vs, poly=poly)
 
     """
-    cdef cnp.uint64_t[::1] dns_poly
-    cdef cnp.uint64_t[:, :] dns_vinit
-
-    global is_initialized
-    if not is_initialized:
-        dns = np.load(os.path.join(os.path.dirname(__file__),
-                      "_sobol_direction_numbers.npz"))
-        dns_poly = dns["poly"].astype(np.uint64)
-        dns_vinit = dns["vinit"].astype(np.uint64)
-        for i in range(MAXDIM):
-            poly[i] = dns_poly[i]
-        for i in range(MAXDIM):
-            for j in range(MAXDEG):
-                vinit[i][j] = dns_vinit[i, j]
-        is_initialized = True
+    dns = np.load(os.path.join(os.path.dirname(__file__),
+                  "_sobol_direction_numbers.npz"))
+    dns_poly = dns["poly"].astype(dtype)
+    dns_vinit = dns["vinit"].astype(dtype)
+    for i in range(MAXDIM):
+        poly[i] = dns_poly[i]
+    for i in range(MAXDIM):
+        for j in range(MAXDEG):
+            vinit[i][j] = dns_vinit[i, j]
 
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef int bit_length(const cnp.uint64_t n):
+cdef int bit_length(uint_32_64 n):
     cdef int bits = 0
-    cdef cnp.uint64_t nloc = n
+    cdef uint_32_64 nloc = n
     while nloc != 0:
         nloc >>= 1
         bits += 1
@@ -118,7 +141,7 @@ cdef int bit_length(const cnp.uint64_t n):
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef int low_0_bit(const cnp.uint64_t x) nogil:
+cdef int low_0_bit(uint_32_64 x) nogil:
     """Get the position of the right-most 0 bit for an integer.
 
     Examples:
@@ -152,7 +175,7 @@ cdef int low_0_bit(const cnp.uint64_t x) nogil:
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef int ibits(const cnp.uint64_t x, const int pos, const int length) nogil:
+cdef int ibits(uint_32_64 x, const int pos, const int length) nogil:
     """Extract a sequence of bits from the bit representation of an integer.
 
     Extract the sequence from position `pos` (inclusive) to ``pos + length``
@@ -192,11 +215,19 @@ cdef int ibits(const cnp.uint64_t x, const int pos, const int length) nogil:
 @cython.boundscheck(False)
 @cython.wraparound(False)
 cpdef void _initialize_v(
-    cnp.uint64_t[:, ::1] v, const int dim, const int bits
+    uint_32_64[:, ::1] v, const int dim, const int bits
 ):
     """Initialize matrix of size ``dim * bits`` with direction numbers."""
     cdef int d, i, j, k, m
-    cdef cnp.uint64_t p, newv, pow2
+    cdef uint_32_64 p, newv, pow2
+    cdef uint_32_64[:] poly = get_poly_vinit(
+        'poly',
+        np.uint32 if uint_32_64 is cnp.uint32_t else np.uint64
+    )
+    cdef uint_32_64[:, ::1] vinit = get_poly_vinit(
+        'vinit',
+        np.uint32 if uint_32_64 is cnp.uint32_t else np.uint64
+    )
 
     if dim == 0:
         return
@@ -240,16 +271,16 @@ cpdef void _initialize_v(
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cpdef void _draw(const cnp.uint64_t n,
-                 const cnp.uint64_t num_gen,
+cpdef void _draw(const uint_32_64 n,
+                 const uint_32_64 num_gen,
                  const int dim,
-                 const float scale,
-                 cnp.uint64_t[:, ::1] sv,
-                 cnp.uint64_t[::1] quasi,
-                 cnp.float_t[:, ::1] sample) nogil:
+                 const float_32_64 scale,
+                 uint_32_64[:, ::1] sv,
+                 uint_32_64[::1] quasi,
+                 float_32_64[:, ::1] sample) nogil:
     cdef int j, l
-    cdef cnp.uint64_t num_gen_loc = num_gen
-    cdef cnp.uint64_t i, qtmp
+    cdef uint_32_64 num_gen_loc = num_gen
+    cdef uint_32_64 i, qtmp
 
     for i in range(n):
         l = low_0_bit(num_gen_loc)
@@ -262,14 +293,14 @@ cpdef void _draw(const cnp.uint64_t n,
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cpdef void _fast_forward(const cnp.uint64_t n,
-                         const cnp.uint64_t num_gen,
+cpdef void _fast_forward(const uint_32_64 n,
+                         const uint_32_64 num_gen,
                          const int dim,
-                         cnp.uint64_t[:, ::1] sv,
-                         cnp.uint64_t[::1] quasi) nogil:
+                         uint_32_64[:, ::1] sv,
+                         uint_32_64[::1] quasi) nogil:
     cdef int j, l
-    cdef cnp.uint64_t num_gen_loc = num_gen
-    cdef cnp.uint64_t i
+    cdef uint_32_64 num_gen_loc = num_gen
+    cdef uint_32_64 i
     for i in range(n):
         l = low_0_bit(num_gen_loc)
         for j in range(dim):
@@ -279,11 +310,11 @@ cpdef void _fast_forward(const cnp.uint64_t n,
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef cnp.uint64_t cdot_pow2(cnp.uint64_t[::1] a) nogil:
+cdef uint_32_64 cdot_pow2(uint_32_64[::1] a) nogil:
     cdef int i
     cdef int size = a.shape[0]
-    cdef cnp.uint64_t z = 0
-    cdef cnp.uint64_t pow2 = 1
+    cdef uint_32_64 z = 0
+    cdef uint_32_64 pow2 = 1
     for i in range(size):
         z += a[size - 1 - i] * pow2
         pow2 *= 2
@@ -294,11 +325,11 @@ cdef cnp.uint64_t cdot_pow2(cnp.uint64_t[::1] a) nogil:
 @cython.wraparound(False)
 cpdef void _cscramble(const int dim,
                       const int bits,
-                      cnp.uint64_t[:, :, ::1] ltm,
-                      cnp.uint64_t[:, ::1] sv) nogil:
+                      uint_32_64[:, :, ::1] ltm,
+                      uint_32_64[:, ::1] sv) nogil:
     """Scrambling using (left) linear matrix scramble (LMS)."""
     cdef int d, i, j, k, p
-    cdef cnp.uint64_t l, lsmdp, t1, t2, vdj
+    cdef uint_32_64 l, lsmdp, t1, t2, vdj
 
     # Set diagonals of bits x bits arrays to 1
     for d in range(dim):

--- a/scipy/stats/_sobol.pyx
+++ b/scipy/stats/_sobol.pyx
@@ -121,11 +121,8 @@ def _initialize_direction_numbers(poly, vinit, dtype):
                   "_sobol_direction_numbers.npz"))
     dns_poly = dns["poly"].astype(dtype)
     dns_vinit = dns["vinit"].astype(dtype)
-    for i in range(MAXDIM):
-        poly[i] = dns_poly[i]
-    for i in range(MAXDIM):
-        for j in range(MAXDEG):
-            vinit[i][j] = dns_vinit[i, j]
+    poly[:MAXDIM] = dns_poly[:MAXDIM]
+    vinit[:MAXDIM, :MAXDEG] = dns_vinit[:MAXDIM, :MAXDEG]
 
 
 @cython.boundscheck(False)
@@ -243,7 +240,7 @@ cpdef void _initialize_v(
 
         # First m elements of row d comes from vinit
         for j in range(m):
-            v[d, j] = vinit[d][j]
+            v[d, j] = vinit[d, j]
 
         # Fill in remaining elements of v as in Section 2 (top of pg. 90) of:
         #

--- a/scipy/stats/_sobol.pyx
+++ b/scipy/stats/_sobol.pyx
@@ -146,8 +146,8 @@ def _initialize_direction_numbers(poly, vinit, dtype):
                   "_sobol_direction_numbers.npz"))
     dns_poly = dns["poly"].astype(dtype)
     dns_vinit = dns["vinit"].astype(dtype)
-    poly[:MAXDIM] = dns_poly[:MAXDIM]
-    vinit[:MAXDIM, :MAXDEG] = dns_vinit[:MAXDIM, :MAXDEG]
+    poly[...] = dns_poly
+    vinit[...] = dns_vinit
 
 
 @cython.boundscheck(False)
@@ -264,8 +264,7 @@ cpdef void _initialize_v(
         m = bit_length(p) - 1
 
         # First m elements of row d comes from vinit
-        for j in range(m):
-            v[d, j] = vinit[d, j]
+        v[d, :m] = vinit[d, :m]
 
         # Fill in remaining elements of v as in Section 2 (top of pg. 90) of:
         #

--- a/scipy/stats/_sobol.pyx
+++ b/scipy/stats/_sobol.pyx
@@ -266,15 +266,33 @@ cpdef void _initialize_v(
         pow2 = pow2 << 1
 
 
+def _draw(
+    n,
+    num_gen,
+    const int dim,
+    scale,
+    uint_32_64[:, ::1] sv,
+    uint_32_64[::1] quasi,
+    float_32_64[:, ::1] sample
+):
+    # necessary wrapper to guide Cython for n, num_gen and scale
+    cdef uint_32_64 n_ = n
+    cdef uint_32_64 num_gen_ = num_gen
+    cdef float_32_64 scale_ = scale
+    draw(n_, num_gen_, dim, scale_, sv, quasi, sample)
+
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cpdef void _draw(const uint_32_64 n,
-                 const uint_32_64 num_gen,
-                 const int dim,
-                 const float_32_64 scale,
-                 uint_32_64[:, ::1] sv,
-                 uint_32_64[::1] quasi,
-                 float_32_64[:, ::1] sample) nogil:
+cdef void draw(
+    const uint_32_64 n,
+    const uint_32_64 num_gen,
+    const int dim,
+    const float_32_64 scale,
+    uint_32_64[:, ::1] sv,
+    uint_32_64[::1] quasi,
+    float_32_64[:, ::1] sample
+) nogil:
     cdef int j, l
     cdef uint_32_64 num_gen_loc = num_gen
     cdef uint_32_64 i, qtmp

--- a/scipy/stats/_sobol.pyx
+++ b/scipy/stats/_sobol.pyx
@@ -44,7 +44,28 @@ _vinit_dict = {}
 
 
 def get_poly_vinit(kind, dtype):
+    """Initialize and cache the direction numbers.
 
+    Uses a dictionary to store the arrays. `kind` allows to select which
+    dictionary to pull. The key of each dictionary corresponds to the `dtype`.
+    If the key is not present in any of the dictionary, both dictionaries are
+    initialized with `_initialize_direction_numbers`, for the given `dtype`.
+
+    This is only used during the initialization step in `_initialize_v`.
+
+    Parameters
+    ----------
+    kind : {'poly', 'vinit'}
+        Select which dictionary to pull.
+    dtype : {np.uint32, np.uint64}
+        Which dtype to use.
+
+    Returns
+    -------
+    poly_vinit : np.ndarray
+        Either ``poly`` or ``vinit`` matrix.
+
+    """
     if kind == 'poly':
         poly_vinit = _poly_dict.get(dtype)
     else:
@@ -65,8 +86,17 @@ def get_poly_vinit(kind, dtype):
 
 
 def _initialize_direction_numbers(poly, vinit, dtype):
-    """Load direction numbers.
+    """Load direction numbers into two arrays.
 
+    Parameters
+    ----------
+    poly, vinit : np.ndarray
+        Direction numbers arrays to fill.
+    dtype : {np.uint32, np.uint64}
+        Which dtype to use.
+
+    Notes
+    -----
     Direction numbers obtained using the search criterion D(6)
     up to the dimension 21201. This is the recommended choice by the authors.
 
@@ -155,12 +185,12 @@ cdef int low_0_bit(uint_32_64 x) nogil:
 
     Parameters
     ----------
-    x: int
+    x : int
         An integer.
 
     Returns
     -------
-    position: int
+    position : int
         Position of the right-most 0 bit.
 
     """
@@ -193,16 +223,16 @@ cdef int ibits(uint_32_64 x, const int pos, const int length) nogil:
 
     Parameters
     ----------
-    x: int
+    x : int
         Integer to convert to bit representation.
-    pos: int
+    pos : int
         Starting position of sequence in bit representation of integer.
-    length: int
+    length : int
         Length of sequence (number of bits).
 
     Returns
     -------
-    ibits: int
+    ibits : int
         Integer value corresponding to bit sequence.
 
     """

--- a/scipy/stats/_unuran/unuran_wrapper.pyx.templ
+++ b/scipy/stats/_unuran/unuran_wrapper.pyx.templ
@@ -168,7 +168,9 @@ cdef class _URNG:
     cdef unur_urng *get_qurng(self, size, qmc_engine) except *:
         cdef unur_urng *unuran_urng
         self.i = 0
-        self.qrvs_array = np.ascontiguousarray(qmc_engine.random(size).ravel())
+        self.qrvs_array = np.ascontiguousarray(
+            qmc_engine.random(size).ravel().astype(np.float64)
+        )
         unuran_urng = unur_urng_new(<URNG_FUNCT>self._next_qdouble,
                                     <void *>self)
         return unuran_urng


### PR DESCRIPTION
Follow up of #15647 and part of #14510

Use fused type to either compute on 32 or 64 bits depending on the number of bits selected by the user.
The current implementation allow a variable number of bits in [0, 64]. For bits in [0, 32], this PR use `np.uint32` ~and `np.float32`~ types, while values in [33, 64] use `np.uint64` ~and `np.float64`~.

There is the possibility to only allow 3 values for `bits`. `None, 32, 64`. `None` would use 30 bits for backward compatibility. Either here or latter, we can deprecate the value. I would default to 32 bits as most users would not need to go beyond 2^32 points. This will be slightly more performant.

For now I am using `None` which default to 30 bits.

I am hesitant to add a deprecation warning yet. This would mean updating a few areas in our code. `shgo` and `differential_evolution` are using this and it would be a backward incompatibility. We cannot properly show with a warning because `Sobol`'s arguments are not part of the public API of the optimizers. So it would have to go in the release notes maybe during a few releases before we change this. Thoughts?

(I am waiting for this PR to land to update our release notes as this can change things in different directions.)