### PR TITLE
CI: don't run meson tests on forks and remove skip flags

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   Python-38-dbg:
     name: Python 3.8-dbg
-    if: "github.repository == 'scipy/scipy' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
+    if: "github.repository == 'scipy/scipy' && !contains(github.ref, 'maintenance/') && !contains(github.base_ref, 'maintenance/')"
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   Python-38-dbg:
     name: Python 3.8-dbg
-    if: "github.repository == 'scipy/scipy' && !contains(github.ref, 'maintenance/') && !contains(github.base_ref, 'maintenance/')"
+    if: "(github.repository == 'scipy/scipy' && !contains(github.ref, 'maintenance/') && !contains(github.base_ref, 'maintenance/')) || (github.repository == '')"
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   Python-38-dbg:
     name: Python 3.8-dbg
-    if: "(github.repository == 'scipy/scipy' && !contains(github.ref, 'maintenance/') && !contains(github.base_ref, 'maintenance/')) || (github.repository == '')"
+    if: "github.repository == 'scipy/scipy' || github.repository == ''"
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -26,7 +26,7 @@ jobs:
   test_meson:
     name: Meson build
     # If using act to run CI locally the github object does not exist and the usual skipping should not be enforced
-    if: "github.repository == 'scipy/scipy' && !contains(github.ref, 'maintenance/') && !contains(github.base_ref, 'maintenance/')"
+    if: "(github.repository == 'scipy/scipy' && !contains(github.ref, 'maintenance/') && !contains(github.base_ref, 'maintenance/')) || (github.repository == '')"
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -26,7 +26,7 @@ jobs:
   test_meson:
     name: Meson build
     # If using act to run CI locally the github object does not exist and the usual skipping should not be enforced
-    if: "(github.repository == 'scipy/scipy' && !contains(github.ref, 'maintenance/') && !contains(github.base_ref, 'maintenance/')) || (github.repository == '')"
+    if: "github.repository == 'scipy/scipy' || github.repository == ''"
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -26,7 +26,7 @@ jobs:
   test_meson:
     name: Meson build
     # If using act to run CI locally the github object does not exist and the usual skipping should not be enforced
-    if: "github.repository != '' || github.repository == 'scipy/scipy' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]') && !contains(github.ref, 'maintenance/') && !contains(github.base_ref, 'maintenance/')"
+    if: "github.repository == 'scipy/scipy' && !contains(github.ref, 'maintenance/') && !contains(github.base_ref, 'maintenance/')"
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   test_macos:
     name: macOS Test Matrix
-    if: "(github.repository == 'scipy/scipy' && !contains(github.ref, 'maintenance/') && !contains(github.base_ref, 'maintenance/')) || (github.repository == '')"
+    if: "github.repository == 'scipy/scipy' || github.repository == ''"
     runs-on: macos-latest
     strategy:
       max-parallel: 3

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   test_macos:
     name: macOS Test Matrix
-    if: "github.repository == 'scipy/scipy' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
+    if: "github.repository == 'scipy/scipy' && !contains(github.ref, 'maintenance/') && !contains(github.base_ref, 'maintenance/')"
     runs-on: macos-latest
     strategy:
       max-parallel: 3

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   test_macos:
     name: macOS Test Matrix
-    if: "github.repository == 'scipy/scipy' && !contains(github.ref, 'maintenance/') && !contains(github.base_ref, 'maintenance/')"
+    if: "(github.repository == 'scipy/scipy' && !contains(github.ref, 'maintenance/') && !contains(github.base_ref, 'maintenance/')) || (github.repository == '')"
     runs-on: macos-latest
     strategy:
       max-parallel: 3

--- a/.github/workflows/macos_meson.yml
+++ b/.github/workflows/macos_meson.yml
@@ -22,7 +22,7 @@ jobs:
   test_meson:
     name: Meson build
     # If using act to run CI locally the github object does not exist and the usual skipping should not be enforced
-    if: "github.repository != '' || github.repository == 'scipy/scipy' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
+    if: "github.repository == 'scipy/scipy' && !contains(github.ref, 'maintenance/') && !contains(github.base_ref, 'maintenance/')"
     runs-on: macos-latest
     strategy:
       matrix:

--- a/.github/workflows/macos_meson.yml
+++ b/.github/workflows/macos_meson.yml
@@ -22,7 +22,7 @@ jobs:
   test_meson:
     name: Meson build
     # If using act to run CI locally the github object does not exist and the usual skipping should not be enforced
-    if: "(github.repository == 'scipy/scipy' && !contains(github.ref, 'maintenance/') && !contains(github.base_ref, 'maintenance/')) || (github.repository == '')"
+    if: "github.repository == 'scipy/scipy' || github.repository == ''"
     runs-on: macos-latest
     strategy:
       matrix:

--- a/.github/workflows/macos_meson.yml
+++ b/.github/workflows/macos_meson.yml
@@ -22,7 +22,7 @@ jobs:
   test_meson:
     name: Meson build
     # If using act to run CI locally the github object does not exist and the usual skipping should not be enforced
-    if: "github.repository == 'scipy/scipy' && !contains(github.ref, 'maintenance/') && !contains(github.base_ref, 'maintenance/')"
+    if: "(github.repository == 'scipy/scipy' && !contains(github.ref, 'maintenance/') && !contains(github.base_ref, 'maintenance/')) || (github.repository == '')"
     runs-on: macos-latest
     strategy:
       matrix:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,7 +19,7 @@ jobs:
     name: Meson Windows tests
     # Ensure (a) this doesn't run on forks by default, and
     #        (b) it does run with Act locally (`github` doesn't exist there)
-    if: "github.repository == 'scipy/scipy' && !contains(github.ref, 'maintenance/') && !contains(github.base_ref, 'maintenance/')"
+    if: "(github.repository == 'scipy/scipy' && !contains(github.ref, 'maintenance/') && !contains(github.base_ref, 'maintenance/')) || (github.repository == '')"
     runs-on: windows-2019
     steps:
       - name: Set up Python

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,7 +19,7 @@ jobs:
     name: Meson Windows tests
     # Ensure (a) this doesn't run on forks by default, and
     #        (b) it does run with Act locally (`github` doesn't exist there)
-    if: "github.repository != '' || github.repository == 'scipy/scipy'"
+    if: "github.repository == 'scipy/scipy' && !contains(github.ref, 'maintenance/') && !contains(github.base_ref, 'maintenance/')"
     runs-on: windows-2019
     steps:
       - name: Set up Python

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,7 +19,7 @@ jobs:
     name: Meson Windows tests
     # Ensure (a) this doesn't run on forks by default, and
     #        (b) it does run with Act locally (`github` doesn't exist there)
-    if: "(github.repository == 'scipy/scipy' && !contains(github.ref, 'maintenance/') && !contains(github.base_ref, 'maintenance/')) || (github.repository == '')"
+    if: "github.repository == 'scipy/scipy' || github.repository == ''"
     runs-on: windows-2019
     steps:
       - name: Set up Python


### PR DESCRIPTION
#### Reference issue

Linux, macOS, and Windows meson jobs run on forks.

#### What does this implement/fix?

This PR fixes the meson CI jobs to not run on forks. Also, since GitHub Actions officially has [special flags](https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs) to skip runs, we don't need custom checks for them in the commit message and skip manually.

#### Additional information

N/A