### PR TITLE
[DOC] improper type syntax in basinhopping docstring.

### DIFF
--- a/scipy/optimize/_basinhopping.py
+++ b/scipy/optimize/_basinhopping.py
@@ -422,8 +422,7 @@ def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
     niter_success : integer, optional
         Stop the run if the global minimum candidate remains the same for this
         number of iterations.
-    seed : {None, int, `numpy.random.Generator`,
-            `numpy.random.RandomState`}, optional
+    seed : {None, int, `numpy.random.Generator`, `numpy.random.RandomState`}, optional
 
         If `seed` is None (or `np.random`), the `numpy.random.RandomState`
         singleton is used.
@@ -491,13 +490,13 @@ def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
     This global minimization method has been shown to be extremely efficient
     for a wide variety of problems in physics and chemistry. It is
     particularly useful when the function has many minima separated by large
-    barriers. See the Cambridge Cluster Database
-    http://www-wales.ch.cam.ac.uk/CCD.html for databases of molecular systems
-    that have been optimized primarily using basin-hopping. This database
-    includes minimization problems exceeding 300 degrees of freedom.
+    barriers. See the `Cambridge Cluster Database
+    <https://www-wales.ch.cam.ac.uk/CCD.html>`_ for databases of molecular
+    systems that have been optimized primarily using basin-hopping. This
+    database includes minimization problems exceeding 300 degrees of freedom.
 
-    See the free software program GMIN (http://www-wales.ch.cam.ac.uk/GMIN) for
-    a Fortran implementation of basin-hopping. This implementation has many
+    See the free software program `GMIN <https://www-wales.ch.cam.ac.uk/GMIN>`_
+    for a Fortran implementation of basin-hopping. This implementation has many
     different variations of the procedure described above, including more
     advanced step taking algorithms and alternate acceptance criterion.
 


### PR DESCRIPTION
from the current generated docs in https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.basinhopping.html
it looks like the type must be one line, or the second line get
interpreted as a blockquote that appear as the first line in description
of this parameter.

Use this opportunity to https-ify url (after checking they work over
https) and make them real links

[ci skip]
[skip azp]
[skip action]

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->
