### PR TITLE
BLD: fix regression in building _lsap with symbol visibility

### DIFF
--- a/scipy/optimize/_lsap.c
+++ b/scipy/optimize/_lsap.c
@@ -189,7 +189,7 @@ static struct PyModuleDef moduledef = {
     NULL,
 };
 
-PyObject*
+PyMODINIT_FUNC
 PyInit__lsap(void)
 {
     import_array();


### PR DESCRIPTION
In commit 6d310c89ab1bdab57464d7ef6016818979792ca8, the PyMODINIT_FUNC annotation was dropped from this module. It had been recently added, but then a long-running PR was merged and, presumably due to `git rebase`, reverted this diff hunk.

#### Reference issue

Fixes gh-16540