### PR TITLE
MAINT: Improve test speed, add timeouts

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           python3.8-dbg -c 'import sys; print("Python debug build:", hasattr(sys, "gettotalrefcount"))'
           python3.8-dbg -m pip install --upgrade pip "setuptools<60.0" wheel
-          python3.8-dbg -m pip install --upgrade numpy cython pytest pytest-xdist pybind11
+          python3.8-dbg -m pip install --upgrade numpy cython pytest pytest-xdist pytest-timeout pybind11
           python3.8-dbg -m pip install --upgrade mpmath gmpy2 pythran threadpoolctl
           python3.8-dbg -m pip uninstall -y nose
           cd ..
@@ -49,7 +49,7 @@ jobs:
       - name: Testing SciPy
         if: ${{ github.event_name == 'pull_request' }}
         run: |
-          python3.8-dbg -u runtests.py -n -g -j2 -m fast -- -rfEX --durations=10 2>&1 | tee runtests.log
+          python3.8-dbg -u runtests.py -n -g -j2 -m fast -- -rfEX --durations=10 --timeout=60 2>&1 | tee runtests.log
           python3.8-dbg tools/validate_runtests_log.py fast < runtests.log
       - name: Dynamic symbol hiding check on Linux
         if: ${{ github.event_name == 'pull_request' }}
@@ -81,7 +81,7 @@ jobs:
     - name: Install packages
       run: |
         pip install --user git+https://github.com/numpy/numpy.git
-        python -m pip install --user "setuptools<60.0" wheel cython pytest pybind11 pytest-xdist
+        python -m pip install --user "setuptools<60.0" wheel cython pytest pybind11 pytest-xdist pytest-timeout
         pip install --user git+https://github.com/serge-sans-paille/pythran.git
         python -m pip install -r mypy_requirements.txt
 
@@ -94,4 +94,4 @@ jobs:
 
     - name: Test SciPy
       run: |
-        python -u runtests.py -n -m fast
+        python -u runtests.py -n -m fast --durations=10 --timeout=60

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -94,4 +94,4 @@ jobs:
 
     - name: Test SciPy
       run: |
-        python -u runtests.py -n -m fast --durations=10 --timeout=60
+        python -u runtests.py -n -m fast -- --durations=10 --timeout=60

--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -57,7 +57,7 @@ jobs:
 
     - name: Install Python packages
       run: |
-        python -m pip install numpy setuptools wheel cython pytest pytest-xdist pybind11 mpmath gmpy2 pythran ninja meson click rich-click doit pydevtool
+        python -m pip install numpy setuptools wheel cython pytest pytest-xdist pytest-timeout pybind11 mpmath gmpy2 pythran ninja meson click rich-click doit pydevtool
 
     - name:  Prepare compiler cache
       id:    prep-ccache

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -80,9 +80,9 @@ jobs:
     - name: Install packages
       run: |
         pip install ${{ matrix.numpy-version }}
-        pip install setuptools==59.8.0 wheel cython pytest pytest-xdist pybind11 pytest-xdist mpmath gmpy2 pythran
+        pip install setuptools==59.8.0 wheel cython pytest pytest-xdist pytest-timeout pybind11 pytest-xdist mpmath gmpy2 pythran
 
     - name: Test SciPy
       run: |
         export LIBRARY_PATH="$LIBRARY_PATH:/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib"
-        SCIPY_USE_PYTHRAN=`test ${{ matrix.python-version }} != 3.9; echo $?` python -u runtests.py
+        SCIPY_USE_PYTHRAN=`test ${{ matrix.python-version }} != 3.9; echo $?` python -u runtests.py --durations=10 --timeout=60

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -85,4 +85,4 @@ jobs:
     - name: Test SciPy
       run: |
         export LIBRARY_PATH="$LIBRARY_PATH:/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib"
-        SCIPY_USE_PYTHRAN=`test ${{ matrix.python-version }} != 3.9; echo $?` python -u runtests.py --durations=10 --timeout=60
+        SCIPY_USE_PYTHRAN=`test ${{ matrix.python-version }} != 3.9; echo $?` python -u runtests.py -- --durations=10 --timeout=60

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -42,7 +42,7 @@ jobs:
           gfortran --version
       - name: pip-packages
         run: |
-          pip install numpy==1.22.2 cython pybind11 pythran meson ninja pytest pytest-xdist
+          pip install numpy==1.22.2 cython pybind11 pythran meson ninja pytest pytest-xdist pytest-timeout
       - name: openblas-libs
         run: |
           # Download and install pre-built OpenBLAS library

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -192,7 +192,7 @@ stages:
             cd ../scipy && \
             CC=gcc-5 CXX=g++-5 F77=gfortran-8 F90=gfortran-8 python3.8 setup.py install && \
             python3.8 tools/openblas_support.py --check_version $(openblas_version) && \
-            python3.8 runtests.py -n --mode=full -- -n auto -s --junitxml=junit/test-results.xml --cov-config=.coveragerc --cov-report=xml --cov-report=html --timeout=60"
+            python3.8 runtests.py -n --mode=full -- -n auto -s --junitxml=junit/test-results.xml --cov-config=.coveragerc --cov-report=xml --cov-report=html --durations=10 --timeout=60"
       displayName: 'Run 32-bit Ubuntu Docker Build / Tests'
     - task: PublishTestResults@2
       condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -192,7 +192,7 @@ stages:
             cd ../scipy && \
             CC=gcc-5 CXX=g++-5 F77=gfortran-8 F90=gfortran-8 python3.8 setup.py install && \
             python3.8 tools/openblas_support.py --check_version $(openblas_version) && \
-            python3.8 runtests.py -n --mode=full -- -n auto -s --junitxml=junit/test-results.xml --cov-config=.coveragerc --cov-report=xml --cov-report=html"
+            python3.8 runtests.py -n --mode=full -- -n auto -s --junitxml=junit/test-results.xml --cov-config=.coveragerc --cov-report=xml --cov-report=html --timeout=60"
       displayName: 'Run 32-bit Ubuntu Docker Build / Tests'
     - task: PublishTestResults@2
       condition: succeededOrFailed()
@@ -348,7 +348,7 @@ stages:
     - powershell: |
         $env:PATH = "C:\\ProgramData\\chocolatey\\lib\\mingw\\tools\\install\\mingw$(BITS)\\bin;" + $env:PATH
         $env:SCIPY_USE_PYTHRAN=$(SCIPY_USE_PYTHRAN)
-        python runtests.py -n --mode=$(TEST_MODE) -- -n 2 --junitxml=junit/test-results.xml --durations=10
+        python runtests.py -n --mode=$(TEST_MODE) -- -n 2 --junitxml=junit/test-results.xml --durations=10 --timeout=60
       displayName: 'Run SciPy Test Suite'
     - task: PublishTestResults@2
       condition: succeededOrFailed()

--- a/ci/azure-travis-template.yaml
+++ b/ci/azure-travis-template.yaml
@@ -76,6 +76,7 @@ steps:
     pybind11
     pytest
     pytest-xdist
+    pytest-timeout
   displayName: 'Install common python dependencies'
 - ${{ if eq(parameters.test_mode, 'full') }}:
   - script: pip install matplotlib scikit-umfpack scikit-sparse

--- a/ci/azure-travis-template.yaml
+++ b/ci/azure-travis-template.yaml
@@ -139,7 +139,7 @@ steps:
   displayName: 'Build SciPy'
 - script: |
     set -euo pipefail
-    python -u runtests.py -g -j2 -m ${{ parameters.test_mode }} ${COVERAGE:-} ${USE_WHEEL_BUILD:-} -- -rfEX --durations=10 2>&1 | tee runtests.log
+    python -u runtests.py -g -j2 -m ${{ parameters.test_mode }} ${COVERAGE:-} ${USE_WHEEL_BUILD:-} -- -rfEX --durations=10 --timeout=60 2>&1 | tee runtests.log
     tools/validate_runtests_log.py ${{ parameters.test_mode }} < runtests.log
   env:
     ${{ if eq(parameters.coverage, true) }}:

--- a/environment.yml
+++ b/environment.yml
@@ -24,6 +24,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-xdist
+  - pytest-timeout
   - asv<0.5
   # For type annotations
   - mypy

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -2295,6 +2295,7 @@ class TestLinprogHiGHSMIP():
         np.testing.assert_allclose(res.fun, -12)
 
     @pytest.mark.slow
+    @pytest.mark.timeout(120)  # prerelease_deps_coverage_64bit_blas job
     def test_mip6(self):
         # solve a larger MIP with only equality constraints
         # source: https://www.mathworks.com/help/optim/ug/intlinprog.html

--- a/scipy/optimize/tests/test_milp.py
+++ b/scipy/optimize/tests/test_milp.py
@@ -236,6 +236,7 @@ def test_milp_5():
 
 
 @pytest.mark.slow
+@pytest.mark.timeout(120)  # prerelease_deps_coverage_64bit_blas job
 def test_milp_6():
     # solve a larger MIP with only equality constraints
     # source: https://www.mathworks.com/help/optim/ug/intlinprog.html

--- a/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
@@ -768,6 +768,7 @@ class TestSpsolveTriangular:
             assert_array_almost_equal(A.dot(x), b)
 
     @pytest.mark.slow
+    @pytest.mark.timeout(120)  # prerelease_deps_coverage_64bit_blas job
     @sup_sparse_efficiency
     def test_random(self):
         def random_triangle_matrix(n, lower=True):

--- a/scipy/sparse/linalg/tests/test_propack.py
+++ b/scipy/sparse/linalg/tests/test_propack.py
@@ -110,7 +110,7 @@ def test_svdp(ctor, precision, irl, which):
 
 @pytest.mark.parametrize('precision', _dtype_testing)
 @pytest.mark.parametrize('irl', (False, True))
-@pytest.mark.slowtest(120)  # True, complex8 > 60 s: prerel deps cov 64bit blas
+@pytest.mark.timeout(120)  # True, complex8 > 60 s: prerel deps cov 64bit blas
 def test_examples(precision, irl):
     # Note: atol for complex8 bumped from 1e-4 to 1e-3 because of test failures
     # with BLIS, Netlib, and MKL+AVX512 - see

--- a/scipy/sparse/linalg/tests/test_propack.py
+++ b/scipy/sparse/linalg/tests/test_propack.py
@@ -110,6 +110,7 @@ def test_svdp(ctor, precision, irl, which):
 
 @pytest.mark.parametrize('precision', _dtype_testing)
 @pytest.mark.parametrize('irl', (False, True))
+@pytest.mark.slowtest(120)  # True, complex8 > 60 s: prerel deps cov 64bit blas
 def test_examples(precision, irl):
     # Note: atol for complex8 bumped from 1e-4 to 1e-3 because of test failures
     # with BLIS, Netlib, and MKL+AVX512 - see

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -259,22 +259,22 @@ def cases_test_moments():
             yield pytest.param(distname, arg, True, True, True,
                                marks=pytest.mark.xslow(reason="too slow"))
             continue
-        # takes > 60 sec on Linux 32-bit and ~200 sec on Azure Windows
-        if distname == 'skewnorm':
-            yield pytest.param(distname, arg, True, True, True,
-                               marks=pytest.mark.timeout(300))
-            continue
 
         cond1 = distname not in fail_normalization
         cond2 = distname not in fail_higher
 
-        yield distname, arg, cond1, cond2, False
+        marks = list()
+        if distname == 'skewnorm':
+            # takes > 60 sec on Linux 32-bit and ~200 sec on Azure Windows
+            marks.append(pytest.mark.timeout(300))
+
+        yield pytest.param(distname, arg, cond1, cond2, False, marks=marks)
 
         if not cond1 or not cond2:
             # Run the distributions that have issues twice, once skipping the
             # not_ok parts, once with the not_ok parts but marked as knownfail
             yield pytest.param(distname, arg, True, True, True,
-                               marks=pytest.mark.xfail)
+                               marks=[pytest.mark.xfail] + marks)
 
 
 @pytest.mark.slow

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -1,4 +1,3 @@
-import sys
 import numpy as np
 import numpy.testing as npt
 import pytest
@@ -260,8 +259,8 @@ def cases_test_moments():
             yield pytest.param(distname, arg, True, True, True,
                                marks=pytest.mark.xslow(reason="too slow"))
             continue
-        # takes ~200 sec on Azure Windows
-        if distname == 'skewnorm' and sys.platform == 'win32':
+        # takes > 60 sec on Linux 32-bit and ~200 sec on Azure Windows
+        if distname == 'skewnorm':
             yield pytest.param(distname, arg, True, True, True,
                                marks=pytest.mark.timeout(300))
             continue

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -1,4 +1,4 @@
-
+import sys
 import numpy as np
 import numpy.testing as npt
 import pytest
@@ -259,6 +259,11 @@ def cases_test_moments():
         if distname in distxslow_test_moments:
             yield pytest.param(distname, arg, True, True, True,
                                marks=pytest.mark.xslow(reason="too slow"))
+            continue
+        # takes ~200 sec on Azure Windows
+        if distname == 'skewnorm' and sys.platform == 'win32':
+            yield pytest.param(distname, arg, True, True, True,
+                               marks=pytest.mark.timeout(300))
             continue
 
         cond1 = distname not in fail_normalization


### PR DESCRIPTION
Not 100% sure this is the best approach, but in https://github.com/scipy/scipy/pull/16485 I noticed the timings:
```
1076.65s call     interpolate/tests/test_rbfinterp.py::TestRBFInterpolatorNeighborsInf::test_chunking
1019.62s call     interpolate/tests/test_rbfinterp.py::TestRBFInterpolatorNeighborsNone::test_chunking
619.26s call     interpolate/tests/test_rbfinterp.py::TestRBFInterpolatorNeighbors20::test_chunking
205.55s call     stats/tests/test_continuous_basic.py::test_moments[skewnorm-arg92-True-True-False]
```
The first three we can fix easily with a `monkeypatch` to force it to use the desired code path on a smaller input. The last one I guess we live with for now, though maybe we should `.xslow` it on Windows (?).

To prevent this sort of problem in the future I added `--timeout=60` so that if someone *really* wants to add a test that takes longer than a minute, they have to be intentional about it and add a `pytest.mark.timeout`.

cc @segasai @ev-br since it looks like you worked on https://github.com/scipy/scipy/pull/15190 where this was perhaps added