### PR TITLE
CI: pin Pip to 22.0.4 to avoid issues with `--no-build-isolation`

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -248,7 +248,7 @@ stages:
         git submodule update --init
       displayName: 'Fetch submodules'
     - script: |
-        python -m pip install --upgrade pip "setuptools==59.6.0" wheel
+        python -m pip install --upgrade "pip==22.0.4" "setuptools==59.6.0" wheel
       displayName: 'Install tools'
     - powershell: |
         $pyversion = python -c "import sys; print(sys.version.split()[0])"

--- a/ci/azure-travis-template.yaml
+++ b/ci/azure-travis-template.yaml
@@ -64,7 +64,7 @@ steps:
   displayName: 'Add ccache to path'
 - script: >-
     pip install --upgrade ${{parameters.numpy_spec}} &&
-    pip install --upgrade pip setuptools==59.6.0 wheel &&
+    pip install --upgrade pip==22.0.4 setuptools==59.6.0 wheel &&
     pip install ${{parameters.other_spec}}
     cython
     gmpy2


### PR DESCRIPTION
This change can be reverted once Pip releases its next version with a fix for https://github.com/pypa/pip/issues/11116.

At the moment all our Azure builds are failing with errors like:
```
ERROR: Some build dependencies for file:///D:/a/1/s conflict with the backend dependencies:
numpy==1.21.4 is incompatible with numpy==1.18.5; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'.
```

The short summary of the issue is: pip 22.1 is unusable for us with `--no-build-isolation`, since it trips up over the pins in our `pyproject.toml` file.

[skip github]