### PR TITLE
BUG: refguide-check: allow multiline namedtuples

### DIFF
--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -506,7 +506,7 @@ def try_convert_namedtuple(got):
     regex = (r'[\w\d_]+\(' +
              ', '.join([r'[\w\d_]+=(.+)']*num) +
              r'\)')
-    grp = re.findall(regex, got.replace('\n', ' '))
+    grp = re.findall(regex, " ".join(got.split()))
     # fold it back to a tuple
     got_again = '(' + ', '.join(grp[0]) + ')'
     return got_again


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

closes gh-16081

#### What does this implement/fix?
<!--Please explain your changes.-->

Make refguide-check understand multiline namedtuples.

#### Additional information
<!--Any additional information you think is important.-->

The failure is this:

```
Failed example:
    stats.describe(a)
Expected:
    DescribeResult(nobs=10, minmax=(0, 9), mean=4.5,
                   variance=9.166666666666666, skewness=0.0,
                   kurtosis=-1.2242424242424244)
```

The version in main replaced the linefeed characters with spaces. This way indentation became just a bunch of whitespace, which apparently confused the regex in `try_convert_namedtuples`. For me, removing whitespace is way simpler than wrangling with a regex :-).