### PR TITLE
MAINT, TST: sup warning for theilslopes

### DIFF
--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -947,7 +947,8 @@ def test_theilslopes_warnings():
     with pytest.warns(RuntimeWarning, match="All `x` coordinates are..."):
         res = mstats.theilslopes([0, 1], [0, 0])
         assert np.all(np.isnan(res))
-    with pytest.warns(RuntimeWarning, match="invalid value encountered..."):
+    with suppress_warnings() as sup:
+        sup.filter(RuntimeWarning, "invalid value encountered...")
         res = mstats.theilslopes([0, 0, 0], [0, 1, 0])
         assert_allclose(res, (0, 0, np.nan, np.nan))
 


### PR DESCRIPTION
Fixes #16358 

* suppress rather than check for a warning
in `test_theilslopes_warnings()` because
the warning does not show up for 32-bit Windows
with at least some versions of NumPy (issue
for wheels repo), based on suggestion from
Matt in matching issue

* this is so far allowing 32-bit Windows test suite to pass
on my wheels repo fork here when pointing to the hash of the commit
in this PR: https://github.com/tylerjereddy/scipy-wheels/pull/2
(compared to original failure when wheels repo points at `main`
here: https://github.com/MacPython/scipy-wheels/pull/166 ) 