### PR TITLE
DOC: interpolate: details rectilinear grids in docstrings

### DIFF
--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -2352,10 +2352,10 @@ class RegularGridInterpolator:
     """
     Interpolation on a regular or rectilinear grid in arbitrary dimensions.
 
-    The data must be defined on a rectilinear grid; that is, a rectangular grid 
-    with even or uneven spacing. Linear, nearest-neighbor, spline interpolations 
-    are supported. After setting up the interpolator object, the interpolation 
-    method may be chosen at each evaluation.
+    The data must be defined on a rectilinear grid; that is, a rectangular
+    grid with even or uneven spacing. Linear, nearest-neighbor, spline
+    interpolations are supported. After setting up the interpolator object,
+    the interpolation method may be chosen at each evaluation.
 
     Parameters
     ----------
@@ -2748,9 +2748,9 @@ def interpn(points, values, xi, method="linear", bounds_error=True,
     """
     Multidimensional interpolation on regular or rectilinear grids.
 
-    Strictly speaking, not all regular grids are supported - this function works 
-    on *rectilinear* grids, that is, a rectangular grid with even or uneven 
-    spacing.
+    Strictly speaking, not all regular grids are supported - this function
+    works on *rectilinear* grids, that is, a rectangular grid with even or
+    uneven spacing.
 
     Parameters
     ----------
@@ -2818,7 +2818,7 @@ def interpn(points, values, xi, method="linear", bounds_error=True,
                            in N dimensions
 
     RegularGridInterpolator : Linear and nearest-neighbor Interpolation on a
-                              regular or rectilinear grid in arbitrary 
+                              regular or rectilinear grid in arbitrary
                               dimensions
 
     RectBivariateSpline : Bivariate spline approximation over a rectangular mesh

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -2350,12 +2350,12 @@ class NdPPoly:
 
 class RegularGridInterpolator:
     """
-    Interpolation on a regular grid in arbitrary dimensions.
+    Interpolation on a regular or rectilinear grid in arbitrary dimensions.
 
-    The data must be defined on a regular grid; the grid spacing however may be
-    uneven. Linear, nearest-neighbor, spline interpolations are supported.
-    After setting up the interpolator object, the interpolation method may be
-    chosen at each evaluation.
+    The data must be defined on a rectilinear grid; that is, a rectangular grid 
+    with even or uneven spacing. Linear, nearest-neighbor, spline interpolations 
+    are supported. After setting up the interpolator object, the interpolation 
+    method may be chosen at each evaluation.
 
     Parameters
     ----------
@@ -2746,10 +2746,11 @@ class RegularGridInterpolator:
 def interpn(points, values, xi, method="linear", bounds_error=True,
             fill_value=np.nan):
     """
-    Multidimensional interpolation on regular grids.
+    Multidimensional interpolation on regular or rectilinear grids.
 
-    Strictly speaking, not all regular grids are supported, and this function
-    works on *rectilinear* grids.
+    Strictly speaking, not all regular grids are supported - this function works 
+    on *rectilinear* grids, that is, a rectangular grid with even or uneven 
+    spacing.
 
     Parameters
     ----------
@@ -2817,7 +2818,8 @@ def interpn(points, values, xi, method="linear", bounds_error=True,
                            in N dimensions
 
     RegularGridInterpolator : Linear and nearest-neighbor Interpolation on a
-                              regular grid in arbitrary dimensions
+                              regular or rectilinear grid in arbitrary 
+                              dimensions
 
     RectBivariateSpline : Bivariate spline approximation over a rectangular mesh
 


### PR DESCRIPTION
Adds some clarifying language to the interpn and RegularGridInterpolator docstrings relating to rectilinear grids.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #16121 by hopefully clarifying the language added in response to #16073 and #14926.

#### What does this implement/fix?
<!--Please explain your changes.-->
Attempts to make it both clear and obvious that interpn and RegularGridInterpolator support rectilinear grids, and what that means in practice. Essentially, just a suggested change of wording from #16073.
