### PR TITLE
ENH: Add Cauchy RBF to Scipy.interpolate

### DIFF
--- a/scipy/interpolate/_rbf.py
+++ b/scipy/interpolate/_rbf.py
@@ -169,7 +169,7 @@ class Rbf:
         return xlogy(r**2, r)
 
     def _h_cauchy(self, r):
-        return 1/(1+r)
+        return 1.0/(1.0+r)
 
     # Setup self._function and do smoke test on initial r
     def _init_function(self, r):

--- a/scipy/interpolate/_rbf.py
+++ b/scipy/interpolate/_rbf.py
@@ -79,6 +79,7 @@ class Rbf:
             'cubic': r**3
             'quintic': r**5
             'thin_plate': r**2 * log(r)
+            'cauchy': 1/(1+r)
 
         If callable, then it must take 2 arguments (self, r). The epsilon
         parameter will be available as self.epsilon. Other keyword
@@ -166,6 +167,9 @@ class Rbf:
 
     def _h_thin_plate(self, r):
         return xlogy(r**2, r)
+
+    def _h_cauchy(self, r):
+        return 1/(1+r)
 
     # Setup self._function and do smoke test on initial r
     def _init_function(self, r):

--- a/scipy/interpolate/_rbfinterp.py
+++ b/scipy/interpolate/_rbfinterp.py
@@ -29,7 +29,8 @@ _AVAILABLE = {
 
 
 # The shape parameter does not need to be specified when using these RBFs.
-_SCALE_INVARIANT = {"linear", "thin_plate_spline", "cubic", "quintic", "cauchy"}
+_SCALE_INVARIANT = {"linear", "thin_plate_spline",
+                    "cubic", "quintic", "cauchy"}
 
 
 # For RBFs that are conditionally positive definite of order m, the interpolant

--- a/scipy/interpolate/_rbfinterp.py
+++ b/scipy/interpolate/_rbfinterp.py
@@ -23,12 +23,13 @@ _AVAILABLE = {
     "multiquadric",
     "inverse_multiquadric",
     "inverse_quadratic",
-    "gaussian"
+    "gaussian",
+    "cauchy"
     }
 
 
 # The shape parameter does not need to be specified when using these RBFs.
-_SCALE_INVARIANT = {"linear", "thin_plate_spline", "cubic", "quintic"}
+_SCALE_INVARIANT = {"linear", "thin_plate_spline", "cubic", "quintic", "cauchy"}
 
 
 # For RBFs that are conditionally positive definite of order m, the interpolant
@@ -41,7 +42,8 @@ _NAME_TO_MIN_DEGREE = {
     "linear": 0,
     "thin_plate_spline": 1,
     "cubic": 1,
-    "quintic": 2
+    "quintic": 2,
+    "cauchy": 1
     }
 
 
@@ -157,6 +159,7 @@ class RBFInterpolator:
             - 'inverse_multiquadric' : ``1/sqrt(1 + r**2)``
             - 'inverse_quadratic'    : ``1/(1 + r**2)``
             - 'gaussian'             : ``exp(-r**2)``
+            - 'cauchy'               : ``1/(1+r)``
 
         Default is 'thin_plate_spline'.
     epsilon : float, optional
@@ -174,6 +177,7 @@ class RBFInterpolator:
             - 'thin_plate_spline' : 1
             - 'cubic'             : 1
             - 'quintic'           : 2
+            - 'cauchy'            : 1
 
         The default value is the minimum degree for `kernel` or 0 if there is
         no minimum degree. Set this to -1 for no added polynomial.
@@ -253,6 +257,8 @@ class RBFInterpolator:
     .. [3] Wahba, G., 1990. Spline Models for Observational Data. SIAM.
 
     .. [4] http://pages.stat.wisc.edu/~wahba/stat860public/lect/lect8/lect8.pdf
+
+    .. [5] https://faculty.cc.gatech.edu/~isbell/tutorials/rbf-intro.pdf
 
     Examples
     --------

--- a/scipy/interpolate/_rbfinterp_pythran.py
+++ b/scipy/interpolate/_rbfinterp_pythran.py
@@ -36,6 +36,10 @@ def gaussian(r):
     return np.exp(-r**2)
 
 
+def cauchy(r):
+    return 1.0/(1.0+r)
+
+
 NAME_TO_FUNC = {
    "linear": linear,
    "thin_plate_spline": thin_plate_spline,
@@ -44,7 +48,8 @@ NAME_TO_FUNC = {
    "multiquadric": multiquadric,
    "inverse_multiquadric": inverse_multiquadric,
    "inverse_quadratic": inverse_quadratic,
-   "gaussian": gaussian
+   "gaussian": gaussian,
+   "cauchy": cauchy
    }
 
 

--- a/scipy/interpolate/tests/test_rbf.py
+++ b/scipy/interpolate/tests/test_rbf.py
@@ -117,7 +117,8 @@ def test_rbf_regularity():
         'cubic': 0.15,
         'quintic': 0.1,
         'thin-plate': 0.1,
-        'linear': 0.2
+        'linear': 0.2,
+        'cauchy': 0.4
     }
     for function in FUNCTIONS:
         check_rbf1d_regularity(function, tolerances.get(function, 1e-2))
@@ -145,7 +146,8 @@ def test_2drbf_regularity():
         'cubic': 0.15,
         'quintic': 0.1,
         'thin-plate': 0.15,
-        'linear': 0.2
+        'linear': 0.2,
+        'cauchy': 0.4
     }
     for function in FUNCTIONS:
         check_2drbf1d_regularity(function, tolerances.get(function, 1e-2))

--- a/scipy/interpolate/tests/test_rbf.py
+++ b/scipy/interpolate/tests/test_rbf.py
@@ -8,7 +8,7 @@ from numpy import linspace, sin, cos, random, exp, allclose
 from scipy.interpolate._rbf import Rbf
 
 FUNCTIONS = ('multiquadric', 'inverse multiquadric', 'gaussian',
-             'cubic', 'quintic', 'thin-plate', 'linear')
+             'cubic', 'quintic', 'thin-plate', 'linear', 'cauchy')
 
 
 def check_rbf1d_interpolation(function):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### What does this implement/fix?
Implements the Cauchy RBF described in some literature. Some references are as follows.
- https://faculty.cc.gatech.edu/~isbell/tutorials/rbf-intro.pdf
- http://people.whitman.edu/~hundledr/courses/M472/Ch11_2008.pdf

Python docstring is updated accordingly to reflect the added RBF.
