### PR TITLE
BUG: Allow `spsolve_triangular` to work with matrices with zeros in the diagonal.

### DIFF
--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -631,6 +631,7 @@ def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False,
         # Get indices for i-th row.
         indptr_start = A.indptr[i]
         indptr_stop = A.indptr[i + 1]
+
         if lower:
             A_diagonal_index_row_i = indptr_stop - 1
             A_off_diagonal_indices_row_i = slice(indptr_start, indptr_stop - 1)
@@ -643,7 +644,7 @@ def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False,
                                   or A.indices[A_diagonal_index_row_i] < i):
             raise LinAlgError(
                 'A is singular: diagonal {} is zero.'.format(i))
-        if A.indices[A_diagonal_index_row_i] > i:
+        if not unit_diagonal and A.indices[A_diagonal_index_row_i] > i:
             raise LinAlgError(
                 'A is not triangular: A[{}, {}] is nonzero.'
                 ''.format(i, A.indices[A_diagonal_index_row_i]))

--- a/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
@@ -724,7 +724,8 @@ class TestSpsolveTriangular:
 
     def test_zero_diagonal(self):
         n = 5
-        A = np.random.randn(n, n)
+        rng = np.random.default_rng(43876432987)
+        A = rng.standard_normal((n, n))
         b = np.arange(n)
         A = scipy.sparse.tril(A, k=0, format='csr')
 

--- a/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
@@ -735,11 +735,11 @@ class TestSpsolveTriangular:
         assert_allclose(A.dot(x), b)
 
         # Regression test from gh-15199
-        l = np.array([[0, 0, 0], [1, 0, 0], [1, 1, 0]], dtype=np.float64)
+        A = np.array([[0, 0, 0], [1, 0, 0], [1, 1, 0]], dtype=np.float64)
         b = np.array([1., 2., 3.])
         with suppress_warnings() as sup:
             sup.filter(SparseEfficiencyWarning, "CSR matrix format is")
-            spsolve_triangular(l, b, unit_diagonal=True)
+            spsolve_triangular(A, b, unit_diagonal=True)
 
     def test_singular(self):
         n = 5

--- a/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
@@ -734,6 +734,13 @@ class TestSpsolveTriangular:
         A.setdiag(1)
         assert_allclose(A.dot(x), b)
 
+        # Regression test from gh-15199
+        l = np.array([[0, 0, 0], [1, 0, 0], [1, 1, 0]], dtype=np.float64)
+        b = np.array([1., 2., 3.])
+        with suppress_warnings() as sup:
+            sup.filter(SparseEfficiencyWarning, "CSR matrix format is")
+            spsolve_triangular(l, b, unit_diagonal=True)
+
     def test_singular(self):
         n = 5
         A = csr_matrix((n, n))

--- a/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
@@ -731,7 +731,7 @@ class TestSpsolveTriangular:
         x = spsolve_triangular(A, b, unit_diagonal=True, lower=True)
 
         A.setdiag(1)
-        assert_array_almost_equal(A.dot(x), b)
+        assert_allclose(A.dot(x), b)
 
     def test_singular(self):
         n = 5

--- a/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
@@ -722,6 +722,17 @@ class TestSpsolveTriangular:
     def setup_method(self):
         use_solver(useUmfpack=False)
 
+    def test_zero_diagonal(self):
+        n = 5
+        A = np.random.randn(n, n)
+        b = np.arange(n)
+        A = scipy.sparse.tril(A, k=0, format='csr')
+
+        x = spsolve_triangular(A, b, unit_diagonal=True, lower=True)
+
+        A.setdiag(1)
+        assert_array_almost_equal(A.dot(x), b)
+
     def test_singular(self):
         n = 5
         A = csr_matrix((n, n))


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes https://github.com/scipy/scipy/issues/15199

#### What does this implement/fix?

Fixes `spsolve_triangular` to work with matrices that have zeros in the diagonals when specifying `unit_diagonal=True`.
