### PR TITLE
REL: DOC: fix documentation URLs for the 1.8.x releases

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -89,9 +89,8 @@ doc-dist: html-scipyorg html
 	-test -d build/htmlhelp || make htmlhelp-build
 	-rm -rf build/dist
 	mkdir -p build/dist
-	cp -r build/html-scipyorg build/dist
-	touch build/dist/index.html
-	(cd build/html && zip -9qr ../dist/scipy-html.zip .)
+	cp -r build/html-scipyorg/* build/dist
+	(cd build/html-scipyorg && zip -9qr ../dist/scipy-html.zip .)
 	cp build/latex/scipy-ref.pdf build/dist
 	chmod ug=rwX,o=rX -R build/dist
 	find build/dist -type d -print0 | xargs -0r chmod g+s


### PR DESCRIPTION
I applied this to the 1.8.1 docs, and things seem to work as expected after removing these rules from `.htaccess`:

```
RewriteRule ^scipy/scipy-html.zip /doc/scipy-1.8.1/scipy-html-1.8.1.zip [L]
RewriteRule ^scipy/scipy-ref.pdf  /doc/scipy-1.8.1/scipy-ref-1.8.1.pdf  [L]
RewriteRule ^scipy/(.*) /doc/scipy-1.8.1/$1 [NC,L]
```

[ci skip]

I'm now fixing `1.8.0` docs. Let's wait with merging this to see if we don't get new issues for a day or so after that.