### PR TITLE
DOC: Document QUADPACK routines used in `*quad`

### DIFF
--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -335,7 +335,7 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
     ----------
 
     .. [1] Piessens, Robert; de Doncker-Kapenga, Elise;
-           Uberhuber, Christoph W.; Kahaner, David (1983).
+           Überhuber, Christoph W.; Kahaner, David (1983).
            QUADPACK: A subroutine package for automatic integration.
            Springer-Verlag.
            ISBN 978-3-540-12553-2.
@@ -669,7 +669,7 @@ def dblquad(func, a, b, gfun, hfun, args=(), epsabs=1.49e-8, epsrel=1.49e-8):
     ----------
 
     .. [1] Piessens, Robert; de Doncker-Kapenga, Elise;
-           Uberhuber, Christoph W.; Kahaner, David (1983).
+           Überhuber, Christoph W.; Kahaner, David (1983).
            QUADPACK: A subroutine package for automatic integration.
            Springer-Verlag.
            ISBN 978-3-540-12553-2.
@@ -792,7 +792,7 @@ def tplquad(func, a, b, gfun, hfun, qfun, rfun, args=(), epsabs=1.49e-8,
     ----------
 
     .. [1] Piessens, Robert; de Doncker-Kapenga, Elise;
-           Uberhuber, Christoph W.; Kahaner, David (1983).
+           Überhuber, Christoph W.; Kahaner, David (1983).
            QUADPACK: A subroutine package for automatic integration.
            Springer-Verlag.
            ISBN 978-3-540-12553-2.
@@ -1009,7 +1009,7 @@ def nquad(func, ranges, args=None, opts=None, full_output=False):
     ----------
 
     .. [1] Piessens, Robert; de Doncker-Kapenga, Elise;
-           Uberhuber, Christoph W.; Kahaner, David (1983).
+           Überhuber, Christoph W.; Kahaner, David (1983).
            QUADPACK: A subroutine package for automatic integration.
            Springer-Verlag.
            ISBN 978-3-540-12553-2.

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -23,8 +23,7 @@ class IntegrationWarning(UserWarning):
 def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
          limit=50, points=None, weight=None, wvar=None, wopts=None, maxp1=50,
          limlst=50):
-    """ over infinite intervals. The infinite range is
-        mapped onto a fi
+    """
     Compute a definite integral.
 
     Integrate func from `a` to `b` (possibly infinite interval) using a
@@ -286,7 +285,7 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
     qagie
         handles integration over infinite intervals. The infinite range is
         mapped onto a finite interval and subsequently the same strategy as
-        in QAGS is applied.
+        in ``QAGS`` is applied.
     qagpe
         serves the same purposes as QAGS, but also allows the
         user to provide explicit information about the location
@@ -303,14 +302,14 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
 
         An adaptive subdivision scheme is used in connection
         with an extrapolation procedure, which is a modification
-        of that in QAGS and allows the algorithm to deal with
+        of that in ``QAGS`` and allows the algorithm to deal with
         singularities in :math:`f(x)`.
     qawfe
         calculates the Fourier transform
         :math:`\\int^\\infty_a \\cos(\\omega x)f(x)dx` or
         :math:`\\int^\\infty_a \\sin(\\omega x)f(x)dx`
-        for user-provided :math:`\\omega` and :math:`f`. The procedure of QAWO
-        is applied on successive finite intervals, and convergence
+        for user-provided :math:`\\omega` and :math:`f`. The procedure of
+        ``QAWO`` is applied on successive finite intervals, and convergence
         acceleration by means of the :math:`\\varepsilon`-algorithm is applied
         to the series of integral approximations.
     qawse
@@ -650,9 +649,9 @@ def dblquad(func, a, b, gfun, hfun, args=(), epsabs=1.49e-8, epsrel=1.49e-8):
 
     `quad` calls routines from the FORTRAN library QUADPACK. This section
     provides details on the conditions for each routine to be called and a
-    short description of each routine. For each level of integration qagse
-    is used for finite limits or qagie is used, if either limit (or both!) are
-    infinite. The following provides a short desciption from [1]_ for each
+    short description of each routine. For each level of integration, ``qagse``
+    is used for finite limits or ``qagie`` is used if either limit (or both!)
+    are infinite. The following provides a short description from [1]_ for each
     routine.
 
     qagse
@@ -663,7 +662,7 @@ def dblquad(func, a, b, gfun, hfun, args=(), epsabs=1.49e-8, epsrel=1.49e-8):
     qagie
         handles integration over infinite intervals. The infinite range is
         mapped onto a finite interval and subsequently the same strategy as
-        in QAGS is applied.
+        in ``QAGS`` is applied.
 
     References
     ----------
@@ -773,9 +772,9 @@ def tplquad(func, a, b, gfun, hfun, qfun, rfun, args=(), epsabs=1.49e-8,
 
     `quad` calls routines from the FORTRAN library QUADPACK. This section
     provides details on the conditions for each routine to be called and a
-    short description of each routine. For each level of integration qagse
-    is used for finite limits or qagie is used, if either limit (or both!) are
-    infinite. The following provides a short desciption from [1]_ for each
+    short description of each routine. For each level of integration, ``qagse``
+    is used for finite limits or ``qagie`` is used, if either limit (or both!)
+    are infinite. The following provides a short description from [1]_ for each
     routine.
 
     qagse
@@ -786,7 +785,7 @@ def tplquad(func, a, b, gfun, hfun, qfun, rfun, args=(), epsabs=1.49e-8,
     qagie
         handles integration over infinite intervals. The infinite range is
         mapped onto a finite interval and subsequently the same strategy as
-        in QAGS is applied.
+        in ``QAGS`` is applied.
 
     References
     ----------
@@ -930,6 +929,9 @@ def nquad(func, ranges, args=None, opts=None, full_output=False):
     fixed_quad : fixed-order Gaussian quadrature
     quadrature : adaptive Gaussian quadrature
 
+    Notes
+    -----
+
     **Details of QUADPACK level routines**
 
     `nquad` calls routines from the FORTRAN library QUADPACK. This section
@@ -960,7 +962,7 @@ def nquad(func, ranges, args=None, opts=None, full_output=False):
     qagie
         handles integration over infinite intervals. The infinite range is
         mapped onto a finite interval and subsequently the same strategy as
-        in QAGS is applied.
+        in ``QAGS`` is applied.
     qagpe
         serves the same purposes as QAGS, but also allows the
         user to provide explicit information about the location
@@ -977,14 +979,14 @@ def nquad(func, ranges, args=None, opts=None, full_output=False):
 
         An adaptive subdivision scheme is used in connection
         with an extrapolation procedure, which is a modification
-        of that in QAGS and allows the algorithm to deal with
+        of that in ``QAGS`` and allows the algorithm to deal with
         singularities in :math:`f(x)`.
     qawfe
         calculates the Fourier transform
         :math:`\int^\infty_a \cos(\omega x)f(x)dx` or
         :math:`\int^\infty_a \sin(\omega x)f(x)dx`
-        for user-provided :math:`\omega` and :math:`f`. The procedure of QAWO
-        is applied on successive finite intervals, and convergence
+        for user-provided :math:`\omega` and :math:`f`. The procedure of
+        ``QAWO`` is applied on successive finite intervals, and convergence
         acceleration by means of the :math:`\varepsilon`-algorithm is applied
         to the series of integral approximations.
     qawse

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -23,7 +23,8 @@ class IntegrationWarning(UserWarning):
 def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
          limit=50, points=None, weight=None, wvar=None, wopts=None, maxp1=50,
          limlst=50):
-    """
+    """ over infinite intervals. The infinite range is
+        mapped onto a fi
     Compute a definite integral.
 
     Integrate func from `a` to `b` (possibly infinite interval) using a
@@ -641,6 +642,38 @@ def dblquad(func, a, b, gfun, hfun, args=(), epsabs=1.49e-8, epsrel=1.49e-8):
     romb : integrator for sampled data
     scipy.special : for coefficients and roots of orthogonal polynomials
 
+
+    Notes
+    -----
+
+    **Details of QUADPACK level routines**
+
+    `quad` calls routines from the FORTRAN library QUADPACK. This section
+    provides details on the conditions for each routine to be called and a
+    short description of each routine. For each level of integration qagse
+    is used for finite limits or qagie is used, if either limit (or both!) are
+    infinite. The following provides a short desciption from [1]_ for each
+    routine.
+
+    qagse
+        is an integrator based on globally adaptive interval
+        subdivision in connection with extrapolation, which will
+        eliminate the effects of integrand singularities of
+        several types.
+    qagie
+        handles integration over infinite intervals. The infinite range is
+        mapped onto a finite interval and subsequently the same strategy as
+        in QAGS is applied.
+
+    References
+    ----------
+
+    .. [1] Piessens, Robert; de Doncker-Kapenga, Elise;
+           Uberhuber, Christoph W.; Kahaner, David (1983).
+           QUADPACK: A subroutine package for automatic integration.
+           Springer-Verlag.
+           ISBN 978-3-540-12553-2.
+
     Examples
     --------
     Compute the double integral of ``x * y**2`` over the box
@@ -732,6 +765,37 @@ def tplquad(func, a, b, gfun, hfun, qfun, rfun, args=(), epsabs=1.49e-8,
     ode : ODE integrators
     odeint : ODE integrators
     scipy.special : For coefficients and roots of orthogonal polynomials
+
+    Notes
+    -----
+
+    **Details of QUADPACK level routines**
+
+    `quad` calls routines from the FORTRAN library QUADPACK. This section
+    provides details on the conditions for each routine to be called and a
+    short description of each routine. For each level of integration qagse
+    is used for finite limits or qagie is used, if either limit (or both!) are
+    infinite. The following provides a short desciption from [1]_ for each
+    routine.
+
+    qagse
+        is an integrator based on globally adaptive interval
+        subdivision in connection with extrapolation, which will
+        eliminate the effects of integrand singularities of
+        several types.
+    qagie
+        handles integration over infinite intervals. The infinite range is
+        mapped onto a finite interval and subsequently the same strategy as
+        in QAGS is applied.
+
+    References
+    ----------
+
+    .. [1] Piessens, Robert; de Doncker-Kapenga, Elise;
+           Uberhuber, Christoph W.; Kahaner, David (1983).
+           QUADPACK: A subroutine package for automatic integration.
+           Springer-Verlag.
+           ISBN 978-3-540-12553-2.
 
     Examples
     --------
@@ -865,6 +929,90 @@ def nquad(func, ranges, args=None, opts=None, full_output=False):
     dblquad, tplquad : double and triple integrals
     fixed_quad : fixed-order Gaussian quadrature
     quadrature : adaptive Gaussian quadrature
+
+    **Details of QUADPACK level routines**
+
+    `nquad` calls routines from the FORTRAN library QUADPACK. This section
+    provides details on the conditions for each routine to be called and a
+    short description of each routine. The routine called depends on
+    `weight`, `points` and the integration limits `a` and `b`.
+
+    ================  ==============  ==========  =====================
+    QUADPACK routine  `weight`        `points`    infinite bounds
+    ================  ==============  ==========  =====================
+    qagse             None            No          No
+    qagie             None            No          Yes
+    qagpe             None            Yes         No
+    qawoe             'sin', 'cos'    No          No
+    qawfe             'sin', 'cos'    No          either `a` or `b`
+    qawse             'alg*'          No          No
+    qawce             'cauchy'        No          No
+    ================  ==============  ==========  =====================
+
+    The following provides a short desciption from [1]_ for each
+    routine.
+
+    qagse
+        is an integrator based on globally adaptive interval
+        subdivision in connection with extrapolation, which will
+        eliminate the effects of integrand singularities of
+        several types.
+    qagie
+        handles integration over infinite intervals. The infinite range is
+        mapped onto a finite interval and subsequently the same strategy as
+        in QAGS is applied.
+    qagpe
+        serves the same purposes as QAGS, but also allows the
+        user to provide explicit information about the location
+        and type of trouble-spots i.e. the abscissae of internal
+        singularities, discontinuities and other difficulties of
+        the integrand function.
+    qawoe
+        is an integrator for the evaluation of
+        :math:`\\int^b_a \\cos(\\omega x)f(x)dx` or
+        :math:`\\int^b_a \\sin(\\omega x)f(x)dx`
+        over a finite interval [a,b], where :math:`\\omega` and :math:`f`
+        are specified by the user. The rule evaluation component is based
+        on the modified Clenshaw-Curtis technique
+
+        An adaptive subdivision scheme is used in connection
+        with an extrapolation procedure, which is a modification
+        of that in QAGS and allows the algorithm to deal with
+        singularities in :math:`f(x)`.
+    qawfe
+        calculates the Fourier transform
+        :math:`\\int^\\infty_a \\cos(\\omega x)f(x)dx` or
+        :math:`\\int^\\infty_a \\sin(\\omega x)f(x)dx`
+        for user-provided :math:`\\omega` and :math:`f`. The procedure of QAWO
+        is applied on successive finite intervals, and convergence
+        acceleration by means of the :math:`\\varepsilon`-algorithm is applied
+        to the series of integral approximations.
+    qawse
+        approximate :math:`\\int^b_a w(x)f(x)dx`, with :math:`a < b` where
+        :math:`w(x) = (x-a)^{\\alpha}(b-x)^{\\beta}v(x)` with
+        :math:`\\alpha,\\beta > -1`, where :math:`v(x)` may be one of the
+        following functions: :math:`1`, :math:`\\log(x-a)`, :math:`\\log(b-x)`,
+        :math:`\\log(x-a)\\log(b-x)`.
+
+        The user specifies :math:`\\alpha`, :math:`\\beta` and the type of the
+        function :math:`v`. A globally adaptive subdivision strategy is
+        applied, with modified Clenshaw-Curtis integration on those
+        subintervals which contain `a` or `b`.
+    qawce
+        compute :math:`\\int^b_a f(x) / (x-c)dx` where the integral must be
+        interpreted as a Cauchy principal value integral, for user specified
+        :math:`c` and :math:`f`. The strategy is globally adaptive. Modified
+        Clenshaw-Curtis integration is used on those intervals containing the
+        point :math:`x = c`.
+
+    References
+    ----------
+
+    .. [1] Piessens, Robert; de Doncker-Kapenga, Elise;
+           Uberhuber, Christoph W.; Kahaner, David (1983).
+           QUADPACK: A subroutine package for automatic integration.
+           Springer-Verlag.
+           ISBN 978-3-540-12553-2.
 
     Examples
     --------

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -969,9 +969,9 @@ def nquad(func, ranges, args=None, opts=None, full_output=False):
         the integrand function.
     qawoe
         is an integrator for the evaluation of
-        :math:`\\int^b_a \\cos(\\omega x)f(x)dx` or
-        :math:`\\int^b_a \\sin(\\omega x)f(x)dx`
-        over a finite interval [a,b], where :math:`\\omega` and :math:`f`
+        :math:`\int^b_a \cos(\omega x)f(x)dx` or
+        :math:`\int^b_a \sin(\omega x)f(x)dx`
+        over a finite interval [a,b], where :math:`\omega` and :math:`f`
         are specified by the user. The rule evaluation component is based
         on the modified Clenshaw-Curtis technique
 
@@ -981,25 +981,25 @@ def nquad(func, ranges, args=None, opts=None, full_output=False):
         singularities in :math:`f(x)`.
     qawfe
         calculates the Fourier transform
-        :math:`\\int^\\infty_a \\cos(\\omega x)f(x)dx` or
-        :math:`\\int^\\infty_a \\sin(\\omega x)f(x)dx`
-        for user-provided :math:`\\omega` and :math:`f`. The procedure of QAWO
+        :math:`\int^\infty_a \cos(\omega x)f(x)dx` or
+        :math:`\int^\infty_a \sin(\omega x)f(x)dx`
+        for user-provided :math:`\omega` and :math:`f`. The procedure of QAWO
         is applied on successive finite intervals, and convergence
-        acceleration by means of the :math:`\\varepsilon`-algorithm is applied
+        acceleration by means of the :math:`\varepsilon`-algorithm is applied
         to the series of integral approximations.
     qawse
-        approximate :math:`\\int^b_a w(x)f(x)dx`, with :math:`a < b` where
-        :math:`w(x) = (x-a)^{\\alpha}(b-x)^{\\beta}v(x)` with
-        :math:`\\alpha,\\beta > -1`, where :math:`v(x)` may be one of the
-        following functions: :math:`1`, :math:`\\log(x-a)`, :math:`\\log(b-x)`,
-        :math:`\\log(x-a)\\log(b-x)`.
+        approximate :math:`\int^b_a w(x)f(x)dx`, with :math:`a < b` where
+        :math:`w(x) = (x-a)^{\alpha}(b-x)^{\beta}v(x)` with
+        :math:`\alpha,\beta > -1`, where :math:`v(x)` may be one of the
+        following functions: :math:`1`, :math:`\log(x-a)`, :math:`\log(b-x)`,
+        :math:`\log(x-a)\log(b-x)`.
 
-        The user specifies :math:`\\alpha`, :math:`\\beta` and the type of the
+        The user specifies :math:`\alpha`, :math:`\beta` and the type of the
         function :math:`v`. A globally adaptive subdivision strategy is
         applied, with modified Clenshaw-Curtis integration on those
         subintervals which contain `a` or `b`.
     qawce
-        compute :math:`\\int^b_a f(x) / (x-c)dx` where the integral must be
+        compute :math:`\int^b_a f(x) / (x-c)dx` where the integral must be
         interpreted as a Cauchy principal value integral, for user specified
         :math:`c` and :math:`f`. The strategy is globally adaptive. Modified
         Clenshaw-Curtis integration is used on those intervals containing the


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
closes gh-13872

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR adds additional documentation of the QUADPACK routines used in `dblquad`, `tplquad` and `nquad`. It is very similar to gh-16043.

#### Additional information
<!--Any additional information you think is important.-->
