### PR TITLE
DOC: optimize: remove callback doc from the options in  `_minimize_lbfgsb` and `_minimize_cobyla` doc

### DIFF
--- a/scipy/optimize/_cobyla_py.py
+++ b/scipy/optimize/_cobyla_py.py
@@ -207,9 +207,6 @@ def _minimize_cobyla(fun, x0, args=(), constraints=(),
         Maximum number of function evaluations.
     catol : float
         Tolerance (absolute) for constraint violations
-    callback : callable, optional
-        Called after each iteration, as ``callback(x)``, where ``x`` is the
-        current parameter vector.
 
     """
     _check_unknown_options(unknown_options)

--- a/scipy/optimize/_lbfgsb_py.py
+++ b/scipy/optimize/_lbfgsb_py.py
@@ -250,9 +250,6 @@ def _minimize_lbfgsb(fun, x0, args=(), jac=None, bounds=None,
         ``iprint = 99``   print details of every iteration except n-vectors;
         ``iprint = 100``  print also the changes of active set and final x;
         ``iprint > 100``  print details of every iteration including x and g.
-    callback : callable, optional
-        Called after each iteration, as ``callback(xk)``, where ``xk`` is the
-        current parameter vector.
     maxls : int, optional
         Maximum number of line search steps (per iteration). Default is 20.
     finite_diff_rel_step : None or array_like, optional


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Fix #16127 

#### What does this implement/fix?
<!--Please explain your changes.-->
I removed “callback” doc from the “options” in  `_minimize_lbfgsb` and `_minimize_cobyla` doc, because it is an optional argument, but not an option in the “option” dict.

#### Additional information
<!--Any additional information you think is important.-->
