### PR TITLE
[DOC] fix typo in cython optimize help example

### DIFF
--- a/scipy/optimize/cython_optimize/__init__.py
+++ b/scipy/optimize/cython_optimize/__init__.py
@@ -107,7 +107,7 @@ error, and 0 means the solver converged. Continuing from the previous example::
 
 
     # cython brentq solver with full output
-    cdef brent_full_output brentq_full_output_wrapper_example(
+    cdef zeros_full_output brentq_full_output_wrapper_example(
             dict args, double xa, double xb, double xtol, double rtol,
             int mitr):
         cdef test_params myargs = args


### PR DESCRIPTION
- In the "full output" example, I think the return type should be `zeros_full_output` not `brent_full_output` which is undefined

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
no related issues

#### What does this implement/fix?
the example for full output has an undefined return type "`brent_full_output`", but I think it should be the `zeros_full_output` type declared in the `_zeros.pxd`

#### Additional information
This is a documentation fix only, there are no code changes. I believe this PR is correct because this Gist example has `zeros_full_output` and runs without error:
https://colab.research.google.com/gist/mikofski/ac30065073d0d32d6ea3569f6e24e5ec/cython_optimize_brentq_example.ipynb

(note you must log into to Google to run the example)