### PR TITLE
DEP: specify version to remove dual_annealing argument 'local_search_options'

### DIFF
--- a/scipy/optimize/_dual_annealing.py
+++ b/scipy/optimize/_dual_annealing.py
@@ -522,8 +522,8 @@ def dual_annealing(func, bounds, args=(), maxiter=1000,
         should be supplied.
 
         .. deprecated:: 1.8.0
-            dual_annealing argument 'local_search_options' is deprecated in
-            favor of 'minimizer_kwargs' and will be removed in SciPy 1.10.0.
+            dual_annealing argument `local_search_options` is deprecated in
+            favor of `minimizer_kwargs` and will be removed in SciPy 1.10.0.
 
     Returns
     -------

--- a/scipy/optimize/_dual_annealing.py
+++ b/scipy/optimize/_dual_annealing.py
@@ -521,6 +521,10 @@ def dual_annealing(func, bounds, args=(), maxiter=1000,
         Backwards compatible flag for `minimizer_kwargs`, only one of these
         should be supplied.
 
+        .. deprecated:: 1.8.0
+            dual_annealing argument 'local_search_options' is deprecated in
+            favor of 'minimizer_kwargs' and will be removed in SciPy 1.10.0.
+
     Returns
     -------
     res : OptimizeResult
@@ -650,7 +654,8 @@ def dual_annealing(func, bounds, args=(), maxiter=1000,
                          "'local_search_options' (deprecated); not both!")
     if local_search_options is not None:
         warnings.warn("dual_annealing argument 'local_search_options' is "
-                      "deprecated in favor of 'minimizer_kwargs'",
+                      "deprecated in favor of 'minimizer_kwargs' and will be "
+                      "removed in SciPy 1.10.0.",
                       category=DeprecationWarning, stacklevel=2)
         minimizer_kwargs = local_search_options
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #15744
#### What does this implement/fix?
<!--Please explain your changes.-->
Specifies which version the deprecated keyword is going to be removed.
#### Additional information
<!--Any additional information you think is important.-->
