### PR TITLE
DEP: Remove deprecated check for non equidistant time samples in signal.lsim

### DIFF
--- a/scipy/signal/_ltisys.py
+++ b/scipy/signal/_ltisys.py
@@ -2099,6 +2099,10 @@ def lsim(system, U, T, X0=None, interp=True):
 
     dt = T[1] - T[0]
 
+    if not np.allclose(np.diff(T), dt):
+        raise ValueError("Time steps are not equally spaced. Use lsim2 for "
+            "non-uniform timesteps, although may be slow and/or inacurrate ")
+
     if no_input:
         # Zero input: just use matrix exponential
         # take transpose because state is a row vector

--- a/scipy/signal/_ltisys.py
+++ b/scipy/signal/_ltisys.py
@@ -2101,7 +2101,8 @@ def lsim(system, U, T, X0=None, interp=True):
 
     if not np.allclose(np.diff(T), dt):
         raise ValueError("Time steps are not equally spaced. Use lsim2 for "
-            "non-uniform timesteps, although may be slow and/or inacurrate ")
+                         "non-uniform timesteps, although may be slow and/or "
+                         "inacurrate ")
 
     if no_input:
         # Zero input: just use matrix exponential

--- a/scipy/signal/_ltisys.py
+++ b/scipy/signal/_ltisys.py
@@ -2098,10 +2098,6 @@ def lsim(system, U, T, X0=None, interp=True):
         return T, squeeze(yout), squeeze(xout)
 
     dt = T[1] - T[0]
-    if not np.allclose((T[1:] - T[:-1]) / dt, 1.0):
-        warnings.warn("Non-uniform timesteps are deprecated. Results may be "
-                      "slow and/or inaccurate.", DeprecationWarning)
-        return lsim2(system, U, T, X0)
 
     if no_input:
         # Zero input: just use matrix exponential

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -496,7 +496,7 @@ class TestLsim:
 
     def test_non_uniform_time(self):
         system = self.lti_nowarn(-1.,1.,1.,0.)
-        t = np.linspace(10)
+        t = np.linspace(0,1)
         t[3] = 0
         u = np.zeros_like(t)
 

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -495,8 +495,8 @@ class TestLsim:
         assert_almost_equal(y, expected_y)
 
     def test_non_uniform_time(self):
-        system = self.lti_nowarn(-1.,1.,1.,0.)
-        t = np.linspace(0,1)
+        system = self.lti_nowarn(-1.0, 1.0, 1.0, 0.0)
+        t = np.linspace(0, 1)
         t[3] = 0
         u = np.zeros_like(t)
 

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -494,6 +494,15 @@ class TestLsim:
         expected_y = np.exp(-tout)
         assert_almost_equal(y, expected_y)
 
+    def test_non_uniform_time(self):
+        system = self.lti_nowarn(-1.,1.,1.,0.)
+        t = np.linspace(10)
+        t[3] = 0
+        u = np.zeros_like(t)
+
+        with assert_raises(ValueError):
+            tout, y, x = lsim(system, u, t)
+
 
 class Test_lsim2:
 


### PR DESCRIPTION

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes gh-15755

#### What does this fix?
Remove deprecated check for non equidistant time samples in signal.lsim
