### PR TITLE
ENH: Improved documentation of parameters 'scaling' and 'mode' of signal.spectrogram()

### DIFF
--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -646,21 +646,33 @@ def spectrogram(x, fs=1.0, window=('tukey', .25), nperseg=None, noverlap=None,
         `False` return a two-sided spectrum. Defaults to `True`, but for
         complex data, a two-sided spectrum is always returned.
     scaling : { 'density', 'spectrum' }, optional
-        Selects between computing the power spectral density ('density')
-        where `Sxx` has units of V**2/Hz and computing the power
-        spectrum ('spectrum') where `Sxx` has units of V**2, if `x`
-        is measured in V and `fs` is measured in Hz. Defaults to
-        'density'.
+        Selects between normalizing the window to unit power (``'density'``) or
+        unit area (``'spectrum'``). See the `mode` parameter for more
+        information. Defaults to ``'density'``.
     axis : int, optional
         Axis along which the spectrogram is computed; the default is over
         the last axis (i.e. ``axis=-1``).
     mode : str, optional
-        Defines what kind of return values are expected. Options are
-        ['psd', 'complex', 'magnitude', 'angle', 'phase']. 'complex' is
-        equivalent to the output of `stft` with no padding or boundary
-        extension. 'magnitude' returns the absolute magnitude of the
-        STFT. 'angle' and 'phase' return the complex angle of the STFT,
-        with and without unwrapping, respectively.
+        This parameter defines how the output from the short-time Fourier
+        transform, i.e., calling `stft` with no padding or boundary extension,
+        is transformed. Assuming that `x` is measured in V and `fs` in Hertz
+        then return:
+
+        ``'psd'``:
+            The absolute square of the `stft`. The unit is V² if
+            ``scaling = 'spectrum'``. For ``scaling = 'density'`` each line
+            along the frequency can be interpreted as a power spectral
+            density and the unit is V²/Hz.
+        ``'complex'``:
+            The output of the `stft` is not transformed - the unit is V.
+        ``'magnitude'``:
+            The absolute value of the `stft` - the unit is V. When
+            ``scaling = 'magnitude'`` each frequency line can be interpreted
+            as a magnitude spectrum.
+        ``'angle'``:
+            Complex angle (without unwrapping) of the `stft` - the unit is rad.
+        ``'phase'``:
+            Complex angle (with unwrapping) of the `stft` - the unit is rad.
 
     Returns
     -------
@@ -674,6 +686,7 @@ def spectrogram(x, fs=1.0, window=('tukey', .25), nperseg=None, noverlap=None,
 
     See Also
     --------
+    stft: Compute the Short-time Fourier Transform (STFT)
     periodogram: Simple, optionally modified periodogram
     lombscargle: Lomb-Scargle periodogram for unevenly sampled data
     welch: Power spectral density by Welch's method.

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -659,10 +659,10 @@ def spectrogram(x, fs=1.0, window=('tukey', .25), nperseg=None, noverlap=None,
         then return:
 
         ``'psd'``:
-            The absolute square of the `stft`. The unit is V² if
+            The absolute square of the `stft`. The unit is V**2 if
             ``scaling = 'spectrum'``. For ``scaling = 'density'`` each line
             along the frequency can be interpreted as a power spectral
-            density and the unit is V²/Hz.
+            density and the unit is V**2/Hz.
         ``'complex'``:
             The output of the `stft` is not transformed - the unit is V.
         ``'magnitude'``:

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -607,7 +607,7 @@ def csd(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
 def spectrogram(x, fs=1.0, window=('tukey', .25), nperseg=None, noverlap=None,
                 nfft=None, detrend='constant', return_onesided=True,
                 scaling='density', axis=-1, mode='psd'):
-    """Compute a spectrogram with consecutive Fourier transforms.
+    r"""Compute a spectrogram with consecutive Fourier transforms.
 
     Spectrograms can be used as a way of visualizing the change of a
     nonstationary signal's frequency content over time.
@@ -695,13 +695,51 @@ def spectrogram(x, fs=1.0, window=('tukey', .25), nperseg=None, noverlap=None,
 
     Notes
     -----
+    The spectrogram can be interpreted as a wrapper of the short-time
+    Fourier Transform (`stft`). The `stft` is more flexible in specifying the
+    boundary behavior and always retuns complex values (``mode=complex``).
+    Common uses of spectrograms are investigations of the evolution of a
+    magnitude spectrum  (``mode='magnitude', scaling='magnitude'``) or of a
+    power spectral density (``mode='psd', scaling='density'``) over time.
+
     An appropriate amount of overlap will depend on the choice of window
-    and on your requirements. In contrast to welch's method, where the
+    and on your requirements. In contrast to Welch's method, where the
     entire data stream is averaged over, one may wish to use a smaller
     overlap (or perhaps none at all) when computing a spectrogram, to
     maintain some statistical independence between individual segments.
     It is for this reason that the default window is a Tukey window with
     1/8th of a window's length overlap at each end.
+
+    Not all combinations of the parameters `mode`, `scaling` and
+    `return_onesided` allow a straight-forward interpretation. As an example
+    a 10-second single cosine test signal with amplitude 10 V is investigated:
+    Its power is 50 V\ :sup:`2` (``sum(x**2)/len(x)``). The following table
+    shows how the maximum and the power of the spectrogram depend on the input
+    parameters:
+
+    .. code-block:: text
+
+        mode       scaling    return_onesided  max(S)    Power
+        =========  =========  ===============  ========  =====
+        psd        density         True        113.4      50
+        psd        density         False       56.7       50
+        psd        spectrum        True        50.0       22
+        psd        spectrum        False       25.0       22
+        complex    density         True        7.5+0.0j   94.7
+        complex    density         False       7.5+0.0j  378.8
+        complex    spectrum        True        5.0+0.0j   41.7
+        complex    spectrum        False       5.0+0.0j  167
+        magnitude  density         True        7.5        94.7
+        magnitude  density         False       7.5       378.8
+
+    The power was calculated from the middle frequency slice by
+    ``sum(S[:, k_m]) * df`` for ``scaling='psd'`` and by
+    ``sum(S[:, k_m])**2 * df`` for ``scaling='magnitude'``.
+    Here, `df` is the spacing between the frequency bins.
+    The entries where ``max(S)`` equals 5 allow to infer that the amplitude of
+    the cosine is 10. The ``mode='psd', scaling='density'`` show the true power
+    spectral density, since numerically integrating over a slice gives
+    50 V\ :sup:`2`.
 
     .. versionadded:: 0.16.0
 

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -647,8 +647,9 @@ def spectrogram(x, fs=1.0, window=('tukey', .25), nperseg=None, noverlap=None,
         complex data, a two-sided spectrum is always returned.
     scaling : { 'density', 'spectrum' }, optional
         Selects between normalizing the window to unit power (``'density'``) or
-        unit area (``'spectrum'``). See the `mode` parameter for more
-        information. Defaults to ``'density'``.
+        unit area (``'spectrum'``). Note that the parameter `mode` has to be
+        set to ``'psd', 'complex'`` or ``'magnitude'`` to have an effect.
+        Defaults to ``'density'``.
     axis : int, optional
         Axis along which the spectrogram is computed; the default is over
         the last axis (i.e. ``axis=-1``).

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -717,8 +717,10 @@ def spectrogram(x, fs=1.0, window=('tukey', .25), nperseg=None, noverlap=None,
     shows how the maximum and the power of the spectrogram depend on the input
     parameters:
 
-    .. code-block:: text
+    .. table::
+        :class: table-sm
 
+        =========  =========  ===============  ========  =====
         mode       scaling    return_onesided  max(S)    Power
         =========  =========  ===============  ========  =====
         psd        density         True        113.4      50
@@ -731,6 +733,7 @@ def spectrogram(x, fs=1.0, window=('tukey', .25), nperseg=None, noverlap=None,
         complex    spectrum        False       5.0+0.0j  167
         magnitude  density         True        7.5        94.7
         magnitude  density         False       7.5       378.8
+        =========  =========  ===============  ========  =====
 
     The power was calculated from the middle frequency slice by
     ``sum(S[:, k_m]) * df`` for ``scaling='psd'`` and by


### PR DESCRIPTION
This PR tries to improve the docstring of signal.spectrogram().

Closes #14903 

