### PR TITLE
MAINT: signal: Fix matplotlib deprecation warning in the chirp docstring

### DIFF
--- a/scipy/signal/_waveforms.py
+++ b/scipy/signal/_waveforms.py
@@ -370,11 +370,13 @@ def chirp(t, f0, t1, f1, method='linear', phi=0, vertex_zero=True):
 
     >>> def plot_spectrogram(title, w, fs):
     ...     ff, tt, Sxx = spectrogram(w, fs=fs, nperseg=256, nfft=576)
-    ...     plt.pcolormesh(tt, ff[:145], Sxx[:145], cmap='gray_r', shading='gouraud')
-    ...     plt.title(title)
-    ...     plt.xlabel('t (sec)')
-    ...     plt.ylabel('Frequency (Hz)')
-    ...     plt.grid()
+    ...     fig, ax = plt.subplots()
+    ...     ax.pcolormesh(tt, ff[:145], Sxx[:145], cmap='gray_r',
+    ...                   shading='gouraud')
+    ...     ax.set_title(title)
+    ...     ax.set_xlabel('t (sec)')
+    ...     ax.set_ylabel('Frequency (Hz)')
+    ...     ax.grid(True)
     ...
 
     Quadratic chirp from 1500 Hz to 250 Hz


### PR DESCRIPTION
The code in the chirp docstring was generating the warning

    matplotlib._api.deprecation.MatplotlibDeprecationWarning:
    Auto-removal of grids by pcolor() and pcolormesh() is deprecated
    since 3.5 and will be removed two minor releases later; please
    call grid(False) first.

The revised code creates a new axis for each spectrogram plot,
so it doesn't encounter the case where the warning was being
generated.

This avoids some of the warnings reported in gh-16531.
