### PR TITLE
MAINT: stats.theilslopes: warn and return `nan` for degenerate input

### DIFF
--- a/scipy/stats/_stats_mstats_common.py
+++ b/scipy/stats/_stats_mstats_common.py
@@ -1,3 +1,4 @@
+import warnings
 import numpy as np
 import scipy.stats._stats_py
 from . import distributions
@@ -317,6 +318,9 @@ def theilslopes(y, x=None, alpha=0.95, method='separate'):
     deltax = x[:, np.newaxis] - x
     deltay = y[:, np.newaxis] - y
     slopes = deltay[deltax > 0] / deltax[deltax > 0]
+    if not slopes.size:
+        msg = "All `x` coordinates are identical."
+        warnings.warn(msg, RuntimeWarning, stacklevel=2)
     slopes.sort()
     medslope = np.median(slopes)
     if method == 'joint':
@@ -338,10 +342,14 @@ def theilslopes(y, x=None, alpha=0.95, method='separate'):
                      sum(k * (k-1) * (2*k + 5) for k in nxreps) -
                      sum(k * (k-1) * (2*k + 5) for k in nyreps))
     # Find the confidence interval indices in `slopes`
-    sigma = np.sqrt(sigsq)
-    Ru = min(int(np.round((nt - z*sigma)/2.)), len(slopes)-1)
-    Rl = max(int(np.round((nt + z*sigma)/2.)) - 1, 0)
-    delta = slopes[[Rl, Ru]]
+    try:
+        sigma = np.sqrt(sigsq)
+        Ru = min(int(np.round((nt - z*sigma)/2.)), len(slopes)-1)
+        Rl = max(int(np.round((nt + z*sigma)/2.)) - 1, 0)
+        delta = slopes[[Rl, Ru]]
+    except (ValueError, IndexError):
+        delta = (np.nan, np.nan)
+
     return medslope, medinter, delta[0], delta[1]
 
 

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -942,6 +942,16 @@ def test_theilslopes():
     assert_almost_equal(lower, 3.71, decimal=2)
 
 
+def test_theilslopes_warnings():
+    # Test `theilslopes` with degenerate input; see gh-15943
+    with pytest.warns(RuntimeWarning, match="All `x` coordinates are..."):
+        res = mstats.theilslopes([0, 1], [0, 0])
+        assert np.all(np.isnan(res))
+    with pytest.warns(RuntimeWarning, match="invalid value encountered..."):
+        res = mstats.theilslopes([0, 0, 0], [0, 1, 0])
+        assert_allclose(res, (0, 0, np.nan, np.nan))
+
+
 def test_siegelslopes():
     # method should be exact for straight line
     y = 2 * np.arange(10) + 0.5


### PR DESCRIPTION
#### Reference issue
Resolves defect of gh-15943 (does not address enhancement)

#### What does this implement/fix?
`theilslopes` errors out with degenerate input. This PR makes `theilslopes` fail more gracefully for the examples in gh-15943. `theilslopes` still raises errors for other types of degenerate input, but those have not been reported as problematic (e.g. one or both inputs empty).

#### Additional information
```
>>> mstats.theilslopes([0, 0, 0], [0, 1, 0])
C:\Users\matth\scipy\scipy\stats\_stats_mstats_common.py:346: RuntimeWarning: invalid value encountered in sqrt
  sigma = np.sqrt(sigsq)
Out[127]: (0.0, 0.0, nan, nan)

>>> mstats.theilslopes([0, 1], [0, 0])
C:\Users\matth\scipy\scipy\stats\_mstats_basic.py:1088: RuntimeWarning: All `x` coordinates are identical.
  return stats_theilslopes(y, x, alpha=alpha, method=method)
C:\Users\matth\anaconda3\envs\scipydev\lib\site-packages\numpy\core\fromnumeric.py:3440: RuntimeWarning: Mean of empty slice.
  return _methods._mean(a, axis=axis, dtype=dtype,
Out[136]: (nan, nan, nan, nan)
```