### PR TITLE
TST: sparse.linalg: Add tests for the parameter `show`

### DIFF
--- a/scipy/sparse/linalg/_isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_iterative.py
@@ -530,6 +530,27 @@ def test_x0_equals_Mb(solver):
             assert_normclose(A.dot(x), b, tol=tol)
 
 
+@pytest.mark.parametrize(('solver', 'solverstring'), [(tfqmr, 'TFQMR')])
+def test_show(solver, solverstring, capsys):
+    def cb(x):
+        count[0] += 1
+
+    for i in [0, 20]:
+        case = params.cases[i]
+        A = case.A
+        b = case.b
+        count = [0]
+        x, info = solver(A, b, callback=cb, show=True)
+        out, err = capsys.readouterr()
+        if i == 20:  # Asymmetric and Positive Definite
+            assert_equal(out, f"{solverstring}: Linear solve not converged "
+                              f"due to reach MAXIT iterations {count[0]}\n")
+        else:  # 1-D Poisson equations
+            assert_equal(out, f"{solverstring}: Linear solve converged due to "
+                              f"reach TOL iterations {count[0]}\n")
+        assert_equal(err, '')
+
+
 #------------------------------------------------------------------------------
 
 class TestQMR:


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
In this PR, the test cases of  `show=True` of TFQMR are added to verify the correctness of the output information.

#### Additional information
<!--Any additional information you think is important.-->
