### PR TITLE
MAINT: stats.truncnorm: improve CDF accuracy/speed

### DIFF
--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1009,6 +1009,16 @@ class TestTruncnorm:
             assert_almost_equal(stats.truncnorm.pdf(xvals, low, high),
                                 stats.truncnorm.pdf(xvals2, -high, -low)[::-1])
 
+    def test_cdf_tail_15110_14753(self):
+        # Check accuracy issues reported in gh-14753 and gh-155110
+        # Ground truth values calculated using Wolfram Alpha, e.g.
+        # (CDF[NormalDistribution[0,1],83/10]-CDF[NormalDistribution[0,1],8])/
+        #     (1 - CDF[NormalDistribution[0,1],8])
+        assert_allclose(stats.truncnorm(13., 15.).cdf(14.),
+                        0.9999987259565643)
+        assert_allclose(stats.truncnorm(8, np.inf).cdf(8.3),
+                        0.9163220907327540)
+
     def _test_moments_one_range(self, a, b, expected, rtol=1e-7):
         m0, v0, s0, k0 = expected[:4]
         m, v, s, k = stats.truncnorm.stats(a, b, moments='mvsk')


### PR DESCRIPTION
#### Reference issue
closes gh-15110
closes gh-14753
closes gh-12733

#### What does this implement/fix?
There were several open issues about `truncnorm.cdf` accuracy and speed. This resolves them by replacing the `_logcdf` implementation. It uses the definition of the truncnorm CDF $\frac{\Phi(x) - \Phi(a)}{\Phi(b)- \Phi(a)}$ with a few tricks:

- `logsumexp` to compute $\log(x + y)$ from $\log(x)$ and $\log(y)$
- compute $\log(x - y)$ from $\log(x)$ and $\log(y)$ using the `logsumexp` and $-\exp(y) = \exp(y + \pi i)$
- doing all the calculations in the left tail (exploiting symmetry)

#### Additional information
The `_log_gauss_mass` function could be used to implement many of the other methods. I think this includes `ppf` (using `ndtri_exp`), which might make it speedy enough for the default inverse transform sampling `rvs`. I'd be happy to work on those as a followup. It's possible that other truncated distributions could benefit from the same idea.