### PR TITLE
MAINT: remove unused `DeprecatedImport`

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -1,7 +1,6 @@
 from contextlib import contextmanager
 import functools
 import operator
-import sys
 import warnings
 import numbers
 from collections import namedtuple
@@ -168,40 +167,6 @@ def float_factorial(n: int) -> float:
     Returns infinity when result is too large for a double
     """
     return float(math.factorial(n)) if n < 171 else np.inf
-
-
-class DeprecatedImport:
-    """
-    Deprecated import with redirection and warning.
-
-    Examples
-    --------
-    Suppose you previously had in some module::
-
-        from foo import spam
-
-    If this has to be deprecated, do::
-
-        spam = DeprecatedImport("foo.spam", "baz")
-
-    to redirect users to use "baz" module instead.
-
-    """
-
-    def __init__(self, old_module_name, new_module_name):
-        self._old_name = old_module_name
-        self._new_name = new_module_name
-        __import__(self._new_name)
-        self._mod = sys.modules[self._new_name]
-
-    def __dir__(self):
-        return dir(self._mod)
-
-    def __getattr__(self, name):
-        warnings.warn("Module %s is deprecated, use %s instead"
-                      % (self._old_name, self._new_name),
-                      DeprecationWarning)
-        return getattr(self._mod, name)
 
 
 # copy-pasted from scikit-learn utils/validation.py


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Follow up to #16299
#### What does this implement/fix?
<!--Please explain your changes.-->
In the review for #16299 it was noted that `DeprecatedImport` could be removed as

1. It is no longer used anywhere in the library
2. It does not allow you to include a timeline for removal in the warning message of the `DeprecatedImport` which is contrary to the recent work we have done to try ensure all deprecation have a clear timeline for removal.

#### Additional information
<!--Any additional information you think is important.-->
