### PR TITLE
MAINT: optimize.brute should coerce non-tuple args to tuple

### DIFF
--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -3489,6 +3489,9 @@ def brute(func, ranges, args=(), Ns=20, full_output=0, finish=fmin,
     if (N > 1):
         grid = np.reshape(grid, (inpt_shape[0], np.prod(inpt_shape[1:]))).T
 
+    if not isinstance(args, tuple):
+        args = (args,)
+
     wrapped_func = _Brute_Wrapper(func, args)
 
     # iterate over input arrays, possibly in parallel

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -3489,7 +3489,7 @@ def brute(func, ranges, args=(), Ns=20, full_output=0, finish=fmin,
     if (N > 1):
         grid = np.reshape(grid, (inpt_shape[0], np.prod(inpt_shape[1:]))).T
 
-    if not isinstance(args, tuple):
+    if not np.iterable(args):
         args = (args,)
 
     wrapped_func = _Brute_Wrapper(func, args)

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -2203,10 +2203,10 @@ class TestBrute:
     def test_coerce_args_param(self):
         # optimize.brute should coerce non-iterable args to a tuple.
         def f(x, *args):
-            return x ** args
+            return x ** args[0]
 
         resbrute = optimize.brute(f, (slice(-4, 4, .25),), args=2)
-        assert_almost_equal(resbrute, 0)
+        assert_allclose(resbrute, 0)
 
 
 def test_cobyla_threadsafe():

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -2200,6 +2200,16 @@ class TestBrute:
                           match=r'Either final optimization did not succeed'):
             optimize.brute(func, self.rranges, args=self.params, disp=True)
 
+    def test_coerce_args_param(self):
+        # As for optimize.minimize, optimize.brute should coerce non-tuple args.
+        # See https://stackoverflow.com/q/72629505/4316405 for a case where
+        # this previously caused confusion.
+        def f(x, *args):
+            return x ** args
+
+        resbrute = optimize.brute(f, (slice(-4, 4, .25),), args=2)
+        assert_almost_equal(resbrute, 0)
+
 
 def test_cobyla_threadsafe():
 

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -2201,9 +2201,7 @@ class TestBrute:
             optimize.brute(func, self.rranges, args=self.params, disp=True)
 
     def test_coerce_args_param(self):
-        # As for optimize.minimize, optimize.brute should coerce non-tuple args.
-        # See https://stackoverflow.com/q/72629505/4316405 for a case where
-        # this previously caused confusion.
+        # optimize.brute should coerce non-iterable args to a tuple.
         def f(x, *args):
             return x ** args
 


### PR DESCRIPTION
See [this SO post](https://stackoverflow.com/q/72629505/4316405) for context. Basically: optimize.minimize coerces non-tuple args to tuples, but optimize.brute does not. This PR corrects that inconsistency.