### PR TITLE
MAINT: skip complex128 propack tests on windows (& module clean-up)

### DIFF
--- a/scipy/sparse/linalg/tests/test_propack.py
+++ b/scipy/sparse/linalg/tests/test_propack.py
@@ -8,6 +8,8 @@ from pytest import raises as assert_raises
 from scipy.sparse.linalg._svdp import _svdp
 from scipy.sparse import csr_matrix, csc_matrix, coo_matrix
 
+
+# dtype_flavour to tolerance
 TOLS = {
     np.float32: 1e-4,
     np.float64: 1e-8,
@@ -15,16 +17,9 @@ TOLS = {
     np.complex128: 1e-8,
 }
 
-_dtype_map = {
-    "single": np.float32,
-    "double": np.float64,
-    "complex8": np.complex64,
-    "complex16": np.complex128,
-}
-
 
 def is_complex_type(dtype):
-    return np.dtype(dtype).char.isupper()
+    return np.dtype(dtype).kind == "c"
 
 
 def is_32bit():
@@ -35,20 +30,21 @@ def is_windows():
     return 'win32' in sys.platform
 
 
-_dtype_testing = []
-for dtype in _dtype_map:
-    if 'complex' in dtype and is_32bit():
-        # PROPACK has issues w/ complex on 32-bit; see gh-14433
-        marks = [pytest.mark.skip]
-    elif 'complex16' in dtype and is_windows():
-        # windows crashes for complex128 (so don't xfail); see gh-15108
-        marks = [pytest.mark.skip]
-    elif 'complex' in dtype:
-        marks = [pytest.mark.slow]  # type: ignore[list-item]
-    else:
-        marks = []
-    _dtype_testing.append(pytest.param(dtype, marks=marks))
-_dtype_testing = tuple(_dtype_testing)  # type: ignore[assignment]
+_dtypes = []
+for dtype_flavour in TOLS.keys():
+    marks = []
+    if is_complex_type(dtype_flavour):
+        if is_32bit():
+            # PROPACK has issues w/ complex on 32-bit; see gh-14433
+            marks = [pytest.mark.skip]
+        elif is_windows() and np.dtype(dtype_flavour).itemsize == 16:
+            # windows crashes for complex128 (so don't xfail); see gh-15108
+            marks = [pytest.mark.skip]
+        else:
+            marks = [pytest.mark.slow]  # type: ignore[list-item]
+    _dtypes.append(pytest.param(dtype_flavour, marks=marks,
+                                id=dtype_flavour.__name__))
+_dtypes = tuple(_dtypes)  # type: ignore[assignment]
 
 
 def generate_matrix(constructor, n, m, f,
@@ -95,12 +91,11 @@ def check_svdp(n, m, constructor, dtype, k, irl_mode, which, f=0.8):
 
 
 @pytest.mark.parametrize('ctor', (np.array, csr_matrix, csc_matrix))
-@pytest.mark.parametrize('precision', _dtype_testing)
+@pytest.mark.parametrize('dtype', _dtypes)
 @pytest.mark.parametrize('irl', (True, False))
 @pytest.mark.parametrize('which', ('LM', 'SM'))
-def test_svdp(ctor, precision, irl, which):
+def test_svdp(ctor, dtype, irl, which):
     np.random.seed(0)
-    dtype = _dtype_map[precision]
     n, m, k = 10, 20, 3
     if which == 'SM' and not irl:
         message = "`which`='SM' requires irl_mode=True"
@@ -115,19 +110,19 @@ def test_svdp(ctor, precision, irl, which):
             check_svdp(n, m, ctor, dtype, k, irl, which)
 
 
-@pytest.mark.parametrize('precision', _dtype_testing)
+@pytest.mark.parametrize('dtype', _dtypes)
 @pytest.mark.parametrize('irl', (False, True))
-@pytest.mark.timeout(120)  # True, complex8 > 60 s: prerel deps cov 64bit blas
-def test_examples(precision, irl):
-    # Note: atol for complex8 bumped from 1e-4 to 1e-3 because of test failures
+@pytest.mark.timeout(120)  # True, complex64 > 60 s: prerel deps cov 64bit blas
+def test_examples(dtype, irl):
+    # Note: atol for complex64 bumped from 1e-4 to 1e-3 due to test failures
     # with BLIS, Netlib, and MKL+AVX512 - see
     # https://github.com/conda-forge/scipy-feedstock/pull/198#issuecomment-999180432
     atol = {
-        'single': 1.3e-4,
-        'double': 1e-9,
-        'complex8': 1e-3,
-        'complex16': 1e-9,
-    }[precision]
+        np.float32: 1.3e-4,
+        np.float64: 1e-9,
+        np.complex64: 1e-3,
+        np.complex128: 1e-9,
+    }[dtype]
 
     path_prefix = os.path.dirname(__file__)
     # Test matrices from `illc1850.coord` and `mhd1280b.cua` distributed with
@@ -136,18 +131,17 @@ def test_examples(precision, irl):
     filename = os.path.join(path_prefix, relative_path)
     data = np.load(filename, allow_pickle=True)
 
-    dtype = _dtype_map[precision]
-    if precision in {'single', 'double'}:
-        A = data['A_real'].item().astype(dtype)
-    elif precision in {'complex8', 'complex16'}:
+    if is_complex_type(dtype):
         A = data['A_complex'].item().astype(dtype)
+    else:
+        A = data['A_real'].item().astype(dtype)
 
     k = 200
     u, s, vh, _ = _svdp(A, k, irl_mode=irl, random_state=0)
 
     # complex example matrix has many repeated singular values, so check only
     # beginning non-repeated singular vectors to avoid permutations
-    sv_check = 27 if precision in {'complex8', 'complex16'} else k
+    sv_check = 27 if is_complex_type(dtype) else k
     u = u[:, :sv_check]
     vh = vh[:sv_check, :]
     s = s[:sv_check]
@@ -168,8 +162,8 @@ def test_examples(precision, irl):
 
 
 @pytest.mark.parametrize('shifts', (None, -10, 0, 1, 10, 70))
-@pytest.mark.parametrize('precision', ('single', 'double'))
-def test_shifts(shifts, precision):
+@pytest.mark.parametrize('dtype', _dtypes[:2])
+def test_shifts(shifts, dtype):
     np.random.seed(0)
     n, k = 70, 10
     A = np.random.random((n, n))

--- a/scipy/sparse/linalg/tests/test_propack.py
+++ b/scipy/sparse/linalg/tests/test_propack.py
@@ -31,10 +31,17 @@ def is_32bit():
     return sys.maxsize <= 2**32  # (usually 2**31-1 on 32-bit)
 
 
+def is_windows():
+    return 'win32' in sys.platform
+
+
 _dtype_testing = []
 for dtype in _dtype_map:
     if 'complex' in dtype and is_32bit():
         # PROPACK has issues w/ complex on 32-bit; see gh-14433
+        marks = [pytest.mark.skip]
+    elif 'complex16' in dtype and is_windows():
+        # windows crashes for complex128 (so don't xfail); see gh-15108
         marks = [pytest.mark.skip]
     elif 'complex' in dtype:
         marks = [pytest.mark.slow]  # type: ignore[list-item]


### PR DESCRIPTION
In addition to forward-porting the minimal commit from https://github.com/scipy/scipy/pull/16512, I wanted to clean up the dtype-handling in that test module a bit. Also tested that this works in https://github.com/conda-forge/scipy-feedstock/pull/206