### PR TITLE
BLD: raise an error with clear message for too-new Python version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -49,6 +49,14 @@ copier = find_program(['cp', 'scipy/_build_utils/copyfiles.py'])
 # https://mesonbuild.com/Python-module.html
 py_mod = import('python')
 py3 = py_mod.find_installation()
+# SciPy 1.9.0-specific error message, see the same message in
+# `scipy/__init__.py` and gh-14986
+if py3.language_version().version_compare('>=3.12')
+  error('Your Python version is too new. SciPy 1.9 supports ' +
+        'Python 3.8-3.11; if you are trying to build from source for the ' +
+        'most recent SciPy version you may hit this error as well. Please ' +
+        'build from the `main` branch on GitHub instead.')
+endif
 py3_dep = py3.dependency()
 
 subdir('scipy')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ maintainers = [
 # Note: Python and NumPy upper version bounds should be set correctly in
 # release branches, see:
 #     https://scipy.github.io/devdocs/dev/core-dev/index.html#version-ranges-for-numpy-and-other-dependencies
-requires-python = ">=3.8,<3.12"
+requires-python = ">=3.8"
 dependencies = [
     # TODO: update to "pin-compatible" once possible, see
     # https://github.com/FFY00/meson-python/issues/29

--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -57,6 +57,19 @@ Utility tools
 
 """
 
+# Note: this patch is specific to SciPy 1.9.0; other SciPy versions will
+#       have a correct upper bound in `python_requires` in pyproject.toml
+#       (or in setup.py for SciPy 1.7.x-1.8.x).
+import sys
+if sys.version_info >= (3, 12):
+    _msg = ("Your Python version is too new. SciPy 1.9 supports "
+            "Python 3.8-3.11; if you are trying to build from source for the "
+            "most recent SciPy version you may hit this error as well. Please "
+            "build from the `main` branch on GitHub instead.")
+    raise RuntimeError(_msg)
+del sys
+
+
 from numpy import show_config as show_numpy_config
 if show_numpy_config is None:
     raise ImportError(


### PR DESCRIPTION
This works for both `python install xxx`, which gives:
```
RuntimeError: Your Python version is too new. SciPy 1.9 supports Python 3.8-3.11; if you are trying to build from source for the most recent SciPy version you may hit this error as well. Please build from the `main` branch on GitHub instead.
```
as the last line.

For installing through `meson` or `meson-python`, we get:
```
meson.build:55:2: ERROR: Problem encountered: Your Python version is too new. SciPy 1.9 supports Python 3.8-3.11; if you are trying to build from source for the most recent SciPy version you may hit this error as well. Please build from the `main` branch on GitHub instead.

A full log can be found at /home/path/to/log
Meson build setup failed! ({0} elapsed)
```

Through `pip` or `build` we get some more boilerplate at the end that is not avoidable, but the error message is still clear:
```
      Program python3 found: YES (/home/rgommers/anaconda3/envs/scipy-dev/bin/python3.10)

      ../../meson.build:55:2: ERROR: Problem encountered: Your Python version is too new. SciPy 1.9 supports Python 3.8-3.11; if you are trying to build from source for the most recent SciPy version you may hit this error as well. Please build from the `main` branch on GitHub instead.

      ...
      AttributeError: module 'mesonpy' has no attribute 'prepare_metadata_for_build_wheel'

      During handling of the above exception, another exception occurred:

          ....
          raise CalledProcessError(retcode, cmd)
      subprocess.CalledProcessError: Command '['meson', 'setup', '--native-file=/home/rgommers/code/scipy/.mesonpy-native-file.ini', '-Ddebug=true', '-Doptimization=2', '--prefix=/home/rgommers/anaconda3/envs/scipy-dev', '/home/rgommers/code/scipy', '/home/rgommers/code/scipy/.mesonpy-_3w2qa5b/build']' returned non-zero exit status 1.

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```

Closes gh-14986

Note that this patch should be reverted after SciPy 1.9.0 is released. We just need a single sdist on PyPI with this message. After that we can simply rely on the correct metadata in `pyproject.toml`.

_Note: this patch will go into `maintenance/1.9.x` after `1.9.0rc2` and before `1.9.0rc3`_