### PR TITLE
ENH: improve scipy.interpolate.RegularGridInterpolator performance

### DIFF
--- a/benchmarks/benchmarks/interpolate.py
+++ b/benchmarks/benchmarks/interpolate.py
@@ -243,3 +243,36 @@ class Interpolate(Benchmark):
             interpolate.interp1d(self.x, self.y, kind="linear")
         else:
             np.interp(self.z, self.x, self.y)
+
+
+class RegularGridInterpolator(Benchmark):
+    """
+    Benchmark RegularGridInterpolator with method="linear".
+    """
+    param_names = ['ndim', 'max_coord_size', 'n_samples']
+    params = [
+        [2, 3, 4],
+        [10, 40, 200],
+        [10, 100, 1000, 10000],
+    ]
+
+    def setup(self, ndim, max_coord_size, n_samples):
+        rng = np.random.default_rng(314159)
+
+        # coordinates halve in size over the dimensions
+        coord_sizes = [max_coord_size // 2**i for i in range(ndim)]
+        self.points = [np.sort(rng.random(size=s)) for s in coord_sizes]
+        self.values = rng.random(size=coord_sizes)
+
+        # choose in-bounds sample points xi
+        bounds = [(p[0], p[-1]) for p in self.points]
+        xi = [rng.uniform(low, high, size=n_samples) for low, high in bounds]
+        self.xi = np.array(xi).T
+
+        self.interp = interpolate.RegularGridInterpolator(
+            self.points,
+            self.values,
+        )
+
+    def time_rgi(self, ndim, max_coord_size, n_samples):
+        self.interp(self.xi)

--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -347,14 +347,29 @@ class RegularGridInterpolator:
         # slice for broadcasting over trailing dimensions in self.values
         vslice = (slice(None),) + (None,)*(self.values.ndim - len(indices))
 
-        # find relevant values
-        # each i and i+1 represents a edge
-        edges = itertools.product(*[[i, i + 1] for i in indices])
+        # Compute shifting up front before zipping everything together
+        shift_norm_distances = [1 - yi for yi in norm_distances]
+        shift_indices = [i + 1 for i in indices]
+
+        # The formula for linear interpolation in 2d takes the form:
+        # values = self.values[(i0, i1)] * (1 - y0) * (1 - y1) + \
+        #          self.values[(i0, i1 + 1)] * (1 - y0) * y1 + \
+        #          self.values[(i0 + 1, i1)] * y0 * (1 - y1) + \
+        #          self.values[(i0 + 1, i1 + 1)] * y0 * y1
+        # We pair i with 1 - yi (zipped1) and i + 1 with yi (zipped2)
+        zipped1 = zip(indices, shift_norm_distances)
+        zipped2 = zip(shift_indices, norm_distances)
+
+        # Take all products of zipped1 and zipped2 and iterate over them
+        # to get the terms in the above formula. This corresponds to iterating
+        # over the vertices of a hypercube.
+        hypercube = itertools.product(*zip(zipped1, zipped2))
         values = 0.
-        for edge_indices in edges:
+        for h in hypercube:
+            edge_indices, weights = zip(*h)
             weight = 1.
-            for ei, i, yi in zip(edge_indices, indices, norm_distances):
-                weight *= np.where(ei == i, 1 - yi, yi)
+            for w in weights:
+                weight *= w
             values += np.asarray(self.values[edge_indices]) * weight[vslice]
         return values
 


### PR DESCRIPTION
#### What does this implement/fix?

This PR reimplements the `scipy.interpolate.RegularGridInterpolator._evaluate_linear` method to be slightly more performant.

To compute linear interpolation over an n-dimensional grid, the `_evaluate_linear` method iterates over the vertices of an n-d hypercube. The previous implementation uses `np.where` to determine the "weights" to attach to the grid values at a vertex. These weights can instead be directly inferred from the vertex iteration order. The proposed implementation included here takes this approach, eliminating the unnecessary call to `np.where`. This change gives a nontrivial speedup in most situations.

#### Additional information

I wrote a set of benchmarks specifically for the `RegularGridInterpolator`. Below are the results of running the benchmarks locally.

*Previous implementation*

```
              --                                          n_samples
              ----------------------- --------------------------------------------------
               ndim   max_coord_size       10        100          1000         10000
              ====== ================ =========== ========== ============= =============
                2           10          177±7μs    213±20μs     311±40μs    1.03±0.03ms
                2           40         160±0.8μs   197±9μs      338±10μs    1.31±0.05ms
                2          200          177±7μs    184±9μs      356±20μs     1.89±0.2ms
                3           10          291±20μs   318±10μs     462±30μs     1.88±0.1ms
                3           40          309±10μs   339±20μs     589±20μs     2.29±0.2ms
                3          200          310±7μs    311±3μs      678±70μs     3.26±0.1ms
                4           10          544±30μs   566±10μs    1.05±0.1ms    3.80±0.3ms
                4           40          601±40μs   601±20μs    976±100μs     4.10±0.7ms
                4          200          661±10μs   744±50μs   1.38±0.03ms    9.26±0.3ms
```

*New implementation this PR aims to merge*

```
              --                                        n_samples
              ----------------------- ----------------------------------------------
               ndim   max_coord_size      10        100        1000        10000
              ====== ================ ========== ========== ========== =============
                2           10         142±8μs    151±4μs    229±5μs      907±20μs
                2           40         136±10μs   153±30μs   260±8μs     1.20±0.1ms
                2          200         146±9μs    152±7μs    289±20μs    1.54±0.2ms
                3           10         239±40μs   255±30μs   401±80μs    1.58±0.3ms
                3           40         204±10μs   223±10μs   401±80μs    1.85±0.2ms
                3          200         205±20μs   262±30μs   533±60μs    2.63±0.1ms
                4           10         311±20μs   316±9μs    565±20μs   2.36±0.06ms
                4           40         298±20μs   354±20μs   687±20μs    3.75±0.3ms
                4          200         395±30μs   423±10μs   910±70μs    7.65±0.4ms
```


