### PR TITLE
BUG: Fix error in error message for incorrect sample dimension in interpn

### DIFF
--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -602,7 +602,7 @@ def interpn(points, values, xi, method="linear", bounds_error=True,
     if xi.shape[-1] != len(grid):
         raise ValueError("The requested sample points xi have dimension "
                          "%d, but this RegularGridInterpolator has "
-                         "dimension %d" % (xi.shape[1], len(grid)))
+                         "dimension %d" % (xi.shape[-1], len(grid)))
 
     if bounds_error:
         for i, p in enumerate(xi.T):

--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -815,3 +815,13 @@ class TestInterpN:
         match = "must be strictly ascending or descending"
         with pytest.raises(ValueError, match=match):
             interpn((x, y), z, xi)
+
+    def test_invalid_xi_dimensions(self):
+        # https://github.com/scipy/scipy/issues/16519
+        points = [(0, 1)]
+        values = [0, 1]
+        xi = np.ones((1, 1, 3))
+        msg = ("The requested sample points xi have dimension 3, but this "
+               "RegularGridInterpolator has dimension 1")
+        with assert_raises(ValueError, match=msg):
+            interpn(points, values, xi)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #16519 
#### What does this implement/fix?
<!--Please explain your changes.-->
Corrects error message to be consistent with check and adds test.
#### Additional information
<!--Any additional information you think is important.-->
In the example of the test error message would previously state:
```
The requested sample points xi have dimension 1, but this RegularGridInterpolator has dimension 1
```
and now states
```
The requested sample points xi have dimension 3, but this RegularGridInterpolator has dimension 1
```