### PR TITLE
MAINT: revert addition of multivariate_beta

### DIFF
--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -160,6 +160,7 @@ Multivariate distributions
 
    multivariate_normal    -- Multivariate normal distribution
    matrix_normal          -- Matrix normal distribution
+   dirichlet              -- Dirichlet
    wishart                -- Wishart
    invwishart             -- Inverse Wishart
    multinomial            -- Multinomial distribution

--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -160,7 +160,6 @@ Multivariate distributions
 
    multivariate_normal    -- Multivariate normal distribution
    matrix_normal          -- Matrix normal distribution
-   multivariate_beta      -- Multivariate beta distribution (Dirichlet)
    wishart                -- Wishart
    invwishart             -- Inverse Wishart
    multinomial            -- Multinomial distribution

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -17,7 +17,6 @@ from . import _mvn
 
 __all__ = ['multivariate_normal',
            'matrix_normal',
-           'multivariate_beta',
            'dirichlet',
            'wishart',
            'invwishart',
@@ -1294,18 +1293,8 @@ def _lnB(alpha):
     return np.sum(gammaln(alpha)) - gammaln(np.sum(alpha))
 
 
-_dirichlet_depr_message = (
-"""  # noqa
-`dirichlet` is deprecated due to an interface inconsistency: compared to
-other distributions, methods `pdf` and `logpdf` expect the transpose of the
-input `x`. Please use `multivariate_beta`, which corrects this inconsistency.
-In SciPy 1.11.0, this deprecation warning will be removed and `dirichlet` will
-become an alias for `multivariate_beta`.
-""")
-
-
 class dirichlet_gen(multi_rv_generic):
-    r"""A Dirichlet random variable (deprecated, use `multivariate_beta` instead).
+    r"""A Dirichlet random variable.
 
     The ``alpha`` keyword specifies the concentration parameters of the
     distribution.
@@ -1331,10 +1320,6 @@ class dirichlet_gen(multi_rv_generic):
     ----------
     %(_dirichlet_doc_default_callparams)s
     %(_doc_random_state)s
-
-    See Also
-    --------
-    multivariate_beta
 
     Notes
     -----
@@ -1368,8 +1353,6 @@ class dirichlet_gen(multi_rv_generic):
     Note that the `dirichlet` interface is somewhat inconsistent.
     The array returned by the rvs function is transposed
     with respect to the format expected by the pdf and logpdf.
-    For a consistent interface to the same distribution, use
-    `multivariate_beta`.
 
     Examples
     --------
@@ -1419,8 +1402,6 @@ class dirichlet_gen(multi_rv_generic):
         super().__init__(seed)
         self.__doc__ = doccer.docformat(self.__doc__, dirichlet_docdict_params)
 
-    @np.deprecate(old_name="dirichlet", new_name="multivariate_beta",
-                  message=_dirichlet_depr_message)
     def __call__(self, alpha, seed=None):
         return dirichlet_frozen(alpha, seed=seed)
 
@@ -1429,7 +1410,7 @@ class dirichlet_gen(multi_rv_generic):
         return _dirichlet_check_input(alpha, x)
 
     def _logpdf(self, x, alpha):
-        """Log of the multivariate beta (Dirichlet) PDF.
+        """Log of the Dirichlet PDF.
 
         Parameters
         ----------
@@ -1448,7 +1429,7 @@ class dirichlet_gen(multi_rv_generic):
         return - lnB + np.sum((xlogy(alpha - 1, x.T)).T, 0)
 
     def logpdf(self, x, alpha):
-        """Log of the multivariate beta (Dirichlet) PDF.
+        """Log of the Dirichlet PDF.
 
         Parameters
         ----------
@@ -1469,7 +1450,7 @@ class dirichlet_gen(multi_rv_generic):
         return _squeeze_output(out)
 
     def pdf(self, x, alpha):
-        """The multivariate beta (Dirichlet) probability density function.
+        """The Dirichlet probability density function.
 
         Parameters
         ----------
@@ -1490,7 +1471,7 @@ class dirichlet_gen(multi_rv_generic):
         return _squeeze_output(out)
 
     def mean(self, alpha):
-        """Mean of the multivariate beta (Dirichlet) distribution.
+        """Mean of the Dirichlet distribution.
 
         Parameters
         ----------
@@ -1499,7 +1480,7 @@ class dirichlet_gen(multi_rv_generic):
         Returns
         -------
         mu : ndarray or scalar
-            Mean of the multivariate beta (Dirichlet) distribution.
+            Mean of the Dirichlet distribution.
 
         """
         alpha = _dirichlet_check_parameters(alpha)
@@ -1508,7 +1489,7 @@ class dirichlet_gen(multi_rv_generic):
         return _squeeze_output(out)
 
     def var(self, alpha):
-        """Variance of the multivariate beta (Dirichlet) distribution.
+        """Variance of the Dirichlet distribution.
 
         Parameters
         ----------
@@ -1529,7 +1510,7 @@ class dirichlet_gen(multi_rv_generic):
 
     def entropy(self, alpha):
         """
-        Differential entropy of the multivariate beta (Dirichlet) distribution.
+        Differential entropy of the Dirichlet distribution.
 
         Parameters
         ----------
@@ -1538,7 +1519,7 @@ class dirichlet_gen(multi_rv_generic):
         Returns
         -------
         h : scalar
-            Entropy of the multivariate beta (Dirichlet) distribution
+            Entropy of the Dirichlet distribution
 
         """
 
@@ -1554,7 +1535,7 @@ class dirichlet_gen(multi_rv_generic):
 
     def rvs(self, alpha, size=1, random_state=None):
         """
-        Draw random samples from a multivariate beta (Dirichlet) distribution.
+        Draw random samples from a Dirichlet distribution.
 
         Parameters
         ----------
@@ -1576,15 +1557,6 @@ class dirichlet_gen(multi_rv_generic):
 
 
 dirichlet = dirichlet_gen()
-
-
-# deprecate each public method of `dirichlet` but not `multivariate_beta`
-_dirichlet_method_names = ["entropy", "logpdf", "mean", "pdf",
-                           "rvs", "var"]
-for m in _dirichlet_method_names:
-    wrapper = np.deprecate(getattr(dirichlet, m), f"dirichlet.{m}",
-                           f"multivariate_beta.{m}", _dirichlet_depr_message)
-    setattr(dirichlet, m, wrapper)
 
 
 class dirichlet_frozen(multi_rv_frozen):
@@ -1609,134 +1581,6 @@ class dirichlet_frozen(multi_rv_frozen):
 
     def rvs(self, size=1, random_state=None):
         return self._dist.rvs(self.alpha, size, random_state)
-
-
-class multivariate_beta_gen(dirichlet_gen):
-    r"""A multivariate beta (Dirichlet) random variable.
-
-    The ``alpha`` keyword specifies the concentration parameters of the
-    distribution.
-
-    .. versionadded:: 1.9.0
-
-    Methods
-    -------
-    pdf(x, alpha)
-        Probability density function.
-    logpdf(x, alpha)
-        Log of the probability density function.
-    rvs(alpha, size=1, random_state=None)
-        Draw random samples from a multivariate beta distribution.
-    mean(alpha)
-        The mean of the multivariate beta distribution
-    var(alpha)
-        The variance of the multivariate beta distribution
-    entropy(alpha)
-        Compute the differential entropy of the multivariate beta distribution.
-
-    Parameters
-    ----------
-    %(_dirichlet_doc_default_callparams)s
-    %(_doc_random_state)s
-
-    Notes
-    -----
-    Each :math:`\alpha` entry must be positive. The distribution has only
-    support on the simplex defined by
-
-    .. math::
-        \sum_{i=1}^{K} x_i = 1
-
-    where :math:`0 < x_i < 1`.
-
-    If the quantiles don't lie within the simplex, a ``ValueError`` is raised.
-
-    The probability density function for `multivariate_beta` is
-
-    .. math::
-
-        f(x) = \frac{1}{\mathrm{B}(\boldsymbol\alpha)}
-               \prod_{i=1}^K x_i^{\alpha_i - 1}
-
-    where
-
-    .. math::
-
-        \mathrm{B}(\boldsymbol\alpha) = \frac{\prod_{i=1}^K \Gamma(\alpha_i)}
-                                     {\Gamma\bigl(\sum_{i=1}^K \alpha_i\bigr)}
-
-    and :math:`\boldsymbol\alpha=(\alpha_1,\ldots,\alpha_K)`, the
-    concentration parameters and :math:`K` is the dimension of the space
-    where :math:`x` takes values.
-
-    Examples
-    --------
-    >>> from scipy.stats import multivariate_beta
-
-    Generate a multivariate_beta random variable
-
-    >>> quantiles = np.array([0.2, 0.2, 0.6])  # specify quantiles
-    >>> alpha = np.array([0.4, 5, 15])  # specify concentration parameters
-    >>> multivariate_beta.pdf(quantiles, alpha)
-    0.2843831684937255
-
-    The same PDF but following a log scale
-
-    >>> multivariate_beta.logpdf(quantiles, alpha)
-    -1.2574327653159187
-
-    Once we specify the multivariate beta distribution
-    we can then calculate quantities of interest
-
-    >>> multivariate_beta.mean(alpha)  # get the mean of the distribution
-    array([0.01960784, 0.24509804, 0.73529412])
-    >>> multivariate_beta.var(alpha) # get variance
-    array([0.00089829, 0.00864603, 0.00909517])
-    >>> multivariate_beta.entropy(alpha)  # calculate the differential entropy
-    -4.3280162474082715
-
-    We can also return random samples from the distribution
-
-    >>> multivariate_beta.rvs(alpha, size=1, random_state=1)
-    array([[0.00766178, 0.24670518, 0.74563305]])
-    >>> multivariate_beta.rvs(alpha, size=2, random_state=2)
-    array([[0.01639427, 0.1292273 , 0.85437844],
-           [0.00156917, 0.19033695, 0.80809388]])
-
-    Alternatively, the object may be called (as a function) to fix
-    concentration parameters, returning a "frozen" multivariate beta
-    random variable:
-
-    >>> rv = multivariate_beta(alpha)
-    >>> # Frozen object with the same methods but holding the given
-    >>> # concentration parameters fixed.
-
-    """
-    def __call__(self, alpha, seed=None):
-        return multivariate_beta_frozen(alpha, seed=seed)
-
-    def _check_input(self, alpha, x):
-        x = np.moveaxis(x, -1, 0)
-        return _dirichlet_check_input(alpha, x)
-
-
-class multivariate_beta_frozen(dirichlet_frozen):
-    def __init__(self, alpha, seed=None):
-        self.alpha = _dirichlet_check_parameters(alpha)
-        self._dist = multivariate_beta_gen(seed)
-
-
-multivariate_beta = multivariate_beta_gen()
-
-
-# Set frozen generator docstrings from corresponding docstrings in
-# multivariate_normal_gen and fill in default strings in class docstrings
-for name in ['logpdf', 'pdf', 'rvs', 'mean', 'var', 'entropy']:
-    method = dirichlet_gen.__dict__[name]
-    method_frozen = dirichlet_frozen.__dict__[name]
-    method_frozen.__doc__ = doccer.docformat(
-        method.__doc__, dirichlet_docdict_noparams)
-    method.__doc__ = doccer.docformat(method.__doc__, dirichlet_docdict_params)
 
 
 _wishart_doc_default_callparams = """\

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -1230,6 +1230,7 @@ def _dirichlet_check_parameters(alpha):
 
 
 def _dirichlet_check_input(alpha, x):
+    x = np.asarray(x)
 
     if x.shape[0] + 1 != alpha.shape[0] and x.shape[0] != alpha.shape[0]:
         raise ValueError("Vector 'x' must have either the same number "
@@ -1405,12 +1406,8 @@ class dirichlet_gen(multi_rv_generic):
     def __call__(self, alpha, seed=None):
         return dirichlet_frozen(alpha, seed=seed)
 
-    def _check_input(self, alpha, x):
-        x = np.asarray(x)
-        return _dirichlet_check_input(alpha, x)
-
     def _logpdf(self, x, alpha):
-        """Log of the Dirichlet PDF.
+        """Log of the Dirichlet probability density function.
 
         Parameters
         ----------
@@ -1429,7 +1426,7 @@ class dirichlet_gen(multi_rv_generic):
         return - lnB + np.sum((xlogy(alpha - 1, x.T)).T, 0)
 
     def logpdf(self, x, alpha):
-        """Log of the Dirichlet PDF.
+        """Log of the Dirichlet probability density function.
 
         Parameters
         ----------
@@ -1444,7 +1441,7 @@ class dirichlet_gen(multi_rv_generic):
 
         """
         alpha = _dirichlet_check_parameters(alpha)
-        x = self._check_input(alpha, x)
+        x = _dirichlet_check_input(alpha, x)
 
         out = self._logpdf(x, alpha)
         return _squeeze_output(out)
@@ -1465,7 +1462,7 @@ class dirichlet_gen(multi_rv_generic):
 
         """
         alpha = _dirichlet_check_parameters(alpha)
-        x = self._check_input(alpha, x)
+        x = _dirichlet_check_input(alpha, x)
 
         out = np.exp(self._logpdf(x, alpha))
         return _squeeze_output(out)
@@ -1581,6 +1578,16 @@ class dirichlet_frozen(multi_rv_frozen):
 
     def rvs(self, size=1, random_state=None):
         return self._dist.rvs(self.alpha, size, random_state)
+
+
+# Set frozen generator docstrings from corresponding docstrings in
+# multivariate_normal_gen and fill in default strings in class docstrings
+for name in ['logpdf', 'pdf', 'rvs', 'mean', 'var', 'entropy']:
+    method = dirichlet_gen.__dict__[name]
+    method_frozen = dirichlet_frozen.__dict__[name]
+    method_frozen.__doc__ = doccer.docformat(
+        method.__doc__, dirichlet_docdict_noparams)
+    method.__doc__ = doccer.docformat(method.__doc__, dirichlet_docdict_params)
 
 
 _wishart_doc_default_callparams = """\

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -25,8 +25,7 @@ from scipy.stats import (multivariate_normal, multivariate_hypergeom,
                          random_correlation, unitary_group, dirichlet,
                          beta, wishart, multinomial, invwishart, chi2,
                          invgamma, norm, uniform, ks_2samp, kstest, binom,
-                         hypergeom, multivariate_t, cauchy, normaltest,
-                         multivariate_beta)
+                         hypergeom, multivariate_t, cauchy, normaltest)
 
 from scipy.integrate import romb
 from scipy.special import multigammaln
@@ -639,7 +638,7 @@ class TestMatrixNormal:
         assert_allclose(sample_rowcov, U, atol=0.1)
 
 
-class DirichletTest:
+class TestDirichlet:
 
     def test_frozen_dirichlet(self):
         np.random.seed(2846)
@@ -647,116 +646,112 @@ class DirichletTest:
         n = np.random.randint(1, 32)
         alpha = np.random.uniform(10e-10, 100, n)
 
-        d = self.dist(alpha)
+        d = dirichlet(alpha)
 
-        assert_equal(d.var(), self.dist.var(alpha))
-        assert_equal(d.mean(), self.dist.mean(alpha))
-        assert_equal(d.entropy(), self.dist.entropy(alpha))
+        assert_equal(d.var(), dirichlet.var(alpha))
+        assert_equal(d.mean(), dirichlet.mean(alpha))
+        assert_equal(d.entropy(), dirichlet.entropy(alpha))
         num_tests = 10
         for i in range(num_tests):
             x = np.random.uniform(10e-10, 100, n)
             x /= np.sum(x)
-            assert_equal(d.pdf(x[:-1]), self.dist.pdf(x[:-1], alpha))
-            assert_equal(d.logpdf(x[:-1]), self.dist.logpdf(x[:-1], alpha))
+            assert_equal(d.pdf(x[:-1]), dirichlet.pdf(x[:-1], alpha))
+            assert_equal(d.logpdf(x[:-1]), dirichlet.logpdf(x[:-1], alpha))
 
     def test_numpy_rvs_shape_compatibility(self):
         np.random.seed(2846)
         alpha = np.array([1.0, 2.0, 3.0])
         x = np.random.dirichlet(alpha, size=7)
         assert_equal(x.shape, (7, 3))
-        if self.dist == multivariate_beta:
-            x = x.T
-        assert_raises(ValueError, self.dist.pdf, x, alpha)
-        assert_raises(ValueError, self.dist.logpdf, x, alpha)
-        self.dist.pdf(x.T, alpha)
-        self.dist.pdf(x.T[:-1], alpha)
-        self.dist.logpdf(x.T, alpha)
-        self.dist.logpdf(x.T[:-1], alpha)
+        assert_raises(ValueError, dirichlet.pdf, x, alpha)
+        assert_raises(ValueError, dirichlet.logpdf, x, alpha)
+        dirichlet.pdf(x.T, alpha)
+        dirichlet.pdf(x.T[:-1], alpha)
+        dirichlet.logpdf(x.T, alpha)
+        dirichlet.logpdf(x.T[:-1], alpha)
 
     def test_alpha_with_zeros(self):
         np.random.seed(2846)
         alpha = [1.0, 0.0, 3.0]
         # don't pass invalid alpha to np.random.dirichlet
         x = np.random.dirichlet(np.maximum(1e-9, alpha), size=7).T
-        assert_raises(ValueError, self.dist.pdf, x, alpha)
-        assert_raises(ValueError, self.dist.logpdf, x, alpha)
+        assert_raises(ValueError, dirichlet.pdf, x, alpha)
+        assert_raises(ValueError, dirichlet.logpdf, x, alpha)
 
     def test_alpha_with_negative_entries(self):
         np.random.seed(2846)
         alpha = [1.0, -2.0, 3.0]
         # don't pass invalid alpha to np.random.dirichlet
         x = np.random.dirichlet(np.maximum(1e-9, alpha), size=7).T
-        assert_raises(ValueError, self.dist.pdf, x, alpha)
-        assert_raises(ValueError, self.dist.logpdf, x, alpha)
+        assert_raises(ValueError, dirichlet.pdf, x, alpha)
+        assert_raises(ValueError, dirichlet.logpdf, x, alpha)
 
     def test_data_with_zeros(self):
         alpha = np.array([1.0, 2.0, 3.0, 4.0])
         x = np.array([0.1, 0.0, 0.2, 0.7])
-        self.dist.pdf(x, alpha)
-        self.dist.logpdf(x, alpha)
+        dirichlet.pdf(x, alpha)
+        dirichlet.logpdf(x, alpha)
         alpha = np.array([1.0, 1.0, 1.0, 1.0])
-        assert_almost_equal(self.dist.pdf(x, alpha), 6)
-        assert_almost_equal(self.dist.logpdf(x, alpha), np.log(6))
+        assert_almost_equal(dirichlet.pdf(x, alpha), 6)
+        assert_almost_equal(dirichlet.logpdf(x, alpha), np.log(6))
 
     def test_data_with_zeros_and_small_alpha(self):
         alpha = np.array([1.0, 0.5, 3.0, 4.0])
         x = np.array([0.1, 0.0, 0.2, 0.7])
-        assert_raises(ValueError, self.dist.pdf, x, alpha)
-        assert_raises(ValueError, self.dist.logpdf, x, alpha)
+        assert_raises(ValueError, dirichlet.pdf, x, alpha)
+        assert_raises(ValueError, dirichlet.logpdf, x, alpha)
 
     def test_data_with_negative_entries(self):
         alpha = np.array([1.0, 2.0, 3.0, 4.0])
         x = np.array([0.1, -0.1, 0.3, 0.7])
-        assert_raises(ValueError, self.dist.pdf, x, alpha)
-        assert_raises(ValueError, self.dist.logpdf, x, alpha)
+        assert_raises(ValueError, dirichlet.pdf, x, alpha)
+        assert_raises(ValueError, dirichlet.logpdf, x, alpha)
 
     def test_data_with_too_large_entries(self):
         alpha = np.array([1.0, 2.0, 3.0, 4.0])
         x = np.array([0.1, 1.1, 0.3, 0.7])
-        assert_raises(ValueError, self.dist.pdf, x, alpha)
-        assert_raises(ValueError, self.dist.logpdf, x, alpha)
+        assert_raises(ValueError, dirichlet.pdf, x, alpha)
+        assert_raises(ValueError, dirichlet.logpdf, x, alpha)
 
     def test_data_too_deep_c(self):
         alpha = np.array([1.0, 2.0, 3.0])
         x = np.full((2, 7, 7), 1 / 14)
-        assert_raises(ValueError, self.dist.pdf, x, alpha)
-        assert_raises(ValueError, self.dist.logpdf, x, alpha)
+        assert_raises(ValueError, dirichlet.pdf, x, alpha)
+        assert_raises(ValueError, dirichlet.logpdf, x, alpha)
 
     def test_alpha_too_deep(self):
         alpha = np.array([[1.0, 2.0], [3.0, 4.0]])
         x = np.full((2, 2, 7), 1 / 4)
-        assert_raises(ValueError, self.dist.pdf, x, alpha)
-        assert_raises(ValueError, self.dist.logpdf, x, alpha)
+        assert_raises(ValueError, dirichlet.pdf, x, alpha)
+        assert_raises(ValueError, dirichlet.logpdf, x, alpha)
 
     def test_alpha_correct_depth(self):
         alpha = np.array([1.0, 2.0, 3.0])
         x = np.full((3, 7), 1 / 3)
-        if self.dist == multivariate_beta:
-            x = x.T
-        self.dist.pdf(x, alpha)
-        self.dist.logpdf(x, alpha)
+        dirichlet.pdf(x, alpha)
+        dirichlet.logpdf(x, alpha)
 
     def test_non_simplex_data(self):
         alpha = np.array([1.0, 2.0, 3.0])
         x = np.full((3, 7), 1 / 2)
-        assert_raises(ValueError, self.dist.pdf, x, alpha)
-        assert_raises(ValueError, self.dist.logpdf, x, alpha)
+        assert_raises(ValueError, dirichlet.pdf, x, alpha)
+        assert_raises(ValueError, dirichlet.logpdf, x, alpha)
 
     def test_data_vector_too_short(self):
         alpha = np.array([1.0, 2.0, 3.0, 4.0])
         x = np.full((2, 7), 1 / 2)
-        assert_raises(ValueError, self.dist.pdf, x, alpha)
-        assert_raises(ValueError, self.dist.logpdf, x, alpha)
+        assert_raises(ValueError, dirichlet.pdf, x, alpha)
+        assert_raises(ValueError, dirichlet.logpdf, x, alpha)
 
     def test_data_vector_too_long(self):
         alpha = np.array([1.0, 2.0, 3.0, 4.0])
         x = np.full((5, 7), 1 / 5)
-        assert_raises(ValueError, self.dist.pdf, x, alpha)
-        assert_raises(ValueError, self.dist.logpdf, x, alpha)
+        assert_raises(ValueError, dirichlet.pdf, x, alpha)
+        assert_raises(ValueError, dirichlet.logpdf, x, alpha)
 
     def test_mean_and_var(self):
         alpha = np.array([1., 0.8, 0.2])
-        d = self.dist(alpha)
+        d = dirichlet(alpha)
 
         expected_var = [1. / 12., 0.08, 0.03]
         expected_mean = [0.5, 0.4, 0.1]
@@ -766,7 +761,7 @@ class DirichletTest:
 
     def test_scalar_values(self):
         alpha = np.array([0.2])
-        d = self.dist(alpha)
+        d = dirichlet(alpha)
 
         # For alpha of length 1, mean and var should be scalar instead of array
         assert_equal(d.mean().ndim, 0)
@@ -783,7 +778,7 @@ class DirichletTest:
         n = np.random.randint(1, 32)
         alpha = np.random.uniform(10e-10, 100, n)
 
-        d = self.dist(alpha)
+        d = dirichlet(alpha)
         num_tests = 10
         for i in range(num_tests):
             x = np.random.uniform(10e-10, 100, n)
@@ -796,7 +791,7 @@ class DirichletTest:
 
         n = np.random.randint(1, 32)
         alpha = np.random.uniform(10e-10, 100, n)
-        d = self.dist(alpha)
+        d = dirichlet(alpha)
 
         num_tests = 10
         num_multiple = 5
@@ -809,10 +804,7 @@ class DirichletTest:
                     xm = np.vstack((xm, x))
                 else:
                     xm = x
-            if self.dist == multivariate_beta:
-                rm = d.pdf(xm)
-            else:
-                rm = d.pdf(xm.T)
+            rm = d.pdf(xm.T)
             rs = None
             for xs in xm:
                 r = d.pdf(xs)
@@ -826,52 +818,17 @@ class DirichletTest:
         np.random.seed(2846)
 
         alpha = np.random.uniform(10e-10, 100, 2)
-        d = self.dist(alpha)
+        d = dirichlet(alpha)
         b = beta(alpha[0], alpha[1])
 
         num_tests = 10
         for i in range(num_tests):
             x = np.random.uniform(10e-10, 100, 2)
             x /= np.sum(x)
-            if self.dist == multivariate_beta:
-                assert_almost_equal(b.pdf(x), d.pdf(x[:, np.newaxis]))
-            else:
-                assert_almost_equal(b.pdf(x), d.pdf([x]))
+            assert_almost_equal(b.pdf(x), d.pdf([x]))
 
         assert_almost_equal(b.mean(), d.mean()[0])
         assert_almost_equal(b.var(), d.var()[0])
-
-
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
-class TestDirichlet(DirichletTest):
-    dist = dirichlet
-
-
-def test_dirichlet_deprecation():
-    with pytest.deprecated_call():
-        dirichlet.rvs([1, 2, 3])
-
-    with pytest.deprecated_call():
-        dirichlet([1, 2, 3])
-
-
-class TestMultivariateBeta(DirichletTest):
-    dist = multivariate_beta
-
-    def test_accepts_random_variates(self):
-        # dirichlet.pdf does not accept output of dirichlet.rvs
-        # multivariate_beta does; see gh-6006
-        alpha = [1, 3, 4]
-        d = self.dist(alpha)
-
-        rvs = d.rvs()
-        pdf = d.pdf(rvs)  # no error
-        assert pdf == self.dist.pdf(rvs, alpha)
-
-        rvs2 = d.rvs(size=10)
-        pdf2 = d.pdf(rvs2)
-        for rvs_i, pdf_i in zip(rvs2, pdf2):
-            assert pdf_i == self.dist.pdf(rvs_i, alpha)
 
 
 def test_multivariate_normal_dimensions_mismatch():
@@ -2220,7 +2177,7 @@ def test_random_state_property():
     scale[1, 0] = 0.5
     dists = [
         [multivariate_normal, ()],
-        [multivariate_beta, (np.array([1.]), )],
+        [dirichlet, (np.array([1.]), )],
         [wishart, (10, scale)],
         [invwishart, (10, scale)],
         [multinomial, (5, [0.5, 0.4, 0.1])],


### PR DESCRIPTION
#### Reference issue

Reverts gh-16042

#### What does this implement/fix?

There are multiple issues with multivariate distributions which need to be addressed before adding new distributions. So, this PR reverts addition of `multivariate_beta` (which fixed only one of the `dirichlet` issues). It would be good to fix all the issues together before adding distributions we'd need to fix again.

#### Additional information

@mdhaber
