### PR TITLE
BUG: stats: fix skewnorm pdf when a=0

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -7635,7 +7635,10 @@ class skew_norm_gen(rv_continuous):
         return [_ShapeInfo("a", False, (-np.inf, np.inf), (False, False))]
 
     def _pdf(self, x, a):
-        return 2.*_norm_pdf(x)*_norm_cdf(a*x)
+        return _lazywhere(
+            a == 0, (x, a), lambda x, a: _norm_pdf(x),
+            f2=lambda x, a: 2.*_norm_pdf(x)*_norm_cdf(a*x)
+        )
 
     def _cdf_single(self, x, *args):
         _a, _b = self._get_support(*args)

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -882,7 +882,7 @@ def test_frozen_attributes():
 
 def test_skewnorm_pdf_gh16038():
     rng = np.random.default_rng(0)
-    x, a = 0, 0
+    x, a = -np.inf, 0
     npt.assert_equal(stats.skewnorm.pdf(x, a), stats.norm.pdf(x))
     x, a = rng.random(size=(3, 3)), rng.random(size=(3, 3))
     mask = rng.random(size=(3, 3)) < 0.5

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -878,3 +878,16 @@ def test_frozen_attributes():
     frozen_norm = stats.norm()
     assert isinstance(frozen_norm, rv_continuous_frozen)
     delattr(stats.norm, 'pmf')
+
+
+def test_skewnorm_pdf_gh16038():
+    rng = np.random.default_rng(0)
+    x, a = 0, 0
+    npt.assert_equal(stats.skewnorm.pdf(x, a), stats.norm.pdf(x))
+    x, a = rng.random(size=(3, 3)), rng.random(size=(3, 3))
+    mask = rng.random(size=(3, 3)) < 0.5
+    a[mask] = 0
+    x_norm = x[mask]
+    res = stats.skewnorm.pdf(x, a)
+    npt.assert_equal(res[mask], stats.norm.pdf(x_norm))
+    npt.assert_equal(res[~mask], stats.skewnorm.pdf(x[~mask], a[~mask]))


### PR DESCRIPTION
#### Reference issue

Fixes #16038

#### What does this implement/fix?

Fix the `skewnorm` PDF when `a=0`. As described in #16038, `skewnorm` limits to `norm` when `a=0`. All the methods except PDF matched `norm`'s methods. This PR fixes this and adds appropriate tests.
