### PR TITLE
ENH: stats.bootstrap: return bootstrap distribution

### DIFF
--- a/scipy/stats/_resampling.py
+++ b/scipy/stats/_resampling.py
@@ -365,11 +365,11 @@ def bootstrap(data, statistic, *, n_resamples=9999, batch=None,
     >>> data = (data,)  # samples must be in a sequence
     >>> res = bootstrap(data, np.std, confidence_level=0.9,
     ...                 random_state=rng)
-    >>> plt.hist(res.bootstrap_distribution, bins=25)
-    >>> plt.title('Bootstrap Distribution')
-    >>> plt.xlabel('statistic value')
-    >>> plt.ylabel('frequency')
-    >>> plt.show()
+    >>> fig, ax = plt.subplots()
+    >>> ax.hist(res.bootstrap_distribution, bins=25)
+    >>> ax.set_title('Bootstrap Distribution')
+    >>> ax.set_xlabel('statistic value')
+    >>> ax.set_ylabel('frequency')
 
     The standard error quantifies this variability. It is calculated as the
     standard deviation of the bootstrap distribution.
@@ -384,12 +384,12 @@ def bootstrap(data, statistic, *, n_resamples=9999, batch=None,
 
     >>> x = np.linspace(3, 5)
     >>> pdf = norm.pdf(x, loc=std_sample, scale=res.standard_error)
-    >>> plt.hist(res.bootstrap_distribution, bins=25, density=True)
-    >>> plt.plot(x, pdf)
-    >>> plt.title('Normal Approximation of the Bootstrap Distribution')
-    >>> plt.xlabel('statistic value')
-    >>> plt.ylabel('pdf')
-    >>> plt.show()
+    >>> fig, ax = plt.subplots()
+    >>> ax.hist(res.bootstrap_distribution, bins=25, density=True)
+    >>> ax.plot(x, pdf)
+    >>> ax.set_title('Normal Approximation of the Bootstrap Distribution')
+    >>> ax.set_xlabel('statistic value')
+    >>> ax.set_ylabel('pdf')
 
     This suggests that we could construct a 90% confidence interval on the
     statistic based on quantiles of this normal distribution.

--- a/scipy/stats/_resampling.py
+++ b/scipy/stats/_resampling.py
@@ -210,7 +210,7 @@ def _bootstrap_iv(data, statistic, vectorized, paired, axis, confidence_level,
             method, random_state)
 
 
-fields = ['confidence_interval', 'standard_error']
+fields = ['confidence_interval', 'bootstrap_distribution', 'standard_error']
 BootstrapResult = make_dataclass("BootstrapResult", fields)
 
 
@@ -303,9 +303,13 @@ def bootstrap(data, statistic, *, n_resamples=9999, batch=None,
         confidence_interval : ConfidenceInterval
             The bootstrap confidence interval as an instance of
             `collections.namedtuple` with attributes `low` and `high`.
+        bootstrap_distribution : ndarray
+            The bootstrap distribution, that is, the value of `statistic` for
+            each resample. The last dimension corresponds with the resamples
+            (e.g. ``res.bootstrap_distribution.shape[-1] == n_resamples``).
         standard_error : float or ndarray
             The bootstrap standard error, that is, the sample standard
-            deviation of the bootstrap distribution
+            deviation of the bootstrap distribution.
 
     Warns
     -----
@@ -340,7 +344,7 @@ def bootstrap(data, statistic, *, n_resamples=9999, batch=None,
     >>> dist = norm(loc=2, scale=4)  # our "unknown" distribution
     >>> data = dist.rvs(size=100, random_state=rng)
 
-    We are interested int the standard deviation of the distribution.
+    We are interested in the standard deviation of the distribution.
 
     >>> std_true = dist.std()      # the true value of the statistic
     >>> print(std_true)
@@ -349,19 +353,60 @@ def bootstrap(data, statistic, *, n_resamples=9999, batch=None,
     >>> print(std_sample)
     3.9460644295563863
 
-    We can calculate a 90% confidence interval of the statistic using
-    `bootstrap`.
+    The bootstrap is used to approximate the variability we would expect if we
+    were to repeatedly sample from the unknown distribution and calculate the
+    statistic of the sample each time. It does this by repeatedly resampling
+    values *from the original sample* with replacement and calculating the
+    statistic of each resample. This results in a "bootstrap distribution" of
+    the statistic.
 
+    >>> import matplotlib.pyplot as plt
     >>> from scipy.stats import bootstrap
     >>> data = (data,)  # samples must be in a sequence
     >>> res = bootstrap(data, np.std, confidence_level=0.9,
     ...                 random_state=rng)
+    >>> plt.hist(res.bootstrap_distribution, bins=25)
+    >>> plt.title('Bootstrap Distribution')
+    >>> plt.xlabel('statistic value')
+    >>> plt.ylabel('frequency')
+    >>> plt.show()
+
+    The standard error quantifies this variability. It is calculated as the
+    standard deviation of the bootstrap distribution.
+
+    >>> res.standard_error
+    0.24427002125829136
+    >>> res.standard_error == np.std(res.bootstrap_distribution, ddof=1)
+    True
+
+    The bootstrap distribution of the statistic is often approximately normal
+    with scale equal to the standard error.
+
+    >>> x = np.linspace(3, 5)
+    >>> pdf = norm.pdf(x, loc=std_sample, scale=res.standard_error)
+    >>> plt.hist(res.bootstrap_distribution, bins=25, density=True)
+    >>> plt.plot(x, pdf)
+    >>> plt.title('Normal Approximation of the Bootstrap Distribution')
+    >>> plt.xlabel('statistic value')
+    >>> plt.ylabel('pdf')
+    >>> plt.show()
+
+    This suggests that we could construct a 90% confidence interval on the
+    statistic based on quantiles of this normal distribution.
+
+    >>> norm.interval(0.9, loc=std_sample, scale=res.standard_error)
+    (3.5442759991341726, 4.3478528599786)
+
+    However, the normal approximation is not always accurate. By default,
+    `bootstrap` uses more advanced techniques to make the confidence interval
+    more accurate.
+
     >>> print(res.confidence_interval)
     ConfidenceInterval(low=3.57655333533867, high=4.382043696342881)
 
-    If we sample from the distribution 1000 times and form a bootstrap
+    If we sample from the original distribution 1000 times and form a bootstrap
     confidence interval for each sample, the confidence interval
-    contains the true value of the statistic approximately 900 times.
+    contains the true value of the statistic approximately 90% of the time.
 
     >>> n_trials = 1000
     >>> ci_contains_true_std = 0
@@ -493,6 +538,7 @@ def bootstrap(data, statistic, *, n_resamples=9999, batch=None,
         ci_l, ci_u = 2*theta_hat - ci_u, 2*theta_hat - ci_l
 
     return BootstrapResult(confidence_interval=ConfidenceInterval(ci_l, ci_u),
+                           bootstrap_distribution=theta_hat_b,
                            standard_error=np.std(theta_hat_b, ddof=1, axis=-1))
 
 

--- a/scipy/stats/_resampling.py
+++ b/scipy/stats/_resampling.py
@@ -397,9 +397,12 @@ def bootstrap(data, statistic, *, n_resamples=9999, batch=None,
     >>> norm.interval(0.9, loc=std_sample, scale=res.standard_error)
     (3.5442759991341726, 4.3478528599786)
 
-    However, the normal approximation is not always accurate. By default,
-    `bootstrap` uses more advanced techniques to make the confidence interval
-    more accurate.
+    Due to central limit theorem, this normal approximation is accurate for a
+    variety of statistics and distributions underlying the samples; however,
+    the approximation is not reliable in all cases. Because `bootstrap` is
+    designed to work with arbitrary underyling distributions and statistics,
+    it uses more advanced techniques to generate an accurate confidence
+    interval.
 
     >>> print(res.confidence_interval)
     ConfidenceInterval(low=3.57655333533867, high=4.382043696342881)

--- a/scipy/stats/_resampling.py
+++ b/scipy/stats/_resampling.py
@@ -370,6 +370,7 @@ def bootstrap(data, statistic, *, n_resamples=9999, batch=None,
     >>> ax.set_title('Bootstrap Distribution')
     >>> ax.set_xlabel('statistic value')
     >>> ax.set_ylabel('frequency')
+    >>> plt.show()
 
     The standard error quantifies this variability. It is calculated as the
     standard deviation of the bootstrap distribution.
@@ -390,6 +391,7 @@ def bootstrap(data, statistic, *, n_resamples=9999, batch=None,
     >>> ax.set_title('Normal Approximation of the Bootstrap Distribution')
     >>> ax.set_xlabel('statistic value')
     >>> ax.set_ylabel('pdf')
+    >>> plt.show()
 
     This suggests that we could construct a 90% confidence interval on the
     statistic based on quantiles of this normal distribution.
@@ -400,7 +402,7 @@ def bootstrap(data, statistic, *, n_resamples=9999, batch=None,
     Due to central limit theorem, this normal approximation is accurate for a
     variety of statistics and distributions underlying the samples; however,
     the approximation is not reliable in all cases. Because `bootstrap` is
-    designed to work with arbitrary underyling distributions and statistics,
+    designed to work with arbitrary underlying distributions and statistics,
     it uses more advanced techniques to generate an accurate confidence
     interval.
 

--- a/scipy/stats/tests/test_resampling.py
+++ b/scipy/stats/tests/test_resampling.py
@@ -141,6 +141,8 @@ def test_bootstrap_vectorized(method, axis, paired):
     z = np.random.rand(n_samples)
     res1 = bootstrap((x, y, z), my_statistic, paired=paired, method=method,
                      random_state=0, axis=0, n_resamples=100)
+    assert (res1.bootstrap_distribution.shape
+            == res1.standard_error.shape + (100,))
 
     reshape = [1, 1, 1]
     reshape[axis] = n_samples
@@ -512,7 +514,7 @@ def test_vector_valued_statistic(method):
         return stats.norm.fit(data)
 
     res = bootstrap((sample,), statistic, method=method, axis=-1,
-                    vectorized=False)
+                    vectorized=False, n_resamples=9999)
 
     counts = np.sum((res.confidence_interval.low.T < params)
                     & (res.confidence_interval.high.T > params),
@@ -522,6 +524,7 @@ def test_vector_valued_statistic(method):
     assert res.confidence_interval.low.shape == (2, 100)
     assert res.confidence_interval.high.shape == (2, 100)
     assert res.standard_error.shape == (2, 100)
+    assert res.bootstrap_distribution.shape == (2, 100, 9999)
 
 
 # --- Test Monte Carlo Hypothesis Test --- #


### PR DESCRIPTION
#### Reference issue
gh-16433 

#### What does this implement/fix?
One of the requests in gh-16433 was for `stats.bootstrap` to return the bootstrap distribution. This PR implements that suggestion.

#### Additional information
I also added this to the example. @FlorinAndrei If you could review the example from a technical standpoint, I think it would help ensure that this enhancement makes it into SciPy 1.10. 
