### PR TITLE
MAINT: stats.nbinom.logcdf: fix vectorization

### DIFF
--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -344,7 +344,8 @@ class nbinom_gen(rv_discrete):
         def f1(k, n, p):
             return np.log1p(-special.betainc(k + 1, n, 1 - p))
 
-        logcdf = np.empty_like(cdf)
+        # do calc in place
+        logcdf = cdf
         with np.errstate(divide='ignore'):
             logcdf[cond] = f1(k[cond], n[cond], p[cond])
             logcdf[~cond] = np.log(cdf[~cond])

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -344,11 +344,11 @@ class nbinom_gen(rv_discrete):
         def f1(k, n, p):
             return np.log1p(-special.betainc(k + 1, n, 1 - p))
 
-        def f2(k, n, p):
-            return np.log(cdf)
-
+        logcdf = np.empty_like(cdf)
         with np.errstate(divide='ignore'):
-            return _lazywhere(cond, (x, n, p), f=f1, f2=f2)
+            logcdf[cond] = f1(k[cond], n[cond], p[cond])
+            logcdf[~cond] = np.log(cdf[~cond])
+        return logcdf
 
     def _sf(self, x, n, p):
         k = floor(x)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -361,6 +361,12 @@ class TestNBinom:
         val = scipy.stats.nbinom.logpmf(0, 1, 1)
         assert_equal(val, 0)
 
+    def test_logcdf_gh16159(self):
+        # check that gh16159 is resolved.
+        vals = stats.nbinom.logcdf([0, 5, 0, 5], n=4.8, p=0.45)
+        ref = np.log(stats.nbinom.cdf([0, 5, 0, 5], n=4.8, p=0.45))
+        assert_allclose(vals, ref)
+
 
 class TestGenInvGauss:
     def setup_method(self):


### PR DESCRIPTION
#### Reference issue
Closes gh-16159

#### What does this implement/fix?
The vectorization of `stats.nbinom.logcdf` was broken due to a mistake in the use of `_lazywhere`. This fixes it.
