### PR TITLE
MAINT: stats.vonmises: wrap rvs to -pi, pi interval

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -8986,6 +8986,10 @@ class vonmises_gen(rv_continuous):
     def _rvs(self, kappa, size=None, random_state=None):
         return random_state.vonmises(0.0, kappa, size=size)
 
+    def rvs(self, *args, **kwds):
+        rvs = super().rvs(*args, **kwds)
+        return np.mod(rvs + np.pi, 2*np.pi) - np.pi
+
     def _pdf(self, x, kappa):
         # vonmises.pdf(x, kappa) = exp(kappa * cos(x)) / (2*pi*I[0](kappa))
         #                        = exp(kappa * (cos(x) - 1)) /

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -9025,6 +9025,7 @@ class vonmises_gen(rv_continuous):
     def _rvs(self, kappa, size=None, random_state=None):
         return random_state.vonmises(0.0, kappa, size=size)
 
+    @inherit_docstring_from(rv_continuous)
     def rvs(self, *args, **kwds):
         rvs = super().rvs(*args, **kwds)
         return np.mod(rvs + np.pi, 2*np.pi) - np.pi

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -132,6 +132,20 @@ def test_vonmises_pdf(x, kappa, expected_pdf):
     assert_allclose(pdf, expected_pdf, rtol=1e-15)
 
 
+def test_vonmises_rvs_gh4598():
+    # check that random variates wrap around as discussed in gh-4598
+    seed = abs(hash('von_mises_rvs'))
+    rng1 = np.random.default_rng(seed)
+    rng2 = np.random.default_rng(seed)
+    rng3 = np.random.default_rng(seed)
+    rvs1 = stats.vonmises(1, loc=0, scale=1).rvs(random_state=rng1)
+    rvs2 = stats.vonmises(1, loc=2*np.pi, scale=1).rvs(random_state=rng2)
+    rvs3 = stats.vonmises(1, loc=0,
+                          scale=(2*np.pi/rvs1+1)).rvs(random_state=rng3)
+    assert_allclose(rvs1, rvs2, atol=1e-15)
+    assert_allclose(rvs1, rvs3, atol=1e-15)
+
+
 def _assert_less_or_close_loglike(dist, data, func, **kwds):
     """
     This utility function checks that the log-likelihood (computed by

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -141,7 +141,7 @@ def test_vonmises_rvs_gh4598():
     rvs1 = stats.vonmises(1, loc=0, scale=1).rvs(random_state=rng1)
     rvs2 = stats.vonmises(1, loc=2*np.pi, scale=1).rvs(random_state=rng2)
     rvs3 = stats.vonmises(1, loc=0,
-                          scale=(2*np.pi/rvs1+1)).rvs(random_state=rng3)
+                          scale=(2*np.pi/abs(rvs1)+1)).rvs(random_state=rng3)
     assert_allclose(rvs1, rvs2, atol=1e-15)
     assert_allclose(rvs1, rvs3, atol=1e-15)
 


### PR DESCRIPTION
#### Reference issue
Removes defect label from gh-4598

#### What does this implement/fix?
The distribution interface does not have proper support for circular distributions, so `vonmises` can produce random variates beyond the standard $[-\pi, \pi]$ interval when `loc != 0` or `scale > 1`. This PR wraps the random variates produced by `vonmises` to the standard interval. We still need a proper circular distribution infrastructure (tracked in gh-15928), but let's fix this bug in the meantime.

#### Additional information
I don't really think there are backward compatibility concerns. It wouldn't make much sense for a user's code to rely on the random variates to go beyond the standard interval. Also, if a user's code wraps the random variates to the standard interval, it would just become redundant.

~~If desired, it would also be very easy to wrap input `x` to the standard interval inside methods like `_pdf` so that PDF/CDF/RVS would be consistent for `scale=1`.
![image](https://user-images.githubusercontent.com/6570539/178642065-1315a549-da06-45e2-a5c2-d774453e3923.png)~~

~~It still wouldn't be meaningful for `scale != 1 `, but that's no worse than things are now.  (And isn't `kappa` the more familiar scale parameter anyway?) Since it's pretty simple, I think a partial fix is better than nothing.~~ PDF already behaves like this; I misunderstood.
