### PR TITLE
BUG: special: DECREF scipy_special object before exiting sf_error().

### DIFF
--- a/scipy/special/sf_error.c
+++ b/scipy/special/sf_error.c
@@ -108,6 +108,9 @@ void sf_error(const char *func_name, sf_error_t code, const char *fmt, ...)
 	/* Sentinel, should never get here */
 	py_SpecialFunctionWarning = NULL;
     }
+    /* Done with scipy_special */
+    Py_DECREF(scipy_special);
+
     if (py_SpecialFunctionWarning == NULL) {
 	PyErr_Clear();
 	goto skip_warn;

--- a/scipy/special/tests/test_sf_error.py
+++ b/scipy/special/tests/test_sf_error.py
@@ -1,3 +1,4 @@
+import sys
 import warnings
 
 from numpy.testing import assert_, assert_equal
@@ -64,6 +65,18 @@ def test_seterr():
                 _check_action(_sf_error_test_function, (error_code,), action)
     finally:
         sc.seterr(**entry_err)
+
+
+def test_sf_error_special_refcount():
+    # Regression test for gh-16233.
+    # Check that the reference count of scipy.special is not increased
+    # when a SpecialFunctionError is raised.
+    refcount_before = sys.getrefcount(sc)
+    with sc.errstate(all='raise'):
+        with pytest.raises(sc.SpecialFunctionError, match='domain error'):
+            sc.ndtri(2.0)
+    refcount_after = sys.getrefcount(sc)
+    assert refcount_after == refcount_before
 
 
 def test_errstate_pyx_basic():


### PR DESCRIPTION
Closes gh-16233.
