### PR TITLE
DOC,MAINT: remove `quad_explain` that has become irrelevant.

### DIFF
--- a/scipy/integrate/__init__.py
+++ b/scipy/integrate/__init__.py
@@ -19,7 +19,6 @@ Integrating functions, given function object
    fixed_quad    -- Integrate func(x) using Gaussian quadrature of order n
    quadrature    -- Integrate with given tolerance using Gaussian quadrature
    romberg       -- Integrate func using Romberg integration
-   quad_explain  -- Print information for use of quad
    newton_cotes  -- Weights and error coefficient for Newton-Cotes integration
    IntegrationWarning -- Warning on issues during integration
    AccuracyWarning  -- Warning on issues during quadrature integration

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -8,8 +8,7 @@ from . import _quadpack
 import numpy
 from numpy import Inf
 
-__all__ = ['quad', 'dblquad', 'tplquad', 'nquad', 'quad_explain',
-           'IntegrationWarning']
+__all__ = ["quad", "dblquad", "tplquad", "nquad", "IntegrationWarning"]
 
 
 error = _quadpack.error
@@ -19,31 +18,6 @@ class IntegrationWarning(UserWarning):
     Warning on issues during integration.
     """
     pass
-
-
-def quad_explain(output=sys.stdout):
-    """
-    Print extra information about integrate.quad() parameters and returns.
-
-    Parameters
-    ----------
-    output : instance with "write" method, optional
-        Information about `quad` is passed to ``output.write()``.
-        Default is ``sys.stdout``.
-
-    Returns
-    -------
-    None
-
-    Examples
-    --------
-    We can show detailed information of the `integrate.quad` function in stdout:
-
-    >>> from scipy.integrate import quad_explain
-    >>> quad_explain()
-
-    """
-    output.write(quad.__doc__)
 
 
 def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
@@ -96,7 +70,6 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
         An estimate of the absolute error in the result.
     infodict : dict
         A dictionary containing additional information.
-        Run scipy.integrate.quad_explain() for more information.
     message
         A convergence message.
     explain
@@ -784,7 +757,7 @@ def nquad(func, ranges, args=None, opts=None, full_output=False):
           - wvar   = None
           - wopts  = None
 
-        For more information on these options, see `quad` and `quad_explain`.
+        For more information on these options, see `quad`.
 
     full_output : bool, optional
         Partial implementation of ``full_output`` from scipy.integrate.quad.

--- a/scipy/integrate/quadpack.py
+++ b/scipy/integrate/quadpack.py
@@ -6,8 +6,12 @@ import warnings
 from . import _quadpack_py
 
 __all__ = [  # noqa: F822
-    'quad', 'dblquad', 'tplquad', 'nquad', 'quad_explain',
-    'IntegrationWarning', 'error'
+    "quad",
+    "dblquad",
+    "tplquad",
+    "nquad",
+    "IntegrationWarning",
+    "error",
 ]
 
 

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -121,7 +121,6 @@ DOCTEST_SKIPLIST = set([
     'scipy.special.sinc',  # comes from numpy
     'scipy.misc.who',  # comes from numpy
     'scipy.optimize.show_options',
-    'scipy.integrate.quad_explain',
     'io.rst',   # XXX: need to figure out how to deal w/ mat files
 ])
 


### PR DESCRIPTION
As far as I can tell this was originally written by Travis in 2001,
before IPython's `?` and Python's help() would show docstring.

Through the years it has slowly mutate to do less and less until
it ended us just printing the docstring to stdout.

I don't believe this is necessary anymore.

This even leads to unnecessary churn, (like #7168, listing this function
as needing a docstring example).

In addition, the implementation is slightly incorrect: having
`sys.stdout` as a default value means it get evaluated at import time,
and this any context manager like contextlib's `redirect_stdout` will not
work as the reference is still to the original stdout. (This being the
main reason I found this while working on my new documentation project,
testing this functions broke the output capturing)

So all in all, I think removal is the right course.

Marked with [skip azp] [skip circle] [skip actions], so here I was on the fence of whether or not if was needed. Let me know if I need to force-push without the markers 


