### PR TITLE
MAINT: stats: fix skew/kurtosis empty 1d input

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -1156,18 +1156,6 @@ def moment(a, moment=1, axis=0, nan_policy='propagate'):
         a = ma.masked_invalid(a)
         return mstats_basic.moment(a, moment, axis)
 
-    if a.size == 0:
-        moment_shape = list(a.shape)
-        del moment_shape[axis]
-        dtype = a.dtype.type if a.dtype.kind in 'fc' else np.float64
-        # empty array, return nan(s) with shape matching `moment`
-        out_shape = (moment_shape if np.isscalar(moment)
-                     else [len(moment)] + moment_shape)
-        if len(out_shape) == 0:
-            return dtype(np.nan)
-        else:
-            return np.full(out_shape, np.nan, dtype=dtype)
-
     # for array_like moment input, return a value for each.
     if not np.isscalar(moment):
         mean = a.mean(axis, keepdims=True)
@@ -1181,6 +1169,10 @@ def moment(a, moment=1, axis=0, nan_policy='propagate'):
 def _moment(a, moment, axis, *, mean=None):
     if np.abs(moment - np.round(moment)) > 0:
         raise ValueError("All moment parameters must be integers")
+
+    # moment of empty array is the same regardless of order
+    if a.size == 0:
+        return np.mean(a, axis=axis)
 
     if moment == 0 or moment == 1:
         # By definition the zeroth moment about the mean is 1, and the first

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2945,16 +2945,18 @@ class TestMoments:
         assert_allclose(y, [0, 1.25, 0, 2.5625])
 
         # test empty input
-        y = stats.moment([])
-        self._assert_equal(y, np.nan, dtype=np.float64)
-        y = stats.moment(np.array([], dtype=np.float32))
-        self._assert_equal(y, np.nan, dtype=np.float32)
-        y = stats.moment(np.zeros((1, 0)), axis=0)
-        self._assert_equal(y, [], shape=(0,), dtype=np.float64)
-        y = stats.moment([[]], axis=1)
-        self._assert_equal(y, np.nan, shape=(1,), dtype=np.float64)
-        y = stats.moment([[]], moment=[0, 1], axis=0)
-        self._assert_equal(y, [], shape=(2, 0))
+        message = "Mean of empty slice."
+        with pytest.warns(RuntimeWarning, match=message):
+            y = stats.moment([])
+            self._assert_equal(y, np.nan, dtype=np.float64)
+            y = stats.moment(np.array([], dtype=np.float32))
+            self._assert_equal(y, np.nan, dtype=np.float32)
+            y = stats.moment(np.zeros((1, 0)), axis=0)
+            self._assert_equal(y, [], shape=(0,), dtype=np.float64)
+            y = stats.moment([[]], axis=1)
+            self._assert_equal(y, np.nan, shape=(1,), dtype=np.float64)
+            y = stats.moment([[]], moment=[0, 1], axis=0)
+            self._assert_equal(y, [], shape=(2, 0))
 
         x = np.arange(10.)
         x[9] = np.nan
@@ -3110,6 +3112,13 @@ class TestMoments:
             a = rng.random(size=(100, 10))
             a[:, 0] = 1.01
             stats.skew(a)[0]
+
+    def test_empty_1d(self):
+        message = "Mean of empty slice."
+        with pytest.warns(RuntimeWarning, match=message):
+            stats.skew([])
+        with pytest.warns(RuntimeWarning, match=message):
+            stats.kurtosis([])
 
 
 class TestStudentTest:


### PR DESCRIPTION
#### Reference issue
gh-15905

#### What does this implement/fix?
Currently in `main`:
```python3
stats.skew([])  # kurtosis, too
```
produces an ugly error.

<details>

```
C:\Users\matth\Desktop\scipy\scipy\stats\_stats_py.py:1336: RuntimeWarning: Mean of empty slice.
  np.place(vals, can_correct, nval)
Traceback (most recent call last):

  File "C:\Users\matth\AppData\Local\Temp\ipykernel_2528\930322391.py", line 1, in <module>
    stats.skew([])

  File "C:\Users\matth\Desktop\scipy\scipy\stats\_axis_nan_policy.py", line 491, in axis_nan_policy_wrapper
    res = hypotest_fun_out(*samples, **kwds)

  File "C:\Users\matth\Desktop\scipy\scipy\stats\_stats_py.py", line 1337, in skew
    vals = np.where(zero, np.nan, m3 / m2**1.5)

  File "C:\Users\matth\Desktop\scipy\scipy\stats\_stats_py.py", line 1214, in _moment
    rel_diff = np.max(np.abs(a_zero_mean), axis=axis,

  File "<__array_function__ internals>", line 5, in amax

  File "C:\Users\matth\Miniconda3\envs\scipydev\lib\site-packages\numpy\core\fromnumeric.py", line 2754, in amax
    return _wrapreduction(a, np.maximum, 'max', axis, None, out,

  File "C:\Users\matth\Miniconda3\envs\scipydev\lib\site-packages\numpy\core\fromnumeric.py", line 86, in _wrapreduction
    return ufunc.reduce(obj, axis, dtype, out, **passkwargs)

ValueError: zero-size array to reduction operation maximum which has no identity
```

</details>

Instead, `skew` and `kurtosis` should behave exactly like `np.mean` when the input is empty. This PR makes that happen.

#### Additional information
Without this PR, this would be a regression in 1.9.0 caused by gh-15905, hence the backport candidate label @tylerjereddy. I understand if it's too late, though.