### PR TITLE
DOC: Interpolative tutorial - wrong matrix fill var

### DIFF
--- a/scipy/linalg/interpolative.py
+++ b/scipy/linalg/interpolative.py
@@ -163,7 +163,7 @@ We can also do this explicitly via:
 >>> n = 1000
 >>> A = np.empty((n, n), order='F')
 >>> for j in range(n):
->>>     for i in range(m):
+>>>     for i in range(n):
 >>>         A[i,j] = 1. / (i + j + 1)
 
 Note the use of the flag ``order='F'`` in :func:`numpy.empty`. This


### PR DESCRIPTION
We must use the same square matrix size variable "n" for filling matrix in cycle instead of undefined "m"

#### What does this implement/fix?
Fixes interpolative matrix decomposition tutorial
