### PR TITLE
Add a `pchip` mode to RegularGridInterpolator.

### DIFF
--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -55,7 +55,7 @@ class RegularGridInterpolator:
         The method of interpolation to perform. Supported are "linear",
         "nearest", "slinear", "cubic", "quintic" and "pchip". This
         parameter will become the default for the object's ``__call__``
-         method. Default is "linear".
+        method. Default is "linear".
 
     bounds_error : bool, optional
         If True, when interpolated values are requested outside of the

--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -53,9 +53,9 @@ class RegularGridInterpolator:
 
     method : str, optional
         The method of interpolation to perform. Supported are "linear",
-        "nearest", "slinear", "cubic", and "quintic". This parameter will
-        become the default for the object's ``__call__`` method.
-        Default is "linear".
+        "nearest", "slinear", "cubic", "quintic" and "pchip". This
+        parameter will become the default for the object's ``__call__``
+         method. Default is "linear".
 
     bounds_error : bool, optional
         If True, when interpolated values are requested outside of the
@@ -205,7 +205,7 @@ class RegularGridInterpolator:
     # this class is based on code originally programmed by Johannes Buchner,
     # see https://github.com/JohannesBuchner/regulargrid
 
-    _SPLINE_DEGREE_MAP = {"slinear": 1, "cubic": 3, "quintic": 5, }
+    _SPLINE_DEGREE_MAP = {"slinear": 1, "cubic": 3, "quintic": 5, 'pchip': 3}
     _SPLINE_METHODS = list(_SPLINE_DEGREE_MAP.keys())
     _ALL_METHODS = ["linear", "nearest"] + _SPLINE_METHODS
 
@@ -332,8 +332,7 @@ class RegularGridInterpolator:
         elif method in self._SPLINE_METHODS:
             if is_method_changed:
                 self._validate_grid_dimensions(self.grid, method)
-            result = self._evaluate_spline(self.values.T, xi,
-                                           self._SPLINE_DEGREE_MAP[method])
+            result = self._evaluate_spline(self.values.T, xi, method)
 
         if not self.bounds_error and self.fill_value is not None:
             result[out_of_bounds] = self.fill_value
@@ -372,11 +371,17 @@ class RegularGridInterpolator:
                                  f" but method {method} requires at least "
                                  f" {k+1} points per dimension.")
 
-    def _evaluate_spline(self, values, xi, spline_degree):
+    def _evaluate_spline(self, values, xi, method):
         # ensure xi is 2D list of points to evaluate
         if xi.ndim == 1:
             xi = xi.reshape((1, xi.size))
         m, n = xi.shape
+
+        if method == 'pchip':
+            _eval_func = self._do_pchip
+        else:
+            _eval_func = self._do_spline_fit
+        k = self._SPLINE_DEGREE_MAP[method]
 
         # Non-stationary procedure: difficult to vectorize this part entirely
         # into numpy-level operations. Unfortunately this requires explicit
@@ -385,10 +390,10 @@ class RegularGridInterpolator:
         # can at least vectorize the first pass across all points in the
         # last variable of xi.
         last_dim = n - 1
-        first_values = self._do_spline_fit(self.grid[last_dim],
-                                           values,
-                                           xi[:, last_dim],
-                                           spline_degree)
+        first_values = _eval_func(self.grid[last_dim],
+                                  values,
+                                  xi[:, last_dim],
+                                  k)
 
         # the rest of the dimensions have to be on a per point-in-xi basis
         result = np.empty(m, dtype=self.values.dtype)
@@ -400,11 +405,10 @@ class RegularGridInterpolator:
             for i in range(last_dim-1, -1, -1):
                 # Interpolate for each 1D from the last dimensions.
                 # This collapses each 1D sequence into a scalar.
-                folded_values = self._do_spline_fit(self.grid[i],
-                                                    folded_values,
-                                                    xi[j, i],
-                                                    spline_degree)
-
+                folded_values = _eval_func(self.grid[i],
+                                           folded_values,
+                                           xi[j, i],
+                                           k)
             result[j] = folded_values
 
         return result
@@ -412,6 +416,12 @@ class RegularGridInterpolator:
     @staticmethod
     def _do_spline_fit(x, y, pt, k):
         local_interp = make_interp_spline(x, y, k=k, axis=0)
+        values = local_interp(pt)
+        return values
+
+    @staticmethod
+    def _do_pchip(x, y, pt, k):
+        local_interp = PchipInterpolator(x, y, axis=0)
         values = local_interp(pt)
         return values
 


### PR DESCRIPTION
#### What does this implement/fix?
<!--Please explain your changes.-->

Add a pchip interpolation kind to the RegularGridInterpolator. It implements a continuous, C^1 monotone interpolant, while the recently-merged cubic spline kind is C^2 continuous and global.

As a data point, Octave allows this (https://octave.sourceforge.io/octave/function/interp2.html), and I think it makes sense to have a tensor product monotone interpolant : global splines are prone to oscillations and overshooting, and if this happens, it's not easy for a user to do anything about it. OTOH, pchip is monotone by construction.


#### Additional information
<!--Any additional information you think is important.-->

<s>This is an ENH part of gh-16132 which only adds the new interpolation kind. The PR is currently branched off gh-16223, so will need a rebase after gh-16223 is in. </s> rebased.
