### PR TITLE
DEP: add warning to `sparse.gmres` deprecated kwarg `restrt`

### DIFF
--- a/scipy/optimize/_nonlin.py
+++ b/scipy/optimize/_nonlin.py
@@ -1431,7 +1431,7 @@ class KrylovJacobian(Jacobian):
 
         if self.method is scipy.sparse.linalg.gmres:
             # Replace GMRES's outer iteration with Newton steps
-            self.method_kw['restrt'] = inner_maxiter
+            self.method_kw['restart'] = inner_maxiter
             self.method_kw['maxiter'] = 1
             self.method_kw.setdefault('atol', 0)
         elif self.method in (scipy.sparse.linalg.gcrotmk,

--- a/scipy/sparse/linalg/_isolve/iterative.py
+++ b/scipy/sparse/linalg/_isolve/iterative.py
@@ -544,8 +544,11 @@ def gmres(A, b, x0=None, tol=1e-5, restart=None, maxiter=None, M=None, callback=
           - ``legacy`` (default): same as ``pr_norm``, but also changes the
             meaning of 'maxiter' to count inner iterations instead of restart
             cycles.
-    restrt : int, optional
-        DEPRECATED - use `restart` instead.
+    restrt : int, optional, deprecated
+
+        .. deprecated:: 0.11.0
+           `gmres` keyword argument `restrt` is deprecated infavour of
+           `restart` and will be removed in SciPy 1.12.0.
 
     See Also
     --------
@@ -582,6 +585,10 @@ def gmres(A, b, x0=None, tol=1e-5, restart=None, maxiter=None, M=None, callback=
     elif restart is not None:
         raise ValueError("Cannot specify both restart and restrt keywords. "
                          "Preferably use 'restart' only.")
+    else:
+        msg = ("'gmres' keyword argument 'restrt' is deprecated infavour of "
+               "'restart' and will be removed in SciPy 1.12.0.")
+        warnings.warn(msg, DeprecationWarning, stacklevel=2)
 
     if callback is not None and callback_type is None:
         # Warn about 'callback_type' semantic changes.

--- a/scipy/sparse/linalg/_isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_iterative.py
@@ -781,3 +781,10 @@ class TestGMRES:
         assert info == 20
         assert count[0] == 21
         x_cb(x)
+
+    def test_restrt_dep(self):
+        with pytest.warns(
+            DeprecationWarning,
+            match="'gmres' keyword argument 'restrt'"
+        ):
+            gmres(np.array([1]), np.array([1]), restrt=10)


### PR DESCRIPTION
#### What does this implement/fix?
<!--Please explain your changes.-->
The keyword argument `restrt` of `sparse.gmres` has been deprecated in documentation only. This pr raises and warning and adds a timeline for removal.
#### Additional information
<!--Any additional information you think is important.-->
cc. @h-vetinari another one for the list :smile: 