### PR TITLE
DEP: add deprecation warning for binom_test

### DIFF
--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -2652,14 +2652,11 @@ def levene(*samples, center='median', proportiontocut=0.05):
 def binom_test(x, n=None, p=0.5, alternative='two-sided'):
     """Perform a test that the probability of success is p.
 
-    Note: `binom_test` is deprecated; it is recommended that `binomtest`
-    be used instead.
-
     This is an exact, two-sided test of the null hypothesis
     that the probability of success in a Bernoulli experiment
     is `p`.
 
-    .. deprecated:: 1.12.0
+    .. deprecated:: 1.10.0
         'binom_test' is deprecated in favour of 'binomtest' and will
         be removed in Scipy 1.12.0.
 

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -2647,7 +2647,7 @@ def levene(*samples, center='median', proportiontocut=0.05):
 
 
 @_deprecated("'binom_test' is deprecated in favour of"
-             "'binomtest' and will be removed in Scipy 1.11.0.")
+             " 'binomtest' and will be removed in Scipy 1.11.0.")
 def binom_test(x, n=None, p=0.5, alternative='two-sided'):
     """Perform a test that the probability of success is p.
 

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -2658,6 +2658,10 @@ def binom_test(x, n=None, p=0.5, alternative='two-sided'):
     that the probability of success in a Bernoulli experiment
     is `p`.
 
+    .. deprecated:: 0.19.0
+        'binom_test' is deprecated in favour of 'binomtest' and will
+        be removed in Scipy 1.11.0.
+
     Parameters
     ----------
     x : int or array_like

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -2647,7 +2647,8 @@ def levene(*samples, center='median', proportiontocut=0.05):
 
 
 @_deprecated("'binom_test' is deprecated in favour of"
-             " 'binomtest' and will be removed in Scipy 1.11.0.")
+             " 'binomtest' from version 1.7.0 and will"
+             " be removed in Scipy 1.12.0.")
 def binom_test(x, n=None, p=0.5, alternative='two-sided'):
     """Perform a test that the probability of success is p.
 
@@ -2658,9 +2659,9 @@ def binom_test(x, n=None, p=0.5, alternative='two-sided'):
     that the probability of success in a Bernoulli experiment
     is `p`.
 
-    .. deprecated:: 0.19.0
+    .. deprecated:: 1.12.0
         'binom_test' is deprecated in favour of 'binomtest' and will
-        be removed in Scipy 1.11.0.
+        be removed in Scipy 1.12.0.
 
     Parameters
     ----------

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -2694,6 +2694,10 @@ def binom_test(x, n=None, p=0.5, alternative='two-sided'):
     because the returned p-value is greater than the critical value of 5%.
 
     """
+    msg = ("'binom_test' is deprecated in favour of"
+           "'binomtest' and will be removed in Scipy 1.11.0.")
+    warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
+
     x = atleast_1d(x).astype(np.int_)
     if len(x) == 2:
         n = x[1] + x[0]

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -22,6 +22,7 @@ from . import distributions
 from ._distn_infrastructure import rv_generic
 from ._hypotests import _get_wilcoxon_distr
 from ._axis_nan_policy import _axis_nan_policy_factory
+from .._lib.deprecation import _deprecated
 
 
 __all__ = ['mvsdist',
@@ -2645,6 +2646,8 @@ def levene(*samples, center='median', proportiontocut=0.05):
     return LeveneResult(W, pval)
 
 
+@_deprecated("'binom_test' is deprecated in favour of"
+             "'binomtest' and will be removed in Scipy 1.11.0.")
 def binom_test(x, n=None, p=0.5, alternative='two-sided'):
     """Perform a test that the probability of success is p.
 
@@ -2694,10 +2697,6 @@ def binom_test(x, n=None, p=0.5, alternative='two-sided'):
     because the returned p-value is greater than the critical value of 5%.
 
     """
-    msg = ("'binom_test' is deprecated in favour of"
-           "'binomtest' and will be removed in Scipy 1.11.0.")
-    warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
-
     x = atleast_1d(x).astype(np.int_)
     if len(x) == 2:
         n = x[1] + x[0]

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -728,14 +728,27 @@ class TestLevene:
         assert_raises(ValueError, stats.levene, g1, x)
 
 
-class TestBinomP:
-    """Tests for deprecated stats.binom_test."""
-
+class TestBinomTestP:
+    """
+    Tests for stats.binomtest as a replacement for deprecated stats.binom_test.
+    """
     @staticmethod
     def binom_test_func(x, n=None, p=0.5, alternative='two-sided'):
-        with np.testing.suppress_warnings() as sup:
-            sup.filter(DeprecationWarning, "'binom_test' is deprecated")
-            return stats.binom_test(x, n, p=p, alternative=alternative)
+        # This processing of x and n is copied from from binom_test.
+        x = np.atleast_1d(x).astype(np.int_)
+        if len(x) == 2:
+            n = x[1] + x[0]
+            x = x[0]
+        elif len(x) == 1:
+            x = x[0]
+            if n is None or n < x:
+                raise ValueError("n must be >= x")
+            n = np.int_(n)
+        else:
+            raise ValueError("Incorrect length for x.")
+
+        result = stats.binomtest(x, n, p=p, alternative=alternative)
+        return result.pvalue
 
     def test_data(self):
         pval = self.binom_test_func(100, 250)
@@ -774,29 +787,6 @@ class TestBinomP:
     def test_boost_overflow_raises(self):
         # Boost.Math error policy should raise exceptions in Python
         assert_raises(OverflowError, self.binom_test_func, 5.0, 6, p=sys.float_info.min)
-
-
-class TestBinomTestP(TestBinomP):
-    """
-    Tests for stats.binomtest as a replacement for stats.binom_test.
-    """
-    @staticmethod
-    def binom_test_func(x, n=None, p=0.5, alternative='two-sided'):
-        # This processing of x and n is copied from from binom_test.
-        x = np.atleast_1d(x).astype(np.int_)
-        if len(x) == 2:
-            n = x[1] + x[0]
-            x = x[0]
-        elif len(x) == 1:
-            x = x[0]
-            if n is None or n < x:
-                raise ValueError("n must be >= x")
-            n = np.int_(n)
-        else:
-            raise ValueError("Incorrect length for x.")
-
-        result = stats.binomtest(x, n, p=p, alternative=alternative)
-        return result.pvalue
 
 
 class TestBinomTest:

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -728,10 +728,27 @@ class TestLevene:
         assert_raises(ValueError, stats.levene, g1, x)
 
 
-class TestBinomP:
-    """Tests for stats.binom_test."""
+class TestBinomTestP:
+    """
+    Tests for stats.binomtest
+    """
+    @staticmethod
+    def binom_test_func(x, n=None, p=0.5, alternative='two-sided'):
+        # This processing of x and n is copied from deprecated stats.binom_test
+        x = np.atleast_1d(x).astype(np.int_)
+        if len(x) == 2:
+            n = x[1] + x[0]
+            x = x[0]
+        elif len(x) == 1:
+            x = x[0]
+            if n is None or n < x:
+                raise ValueError("n must be >= x")
+            n = np.int_(n)
+        else:
+            raise ValueError("Incorrect length for x.")
 
-    binom_test_func = staticmethod(stats.binom_test)
+        result = stats.binomtest(x, n, p=p, alternative=alternative)
+        return result.pvalue
 
     def test_data(self):
         pval = self.binom_test_func(100, 250)
@@ -770,29 +787,6 @@ class TestBinomP:
     def test_boost_overflow_raises(self):
         # Boost.Math error policy should raise exceptions in Python
         assert_raises(OverflowError, self.binom_test_func, 5.0, 6, p=sys.float_info.min)
-
-
-class TestBinomTestP(TestBinomP):
-    """
-    Tests for stats.binomtest as a replacement for stats.binom_test.
-    """
-    @staticmethod
-    def binom_test_func(x, n=None, p=0.5, alternative='two-sided'):
-        # This processing of x and n is copied from from binom_test.
-        x = np.atleast_1d(x).astype(np.int_)
-        if len(x) == 2:
-            n = x[1] + x[0]
-            x = x[0]
-        elif len(x) == 1:
-            x = x[0]
-            if n is None or n < x:
-                raise ValueError("n must be >= x")
-            n = np.int_(n)
-        else:
-            raise ValueError("Incorrect length for x.")
-
-        result = stats.binomtest(x, n, p=p, alternative=alternative)
-        return result.pvalue
 
 
 class TestBinomTest:

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -728,27 +728,14 @@ class TestLevene:
         assert_raises(ValueError, stats.levene, g1, x)
 
 
-class TestBinomTestP:
-    """
-    Tests for stats.binomtest
-    """
+class TestBinomP:
+    """Tests for deprecated stats.binom_test."""
+
     @staticmethod
     def binom_test_func(x, n=None, p=0.5, alternative='two-sided'):
-        # This processing of x and n is copied from deprecated stats.binom_test
-        x = np.atleast_1d(x).astype(np.int_)
-        if len(x) == 2:
-            n = x[1] + x[0]
-            x = x[0]
-        elif len(x) == 1:
-            x = x[0]
-            if n is None or n < x:
-                raise ValueError("n must be >= x")
-            n = np.int_(n)
-        else:
-            raise ValueError("Incorrect length for x.")
-
-        result = stats.binomtest(x, n, p=p, alternative=alternative)
-        return result.pvalue
+        with np.testing.suppress_warnings() as sup:
+            sup.filter(DeprecationWarning, "'binom_test' is deprecated")
+            return stats.binom_test(x, n, p=p, alternative=alternative)
 
     def test_data(self):
         pval = self.binom_test_func(100, 250)
@@ -787,6 +774,29 @@ class TestBinomTestP:
     def test_boost_overflow_raises(self):
         # Boost.Math error policy should raise exceptions in Python
         assert_raises(OverflowError, self.binom_test_func, 5.0, 6, p=sys.float_info.min)
+
+
+class TestBinomTestP(TestBinomP):
+    """
+    Tests for stats.binomtest as a replacement for stats.binom_test.
+    """
+    @staticmethod
+    def binom_test_func(x, n=None, p=0.5, alternative='two-sided'):
+        # This processing of x and n is copied from from binom_test.
+        x = np.atleast_1d(x).astype(np.int_)
+        if len(x) == 2:
+            n = x[1] + x[0]
+            x = x[0]
+        elif len(x) == 1:
+            x = x[0]
+            if n is None or n < x:
+                raise ValueError("n must be >= x")
+            n = np.int_(n)
+        else:
+            raise ValueError("Incorrect length for x.")
+
+        result = stats.binomtest(x, n, p=p, alternative=alternative)
+        return result.pvalue
 
 
 class TestBinomTest:

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -5954,7 +5954,7 @@ class TestGeometricStandardDeviation:
 
 def test_binom_test_deprecation():
     deprecation_msg = ("'binom_test' is deprecated in favour of"
-                       "'binomtest' and will be removed in Scipy 1.11.0.")
+                       " 'binomtest' and will be removed in Scipy 1.11.0.")
     with pytest.warns(DeprecationWarning, match=deprecation_msg):
         stats.binom_test([1, 1])
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -5952,6 +5952,13 @@ class TestGeometricStandardDeviation:
         assert_equal(gstd_actual.mask, mask)
 
 
+def test_binom_test_deprecation():
+    deprecation_msg = ("'binom_test' is deprecated in favour of"
+                       "'binomtest' and will be removed in Scipy 1.11.0.")
+    with pytest.warns(DeprecationWarning, match=deprecation_msg):
+        stats.binom_test([1, 1])
+
+
 def test_binomtest():
     # precision tests compared to R for ticket:986
     pp = np.concatenate((np.linspace(0.1, 0.2, 5),
@@ -5968,10 +5975,10 @@ def test_binomtest():
                2.6102587134694721e-006]
 
     for p, res in zip(pp, results):
-        assert_approx_equal(stats.binom_test(x, n, p), res,
+        assert_approx_equal(stats.binomtest(x, n, p).pvalue, res,
                             significant=12, err_msg='fail forp=%f' % p)
 
-    assert_approx_equal(stats.binom_test(50, 100, 0.1),
+    assert_approx_equal(stats.binomtest(50, 100, 0.1).pvalue,
                         5.8320387857343647e-024,
                         significant=12)
 
@@ -5997,14 +6004,14 @@ def test_binomtest2():
     ]
 
     for k in range(1, 11):
-        res1 = [stats.binom_test(v, k, 0.5) for v in range(k + 1)]
+        res1 = [stats.binomtest(v, k, 0.5).pvalue for v in range(k + 1)]
         assert_almost_equal(res1, res2[k-1], decimal=10)
 
 
 def test_binomtest3():
     # test added for issue #2384
     # test when x == n*p and neighbors
-    res3 = [stats.binom_test(v, v*k, 1./k)
+    res3 = [stats.binomtest(v, v*k, 1./k).pvalue
             for v in range(1, 11) for k in range(2, 11)]
     assert_equal(res3, np.ones(len(res3), int))
 
@@ -6086,9 +6093,9 @@ def test_binomtest3():
          0.736270323773157, 0.737718376096348
         ])
 
-    res4_p1 = [stats.binom_test(v+1, v*k, 1./k)
+    res4_p1 = [stats.binomtest(v+1, v*k, 1./k).pvalue
                for v in range(1, 11) for k in range(2, 11)]
-    res4_m1 = [stats.binom_test(v-1, v*k, 1./k)
+    res4_m1 = [stats.binomtest(v-1, v*k, 1./k).pvalue
                for v in range(1, 11) for k in range(2, 11)]
 
     assert_almost_equal(res4_p1, binom_testp1, decimal=13)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -5974,13 +5974,14 @@ def test_binomtest():
                0.12044570587262322, 0.88154763174802508, 0.027120993063129286,
                2.6102587134694721e-006]
 
-    for p, res in zip(pp, results):
-        assert_approx_equal(stats.binomtest(x, n, p).pvalue, res,
-                            significant=12, err_msg='fail forp=%f' % p)
-
-    assert_approx_equal(stats.binomtest(50, 100, 0.1).pvalue,
-                        5.8320387857343647e-024,
-                        significant=12)
+    with np.testing.suppress_warnings() as sup:
+        sup.filter(DeprecationWarning, "'binom_test' is deprecated")
+        for p, res in zip(pp, results):
+            assert_approx_equal(stats.binom_test(x, n, p), res,
+                                significant=12, err_msg='fail forp=%f' % p)
+            assert_approx_equal(stats.binom_test(50, 100, 0.1),
+                                5.8320387857343647e-024,
+                                significant=12)
 
 
 def test_binomtest2():
@@ -6002,18 +6003,21 @@ def test_binomtest2():
          1.000000000, 0.753906250, 0.343750000, 0.109375000, 0.021484375,
          0.001953125]
     ]
-
-    for k in range(1, 11):
-        res1 = [stats.binomtest(v, k, 0.5).pvalue for v in range(k + 1)]
-        assert_almost_equal(res1, res2[k-1], decimal=10)
+    with np.testing.suppress_warnings() as sup:
+        sup.filter(DeprecationWarning, "'binom_test' is deprecated")
+        for k in range(1, 11):
+            res1 = [stats.binom_test(v, k, 0.5) for v in range(k + 1)]
+            assert_almost_equal(res1, res2[k-1], decimal=10)
 
 
 def test_binomtest3():
-    # test added for issue #2384
-    # test when x == n*p and neighbors
-    res3 = [stats.binomtest(v, v*k, 1./k).pvalue
-            for v in range(1, 11) for k in range(2, 11)]
-    assert_equal(res3, np.ones(len(res3), int))
+    with np.testing.suppress_warnings() as sup:
+        sup.filter(DeprecationWarning, "'binom_test' is deprecated")
+        # test added for issue #2384
+        # test when x == n*p and neighbors
+        res3 = [stats.binom_test(v, v*k, 1./k)
+                for v in range(1, 11) for k in range(2, 11)]
+        assert_equal(res3, np.ones(len(res3), int))
 
     # > bt=c()
     # > for(i in as.single(1:10)) {
@@ -6092,14 +6096,15 @@ def test_binomtest3():
          0.7286603031173616, 0.7319999279787631, 0.7344267920995765,
          0.736270323773157, 0.737718376096348
         ])
+    with np.testing.suppress_warnings() as sup:
+        sup.filter(DeprecationWarning, "'binom_test' is deprecated")
+        res4_p1 = [stats.binom_test(v+1, v*k, 1./k)
+                   for v in range(1, 11) for k in range(2, 11)]
+        res4_m1 = [stats.binom_test(v-1, v*k, 1./k)
+                   for v in range(1, 11) for k in range(2, 11)]
 
-    res4_p1 = [stats.binomtest(v+1, v*k, 1./k).pvalue
-               for v in range(1, 11) for k in range(2, 11)]
-    res4_m1 = [stats.binomtest(v-1, v*k, 1./k).pvalue
-               for v in range(1, 11) for k in range(2, 11)]
-
-    assert_almost_equal(res4_p1, binom_testp1, decimal=13)
-    assert_almost_equal(res4_m1, binom_testm1, decimal=13)
+        assert_almost_equal(res4_p1, binom_testp1, decimal=13)
+        assert_almost_equal(res4_m1, binom_testm1, decimal=13)
 
 
 class TestTrim:

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -5958,9 +5958,10 @@ def test_binom_test_deprecation(alternative):
                        " 'binomtest' from version 1.7.0 and will"
                        " be removed in Scipy 1.12.0.")
     num = 10
-    X = np.random.randint(10, 100, (num,))
-    N = X + np.random.randint(0, 100, (num,))
-    P = np.random.uniform(0, 1, (num,))
+    rng = np.random.default_rng(156114182869662948677852568516310985853)
+    X = rng.integers(10, 100, (num,))
+    N = X + rng.integers(0, 100, (num,))
+    P = rng.uniform(0, 1, (num,))
     for x, n, p in zip(X, N, P):
         with pytest.warns(DeprecationWarning, match=deprecation_msg):
             res = stats.binom_test(x, n, p, alternative=alternative)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -5986,9 +5986,9 @@ def test_binomtest():
     for p, res in zip(pp, results):
         assert_approx_equal(stats.binomtest(x, n, p).pvalue, res,
                             significant=12, err_msg='fail forp=%f' % p)
-        assert_approx_equal(stats.binomtest(50, 100, 0.1).pvalue,
-                            5.8320387857343647e-024,
-                            significant=12)
+    assert_approx_equal(stats.binomtest(50, 100, 0.1).pvalue,
+                        5.8320387857343647e-024,
+                        significant=12)
 
 
 def test_binomtest2():

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -5952,11 +5952,19 @@ class TestGeometricStandardDeviation:
         assert_equal(gstd_actual.mask, mask)
 
 
-def test_binom_test_deprecation():
+@pytest.mark.parametrize('alternative', ['two-sided', 'greater', 'less'])
+def test_binom_test_deprecation(alternative):
     deprecation_msg = ("'binom_test' is deprecated in favour of"
-                       " 'binomtest' and will be removed in Scipy 1.11.0.")
-    with pytest.warns(DeprecationWarning, match=deprecation_msg):
-        stats.binom_test([1, 1])
+                       " 'binomtest' from version 1.7.0 and will"
+                       " be removed in Scipy 1.12.0.")
+    num = 10
+    X = np.random.randint(10, 100, (num,))
+    N = X + np.random.randint(0, 100, (num,))
+    P = np.random.uniform(0, 1, (num,))
+    for x, n, p in zip(X, N, P):
+        with pytest.warns(DeprecationWarning, match=deprecation_msg):
+            res = stats.binom_test(x, n, p, alternative=alternative)
+        assert res == stats.binomtest(x, n, p, alternative=alternative).pvalue
 
 
 def test_binomtest():
@@ -5974,14 +5982,12 @@ def test_binomtest():
                0.12044570587262322, 0.88154763174802508, 0.027120993063129286,
                2.6102587134694721e-006]
 
-    with np.testing.suppress_warnings() as sup:
-        sup.filter(DeprecationWarning, "'binom_test' is deprecated")
-        for p, res in zip(pp, results):
-            assert_approx_equal(stats.binom_test(x, n, p), res,
-                                significant=12, err_msg='fail forp=%f' % p)
-            assert_approx_equal(stats.binom_test(50, 100, 0.1),
-                                5.8320387857343647e-024,
-                                significant=12)
+    for p, res in zip(pp, results):
+        assert_approx_equal(stats.binomtest(x, n, p).pvalue, res,
+                            significant=12, err_msg='fail forp=%f' % p)
+        assert_approx_equal(stats.binomtest(50, 100, 0.1).pvalue,
+                            5.8320387857343647e-024,
+                            significant=12)
 
 
 def test_binomtest2():
@@ -6003,21 +6009,17 @@ def test_binomtest2():
          1.000000000, 0.753906250, 0.343750000, 0.109375000, 0.021484375,
          0.001953125]
     ]
-    with np.testing.suppress_warnings() as sup:
-        sup.filter(DeprecationWarning, "'binom_test' is deprecated")
-        for k in range(1, 11):
-            res1 = [stats.binom_test(v, k, 0.5) for v in range(k + 1)]
-            assert_almost_equal(res1, res2[k-1], decimal=10)
+    for k in range(1, 11):
+        res1 = [stats.binomtest(v, k, 0.5).pvalue for v in range(k + 1)]
+        assert_almost_equal(res1, res2[k-1], decimal=10)
 
 
 def test_binomtest3():
-    with np.testing.suppress_warnings() as sup:
-        sup.filter(DeprecationWarning, "'binom_test' is deprecated")
-        # test added for issue #2384
-        # test when x == n*p and neighbors
-        res3 = [stats.binom_test(v, v*k, 1./k)
-                for v in range(1, 11) for k in range(2, 11)]
-        assert_equal(res3, np.ones(len(res3), int))
+    # test added for issue #2384
+    # test when x == n*p and neighbors
+    res3 = [stats.binomtest(v, v*k, 1./k).pvalue
+            for v in range(1, 11) for k in range(2, 11)]
+    assert_equal(res3, np.ones(len(res3), int))
 
     # > bt=c()
     # > for(i in as.single(1:10)) {
@@ -6096,15 +6098,14 @@ def test_binomtest3():
          0.7286603031173616, 0.7319999279787631, 0.7344267920995765,
          0.736270323773157, 0.737718376096348
         ])
-    with np.testing.suppress_warnings() as sup:
-        sup.filter(DeprecationWarning, "'binom_test' is deprecated")
-        res4_p1 = [stats.binom_test(v+1, v*k, 1./k)
-                   for v in range(1, 11) for k in range(2, 11)]
-        res4_m1 = [stats.binom_test(v-1, v*k, 1./k)
-                   for v in range(1, 11) for k in range(2, 11)]
 
-        assert_almost_equal(res4_p1, binom_testp1, decimal=13)
-        assert_almost_equal(res4_m1, binom_testm1, decimal=13)
+    res4_p1 = [stats.binomtest(v+1, v*k, 1./k).pvalue
+               for v in range(1, 11) for k in range(2, 11)]
+    res4_m1 = [stats.binomtest(v-1, v*k, 1./k).pvalue
+               for v in range(1, 11) for k in range(2, 11)]
+
+    assert_almost_equal(res4_p1, binom_testp1, decimal=13)
+    assert_almost_equal(res4_m1, binom_testm1, decimal=13)
 
 
 class TestTrim:


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #16256.

#### What does this implement/fix?
<!--Please explain your changes.-->

`stats.binom_test` was deprecated in documentation only. This PR adds a deprecation warning and test.

#### Additional information
<!--Any additional information you think is important.-->
