### PR TITLE
ENH: stats.chi2_contingency: convert output tuple to Bunch

### DIFF
--- a/scipy/stats/contingency.py
+++ b/scipy/stats/contingency.py
@@ -236,21 +236,23 @@ def chi2_contingency(observed, correction=True, lambda_=None):
     >>> from scipy.stats import chi2_contingency
     >>> obs = np.array([[10, 10, 20], [20, 20, 20]])
     >>> chi2_contingency(obs)
-    Chi2ContingencyResult(statistic=2.7777777777777777,
-                          pvalue=0.24935220877729619,
-                          dof=2,
-                          expected_freq=array([[ 12.,  12.,  16.],
-                                               [ 18.,  18.,  24.]]))
+    Chi2ContingencyResult(
+        statistic=2.7777777777777777,
+        pvalue=0.24935220877729619,
+        dof=2,
+        expected_freq=array([[ 12.,  12.,  16.],
+                             [ 18.,  18.,  24.]]))
 
     Perform the test using the log-likelihood ratio (i.e. the "G-test")
     instead of Pearson's chi-squared statistic.
 
     >>> chi2_contingency(obs, lambda_="log-likelihood")
-    Chi2ContingencyResult(statistic=2.7688587616781319,
-                          pvalue=0.25046668010954165,
-                          dof=2,
-                          expected_freq=array([[ 12.,  12.,  16.],
-                                               [ 18.,  18.,  24.]]))
+    Chi2ContingencyResult(
+        statistic=2.7688587616781319,
+        pvalue=0.25046668010954165,
+        dof=2,
+        expected_freq=array([[ 12.,  12.,  16.],
+                             [ 18.,  18.,  24.]]))
 
     A four-way example (2 x 2 x 2 x 2):
 
@@ -264,17 +266,18 @@ def chi2_contingency(observed, correction=True, lambda_=None):
     ...       [[14, 17],
     ...        [15, 16]]]])
     >>> chi2_contingency(obs)
-    Chi2ContingencyResult(statistic=8.7584514426741897,
-                          pvalue=0.64417725029295503,
-                          dof=11,
-                          expected_freq=array([[[[ 14.15462386,  14.15462386],
-                                                 [ 16.49423111,  16.49423111]],
-                                                [[ 11.2461395 ,  11.2461395 ],
-                                                 [ 13.10500554,  13.10500554]]],
-                                               [[[ 19.5591166 ,  19.5591166 ],
-                                                 [ 22.79202844,  22.79202844]],
-                                                [[ 15.54012004,  15.54012004],
-                                                 [ 18.10873492,  18.10873492]]]]))
+    Chi2ContingencyResult(
+        statistic=8.7584514426741897,
+        pvalue=0.64417725029295503,
+        dof=11,
+        expected_freq=array([[[[ 14.15462386,  14.15462386],
+                               [ 16.49423111,  16.49423111]],
+                              [[ 11.2461395 ,  11.2461395 ],
+                               [ 13.10500554,  13.10500554]]],
+                             [[[ 19.5591166 ,  19.5591166 ],
+                               [ 22.79202844,  22.79202844]],
+                              [[ 15.54012004,  15.54012004],
+                               [ 18.10873492,  18.10873492]]]]))
     """
     observed = np.asarray(observed)
     if np.any(observed < 0):

--- a/scipy/stats/contingency.py
+++ b/scipy/stats/contingency.py
@@ -235,24 +235,25 @@ def chi2_contingency(observed, correction=True, lambda_=None):
 
     >>> from scipy.stats import chi2_contingency
     >>> obs = np.array([[10, 10, 20], [20, 20, 20]])
-    >>> chi2_contingency(obs)
-    Chi2ContingencyResult(
-        statistic=2.7777777777777777,
-        pvalue=0.24935220877729622,
-        dof=2,
-        expected_freq=array([[12., 12., 16.],
-                             [18., 18., 24.]]))
+    >>> res = chi2_contingency(obs)
+    >>> res.statistic
+    2.7777777777777777
+    >>> res.pvalue
+    0.24935220877729619
+    >>> res.dof
+    2
+    >>> res.expected_freq
+    array([[ 12.,  12.,  16.],
+           [ 18.,  18.,  24.]])
 
     Perform the test using the log-likelihood ratio (i.e. the "G-test")
     instead of Pearson's chi-squared statistic.
 
-    >>> chi2_contingency(obs, lambda_="log-likelihood")
-    Chi2ContingencyResult(
-        statistic=2.768858761678132,
-        pvalue=0.25046668010954165,
-        dof=2,
-        expected_freq=array([[12., 12., 16.],
-                             [18., 18., 24.]]))
+    >>> res = chi2_contingency(obs, lambda_="log-likelihood")
+    >>> res.statistic
+    2.7688587616781319
+    >>> res.pvalue
+    0.25046668010954165
 
     A four-way example (2 x 2 x 2 x 2):
 
@@ -265,20 +266,11 @@ def chi2_contingency(observed, correction=True, lambda_=None):
     ...        [30, 22]],
     ...       [[14, 17],
     ...        [15, 16]]]])
-    >>> chi2_contingency(obs)
-    Chi2ContingencyResult(
-        statistic=8.75845144267419,
-        pvalue=0.6441772502929553,
-        dof=11,
-        expected_freq=array([[[[14.15462386, 14.15462386],
-                               [16.49423111, 16.49423111]],
-                              [[11.2461395 , 11.2461395 ],
-                               [13.10500554, 13.10500554]]],
-                             [[[19.5591166 , 19.5591166 ],
-                               [22.79202844, 22.79202844]],
-                              [[15.54012004, 15.54012004],
-                               [18.10873492, 18.10873492]]]]))
-
+    >>> res = chi2_contingency(obs)
+    >>> res.statistic
+    8.7584514426741897
+    >>> res.pvalue
+    0.64417725029295503
     """
     observed = np.asarray(observed)
     if np.any(observed < 0):

--- a/scipy/stats/contingency.py
+++ b/scipy/stats/contingency.py
@@ -238,21 +238,21 @@ def chi2_contingency(observed, correction=True, lambda_=None):
     >>> chi2_contingency(obs)
     Chi2ContingencyResult(
         statistic=2.7777777777777777,
-        pvalue=0.24935220877729619,
+        pvalue=0.24935220877729622,
         dof=2,
-        expected_freq=array([[ 12.,  12.,  16.],
-                             [ 18.,  18.,  24.]]))
+        expected_freq=array([[12., 12., 16.],
+                             [18., 18., 24.]]))
 
     Perform the test using the log-likelihood ratio (i.e. the "G-test")
     instead of Pearson's chi-squared statistic.
 
     >>> chi2_contingency(obs, lambda_="log-likelihood")
     Chi2ContingencyResult(
-        statistic=2.7688587616781319,
+        statistic=2.768858761678132,
         pvalue=0.25046668010954165,
         dof=2,
-        expected_freq=array([[ 12.,  12.,  16.],
-                             [ 18.,  18.,  24.]]))
+        expected_freq=array([[12., 12., 16.],
+                             [18., 18., 24.]]))
 
     A four-way example (2 x 2 x 2 x 2):
 
@@ -267,17 +267,18 @@ def chi2_contingency(observed, correction=True, lambda_=None):
     ...        [15, 16]]]])
     >>> chi2_contingency(obs)
     Chi2ContingencyResult(
-        statistic=8.7584514426741897,
-        pvalue=0.64417725029295503,
+        statistic=8.75845144267419,
+        pvalue=0.6441772502929553,
         dof=11,
-        expected_freq=array([[[[ 14.15462386,  14.15462386],
-                               [ 16.49423111,  16.49423111]],
-                              [[ 11.2461395 ,  11.2461395 ],
-                               [ 13.10500554,  13.10500554]]],
-                             [[[ 19.5591166 ,  19.5591166 ],
-                               [ 22.79202844,  22.79202844]],
-                              [[ 15.54012004,  15.54012004],
-                               [ 18.10873492,  18.10873492]]]]))
+        expected_freq=array([[[[14.15462386, 14.15462386],
+                               [16.49423111, 16.49423111]],
+                              [[11.2461395 , 11.2461395 ],
+                               [13.10500554, 13.10500554]]],
+                             [[[19.5591166 , 19.5591166 ],
+                               [22.79202844, 22.79202844]],
+                              [[15.54012004, 15.54012004],
+                               [18.10873492, 18.10873492]]]]))
+
     """
     observed = np.asarray(observed)
     if np.any(observed < 0):

--- a/scipy/stats/contingency.py
+++ b/scipy/stats/contingency.py
@@ -26,6 +26,7 @@ import numpy as np
 from ._stats_py import power_divergence
 from ._relative_risk import relative_risk
 from ._crosstab import crosstab
+from scipy._lib._bunch import _make_tuple_bunch
 
 
 __all__ = ['margins', 'expected_freq', 'chi2_contingency', 'crosstab',
@@ -129,6 +130,12 @@ def expected_freq(observed):
     return expected
 
 
+Chi2ContingencyResult = _make_tuple_bunch(
+    'Chi2ContingencyResult',
+    ['statistic', 'pvalue', 'dof', 'expected_freq'], []
+)
+
+
 def chi2_contingency(observed, correction=True, lambda_=None):
     """Chi-square test of independence of variables in a contingency table.
 
@@ -160,14 +167,17 @@ def chi2_contingency(observed, correction=True, lambda_=None):
 
     Returns
     -------
-    chi2 : float
-        The test statistic.
-    p : float
-        The p-value of the test
-    dof : int
-        Degrees of freedom
-    expected : ndarray, same shape as `observed`
-        The expected frequencies, based on the marginal sums of the table.
+    res : Chi2ContingencyResult
+        An object containing attributes:
+
+        statistic : float
+            The test statistic.
+        pvalue : float
+            The p-value of the test.
+        dof : int
+            The degrees of freedom.
+        expected_freq : ndarray, same shape as `observed`
+            The expected frequencies, based on the marginal sums of the table.
 
     See Also
     --------
@@ -199,12 +209,13 @@ def chi2_contingency(observed, correction=True, lambda_=None):
     If these were already known, and if the Yates' correction was not
     required, one could use stats.chisquare.  That is, if one calls::
 
-        chi2, p, dof, ex = chi2_contingency(obs, correction=False)
+        res = chi2_contingency(obs, correction=False)
 
     then the following is true::
 
-        (chi2, p) == stats.chisquare(obs.ravel(), f_exp=ex.ravel(),
-                                     ddof=obs.size - 1 - dof)
+        (res.statistic, res.pvalue) == stats.chisquare(obs.ravel(),
+                                                       f_exp=ex.ravel(),
+                                                       ddof=obs.size - 1 - dof)
 
     The `lambda_` argument was added in version 0.13.0 of scipy.
 
@@ -225,18 +236,21 @@ def chi2_contingency(observed, correction=True, lambda_=None):
     >>> from scipy.stats import chi2_contingency
     >>> obs = np.array([[10, 10, 20], [20, 20, 20]])
     >>> chi2_contingency(obs)
-    (2.7777777777777777,
-     0.24935220877729619,
-     2,
-     array([[ 12.,  12.,  16.],
-            [ 18.,  18.,  24.]]))
+    Chi2ContingencyResult(statistic=2.7777777777777777,
+                          pvalue=0.24935220877729619,
+                          dof=2,
+                          expected_freq=array([[ 12.,  12.,  16.],
+                                               [ 18.,  18.,  24.]]))
 
     Perform the test using the log-likelihood ratio (i.e. the "G-test")
     instead of Pearson's chi-squared statistic.
 
-    >>> g, p, dof, expctd = chi2_contingency(obs, lambda_="log-likelihood")
-    >>> g, p
-    (2.7688587616781319, 0.25046668010954165)
+    >>> chi2_contingency(obs, lambda_="log-likelihood")
+    Chi2ContingencyResult(statistic=2.7688587616781319,
+                          pvalue=0.25046668010954165,
+                          dof=2,
+                          expected_freq=array([[ 12.,  12.,  16.],
+                                               [ 18.,  18.,  24.]]))
 
     A four-way example (2 x 2 x 2 x 2):
 
@@ -250,17 +264,17 @@ def chi2_contingency(observed, correction=True, lambda_=None):
     ...       [[14, 17],
     ...        [15, 16]]]])
     >>> chi2_contingency(obs)
-    (8.7584514426741897,
-     0.64417725029295503,
-     11,
-     array([[[[ 14.15462386,  14.15462386],
-              [ 16.49423111,  16.49423111]],
-             [[ 11.2461395 ,  11.2461395 ],
-              [ 13.10500554,  13.10500554]]],
-            [[[ 19.5591166 ,  19.5591166 ],
-              [ 22.79202844,  22.79202844]],
-             [[ 15.54012004,  15.54012004],
-              [ 18.10873492,  18.10873492]]]]))
+    Chi2ContingencyResult(statistic=8.7584514426741897,
+                          pvalue=0.64417725029295503,
+                          dof=11,
+                          expected_freq=array([[[[ 14.15462386,  14.15462386],
+                                                 [ 16.49423111,  16.49423111]],
+                                                [[ 11.2461395 ,  11.2461395 ],
+                                                 [ 13.10500554,  13.10500554]]],
+                                               [[[ 19.5591166 ,  19.5591166 ],
+                                                 [ 22.79202844,  22.79202844]],
+                                                [[ 15.54012004,  15.54012004],
+                                                 [ 18.10873492,  18.10873492]]]]))
     """
     observed = np.asarray(observed)
     if np.any(observed < 0):
@@ -298,7 +312,7 @@ def chi2_contingency(observed, correction=True, lambda_=None):
                                    ddof=observed.size - 1 - dof, axis=None,
                                    lambda_=lambda_)
 
-    return chi2, p, dof, expected
+    return Chi2ContingencyResult(chi2, p, dof, expected)
 
 
 def association(observed, method="cramer", correction=False, lambda_=None):
@@ -387,7 +401,7 @@ def association(observed, method="cramer", correction=False, lambda_=None):
     chi2_stat = chi2_contingency(arr, correction=correction,
                                  lambda_=lambda_)
 
-    phi2 = chi2_stat[0] / arr.sum()
+    phi2 = chi2_stat.statistic / arr.sum()
     n_rows, n_cols = arr.shape
     if method == "cramer":
         value = phi2 / min(n_cols - 1, n_rows - 1)

--- a/scipy/stats/tests/test_contingency.py
+++ b/scipy/stats/tests/test_contingency.py
@@ -209,6 +209,13 @@ def test_chi2_contingency_yates_gh13875():
     assert_allclose(p, 1, rtol=1e-12)
 
 
+@pytest.mark.parametrize("correction", [False, True])
+def test_result(correction):
+    obs = np.array([[1, 2], [1, 2]])
+    res = chi2_contingency(obs, correction=correction)
+    assert_equal((res.statistic, res.pvalue, res.dof, res.expected_freq), res)
+
+
 def test_bad_association_args():
     # Invalid Test Statistic
     assert_raises(ValueError, association, [[1, 2], [3, 4]], "X")


### PR DESCRIPTION
Reference issue

https://github.com/scipy/scipy/issues/16364
https://github.com/scipy/scipy/issues/13118

What does this implement/fix?

https://github.com/scipy/scipy/issues/16364 suggests that all statistical functions that currently return tuples should return Bunch objects. This PR converts the tuple returned by stats.chi2_contingency to a Bunch.