### PR TITLE
BUG: signal: Fix calculation of extended image indices in convolve2d.

### DIFF
--- a/scipy/signal/_firfilter.c
+++ b/scipy/signal/_firfilter.c
@@ -99,16 +99,52 @@ static OneMultAddFunction *OneMultAdd[]={NULL,
 					 CLONGDOUBLE_onemultadd,
                                          NULL, NULL, NULL, NULL};
 
+
+//
+// reflect_symm_index(j, m) maps an arbitrary integer j to the interval [0, m).
+//
+// * j can have any value.
+// * m is assumed to be positive.
+//
+// The mapping from j to [0, m) is via reflection about the edges of the array.
+// That is, the "base" array is [0, 1, 2, ..., m-1].  To continue to the right,
+// the indices count down: [m-1, m-2, ... 0], and then count up again
+// [0, 1, ..., m-1], and so on. The same extension pattern is followed on the
+// left.
+//
+// Example, with m = 5:
+//                           ----extension--------|-----base----|----extension----
+//                        j: -7 -6 -5 -4 -3 -2 -1  0  1  2  3  4  5  6  7  8  9 10
+// reflect_symm_index(j, 5):  3  4  4  3  2  1  0  0  1  2  3  4  4  3  2  1  0  0
+//
 static int64_t
 reflect_symm_index(int64_t j, int64_t m)
 {
+    // First map j to k in the interval [0, 2*m-1).
+    // Then flip the k values that are greater than or equal to m.
     int64_t k = (j >= 0) ? (j % (2*m)) : (abs(j + 1) % (2*m));
     return (k >= m) ? (2*m - k - 1) : k;
 }
 
+//
+// circular_wrap_index(j, m) maps an arbitrary integer j to the interval [0, m).
+// The mapping makes the indices periodic.
+//
+// * j can have any value.
+// * m is assumed to be positive.
+//
+// Example, with m = 5:
+//                            ----extension--------|-----base----|----extension----
+//                         j: -7 -6 -5 -4 -3 -2 -1  0  1  2  3  4  5  6  7  8  9 10
+// circular_wrap_index(j, 5):  3  4  0  1  2  3  4  0  1  2  3  4  0  1  2  3  4  0
+//
 static int64_t
 circular_wrap_index(int64_t j, int64_t m)
 {
+    // About the negative case: in C, -3 % 5 is -3, so that explains
+    // the " + m" after j % m.  But -5 % 5 is 0, and so -5 % 5 + 5 is 5,
+    // which we want to wrap around to 0.  That's why the second " % m" is
+    // included in the expression.
     return (j >= 0) ? (j % m) : ((j % m + m) % m);
 }
 
@@ -176,12 +212,7 @@ int pylab_convolve_2d (char  *in,        /* Input data Ns[0] x Ns[1] */
 	int64_t ind0 = convolve ? (new_m-j): (new_m+j);
 	bool bounds_pad_flag = false;
 
-	if (ind0 < 0) {
-	  if (boundary == REFLECT) ind0 = reflect_symm_index(ind0, Ns[0]);
-	  else if (boundary == CIRCULAR) ind0 = circular_wrap_index(ind0, Ns[0]);
-	  else bounds_pad_flag = true;
-	}
-	else if (ind0 >= Ns[0]) {
+	if ((ind0 < 0) || (ind0 >= Ns[0])) {
 	  if (boundary == REFLECT) ind0 = reflect_symm_index(ind0, Ns[0]);
 	  else if (boundary == CIRCULAR) ind0 = circular_wrap_index(ind0, Ns[0]);
 	  else bounds_pad_flag = true;
@@ -197,12 +228,7 @@ int pylab_convolve_2d (char  *in,        /* Input data Ns[0] x Ns[1] */
 	else  {
 	  for (int64_t k=0; k < Nwin[1]; k++) {
 	    int64_t ind1 = convolve ? (new_n-k) : (new_n+k);
-	    if (ind1 < 0) {
-	      if (boundary == REFLECT) ind1 = reflect_symm_index(ind1, Ns[1]);
-	      else if (boundary == CIRCULAR) ind1 = circular_wrap_index(ind1, Ns[1]);
-	      else bounds_pad_flag = true;
-	    }
-	    else if (ind1 >= Ns[1]) {
+	    if ((ind1 < 0) || (ind1 >= Ns[1])) {
 	      if (boundary == REFLECT) ind1 = reflect_symm_index(ind1, Ns[1]);
 	      else if (boundary == CIRCULAR) ind1 = circular_wrap_index(ind1, Ns[1]);
 	      else bounds_pad_flag = true;

--- a/scipy/signal/_firfilter.c
+++ b/scipy/signal/_firfilter.c
@@ -99,6 +99,19 @@ static OneMultAddFunction *OneMultAdd[]={NULL,
 					 CLONGDOUBLE_onemultadd,
                                          NULL, NULL, NULL, NULL};
 
+static int64_t
+reflect_symm_index(int64_t j, int64_t m)
+{
+    int64_t k = (j >= 0) ? (j % (2*m)) : (abs(j + 1) % (2*m));
+    return (k >= m) ? (2*m - k - 1) : k;
+}
+
+static int64_t
+circular_wrap_index(int64_t j, int64_t m)
+{
+    return (j >= 0) ? (j % m) : ((j % m + m) % m);
+}
+
 
 /* This could definitely be more optimized... */
 
@@ -164,13 +177,13 @@ int pylab_convolve_2d (char  *in,        /* Input data Ns[0] x Ns[1] */
 	bool bounds_pad_flag = false;
 
 	if (ind0 < 0) {
-	  if (boundary == REFLECT) ind0 = -1-ind0;
-	  else if (boundary == CIRCULAR) ind0 = Ns[0] + ind0;
+	  if (boundary == REFLECT) ind0 = reflect_symm_index(ind0, Ns[0]);
+	  else if (boundary == CIRCULAR) ind0 = circular_wrap_index(ind0, Ns[0]);
 	  else bounds_pad_flag = true;
 	}
 	else if (ind0 >= Ns[0]) {
-	  if (boundary == REFLECT) ind0 = Ns[0]+Ns[0]-1-ind0;
-	  else if (boundary == CIRCULAR) ind0 = ind0 - Ns[0];
+	  if (boundary == REFLECT) ind0 = reflect_symm_index(ind0, Ns[0]);
+	  else if (boundary == CIRCULAR) ind0 = circular_wrap_index(ind0, Ns[0]);
 	  else bounds_pad_flag = true;
 	}
 
@@ -185,13 +198,13 @@ int pylab_convolve_2d (char  *in,        /* Input data Ns[0] x Ns[1] */
 	  for (int64_t k=0; k < Nwin[1]; k++) {
 	    int64_t ind1 = convolve ? (new_n-k) : (new_n+k);
 	    if (ind1 < 0) {
-	      if (boundary == REFLECT) ind1 = -1-ind1;
-	      else if (boundary == CIRCULAR) ind1 = Ns[1] + ind1;
+	      if (boundary == REFLECT) ind1 = reflect_symm_index(ind1, Ns[1]);
+	      else if (boundary == CIRCULAR) ind1 = circular_wrap_index(ind1, Ns[1]);
 	      else bounds_pad_flag = true;
 	    }
 	    else if (ind1 >= Ns[1]) {
-	      if (boundary == REFLECT) ind1 = Ns[1]+Ns[1]-1-ind1;
-	      else if (boundary == CIRCULAR) ind1 = ind1 - Ns[1];
+	      if (boundary == REFLECT) ind1 = reflect_symm_index(ind1, Ns[1]);
+	      else if (boundary == CIRCULAR) ind1 = circular_wrap_index(ind1, Ns[1]);
 	      else bounds_pad_flag = true;
 	    }
 

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -22,7 +22,7 @@ from scipy.ndimage import correlate1d
 from scipy.optimize import fmin, linear_sum_assignment
 from scipy import signal
 from scipy.signal import (
-    correlate, correlation_lags, convolve, convolve2d,
+    correlate, correlate2d, correlation_lags, convolve, convolve2d,
     fftconvolve, oaconvolve, choose_conv_method,
     hilbert, hilbert2, lfilter, lfilter_zi, filtfilt, butter, zpk2tf, zpk2sos,
     invres, invresz, vectorstrength, lfiltic, tf2sos, sosfilt, sosfiltfilt,
@@ -347,6 +347,44 @@ class _TestConvolve2d:
                    [52, 48, 62, 80, 84],
                    [82, 78, 92, 110, 114]])
         assert_array_equal(c, d)
+
+    @pytest.mark.parametrize('func', [convolve2d, correlate2d])
+    @pytest.mark.parametrize('boundary, expected',
+                             [('symm', [[37.0, 42.0, 44.0, 45.0]]),
+                              ('wrap', [[43.0, 44.0, 42.0, 39.0]])])
+    def test_same_with_boundary(self, func, boundary, expected):
+        # Test boundary='symm' and boundary='wrap' with a "long" kernel.
+        # The size of the kernel requires that the values in the "image"
+        # be extended more than once to handle the requested boundary method.
+        # This is a regression test for gh-8684 and gh-8814.
+        image = np.array([[2.0, -1.0, 3.0, 4.0]])
+        kernel = np.ones((1, 21))
+        result = func(image, kernel, mode='same', boundary=boundary)
+        # The expected results were calculated "by hand".  Because the
+        # kernel is all ones, the same result is expected for convolve2d
+        # and correlate2d.
+        assert_array_equal(result, expected)
+
+    def test_boundary_extension_same(self):
+        # Regression test for gh-12686.
+        # Use ndimage.convolve with appropriate arguments to create the
+        # expected result.
+        import scipy.ndimage as ndi
+        a = np.arange(1, 10*3+1, dtype=float).reshape(10, 3)
+        b = np.arange(1, 10*10+1, dtype=float).reshape(10, 10)
+        c = convolve2d(a, b, mode='same', boundary='wrap')
+        assert_array_equal(c, ndi.convolve(a, b, mode='wrap', origin=(-1, -1)))
+
+    def test_boundary_extension_full(self):
+        # Regression test for gh-12686.
+        # Use ndimage.convolve with appropriate arguments to create the
+        # expected result.
+        import scipy.ndimage as ndi
+        a = np.arange(1, 3*3+1, dtype=float).reshape(3, 3)
+        b = np.arange(1, 6*6+1, dtype=float).reshape(6, 6)
+        c = convolve2d(a, b, mode='full', boundary='wrap')
+        apad = np.pad(a, ((3, 3), (3, 3)), 'wrap')
+        assert_array_equal(c, ndi.convolve(apad, b, mode='wrap')[:-1, :-1])
 
     def test_invalid_shapes(self):
         # By "invalid," we mean that no one


### PR DESCRIPTION
To handle the `boundary` arguments "wrap" and "symm", the `convolve2d`
code computes indices into the first argument that might be negative or
larger than the size of the image.  The code adjusts negative or big
values so that the adjusted index refers to the correct data element
within the array.  The problem was that this adjustment code assumed
that it would only require that the data be extended *once*. E.g. if
an axis had length 100, it assumed that the extended index would be
in [-100, 200].  This is not true in general; the kernel (i.e. the
second argument of `convolve2d`) can be any size, and so the required
extension could be any size.  If the kernel was too big, the adjusted
indices might still be negative or too big, resulting in attempts to
access memory outside of input array's data.  That could result in
reading garbage, or a segmentation fault.

The fix is to use a couple helper functions that can handle arbitrarily
large kernel dimensions when computing the extended data.

Closes gh-8684.
Closes gh-8814.
Closes gh-12686.
