### PR TITLE
MAINT: stats.rv_continuous: consistently return NumPy scalars

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -1165,6 +1165,7 @@ class rv_generic:
         else:  # no valid args
             output = [default.copy() for _ in moments]
 
+        output = [out[()] for out in output]
         if len(output) == 1:
             return output[0]
         else:

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -1599,7 +1599,7 @@ class rv_generic:
         loc, scale, args = self._unpack_loc_scale(theta)
         if not self._argcheck(*args) or scale <= 0:
             return inf
-        x = asarray((x-loc) / scale)
+        x = (asarray(x)-loc) / scale
         n_log_scale = len(x) * log(scale)
         if np.any(~self._support_mask(x, *args)):
             return inf

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -1373,9 +1373,7 @@ class rv_generic:
             res2 *= loc**n
             place(result, i2, res2)
 
-        if result.ndim == 0:
-            return result.item()
-        return result
+        return result[()]
 
     def median(self, *args, **kwds):
         """Median of the distribution.
@@ -2912,7 +2910,7 @@ class rv_continuous(rv_generic):
 
         if conditional:
             vals /= invfac
-        return vals
+        return np.array(vals)[()]  # make it a numpy scalar like other methods
 
     def _param_info(self):
         shape_info = self._shape_info()

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -1204,7 +1204,7 @@ class rv_generic:
         goodscale = goodargs[0]
         goodargs = goodargs[1:]
         place(output, cond0, self.vecentropy(*goodargs) + log(goodscale))
-        return output
+        return output[()]
 
     def moment(self, order=None, *args, **kwds):
         """non-central moment of distribution of specified order.

--- a/scipy/stats/tests/common_tests.py
+++ b/scipy/stats/tests/common_tests.py
@@ -90,7 +90,6 @@ def check_kurt_expect(distfn, arg, m, v, k, msg):
 
 def check_entropy(distfn, arg, msg):
     ent = distfn.entropy(*arg)
-    assert ent.shape == () and not isinstance(ent, np.ndarray)
     npt.assert_(not np.isnan(ent), msg + 'test Entropy is nan')
 
 

--- a/scipy/stats/tests/common_tests.py
+++ b/scipy/stats/tests/common_tests.py
@@ -90,6 +90,7 @@ def check_kurt_expect(distfn, arg, m, v, k, msg):
 
 def check_entropy(distfn, arg, msg):
     ent = distfn.entropy(*arg)
+    assert ent.shape == () and not isinstance(ent, np.ndarray)
     npt.assert_(not np.isnan(ent), msg + 'test Entropy is nan')
 
 

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -910,3 +910,35 @@ def test_skewnorm_pdf_gh16038():
     res = stats.skewnorm.pdf(x, a)
     npt.assert_equal(res[mask], stats.norm.pdf(x_norm))
     npt.assert_equal(res[~mask], stats.skewnorm.pdf(x[~mask], a[~mask]))
+
+
+# for scalar input, these functions should return scalar output
+scalar_out = [['rvs', []], ['pdf', [0]], ['logpdf', [0]], ['cdf', [0]],
+              ['logcdf', [0]], ['sf', [0]], ['logsf', [0]], ['ppf', [0]],
+              ['isf', [0]], ['moment', [1]], ['entropy', []], ['expect', []],
+              ['median', []], ['mean', []], ['std', []], ['var', []]]
+scalars_out = [['interval', [0.95]], ['support', []], ['stats', ['mv']]]
+
+
+@pytest.mark.parametrize('case', scalar_out + scalars_out)
+def test_scalar_for_scalar(case):
+    # Some rv_continuous functions returns 0d array instead of numpy scalar
+    # Guard against regression
+    method_name, args = case
+    method = getattr(stats.norm(), method_name)
+    res = method(*args)
+    if case in scalar_out:
+        assert res.shape == () and not isinstance(res, np.ndarray)
+    else:
+        assert res[0].shape == () and not isinstance(res[0], np.ndarray)
+        assert res[1].shape == () and not isinstance(res[1], np.ndarray)
+
+
+def test_scalar_for_scalar2():
+    # test methods that are not part of frozen distributions
+    res = stats.norm.fit([1, 2, 3])
+    assert res[0].shape == () and not isinstance(res[0], np.ndarray)
+    assert res[1].shape == () and not isinstance(res[1], np.ndarray)
+    res = stats.norm.fit_loc_scale([1, 2, 3])
+    assert res[0].shape == () and not isinstance(res[0], np.ndarray)
+    assert res[1].shape == () and not isinstance(res[1], np.ndarray)

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -149,6 +149,8 @@ def test_cont_basic(distname, arg, sn, n_fit_samples):
     rng = np.random.RandomState(765456)
     rvs = distfn.rvs(size=sn, *arg, random_state=rng)
     m, v = distfn.stats(*arg)
+    assert m.shape == () and not isinstance(m, np.ndarray)
+    assert v.shape == () and not isinstance(v, np.ndarray)
 
     if distname not in {'laplace_asymmetric'}:
         check_sample_meanvar_(m, v, rvs)

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -149,8 +149,6 @@ def test_cont_basic(distname, arg, sn, n_fit_samples):
     rng = np.random.RandomState(765456)
     rvs = distfn.rvs(size=sn, *arg, random_state=rng)
     m, v = distfn.stats(*arg)
-    assert m.shape == () and not isinstance(m, np.ndarray)
-    assert v.shape == () and not isinstance(v, np.ndarray)
 
     if distname not in {'laplace_asymmetric'}:
         check_sample_meanvar_(m, v, rvs)
@@ -922,7 +920,7 @@ scalars_out = [['interval', [0.95]], ['support', []], ['stats', ['mv']]]
 
 @pytest.mark.parametrize('case', scalar_out + scalars_out)
 def test_scalar_for_scalar(case):
-    # Some rv_continuous functions returns 0d array instead of numpy scalar
+    # Some rv_continuous functions returned 0d array instead of NumPy scalar
     # Guard against regression
     method_name, args = case
     method = getattr(stats.norm(), method_name)
@@ -935,7 +933,7 @@ def test_scalar_for_scalar(case):
 
 
 def test_scalar_for_scalar2():
-    # test methods that are not part of frozen distributions
+    # test methods that are not attributes of frozen distributions
     res = stats.norm.fit([1, 2, 3])
     assert res[0].shape == () and not isinstance(res[0], np.ndarray)
     assert res[1].shape == () and not isinstance(res[1], np.ndarray)

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -942,3 +942,5 @@ def test_scalar_for_scalar2():
     res = stats.norm.fit_loc_scale([1, 2, 3])
     assert res[0].shape == () and not isinstance(res[0], np.ndarray)
     assert res[1].shape == () and not isinstance(res[1], np.ndarray)
+    res = stats.norm.nnlf((0, 1), [1, 2, 3])
+    assert res.shape == () and not isinstance(res, np.ndarray)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1824,11 +1824,11 @@ class TestPearson3:
         # The first moment is equal to the loc, which defaults to zero
         moment = stats.pearson3.moment(1, 2)
         assert_equal(moment, 0)
-        assert_equal(type(moment), float)
+        assert moment.shape == () and not isinstance(moment, np.ndarray)
 
         moment = stats.pearson3.moment(1, 0.000001)
         assert_equal(moment, 0)
-        assert_equal(type(moment), float)
+        assert moment.shape == () and not isinstance(moment, np.ndarray)
 
 
 class TestKappa4:


### PR DESCRIPTION
#### What does this implement/fix?
Almost all stats functions return a scalar or scalars given scalar input; e.g.:
```python3
stats.norm.rvs()  # 0.013802766485016257
stats.norm.pdf(0)  # 0.3989422804014327
stats.norm.interval(0.95)  # (-1.959963984540054, 1.959963984540054)
```
`entropy` and `stats` don't:
```python3
stats.norm.entropy()  # array(1.41893853)
stats.norm.stats('mv')  # (array(0.), array(1.))
```
but should.

Similarly, almost all stats functions that return scalars return a _NumPy_ scalar rather than a Python scalar.
`expect` and `moment` don't, but should.

This PR fixes these inconsistencies. While adding tests, I found that `nnlf` didn't accept array_likes, so I fixed that, too, so that the test would run.

#### Additional information
Advantages of array scalars from [here](https://numpy.org/doc/stable/user/basics.types.html#array-scalars).

> The primary advantage of using array scalars is that they preserve the array type (Python may not have a matching scalar type available, e.g. int16). Therefore, the use of array scalars ensures identical behaviour between arrays and scalars, irrespective of whether the value is inside an array or not. NumPy scalars also have many of the same methods arrays do.

Perhaps more importantly for `scipy.stats`: consistency.