### PR TITLE
ENH: Tweak theilslopes and siegelslopes to return a tuple_bunch

### DIFF
--- a/scipy/stats/_mstats_basic.py
+++ b/scipy/stats/_mstats_basic.py
@@ -1052,14 +1052,17 @@ def theilslopes(y, x=None, alpha=0.95, method='separate'):
 
     Returns
     -------
-    medslope : float
-        Theil slope.
-    medintercept : float
-        Intercept of the Theil line, as ``median(y) - medslope*median(x)``.
-    lo_slope : float
-        Lower bound of the confidence interval on `medslope`.
-    up_slope : float
-        Upper bound of the confidence interval on `medslope`.
+    result : ``TheilslopesResult`` instance
+        The return value is an object with the following attributes:
+
+        medslope : float
+            Theil slope.
+        medintercept : float
+            Intercept of the Theil line.
+        lo_slope : float
+            Lower bound of the confidence interval on `medslope`.
+        up_slope : float
+            Upper bound of the confidence interval on `medslope`.
 
     See Also
     --------
@@ -1111,10 +1114,13 @@ def siegelslopes(y, x=None, method="hierarchical"):
 
     Returns
     -------
-    medslope : float
-        Estimate of the slope of the regression line.
-    medintercept : float
-        Estimate of the intercept of the regression line.
+    result : ``SiegelslopesResult`` instance
+        The return value is an object with the following attributes:
+
+        medslope : float
+            Estimate of the slope of the regression line.
+        medintercept : float
+            Estimate of the intercept of the regression line.
 
     See Also
     --------

--- a/scipy/stats/_stats_mstats_common.py
+++ b/scipy/stats/_stats_mstats_common.py
@@ -12,6 +12,11 @@ LinregressResult = _make_tuple_bunch('LinregressResult',
                                      ['slope', 'intercept', 'rvalue',
                                       'pvalue', 'stderr'],
                                      extra_field_names=['intercept_stderr'])
+TheilslopesResult = _make_tuple_bunch('TheilslopesResult',
+                                      ['medslope', 'medintercept',
+                                       'lo_slope', 'up_slope'])
+SiegelslopesResult = _make_tuple_bunch('SiegelslopesResult',
+                                       ['medslope', 'medintercept'])
 
 
 def linregress(x, y=None, alternative='two-sided'):
@@ -235,14 +240,17 @@ def theilslopes(y, x=None, alpha=0.95, method='separate'):
 
     Returns
     -------
-    medslope : float
-        Theil slope.
-    medintercept : float
-        Intercept of the Theil line.
-    lo_slope : float
-        Lower bound of the confidence interval on `medslope`.
-    up_slope : float
-        Upper bound of the confidence interval on `medslope`.
+    result : ``TheilslopesResult`` instance
+        The return value is an object with the following attributes:
+
+        medslope : float
+            Theil slope.
+        medintercept : float
+            Intercept of the Theil line.
+        lo_slope : float
+            Lower bound of the confidence interval on `medslope`.
+        up_slope : float
+            Upper bound of the confidence interval on `medslope`.
 
     See Also
     --------
@@ -257,6 +265,13 @@ def theilslopes(y, x=None, alpha=0.95, method='separate'):
     in [4]_. The approach to compute the intercept can be determined by the
     parameter ``method``. A confidence interval for the intercept is not
     given as this question is not addressed in [1]_.
+
+    For compatibility with older versions of SciPy, the return value acts
+    like a ``namedtuple`` of length 4, with fields ``medslope``,
+    ``medintercept``, ``lo_slope``, and ``up_slope``, so one can continue to
+    write::
+
+        medslope, medintercept, lo_slope, up_slope = theilslopes(y, x)
 
     References
     ----------
@@ -350,7 +365,8 @@ def theilslopes(y, x=None, alpha=0.95, method='separate'):
     except (ValueError, IndexError):
         delta = (np.nan, np.nan)
 
-    return medslope, medinter, delta[0], delta[1]
+    return TheilslopesResult(medslope=medslope, medintercept=medinter,
+                             lo_slope=delta[0], up_slope=delta[1])
 
 
 def _find_repeats(arr):
@@ -395,10 +411,13 @@ def siegelslopes(y, x=None, method="hierarchical"):
 
     Returns
     -------
-    medslope : float
-        Estimate of the slope of the regression line.
-    medintercept : float
-        Estimate of the intercept of the regression line.
+    result : ``SiegelslopesResult`` instance
+        The return value is an object with the following attributes:
+
+        medslope : float
+            Estimate of the slope of the regression line.
+        medintercept : float
+            Estimate of the intercept of the regression line.
 
     See Also
     --------
@@ -421,6 +440,12 @@ def siegelslopes(y, x=None, method="hierarchical"):
     The implementation computes `n` times the median of a vector of size `n`
     which can be slow for large vectors. There are more efficient algorithms
     (see [2]_) which are not implemented here.
+
+    For compatibility with older versions of SciPy, the return value acts
+    like a ``namedtuple`` of length 2, with fields ``medslope`` and
+    ``medintercept``, so one can continue to write::
+
+        medslope, medintercept = siegelslopes(y, x)
 
     References
     ----------
@@ -489,4 +514,4 @@ def siegelslopes(y, x=None, method="hierarchical"):
     else:
         medinter = np.median(y - medslope*x)
 
-    return medslope, medinter
+    return SiegelslopesResult(medslope=medslope, medintercept=medinter)

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -953,7 +953,10 @@ def test_theilslopes_warnings():
 
 
 def test_theilslopes_namedtuple_consistency():
-    """Simple test to ensure tuple backwards-compatibility of returned object"""
+    """
+    Simple test to ensure tuple backwards-compatibility of the returned
+    TheilslopesResult object
+    """
     y = [1, 2, 4]
     x = [4, 6, 8]
     medslope, medintercept, lo_slope, up_slope = mstats.theilslopes(y, x)
@@ -996,7 +999,10 @@ def test_siegelslopes():
 
 
 def test_siegelslopes_namedtuple_consistency():
-    """Simple test to ensure tuple backwards-compatibility of returned object"""
+    """
+    Simple test to ensure tuple backwards-compatibility of the returned
+    SiegelslopesResult object.
+    """
     y = [1, 2, 4]
     x = [4, 6, 8]
     medslope, medintercept = mstats.siegelslopes(y, x)

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -952,6 +952,20 @@ def test_theilslopes_warnings():
         assert_allclose(res, (0, 0, np.nan, np.nan))
 
 
+def test_theilslopes_namedtuple_consistency():
+    """Simple test to ensure tuple backwards-compatibility of returned object"""
+    y = [1, 2, 4]
+    x = [4, 6, 8]
+    medslope, medintercept, lo_slope, up_slope = mstats.theilslopes(y, x)
+    result = mstats.theilslopes(y, x)
+
+    # note all four returned values are distinct here
+    assert_equal(medslope, result.medslope)
+    assert_equal(medintercept, result.medintercept)
+    assert_equal(lo_slope, result.lo_slope)
+    assert_equal(up_slope, result.up_slope)
+
+
 def test_siegelslopes():
     # method should be exact for straight line
     y = 2 * np.arange(10) + 0.5
@@ -979,6 +993,18 @@ def test_siegelslopes():
     slope, intercept = mstats.siegelslopes(y, x, method='separate')
     assert_allclose(slope, slope_ols, rtol=0.1)
     assert_allclose(intercept, intercept_ols, rtol=0.1)
+
+
+def test_siegelslopes_namedtuple_consistency():
+    """Simple test to ensure tuple backwards-compatibility of returned object"""
+    y = [1, 2, 4]
+    x = [4, 6, 8]
+    medslope, medintercept = mstats.siegelslopes(y, x)
+    result = mstats.siegelslopes(y, x)
+
+    # note both returned values are distinct here
+    assert_equal(medslope, result.medslope)
+    assert_equal(medintercept, result.medintercept)
 
 
 def test_plotting_positions():


### PR DESCRIPTION
I was surprised that I couldn't access the attributes by name of `stats.theilslopes` and `stats.siegelslopes`'s return values, so this makes their behavior consistent with `stats.linregress` (where you can do that).

I'm using the `_make_tuple_bunch` function for consistency, though a namedtuple would work fine here.

This was mentioned a long time ago in https://github.com/scipy/scipy/issues/3665, but was never moved into the regression functions other than `linregress`.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

N/A (unless you count https://github.com/scipy/scipy/issues/3665).

#### What does this implement/fix?
<!--Please explain your changes.-->

Changes the return values of `stats.theilslopes` and `stats.siegelslopes` to be consistent with `stats.linregress`'s `LinregressResult` object. For these cases, they are essentially namedtuples since there are no extra fields.

The documentation changes have to be duplicated into `mstats` as well as `stats`.

#### Additional information
<!--Any additional information you think is important.-->

I also added two small tests to make sure the unpacking actually still works for backwards compatibility.