### PR TITLE
MAINT: sparse.linalg: Update some docstrings.

### DIFF
--- a/scipy/sparse/linalg/_isolve/iterative.py
+++ b/scipy/sparse/linalg/_isolve/iterative.py
@@ -3,6 +3,7 @@
 __all__ = ['bicg','bicgstab','cg','cgs','gmres','qmr']
 
 import warnings
+from textwrap import dedent
 import numpy as np
 
 from . import _iterative
@@ -60,7 +61,6 @@ M : {sparse matrix, ndarray, LinearOperator}
 callback : function
     User-supplied function to call after each iteration.  It is called
     as callback(xk), where xk is the current solution vector.
-
 """
 
 
@@ -120,7 +120,7 @@ def set_docstring(header, Ainfo, footer='', atol_default='0'):
     def combine(fn):
         fn.__doc__ = '\n'.join((header, common_doc1,
                                 '    ' + Ainfo.replace('\n', '\n    '),
-                                common_doc2, footer))
+                                common_doc2, dedent(footer)))
         return fn
     return combine
 
@@ -130,8 +130,7 @@ def set_docstring(header, Ainfo, footer='', atol_default='0'):
                'Alternatively, ``A`` can be a linear operator which can\n'
                'produce ``Ax`` and ``A^T x`` using, e.g.,\n'
                '``scipy.sparse.linalg.LinearOperator``.',
-               footer="""
-
+               footer="""\
                Examples
                --------
                >>> from scipy.sparse import csc_matrix
@@ -218,15 +217,17 @@ def bicg(A, b, x0=None, tol=1e-5, maxiter=None, M=None, callback=None, atol=None
                'Alternatively, ``A`` can be a linear operator which can\n'
                'produce ``Ax`` using, e.g.,\n'
                '``scipy.sparse.linalg.LinearOperator``.',
-               footer="""
-
+               footer="""\
                Examples
                --------
                >>> from scipy.sparse import csc_matrix
                >>> from scipy.sparse.linalg import bicgstab
-               >>> R = np.random.randn(5, 5)
+               >>> R = np.array([[4, 2, 0, 1],
+               ...               [3, 0, 0, 2],
+               ...               [0, 1, 1, 1],
+               ...               [0, 2, 1, 0]])
                >>> A = csc_matrix(R)
-               >>> b = np.random.randn(5)
+               >>> b = np.array([-1, -0.5, -1, 2])
                >>> x, exit_code = bicgstab(A, b)
                >>> print(exit_code)  # 0 indicates successful convergence
                0
@@ -300,16 +301,17 @@ def bicgstab(A, b, x0=None, tol=1e-5, maxiter=None, M=None, callback=None, atol=
                'Alternatively, ``A`` can be a linear operator which can\n'
                'produce ``Ax`` using, e.g.,\n'
                '``scipy.sparse.linalg.LinearOperator``.',
-               footer="""
-
+               footer="""\
                Examples
                --------
                >>> from scipy.sparse import csc_matrix
                >>> from scipy.sparse.linalg import cg
-               >>> R = np.random.randn(5, 5)
-               >>> positive_definite = R @ R.T
-               >>> A = csc_matrix(positive_definite)
-               >>> b = np.random.randn(5)
+               >>> P = np.array([[4, 0, 1, 0],
+               ...               [0, 5, 0, 0],
+               ...               [1, 0, 3, 2],
+               ...               [0, 0, 2, 4]])
+               >>> A = csc_matrix(P)
+               >>> b = np.array([-1, -0.5, -1, 2])
                >>> x, exit_code = cg(A, b)
                >>> print(exit_code)    # 0 indicates successful convergence
                0
@@ -388,15 +390,17 @@ def cg(A, b, x0=None, tol=1e-5, maxiter=None, M=None, callback=None, atol=None):
                'Alternatively, ``A`` can be a linear operator which can\n'
                'produce ``Ax`` using, e.g.,\n'
                '``scipy.sparse.linalg.LinearOperator``.',
-               footer="""
-
+               footer="""\
                Examples
                --------
                >>> from scipy.sparse import csc_matrix
                >>> from scipy.sparse.linalg import cgs
-               >>> R = np.random.randn(5, 5)
+               >>> R = np.array([[4, 2, 0, 1],
+               ...               [3, 0, 0, 2],
+               ...               [0, 1, 1, 1],
+               ...               [0, 2, 1, 0]])
                >>> A = csc_matrix(R)
-               >>> b = np.random.randn(5)
+               >>> b = np.array([-1, -0.5, -1, 2])
                >>> x, exit_code = cgs(A, b)
                >>> print(exit_code)  # 0 indicates successful convergence
                0


### PR DESCRIPTION
Two changes:

* The docstrings of bicg, bicgstab, cg and cgs are generated with the
  decorator 'set_docstring()'.  Before this change, the "Examples" section
  of the generated docstrings was preceded by four blank lines, and was
  indented 15 spaces.  This change fixes those whitespace issues.

* The examples in the docstrings of bicgstab, cg and cgs were using
  randomly generated arrays with no seed set.  The docstrings
  include the check 'np.allclose(A.dot(x), b)', but in fact, this
  check was returning False in about 4.5% of runs of the bicgstab
  example, 0.03% of the runs in the cg example, and 0.14% of the
  runs in the cgs example.

  The examples have been updated to use literal arrays instead
  of randomly generated arrays.  This avoids the problem of the
  occasional failure of 'allclose', and is also more useful
  because the reader can see the actual numbers being used.

