### PR TITLE
Docstring fixes in lobpcg.py

### DIFF
--- a/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
@@ -139,7 +139,7 @@ def lobpcg(
     retLambdaHistory=False,
     retResidualNormsHistory=False,
 ):
-    """Locally Optimal Block Preconditioned Conjugate Gradient Method (LOBPCG)
+    """Locally Optimal Block Preconditioned Conjugate Gradient Method (LOBPCG).
 
     LOBPCG is a preconditioned eigensolver for large symmetric positive
     definite (SPD) generalized eigenproblems.
@@ -159,7 +159,7 @@ def lobpcg(
         Preconditioner to `A`; by default ``M = Identity``.
         `M` should approximate the inverse of `A`.
     Y : ndarray, float32 or float64, optional
-        n-by-sizeY matrix of constraints (non-sparse), sizeY < n
+        An n-by-sizeY matrix of constraints (non-sparse), sizeY < n.
         The iterations will be performed in the B-orthogonal complement
         of the column-space of Y. Y must be full rank.
     tol : scalar, optional
@@ -179,7 +179,7 @@ def lobpcg(
     Returns
     -------
     w : ndarray
-        Array of ``k`` eigenvalues
+        Array of ``k`` eigenvalues.
     v : ndarray
         An array of ``k`` eigenvectors.  `v` has the same shape as `X`.
     lambdas : list of ndarray, optional
@@ -241,7 +241,6 @@ def lobpcg(
 
     Examples
     --------
-
     Solve ``A x = lambda x`` with constraints and preconditioning.
 
     >>> import numpy as np
@@ -307,7 +306,6 @@ def lobpcg(
 
     Note that the vectors passed in Y are the eigenvectors of the 3 smallest
     eigenvalues. The results returned are orthogonal to those.
-
     """
     blockVectorX = X
     blockVectorY = Y


### PR DESCRIPTION
Docstring fixes to errors found in https://github.com/scikit-learn/scikit-learn/issues/23596

#### What does this implement/fix?
Fixes
E           # Errors
E           
E            - GL03: Double line break found; please use only one blank line to separate sections or paragraphs, and do not leave blank lines at the end of docstrings
E            - SS03: Summary does not end with a period
E            - PR08: Parameter "Y" description should start with a capital letter
E            - RT05: Return value description should finish with "."

