### PR TITLE
MAINT: Remove old filtered warnings

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -71,7 +71,7 @@ import datetime
 import importlib.util
 import json  # noqa: E402
 from sysconfig import get_path
-from types import ModuleType as new_module
+from types import ModuleType as new_module  # noqa: E402
 
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__)))
 

--- a/dev.py
+++ b/dev.py
@@ -71,11 +71,7 @@ import datetime
 import importlib.util
 import json  # noqa: E402
 from sysconfig import get_path
-
-try:
-    from types import ModuleType as new_module
-except ImportError:  # old Python
-    from imp import new_module
+from types import ModuleType as new_module
 
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__)))
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -154,7 +154,6 @@ warnings.filterwarnings('default', module='sphinx')  # internal warnings
 for key in (
         r"'U' mode is deprecated",  # sphinx io
         r"OpenSSL\.rand is deprecated",  # OpenSSL package in linkcheck
-        r"Using or importing the ABCs from",  # 3.5 importlib._bootstrap
         r"distutils Version",  # distutils
         ):
     warnings.filterwarnings(  # deal with other modules having bad imports

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -152,7 +152,6 @@ warnings.filterwarnings('error')
 warnings.filterwarnings('default', module='sphinx')  # internal warnings
 # global weird ones that can be safely ignored
 for key in (
-        r"'U' mode is deprecated",  # sphinx io
         r"OpenSSL\.rand is deprecated",  # OpenSSL package in linkcheck
         r"distutils Version",  # distutils
         ):

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,7 +7,6 @@ filterwarnings =
     always::scipy._lib._testutils.FPUModeChangeWarning
     ignore:.*deprecated and ignored since IPython.*:DeprecationWarning
     once:.*LAPACK bug 0038.*:RuntimeWarning
-    ignore:Using or importing the ABCs from 'collections'*:DeprecationWarning
     ignore:can't resolve package from __spec__ or __package__, falling back on __name__ and __path__:ImportWarning
     ignore:assertions not in test modules or plugins:pytest.PytestConfigWarning
     ignore:'environmentfilter' is renamed to 'pass_environment'

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,8 +9,6 @@ filterwarnings =
     once:.*LAPACK bug 0038.*:RuntimeWarning
     ignore:Using or importing the ABCs from 'collections'*:DeprecationWarning
     ignore:can't resolve package from __spec__ or __package__, falling back on __name__ and __path__:ImportWarning
-    once:the imp module is deprecated in favour of importlib.*:DeprecationWarning
-    once:the imp module is deprecated in favour of importlib.*:PendingDeprecationWarning
     ignore:assertions not in test modules or plugins:pytest.PytestConfigWarning
     ignore:'environmentfilter' is renamed to 'pass_environment'
     ignore:'contextfunction' is renamed to 'pass_context'

--- a/runtests.py
+++ b/runtests.py
@@ -67,10 +67,7 @@ import shutil
 import subprocess
 import time
 import datetime
-try:
-    from types import ModuleType as new_module
-except ImportError:  # old Python
-    from imp import new_module
+from types import ModuleType as new_module
 
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__)))
 

--- a/runtests.py
+++ b/runtests.py
@@ -67,7 +67,7 @@ import shutil
 import subprocess
 import time
 import datetime
-from types import ModuleType as new_module
+from types import ModuleType as new_module  # noqa: E402
 
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__)))
 


### PR DESCRIPTION
The test failures seem unrelated to the changes.