### PR TITLE
MAINT: remove questionable uses of `Py_FatalError` in module init

### DIFF
--- a/scipy/integrate/_ode.py
+++ b/scipy/integrate/_ode.py
@@ -79,8 +79,6 @@ an alternative to ode with the zvode solver, sometimes performing better.
 #     IntegratorBase.integrator_classes.append(myodeint)
 
 __all__ = ['ode', 'complex_ode']
-__version__ = "$Id$"
-__docformat__ = "restructuredtext en"
 
 import re
 import warnings

--- a/scipy/integrate/_odepackmodule.c
+++ b/scipy/integrate/_odepackmodule.c
@@ -825,19 +825,26 @@ static struct PyModuleDef moduledef = {
 PyMODINIT_FUNC
 PyInit__odepack(void)
 {
-    PyObject *m, *d, *s;
+    PyObject *module, *mdict;
 
-    m = PyModule_Create(&moduledef);
-    import_array();
-    d = PyModule_GetDict(m);
-
-    s = PyUnicode_FromString(" 1.9 ");
-    PyDict_SetItemString(d, "__version__", s);
-    odepack_error = PyErr_NewException ("odepack.error", NULL, NULL);
-    Py_DECREF(s);
-    PyDict_SetItemString(d, "error", odepack_error);
-    if (PyErr_Occurred()) {
-        Py_FatalError("can't initialize module odepack");
+    module = PyModule_Create(&moduledef);
+    if (module == NULL) {
+        return NULL;
     }
-    return m;
+
+    import_array();
+
+    mdict = PyModule_GetDict(module);
+    if (mdict == NULL) {
+        return NULL;
+    }
+    odepack_error = PyErr_NewException("_odepack.error", NULL, NULL);
+    if (odepack_error == NULL) {
+        return NULL;
+    }
+    if (PyDict_SetItemString(mdict, "error", odepack_error)) {
+        return NULL;
+    }
+
+    return module;
 }

--- a/scipy/integrate/_quadpackmodule.c
+++ b/scipy/integrate/_quadpackmodule.c
@@ -29,19 +29,27 @@ static struct PyModuleDef moduledef = {
 PyMODINIT_FUNC
 PyInit__quadpack(void)
 {
-    PyObject *m, *d, *s;
+    PyObject *module, *mdict;
 
-    m = PyModule_Create(&moduledef);
-    import_array();
-    d = PyModule_GetDict(m);
-
-    s = PyUnicode_FromString(" 1.13 ");
-    PyDict_SetItemString(d, "__version__", s);
-    quadpack_error = PyErr_NewException ("quadpack.error", NULL, NULL);
-    Py_DECREF(s);
-    PyDict_SetItemString(d, "error", quadpack_error);
-    if (PyErr_Occurred()) {
-        Py_FatalError("can't initialize module quadpack");
+    module = PyModule_Create(&moduledef);
+    if (module == NULL) {
+        return NULL;
     }
-    return m;
+
+    import_array();
+
+    mdict = PyModule_GetDict(module);
+    if (mdict == NULL) {
+        return NULL;
+    }
+
+    quadpack_error = PyErr_NewException ("_quadpack.error", NULL, NULL);
+    if (quadpack_error == NULL) {
+        return NULL;
+    }
+    if (PyDict_SetItemString(mdict, "error", quadpack_error)) {
+        return NULL;
+    }
+
+    return module;
 }

--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -1550,20 +1550,24 @@ static struct PyModuleDef moduledef = {
 PyMODINIT_FUNC
 PyInit__fitpack(void)
 {
-    PyObject *m, *d, *s;
+    PyObject *module, *mdict;
 
-    m = PyModule_Create(&moduledef);
-    import_array();
-
-    d = PyModule_GetDict(m);
-
-    s = PyUnicode_FromString(" 1.7 ");
-    PyDict_SetItemString(d, "__version__", s);
-    fitpack_error = PyErr_NewException ("fitpack.error", NULL, NULL);
-    Py_DECREF(s);
-    if (PyErr_Occurred()) {
-        Py_FatalError("can't initialize module fitpack");
+    module = PyModule_Create(&moduledef);
+    if (module == NULL) {
+        return NULL;
     }
 
-    return m;
+    import_array();
+
+    mdict = PyModule_GetDict(module);
+
+    fitpack_error = PyErr_NewException ("_fitpack.error", NULL, NULL);
+    if (fitpack_error == NULL) {
+        return NULL;
+    }
+    if (PyDict_SetItemString(mdict, "error", fitpack_error)) {
+        return NULL;
+    }
+
+    return module;
 }

--- a/scipy/optimize/_minpackmodule.c
+++ b/scipy/optimize/_minpackmodule.c
@@ -29,20 +29,26 @@ static struct PyModuleDef moduledef = {
 PyMODINIT_FUNC
 PyInit__minpack(void)
 {
-    PyObject *m, *d, *s;
+    PyObject *module, *mdict;
 
-    m = PyModule_Create(&moduledef);
+    module = PyModule_Create(&moduledef);
+    if (module == NULL) {
+        return NULL;
+    }
+
     import_array();
 
-    d = PyModule_GetDict(m);
+    mdict = PyModule_GetDict(module);
+    if (mdict == NULL) {
+        return NULL;
+    }
+    minpack_error = PyErr_NewException ("_minpack.error", NULL, NULL);
+    if (minpack_error == NULL) {
+        return NULL;
+    }
+    if (PyDict_SetItemString(mdict, "error", minpack_error)) {
+        return NULL;
+    }
 
-    s = PyUnicode_FromString(" 1.10 ");
-    PyDict_SetItemString(d, "__version__", s);
-    Py_DECREF(s);
-    minpack_error = PyErr_NewException ("minpack.error", NULL, NULL);
-    PyDict_SetItemString(d, "error", minpack_error);
-    if (PyErr_Occurred())
-        Py_FatalError("can't initialize module minpack");
-
-    return m;
+    return module;
 }

--- a/scipy/signal/_splinemodule.c
+++ b/scipy/signal/_splinemodule.c
@@ -554,21 +554,13 @@ static struct PyModuleDef moduledef = {
 PyMODINIT_FUNC
 PyInit__spline(void)
 {
-    PyObject *m, *d, *s;
+    PyObject *module;
+    module = PyModule_Create(&moduledef);
+    if (module == NULL) {
+        return NULL;
+    }
 
-    m = PyModule_Create(&moduledef);
     import_array();
 
-    /* Add some symbolic constants to the module */
-    d = PyModule_GetDict(m);
-
-    s = PyUnicode_FromString("0.2");
-    PyDict_SetItemString(d, "__version__", s);
-    Py_DECREF(s);
-
-    /* Check for errors */
-    if (PyErr_Occurred()) {
-        Py_FatalError("can't initialize module array");
-    }
-    return m;
+    return module;
 }

--- a/scipy/sparse/linalg/_dsolve/_superlumodule.c
+++ b/scipy/sparse/linalg/_dsolve/_superlumodule.c
@@ -329,27 +329,30 @@ static struct PyModuleDef moduledef = {
 PyMODINIT_FUNC
 PyInit__superlu(void)
 {
-    PyObject *m, *d;
+    PyObject *module, *mdict;
 
     import_array();
 
     if (PyType_Ready(&SuperLUType) < 0) {
         return NULL;
     }
-
     if (PyType_Ready(&SuperLUGlobalType) < 0) {
     	return NULL;
     }
 
-    m = PyModule_Create(&moduledef);
-    d = PyModule_GetDict(m);
+    module = PyModule_Create(&moduledef);
+    if (module == NULL) {
+        return NULL;
+    }
+    mdict = PyModule_GetDict(module);
+    if (mdict == NULL) {
+        return NULL;
+    }
 
     Py_INCREF(&PyArrayFlags_Type);
-    PyDict_SetItemString(d, "SuperLU",
-			 (PyObject *) &SuperLUType);
+    if (PyDict_SetItemString(mdict, "SuperLU", (PyObject *) &SuperLUType)) {
+        return NULL;
+    }
 
-    if (PyErr_Occurred())
-	Py_FatalError("can't initialize module _superlu");
-
-    return m;
+    return module;
 }


### PR DESCRIPTION
Returning `NULL` allows the importer to recover (e.g., in out-of-memory situations). Aborting the whole process should only be done as a last resort.

See for example https://stackoverflow.com/questions/46687928/should-a-c-extension-fail-in-module-init-if-a-pymodule-add-function-fails for more context.