### PR TITLE
DOC: expand RegularGridInterpolator docstring

### DIFF
--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -2350,7 +2350,7 @@ class NdPPoly:
 
 class RegularGridInterpolator:
     """
-    Interpolation on a regular grid in arbitrary dimensions
+    Interpolation on a regular grid in arbitrary dimensions.
 
     The data must be defined on a regular grid; the grid spacing however may be
     uneven. Linear and nearest-neighbor interpolation are supported. After
@@ -2374,11 +2374,12 @@ class RegularGridInterpolator:
         If True, when interpolated values are requested outside of the
         domain of the input data, a ValueError is raised.
         If False, then `fill_value` is used.
+        Default is True.
 
-    fill_value : number, optional
-        If provided, the value to use for points outside of the
-        interpolation domain. If None, values outside
-        the domain are extrapolated.
+    fill_value : float or None, optional
+        The value to use for points outside of the interpolation domain.
+        If None, values outside the domain are extrapolated.
+        Default is ``np.nan``.
 
     Methods
     -------
@@ -2386,9 +2387,12 @@ class RegularGridInterpolator:
 
     Notes
     -----
-    Contrary to LinearNDInterpolator and NearestNDInterpolator, this class
+    Contrary to `LinearNDInterpolator` and `NearestNDInterpolator`, this class
     avoids expensive triangulation of the input data by taking advantage of the
     regular grid structure.
+
+    In other words, this class assumes that the data is defined on a
+    *rectilinear* grid.
 
     If any of `points` have a dimension of size 1, linear interpolation will
     return an array of `nan` values. Nearest-neighbor interpolation will work
@@ -2409,27 +2413,31 @@ class RegularGridInterpolator:
     >>> xg, yg ,zg = np.meshgrid(x, y, z, indexing='ij', sparse=True)
     >>> data = f(xg, yg, zg)
 
-    ``data`` is now a 3-D array with ``data[i,j,k] = f(x[i], y[j], z[k])``.
+    ``data`` is now a 3-D array with ``data[i, j, k] = f(x[i], y[j], z[k])``.
     Next, define an interpolating function from this data:
 
-    >>> my_interpolating_function = RegularGridInterpolator((x, y, z), data)
+    >>> interp = RegularGridInterpolator((x, y, z), data)
 
     Evaluate the interpolating function at the two points
     ``(x,y,z) = (2.1, 6.2, 8.3)`` and ``(3.3, 5.2, 7.1)``:
 
-    >>> pts = np.array([[2.1, 6.2, 8.3], [3.3, 5.2, 7.1]])
-    >>> my_interpolating_function(pts)
+    >>> pts = np.array([[2.1, 6.2, 8.3],
+    ...                 [3.3, 5.2, 7.1]])
+    >>> interp(pts)
     array([ 125.80469388,  146.30069388])
 
-    which is indeed a close approximation to
-    ``[f(2.1, 6.2, 8.3), f(3.3, 5.2, 7.1)]``.
+    which is indeed a close approximation to 
+
+    >>> f(2.1, 6.2, 8.3), f(3.3, 5.2, 7.1)
+    (125.54200000000002, 145.894)
+
 
     See also
     --------
-    NearestNDInterpolator : Nearest neighbor interpolation on unstructured
+    NearestNDInterpolator : Nearest neighbor interpolation on *unstructured*
                             data in N dimensions
 
-    LinearNDInterpolator : Piecewise linear interpolant on unstructured data
+    LinearNDInterpolator : Piecewise linear interpolant on *unstructured* data
                            in N dimensions
 
     References
@@ -2442,6 +2450,7 @@ class RegularGridInterpolator:
            and multilinear table interpolation in many dimensions." MATH.
            COMPUT. 50.181 (1988): 189-196.
            https://www.ams.org/journals/mcom/1988-50-181/S0025-5718-1988-0917826-0/S0025-5718-1988-0917826-0.pdf
+           :doi:`10.1090/S0025-5718-1988-0917826-0`
 
     """
     # this class is based on code originally programmed by Johannes Buchner,

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -2385,6 +2385,21 @@ class RegularGridInterpolator:
     -------
     __call__
 
+    Attributes
+    ----------
+    grid : tuple of ndarrays
+        The points defining the regular grid in n dimensions.
+        This tuple defines the full grid via
+        ``np.meshgrid(*grid, indexing='ij')``
+    values : ndarray
+        Data values at the grid.
+    method : str
+        Interpolation method.
+    fill_value : float or ``None``
+        Use this value for out-of-bounds arguments to `__call__`.
+    bounds_error : bool
+        If ``True``, out-of-bounds argument raise a ``ValueError``.
+
     Notes
     -----
     Contrary to `LinearNDInterpolator` and `NearestNDInterpolator`, this class

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -2531,17 +2531,39 @@ class RegularGridInterpolator:
 
     def __call__(self, xi, method=None):
         """
-        Interpolation at coordinates
+        Interpolation at coordinates.
 
         Parameters
         ----------
         xi : ndarray of shape (..., ndim)
-            The coordinates to sample the gridded data at
+            The coordinates to evaluate the interpolator at.
 
         method : str
             The method of interpolation to perform. Supported are "linear" and
             "nearest".
 
+        Examples
+        --------
+        Here we define a nearest-neighbor interpolator of a simple function
+
+        >>> x, y = np.array([0, 1, 2]), np.array([1, 3, 7])
+        >>> def f(x, y):
+        ...     return x**2 + y**2
+        >>> data = f(*np.meshgrid(x, y, indexing='ij', sparse=True))
+        >>> from scipy.interpolate import RegularGridInterpolator
+        >>> interp = RegularGridInterpolator((x, y), data, method='nearest')
+
+        By construction, the interpolator uses the nearest-neighbor
+        interpolation
+
+        >>> interp([[1.5, 1.3], [0.3, 4.5]])
+        array([2., 9.])
+
+        We can however evaluate the linear interpolant by overriding the
+        `method` parameter
+
+        >>> interp([[1.5, 1.3], [0.3, 4.5]], method='linear')
+        array([ 4.7, 24.3])
         """
         method = self.method if method is None else method
         if method not in ["linear", "nearest"]:

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -2426,11 +2426,10 @@ class RegularGridInterpolator:
     >>> interp(pts)
     array([ 125.80469388,  146.30069388])
 
-    which is indeed a close approximation to 
+    which is indeed a close approximation to
 
     >>> f(2.1, 6.2, 8.3), f(3.3, 5.2, 7.1)
     (125.54200000000002, 145.894)
-
 
     As a second example, we interpolate and extrapolate a 2D data:
 
@@ -2446,7 +2445,8 @@ class RegularGridInterpolator:
     >>> import matplotlib.pyplot as plt
     >>> fig = plt.figure()
     >>> ax = fig.add_subplot(projection='3d')
-    >>> ax.scatter(xg.ravel(), yg.ravel(), data.ravel(), s=60, c='k', label='data')
+    >>> ax.scatter(xg.ravel(), yg.ravel(), data.ravel(),
+    ...            s=60, c='k', label='data')
 
     Evaluate and plot the interpolator on a finer grid
 
@@ -2462,7 +2462,6 @@ class RegularGridInterpolator:
     >>> ax.plot_wireframe(X, Y, ff(X, Y), rstride=3, cstride=3,
     ...                   alpha=0.4, label='ground truth')
     >>> plt.legend()
-
 
     See also
     --------

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -2660,6 +2660,9 @@ def interpn(points, values, xi, method="linear", bounds_error=True,
     """
     Multidimensional interpolation on regular grids.
 
+    Strictly speaking, not all regular grids are supported, and this function
+    works on *rectilinear* grids.
+
     Parameters
     ----------
     points : tuple of ndarray of float, with shapes (m1, ), ..., (mn, )

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -2432,6 +2432,38 @@ class RegularGridInterpolator:
     (125.54200000000002, 145.894)
 
 
+    As a second example, we interpolate and extrapolate a 2D data:
+
+    >>> x, y = np.array([-2, 0, 4]), np.array([-2, 0, 2, 5])
+    >>> def ff(x, y):
+    ...     return x**2 + y**2
+
+    >>> xg, yg = np.meshgrid(x, y, indexing='ij')
+    >>> data = ff(xg, yg)
+    >>> interp = RegularGridInterpolator((x, y), data,
+    ...                                  bounds_error=False, fill_value=None)
+
+    >>> import matplotlib.pyplot as plt
+    >>> fig = plt.figure()
+    >>> ax = fig.add_subplot(projection='3d')
+    >>> ax.scatter(xg.ravel(), yg.ravel(), data.ravel(), s=60, c='k', label='data')
+
+    Evaluate and plot the interpolator on a finer grid
+
+    >>> xx = np.linspace(-4, 9, 31)
+    >>> yy = np.linspace(-4, 9, 31)
+    >>> X, Y = np.meshgrid(xx, yy, indexing='ij')
+
+    >>> # interpolator
+    >>> ax.plot_wireframe(X, Y, interp((X, Y)), rstride=3, cstride=3,
+    ...                   alpha=0.4, color='m', label='linear interp')
+
+    >>> # ground truth
+    >>> ax.plot_wireframe(X, Y, ff(X, Y), rstride=3, cstride=3,
+    ...                   alpha=0.4, label='ground truth')
+    >>> plt.legend()
+
+
     See also
     --------
     NearestNDInterpolator : Nearest neighbor interpolation on *unstructured*


### PR DESCRIPTION
#### What does this implement/fix?
<!--Please explain your changes.-->

Expand the docstring examples of RegularGridInterpolator, stress the `fill_value = None` being the extrapolation mode, add a docstring example to the `__call__` method docstring.

#### Additional information
<!--Any additional information you think is important.-->

Also mention the Rectilinear / Rectangular grid naming issue, so that this PR hopefully closes https://github.com/scipy/scipy/issues/14926.

While technically, what this class assumes is, uhm, recilinear grids (did not know the word before gh-14926), and that not all regular grids are supported (bcc / fcc lattices etc), I believe that
- it's way too late to rename the class
- adding an alias is also not desired (API surface)
- the issue is best addressed as a doc issue, which this PR tries to do. If someone has suggestions for a better wording, that would be most welcome. 

[ci skip] [skip ci]