### PR TITLE
DOC: Update Returns section of optimize.linprog.

### DIFF
--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -360,7 +360,7 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
         A :class:`scipy.optimize.OptimizeResult` consisting of the fields
         below. Note that the return types of the fields may depend on whether
         the optimization was successful, therefore it is recommended to check
-        `OptimizeResult.success` before relying on the other fields:
+        `OptimizeResult.status` before relying on the other fields:
 
         x : 1-D array
             The values of the decision variables that minimizes the

--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -357,7 +357,10 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
     Returns
     -------
     res : OptimizeResult
-        A :class:`scipy.optimize.OptimizeResult` consisting of the fields:
+        A :class:`scipy.optimize.OptimizeResult` consisting of the fields
+        below. Note that the return types of the fields may depend on whether
+        the optimization was successful, therefore it is recommended to check
+        `OptimizeResult.success` before relying on the other fields:
 
         x : 1-D array
             The values of the decision variables that minimizes the


### PR DESCRIPTION
Update the description of the OptimizeResult object to
note that the return type of the individual fields depends on
whether the optimization terminates successfully.

Add recommendation for users to check the OptimizeResult.success
attribute prior to any subsequent analysis.

I thought this was less invasive than changing the parameter types for the individual fields to `or None`, but YMMV.

Closes #16466 as the result notes have already been updated.