### PR TITLE
TST: add timeout to `test_kappa4_array_gh13582`

### DIFF
--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -858,6 +858,7 @@ def test_kappa3_array_gh13582():
     npt.assert_allclose(res, res2)
 
 
+@pytest.mark.timeout(120)
 def test_kappa4_array_gh13582():
     h = np.array([-0.5, 2.5, 3.5, 4.5, -3])
     k = np.array([-0.5, 1, -1.5, 0, 3.5])


### PR DESCRIPTION
Relates to #16494

This test is sometimes a problem on macOS jobs. Locally it runs bellow 10s.

Not running the CI as nothing changed.