### PR TITLE
MAINT: fix umfpack test failure with numpy 1.23

### DIFF
--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -514,7 +514,11 @@ def factorized(A):
         umf.numeric(A)
 
         def solve(b):
-            return umf.solve(umfpack.UMFPACK_A, A, b, autoTranspose=True)
+            with np.errstate(divide="ignore", invalid="ignore"):
+                # Ignoring warnings with numpy >= 1.23.0, see gh-16523
+                result = umf.solve(umfpack.UMFPACK_A, A, b, autoTranspose=True)
+
+            return result
 
         return solve
     else:


### PR DESCRIPTION
The reason is a divide-by-zero warning that our test suite settings convert to an error. So ignore these warnings, because they're coming from inside `scikit-umfpack`.

This has been failing consistently in the Azure pre-release job.

Closes gh-16523

[skip github]