### PR TITLE
MAINT: stats.gaussian_kde: raise informative message with degenerate data

### DIFF
--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -1,4 +1,4 @@
-from scipy import stats
+from scipy import stats, linalg
 import numpy as np
 from numpy.testing import (assert_almost_equal, assert_,
     assert_array_almost_equal, assert_array_almost_equal_nulp, assert_allclose)
@@ -482,3 +482,15 @@ def test_seed():
     test_seed_sub(gkde_2d)
     gkde_2d_weighted = stats.gaussian_kde(xn_2d, weights=wn)
     test_seed_sub(gkde_2d_weighted)
+
+
+def test_singular_data_covariance_gh10205():
+    # When the data lie in a lower-dimensional subspace, raise an informative
+    # error message.
+    rng = np.random.default_rng(abs(hash("Singular Covariance")))
+    mu = np.array([1, 10, 20])
+    sigma = np.array([[4, 10, 0], [10, 25, 0], [0, 0, 100]])
+    data = rng.multivariate_normal(mu, sigma, 1000)
+    msg = "The data appears to lie in a lower-dimensional subspace..."
+    with assert_raises(linalg.LinAlgError, match=msg):
+        stats.gaussian_kde(data.T)

--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -485,12 +485,15 @@ def test_seed():
 
 
 def test_singular_data_covariance_gh10205():
-    # When the data lie in a lower-dimensional subspace, raise an informative
-    # error message.
-    rng = np.random.default_rng(abs(hash("Singular Covariance")))
+    # When the data lie in a lower-dimensional subspace and this causes
+    # and exception, check that the error message is informative.
+    rng = np.random.default_rng(2321583144339784787)
     mu = np.array([1, 10, 20])
     sigma = np.array([[4, 10, 0], [10, 25, 0], [0, 0, 100]])
     data = rng.multivariate_normal(mu, sigma, 1000)
-    msg = "The data appears to lie in a lower-dimensional subspace..."
-    with assert_raises(linalg.LinAlgError, match=msg):
+    try:  # doesn't raise any error on some platforms, and that's OK
         stats.gaussian_kde(data.T)
+    except linalg.LinAlgError:
+        msg = "The data appears to lie in a lower-dimensional subspace..."
+        with assert_raises(linalg.LinAlgError, match=msg):
+            stats.gaussian_kde(data.T)


### PR DESCRIPTION
#### Reference issue
gh-10205

#### What does this implement/fix?
gh-10205 reported that `gaussian_kde` raised a confusing error for their data. The data is degenerate: it lies in a lower-dimensional subspace of the space in which it is expressed. This PR documents that `gaussian_kde` does not support such data and attempts to clarifies the error message and outline a possible solution.

#### Additional information
After merging this, we can remove the defect label from gh-10205 and use it to track two enhancements for KDE: support for singular matrices and eliminating regular use of the covariance matrix inverse (gh-5087). I think we can accomplish both with `scipy.linalg.ldl`.