### PR TITLE
CI: Fix refguidecheck failures; unpin Sphinx

### DIFF
--- a/ci/azure-travis-template.yaml
+++ b/ci/azure-travis-template.yaml
@@ -82,7 +82,7 @@ steps:
   - script: pip install pytest-cov coverage codecov
     displayName: 'Install coverage dependencies'
 - ${{ if eq(parameters.refguide_check, true) }}:
-  - script: pip install matplotlib sphinx==3.1 numpydoc
+  - script: pip install matplotlib sphinx numpydoc
     displayName: 'Install documentation dependencies'
   - script: sudo apt-get install -y wamerican-small
     displayName: 'Install word list (for csgraph tutorial)'

--- a/environment.yml
+++ b/environment.yml
@@ -27,7 +27,7 @@ dependencies:
   - typing_extensions
   # For building docs
   - sphinx
-  - numpydoc=1.1.0
+  - numpydoc
   - ipython
   - matplotlib
   - pydata-sphinx-theme>=0.8.1

--- a/environment_meson.yml
+++ b/environment_meson.yml
@@ -30,7 +30,7 @@ dependencies:
   - typing_extensions
   # For building docs
   - sphinx
-  - numpydoc=1.1.0
+  - numpydoc
   - ipython
   - matplotlib
   - pydata-sphinx-theme>=0.8.1


### PR DESCRIPTION
#### Reference issue
Closes gh-16074

#### What does this implement/fix?
Removing `3.1` pin on `sphinx`.

Besides I'm also using this opportunity to clean up numpydoc pin in environment.yml & environment_meson.yml which was removed earlier last month in #15443. Note that this has nothing to do with the fix for #16074.