### PR TITLE
MAINT: 1.8.1 backports/prep

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
             pip install --install-option="--no-cython-compile" cython
             pip install numpy==1.21.5
             pip install -r doc_requirements.txt
-            pip install nose mpmath argparse Pillow asv pythran
+            pip install nose mpmath argparse "Pillow==9.0.1" asv pythran
             pip install pybind11
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,6 +120,7 @@ jobs:
             asv machine --machine CircleCI
             export SCIPY_GLOBAL_BENCH_NUMTRIALS=1
             export SCIPY_ALLOW_BENCH_IMPORT_ERRORS=0
+            export OPENBLAS_NUM_THREADS=1
             time asv --config asv.conf.json dev -m CircleCI --python=same --bench '^((?!BenchGlobal|QuadraticAssignment).)*$'
             asv --config asv.conf.json publish
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -326,7 +326,6 @@ stages:
             refreshenv
         }
         $env:PATH = "C:\\ProgramData\\chocolatey\\lib\\mingw\\tools\\install\\mingw$(BITS)\\bin;" + $env:PATH
-        $env:SCIPY_USE_PYTHRAN=0
 
         mkdir dist
         pip wheel --no-build-isolation -v -v -v --wheel-dir=dist .

--- a/ci/azure-travis-template.yaml
+++ b/ci/azure-travis-template.yaml
@@ -82,7 +82,7 @@ steps:
   - script: pip install pytest-cov coverage codecov
     displayName: 'Install coverage dependencies'
 - ${{ if eq(parameters.refguide_check, true) }}:
-  - script: pip install matplotlib sphinx==3.1
+  - script: pip install matplotlib sphinx==3.1 "Jinja2<=3.0.3"
     displayName: 'Install documentation dependencies'
   - script: sudo apt-get install -y wamerican-small
     displayName: 'Install word list (for csgraph tutorial)'

--- a/doc/release/1.8.1-notes.rst
+++ b/doc/release/1.8.1-notes.rst
@@ -5,15 +5,52 @@ SciPy 1.8.1 Release Notes
 .. contents::
 
 SciPy 1.8.1 is a bug-fix release with no new features
-compared to 1.8.0.
+compared to 1.8.0. Notably, usage of Pythran has been
+restored for Windows builds/binaries.
 
 Authors
 =======
 
+* Maximilian Nöthe
+* DWesl (4)
+* Isuru Fernando (1)
+* Ralf Gommers (2)
+* Matt Haberland (1)
+* Andrew Nelson (1)
+* Dimitri Papadopoulos Orfanos (1) +
+* Tirth Patel (2)
+* Tyler Reddy (18)
+* Pamphile Roy (5)
+* H. Vetinari (2)
+
+A total of 11 people contributed to this release.
+People with a "+" by their names contributed a patch for the first time.
+This list of names is automatically generated, and may not be fully complete.
 
 Issues closed for 1.8.1
 -----------------------
 
+* `#15433 <https://github.com/scipy/scipy/issues/15433>`__: BUG: optimize: minimize: \`ValueError\` when \`np.all(lb==ub)\`
+* `#15539 <https://github.com/scipy/scipy/issues/15539>`__: BUG: Questionable macOS wheel contents
+* `#15543 <https://github.com/scipy/scipy/issues/15543>`__: REL: list contributors using GitHub handles
+* `#15552 <https://github.com/scipy/scipy/issues/15552>`__: BUG: MacOS universal2 wheels have two gfortran shared libraries,...
+* `#15636 <https://github.com/scipy/scipy/issues/15636>`__: BUG: DOCS incorrect \`source\` link on docs
+* `#15678 <https://github.com/scipy/scipy/issues/15678>`__: BUG: scipy.stats.skew does not work with scipy.stats.bootstrap
 
 Pull requests for 1.8.1
 -----------------------
+
+* `#15167 <https://github.com/scipy/scipy/pull/15167>`__: CI: make sure CI stays on VS2019 unless changed explicitly
+* `#15306 <https://github.com/scipy/scipy/pull/15306>`__: Revert "BLD Respect the --skip-build flag in setup.py"
+* `#15504 <https://github.com/scipy/scipy/pull/15504>`__: MAINT: np.all(lb == ub) for optimize.minimize
+* `#15530 <https://github.com/scipy/scipy/pull/15530>`__: REL: prep for SciPy 1.8.1
+* `#15531 <https://github.com/scipy/scipy/pull/15531>`__: [BUG] Fix importing scipy.lib._pep440
+* `#15558 <https://github.com/scipy/scipy/pull/15558>`__: CI: re-enable Pythran in Azure Windows CI jobs
+* `#15566 <https://github.com/scipy/scipy/pull/15566>`__: BUG: fix error message
+* `#15580 <https://github.com/scipy/scipy/pull/15580>`__: BUG: Avoid C Preprocessor symbol in _hypotests_pythran.py.
+* `#15614 <https://github.com/scipy/scipy/pull/15614>`__: REL: filter out @ in authors name and add count
+* `#15637 <https://github.com/scipy/scipy/pull/15637>`__: DOC, MAINT: fix links to wrapped functions and SciPy's distributions
+* `#15669 <https://github.com/scipy/scipy/pull/15669>`__: BUG: stats: fix a bug in UNU.RAN error handler
+* `#15691 <https://github.com/scipy/scipy/pull/15691>`__: MAINT: stats: bootstrap: fix bug with \`method="BCa"\` when \`statistic\`...
+* `#15910 <https://github.com/scipy/scipy/pull/15910>`__: make sure CI stays on VS2019 unless changed explicitly
+

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -20,6 +20,8 @@ needs_sphinx = '2.0'
 # ua._Function should not be treated as an attribute
 from sphinx.util import inspect
 import scipy._lib.uarray as ua
+from scipy.stats._distn_infrastructure import rv_generic  # noqa: E402
+from scipy.stats._multivariate import multi_rv_generic  # noqa: E402
 old_isdesc = inspect.isdescriptor
 inspect.isdescriptor = (lambda obj: old_isdesc(obj)
                         and not isinstance(obj, ua._Function))
@@ -470,6 +472,12 @@ def linkcode_resolve(domain, info):
         except Exception:
             return None
 
+    # Use the original function object if it is wrapped.
+    obj = getattr(obj, "__wrapped__", obj)
+    # SciPy's distributions are instances of *_gen. Point to this
+    # class since it contains the implementation of all the methods.
+    if isinstance(obj, (rv_generic, multi_rv_generic)):
+        obj = obj.__class__
     try:
         fn = inspect.getsourcefile(obj)
     except Exception:

--- a/doc/source/dev/core-dev/newfeatures.rst.inc
+++ b/doc/source/dev/core-dev/newfeatures.rst.inc
@@ -1,6 +1,5 @@
 .. _deciding-on-new-features:
 
-========================
 Deciding on new features
 ========================
 The general decision rule to accept a proposed new feature has so far

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -17,9 +17,9 @@ import numpy as np
 
 # unconstrained minimization
 from ._optimize import (_minimize_neldermead, _minimize_powell, _minimize_cg,
-                       _minimize_bfgs, _minimize_newtoncg,
-                       _minimize_scalar_brent, _minimize_scalar_bounded,
-                       _minimize_scalar_golden, MemoizeJac)
+                        _minimize_bfgs, _minimize_newtoncg,
+                        _minimize_scalar_brent, _minimize_scalar_bounded,
+                        _minimize_scalar_golden, MemoizeJac, OptimizeResult)
 from ._trustregion_dogleg import _minimize_dogleg
 from ._trustregion_ncg import _minimize_trust_ncg
 from ._trustregion_krylov import _minimize_trust_krylov
@@ -33,7 +33,8 @@ from ._cobyla_py import _minimize_cobyla
 from ._slsqp_py import _minimize_slsqp
 from ._constraints import (old_bound_to_new, new_bounds_to_old,
                            old_constraint_to_new, new_constraint_to_old,
-                           NonlinearConstraint, LinearConstraint, Bounds)
+                           NonlinearConstraint, LinearConstraint, Bounds,
+                           PreparedConstraint)
 from ._differentiable_functions import FD_METHODS
 
 MINIMIZE_METHODS = ['nelder-mead', 'powell', 'cg', 'bfgs', 'newton-cg',
@@ -626,12 +627,22 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
             # These methods can't take the finite-difference derivatives they
             # need when a variable is fixed by the bounds. To avoid this issue,
             # remove fixed variables from the problem.
+            # NOTE: if this list is expanded, then be sure to update the
+            # accompanying tests and test_optimize.eb_data. Consider also if
+            # default OptimizeResult will need updating.
 
             # convert to new-style bounds so we only have to consider one case
             bounds = standardize_bounds(bounds, x0, 'new')
 
             # determine whether any variables are fixed
             i_fixed = (bounds.lb == bounds.ub)
+
+            if np.all(i_fixed):
+                # all the parameters are fixed, a minimizer is not able to do
+                # anything
+                return _optimize_result_for_equal_bounds(
+                    fun, bounds, meth, args=args, constraints=constraints
+                )
 
             # determine whether finite differences are needed for any grad/jac
             fd_needed = (not callable(jac))
@@ -941,7 +952,7 @@ def standardize_constraints(constraints, x0, meth):
     else:
         constraints = list(constraints)  # ensure it's a mutable sequence
 
-    if meth == 'trust-constr':
+    if meth in ['trust-constr', 'new']:
         for i, con in enumerate(constraints):
             if not isinstance(con, new_constraint_types):
                 constraints[i] = old_constraint_to_new(i, con)
@@ -954,3 +965,45 @@ def standardize_constraints(constraints, x0, meth):
                 constraints.extend(old_constraints[1:])  # appends 1 if present
 
     return constraints
+
+
+def _optimize_result_for_equal_bounds(
+        fun, bounds, method, args=(), constraints=()
+):
+    """
+    Provides a default OptimizeResult for when a bounded minimization method
+    has (lb == ub).all().
+
+    Parameters
+    ----------
+    fun: callable
+    bounds: Bounds
+    method: str
+    constraints: Constraint
+    """
+    success = True
+    message = 'All independent variables were fixed by bounds.'
+
+    # bounds is new-style
+    x0 = bounds.lb
+
+    if constraints:
+        message = ("All independent variables were fixed by bounds at values"
+                   " that satisfy the constraints")
+        constraints = standardize_constraints(constraints, x0, 'new')
+
+    maxcv = 0
+    for c in constraints:
+        pc = PreparedConstraint(c, x0)
+        violation = pc.violation(x0)
+        if np.sum(violation):
+            maxcv = max(maxcv, np.max(violation))
+            success = False
+            message = (f"All independent variables were fixed by bounds, but "
+                       f"the independent variables do not satisfy the "
+                       f"constraints exactly. (Maximum violation: {maxcv}).")
+
+    return OptimizeResult(
+        x=x0, fun=fun(x0, *args), success=success, message=message, nfev=1,
+        njev=0, nhev=0,
+    )

--- a/scipy/sparse/linalg/_eigen/_svds.py
+++ b/scipy/sparse/linalg/_eigen/_svds.py
@@ -107,7 +107,7 @@ def _iv(A, k, ncv, tol, which, v0, maxiter,
 
         shape = (A.shape[0],) if solver == 'propack' else (min(A.shape),)
         if v0.shape != shape:
-            message = "`v0` must have shape {shape}."
+            message = f"`v0` must have shape {shape}."
             raise ValueError(message)
 
     # input validation/standardization for `maxiter`

--- a/scipy/stats/_bootstrap.py
+++ b/scipy/stats/_bootstrap.py
@@ -104,7 +104,7 @@ def _bca_interval(data, statistic, axis, alpha, theta_hat_b, batch):
     sample = data[0]  # only works with 1 sample statistics right now
 
     # calculate z0_hat
-    theta_hat = statistic(sample, axis=axis)[..., None]
+    theta_hat = np.asarray(statistic(sample, axis=axis))[..., None]
     percentile = _percentile_of_score(theta_hat_b, theta_hat, axis=-1)
     z0_hat = ndtri(percentile)
 

--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -12,8 +12,8 @@ from scipy.special import gamma, kv, gammaln, comb, factorial
 from . import _wilcoxon_data
 import scipy.stats._bootstrap as _bootstrap
 from scipy._lib._util import check_random_state
-from ._hypotests_pythran import _Q, _a_ij_Aij_Dij2
-from ._hypotests_pythran import _concordant_pairs as _P
+from ._hypotests_pythran import _a_ij_Aij_Dij2
+from ._hypotests_pythran import _concordant_pairs as _P, _discordant_pairs as _Q
 from ._axis_nan_policy import _broadcast_arrays
 
 __all__ = ['epps_singleton_2samp', 'cramervonmises', 'somersd',

--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -12,7 +12,9 @@ from scipy.special import gamma, kv, gammaln, comb, factorial
 from . import _wilcoxon_data
 import scipy.stats._bootstrap as _bootstrap
 from scipy._lib._util import check_random_state
-from ._hypotests_pythran import _Q, _P, _a_ij_Aij_Dij2
+from ._hypotests_pythran import _Q, _a_ij_Aij_Dij2
+from ._hypotests_pythran import _concordant_pairs as _P
+from ._axis_nan_policy import _broadcast_arrays
 
 __all__ = ['epps_singleton_2samp', 'cramervonmises', 'somersd',
            'barnard_exact', 'boschloo_exact', 'cramervonmises_2samp',

--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -16,7 +16,6 @@ from ._hypotests_pythran import _a_ij_Aij_Dij2
 from ._hypotests_pythran import (
     _concordant_pairs as _P, _discordant_pairs as _Q
 )
-from ._axis_nan_policy import _broadcast_arrays
 
 __all__ = ['epps_singleton_2samp', 'cramervonmises', 'somersd',
            'barnard_exact', 'boschloo_exact', 'cramervonmises_2samp',

--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -13,7 +13,9 @@ from . import _wilcoxon_data
 import scipy.stats._bootstrap as _bootstrap
 from scipy._lib._util import check_random_state
 from ._hypotests_pythran import _a_ij_Aij_Dij2
-from ._hypotests_pythran import _concordant_pairs as _P, _discordant_pairs as _Q
+from ._hypotests_pythran import (
+    _concordant_pairs as _P, _discordant_pairs as _Q
+)
 from ._axis_nan_policy import _broadcast_arrays
 
 __all__ = ['epps_singleton_2samp', 'cramervonmises', 'somersd',

--- a/scipy/stats/_hypotests_pythran.py
+++ b/scipy/stats/_hypotests_pythran.py
@@ -14,9 +14,9 @@ def _Dij(A, i, j):
     # See `somersd` References [2] bottom of page 309
     return A[i+1:, :j].sum() + A[:i, j+1:].sum()
 
-#pythran export _P(float[:,:])
-#pythran export _P(int[:,:])
-def _P(A):
+#pythran export _concordant_pairs(float[:,:])
+#pythran export _concordant_pairs(int[:,:])
+def _concordant_pairs(A):
     """Twice the number of concordant pairs, excluding ties."""
     # See `somersd` References [2] bottom of page 309
     m, n = A.shape

--- a/scipy/stats/_hypotests_pythran.py
+++ b/scipy/stats/_hypotests_pythran.py
@@ -14,6 +14,7 @@ def _Dij(A, i, j):
     # See `somersd` References [2] bottom of page 309
     return A[i+1:, :j].sum() + A[:i, j+1:].sum()
 
+
 #pythran export _concordant_pairs(float[:,:])
 #pythran export _concordant_pairs(int[:,:])
 def _concordant_pairs(A):
@@ -26,6 +27,7 @@ def _concordant_pairs(A):
             count += A[i, j]*_Aij(A, i, j)
     return count
 
+
 #pythran export _discordant_pairs(float[:,:])
 #pythran export _discordant_pairs(int[:,:])
 def _discordant_pairs(A):
@@ -37,6 +39,7 @@ def _discordant_pairs(A):
         for j in range(n):
             count += A[i, j]*_Dij(A, i, j)
     return count
+
 
 #pythran export _a_ij_Aij_Dij2(float[:,:])
 #pythran export _a_ij_Aij_Dij2(int[:,:])

--- a/scipy/stats/_hypotests_pythran.py
+++ b/scipy/stats/_hypotests_pythran.py
@@ -26,9 +26,9 @@ def _concordant_pairs(A):
             count += A[i, j]*_Aij(A, i, j)
     return count
 
-#pythran export _Q(float[:,:])
-#pythran export _Q(int[:,:])
-def _Q(A):
+#pythran export _discordant_pairs(float[:,:])
+#pythran export _discordant_pairs(int[:,:])
+def _discordant_pairs(A):
     """Twice the number of discordant pairs, excluding ties."""
     # See `somersd` References [2] bottom of page 309
     m, n = A.shape

--- a/scipy/stats/_hypotests_pythran.py
+++ b/scipy/stats/_hypotests_pythran.py
@@ -15,8 +15,8 @@ def _Dij(A, i, j):
     return A[i+1:, :j].sum() + A[:i, j+1:].sum()
 
 
-#pythran export _concordant_pairs(float[:,:])
-#pythran export _concordant_pairs(int[:,:])
+# pythran export _concordant_pairs(float[:,:])
+# pythran export _concordant_pairs(int[:,:])
 def _concordant_pairs(A):
     """Twice the number of concordant pairs, excluding ties."""
     # See `somersd` References [2] bottom of page 309
@@ -28,8 +28,8 @@ def _concordant_pairs(A):
     return count
 
 
-#pythran export _discordant_pairs(float[:,:])
-#pythran export _discordant_pairs(int[:,:])
+# pythran export _discordant_pairs(float[:,:])
+# pythran export _discordant_pairs(int[:,:])
 def _discordant_pairs(A):
     """Twice the number of discordant pairs, excluding ties."""
     # See `somersd` References [2] bottom of page 309

--- a/scipy/stats/_unuran/unuran_callback.h
+++ b/scipy/stats/_unuran/unuran_callback.h
@@ -68,6 +68,9 @@ done:                                                                           
 void error_handler(const char *objid, const char *file, int line, const char *errortype, int unur_errno, const char *reason)
 {
     if ( unur_errno != UNUR_SUCCESS ) {
+        if (PyErr_Occurred()) {
+            return;
+        }
         FILE *LOG = unur_get_stream();
         char objid_[256], reason_[256];
         (objid == NULL || strcmp(objid, "") == 0) ? strcpy(objid_, "unknown") : strcpy(objid_, objid);

--- a/setup.py
+++ b/setup.py
@@ -232,16 +232,17 @@ def get_build_ext_override():
         try:
             import pythran
             from pythran.dist import PythranBuildExt
+        except ImportError:
+            BaseBuildExt = npy_build_ext
+        else:
             BaseBuildExt = PythranBuildExt[npy_build_ext]
-            importlib.import_module('scipy/_lib/_pep440')
+            _pep440 = importlib.import_module('scipy._lib._pep440')
             if _pep440.parse(pythran.__version__) < _pep440.Version('0.10.0'):
                 raise RuntimeError("The installed `pythran` is too old, >= "
                                    "0.10.0 is needed, {} detected. Please "
                                    "upgrade Pythran, or use `export "
                                    "SCIPY_USE_PYTHRAN=0`.".format(
                                    pythran.__version__))
-        except ImportError:
-            BaseBuildExt = npy_build_ext
     else:
         BaseBuildExt = npy_build_ext
 
@@ -345,7 +346,10 @@ def generate_cython():
         try:
             # Note, pip may not be installed or not have been used
             import pip
-            importlib.import_module('scipy/_lib/_pep440')
+        except (ImportError, ModuleNotFoundError):
+            raise RuntimeError("Running cythonize failed!")
+        else:
+            _pep440 = importlib.import_module('scipy._lib._pep440')
             if _pep440.parse(pip.__version__) < _pep440.Version('18.0.0'):
                 raise RuntimeError("Cython not found or too old. Possibly due "
                                    "to `pip` being too old, found version {}, "
@@ -353,8 +357,6 @@ def generate_cython():
                                    pip.__version__))
             else:
                 raise RuntimeError("Running cythonize failed!")
-        except (ImportError, ModuleNotFoundError):
-            raise RuntimeError("Running cythonize failed!")
 
 
 def parse_setuppy_commands():

--- a/setup.py
+++ b/setup.py
@@ -582,8 +582,6 @@ def setup_package():
     if "--force" in sys.argv:
         run_build = True
         sys.argv.remove('--force')
-    elif "--skip-build" in sys.argv:
-        run_build = False
     else:
         # Raise errors for unsupported commands, improve help output, etc.
         run_build = check_setuppy_command()

--- a/tools/authors.py
+++ b/tools/authors.py
@@ -62,7 +62,7 @@ def main():
             names.update((name,))
 
         # Look for "thanks to" messages in the commit log
-        m = re.search(r'([Tt]hanks to|[Cc]ourtesy of) ([A-Z][A-Za-z]*? [A-Z][A-Za-z]*? [A-Z][A-Za-z]*|[A-Z][A-Za-z]*? [A-Z]\. [A-Z][A-Za-z]*|[A-Z][A-Za-z ]*? [A-Z][A-Za-z]*|[a-z0-9]+)($|\.| )', line)
+        m = re.search(r'([Tt]hanks to|[Cc]ourtesy of|Co-authored-by:) ([A-Z][A-Za-z]*? [A-Z][A-Za-z]*? [A-Z][A-Za-z]*|[A-Z][A-Za-z]*? [A-Z]\. [A-Z][A-Za-z]*|[A-Z][A-Za-z ]*? [A-Z][A-Za-z]*|[a-z0-9]+)($|\.| )', line)
         if m:
             name = m.group(2)
             if name not in (u'this',):
@@ -77,12 +77,12 @@ def main():
 
     # Find all authors before the named range
     for line in git.pipe('log', '--pretty=@@@%an@@@%n@@@%cn@@@%n%b',
-                         '%s' % (rev1,)):
+                         f'{rev1}'):
         analyze_line(line, all_authors)
 
     # Find authors in the named range
     for line in git.pipe('log', '--pretty=@@@%an@@@%n@@@%cn@@@%n%b',
-                         '%s..%s' % (rev1, rev2)):
+                         f'{rev1}..{rev2}'):
         analyze_line(line, authors, disp=options.debug)
 
     # Sort

--- a/tools/authors.py
+++ b/tools/authors.py
@@ -114,6 +114,10 @@ def main():
         # return for early exit so we only print new authors
         return
 
+    try:
+        authors.pop('GitHub')
+    except KeyError:
+        pass
     # Order by name. Could order by count with authors.most_common()
     authors = sorted(authors.items(), key=lambda i: name_key(i[0]))
 
@@ -127,8 +131,6 @@ Authors
     for author, count in authors:
         # remove @ if only GH handle is available
         author_clean = author.strip('@')
-        if author == 'GitHub':
-            continue
 
         if author in all_authors:
             stdout_b.write((f"* {author_clean} ({count})\n").encode('utf-8'))

--- a/tools/authors.py
+++ b/tools/authors.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
 # -*- encoding:utf-8 -*-
 """
-git-authors [OPTIONS] REV1..REV2
+List the authors who contributed within a given revision interval::
 
-List the authors who contributed within a given revision interval.
+    python tools/authors.py REV1..REV2
+
+`REVx` being a commit hash.
 
 To change the name mapping, edit .mailmap on the top-level of the
 repository.
@@ -122,10 +124,15 @@ Authors
 """)
 
     for author in authors:
+        # remove @ if only GH handle is available
+        author_clean = author.strip('@')
+        if author == 'GitHub':
+            continue
+
         if author in all_authors:
-            stdout_b.write(("* %s\n" % author).encode('utf-8'))
+            stdout_b.write(("* %s\n" % author_clean).encode('utf-8'))
         else:
-            stdout_b.write(("* %s +\n" % author).encode('utf-8'))
+            stdout_b.write(("* %s +\n" % author_clean).encode('utf-8'))
 
     stdout_b.write(("""
 A total of %(count)d people contributed to this release.


### PR DESCRIPTION
* backport 10/11 of the current `backport-candidate` PRs--one is missing because https://github.com/scipy/scipy/pull/15561#issuecomment-1086747474 is a tad annoying to do manually
* probably the most important thing getting fixed is the restoration of Pythran for Windows builds?
* unfortunately, I don't see any signs that we'll have the `PROPACK` stuff fully enabled/Windows portable for `1.8.1` (some issues came up last minute for `1.8.0`, so have an environment variable to control its usage on the maintenance branch)
* this is the first test of the new authors machinery updates from @tupui 