### PR TITLE
MAINT Add an extra END to prini.f

### DIFF
--- a/scipy/linalg/src/id_dist/src/prini.f
+++ b/scipy/linalg/src/id_dist/src/prini.f
@@ -111,3 +111,4 @@ C
  1800 FORMAT(1X,80A1)
          RETURN
          END
+         END


### PR DESCRIPTION
This seems to fix `f2c prini.f` without changing the behavior of
`gfortran -c prini.f -o prini.o`. I am not sure whether this patch 
is correct since I am not knowledgeable about fortran.