### PR TITLE
ENH: Prevent unnecessary matvec in scipy.optimize

### DIFF
--- a/scipy/optimize/_nonlin.py
+++ b/scipy/optimize/_nonlin.py
@@ -891,7 +891,8 @@ class BroydenFirst(GenericBroyden):
         if not np.isfinite(r).all():
             # singular; reset the Jacobian approximation
             self.setup(self.last_x, self.last_f, self.func)
-        return self.Gm.matvec(f)
+            return self.Gm.matvec(f)
+        return r
 
     def matvec(self, f):
         return self.Gm.solve(f)


### PR DESCRIPTION
Closes #16097

Matvec is called twice in the solver for Broyden's method in scipy.optimize.
When it only needs to be called once most of the time and the special case is handled separately.
