### PR TITLE
MAINT: stats: not using nested TypeErrors in _contains_nan

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -83,51 +83,39 @@ __all__ = ['find_repeats', 'gmean', 'hmean', 'pmean', 'mode', 'tmean', 'tvar',
            'brunnermunzel', 'alexandergovern']
 
 
-# This should probably be rewritten to avoid nested TypeErrors in favor of
-# branching based on dtype.
 def _contains_nan(a, nan_policy='propagate', use_summation=True):
-    if not isinstance(a, np.ndarray):
-        use_summation = False  # some array_likes ignore nans (e.g. pandas)
     policies = ['propagate', 'raise', 'omit']
     if nan_policy not in policies:
         raise ValueError("nan_policy must be one of {%s}" %
                          ', '.join("'%s'" % s for s in policies))
-    # only inexact (floating/complexfloating) and object arrays support np.nan
-    if not (np.issubdtype(a.dtype, np.inexact)
-            or np.issubdtype(a.dtype, object)):
-        return False, nan_policy
-    try:
+
+    if np.issubdtype(a.dtype, np.number):
         # The summation method avoids creating a (potentially huge) array.
         # But, it will set contains_nan to True for (e.g.) [-inf, ..., +inf].
         # If this is undesirable, set use_summation to False instead.
         if use_summation:
             with np.errstate(invalid='ignore', over='ignore'):
-                contains_nan = np.isnan(np.sum(a))
+                # we should use build-in sum instead of np.sum because np.sum
+                # ignores nan when the input is pandas series.
+                contains_nan = np.isnan(sum(a.ravel()))
         else:
             contains_nan = np.isnan(a).any()
-    except TypeError:
-        # This can happen when attempting to sum things which are not
-        # numbers (e.g. as in the function `mode`). Try an alternative method:
-        try:
-            contains_nan = np.any(np.isnan(a))
-        except TypeError:
-            try:
-                # This can happen when attempting to check nan with np.isnan
-                # for string array (e.g. as in the function `rankdata`).
-                contains_nan = False
-                for el in a.ravel():
-                    # isnan doesn't work on elements of string arrays
-                    if np.issubdtype(type(el), np.number) and np.isnan(el):
-                        contains_nan = True
-                        break
-            except TypeError:
-                # Don't know what to do. Fall back to omitting nan values and
-                # issue a warning.
-                contains_nan = False
-                nan_policy = 'omit'
-                warnings.warn("The input array could not be properly "
-                              "checked for nan values. nan values "
-                              "will be ignored.", RuntimeWarning)
+    elif np.issubdtype(a.dtype, np.character) or np.issubdtype(a.dtype, object):
+        # This can happen when attempting to check nan with np.isnan
+        # for string array (e.g. as in the function `rankdata`).
+        contains_nan = False
+        for el in a.ravel():
+            # isnan doesn't work on elements of string arrays
+            if np.issubdtype(type(el), np.number) and np.isnan(el):
+                contains_nan = True
+                break
+    else:
+        # Don't know what to do for this dtype. Fall back to return no nans and
+        # issue a warning.
+        contains_nan = False
+        warnings.warn("The input array could not be properly "
+                      "checked for nan values. nan values "
+                      "will be ignored.", RuntimeWarning)
 
     if contains_nan and nan_policy == 'raise':
         raise ValueError("The input contains nan values")

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -99,8 +99,6 @@ def _contains_nan(a, nan_policy='propagate', use_summation=True):
         else:
             contains_nan = np.isnan(a).any()
     elif np.issubdtype(a.dtype, object):
-        # This can happen when attempting to check nan with np.isnan
-        # for string array (e.g. as in the function `rankdata`).
         contains_nan = False
         for el in a.ravel():
             # isnan doesn't work on elements of string arrays

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -84,13 +84,12 @@ __all__ = ['find_repeats', 'gmean', 'hmean', 'pmean', 'mode', 'tmean', 'tvar',
 
 
 def _contains_nan(a, nan_policy='propagate', use_summation=True):
+    if not isinstance(a, np.ndarray):
+        use_summation = False  # some array_likes ignore nans (e.g. pandas)
     policies = ['propagate', 'raise', 'omit']
     if nan_policy not in policies:
         raise ValueError("nan_policy must be one of {%s}" %
                          ', '.join("'%s'" % s for s in policies))
-
-    if not isinstance(a, np.ndarray):
-        use_summation = False  # some array_likes ignore nans (e.g. pandas)
 
     if np.issubdtype(a.dtype, np.number):
         # The summation method avoids creating a (potentially huge) array.

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -91,7 +91,7 @@ def _contains_nan(a, nan_policy='propagate', use_summation=True):
         raise ValueError("nan_policy must be one of {%s}" %
                          ', '.join("'%s'" % s for s in policies))
 
-    if np.issubdtype(a.dtype, np.number):
+    if np.issubdtype(a.dtype, np.inexact):
         # The summation method avoids creating a (potentially huge) array.
         # But, it will set contains_nan to True for (e.g.) [-inf, ..., +inf].
         # If this is undesirable, set use_summation to False instead.

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -110,7 +110,7 @@ def _contains_nan(a, nan_policy='propagate', use_summation=True):
                 contains_nan = True
                 break
     else:
-        # Don't know what to do for this dtype. Fall back to return no nans
+        # Only `object` and `inexact` arrays can have NaNs
         contains_nan = False
 
     if contains_nan and nan_policy == 'raise':

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -93,8 +93,6 @@ def _contains_nan(a, nan_policy='propagate', use_summation=True):
 
     if np.issubdtype(a.dtype, np.inexact):
         # The summation method avoids creating a (potentially huge) array.
-        # But, it will set contains_nan to True for (e.g.) [-inf, ..., +inf].
-        # If this is undesirable, set use_summation to False instead.
         if use_summation:
             with np.errstate(invalid='ignore', over='ignore'):
                 contains_nan = np.isnan(np.sum(a))

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -98,7 +98,7 @@ def _contains_nan(a, nan_policy='propagate', use_summation=True):
         # If this is undesirable, set use_summation to False instead.
         if use_summation:
             with np.errstate(invalid='ignore', over='ignore'):
-                contains_nan = np.isnan(np.sum(a.ravel()))
+                contains_nan = np.isnan(np.sum(a))
         else:
             contains_nan = np.isnan(a).any()
     elif np.issubdtype(a.dtype, object):

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -101,7 +101,7 @@ def _contains_nan(a, nan_policy='propagate', use_summation=True):
     elif np.issubdtype(a.dtype, object):
         contains_nan = False
         for el in a.ravel():
-            # isnan doesn't work on elements of string arrays
+            # isnan doesn't work on non-numeric elements
             if np.issubdtype(type(el), np.number) and np.isnan(el):
                 contains_nan = True
                 break

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -100,7 +100,7 @@ def _contains_nan(a, nan_policy='propagate', use_summation=True):
                 contains_nan = np.isnan(sum(a.ravel()))
         else:
             contains_nan = np.isnan(a).any()
-    elif np.issubdtype(a.dtype, np.character) or np.issubdtype(a.dtype, object):
+    elif np.issubdtype(a.dtype, object):
         # This can happen when attempting to check nan with np.isnan
         # for string array (e.g. as in the function `rankdata`).
         contains_nan = False
@@ -110,12 +110,8 @@ def _contains_nan(a, nan_policy='propagate', use_summation=True):
                 contains_nan = True
                 break
     else:
-        # Don't know what to do for this dtype. Fall back to return no nans and
-        # issue a warning.
+        # Don't know what to do for this dtype. Fall back to return no nans
         contains_nan = False
-        warnings.warn("The input array could not be properly "
-                      "checked for nan values. nan values "
-                      "will be ignored.", RuntimeWarning)
 
     if contains_nan and nan_policy == 'raise':
         raise ValueError("The input contains nan values")

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -89,15 +89,16 @@ def _contains_nan(a, nan_policy='propagate', use_summation=True):
         raise ValueError("nan_policy must be one of {%s}" %
                          ', '.join("'%s'" % s for s in policies))
 
+    if not isinstance(a, np.ndarray):
+        use_summation = False  # some array_likes ignore nans (e.g. pandas)
+
     if np.issubdtype(a.dtype, np.number):
         # The summation method avoids creating a (potentially huge) array.
         # But, it will set contains_nan to True for (e.g.) [-inf, ..., +inf].
         # If this is undesirable, set use_summation to False instead.
         if use_summation:
             with np.errstate(invalid='ignore', over='ignore'):
-                # we should use build-in sum instead of np.sum because np.sum
-                # ignores nan when the input is pandas series.
-                contains_nan = np.isnan(sum(a.ravel()))
+                contains_nan = np.isnan(np.sum(a.ravel()))
         else:
             contains_nan = np.isnan(a).any()
     elif np.issubdtype(a.dtype, object):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Ref: https://github.com/scipy/scipy/pull/16318#issuecomment-1153036466, https://github.com/scipy/scipy/issues/16211, 

#### What does this implement/fix?
<!--Please explain your changes.-->
As discussed in this https://github.com/scipy/scipy/pull/16318#issuecomment-1153036466, I cleaned up the `stats._contains_nan` by using type branching instead of nested TypeErrors.

I tested this code using pandas input manually using the example in #16211, it works.
```
Numpy array: [nan nan nan nan nan nan nan nan nan nan 24. 24. 24. 24. 24. 24. 24. 24.
 24. 24. 24. 24. 24. 24. 24. 24. 24. 24. 24. 24. 24. 24. 24. 24. 24. 25.
 26. 27. 28. 29. 30. 31. 32. 33. 34. 35. 36. 37. 38. 39. 40. 41. 42. 43.
 44. 45. 46. 47. 48. 49. 50. 51. 52. 53. 54. 55. 56. 57. 58. 59. 60. 61.
 62. 63. 64. 65. 66. 67. 68. 69. 70. 71. 72. 73. 74. 75. 76. 77. 78. 79.
 80. 81. 82. 83. 84. 85. 86. 87. 88. 89. 90. 91. 92. 93. 94. 95. 95. 95.
 95. 95. nan nan nan nan nan nan nan nan nan nan]
Pandas series: [nan nan nan nan nan nan nan nan nan nan 24. 24. 24. 24. 24. 24. 24. 24.
 24. 24. 24. 24. 24. 24. 24. 24. 24. 24. 24. 24. 24. 24. 24. 24. 24. 25.
 26. 27. 28. 29. 30. 31. 32. 33. 34. 35. 36. 37. 38. 39. 40. 41. 42. 43.
 44. 45. 46. 47. 48. 49. 50. 51. 52. 53. 54. 55. 56. 57. 58. 59. 60. 61.
 62. 63. 64. 65. 66. 67. 68. 69. 70. 71. 72. 73. 74. 75. 76. 77. 78. 79.
 80. 81. 82. 83. 84. 85. 86. 87. 88. 89. 90. 91. 92. 93. 94. 95. 95. 95.
 95. 95. nan nan nan nan nan nan nan nan nan nan]

```
#### Additional information
<!--Any additional information you think is important.-->
