### PR TITLE
BUG: allow scalar input to the `.dot` method of sparse matrices

### DIFF
--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -410,7 +410,10 @@ class spmatrix:
         array([ 1, -3, -1], dtype=int64)
 
         """
-        return self @ other
+        if np.isscalar(other):
+            return self * other
+        else:
+            return self @ other
 
     def power(self, n, dtype=None):
         """Element-wise power."""

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1629,6 +1629,14 @@ class _TestCommon:
         assert_equal(eval('A @ B'), "matrix on the left")
         assert_equal(eval('B @ A'), "matrix on the right")
 
+    def test_dot_scalar(self):
+        M = self.spmatrix(array([[3,0,0],[0,1,0],[2,0,3.0],[2,3,0]]))
+        scalar = 10
+        actual = M.dot(scalar)
+        expected = M * scalar
+
+        assert_allclose(actual.toarray(), expected.toarray())
+
     def test_matmul(self):
         M = self.spmatrix(array([[3,0,0],[0,1,0],[2,0,3.0],[2,3,0]]))
         B = self.spmatrix(array([[0,1],[1,0],[0,2]],'d'))
@@ -3620,7 +3628,7 @@ class TestCSR(sparse_test_class()):
         ij = vstack((row,col))
         csr = csr_matrix((data,ij),(4,3))
         assert_array_equal(arange(12).reshape(4, 3), csr.toarray())
-        
+
         # using Python lists and a specified dtype
         csr = csr_matrix(([2**63 + 1, 1], ([0, 1], [0, 1])), dtype=np.uint64)
         dense = array([[2**63 + 1, 0], [0, 1]], dtype=np.uint64)


### PR DESCRIPTION


<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Fix for https://github.com/scipy/scipy/issues/15258.

#### What does this implement/fix?
<!--Please explain your changes.-->

The new array interface for sparse matrices (https://github.com/scipy/scipy/pull/14822) disallowed using scalars in the `dot()` method. This patch reintroduces this functionality so that scipy sparse matrices provide similar interfaces as those provided by numpy.
