### PR TITLE
DOC: Describe FORTRAN routines used in quad

### DIFF
--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -284,19 +284,19 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
 
     **Details of QUADPACK level routines**
 
-    *quad* calls routines from the FORTRAN library QUADPACK. This section
+    `quad` calls routines from the FORTRAN library QUADPACK. This section
     provides details on the conditions for each routine to be called and a
     short description of each routine. The routine called depends on
-    ``weight``, ``points`` and the integration limits ``a`` and ``b``.
+    `weight`, `points` and the integration limits `a` and `b`.
 
     ================  ==============  ==========  =====================
-    QUADPACK routine  ``weight``      ``points``  infinite bounds
+    QUADPACK routine  `weight`        `points`    infinite bounds
     ================  ==============  ==========  =====================
     qagse             None            No          No
     qagie             None            No          Yes
     qagpe             None            Yes         No
     qawoe             'sin', 'cos'    No          No
-    qawfe             'sin', 'cos'    No          either ``a`` or ``b``
+    qawfe             'sin', 'cos'    No          either `a` or `b`
     qawse             'alg*'          No          No
     qawce             'cauchy'        No          No
     ================  ==============  ==========  =====================
@@ -336,9 +336,9 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
         :math:`\\int^\\infty_a \\cos(\\omega x)f(x)dx` or
         :math:`\\int^\\infty_a \\sin(\\omega x)f(x)dx`
         for user-provided :math:`\\omega` and :math:`f`. The procedure of QAWO
-        is applied on successive finite intervals, and convergence acceleration
-        by means of the :math:`\\varepsilon`-algorithm is applied to the series
-        of integral approximations.
+        is applied on successive finite intervals, and convergence
+        acceleration by means of the :math:`\\varepsilon`-algorithm is applied
+        to the series of integral approximations.
     qawse
         approximate :math:`\\int^b_a w(x)f(x)dx`, with :math:`a < b` where
         :math:`w(x) = (x-a)^{\\alpha}(b-x)^{\\beta}v(x)` with
@@ -349,7 +349,7 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
         The user specifies :math:`\\alpha`, :math:`\\beta` and the type of the
         function :math:`v`. A globally adaptive subdivision strategy is
         applied, with modified Clenshaw-Curtis integration on those
-        subintervals which contain a or b.
+        subintervals which contain `a` or `b`.
     qawce
         compute :math:`\\int^b_a f(x) / (x-c)dx` where the integral must be
         interpreted as a Cauchy principal value integral, for user specified
@@ -360,9 +360,11 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
     References
     ----------
 
-    .. [1] Piessens, Robert; de Doncker-Kapenga, Elise; Überhuber, Christoph W.;
-        Kahaner, David (1983). QUADPACK: A subroutine package for automatic
-        integration. Springer-Verlag. ISBN 978-3-540-12553-2.
+    .. [1] Piessens, Robert; de Doncker-Kapenga, Elise;
+           Überhuber, Christoph W.; Kahaner, David (1983).
+           QUADPACK: A subroutine package for automatic integration.
+           Springer-Verlag.
+           ISBN 978-3-540-12553-2.
 
     Examples
     --------

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -281,6 +281,89 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
         ``infodict['rslist']``.  See the explanation dictionary (last entry
         in the output tuple) for the meaning of the codes.
 
+
+    **Details of QUADPACK level routines**
+
+    *quad* calls routines from the FORTRAN library QUADPACK. This section
+    provides details on the conditions for each routine to be called and a
+    short description of each routine. The routine called depends on
+    ``weight``, ``points`` and the integration limits ``a`` and ``b``.
+
+    ================  ==============  ==========  =====================
+    QUADPACK routine  ``weight``      ``points``  infinite bounds
+    ================  ==============  ==========  =====================
+    qagse             None            No          No
+    qagie             None            No          Yes
+    qagpe             None            Yes         No
+    qawoe             'sin', 'cos'    No          No
+    qawfe             'sin', 'cos'    No          either ``a`` or ``b``
+    qawse             'alg*'          No          No
+    qawce             'cauchy'        No          No
+    ================  ==============  ==========  =====================
+
+    The following provides a short desciption from [1]_ for each
+    routine.
+
+    qagse
+        is an integrator based on globally adaptive interval
+        subdivision in connection with extrapolation, which will
+        eliminate the effects of integrand singularities of
+        several types.
+    qagie
+        handles integration over infinite intervals. The infinite range is
+        mapped onto a finite interval and subsequently the same strategy as
+        in QAGS is applied.
+    qagpe
+        serves the same purposes as QAGS, but also allows the
+        user to provide explicit information about the location
+        and type of trouble-spots i.e. the abscissae of internal
+        singularities, discontinuities and other difficulties of
+        the integrand function.
+    qawoe
+        is an integrator for the evaluation of
+        :math:`\\int^b_a \\cos(\\omega x)f(x)dx` or
+        :math:`\\int^b_a \\sin(\\omega x)f(x)dx`
+        over a finite interval [a,b], where :math:`\\omega` and :math:`f`
+        are specified by the user. The rule evaluation component is based
+        on the modified Clenshaw-Curtis technique
+
+        An adaptive subdivision scheme is used in connection
+        with an extrapolation procedure, which is a modification
+        of that in QAGS and allows the algorithm to deal with
+        singularities in :math:`f(x)`.
+    qawfe
+        calculates the Fourier transform
+        :math:`\\int^\\infty_a \\cos(\\omega x)f(x)dx` or
+        :math:`\\int^\\infty_a \\sin(\\omega x)f(x)dx`
+        for user-provided :math:`\\omega` and :math:`f`. The procedure of QAWO
+        is applied on successive finite intervals, and convergence acceleration
+        by means of the :math:`\\varepsilon`-algorithm is applied to the series
+        of integral approximations.
+    qawse
+        approximate :math:`\\int^b_a w(x)f(x)dx`, with :math:`a < b` where
+        :math:`w(x) = (x-a)^{\\alpha}(b-x)^{\\beta}v(x)` with
+        :math:`\\alpha,\\beta > -1`, where :math:`v(x)` may be one of the
+        following functions: :math:`1`, :math:`\\log(x-a)`, :math:`\\log(b-x)`,
+        :math:`\\log(x-a)\\log(b-x)`.
+
+        The user specifies :math:`\\alpha`, :math:`\\beta` and the type of the
+        function :math:`v`. A globally adaptive subdivision strategy is
+        applied, with modified Clenshaw-Curtis integration on those
+        subintervals which contain a or b.
+    qawce
+        compute :math:`\\int^b_a f(x) / (x-c)dx` where the integral must be
+        interpreted as a Cauchy principal value integral, for user specified
+        :math:`c` and :math:`f`. The strategy is globally adaptive. Modified
+        Clenshaw-Curtis integration is used on those intervals containing the
+        point :math:`x = c`.
+
+    References
+    ----------
+
+    .. [1] Piessens, Robert; de Doncker-Kapenga, Elise; Überhuber, Christoph W.;
+        Kahaner, David (1983). QUADPACK: A subroutine package for automatic
+        integration. Springer-Verlag. ISBN 978-3-540-12553-2.
+
     Examples
     --------
     Calculate :math:`\\int^4_0 x^2 dx` and compare with an analytic result

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -361,7 +361,7 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
     ----------
 
     .. [1] Piessens, Robert; de Doncker-Kapenga, Elise;
-           Überhuber, Christoph W.; Kahaner, David (1983).
+           Uberhuber, Christoph W.; Kahaner, David (1983).
            QUADPACK: A subroutine package for automatic integration.
            Springer-Verlag.
            ISBN 978-3-540-12553-2.


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
closes gh-13872

#### What does this implement/fix?
This PR adds documentation of the PROPACK level functions to `quad`. It currently adds two things. One is a table detailing under which conditions each function is called. The second is a description of the algorithms used. 

#### Additional information
<!--Any additional information you think is important.-->
This currently only applies to `quad` there are many more functions (`dblquad`, `tplquad`, etc.) that uses these functions but I wanted to start with one and get feedback on the implementation.