### PR TITLE
DEP: add deprecation warning for vertices attribute in qhull

### DIFF
--- a/scipy/spatial/_qhull.pyx
+++ b/scipy/spatial/_qhull.pyx
@@ -1723,6 +1723,7 @@ class Delaunay(_QhullUser):
         Same as `simplices`, but deprecated.
 
         .. deprecated:: 0.12.0
+
         Delaunay attribute `vertices` is deprecated in favour of `simplices`
         and will be removed in Scipy 1.11.0.
     vertex_neighbor_vertices : tuple of two ndarrays of int; (indptr, indices)
@@ -1871,7 +1872,7 @@ class Delaunay(_QhullUser):
     @property
     def vertices(self):
         msg = ("Delaunay attribute 'vertices' is deprecated in favour of "
-        "'simplices' and will be removed in Scipy 1.11.0.")
+               "'simplices' and will be removed in Scipy 1.11.0.")
         warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
         return self._vertices
 

--- a/scipy/spatial/_qhull.pyx
+++ b/scipy/spatial/_qhull.pyx
@@ -22,6 +22,7 @@ from scipy._lib.messagestream cimport MessageStream
 import os
 import sys
 import tempfile
+import warnings
 
 np.import_array()
 
@@ -1720,6 +1721,10 @@ class Delaunay(_QhullUser):
         .. versionadded:: 0.12.0
     vertices
         Same as `simplices`, but deprecated.
+
+        .. deprecated:: 0.12.0
+        Delaunay attribute `vertices` is deprecated in favour of `simplices`
+        and will be removed in Scipy 1.11.0.
     vertex_neighbor_vertices : tuple of two ndarrays of int; (indptr, indices)
         Neighboring vertices of vertices. The indices of neighboring
         vertices of vertex `k` are ``indices[indptr[k]:indptr[k+1]]``.
@@ -1859,9 +1864,16 @@ class Delaunay(_QhullUser):
         self._vertex_neighbor_vertices = None
 
         # Backwards compatibility (Scipy < 0.12.0)
-        self.vertices = self.simplices
+        self._vertices = self.simplices
 
         _QhullUser._update(self, qhull)
+
+    @property
+    def vertices(self):
+        msg = ("Delaunay attribute 'vertices' is deprecated in favour of "
+        "'simplices' and will be removed in Scipy 1.11.0.")
+        warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
+        return self._vertices
 
     def add_points(self, points, restart=False):
         self._add_points(points, restart)

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -186,7 +186,7 @@ class TestUtilities:
         # |1 \|
         # +---+
 
-        assert_equal(tri.vertices, [[1, 3, 2], [3, 1, 0]])
+        assert_equal(tri.simplices, [[1, 3, 2], [3, 1, 0]])
 
         for p in [(0.25, 0.25, 1),
                   (0.75, 0.75, 0),
@@ -210,7 +210,7 @@ class TestUtilities:
 
         dist = tri.plane_distance(p)
 
-        for j, v in enumerate(tri.vertices):
+        for j, v in enumerate(tri.simplices):
             x1 = z[v[0]]
             x2 = z[v[1]]
             x3 = z[v[2]]
@@ -288,7 +288,7 @@ class TestUtilities:
                                       unit_cube=False,
                                       unit_cube_tol=0):
         """Check that a triangulation has reasonable barycentric transforms"""
-        vertices = tri.points[tri.vertices]
+        vertices = tri.points[tri.simplices]
         sc = 1/(tri.ndim + 1.0)
         centroids = vertices.sum(axis=1) * sc
 
@@ -439,9 +439,9 @@ class TestDelaunay:
 
             tri = qhull.Delaunay(points)
 
-            tri.vertices.sort()
+            tri.simplices.sort()
 
-            assert_equal(tri.vertices, np.arange(nd+1, dtype=int)[None,:])
+            assert_equal(tri.simplices, np.arange(nd+1, dtype=int)[None, :])
             assert_equal(tri.neighbors, -1 + np.zeros((nd+1), dtype=int)[None,:])
 
     def test_2d_square(self):
@@ -449,7 +449,7 @@ class TestDelaunay:
         points = np.array([(0,0), (0,1), (1,1), (1,0)], dtype=np.double)
         tri = qhull.Delaunay(points)
 
-        assert_equal(tri.vertices, [[1, 3, 2], [3, 1, 0]])
+        assert_equal(tri.simplices, [[1, 3, 2], [3, 1, 0]])
         assert_equal(tri.neighbors, [[-1, -1, 1], [-1, -1, 0]])
 
     def test_duplicate_points(self):
@@ -467,13 +467,13 @@ class TestDelaunay:
         # both should succeed
         points = DATASETS['pathological-1']
         tri = qhull.Delaunay(points)
-        assert_equal(tri.points[tri.vertices].max(), points.max())
-        assert_equal(tri.points[tri.vertices].min(), points.min())
+        assert_equal(tri.points[tri.simplices].max(), points.max())
+        assert_equal(tri.points[tri.simplices].min(), points.min())
 
         points = DATASETS['pathological-2']
         tri = qhull.Delaunay(points)
-        assert_equal(tri.points[tri.vertices].max(), points.max())
-        assert_equal(tri.points[tri.vertices].min(), points.min())
+        assert_equal(tri.points[tri.simplices].max(), points.max())
+        assert_equal(tri.points[tri.simplices].min(), points.min())
 
     def test_joggle(self):
         # Check that the option QJ indeed guarantees that all input points
@@ -542,6 +542,13 @@ class TestDelaunay:
 
         assert_unordered_tuple_list_equal(obj2.simplices, obj3.simplices,
                                           tpl=sorted_tuple)
+
+    def test_vertices_deprecation(self):
+        tri = qhull.Delaunay([(0, 0), (0, 1), (1, 0)])
+        msg = ("Delaunay attribute 'vertices' is deprecated in favour of "
+               "'simplices' and will be removed in Scipy 1.11.0.")
+        with pytest.warns(DeprecationWarning, match=msg):
+            tri.vertices
 
 
 def assert_hulls_equal(points, facets_1, facets_2):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
closes #16255
#### What does this implement/fix?
<!--Please explain your changes.-->
The attribute `vertices` was deprecated in documentation only. This pr adds a deprecation warning and test with details for removal.
#### Additional information
<!--Any additional information you think is important.-->
