### PR TITLE
REL: more tweaks to sdist contents

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,8 +6,6 @@
 .circleci/* export-ignore
 .github/* export-ignore
 ci/* export-ignore
-doc/* export-ignore
-doc/source/_static/scipy-mathjax/* export-ignore
 .coveragerc export-ignore
 .git* export-ignore
 *.yml export-ignore

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include MANIFEST.in
 include *.txt
 # Top-level build script
 include setup.py
+include meson.build
 include pyproject.toml
 # All source files
 recursive-include scipy *
@@ -9,10 +10,11 @@ recursive-include benchmarks *
 # All documentation
 recursive-include doc *
 # Add build and testing tools
-include runtests.py
+include runtests.py dev.py
 include .coveragerc
 include site.cfg.example
-include tox.ini pytest.ini
+include tox.ini pytest.ini mypy.ini
+include CITATION.bib
 recursive-include tools *
 # Exclude what we don't want to include
 recursive-exclude scipy/linalg/src/id_dist/src *_subr_*.f


### PR DESCRIPTION
We did ship `doc/` after all, and it makes sense to include as a snapshot, or for building the docs from sdist as some packagers may want to do.

Also add a couple of files to the setup.py-generated sdist, for consistency.

For a comprehensive test of the differences between sdists generated by `distutils` and by `meson-python`, I ran:

```bash
set -x
git clean -xdf
python setup.py sdist
mv dist/scipy*.tar.gz ../scipy-setuppy.tar.gz
git clean -xdf
python -m build --sdist
mv dist/scipy*.tar.gz ../scipy-meson.tar.gz
git clean -xdf
mkdir dist
cd dist
mkdir sdist_content_setuppy
cd sdist_content_setuppy
tar -xzvf ../../../scipy-setuppy.tar.gz
cd ..
mkdir sdist_content_meson
cd sdist_content_meson
tar -xzvf ../../../scipy-meson.tar.gz
cd ../..
python ../tmp/compare_sdists.py
```

With the contents of `compare_sdists.py` being:

```python
import os

def list_files(basedir):
    """
    Returns all files in the given directory (including in subdirs)
    """
    files_out = list()
    for root, dirnames, filenames in os.walk(basedir):
        if root == 'dist':
            continue
        for filename in filenames:
            relpath = os.path.relpath(
                        os.path.join(root, filename),
                        start=basedir)
            files_out.append(relpath)

    return files_out

def compare_files(tree1, tree2):
    print(f"\n\nNot in f{tree2}\n\n")
    files_tree1 = list_files(tree1)
    files_tree2 = list_files(tree2)
    for file in files_tree1:
        if not file in files_tree2:
            print(file)

    print(f"\n\nNot in f{tree1}\n\n")
    for file in files_tree2:
        if not file in files_tree1:
            print(file)

if __name__ == '__main__':
    tree1 = '/home/rgommers/code/scipy/dist/sdist_content_meson/scipy-1.10.0.dev0/'
    tree2 = '/home/rgommers/code/scipy/dist/sdist_content_setuppy/scipy-1.10.0.dev0+1347.5ff12cc/'
    assert os.path.exists(tree1)
    assert os.path.exists(tree2)
    compare_files(tree1, tree2)
```

The result:

```

Not in f/home/rgommers/code/scipy/dist/sdist_content_setuppy/scipy-1.10.0.dev0+1347.5ff12cc/

LICENSES_bundled.txt
CONTRIBUTING.rst
scipy/special/tests/data/boost/ellint_rf_0yy_ipp/ellint_rf_0yy.txt
scipy/special/tests/data/boost/bessel_i_prime_int_data_ipp/bessel_i_prime_int_data.txt
<many more .txt files in tests/data/>

Not in f/home/rgommers/code/scipy/dist/sdist_content_meson/scipy-1.10.0.dev0/

.coveragerc
MANIFEST.in
scipy/version.py
scipy/linalg/_matfuncs_sqrtm_triu.cpp
scipy/fftpack/MANIFEST.in
scipy/_lib/highs/.git
scipy/_lib/boost/.git
scipy/_lib/unuran/.git
scipy/stats/_hypotests_pythran.cpp
scipy/stats/_boost/.gitignore
scipy/special/tests/data/gsl.npz
scipy/special/tests/data/local.npz
scipy/special/tests/data/boost.npz
scipy/interpolate/_rbfinterp_pythran.cpp
scipy/signal/_correlate_nd.c
scipy/signal/_spectral.cpp
scipy/signal/_bspline_util.c
scipy/signal/_max_len_seq_inner.cpp
scipy/signal/_lfilter.c
scipy/optimize/_group_columns.cpp
scipy/sparse/linalg/_propack/.gitignore
scipy/sparse/linalg/_propack/PROPACK/.git
tools/docker_dev/workspace_config
tools/docker_dev/Dockerfile
tools/docker_dev/fix_permissions
tools/docker_dev/environment.yml
tools/docker_dev/settings.json
tools/docker_dev/gitpod.Dockerfile
tools/docker_dev/meson.Dockerfile
tools/ci/README.txt
doc/source/_static/scipy-mathjax/.git
```

So we're leaving out:

1. All generated files
2. Some CI files (consistent, since most CI files aren't included in
                  either sdist)
3. .git and .gitignore files
4. MANIFEST.in (not useful, one cannot create an sdist from an sdist)
5. .coveragerc (basically also a CI file)

So I'm now happier that this is all correct, and any deltas between distutils and meson are an improvement.