### PR TITLE
BLD: specify `cython_lapack` dependency for `matfuncs_expm`

### DIFF
--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -252,7 +252,7 @@ _matfuncs_expm_pyx = custom_target('_matfuncs_expm',
 )
 
 py3.extension_module('_matfuncs_expm',
-  linalg_init_cython_gen.process(_matfuncs_expm_pyx),
+  linalg_cython_gen.process(_matfuncs_expm_pyx),
   c_args: cython_c_args,
   include_directories: inc_np,
   dependencies: py3_dep,


### PR DESCRIPTION
Matfuncs_expm does not only depend on the __init__ file, but on
cython_lapack etc.  Specify in dependencies.

Closes gh-15962

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->