### PR TITLE
CI: clean up scikit-umfpack and scikit-sparse usage in CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Configuring Test Environment
         run: |
           sudo apt-get update
-          sudo apt install python3.8-dbg python3.8-dev libatlas-base-dev liblapack-dev gfortran libgmp-dev libmpfr-dev libsuitesparse-dev ccache swig libmpc-dev
+          sudo apt install python3.8-dbg python3.8-dev libatlas-base-dev liblapack-dev gfortran libgmp-dev libmpfr-dev ccache swig libmpc-dev
           free -m
           python3.8-dbg --version # just to check
           export NPY_NUM_BUILD_JOBS=2
@@ -76,7 +76,7 @@ jobs:
 
     - name: Install other build dependencies
       run: |
-        sudo apt-get install libatlas-base-dev liblapack-dev gfortran libgmp-dev libmpfr-dev libsuitesparse-dev ccache libmpc-dev
+        sudo apt-get install libatlas-base-dev liblapack-dev gfortran libgmp-dev libmpfr-dev ccache libmpc-dev
 
     - name: Install packages
       run: |

--- a/ci/azure-travis-template.yaml
+++ b/ci/azure-travis-template.yaml
@@ -79,8 +79,14 @@ steps:
     pytest-timeout
   displayName: 'Install common python dependencies'
 - ${{ if eq(parameters.test_mode, 'full') }}:
-  - script: pip install matplotlib scikit-umfpack scikit-sparse
-    displayName: 'Install full mode dependencies'
+  - script: >-
+      pip install matplotlib
+      # These two scikits both depend on scipy, so use `--no-deps`
+      # Also note that they don't provide wheels, so we build them from
+      # source (only in this job, it's a small optional dependency so test
+      # only in a single place)
+      pip install scikit-umfpack scikit-sparse --no-deps
+    displayName: 'Install full mode optional dependencies'
 - ${{ if eq(parameters.coverage, true) }}:
   - script: pip install pytest-cov coverage codecov
     displayName: 'Install coverage dependencies'


### PR DESCRIPTION
Two things improved here:
- don't install suitesparse when it is not needed
- don't pull in scipy as a dependency for these two scikits

I considered dropping `scikit-umfpack` and `scikit-sparse` completely, because they're effectively unmaintained and used rarely. But I decided to leave that alone, because they're in general unproblematic. `scikit-sparse` isn't even installable for Python >= 3.10 anymore though, so if no one fixes that issue then we'll remove it at some point.