### PR TITLE
MAINT: interpolate/RGI: only call `find_indices` when needed

### DIFF
--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -320,12 +320,13 @@ class RegularGridInterpolator:
                     raise ValueError("One of the requested xi is out of bounds "
                                      "in dimension %d" % i)
 
-        indices, norm_distances, out_of_bounds = self._find_indices(xi.T)
         if method == "linear":
+            indices, norm_distances, out_of_bounds = self._find_indices(xi.T)
             result = self._evaluate_linear(indices,
                                            norm_distances,
                                            out_of_bounds)
         elif method == "nearest":
+            indices, norm_distances, out_of_bounds = self._find_indices(xi.T)
             result = self._evaluate_nearest(indices,
                                             norm_distances,
                                             out_of_bounds)


### PR DESCRIPTION
Recently added tensor-product spline modes of `RegularGridInterpolator` (`cubic`, `quintic` and `pchip`) do not need a call to `find_indices`, and discare the output immediately. So only call it for  `linear` and `nearest` modes.
This is probably a minor perf improvement (not sure if it's worth adding a benchmark just for this, so am skipping it; a benchmark can be added if/when there is a larger refactor). 