### PR TITLE
ENH: sparse.linalg: Add the case where only a single side preconditioner is used and corresponding complete tests

### DIFF
--- a/scipy/sparse/linalg/_isolve/iterative.py
+++ b/scipy/sparse/linalg/_isolve/iterative.py
@@ -8,7 +8,7 @@ import numpy as np
 from . import _iterative
 
 from scipy.sparse.linalg._interface import LinearOperator
-from .utils import make_system
+from .utils import make_system, id
 from scipy._lib._util import _aligned_zeros
 from scipy._lib._threadsafety import non_reentrant
 
@@ -779,26 +779,54 @@ def qmr(A, b, x0=None, tol=1e-5, maxiter=None, M1=None, M2=None, callback=None,
     A_ = A
     A, M, x, b, postprocess = make_system(A, None, x0, b)
 
+    # Check and deal with the left and/or right preconditioner
+    def left_psolve(b):
+        return A_.psolve(b, 'left')
+
+    def right_psolve(b):
+        return A_.psolve(b, 'right')
+
+    def left_rpsolve(b):
+        return A_.rpsolve(b, 'left')
+
+    def right_rpsolve(b):
+        return A_.rpsolve(b, 'right')
+
     if M1 is None and M2 is None:
-        if hasattr(A_,'psolve'):
-            def left_psolve(b):
-                return A_.psolve(b,'left')
-
-            def right_psolve(b):
-                return A_.psolve(b,'right')
-
-            def left_rpsolve(b):
-                return A_.rpsolve(b,'left')
-
-            def right_rpsolve(b):
-                return A_.rpsolve(b,'right')
-            M1 = LinearOperator(A.shape, matvec=left_psolve, rmatvec=left_rpsolve)
-            M2 = LinearOperator(A.shape, matvec=right_psolve, rmatvec=right_rpsolve)
+        if hasattr(A_, 'psolve') and not hasattr(A_, 'rpsolve'):
+            M1 = LinearOperator(A.shape, matvec=left_psolve, rmatvec=id)
+            M2 = LinearOperator(A.shape, matvec=right_psolve, rmatvec=id)
+        elif not hasattr(A_, 'psolve') and hasattr(A_, 'rpsolve'):
+            M1 = LinearOperator(A.shape, matvec=id, rmatvec=left_rpsolve)
+            M2 = LinearOperator(A.shape, matvec=id, rmatvec=right_rpsolve)
+        elif hasattr(A_, 'psolve') and hasattr(A_, 'rpsolve'):
+            M1 = LinearOperator(A.shape,
+                                matvec=left_psolve, rmatvec=left_rpsolve)
+            M2 = LinearOperator(A.shape,
+                                matvec=right_psolve, rmatvec=right_rpsolve)
         else:
-            def id(b):
-                return b
             M1 = LinearOperator(A.shape, matvec=id, rmatvec=id)
             M2 = LinearOperator(A.shape, matvec=id, rmatvec=id)
+    elif M1 is not None and M2 is None:
+        if hasattr(A_, 'psolve') and not hasattr(A_, 'rpsolve'):
+            M2 = LinearOperator(A.shape, matvec=right_psolve, rmatvec=id)
+        elif not hasattr(A_, 'psolve') and hasattr(A_, 'rpsolve'):
+            M2 = LinearOperator(A.shape, matvec=id, rmatvec=right_rpsolve)
+        elif hasattr(A_, 'psolve') and hasattr(A_, 'rpsolve'):
+            M2 = LinearOperator(A.shape,
+                                matvec=right_psolve, rmatvec=right_rpsolve)
+        else:
+            M2 = LinearOperator(A.shape, matvec=id, rmatvec=id)
+    elif M1 is None and M2 is not None:
+        if hasattr(A_, 'psolve') and not hasattr(A_, 'rpsolve'):
+            M1 = LinearOperator(A.shape, matvec=left_psolve, rmatvec=id)
+        elif not hasattr(A_, 'psolve') and hasattr(A_, 'rpsolve'):
+            M1 = LinearOperator(A.shape, matvec=id, rmatvec=left_rpsolve)
+        elif hasattr(A_, 'psolve') and hasattr(A_, 'rpsolve'):
+            M1 = LinearOperator(A.shape,
+                                matvec=left_psolve, rmatvec=left_rpsolve)
+        else:
+            M1 = LinearOperator(A.shape, matvec=id, rmatvec=id)
 
     n = len(b)
     if maxiter is None:

--- a/scipy/sparse/linalg/_isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_iterative.py
@@ -268,16 +268,60 @@ def check_precond_dummy(solver, case):
         x, info = solver(A, b, M1=precond, M2=precond, x0=x0, tol=tol)
     else:
         x, info = solver(A, b, M=precond, x0=x0, tol=tol)
-    assert_equal(info,0)
+    assert_equal(info, 0)
     assert_normclose(A.dot(x), b, tol)
 
     A = aslinearoperator(A)
     A.psolve = identity
     A.rpsolve = identity
+    if solver is qmr:
+        def assert_array_normclose(a, b, tol=1e-8):
+            d = b - a
+            d2 = d * d
+            residual = np.sqrt(max(d2.sum(axis=0)))
+            tolerance = tol * bNorm
+            msg = f"residual ({residual}) not smaller than " \
+                  f"tolerance ({tolerance})"
+            assert_(residual < tolerance, msg=msg)
 
-    x, info = solver(A, b, x0=x0, tol=tol)
-    assert_equal(info,0)
-    assert_normclose(A@x, b, tol=tol)
+        bNorm = norm(b)
+        bArray = np.array([b, b, b]).T
+
+        x, infoX = solver(A, b, x0=x0, tol=tol)
+        y, infoY = solver(A, b, M1=precond, x0=x0, tol=tol)
+        z, infoZ = solver(A, b, M2=precond, x0=x0, tol=tol)
+        assert_equal(abs(infoX) + abs(infoY) + abs(infoZ), 0)
+        xyz = np.array([x, y, z]).T
+        assert_array_normclose(A@xyz, bArray, tol)
+
+        del A.rpsolve
+        x, infoX = solver(A, b, x0=x0, tol=tol)
+        y, infoY = solver(A, b, M1=precond, x0=x0, tol=tol)
+        z, infoZ = solver(A, b, M2=precond, x0=x0, tol=tol)
+        assert_equal(abs(infoX) + abs(infoY) + abs(infoZ), 0)
+        xyz = np.array([x, y, z]).T
+        assert_array_normclose(A@xyz, bArray, tol)
+
+        del A.psolve
+        A.rpsolve = identity
+        x, infoX = solver(A, b, x0=x0, tol=tol)
+        y, infoY = solver(A, b, M1=precond, x0=x0, tol=tol)
+        z, infoZ = solver(A, b, M2=precond, x0=x0, tol=tol)
+        assert_equal(abs(infoX) + abs(infoY) + abs(infoZ), 0)
+        xyz = np.array([x, y, z]).T
+        assert_array_normclose(A@xyz, bArray, tol)
+
+        del A.rpsolve
+        x, infoX = solver(A, b, x0=x0, tol=tol)
+        y, infoY = solver(A, b, M1=precond, x0=x0, tol=tol)
+        z, infoZ = solver(A, b, M2=precond, x0=x0, tol=tol)
+        assert_equal(abs(infoX) + abs(infoY) + abs(infoZ), 0)
+        xyz = np.array([x, y, z]).T
+        assert_array_normclose(A@xyz, bArray, tol)
+    else:
+        x, info = solver(A, b, x0=x0, tol=tol)
+        assert_equal(info, 0)
+        assert_normclose(A@x, b, tol=tol)
 
 
 def test_precond_dummy():


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes gh-15353 because my forked scipy repository is removed by mistake.
To resolve the issue https://github.com/scipy/scipy/issues/14027

#### What does this implement/fix?
<!--Please explain your changes.-->
For QMR algorithm, the left/right/both/no preconditioner should be available. In this PR, add the branches of the case where the left/right/both/no preconditioner is used and complete corresponding tests.

#### Additional information
<!--Any additional information you think is important.-->
