### PR TITLE
DOC: stats: clarify truncnorm shape parameter definition

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -8200,15 +8200,14 @@ class truncnorm_gen(rv_continuous):
     Notes
     -----
     The standard form of this distribution is a standard normal truncated to
-    the range [a, b] --- notice that a and b are defined over the domain of the
-    standard normal.  To convert clip values for a specific mean and standard
-    deviation, use::
+    the range ``[a, b]``, where ``a`` and ``b`` are user-provided shape
+    parameters. The parameter ``loc`` shifts the mean of the underlying normal
+    distribution, and ``scale`` controls the standard deviation of the
+    underlying normal, but ``a`` and ``b`` are still defined over the domain
+    of the *standard* normal. To convert clip values defined over the domain
+    of a shifted and scaled normal to the required form, use::
 
-        a, b = (myclip_a - my_mean) / my_std, (myclip_b - my_mean) / my_std
-
-    `truncnorm` takes :math:`a` and :math:`b` as shape parameters.
-
-    %(after_notes)s
+        a, b = (myclip_a - loc) / scale, (myclip_b - loc) / scale
 
     %(example)s
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -8206,7 +8206,7 @@ class truncnorm_gen(rv_continuous):
     underlying normal, but ``a`` and ``b`` are still defined with respect to
     the *standard* normal. If ``myclip_a`` and ``myclip_b`` are clip values
     defined with respect to a shifted and scaled normal, they can be converted
-    the the required form according to::
+    the required form according to::
 
         a, b = (myclip_a - loc) / scale, (myclip_b - loc) / scale
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -8203,9 +8203,10 @@ class truncnorm_gen(rv_continuous):
     the range ``[a, b]``, where ``a`` and ``b`` are user-provided shape
     parameters. The parameter ``loc`` shifts the mean of the underlying normal
     distribution, and ``scale`` controls the standard deviation of the
-    underlying normal, but ``a`` and ``b`` are still defined over the domain
-    of the *standard* normal. To convert clip values defined over the domain
-    of a shifted and scaled normal to the required form, use::
+    underlying normal, but ``a`` and ``b`` are still defined with respect to
+    the *standard* normal. If ``myclip_a`` and ``myclip_b`` are clip values
+    defined with respect to a shifted and scaled normal, they can be converted
+    the the required form according to::
 
         a, b = (myclip_a - loc) / scale, (myclip_b - loc) / scale
 


### PR DESCRIPTION
#### Reference issue
Closes gh-15082

#### What does this implement/fix?
Issue gh-15082 was due to a misunderstanding of the `truncnorm` shape parameters. To resolve the issue, the OP suggested that the documentation be clarified. This PR attempts to do that.

@mikewojnowicz, would this resolve gh-15082?