### PR TITLE
MAINT: optimize: always return a float from goal functional wrapper

### DIFF
--- a/scipy/optimize/_direct_py.py
+++ b/scipy/optimize/_direct_py.py
@@ -253,7 +253,8 @@ def direct(
             f = func(x)
         else:
             f = func(x, *args)
-        return f
+        # always return a float
+        return np.asarray(f).item()
 
     # TODO: fix disp argument
     x, fun, ret_code, nfev, nit = _direct(


### PR DESCRIPTION
This is another small fix for array-scalar conversion like https://github.com/scipy/scipy/pull/13864. Tests will otherwise yield a warning with NumPy's https://github.com/numpy/numpy/pull/10615.