### PR TITLE
DOC: update benchmarking docs to use dev.py user interface

### DIFF
--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -42,6 +42,7 @@
         "pytest": [],
         "pythran": [],
         "pybind11": [],
+        "meson-python": [],
     },
 
     // The directory (relative to the current directory) that benchmarks are

--- a/dev.py
+++ b/dev.py
@@ -839,7 +839,7 @@ class Bench(Task):
 
     @classmethod
     def run(cls, **kwargs):
-        """run benchamark"""
+        """run benchmark"""
         kwargs.update(cls.ctx.get())
         Args = namedtuple('Args', [k for k in kwargs.keys()])
         args = Args(**kwargs)

--- a/doc/source/dev/contributor/benchmarking.rst
+++ b/doc/source/dev/contributor/benchmarking.rst
@@ -92,9 +92,9 @@ submitting a pull request.
 To run all benchmarks, navigate to the root SciPy directory at the
 command line and execute::
 
-   python dev.py --bench
+   python dev.py bench
 
-where ``--bench`` activates the benchmark suite instead of the test
+where ``bench`` activates the benchmark suite instead of the test
 suite. This builds SciPy and runs the benchmarks. (*Note: this could
 take a while. Benchmarks often take longer to run than unit tests, and
 each benchmark is run multiple times to measure the distribution in
@@ -104,17 +104,17 @@ To run benchmarks from a particular benchmark module, such as
 ``optimize_linprog.py``, simply append the filename without the
 extension::
 
-   python dev.py --bench optimize_linprog
+   python dev.py bench -t optimize_linprog
 
 To run a benchmark defined in a class, such as ``KleeMinty`` from
 ``optimize_linprog.py``::
 
-   python dev.py --bench optimize_linprog.KleeMinty
+   python dev.py bench -t optimize_linprog.KleeMinty
 
 To compare benchmark results between the active branch and another, such
 as ``main``::
 
-   python dev.py --bench-compare main optimize_linprog.KleeMinty
+python dev.py bench -t main
 
 All of the commands above display the results in plain text in the
 console, and the results are not saved for comparison with future

--- a/doc/source/dev/contributor/benchmarking.rst
+++ b/doc/source/dev/contributor/benchmarking.rst
@@ -92,7 +92,7 @@ submitting a pull request.
 To run all benchmarks, navigate to the root SciPy directory at the
 command line and execute::
 
-   python runtests.py --bench
+   python dev.py --bench
 
 where ``--bench`` activates the benchmark suite instead of the test
 suite. This builds SciPy and runs the benchmarks. (*Note: this could
@@ -104,17 +104,17 @@ To run benchmarks from a particular benchmark module, such as
 ``optimize_linprog.py``, simply append the filename without the
 extension::
 
-   python runtests.py --bench optimize_linprog
+   python dev.py --bench optimize_linprog
 
 To run a benchmark defined in a class, such as ``KleeMinty`` from
 ``optimize_linprog.py``::
 
-   python runtests.py --bench optimize_linprog.KleeMinty
+   python dev.py --bench optimize_linprog.KleeMinty
 
 To compare benchmark results between the active branch and another, such
 as ``main``::
 
-   python runtests.py --bench-compare main optimize_linprog.KleeMinty
+   python dev.py --bench-compare main optimize_linprog.KleeMinty
 
 All of the commands above display the results in plain text in the
 console, and the results are not saved for comparison with future

--- a/doc/source/dev/contributor/benchmarking.rst
+++ b/doc/source/dev/contributor/benchmarking.rst
@@ -114,7 +114,7 @@ To run a benchmark defined in a class, such as ``KleeMinty`` from
 To compare benchmark results between the active branch and another, such
 as ``main``::
 
-python dev.py bench -t main
+python dev.py bench --compare main  # select again by `-t optimize_linprog`
 
 All of the commands above display the results in plain text in the
 console, and the results are not saved for comparison with future


### PR DESCRIPTION
The runtest.py module is being phased out in favor of the dev.py module.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
This fixes the documentation to include the new test module.
#### Additional information
<!--Any additional information you think is important.-->
