### PR TITLE
Doc: fix arch linux building from source local dependencies instructions

### DIFF
--- a/doc/source/dev/contributor/building.rst
+++ b/doc/source/dev/contributor/building.rst
@@ -99,7 +99,7 @@ dependencies to build it on your system.
 
         To install SciPy build requirements, you can do::
 
-          sudo pacman -S gcc-fortran openblas lapack
+          sudo pacman -S gcc-fortran openblas
 
     All further work should proceed in a virtual environment. Popular options
     include the standard library ``venv`` module or a separate ``virtualenv``

--- a/doc/source/dev/contributor/building.rst
+++ b/doc/source/dev/contributor/building.rst
@@ -99,7 +99,7 @@ dependencies to build it on your system.
 
         To install SciPy build requirements, you can do::
 
-          sudo pacman -S gcc-gfortran python-devel openblas-devel lapack-devel
+          sudo pacman -S gcc-fortran openblas lapack
 
     All further work should proceed in a virtual environment. Popular options
     include the standard library ``venv`` module or a separate ``virtualenv``


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
The current instructions for build from source on arch are incorrect:
```
[jakeb@jake-vostro157510 scipy]$ sudo pacman -S gcc-gfortran python-devel openblas-devel lapack-devel
error: target not found: gcc-gfortran
error: target not found: python-devel
error: target not found: openblas-devel
error: target not found: lapack-devel
```
`gcc-gfortran` should be `gcc-fortran`
`python-devel` is not needed as arch comes with python header files
`openblas-devel` should be `openblas`
`lapack-devel` should be `lapack`
#### Additional information
<!--Any additional information you think is important.-->
