### PR TITLE
TST: stats: simplify `check_sample_mean`

### DIFF
--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -148,11 +148,9 @@ def test_cont_basic(distname, arg, sn, n_fit_samples):
 
     rng = np.random.RandomState(765456)
     rvs = distfn.rvs(size=sn, *arg, random_state=rng)
-    sm = rvs.mean()
-    sv = rvs.var()
     m, v = distfn.stats(*arg)
 
-    check_sample_meanvar_(distfn, arg, m, v, sm, sv, sn, distname + 'sample mean test')
+    check_sample_meanvar_(m, v, rvs)
     check_cdf_ppf(distfn, arg, distname)
     check_sf_isf(distfn, arg, distname)
     check_pdf(distfn, arg, distname)
@@ -465,28 +463,18 @@ def test_method_of_moments():
     npt.assert_almost_equal(loc+scale, b, decimal=4)
 
 
-def check_sample_meanvar_(distfn, arg, m, v, sm, sv, sn, msg):
+def check_sample_meanvar_(popmean, popvar, sample):
     # this did not work, skipped silently by nose
-    if np.isfinite(m):
-        check_sample_mean(sm, sv, sn, m)
-    if np.isfinite(v):
-        check_sample_var(sv, sn, v)
+    if np.isfinite(popmean):
+        check_sample_mean(sample, popmean)
+    if np.isfinite(popvar):
+        check_sample_var(sample.var(), len(sample), popvar)
 
 
-def check_sample_mean(sm, v, n, popmean):
-    # from stats._stats_py.ttest_1samp(a, popmean):
-    # Calculates the t-obtained for the independent samples T-test on ONE group
-    # of scores a, given a population mean.
-    #
-    # Returns: t-value, two-tailed prob
-    df = n-1
-    svar = ((n-1)*v) / float(df)    # looks redundant
-    t = (sm-popmean) / np.sqrt(svar*(1.0/n))
-    prob = betainc(0.5*df, 0.5, df/(df + t*t))
-
-    # return t,prob
-    npt.assert_(prob > 0.01, 'mean fail, t,prob = %f, %f, m, sm=%f,%f' %
-                (t, prob, popmean, sm))
+def check_sample_mean(sample, popmean):
+    # Checks for unlikely difference between sample mean and population mean
+    prob = stats.ttest_1samp(sample, popmean).pvalue
+    assert prob > 0.01
 
 
 def check_sample_var(sv, n, popvar):


### PR DESCRIPTION
#### Reference issue
Closes gh-2623

#### What does this implement/fix?
gh-2623 makes two recommendations about the stats distribution test suite:
1. Make it easy to run the test suite with large `n`, and occasionally do so (e.g. when new distributions are added).
2. Consider using equivalence tests (e.g. [TOST](https://en.wikipedia.org/wiki/Equivalence_test) instead of `check_sample_mean`).

This PR doesn't really do either.
1) I think this point is already satisfied. It's as simple as changing [this line](https://github.com/scipy/scipy/blob/4d66d813205fc7280633469b3e2a7276b4dfe72e/scipy/stats/tests/test_continuous_basic.py#L139) and running the test suite. 
2) I've considered this. I don't know that equivalence tests are appropriate. TOST seems great if you want to show that the difference between two population means is small enough to consider them "equivalent". I think the only reasonable definition of "small enough" in our case is _zero_ - the (population) mean of the distribution underlying the random sample should be exactly equal to the distribution's (population) mean. TOST does not help us in this case.

Instead, the PR simplifies `check_sample_mean` to make it more obvious what it is doing: asserting that a one-sample t-test fails to reject the null hypothesis. It's not a very strong test, but it could let us know when something is very wrong. I think that's OK.

The other purpose is to raise awareness about the old issue and get more feedback about whether it can be closed.