### PR TITLE
TST: test_nodata respect endianness

### DIFF
--- a/scipy/io/arff/tests/test_arffread.py
+++ b/scipy/io/arff/tests/test_arffread.py
@@ -106,7 +106,7 @@ class TestNoData:
         data, meta = loadarff(nodata_filename)
         if sys.byteorder == 'big':
             end = '>'
-        elif sys.byteorder == 'little':
+        else:
             end = '<'
         expected_dtype = np.dtype([('sepallength', f'{end}f8'),
                                    ('sepalwidth', f'{end}f8'),

--- a/scipy/io/arff/tests/test_arffread.py
+++ b/scipy/io/arff/tests/test_arffread.py
@@ -104,10 +104,14 @@ class TestNoData:
         # Reading it should result in an array with length 0.
         nodata_filename = os.path.join(data_path, 'nodata.arff')
         data, meta = loadarff(nodata_filename)
-        expected_dtype = np.dtype([('sepallength', '<f8'),
-                                   ('sepalwidth', '<f8'),
-                                   ('petallength', '<f8'),
-                                   ('petalwidth', '<f8'),
+        if sys.byteorder == 'big':
+            end = '>'
+        elif sys.byteorder == 'little':
+            end = '<'
+        expected_dtype = np.dtype([('sepallength', f'{end}f8'),
+                                   ('sepalwidth', f'{end}f8'),
+                                   ('petallength', f'{end}f8'),
+                                   ('petalwidth', f'{end}f8'),
                                    ('class', 'S15')])
         assert_equal(data.dtype, expected_dtype)
         assert_equal(data.size, 0)


### PR DESCRIPTION
Fixes #15931

* the `nodata.arff` file read by this test contains
no data whatsoever that could possibly indicate
the desired endianness of the empty data fields,
so adjust the test to expect the native endianness,
and pass on the big endian gcc compile farm machine
`gcc203`

* even if there were actual floating point values
in the fields, I still don't see how we'd retrive
the desired endianness from those--it seems like
we'd still end up with the native endianness of
the machine reading the file, and this is indeed
what happens for me when I test on `gcc203` with
our `loadarff` docstring example:

```python
Python 3.9.12 (main, Mar 24 2022, 13:02:21)
[GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from scipy.io import arff
>>> from io import StringIO
>>> content = """
... @relation foo
... @attribute width  numeric
... @attribute height numeric
... @attribute color  {red,green,blue,yellow,black}
... @data
... 5.0,3.25,blue
... 4.5,3.75,green
... 3.0,4.00,red
... """
>>> f = StringIO(content)
>>> data, meta = arff.loadarff(f)
>>> data
array([(5. , 3.25, b'blue'), (4.5, 3.75, b'green'), (3. , 4.  ,
b'red')],
      dtype=[('width', '>f8'), ('height', '>f8'), ('color', 'S6')])
>>>
```

* the only other solution I could think of is if this file
format specification stipulated that retrieved data were
to be encoded as little endian--I didn't find evidence of
that based on the descriptions I could find online for
this ASCII file format
