### PR TITLE
TST: stats.mstats.ttests: fix mistakes in tests

### DIFF
--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -1210,8 +1210,7 @@ class TestTtest_rel():
         np.random.seed(1234567)
         outcome = ma.masked_array(np.random.randn(3, 2),
                                   mask=[[1, 0], [1, 0], [1, 0]])
-        with suppress_warnings() as sup:
-            sup.filter(RuntimeWarning, "invalid value encountered in absolute")
+        with np.errstate(invalid='ignore', divide='ignore'):
             for pair in [(outcome[:, 0], outcome[:, 1]), ([np.nan, np.nan], [1.0, 2.0])]:
                 t, p = mstats.ttest_rel(*pair)
                 assert_array_equal(t, (np.nan, np.nan))
@@ -1309,9 +1308,9 @@ class TestTtest_ind():
         np.random.seed(1234567)
         outcome = ma.masked_array(np.random.randn(3, 2),
                                   mask=[[1, 0], [1, 0], [1, 0]])
-        with suppress_warnings() as sup:
-            sup.filter(RuntimeWarning, "invalid value encountered in absolute")
-            for pair in [(outcome[:, 0], outcome[:, 1]), ([np.nan, np.nan], [1.0, 2.0])]:
+        with np.errstate(invalid='ignore', divide='ignore'):
+            for pair in [(outcome[:, 0], outcome[:, 1]),
+                         ([np.nan, np.nan], [1.0, 2.0])]:
                 t, p = mstats.ttest_ind(*pair)
                 assert_array_equal(t, (np.nan, np.nan))
                 assert_array_equal(p, (np.nan, np.nan))

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -1209,7 +1209,7 @@ class TestTtest_rel():
     def test_fully_masked(self):
         np.random.seed(1234567)
         outcome = ma.masked_array(np.random.randn(3, 2),
-                                  mask=[[1, 1, 1], [0, 0, 0]])
+                                  mask=[[1, 0], [1, 0], [1, 0]])
         with suppress_warnings() as sup:
             sup.filter(RuntimeWarning, "invalid value encountered in absolute")
             for pair in [(outcome[:, 0], outcome[:, 1]), ([np.nan, np.nan], [1.0, 2.0])]:
@@ -1307,7 +1307,8 @@ class TestTtest_ind():
 
     def test_fully_masked(self):
         np.random.seed(1234567)
-        outcome = ma.masked_array(np.random.randn(3, 2), mask=[[1, 1, 1], [0, 0, 0]])
+        outcome = ma.masked_array(np.random.randn(3, 2),
+                                  mask=[[1, 0], [1, 0], [1, 0]])
         with suppress_warnings() as sup:
             sup.filter(RuntimeWarning, "invalid value encountered in absolute")
             for pair in [(outcome[:, 0], outcome[:, 1]), ([np.nan, np.nan], [1.0, 2.0])]:


### PR DESCRIPTION
#### Reference issue
NA

#### What does this implement/fix?
There are some `stats.mstats` CI failures with Python 3.11 and NumPy main (see details below) that led me to some mistakes in our tests.  This PR fixes those mistakes.

#### Additional information
I don't think these mistakes are the _causes_ of the CI failures, though... there does seem to be something that has changed in Python 3.11 or NumPy main.

<details>

```
=================================== FAILURES ===================================
______________________ TestCorr.test_kendalltau_seasonal _______________________
../testenv/lib/python3.11/site-packages/scipy/stats/tests/test_mstats_basic.py:405: in test_kendalltau_seasonal
    assert_almost_equal(output['global p-value (indep)'], 0.008, 3)
        output     = {'chi2 total': 0.9138890055275067, 'chi2 trend': 0.03518368100765739, 'global p-value (dep)': 0.9592698679548645, 'global p-value (indep)': 0.9415878180349753, ...}
        self       = <scipy.stats.tests.test_mstats_basic.TestCorr object at 0x7f4984171b90>
        x          = masked_array(
  data=[[--, 4.0, 3.0, --],
        [--, 3.0, 2.0, 6.0],
        [4.0, 5.0, 5.0, 11.0],
        [2.0, 3.... False, False, False],
        [False, False, False, False],
        [False, False,  True, False]],
  fill_value=1e+20)
/home/runner/.local/lib/python3.11/site-packages/numpy/ma/testutils.py:189: in assert_almost_equal
    raise AssertionError(msg)
E   AssertionError: 
E   Items are not equal:
E    ACTUAL: 0.9415878180349753
E    DESIRED: 0.008
        actual     = 0.9415878180349753
        decimal    = 3
        desired    = 0.008
        err_msg    = ''
        msg        = '\nItems are not equal:\n ACTUAL: 0.9415878180349753\n DESIRED: 0.008'
        verbose    = True
_______________________ TestTtest_rel.test_fully_masked ________________________
../testenv/lib/python3.11/site-packages/scipy/stats/tests/test_mstats_basic.py:1218: in test_fully_masked
    assert_array_equal(p, (np.nan, np.nan))
        outcome    = masked_array(
  data=[[--, --],
        [--, 0.6433801600172545],
        [0.026139395443102165, 0.08038096427837299]],
  mask=[[ True,  True],
        [ True, False],
        [False, False]],
  fill_value=1e+20)
        p          = 1.0
        pair       = ([nan, nan], [1.0, 2.0])
        self       = <scipy.stats.tests.test_mstats_basic.TestTtest_rel object at 0x7f4983f67b50>
        sup        = <numpy.testing._private.utils.suppress_warnings object at 0x7f4986dc9bd0>
        t          = masked
/home/runner/.local/lib/python3.11/site-packages/numpy/ma/testutils.py:225: in assert_array_equal
    assert_array_compare(operator.__eq__, x, y,
        err_msg    = ''
        verbose    = True
        x          = 1.0
        y          = (nan, nan)
/home/runner/.local/lib/python3.11/site-packages/numpy/ma/testutils.py:213: in assert_array_compare
    return np.testing.assert_array_compare(comparison,
        comparison = <built-in function eq>
        err_msg    = ''
        fill_value = True
        header     = 'Arrays are not equal'
        m          = False
        verbose    = True
        x          = masked_array(data=1.,
             mask=False,
       fill_value=1e+20)
        y          = masked_array(data=[nan, nan],
             mask=False,
       fill_value=1e+20)
/opt/hostedtoolcache/Python/3.11.0-beta.4/x64/lib/python3.11/contextlib.py:81: in inner
    return func(*args, **kwds)
E   AssertionError: 
E   Arrays are not equal
E   
E   x and y nan location mismatch:
E    x: array(1.)
E    y: array([nan, nan])
        args       = (<built-in function eq>, array(1.), array([nan, nan]))
        func       = <function assert_array_compare at 0x7f4991f41580>
        kwds       = {'err_msg': '', 'header': 'Arrays are not equal', 'verbose': True}
        self       = <contextlib._GeneratorContextManager object at 0x7f4991f29110>
_______________________ TestTtest_ind.test_fully_masked ________________________
../testenv/lib/python3.11/site-packages/scipy/stats/tests/test_mstats_basic.py:1316: in test_fully_masked
    assert_array_equal(p, (np.nan, np.nan))
        outcome    = masked_array(
  data=[[--, --],
        [--, 0.6433801600172545],
        [0.026139395443102165, 0.08038096427837299]],
  mask=[[ True,  True],
        [ True, False],
        [False, False]],
  fill_value=1e+20)
        p          = 1.0
        pair       = (masked_array(data=[--, --, 0.026139395443102165],
             mask=[ True,  True, False],
       fill_value=1e+20), ...(data=[--, 0.6433801600172545, 0.08038096427837299],
             mask=[ True, False, False],
       fill_value=1e+20))
        self       = <scipy.stats.tests.test_mstats_basic.TestTtest_ind object at 0x7f4983f65210>
        sup        = <numpy.testing._private.utils.suppress_warnings object at 0x7f497b282390>
        t          = masked
/home/runner/.local/lib/python3.11/site-packages/numpy/ma/testutils.py:225: in assert_array_equal
    assert_array_compare(operator.__eq__, x, y,
        err_msg    = ''
        verbose    = True
        x          = 1.0
        y          = (nan, nan)
/home/runner/.local/lib/python3.11/site-packages/numpy/ma/testutils.py:213: in assert_array_compare
    return np.testing.assert_array_compare(comparison,
        comparison = <built-in function eq>
        err_msg    = ''
        fill_value = True
        header     = 'Arrays are not equal'
        m          = False
        verbose    = True
        x          = masked_array(data=1.,
             mask=False,
       fill_value=1e+20)
        y          = masked_array(data=[nan, nan],
             mask=False,
       fill_value=1e+20)
/opt/hostedtoolcache/Python/3.11.0-beta.4/x64/lib/python3.11/contextlib.py:81: in inner
    return func(*args, **kwds)
E   AssertionError: 
E   Arrays are not equal
E   
E   x and y nan location mismatch:
E    x: array(1.)
E    y: array([nan, nan])
        args       = (<built-in function eq>, array(1.), array([nan, nan]))
        func       = <function assert_array_compare at 0x7f4991f41580>
        kwds       = {'err_msg': '', 'header': 'Arrays are not equal', 'verbose': True}
        self       = <contextlib._GeneratorContextManager object at 0x7f4991f29110>
______________________ TestTtest_1samp.test_fully_masked _______________________
../testenv/lib/python3.11/site-packages/scipy/stats/tests/test_mstats_basic.py:1403: in test_fully_masked
    assert_array_equal(p, expected)
        expected   = (nan, nan)
        outcome    = masked_array(data=[--, --, --],
             mask=[ True,  True,  True],
       fill_value=1e+20,
            dtype=float64)
        p          = 1.0
        pair       = ((nan, nan), 0.0)
        self       = <scipy.stats.tests.test_mstats_basic.TestTtest_1samp object at 0x7f4983ae95d0>
        sup        = <numpy.testing._private.utils.suppress_warnings object at 0x7f49799395d0>
        t          = masked
/home/runner/.local/lib/python3.11/site-packages/numpy/ma/testutils.py:225: in assert_array_equal
    assert_array_compare(operator.__eq__, x, y,
        err_msg    = ''
        verbose    = True
        x          = 1.0
        y          = (nan, nan)
/home/runner/.local/lib/python3.11/site-packages/numpy/ma/testutils.py:213: in assert_array_compare
    return np.testing.assert_array_compare(comparison,
        comparison = <built-in function eq>
        err_msg    = ''
        fill_value = True
        header     = 'Arrays are not equal'
        m          = False
        verbose    = True
        x          = masked_array(data=1.,
             mask=False,
       fill_value=1e+20)
        y          = masked_array(data=[nan, nan],
             mask=False,
       fill_value=1e+20)
/opt/hostedtoolcache/Python/3.11.0-beta.4/x64/lib/python3.11/contextlib.py:81: in inner
    return func(*args, **kwds)
E   AssertionError: 
E   Arrays are not equal
E   
E   x and y nan location mismatch:
E    x: array(1.)
E    y: array([nan, nan])
        args       = (<built-in function eq>, array(1.), array([nan, nan]))
        func       = <function assert_array_compare at 0x7f4991f41580>
        kwds       = {'err_msg': '', 'header': 'Arrays are not equal', 'verbose': True}
        self       = <contextlib._GeneratorContextManager object at 0x7f4991f29110>
______________________ TestDescribe.test_basic_with_axis _______________________
../testenv/lib/python3.11/site-packages/scipy/stats/tests/test_mstats_basic.py:1465: in test_basic_with_axis
    result = mstats.describe(a, axis=1)
        a          = masked_array(
  data=[[0, 1, 2, 3, 4, --],
        [5, 5, --, --, 3, 3]],
  mask=[[False, False, False, False, False,  True],
        [False, False,  True,  True, False, False]],
  fill_value=999999)
        self       = <scipy.stats.tests.test_mstats_basic.TestDescribe object at 0x7f4983ae19d0>
../testenv/lib/python3.11/site-packages/scipy/stats/_mstats_basic.py:2812: in describe
    mm = (ma.minimum.reduce(a, axis=axis), ma.maximum.reduce(a, axis=axis))
        a          = masked_array(
  data=[[0, 1, 2, 3, 4, --],
        [5, 5, --, --, 3, 3]],
  mask=[[False, False, False, False, False,  True],
        [False, False,  True,  True, False, False]],
  fill_value=999999)
        axis       = 1
        bias       = True
        ddof       = 0
        n          = array([5, 4])
/home/runner/.local/lib/python3.11/site-packages/numpy/ma/core.py:6885: in reduce
    elif m:
E   ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
        axis       = 1
        kwargs     = {'axis': 1}
        m          = array([False, False])
        self       = <numpy.ma.core._extrema_operation object at 0x7f4992971bd0>
        t          = array([0, 3])
        target     = masked_array(
  data=[[                  0,                   1,                   2,
                           3,   ...854775807,
         9223372036854775807,                   3,                   3]],
  mask=False,
  fill_value=999999)
__________________________ TestTrimmedStats.test_tmin __________________________
../testenv/lib/python3.11/site-packages/scipy/stats/tests/test_stats.py:165: in test_tmin
    assert_equal(stats.tmin(x, lowerlimit=0, inclusive=False), [2, 1])
        self       = <scipy.stats.tests.test_stats.TestTrimmedStats object at 0x7f49823fa350>
        x          = array([[0, 1],
       [2, 3],
       [4, 5],
       [6, 7],
       [8, 9]])
../testenv/lib/python3.11/site-packages/scipy/stats/_stats_py.py:874: in tmin
    res = ma.minimum.reduce(am, axis).data
        a          = array([[0, 1],
       [2, 3],
       [4, 5],
       [6, 7],
       [8, 9]])
        am         = masked_array(
  data=[[--, 1],
        [2, 3],
        [4, 5],
        [6, 7],
        [8, 9]],
  mask=[[ True, False],
        [False, False],
        [False, False],
        [False, False],
        [False, False]],
  fill_value=999999)
        axis       = 0
        contains_nan = False
        inclusive  = False
        lowerlimit = 0
        nan_policy = 'propagate'
/home/runner/.local/lib/python3.11/site-packages/numpy/ma/core.py:6885: in reduce
    elif m:
E   ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
        axis       = 0
        kwargs     = {'axis': 0}
        m          = array([False, False])
        self       = <numpy.ma.core._extrema_operation object at 0x7f4992971bd0>
        t          = array([2, 1])
        target     = masked_array(
  data=[[9223372036854775807,                   1],
        [                  2,                   3],
...       6,                   7],
        [                  8,                   9]],
  mask=False,
  fill_value=999999)
__________________________ TestTrimmedStats.test_tmax __________________________
../testenv/lib/python3.11/site-packages/scipy/stats/tests/test_stats.py:190: in test_tmax
    assert_equal(stats.tmax(x, upperlimit=9, inclusive=False), [8, 7])
        self       = <scipy.stats.tests.test_stats.TestTrimmedStats object at 0x7f49823f8490>
        x          = array([[0, 1],
       [2, 3],
       [4, 5],
       [6, 7],
       [8, 9]])
../testenv/lib/python3.11/site-packages/scipy/stats/_stats_py.py:935: in tmax
    res = ma.maximum.reduce(am, axis).data
        a          = array([[0, 1],
       [2, 3],
       [4, 5],
       [6, 7],
       [8, 9]])
        am         = masked_array(
  data=[[0, 1],
        [2, 3],
        [4, 5],
        [6, 7],
        [8, --]],
  mask=[[False, False],
        [False, False],
        [False, False],
        [False, False],
        [False,  True]],
  fill_value=999999)
        axis       = 0
        contains_nan = False
        inclusive  = False
        nan_policy = 'propagate'
        upperlimit = 9
/home/runner/.local/lib/python3.11/site-packages/numpy/ma/core.py:6885: in reduce
    elif m:
E   ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
        axis       = 0
        kwargs     = {'axis': 0}
        m          = array([False, False])
        self       = <numpy.ma.core._extrema_operation object at 0x7f4992971a50>
        t          = array([8, 7])
        target     = masked_array(
  data=[[                   0,                    1],
        [                   2,                    ...    6,                    7],
        [                   8, -9223372036854775808]],
  mask=False,
  fill_value=999999)
_________________________ test_chisquare_masked_arrays _________________________
../testenv/lib/python3.11/site-packages/scipy/stats/tests/test_stats.py:3579: in test_chisquare_masked_arrays
    mat.assert_array_almost_equal(g, expected_g, decimal=15)
        chi2       = <scipy.stats._continuous_distns.chi2_gen object at 0x7f498daf5450>
        chisq      = masked_array(data=[24.0, 0.5],
             mask=[False, False],
       fill_value=1e+20)
        expected_chisq = array([24. ,  0.5])
        expected_g = array([22.18070978,  0.50534308])
        g          = array([nan, nan])
        mask       = array([[0, 1],
       [0, 1],
       [0, 0],
       [0, 0],
       [1, 0]])
        mobs       = masked_array(
  data=[[8, --],
        [8, --],
        [16, 3],
        [32, 4],
        [--, 5]],
  mask=[[False,  T...,
        [False,  True],
        [False, False],
        [False, False],
        [ True, False]],
  fill_value=999999)
        obs        = array([[ 8, -1],
       [ 8, -1],
       [16,  3],
       [32,  4],
       [-1,  5]])
        p          = array([nan, nan])
/home/runner/.local/lib/python3.11/site-packages/numpy/ma/testutils.py:265: in assert_array_almost_equal
    assert_array_compare(compare, x, y, err_msg=err_msg, verbose=verbose,
        compare    = <function assert_array_almost_equal.<locals>.compare at 0x7f49796bf1a0>
        decimal    = 15
        err_msg    = ''
        verbose    = True
        x          = array([nan, nan])
        y          = array([22.18070978,  0.50534308])
/home/runner/.local/lib/python3.11/site-packages/numpy/ma/testutils.py:213: in assert_array_compare
    return np.testing.assert_array_compare(comparison,
        comparison = <function assert_array_almost_equal.<locals>.compare at 0x7f49796bf1a0>
        err_msg    = ''
        fill_value = True
        header     = 'Arrays are not almost equal'
        m          = False
        verbose    = True
        x          = masked_array(data=[nan, nan],
             mask=False,
       fill_value=1e+20)
        y          = masked_array(data=[22.18070978,  0.50534308],
             mask=False,
       fill_value=1e+20)
/opt/hostedtoolcache/Python/3.11.0-beta.4/x64/lib/python3.11/contextlib.py:81: in inner
    return func(*args, **kwds)
E   AssertionError: 
E   Arrays are not almost equal
E   
E   x and y nan location mismatch:
E    x: array([nan, nan])
E    y: array([22.18071 ,  0.505343])
        args       = (<function assert_array_almost_equal.<locals>.compare at 0x7f49796bf1a0>, array([nan, nan]), array([22.18070978,  0.50534308]))
        func       = <function assert_array_compare at 0x7f4991f41580>
        kwds       = {'err_msg': '', 'header': 'Arrays are not almost equal', 'verbose': True}
        self       = <contextlib._GeneratorContextManager object at 0x7f4991f29110>
============================= slowest 10 durations =============================
16.78s call     build/testenv/lib/python3.11/site-packages/scipy/stats/tests/test_continuous_basic.py::test_kappa4_array_gh13582
12.15s call     build/testenv/lib/python3.11/site-packages/scipy/stats/tests/test_continuous_basic.py::test_cont_basic[500-200-skewnorm-arg91]
9.79s call     build/testenv/lib/python3.11/site-packages/scipy/optimize/tests/test_direct.py::TestDIRECT::test_segmentation_fault[False]
7.76s call     build/testenv/lib/python3.11/site-packages/scipy/sparse/linalg/_isolve/tests/test_iterative.py::test_precond_inverse[case1]
7.44s call     build/testenv/lib/python3.11/site-packages/scipy/_lib/tests/test_import_cycles.py::test_modules_importable
5.82s call     build/testenv/lib/python3.11/site-packages/scipy/optimize/tests/test_lsq_linear.py::TestBVLS::test_large_rank_deficient
5.80s call     build/testenv/lib/python3.11/site-packages/scipy/optimize/tests/test_lsq_linear.py::TestTRF::test_large_rank_deficient
4.73s call     build/testenv/lib/python3.11/site-packages/scipy/stats/tests/test_continuous_basic.py::test_cont_basic[500-200-truncweibull_min-arg100]
3.94s call     build/testenv/lib/python3.11/site-packages/scipy/optimize/tests/test_optimize.py::TestOptimizeSimple::test_minimize_callback_copies_array[fmin]
3.70s call     build/testenv/lib/python3.11/site-packages/scipy/optimize/_trustregion_constr/tests/test_report.py::test_gh12922
=========================== short test summary info ============================
FAILED ../testenv/lib/python3.11/site-packages/scipy/stats/tests/test_mstats_basic.py::TestCorr::test_kendalltau_seasonal
FAILED ../testenv/lib/python3.11/site-packages/scipy/stats/tests/test_mstats_basic.py::TestTtest_rel::test_fully_masked
FAILED ../testenv/lib/python3.11/site-packages/scipy/stats/tests/test_mstats_basic.py::TestTtest_ind::test_fully_masked
FAILED ../testenv/lib/python3.11/site-packages/scipy/stats/tests/test_mstats_basic.py::TestTtest_1samp::test_fully_masked
FAILED ../testenv/lib/python3.11/site-packages/scipy/stats/tests/test_mstats_basic.py::TestDescribe::test_basic_with_axis
FAILED ../testenv/lib/python3.11/site-packages/scipy/stats/tests/test_stats.py::TestTrimmedStats::test_tmin
FAILED ../testenv/lib/python3.11/site-packages/scipy/stats/tests/test_stats.py::TestTrimmedStats::test_tmax
FAILED ../testenv/lib/python3.11/site-packages/scipy/stats/tests/test_stats.py::test_chisquare_masked_arrays
= 8 failed, 36740 passed, 2162 skipped, 12114 deselected, 139 xfailed, 7 xpassed in 541.04s (0:09:01) =
```

</details>

@seberg Is this failing in NumPy main?

```python3
import numpy as np
data = [[0, 1, 2, 3, 4, 9], [5, 5, 0, 9, 3, 3]]
mask = [[0, 0, 0, 0, 0, 1], [0, 0, 1, 1, 0, 0]]
a = np.ma.masked_array(data, mask=mask)
np.ma.minimum.reduce(a, axis=1)
np.ma.maximum.reduce(a, axis=1)
```

Based on CI, it looks like it is resulting in:
```
/home/runner/.local/lib/python3.11/site-packages/numpy/ma/core.py:6885: in reduce
    elif m:
E   ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```