### PR TITLE
TST: interpolate: mark rbf chunking tests as slow

### DIFF
--- a/scipy/interpolate/tests/test_rbfinterp.py
+++ b/scipy/interpolate/tests/test_rbfinterp.py
@@ -154,6 +154,7 @@ class _TestRBFInterpolator:
 
         assert_allclose(yitp1, yitp2, atol=1e-8)
 
+    @pytest.mark.slow
     def test_chunking(self):
         # If the observed data comes from a polynomial, then the interpolant
         # should be able to reproduce the polynomial exactly, provided that


### PR DESCRIPTION

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

closes gh-16136

#### What does this implement/fix?
<!--Please explain your changes.-->

Mark RBFInterpolator chunking tests as slow, because:


```
$ python dev.py -t scipy.interpolate.tests.test_rbfinterp -- --durations=10
ninja: Entering directory `build'
[2/2] Generating scipy/generate-config with a custom command
Build OK
Installing, see meson-install.log...
Installation OK
Running tests for scipy version:1.9.0.dev0+1994.c166a9b, installed at:/home/br/repos/scipy/scipy/build-install/lib/python3.8/site-packages/scipy
=========================================================================================== test session starts ===========================================================================================
platform linux -- Python 3.8.10, pytest-7.1.2, pluggy-1.0.0
rootdir: /home/br/repos/scipy/scipy, configfile: pytest.ini
collected 185 items                                                                                                                                                                                       

scipy/interpolate/tests/test_rbfinterp.py ......................................................................................................................................................... [ 82%]
................................                                                                                                                                                                    [100%]

========================================================================================== slowest 10 durations ===========================================================================================
20.90s call     build-install/lib/python3.8/site-packages/scipy/interpolate/tests/test_rbfinterp.py::TestRBFInterpolatorNeighborsInf::test_chunking
10.48s call     build-install/lib/python3.8/site-packages/scipy/interpolate/tests/test_rbfinterp.py::TestRBFInterpolatorNeighbors20::test_chunking
2.11s call     build-install/lib/python3.8/site-packages/scipy/interpolate/tests/test_rbfinterp.py::TestRBFInterpolatorNeighborsNone::test_chunking
0.48s call     build-install/lib/python3.8/site-packages/scipy/interpolate/tests/test_rbfinterp.py::TestRBFInterpolatorNeighborsInf::test_smoothing_misfit[thin_plate_spline]
0.47s call     build-install/lib/python3.8/site-packages/scipy/interpolate/tests/test_rbfinterp.py::TestRBFInterpolatorNeighborsInf::test_smoothing_misfit[linear]
0.36s call     build-install/lib/python3.8/site-packages/scipy/interpolate/tests/test_rbfinterp.py::test_conditionally_positive_definite[cubic]
0.35s call     build-install/lib/python3.8/site-packages/scipy/interpolate/tests/test_rbfinterp.py::test_conditionally_positive_definite[quintic]
0.35s call     build-install/lib/python3.8/site-packages/scipy/interpolate/tests/test_rbfinterp.py::test_conditionally_positive_definite[thin_plate_spline]
0.35s call     build-install/lib/python3.8/site-packages/scipy/interpolate/tests/test_rbfinterp.py::test_conditionally_positive_definite[gaussian]
0.35s call     build-install/lib/python3.8/site-packages/scipy/interpolate/tests/test_rbfinterp.py::test_conditionally_positive_definite[linear]
========================================================================================== 185 passed in 40.77s ===========================================================================================
```

