### PR TITLE
DOC: fix incorrect formatting of deprecation tags

### DIFF
--- a/scipy/spatial/_qhull.pyx
+++ b/scipy/spatial/_qhull.pyx
@@ -1723,9 +1723,8 @@ class Delaunay(_QhullUser):
         Same as `simplices`, but deprecated.
 
         .. deprecated:: 0.12.0
-
-        Delaunay attribute `vertices` is deprecated in favour of `simplices`
-        and will be removed in Scipy 1.11.0.
+            Delaunay attribute `vertices` is deprecated in favour of `simplices`
+            and will be removed in Scipy 1.11.0.
     vertex_neighbor_vertices : tuple of two ndarrays of int; (indptr, indices)
         Neighboring vertices of vertices. The indices of neighboring
         vertices of vertex `k` are ``indices[indptr[k]:indptr[k+1]]``.

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -816,10 +816,9 @@ def kulsinski(u, v, w=None):
     :math:`k < n`.
 
     .. deprecated:: 0.12.0
-
-    Kulsinski has been deprecated from scipy.spatial.distance in SciPy 1.9.0
-    and it will be removed in SciPy 1.11.0. It is superseded by
-    scipy.spatial.distance.kulczynski1.
+        Kulsinski has been deprecated from `scipy.spatial.distance` in
+        SciPy 1.9.0 and it will be removed in SciPy 1.11.0. It is superseded
+        by scipy.spatial.distance.kulczynski1.
 
     Parameters
     ----------


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
Follow up to https://github.com/scipy/scipy/pull/16265 and https://github.com/scipy/scipy/pull/16258. In the process of #16315 I realised that some of my previous merged pr's had some incorrect formatting which meant the docs wont have rendered quite right. This pr fixes these errors.
#### Additional information
<!--Any additional information you think is important.-->
@tupui did a search for all `.. deprecated::` and these two were the only ones I could find that were incorrect.