### PR TITLE
BUG: fix a crash in `fpknot`

### DIFF
--- a/scipy/interpolate/fitpack/fpknot.f
+++ b/scipy/interpolate/fitpack/fpknot.f
@@ -20,7 +20,11 @@ c  ..local scalars..
       real*8 an,am,fpmax
       integer ihalf,j,jbegin,jj,jk,jpoint,k,maxbeg,maxpt,
      * next,nrx,number
-c  ..
+
+c  note: do not initialize on the same line to avoid saving between calls
+      logical iserr
+      iserr = .TRUE.
+
       k = (n-nrint-1)/2
 c  search for knot interval t(number+k) <= x <= t(number+k+1) where
 c  fpint(number) is maximal on the condition that nrdata(number)
@@ -30,12 +34,15 @@ c  not equals zero.
       do 20 j=1,nrint
         jpoint = nrdata(j)
         if(fpmax.ge.fpint(j) .or. jpoint.eq.0) go to 10
+        iserr = .FALSE.
         fpmax = fpint(j)
         number = j
         maxpt = jpoint
         maxbeg = jbegin
   10    jbegin = jbegin+jpoint+1
   20  continue
+c  error condition detected, go to exit
+      if(iserr) go to 50
 c  let coincide the new knot t(number+k+1) with a data point x(nrx)
 c  inside the old knot interval t(number+k) <= x <= t(number+k+1).
       ihalf = maxpt/2+1
@@ -59,7 +66,7 @@ c  adjust the different parameters.
       fpint(next) = fpmax*an/am
       jk = next+k
       t(jk) = x(nrx)
-      n = n+1
+  50  n = n+1
       nrint = nrint+1
       return
       end

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -325,6 +325,33 @@ class TestUnivariateSpline:
         assert_allclose(spl1([0.1, 0.5, 0.9, 0.99]),
                         spl2([0.1, 0.5, 0.9, 0.99]))
 
+    def test_fpknot_oob_crash(self):
+        # https://github.com/scipy/scipy/issues/3691
+        x = range(109)
+        y = [0., 0., 0., 0., 0., 10.9, 0., 11., 0.,
+             0., 0., 10.9, 0., 0., 0., 0., 0., 0.,
+             10.9, 0., 0., 0., 11., 0., 0., 0., 10.9,
+             0., 0., 0., 10.5, 0., 0., 0., 10.7, 0.,
+             0., 0., 11., 0., 0., 0., 0., 0., 0.,
+             10.9, 0., 0., 10.7, 0., 0., 0., 10.6, 0.,
+             0., 0., 10.5, 0., 0., 10.7, 0., 0., 10.5,
+             0., 0., 11.5, 0., 0., 0., 10.7, 0., 0.,
+             10.7, 0., 0., 10.9, 0., 0., 10.8, 0., 0.,
+             0., 10.7, 0., 0., 10.6, 0., 0., 0., 10.4,
+             0., 0., 10.6, 0., 0., 10.5, 0., 0., 0.,
+             10.7, 0., 0., 0., 10.4, 0., 0., 0., 10.8, 0.]
+        with suppress_warnings() as sup:
+            r = sup.record(
+                UserWarning,
+                r"""
+The maximal number of iterations maxit \(set to 20 by the program\)
+allowed for finding a smoothing spline with fp=s has been reached: s
+too small.
+There is an approximation returned but the corresponding weighted sum
+of squared residuals does not satisfy the condition abs\(fp-s\)/s < tol.""")
+            UnivariateSpline(x, y, k=1)
+            assert_equal(len(r), 1)
+
 
 class TestLSQBivariateSpline:
     # NOTE: The systems in this test class are rank-deficient


### PR DESCRIPTION
Caused by an OOB access due to uninitialized local variables.

Fixes #3691.