### PR TITLE
ENH: linalg: Cholesky factorization update/downdate 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,6 +188,7 @@ scipy/linalg/_interpolativemodule.c
 scipy/linalg/_solve_toeplitz.c
 scipy/linalg/_decomp_update.c
 scipy/linalg/_decomp_update.pyx
+scipy/linalg/_cholesky_update.c
 scipy/linalg/_cythonized_array_utils.c
 scipy/linalg/_blas_subroutine_wrappers.f
 scipy/linalg/_blas_subroutines.h

--- a/benchmarks/benchmarks/linalg_cholesky_update.py
+++ b/benchmarks/benchmarks/linalg_cholesky_update.py
@@ -36,7 +36,7 @@ class CholUpdate(Benchmark):
                         overwrite_rz=False, check_finite=False)
 
     def time_cholesky(self, *args):
-        # overwrite = True will fail with LinAlgErrors 
+        # overwrite = True will fail with LinAlgErrors
         # unclear why since setup should always be called.
         scipy.linalg.cholesky(self.a, lower=False, check_finite=False,
                               overwrite_a=False)

--- a/benchmarks/benchmarks/linalg_cholesky_update.py
+++ b/benchmarks/benchmarks/linalg_cholesky_update.py
@@ -34,9 +34,3 @@ class CholUpdate(Benchmark):
     def time_update20(self, *args):
         cholesky_update(self.r, self.u2, downdate=False, lower=False,
                         overwrite_rz=False, check_finite=False)
-
-    def time_cholesky(self, *args):
-        # overwrite = True will fail with LinAlgErrors
-        # unclear why since setup should always be called.
-        scipy.linalg.cholesky(self.a, lower=False, check_finite=False,
-                              overwrite_a=False)

--- a/benchmarks/benchmarks/linalg_cholesky_update.py
+++ b/benchmarks/benchmarks/linalg_cholesky_update.py
@@ -1,0 +1,42 @@
+from .common import Benchmark, safe_import
+import numpy as np
+import scipy.linalg
+
+with safe_import():
+    from scipy.linalg._cholesky_update import cholesky_update
+
+
+class CholUpdate(Benchmark):
+    sizes = [100, 500, 1000, 2000]
+    shapes = [(i, i) for i in sizes]
+    orders = ['C', 'F']
+    param_names = ['shape', 'order']
+    params = [shapes, orders]
+
+    def setup(self, shape, order):
+        np.random.seed(29382)
+        a = np.random.random(shape)
+        a = a + a.conj().T + a.shape[0] * np.eye(a.shape[0])
+        u1 = np.random.random((a.shape[0], 1))
+        u2 = np.random.random((a.shape[0], 2))
+        u20 = np.random.random((a.shape[0], 20))
+
+        self.a = a.copy(order=order)
+        self.r = scipy.linalg.cholesky(a, lower=False).copy(order=order)
+        self.u1 = u1.copy(order=order)
+        self.u2 = u2.copy(order=order)
+        self.u20 = u20.copy(order=order)
+
+    def time_update1(self, *args):
+        cholesky_update(self.r, self.u1, downdate=False, lower=False,
+                        overwrite_rz=False, check_finite=False)
+
+    def time_update20(self, *args):
+        cholesky_update(self.r, self.u2, downdate=False, lower=False,
+                        overwrite_rz=False, check_finite=False)
+
+    def time_cholesky(self, *args):
+        # overwrite = True will fail with LinAlgErrors 
+        # unclear why since setup should always be called.
+        scipy.linalg.cholesky(self.a, lower=False, check_finite=False,
+                              overwrite_a=False)

--- a/mypy.ini
+++ b/mypy.ini
@@ -113,6 +113,9 @@ ignore_missing_imports = True
 [mypy-scipy.linalg._decomp_update]
 ignore_missing_imports = True
 
+[mypy-scipy.linalg._cholesky_update]
+ignore_missing_imports = True
+
 [mypy-scipy.linalg._solve_toeplitz]
 ignore_missing_imports = True
 

--- a/scipy/linalg/__init__.py
+++ b/scipy/linalg/__init__.py
@@ -82,6 +82,7 @@ Decompositions
    ldl - LDL.T decomposition of a Hermitian or a symmetric matrix.
    cholesky - Cholesky decomposition of a matrix
    cholesky_banded - Cholesky decomp. of a sym. or Hermitian banded matrix
+   cholesky_update - Rank-k update of a Cholesky decomposition
    cho_factor - Cholesky decomposition for use in solving a linear system
    cho_solve - Solve previously factored linear system
    cho_solve_banded - Solve previously factored banded linear system

--- a/scipy/linalg/__init__.py
+++ b/scipy/linalg/__init__.py
@@ -201,6 +201,7 @@ from ._decomp import *
 from ._decomp_lu import *
 from ._decomp_ldl import *
 from ._decomp_cholesky import *
+from ._cholesky_update import *
 from ._decomp_qr import *
 from ._decomp_qz import *
 from ._decomp_svd import *

--- a/scipy/linalg/_cholesky_update.pyx
+++ b/scipy/linalg/_cholesky_update.pyx
@@ -506,6 +506,34 @@ def cholesky_update(R, z, downdate=False, lower=False, overwrite_rz=False,
     ------
     LinAlgError : 
         If a downdate results in a non-positive definite matrix.
+
+    Examples
+    --------
+    >>> from scipy import linalg
+    >>> a = np.array([[  3., -1.,  0.],
+    ...               [ -2.,  4.,  1.],
+    ...               [ -3., -8.,  7.]])
+    >>> r = linalg.cholesky(a, lower=False)
+
+    Given this Cholesky decomposition, perform a rank-1 update
+
+    >>> u = np.array([  1.,  4., -2.])
+    >>> r_upd = linalg.cholesky_update(r, u, downdate=False)
+    >>> r_upd
+    array([[ 2.        ,  1.5       , -1.        ],
+           [ 0.        ,  4.21307489, -1.30545982],
+           [ 0.        ,  0.        ,  2.88023864]])
+
+    The equivalent update can be obtained more slowly with the following.
+
+    >>> a1 = a + np.outer(u, u)
+    >>> r_upd_direct = linalg.cholesky(a1, lower=False)
+
+    Check that the results are equivalent:
+
+    >>> np.allclose(r_upd_direct, r_upd)
+    True
+
     """
     cdef cnp.ndarray r1, z1
     cdef int typecode, n, p

--- a/scipy/linalg/_cholesky_update.pyx
+++ b/scipy/linalg/_cholesky_update.pyx
@@ -1,0 +1,603 @@
+"""
+Routines for updating a Cholesky factorization
+
+.. versionadded:: X.Y.Z
+
+"""
+#
+# Copyright (C) 2022 Giacomo Meanti
+# some functions copied from _decomp_update.pyx (Copyright 2014 Eric Moore)
+# 
+# Two algorithms are implemented in this module: one for rank-1 
+# updates and downdates, which follows ref 1. and another for
+# rank-p updates and downdates which follows ref 2.
+#
+# Useful references for Cholesky factorization up and downdating:
+#
+# 1. Pan, C. T. A modification to the linpack downdating algorithm. 
+#    BIT Numerical Mathematics 30, 707-722 (1990).
+# 2. Van de Geijn, R. A., Van Zee, F. G. High-Performance Up-and-Downdating 
+#    via Householder-like Transformations. 
+#    ACM Trans. Math. Softw. 38, 1-17 (2011).
+#
+
+__all__ = ["cholesky_update"]
+
+cimport cython
+from libc.math cimport sqrt, copysign, hypot
+cimport libc.limits
+cimport libc.float
+cimport numpy as cnp
+from . cimport cython_blas as blas_pointers
+from . cimport cython_lapack as lapack_pointers
+
+import numpy as np
+
+
+cdef extern from "<complex.h>" nogil:
+    float complex I
+
+
+# These are commented out in the numpy support we cimported above.
+# Here I have declared them as taking void* instead of PyArrayDescr
+# and object. In this file, only NULL is passed to these parameters.
+cdef extern from *:
+    cnp.ndarray PyArray_CheckFromAny(object, void*, int, int, int, void*)
+    cnp.ndarray PyArray_FromArray(cnp.ndarray, void*, int)
+
+# This is used in place of, e.g., cnp.NPY_C_CONTIGUOUS, to indicate that a C
+# F or non contiguous array is acceptable.
+DEF ARRAY_ANYORDER = 0
+
+
+ctypedef float complex float_complex
+ctypedef double complex double_complex
+ctypedef fused float_t:
+    float
+    double
+    float_complex
+    double_complex
+
+ctypedef fused real_t:
+    float
+    double
+
+ctypedef fused complex_t:
+    float_complex
+    double_complex
+
+#------------------------------------------------------------------------------
+# Helper functions for indexing and complex support
+#------------------------------------------------------------------------------
+
+cdef inline float_t* index2(float_t* a, int* astrides, int i, int j) nogil:
+    return a + i*astrides[0] + j*astrides[1]
+
+cdef inline float_t* index1(float_t* a, int* astrides, int i) nogil:
+    return a + i*astrides[0]
+
+cdef void float_t_conj(int n, float_t* x, int* xs) nogil:
+    cdef int j
+    if float_t is float_complex or float_t is double_complex:
+        for j in range(n):
+            index1(x, xs, j)[0] = index1(x, xs, j)[0].conjugate()
+
+cdef void float_t_2d_conj(int m, int n, float_t* x, int* xs) nogil:
+    cdef int i, j
+    if float_t is float_complex or float_t is double_complex:
+        for i in range(m):
+            for j in range(n):
+                index2(x, xs, i, j)[0] = index2(x, xs, i, j)[0].conjugate()
+
+cdef float_t float_t_sqrt(float_t x) nogil:
+    if float_t is float:
+        return sqrt(x)
+    elif float_t is double:
+        return sqrt(x)
+    elif float_t is float_complex:
+        return <float_complex>sqrt(<double>((<float*>&x)[0]))
+    else:
+        return sqrt((<double*>&x)[0])
+
+cdef inline bint float_t_less_than(float_t x, float_t y) nogil:
+    if float_t is float or float_t is double:
+        return x < y
+    else:
+        return x.real < y.real
+
+#------------------------------------------------------------------------------
+# BLAS and LAPACK wrappers
+#------------------------------------------------------------------------------
+
+cdef inline void scal(int n, float_t a, float_t* x, int incx) nogil:
+    # Some? BLAS distributions don't properly handle negative stride.
+    # https://stackoverflow.com/questions/44875236/why-are-non-positive-strides-disallowed-in-the-blas-gemm-family-of-functions
+    if incx < 0:
+        incx = -incx
+        if float_t is float:
+            blas_pointers.sscal(&n, &a, x - (n - 1) * incx, &incx)
+        elif float_t is double:
+            blas_pointers.dscal(&n, &a, x - (n - 1) * incx, &incx)
+        elif float_t is float_complex:
+            blas_pointers.cscal(&n, &a, x - (n - 1) * incx, &incx)
+        else:  # float_t is double_complex:
+            blas_pointers.zscal(&n, &a, x - (n - 1) * incx, &incx)
+    else:
+        if float_t is float:
+            blas_pointers.sscal(&n, &a, x, &incx)
+        elif float_t is double:
+            blas_pointers.dscal(&n, &a, x, &incx)
+        elif float_t is float_complex:
+            blas_pointers.cscal(&n, &a, x, &incx)
+        else:  # float_t is double_complex:
+            blas_pointers.zscal(&n, &a, x, &incx)
+
+cdef inline void axpy(int n, float_t a, float_t* x, int incx, float_t* y,
+                      int incy) nogil:
+    if float_t is float:
+        blas_pointers.saxpy(&n, &a, x, &incx, y, &incy)
+    elif float_t is double:
+        blas_pointers.daxpy(&n, &a, x, &incx, y, &incy)
+    elif float_t is float_complex:
+        blas_pointers.caxpy(&n, &a, x, &incx, y, &incy)
+    else:  # float_t is double_complex:
+        blas_pointers.zaxpy(&n, &a, x, &incx, y, &incy)
+
+cdef inline void larfg(int n, float_t* alpha, float_t* x, int incx,
+                       float_t* tau) nogil:
+    if float_t is float:
+        lapack_pointers.slarfg(&n, alpha, x, &incx, tau)
+    elif float_t is double:
+        lapack_pointers.dlarfg(&n, alpha, x, &incx, tau)
+    elif float_t is float_complex:
+        lapack_pointers.clarfg(&n, alpha, x, &incx, tau)
+    else:  # float_t is double_complex:
+        lapack_pointers.zlarfg(&n, alpha, x, &incx, tau)
+
+cdef inline void gemv(char* trans, int m, int n, float_t alpha, float_t* a,
+                      int lda, float_t* x, int incx, float_t beta, float_t* y,
+                      int incy) nogil:
+    if float_t is float:
+        blas_pointers.sgemv(trans, &m, &n, &alpha, a, &lda, x, &incx,
+                &beta, y, &incy)
+    elif float_t is double:
+        blas_pointers.dgemv(trans, &m, &n, &alpha, a, &lda, x, &incx,
+                &beta, y, &incy)
+    elif float_t is float_complex:
+        blas_pointers.cgemv(trans, &m, &n, &alpha, a, &lda, x, &incx,
+                &beta, y, &incy)
+    else:  # float_t is double_complex:
+        blas_pointers.zgemv(trans, &m, &n, &alpha, a, &lda, x, &incx,
+                &beta, y, &incy)
+
+cdef inline void copy(int n, float_t* x, int incx, float_t* y, int incy) nogil:
+    if float_t is float:
+        blas_pointers.scopy(&n, x, &incx, y, &incy)
+    elif float_t is double:
+        blas_pointers.dcopy(&n, x, &incx, y, &incy)
+    elif float_t is float_complex:
+        blas_pointers.ccopy(&n, x, &incx, y, &incy)
+    else:  # float_t is double_complex:
+        blas_pointers.zcopy(&n, x, &incx, y, &incy)
+
+cdef inline void ger(int m, int n, float_t alpha, float_t* x, int incx,
+                     float_t* y, int incy, float_t* a, int lda) nogil:
+    if float_t is float:
+        blas_pointers.sger(&m, &n, &alpha, x, &incx, y, &incy, a, &lda)
+    elif float_t is double:
+        blas_pointers.dger(&m, &n, &alpha, x, &incx, y, &incy, a, &lda)
+    elif float_t is float_complex:
+        blas_pointers.cgerc(&m, &n, &alpha, x, &incx, y, &incy, a, &lda)
+    else:
+        blas_pointers.zgerc(&m, &n, &alpha, x, &incx, y, &incy, a, &lda)
+
+cdef inline real_t nrm2(int n, real_t *x, int incx) nogil:
+    if real_t is float:
+        return blas_pointers.snrm2(&n, x, &incx)
+    else:
+        return blas_pointers.dnrm2(&n, x, &incx)
+
+#------------------------------------------------------------------------------
+# Negative larfg: generate a hausholder rotation with negative sign
+#------------------------------------------------------------------------------
+
+cdef inline real_t cathetus(real_t a, real_t b) nogil:
+    return sqrt((a - b) * (a + b));
+
+cdef void neg_larfg_real(int n, real_t *alpha, real_t *x, int incx,
+                         real_t *tau) nogil:
+    cdef real_t xnorm, beta
+
+    xnorm = nrm2(n - 1, x, incx)
+    beta = -copysign(cathetus(alpha[0], xnorm), alpha[0])
+    tau[0] = (beta - alpha[0]) / beta
+    scal(n - 1, 1 / (alpha[0] - beta), x, incx)
+    alpha[0] = beta
+
+cdef void neg_larfg_fc(int n, float_complex *alpha, float_complex *x, int incx,
+                       float_complex *tau) nogil:
+    cdef float xnorm, beta
+    cdef int nm1 = n - 1
+    xnorm = blas_pointers.scnrm2(&nm1, x, &incx)
+    beta = -copysign(cathetus(alpha[0].real, xnorm), alpha[0].real)
+    tau[0] = (beta - alpha[0].real) / beta + (-alpha[0].imag / beta) * I
+    scal(n - 1, 1 / (alpha[0] - beta), x, incx)
+    alpha[0] = beta
+
+cdef void neg_larfg_dc(int n, double_complex *alpha, double_complex *x,
+                       int incx, double_complex *tau) nogil:
+    cdef double xnorm, beta
+    cdef int nm1 = n - 1
+    xnorm = blas_pointers.dznrm2(&nm1, x, &incx)
+    beta = -copysign(cathetus(alpha[0].real, xnorm), alpha[0].real)
+    tau[0] = (beta - alpha[0].real) / beta + (-alpha[0].imag / beta) * I
+    scal(n - 1, 1 / (alpha[0] - beta), x, incx)
+    alpha[0] = beta
+
+cdef void neg_larfg(int n, float_t *alpha, float_t *x, int incx,
+                    float_t *tau) nogil:
+    if float_t is float or float_t is double:
+        neg_larfg_real(n, alpha, x, incx, tau)
+    elif float_t is float_complex:
+        neg_larfg_fc(n, alpha, x, incx, tau)
+    else:
+        neg_larfg_dc(n, alpha, x, incx, tau)
+
+#------------------------------------------------------------------------------
+# Cholesky update (rank-1 and rank-p)
+#------------------------------------------------------------------------------
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+@cython.nonecheck(False)
+@cython.cdivision(True)
+cdef int upd1_u(float_t *r, int *rs, float_t *z, int *zs, int n,
+                float_t eps, bint downdate) nogil:
+    cdef float_t alpha = 1.0
+    cdef float_t beta_prev = 1.0
+    cdef float_t sign = -1.0 if downdate else 1.0
+    cdef float_t a, beta
+    cdef int i
+
+    for i in range(n):
+        # a = z[i] / r[i, i]
+        a = index1(z, zs, i)[0] / index2(r, rs, i, i)[0]
+
+        alpha = alpha + sign * (a.conjugate() * a)
+        if float_t_less_than(alpha, eps):
+            return -(i + 1)
+        beta = float_t_sqrt(alpha)
+
+        if n - i - 1 > 0:
+            # z = -a * R + z
+            float_t_conj(n - i - 1, index1(z, zs, i+1), zs)
+            axpy(n=n - i - 1, a=-a.conjugate(), x=index2(r, rs, i, i + 1),
+                 incx=rs[1], y=index1(z, zs, i + 1), incy=zs[0])
+
+        scal(n - i, beta / beta_prev, index2(r, rs, i, i), rs[1])
+
+        if n - i - 1 > 0:
+            # R = -a/(beta*beta_m1) * z + R
+            axpy(n=n - i - 1, a=sign * a / (beta * beta_prev),
+                 x=index1(z, zs, i + 1), incx=zs[0],
+                 y=index2(r, rs, i, i + 1), incy=rs[1])
+            float_t_conj(n - i - 1, index1(z, zs, i+1), zs)
+        beta_prev = beta
+
+    return 0
+
+
+
+cdef int updp_u(float_t *r, int *rs, float_t *z, int *zs, float_t *w,
+                int n, int p, bint zisF, float_t eps, bint downdate) nogil:
+    """
+    r is n x n square matrix, upper triangular
+    z is n x p matrix, each column contains an update to r.
+    w is n vector, contains working memory.
+
+    https://www.cs.utexas.edu/users/flame/pubs/flawn41.pdf
+    """
+    cdef int i, j
+    cdef float_t tau
+    cdef char* T = 'T' if float_t is float or float_t is double else 'C'
+    cdef char* N = 'N'
+    cdef float_t sign = -1.0 if downdate else 1.0
+
+    if zisF and zs[1] == 1 and p == 1:
+        # doesn't matter as it's never actually used (since p == 1
+        # goes to upd1_u), but otherwise lda parameter to ger is wrong
+        zs[1] = n
+    elif not zisF and zs[0] == 1 and p == 1:
+        zs[0] = n
+
+    for i in range(n):
+        # Compute householder rotation. The rotation vector overwrites z[i, :],
+        # and the scalar beta overwrites r[i, i].
+        if downdate:
+            neg_larfg(p + 1, index2(r, rs, i, i), x=index2(z, zs, i, 0),
+                      incx=zs[1], tau=&tau)
+            if tau != tau:
+                return -(i + 1)
+        else:
+            larfg(p + 1, index2(r, rs, i, i), x=index2(z, zs, i, 0),
+                  incx=zs[1], tau=&tau)
+        if i >= n - 1:
+            break
+
+        # We call the working arrays for the current iteration (loosely following the paper)
+        # r12: r[i, i+1:]   n - i - 1
+        # c2: z[i+1:, :]    n - i - 1, p
+        # u: z[i, :]        p
+        # w:                n - i - 1
+
+        # 1. copy r12 into w
+        copy(n - i - 1, x=index2(r, rs, i, i+1), incx=rs[1], y=w, incy=1)
+        # 2. w = tau * C2 @ u + tau * w
+        if zisF:
+            # w = tau * conj(C2) @ u + tau * w
+            float_t_2d_conj(n - i - 1, p, index2(z, zs, i + 1, 0), zs)
+            gemv(N, m=n-i-1, n=p, alpha=sign * tau, a=index2(z, zs, i+1, 0),
+                 lda=zs[1], x=index2(z, zs, i, 0), incx=zs[1], beta=tau,
+                 y=w, incy=1)
+        else:
+            # w = tau * C2^H @ u + tau * w
+            gemv(T, m=p, n=n-i-1, alpha=sign * tau, a=index2(z, zs, i+1, 0),
+                 lda=zs[0], x=index2(z, zs, i, 0), incx=zs[1], beta=tau,
+                 y=w, incy=1)
+        # 3. C2 = C2 - w @ u^H
+        if zisF:
+            # conj(C2) = conj(C2) - w @ u^H
+            ger(m=n-i-1, n=p, alpha=-1.0, x=w, incx=1, y=index2(z, zs, i, 0),
+                incy=zs[1], a=index2(z, zs, i+1, 0), lda=zs[1])
+            float_t_2d_conj(n - i - 1, p, index2(z, zs, i + 1, 0), zs)
+        else:
+            # u @ w^H
+            ger(m=p, n=n-i-1, alpha=-1.0, x=index2(z, zs, i, 0), incx=zs[1],
+                y=w, incy=1, a=index2(z, zs, i+1, 0), lda=zs[0])
+        # 4. r12 = r12 - w
+        for j in range(n - i - 1):
+            index2(r, rs, i, i + 1 + j)[0] -= w[j]
+    return 0
+
+
+cdef validate_array(cnp.ndarray a, bint chkfinite):
+    # here we check that a has positive strides and that its size is small
+    # enough to fit in into an int, as BLAS/LAPACK require
+    cdef bint copy = False
+    cdef int j
+
+    for j in range(a.ndim):
+        if a.strides[j] <= 0:
+            copy = True
+        if (a.strides[j] / a.descr.itemsize) >= libc.limits.INT_MAX:
+            copy = True
+        if a.shape[j] >= libc.limits.INT_MAX:
+            raise ValueError('Input array too large for use with BLAS')
+
+    if chkfinite:
+        if not np.isfinite(a).all():
+            raise ValueError('array must not contain infs or NaNs')
+
+    if copy:
+        return PyArray_FromArray(a, NULL, cnp.NPY_F_CONTIGUOUS)
+    return a
+
+
+cdef tuple validate_inputs(object r0, object z0, bint overwrite_r,
+                           bint overwrite_z,  int order_r, int order_z,
+                           bint check_finite):
+    cdef cnp.ndarray r, z
+    cdef int typecode
+    cdef int p
+
+    order_r |= cnp.NPY_BEHAVED_NS | cnp.NPY_ELEMENTSTRIDES
+    order_z |= cnp.NPY_BEHAVED_NS | cnp.NPY_ELEMENTSTRIDES
+    if not overwrite_r:
+        order_r |= cnp.NPY_ENSURECOPY
+    if not overwrite_z:
+        order_z |= cnp.NPY_ENSURECOPY
+
+    # in the interests of giving better error messages take any number of
+    # dimensions here.
+    r = PyArray_CheckFromAny(r0, NULL, 0, 0, order_r, NULL)
+    z = PyArray_CheckFromAny(z0, NULL, 0, 0, order_z, NULL)
+
+    # Check shapes
+    if z.ndim == 0:
+        raise ValueError()
+
+    if r.ndim != 2:
+        raise ValueError()
+    if r.shape[0] != r.shape[1]:
+        raise ValueError()
+    if r.shape[0] != z.shape[0]:
+        raise ValueError()
+
+    if z.ndim == 1:
+        p = 1
+    elif z.ndim == 2:
+        p = z.shape[1]
+    else:
+        raise ValueError()
+
+    # Check dtypes
+    typecode = cnp.PyArray_TYPE(r)
+    if typecode != cnp.PyArray_TYPE(z):
+        raise ValueError('R and z must have the same dtype')
+
+    if not (typecode == cnp.NPY_FLOAT or typecode == cnp.NPY_DOUBLE
+            or typecode == cnp.NPY_CFLOAT or typecode == cnp.NPY_CDOUBLE):
+        raise ValueError('Only arrays with dtypes float32, float64, '
+                         'complex64, and complex128 are supported.')
+
+    r = validate_array(r, check_finite)
+    z = validate_array(z, check_finite)
+
+    return r, z, typecode, r.shape[0], p
+
+
+cdef void* extract(cnp.ndarray arr, int* arrs):
+    with cython.cdivision(True):    # Assumes itemsize != 0.
+        if arr.ndim == 2:
+            arrs[0] = arr.strides[0] / cnp.PyArray_ITEMSIZE(arr)
+            arrs[1] = arr.strides[1] / cnp.PyArray_ITEMSIZE(arr)
+        elif arr.ndim == 1:
+            arrs[0] = arr.strides[0] / cnp.PyArray_ITEMSIZE(arr)
+            arrs[1] = 0
+    return cnp.PyArray_DATA(arr)
+
+
+@cython.embedsignature(True)
+def cholesky_update(R, z, downdate=False, lower=False, overwrite_rz=False,
+                    check_finite=True):
+    """
+    Rank-P Cholesky decomposition update
+
+    Given the Cholesky factorization of ``A`` as ``A = LL^*`` or ``A = U^* U``,
+    returns the updated factorization of ``A + zz^*`` or ``A - zz^*``.
+
+    Parameters:
+    -----------
+    R : (N, N) array_like
+        Triangular matrix from the Cholesky decomposition of `A`.
+    z : (N,) or (N, P) array_like
+        Update vector(s)
+    downdate : bool, optional
+        Whether the rank-p update is to be added or subtracted from `A`.
+    lower : bool, optional
+        Whether `R` is a lower- or upper-triangular matrix.
+    overwrite_rz : bool, optional
+        Whether to overwrite data in `R` and `z`. If True, `R` will contain the
+        updated factorization.
+    check_finite : bool, optional
+        Whether to check that the input matrix contains only finite numbers.
+        Disabling may give a performance gain, but may result in problems
+        (crashes, non-termination) if the inputs do contain infinities or NaNs.
+
+    Returns:
+    --------
+    R1 : ndarray
+        Updated Cholesky decomposition. Will have the same triangular pattern
+        as `R`.
+
+    See Also
+    --------
+    cholesky : Cholesky factorization
+
+    Notes
+    -----
+
+    .. versionadded:: X.Y.Z
+
+    References
+    ----------
+    .. [1] Van de Geijn, R. A., Van Zee, F. G. High-Performance
+           Up-and-Downdating via Householder-like Transformations.
+           ACM Trans. Math. Softw. 38, 1-17 (2011).
+    .. [2] Pan, C. T. A modification to the linpack downdating algorithm. BIT
+           Numerical Mathematics 30, 707-722 (1990).
+
+    Raises
+    ------
+    LinAlgError : if the downdate results in a non-positive definite matrix.
+    """
+    cdef cnp.ndarray r1, z1
+    cdef int typecode, n, p
+    cdef bint chkfinite = check_finite, overwrite = overwrite_rz
+    cdef bint is_upper = not lower, do_downdate = downdate
+
+    cdef void* rptr
+    cdef void* zptr
+    cdef int rstrides[2]
+    cdef int zstrides[2]
+
+    r1, z1, typecode, n, p = validate_inputs(R, z, overwrite, overwrite,
+        ARRAY_ANYORDER, ARRAY_ANYORDER, chkfinite)
+
+    cdef float eps_f = n * libc.float.FLT_EPSILON
+    cdef double eps_d = n * libc.float.DBL_EPSILON
+    cdef float_complex eps_cf = eps_f
+    cdef float_complex eps_cd = eps_d
+
+    rptr = extract(r1, rstrides)
+    cdef int ws
+    if not is_upper:
+        # Only upper is implemented. So for lower triangular inputs
+        # we must transpose (just switch the memory layout since the
+        # matrix is square).
+        ws = rstrides[0]
+        rstrides[0] = rstrides[1]
+        rstrides[1] = ws
+
+    cdef int info = 0
+    cdef bint z_is_f
+    cdef cnp.ndarray w0
+    cdef void* wptr
+    cdef cnp.npy_intp wlength = n
+    if p == 1:  # z1 is 1D or column-vector
+        zptr = extract(z1, zstrides)
+        with nogil:
+            if typecode == cnp.NPY_FLOAT:
+                info = upd1_u(<float*>rptr, rstrides, <float*>zptr, zstrides,
+                              n, eps_f, do_downdate)
+            elif typecode == cnp.NPY_DOUBLE:
+                info = upd1_u(<double*>rptr, rstrides, <double*>zptr, zstrides,
+                              n, eps_d, do_downdate)
+            elif typecode == cnp.NPY_CFLOAT:
+                # TODO: Maybe only conj the triangle we're interested in?
+                if not is_upper:
+                    float_t_2d_conj(n, n, <float_complex*>rptr, rstrides)
+                info = upd1_u(<float_complex*>rptr, rstrides,
+                              <float_complex*>zptr, zstrides, n, eps_cf,
+                              do_downdate)
+                if not is_upper:
+                    float_t_2d_conj(n, n, <float_complex*>rptr, rstrides)
+            else:
+                if not is_upper:
+                    float_t_2d_conj(n, n, <double_complex*>rptr, rstrides)
+                info = upd1_u(<double_complex*>rptr, rstrides,
+                              <double_complex*>zptr, zstrides, n, eps_cd,
+                              do_downdate)
+                if not is_upper:
+                    float_t_2d_conj(n, n, <double_complex*>rptr, rstrides)
+    else:
+        # Copy z if it's not contiguous
+        if not cnp.PyArray_ISONESEGMENT(z1):
+            z1 = PyArray_FromArray(z1, NULL, cnp.NPY_F_CONTIGUOUS)
+        z_is_f = cnp.PyArray_IS_F_CONTIGUOUS(z1)
+        zptr = extract(z1, zstrides)
+        # Create work array (length n)
+        w0 = cnp.PyArray_EMPTY(1, &wlength, typecode, 1)
+        wptr = cnp.PyArray_DATA(w0)
+        with nogil:
+            if typecode == cnp.NPY_FLOAT:
+                info = updp_u(<float*>rptr, rstrides, <float*>zptr, zstrides,
+                              <float*>wptr, n, p, z_is_f, eps_f, do_downdate)
+            elif typecode == cnp.NPY_DOUBLE:
+                info = updp_u(<double*>rptr, rstrides, <double*>zptr, zstrides,
+                              <double*>wptr, n, p, z_is_f, eps_f, do_downdate)
+            elif typecode == cnp.NPY_CFLOAT:
+                if not is_upper:
+                    float_t_2d_conj(n, n, <float_complex*>rptr, rstrides)
+                info = updp_u(<float_complex*>rptr, rstrides,
+                              <float_complex*>zptr, zstrides,
+                              <float_complex*>wptr, n, p, z_is_f, eps_f,
+                              do_downdate)
+                if not is_upper:
+                    float_t_2d_conj(n, n, <float_complex*>rptr, rstrides)
+            else:
+                if not is_upper:
+                    float_t_2d_conj(n, n, <double_complex*>rptr, rstrides)
+                info = updp_u(<double_complex*>rptr, rstrides,
+                              <double_complex*>zptr, zstrides,
+                              <double_complex*>wptr, n, p, z_is_f, eps_f,
+                              do_downdate)
+                if not is_upper:
+                    float_t_2d_conj(n, n, <double_complex*>rptr, rstrides)
+    if info != 0:
+        raise np.linalg.LinAlgError(
+            "Update causes %d-th leading minor of the "
+            "array to not be positive definite." % (-info))
+    return r1
+
+cnp.import_array()

--- a/scipy/linalg/_cholesky_update.pyx
+++ b/scipy/linalg/_cholesky_update.pyx
@@ -456,10 +456,10 @@ cdef void* extract(cnp.ndarray arr, int* arrs):
 def cholesky_update(R, z, downdate=False, lower=False, overwrite_rz=False,
                     check_finite=True):
     """
-    Rank-P Cholesky decomposition update
+    Rank-P Cholesky decomposition update.
 
-    Given the Cholesky factorization of ``A`` as ``A = LL^*`` or ``A = U^* U``,
-    returns the updated factorization of ``A + zz^*`` or ``A - zz^*``.
+    Given the Cholesky factorization :math:`A=LL^*` or :math:`A=U^*U`,
+    returns the updated factorization of :math:`A + zz^*` or :math:`A - zz^*`.
 
     Parameters
     ----------
@@ -481,7 +481,7 @@ def cholesky_update(R, z, downdate=False, lower=False, overwrite_rz=False,
 
     Returns
     -------
-    R1 : ndarray
+    R1 : (N, N) ndarray
         Updated Cholesky decomposition. Will have the same triangular pattern
         as `R`.
 

--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -247,6 +247,15 @@ py3.extension_module('_decomp_update',
   subdir: 'scipy/linalg'
 )
 
+py3.extension_module('_cholesky_update',
+  linalg_cython_gen.process('_cholesky_update.pyx'),
+  c_args: cython_c_args,
+  include_directories: inc_np,
+  dependencies: py3_dep,
+  install: true,
+  subdir: 'scipy/linalg'
+)
+
 # _matfuncs_expm:
 _matfuncs_expm_pyx = custom_target('_matfuncs_expm',
   output: '_matfuncs_expm.pyx',

--- a/scipy/linalg/setup.py
+++ b/scipy/linalg/setup.py
@@ -146,6 +146,9 @@ def configuration(parent_package='', top_path=None):
     config.add_extension('_decomp_update',
                          sources=['_decomp_update.c'])
 
+    config.add_extension('_cholesky_update',
+                         sources=['_cholesky_update.c'])
+
     config.add_data_files('_cythonized_array_utils.pxd')
 
     config.add_extension('_cythonized_array_utils',

--- a/scipy/linalg/tests/meson.build
+++ b/scipy/linalg/tests/meson.build
@@ -11,6 +11,7 @@ python_sources = [
   'test_decomp_ldl.py',
   'test_decomp_polar.py',
   'test_decomp_update.py',
+  'test_cholesky_update.py',
   'test_fblas.py',
   'test_interpolative.py',
   'test_lapack.py',

--- a/scipy/linalg/tests/test_cholesky_update.py
+++ b/scipy/linalg/tests/test_cholesky_update.py
@@ -106,8 +106,8 @@ def make_nonnative(arrs):
 
 class BaseCholdeltas:
     def setup_method(self):
-        self.rtol = 10.0 ** -(np.finfo(self.dtype).precision)
-        self.atol = 1 * np.finfo(self.dtype).eps
+        self.rtol = 10.0 ** -(np.finfo(self.dtype).precision - 2)
+        self.atol = 5 * np.finfo(self.dtype).eps
 
     def generate(self, type, which='1d'):
         np.random.seed(12)

--- a/scipy/linalg/tests/test_cholesky_update.py
+++ b/scipy/linalg/tests/test_cholesky_update.py
@@ -143,11 +143,11 @@ class BaseCholdeltas:
 def get_updated(a, u, downdate):
     if downdate:
         if u.ndim > 1:
-            return a - u @ u.T.conjugate()
+            return a - np.dot(u, u.T.conjugate())
         return a - np.outer(u, u.conj())
     else:
         if u.ndim > 1:
-            return a + u @ u.T.conjugate()
+            return a + np.dot(u, u.T.conjugate())
         return a + np.outer(u, u.conj())
 
 

--- a/scipy/linalg/tests/test_cholesky_update.py
+++ b/scipy/linalg/tests/test_cholesky_update.py
@@ -42,7 +42,8 @@ def check_cholesky(a, r, lower, rtol, atol):
         assert_upper_tri(r, rtol=rtol, atol=atol)
         a1 = np.dot(r.T.conj(), r)
     assert_allclose(a1, a, rtol=rtol, atol=atol)
-    assert_allclose(scipy.linalg.cholesky(a, lower=lower), r, rtol=rtol, atol=atol)
+    assert_allclose(scipy.linalg.cholesky(a, lower=lower), r,
+                    rtol=rtol, atol=atol)
 
 
 def make_strided(arrs):
@@ -119,7 +120,7 @@ class BaseCholdeltas:
 
         # Make symmetric and PD
         a = a + a.T.conj() + a.shape[0] * np.eye(a.shape[0], dtype=self.dtype)
-        l = scipy.linalg.cholesky(a, lower=True)
+        lo = scipy.linalg.cholesky(a, lower=True)
         r = scipy.linalg.cholesky(a, lower=False)
 
         # Generate the update vector
@@ -136,7 +137,7 @@ class BaseCholdeltas:
             b = np.random.random(u.shape)
             u = u + 1j * b
         u = u.astype(self.dtype)
-        return a, u, l, r
+        return a, u, lo, r
 
 
 def get_updated(a, u, downdate):
@@ -151,10 +152,10 @@ def get_updated(a, u, downdate):
 
 
 class BaseCholUpdate(BaseCholdeltas):
-    def base_update1_test(self, a, u, l, r, lower: bool, downdate: bool):
+    def base_update1_test(self, a, u, lo, r, lower: bool, downdate: bool):
         a1 = get_updated(a, u, downdate)
         if lower:
-            d = cholesky_update(l, u, downdate=downdate, lower=True,
+            d = cholesky_update(lo, u, downdate=downdate, lower=True,
                                 overwrite_rz=False)
         else:
             d = cholesky_update(r, u, downdate=downdate, lower=False,
@@ -163,7 +164,7 @@ class BaseCholUpdate(BaseCholdeltas):
 
         # Check with the same matrix passed to fn to ensure no overwrite
         if lower:
-            a2 = np.dot(l, l.T.conj())
+            a2 = np.dot(lo, lo.T.conj())
         else:
             a2 = np.dot(r.T.conj(), r)
         a2 = get_updated(a2, u, downdate)
@@ -171,98 +172,98 @@ class BaseCholUpdate(BaseCholdeltas):
 
     def test_u1_l_dd_sqr(self):
         for which in ['1d', 'col']:
-            a, u, l, r = self.generate('sqr', which=which)
-            self.base_update1_test(a, u, l, r, lower=True, downdate=True)
+            a, u, lo, r = self.generate('sqr', which=which)
+            self.base_update1_test(a, u, lo, r, lower=True, downdate=True)
 
     def test_u1_l_dd_1x1(self):
         for which in ['1d', 'col']:
-            a, u, l, r = self.generate('1x1', which=which)
-            self.base_update1_test(a, u, l, r, lower=True, downdate=True)
+            a, u, lo, r = self.generate('1x1', which=which)
+            self.base_update1_test(a, u, lo, r, lower=True, downdate=True)
 
     def test_u1_u_dd_sqr(self):
         for which in ['1d', 'col']:
-            a, u, l, r = self.generate('sqr', which=which)
-            self.base_update1_test(a, u, l, r, lower=False, downdate=True)
+            a, u, lo, r = self.generate('sqr', which=which)
+            self.base_update1_test(a, u, lo, r, lower=False, downdate=True)
 
     def test_u1_u_dd_1x1(self):
         for which in ['1d', 'col']:
-            a, u, l, r = self.generate('1x1', which=which)
-            self.base_update1_test(a, u, l, r, lower=False, downdate=True)
+            a, u, lo, r = self.generate('1x1', which=which)
+            self.base_update1_test(a, u, lo, r, lower=False, downdate=True)
 
     def test_u1_l_ud_sqr(self):
         for which in ['1d', 'col']:
-            a, u, l, r = self.generate('sqr', which=which)
-            self.base_update1_test(a, u, l, r, lower=True, downdate=False)
+            a, u, lo, r = self.generate('sqr', which=which)
+            self.base_update1_test(a, u, lo, r, lower=True, downdate=False)
 
     def test_u1_l_ud_1x1(self):
         for which in ['1d', 'col']:
-            a, u, l, r = self.generate('1x1', which=which)
-            self.base_update1_test(a, u, l, r, lower=True, downdate=False)
+            a, u, lo, r = self.generate('1x1', which=which)
+            self.base_update1_test(a, u, lo, r, lower=True, downdate=False)
 
     def test_u1_u_ud_sqr(self):
         for which in ['1d', 'col']:
-            a, u, l, r = self.generate('sqr', which=which)
-            self.base_update1_test(a, u, l, r, lower=False, downdate=False)
+            a, u, lo, r = self.generate('sqr', which=which)
+            self.base_update1_test(a, u, lo, r, lower=False, downdate=False)
 
     def test_u1_u_ud_1x1(self):
         for which in ['1d', 'col']:
-            a, u, l, r = self.generate('1x1', which=which)
-            self.base_update1_test(a, u, l, r, lower=True, downdate=False)
+            a, u, lo, r = self.generate('1x1', which=which)
+            self.base_update1_test(a, u, lo, r, lower=True, downdate=False)
 
     def test_up_l_dd_sqr(self):
         for which in ['p']:
-            a, u, l, r = self.generate('sqr', which=which)
-            self.base_update1_test(a, u, l, r, lower=True, downdate=True)
+            a, u, lo, r = self.generate('sqr', which=which)
+            self.base_update1_test(a, u, lo, r, lower=True, downdate=True)
 
     def test_up_l_dd_1x1(self):
         for which in ['p']:
-            a, u, l, r = self.generate('1x1', which=which)
-            self.base_update1_test(a, u, l, r, lower=True, downdate=True)
+            a, u, lo, r = self.generate('1x1', which=which)
+            self.base_update1_test(a, u, lo, r, lower=True, downdate=True)
 
     def test_up_u_dd_sqr(self):
         for which in ['p']:
-            a, u, l, r = self.generate('sqr', which=which)
-            self.base_update1_test(a, u, l, r, lower=False, downdate=True)
+            a, u, lo, r = self.generate('sqr', which=which)
+            self.base_update1_test(a, u, lo, r, lower=False, downdate=True)
 
     def test_up_u_dd_1x1(self):
         for which in ['p']:
-            a, u, l, r = self.generate('1x1', which=which)
-            self.base_update1_test(a, u, l, r, lower=False, downdate=True)
+            a, u, lo, r = self.generate('1x1', which=which)
+            self.base_update1_test(a, u, lo, r, lower=False, downdate=True)
 
     def test_up_l_ud_sqr(self):
         for which in ['p']:
-            a, u, l, r = self.generate('sqr', which=which)
-            self.base_update1_test(a, u, l, r, lower=True, downdate=False)
+            a, u, lo, r = self.generate('sqr', which=which)
+            self.base_update1_test(a, u, lo, r, lower=True, downdate=False)
 
     def test_up_l_ud_1x1(self):
         for which in ['p']:
-            a, u, l, r = self.generate('1x1', which=which)
-            self.base_update1_test(a, u, l, r, lower=True, downdate=False)
+            a, u, lo, r = self.generate('1x1', which=which)
+            self.base_update1_test(a, u, lo, r, lower=True, downdate=False)
 
     def test_up_u_ud_sqr(self):
         for which in ['p']:
-            a, u, l, r = self.generate('sqr', which=which)
-            self.base_update1_test(a, u, l, r, lower=False, downdate=False)
+            a, u, lo, r = self.generate('sqr', which=which)
+            self.base_update1_test(a, u, lo, r, lower=False, downdate=False)
 
     def test_up_u_ud_1x1(self):
         for which in ['p']:
-            a, u, l, r = self.generate('1x1', which=which)
-            self.base_update1_test(a, u, l, r, lower=False, downdate=False)
+            a, u, lo, r = self.generate('1x1', which=which)
+            self.base_update1_test(a, u, lo, r, lower=False, downdate=False)
 
     def test_list_input(self):
-        a, u, l, r = self.generate('sqr', '1d')
+        a, u, lo, r = self.generate('sqr', '1d')
 
-        d = cholesky_update(l, list(u), downdate=False, lower=True,
+        d = cholesky_update(lo, list(u), downdate=False, lower=True,
                             overwrite_rz=False)
         check_cholesky(get_updated(a, u, downdate=False), d, lower=True,
                        rtol=self.rtol, atol=self.atol)
 
-        d = cholesky_update(list(l), u, downdate=False, lower=True,
+        d = cholesky_update(list(lo), u, downdate=False, lower=True,
                             overwrite_rz=False)
         check_cholesky(get_updated(a, u, downdate=False), d, lower=True,
                        rtol=self.rtol, atol=self.atol)
 
-        d = cholesky_update(list(l), list(u), downdate=False, lower=True,
+        d = cholesky_update(list(lo), list(u), downdate=False, lower=True,
                             overwrite_rz=False)
         check_cholesky(get_updated(a, u, downdate=False), d, lower=True,
                        rtol=self.rtol, atol=self.atol)
@@ -270,12 +271,12 @@ class BaseCholUpdate(BaseCholdeltas):
     def test_check_nan(self):
         a, u0, l0, r = self.generate('sqr', '1d')
 
-        l = l0.copy('F')
-        l[1, 1] = np.nan
-        assert_raises(ValueError, cholesky_update, l, u0, False, False)
-        assert_raises(ValueError, cholesky_update, l, u0, False, True)
-        assert_raises(ValueError, cholesky_update, l, u0, True, False)
-        assert_raises(ValueError, cholesky_update, l, u0, True, True)
+        lo = l0.copy('F')
+        lo[1, 1] = np.nan
+        assert_raises(ValueError, cholesky_update, lo, u0, False, False)
+        assert_raises(ValueError, cholesky_update, lo, u0, False, True)
+        assert_raises(ValueError, cholesky_update, lo, u0, True, False)
+        assert_raises(ValueError, cholesky_update, lo, u0, True, True)
 
         u = u0.copy('F')
         u[1] = np.nan
@@ -287,12 +288,12 @@ class BaseCholUpdate(BaseCholdeltas):
     def test_check_nan_p(self):
         a, u0, l0, r = self.generate('sqr', 'p')
 
-        l = l0.copy('F')
-        l[1, 1] = np.nan
-        assert_raises(ValueError, cholesky_update, l, u0, False, False)
-        assert_raises(ValueError, cholesky_update, l, u0, False, True)
-        assert_raises(ValueError, cholesky_update, l, u0, True, False)
-        assert_raises(ValueError, cholesky_update, l, u0, True, True)
+        lo = l0.copy('F')
+        lo[1, 1] = np.nan
+        assert_raises(ValueError, cholesky_update, lo, u0, False, False)
+        assert_raises(ValueError, cholesky_update, lo, u0, False, True)
+        assert_raises(ValueError, cholesky_update, lo, u0, True, False)
+        assert_raises(ValueError, cholesky_update, lo, u0, True, True)
 
         u = u0.copy('F')
         u[0, 0] = np.nan
@@ -304,12 +305,12 @@ class BaseCholUpdate(BaseCholdeltas):
     def test_check_finite(self):
         a, u0, l0, r = self.generate('sqr', '1d')
 
-        l = l0.copy('F')
-        l[1, 1] = np.inf
-        assert_raises(ValueError, cholesky_update, l, u0, False, False)
-        assert_raises(ValueError, cholesky_update, l, u0, False, True)
-        assert_raises(ValueError, cholesky_update, l, u0, True, False)
-        assert_raises(ValueError, cholesky_update, l, u0, True, True)
+        lo = l0.copy('F')
+        lo[1, 1] = np.inf
+        assert_raises(ValueError, cholesky_update, lo, u0, False, False)
+        assert_raises(ValueError, cholesky_update, lo, u0, False, True)
+        assert_raises(ValueError, cholesky_update, lo, u0, True, False)
+        assert_raises(ValueError, cholesky_update, lo, u0, True, True)
 
         u = u0.copy('F')
         u[1] = np.inf
@@ -321,12 +322,12 @@ class BaseCholUpdate(BaseCholdeltas):
     def test_check_finite_p(self):
         a, u0, l0, r = self.generate('sqr', 'p')
 
-        l = l0.copy('F')
-        l[1, 1] = np.inf
-        assert_raises(ValueError, cholesky_update, l, u0, False, False)
-        assert_raises(ValueError, cholesky_update, l, u0, False, True)
-        assert_raises(ValueError, cholesky_update, l, u0, True, False)
-        assert_raises(ValueError, cholesky_update, l, u0, True, True)
+        lo = l0.copy('F')
+        lo[1, 1] = np.inf
+        assert_raises(ValueError, cholesky_update, lo, u0, False, False)
+        assert_raises(ValueError, cholesky_update, lo, u0, False, True)
+        assert_raises(ValueError, cholesky_update, lo, u0, True, False)
+        assert_raises(ValueError, cholesky_update, lo, u0, True, True)
 
         u = u0.copy('F')
         u[1, 0] = np.inf
@@ -343,11 +344,11 @@ class BaseCholUpdate(BaseCholdeltas):
             a1 = get_updated(a, u0, downdate=False)
 
             # if overwriteable is True
-            # For l and u we try first with overwrite=False, then with
+            # For lo and u we try first with overwrite=False, then with
             # overwrite=True and make sure that overwriting occurred
             # appropriately.
             u = u0.copy('F')
-            l = l0.copy('F')
+            lo = l0.copy('F')
             d1 = cholesky_update(ls, u, False, lower=True, overwrite_rz=False)
             check_cholesky(a1, d1, lower=True, rtol=self.rtol, atol=self.atol)
             d1o = cholesky_update(ls, u, False, lower=True, overwrite_rz=True)
@@ -363,13 +364,13 @@ class BaseCholUpdate(BaseCholdeltas):
                               self.rtol, self.atol)
 
             u = u0.copy('F')
-            l = l0.copy('F')
-            d2 = cholesky_update(l, us, False, lower=True, overwrite_rz=False)
+            lo = l0.copy('F')
+            d2 = cholesky_update(lo, us, False, lower=True, overwrite_rz=False)
             check_cholesky(a1, d2, lower=True, rtol=self.rtol, atol=self.atol)
-            d2o = cholesky_update(l, us, False, lower=True, overwrite_rz=True)
+            d2o = cholesky_update(lo, us, False, lower=True, overwrite_rz=True)
             check_cholesky(a1, d2o, lower=True, rtol=self.rtol, atol=self.atol)
             if r_overwriteable:
-                assert_allclose(d2o, l, rtol=self.rtol, atol=self.atol)
+                assert_allclose(d2o, lo, rtol=self.rtol, atol=self.atol)
             elif type != '1x1':
                 assert_raises(AssertionError, assert_allclose, d2o, ls,
                               rtol=self.rtol, atol=self.atol)
@@ -380,9 +381,9 @@ class BaseCholUpdate(BaseCholdeltas):
             # Now with both strided (need to be recreated since they were
             # overwritten above)
             u = u0.copy('F')
-            l = l0.copy('F')
+            lo = l0.copy('F')
             # since some of these were consumed above
-            us, ls = adjust_strides((u, l))
+            us, ls = adjust_strides((u, lo))
             d3 = cholesky_update(ls, us, False, lower=True, overwrite_rz=False)
             check_cholesky(a1, d3, lower=True, rtol=self.rtol, atol=self.atol)
             d3o = cholesky_update(ls, us, False, lower=True, overwrite_rz=True)
@@ -504,12 +505,12 @@ class BaseCholUpdate(BaseCholdeltas):
 
     """ Test edge cases which should error out """
     def test_empty_l(self):
-        a, u, l, r = self.generate('sqr', which='col')
+        a, u, lo, r = self.generate('sqr', which='col')
         assert_raises(ValueError, cholesky_update, np.array([]), u)
 
     def test_empty_u(self):
-        a, u, l, r = self.generate('sqr', which='col')
-        assert_raises(ValueError, cholesky_update, l, np.array([]))
+        a, u, lo, r = self.generate('sqr', which='col')
+        assert_raises(ValueError, cholesky_update, lo, np.array([]))
 
     def test_unsupported_dtypes(self):
         dts = ['int8', 'int16', 'int32', 'int64',
@@ -518,12 +519,12 @@ class BaseCholUpdate(BaseCholdeltas):
                'bool']
         a, u0, l0, r = self.generate('sqr', which='col')
         for dtype in dts:
-            l = l0.real.astype(dtype)
+            lo = l0.real.astype(dtype)
             u = u0.real.astype(dtype)
-            assert_raises(ValueError, cholesky_update, l, u0)
-            assert_raises(ValueError, cholesky_update, l, u0)
-            assert_raises(ValueError, cholesky_update, l, u0)
-            assert_raises(ValueError, cholesky_update, l, u0)
+            assert_raises(ValueError, cholesky_update, lo, u0)
+            assert_raises(ValueError, cholesky_update, lo, u0)
+            assert_raises(ValueError, cholesky_update, lo, u0)
+            assert_raises(ValueError, cholesky_update, lo, u0)
 
             assert_raises(ValueError, cholesky_update, l0, u)
             assert_raises(ValueError, cholesky_update, l0, u)
@@ -536,24 +537,24 @@ class BaseCholUpdate(BaseCholdeltas):
         assert_raises(ValueError, cholesky_update, l0, u0[0, 0])
 
     def test_mismatched_shapes(self):
-        a, u, l, r = self.generate('sqr', which='col')
+        a, u, lo, r = self.generate('sqr', which='col')
         a0, u0, l0, r0 = self.generate('1x1', which='col')
 
-        assert_raises(ValueError, cholesky_update, l, u0)
+        assert_raises(ValueError, cholesky_update, lo, u0)
         assert_raises(ValueError, cholesky_update, l0, u)
 
     def test_l_nonsquare(self):
         a, u, l0, r = self.generate('sqr', which='col')
-        l = np.concatenate((l0, l0[0, None]), axis=0)
-        assert_raises(ValueError, cholesky_update, l, u)
+        lo = np.concatenate((l0, l0[0, None]), axis=0)
+        assert_raises(ValueError, cholesky_update, lo, u)
 
-        l = np.concatenate((l0, l0[:, 0][:, None]), axis=1)
-        assert_raises(ValueError, cholesky_update, l, u)
+        lo = np.concatenate((l0, l0[:, 0][:, None]), axis=1)
+        assert_raises(ValueError, cholesky_update, lo, u)
 
     def test_3d_inputs(self):
         a, u0, l0, r = self.generate('sqr', which='col')
-        l = l0[..., None]
-        assert_raises(ValueError, cholesky_update, l, u0)
+        lo = l0[..., None]
+        assert_raises(ValueError, cholesky_update, lo, u0)
         u = u0[..., None]
         assert_raises(ValueError, cholesky_update, l0, u)
 

--- a/scipy/linalg/tests/test_cholesky_update.py
+++ b/scipy/linalg/tests/test_cholesky_update.py
@@ -42,6 +42,7 @@ def check_cholesky(a, r, lower, rtol, atol):
         assert_upper_tri(r, rtol=rtol, atol=atol)
         a1 = np.dot(r.T.conj(), r)
     assert_allclose(a1, a, rtol=rtol, atol=atol)
+    assert_allclose(scipy.linalg.cholesky(a, lower=lower), r, rtol=rtol, atol=atol)
 
 
 def make_strided(arrs):

--- a/scipy/linalg/tests/test_cholesky_update.py
+++ b/scipy/linalg/tests/test_cholesky_update.py
@@ -1,0 +1,604 @@
+import itertools
+
+import numpy as np
+from numpy.testing import assert_allclose
+from pytest import raises as assert_raises
+import scipy.linalg
+from scipy.linalg._cholesky_update import cholesky_update
+
+
+def assert_upper_tri(a, rtol=None, atol=None):
+    if rtol is None:
+        rtol = 10.0 ** -(np.finfo(a.dtype).precision-2)
+    if atol is None:
+        atol = 2*np.finfo(a.dtype).eps
+    mask = np.tri(a.shape[0], a.shape[1], -1, np.bool_)
+    assert_allclose(a[mask], 0.0, rtol=rtol, atol=atol)
+
+
+def assert_lower_tri(a, rtol=None, atol=None):
+    if rtol is None:
+        rtol = 10.0 ** -(np.finfo(a.dtype).precision-2)
+    if atol is None:
+        atol = 2*np.finfo(a.dtype).eps
+    mask = np.triu(np.ones((a.shape[0], a.shape[1]), dtype=np.bool_), 1)
+    assert_allclose(a[mask], 0.0, rtol=rtol, atol=atol)
+
+
+def assert_allclose_tri(exp, act, lower, rtol, atol):
+    if lower:
+        assert_allclose(np.tril(exp, -1), np.tril(act, -1),
+                        rtol=rtol, atol=atol)
+    else:
+        assert_allclose(np.triu(exp, 1), np.triu(act, 1),
+                        rtol=rtol, atol=atol)
+
+
+def check_cholesky(a, r, lower, rtol, atol):
+    if lower:
+        assert_lower_tri(r, rtol=rtol, atol=atol)
+        a1 = np.dot(r, r.T.conj())
+    else:
+        assert_upper_tri(r, rtol=rtol, atol=atol)
+        a1 = np.dot(r.T.conj(), r)
+    assert_allclose(a1, a, rtol=rtol, atol=atol)
+
+
+def make_strided(arrs):
+    strides = [(3, 7), (2, 2), (3, 4), (4, 2), (5, 4), (2, 3), (2, 1), (4, 5)]
+    kmax = len(strides)
+    k = 0
+    ret = []
+    for a in arrs:
+        if a.ndim == 1:
+            s = strides[k % kmax]
+            k += 1
+            base = np.zeros(s[0]*a.shape[0]+s[1], a.dtype)
+            view = base[s[1]::s[0]]
+            view[...] = a
+        elif a.ndim == 2:
+            s = strides[k % kmax]
+            t = strides[(k+1) % kmax]
+            k += 2
+            base = np.zeros((s[0]*a.shape[0]+s[1], t[0]*a.shape[1]+t[1]),
+                            a.dtype)
+            view = base[s[1]::s[0], t[1]::t[0]]
+            view[...] = a
+        else:
+            raise ValueError('make_strided only works for ndim = 1 or'
+                             ' 2 arrays')
+        ret.append(view)
+    return ret
+
+
+def negate_strides(arrs):
+    ret = []
+    for a in arrs:
+        b = np.zeros_like(a)
+        if b.ndim == 2:
+            b = b[::-1, ::-1]
+        elif b.ndim == 1:
+            b = b[::-1]
+        else:
+            raise ValueError('negate_strides only works for ndim = 1 or'
+                             ' 2 arrays')
+        b[...] = a
+        ret.append(b)
+    return ret
+
+
+def nonitemsize_strides(arrs):
+    out = []
+    for a in arrs:
+        a_dtype = a.dtype
+        b = np.zeros(a.shape, [('a', a_dtype), ('junk', 'S1')])
+        c = b.getfield(a_dtype)
+        c[...] = a
+        out.append(c)
+    return out
+
+
+def make_nonnative(arrs):
+    return [a.astype(a.dtype.newbyteorder()) for a in arrs]
+
+
+class BaseCholdeltas:
+    def setup_method(self):
+        self.rtol = 10.0 ** -(np.finfo(self.dtype).precision)
+        self.atol = 1 * np.finfo(self.dtype).eps
+
+    def generate(self, type, which='1d'):
+        np.random.seed(12)
+        shape = {'sqr': (3, 3), '1x1': (1, 1)}[type]
+        a = np.random.random(shape)
+        if np.iscomplexobj(self.dtype.type(1)):
+            b = np.random.random(shape)
+            a = a + 1j * b
+        a = a.astype(self.dtype)
+
+        # Make symmetric and PD
+        a = a + a.T.conj() + a.shape[0] * np.eye(a.shape[0], dtype=self.dtype)
+        l = scipy.linalg.cholesky(a, lower=True)
+        r = scipy.linalg.cholesky(a, lower=False)
+
+        # Generate the update vector
+        if which == '1d':
+            u = np.random.random(a.shape[0])
+        elif which == 'col':
+            u = np.random.random((a.shape[0], 1))
+        elif which == 'p':
+            # u = np.random.random((2, a.shape[0]))
+            u = np.random.random((a.shape[0], 2))
+        else:
+            raise ValueError('which should be either "1d" or "col" or "p"')
+        if np.iscomplexobj(self.dtype.type(1)):
+            b = np.random.random(u.shape)
+            u = u + 1j * b
+        u = u.astype(self.dtype)
+        return a, u, l, r
+
+
+def get_updated(a, u, downdate):
+    if downdate:
+        if u.ndim > 1:
+            return a - u @ u.T.conjugate()
+        return a - np.outer(u, u.conj())
+    else:
+        if u.ndim > 1:
+            return a + u @ u.T.conjugate()
+        return a + np.outer(u, u.conj())
+
+
+class BaseCholUpdate(BaseCholdeltas):
+    def base_update1_test(self, a, u, l, r, lower: bool, downdate: bool):
+        a1 = get_updated(a, u, downdate)
+        if lower:
+            d = cholesky_update(l, u, downdate=downdate, lower=True,
+                                overwrite_rz=False)
+        else:
+            d = cholesky_update(r, u, downdate=downdate, lower=False,
+                                overwrite_rz=False)
+        check_cholesky(a1, d, lower=lower, rtol=self.rtol, atol=self.atol)
+
+        # Check with the same matrix passed to fn to ensure no overwrite
+        if lower:
+            a2 = np.dot(l, l.T.conj())
+        else:
+            a2 = np.dot(r.T.conj(), r)
+        a2 = get_updated(a2, u, downdate)
+        check_cholesky(a2, d, lower=lower, rtol=self.rtol, atol=self.atol)
+
+    def test_u1_l_dd_sqr(self):
+        for which in ['1d', 'col']:
+            a, u, l, r = self.generate('sqr', which=which)
+            self.base_update1_test(a, u, l, r, lower=True, downdate=True)
+
+    def test_u1_l_dd_1x1(self):
+        for which in ['1d', 'col']:
+            a, u, l, r = self.generate('1x1', which=which)
+            self.base_update1_test(a, u, l, r, lower=True, downdate=True)
+
+    def test_u1_u_dd_sqr(self):
+        for which in ['1d', 'col']:
+            a, u, l, r = self.generate('sqr', which=which)
+            self.base_update1_test(a, u, l, r, lower=False, downdate=True)
+
+    def test_u1_u_dd_1x1(self):
+        for which in ['1d', 'col']:
+            a, u, l, r = self.generate('1x1', which=which)
+            self.base_update1_test(a, u, l, r, lower=False, downdate=True)
+
+    def test_u1_l_ud_sqr(self):
+        for which in ['1d', 'col']:
+            a, u, l, r = self.generate('sqr', which=which)
+            self.base_update1_test(a, u, l, r, lower=True, downdate=False)
+
+    def test_u1_l_ud_1x1(self):
+        for which in ['1d', 'col']:
+            a, u, l, r = self.generate('1x1', which=which)
+            self.base_update1_test(a, u, l, r, lower=True, downdate=False)
+
+    def test_u1_u_ud_sqr(self):
+        for which in ['1d', 'col']:
+            a, u, l, r = self.generate('sqr', which=which)
+            self.base_update1_test(a, u, l, r, lower=False, downdate=False)
+
+    def test_u1_u_ud_1x1(self):
+        for which in ['1d', 'col']:
+            a, u, l, r = self.generate('1x1', which=which)
+            self.base_update1_test(a, u, l, r, lower=True, downdate=False)
+
+    def test_up_l_dd_sqr(self):
+        for which in ['p']:
+            a, u, l, r = self.generate('sqr', which=which)
+            self.base_update1_test(a, u, l, r, lower=True, downdate=True)
+
+    def test_up_l_dd_1x1(self):
+        for which in ['p']:
+            a, u, l, r = self.generate('1x1', which=which)
+            self.base_update1_test(a, u, l, r, lower=True, downdate=True)
+
+    def test_up_u_dd_sqr(self):
+        for which in ['p']:
+            a, u, l, r = self.generate('sqr', which=which)
+            self.base_update1_test(a, u, l, r, lower=False, downdate=True)
+
+    def test_up_u_dd_1x1(self):
+        for which in ['p']:
+            a, u, l, r = self.generate('1x1', which=which)
+            self.base_update1_test(a, u, l, r, lower=False, downdate=True)
+
+    def test_up_l_ud_sqr(self):
+        for which in ['p']:
+            a, u, l, r = self.generate('sqr', which=which)
+            self.base_update1_test(a, u, l, r, lower=True, downdate=False)
+
+    def test_up_l_ud_1x1(self):
+        for which in ['p']:
+            a, u, l, r = self.generate('1x1', which=which)
+            self.base_update1_test(a, u, l, r, lower=True, downdate=False)
+
+    def test_up_u_ud_sqr(self):
+        for which in ['p']:
+            a, u, l, r = self.generate('sqr', which=which)
+            self.base_update1_test(a, u, l, r, lower=False, downdate=False)
+
+    def test_up_u_ud_1x1(self):
+        for which in ['p']:
+            a, u, l, r = self.generate('1x1', which=which)
+            self.base_update1_test(a, u, l, r, lower=False, downdate=False)
+
+    def test_list_input(self):
+        a, u, l, r = self.generate('sqr', '1d')
+
+        d = cholesky_update(l, list(u), downdate=False, lower=True,
+                            overwrite_rz=False)
+        check_cholesky(get_updated(a, u, downdate=False), d, lower=True,
+                       rtol=self.rtol, atol=self.atol)
+
+        d = cholesky_update(list(l), u, downdate=False, lower=True,
+                            overwrite_rz=False)
+        check_cholesky(get_updated(a, u, downdate=False), d, lower=True,
+                       rtol=self.rtol, atol=self.atol)
+
+        d = cholesky_update(list(l), list(u), downdate=False, lower=True,
+                            overwrite_rz=False)
+        check_cholesky(get_updated(a, u, downdate=False), d, lower=True,
+                       rtol=self.rtol, atol=self.atol)
+
+    def test_check_nan(self):
+        a, u0, l0, r = self.generate('sqr', '1d')
+
+        l = l0.copy('F')
+        l[1, 1] = np.nan
+        assert_raises(ValueError, cholesky_update, l, u0, False, False)
+        assert_raises(ValueError, cholesky_update, l, u0, False, True)
+        assert_raises(ValueError, cholesky_update, l, u0, True, False)
+        assert_raises(ValueError, cholesky_update, l, u0, True, True)
+
+        u = u0.copy('F')
+        u[1] = np.nan
+        assert_raises(ValueError, cholesky_update, l0, u, False, False)
+        assert_raises(ValueError, cholesky_update, l0, u, False, True)
+        assert_raises(ValueError, cholesky_update, l0, u, True, False)
+        assert_raises(ValueError, cholesky_update, l0, u, True, True)
+
+    def test_check_nan_p(self):
+        a, u0, l0, r = self.generate('sqr', 'p')
+
+        l = l0.copy('F')
+        l[1, 1] = np.nan
+        assert_raises(ValueError, cholesky_update, l, u0, False, False)
+        assert_raises(ValueError, cholesky_update, l, u0, False, True)
+        assert_raises(ValueError, cholesky_update, l, u0, True, False)
+        assert_raises(ValueError, cholesky_update, l, u0, True, True)
+
+        u = u0.copy('F')
+        u[0, 0] = np.nan
+        assert_raises(ValueError, cholesky_update, l0, u, False, False)
+        assert_raises(ValueError, cholesky_update, l0, u, False, True)
+        assert_raises(ValueError, cholesky_update, l0, u, True, False)
+        assert_raises(ValueError, cholesky_update, l0, u, True, True)
+
+    def test_check_finite(self):
+        a, u0, l0, r = self.generate('sqr', '1d')
+
+        l = l0.copy('F')
+        l[1, 1] = np.inf
+        assert_raises(ValueError, cholesky_update, l, u0, False, False)
+        assert_raises(ValueError, cholesky_update, l, u0, False, True)
+        assert_raises(ValueError, cholesky_update, l, u0, True, False)
+        assert_raises(ValueError, cholesky_update, l, u0, True, True)
+
+        u = u0.copy('F')
+        u[1] = np.inf
+        assert_raises(ValueError, cholesky_update, l0, u, False, False)
+        assert_raises(ValueError, cholesky_update, l0, u, False, True)
+        assert_raises(ValueError, cholesky_update, l0, u, True, False)
+        assert_raises(ValueError, cholesky_update, l0, u, True, True)
+
+    def test_check_finite_p(self):
+        a, u0, l0, r = self.generate('sqr', 'p')
+
+        l = l0.copy('F')
+        l[1, 1] = np.inf
+        assert_raises(ValueError, cholesky_update, l, u0, False, False)
+        assert_raises(ValueError, cholesky_update, l, u0, False, True)
+        assert_raises(ValueError, cholesky_update, l, u0, True, False)
+        assert_raises(ValueError, cholesky_update, l, u0, True, True)
+
+        u = u0.copy('F')
+        u[1, 0] = np.inf
+        assert_raises(ValueError, cholesky_update, l0, u, False, False)
+        assert_raises(ValueError, cholesky_update, l0, u, False, True)
+        assert_raises(ValueError, cholesky_update, l0, u, True, False)
+        assert_raises(ValueError, cholesky_update, l0, u, True, True)
+
+    def base_non_simple_strides(self, adjust_strides, which, r_overwriteable,
+                                u_overwriteable):
+        for type in ['sqr', '1x1']:
+            a, u0, l0, r = self.generate(type, which=which)
+            us, ls = adjust_strides((u0, l0))
+            a1 = get_updated(a, u0, downdate=False)
+
+            # if overwriteable is True
+            # For l and u we try first with overwrite=False, then with
+            # overwrite=True and make sure that overwriting occurred
+            # appropriately.
+            u = u0.copy('F')
+            l = l0.copy('F')
+            d1 = cholesky_update(ls, u, False, lower=True, overwrite_rz=False)
+            check_cholesky(a1, d1, lower=True, rtol=self.rtol, atol=self.atol)
+            d1o = cholesky_update(ls, u, False, lower=True, overwrite_rz=True)
+            check_cholesky(a1, d1o, lower=True, rtol=self.rtol, atol=self.atol)
+            if r_overwriteable:
+                assert_allclose(d1o, ls, rtol=self.rtol, atol=self.atol)
+            elif type != '1x1':
+                assert_raises(AssertionError, assert_allclose, d1o, ls,
+                              rtol=self.rtol, atol=self.atol)
+            if u_overwriteable and len(u0) != 1:
+                # if u contains single element it won't be modified.
+                assert_raises(AssertionError, assert_allclose, u0, u,
+                              self.rtol, self.atol)
+
+            u = u0.copy('F')
+            l = l0.copy('F')
+            d2 = cholesky_update(l, us, False, lower=True, overwrite_rz=False)
+            check_cholesky(a1, d2, lower=True, rtol=self.rtol, atol=self.atol)
+            d2o = cholesky_update(l, us, False, lower=True, overwrite_rz=True)
+            check_cholesky(a1, d2o, lower=True, rtol=self.rtol, atol=self.atol)
+            if r_overwriteable:
+                assert_allclose(d2o, l, rtol=self.rtol, atol=self.atol)
+            elif type != '1x1':
+                assert_raises(AssertionError, assert_allclose, d2o, ls,
+                              rtol=self.rtol, atol=self.atol)
+            if u_overwriteable and len(u0) != 1:
+                assert_raises(AssertionError, assert_allclose, u0, us,
+                              rtol=self.rtol, atol=self.atol)
+
+            # Now with both strided (need to be recreated since they were
+            # overwritten above)
+            u = u0.copy('F')
+            l = l0.copy('F')
+            # since some of these were consumed above
+            us, ls = adjust_strides((u, l))
+            d3 = cholesky_update(ls, us, False, lower=True, overwrite_rz=False)
+            check_cholesky(a1, d3, lower=True, rtol=self.rtol, atol=self.atol)
+            d3o = cholesky_update(ls, us, False, lower=True, overwrite_rz=True)
+            check_cholesky(a1, d3o, lower=True, rtol=self.rtol, atol=self.atol)
+            if r_overwriteable:
+                assert_allclose(d3o, ls, rtol=self.rtol, atol=self.atol)
+            elif type != '1x1':
+                assert_raises(AssertionError, assert_allclose, d3o, ls,
+                              rtol=self.rtol, atol=self.atol)
+            if u_overwriteable and len(u0) != 1:
+                assert_raises(AssertionError, assert_allclose, u0, us,
+                              rtol=self.rtol, atol=self.atol)
+
+    def test_non_unit_strides_1d(self):
+        self.base_non_simple_strides(make_strided, '1d', True, True)
+
+    def test_neg_strides_1d(self):
+        self.base_non_simple_strides(negate_strides, '1d', False, False)
+
+    def test_non_itemize_strides_1d(self):
+        self.base_non_simple_strides(nonitemsize_strides, '1d', False, False)
+
+    def test_non_native_byte_order_1d(self):
+        self.base_non_simple_strides(make_nonnative, '1d', False, False)
+
+    def test_non_unit_strides_col(self):
+        self.base_non_simple_strides(make_strided, 'col', True, True)
+
+    def test_neg_strides_col(self):
+        self.base_non_simple_strides(negate_strides, 'col', False, False)
+
+    def test_non_itemize_strides_col(self):
+        self.base_non_simple_strides(nonitemsize_strides, 'col', False, False)
+
+    def test_non_native_byte_order_col(self):
+        self.base_non_simple_strides(make_nonnative, 'col', False, False)
+
+    def test_non_unit_strides_p(self):
+        self.base_non_simple_strides(make_strided, 'p', True, False)
+
+    def test_neg_strides_p(self):
+        self.base_non_simple_strides(negate_strides, 'p', False, False)
+
+    def test_non_itemize_strides_p(self):
+        self.base_non_simple_strides(nonitemsize_strides, 'p', False, False)
+
+    def test_non_native_byte_order_p(self):
+        self.base_non_simple_strides(make_nonnative, 'p', False, False)
+
+    def base_overwrite_chol(self, which):
+        for lower, downdate, type in itertools.product(
+                [True, False], [True, False], ['sqr', '1x1']):
+            a, u0, l0, r0 = self.generate(type, which=which)
+            a1 = get_updated(a, u0, downdate)
+            mat0 = l0 if lower else r0
+
+            # Don't overwrite
+            u = u0.copy('F')
+            mat = mat0.copy('F')
+            d1 = cholesky_update(mat, u, downdate, lower, overwrite_rz=False)
+            check_cholesky(a1, d1, lower=lower, rtol=self.rtol, atol=self.atol)
+            check_cholesky(a, mat, lower=lower, rtol=self.rtol, atol=self.atol)
+
+            u = u0.copy('F')
+            mat = mat0.copy('F')
+            d2 = cholesky_update(mat, u, downdate, lower, overwrite_rz=True)
+            check_cholesky(a1, d2, lower=lower, rtol=self.rtol, atol=self.atol)
+            assert_allclose(d2, mat, rtol=self.rtol, atol=self.atol)
+            # Check that the untouched triangle remains the same
+            assert_allclose_tri(mat0, d2, lower=not lower, rtol=self.rtol,
+                                atol=self.atol)
+            if len(u) > 1:
+                assert_raises(AssertionError, assert_allclose, u, u0,
+                              rtol=self.rtol, atol=self.atol)
+
+            u = u0.copy('C')
+            mat = mat0.copy('C')
+            d3 = cholesky_update(mat, u, downdate, lower, overwrite_rz=True)
+            check_cholesky(a1, d3, lower=lower, rtol=self.rtol, atol=self.atol)
+            assert_allclose(d3, mat, rtol=self.rtol, atol=self.atol)
+            assert_allclose_tri(mat0, d3, lower=not lower, rtol=self.rtol,
+                                atol=self.atol)
+            if len(u) > 1:
+                assert_raises(AssertionError, assert_allclose, u, u0,
+                              rtol=self.rtol, atol=self.atol)
+
+            u = u0.copy('C')
+            mat = mat0.copy('F')
+            d4 = cholesky_update(mat, u, downdate, lower, overwrite_rz=True)
+            check_cholesky(a1, d4, lower=lower, rtol=self.rtol, atol=self.atol)
+            assert_allclose(d4, mat, rtol=self.rtol, atol=self.atol)
+            # Check that the untouched triangle remains the same
+            assert_allclose_tri(mat0, d4, lower=not lower, rtol=self.rtol,
+                                atol=self.atol)
+            if len(u) > 1:
+                assert_raises(AssertionError, assert_allclose, u, u0,
+                              rtol=self.rtol, atol=self.atol)
+
+            u = u0.copy('F')
+            mat = mat0.copy('C')
+            d5 = cholesky_update(mat, u, downdate, lower, overwrite_rz=True)
+            check_cholesky(a1, d5, lower=lower, rtol=self.rtol, atol=self.atol)
+            assert_allclose(d5, mat, rtol=self.rtol, atol=self.atol)
+            # Check that the untouched triangle remains the same
+            assert_allclose_tri(mat0, d5, lower=not lower, rtol=self.rtol,
+                                atol=self.atol)
+            if len(u) > 1:
+                assert_raises(AssertionError, assert_allclose, u, u0,
+                              rtol=self.rtol, atol=self.atol)
+
+    def test_overwrite_1d(self):
+        self.base_overwrite_chol('1d')
+
+    def test_overwrite_col(self):
+        self.base_overwrite_chol('col')
+
+    def test_overwrite_p(self):
+        self.base_overwrite_chol('p')
+
+    """ Test edge cases which should error out """
+    def test_empty_l(self):
+        a, u, l, r = self.generate('sqr', which='col')
+        assert_raises(ValueError, cholesky_update, np.array([]), u)
+
+    def test_empty_u(self):
+        a, u, l, r = self.generate('sqr', which='col')
+        assert_raises(ValueError, cholesky_update, l, np.array([]))
+
+    def test_unsupported_dtypes(self):
+        dts = ['int8', 'int16', 'int32', 'int64',
+               'uint8', 'uint16', 'uint32', 'uint64',
+               'float16', 'longdouble', 'longcomplex',
+               'bool']
+        a, u0, l0, r = self.generate('sqr', which='col')
+        for dtype in dts:
+            l = l0.real.astype(dtype)
+            u = u0.real.astype(dtype)
+            assert_raises(ValueError, cholesky_update, l, u0)
+            assert_raises(ValueError, cholesky_update, l, u0)
+            assert_raises(ValueError, cholesky_update, l, u0)
+            assert_raises(ValueError, cholesky_update, l, u0)
+
+            assert_raises(ValueError, cholesky_update, l0, u)
+            assert_raises(ValueError, cholesky_update, l0, u)
+            assert_raises(ValueError, cholesky_update, l0, u)
+            assert_raises(ValueError, cholesky_update, l0, u)
+
+    def test_scalar(self):
+        a, u0, l0, r = self.generate('1x1', which='col')
+        assert_raises(ValueError, cholesky_update, l0[0, 0], u0)
+        assert_raises(ValueError, cholesky_update, l0, u0[0, 0])
+
+    def test_mismatched_shapes(self):
+        a, u, l, r = self.generate('sqr', which='col')
+        a0, u0, l0, r0 = self.generate('1x1', which='col')
+
+        assert_raises(ValueError, cholesky_update, l, u0)
+        assert_raises(ValueError, cholesky_update, l0, u)
+
+    def test_l_nonsquare(self):
+        a, u, l0, r = self.generate('sqr', which='col')
+        l = np.concatenate((l0, l0[0, None]), axis=0)
+        assert_raises(ValueError, cholesky_update, l, u)
+
+        l = np.concatenate((l0, l0[:, 0][:, None]), axis=1)
+        assert_raises(ValueError, cholesky_update, l, u)
+
+    def test_3d_inputs(self):
+        a, u0, l0, r = self.generate('sqr', which='col')
+        l = l0[..., None]
+        assert_raises(ValueError, cholesky_update, l, u0)
+        u = u0[..., None]
+        assert_raises(ValueError, cholesky_update, l0, u)
+
+    def test_non_pd(self):
+        a0, u0, l0, r0 = self.generate('sqr', which='col')
+        a1 = a0 - (a0.shape[0] - 1.9) * np.eye(a0.shape[0], dtype=self.dtype)
+        for lower in [True, False]:
+            l1 = scipy.linalg.cholesky(a1, lower=lower)
+
+            u1 = u0 * 5
+            a2 = get_updated(a1, u1, downdate=True)
+            assert_raises(np.linalg.LinAlgError, scipy.linalg.cholesky, a2,
+                          lower=lower)
+            assert_raises(np.linalg.LinAlgError, cholesky_update, l1, u1,
+                          lower=lower, downdate=True)
+            # update should never fail
+            cholesky_update(l1, u1, lower=lower, downdate=False)
+
+    def test_non_pd_p(self):
+        a0, u0, l0, r0 = self.generate('sqr', which='p')
+        a1 = a0 - (a0.shape[0] - 1.9) * np.eye(a0.shape[0], dtype=self.dtype)
+        for lower in [False]:
+
+            l1 = scipy.linalg.cholesky(a1, lower=lower)
+
+            u1 = u0 * 1.3
+            a2 = get_updated(a1, u1, downdate=True)
+            assert_raises(np.linalg.LinAlgError, scipy.linalg.cholesky, a2,
+                          lower=lower)
+            assert_raises(np.linalg.LinAlgError, cholesky_update, l1, u1,
+                          lower=lower, downdate=True)
+            # update should never fail
+            cholesky_update(l1, u1, lower=lower, downdate=False)
+
+
+class TestCholUpdate_f(BaseCholUpdate):
+    dtype = np.dtype('f')
+
+
+class TestCholUpdate_d(BaseCholUpdate):
+    dtype = np.dtype('d')
+
+
+class TestCholUpdate_F(BaseCholUpdate):
+    dtype = np.dtype('F')
+
+
+class TestCholUpdate_D(BaseCholUpdate):
+    dtype = np.dtype('D')


### PR DESCRIPTION
Closes https://github.com/scipy/scipy/issues/8188

This PR picks up where a previous now seemingly abandoned PR left off (https://github.com/scipy/scipy/pull/8286) to implement update and downdate for the Cholesky factorization.
On top of the previous PR rank-k updates are also implemented using an algorithm described in [a paper] [0] (https://www.cs.utexas.edu/users/flame/pubs/flawn41.pdf) by van de Geijn and Van Zee. The rank-1 downdates use the algorithm by Pan [1] (unfortunately I couldn't find a non-paywalled paper), and the updates use the same modification as in #8286.

The code is in cython for speed. A simple benchmark comparing rank-1, rank-2 and rank-20 updates to redoing the factorization from scratch shows that the rank-1 update has good speedup, but the rank-k updates are not as good.

![bench](https://user-images.githubusercontent.com/9317941/176565109-679fcddd-f20c-4d5a-8c54-7a92c534388e.png)

If deemed necessary it should be possible to
 - fix the different performance depending on the contiguity of input matrices
 - use block rotations to speed up the rank-k updates (not sure exactly how, references are sparse on this).

Let me know what your thoughts on this are,
Giacomo

[0]: Van de Geijn, R. A., Van Zee, F. G. "High-Performance Up-and-Downdating via Householder-like Transformations". ACM Trans. Math. Softw. 38, 1-17 (2011).
[1]: Pan, C-T. "A modification to the LINPACK downdating algorithm." BIT Numerical Mathematics 30.4 (1990): 707-722.
