### PR TITLE
DEP: stats.spearmanr: deprecate existing behavior with 2D inputs

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -4672,7 +4672,7 @@ def spearmanr(a, b=None, axis=0, nan_policy='propagate',
 
     a, axisout = _chk_asarray(a, axis)
     if a.ndim > 1:
-        warnings.warn(dep_msg, DeprecationWarning)
+        warnings.warn(dep_msg, DeprecationWarning, stacklevel=2)
 
     if a.ndim > 2:
         raise ValueError("spearmanr only handles 1-D or 2-D arrays")
@@ -4686,7 +4686,7 @@ def spearmanr(a, b=None, axis=0, nan_policy='propagate',
         # of a 2-D `a`.
         b, _ = _chk_asarray(b, axis)
         if b.ndim > 1:
-            warnings.warn(dep_msg, DeprecationWarning)
+            warnings.warn(dep_msg, DeprecationWarning, stacklevel=2)
         if axisout == 0:
             a = np.column_stack((a, b))
         else:

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -4662,7 +4662,18 @@ def spearmanr(a, b=None, axis=0, nan_policy='propagate',
                          "supplied axis argument {}, please use only "
                          "values 0, 1 or None for axis".format(axis))
 
+    dep_msg = ("The behavior of `spearmanr` with 2D input is deprecated "
+               "as of SciPy 1.9.0. In SciPy 1.11.0, the behavior will "
+               "change to be consistent with that of other reduction "
+               "functions, such as `f_oneway`. For example, the existing "
+               "behavior of `spearmanr(a)` with 2D `a` will be possible "
+               "with `spearmanr(a[:, np.newaxis, :], a[:, :, np.newaxis])`"
+               )
+
     a, axisout = _chk_asarray(a, axis)
+    if a.ndim > 1:
+        warnings.warn(dep_msg, DeprecationWarning)
+
     if a.ndim > 2:
         raise ValueError("spearmanr only handles 1-D or 2-D arrays")
 
@@ -4674,10 +4685,14 @@ def spearmanr(a, b=None, axis=0, nan_policy='propagate',
         # Concatenate a and b, so that we now only have to handle the case
         # of a 2-D `a`.
         b, _ = _chk_asarray(b, axis)
+        if b.ndim > 1:
+            warnings.warn(dep_msg, DeprecationWarning)
         if axisout == 0:
             a = np.column_stack((a, b))
         else:
             a = np.row_stack((a, b))
+
+
 
     n_vars = a.shape[1 - axisout]
     n_obs = a.shape[axisout]

--- a/scipy/stats/tests/test_resampling.py
+++ b/scipy/stats/tests/test_resampling.py
@@ -1373,7 +1373,8 @@ class TestPermutationTest:
             return stats.spearmanr(x, y).correlation
 
         res = permutation_test((x,), statistic1d, permutation_type='pairings',
-                               n_resamples=np.inf, alternative=alternative)
+                               n_resamples=np.inf, alternative=alternative,
+                               vectorized=False)
 
         assert_allclose(res.statistic, expected_statistic, rtol=self.rtol)
         assert_allclose(res.pvalue, expected_pvalue, atol=1e-13)


### PR DESCRIPTION
#### Reference issue
Part of gh-9307
gh-14651 

#### What does this implement/fix?
The behavior of `stats.spearmanr` with 2D input is inconsistent with all other stats reduction functions as described [here](https://github.com/scipy/scipy/issues/9307#issuecomment-1032070343). This PR deprecates the existing behavior, which will be replaced with more consistent behavior in SciPy 1.11.0.

#### Additional information
Already discussed [here](https://github.com/scipy/scipy/issues/9307#issuecomment-1116871761). [Email](https://mail.python.org/archives/list/scipy-dev@python.org/thread/XUEEXNZU6HFGCKXXWHCXA4DEE2JCDQUA/) sent to mailing list 5/6/2022.
