### PR TITLE
MAINT: stats: more accurate error message for `multivariate_normal`

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -692,7 +692,7 @@ class multivariate_normal_frozen(multi_rv_frozen):
         mean : array_like, default: ``[0]``
             Mean of the distribution.
         cov : array_like, default: ``[1]``
-            Symmetric positive semidefinite covariance matrix of the
+            Symmetric positive (semi)definite covariance matrix of the
             distribution.
         allow_singular : bool, default: ``False``
             Whether to allow a singular covariance matrix.

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -163,7 +163,7 @@ class _PSD:
         d = s[s > eps]
         if len(d) < len(s) and not allow_singular:
             msg = ("When `allow_singular is False`, the input matrix must be "
-                  "symmetric positive definite.")
+                   "symmetric positive definite.")
             raise np.linalg.LinAlgError(msg)
         s_pinv = _pinv_1d(s, eps)
         U = np.multiply(u, np.sqrt(s_pinv))
@@ -232,12 +232,12 @@ class multi_rv_frozen:
 
 
 _mvn_doc_default_callparams = """\
-mean : array_like, optional
-    Mean of the distribution (default zero)
-cov : array_like, optional
-    Covariance matrix of the distribution (default one)
-allow_singular : bool, optional
-    Whether to allow a singular covariance matrix.  (Default: False)
+mean : array_like, default: ``[0]``
+    Mean of the distribution.
+cov : array_like, default: ``[1]``
+    Symmetric positive semidefinite covariance matrix of the distribution.
+allow_singular : bool, default: ``False``
+    Whether to allow a singular covariance matrix.
 """
 
 _mvn_doc_callparams_note = """\
@@ -689,13 +689,13 @@ class multivariate_normal_frozen(multi_rv_frozen):
 
         Parameters
         ----------
-        mean : array_like, optional
-            Mean of the distribution (default zero)
-        cov : array_like, optional
-            Covariance matrix of the distribution (default one)
-        allow_singular : bool, optional
-            If this flag is True then tolerate a singular
-            covariance matrix (default False).
+        mean : array_like, default: ``[0]``
+            Mean of the distribution.
+        cov : array_like, default: ``[1]``
+            Symmetric positive semidefinite covariance matrix of the
+            distribution.
+        allow_singular : bool, default: ``False``
+            Whether to allow a singular covariance matrix.
         seed : {None, int, `numpy.random.Generator`,
                 `numpy.random.RandomState`}, optional
 

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -296,8 +296,11 @@ class multivariate_normal_gen(multi_rv_generic):
     -----
     %(_mvn_doc_callparams_note)s
 
-    The covariance matrix `cov` must be a (symmetric) positive
-    semi-definite matrix. The determinant and inverse of `cov` are computed
+    The covariance matrix `cov` must be a symmetric positive semidefinite
+    matrix when `allow_singular` is True; it must be (strictly) positive
+    definite when `allow_singular` is False.
+    Symmetry is not checked; only the lower triangular portion is used.
+    The determinant and inverse of `cov` are computed
     as the pseudo-determinant and pseudo-inverse, respectively, so
     that `cov` does not need to have full rank.
 

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -158,10 +158,13 @@ class _PSD:
 
         eps = _eigvalsh_to_eps(s, cond, rcond)
         if np.min(s) < -eps:
-            raise ValueError('the input matrix must be positive semidefinite')
+            msg = "The input matrix must be symmetric positive semidefinite."
+            raise ValueError(msg)
         d = s[s > eps]
         if len(d) < len(s) and not allow_singular:
-            raise np.linalg.LinAlgError('singular matrix')
+            msg = ("When `allow_singular is False`, the input matrix must be "
+                  "symmetric positive definite.")
+            raise np.linalg.LinAlgError(msg)
         s_pinv = _pinv_1d(s, eps)
         U = np.multiply(u, np.sqrt(s_pinv))
 

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -235,7 +235,7 @@ _mvn_doc_default_callparams = """\
 mean : array_like, default: ``[0]``
     Mean of the distribution.
 cov : array_like, default: ``[1]``
-    Symmetric positive semidefinite covariance matrix of the distribution.
+    Symmetric positive (semi)definite covariance matrix of the distribution.
 allow_singular : bool, default: ``False``
     Whether to allow a singular covariance matrix.
 """

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -325,6 +325,13 @@ class TestMultivariateNormal:
         assert_raises(e, multivariate_normal.cdf, x, mean, cov)
         assert_raises(e, multivariate_normal.logcdf, x, mean, cov)
 
+        # Message used to be "singular matrix", but this is more accurate.
+        # See gh-15508
+        cov = [[1., 0.], [1., 1.]]
+        msg = "When `allow_singular is False`, the input matrix"
+        with pytest.raises(np.linalg.LinAlgError, match=msg):
+            multivariate_normal(cov=cov)
+
     def test_R_values(self):
         # Compare the multivariate pdf with some values precomputed
         # in R version 3.0.1 (2013-05-16) on Mac OS X 10.6.


### PR DESCRIPTION
#### Reference issue
Closes gh-15508

#### What does this implement/fix?
gh-15508 reported that `multivariate_normal` reported the error `singular matrix` with an input that was not singular. This PR makes the error message more accurate and adds notes to the documentation to explain that symmetry of the matrix is assumed. (gh-15579 explored checking for symmetry, but participants decided against adding the check.)
