### PR TITLE
BUG: special: Fix the test 'test_d' that is run when SCIPY_XSLOW is defined.

### DIFF
--- a/scipy/special/tests/test_precompute_gammainc.py
+++ b/scipy/special/tests/test_precompute_gammainc.py
@@ -77,7 +77,7 @@ def test_d():
                    (9, 12, mp.mpf('0.870823417786464116761231237189e-6'))]
         d = compute_d(10, 13)
         res = [d[k][n] for k, n, std in dataset]
-        std = map(lambda x: x[2], dataset)
+        std = [x[2] for x in dataset]
         mp_assert_allclose(res, std)
 
 


### PR DESCRIPTION
When the environment variable 'SCIPY_XSLOW' is defined, the test 'test_d()'
in 'special/tests/test_precompute_gammainc.py' was failing because it was
passing the result of a call to map() as the 'std' argument of the test
function 'mp_assert_allclose()'.  The essential part of the error message
was:

```
scipy/special/_mptestutils.py:429: in mp_assert_allclose
    n = len(std)
E   TypeError: object of type 'map' has no len()
```

'mp_assert_allclose' expected the 'std' argument to be an object that
can be passed to 'len()', but a 'map' object is not.

The immediate fix is to replace this use of 'map'

    std = map(lambda x: x[2], dataset)

in 'test_d()' with the simpler and more efficient list comprehension

    std = [x[2] for x in dataset]

That would be enough to fix the bug, but I have also updated
'mp_assert_allclose' to allow iterators. I also simplified the
code a bit; specifically, an unnecessary try/except statement was
eliminated.
