### PR TITLE
REL: DOC: fix documentation URLs 

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -82,9 +82,8 @@ doc-dist: html-scipyorg html
 	-test -d build/htmlhelp || make htmlhelp-build
 	-rm -rf build/dist
 	mkdir -p build/dist
-	cp -r build/html-scipyorg build/dist
-	touch build/dist/index.html
-	(cd build/html && zip -9qr ../dist/scipy-html.zip .)
+	cp -r build/html-scipyorg/* build/dist
+	(cd build/html-scipyorg && zip -9qr ../dist/scipy-html.zip .)
 	chmod ug=rwX,o=rX -R build/dist
 	find build/dist -type d -print0 | xargs -0r chmod g+s
 	cd build/dist && tar czf ../dist.tar.gz *


### PR DESCRIPTION
This is a forward port of gh-16221

Closes gh-14267

I applied this to the 1.8.0/1.8.1 docs, and things seem to work as
expected after removing these rules from `.htaccess`:

```
RewriteRule ^scipy/scipy-html.zip /doc/scipy-1.8.1/scipy-html-1.8.1.zip [L]
RewriteRule ^scipy/scipy-ref.pdf  /doc/scipy-1.8.1/scipy-ref-1.8.1.pdf  [L]
RewriteRule ^scipy/(.*) /doc/scipy-1.8.1/$1 [NC,L]
```

[ci skip]