### PR TITLE
TST, MAINT: adjust 32-bit xfails for HiGHS

### DIFF
--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -2,6 +2,7 @@
 Unit test for Linear Programming
 """
 import sys
+import platform
 
 import numpy as np
 from numpy.testing import (assert_, assert_allclose, assert_equal,
@@ -2199,6 +2200,10 @@ class TestLinprogHiGHSMIP():
     method = "highs"
     options = {}
 
+    @pytest.mark.xfail(condition=(sys.maxsize < 2 ** 32 and
+                       platform.system() == "Linux"),
+                       run=False,
+                       reason="gh-16347")
     def test_mip1(self):
         # solve non-relaxed magic square problem (finally!)
         # also check that values are all integers - they don't always

--- a/scipy/optimize/tests/test_milp.py
+++ b/scipy/optimize/tests/test_milp.py
@@ -57,8 +57,10 @@ def test_milp_iv():
         milp([1, 2, 3], bounds=([1, 2, 3], [set(), 4, 5]))
 
 
-@pytest.mark.xfail(strict=True, reason="Needs to be fixed in `_highs_wrapper`")
+@pytest.mark.xfail(run=False,
+                   reason="Needs to be fixed in `_highs_wrapper`")
 def test_milp_options(capsys):
+    # run=False now because of gh-16347
     message = "Unrecognized options detected: {'ekki'}..."
     options = {'ekki': True}
     with pytest.warns(RuntimeWarning, match=message):


### PR DESCRIPTION
Fixes #16347

* ensure that two HiGHS-related tests
that segfault for 32-bit Linux runs
in the wheels repo are not only marked
with `xfail`, but do not execute at all
(to avoid segfaulting, of course)

* for one of the tests, this will be conditional
on 32-bit platform

* for the other test, there was already an `xfail`
mark so I've just bumped it up to not execute for
now

* I reproduced the two failures in a 32-bit Linux Docker
image (`i386/ubuntu:bionic`), and confirmed full suite passing after the
adjustments