### PR TITLE
BLD: CI: fix issue in wheel metadata, and add basic "build in Ubuntu venv" CI job

### DIFF
--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -57,7 +57,7 @@ jobs:
 
     - name: Install Python packages
       run: |
-        python -m pip install numpy setuptools wheel cython pytest pytest-xdist pybind11 mpmath gmpy2 pythran ninja meson==0.60.3
+        python -m pip install numpy setuptools wheel cython pytest pytest-xdist pybind11 mpmath gmpy2 pythran ninja meson
 
     - name:  Prepare compiler cache
       id:    prep-ccache
@@ -102,3 +102,42 @@ jobs:
       run: |
         export OMP_NUM_THREADS=2
         python dev.py -n -j 2
+
+  test_venv_install:
+    name: Pip install into venv
+    if: "github.repository == 'scipy/scipy' || github.repository == ''"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+
+    - name: Setup Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+
+    - name: Install Ubuntu dependencies
+      run: |
+        # We're not running the full test suite here, only testing the install
+        # into a venv is working, so leave out optional dependencies. That's
+        # also why we can get away with an old version of OpenBLAS from Ubuntu
+        sudo apt-get update
+        sudo apt-get install -y libopenblas-dev pkg-config gfortran
+
+    - name: Create venv, install SciPy
+      run: |
+        python -m venv ../venvs/scipy-venv
+        source ../venvs/scipy-venv/bin/activate
+        # Note that this uses build isolation. That's why we don't need build
+        # dependencies to be installed in the venv itself.
+        python -m pip install . -vv
+
+    - name: Basic imports and tests
+      run: |
+        source ../venvs/scipy-venv/bin/activate
+        cd ..
+        python -c "import scipy"
+        python -c "import scipy.linalg"
+        python -m pip install pytest
+        python -c "from scipy import cluster; cluster.test()"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,13 +54,7 @@ requires = [
 [project]
 name = "SciPy"
 license = {file = "LICENSE.txt"}
-description = """
-SciPy (pronounced "Sigh Pie") is an open-source software for mathematics,
-science, and engineering. It includes modules for statistics, optimization,
-integration, linear algebra, Fourier transforms, signal and image processing,
-ODE solvers, and more.
-"""
-
+description = "Fundamental algorithms for scientific computing in Python"
 maintainers = [
     {name = "SciPy Developers", email = "scipy-dev@python.org"},
 ]


### PR DESCRIPTION
The `description` field should be a single line, having line breaks results in invalid metadata in a wheel.

This CI job is as minimal as it can be, while testing an isolated build and install into an Ubuntu virtual environment. Debian/Ubuntu is a special case, it has highly problematic Python handling - and it gets worse when you mix in a venv. We've had trouble with this before, so while it should work fine today (although gh-16300 is puzzling right now), it'd be good to have this job to guard against regressions.

Isolated builds use tmpdirs, which defeats `ccache`. So rather than working around that, I removed all caching - that also makes the job very easy to understand.

This job also has the absolute minimum number of dependencies that are required, which is nice to test that the optional dependencies are, in fact, optional.