### PR TITLE
DEP: add deprecation warning to maxiter kwarg in _minimize_tnc

### DIFF
--- a/scipy/optimize/_tnc.py
+++ b/scipy/optimize/_tnc.py
@@ -282,7 +282,7 @@ def fmin_tnc(func, x0, fprime=None, args=(), approx_grad=0,
 
 def _minimize_tnc(fun, x0, args=(), jac=None, bounds=None,
                   eps=1e-8, scale=None, offset=None, mesg_num=None,
-                  maxCGit=-1, maxiter=None, eta=-1, stepmx=0, accuracy=0,
+                  maxCGit=-1, eta=-1, stepmx=0, accuracy=0,
                   minfev=0, ftol=-1, xtol=-1, gtol=-1, rescale=-1, disp=False,
                   callback=None, finite_diff_rel_step=None, maxfun=None,
                   **unknown_options):
@@ -310,9 +310,6 @@ def _minimize_tnc(fun, x0, args=(), jac=None, bounds=None,
         iteration. If maxCGit == 0, the direction chosen is
         -gradient if maxCGit < 0, maxCGit is set to
         max(1,min(50,n/2)). Defaults to -1.
-    maxiter : int, optional
-        Maximum number of function evaluations. This keyword is deprecated
-        in favor of `maxfun`. Only if `maxfun` is None is this keyword used.
     eta : float
         Severity of the line search. If < 0 or > 1, set to 0.25.
         Defaults to -1.
@@ -408,10 +405,7 @@ def _minimize_tnc(fun, x0, args=(), jac=None, bounds=None,
         offset = array([])
 
     if maxfun is None:
-        if maxiter is not None:
-            maxfun = maxiter
-        else:
-            maxfun = max(100, 10*len(x0))
+        maxfun = max(100, 10*len(x0))
 
     rc, nf, nit, x, funv, jacv = moduleTNC.tnc_minimize(
         func_and_grad, x0, low, up, scale,

--- a/scipy/optimize/_tnc.py
+++ b/scipy/optimize/_tnc.py
@@ -413,7 +413,7 @@ def _minimize_tnc(fun, x0, args=(), jac=None, bounds=None,
     if maxfun is None:
         if maxiter is not None:
             warnings.warn(
-                "`maxiter` has been deprecated in favor of `maxfun`"
+                "'maxiter' has been deprecated in favor of 'maxfun'"
                 " and will be removed in SciPy 1.11.0.",
                 DeprecationWarning, stacklevel=3
             )

--- a/scipy/optimize/_tnc.py
+++ b/scipy/optimize/_tnc.py
@@ -314,8 +314,8 @@ def _minimize_tnc(fun, x0, args=(), jac=None, bounds=None,
         max(1,min(50,n/2)). Defaults to -1.
     maxiter : int, optional
         Maximum number of function evaluations. This keyword is deprecated
-        in favor of `maxfun`. Only if `maxfun` is None is this keyword used.
-        It will be completely removed in SciPy 1.11.0.
+        in favor of `maxfun` and will removed in SciPy 1.11.0.
+        Default is None.
     eta : float
         Severity of the line search. If < 0 or > 1, set to 0.25.
         Defaults to -1.
@@ -413,9 +413,10 @@ def _minimize_tnc(fun, x0, args=(), jac=None, bounds=None,
     if maxfun is None:
         if maxiter is not None:
             warnings.warn(
-                        "`maxiter` has been deprecated in favor of `maxfun`. "
-                        "It will be completely removed in SciPy 1.11.0.",
-                        DeprecationWarning)
+                "`maxiter` has been deprecated in favor of `maxfun`"
+                " and will be removed in SciPy 1.11.0.",
+                DeprecationWarning, stacklevel=3
+            )
             maxfun = maxiter
         else:
             maxfun = max(100, 10*len(x0))

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -1187,7 +1187,7 @@ class TestOptimizeSimple(CheckOptimize):
         if method in ['nelder-mead', 'powell', 'cobyla']:
             jac = None
         with suppress_warnings() as sup:
-            sup.filter(DeprecationWarning, "`maxiter` has been deprecated...")
+            sup.filter(DeprecationWarning, "'maxiter' has been deprecated...")
             sol = optimize.minimize(func, x0, jac=jac, method=method,
                                     options=dict(maxiter=20))
         assert_equal(func(sol.x), sol.fun)
@@ -1410,7 +1410,7 @@ class TestOptimizeSimple(CheckOptimize):
             sup.filter(UserWarning, "delta_grad == 0.*")
             sup.filter(RuntimeWarning, ".*does not use Hessian.*")
             sup.filter(RuntimeWarning, ".*does not use gradient.*")
-            sup.filter(DeprecationWarning, "`maxiter` has been deprecated...")
+            sup.filter(DeprecationWarning, "'maxiter' has been deprecated...")
 
             for f, g, h in itertools.product(funcs, grads, hesss):
                 count = [0]
@@ -1724,7 +1724,7 @@ class TestOptimizeScalar:
             sup.filter(UserWarning, "delta_grad == 0.*")
             sup.filter(RuntimeWarning, ".*does not use Hessian.*")
             sup.filter(RuntimeWarning, ".*does not use gradient.*")
-            sup.filter(DeprecationWarning, "`maxiter` has been deprecated...")
+            sup.filter(DeprecationWarning, "'maxiter' has been deprecated...")
 
             count = [0]
             sol = optimize.minimize_scalar(func, bracket=bracket,

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -1186,8 +1186,10 @@ class TestOptimizeSimple(CheckOptimize):
         jac = bad_grad
         if method in ['nelder-mead', 'powell', 'cobyla']:
             jac = None
-        sol = optimize.minimize(func, x0, jac=jac, method=method,
-                                options=dict(maxiter=20))
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning, "`maxiter` has been deprecated...")
+            sol = optimize.minimize(func, x0, jac=jac, method=method,
+                                    options=dict(maxiter=20))
         assert_equal(func(sol.x), sol.fun)
 
         if method == 'slsqp':
@@ -1408,6 +1410,7 @@ class TestOptimizeSimple(CheckOptimize):
             sup.filter(UserWarning, "delta_grad == 0.*")
             sup.filter(RuntimeWarning, ".*does not use Hessian.*")
             sup.filter(RuntimeWarning, ".*does not use gradient.*")
+            sup.filter(DeprecationWarning, "`maxiter` has been deprecated...")
 
             for f, g, h in itertools.product(funcs, grads, hesss):
                 count = [0]
@@ -1721,6 +1724,7 @@ class TestOptimizeScalar:
             sup.filter(UserWarning, "delta_grad == 0.*")
             sup.filter(RuntimeWarning, ".*does not use Hessian.*")
             sup.filter(RuntimeWarning, ".*does not use gradient.*")
+            sup.filter(DeprecationWarning, "`maxiter` has been deprecated...")
 
             count = [0]
             sol = optimize.minimize_scalar(func, bracket=bracket,

--- a/scipy/optimize/tests/test_tnc.py
+++ b/scipy/optimize/tests/test_tnc.py
@@ -348,9 +348,8 @@ class TestTnc:
         assert_equal(res2.nfev, res.nfev)
 
     def test_maxiter_depreciations(self):
-        fg, x = self.f1, [1, 3]
-
-        msg = ("`maxiter` has been deprecated in favor of `maxfun`. "
-               "It will be completely removed in SciPy 1.11.0.")
+        msg = "`maxiter` has been deprecated in favor of `maxfun`"
         with pytest.warns(DeprecationWarning, match=msg):
-            optimize.minimize(fg, x, method="TNC", options={"maxiter": 200})
+            optimize.minimize(
+                self.f1, [1, 3], method="TNC", options={"maxiter": 1}
+            )

--- a/scipy/optimize/tests/test_tnc.py
+++ b/scipy/optimize/tests/test_tnc.py
@@ -346,3 +346,11 @@ class TestTnc:
         assert_allclose(res2.x, res.x)
         assert_allclose(res2.fun, res.fun)
         assert_equal(res2.nfev, res.nfev)
+
+    def test_maxiter_depreciations(self):
+        fg, x = self.f1, [1, 3]
+
+        msg = ("`maxiter` has been deprecated in favor of `maxfun`. "
+               "It will be completely removed in SciPy 1.11.0.")
+        with pytest.warns(DeprecationWarning, match=msg):
+            optimize.minimize(fg, x, method="TNC", options={"maxiter": 200})

--- a/scipy/optimize/tests/test_tnc.py
+++ b/scipy/optimize/tests/test_tnc.py
@@ -348,7 +348,7 @@ class TestTnc:
         assert_equal(res2.nfev, res.nfev)
 
     def test_maxiter_depreciations(self):
-        msg = "`maxiter` has been deprecated in favor of `maxfun`"
+        msg = "'maxiter' has been deprecated in favor of 'maxfun'"
         with pytest.warns(DeprecationWarning, match=msg):
             optimize.minimize(
                 self.f1, [1, 3], method="TNC", options={"maxiter": 1}


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
close #16254 

#### What does this implement/fix?
<!--Please explain your changes.-->
Add deprecation warning to `maxiter` kwarg in _minimize_tnc when it is being called

#### Additional information
<!--Any additional information you think is important.-->
This is my first PR for scipy. Appreciate any comments.
