### PR TITLE
DOC: stats.lognorm: rephrase note about parameterization

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -5025,11 +5025,9 @@ class lognorm_gen(rv_continuous):
 
     %(after_notes)s
 
-    A common parametrization for a lognormal random variable ``Y`` is in
-    terms of the mean, ``mu``, and standard deviation, ``sigma``, of the
-    unique normally distributed random variable ``X`` such that exp(X) = Y.
-    This parametrization corresponds to setting ``s = sigma`` and ``scale =
-    exp(mu)``.
+    Suppose a normally distributed random variable ``X`` has  mean ``mu`` and
+    standard deviation ``sigma``. Then ``Y = exp(X)`` is lognormally
+    distributed with ``s = sigma`` and ``scale = exp(mu)``.
 
     %(example)s
 


### PR DESCRIPTION
#### Reference issue
Closes gh-15133

#### What does this implement/fix?
In response to the misunderstanding in gh-15133, @rkern suggested that the note about `lognorm`'s parameterization could be clarified:
> It's certainly likely that a rephrasing of that sentence could be clearer. Perhaps introducing the normally-distributed `X` random variable and its transformation to `Y` first, then talking about the mean and standard deviation of `X`.

This PR attempts to implement that suggestion.