### PR TITLE
MAINT: better UNU.RAN licensing information

### DIFF
--- a/LICENSES_bundled.txt
+++ b/LICENSES_bundled.txt
@@ -246,3 +246,8 @@ Name: Biasedurn
 Files: scipy/stats/biasedurn/*
 License 3-Clause BSD
   For details, see scipy/stats/biasedurn/license.txt
+
+Name: UNU.RAN
+Files: scipy/_lib/unuran/*
+License 3-Clause BSD
+  For details, see scipy/_lib/unuran/license.txt


### PR DESCRIPTION
* Update UNU.RAN following licensing updates from https://github.com/scipy/unuran/pull/4
* Add UNU.RAN to the license bundled file

@tylerjereddy marking this one as well. Same as the other one, up to you to decide what to do in this situation.