### PR TITLE
FIX: show warning when passing NAN into input of convolve method

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -1338,6 +1338,13 @@ def convolve(in1, in2, mode='full', method='auto'):
         An N-dimensional array containing a subset of the discrete linear
         convolution of `in1` with `in2`.
 
+    Warns
+    -----
+    RuntimeWarning
+        Use of the FFT convolution on input containing NAN or INF will lead
+        to the entire output being NAN or INF. Use method='direct' when your
+        input contains NAN or INF values.
+
     See Also
     --------
     numpy.polymul : performs polynomial multiplication (same operation, but
@@ -1402,6 +1409,13 @@ def convolve(in1, in2, mode='full', method='auto'):
         result_type = np.result_type(volume, kernel)
         if result_type.kind in {'u', 'i'}:
             out = np.around(out)
+
+        if np.isnan(out.flat[0]) or np.isinf(out.flat[0]):
+            warnings.warn("Use of fft convolution on input with NAN or inf"
+                          " results in NAN or inf output. Consider using"
+                          " method='direct' instead.",
+                          category=RuntimeWarning, stacklevel=2)
+
         return out.astype(result_type)
     elif method == 'direct':
         # fastpath to faster numpy.convolve for 1d inputs when possible

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -777,6 +777,17 @@ class TestFFTConvolve:
         out = fftconvolve(a, b, 'full', axes=[0])
         assert_allclose(out, expected, atol=1e-10)
 
+    def test_fft_nan(self):
+        n = 1000
+        rng = np.random.default_rng(43876432987)
+        sig_nan = rng.standard_normal(n)
+
+        for val in [np.nan, np.inf]:
+            sig_nan[100] = val
+            coeffs = signal.firwin(200, 0.2)
+
+            with pytest.warns(RuntimeWarning, match="Use of fft convolution"):
+                signal.convolve(sig_nan, coeffs, mode='same', method='fft')
 
 def fftconvolve_err(*args, **kwargs):
     raise RuntimeError('Fell back to fftconvolve')


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Fix for : https://github.com/scipy/scipy/issues/15927

#### What does this implement/fix?
<!--Please explain your changes.-->

Throws a warning from the `convolve` function when using FFT convolution and NANs values are found in the output. This is done because FFT convolution forces the entire output to be NAN or INF if a single NAN or INF is found in the input arrays.
