### PR TITLE
MAINT: fix issues with Python scalar related casting behavior (NEP 50)

### DIFF
--- a/scipy/io/_idl.py
+++ b/scipy/io/_idl.py
@@ -795,8 +795,9 @@ def readsav(file_name, idict=None, python_dict=False,
 
             # Check if the end of the file has been reached
             if RECTYPE_DICT[rectype] == 'END_MARKER':
-                fout.write(struct.pack('>I', int(nextrec) % 2**32))
-                fout.write(struct.pack('>I', int((nextrec - (nextrec % 2**32)) / 2**32)))
+                modval = np.int64(2**32)
+                fout.write(struct.pack('>I', int(nextrec) % modval))
+                fout.write(struct.pack('>I', int((nextrec - (nextrec % modval)) / modval)))
                 fout.write(unknown)
                 break
 

--- a/scipy/linalg/tests/test_special_matrices.py
+++ b/scipy/linalg/tests/test_special_matrices.py
@@ -552,7 +552,7 @@ class TestPascal:
 
     def test_big(self):
         p = pascal(50)
-        assert_equal(p[-1, -1], comb(98, 49, exact=True))
+        assert p[-1, -1] == comb(98, 49, exact=True)
 
     def test_threshold(self):
         # Regression test.  An early version of `pascal` returned an
@@ -562,7 +562,7 @@ class TestPascal:
         p = pascal(34)
         assert_equal(2*p.item(-1, -2), p.item(-1, -1), err_msg="n = 34")
         p = pascal(35)
-        assert_equal(2*p.item(-1, -2), p.item(-1, -1), err_msg="n = 35")
+        assert_equal(2.*p.item(-1, -2), 1.*p.item(-1, -1), err_msg="n = 35")
 
 
 def test_invpascal():

--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -776,5 +776,5 @@ def test_fp32_gh12991():
     # unchanged from the initial solution.
     # It was terminating early because the underlying approx_derivative
     # used a step size for FP64 when the working space was FP32.
-    assert res.nfev > 3
+    assert res.nfev > 2
     assert_allclose(res.x, np.array([0.4082241, 0.15530563]), atol=5e-5)

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -4843,6 +4843,8 @@ def besselap(N, norm='phase'):
     """
     if abs(int(N)) != N:
         raise ValueError("Filter order must be a nonnegative integer")
+
+    N = int(N)  # calculation below doesn't always fit in np.int64
     if N == 0:
         p = []
         k = 1

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1318,7 +1318,7 @@ class TestCombinatorics:
         assert_equal(special.comb(ii, ii-1, exact=True), ii)
 
         expected = 100891344545564193334812497256
-        assert_equal(special.comb(100, 50, exact=True), expected)
+        assert special.comb(100, 50, exact=True) == expected
 
     @pytest.mark.parametrize("repetition", [True, False])
     @pytest.mark.parametrize("legacy", [True, False])
@@ -1355,8 +1355,9 @@ class TestCombinatorics:
         k = 30
         np_n = np.int64(n)
         np_k = np.int64(k)
-        assert_equal(special.comb(np_n, np_k, exact=True),
-                     special.comb(n, k, exact=True))
+        res_np = special.comb(np_n, np_k, exact=True)
+        res_py = special.comb(n, k, exact=True)
+        assert res_np == res_py
 
     def test_comb_zeros(self):
         assert_equal(special.comb(2, 3, exact=True), 0)


### PR DESCRIPTION
A few more straightforward fixes. Together with gh-16424 and gh-16428, this should make the test suite pass with `NPY_PROMOTION_STATE=weak` and https://github.com/numpy/numpy/pull/21626