### PR TITLE
Documentation update signal.iirdesign

### DIFF
--- a/doc/source/_static/version_switcher.json
+++ b/doc/source/_static/version_switcher.json
@@ -1,11 +1,16 @@
 [
     {
-        "name": "1.9.0 (dev)",
+        "name": "1.10.0 (dev)",
         "version": "dev",
         "url": "https://scipy.github.io/devdocs/"
     },
     {
-        "name": "1.8.1 (stable)",
+        "name": "1.9.0 (stable)",
+        "version":"1.9.0",
+        "url": "https://docs.scipy.org/doc/scipy-1.9.0/"
+    },
+    {
+        "name": "1.8.1",
         "version":"1.8.1",
         "url": "https://docs.scipy.org/doc/scipy-1.8.1/"
     },

--- a/tools/version_utils.py
+++ b/tools/version_utils.py
@@ -81,7 +81,13 @@ def git_version(cwd):
         return out
 
     try:
-        out = _minimal_ext_cmd(['git', 'rev-parse', 'HEAD'])
+        git_dir = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+        git_dir = os.path.join(git_dir, ".git")
+        out = _minimal_ext_cmd(['git',
+                                '--git-dir',
+                                git_dir,
+                                'rev-parse',
+                                'HEAD'])
         GIT_REVISION = out.strip().decode('ascii')[:7]
 
         # We need a version number that's regularly incrementing for newer commits,


### PR DESCRIPTION
#### Reference issue
Closes: [1145761925](https://github.com/scipy/scipy/issues/16342#issuecomment-1145761925)

#### What does this implement/fix?
Confusion about filter options of `signal.iirdesign`.
Documentation [scipy.signal.iirfilter](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.iirfilter.html), shows in options that Bessel Filter is supported as `ftype`.
This is not the case, documentation should be updated.
