### PR TITLE
BUG: fix `interpolate.RegularGridInterpolator` `out_of_bounds` referenced before assignment bug

### DIFF
--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -319,14 +319,17 @@ class RegularGridInterpolator:
                                       np.all(p <= self.grid[i][-1])):
                     raise ValueError("One of the requested xi is out of bounds "
                                      "in dimension %d" % i)
+            out_of_bounds = None
+        else:
+            out_of_bounds = self._find_out_of_bounds(xi.T)
 
         if method == "linear":
-            indices, norm_distances, out_of_bounds = self._find_indices(xi.T)
+            indices, norm_distances = self._find_indices(xi.T)
             result = self._evaluate_linear(indices,
                                            norm_distances,
                                            out_of_bounds)
         elif method == "nearest":
-            indices, norm_distances, out_of_bounds = self._find_indices(xi.T)
+            indices, norm_distances = self._find_indices(xi.T)
             result = self._evaluate_nearest(indices,
                                             norm_distances,
                                             out_of_bounds)
@@ -446,8 +449,6 @@ class RegularGridInterpolator:
         indices = []
         # compute distance to lower edge in unity units
         norm_distances = []
-        # check for out of bounds xi
-        out_of_bounds = np.zeros((xi.shape[1]), dtype=bool)
         # iterate through dimensions
         for x, grid in zip(xi, self.grid):
             i = np.searchsorted(grid, x) - 1
@@ -462,10 +463,16 @@ class RegularGridInterpolator:
                 norm_dist = np.where(denom != 0, (x - grid[i]) / denom, 0)
             norm_distances.append(norm_dist)
 
-            if not self.bounds_error:
-                out_of_bounds += x < grid[0]
-                out_of_bounds += x > grid[-1]
-        return indices, norm_distances, out_of_bounds
+        return indices, norm_distances
+    
+    def _find_out_of_bounds(self, xi):
+        # check for out of bounds xi
+        out_of_bounds = np.zeros((xi.shape[1]), dtype=bool)
+        # iterate through dimensions
+        for x, grid in zip(xi, self.grid):
+            out_of_bounds += x < grid[0]
+            out_of_bounds += x > grid[-1]
+        return out_of_bounds
 
 
 def interpn(points, values, xi, method="linear", bounds_error=True,

--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -464,7 +464,7 @@ class RegularGridInterpolator:
             norm_distances.append(norm_dist)
 
         return indices, norm_distances
-    
+
     def _find_out_of_bounds(self, xi):
         # check for out of bounds xi
         out_of_bounds = np.zeros((xi.shape[1]), dtype=bool)

--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -528,7 +528,7 @@ class TestRegularGridInterpolator:
         match = "must be strictly ascending or descending"
         with pytest.raises(ValueError, match=match):
             RegularGridInterpolator(points, values)
-    
+
     @parametrize_rgi_interp_methods
     def test_fill_value(self, method):
         interp = RegularGridInterpolator([np.arange(6)], np.ones(6),

--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -14,7 +14,7 @@ from scipy.interpolate import (RegularGridInterpolator, interpn,
 
 from scipy.sparse._sputils import matrix
 
-paramatize_rgi_interp_methods = pytest.mark.parametrize(
+parametrize_rgi_interp_methods = pytest.mark.parametrize(
     "method", ['linear', 'nearest', 'slinear', 'cubic', 'quintic', 'pchip']
 )
 
@@ -63,7 +63,7 @@ class TestRegularGridInterpolator:
         values = (values0 + values1 * 10 + values2 * 100 + values3 * 1000)
         return points, values
 
-    @paramatize_rgi_interp_methods
+    @parametrize_rgi_interp_methods
     def test_list_input(self, method):
         points, values = self._get_sample_4d_3()
 
@@ -115,7 +115,7 @@ class TestRegularGridInterpolator:
         v2 = interp(sample)
         assert_allclose(v1, v2)
 
-    @paramatize_rgi_interp_methods
+    @parametrize_rgi_interp_methods
     def test_complex(self, method):
         points, values = self._get_sample_4d_3()
         values = values - 2j*values
@@ -528,6 +528,12 @@ class TestRegularGridInterpolator:
         match = "must be strictly ascending or descending"
         with pytest.raises(ValueError, match=match):
             RegularGridInterpolator(points, values)
+    
+    @parametrize_rgi_interp_methods
+    def test_fill_value(self, method):
+        interp = RegularGridInterpolator([np.arange(6)], np.ones(6),
+                                         method=method, bounds_error=False)
+        assert np.isnan(interp([10]))
 
 
 class MyValue:

--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -14,6 +14,9 @@ from scipy.interpolate import (RegularGridInterpolator, interpn,
 
 from scipy.sparse._sputils import matrix
 
+paramatize_rgi_interp_methods = pytest.mark.parametrize(
+    "method", ['linear', 'nearest', 'slinear', 'cubic', 'quintic', 'pchip']
+)
 
 class TestRegularGridInterpolator:
     def _get_sample_4d(self):
@@ -60,23 +63,22 @@ class TestRegularGridInterpolator:
         values = (values0 + values1 * 10 + values2 * 100 + values3 * 1000)
         return points, values
 
-    def test_list_input(self):
+    @paramatize_rgi_interp_methods
+    def test_list_input(self, method):
         points, values = self._get_sample_4d_3()
 
         sample = np.asarray([[0.1, 0.1, 1., .9], [0.2, 0.1, .45, .8],
                              [0.5, 0.5, .5, .5]])
 
-        for method in ['linear', 'nearest',
-                       'slinear', 'cubic', 'quintic', 'pchip']:
-            interp = RegularGridInterpolator(points,
-                                             values.tolist(),
-                                             method=method)
-            v1 = interp(sample.tolist())
-            interp = RegularGridInterpolator(points,
-                                             values,
-                                             method=method)
-            v2 = interp(sample)
-            assert_allclose(v1, v2)
+        interp = RegularGridInterpolator(points,
+                                         values.tolist(),
+                                         method=method)
+        v1 = interp(sample.tolist())
+        interp = RegularGridInterpolator(points,
+                                         values,
+                                         method=method)
+        v2 = interp(sample)
+        assert_allclose(v1, v2)
 
     def test_spline_dim_error(self):
         points, values = self._get_sample_4d_4()
@@ -113,24 +115,20 @@ class TestRegularGridInterpolator:
         v2 = interp(sample)
         assert_allclose(v1, v2)
 
-    def test_complex(self):
+    @paramatize_rgi_interp_methods
+    def test_complex(self, method):
         points, values = self._get_sample_4d_3()
         values = values - 2j*values
         sample = np.asarray([[0.1, 0.1, 1., .9], [0.2, 0.1, .45, .8],
                              [0.5, 0.5, .5, .5]])
 
-        for method in ['linear', 'nearest',
-                       'slinear', 'cubic', 'quintic', 'pchip']:
-            interp = RegularGridInterpolator(points, values,
-                                             method=method)
-            rinterp = RegularGridInterpolator(points, values.real,
-                                              method=method)
-            iinterp = RegularGridInterpolator(points, values.imag,
-                                              method=method)
+        interp = RegularGridInterpolator(points, values, method=method)
+        rinterp = RegularGridInterpolator(points, values.real, method=method)
+        iinterp = RegularGridInterpolator(points, values.imag, method=method)
 
-            v1 = interp(sample)
-            v2 = rinterp(sample) + 1j*iinterp(sample)
-            assert_allclose(v1, v2)
+        v1 = interp(sample)
+        v2 = rinterp(sample) + 1j*iinterp(sample)
+        assert_allclose(v1, v2)
 
     def test_cubic_vs_pchip(self):
         x, y = [1, 2, 3, 4], [1, 2, 3, 4]


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
In debugging #16508 a bug was found where when `bounds_error` was false and try to extrapolate  `out_of_bounds` was referenced before assignment. This was caused by this snippet:
https://github.com/scipy/scipy/blob/a60206b29d548a6543d75ac95558d52492d3ecaf/scipy/interpolate/_rgi.py#L323-L339
Have fixed the bug and added a test.
#### Additional information
<!--Any additional information you think is important.-->
Also parameterised some of the tests which used the same parameterisation as the new test.