### PR TITLE
DEP: remove tol & max_intervals from NumericalInverseHermite

### DIFF
--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -479,7 +479,7 @@ from .contingency import chi2_contingency
 from ._resampling import bootstrap, monte_carlo_test, permutation_test
 from ._entropy import *
 from ._hypotests import *
-from ._rvs_sampling import rvs_ratio_uniforms, NumericalInverseHermite
+from ._rvs_sampling import rvs_ratio_uniforms
 from ._page_trend_test import page_trend_test
 from ._mannwhitneyu import mannwhitneyu
 from ._fit import fit

--- a/scipy/stats/_rvs_sampling.py
+++ b/scipy/stats/_rvs_sampling.py
@@ -171,26 +171,3 @@ def rvs_ratio_uniforms(pdf, umax, vmin, vmax, size=1, c=0, random_state=None):
         i += 1
 
     return np.reshape(x, size1d)
-
-
-class NumericalInverseHermite:
-    @_deprecated(
-        "NumericalInverseHermite has been deprecated from `scipy.stats` "
-        "and will be removed in SciPy 1.10.0. "
-        " To use `NumericalInverseHermite`, import/use it from "
-        "`scipy.stats.sampling` module instead. "
-        "i.e. `from scipy.stats.sampling import NumericalInverseHermite`"
-    )
-    def __init__(self, *args, **kwargs):
-        self.hinv = unuran_wrapper.NumericalInverseHermite(*args, **kwargs)
-        self.intervals = self.hinv.intervals
-        self.midpoint_error = self.hinv.midpoint_error
-
-    def rvs(self, *args, **kwargs):
-        return self.hinv.rvs(*args, **kwargs)
-
-    def ppf(self, *args, **kwargs):
-        return self.hinv.ppf(*args, **kwargs)
-
-    def qrvs(self, *args, **kwargs):
-        return self.hinv.qrvs(*args, **kwargs)

--- a/scipy/stats/_unuran/unuran_wrapper.pyx.templ
+++ b/scipy/stats/_unuran/unuran_wrapper.pyx.templ
@@ -1829,10 +1829,6 @@ cdef class NumericalInverseHermite(Method):
     refinement could exceed the maximum allowed number of intervals, which is
     100000.
 
-    This method accepted a `tol` parameter to specify the maximum tolerable u-error
-    but it has now been deprecated in the favor of `u_resolution`. `tol` will be
-    removed completely in SciPy 1.10.0.
-
     References
     ----------
     .. [1] Hörmann, Wolfgang, and Josef Leydold. "Continuous random variate
@@ -1976,12 +1972,10 @@ cdef class NumericalInverseHermite(Method):
                   domain=None,
                   order=3,
                   u_resolution=1e-12,
-                  tol=None,
                   construction_points=None,
-                  max_intervals=100000,
                   random_state=None):
-        domain, order, u_resolution = self._validate_args(dist, domain, order, max_intervals,
-                                                          u_resolution, tol, construction_points)
+        domain, order, u_resolution = self._validate_args(dist, domain, order,
+                                                          u_resolution, construction_points)
 
         # save all the arguments for pickling support
         self._kwargs = {
@@ -1989,8 +1983,6 @@ cdef class NumericalInverseHermite(Method):
             'domain': domain,
             'order': order,
             'u_resolution': u_resolution,
-            'tol': tol,
-            'max_intervals': max_intervals,
             'construction_points': construction_points,
             'random_state': random_state
         }
@@ -2023,30 +2015,17 @@ cdef class NumericalInverseHermite(Method):
 
             self._check_errorcode(unur_hinv_set_order(self.par, order))
             self._check_errorcode(unur_hinv_set_u_resolution(self.par, u_resolution))
-            self._check_errorcode(unur_hinv_set_max_intervals(self.par, max_intervals))
             self._check_errorcode(unur_hinv_set_cpoints(self.par, &self.construction_points_array[0],
                                                         len(self.construction_points_array)))
             self._set_rng(random_state)
         finally:
             _lock.release()
 
-    def _validate_args(self, dist, domain, order, max_intervals, u_resolution, tol,
-                       construction_points):
+    def _validate_args(self, dist, domain, order, u_resolution, construction_points):
         domain = _validate_domain(domain, dist)
         # UNU.RAN raises warning and sets a default value. Prefer an error instead.
         if order not in {1, 3, 5}:
             raise ValueError("`order` must be either 1, 3, or 5.")
-        if int(max_intervals) != max_intervals or max_intervals <= 1:
-            raise ValueError("`max_intervals' must be an integer greater than 1.")
-        if max_intervals != 100000:
-            warnings.warn("`max_intervals` has been deprecated. "
-                          "It will be completely removed in SciPy 1.10.0.",
-                          DeprecationWarning)
-        if tol is not None:
-            warnings.warn("`tol` has been deprecated and replaced with `u_resolution`. "
-                          "It will be completely removed in SciPy 1.10.0.",
-                          DeprecationWarning)
-            u_resolution = tol
         u_resolution = float(u_resolution)
         self.construction_points_array = np.ascontiguousarray(construction_points,
                                                               dtype=np.float64)

--- a/scipy/stats/tests/test_sampling.py
+++ b/scipy/stats/tests/test_sampling.py
@@ -1033,10 +1033,6 @@ class TestNumericalInverseHermite:
             NumericalInverseHermite(StandardNormal(),
                                     u_resolution='ekki')
 
-        match = "`max_intervals' must be..."
-        with pytest.raises(ValueError, match=match):
-            NumericalInverseHermite(StandardNormal(), max_intervals=-1)
-
     rngs = [None, 0, np.random.RandomState(0)]
     if NumpyVersion(np.__version__) >= '1.18.0':
         rngs.append(np.random.default_rng(0))  # type: ignore
@@ -1128,12 +1124,6 @@ class TestNumericalInverseHermite:
         max_error, mae = rng.u_error()
         assert max_error < 1e-14
         assert mae <= max_error
-
-    def test_deprecations(self):
-        msg = ("`tol` has been deprecated and replaced with `u_resolution`. "
-               "It will be completely removed in SciPy 1.10.0.")
-        with pytest.warns(DeprecationWarning, match=msg):
-            NumericalInverseHermite(StandardNormal(), tol=1e-12)
 
 
 class TestDiscreteGuideTable:


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #15749
#### What does this implement/fix?
<!--Please explain your changes.-->
Executes deprecation of `tol` and `max_intervals` from `NumericalInverseHermite`. Also removes deprecated way of importing 
`NumericalInverseHermite`.
#### Additional information
<!--Any additional information you think is important.-->
