### PR TITLE
CI: Update Python 3.8-dbg job to ubuntu-20.04

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,7 +18,7 @@ jobs:
   Python-38-dbg:
     name: Python 3.8-dbg
     if: "github.repository == 'scipy/scipy' || github.repository == ''"
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Bumping the ubuntu to focal updates python-3.8-dbg package to `3.8.10` (earlier 3.8.0 in bionic) provided by the package manager. This should fix the failing python3.8-dbg CI job in #15607. Tested in anirudhdagar/scipy#7.

[skip azp]

cc @rgommers 