### PR TITLE
MAINT: sparse.linalg: Missing tfqmr in the re-entrancy test

### DIFF
--- a/scipy/sparse/linalg/_isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_iterative.py
@@ -143,7 +143,7 @@ class IterativeParams:
 
         # Non-symmetric and Positive Definite
         #
-        # cgs, qmr, and bicg fail to converge on this one
+        # cgs, qmr, bicg and tfqmr fail to converge on this one
         #   -- algorithmic limitation apparently
         data = ones((2,10))
         data[0,:] = 2
@@ -154,7 +154,7 @@ class IterativeParams:
         self.cases.append(Case("nonsymposdef", A.astype('F'),
                                skip=sym_solvers+[cgs, qmr, bicg, tfqmr]))
 
-        # Symmetric, non-pd, hitting cgs/bicg/bicgstab/qmr breakdown
+        # Symmetric, non-pd, hitting cgs/bicg/bicgstab/qmr/tfqmr breakdown
         A = np.array([[0, 0, 0, 0, 0, 1, -1, -0, -0, -0, -0],
                       [0, 0, 0, 0, 0, 2, -0, -1, -0, -0, -0],
                       [0, 0, 0, 0, 0, 2, -0, -0, -1, -0, -0],
@@ -348,7 +348,7 @@ def test_precond_inverse(case):
 
 def test_reentrancy():
     non_reentrant = [cg, cgs, bicg, bicgstab, gmres, qmr]
-    reentrant = [lgmres, minres, gcrotmk]
+    reentrant = [lgmres, minres, gcrotmk, tfqmr]
     for solver in reentrant + non_reentrant:
         with suppress_warnings() as sup:
             sup.filter(DeprecationWarning, ".*called without specifying.*")


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes gh-15426 because my forked scipy repository is removed by mistake.

#### What does this implement/fix?
<!--Please explain your changes.-->
TFQMR implementation is re-entrant, forget to add it to test_reentrancy, this PR fixed the hole.

#### Additional information
<!--Any additional information you think is important.-->
