### PR TITLE
DEP: add warning for documented-as-deprecated extradoc

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -1921,6 +1921,10 @@ class rv_continuous(rv_generic):
 
         super().__init__(seed)
 
+        if extradoc is not None:
+            warnings.warn("extradoc is deprecated and will be removed in "
+                          "SciPy 1.11.0", DeprecationWarning)
+
         # save the ctor parameters, cf generic freeze
         self._ctor_param = dict(
             momtype=momtype, a=a, b=b, xtol=xtol,
@@ -3048,7 +3052,7 @@ class rv_discrete(rv_generic):
         If not provided, shape parameters will be inferred from
         the signatures of the private methods, ``_pmf`` and ``_cdf`` of
         the instance.
-    extradoc :  str, optional
+    extradoc :  str, optional, deprecated
         This string is used as the last part of the docstring returned when a
         subclass has no docstring of its own. Note: `extradoc` exists for
         backwards compatibility, do not use for new subclasses.
@@ -3158,6 +3162,10 @@ class rv_discrete(rv_generic):
                  shapes=None, extradoc=None, seed=None):
 
         super().__init__(seed)
+
+        if extradoc is not None:
+            warnings.warn("extradoc is deprecated and will be removed in "
+                          "SciPy 1.11.0", DeprecationWarning)
 
         # cf generic freeze
         self._ctor_param = dict(
@@ -3838,6 +3846,10 @@ class rv_sample(rv_discrete):
                  shapes=None, extradoc=None, seed=None):
 
         super(rv_discrete, self).__init__(seed)
+
+        if extradoc is not None:
+            warnings.warn("extradoc is deprecated and will be removed in "
+                          "SciPy 1.11.0", DeprecationWarning)
 
         if values is None:
             raise ValueError("rv_sample.__init__(..., values=None,...)")


### PR DESCRIPTION
Copying from #15748:
> It's been 10 years since extradoc has been deprecated, although in documentation only: https://github.com/scipy/scipy/commit/eb90ace863f0538dcacb67bcf246918037dc298b, see https://github.com/scipy/scipy/blob/v1.8.0/scipy/stats/_distn_infrastructure.py#L1564-L1567 for current location.

> The only use of `extradoc` that I can find outside of `_distn_infrastructure` is the [following](https://github.com/scipy/scipy/blob/v1.8.0/scipy/stats/tests/test_distributions.py#L4721-L4724), which refers to #1842.
> 
> `gamma_gen` nowadays [uses](https://github.com/scipy/scipy/blame/v1.8.0/scipy/stats/_continuous_distns.py#L2701) [`@extend_notes_in_docstring`](https://github.com/scipy/scipy/blob/v1.8.0/scipy/_lib/doccer.py#L126), where `extradoc` doesn't appear. I think we can definitely deprecate it.




Closes #15748