### PR TITLE
DOC: add import NumPy in QMC examples.

### DIFF
--- a/scipy/stats/_kde.py
+++ b/scipy/stats/_kde.py
@@ -155,6 +155,7 @@ class gaussian_kde:
     --------
     Generate some random two-dimensional data:
 
+    >>> import numpy as np
     >>> from scipy import stats
     >>> def measure(n):
     ...     "Measurement model, return two coupled measurements."

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -261,6 +261,7 @@ def discrepancy(
     --------
     Calculate the quality of the sample using the discrepancy:
 
+    >>> import numpy as np
     >>> from scipy.stats import qmc
     >>> space = np.array([[1, 3], [2, 6], [3, 2], [4, 5], [5, 1], [6, 4]])
     >>> l_bounds = [0.5, 0.5]
@@ -336,6 +337,7 @@ def update_discrepancy(
     We can also compute iteratively the discrepancy by using
     ``iterative=True``.
 
+    >>> import numpy as np
     >>> from scipy.stats import qmc
     >>> space = np.array([[1, 3], [2, 6], [3, 2], [4, 5], [5, 1], [6, 4]])
     >>> l_bounds = [0.5, 0.5]
@@ -1677,6 +1679,7 @@ class PoissonDisk(QMCEngine):
     --------
     Generate a 2D sample using a `radius` of 0.2.
 
+    >>> import numpy as np
     >>> import matplotlib.pyplot as plt
     >>> from matplotlib.collections import PatchCollection
     >>> from scipy.stats import qmc
@@ -2397,6 +2400,7 @@ def _lloyd_centroidal_voronoi_tessellation(
 
     Examples
     --------
+    >>> import numpy as np
     >>> from scipy.spatial import distance
     >>> rng = np.random.default_rng()
     >>> sample = rng.random((128, 2))

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -1127,7 +1127,6 @@ class LatinHypercube(QMCEngine):
     --------
     Generate samples from a Latin hypercube generator.
 
-    >>> import numpy as np
     >>> from scipy.stats import qmc
     >>> sampler = qmc.LatinHypercube(d=2)
     >>> sample = sampler.random(n=5)
@@ -2404,7 +2403,6 @@ def _lloyd_centroidal_voronoi_tessellation(
     >>> import numpy as np
     >>> from scipy.spatial import distance
     >>> rng = np.random.default_rng()
-    >>> import numpy as np
     >>> sample = rng.random((128, 2))
 
     .. note::

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -1127,6 +1127,7 @@ class LatinHypercube(QMCEngine):
     --------
     Generate samples from a Latin hypercube generator.
 
+    >>> import numpy as np
     >>> from scipy.stats import qmc
     >>> sampler = qmc.LatinHypercube(d=2)
     >>> sample = sampler.random(n=5)
@@ -1679,7 +1680,7 @@ class PoissonDisk(QMCEngine):
     --------
     Generate a 2D sample using a `radius` of 0.2.
 
-    >>> import numpy as np
+    >>> import numpy
     >>> import matplotlib.pyplot as plt
     >>> from matplotlib.collections import PatchCollection
     >>> from scipy.stats import qmc
@@ -2403,6 +2404,7 @@ def _lloyd_centroidal_voronoi_tessellation(
     >>> import numpy as np
     >>> from scipy.spatial import distance
     >>> rng = np.random.default_rng()
+    >>> import numpy as np
     >>> sample = rng.random((128, 2))
 
     .. note::

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -1679,7 +1679,7 @@ class PoissonDisk(QMCEngine):
     --------
     Generate a 2D sample using a `radius` of 0.2.
 
-    >>> import numpy
+    >>> import numpy as np
     >>> import matplotlib.pyplot as plt
     >>> from matplotlib.collections import PatchCollection
     >>> from scipy.stats import qmc


### PR DESCRIPTION
Relates to #13049

## Example PR for SciPy2022 sprint on July 16th-17th

We want our examples to be self-contained. Most of our examples are missing `import numpy as np`.

Look for a single file which contains examples with missing imports and add at the top of the example section the missing imports.

_Extra:_
Take some time to properly name your PR, describe it. You commit message is also very important. E.g. think about our CI: adding `[skip actions] [skip azp]` would help save resources.

I made some deliberate mistakes to show how a review happens and what to expect.

Happy contributing!!!