### PR TITLE
DOC: special.entr: add context

### DIFF
--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -3132,8 +3132,9 @@ add_newdoc("entr",
 
     References
     ----------
-    .. [1] Grant, Boyd, and Ye, "The CVX Users' Guide",
-           http://web.cvxr.com/cvx/doc/CVX.pdf
+    .. [1] Boyd, Stephen and Lieven Vandenberghe. *Convex optimization*.
+           Cambridge University Press, 2004.
+           :doi:`https://doi.org/10.1017/CBO9780511804441`
 
     """)
 
@@ -7438,9 +7439,9 @@ add_newdoc("kl_div",
 
     References
     ----------
-    .. [1] Grant, Boyd, and Ye, "The CVX Users' Guide",
-           http://web.cvxr.com/cvx/doc/CVX.pdf
-
+    .. [1] Boyd, Stephen and Lieven Vandenberghe. *Convex optimization*.
+           Cambridge University Press, 2004.
+           :doi:`https://doi.org/10.1017/CBO9780511804441`
 
     """)
 
@@ -10247,8 +10248,9 @@ add_newdoc("rel_entr",
 
     References
     ----------
-    .. [1] Grant, Boyd, and Ye, "The CVX Users' Guide",
-           http://web.cvxr.com/cvx/doc/CVX.pdf
+    .. [1] Boyd, Stephen and Lieven Vandenberghe. *Convex optimization*.
+           Cambridge University Press, 2004.
+           :doi:`https://doi.org/10.1017/CBO9780511804441`
     .. [2] Kullback-Leibler divergence,
            https://en.wikipedia.org/wiki/Kullback%E2%80%93Leibler_divergence
 

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -3110,13 +3110,30 @@ add_newdoc("entr",
 
     See Also
     --------
-    kl_div, rel_entr
+    kl_div
+    rel_entr
+    scipy.stats.entropy
 
     Notes
     -----
+    .. versionadded:: 0.15.0
+
     This function is concave.
 
-    .. versionadded:: 0.15.0
+    The origin of this function is in convex programming; see [1]_.
+    Given a probability distribution :math:`p_1, \ldots, p_n`,
+    the definition of entropy in the context of *information theory* is
+
+    .. math::
+
+        \sum_{i = 1}^n \mathrm{entr}(p_i).
+
+    To compute the latter quantity, use `scipy.stats.entropy`.
+
+    References
+    ----------
+    .. [1] Grant, Boyd, and Ye, "The CVX Users' Guide",
+           http://web.cvxr.com/cvx/doc/CVX.pdf
 
     """)
 
@@ -7403,7 +7420,9 @@ add_newdoc("kl_div",
 
     See Also
     --------
-    entr, rel_entr
+    entr
+    rel_entr
+    scipy.stats.entropy
 
     Notes
     -----
@@ -7419,8 +7438,8 @@ add_newdoc("kl_div",
 
     References
     ----------
-    .. [1] Grant, Boyd, and Ye, "CVX: Matlab Software for Disciplined Convex
-        Programming", http://cvxr.com/cvx/
+    .. [1] Grant, Boyd, and Ye, "The CVX Users' Guide",
+           http://web.cvxr.com/cvx/doc/CVX.pdf
 
 
     """)
@@ -10203,7 +10222,9 @@ add_newdoc("rel_entr",
 
     See Also
     --------
-    entr, kl_div
+    entr
+    kl_div
+    scipy.stats.entropy
 
     Notes
     -----
@@ -10213,21 +10234,23 @@ add_newdoc("rel_entr",
 
     The origin of this function is in convex programming; see
     [1]_. Given two discrete probability distributions :math:`p_1,
-    \ldots, p_n` and :math:`q_1, \ldots, q_n`, to get the relative
-    entropy of statistics compute the sum
+    \ldots, p_n` and :math:`q_1, \ldots, q_n`, the definition of relative
+    entropy in the context of *information theory* is
 
     .. math::
 
         \sum_{i = 1}^n \mathrm{rel\_entr}(p_i, q_i).
 
+    To compute the latter quantity, use `scipy.stats.entropy`.
+
     See [2]_ for details.
 
     References
     ----------
-    .. [1] Grant, Boyd, and Ye, "CVX: Matlab Software for Disciplined Convex
-        Programming", http://cvxr.com/cvx/
+    .. [1] Grant, Boyd, and Ye, "The CVX Users' Guide",
+           http://web.cvxr.com/cvx/doc/CVX.pdf
     .. [2] Kullback-Leibler divergence,
-        https://en.wikipedia.org/wiki/Kullback%E2%80%93Leibler_divergence
+           https://en.wikipedia.org/wiki/Kullback%E2%80%93Leibler_divergence
 
     """)
 

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -3110,9 +3110,7 @@ add_newdoc("entr",
 
     See Also
     --------
-    kl_div
-    rel_entr
-    scipy.stats.entropy
+    kl_div, rel_entr, scipy.stats.entropy
 
     Notes
     -----
@@ -7421,9 +7419,7 @@ add_newdoc("kl_div",
 
     See Also
     --------
-    entr
-    rel_entr
-    scipy.stats.entropy
+    entr, rel_entr, scipy.stats.entropy
 
     Notes
     -----
@@ -10223,9 +10219,7 @@ add_newdoc("rel_entr",
 
     See Also
     --------
-    entr
-    kl_div
-    scipy.stats.entropy
+    entr, kl_div, scipy.stats.entropy
 
     Notes
     -----


### PR DESCRIPTION
#### Reference issue
gh-11015
gh-11006
gh-3421

#### What does this implement/fix?
https://github.com/scipy/scipy/issues/3421#issuecomment-100654668 reported confusion about the `scipy.special` functions `entr`, `rel_entr`, and `kl_div`. This attempts to clarify that they are used in the context of convex programming and that `scipy.stats.entropy` should be used for information theory.
