### PR TITLE
BLD: fix `__STDC_VERSION__` check in `special/_round.h`

### DIFF
--- a/scipy/special/_round.h
+++ b/scipy/special/_round.h
@@ -49,8 +49,8 @@ double add_round_down(double a, double b)
 
 
 /* Helper code for testing _round.h. */
-#if __STDC_VERSION__ >= 199901L
-/* We have C99 */
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) || defined(__cplusplus)
+/* We have C99, or C++11 or higher; both have fenv.h */
 #include <fenv.h>
 #else
 


### PR DESCRIPTION
This check should always be conditional (as it is everywhere else in the code base and in the Boost submodule), because it does not have to be defined according to the C standard.

Closes gh-9213