### PR TITLE
DOC: Add alt-text to tutorial images

### DIFF
--- a/doc/source/tutorial/fft.rst
+++ b/doc/source/tutorial/fft.rst
@@ -80,7 +80,7 @@ corresponding to positive frequencies is plotted.
 The example plots the FFT of the sum of two sines.
 
 .. plot::
-    :alt: "..."
+    :alt: "This code generates an X-Y plot showing amplitude on the Y axis vs frequency on the X axis. A single blue trace has an amplitude of zero all the way across with the exception of two peaks. The taller first peak is at 50 Hz with a second peak at 80 Hz."
 
     >>> from scipy.fft import fft, fftfreq
     >>> # Number of sample points
@@ -108,7 +108,7 @@ and shows the effect of windowing (the zero component of the FFT has been
 truncated for illustrative purposes).
 
 .. plot::
-    :alt: "..."
+    :alt: "This code generates an X-Y log-linear plot with amplitude on the Y axis vs frequency on the X axis. The first trace is the FFT with two peaks at 50 and 80 Hz and a noise floor around an amplitude of 1e-2. The second trace is the windowed FFT and has the same two peaks but the noise floor is much lower around an amplitude of 1e-7 due to the window function."
 
     >>> from scipy.fft import fft, fftfreq
     >>> # Number of sample points
@@ -153,7 +153,7 @@ The example below plots the FFT of two complex exponentials; note the
 asymmetric spectrum.
 
 .. plot::
-    :alt: "..."
+    :alt: "This code generates an X-Y plot with amplitude on the Y axis vs frequency on the X axis. The trace is zero-valued across the plot except for two sharp peaks at -80 and 50 Hz. The 50 Hz peak on the right is twice as tall."
 
     >>> from scipy.fft import fft, fftfreq, fftshift
     >>> # number of signal points
@@ -235,7 +235,7 @@ The example below demonstrates a 2-D IFFT and plots the resulting
 (2-D) time-domain signals.
 
 .. plot::
-    :alt: "..."
+    :alt: "This code generates six heatmaps arranged in a 2x3 grid. The top row shows mostly blank canvases with the exception of two tiny red peaks on each image. The bottom row shows the real-part of the inverse FFT of each image above it. The first column has two dots arranged horizontally in the top image and in the bottom image a smooth grayscale plot of 5 black vertical stripes representing the 2-D time domain signal. The second column has two dots arranged vertically in the top image and in the bottom image a smooth grayscale plot of 5 horizontal black stripes representing the 2-D time domain signal. In the last column the top image has two dots diagonally located; the corresponding image below has perhaps 20 black stripes at a 60 degree angle."
 
     >>> from scipy.fft import ifftn
     >>> import matplotlib.pyplot as plt
@@ -431,7 +431,7 @@ provides a five-fold compression rate.
 
 
 .. plot::
-    :alt: "..."
+    :alt: "This code generates an X-Y plot showing amplitude on the Y axis and time on the X axis. The first blue trace is the original signal and starts at amplitude 1 and oscillates down to 0 amplitude over the duration of the plot resembling a frequency chirp. The second red trace is the x_20 reconstruction using the DCT and closely follows the original signal in the high amplitude region but it is unclear to the right side of the plot. The third green trace is the x_15 reconstruction using the DCT and is less precise than the x_20 reconstruction but still similar to x."
 
     >>> from scipy.fft import dct, idct
     >>> import matplotlib.pyplot as plt

--- a/doc/source/tutorial/fft.rst
+++ b/doc/source/tutorial/fft.rst
@@ -80,6 +80,7 @@ corresponding to positive frequencies is plotted.
 The example plots the FFT of the sum of two sines.
 
 .. plot::
+    :alt: "..."
 
     >>> from scipy.fft import fft, fftfreq
     >>> # Number of sample points
@@ -107,6 +108,7 @@ and shows the effect of windowing (the zero component of the FFT has been
 truncated for illustrative purposes).
 
 .. plot::
+    :alt: "..."
 
     >>> from scipy.fft import fft, fftfreq
     >>> # Number of sample points
@@ -151,6 +153,7 @@ The example below plots the FFT of two complex exponentials; note the
 asymmetric spectrum.
 
 .. plot::
+    :alt: "..."
 
     >>> from scipy.fft import fft, fftfreq, fftshift
     >>> # number of signal points
@@ -232,6 +235,7 @@ The example below demonstrates a 2-D IFFT and plots the resulting
 (2-D) time-domain signals.
 
 .. plot::
+    :alt: "..."
 
     >>> from scipy.fft import ifftn
     >>> import matplotlib.pyplot as plt
@@ -427,6 +431,7 @@ provides a five-fold compression rate.
 
 
 .. plot::
+    :alt: "..."
 
     >>> from scipy.fft import dct, idct
     >>> import matplotlib.pyplot as plt

--- a/doc/source/tutorial/interpolate.rst
+++ b/doc/source/tutorial/interpolate.rst
@@ -162,7 +162,7 @@ The following example demonstrates its use, and compares the interpolation resul
 using each method.
 
 .. plot::
-   :alt: "..."
+   :alt: " "
 
    >>> import matplotlib.pyplot as plt
    >>> from scipy.interpolate import RegularGridInterpolator
@@ -258,7 +258,7 @@ and the integral of the spline between any two points (
 example that follows.
 
 .. plot::
-   :alt: "..."
+   :alt: " "
 
    >>> import numpy as np
    >>> import matplotlib.pyplot as plt
@@ -385,7 +385,7 @@ spline.
 
 
 .. plot::
-   :alt: "..."
+   :alt: " "
 
    >>> import numpy as np
    >>> import matplotlib.pyplot as plt
@@ -464,7 +464,7 @@ of each argument is determined by the number of indexing objects
 passed in :obj:`mgrid <numpy.mgrid>`.
 
 .. plot::
-   :alt: "..."
+   :alt: " "
 
    >>> import numpy as np
    >>> from scipy import interpolate
@@ -526,7 +526,7 @@ This example compares the usage of the `Rbf` and `UnivariateSpline` classes
 from the scipy.interpolate module.
 
 .. plot::
-    :alt: "..."
+    :alt: " "
 
     >>> import numpy as np
     >>> from scipy.interpolate import Rbf, InterpolatedUnivariateSpline
@@ -566,7 +566,7 @@ from the scipy.interpolate module.
 This example shows how to interpolate scattered 2-D data:
 
 .. plot::
-    :alt: "..."
+    :alt: " "
 
     >>> import numpy as np
     >>> from scipy.interpolate import Rbf

--- a/doc/source/tutorial/interpolate.rst
+++ b/doc/source/tutorial/interpolate.rst
@@ -46,6 +46,7 @@ specified at instantiation time. The following example demonstrates
 its use, for linear and cubic spline interpolation:
 
 .. plot::
+   :alt: "..."
 
    >>> from scipy.interpolate import interp1d
 
@@ -72,6 +73,7 @@ interpolating filter. The following example demonstrates their use, using the
 same data as in the previous example:
 
 .. plot::
+   :alt: "..."
 
    >>> from scipy.interpolate import interp1d
 
@@ -102,6 +104,7 @@ function *f(x, y)* you only know the values at points *(x[i], y[i])*
 that do not form a regular grid.
 
 .. plot::
+    :alt: "..."
 
     Suppose we want to interpolate the 2-D function
 
@@ -159,6 +162,7 @@ The following example demonstrates its use, and compares the interpolation resul
 using each method.
 
 .. plot::
+   :alt: "..."
 
    >>> import matplotlib.pyplot as plt
    >>> from scipy.interpolate import RegularGridInterpolator
@@ -254,6 +258,7 @@ and the integral of the spline between any two points (
 example that follows.
 
 .. plot::
+   :alt: "..."
 
    >>> import numpy as np
    >>> import matplotlib.pyplot as plt
@@ -380,6 +385,7 @@ spline.
 
 
 .. plot::
+   :alt: "..."
 
    >>> import numpy as np
    >>> import matplotlib.pyplot as plt
@@ -458,6 +464,7 @@ of each argument is determined by the number of indexing objects
 passed in :obj:`mgrid <numpy.mgrid>`.
 
 .. plot::
+   :alt: "..."
 
    >>> import numpy as np
    >>> from scipy import interpolate
@@ -519,6 +526,7 @@ This example compares the usage of the `Rbf` and `UnivariateSpline` classes
 from the scipy.interpolate module.
 
 .. plot::
+    :alt: "..."
 
     >>> import numpy as np
     >>> from scipy.interpolate import Rbf, InterpolatedUnivariateSpline
@@ -558,6 +566,7 @@ from the scipy.interpolate module.
 This example shows how to interpolate scattered 2-D data:
 
 .. plot::
+    :alt: "..."
 
     >>> import numpy as np
     >>> from scipy.interpolate import Rbf

--- a/doc/source/tutorial/interpolate.rst
+++ b/doc/source/tutorial/interpolate.rst
@@ -46,7 +46,7 @@ specified at instantiation time. The following example demonstrates
 its use, for linear and cubic spline interpolation:
 
 .. plot::
-   :alt: "..."
+   :alt: "This code generates an X-Y plot of a time-series with amplitude on the Y axis and time on the X axis. The original time-series is shown as a series of blue markers roughly defining some kind of oscillation. An orange trace showing the linear interpolation is drawn atop the data forming a jagged representation of the original signal. A dotted green cubic interpolation is also drawn that appears to smoothly represent the source data."
 
    >>> from scipy.interpolate import interp1d
 
@@ -73,7 +73,7 @@ interpolating filter. The following example demonstrates their use, using the
 same data as in the previous example:
 
 .. plot::
-   :alt: "..."
+   :alt: "This code generates an X-Y plot of a time-series with amplitude on the Y axis and time on the X axis. The original time-series is shown as a series of blue markers roughly defining some kind of oscillation. An orange trace showing the nearest neighbor interpolation is drawn atop the original with a stair-like appearance where the original data is right in the middle of each stair step. A green trace showing the previous neighbor interpolation looks similar to the orange trace but the original data is at the back of each stair step. Similarly a dotted red trace showing the next neighbor interpolation goes through each of the previous points, but it is centered at the front edge of each stair."
 
    >>> from scipy.interpolate import interp1d
 

--- a/doc/source/tutorial/interpolate.rst
+++ b/doc/source/tutorial/interpolate.rst
@@ -104,7 +104,7 @@ function *f(x, y)* you only know the values at points *(x[i], y[i])*
 that do not form a regular grid.
 
 .. plot::
-    :alt: "..."
+    :alt: " "
 
     Suppose we want to interpolate the 2-D function
 

--- a/doc/source/tutorial/linalg.rst
+++ b/doc/source/tutorial/linalg.rst
@@ -370,7 +370,7 @@ coefficients :math:`c_{1}` and :math:`c_{2}` are estimated using
 linear least squares.
 
 .. plot::
-   :alt: "..."
+   :alt: " "
 
    >>> import numpy as np
    >>> from scipy import linalg

--- a/doc/source/tutorial/linalg.rst
+++ b/doc/source/tutorial/linalg.rst
@@ -370,6 +370,7 @@ coefficients :math:`c_{1}` and :math:`c_{2}` are estimated using
 linear least squares.
 
 .. plot::
+   :alt: "..."
 
    >>> import numpy as np
    >>> from scipy import linalg

--- a/doc/source/tutorial/ndimage.rst
+++ b/doc/source/tutorial/ndimage.rst
@@ -235,6 +235,7 @@ Smoothing filters
 
   .. plot:: tutorial/examples/gaussian_filter_plot1.py
       :align: center
+      :alt: "..."
       :include-source: 0
 
   .. note::
@@ -813,6 +814,7 @@ while modes `mirror` and `wrap` treat the image as if it's extent ends exactly
 at the first and last sample point rather than 0.5 samples past it.
 
 .. plot:: tutorial/examples/plot_boundary_modes.py
+   :alt: "..."
    :include-source: False
 
 The coordinates of image samples fall on integer sampling locations
@@ -824,6 +826,7 @@ illustrate the sampling locations involved in the interpolation of the value at
 the location of the red x.
 
 .. plot:: tutorial/examples/plot_interp_grid.py
+   :alt: "..."
    :include-source: False
 
 
@@ -974,6 +977,7 @@ This is a viusal presentation of `generate_binary_structure` in 3D:
 
   .. plot:: tutorial/examples/ndimage/3D_binary_structure.py
       :align: center
+      :alt: "..."
       :include-source: 0
 
 Most binary morphology functions can be expressed in terms of the
@@ -981,6 +985,7 @@ basic operations erosion and dilation, which can be seen here:
 
   .. plot:: tutorial/examples/morphology_binary_dilation_erosion.py
       :align: center
+      :alt: "..."
       :include-source: 0
 
 - The :func:`binary_erosion` function implements binary erosion of

--- a/doc/source/tutorial/ndimage.rst
+++ b/doc/source/tutorial/ndimage.rst
@@ -235,7 +235,7 @@ Smoothing filters
 
   .. plot:: tutorial/examples/gaussian_filter_plot1.py
       :align: center
-      :alt: "..."
+      :alt: " "
       :include-source: 0
 
   .. note::
@@ -814,7 +814,7 @@ while modes `mirror` and `wrap` treat the image as if it's extent ends exactly
 at the first and last sample point rather than 0.5 samples past it.
 
 .. plot:: tutorial/examples/plot_boundary_modes.py
-   :alt: "..."
+   :alt: " "
    :include-source: False
 
 The coordinates of image samples fall on integer sampling locations
@@ -826,7 +826,7 @@ illustrate the sampling locations involved in the interpolation of the value at
 the location of the red x.
 
 .. plot:: tutorial/examples/plot_interp_grid.py
-   :alt: "..."
+   :alt: " "
    :include-source: False
 
 
@@ -977,7 +977,7 @@ This is a viusal presentation of `generate_binary_structure` in 3D:
 
   .. plot:: tutorial/examples/ndimage/3D_binary_structure.py
       :align: center
-      :alt: "..."
+      :alt: " "
       :include-source: 0
 
 Most binary morphology functions can be expressed in terms of the
@@ -985,7 +985,7 @@ basic operations erosion and dilation, which can be seen here:
 
   .. plot:: tutorial/examples/morphology_binary_dilation_erosion.py
       :align: center
-      :alt: "..."
+      :alt: " "
       :include-source: 0
 
 - The :func:`binary_erosion` function implements binary erosion of

--- a/doc/source/tutorial/optimize.rst
+++ b/doc/source/tutorial/optimize.rst
@@ -776,6 +776,7 @@ This function looks like an egg carton::
    >>> plt.show()
 
 .. plot:: tutorial/examples/optimize_global_2.py
+   :alt: "..."
    :align: center
    :include-source: 0
 
@@ -851,6 +852,7 @@ We'll now plot all found minima on a heatmap of the function::
 
 .. plot:: tutorial/examples/optimize_global_1.py
    :align: center
+   :alt: "..."
    :include-source: 0
 
 Least-squares minimization (:func:`least_squares`)
@@ -920,6 +922,7 @@ The code below implements least-squares estimation of :math:`\mathbf{x}` and
 finally plots the original data and the fitted model function:
 
 .. plot::
+    :alt: "..."
 
     >>> from scipy.optimize import least_squares
 
@@ -1251,6 +1254,7 @@ exactly, forms an approximation for it.
 The problem we have can now be solved as follows:
 
 .. plot::
+    :alt: "..."
 
     import numpy as np
     from scipy.optimize import root

--- a/doc/source/tutorial/optimize.rst
+++ b/doc/source/tutorial/optimize.rst
@@ -776,7 +776,7 @@ This function looks like an egg carton::
    >>> plt.show()
 
 .. plot:: tutorial/examples/optimize_global_2.py
-   :alt: "..."
+   :alt: "A 3-D plot shown from a three-quarter view. The function is very noisy with dozens of valleys and peaks. There is no clear min or max discernable from this view and it's not possible to see all the local peaks and valleys from this view." 
    :align: center
    :include-source: 0
 
@@ -852,7 +852,7 @@ We'll now plot all found minima on a heatmap of the function::
 
 .. plot:: tutorial/examples/optimize_global_1.py
    :align: center
-   :alt: "..."
+   :alt: "This X-Y plot is a heatmap with the Z value denoted with the lowest points as black and the highest values as white. The image resembles a chess board rotated 45 degrees but heavily smoothed. A red dot is located at many of the minima on the grid resulting from the SHGO optimizer. SHGO shows the global minima as a red X in the top right. A local minima found with dual annealing is a white circle marker in the top left. A different local minima found with basinhopping is a yellow marker in the top center. The code is plotting the differential evolution result as a cyan circle, but it is not visible on the plot. At a glance it's not clear which of these valleys is the true global minima."
    :include-source: 0
 
 Least-squares minimization (:func:`least_squares`)
@@ -922,7 +922,7 @@ The code below implements least-squares estimation of :math:`\mathbf{x}` and
 finally plots the original data and the fitted model function:
 
 .. plot::
-    :alt: "..."
+    :alt: "This code plots an X-Y time-series. The series starts in the lower left at (0, 0) and rapidly trends up to the maximum of 0.2 then flattens out. The fitted model is shown as a smooth orange trace and is well fit to the data."
 
     >>> from scipy.optimize import least_squares
 
@@ -1254,7 +1254,7 @@ exactly, forms an approximation for it.
 The problem we have can now be solved as follows:
 
 .. plot::
-    :alt: "..."
+    :alt: "This code generates a 2-D heatmap with Z values from 0 to 1. The graph resembles a smooth, dark blue-green, U shape, with an open yellow top. The right, bottom, and left edges have a value near zero and the top has a value close to 1. The center of the solution space has a value close to 0.8."
 
     import numpy as np
     from scipy.optimize import root

--- a/doc/source/tutorial/signal.rst
+++ b/doc/source/tutorial/signal.rst
@@ -117,6 +117,7 @@ coefficients and is faster than :func:`convolve2d`, which convolves arbitrary
 conditions.
 
 .. plot::
+   :alt: "..."
 
    >>> import numpy as np
    >>> from scipy import signal, misc
@@ -308,6 +309,7 @@ enhancing, and edge-detection for an image.
 
 
 .. plot::
+   :alt: "..."
 
    >>> import numpy as np
    >>> from scipy import signal, misc
@@ -354,6 +356,7 @@ example, we consider a Gaussian filter :func:`~scipy.signal.windows.gaussian`
 which is often used for blurring.
 
 .. plot::
+   :alt: "..."
 
    >>> import numpy as np
    >>> from scipy import signal, misc
@@ -525,6 +528,7 @@ types (e.g., low-pass, band-pass...).
 The example below designs a low-pass and a band-stop filter, respectively.
 
 .. plot::
+   :alt: "..."
 
    >>> import numpy as np
    >>> import scipy.signal as signal
@@ -556,6 +560,7 @@ gains, respectively.
 The example below designs a filter with such an arbitrary amplitude response.
 
 .. plot::
+   :alt: "..."
 
    >>> import numpy as np
    >>> import scipy.signal as signal
@@ -590,6 +595,7 @@ compared with the FIR filters from the examples above in order to reach the same
 stop-band attenuation of :math:`\approx 60` dB.
 
 .. plot::
+   :alt: "..."
 
    >>> import numpy as np
    >>> import scipy.signal as signal
@@ -870,6 +876,7 @@ in the amplitude response.
 
 
 .. plot::
+   :alt: "..."
 
    >>> import numpy as np
    >>> import scipy.signal as signal
@@ -913,6 +920,7 @@ The example below calculates the periodogram of a sine signal in white
 Gaussian noise.
 
 .. plot::
+   :alt: "..."
 
    >>> import numpy as np
    >>> import scipy.signal as signal
@@ -949,6 +957,7 @@ the spectrogram.
 
 
 .. plot::
+   :alt: "..."
 
    >>> import numpy as np
    >>> import scipy.signal as signal
@@ -1051,6 +1060,7 @@ The example below removes the constant and linear trend of a second-order
 polynomial time series and plots the remaining signal components.
 
 .. plot::
+   :alt: "..."
 
    >>> import numpy as np
    >>> import scipy.signal as signal

--- a/doc/source/tutorial/signal.rst
+++ b/doc/source/tutorial/signal.rst
@@ -117,7 +117,7 @@ coefficients and is faster than :func:`convolve2d`, which convolves arbitrary
 conditions.
 
 .. plot::
-   :alt: "..."
+   :alt: "This code displays two plots. The first plot is a normal grayscale photo of a raccoon climbing on a palm plant. The second plot has the 2-D spline filter applied to the photo and is completely grey except the edges of the photo have been emphasized, especially on the raccoon fur and palm fronds."
 
    >>> import numpy as np
    >>> from scipy import signal, misc
@@ -309,7 +309,7 @@ enhancing, and edge-detection for an image.
 
 
 .. plot::
-   :alt: "..."
+   :alt: "This code displays two plots. The first plot is the familiar photo of a raccoon climbing on a palm. The second plot has the FIR filter applied and has the two copies of the photo superimposed due to the twin peaks manually set in the filter kernel definition."
 
    >>> import numpy as np
    >>> from scipy import signal, misc
@@ -356,7 +356,7 @@ example, we consider a Gaussian filter :func:`~scipy.signal.windows.gaussian`
 which is often used for blurring.
 
 .. plot::
-   :alt: "..."
+   :alt: "This code displays two plots. The first plot is a grayscale photo of two people climbing a wooden staircase taken from below. The second plot has the 2-D gaussian FIR window applied and appears very blurry. You can still tell it's a photo but the subject is ambiguous."
 
    >>> import numpy as np
    >>> from scipy import signal, misc
@@ -528,7 +528,7 @@ types (e.g., low-pass, band-pass...).
 The example below designs a low-pass and a band-stop filter, respectively.
 
 .. plot::
-   :alt: "..."
+   :alt: "This code displays an X-Y plot with the amplitude response on the Y axis vs frequency on the X axis. The first (low-pass) trace in blue starts with a pass-band at 0 dB and curves down around halfway through with some ripple in the stop-band about 80 dB down. The second (band-stop) trace in red starts and ends at 0 dB, but the middle third is down about 60 dB from the peak with some ripple where the filter would supress a signal."
 
    >>> import numpy as np
    >>> import scipy.signal as signal
@@ -560,7 +560,7 @@ gains, respectively.
 The example below designs a filter with such an arbitrary amplitude response.
 
 .. plot::
-   :alt: "..."
+   :alt: "This code displays an X-Y plot with amplitude response on the Y axis vs frequency on the X axis. A single trace forms a shape similar to a heartbeat signal."
 
    >>> import numpy as np
    >>> import scipy.signal as signal
@@ -595,7 +595,7 @@ compared with the FIR filters from the examples above in order to reach the same
 stop-band attenuation of :math:`\approx 60` dB.
 
 .. plot::
-   :alt: "..."
+   :alt: "This code generates an X-Y plot with amplitude response on the Y axis vs Frequency on the X axis. A single trace shows a smooth low-pass filter with the left third passband near 0 dB. The right two-thirds are about 60 dB down with two sharp narrow valleys dipping down to -100 dB."
 
    >>> import numpy as np
    >>> import scipy.signal as signal
@@ -876,7 +876,7 @@ in the amplitude response.
 
 
 .. plot::
-   :alt: "..."
+   :alt: "This code displays two plots. The first plot is an IIR filter response as an X-Y plot with amplitude response on the Y axis vs frequency on the X axis. The low-pass filter shown has a passband from 0 to 100 Hz with 0 dB response and a stop-band from about 175 Hz to 1 KHz about 40 dB down. There are two sharp discontinuities in the filter near 175 Hz and 300 Hz. The second plot is an X-Y showing the transfer function in the complex plane. The Y axis is real-valued an the X axis is complex-valued. The filter has four zeros near [300+0j, 175+0j, -175+0j, -300+0j] shown as blue X markers. The filter also has four poles near [50-30j, -50-30j, 100-8j, -100-8j] shown as red dots."
 
    >>> import numpy as np
    >>> import scipy.signal as signal
@@ -920,7 +920,7 @@ The example below calculates the periodogram of a sine signal in white
 Gaussian noise.
 
 .. plot::
-   :alt: "..."
+   :alt: "This code displays a single X-Y log-linear plot with the power spectral density on the Y axis vs frequency on the X axis. A single blue trace shows a noise floor with a power level of 1e-3 with a single peak at 1270 Hz up to a power of 1. The noise floor measurements appear noisy and oscillate down to 1e-7."
 
    >>> import numpy as np
    >>> import scipy.signal as signal
@@ -957,7 +957,7 @@ the spectrogram.
 
 
 .. plot::
-   :alt: "..."
+   :alt: "This code displays a single X-Y log-linear plot with the power spectral density on the Y axis vs frequency on the X axis. A single blue trace shows a smooth noise floor at a power level of 6e-2 with a single peak up to a power level of 2 at 1270 Hz."
 
    >>> import numpy as np
    >>> import scipy.signal as signal
@@ -1060,7 +1060,7 @@ The example below removes the constant and linear trend of a second-order
 polynomial time series and plots the remaining signal components.
 
 .. plot::
-   :alt: "..."
+   :alt: "This code generates an X-Y plot with no units. A red trace corresponding to the original signal curves from the bottom left to the top right. A blue trace has the constant detrend applied and is below the red trace with zero Y offset. The last black trace has the linear detrend applied and is almost flat from left to right highlighting the curve of the original signal. This last trace has an average slope of zero and looks very different."
 
    >>> import numpy as np
    >>> import scipy.signal as signal

--- a/doc/source/tutorial/spatial.rst
+++ b/doc/source/tutorial/spatial.rst
@@ -168,7 +168,7 @@ First, one can use the `KDTree` to answer the question "which of the
 points is closest to this one", and define the regions that way:
 
 .. plot::
-   :alt: "..."
+   :alt: " "
 
    >>> from scipy.spatial import KDTree
    >>> points = np.array([[0, 0], [0, 1], [0, 2], [1, 0], [1, 1], [1, 2],
@@ -286,7 +286,7 @@ Voronoi diagrams can be used to create interesting generative art.  Try playing
 with the settings of this ``mandala`` function to create your own!
 
 .. plot::
-   :alt: "..."
+   :alt: " "
 
    >>> import numpy as np
    >>> from scipy import spatial

--- a/doc/source/tutorial/spatial.rst
+++ b/doc/source/tutorial/spatial.rst
@@ -23,7 +23,7 @@ avoid triangles with small angles.
 Delaunay triangulation can be computed using `scipy.spatial` as follows:
 
 .. plot::
-   :alt: "..."
+   :alt: "This code generates an X-Y plot with four green points annotated 0 through 3 roughly in the shape of a box. The box is outlined with a diagonal line between points 0 and 3 forming two adjacent triangles. The top triangle is annotated as #1 and the bottom triangle is annotated as #0."
 
    >>> from scipy.spatial import Delaunay
    >>> points = np.array([[0, 0], [0, 1.1], [1, 0], [1, 1]])
@@ -134,7 +134,7 @@ These can be computed via the Qhull wrappers in `scipy.spatial` as
 follows:
 
 .. plot::
-   :alt: "..."
+   :alt: "This code generates an X-Y plot with a few dozen random blue markers randomly distributed throughout. A single black line forms a convex hull around the boundary of the markers."
 
    >>> from scipy.spatial import ConvexHull
    >>> rng = np.random.default_rng()

--- a/doc/source/tutorial/spatial.rst
+++ b/doc/source/tutorial/spatial.rst
@@ -23,6 +23,7 @@ avoid triangles with small angles.
 Delaunay triangulation can be computed using `scipy.spatial` as follows:
 
 .. plot::
+   :alt: "..."
 
    >>> from scipy.spatial import Delaunay
    >>> points = np.array([[0, 0], [0, 1.1], [1, 0], [1, 1]])
@@ -133,6 +134,7 @@ These can be computed via the Qhull wrappers in `scipy.spatial` as
 follows:
 
 .. plot::
+   :alt: "..."
 
    >>> from scipy.spatial import ConvexHull
    >>> rng = np.random.default_rng()
@@ -166,6 +168,7 @@ First, one can use the `KDTree` to answer the question "which of the
 points is closest to this one", and define the regions that way:
 
 .. plot::
+   :alt: "..."
 
    >>> from scipy.spatial import KDTree
    >>> points = np.array([[0, 0], [0, 1], [0, 2], [1, 0], [1, 1], [1, 2],
@@ -283,6 +286,7 @@ Voronoi diagrams can be used to create interesting generative art.  Try playing
 with the settings of this ``mandala`` function to create your own!
 
 .. plot::
+   :alt: "..."
 
    >>> import numpy as np
    >>> from scipy import spatial

--- a/doc/source/tutorial/special.rst
+++ b/doc/source/tutorial/special.rst
@@ -35,7 +35,7 @@ the vibrational modes of a thin drum head.  Here is an example of a circular
 drum head anchored at the edge:
 
 .. plot::
-   :alt: "..."
+   :alt: "This code generates a 3-D representation of the vibrational modes on a drum head viewed at a three-quarter angle. A circular region on the X-Y plane is defined with a Z value of 0 around the edge. Within the circle a single smooth valley exists on the -X side and a smooth peak exists on the +X side. The image resembles a yin-yang at this angle."
 
    >>> from scipy import special
    >>> def drumhead_height(n, k, distance, angle, t):

--- a/doc/source/tutorial/special.rst
+++ b/doc/source/tutorial/special.rst
@@ -35,6 +35,7 @@ the vibrational modes of a thin drum head.  Here is an example of a circular
 drum head anchored at the edge:
 
 .. plot::
+   :alt: "..."
 
    >>> from scipy import special
    >>> def drumhead_height(n, k, distance, angle, t):

--- a/doc/source/tutorial/stats.rst
+++ b/doc/source/tutorial/stats.rst
@@ -938,7 +938,7 @@ sampled from the PDF are shown as blue dashes at the bottom of the figure (this
 is called a rug plot):
 
 .. plot::
-    :alt: "..."
+    :alt: " "
 
     >>> from scipy import stats
     >>> import matplotlib.pyplot as plt
@@ -977,7 +977,7 @@ get a less smoothed-out result.
 
 .. plot:: tutorial/stats/plots/kde_plot2.py
    :align: center
-   :alt: "..."
+   :alt: " "
    :include-source: 0
 
 We see that if we set bandwidth to be very narrow, the obtained estimate for
@@ -992,7 +992,7 @@ distribution we take a Student's T distribution with 5 degrees of freedom.
 
 .. plot:: tutorial/stats/plots/kde_plot3.py
    :align: center
-   :alt: "..."
+   :alt: " "
    :include-source: 1
 
 We now take a look at a bimodal distribution with one wider and one narrower
@@ -1036,7 +1036,7 @@ each feature.
 
 .. plot:: tutorial/stats/plots/kde_plot4.py
    :align: center
-   :alt: "..."
+   :alt: " "
    :include-source: 0
 
 As expected, the KDE is not as close to the true PDF as we would like due to
@@ -1164,7 +1164,7 @@ The simulation relationship can be plotted below:
 
 .. plot:: tutorial/stats/plots/mgc_plot1.py
    :align: center
-   :alt: "..."
+   :alt: " "
    :include-source: 0
 
 Now, we can see the test statistic, p-value, and MGC map visualized below. The
@@ -1179,7 +1179,7 @@ optimal scale is shown on the map as a red "x":
 
 .. plot:: tutorial/stats/plots/mgc_plot2.py
    :align: center
-   :alt: "..."
+   :alt: " "
    :include-source: 0
 
 It is clear from here, that MGC is able to determine a relationship between the
@@ -1202,7 +1202,7 @@ The simulation relationship can be plotted below:
 
 .. plot:: tutorial/stats/plots/mgc_plot3.py
    :align: center
-   :alt: "..."
+   :alt: " "
    :include-source: 0
 
 Now, we can see the test statistic, p-value, and MGC map visualized below. The
@@ -1217,7 +1217,7 @@ optimal scale is shown on the map as a red "x":
 
 .. plot:: tutorial/stats/plots/mgc_plot4.py
    :align: center
-   :alt: "..."
+   :alt: " "
    :include-source: 0
 
 It is clear from here, that MGC is able to determine a relationship again
@@ -1248,7 +1248,7 @@ of random points can produce radically different results.
 
 .. plot:: tutorial/stats/plots/qmc_plot_mc.py
    :align: center
-   :alt: "..."
+   :alt: " "
    :include-source: 0
 
 In both cases in the plot above, points are generated randomly without any
@@ -1270,7 +1270,7 @@ theoretical rate of :math:`O(n^{-1/2})`.
 
 .. plot:: tutorial/stats/plots/qmc_plot_conv_mc.py
    :align: center
-   :alt: "..."
+   :alt: " "
    :include-source: 0
 
 Although the convergence is ensured, practitioners tend to want to have an
@@ -1298,7 +1298,7 @@ This exponential growth is called "the curse of dimensionality".
 
 .. plot:: tutorial/stats/plots/qmc_plot_curse.py
    :align: center
-   :alt: "..."
+   :alt: " "
    :include-source: 0
 
 To mitigate this issue, QMC methods have been designed. They are
@@ -1310,7 +1310,7 @@ sequences.
 
 .. plot:: tutorial/stats/plots/qmc_plot_mc_qmc.py
    :align: center
-   :alt: "..."
+   :alt: " "
    :include-source: 0
 
 This figure presents 2 sets of 256 points. The design of the left is a plain
@@ -1328,7 +1328,7 @@ that the *Sobol'* method has a rate of :math:`O(n^{-1})`:
 
 .. plot:: tutorial/stats/plots/qmc_plot_conv_mc_sobol.py
    :align: center
-   :alt: "..."
+   :alt: " "
    :include-source: 0
 
 We refer to the documentation of :mod:`scipy.stats.qmc` for
@@ -1357,7 +1357,7 @@ The lower the discrepancy, the more uniform a sample is.
 
 .. plot:: tutorial/stats/plots/qmc_plot_discrepancy.py
    :align: center
-   :alt: "..."
+   :alt: " "
    :include-source: 0
 
 Using a QMC engine
@@ -1369,7 +1369,7 @@ sequences.
 
 .. plot:: tutorial/stats/plots/qmc_plot_sobol_halton.py
    :align: center
-   :alt: "..."
+   :alt: " "
    :include-source: 1
 
 .. warning:: QMC methods require particular care and the user must read the

--- a/doc/source/tutorial/stats.rst
+++ b/doc/source/tutorial/stats.rst
@@ -614,11 +614,13 @@ the probabilities.
 
 .. plot:: tutorial/examples/normdiscr_plot1.py
    :align: center
+   :alt: "..."
    :include-source: 0
 
 
 .. plot:: tutorial/examples/normdiscr_plot2.py
    :align: center
+   :alt: "..."
    :include-source: 0
 
 
@@ -936,6 +938,7 @@ sampled from the PDF are shown as blue dashes at the bottom of the figure (this
 is called a rug plot):
 
 .. plot::
+    :alt: "..."
 
     >>> from scipy import stats
     >>> import matplotlib.pyplot as plt
@@ -974,6 +977,7 @@ get a less smoothed-out result.
 
 .. plot:: tutorial/stats/plots/kde_plot2.py
    :align: center
+   :alt: "..."
    :include-source: 0
 
 We see that if we set bandwidth to be very narrow, the obtained estimate for
@@ -988,6 +992,7 @@ distribution we take a Student's T distribution with 5 degrees of freedom.
 
 .. plot:: tutorial/stats/plots/kde_plot3.py
    :align: center
+   :alt: "..."
    :include-source: 1
 
 We now take a look at a bimodal distribution with one wider and one narrower
@@ -1031,6 +1036,7 @@ each feature.
 
 .. plot:: tutorial/stats/plots/kde_plot4.py
    :align: center
+   :alt: "..."
    :include-source: 0
 
 As expected, the KDE is not as close to the true PDF as we would like due to
@@ -1085,6 +1091,7 @@ the individual data points on top.
 
 .. plot:: tutorial/stats/plots/kde_plot5.py
    :align: center
+   :alt: "..."
    :include-source: 0
 
 
@@ -1157,6 +1164,7 @@ The simulation relationship can be plotted below:
 
 .. plot:: tutorial/stats/plots/mgc_plot1.py
    :align: center
+   :alt: "..."
    :include-source: 0
 
 Now, we can see the test statistic, p-value, and MGC map visualized below. The
@@ -1171,6 +1179,7 @@ optimal scale is shown on the map as a red "x":
 
 .. plot:: tutorial/stats/plots/mgc_plot2.py
    :align: center
+   :alt: "..."
    :include-source: 0
 
 It is clear from here, that MGC is able to determine a relationship between the
@@ -1193,6 +1202,7 @@ The simulation relationship can be plotted below:
 
 .. plot:: tutorial/stats/plots/mgc_plot3.py
    :align: center
+   :alt: "..."
    :include-source: 0
 
 Now, we can see the test statistic, p-value, and MGC map visualized below. The
@@ -1207,6 +1217,7 @@ optimal scale is shown on the map as a red "x":
 
 .. plot:: tutorial/stats/plots/mgc_plot4.py
    :align: center
+   :alt: "..."
    :include-source: 0
 
 It is clear from here, that MGC is able to determine a relationship again
@@ -1237,6 +1248,7 @@ of random points can produce radically different results.
 
 .. plot:: tutorial/stats/plots/qmc_plot_mc.py
    :align: center
+   :alt: "..."
    :include-source: 0
 
 In both cases in the plot above, points are generated randomly without any
@@ -1258,6 +1270,7 @@ theoretical rate of :math:`O(n^{-1/2})`.
 
 .. plot:: tutorial/stats/plots/qmc_plot_conv_mc.py
    :align: center
+   :alt: "..."
    :include-source: 0
 
 Although the convergence is ensured, practitioners tend to want to have an
@@ -1285,6 +1298,7 @@ This exponential growth is called "the curse of dimensionality".
 
 .. plot:: tutorial/stats/plots/qmc_plot_curse.py
    :align: center
+   :alt: "..."
    :include-source: 0
 
 To mitigate this issue, QMC methods have been designed. They are
@@ -1296,6 +1310,7 @@ sequences.
 
 .. plot:: tutorial/stats/plots/qmc_plot_mc_qmc.py
    :align: center
+   :alt: "..."
    :include-source: 0
 
 This figure presents 2 sets of 256 points. The design of the left is a plain
@@ -1313,6 +1328,7 @@ that the *Sobol'* method has a rate of :math:`O(n^{-1})`:
 
 .. plot:: tutorial/stats/plots/qmc_plot_conv_mc_sobol.py
    :align: center
+   :alt: "..."
    :include-source: 0
 
 We refer to the documentation of :mod:`scipy.stats.qmc` for
@@ -1341,6 +1357,7 @@ The lower the discrepancy, the more uniform a sample is.
 
 .. plot:: tutorial/stats/plots/qmc_plot_discrepancy.py
    :align: center
+   :alt: "..."
    :include-source: 0
 
 Using a QMC engine
@@ -1352,6 +1369,7 @@ sequences.
 
 .. plot:: tutorial/stats/plots/qmc_plot_sobol_halton.py
    :align: center
+   :alt: "..."
    :include-source: 1
 
 .. warning:: QMC methods require particular care and the user must read the

--- a/doc/source/tutorial/stats.rst
+++ b/doc/source/tutorial/stats.rst
@@ -614,13 +614,13 @@ the probabilities.
 
 .. plot:: tutorial/examples/normdiscr_plot1.py
    :align: center
-   :alt: "..."
+   :alt: "An X-Y histogram plot showing the distribution of random variates. A blue trace shows a normal bell curve. A blue bar chart perfectly approximates the curve showing the true distribution. A red bar chart representing the sample is well described by the blue trace but not exact."
    :include-source: 0
 
 
 .. plot:: tutorial/examples/normdiscr_plot2.py
    :align: center
-   :alt: "..."
+   :alt: "An X-Y histogram plot showing the cumulative distribution of random variates. A blue trace shows a CDF for a typical normal distribution. A blue bar chart perfectly approximates the curve showing the true distribution. A red bar chart representing the sample is well described by the blue trace but not exact."
    :include-source: 0
 
 
@@ -1091,7 +1091,7 @@ the individual data points on top.
 
 .. plot:: tutorial/stats/plots/kde_plot5.py
    :align: center
-   :alt: "..."
+   :alt: "An X-Y plot showing a random scattering of points around a 2-D gaussian. The distribution has a semi-major axis at 45 degrees with a semi-minor axis about half as large. Each point in the plot is highlighted with the outer region in red, then yellow, then green, with the center in blue. "
    :include-source: 0
 
 

--- a/doc/source/tutorial/stats/sampling.rst
+++ b/doc/source/tutorial/stats/sampling.rst
@@ -186,7 +186,7 @@ We can also check that the samples are drawn from the correct distribution
 by visualizing the histogram of the samples:
 
 .. plot::
-    :alt: "..."
+    :alt: "This code generates an X-Y plot with the probability distribution function of X on the Y axis and values of X on the X axis. A red trace showing the true distribution is a typical normal distribution with tails near zero at the edges and a smooth peak around the center near 0.4. A blue bar graph of random variates is shown below the red trace with a distribution similar to the truth, but with clear imperfections."
 
     >>> import matplotlib.pyplot as plt
     >>> from scipy.stats import norm

--- a/doc/source/tutorial/stats/sampling.rst
+++ b/doc/source/tutorial/stats/sampling.rst
@@ -186,6 +186,7 @@ We can also check that the samples are drawn from the correct distribution
 by visualizing the histogram of the samples:
 
 .. plot::
+    :alt: "..."
 
     >>> import matplotlib.pyplot as plt
     >>> from scipy.stats import norm

--- a/doc/source/tutorial/stats/sampling_dau.rst
+++ b/doc/source/tutorial/stats/sampling_dau.rst
@@ -57,7 +57,7 @@ method in the distribution object:
     10
 
 .. plot::
-    :alt: "..."
+    :alt: " "
 
     >>> import matplotlib.pyplot as plt
     >>> from scipy.stats.sampling import DiscreteAliasUrn

--- a/doc/source/tutorial/stats/sampling_dau.rst
+++ b/doc/source/tutorial/stats/sampling_dau.rst
@@ -57,6 +57,7 @@ method in the distribution object:
     10
 
 .. plot::
+    :alt: "..."
 
     >>> import matplotlib.pyplot as plt
     >>> from scipy.stats.sampling import DiscreteAliasUrn

--- a/doc/source/tutorial/stats/sampling_hinv.rst
+++ b/doc/source/tutorial/stats/sampling_hinv.rst
@@ -113,6 +113,7 @@ look at its histogram:
 
 .. plot:: tutorial/stats/plots/hinv_plot.py
    :align: center
+   :alt: "..."
    :include-source: 0
 
 Given the derivative of the PDF w.r.t the variate (i.e. ``x``), we can use

--- a/doc/source/tutorial/stats/sampling_hinv.rst
+++ b/doc/source/tutorial/stats/sampling_hinv.rst
@@ -113,7 +113,7 @@ look at its histogram:
 
 .. plot:: tutorial/stats/plots/hinv_plot.py
    :align: center
-   :alt: "..."
+   :alt: " "
    :include-source: 0
 
 Given the derivative of the PDF w.r.t the variate (i.e. ``x``), we can use

--- a/doc/source/tutorial/stats/sampling_pinv.rst
+++ b/doc/source/tutorial/stats/sampling_pinv.rst
@@ -119,7 +119,7 @@ We can look at the histogram of the random variates to check how well they fit
 our distribution:
 
 .. plot::
-    :alt: "..."
+    :alt: " "
 
     >>> import matplotlib.pyplot as plt
     >>> from scipy.stats import norm

--- a/doc/source/tutorial/stats/sampling_pinv.rst
+++ b/doc/source/tutorial/stats/sampling_pinv.rst
@@ -119,6 +119,7 @@ We can look at the histogram of the random variates to check how well they fit
 our distribution:
 
 .. plot::
+    :alt: "..."
 
     >>> import matplotlib.pyplot as plt
     >>> from scipy.stats import norm

--- a/doc/source/tutorial/stats/sampling_srou.rst
+++ b/doc/source/tutorial/stats/sampling_srou.rst
@@ -51,7 +51,7 @@ We can check that the samples are from the given distribution by visualizing
 its histogram:
 
 .. plot::
-    :alt: "..."
+    :alt: " "
 
     >>> from scipy.stats.sampling import SimpleRatioUniforms
     >>> from scipy.stats import norm

--- a/doc/source/tutorial/stats/sampling_srou.rst
+++ b/doc/source/tutorial/stats/sampling_srou.rst
@@ -51,6 +51,7 @@ We can check that the samples are from the given distribution by visualizing
 its histogram:
 
 .. plot::
+    :alt: "..."
 
     >>> from scipy.stats.sampling import SimpleRatioUniforms
     >>> from scipy.stats import norm


### PR DESCRIPTION
## SciPy2022 Alt-text workshop

This PR adds [alt text](https://www.w3.org/WAI/fundamentals/accessibility-intro/#examples) across multiple tutorial images. Full disclosure, there are still images in this repo in need of alt text. But this is a great start! We'll hopefully be back to address more in the future.

If you have any questions about reviewing alt text, let us know and we'd be happy to tell you what to review for.

Thanks in advance for reviewing this PR!

This alt text was contributed by wonderful volunteers at the recent [SciPy2022 alt text workshop](https://hackmd.io/bfhftUCiTRqx2S8CTGUt6g?view)! They teamed up to make this awesome PR.