### PR TITLE
BUG: Handle base case for scipy.integrate.simpson when span along the axis is 0 

### DIFF
--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -411,13 +411,12 @@ def _basic_simpson(y, start, stop, x, dx, axis):
         h1 = np.float64(h[sl1])
         hsum = h0 + h1
         hprod = h0 * h1
-        h0divh1 = np.true_divide(h0, 
-                                h1, 
+        h0divh1 = np.true_divide(h0, h1, 
                                 out=np.zeros_like(h0), 
                                 where=h1 != 0)
         tmp = hsum/6.0 * (y[slice0] * (2.0 - np.true_divide(1.0, h0divh1,
                                                             out=np.zeros_like(h0divh1), 
-                                                            where=h0divh1 != 0))
+                                                            where=h0divh1 != 0)) +
                           y[slice1] * (hsum * np.true_divide(hsum, hprod,
                                                             out=np.zeros_like(hsum), 
                                                             where=hprod != 0)) +

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -407,14 +407,14 @@ def _basic_simpson(y, start, stop, x, dx, axis):
         h = np.diff(x, axis=axis)
         sl0 = tupleset(slice_all, axis, slice(start, stop, step))
         sl1 = tupleset(slice_all, axis, slice(start+1, stop+1, step))
-        h0 = h[sl0]
-        h1 = h[sl1]
+        h0 = np.float(h[sl0])
+        h1 = np.float(h[sl1])
         hsum = h0 + h1
         hprod = h0 * h1
-        h0divh1 = np.true_divide(h0, h1, out=np.zeros_like(h0), where=h1!=0, casting="unsafe", dtype=np.float64)
-        tmp = hsum/6.0 * (y[slice0] * ( 2 - np.true_divide(1.0, h0divh1, out=np.zeros_like(h0divh1), where=h0divh1!=0, casting="unsafe", dtype=np.float64) ) +
+        h0divh1 = np.true_divide(h0, h1, out=np.zeros_like(h0), where=h1!=0, dtype=np.float64)
+        tmp = hsum/6.0 * (y[slice0] * ( 2.0 - np.true_divide(1.0, h0divh1, out=np.zeros_like(h0divh1), where=h0divh1!=0, casting="unsafe", dtype=np.float64) ) +
                           y[slice1] * ( hsum * np.true_divide(hsum, hprod, out=np.zeros_like(hsum), where=hprod!=0, casting="unsafe", dtype=np.float64) ) +
-                          y[slice2] * (2 - h0divh1))
+                          y[slice2] * (2.0 - h0divh1))
         print("-1: ",h0,h1)
         print("0: ",np.true_divide(h0, h1, out=np.zeros_like(h0), where=h1!=0, casting="unsafe", dtype=np.float64))
         print("1: ",2 - np.true_divide(1.0, h0divh1, out=np.zeros_like(h0divh1), where=h0divh1!=0, casting="unsafe", dtype=np.float64))

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -411,14 +411,14 @@ def _basic_simpson(y, start, stop, x, dx, axis):
         h1 = h[sl1]
         hsum = h0 + h1
         hprod = h0 * h1
-        h0divh1 = np.divide(h0, h1, out=np.zeros_like(h0), where=h1!=0, casting="unsafe", dtype=np.float64)
-        tmp = hsum/6.0 * (y[slice0] * ( 2 - np.divide(1.0, h0divh1, out=np.zeros_like(h0divh1), where=h0divh1!=0, casting="unsafe", dtype=np.float64) ) +
-                          y[slice1] * ( hsum * np.divide(hsum, hprod, out=np.zeros_like(hsum), where=hprod!=0, casting="unsafe", dtype=np.float64) ) +
+        h0divh1 = np.true_divide(h0, h1, out=np.zeros_like(h0), where=h1!=0, casting="unsafe", dtype=np.float64)
+        tmp = hsum/6.0 * (y[slice0] * ( 2 - np.true_divide(1.0, h0divh1, out=np.zeros_like(h0divh1), where=h0divh1!=0, casting="unsafe", dtype=np.float64) ) +
+                          y[slice1] * ( hsum * np.true_divide(hsum, hprod, out=np.zeros_like(hsum), where=hprod!=0, casting="unsafe", dtype=np.float64) ) +
                           y[slice2] * (2 - h0divh1))
         print("-1: ",h0,h1)
-        print("0: ",np.divide(h0, h1, out=np.zeros_like(h0), where=h1!=0, casting="unsafe", dtype=np.float64))
-        print("1: ",2 - np.divide(1.0, h0divh1, out=np.zeros_like(h0divh1), where=h0divh1!=0, casting="unsafe", dtype=np.float64))
-        print("2: ",hsum * np.divide(hsum, hprod, out=np.zeros_like(hsum), where=hprod!=0, casting="unsafe", dtype=np.float64))
+        print("0: ",np.true_divide(h0, h1, out=np.zeros_like(h0), where=h1!=0, casting="unsafe", dtype=np.float64))
+        print("1: ",2 - np.true_divide(1.0, h0divh1, out=np.zeros_like(h0divh1), where=h0divh1!=0, casting="unsafe", dtype=np.float64))
+        print("2: ",hsum * np.true_divide(hsum, hprod, out=np.zeros_like(hsum), where=hprod!=0, casting="unsafe", dtype=np.float64))
         print("3: ",(2 - h0divh1))
         result = np.sum(tmp, axis=axis)
     return result

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -412,12 +412,14 @@ def _basic_simpson(y, start, stop, x, dx, axis):
         hsum = h0 + h1
         hprod = h0 * h1
         h0divh1 = np.true_divide(h0, h1, out=np.zeros_like(h0), where=h1 != 0)
-        tmp = hsum/6.0 * (y[slice0] * (2.0 - np.true_divide(1.0, h0divh1,
-                                                            out=np.zeros_like(h0divh1),
-                                                            where=h0divh1 != 0)) +
-                          y[slice1] * (hsum * np.true_divide(hsum, hprod,
-                                                             out=np.zeros_like(hsum),
-                                                             where=hprod != 0)) +
+        tmp = hsum/6.0 * (y[slice0] *
+                          (2.0 - np.true_divide(1.0, h0divh1,
+                                                out=np.zeros_like(h0divh1),
+                                                where=h0divh1 != 0)) +
+                          y[slice1] * (hsum *
+                                       np.true_divide(hsum, hprod,
+                                                      out=np.zeros_like(hsum),
+                                                      where=hprod != 0)) +
                           y[slice2] * (2.0 - h0divh1))
         result = np.sum(tmp, axis=axis)
     return result

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -412,8 +412,8 @@ def _basic_simpson(y, start, stop, x, dx, axis):
         hsum = h0 + h1
         hprod = h0 * h1
         h0divh1 = np.true_divide(h0, h1, out=np.zeros_like(h0), where=h1!=0, dtype=np.float64)
-        tmp = hsum/6.0 * (y[slice0] * ( 2.0 - np.true_divide(1.0, h0divh1, out=np.zeros_like(h0divh1), where=h0divh1!=0, casting="unsafe", dtype=np.float64) ) +
-                          y[slice1] * ( hsum * np.true_divide(hsum, hprod, out=np.zeros_like(hsum), where=hprod!=0, casting="unsafe", dtype=np.float64) ) +
+        tmp = hsum/6.0 * (y[slice0] * ( 2.0 - np.true_divide(1.0, h0divh1, out=np.zeros_like(h0divh1), where=h0divh1!=0, dtype=np.float64) ) +
+                          y[slice1] * ( hsum * np.true_divide(hsum, hprod, out=np.zeros_like(hsum), where=hprod!=0, dtype=np.float64) ) +
                           y[slice2] * (2.0 - h0divh1))
         result = np.sum(tmp, axis=axis)
     return result

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -411,14 +411,14 @@ def _basic_simpson(y, start, stop, x, dx, axis):
         h1 = h[sl1]
         hsum = h0 + h1
         hprod = h0 * h1
-        h0divh1 = np.divide(h0, h1, out=np.zeros_like(h0), where=h1!=0, casting="unsafe")
-        tmp = hsum/6.0 * (y[slice0] * ( 2 - np.divide(1.0, h0divh1, out=np.zeros_like(h0divh1), where=h0divh1!=0, casting="unsafe") ) +
-                          y[slice1] * ( hsum * np.divide(hsum, hprod, out=np.zeros_like(hsum), where=hprod!=0, casting="unsafe") ) +
+        h0divh1 = np.divide(h0, h1, out=np.zeros_like(h0), where=h1!=0, casting="unsafe", dtype=np.float64)
+        tmp = hsum/6.0 * (y[slice0] * ( 2 - np.divide(1.0, h0divh1, out=np.zeros_like(h0divh1), where=h0divh1!=0, casting="unsafe", dtype=np.float64) ) +
+                          y[slice1] * ( hsum * np.divide(hsum, hprod, out=np.zeros_like(hsum), where=hprod!=0, casting="unsafe", dtype=np.float64) ) +
                           y[slice2] * (2 - h0divh1))
         print("-1: ",h0,h1)
-        print("0: ",np.divide(h0, h1, out=np.zeros_like(h0), where=h1!=0, casting="unsafe"))
-        print("1: ",2 - np.divide(1.0, h0divh1, out=np.zeros_like(h0divh1), where=h0divh1!=0, casting="unsafe"))
-        print("2: ",hsum * np.divide(hsum, hprod, out=np.zeros_like(hsum), where=hprod!=0, casting="unsafe"))
+        print("0: ",np.divide(h0, h1, out=np.zeros_like(h0), where=h1!=0, casting="unsafe", dtype=np.float64))
+        print("1: ",2 - np.divide(1.0, h0divh1, out=np.zeros_like(h0divh1), where=h0divh1!=0, casting="unsafe", dtype=np.float64))
+        print("2: ",hsum * np.divide(hsum, hprod, out=np.zeros_like(hsum), where=hprod!=0, casting="unsafe", dtype=np.float64))
         print("3: ",(2 - h0divh1))
         result = np.sum(tmp, axis=axis)
     return result

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -407,13 +407,13 @@ def _basic_simpson(y, start, stop, x, dx, axis):
         h = np.diff(x, axis=axis)
         sl0 = tupleset(slice_all, axis, slice(start, stop, step))
         sl1 = tupleset(slice_all, axis, slice(start+1, stop+1, step))
-        h0 = np.float(h[sl0])
-        h1 = np.float(h[sl1])
+        h0 = np.float64(h[sl0])
+        h1 = np.float64(h[sl1])
         hsum = h0 + h1
         hprod = h0 * h1
-        h0divh1 = np.true_divide(h0, h1, out=np.zeros_like(h0), where=h1!=0, dtype=np.float64)
-        tmp = hsum/6.0 * (y[slice0] * ( 2.0 - np.true_divide(1.0, h0divh1, out=np.zeros_like(h0divh1), where=h0divh1!=0, dtype=np.float64) ) +
-                          y[slice1] * ( hsum * np.true_divide(hsum, hprod, out=np.zeros_like(hsum), where=hprod!=0, dtype=np.float64) ) +
+        h0divh1 = np.true_divide(h0, h1, out=np.zeros_like(h0), where=h1 != 0, dtype=np.float64)
+        tmp = hsum/6.0 * (y[slice0] * (2.0 - np.true_divide(1.0, h0divh1, out=np.zeros_like(h0divh1), where=h0divh1 != 0, dtype=np.float64)) +
+                          y[slice1] * (hsum * np.true_divide(hsum, hprod, out=np.zeros_like(hsum), where=hprod != 0, dtype=np.float64)) +
                           y[slice2] * (2.0 - h0divh1))
         result = np.sum(tmp, axis=axis)
     return result

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -415,6 +415,9 @@ def _basic_simpson(y, start, stop, x, dx, axis):
         tmp = hsum/6.0 * (y[slice0] * ( 2 - np.divide(1.0, h0divh1, out=np.zeros_like(h0divh1), where=h0divh1!=0, casting="unsafe") ) +
                           y[slice1] * ( hsum * np.divide(hsum, hprod, out=np.zeros_like(hsum), where=hprod!=0, casting="unsafe") ) +
                           y[slice2] * (2 - h0divh1))
+        print("1: ",2 - np.divide(1.0, h0divh1, out=np.zeros_like(h0divh1), where=h0divh1!=0, casting="unsafe"))
+        print("2: ",hsum * np.divide(hsum, hprod, out=np.zeros_like(hsum), where=hprod!=0, casting="unsafe"))
+        print("3: ",(2 - h0divh1))
         result = np.sum(tmp, axis=axis)
     return result
 

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -411,15 +411,13 @@ def _basic_simpson(y, start, stop, x, dx, axis):
         h1 = np.float64(h[sl1])
         hsum = h0 + h1
         hprod = h0 * h1
-        h0divh1 = np.true_divide(h0, h1, 
-                                out=np.zeros_like(h0), 
-                                where=h1 != 0)
+        h0divh1 = np.true_divide(h0, h1, out=np.zeros_like(h0), where=h1 != 0)
         tmp = hsum/6.0 * (y[slice0] * (2.0 - np.true_divide(1.0, h0divh1,
-                                                            out=np.zeros_like(h0divh1), 
+                                                            out=np.zeros_like(h0divh1),
                                                             where=h0divh1 != 0)) +
                           y[slice1] * (hsum * np.true_divide(hsum, hprod,
-                                                            out=np.zeros_like(hsum), 
-                                                            where=hprod != 0)) +
+                                                             out=np.zeros_like(hsum),
+                                                             where=hprod != 0)) +
                           y[slice2] * (2.0 - h0divh1))
         result = np.sum(tmp, axis=axis)
     return result

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -415,6 +415,7 @@ def _basic_simpson(y, start, stop, x, dx, axis):
         tmp = hsum/6.0 * (y[slice0] * ( 2 - np.divide(1.0, h0divh1, out=np.zeros_like(h0divh1), where=h0divh1!=0, casting="unsafe") ) +
                           y[slice1] * ( hsum * np.divide(hsum, hprod, out=np.zeros_like(hsum), where=hprod!=0, casting="unsafe") ) +
                           y[slice2] * (2 - h0divh1))
+        print("0: ",np.divide(h0, h1, out=np.zeros_like(h0), where=h1!=0, casting="unsafe"))
         print("1: ",2 - np.divide(1.0, h0divh1, out=np.zeros_like(h0divh1), where=h0divh1!=0, casting="unsafe"))
         print("2: ",hsum * np.divide(hsum, hprod, out=np.zeros_like(hsum), where=hprod!=0, casting="unsafe"))
         print("3: ",(2 - h0divh1))

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -415,11 +415,6 @@ def _basic_simpson(y, start, stop, x, dx, axis):
         tmp = hsum/6.0 * (y[slice0] * ( 2.0 - np.true_divide(1.0, h0divh1, out=np.zeros_like(h0divh1), where=h0divh1!=0, casting="unsafe", dtype=np.float64) ) +
                           y[slice1] * ( hsum * np.true_divide(hsum, hprod, out=np.zeros_like(hsum), where=hprod!=0, casting="unsafe", dtype=np.float64) ) +
                           y[slice2] * (2.0 - h0divh1))
-        print("-1: ",h0,h1)
-        print("0: ",np.true_divide(h0, h1, out=np.zeros_like(h0), where=h1!=0, casting="unsafe", dtype=np.float64))
-        print("1: ",2 - np.true_divide(1.0, h0divh1, out=np.zeros_like(h0divh1), where=h0divh1!=0, casting="unsafe", dtype=np.float64))
-        print("2: ",hsum * np.true_divide(hsum, hprod, out=np.zeros_like(hsum), where=hprod!=0, casting="unsafe", dtype=np.float64))
-        print("3: ",(2 - h0divh1))
         result = np.sum(tmp, axis=axis)
     return result
 

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -411,9 +411,9 @@ def _basic_simpson(y, start, stop, x, dx, axis):
         h1 = h[sl1]
         hsum = h0 + h1
         hprod = h0 * h1
-        h0divh1 = h0 / h1
-        tmp = hsum/6.0 * (y[slice0] * (2 - 1.0/h0divh1) +
-                          y[slice1] * (hsum * hsum / hprod) +
+        h0divh1 = np.divide(h0, h1, out=np.zeros_like(h0), where=h1!=0, casting="unsafe")
+        tmp = hsum/6.0 * (y[slice0] * ( 2 - np.divide(1.0, h0divh1, out=np.zeros_like(h0divh1), where=h0divh1!=0, casting="unsafe") ) +
+                          y[slice1] * ( hsum * np.divide(hsum, hprod, out=np.zeros_like(hsum), where=hprod!=0, casting="unsafe") ) +
                           y[slice2] * (2 - h0divh1))
         result = np.sum(tmp, axis=axis)
     return result

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -411,9 +411,16 @@ def _basic_simpson(y, start, stop, x, dx, axis):
         h1 = np.float64(h[sl1])
         hsum = h0 + h1
         hprod = h0 * h1
-        h0divh1 = np.true_divide(h0, h1, out=np.zeros_like(h0), where=h1 != 0, dtype=np.float64)
-        tmp = hsum/6.0 * (y[slice0] * (2.0 - np.true_divide(1.0, h0divh1, out=np.zeros_like(h0divh1), where=h0divh1 != 0, dtype=np.float64)) +
-                          y[slice1] * (hsum * np.true_divide(hsum, hprod, out=np.zeros_like(hsum), where=hprod != 0, dtype=np.float64)) +
+        h0divh1 = np.true_divide(h0, 
+                                h1, 
+                                out=np.zeros_like(h0), 
+                                where=h1 != 0)
+        tmp = hsum/6.0 * (y[slice0] * (2.0 - np.true_divide(1.0, h0divh1,
+                                                            out=np.zeros_like(h0divh1), 
+                                                            where=h0divh1 != 0))
+                          y[slice1] * (hsum * np.true_divide(hsum, hprod,
+                                                            out=np.zeros_like(hsum), 
+                                                            where=hprod != 0)) +
                           y[slice2] * (2.0 - h0divh1))
         result = np.sum(tmp, axis=axis)
     return result

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -415,6 +415,7 @@ def _basic_simpson(y, start, stop, x, dx, axis):
         tmp = hsum/6.0 * (y[slice0] * ( 2 - np.divide(1.0, h0divh1, out=np.zeros_like(h0divh1), where=h0divh1!=0, casting="unsafe") ) +
                           y[slice1] * ( hsum * np.divide(hsum, hprod, out=np.zeros_like(hsum), where=hprod!=0, casting="unsafe") ) +
                           y[slice2] * (2 - h0divh1))
+        print("-1: ",h0,h1)
         print("0: ",np.divide(h0, h1, out=np.zeros_like(h0), where=h1!=0, casting="unsafe"))
         print("1: ",2 - np.divide(1.0, h0divh1, out=np.zeros_like(h0divh1), where=h0divh1!=0, casting="unsafe"))
         print("2: ",hsum * np.divide(hsum, hprod, out=np.zeros_like(hsum), where=hprod!=0, casting="unsafe"))

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -164,6 +164,13 @@ class TestQuadrature:
         assert_equal(simpson(y, x=x, axis=0), 0.0)
         assert_equal(simpson(y, x=x, axis=-1), 0.0)
 
+        x = np.array([[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]])
+        y = np.power(x, 2)
+        zero_axis = [0.0, 0.0, 0.0, 0.0]
+        default_axis = [21.16666667, 21.16666667, 21.16666667]
+        assert_equal(simpson(y, x=x, axis=0), zero_axis)
+        assert_equal(simpson(y, x=x, axis=-1), default_axis)
+
         x = np.array([[1, 2, 3, 4], [2, 2, 4, 4], [3, 2, 5, 4]])
         y = np.power(x, 2)
         zero_axis = [8.66666667, 0.0, 32.66666667, 0.0]

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -164,17 +164,17 @@ class TestQuadrature:
         assert_equal(simpson(y, x=x, axis=0), 0.0)
         assert_equal(simpson(y, x=x, axis=-1), 0.0)
 
-        x = np.array([[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]])
+        x = np.array([[1, 2, 4, 8], [1, 2, 4, 8], [1, 2, 4, 8]])
         y = np.power(x, 2)
         zero_axis = [0.0, 0.0, 0.0, 0.0]
-        default_axis = [21.16666667, 21.16666667, 21.16666667]
+        default_axis = [175.75, 175.75, 175.75]
         assert_equal(simpson(y, x=x, axis=0), zero_axis)
         assert_equal(simpson(y, x=x, axis=-1), default_axis)
 
-        x = np.array([[1, 2, 3, 4], [2, 2, 4, 4], [3, 2, 5, 4]])
+        x = np.array([[1, 2, 4, 8], [1, 2, 4, 8], [1, 8, 16, 32]])
         y = np.power(x, 2)
-        zero_axis = [8.66666667, 0.0, 32.66666667, 0.0]
-        default_axis = [21.16666667, 13.33333333, 12.16666667]
+        zero_axis = [0.0, 136.0, 1088.0, 8704.0]
+        default_axis = [175.75, 175.75, 11292.25]
         assert_equal(simpson(y, x=x, axis=0), zero_axis)
         assert_equal(simpson(y, x=x, axis=-1), default_axis)
 

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -153,6 +153,24 @@ class TestQuadrature:
         assert_equal(simpson(y, x=x, even='first'), 13.75)
         assert_equal(simpson(y, x=x, even='last'), 14)
 
+        # Tests for checking base case
+        x = np.array([3])
+        y = np.power(x, 2)
+        assert_equal(simpson(y, x=x, axis=0), 0.0)
+        assert_equal(simpson(y, x=x, axis=-1), 0.0)
+
+        x = np.array([3, 3, 3, 3])
+        y = np.power(x, 2)
+        assert_equal(simpson(y, x=x, axis=0), 0.0)
+        assert_equal(simpson(y, x=x, axis=-1), 0.0)
+
+        x = np.array([[1, 2, 3, 4], [2, 2, 4, 4], [3, 2, 5, 4]])
+        y = np.power(x, 2)
+        zero_axis = [8.66666667, 0.0, 32.66666667, 0.0]
+        default_axis = [21.16666667, 13.33333333, 12.16666667]
+        assert_equal(simpson(y, x=x, axis=0), zero_axis)
+        assert_equal(simpson(y, x=x, axis=-1), default_axis)
+
     def test_simps(self):
         # Basic coverage test for the alias
         y = np.arange(4)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #15721 

#### What does this implement/fix?
<!--Please explain your changes.-->
As described in the issue, the current implementation of `scipy.integrate.simpson` return `NaN` for when the span along the integrable axis is `0`. 
I change the code so that `0` is returned for that situation instead of `NaN`.

<!-- #### Additional information -->
<!--Any additional information you think is important.-->
