### PR TITLE
DEV: add meson-python to environment.yml

### DIFF
--- a/INSTALL.rst.txt
+++ b/INSTALL.rst.txt
@@ -41,9 +41,9 @@ __ https://www.numpy.org/
 
 If building from source, SciPy also requires:
 
-3) setuptools__ < 60.0
+3) Meson >= 0.62.1
 
-__ https://github.com/pypa/setuptools
+__ https://github.com/mesonbuild/meson
 
 4) pybind11__ >= 2.4.3
 
@@ -56,6 +56,17 @@ __ http://www.sphinx-doc.org/
 6) Cython__ >= 0.29.21
 
 __ http://cython.org/
+
+7) Pythran__ => 0.11.0
+
+__ https://pythran.readthedocs.io/en/latest/
+
+8) Ninja__
+
+__ https://ninja-build.org/
+
+9) If you want to install via wheels: `meson-python` and `wheel`
+
 
 Windows
 -------

--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - cython
   - compilers
   - meson
+  - meson-python
   - ninja
   - numpy
   - openblas


### PR DESCRIPTION
We now have a conda-forge package for `meson-python`, so add it.

Also some edits to `INSTALL.rst.txt`. This file is annoying and I'd like to replace it with something else at some point, but not today. So just make it closer to the current status for now.

[ci skip]

