### PR TITLE
DOC: stats.energy_distance: disambiguate definition vs squared energy distance

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8567,7 +8567,7 @@ def energy_distance(u_values, v_values, u_weights=None, v_weights=None):
     independent random variables whose probability distribution is :math:`u`
     (resp. :math:`v`).
 
-    This is the square root of a quantity also referred to as the "energy
+    Sometimes the square of this quantity is referred to as the "energy
     distance" (e.g. in [2]_, [4]_), but as noted in [1]_ and [3]_, this square
     root version satisfies the axioms of a distance function (metric).
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8568,8 +8568,8 @@ def energy_distance(u_values, v_values, u_weights=None, v_weights=None):
     (resp. :math:`v`).
 
     Sometimes the square of this quantity is referred to as the "energy
-    distance" (e.g. in [2]_, [4]_), but as noted in [1]_ and [3]_, this square
-    root version satisfies the axioms of a distance function (metric).
+    distance" (e.g. in [2]_, [4]_), but as noted in [1]_ and [3]_, only the
+    definition above satisfies the axioms of a distance function (metric).
 
     As shown in [2]_, for one-dimensional real-valued variables, the energy
     distance is linked to the non-distribution-free version of the Cramér-von

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8567,6 +8567,10 @@ def energy_distance(u_values, v_values, u_weights=None, v_weights=None):
     independent random variables whose probability distribution is :math:`u`
     (resp. :math:`v`).
 
+    This is the square root of a quantity also referred to as the "energy
+    distance" (e.g. in [2]_, [4]_), but as noted in [1]_ and [3]_, this square
+    root version satisfies the axioms of a distance function (metric).
+
     As shown in [2]_, for one-dimensional real-valued variables, the energy
     distance is linked to the non-distribution-free version of the Cramér-von
     Mises distance:
@@ -8587,12 +8591,12 @@ def energy_distance(u_values, v_values, u_weights=None, v_weights=None):
 
     References
     ----------
-    .. [1] "Energy distance", https://en.wikipedia.org/wiki/Energy_distance
+    .. [1] Rizzo, Szekely "Energy distance." Wiley Interdisciplinary Reviews:
+           Computational Statistics, 8(1):27-38 (2015).
     .. [2] Szekely "E-statistics: The energy of statistical samples." Bowling
            Green State University, Department of Mathematics and Statistics,
            Technical Report 02-16 (2002).
-    .. [3] Rizzo, Szekely "Energy distance." Wiley Interdisciplinary Reviews:
-           Computational Statistics, 8(1):27-38 (2015).
+    .. [3] "Energy distance", https://en.wikipedia.org/wiki/Energy_distance
     .. [4] Bellemare, Danihelka, Dabney, Mohamed, Lakshminarayanan, Hoyer,
            Munos "The Cramer Distance as a Solution to Biased Wasserstein
            Gradients" (2017). :arXiv:`1705.10743`.


### PR DESCRIPTION
#### Reference issue
Closes gh-14161

#### What does this implement/fix?
The quantity returned by `stats.energy_distance` is the square root of a quantity also referred to as the "energy distance". However, only the square root version (as used by SciPy) satisfies all axioms of a distance function / metric. This PR adds a note to disambiguate between the two versions.