### PR TITLE
BUG: interpolate: RGI(nan) is nan

### DIFF
--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -2535,7 +2535,7 @@ class RegularGridInterpolator:
         xi = xi.reshape(-1, xi_shape[-1])
 
         # find nans in input
-        nans = [np.isnan(v).any() for v in xi]
+        nans = np.any(np.isnan(xi), axis=-1)
 
         if self.bounds_error:
             for i, p in enumerate(xi.T):

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -2516,6 +2516,9 @@ class RegularGridInterpolator:
         xi_shape = xi.shape
         xi = xi.reshape(-1, xi_shape[-1])
 
+        # find nans in input
+        nans = [np.isnan(v).any() for v in xi]
+
         if self.bounds_error:
             for i, p in enumerate(xi.T):
                 if not np.logical_and(np.all(self.grid[i][0] <= p),
@@ -2535,6 +2538,9 @@ class RegularGridInterpolator:
         if not self.bounds_error and self.fill_value is not None:
             result[out_of_bounds] = self.fill_value
 
+        # f(nan) = nan, if any
+        if np.any(nans):
+            result[nans] = np.nan
         return result.reshape(xi_shape[:-1] + self.values.shape[ndim:])
 
     def _evaluate_linear(self, indices, norm_distances, out_of_bounds):

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -2616,6 +2616,67 @@ class TestRegularGridInterpolator:
         RegularGridInterpolator(points, values)
         RegularGridInterpolator(points, values, fill_value=0.)
 
+    def test_length_one_axis(self):
+        # gh-5890, gh-9524 : length-1 axis is legal for method='linear'.
+        # Along the axis it's linear interpolation; away from the length-1 axis,
+        # it's an extrapolation, so fill_value should be used.
+        def f(x, y):
+            return x + y
+        x = np.linspace(1, 1, 1)
+        y = np.linspace(1, 10, 10)
+        data = f(*np.meshgrid(x, y, indexing="ij", sparse=True))
+
+        interp = RegularGridInterpolator((x, y), data, method="linear",
+                                          bounds_error=False, fill_value=101)
+
+        # check values at the grid
+        assert_allclose(interp(np.array([[1, 1], [1, 5], [1, 10]])),
+                        [2, 6, 11],
+                        atol=1e-14)
+
+        # check off-grid interpolation is indeed linear
+        assert_allclose(interp(np.array([[1, 1.4], [1, 5.3], [1, 10]])),
+                        [2.4, 6.3, 11],
+                        atol=1e-14)
+
+        # check exrapolation w/ fill_value
+        assert_allclose(interp(np.array([1.1, 2.4])),
+                        interp.fill_value,
+                        atol=1e-14)
+
+        # check actual extrapolation: linear along the `y` axis, const along `x`
+        interp.fill_value = None
+        assert_allclose(interp([[1, 0.3], [1, 11.5]]),
+                        [1.3, 12.5], atol=1e-15)
+
+        assert_allclose(interp([[1.5, 0.3], [1.9, 11.5]]),
+                        [1.3, 12.5], atol=1e-15)
+
+        # extrapolation with method='nearest'
+        interp = RegularGridInterpolator((x, y), data, method="nearest",
+                                          bounds_error=False, fill_value=None)
+        assert_allclose(interp([[1.5, 1.8], [-4, 5.1]]),
+                               [3, 6], atol=1e-15)
+
+    def test_nan_x_1d(self):
+        # gh-6624 : if x is nan, result should be nan
+        f = RegularGridInterpolator(([1, 2, 3],), [10, 20, 30],
+                                    bounds_error=False, method='nearest')
+        assert np.isnan(f([np.nan]))
+
+    def test_nan_x_2d(self):
+        x, y = np.array([0, 1, 2]), np.array([1, 3, 7])
+        def f(x, y):
+            return x**2 + y**2
+        xg, yg = np.meshgrid(x, y, indexing='ij', sparse=True)
+        data = f(xg, yg)
+        interp = RegularGridInterpolator((x, y), data,
+                                         method='nearest', bounds_error=False)
+
+        res = interp([[1.5, np.nan], [1, 1]])
+        assert_allclose(res[1], 2, atol=1e-14 )
+        assert np.isnan(res[0])
+
     def test_broadcastable_input(self):
         # input data
         np.random.seed(0)
@@ -2890,3 +2951,27 @@ class TestInterpN:
             v1 = interpn((x, y), values, sample, method=method)
             v2 = interpn((x, y), np.asarray(values), sample, method=method)
             assert_allclose(v1, v2)
+
+    def test_length_one_axis(self):
+        # gh-5890, gh-9524 : length-1 axis is legal for method='linear'.
+        # Along the axis it's linear interpolation; away from the length-1 axis,
+        # it's an extrapolation, so fill_value should be used.
+
+        values = np.array([[0.1, 1, 10]])
+        xi = np.array([[1, 2.2], [1, 3.2], [1, 3.8]])
+
+        res = interpn(([1], [2, 3, 4]), values, xi)
+        wanted = [0.9*0.2 + 0.1,   # on [2, 3) it's 0.9*(x-2) + 0.1
+                  9*0.2 + 1,       # on [3, 4] it's 9*(x-3) + 1
+                  9*0.8 + 1
+                 ]
+
+        assert_allclose(res, wanted, atol=1e-15)
+
+        # check extrapolation
+        xi = np.array([[1.1, 2.2], [1.5, 3.2], [-2.3, 3.8]])
+        res = interpn(([1], [2, 3, 4]), values, xi,
+                      bounds_error=False, fill_value=None)
+
+        assert_allclose(res, wanted, atol=1e-15)
+

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -2756,7 +2756,13 @@ class TestRegularGridInterpolator:
         x = rng.random(size=100)*4
         i = rng.random(size=100) > 0.5
         x[i] = np.nan
-        res = f(x)
+        with np.errstate(invalid='ignore'):
+            # out-of-bounds comparisons, `out_of_bounds += x < grid[0]`,
+            # generate numpy warnings if `x` contains nans.
+            # These warnings should propagate to user (since `x` is user
+            # input) and we simply filter them out.
+            res = f(x)
+
         assert_equal(res[i], np.nan)
         assert_equal(res[~i], f(x[~i]))
 
@@ -2786,7 +2792,13 @@ class TestRegularGridInterpolator:
         x[i1] = np.nan
         y[i2] = np.nan
         z = np.array([x, y]).T
-        res = interp(z)
+        with np.errstate(invalid='ignore'):
+            # out-of-bounds comparisons, `out_of_bounds += x < grid[0]`,
+            # generate numpy warnings if `x` contains nans.
+            # These warnings should propagate to user (since `x` is user
+            # input) and we simply filter them out.
+            res = interp(z)
+
         assert_equal(res[i], np.nan)
         assert_equal(res[~i], interp(z[~i]))
 

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -2763,15 +2763,17 @@ class TestRegularGridInterpolator:
     @pytest.mark.parametrize("method", ['nearest', 'linear'])
     def test_nan_x_2d(self, method):
         x, y = np.array([0, 1, 2]), np.array([1, 3, 7])
+
         def f(x, y):
             return x**2 + y**2
+
         xg, yg = np.meshgrid(x, y, indexing='ij', sparse=True)
         data = f(xg, yg)
         interp = RegularGridInterpolator((x, y), data,
                                          method=method, bounds_error=False)
 
         res = interp([[1.5, np.nan], [1, 1]])
-        assert_allclose(res[1], 2, atol=1e-14 )
+        assert_allclose(res[1], 2, atol=1e-14)
         assert np.isnan(res[0])
 
         # test arbitrary nan pattern

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -2746,7 +2746,7 @@ class TestRegularGridInterpolator:
 
     def test_nan_x_1d(self):
         # gh-6624 : if x is nan, result should be nan
-        f = RegularGridInterpolator(([1, 2, 3],), [10, 20, 30],
+        f = RegularGridInterpolator(([1, 2, 3],), [10, 20, 30], fill_value=1,
                                     bounds_error=False, method='nearest')
         assert np.isnan(f([np.nan]))
 

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -2778,7 +2778,8 @@ class TestRegularGridInterpolator:
         interp = RegularGridInterpolator((x, y), data,
                                          method=method, bounds_error=False)
 
-        res = interp([[1.5, np.nan], [1, 1]])
+        with np.errstate(invalid='ignore'):
+            res = interp([[1.5, np.nan], [1, 1]])
         assert_allclose(res[1], 2, atol=1e-14)
         assert np.isnan(res[0])
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

 closes gh-6624

#### What does this implement/fix?
<!--Please explain your changes.-->

Make RegularGridInterpolator have  `f(nan) = nan`.

#### Additional information
<!--Any additional information you think is important.-->

Will need to be rebased on gh-16070 first.