### PR TITLE
DOC: optimize: fix doc that `curve_fit` xdata should be float convertible

### DIFF
--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -547,7 +547,8 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
     xdata : array_like or object
         The independent variable where the data is measured.
         Should usually be an M-length sequence or an (k,M)-shaped array for
-        functions with k predictors, but can actually be any object.
+        functions with k predictors, and each element should be float
+        convertible if it is an array like object.
     ydata : array_like
         The dependent data, a length M array - nominally ``f(xdata, ...)``.
     p0 : array_like, optional

--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -544,7 +544,7 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
         The model function, f(x, ...). It must take the independent
         variable as the first argument and the parameters to fit as
         separate remaining arguments.
-    xdata : array_like or object
+    xdata : array_like
         The independent variable where the data is measured.
         Should usually be an M-length sequence or an (k,M)-shaped array for
         functions with k predictors, and each element should be float


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #12632 

#### What does this implement/fix?
<!--Please explain your changes.-->
As reported in #12632, `optimize.curve_fit` converts `xdata` to a float array if it is an array like object.
https://github.com/scipy/scipy/blob/8692c887ac341ace4183f115c55290ec9daf470b/scipy/optimize/minpack.py#L738-L744

However, the `curve_fit` doc says:
https://github.com/scipy/scipy/blob/8692c887ac341ace4183f115c55290ec9daf470b/scipy/optimize/minpack.py#L549
I think this `but can actually be any object` is confusing, because an error will be thrown when a string array is passed:
```
In [6]: from scipy.optimize import curve_fit

In [12]: xdata = np.linspace(0, 4, 5)

In [14]: ydata = func(xdata, 2.5, 1.3, 0.5)

In [15]: curve_fit(func, xdata, ydata)
Out[15]:
(array([2.5, 1.3, 0.5]),
 array([[ 2.84539581e-32, -1.18219014e-32, -1.07893311e-32],
        [-1.18219014e-32,  6.43888987e-32,  1.94671101e-32],
        [-1.07893311e-32,  1.94671101e-32,  1.15640501e-32]]))

In [17]: xdata_str = np.array(["a", "b", "c", "d", "e"])

In [18]: curve_fit(func, xdata_str, ydata)
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-18-da598f831819> in <cell line: 1>()
----> 1 curve_fit(func, xdata_str, ydata)

/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/scipy/optimize/_minpack_py.py in curve_fit(f, xdata, ydata, p0, sigma, absolute_sigma, check_finite, bounds, method, jac, **kwargs)
    741         # non-array_like `xdata`.
    742         if check_finite:
--> 743             xdata = np.asarray_chkfinite(xdata, float)
    744         else:
    745             xdata = np.asarray(xdata, float)

/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/numpy/lib/function_base.py in asarray_chkfinite(a, dtype, order)
    623
    624     """
--> 625     a = asarray(a, dtype=dtype, order=order)
    626     if a.dtype.char in typecodes['AllFloat'] and not np.isfinite(a).all():
    627         raise ValueError(

ValueError: could not convert string to float: 'a'
```

So I clarified the doc.

[skip azp] [skip actions]