### PR TITLE
BLD: fix issue with `python setup.py install` and `_directmodule`

### DIFF
--- a/scipy/optimize/__init__.py
+++ b/scipy/optimize/__init__.py
@@ -421,7 +421,7 @@ from ._hessian_update_strategy import HessianUpdateStrategy, BFGS, SR1
 from ._shgo import shgo
 from ._dual_annealing import dual_annealing
 from ._qap import quadratic_assignment
-from ._direct import direct
+from ._direct_py import direct
 from ._milp import milp
 
 # Deprecated namespaces, to be removed in v2.0.0

--- a/scipy/optimize/_direct_py.py
+++ b/scipy/optimize/_direct_py.py
@@ -6,7 +6,7 @@ from typing import (
 import numpy as np
 from scipy.optimize import OptimizeResult
 from ._constraints import old_bound_to_new, Bounds
-from ._directmodule import direct as _direct  # type: ignore
+from ._direct import direct as _direct  # type: ignore
 
 if TYPE_CHECKING:
     import numpy.typing as npt

--- a/scipy/optimize/_directmodule.c
+++ b/scipy/optimize/_directmodule.c
@@ -74,7 +74,7 @@ DIRECTMethods[] = {
 
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
-    "_directmodule",
+    "_direct",
     NULL,
     -1,
     DIRECTMethods,
@@ -85,7 +85,7 @@ static struct PyModuleDef moduledef = {
 };
 
 PyMODINIT_FUNC
-PyInit__directmodule(void)
+PyInit__direct(void)
 {
     PyObject *module;
 

--- a/scipy/optimize/meson.build
+++ b/scipy/optimize/meson.build
@@ -6,7 +6,7 @@ fortran_ignore_warnings = [
   '-Wno-unused-variable'
 ]
 
-_directmodule = py3.extension_module('_directmodule',
+_direct = py3.extension_module('_direct',
   ['_direct/direct_wrap.c',
    '_direct/direct-internal.h',
    '_direct/DIRect.c',
@@ -281,7 +281,7 @@ py3.install_sources([
   '_constraints.py',
   '_differentiable_functions.py',
   '_differentialevolution.py',
-  '_direct.py',
+  '_direct_py.py',
   '_dual_annealing.py',
   '_hessian_update_strategy.py',
   '_lbfgsb_py.py',

--- a/scipy/optimize/setup.py
+++ b/scipy/optimize/setup.py
@@ -104,7 +104,7 @@ def configuration(parent_package='', top_path=None):
                        include_dirs=[get_python_inc()],
                        **numpy_nodepr_api)
 
-    config.add_extension('_directmodule',
+    config.add_extension('_direct',
                          sources=['_directmodule.c'],
                          libraries=['_direct_lib'],
                          depends=(sources + headers),


### PR DESCRIPTION
See if this works, or if it reproduces the `PyInit_direct` issue seen in https://github.com/scipy/scipy/pull/16187#issuecomment-1138953272

We currently do not have any CI jobs that test `python setup.py install`, and it may simply be broken.

[skip actions]
