### PR TITLE
BUG Fix signature of D_IIR_forback(1,2)

### DIFF
--- a/scipy/signal/_bspline_util.c.in
+++ b/scipy/signal/_bspline_util.c.in
@@ -179,12 +179,12 @@ void {{SUB}}_IIR_order2_cascade({{TYP}} cs, {{TYP}} z1, {{TYP}} z2,
 #ifdef __GNUC__
 {{endif}}
 int {{SUB}}_IIR_forback1({{TYP}} c0, {{TYP}} z1, {{TYP}} *x, {{TYP}} *y,
-               int N, int stridex, int stridey, float precision)
+               int N, int stridex, int stridey, {{TYP}} precision)
 {
     {{TYP}} *yp = NULL;
     {{TYP}} *xptr = x;
     {{TYP}} yp0, powz1, diff;
-    float err;
+    {{TYP}} err;
     int k;
 
     if (ABSQ(z1) >= 1.0) return -2; /* z1 not less than 1 */
@@ -430,7 +430,7 @@ static {{TYP}} {{SUB}}_hs(int, {{TYP}}, double, double);
 
 {{for SUB, TYP in zip(RNAME, RTYPE)}}
 int {{SUB}}_IIR_forback2 (double r, double omega, {{TYP}} *x, {{TYP}} *y,
-		int N, int stridex, int stridey, float precision) {
+		int N, int stridex, int stridey, {{TYP}} precision) {
     {{TYP}} cs;
     {{TYP}} *yp = NULL;
     {{TYP}} *yptr;

--- a/scipy/signal/_bspline_util.c.in
+++ b/scipy/signal/_bspline_util.c.in
@@ -45,11 +45,12 @@ compute_root_from_lambda(lambda, r, omega)
 CNAME = ['C', 'Z']
 CTYPE = ['__complex__ float', '__complex__ double']
 
-RNAME = ['D', 'S']
-RTYPE = ['double', 'float']
+RNAME = ['S', 'D']
+RTYPE = ['float', 'double']
 
 NAMES = CNAME + RNAME
 TYPES = CTYPE + RTYPE
+RTYPES = RTYPE + RTYPE
 
 }}
 
@@ -176,17 +177,17 @@ void {{SUB}}_IIR_order2_cascade({{TYP}} cs, {{TYP}} z1, {{TYP}} z2,
 
 */
 
-{{for SUB, TYP in zip(NAMES, TYPES)}}
+{{for SUB, TYP, RTYP in zip(NAMES, TYPES, RTYPES)}}
 {{if SUB in CNAME}}
 #ifdef __GNUC__
 {{endif}}
 int {{SUB}}_IIR_forback1({{TYP}} c0, {{TYP}} z1, {{TYP}} *x, {{TYP}} *y,
-               int N, int stridex, int stridey, {{TYP}} precision)
+                   int N, int stridex, int stridey, {{RTYP}} precision)
 {
     {{TYP}} *yp = NULL;
     {{TYP}} *xptr = x;
     {{TYP}} yp0, powz1, diff;
-    {{TYP}} err;
+    {{RTYP}} err;
     int k;
 
     if (ABSQ(z1) >= 1.0) return -2; /* z1 not less than 1 */

--- a/scipy/signal/_bspline_util.c.in
+++ b/scipy/signal/_bspline_util.c.in
@@ -5,6 +5,8 @@
 #include <string.h>
 #include <stdio.h>
 
+#include "_splinemodule.h"
+
 #define NO_IMPORT_ARRAY
 #include "numpy/arrayobject.h"
 

--- a/scipy/signal/_splinemodule.c
+++ b/scipy/signal/_splinemodule.c
@@ -1,30 +1,4 @@
-#include "Python.h"
-#include "numpy/arrayobject.h"
-#include <math.h>
-
-
-#define PYERR(message) do {PyErr_SetString(PyExc_ValueError, message); goto fail;} while(0)
-
-static void convert_strides(npy_intp*,npy_intp*,int,int);
-
-extern int S_cubic_spline2D(float*,float*,int,int,double,npy_intp*,npy_intp*,float);
-extern int S_quadratic_spline2D(float*,float*,int,int,double,npy_intp*,npy_intp*,float);
-extern int S_IIR_forback1(float,float,float*,float*,int,int,int,float);
-extern int S_IIR_forback2(double,double,float*,float*,int,int,int,float);
-extern int S_separable_2Dconvolve_mirror(float*,float*,int,int,float*,float*,int,int,npy_intp*,npy_intp*);
-
-extern int D_cubic_spline2D(double*,double*,int,int,double,npy_intp*,npy_intp*,double);
-extern int D_quadratic_spline2D(double*,double*,int,int,double,npy_intp*,npy_intp*,double);
-extern int D_IIR_forback1(double,double,double*,double*,int,int,int,double);
-extern int D_IIR_forback2(double,double,double*,double*,int,int,int,double);
-extern int D_separable_2Dconvolve_mirror(double*,double*,int,int,double*,double*,int,int,npy_intp*,npy_intp*);
-
-#ifdef __GNUC__
-extern int C_IIR_forback1(__complex__ float,__complex__ float,__complex__ float*,__complex__ float*,int,int,int,float);
-extern int C_separable_2Dconvolve_mirror(__complex__ float*,__complex__ float*,int,int,__complex__ float*,__complex__ float*,int,int,npy_intp*,npy_intp*);
-extern int Z_IIR_forback1(__complex__ double,__complex__ double,__complex__ double*,__complex__ double*,int,int,int,double);
-extern int Z_separable_2Dconvolve_mirror(__complex__ double*,__complex__ double*,int,int,__complex__ double*,__complex__ double*,int,int,npy_intp*,npy_intp*);
-#endif
+#include "_splinemodule.h"
 
 static void
 convert_strides(npy_intp* instrides,npy_intp* convstrides,int size,int N)

--- a/scipy/signal/_splinemodule.c
+++ b/scipy/signal/_splinemodule.c
@@ -15,8 +15,8 @@ extern int S_separable_2Dconvolve_mirror(float*,float*,int,int,float*,float*,int
 
 extern int D_cubic_spline2D(double*,double*,int,int,double,npy_intp*,npy_intp*,double);
 extern int D_quadratic_spline2D(double*,double*,int,int,double,npy_intp*,npy_intp*,double);
-extern int D_IIR_forback1(double,double,double*,double*,int,int,int,double);
-extern int D_IIR_forback2(double,double,double*,double*,int,int,int,double);
+extern int D_IIR_forback1(double,double,double*,double*,int,int,int,float);
+extern int D_IIR_forback2(double,double,double*,double*,int,int,int,float);
 extern int D_separable_2Dconvolve_mirror(double*,double*,int,int,double*,double*,int,int,npy_intp*,npy_intp*);
 
 #ifdef __GNUC__

--- a/scipy/signal/_splinemodule.c
+++ b/scipy/signal/_splinemodule.c
@@ -15,14 +15,14 @@ extern int S_separable_2Dconvolve_mirror(float*,float*,int,int,float*,float*,int
 
 extern int D_cubic_spline2D(double*,double*,int,int,double,npy_intp*,npy_intp*,double);
 extern int D_quadratic_spline2D(double*,double*,int,int,double,npy_intp*,npy_intp*,double);
-extern int D_IIR_forback1(double,double,double*,double*,int,int,int,float);
-extern int D_IIR_forback2(double,double,double*,double*,int,int,int,float);
+extern int D_IIR_forback1(double,double,double*,double*,int,int,int,double);
+extern int D_IIR_forback2(double,double,double*,double*,int,int,int,double);
 extern int D_separable_2Dconvolve_mirror(double*,double*,int,int,double*,double*,int,int,npy_intp*,npy_intp*);
 
 #ifdef __GNUC__
 extern int C_IIR_forback1(__complex__ float,__complex__ float,__complex__ float*,__complex__ float*,int,int,int,float);
 extern int C_separable_2Dconvolve_mirror(__complex__ float*,__complex__ float*,int,int,__complex__ float*,__complex__ float*,int,int,npy_intp*,npy_intp*);
-extern int Z_IIR_forback1(__complex__ double,__complex__ double,__complex__ double*,__complex__ double*,int,int,int,float);
+extern int Z_IIR_forback1(__complex__ double,__complex__ double,__complex__ double*,__complex__ double*,int,int,int,double);
 extern int Z_separable_2Dconvolve_mirror(__complex__ double*,__complex__ double*,int,int,__complex__ double*,__complex__ double*,int,int,npy_intp*,npy_intp*);
 #endif
 

--- a/scipy/signal/_splinemodule.c
+++ b/scipy/signal/_splinemodule.c
@@ -22,7 +22,7 @@ extern int D_separable_2Dconvolve_mirror(double*,double*,int,int,double*,double*
 #ifdef __GNUC__
 extern int C_IIR_forback1(__complex__ float,__complex__ float,__complex__ float*,__complex__ float*,int,int,int,float);
 extern int C_separable_2Dconvolve_mirror(__complex__ float*,__complex__ float*,int,int,__complex__ float*,__complex__ float*,int,int,npy_intp*,npy_intp*);
-extern int Z_IIR_forback1(__complex__ double,__complex__ double,__complex__ double*,__complex__ double*,int,int,int,double);
+extern int Z_IIR_forback1(__complex__ double,__complex__ double,__complex__ double*,__complex__ double*,int,int,int,float);
 extern int Z_separable_2Dconvolve_mirror(__complex__ double*,__complex__ double*,int,int,__complex__ double*,__complex__ double*,int,int,npy_intp*,npy_intp*);
 #endif
 

--- a/scipy/signal/_splinemodule.h
+++ b/scipy/signal/_splinemodule.h
@@ -1,0 +1,27 @@
+#include "Python.h"
+#include "numpy/arrayobject.h"
+#include <math.h>
+
+
+#define PYERR(message) do {PyErr_SetString(PyExc_ValueError, message); goto fail;} while(0)
+
+static void convert_strides(npy_intp*,npy_intp*,int,int);
+
+extern int S_cubic_spline2D(float*,float*,int,int,double,npy_intp*,npy_intp*,float);
+extern int S_quadratic_spline2D(float*,float*,int,int,double,npy_intp*,npy_intp*,float);
+extern int S_IIR_forback1(float,float,float*,float*,int,int,int,float);
+extern int S_IIR_forback2(double,double,float*,float*,int,int,int,float);
+extern int S_separable_2Dconvolve_mirror(float*,float*,int,int,float*,float*,int,int,npy_intp*,npy_intp*);
+
+extern int D_cubic_spline2D(double*,double*,int,int,double,npy_intp*,npy_intp*,double);
+extern int D_quadratic_spline2D(double*,double*,int,int,double,npy_intp*,npy_intp*,double);
+extern int D_IIR_forback1(double,double,double*,double*,int,int,int,double);
+extern int D_IIR_forback2(double,double,double*,double*,int,int,int,double);
+extern int D_separable_2Dconvolve_mirror(double*,double*,int,int,double*,double*,int,int,npy_intp*,npy_intp*);
+
+#ifdef __GNUC__
+extern int C_IIR_forback1(__complex__ float,__complex__ float,__complex__ float*,__complex__ float*,int,int,int,float);
+extern int C_separable_2Dconvolve_mirror(__complex__ float*,__complex__ float*,int,int,__complex__ float*,__complex__ float*,int,int,npy_intp*,npy_intp*);
+extern int Z_IIR_forback1(__complex__ double,__complex__ double,__complex__ double*,__complex__ double*,int,int,int,double);
+extern int Z_separable_2Dconvolve_mirror(__complex__ double*,__complex__ double*,int,int,__complex__ double*,__complex__ double*,int,int,npy_intp*,npy_intp*);
+#endif


### PR DESCRIPTION
The precision parameter has type float but it is declared in `_splinemodule.c`
with type double.

From the code it looks to me like precision is supposed to be type float, 
since `err` is also declared as a `float`, but it would also be possible to
switch the definition of the function.

I am a bit surprised this wasn't detected, since it seems like this should
be very buggy. Is this function used in the test suite ever? Why doesn't
this invalid declaration cause linker errors?