### PR TITLE
CI: Test NumPy main branch also with Python 3.11

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11-dev"]
+        python-version: ["3.11-dev"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.11-dev"]
 
     steps:
     - uses: actions/checkout@v3
@@ -73,18 +73,6 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         architecture: x64
-
-# Keeping this for later 3.11. Might not be needed as GH seems to provide
-# pre-released versions of 3.11
-#    - name: Install Python 3.11
-#      if: matrix.python-version == '3.11'
-#      run: |
-#        sudo add-apt-repository ppa:deadsnakes/ppa
-#        sudo apt-get update
-#        sudo apt install -y --no-install-recommends python3.11-dev python3.11-distutils python3.11-venv
-#        # GitHub doesn't provide a pip interface with py3.11 yet. Therefore, install it manually :
-#        curl -O https://bootstrap.pypa.io/get-pip.py && python3.11 get-pip.py && rm get-pip.py
-#        python3.11 -m pip install --upgrade pip setuptools
 
     - name: Install other build dependencies
       run: |


### PR DESCRIPTION
Add a Python 3.11 job to the NumPy main branch test configuration.

Python 3.11 is [now in beta](https://blog.python.org/2022/05/python-3110b1-is-now-available.html) and feature stable. By adding a Python 3.11 test run we can catch errors and bugs before Python 3.11 will become stable, and packages dependent on SciPy can start working on their Python 3.11 support. SciPy is one of the most used packages and a package on which many other packages depend, so early support will help speed up Python 3.11 adoption.

Python 3.11 is expected to be released as stable in October 2022, with many new features including:

> - [PEP 657](https://www.python.org/dev/peps/pep-0657/) -- Include Fine-Grained Error Locations in Tracebacks
> - [PEP 654](https://www.python.org/dev/peps/pep-0654/) -- Exception Groups and except*
> - [PEP 673](https://www.python.org/dev/peps/pep-0673/) -- Self Type
> - [PEP 646](https://www.python.org/dev/peps/pep-0646/)-- Variadic Generics
> - [PEP 680](https://www.python.org/dev/peps/pep-0680/)-- tomllib: Support for Parsing TOML in the Standard Library
> - [PEP 675](https://www.python.org/dev/peps/pep-0675/)-- Arbitrary Literal String Type
> - [PEP 655](https://www.python.org/dev/peps/pep-0655/)-- Marking individual TypedDict items as required or potentially-missing
> - [bpo-46752](https://bugs.python.org/issue46752)-- Introduce task groups to asyncio
> - The [Faster Cpython Project](https://github.com/faster-cpython) is already yielding some exciting results. Python 3.11 is up to 10-60% faster than Python 3.10. On average, we measured a 1.22x speedup on the standard benchmark suite. See [Faster CPython for details.](https://docs.python.org/3.11/whatsnew/3.11.html#faster-cpython)