### PR TITLE
ENH: adding a logpdf function to von-mises distribution 

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -8994,8 +8994,8 @@ class vonmises_gen(rv_continuous):
         return np.exp(kappa*sc.cosm1(x)) / (2*np.pi*sc.i0e(kappa))
 
     def _logpdf(self, x, kappa):
-        # vonmises.pdf(x, kappa) = exp(kappa * cos(x)) / (2*pi*I[0](kappa))
-        return kappa * np.cos(x) - np.log(2*np.pi) - np.log(sc.i0(kappa))
+        # vonmises.pdf(x, kappa) = exp(kappa * cosm1(x)) / (2*pi*i0e(kappa))
+        return kappa * sc.cosm1(x) - np.log(2*np.pi) - np.log(sc.i0e(kappa))
 
     def _cdf(self, x, kappa):
         return _stats.von_mises_cdf(kappa, x)

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -8993,6 +8993,10 @@ class vonmises_gen(rv_continuous):
         #                        = exp(kappa * cosm1(x)) / (2*pi*i0e(kappa))
         return np.exp(kappa*sc.cosm1(x)) / (2*np.pi*sc.i0e(kappa))
 
+    def _logpdf(self, x, kappa):
+        # vonmises.pdf(x, kappa) = exp(kappa * cos(x)) / (2*pi*I[0](kappa))
+        return kappa * np.cos(x) - np.log(2*np.pi) - np.log(sc.i0(kappa))
+
     def _cdf(self, x, kappa):
         return _stats.von_mises_cdf(kappa, x)
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -137,11 +137,10 @@ def test_vonmises_pdf(x, kappa, expected_pdf):
 @pytest.mark.parametrize('x, kappa, expected_logpdf',
                          [(0.1, 0.01, -1.8279520246003170),
                           (0.1, 25.0, 0.5604990605420549),
-                          (0.1, 800, -1.5734679473375139),
+                          (0.1, 800, -1.5734567947337514),
                           (2.0, 0.01, -1.8420635346185686),
                           (2.0, 25.0, -34.7182759850871489),
                           (2.0, 800, -1130.4942582548682739)])
-
 def test_vonmises_logpdf(x, kappa, expected_logpdf):
     logpdf = stats.vonmises.logpdf(x, kappa)
     assert_allclose(logpdf, expected_logpdf, rtol=1e-15)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -131,6 +131,7 @@ def test_vonmises_pdf(x, kappa, expected_pdf):
     pdf = stats.vonmises.pdf(x, kappa)
     assert_allclose(pdf, expected_pdf, rtol=1e-15)
 
+
 # Expected values of the vonmises LOGPDF were computed
 # using wolfram alpha:
 # kappa * cos(x) - log(2*pi*I0(kappa))

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -119,7 +119,7 @@ def test_vonmises_numerical():
 #     num = mpmath.exp(kappa*mpmath.cos(x))
 #     den = 2 * mpmath.pi * mpmath.besseli(0, kappa)
 #     return num/den
-#
+
 @pytest.mark.parametrize('x, kappa, expected_pdf',
                          [(0.1, 0.01, 0.16074242744907072),
                           (0.1, 25.0, 1.7515464099118245),
@@ -127,10 +127,25 @@ def test_vonmises_numerical():
                           (2.0, 0.01, 0.15849003875385817),
                           (2.0, 25.0, 8.356882934278192e-16),
                           (2.0, 800, 0.0)])
+
 def test_vonmises_pdf(x, kappa, expected_pdf):
     pdf = stats.vonmises.pdf(x, kappa)
     assert_allclose(pdf, expected_pdf, rtol=1e-15)
 
+# Expected values of the vonmises LOGPDF were computed
+# using wolfram alpha:
+# kappa * cos(x) - log(2*pi*I0(kappa))
+@pytest.mark.parametrize('x, kappa, expected_logpdf',
+                         [(0.1, 0.01, -1.82795),
+                          (0.1, 25.0, 0.560499),
+                          (0.1, 800, -1.57346),
+                          (2.0, 0.01, -1.84206),
+                          (2.0, 25.0, -34.718276),
+                          (2.0, 800, -1130.494258)])
+
+def test_vonmises_logpdf(x, kappa, expected_logpdf):
+    logpdf = stats.vonmises.logpdf(x, kappa)
+    assert_allclose(logpdf, expected_logpdf, rtol=1e-5)
 
 def _assert_less_or_close_loglike(dist, data, func, **kwds):
     """

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -145,7 +145,7 @@ def test_vonmises_pdf(x, kappa, expected_pdf):
 
 def test_vonmises_logpdf(x, kappa, expected_logpdf):
     logpdf = stats.vonmises.logpdf(x, kappa)
-    assert_allclose(logpdf, expected_logpdf, rtol=1e-5)
+    assert_allclose(logpdf, expected_logpdf, rtol=1e-15)
 
 def _assert_less_or_close_loglike(dist, data, func, **kwds):
     """

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -142,7 +142,6 @@ def test_vonmises_pdf(x, kappa, expected_pdf):
                           (2.0, 0.01, -1.84206),
                           (2.0, 25.0, -34.718276),
                           (2.0, 800, -1130.494258)])
-
 def test_vonmises_logpdf(x, kappa, expected_logpdf):
     logpdf = stats.vonmises.logpdf(x, kappa)
     assert_allclose(logpdf, expected_logpdf, rtol=1e-5)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -136,12 +136,12 @@ def test_vonmises_pdf(x, kappa, expected_pdf):
 # using wolfram alpha:
 # kappa * cos(x) - log(2*pi*I0(kappa))
 @pytest.mark.parametrize('x, kappa, expected_logpdf',
-                         [(0.1, 0.01, -1.82795),
-                          (0.1, 25.0, 0.560499),
-                          (0.1, 800, -1.57346),
-                          (2.0, 0.01, -1.84206),
-                          (2.0, 25.0, -34.718276),
-                          (2.0, 800, -1130.494258)])
+                         [(0.1, 0.01, -1.8279520246003170),
+                          (0.1, 25.0, 0.5604990605420549),
+                          (0.1, 800, -1.5734679473375139),
+                          (2.0, 0.01, -1.8420635346185686),
+                          (2.0, 25.0, -34.7182759850871489),
+                          (2.0, 800, -1130.4942582548682739)])
 
 def test_vonmises_logpdf(x, kappa, expected_logpdf):
     logpdf = stats.vonmises.logpdf(x, kappa)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -127,7 +127,6 @@ def test_vonmises_numerical():
                           (2.0, 0.01, 0.15849003875385817),
                           (2.0, 25.0, 8.356882934278192e-16),
                           (2.0, 800, 0.0)])
-
 def test_vonmises_pdf(x, kappa, expected_pdf):
     pdf = stats.vonmises.pdf(x, kappa)
     assert_allclose(pdf, expected_pdf, rtol=1e-15)


### PR DESCRIPTION
In the current implementation of von-mises distribution, only pdf is defined. So presumably logpdf first calls pdf and applies logarithm on it. One issue is that when Kappa (concentration) is big, for values close to pi, pdf may return 0 due to numerical error while the true value should be a small non-zero value. This causes logpdf to return -inf. 
This PR adds a logpdf function which directly calculates logpdf without first calling pdf. It expands the range of Kappa values for which logpdf can still return a finite number. For example, `pdf` returns 0 for `scipy.stats.vonmises.pdf(np.pi,kappa=400)`, but the newly defined `logpdf` can still return a finite number for `scipy.stats.vonmises.logpdf(np.pi,kappa=700)`. It will still go to -inf when kappa is set to 800, because `scipy.special.i0` would return infinite number. A future improvement would be defining a logi0 function if its formula is available, but I don't know the formula for that.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
