### PR TITLE
DOC: wavfile: floating point does not range from -1 to +1

### DIFF
--- a/scipy/io/wavfile.py
+++ b/scipy/io/wavfile.py
@@ -572,7 +572,7 @@ def read(filename, mmap=False):
     =====================  ===========  ===========  =============
          WAV format            Min          Max       NumPy dtype
     =====================  ===========  ===========  =============
-    32-bit floating-point  -1.0         +1.0         float32
+    32-bit floating-point  -3.4028e+38  +3.4028e+38  float32
     32-bit integer PCM     -2147483648  +2147483647  int32
     24-bit integer PCM     -2147483648  +2147483392  int32
     16-bit integer PCM     -32768       +32767       int16
@@ -732,7 +732,7 @@ def write(filename, rate, data):
     =====================  ===========  ===========  =============
          WAV format            Min          Max       NumPy dtype
     =====================  ===========  ===========  =============
-    32-bit floating-point  -1.0         +1.0         float32
+    32-bit floating-point  -3.4028e+38  +3.4028e+38  float32
     32-bit PCM             -2147483648  +2147483647  int32
     16-bit PCM             -32768       +32767       int16
     8-bit PCM              0            255          uint8


### PR DESCRIPTION
The documentation for the IEEE_FLOAT variant of reading and writing WAV files seems to be incorrect, as demonstrated by the code below. 

I'm not sure what the right way to fix it is. Feedback appreciated, and I'll do my best to do it properly.

```
import numpy as np
from scipy.io import wavfile

# %% Writing supposedly saturated file

A = 200
f = 5
fs = 44100
t = np.linspace(0, 1, fs + 1)

testSignal = A * np.sin(2 * np.pi * f * t)

wavfile.write('test.wav', fs, testSignal.astype(float))


# %% Reading file with intact values 

_, writtenData = wavfile.read('test.wav')

import matplotlib.pyplot as plt

plt.rcParams["figure.figsize"] = [7.50, 3.50]
plt.rcParams["figure.autolayout"] = True

plt.plot(t, writtenData)
plt.ylabel("Signal")
plt.xlabel("Time")
```
plt.show()

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
