### PR TITLE
DEP: Execute deprecation of scipy.linalg.blas.{clapack, flapack}

### DIFF
--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -820,10 +820,6 @@ except ImportError:
     HAS_ILP64 = False
     _flapack_64 = None
 
-# Backward compatibility
-from scipy._lib._util import DeprecatedImport as _DeprecatedImport
-clapack = _DeprecatedImport("scipy.linalg.blas.clapack", "scipy.linalg.lapack")
-flapack = _DeprecatedImport("scipy.linalg.blas.flapack", "scipy.linalg.lapack")
 
 # Expose all functions (only flapack --- clapack is an implementation detail)
 empty_module = None


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #16251
#### What does this implement/fix?
<!--Please explain your changes.-->
Removes deprecated import that were added as a backwards compatibility shim in #406. `cblas` and `fblas` were already removed in #4347 so think it should be fine to remove `clapack` and `flapack` as they have been deprecated for over 9 years!
#### Additional information
<!--Any additional information you think is important.-->
Note: [DeprecatedImport](https://github.com/scipy/scipy/blob/main/scipy/_lib/_util.py#L173-L204) is now longer used at all in SciPy so could potentially be removed.