### PR TITLE
DOC: Plot poles as x and zeros as o in signal

### DIFF
--- a/doc/source/tutorial/signal.rst
+++ b/doc/source/tutorial/signal.rst
@@ -888,8 +888,8 @@ in the amplitude response.
 
    >>> z, p, k = signal.tf2zpk(b, a)
 
-   >>> plt.plot(np.real(z), np.imag(z), 'xb')
-   >>> plt.plot(np.real(p), np.imag(p), 'or')
+   >>> plt.plot(np.real(z), np.imag(z), 'ob', markerfacecolor='none')
+   >>> plt.plot(np.real(p), np.imag(p), 'xr')
    >>> plt.legend(['Zeros', 'Poles'], loc=2)
 
    >>> plt.title('Pole / Zero Plot')

--- a/doc/source/tutorial/signal.rst
+++ b/doc/source/tutorial/signal.rst
@@ -893,8 +893,8 @@ in the amplitude response.
    >>> plt.legend(['Zeros', 'Poles'], loc=2)
 
    >>> plt.title('Pole / Zero Plot')
-   >>> plt.ylabel('Real')
-   >>> plt.xlabel('Imaginary')
+   >>> plt.xlabel('Real')
+   >>> plt.ylabel('Imaginary')
    >>> plt.grid()
    >>> plt.show()
 


### PR DESCRIPTION
#### What does this implement/fix?
[The scipy.signal user guide](https://docs.scipy.org/doc/scipy/tutorial/signal.html#analog-filter-design) currently shows this image:

![](https://docs.scipy.org/doc/scipy/_images/signal-7_01_00.png)

But it is conventional to show poles as x and zeros as o:

![zero-pole-plot 1](https://user-images.githubusercontent.com/58611/167281735-2e072d0e-a2bd-439d-b288-1fd6cc1ae724.gif)

![Poles-and-zeros-of-the-open-loop-transfer-function-P-1-s-and-the-closed-loop-transfer_W640 1](https://user-images.githubusercontent.com/58611/167281742-adcdaf76-c6ce-49b2-bf58-3bdbd1734952.jpg)
