### PR TITLE
DEV: Fix meson debian python build

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -390,12 +390,12 @@ def get_project_info():
     except ImportError:
         # this may fail when running with --no-build, so try to detect
         # an installed scipy in a subdir inside a repo
-        site_dir = get_installed_path()
+        install_dir = get_installed_path()
         print("Trying to find scipy from development installed "
-              "path at:", site_dir)
-        sys.path.insert(0, site_dir)
+              "path at:", install_dir)
+        sys.path.insert(0, install_dir)
         os.environ['PYTHONPATH'] = \
-            os.pathsep.join((site_dir, os.environ.get('PYTHONPATH', '')))
+            os.pathsep.join((install_dir, os.environ.get('PYTHONPATH', '')))
         test, version, mod_path = runtests.import_module()
     return test, version, mod_path
 
@@ -458,7 +458,7 @@ def install_project(args):
         dist_dir = get_dist_packages(site_dir)
         non_empty = len(os.listdir(PATH_INSTALLED))
         if non_empty and not(
-            os.path.exists(site_dir) or os.path.exists(dist_dir)):
+                os.path.exists(site_dir) or os.path.exists(dist_dir)):
             raise RuntimeError("Can't install in non-empty directory: "
                                f"'{PATH_INSTALLED}'")
     cmd = ["meson", "install", "-C", args.build_dir]

--- a/dev.py
+++ b/dev.py
@@ -171,12 +171,12 @@ def main(argv):
 
     global PATH_INSTALLED
     build_dir = Path(args.build_dir)
-    install_dir = args.install_prefix
-    if not install_dir:
-        install_dir = build_dir.parent / (build_dir.stem + "-install")
+    install_prefix = args.install_prefix
+    if not install_prefix:
+        install_prefix = build_dir.parent / (build_dir.stem + "-install")
     PATH_INSTALLED = os.path.join(
         os.path.abspath(os.path.dirname(__file__)),
-        install_dir
+        install_prefix
     )
 
     if args.win_cp_openblas and platform.system() != 'Windows':

--- a/dev.py
+++ b/dev.py
@@ -50,6 +50,7 @@ else:
 
 import sys
 import os
+import warnings  # noqa: E402
 from pathlib import Path
 import platform
 # the following multiprocessing import is necessary to prevent tests that use
@@ -60,8 +61,10 @@ import multiprocessing
 # distutils is required to infer meson install path
 # if this needs to be replaced for Python 3.12 support and there's no
 # stdlib alternative, use the hack discussed in gh-16058
-from distutils import dist  # noqa: E402
-from distutils.command.install import INSTALL_SCHEMES  # noqa: E402
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    from distutils import dist
+    from distutils.command.install import INSTALL_SCHEMES
 
 # In case we are run from the source directory, we don't want to import the
 # project from there:

--- a/do.py
+++ b/do.py
@@ -97,6 +97,7 @@ class RefguideCheck(Task):
 import os
 import subprocess
 import sys
+import warnings
 import shutil
 import json
 import datetime
@@ -110,8 +111,10 @@ from sysconfig import get_path
 # distutils is required to infer meson install path
 # if this needs to be replaced for Python 3.12 support and there's no
 # stdlib alternative, use CmdAction and the hack discussed in gh-16058
-from distutils import dist
-from distutils.command.install import INSTALL_SCHEMES
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    from distutils import dist
+    from distutils.command.install import INSTALL_SCHEMES
 
 from pathlib import Path
 from collections import namedtuple


### PR DESCRIPTION
#### Reference issue
Closes gh-16054

#### What does this implement/fix?
This is a hacky solution for falling back from site-packages path dir to trying dist-packages path dir in case of debian python based meson build.

cc @rgommers 