### PR TITLE
MAINT: sparse: Support tuple input parameters for the shape in `spdiags`

### DIFF
--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -64,10 +64,9 @@ def spdiags(data, diags, m=None, n=None, format=None):
     """
     if m is None and n is None:
         m = n = len(data[0])
-    elif m is not None and n is None:
-        m, n = m[0], m[1]
-    shape = (m, n)
-    return dia_matrix((data, diags), shape=shape).asformat(format)
+    elif n is None:
+        m, n = m
+    return dia_matrix((data, diags), shape=(m, n)).asformat(format)
 
 
 def diags(diagonals, offsets=0, shape=None, format=None, dtype=None):

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -23,7 +23,7 @@ from ._dia import dia_matrix
 from ._base import issparse
 
 
-def spdiags(data, diags, m, n, format=None):
+def spdiags(data, diags, m=None, n=None, format=None):
     """
     Return a sparse matrix from diagonals.
 
@@ -37,8 +37,10 @@ def spdiags(data, diags, m, n, format=None):
         * k = 0  the main diagonal
         * k > 0  the kth upper diagonal
         * k < 0  the kth lower diagonal
-    m, n : int
-        Shape of the result
+    m, n : int, tuple, optional
+        Shape of the result. If `n` is None and `m` is a given tuple,
+        the shape is this tuple. If omitted, the matrix is square and
+        its shape is len(data[0]).
     format : str, optional
         Format of the result. By default (format=None) an appropriate sparse
         matrix format is returned. This choice is subject to change.
@@ -60,7 +62,12 @@ def spdiags(data, diags, m, n, format=None):
            [0, 0, 3, 4]])
 
     """
-    return dia_matrix((data, diags), shape=(m, n)).asformat(format)
+    if m is None and n is None:
+        m = n = len(data[0])
+    elif m is not None and n is None:
+        m, n = m[0], m[1]
+    shape = (m, n)
+    return dia_matrix((data, diags), shape=shape).asformat(format)
 
 
 def diags(diagonals, offsets=0, shape=None, format=None, dtype=None):

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -71,9 +71,18 @@ class TestConstructUtils:
                                                  [0, 0,13, 0, 0],
                                                  [1, 0, 0,14, 0],
                                                  [0, 2, 0, 0,15]]))
+        cases.append((diags3, [-1, 1, 2], len(diags3[0]), len(diags3[0]),
+                      [[0, 7, 13, 0, 0],
+                       [1, 0, 8, 14, 0],
+                       [0, 2, 0, 9, 15],
+                       [0, 0, 3, 0, 10],
+                       [0, 0, 0, 4, 0]]))
 
         for d, o, m, n, result in cases:
+            if len(d[0]) == m and m == n:
+                assert_equal(construct.spdiags(d, o).toarray(), result)
             assert_equal(construct.spdiags(d, o, m, n).toarray(), result)
+            assert_equal(construct.spdiags(d, o, (m, n)).toarray(), result)
 
     def test_diags(self):
         a = array([1, 2, 3, 4, 5])


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
For the convenience of users, the sparse diagonal matrix function `spdiags` support tuple input of matrix shape, which is consistent with the input parameter (tuple form) of `diags` (The purpose is to make users no longer need to distinguish whether the shape input parameter is a tuple or just two integers). Because backward compatibility is also considered, shape input parameters of integer type in `spdiags` are still reserved.

#### Additional information
<!--Any additional information you think is important.-->
