### PR TITLE
BUG: Fix power operator behaviour for sparse arrays to be consistent with numpy arrays

### DIFF
--- a/scipy/sparse/_arrays.py
+++ b/scipy/sparse/_arrays.py
@@ -49,6 +49,10 @@ class _sparray:
     def __rmul__(self, *args, **kwargs):
         return self.multiply(*args, **kwargs)
 
+    # Restore elementwise power
+    def __pow__(self, *args, **kwargs):
+        return self.power(*args, **kwargs)
+
 
 def _matrix_doc_to_array(docstr):
     # For opimized builds with stripped docstrings

--- a/scipy/sparse/tests/test_array_api.py
+++ b/scipy/sparse/tests/test_array_api.py
@@ -331,3 +331,9 @@ def test_spilu():
     ])
     LU = spla.spilu(X)
     npt.assert_allclose(LU.solve(np.array([1, 2, 3, 4])), [1, 0, 0, 0])
+
+
+@parametrize_sparrays
+def test_power_operator(A):
+    # https://github.com/scipy/scipy/issues/15948
+    npt.assert_equal((A**2).todense(), (A.todense())**2)


### PR DESCRIPTION

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes gh-15948
#### What does this implement/fix?
<!--Please explain your changes.-->
Previously for sparse arrays the power operator behaved like it was a matrix whereas it should be element wise as it is an array.
#### Additional information
<!--Any additional information you think is important.-->
