### PR TITLE
DOC: stats.mood: validity only when observations are unique

### DIFF
--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -2927,6 +2927,9 @@ def mood(x, y, axis=0, alternative="two-sided"):
     resulting z and p values will have shape ``(n0, n2, n3)``.  Note that
     ``n1`` and ``m1`` don't have to be equal, but the other dimensions do.
 
+    In this implementation, the test statistic and p-value are only valid when
+    all observations are unique.
+
     Examples
     --------
     >>> from scipy import stats


### PR DESCRIPTION
#### Reference issue
gh-13730

#### What does this implement/fix?
The `scipy.stats.mood` test statistic (and p-value) is not defined correctly when there are repeated observations / ties, and the fix is not trivial. In the meantime, this documents that the implementation is only valid when all observations are unique.
