### PR TITLE
DOC: update the RegularGridInterpolator docstring

### DIFF
--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -110,7 +110,10 @@ class RegularGridInterpolator:
 
     Examples
     --------
-    Evaluate a simple example function on the points of a 3-D grid:
+    **Evaluate a function on the points of a 3-D grid**
+
+    As a first example, we evaluate a simple example function on the points of
+    a 3-D grid:
 
     >>> from scipy.interpolate import RegularGridInterpolator
     >>> def f(x, y, z):
@@ -139,6 +142,7 @@ class RegularGridInterpolator:
     >>> f(2.1, 6.2, 8.3), f(3.3, 5.2, 7.1)
     (125.54200000000002, 145.894)
 
+    **Interpolate and extrapolate a 2D data**
     As a second example, we interpolate and extrapolate a 2D data:
 
     >>> x, y = np.array([-2, 0, 4]), np.array([-2, 0, 2, 5])
@@ -171,16 +175,36 @@ class RegularGridInterpolator:
     ...                   alpha=0.4, label='ground truth')
     >>> plt.legend()
 
+    **Length-one axes**
+    If one of the grid dimensions has length one, linear and nearest
+    interpolators will extrapolate in that direction, as  controlled by the
+    `fill_value`. For instance:
+
+    >>> x = np.array([0, 5., 10])
+    >>> y = np.array([0.])
+    >>> def f(x,y):
+    ...     return (y+1) * x
+    >>> data = f(*np.meshgrid(x,y, indexing='ij', sparse=True))
+    >>> interp = RegularGridInterpolator((x, y), data,
+    ...                                  fill_value=None, bounds_error=False)
+    >>> interp([[6, 0], [6, 1]])
+    array([6., 6.])
+
     Other examples are given
     :ref:`in the tutorial <tutorial-interpolate_regular_grid_interpolator>`.
 
-    See also
+    See Also
     --------
     NearestNDInterpolator : Nearest neighbor interpolation on *unstructured*
                             data in N dimensions
 
     LinearNDInterpolator : Piecewise linear interpolant on *unstructured* data
                            in N dimensions
+
+    interpn : a convenience function which wraps `RegularGridInterpolator`
+
+    scipy.ndimage.map_coordinates : interpolation on grids with equal spacing
+                                    (suitable for e.g., N-D image resampling)
 
     References
     ----------
@@ -511,11 +535,14 @@ def interpn(points, values, xi, method="linear", bounds_error=True,
     LinearNDInterpolator : Piecewise linear interpolant on unstructured data
                            in N dimensions
 
-    RegularGridInterpolator : Linear and nearest-neighbor Interpolation on a
-                              regular or rectilinear grid in arbitrary
-                              dimensions
+    RegularGridInterpolator : interpolation on a regular or rectilinear grid
+                              in arbitrary dimensions (`interpn` wraps this
+                              class).
 
     RectBivariateSpline : Bivariate spline approximation over a rectangular mesh
+
+    scipy.ndimage.map_coordinates : interpolation on grids with equal spacing
+                                    (suitable for e.g., N-D image resampling)
 
     """
     # sanity check 'method' kwarg

--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -96,14 +96,10 @@ class RegularGridInterpolator:
     In other words, this class assumes that the data is defined on a
     *rectilinear* grid.
 
-    If any of `points` have a dimension of size 1, linear interpolation will
-    return an array of `nan` values. Nearest-neighbor interpolation will work
-    as usual in this case.
-
     .. versionadded:: 0.14
 
     The 'slinear'(k=1), 'cubic'(k=3), and 'quintic'(k=5) methods are
-    spline-based interpolators, the `k` is spline degree,
+    tensor-product spline interpolators, where `k` is the spline degree,
     If any dimension has fewer points than `k` + 1, an error will be raised.
 
     .. versionadded:: 1.9

--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -138,9 +138,9 @@ class RegularGridInterpolator:
     >>> f(2.1, 6.2, 8.3), f(3.3, 5.2, 7.1)
     (125.54200000000002, 145.894)
 
-    **Interpolate and extrapolate a 2D data**
+    **Interpolate and extrapolate a 2D dataset**
 
-    As a second example, we interpolate and extrapolate a 2D data:
+    As a second example, we interpolate and extrapolate a 2D data set:
 
     >>> x, y = np.array([-2, 0, 4]), np.array([-2, 0, 2, 5])
     >>> def ff(x, y):
@@ -171,24 +171,9 @@ class RegularGridInterpolator:
     >>> ax.plot_wireframe(X, Y, ff(X, Y), rstride=3, cstride=3,
     ...                   alpha=0.4, label='ground truth')
     >>> plt.legend()
+    >>> plt.show()
 
-    **Length-one axes**
-
-    If one of the grid dimensions has length one, linear and nearest
-    interpolators will extrapolate in that direction, as controlled by the
-    `fill_value`. For instance:
-
-    >>> x = np.array([0, 5., 10])
-    >>> y = np.array([0.])
-    >>> def f(x, y):
-    ...     return (y+1) * x
-    >>> data = f(*np.meshgrid(x, y, indexing='ij', sparse=True))
-    >>> interp = RegularGridInterpolator((x, y), data,
-    ...                                  fill_value=None, bounds_error=False)
-    >>> interp([[6, 0], [6, 1]])
-    array([6., 6.])
-
-    **Other examples** are given
+    Other examples are given
     :ref:`in the tutorial <tutorial-interpolate_regular_grid_interpolator>`.
 
     See Also

--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -175,14 +175,14 @@ class RegularGridInterpolator:
     **Length-one axes**
 
     If one of the grid dimensions has length one, linear and nearest
-    interpolators will extrapolate in that direction, as  controlled by the
+    interpolators will extrapolate in that direction, as controlled by the
     `fill_value`. For instance:
 
     >>> x = np.array([0, 5., 10])
     >>> y = np.array([0.])
-    >>> def f(x,y):
+    >>> def f(x, y):
     ...     return (y+1) * x
-    >>> data = f(*np.meshgrid(x,y, indexing='ij', sparse=True))
+    >>> data = f(*np.meshgrid(x, y, indexing='ij', sparse=True))
     >>> interp = RegularGridInterpolator((x, y), data,
     ...                                  fill_value=None, bounds_error=False)
     >>> interp([[6, 0], [6, 1]])

--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -139,6 +139,7 @@ class RegularGridInterpolator:
     (125.54200000000002, 145.894)
 
     **Interpolate and extrapolate a 2D data**
+
     As a second example, we interpolate and extrapolate a 2D data:
 
     >>> x, y = np.array([-2, 0, 4]), np.array([-2, 0, 2, 5])
@@ -172,6 +173,7 @@ class RegularGridInterpolator:
     >>> plt.legend()
 
     **Length-one axes**
+
     If one of the grid dimensions has length one, linear and nearest
     interpolators will extrapolate in that direction, as  controlled by the
     `fill_value`. For instance:
@@ -186,7 +188,7 @@ class RegularGridInterpolator:
     >>> interp([[6, 0], [6, 1]])
     array([6., 6.])
 
-    Other examples are given
+    **Other examples** are given
     :ref:`in the tutorial <tutorial-interpolate_regular_grid_interpolator>`.
 
     See Also


### PR DESCRIPTION
#### What does this implement/fix?
<!--Please explain your changes.-->

Add the note that RGI actually extrapolates if the input grid has length-one dimensions. This behavior is new in scipy 1.9.0-to-be, so update the docstring to be consistent with code.

The example is taken from gh-7560, as suggested by Matt in https://github.com/scipy/scipy/pull/16070#issuecomment-1114341794.

#### Additional information
<!--Any additional information you think is important.-->

It'd be nice to add this to 1.9.0 since it documents a small enhancement which is new in 1.9.0. But of course it's not a blocker.