### PR TITLE
ENH: Use circleci-artifacts-redirector-action

### DIFF
--- a/.circleci/artifact_path
+++ b/.circleci/artifact_path
@@ -1,1 +1,0 @@
-0/html-scipyorg/index.html

--- a/.github/workflows/circle_artifacts.yml
+++ b/.github/workflows/circle_artifacts.yml
@@ -1,0 +1,13 @@
+on: [status]
+jobs:
+  circleci_artifacts_redirector_job:
+    runs-on: ubuntu-20.04
+    name: Run CircleCI artifacts redirector
+    steps:
+      - name: GitHub Action step
+        uses: larsoner/circleci-artifacts-redirector-action@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          artifact-path: 0/html-scipyorg/index.html
+          circleci-jobs: build_docs
+          job-title: Check the rendered docs here!


### PR DESCRIPTION
[circleci-artifacts-redirector](https://github.com/larsoner/circleci-artifacts-redirector) is deprecated and doesn't provide the correct artifacts links anymore because CircleCI changed how the create the links, so I just uninstalled it for the SciPy repo. This PR adds the newer project [circleci-artifacts-redirector-action](https://github.com/larsoner/circleci-artifacts-redirector-action), which has been updated to support the new CircleCI linking scheme. This is essentially the same config used in other repos like scikit-learn and it seems to be working:

https://github.com/scikit-learn/scikit-learn/blob/main/.github/workflows/artifact-redirector.yml

We can't really test it until it's merged with `main` because it works `[on status]`, so I've tagged this with `[ci skip]`. Feel free to merge and hopefully we'll see PRs start having correct artifacts links again!