### PR TITLE
MAINT: stats.fisher_exact: improve docs and fix bugs

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -4236,6 +4236,15 @@ def pearsonr(x, y, *, alternative='two-sided'):
 def fisher_exact(table, alternative='two-sided'):
     """Perform a Fisher exact test on a 2x2 contingency table.
 
+    The null hypothesis is that the true odds ratio of the populations
+    underlying the observations is one, and the observations were sampled at
+    random from these populations. The statistic returned is the unconditional
+    maximum likelihood estimate of the odds ratio, and the p-value is the
+    probability under the null hypothesis of obtaining a table at least as
+    extreme as the one that was actually observed. There are other possible
+    choices of statistic and two-sided p-value definition associated with
+    Fisher's exact test; please see the Notes for more information.
+
     Parameters
     ----------
     table : array_like of ints
@@ -4244,9 +4253,10 @@ def fisher_exact(table, alternative='two-sided'):
         Defines the alternative hypothesis.
         The following options are available (default is 'two-sided'):
 
-        * 'two-sided'
-        * 'less': one-sided
-        * 'greater': one-sided
+        * 'two-sided': the odds ratio of the underlying population is not one
+        * 'less': the odds ratio of the underlying population is less than one
+        * 'greater': the odds ratio of the underlying population is greater
+          than one
 
         See the Notes for more details.
 
@@ -4255,9 +4265,8 @@ def fisher_exact(table, alternative='two-sided'):
     oddsratio : float
         This is prior odds ratio and not a posterior estimate.
     p_value : float
-        P-value, the probability of obtaining a distribution at least as
-        extreme as the one that was actually observed, assuming that the
-        null hypothesis is true.
+        P-value, the probability under the null hypothesis of obtaining a
+        table at least as extreme as the one that was actually observed.
 
     See Also
     --------
@@ -4273,7 +4282,10 @@ def fisher_exact(table, alternative='two-sided'):
     -----
     *Null hypothesis and p-values*
 
-    The null hypothesis is that the input table is from the hypergeometric
+    The null hypothesis is that the true odds ratio of the populations
+    underlying the observations is one, and the observations were sampled at
+    random from these populations. Equivalently,
+    the null hypothesis is that the input table is from the hypergeometric
     distribution with parameters (as used in `hypergeom`)
     ``M = a + b + c + d``, ``n = a + b`` and ``N = a + c``, where the
     input table is ``[[a, b], [c, d]]``.  This distribution has support
@@ -4461,7 +4473,7 @@ def fisher_exact(table, alternative='two-sided'):
         pexact = hypergeom.pmf(c[0, 0], n1 + n2, n1, n)
         pmode = hypergeom.pmf(mode, n1 + n2, n1, n)
 
-        epsilon = 1 - 1e-4
+        epsilon = 1 - 1e-14
         if np.abs(pexact - pmode) / np.maximum(pexact, pmode) <= 1 - epsilon:
             return oddsratio, 1.
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -4239,7 +4239,7 @@ def fisher_exact(table, alternative='two-sided'):
 
     The null hypothesis is that the true odds ratio of the populations
     underlying the observations is one, and the observations were sampled
-    from these populations under under a condition: the marginals of the
+    from these populations under a condition: the marginals of the
     resulting table must equal those of the observed table. The statistic
     returned is the unconditional maximum likelihood estimate of the odds
     ratio, and the p-value is the probability under the null hypothesis of

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -4465,7 +4465,7 @@ def fisher_exact(table, alternative='two-sided'):
 
     pvalue = min(pvalue, 1.0)
 
-    return oddsratio, pvalue # exact, guess, n1 + n2, n1, n, mode
+    return oddsratio, pvalue
 
 
 class SpearmanRConstantInputWarning(RuntimeWarning):

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -4237,13 +4237,15 @@ def fisher_exact(table, alternative='two-sided'):
     """Perform a Fisher exact test on a 2x2 contingency table.
 
     The null hypothesis is that the true odds ratio of the populations
-    underlying the observations is one, and the observations were sampled at
-    random from these populations. The statistic returned is the unconditional
-    maximum likelihood estimate of the odds ratio, and the p-value is the
-    probability under the null hypothesis of obtaining a table at least as
-    extreme as the one that was actually observed. There are other possible
-    choices of statistic and two-sided p-value definition associated with
-    Fisher's exact test; please see the Notes for more information.
+    underlying the observations is one, and the observations were sampled
+    from these populations under under a condition: the marginals of the
+    resulting table must equal those of the observed table. The statistic
+    returned is the unconditional maximum likelihood estimate of the odds
+    ratio, and the p-value is the probability under the null hypothesis of
+    obtaining a table at least as extreme as the one that was actually
+    observed. There are other possible choices of statistic and two-sided
+    p-value definition associated with Fisher's exact test; please see the
+    Notes for more information.
 
     Parameters
     ----------
@@ -4284,7 +4286,8 @@ def fisher_exact(table, alternative='two-sided'):
 
     The null hypothesis is that the true odds ratio of the populations
     underlying the observations is one, and the observations were sampled at
-    random from these populations. Equivalently,
+    random from these populations under a condition: the marginals of the
+    resulting table must equal those of the observed table. Equivalently,
     the null hypothesis is that the input table is from the hypergeometric
     distribution with parameters (as used in `hypergeom`)
     ``M = a + b + c + d``, ``n = a + b`` and ``N = a + c``, where the

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -537,6 +537,17 @@ class TestFisherExact:
             np.testing.assert_almost_equal(res[1], res_r[1], decimal=11,
                                            verbose=True)
 
+    def test_gh4130(self):
+        # Previously, a fudge factor used to distinguish between theoeretically
+        # and numerically different probability masses was 1e-4; it has been
+        # tightened to fix gh4130. Accuracy checked against R fisher.test.
+        # options(digits=16)
+        # table <- matrix(c(6, 108, 37, 200), nrow = 2)
+        # fisher.test(table, alternative = "t")
+        x = [[6,37], [108, 200]]
+        res = stats.fisher_exact(x)
+        assert_allclose(res[1], 0.005092697748126)
+
     @pytest.mark.slow
     def test_large_numbers(self):
         # Test with some large numbers. Regression test for #1401

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -552,12 +552,12 @@ class TestFisherExact:
         # That package has an (absolute?) fudge factor of 1e-6; too big
         x = [[22, 0], [0, 102]]
         res = stats.fisher_exact(x)
-        assert_allclose(res[1], 7.175067e-25)
+        assert_allclose(res[1], 7.175066786244549e-25)
 
         # case from https://github.com/brentp/fishers_exact_test/issues/1
         x = [[94, 48], [3577, 16988]]
         res = stats.fisher_exact(x)
-        assert_allclose(res[1], 2.069356e-37)
+        assert_allclose(res[1], 2.069356340993818e-37)
 
     def test_gh9231(self):
         # Previously, fisher_exact was extremely slow for this table

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -548,6 +548,13 @@ class TestFisherExact:
         res = stats.fisher_exact(x)
         assert_allclose(res[1], 0.005092697748126)
 
+    def test_gh9231(self):
+        # Previously, fisher_exact was extremely slow for this table
+        # As reported in gh-9231, the p-value should be very nearly zero
+        x = [[5829225, 5692693], [5760959, 5760959]]
+        res = stats.fisher_exact(x)
+        assert_allclose(res[1], 0, atol=1e-170)
+
     @pytest.mark.slow
     def test_large_numbers(self):
         # Test with some large numbers. Regression test for #1401

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -548,6 +548,17 @@ class TestFisherExact:
         res = stats.fisher_exact(x)
         assert_allclose(res[1], 0.005092697748126)
 
+        # case from https://github.com/brentp/fishers_exact_test/issues/27
+        # That package has an (absolute?) fudge factor of 1e-6; too big
+        x = [[22, 0], [0, 102]]
+        res = stats.fisher_exact(x)
+        assert_allclose(res[1], 7.175067e-25)
+
+        # case from https://github.com/brentp/fishers_exact_test/issues/1
+        x = [[94, 48], [3577, 16988]]
+        res = stats.fisher_exact(x)
+        assert_allclose(res[1], 2.069356e-37)
+
     def test_gh9231(self):
         # Previously, fisher_exact was extremely slow for this table
         # As reported in gh-9231, the p-value should be very nearly zero

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -544,7 +544,7 @@ class TestFisherExact:
         # options(digits=16)
         # table <- matrix(c(6, 108, 37, 200), nrow = 2)
         # fisher.test(table, alternative = "t")
-        x = [[6,37], [108, 200]]
+        x = [[6, 37], [108, 200]]
         res = stats.fisher_exact(x)
         assert_allclose(res[1], 0.005092697748126)
 


### PR DESCRIPTION
#### Reference issue
Closes gh-4130
Closes gh-9231

#### What does this implement/fix?
gh-4130 was originally about inaccurate p-values due to a large fudge factor of 1e-4 used in the implementation. IIUC, the fudge factor is a relative tolerance used to compare numerically distinct but theoeretically equal probability masses. The `hypergeom` distribution is from Boost now, so it is more accurate that what we had before. Perhaps 1e-14 is too tight, but in this case, I think we're looking at small inaccuracies in the reported p-value.

Most of the discussion in that issue is actually about confusion surrounding the definition of two-sided p-value, so I added some additional information to the documentation, including a more intutitive (but also accurate) explanation of the null hypothesis.

gh-9231 exposed a bug that made `fisher_exact` very slow in some cases. This PR fixes it by replacing the binary search in `fisher_exact` with the one written for `binomtest`.
