### PR TITLE
TST: signal: Convert a test with 'assert_array_less' to 'less or almost equal'.

### DIFF
--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -1001,7 +1001,9 @@ class TestSOSFreqz:
         dB = 20*np.log10(np.maximum(np.abs(h), 1e-10))
         w /= np.pi
         assert_allclose(dB[w >= 0.3], 0, atol=.55)
-        assert_array_less(dB[w <= 0.2], -150)
+        # Allow some numerical slop in the upper bound -150, so this is
+        # a check that dB[w <= 0.2] is less than or almost equal to -150.
+        assert dB[w <= 0.2].max() < -150*(1 - 1e-12)
 
     @mpmath_check("0.10")
     def test_sos_freqz_against_mp(self):


### PR DESCRIPTION
The constant upper bound that is used in the call of assert_array_less is increased with a relative change of 1e-12,  converting the test into 'less or almost equal'.

This fixes the failure of the test `TestSOSFreqz.test_sosfreqz_design_ellip` that has started occurring recently:

```
___________________ TestSOSFreqz.test_sosfreqz_design_ellip ____________________
../testenv/lib/python3.10/site-packages/scipy/signal/tests/test_filter_design.py:1004: in test_sosfreqz_design_ellip
    assert_array_less(dB[w <= 0.2], -150)
E   AssertionError: 
E   Arrays are not less-ordered
E   
E   Mismatched elements: 1 / 103 (0.971%)
E   Max absolute difference: 43.79259854
E   Max relative difference: 0.29195066
E    x: array([-150.      , -150.037677, -150.15139 , -150.343226, -150.616839,
E          -150.977726, -151.433699, -151.995613, -152.678537, -153.503667,
E          -154.501577, -155.718136, -157.226108, -159.150629, -161.734827,...
E    y: array(-150)
```
This fix is based on the other tests in the same file that check the frequency response of a filter using `assert_array_less`.  Most of the other uses of the test function already have some "slop" in the upper bound, so they are actually testing "less or almost equal".  Apparently numerical noise can result in the gain being slight more than the requested upper bound.

