### PR TITLE
MAINT: correct wrong license of Biasedurn

### DIFF
--- a/LICENSES_bundled.txt
+++ b/LICENSES_bundled.txt
@@ -241,3 +241,8 @@ Name: Boost
 Files: scipy/_lib/boost/*
 License: Boost Software License - Version 1.0
   For details, see scipy/_lib/boost/LICENSE_1_0.txt
+
+Name: Biasedurn
+Files: scipy/stats/biasedurn/*
+License 3-Clause BSD
+  For details, see scipy/stats/biasedurn/license.txt

--- a/scipy/stats/biasedurn/erfres.cpp
+++ b/scipy/stats/biasedurn/erfres.cpp
@@ -23,7 +23,7 @@ ERFRES_N =   13    (number of tables)
 ERFRES_L =   48    (length of each table)
 
 * Copyright 2004-2008 by Agner Fog. 
-* GNU General Public License http://www.gnu.org/licenses/gpl.html
+* Released under SciPy's license with permission of Agner Fog; see license.txt
 *****************************************************************************/
 extern "C" {
 

--- a/scipy/stats/biasedurn/fnchyppr.cpp
+++ b/scipy/stats/biasedurn/fnchyppr.cpp
@@ -19,7 +19,7 @@
 * instructions.
 *
 * Copyright 2002-2014 by Agner Fog. 
-* GNU General Public License http://www.gnu.org/licenses/gpl.html
+* Released under SciPy's license with permission of Agner Fog; see license.txt
 *****************************************************************************/
 
 #include <string.h>                    // memcpy function

--- a/scipy/stats/biasedurn/randomc.h
+++ b/scipy/stats/biasedurn/randomc.h
@@ -90,7 +90,7 @@
 * instructions for these random number generators.
 *
 * Copyright 1997-2008 by Agner Fog. 
-* GNU General Public License http://www.gnu.org/licenses/gpl.html
+* Released under SciPy's license with permission of Agner Fog; see license.txt
 *******************************************************************************/
 
 #ifndef RANDOMC_H

--- a/scipy/stats/biasedurn/stoc1.cpp
+++ b/scipy/stats/biasedurn/stoc1.cpp
@@ -20,7 +20,7 @@
 * The file ran-instructions.pdf contains general instructions.
 *
 * Copyright 2002-2008 by Agner Fog. 
-* GNU General Public License http://www.gnu.org/licenses/gpl.html
+* Released under SciPy's license with permission of Agner Fog; see license.txt
 *****************************************************************************/
 
 #include "stocc.h"     // class definition

--- a/scipy/stats/biasedurn/stoc3.cpp
+++ b/scipy/stats/biasedurn/stoc3.cpp
@@ -24,7 +24,7 @@
 * The file ran-instructions.pdf contains general instructions.
 *
 * Copyright 2002-2008 by Agner Fog. 
-* GNU General Public License http://www.gnu.org/licenses/gpl.html
+* Released under SciPy's license with permission of Agner Fog; see license.txt
 *****************************************************************************/
 
 #include <string.h>                    // memcpy function

--- a/scipy/stats/biasedurn/stocc.h
+++ b/scipy/stats/biasedurn/stocc.h
@@ -194,7 +194,7 @@
 * the methods for calculating and sampling from these.
 *
 * Copyright 2004-2013 by Agner Fog. 
-* GNU General Public License http://www.gnu.org/licenses/gpl.html
+* Released under SciPy's license with permission of Agner Fog; see license.txt
 *******************************************************************************/
 
 #ifndef STOCC_H

--- a/scipy/stats/biasedurn/wnchyppr.cpp
+++ b/scipy/stats/biasedurn/wnchyppr.cpp
@@ -21,7 +21,7 @@
 * instructions.
 *
 * Copyright 2002-2008 by Agner Fog. 
-* GNU General Public License http://www.gnu.org/licenses/gpl.html
+* Released under SciPy's license with permission of Agner Fog; see license.txt
 *****************************************************************************/
 
 #include <string.h>                    // memcpy function


### PR DESCRIPTION
ENH: Replace mention of gpl in the biasedurn implementation. 
Written permission was given by the original author to re-license under the SciPy license.

#### Reference issue
relates to #13330

#### What does this implement/fix?
Fixes potential gap in licensing information.
