### PR TITLE
BUG: stats: fix multivariate_hypergeom.rvs method

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -4872,9 +4872,11 @@ class multivariate_hypergeom_gen(multi_rv_generic):
         # https://github.com/numpy/numpy/pull/13794
         for c in range(m.shape[-1] - 1):
             rem = rem - m[..., c]
-            rvs[..., c] = ((n != 0) *
-                           random_state.hypergeometric(m[..., c], rem,
-                                                       n + (n == 0),
+            n0mask = n == 0
+            rvs[..., c] = (~n0mask *
+                           random_state.hypergeometric(m[..., c],
+                                                       rem + n0mask,
+                                                       n + n0mask,
                                                        size=size))
             n = n - rvs[..., c]
         rvs[..., m.shape[-1] - 1] = n

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -1976,6 +1976,17 @@ class TestMultivariateHypergeom:
         rvs = rv.rvs(size=(1000, 2), random_state=123)
         assert_allclose(rvs.mean(0), rv.mean(), rtol=1e-2)
 
+    @pytest.mark.parametrize('m, n', (
+        ([0, 0, 20, 0, 0], 5), ([0, 0, 0, 0, 0], 0), ([0, 0], 0),
+        ([0, 0], 0), ([0], 0)
+    ))
+    def test_rvs_gh16171(self, m, n):
+        res = multivariate_hypergeom.rvs(m, n)
+        m = np.asarray(m)
+        res_ex = m.copy()
+        res_ex[m != 0] = n
+        assert_equal(res, res_ex)
+
     @pytest.mark.parametrize(
         "x, m, n, expected",
         [

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -1977,7 +1977,7 @@ class TestMultivariateHypergeom:
         assert_allclose(rvs.mean(0), rv.mean(), rtol=1e-2)
 
     @pytest.mark.parametrize('m, n', (
-        ([0, 0, 20, 0, 0], 5), ([0, 0, 0, 0, 0], 0), ([0, 0], 0),
+        ([0, 0, 20, 0, 0], 5), ([0, 0, 0, 0, 0], 0),
         ([0, 0], 0), ([0], 0)
     ))
     def test_rvs_gh16171(self, m, n):


### PR DESCRIPTION
#### Reference issue

fixes #16171 

#### What does this implement/fix?

Fixes multivariate_hypergeom.rvs method when the last two or more elements of the population are 0.
