### PR TITLE
BUG: Remove the need to specify window_size for find_peaks_cwt().

### DIFF
--- a/scipy/signal/_peak_finding.py
+++ b/scipy/signal/_peak_finding.py
@@ -1290,7 +1290,7 @@ def find_peaks_cwt(vector, widths, wavelet=None, max_distances=None,
     if wavelet is None:
         wavelet = ricker
 
-    cwt_dat = cwt(vector, wavelet, widths, window_size=window_size)
+    cwt_dat = cwt(vector, wavelet, widths)
     ridge_lines = _identify_ridge_lines(cwt_dat, max_distances, gap_thresh)
     filtered = _filter_ridge_lines(cwt_dat, ridge_lines, min_length=min_length,
                                    window_size=window_size, min_snr=min_snr,

--- a/scipy/signal/_wavelets.py
+++ b/scipy/signal/_wavelets.py
@@ -456,8 +456,6 @@ def cwt(data, wavelet, widths, dtype=None, **kwargs):
     ...            vmax=abs(cwtmatr).max(), vmin=-abs(cwtmatr).max())
     >>> plt.show()
     """
-    if wavelet == ricker:
-        window_size = kwargs.pop('window_size', None)
     # Determine output type
     if dtype is None:
         if np.asarray(wavelet(1, widths[0], **kwargs)).dtype.char in 'FDG':
@@ -468,14 +466,6 @@ def cwt(data, wavelet, widths, dtype=None, **kwargs):
     output = np.empty((len(widths), len(data)), dtype=dtype)
     for ind, width in enumerate(widths):
         N = np.min([10 * width, len(data)])
-        # the conditional block below and the window_size
-        # kwarg pop above may be removed eventually; these
-        # are shims for 32-bit arch + NumPy <= 1.14.5 to
-        # address gh-11095
-        if wavelet == ricker and window_size is None:
-            ceil = np.ceil(N)
-            if ceil != N:
-                N = int(N)
         wavelet_data = np.conj(wavelet(N, width, **kwargs)[::-1])
         output[ind] = convolve(data, wavelet_data, mode='same')
     return output

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -828,7 +828,6 @@ class TestFindPeaksCwt:
 
         np.testing.assert_equal(np.array([100]), a)
 
-
     def test_find_peaks_window_size(self):
         """
         Verify that window_size is passed correctly to private function and

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -20,6 +20,7 @@ from scipy.signal._peak_finding import (
     find_peaks_cwt,
     _identify_ridge_lines
 )
+from scipy.signal.windows import gaussian
 from scipy.signal._peak_finding_utils import _local_maxima_1d, PeakPropertyWarning
 
 
@@ -819,6 +820,14 @@ class TestFindPeaksCwt:
         widths = np.arange(10, 50)
         found_locs = find_peaks_cwt(test_data, widths, min_snr=5, noise_perc=30)
         np.testing.assert_equal(len(found_locs), 0)
+
+    def test_find_peaks_with_non_default_wavelets(self):
+        x = gaussian(200, 2)
+        widths = np.array([1, 2, 3, 4])
+        a = find_peaks_cwt(x, widths, wavelet=gaussian)
+
+        np.testing.assert_equal(np.array([100]), a)
+
 
     def test_find_peaks_window_size(self):
         """


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

Closes https://github.com/scipy/scipy/issues/12739
Closes https://github.com/scipy/scipy/issues/15094
Closes https://github.com/scipy/scipy/issues/14229

All these issues relate to use of the `window_size` parameter passed into the `cwt` function called by `find_peaks_cwt()` that was introduced for compatibility with numpy <= 1.14. Since that is no longer necessary, this PR removes the need for specifying the `window_size` and simplifies specification of wavelets.
