### PR TITLE
DOC: Fix grammar in `hierarchy.cut_tree`

### DIFF
--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -1332,8 +1332,8 @@ def cut_tree(Z, n_clusters=None, height=None):
     -------
     cutree : array
         An array indicating group membership at each agglomeration step. I.e.,
-        for a full cut tree, in the first column every data point is in the same
-        cluster. At the next step, two nodes are merged. Finally, all
+        for a full cut tree, in the first column every data point is in the
+        same cluster. At the next step, two nodes are merged. Finally, all
         singleton and non-singleton clusters are in one group. If `n_clusters`
         or `height` are given, the columns correspond to the columns of
         `n_clusters` or `height`.

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -1332,7 +1332,7 @@ def cut_tree(Z, n_clusters=None, height=None):
     -------
     cutree : array
         An array indicating group membership at each agglomeration step. I.e.,
-        for a full cut tree, in the first column each data point is in its own
+        for a full cut tree, in the first column every data point is in the same
         cluster. At the next step, two nodes are merged. Finally, all
         singleton and non-singleton clusters are in one group. If `n_clusters`
         or `height` are given, the columns correspond to the columns of

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -1332,7 +1332,7 @@ def cut_tree(Z, n_clusters=None, height=None):
     -------
     cutree : array
         An array indicating group membership at each agglomeration step. I.e.,
-        for a full cut tree, in the first column every data point is in the same
+        for a full cut tree, in the first column each data point is in its own
         cluster. At the next step, two nodes are merged. Finally, all
         singleton and non-singleton clusters are in one group. If `n_clusters`
         or `height` are given, the columns correspond to the columns of


### PR DESCRIPTION

#### Reference issue
Closes #16169

#### What does this implement/fix?
Fix the doc of hierarchy.py file.

#### Additional information
As suggested in the issue #16169 we changed the info 'in the first column each data point is in its own cluster' to 'in the first column every data point is in the same cluster' in the file hierarchy.py.
