### PR TITLE
MAINT: stats.rv_generic: fix unnecessary call to `_munp` in `moment`

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -1390,7 +1390,7 @@ class rv_generic:
         mu, mu2, g1, g2 = None, None, None, None
         if (n > 0) and (n < 5):
             if self._stats_has_moments:
-                mdict = {'moments': {1: 'm', 2: 'v', 3: 'vs', 4: 'vk'}[n]}
+                mdict = {'moments': {1: 'm', 2: 'v', 3: 'vs', 4: 'mvsk'}[n]}
             else:
                 mdict = {}
             mu, mu2, g1, g2 = self._stats(*shapes, **mdict)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -6943,3 +6943,20 @@ def test_distr_params_lists():
     cont_distnames = {name for name, _ in distcont}
     invcont_distnames = {name for name, _ in invdistcont}
     assert cont_distnames == invcont_distnames
+
+
+def test_moment_order_4():
+    # gh-13655 reported that if a distribution has a `_stats` method that
+    # accepts the `moments` parameter, then if the distribution's `moment`
+    # method is called with `order=4`, the faster/more accurate`_stats` gets
+    # called, but the results aren't used, and the generic `_munp` method is
+    # called to calculate the moment anyway. This tests that the issue has
+    # been fixed.
+    # stats.skewnorm._stats accepts the `moments` keyword
+    stats.skewnorm._stats(a=0, moments='k')  # no failure = has `moments`
+    # When `moment` is called, `_stats` is used, so the moment is very accurate
+    # (exactly equal to Pearson's kurtosis of the normal distribution, 3)
+    assert stats.skewnorm.moment(order=4, a=0) == 3.0
+    # Had the moment been calculated using `_munp`, the result would have been
+    # less accurate:
+    assert stats.skewnorm._munp(4, 0) != 3.0


### PR DESCRIPTION
#### Reference issue
Closes gh-13655

#### What does this implement/fix?
gh-13655 reported that the `moment` method of a distribution would unnecessarily use the generic moment method `_munp` to calculate the moment even if the distribution-specific `_stats` method is defined. This fixes the problem.

#### Additional information
Try:
```python3
from scipy import stats
print(stats.skewnorm.moment(order=4, a=0))  # should be exactly 3 (Pearson kurtosis of normal distribution)
```
in `main`, then with this PR. Note the long execution time and inaccurate result in `main` are fixed with this PR.