### PR TITLE
ENH: stats.permutation_test: refine comparison of observed statistic to null distribution

### DIFF
--- a/scipy/stats/_resampling.py
+++ b/scipy/stats/_resampling.py
@@ -1359,7 +1359,7 @@ def permutation_test(data, statistic, *, permutation_type='independent',
     >>> unique = np.unique(null)
     >>> unique
     array([-1. , -0.8, -0.8, -0.6, -0.4, -0.2, -0.2,  0. ,  0.2,  0.2,  0.4,
-            0.6,  0.8,  0.8,  1. ])
+            0.6,  0.8,  0.8,  1. ]) # may vary
     >>> unique[np.isclose(r, unique)].tolist()
     [0.7999999999999999, 0.8]
 
@@ -1370,7 +1370,7 @@ def permutation_test(data, statistic, *, permutation_type='independent',
 
     >>> incorrect_pvalue = np.count_nonzero(null >= r) / len(null)
     >>> incorrect_pvalue
-    0.1111111111111111
+    0.1111111111111111  # may vary
 
     Instead, `permutation_test` treats elements of the null distribution that
     are within a factor of ``1+1e-14`` of the observed value of the statistic
@@ -1412,14 +1412,15 @@ def permutation_test(data, statistic, *, permutation_type='independent',
     # relative tolerance for detecting numerically distinct but
     # theoretically equal values in the null distribution
     eps = 1e-14
+    gamma = (1 + eps)**np.sign(observed)
 
     def less(null_distribution, observed):
-        cmps = null_distribution <= observed * (1+eps)
+        cmps = null_distribution <= observed * gamma
         pvalues = (cmps.sum(axis=0) + adjustment) / (n_resamples + adjustment)
         return pvalues
 
     def greater(null_distribution, observed):
-        cmps = null_distribution >= observed / (1+eps)
+        cmps = null_distribution >= observed / gamma
         pvalues = (cmps.sum(axis=0) + adjustment) / (n_resamples + adjustment)
         return pvalues
 

--- a/scipy/stats/_resampling.py
+++ b/scipy/stats/_resampling.py
@@ -1374,10 +1374,10 @@ def permutation_test(data, statistic, *, permutation_type='independent',
     0.1111111111111111  # may vary
 
     Instead, `permutation_test` treats elements of the null distribution that
-    are within a factor of ``1+1e-14`` of the observed value of the statistic
-    to be equal to the test statistic.
+    are within ``max(1e-14, abs(r)*1e-14)`` of the observed value of the
+    statistic ``r`` to be equal to ``r``.
 
-    >>> correct_pvalue = np.count_nonzero(null >= r / (1+1e-14)) / len(null)
+    >>> correct_pvalue = np.count_nonzero(null >= r - 1e-14) / len(null)
     >>> correct_pvalue
     0.16666666666666666
     >>> res.pvalue == correct_pvalue
@@ -1413,15 +1413,15 @@ def permutation_test(data, statistic, *, permutation_type='independent',
     # relative tolerance for detecting numerically distinct but
     # theoretically equal values in the null distribution
     eps = 1e-14
-    gamma = (1 + eps)**np.sign(observed)
+    gamma = np.maximum(eps, np.abs(eps * observed))
 
     def less(null_distribution, observed):
-        cmps = null_distribution <= observed * gamma
+        cmps = null_distribution <= observed + gamma
         pvalues = (cmps.sum(axis=0) + adjustment) / (n_resamples + adjustment)
         return pvalues
 
     def greater(null_distribution, observed):
-        cmps = null_distribution >= observed / gamma
+        cmps = null_distribution >= observed - gamma
         pvalues = (cmps.sum(axis=0) + adjustment) / (n_resamples + adjustment)
         return pvalues
 

--- a/scipy/stats/_resampling.py
+++ b/scipy/stats/_resampling.py
@@ -1334,6 +1334,7 @@ def permutation_test(data, statistic, *, permutation_type='independent',
     >>> plt.title("Permutation distribution of test statistic")
     >>> plt.xlabel("Value of Statistic")
     >>> plt.ylabel("Frequency")
+    >>> plt.show()
 
     Inspection of the null distribution is essential if the statistic suffers
     from inaccuracy due to limited machine precision. Consider the following

--- a/scipy/stats/_resampling.py
+++ b/scipy/stats/_resampling.py
@@ -1224,6 +1224,21 @@ def permutation_test(data, statistic, *, permutation_type='independent',
     only one sample, then the null distribution is formed by independently
     changing the *sign* of each observation.
 
+    .. warning::
+        The p-value is calculated by counting the elements of the null
+        distribution that are as extreme or more extreme than the observed
+        value of the statistic. Due to the use of finite precision arithmetic,
+        some statistic functions return numerically distinct values when the
+        theoretical values would be exactly equal. In some cases, this could
+        lead to a large error in the calculated p-value. `permutation_test`
+        guards against this by considering elements in the null distribution
+        that are "close" (within a factor of ``1+1e-14``) to the observed
+        value of the test statistic as equal to the observed value of the
+        test statistic. However, the user is advised to inspect the null
+        distribution to assess whether this method of comparison is
+        appropriate, and if not, calculate the p-value manually. See example
+        below.
+
     References
     ----------
 
@@ -1320,6 +1335,59 @@ def permutation_test(data, statistic, *, permutation_type='independent',
     >>> plt.xlabel("Value of Statistic")
     >>> plt.ylabel("Frequency")
 
+    Inspection of the null distribution is essential if the statistic suffers
+    from inaccuracy due to limited machine precision. Consider the following
+    case:
+
+    >>> from scipy.stats import pearsonr
+    >>> x = [1, 2, 4, 3]
+    >>> y = [2, 4, 6, 8]
+    >>> def statistic(x, y):
+    ...     return pearsonr(x, y).statistic
+    >>> res = permutation_test((x, y), statistic, vectorized=False,
+    ...                        permutation_type='pairings',
+    ...                        alternative='greater')
+    >>> r, pvalue, null = res.statistic, res.pvalue, res.null_distribution
+
+    In this case, some elements of the null distribution differ from the
+    observed value of the correlation coefficient ``r`` due to numerical noise.
+    We manually inspect the elements of the null distribution that are nearly
+    the same as the observed value of the test statistic.
+
+    >>> r
+    0.8
+    >>> unique = np.unique(null)
+    >>> unique
+    array([-1. , -0.8, -0.8, -0.6, -0.4, -0.2, -0.2,  0. ,  0.2,  0.2,  0.4,
+            0.6,  0.8,  0.8,  1. ])
+    >>> unique[np.isclose(r, unique)].tolist()
+    [0.7999999999999999, 0.8]
+
+    If `permutation_test` were to perform the comparison naively, the
+    elements of the null distribution with value ``0.7999999999999999`` would
+    not be considered as extreme or more extreme as the observed value of the
+    statistic, so the calculated p-value would be too small.
+
+    >>> incorrect_pvalue = np.count_nonzero(null >= r) / len(null)
+    >>> incorrect_pvalue
+    0.1111111111111111
+
+    Instead, `permutation_test` treats elements of the null distribution that
+    are within a factor of ``1+1e-14`` of the observed value of the statistic
+    to be equal to the test statistic.
+
+    >>> correct_pvalue = np.count_nonzero(null >= r / (1+1e-14)) / len(null)
+    >>> correct_pvalue
+    0.16666666666666666
+    >>> res.pvalue == correct_pvalue
+    True
+
+    This method of comparison is expected to be accurate in most practical
+    situations, but the user is advised to assess this by inspecting the
+    elements of the null distribution that are close to the observed value
+    of the statistic. Also, consider the use of statistics that can be
+    calculated using exact arithmetic (e.g. integer statistics).
+
     """
     args = _permutation_test_iv(data, statistic, permutation_type, vectorized,
                                 n_resamples, batch, alternative, axis,
@@ -1341,13 +1409,17 @@ def permutation_test(data, statistic, *, permutation_type='independent',
     # See References [2] and [3]
     adjustment = 0 if exact_test else 1
 
+    # relative tolerance for detecting numerically distinct but
+    # theoretically equal values in the null distribution
+    eps = 1e-14
+
     def less(null_distribution, observed):
-        cmps = null_distribution <= observed
+        cmps = null_distribution <= observed * (1+eps)
         pvalues = (cmps.sum(axis=0) + adjustment) / (n_resamples + adjustment)
         return pvalues
 
     def greater(null_distribution, observed):
-        cmps = null_distribution >= observed
+        cmps = null_distribution >= observed / (1+eps)
         pvalues = (cmps.sum(axis=0) + adjustment) / (n_resamples + adjustment)
         return pvalues
 

--- a/scipy/stats/tests/test_resampling.py
+++ b/scipy/stats/tests/test_resampling.py
@@ -1407,11 +1407,7 @@ class TestPermutationTest:
                                      permutation_type='pairings')
         r, pvalue, null = res.statistic, res.pvalue, res.null_distribution
 
-        assert r == 0.8
-
-        incorrect_p = 2 * np.sum(null >= r) / len(null)
         correct_p = 2 * np.sum(null >= r / (1+1e-14)) / len(null)
-        assert pvalue != incorrect_p
         assert pvalue == correct_p == 1/3
         # Compare against other exact correlation tests using R corr.test
         # options(digits=16)

--- a/scipy/stats/tests/test_resampling.py
+++ b/scipy/stats/tests/test_resampling.py
@@ -1407,7 +1407,7 @@ class TestPermutationTest:
                                      permutation_type='pairings')
         r, pvalue, null = res.statistic, res.pvalue, res.null_distribution
 
-        correct_p = 2 * np.sum(null >= r / (1+1e-14)) / len(null)
+        correct_p = 2 * np.sum(null >= r - 1e-14) / len(null)
         assert pvalue == correct_p == 1/3
         # Compare against other exact correlation tests using R corr.test
         # options(digits=16)

--- a/scipy/stats/tests/test_resampling.py
+++ b/scipy/stats/tests/test_resampling.py
@@ -1393,6 +1393,33 @@ class TestPermutationTest:
         got = list(_resampling._batch_generator(iterable, batch))
         assert got == expected
 
+    def test_finite_precision_statistic(self):
+        # Some statistics return numerically distinct values when the values
+        # should be equal in theory. Test that `permutation_test` accounts
+        # for this in some way.
+        x = [1, 2, 4, 3]
+        y = [2, 4, 6, 8]
+
+        def statistic(x, y):
+            return stats.pearsonr(x, y)[0]
+
+        res = stats.permutation_test((x, y), statistic, vectorized=False,
+                                     permutation_type='pairings')
+        r, pvalue, null = res.statistic, res.pvalue, res.null_distribution
+
+        assert r == 0.8
+
+        incorrect_p = 2 * np.sum(null >= r) / len(null)
+        correct_p = 2 * np.sum(null >= r / (1+1e-14)) / len(null)
+        assert pvalue != incorrect_p
+        assert pvalue == correct_p == 1/3
+        # Compare against other exact correlation tests using R corr.test
+        # options(digits=16)
+        # x = c(1, 2, 4, 3)
+        # y = c(2, 4, 6, 8)
+        # cor.test(x, y, alternative = "t", method = "spearman")  # 0.333333333
+        # cor.test(x, y, alternative = "t", method = "kendall")  # 0.333333333
+
 
 def test_all_partitions_concatenated():
     # make sure that _all_paritions_concatenated produces the correct number


### PR DESCRIPTION
#### Reference issue
gh-7882

#### What does this implement/fix?
In `permutation_test`, elements of the null distribution may differ from the observed value of the test statistic due to numerical noise. In some cases, this can lead to much larger errors in the p-value. This PR accounts for this problem. 

#### Additional information
Also considered:
* Exposing absolute and relative tolerances to the user
* Warning the user if `np.count_nonzero(np.isclose(res.statistic, np.unique(res.null_distribution))) > 1`

The former complicates the API, and it seems unreasonable for the user to know more appropriate tolerances a priori. Instead, I gave an example of how one might inspect the null distribution and refine the p-value calculation if needed.

I would be happy to implement the latter. Note that `np.unique` is _not_ vectorized to act over 1D axis slices (as this could lead to jagged array output). There are a few ways to handle this, but I think what I might do is use `numpy.apply_along_axis` or `np.nditer` to loop over the 1D axes and raise the warning for each slice that fails `np.count_nonzero(np.isclose(res.statistic, np.unique(slice))) > 1`.

Similar logic might be added to and `monte_carlo_test` and `bootstrap`.