### PR TITLE
REL: prep for SciPy 1.8.2

### DIFF
--- a/doc/release/1.8.2-notes.rst
+++ b/doc/release/1.8.2-notes.rst
@@ -1,0 +1,19 @@
+==========================
+SciPy 1.8.2 Release Notes
+==========================
+
+.. contents::
+
+SciPy 1.8.2 is a bug-fix release with no new features
+compared to 1.8.1.
+
+Authors
+=======
+
+
+Issues closed for 1.8.2
+-----------------------
+
+
+Pull requests for 1.8.2
+-----------------------

--- a/doc/source/release.1.8.2.rst
+++ b/doc/source/release.1.8.2.rst
@@ -1,0 +1,1 @@
+.. include:: ../release/1.8.2-notes.rst

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -8,6 +8,7 @@ see the `commit logs <https://github.com/scipy/scipy/commits/>`_.
 .. toctree::
    :maxdepth: 1
 
+   release.1.8.2
    release.1.8.1
    release.1.8.0
    release.1.7.3

--- a/pavement.py
+++ b/pavement.py
@@ -68,10 +68,10 @@ except AttributeError:
 #-----------------------------------
 
 # Source of the release notes
-RELEASE = 'doc/release/1.8.1-notes.rst'
+RELEASE = 'doc/release/1.8.2-notes.rst'
 
 # Start/end of the log (from git)
-LOG_START = 'v1.8.0'
+LOG_START = 'v1.8.1'
 LOG_END = 'maintenance/1.8.x'
 
 

--- a/setup.py
+++ b/setup.py
@@ -56,8 +56,8 @@ Operating System :: MacOS
 
 MAJOR = 1
 MINOR = 8
-MICRO = 1
-ISRELEASED = True
+MICRO = 2
+ISRELEASED = False
 IS_RELEASE_BRANCH = True
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 


### PR DESCRIPTION
I'm hoping we don't need a `1.8.2`.

Since branching of `1.9.0` is ideally slated to happen in a bit over a week, I suspect many of us will try to pour what energy we have into that process.