### PR TITLE
Added class ExactKrylovJacobian

### DIFF
--- a/scipy/optimize/_nonlin.py
+++ b/scipy/optimize/_nonlin.py
@@ -1507,6 +1507,21 @@ class KrylovJacobian(Jacobian):
             if hasattr(self.preconditioner, 'setup'):
                 self.preconditioner.setup(x, f, func)
 
+class ExactKrylovJacobian(KrylovJacobian):
+
+    def __init__(self,exactgrad, rdiff=None, method='lgmres', inner_maxiter=20,inner_M=None, outer_k=10, **kw):
+
+        KrylovJacobian.__init__(self, rdiff, method, inner_maxiter,inner_M, outer_k, **kw)
+        self.exactgrad = exactgrad
+
+    def matvec(self, v):
+        return self.exactgrad(self.x0,v)
+
+    def rmatvec(self, v):
+        return self.exactgrad(self.x0,v)
+        
+    
+
 
 #------------------------------------------------------------------------------
 # Wrapper functions


### PR DESCRIPTION
Hi,

This PR addresses issue #15367 

I've been using this code for a while now in a personal project of mine.
I use it as a parametrized substitution of ```scipy.optimize.nonlin.KrylovJacobian```. It showed very good convergence behavior near a solution, where massive cancellation is avoided.
My usage case looks something like this:

```
if (Use_exact_Jacobian):

    FGrad = lambda x,dx : Compute_action_hess_mul(x,dx,callfun)
    jacobian = ExactKrylovJacobian(exactgrad=FGrad,**jac_options)

else: 
    jacobian = scipy.optimize.nonlin.KrylovJacobian(**jac_options)

x0 = np.copy(best_sol.x)
opt_result = scipy.optimize.nonlin.nonlin_solve(F=F,x0=x0,jacobian=jacobian,verbose=disp_scipy_opt,maxiter=maxiter,f_tol=gradtol,line_search=line_search,callback=best_sol.update,raise_exception=False)
                
```

I have little experience contribution to big open source project, so don't hesitate to tell me if more info is required etc...

In particular, I have little understanding of the inner workings of scipy.optimize, so I am not sure how to best propagate these changes at the user level.

Cheers,


