### PR TITLE
ENH: stats.nct: replace with boost implementation

### DIFF
--- a/scipy/stats/_boost/__init__.py
+++ b/scipy/stats/_boost/__init__.py
@@ -27,3 +27,9 @@ from scipy.stats._boost.ncf_ufunc import (
     _ncf_isf, _ncf_mean, _ncf_variance,
     _ncf_skewness, _ncf_kurtosis_excess,
 )
+
+from scipy.stats._boost.nct_ufunc import (
+    _nct_pdf, _nct_cdf, _nct_sf, _nct_ppf,
+    _nct_isf, _nct_mean, _nct_variance,
+    _nct_skewness, _nct_kurtosis_excess,
+)

--- a/scipy/stats/_boost/include/_info.py
+++ b/scipy/stats/_boost/include/_info.py
@@ -14,6 +14,7 @@ _klass_mapper = {
     'negative_binomial': _KlassMap('nbinom', ('n', 'p')),
     'hypergeometric': _KlassMap('hypergeom', ('r', 'n', 'N')),
     'non_central_f': _KlassMap('ncf', ('dfn', 'dfd', 'nc')),
+    'non_central_t': _KlassMap('nct', ('df', 'nc')),
 }
 
 # functions that take ctor params and parameter "x"

--- a/scipy/stats/_boost/meson.build
+++ b/scipy/stats/_boost/meson.build
@@ -57,6 +57,15 @@ ncf_ufunc = py3.extension_module('ncf_ufunc',
   subdir: 'scipy/stats/_boost'
 )
 
+ncf_ufunc = py3.extension_module('nct_ufunc',
+  nct_ufunc_pyx,
+  include_directories: [include, inc_np, inc_boost],
+  cpp_args: [cpp_args, cython_cpp_args],
+  dependencies: [py3_dep],
+  install: true,
+  subdir: 'scipy/stats/_boost'
+)
+
 py3.install_sources([
     '__init__.py'
   ],

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -6507,60 +6507,25 @@ class nct_gen(rv_continuous):
         return n * np.sqrt(df) / np.sqrt(c2)
 
     def _pdf(self, x, df, nc):
-        n = df*1.0
-        nc = nc*1.0
-        x2 = x*x
-        ncx2 = nc*nc*x2
-        fac1 = n + x2
-        trm1 = (n/2.*np.log(n) + sc.gammaln(n+1)
-                - (n*np.log(2) + nc*nc/2 + (n/2)*np.log(fac1)
-                   + sc.gammaln(n/2)))
-        Px = np.exp(trm1)
-        valF = ncx2 / (2*fac1)
-        trm1 = (np.sqrt(2)*nc*x*sc.hyp1f1(n/2+1, 1.5, valF)
-                / np.asarray(fac1*sc.gamma((n+1)/2)))
-        trm2 = (sc.hyp1f1((n+1)/2, 0.5, valF)
-                / np.asarray(np.sqrt(fac1)*sc.gamma(n/2+1)))
-        Px *= trm1+trm2
-        return Px
+        return np.clip(_boost._nct_pdf(x, df, nc), 0, None)
 
     def _cdf(self, x, df, nc):
-        return sc.nctdtr(df, nc, x)
+        return np.clip(_boost._nct_cdf(x, df, nc), 0, 1)
 
     def _ppf(self, q, df, nc):
-        return sc.nctdtrit(df, nc, q)
+        return _boost._nct_ppf(q, df, nc)
+
+    def _sf(self, x, df, nc):
+        return np.clip(_boost._nct_sf(x, df, nc), 0, 1)
+
+    def _isf(self, x, df, nc):
+        return _boost._nct_isf(x, df, nc)
 
     def _stats(self, df, nc, moments='mv'):
-        #
-        # See D. Hogben, R.S. Pinkham, and M.B. Wilk,
-        # 'The moments of the non-central t-distribution'
-        # Biometrika 48, p. 465 (2961).
-        # e.g. https://www.jstor.org/stable/2332772 (gated)
-        #
-        mu, mu2, g1, g2 = None, None, None, None
-
-        gfac = np.exp(sc.betaln(df/2-0.5, 0.5) - sc.gammaln(0.5))
-        c11 = np.sqrt(df/2.) * gfac
-        c20 = np.where(df > 2., df / (df-2.), np.nan)
-        c22 = c20 - c11*c11
-        mu = np.where(df > 1, nc*c11, np.nan)
-        mu2 = np.where(df > 2, c22*nc*nc + c20, np.nan)
-        if 's' in moments:
-            c33t = df * (7.-2.*df) / (df-2.) / (df-3.) + 2.*c11*c11
-            c31t = 3.*df / (df-2.) / (df-3.)
-            mu3 = (c33t*nc*nc + c31t) * c11*nc
-            g1 = np.where(df > 3, mu3 / np.power(mu2, 1.5), np.nan)
-        # kurtosis
-        if 'k' in moments:
-            c44 = df*df / (df-2.) / (df-4.)
-            c44 -= c11*c11 * 2.*df*(5.-df) / (df-2.) / (df-3.)
-            c44 -= 3.*c11**4
-            c42 = df / (df-4.) - c11*c11 * (df-1.) / (df-3.)
-            c42 *= 6.*df / (df-2.)
-            c40 = 3.*df*df / (df-2.) / (df-4.)
-
-            mu4 = c44 * nc**4 + c42*nc**2 + c40
-            g2 = np.where(df > 4, mu4/mu2**2 - 3., np.nan)
+        mu = _boost._nct_mean(df, nc)
+        mu2 = _boost._nct_variance(df, nc)
+        g1 = _boost._nct_skewness(df, nc) if 's' in moments else None
+        g2 = _boost._nct_kurtosis_excess(df, nc) if 'k' in moments else None
         return mu, mu2, g1, g2
 
 

--- a/scipy/stats/meson.build
+++ b/scipy/stats/meson.build
@@ -120,7 +120,8 @@ _stats_gen_pyx = custom_target('_stats_gen_pyx',
     'nbinom_ufunc.pyx',  # 5 (S_B)
     'templated_pyufunc.pxd',  # 6 (S_B)
     'unuran_wrapper.pyx',  # 7 (used in stats/_unuran)
-    'ncf_ufunc.pyx'  # 8 (S_B)
+    'ncf_ufunc.pyx'  # 8 (S_B),
+    'nct_ufunc.pyx'  # 9 (S_B),
   ],
   input: '_generate_pyx.py',
   command: [py3, '@INPUT@', '-o', '@OUTDIR@'],
@@ -139,6 +140,7 @@ binom_ufunc_pyx = cython_stats_gen_cpp.process(_stats_gen_pyx[2])
 hypergeom_ufunc_pyx = cython_stats_gen_cpp.process(_stats_gen_pyx[4])
 nbinom_ufunc_pyx = cython_stats_gen_cpp.process(_stats_gen_pyx[5])
 ncf_ufunc_pyx = cython_stats_gen_cpp.process(_stats_gen_pyx[8])
+nct_ufunc_pyx = cython_stats_gen_cpp.process(_stats_gen_pyx[9])
 # Extra dependency from _lib
 unuran_wrap_pyx = lib_cython_gen.process(_stats_gen_pyx[7])
 


### PR DESCRIPTION
#### Reference issue
Closes gh-7104 (very few distributions are accurate to machine precision in all cases, so no need to track this enhancement request)

#### What does this implement/fix?
This replaces SciPy's implementation of the noncentral t distribution with the one from Boost. It also clips PDF below (at 0) and CDF/SF between 0 and 1 to ensure that the negative values observed in gh-7104 don't occur.

I don't have a reference implementation of the CDF to compare against (Wolfram Alpha times out), but one advantage is that it smoothes out the CDF near 0, at least for the parameters in gh-7104. In this PR:
![image](https://user-images.githubusercontent.com/6570539/178654905-d7317ea3-93aa-49ec-9fda-f4e9c09cf59e.png)

vs main:
![image](https://user-images.githubusercontent.com/6570539/178655062-f5d1ebb7-478d-466e-b001-54135c7a5bfa.png)

#### Additional information
We should probably leave in SciPy's PDF for now, and maybe file an issue with Boost. Boost's PDF doesn't look quite as good.
![image](https://user-images.githubusercontent.com/6570539/178655687-68218418-d0ca-4c94-8f56-be9dd7e479e0.png)

vs main:
![image](https://user-images.githubusercontent.com/6570539/178655190-8e3aaf29-1038-4cbc-b08e-6604806e98b5.png)

and checking out the numerical value at `x = 1`, [Wolfram Alpha](https://www.wolframalpha.com/input?i=PDF%5BNoncentralStudentTDistribution%5B8%2C8.26915191978%5D%2C+1%5D) gives `8.51798811×10^-12`. SciPy's implementation agrees; Boost's is half that. It looks like they are stitching together two implementations for the PDF near there, so the transition is not very smooth or accurate.