### PR TITLE
MAINT: few more 1.9.0 backports

### DIFF
--- a/doc/release/1.9.0-notes.rst
+++ b/doc/release/1.9.0-notes.rst
@@ -432,7 +432,7 @@ Authors
 * CJ Carey (3)
 * Thomas A Caswell (2)
 * Ali Cetin (2) +
-* Hood Chatham (4) +
+* Hood Chatham (5) +
 * Klesk Chonkin (1)
 * Craig Citro (1) +
 * Dan Cogswell (1) +
@@ -450,11 +450,11 @@ Authors
 * Isuru Fernando (3)
 * Joseph Fox-Rabinovitz (1)
 * Ryan Gibson (4) +
-* Ralf Gommers (304)
+* Ralf Gommers (307)
 * Srinivas Gorur-Shandilya (1) +
 * Alex Griffing (2)
 * h-vetinari (3)
-* Matt Haberland (440)
+* Matt Haberland (441)
 * Tristan Hearn (1) +
 * Jonathan Helgert (1) +
 * Samuel Hinton (1) +
@@ -475,6 +475,7 @@ Authors
 * Peter Mahler Larsen (8)
 * Eric Larson (4)
 * Laurynas Mikšys (1) +
+* Antony Lee (1)
 * Gregory R. Lee (2)
 * lerichi (1) +
 * Tim Leslie (2)
@@ -503,7 +504,7 @@ Authors
 * Amit Portnoy (1) +
 * Quentin Barthélemy (9)
 * Patrick N. Raanes (1) +
-* Tyler Reddy (108)
+* Tyler Reddy (114)
 * Pamphile Roy (196)
 * Vivek Roy (2) +
 * Niyas Sait (2) +
@@ -548,7 +549,7 @@ Authors
 * Pavel Zun (1) +
 * David Zwicker (1) +
 
-A total of 152 people contributed to this release.
+A total of 153 people contributed to this release.
 People with a "+" by their names contributed a patch for the first time.
 This list of names is automatically generated, and may not be fully complete.
 
@@ -557,11 +558,18 @@ This list of names is automatically generated, and may not be fully complete.
 Issues closed for 1.9.0
 ***********************
 
+* `#1884 <https://github.com/scipy/scipy/issues/1884>`__: stats distributions fit problems (Trac #1359)
 * `#2047 <https://github.com/scipy/scipy/issues/2047>`__: derivatives() method is missing in BivariateSpline (Trac #1522)
+* `#2071 <https://github.com/scipy/scipy/issues/2071>`__: TST: stats: \`check_sample_var\` should be two-sided (Trac #1546)
 * `#2414 <https://github.com/scipy/scipy/issues/2414>`__: stats binom at non-integer n (Trac #1895)
 * `#2623 <https://github.com/scipy/scipy/issues/2623>`__: stats.distributions statistical power of test suite
+* `#2625 <https://github.com/scipy/scipy/issues/2625>`__: wilcoxon() function does not return z-statistic
 * `#2650 <https://github.com/scipy/scipy/issues/2650>`__: (2D) Interpolation functions should work with complex numbers
+* `#2834 <https://github.com/scipy/scipy/issues/2834>`__: ksone fitting
 * `#2868 <https://github.com/scipy/scipy/issues/2868>`__: nan and stats.percentileofscore
+* `#2877 <https://github.com/scipy/scipy/issues/2877>`__: distributions.ncf numerical issues
+* `#2993 <https://github.com/scipy/scipy/issues/2993>`__: optimize.approx_fprime & jacobians
+* `#3214 <https://github.com/scipy/scipy/issues/3214>`__: stats distributions ppf-cdf roundtrip
 * `#3758 <https://github.com/scipy/scipy/issues/3758>`__: discrete distribution defined by \`values\` with non-integer...
 * `#4130 <https://github.com/scipy/scipy/issues/4130>`__: BUG: stats: fisher_exact returns incorrect p-value
 * `#4897 <https://github.com/scipy/scipy/issues/4897>`__: expm is 10x as slow as matlab according to http://stackoverflow.com/questions/30048315
@@ -569,27 +577,40 @@ Issues closed for 1.9.0
 * `#5266 <https://github.com/scipy/scipy/issues/5266>`__: Deprecated routines in Netlib LAPACK >3.5.0
 * `#5890 <https://github.com/scipy/scipy/issues/5890>`__: Undefined behavior when using scipy.interpolate.RegularGridInterpolator...
 * `#5982 <https://github.com/scipy/scipy/issues/5982>`__: Keyword collision in scipy.stats.levy_stable.interval
-* `#6006 <https://github.com/scipy/scipy/issues/6006>`__: Dirichlet doesn't accept its own random variates as input to...
 * `#6472 <https://github.com/scipy/scipy/issues/6472>`__: scipy.stats.invwishart does not check if scale matrix is symmetric
+* `#6551 <https://github.com/scipy/scipy/issues/6551>`__: BUG: stats: inconsistency in docs and behavior of gmean and hmean
 * `#6624 <https://github.com/scipy/scipy/issues/6624>`__: incorrect handling of nan by RegularGridInterpolator
 * `#6882 <https://github.com/scipy/scipy/issues/6882>`__: Certain recursive scipy.integrate.quad (e.g. dblquad and nquad)...
 * `#7469 <https://github.com/scipy/scipy/issues/7469>`__: Misleading interp2d documentation
 * `#7560 <https://github.com/scipy/scipy/issues/7560>`__: Should RegularGridInterpolator support length 1 dimensions?
 * `#8928 <https://github.com/scipy/scipy/issues/8928>`__: BUG: scipy.stats.norm wrong expected value of function when loc...
 * `#9231 <https://github.com/scipy/scipy/issues/9231>`__: infinite loop in stats.fisher_exact
+* `#9313 <https://github.com/scipy/scipy/issues/9313>`__: geometric distribution stats.geom returns negative values if...
 * `#9524 <https://github.com/scipy/scipy/issues/9524>`__: interpn returns nan with perfectly valid data
 * `#9591 <https://github.com/scipy/scipy/issues/9591>`__: scipy.interpolate.interp1d with kind=“previous” doesn't extrapolate...
+* `#9815 <https://github.com/scipy/scipy/issues/9815>`__: stats.mode's nan_policy 'propagate' not working?
 * `#9944 <https://github.com/scipy/scipy/issues/9944>`__: documentation for \`scipy.interpolate.RectBivariateSpline\` is...
 * `#9999 <https://github.com/scipy/scipy/issues/9999>`__: BUG: malloc() calls in Cython and C that are not checked for...
+* `#10096 <https://github.com/scipy/scipy/issues/10096>`__: Add literature reference for circstd (and circvar?)
+* `#10446 <https://github.com/scipy/scipy/issues/10446>`__: RuntimeWarning: invalid value encountered in stats.genextreme
 * `#10577 <https://github.com/scipy/scipy/issues/10577>`__: Additional discussion for scipy.stats roadmap
+* `#10821 <https://github.com/scipy/scipy/issues/10821>`__: Errors with the Yeo-Johnson Transform that also Appear in Scikit-Learn
 * `#10983 <https://github.com/scipy/scipy/issues/10983>`__: LOBPCG inefficinet when computing > 20% of eigenvalues
 * `#11145 <https://github.com/scipy/scipy/issues/11145>`__: unexpected SparseEfficiencyWarning at scipy.sparse.linalg.splu
 * `#11406 <https://github.com/scipy/scipy/issues/11406>`__: scipy.sparse.linalg.svds (v1.4.1) on singular matrix does not...
 * `#11447 <https://github.com/scipy/scipy/issues/11447>`__: scipy.interpolate.interpn: Handle ValueError('The points in dimension...
+* `#11673 <https://github.com/scipy/scipy/issues/11673>`__: intlinprog: integer linear program solver
+* `#11742 <https://github.com/scipy/scipy/issues/11742>`__: MAINT: stats: getting skewness alone takes 34000x longer than...
+* `#11806 <https://github.com/scipy/scipy/issues/11806>`__: Unexpectedly poor results when distribution fitting with \`weibull_min\`...
 * `#11828 <https://github.com/scipy/scipy/issues/11828>`__: UnivariateSpline gives varying results when multithreaded on...
+* `#11948 <https://github.com/scipy/scipy/issues/11948>`__: fitting discrete distributions
+* `#12073 <https://github.com/scipy/scipy/issues/12073>`__: Add note in documentation
 * `#12456 <https://github.com/scipy/scipy/issues/12456>`__: Add generalized mean calculation
 * `#12480 <https://github.com/scipy/scipy/issues/12480>`__: RectBivariateSpline derivative evaluator is slow
 * `#12485 <https://github.com/scipy/scipy/issues/12485>`__: linprog returns an incorrect message
+* `#12506 <https://github.com/scipy/scipy/issues/12506>`__: ENH: stats: one-sided p-values for statistical tests
+* `#12545 <https://github.com/scipy/scipy/issues/12545>`__: stats.pareto.fit raises RuntimeWarning
+* `#12548 <https://github.com/scipy/scipy/issues/12548>`__: scipy.stats.skew returning MaskedArray
 * `#12633 <https://github.com/scipy/scipy/issues/12633>`__: Offer simpler development workflow?
 * `#12658 <https://github.com/scipy/scipy/issues/12658>`__: scipy.stats.levy_stable.pdf can be inaccurate and return nan
 * `#12838 <https://github.com/scipy/scipy/issues/12838>`__: Accept multiple matrices in \`scipy.linalg.expm\`
@@ -598,6 +619,7 @@ Issues closed for 1.9.0
 * `#12871 <https://github.com/scipy/scipy/issues/12871>`__: Levy Stable distribution uses parameterisation that is not location...
 * `#13200 <https://github.com/scipy/scipy/issues/13200>`__: Errors made by scipy.optimize.linprog
 * `#13462 <https://github.com/scipy/scipy/issues/13462>`__: Too many warnings and results objects in public API for scipy.stats
+* `#13582 <https://github.com/scipy/scipy/issues/13582>`__: ENH: stats: \`rv_continuous.stats\` with array shapes: use \`_stats\`...
 * `#13615 <https://github.com/scipy/scipy/issues/13615>`__: RFC: switch to Meson as a build system
 * `#13632 <https://github.com/scipy/scipy/issues/13632>`__: stats.rv_discrete is not checking that xk values are integers
 * `#13655 <https://github.com/scipy/scipy/issues/13655>`__: MAINT: stats.rv_generic: \`moment\` method falls back to \`_munp\`...
@@ -608,6 +630,7 @@ Issues closed for 1.9.0
 * `#13996 <https://github.com/scipy/scipy/issues/13996>`__: Fisk distribution documentation typo
 * `#14035 <https://github.com/scipy/scipy/issues/14035>`__: \`roots_jacobi\` support for large parameter values
 * `#14081 <https://github.com/scipy/scipy/issues/14081>`__: \`scipy.optimize._linprog_simplex._apply_pivot\` relies on asymmetric...
+* `#14095 <https://github.com/scipy/scipy/issues/14095>`__: scipy.stats.norm.pdf takes too much time and memory
 * `#14162 <https://github.com/scipy/scipy/issues/14162>`__: Thread safety RectBivariateSpline
 * `#14267 <https://github.com/scipy/scipy/issues/14267>`__: BUG: online doc returns 404 - wrong \`reference\` in url
 * `#14313 <https://github.com/scipy/scipy/issues/14313>`__: ks_2samp: example description does not match example output
@@ -625,6 +648,7 @@ Issues closed for 1.9.0
 * `#14745 <https://github.com/scipy/scipy/issues/14745>`__: BUG: scipy.ndimage.convolve documentation is incorrect
 * `#14750 <https://github.com/scipy/scipy/issues/14750>`__: ENH: Add one more derivative-free optimization method
 * `#14777 <https://github.com/scipy/scipy/issues/14777>`__: BUG: Wrong limit and no warning in stats.t for df=np.inf
+* `#14793 <https://github.com/scipy/scipy/issues/14793>`__: BUG: Missing pairs in cKDTree.query_pairs when coordinates contain...
 * `#14861 <https://github.com/scipy/scipy/issues/14861>`__: BUG: unclear error message when all bounds are all equal for...
 * `#14889 <https://github.com/scipy/scipy/issues/14889>`__: BUG: NumPy's \`random\` module should not be in the \`scipy\`...
 * `#14914 <https://github.com/scipy/scipy/issues/14914>`__: CI job with code coverage is failing (yet again)
@@ -729,8 +753,13 @@ Issues closed for 1.9.0
 * `#16337 <https://github.com/scipy/scipy/issues/16337>`__: TST: stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full...
 * `#16347 <https://github.com/scipy/scipy/issues/16347>`__: TST, MAINT: 32-bit Linux test failures in wheels repo
 * `#16358 <https://github.com/scipy/scipy/issues/16358>`__: TST, MAINT: test_theilslopes_warnings fails on 32-bit Windows
-* `#16378 <https://github.com/scipy/scipy/issues/16378>`__: DOC: pydata-sphinx-theme v0.9 defaults to darkmode...
+* `#16378 <https://github.com/scipy/scipy/issues/16378>`__: DOC: pydata-sphinx-theme v0.9 defaults to darkmode depending...
+* `#16381 <https://github.com/scipy/scipy/issues/16381>`__: BUG: bootstrap get ValueError for paired statistic
+* `#16382 <https://github.com/scipy/scipy/issues/16382>`__: BUG: truncnorm.fit does not fit correctly
+* `#16403 <https://github.com/scipy/scipy/issues/16403>`__: MAINT: NumPy main will require a few updates due to new floating...
 * `#16409 <https://github.com/scipy/scipy/issues/16409>`__: BUG: SIGSEGV in qhull when array type is wrong
+* `#16419 <https://github.com/scipy/scipy/issues/16419>`__: BUG: scipy.stats.nbinom.logcdf returns wrong results when some...
+* `#16426 <https://github.com/scipy/scipy/issues/16426>`__: BUG: stats.shapiro inplace modification of user array
 
 ***********************
 Pull requests for 1.9.0
@@ -744,6 +773,7 @@ Pull requests for 1.9.0
 * `#13955 <https://github.com/scipy/scipy/pull/13955>`__: DOC: SciPy extensions for code style and docstring guidelines.
 * `#14003 <https://github.com/scipy/scipy/pull/14003>`__: DOC: clarify the definition of the pdf of \`stats.fisk\`
 * `#14036 <https://github.com/scipy/scipy/pull/14036>`__: ENH: fix numerical issues in roots_jacobi and related special...
+* `#14087 <https://github.com/scipy/scipy/pull/14087>`__: DOC: explain null hypotheses in ttest functions
 * `#14142 <https://github.com/scipy/scipy/pull/14142>`__: DOC: Add better error message for unpacking issue
 * `#14143 <https://github.com/scipy/scipy/pull/14143>`__: Support LinearOperator in expm_multiply
 * `#14300 <https://github.com/scipy/scipy/pull/14300>`__: ENH: Adding DIRECT algorithm to \`\`scipy.optimize\`\`
@@ -756,6 +786,7 @@ Pull requests for 1.9.0
 * `#15001 <https://github.com/scipy/scipy/pull/15001>`__: ENH: sparse.linalg: More comprehensive tests (Not only for 1-D...
 * `#15026 <https://github.com/scipy/scipy/pull/15026>`__: ENH: allow approx_fprime to work with vector-valued func
 * `#15079 <https://github.com/scipy/scipy/pull/15079>`__: ENH:linalg: expm overhaul and ndarray processing
+* `#15140 <https://github.com/scipy/scipy/pull/15140>`__: ENH: Make \`stats.kappa3\` work with array inputs
 * `#15154 <https://github.com/scipy/scipy/pull/15154>`__: DOC: a small bug in docstring example of \`lobpcg\`
 * `#15165 <https://github.com/scipy/scipy/pull/15165>`__: MAINT: Avoid using del to remove numpy symbols in scipy.__init__.py
 * `#15168 <https://github.com/scipy/scipy/pull/15168>`__: REL: set version to 1.9.0.dev0
@@ -778,6 +809,7 @@ Pull requests for 1.9.0
 * `#15234 <https://github.com/scipy/scipy/pull/15234>`__: TST: stats: mark very slow tests as \`xslow\`
 * `#15243 <https://github.com/scipy/scipy/pull/15243>`__: DOC: stats: add reference for gstd
 * `#15244 <https://github.com/scipy/scipy/pull/15244>`__: Added example for morphology: binary_dilation and erosion
+* `#15250 <https://github.com/scipy/scipy/pull/15250>`__: ENH: Make \`stats.kappa4\` work with array
 * `#15251 <https://github.com/scipy/scipy/pull/15251>`__: [MRG] ENH: Update \`laplacian\` function introducing the new...
 * `#15255 <https://github.com/scipy/scipy/pull/15255>`__: MAINT: Remove \`distutils\` usage in \`runtests.py\` to fix deprecation...
 * `#15259 <https://github.com/scipy/scipy/pull/15259>`__: MAINT: optimize, special, signal: Use custom warnings instead...
@@ -883,6 +915,7 @@ Pull requests for 1.9.0
 * `#15578 <https://github.com/scipy/scipy/pull/15578>`__: Make Windows Python setup more standard
 * `#15581 <https://github.com/scipy/scipy/pull/15581>`__: MAINT: clarify deprecation warning spatial.transform.rotation
 * `#15583 <https://github.com/scipy/scipy/pull/15583>`__: DOC: clarify O(N) SO(N) in random rotations
+* `#15586 <https://github.com/scipy/scipy/pull/15586>`__: ENH: stats: Add 'alternative' and confidence interval to pearsonr
 * `#15590 <https://github.com/scipy/scipy/pull/15590>`__: DOC: factorialk docstring inconsistent with code
 * `#15597 <https://github.com/scipy/scipy/pull/15597>`__: DOC: update \`hyp2f1\` docstring example based on doctest
 * `#15598 <https://github.com/scipy/scipy/pull/15598>`__: BUG/ENH: \`lsq_linear\`: fixed incorrect \`lsmr_tol\` in first...
@@ -894,6 +927,7 @@ Pull requests for 1.9.0
 * `#15625 <https://github.com/scipy/scipy/pull/15625>`__: MAINT: Clean up \`type: ignore\` comments related to third-party...
 * `#15626 <https://github.com/scipy/scipy/pull/15626>`__: TST, MAINT: ignore np distutils dep
 * `#15629 <https://github.com/scipy/scipy/pull/15629>`__: MAINT: stats: fix \`trim1\` \`axis\` behavior
+* `#15632 <https://github.com/scipy/scipy/pull/15632>`__: ENH: stats.wilcoxon: return z-statistic (as requested)
 * `#15634 <https://github.com/scipy/scipy/pull/15634>`__: CI: Improve concurrency to cancel running jobs on PR update
 * `#15645 <https://github.com/scipy/scipy/pull/15645>`__: DOC: Add code example to the documentation of \`sparse.linalg.cg\`.
 * `#15646 <https://github.com/scipy/scipy/pull/15646>`__: DOC: stats.ks_1samp: correct examples
@@ -901,6 +935,7 @@ Pull requests for 1.9.0
 * `#15648 <https://github.com/scipy/scipy/pull/15648>`__: DOC: Add examples to documentation for \`scipy.special.ellipr{c,d,f,g,j}\`
 * `#15649 <https://github.com/scipy/scipy/pull/15649>`__: DEV/DOC: remove latex/pdf documentation
 * `#15651 <https://github.com/scipy/scipy/pull/15651>`__: DOC: stats.ks_2samp/stats.kstest: correct examples
+* `#15652 <https://github.com/scipy/scipy/pull/15652>`__: DOC: stats.circstd: add reference, notes, comments
 * `#15655 <https://github.com/scipy/scipy/pull/15655>`__: REL: fix small issue in pavement.py for release note writing
 * `#15656 <https://github.com/scipy/scipy/pull/15656>`__: DOC: Fix example for subset_by_index in eigh doc
 * `#15661 <https://github.com/scipy/scipy/pull/15661>`__: DOC: Additional examples for optimize user guide
@@ -919,6 +954,7 @@ Pull requests for 1.9.0
 * `#15712 <https://github.com/scipy/scipy/pull/15712>`__: ENH: \`scipy.stats.qmc.Sobol\`: allow 32 or 64 bit computation
 * `#15715 <https://github.com/scipy/scipy/pull/15715>`__: ENH: stats: add _axis_nan_policy_factory to moment
 * `#15718 <https://github.com/scipy/scipy/pull/15718>`__: ENH: Migration of \`write_release_and_log\` into standalone script
+* `#15723 <https://github.com/scipy/scipy/pull/15723>`__: TST: stats: make \`check_sample_var\` two-sided
 * `#15724 <https://github.com/scipy/scipy/pull/15724>`__: TST: stats: simplify \`check_sample_mean\`
 * `#15725 <https://github.com/scipy/scipy/pull/15725>`__: DEV: Try to detect scipy from dev installed path
 * `#15728 <https://github.com/scipy/scipy/pull/15728>`__: ENH: changed vague exception messages to a more descriptive ones...
@@ -927,6 +963,7 @@ Pull requests for 1.9.0
 * `#15766 <https://github.com/scipy/scipy/pull/15766>`__: BUG: improve exceptions for private attributes in refactored...
 * `#15768 <https://github.com/scipy/scipy/pull/15768>`__: [DOC] fix typo in cython optimize help example
 * `#15769 <https://github.com/scipy/scipy/pull/15769>`__: MAINT: stats: check integrality in \`_argcheck\` as needed
+* `#15771 <https://github.com/scipy/scipy/pull/15771>`__: MAINT: stats: resolve discrete rvs dtype platform dependency
 * `#15774 <https://github.com/scipy/scipy/pull/15774>`__: MAINT: stats: remove deprecated \`median_absolute_deviation\`
 * `#15775 <https://github.com/scipy/scipy/pull/15775>`__: DOC: stats.lognorm: rephrase note about parameterization
 * `#15776 <https://github.com/scipy/scipy/pull/15776>`__: DOC: stats.powerlaw: more explicit explanation of support
@@ -1004,16 +1041,19 @@ Pull requests for 1.9.0
 * `#15946 <https://github.com/scipy/scipy/pull/15946>`__: DEP: remove inheritance to \`QMCEngine\` in \`MultinomialQMC\`...
 * `#15947 <https://github.com/scipy/scipy/pull/15947>`__: DOC: Revamp contributor setup guides
 * `#15953 <https://github.com/scipy/scipy/pull/15953>`__: DOC: Add meson docs to use gcc, clang build in parallel and optimization...
+* `#15955 <https://github.com/scipy/scipy/pull/15955>`__: BUG Fix signature of D_IIR_forback(1,2)
 * `#15959 <https://github.com/scipy/scipy/pull/15959>`__: ENH: Developer CLI for SciPy
 * `#15965 <https://github.com/scipy/scipy/pull/15965>`__: MAINT: stats: ensure that \`rv_continuous._fitstart\` shapes...
 * `#15968 <https://github.com/scipy/scipy/pull/15968>`__: BUG: Fix debug and coverage arguments with dev.py
 * `#15970 <https://github.com/scipy/scipy/pull/15970>`__: BLD: specify \`cython_lapack\` dependency for \`matfuncs_expm\`
 * `#15973 <https://github.com/scipy/scipy/pull/15973>`__: DOC: Add formula renderings to integrate.nquad.
 * `#15981 <https://github.com/scipy/scipy/pull/15981>`__: ENH: optimize: Add Newton-TFQMR method and some tests for Newton-Krylov
+* `#15982 <https://github.com/scipy/scipy/pull/15982>`__: BENCH: stats: Distribution memory and CDF/PPF round trip benchmarks
 * `#15983 <https://github.com/scipy/scipy/pull/15983>`__: TST: sparse.linalg: Add tests for the parameter \`show\`
 * `#15991 <https://github.com/scipy/scipy/pull/15991>`__: TST: fix for np.kron matrix issue.
 * `#15992 <https://github.com/scipy/scipy/pull/15992>`__: DOC: Fixed \`degrees\` parameter in return section
 * `#15997 <https://github.com/scipy/scipy/pull/15997>`__: MAINT: integrate: add \`recursive\` to QUADPACK Fortran sources
+* `#15998 <https://github.com/scipy/scipy/pull/15998>`__: BUG: Fix yeojohnson when transformed data has zero variance
 * `#15999 <https://github.com/scipy/scipy/pull/15999>`__: MAINT: Adds doit.db.db to gitignore
 * `#16004 <https://github.com/scipy/scipy/pull/16004>`__: MAINT: rename MaximumFlowResult.residual to flow
 * `#16005 <https://github.com/scipy/scipy/pull/16005>`__: DOC: sparse.linalg: Fixed the description of input matrix of...
@@ -1090,6 +1130,7 @@ Pull requests for 1.9.0
 * `#16230 <https://github.com/scipy/scipy/pull/16230>`__: BUG: fix extension module initialization, needs use of PyMODINIT_FUNC,...
 * `#16239 <https://github.com/scipy/scipy/pull/16239>`__: MAINT: tools: Add more output to a refguide-check error message.
 * `#16241 <https://github.com/scipy/scipy/pull/16241>`__: DOC: stats: update roadmap
+* `#16242 <https://github.com/scipy/scipy/pull/16242>`__: BUG: Make KDTree more robust against nans.
 * `#16245 <https://github.com/scipy/scipy/pull/16245>`__: DEP: Execute deprecation of pinv2
 * `#16247 <https://github.com/scipy/scipy/pull/16247>`__: DOC:linalg: Remove references to removed pinv2 function
 * `#16248 <https://github.com/scipy/scipy/pull/16248>`__: DOC: prep 1.9.0 release notes
@@ -1126,3 +1167,6 @@ Pull requests for 1.9.0
 * `#16379 <https://github.com/scipy/scipy/pull/16379>`__: DOC: dark theme css adjustments
 * `#16390 <https://github.com/scipy/scipy/pull/16390>`__: TST, MAINT: adjust 32-bit xfails for HiGHS
 * `#16414 <https://github.com/scipy/scipy/pull/16414>`__: BUG: spatial: Handle integer arrays in HalfspaceIntersection.
+* `#16420 <https://github.com/scipy/scipy/pull/16420>`__: MAINT: next round of 1.9.0 backports
+* `#16422 <https://github.com/scipy/scipy/pull/16422>`__: TST: fix test issues with casting-related warnings with numpy...
+* `#16427 <https://github.com/scipy/scipy/pull/16427>`__: MAINT: stats.shapiro: don't modify input in place

--- a/scipy/io/_mmio.py
+++ b/scipy/io/_mmio.py
@@ -13,6 +13,7 @@
 import os
 import sys
 
+import numpy as np
 from numpy import (asarray, real, imag, conj, zeros, ndarray, concatenate,
                    ones, can_cast)
 
@@ -382,8 +383,10 @@ class MMFile:
             else:
                 if issymm and aij != aji:
                     issymm = False
-                if isskew and aij != -aji:
-                    isskew = False
+                with np.errstate(over="ignore"):
+                    # This can give a warning for uint dtypes, so silence that
+                    if isskew and aij != -aji:
+                        isskew = False
                 if isherm and aij != conj(aji):
                     isherm = False
             if not (issymm or isskew or isherm):

--- a/scipy/optimize/tests/test_milp.py
+++ b/scipy/optimize/tests/test_milp.py
@@ -183,7 +183,7 @@ def test_milp_3():
     c = [0, -1]
     A = [[-1, 1], [3, 2], [2, 3]]
     b_u = [1, 12, 12]
-    b_l = np.full_like(b_u, -np.inf)
+    b_l = np.full_like(b_u, -np.inf, dtype=np.float64)
     constraints = LinearConstraint(A, b_l, b_u)
 
     integrality = np.ones_like(c)

--- a/scipy/signal/_bspline_util.c.in
+++ b/scipy/signal/_bspline_util.c.in
@@ -5,6 +5,8 @@
 #include <string.h>
 #include <stdio.h>
 
+#include "_splinemodule.h"
+
 #define NO_IMPORT_ARRAY
 #include "numpy/arrayobject.h"
 
@@ -43,11 +45,12 @@ compute_root_from_lambda(lambda, r, omega)
 CNAME = ['C', 'Z']
 CTYPE = ['__complex__ float', '__complex__ double']
 
-RNAME = ['D', 'S']
-RTYPE = ['double', 'float']
+RNAME = ['S', 'D']
+RTYPE = ['float', 'double']
 
 NAMES = CNAME + RNAME
 TYPES = CTYPE + RTYPE
+RTYPES = RTYPE + RTYPE
 
 }}
 
@@ -174,17 +177,17 @@ void {{SUB}}_IIR_order2_cascade({{TYP}} cs, {{TYP}} z1, {{TYP}} z2,
 
 */
 
-{{for SUB, TYP in zip(NAMES, TYPES)}}
+{{for SUB, TYP, RTYP in zip(NAMES, TYPES, RTYPES)}}
 {{if SUB in CNAME}}
 #ifdef __GNUC__
 {{endif}}
 int {{SUB}}_IIR_forback1({{TYP}} c0, {{TYP}} z1, {{TYP}} *x, {{TYP}} *y,
-               int N, int stridex, int stridey, float precision)
+                   int N, int stridex, int stridey, {{RTYP}} precision)
 {
     {{TYP}} *yp = NULL;
     {{TYP}} *xptr = x;
     {{TYP}} yp0, powz1, diff;
-    float err;
+    {{RTYP}} err;
     int k;
 
     if (ABSQ(z1) >= 1.0) return -2; /* z1 not less than 1 */
@@ -430,7 +433,7 @@ static {{TYP}} {{SUB}}_hs(int, {{TYP}}, double, double);
 
 {{for SUB, TYP in zip(RNAME, RTYPE)}}
 int {{SUB}}_IIR_forback2 (double r, double omega, {{TYP}} *x, {{TYP}} *y,
-		int N, int stridex, int stridey, float precision) {
+		int N, int stridex, int stridey, {{TYP}} precision) {
     {{TYP}} cs;
     {{TYP}} *yp = NULL;
     {{TYP}} *yptr;

--- a/scipy/signal/_splinemodule.c
+++ b/scipy/signal/_splinemodule.c
@@ -1,30 +1,4 @@
-#include "Python.h"
-#include "numpy/arrayobject.h"
-#include <math.h>
-
-
-#define PYERR(message) do {PyErr_SetString(PyExc_ValueError, message); goto fail;} while(0)
-
-static void convert_strides(npy_intp*,npy_intp*,int,int);
-
-extern int S_cubic_spline2D(float*,float*,int,int,double,npy_intp*,npy_intp*,float);
-extern int S_quadratic_spline2D(float*,float*,int,int,double,npy_intp*,npy_intp*,float);
-extern int S_IIR_forback1(float,float,float*,float*,int,int,int,float);
-extern int S_IIR_forback2(double,double,float*,float*,int,int,int,float);
-extern int S_separable_2Dconvolve_mirror(float*,float*,int,int,float*,float*,int,int,npy_intp*,npy_intp*);
-
-extern int D_cubic_spline2D(double*,double*,int,int,double,npy_intp*,npy_intp*,double);
-extern int D_quadratic_spline2D(double*,double*,int,int,double,npy_intp*,npy_intp*,double);
-extern int D_IIR_forback1(double,double,double*,double*,int,int,int,double);
-extern int D_IIR_forback2(double,double,double*,double*,int,int,int,double);
-extern int D_separable_2Dconvolve_mirror(double*,double*,int,int,double*,double*,int,int,npy_intp*,npy_intp*);
-
-#ifdef __GNUC__
-extern int C_IIR_forback1(__complex__ float,__complex__ float,__complex__ float*,__complex__ float*,int,int,int,float);
-extern int C_separable_2Dconvolve_mirror(__complex__ float*,__complex__ float*,int,int,__complex__ float*,__complex__ float*,int,int,npy_intp*,npy_intp*);
-extern int Z_IIR_forback1(__complex__ double,__complex__ double,__complex__ double*,__complex__ double*,int,int,int,double);
-extern int Z_separable_2Dconvolve_mirror(__complex__ double*,__complex__ double*,int,int,__complex__ double*,__complex__ double*,int,int,npy_intp*,npy_intp*);
-#endif
+#include "_splinemodule.h"
 
 static void
 convert_strides(npy_intp* instrides,npy_intp* convstrides,int size,int N)

--- a/scipy/signal/_splinemodule.h
+++ b/scipy/signal/_splinemodule.h
@@ -1,0 +1,27 @@
+#include "Python.h"
+#include "numpy/arrayobject.h"
+#include <math.h>
+
+
+#define PYERR(message) do {PyErr_SetString(PyExc_ValueError, message); goto fail;} while(0)
+
+static void convert_strides(npy_intp*,npy_intp*,int,int);
+
+extern int S_cubic_spline2D(float*,float*,int,int,double,npy_intp*,npy_intp*,float);
+extern int S_quadratic_spline2D(float*,float*,int,int,double,npy_intp*,npy_intp*,float);
+extern int S_IIR_forback1(float,float,float*,float*,int,int,int,float);
+extern int S_IIR_forback2(double,double,float*,float*,int,int,int,float);
+extern int S_separable_2Dconvolve_mirror(float*,float*,int,int,float*,float*,int,int,npy_intp*,npy_intp*);
+
+extern int D_cubic_spline2D(double*,double*,int,int,double,npy_intp*,npy_intp*,double);
+extern int D_quadratic_spline2D(double*,double*,int,int,double,npy_intp*,npy_intp*,double);
+extern int D_IIR_forback1(double,double,double*,double*,int,int,int,double);
+extern int D_IIR_forback2(double,double,double*,double*,int,int,int,double);
+extern int D_separable_2Dconvolve_mirror(double*,double*,int,int,double*,double*,int,int,npy_intp*,npy_intp*);
+
+#ifdef __GNUC__
+extern int C_IIR_forback1(__complex__ float,__complex__ float,__complex__ float*,__complex__ float*,int,int,int,float);
+extern int C_separable_2Dconvolve_mirror(__complex__ float*,__complex__ float*,int,int,__complex__ float*,__complex__ float*,int,int,npy_intp*,npy_intp*);
+extern int Z_IIR_forback1(__complex__ double,__complex__ double,__complex__ double*,__complex__ double*,int,int,int,double);
+extern int Z_separable_2Dconvolve_mirror(__complex__ double*,__complex__ double*,int,int,__complex__ double*,__complex__ double*,int,int,npy_intp*,npy_intp*);
+#endif

--- a/scipy/sparse/tests/test_sparsetools.py
+++ b/scipy/sparse/tests/test_sparsetools.py
@@ -295,7 +295,10 @@ def test_upcast():
             if np.issubdtype(b_dtype, np.complexfloating):
                 b = b0.copy().astype(b_dtype)
             else:
-                b = b0.real.copy().astype(b_dtype)
+                with np.errstate(invalid="ignore"):
+                    # Casting a large value (2**32) to int8 causes a warning in
+                    # numpy >1.23
+                    b = b0.real.copy().astype(b_dtype)
 
             if not (a_dtype == np.bool_ and b_dtype == np.bool_):
                 c = np.zeros((2,), dtype=np.bool_)

--- a/scipy/spatial/ckdtree/src/build.cxx
+++ b/scipy/spatial/ckdtree/src/build.cxx
@@ -99,7 +99,7 @@ build(ckdtree *self, ckdtree_intp_t start_idx, intptr_t end_idx,
         auto partition_pivot = [=](ckdtree_intp_t* first, ckdtree_intp_t* last, double pivot) {
             const auto partition_ptr = std::partition(
                 first, last,
-                [&](ckdtree_intp_t a) { return data[a * m + d] < pivot; });
+                [&](ckdtree_intp_t a) { return !(data[a * m + d] >= pivot); });
             return partition_ptr - indices;
         };
 

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -219,6 +219,10 @@ def _weight_masked(arrays, weights, axis):
 
 
 def _rand_split(arrays, weights, axis, split_per, seed=None):
+    # Coerce `arrays` to float64 if integer, to avoid nan-to-integer issues
+    arrays = [arr.astype(np.float64) if np.issubdtype(arr.dtype, np.integer)
+              else arr for arr in arrays]
+
     # inverse operation for stats.collapse_weights
     weights = np.array(weights, dtype=np.float64)  # modified inplace; need a copy
     seeded_rand = np.random.RandomState(seed)

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -1444,3 +1444,13 @@ def test_kdtree_count_neighbors_weighted(kdtree_class):
     expect = [np.sum(weights[(prev_radius < dist) & (dist <= radius)])
               for prev_radius, radius in zip(itertools.chain([0], r[:-1]), r)]
     assert_allclose(nAB, expect)
+
+
+def test_kdtree_nan():
+    vals = [1, 5, -10, 7, -4, -16, -6, 6, 3, -11]
+    n = len(vals)
+    data = np.concatenate([vals, np.full(n, np.nan)])[:, None]
+
+    query_with_nans = KDTree(data).query_pairs(2)
+    query_without_nans = KDTree(data[:n]).query_pairs(2)
+    assert query_with_nans == query_without_nans

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1786,7 +1786,7 @@ def shapiro(x):
     if N < 3:
         raise ValueError("Data must be at least length 3.")
 
-    x -= np.median(x)
+    x = x - np.median(x)
 
     a = zeros(N, 'f')
     init = 0


### PR DESCRIPTION
* backports for:
  - gh-15955
  - gh-16242
  - gh-16422
  - gh-16427
* update release notes accordingly
  - you may notice a bunch of extra issues showing up beyond the backports because Matt did some manual milestone labeling for things that slipped through recently
  - you may notice a few cases where the same entry has a formatting change--that's because I was able to use the list scripts instead of getting API throttled at work on the last go

If things end up looking good in gh-16353 now, with the new `meson-python` looking solid locally at least, then I'd say we should be on the precipice of attempting `1.9.0rc1` process. Note that I'm on vacation visiting my folks so I may be a little slow, but I'll try to keep the process rolling forward so that we can at least find out if there are any more hurdles sooner than later.