### PR TITLE
DEP: remove signal.windows.hanning

### DIFF
--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -345,10 +345,6 @@ deprecated_windows = ('boxcar', 'triang', 'parzen', 'bohman', 'blackman',
                       'general_gaussian', 'chebwin', 'cosine',
                       'hann', 'exponential', 'tukey')
 
-# backward compatibility imports for actually deprecated windows not
-# in the above list
-from .windows import hanning
-
 
 def deco(name):
     f = getattr(windows, name)

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -22,7 +22,6 @@ window_funcs = [
     ('blackmanharris', ()),
     ('flattop', ()),
     ('bartlett', ()),
-    ('hanning', ()),
     ('barthann', ()),
     ('hamming', ()),
     ('kaiser', (1,)),
@@ -703,8 +702,6 @@ def test_windowfunc_basics():
         window = getattr(windows, window_name)
         with suppress_warnings() as sup:
             sup.filter(UserWarning, "This window is not suitable")
-            if window_name in ('hanning',):
-                sup.filter(DeprecationWarning)
             # Check symmetry for odd and even lengths
             w1 = window(8, *params, sym=True)
             w2 = window(7, *params, sym=False)
@@ -772,7 +769,6 @@ def test_not_needs_params():
                    'cosine',
                    'flattop',
                    'hamming',
-                   'hanning',
                    'nuttall',
                    'parzen',
                    'taylor',

--- a/scipy/signal/windows/__init__.py
+++ b/scipy/signal/windows/__init__.py
@@ -28,7 +28,6 @@ The suite of window functions for filtering and spectral estimation.
    general_hamming         -- Generalized Hamming window
    hamming                 -- Hamming window
    hann                    -- Hann window
-   hanning                 -- Hann window
    kaiser                  -- Kaiser window
    kaiser_bessel_derived   -- Kaiser-Bessel derived window
    nuttall                 -- Nuttall's minimum 4-term Blackman-Harris window
@@ -45,7 +44,7 @@ from ._windows import *
 from . import windows
 
 __all__ = ['boxcar', 'triang', 'parzen', 'bohman', 'blackman', 'nuttall',
-           'blackmanharris', 'flattop', 'bartlett', 'hanning', 'barthann',
+           'blackmanharris', 'flattop', 'bartlett', 'barthann',
            'hamming', 'kaiser', 'kaiser_bessel_derived', 'gaussian',
            'general_gaussian', 'general_cosine', 'general_hamming',
            'chebwin', 'cosine', 'hann', 'exponential', 'tukey', 'taylor',

--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -7,7 +7,7 @@ import numpy as np
 from scipy import linalg, special, fft as sp_fft
 
 __all__ = ['boxcar', 'triang', 'parzen', 'bohman', 'blackman', 'nuttall',
-           'blackmanharris', 'flattop', 'bartlett', 'hanning', 'barthann',
+           'blackmanharris', 'flattop', 'bartlett', 'barthann',
            'hamming', 'kaiser', 'kaiser_bessel_derived', 'gaussian',
            'general_cosine', 'general_gaussian', 'general_hamming',
            'chebwin', 'cosine', 'hann', 'exponential', 'tukey', 'taylor',
@@ -786,11 +786,6 @@ def hann(M, sym=True):
     """
     # Docstring adapted from NumPy's hanning function
     return general_hamming(M, 0.5, sym)
-
-
-@np.deprecate(new_name='scipy.signal.windows.hann')
-def hanning(*args, **kwargs):
-    return hann(*args, **kwargs)
 
 
 def tukey(M, alpha=0.5, sym=True):
@@ -1748,7 +1743,7 @@ def taylor(M, nbar=4, sll=30, norm=True, sym=True):
 
     See Also
     --------
-    chebwin, kaiser, bartlett, blackman, hamming, hanning
+    chebwin, kaiser, bartlett, blackman, hamming, hann
 
     References
     ----------
@@ -2111,7 +2106,7 @@ _win_equiv_raw = {
         'general gauss', 'general_gauss', 'ggs'): (general_gaussian, True),
     ('general hamming', 'general_hamming'): (general_hamming, True),
     ('hamming', 'hamm', 'ham'): (hamming, False),
-    ('hanning', 'hann', 'han'): (hann, False),
+    ('hann', 'han'): (hann, False),
     ('kaiser', 'ksr'): (kaiser, True),
     ('kaiser bessel derived', 'kbd'): (kaiser_bessel_derived, True),
     ('nuttall', 'nutl', 'nut'): (nuttall, False),

--- a/scipy/signal/windows/windows.py
+++ b/scipy/signal/windows/windows.py
@@ -7,7 +7,7 @@ from . import _windows
 
 __all__ = [  # noqa: F822
     'boxcar', 'triang', 'parzen', 'bohman', 'blackman', 'nuttall',
-    'blackmanharris', 'flattop', 'bartlett', 'hanning', 'barthann',
+    'blackmanharris', 'flattop', 'bartlett', 'barthann',
     'hamming', 'kaiser', 'gaussian', 'general_cosine',
     'general_gaussian', 'general_hamming', 'chebwin', 'cosine',
     'hann', 'exponential', 'tukey', 'taylor', 'dpss', 'get_window',


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #15745 

#### What does this implement/fix?
<!--Please explain your changes.-->
Remove the deprecated windows.hanning method. removed it also from test_windows and from __all__ in signal & windows modules

#### Additional information
<!--Any additional information you think is important.-->
