### PR TITLE
MAINT: Fix Windows build warnings in `linalg.interpolative`

### DIFF
--- a/scipy/linalg/src/id_dist/src/iddp_asvd.f
+++ b/scipy/linalg/src/id_dist/src/iddp_asvd.f
@@ -160,8 +160,8 @@ c       for the present routine (please see routine iddp_asvd
 c       for further documentation).
 c
         implicit none
-        integer m,n,krank,list(n),ier
-        real*8 a(m,n),u(m,krank),v(n,krank),
+        integer m,n,krank,ier
+        real*8 a(m,n),u(m,krank),v(n,krank),list(n),
      1         s(krank),proj(krank,n-krank),col(m,krank),
      2         work((krank+1)*(m+3*n)+26*krank**2)
 c

--- a/scipy/linalg/src/id_dist/src/iddp_rsvd.f
+++ b/scipy/linalg/src/id_dist/src/iddp_rsvd.f
@@ -195,9 +195,9 @@ c       for the present routine (please see routine iddp_rsvd
 c       for further documentation).
 c
         implicit none
-        integer m,n,krank,list(n),ier
+        integer m,n,krank,ier
         real*8 p1t,p2t,p3t,p4t,p1,p2,p3,p4,u(m,krank),v(n,krank),
-     1         s(krank),proj(krank,n-krank),col(m*krank),
+     1         s(krank),proj(krank,n-krank),col(m*krank),list(n),
      2         work((krank+1)*(m+3*n)+26*krank**2)
         external matvect,matvec
 c

--- a/scipy/linalg/src/id_dist/src/iddr_asvd.f
+++ b/scipy/linalg/src/id_dist/src/iddr_asvd.f
@@ -88,8 +88,8 @@ c       for the present routine (please see routine iddr_asvd
 c       for further documentation).
 c
         implicit none
-        integer m,n,krank,list(n),ier
-        real*8 a(m,n),u(m,krank),v(n,krank),s(krank),
+        integer m,n,krank,ier
+        real*8 a(m,n),u(m,krank),v(n,krank),s(krank),list(n),
      1         proj(krank,n-krank),col(m*krank),
      2         winit((2*krank+17)*n+27*m+100),
      3         work((krank+1)*(m+3*n)+26*krank**2)

--- a/scipy/linalg/src/id_dist/src/iddr_rsvd.f
+++ b/scipy/linalg/src/id_dist/src/iddr_rsvd.f
@@ -124,9 +124,9 @@ c       for the present routine (please see routine iddr_rsvd
 c       for further documentation).
 c
         implicit none
-        integer m,n,krank,list(n),ier,k
+        integer m,n,krank,ier,k
         real*8 p1t,p2t,p3t,p4t,p1,p2,p3,p4,u(m,krank),v(n,krank),
-     1         s(krank),proj(krank*(n-krank)),col(m*krank),
+     1         s(krank),proj(krank*(n-krank)),col(m*krank),list(n),
      2         work((krank+1)*(m+3*n)+26*krank**2)
         external matvect,matvec
 c

--- a/scipy/linalg/src/id_dist/src/idzp_aid.f
+++ b/scipy/linalg/src/id_dist/src/idzp_aid.f
@@ -122,8 +122,8 @@ c       _N.B._: proj must be at least m*n complex*16 elements long
 c
         implicit none
         integer m,n,krank,list(n),j,k
-        real*8 eps,rnorms(n)
-        complex*16 a(m,n),proj(m,n)
+        real*8 eps
+        complex*16 a(m,n),proj(m,n),rnorms(n)
 c
 c
 c       Copy a into proj.
@@ -170,8 +170,8 @@ c       rnorms -- must be at least n real*8 elements long
 c
         implicit none
         integer n,n2,kranki,krank,list(n),j,k
-        real*8 eps,rnorms(n)
-        complex*16 proj(n2*n)
+        real*8 eps
+        complex*16 proj(n2*n),rnorms(n)
 c
 c
 c       Move the uppermost kranki x n block of the n2 x n matrix proj

--- a/scipy/linalg/src/id_dist/src/idzp_asvd.f
+++ b/scipy/linalg/src/id_dist/src/idzp_asvd.f
@@ -159,9 +159,9 @@ c       for the present routine (please see routine idzp_asvd
 c       for further documentation).
 c
         implicit none
-        integer m,n,krank,list(n),ier
+        integer m,n,krank,ier
         real*8 s(krank)
-        complex*16 a(m,n),u(m,krank),v(n,krank),
+        complex*16 a(m,n),u(m,krank),v(n,krank),list(n),
      1             proj(krank,n-krank),col(m,krank),
      2             work((krank+1)*(m+3*n+10)+9*krank**2)
 c

--- a/scipy/linalg/src/id_dist/src/idzp_asvd.f
+++ b/scipy/linalg/src/id_dist/src/idzp_asvd.f
@@ -159,9 +159,9 @@ c       for the present routine (please see routine idzp_asvd
 c       for further documentation).
 c
         implicit none
-        integer m,n,krank,ier
+        integer m,n,krank,list(n),ier
         real*8 s(krank)
-        complex*16 a(m,n),u(m,krank),v(n,krank),list(n),
+        complex*16 a(m,n),u(m,krank),v(n,krank),
      1             proj(krank,n-krank),col(m,krank),
      2             work((krank+1)*(m+3*n+10)+9*krank**2)
 c

--- a/scipy/linalg/src/id_dist/src/idzr_asvd.f
+++ b/scipy/linalg/src/id_dist/src/idzr_asvd.f
@@ -91,9 +91,9 @@ c       for the present routine (please see routine idzr_asvd
 c       for further documentation).
 c
         implicit none
-        integer m,n,krank,list(n),ier
+        integer m,n,krank,ier
         real*8 s(krank)
-        complex*16 a(m,n),u(m,krank),v(n,krank),
+        complex*16 a(m,n),u(m,krank),v(n,krank),list(n),
      1             proj(krank,n-krank),col(m*krank),
      2             winit((2*krank+17)*n+21*m+80),
      3             work((krank+1)*(m+3*n+10)+9*krank**2)

--- a/scipy/linalg/src/id_dist/src/idzr_rsvd.f
+++ b/scipy/linalg/src/id_dist/src/idzr_rsvd.f
@@ -125,10 +125,10 @@ c       for the present routine (please see routine idzr_rsvd
 c       for further documentation).
 c
         implicit none
-        integer m,n,krank,list(n),ier,k
+        integer m,n,krank,ier,k
         real*8 s(krank)
         complex*16 p1t,p2t,p3t,p4t,p1,p2,p3,p4,u(m,krank),v(n,krank),
-     1             proj(krank*(n-krank)),col(m*krank),
+     1             proj(krank*(n-krank)),col(m*krank),list(n),
      2             work((krank+1)*(m+3*n+10)+9*krank**2)
         external matveca,matvec
 c


### PR DESCRIPTION
* Reference issue: https://github.com/rgommers/scipy/issues/120

cc @rgommers 