### PR TITLE
MAINT: future-proof `stats.kde` for changes in numpy casting rules

### DIFF
--- a/scipy/stats/_kde.py
+++ b/scipy/stats/_kde.py
@@ -567,7 +567,7 @@ class gaussian_kde:
             self._data_inv_cov = linalg.inv(self._data_covariance)
 
         self.covariance = self._data_covariance * self.factor**2
-        self.inv_cov = self._data_inv_cov / self.factor**2
+        self.inv_cov = (self._data_inv_cov / self.factor**2).astype(np.float64)
         L = linalg.cholesky(self.covariance*2*pi)
         self.log_det = 2*np.log(np.diag(L)).sum()
 

--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -319,14 +319,10 @@ def test_kde_integer_input():
 _ftypes = ['float32', 'float64', 'float96', 'float128', 'int32', 'int64']
 
 @pytest.mark.parametrize("bw_type", _ftypes + ["scott", "silverman"])
-@pytest.mark.parametrize("weights_type", _ftypes)
-@pytest.mark.parametrize("dataset_type", _ftypes)
-@pytest.mark.parametrize("point_type", _ftypes)
-def test_kde_output_dtype(point_type, dataset_type, weights_type, bw_type):
+@pytest.mark.parametrize("dtype", _ftypes)
+def test_kde_output_dtype(dtype, bw_type):
     # Check whether the datatypes are available
-    point_type = getattr(np, point_type, None)
-    dataset_type = getattr(np, weights_type, None)
-    weights_type = getattr(np, weights_type, None)
+    dtype = getattr(np, dtype, None)
 
     if bw_type in ["scott", "silverman"]:
         bw = bw_type
@@ -334,13 +330,13 @@ def test_kde_output_dtype(point_type, dataset_type, weights_type, bw_type):
         bw_type = getattr(np, bw_type, None)
         bw = bw_type(3) if bw_type else None
 
-    if any(dt is None for dt in [point_type, dataset_type, weights_type, bw]):
+    if any(dt is None for dt in [dtype, bw]):
         pytest.skip()
 
-    weights = np.arange(5, dtype=weights_type)
-    dataset = np.arange(5, dtype=dataset_type)
+    weights = np.arange(5, dtype=dtype)
+    dataset = np.arange(5, dtype=dtype)
     k = stats.gaussian_kde(dataset, bw_method=bw, weights=weights)
-    points = np.arange(5, dtype=point_type)
+    points = np.arange(5, dtype=dtype)
     result = k(points)
     # weights are always cast to float64
     assert result.dtype == np.result_type(dataset, points, np.float64(weights),


### PR DESCRIPTION
This fixes failures (about 150 of them) of the form:
```
FAILED scipy/stats/tests/test_kdeoth.py::test_kde_output_dtype[int64-int64-float64-float128] - TypeError: array type float128 is unsupported
```
that are happening when testing against https://github.com/numpy/numpy/pull/21626 with `NPY_PROMOTION_STATE=weak`.

The issue is caused by inconsistent float128 handling. In this line:
```
result = gaussian_kernel_estimate[spec](self.dataset.T, self.weights[:, None],
                                        points.T, self.inv_cov, output_dtype)
```
The first 3 input arrays are float128, but `inv_cov` is float64 because `scipy.linalg` functions happen to return `float64` output for `float128` input. `numpy.linalg` on the other hand will raise an exception (which is the more sensible behavior).
    
Now why this changes with the NEP 50 branch and setting `NPY_PROMOTION_STATE=weak` rather than the default (= `legacy`) is because an expression of the form:
```
np.array([[3.5]], dtype=np.float64) / np.float128(3)
```
starts returning a float128 output rather than a float64 one. This happens because of rule number 2 in NEP 50:
    
_NumPy scalars and 0-D arrays should behave consistently with their N-D counterparts._
    
So that is working as designed, it is just exposing some rather poor dtype handling in `stats.kde` that happened to work before.



Also clean up `stats.kde` test case, it was too heavily parametrized.Testing all combinations of dtypes for 4 different parameters makes little sense, this results in dozen of test failures that are all the same. This reduces it to two test failures for `float128` with the NEP 50 branch of numpy.
