### PR TITLE
BUG: adds warning to scipy.stats.brunnermunzel

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8234,10 +8234,10 @@ def brunnermunzel(x, y, alternative="two-sided", distribution="t",
         df = df_numer / df_denom
 
         if (df_numer == 0) and (df_denom == 0):
-            warnings.warn("p-value cannot be estimated  "
-                          "because denominator and numerator of "
-                          "t-distribution are 0. Try using "
-                          "distribution='normal' ", RuntimeWarning)
+            message = ("p-value cannot be estimated with `distribution='t' " 
+                       "because degrees of freedom parameter is undefined "
+                       "(0/0). Try using `distribution='normal'")
+            warnings.warn(message, RuntimeWarning)
 
         p = distributions.t.cdf(wbfn, df)
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8240,8 +8240,6 @@ def brunnermunzel(x, y, alternative="two-sided", distribution="t",
             warnings.warn(message, RuntimeWarning)
 
         p = distributions.t.cdf(wbfn, df)
-
-
     elif distribution == "normal":
         p = distributions.norm.cdf(wbfn)
     else:

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8234,7 +8234,7 @@ def brunnermunzel(x, y, alternative="two-sided", distribution="t",
         df = df_numer / df_denom
 
         if (df_numer == 0) and (df_denom == 0):
-            message = ("p-value cannot be estimated with `distribution='t' " 
+            message = ("p-value cannot be estimated with `distribution='t' "
                        "because degrees of freedom parameter is undefined "
                        "(0/0). Try using `distribution='normal'")
             warnings.warn(message, RuntimeWarning)

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8232,7 +8232,16 @@ def brunnermunzel(x, y, alternative="two-sided", distribution="t",
         df_denom = np.power(nx * Sx, 2.0) / (nx - 1)
         df_denom += np.power(ny * Sy, 2.0) / (ny - 1)
         df = df_numer / df_denom
+
+        if (df_numer == 0) and (df_denom == 0):
+            warnings.warn("p-value cannot be estimated  "
+                          "because denominator and numerator of "
+                          "t-distribution are 0. Try using "
+                          "distribution='normal' ", RuntimeWarning)
+
         p = distributions.t.cdf(wbfn, df)
+
+
     elif distribution == "normal":
         p = distributions.norm.cdf(wbfn)
     else:

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -6982,7 +6982,7 @@ class TestBrunnerMunzel:
 
     def test_brunnermunzel_return_nan(self):
         """ tests that a warning is emitted when p is nan
-        p-value with t-distributions can be nan (0/0)
+        p-value with t-distributions can be nan (0/0) (see gh-15843)
         """
         x = [1, 2, 3]
         y = [5, 6, 7, 8, 9]
@@ -6992,14 +6992,14 @@ class TestBrunnerMunzel:
 
     def test_brunnermunzel_normal_dist(self):
         """ tests that a p is 0 for datasets that cause p->nan
-        when t-distribution is used
+        when t-distribution is used (see gh-15843)
         """
         x = [1, 2, 3]
         y = [5, 6, 7, 8, 9]
 
         with pytest.warns(RuntimeWarning, match='divide by zero'):
             _, p = stats.brunnermunzel(x, y, distribution="normal")
-        assert_equal(p, 0) 
+        assert_equal(p, 0)
 
 
 class TestRatioUniforms:

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -6980,6 +6980,27 @@ class TestBrunnerMunzel:
         assert_approx_equal(p1, 0.0057862086661515377,
                             significant=self.significant)
 
+    def test_brunnermunzel_return_nan(self):
+        """ tests that a warning is emitted when p is nan
+        p-value with t-distributions can be nan (0/0)
+        """
+        x = [1, 2, 3]
+        y = [5, 6, 7, 8, 9]
+
+        with pytest.warns(RuntimeWarning, match='p-value cannot be estimated'):
+            stats.brunnermunzel(x, y, distribution="t")
+
+    def test_brunnermunzel_normal_dist(self):
+        """ tests that a p is 0 for datasets that cause p->nan
+        when t-distribution is used
+        """
+        x = [1, 2, 3]
+        y = [5, 6, 7, 8, 9]
+
+        with pytest.warns(RuntimeWarning, match='divide by zero'):
+            _, p = stats.brunnermunzel(x, y, distribution="normal")
+        assert_equal(p, 0) 
+
 
 class TestRatioUniforms:
     """ Tests for rvs_ratio_uniforms.


### PR DESCRIPTION
#### Reference issue
closes #15843

#### What does this implement/fix?

emits a warning when `scipy.stats.brunnermunzel` cannot compute p-value
because both numerator and denominator are 0, and therefore p-value is nan
also suggests an alternative (using distribution="normal")

~~This change does not change any output/no code is changed. The only change
is emitting a warning in some cases where output p-value is nan~~


also add two tests:

1. `test_brunnermunzel_return_nan` tests that the correct warning is raised when using a t-distribution
2. `test_brunnermunzel_normal_dist` tests that p=0 when using a normal dist with the problematic dataset
