### PR TITLE
MAINT: Cleanup unused code in meson-files

### DIFF
--- a/scipy/_lib/_uarray/meson.build
+++ b/scipy/_lib/_uarray/meson.build
@@ -3,8 +3,6 @@
 # TODO: this used -std=c++14 if available, add c++11 otherwise
 #       can we now rely on c++14 unconditionally?
 
-compiler = meson.get_compiler('cpp')
-
 py3.extension_module('_uarray',
   ['_uarray_dispatch.cxx', 'vectorcall.cxx'],
   cpp_args: ['-Wno-terminate', '-Wno-unused-function'],

--- a/scipy/spatial/meson.build
+++ b/scipy/spatial/meson.build
@@ -56,9 +56,6 @@ ckdtree_src = [
   'ckdtree/src/sparse_distances.cxx'
 ]
 
-cpp_args = []
-compiler = meson.get_compiler('cpp')
-
 ckdtree = py3.extension_module('_ckdtree',
   ckdtree_src + [cython_gen_cpp.process('_ckdtree.pyx')],
   cpp_args: cython_cpp_args,
@@ -84,7 +81,7 @@ _distance_wrap = py3.extension_module('_distance_wrap',
 
 _distance_pybind = py3.extension_module('_distance_pybind',
   ['src/distance_pybind.cpp'],
-  cpp_args: cpp_args + [numpy_nodepr_api],
+  cpp_args: [numpy_nodepr_api],
   include_directories: [incdir_pybind11, incdir_numpy, 'src/'],
   dependencies: [py3_dep],
   install: true,


### PR DESCRIPTION
gh-16165 removed `/EHsc` and `-fvisibility=hidden` flags, for reasons
that aren't clear to me. So this returns them and writes it in a more
meson-ic way (if that's a word).
