### PR TITLE
MAINT: stats.rankdata: change default to nan_policy='propagate'

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -9038,7 +9038,7 @@ def _square_of_sums(a, axis=0):
         return float(s) * s
 
 
-def rankdata(a, method='average', *, axis=None, nan_policy='omit'):
+def rankdata(a, method='average', *, axis=None, nan_policy='propagate'):
     """Assign ranks to data, dealing with ties appropriately.
 
     By default (``axis=None``), the data array is first flattened, and a flat
@@ -9071,23 +9071,23 @@ def rankdata(a, method='average', *, axis=None, nan_policy='omit'):
     axis : {None, int}, optional
         Axis along which to perform the ranking. If ``None``, the data array
         is first flattened.
-    nan_policy : {'omit', 'propagate', 'raise'}, optional
+    nan_policy : {'propagate', 'omit', 'raise'}, optional
         Defines how to handle when input contains nan.
-        The following options are available (default is 'omit'):
+        The following options are available (default is 'propagate'):
 
-          * 'omit': performs the calculations ignoring nan values
           * 'propagate': propagates nans through the rank calculation
+          * 'omit': performs the calculations ignoring nan values
           * 'raise': raises an error
 
         .. note::
 
+            When `nan_policy` is 'propagate', the output is an array of *all*
+            nans because ranks relative to nans in the input are undefined.
             When `nan_policy` is 'omit', nans in `a` are ignored when ranking
             the other values, and the corresponding locations of the output
             are nan. This behavior is the default because it is intuitive and
             compatible with the behavior before the `nan_policy` parameter
             was introduced.
-            When `nan_policy` is 'propagate', the output is an array of *all*
-            nans because ranks relative to nans in the input are undefined.
 
         .. versionadded:: 1.10
 
@@ -9120,10 +9120,10 @@ def rankdata(a, method='average', *, axis=None, nan_policy='omit'):
     >>> rankdata([[0, 2, 2], [3, 2, 5]], axis=1)
     array([[1. , 2.5, 2.5],
            [2. , 1. , 3. ]])
-    >>> rankdata([0, 2, 3, np.nan, -2, np.nan], nan_policy="omit")
-    array([ 2.,  3.,  4., nan,  1., nan])
     >>> rankdata([0, 2, 3, np.nan, -2, np.nan], nan_policy="propagate")
     array([nan, nan, nan, nan, nan, nan])
+    >>> rankdata([0, 2, 3, np.nan, -2, np.nan], nan_policy="omit")
+    array([ 2.,  3.,  4., nan,  1., nan])
 
     """
     if method not in ('average', 'min', 'max', 'dense', 'ordinal'):


### PR DESCRIPTION
#### Reference issue
gh-16140

#### What does this implement/fix?
gh-16140 added `nan_policy` to `stats.rankdata`, but the default value is `'omit'` instead of the usual `'propagate'`. I merged it, but I'm reconsidering this choice of default. I thought I'd open this for further discussion (and to set a precedent for other `nan_policy` implementations where `'propagate'` doesn't just mean "run the code without considering NaNs").

On one hand, `'omit'` is a good default because it more closely matches the behavior before the introduction of the `nan_policy`.

Before `nan_policy`:
```python3
from scipy.stats import rankdata
rankdata([0, 2, 3, 2, np.nan, np.nan])  # array([1.  2.5 4.  2.5 5.  6. ])
```

After gh-16140:
```python3
rankdata([0, 2, 3, 2, np.nan, np.nan])  # array([1.  2.5 4.  2.5 np.nan np.nan ])
rankdata([0, 2, 3, 2, np.nan, np.nan], nan_policy='omit')  # same as above
rankdata([0, 2, 3, 2, np.nan, np.nan], nan_policy='propagate')  # array([nan, nan, nan, nan, nan, nan])
```

But the behavior of the original code wasn't intentional; it was an artifact of the implementation. So this PR suggests making the default `nan_policy='propagate'` like pretty much every other stats function.

One other thought is that `rankdata` might be easier to use if `nan_policy='omit'` were the default - but the same could be said of any other stats function. The counter-argument is that it is also easier to make mistakes you don't catch if `nan_policy='omit'` is the default. For better or for worse, `nan_policy='propagate'` is the default in other functions, so I think that `stats` as a whole would be easier to use if the user doesn't need to remember (or look up) a different default for each function.

#### Additional information
gh-13572 added `nan_policy` with default `'propagate'` to `stats.percentileofscore`. It's worth mentioning because, like `rankdata`, `nan_policy='propagate'` changes the behavior compared to "just run the code without considering NaNs" (as the code did before the PR; see gh-2868).