### PR TITLE
MAINT: fix `shgo` issue where arguments to objective function aren't passed properly

### DIFF
--- a/scipy/optimize/_shgo.py
+++ b/scipy/optimize/_shgo.py
@@ -896,8 +896,12 @@ class SHGO:
         """
         # Iterate the complex
         if self.n_sampled == 0:
-            # Initial triangulation of the hyper-rectangle
-            self.HC = Complex(self.dim, self.func, self.args,
+            # Initial triangulation of the hyper-rectangle. Note that
+            # the `func_args` argument of the Complex constructor is
+            # an empty tuple, since self.func is a *wrapped* function
+            # that already takes the original function arguments into
+            # account.
+            self.HC = Complex(self.dim, self.func, (),
                               self.symmetry, self.bounds, self.g_cons,
                               self.g_args)
         else:


### PR DESCRIPTION
#### Reference issue
Fixes bug #14589

#### What does this implement/fix?
A bug was introduced in the SHGO implementation of SciPy such that when the `args` parameter of `scipy.optimize.shgo` is used, `*(args + args)` is effectively passed to the objective function instead of `*args`. This pull request fixes that bug.