### PR TITLE
CI: test distro Python install on Ubuntu Jammy (22.04 LTS)

### DIFF
--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -102,17 +102,11 @@ jobs:
   test_venv_install:
     name: Pip install into venv
     if: "github.repository == 'scipy/scipy' || github.repository == ''"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
-
-    - name: Setup Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.10"
-        cache-dependency-path: 'environment.yml'
 
     - name: Install Ubuntu dependencies
       run: |
@@ -120,7 +114,7 @@ jobs:
         # into a venv is working, so leave out optional dependencies. That's
         # also why we can get away with an old version of OpenBLAS from Ubuntu
         sudo apt-get update
-        sudo apt-get install -y libopenblas-dev pkg-config gfortran
+        sudo apt-get install -y python3-dev libopenblas-dev pkg-config gfortran
 
     - name: Create venv, install SciPy
       run: |


### PR DESCRIPTION
This fixes the intent (using system Python) of this CI job, which was first added in gh-16309. Builds on Debian/Ubuntu are "special", because those distros patch `distutils`/`sysconfig` in ways that are quite unhelpful. The build was broken until `meson-python` 0.6.0

We want to keep this job running to guard against regressions. It's pretty quick to run, so costs little.

Closes gh-16300