### PR TITLE
ENH: Add creation functions for sparse arrays

### DIFF
--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -279,6 +279,9 @@ from ._arrays import (
     csr_array, csc_array, lil_array, dok_array, coo_array, dia_array, bsr_array
 )
 
+# An `array` namespace for sparse array creation functions
+from . import array
+
 # For backward compatibility with v0.19.
 from . import csgraph
 

--- a/scipy/sparse/array.py
+++ b/scipy/sparse/array.py
@@ -1,5 +1,5 @@
 """
-Scipy sparse arrays
+Sparse array creation functions e.g. `eye`, `diags`, etc.
 """
 
 from . import _construct

--- a/scipy/sparse/array.py
+++ b/scipy/sparse/array.py
@@ -1,0 +1,105 @@
+"""
+Scipy sparse arrays
+"""
+
+from . import _construct
+from ._arrays import (
+    bsr_array,
+    coo_array,
+    csc_array,
+    csr_array,
+    dia_array,
+    dok_array,
+    lil_array,
+    _matrix_doc_to_array,
+)
+
+__all__ = [
+    "block_diag",
+    "bmat",
+    "diags",
+    "eye",
+    "hstack",
+    "identity",
+    "kron",
+    "kronsum",
+    "random",
+    "spdiags",
+    "vstack",
+]
+
+
+# Map sparse format strings to the corresponding sparse array container
+_fmt_to_sparray = {
+    "bsr": bsr_array, "coo": coo_array, "csc": csc_array, "csr": csr_array,
+    "dia": dia_array, "dok": dok_array, "lil": lil_array,
+}
+
+
+def block_diag(mats, format=None, dtype=None):
+    M = _construct.block_diag(mats, format, dtype)
+    return _fmt_to_sparray[M.format](M)
+
+
+def bmat(blocks, format=None, dtype=None):
+    M = _construct.bmat(blocks, format, dtype)
+    return _fmt_to_sparray[M.format](M)
+
+
+def diags(diagonals, offsets=0, shape=None, format=None, dtype=None):
+    M = _construct.diags(diagonals, offsets, shape, format, dtype)
+    return _fmt_to_sparray[M.format](M)
+
+
+def eye(m, n=None, k=0, dtype=float, format=None):
+    M = _construct.eye(m, n, k, dtype, format)
+    return _fmt_to_sparray[M.format](M)
+
+
+def hstack(blocks, format=None, dtype=None):
+    M = _construct.hstack(blocks, format, dtype)
+    return _fmt_to_sparray[M.format](M)
+
+
+def identity(n, dtype='d', format=None):
+    M = _construct.identity(n, dtype, format)
+    return _fmt_to_sparray[M.format](M)
+
+
+def kron(A, B, format=None):
+    M = _construct.kron(A, B, format)
+    return _fmt_to_sparray[M.format](M)
+
+
+def kronsum(A, B, format=None):
+    M = _construct.kronsum(A, B, format)
+    return _fmt_to_sparray[M.format](M)
+
+
+def random(m, n, density=0.01, format='coo', dtype=None, random_state=None,
+           data_rvs=None):
+    M = _construct.random(m, n, density, format, dtype, random_state, data_rvs)
+    return _fmt_to_sparray[M.format](M)
+
+
+def spdiags(data, diags, m, n, format=None):
+    M = _construct.spdiags(data, diags, m, n, format)
+    return _fmt_to_sparray[M.format](M)
+
+
+def vstack(blocks, format=None, dtype=None):
+    M = _construct.vstack(blocks, format, dtype)
+    return _fmt_to_sparray[M.format](M)
+
+
+block_diag.__doc__ = _matrix_doc_to_array(_construct.block_diag.__doc__)
+bmat.__doc__ = _matrix_doc_to_array(_construct.bmat.__doc__)
+diags.__doc__ = _matrix_doc_to_array(_construct.diags.__doc__)
+eye.__doc__ = _matrix_doc_to_array(_construct.eye.__doc__)
+hstack.__doc__ = _matrix_doc_to_array(_construct.hstack.__doc__)
+identity.__doc__ = _matrix_doc_to_array(_construct.identity.__doc__)
+kron.__doc__ = _matrix_doc_to_array(_construct.kron.__doc__)
+kronsum.__doc__ = _matrix_doc_to_array(_construct.kronsum.__doc__)
+random.__doc__ = _matrix_doc_to_array(_construct.random.__doc__)
+spdiags.__doc__ = _matrix_doc_to_array(_construct.spdiags.__doc__)
+vstack.__doc__ = _matrix_doc_to_array(_construct.vstack.__doc__)

--- a/scipy/sparse/array.py
+++ b/scipy/sparse/array.py
@@ -29,6 +29,10 @@ __all__ = [
 ]
 
 
+def __dir__():
+    return __all__
+
+
 # Map sparse format strings to the corresponding sparse array container
 _fmt_to_sparray = {
     "bsr": bsr_array, "coo": coo_array, "csc": csc_array, "csr": csr_array,

--- a/scipy/sparse/tests/test_array_creation.py
+++ b/scipy/sparse/tests/test_array_creation.py
@@ -1,6 +1,7 @@
 import pytest
 
-from .. import _construct, array, coo_matrix
+from .. import _construct, array, coo_matrix, _arrays
+
 
 np = pytest.importorskip("numpy")
 
@@ -24,7 +25,9 @@ def test_default_container_format(fn, args):
     """Default container format for array creation functions should be the same
     as their matrix counterparts."""
     ary_fn, mat_fn = (getattr(mod, fn) for mod in (array, _construct))
-    assert ary_fn(*args).format == mat_fn(*args).format
+    a = ary_fn(*args)
+    assert isinstance(a, _arrays._sparray)
+    assert a.format == mat_fn(*args).format
 
 
 @pytest.mark.parametrize("fn", ("hstack", "vstack"))
@@ -35,7 +38,9 @@ def test_stacks_default_container_format(fn):
     B = coo_matrix([[0, 1], [1, 0]])
 
     ary_fn, mat_fn = (getattr(mod, fn) for mod in (array, _construct))
-    assert ary_fn([A, B]).format == mat_fn([A, B]).format
+    a = ary_fn([A, B])
+    assert isinstance(a, _arrays._sparray)
+    assert a.format == mat_fn([A, B]).format
 
 
 def test_blocks_default_container_format():
@@ -48,9 +53,11 @@ def test_blocks_default_container_format():
     # block diag
     a = array.block_diag((A, B, C))
     m = _construct.block_diag((A, B, C))
+    assert isinstance(a, _arrays._sparray)
     assert a.format == m.format
 
     # bmat
     a = array.bmat([[A, None], [None, C]])
     m = _construct.bmat([[A, None], [None, C]])
+    assert isinstance(a, _arrays._sparray)
     assert a.format == m.format

--- a/scipy/sparse/tests/test_array_creation.py
+++ b/scipy/sparse/tests/test_array_creation.py
@@ -1,0 +1,56 @@
+import pytest
+
+from .. import _construct, array, coo_matrix
+
+np = pytest.importorskip("numpy")
+
+
+@pytest.mark.parametrize(
+    ("fn", "args"),
+    [
+        ("diags", ([0, 1, 2],)),
+        ("eye", (3,)),
+        ("spdiags", ([1, 2, 3], 0, 3, 3)),
+        ("identity", (3,)),
+        # kron with dense B
+        ("kron", (np.array([[1, 2], [3, 4]]), np.array([[4, 3], [2, 1]]))),
+        # kron with sparse B
+        ("kron", (np.array([[1, 2], [3, 4]]), np.array([[1, 0], [0, 0]]))),
+        ("kronsum", (np.array([[1, 0], [0, 1]]), np.array([[0, 1], [1, 0]]))),
+        ("random", (3, 3)),
+    ],
+)
+def test_default_container_format(fn, args):
+    """Default container format for array creation functions should be the same
+    as their matrix counterparts."""
+    ary_fn, mat_fn = (getattr(mod, fn) for mod in (array, _construct))
+    assert ary_fn(*args).format == mat_fn(*args).format
+
+
+@pytest.mark.parametrize("fn", ("hstack", "vstack"))
+def test_stacks_default_container_format(fn):
+    """Same idea as `test_default_container_format`, but for the stacking
+    creation functions."""
+    A = coo_matrix(np.eye(2))
+    B = coo_matrix([[0, 1], [1, 0]])
+
+    ary_fn, mat_fn = (getattr(mod, fn) for mod in (array, _construct))
+    assert ary_fn([A, B]).format == mat_fn([A, B]).format
+
+
+def test_blocks_default_container_format():
+    """Same idea as `test_default_container_format`, but for the block
+    block creation funtions."""
+    A = coo_matrix(np.eye(2))
+    B = coo_matrix([[2], [0]])
+    C = coo_matrix([[3]])
+
+    # block diag
+    a = array.block_diag((A, B, C))
+    m = _construct.block_diag((A, B, C))
+    assert a.format == m.format
+
+    # bmat
+    a = array.bmat([[A, None], [None, C]])
+    m = _construct.bmat([[A, None], [None, C]])
+    assert a.format == m.format

--- a/scipy/sparse/tests/test_array_creation.py
+++ b/scipy/sparse/tests/test_array_creation.py
@@ -1,9 +1,7 @@
 import pytest
+import numpy as np
 
 from .. import _construct, array, coo_matrix, _arrays
-
-
-np = pytest.importorskip("numpy")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Adds a version of the sparse creation functions that create sparse arrays instead of matrices. Currently, if a user wants to create a sparse array object with one of the typical creation functions in `scipy.sparse`, they have to manually convert the result of the existing creation function, which returns a matrix. For example:

```python
>>> import scipy as sp
>>> sp.sparse.csr_array(sp.sparse.diags(np.arange(10)))
<10x10 sparse array of type '<class 'numpy.float64'>'
        with 9 stored elements in Compressed Sparse Row format>
```

Having "array versions" of the creation functions can help users work with/adopt the sparse array interface without having to do the explicit wrapping as above.

Re: organization - I've decide to go with adding an (intentionally) public `array` namespace within scipy.sparse. I'm certainly open to other ideas though.

In terms of implementation I tried to go with the simplest approach I could think of. Again, very open to suggestions for perhaps a more elegant approach to the wrapping with less repetition. My hope is that the approach is immediately grokable!

Finally, re: tests - the only tests I've added to start are those that a) check that the results are indeed sparse arrays, and check that the default format is consistent with the corresponding matrix creation function. Additional testing ideas very much welcome!