### PR TITLE
DEP: sharpen deprecation in NumericalInverseHermite

### DIFF
--- a/scipy/stats/_unuran/unuran_wrapper.pyx.templ
+++ b/scipy/stats/_unuran/unuran_wrapper.pyx.templ
@@ -1831,7 +1831,7 @@ cdef class NumericalInverseHermite(Method):
 
     This method accepted a `tol` parameter to specify the maximum tolerable u-error
     but it has now been deprecated in the favor of `u_resolution`. `tol` will be
-    removed completely in a future release.
+    removed completely in SciPy 1.10.0.
 
     References
     ----------
@@ -2040,11 +2040,11 @@ cdef class NumericalInverseHermite(Method):
             raise ValueError("`max_intervals' must be an integer greater than 1.")
         if max_intervals != 100000:
             warnings.warn("`max_intervals` has been deprecated. "
-                          "It will be completely removed in a future release.",
+                          "It will be completely removed in SciPy 1.10.0.",
                           DeprecationWarning)
         if tol is not None:
             warnings.warn("`tol` has been deprecated and replaced with `u_resolution`. "
-                          "It will be completely removed in a future release.",
+                          "It will be completely removed in SciPy 1.10.0.",
                           DeprecationWarning)
             u_resolution = tol
         u_resolution = float(u_resolution)

--- a/scipy/stats/tests/test_sampling.py
+++ b/scipy/stats/tests/test_sampling.py
@@ -1131,7 +1131,7 @@ class TestNumericalInverseHermite:
 
     def test_deprecations(self):
         msg = ("`tol` has been deprecated and replaced with `u_resolution`. "
-               "It will be completely removed in a future release.")
+               "It will be completely removed in SciPy 1.10.0.")
         with pytest.warns(DeprecationWarning, match=msg):
             NumericalInverseHermite(StandardNormal(), tol=1e-12)
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
closes gh-15749
#### What does this implement/fix?
<!--Please explain your changes.-->
Sharpens deprecation to state features will be removed in scipy 1.10.0 as per issue.
#### Additional information
<!--Any additional information you think is important.-->
