### PR TITLE
ENH: Speed up hdquantile_sd via cumulative sums

### DIFF
--- a/scipy/stats/_mstats_extras.py
+++ b/scipy/stats/_mstats_extras.py
@@ -167,12 +167,10 @@ def hdquantiles_sd(data, prob=list([.25,.5,.75]), axis=None):
             w = _w[1:] - _w[:-1]
             # cumulative sum of weights and data points if
             # ith point is left out for jackknife
-            cumulativeSumLeft = np.append([0], np.cumsum(w * xsorted[:-1]))
+            mx_ = np.zeros_like(xsorted)
+            mx_[1:] = np.cumsum(w * xsorted[:-1])
             # similar but from the right
-            cumulativeSumRight = np.append([0],
-                                           np.cumsum(w[::-1] * xsorted[:0:-1])
-                                           )[::-1]
-            mx_ = cumulativeSumLeft + cumulativeSumRight
+            mx_[:-1] += np.cumsum(w[::-1] * xsorted[:0:-1])[::-1]
             hdsd[i] = np.sqrt(mx_.var() * (n - 1))
         return hdsd
 

--- a/scipy/stats/_mstats_extras.py
+++ b/scipy/stats/_mstats_extras.py
@@ -165,10 +165,14 @@ def hdquantiles_sd(data, prob=list([.25,.5,.75]), axis=None):
         for (i,p) in enumerate(prob):
             _w = betacdf(vv, n*p, n*(1-p))
             w = _w[1:] - _w[:-1]
-            mx_ = np.fromiter([w[:k] @ xsorted[:k] + w[k:] @ xsorted[k+1:]
-                               for k in range(n)], dtype=float_)
-            # mx_var = np.array(mx_.var(), copy=False, ndmin=1) * n / (n - 1)
-            # hdsd[i] = (n - 1) * np.sqrt(mx_var / n)
+            # cumulative sum of weights and data points if
+            # ith point is left out for jackknife
+            cumulativeSumLeft = np.append([0], np.cumsum(w * xsorted[:-1]))
+            # similar but from the right
+            cumulativeSumRight = np.append([0],
+                                           np.cumsum(w[::-1] * xsorted[:0:-1])
+                                           )[::-1]
+            mx_ = cumulativeSumLeft + cumulativeSumRight
             hdsd[i] = np.sqrt(mx_.var() * (n - 1))
         return hdsd
 

--- a/scipy/stats/tests/test_mstats_extras.py
+++ b/scipy/stats/tests/test_mstats_extras.py
@@ -139,6 +139,9 @@ class TestQuantiles:
         # Test actual values for good measure
         assert_almost_equal(hd_std_errs, [0.0379258, 0.0380656, 0.0380013])
 
+        two_data_points = ms.hdquantiles_sd([1, 2])
+        assert_almost_equal(two_data_points, [0.5, 0.5, 0.5])
+
     def test_mquantiles_cimj(self):
         # Only test that code runs, implementation not checked for correctness
         ci_lower, ci_upper = ms.mquantiles_cimj(self.data)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
N/A

#### What does this implement/fix?
Previous implementations were O(n^2), but much of the work done can be reduced by instead keeping a cumulative sum creating an O(n) runtime. This is possible since the hdquantile is simply a weighted sum of data points, and the hdquantile_sd is a jackknife (another weighted sum).

A speed test is on [colab](https://colab.research.google.com/drive/1EtBXKewCaGO9ESdqMF7vgJvizkyjJ_do?usp=sharing). It is mostly a copy paste of @rcasero 's code (thank you for sharing!) in https://github.com/scipy/scipy/pull/13566. For 1 million data points, the time for calculating 5 quantiles goes from 2300 seconds to 1.6 seconds! The test also ensures the results are equal.

#### Additional information
<!--Any additional information you think is important.-->
