### PR TITLE
Export MemoizeJac and ScalarFunction

### DIFF
--- a/scipy/optimize/__init__.py
+++ b/scipy/optimize/__init__.py
@@ -417,6 +417,7 @@ from ._lsq import least_squares, lsq_linear
 from ._constraints import (NonlinearConstraint,
                            LinearConstraint,
                            Bounds)
+from ._differentiable_functions import ScalarFunction
 from ._hessian_update_strategy import HessianUpdateStrategy, BFGS, SR1
 from ._shgo import shgo
 from ._dual_annealing import dual_annealing

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -21,7 +21,7 @@ __all__ = ['fmin', 'fmin_powell', 'fmin_bfgs', 'fmin_ncg', 'fmin_cg',
            'fminbound', 'brent', 'golden', 'bracket', 'rosen', 'rosen_der',
            'rosen_hess', 'rosen_hess_prod', 'brute', 'approx_fprime',
            'line_search', 'check_grad', 'OptimizeResult', 'show_options',
-           'OptimizeWarning']
+           'OptimizeWarning', 'MemoizeJac']
 
 __docformat__ = "restructuredtext en"
 

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -20,14 +20,17 @@ import pytest
 from pytest import raises as assert_raises
 
 from scipy import optimize
-from scipy.optimize._minimize import Bounds, NonlinearConstraint
+from scipy.optimize import (Bounds,
+                            NonlinearConstraint,
+                            ScalarFunction,
+                            MemoizeJac,
+                            show_options)
 from scipy.optimize._minimize import MINIMIZE_METHODS, MINIMIZE_SCALAR_METHODS
 from scipy.optimize._linprog import LINPROG_METHODS
 from scipy.optimize._root import ROOT_METHODS
 from scipy.optimize._root_scalar import ROOT_SCALAR_METHODS
 from scipy.optimize._qap import QUADRATIC_ASSIGNMENT_METHODS
-from scipy.optimize._differentiable_functions import ScalarFunction, FD_METHODS
-from scipy.optimize._optimize import MemoizeJac, show_options
+from scipy.optimize._differentiable_functions import FD_METHODS
 
 
 def test_check_grad():


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

The commit https://github.com/scipy/scipy/commit/6b08e087171479b30fc2dc015d2074a24844789e deprecated the `scipy.optimize.optimize` namespace in favor of the `scipy.optimize` namespace.  However, a couple of classes, namely `MemoizeJac` and `ScalarFunction` which were previously available in `scipy.optimize.optimize` were not exported in `scipy.optimize`.  Currently, they must be imported from (e.g.) `scipy.optimize._optimize` to avoid the deprecation warning.

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

This PR exports `MemoizeJac` and `ScalarFunction` in the `scipy.optimize` namespace.  Additionally, the `test_optimize.py` file was updated to use the public API for imports whenever possible to catch further unintentional deprecations and namespace changes.

#### Additional information
<!--Any additional information you think is important.-->
