### PR TITLE
BUG: optimize: Fix differential_evolution error message.

### DIFF
--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -1086,8 +1086,8 @@ class DifferentialEvolutionSolver:
             if DE_result.maxcv > 0:
                 # if the result is infeasible then success must be False
                 DE_result.success = False
-                DE_result.message = ("The solution does not satisfy the"
-                                    " constraints, MAXCV = " % DE_result.maxcv)
+                DE_result.message = ("The solution does not satisfy the "
+                                     f"constraints, MAXCV = {DE_result.maxcv}")
 
         return DE_result
 


### PR DESCRIPTION
When DifferentialEvolutionSolver.solve() gets to the end of its
calculation and discovers that the constraints are not satisfied, it
sets the `success` attribute of the result to False and assigns a
string to the `message` attribute.  The code that generated the
message had a bug; in fact, it *should* have raised an exception if
it ever ran, but apparently the differential evolution code catches
and ignores such exceptions (a strange behavior that hides bugs like
this one).
