### PR TITLE
MAINT: sparse.linalg: Change ambiguous parameter name `tol` in sparse linear solver into `rtol`

### DIFF
--- a/scipy/optimize/_nonlin.py
+++ b/scipy/optimize/_nonlin.py
@@ -1478,7 +1478,7 @@ class KrylovJacobian(Jacobian):
         if 'tol' in self.method_kw:
             sol, info = self.method(self.op, rhs, **self.method_kw)
         else:
-            sol, info = self.method(self.op, rhs, tol=tol, **self.method_kw)
+            sol, info = self.method(self.op, rhs, rtol=tol, **self.method_kw)
         return sol
 
     def update(self, x, f):

--- a/scipy/sparse/linalg/_eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/_eigen/arpack/arpack.py
@@ -946,7 +946,7 @@ def gmres_loose(A, b, tol):
     """
     b = np.asarray(b)
     min_tol = 1000 * np.sqrt(b.size) * np.finfo(b.dtype).eps
-    return gmres(A, b, tol=max(tol, min_tol), atol=0)
+    return gmres(A, b, rtol=max(tol, min_tol), atol=0)
 
 
 class IterInv(LinearOperator):

--- a/scipy/sparse/linalg/_isolve/_gcrotmk.py
+++ b/scipy/sparse/linalg/_isolve/_gcrotmk.py
@@ -179,7 +179,7 @@ def _fgmres(matvec, v0, m, atol, lpsolve=None, rpsolve=None, cs=(), outer_v=(),
     return Q, R, B, vs, zs, y, res
 
 
-def gcrotmk(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
+def gcrotmk(A, b, x0=None, rtol=1e-5, maxiter=1000, M=None, callback=None,
             m=20, k=None, CU=None, discard_C=False, truncate='oldest',
             atol=None):
     """
@@ -196,9 +196,9 @@ def gcrotmk(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
         Right hand side of the linear system. Has shape (N,) or (N,1).
     x0 : ndarray
         Starting guess for the solution.
-    tol, atol : float, optional
-        Tolerances for convergence, ``norm(residual) <= max(tol*norm(b), atol)``.
-        The default for ``atol`` is `tol`.
+    rtol, atol : float, optional
+        Tolerances for convergence, ``norm(residual) <= max(rtol*norm(b), atol)``.
+        The default for ``atol`` is None (use `rtol`).
 
         .. warning::
 
@@ -285,9 +285,9 @@ def gcrotmk(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
     if atol is None:
         warnings.warn("scipy.sparse.linalg.gcrotmk called without specifying `atol`. "
                       "The default value will change in the future. To preserve "
-                      "current behavior, set ``atol=tol``.",
+                      "current behavior, set ``atol=rtol``.",
                       category=DeprecationWarning, stacklevel=2)
-        atol = tol
+        atol = rtol
 
     matvec = A.matvec
     psolve = M.matvec
@@ -380,7 +380,7 @@ def gcrotmk(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
         beta = nrm2(r)
 
         # -- check stopping condition
-        beta_tol = max(atol, tol * b_norm)
+        beta_tol = max(atol, rtol * b_norm)
 
         if beta <= beta_tol and (j_outer > 0 or CU):
             # recompute residual to avoid rounding error
@@ -400,7 +400,7 @@ def gcrotmk(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
                                                r/beta,
                                                ml,
                                                rpsolve=psolve,
-                                               atol=max(atol, tol*b_norm)/beta,
+                                               atol=max(atol, rtol*b_norm)/beta,
                                                cs=cs)
             y *= beta
         except LinAlgError:

--- a/scipy/sparse/linalg/_isolve/iterative.py
+++ b/scipy/sparse/linalg/_isolve/iterative.py
@@ -41,8 +41,8 @@ Other Parameters
 ----------------
 x0 : ndarray
     Starting guess for the solution.
-tol, atol : float, optional
-    Tolerances for convergence, ``norm(residual) <= max(tol*norm(b), atol)``.
+rtol, atol : float, optional
+    Tolerances for convergence, ``norm(residual) <= max(rtol*norm(b), atol)``.
     The default for ``atol`` is ``'legacy'``, which emulates
     a different legacy behavior.
 
@@ -75,13 +75,13 @@ def _stoptest(residual, atol):
         return resid, 0
 
 
-def _get_atol(tol, atol, bnrm2, get_residual, routine_name):
+def _get_atol(rtol, atol, bnrm2, get_residual, routine_name):
     """
     Parse arguments for absolute tolerance in termination condition.
 
     Parameters
     ----------
-    tol, atol : object
+    rtol, atol : object
         The arguments passed into the solver routine by user.
     bnrm2 : float
         2-norm of the rhs vector.
@@ -101,19 +101,19 @@ def _get_atol(tol, atol, bnrm2, get_residual, routine_name):
                       category=DeprecationWarning, stacklevel=4)
         atol = 'legacy'
 
-    tol = float(tol)
+    rtol = float(rtol)
 
     if atol == 'legacy':
         # emulate old legacy behavior
         resid = get_residual()
-        if resid <= tol:
+        if resid <= rtol:
             return 'exit'
         if bnrm2 == 0:
-            return tol
+            return rtol
         else:
-            return tol * float(bnrm2)
+            return rtol * float(bnrm2)
     else:
-        return max(float(atol), tol * float(bnrm2))
+        return max(float(atol), rtol * float(bnrm2))
 
 
 def set_docstring(header, Ainfo, footer='', atol_default='0'):
@@ -146,7 +146,7 @@ def set_docstring(header, Ainfo, footer='', atol_default='0'):
                """
                )
 @non_reentrant()
-def bicg(A, b, x0=None, tol=1e-5, maxiter=None, M=None, callback=None, atol=None):
+def bicg(A, b, x0=None, rtol=1e-5, maxiter=None, M=None, callback=None, atol=None):
     A,M,x,b,postprocess = make_system(A, M, x0, b)
 
     n = len(b)
@@ -159,7 +159,7 @@ def bicg(A, b, x0=None, tol=1e-5, maxiter=None, M=None, callback=None, atol=None
     revcom = getattr(_iterative, ltr + 'bicgrevcom')
 
     get_residual = lambda: np.linalg.norm(matvec(x) - b)
-    atol = _get_atol(tol, atol, np.linalg.norm(b), get_residual, 'bicg')
+    atol = _get_atol(rtol, atol, np.linalg.norm(b), get_residual, 'bicg')
     if atol == 'exit':
         return postprocess(x), 0
 
@@ -235,7 +235,7 @@ def bicg(A, b, x0=None, tol=1e-5, maxiter=None, M=None, callback=None, atol=None
                True
                """)
 @non_reentrant()
-def bicgstab(A, b, x0=None, tol=1e-5, maxiter=None, M=None, callback=None, atol=None):
+def bicgstab(A, b, x0=None, rtol=1e-5, maxiter=None, M=None, callback=None, atol=None):
     A, M, x, b, postprocess = make_system(A, M, x0, b)
 
     n = len(b)
@@ -248,7 +248,7 @@ def bicgstab(A, b, x0=None, tol=1e-5, maxiter=None, M=None, callback=None, atol=
     revcom = getattr(_iterative, ltr + 'bicgstabrevcom')
 
     get_residual = lambda: np.linalg.norm(matvec(x) - b)
-    atol = _get_atol(tol, atol, np.linalg.norm(b), get_residual, 'bicgstab')
+    atol = _get_atol(rtol, atol, np.linalg.norm(b), get_residual, 'bicgstab')
     if atol == 'exit':
         return postprocess(x), 0
 
@@ -320,7 +320,7 @@ def bicgstab(A, b, x0=None, tol=1e-5, maxiter=None, M=None, callback=None, atol=
 
                """)
 @non_reentrant()
-def cg(A, b, x0=None, tol=1e-5, maxiter=None, M=None, callback=None, atol=None):
+def cg(A, b, x0=None, rtol=1e-5, maxiter=None, M=None, callback=None, atol=None):
     A, M, x, b, postprocess = make_system(A, M, x0, b)
 
     n = len(b)
@@ -333,7 +333,7 @@ def cg(A, b, x0=None, tol=1e-5, maxiter=None, M=None, callback=None, atol=None):
     revcom = getattr(_iterative, ltr + 'cgrevcom')
 
     get_residual = lambda: np.linalg.norm(matvec(x) - b)
-    atol = _get_atol(tol, atol, np.linalg.norm(b), get_residual, 'cg')
+    atol = _get_atol(rtol, atol, np.linalg.norm(b), get_residual, 'cg')
     if atol == 'exit':
         return postprocess(x), 0
 
@@ -409,7 +409,7 @@ def cg(A, b, x0=None, tol=1e-5, maxiter=None, M=None, callback=None, atol=None):
                """
                )
 @non_reentrant()
-def cgs(A, b, x0=None, tol=1e-5, maxiter=None, M=None, callback=None, atol=None):
+def cgs(A, b, x0=None, rtol=1e-5, maxiter=None, M=None, callback=None, atol=None):
     A, M, x, b, postprocess = make_system(A, M, x0, b)
 
     n = len(b)
@@ -422,7 +422,7 @@ def cgs(A, b, x0=None, tol=1e-5, maxiter=None, M=None, callback=None, atol=None)
     revcom = getattr(_iterative, ltr + 'cgsrevcom')
 
     get_residual = lambda: np.linalg.norm(matvec(x) - b)
-    atol = _get_atol(tol, atol, np.linalg.norm(b), get_residual, 'cgs')
+    atol = _get_atol(rtol, atol, np.linalg.norm(b), get_residual, 'cgs')
     if atol == 'exit':
         return postprocess(x), 0
 
@@ -481,7 +481,7 @@ def cgs(A, b, x0=None, tol=1e-5, maxiter=None, M=None, callback=None, atol=None)
 
 
 @non_reentrant()
-def gmres(A, b, x0=None, tol=1e-5, restart=None, maxiter=None, M=None, callback=None,
+def gmres(A, b, x0=None, rtol=1e-5, restart=None, maxiter=None, M=None, callback=None,
           restrt=None, atol=None, callback_type=None):
     """
     Use Generalized Minimal RESidual iteration to solve ``Ax = b``.
@@ -510,8 +510,8 @@ def gmres(A, b, x0=None, tol=1e-5, restart=None, maxiter=None, M=None, callback=
     ----------------
     x0 : ndarray
         Starting guess for the solution (a vector of zeros by default).
-    tol, atol : float, optional
-        Tolerances for convergence, ``norm(residual) <= max(tol*norm(b), atol)``.
+    rtol, atol : float, optional
+        Tolerances for convergence, ``norm(residual) <= max(rtol*norm(b), atol)``.
         The default for ``atol`` is ``'legacy'``, which emulates
         a different legacy behavior.
 
@@ -627,7 +627,7 @@ def gmres(A, b, x0=None, tol=1e-5, restart=None, maxiter=None, M=None, callback=
     bnrm2 = np.linalg.norm(b)
     Mb_nrm2 = np.linalg.norm(psolve(b))
     get_residual = lambda: np.linalg.norm(matvec(x) - b)
-    atol = _get_atol(tol, atol, bnrm2, get_residual, 'gmres')
+    atol = _get_atol(rtol, atol, bnrm2, get_residual, 'gmres')
     if atol == 'exit':
         return postprocess(x), 0
 
@@ -721,7 +721,7 @@ def gmres(A, b, x0=None, tol=1e-5, restart=None, maxiter=None, M=None, callback=
 
 
 @non_reentrant()
-def qmr(A, b, x0=None, tol=1e-5, maxiter=None, M1=None, M2=None, callback=None,
+def qmr(A, b, x0=None, rtol=1e-5, maxiter=None, M1=None, M2=None, callback=None,
         atol=None):
     """Use Quasi-Minimal Residual iteration to solve ``Ax = b``.
 
@@ -749,8 +749,8 @@ def qmr(A, b, x0=None, tol=1e-5, maxiter=None, M1=None, M2=None, callback=None,
     ----------------
     x0 : ndarray
         Starting guess for the solution.
-    tol, atol : float, optional
-        Tolerances for convergence, ``norm(residual) <= max(tol*norm(b), atol)``.
+    rtol, atol : float, optional
+        Tolerances for convergence, ``norm(residual) <= max(rtol*norm(b), atol)``.
         The default for ``atol`` is ``'legacy'``, which emulates
         a different legacy behavior.
 
@@ -819,7 +819,7 @@ def qmr(A, b, x0=None, tol=1e-5, maxiter=None, M1=None, M2=None, callback=None,
     revcom = getattr(_iterative, ltr + 'qmrrevcom')
 
     get_residual = lambda: np.linalg.norm(A.matvec(x) - b)
-    atol = _get_atol(tol, atol, np.linalg.norm(b), get_residual, 'qmr')
+    atol = _get_atol(rtol, atol, np.linalg.norm(b), get_residual, 'qmr')
     if atol == 'exit':
         return postprocess(x), 0
 

--- a/scipy/sparse/linalg/_isolve/lgmres.py
+++ b/scipy/sparse/linalg/_isolve/lgmres.py
@@ -12,7 +12,7 @@ from ._gcrotmk import _fgmres
 __all__ = ['lgmres']
 
 
-def lgmres(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
+def lgmres(A, b, x0=None, rtol=1e-5, maxiter=1000, M=None, callback=None,
            inner_m=30, outer_k=3, outer_v=None, store_outer_Av=True,
            prepend_outer_v=False, atol=None):
     """
@@ -33,9 +33,9 @@ def lgmres(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
         Right hand side of the linear system. Has shape (N,) or (N,1).
     x0 : ndarray
         Starting guess for the solution.
-    tol, atol : float, optional
-        Tolerances for convergence, ``norm(residual) <= max(tol*norm(b), atol)``.
-        The default for ``atol`` is `tol`.
+    rtol, atol : float, optional
+        Tolerances for convergence, ``norm(residual) <= max(rtol*norm(b), atol)``.
+        The default for ``atol`` is None (use `rtol`).
 
         .. warning::
 
@@ -130,9 +130,9 @@ def lgmres(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
     if atol is None:
         warnings.warn("scipy.sparse.linalg.lgmres called without specifying `atol`. "
                       "The default value will change in the future. To preserve "
-                      "current behavior, set ``atol=tol``.",
+                      "current behavior, set ``atol=rtol``.",
                       category=DeprecationWarning, stacklevel=2)
-        atol = tol
+        atol = rtol
 
     matvec = A.matvec
     psolve = M.matvec
@@ -166,7 +166,7 @@ def lgmres(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
 
         # -- check stopping condition
         r_norm = nrm2(r_outer)
-        if r_norm <= max(atol, tol * b_norm):
+        if r_norm <= max(atol, rtol * b_norm):
             break
 
         # -- inner LGMRES iteration
@@ -180,7 +180,7 @@ def lgmres(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
 
         v0 = scal(1.0/inner_res_0, v0)
 
-        ptol = min(ptol_max_factor, max(atol, tol*b_norm)/r_norm)
+        ptol = min(ptol_max_factor, max(atol, rtol*b_norm)/r_norm)
 
         try:
             Q, R, B, vs, zs, y, pres = _fgmres(matvec,

--- a/scipy/sparse/linalg/_isolve/minres.py
+++ b/scipy/sparse/linalg/_isolve/minres.py
@@ -7,7 +7,7 @@ from .utils import make_system
 __all__ = ['minres']
 
 
-def minres(A, b, x0=None, shift=0.0, tol=1e-5, maxiter=None,
+def minres(A, b, x0=None, shift=0.0, rtol=1e-5, maxiter=None,
            M=None, callback=None, show=False, check=False):
     """
     Use MINimum RESidual iteration to solve Ax=b
@@ -43,9 +43,9 @@ def minres(A, b, x0=None, shift=0.0, tol=1e-5, maxiter=None,
         Starting guess for the solution.
     shift : float
         Value to apply to the system ``(A - shift * I)x = b``. Default is 0.
-    tol : float
+    rtol : float
         Tolerance to achieve. The algorithm terminates when the relative
-        residual is below `tol`.
+        residual is below `rtol`.
     maxiter : integer
         Maximum number of iterations.  Iteration will stop after maxiter
         steps even if the specified tolerance has not been achieved.
@@ -116,8 +116,8 @@ def minres(A, b, x0=None, shift=0.0, tol=1e-5, maxiter=None,
 
     if show:
         print(first + 'Solution of symmetric Ax = b')
-        print(first + 'n      =  %3g     shift  =  %23.14e' % (n,shift))
-        print(first + 'itnlim =  %3g     rtol   =  %11.2e' % (maxiter,tol))
+        print(first + 'n      =  %3g     shift  =  %23.14e' % (n, shift))
+        print(first + 'itnlim =  %3g     rtol   =  %11.2e' % (maxiter, rtol))
         print()
 
     istop = 0
@@ -271,7 +271,7 @@ def minres(A, b, x0=None, shift=0.0, tol=1e-5, maxiter=None,
         ynorm = norm(x)
         epsa = Anorm * eps
         epsx = Anorm * ynorm * eps
-        epsr = Anorm * ynorm * tol
+        epsr = Anorm * ynorm * rtol
         diag = gbar
 
         if diag == 0:
@@ -300,7 +300,7 @@ def minres(A, b, x0=None, shift=0.0, tol=1e-5, maxiter=None,
         # In rare cases, istop is already -1 from above (Abar = const*I).
 
         if istop == 0:
-            t1 = 1 + test1      # These tests work if tol < eps
+            t1 = 1 + test1      # These tests work if rtol < eps
             t2 = 1 + test2
             if t2 <= 1:
                 istop = 2
@@ -315,9 +315,9 @@ def minres(A, b, x0=None, shift=0.0, tol=1e-5, maxiter=None,
                 istop = 3
             # if rnorm <= epsx   : istop = 2
             # if rnorm <= epsr   : istop = 1
-            if test2 <= tol:
+            if test2 <= rtol:
                 istop = 2
-            if test1 <= tol:
+            if test1 <= rtol:
                 istop = 1
 
         # See if it is time to print something.
@@ -388,5 +388,5 @@ if __name__ == '__main__':
     M = spdiags([1.0/arange(1,n+1,dtype=float)], [0], n, n, format='csr')
     A.psolve = M.matvec
     b = zeros(A.shape[0])
-    x = minres(A,b,tol=1e-12,maxiter=None,callback=cb)
-    # x = cg(A,b,x0=b,tol=1e-12,maxiter=None,callback=cb)[0]
+    x = minres(A, b, rtol=1e-12, maxiter=None, callback=cb)
+    # x = cg(A,b,x0=b,rtol=1e-12,maxiter=None,callback=cb)[0]

--- a/scipy/sparse/linalg/_isolve/tests/demo_lgmres.py
+++ b/scipy/sparse/linalg/_isolve/tests/demo_lgmres.py
@@ -35,7 +35,7 @@ print("MatrixMarket problem %s" % problem)
 print(f"Invert {Am.shape[0]} x {Am.shape[1]} matrix; nnz = {Am.nnz}")
 
 count[0] = 0
-x0, info = la.gmres(A, b, restrt=M, tol=1e-14)
+x0, info = la.gmres(A, b, restrt=M, rtol=1e-14)
 count_0 = count[0]
 err0 = np.linalg.norm(Am@x0 - b) / bnorm
 print(f"GMRES({M}): {count_0} matvecs, relative residual: {err0}")
@@ -43,7 +43,7 @@ if info != 0:
     print("Didn't converge")
 
 count[0] = 0
-x1, info = la.lgmres(A, b, inner_m=M-6*2, outer_k=6, tol=1e-14)
+x1, info = la.lgmres(A, b, inner_m=M-6*2, outer_k=6, rtol=1e-14)
 count_1 = count[0]
 err1 = np.linalg.norm(Am@x1 - b) / bnorm
 print(f"LGMRES({M - 2*6}, 6) [same memory req.]: {count_1} "
@@ -52,7 +52,7 @@ if info != 0:
     print("Didn't converge")
 
 count[0] = 0
-x2, info = la.lgmres(A, b, inner_m=M-6, outer_k=6, tol=1e-14)
+x2, info = la.lgmres(A, b, inner_m=M-6, outer_k=6, rtol=1e-14)
 count_2 = count[0]
 err2 = np.linalg.norm(Am@x2 - b) / bnorm
 print(f"LGMRES({M - 6}, 6) [same subspace size]: {count_2} "

--- a/scipy/sparse/linalg/_isolve/tests/test_gcrotmk.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_gcrotmk.py
@@ -37,7 +37,7 @@ def do_solve(**kw):
     count[0] = 0
     with suppress_warnings() as sup:
         sup.filter(DeprecationWarning, ".*called without specifying.*")
-        x0, flag = gcrotmk(A, b, x0=zeros(A.shape[0]), tol=1e-14, **kw)
+        x0, flag = gcrotmk(A, b, x0=zeros(A.shape[0]), rtol=1e-14, **kw)
     count_0 = count[0]
     assert_(allclose(A@x0, b, rtol=1e-12, atol=1e-12), norm(A@x0-b))
     return x0, count_0
@@ -77,7 +77,7 @@ class TestGCROTMK:
     def test_cornercase(self):
         np.random.seed(1234)
 
-        # Rounding error may prevent convergence with tol=0 --- ensure
+        # Rounding error may prevent convergence with rtol=0 --- ensure
         # that the return values in this case are correct, and no
         # exceptions are raised
 
@@ -91,7 +91,7 @@ class TestGCROTMK:
                 assert_equal(info, 0)
                 assert_allclose(A.dot(x) - b, 0, atol=1e-14)
 
-                x, info = gcrotmk(A, b, tol=0, maxiter=10)
+                x, info = gcrotmk(A, b, rtol=0, maxiter=10)
                 if info == 0:
                     assert_allclose(A.dot(x) - b, 0, atol=1e-14)
 
@@ -100,7 +100,7 @@ class TestGCROTMK:
                 assert_equal(info, 0)
                 assert_allclose(A.dot(x) - b, 0, atol=1e-14)
 
-                x, info = gcrotmk(A, b, tol=0, maxiter=10)
+                x, info = gcrotmk(A, b, rtol=0, maxiter=10)
                 if info == 0:
                     assert_allclose(A.dot(x) - b, 0, atol=1e-14)
 
@@ -111,7 +111,7 @@ class TestGCROTMK:
 
         with suppress_warnings() as sup:
             sup.filter(DeprecationWarning, ".*called without specifying.*")
-            x, info = gcrotmk(A, b, tol=0, maxiter=10)
+            x, info = gcrotmk(A, b, rtol=0, maxiter=10)
             assert_equal(info, 1)
 
     def test_truncate(self):
@@ -122,7 +122,7 @@ class TestGCROTMK:
         for truncate in ['oldest', 'smallest']:
             with suppress_warnings() as sup:
                 sup.filter(DeprecationWarning, ".*called without specifying.*")
-                x, info = gcrotmk(A, b, m=10, k=10, truncate=truncate, tol=1e-4,
+                x, info = gcrotmk(A, b, m=10, k=10, truncate=truncate, rtol=1e-4,
                                   maxiter=200)
             assert_equal(info, 0)
             assert_allclose(A.dot(x) - b, 0, atol=1e-3)

--- a/scipy/sparse/linalg/_isolve/tests/test_lgmres.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_lgmres.py
@@ -40,7 +40,7 @@ def do_solve(**kw):
     with suppress_warnings() as sup:
         sup.filter(DeprecationWarning, ".*called without specifying.*")
         x0, flag = lgmres(A, b, x0=zeros(A.shape[0]),
-                          inner_m=6, tol=1e-14, **kw)
+                          inner_m=6, rtol=1e-14, **kw)
     count_0 = count[0]
     assert_(allclose(A@x0, b, rtol=1e-12, atol=1e-12), norm(A@x0-b))
     return x0, count_0
@@ -113,7 +113,7 @@ class TestLGMRES:
     def test_cornercase(self):
         np.random.seed(1234)
 
-        # Rounding error may prevent convergence with tol=0 --- ensure
+        # Rounding error may prevent convergence with rtol=0 --- ensure
         # that the return values in this case are correct, and no
         # exceptions are raised
 
@@ -128,7 +128,7 @@ class TestLGMRES:
                 assert_equal(info, 0)
                 assert_allclose(A.dot(x) - b, 0, atol=1e-14)
 
-                x, info = lgmres(A, b, tol=0, maxiter=10)
+                x, info = lgmres(A, b, rtol=0, maxiter=10)
                 if info == 0:
                     assert_allclose(A.dot(x) - b, 0, atol=1e-14)
 
@@ -137,7 +137,7 @@ class TestLGMRES:
                 assert_equal(info, 0)
                 assert_allclose(A.dot(x) - b, 0, atol=1e-14)
 
-                x, info = lgmres(A, b, tol=0, maxiter=10)
+                x, info = lgmres(A, b, rtol=0, maxiter=10)
                 if info == 0:
                     assert_allclose(A.dot(x) - b, 0, atol=1e-14)
 
@@ -148,7 +148,7 @@ class TestLGMRES:
 
         with suppress_warnings() as sup:
             sup.filter(DeprecationWarning, ".*called without specifying.*")
-            x, info = lgmres(A, b, tol=0, maxiter=10)
+            x, info = lgmres(A, b, rtol=0, maxiter=10)
             assert_equal(info, 1)
 
     def test_breakdown_with_outer_v(self):

--- a/scipy/sparse/linalg/_isolve/tests/test_minres.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_minres.py
@@ -23,7 +23,7 @@ def test_singular():
     b[0] = 0
     xp, info = minres(A, b)
     assert_equal(info, 0)
-    assert_normclose(A.dot(xp), b, tol=1e-5)
+    assert_normclose(A.dot(xp), b, rtol=1e-5)
 
 
 def test_x0_is_used_by():
@@ -69,8 +69,8 @@ def test_minres_non_default_x0():
     a = np.dot(a, a.T)
     b = np.random.randn(5)
     c = np.random.randn(5)
-    x = minres(a, b, x0=c, tol=tol)[0]
-    assert_normclose(a.dot(x), b, tol=tol)
+    x = minres(a, b, x0=c, rtol=tol)[0]
+    assert_normclose(a.dot(x), b, rtol=tol)
 
 
 def test_minres_precond_non_default_x0():
@@ -82,8 +82,8 @@ def test_minres_precond_non_default_x0():
     c = np.random.randn(5)
     m = np.random.randn(5, 5)
     m = np.dot(m, m.T)
-    x = minres(a, b, M=m, x0=c, tol=tol)[0]
-    assert_normclose(a.dot(x), b, tol=tol)
+    x = minres(a, b, M=m, x0=c, rtol=tol)[0]
+    assert_normclose(a.dot(x), b, rtol=tol)
 
 
 def test_minres_precond_exact_x0():
@@ -94,5 +94,5 @@ def test_minres_precond_exact_x0():
     c = np.ones(10)
     m = np.random.randn(10, 10)
     m = np.dot(m, m.T)
-    x = minres(a, b, M=m, x0=c, tol=tol)[0]
-    assert_normclose(a.dot(x), b, tol=tol)
+    x = minres(a, b, M=m, x0=c, rtol=tol)[0]
+    assert_normclose(a.dot(x), b, rtol=tol)

--- a/scipy/sparse/linalg/_isolve/tfqmr.py
+++ b/scipy/sparse/linalg/_isolve/tfqmr.py
@@ -5,7 +5,7 @@ from .utils import make_system
 __all__ = ['tfqmr']
 
 
-def tfqmr(A, b, x0=None, tol=1e-5, maxiter=None, M=None,
+def tfqmr(A, b, x0=None, rtol=1e-5, maxiter=None, M=None,
           callback=None, atol=None, show=False):
     """
     Use Transpose-Free Quasi-Minimal Residual iteration to solve ``Ax = b``.
@@ -21,10 +21,10 @@ def tfqmr(A, b, x0=None, tol=1e-5, maxiter=None, M=None,
         Right hand side of the linear system. Has shape (N,) or (N,1).
     x0 : {ndarray}
         Starting guess for the solution.
-    tol, atol : float, optional
-        Tolerances for convergence, ``norm(residual) <= max(tol*norm(b-Ax0), atol)``.
-        The default for `tol` is 1.0e-5.
-        The default for `atol` is ``tol * norm(b-Ax0)``.
+    rtol, atol : float, optional
+        Tolerances for convergence, ``norm(residual) <= max(rtol*norm(b-Ax0), atol)``.
+        The default for `rtol` is 1.0e-5.
+        The default for `atol` is ``rtol * norm(b-Ax0)``.
 
         .. warning::
 
@@ -130,9 +130,9 @@ def tfqmr(A, b, x0=None, tol=1e-5, maxiter=None, M=None,
         return (postprocess(x), 0)
 
     if atol is None:
-        atol = tol * r0norm
+        atol = rtol * r0norm
     else:
-        atol = max(atol, tol * r0norm)
+        atol = max(atol, rtol * r0norm)
 
     for iter in range(maxiter):
         even = iter % 2 == 0


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
In some sparse linear iterative solvers, the original parameter name `tol` is ambiguous, this PR will replace `tol` by `rtol` to represent relative residual tolerance. Users will be more clear about the meaning of `rtol`. In addition, refer also to the discussion on `rtol` in the following link https://github.com/scipy/scipy/pull/16202#discussion_r884367708.

#### Additional information
<!--Any additional information you think is important.-->
