### PR TITLE
WIP, BLD, MAINT: git security/version shim

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,9 @@ def git_version():
         return out
 
     try:
-        out = _minimal_ext_cmd(['git', 'rev-parse', 'HEAD'])
+        cwd = os.getcwd()
+        git_dir = os.path.join(cwd, ".git")
+        out = _minimal_ext_cmd(['git', '--git-dir', git_dir, 'rev-parse', 'HEAD'])
         GIT_REVISION = out.strip().decode('ascii')[:7]
 
         # We need a version number that's regularly incrementing for newer commits,


### PR DESCRIPTION
Don't merge yet please, still debug stage.

* this is an attempt to deal with the new
security measure in git:
https://github.blog/2022-04-12-git-security-vulnerability-announced/

* it has been blocking the release of SciPy 1.8.1
and NumPy point release for some time

* I'm going to try to point the problem wheels
repo PR at the hash of this commit/branch before
merging if possible: (this may mean temporarily pointing
the submodule remote at my fork to avoid merging to
main repo)
https://github.com/MacPython/scipy-wheels/pull/167

* based on feedback from Henry over here, this does
seem to help locally:
https://github.com/pypa/manylinux/issues/1309#issuecomment-1120330468
