### PR TITLE
MAINT,BUG: stats: return nan for constant inputs in skew and kurtosis

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -1129,7 +1129,7 @@ def skew(a, axis=0, bias=True, nan_policy='propagate'):
     m3 = _moment(a, 3, axis, mean=mean)
     with np.errstate(all='ignore'):
         zero = (m2 <= (np.finfo(m2.dtype).resolution * mean.squeeze(axis))**2)
-        vals = np.where(zero, 0, m3 / m2**1.5)
+        vals = np.where(zero, np.nan, m3 / m2**1.5)
     if not bias:
         can_correct = ~zero & (n > 2)
         if can_correct.any():
@@ -1241,7 +1241,7 @@ def kurtosis(a, axis=0, fisher=True, bias=True, nan_policy='propagate'):
     m4 = _moment(a, 4, axis, mean=mean)
     with np.errstate(all='ignore'):
         zero = (m2 <= (np.finfo(m2.dtype).resolution * mean.squeeze(axis))**2)
-        vals = np.where(zero, 0, m4 / m2**2.0)
+        vals = np.where(zero, np.nan, m4 / m2**2.0)
 
     if not bias:
         can_correct = ~zero & (n > 3)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2968,7 +2968,7 @@ class TestMoments:
         # Scalar test case
         with pytest.warns(RuntimeWarning, match="Precision loss occurred"):
             y = stats.skew(self.scalar_testcase)
-            assert_approx_equal(y, 0.0)
+            assert np.isnan(y)
         # sum((testmathworks-mean(testmathworks,axis=0))**3,axis=0) /
         #     ((sqrt(var(testmathworks)*4/5))**3)/5
         y = stats.skew(self.testmathworks)
@@ -3004,20 +3004,20 @@ class TestMoments:
         # exact (gh-13245)
         with pytest.warns(RuntimeWarning, match="Precision loss occurred"):
             a = np.repeat(-0.27829495, 10)
-            assert stats.skew(a) == 0.0
-            assert stats.skew(a * float(2**50)) == 0.0
-            assert stats.skew(a / float(2**50)) == 0.0
-            assert stats.skew(a, bias=False) == 0.0
+            assert np.isnan(stats.skew(a))
+            assert np.isnan(stats.skew(a * float(2**50)))
+            assert np.isnan(stats.skew(a / float(2**50)))
+            assert np.isnan(stats.skew(a, bias=False))
 
             # similarly, from gh-11086:
-            assert stats.skew([14.3]*7) == 0.0
-            assert stats.skew(1 + np.arange(-3, 4)*1e-16) == 0
+            assert np.isnan(stats.skew([14.3]*7))
+            assert np.isnan(stats.skew(1 + np.arange(-3, 4)*1e-16))
 
     def test_kurtosis(self):
         # Scalar test case
         with pytest.warns(RuntimeWarning, match="Precision loss occurred"):
             y = stats.kurtosis(self.scalar_testcase)
-            assert_approx_equal(y, -3.0)
+            assert_approx_equal(y, np.nan)
         #   sum((testcase-mean(testcase,axis=0))**4,axis=0)/((sqrt(var(testcase)*3/4))**4)/4
         #   sum((test2-mean(testmathworks,axis=0))**4,axis=0)/((sqrt(var(testmathworks)*4/5))**4)/5
         #   Set flags for axis = 0 and
@@ -3057,10 +3057,10 @@ class TestMoments:
         # exact (gh-13245)
         a = np.repeat(-0.27829495, 10)
         with pytest.warns(RuntimeWarning, match="Precision loss occurred"):
-            assert stats.kurtosis(a, fisher=False) == 0.0
-            assert stats.kurtosis(a * float(2**50), fisher=False) == 0.0
-            assert stats.kurtosis(a / float(2**50), fisher=False) == 0.0
-            assert stats.kurtosis(a, fisher=False, bias=False) == 0.0
+            assert np.isnan(stats.kurtosis(a, fisher=False))
+            assert np.isnan(stats.kurtosis(a * float(2**50), fisher=False))
+            assert np.isnan(stats.kurtosis(a / float(2**50), fisher=False))
+            assert np.isnan(stats.kurtosis(a, fisher=False, bias=False))
 
     def test_moment_accuracy(self):
         # 'moment' must have a small enough error compared to the slower
@@ -5029,9 +5029,9 @@ class TestDescribe:
         assert_equal(n, 1)
         assert_equal(mm, (4.0, 4.0))
         assert_equal(m, 4.0)
-        assert_(np.isnan(v))
-        assert_array_almost_equal(sk, 0.0, decimal=13)
-        assert_array_almost_equal(kurt, -3.0, decimal=13)
+        assert np.isnan(v)
+        assert np.isnan(sk)
+        assert np.isnan(kurt)
 
     def test_describe_numbers(self):
         x = np.vstack((np.ones((3,4)), np.full((2, 4), 2)))

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3017,7 +3017,7 @@ class TestMoments:
         # Scalar test case
         with pytest.warns(RuntimeWarning, match="Precision loss occurred"):
             y = stats.kurtosis(self.scalar_testcase)
-            assert_approx_equal(y, np.nan)
+            assert np.isnan(y)
         #   sum((testcase-mean(testcase,axis=0))**4,axis=0)/((sqrt(var(testcase)*3/4))**4)/4
         #   sum((test2-mean(testmathworks,axis=0))**4,axis=0)/((sqrt(var(testmathworks)*4/5))**4)/5
         #   Set flags for axis = 0 and


### PR DESCRIPTION
#### Reference issue

Follow up of gh-13254

#### What does this implement/fix?

Return `nan` for near-constant inputs in skew and kurtosis.
