### PR TITLE
DOC: fix evaluate_all_bspl example.

### DIFF
--- a/scipy/interpolate/_bspl.pyx
+++ b/scipy/interpolate/_bspl.pyx
@@ -191,15 +191,14 @@ def evaluate_all_bspl(const double[::1] t, int k, double xval, int m, int nu=0):
     Consider a cubic spline
 
     >>> k = 3
-    >>> t = [0., 2., 2., 3., 4.]   # internal knots
+    >>> t = [0., 1., 2., 3., 4.]   # internal knots
     >>> a, b = t[0], t[-1]    # base interval is [a, b)
-    >>> t = [a]*k + t + [b]*k  # add boundary knots
+    >>> t = np.array([a]*k + t + [b]*k)  # add boundary knots
 
     >>> import matplotlib.pyplot as plt
     >>> xx = np.linspace(a, b, 100)
     >>> plt.plot(xx, BSpline.basis_element(t[k:-k])(xx),
-    ...          'r-', lw=5, alpha=0.5)
-    >>> c = ['b', 'g', 'c', 'k']
+    ...          lw=3, alpha=0.5, label='basis_element')
 
     Now we use slide an interval ``t[m]..t[m+1]`` along the base interval
     ``a..b`` and use `evaluate_all_bspl` to compute the restriction of
@@ -209,7 +208,7 @@ def evaluate_all_bspl(const double[::1] t, int k, double xval, int m, int nu=0):
     ...    x1, x2 = t[2*k - i], t[2*k - i + 1]
     ...    xx = np.linspace(x1 - 0.5, x2 + 0.5)
     ...    yy = [evaluate_all_bspl(t, k, x, 2*k - i)[i] for x in xx]
-    ...    plt.plot(xx, yy, c[i] + '--', lw=3, label=str(i))
+    ...    plt.plot(xx, yy, '--', label=str(i))
     ...
     >>> plt.grid(True)
     >>> plt.legend()


### PR DESCRIPTION
1) the first argument of `evaluate_all_bspline` need to be an array and
   not a list, or it crashes:

     File "_bspl.pyx", line 163, in scipy.interpolate._bspl.evaluate_all_bspl
     File "stringsource", line 658, in View.MemoryView.memoryview_cwrapper
     File "stringsource", line 349, in View.MemoryView.memoryview.__cinit__
     TypeError: a bytes-like object is required, not 'list'

So fix it.

2) The initial values were I believe wrong (`2` was present twice)

3) Matplotlib default are sane-er now, so use default color, and reduce
   lw a bit.

4) Also add label for basis element

[ci skip]
[skip azp]
[skip circle]
