### PR TITLE
Refguide check verbosity abs names

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -278,6 +278,8 @@ def main(argv):
     if args.refguide_check:
         cmd = [os.path.join(ROOT_DIR, 'tools', 'refguide_check.py'),
                '--doctests']
+        if args.verbose:
+            cmd += ['-' + 'v'*args.verbose]
         if args.submodule:
             cmd += [args.submodule]
         os.execv(sys.executable, [sys.executable] + cmd)

--- a/do.py
+++ b/do.py
@@ -958,6 +958,8 @@ class RefguideCheck(Task):
     submodule = Option(
         ['--submodule', '-s'], default=None, metavar='SUBMODULE',
         help="Submodule whose tests to run (cluster, constants, ...)")
+    verbose = Option(
+        ['--verbose', '-v'], default=False, is_flag=True, help="verbosity")
 
     @classmethod
     def task_meta(cls, **kwargs):
@@ -967,6 +969,8 @@ class RefguideCheck(Task):
         dirs = Dirs(args)
 
         cmd = [str(dirs.root / 'tools' / 'refguide_check.py'), '--doctests']
+        if args.verbose:
+            cmd += ['-vvv']
         if args.submodule:
             cmd += [args.submodule]
         cmd_str = ' '.join(cmd)

--- a/runtests.py
+++ b/runtests.py
@@ -223,6 +223,8 @@ def main(argv):
     if args.refguide_check:
         cmd = [os.path.join(ROOT_DIR, 'tools', 'refguide_check.py'),
                '--doctests']
+        if args.verbose:
+            cmd += ['-' + 'v'*args.verbose]
         if args.submodule:
             cmd += [args.submodule]
         os.execv(sys.executable, [sys.executable] + cmd)

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -950,7 +950,12 @@ def main(argv):
                 module_names.append(name)
 
     for submodule_name in module_names:
-        module_name = BASE_MODULE + '.' + submodule_name
+        prefix = BASE_MODULE + '.'
+        if not submodule_name.startswith(prefix):
+            module_name = prefix + submodule_name
+        else:
+            module_name = submodule_name
+
         __import__(module_name)
         module = sys.modules[module_name]
 


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Sync https://github.com/numpy/numpy/pull/21574 and https://github.com/numpy/numpy/pull/21572 to scipy/tools/refguide-check.

#### What does this implement/fix?
<!--Please explain your changes.-->

Two tweaks:
1. module names to be doctested can be listed either relative to the BASE_MODULE, as before (i.e. `-s stats`) or with full names (`-s scipy.stats`). This is meant to make easier refguide-checking individual modules/python files.
2. respect the verbosity argument: previously, `$ python runtests.py -s stats --refguide-check -v` was ignoring the `-v` switch. This PR plumbs this through all three interfaces, `runtests.py`, `dev.py` and `doit` (sigh).

#### Additional information
<!--Any additional information you think is important.-->

1 still discovers doctests via the `__all__` dictionary. So it's of limited usability for private submodules, which may or may not have this dictionary. Still I'd like to have the option here to minimize the divergence between the scipy and numpy refguide-checks. At some point these may grow an alternative doctest discovery mechanisms (standard doctests?), but this is for some other day.

2 is also a bare minimum fix. Controlling several verbosity levels may make sense (e.g. dots only, output the names of the objects, output full doctests), but this is also a possible future enhancement.