### PR TITLE
ENH: vectorize along samples `stats.special_ortho_group.rvs`

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -3402,22 +3402,7 @@ class special_ortho_group_gen(multi_rv_generic):
 
         return dim
 
-    def rvs(self, dim, size=1, random_state=None):
-        """Draw random samples from SO(N).
-
-        Parameters
-        ----------
-        dim : integer
-            Dimension of rotation space (N).
-        size : integer, optional
-            Number of samples to draw (default 1).
-
-        Returns
-        -------
-        rvs : ndarray or scalar
-            Random size N-dimensional matrices, dimension (size, dim, dim)
-
-        """
+    def rvs_old(self, dim, size=1, random_state=None):
         random_state = self._get_random_state(random_state)
 
         size = int(size)
@@ -3443,7 +3428,22 @@ class special_ortho_group_gen(multi_rv_generic):
         H = (D*H.T).T
         return H
 
-    def rvs2(self, dim, size=1, random_state=None):
+    def rvs(self, dim, size=1, random_state=None):
+        """Draw random samples from SO(N).
+
+        Parameters
+        ----------
+        dim : integer
+            Dimension of rotation space (N).
+        size : integer, optional
+            Number of samples to draw (default 1).
+
+        Returns
+        -------
+        rvs : ndarray or scalar
+            Random size N-dimensional matrices, dimension (size, dim, dim)
+
+        """
         random_state = self._get_random_state(random_state)
 
         size = int(size)

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -3443,7 +3443,6 @@ class special_ortho_group_gen(multi_rv_generic):
         H = (D*H.T).T
         return H
 
-
     def rvs2(self, dim, size=1, random_state=None):
         random_state = self._get_random_state(random_state)
 
@@ -3460,7 +3459,7 @@ class special_ortho_group_gen(multi_rv_generic):
             xrow = x[..., None, :]
             xcol = x[..., :, None]
             norm2 = np.matmul(xrow, xcol).squeeze((-2, -1))
-            x0 = np.copy(x[..., 0])
+            x0 = x[..., 0].copy()
             D[..., n] = np.where(x0 != 0, np.sign(x0), 1)
             x[..., 0] += D[..., n]*np.sqrt(norm2)
             x /= np.sqrt((norm2 - x0**2 + x[..., 0]**2) / 2.)[..., None]

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -3425,9 +3425,10 @@ class special_ortho_group_gen(multi_rv_generic):
 
         dim = self._process_parameters(dim)
 
-        # H represents a (dim, dim) matrix, while D represents the diagonal of a
-        # (dim, dim) diagonal matrix. The algorithm that follows is broadcasted
-        # on the leading shape in `size` to vectorize along samples.
+        # H represents a (dim, dim) matrix, while D represents the diagonal of
+        # a (dim, dim) diagonal matrix. The algorithm that follows is
+        # broadcasted on the leading shape in `size` to vectorize along
+        # samples.
         H = np.empty(size + (dim, dim))
         H[..., :, :] = np.eye(dim)
         D = np.empty(size + (dim,))
@@ -3464,7 +3465,7 @@ class special_ortho_group_gen(multi_rv_generic):
         # Without vectorization this could be written as H = diag(D) @ H,
         # left-multiplication by a diagonal matrix amounts to multiplying each
         # row of H by an element of the diagonal, so we add a dummy axis for
-        # columns
+        # the column index
         H *= D[..., :, None]
         return H
 

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -3456,14 +3456,16 @@ class special_ortho_group_gen(multi_rv_generic):
         H[..., :, :] = np.eye(dim)
         D = np.empty(size + (dim,))
         for n in range(dim-1):
-            x = random_state.normal(size=size + (dim-n))
-            norm2 = np.matmul(x[..., None, :], x[..., :, None])
+            x = random_state.normal(size=size + (dim-n,))
+            xrow = x[..., None, :]
+            xcol = x[..., :, None]
+            norm2 = np.matmul(xrow, xcol).squeeze((-2, -1))
             x0 = np.copy(x[..., 0])
-            D[..., n] = np.where(x[..., 0] != 0, np.sign(x[..., 0]), 1)
+            D[..., n] = np.where(x0 != 0, np.sign(x0), 1)
             x[..., 0] += D[..., n]*np.sqrt(norm2)
-            x /= np.sqrt((norm2 - x0**2 + x[..., 0]**2) / 2.)
+            x /= np.sqrt((norm2 - x0**2 + x[..., 0]**2) / 2.)[..., None]
             # Householder transformation
-            H[..., :, n:] -= np.matmul(H[..., :, n:], x[..., :, None]) * x[..., None, :]
+            H[..., :, n:] -= np.matmul(H[..., :, n:], xcol) * xrow
         D[..., -1] = (-1)**(dim-1)*D[..., :-1].prod(axis=-1)
         # Equivalent to np.dot(np.diag(D), H) but faster, apparently
         H *= D[..., :, None]

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -3402,32 +3402,6 @@ class special_ortho_group_gen(multi_rv_generic):
 
         return dim
 
-    def rvs_old(self, dim, size=1, random_state=None):
-        random_state = self._get_random_state(random_state)
-
-        size = int(size)
-        if size > 1:
-            return np.array([self.rvs(dim, size=1, random_state=random_state)
-                             for i in range(size)])
-
-        dim = self._process_parameters(dim)
-
-        H = np.eye(dim)
-        D = np.empty((dim,))
-        for n in range(dim-1):
-            x = random_state.normal(size=(dim-n,))
-            norm2 = np.dot(x, x)
-            x0 = x[0].item()
-            D[n] = np.sign(x[0]) if x[0] != 0 else 1
-            x[0] += D[n]*np.sqrt(norm2)
-            x /= np.sqrt((norm2 - x0**2 + x[0]**2) / 2.)
-            # Householder transformation
-            H[:, n:] -= np.outer(np.dot(H[:, n:], x), x)
-        D[-1] = (-1)**(dim-1)*D[:-1].prod()
-        # Equivalent to np.dot(np.diag(D), H) but faster, apparently
-        H = (D*H.T).T
-        return H
-
     def rvs(self, dim, size=1, random_state=None):
         """Draw random samples from SO(N).
 

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -3425,22 +3425,46 @@ class special_ortho_group_gen(multi_rv_generic):
 
         dim = self._process_parameters(dim)
 
+        # H represents a (dim, dim) matrix, while D represents the diagonal of a
+        # (dim, dim) diagonal matrix. The algorithm that follows is broadcasted
+        # on the leading shape in `size` to vectorize along samples.
         H = np.empty(size + (dim, dim))
         H[..., :, :] = np.eye(dim)
         D = np.empty(size + (dim,))
+
         for n in range(dim-1):
+
+            # x is a vector with length dim-n, xrow and xcol are views of it as
+            # a row vector and column vector respectively. It's important they
+            # are views and not copies because we are going to modify x
+            # in-place.
             x = random_state.normal(size=size + (dim-n,))
             xrow = x[..., None, :]
             xcol = x[..., :, None]
+
+            # This is the squared norm of x, without vectorization it would be
+            # dot(x, x), to have proper broadcasting we use matmul and squeeze
+            # out (convert to scalar) the resulting 1x1 matrix
             norm2 = np.matmul(xrow, xcol).squeeze((-2, -1))
+
             x0 = x[..., 0].copy()
             D[..., n] = np.where(x0 != 0, np.sign(x0), 1)
             x[..., 0] += D[..., n]*np.sqrt(norm2)
+
+            # In renormalizing x we have to append an additional axis with
+            # [..., None] to broadcast the scalar against the vector x
             x /= np.sqrt((norm2 - x0**2 + x[..., 0]**2) / 2.)[..., None]
-            # Householder transformation
+
+            # Householder transformation, without vectorization the RHS can be
+            # written as outer(H @ x, x) (apart from the slicing)
             H[..., :, n:] -= np.matmul(H[..., :, n:], xcol) * xrow
+
         D[..., -1] = (-1)**(dim-1)*D[..., :-1].prod(axis=-1)
-        # Equivalent to np.dot(np.diag(D), H) but faster, apparently
+
+        # Without vectorization this could be written as H = diag(D) @ H,
+        # left-multiplication by a diagonal matrix amounts to multiplying each
+        # row of H by an element of the diagonal, so we add a dummy axis for
+        # columns
         H *= D[..., :, None]
         return H
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
#16344

#### What does this implement/fix?
<!--Please explain your changes.-->
Currently `stats.special_ortho_group.rvs` loops in python over each random matrix to output. This PR vectorizes the algorithm to operate on all samples at once. For producing many 2x2 matrices, the speed increase is 120x.

#### Additional information
<!--Any additional information you think is important.-->
