### PR TITLE
DEP: enforced radius in spherical voronoi

### DIFF
--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -168,8 +168,8 @@ class SphericalVoronoi:
 
         if radius is None:
             raise ValueError('`radius` is `None`. '
-                          'Please provide a floating point number '
-                          '(i.e. `radius=1`).')
+                             'Please provide a floating point number '
+                             '(i.e. `radius=1`).')
 
         self.radius = float(radius)
         self.points = np.array(points).astype(np.double)

--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -167,12 +167,9 @@ class SphericalVoronoi:
     def __init__(self, points, radius=1, center=None, threshold=1e-06):
 
         if radius is None:
-            radius = 1.
-            warnings.warn('`radius` is `None`. '
-                          'This will raise an error in a future version. '
+            raise ValueError('`radius` is `None`. '
                           'Please provide a floating point number '
-                          '(i.e. `radius=1`).',
-                          DeprecationWarning)
+                          '(i.e. `radius=1`).')
 
         self.radius = float(radius)
         self.points = np.array(points).astype(np.double)

--- a/scipy/spatial/tests/test_spherical_voronoi.py
+++ b/scipy/spatial/tests/test_spherical_voronoi.py
@@ -148,7 +148,7 @@ class TestSphericalVoronoi:
         assert_array_almost_equal(sv_unit.vertices * 2,
                                   sv_scaled.vertices)
 
-    def test_old_radius_api_warning(self):
+    def test_old_radius_api_error(self):
         with pytest.raises(ValueError, match='`radius` is `None`. *'):
             SphericalVoronoi(self.points, radius=None)
 

--- a/scipy/spatial/tests/test_spherical_voronoi.py
+++ b/scipy/spatial/tests/test_spherical_voronoi.py
@@ -148,16 +148,9 @@ class TestSphericalVoronoi:
         assert_array_almost_equal(sv_unit.vertices * 2,
                                   sv_scaled.vertices)
 
-    def test_old_radius_api(self):
-        sv_unit = SphericalVoronoi(self.points, radius=1)
-        with suppress_warnings() as sup:
-            sup.filter(DeprecationWarning, "`radius` is `None`")
-            sv = SphericalVoronoi(self.points, None)
-            assert_array_almost_equal(sv_unit.vertices, sv.vertices)
-
     def test_old_radius_api_warning(self):
-        with assert_warns(DeprecationWarning):
-            SphericalVoronoi(self.points, None)
+        with pytest.raises(ValueError, match='`radius` is `None`. *'):
+            SphericalVoronoi(self.points, radius=None)
 
     def test_sort_vertices_of_regions(self):
         sv = SphericalVoronoi(self.points)


### PR DESCRIPTION
#### Reference issue
Closes gh-15743.

#### What does this implement/fix?
This enforces a radius in `spatial.SphericalVoronoi`.