### PR TITLE
DOC: Fix broken link and add python headers to contributing guide

### DIFF
--- a/doc/source/dev/contributor/building.rst
+++ b/doc/source/dev/contributor/building.rst
@@ -54,7 +54,7 @@ dependencies to build it on your system.
         install the remaining system-level dependencies, run::
 
           sudo apt install -y gcc g++ gfortran libopenblas-dev liblapack-dev pkg-config
-          sudo apt install -y python3-pip
+          sudo apt install -y python3-pip python3-dev
 
         Alternatively, you can do::
 

--- a/doc/source/dev/dev_quickstart.rst
+++ b/doc/source/dev/dev_quickstart.rst
@@ -68,10 +68,7 @@ Next, set up your development environment.
 
     .. tab:: pip+venv
 
-        .. _system-level: system-level
-        .. |system-level| replace:: **system-level dependencies** 
-
-        **With** |system-level|_ **installed**, execute
+        **With** :ref:`system-level dependencies <system-level>` **installed**, execute
         the following commands at the terminal from the base directory of your
         `SciPy <https://github.com/scipy/scipy>`_ clone:
 


### PR DESCRIPTION
#### What does this implement/fix?
After merging #15947 @ev-br pointed out that 
- the system-level dependencies link under the pip+venv tab was broken (and I found that the previous way this link was built is not recommended either - see [this page](https://docutils.sourceforge.io/FAQ.html#is-nested-inline-markup-possible) for context:
- the `python3-dev` package was missing from the Ubuntu/Debian system-level dependencies list.