### PR TITLE
Added Legendre form of elliptic integrals of the third kind

### DIFF
--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -64,6 +64,8 @@ Elliptic functions and integrals
    elliprf   -- Completely-symmetric elliptic integral of the first kind.
    elliprg   -- Completely-symmetric elliptic integral of the second kind.
    elliprj   -- Symmetric elliptic integral of the third kind.
+   ellipp    -- Legendre form of complete elliptic integral of the third kind.
+   ellippinc -- Legendre form of incomplete elliptic integral of the third kind.
 
 Bessel functions
 ----------------
@@ -671,6 +673,8 @@ from ._spherical_bessel import (
     spherical_kn
 )
 
+from ._ellipp import ellipp, ellippinc
+
 # Deprecated namespaces, to be removed in v2.0.0
 from . import add_newdocs, basic, orthogonal, specfun, sf_error, spfun_stats
 
@@ -689,6 +693,8 @@ __all__ = _ufuncs.__all__ + _basic.__all__ + _orthogonal.__all__ + [
     'spherical_yn',
     'spherical_in',
     'spherical_kn',
+    'ellipp',
+    'ellippinc'
 ]
 
 from scipy._lib._testutils import PytestTester

--- a/scipy/special/_ellipp.py
+++ b/scipy/special/_ellipp.py
@@ -1,0 +1,27 @@
+import np
+from scipy.special import elliprf, elliprj
+
+__all__ = ["ellipp", "ellippinc"]
+
+def ellipp(n, m):
+    n, m = (np.asarray(x) for x in (n, m))
+    if np.any(m >= 1):
+        raise ValueError("m must be < 1")
+    y = 1 - m
+    rf = elliprf(0, y, 1)
+    rj = elliprj(0, y, 1, 1 - n)
+    return rf + rj * n / 3
+
+
+def ellippinc(phi, n, m):
+    phi, n, m = (np.asarray(x) for x in (phi, n, m))
+    nc = np.floor(phi / np.pi + 0.5)
+    phi -= nc * np.pi
+    sin_phi = np.sin(phi)
+    sin2_phi = sin_phi * sin_phi
+    sin3_phi = sin2_phi * sin_phi
+    x = 1 - sin2_phi
+    y = 1 - m * sin2_phi
+    rf = elliprf(x, y, 1)
+    rj = elliprj(x, y, 1, 1 - n * sin2_phi)
+    return sin_phi * rf + sin3_phi * rj * n / 3

--- a/scipy/special/_ellipp.py
+++ b/scipy/special/_ellipp.py
@@ -1,4 +1,4 @@
-import np
+import numpy as np
 from scipy.special import elliprf, elliprj
 
 __all__ = ["ellipp", "ellippinc"]

--- a/scipy/special/tests/test_ellipp.py
+++ b/scipy/special/tests/test_ellipp.py
@@ -1,0 +1,24 @@
+import numpy as np
+from numpy.testing import assert_allclose
+from scipy.special import ellipp, ellippinc
+
+
+def test_ellipp_sympy():
+    n = np.array([-0.5, 0.0, 0.3, 1.3, -0.7])
+    m = np.array([0.0, 0.2, 0.4, 0.8, 0.5])
+    p_scipy = ellipp(n, m)
+    # p_sympy = np.fromiter((sy.re(sy.elliptic_pi(ni, mi)).evalf()
+    #                        for ni, mi in zip(n, m)), dtype=float)
+    p_sympy = np.array([1.28254983, 1.6596236, 2.14879542, -1.7390616, 1.3902519])
+    assert_allclose(p_scipy, p_sympy)
+
+
+def test_ellippinc_sympy():
+    n = np.array([-0.5, 0.0, 0.3, 1.3, -0.7])
+    m = np.array([0.0, 0.2, 0.4, 0.8, 0.5])
+    phi = np.array([-2.5, 0.0, 0.5, 5.5, 7.2])
+    p_scipy = ellippinc(phi, n, m)
+    # p_sympy = np.fromiter((sy.re(sy.elliptic_pi(ni, phii, mi)).evalf()
+    #                        for ni, phii, mi in zip(n, phi, m)), dtype=float)
+    p_sympy = np.array([0.60501809, 0.0, 0.52106308, -1.24837946, 0.84754152])
+    assert_allclose(p_scipy, p_sympy)


### PR DESCRIPTION
#### Reference issue
Addresses #4452.

#### What does this implement/fix?
This adds the functions `ellipp` and `ellippinc`, the Legendre forms of the complete and incomplete elliptic integrals of the third kind.
