### PR TITLE
DEP: remove n_jobs from cKDTree

### DIFF
--- a/scipy/spatial/_ckdtree.pyx
+++ b/scipy/spatial/_ckdtree.pyx
@@ -382,7 +382,7 @@ cdef class cKDTreeNode:
 
 
 cdef np.intp_t get_num_workers(workers: object, kwargs: dict) except -1:
-    """Handle the workers argument, translating the old n_jobs name"""
+    """Handle the workers argument"""
     if workers is None:
         workers = 1
 
@@ -696,7 +696,7 @@ cdef class cKDTree:
             Number of workers to use for parallel processing. If -1 is given
             all CPU threads are used. Default: 1.
 
-            .. versionchanged:: 1.6.0
+            .. versionchanged:: 1.9.0
                The "n_jobs" argument was renamed "workers". The old name
                "n_jobs" was deprecated in SciPy 1.6.0 and was removed in
                SciPy 1.9.0.
@@ -869,7 +869,7 @@ cdef class cKDTree:
             Number of jobs to schedule for parallel processing. If -1 is given
             all processors are used. Default: 1.
 
-            .. versionchanged:: 1.6.0
+            .. versionchanged:: 1.9.0
                The "n_jobs" argument was renamed "workers". The old name
                "n_jobs" was deprecated in SciPy 1.6.0 and was removed in
                SciPy 1.9.0.

--- a/scipy/spatial/_ckdtree.pyx
+++ b/scipy/spatial/_ckdtree.pyx
@@ -384,14 +384,7 @@ cdef class cKDTreeNode:
 cdef np.intp_t get_num_workers(workers: object, kwargs: dict) except -1:
     """Handle the workers argument, translating the old n_jobs name"""
     if workers is None:
-        if 'n_jobs' in kwargs:
-            warnings.warn(
-                'The n_jobs argument has been renamed "workers". '
-                'The old name "n_jobs" will stop working in SciPy 1.8.0.',
-                DeprecationWarning)
-            workers = kwargs.pop('n_jobs')
-        else:
-            workers = 1
+        workers = 1
 
     if len(kwargs) > 0:
         raise TypeError(
@@ -705,7 +698,8 @@ cdef class cKDTree:
 
             .. versionchanged:: 1.6.0
                The "n_jobs" argument was renamed "workers". The old name
-               "n_jobs" is deprecated and will stop working in SciPy 1.8.0.
+               "n_jobs" was deprecated in SciPy 1.6.0 and was removed in
+               SciPy 1.9.0.
 
         Returns
         -------
@@ -877,7 +871,8 @@ cdef class cKDTree:
 
             .. versionchanged:: 1.6.0
                The "n_jobs" argument was renamed "workers". The old name
-               "n_jobs" is deprecated and will stop working in SciPy 1.8.0.
+               "n_jobs" was deprecated in SciPy 1.6.0 and was removed in
+               SciPy 1.9.0.
 
         return_sorted : bool, optional
             Sorts returned indicies if True and does not sort them if False. If

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -475,23 +475,6 @@ def test_query_ball_point_multithreading(kdtree_type):
             assert_array_equal(l1[i], l3[i])
 
 
-def test_n_jobs():
-    # Test for the deprecated argument name "n_jobs" aliasing "workers"
-    points = np.random.randn(50, 2)
-    T = cKDTree(points)
-    with pytest.deprecated_call(match="n_jobs argument has been renamed"):
-        T.query_ball_point(points, 0.003, n_jobs=1)
-
-    with pytest.deprecated_call(match="n_jobs argument has been renamed"):
-        T.query(points, 1, n_jobs=1)
-
-    with pytest.raises(TypeError, match="Unexpected keyword argument"):
-        T.query_ball_point(points, 0.003, workers=1, n_jobs=1)
-
-    with pytest.raises(TypeError, match="Unexpected keyword argument"):
-        T.query(points, 1, workers=1, n_jobs=1)
-
-
 class two_trees_consistency:
 
     def distance(self, a, b, p):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #15750
#### What does this implement/fix?
<!--Please explain your changes.-->
Remove the keyword argument `n_jobs` from cKDTree as it was due for removal in 1.8.0 but this was missed.
#### Additional information
<!--Any additional information you think is important.-->
