### PR TITLE
DOC: update macOS and Linux contributor docs to use Python 3.9

### DIFF
--- a/doc/source/dev/contributor/quickstart_mac.rst
+++ b/doc/source/dev/contributor/quickstart_mac.rst
@@ -46,7 +46,7 @@ Building SciPy
 
 #. Enter ``conda create --name scipydev`` to create an empty virtual environment named ``scipydev`` (or another name that you prefer). This tells ``conda`` to create a new, empty environment for our packages. Activate the environment with ``conda activate scipydev``. Note that you'll need to have this virtual environment active whenever you want to work with the development version of SciPy.
 
-#. Enter ``conda config --env --add channels conda-forge`` to tell Anaconda the source we want for our packages. Then enter ``conda install python=3.8 numpy pybind11 cython pythran pytest compilers sphinx pydata-sphinx-theme sphinx-panels matplotlib mypy`` to install the following packages:
+#. Enter ``conda config --env --add channels conda-forge`` to tell Anaconda the source we want for our packages. Then enter ``conda install python=3.9 numpy pybind11 cython pythran pytest compilers sphinx pydata-sphinx-theme sphinx-panels matplotlib mypy`` to install the following packages:
 
    * ``numpy pybind11 cython pythran`` are four packages that SciPy depends on.
 

--- a/doc/source/dev/contributor/quickstart_ubuntu.rst
+++ b/doc/source/dev/contributor/quickstart_ubuntu.rst
@@ -45,7 +45,7 @@ Building SciPy
 
       If ``conda`` is not a recognized command, try restarting your terminal. If it is still not recognized, please see "Should I add Anaconda to the macOS or Linux PATH?" in the `Anaconda FAQ`_.
 
-#. Enter ``conda config --env --add channels conda-forge`` to tell Anaconda the source we want for our packages. Then enter ``conda create --name scipydev python=3.8 numpy pybind11 cython pythran pytest gfortran_linux-64 gxx_linux-64 sphinx pydata-sphinx-theme sphinx-panels matplotlib mypy git``. |br| This tells ``conda`` to create a virtual environment named ``scipydev`` (or another name that you prefer) with several packages.
+#. Enter ``conda config --env --add channels conda-forge`` to tell Anaconda the source we want for our packages. Then enter ``conda create --name scipydev python=3.9 numpy pybind11 cython pythran pytest gfortran_linux-64 gxx_linux-64 sphinx pydata-sphinx-theme sphinx-panels matplotlib mypy git``. |br| This tells ``conda`` to create a virtual environment named ``scipydev`` (or another name that you prefer) with several packages.
 
    * ``numpy pybind11 cython pythran`` are four packages that SciPy depends on.
 


### PR DESCRIPTION
This avoids an issue with M1. Python 3.8 had issues on M1 Macbooks, so best to just use 3.9. We do release 3.8 wheels, but IIRC we needed a fix in the wheels repo to make that work. M1 is too new to be using 3.8 in development.

Also update the corresponding Linux instructions while we're at it.

Closes gh-15784

[ci skip]