### PR TITLE
DOC: better links in readme for newcomers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ integration, linear algebra, Fourier transforms, signal and image processing,
 ODE solvers, and more.
 
 - **Website:** https://scipy.org
-- **Documentation:** https://docs.scipy.org/
+- **Documentation:** https://docs.scipy.org/doc/scipy/
 - **Mailing list:** https://mail.python.org/mailman3/lists/scipy-dev.python.org/
 - **Source code:** https://github.com/scipy/scipy
 - **Contributing:** https://scipy.github.io/devdocs/dev/index.html
@@ -46,7 +46,7 @@ Call for Contributions
 
 We appreciate and welcome contributions. Small improvements or fixes are always appreciated; issues labeled as "good
 first issue" may be a good starting point. Have a look at `our contributing
-guide <http://scipy.github.io/devdocs/dev/hacking.html>`__.
+guide <https://scipy.github.io/devdocs/dev/index.html>`__.
 
 Writing code isn’t the only way to contribute to SciPy. You can also:
 

--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,7 @@ ODE solvers, and more.
 
 - **Website:** https://scipy.org
 - **Documentation:** https://docs.scipy.org/doc/scipy/
+- **Development version of the documentation:** https://scipy.github.io/devdocs
 - **Mailing list:** https://mail.python.org/mailman3/lists/scipy-dev.python.org/
 - **Source code:** https://github.com/scipy/scipy
 - **Contributing:** https://scipy.github.io/devdocs/dev/index.html


### PR DESCRIPTION
During the sprint, we noticed that almost every newcomers were looking into `HACKING.rst.txt`. This is confusing and we should have a single place for users to look at: our dev doc.

I propose to also move `HACKING.rst.txt` from the tree root into our doc. (not done yet here).

---

Something else for the newcomers first path:

* At the end of the [quick start](https://scipy.github.io/devdocs/dev/dev_quickstart.html) guide, we should link to the [dev workflow](https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#development-workflow)
* The dev workflow should be updated to use `dev.py`. This page is not very visible in the TOC (we can use bold or have it as text instead of in the list, add a link to it in the text at the top of the page, etc.).
* The dev workflow is somehow similar to the quick start document and they could almost be merged. 

I can work on these in a PR if wanted.

@melissawm what do you think?