### PR TITLE
TST: fix test failure due to changes in numpy scalar behavior.

### DIFF
--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2190,7 +2190,8 @@ class TestCorrelateComplex:
 
         y_r = (correlate(a.real, b.real)
                + correlate(a.imag, b.imag)).astype(dt)
-        y_r += 1j * (-correlate(a.real, b.imag) + correlate(a.imag, b.real))
+        y_r += 1j * np.array(-correlate(a.real, b.imag) +
+                             correlate(a.imag, b.real))
 
         y = correlate(a, b, 'full')
         assert_array_almost_equal(y, y_r, decimal=self.decimal(dt) - 1)


### PR DESCRIPTION
Closes gh-16174. Note that this will likely be fixed in NumPy, but the test is fine written this way and it fixes an annoying CI failure, so we can leave the test like this.

[skip azurepipelines]
