### PR TITLE
MAINT: have get_index_dtype follow its documentation and return int32 or int64

### DIFF
--- a/scipy/optimize/_group_columns.py
+++ b/scipy/optimize/_group_columns.py
@@ -52,10 +52,10 @@ def group_dense(m, n, A):
     return groups
 
 
-#pythran export group_sparse(int, int, intc[], intc[])
-#pythran export group_sparse(int, int, int[], int[])
-#pythran export group_sparse(int, int, intc[::], intc[::])
-#pythran export group_sparse(int, int, int[::], int[::])
+#pythran export group_sparse(int, int, int32[], int32[])
+#pythran export group_sparse(int, int, int64[], int64[])
+#pythran export group_sparse(int, int, int32[::], int32[::])
+#pythran export group_sparse(int, int, int64[::], int64[::])
 def group_sparse(m, n, indices, indptr):
     groups = -np.ones(n, dtype=np.intp)
     current_group = 0

--- a/scipy/signal/_max_len_seq.py
+++ b/scipy/signal/_max_len_seq.py
@@ -101,14 +101,15 @@ def max_len_seq(nbits, state=None, length=None, taps=None):
     >>> plt.show()
 
     """
+    taps_dtype = np.int32 if np.intp().itemsize == 4 else np.int64
     if taps is None:
         if nbits not in _mls_taps:
             known_taps = np.array(list(_mls_taps.keys()))
             raise ValueError('nbits must be between %s and %s if taps is None'
                              % (known_taps.min(), known_taps.max()))
-        taps = np.array(_mls_taps[nbits], np.intp)
+        taps = np.array(_mls_taps[nbits], taps_dtype)
     else:
-        taps = np.unique(np.array(taps, np.intp))[::-1]
+        taps = np.unique(np.array(taps, taps_dtype))[::-1]
         if np.any(taps < 0) or np.any(taps > nbits) or taps.size < 1:
             raise ValueError('taps must be non-empty with values between '
                              'zero and nbits (inclusive)')

--- a/scipy/signal/_max_len_seq_inner.py
+++ b/scipy/signal/_max_len_seq_inner.py
@@ -3,8 +3,8 @@
 
 import numpy as np
 
-#pythran export _max_len_seq_inner(intp[], int8[], int, int, int8[])
-#pythran export _max_len_seq_inner(int[], int8[], int, int, int8[])
+#pythran export _max_len_seq_inner(int32[], int8[], int, int, int8[])
+#pythran export _max_len_seq_inner(int64[], int8[], int, int, int8[])
 
 # Fast inner loop of max_len_seq.
 def _max_len_seq_inner(taps, state, nbits, length, seq):

--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -169,7 +169,8 @@ def get_index_dtype(arrays=(), maxval=None, check_contents=False):
     int32min = np.int32(np.iinfo(np.int32).min)
     int32max = np.int32(np.iinfo(np.int32).max)
 
-    dtype = np.intc
+    # not using intc directly due to misinteractions with pythran
+    dtype = np.int32 if np.intc().itemsize == 4 else np.int64
     if maxval is not None:
         maxval = np.int64(maxval)
         if maxval > int32max:


### PR DESCRIPTION
This also avoids np.intc which is a portability pain.
Adjust group_sparse signature accordingly.

This should also fix https://github.com/serge-sans-paille/pythran/issues/2002

