### PR TITLE
DOC: stats: symmetry not checked for (inv)wishart distributions

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -1643,6 +1643,11 @@ class wishart_gen(multi_rv_generic):
     %(_doc_default_callparams)s
     %(_doc_random_state)s
 
+    Raises
+    ------
+    scipy.linalg.LinAlgError
+        If the scale matrix `scale` is not positive definite.
+
     See Also
     --------
     invwishart, chi2

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -1653,7 +1653,8 @@ class wishart_gen(multi_rv_generic):
 
     The scale matrix `scale` must be a symmetric positive definite
     matrix. Singular matrices, including the symmetric positive semi-definite
-    case, are not supported.
+    case, are not supported. Symmetry is not checked; only the lower triangular
+    portion is used.
 
     The Wishart distribution is often denoted
 
@@ -2393,7 +2394,8 @@ class invwishart_gen(wishart_gen):
 
     The scale matrix `scale` must be a symmetric positive definite
     matrix. Singular matrices, including the symmetric positive semi-definite
-    case, are not supported.
+    case, are not supported. Symmetry is not checked; only the lower triangular
+    portion is used.
 
     The inverse Wishart distribution is often denoted
 


### PR DESCRIPTION
#### Reference issue
Closes gh-6472
Similar to gh-16091
Similar to gh-16030 for `multivariate_normal`

#### What does this implement/fix?
As with other multivariate distributions, the matrix shape parameter `scale` of `invwishart` is not checked for symmetry. The PR documents this fact for `wishart` and `invwishart`.

It also makes sense to document the cause of a `LinAlgError` for `wishart` as done for `invwishart` in gh-16091, while we're at it.