### PR TITLE
CI: fix Azure workflows

### DIFF
--- a/ci/azure-travis-template.yaml
+++ b/ci/azure-travis-template.yaml
@@ -64,7 +64,7 @@ steps:
   displayName: 'Add ccache to path'
 - script: >-
     pip install --upgrade ${{parameters.numpy_spec}} &&
-    pip install --upgrade pip==20.2.4 setuptools wheel &&
+    pip install --upgrade pip==20.2.4 setuptools==59.6.0 wheel &&
     pip install ${{parameters.other_spec}}
     cython
     gmpy2

--- a/ci/azure-travis-template.yaml
+++ b/ci/azure-travis-template.yaml
@@ -82,7 +82,7 @@ steps:
   - script: pip install pytest-cov coverage codecov
     displayName: 'Install coverage dependencies'
 - ${{ if eq(parameters.refguide_check, true) }}:
-  - script: pip install matplotlib sphinx==3.1 numpydoc==1.1
+  - script: pip install matplotlib sphinx==3.1 numpydoc==1.1 "Jinja2<=3.0.3"
     displayName: 'Install documentation dependencies'
   - script: sudo apt-get install -y wamerican-small
     displayName: 'Install word list (for csgraph tutorial)'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,12 @@ requires = [
 [project]
 name = "SciPy"
 license = {file = "LICENSE.txt"}
+description = """
+SciPy (pronounced "Sigh Pie") is an open-source software for mathematics,
+science, and engineering. It includes modules for statistics, optimization,
+integration, linear algebra, Fourier transforms, signal and image processing,
+ODE solvers, and more.
+"""
 
 maintainers = [
     {name = "SciPy Developers", email = "scipy-dev@python.org"},
@@ -76,7 +82,7 @@ classifiers = [
     "Operating System :: Unix",
     "Operating System :: MacOS",
 ]
-dynamic = ['version', 'description']
+dynamic = ['version']
 
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
Azure pipelines are failing. Ex: https://dev.azure.com/scipy-org/SciPy/_build/results?buildId=17282&view=logs&jobId=7902a2c1-7b88-5b2d-6408-84b88759c642&j=7902a2c1-7b88-5b2d-6408-84b88759c642&t=893309fc-8329-5d49-356d-625e41704eb4

* pin `setuptools<0.60`
* pin `Jinja2<3.1.0` 
* missing description in `pyproject.toml`



<details>
<summary>Details</summary>

```
  `numpy.distutils` is deprecated since NumPy 1.23.0, as a result
  of the deprecation of `distutils` itself. It will be removed for
  Python >= 3.12. For older Python versions it will remain present.
  It is recommended to use `setuptools < 60.0` for those Python versions.
  For more details, see:
    https://numpy.org/devdocs/reference/distutils_status_migration.html 


  from numpy.distutils.core import setup
Running from SciPy source directory.
/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/setuptools/config/pyprojecttoml.py:100: _ExperimentalProjectMetadata: Support for project metadata in `pyproject.toml` is still experimental and may be removed (or change) in future releases.
  warnings.warn(msg, _ExperimentalProjectMetadata)
Traceback (most recent call last):
  File "setup.py", line 532, in <module>
    setup_package()
  File "setup.py", line 528, in setup_package

```
</details>