### PR TITLE
MAINT, TST: bump tol for _axis_nan_policy_test

### DIFF
--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -291,7 +291,11 @@ def _axis_nan_policy_test(hypotest, args, kwds, n_samples, n_outputs, paired,
             res = unpacker(hypotest(*data, axis=axis, nan_policy=nan_policy,
                                     *args, **kwds))
 
-        assert_equal(res[0], statistics)
+        if hypotest.__name__ in {"gmean"}:
+            assert_allclose(res[0], statistics, rtol=2e-16)
+        else:
+            assert_equal(res[0], statistics)
+
         assert_equal(res[0].dtype, statistics.dtype)
         if len(res) == 2:
             assert_equal(res[1], pvalues)


### PR DESCRIPTION
Fixes #16337

* apply the patch Matt suggested in gh-16337

* I was easily able to reproduce the failure reported
there on a Linux box with a Python `3.9` `venv` where NumPy
`1.19.3` was used at test/runtime to mimic the wheels
repo, and confirm that the tests pass with this patch
(so, if you need me to iterate on the patch it should
be straightforward)