### PR TITLE
BLD: fix an outdated requirement for macOS arm64 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,10 @@ requires = [
     # to be able to sync more easily with oldest-supported-numpy
     "numpy==1.19.5; python_version=='3.8' and platform_machine=='aarch64' and platform_python_implementation != 'PyPy'",
 
-    # arm64 on Darwin supports Python 3.8 and above requires numpy>=1.20.0
-    "numpy==1.20.0; python_version=='3.8' and platform_machine=='arm64' and platform_system=='Darwin'",
-    "numpy==1.20.0; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Darwin'",
+    # arm64 on Darwin supports Python 3.8 and above requires numpy>=1.21.0
+    # (first version with arm64 wheels available)
+    "numpy==1.21.0; python_version=='3.8' and platform_machine=='arm64' and platform_system=='Darwin'",
+    "numpy==1.21.0; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Darwin'",
 
     # loongarch64 requires numpy>=1.22.0
     "numpy==1.22.0; platform_machine=='loongarch64'",


### PR DESCRIPTION
NumPy 1.20 did build on macOS arm64, but there are no wheels. This change matches an earlier one made in `oldest-supported-numpy`.

[ci skip]
