### PR TITLE
DOC: remove deprecated functions from refguide

### DIFF
--- a/doc/release/0.15.0-notes.rst
+++ b/doc/release/0.15.0-notes.rst
@@ -86,7 +86,7 @@ for computing reorderings of sparse graphs were added.
 ``scipy.stats`` improvements
 ----------------------------
 
-Added a Dirichlet multivariate distribution, `scipy.stats.dirichlet`.
+Added a Dirichlet multivariate distribution, ``scipy.stats.dirichlet``.
 
 The new function `scipy.stats.median_test` computes Mood's median test.
 

--- a/doc/release/1.0.0-notes.rst
+++ b/doc/release/1.0.0-notes.rst
@@ -378,7 +378,7 @@ Name - (accessing/setting has been removed) - (setting has been removed)
 ``signal.freqz(b, a)`` with ``b`` or ``a`` >1-D raises a ``ValueError``.  This
 was a corner case for which it was unclear that the behavior was well-defined.
 
-The method ``var`` of `scipy.stats.dirichlet` now returns a scalar rather than
+The method ``var`` of ``scipy.stats.dirichlet`` now returns a scalar rather than
 an ndarray when the length of alpha is 1.
 
 

--- a/doc/release/1.7.0-notes.rst
+++ b/doc/release/1.7.0-notes.rst
@@ -260,7 +260,7 @@ interval and standard error of a statistic.
 The new function `scipy.stats.contingency.crosstab` computes a contingency
 table (i.e. a table of counts of unique entries) for the given data.
 
-`scipy.stats.NumericalInverseHermite` enables fast random variate sampling
+``scipy.stats.NumericalInverseHermite`` enables fast random variate sampling
 and percentile point function evaluation of an arbitrary univariate statistical
 distribution.
 

--- a/doc/release/1.8.0-notes.rst
+++ b/doc/release/1.8.0-notes.rst
@@ -155,7 +155,7 @@ The ``trace`` method has been added for sparse matrices.
 ``concatenate`` method.
 
 Add `scipy.spatial.distance.kulczynski1` in favour of
-`scipy.spatial.distance.kulsinski` which will be deprecated in the next
+``scipy.spatial.distance.kulsinski`` which will be deprecated in the next
 release.
 
 `scipy.spatial.distance.minkowski` now also supports ``0<p<1``.

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -892,11 +892,6 @@ def kulczynski1(u, v, *, w=None):
     kulczynski1 : float
         The Kulczynski 1 distance between vectors `u` and `v`.
 
-    See Also
-    --------
-
-    kulsinski
-
     Notes
     -----
     This measure has a minimum value of 0 and no upper limit.
@@ -1961,7 +1956,7 @@ def pdist(X, metric='euclidean', *, out=None, **kwargs):
         The distance metric to use. The distance function can
         be 'braycurtis', 'canberra', 'chebyshev', 'cityblock',
         'correlation', 'cosine', 'dice', 'euclidean', 'hamming',
-        'jaccard', 'jensenshannon', 'kulsinski', 'kulczynski1',
+        'jaccard', 'jensenshannon', 'kulczynski1',
         'mahalanobis', 'matching', 'minkowski', 'rogerstanimoto',
         'russellrao', 'seuclidean', 'sokalmichener', 'sokalsneath',
         'sqeuclidean', 'yule'.
@@ -2153,10 +2148,10 @@ def pdist(X, metric='euclidean', *, out=None, **kwargs):
         Computes the Dice distance between each pair of boolean
         vectors. (see dice function documentation)
 
-    18. ``Y = pdist(X, 'kulsinski')``
+    18. ``Y = pdist(X, 'kulczynski1')``
 
-        Computes the Kulsinski distance between each pair of
-        boolean vectors. (see kulsinski function documentation)
+        Computes the kulczynski1 distance between each pair of
+        boolean vectors. (see kulczynski1 function documentation)
 
     19. ``Y = pdist(X, 'rogerstanimoto')``
 
@@ -2622,7 +2617,7 @@ def cdist(XA, XB, metric='euclidean', *, out=None, **kwargs):
         The distance metric to use. If a string, the distance function can be
         'braycurtis', 'canberra', 'chebyshev', 'cityblock', 'correlation',
         'cosine', 'dice', 'euclidean', 'hamming', 'jaccard', 'jensenshannon',
-        'kulsinski', 'kulczynski1', 'mahalanobis', 'matching', 'minkowski',
+        'kulczynski1', 'mahalanobis', 'matching', 'minkowski',
         'rogerstanimoto', 'russellrao', 'seuclidean', 'sokalmichener',
         'sokalsneath', 'sqeuclidean', 'yule'.
     **kwargs : dict, optional
@@ -2810,10 +2805,10 @@ def cdist(XA, XB, metric='euclidean', *, out=None, **kwargs):
         Computes the Dice distance between the boolean vectors. (see
         `dice` function documentation)
 
-    18. ``Y = cdist(XA, XB, 'kulsinski')``
+    18. ``Y = cdist(XA, XB, 'kulczynski1')``
 
-        Computes the Kulsinski distance between the boolean
-        vectors. (see `kulsinski` function documentation)
+        Computes the kulczynski distance between the boolean
+        vectors. (see `kulczynski1` function documentation)
 
     19. ``Y = cdist(XA, XB, 'rogerstanimoto')``
 

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -60,7 +60,6 @@ computing the distances between all pairs.
    dice             -- the Dice dissimilarity.
    hamming          -- the Hamming distance.
    jaccard          -- the Jaccard distance.
-   kulsinski        -- the Kulsinski distance.
    kulczynski1      -- the Kulczynski 1 distance.
    rogerstanimoto   -- the Rogers-Tanimoto dissimilarity.
    russellrao       -- the Russell-Rao dissimilarity.

--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -161,7 +161,6 @@ Multivariate distributions
    multivariate_normal    -- Multivariate normal distribution
    matrix_normal          -- Matrix normal distribution
    multivariate_beta      -- Multivariate beta distribution (Dirichlet)
-   dirichlet              -- Dirichlet (deprecated; see `multivariate_beta`)
    wishart                -- Wishart
    invwishart             -- Inverse Wishart
    multinomial            -- Multinomial distribution
@@ -395,7 +394,6 @@ Random variate generation / CDF Inversion
    :toctree: generated/
 
    rvs_ratio_uniforms
-   NumericalInverseHermite
 
 Distribution Fitting
 --------------------

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -1639,10 +1639,6 @@ class multivariate_beta_gen(dirichlet_gen):
     %(_dirichlet_doc_default_callparams)s
     %(_doc_random_state)s
 
-    See Also
-    --------
-    dirichlet
-
     Notes
     -----
     Each :math:`\alpha` entry must be positive. The distribution has only


### PR DESCRIPTION
This should fix an oversight from #16265

Not 100% sure this is what should be done here (locally it fixes the ref guide check). But makes sense to not advertise this in the doc.