### PR TITLE
MAINT: stats: replace `np.var` with `_moment(..., 2)` to warn on constant input

### DIFF
--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3096,7 +3096,8 @@ class TestStudentTest:
     P1_1_g = 1 - (P1_1 / 2)
 
     def test_onesample(self):
-        with suppress_warnings() as sup, np.errstate(invalid="ignore"):
+        with suppress_warnings() as sup, np.errstate(invalid="ignore"), \
+                pytest.warns(RuntimeWarning, match="Precision loss occurred"):
             sup.filter(RuntimeWarning, "Degrees of freedom <= 0 for slice")
             t, p = stats.ttest_1samp(4., 3.)
         assert_(np.isnan(t))
@@ -4007,7 +4008,8 @@ def test_ttest_rel():
     assert_array_almost_equal([t,p],tpr)
 
     # test scalars
-    with suppress_warnings() as sup, np.errstate(invalid="ignore"):
+    with suppress_warnings() as sup, np.errstate(invalid="ignore"), \
+            pytest.warns(RuntimeWarning, match="Precision loss occurred"):
         sup.filter(RuntimeWarning, "Degrees of freedom <= 0 for slice")
         t, p = stats.ttest_rel(4., 3.)
     assert_(np.isnan(t))
@@ -4061,7 +4063,8 @@ def test_ttest_rel():
     assert_raises(ValueError, stats.ttest_rel, x, y, nan_policy='foobar')
 
     # test zero division problem
-    t, p = stats.ttest_rel([0, 0, 0], [1, 1, 1])
+    with pytest.warns(RuntimeWarning, match="Precision loss occurred"):
+        t, p = stats.ttest_rel([0, 0, 0], [1, 1, 1])
     assert_equal((np.abs(t), p), (np.inf, 0))
     with np.errstate(invalid="ignore"):
         assert_equal(stats.ttest_rel([0, 0, 0], [0, 0, 0]), (np.nan, np.nan))
@@ -4195,7 +4198,8 @@ def test_ttest_ind():
                               [t, p])
 
     # test scalars
-    with suppress_warnings() as sup, np.errstate(invalid="ignore"):
+    with suppress_warnings() as sup, np.errstate(invalid="ignore"), \
+            pytest.warns(RuntimeWarning, match="Precision loss occurred"):
         sup.filter(RuntimeWarning, "Degrees of freedom <= 0 for slice")
         t, p = stats.ttest_ind(4., 3.)
     assert_(np.isnan(t))
@@ -4256,7 +4260,8 @@ def test_ttest_ind():
     assert_raises(ValueError, stats.ttest_ind, x, y, nan_policy='foobar')
 
     # test zero division problem
-    t, p = stats.ttest_ind([0, 0, 0], [1, 1, 1])
+    with pytest.warns(RuntimeWarning, match="Precision loss occurred"):
+        t, p = stats.ttest_ind([0, 0, 0], [1, 1, 1])
     assert_equal((np.abs(t), p), (np.inf, 0))
 
     with np.errstate(invalid="ignore"):
@@ -4593,6 +4598,7 @@ class Test_ttest_ind_common:
         with suppress_warnings() as sup, np.errstate(invalid="ignore"):
             sup.filter(RuntimeWarning,
                        "invalid value encountered in less_equal")
+            sup.filter(RuntimeWarning, "Precision loss occurred")
             res = stats.ttest_ind(a, b, axis=axis, **kwds)
         p_nans = np.isnan(res.pvalue)
         assert_array_equal(p_nans, expected)
@@ -4848,7 +4854,8 @@ def test_ttest_ind_with_uneq_var():
     assert_equal(t.shape, (3, 2))
 
     # test zero division problem
-    t, p = stats.ttest_ind([0, 0, 0], [1, 1, 1], equal_var=False)
+    with pytest.warns(RuntimeWarning, match="Precision loss occurred"):
+        t, p = stats.ttest_ind([0, 0, 0], [1, 1, 1], equal_var=False)
     assert_equal((np.abs(t), p), (np.inf, 0))
     with np.errstate(all='ignore'):
         assert_equal(stats.ttest_ind([0, 0, 0], [0, 0, 0], equal_var=False),


### PR DESCRIPTION
#### Reference issue
Closes gh-14418
Follow-up to gh-15905

#### What does this implement/fix?
gh-14418 reported that `ttest_ind` gives unreliable results when input arrays are constant (i.e. contain only one unique value). Ultimately, this is due to catastrophic cancellation when calculating variance. This PR resolves the issue by using `_moment` to calculate the variance (and `_moment` warns when the input data are identical or nearly identical).

```
>>> from scipy.stats import ttest_ind
>>> ttest_ind([0.04]*10, [0.04]*30)
C:\Users\matth\AppData\Local\Temp\ipykernel_50616\217009264.py:1: RuntimeWarning: Precision loss occurred in 
moment calculation due to catastrophic cancellation. This occurs when the data are nearly identical. Results
may be unreliable.
  ttest_ind([0.04]*10, [0.04]*30)
Ttest_indResult(statistic=-5.338539126015656, pvalue=4.591739995593669e-06)
```

#### Additional information
Do we need new unit tests, or is the addition of `pytest.warns` to the existing unit tests OK?

I went ahead and applied the change not only to the tests but also to `describe`. 

`_moment` is slower than `np.var`. For the example above, on `main`:
```
%timeit ttest_ind([0.04]*10, [0.04]*30)  # 85.1 µs ± 472 ns per loop on main, 166 µs ± 1.52 µs per loop in PR
```
For a random array of size 10000, `ttest_1samp` takes ~67 µs in main and 114 µs in the PR.
For a random array of size 100000, `ttest_1samp` takes ~216 µs in main and 335 µs in the PR.

It might be possible to recover some of the time by performing the data constancy check separately, then using `np.var` to calculate the variance. We could also optimize a bit by using the mean, which already needs to be calculated outside of `_var`. (The difficulty with that is that we need the mean with `keepdims=True`.)
