### PR TITLE
MAINT: additional 1.8.1 backports/adjustments

### DIFF
--- a/LICENSES_bundled.txt
+++ b/LICENSES_bundled.txt
@@ -246,3 +246,8 @@ Name: Boost
 Files: scipy/_lib/boost/*
 License: Boost Software License - Version 1.0
   For details, see scipy/_lib/boost/LICENSE_1_0.txt
+
+Name: Biasedurn
+Files: scipy/stats/biasedurn/*
+License 3-Clause BSD
+  For details, see scipy/stats/biasedurn/license.txt

--- a/LICENSES_bundled.txt
+++ b/LICENSES_bundled.txt
@@ -251,3 +251,8 @@ Name: Biasedurn
 Files: scipy/stats/biasedurn/*
 License 3-Clause BSD
   For details, see scipy/stats/biasedurn/license.txt
+
+Name: UNU.RAN
+Files: scipy/_lib/unuran/*
+License 3-Clause BSD
+  For details, see scipy/_lib/unuran/license.txt

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -242,7 +242,7 @@ stages:
         git submodule update --init
       displayName: 'Fetch submodules'
     - script: |
-        python -m pip install --upgrade pip "setuptools==59.6.0" wheel
+        python -m pip install --upgrade "pip==22.0.4" "setuptools==59.6.0" wheel
       displayName: 'Install tools'
     - powershell: |
         $pyversion = python -c "import sys; print(sys.version.split()[0])"

--- a/doc/release/1.8.1-notes.rst
+++ b/doc/release/1.8.1-notes.rst
@@ -13,6 +13,7 @@ Authors
 
 * Henry Schreiner
 * Maximilian Nöthe
+* Sebastian Berg (1)
 * Sameer Deshmukh (1) +
 * DWesl (4)
 * Isuru Fernando (1)
@@ -21,12 +22,12 @@ Authors
 * Andrew Nelson (1)
 * Dimitri Papadopoulos Orfanos (1) +
 * Tirth Patel (3)
-* Tyler Reddy (33)
+* Tyler Reddy (36)
 * Pamphile Roy (5)
 * Niyas Sait (1) +
 * H. Vetinari (2)
 
-A total of 14 people contributed to this release.
+A total of 15 people contributed to this release.
 People with a "+" by their names contributed a patch for the first time.
 This list of names is automatically generated, and may not be fully complete.
 
@@ -63,4 +64,5 @@ Pull requests for 1.8.1
 * `#16035 <https://github.com/scipy/scipy/pull/16035>`__: BUG: allow scalar input to the \`.dot\` method of sparse matrices
 * `#16041 <https://github.com/scipy/scipy/pull/16041>`__: MAINT: add include dir explicitly for PROPACK to build with classic...
 * `#16139 <https://github.com/scipy/scipy/pull/16139>`__: WIP, BLD, MAINT: git security/version shim
+* `#16152 <https://github.com/scipy/scipy/pull/16152>`__: TST: Fortify invalid-value warning filters to small changes in...
 

--- a/doc/release/1.8.1-notes.rst
+++ b/doc/release/1.8.1-notes.rst
@@ -15,19 +15,21 @@ Authors
 * Maximilian Nöthe
 * Sebastian Berg (1)
 * Sameer Deshmukh (1) +
+* Niels Doucet (1) +
 * DWesl (4)
 * Isuru Fernando (1)
-* Ralf Gommers (2)
+* Ralf Gommers (4)
 * Matt Haberland (1)
 * Andrew Nelson (1)
 * Dimitri Papadopoulos Orfanos (1) +
 * Tirth Patel (3)
-* Tyler Reddy (36)
-* Pamphile Roy (5)
+* Tyler Reddy (46)
+* Pamphile Roy (7)
 * Niyas Sait (1) +
 * H. Vetinari (2)
+* Warren Weckesser (1)
 
-A total of 15 people contributed to this release.
+A total of 17 people contributed to this release.
 People with a "+" by their names contributed a patch for the first time.
 This list of names is automatically generated, and may not be fully complete.
 
@@ -41,6 +43,7 @@ Issues closed for 1.8.1
 * `#15552 <https://github.com/scipy/scipy/issues/15552>`__: BUG: MacOS universal2 wheels have two gfortran shared libraries,...
 * `#15636 <https://github.com/scipy/scipy/issues/15636>`__: BUG: DOCS incorrect \`source\` link on docs
 * `#15678 <https://github.com/scipy/scipy/issues/15678>`__: BUG: scipy.stats.skew does not work with scipy.stats.bootstrap
+* `#16174 <https://github.com/scipy/scipy/issues/16174>`__: Failure of \`TestCorrelateComplex.test_rank0\` in CI with NumPy...
 
 
 Pull requests for 1.8.1
@@ -59,10 +62,16 @@ Pull requests for 1.8.1
 * `#15669 <https://github.com/scipy/scipy/pull/15669>`__: BUG: stats: fix a bug in UNU.RAN error handler
 * `#15691 <https://github.com/scipy/scipy/pull/15691>`__: MAINT: stats: bootstrap: fix bug with \`method="BCa"\` when \`statistic\`...
 * `#15798 <https://github.com/scipy/scipy/pull/15798>`__: MAINT,BUG: stats: update to UNU.RAN 1.9.0
+* `#15870 <https://github.com/scipy/scipy/pull/15870>`__: TST: signal: Convert a test with 'assert_array_less' to 'less...
 * `#15910 <https://github.com/scipy/scipy/pull/15910>`__: make sure CI stays on VS2019 unless changed explicitly
 * `#15926 <https://github.com/scipy/scipy/pull/15926>`__: MAINT: 1.8.1 backports/prep
 * `#16035 <https://github.com/scipy/scipy/pull/16035>`__: BUG: allow scalar input to the \`.dot\` method of sparse matrices
 * `#16041 <https://github.com/scipy/scipy/pull/16041>`__: MAINT: add include dir explicitly for PROPACK to build with classic...
 * `#16139 <https://github.com/scipy/scipy/pull/16139>`__: WIP, BLD, MAINT: git security/version shim
 * `#16152 <https://github.com/scipy/scipy/pull/16152>`__: TST: Fortify invalid-value warning filters to small changes in...
+* `#16155 <https://github.com/scipy/scipy/pull/16155>`__: MAINT: correct wrong license of Biasedurn
+* `#16158 <https://github.com/scipy/scipy/pull/16158>`__: MAINT: better UNU.RAN licensing information
+* `#16163 <https://github.com/scipy/scipy/pull/16163>`__: MAINT: update UNU.RAN copyright information
+* `#16172 <https://github.com/scipy/scipy/pull/16172>`__: CI: pin Pip to 22.0.4 to avoid issues with \`--no-build-isolation\`
+* `#16175 <https://github.com/scipy/scipy/pull/16175>`__: TST: fix test failure due to changes in numpy scalar behavior.
 

--- a/doc/release/1.8.1-notes.rst
+++ b/doc/release/1.8.1-notes.rst
@@ -11,31 +11,36 @@ restored for Windows builds/binaries.
 Authors
 =======
 
+* Henry Schreiner
 * Maximilian Nöthe
+* Sameer Deshmukh (1) +
 * DWesl (4)
 * Isuru Fernando (1)
 * Ralf Gommers (2)
 * Matt Haberland (1)
 * Andrew Nelson (1)
 * Dimitri Papadopoulos Orfanos (1) +
-* Tirth Patel (2)
-* Tyler Reddy (18)
+* Tirth Patel (3)
+* Tyler Reddy (33)
 * Pamphile Roy (5)
+* Niyas Sait (1) +
 * H. Vetinari (2)
 
-A total of 11 people contributed to this release.
+A total of 14 people contributed to this release.
 People with a "+" by their names contributed a patch for the first time.
 This list of names is automatically generated, and may not be fully complete.
 
 Issues closed for 1.8.1
 -----------------------
 
+* `#15258 <https://github.com/scipy/scipy/issues/15258>`__: BUG: sparse \`dot\` method should accept scalars
 * `#15433 <https://github.com/scipy/scipy/issues/15433>`__: BUG: optimize: minimize: \`ValueError\` when \`np.all(lb==ub)\`
 * `#15539 <https://github.com/scipy/scipy/issues/15539>`__: BUG: Questionable macOS wheel contents
 * `#15543 <https://github.com/scipy/scipy/issues/15543>`__: REL: list contributors using GitHub handles
 * `#15552 <https://github.com/scipy/scipy/issues/15552>`__: BUG: MacOS universal2 wheels have two gfortran shared libraries,...
 * `#15636 <https://github.com/scipy/scipy/issues/15636>`__: BUG: DOCS incorrect \`source\` link on docs
 * `#15678 <https://github.com/scipy/scipy/issues/15678>`__: BUG: scipy.stats.skew does not work with scipy.stats.bootstrap
+
 
 Pull requests for 1.8.1
 -----------------------
@@ -52,5 +57,10 @@ Pull requests for 1.8.1
 * `#15637 <https://github.com/scipy/scipy/pull/15637>`__: DOC, MAINT: fix links to wrapped functions and SciPy's distributions
 * `#15669 <https://github.com/scipy/scipy/pull/15669>`__: BUG: stats: fix a bug in UNU.RAN error handler
 * `#15691 <https://github.com/scipy/scipy/pull/15691>`__: MAINT: stats: bootstrap: fix bug with \`method="BCa"\` when \`statistic\`...
+* `#15798 <https://github.com/scipy/scipy/pull/15798>`__: MAINT,BUG: stats: update to UNU.RAN 1.9.0
 * `#15910 <https://github.com/scipy/scipy/pull/15910>`__: make sure CI stays on VS2019 unless changed explicitly
+* `#15926 <https://github.com/scipy/scipy/pull/15926>`__: MAINT: 1.8.1 backports/prep
+* `#16035 <https://github.com/scipy/scipy/pull/16035>`__: BUG: allow scalar input to the \`.dot\` method of sparse matrices
+* `#16041 <https://github.com/scipy/scipy/pull/16041>`__: MAINT: add include dir explicitly for PROPACK to build with classic...
+* `#16139 <https://github.com/scipy/scipy/pull/16139>`__: WIP, BLD, MAINT: git security/version shim
 

--- a/doc/source/tutorial/stats/sampling_pinv.rst
+++ b/doc/source/tutorial/stats/sampling_pinv.rst
@@ -83,13 +83,6 @@ There are some restrictions for the given distribution:
   is very small. E.g., the Cauchy distribution is likely to show this problem
   when the requested u-resolution is less then 1.e-12.
 
-.. warning::
-    This method does not work for densities with constant parts (e.g.
-    `uniform` distribution) and segmentation faults if such a density is
-    passed to the constructor. It is recommended to use the
-    `composition method <https://statmath.wu.ac.at/software/unuran/doc/unuran.html#Composition>`__
-    to sample from such distributions.
-
 Following four steps are carried out by the algorithm during setup:
 
 * Computing the end points of the distribution: If a finite support is given,

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -1001,7 +1001,9 @@ class TestSOSFreqz:
         dB = 20*np.log10(np.maximum(np.abs(h), 1e-10))
         w /= np.pi
         assert_allclose(dB[w >= 0.3], 0, atol=.55)
-        assert_array_less(dB[w <= 0.2], -150)
+        # Allow some numerical slop in the upper bound -150, so this is
+        # a check that dB[w <= 0.2] is less than or almost equal to -150.
+        assert dB[w <= 0.2].max() < -150*(1 - 1e-12)
 
     @mpmath_check("0.10")
     def test_sos_freqz_against_mp(self):

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2141,7 +2141,8 @@ class TestCorrelateComplex:
 
         y_r = (correlate(a.real, b.real)
                + correlate(a.imag, b.imag)).astype(dt)
-        y_r += 1j * (-correlate(a.real, b.imag) + correlate(a.imag, b.real))
+        y_r += 1j * np.array(-correlate(a.real, b.imag) +
+                             correlate(a.imag, b.real))
 
         y = correlate(a, b, 'full')
         assert_array_almost_equal(y, y_r, decimal=self.decimal(dt) - 1)

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -410,7 +410,10 @@ class spmatrix:
         array([ 1, -3, -1], dtype=int64)
 
         """
-        return self @ other
+        if np.isscalar(other):
+            return self * other
+        else:
+            return self @ other
 
     def power(self, n, dtype=None):
         """Element-wise power."""

--- a/scipy/sparse/linalg/_propack/setup.py
+++ b/scipy/sparse/linalg/_propack/setup.py
@@ -45,10 +45,9 @@ def configuration(parent_package='', top_path=None):
 
     for prefix, directory in type_dict.items():
         propack_lib = f'_{prefix}propack'
-
         # Use risc msg implementation for 64-bit machines, pentium for 32-bit
-        src = list((pathlib.Path(
-            __file__).parent / 'PROPACK' / directory).glob('*.F'))
+        src_dir = pathlib.Path(__file__).parent / 'PROPACK' / directory
+        src = list(src_dir.glob('*.F'))
         if _is_32bit():
             # don't ask me why, 32-bit blows up without second.F
             src = [str(p) for p in src if 'risc' not in str(p)]
@@ -67,6 +66,7 @@ def configuration(parent_package='', top_path=None):
         config.add_library(propack_lib,
                            sources=src,
                            macros=cmacros,
+                           include_dirs=src_dir,
                            depends=['setup.py'])
         ext = config.add_extension(f'_{prefix}propack',
                                    sources=f'{prefix}propack.pyf',

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1630,7 +1630,10 @@ class _TestCommon:
         assert_equal(eval('B @ A'), "matrix on the right")
 
     def test_dot_scalar(self):
-        M = self.spmatrix(array([[3,0,0],[0,1,0],[2,0,3.0],[2,3,0]]))
+        M = self.spmatrix(array([[3, 0, 0],
+                                 [0, 1, 0],
+                                 [2, 0, 3.0],
+                                 [2, 3, 0]]))
         scalar = 10
         actual = M.dot(scalar)
         expected = M * scalar

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1629,6 +1629,14 @@ class _TestCommon:
         assert_equal(eval('A @ B'), "matrix on the left")
         assert_equal(eval('B @ A'), "matrix on the right")
 
+    def test_dot_scalar(self):
+        M = self.spmatrix(array([[3,0,0],[0,1,0],[2,0,3.0],[2,3,0]]))
+        scalar = 10
+        actual = M.dot(scalar)
+        expected = M * scalar
+
+        assert_allclose(actual.toarray(), expected.toarray())
+
     def test_matmul(self):
         M = self.spmatrix(array([[3,0,0],[0,1,0],[2,0,3.0],[2,3,0]]))
         B = self.spmatrix(array([[0,1],[1,0],[0,2]],'d'))
@@ -3620,7 +3628,7 @@ class TestCSR(sparse_test_class()):
         ij = vstack((row,col))
         csr = csr_matrix((data,ij),(4,3))
         assert_array_equal(arange(12).reshape(4, 3), csr.toarray())
-        
+
         # using Python lists and a specified dtype
         csr = csr_matrix(([2**63 + 1, 1], ([0, 1], [0, 1])), dtype=np.uint64)
         dense = array([[2**63 + 1, 0], [0, 1]], dtype=np.uint64)

--- a/scipy/stats/_unuran/setup.py
+++ b/scipy/stats/_unuran/setup.py
@@ -42,16 +42,6 @@ def _get_sources(dirs):
     return sources
 
 
-def _get_version(unuran_dir, configure_dot_ac, target_name):
-    configure_dot_ac = unuran_dir / configure_dot_ac
-    with open(configure_dot_ac, "r") as f:
-        s = f.read()
-        start_idx = s.find(target_name)
-        end_idx = s[start_idx:].find(")") + len(s[:start_idx])
-        version = s[start_idx:end_idx].split(",")[1][1:-1]
-    return version
-
-
 def configuration(parent_package="", top_path=None):
     from numpy.distutils.misc_util import Configuration
     from scipy._lib._unuran_utils import _unuran_dir
@@ -64,8 +54,7 @@ def configuration(parent_package="", top_path=None):
 
     # UNU.RAN info
     UNURAN_DIR = _unuran_dir(ret_path=True).resolve()
-    UNURAN_VERSION = _get_version(UNURAN_DIR, "unuran/configure.ac",
-                                  "AM_INIT_AUTOMAKE")
+    UNURAN_VERSION = "16:0:0"
 
     DEFINE_MACROS = [
         ("HAVE_ALARM", "1"),

--- a/scipy/stats/_unuran/unuran_wrapper.pyx.templ
+++ b/scipy/stats/_unuran/unuran_wrapper.pyx.templ
@@ -1275,13 +1275,6 @@ cdef class NumericalInversePolynomial(Method):
         If `random_state` is already a ``Generator`` or ``RandomState`` instance then
         that instance is used.
 
-    Notes
-    -----
-    This method does not work for densities with constant parts (e.g. `uniform`
-    distribution) and segmentation faults if such a density is passed to the
-    constructor. It is recommended to use the composition method to sample from
-    such distributions.
-
     References
     ----------
     .. [1] Derflinger, Gerhard, Wolfgang Hörmann, and Josef Leydold. "Random variate

--- a/scipy/stats/biasedurn/erfres.cpp
+++ b/scipy/stats/biasedurn/erfres.cpp
@@ -23,7 +23,7 @@ ERFRES_N =   13    (number of tables)
 ERFRES_L =   48    (length of each table)
 
 * Copyright 2004-2008 by Agner Fog. 
-* GNU General Public License http://www.gnu.org/licenses/gpl.html
+* Released under SciPy's license with permission of Agner Fog; see license.txt
 *****************************************************************************/
 extern "C" {
 

--- a/scipy/stats/biasedurn/fnchyppr.cpp
+++ b/scipy/stats/biasedurn/fnchyppr.cpp
@@ -19,7 +19,7 @@
 * instructions.
 *
 * Copyright 2002-2014 by Agner Fog. 
-* GNU General Public License http://www.gnu.org/licenses/gpl.html
+* Released under SciPy's license with permission of Agner Fog; see license.txt
 *****************************************************************************/
 
 #include <string.h>                    // memcpy function

--- a/scipy/stats/biasedurn/randomc.h
+++ b/scipy/stats/biasedurn/randomc.h
@@ -90,7 +90,7 @@
 * instructions for these random number generators.
 *
 * Copyright 1997-2008 by Agner Fog. 
-* GNU General Public License http://www.gnu.org/licenses/gpl.html
+* Released under SciPy's license with permission of Agner Fog; see license.txt
 *******************************************************************************/
 
 #ifndef RANDOMC_H

--- a/scipy/stats/biasedurn/stoc1.cpp
+++ b/scipy/stats/biasedurn/stoc1.cpp
@@ -20,7 +20,7 @@
 * The file ran-instructions.pdf contains general instructions.
 *
 * Copyright 2002-2008 by Agner Fog. 
-* GNU General Public License http://www.gnu.org/licenses/gpl.html
+* Released under SciPy's license with permission of Agner Fog; see license.txt
 *****************************************************************************/
 
 #include "stocc.h"     // class definition

--- a/scipy/stats/biasedurn/stoc3.cpp
+++ b/scipy/stats/biasedurn/stoc3.cpp
@@ -24,7 +24,7 @@
 * The file ran-instructions.pdf contains general instructions.
 *
 * Copyright 2002-2008 by Agner Fog. 
-* GNU General Public License http://www.gnu.org/licenses/gpl.html
+* Released under SciPy's license with permission of Agner Fog; see license.txt
 *****************************************************************************/
 
 #include <string.h>                    // memcpy function

--- a/scipy/stats/biasedurn/stocc.h
+++ b/scipy/stats/biasedurn/stocc.h
@@ -194,7 +194,7 @@
 * the methods for calculating and sampling from these.
 *
 * Copyright 2004-2013 by Agner Fog. 
-* GNU General Public License http://www.gnu.org/licenses/gpl.html
+* Released under SciPy's license with permission of Agner Fog; see license.txt
 *******************************************************************************/
 
 #ifndef STOCC_H

--- a/scipy/stats/biasedurn/wnchyppr.cpp
+++ b/scipy/stats/biasedurn/wnchyppr.cpp
@@ -21,7 +21,7 @@
 * instructions.
 *
 * Copyright 2002-2008 by Agner Fog. 
-* GNU General Public License http://www.gnu.org/licenses/gpl.html
+* Released under SciPy's license with permission of Agner Fog; see license.txt
 *****************************************************************************/
 
 #include <string.h>                    // memcpy function

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1433,11 +1433,10 @@ class TestPareto:
                                                     - 2)/(data.min() - 2)))))
         assert_equal(loc_mle_a, 2)
 
-    @pytest.mark.filterwarnings("ignore:invalid value encountered in "
-                                "double_scalars")
     @pytest.mark.parametrize("rvs_shape", [1, 2])
     @pytest.mark.parametrize("rvs_loc", [0, 2])
     @pytest.mark.parametrize("rvs_scale", [1, 5])
+    @np.errstate(invalid="ignore")
     def test_fit_MLE_comp_optimzer(self, rvs_shape, rvs_loc, rvs_scale):
         data = stats.pareto.rvs(size=100, b=rvs_shape, scale=rvs_scale,
                                 loc=rvs_loc)

--- a/scipy/stats/tests/test_sampling.py
+++ b/scipy/stats/tests/test_sampling.py
@@ -1,4 +1,3 @@
-import math
 import threading
 import pickle
 import pytest
@@ -683,10 +682,6 @@ class TestNumericalInversePolynomial:
     very_slow_dists = ['studentized_range', 'trapezoid', 'triang', 'vonmises',
                        'levy_stable', 'kappa4', 'ksone', 'kstwo', 'levy_l',
                        'gausshyper', 'anglit']
-    # for some reason, UNU.RAN segmentation faults for the uniform.
-    fatal_fail_dists = ['uniform']
-    # fails for unbounded PDFs
-    unbounded_pdf_fail_dists = ['beta']
     # for these distributions, some assertions fail due to minor
     # numerical differences. They can be avoided either by changing
     # the seed or by increasing the u_resolution.
@@ -700,10 +695,6 @@ class TestNumericalInversePolynomial:
             pytest.skip(f"PINV too slow for {distname}")
         if distname in self.fail_dists:
             pytest.skip(f"PINV fails for {distname}")
-        if distname in self.unbounded_pdf_fail_dists:
-            pytest.skip("PINV fails for unbounded PDFs.")
-        if distname in self.fatal_fail_dists:
-            pytest.xfail(f"PINV segmentation faults for {distname}")
         dist = (getattr(stats, distname)
                 if isinstance(distname, str)
                 else distname)


### PR DESCRIPTION
* backport all three merged PRs with the appropriate label:
  * gh-15798
  * gh-16035
  * gh-16041
 * add Henry Schreiner to the release notes for providing [critical assitance](https://github.com/pypa/manylinux/issues/1309#issuecomment-1120330468) in handling the new [`git` security measure](https://github.blog/2022-04-12-git-security-vulnerability-announced/)
 * I do anticipate that we'll see a few CI failures that we also saw in gh-16139, though I believe we can probably safely ignore them (wheels repo CI is passing, etc.); we should check for anything new beyond those though, since there were some non-trivial merge conflicts/submodule changes