### PR TITLE
BUG: Change (n+1) to n for correct jackknife calculation of hd quantile standard error

### DIFF
--- a/scipy/stats/_mstats_extras.py
+++ b/scipy/stats/_mstats_extras.py
@@ -163,7 +163,7 @@ def hdquantiles_sd(data, prob=list([.25,.5,.75]), axis=None):
         betacdf = beta.cdf
 
         for (i,p) in enumerate(prob):
-            _w = betacdf(vv, (n+1)*p, (n+1)*(1-p))
+            _w = betacdf(vv, n*p, n*(1-p))
             w = _w[1:] - _w[:-1]
             mx_ = np.fromiter([w[:k] @ xsorted[:k] + w[k:] @ xsorted[k+1:]
                                for k in range(n)], dtype=float_)


### PR DESCRIPTION

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
N/A

#### What does this implement/fix?
In [Harrell and Davis' original paper](http://rfuncs.project.s3.amazonaws.com/Harrell82A+New+Distribution-Free+Quantile+Estimator.pdf) (Formula 4), the standard error calculation for the quantiles is a jackknife estimator. A jackknife estimator requires calculating the estimator in a leave-one-out fashion; however, the current implementation uses `(n+1)` when calculating the weights used in the jackknife, when it should use `n`, as the jackknife leaves 1 data point out.

Appropriate unit tests updated. Changes include testing against the new correct values, and doing a rudimentary jackknife calculation to compare to the actual method.

<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
Funny enough, Harrell actually makes the same mistake in his [implementation](https://github.com/harrelfe/Hmisc/blob/master/R/Misc.s#L1283), which I'm guessing was used to verify correctness of the previous one.
