### PR TITLE
DEP: Execute deprecation for squeezing input vectors in spatial.distance

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -298,16 +298,7 @@ def _validate_vector(u, dtype=None):
     u = np.asarray(u, dtype=dtype, order='c')
     if u.ndim == 1:
         return u
-
-    # Ensure values such as u=1 and u=[1] still return 1-D arrays.
-    u = np.atleast_1d(u.squeeze())
-    if u.ndim > 1:
-        raise ValueError("Input vector should be 1-D.")
-    warnings.warn(
-        "scipy.spatial.distance metrics ignoring length-1 dimensions is "
-        "deprecated in SciPy 1.7 and will raise an error in SciPy 1.9.",
-        DeprecationWarning)
-    return u
+    raise ValueError("Input vector should be 1-D.")
 
 
 def _validate_weights(w, dtype=np.double):

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -1579,39 +1579,6 @@ class TestSomeDistanceFunctions:
             assert_almost_equal(dist, np.sqrt(6.0))
 
 
-def construct_squeeze_tests():
-    # Construct a class like TestSomeDistanceFunctions but testing 2-d vectors
-    # with a length-1 dimension which is deprecated
-    def setup_method(self):
-        # 1D arrays
-        x = np.array([1.0, 2.0, 3.0])
-        y = np.array([1.0, 1.0, 5.0])
-        # 3x1 arrays
-        x31 = x[:, np.newaxis]
-        y31 = y[:, np.newaxis]
-        # 1x3 arrays
-        x13 = x31.T
-        y13 = y31.T
-
-        self.cases = [(x31, y31), (x13, y13), (x31, y13)]
-
-    sup = suppress_warnings()
-    sup.filter(DeprecationWarning,
-            ".*distance metrics ignoring length-1 dimensions is deprecated.*")
-    base = TestSomeDistanceFunctions
-    attrs = {
-        name: sup(getattr(base, name))
-        for name in dir(base)
-        if name.startswith('test_')
-    }
-    attrs['setup_method'] = setup_method
-    name = 'TestDistanceFunctionsSqueeze'
-    globals()[name] = type(name, (base,), attrs)
-
-
-construct_squeeze_tests()
-
-
 class TestSquareForm:
     checked_dtypes = [np.float64, np.float32, np.int32, np.int8, bool]
 
@@ -1931,18 +1898,15 @@ def test_euclideans():
     assert_almost_equal(weuclidean(x1, x2), np.sqrt(3), decimal=14)
 
     # Check flattening for (1, N) or (N, 1) inputs
-    with pytest.warns(DeprecationWarning,
-                      match="ignoring length-1 dimensions is deprecated"):
-        assert_almost_equal(weuclidean(x1[np.newaxis, :], x2[np.newaxis, :]),
-                            np.sqrt(3), decimal=14)
-    with pytest.warns(DeprecationWarning,
-                      match="ignoring length-1 dimensions is deprecated"):
-        assert_almost_equal(wsqeuclidean(x1[np.newaxis, :], x2[np.newaxis, :]),
-                            3.0, decimal=14)
-    with pytest.warns(DeprecationWarning,
-                      match="ignoring length-1 dimensions is deprecated"):
-        assert_almost_equal(wsqeuclidean(x1[:, np.newaxis], x2[:, np.newaxis]),
-                            3.0, decimal=14)
+    with assert_raises(ValueError,
+                       match="Input vector should be 1-D"):
+        weuclidean(x1[np.newaxis, :], x2[np.newaxis, :]), np.sqrt(3)
+    with assert_raises(ValueError,
+                       match="Input vector should be 1-D"):
+        wsqeuclidean(x1[np.newaxis, :], x2[np.newaxis, :])
+    with assert_raises(ValueError,
+                       match="Input vector should be 1-D"):
+        wsqeuclidean(x1[:, np.newaxis], x2[:, np.newaxis])
 
     # Distance metrics only defined for vectors (= 1-D)
     x = np.arange(4).reshape(2, 2)
@@ -2129,21 +2093,19 @@ def test__validate_vector():
     assert_equal(y, x)
 
     x = 1
-    with pytest.warns(DeprecationWarning,
-                      match="ignoring length-1 dimensions is deprecated"):
-        y = _validate_vector(x)
-    assert_equal(y.ndim, 1)
-    assert_equal(y, [x])
+    with assert_raises(ValueError,
+                       match="Input vector should be 1-D"):
+        _validate_vector(x)
 
     x = np.arange(5).reshape(1, -1, 1)
-    with pytest.warns(DeprecationWarning,
-                      match="ignoring length-1 dimensions is deprecated"):
-        y = _validate_vector(x)
-    assert_equal(y.ndim, 1)
-    assert_array_equal(y, x[0, :, 0])
+    with assert_raises(ValueError,
+                       match="Input vector should be 1-D"):
+        _validate_vector(x)
 
     x = [[1, 2], [3, 4]]
-    assert_raises(ValueError, _validate_vector, x)
+    with assert_raises(ValueError,
+                       match="Input vector should be 1-D"):
+        _validate_vector(x)
 
 def test_yule_all_same():
     # Test yule avoids a divide by zero when exactly equal


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #15740
#### What does this implement/fix?
<!--Please explain your changes.-->
Squeezing vector inputs was deprecated with promised removal for 1.9. This pr executes this.
#### Additional information
<!--Any additional information you think is important.-->
