### PR TITLE
MAINT: stats: ensure that `rv_continuous._fitstart` shapes do not violate `_argcheck`

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -2316,6 +2316,10 @@ class truncweibull_min_gen(rv_continuous):
         ib = _ShapeInfo("b", False, (0, np.inf), (False, False))
         return [ic, ia, ib]
 
+    def _fitstart(self, data):
+        # Arbitrary, but default a=b=c=1 is not valid
+        return super()._fitstart(data, args=(1, 0, 1))
+
     def _get_support(self, c, a, b):
         return a, b
 
@@ -3337,6 +3341,11 @@ class genhyperbolic_gen(rv_continuous):
         ia = _ShapeInfo("a", False, (0, np.inf), (True, False))
         ib = _ShapeInfo("b", False, (-np.inf, np.inf), (False, False))
         return [ip, ia, ib]
+
+    def _fitstart(self, data):
+        # Arbitrary, but the default a=b=1 is not valid
+        return super()._fitstart(data, args=(1, 1, 0.5))
+
 
     def _logpdf(self, x, p, a, b):
         # kve instead of kv works better for large values of p
@@ -4484,6 +4493,10 @@ class norminvgauss_gen(rv_continuous):
         ia = _ShapeInfo("a", False, (0, np.inf), (False, False))
         ib = _ShapeInfo("b", False, (-np.inf, np.inf), (False, False))
         return [ia, ib]
+
+    def _fitstart(self, data):
+        # Arbitrary, but the default a=b=1 is not valid
+        return super()._fitstart(data, args=(1, 0.5))
 
     def _pdf(self, x, a, b):
         gamma = np.sqrt(a**2 - b**2)
@@ -7289,6 +7302,10 @@ class reciprocal_gen(rv_continuous):
         ib = _ShapeInfo("b", False, (0, np.inf), (False, False))
         return [ia, ib]
 
+    def _fitstart(self, data):
+        # Reasonable, since support is [a, b]
+        return super()._fitstart(data, args=(np.min(data), np.max(data)))
+
     def _get_support(self, a, b):
         return a, b
 
@@ -8275,6 +8292,10 @@ class truncnorm_gen(rv_continuous):
         ib = _ShapeInfo("b", False, (-np.inf, np.inf), (False, True))
         return [ia, ib]
 
+    def _fitstart(self, data):
+        # Reasonable, since support is [a, b]
+        return super()._fitstart(data, args=(np.min(data), np.max(data)))
+
     def _get_support(self, a, b):
         return a, b
 
@@ -9133,6 +9154,10 @@ class crystalball_gen(rv_continuous):
         ibeta = _ShapeInfo("beta", False, (0, np.inf), (False, False))
         im = _ShapeInfo("m", False, (1, np.inf), (False, False))
         return [ibeta, im]
+
+    def _fitstart(self, data):
+        # Arbitrary, but the default m=1 is not valid
+        return super()._fitstart(data, args=(1, 1.5))
 
     def _pdf(self, x, beta, m):
         """

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -3346,7 +3346,6 @@ class genhyperbolic_gen(rv_continuous):
         # Arbitrary, but the default a=b=1 is not valid
         return super()._fitstart(data, args=(1, 1, 0.5))
 
-
     def _logpdf(self, x, p, a, b):
         # kve instead of kv works better for large values of p
         # and smaller values of sqrt(a^2  - b^2)

--- a/scipy/stats/tests/test_fit.py
+++ b/scipy/stats/tests/test_fit.py
@@ -212,6 +212,25 @@ def cases_test_fit():
             yield dist
 
 
+def cases_test_fitstart():
+    for distname, shapes in dict(distcont).items():
+        if not isinstance(distname, str) or distname in {'studentized_range'}:
+            continue
+        yield distname, shapes
+
+
+@pytest.mark.parametrize('distname, shapes', cases_test_fitstart())
+def test_fitstart(distname, shapes):
+    dist = getattr(stats, distname)
+    rng = np.random.default_rng(216342614)
+    data = rng.random(10)
+
+    with np.errstate(invalid='ignore', divide='ignore'):  # irrelevant to test
+        guess = dist._fitstart(data)
+
+    assert dist._argcheck(*guess[:-2])
+
+
 def assert_nllf_less_or_close(dist, data, params1, params0, rtol=1e-7, atol=0):
     nllf1 = dist.nnlf(params1, data)
     nllf0 = dist.nnlf(params0, data)


### PR DESCRIPTION
#### Reference issue
Closes gh-15689

#### What does this implement/fix?
gh-15689 reported that when using the `fit` method of `rv_continuous`, the `_fitstart` still needs to be overridden for several distributions because the default value of shape parameters (all `1`) violates `_argcheck`. This PR overrides `_fitstart` as needed and adds a test to ensure that new distributions do not have the same problem.

#### Additional information
Most of shape values produced by these overrides are arbitrary, but better than all `1`, and I think the need to improve distribution fitting on a case-by-case basis is adequately documented outside of gh-15689.