### PR TITLE
BUG: Fix norm for sparse arrays

### DIFF
--- a/scipy/sparse/linalg/_norm.py
+++ b/scipy/sparse/linalg/_norm.py
@@ -177,6 +177,11 @@ def norm(x, ord=None, axis=None):
             except TypeError as e:
                 raise ValueError('Invalid norm order for vectors.') from e
             M = np.power(abs(x).power(ord).sum(axis=a), 1 / ord)
-        return M.A.ravel()
+        if hasattr(M, 'toarray'):
+            return M.toarray().ravel()
+        elif hasattr(M, 'A'):
+            return M.A.ravel()
+        else:
+            return M.ravel()
     else:
         raise ValueError("Improper number of dimensions to norm.")

--- a/scipy/sparse/linalg/tests/test_norm.py
+++ b/scipy/sparse/linalg/tests/test_norm.py
@@ -3,11 +3,24 @@
 
 import numpy as np
 from numpy.linalg import norm as npnorm
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_equal
 from pytest import raises as assert_raises
 
 import scipy.sparse
 from scipy.sparse.linalg import norm as spnorm
+
+
+# https://github.com/scipy/scipy/issues/16031
+def test_sparray_norm():
+    row = np.array([0, 0, 1, 1])
+    col = np.array([0, 1, 2, 3])
+    data = np.array([4, 5, 7, 9])
+    test_arr = scipy.sparse.coo_array((data, (row, col)), shape=(2, 4))
+    test_mat = scipy.sparse.coo_matrix((data, (row, col)), shape=(2, 4))
+    assert_equal(spnorm(test_arr, ord=1, axis=0), np.array([4, 5, 7, 9]))
+    assert_equal(spnorm(test_mat, ord=1, axis=0), np.array([4, 5, 7, 9]))
+    assert_equal(spnorm(test_arr, ord=1, axis=1), np.array([9, 16]))
+    assert_equal(spnorm(test_mat, ord=1, axis=1), np.array([9, 16]))
 
 
 class TestNorm:


### PR DESCRIPTION
Fix #16031

Here is the main issue:
```
In [1]: import numpy as np
   ...: import scipy.sparse
   ...: a = np.arange(9) - 4
   ...: b = a.reshape((3, 3))
   ...: mat = scipy.sparse.csr_matrix(b)
   ...: arr = scipy.sparse.csr_array(b)

In [2]: abs(mat).sum(axis=0)
   ...:
Out[2]: matrix([[7, 6, 7]])

In [3]: abs(arr).sum(axis=0)
   ...:
Out[3]: array([7, 6, 7])
```
and
```
In [4]: arr.A
/home/jarrod/.venv/test/lib64/python3.9/site-packages/scipy/sparse/_base.py:742: VisibleDeprecationWarning: Please use `.todense()` instead
  warn(np.VisibleDeprecationWarning(
Out[4]:
array([[-4, -3, -2],
       [-1,  0,  1],
       [ 2,  3,  4]])
﻿
In [5]: abs(arr).sum(axis=0).A
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Input In [5], in <cell line: 1>()
----> 1 abs(arr).sum(axis=0).A
﻿
AttributeError: 'numpy.ndarray' object has no attribute 'A'
```
while
```
In [6]: abs(mat).sum(axis=0).A
Out[6]: array([[7, 6, 7]])
```

In other words, summing a sparse matrix yields a dense matrix (with `.A`), while summing a sparse array yields a dense array (without `.A`).
