### PR TITLE
DEP: sharpen deprecation warning for `spmatrix` attributes

### DIFF
--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -742,17 +742,24 @@ class spmatrix:
     def __getattr__(self, attr):
         if attr == 'A':
             if self._is_array:
-                warn(np.VisibleDeprecationWarning(
-                    "Please use `.todense()` instead"
-                ))
+                warn(
+                    "Attribute 'A' is deprecated in favour of method "
+                    "'.toarray()' instead and will be removed in SciPy "
+                    "1.12.0",
+                    DeprecationWarning,
+                    stacklevel=2
+                )
             return self.toarray()
         elif attr == 'T':
             return self.transpose()
         elif attr == 'H':
             if self._is_array:
-                warn(np.VisibleDeprecationWarning(
-                    "Please use `.conj().T` instead"
-                ))
+                warn(
+                    "Attribute 'H' is deprecated in favour of '.conj().T' "
+                    "instead and will be removed in SciPy 1.12.0",
+                    DeprecationWarning,
+                    stacklevel=2
+                )
             return self.getH()
         elif attr == 'real':
             return self._real()

--- a/scipy/sparse/tests/test_array_api.py
+++ b/scipy/sparse/tests/test_array_api.py
@@ -139,13 +139,13 @@ def test_dense_divide(A):
 
 @parametrize_sparrays
 def test_no_A_attr(A):
-    with pytest.warns(np.VisibleDeprecationWarning):
+    with pytest.warns(DeprecationWarning, match="Attribute 'A'"):
         A.A
 
 
 @parametrize_sparrays
 def test_no_H_attr(A):
-    with pytest.warns(np.VisibleDeprecationWarning):
+    with pytest.warns(DeprecationWarning, match="Attribute 'H'"):
         A.H
 
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
Sharpens some preexisting deprecation warning for attributes `A` and `H` of `spmatrix` with a timeline for removal. 
#### Additional information
<!--Any additional information you think is important.-->
cc. @h-vetinari another for the list