### PR TITLE
ENH: Add missing "characteristic impedance of vacuum"

### DIFF
--- a/scipy/constants/_codata.py
+++ b/scipy/constants/_codata.py
@@ -1718,14 +1718,6 @@ exact_values = {
     'joule-kilogram relationship': (1 / (c * c), 'kg', 0.0),
     'kilogram-joule relationship': (c * c, 'J', 0.0),
     'hertz-inverse meter relationship': (1 / c, 'm^-1', 0.0),
-
-    # The following derived quantities are no longer exact (CODATA2018):
-    # specify separately
-    'characteristic impedance of vacuum': (
-        sqrt(mu0 / epsilon0), 'ohm',
-        sqrt(mu0 / epsilon0) * 0.5 * (
-            physical_constants['vacuum mag. permeability'][2] / mu0
-            + physical_constants['vacuum electric permittivity'][2] / epsilon0))
 }
 
 # sanity check

--- a/scipy/constants/_codata.py
+++ b/scipy/constants/_codata.py
@@ -1194,6 +1194,7 @@ Boltzmann constant                                          1.380 649 e-23      
 Boltzmann constant in eV/K                                  8.617 333 262... e-5     (exact)                  eV K^-1
 Boltzmann constant in Hz/K                                  2.083 661 912... e10     (exact)                  Hz K^-1
 Boltzmann constant in inverse meter per kelvin              69.503 480 04...         (exact)                  m^-1 K^-1
+characteristic impedance of vacuum                          376.730 313 668          0.000 000 057            ohm
 classical electron radius                                   2.817 940 3262 e-15      0.000 000 0013 e-15      m
 Compton wavelength                                          2.426 310 238 67 e-12    0.000 000 000 73 e-12    m
 conductance quantum                                         7.748 091 729... e-5     (exact)                  S


### PR DESCRIPTION
#### Reference issue
Closes gh-16068

#### What does this implement/fix?
The constant "characteristic impedance of vacuum" was not listed on the imported website during gh-10920 (see https://github.com/scipy/scipy/issues/16068#issuecomment-1113468924)
