### PR TITLE
TST: stats: xfail_on_32bit studentized_range moment test

### DIFF
--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -5387,6 +5387,7 @@ class TestStudentizedRange:
                         rtol=src_case["expected_rtol"])
 
     @pytest.mark.slow
+    @pytest.mark.xfail_on_32bit("intermittent RuntimeWarning: invalid value.")
     @pytest.mark.parametrize("case_result", pregenerated_data["moment_data"])
     def test_moment_against_mp(self, case_result):
         src_case = case_result["src_case"]
@@ -5428,6 +5429,7 @@ class TestStudentizedRange:
         assert_allclose(res, r_res)
 
     @pytest.mark.slow
+    @pytest.mark.xfail_on_32bit("intermittent RuntimeWarning: invalid value.")
     def test_moment_vectorization(self):
         # Test moment broadcasting. Calls `_munp` directly because
         # `rv_continuous.moment` is broken at time of writing. See gh-12192


### PR DESCRIPTION
#### Reference issue
gh-15817, for example

#### What does this implement/fix?
These invalid value `RuntimeWarning`s occur intermittently on 32-bit CI. I don't want to silence the warnings themselves until we know whether the result is accurate and have a sense of the underlying cause. (That said, `studentized_range.moment` is probably not used enough in the wild for this to be a practical concern.) I'll add a note about this to gh-15121 so we can follow up.

<details>

```
=================================== FAILURES ===================================
__________ TestStudentizedRange.test_moment_against_mp[case_result1] ___________
[gw0] linux -- Python 3.8.0 /usr/bin/python3.8
/usr/local/lib/python3.8/dist-packages/scipy/stats/tests/test_distributions.py:5395: in test_moment_against_mp
    res = stats.studentized_range.moment(*mkv)
        case_result = {'mp_result': 1.8342745127927962, 'src_case': {'expected_atol': 1e-09, 'expected_rtol': 1e-09, 'k': 3, 'm': 1, ...}}
        mkv        = (1, 3, 10)
        mp_result  = 1.8342745127927962
        self       = <scipy.stats.tests.test_distributions.TestStudentizedRange object at 0xe3358c70>
        src_case   = {'expected_atol': 1e-09, 'expected_rtol': 1e-09, 'k': 3, 'm': 1, ...}
/usr/local/lib/python3.8/dist-packages/scipy/stats/_distn_infrastructure.py:1398: in moment
    val[...] = _moment_from_stats(n, mu, mu2, g1, g2, self._munp, shapes)
        args       = [array([3]), array([10]), array([0]), array([1])]
        g1         = None
        g2         = None
        got_keyword_n = False
        got_order  = True
        has_shape_n = False
        i0         = True
        i1         = True
        i2         = False
        kwds       = {}
        loc        = array([0])
        mdict      = {'moments': 'm'}
        mu         = None
        mu2        = None
        n          = 1
        order      = 1
        scale      = array([1])
        self       = <scipy.stats._continuous_distns.studentized_range_gen object at 0xeb6682c8>
        shapes     = [array([3]), array([10])]
        val        = array([1.])
/usr/local/lib/python3.8/dist-packages/scipy/stats/_distn_infrastructure.py:371: in _moment_from_stats
    val = moment_func(1, *args)
        args       = [array([3]), array([10])]
        g1         = None
        g2         = None
        moment_func = <bound method studentized_range_gen._munp of <scipy.stats._continuous_distns.studentized_range_gen object at 0xeb6682c8>>
        mu         = None
        mu2        = None
        n          = 1
/usr/local/lib/python3.8/dist-packages/scipy/stats/_continuous_distns.py:9334: in _munp
    return np.float64(ufunc(K, k, df))
E   RuntimeWarning: invalid value encountered in ? (vectorized)
        K          = 1
        _a         = 0
        _b         = inf
        _single_moment = <function studentized_range_gen._munp.<locals>._single_moment at 0xd4285148>
        cython_symbol = '_studentized_range_moment'
        df         = array([10])
        k          = array([3])
        self       = <scipy.stats._continuous_distns.studentized_range_gen object at 0xeb6682c8>
        ufunc      = <ufunc '? (vectorized)'>
________________ TestStudentizedRange.test_moment_vectorization ________________
[gw0] linux -- Python 3.8.0 /usr/bin/python3.8
/usr/local/lib/python3.8/dist-packages/scipy/stats/tests/test_distributions.py:5434: in test_moment_vectorization
    m = stats.studentized_range._munp([1, 2], [4, 5], [10, 11])
        self       = <scipy.stats.tests.test_distributions.TestStudentizedRange object at 0xe3358e80>
/usr/local/lib/python3.8/dist-packages/scipy/stats/_continuous_distns.py:9334: in _munp
    return np.float64(ufunc(K, k, df))
E   RuntimeWarning: invalid value encountered in ? (vectorized)
        K          = [1, 2]
        _a         = 0
        _b         = inf
        _single_moment = <function studentized_range_gen._munp.<locals>._single_moment at 0xd413cbf8>
        cython_symbol = '_studentized_range_moment'
        df         = [10, 11]
        k          = [4, 5]
        self       = <scipy.stats._continuous_distns.studentized_range_gen object at 0xeb6682c8>
        ufunc      = <ufunc '? (vectorized)'>
--------- generated xml file: /scipy/build/test/junit/test-results.xml ---------
=========================== short test summary info ============================
FAILED ../../stats/tests/test_distributions.py::TestStudentizedRange::test_moment_against_mp[case_result1]
FAILED ../../stats/tests/test_distributions.py::TestStudentizedRange::test_moment_vectorization
= 2 failed, 47799 passed, 2560 skipped, 603 xfailed, 11 xpassed in 825.38s (0:13:45)
```

</details>

#### Additional information
@DominicChm it would be good to know if this is easily reproduced on a 32-bit machine. 