### PR TITLE
DEP: execute deprecation of inexact indices into sparse matrices

### DIFF
--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -3,7 +3,6 @@
 
 import sys
 import operator
-import warnings
 import numpy as np
 from scipy._lib._util import prod
 
@@ -213,8 +212,8 @@ def isintlike(x):
         except (TypeError, ValueError):
             return False
         if loose_int:
-            warnings.warn("Inexact indices into sparse matrices are deprecated",
-                          DeprecationWarning)
+            msg = "Inexact indices into sparse matrices are not allowed"
+            raise ValueError(msg)
         return loose_int
     return True
 

--- a/scipy/sparse/tests/test_sputils.py
+++ b/scipy/sparse/tests/test_sputils.py
@@ -44,9 +44,10 @@ class TestSparseUtils:
         assert_equal(sputils.isintlike(-4), True)
         assert_equal(sputils.isintlike(np.array(3)), True)
         assert_equal(sputils.isintlike(np.array([3])), False)
-        with suppress_warnings() as sup:
-            sup.filter(DeprecationWarning,
-                       "Inexact indices into sparse matrices are deprecated")
+        with assert_raises(
+            ValueError,
+            match="Inexact indices into sparse matrices are not allowed"
+        ):
             assert_equal(sputils.isintlike(3.0), True)
 
         assert_equal(sputils.isintlike(2.5), False)

--- a/scipy/sparse/tests/test_sputils.py
+++ b/scipy/sparse/tests/test_sputils.py
@@ -48,7 +48,7 @@ class TestSparseUtils:
             ValueError,
             match="Inexact indices into sparse matrices are not allowed"
         ):
-            assert_equal(sputils.isintlike(3.0), True)
+            sputils.isintlike(3.0)
 
         assert_equal(sputils.isintlike(2.5), False)
         assert_equal(sputils.isintlike(1 + 3j), False)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #15732
#### What does this implement/fix?
<!--Please explain your changes.-->
executes deprecation of inexact indices into sparse matrices as it has been deprecated for over 5 years
#### Additional information
<!--Any additional information you think is important.-->
