### PR TITLE
BUG: check that iirfilter argument Wn satisfies Wn[0] < Wn[1]

### DIFF
--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -2342,6 +2342,8 @@ def iirfilter(N, Wn, rp=None, rs=None, btype='band', analog=False,
         half-cycles / sample.)
 
         For analog filters, `Wn` is an angular frequency (e.g., rad/s).
+
+        When Wn is a length-2 sequence, Wn[0] must be less than Wn[1].
     rp : float, optional
         For Chebyshev and elliptic filters, provides the maximum ripple
         in the passband. (dB)
@@ -2461,6 +2463,9 @@ def iirfilter(N, Wn, rp=None, rs=None, btype='band', analog=False,
 
     if numpy.any(Wn <= 0):
         raise ValueError("filter critical frequencies must be greater than 0")
+
+    if Wn.size > 1 and not Wn[0] < Wn[1]:
+        raise ValueError("Wn[0] must be less than Wn[1]")
 
     try:
         btype = band_dict[btype]

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -2343,7 +2343,7 @@ def iirfilter(N, Wn, rp=None, rs=None, btype='band', analog=False,
 
         For analog filters, `Wn` is an angular frequency (e.g., rad/s).
 
-        When Wn is a length-2 sequence, Wn[0] must be less than Wn[1].
+        When Wn is a length-2 sequence, ``Wn[0]`` must be less than ``Wn[1]``.
     rp : float, optional
         For Chebyshev and elliptic filters, provides the maximum ripple
         in the passband. (dB)

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -3943,6 +3943,15 @@ class TestIIRFilter:
         sos2 = iirfilter(N=1, Wn=1, btype='low', analog=True, output='sos')
         assert_array_almost_equal(sos, sos2)
 
+    def test_wn1_ge_wn0(self):
+        # gh-15773: should raise error if Wn[0] >= Wn[1]
+        with pytest.raises(ValueError,
+                           match=r"Wn\[0\] must be less than Wn\[1\]"):
+            iirfilter(2, [0.5, 0.5])
+        with pytest.raises(ValueError,
+                           match=r"Wn\[0\] must be less than Wn\[1\]"):
+            iirfilter(2, [0.6, 0.5])
+
 
 class TestGroupDelay:
     def test_identity_filter(self):


### PR DESCRIPTION


<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes gh-15773.

#### What does this implement/fix?
Check that Wn[0] < Wn[1], document this requirement, and add a unit test for the error case.

#### Additional information
I don't think there's any use for Wn[1] >= Wn[0], but I may be wrong.
