### PR TITLE
ENH: stats: replace ncf with Boost non_central_f distribution

### DIFF
--- a/scipy/stats/_boost/__init__.py
+++ b/scipy/stats/_boost/__init__.py
@@ -21,3 +21,9 @@ from scipy.stats._boost.hypergeom_ufunc import (
     _hypergeom_isf, _hypergeom_mean, _hypergeom_variance,
     _hypergeom_skewness, _hypergeom_kurtosis_excess,
 )
+
+from scipy.stats._boost.ncf_ufunc import (
+    _ncf_pdf, _ncf_cdf, _ncf_sf, _ncf_ppf,
+    _ncf_isf, _ncf_mean, _ncf_variance,
+    _ncf_skewness, _ncf_kurtosis_excess,
+)

--- a/scipy/stats/_boost/include/_info.py
+++ b/scipy/stats/_boost/include/_info.py
@@ -13,6 +13,7 @@ _klass_mapper = {
     'binomial': _KlassMap('binom', ('n', 'p')),
     'negative_binomial': _KlassMap('nbinom', ('n', 'p')),
     'hypergeometric': _KlassMap('hypergeom', ('r', 'n', 'N')),
+    'non_central_f': _KlassMap('ncf', ('dfn', 'dfd', 'nc')),
 }
 
 # functions that take ctor params and parameter "x"

--- a/scipy/stats/_boost/meson.build
+++ b/scipy/stats/_boost/meson.build
@@ -48,6 +48,15 @@ binom_ufunc = py3.extension_module('binom_ufunc',
   subdir: 'scipy/stats/_boost'
 )
 
+ncf_ufunc = py3.extension_module('ncf_ufunc',
+  ncf_ufunc_pyx,
+  include_directories: [include, inc_np, inc_boost],
+  cpp_args: [cpp_args, cython_cpp_args],
+  dependencies: [py3_dep],
+  install: true,
+  subdir: 'scipy/stats/_boost'
+)
+
 py3.install_sources([
     '__init__.py'
   ],

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -5930,29 +5930,26 @@ class ncf_gen(rv_continuous):
     def _rvs(self, dfn, dfd, nc, size=None, random_state=None):
         return random_state.noncentral_f(dfn, dfd, nc, size)
 
-    def _pdf_skip(self, x, dfn, dfd, nc):
+    def _pdf(self, x, dfn, dfd, nc):
         # ncf.pdf(x, df1, df2, nc) = exp(nc/2 + nc*df1*x/(2*(df1*x+df2))) *
         #             df1**(df1/2) * df2**(df2/2) * x**(df1/2-1) *
         #             (df2+df1*x)**(-(df1+df2)/2) *
         #             gamma(df1/2)*gamma(1+df2/2) *
         #             L^{v1/2-1}^{v2/2}(-nc*v1*x/(2*(v1*x+v2))) /
         #             (B(v1/2, v2/2) * gamma((v1+v2)/2))
-        n1, n2 = dfn, dfd
-        term = -nc/2+nc*n1*x/(2*(n2+n1*x)) + sc.gammaln(n1/2.)+sc.gammaln(1+n2/2.)
-        term -= sc.gammaln((n1+n2)/2.0)
-        Px = np.exp(term)
-        Px *= n1**(n1/2) * n2**(n2/2) * x**(n1/2-1)
-        Px *= (n2+n1*x)**(-(n1+n2)/2)
-        Px *= sc.assoc_laguerre(-nc*n1*x/(2.0*(n2+n1*x)), n2/2, n1/2-1)
-        Px /= sc.beta(n1/2, n2/2)
-        # This function does not have a return.  Drop it for now, the generic
-        # function seems to work OK.
+        return _boost._ncf_pdf(x, dfn, dfd, nc)
 
     def _cdf(self, x, dfn, dfd, nc):
-        return sc.ncfdtr(dfn, dfd, nc, x)
+        return _boost._ncf_cdf(x, dfn, dfd, nc)
 
     def _ppf(self, q, dfn, dfd, nc):
-        return sc.ncfdtri(dfn, dfd, nc, q)
+        return _boost._ncf_ppf(q, dfn, dfd, nc)
+
+    def _sf(self, x, dfn, dfd, nc):
+        return _boost._ncf_sf(x, dfn, dfd, nc)
+
+    def _isf(self, x, dfn, dfd, nc):
+        return _boost._ncf_isf(x, dfn, dfd, nc)
 
     def _munp(self, n, dfn, dfd, nc):
         val = (dfn * 1.0/dfd)**n
@@ -5961,21 +5958,12 @@ class ncf_gen(rv_continuous):
         val *= sc.hyp1f1(n+0.5*dfn, 0.5*dfn, 0.5*nc)
         return val
 
-    def _stats(self, dfn, dfd, nc):
-        # Note: the rv_continuous class ensures that dfn > 0 when this function
-        # is called, so we don't have  to check for division by zero with dfn
-        # in the following.
-        mu_num = dfd * (dfn + nc)
-        mu_den = dfn * (dfd - 2)
-        mu = np.full_like(mu_num, dtype=np.float64, fill_value=np.inf)
-        np.true_divide(mu_num, mu_den, where=dfd > 2, out=mu)
-
-        mu2_num = 2*((dfn + nc)**2 + (dfn + 2*nc)*(dfd - 2))*(dfd/dfn)**2
-        mu2_den = (dfd - 2)**2 * (dfd - 4)
-        mu2 = np.full_like(mu2_num, dtype=np.float64, fill_value=np.inf)
-        np.true_divide(mu2_num, mu2_den, where=dfd > 4, out=mu2)
-
-        return mu, mu2, None, None
+    def _stats(self, dfn, dfd, nc, moments='mv'):
+        mu = _boost._ncf_mean(dfn, dfd, nc)
+        mu2 = _boost._ncf_variance(dfn, dfd, nc)
+        g1 = _boost._ncf_skewness(dfn, dfd, nc) if 's' in moments else None
+        g2 = _boost._ncf_kurtosis_excess(dfn, dfd, nc) if 'k' in moments else None
+        return mu, mu2, g1, g2
 
 
 ncf = ncf_gen(a=0.0, name='ncf')

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -5962,7 +5962,8 @@ class ncf_gen(rv_continuous):
         mu = _boost._ncf_mean(dfn, dfd, nc)
         mu2 = _boost._ncf_variance(dfn, dfd, nc)
         g1 = _boost._ncf_skewness(dfn, dfd, nc) if 's' in moments else None
-        g2 = _boost._ncf_kurtosis_excess(dfn, dfd, nc) if 'k' in moments else None
+        g2 = _boost._ncf_kurtosis_excess(
+            dfn, dfd, nc) if 'k' in moments else None
         return mu, mu2, g1, g2
 
 

--- a/scipy/stats/meson.build
+++ b/scipy/stats/meson.build
@@ -119,7 +119,8 @@ _stats_gen_pyx = custom_target('_stats_gen_pyx',
     'hypergeom_ufunc.pyx',  # 4 (S_B)
     'nbinom_ufunc.pyx',  # 5 (S_B)
     'templated_pyufunc.pxd',  # 6 (S_B)
-    'unuran_wrapper.pyx'  # 7 (used in stats/_unuran)
+    'unuran_wrapper.pyx',  # 7 (used in stats/_unuran)
+    'ncf_ufunc.pyx'  # 8 (S_B)
   ],
   input: '_generate_pyx.py',
   command: [py3, '@INPUT@', '-o', '@OUTDIR@'],
@@ -137,6 +138,7 @@ beta_ufunc_pyx = cython_stats_gen_cpp.process(_stats_gen_pyx[1])
 binom_ufunc_pyx = cython_stats_gen_cpp.process(_stats_gen_pyx[2])
 hypergeom_ufunc_pyx = cython_stats_gen_cpp.process(_stats_gen_pyx[4])
 nbinom_ufunc_pyx = cython_stats_gen_cpp.process(_stats_gen_pyx[5])
+ncf_ufunc_pyx = cython_stats_gen_cpp.process(_stats_gen_pyx[8])
 # Extra dependency from _lib
 unuran_wrap_pyx = lib_cython_gen.process(_stats_gen_pyx[7])
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -6441,6 +6441,16 @@ def test_ncf_variance():
     assert_allclose(v, 42.75, rtol=1e-14)
 
 
+def test_ncf_cdf_spotcheck():
+    # Regression test for gh-15582 testing against values from R/MATLAB
+    # Generate check_val from R or MATLAB as follows:
+    #          R: pf(20, df1 = 6, df2 = 33, ncp = 30.4) = 0.998921
+    #     MATLAB: ncfcdf(20, 6, 33, 30.4) = 0.998921
+    scipy_val = stats.ncf.cdf(20, 6, 33, 30.4)
+    check_val = 0.998921
+    assert_allclose(check_val, np.round(scipy_val, decimals=6))
+
+
 class TestHistogram:
     def setup_method(self):
         np.random.seed(1234)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes gh-15582
Closes gh-2877

#### What does this implement/fix?
<!--Please explain your changes.-->

- adds Boost implementation of `ncf` to build system and replaces usage in continuous stats distributions
- adds regression test for linked bug

#### Additional information
<!--Any additional information you think is important.-->
