### PR TITLE
MAINT: update bundled licenses for removal of scipy-sphinx-theme

### DIFF
--- a/LICENSES_bundled.txt
+++ b/LICENSES_bundled.txt
@@ -1,10 +1,9 @@
+
+----
+
 The SciPy repository and source distributions bundle a number of libraries that
 are compatibly licensed.  We list these here.
 
-Name: scipy-sphinx-theme
-Files: doc/scipy-sphinx-theme/*
-License: 3-clause BSD, PSF and Apache 2.0
-  For details, see doc/sphinxext/LICENSE.txt
 
 Name: Decorator
 Files: scipy/_lib/decorator.py


### PR DESCRIPTION
Also add a formatting tweak to make it easier to append license files (it's now the same for `LICENSES_bundled.txt` as for
`LICENSE_<os-name>.txt` in the scipy-wheels repo.

[ci skip]