### PR TITLE
BUG: fix extension module initialization, needs use of PyMODINIT_FUNC, round 2

### DIFF
--- a/scipy/optimize/_directmodule.c
+++ b/scipy/optimize/_directmodule.c
@@ -84,7 +84,8 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
-PyObject *PyInit__directmodule(void)
+PyMODINIT_FUNC
+PyInit__directmodule(void)
 {
     PyObject *module;
 


### PR DESCRIPTION
In gh-16165, a global change was made to move away from plain `PyObject *PyInit_` module initialization functions, to using the `PyMODINIT_FUNC` macro. This is preferred by Python, and guarantees that for example symbol visibility attributes are correctly set.

In gh-14300, a new extension module was added which reintroduced a use of plain `PyObject *`, and once again broke building SciPy with Meson from git master with default visibility=hidden.

/cc @rgommers, @mattip 
Noticed due to failures in https://github.com/mattip/scipy/pull/1