### PR TITLE
DOC: stats.powerlaw: more explicit explanation of support

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -6497,6 +6497,10 @@ class powerlaw_gen(rv_continuous):
 
     %(before_notes)s
 
+    See Also
+    --------
+    pareto
+
     Notes
     -----
     The probability density function for `powerlaw` is:
@@ -6510,6 +6514,11 @@ class powerlaw_gen(rv_continuous):
     `powerlaw` takes ``a`` as a shape parameter for :math:`a`.
 
     %(after_notes)s
+
+    For example, the support of `powerlaw` can be adjusted from the default
+    interval ``[0, 1]`` to the interval ``[c, c+d]`` by setting ``loc=c`` and
+    ``scale=d``. For a power-law distribution with infinite support, see
+    `pareto`.
 
     `powerlaw` is a special case of `beta` with ``b=1``.
 


### PR DESCRIPTION
#### Reference issue
Closes gh-15541

#### What does this implement/fix?
It was suggested in gh-15541 that the documentation of `powerlaw` distribution could explain the support and point to `pareto` as an alternative power-law distribution with infinite support. This PR implements that suggestion.
