### PR TITLE
MAINT: git security shim for 1.9.x

### DIFF
--- a/tools/version_utils.py
+++ b/tools/version_utils.py
@@ -81,8 +81,7 @@ def git_version(cwd):
         return out
 
     try:
-        cwd = os.getcwd()
-        git_dir = os.path.join(cwd, ".git")
+        git_dir = os.path.join(os.path.dirname(__file__), '..')
         out = _minimal_ext_cmd(['git', '--git-dir', git_dir, 'rev-parse', 'HEAD'])
         GIT_REVISION = out.strip().decode('ascii')[:7]
 

--- a/tools/version_utils.py
+++ b/tools/version_utils.py
@@ -81,8 +81,13 @@ def git_version(cwd):
         return out
 
     try:
-        git_dir = os.path.join(os.path.dirname(__file__), '..')
-        out = _minimal_ext_cmd(['git', '--git-dir', git_dir, 'rev-parse', 'HEAD'])
+        git_dir = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+        git_dir = os.path.join(git_dir, ".git")
+        out = _minimal_ext_cmd(['git',
+                                '--git-dir',
+                                git_dir,
+                                'rev-parse',
+                                'HEAD'])
         GIT_REVISION = out.strip().decode('ascii')[:7]
 
         # We need a version number that's regularly incrementing for newer commits,

--- a/tools/version_utils.py
+++ b/tools/version_utils.py
@@ -81,7 +81,9 @@ def git_version(cwd):
         return out
 
     try:
-        out = _minimal_ext_cmd(['git', 'rev-parse', 'HEAD'])
+        cwd = os.getcwd()
+        git_dir = os.path.join(cwd, ".git")
+        out = _minimal_ext_cmd(['git', '--git-dir', git_dir, 'rev-parse', 'HEAD'])
         GIT_REVISION = out.strip().decode('ascii')[:7]
 
         # We need a version number that's regularly incrementing for newer commits,


### PR DESCRIPTION
* replicate gh-16139 on the latest maintenance branch
because the `master` branch of the wheels repo will
encounter the issues described in that PR (for example, see:
https://github.com/MacPython/scipy-wheels/pull/166 which
has Travis and Azure failures caused by those same
versioning issues)

* I think the `cwd` is still correct even though the patch
is being applied to a different file this time (used to be
`setup.py`), though we could double check this by pointing
the wheels PR at the commit hash of this PR on my fork if we want

* any reason not to forward port this as well at this point,
if we're going to need to keep "backporting" it?

(there are other issues in the wheels repo as well, possibly even the PROPACK
Windows stuff to shim around again? but one thing at a time)