### PR TITLE
ENH: stats: add aliases to results objects

### DIFF
--- a/scipy/stats/_binomtest.py
+++ b/scipy/stats/_binomtest.py
@@ -34,6 +34,9 @@ class BinomTestResult:
         self.statistic = statistic
         self.pvalue = pvalue
 
+        # add alias for backward compatibility
+        self.proportion_estimate = statistic
+
     def __repr__(self):
         s = ("BinomTestResult("
              f"k={self.k}, "
@@ -42,17 +45,6 @@ class BinomTestResult:
              f"statistic={self.statistic}, "
              f"pvalue={self.pvalue})")
         return s
-
-    @property
-    def proportion_estimate(self):
-        """
-        An alias for ``statistic``.
-        """
-        return self.statistic
-
-    @proportion_estimate.setter
-    def proportion_estimate(self, proportion_estimate):
-        self.statistic = proportion_estimate
 
     def proportion_ci(self, confidence_level=0.95, method='exact'):
         """

--- a/scipy/stats/_binomtest.py
+++ b/scipy/stats/_binomtest.py
@@ -21,17 +21,17 @@ class BinomTestResult:
         Indicates the alternative hypothesis specified in the input
         to `binomtest`.  It will be one of ``'two-sided'``, ``'greater'``,
         or ``'less'``.
+    statistic: float
+        The estimate of the proportion of successes.
     pvalue : float
         The p-value of the hypothesis test.
-    proportion_estimate : float
-        The estimate of the proportion of successes.
 
     """
-    def __init__(self, k, n, alternative, pvalue, proportion_estimate):
+    def __init__(self, k, n, alternative, statistic, pvalue):
         self.k = k
         self.n = n
         self.alternative = alternative
-        self.proportion_estimate = proportion_estimate
+        self.statistic = statistic
         self.pvalue = pvalue
 
     def __repr__(self):
@@ -39,13 +39,24 @@ class BinomTestResult:
              f"k={self.k}, "
              f"n={self.n}, "
              f"alternative={self.alternative!r}, "
-             f"proportion_estimate={self.proportion_estimate}, "
+             f"statistic={self.statistic}, "
              f"pvalue={self.pvalue})")
         return s
 
+    @property
+    def proportion_estimate(self):
+        """
+        An alias for ``statistic``.
+        """
+        return self.statistic
+
+    @proportion_estimate.setter
+    def proportion_estimate(self, proportion_estimate):
+        self.statistic = proportion_estimate
+
     def proportion_ci(self, confidence_level=0.95, method='exact'):
         """
-        Compute the confidence interval for the estimated proportion.
+        Compute the confidence interval for ``statistic``.
 
         Parameters
         ----------
@@ -87,7 +98,7 @@ class BinomTestResult:
         --------
         >>> from scipy.stats import binomtest
         >>> result = binomtest(k=7, n=50, p=0.1)
-        >>> result.proportion_estimate
+        >>> result.statistic
         0.14
         >>> result.proportion_ci()
         ConfidenceInterval(low=0.05819170033997342, high=0.26739600249700846)
@@ -233,15 +244,15 @@ def binomtest(k, n, p=0.5, alternative='two-sided'):
             Indicates the alternative hypothesis specified in the input
             to `binomtest`.  It will be one of ``'two-sided'``, ``'greater'``,
             or ``'less'``.
+        statistic : float
+            The estimate of the proportion of successes.
         pvalue : float
             The p-value of the hypothesis test.
-        proportion_estimate : float
-            The estimate of the proportion of successes.
 
         The object has the following methods:
 
         proportion_ci(confidence_level=0.95, method='exact') :
-            Compute the confidence interval for ``proportion_estimate``.
+            Compute the confidence interval for ``statistic``.
 
     Notes
     -----
@@ -268,9 +279,10 @@ def binomtest(k, n, p=0.5, alternative='two-sided'):
     The null hypothesis cannot be rejected at the 5% level of significance
     because the returned p-value is greater than the critical value of 5%.
 
-    The estimated proportion is simply ``3/15``:
+    The test statistic is equal to the estimated proportion, which is simply
+    ``3/15``:
 
-    >>> result.proportion_estimate
+    >>> result.statistic
     0.2
 
     We can use the `proportion_ci()` method of the result to compute the
@@ -325,7 +337,7 @@ def binomtest(k, n, p=0.5, alternative='two-sided'):
         pval = min(1.0, pval)
 
     result = BinomTestResult(k=k, n=n, alternative=alternative,
-                             proportion_estimate=k/n, pvalue=pval)
+                             statistic=k/n, pvalue=pval)
     return result
 
 

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -2207,6 +2207,7 @@ def anderson_ksamp(samples, midrank=True):
         pf = np.polyfit(critical, log(sig), 2)
         p = math.exp(np.polyval(pf, A2))
 
+    # create result object with alias for backward compatibility
     res = Anderson_ksampResult(A2, critical, p)
     res.significance_level = p
     return res

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -2135,7 +2135,7 @@ def anderson_ksamp(samples, midrank=True):
     distribution can be rejected at the 5% level because the returned
     test value is greater than the critical value for 5% (1.961) but
     not at the 2.5% level. The interpolation gives an approximate
-    p-value of 5.0%.
+    p-value of 4.99%.
 
     >>> res = stats.anderson_ksamp([rng.normal(size=50),
     ... rng.normal(size=30), rng.normal(size=20)])

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -2121,24 +2121,17 @@ def anderson_ksamp(samples, midrank=True):
     >>> import numpy as np
     >>> from scipy import stats
     >>> rng = np.random.default_rng()
-
-    The null hypothesis that the two random samples come from the same
-    distribution can be rejected at the 5% level because the returned
-    test value is greater than the critical value for 5% (1.961) but
-    not at the 2.5% level. The interpolation gives an approximate
-    significance level of 3.2%:
-
     >>> stats.anderson_ksamp([rng.normal(size=50),
     ... rng.normal(loc=0.5, size=30)])
     (1.974403288713695,
       array([0.325, 1.226, 1.961, 2.718, 3.752, 4.592, 6.546]),
       0.04991293614572478)
 
-
-    The null hypothesis cannot be rejected for three samples from an
-    identical distribution. The reported p-value (25%) has been capped and
-    may not be very accurate (since it corresponds to the value 0.449
-    whereas the statistic is -0.731):
+    The null hypothesis that the two random samples come from the same
+    distribution can be rejected at the 5% level because the returned
+    test value is greater than the critical value for 5% (1.961) but
+    not at the 2.5% level. The interpolation gives an approximate
+    p-value of 5.0%.
 
     >>> stats.anderson_ksamp([rng.normal(size=50),
     ... rng.normal(size=30), rng.normal(size=20)])
@@ -2146,6 +2139,11 @@ def anderson_ksamp(samples, midrank=True):
       array([ 0.44925884,  1.3052767 ,  1.9434184 ,  2.57696569,  3.41634856,
       4.07210043, 5.56419101]),
       0.25)
+
+    The null hypothesis cannot be rejected for three samples from an
+    identical distribution. The reported p-value (25%) has been capped and
+    may not be very accurate (since it corresponds to the value 0.449
+    whereas the statistic is -0.291).
 
     """
     k = len(samples)

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -2042,9 +2042,10 @@ def _anderson_ksamp_right(samples, Z, Zstar, k, n, N):
     return A2kN
 
 
-Anderson_ksampResult = namedtuple('Anderson_ksampResult',
-                                  ('statistic', 'critical_values',
-                                   'significance_level'))
+Anderson_ksampResult = _make_tuple_bunch(
+    'Anderson_ksampResult',
+    ['statistic', 'critical_values', 'pvalue'], []
+)
 
 
 def anderson_ksamp(samples, midrank=True):
@@ -2068,15 +2069,17 @@ def anderson_ksamp(samples, midrank=True):
 
     Returns
     -------
-    statistic : float
-        Normalized k-sample Anderson-Darling test statistic.
-    critical_values : array
-        The critical values for significance levels 25%, 10%, 5%, 2.5%, 1%,
-        0.5%, 0.1%.
-    significance_level : float
-        An approximate significance level at which the null hypothesis for the
-        provided samples can be rejected. The value is floored / capped at
-        0.1% / 25%.
+    res : Anderson_ksampResult
+        An object containing attributes:
+
+        statistic : float
+            Normalized k-sample Anderson-Darling test statistic.
+        critical_values : array
+            The critical values for significance levels 25%, 10%, 5%, 2.5%, 1%,
+            0.5%, 0.1%.
+        pvalue : float
+            The approximate p-value of the test. The value is floored / capped
+            at 0.1% / 25%.
 
     Raises
     ------
@@ -2121,11 +2124,12 @@ def anderson_ksamp(samples, midrank=True):
     >>> import numpy as np
     >>> from scipy import stats
     >>> rng = np.random.default_rng()
-    >>> stats.anderson_ksamp([rng.normal(size=50),
+    >>> res = stats.anderson_ksamp([rng.normal(size=50),
     ... rng.normal(loc=0.5, size=30)])
-    (1.974403288713695,
-      array([0.325, 1.226, 1.961, 2.718, 3.752, 4.592, 6.546]),
-      0.04991293614572478)
+    >>> res.statistic, res.pvalue
+    (1.974403288713695, 0.04991293614572478)
+    >>> res.critical_values
+    array([0.325, 1.226, 1.961, 2.718, 3.752, 4.592, 6.546])
 
     The null hypothesis that the two random samples come from the same
     distribution can be rejected at the 5% level because the returned
@@ -2133,12 +2137,13 @@ def anderson_ksamp(samples, midrank=True):
     not at the 2.5% level. The interpolation gives an approximate
     p-value of 5.0%.
 
-    >>> stats.anderson_ksamp([rng.normal(size=50),
+    >>> res = stats.anderson_ksamp([rng.normal(size=50),
     ... rng.normal(size=30), rng.normal(size=20)])
-    (-0.29103725200789504,
-      array([ 0.44925884,  1.3052767 ,  1.9434184 ,  2.57696569,  3.41634856,
-      4.07210043, 5.56419101]),
-      0.25)
+    >>> res.statistic, res.pvalue
+    (-0.29103725200789504, 0.25)
+    >>> res.critical_values
+    array([ 0.44925884,  1.3052767 ,  1.9434184 ,  2.57696569,  3.41634856,
+      4.07210043, 5.56419101])
 
     The null hypothesis cannot be rejected for three samples from an
     identical distribution. The reported p-value (25%) has been capped and
@@ -2202,7 +2207,9 @@ def anderson_ksamp(samples, midrank=True):
         pf = np.polyfit(critical, log(sig), 2)
         p = math.exp(np.polyval(pf, A2))
 
-    return Anderson_ksampResult(A2, critical, p)
+    res = Anderson_ksampResult(A2, critical, p)
+    res.significance_level = p
+    return res
 
 
 AnsariResult = namedtuple('AnsariResult', ('statistic', 'pvalue'))

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -5535,7 +5535,8 @@ def _euclidean_dist(x):
     return cdist(x, x)
 
 
-MGCResult = namedtuple('MGCResult', ('stat', 'pvalue', 'mgc_dict'))
+MGCResult = _make_tuple_bunch('MGCResult',
+                              ['statistic', 'pvalue', 'mgc_dict'], [])
 
 
 def multiscale_graphcorr(x, y, compute_distance=_euclidean_dist, reps=1000,
@@ -5606,7 +5607,7 @@ def multiscale_graphcorr(x, y, compute_distance=_euclidean_dist, reps=1000,
 
     Returns
     -------
-    stat : float
+    statistic : float
         The sample MGC test statistic within `[-1, 1]`.
     pvalue : float
         The p-value obtained via permutation.
@@ -5714,33 +5715,25 @@ def multiscale_graphcorr(x, y, compute_distance=_euclidean_dist, reps=1000,
     >>> from scipy.stats import multiscale_graphcorr
     >>> x = np.arange(100)
     >>> y = x
-    >>> stat, pvalue, _ = multiscale_graphcorr(x, y, workers=-1)
-    >>> '%.1f, %.3f' % (stat, pvalue)
-    '1.0, 0.001'
-
-    Alternatively,
-
-    >>> x = np.arange(100)
-    >>> y = x
-    >>> mgc = multiscale_graphcorr(x, y)
-    >>> '%.1f, %.3f' % (mgc.stat, mgc.pvalue)
-    '1.0, 0.001'
+    >>> res = multiscale_graphcorr(x, y)
+    >>> res.statistic, res.pvalue
+    (1.0, 0.001)
 
     To run an unpaired two-sample test,
 
     >>> x = np.arange(100)
     >>> y = np.arange(79)
-    >>> mgc = multiscale_graphcorr(x, y)
-    >>> '%.3f, %.2f' % (mgc.stat, mgc.pvalue)  # doctest: +SKIP
-    '0.033, 0.02'
+    >>> res = multiscale_graphcorr(x, y)
+    >>> res.statistic, res.pvalue  # doctest: +SKIP
+    (0.033258146255703246, 0.023)
 
     or, if shape of the inputs are the same,
 
     >>> x = np.arange(100)
     >>> y = x
-    >>> mgc = multiscale_graphcorr(x, y, is_twosamp=True)
-    >>> '%.3f, %.1f' % (mgc.stat, mgc.pvalue)  # doctest: +SKIP
-    '-0.008, 1.0'
+    >>> res = multiscale_graphcorr(x, y, is_twosamp=True)
+    >>> res.statistic, res.pvalue  # doctest: +SKIP
+    (-0.008021809890200488, 1.0)
 
     """
     if not isinstance(x, np.ndarray) or not isinstance(y, np.ndarray):
@@ -5823,7 +5816,9 @@ def multiscale_graphcorr(x, y, compute_distance=_euclidean_dist, reps=1000,
                 "opt_scale": opt_scale,
                 "null_dist": null_dist}
 
-    return MGCResult(stat, pvalue, mgc_dict)
+    res = MGCResult(stat, pvalue, mgc_dict)
+    res.stat = stat
+    return res
 
 
 def _mgc_stat(distx, disty):

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -5607,21 +5607,23 @@ def multiscale_graphcorr(x, y, compute_distance=_euclidean_dist, reps=1000,
 
     Returns
     -------
-    statistic : float
-        The sample MGC test statistic within `[-1, 1]`.
-    pvalue : float
-        The p-value obtained via permutation.
-    mgc_dict : dict
-        Contains additional useful additional returns containing the following
-        keys:
+    res : MGCResult
+        An object containing attributes:
 
-            - mgc_map : ndarray
-                A 2D representation of the latent geometry of the relationship.
-                of the relationship.
-            - opt_scale : (int, int)
-                The estimated optimal scale as a `(x, y)` pair.
-            - null_dist : list
-                The null distribution derived from the permuted matrices
+        statistic : float
+            The sample MGC test statistic within `[-1, 1]`.
+        pvalue : float
+            The p-value obtained via permutation.
+        mgc_dict : dict
+            Contains additional useful results:
+
+                - mgc_map : ndarray
+                    A 2D representation of the latent geometry of the
+                    relationship.
+                - opt_scale : (int, int)
+                    The estimated optimal scale as a `(x, y)` pair.
+                - null_dist : list
+                    The null distribution derived from the permuted matrices.
 
     See Also
     --------

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -5818,6 +5818,7 @@ def multiscale_graphcorr(x, y, compute_distance=_euclidean_dist, reps=1000,
                 "opt_scale": opt_scale,
                 "null_dist": null_dist}
 
+    # create result object with alias for backward compatibility
     res = MGCResult(stat, pvalue, mgc_dict)
     res.stat = stat
     return res

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -498,6 +498,8 @@ class TestAndersonKSamp:
         attributes = ('statistic', 'critical_values', 'significance_level')
         check_named_results(res, attributes)
 
+        assert_equal(res.significance_level, res.pvalue)
+
 
 class TestAnsari:
 

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -998,6 +998,14 @@ class TestBinomTest:
         with pytest.raises(ValueError, match="method must be"):
             res.proportion_ci(method="plate of shrimp")
 
+    def test_alias(self):
+        res = stats.binomtest(3, n=10, p=0.1)
+        assert_equal(res.proportion_estimate, res.statistic)
+        res.statistic = 0.5
+        assert_equal(res.proportion_estimate, res.statistic)
+        res.proportion_estimate = 0.7
+        assert_equal(res.proportion_estimate, res.statistic)
+
 
 class TestFligner:
 

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -884,7 +884,7 @@ class TestBinomTest:
     def test_confidence_intervals1(self, alternative, pval, ci_low, ci_high):
         res = stats.binomtest(20, n=100, p=0.25, alternative=alternative)
         assert_allclose(res.pvalue, pval, rtol=1e-12)
-        assert_equal(res.proportion_estimate, 0.2)
+        assert_equal(res.statistic, 0.2)
         ci = res.proportion_ci(confidence_level=0.95)
         assert_allclose((ci.low, ci.high), (ci_low, ci_high), rtol=1e-12)
 
@@ -899,7 +899,7 @@ class TestBinomTest:
     def test_confidence_intervals2(self, alternative, pval, ci_low, ci_high):
         res = stats.binomtest(3, n=50, p=0.2, alternative=alternative)
         assert_allclose(res.pvalue, pval, rtol=1e-6)
-        assert_equal(res.proportion_estimate, 0.06)
+        assert_equal(res.statistic, 0.06)
         ci = res.proportion_ci(confidence_level=0.99)
         assert_allclose((ci.low, ci.high), (ci_low, ci_high), rtol=1e-6)
 
@@ -974,7 +974,7 @@ class TestBinomTest:
         # the hypothesized proportion.  When alternative is 'two-sided',
         # the p-value is 1.
         res = stats.binomtest(4, 16, 0.25)
-        assert_equal(res.proportion_estimate, 0.25)
+        assert_equal(res.statistic, 0.25)
         assert_equal(res.pvalue, 1.0)
 
     @pytest.mark.parametrize('k, n', [(0, 0), (-1, 2)])

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1003,10 +1003,6 @@ class TestBinomTest:
     def test_alias(self):
         res = stats.binomtest(3, n=10, p=0.1)
         assert_equal(res.proportion_estimate, res.statistic)
-        res.statistic = 0.5
-        assert_equal(res.proportion_estimate, res.statistic)
-        res.proportion_estimate = 0.7
-        assert_equal(res.proportion_estimate, res.statistic)
 
 
 class TestFligner:

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -7550,6 +7550,14 @@ class TestMGCStat:
         _, pvalue, _ = stats.multiscale_graphcorr(x, y, random_state=1)
         assert_allclose(pvalue, 1/1001)
 
+    @pytest.mark.slow
+    @pytest.mark.parametrize("is_twosamp", [True, False])
+    def test_alias(self, is_twosamp):
+        x = np.arange(100)
+        y = np.arange(100)
+        res = stats.multiscale_graphcorr(x, y, is_twosamp=is_twosamp)
+        assert_equal(res.stat, res.statistic)
+
 
 class TestPageTrendTest:
     # expected statistic and p-values generated using R at

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -7551,11 +7551,13 @@ class TestMGCStat:
         assert_allclose(pvalue, 1/1001)
 
     @pytest.mark.slow
-    @pytest.mark.parametrize("is_twosamp", [True, False])
-    def test_alias(self, is_twosamp):
-        x = np.arange(100)
-        y = np.arange(100)
-        res = stats.multiscale_graphcorr(x, y, is_twosamp=is_twosamp)
+    def test_alias(self):
+        np.random.seed(12345678)
+
+        # generate x and y
+        x, y = self._simulations(samps=100, dims=1, sim_type="linear")
+
+        res = stats.multiscale_graphcorr(x, y, random_state=1)
         assert_equal(res.stat, res.statistic)
 
 


### PR DESCRIPTION
#### Reference issue
https://github.com/scipy/scipy/issues/16364

#### What does this implement/fix?
This adds a `statistic` attribute to `BinomTestResult` as an alias for `proportion_estimate` to make `BinomTestResult` consistent with results classes for other statistical tests.

Aliases for `multiscale_graphcorr` and `anderson_ksamp` to be added.
