### PR TITLE
ENH: optimize: Add Newton-TFQMR method and some tests for Newton-Krylov

### DIFF
--- a/scipy/optimize/_nonlin.py
+++ b/scipy/optimize/_nonlin.py
@@ -1320,10 +1320,12 @@ class KrylovJacobian(Jacobian):
     %(params_basic)s
     rdiff : float, optional
         Relative step size to use in numerical differentiation.
-    method : {'lgmres', 'gmres', 'bicgstab', 'cgs', 'minres', 'tfqmr'} or callable
-        Krylov method to use to approximate the Jacobian.
-        Can be a string, or a function implementing the same interface as
-        the iterative solvers in `scipy.sparse.linalg`.
+    method : str or callable, optional
+        Krylov method to use to approximate the Jacobian.  Can be a string,
+        or a function implementing the same interface as the iterative
+        solvers in `scipy.sparse.linalg`. If a string, needs to be one of:
+        ``'lgmres'``, ``'gmres'``, ``'bicgstab'``, ``'cgs'``, ``'minres'``,
+        ``'tfqmr'``.
 
         The default is `scipy.sparse.linalg.lgmres`.
     inner_maxiter : int, optional

--- a/scipy/optimize/_nonlin.py
+++ b/scipy/optimize/_nonlin.py
@@ -1321,7 +1321,7 @@ class KrylovJacobian(Jacobian):
     rdiff : float, optional
         Relative step size to use in numerical differentiation.
     method : {'lgmres', 'gmres', 'bicgstab', 'cgs', 'minres', 'tfqmr'} or
-        function Krylov method to use to approximate the Jacobian.
+        callable Krylov method to use to approximate the Jacobian.
         Can be a string, or a function implementing the same interface as
         the iterative solvers in `scipy.sparse.linalg`.
 

--- a/scipy/optimize/_nonlin.py
+++ b/scipy/optimize/_nonlin.py
@@ -1320,8 +1320,8 @@ class KrylovJacobian(Jacobian):
     %(params_basic)s
     rdiff : float, optional
         Relative step size to use in numerical differentiation.
-    method : {'lgmres', 'gmres', 'bicgstab', 'cgs', 'minres', 'tfqmr'} or
-        callable Krylov method to use to approximate the Jacobian.
+    method : {'lgmres', 'gmres', 'bicgstab', 'cgs', 'minres', 'tfqmr'} or callable
+        Krylov method to use to approximate the Jacobian.
         Can be a string, or a function implementing the same interface as
         the iterative solvers in `scipy.sparse.linalg`.
 
@@ -1413,6 +1413,8 @@ class KrylovJacobian(Jacobian):
                  inner_M=None, outer_k=10, **kw):
         self.preconditioner = inner_M
         self.rdiff = rdiff
+        # Note that this retrieves one of the named functions, or otherwise
+        # uses `method` as is (i.e., for a user-provided callable).
         self.method = dict(
             bicgstab=scipy.sparse.linalg.bicgstab,
             gmres=scipy.sparse.linalg.gmres,
@@ -1429,7 +1431,9 @@ class KrylovJacobian(Jacobian):
             self.method_kw['restrt'] = inner_maxiter
             self.method_kw['maxiter'] = 1
             self.method_kw.setdefault('atol', 0)
-        elif self.method is scipy.sparse.linalg.gcrotmk:
+        elif self.method in (scipy.sparse.linalg.gcrotmk,
+                             scipy.sparse.linalg.bicgstab,
+                             scipy.sparse.linalg.cgs):
             self.method_kw.setdefault('atol', 0)
         elif self.method is scipy.sparse.linalg.lgmres:
             self.method_kw['outer_k'] = outer_k

--- a/scipy/optimize/_nonlin.py
+++ b/scipy/optimize/_nonlin.py
@@ -1320,8 +1320,8 @@ class KrylovJacobian(Jacobian):
     %(params_basic)s
     rdiff : float, optional
         Relative step size to use in numerical differentiation.
-    method : {'lgmres', 'gmres', 'bicgstab', 'cgs', 'minres'} or function
-        Krylov method to use to approximate the Jacobian.
+    method : {'lgmres', 'gmres', 'bicgstab', 'cgs', 'minres', 'tfqmr'} or
+        function Krylov method to use to approximate the Jacobian.
         Can be a string, or a function implementing the same interface as
         the iterative solvers in `scipy.sparse.linalg`.
 
@@ -1383,9 +1383,12 @@ class KrylovJacobian(Jacobian):
 
     References
     ----------
-    .. [1] D.A. Knoll and D.E. Keyes, J. Comp. Phys. 193, 357 (2004).
+    .. [1] C. T. Kelley, Solving Nonlinear Equations with Newton's Method,
+           SIAM, pp.57-83, 2003.
+           :doi:`10.1137/1.9780898718898.ch3`
+    .. [2] D.A. Knoll and D.E. Keyes, J. Comp. Phys. 193, 357 (2004).
            :doi:`10.1016/j.jcp.2003.08.010`
-    .. [2] A.H. Baker and E.R. Jessup and T. Manteuffel,
+    .. [3] A.H. Baker and E.R. Jessup and T. Manteuffel,
            SIAM J. Matrix Anal. Appl. 26, 962 (2005).
            :doi:`10.1137/S0895479803422014`
 
@@ -1416,6 +1419,7 @@ class KrylovJacobian(Jacobian):
             lgmres=scipy.sparse.linalg.lgmres,
             cgs=scipy.sparse.linalg.cgs,
             minres=scipy.sparse.linalg.minres,
+            tfqmr=scipy.sparse.linalg.tfqmr,
             ).get(method, method)
 
         self.method_kw = dict(maxiter=inner_maxiter, M=self.preconditioner)

--- a/scipy/optimize/_root.py
+++ b/scipy/optimize/_root.py
@@ -684,8 +684,8 @@ def _root_krylov_doc():
 
         rdiff : float, optional
             Relative step size to use in numerical differentiation.
-        method : {'lgmres', 'gmres', 'bicgstab', 'cgs', 'minres'} or function
-            Krylov method to use to approximate the Jacobian.
+        method : {'lgmres', 'gmres', 'bicgstab', 'cgs', 'minres', 'tfqmr'} or
+            function Krylov method to use to approximate the Jacobian.
             Can be a string, or a function implementing the same
             interface as the iterative solvers in
             `scipy.sparse.linalg`.

--- a/scipy/optimize/_root.py
+++ b/scipy/optimize/_root.py
@@ -685,7 +685,7 @@ def _root_krylov_doc():
         rdiff : float, optional
             Relative step size to use in numerical differentiation.
         method : {'lgmres', 'gmres', 'bicgstab', 'cgs', 'minres', 'tfqmr'} or
-            function Krylov method to use to approximate the Jacobian.
+            callable Krylov method to use to approximate the Jacobian.
             Can be a string, or a function implementing the same
             interface as the iterative solvers in
             `scipy.sparse.linalg`.

--- a/scipy/optimize/_root.py
+++ b/scipy/optimize/_root.py
@@ -684,11 +684,10 @@ def _root_krylov_doc():
 
         rdiff : float, optional
             Relative step size to use in numerical differentiation.
-        method : {'lgmres', 'gmres', 'bicgstab', 'cgs', 'minres', 'tfqmr'} or
-            callable Krylov method to use to approximate the Jacobian.
-            Can be a string, or a function implementing the same
-            interface as the iterative solvers in
-            `scipy.sparse.linalg`.
+        method : {'lgmres', 'gmres', 'bicgstab', 'cgs', 'minres', 'tfqmr'} or callable
+            Krylov method to use to approximate the Jacobian.  Can be a string,
+            or a function implementing the same interface as the iterative
+            solvers in `scipy.sparse.linalg`.
 
             The default is `scipy.sparse.linalg.lgmres`.
         inner_M : LinearOperator or InverseJacobian

--- a/scipy/optimize/_root.py
+++ b/scipy/optimize/_root.py
@@ -684,10 +684,12 @@ def _root_krylov_doc():
 
         rdiff : float, optional
             Relative step size to use in numerical differentiation.
-        method : {'lgmres', 'gmres', 'bicgstab', 'cgs', 'minres', 'tfqmr'} or callable
+        method : str or callable, optional
             Krylov method to use to approximate the Jacobian.  Can be a string,
             or a function implementing the same interface as the iterative
-            solvers in `scipy.sparse.linalg`.
+            solvers in `scipy.sparse.linalg`. If a string, needs to be one of:
+            ``'lgmres'``, ``'gmres'``, ``'bicgstab'``, ``'cgs'``, ``'minres'``,
+            ``'tfqmr'``.
 
             The default is `scipy.sparse.linalg.lgmres`.
         inner_M : LinearOperator or InverseJacobian

--- a/scipy/optimize/tests/test_nonlin.py
+++ b/scipy/optimize/tests/test_nonlin.py
@@ -2,7 +2,7 @@
 Author: Ondrej Certik
 May 2007
 """
-from numpy.testing import assert_
+from numpy.testing import assert_, suppress_warnings
 import pytest
 
 from scipy.optimize import _nonlin as nonlin, root
@@ -34,6 +34,8 @@ def F(x):
 
 F.xin = [1,1,1,1,1]
 F.KNOWN_BAD = {}
+F.JAC_KSP_BAD = {}
+F.ROOT_JAC_KSP_BAD = {}
 
 
 def F2(x):
@@ -43,6 +45,8 @@ def F2(x):
 F2.xin = [1,2,3,4,5,6]
 F2.KNOWN_BAD = {'linearmixing': nonlin.linearmixing,
                 'excitingmixing': nonlin.excitingmixing}
+F2.JAC_KSP_BAD = {}
+F2.ROOT_JAC_KSP_BAD = {}
 
 
 def F2_lucky(x):
@@ -51,6 +55,8 @@ def F2_lucky(x):
 
 F2_lucky.xin = [0,0,0,0,0,0]
 F2_lucky.KNOWN_BAD = {}
+F2_lucky.JAC_KSP_BAD = {}
+F2_lucky.ROOT_JAC_KSP_BAD = {}
 
 
 def F3(x):
@@ -61,6 +67,8 @@ def F3(x):
 
 F3.xin = [1,2,3]
 F3.KNOWN_BAD = {}
+F3.JAC_KSP_BAD = {}
+F3.ROOT_JAC_KSP_BAD = {}
 
 
 def F4_powell(x):
@@ -72,6 +80,8 @@ F4_powell.xin = [-1, -2]
 F4_powell.KNOWN_BAD = {'linearmixing': nonlin.linearmixing,
                        'excitingmixing': nonlin.excitingmixing,
                        'diagbroyden': nonlin.diagbroyden}
+F4_powell.JAC_KSP_BAD = {'minres'}
+F4_powell.ROOT_JAC_KSP_BAD = {'gmres', 'bicgstab', 'cgs', 'minres', 'tfqmr'}
 
 
 def F5(x):
@@ -82,6 +92,8 @@ F5.xin = [2., 0, 2, 0]
 F5.KNOWN_BAD = {'excitingmixing': nonlin.excitingmixing,
                 'linearmixing': nonlin.linearmixing,
                 'diagbroyden': nonlin.diagbroyden}
+F5.JAC_KSP_BAD = {'cgs', 'minres'}
+F5.ROOT_JAC_KSP_BAD = {'minres'}
 
 
 def F6(x):
@@ -97,6 +109,8 @@ F6.xin = [-0.5, 1.4]
 F6.KNOWN_BAD = {'excitingmixing': nonlin.excitingmixing,
                 'linearmixing': nonlin.linearmixing,
                 'diagbroyden': nonlin.diagbroyden}
+F6.JAC_KSP_BAD = {}
+F6.ROOT_JAC_KSP_BAD = {}
 
 
 #-------------------------------------------------------------------------------
@@ -114,10 +128,36 @@ class TestNonlin:
     """
 
     def _check_nonlin_func(self, f, func, f_tol=1e-2):
+        # Test all methods mentioned in the class `KrylovJacobian`
+        if func == SOLVERS['krylov']:
+            for method in ['gmres', 'bicgstab', 'cgs', 'minres', 'tfqmr']:
+                if method in f.JAC_KSP_BAD:
+                    continue
+                with suppress_warnings() as sup:
+                    sup.filter(DeprecationWarning,
+                               ".*called without specifying")
+                    x = func(f, f.xin, method=method, line_search=None,
+                             f_tol=f_tol, maxiter=200, verbose=0)
+                assert_(np.absolute(f(x)).max() < f_tol)
+
         x = func(f, f.xin, f_tol=f_tol, maxiter=200, verbose=0)
         assert_(np.absolute(f(x)).max() < f_tol)
 
     def _check_root(self, f, method, f_tol=1e-2):
+        # Test Krylov methods
+        if method == 'krylov':
+            for jac_method in ['gmres', 'bicgstab', 'cgs', 'minres', 'tfqmr']:
+                if jac_method in f.ROOT_JAC_KSP_BAD:
+                    continue
+                with suppress_warnings() as sup:
+                    sup.filter(DeprecationWarning,
+                               ".*called without specifying")
+                    res = root(f, f.xin, method=method,
+                               options={'ftol': f_tol, 'maxiter': 200,
+                                        'disp': 0,
+                                        'jac_options': {'method': jac_method}})
+                assert_(np.absolute(res.fun).max() < f_tol)
+
         res = root(f, f.xin, method=method,
                    options={'ftol': f_tol, 'maxiter': 200, 'disp': 0})
         assert_(np.absolute(res.fun).max() < f_tol)
@@ -135,7 +175,9 @@ class TestNonlin:
                     continue
                 self._check_nonlin_func(f, func)
 
-    def test_tol_norm_called(self):
+    @pytest.mark.parametrize("method", ['lgmres', 'gmres', 'bicgstab', 'cgs',
+                                        'minres', 'tfqmr'])
+    def test_tol_norm_called(self, method):
         # Check that supplying tol_norm keyword to nonlin_solve works
         self._tol_norm_used = False
 
@@ -143,8 +185,11 @@ class TestNonlin:
             self._tol_norm_used = True
             return np.absolute(x).max()
 
-        nonlin.newton_krylov(F, F.xin, f_tol=1e-2, maxiter=200, verbose=0,
-             tol_norm=local_norm_func)
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning, ".*called without specifying")
+            nonlin.newton_krylov(F, F.xin, method=method, f_tol=1e-2,
+                                 maxiter=200, verbose=0,
+                                 tol_norm=local_norm_func)
         assert_(self._tol_norm_used)
 
     def test_problem_root(self):

--- a/scipy/optimize/tests/test_nonlin.py
+++ b/scipy/optimize/tests/test_nonlin.py
@@ -139,11 +139,9 @@ class TestNonlin:
             for method in ['gmres', 'bicgstab', 'cgs', 'minres', 'tfqmr']:
                 if method in f.JAC_KSP_BAD:
                     continue
-                with suppress_warnings() as sup:
-                    sup.filter(DeprecationWarning,
-                               ".*called without specifying")
-                    x = func(f, f.xin, method=method, line_search=None,
-                             f_tol=f_tol, maxiter=200, verbose=0)
+
+                x = func(f, f.xin, method=method, line_search=None,
+                         f_tol=f_tol, maxiter=200, verbose=0)
                 assert_(np.absolute(f(x)).max() < f_tol)
 
         x = func(f, f.xin, f_tol=f_tol, maxiter=200, verbose=0)
@@ -155,13 +153,11 @@ class TestNonlin:
             for jac_method in ['gmres', 'bicgstab', 'cgs', 'minres', 'tfqmr']:
                 if jac_method in f.ROOT_JAC_KSP_BAD:
                     continue
-                with suppress_warnings() as sup:
-                    sup.filter(DeprecationWarning,
-                               ".*called without specifying")
-                    res = root(f, f.xin, method=method,
-                               options={'ftol': f_tol, 'maxiter': 200,
-                                        'disp': 0,
-                                        'jac_options': {'method': jac_method}})
+
+                res = root(f, f.xin, method=method,
+                           options={'ftol': f_tol, 'maxiter': 200,
+                                    'disp': 0,
+                                    'jac_options': {'method': jac_method}})
                 assert_(np.absolute(res.fun).max() < f_tol)
 
         res = root(f, f.xin, method=method,
@@ -191,11 +187,9 @@ class TestNonlin:
             self._tol_norm_used = True
             return np.absolute(x).max()
 
-        with suppress_warnings() as sup:
-            sup.filter(DeprecationWarning, ".*called without specifying")
-            nonlin.newton_krylov(F, F.xin, method=method, f_tol=1e-2,
-                                 maxiter=200, verbose=0,
-                                 tol_norm=local_norm_func)
+        nonlin.newton_krylov(F, F.xin, method=method, f_tol=1e-2,
+                             maxiter=200, verbose=0,
+                             tol_norm=local_norm_func)
         assert_(self._tol_norm_used)
 
     def test_problem_root(self):

--- a/scipy/optimize/tests/test_nonlin.py
+++ b/scipy/optimize/tests/test_nonlin.py
@@ -2,7 +2,7 @@
 Author: Ondrej Certik
 May 2007
 """
-from numpy.testing import assert_, suppress_warnings
+from numpy.testing import assert_
 import pytest
 
 from scipy.optimize import _nonlin as nonlin, root

--- a/scipy/optimize/tests/test_nonlin.py
+++ b/scipy/optimize/tests/test_nonlin.py
@@ -80,6 +80,9 @@ F4_powell.xin = [-1, -2]
 F4_powell.KNOWN_BAD = {'linearmixing': nonlin.linearmixing,
                        'excitingmixing': nonlin.excitingmixing,
                        'diagbroyden': nonlin.diagbroyden}
+# In the extreme case, it does not converge for nolinear problem solved by
+# MINRES and root problem solved by GMRES/BiCGStab/CGS/MINRES/TFQMR when using
+# Krylov method to approximate Jacobian
 F4_powell.JAC_KSP_BAD = {'minres'}
 F4_powell.ROOT_JAC_KSP_BAD = {'gmres', 'bicgstab', 'cgs', 'minres', 'tfqmr'}
 
@@ -92,6 +95,9 @@ F5.xin = [2., 0, 2, 0]
 F5.KNOWN_BAD = {'excitingmixing': nonlin.excitingmixing,
                 'linearmixing': nonlin.linearmixing,
                 'diagbroyden': nonlin.diagbroyden}
+# In the extreme case, the Jacobian inversion yielded zero vector for nonlinear
+# problem solved by CGS/MINRES and it does not converge for root problem solved
+# by MINRES and when using Krylov method to approximate Jacobian
 F5.JAC_KSP_BAD = {'cgs', 'minres'}
 F5.ROOT_JAC_KSP_BAD = {'minres'}
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes gh-14862 (Refer to gh-14862 for comments)

#### What does this implement/fix?
<!--Please explain your changes.-->
In this PR, just like GMRES etc., TFQMR method can be used to approximate the inverse of the Jacobian in the process of solving nonlinear equations using Newton-Krylov method and finding root.
References are added on the basis of the PR gh-14862.

#### Additional information
<!--Any additional information you think is important.-->
