### PR TITLE
ENH: signal: add Lanczos window function

### DIFF
--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -34,6 +34,7 @@ window_funcs = [
     ('exponential', ()),
     ('taylor', ()),
     ('tukey', (0.5,)),
+    ('lanczos', ()),
     ]
 
 
@@ -635,6 +636,34 @@ class TestDPSS:
         assert_raises(ValueError, windows.dpss, -1, 1, 3)  # negative M
 
 
+class TestLanczos:
+
+    def test_basic(self):
+        # Analytical results:
+        # sinc(x) = sinc(-x)
+        # sinc(pi) = 0, sinc(0) = 1
+        # Hand computation on WolframAlpha:
+        # sinc(2 pi / 3) = 0.413496672
+        # sinc(pi / 3) = 0.826993343
+        # sinc(3 pi / 5) = 0.504551152
+        # sinc(pi / 5) = 0.935489284
+        assert_allclose(windows.lanczos(6, sym=False),
+                        [0., 0.413496672,
+                         0.826993343, 1., 0.826993343,
+                         0.413496672],
+                        atol=1e-9)
+        assert_allclose(windows.lanczos(6),
+                        [0., 0.504551152,
+                         0.935489284, 0.935489284,
+                         0.504551152, 0.],
+                        atol=1e-9)
+        assert_allclose(windows.lanczos(7, sym=True),
+                        [0., 0.413496672,
+                         0.826993343, 1., 0.826993343,
+                         0.413496672, 0.],
+                        atol=1e-9)
+
+
 class TestGetWindow:
 
     def test_boxcar(self):
@@ -695,6 +724,15 @@ class TestGetWindow:
                         [0.4, 0.6072949, 0.9427051, 0.9427051, 0.6072949])
         assert_allclose(get_window(('general_hamming', 0.7), 5, fftbins=False),
                         [0.4, 0.7, 1.0, 0.7, 0.4])
+
+    def test_lanczos(self):
+        assert_allclose(get_window('lanczos', 6),
+                        [0., 0.413496672, 0.826993343, 1., 0.826993343,
+                         0.413496672], atol=1e-9)
+        assert_allclose(get_window('lanczos', 6, fftbins=False),
+                        [0., 0.504551152, 0.935489284, 0.935489284,
+                         0.504551152, 0.], atol=1e-9)
+        assert_allclose(get_window('lanczos', 6), get_window('sinc', 6))
 
 
 def test_windowfunc_basics():
@@ -776,7 +814,10 @@ def test_not_needs_params():
                    'poisson',
                    'tukey',
                    'tuk',
-                   'triangle']:
+                   'triangle',
+                   'lanczos',
+                   'sinc',
+                   ]:
         win = get_window(winstr, 7)
         assert_equal(len(win), 7)
 

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -668,9 +668,6 @@ class TestLanczos:
             assert_equal(len(windows.lanczos(n, sym=False)), n)
             assert_equal(len(windows.lanczos(n, sym=True)), n)
 
-        # If zero or less, an ValueError is thrown.
-        assert_raises(ValueError, windows.lanczos, -1)
-
 
 class TestGetWindow:
 

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -831,3 +831,10 @@ def test_deprecation():
 def test_deprecated_pickleable():
     dep_hann2 = pickle.loads(pickle.dumps(dep_hann))
     assert_(dep_hann2 is dep_hann)
+
+
+def test_symmetric():
+    for win in [windows.lanczos]:
+        w = win(4096)
+        error = np.max(np.abs(w-np.flip(w)))
+        assert_equal(error, 0.0)

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -834,7 +834,14 @@ def test_deprecated_pickleable():
 
 
 def test_symmetric():
+
     for win in [windows.lanczos]:
+        # Even sampling points
         w = win(4096)
+        error = np.max(np.abs(w-np.flip(w)))
+        assert_equal(error, 0.0)
+
+        # Odd sampling points
+        w = win(4097)
         error = np.max(np.abs(w-np.flip(w)))
         assert_equal(error, 0.0)

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -663,6 +663,14 @@ class TestLanczos:
                          0.413496672, 0.],
                         atol=1e-9)
 
+    def test_array_size(self):
+        for n in [0, 10, 11]:
+            assert_equal(len(windows.lanczos(n, sym=False)), n)
+            assert_equal(len(windows.lanczos(n, sym=True)), n)
+
+        # If zero or less, an ValueError is thrown.
+        assert_raises(ValueError, windows.lanczos, -1)
+
 
 class TestGetWindow:
 

--- a/scipy/signal/windows/__init__.py
+++ b/scipy/signal/windows/__init__.py
@@ -30,12 +30,12 @@ The suite of window functions for filtering and spectral estimation.
    hann                    -- Hann window
    kaiser                  -- Kaiser window
    kaiser_bessel_derived   -- Kaiser-Bessel derived window
+   lanczos                 -- Lanczos window also known as a sinc window
    nuttall                 -- Nuttall's minimum 4-term Blackman-Harris window
    parzen                  -- Parzen window
    taylor                  -- Taylor window
    triang                  -- Triangular window
    tukey                   -- Tukey window
-   lanczos                 -- Lanczos window also known as a sinc window
 
 """
 

--- a/scipy/signal/windows/__init__.py
+++ b/scipy/signal/windows/__init__.py
@@ -35,6 +35,7 @@ The suite of window functions for filtering and spectral estimation.
    taylor                  -- Taylor window
    triang                  -- Triangular window
    tukey                   -- Tukey window
+   lanczos                 -- Lanczos window also known as a sinc window
 
 """
 
@@ -48,4 +49,4 @@ __all__ = ['boxcar', 'triang', 'parzen', 'bohman', 'blackman', 'nuttall',
            'hamming', 'kaiser', 'kaiser_bessel_derived', 'gaussian',
            'general_gaussian', 'general_cosine', 'general_hamming',
            'chebwin', 'cosine', 'hann', 'exponential', 'tukey', 'taylor',
-           'get_window', 'dpss']
+           'get_window', 'dpss', 'lanczos']

--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -2082,8 +2082,8 @@ def lanczos(M, *, sym=True):
     Parameters
     ----------
     M : int
-        Number of points in the output window. If it is negative, ValueError
-        is thrown.
+        Number of points in the output window. If zero, an empty array
+        is returned. An exception is thrown when it is negative.
     sym : bool, optional
         When True (default), generates a symmetric window, for use in filter
         design.

--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -11,7 +11,7 @@ __all__ = ['boxcar', 'triang', 'parzen', 'bohman', 'blackman', 'nuttall',
            'hamming', 'kaiser', 'kaiser_bessel_derived', 'gaussian',
            'general_cosine', 'general_gaussian', 'general_hamming',
            'chebwin', 'cosine', 'hann', 'exponential', 'tukey', 'taylor',
-           'dpss', 'get_window']
+           'dpss', 'get_window', 'lanczos']
 
 
 def _len_guards(M):
@@ -2076,6 +2076,90 @@ def dpss(M, NW, Kmax=None, sym=True, norm=None, return_ratios=False):
     return (windows, ratios) if return_ratios else windows
 
 
+def lanczos(M, *, sym=True):
+    r"""Return a Lanczos window also known as a sinc window.
+
+    Parameters
+    ----------
+    M : int
+        Number of points in the output window. If zero or less, an empty
+        array is returned.
+    sym : bool, optional
+        When True (default), generates a symmetric window, for use in filter
+        design.
+        When False, generates a periodic window, for use in spectral analysis.
+
+    Returns
+    -------
+    w : ndarray
+        The window, with the maximum value normalized to 1 (though the value 1
+        does not appear if `M` is even and `sym` is True).
+
+    Notes
+    -----
+    The Lanczos window is defined as
+
+    .. math::  w(n) = sinc \left( \frac{2n}{M - 1} - 1 \right)
+
+    where
+
+    .. math::  sinc(x) = \frac{\sin(\pi x)}{\pi x}
+
+    The Lanczos window has reduced Gibbs oscillations and is widely used for
+    filtering climate timeseries with good properties in the physical and
+    spectral domains.
+
+    References
+    ----------
+    .. [1] Lanczos, C., and Teichmann, T. (1957). Applied analysis.
+           Physics Today, 10, 44.
+    .. [2] Duchon C. E. (1979) Lanczos Filtering in One and Two Dimensions.
+           Journal of Applied Meteorology, Vol 18, pp 1016-1022.
+    .. [3] Thomson, R. E. and Emery, W. J. (2014) Data Analysis Methods in
+           Physical Oceanography (Third Edition), Elsevier, pp 593-637.
+    .. [4] Wikipedia, "Window function",
+           http://en.wikipedia.org/wiki/Window_function
+
+    Examples
+    --------
+    Plot the window
+
+    >>> from scipy.signal.windows import lanczos
+    >>> from scipy.fft import fft, fftshift
+    >>> import matplotlib.pyplot as plt
+    >>> fig, ax = plt.subplots(1)
+    >>> window = lanczos(51)
+    >>> ax.plot(window)
+    >>> ax.set_title("Lanczos window")
+    >>> ax.set_ylabel("Amplitude")
+    >>> ax.set_xlabel("Sample")
+    >>> fig.tight_layout()
+    >>> plt.show()
+
+    and its frequency response:
+
+    >>> fig, ax = plt.subplots(1)
+    >>> A = fft(window, 2048) / (len(window)/2.0)
+    >>> freq = np.linspace(-0.5, 0.5, len(A))
+    >>> response = 20 * np.log10(np.abs(fftshift(A / abs(A).max())))
+    >>> ax.plot(freq, response)
+    >>> ax.set_xlim(-0.5, 0.5)
+    >>> ax.set_ylim(-120, 0)
+    >>> ax.set_title("Frequency response of the lanczos window")
+    >>> ax.set_ylabel("Normalized magnitude [dB]")
+    >>> ax.set_xlabel("Normalized frequency [cycles per sample]")
+    >>> fig.tight_layout()
+    >>> plt.show()
+    """
+    if _len_guards(M):
+        return np.ones(M)
+    M, needs_trunc = _extend(M, sym)
+
+    w = np.sinc(2. * np.arange(0, M) / (M - 1) - 1.)
+
+    return _truncate(w, needs_trunc)
+
+
 def _fftautocorr(x):
     """Compute the autocorrelation of a real array and crop the result."""
     N = x.shape[-1]
@@ -2115,6 +2199,7 @@ _win_equiv_raw = {
     ('taylor', 'taylorwin'): (taylor, False),
     ('triangle', 'triang', 'tri'): (triang, False),
     ('tukey', 'tuk'): (tukey, False),
+    ('lanczos', 'sinc'): (lanczos, False),
 }
 
 # Fill dict with all valid window name strings
@@ -2171,6 +2256,7 @@ def get_window(window, Nx, fftbins=True):
     - `~scipy.signal.windows.exponential`
     - `~scipy.signal.windows.tukey`
     - `~scipy.signal.windows.taylor`
+    - `~scipy.signal.windows.lanczos`
     - `~scipy.signal.windows.kaiser` (needs beta)
     - `~scipy.signal.windows.kaiser_bessel_derived` (needs beta)
     - `~scipy.signal.windows.gaussian` (needs standard deviation)

--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -2155,7 +2155,18 @@ def lanczos(M, *, sym=True):
         return np.ones(M)
     M, needs_trunc = _extend(M, sym)
 
-    w = np.sinc(2. * np.arange(0, M) / (M - 1) - 1.)
+    # To make sure that the window is symmetric, we concatenate the right hand
+    # half of the window and the flipped one which is the left hand half of
+    # the window.
+    def _calc_right_side_lanczos(n, m):
+        return np.sinc(2. * np.arange(n, m) / (m - 1) - 1.0)
+
+    if M % 2 == 0:
+        wh = _calc_right_side_lanczos(M/2, M)
+        w = np.r_[np.flip(wh), wh]
+    else:
+        wh = _calc_right_side_lanczos((M+1)/2, M)
+        w = np.r_[np.flip(wh), 1.0, wh]
 
     return _truncate(w, needs_trunc)
 

--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -2205,12 +2205,12 @@ _win_equiv_raw = {
     ('hann', 'han'): (hann, False),
     ('kaiser', 'ksr'): (kaiser, True),
     ('kaiser bessel derived', 'kbd'): (kaiser_bessel_derived, True),
+    ('lanczos', 'sinc'): (lanczos, False),
     ('nuttall', 'nutl', 'nut'): (nuttall, False),
     ('parzen', 'parz', 'par'): (parzen, False),
     ('taylor', 'taylorwin'): (taylor, False),
     ('triangle', 'triang', 'tri'): (triang, False),
     ('tukey', 'tuk'): (tukey, False),
-    ('lanczos', 'sinc'): (lanczos, False),
 }
 
 # Fill dict with all valid window name strings

--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -2109,6 +2109,7 @@ def lanczos(M, *, sym=True):
     filtering climate timeseries with good properties in the physical and
     spectral domains.
 
+    .. versionadded:: 1.10
     References
     ----------
     .. [1] Lanczos, C., and Teichmann, T. (1957). Applied analysis.

--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -2110,6 +2110,7 @@ def lanczos(M, *, sym=True):
     spectral domains.
 
     .. versionadded:: 1.10
+
     References
     ----------
     .. [1] Lanczos, C., and Teichmann, T. (1957). Applied analysis.

--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -2082,8 +2082,8 @@ def lanczos(M, *, sym=True):
     Parameters
     ----------
     M : int
-        Number of points in the output window. If zero or less, an empty
-        array is returned.
+        Number of points in the output window. If it is negative, ValueError
+        is thrown.
     sym : bool, optional
         When True (default), generates a symmetric window, for use in filter
         design.


### PR DESCRIPTION
Co-authored-by: Guillaume <serazing@gmail.com>

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Reviving #6837

#### What does this implement/fix?
<!--Please explain your changes.-->
5 years ago, PR #6837 tried to add the Lanczos windows function, but it has been stalled now.
Adding this new window function is already discussed in the mailing list,
- https://mail.python.org/pipermail/scipy-dev/2017-January/021654.html

So, we can revive this PR again based on the latest code base.
I implemented these:
- the new Lanczos windows function and its docstring
- `get_window` support 
- unit tests.
