### PR TITLE
MAINT: remove raw html from README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,12 +1,3 @@
-.. raw:: html
-
-    <p>
-      <h1>
-        <a href="https://docs.scipy.org/doc/scipy/reference/"><img valign="middle" src="doc/source/_static/logo.svg" height="50" height="50" alt="SciPy logo"/></a>
-        SciPy
-      </h1>
-    </p>
-
 .. image:: https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A
   :target: https://numfocus.org
 


### PR DESCRIPTION
This was causing an issue with uploading the sdist to PyPI. Tested on TestPyPI.

There's no point to keep this around, the logo doesn't add anything in the README - that's what we have a website for.

Closes gh-16465

[ci skip]