### PR TITLE
DEV: do.py build. On setup checks if intro-buildoptions.json exists instead of build dir.

### DIFF
--- a/do.py
+++ b/do.py
@@ -391,9 +391,10 @@ class Build(Task):
             if list(build_dir.iterdir()):
                 raise RuntimeError("Can't build into non-empty directory "
                                    f"'{build_dir.absolute()}'")
-        if build_dir.exists():
-            build_options_file = (
-                build_dir / "meson-info" / "intro-buildoptions.json")
+
+        build_options_file = (
+            build_dir / "meson-info" / "intro-buildoptions.json")
+        if build_options_file.exists():
             with open(build_options_file) as f:
                 build_options = json.load(f)
             installdir = None


### PR DESCRIPTION

In case there was a failure on previous setup execution,
there will be a build dir but no buildoptions file.

By checking the file instead of the dir, it ensures the `meson setup` command will be executed when required. 