### PR TITLE
MAINT: stats: remove support for `_rvs` without `size` parameter

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -9,7 +9,6 @@ import keyword
 import re
 import types
 import warnings
-import inspect
 from itertools import zip_longest
 from collections import namedtuple
 
@@ -645,21 +644,6 @@ class rv_generic:
                                    ('moments' in sig.kwonlyargs))
         self._random_state = check_random_state(seed)
 
-        # For historical reasons, `size` was made an attribute that was read
-        # inside _rvs().  The code is being changed so that 'size'
-        # is an argument
-        # to self._rvs(). However some external (non-SciPy) distributions
-        # have not
-        # been updated.  Maintain backwards compatibility by checking if
-        # the self._rvs() signature has the 'size' keyword, or a **kwarg,
-        # and if not set self._size inside self.rvs()
-        # before calling self._rvs().
-        argspec = inspect.getfullargspec(self._rvs)
-        self._rvs_uses_size_attribute = (argspec.varkw is None and
-                                         'size' not in argspec.args and
-                                         'size' not in argspec.kwonlyargs)
-        # Warn on first use only
-        self._rvs_size_warned = False
 
     @property
     def random_state(self):
@@ -1091,20 +1075,7 @@ class rv_generic:
         else:
             random_state = self._random_state
 
-        # Maintain backwards compatibility by setting self._size
-        # for distributions that still need it.
-        if self._rvs_uses_size_attribute:
-            if not self._rvs_size_warned:
-                warnings.warn(
-                    f'The signature of {self._rvs} does not contain '
-                    f'a "size" keyword.  Such signatures are deprecated.',
-                    np.VisibleDeprecationWarning)
-                self._rvs_size_warned = True
-            self._size = size
-            self._random_state = random_state
-            vals = self._rvs(*args)
-        else:
-            vals = self._rvs(*args, size=size, random_state=random_state)
+        vals = self._rvs(*args, size=size, random_state=random_state)
 
         vals = vals * scale + loc
 

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -644,7 +644,6 @@ class rv_generic:
                                    ('moments' in sig.kwonlyargs))
         self._random_state = check_random_state(seed)
 
-
     @property
     def random_state(self):
         """Get or set the generator object for generating random variates.

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -6934,14 +6934,15 @@ class TestWrapCauchy:
         assert_allclose(p[1], 1 - np.arctan(cr*np.tan(np.pi - x2/2))/np.pi)
 
 
-def test_rvs_no_size_warning():
+def test_rvs_no_size_error():
+    # _rvs methods must have parameter `size`; see gh-11394
     class rvs_no_size_gen(stats.rv_continuous):
         def _rvs(self):
             return 1
 
     rvs_no_size = rvs_no_size_gen(name='rvs_no_size')
 
-    with assert_warns(np.VisibleDeprecationWarning):
+    with assert_raises(TypeError, match=re.escape("_rvs() got an unexpected")):
         rvs_no_size.rvs()
 
 


### PR DESCRIPTION
#### Reference issue
Closes gh-15747
gh-11394

#### What does this implement/fix?
gh-11394 deprecated the ability to implement `_rvs` without a `size` parameter. `_rvs` is a private method, but it's in a public class, so immediate removal of support for `_rvs` without a `size` parameter had backward-compatibility concerns. The authors added special treatment for `_rvs` methods without a `size` parameter, but this can be removed now that a deprecation warning has been raised for years. This PR now always passes `size` when `rvs` calls `_rvs`, and it tests that there is an error (rather than deprecation warning) when an `_rvs` method that does not accept `size` gets passed `size`.

#### Additional information
gh-11394 suggested that it was supposed to do something similar w.r.t. `random_state`: remove reliance of `_rvs` methods on a `_random_state` attribute and instead require that they accept a `random_state` parameter. However, it did not raise a deprecation warning for `_rvs` methods that don't accept `random_state`, and `_random_state` is still used throughout the distribution infrastructure, so I didn't touch that.