### PR TITLE
MAINT: stats._moment: warn when catastrophic cancellation occurs

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -1015,9 +1015,10 @@ def _moment(a, moment, axis, *, mean=None):
         a_zero_mean = a - mean
 
         eps = np.finfo(a_zero_mean.dtype).resolution * 10
-        rel_diff = np.max(np.abs(a_zero_mean), axis=axis, keepdims=True)/mean
+        rel_diff = np.max(np.abs(a_zero_mean), axis=axis,
+                          keepdims=True) / np.abs(mean)
         with np.errstate(invalid='ignore'):
-            precision_loss = np.any((0 < rel_diff) & (rel_diff < eps))
+            precision_loss = np.any(rel_diff < eps)
         if precision_loss:
             message = ("Precision loss occurred in moment calculation due to "
                        "catastrophic cancellation. This occurs when the data "

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -1014,7 +1014,7 @@ def _moment(a, moment, axis, *, mean=None):
         mean = a.mean(axis, keepdims=True) if mean is None else mean
         a_zero_mean = a - mean
 
-        eps = np.finfo(a_zero_mean.dtype).resolution * 10
+        eps = np.finfo(a_zero_mean.dtype).resolution * 1e6
         rel_diff = np.max(np.abs(a_zero_mean), axis=axis, keepdims=True)/mean
         if np.any((0 < rel_diff) & (rel_diff < eps)):
             message = ("Precision loss occurred in moment calculation due to "

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -1014,13 +1014,14 @@ def _moment(a, moment, axis, *, mean=None):
         mean = a.mean(axis, keepdims=True) if mean is None else mean
         a_zero_mean = a - mean
 
-        eps = np.finfo(a_zero_mean.dtype).resolution * 1e6
+        eps = np.finfo(a_zero_mean.dtype).resolution * 10
         rel_diff = np.max(np.abs(a_zero_mean), axis=axis, keepdims=True)/mean
         with np.errstate(invalid='ignore'):
             precision_loss = np.any((0 < rel_diff) & (rel_diff < eps))
         if precision_loss:
             message = ("Precision loss occurred in moment calculation due to "
-                       "catastrophc cancellation. Results may be unreliable.")
+                       "catastrophic cancellation. This occurs when the data "
+                       "are nearly identical. Results may be unreliable.")
             warnings.warn(message, RuntimeWarning, stacklevel=4)
 
         if n_list[-1] == 1:

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -1016,7 +1016,9 @@ def _moment(a, moment, axis, *, mean=None):
 
         eps = np.finfo(a_zero_mean.dtype).resolution * 1e6
         rel_diff = np.max(np.abs(a_zero_mean), axis=axis, keepdims=True)/mean
-        if np.any((0 < rel_diff) & (rel_diff < eps)):
+        with np.errstate(invalid='ignore'):
+            precision_loss = np.any((0 < rel_diff) & (rel_diff < eps))
+        if precision_loss:
             message = ("Precision loss occurred in moment calculation due to "
                        "catastrophc cancellation. Results may be unreliable.")
             warnings.warn(message, RuntimeWarning, stacklevel=4)

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -1013,6 +1013,14 @@ def _moment(a, moment, axis, *, mean=None):
         # Starting point for exponentiation by squares
         mean = a.mean(axis, keepdims=True) if mean is None else mean
         a_zero_mean = a - mean
+
+        eps = np.finfo(a_zero_mean.dtype).resolution * 10
+        rel_diff = np.max(np.abs(a_zero_mean), axis=axis, keepdims=True)/mean
+        if np.any((0 < rel_diff) & (rel_diff < eps)):
+            message = ("Precision loss occurred in moment calculation due to "
+                       "catastrophc cancellation. Results may be unreliable.")
+            warnings.warn(message, RuntimeWarning, stacklevel=4)
+
         if n_list[-1] == 1:
             s = a_zero_mean.copy()
         else:

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -273,8 +273,8 @@ def _axis_nan_policy_test(hypotest, args, kwds, n_samples, n_outputs, paired,
             hypotest(*data, axis=axis, nan_policy=nan_policy, *args, **kwds)
 
     else:
-        with (suppress_warnings() as sup,
-              np.errstate(divide='ignore', invalid='ignore')):
+        with suppress_warnings() as sup, \
+             np.errstate(divide='ignore', invalid='ignore'):
             sup.filter(RuntimeWarning, "Precision loss occurred in moment")
             res = unpacker(hypotest(*data, axis=axis, nan_policy=nan_policy,
                                     *args, **kwds))

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -11,7 +11,7 @@ import pytest
 
 import numpy as np
 from numpy.lib import NumpyVersion
-from numpy.testing import assert_allclose, assert_equal
+from numpy.testing import assert_allclose, assert_equal, suppress_warnings
 from scipy import stats
 from scipy.stats._axis_nan_policy import _masked_arrays_2_sentinel_arrays
 
@@ -50,6 +50,10 @@ too_small_messages = {"The input contains nan",  # for nan_policy="raise"
                       "`x` and `y` must be of nonzero size.",
                       "The exact distribution of the Wilcoxon test",
                       "Data input must not be empty"}
+
+# If the message is one of these, results of the function may be inaccurate,
+# but NaNs are not to be placed
+inaccuracy_messages = {"Precision loss occurred in moment calculation"}
 
 
 def _mixed_data_generator(n_samples, n_repetitions, axis, rng,
@@ -245,6 +249,15 @@ def _axis_nan_policy_test(hypotest, args, kwds, n_samples, n_outputs, paired,
                 if any([str(e).startswith(message)
                         for message in too_small_messages]):
                     res1d = np.full(n_outputs, np.nan)
+                elif any([str(e).startswith(message)
+                          for message in inaccuracy_messages]):
+                    with suppress_warnings() as sup:
+                        sup.filter(RuntimeWarning)
+                        res1d = nan_policy_1d(hypotest, data1d, unpacker,
+                                              *args, n_outputs=n_outputs,
+                                              nan_policy=nan_policy,
+                                              paired=paired, _no_deco=True,
+                                              **kwds)
                 else:
                     raise e
         statistics[i] = res1d[0]
@@ -260,7 +273,9 @@ def _axis_nan_policy_test(hypotest, args, kwds, n_samples, n_outputs, paired,
             hypotest(*data, axis=axis, nan_policy=nan_policy, *args, **kwds)
 
     else:
-        with np.errstate(divide='ignore', invalid='ignore'):
+        with (suppress_warnings() as sup,
+              np.errstate(divide='ignore', invalid='ignore')):
+            sup.filter(RuntimeWarning, "Precision loss occurred in moment")
             res = unpacker(hypotest(*data, axis=axis, nan_policy=nan_policy,
                                     *args, **kwds))
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2966,8 +2966,9 @@ class TestMoments:
 
     def test_skewness(self):
         # Scalar test case
-        y = stats.skew(self.scalar_testcase)
-        assert_approx_equal(y, 0.0)
+        with pytest.warns(RuntimeWarning, match="Precision loss occurred"):
+            y = stats.skew(self.scalar_testcase)
+            assert_approx_equal(y, 0.0)
         # sum((testmathworks-mean(testmathworks,axis=0))**3,axis=0) /
         #     ((sqrt(var(testmathworks)*4/5))**3)/5
         y = stats.skew(self.testmathworks)
@@ -3014,8 +3015,9 @@ class TestMoments:
 
     def test_kurtosis(self):
         # Scalar test case
-        y = stats.kurtosis(self.scalar_testcase)
-        assert_approx_equal(y, -3.0)
+        with pytest.warns(RuntimeWarning, match="Precision loss occurred"):
+            y = stats.kurtosis(self.scalar_testcase)
+            assert_approx_equal(y, -3.0)
         #   sum((testcase-mean(testcase,axis=0))**4,axis=0)/((sqrt(var(testcase)*3/4))**4)/4
         #   sum((test2-mean(testmathworks,axis=0))**4,axis=0)/((sqrt(var(testmathworks)*4/5))**4)/5
         #   Set flags for axis = 0 and
@@ -3054,10 +3056,11 @@ class TestMoments:
         # Kurtosis of a constant input should be zero, even when the mean is not
         # exact (gh-13245)
         a = np.repeat(-0.27829495, 10)
-        assert stats.kurtosis(a, fisher=False) == 0.0
-        assert stats.kurtosis(a * float(2**50), fisher=False) == 0.0
-        assert stats.kurtosis(a / float(2**50), fisher=False) == 0.0
-        assert stats.kurtosis(a, fisher=False, bias=False) == 0.0
+        with pytest.warns(RuntimeWarning, match="Precision loss occurred"):
+            assert stats.kurtosis(a, fisher=False) == 0.0
+            assert stats.kurtosis(a * float(2**50), fisher=False) == 0.0
+            assert stats.kurtosis(a / float(2**50), fisher=False) == 0.0
+            assert stats.kurtosis(a, fisher=False, bias=False) == 0.0
 
     def test_moment_accuracy(self):
         # 'moment' must have a small enough error compared to the slower
@@ -5019,7 +5022,8 @@ def test_ttest_1samp_new():
 
 class TestDescribe:
     def test_describe_scalar(self):
-        with suppress_warnings() as sup, np.errstate(invalid="ignore"):
+        with (suppress_warnings() as sup, np.errstate(invalid="ignore"),
+              pytest.warns(RuntimeWarning, match="Precision loss occurred")):
             sup.filter(RuntimeWarning, "Degrees of freedom <= 0 for slice")
             n, mm, m, v, sk, kurt = stats.describe(4.)
         assert_equal(n, 1)
@@ -5116,9 +5120,10 @@ class TestDescribe:
 
 
 def test_normalitytests():
-    assert_raises(ValueError, stats.skewtest, 4.)
-    assert_raises(ValueError, stats.kurtosistest, 4.)
-    assert_raises(ValueError, stats.normaltest, 4.)
+    with pytest.warns(RuntimeWarning, match="Precision loss occurred"):
+        assert_raises(ValueError, stats.skewtest, 4.)
+        assert_raises(ValueError, stats.kurtosistest, 4.)
+        assert_raises(ValueError, stats.normaltest, 4.)
 
     # numbers verified with R: dagoTest in package fBasics
     st_normal, st_skew, st_kurt = (3.92371918, 1.98078826, -0.01403734)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -5022,8 +5022,8 @@ def test_ttest_1samp_new():
 
 class TestDescribe:
     def test_describe_scalar(self):
-        with (suppress_warnings() as sup, np.errstate(invalid="ignore"),
-              pytest.warns(RuntimeWarning, match="Precision loss occurred")):
+        with suppress_warnings() as sup, np.errstate(invalid="ignore"), \
+             pytest.warns(RuntimeWarning, match="Precision loss occurred"):
             sup.filter(RuntimeWarning, "Degrees of freedom <= 0 for slice")
             n, mm, m, v, sk, kurt = stats.describe(4.)
         assert_equal(n, 1)


### PR DESCRIPTION
#### Reference issue
Closes gh-15554
gh-13254
gh-13245
gh-11086
gh-10896

#### What does this implement/fix?
We get reports every once in a while of `skew` and/or `kurtosis` being unreliable with degenerate input. This PR would report a warning rather than trying to produce a correct result. Alternatively, we could replace the values that suffer from severe precision loss with `nan`. Re-reading gh-13254, I still don't think `0` is necessarily correct.
