### PR TITLE
make sure CI stays on VS2019 unless changed explicitly

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -198,7 +198,7 @@ stages:
   - job: Windows
     condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))  # skip for PR merges
     pool:
-      vmImage: 'windows-latest'
+      vmImage: 'windows-2019'
     variables:
       # OPENBLAS64_ variable has same value
       # but only needed for ILP64 build below

--- a/doc/source/dev/toolchain.rst
+++ b/doc/source/dev/toolchain.rst
@@ -108,7 +108,7 @@ Currently, SciPy wheels are being built as follows:
 Linux (nightly)    ``ubuntu-18.04``          GCC 6.5                      See ``azure-pipelines.yml``
 Linux (release)    ``ubuntu-18.04``          GCC 7.5                      Built in separate repo [6]_
 OSX                ``macOS-10.15``           LLVM 12.0.0                  Built in separate repo [6]_
-Windows            ``windows-latest``        Visual Studio 2019 (16.11)   See ``azure-pipelines.yml``
+Windows            ``windows-2019``          Visual Studio 2019 (16.11)   See ``azure-pipelines.yml``
 ================  ========================  ===========================  ==============================
 
 Note that the OSX wheels additionally vendor gfortran 4.9,


### PR DESCRIPTION
Backport of #15167

CC @tylerjereddy