### PR TITLE
Add 'exponential' interpolation to `scipy.interpolate.interp1d`

### DIFF
--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -490,7 +490,7 @@ class interp1d(_Interpolator1D):
         # interpolation methods, in order to avoid circular references to self
         # stored in the bound instance methods, and therefore delayed garbage
         # collection.  See: https://docs.python.org/reference/datamodel.html
-        if kind in ('linear', 'nearest', 'nearest-up', 'previous', 'next'):
+        if kind in ('linear', 'exponential','nearest', 'nearest-up', 'previous', 'next'):
             # Make a "view" of the y array that is rotated to the interpolation
             # axis.
             minval = 2

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -684,7 +684,7 @@ class interp1d(_Interpolator1D):
         b = np.log((y_hi / y_lo)) / (x_hi - x_lo)[:, None]
 
         # 5. Calculate the actual value for each entry in x_new.
-        y_new = np.exp(b*(x_new))/np.exp(b*(x_lo[:, None])) * y_lo
+        y_new = np.exp(b*(x_new[:, None]))/np.exp(b*(x_lo[:, None])) * y_lo
 
         return y_new
 

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -455,8 +455,8 @@ class interp1d(_Interpolator1D):
         elif isinstance(kind, int):
             order = kind
             kind = 'spline'
-        elif kind not in ('linear', 'exponential', 'nearest', 'nearest-up', 'previous',
-                          'next'):
+        elif kind not in ('linear', 'exponential', 'nearest', 'nearest-up',
+                          'previous', 'next'):
             raise NotImplementedError("%s is unsupported: Use fitpack "
                                       "routines for other types." % kind)
         x = array(x, copy=self.copy)
@@ -490,7 +490,8 @@ class interp1d(_Interpolator1D):
         # interpolation methods, in order to avoid circular references to self
         # stored in the bound instance methods, and therefore delayed garbage
         # collection.  See: https://docs.python.org/reference/datamodel.html
-        if kind in ('linear', 'exponential','nearest', 'nearest-up', 'previous', 'next'):
+        if kind in ('linear', 'exponential','nearest', 'nearest-up',
+                    'previous', 'next'):
             # Make a "view" of the y array that is rotated to the interpolation
             # axis.
             minval = 2
@@ -656,7 +657,7 @@ class interp1d(_Interpolator1D):
         y_new = slope*(x_new - x_lo)[:, None] + y_lo
 
         return y_new
-      
+
     def _call_exponential(self, x_new):
         # 2. Find where in the original data, the values to interpolate
         #    would be inserted.
@@ -668,7 +669,8 @@ class interp1d(_Interpolator1D):
         #    of x_new[n] = x[0]
         x_new_indices = x_new_indices.clip(1, len(self.x)-1).astype(int)
 
-        # 4. Calculate the exponential slope of regions that each x_new value falls in.
+        # 4. Calculate the exponential slope of regions that each x_new value
+        # falls in.
         lo = x_new_indices - 1
         hi = x_new_indices
 
@@ -685,7 +687,7 @@ class interp1d(_Interpolator1D):
         y_new = np.exp(b*(x_new))/np.exp(b*(x_lo[:, None])) * y_lo
 
         return y_new
-      
+
     def _call_nearest(self, x_new):
         """ Find nearest neighbor interpolated y_new = f(x_new)."""
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### What does this implement/fix?
Add 1-dimensional exponential interpolation. 
This is similar to the linear interpolation `f(x) = a*x+b` between two data points, but with `g(x) = a*exp(b*x)`.
This is useful for interpolation of an exponential curve (straight lines on a logarithmic x axis).


#### Additional information
The blue plot is a linear interpolation on a logarithmic scale.
The orange plot is the new exponential interpolation.

![2022-06-14 11_00_30-Interpolate](https://user-images.githubusercontent.com/4533248/173538203-69131ffe-1b9e-4d8f-9fdb-0b131d538c49.png)

In the same way one could add a logarithmic interpolation.