### PR TITLE
BUG: use SOS filters in decimate for numerical stability

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -4518,7 +4518,7 @@ def decimate(x, q, n=None, ftype='iir', axis=-1, zero_phase=True):
         n = operator.index(n)
 
     result_type = x.dtype
-    if result_type.kind in 'bui':
+    if not issubclass(result_type.type, np.inexact):
         result_type = np.float64
 
     if ftype == 'fir':

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -4519,7 +4519,7 @@ def decimate(x, q, n=None, ftype='iir', axis=-1, zero_phase=True):
 
     result_type = x.dtype
     if (not np.issubdtype(result_type, np.inexact)
-        or result_type.type == np.float16):
+          or result_type.type == np.float16):
         # upcast integers and float16 to float64
         result_type = np.float64
 

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -4518,8 +4518,8 @@ def decimate(x, q, n=None, ftype='iir', axis=-1, zero_phase=True):
         n = operator.index(n)
 
     result_type = x.dtype
-    if (not np.issubdtype(result_type, np.inexact)
-          or result_type.type == np.float16):
+    if not np.issubdtype(result_type, np.inexact) \
+       or result_type.type == np.float16:
         # upcast integers and float16 to float64
         result_type = np.float64
 

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -4518,7 +4518,9 @@ def decimate(x, q, n=None, ftype='iir', axis=-1, zero_phase=True):
         n = operator.index(n)
 
     result_type = x.dtype
-    if not issubclass(result_type.type, np.inexact):
+    if (not np.issubdtype(result_type, np.inexact)
+        or result_type.type == np.float16):
+        # upcast integers and float16 to float64
         result_type = np.float64
 
     if ftype == 'fir':

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2606,6 +2606,11 @@ class TestDecimate:
         x = signal.decimate(np.ones(10_000, dtype=np.float32), 10)
         assert not any(np.isnan(x))
 
+    def test_float16_upcast(self):
+        # float16 must be upcast to float64
+        x = signal.decimate(np.ones(100, dtype=np.float16), 10)
+        assert x.dtype.type == np.float64
+
 
 class TestHilbert:
 

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2600,6 +2600,12 @@ class TestDecimate:
         x_out = signal.decimate(x, 30, ftype='fir')
         assert_array_less(np.linalg.norm(x_out), 0.01)
 
+    def test_long_float32(self):
+        # regression: gh-15072.  With 32-bit float and either lfilter
+        # or filtfilt, this is numerically unstable
+        x = signal.decimate(np.ones(10_000, dtype=np.float32), 10)
+        assert not any(np.isnan(x))
+
 
 class TestHilbert:
 


### PR DESCRIPTION
#### Reference issue
Fixes gh-13529, fixes gh-15072, and fixes gh-15393.

#### What does this implement/fix?
Use `sosfilt` and `sosfiltfilt` instead of, respectively, `lfilter` and `filtfilt`, for better numerical stability.

#### Additional information
This should produce the same output as previously, except for 32-bit floats where the previous code was numerically unstable.  There may also be differences in output if the caller passed in an LTI object that was marginally stable and is now becomes stable.

I added a regression test for the 32-bit float case, based on gh-15393.

I did *not* update `TestDecimate._test_phaseshift` in `test_signaltools.py`; that still tests the behaviour of `zero_phase`, but not with the actual filter synthesis now used in `decimate`.  It looks to me like it was already out-of-date w.r.t. the FIR case, or at least the code for that is different.