### PR TITLE
ENH: stats.mannwhitneyu: add iterative implementation

### DIFF
--- a/scipy/stats/_mannwhitneyu.py
+++ b/scipy/stats/_mannwhitneyu.py
@@ -34,13 +34,12 @@ class _MWU:
 
     def pmf_recursive(self, k, m, n):
         '''Probability mass function, recursive version'''
-        self._fmnks = -np.ones((1, 1, 1))
         self._resize_fmnks(m, n, np.max(k))
         # could loop over just the unique elements, but probably not worth
         # the time to find them
         for i in np.ravel(k):
             self._f(m, n, i)
-        return self._fmnks[(m, n, k)] / special.binom(m + n, m)
+        return self._fmnks[m, n, k] / special.binom(m + n, m)
 
     def pmf_iterative(self, k, m, n):
         '''Probability mass function, iterative version'''
@@ -110,7 +109,7 @@ def _mwu_f_iterative(m, n, k, fmnks):
     '''Iterative implementation of function of [3] Theorem 2.5'''
 
     def _base_case(m, n, k):
-        '''Base cases from recursive versions'''
+        '''Base cases from recursive version'''
 
         # if already calculated, return the value
         if fmnks.get((m, n, k), -1) >= 0:

--- a/scipy/stats/_mannwhitneyu.py
+++ b/scipy/stats/_mannwhitneyu.py
@@ -23,25 +23,32 @@ class _MWU:
     def __init__(self):
         '''Minimal initializer'''
         self._fmnks = -np.ones((1, 1, 1))
-
-    # def pmf(self, k, m, n):
-    #     '''Probability mass function'''
-    #     self._fmnks = -np.ones((1, 1, 1))
-    #     self._resize_fmnks(m, n, np.max(k))
-    #     # could loop over just the unique elements, but probably not worth
-    #     # the time to find them
-    #     for i in np.ravel(k):
-    #         self._f(m, n, i)
-    #     return self._fmnks[(m, n, k)] / special.binom(m + n, m)
+        self._recursive = None
 
     def pmf(self, k, m, n):
-        '''Probability mass function'''
-        self._fmnks = {}
+        if (self._recursive is None and m <= 500 and n <= 500
+                or self._recursive):
+            return self.pmf_recursive(k, m, n)
+        else:
+            return self.pmf_iterative(k, m, n)
+
+    def pmf_recursive(self, k, m, n):
+        '''Probability mass function, recursive version'''
+        self._fmnks = -np.ones((1, 1, 1))
+        self._resize_fmnks(m, n, np.max(k))
         # could loop over just the unique elements, but probably not worth
         # the time to find them
         for i in np.ravel(k):
-            self._f2(m, n, i)
-        return np.array([self._fmnks[(m, n, ki)] for ki in k]) / special.binom(m + n, m)
+            self._f(m, n, i)
+        return self._fmnks[(m, n, k)] / special.binom(m + n, m)
+
+    def pmf_iterative(self, k, m, n):
+        '''Probability mass function, iterative version'''
+        fmnks = {}
+        for i in np.ravel(k):
+            fmnks = _mwu_f_iterative(m, n, i, fmnks)
+        return (np.array([fmnks[(m, n, ki)] for ki in k])
+                / special.binom(m + n, m))
 
     def cdf(self, k, m, n):
         '''Cumulative distribution function'''
@@ -95,12 +102,19 @@ class _MWU:
         return fmnk
 
 
-    def _f1(self, m, n, k):
-        '''Recursive implementation of function of [3] Theorem 2.5'''
+# Maintain state for faster repeat calls to mannwhitneyu w/ method='exact'
+_mwu_state = _MWU()
+
+
+def _mwu_f_iterative(m, n, k, fmnks):
+    '''Iterative implementation of function of [3] Theorem 2.5'''
+
+    def _base_case(m, n, k):
+        '''Base cases from recursive versions'''
 
         # if already calculated, return the value
-        if self._fmnks.get((m, n, k), -1) >= 0:
-            return self._fmnks[(m, n, k)]
+        if fmnks.get((m, n, k), -1) >= 0:
+            return fmnks[(m, n, k)]
 
         # [3] Theorem 2.5 Line 1
         elif k < 0 or m < 0 or n < 0 or k > m*n:
@@ -112,40 +126,36 @@ class _MWU:
 
         return None
 
-    def _f2(self, m, n, k):
-        '''Non-Recursive implementation of function of [3] Theorem 2.5'''
+    stack = [(m, n, k)]
+    fmnk = None
 
-        stack = [(m, n, k)]
-        fmnk = None
+    while stack:
+        # Popping only if necessary would save a tiny bit of time, but NWI.
+        m, n, k = stack.pop()
 
-        while stack:
-            # Popping only if necessary would save a tiny bit of time, but NWI.
-            m, n, k = stack.pop()
+        # If we're at a base case, continue (stack unwinds)
+        fmnk = _base_case(m, n, k)
+        if fmnk is not None:
+            fmnks[(m, n, k)] = fmnk
+            continue
 
-            fmnk = self._f1(m, n, k)
-            if fmnk is not None:
-                self._fmnks[(m, n, k)] = fmnk
-                continue
+        # If both terms are base cases, continue (stack unwinds)
+        f1 = _base_case(m-1, n, k-n)
+        f2 = _base_case(m, n-1, k)
+        if f1 is not None and f2 is not None:
+            # [3] Theorem 2.5 Line 3 / Equation 3
+            fmnk = f1 + f2
+            fmnks[(m, n, k)] = fmnk
+            continue
 
-            f1 = self._f1(m-1, n, k-n)
-            f2 = self._f1(m, n-1, k)
-            if f1 is not None and f2 is not None:
-                # [3] Theorem 2.5 Line 3 / Equation 3
-                fmnk = f1 + f2
-                self._fmnks[(m, n, k)] = fmnk
-                continue
+        # recurse deeper
+        stack.append((m, n, k))
+        if f1 is None:
+            stack.append((m-1, n, k-n))
+        if f2 is None:
+            stack.append((m, n-1, k))
 
-            stack.append((m, n, k))
-            if f1 is None:
-                stack.append((m-1, n, k-n))
-            if f2 is None:
-                stack.append((m, n-1, k))
-
-        return fmnk
-
-
-# Maintain state for faster repeat calls to mannwhitneyu w/ method='exact'
-_mwu_state = _MWU()
+    return fmnks
 
 
 def _tie_term(ranks):

--- a/scipy/stats/tests/test_hypotests.py
+++ b/scipy/stats/tests/test_hypotests.py
@@ -653,7 +653,7 @@ def test_mann_whitney_u_switch():
     y = rng.random(500)
     stats.mannwhitneyu(x, y, method='exact')
 
-    # iterative algorithm has modified _mwu_state._fmnks
+    # recursive algorithm has modified _mwu_state._fmnks
     assert not np.all(_mwu_state._fmnks == -1)
 
 

--- a/scipy/stats/tests/test_hypotests.py
+++ b/scipy/stats/tests/test_hypotests.py
@@ -172,6 +172,9 @@ class TestCvm:
 
 
 class TestMannWhitneyU:
+    def setup(self):
+        _mwu_state._recursive = True
+
     # All magic numbers are from R wilcox.test unless otherwise specied
     # https://rdrr.io/r/stats/wilcox.test.html
 
@@ -615,6 +618,43 @@ class TestMannWhitneyU:
         res = mannwhitneyu(x, y, use_continuity=True, alternative=alternative,
                            method="asymptotic")
         assert_allclose(res, expected, rtol=1e-12)
+
+    def teardown(self):
+        _mwu_state._recursive = None
+
+
+class TestMannWhitneyU_iterative(TestMannWhitneyU):
+    def setup(self):
+        _mwu_state._recursive = False
+
+    def teardown(self):
+        _mwu_state._recursive = None
+
+
+@pytest.mark.xslow
+def test_mann_whitney_u_switch():
+    # Check that mannwhiteneyu switches between recursive and iterative
+    # implementations at n = 500
+
+    # ensure that recursion is not enforced
+    _mwu_state._recursive = None
+    _mwu_state._fmnks = -np.ones((1, 1, 1))
+
+    rng = np.random.default_rng(9546146887652)
+    x = rng.random(5)
+
+    # use iterative algorithm because n > 500
+    y = rng.random(501)
+    stats.mannwhitneyu(x, y, method='exact')
+    # iterative algorithm doesn't modify _mwu_state._fmnks
+    assert np.all(_mwu_state._fmnks == -1)
+
+    # use recursive algorithm because n <= 500
+    y = rng.random(500)
+    stats.mannwhitneyu(x, y, method='exact')
+
+    # iterative algorithm has modified _mwu_state._fmnks
+    assert not np.all(_mwu_state._fmnks == -1)
 
 
 class TestSomersD(_TestPythranFunc):


### PR DESCRIPTION
#### Reference issue
Closes gh-14622
Supersedes gh-14854

#### What does this implement/fix?
gh-14622 reported that `mannwhitenyu`'s implementation fails for sufficiently large samples because it reached the maximum recursion depth. This PR adds an iterative implementation that kicks in when either of the sample sizes exceeds 500. 

#### Additional information
I wrote this because converting the recursive implementation to an iterative implementation was easier for me than finding and correcting the bug that stalled gh-14854. This is also slightly faster than the version in gh-14854 for the cases tested, and it lends itself well to being pythranized. 
