### PR TITLE
ENH: Add root-mean-square to scipy

### DIFF
--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -251,6 +251,7 @@ Summary statistics
    tmax              --
    tstd              --
    tsem              --
+   rms               -- Root-mean-square
    variation         -- Coefficient of variation
    find_repeats
    rankdata

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -963,7 +963,7 @@ def rms(a, *, axis=0):
     if np.ndim(a) == 0:
         axis = None
 
-    return np.sqrt(np.mean(np.abs(a) ** 2, axis=axis))
+    return np.sqrt((np.abs(a) ** 2).mean(axis=axis))
 
 
 #####################################

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -910,7 +910,7 @@ def tsem(a, limits=None, inclusive=(True, True), axis=0, ddof=1):
     return sd / np.sqrt(am.count())
 
 
-def rms(a, axis=0):
+def rms(a, *, axis=0):
     r"""Return an array of the root-mean-square value of the passed array.
 
     The root-mean-square is also called the "quadratic mean".

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -76,7 +76,7 @@ from scipy.stats._mstats_basic import (PointbiserialrResult, Ttest_1sampResult, 
 
 # Functions/classes in other files should be added in `__init__.py`, not here
 __all__ = ['find_repeats', 'gmean', 'hmean', 'pmean', 'mode', 'tmean', 'tvar',
-           'tmin', 'tmax', 'tstd', 'tsem', 'moment',
+           'tmin', 'tmax', 'tstd', 'tsem', 'rms', 'moment',
            'skew', 'kurtosis', 'describe', 'skewtest', 'kurtosistest',
            'normaltest', 'jarque_bera',
            'scoreatpercentile', 'percentileofscore',
@@ -908,6 +908,53 @@ def tsem(a, limits=None, inclusive=(True, True), axis=0, ddof=1):
     am = _mask_to_limits(a, limits, inclusive)
     sd = np.sqrt(np.ma.var(am, ddof=ddof, axis=axis))
     return sd / np.sqrt(am.count())
+
+
+def rms(a, axis=0):
+    r"""Return an array of the root-mean-square value of the passed array.
+
+    The root-mean-square is also called the "quadratic mean".
+
+    Parameters
+    ----------
+    a : array_like
+        n-dimensional array of which to find rms.
+    axis : int or None, optional
+        Axis along which to operate. Default is 0. If None, compute over
+        the whole array `a`.
+
+    Returns
+    -------
+    rms : ndarray
+        Array of rms values.
+
+    Notes
+    -----
+    Input `a` is converted to an `np.ndarray` before taking the rms.
+    To avoid the possibility of unexpected conversions, convert `a` to an
+    `np.ndarray` of the desired type before using `rms`.
+
+    Examples
+    --------
+    >>> a = np.array([[6, 8, 3, 0],
+    ...               [3, 2, 1, 7],
+    ...               [8, 1, 8, 4],
+    ...               [5, 3, 0, 5],
+    ...               [4, 7, 5, 9]])
+    >>> from scipy import stats
+    >>> stats.rms(a)
+    array([5.47722558, 5.03984127, 4.44971909, 5.84807661])
+
+    To get rms of whole array, specify ``axis=None``:
+
+    >>> stats.rms(a, axis=None)
+    5.229722745997153
+
+    """
+    if np.ndim(a) == 0:
+        axis = None
+
+    return np.sqrt(np.mean(np.abs(a) ** 2, axis=axis))
 
 
 #####################################

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -934,6 +934,15 @@ def rms(a, *, axis=0):
     To avoid the possibility of unexpected conversions, convert `a` to an
     `np.ndarray` of the desired type before using `rms`.
 
+    For complex inputs, the absolute value is taken first:
+    ``sqrt(mean(abs(a)**2))``._[1]
+
+    References
+    ----------
+    .. [1] Smith, J. O. (2007). "Mathematics of the Discrete Fourier Transform
+       (DFT): With Audio Applications".
+       https://ccrma.stanford.edu/~jos/st/Other_Lp_Norms.html
+
     Examples
     --------
     >>> a = np.array([[6, 8, 3, 0],

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -241,13 +241,13 @@ class TestRMS:
         #  Test a 2d list
         a = [[10, 20, 30, 40], [50, 60, 70, 80], [90, 100, 110, 120]]
         desired = (25/3) * np.sqrt(78)
-        assert_allclose(stats.rms(a, None), desired)
+        assert_allclose(stats.rms(a, axis=None), desired)
 
     def test_2d_array(self):
         #  Test a 2d array
         a = [[-10, 20, -30, 40], [-50, 60, -70, 80], [-90, 100, -110, 120]]
         desired = (25/3) * np.sqrt(78)
-        assert_allclose(stats.rms(a, None), desired)
+        assert_allclose(stats.rms(a, axis=None), desired)
 
     def test_2d_axis0(self):
         #  Test a 2d list with axis=0
@@ -263,12 +263,12 @@ class TestRMS:
         #  Test a 2d list with axis=1
         a = [[10, 20, 30, 40], [50, 60, 70, 80], [90, 100, 110, 120]]
         desired = np.array([27.38612788, 65.95452979, 105.5935604])
-        assert_allclose(stats.rms(a, 1), desired)
+        assert_allclose(stats.rms(a, axis=1), desired)
 
         a = array([[1, 2, 3, 4], [-1, -2, -3, -4], [1, 2, 3, 4]])
         v = 2.738612788
         desired = array([v, v, v])
-        assert_allclose(stats.rms(a, 1), desired)
+        assert_allclose(stats.rms(a, axis=1), desired)
 
     def test_large_values(self):
         a = array([1e50, 1e100, 1e150])
@@ -281,7 +281,7 @@ class TestRMS:
         a = np.random.randn(5, 4, 3, 4)  # Also test 4D array
         a -= a.mean()
         desired = a.std()
-        assert_allclose(stats.rms(a, None), desired)
+        assert_allclose(stats.rms(a, axis=None), desired)
 
     def test_complex(self):
         # http://www-fourier.univ-grenoble-alpes.fr/~parisse/giac/doc/en/cascmd_en/cascmd_en954.html

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -210,6 +210,86 @@ class TestTrimmedStats:
                             significant=self.dprec)
 
 
+class TestRMS:
+    def test_1d_list(self):
+        #  Test a 1d list
+        a = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
+        desired = 5*np.sqrt(154)
+        assert_allclose(stats.rms(a), desired)
+
+        a = [1, 2, 3, 4]
+        desired = np.sqrt(30)/2
+        assert_allclose(stats.rms(a), desired)
+
+        # http://www-fourier.univ-grenoble-alpes.fr/~parisse/giac/doc/en/cascmd_en/cascmd_en954.html
+        a = [1, 2, 5, 8, 3, 6, 7, 9, -1]
+        desired = np.sqrt(30)
+        assert_allclose(stats.rms(a), desired)
+
+    def test_1d_array(self):
+        #  Test a 1d array
+        a = np.array([10, -20, 30, -40, 50, -60, 70, -80, 90, -100])
+        desired = 5*np.sqrt(154)
+        assert_allclose(stats.rms(a), desired)
+
+        a = array([-1, 2, -3, 4], float32)
+        desired = np.sqrt(30)/2
+        assert_allclose(stats.rms(a), desired)
+
+    # Note the next tests use axis=None as default, not axis=0
+    def test_2d_list(self):
+        #  Test a 2d list
+        a = [[10, 20, 30, 40], [50, 60, 70, 80], [90, 100, 110, 120]]
+        desired = (25/3) * np.sqrt(78)
+        assert_allclose(stats.rms(a, None), desired)
+
+    def test_2d_array(self):
+        #  Test a 2d array
+        a = [[-10, 20, -30, 40], [-50, 60, -70, 80], [-90, 100, -110, 120]]
+        desired = (25/3) * np.sqrt(78)
+        assert_allclose(stats.rms(a, None), desired)
+
+    def test_2d_axis0(self):
+        #  Test a 2d list with axis=0
+        a = [[10, 20, 30, 40], [50, 60, 70, 80], [90, 100, 110, 120]]
+        desired = [59.72157622, 68.31300511, 77.24420151, 86.40987598]
+        assert_allclose(stats.rms(a), desired)
+
+        a = array([[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]])
+        desired = array([1, 2, 3, 4])
+        assert_allclose(stats.rms(a), desired)
+
+    def test_2d_axis1(self):
+        #  Test a 2d list with axis=1
+        a = [[10, 20, 30, 40], [50, 60, 70, 80], [90, 100, 110, 120]]
+        desired = np.array([27.38612788, 65.95452979, 105.5935604])
+        assert_allclose(stats.rms(a, 1), desired)
+
+        a = array([[1, 2, 3, 4], [-1, -2, -3, -4], [1, 2, 3, 4]])
+        v = 2.738612788
+        desired = array([v, v, v])
+        assert_allclose(stats.rms(a, 1), desired)
+
+    def test_large_values(self):
+        a = array([1e50, 1e100, 1e150])
+        desired = 5.773502692e149
+        assert_allclose(stats.rms(a), desired)
+
+    def test_std(self):
+        # Without DC offset, RMS is equivalent to standard deviation
+        np.random.seed(3)
+        a = np.random.randn(5, 4, 3, 4)  # Also test 4D array
+        a -= a.mean()
+        desired = a.std()
+        assert_allclose(stats.rms(a, None), desired)
+
+    def test_complex(self):
+        # http://www-fourier.univ-grenoble-alpes.fr/~parisse/giac/doc/en/cascmd_en/cascmd_en954.html
+        a = [1, 1-1j, 2+3j, 5-2j]
+        desired = 3/2 * np.sqrt(5)
+        assert_allclose(stats.rms(a), desired)
+
+
 class TestCorrPearsonr:
     """ W.II.D. Compute a correlation matrix on all the variables.
 


### PR DESCRIPTION
#### Reference issue
Closes https://github.com/scipy/scipy/issues/16179

#### What does this implement/fix?
This adds a convenience function for calculating the root-mean-square value of an array.

#### Additional information
Rationale is at https://github.com/scipy/scipy/issues/16179
