### PR TITLE
Overhaul `factorial{,2,k}`: API coherence, bug fixes & consistent array-support

### DIFF
--- a/benchmarks/benchmarks/special.py
+++ b/benchmarks/benchmarks/special.py
@@ -110,7 +110,7 @@ class Factorial(Benchmark):
     def time_factorial_exact_false_array_negative_float(self):
         factorial(self.negative_floats, exact=False)
 
-    @with_attributes(params=[(100, 200, 400)],
+    @with_attributes(params=[(100, 200, 400, 10_000, 20_000)],
                      param_names=['n'])
     def time_factorial_exact_true_scalar_positive_int(self, n):
         factorial(n, exact=True)
@@ -118,17 +118,11 @@ class Factorial(Benchmark):
     def time_factorial_exact_true_scalar_negative_int(self):
         factorial(-10000, exact=True)
 
-    def time_factorial_exact_true_scalar_negative_float(self):
-        factorial(-10000.8, exact=True)
-
     def time_factorial_exact_true_array_positive_int(self):
         factorial(self.positive_ints, exact=True)
 
     def time_factorial_exact_true_array_negative_int(self):
         factorial(self.negative_ints, exact=True)
-
-    def time_factorial_exact_true_array_negative_float(self):
-        factorial(self.negative_floats, exact=True)
 
 
 class Factorial2(Benchmark):
@@ -150,7 +144,7 @@ class Factorial2(Benchmark):
     def time_factorial2_exact_false_array_negative_int(self):
         factorial2(self.negative_ints, exact=False)
 
-    @with_attributes(params=[(100, 200, 400)],
+    @with_attributes(params=[(100, 200, 400, 10_000, 20_000)],
                      param_names=['n'])
     def time_factorial2_exact_true_scalar_positive_int(self, n):
         factorial2(n, exact=True)
@@ -160,7 +154,7 @@ class Factorial2(Benchmark):
 
 
 class FactorialK(Benchmark):
-    @with_attributes(params=[(100, 500), range(1, 10)],
+    @with_attributes(params=[(100, 500, 10_000, 20_000), (3, 6, 9)],
                      param_names=['n', 'k'])
     def time_factorialk_exact_true_scalar_positive_int(self, n, k):
         factorialk(n, k, exact=True)

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2803,7 +2803,13 @@ def factorial(n, exact=False):
         if np.ndim(n) == 0:
             if np.isnan(n):
                 return n
-            return 0 if n < 0 else math.factorial(n)
+            elif n < 0:
+                return 0
+            elif np.issubdtype(type(n), np.integer):
+                return math.factorial(n)
+            # we do not raise for non-integers with exact=True due to
+            # historical reasons, though deprecation would be possible
+            return _ufuncs._factorial(n)
         else:
             n = asarray(n)
             un = np.unique(n)

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2881,6 +2881,12 @@ def factorial(n, exact=False):
         # scalar cases
         if n is None or np.isnan(n):
             return np.nan
+        elif not (np.issubdtype(type(n), np.integer)
+                  or np.issubdtype(type(n), np.floating)):
+            raise ValueError(
+                f"Unsupported datatype for factorial: {type(n)}\n"
+                "Permitted data types are integers and floating point numbers"
+            )
         elif n < 0:
             return 0
         elif exact and np.issubdtype(type(n), np.integer):

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2860,7 +2860,7 @@ def factorial(n, exact=False):
     # don't use isscalar due to numpy/numpy#23574; 0-dim arrays treated below
     if np.ndim(n) == 0 and not isinstance(n, np.ndarray):
         # scalar cases
-        if np.isnan(n):
+        if n is None or np.isnan(n):
             return np.nan
         elif n < 0:
             return 0
@@ -2936,7 +2936,7 @@ def factorial2(n, exact=False):
     # don't use isscalar due to numpy/numpy#23574; 0-dim arrays treated below
     if np.ndim(n) == 0 and not isinstance(n, np.ndarray):
         # scalar cases
-        if np.isnan(n):
+        if n is None or np.isnan(n):
             return np.nan
         elif not np.issubdtype(type(n), np.integer):
             msg = "factorial2 does not support non-integral scalar arguments"
@@ -3014,7 +3014,7 @@ def factorialk(n, k, exact=True):
     # don't use isscalar due to numpy/numpy#23574; 0-dim arrays treated below
     if np.ndim(n) == 0 and not isinstance(n, np.ndarray):
         # scalar cases
-        if np.isnan(n):
+        if n is None or np.isnan(n):
             return np.nan
         elif not np.issubdtype(type(n), np.integer):
             msg = "factorialk does not support non-integral scalar arguments!"

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2725,23 +2725,30 @@ def perm(N, k, exact=False):
 
 
 # https://stackoverflow.com/a/16327037
-def _range_prod(lo, hi):
+def _range_prod(lo, hi, k=1):
     """
-    Product of a range of numbers.
+    Product of a range of numbers spaced k apart (from hi).
 
-    Returns the product of
+    For k=1, this returns the product of
     lo * (lo+1) * (lo+2) * ... * (hi-2) * (hi-1) * hi
     = hi! / (lo-1)!
+
+    For k>1, it correspond to taking only every k'th number when
+    counting down from hi - e.g. 18!!!! = _range_prod(1, 18, 4).
 
     Breaks into smaller products first for speed:
     _range_prod(2, 9) = ((2*3)*(4*5))*((6*7)*(8*9))
     """
-    if lo + 1 < hi:
+    if lo + k < hi:
         mid = (hi + lo) // 2
-        return _range_prod(lo, mid) * _range_prod(mid + 1, hi)
-    if lo == hi:
-        return lo
-    return lo * hi
+        if k > 1:
+            # make sure mid is a multiple of k away from hi
+            mid = mid - ((mid - hi) % k)
+        return _range_prod(lo, mid, k) * _range_prod(mid + k, hi, k)
+    elif lo + k == hi:
+        return lo * hi
+    else:
+        return hi
 
 
 def factorial(n, exact=False):
@@ -2878,10 +2885,7 @@ def factorial2(n, exact=False):
             return 0
         if n == 0:
             return 1
-        val = 1
-        for k in range(n, 0, -2):
-            val *= k
-        return val
+        return _range_prod(1, n, k=2)
     else:
         n = asarray(n)
         vals = zeros(n.shape, 'd')
@@ -2943,10 +2947,7 @@ def factorialk(n, k, exact=True):
             return 0
         if n == 0:
             return 1
-        val = 1
-        for j in range(n, 0, -k):
-            val = val*j
-        return val
+        return _range_prod(1, n, k=k)
     else:
         raise NotImplementedError
 

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2852,8 +2852,7 @@ def factorial2(n, exact=False):
     ----------
     n : int or array_like
         Calculate ``n!!``.  Arrays are only supported with `exact` set
-        to False. If ``n < -1``, the return value is 0.
-        Otherwise if ``n <= 0``, the return value is 1.
+        to False.  If ``n < 0``, the return value is 0.
     exact : bool, optional
         The result can be approximated rapidly using the gamma-formula
         above (default).  If `exact` is set to True, calculate the
@@ -2875,9 +2874,9 @@ def factorial2(n, exact=False):
 
     """
     if exact:
-        if n < -1:
+        if n < 0:
             return 0
-        if n <= 0:
+        if n == 0:
             return 1
         val = 1
         for k in range(n, 0, -2):
@@ -2886,8 +2885,8 @@ def factorial2(n, exact=False):
     else:
         n = asarray(n)
         vals = zeros(n.shape, 'd')
-        cond1 = (n % 2) & (n >= -1)
-        cond2 = (1-(n % 2)) & (n >= -1)
+        cond1 = (n % 2) & (n >= 0)
+        cond2 = (1-(n % 2)) & (n >= 0)
         oddn = extract(cond1, n)
         evenn = extract(cond2, n)
         nd2o = oddn / 2.0
@@ -2913,8 +2912,7 @@ def factorialk(n, k, exact=True):
     Parameters
     ----------
     n : int
-        Calculate multifactorial. If ``n < 1 - k``, the return value is 0.
-        Otherwise if ``n <= 0``, the return value is 1.
+        Calculate multifactorial. If `n` < 0, the return value is 0.
     k : int
         Order of multifactorial.
     exact : bool, optional
@@ -2941,9 +2939,9 @@ def factorialk(n, k, exact=True):
 
     """
     if exact:
-        if n < 1-k:
+        if n < 0:
             return 0
-        if n <= 0:
+        if n == 0:
             return 1
         val = 1
         for j in range(n, 0, -k):

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2807,14 +2807,19 @@ def _exact_factorialx_array(n, k=1):
     for lane in range(0, k):
         ul = un[(un % k) == lane] if k > 1 else un
         if ul.size:
+            # after np.unique, un resp. ul are sorted, ul[0] is the smallest;
             # cast to python ints to avoid overflow with np.int-types
             val = _range_prod(1, int(ul[0]), k=k)
             out[n == ul[0]] = val
             for i in range(len(ul) - 1):
-                prev = ul[i] + 1
+                # by the filtering above, we have ensured that prev & current
+                # are a multiple of k apart
+                prev = ul[i]
                 current = ul[i + 1]
+                # we already multiplied all factors until prev; continue
+                # building the full factorial from the following (`prev + 1`);
                 # use int() for the same reason as above
-                val *= _range_prod(int(prev), int(current), k=k)
+                val *= _range_prod(int(prev + 1), int(current), k=k)
                 out[n == current] = val
 
     if np.isnan(n).any():

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2881,6 +2881,22 @@ def factorial(n, exact=False):
             f"Unsupported datatype for factorial: {n.dtype}\n"
             "Permitted data types are integers and floating point numbers"
         )
+    if exact and not np.issubdtype(n.dtype, np.integer):
+        # legacy behaviour is to support mixed integers/NaNs;
+        # deprecate this for exact=True
+        n_flt = n[~np.isnan(n)]
+        if np.allclose(n_flt, n_flt.astype(np.int64)):
+            warnings.warn(
+                "Non-integer arrays (e.g. due to presence of NaNs) "
+                "together with exact=True are deprecated. Either ensure "
+                "that the the array has integer dtype or use exact=False.",
+                DeprecationWarning,
+                stacklevel=2
+            )
+        else:
+            msg = ("factorial with exact=True does not "
+                   "support non-integral arrays")
+            raise ValueError(msg)
 
     if exact:
         return _exact_factorialx_array(n)

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -3008,6 +3008,8 @@ def factorialk(n, k, exact=True):
     10
 
     """
+    if not np.issubdtype(type(k), np.integer) or k < 1:
+        raise ValueError(f"k must be a positive integer, received: {k}")
     if not exact:
         raise NotImplementedError
 

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2763,6 +2763,10 @@ def _exact_factorial_array(n):
     computed once, with each other result computed in the process.
     """
     un = np.unique(n)
+    # numpy changed nan-sorting behaviour with 1.21, see numpy/numpy#18070;
+    # to unify the behaviour, we remove the nan's here; the respective
+    # values will be set separately at the end
+    un = un[~np.isnan(un)]
 
     # Convert to object array of long ints if np.int_ can't handle size
     if np.isnan(n).any():
@@ -2777,11 +2781,9 @@ def _exact_factorial_array(n):
     out = np.empty_like(n, dtype=dt)
 
     # Handle invalid/trivial values
-    # Ignore runtime warning when less operator used w/np.nan
-    with np.errstate(all='ignore'):
-        un = un[un > 1]
-        out[n < 2] = 1
-        out[n < 0] = 0
+    un = un[un > 1]
+    out[n < 2] = 1
+    out[n < 0] = 0
 
     # Calculate products of each range of numbers
     if un.size:
@@ -2796,7 +2798,7 @@ def _exact_factorial_array(n):
 
     if np.isnan(n).any():
         out = out.astype(np.float64)
-        out[np.isnan(n)] = n[np.isnan(n)]
+        out[np.isnan(n)] = np.nan
     return out
 
 
@@ -2863,6 +2865,9 @@ def factorial(n, exact=False):
 
     # arrays & array-likes
     n = asarray(n)
+    if n.size == 0:
+        # return empty arrays unchanged
+        return n
     if not (np.issubdtype(n.dtype, np.integer)
             or np.issubdtype(n.dtype, np.floating)):
         raise ValueError(
@@ -2940,6 +2945,9 @@ def factorial2(n, exact=False):
         return _approx(n)
     # arrays & array-likes
     n = asarray(n)
+    if n.size == 0:
+        # return empty arrays unchanged
+        return n
     if not np.issubdtype(n.dtype, np.integer):
         raise ValueError("factorial2 does not support non-integral arrays")
     # approximation

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -3043,6 +3043,11 @@ def factorialk(n, k, exact=True):
     if not exact:
         raise NotImplementedError
 
+    helpmsg = ""
+    if k in {1, 2}:
+        func = "factorial" if k == 1 else "factorial2"
+        helpmsg = f"\nYou can try to use {func} instead"
+
     # don't use isscalar due to numpy/numpy#23574; 0-dim arrays treated below
     if np.ndim(n) == 0 and not isinstance(n, np.ndarray):
         # scalar cases
@@ -3050,7 +3055,7 @@ def factorialk(n, k, exact=True):
             return np.nan
         elif not np.issubdtype(type(n), np.integer):
             msg = "factorialk does not support non-integral scalar arguments!"
-            raise ValueError(msg)
+            raise ValueError(msg + helpmsg)
         elif n < 0:
             return 0
         elif n in {0, 1}:
@@ -3063,7 +3068,7 @@ def factorialk(n, k, exact=True):
         return n
     if not np.issubdtype(n.dtype, np.integer):
         msg = "factorialk does not support non-integral arrays!"
-        raise ValueError(msg)
+        raise ValueError(msg + helpmsg)
     return _exact_factorialx_array(n, k=k)
 
 

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2806,7 +2806,7 @@ def factorial(n, exact=False):
             return 0 if n < 0 else math.factorial(n)
         else:
             n = asarray(n)
-            un = np.unique(n).astype(object)
+            un = np.unique(n)
 
             # Convert to object array of long ints if np.int_ can't handle size
             if np.isnan(n).any():
@@ -2834,7 +2834,8 @@ def factorial(n, exact=False):
                 for i in range(len(un) - 1):
                     prev = un[i] + 1
                     current = un[i + 1]
-                    val *= _range_prod(prev, current)
+                    # cast to python ints to avoid overflow with np.int-types
+                    val *= _range_prod(int(prev), int(current))
                     out[n == current] = val
 
             if np.isnan(n).any():

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1954,6 +1954,24 @@ class TestExp:
 
 
 class TestFactorialFunctions:
+    @pytest.mark.parametrize("n", [-1, -2, -3])
+    @pytest.mark.parametrize("exact", [True, False])
+    def test_factorialx_negative(self, exact, n):
+        assert_equal(special.factorial(n, exact=exact), 0)
+        assert_equal(special.factorial2(n, exact=exact), 0)
+        assert_equal(special.factorialk(n, 3, exact=True), 0)
+
+    @pytest.mark.parametrize("exact", [True, False])
+    def test_factorialx_negative_array(self, exact):
+        assert_func = assert_array_equal if exact else assert_allclose
+        # Consistent output for n < 0
+        assert_func(special.factorial([-5, -4, 0, 1], exact=exact),
+                    [0, 0, 1, 1])
+        # assert_func(special.factorial2([-5, -4, 0, 1], exact=exact),
+        #             [0, 0, 1, 1])
+        # assert_func(special.factorialk([-5, -4, 0, 1], 3, exact=True),
+        #             [0, 0, 1, 1])
+
     def test_factorial(self):
         # Some known values, float math
         assert_array_almost_equal(special.factorial(0), 1)
@@ -1989,12 +2007,6 @@ class TestFactorialFunctions:
         # int32 array
         assert_equal(special.factorial(np.arange(-3, 5), True),
                      special.factorial(np.arange(-3, 5), False))
-
-        # Consistent output for n < 0
-        for exact in (True, False):
-            assert_array_equal(0, special.factorial(-3, exact))
-            assert_array_equal([1, 2, 0, 0],
-                               special.factorial([1, 2, -5, -4], exact))
 
         for n in range(0, 22):
             # Compare all with math.factorial

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1987,6 +1987,19 @@ class TestFactorialFunctions:
         assert_equal(special.factorial([[5, 3], [4, 3]], True),
                      [[120, 6], [24, 6]])
 
+    # note that n=170 is the last integer such that factorial(n) fits float64
+    @pytest.mark.parametrize('n', range(30, 180, 10))
+    def test_factorial_accuracy(self, n):
+        # Compare exact=True vs False, i.e. that the accuracy of the
+        # approximation is better than the specified tolerance.
+
+        rtol = 6e-14 if sys.platform == 'win32' else 1e-15
+        # need to cast exact result to float due to numpy/numpy#21220
+        assert_allclose(float(special.factorial(n, exact=True)),
+                        special.factorial(n, exact=False), rtol=rtol)
+        assert_allclose(special.factorial([n], exact=True).astype(float),
+                        special.factorial([n], exact=False), rtol=rtol)
+
     @pytest.mark.parametrize('n',
                              list(range(0, 22)) + list(range(30, 180, 10)))
     def test_factorial_int_reference(self, n):
@@ -2000,13 +2013,6 @@ class TestFactorialFunctions:
                         rtol=rtol)
         assert_allclose(float(correct), special.factorial([n], False)[0],
                         rtol=rtol)
-
-        # Compare exact=True vs False, scalar vs array;
-        # need to cast exact result to float due to numpy/numpy#21220
-        assert_allclose(float(special.factorial(n, exact=True)),
-                        special.factorial(n, exact=False), rtol=rtol)
-        assert_allclose(float(special.factorial([n], exact=True)),
-                        special.factorial([n], exact=False), rtol=rtol)
 
     @pytest.mark.parametrize("exact", [True, False])
     def test_factorial_float_reference(self, exact):
@@ -2036,6 +2042,19 @@ class TestFactorialFunctions:
     ])
     def test_factorial_0d_return_type(self, x, exact):
         assert np.isscalar(special.factorial(x, exact=exact))
+
+    # use odd increment to make sure both odd & even numbers are tested!
+    @pytest.mark.parametrize('n', range(30, 180, 11))
+    def test_factorial2_accuracy(self, n):
+        # Compare exact=True vs False, i.e. that the accuracy of the
+        # approximation is better than the specified tolerance.
+
+        rtol = 2e-14 if sys.platform == 'win32' else 1e-15
+        # need to cast exact result to float due to numpy/numpy#21220
+        assert_allclose(float(special.factorial2(n, exact=True)),
+                        special.factorial2(n, exact=False), rtol=rtol)
+        assert_allclose(special.factorial2([n], exact=True).astype(float),
+                        special.factorial2([n], exact=False), rtol=rtol)
 
     @pytest.mark.parametrize('n',
                              list(range(0, 22)) + list(range(30, 180, 11)))

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1975,8 +1975,9 @@ class TestFactorialFunctions:
         # Consistent output for n < 0
         assert_func(special.factorial([-5, -4, 0, 1], exact=exact),
                     [0, 0, 1, 1])
-        assert_func(special.factorial2([-5, -4, 0, 1], exact=exact),
-                    [0, 0, 1, 1])
+        # no exact array-path for factorial2 yet
+        assert_allclose(special.factorial2([-5, -4, 0, 1], exact=exact),
+                        [0, 0, 1, 1])
         # assert_func(special.factorialk([-5, -4, 0, 1], 3, exact=True),
         #             [0, 0, 1, 1])
 

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -2210,6 +2210,11 @@ class TestFactorialFunctions:
             with pytest.raises(ValueError, match="factorialk does not*"):
                 special.factorialk(n, 3)
 
+    @pytest.mark.parametrize("k", [0, 1.1, np.nan, "1"])
+    def test_factorialk_raises_k(self, k):
+        with pytest.raises(ValueError, match="k must be a positive integer*"):
+            special.factorialk(1, k)
+
     # GH-13122: special.factorial() argument should be an array of integers.
     # On Python 3.10, math.factorial() reject float.
     # On Python 3.9, a DeprecationWarning is emitted.

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -2008,6 +2008,26 @@ class TestFactorialFunctions:
         assert_allclose(float(special.factorial([n], exact=True)),
                         special.factorial([n], exact=False), rtol=rtol)
 
+    @pytest.mark.parametrize("exact", [True, False])
+    def test_factorial_float_reference(self, exact):
+        def _check(n, expected):
+            # support for exact=True with scalar floats grandfathered in
+            assert_allclose(special.factorial(n, exact=exact), expected)
+            # non-integer types in arrays only allowed with exact=False
+            assert_allclose(special.factorial([n])[0], expected)
+
+        # Reference values from mpmath for gamma(n+1)
+        _check(0.01, 0.994325851191506032181932988)
+        _check(1.11, 1.051609009483625091514147465)
+        _check(5.55, 314.9503192327208241614959052)
+        _check(11.1, 50983227.84411615655137170553)
+        _check(33.3, 2.493363339642036352229215273e+37)
+        _check(55.5, 9.479934358436729043289162027e+73)
+        _check(77.7, 3.060540559059579022358692625e+114)
+        _check(99.9, 5.885840419492871504575693337e+157)
+        # close to maximum for float64
+        _check(170.6243, 1.79698185749571048960082e+308)
+
     @pytest.mark.parametrize('x, exact', [
         (1, True),
         (1, False),

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -2126,7 +2126,7 @@ class TestFactorialFunctions:
     @pytest.mark.parametrize("content",
                              [[], [1], [1.1], [np.nan], [np.nan, 1]],
                              ids=["[]", "[1]", "[1.1]", "[NaN]", "[NaN, 1]"])
-    def test_factorial_corner_cases(self, content, dim, exact, dtype):
+    def test_factorial_array_corner_cases(self, content, dim, exact, dtype):
         if dtype == np.int64 and any(np.isnan(x) for x in content):
             pytest.skip("impossible combination")
         n = np.array(content, ndmin=dim, dtype=dtype)
@@ -2159,6 +2159,20 @@ class TestFactorialFunctions:
                 r = special.factorial(n.ravel(), exact=exact) if n.size else []
             expected = np.array(r, ndmin=dim, dtype=dtype)
             assert_equal(result, expected)
+
+    @pytest.mark.parametrize("exact", [True, False])
+    @pytest.mark.parametrize("n", [1, 1.1, 2 + 2j, np.nan, None],
+                             ids=["1", "1.1", "2+2j", "NaN", "None"])
+    def test_factorial_scalar_corner_cases(self, n, exact):
+        if (n is None or n is np.nan or np.issubdtype(type(n), np.integer)
+                or np.issubdtype(type(n), np.floating)):
+            # no error
+            result = special.factorial(n, exact=exact)
+            exp = np.nan if n is np.nan or n is None else special.factorial(n)
+            assert_equal(result, exp)
+        else:
+            with pytest.raises(ValueError, match="Unsupported datatype*"):
+                special.factorial(n, exact=exact)
 
     # use odd increment to make sure both odd & even numbers are tested!
     @pytest.mark.parametrize('n', range(30, 180, 11))
@@ -2194,7 +2208,7 @@ class TestFactorialFunctions:
     # test empty & non-empty arrays, with nans and mixed
     @pytest.mark.parametrize("content", [[], [1], [np.nan], [np.nan, 1]],
                              ids=["[]", "[1]", "[NaN]", "[NaN, 1]"])
-    def test_factorial2_corner_cases(self, content, dim, exact, dtype):
+    def test_factorial2_array_corner_cases(self, content, dim, exact, dtype):
         if dtype == np.int64 and any(np.isnan(x) for x in content):
             pytest.skip("impossible combination")
         n = np.array(content, ndmin=dim, dtype=dtype)
@@ -2208,6 +2222,19 @@ class TestFactorialFunctions:
         else:
             with pytest.raises(ValueError, match="factorial2 does not*"):
                 special.factorial2(n, 3)
+
+    @pytest.mark.parametrize("exact", [True, False])
+    @pytest.mark.parametrize("n", [1, 1.1, 2 + 2j, np.nan, None],
+                             ids=["1", "1.1", "2+2j", "NaN", "None"])
+    def test_factorial2_scalar_corner_cases(self, n, exact):
+        if n is None or n is np.nan or np.issubdtype(type(n), np.integer):
+            # no error
+            result = special.factorial2(n, exact=exact)
+            exp = np.nan if n is np.nan or n is None else special.factorial(n)
+            assert_equal(result, exp)
+        else:
+            with pytest.raises(ValueError, match="factorial2 does not*"):
+                special.factorial2(n, exact=exact)
 
     @pytest.mark.parametrize('k', list(range(1, 5)) + [10, 20])
     @pytest.mark.parametrize('n',
@@ -2232,7 +2259,7 @@ class TestFactorialFunctions:
     # test empty & non-empty arrays, with nans and mixed
     @pytest.mark.parametrize("content", [[], [1], [np.nan], [np.nan, 1]],
                              ids=["[]", "[1]", "[NaN]", "[NaN, 1]"])
-    def test_factorialk_corner_cases(self, content, dim, dtype):
+    def test_factorialk_array_corner_cases(self, content, dim, dtype):
         if dtype == np.int64 and any(np.isnan(x) for x in content):
             pytest.skip("impossible combination")
         n = np.array(content, ndmin=dim, dtype=dtype)
@@ -2242,6 +2269,24 @@ class TestFactorialFunctions:
         else:
             with pytest.raises(ValueError, match="factorialk does not*"):
                 special.factorialk(n, 3)
+
+    @pytest.mark.parametrize("exact", [True, False])
+    @pytest.mark.parametrize("k", range(1, 5))
+    @pytest.mark.parametrize("n", [1, 1.1, 2 + 2j, np.nan, None],
+                             ids=["1", "1.1", "2+2j", "NaN", "None"])
+    def test_factorialk_scalar_corner_cases(self, n, k, exact):
+        if not exact:
+            with pytest.raises(NotImplementedError):
+                special.factorialk(n, k=k, exact=exact)
+        elif n is None or n is np.nan or np.issubdtype(type(n), np.integer):
+            # no error
+            result = special.factorial2(n, exact=exact)
+            nan_cond = n is np.nan or n is None
+            expected = np.nan if nan_cond else special.factorialk(n, k=k)
+            assert_equal(result, expected)
+        else:
+            with pytest.raises(ValueError, match="factorialk does not*"):
+                special.factorialk(n, k=k, exact=exact)
 
     @pytest.mark.parametrize("k", [0, 1.1, np.nan, "1"])
     def test_factorialk_raises_k(self, k):

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -2052,6 +2052,25 @@ class TestFactorialFunctions:
         assert_allclose(special.factorialk(n, 3, exact=True),
                         np.array(exp[3], ndmin=dim))
 
+    @pytest.mark.parametrize("exact", [True, False])
+    @pytest.mark.parametrize("level", range(1, 5))
+    def test_factorialx_array_like(self, level, exact):
+        def _nest_me(x, k=1):
+            if k == 0:
+                return x
+            else:
+                return _nest_me([x], k-1)
+
+        n = _nest_me([5], k=level-1)  # nested list
+        exp_nucleus = {1: 120, 2: 15, 3: 10}
+        assert_func = assert_array_equal if exact else assert_allclose
+        assert_func(special.factorial(n, exact=exact),
+                    np.array(exp_nucleus[1], ndmin=level))
+        assert_func(special.factorial2(n, exact=exact),
+                    np.array(exp_nucleus[2], ndmin=level))
+        assert_func(special.factorialk(n, 3, exact=True),
+                    np.array(exp_nucleus[3], ndmin=level))
+
     # note that n=170 is the last integer such that factorial(n) fits float64
     @pytest.mark.parametrize('n', range(30, 180, 10))
     def test_factorial_accuracy(self, n):

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1981,14 +1981,20 @@ class TestFactorialFunctions:
                     [0, 0, 1, 1])
 
     @pytest.mark.parametrize("exact", [True, False])
-    @pytest.mark.parametrize("content", [np.nan], ids=["NaN"])
+    @pytest.mark.parametrize("content", [np.nan, None, np.datetime64('nat')],
+                             ids=["NaN", "None", "NaT"])
     def test_factorialx_nan(self, content, exact):
         # scalar
         assert special.factorial(content, exact=exact) is np.nan
         assert special.factorial2(content, exact=exact) is np.nan
         assert special.factorialk(content, 3, exact=True) is np.nan
         # array-like (initializes np.array with default dtype)
-        assert np.isnan(special.factorial([content], exact=exact)[0])
+        if content is not np.nan:
+            # None causes object dtype, which is not supported; as is datetime
+            with pytest.raises(ValueError, match="Unsupported datatype.*"):
+                special.factorial([content], exact=exact)
+        else:
+            assert np.isnan(special.factorial([content], exact=exact)[0])
         # factorial{2,k} don't support array case due to dtype constraints
         with pytest.raises(ValueError, match="factorial2 does not support.*"):
             special.factorial2([content], exact=exact)

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1975,11 +1975,10 @@ class TestFactorialFunctions:
         # Consistent output for n < 0
         assert_func(special.factorial([-5, -4, 0, 1], exact=exact),
                     [0, 0, 1, 1])
-        # no exact array-path for factorial2 yet
-        assert_allclose(special.factorial2([-5, -4, 0, 1], exact=exact),
-                        [0, 0, 1, 1])
-        # assert_func(special.factorialk([-5, -4, 0, 1], 3, exact=True),
-        #             [0, 0, 1, 1])
+        assert_func(special.factorial2([-5, -4, 0, 1], exact=exact),
+                    [0, 0, 1, 1])
+        assert_func(special.factorialk([-5, -4, 0, 1], 3, exact=True),
+                    [0, 0, 1, 1])
 
     @pytest.mark.parametrize("exact", [True, False])
     @pytest.mark.parametrize("content", [np.nan], ids=["NaN"])
@@ -1993,8 +1992,8 @@ class TestFactorialFunctions:
         # factorial{2,k} don't support array case due to dtype constraints
         with pytest.raises(ValueError, match="factorial2 does not support.*"):
             special.factorial2([content], exact=exact)
-        # with pytest.raises(ValueError, match="factorialk does not support.*"):
-        #     special.factorialk([content], 3, exact=True)
+        with pytest.raises(ValueError, match="factorialk does not support.*"):
+            special.factorialk([content], 3, exact=True)
         # array-case also tested in test_factorial{,2,k}_corner_cases
 
     @pytest.mark.parametrize("levels", range(1, 5))
@@ -2027,7 +2026,7 @@ class TestFactorialFunctions:
 
         _check(special.factorial(n, exact=exact), exp_nucleus[1])
         _check(special.factorial2(n, exact=exact), exp_nucleus[2])
-        # _check(special.factorialk(n, 3, exact=True), exp_nucleus[3])
+        _check(special.factorialk(n, 3, exact=True), exp_nucleus[3])
 
     @pytest.mark.parametrize("exact", [True, False])
     @pytest.mark.parametrize("dim", range(0, 5))
@@ -2038,8 +2037,8 @@ class TestFactorialFunctions:
                         np.array(exp[1], ndmin=dim))
         assert_allclose(special.factorial2(n, exact=exact),
                         np.array(exp[2], ndmin=dim))
-        # assert_allclose(special.factorialk(n, 3, exact=True),
-        #                 np.array(exp[3], ndmin=dim))
+        assert_allclose(special.factorialk(n, 3, exact=True),
+                        np.array(exp[3], ndmin=dim))
 
     # note that n=170 is the last integer such that factorial(n) fits float64
     @pytest.mark.parametrize('n', range(30, 180, 10))
@@ -2144,7 +2143,7 @@ class TestFactorialFunctions:
         correct = functools.reduce(operator.mul, list(range(n, 0, -2)), 1)
 
         assert_array_equal(correct, special.factorial2(n, True))
-        # assert_array_equal(correct, special.factorial2([n], True)[0])
+        assert_array_equal(correct, special.factorial2([n], True)[0])
 
         assert_allclose(float(correct), special.factorial2(n, False))
         assert_allclose(float(correct), special.factorial2([n], False)[0])
@@ -2163,8 +2162,9 @@ class TestFactorialFunctions:
         if np.issubdtype(n.dtype, np.integer) or (not content):
             # no error
             result = special.factorial2(n, exact=exact)
-            # assert_allclose chokes on object dtype
-            func = assert_equal if (not content) else assert_allclose
+            # expected result is identical to n for exact=True resp. empty
+            # arrays (assert_allclose chokes on object), otherwise up to tol
+            func = assert_equal if exact or (not content) else assert_allclose
             func(result, n)
         else:
             with pytest.raises(ValueError, match="factorial2 does not*"):
@@ -2181,13 +2181,12 @@ class TestFactorialFunctions:
         correct = functools.reduce(operator.mul, list(range(n, 0, -k)), 1)
 
         assert_array_equal(correct, special.factorialk(n, k, True))
-        # assert_array_equal(correct, special.factorialk([n], k, True)[0])
+        assert_array_equal(correct, special.factorialk([n], k, True)[0])
 
         # exact=False not yet supported
         # assert_allclose(float(correct), special.factorialk(n, k, False))
         # assert_allclose(float(correct), special.factorialk([n], k, False)[0])
 
-    @pytest.mark.skipif(True, reason="no array support for factorialk yet")
     @pytest.mark.parametrize("dtype", [np.int64, np.float64,
                                        np.complex128, object])
     @pytest.mark.parametrize("dim", range(0, 5))


### PR DESCRIPTION
This is some of the work towards #15600. It's still missing several things (mainly `extend='complex'`), but it's very big as-is, so I wanted to post this as just a something to further the discussion.

Currently it contains several small behaviour changes:
* Make `factorial2` / `factorialk` return 0 for small negative integers
  * See https://github.com/scipy/scipy/pull/15841/commits/016919afbee64c243d9aa48e1f540048f8765ef7 and this [comment](https://github.com/scipy/scipy/issues/15600#issuecomment-1074910868).
  * Currently no mitigation/deprecation for the behaviour change implemented, though this is mainly because of the WIP - we can adapt however we'd like.
* Make both `factorial` / `factorial2` consistently return the same type as the input. This changes `factorial2` to not return 0-dim arrays for scalar inputs, and - inversely - changes `factorial` to not turn 0-dim arrays into scalars.
  * See https://github.com/scipy/scipy/pull/15841/commits/58abcb60d7f99b2ad8d11589c03793f7a5eaf1ba and this [comment](https://github.com/scipy/scipy/issues/15600#issuecomment-1072942167).
  * As above - no deprecation for the behaviour change yet, but happy to discuss (though https://github.com/scipy/scipy/pull/10954 was treated as a bugfix as well...).
* Switch the output type of `factorialk` to `object` for `k >= 10` (I think this is a reasonable trade-off, for more details see https://github.com/scipy/scipy/pull/15841/commits/99d088a48c9c797e81710c8e7eb48a119285781b) 
* ~Switch the float approximation for `factorial2` to the one from https://github.com/scipy/scipy/pull/15349~ deferred due to ambiguity of the extension.

In addition, it adds array-support for factorialk, exact=True array-support for factorial2 (and many related fixes), and also fixes #13122; Finally, it cleans up and parametrizes a lot of tests, and adds a whole bunch of new ones.

### Note: the individual commits should be much easier to review than the entire diff at once.