### PR TITLE
BUG: fix extension module initialization, needs use of `PyMODINIT_FUNC`

### DIFF
--- a/scipy/_lib/_fpumode.c
+++ b/scipy/_lib/_fpumode.c
@@ -59,7 +59,8 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
-PyObject *PyInit__fpumode(void)
+PyMODINIT_FUNC
+PyInit__fpumode(void)
 {
     return PyModule_Create(&moduledef);
 }

--- a/scipy/_lib/_uarray/_uarray_dispatch.cxx
+++ b/scipy/_lib/_uarray/_uarray_dispatch.cxx
@@ -1775,13 +1775,8 @@ PyModuleDef uarray_module = {
 
 } // namespace
 
-#if defined(WIN32) || defined(_WIN32)
-#  define MODULE_EXPORT __declspec(dllexport)
-#else
-#  define MODULE_EXPORT __attribute__((visibility("default")))
-#endif
-
-extern "C" MODULE_EXPORT PyObject * PyInit__uarray(void) {
+PyMODINIT_FUNC
+PyInit__uarray(void) {
 
   auto m = py_ref::steal(PyModule_Create(&uarray_module));
   if (!m)

--- a/scipy/_lib/_uarray/_uarray_dispatch.cxx
+++ b/scipy/_lib/_uarray/_uarray_dispatch.cxx
@@ -1775,7 +1775,18 @@ PyModuleDef uarray_module = {
 
 } // namespace
 
+// Can be removed when Python 3.9 is the lowest supported version,
+// see gh-16165 for details.
+#if (PY_VERSION_HEX < 0x03090000)
+#  if defined(WIN32) || defined(_WIN32)
+#    define MODULE_EXPORT __declspec(dllexport)
+#  else
+#    define MODULE_EXPORT __attribute__((visibility("default")))
+#  endif
+extern "C" MODULE_EXPORT PyObject *
+#else
 PyMODINIT_FUNC
+#endif
 PyInit__uarray(void) {
 
   auto m = py_ref::steal(PyModule_Create(&uarray_module));

--- a/scipy/_lib/_uarray/meson.build
+++ b/scipy/_lib/_uarray/meson.build
@@ -3,22 +3,11 @@
 # TODO: this used -std=c++14 if available, add c++11 otherwise
 #       can we now rely on c++14 unconditionally?
 
-# FIXME: /EHsc is the default already, and for hidden use gnu_symbol_visibility
-# (see fft/_pocketfft)
-
 compiler = meson.get_compiler('cpp')
-
-if compiler.get_id() in ['msvc', 'clang-cl']
-  cpp_args = '/EHsc'
-elif compiler.has_argument('-fvisibility=hidden')
-  cpp_args = '-fvisibility=hidden'
-else
-  cpp_args = ''
-endif
 
 py3.extension_module('_uarray',
   ['_uarray_dispatch.cxx', 'vectorcall.cxx'],
-  cpp_args: [cpp_args, '-Wno-terminate', '-Wno-unused-function'],
+  cpp_args: ['-Wno-terminate', '-Wno-unused-function'],
   dependencies: py3_dep,
   install: true,
   subdir: 'scipy/_lib/_uarray'

--- a/scipy/_lib/src/_test_ccallback.c
+++ b/scipy/_lib/src/_test_ccallback.c
@@ -400,7 +400,8 @@ static struct PyModuleDef test_ccallback_module = {
 };
 
 
-PyObject *PyInit__test_ccallback(void)
+PyMODINIT_FUNC
+PyInit__test_ccallback(void)
 {
     return PyModule_Create(&test_ccallback_module);
 }

--- a/scipy/integrate/_odepackmodule.c
+++ b/scipy/integrate/_odepackmodule.c
@@ -822,7 +822,7 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
-PyObject *
+PyMODINIT_FUNC
 PyInit__odepack(void)
 {
     PyObject *m, *d, *s;

--- a/scipy/integrate/_quadpackmodule.c
+++ b/scipy/integrate/_quadpackmodule.c
@@ -26,7 +26,8 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
-PyObject *PyInit__quadpack(void)
+PyMODINIT_FUNC
+PyInit__quadpack(void)
 {
     PyObject *m, *d, *s;
 

--- a/scipy/integrate/tests/_test_multivariate.c
+++ b/scipy/integrate/tests/_test_multivariate.c
@@ -109,7 +109,8 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
-PyObject *PyInit__test_multivariate(void)
+PyMODINIT_FUNC
+PyInit__test_multivariate(void)
 {
     PyObject *m;
     m = PyModule_Create(&moduledef);

--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -1547,7 +1547,8 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
-PyObject *PyInit__fitpack(void)
+PyMODINIT_FUNC
+PyInit__fitpack(void)
 {
     PyObject *m, *d, *s;
 

--- a/scipy/ndimage/src/_ctest.c
+++ b/scipy/ndimage/src/_ctest.c
@@ -170,7 +170,8 @@ static struct PyModuleDef _ctest = {
 };
 
 
-PyObject *PyInit__ctest(void)
+PyMODINIT_FUNC
+PyInit__ctest(void)
 {
     return PyModule_Create(&_ctest);
 }

--- a/scipy/ndimage/src/nd_image.c
+++ b/scipy/ndimage/src/nd_image.c
@@ -1176,7 +1176,8 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
-PyObject *PyInit__nd_image(void)
+PyMODINIT_FUNC
+PyInit__nd_image(void)
 {
     PyObject *m;
 

--- a/scipy/odr/__odrpack.c
+++ b/scipy/odr/__odrpack.c
@@ -1293,7 +1293,8 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
-PyObject *PyInit___odrpack(void)
+PyMODINIT_FUNC
+PyInit___odrpack(void)
 {
     PyObject *m;
     import_array();

--- a/scipy/optimize/_lsap_module.c
+++ b/scipy/optimize/_lsap_module.c
@@ -114,7 +114,7 @@ static struct PyModuleDef moduledef = {
     NULL,
 };
 
-PyObject*
+PyMODINIT_FUNC
 PyInit__lsap_module(void)
 {
     PyObject* m;

--- a/scipy/optimize/_minpackmodule.c
+++ b/scipy/optimize/_minpackmodule.c
@@ -25,7 +25,9 @@ static struct PyModuleDef moduledef = {
     NULL,
     NULL
 };
-PyObject *PyInit__minpack(void)
+
+PyMODINIT_FUNC
+PyInit__minpack(void)
 {
     PyObject *m, *d, *s;
 

--- a/scipy/optimize/tnc/moduleTNC.c.old
+++ b/scipy/optimize/tnc/moduleTNC.c.old
@@ -321,7 +321,8 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
-PyObject *PyInit__moduleTNC(void)
+PyMODINIT_FUNC
+PyInit__moduleTNC(void)
 {
     import_array();
     return PyModule_Create(&moduledef);

--- a/scipy/optimize/zeros.c
+++ b/scipy/optimize/zeros.c
@@ -197,7 +197,8 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
-PyObject *PyInit__zeros(void)
+PyMODINIT_FUNC
+PyInit__zeros(void)
 {
     PyObject *m;
 

--- a/scipy/signal/_sigtoolsmodule.c
+++ b/scipy/signal/_sigtoolsmodule.c
@@ -1418,12 +1418,14 @@ static struct PyModuleDef moduledef = {
     NULL,
     NULL
 };
-PyObject *PyInit__sigtools(void)
+
+PyMODINIT_FUNC
+PyInit__sigtools(void)
 {
     PyObject *m;
 
     m = PyModule_Create(&moduledef);
-	import_array();
+    import_array();
 
     scipy_signal__sigtools_linear_filter_module_init();
 

--- a/scipy/signal/_splinemodule.c
+++ b/scipy/signal/_splinemodule.c
@@ -551,7 +551,8 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
-PyObject *PyInit__spline(void)
+PyMODINIT_FUNC
+PyInit__spline(void)
 {
     PyObject *m, *d, *s;
 

--- a/scipy/sparse/linalg/_dsolve/_superlumodule.c
+++ b/scipy/sparse/linalg/_dsolve/_superlumodule.c
@@ -326,7 +326,8 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
-PyObject *PyInit__superlu(void)
+PyMODINIT_FUNC
+PyInit__superlu(void)
 {
     PyObject *m, *d;
 

--- a/scipy/sparse/sparsetools/sparsetools.cxx
+++ b/scipy/sparse/sparsetools/sparsetools.cxx
@@ -563,7 +563,8 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
-PyObject *PyInit__sparsetools(void)
+PyMODINIT_FUNC
+PyInit__sparsetools(void)
 {
     PyObject *m;
     m = PyModule_Create(&moduledef);

--- a/scipy/spatial/meson.build
+++ b/scipy/spatial/meson.build
@@ -59,16 +59,8 @@ ckdtree_src = [
 cpp_args = []
 compiler = meson.get_compiler('cpp')
 
-if compiler.get_id() == 'msvc'
-  cpp_args = cpp_args + ['/EHsc']
-elif compiler.has_argument('-fvisibility=hidden')
-  cpp_args = cpp_args + ['-fvisibility=hidden']
-endif
-
 ckdtree = py3.extension_module('_ckdtree',
   ckdtree_src + [cython_gen_cpp.process('_ckdtree.pyx')],
-  # Cannot use -fnovisibility=hidden for Cython cpp, because it
-  # conceals PyInit_ckdtree symbol, and prevents module load.
   cpp_args: cython_cpp_args,
   include_directories: [
     incdir_numpy,

--- a/scipy/spatial/src/distance_wrap.c
+++ b/scipy/spatial/src/distance_wrap.c
@@ -847,7 +847,8 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
-PyObject *PyInit__distance_wrap(void)
+PyMODINIT_FUNC
+PyInit__distance_wrap(void)
 {
     PyObject *m;
 


### PR DESCRIPTION
This is related to gh-15996. After a change in Meson to use visibility=hidden by default, imports were failing.

What is going on here is that CPython creates C/C++ default behavior of:
```C
#ifndef PyMODINIT_FUNC
#       if defined(__cplusplus)
#               define PyMODINIT_FUNC extern "C" Py_EXPORTED_SYMBOL PyObject*
#       else /* __cplusplus */
#               define PyMODINIT_FUNC Py_EXPORTED_SYMBOL PyObject*
#       endif /* __cplusplus */   
#endif
```
and we, by using plain `PyObject *`, were missing the part where the module initialization function was explicitly marked as exported.

It looks like we've never used `PyMODINIT_FUNC` correctly. The only relevant change that I could find so quickly is gh-12086, which removed `PyMODINIT_FUNC` from the only three modules that used it (and so was incorrect).
