### PR TITLE
BUG: fix a bug in _ttest_finish() from scipy.stats 

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -5861,9 +5861,9 @@ def _ttest_finish(df, t, alternative):
     # can be shared between the ``stats`` and ``mstats`` versions.
 
     if alternative == 'less':
-        pval = special.stdtr(df, t)
-    elif alternative == 'greater':
         pval = special.stdtr(df, -t)
+    elif alternative == 'greater':
+        pval = special.stdtr(df, t)
     elif alternative == 'two-sided':
         pval = special.stdtr(df, -np.abs(t))*2
     else:


### PR DESCRIPTION
## Describe the Issue
I think there is a mistake about the sign of the variable 't' in _ttest_finish(). The codes run well but will **produce wrong results** in paired T-test (e.g., scipy.stats.ttest_rel(), scipy.stats.ttest_ind()). Specifically, the p-values of the alternative with 'greater' and 'less' are reversed due to the wrong sign of the variable 't'.

## Reproducing Code Example
```
import numpy as np
x = np.random.normal(10,1,10)
y = np.zeros(10)
scipy.stats.ttest_rel(x, y, alternative='less')
```
In this case, the null hypothesis is x<y, which should be rejected (with a very small p-value). However, the generated p-value is nearly 1, which is false. 

```
import numpy as np
x = np.random.normal(10,1,10)
y = np.zeros(10)
scipy.stats.ttest_rel(x, y, alternative='greater')
```
In this case, the null hypothesis is x>y, which should not be rejected. However, the generated p-value is nearly 0, which is false. 

In fact, their results are reversed.

## SciPy/NumPy/Python version information
1.8.0 1.22.3 sys.version_info(major=3, minor=8, micro=10, releaselevel='final', serial=0)