### PR TITLE
CI:Pin pytest version to 7.0.1 on Azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -172,7 +172,7 @@ stages:
             curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
             python3.8 get-pip.py && \
             pip3 --version && \
-            pip3 install setuptools==59.6.0 wheel numpy==1.18.5 cython==0.29.18 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath pythran==0.10.0 --user && \
+            pip3 install setuptools==59.6.0 wheel numpy==1.18.5 cython==0.29.18 pybind11 pytest==7.0.1 pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath pythran==0.10.0 --user && \
             apt-get -y install gcc-5 g++-5 gfortran-8 wget && \
             cd .. && \
             mkdir openblas && cd openblas && \
@@ -285,7 +285,7 @@ stages:
         Pillow
         pybind11
         pythran==0.10.0
-        pytest
+        pytest==7.0.1
         pytest-cov
         pytest-env
         pytest-timeout

--- a/ci/azure-travis-template.yaml
+++ b/ci/azure-travis-template.yaml
@@ -72,7 +72,7 @@ steps:
     mpmath
     pythran
     pybind11
-    pytest
+    pytest==7.0.1
     pytest-xdist
   displayName: 'Install common python dependencies'
 - ${{ if eq(parameters.test_mode, 'full') }}:


### PR DESCRIPTION


#### Reference issue
Closes #15780 

#### What does this implement/fix?
It seems that the `conftest.py` is only taken into account in meson builds (I think). Hence I am testing whether adding the markers explicitly to pytest.ini file would help.

