### PR TITLE
DEP: add actual DeprecationWarning for sym_pos-keyword of scipy.linalg.solve

### DIFF
--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -167,9 +167,9 @@ def solve(a, b, sym_pos=False, lower=False, overwrite_a=False,
 
     # Backwards compatibility - old keyword.
     if sym_pos:
-        message = ("The `sym_pos` keyword is deprecated and should be "
-                   "replaced by using `assume_a = 'pos'`. `sym_pos` will be "
-                   "removed in SciPy 1.11.0.")
+        message = ("The 'sym_pos' keyword is deprecated and should be "
+                   "replaced by using 'assume_a = \"pos\"'. 'sym_pos' will be"
+                   " removed in SciPy 1.11.0.")
         warn(message, DeprecationWarning, stacklevel=2)
         assume_a = 'pos'
 

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -167,7 +167,7 @@ def solve(a, b, sym_pos=False, lower=False, overwrite_a=False,
 
     # Backwards compatibility - old keyword.
     if sym_pos:
-        message = ("This key is deprecated and ``assume_a = 'pos'`` keyword is"
+        message = ("This key is deprecated and `assume_a = 'pos'` keyword is"
                    " recommended instead. The functionality is the same. "
                    "`sym_pos` will be removed in SciPy 1.11.0.")
         warn(message, DeprecationWarning, stacklevel=2)

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -72,9 +72,10 @@ def solve(a, b, sym_pos=False, lower=False, overwrite_a=False,
         Assume `a` is symmetric and positive definite.
 
         .. deprecated:: 0.19.0
-        This key is deprecated and ``assume_a = 'pos'`` keyword is recommended
-        instead. The functionality is the same. `sym_pos` will be removed in
-        SciPy 1.11.0.
+           This key is deprecated and ``assume_a = 'pos'`` keyword is recommended
+           instead. The functionality is the same. `sym_pos` will be removed in
+           SciPy 1.11.0.
+
     lower : bool, optional
         If True, only the data contained in the lower triangle of `a`. Default
         is to use upper triangle. (ignored for ``'gen'``)

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -68,10 +68,13 @@ def solve(a, b, sym_pos=False, lower=False, overwrite_a=False,
         Square input data
     b : (N, NRHS) array_like
         Input data for the right hand side.
-    sym_pos : bool, optional
-        Assume `a` is symmetric and positive definite. This key is deprecated
-        and assume_a = 'pos' keyword is recommended instead. The functionality
-        is the same. It will be removed in the future.
+    sym_pos : bool, optional, deprecated
+        Assume `a` is symmetric and positive definite.
+
+        .. deprecated:: 0.19.0
+        This key is deprecated and ``assume_a = 'pos'`` keyword is recommended
+        instead. The functionality is the same. `sym_pos` will be removed in
+        SciPy 1.11.0.
     lower : bool, optional
         If True, only the data contained in the lower triangle of `a`. Default
         is to use upper triangle. (ignored for ``'gen'``)
@@ -164,6 +167,10 @@ def solve(a, b, sym_pos=False, lower=False, overwrite_a=False,
 
     # Backwards compatibility - old keyword.
     if sym_pos:
+        message = ("This key is deprecated and ``assume_a = 'pos'`` keyword is"
+                   " recommended instead. The functionality is the same. "
+                   "`sym_pos` will be removed in SciPy 1.11.0.")
+        warn(message, DeprecationWarning, stacklevel=2)
         assume_a = 'pos'
 
     if assume_a not in ('gen', 'sym', 'her', 'pos'):

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -72,9 +72,8 @@ def solve(a, b, sym_pos=False, lower=False, overwrite_a=False,
         Assume `a` is symmetric and positive definite.
 
         .. deprecated:: 0.19.0
-           This key is deprecated and ``assume_a = 'pos'`` keyword is
-           recommended instead. The functionality is the same. `sym_pos`
-           will be removed in SciPy 1.11.0.
+            This keyword is deprecated and should be replaced by using
+           ``assume_a = 'pos'``. `sym_pos` will be removed in SciPy 1.11.0.
 
     lower : bool, optional
         If True, only the data contained in the lower triangle of `a`. Default
@@ -168,9 +167,9 @@ def solve(a, b, sym_pos=False, lower=False, overwrite_a=False,
 
     # Backwards compatibility - old keyword.
     if sym_pos:
-        message = ("This key is deprecated and `assume_a = 'pos'` keyword is"
-                   " recommended instead. The functionality is the same. "
-                   "`sym_pos` will be removed in SciPy 1.11.0.")
+        message = ("The `sym_pos` keyword is deprecated and should be "
+                   "replaced by using `assume_a = 'pos'`. `sym_pos` will be "
+                   "removed in SciPy 1.11.0.")
         warn(message, DeprecationWarning, stacklevel=2)
         assume_a = 'pos'
 

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -72,9 +72,9 @@ def solve(a, b, sym_pos=False, lower=False, overwrite_a=False,
         Assume `a` is symmetric and positive definite.
 
         .. deprecated:: 0.19.0
-           This key is deprecated and ``assume_a = 'pos'`` keyword is recommended
-           instead. The functionality is the same. `sym_pos` will be removed in
-           SciPy 1.11.0.
+           This key is deprecated and ``assume_a = 'pos'`` keyword is
+           recommended instead. The functionality is the same. `sym_pos`
+           will be removed in SciPy 1.11.0.
 
     lower : bool, optional
         If True, only the data contained in the lower triangle of `a`. Default

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -618,6 +618,20 @@ class TestSolve:
             b = random([n, 3])
             x = solve(a, b)
             assert_array_almost_equal(dot(a, x), b)
+    
+    def test_sym_pos_dep(self):
+        n = 20
+        a = random([n, n])
+        b = random([n])
+        for i in range(n):
+            a[i, i] = abs(20*(.1+a[i, i]))
+            for j in range(i):
+                a[i, j] = a[j, i]
+        with pytest.warns(
+                DeprecationWarning,
+                match="The `sym_pos` keyword is deprecated",
+            ):
+                solve(a, b, sym_pos=1)
 
     def test_random_sym(self):
         n = 20
@@ -628,11 +642,7 @@ class TestSolve:
                 a[i, j] = a[j, i]
         for i in range(4):
             b = random([n])
-            with pytest.warns(
-                DeprecationWarning,
-                match="The `sym_pos` keyword is deprecated",
-            ):
-                x = solve(a, b, sym_pos=1)
+            x = solve(a, b, assume_a="pos")
             assert_array_almost_equal(dot(a, x), b)
 
     def test_random_sym_complex(self):
@@ -645,11 +655,7 @@ class TestSolve:
                 a[i, j] = conjugate(a[j, i])
         b = random([n])+2j*random([n])
         for i in range(2):
-            with pytest.warns(
-                DeprecationWarning,
-                match="The `sym_pos` keyword is deprecated",
-            ):
-                x = solve(a, b, sym_pos=1)
+            x = solve(a, b, assume_a="pos")
             assert_array_almost_equal(dot(a, x), b)
 
     def test_check_finite(self):

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -630,7 +630,7 @@ class TestSolve:
             b = random([n])
             with pytest.warns(
                 DeprecationWarning,
-                match="This key is deprecated and ``assume_a = 'pos'``",
+                match="This key is deprecated and `assume_a = 'pos'`",
             ):
                 x = solve(a, b, sym_pos=1)
             assert_array_almost_equal(dot(a, x), b)
@@ -647,7 +647,7 @@ class TestSolve:
         for i in range(2):
             with pytest.warns(
                 DeprecationWarning,
-                match="This key is deprecated and ``assume_a = 'pos'``",
+                match="This key is deprecated and `assume_a = 'pos'`",
             ):
                 x = solve(a, b, sym_pos=1)
             assert_array_almost_equal(dot(a, x), b)

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -630,7 +630,7 @@ class TestSolve:
             b = random([n])
             with pytest.warns(
                 DeprecationWarning,
-                match="This key is deprecated and `assume_a = 'pos'`",
+                match="The `sym_pos` keyword is deprecated",
             ):
                 x = solve(a, b, sym_pos=1)
             assert_array_almost_equal(dot(a, x), b)
@@ -647,7 +647,7 @@ class TestSolve:
         for i in range(2):
             with pytest.warns(
                 DeprecationWarning,
-                match="This key is deprecated and `assume_a = 'pos'`",
+                match="The `sym_pos` keyword is deprecated",
             ):
                 x = solve(a, b, sym_pos=1)
             assert_array_almost_equal(dot(a, x), b)

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -628,7 +628,11 @@ class TestSolve:
                 a[i, j] = a[j, i]
         for i in range(4):
             b = random([n])
-            x = solve(a, b, sym_pos=1)
+            with pytest.warns(
+                DeprecationWarning,
+                match="This key is deprecated and ``assume_a = 'pos'``",
+            ):
+                x = solve(a, b, sym_pos=1)
             assert_array_almost_equal(dot(a, x), b)
 
     def test_random_sym_complex(self):
@@ -641,7 +645,11 @@ class TestSolve:
                 a[i, j] = conjugate(a[j, i])
         b = random([n])+2j*random([n])
         for i in range(2):
-            x = solve(a, b, sym_pos=1)
+            with pytest.warns(
+                DeprecationWarning,
+                match="This key is deprecated and ``assume_a = 'pos'``",
+            ):
+                x = solve(a, b, sym_pos=1)
             assert_array_almost_equal(dot(a, x), b)
 
     def test_check_finite(self):

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -618,20 +618,13 @@ class TestSolve:
             b = random([n, 3])
             x = solve(a, b)
             assert_array_almost_equal(dot(a, x), b)
-    
+
     def test_sym_pos_dep(self):
-        n = 20
-        a = random([n, n])
-        b = random([n])
-        for i in range(n):
-            a[i, i] = abs(20*(.1+a[i, i]))
-            for j in range(i):
-                a[i, j] = a[j, i]
         with pytest.warns(
                 DeprecationWarning,
-                match="The `sym_pos` keyword is deprecated",
-            ):
-                solve(a, b, sym_pos=1)
+                match="The 'sym_pos' keyword is deprecated",
+        ):
+            solve([[1.]], [1], sym_pos=True)
 
     def test_random_sym(self):
         n = 20

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -114,7 +114,10 @@ def _get_solver(M, sparse=False, lstsq=False, sym_pos=True,
                 # this seems to cache the matrix factorization, so solving
                 # with multiple right hand sides is much faster
                 def solve(r, sym_pos=sym_pos):
-                    return sp.linalg.solve(M, r, sym_pos=sym_pos)
+                    if sym_pos:
+                        return sp.linalg.solve(M, r, assume_a="pos")
+                    else:
+                        return sp.linalg.solve(M, r)
     # There are many things that can go wrong here, and it's hard to say
     # what all of them are. It doesn't really matter: if the matrix can't be
     # factorized, return None. get_solver will be called again with different

--- a/scipy/signal/_fir_filter_design.py
+++ b/scipy/signal/_fir_filter_design.py
@@ -1050,7 +1050,7 @@ def firls(numtaps, bands, desired, weight=None, nyq=None, fs=None):
     try:  # try the fast way
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('always')
-            a = solve(Q, b, sym_pos=True, check_finite=False)
+            a = solve(Q, b, assume_a="pos", check_finite=False)
         for ww in w:
             if (ww.category == LinAlgWarning and
                     str(ww.message).startswith('Ill-conditioned matrix')):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #15735
#### What does this implement/fix?
<!--Please explain your changes.-->
The `sym_pos` keyword of `scipy.linalg.solve` has been deprecated in the documentation but no explicit warning is raised. This pr raises a deprecation warning so that `sym_pos` can be removed in SciPy 1.11.0.
#### Additional information
<!--Any additional information you think is important.-->
