### PR TITLE
TST: updated rng syntax 

### DIFF
--- a/scipy/spatial/tests/test_hausdorff.py
+++ b/scipy/spatial/tests/test_hausdorff.py
@@ -115,10 +115,11 @@ class TestHausdorff:
     def test_invalid_dimensions(self):
         # Ensure that a ValueError is raised when the number of columns
         # is not the same
-        np.random.seed(1234)
-        A = np.random.rand(3, 2)
-        B = np.random.rand(4, 5)
-        with pytest.raises(ValueError):
+        rng = np.random.default_rng(189048172503940875434364128139223470523)
+        A = rng.random((3, 2))
+        B = rng.random((3, 5))
+        msg = r"number of columns is not the same"
+        with pytest.raises(ValueError, match=msg):
             directed_hausdorff(A, B)
 
     @pytest.mark.parametrize("A, B, seed, expected", [

--- a/scipy/spatial/tests/test_hausdorff.py
+++ b/scipy/spatial/tests/test_hausdorff.py
@@ -118,7 +118,7 @@ class TestHausdorff:
         rng = np.random.default_rng(189048172503940875434364128139223470523)
         A = rng.random((3, 2))
         B = rng.random((3, 5))
-        msg = r"number of columns is not the same"
+        msg = r"need to have the same number of columns"
         with pytest.raises(ValueError, match=msg):
             directed_hausdorff(A, B)
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

There is no reference issue. This update was suggested at scipy conference sprint. 

#### What does this implement/fix?
<!--Please explain your changes.-->

Updated Hausdorff test_invalid_dimensions() to use numpy rng and new seed. Also changed input array shapes so that row size is the same in both arrays and test only checks column size. Finally, added match param to pytest exception message.

#### Additional information
<!--Any additional information you think is important.-->


cc @tupui 