### PR TITLE
BLD: add a build option to force use of the g77 ABI with Meson

### DIFF
--- a/doc/source/dev/contributor/building_faq.rst
+++ b/doc/source/dev/contributor/building_faq.rst
@@ -80,10 +80,10 @@ Now you have a branch in your local development area to code review in Python.
 How do I deal with Fortran ABI mismatch?
 ========================================
 
-Some linear algebra libraries are built with G77 ABI and others with
+Some linear algebra libraries are built with g77 ABI and others with
 GFortran ABI, and these two ABIs are incompatible. Therefore, if you
-build scipy with `gfortran` and link to a linear algebra library, like
-MKL, which is built with G77 ABI, then there'll be an exception or a
+build SciPy with ``gfortran`` and link to a linear algebra library, like
+MKL, which is built with g77 ABI, then there'll be an exception or a
 segfault. SciPy fixes this by using the CBLAS API for the few
 functions in the BLAS API that suffers from this issue.
 
@@ -91,9 +91,25 @@ Note that SciPy needs to know at build time, what needs to be done and
 the build system will automatically check whether linear algebra
 library is MKL and if so, use the CBLAS API instead of the BLAS API.
 If autodetection fails or if the user wants to override this
-autodetection mechanism, setting the environment variable
-`SCIPY_USE_G77_ABI_WRAPPER` to 0 or 1 to disable or enable using CBLAS
-API.
+autodetection mechanism, use the following:
+
+_For ``meson`` based builds (new in 1.9.0):_
+
+Use the ``-Duse-g77-abi=true`` build option. E.g.,::
+
+    $ meson setup build -Duse-g77-abi=true
+
+A more complete example, also configuring the BLAS/LAPACK libraries and picking
+a better Python install behavior (this is what conda-forge could be using for
+example)::
+
+    $ meson setup builddir -Duse-g77-abi=true -Dblas=blas -Dlapack=lapack -Dpython.install_env=auto
+    $ meson install -C builddir
+
+_For ``distutils`` based builds:_
+
+Set the environment variable ``SCIPY_USE_G77_ABI_WRAPPER`` to 0 or 1 to disable
+or enable using CBLAS API.
 
 How do I use a custom BLAS distribution on Linux?
 =================================================

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,3 +2,7 @@ option('blas', type: 'string', value: 'openblas',
         description: 'option for BLAS library switching')
 option('lapack', type: 'string', value: 'openblas',
         description: 'option for LAPACK library switching')
+option('use-g77-abi', type: 'boolean', value: 'false',
+        description: 'If set to true, forces using g77 compatibility wrappers ' +
+                     'for LAPACK functions. The default is to use gfortran ' +
+                     'ABI for all LAPACK libraries except MKL.')

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -119,7 +119,7 @@ numpy_nodepr_api = '-DNPY_NO_DEPRECATED_API=NPY_1_9_API_VERSION'
 blas = dependency(get_option('blas'))
 lapack = dependency(get_option('lapack'))
 
-if blas.name() == 'mkl' or lapack.name() == 'mkl'
+if blas.name() == 'mkl' or lapack.name() == 'mkl' or get_option('use-g77-abi')
   g77_abi_wrappers = files([
     '_build_utils/src/wrap_g77_abi_f.f',
     '_build_utils/src/wrap_g77_abi_c.c'


### PR DESCRIPTION
[ci skip]

This feature was implemented for `disutils` in gh-10591. It's probably only used by conda-forge, but in principle it also makes sense for other packagers that want a runtime-swappable BLAS/LAPACK.

Cc @isuruf for visibility.