### PR TITLE
MAINT: stats.shapiro: subtract median from shapiro input

### DIFF
--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1771,6 +1771,8 @@ def shapiro(x):
     if N < 3:
         raise ValueError("Data must be at least length 3.")
 
+    x -= np.median(x)
+
     a = zeros(N, 'f')
     init = 0
 

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -197,6 +197,23 @@ class TestShapiro:
         assert_almost_equal(pw, 1.0)
         assert_almost_equal(shapiro_test.pvalue, 1.0)
 
+    def test_gh14462(self):
+        # shapiro is theoretically location-invariant, but when the magnitude
+        # of the values is much greater than the variance, there can be
+        # numerical issues. Fixed by subtracting median from the data.
+        # See gh-14462.
+
+        trans_val, maxlog = stats.boxcox([122500, 474400, 110400])
+        res = stats.shapiro(trans_val)
+
+        # Reference from R:
+        # options(digits=16)
+        # x = c(0.00000000e+00, 3.39996924e-08, -6.35166875e-09)
+        # shapiro.test(x)
+        ref = (0.86468431705371, 0.2805581751566)
+
+        assert_allclose(res, ref, rtol=1e-5)
+
 
 class TestAnderson:
     def test_normal(self):


### PR DESCRIPTION
#### Reference issue
Closes gh-14462

#### What does this implement/fix?
gh-14462 reported that `shapiro` returned a negative p-value for certain data because the magnitudes of the values was much greater than the variance. This PR addresses the issue as recommended [here ](https://github.com/scipy/scipy/issues/14462#issuecomment-885789566) - by subtracting the median of the data from the data. 

It is valid to subtract a constant from the data because the statistic is scale and location invariant. From the original paper:
![image](https://user-images.githubusercontent.com/6570539/158127192-7bc5b9e6-6354-4d0d-a7b7-dcfd9a48115a.png)

