### PR TITLE
DOC: add import NumPy in linalg decomposition function examples

### DIFF
--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -181,6 +181,7 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
 
     Examples
     --------
+    >>> import numpy as np
     >>> from scipy import linalg
     >>> a = np.array([[0., -1.], [1., 0.]])
     >>> linalg.eigvals(a)
@@ -405,6 +406,7 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
 
     Examples
     --------
+    >>> import numpy as np
     >>> from scipy.linalg import eigh
     >>> A = np.array([[6, 3, 1, 5], [3, 0, 5, 1], [1, 5, 6, 2], [5, 1, 2, 2]])
     >>> w, v = eigh(A)
@@ -733,6 +735,7 @@ def eig_banded(a_band, lower=False, eigvals_only=False, overwrite_a_band=False,
 
     Examples
     --------
+    >>> import numpy as np
     >>> from scipy.linalg import eig_banded
     >>> A = np.array([[1, 5, 2, 0], [5, 2, 5, 2], [2, 5, 3, 5], [0, 2, 5, 4]])
     >>> Ab = np.array([[1, 2, 3, 4], [5, 5, 5, 0], [2, 2, 0, 0]])
@@ -862,6 +865,7 @@ def eigvals(a, b=None, overwrite_a=False, check_finite=True,
 
     Examples
     --------
+    >>> import numpy as np
     >>> from scipy import linalg
     >>> a = np.array([[0., -1.], [1., 0.]])
     >>> linalg.eigvals(a)
@@ -1000,6 +1004,7 @@ def eigvalsh(a, b=None, lower=True, overwrite_a=False,
     --------
     For more examples see `scipy.linalg.eigh`.
 
+    >>> import numpy as np
     >>> from scipy.linalg import eigvalsh
     >>> A = np.array([[6, 3, 1, 5], [3, 0, 5, 1], [1, 5, 6, 2], [5, 1, 2, 2]])
     >>> w = eigvalsh(A)
@@ -1094,6 +1099,7 @@ def eigvals_banded(a_band, lower=False, overwrite_a_band=False,
 
     Examples
     --------
+    >>> import numpy as np
     >>> from scipy.linalg import eigvals_banded
     >>> A = np.array([[1, 5, 2, 0], [5, 2, 5, 2], [2, 5, 3, 5], [0, 2, 5, 4]])
     >>> Ab = np.array([[1, 2, 3, 4], [5, 5, 5, 0], [2, 2, 0, 0]])
@@ -1172,6 +1178,7 @@ def eigvalsh_tridiagonal(d, e, select='a', select_range=None,
 
     Examples
     --------
+    >>> import numpy as np
     >>> from scipy.linalg import eigvalsh_tridiagonal, eigvalsh
     >>> d = 3*np.ones(4)
     >>> e = -1*np.ones(3)
@@ -1266,6 +1273,7 @@ def eigh_tridiagonal(d, e, eigvals_only=False, select='a', select_range=None,
 
     Examples
     --------
+    >>> import numpy as np
     >>> from scipy.linalg import eigh_tridiagonal
     >>> d = 3*np.ones(4)
     >>> e = -1*np.ones(3)
@@ -1391,6 +1399,7 @@ def hessenberg(a, calc_q=False, overwrite_a=False, check_finite=True):
 
     Examples
     --------
+    >>> import numpy as np
     >>> from scipy.linalg import hessenberg
     >>> A = np.array([[2, 5, 8, 7], [5, 2, 2, 8], [7, 5, 6, 6], [5, 4, 4, 8]])
     >>> H, Q = hessenberg(A, calc_q=True)
@@ -1484,6 +1493,7 @@ def cdf2rdf(w, v):
 
     Examples
     --------
+    >>> import numpy as np
     >>> X = np.array([[1, 2, 3], [0, 4, 5], [0, -5, 4]])
     >>> X
     array([[ 1,  2,  3],

--- a/scipy/linalg/_decomp_cholesky.py
+++ b/scipy/linalg/_decomp_cholesky.py
@@ -74,6 +74,7 @@ def cholesky(a, lower=False, overwrite_a=False, check_finite=True):
 
     Examples
     --------
+    >>> import numpy as np
     >>> from scipy.linalg import cholesky
     >>> a = np.array([[1,-2j],[2j,5]])
     >>> L = cholesky(a, lower=True)
@@ -137,6 +138,7 @@ def cho_factor(a, lower=False, overwrite_a=False, check_finite=True):
 
     Examples
     --------
+    >>> import numpy as np
     >>> from scipy.linalg import cho_factor
     >>> A = np.array([[9, 3, 1, 5], [3, 7, 5, 1], [1, 5, 9, 2], [5, 1, 2, 6]])
     >>> c, low = cho_factor(A)
@@ -181,6 +183,7 @@ def cho_solve(c_and_lower, b, overwrite_b=False, check_finite=True):
 
     Examples
     --------
+    >>> import numpy as np
     >>> from scipy.linalg import cho_factor, cho_solve
     >>> A = np.array([[9, 3, 1, 5], [3, 7, 5, 1], [1, 5, 9, 2], [5, 1, 2, 6]])
     >>> c, low = cho_factor(A)
@@ -260,6 +263,7 @@ def cholesky_banded(ab, overwrite_ab=False, lower=False, check_finite=True):
 
     Examples
     --------
+    >>> import numpy as np
     >>> from scipy.linalg import cholesky_banded
     >>> from numpy import allclose, zeros, diag
     >>> Ab = np.array([[0, 0, 1j, 2, 3j], [0, -1, -2, 3, 4], [9, 8, 7, 6, 9]])
@@ -321,6 +325,7 @@ def cho_solve_banded(cb_and_lower, b, overwrite_b=False, check_finite=True):
 
     Examples
     --------
+    >>> import numpy as np
     >>> from scipy.linalg import cholesky_banded, cho_solve_banded
     >>> Ab = np.array([[0, 0, 1j, 2, 3j], [0, -1, -2, 3, 4], [9, 8, 7, 6, 9]])
     >>> A = np.diag(Ab[0,2:], k=2) + np.diag(Ab[1,1:], k=1)

--- a/scipy/linalg/_decomp_lu.py
+++ b/scipy/linalg/_decomp_lu.py
@@ -53,6 +53,7 @@ def lu_factor(a, overwrite_a=False, check_finite=True):
 
     Examples
     --------
+    >>> import numpy as np
     >>> from scipy.linalg import lu_factor
     >>> A = np.array([[2, 5, 8, 7], [5, 2, 2, 8], [7, 5, 6, 6], [5, 4, 4, 8]])
     >>> lu, piv = lu_factor(A)
@@ -121,6 +122,7 @@ def lu_solve(lu_and_piv, b, trans=0, overwrite_b=False, check_finite=True):
 
     Examples
     --------
+    >>> import numpy as np
     >>> from scipy.linalg import lu_factor, lu_solve
     >>> A = np.array([[2, 5, 8, 7], [5, 2, 2, 8], [7, 5, 6, 6], [5, 4, 4, 8]])
     >>> b = np.array([1, 1, 1, 1])
@@ -198,6 +200,7 @@ def lu(a, permute_l=False, overwrite_a=False, check_finite=True):
 
     Examples
     --------
+    >>> import numpy as np
     >>> from scipy.linalg import lu
     >>> A = np.array([[2, 5, 8, 7], [5, 2, 2, 8], [7, 5, 6, 6], [5, 4, 4, 8]])
     >>> p, l, u = lu(A)

--- a/scipy/linalg/_decomp_polar.py
+++ b/scipy/linalg/_decomp_polar.py
@@ -45,6 +45,7 @@ def polar(a, side="right"):
 
     Examples
     --------
+    >>> import numpy as np
     >>> from scipy.linalg import polar
     >>> a = np.array([[1, -1], [2, 4]])
     >>> u, p = polar(a)

--- a/scipy/linalg/_decomp_qr.py
+++ b/scipy/linalg/_decomp_qr.py
@@ -84,6 +84,7 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False,
 
     Examples
     --------
+    >>> import numpy as np
     >>> from scipy import linalg
     >>> rng = np.random.default_rng()
     >>> a = rng.standard_normal((9, 6))
@@ -230,6 +231,7 @@ def qr_multiply(a, c, mode='right', pivoting=False, conjugate=False,
 
     Examples
     --------
+    >>> import numpy as np
     >>> from scipy.linalg import qr_multiply, qr
     >>> A = np.array([[1, 3, 3], [2, 3, 2], [2, 3, 3], [1, 3, 2]])
     >>> qc, r1, piv1 = qr_multiply(A, 2*np.eye(4), pivoting=1)
@@ -369,6 +371,7 @@ def rq(a, overwrite_a=False, lwork=None, mode='full', check_finite=True):
 
     Examples
     --------
+    >>> import numpy as np
     >>> from scipy import linalg
     >>> rng = np.random.default_rng()
     >>> a = rng.standard_normal((6, 9))

--- a/scipy/linalg/_decomp_qz.py
+++ b/scipy/linalg/_decomp_qz.py
@@ -224,6 +224,7 @@ def qz(A, B, output='real', lwork=None, sort=None, overwrite_a=False,
 
     Examples
     --------
+    >>> import numpy as np
     >>> from scipy import linalg
     >>> rng = np.random.default_rng()
     >>> A = np.arange(9).reshape((3, 3))
@@ -339,6 +340,7 @@ def ordqz(A, B, sort='lhp', output='real', overwrite_a=False,
 
     Examples
     --------
+    >>> import numpy as np
     >>> from scipy.linalg import ordqz
     >>> A = np.array([[2, 5, 8, 7], [5, 2, 2, 8], [7, 5, 6, 6], [5, 4, 4, 8]])
     >>> B = np.array([[0, 6, 0, 0], [5, 0, 2, 1], [5, 2, 6, 6], [4, 7, 7, 7]])

--- a/scipy/linalg/_decomp_schur.py
+++ b/scipy/linalg/_decomp_schur.py
@@ -85,6 +85,7 @@ def schur(a, output='real', lwork=None, overwrite_a=False, sort=None,
 
     Examples
     --------
+    >>> import numpy as np
     >>> from scipy.linalg import schur, eigvals
     >>> A = np.array([[0, 2, 2], [0, 1, 2], [1, 0, 1]])
     >>> T, Z = schur(A)
@@ -238,6 +239,7 @@ def rsf2csf(T, Z, check_finite=True):
 
     Examples
     --------
+    >>> import numpy as np
     >>> from scipy.linalg import schur, rsf2csf
     >>> A = np.array([[0, 2, 2], [0, 1, 2], [1, 0, 1]])
     >>> T, Z = schur(A)

--- a/scipy/linalg/_decomp_svd.py
+++ b/scipy/linalg/_decomp_svd.py
@@ -182,6 +182,7 @@ def svdvals(a, overwrite_a=False, check_finite=True):
 
     Examples
     --------
+    >>> import numpy as np
     >>> from scipy.linalg import svdvals
     >>> m = np.array([[1.0, 0.0],
     ...               [2.0, 3.0],
@@ -255,6 +256,7 @@ def diagsvd(s, M, N):
 
     Examples
     --------
+    >>> import numpy as np
     >>> from scipy.linalg import diagsvd
     >>> vals = np.array([1, 2, 3])  # The array representing the computed svd
     >>> diagsvd(vals, 3, 4)
@@ -307,6 +309,7 @@ def orth(A, rcond=None):
 
     Examples
     --------
+    >>> import numpy as np
     >>> from scipy.linalg import orth
     >>> A = np.array([[2, 0, 0], [0, 5, 0]])  # rank 2 array
     >>> orth(A)
@@ -356,6 +359,7 @@ def null_space(A, rcond=None):
     --------
     1-D null space:
 
+    >>> import numpy as np
     >>> from scipy.linalg import null_space
     >>> A = np.array([[1, 1], [1, 1]])
     >>> ns = null_space(A)

--- a/scipy/linalg/_decomp_update.pyx.in
+++ b/scipy/linalg/_decomp_update.pyx.in
@@ -1466,6 +1466,7 @@ def qr_delete(Q, R, k, int p=1, which='row', overwrite_qr=False,
 
     Examples
     --------
+    >>> import numpy as np
     >>> from scipy import linalg
     >>> a = np.array([[  3.,  -2.,  -2.],
     ...               [  6.,  -9.,  -3.],
@@ -1692,6 +1693,7 @@ def qr_insert(Q, R, u, k, which='row', rcond=None, overwrite_qru=False, check_fi
 
     Examples
     --------
+    >>> import numpy as np
     >>> from scipy import linalg
     >>> a = np.array([[  3.,  -2.,  -2.],
     ...               [  6.,  -7.,   4.],
@@ -2093,6 +2095,7 @@ def qr_update(Q, R, u, v, overwrite_qruv=False, check_finite=True):
 
     Examples
     --------
+    >>> import numpy as np
     >>> from scipy import linalg
     >>> a = np.array([[  3.,  -2.,  -2.],
     ...               [  6.,  -9.,  -3.],


### PR DESCRIPTION
Relates to https://github.com/scipy/scipy/issues/13049

This PR (which is part of the SciPy sprint) adds the missing `import numpy as np` for examples in `linalg/_decomp_...py` files