### PR TITLE
DOC: fixing a sign issue in FFTlog function documentation

### DIFF
--- a/scipy/fft/_fftlog.py
+++ b/scipy/fft/_fftlog.py
@@ -71,7 +71,7 @@ def fht(a, dln, mu, offset=0.0, bias=0.0):
         r_j = r_c \exp[(j-j_c) \, \mathtt{dln}]
 
     centred about the point :math:`r_c`.  Note that the central index
-    :math:`j_c = (n+1)/2` is half-integral if :math:`n` is even, so that
+    :math:`j_c = (n-1)/2` is half-integral if :math:`n` is even, so that
     :math:`r_c` falls between two input elements.  Similarly, the output
     array `A` is a periodic sequence of length :math:`n`, also uniformly
     logarithmically spaced with spacing `dln`


### PR DESCRIPTION

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
closes #16027 

#### What does this implement/fix?
Fixes sign issue in documentation, code indicates ```j_c = (n-1)/2``` which is now reflected in the docstring.

#### Additional information
tests passed locally
