### PR TITLE
ENH: stats.jarque_bera: add axis, nan_policy, masked array support

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -1861,10 +1861,7 @@ def normaltest(a, axis=0, nan_policy='propagate'):
     return NormaltestResult(k2, distributions.chi2.sf(k2, 2))
 
 
-JarqueBeraResult = namedtuple('JarqueBeraResult', ('statistic', 'pvalue'))
-
-
-@_axis_nan_policy_factory(tuple_to_result=JarqueBeraResult, default_axis=None)
+@_axis_nan_policy_factory(SignificanceResult, default_axis=None)
 def jarque_bera(x, *, axis=None):
     """Perform the Jarque-Bera goodness of fit test on sample data.
 
@@ -1887,7 +1884,7 @@ def jarque_bera(x, *, axis=None):
 
     Returns
     -------
-    result : JarqueBeraResult
+    result : SignificanceResult
         An object with the following attributes:
 
         statistic : float
@@ -1931,7 +1928,7 @@ def jarque_bera(x, *, axis=None):
     statistic = n / 6 * (s**2 + k**2 / 4)
     pvalue = distributions.chi2.sf(statistic, df=2)
 
-    return JarqueBeraResult(statistic, pvalue)
+    return SignificanceResult(statistic, pvalue)
 
 
 #####################################

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -1861,7 +1861,7 @@ def normaltest(a, axis=0, nan_policy='propagate'):
     return NormaltestResult(k2, distributions.chi2.sf(k2, 2))
 
 
-Jarque_beraResult = namedtuple('Jarque_beraResult', ('statistic', 'pvalue'))
+JarqueBeraResult = namedtuple('JarqueBeraResult', ('statistic', 'pvalue'))
 
 
 def jarque_bera(x):
@@ -1881,10 +1881,13 @@ def jarque_bera(x):
 
     Returns
     -------
-    jb_value : float
-        The test statistic.
-    p : float
-        The p-value for the hypothesis test.
+    result : JarqueBeraResult
+        An object with the following attributes:
+
+        statistic : float
+            The test statistic.
+        pvalue : float
+            The p-value for the hypothesis test.
 
     References
     ----------
@@ -1918,7 +1921,7 @@ def jarque_bera(x):
     jb_value = n / 6 * (skewness**2 + (kurtosis - 3)**2 / 4)
     p = 1 - distributions.chi2.cdf(jb_value, 2)
 
-    return Jarque_beraResult(jb_value, p)
+    return JarqueBeraResult(jb_value, p)
 
 
 #####################################

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -1864,7 +1864,7 @@ def normaltest(a, axis=0, nan_policy='propagate'):
 JarqueBeraResult = namedtuple('JarqueBeraResult', ('statistic', 'pvalue'))
 
 
-def jarque_bera(x):
+def jarque_bera(x, *, axis=None):
     """Perform the Jarque-Bera goodness of fit test on sample data.
 
     The Jarque-Bera test tests whether the sample data has the skewness and
@@ -1878,6 +1878,11 @@ def jarque_bera(x):
     ----------
     x : array_like
         Observations of a random variable.
+    axis : int or None, default: 0
+        If an int, the axis of the input along which to compute the statistic.
+        The statistic of each axis-slice (e.g. row) of the input will appear in
+        a corresponding element of the output.
+        If ``None``, the input will be raveled before computing the statistic.
 
     Returns
     -------
@@ -1910,18 +1915,22 @@ def jarque_bera(x):
 
     """
     x = np.asarray(x)
-    n = x.size
+    if axis is None:
+        x = x.ravel()
+        axis = 0
+
+    n = x.shape[axis]
     if n == 0:
         raise ValueError('At least one observation is required.')
 
-    mu = x.mean()
+    mu = x.mean(axis=axis, keepdims=True)
     diffx = x - mu
-    skewness = (1 / n * np.sum(diffx**3)) / (1 / n * np.sum(diffx**2))**(3 / 2.)
-    kurtosis = (1 / n * np.sum(diffx**4)) / (1 / n * np.sum(diffx**2))**2
-    jb_value = n / 6 * (skewness**2 + (kurtosis - 3)**2 / 4)
-    p = 1 - distributions.chi2.cdf(jb_value, 2)
+    s = skew(diffx, axis=axis, _no_deco=True)
+    k = kurtosis(diffx, axis=axis, _no_deco=True)
+    statistic = n / 6 * (s**2 + k**2 / 4)
+    pvalue = distributions.chi2.sf(statistic, df=2)
 
-    return JarqueBeraResult(jb_value, p)
+    return JarqueBeraResult(statistic, pvalue)
 
 
 #####################################

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -1864,6 +1864,7 @@ def normaltest(a, axis=0, nan_policy='propagate'):
 JarqueBeraResult = namedtuple('JarqueBeraResult', ('statistic', 'pvalue'))
 
 
+@_axis_nan_policy_factory(tuple_to_result=JarqueBeraResult, default_axis=None)
 def jarque_bera(x, *, axis=None):
     """Perform the Jarque-Bera goodness of fit test on sample data.
 

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -37,6 +37,7 @@ axis_nan_policy_cases = [
     (stats.kstatvar, tuple(), dict(), 1, 1, False, lambda x: (x,)),
     (stats.moment, tuple(), dict(), 1, 1, False, lambda x: (x,)),
     (stats.moment, tuple(), dict(moment=[1, 2]), 1, 2, False, None),
+    (stats.jarque_bera, tuple(), dict(), 1, 2, False, None),
 ]
 
 # If the message is one of those expected, put nans in

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -5387,8 +5387,6 @@ class TestJarqueBera:
         assert_allclose(res, resT)
 
 
-
-
 def test_skewtest_too_few_samples():
     # Regression test for ticket #1492.
     # skewtest requires at least 8 samples; 7 should raise a ValueError.

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -5370,6 +5370,24 @@ class TestJarqueBera:
     def test_jarque_bera_size(self):
         assert_raises(ValueError, stats.jarque_bera, [])
 
+    def test_axis(self):
+        rng = np.random.default_rng(abs(hash('JarqueBera')))
+        x = rng.random(size=(2, 45))
+
+        assert_equal(stats.jarque_bera(x, axis=None),
+                     stats.jarque_bera(x.ravel()))
+
+        res = stats.jarque_bera(x, axis=1)
+        s0, p0 = stats.jarque_bera(x[0, :])
+        s1, p1 = stats.jarque_bera(x[1, :])
+        assert_allclose(res.statistic, [s0, s1])
+        assert_allclose(res.pvalue, [p0, p1])
+
+        resT = stats.jarque_bera(x.T, axis=0)
+        assert_allclose(res, resT)
+
+
+
 
 def test_skewtest_too_few_samples():
     # Regression test for ticket #1492.


### PR DESCRIPTION
#### Reference issue
gh-14651 

#### What does this implement/fix?
This PR adds `axis`, `nan_policy`, masked array, and `keepdims` support to `stats.jarque_bera`. It also takes the opportunity to clean up the docstring a bit. Most of the changes are to add native vectorization. The last commit adding all the features has a two-line diff. It's nice when the decorator works without any trouble!

#### Additional information
I am writing a tutorial about the resampling methods in `scipy.stats` that features `jarque_bera`, and to demonstrate the `vectorized` argument, I thought it would be helpful if `jarque_bera` were natively vectorized.

While I was at it, I decided to apply the decorator. It was super easy; the only nonstandard thing is that the default axis behavior was like `None` before (hence `default_axis=None`).

I basically rewrote the whole function, but it should be pretty clear what's going on if this is reviewed commit by commit.