### PR TITLE
BUG: `sparse.linalg.expm_multiply` fails for `start > stop / 2`, `start < 0`, and `stop < start`

### DIFF
--- a/scipy/sparse/linalg/_expm_multiply.py
+++ b/scipy/sparse/linalg/_expm_multiply.py
@@ -699,7 +699,8 @@ def _expm_multiply_interval(A, B, start=None, stop=None, num=None,
     if t_0*A_1_norm == 0:
         m_star_0, s_0 = 0, 1
     else:
-        norm_info_0 = LazyOperatorNormInfo(t_0*A, A_1_norm=t_0*A_1_norm, ell=ell)
+        norm_info_0 = LazyOperatorNormInfo(t_0*A,
+                A_1_norm=t_0*A_1_norm, ell=ell)
         m_star_0, s_0 = _fragment_3_1(norm_info_0, n0, tol, ell=ell)
     X[0] = _expm_multiply_simple_core(A, B, t_0, mu, m_star_0, s_0)
 

--- a/scipy/sparse/linalg/_expm_multiply.py
+++ b/scipy/sparse/linalg/_expm_multiply.py
@@ -699,8 +699,10 @@ def _expm_multiply_interval(A, B, start=None, stop=None, num=None,
     if t_0*A_1_norm == 0:
         m_star_0, s_0 = 0, 1
     else:
-        norm_info_0 = LazyOperatorNormInfo(t_0*A,
-                A_1_norm=abs(t_0)*A_1_norm, ell=ell)
+        norm_info_0 = LazyOperatorNormInfo(
+                t_0*A,
+                A_1_norm=abs(t_0)*A_1_norm,
+                ell=ell)
         m_star_0, s_0 = _fragment_3_1(norm_info_0, n0, tol, ell=ell)
     X[0] = _expm_multiply_simple_core(A, B, t_0, mu, m_star_0, s_0)
 

--- a/scipy/sparse/linalg/_expm_multiply.py
+++ b/scipy/sparse/linalg/_expm_multiply.py
@@ -711,7 +711,6 @@ def _expm_multiply_interval(A, B, start=None, stop=None, num=None,
     else:
         m_star, s = _fragment_3_1(norm_info, n0, tol, ell=ell)
 
-
     # Compute the expm action at the rest of the time points.
     if q <= s:
         if status_only:

--- a/scipy/sparse/linalg/_expm_multiply.py
+++ b/scipy/sparse/linalg/_expm_multiply.py
@@ -268,12 +268,16 @@ def _expm_multiply_simple(A, B, t=1.0, traceA=None, balance=False):
         m_star, s = 0, 1
     else:
         ell = 2
-        norm_info = LazyOperatorNormInfo(t*A, A_1_norm=abs(t)*A_1_norm, ell=ell)
+        norm_info = LazyOperatorNormInfo(
+                t*A,
+                A_1_norm=abs(t)*A_1_norm,
+                ell=ell)
         m_star, s = _fragment_3_1(norm_info, n0, tol, ell=ell)
     return _expm_multiply_simple_core(A, B, t, mu, m_star, s, tol, balance)
 
 
-def _expm_multiply_simple_core(A, B, t, mu, m_star, s, tol=None, balance=False):
+def _expm_multiply_simple_core(A, B, t, mu, m_star, s,
+                               tol=None, balance=False):
     """
     A helper function.
     """

--- a/scipy/sparse/linalg/_expm_multiply.py
+++ b/scipy/sparse/linalg/_expm_multiply.py
@@ -673,6 +673,10 @@ def _expm_multiply_interval(A, B, start=None, stop=None, num=None,
         linspace_kwargs['num'] = num
     if endpoint is not None:
         linspace_kwargs['endpoint'] = endpoint
+    reverse = False
+    if start > stop:
+        reverse = True
+        stop, start = start, stop
     samples, step = np.linspace(start, stop, **linspace_kwargs)
 
     # Convert the linspace output to the notation used by the publication.
@@ -716,22 +720,23 @@ def _expm_multiply_interval(A, B, start=None, stop=None, num=None,
         if status_only:
             return 0
         else:
-            return _expm_multiply_interval_core_0(A, X,
+            X, status = _expm_multiply_interval_core_0(A, X,
                     h, mu, q, norm_info, tol, ell,n0)
     elif not (q % s):
         if status_only:
             return 1
         else:
-            return _expm_multiply_interval_core_1(A, X,
+            X, status = _expm_multiply_interval_core_1(A, X,
                     h, mu, m_star, s, q, tol)
     elif (q % s):
         if status_only:
             return 2
         else:
-            return _expm_multiply_interval_core_2(A, X,
+            X, status = _expm_multiply_interval_core_2(A, X,
                     h, mu, m_star, s, q, tol)
     else:
         raise Exception('internal error')
+    return X if not reverse else X[::-1], status
 
 
 def _expm_multiply_interval_core_0(A, X, h, mu, q, norm_info, tol, ell, n0):

--- a/scipy/sparse/linalg/_expm_multiply.py
+++ b/scipy/sparse/linalg/_expm_multiply.py
@@ -693,11 +693,6 @@ def _expm_multiply_interval(A, B, start=None, stop=None, num=None,
     A = A - mu * ident
     A_1_norm = onenormest(A) if is_linear_operator else _exact_1_norm(A)
     ell = 2
-    norm_info = LazyOperatorNormInfo(t*A, A_1_norm=abs(t)*A_1_norm, ell=ell)
-    if t*A_1_norm == 0:
-        m_star, s = 0, 1
-    else:
-        m_star, s = _fragment_3_1(norm_info, n0, tol, ell=ell)
 
     # Compute the expm action up to the initial time point.
     if t_0*A_1_norm == 0:
@@ -709,6 +704,13 @@ def _expm_multiply_interval(A, B, start=None, stop=None, num=None,
                 ell=ell)
         m_star_0, s_0 = _fragment_3_1(norm_info_0, n0, tol, ell=ell)
     X[0] = _expm_multiply_simple_core(A, B, t_0, mu, m_star_0, s_0)
+
+    norm_info = LazyOperatorNormInfo(t*A, A_1_norm=abs(t)*A_1_norm, ell=ell)
+    if t*A_1_norm == 0:
+        m_star, s = 0, 1
+    else:
+        m_star, s = _fragment_3_1(norm_info, n0, tol, ell=ell)
+
 
     # Compute the expm action at the rest of the time points.
     if q <= s:

--- a/scipy/sparse/linalg/_expm_multiply.py
+++ b/scipy/sparse/linalg/_expm_multiply.py
@@ -268,7 +268,7 @@ def _expm_multiply_simple(A, B, t=1.0, traceA=None, balance=False):
         m_star, s = 0, 1
     else:
         ell = 2
-        norm_info = LazyOperatorNormInfo(t*A, A_1_norm=t*A_1_norm, ell=ell)
+        norm_info = LazyOperatorNormInfo(t*A, A_1_norm=abs(t)*A_1_norm, ell=ell)
         m_star, s = _fragment_3_1(norm_info, n0, tol, ell=ell)
     return _expm_multiply_simple_core(A, B, t, mu, m_star, s, tol, balance)
 
@@ -689,7 +689,7 @@ def _expm_multiply_interval(A, B, start=None, stop=None, num=None,
     A = A - mu * ident
     A_1_norm = onenormest(A) if is_linear_operator else _exact_1_norm(A)
     ell = 2
-    norm_info = LazyOperatorNormInfo(t*A, A_1_norm=t*A_1_norm, ell=ell)
+    norm_info = LazyOperatorNormInfo(t*A, A_1_norm=abs(t)*A_1_norm, ell=ell)
     if t*A_1_norm == 0:
         m_star, s = 0, 1
     else:
@@ -700,7 +700,7 @@ def _expm_multiply_interval(A, B, start=None, stop=None, num=None,
         m_star_0, s_0 = 0, 1
     else:
         norm_info_0 = LazyOperatorNormInfo(t_0*A,
-                A_1_norm=t_0*A_1_norm, ell=ell)
+                A_1_norm=abs(t_0)*A_1_norm, ell=ell)
         m_star_0, s_0 = _fragment_3_1(norm_info_0, n0, tol, ell=ell)
     X[0] = _expm_multiply_simple_core(A, B, t_0, mu, m_star_0, s_0)
 

--- a/scipy/sparse/linalg/_expm_multiply.py
+++ b/scipy/sparse/linalg/_expm_multiply.py
@@ -696,7 +696,12 @@ def _expm_multiply_interval(A, B, start=None, stop=None, num=None,
         m_star, s = _fragment_3_1(norm_info, n0, tol, ell=ell)
 
     # Compute the expm action up to the initial time point.
-    X[0] = _expm_multiply_simple_core(A, B, t_0, mu, m_star, s)
+    if t_0*A_1_norm == 0:
+        m_star_0, s_0 = 0, 1
+    else:
+        norm_info_0 = LazyOperatorNormInfo(t_0*A, A_1_norm=t_0*A_1_norm, ell=ell)
+        m_star_0, s_0 = _fragment_3_1(norm_info_0, n0, tol, ell=ell)
+    X[0] = _expm_multiply_simple_core(A, B, t_0, mu, m_star_0, s_0)
 
     # Compute the expm action at the rest of the time points.
     if q <= s:


### PR DESCRIPTION
#### Reference issue
Closes gh-16363 and gh-16375

#### What does this fix?
[The article used as the source for the algorithm](http://eprints.maths.manchester.ac.uk/1591/1/alhi11.pdf) requires the computation of two constants, `mu_star` and `s` which depend on (among other things) the `LazyOperatorNormInfo` of `t * A`.

For `_expm_multiply_interval` this `t` is defined as `samples[~0] - samples[0]` (the "width" of the interval). However, for `_expm_multiply_simple` this `t` is simply the `t` at which `expm(t * A)` is being calculated. When `start != 0`, `expm_multiply` will use `_expm_multiply_simple` with `t = t_0 = samples[0]`, _but will still use the same `mu_star` and `s` calculated for the whole interval from `start` to `stop`_.

Additionally, this fixes issues caused by calculating the 1-norm of `tA` as `||tA|| = t * ||A||` instead of `||tA|| = |t| * ||A||`. See #16375.

#### Old Behavior
![expmerror](https://user-images.githubusercontent.com/16090923/172491031-939fd155-7542-4345-98ab-4cb6b2787888.png)

#### New Behavior
![expm_fixed](https://user-images.githubusercontent.com/16090923/172491051-51ad1796-28a4-479a-8fa1-97b6a72c8a47.png)