### PR TITLE
DOC: BLD: remove `-scipyopt` from html Make command and build output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,16 +119,16 @@ jobs:
           no_output_timeout: 25m
           command: |
             export PYTHONPATH=$PWD/build-install/lib/python3.8/site-packages
-            python dev.py -n -j2 --doc html-scipyorg
+            python dev.py -n -j2 --doc html
 
       - store_artifacts:
-          path: doc/build/html-scipyorg
-          destination: html-scipyorg
+          path: doc/build/html
+          destination: html
 
       - persist_to_workspace:
           root: doc/build
           paths:
-            - html-scipyorg
+            - html
 
 # Run benchmarks
 
@@ -185,7 +185,7 @@ jobs:
             (git checkout --orphan tmp && git branch -D gh-pages || true);
             git checkout --orphan gh-pages;
             git reset --hard;
-            cp -R /tmp/build/html-scipyorg/. .;
+            cp -R /tmp/build/html/. .;
             touch .nojekyll;
             git config --global user.email "scipy-circleci-bot@nomail";
             git config --global user.name "scipy-circleci-bot";

--- a/.github/workflows/circle_artifacts.yml
+++ b/.github/workflows/circle_artifacts.yml
@@ -8,6 +8,6 @@ jobs:
         uses: larsoner/circleci-artifacts-redirector-action@master
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-path: 0/html-scipyorg/index.html
+          artifact-path: 0/html/index.html
           circleci-jobs: build_docs
           job-title: Check the rendered docs here!

--- a/dev.py
+++ b/dev.py
@@ -162,7 +162,7 @@ def main(argv):
     parser.add_argument("--mypy", action="store_true", default=False,
                         help="Run mypy on the codebase")
     parser.add_argument("--doc", action="append", nargs="?",
-                        const="html-scipyorg", help="Build documentation")
+                        const="html", help="Build documentation")
     parser.add_argument("--win-cp-openblas", action="store_true",
                         help="If set, and on Windows, copy OpenBLAS lib to "
                         "install directory after meson install. "

--- a/do.py
+++ b/do.py
@@ -907,7 +907,7 @@ class Mypy(Task):
 class Doc(Task):
     """:wrench: Build documentation
 
-TARGETS: Sphinx build targets [default: 'html-scipyorg']
+TARGETS: Sphinx build targets [default: 'html']
 """
     ctx = CONTEXT
 
@@ -928,7 +928,7 @@ TARGETS: Sphinx build targets [default: 'html-scipyorg']
             targets = ''
         else:
             task_dep = ['build']
-            targets = ' '.join(args) if args else 'html-scipyorg'
+            targets = ' '.join(args) if args else 'html'
 
         kwargs.update(cls.ctx.get())
         Args = namedtuple('Args', [k for k in kwargs.keys()])

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -20,7 +20,6 @@ ALLSPHINXOPTS   = -d build/doctrees $(SPHINXOPTS) source
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo "  html      to make standalone HTML files"
-	@echo "  html-scipyorg  to make standalone HTML files with scipy.org theming"
 	@echo "  pickle    to make pickle files (usable by e.g. sphinx-web)"
 	@echo "  htmlhelp  to make HTML files and a HTML help project"
 	@echo "  changes   to make an overview over all changed/added/deprecated items"
@@ -29,7 +28,7 @@ help:
 	@echo "  dist      to make a distribution-ready tree (installing Scipy in venv)"
 	@echo "  doc-dist  to make a distribution-ready tree (assuming Scipy is installed)"
 	@echo "  upload USERNAME=... RELEASE=... to upload built docs to docs.scipy.org"
-	@echo "  show      to show the html-scipyorg output"
+	@echo "  show      to show the HTML output"
 
 clean:
 	-rm -rf build/* source/reference/generated
@@ -78,12 +77,12 @@ dist:
 
 doc-dist: VERSIONWARNING=-t versionwarning
 
-doc-dist: html-scipyorg html
+doc-dist: html
 	-test -d build/htmlhelp || make htmlhelp-build
 	-rm -rf build/dist
 	mkdir -p build/dist
-	cp -r build/html-scipyorg/* build/dist
-	(cd build/html-scipyorg && zip -9qr ../dist/scipy-html.zip .)
+	cp -r build/html/* build/dist
+	(cd build/html && zip -9qr ../dist/scipy-html.zip .)
 	chmod ug=rwX,o=rX -R build/dist
 	find build/dist -type d -print0 | xargs -0r chmod g+s
 	cd build/dist && tar czf ../dist.tar.gz *
@@ -108,15 +107,7 @@ upload:
 html: version-check html-build
 html-build:
 	mkdir -p build/html build/doctrees
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) build/html $(FILES)
-	@echo
-	@echo "Build finished. The HTML pages are in build/html."
-
-html-scipyorg:
-	mkdir -p build/html build/doctrees
-	$(SPHINXBUILD) -WT --keep-going -t scipyorg $(VERSIONWARNING) -b html $(ALLSPHINXOPTS) build/html-scipyorg $(FILES)
-	@echo
-	@echo "Build finished. The HTML pages are in build/html-scipyorg."
+	$(SPHINXBUILD) -WT --keep-going $(VERSIONWARNING) -b html $(ALLSPHINXOPTS) build/html $(FILES)
 
 coverage: build version-check
 	mkdir -p build/coverage build/doctrees
@@ -137,4 +128,4 @@ linkcheck: version-check
 	      "or in build/linkcheck/output.txt."
 
 show:
-	@python -c "import webbrowser; webbrowser.open_new_tab('file://$(PWD)/build/html-scipyorg/index.html')"
+	@python -c "import webbrowser; webbrowser.open_new_tab('file://$(PWD)/build/html/index.html')"

--- a/doc/README.md
+++ b/doc/README.md
@@ -21,7 +21,7 @@ Alternatively, if you prefer to build SciPy and the docs separately rather
 than use `runtests.py`:
 ```
 python setup.py develop  # in the root of the repo
-cd doc && make html-scipyorg
+cd doc && make html
 ```
 
 In case the SciPy version found by the above command is different from that of the
@@ -34,7 +34,7 @@ This indicates that you're likely picking up the wrong SciPy install, check
 with `python -c "import scipy; print(scipy.__file__)"`.
 
 If the build is successful, you can open it in your browser with `make show`
-(which will open `build/html-scipyorg/index.html`).
+(which will open `build/html/index.html`).
 
 ## Building documentation for a release
 

--- a/doc/source/dev/contributor/quickstart_gitpod.rst
+++ b/doc/source/dev/contributor/quickstart_gitpod.rst
@@ -117,7 +117,7 @@ The documentation is pre-built during your workspace initialization. So once thi
 Option 1: Using Liveserve
 ***************************
 
-#. View the documentation in ``scipy/doc/build/html-scipyorg``. You can start with ``index.html`` and browse, or you can jump straight to the file you're interested in.
+#. View the documentation in ``scipy/doc/build/html``. You can start with ``index.html`` and browse, or you can jump straight to the file you're interested in.
 #. To see the rendered version of a page, you can right-click on the ``.html`` file and click on **Open with Live Serve**. Alternatively, you can open the file in the editor and click on the **Go live** button on the status bar.
 
     .. image:: ../../_static/gitpod/vscode-statusbar.png
@@ -145,7 +145,7 @@ A quick and easy way to see live changes in a ``.rst`` file as you work on it us
     .. image:: ../../_static/gitpod/rst-rendering.png
         :alt: Gitpod workspace - Quickstart Docker rst file opened on the left and rendered version on the right group of the editor.
 
-If you want to see the final output with the ``html`` theme you will need to rebuild the docs with ``make html-scipyorg`` and use Live Serve as described in option 1.
+If you want to see the final output with the ``html`` theme you will need to rebuild the docs with ``make html`` and use Live Serve as described in option 1.
 
 FAQ's
 -----

--- a/doc/source/dev/contributor/rendering_documentation.rst
+++ b/doc/source/dev/contributor/rendering_documentation.rst
@@ -38,7 +38,7 @@ To render the documentation on your own machine:
    Some of the documentation theme files are not distributed
    with the main ``scipy`` repository; this keeps them up to date using
    `git submodules`_.
-#. Enter ``make html-scipyorg``. If you have multiple version of Python on
+#. Enter ``make html``. If you have multiple version of Python on
    your path, you can choose which version to use by appending
    ``PYTHON=python3.9`` to this command, where ``python3.9`` is to be
    replaced with the name of the Python you use for SciPy development.
@@ -46,7 +46,7 @@ To render the documentation on your own machine:
    to execute the documentation build instructions from the ``Makefile``.
    This can take a while the first time, but subsequent documentation builds
    are typically much faster.
-#. View the documentation in ``scipy/doc/build/html-scipyorg``. You can start
+#. View the documentation in ``scipy/doc/build/html``. You can start
    with ``index.html`` and browse, or you can jump straight to the file you’re
    interested in.
 

--- a/doc/source/dev/contributor/runtests.rst
+++ b/doc/source/dev/contributor/runtests.rst
@@ -84,7 +84,7 @@ Other useful options include:
    ``scipy/build/coverage/index.html``. *Note:* |pytest-cov|_ *must be
    installed.*
 -  ``--doc`` to build the docs in ``scipy/doc/build``. By default,
-   docs are built only in the ``html-scipyorg`` format, but you can
+   docs are built only in the ``html`` format, but you can
    change this by appending the name of the desired format.
 -  ``--refguide-check`` to check whether the objects in a Scipy submodule's
    ``__all__`` dict correspond to the objects included in the reference

--- a/doc/source/dev/contributor/using_act.rst
+++ b/doc/source/dev/contributor/using_act.rst
@@ -47,7 +47,8 @@ To run the job with verbose logging, push in the following command::
 
   act -v
 
-To reuse the containers in `act` to maintain state, push in the following command::
+To reuse the containers in ``act`` to maintain state, push in the following
+command::
 
   act -j <JOB_NAME> --bind --reuse
 
@@ -59,7 +60,7 @@ pushing the following command::
 
   act --secret-file my.secrets
 
-If the environment variables are supplied via `.env` file, use the following
+If the environment variables are supplied via ``.env`` file, use the following
 command::
 
   act --env-file my.env

--- a/runtests.py
+++ b/runtests.py
@@ -132,7 +132,7 @@ def main(argv):
     parser.add_argument("--mypy", action="store_true", default=False,
                         help="Run mypy on the codebase")
     parser.add_argument("--doc", action="append", nargs="?",
-                        const="html-scipyorg", help="Build documentation")
+                        const="html", help="Build documentation")
     args = parser.parse_args(argv)
 
     if args.pep8:

--- a/tools/docker_dev/settings.json
+++ b/tools/docker_dev/settings.json
@@ -1,7 +1,7 @@
 {
     "python.defaultInterpreterPath": "/opt/conda/envs/scipy-dev/bin/python",
     // rst related - for the docs
-    "esbonio.sphinx.buildDir": "${workspaceRoot}/doc/build/html-scipyorg",
+    "esbonio.sphinx.buildDir": "${workspaceRoot}/doc/build/html",
     "esbonio.sphinx.confDir"  : "",
     // will use docutils only
     "esbonio.server.enabled": false,


### PR DESCRIPTION
We had duplicate `html` and `html-scipyorg` commands that were unnecessary; so get rid of one of them.