### PR TITLE
BUG: scipy.integrate.simps returns 0 for array x with no span

### DIFF
--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -508,6 +508,8 @@ def simpson(y, x=None, dx=1.0, axis=-1, even='avg'):
     returnshape = 0
     if x is not None:
         x = np.asarray(x)
+        if np.all((x==x[0])):
+            return 0
         if len(x.shape) == 1:
             shapex = [1] * nd
             shapex[axis] = x.shape[0]


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #15721

#### What does this implement/fix?
<!--Please explain your changes.-->
As described in the issue, `scipy.integrate.simps` returns `NaN` for array x with zero span (all same elements). 
Added a piece of code to return 0 whenever x has same elements in it.

<!--#### Additional information-->
<!--Any additional information you think is important.-->
