### PR TITLE
DOC: stats.invwishart: document LinAlgError raised when `scale` is not PD

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -2378,6 +2378,11 @@ class invwishart_gen(wishart_gen):
     %(_doc_default_callparams)s
     %(_doc_random_state)s
 
+    Raises
+    ------
+    scipy.linalg.LinAlgError
+        If the scale matrix `scale` is not positive definite.
+
     See Also
     --------
     wishart


### PR DESCRIPTION
#### Reference issue
Closes gh-6471

#### What does this implement/fix?
gh-6471 reported confusion that the error message `LinAlgError: 2-th leading minor not positive definite` raised by `stats.invwishart` meant that the `scale` matrix was not positive definite.
This PR resolves the issue by adding `scipy.linalg.LinAlgError` to the "Raises" section of the documentation.
