### PR TITLE
MAINT: integrate: add `recursive` to QUADPACK Fortran sources

### DIFF
--- a/scipy/integrate/quadpack/dqag.f
+++ b/scipy/integrate/quadpack/dqag.f
@@ -1,5 +1,5 @@
-      subroutine dqag(f,a,b,epsabs,epsrel,key,result,abserr,neval,ier,
-     *    limit,lenw,last,iwork,work)
+      recursive subroutine dqag(f,a,b,epsabs,epsrel,key,result,abserr,
+     *    neval,ier,limit,lenw,last,iwork,work)
 c***begin prologue  dqag
 c***date written   800101   (yymmdd)
 c***revision date  830518   (yymmdd)

--- a/scipy/integrate/quadpack/dqage.f
+++ b/scipy/integrate/quadpack/dqage.f
@@ -1,5 +1,5 @@
-      subroutine dqage(f,a,b,epsabs,epsrel,key,limit,result,abserr,
-     *   neval,ier,alist,blist,rlist,elist,iord,last)
+      recursive subroutine dqage(f,a,b,epsabs,epsrel,key,limit,result,
+     *   abserr,neval,ier,alist,blist,rlist,elist,iord,last)
 c***begin prologue  dqage
 c***date written   800101   (yymmdd)
 c***revision date  830518   (yymmdd)

--- a/scipy/integrate/quadpack/dqagi.f
+++ b/scipy/integrate/quadpack/dqagi.f
@@ -1,5 +1,5 @@
-      subroutine dqagi(f,bound,inf,epsabs,epsrel,result,abserr,neval,
-     *   ier,limit,lenw,last,iwork,work)
+      recursive subroutine dqagi(f,bound,inf,epsabs,epsrel,result,
+     *   abserr,neval,ier,limit,lenw,last,iwork,work)
 c***begin prologue  dqagi
 c***date written   800101   (yymmdd)
 c***revision date  830518   (yymmdd)

--- a/scipy/integrate/quadpack/dqagie.f
+++ b/scipy/integrate/quadpack/dqagie.f
@@ -1,5 +1,5 @@
-      subroutine dqagie(f,bound,inf,epsabs,epsrel,limit,result,abserr,
-     *   neval,ier,alist,blist,rlist,elist,iord,last)
+      recursive subroutine dqagie(f,bound,inf,epsabs,epsrel,limit,
+     *   result,abserr,neval,ier,alist,blist,rlist,elist,iord,last)
 c***begin prologue  dqagie
 c***date written   800101   (yymmdd)
 c***revision date  830518   (yymmdd)

--- a/scipy/integrate/quadpack/dqagp.f
+++ b/scipy/integrate/quadpack/dqagp.f
@@ -1,5 +1,5 @@
-      subroutine dqagp(f,a,b,npts2,points,epsabs,epsrel,result,abserr,
-     *   neval,ier,leniw,lenw,last,iwork,work)
+      recursive subroutine dqagp(f,a,b,npts2,points,epsabs,epsrel,
+     *   result,abserr,neval,ier,leniw,lenw,last,iwork,work)
 c***begin prologue  dqagp
 c***date written   800101   (yymmdd)
 c***revision date  830518   (yymmdd)

--- a/scipy/integrate/quadpack/dqagpe.f
+++ b/scipy/integrate/quadpack/dqagpe.f
@@ -1,6 +1,6 @@
-      subroutine dqagpe(f,a,b,npts2,points,epsabs,epsrel,limit,result,
-     *   abserr,neval,ier,alist,blist,rlist,elist,pts,iord,level,ndin,
-     *   last)
+      recursive subroutine dqagpe(f,a,b,npts2,points,epsabs,epsrel,
+     *   limit,result,abserr,neval,ier,alist,blist,rlist,elist,pts,
+     *   iord,level,ndin,last)
 c***begin prologue  dqagpe
 c***date written   800101   (yymmdd)
 c***revision date  830518   (yymmdd)

--- a/scipy/integrate/quadpack/dqags.f
+++ b/scipy/integrate/quadpack/dqags.f
@@ -1,5 +1,5 @@
-      subroutine dqags(f,a,b,epsabs,epsrel,result,abserr,neval,ier,
-     *   limit,lenw,last,iwork,work)
+      recursive subroutine dqags(f,a,b,epsabs,epsrel,result,abserr,
+     *   neval,ier,limit,lenw,last,iwork,work)
 c***begin prologue  dqags
 c***date written   800101   (yymmdd)
 c***revision date  830518   (yymmdd)

--- a/scipy/integrate/quadpack/dqagse.f
+++ b/scipy/integrate/quadpack/dqagse.f
@@ -1,5 +1,5 @@
-      subroutine dqagse(f,a,b,epsabs,epsrel,limit,result,abserr,neval,
-     *   ier,alist,blist,rlist,elist,iord,last)
+      recursive subroutine dqagse(f,a,b,epsabs,epsrel,limit,result,
+     *   abserr,neval,ier,alist,blist,rlist,elist,iord,last)
 c***begin prologue  dqagse
 c***date written   800101   (yymmdd)
 c***revision date  830518   (yymmdd)

--- a/scipy/integrate/quadpack/dqawc.f
+++ b/scipy/integrate/quadpack/dqawc.f
@@ -1,5 +1,5 @@
-      subroutine dqawc(f,a,b,c,epsabs,epsrel,result,abserr,neval,ier,
-     *   limit,lenw,last,iwork,work)
+      recursive subroutine dqawc(f,a,b,c,epsabs,epsrel,result,abserr,
+     *   neval,ier,limit,lenw,last,iwork,work)
 c***begin prologue  dqawc
 c***date written   800101   (yymmdd)
 c***revision date  830518   (yymmdd)

--- a/scipy/integrate/quadpack/dqawce.f
+++ b/scipy/integrate/quadpack/dqawce.f
@@ -1,5 +1,5 @@
-      subroutine dqawce(f,a,b,c,epsabs,epsrel,limit,result,abserr,neval,
-     *   ier,alist,blist,rlist,elist,iord,last)
+      recursive subroutine dqawce(f,a,b,c,epsabs,epsrel,limit,result,
+     *   abserr,neval,ier,alist,blist,rlist,elist,iord,last)
 c***begin prologue  dqawce
 c***date written   800101   (yymmdd)
 c***revision date  830518   (yymmdd)

--- a/scipy/integrate/quadpack/dqawf.f
+++ b/scipy/integrate/quadpack/dqawf.f
@@ -1,5 +1,5 @@
-      subroutine dqawf(f,a,omega,integr,epsabs,result,abserr,neval,ier,
-     *   limlst,lst,leniw,maxp1,lenw,iwork,work)
+      recursive subroutine dqawf(f,a,omega,integr,epsabs,result,
+     *   abserr,neval,ier,limlst,lst,leniw,maxp1,lenw,iwork,work)
 c***begin prologue  dqawf
 c***date written   800101   (yymmdd)
 c***revision date  830518   (yymmdd)

--- a/scipy/integrate/quadpack/dqawfe.f
+++ b/scipy/integrate/quadpack/dqawfe.f
@@ -1,6 +1,6 @@
-      subroutine dqawfe(f,a,omega,integr,epsabs,limlst,limit,maxp1,
-     *   result,abserr,neval,ier,rslst,erlst,ierlst,lst,alist,blist,
-     *   rlist,elist,iord,nnlog,chebmo)
+      recursive subroutine dqawfe(f,a,omega,integr,epsabs,limlst,
+     *   limit,maxp1,result,abserr,neval,ier,rslst,erlst,ierlst,lst,
+     *   alist,blist,rlist,elist,iord,nnlog,chebmo)
 c***begin prologue  dqawfe
 c***date written   800101   (yymmdd)
 c***revision date  830518   (yymmdd)

--- a/scipy/integrate/quadpack/dqawo.f
+++ b/scipy/integrate/quadpack/dqawo.f
@@ -1,5 +1,5 @@
-      subroutine dqawo(f,a,b,omega,integr,epsabs,epsrel,result,abserr,
-     *   neval,ier,leniw,maxp1,lenw,last,iwork,work)
+      recursive subroutine dqawo(f,a,b,omega,integr,epsabs,epsrel,
+     *   result,abserr,neval,ier,leniw,maxp1,lenw,last,iwork,work)
 c***begin prologue  dqawo
 c***date written   800101   (yymmdd)
 c***revision date  830518   (yymmdd)

--- a/scipy/integrate/quadpack/dqawoe.f
+++ b/scipy/integrate/quadpack/dqawoe.f
@@ -1,6 +1,6 @@
-      subroutine dqawoe (f,a,b,omega,integr,epsabs,epsrel,limit,icall,
-     *  maxp1,result,abserr,neval,ier,last,alist,blist,rlist,elist,iord,
-     *   nnlog,momcom,chebmo)
+      recursive subroutine dqawoe (f,a,b,omega,integr,epsabs,epsrel,
+     *  limit,icall,maxp1,result,abserr,neval,ier,last,alist,blist,
+     *  rlist,elist,iord,nnlog,momcom,chebmo)
 c***begin prologue  dqawoe
 c***date written   800101   (yymmdd)
 c***revision date  830518   (yymmdd)

--- a/scipy/integrate/quadpack/dqaws.f
+++ b/scipy/integrate/quadpack/dqaws.f
@@ -1,5 +1,5 @@
-      subroutine dqaws(f,a,b,alfa,beta,integr,epsabs,epsrel,result,
-     *   abserr,neval,ier,limit,lenw,last,iwork,work)
+      recursive subroutine dqaws(f,a,b,alfa,beta,integr,epsabs,epsrel,
+     *   result,abserr,neval,ier,limit,lenw,last,iwork,work)
 c***begin prologue  dqaws
 c***date written   800101   (yymmdd)
 c***revision date  830518   (yymmdd)

--- a/scipy/integrate/quadpack/dqawse.f
+++ b/scipy/integrate/quadpack/dqawse.f
@@ -1,5 +1,6 @@
-      subroutine dqawse(f,a,b,alfa,beta,integr,epsabs,epsrel,limit,
-     *   result,abserr,neval,ier,alist,blist,rlist,elist,iord,last)
+      recursive subroutine dqawse(f,a,b,alfa,beta,integr,epsabs,epsrel,
+     *   limit,result,abserr,neval,ier,alist,blist,rlist,elist,iord,
+     *   last)
 c***begin prologue  dqawse
 c***date written   800101   (yymmdd)
 c***revision date  830518   (yymmdd)

--- a/scipy/integrate/quadpack/dqc25c.f
+++ b/scipy/integrate/quadpack/dqc25c.f
@@ -1,4 +1,4 @@
-      subroutine dqc25c(f,a,b,c,result,abserr,krul,neval)
+      recursive subroutine dqc25c(f,a,b,c,result,abserr,krul,neval)
 c***begin prologue  dqc25c
 c***date written   810101   (yymmdd)
 c***revision date  830518   (yymmdd)

--- a/scipy/integrate/quadpack/dqc25f.f
+++ b/scipy/integrate/quadpack/dqc25f.f
@@ -1,5 +1,5 @@
-      subroutine dqc25f(f,a,b,omega,integr,nrmom,maxp1,ksave,result,
-     *   abserr,neval,resabs,resasc,momcom,chebmo)
+      recursive subroutine dqc25f(f,a,b,omega,integr,nrmom,maxp1,
+     *   ksave,result,abserr,neval,resabs,resasc,momcom,chebmo)
 c***begin prologue  dqc25f
 c***date written   810101   (yymmdd)
 c***revision date  830518   (yymmdd)

--- a/scipy/integrate/quadpack/dqc25s.f
+++ b/scipy/integrate/quadpack/dqc25s.f
@@ -1,5 +1,5 @@
-      subroutine dqc25s(f,a,b,bl,br,alfa,beta,ri,rj,rg,rh,result,
-     *   abserr,resasc,integr,nev)
+      recursive subroutine dqc25s(f,a,b,bl,br,alfa,beta,ri,rj,rg,rh,
+     *   result,abserr,resasc,integr,nev)
 c***begin prologue  dqc25s
 c***date written   810101   (yymmdd)
 c***revision date  830518   (yymmdd)

--- a/scipy/integrate/quadpack/dqcheb.f
+++ b/scipy/integrate/quadpack/dqcheb.f
@@ -1,4 +1,4 @@
-      subroutine dqcheb(x,fval,cheb12,cheb24)
+      recursive subroutine dqcheb(x,fval,cheb12,cheb24)
 c***begin prologue  dqcheb
 c***refer to  dqc25c,dqc25f,dqc25s
 c***routines called  (none)

--- a/scipy/integrate/quadpack/dqelg.f
+++ b/scipy/integrate/quadpack/dqelg.f
@@ -1,4 +1,4 @@
-      subroutine dqelg(n,epstab,result,abserr,res3la,nres)
+      recursive subroutine dqelg(n,epstab,result,abserr,res3la,nres)
 c***begin prologue  dqelg
 c***refer to  dqagie,dqagoe,dqagpe,dqagse
 c***routines called  d1mach

--- a/scipy/integrate/quadpack/dqk15.f
+++ b/scipy/integrate/quadpack/dqk15.f
@@ -1,4 +1,4 @@
-      subroutine dqk15(f,a,b,result,abserr,resabs,resasc)
+      recursive subroutine dqk15(f,a,b,result,abserr,resabs,resasc)
 c***begin prologue  dqk15
 c***date written   800101   (yymmdd)
 c***revision date  830518   (yymmdd)

--- a/scipy/integrate/quadpack/dqk15i.f
+++ b/scipy/integrate/quadpack/dqk15i.f
@@ -1,4 +1,5 @@
-      subroutine dqk15i(f,boun,inf,a,b,result,abserr,resabs,resasc)
+      recursive subroutine dqk15i(f,boun,inf,a,b,result,abserr,resabs,
+     *   resasc)
 c***begin prologue  dqk15i
 c***date written   800101   (yymmdd)
 c***revision date  830518   (yymmdd)

--- a/scipy/integrate/quadpack/dqk15w.f
+++ b/scipy/integrate/quadpack/dqk15w.f
@@ -1,4 +1,4 @@
-      subroutine dqk15w(f,w,p1,p2,p3,p4,kp,a,b,result,abserr,
+      recursive subroutine dqk15w(f,w,p1,p2,p3,p4,kp,a,b,result,abserr,
      *   resabs,resasc)
 c***begin prologue  dqk15w
 c***date written   810101   (yymmdd)

--- a/scipy/integrate/quadpack/dqk21.f
+++ b/scipy/integrate/quadpack/dqk21.f
@@ -1,4 +1,4 @@
-      subroutine dqk21(f,a,b,result,abserr,resabs,resasc)
+      recursive subroutine dqk21(f,a,b,result,abserr,resabs,resasc)
 c***begin prologue  dqk21
 c***date written   800101   (yymmdd)
 c***revision date  830518   (yymmdd)

--- a/scipy/integrate/quadpack/dqk31.f
+++ b/scipy/integrate/quadpack/dqk31.f
@@ -1,4 +1,4 @@
-      subroutine dqk31(f,a,b,result,abserr,resabs,resasc)
+      recursive subroutine dqk31(f,a,b,result,abserr,resabs,resasc)
 c***begin prologue  dqk31
 c***date written   800101   (yymmdd)
 c***revision date  830518   (yymmdd)

--- a/scipy/integrate/quadpack/dqk41.f
+++ b/scipy/integrate/quadpack/dqk41.f
@@ -1,4 +1,4 @@
-      subroutine dqk41(f,a,b,result,abserr,resabs,resasc)
+      recursive subroutine dqk41(f,a,b,result,abserr,resabs,resasc)
 c***begin prologue  dqk41
 c***date written   800101   (yymmdd)
 c***revision date  830518   (yymmdd)

--- a/scipy/integrate/quadpack/dqk51.f
+++ b/scipy/integrate/quadpack/dqk51.f
@@ -1,4 +1,4 @@
-      subroutine dqk51(f,a,b,result,abserr,resabs,resasc)
+      recursive subroutine dqk51(f,a,b,result,abserr,resabs,resasc)
 c***begin prologue  dqk51
 c***date written   800101   (yymmdd)
 c***revision date  830518   (yymmdd)

--- a/scipy/integrate/quadpack/dqk61.f
+++ b/scipy/integrate/quadpack/dqk61.f
@@ -1,4 +1,4 @@
-      subroutine dqk61(f,a,b,result,abserr,resabs,resasc)
+      recursive subroutine dqk61(f,a,b,result,abserr,resabs,resasc)
 c***begin prologue  dqk61
 c***date written   800101   (yymmdd)
 c***revision date  830518   (yymmdd)

--- a/scipy/integrate/quadpack/dqmomo.f
+++ b/scipy/integrate/quadpack/dqmomo.f
@@ -1,4 +1,4 @@
-      subroutine dqmomo(alfa,beta,ri,rj,rg,rh,integr)
+      recursive subroutine dqmomo(alfa,beta,ri,rj,rg,rh,integr)
 c***begin prologue  dqmomo
 c***date written   820101   (yymmdd)
 c***revision date  830518   (yymmdd)

--- a/scipy/integrate/quadpack/dqng.f
+++ b/scipy/integrate/quadpack/dqng.f
@@ -1,4 +1,5 @@
-      subroutine dqng(f,a,b,epsabs,epsrel,result,abserr,neval,ier)
+      recursive subroutine dqng(f,a,b,epsabs,epsrel,result,abserr,
+     *   neval,ier)
 c***begin prologue  dqng
 c***date written   800101   (yymmdd)
 c***revision date  810101   (yymmdd)

--- a/scipy/integrate/quadpack/dqpsrt.f
+++ b/scipy/integrate/quadpack/dqpsrt.f
@@ -1,4 +1,5 @@
-      subroutine dqpsrt(limit,last,maxerr,ermax,elist,iord,nrmax)
+      recursive subroutine dqpsrt(limit,last,maxerr,ermax,elist,iord,
+     *   nrmax)
 c***begin prologue  dqpsrt
 c***refer to  dqage,dqagie,dqagpe,dqawse
 c***routines called  (none)


### PR DESCRIPTION

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

gh-6882

#### What does this implement/fix?
<!--Please explain your changes.-->

Mark QUADPACK subroutines as `recursive`, per https://github.com/scipy/scipy/issues/6882#issuecomment-279760420

#### Additional information
<!--Any additional information you think is important.-->

Cannot properly test with it `ifort`. So far our test suite can only check that this patch does not break the usual build.