### PR TITLE
DEP: remove old BSR methods

### DIFF
--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -335,18 +335,6 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
     # Arithmetic methods #
     ######################
 
-    @np.deprecate(message="BSR matvec is deprecated in SciPy 0.19.0. "
-                          "Use * operator instead.")
-    def matvec(self, other):
-        """Multiply matrix by vector."""
-        return self * other
-
-    @np.deprecate(message="BSR matmat is deprecated in SciPy 0.19.0. "
-                          "Use * operator instead.")
-    def matmat(self, other):
-        """Multiply this sparse matrix by other matrix."""
-        return self * other
-
     def _add_dense(self, other):
         return self.tocoo(copy=False)._add_dense(other)
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #15759

#### What does this implement/fix?
<!--Please explain your changes.-->
Removed the deprecated bsr methods matmat and matvec.

#### Additional information
<!--Any additional information you think is important.-->
