### PR TITLE
MAINT: add a more informative error message for broken installs

### DIFF
--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -145,7 +145,17 @@ else:
                       UserWarning)
     del _pep440
 
-    from scipy._lib._ccallback import LowLevelCallable
+    # This is the first import of an extension module within SciPy. If there's
+    # a general issue with the install, such that extension modules are missing
+    # or cannot be imported, this is where we'll get a failure - so give an
+    # informative error message.
+    try:
+        from scipy._lib._ccallback import LowLevelCallable
+    except ImportError as e:
+        msg = "The `scipy` install you are using seems to be broken, " + \
+              "(extension modules cannot be imported), " + \
+              "please try reinstalling."
+        raise ImportError(msg) from e
 
     from scipy._lib._testutils import PytestTester
     test = PytestTester(__name__)


### PR DESCRIPTION
The line:
```
ImportError: cannot import name '_ccallback_c' from 'scipy._lib'
```
can be found in a lot of bug reports floating around on Stack Overflow and in other places. It has nothing to do with `_ccallback_c` in all cases I looked at, it's always a generic problem with extension modules. The solution is typically to reinstall, and the problem goes away. So say that in the `ImportError` message.

Also seen in gh-16300 just now.