### PR TITLE
BUG Enables find_peaks to work on read-only data

### DIFF
--- a/scipy/signal/_peak_finding_utils.pyx
+++ b/scipy/signal/_peak_finding_utils.pyx
@@ -17,7 +17,7 @@ __all__ = ['_local_maxima_1d', '_select_by_peak_distance', '_peak_prominences',
            '_peak_widths']
 
 
-def _local_maxima_1d(np.float64_t[::1] x not None):
+def _local_maxima_1d(const np.float64_t[::1] x not None):
     """
     Find local maxima in a 1D array.
 
@@ -163,7 +163,7 @@ class PeakPropertyWarning(RuntimeWarning):
     pass
 
 
-def _peak_prominences(np.float64_t[::1] x not None,
+def _peak_prominences(const np.float64_t[::1] x not None,
                       np.intp_t[::1] peaks not None,
                       np.intp_t wlen):
     """
@@ -261,7 +261,7 @@ def _peak_prominences(np.float64_t[::1] x not None,
     return prominences.base, left_bases.base, right_bases.base
 
 
-def _peak_widths(np.float64_t[::1] x not None,
+def _peak_widths(const np.float64_t[::1] x not None,
                  np.intp_t[::1] peaks not None,
                  np.float64_t rel_height,
                  np.float64_t[::1] prominences not None,

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -135,7 +135,7 @@ class TestLocalMaxima1d:
         """Test input validation and raised exceptions."""
         with raises(ValueError, match="wrong number of dimensions"):
             _local_maxima_1d(np.ones((1, 1)))
-        with raises(ValueError, match="expected 'float64_t'"):
+        with raises(ValueError, match="expected 'const float64_t'"):
             _local_maxima_1d(np.ones(1, dtype=int))
         with raises(TypeError, match="list"):
             _local_maxima_1d([1., 2.])
@@ -769,6 +769,26 @@ class TestFindPeaks:
         assert_equal(props["width_heights"], 1)
         for key in ("left_bases", "right_bases", "left_ips", "right_ips"):
             assert_equal(props[key], peaks)
+
+    @pytest.mark.parametrize("kwargs", [
+        {},
+        {"distance": 3.0},
+        {"prominence": (None, None)},
+        {"width": (None, 2)},
+
+    ])
+    def test_readonly_array(self, kwargs):
+        """
+        Test readonly arrays are accepted.
+        """
+        x = np.linspace(0, 10, 15)
+        peaks, _ = find_peaks(x)
+
+        x_readonly = x.copy()
+        x_readonly.flags.writeable = False
+        peaks_only, _ = find_peaks(x_readonly, **kwargs)
+
+        assert_allclose(peaks, peaks_only)
 
 
 class TestFindPeaksCwt:

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -782,10 +782,10 @@ class TestFindPeaks:
         Test readonly arrays are accepted.
         """
         x = np.linspace(0, 10, 15)
-        peaks, _ = find_peaks(x)
-
         x_readonly = x.copy()
         x_readonly.flags.writeable = False
+
+        peaks, _ = find_peaks(x)
         peaks_readonly, _ = find_peaks(x_readonly, **kwargs)
 
         assert_allclose(peaks, peaks_readonly)

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -786,9 +786,9 @@ class TestFindPeaks:
 
         x_readonly = x.copy()
         x_readonly.flags.writeable = False
-        peaks_only, _ = find_peaks(x_readonly, **kwargs)
+        peaks_readonly, _ = find_peaks(x_readonly, **kwargs)
 
-        assert_allclose(peaks, peaks_only)
+        assert_allclose(peaks, peaks_readonly)
 
 
 class TestFindPeaksCwt:


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes gh-16197

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR enables the Cython to work on readonly memoryviews.
