### PR TITLE
DEP: remove py_vq2

### DIFF
--- a/scipy/cluster/vq.py
+++ b/scipy/cluster/vq.py
@@ -262,10 +262,6 @@ def py_vq(obs, code_book, check_finite=True):
     return code, min_dist
 
 
-# py_vq2 was equivalent to py_vq
-py_vq2 = np.deprecate(py_vq, old_name='py_vq2', new_name='py_vq')
-
-
 def _kmeans(obs, guess, thresh=1e-5):
     """ "raw" version of k-means.
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #15760 

#### What does this implement/fix?
<!--Please explain your changes.-->
Removed the deprecated py_vq2 from cluster/vq.py

#### Additional information
<!--Any additional information you think is important.-->
