### PR TITLE
BUG: Fix yeojohnson when transformed data has zero variance

### DIFF
--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1583,7 +1583,7 @@ def yeojohnson_llf(lmb, data):
     loglike = np.empty_like(trans_var)
 
     # Avoid RuntimeWarning raised by np.log when the variance is too low
-    tiny_variance = trans_var < np.finfo(trans_var).tiny
+    tiny_variance = trans_var < np.finfo(trans_var.dtype).tiny
     loglike[tiny_variance] = np.inf
 
     loglike[~tiny_variance] = (

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -18,7 +18,6 @@ from . import _statlib
 from . import _stats_py
 from ._stats_py import find_repeats, _contains_nan, _normtest_finish
 from .contingency import chi2_contingency
-from ._constants import _XMIN
 from . import distributions
 from ._distn_infrastructure import rv_generic
 from ._hypotests import _get_wilcoxon_distr
@@ -1584,7 +1583,7 @@ def yeojohnson_llf(lmb, data):
     loglike = np.empty_like(trans_var)
 
     # Avoid RuntimeWarning raised by np.log when the variance is too low
-    tiny_variance = trans_var < _XMIN
+    tiny_variance = trans_var < np.finfo(trans_var).tiny
     loglike[tiny_variance] = np.inf
 
     loglike[~tiny_variance] = (

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -2103,6 +2103,19 @@ class TestYeojohnson:
         assert_allclose(xt_int, xt_float, rtol=1e-7)
         assert_allclose(lmbda_int, lmbda_float, rtol=1e-7)
 
+    def test_input_high_variance(self):
+        # non-regression test for gh-10821
+        x = np.array([3251637.22, 620695.44, 11642969.00, 2223468.22,
+                      85307500.00, 16494389.89, 917215.88, 11642969.00,
+                      2145773.87, 4962000.00, 620695.44, 651234.50,
+                      1907876.71, 4053297.88, 3251637.22, 3259103.08,
+                      9547969.00, 20631286.23, 12807072.08, 2383819.84,
+                      90114500.00, 17209575.46, 12852969.00, 2414609.99,
+                      2170368.23])
+        xt_yeo, lam_yeo = stats.yeojohnson(x)
+        xt_box = stats.boxcox(x + 1, lmbda=lam_yeo)
+        assert_allclose(xt_yeo, xt_box)
+
 
 class TestYeojohnsonNormmax:
     def setup_method(self):

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -2113,8 +2113,9 @@ class TestYeojohnson:
                       90114500.00, 17209575.46, 12852969.00, 2414609.99,
                       2170368.23])
         xt_yeo, lam_yeo = stats.yeojohnson(x)
-        xt_box = stats.boxcox(x + 1, lmbda=lam_yeo)
-        assert_allclose(xt_yeo, xt_box)
+        xt_box, lam_box = stats.boxcox(x + 1)
+        assert_allclose(xt_yeo, xt_box, rtol=1e-6)
+        assert_allclose(lam_yeo, lam_box, rtol=1e-6)
 
 
 class TestYeojohnsonNormmax:


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes https://github.com/scipy/scipy/issues/10821

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR updates `yeojohnson_llf` to handle cases where the variance is zero in the transformed space. Note that `yeojohnson_llf` returns `_XMAX` when the variance is too low, because the formula is `-N/2 * log(variance)`. `_neg_llf` will consider those to be uninteresting by replacing the `_XMAX` with `-_XMAX`.

#### Additional information
The `np.errstate(over='ignore')` is used because `_neg_llf` will return `_XMAX` which causes an overflow in `optimize.brent`.