### PR TITLE
TST: stats.permutation_test: strengthen test against `ks_2samp`

### DIFF
--- a/scipy/stats/tests/test_resampling.py
+++ b/scipy/stats/tests/test_resampling.py
@@ -1001,20 +1001,22 @@ class TestPermutationTest:
 
     # -- Independent (Unpaired) Sample Tests -- #
 
-    def test_against_kstest(self):
+    @pytest.mark.parametrize('alternative', ("less", "greater", "two-sided"))
+    def test_against_kstest(self, alternative):
         np.random.seed(0)
         x = stats.norm.rvs(size=4, scale=1)
         y = stats.norm.rvs(size=5, loc=3, scale=3)
 
-        alternative = 'greater'
         expected = stats.ks_2samp(x, y, alternative=alternative, mode='exact')
 
         def statistic1d(x, y):
             return stats.ks_2samp(x, y, mode='asymp',
                                   alternative=alternative).statistic
 
+        # kstest is always a one-tailed 'greater' test
+        # it's the statistic that changes (D+ vs D- vs max(D+, D-))
         res = permutation_test((x, y), statistic1d, n_resamples=np.inf,
-                               alternative=alternative)
+                               alternative='greater')
 
         assert_allclose(res.statistic, expected.statistic, rtol=self.rtol)
         assert_allclose(res.pvalue, expected.pvalue, rtol=self.rtol)

--- a/scipy/stats/tests/test_resampling.py
+++ b/scipy/stats/tests/test_resampling.py
@@ -1002,10 +1002,10 @@ class TestPermutationTest:
     # -- Independent (Unpaired) Sample Tests -- #
 
     @pytest.mark.parametrize('alternative', ("less", "greater", "two-sided"))
-    def test_against_kstest(self, alternative):
-        np.random.seed(0)
-        x = stats.norm.rvs(size=4, scale=1)
-        y = stats.norm.rvs(size=5, loc=3, scale=3)
+    def test_against_ks_2samp(self, alternative):
+        rng = np.random.default_rng(abs(hash("ks_2samp")))
+        x = rng.normal(size=4, scale=1)
+        y = rng.normal(size=5, loc=3, scale=3)
 
         expected = stats.ks_2samp(x, y, alternative=alternative, mode='exact')
 
@@ -1013,7 +1013,7 @@ class TestPermutationTest:
             return stats.ks_2samp(x, y, mode='asymp',
                                   alternative=alternative).statistic
 
-        # kstest is always a one-tailed 'greater' test
+        # ks_2samp is always a one-tailed 'greater' test
         # it's the statistic that changes (D+ vs D- vs max(D+, D-))
         res = permutation_test((x, y), statistic1d, n_resamples=np.inf,
                                alternative='greater')


### PR DESCRIPTION
#### What does this implement/fix?
This strengthens the test of `permutation_test` against against the exact result returned by `ks_2samp`. Previously, it only tested with `alternative='greater'`; this PR performs the test with all three alternatives.

#### Additional information
When I was writing the `permutation_test` tests, I couldn't get `permutation_test` to reproduce the results produced by `ks_2samp` with `alternative='less'` or `alternative='two-sided'`. I thought this was OK, figuring that it was due to my own misunderstanding rather than a problem with either `permutation_test` or `ks_2samp`. It was my own misunderstanding. This PR fixes that.

At some point I will reduce the scope of the `permutation_test` test suite to speed things up. In the meantime, I thought I should add this in because it always seemed unusual to test with all three alternatives for most hypothesis tests but only `alternative='greater'` for `ks_2samp`.
