### PR TITLE
DOC: Improve misleading documentation for `ttest_ind_from_stats`

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -5901,14 +5901,14 @@ def ttest_ind_from_stats(mean1, std1, nobs1, mean2, std2, nobs2,
         The mean(s) of sample 1.
     std1 : array_like
         The unbiased estimate of the standard deviation(s) of sample 1 (i.e.
-        `ddof=1`).
+        ``ddof=1``).
     nobs1 : array_like
         The number(s) of observations of sample 1.
     mean2 : array_like
         The mean(s) of sample 2.
     std2 : array_like
         The unbiased estimate of the standard deviations(s) of sample 2 (i.e.
-        `ddof=1`).
+        ``ddof=1``).
     nobs2 : array_like
         The number(s) of observations of sample 2.
     equal_var : bool, optional
@@ -5954,7 +5954,7 @@ def ttest_ind_from_stats(mean1, std1, nobs1, mean2, std2, nobs2,
     Examples
     --------
     Suppose we have the summary data for two samples, as follows (with the
-    Samples Variance being the unbiased estimate)::
+    Sample Variance being the unbiased estimate)::
 
                          Sample   Sample
                    Size   Mean   Variance

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -5952,7 +5952,7 @@ def ttest_ind_from_stats(mean1, std1, nobs1, mean2, std2, nobs2,
     Examples
     --------
     Suppose we have the summary data for two samples, as follows (with the
-    Sample Variance being the corrected variance calculated from each sample)::
+    Sample Variance being the corrected sample variance)::
 
                          Sample   Sample
                    Size   Mean   Variance

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -5900,13 +5900,15 @@ def ttest_ind_from_stats(mean1, std1, nobs1, mean2, std2, nobs2,
     mean1 : array_like
         The mean(s) of sample 1.
     std1 : array_like
-        The standard deviation(s) of sample 1.
+        The unbiased estimate of the standard deviation(s) of sample 1 (i.e.
+        `ddof=1`).
     nobs1 : array_like
         The number(s) of observations of sample 1.
     mean2 : array_like
         The mean(s) of sample 2.
     std2 : array_like
-        The standard deviations(s) of sample 2.
+        The unbiased estimate of the standard deviations(s) of sample 2 (i.e.
+        `ddof=1`).
     nobs2 : array_like
         The number(s) of observations of sample 2.
     equal_var : bool, optional
@@ -5951,7 +5953,8 @@ def ttest_ind_from_stats(mean1, std1, nobs1, mean2, std2, nobs2,
 
     Examples
     --------
-    Suppose we have the summary data for two samples, as follows::
+    Suppose we have the summary data for two samples, as follows (with the
+    Samples Variance being the unbiased estimate)::
 
                          Sample   Sample
                    Size   Mean   Variance

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -5900,15 +5900,13 @@ def ttest_ind_from_stats(mean1, std1, nobs1, mean2, std2, nobs2,
     mean1 : array_like
         The mean(s) of sample 1.
     std1 : array_like
-        The unbiased estimate of the standard deviation(s) of sample 1 (i.e.
-        ``ddof=1``).
+        The corrected sample standard deviation of sample 1 (i.e. ``ddof=1``).
     nobs1 : array_like
         The number(s) of observations of sample 1.
     mean2 : array_like
         The mean(s) of sample 2.
     std2 : array_like
-        The unbiased estimate of the standard deviations(s) of sample 2 (i.e.
-        ``ddof=1``).
+        The corrected sample standard deviation of sample 2 (i.e. ``ddof=1``).
     nobs2 : array_like
         The number(s) of observations of sample 2.
     equal_var : bool, optional
@@ -5954,7 +5952,7 @@ def ttest_ind_from_stats(mean1, std1, nobs1, mean2, std2, nobs2,
     Examples
     --------
     Suppose we have the summary data for two samples, as follows (with the
-    Sample Variance being the unbiased estimate)::
+    Sample Variance being the corrected variance calculated from each sample)::
 
                          Sample   Sample
                    Size   Mean   Variance


### PR DESCRIPTION
Clarified that the standard deviation parameters should be the unbiased estimates, in both the `Parameters` and `Examples` section.

Closes #16007