### PR TITLE
DOC: misleading use of function tukey (needs alpha parameter)

### DIFF
--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -2173,8 +2173,8 @@ def get_window(window, Nx, fftbins=True):
     - `~scipy.signal.windows.barthann`
     - `~scipy.signal.windows.cosine`
     - `~scipy.signal.windows.exponential`
-    - `~scipy.signal.windows.tukey`
     - `~scipy.signal.windows.taylor`
+    - `~scipy.signal.windows.tukey` (needs alpha)
     - `~scipy.signal.windows.kaiser` (needs beta)
     - `~scipy.signal.windows.kaiser_bessel_derived` (needs beta)
     - `~scipy.signal.windows.gaussian` (needs standard deviation)


### PR DESCRIPTION
DOC: Added docs info about how to use tukey.

The user should provide a tuple with `alpha` parameter.
(without it get_window function returns a ValueError )

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
I've added only the explicit need of providing alpha as argument.
before:
    - `~scipy.signal.windows.tukey`
after:
    - `~scipy.signal.windows.tukey` (needs alpha)

#### Additional information
<!--Any additional information you think is important.-->

