### PR TITLE
ENH: Provide access to tableau data of the HiGHS LP solver

### DIFF
--- a/scipy/optimize/_highs/cython/src/Highs.pxd
+++ b/scipy/optimize/_highs/cython/src/Highs.pxd
@@ -17,6 +17,9 @@ from .HighsLp cimport (
 )
 from .HConst cimport HighsModelStatus
 
+cdef extern from "util/HighsInt.h":
+    ctypedef int HighsInt  # because we're compiling with HIGHSINT64 off
+
 cdef extern from "Highs.h":
     # From HiGHS/src/Highs.h
     cdef cppclass Highs:
@@ -54,3 +57,11 @@ cdef extern from "Highs.h":
         HighsStatus setHighsOptionValueDbl "setOptionValue" (const string & option, const double value)
 
         string primalDualStatusToString(const int primal_dual_status)
+
+        HighsStatus getBasicVariables(HighsInt* basic_variables)
+        HighsStatus getReducedRow(const HighsInt row, double* row_vector,
+                                 HighsInt* row_num_nz, HighsInt* row_indices,
+                                 const double* pass_basis_inverse_row_vector)
+        HighsStatus getReducedColumn(const HighsInt col, double* col_vector,
+                                    HighsInt* col_num_nz,
+                                    HighsInt* col_indices)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes #15915

#### What does this implement/fix?
<!--Please explain your changes.-->

Adds Cython function declarations for `Highs::getBasicVariables`, `Highs::getReducedRow`, and `Highs::getReducedColumn`.  Only exposed for Cython interface consumers, no functional differences in `optimize.linprog` or `optimize.milp`.

#### Additional information
<!--Any additional information you think is important.-->
