### PR TITLE
ENH: stats.combine_pvalues: convert output tuple to Bunch

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8477,8 +8477,8 @@ def brunnermunzel(x, y, alternative="two-sided", distribution="t",
     return BrunnerMunzelResult(wbfn, p)
 
 
-SignificanceResult= _make_tuple_bunch('SignificanceResult',
-                                      ['statistic', 'pvalue'], [])
+SignificanceResult = _make_tuple_bunch('SignificanceResult',
+                                       ['statistic', 'pvalue'], [])
 
 
 def combine_pvalues(pvalues, method='fisher', weights=None):

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8477,6 +8477,10 @@ def brunnermunzel(x, y, alternative="two-sided", distribution="t",
     return BrunnerMunzelResult(wbfn, p)
 
 
+CombinePValuesResult = _make_tuple_bunch('CombinePValuesResult',
+                                         ['statistic', 'pvalue'], [])
+
+
 def combine_pvalues(pvalues, method='fisher', weights=None):
     """
     Combine p-values from independent tests that bear upon the same hypothesis.
@@ -8511,10 +8515,13 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
 
     Returns
     -------
-    statistic: float
-        The statistic calculated by the specified method.
-    pval: float
-        The combined p-value.
+    res : CombinePValuesResult
+        An object containing attributes:
+
+        statistic : float
+            The statistic calculated by the specified method.
+        pvalue : float
+            The combined p-value.
 
     Notes
     -----
@@ -8616,7 +8623,7 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
             "'pearson', 'mudholkar_george', 'tippett', and 'stouffer'"
         )
 
-    return (statistic, pval)
+    return CombinePValuesResult(statistic, pval)
 
 
 #####################################

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8477,8 +8477,8 @@ def brunnermunzel(x, y, alternative="two-sided", distribution="t",
     return BrunnerMunzelResult(wbfn, p)
 
 
-CombinePValuesResult = _make_tuple_bunch('CombinePValuesResult',
-                                         ['statistic', 'pvalue'], [])
+SignificanceResult= _make_tuple_bunch('SignificanceResult',
+                                      ['statistic', 'pvalue'], [])
 
 
 def combine_pvalues(pvalues, method='fisher', weights=None):
@@ -8515,7 +8515,7 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
 
     Returns
     -------
-    res : CombinePValuesResult
+    res : SignificanceResult
         An object containing attributes:
 
         statistic : float
@@ -8623,7 +8623,7 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
             "'pearson', 'mudholkar_george', 'tippett', and 'stouffer'"
         )
 
-    return CombinePValuesResult(statistic, pval)
+    return SignificanceResult(statistic, pval)
 
 
 #####################################

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -6800,11 +6800,10 @@ class TestCombinePvalues:
         Z_p, p_p = stats.combine_pvalues([.01, .2, .3], method='pearson')
         assert_approx_equal(0.5 * (Z_f+Z_p), Z, significant=4)
 
+    methods = ["fisher", "pearson", "tippett", "stouffer", "mudholkar_george"]
+
     @pytest.mark.parametrize("variant", ["single", "all", "random"])
-    @pytest.mark.parametrize(
-        "method",
-        ["fisher", "pearson", "tippett", "stouffer", "mudholkar_george"],
-    )
+    @pytest.mark.parametrize("method", methods)
     def test_monotonicity(self, variant, method):
         # Test that result increases monotonically with respect to input.
         m, n = 10, 7
@@ -6827,6 +6826,12 @@ class TestCombinePvalues:
             for pvalues in pvaluess
         ]
         assert np.all(np.diff(combined_pvalues) >= 0)
+
+    @pytest.mark.parametrize("method", methods)
+    def test_result(self, method):
+        res = stats.combine_pvalues([.01, .2, .3], method=method)
+        assert_equal((res.statistic, res.pvalue), res)
+
 
 class TestCdfDistanceValidation:
     """


### PR DESCRIPTION
#### Reference issue
gh-16364
gh-13118

#### What does this implement/fix?
gh-16364 suggests that all statistical functions that currently return tuples should return Bunch objects. This PR converts the tuple returned by `stats.combine_pvalues` to a Bunch.

#### Additional information
Let's get this how we want it so it can serve as an example for new contributors wishing to help address gh-16364.