### PR TITLE
Mark fitpack sources as `recursive`

### DIFF
--- a/scipy/interpolate/fitpack/bispeu.f
+++ b/scipy/interpolate/fitpack/bispeu.f
@@ -1,4 +1,6 @@
-      subroutine bispeu(tx,nx,ty,ny,c,kx,ky,x,y,z,m,wrk,lwrk, ier)
+      recursive subroutine bispeu(tx,nx,ty,ny,c,kx,ky,x,y,z,m,wrk,
+     *   lwrk, ier)
+      implicit none
 c  subroutine bispeu evaluates on a set of points (x(i),y(i)),i=1,...,m
 c  a bivariate spline s(x,y) of degrees kx and ky, given in the
 c  b-spline representation.

--- a/scipy/interpolate/fitpack/bispev.f
+++ b/scipy/interpolate/fitpack/bispev.f
@@ -1,5 +1,6 @@
-      subroutine bispev(tx,nx,ty,ny,c,kx,ky,x,mx,y,my,z,wrk,lwrk,
-     * iwrk,kwrk,ier)
+      recursive subroutine bispev(tx,nx,ty,ny,c,kx,ky,x,mx,y,my,z,
+     *    wrk,lwrk,iwrk,kwrk,ier)
+      implicit none
 c  subroutine bispev evaluates on a grid (x(i),y(j)),i=1,...,mx; j=1,...
 c  ,my a bivariate spline s(x,y) of degrees kx and ky, given in the
 c  b-spline representation.

--- a/scipy/interpolate/fitpack/clocur.f
+++ b/scipy/interpolate/fitpack/clocur.f
@@ -1,5 +1,6 @@
-      subroutine clocur(iopt,ipar,idim,m,u,mx,x,w,k,s,nest,n,t,nc,c,fp,
-     * wrk,lwrk,iwrk,ier)
+      recursive subroutine clocur(iopt,ipar,idim,m,u,mx,x,w,k,s,nest,
+     * n,t,nc,c,fp,wrk,lwrk,iwrk,ier)
+      implicit none
 c  given the ordered set of m points x(i) in the idim-dimensional space
 c  with x(1)=x(m), and given also a corresponding set of strictly in-
 c  creasing values u(i) and the set of positive numbers w(i),i=1,2,...,m

--- a/scipy/interpolate/fitpack/cocosp.f
+++ b/scipy/interpolate/fitpack/cocosp.f
@@ -1,5 +1,6 @@
-      subroutine cocosp(m,x,y,w,n,t,e,maxtr,maxbin,c,sq,sx,bind,wrk,
-     * lwrk,iwrk,kwrk,ier)
+      recursive subroutine cocosp(m,x,y,w,n,t,e,maxtr,maxbin,c,sq,
+     * sx,bind,wrk,lwrk,iwrk,kwrk,ier)
+      implicit none
 c  given the set of data points (x(i),y(i)) and the set of positive
 c  numbers w(i),i=1,2,...,m, subroutine cocosp determines the weighted
 c  least-squares cubic spline s(x) with given knots t(j),j=1,2,...,n

--- a/scipy/interpolate/fitpack/concon.f
+++ b/scipy/interpolate/fitpack/concon.f
@@ -1,5 +1,6 @@
-      subroutine concon(iopt,m,x,y,w,v,s,nest,maxtr,maxbin,n,t,c,sq,
-     * sx,bind,wrk,lwrk,iwrk,kwrk,ier)
+      recursive subroutine concon(iopt,m,x,y,w,v,s,nest,maxtr,maxbin,
+     * n,t,c,sq,sx,bind,wrk,lwrk,iwrk,kwrk,ier)
+      implicit none
 c  given the set of data points (x(i),y(i)) and the set of positive
 c  numbers w(i), i=1,2,...,m,subroutine concon determines a cubic spline
 c  approximation s(x) which satisfies the following local convexity

--- a/scipy/interpolate/fitpack/concur.f
+++ b/scipy/interpolate/fitpack/concur.f
@@ -1,5 +1,5 @@
-      subroutine concur(iopt,idim,m,u,mx,x,xx,w,ib,db,nb,ie,de,ne,k,s,
-     * nest,n,t,nc,c,np,cp,fp,wrk,lwrk,iwrk,ier)
+      recursive subroutine concur(iopt,idim,m,u,mx,x,xx,w,ib,db,nb,
+     * ie,de,ne,k,s,nest,n,t,nc,c,np,cp,fp,wrk,lwrk,iwrk,ier)
       implicit none
 c  given the ordered set of m points x(i) in the idim-dimensional space
 c  and given also a corresponding set of strictly increasing values u(i)

--- a/scipy/interpolate/fitpack/cualde.f
+++ b/scipy/interpolate/fitpack/cualde.f
@@ -1,4 +1,5 @@
-      subroutine cualde(idim,t,n,c,nc,k1,u,d,nd,ier)
+      recursive subroutine cualde(idim,t,n,c,nc,k1,u,d,nd,ier)
+      implicit none
 c  subroutine cualde evaluates at the point u all the derivatives
 c                     (l)
 c     d(idim*l+j) = sj   (u) ,l=0,1,...,k, j=1,2,...,idim

--- a/scipy/interpolate/fitpack/curev.f
+++ b/scipy/interpolate/fitpack/curev.f
@@ -1,4 +1,5 @@
-      subroutine curev(idim,t,n,c,nc,k,u,m,x,mx,ier)
+      recursive subroutine curev(idim,t,n,c,nc,k,u,m,x,mx,ier)
+      implicit none
 c  subroutine curev evaluates in a number of points u(i),i=1,2,...,m
 c  a spline curve s(u) of degree k and dimension idim, given in its
 c  b-spline representation.

--- a/scipy/interpolate/fitpack/curfit.f
+++ b/scipy/interpolate/fitpack/curfit.f
@@ -1,5 +1,6 @@
-      subroutine curfit(iopt,m,x,y,w,xb,xe,k,s,nest,n,t,c,fp,
-     * wrk,lwrk,iwrk,ier)
+      recursive subroutine curfit(iopt,m,x,y,w,xb,xe,k,s,nest,n,
+     *   t,c,fp,wrk,lwrk,iwrk,ier)
+      implicit none
 c  given the set of data points (x(i),y(i)) and the set of positive
 c  numbers w(i),i=1,2,...,m,subroutine curfit determines a smooth spline
 c  approximation of degree k on the interval xb <= x <= xe.

--- a/scipy/interpolate/fitpack/dblint.f
+++ b/scipy/interpolate/fitpack/dblint.f
@@ -1,4 +1,7 @@
-      real*8 function dblint(tx,nx,ty,ny,c,kx,ky,xb,xe,yb,ye,wrk)
+      recursive function dblint(tx,nx,ty,ny,c,kx,ky,xb,xe,yb,
+     *    ye,wrk) result(dblint_res)
+      implicit none
+      real*8 :: dblint_res
 c  function dblint calculates the double integral
 c         / xe  / ye
 c        |     |      s(x,y) dx dy
@@ -72,7 +75,7 @@ c  we calculate the integrals of the normalized b-splines ni,kx+1(x)
 c  we calculate the integrals of the normalized b-splines nj,ky+1(y)
       call fpintb(ty,ny,wrk(nkx1+1),nky1,yb,ye)
 c  calculate the integral of s(x,y)
-      dblint = 0.
+      dblint_res = 0.
       do 200 i=1,nkx1
         res = wrk(i)
         if(res.eq.0.) go to 200
@@ -81,7 +84,7 @@ c  calculate the integral of s(x,y)
         do 100 j=1,nky1
           m = m+1
           l = l+1
-          dblint = dblint+res*wrk(l)*c(m)
+          dblint_res = dblint_res + res*wrk(l)*c(m)
  100    continue
  200  continue
       return

--- a/scipy/interpolate/fitpack/evapol.f
+++ b/scipy/interpolate/fitpack/evapol.f
@@ -1,4 +1,6 @@
-      real*8 function evapol(tu,nu,tv,nv,c,rad,x,y)
+      recursive function evapol(tu,nu,tv,nv,c,rad,x,y) result(e_res)
+      implicit none
+      real*8 :: e_res
 c  function program evacir evaluates the function f(x,y) = s(u,v),
 c  defined through the transformation
 c      x = u*rad(v)*cos(v)    y = u*rad(v)*sin(v)
@@ -76,7 +78,7 @@ c  calculate the (u,v)-coordinates of the given point.
       if(u.gt.one) u = one
 c  evaluate s(u,v)
   10  call bispev(tu,nu,tv,nv,c,3,3,u,1,v,1,f,wrk,8,iwrk,2,ier)
-      evapol = f
+      e_res = f
       return
       end
 

--- a/scipy/interpolate/fitpack/fourco.f
+++ b/scipy/interpolate/fitpack/fourco.f
@@ -1,4 +1,5 @@
-      subroutine fourco(t,n,c,alfa,m,ress,resc,wrk1,wrk2,ier)
+      recursive subroutine fourco(t,n,c,alfa,m,ress,resc,wrk1,wrk2,ier)
+      implicit none
 c  subroutine fourco calculates the integrals
 c                    /t(n-3)
 c    ress(i) =      !        s(x)*sin(alfa(i)*x) dx    and

--- a/scipy/interpolate/fitpack/fpader.f
+++ b/scipy/interpolate/fitpack/fpader.f
@@ -1,4 +1,4 @@
-      subroutine fpader(t,n,c,k1,x,l,d)
+      recursive subroutine fpader(t,n,c,k1,x,l,d)
 c  subroutine fpader calculates the derivatives
 c             (j-1)
 c     d(j) = s     (x) , j=1,2,...,k1

--- a/scipy/interpolate/fitpack/fpadno.f
+++ b/scipy/interpolate/fitpack/fpadno.f
@@ -1,5 +1,6 @@
-      subroutine fpadno(maxtr,up,left,right,info,count,merk,jbind,
-     * n1,ier)
+      recursive subroutine fpadno(maxtr,up,left,right,info,count,
+     *   merk,jbind,n1,ier)
+      implicit none
 c  subroutine fpadno adds a branch of length n1 to the triply linked
 c  tree,the information of which is kept in the arrays up,left,right
 c  and info. the information field of the nodes of this new branch is

--- a/scipy/interpolate/fitpack/fpadpo.f
+++ b/scipy/interpolate/fitpack/fpadpo.f
@@ -1,4 +1,5 @@
-      subroutine fpadpo(idim,t,n,c,nc,k,cp,np,cc,t1,t2)
+      recursive subroutine fpadpo(idim,t,n,c,nc,k,cp,np,cc,t1,t2)
+      implicit none
 c  given a idim-dimensional spline curve of degree k, in its b-spline
 c  representation ( knots t(j),j=1,...,n , b-spline coefficients c(j),
 c  j=1,...,nc) and given also a polynomial curve in its b-spline

--- a/scipy/interpolate/fitpack/fpback.f
+++ b/scipy/interpolate/fitpack/fpback.f
@@ -1,4 +1,5 @@
-      subroutine fpback(a,z,n,k,c,nest)
+      recursive subroutine fpback(a,z,n,k,c,nest)
+      implicit none
 c  subroutine fpback calculates the solution of the system of
 c  equations a*c = z with a a n x n upper triangular matrix
 c  of bandwidth k.

--- a/scipy/interpolate/fitpack/fpbacp.f
+++ b/scipy/interpolate/fitpack/fpbacp.f
@@ -1,4 +1,5 @@
-      subroutine fpbacp(a,b,z,n,k,c,k1,nest)
+      recursive subroutine fpbacp(a,b,z,n,k,c,k1,nest)
+      implicit none
 c  subroutine fpbacp calculates the solution of the system of equations
 c  g * c = z  with g  a n x n upper triangular matrix of the form
 c            ! a '   !

--- a/scipy/interpolate/fitpack/fpbfout.f
+++ b/scipy/interpolate/fitpack/fpbfout.f
@@ -1,4 +1,5 @@
-      subroutine fpbfou(t,n,par,ress,resc)
+      recursive subroutine fpbfou(t,n,par,ress,resc)
+      implicit none
 c  subroutine fpbfou calculates the integrals
 c                    /t(n-3)
 c    ress(j) =      !        nj,4(x)*sin(par*x) dx    and

--- a/scipy/interpolate/fitpack/fpbisp.f
+++ b/scipy/interpolate/fitpack/fpbisp.f
@@ -1,4 +1,6 @@
-      subroutine fpbisp(tx,nx,ty,ny,c,kx,ky,x,mx,y,my,z,wx,wy,lx,ly)
+      recursive subroutine fpbisp(tx,nx,ty,ny,c,kx,ky,x,mx,y,my,
+     *     z,wx,wy,lx,ly)
+      implicit none
 c  ..scalar arguments..
       integer nx,ny,kx,ky,mx,my
 c  ..array arguments..
@@ -6,7 +8,7 @@ c  ..array arguments..
       real*8 tx(nx),ty(ny),c((nx-kx-1)*(ny-ky-1)),x(mx),y(my),z(mx*my),
      * wx(mx,kx+1),wy(my,ky+1)
 c  ..local scalars..
-      integer kx1,ky1,l,l1,l2,m,nkx1,nky1
+      integer kx1,ky1,l,l1,l2,m,nkx1,nky1, i, i1, j, j1
       real*8 arg,sp,tb,te
 c  ..local arrays..
       real*8 h(6)

--- a/scipy/interpolate/fitpack/fpbspl.f
+++ b/scipy/interpolate/fitpack/fpbspl.f
@@ -1,4 +1,4 @@
-      subroutine fpbspl(t,n,k,x,l,h)
+      recursive subroutine fpbspl(t,n,k,x,l,h)
 c  subroutine fpbspl evaluates the (k+1) non-zero b-splines of
 c  degree k at t(l) <= x < t(l+1) using the stable recurrence
 c  relation of de boor and cox.

--- a/scipy/interpolate/fitpack/fpchec.f
+++ b/scipy/interpolate/fitpack/fpchec.f
@@ -1,4 +1,5 @@
-      subroutine fpchec(x,m,t,n,k,ier)
+      recursive subroutine fpchec(x,m,t,n,k,ier)
+      implicit none
 c  subroutine fpchec verifies the number and the position of the knots
 c  t(j),j=1,2,...,n of a spline of degree k, in relation to the number
 c  and the position of the data points x(i),i=1,2,...,m. if all of the

--- a/scipy/interpolate/fitpack/fpched.f
+++ b/scipy/interpolate/fitpack/fpched.f
@@ -1,4 +1,5 @@
-      subroutine fpched(x,m,t,n,k,ib,ie,ier)
+      recursive subroutine fpched(x,m,t,n,k,ib,ie,ier)
+      implicit none
 c  subroutine fpched verifies the number and the position of the knots
 c  t(j),j=1,2,...,n of a spline of degree k,with ib derative constraints
 c  at x(1) and ie constraints at x(m), in relation to the number and

--- a/scipy/interpolate/fitpack/fpchep.f
+++ b/scipy/interpolate/fitpack/fpchep.f
@@ -1,4 +1,5 @@
-      subroutine fpchep(x,m,t,n,k,ier)
+      recursive subroutine fpchep(x,m,t,n,k,ier)
+      implicit none
 c  subroutine fpchep verifies the number and the position of the knots
 c  t(j),j=1,2,...,n of a periodic spline of degree k, in relation to
 c  the number and the position of the data points x(i),i=1,2,...,m.

--- a/scipy/interpolate/fitpack/fpclos.f
+++ b/scipy/interpolate/fitpack/fpclos.f
@@ -1,5 +1,6 @@
-      subroutine fpclos(iopt,idim,m,u,mx,x,w,k,s,nest,tol,maxit,k1,k2,
-     * n,t,nc,c,fp,fpint,z,a1,a2,b,g1,g2,q,nrdata,ier)
+      recursive subroutine fpclos(iopt,idim,m,u,mx,x,w,k,s,nest,tol,
+     *  maxit,k1,k2,n,t,nc,c,fp,fpint,z,a1,a2,b,g1,g2,q,nrdata,ier)
+      implicit none
 c  ..
 c  ..scalar arguments..
       real*8 s,tol,fp

--- a/scipy/interpolate/fitpack/fpcoco.f
+++ b/scipy/interpolate/fitpack/fpcoco.f
@@ -1,5 +1,6 @@
-      subroutine fpcoco(iopt,m,x,y,w,v,s,nest,maxtr,maxbin,n,t,c,sq,sx,
-     * bind,e,wrk,lwrk,iwrk,kwrk,ier)
+      recursive subroutine fpcoco(iopt,m,x,y,w,v,s,nest,maxtr,maxbin,
+     *   n,t,c,sq,sx,bind,e,wrk,lwrk,iwrk,kwrk,ier)
+      implicit none
 c  ..scalar arguments..
       real*8 s,sq
       integer iopt,m,nest,maxtr,maxbin,n,lwrk,kwrk,ier

--- a/scipy/interpolate/fitpack/fpcons.f
+++ b/scipy/interpolate/fitpack/fpcons.f
@@ -1,5 +1,6 @@
-      subroutine fpcons(iopt,idim,m,u,mx,x,w,ib,ie,k,s,nest,tol,maxit,
-     * k1,k2,n,t,nc,c,fp,fpint,z,a,b,g,q,nrdata,ier)
+      recursive subroutine fpcons(iopt,idim,m,u,mx,x,w,ib,ie,k,s,nest,
+     *  tol,maxit,k1,k2,n,t,nc,c,fp,fpint,z,a,b,g,q,nrdata,ier)
+ccc      implicit none   c XXX: mmnin/nmin variables on line 61
 c  ..
 c  ..scalar arguments..
       real*8 s,tol,fp

--- a/scipy/interpolate/fitpack/fpcosp.f
+++ b/scipy/interpolate/fitpack/fpcosp.f
@@ -1,6 +1,7 @@
-      subroutine fpcosp(m,x,y,w,n,t,e,maxtr,maxbin,c,sq,sx,bind,nm,mb,a,
-     *
+      recursive subroutine fpcosp(m,x,y,w,n,t,e,maxtr,maxbin,c,sq,sx,
+     * bind,nm,mb,a,
      * b,const,z,zz,u,q,info,up,left,right,jbind,ibind,ier)
+      implicit none
 c  ..
 c  ..scalar arguments..
       real*8 sq

--- a/scipy/interpolate/fitpack/fpcsin.f
+++ b/scipy/interpolate/fitpack/fpcsin.f
@@ -1,4 +1,5 @@
-      subroutine fpcsin(a,b,par,sia,coa,sib,cob,ress,resc)
+      recursive subroutine fpcsin(a,b,par,sia,coa,sib,cob,ress,resc)
+      implicit none
 c  fpcsin calculates the integrals ress=integral((b-x)**3*sin(par*x))
 c  and resc=integral((b-x)**3*cos(par*x)) over the interval (a,b),
 c  given sia=sin(par*a),coa=cos(par*a),sib=sin(par*b) and cob=cos(par*b)

--- a/scipy/interpolate/fitpack/fpcurf.f
+++ b/scipy/interpolate/fitpack/fpcurf.f
@@ -1,5 +1,6 @@
-      subroutine fpcurf(iopt,x,y,w,m,xb,xe,k,s,nest,tol,maxit,k1,k2,
-     * n,t,c,fp,fpint,z,a,b,g,q,nrdata,ier)
+      recursive subroutine fpcurf(iopt,x,y,w,m,xb,xe,k,s,nest,tol,
+     *   maxit,k1,k2,n,t,c,fp,fpint,z,a,b,g,q,nrdata,ier)
+      implicit none
 c  ..
 c  ..scalar arguments..
       real*8 xb,xe,s,tol,fp

--- a/scipy/interpolate/fitpack/fpcuro.f
+++ b/scipy/interpolate/fitpack/fpcuro.f
@@ -1,4 +1,5 @@
-      subroutine fpcuro(a,b,c,d,x,n)
+      recursive subroutine fpcuro(a,b,c,d,x,n)
+      implicit none
 c  subroutine fpcuro finds the real zeros of a cubic polynomial
 c  p(x) = a*x**3+b*x**2+c*x+d.
 c

--- a/scipy/interpolate/fitpack/fpcyt1.f
+++ b/scipy/interpolate/fitpack/fpcyt1.f
@@ -1,4 +1,5 @@
-      subroutine fpcyt1(a,n,nn)
+      recursive subroutine fpcyt1(a,n,nn)
+      implicit none
 c (l u)-decomposition of a cyclic tridiagonal matrix with the non-zero
 c elements stored as follows
 c

--- a/scipy/interpolate/fitpack/fpcyt2.f
+++ b/scipy/interpolate/fitpack/fpcyt2.f
@@ -1,4 +1,5 @@
-      subroutine fpcyt2(a,n,b,c,nn)
+      recursive subroutine fpcyt2(a,n,b,c,nn)
+      implicit none
 c subroutine fpcyt2 solves a linear n x n system
 c         a * c = b
 c where matrix a is a cyclic tridiagonal matrix, decomposed

--- a/scipy/interpolate/fitpack/fpdeno.f
+++ b/scipy/interpolate/fitpack/fpdeno.f
@@ -1,4 +1,5 @@
-      subroutine fpdeno(maxtr,up,left,right,nbind,merk)
+      recursive subroutine fpdeno(maxtr,up,left,right,nbind,merk)
+      implicit none
 c  subroutine fpdeno frees the nodes of all branches of a triply linked
 c  tree with length < nbind by putting to zero their up field.
 c  on exit the parameter merk points to the terminal node of the

--- a/scipy/interpolate/fitpack/fpdisc.f
+++ b/scipy/interpolate/fitpack/fpdisc.f
@@ -1,4 +1,5 @@
-      subroutine fpdisc(t,n,k2,b,nest)
+      recursive subroutine fpdisc(t,n,k2,b,nest)
+      implicit none
 c  subroutine fpdisc calculates the discontinuity jumps of the kth
 c  derivative of the b-splines of degree k at the knots t(k+2)..t(n-k-1)
 c  ..scalar arguments..

--- a/scipy/interpolate/fitpack/fpfrno.f
+++ b/scipy/interpolate/fitpack/fpfrno.f
@@ -1,5 +1,6 @@
-      subroutine fpfrno(maxtr,up,left,right,info,point,merk,n1,
-     * count,ier)
+      recursive subroutine fpfrno(maxtr,up,left,right,info,point,
+     *   merk,n1,count,ier)
+      implicit none
 c  subroutine fpfrno collects the free nodes (up field zero) of the
 c  triply linked tree the information of which is kept in the arrays
 c  up,left,right and info. the maximal length of the branches of the

--- a/scipy/interpolate/fitpack/fpgivs.f
+++ b/scipy/interpolate/fitpack/fpgivs.f
@@ -1,4 +1,5 @@
-      subroutine fpgivs(piv,ww,cos,sin)
+      recursive subroutine fpgivs(piv,ww,cos,sin)
+      implicit none
 c  subroutine fpgivs calculates the parameters of a givens
 c  transformation .
 c  ..

--- a/scipy/interpolate/fitpack/fpgrdi.f
+++ b/scipy/interpolate/fitpack/fpgrdi.f
@@ -1,6 +1,7 @@
-      subroutine fpgrdi(ifsu,ifsv,ifbu,ifbv,iback,u,mu,v,mv,z,mz,dz,
-     * iop0,iop1,tu,nu,tv,nv,p,c,nc,sq,fp,fpu,fpv,mm,mvnu,spu,spv,
-     * right,q,au,av1,av2,bu,bv,aa,bb,cc,cosi,nru,nrv)
+      recursive subroutine fpgrdi(ifsu,ifsv,ifbu,ifbv,iback,u,mu,v,
+     * mv,z,mz,dz,iop0,iop1,tu,nu,tv,nv,p,c,nc,sq,fp,fpu,fpv,mm,
+     * mvnu,spu,spv,right,q,au,av1,av2,bu,bv,aa,bb,cc,cosi,nru,nrv)
+      implicit none
 c  ..
 c  ..scalar arguments..
       real*8 p,sq,fp

--- a/scipy/interpolate/fitpack/fpgrpa.f
+++ b/scipy/interpolate/fitpack/fpgrpa.f
@@ -1,6 +1,7 @@
-      subroutine fpgrpa(ifsu,ifsv,ifbu,ifbv,idim,ipar,u,mu,v,mv,z,mz,
-     * tu,nu,tv,nv,p,c,nc,fp,fpu,fpv,mm,mvnu,spu,spv,right,q,au,au1,
-     * av,av1,bu,bv,nru,nrv)
+      recursive subroutine fpgrpa(ifsu,ifsv,ifbu,ifbv,idim,ipar,u,mu,
+     * v,mv,z,mz,tu,nu,tv,nv,p,c,nc,fp,fpu,fpv,mm,mvnu,spu,spv,
+     * right,q,au,au1,av,av1,bu,bv,nru,nrv)
+      implicit none
 c  ..
 c  ..scalar arguments..
       real*8 p,fp
@@ -14,7 +15,7 @@ c  ..local scalars..
       real*8 arg,fac,term,one,half,value
       integer i,id,ii,it,iz,i1,i2,j,jz,k,k1,k2,l,l1,l2,mvv,k0,muu,
      * ncof,nroldu,nroldv,number,nmd,numu,numu1,numv,numv1,nuu,nvv,
-     * nu4,nu7,nu8,nv4,nv7,nv8
+     * nu4,nu7,nu8,nv4,nv7,nv8, n33
 c  ..local arrays..
       real*8 h(5)
 c  ..subroutine references..

--- a/scipy/interpolate/fitpack/fpgrre.f
+++ b/scipy/interpolate/fitpack/fpgrre.f
@@ -1,6 +1,7 @@
-      subroutine fpgrre(ifsx,ifsy,ifbx,ifby,x,mx,y,my,z,mz,kx,ky,tx,nx,
-     * ty,ny,p,c,nc,fp,fpx,fpy,mm,mynx,kx1,kx2,ky1,ky2,spx,spy,right,q,
-     * ax,ay,bx,by,nrx,nry)
+      recursive subroutine fpgrre(ifsx,ifsy,ifbx,ifby,x,mx,y,my,z,mz,
+     * kx,ky,tx,nx,ty,ny,p,c,nc,fp,fpx,fpy,mm,mynx,kx1,kx2,ky1,ky2,
+     * spx,spy,right,q,ax,ay,bx,by,nrx,nry)
+      implicit none
 c  ..
 c  ..scalar arguments..
       real*8 p,fp

--- a/scipy/interpolate/fitpack/fpgrsp.f
+++ b/scipy/interpolate/fitpack/fpgrsp.f
@@ -1,6 +1,8 @@
-      subroutine fpgrsp(ifsu,ifsv,ifbu,ifbv,iback,u,mu,v,mv,r,mr,dr,
-     * iop0,iop1,tu,nu,tv,nv,p,c,nc,sq,fp,fpu,fpv,mm,mvnu,spu,spv,
-     * right,q,au,av1,av2,bu,bv,a0,a1,b0,b1,c0,c1,cosi,nru,nrv)
+      recursive subroutine fpgrsp(ifsu,ifsv,ifbu,ifbv,iback,u,mu,v,
+     * mv,r,mr,dr,iop0,iop1,tu,nu,tv,nv,p,c,nc,sq,fp,fpu,fpv,mm,
+     * mvnu,spu,spv,right,q,au,av1,av2,bu,bv,a0,a1,b0,b1,c0,c1,
+     * cosi,nru,nrv)
+      implicit none
 c  ..
 c  ..scalar arguments..
       real*8 p,sq,fp

--- a/scipy/interpolate/fitpack/fpinst.f
+++ b/scipy/interpolate/fitpack/fpinst.f
@@ -1,4 +1,5 @@
-      subroutine fpinst(iopt,t,n,c,k,x,l,tt,nn,cc,nest)
+      recursive subroutine fpinst(iopt,t,n,c,k,x,l,tt,nn,cc,nest)
+      implicit none
 c  given the b-spline representation (knots t(j),j=1,2,...,n, b-spline
 c  coefficients c(j),j=1,2,...,n-k-1) of a spline of degree k, fpinst
 c  calculates the b-spline representation (knots tt(j),j=1,2,...,nn,

--- a/scipy/interpolate/fitpack/fpintb.f
+++ b/scipy/interpolate/fitpack/fpintb.f
@@ -1,4 +1,4 @@
-      subroutine fpintb(t,n,bint,nk1,x,y)
+      recursive subroutine fpintb(t,n,bint,nk1,x,y)
       implicit none
 c  subroutine fpintb calculates integrals of the normalized b-splines
 c  nj,k+1(x) of degree k, defined on the set of knots t(j),j=1,2,...n.

--- a/scipy/interpolate/fitpack/fpknot.f
+++ b/scipy/interpolate/fitpack/fpknot.f
@@ -1,4 +1,5 @@
-      subroutine fpknot(x,m,t,n,fpint,nrdata,nrint,nest,istart)
+      recursive subroutine fpknot(x,m,t,n,fpint,nrdata,nrint,nest,
+     *   istart)
       implicit none
 c  subroutine fpknot locates an additional knot for a spline of degree
 c  k and adjusts the corresponding parameters,i.e.

--- a/scipy/interpolate/fitpack/fpopdi.f
+++ b/scipy/interpolate/fitpack/fpopdi.f
@@ -1,6 +1,7 @@
-      subroutine fpopdi(ifsu,ifsv,ifbu,ifbv,u,mu,v,mv,z,mz,z0,dz,
-     * iopt,ider,tu,nu,tv,nv,nuest,nvest,p,step,c,nc,fp,fpu,fpv,
-     * nru,nrv,wrk,lwrk)
+      recursive subroutine fpopdi(ifsu,ifsv,ifbu,ifbv,u,mu,v,mv,z,
+     * mz,z0,dz,iopt,ider,tu,nu,tv,nv,nuest,nvest,p,step,c,nc,fp,
+     * fpu,fpv,nru,nrv,wrk,lwrk)
+      implicit none
 c  given the set of function values z(i,j) defined on the rectangular
 c  grid (u(i),v(j)),i=1,2,...,mu;j=1,2,...,mv, fpopdi determines a
 c  smooth bicubic spline approximation with given knots tu(i),i=1,..,nu

--- a/scipy/interpolate/fitpack/fpopsp.f
+++ b/scipy/interpolate/fitpack/fpopsp.f
@@ -1,6 +1,7 @@
-      subroutine fpopsp(ifsu,ifsv,ifbu,ifbv,u,mu,v,mv,r,mr,r0,r1,dr,
-     * iopt,ider,tu,nu,tv,nv,nuest,nvest,p,step,c,nc,fp,fpu,fpv,
-     * nru,nrv,wrk,lwrk)
+      recursive subroutine fpopsp(ifsu,ifsv,ifbu,ifbv,u,mu,v,mv,r,
+     * mr,r0,r1,dr,iopt,ider,tu,nu,tv,nv,nuest,nvest,p,step,c,nc,
+     * fp,fpu,fpv,nru,nrv,wrk,lwrk)
+      implicit none
 c  given the set of function values r(i,j) defined on the rectangular
 c  grid (u(i),v(j)),i=1,2,...,mu;j=1,2,...,mv, fpopsp determines a
 c  smooth bicubic spline approximation with given knots tu(i),i=1,..,nu
@@ -57,7 +58,7 @@ c  ..array arguments..
 c  ..local scalars..
       real*8 sq,sqq,sq0,sq1,step1,step2,three
       integer i,id0,iop0,iop1,i1,j,l,lau,lav1,lav2,la0,la1,lbu,lbv,lb0,
-     * lb1,lc0,lc1,lcs,lq,lri,lsu,lsv,l1,l2,mm,mvnu,number
+     * lb1,lc0,lc1,lcs,lq,lri,lsu,lsv,l1,l2,mm,mvnu,number, id1
 c  ..local arrays..
       integer nr(6)
       real*8 delta(6),drr(6),sum(6),a(6,6),g(6)

--- a/scipy/interpolate/fitpack/fporde.f
+++ b/scipy/interpolate/fitpack/fporde.f
@@ -1,4 +1,5 @@
-      subroutine fporde(x,y,m,kx,ky,tx,nx,ty,ny,nummer,index,nreg)
+      recursive subroutine fporde(x,y,m,kx,ky,tx,nx,ty,ny,nummer,
+     *   index,nreg)
 c  subroutine fporde sorts the data points (x(i),y(i)),i=1,2,...,m
 c  according to the panel tx(l)<=x<tx(l+1),ty(k)<=y<ty(k+1), they belong
 c  to. for each panel a stack is constructed  containing the numbers

--- a/scipy/interpolate/fitpack/fppasu.f
+++ b/scipy/interpolate/fitpack/fppasu.f
@@ -1,6 +1,7 @@
       subroutine fppasu(iopt,ipar,idim,u,mu,v,mv,z,mz,s,nuest,nvest,
      * tol,maxit,nc,nu,tu,nv,tv,c,fp,fp0,fpold,reducu,reducv,fpintu,
      * fpintv,lastdi,nplusu,nplusv,nru,nrv,nrdatu,nrdatv,wrk,lwrk,ier)
+      implicit none
 c  ..
 c  ..scalar arguments..
       real*8 s,tol,fp,fp0,fpold,reducu,reducv

--- a/scipy/interpolate/fitpack/fpperi.f
+++ b/scipy/interpolate/fitpack/fpperi.f
@@ -1,5 +1,6 @@
-      subroutine fpperi(iopt,x,y,w,m,k,s,nest,tol,maxit,k1,k2,n,t,c,
-     * fp,fpint,z,a1,a2,b,g1,g2,q,nrdata,ier)
+      recursive subroutine fpperi(iopt,x,y,w,m,k,s,nest,tol,maxit,
+     *   k1,k2,n,t,c,fp,fpint,z,a1,a2,b,g1,g2,q,nrdata,ier)
+      implicit none
 c  ..
 c  ..scalar arguments..
       real*8 s,tol,fp

--- a/scipy/interpolate/fitpack/fppocu.f
+++ b/scipy/interpolate/fitpack/fppocu.f
@@ -1,4 +1,5 @@
-      subroutine fppocu(idim,k,a,b,ib,db,nb,ie,de,ne,cp,np)
+      recursive subroutine fppocu(idim,k,a,b,ib,db,nb,ie,de,ne,cp,np)
+      implicit none
 c  subroutine fppocu finds a idim-dimensional polynomial curve p(u) =
 c  (p1(u),p2(u),...,pidim(u)) of degree k, satisfying certain derivative
 c  constraints at the end points a and b, i.e.

--- a/scipy/interpolate/fitpack/fppogr.f
+++ b/scipy/interpolate/fitpack/fppogr.f
@@ -1,7 +1,8 @@
-      subroutine fppogr(iopt,ider,u,mu,v,mv,z,mz,z0,r,s,nuest,nvest,
-     * tol,maxit,nc,nu,tu,nv,tv,c,fp,fp0,fpold,reducu,reducv,fpintu,
-     * fpintv,dz,step,lastdi,nplusu,nplusv,lasttu,nru,nrv,nrdatu,
-     * nrdatv,wrk,lwrk,ier)
+      recursive subroutine fppogr(iopt,ider,u,mu,v,mv,z,mz,z0,r,s,
+     * nuest,nvest,tol,maxit,nc,nu,tu,nv,tv,c,fp,fp0,fpold,reducu,
+     * reducv,fpintu,fpintv,dz,step,lastdi,nplusu,nplusv,lasttu,nru,
+     * nrv,nrdatu,nrdatv,wrk,lwrk,ier)
+      implicit none
 c  ..
 c  ..scalar arguments..
       integer mu,mv,mz,nuest,nvest,maxit,nc,nu,nv,lastdi,nplusu,nplusv,

--- a/scipy/interpolate/fitpack/fppola.f
+++ b/scipy/interpolate/fitpack/fppola.f
@@ -1,7 +1,8 @@
-      subroutine fppola(iopt1,iopt2,iopt3,m,u,v,z,w,rad,s,nuest,nvest,
-     * eta,tol,maxit,ib1,ib3,nc,ncc,intest,nrest,nu,tu,nv,tv,c,fp,sup,
-     * fpint,coord,f,ff,row,cs,cosi,a,q,bu,bv,spu,spv,h,index,nummer,
-     * wrk,lwrk,ier)
+      recursive subroutine fppola(iopt1,iopt2,iopt3,m,u,v,z,w,rad,s,
+     * nuest,nvest,eta,tol,maxit,ib1,ib3,nc,ncc,intest,nrest,nu,tu,nv,
+     * tv,c,fp,sup,fpint,coord,f,ff,row,cs,cosi,a,q,bu,bv,spu,spv,h,
+     * index,nummer,wrk,lwrk,ier)
+      implicit none
 c  ..scalar arguments..
       integer iopt1,iopt2,iopt3,m,nuest,nvest,maxit,ib1,ib3,nc,ncc,
      * intest,nrest,nu,nv,lwrk,ier
@@ -22,7 +23,7 @@ c  ..local scalars..
       integer i,iband,iband3,iband4,ich1,ich3,ii,il,in,ipar,ipar1,irot,
      * iter,i1,i2,i3,j,jrot,j1,j2,k,l,la,lf,lh,ll,lu,lv,lwest,l1,l2,
      * l3,l4,ncof,ncoff,nvv,nv4,nreg,nrint,nrr,nr1,nuu,nu4,num,num1,
-     * numin,nvmin,rank,iband1
+     * numin,nvmin,rank,iband1, jlu
 c  ..local arrays..
       real*8 hu(4),hv(4)
 c  ..function references..

--- a/scipy/interpolate/fitpack/fprank.f
+++ b/scipy/interpolate/fitpack/fprank.f
@@ -1,4 +1,5 @@
-      subroutine fprank(a,f,n,m,na,tol,c,sq,rank,aa,ff,h)
+      recursive subroutine fprank(a,f,n,m,na,tol,c,sq,rank,aa,ff,h)
+      implicit none
 c  subroutine fprank finds the minimum norm solution of a least-
 c  squares problem in case of rank deficiency.
 c

--- a/scipy/interpolate/fitpack/fprati.f
+++ b/scipy/interpolate/fitpack/fprati.f
@@ -1,4 +1,6 @@
-      real*8 function fprati(p1,f1,p2,f2,p3,f3)
+      recursive function fprati(p1,f1,p2,f2,p3,f3) result(fprati_res)
+      implicit none
+      real*8 :: fprati_res
 c  given three points (p1,f1),(p2,f2) and (p3,f3), function fprati
 c  gives the value of p such that the rational interpolating function
 c  of the form r(p) = (u*p+v)/(p+w) equals zero at p.
@@ -24,6 +26,6 @@ c  adjust the value of p1,f1,p3 and f3 such that f1 > 0 and f3 < 0.
       go to 40
   30  p3 = p2
       f3 = f2
-  40  fprati = p
+  40  fprati_res = p
       return
       end

--- a/scipy/interpolate/fitpack/fpregr.f
+++ b/scipy/interpolate/fitpack/fpregr.f
@@ -1,7 +1,8 @@
-      subroutine fpregr(iopt,x,mx,y,my,z,mz,xb,xe,yb,ye,kx,ky,s,
-     * nxest,nyest,tol,maxit,nc,nx,tx,ny,ty,c,fp,fp0,fpold,reducx,
-     * reducy,fpintx,fpinty,lastdi,nplusx,nplusy,nrx,nry,nrdatx,nrdaty,
-     * wrk,lwrk,ier)
+      recursive subroutine fpregr(iopt,x,mx,y,my,z,mz,xb,xe,yb,ye,
+     * kx,ky,s,nxest,nyest,tol,maxit,nc,nx,tx,ny,ty,c,fp,fp0,fpold,
+     * reducx,reducy,fpintx,fpinty,lastdi,nplusx,nplusy,nrx,nry,
+     * nrdatx,nrdaty,wrk,lwrk,ier)
+      implicit none
 c  ..
 c  ..scalar arguments..
       real*8 xb,xe,yb,ye,s,tol,fp,fp0,fpold,reducx,reducy

--- a/scipy/interpolate/fitpack/fprota.f
+++ b/scipy/interpolate/fitpack/fprota.f
@@ -1,4 +1,4 @@
-      subroutine fprota(cos,sin,a,b)
+      recursive subroutine fprota(cos,sin,a,b)
 c  subroutine fprota applies a givens rotation to a and b.
 c  ..
 c  ..scalar arguments..

--- a/scipy/interpolate/fitpack/fprppo.f
+++ b/scipy/interpolate/fitpack/fprppo.f
@@ -1,4 +1,5 @@
-      subroutine fprppo(nu,nv,if1,if2,cosi,ratio,c,f,ncoff)
+      recursive subroutine fprppo(nu,nv,if1,if2,cosi,ratio,c,f,ncoff)
+      implicit none
 c  given the coefficients of a constrained bicubic spline, as determined
 c  in subroutine fppola, subroutine fprppo calculates the coefficients
 c  in the standard b-spline representation of bicubic splines.

--- a/scipy/interpolate/fitpack/fprpsp.f
+++ b/scipy/interpolate/fitpack/fprpsp.f
@@ -1,4 +1,5 @@
-      subroutine fprpsp(nt,np,co,si,c,f,ncoff)
+      recursive subroutine fprpsp(nt,np,co,si,c,f,ncoff)
+      implicit none
 c  given the coefficients of a spherical spline function, subroutine
 c  fprpsp calculates the coefficients in the standard b-spline re-
 c  presentation of this bicubic spline.

--- a/scipy/interpolate/fitpack/fpseno.f
+++ b/scipy/interpolate/fitpack/fpseno.f
@@ -1,4 +1,6 @@
-      subroutine fpseno(maxtr,up,left,right,info,merk,ibind,nbind)
+      recursive subroutine fpseno(maxtr,up,left,right,info,merk,
+     *    ibind,nbind)
+      implicit none
 c  subroutine fpseno fetches a branch of a triply linked tree the
 c  information of which is kept in the arrays up,left,right and info.
 c  the branch has a specified length nbind and is determined by the

--- a/scipy/interpolate/fitpack/fpspgr.f
+++ b/scipy/interpolate/fitpack/fpspgr.f
@@ -1,7 +1,8 @@
-      subroutine fpspgr(iopt,ider,u,mu,v,mv,r,mr,r0,r1,s,nuest,nvest,
-     * tol,maxit,nc,nu,tu,nv,tv,c,fp,fp0,fpold,reducu,reducv,fpintu,
-     * fpintv,dr,step,lastdi,nplusu,nplusv,lastu0,lastu1,nru,nrv,
-     * nrdatu,nrdatv,wrk,lwrk,ier)
+      recursive subroutine fpspgr(iopt,ider,u,mu,v,mv,r,mr,r0,r1,s,
+     * nuest,nvest,tol,maxit,nc,nu,tu,nv,tv,c,fp,fp0,fpold,reducu,
+     * reducv,fpintu,fpintv,dr,step,lastdi,nplusu,nplusv,lastu0,
+     * lastu1,nru,nrv,nrdatu,nrdatv,wrk,lwrk,ier)
+      implicit none
 c  ..
 c  ..scalar arguments..
       integer mu,mv,mr,nuest,nvest,maxit,nc,nu,nv,lastdi,nplusu,nplusv,

--- a/scipy/interpolate/fitpack/fpsphe.f
+++ b/scipy/interpolate/fitpack/fpsphe.f
@@ -1,7 +1,8 @@
-      subroutine fpsphe(iopt,m,teta,phi,r,w,s,ntest,npest,eta,tol,maxit,
-     *
+      recursive subroutine fpsphe(iopt,m,teta,phi,r,w,s,ntest,npest,
+     * eta,tol,maxit,
      * ib1,ib3,nc,ncc,intest,nrest,nt,tt,np,tp,c,fp,sup,fpint,coord,f,
      * ff,row,coco,cosi,a,q,bt,bp,spt,spp,h,index,nummer,wrk,lwrk,ier)
+      implicit none
 c  ..
 c  ..scalar arguments..
       integer iopt,m,ntest,npest,maxit,ib1,ib3,nc,ncc,intest,nrest,

--- a/scipy/interpolate/fitpack/fpsuev.f
+++ b/scipy/interpolate/fitpack/fpsuev.f
@@ -1,4 +1,6 @@
-      subroutine fpsuev(idim,tu,nu,tv,nv,c,u,mu,v,mv,f,wu,wv,lu,lv)
+      recursive subroutine fpsuev(idim,tu,nu,tv,nv,c,u,mu,v,mv,f,
+     *   wu,wv,lu,lv)
+      implicit none
 c  ..scalar arguments..
       integer idim,nu,nv,mu,mv
 c  ..array arguments..

--- a/scipy/interpolate/fitpack/fpsurf.f
+++ b/scipy/interpolate/fitpack/fpsurf.f
@@ -1,7 +1,8 @@
-      subroutine fpsurf(iopt,m,x,y,z,w,xb,xe,yb,ye,kxx,kyy,s,nxest,
-     * nyest,eta,tol,maxit,nmax,km1,km2,ib1,ib3,nc,intest,nrest,
-     * nx0,tx,ny0,ty,c,fp,fp0,fpint,coord,f,ff,a,q,bx,by,spx,spy,h,
-     * index,nummer,wrk,lwrk,ier)
+      recursive subroutine fpsurf(iopt,m,x,y,z,w,xb,xe,yb,ye,kxx,kyy,
+     * s,nxest, nyest,eta,tol,maxit,nmax,km1,km2,ib1,ib3,nc,intest,
+     * nrest,nx0,tx,ny0,ty,c,fp,fp0,fpint,coord,f,ff,a,q,bx,by,spx,
+     * spy,h,index,nummer,wrk,lwrk,ier)
+      implicit none
 c  ..
 c  ..scalar arguments..
       real*8 xb,xe,yb,ye,s,eta,tol,fp,fp0

--- a/scipy/interpolate/fitpack/fpsysy.f
+++ b/scipy/interpolate/fitpack/fpsysy.f
@@ -1,4 +1,5 @@
-      subroutine fpsysy(a,n,g)
+      recursive subroutine fpsysy(a,n,g)
+      implicit none
 c subroutine fpsysy solves a linear n x n symmetric system
 c    (a) * (b) = (g)
 c on input, vector g contains the right hand side ; on output it will

--- a/scipy/interpolate/fitpack/fptrnp.f
+++ b/scipy/interpolate/fitpack/fptrnp.f
@@ -1,4 +1,5 @@
-      subroutine fptrnp(m,mm,idim,n,nr,sp,p,b,z,a,q,right)
+      recursive subroutine fptrnp(m,mm,idim,n,nr,sp,p,b,z,a,q,right)
+      implicit none
 c  subroutine fptrnp reduces the (m+n-7) x (n-4) matrix a to upper
 c  triangular form and applies the same givens transformations to
 c  the (m) x (mm) x (idim) matrix z to obtain the (n-4) x (mm) x

--- a/scipy/interpolate/fitpack/fptrpe.f
+++ b/scipy/interpolate/fitpack/fptrpe.f
@@ -1,4 +1,5 @@
-      subroutine fptrpe(m,mm,idim,n,nr,sp,p,b,z,a,aa,q,right)
+      recursive subroutine fptrpe(m,mm,idim,n,nr,sp,p,b,z,a,aa,q,right)
+      implicit none
 c  subroutine fptrpe reduces the (m+n-7) x (n-7) cyclic bandmatrix a
 c  to upper triangular form and applies the same givens transformations
 c  to the (m) x (mm) x (idim) matrix z to obtain the (n-7) x (mm) x
@@ -16,6 +17,7 @@ c  ..local scalars..
       real*8 co,pinv,piv,si,one
       integer i,irot,it,ii,i2,i3,j,jj,l,mid,nmd,m2,m3,
      * nrold,n4,number,n1,n7,n11,m1
+      integer i1, ij,j1,jk,jper,l0,l1, ik
 c  ..local arrays..
       real*8 h(5),h1(5),h2(4)
 c  ..subroutine references..

--- a/scipy/interpolate/fitpack/insert.f
+++ b/scipy/interpolate/fitpack/insert.f
@@ -1,4 +1,5 @@
-      subroutine insert(iopt,t,n,c,k,x,tt,nn,cc,nest,ier)
+      recursive subroutine insert(iopt,t,n,c,k,x,tt,nn,cc,nest,ier)
+      implicit none
 c  subroutine insert inserts a new knot x into a spline function s(x)
 c  of degree k and calculates the b-spline representation of s(x) with
 c  respect to the new set of knots. in addition, if iopt.ne.0, s(x)

--- a/scipy/interpolate/fitpack/parcur.f
+++ b/scipy/interpolate/fitpack/parcur.f
@@ -1,5 +1,6 @@
-      subroutine parcur(iopt,ipar,idim,m,u,mx,x,w,ub,ue,k,s,nest,n,t,
-     * nc,c,fp,wrk,lwrk,iwrk,ier)
+      recursive subroutine parcur(iopt,ipar,idim,m,u,mx,x,w,ub,ue,k,s,
+     * nest,n,t,nc,c,fp,wrk,lwrk,iwrk,ier)
+      implicit none
 c  given the ordered set of m points x(i) in the idim-dimensional space
 c  and given also a corresponding set of strictly increasing values u(i)
 c  and the set of positive numbers w(i),i=1,2,...,m, subroutine parcur

--- a/scipy/interpolate/fitpack/parder.f
+++ b/scipy/interpolate/fitpack/parder.f
@@ -1,5 +1,6 @@
-      subroutine parder(tx,nx,ty,ny,c,kx,ky,nux,nuy,x,mx,y,my,z,
-     * wrk,lwrk,iwrk,kwrk,ier)
+      recursive subroutine parder(tx,nx,ty,ny,c,kx,ky,nux,nuy,x,mx,
+     * y,my,z,wrk,lwrk,iwrk,kwrk,ier)
+      implicit none
 c  subroutine parder evaluates on a grid (x(i),y(j)),i=1,...,mx; j=1,...
 c  ,my the partial derivative ( order nux,nuy) of a bivariate spline
 c  s(x,y) of degrees kx and ky, given in the b-spline representation.

--- a/scipy/interpolate/fitpack/pardeu.f
+++ b/scipy/interpolate/fitpack/pardeu.f
@@ -1,5 +1,6 @@
-      subroutine pardeu(tx,nx,ty,ny,c,kx,ky,nux,nuy,x,y,z,m,
+      recursive subroutine pardeu(tx,nx,ty,ny,c,kx,ky,nux,nuy,x,y,z,m,
      * wrk,lwrk,iwrk,kwrk,ier)
+      implicit none
 c  subroutine pardeu evaluates on a set of points (x(i),y(i)),i=1,...,m
 c  the partial derivative ( order nux,nuy) of a bivariate spline
 c  s(x,y) of degrees kx and ky, given in the b-spline representation.

--- a/scipy/interpolate/fitpack/pardtc.f
+++ b/scipy/interpolate/fitpack/pardtc.f
@@ -1,4 +1,5 @@
-      subroutine pardtc(tx,nx,ty,ny,c,kx,ky,nux,nuy,newc,ier)
+      recursive subroutine pardtc(tx,nx,ty,ny,c,kx,ky,nux,nuy,
+     *   newc,ier)
       implicit none
 c  subroutine pardtc takes the knots and coefficients of a bivariate
 c  spline, and returns the coefficients for a new bivariate spline that

--- a/scipy/interpolate/fitpack/parsur.f
+++ b/scipy/interpolate/fitpack/parsur.f
@@ -1,5 +1,6 @@
-      subroutine parsur(iopt,ipar,idim,mu,u,mv,v,f,s,nuest,nvest,
-     * nu,tu,nv,tv,c,fp,wrk,lwrk,iwrk,kwrk,ier)
+      recursive subroutine parsur(iopt,ipar,idim,mu,u,mv,v,f,s,nuest,
+     * nvest,nu,tu,nv,tv,c,fp,wrk,lwrk,iwrk,kwrk,ier)
+      implicit none
 c  given the set of ordered points f(i,j) in the idim-dimensional space,
 c  corresponding to grid values (u(i),v(j)) ,i=1,...,mu ; j=1,...,mv,
 c  parsur determines a smooth approximating spline surface s(u,v) , i.e.

--- a/scipy/interpolate/fitpack/percur.f
+++ b/scipy/interpolate/fitpack/percur.f
@@ -1,5 +1,6 @@
-      subroutine percur(iopt,m,x,y,w,k,s,nest,n,t,c,fp,
+      recursive subroutine percur(iopt,m,x,y,w,k,s,nest,n,t,c,fp,
      * wrk,lwrk,iwrk,ier)
+      implicit none
 c  given the set of data points (x(i),y(i)) and the set of positive
 c  numbers w(i),i=1,2,...,m-1, subroutine percur determines a smooth
 c  periodic spline approximation of degree k with period per=x(m)-x(1).

--- a/scipy/interpolate/fitpack/pogrid.f
+++ b/scipy/interpolate/fitpack/pogrid.f
@@ -1,5 +1,6 @@
-      subroutine pogrid(iopt,ider,mu,u,mv,v,z,z0,r,s,nuest,nvest,
-     * nu,tu,nv,tv,c,fp,wrk,lwrk,iwrk,kwrk,ier)
+      recursive subroutine pogrid(iopt,ider,mu,u,mv,v,z,z0,r,s,
+     * nuest,nvest,nu,tu,nv,tv,c,fp,wrk,lwrk,iwrk,kwrk,ier)
+      implicit none
 c  subroutine pogrid fits a function f(x,y) to a set of data points
 c  z(i,j) given at the nodes (x,y)=(u(i)*cos(v(j)),u(i)*sin(v(j))),
 c  i=1,...,mu ; j=1,...,mv , of a radius-angle grid over a disc

--- a/scipy/interpolate/fitpack/polar.f
+++ b/scipy/interpolate/fitpack/polar.f
@@ -1,5 +1,5 @@
-      subroutine polar(iopt,m,x,y,z,w,rad,s,nuest,nvest,eps,nu,tu,
-     *  nv,tv,u,v,c,fp,wrk1,lwrk1,wrk2,lwrk2,iwrk,kwrk,ier)
+      recursive subroutine polar(iopt,m,x,y,z,w,rad,s,nuest,nvest,
+     *  eps,nu,tu,nv,tv,u,v,c,fp,wrk1,lwrk1,wrk2,lwrk2,iwrk,kwrk,ier)
       implicit none
 c  subroutine polar fits a smooth function f(x,y) to a set of data
 c  points (x(i),y(i),z(i)) scattered arbitrarily over an approximation

--- a/scipy/interpolate/fitpack/profil.f
+++ b/scipy/interpolate/fitpack/profil.f
@@ -1,4 +1,5 @@
-      subroutine profil(iopt,tx,nx,ty,ny,c,kx,ky,u,nu,cu,ier)
+      recursive subroutine profil(iopt,tx,nx,ty,ny,c,kx,ky,u,nu,cu,ier)
+      implicit none
 c  if iopt=0 subroutine profil calculates the b-spline coefficients of
 c  the univariate spline f(y) = s(u,y) with s(x,y) a bivariate spline of
 c  degrees kx and ky, given in the b-spline representation.

--- a/scipy/interpolate/fitpack/regrid.f
+++ b/scipy/interpolate/fitpack/regrid.f
@@ -1,5 +1,6 @@
-      subroutine regrid(iopt,mx,x,my,y,z,xb,xe,yb,ye,kx,ky,s,
+      recursive subroutine regrid(iopt,mx,x,my,y,z,xb,xe,yb,ye,kx,ky,s,
      * nxest,nyest,nx,tx,ny,ty,c,fp,wrk,lwrk,iwrk,kwrk,ier)
+      implicit none
 c given the set of values z(i,j) on the rectangular grid (x(i),y(j)),
 c i=1,...,mx;j=1,...,my, subroutine regrid determines a smooth bivar-
 c iate spline approximation s(x,y) of degrees kx and ky on the rect-

--- a/scipy/interpolate/fitpack/spalde.f
+++ b/scipy/interpolate/fitpack/spalde.f
@@ -1,4 +1,5 @@
-      subroutine spalde(t,n,c,k1,x,d,ier)
+      recursive subroutine spalde(t,n,c,k1,x,d,ier)
+      implicit none
 c  subroutine spalde evaluates at a point x all the derivatives
 c              (j-1)
 c      d(j) = s     (x) , j=1,2,...,k1

--- a/scipy/interpolate/fitpack/spgrid.f
+++ b/scipy/interpolate/fitpack/spgrid.f
@@ -1,5 +1,6 @@
-      subroutine spgrid(iopt,ider,mu,u,mv,v,r,r0,r1,s,nuest,nvest,
-     * nu,tu,nv,tv,c,fp,wrk,lwrk,iwrk,kwrk,ier)
+      recursive subroutine spgrid(iopt,ider,mu,u,mv,v,r,r0,r1,s,
+     * nuest,nvest,nu,tu,nv,tv,c,fp,wrk,lwrk,iwrk,kwrk,ier)
+      implicit none
 c  given the function values r(i,j) on the latitude-longitude grid
 c  (u(i),v(j)), i=1,...,mu ; j=1,...,mv , spgrid determines a smooth
 c  bicubic spline approximation on the rectangular domain 0<=u<=pi,

--- a/scipy/interpolate/fitpack/sphere.f
+++ b/scipy/interpolate/fitpack/sphere.f
@@ -1,5 +1,5 @@
-      subroutine sphere(iopt,m,teta,phi,r,w,s,ntest,npest,eps,
-     *  nt,tt,np,tp,c,fp,wrk1,lwrk1,wrk2,lwrk2,iwrk,kwrk,ier)
+      recursive subroutine sphere(iopt,m,teta,phi,r,w,s,ntest,npest,
+     *  eps,nt,tt,np,tp,c,fp,wrk1,lwrk1,wrk2,lwrk2,iwrk,kwrk,ier)
       implicit none
 c  subroutine sphere determines a smooth bicubic spherical spline
 c  approximation s(teta,phi), 0 <= teta <= pi ; 0 <= phi <= 2*pi

--- a/scipy/interpolate/fitpack/splder.f
+++ b/scipy/interpolate/fitpack/splder.f
@@ -1,4 +1,4 @@
-      subroutine splder(t,n,c,k,nu,x,y,m,e,wrk,ier)
+      recursive subroutine splder(t,n,c,k,nu,x,y,m,e,wrk,ier)
       implicit none  
 c  subroutine splder evaluates in a number of points x(i),i=1,2,...,m
 c  the derivative of order nu of a spline s(x) of degree k,given in

--- a/scipy/interpolate/fitpack/splev.f
+++ b/scipy/interpolate/fitpack/splev.f
@@ -1,4 +1,4 @@
-      subroutine splev(t,n,c,k,x,y,m,e,ier)
+      recursive subroutine splev(t,n,c,k,x,y,m,e,ier)
 c  subroutine splev evaluates in a number of points x(i),i=1,2,...,m
 c  a spline s(x) of degree k, given in its b-spline representation.
 c

--- a/scipy/interpolate/fitpack/splint.f
+++ b/scipy/interpolate/fitpack/splint.f
@@ -1,5 +1,6 @@
-      real*8 function splint(t,n,c,k,a,b,wrk)
+      recursive function splint(t,n,c,k,a,b,wrk) result(splint_res)
       implicit none
+      real*8 :: splint_res
 c  function splint calculates the integral of a spline function s(x)
 c  of degree k, which is given in its normalized b-spline representation
 c
@@ -51,9 +52,9 @@ c  calculate the integrals wrk(i) of the normalized b-splines
 c  ni,k+1(x), i=1,2,...nk1.
       call fpintb(t,n,wrk,nk1,a,b)
 c  calculate the integral of s(x).
-      splint = 0.0d0
+      splint_res = 0.0d0
       do 10 i=1,nk1
-        splint = splint+c(i)*wrk(i)
+        splint_res = splint_res+c(i)*wrk(i)
   10  continue
       return
       end

--- a/scipy/interpolate/fitpack/sproot.f
+++ b/scipy/interpolate/fitpack/sproot.f
@@ -1,4 +1,5 @@
-      subroutine sproot(t,n,c,zero,mest,m,ier)
+      recursive subroutine sproot(t,n,c,zero,mest,m,ier)
+      implicit none
 c  subroutine sproot finds the zeros of a cubic spline s(x),which is
 c  given in its normalized b-spline representation.
 c

--- a/scipy/interpolate/fitpack/surev.f
+++ b/scipy/interpolate/fitpack/surev.f
@@ -1,5 +1,6 @@
-      subroutine surev(idim,tu,nu,tv,nv,c,u,mu,v,mv,f,mf,wrk,lwrk,
-     * iwrk,kwrk,ier)
+      recursive subroutine surev(idim,tu,nu,tv,nv,c,u,mu,v,mv,f,mf,
+     * wrk,lwrk,iwrk,kwrk,ier)
+      implicit none
 c  subroutine surev evaluates on a grid (u(i),v(j)),i=1,...,mu; j=1,...
 c  ,mv a bicubic spline surface of dimension idim, given in the
 c  b-spline representation.

--- a/scipy/interpolate/fitpack/surfit.f
+++ b/scipy/interpolate/fitpack/surfit.f
@@ -1,5 +1,7 @@
-      subroutine surfit(iopt,m,x,y,z,w,xb,xe,yb,ye,kx,ky,s,nxest,nyest,
-     *  nmax,eps,nx,tx,ny,ty,c,fp,wrk1,lwrk1,wrk2,lwrk2,iwrk,kwrk,ier)
+      recursive subroutine surfit(iopt,m,x,y,z,w,xb,xe,yb,ye,kx,ky,s,
+     *  nxest,nyest,nmax,eps,nx,tx,ny,ty,c,fp,wrk1,lwrk1,wrk2,lwrk2,
+     *  iwrk,kwrk,ier)
+      implicit none
 c given the set of data points (x(i),y(i),z(i)) and the set of positive
 c numbers w(i),i=1,...,m, subroutine surfit determines a smooth bivar-
 c iate spline approximation s(x,y) of degrees kx and ky on the rect-


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Hopefully closes gh-11828, closes gh-14162

#### What does this implement/fix?
<!--Please explain your changes.-->

Mark FITPACK functions/subroutines `recursive`, as suggested in https://github.com/scipy/scipy/issues/11828#issuecomment-612529411

This change Fortran 90 only, so  it makes SciPy not F77 compliant. It probably was not already anyway, as we dropped F77 a while ago.

I'm also adding `implicit none` to all sources in the same patch. It's likely a bad form to lump two changes into the same patch, but since I've already had 80-odd files open, decided to do it anyway. The only non-trivial fix due to `implicit none` is in `fpcons.f`, which might need checking --- the first thing to check is if we actually use this file: not all of FITPACK is wrapped. But this is for some other day.

#### Additional information
<!--Any additional information you think is important.-->

Threading issues were reported on Windows in gh-11828 and gh-14162, which I cannot test at the moment, so testing on Windows would be great. The OP reports have reproducible code examples, so it's a matter of somebody having access to a windows machine. @thomasaarholt  @unknownUser123456 would be great of you could rerun your code samples. 