### PR TITLE
MAINT: Cleaner f2py

### DIFF
--- a/scipy/linalg/flapack_other.pyf.src
+++ b/scipy/linalg/flapack_other.pyf.src
@@ -29,9 +29,10 @@ subroutine <prefix2>gejsv(joba,jobu,jobv,jobr,jobt,jobp,m,n,a,lda,sva,u,ldu,v,ld
     <ftype2> intent(in,copy), dimension(lda, n) :: a
     integer intent(hide), depend(a) :: lda = max(1, shape(a, 0))
     <ftype2> intent(out), depend(n), dimension(n) :: sva
-    <ftype2> intent(out), depend(ldu, n, jobt, jobu, m), dimension(((jobt == 0)&&(jobu == 3)?0:m), ((jobt == 0)&&(jobu == 3)?0:(jobu == 1?m:n))) :: u
+    ! TODO: Use arithmetic because f2py does not like nested conditionals
+    <ftype2> intent(out), depend(ldu, n, jobt, jobu, m), dimension(((jobt == 0)*(jobu == 3)?0:m), ((jobt == 0)*(jobu == 3)?0:(jobu == 1?m:n))) :: u
     integer intent(hide), depend(m, jobu) :: ldu = max(1, (jobu < 3?m:1))
-    <ftype2> intent(out), depend(ldv, n, jobt, jobv), dimension(((jobt == 0)&&(jobv == 3)?0:ldv),((jobt == 0)&&(jobv == 3)?0:n)) :: v
+    <ftype2> intent(out), depend(ldv, n, jobt, jobv), dimension(((jobt == 0)*(jobv == 3)?0:ldv),((jobt == 0)*(jobv == 3)?0:n)) :: v
     integer intent(hide), depend(n, jobv) :: ldv = max(1, (jobv < 3?n:1))
     <ftype2> intent(hide), depend(lwork), dimension(lwork) :: work
     <ftype2> intent(out), dimension(7) :: workout
@@ -563,7 +564,7 @@ subroutine <prefix2c>uncsd(compute_u1,compute_u2,compute_v1t,compute_v2t,trans,s
     !  Moreover, the rank of the identity matrices are min(p, q) - r,
     !  min(p, m - q) - r, min(m - p, q) - r, and min(m - p, m - q) - r
     !  respectively.
-    
+
 
     callstatement (*f2py_func)((compute_u1?"Y":"N"),(compute_u2?"Y":"N"),(compute_v1t?"Y":"N"),(compute_v2t?"Y":"N"),(trans?"T":"N"),(signs?"O":"D"),&m,&p,&q,x11,&ldx11,x12,&ldx12,x21,&ldx21,x22,&ldx22,theta,u1,&ldu1,u2,&ldu2,v1t,&ldv1t,v2t,&ldv2t,work,&lwork,rwork,&lrwork,iwork,&info)
     callprotoargument char*,char*,char*,char*,char*,char*,F_INT*,F_INT*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*
@@ -1311,7 +1312,7 @@ subroutine <prefix>ppcon(lower,n,ap,anorm,rcond,work,irwork,info,L)
     threadsafe
     callstatement (*f2py_func)((lower?"L":"U"),&n,ap,&anorm,&rcond,work,irwork,&info)
     callprotoargument char*,F_INT*,<ctype>*,<ctypereal>*,<ctypereal>*,<ctype>*,<F_INT,F_INT,float,double>*,F_INT*
- 
+
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
     integer intent(in),check(n>=0) :: n
     <ftype> dimension(L),intent(in) :: ap
@@ -1321,7 +1322,7 @@ subroutine <prefix>ppcon(lower,n,ap,anorm,rcond,work,irwork,info,L)
     <ftype> depend(n),dimension(<3*n,3*n,2*n,2*n>),intent(hide,cache):: work
     <integer,integer,real, double precision> dimension(n), intent(hide,cache),depend(n) :: irwork
     integer intent(out):: info
- 
+
 end subroutine <prefix>ppcon
 
 subroutine <prefix>ppsv(lower,n,nrhs,ap,b,ldb,info,L)
@@ -1339,7 +1340,7 @@ subroutine <prefix>ppsv(lower,n,nrhs,ap,b,ldb,info,L)
     threadsafe
     callstatement (*f2py_func)((lower?"L":"U"),&n,&nrhs,ap,b,&ldb,&info)
     callprotoargument char*,F_INT*,F_INT*,<ctype>*,<ctype>*,F_INT*,F_INT*
-    
+
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
     integer intent(in),check(n>=0) :: n
     integer intent(hide),depend(b) :: ldb = max(1, shape(b,0))
@@ -1354,7 +1355,7 @@ end subroutine <prefix>ppsv
 subroutine <prefix>pptrf(lower,n,ap,info,L)
     ! ?PPTRF computes the Cholesky factorization of a symmetric/hermitian
     ! positive definite matrix A stored in packed format.
-    ! 
+    !
     ! The factorization has the form
     !    A = U**T * U,  if UPLO = 'U', or
     !    A = L  * L**T,  if UPLO = 'L',
@@ -1362,7 +1363,7 @@ subroutine <prefix>pptrf(lower,n,ap,info,L)
     threadsafe
     callstatement (*f2py_func)((lower?"L":"U"),&n,ap,&info)
     callprotoargument char*,F_INT*,<ctype>*,F_INT*
-    
+
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
     integer intent(in),check(n>=0) :: n
     <ftype> dimension(L),intent(in,out,copy,out=ul) :: ap
@@ -1378,7 +1379,7 @@ subroutine <prefix>pptri(lower,n,ap,info,L)
     threadsafe
     callstatement (*f2py_func)((lower?"L":"U"),&n,ap,&info)
     callprotoargument char*,F_INT*,<ctype>*,F_INT*
-    
+
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
     integer intent(in),check(n>=0) :: n
     <ftype> dimension(L),intent(in,out,copy,out=uli) :: ap
@@ -1394,7 +1395,7 @@ subroutine <prefix>pptrs(lower,n,nrhs,ap,b,ldb,info,L)
     threadsafe
     callstatement (*f2py_func)((lower?"L":"U"),&n,&nrhs,ap,b,&ldb,&info)
     callprotoargument char*,F_INT*,F_INT*,<ctype>*,<ctype>*,F_INT*,F_INT*
-    
+
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
     integer intent(in),check(n>=0) :: n
     integer intent(hide),depend(b) :: ldb = max(1, shape(b,0))

--- a/scipy/linalg/flapack_sym_herm.pyf.src
+++ b/scipy/linalg/flapack_sym_herm.pyf.src
@@ -38,18 +38,18 @@ subroutine <prefix2>syev_lwork(lower,n,w,a,lda,work,lwork,info)
 
     callstatement (*f2py_func)("N",(lower?"L":"U"),&n,&a,&lda,&w,&work,&lwork,&info)
     callprotoargument char*,char*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*
-    
+
      integer intent(in):: n
      integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
-     
+
      integer intent(hide),depend(n):: lda = MAX(1, n)
      <ftype2> intent(hide):: a
      <ftype2> intent(hide):: w
      integer intent(hide):: lwork = -1
-    
+
      <ftype2> intent(out):: work
      integer intent(out):: info
-     
+
 end subroutine <prefix2>syev_lwork
 
 subroutine <prefix2c>heev(compute_v,lower,n,w,a,lda,work,lwork,rwork,info)
@@ -91,7 +91,7 @@ subroutine <prefix2c>heev_lwork(lower,n,w,a,lda,work,lwork,rwork,info)
 
      integer intent(in):: n
      integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
-     
+
      integer intent(hide),depend(n):: lda = MAX(1, n)
      <ftype2c> intent(hide):: a
      <ftype2> intent(hide):: w
@@ -100,7 +100,7 @@ subroutine <prefix2c>heev_lwork(lower,n,w,a,lda,work,lwork,rwork,info)
 
      <ftype2c> intent(out):: work
      integer intent(out):: info
-     
+
 end subroutine <prefix2c>heev_lwork
 
 subroutine <prefix2>syevd(compute_v,lower,n,w,a,lda,work,lwork,iwork,liwork,info)
@@ -145,13 +145,13 @@ subroutine <prefix2>syevd_lwork(compute_v,lower,n,w,a,lda,work,lwork,iwork,liwor
     integer intent(in):: n
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
     integer optional,intent(in),check(compute_v==0||compute_v==1) :: compute_v = 1
-    
+
     integer intent(hide):: lda = MAX(1,n)
     <ftype2> intent(hide):: a
     <ftype2> intent(hide):: w
     integer intent(hide):: lwork = -1
     integer intent(hide):: liwork = -1
-    
+
     <ftype2> intent(out):: work
     integer intent(out):: iwork
     integer intent(out):: info
@@ -194,23 +194,23 @@ end subroutine <prefix2c>heevd
 
 subroutine <prefix2c>heevd_lwork(compute_v,lower,n,w,a,lda,work,lwork,iwork,liwork,rwork,lrwork,info)
     ! LWORK routines for heevd
-    
+
     fortranname <prefix2c>heevd
-    
+
     callstatement (*f2py_func)((compute_v?"V":"N"),(lower?"L":"U"),&n,&a,&lda,&w,&work,&lwork,&rwork,&lrwork,&iwork,&liwork,&info)
     callprotoargument char*,char*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*,F_INT*
 
     integer intent(in):: n
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
     integer optional,intent(in),check(compute_v==0||compute_v==1) :: compute_v = 1
-    
+
     integer intent(hide):: lda=MAX(1,n)
     <ftype2c> intent(hide):: a
     <ftype2> intent(hide):: w
     integer intent(hide):: lwork=-1
     integer intent(hide):: liwork=-1
     integer intent(hide):: lrwork=-1
-    
+
     <ftype2c> intent(out):: work
     <ftype2> intent(out):: rwork
     integer intent(out):: iwork
@@ -775,7 +775,8 @@ subroutine <prefix2>syevr(compute_v,range,lower,n,a,lda,vl,vu,il,iu,abstol,w,z,m
     <ftype2> intent(out),dimension((compute_v?MAX(0,n):0),(compute_v?(*range=='I'?iu-il+1:MAX(1,n)):0)),depend(n,compute_v,range,iu,il) :: z
     integer intent(out) :: m
     ! Only returned if range=='A' or range=='I' and il, iu = 1, n
-    integer intent(out),dimension((compute_v?(2*(*range=='A'||(*range=='I' && iu-il+1==n)?n:0)):0)),depend(n,iu,il,compute_v,range) :: isuppz
+    ! TODO: Use arithmetic because f2py does not like nested conditionals
+    integer intent(out),dimension((compute_v?(2*((*range=='A')*((*range=='I')+(iu-il+1==n))?n:0)):0)),depend(n,iu,il,compute_v,range) :: isuppz
     integer intent(out) :: info
 
 end subroutine <prefix2>syevr
@@ -900,7 +901,7 @@ subroutine <prefix2>syevx(compute_v,range,lower,n,a,lda,vl,vu,il,iu,abstol,w,z,m
 
     callstatement (*f2py_func)((compute_v?"V":"N"),range,(lower?"L":"U"),&n,a,&lda,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,work,&lwork,iwork,ifail,&info)
     callprotoargument char*,char*,char*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*,F_INT*
-    
+
     integer optional,intent(in),check(compute_v==1||compute_v==0):: compute_v = 1
     character optional,intent(in),check(*range=='A'||*range=='V' ||*range=='I') :: range='A'
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
@@ -923,7 +924,7 @@ subroutine <prefix2>syevx(compute_v,range,lower,n,a,lda,vl,vu,il,iu,abstol,w,z,m
     integer intent(out) :: m
     integer intent(out),dimension((compute_v?n:0)),depend(compute_v,n):: ifail
     integer intent(out) :: info
-    
+
 end subroutine <prefix2>syevx
 
 subroutine <prefix2>syevx_lwork(lower,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,work,lwork,iwork,ifail,info)
@@ -932,7 +933,7 @@ subroutine <prefix2>syevx_lwork(lower,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,work,
     fortranname <prefix2>syevx
     callstatement (*f2py_func)("N","A",(lower?"L":"U"),&n,&a,&lda,&vl,&vu,&il,&iu,&abstol,&m,&w,&z,&ldz,&work,&lwork,&iwork,&ifail,&info)
     callprotoargument char*,char*,char*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*,F_INT*
-    
+
     integer intent(in):: n
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
 
@@ -950,7 +951,7 @@ subroutine <prefix2>syevx_lwork(lower,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,work,
     integer intent(hide):: lwork = -1
     integer intent(hide):: iwork
     integer intent(hide):: ifail
-        
+
     <ftype2> intent(out):: work
     integer intent(out):: info
 
@@ -964,7 +965,7 @@ subroutine <prefix2c>heevx(compute_v,range,lower,n,a,lda,vl,vu,il,iu,abstol,w,z,
 
     callstatement (*f2py_func)((compute_v?"V":"N"),range,(lower?"L":"U"),&n,a,&lda,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,work,&lwork,rwork,iwork,ifail,&info)
     callprotoargument char*,char*,char*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*
-    
+
     integer optional,intent(in),check(compute_v==1||compute_v==0):: compute_v = 1
     character optional,intent(in),check(*range=='A'||*range=='V' ||*range=='I') :: range='A'
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
@@ -988,7 +989,7 @@ subroutine <prefix2c>heevx(compute_v,range,lower,n,a,lda,vl,vu,il,iu,abstol,w,z,
     integer intent(out) :: m
     integer intent(out),dimension(compute_v*n),depend(compute_v,n):: ifail
     integer intent(out) :: info
-    
+
 end subroutine <prefix2c>heevx
 
 subroutine <prefix2c>heevx_lwork(lower,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,work,lwork,rwork,iwork,ifail,info)
@@ -997,7 +998,7 @@ subroutine <prefix2c>heevx_lwork(lower,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,work
     fortranname <prefix2c>heevx
     callstatement (*f2py_func)("N","A",(lower?"L":"U"),&n,&a,&lda,&vl,&vu,&il,&iu,&abstol,&m,&w,&z,&ldz,&work,&lwork,&rwork,&iwork,&ifail,&info)
     callprotoargument char*,char*,char*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*
-    
+
     integer intent(in):: n
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
 
@@ -1016,7 +1017,7 @@ subroutine <prefix2c>heevx_lwork(lower,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,work
     <ftype2> intent(hide):: rwork
     integer intent(hide):: iwork
     integer intent(hide):: ifail
-        
+
     <ftype2c> intent(out):: work
     integer intent(out):: info
 
@@ -1200,7 +1201,7 @@ subroutine <prefix2>sygvx(itype,jobz,range,uplo,n,a,lda,b,ldb,vl,vu,il,iu,abstol
 
     callstatement (*f2py_func)(&itype,jobz,range,uplo,&n,a,&lda,b,&ldb,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,work,&lwork,iwork,ifail,&info)
     callprotoargument F_INT*,char*,char*,char*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*,F_INT*
-    
+
     integer optional,intent(in),check(itype>0||itype<4) :: itype=1
     character optional,intent(in),check(*jobz=='N'||*jobz=='V') :: jobz="V"
     character optional,intent(in),check(*uplo=='U'||*uplo=='L') :: uplo="L"
@@ -1270,7 +1271,7 @@ subroutine <prefix2c>hegvx(itype,jobz,range,uplo,n,a,lda,b,ldb,vl,vu,il,iu,absto
     ! range of values or a range of indices for the desired eigenvalues.
     callstatement (*f2py_func)(&itype,jobz,range,uplo,&n,a,&lda,b,&ldb,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,work,&lwork,rwork,iwork,ifail,&info)
     callprotoargument F_INT*,char*,char*,char*,F_INT*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,<ctype2>*,F_INT*,F_INT*,<ctype2>*,F_INT*,<ctype2>*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*
-    
+
     integer optional,intent(in),check(itype>0||itype<4) :: itype=1
     character optional,intent(in),check(*jobz=='N'||*jobz=='V') :: jobz='V'
     character optional,intent(in),check(*uplo=='U'||*uplo=='L') :: uplo='L'

--- a/scipy/special/specfun.pyf
+++ b/scipy/special/specfun.pyf
@@ -70,14 +70,14 @@ python module _specfun ! in
             double precision intent(in), check(v>=1) :: v
             double precision intent(in) :: x
             double precision intent(out) :: vm
-            double precision intent(out),depend(v),dimension((int)v+1) :: vl
-            double precision intent(out),depend(v),dimension((int)v+1) :: dl
+            double precision intent(out),depend(v),dimension(v+1) :: vl
+            double precision intent(out),depend(v),dimension(v+1) :: dl
         end subroutine lamv
         subroutine pbdv(v,x,dv,dp,pdf,pdd) ! in :_specfun:specfun.f
-            double precision intent(in),check((abs((int)v)+2)>=2) :: v
+            double precision intent(in),check((abs(v)+2)>=2) :: v
             double precision intent(in) :: x
-            double precision intent(out),depend(v),dimension(abs((int)v)+2) :: dv
-            double precision intent(out),depend(v),dimension(abs((int)v)+2) :: dp
+            double precision intent(out),depend(v),dimension(abs(v)+2) :: dv
+            double precision intent(out),depend(v),dimension(abs(v)+2) :: dp
             double precision intent(out) :: pdf
             double precision intent(out) :: pdd
         end subroutine pbdv


### PR DESCRIPTION
Running NumPy + SciPy on M1, I've run into various problems with linear algebra, including with SVD in https://github.com/numpy/numpy/issues/21756 / https://github.com/xianyi/OpenBLAS/issues/3654. But another problem (maybe related or not, unclear so far) is that sometimes linear algebraic operations give incorrect results, including (at least) those having to do with symmetric eigen decompositions.

I will boil this down to minimal examples/data at some point, but I noticed when building SciPy locally on M1 at least I get some warnings for `ssyevr` and a few other functions that might be problematic. Can warnings like this be safely ignored, or might they actually be problematic (it seems like they probably are)?
```
...
			Block: ssyevr
/Users/larsoner/python/numpy/numpy/f2py/symbolic.py:1508: ExprWarning: fromstring: treating "'A'||" as symbol (original=(compute_v?(2*(*range=='A'||(*range=='I' && iu-il+1==n)?n:0)):0))
  ewarn(
/Users/larsoner/python/numpy/numpy/f2py/symbolic.py:1508: ExprWarning: fromstring: treating "'I' && iu" as symbol (original=(compute_v?(2*(*range=='A'||(*range=='I' && iu-il+1==n)?n:0)):0))
  ewarn(
...
			Block: sgejsv
/Users/larsoner/python/numpy/numpy/f2py/symbolic.py:1508: ExprWarning: fromstring: treating '(jobt == 0)&&' as symbol (original=((jobt == 0)&&(jobu == 3)?0:m))
  ewarn(
/Users/larsoner/python/numpy/numpy/f2py/symbolic.py:1508: ExprWarning: fromstring: treating '(jobt == 0)&&' as symbol (original=((jobt == 0)&&(jobu == 3)?0:(jobu == 1?m:n)))
  ewarn(
/Users/larsoner/python/numpy/numpy/f2py/symbolic.py:1508: ExprWarning: fromstring: treating '(jobt == 0)&&' as symbol (original=((jobt == 0)&&(jobv == 3)?0:ldv))
  ewarn(
/Users/larsoner/python/numpy/numpy/f2py/symbolic.py:1508: ExprWarning: fromstring: treating '(jobt == 0)&&' as symbol (original=((jobt == 0)&&(jobv == 3)?0:n))
  ewarn(
...
<later, using RuntimeError in place of ewarn in f2py>
...
			Block: lamv
RuntimeError: fromstring: treating '(int)v' as symbol (original=(int)v+1)
```

If they are indeed potentially problematic, I suggest we 1) fix them, 2) add a command-line option to `f2py` to raise an error when this warning occurs, and 3) start using this command-line option if available.

I've worked around the parsing issues in f2py here by using arithmetic equivalents to the logical operators (though they don't short-circuit it's probably negligible speed loss) so that with the `ewarn` in `f2py` replaced by `raise RuntimeError` now `python setup.py develop` works, meaning that there should no longer be any symbol issues in our codebase.