### PR TITLE
ENH: Provide more information when a value is out of bounds in interp1d.

### DIFF
--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -729,13 +729,16 @@ class interp1d(_Interpolator1D):
         below_bounds = x_new < self.x[0]
         above_bounds = x_new > self.x[-1]
 
-        # !! Could provide more information about which values are out of bounds
         if self.bounds_error and below_bounds.any():
-            raise ValueError("A value in x_new is below the interpolation "
-                             "range.")
+            below_bounds_value = x_new[np.argmax(below_bounds)]
+            raise ValueError("A value ({}) in x_new is below "
+                             "the interpolation range's minimum value ({})."
+                             .format(below_bounds_value, self.x[0]))
         if self.bounds_error and above_bounds.any():
-            raise ValueError("A value in x_new is above the interpolation "
-                             "range.")
+            above_bounds_value = x_new[np.argmax(above_bounds)]
+            raise ValueError("A value ({}) in x_new is above "
+                             "the interpolation range's maximum value ({})."
+                             .format(above_bounds_value, self.x[-1]))
 
         # !! Should we emit a warning if some values are out of bounds?
         # !! matlab does not.

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -434,7 +434,7 @@ class TestInterp1D:
         assert_array_almost_equal(interp10([2.4, 5.6, 6.0]),
                                   np.array([2., 5., 6.]))
 
-    def bounds_check_helper(self,interpolant, test_array, fail_value):
+    def bounds_check_helper(self, interpolant, test_array, fail_value):
         # Asserts that a ValueError is raised and that the error message
         # contains the value causing this exception.
         assert_raises(ValueError, interpolant, test_array)

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -434,6 +434,15 @@ class TestInterp1D:
         assert_array_almost_equal(interp10([2.4, 5.6, 6.0]),
                                   np.array([2., 5., 6.]))
 
+    def bounds_check_helper(self,interpolant, test_array, fail_value):
+        # Asserts that a ValueError is raised and that the error message
+        # contains the value causing this exception.
+        assert_raises(ValueError, interpolant, test_array)
+        try:
+            interpolant(test_array)
+        except ValueError as err:
+            assert("{}".format(fail_value) in str(err))
+
     def _bounds_check(self, kind='linear'):
         # Test that our handling of out-of-bounds input is correct.
         extrap10 = interp1d(self.x10, self.y10, fill_value=self.fill_value,
@@ -450,8 +459,12 @@ class TestInterp1D:
 
         raises_bounds_error = interp1d(self.x10, self.y10, bounds_error=True,
                                        kind=kind)
-        assert_raises(ValueError, raises_bounds_error, -1.0)
-        assert_raises(ValueError, raises_bounds_error, 11.0)
+
+        self.bounds_check_helper(raises_bounds_error, -1.0, -1.0)
+        self.bounds_check_helper(raises_bounds_error, 11.0, 11.0)
+        self.bounds_check_helper(raises_bounds_error, [0.0, -1.0, 0.0], -1.0)
+        self.bounds_check_helper(raises_bounds_error, [0.0, 1.0, 21.0], 21.0)
+
         raises_bounds_error([0.0, 5.0, 9.0])
 
     def _bounds_check_int_nan_fill(self, kind='linear'):


### PR DESCRIPTION
#### What does this implement/fix?

Consider the following code snippet:

```
from scipy.interpolate import interp1d

x = [-1,1]
y = [0,0]

inter = interp1d(x,y)

inter(1.1)
inter(-1.1)
```

Currently, scipy.interpolate.interp1d raises a very uninformative error when a value is out of bounds, i.e.

> ValueError: A value in x_new is above the interpolation range.
> ValueError: A value in x_new is below the interpolation range.

As noted in a comment left behind in the code, this message could provide information on which values are out of bounds. With this commit, the message now reads

> ValueError: A value (-1.1) in x_new is below the interpolation range's minimum value (-1).
> ValueError: A value (1.1) in x_new is above the interpolation range's maximum value (1).