### PR TITLE
DOC: reflect correctly where windows wheels are built

### DIFF
--- a/doc/source/dev/toolchain.rst
+++ b/doc/source/dev/toolchain.rst
@@ -109,7 +109,7 @@ Currently, SciPy wheels are being built as follows:
 Linux (nightly)    ``ubuntu-18.04``          GCC 6.5                      See ``azure-pipelines.yml``
 Linux (release)    ``ubuntu-18.04``          GCC 7.5                      Built in separate repo [6]_
 OSX                ``macOS-10.15``           LLVM 12.0.0                  Built in separate repo [6]_
-Windows            ``windows-2019``          Visual Studio 2019 (16.11)   See ``azure-pipelines.yml``
+Windows            ``windows-2019``          Visual Studio 2019 (16.11)   Built in separate repo [6]_
 ================  ========================  ===========================  ==============================
 
 Note that the OSX wheels additionally vendor gfortran 4.9,


### PR DESCRIPTION
Follow-up to https://github.com/scipy/scipy/pull/15167 now that the scipy-wheels situation has been updated by https://github.com/MacPython/scipy-wheels/pull/166. Still waiting for the cibuildwheel stuff to hit for more extensive updates (e.g. picking up the gfortran bump again).