### PR TITLE
MAINT: move `import_array` before module creation in module inits

### DIFF
--- a/scipy/integrate/_odepackmodule.c
+++ b/scipy/integrate/_odepackmodule.c
@@ -827,12 +827,12 @@ PyInit__odepack(void)
 {
     PyObject *module, *mdict;
 
+    import_array();
+
     module = PyModule_Create(&moduledef);
     if (module == NULL) {
         return NULL;
     }
-
-    import_array();
 
     mdict = PyModule_GetDict(module);
     if (mdict == NULL) {

--- a/scipy/integrate/_quadpackmodule.c
+++ b/scipy/integrate/_quadpackmodule.c
@@ -31,12 +31,12 @@ PyInit__quadpack(void)
 {
     PyObject *module, *mdict;
 
+    import_array();
+
     module = PyModule_Create(&moduledef);
     if (module == NULL) {
         return NULL;
     }
-
-    import_array();
 
     mdict = PyModule_GetDict(module);
     if (mdict == NULL) {

--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -1552,12 +1552,12 @@ PyInit__fitpack(void)
 {
     PyObject *module, *mdict;
 
+    import_array();
+
     module = PyModule_Create(&moduledef);
     if (module == NULL) {
         return NULL;
     }
-
-    import_array();
 
     mdict = PyModule_GetDict(module);
 

--- a/scipy/ndimage/src/nd_image.c
+++ b/scipy/ndimage/src/nd_image.c
@@ -1179,10 +1179,6 @@ static struct PyModuleDef moduledef = {
 PyMODINIT_FUNC
 PyInit__nd_image(void)
 {
-    PyObject *m;
-
-    m = PyModule_Create(&moduledef);
     import_array();
-
-    return m;
+    return PyModule_Create(&moduledef);
 }

--- a/scipy/optimize/_directmodule.c
+++ b/scipy/optimize/_directmodule.c
@@ -87,14 +87,6 @@ static struct PyModuleDef moduledef = {
 PyMODINIT_FUNC
 PyInit__direct(void)
 {
-    PyObject *module;
-
-    module = PyModule_Create(&moduledef);
-    if (module == NULL) {
-        return NULL;
-    }
-
     import_array();
-
-    return module;
+    return PyModule_Create(&moduledef);
 }

--- a/scipy/optimize/_lsap.c
+++ b/scipy/optimize/_lsap.c
@@ -192,8 +192,6 @@ static struct PyModuleDef moduledef = {
 PyObject*
 PyInit__lsap(void)
 {
-    PyObject* m;
-    m = PyModule_Create(&moduledef);
     import_array();
-    return m;
+    return PyModule_Create(&moduledef);
 }

--- a/scipy/optimize/_minpackmodule.c
+++ b/scipy/optimize/_minpackmodule.c
@@ -31,12 +31,12 @@ PyInit__minpack(void)
 {
     PyObject *module, *mdict;
 
+    import_array();
+
     module = PyModule_Create(&moduledef);
     if (module == NULL) {
         return NULL;
     }
-
-    import_array();
 
     mdict = PyModule_GetDict(module);
     if (mdict == NULL) {

--- a/scipy/signal/_sigtoolsmodule.c
+++ b/scipy/signal/_sigtoolsmodule.c
@@ -1413,12 +1413,16 @@ static struct PyModuleDef moduledef = {
 PyMODINIT_FUNC
 PyInit__sigtools(void)
 {
-    PyObject *m;
+    PyObject *module;
 
-    m = PyModule_Create(&moduledef);
     import_array();
+
+    module = PyModule_Create(&moduledef);
+    if (module == NULL) {
+        return NULL;
+    }
 
     scipy_signal__sigtools_linear_filter_module_init();
 
-    return m;
+    return module;
 }

--- a/scipy/signal/_splinemodule.c
+++ b/scipy/signal/_splinemodule.c
@@ -554,13 +554,6 @@ static struct PyModuleDef moduledef = {
 PyMODINIT_FUNC
 PyInit__spline(void)
 {
-    PyObject *module;
-    module = PyModule_Create(&moduledef);
-    if (module == NULL) {
-        return NULL;
-    }
-
     import_array();
-
-    return module;
+    return PyModule_Create(&moduledef);
 }

--- a/scipy/sparse/sparsetools/sparsetools.cxx
+++ b/scipy/sparse/sparsetools/sparsetools.cxx
@@ -566,10 +566,8 @@ static struct PyModuleDef moduledef = {
 PyMODINIT_FUNC
 PyInit__sparsetools(void)
 {
-    PyObject *m;
-    m = PyModule_Create(&moduledef);
     import_array();
-    return m;
+    return PyModule_Create(&moduledef);
 }
 
 } /* extern "C" */

--- a/scipy/spatial/src/distance_wrap.c
+++ b/scipy/spatial/src/distance_wrap.c
@@ -850,10 +850,6 @@ static struct PyModuleDef moduledef = {
 PyMODINIT_FUNC
 PyInit__distance_wrap(void)
 {
-    PyObject *m;
-
-    m = PyModule_Create(&moduledef);
     import_array();
-
-    return m;
+    return PyModule_Create(&moduledef);
 }


### PR DESCRIPTION
This seems to be the right order, fixes an issue where the reference to the newly created module isn't decreased if `import_array` fails.

Note that `import_array` already does its own error checking, and returns `NULL` if NumPy initialization fails, so no checks are needed. This makes the code a bit more concise.

Closes gh-16231