### PR TITLE
ENH: more numerically stable version of `softmax`

### DIFF
--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -160,7 +160,16 @@ def softmax(x, axis=None):
 
     The `softmax` function is the gradient of `logsumexp`.
 
+    The implementation uses shifting to avoid overflow. See [1]_ for more
+    details.
+
     .. versionadded:: 1.2.0
+
+    References
+    ----------
+    .. [1] P. Blanchard, D.J. Higham, N.J. Higham, "Accurately computing the
+       log-sum-exp and softmax functions", IMA Journal of Numerical Analysis,
+       Vol.41(4), :doi:`10.1093/imanum/draa038`.
 
     Examples
     --------

--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -215,10 +215,13 @@ def softmax(x, axis=None):
 
 
 def log_softmax(x, axis=None):
-    r"""
-    Logarithm of softmax function::
+    r"""Compute the logarithm of the softmax function.
+
+    In principle::
 
         log_softmax(x) = log(softmax(x))
+
+    but using a more accurate implementation.
 
     Parameters
     ----------

--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -128,8 +128,7 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
 
 
 def softmax(x, axis=None):
-    r"""
-    Softmax function
+    r"""Compute the softmax function.
 
     The softmax function transforms each element of a collection by
     computing the exponential of each element divided by the sum of the

--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -16,18 +16,18 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
         and all elements are summed.
 
         .. versionadded:: 0.11.0
-    keepdims : bool, optional
-        If this is set to True, the axes which are reduced are left in the
-        result as dimensions with size one. With this option, the result
-        will broadcast correctly against the original array.
-
-        .. versionadded:: 0.15.0
     b : array-like, optional
         Scaling factor for exp(`a`) must be of the same shape as `a` or
         broadcastable to `a`. These values may be negative in order to
         implement subtraction.
 
         .. versionadded:: 0.12.0
+    keepdims : bool, optional
+        If this is set to True, the axes which are reduced are left in the
+        result as dimensions with size one. With this option, the result
+        will broadcast correctly against the original array.
+
+        .. versionadded:: 0.15.0
     return_sign : bool, optional
         If this is set to True, the result will be a pair containing sign
         information; if False, results that are negative will be returned
@@ -60,9 +60,9 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
     --------
     >>> from scipy.special import logsumexp
     >>> a = np.arange(10)
-    >>> np.log(np.sum(np.exp(a)))
-    9.4586297444267107
     >>> logsumexp(a)
+    9.4586297444267107
+    >>> np.log(np.sum(np.exp(a)))
     9.4586297444267107
 
     With weights

--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -181,7 +181,7 @@ def softmax(x, axis=None):
            [  1.21863e-05,   2.68421e-01,   7.29644e-01,   3.31258e-05]])
 
     >>> m.sum()
-    1.0000000000000002
+    1.0
 
     Compute the softmax transformation along the first axis (i.e., the
     columns).
@@ -208,9 +208,10 @@ def softmax(x, axis=None):
     array([ 1.,  1.,  1.])
 
     """
-
-    # compute in log space for numerical stability
-    return np.exp(x - logsumexp(x, axis=axis, keepdims=True))
+    x = _asarray_validated(x, check_finite=False)
+    x_max = np.amax(x, axis=axis, keepdims=True)
+    exp_x_shifted = np.exp(x - x_max)
+    return exp_x_shifted / np.sum(exp_x_shifted, axis=axis, keepdims=True)
 
 
 def log_softmax(x, axis=None):


### PR DESCRIPTION
#### Reference issue
There is no issue that this PR closes.

#### What does this implement/fix?
This implements a more accurate version of `softmax` and makes some improvements to the docstrings in `_logsumexp.py`

#### Additional information
This is based on the following paper: Pierre Blanchard, Desmond J. Higham, Nicholas J. Higham, **Accurately computing the log-sum-exp and softmax functions**, *IMA Journal of Numerical Analysis*, Volume 41, Issue 4, October 2021, Pages 2311–2330, [DOI](https://doi.org/10.1093/imanum/draa038). There is also an [online seminar](https://media.ed.ac.uk/playlist/dedicated/51612401/1_ttaqxfs9/1_inp881ig) (the first half is about the paper) given by Des Higham and a [blog post](https://nhigham.com/2020/02/03/accurately-computing-the-softmax-function) by Nick Higham.

The paper derives error bounds for different implementations of `logsumexp` and `softmax`, indicating which implementations are more accurate. Then it demonstrates the theory on an example from deep learning. To make it easier, I reproduced the results with a randomly-generated benchmark. Here is the code demonstrating different implementations of `logsumexp`, `softmax`, and `log_softmax`: [logsumexp_test.py.txt](https://github.com/scipy/scipy/files/8693862/logsumexp_test.py.txt) (".txt" should be removed). The result is the following figure:

![comparison](https://user-images.githubusercontent.com/1268421/168447990-2fa23c64-97b4-424a-95f8-6711f03a8345.png)

The following are specific remarks:

- `logsumexp`:
  - SciPy uses the "shifted" implementation.
  - The paper discusses the naive and "log1p" implementations ("log1p" is like "shifted", with the additional trick of using `log1p` after shifting).
  - The paper argues that the "log1p" implementation avoids overflow and is of similar accuracy to the naive implementation when there is no overflow.
  - The figure shows that the different implementations of `logsumexp` are of similar accuracy to the naive implementation (when there is no overflow).
  - I didn't implement the "log1p" version because: 1. I don't know how to do it for multi-dimensional arrays, 2. it doesn't seem to be worth the effort in terms of accuracy, and 3. the implementation of `logsumexp` is already somewhat complex because of the support for weights (where the `log1p` trick cannot be used in general).
- `softmax`:
  - SciPy uses the "alternative" implementation.
  - The paper discusses all three implementations.
  - The paper argues that the "shifted" implementation avoids overflow, it is of similar accuracy to the naive implementation when there is no overflow, and it is more accurate than the "alternative" implementation.
  - The figure confirms the results of the paper.
  - Changing SciPy's implementation also improved the example in the docstring.
- `log_softmax`:
  - SciPy uses the "alternative2" implementation (it is similar to "alternative", except that it avoids an additional shifting).
  - The paper doesn't discuss `log_softmax`.
  - The figure shows that SciPy's implementation is accurate enough, although the implementation could be simplified at the cost of an additional shifting.

There was a discussion happening in a PR [here](https://github.com/scipy/scipy/pull/8872#discussion_r192577457), but before the above paper was published. Interestingly, [`scikit-learn` had implemented](https://github.com/scikit-learn/scikit-learn/pull/5225) the more accurate version of `softmax`.
