### PR TITLE
MAINT: stats: override `loguniform.fit` to resolve overparameterization

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -7363,6 +7363,15 @@ class reciprocal_gen(rv_continuous):
     def _entropy(self, a, b):
         return 0.5*np.log(a*b)+np.log(np.log(b*1.0/a))
 
+    fit_note = """\
+        `loguniform`/`reciprocal` is over-parameterized. `fit` automatically
+         fixes `scale` to 1 unless `fscale` is provided by the user.\n\n"""
+
+    @extend_notes_in_docstring(rv_continuous, notes=fit_note)
+    def fit(self, data, *args, **kwds):
+        fscale = kwds.pop('fscale', 1)
+        return super().fit(data, *args, fscale=fscale, **kwds)
+
 
 loguniform = reciprocal_gen(name="loguniform")
 reciprocal = reciprocal_gen(name="reciprocal")


### PR DESCRIPTION
#### Reference issue
Closes gh-14716
Supersedes gh-15889

#### What does this implement/fix?
The `loguniform`/`reciprocal` distribution is overparameterized, which negatively impacts fitting the distribution to data. This fixes the problem by enforcing `fscale=1` while fitting unless the user passes `fscale`.