### PR TITLE
DOC: Import Error in examples

### DIFF
--- a/scipy/optimize/_numdiff.py
+++ b/scipy/optimize/_numdiff.py
@@ -412,7 +412,7 @@ def approx_derivative(fun, x0, method='3-point', rel_step=None, abs_step=None,
     Examples
     --------
     >>> import numpy as np
-    >>> from scipy.optimize import approx_derivative
+    >>> from scipy.optimize._numdiff import approx_derivative
     >>>
     >>> def f(x, c1, c2):
     ...     return np.array([x[0] * np.sin(c1 * x[1]),
@@ -726,7 +726,7 @@ def check_derivative(fun, jac, x0, bounds=(-np.inf, np.inf), args=(),
     Examples
     --------
     >>> import numpy as np
-    >>> from scipy.optimize import check_derivative
+    >>> from scipy.optimize._numdiff import check_derivative
     >>>
     >>>
     >>> def f(x, c1, c2):


### PR DESCRIPTION
Trying to run the two examples fails.

I understand that this is in a private module. It was unclear to me if
those were meant to be public or not.
Alternative is to just remove the imports as those examples test the
functions themselves, and it it is common have  implied imports
