### PR TITLE
BUG: eps param no effect fixed

### DIFF
--- a/scipy/spatial/ckdtree/src/query_pairs.cxx
+++ b/scipy/spatial/ckdtree/src/query_pairs.cxx
@@ -98,6 +98,7 @@ traverse_checking(const ckdtree *self,
             const double p = tracker->p;
             const double tub = tracker->upper_bound;
             const double *data = self->raw_data;
+            const double epsfac = tracker->epsfac;
             const ckdtree_intp_t *indices = self->raw_indices;
             const ckdtree_intp_t m = self->m;
             const ckdtree_intp_t start1 = lnode1->start_idx;
@@ -136,7 +137,7 @@ traverse_checking(const ckdtree *self,
                             data + indices[j] * m,
                             p, m, tub);
 
-                    if (d <= tub)
+                    if (d <= tub/epsfac)
                         add_ordered_pair(results, indices[i], indices[j]);
                 }
             }

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -782,6 +782,21 @@ def test_kdtree_query_pairs(kdtree_type):
     assert_array_equal(l0, l2)
 
 
+def test_query_pairs_eps(kdtree_type):
+        spacing = np.sqrt(2) 
+        # irrational spacing to have potential rounding errors
+        x_range = np.linspace(0, 3 * spacing, 4)
+        y_range = np.linspace(0, 3 * spacing, 4)
+        xy_array = [(xi, yi) for xi in x_range for yi in y_range]
+        tree = kdtree_type(xy_array)
+
+        pairs_eps = tree.query_pairs(r=spacing, eps=.1)
+        # result: 24 with eps, 16 without due to rounding
+        pairs = tree.query_pairs(r=spacing * 1.01)
+        # result: 24
+        assert_equal(pairs, pairs_eps)
+
+
 def test_ball_point_ints(kdtree_type):
     # Regression test for #1373.
     x, y = np.mgrid[0:4, 0:4]

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -783,7 +783,7 @@ def test_kdtree_query_pairs(kdtree_type):
 
 
 def test_query_pairs_eps(kdtree_type):
-    spacing = np.sqrt(2) 
+    spacing = np.sqrt(2)
     # irrational spacing to have potential rounding errors
     x_range = np.linspace(0, 3 * spacing, 4)
     y_range = np.linspace(0, 3 * spacing, 4)

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -783,18 +783,17 @@ def test_kdtree_query_pairs(kdtree_type):
 
 
 def test_query_pairs_eps(kdtree_type):
-        spacing = np.sqrt(2) 
-        # irrational spacing to have potential rounding errors
-        x_range = np.linspace(0, 3 * spacing, 4)
-        y_range = np.linspace(0, 3 * spacing, 4)
-        xy_array = [(xi, yi) for xi in x_range for yi in y_range]
-        tree = kdtree_type(xy_array)
-
-        pairs_eps = tree.query_pairs(r=spacing, eps=.1)
-        # result: 24 with eps, 16 without due to rounding
-        pairs = tree.query_pairs(r=spacing * 1.01)
-        # result: 24
-        assert_equal(pairs, pairs_eps)
+    spacing = np.sqrt(2) 
+    # irrational spacing to have potential rounding errors
+    x_range = np.linspace(0, 3 * spacing, 4)
+    y_range = np.linspace(0, 3 * spacing, 4)
+    xy_array = [(xi, yi) for xi in x_range for yi in y_range]
+    tree = kdtree_type(xy_array)
+    pairs_eps = tree.query_pairs(r=spacing, eps=.1)
+    # result: 24 with eps, 16 without due to rounding
+    pairs = tree.query_pairs(r=spacing * 1.01)
+    # result: 24
+    assert_equal(pairs, pairs_eps)
 
 
 def test_ball_point_ints(kdtree_type):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #16600

#### What does this implement/fix?
Adds eps to be considered in kdtree's `query_pairs()` function

#### Additional information
Would you like me to implement a test in `scipy/spatial/tests/test_kdtree.py` that uses code similar to the example in issue #16600?
