### PR TITLE
MAINT: stats: resolve discrete rvs dtype platform dependency

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -1106,7 +1106,7 @@ class rv_generic:
             if size == ():
                 vals = int(vals)
             else:
-                vals = vals.astype(int)
+                vals = vals.astype(np.int64)
 
         return vals
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -647,6 +647,15 @@ class TestGeom:
         assert_(isinstance(val, numpy.ndarray))
         assert_(val.dtype.char in typecodes['AllInteger'])
 
+    def test_rvs_9313(self):
+        # previously, RVS were converted to `np.int32` on some platforms,
+        # causing overflow for moderately large integer output (gh-9313).
+        # Check that this is resolved to the extent possible w/ `np.int64`.
+        rng = np.random.default_rng(649496242618848)
+        rvs = stats.geom.rvs(np.exp(-35), size=5, random_state=rng)
+        assert rvs.dtype == np.int64
+        assert np.all(rvs > np.iinfo(np.int32).max)
+
     def test_pmf(self):
         vals = stats.geom.pmf([1, 2, 3], 0.5)
         assert_array_almost_equal(vals, [0.5, 0.25, 0.125])


### PR DESCRIPTION
#### Reference issue
Closes gh-9313
Supersedes gh-10415 and gh-9319.

#### What does this implement/fix?
The behavior of `vals.astype(int)` seems to be platform-dependent. On some machines, this converts `vals` to `dtype('int32')`, which can cause overflows in discrete distribution random variate sampling. I suggest that we consider the platform-dependence of this behavior to be a bug and that we resolve the ambiguity by using `vals.astype(np.int64)` in `stats.rv_generic.rvs`.

There may be a larger issue here (use of `astype(int)` throughout SciPy). If so, please open an issue to discuss more broadly, but the scope of this PR is `stats.rv_generic.rvs`.
