### PR TITLE
MAINT: retry openblas download in CI

### DIFF
--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -6,6 +6,7 @@ import sys
 import shutil
 import tarfile
 import textwrap
+import time
 import zipfile
 
 from tempfile import mkstemp, gettempdir
@@ -92,11 +93,16 @@ def download_openblas(target, plat, ilp64):
         return None
     filename = f'{BASEURL}/openblas{fnsuffix}-{OPENBLAS_LONG}-{suffix}'
     req = Request(url=filename, headers=headers)
-    try:
-        response = urlopen(req)
-    except HTTPError:
-        print(f'Could not download "{filename}"', file=sys.stderr)
-        raise
+
+    for _ in range(3):
+        try:
+            time.sleep(1)
+            response = urlopen(req)
+            break
+        except HTTPError:
+            print(f'Could not download "{filename}"', file=sys.stderr)
+            raise
+
     length = response.getheader('content-length')
     if response.status != 200:
         print(f'Could not download "{filename}"', file=sys.stderr)


### PR DESCRIPTION
Seen recently in the CI a few times, e.g. [here](https://github.com/scipy/scipy/runs/6662045923?check_suite_focus=true). Adds a retry to download openblas.

```
++ python tools/openblas_support.py
[21](https://github.com/scipy/scipy/runs/6662045923?check_suite_focus=true#step:5:22)
Could not download "https://anaconda.org/multibuild-wheels-staging/openblas-libs/v0.3.18/download/openblas-v0.3.18-macosx_10_9_x86_64-gf_1becaaa.tar.gz"
[22](https://github.com/scipy/scipy/runs/6662045923?check_suite_focus=true#step:5:23)
Traceback (most recent call last):
[23](https://github.com/scipy/scipy/runs/6662045923?check_suite_focus=true#step:5:24)
  File "tools/openblas_support.py", line 339, in <module>
[24](https://github.com/scipy/scipy/runs/6662045923?check_suite_focus=true#step:5:25)
    print(setup_openblas())
[25](https://github.com/scipy/scipy/runs/6662045923?check_suite_focus=true#step:5:26)
  File "tools/openblas_support.py", line 126, in setup_openblas
[26](https://github.com/scipy/scipy/runs/6662045923?check_suite_focus=true#step:5:27)
    typ = download_openblas(tmp, plat, ilp64)
[27](https://github.com/scipy/scipy/runs/6662045923?check_suite_focus=true#step:5:28)
  File "tools/openblas_support.py", line 96, in download_openblas
[28](https://github.com/scipy/scipy/runs/6662045923?check_suite_focus=true#step:5:29)
    response = urlopen(req)
[29](https://github.com/scipy/scipy/runs/6662045923?check_suite_focus=true#step:5:30)
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/urllib/request.py", line 222, in urlopen
[30](https://github.com/scipy/scipy/runs/6662045923?check_suite_focus=true#step:5:31)
    return opener.open(url, data, timeout)
[31](https://github.com/scipy/scipy/runs/6662045923?check_suite_focus=true#step:5:32)
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/urllib/request.py", line 531, in open
[32](https://github.com/scipy/scipy/runs/6662045923?check_suite_focus=true#step:5:33)
    response = meth(req, response)
[33](https://github.com/scipy/scipy/runs/6662045923?check_suite_focus=true#step:5:34)
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/urllib/request.py", line 640, in http_response
[34](https://github.com/scipy/scipy/runs/6662045923?check_suite_focus=true#step:5:35)
    response = self.parent.error(
[35](https://github.com/scipy/scipy/runs/6662045923?check_suite_focus=true#step:5:36)
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/urllib/request.py", line 569, in error
[36](https://github.com/scipy/scipy/runs/6662045923?check_suite_focus=true#step:5:37)
    return self._call_chain(*args)
[37](https://github.com/scipy/scipy/runs/6662045923?check_suite_focus=true#step:5:38)
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/urllib/request.py", line 502, in _call_chain
[38](https://github.com/scipy/scipy/runs/6662045923?check_suite_focus=true#step:5:39)
    result = func(*args)
[39](https://github.com/scipy/scipy/runs/6662045923?check_suite_focus=true#step:5:40)
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/urllib/request.py", line 649, in http_error_default
[40](https://github.com/scipy/scipy/runs/6662045923?check_suite_focus=true#step:5:41)
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
[41](https://github.com/scipy/scipy/runs/6662045923?check_suite_focus=true#step:5:42)
urllib.error.HTTPError: HTTP Error 403: Forbidden
```