### PR TITLE
MAINT: stats: fix _contains_nan on Pandas Series

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -87,6 +87,8 @@ __all__ = ['find_repeats', 'gmean', 'hmean', 'pmean', 'mode', 'tmean', 'tvar',
 
 
 def _contains_nan(a, nan_policy='propagate', use_summation=True):
+    if not isinstance(a, np.ndarray):
+        use_summation = False  # some array_likes ignore nans (e.g. pandas)
     policies = ['propagate', 'raise', 'omit']
     if nan_policy not in policies:
         raise ValueError("nan_policy must be one of {%s}" %


### PR DESCRIPTION
#### Reference issue
closes gh-16211

#### What does this implement/fix?
`_contains_nan`, the `stats` function that tries to beat `np.any(np.isnan(a))` at checking for `nan`s in an array, first tries `np.isnan(a.sum())`. If `a` is a Pandas Series, `sum` omits NaNs by default, so this doesn't work. This PR fixes the problem by skipping this strategy unless `a` is an `ndarray`.

#### Additional information
Ideas for tests and better ways of checking for NumPy array-ness are welcome. 
In the meantime, please test manually using the code in gh-16211. (CI doesn't have Pandas, to my knowledge, and I don't think it's important enough to write a class that behaves like them.)