### PR TITLE
DOC: interpolate: fix typos "the the" -> "the"

### DIFF
--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -434,7 +434,7 @@ class Akima1DInterpolator(CubicHermiteSpline):
         f1 = dm[2:]
         f2 = dm[:-2]
         f12 = f1 + f2
-        # These are the mask of where the the slope at breakpoint is defined:
+        # These are the mask of where the slope at breakpoint is defined:
         ind = np.nonzero(f12 > 1e-9 * np.max(f12))
         x_ind, y_ind = ind[0], ind[1:]
         # Set the slope at breakpoint

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -1197,7 +1197,7 @@ class PPoly(_PPolyBase):
 
     def solve(self, y=0., discontinuity=True, extrapolate=None):
         """
-        Find real solutions of the the equation ``pp(x) == y``.
+        Find real solutions of the equation ``pp(x) == y``.
 
         Parameters
         ----------
@@ -1269,7 +1269,7 @@ class PPoly(_PPolyBase):
 
     def roots(self, discontinuity=True, extrapolate=None):
         """
-        Find real roots of the the piecewise polynomial.
+        Find real roots of the piecewise polynomial.
 
         Parameters
         ----------


### PR DESCRIPTION
#### What does this implement/fix?
<!--Please explain your changes.-->

Just straightforward typo fixes.

#### Additional information
<!--Any additional information you think is important.-->

Test-driving https://github.com/scipy/scipy/issues/16124#issuecomment-1118484145 on skipping the CI.