### PR TITLE
DOC: Update scipy.signal.bilinear

### DIFF
--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -2073,9 +2073,9 @@ def bilinear(b, a, fs=1.0):
 
     Returns
     -------
-    z : ndarray
+    b : ndarray
         Numerator of the transformed digital filter transfer function.
-    p : ndarray
+    a : ndarray
         Denominator of the transformed digital filter transfer function.
 
     See Also


### PR DESCRIPTION
#### Reference issue
Closes #16369

#### What does this implement/fix?
Updates docstring return variable names to match B/A transfer function custom instead of ZPK.
