### PR TITLE
BUG: Make KDTree more robust against nans.

### DIFF
--- a/scipy/spatial/ckdtree/src/build.cxx
+++ b/scipy/spatial/ckdtree/src/build.cxx
@@ -99,7 +99,7 @@ build(ckdtree *self, ckdtree_intp_t start_idx, intptr_t end_idx,
         auto partition_pivot = [=](ckdtree_intp_t* first, ckdtree_intp_t* last, double pivot) {
             const auto partition_ptr = std::partition(
                 first, last,
-                [&](ckdtree_intp_t a) { return data[a * m + d] < pivot; });
+                [&](ckdtree_intp_t a) { return !(data[a * m + d] >= pivot); });
             return partition_ptr - indices;
         };
 

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -1444,3 +1444,13 @@ def test_kdtree_count_neighbors_weighted(kdtree_class):
     expect = [np.sum(weights[(prev_radius < dist) & (dist <= radius)])
               for prev_radius, radius in zip(itertools.chain([0], r[:-1]), r)]
     assert_allclose(nAB, expect)
+
+
+def test_kdtree_nan():
+    vals = [1, 5, -10, 7, -4, -16, -6, 6, 3, -11]
+    n = len(vals)
+    data = np.concatenate([vals, np.full(n, np.nan)])[:, None]
+
+    query_with_nans = KDTree(data).query_pairs(2)
+    query_without_nans = KDTree(data[:n]).query_pairs(2)
+    assert query_with_nans == query_without_nans


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #14793

#### What does this implement/fix?
<!--Please explain your changes.-->
In KDTree construction, when splitting on the median, calling
std::nth_element and then std::partition (via partition_pivot) in
succession caused inconsistent tree builds, because nth_element
effectively treats nans as smaller than anything (the check it does is
`!(*j < *i)` for all i on the left and j on the right, cf. cppreference)
whereas partition (as written here) treats nans as larger (the predicate
in partition_pivot returns false for nans, which are thus placed on the
right), which caused various bugs with inputs containing nans: silently
incorrect values in some cases, segfaults in others (e.g. the added
test).

To fix that, rewrite the partition predicate to match (effectively) the
form used by std::nth_element.  While one may consider trying
`p = start_idx + n_points / 2` instead, this fails because there may be
many points equal to the median which nth_partition places at arbitrary
places on the left.

#### Additional information
<!--Any additional information you think is important.-->
I have not audited the code for further possible nan bugs, nor whether
this helps for the related #14527.