### PR TITLE
MAINT: use correct type for element wise comparison

### DIFF
--- a/scipy/io/matlab/_miobase.py
+++ b/scipy/io/matlab/_miobase.py
@@ -421,7 +421,7 @@ def arr_to_chars(arr):
     arr = np.ndarray(shape=dims,
                      dtype=arr_dtype_number(arr, 1),
                      buffer=arr)
-    empties = [arr == '']
+    empties = [arr == np.array([''], dtype=arr_dtype_number(arr, 1))]
     if not np.any(empties):
         return arr
     arr = arr.copy()

--- a/scipy/io/matlab/_miobase.py
+++ b/scipy/io/matlab/_miobase.py
@@ -421,7 +421,7 @@ def arr_to_chars(arr):
     arr = np.ndarray(shape=dims,
                      dtype=arr_dtype_number(arr, 1),
                      buffer=arr)
-    empties = [arr == np.array([''], dtype=arr_dtype_number(arr, 1))]
+    empties = [arr == np.array('', dtype=arr.dtype)]
     if not np.any(empties):
         return arr
     arr = arr.copy()


### PR DESCRIPTION
Fixes `FutureWarning` from NumPy on `main`.

```python-traceback
scipy/io/matlab/_miobase.py:424: in arr_to_chars
    empties = [arr == '']
E   FutureWarning: elementwise comparison failed; returning scalar instead, but in the future will perform elementwise comparison
        arr        = array([[b'p', b'y', b't', b'h', b'o', b'n']], dtype='|S1')

```


p.s. maybe we could have a NumPy label to have stats on how much NumPy breaks the CI. That could be interesting to see (not to blame NumPy at all, just to be aware of it and motivate things like pinning x upper versions for the release, etc.).