### PR TITLE
MAINT: add include dir explicitly for PROPACK to build with classic flang

### DIFF
--- a/scipy/sparse/linalg/_propack/setup.py
+++ b/scipy/sparse/linalg/_propack/setup.py
@@ -45,10 +45,9 @@ def configuration(parent_package='', top_path=None):
 
     for prefix, directory in type_dict.items():
         propack_lib = f'_{prefix}propack'
-
         # Use risc msg implementation for 64-bit machines, pentium for 32-bit
-        src = list((pathlib.Path(
-            __file__).parent / 'PROPACK' / directory).glob('*.F'))
+        src_dir = pathlib.Path(__file__).parent / 'PROPACK' / directory
+        src = list(src_dir.glob('*.F'))
         if _is_32bit():
             # don't ask me why, 32-bit blows up without second.F
             src = [str(p) for p in src if 'risc' not in str(p)]
@@ -67,6 +66,7 @@ def configuration(parent_package='', top_path=None):
         config.add_library(propack_lib,
                            sources=src,
                            macros=cmacros,
+                           include_dirs=src_dir,
                            depends=['setup.py'])
         ext = config.add_extension(f'_{prefix}propack',
                                    sources=f'{prefix}propack.pyf',


### PR DESCRIPTION
#### What does this implement/fix?

This change adds a minor fix to build Scipy with [classic flang](https://github.com/flang-compiler/flang).

The main motivation behind the change is to enable Scipy for Windows on Arm64 platforms. Classic flang is the only viable FORTRAN compiler for Windows on Arm64 platforms now. LLVM's new flang and gfortran are not yet ported.

#### Additional information

Classic flang struggles to find included header `stat.h` without explicit include directory.

```
F90-S-0017-Unable to open include file: stat.h (.\scipy\sparse\linalg\_propack\PROPACK\single\slansvd.F: 98)
  0 inform,   0 warnings,   1 severes, 0 fatal for slansvd
```

I've used classic flang build from [here](https://github.com/kaadam/flang/releases/tag/v0.2)



