### PR TITLE
DOC: Fix error in kulczynski1 example

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -910,7 +910,7 @@ def kulczynski1(u, v, *, w=None):
     0.0
     >>> distance.kulczynski1([True, False, False], [True, True, False])
     1.0
-    >>> distance.kulczynski1([True, False, False], True)
+    >>> distance.kulczynski1([True, False, False], [True])
     0.5
     >>> distance.kulczynski1([1, 0, 0], [3, 1, 0])
     -3.0


### PR DESCRIPTION
#### Reference issue
Follow up to #16144

#### What does this implement/fix?
This example relies on the `atleast_1d` call that has been removed from `_validate_vector`.
