### PR TITLE
CI: fix Gitpod build after dev.py update to the new CLI

### DIFF
--- a/tools/docker_dev/gitpod.Dockerfile
+++ b/tools/docker_dev/gitpod.Dockerfile
@@ -22,7 +22,7 @@ ARG BASE_CONTAINER=scipy/scipy-dev:latest
 FROM ${BASE_CONTAINER} as build
 
 # Build argument - can pass Meson arguments during the build:
-ARG BUILD_ARG="python dev.py --build-only -j2" \
+ARG BUILD_ARG="python dev.py build -j2" \
     CONDA_ENV=scipy-dev
 
 # -----------------------------------------------------------------------------

--- a/tools/docker_dev/meson.Dockerfile
+++ b/tools/docker_dev/meson.Dockerfile
@@ -20,10 +20,10 @@
 # By default the container will activate the conda environment scipy-dev
 # which contains all the dependencies needed for SciPy development
 # 
-# To build Scipy run: python dev.py --build-only -j2 
-# For the all-in-one (configure,build,test SciPy and docs) use: python dev.py
+# To build Scipy run: python dev.py build -j2
+# For the all-in-one (configure,build,test SciPy and docs) use: python dev.py test
 #
-# To run the tests use: python dev.py -n 
+# To run the tests use: python dev.py --no-build test
 # 
 # This image is based on: Ubuntu 20.04 (focal)
 # https://hub.docker.com/_/ubuntu/?tab=tags&name=focal


### PR DESCRIPTION
I missed this one `dev.py` instance.