### PR TITLE
BUG: cluster: fix `leaves_color_list` issue

### DIFF
--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -3396,7 +3396,7 @@ def _get_leaves_color_list(R):
                                           R['dcoord'],
                                           R['color_list']):
         for (xi, yi) in zip(link_x, link_y):
-            if yi == 0.0 and xi % 5 == 0.0 and xi % 2 == 1:  
+            if yi == 0.0 and (xi % 5 == 0 and xi % 2 == 1):
                 # if yi is 0.0 and xi is divisible by 5 and odd, the point is a leaf
                 # xi of leaves are      5, 15, 25, 35, ... (see `iv_ticks`)
                 # index of leaves are   0,  1,  2,  3, ... as below

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -3396,8 +3396,8 @@ def _get_leaves_color_list(R):
                                           R['dcoord'],
                                           R['color_list']):
         for (xi, yi) in zip(link_x, link_y):
-            if yi == 0.0 and xi % 5 == 0.0 and not xi % 10 == 0:  
-                # if yi is 0.0 and xi is divisible by 5 , the point is a leaf
+            if yi == 0.0 and xi % 5 == 0.0 and xi % 2 == 1:  
+                # if yi is 0.0 and xi is divisible by 5 and odd, the point is a leaf
                 # xi of leaves are      5, 15, 25, 35, ... (see `iv_ticks`)
                 # index of leaves are   0,  1,  2,  3, ... as below
                 leaf_index = (int(xi) - 5) // 10

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -3396,7 +3396,8 @@ def _get_leaves_color_list(R):
                                           R['dcoord'],
                                           R['color_list']):
         for (xi, yi) in zip(link_x, link_y):
-            if yi == 0.0 and xi % 5 == 0.0 and not xi % 10 == 0:  # if yi is 0.0 and xi is divisible by 5 , the point is a leaf
+            if yi == 0.0 and xi % 5 == 0.0 and not xi % 10 == 0:  
+                # if yi is 0.0 and xi is divisible by 5 , the point is a leaf
                 # xi of leaves are      5, 15, 25, 35, ... (see `iv_ticks`)
                 # index of leaves are   0,  1,  2,  3, ... as below
                 leaf_index = (int(xi) - 5) // 10

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -3396,7 +3396,7 @@ def _get_leaves_color_list(R):
                                           R['dcoord'],
                                           R['color_list']):
         for (xi, yi) in zip(link_x, link_y):
-            if yi == 0.0:  # if yi is 0.0, the point is a leaf
+            if yi == 0.0 and xi % 5 == 0.0 and not xi % 10 == 0:  # if yi is 0.0 and xi is divisible by 5 , the point is a leaf
                 # xi of leaves are      5, 15, 25, 35, ... (see `iv_ticks`)
                 # index of leaves are   0,  1,  2,  3, ... as below
                 leaf_index = (int(xi) - 5) // 10

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -3397,7 +3397,8 @@ def _get_leaves_color_list(R):
                                           R['color_list']):
         for (xi, yi) in zip(link_x, link_y):
             if yi == 0.0 and (xi % 5 == 0 and xi % 2 == 1):
-                # if yi is 0.0 and xi is divisible by 5 and odd, the point is a leaf
+                # if yi is 0.0 and xi is divisible by 5 and odd,
+                # the point is a leaf
                 # xi of leaves are      5, 15, 25, 35, ... (see `iv_ticks`)
                 # index of leaves are   0,  1,  2,  3, ... as below
                 leaf_index = (int(xi) - 5) // 10

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -950,7 +950,7 @@ class TestDendrogram:
         # reset color palette (global list)
         set_link_color_palette(None)
    
-    def test_dendrogram_leaf_colors_zero_dist(self) :
+    def test_dendrogram_leaf_colors_zero_dist(self):
         # tests that the colors of leafs are correct for tree
         # with two identical points
         x = np.array([[1, 0, 0], 
@@ -965,7 +965,7 @@ class TestDendrogram:
         colors = d["leaves_color_list"]
         assert_equal(colors, exp_colors)
 
-    def test_dendrogram_leaf_colors(self) :
+    def test_dendrogram_leaf_colors(self):
         # tests that the colors are correct for a tree 
         # with two near points ((0, 0, 1.1) and (0, 0, 1))
         x = np.array([[1, 0, 0], 

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -949,7 +949,37 @@ class TestDendrogram:
 
         # reset color palette (global list)
         set_link_color_palette(None)
+   
+    def test_dendrogram_leaf_colors_zero_dist(self) :
+            # tests that the colors of leafs are correct for tree
+            # with two identical points
+            x = np.array([[1, 0, 0], 
+                [0, 0, 1], 
+                [0, 2, 0], 
+                [0, 0, 1], 
+                [0, 1, 0], 
+                [0, 1, 0]])
+            z = linkage(x, "single")
+            d = dendrogram(z)
+            exp_colors = ['C0', 'C1', 'C1', 'C0', 'C2', 'C2']
+            colors = d["leaves_color_list"]
+            assert_equal(colors, exp_colors)
 
+    def test_dendrogram_leaf_colors(self) :
+            # tests that the colors are correct for a tree 
+            # with two near points ((0, 0, 1.1) and (0, 0, 1))
+            x = np.array([[1, 0, 0], 
+                [0, 0, 1.1], 
+                [0, 2, 0], 
+                [0, 0, 1], 
+                [0, 1, 0], 
+                [0, 1, 0]])
+            z = linkage(x, "single")
+            d = dendrogram(z)
+            exp_colors = ['C0', 'C1', 'C1', 'C0', 'C2', 'C2']
+            colors = d["leaves_color_list"]
+            assert_equal(colors, exp_colors)        
+        
 
 def calculate_maximum_distances(Z):
     # Used for testing correctness of maxdists.

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -960,7 +960,7 @@ class TestDendrogram:
             [0, 1, 0], 
             [0, 1, 0]])
         z = linkage(x, "single")
-        d = dendrogram(z)
+        d = dendrogram(z, no_plot=True)
         exp_colors = ['C0', 'C1', 'C1', 'C0', 'C2', 'C2']
         colors = d["leaves_color_list"]
         assert_equal(colors, exp_colors)
@@ -975,10 +975,10 @@ class TestDendrogram:
             [0, 1, 0], 
             [0, 1, 0]])
         z = linkage(x, "single")
-        d = dendrogram(z)
+        d = dendrogram(z, no_plot=True)
         exp_colors = ['C0', 'C1', 'C1', 'C0', 'C2', 'C2']
         colors = d["leaves_color_list"]
-        assert_equal(colors, exp_colors)        
+        assert_equal(colors, exp_colors)
         
 
 def calculate_maximum_distances(Z):

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -949,16 +949,16 @@ class TestDendrogram:
 
         # reset color palette (global list)
         set_link_color_palette(None)
-   
+
     def test_dendrogram_leaf_colors_zero_dist(self):
         # tests that the colors of leafs are correct for tree
         # with two identical points
-        x = np.array([[1, 0, 0], 
-            [0, 0, 1], 
-            [0, 2, 0], 
-            [0, 0, 1], 
-            [0, 1, 0], 
-            [0, 1, 0]])
+        x = np.array([[1, 0, 0],
+                      [0, 0, 1],
+                      [0, 2, 0],
+                      [0, 0, 1],
+                      [0, 1, 0],
+                      [0, 1, 0]])
         z = linkage(x, "single")
         d = dendrogram(z, no_plot=True)
         exp_colors = ['C0', 'C1', 'C1', 'C0', 'C2', 'C2']
@@ -966,20 +966,20 @@ class TestDendrogram:
         assert_equal(colors, exp_colors)
 
     def test_dendrogram_leaf_colors(self):
-        # tests that the colors are correct for a tree 
+        # tests that the colors are correct for a tree
         # with two near points ((0, 0, 1.1) and (0, 0, 1))
-        x = np.array([[1, 0, 0], 
-            [0, 0, 1.1], 
-            [0, 2, 0], 
-            [0, 0, 1], 
-            [0, 1, 0], 
-            [0, 1, 0]])
+        x = np.array([[1, 0, 0],
+                      [0, 0, 1.1],
+                      [0, 2, 0],
+                      [0, 0, 1],
+                      [0, 1, 0],
+                      [0, 1, 0]])
         z = linkage(x, "single")
         d = dendrogram(z, no_plot=True)
         exp_colors = ['C0', 'C1', 'C1', 'C0', 'C2', 'C2']
         colors = d["leaves_color_list"]
         assert_equal(colors, exp_colors)
-        
+
 
 def calculate_maximum_distances(Z):
     # Used for testing correctness of maxdists.

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -951,34 +951,34 @@ class TestDendrogram:
         set_link_color_palette(None)
    
     def test_dendrogram_leaf_colors_zero_dist(self) :
-            # tests that the colors of leafs are correct for tree
-            # with two identical points
-            x = np.array([[1, 0, 0], 
-                [0, 0, 1], 
-                [0, 2, 0], 
-                [0, 0, 1], 
-                [0, 1, 0], 
-                [0, 1, 0]])
-            z = linkage(x, "single")
-            d = dendrogram(z)
-            exp_colors = ['C0', 'C1', 'C1', 'C0', 'C2', 'C2']
-            colors = d["leaves_color_list"]
-            assert_equal(colors, exp_colors)
+        # tests that the colors of leafs are correct for tree
+        # with two identical points
+        x = np.array([[1, 0, 0], 
+            [0, 0, 1], 
+            [0, 2, 0], 
+            [0, 0, 1], 
+            [0, 1, 0], 
+            [0, 1, 0]])
+        z = linkage(x, "single")
+        d = dendrogram(z)
+        exp_colors = ['C0', 'C1', 'C1', 'C0', 'C2', 'C2']
+        colors = d["leaves_color_list"]
+        assert_equal(colors, exp_colors)
 
     def test_dendrogram_leaf_colors(self) :
-            # tests that the colors are correct for a tree 
-            # with two near points ((0, 0, 1.1) and (0, 0, 1))
-            x = np.array([[1, 0, 0], 
-                [0, 0, 1.1], 
-                [0, 2, 0], 
-                [0, 0, 1], 
-                [0, 1, 0], 
-                [0, 1, 0]])
-            z = linkage(x, "single")
-            d = dendrogram(z)
-            exp_colors = ['C0', 'C1', 'C1', 'C0', 'C2', 'C2']
-            colors = d["leaves_color_list"]
-            assert_equal(colors, exp_colors)        
+        # tests that the colors are correct for a tree 
+        # with two near points ((0, 0, 1.1) and (0, 0, 1))
+        x = np.array([[1, 0, 0], 
+            [0, 0, 1.1], 
+            [0, 2, 0], 
+            [0, 0, 1], 
+            [0, 1, 0], 
+            [0, 1, 0]])
+        z = linkage(x, "single")
+        d = dendrogram(z)
+        exp_colors = ['C0', 'C1', 'C1', 'C0', 'C2', 'C2']
+        colors = d["leaves_color_list"]
+        assert_equal(colors, exp_colors)        
         
 
 def calculate_maximum_distances(Z):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #16558

#### What does this implement/fix?
This fixes `scipy/clustering/hierarchy.py` dendrogram function from returning improper color values for leaves representing clusters with 0 distance between them. 

#### Additional information
<!--Any additional information you think is important.-->
