### PR TITLE
DOC: fix example code values for ttest_ind_from_stats

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -5989,9 +5989,9 @@ def ttest_ind_from_stats(mean1, std1, nobs1, mean2, std2, nobs2,
     and the variance for a binary observation is estimated by
     :math:`\hat{p}(1-\hat{p})`.
 
-    >>> ttest_ind_from_stats(mean1=0.2, std1=np.sqrt(0.16), nobs1=150,
-    ...                      mean2=0.225, std2=np.sqrt(0.17437), nobs2=200)
-    Ttest_indResult(statistic=-0.564327545549774, pvalue=0.5728947691244874)
+    >>> ttest_ind_from_stats(mean1=0.2, std1=np.sqrt(0.161073), nobs1=150,
+    ...                      mean2=0.225, std2=np.sqrt(0.175251), nobs2=200)
+    Ttest_indResult(statistic=-0.5627187905196761, pvalue=0.5739887114209541)
 
     For comparison, we could compute the t statistic and p-value using
     arrays of 0s and 1s and `scipy.stat.ttest_ind`, as above.


### PR DESCRIPTION
Fix the values used for the standard deviation in the example code for `ttest_ind_from_stats` after the changes in feb8c663c1cadfa020835ac3fbb4bcf596c85e7e, and the result as well @mdhaber.

Fixes #16007 