### PR TITLE
DOC: Add more information to entropy docstring

### DIFF
--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -61,18 +61,19 @@ def entropy(pk: np.typing.ArrayLike,
     governed by the discrete distribution `pk` [1]_. The choice of base
     determines the choice of units, ``e`` for nats, ``2`` for bits, etc.
 
-    The relative entropy, ``D(pk|qk)``, quantifies the average number of
-    additional units of information needed per symbol if the encoding is
-    optimized for the probability distribution `qk` when the true distribution
-    is `pk`. Informally, the relative entropy quantifies the expected excess
-    in surprise experienced if one believes the true distribution is `qk` when
-    it is actually `pk`.
+    The relative entropy, ``D(pk|qk)``, quantifies the increase in the average
+    number of units of information needed per symbol if the encoding is
+    optimized for the probability distribution `qk` instead of the true
+    distribution `pk`. Informally, the relative entropy quantifies the expected
+    excess in surprise experienced if one believes the true distribution is
+    `qk` when it is actually `pk`.
 
     A related quantity, the cross entropy ``CE(pk, qk)``, satisfies the
-    equation ``CE(pk, qk) = H(pk) + D(pk|qk)`` and follows the formula ``S =
-    -sum(pk * log(qk), axis=axis)``. It gives the average total number of units
-    of information needed per symbol if an encoding is optimized for the
-    probability distribution `qk` when the true distribution is `pk`.
+    equation ``CE(pk, qk) = H(pk) + D(pk|qk)`` and can also be calculated with
+    the formula ``S = -sum(pk * log(qk), axis=axis)``. It gives the average
+    number of units of information needed per symbol if an encoding is
+    optimized for the probability distribution `qk` when the true distribution
+    is `pk`.
 
     See [2]_ for more information.
 

--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -69,12 +69,10 @@ def entropy(pk: np.typing.ArrayLike,
     it is actually `pk`.
 
     A related quantity, the cross entropy ``CE(pk, qk)``, satisfies the
-    equation ``CE(pk, qk) = H(pk) + D(pk|qk)`` and follows the formula 
-    ``S = -sum(pk * log(qk), axis=axis)``.
-
-    It gives the average total number of units of information needed per
-    symbol if an encoding is optimized for the probability distribution `qk`
-    when the true distribution is `pk`.
+    equation ``CE(pk, qk) = H(pk) + D(pk|qk)`` and follows the formula ``S =
+    -sum(pk * log(qk), axis=axis)``. It gives the average total number of units
+    of information needed per symbol if an encoding is optimized for the
+    probability distribution `qk` when the true distribution is `pk`.
 
     See [2]_ for more information.
 

--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -71,7 +71,9 @@ def entropy(pk: np.typing.ArrayLike,
     by the equation ``H(pk, qk) = H(pk) + KL(pk|qk)``. Informally, the
     Kullback-Leibler divergence quantifies the expected surplus of surprise
     experienced if one believes the true distribution is `qk` when it is
-    actually `pk`. See [2]_ for more information.
+    actually `pk`.
+
+    See [2]_ for more information.
 
     References
     ----------

--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -56,15 +56,15 @@ def entropy(pk: np.typing.ArrayLike,
 
     If messages consisting of sequences of symbols from a set S are to be
     encoded and transmitted over a noiseless channel, then the Shannon entropy
-    ``H(pk)`` gives a lower bound for the average number of units of
+    ``H(pk)`` gives a tight lower bound for the average number of units of
     information needed per symbol if the symbols occur with frequencies
     governed by the discrete distribution `pk` [1]_. The choice of base
     determines the choice of units, ``e`` for nats, ``2`` for bits, etc.
 
-    A related quantity, the cross entropy ``H(pk, qk)``, gives a lower bound
-    for the average number of units of information needed per symbol if the
-    encoding is optimized for the probability distribution `qk` but the true
-    distribution is `pk`. The formula for cross entropy is ``S = -sum(pk *
+    A related quantity, the cross entropy ``H(pk, qk)``, gives a tight lower
+    bound for the average number of units of information needed per symbol if
+    the encoding is optimized for the probability distribution `qk` but the
+    true distribution is `pk`. The formula for cross entropy is ``S = -sum(pk *
     log(qk), axis=axis)``.
 
     Shannon entropy, cross entropy, and Kullback-Leibler divergence are related

--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -83,7 +83,7 @@ def entropy(pk: np.typing.ArrayLike,
     .. [2] Thomas M. Cover and Joy A. Thomas. 2006. Elements of Information
            Theory (Wiley Series in Telecommunications and Signal Processing).
            Wiley-Interscience, USA.
-    
+
 
     Examples
     --------

--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -41,7 +41,7 @@ def entropy(pk: np.typing.ArrayLike,
         the same format as `pk`.
     base : float, optional
         The logarithmic base to use, defaults to ``e`` (natural logarithm).
-    axis: int, optional
+    axis : int, optional
         The axis along which the entropy is calculated. Default is 0.
 
     Returns

--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -56,16 +56,16 @@ def entropy(pk: np.typing.ArrayLike,
 
     If messages consisting of sequences of symbols from a set S are to be
     encoded and transmitted over a noiseless channel, then the Shannon entropy
-    ``H(pk)`` gives a lower bound for the average number of information units
-    needed per symbol if the symbols occur with frequencies governed by the
-    discrete distribution `pk` [1]_. The choice of base determines the choice
-    of units, ``e`` for nats, ``2`` for bits etc.
+    ``H(pk)`` gives a lower bound for the average number of units of
+    information needed per symbol if the symbols occur with frequencies
+    governed by the discrete distribution `pk` [1]_. The choice of base
+    determines the choice of units, ``e`` for nats, ``2`` for bits, etc.
 
-    A related quantity, the cross entropy ``H(pk, qk)`` gives a lower bound for
-    the average number of information units needed per symbol if the encoding
-    is optimized for the probability distribution `qk` but the true
-    distribution is `pk`. The formula for cross entropy is
-    ``S = -sum(pk * log(qk), axis=axis)``.
+    A related quantity, the cross entropy ``H(pk, qk)``, gives a lower bound
+    for the average number of units of information needed per symbol if the
+    encoding is optimized for the probability distribution `qk` but the true
+    distribution is `pk`. The formula for cross entropy is ``S = -sum(pk *
+    log(qk), axis=axis)``.
 
     Shannon entropy, cross entropy, and Kullback-Leibler divergence are related
     by the equation ``H(pk, qk) = H(pk) + KL(pk|qk)``. Informally, the
@@ -106,7 +106,7 @@ def entropy(pk: np.typing.ArrayLike,
 
     Cross entropy:
 
-    The cross entropy can be computed using the equation
+    The cross entropy can be calculated using the equation
     ``H(pk, qk) = H(pk) + KL(pk|qk)``:
 
     >>> entropy([1/2, 1/2]) + entropy([1/2, 1/2], qk=[9/10, 1/10])

--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -20,7 +20,7 @@ def entropy(pk: np.typing.ArrayLike,
             axis: int = 0
             ) -> Union[np.number, np.ndarray]:
     """
-    Calculate the Shannon entropy/cross entropy of given distribution(s).
+    Calculate the Shannon entropy/relative entropy of given distribution(s).
 
     If only probabilities `pk` are given, the Shannon entropy is calculated as
     ``H = -sum(pk * log(pk))``.
@@ -47,7 +47,7 @@ def entropy(pk: np.typing.ArrayLike,
 
     Returns
     -------
-    H : {float, array_like}
+    S : {float, array_like}
         The calculated entropy.
 
     Notes
@@ -55,12 +55,12 @@ def entropy(pk: np.typing.ArrayLike,
     Informally, the Shannon entropy quantifies the expected uncertainty
     inherent in the possible outcomes of a discrete random variable.
     For example,
-    if messages consisting of sequences of symbols from a set ``S`` are to be
+    if messages consisting of sequences of symbols from a set are to be
     encoded and transmitted over a noiseless channel, then the Shannon entropy
     ``H(pk)`` gives a tight lower bound for the average number of units of
     information needed per symbol if the symbols occur with frequencies
     governed by the discrete distribution `pk` [1]_. The choice of base
-    determines the choice of units; e.g. ``e`` for nats, ``2`` for bits, etc.
+    determines the choice of units; e.g., ``e`` for nats, ``2`` for bits, etc.
 
     The relative entropy, ``D(pk|qk)``, quantifies the increase in the average
     number of units of information needed per symbol if the encoding is

--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -21,11 +21,12 @@ def entropy(pk: np.typing.ArrayLike,
             ) -> Union[np.number, np.ndarray]:
     """Calculate the entropy of a distribution for given probability values.
 
-    If only probabilities `pk` are given, the entropy is calculated as
+    If only probabilities `pk` are given, the Shannon entropy is calculated as
     ``S = -sum(pk * log(pk), axis=axis)``.
 
     If `qk` is not None, then compute the Kullback-Leibler divergence
-    ``S = sum(pk * log(pk / qk), axis=axis)``.
+    ``S = sum(pk * log(pk / qk), axis=axis)``. This quantity is also known
+    as the relative entropy.
 
     This routine will normalize `pk` and `qk` if they don't sum to 1.
 
@@ -40,13 +41,47 @@ def entropy(pk: np.typing.ArrayLike,
         the same format as `pk`.
     base : float, optional
         The logarithmic base to use, defaults to ``e`` (natural logarithm).
-    axis : int, optional
+    axis: int, optional
         The axis along which the entropy is calculated. Default is 0.
 
     Returns
     -------
     S : {float, array_like}
         The calculated entropy.
+
+    Notes
+    -----
+    Informally, the Shannon entropy quantifies the expected uncertainty
+    inherent in the possible outcomes of a discrete random variable.
+
+    If messages consisting of sequences of symbols from a set S are to be
+    encoded and transmitted over a noiseless channel, then the Shannon entropy
+    ``H(pk)`` gives a lower bound for the average number of information units
+    needed per symbol if the symbols occur with frequencies governed by the
+    discrete distribution `pk` [1]_. The choice of base determines the choice
+    of units, ``e`` for nats, ``2`` for bits etc.
+
+    A related quantity, the cross entropy ``H(pk, qk)`` gives a lower bound for
+    the average number of information units needed per symbol if the encoding
+    is optimized for the probability distribution `qk` but the true
+    distribution is `pk`. The formula for cross entropy is
+    ``S = -sum(pk * log(qk), axis=axis)``.
+
+    Shannon entropy, cross entropy, and Kullback-Leibler divergence are related
+    by the equation ``H(pk, qk) = H(pk) + KL(pk|qk)``. Informally, the
+    Kullback-Leibler divergence quantifies the expected surplus of surprise
+    experienced if one believes the true distribution is `qk` when it is
+    actually `pk`. See [2]_ for more information.
+
+    References
+    ----------
+    .. [1] Shannon, C.E. (1948), A Mathematical Theory of Communication.
+           Bell System Technical Journal, 27: 379-423.
+           https://doi.org/10.1002/j.1538-7305.1948.tb01338.x
+    .. [2] Thomas M. Cover and Joy A. Thomas. 2006. Elements of Information
+           Theory (Wiley Series in Telecommunications and Signal Processing).
+           Wiley-Interscience, USA.
+    
 
     Examples
     --------
@@ -68,6 +103,14 @@ def entropy(pk: np.typing.ArrayLike,
 
     >>> entropy([1/2, 1/2], qk=[9/10, 1/10])
     0.5108256237659907
+
+    Cross entropy:
+
+    The cross entropy can be computed using the equation
+    ``H(pk, qk) = H(pk) + KL(pk|qk)``:
+
+    >>> entropy([1/2, 1/2]) + entropy([1/2, 1/2], qk=[9/10, 1/10])
+    1.203972804325936
 
     """
     if base is not None and base <= 0:

--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -61,11 +61,11 @@ def entropy(pk: np.typing.ArrayLike,
     governed by the discrete distribution `pk` [1]_. The choice of base
     determines the choice of units, ``e`` for nats, ``2`` for bits, etc.
 
-    A related quantity, the cross entropy ``H(pk, qk)``, gives a tight lower
-    bound for the average number of units of information needed per symbol if
-    the encoding is optimized for the probability distribution `qk` but the
-    true distribution is `pk`. The formula for cross entropy is ``S = -sum(pk *
-    log(qk), axis=axis)``.
+    A related quantity, the cross entropy ``H(pk, qk)``, gives the average
+    number of units of information needed per symbol if the encoding is
+    optimized for the probability distribution `qk` but the true distribution
+    is `pk`. The formula for cross entropy is ``S = -sum(pk * log(qk),
+    axis=axis)``.
 
     Shannon entropy, cross entropy, and Kullback-Leibler divergence are related
     by the equation ``H(pk, qk) = H(pk) + KL(pk|qk)``. Informally, the

--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -19,13 +19,14 @@ def entropy(pk: np.typing.ArrayLike,
             base: Optional[float] = None,
             axis: int = 0
             ) -> Union[np.number, np.ndarray]:
-    """Calculate the entropy of a distribution for given probability values.
+    """
+    Calculate the Shannon entropy/cross entropy of given distribution(s).
 
     If only probabilities `pk` are given, the Shannon entropy is calculated as
-    ``S = -sum(pk * log(pk), axis=axis)``.
+    ``H = -sum(pk * log(pk))``.
 
     If `qk` is not None, then compute the relative entropy
-    ``S = sum(pk * log(pk / qk), axis=axis)``. This quantity is also known
+    ``D = sum(pk * log(pk / qk))``. This quantity is also known
     as the Kullback-Leibler divergence.
 
     This routine will normalize `pk` and `qk` if they don't sum to 1.
@@ -46,20 +47,20 @@ def entropy(pk: np.typing.ArrayLike,
 
     Returns
     -------
-    S : {float, array_like}
+    H : {float, array_like}
         The calculated entropy.
 
     Notes
     -----
     Informally, the Shannon entropy quantifies the expected uncertainty
     inherent in the possible outcomes of a discrete random variable.
-
-    If messages consisting of sequences of symbols from a set S are to be
+    For example,
+    if messages consisting of sequences of symbols from a set ``S`` are to be
     encoded and transmitted over a noiseless channel, then the Shannon entropy
     ``H(pk)`` gives a tight lower bound for the average number of units of
     information needed per symbol if the symbols occur with frequencies
     governed by the discrete distribution `pk` [1]_. The choice of base
-    determines the choice of units, ``e`` for nats, ``2`` for bits, etc.
+    determines the choice of units; e.g. ``e`` for nats, ``2`` for bits, etc.
 
     The relative entropy, ``D(pk|qk)``, quantifies the increase in the average
     number of units of information needed per symbol if the encoding is
@@ -70,10 +71,11 @@ def entropy(pk: np.typing.ArrayLike,
 
     A related quantity, the cross entropy ``CE(pk, qk)``, satisfies the
     equation ``CE(pk, qk) = H(pk) + D(pk|qk)`` and can also be calculated with
-    the formula ``S = -sum(pk * log(qk), axis=axis)``. It gives the average
+    the formula ``CE = -sum(pk * log(qk))``. It gives the average
     number of units of information needed per symbol if an encoding is
     optimized for the probability distribution `qk` when the true distribution
-    is `pk`.
+    is `pk`. It is not computed directly by `entropy`, but it can be computed
+    using two calls to the function (see Examples).
 
     See [2]_ for more information.
 
@@ -89,32 +91,40 @@ def entropy(pk: np.typing.ArrayLike,
 
     Examples
     --------
-
-    >>> from scipy.stats import entropy
-
-    Bernoulli trial with different p.
     The outcome of a fair coin is the most uncertain:
 
-    >>> entropy([1/2, 1/2], base=2)
+    >>> from scipy.stats import entropy
+    >>> base = 2  # work in units of bits
+    >>> pk = np.array([1/2, 1/2])  # fair coin
+    >>> H = entropy(pk, base=base)
+    >>> H
     1.0
+    >>> H == -np.sum(pk * np.log(pk)) / np.log(base)
+    True
 
     The outcome of a biased coin is less uncertain:
 
-    >>> entropy([9/10, 1/10], base=2)
+    >>> qk = np.array([9/10, 1/10])  # biased coin
+    >>> entropy(qk, base=base)
     0.46899559358928117
 
-    Relative entropy:
+    The relative entropy between the fair coin and biased coin is calculated
+    as:
 
-    >>> entropy([1/2, 1/2], qk=[9/10, 1/10])
-    0.5108256237659907
+    >>> D = entropy(pk, qk, base=base)
+    >>> D
+    0.7369655941662062
+    >>> D == np.sum(pk * np.log(pk/qk)) / np.log(base)
+    True
 
-    Cross entropy:
+    The cross entropy can be calculated as the sum of the entropy and
+    relative entropy`:
 
-    The cross entropy can be calculated using the equation
-    ``CE(pk, qk) = H(pk) + D(pk|qk)``:
-
-    >>> entropy([1/2, 1/2]) + entropy([1/2, 1/2], qk=[9/10, 1/10])
-    1.203972804325936
+    >>> CE = entropy(pk, base=base) + entropy(pk, qk, base=base)
+    >>> CE
+    1.736965594166206
+    >>> CE == -np.sum(pk * np.log(qk)) / np.log(base)
+    True
 
     """
     if base is not None and base <= 0:

--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -24,9 +24,9 @@ def entropy(pk: np.typing.ArrayLike,
     If only probabilities `pk` are given, the Shannon entropy is calculated as
     ``S = -sum(pk * log(pk), axis=axis)``.
 
-    If `qk` is not None, then compute the Kullback-Leibler divergence
+    If `qk` is not None, then compute the relative entropy
     ``S = sum(pk * log(pk / qk), axis=axis)``. This quantity is also known
-    as the relative entropy.
+    as the Kullback-Leibler divergence.
 
     This routine will normalize `pk` and `qk` if they don't sum to 1.
 
@@ -61,17 +61,20 @@ def entropy(pk: np.typing.ArrayLike,
     governed by the discrete distribution `pk` [1]_. The choice of base
     determines the choice of units, ``e`` for nats, ``2`` for bits, etc.
 
-    A related quantity, the cross entropy ``H(pk, qk)``, gives the average
-    number of units of information needed per symbol if the encoding is
-    optimized for the probability distribution `qk` but the true distribution
-    is `pk`. The formula for cross entropy is ``S = -sum(pk * log(qk),
-    axis=axis)``.
+    The relative entropy, ``D(pk|qk)``, quantifies the average number of
+    additional units of information needed per symbol if the encoding is
+    optimized for the probability distribution `qk` when the true distribution
+    is `pk`. Informally, the relative entropy quantifies the expected excess
+    in surprise experienced if one believes the true distribution is `qk` when
+    it is actually `pk`.
 
-    Shannon entropy, cross entropy, and Kullback-Leibler divergence are related
-    by the equation ``H(pk, qk) = H(pk) + KL(pk|qk)``. Informally, the
-    Kullback-Leibler divergence quantifies the expected surplus of surprise
-    experienced if one believes the true distribution is `qk` when it is
-    actually `pk`.
+    A related quantity, the cross entropy ``CE(pk, qk)``, satisfies the
+    equation ``CE(pk, qk) = H(pk) + D(pk|qk)`` and follows the formula 
+    ``S = -sum(pk * log(qk), axis=axis)``.
+
+    It gives the average total number of units of information needed per
+    symbol if an encoding is optimized for the probability distribution `qk`
+    when the true distribution is `pk`.
 
     See [2]_ for more information.
 
@@ -109,7 +112,7 @@ def entropy(pk: np.typing.ArrayLike,
     Cross entropy:
 
     The cross entropy can be calculated using the equation
-    ``H(pk, qk) = H(pk) + KL(pk|qk)``:
+    ``CE(pk, qk) = H(pk) + D(pk|qk)``:
 
     >>> entropy([1/2, 1/2]) + entropy([1/2, 1/2], qk=[9/10, 1/10])
     1.203972804325936

--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -61,8 +61,8 @@ def entropy(pk: np.typing.ArrayLike,
     governed by the discrete distribution `pk` [1]_. The choice of base
     determines the choice of units, ``e`` for nats, ``2`` for bits, etc.
 
-    A related quantity, the cross entropy ``H(pk, qk)``, gives the expected
-    average number of units of information needed per symbol if the encoding is
+    A related quantity, the cross entropy ``H(pk, qk)``, gives the average
+    number of units of information needed per symbol if the encoding is
     optimized for the probability distribution `qk` but the true distribution
     is `pk`. The formula for cross entropy is ``S = -sum(pk * log(qk),
     axis=axis)``.

--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -61,8 +61,8 @@ def entropy(pk: np.typing.ArrayLike,
     governed by the discrete distribution `pk` [1]_. The choice of base
     determines the choice of units, ``e`` for nats, ``2`` for bits, etc.
 
-    A related quantity, the cross entropy ``H(pk, qk)``, gives the average
-    number of units of information needed per symbol if the encoding is
+    A related quantity, the cross entropy ``H(pk, qk)``, gives the expected
+    average number of units of information needed per symbol if the encoding is
     optimized for the probability distribution `qk` but the true distribution
     is `pk`. The formula for cross entropy is ``S = -sum(pk * log(qk),
     axis=axis)``.


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes gh-3421

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR adds information to the docstring for `scipy.stats.entropy` giving an overview of the relationship between entropy, Kullback-Leibler divergence, and cross-entropy. The significance of these quantities in information theory is also briefly stated. In addition, relative entropy is explicitly given as a synonym for Kullback-Leibler divergence and an example has been added showing how to calculate cross entropy using the function `entropy`.

#### Additional information
<!--Any additional information you think is important.-->
There was concern expressed in gh-3421 that the behavior of `entropy` may be surprising to some users. Rather than adding new functions to the API and/or making backwards incompatible changes to `entropy`, I think it's reasonable just to add more information to the docstring to clarify the behavior of the function. @mdhaber let me know what you think.