### PR TITLE
TST: optimize: skip failing test of deprecated solver

### DIFF
--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -1698,6 +1698,9 @@ class LinprogSimplexTests(LinprogCommonTests):
 class LinprogIPTests(LinprogCommonTests):
     method = "interior-point"
 
+    def test_bug_10466(self):
+        pytest.skip("Test is failing, but solver is deprecated.")
+
 
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 class LinprogRSTests(LinprogCommonTests):
@@ -1940,9 +1943,6 @@ if has_cholmod:
 if has_umfpack:
     class TestLinprogIPSparseUmfpack(LinprogIPTests):
         options = {"sparse": True, "cholesky": False}
-
-        def test_bug_10466(self):
-            pytest.skip("Autoscale doesn't fix everything, and that's OK.")
 
         def test_network_flow_limited_capacity(self):
             pytest.skip("Failing due to numerical issues on some platforms.")


### PR DESCRIPTION
#### Reference issue
Close gh-13846

#### What does this implement/fix?
Linprog test` test_bug_10466 ` is failing with some interior-point options, but the interior-point solver is deprecated, so this skips the test.
