### PR TITLE
DEP: deal with deprecation of ndim >1 in bspline

### DIFF
--- a/scipy/interpolate/_fitpack_py.py
+++ b/scipy/interpolate/_fitpack_py.py
@@ -359,8 +359,8 @@ def splev(x, tck, der=0, ext=0):
     if isinstance(tck, BSpline):
         if tck.c.ndim > 1:
             mesg = ("Calling splev() with BSpline objects with c.ndim > 1 is "
-                   "not recommended. Use BSpline.__call__(x) instead.")
-            warnings.warn(mesg, DeprecationWarning)
+                    "not allowed. Use BSpline.__call__(x) instead.")
+            raise ValueError(mesg)
 
         # remap the out-of-bounds behavior
         try:
@@ -427,8 +427,8 @@ def splint(a, b, tck, full_output=0):
     if isinstance(tck, BSpline):
         if tck.c.ndim > 1:
             mesg = ("Calling splint() with BSpline objects with c.ndim > 1 is "
-                   "not recommended. Use BSpline.integrate() instead.")
-            warnings.warn(mesg, DeprecationWarning)
+                    "not allowed. Use BSpline.integrate() instead.")
+            raise ValueError(mesg)
 
         if full_output != 0:
             mesg = ("full_output = %s is not supported. Proceeding as if "
@@ -491,8 +491,8 @@ def sproot(tck, mest=10):
     if isinstance(tck, BSpline):
         if tck.c.ndim > 1:
             mesg = ("Calling sproot() with BSpline objects with c.ndim > 1 is "
-                    "not recommended.")
-            warnings.warn(mesg, DeprecationWarning)
+                    "not allowed.")
+            raise ValueError(mesg)
 
         t, c, k = tck.tck
 

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -726,10 +726,8 @@ class TestInterop:
 
         # With N-D coefficients, there's a quirck:
         # splev(x, BSpline) is equivalent to BSpline(x)
-        with suppress_warnings() as sup:
-            sup.filter(DeprecationWarning,
-                       "Calling splev.. with BSpline objects with c.ndim > 1 is not recommended.")
-            assert_allclose(splev(xnew, b2), b2(xnew), atol=1e-15, rtol=1e-15)
+        with assert_raises(ValueError, match="Calling splev.. with BSpline"):
+            splev(xnew, b2)
 
         # However, splev(x, BSpline.tck) needs some transposes. This is because
         # BSpline interpolates along the first axis, while the legacy FITPACK
@@ -835,14 +833,8 @@ class TestInterop:
         assert_allclose(sproot((b.t, b.c, b.k)), roots, atol=1e-7, rtol=1e-7)
 
         # ... and deals with trailing dimensions if coef array is N-D
-        with suppress_warnings() as sup:
-            sup.filter(DeprecationWarning,
-                       "Calling sproot.. with BSpline objects with c.ndim > 1 is not recommended.")
-            r = sproot(b2, mest=50)
-        r = np.asarray(r)
-
-        assert_equal(r.shape, (3, 2, 4))
-        assert_allclose(r - roots, 0, atol=1e-12)
+        with assert_raises(ValueError, match="Calling sproot.. with BSpline"):
+            sproot(b2, mest=50)
 
         # and legacy behavior is preserved for a tck tuple w/ N-D coef
         c2r = b2.c.transpose(1, 2, 0)
@@ -859,10 +851,8 @@ class TestInterop:
                         b.integrate(0, 1), atol=1e-14)
 
         # ... and deals with N-D arrays of coefficients
-        with suppress_warnings() as sup:
-            sup.filter(DeprecationWarning,
-                       "Calling splint.. with BSpline objects with c.ndim > 1 is not recommended.")
-            assert_allclose(splint(0, 1, b2), b2.integrate(0, 1), atol=1e-14)
+        with assert_raises(ValueError, match="Calling splint.. with BSpline"):
+            splint(0, 1, b2)
 
         # and the legacy behavior is preserved for a tck tuple w/ N-D coef
         c2r = b2.c.transpose(1, 2, 0)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #15734
#### What does this implement/fix?
<!--Please explain your changes.-->
This behaviour has raised a deprecation warning for 5+ years, this pr switches this to raising an error.
#### Additional information
<!--Any additional information you think is important.-->
