### PR TITLE
DOC, MAINT: Remove numpydoc submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "doc/sphinxext"]
-	path = doc/sphinxext
-	url = https://github.com/numpy/numpydoc.git
 [submodule "doc/source/_static/scipy-mathjax"]
 	path = doc/source/_static/scipy-mathjax
 	url = https://github.com/scipy/scipy-mathjax.git

--- a/LICENSES_bundled.txt
+++ b/LICENSES_bundled.txt
@@ -1,11 +1,6 @@
 The SciPy repository and source distributions bundle a number of libraries that
 are compatibly licensed.  We list these here.
 
-Name: Numpydoc
-Files: doc/sphinxext/numpydoc/*
-License: 2-clause BSD
-  For details, see doc/sphinxext/LICENSE.txt
-
 Name: scipy-sphinx-theme
 Files: doc/scipy-sphinx-theme/*
 License: 3-clause BSD, PSF and Apache 2.0

--- a/ci/azure-travis-template.yaml
+++ b/ci/azure-travis-template.yaml
@@ -82,7 +82,7 @@ steps:
   - script: pip install pytest-cov coverage codecov
     displayName: 'Install coverage dependencies'
 - ${{ if eq(parameters.refguide_check, true) }}:
-  - script: pip install matplotlib sphinx==3.1
+  - script: pip install matplotlib sphinx==3.1 numpydoc==1.1
     displayName: 'Install documentation dependencies'
   - script: sudo apt-get install -y wamerican-small
     displayName: 'Install word list (for csgraph tutorial)'

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -33,7 +33,6 @@ inspect.isdescriptor = (lambda obj: old_isdesc(obj)
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 
-sys.path.insert(0, os.path.abspath('../sphinxext'))
 sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 
 import numpydoc.docscrape as np_docscrape  # noqa:E402

--- a/doc/source/dev/toolchain.rst
+++ b/doc/source/dev/toolchain.rst
@@ -291,10 +291,6 @@ numpydoc              Whatever recent versions work. >= 0.8.0.
 matplotlib            Generally suggest >= 2.0.
 ====================  =================================================
 
-[The ``numpydoc`` package is also used, but that is currently
-packaged in ``doc/sphinxext``.]
-
-
 .. note::
 
     Developer Note: The versions of ``numpy`` and ``matplotlib`` required have

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -3,4 +3,5 @@
 Sphinx!=3.1.0, !=4.1.0
 pydata-sphinx-theme>=0.6.1
 sphinx-panels>=0.5.2
+numpydoc==1.1
 matplotlib>2

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -43,7 +43,6 @@ import sphinx
 from docutils.parsers.rst import directives
 from pkg_resources import parse_version
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'doc', 'sphinxext'))
 from numpydoc.docscrape_sphinx import get_doc_object
 from numpydoc.docscrape import NumpyDocString  # noqa
 from scipy.stats._distr_params import distcont, distdiscrete  # noqa


### PR DESCRIPTION
This PR updates how the scipy documentation uses numpydoc; removing numpydoc as a git submodule and instead relying on the released version as a dependency. `numpydoc` is already listed as a dependency in most relevant places (pyproject.toml, various `environments` files). This PR completes the process by removing the git submodule and various other manual shims and references.

#### Reference issue
There is no reference issue, but this was discussed in the [scipy community meeting](https://github.com/scipy/archive/blob/ae2e5093822e1b43ea5b39b697552490c40a7e5f/community_meetings/2022_02_16_meeting_minutes.md#agenda).

#### What does this implement/fix?
Updates/simplifies how the numpydoc doc dependency is managed.

#### Additional information
Note that [explicit testing against scipy is part of the release process for numpydoc](https://github.com/numpy/numpydoc/blob/main/RELEASE.rst#introduction).
