### PR TITLE
MAINT: Fix expit function name typo in test_optimize.py

### DIFF
--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -32,32 +32,32 @@ from scipy.optimize._optimize import MemoizeJac, show_options
 
 def test_check_grad():
     # Verify if check_grad is able to estimate the derivative of the
-    # logistic function.
+    # expit (logistic sigmoid) function.
 
-    def logit(x):
+    def expit(x):
         return 1 / (1 + np.exp(-x))
 
-    def der_logit(x):
+    def der_expit(x):
         return np.exp(-x) / (1 + np.exp(-x))**2
 
     x0 = np.array([1.5])
 
-    r = optimize.check_grad(logit, der_logit, x0)
+    r = optimize.check_grad(expit, der_expit, x0)
     assert_almost_equal(r, 0)
-    r = optimize.check_grad(logit, der_logit, x0,
+    r = optimize.check_grad(expit, der_expit, x0,
                             direction='random', seed=1234)
     assert_almost_equal(r, 0)
 
-    r = optimize.check_grad(logit, der_logit, x0, epsilon=1e-6)
+    r = optimize.check_grad(expit, der_expit, x0, epsilon=1e-6)
     assert_almost_equal(r, 0)
-    r = optimize.check_grad(logit, der_logit, x0, epsilon=1e-6,
+    r = optimize.check_grad(expit, der_expit, x0, epsilon=1e-6,
                             direction='random', seed=1234)
     assert_almost_equal(r, 0)
 
     # Check if the epsilon parameter is being considered.
-    r = abs(optimize.check_grad(logit, der_logit, x0, epsilon=1e-1) - 0)
+    r = abs(optimize.check_grad(expit, der_expit, x0, epsilon=1e-1) - 0)
     assert r > 1e-7
-    r = abs(optimize.check_grad(logit, der_logit, x0, epsilon=1e-1,
+    r = abs(optimize.check_grad(expit, der_expit, x0, epsilon=1e-1,
                                 direction='random', seed=1234) - 0)
     assert r > 1e-7
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #16580 

#### What does this implement/fix?
In ` scipy/optimize/tests/test_optimize.py`, one of the functions used in a test case is the expit/logistic sigmoid function, but the function was incorrectly named the logit function, which is not the same.
