### PR TITLE
REL: set version to 1.10.0.dev0

### DIFF
--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -1,0 +1,129 @@
+==========================
+SciPy 1.10.0 Release Notes
+==========================
+
+.. note:: Scipy 1.10.0 is not released yet!
+
+.. contents::
+
+SciPy 1.10.0 is the culmination of X months of hard work. It contains
+many new features, numerous bug-fixes, improved test coverage and better
+documentation. There have been a number of deprecations and API changes
+in this release, which are documented below. All users are encouraged to
+upgrade to this release, as there are a large number of bug-fixes and
+optimizations. Before upgrading, we recommend that users check that
+their own code does not use deprecated SciPy functionality (to do so,
+run your code with ``python -Wd`` and check for ``DeprecationWarning`` s).
+Our development attention will now shift to bug-fix releases on the
+1.10.x branch, and on adding new features on the main branch.
+
+This release requires Python 3.8+ and NumPy 1.18.5 or greater.
+
+For running on PyPy, PyPy3 6.0+ is required.
+
+
+**************************
+Highlights of this release
+**************************
+
+
+************
+New features
+************
+
+`scipy.cluster` improvements
+============================
+
+
+`scipy.interpolate` improvements
+================================
+
+
+`scipy.linalg` improvements
+===========================
+
+
+`scipy.ndimage` improvements
+============================
+
+
+`scipy.optimize` improvements
+=============================
+
+
+`scipy.signal` improvements
+===========================
+
+
+`scipy.sparse` improvements
+===========================
+
+
+
+`scipy.spatial` improvements
+============================
+
+
+`scipy.special` improvements
+============================
+
+
+`scipy.stats` improvements
+==========================
+
+Hypothesis Tests
+----------------
+
+
+Sample statistics
+-----------------
+
+
+Statistical Distributions
+-------------------------
+
+
+Other
+-----
+
+
+
+
+*******************
+Deprecated features
+*******************
+
+`scipy.linalg` deprecations
+===========================
+
+
+`scipy.spatial` deprecations
+============================
+
+
+
+******************************
+Backwards incompatible changes
+******************************
+
+*************
+Other changes
+*************
+
+
+
+*******
+Authors
+*******
+
+
+
+************************
+Issues closed for 1.10.0
+************************
+
+
+************************
+Pull requests for 1.10.0
+************************
+

--- a/doc/source/release.1.10.0.rst
+++ b/doc/source/release.1.10.0.rst
@@ -1,0 +1,1 @@
+.. include:: ../release/1.10.0-notes.rst

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -8,6 +8,7 @@ see the `commit logs <https://github.com/scipy/scipy/commits/>`_.
 .. toctree::
    :maxdepth: 1
 
+   release.1.10.0
    release.1.9.0
    release.1.8.1
    release.1.8.0

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@ project(
   # Note that the git commit hash cannot be added dynamically here (it is added
   # in the dynamically generated and installed `scipy/version.py` though - see
   # tools/version_utils.py
-  version: '1.9.0.dev0',
+  version: '1.10.0.dev0',
   license: 'BSD-3',
   meson_version: '>= 0.60',
   default_options: [

--- a/tools/version_utils.py
+++ b/tools/version_utils.py
@@ -4,7 +4,7 @@ import argparse
 
 
 MAJOR = 1
-MINOR = 9
+MINOR = 10
 MICRO = 0
 ISRELEASED = False
 IS_RELEASE_BRANCH = False


### PR DESCRIPTION
* don't merge until the `1.9.0` release notes have been
finalized + merged & the `maintenance/1.9.x` branch
has been pushed

* this PR is a bit different than in the past because
of the build system modernizations (for what I did
last time see: gh-15168)

* bump version number in `tools/version_utils.py` (used
to be in `setup.py`) and in the new `meson.build`

* `pavement.py` has NOT been updated this time, since it
has been purged from all release docs as far as I can tell
(and so have references to `paver` it seems)

* early draft of `1.10.0` release notes infra (usual procedure
here I think)