### PR TITLE
BUG: stats: Fix handling of float32 inputs for the boost-based ufuncs.

### DIFF
--- a/scipy/stats/_boost/include/Templated_PyUFunc.hpp
+++ b/scipy/stats/_boost/include/Templated_PyUFunc.hpp
@@ -2,30 +2,6 @@
 #define TEMPLATED_PYUFUNC_HPP
 
 #include <cstddef>
-
-// C++ standard dependent implementation
-// TODO: remove C++11 implementation when SciPy supports C++14 on all platforms
-#define USE_CPP14 (__cplusplus >= 201402L)
-
-#if USE_CPP14 && !defined(__wasm32__) && !defined(__wasm64__)
-
-#include <type_traits>
-#include <utility>
-#define UFUNC_STATIC_ASSERT(cond, msg) static_assert(cond, msg)
-#define UFUNC_CALLFUNC(RealType, NINPUTS, func, inputs)		      \
-    *output = callfunc<RealType>(std::make_index_sequence<NINPUTS>{}, \
-				 func, inputs);
-
-// Variadic magic to cast to and call a function with NINPUTS
-template <class RealType, std::size_t ... Is>
-RealType
-callfunc(std::index_sequence<Is ...>, void* func, RealType **inputs)
-{
-    return (reinterpret_cast<RealType(*)(...)>(func))(*inputs[Is] ...);
-}
-
-#else // USE_CPP14
-
 #include <stdexcept>
 #include <boost/static_assert.hpp>
 #define UFUNC_STATIC_ASSERT(cond, msg) BOOST_STATIC_ASSERT_MSG(cond, msg)
@@ -53,8 +29,6 @@ callfunc(void* func, RealType **inputs)
 				 "handles too few args!");
     }
 }
-
-#endif // USE_CPP14
 
 
 /** \brief UFUNC loop function that handles any type and number of inputs.

--- a/scipy/stats/_boost/include/code_gen.py
+++ b/scipy/stats/_boost/include/code_gen.py
@@ -5,13 +5,14 @@ from warnings import warn
 from textwrap import dedent
 from shutil import copyfile
 import pathlib
-import os
+import sys
 import argparse
 
 from gen_func_defs_pxd import (  # type: ignore
     _gen_func_defs_pxd)
 from _info import (  # type: ignore
     _x_funcs, _no_x_funcs, _klass_mapper)
+
 
 class _MethodDef(NamedTuple):
     ufunc_name: str
@@ -182,10 +183,14 @@ if __name__ == '__main__':
         f'{src_dir}/func_defs.pxd',
         x_funcs=_x_funcs,
         no_x_funcs=_no_x_funcs)
+    float_types = ['NPY_FLOAT', 'NPY_DOUBLE']
+    # Don't generate the 'long double' ufunc loops on Windows.
+    if sys.platform != 'win32':
+        float_types.append('NPY_LONGDOUBLE')
     for b, s in _klass_mapper.items():
         _ufunc_gen(
             scipy_dist=s.scipy_name,
-            types=['NPY_FLOAT', 'NPY_DOUBLE', 'NPY_LONGDOUBLE'],
+            types=float_types,
             ctor_args=s.ctor_args,
             filename=f'{src_dir}/{s.scipy_name}_ufunc.pyx',
             boost_dist=f'{b}_distribution',

--- a/scipy/stats/tests/meson.build
+++ b/scipy/stats/tests/meson.build
@@ -4,6 +4,7 @@ py3.install_sources([
     'studentized_range_mpmath_ref.py',
     'test_axis_nan_policy.py',
     'test_binned_statistic.py',
+    'test_boost_ufuncs.py',
     'test_contingency.py',
     'test_continuous_basic.py',
     'test_crosstab.py',

--- a/scipy/stats/tests/test_boost_ufuncs.py
+++ b/scipy/stats/tests/test_boost_ufuncs.py
@@ -1,0 +1,39 @@
+
+import pytest
+import numpy as np
+from numpy.testing import assert_allclose
+from scipy.stats import _boost
+
+
+rtols = {np.float32: 32*np.finfo(np.float32).eps,
+         np.float64: 32*np.finfo(np.float64).eps,
+         np.longdouble: 32*np.finfo(np.longdouble).eps}
+
+
+# Each item in this list is
+#   (func, args, expected_value)
+# All the values can be represented exactly, even with np.float32.
+#
+# This is not an exhaustive test data set of all the functions!
+# It is a spot check of several functions, primarily for
+# checking that the different data types are handled correctly.
+test_data = [
+    (_boost._beta_cdf, (0.5, 2, 3), 0.6875),
+    (_boost._beta_ppf, (0.6875, 2, 3), 0.5),
+    (_boost._beta_pdf, (0.5, 2, 3), 1.5),
+    (_boost._beta_sf, (0.5, 2, 1), 0.75),
+    (_boost._beta_isf, (0.75, 2, 1), 0.5),
+    (_boost._binom_cdf, (1, 3, 0.5), 0.5),
+    (_boost._binom_pdf, (1, 4, 0.5), 0.25),
+    (_boost._hypergeom_cdf, (2, 3, 5, 6), 0.5),
+    (_boost._nbinom_cdf, (1, 4, 0.25), 0.015625),
+    (_boost._ncf_mean, (10, 12, 2.5), 1.5),
+]
+
+
+@pytest.mark.parametrize('func, args, expected', test_data)
+@pytest.mark.parametrize('typ, rtol', rtols.items())
+def test_stats_boost_ufunc(func, args, expected, typ, rtol):
+    args = (typ(arg) for arg in args)
+    value = func(*args)
+    assert_allclose(value, expected, rtol=rtol)

--- a/scipy/stats/tests/test_boost_ufuncs.py
+++ b/scipy/stats/tests/test_boost_ufuncs.py
@@ -5,9 +5,9 @@ from numpy.testing import assert_allclose
 from scipy.stats import _boost
 
 
-rtols = {np.float32: 32*np.finfo(np.float32).eps,
-         np.float64: 32*np.finfo(np.float64).eps,
-         np.longdouble: 32*np.finfo(np.longdouble).eps}
+type_char_to_type_tol = {'f': (np.float32, 32*np.finfo(np.float32).eps),
+                         'd': (np.float64, 32*np.finfo(np.float64).eps),
+                         'g': (np.longdouble, 32*np.finfo(np.longdouble).eps)}
 
 
 # Each item in this list is
@@ -32,8 +32,12 @@ test_data = [
 
 
 @pytest.mark.parametrize('func, args, expected', test_data)
-@pytest.mark.parametrize('typ, rtol', rtols.items())
-def test_stats_boost_ufunc(func, args, expected, typ, rtol):
-    args = (typ(arg) for arg in args)
-    value = func(*args)
-    assert_allclose(value, expected, rtol=rtol)
+def test_stats_boost_ufunc(func, args, expected):
+    type_sigs = func.types
+    type_chars = [sig.split('->')[-1] for sig in type_sigs]
+    for type_char in type_chars:
+        typ, rtol = type_char_to_type_tol[type_char]
+        args = [typ(arg) for arg in args]
+        value = func(*args)
+        assert isinstance(value, typ)
+        assert_allclose(value, expected, rtol=rtol)


### PR DESCRIPTION
The C++14 code for calling the underlying C++ function that does
the actual scalar calculation for a ufunc had a bug where the
float arguments were implicitly cast to double while the function
expected float, resulting in incorrect output.

The fix here is to remove the C++14 version of the code, and
use only the less elegant C++11 code.

Closes gh-15961
