### PR TITLE
ENH: stats.rv_continuous.expect: split interval to improve reliability

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -2885,6 +2885,13 @@ class rv_continuous(rv_generic):
         finite. For example ``cauchy(0).mean()`` returns ``np.nan`` and
         ``cauchy(0).expect()`` returns ``0.0``.
 
+        Likewise, the accuracy of results are not verified by the function.
+        `scipy.integrate.quad` is typically reliable for integrals that are
+        numerically favorable, but it is not guaranteed to converge
+        to a correct value for all possible intervals and integrands. This
+        function is provided for convenience; for critical applications,
+        check results against other integration methods.
+
         The function is not vectorized.
 
         Examples
@@ -2928,9 +2935,15 @@ class rv_continuous(rv_generic):
         else:
             invfac = 1.0
         kwds['args'] = args
-        # Silence floating point warnings from integration.
-        with np.errstate(all='ignore'):
-            vals = integrate.quad(fun, lb, ub, **kwds)[0] / invfac
+        # split the interval to (hopefully) help integrator; see gh-8928
+        alpha = 0.01  # split body from tails at `alpha` probability mass
+        c = loc + self._ppf(alpha, *args)*scale
+        d = loc + self._isf(alpha, *args)*scale
+        # Do not silence warnings from integration.
+        lbc = integrate.quad(fun, lb, c, **kwds)[0]
+        cd = integrate.quad(fun, c, d, **kwds)[0]
+        dub = integrate.quad(fun, d, ub, **kwds)[0]
+        vals = (lbc + cd + dub) / invfac
         return vals
 
     def _param_info(self):

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -2935,15 +2935,16 @@ class rv_continuous(rv_generic):
         else:
             invfac = 1.0
         kwds['args'] = args
-        # split the interval to (hopefully) help integrator; see gh-8928
-        alpha = 0.01  # split body from tails at `alpha` probability mass
-        c = loc + self._ppf(alpha, *args)*scale
-        d = loc + self._isf(alpha, *args)*scale
+        # split the interval to help integrator; see gh-8928
+        alpha = 0.05  # split body from tails at `alpha` probability mass
+        # considered separate calls to _ppf/_isf, but accuracy is not needed
+        c, d = loc + self._ppf(np.array([alpha, 1-alpha]), *args)*scale
         # Do not silence warnings from integration.
         lbc = integrate.quad(fun, lb, c, **kwds)[0]
         cd = integrate.quad(fun, c, d, **kwds)[0]
         dub = integrate.quad(fun, d, ub, **kwds)[0]
         vals = (lbc + cd + dub) / invfac
+
         return vals
 
     def _param_info(self):

--- a/scipy/stats/tests/common_tests.py
+++ b/scipy/stats/tests/common_tests.py
@@ -24,9 +24,7 @@ def check_normalization(distfn, args, distname):
     norm_moment = distfn.moment(0, *args)
     npt.assert_allclose(norm_moment, 1.0)
 
-    # this is a temporary plug: either ncf or expect is problematic;
-    # best be marked as a knownfail, but I've no clue how to do it.
-    if distname == "ncf":
+    if distname == "rv_histogram_instance":
         atol, rtol = 1e-5, 0
     else:
         atol, rtol = 1e-7, 1e-7
@@ -66,10 +64,10 @@ def check_mean_expect(distfn, arg, m, msg):
 
 
 def check_var_expect(distfn, arg, m, v, msg):
+    kwargs = {'rtol': 5e-6} if msg=="rv_histogram_instance" else {}
     if np.isfinite(v):
         m2 = distfn.expect(lambda x: x*x, arg)
-        npt.assert_almost_equal(m2, v + m*m, decimal=5, err_msg=msg +
-                            ' - 2st moment (expect)')
+        npt.assert_allclose(m2, v + m*m, **kwargs)
 
 
 def check_skew_expect(distfn, arg, m, v, s, msg):

--- a/scipy/stats/tests/common_tests.py
+++ b/scipy/stats/tests/common_tests.py
@@ -64,7 +64,7 @@ def check_mean_expect(distfn, arg, m, msg):
 
 
 def check_var_expect(distfn, arg, m, v, msg):
-    kwargs = {'rtol': 5e-6} if msg=="rv_histogram_instance" else {}
+    kwargs = {'rtol': 5e-6} if msg == "rv_histogram_instance" else {}
     if np.isfinite(v):
         m2 = distfn.expect(lambda x: x*x, arg)
         npt.assert_allclose(m2, v + m*m, **kwargs)

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -248,8 +248,8 @@ def test_levy_stable_random_state_property():
 
 
 def cases_test_moments():
-    fail_normalization = set(['vonmises'])
-    fail_higher = set(['vonmises', 'ncf'])
+    fail_normalization = set()
+    fail_higher = set(['ncf'])
 
     for distname, arg in distcont[:] + [(histogram_test_instance, tuple())]:
         if distname == 'levy_stable':
@@ -286,19 +286,23 @@ def test_moments(distname, arg, normalization_ok, higher_ok, is_xfailing):
     with npt.suppress_warnings() as sup:
         sup.filter(IntegrationWarning,
                    "The integral is probably divergent, or slowly convergent.")
+        sup.filter(IntegrationWarning,
+                   "The maximum number of subdivisions.")
+
         if is_xfailing:
             sup.filter(IntegrationWarning)
 
         m, v, s, k = distfn.stats(*arg, moments='mvsk')
 
-        if normalization_ok:
-            check_normalization(distfn, arg, distname)
+        with np.errstate(all="ignore"):
+            if normalization_ok:
+                check_normalization(distfn, arg, distname)
 
-        if higher_ok:
-            check_mean_expect(distfn, arg, m, distname)
-            check_skew_expect(distfn, arg, m, v, s, distname)
-            check_var_expect(distfn, arg, m, v, distname)
-            check_kurt_expect(distfn, arg, m, v, k, distname)
+            if higher_ok:
+                check_mean_expect(distfn, arg, m, distname)
+                check_skew_expect(distfn, arg, m, v, s, distname)
+                check_var_expect(distfn, arg, m, v, distname)
+                check_kurt_expect(distfn, arg, m, v, k, distname)
 
         check_moment(distfn, arg, m, v, distname)
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -4545,6 +4545,27 @@ class TestExpect:
         assert_allclose(stats.gamma.expect(args=(148,)), 148)
         assert_allclose(stats.logistic.expect(loc=85), 85)
 
+    def test_lb_ub_gh15855(self):
+        # Make sure changes to `expect` made in gh15855 treat lb/ub correctly
+        dist = stats.uniform
+        ref = dist.mean(loc=10, scale=5)  # 12.5
+        # moment over whole distribution
+        assert_allclose(dist.expect(loc=10, scale=5), ref)
+        # moment over whole distribution, lb and ub outside of support
+        assert_allclose(dist.expect(loc=10, scale=5, lb=9, ub=16), ref)
+        # moment over 60% of distribution, [lb, ub] centered within support
+        assert_allclose(dist.expect(loc=10, scale=5, lb=11, ub=14), ref*0.6)
+        # moment over truncated distribution, essentially
+        assert_allclose(dist.expect(loc=10, scale=5, lb=11, ub=14,
+                                    conditional=True), ref)
+        # moment over 40% of distribution, [lb, ub] not centered within support
+        assert_allclose(dist.expect(loc=10, scale=5, lb=11, ub=13), 12*0.4)
+        # moment with lb > ub
+        assert_allclose(dist.expect(loc=10, scale=5, lb=13, ub=11), -12*0.4)
+        # moment with lb > ub, conditional
+        assert_allclose(dist.expect(loc=10, scale=5, lb=13, ub=11,
+                                    conditional=True), 12)
+
 
 class TestNct:
     def test_nc_parameter(self):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -4369,9 +4369,10 @@ class TestFrozen:
             return x
 
         gm = stats.gamma(a=2, loc=3, scale=4)
-        gm_val = gm.expect(func, lb=1, ub=2, conditional=True)
-        gamma_val = stats.gamma.expect(func, args=(2,), loc=3, scale=4,
-                                       lb=1, ub=2, conditional=True)
+        with np.errstate(invalid="ignore", divide="ignore"):
+            gm_val = gm.expect(func, lb=1, ub=2, conditional=True)
+            gamma_val = stats.gamma.expect(func, args=(2,), loc=3, scale=4,
+                                           lb=1, ub=2, conditional=True)
         assert_allclose(gm_val, gamma_val)
 
         p = stats.poisson(3, loc=4)
@@ -4534,6 +4535,15 @@ class TestExpect:
         for mu in [5, 7]:
             m5 = stats.poisson.moment(5, mu)
             assert_allclose(m5, poiss_moment5(mu), rtol=1e-10)
+
+    def test_challenging_cases_gh8928(self):
+        # Several cases where `expect` failed to produce a correct result were
+        # reported in gh-8928. Check that these cases have been resolved.
+        assert_allclose(stats.norm.expect(loc=36, scale=1.0), 36)
+        assert_allclose(stats.norm.expect(loc=40, scale=1.0), 40)
+        assert_allclose(stats.norm.expect(loc=10, scale=0.1), 10)
+        assert_allclose(stats.gamma.expect(args=(148,)), 148)
+        assert_allclose(stats.logistic.expect(loc=85), 85)
 
 
 class TestNct:


### PR DESCRIPTION
#### Reference issue
Closes gh-8928

#### What does this implement/fix?
gh-8928 reported many examples where `rv_continuous.expect` gave inaccurate results. Since it relies on `quad`, we cannot expect `expect` to be perfect for all intervals and integrands, but it can be improved based on knowledge of where the distribution's probability mass is non-negligble. This PR attempts to make `expect` more reliable (albeit slower) by splitting the interval at the tails and evaluating the integral for the left tail, body, and right tail separately.

#### Additional information
I will add tests from the original issue. 

Hopefully, this addresses the `stats`-specific part of the issue. I think that is all we can really aim for here: take advantage of the stats-specific part of the problem to improve the results. Beyond that, this is an `integrate` issue.

I skipped CI in the initial commit because I need to check locally which tests break due to removing use of `np.errstate` from `expect`. We can silience the integrator warnings in the tests, but users should see when the integrator knows it's having trouble.

Perhaps instead of splitting the integral explicitly, we can use the `points` argument of `quad`. I'll try that.