### PR TITLE
TST: stats.rv_continuous: more direct test for numpy scalar output

### DIFF
--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -926,19 +926,19 @@ def test_scalar_for_scalar(case):
     method = getattr(stats.norm(), method_name)
     res = method(*args)
     if case in scalar_out:
-        assert res.shape == () and not isinstance(res, np.ndarray)
+        assert isinstance(res, np.number)
     else:
-        assert res[0].shape == () and not isinstance(res[0], np.ndarray)
-        assert res[1].shape == () and not isinstance(res[1], np.ndarray)
+        assert isinstance(res[0], np.number)
+        assert isinstance(res[1], np.number)
 
 
 def test_scalar_for_scalar2():
     # test methods that are not attributes of frozen distributions
     res = stats.norm.fit([1, 2, 3])
-    assert res[0].shape == () and not isinstance(res[0], np.ndarray)
-    assert res[1].shape == () and not isinstance(res[1], np.ndarray)
+    assert isinstance(res[0], np.number)
+    assert isinstance(res[1], np.number)
     res = stats.norm.fit_loc_scale([1, 2, 3])
-    assert res[0].shape == () and not isinstance(res[0], np.ndarray)
-    assert res[1].shape == () and not isinstance(res[1], np.ndarray)
+    assert isinstance(res[0], np.number)
+    assert isinstance(res[1], np.number)
     res = stats.norm.nnlf((0, 1), [1, 2, 3])
-    assert res.shape == () and not isinstance(res, np.ndarray)
+    assert isinstance(res, np.number)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1814,11 +1814,11 @@ class TestPearson3:
         # The first moment is equal to the loc, which defaults to zero
         moment = stats.pearson3.moment(1, 2)
         assert_equal(moment, 0)
-        assert moment.shape == () and not isinstance(moment, np.ndarray)
+        assert isinstance(moment, np.number)
 
         moment = stats.pearson3.moment(1, 0.000001)
         assert_equal(moment, 0)
-        assert moment.shape == () and not isinstance(moment, np.ndarray)
+        assert isinstance(moment, np.number)
 
 
 class TestKappa4:


### PR DESCRIPTION
#### Reference issue
Simple refactor of test in gh-16596

#### What does this implement/fix?
gh-16596 had a very indirect test for an object being a NumPy scalar. This replaces it with a much more direct test.