### PR TITLE
DEP: raise if fillvalue cannot be cast to output type in signal.convolve2d

### DIFF
--- a/scipy/signal/_sigtoolsmodule.c
+++ b/scipy/signal/_sigtoolsmodule.c
@@ -1086,13 +1086,8 @@ static PyObject *_sigtools_convolve2d(PyObject *NPY_UNUSED(dummy), PyObject *arg
             afill = (PyArrayObject *)PyArray_Cast(tmp, typenum);
             Py_DECREF(tmp);
             if (afill == NULL) goto fail;
-            /* Deprecated 2017-07, scipy version 1.0.0 */
-            if (DEPRECATE("could not cast `fillvalue` directly to the output "
-                          "type (it was first converted to complex). "
-                          "This is deprecated and will raise an error in the "
-                          "future.") < 0) {
-                goto fail;
-            }
+            PYERR("could not cast `fillvalue` directly to the output "
+                  "type (it was first converted to complex).");
         }
         if (PyArray_SIZE(afill) != 1) {
             if (PyArray_SIZE(afill) == 0) {
@@ -1100,12 +1095,8 @@ static PyObject *_sigtools_convolve2d(PyObject *NPY_UNUSED(dummy), PyObject *arg
                                 "`fillvalue` cannot be an empty array.");
                 goto fail;
             }
-            /* Deprecated 2017-07, scipy version 1.0.0 */
-            if (DEPRECATE("`fillvalue` must be scalar or an array with "
-                          "one element. "
-                          "This will raise an error in the future.") < 0) {
-                goto fail;
-            }
+            PYERR("`fillvalue` must be scalar or an array with "
+                  "one element.");
         }
     }
     else {

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -12,7 +12,7 @@ from pytest import raises as assert_raises
 from numpy.testing import (
     assert_equal,
     assert_almost_equal, assert_array_equal, assert_array_almost_equal,
-    assert_allclose, assert_, assert_warns, assert_array_less,
+    assert_allclose, assert_, assert_array_less,
     suppress_warnings)
 from numpy import array, arange
 import numpy as np
@@ -300,30 +300,16 @@ class _TestConvolve2d:
                    [32, 46, 67, 62, 48]])
         assert_array_equal(c, d)
 
-    def test_fillvalue_deprecations(self):
-        # Deprecated 2017-07, scipy version 1.0.0
-        with suppress_warnings() as sup:
-            sup.filter(np.ComplexWarning, "Casting complex values to real")
-            r = sup.record(DeprecationWarning, "could not cast `fillvalue`")
-            convolve2d([[1]], [[1, 2]], fillvalue=1j)
-            assert_(len(r) == 1)
-            warnings.filterwarnings(
-                "error", message="could not cast `fillvalue`",
-                category=DeprecationWarning)
-            assert_raises(DeprecationWarning, convolve2d, [[1]], [[1, 2]],
-                          fillvalue=1j)
+    def test_fillvalue_errors(self):
+        msg = "could not cast `fillvalue` directly to the output "
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=np.ComplexWarning)
+            with assert_raises(ValueError, match=msg):
+                convolve2d([[1]], [[1, 2]], fillvalue=1j)
 
-        with suppress_warnings():
-            warnings.filterwarnings(
-                "always", message="`fillvalue` must be scalar or an array ",
-                category=DeprecationWarning)
-            assert_warns(DeprecationWarning, convolve2d, [[1]], [[1, 2]],
-                         fillvalue=[1, 2])
-            warnings.filterwarnings(
-                "error", message="`fillvalue` must be scalar or an array ",
-                category=DeprecationWarning)
-            assert_raises(DeprecationWarning, convolve2d, [[1]], [[1, 2]],
-                          fillvalue=[1, 2])
+        msg = "`fillvalue` must be scalar or an array with "
+        with assert_raises(ValueError, match=msg):
+            convolve2d([[1]], [[1, 2]], fillvalue=[1, 2])
 
     def test_fillvalue_empty(self):
         # Check that fillvalue being empty raises an error:

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -302,8 +302,8 @@ class _TestConvolve2d:
 
     def test_fillvalue_errors(self):
         msg = "could not cast `fillvalue` directly to the output "
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=np.ComplexWarning)
+        with np.testing.suppress_warnings() as sup:
+            sup.filter(np.ComplexWarning, "Casting complex values")
             with assert_raises(ValueError, match=msg):
                 convolve2d([[1]], [[1, 2]], fillvalue=1j)
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
closes #15742
#### What does this implement/fix?
<!--Please explain your changes.-->
Executes deprecation to raise valueerror if fillvalue cannot be cast to output type as this has been deprecated for 5 years.
#### Additional information
<!--Any additional information you think is important.-->
