### PR TITLE
MAINT: fix missing `f` prefix on f-strings

### DIFF
--- a/benchmarks/benchmarks/stats_sampling.py
+++ b/benchmarks/benchmarks/stats_sampling.py
@@ -182,7 +182,7 @@ class SimpleRatioUniforms(Benchmark):
                 random_state=self.urng
             )
         except sampling.UNURANError:
-            raise NotImplementedError("{dist} not T-concave")
+            raise NotImplementedError(f"{dist} not T-concave")
 
     def time_srou_setup(self, dist, cdf_at_mode):
         if cdf_at_mode:

--- a/scipy/sparse/csgraph/_laplacian.py
+++ b/scipy/sparse/csgraph/_laplacian.py
@@ -523,7 +523,7 @@ def _laplacian_dense_flo(graph, normed, axis, copy, form, dtype, symmetrized):
 def _laplacian_dense(graph, normed, axis, copy, form, dtype, symmetrized):
 
     if form != "array":
-        raise ValueError('{form!r} must be "array"')
+        raise ValueError(f'{form!r} must be "array"')
 
     if dtype is None:
         dtype = graph.dtype


### PR DESCRIPTION
#### Reference issue
Closes gh-16036

#### What does this implement/fix?
Adds missing `f` prefix on f-strings