### PR TITLE
DOC: fix conda env name in quickstart guide [skip ci]

### DIFF
--- a/doc/source/dev/dev_quickstart.rst
+++ b/doc/source/dev/dev_quickstart.rst
@@ -61,7 +61,7 @@ Next, set up your development environment.
             # Create an environment with all development dependencies
             conda env create -f environment_meson.yml  # works with `mamba` too
             # Activate the environment
-            conda activate scipy-dev
+            conda activate scipy-meson
 
         Your command prompt now lists the name of your new environment, like so
         ``(scipy-dev)$``.


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
The quickstart instruction tell you to activate the conda environment `scipy-dev` however it is actually called `scipy-meson`.
#### Additional information
<!--Any additional information you think is important.-->
