### PR TITLE
BUG: sparse: Fix indexing sparse matrix with empty index arguments.

### DIFF
--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -695,7 +695,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         M = len(indices)
         new_shape = self._swap((M, N))
         if M == 0:
-            return self.__class__(new_shape)
+            return self.__class__(new_shape, dtype=self.dtype)
 
         row_nnz = self.indptr[indices + 1] - self.indptr[indices]
         idx_dtype = self.indices.dtype
@@ -722,7 +722,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         M = len(range(start, stop, step))
         new_shape = self._swap((M, N))
         if M == 0:
-            return self.__class__(new_shape)
+            return self.__class__(new_shape, dtype=self.dtype)
 
         # Work out what slices are needed for `row_nnz`
         # start,stop can be -1, only if step is negative
@@ -761,7 +761,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         k = len(idx)
         new_shape = self._swap((M, k))
         if k == 0:
-            return self.__class__(new_shape)
+            return self.__class__(new_shape, dtype=self.dtype)
 
         # pass 1: count idx entries and compute new indptr
         col_offsets = np.zeros(N, dtype=idx_dtype)
@@ -789,7 +789,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         start, stop, step = idx.indices(N)
         N = len(range(start, stop, step))
         if N == 0:
-            return self.__class__(self._swap((M, N)))
+            return self.__class__(self._swap((M, N)), dtype=self.dtype)
         if step == 1:
             return self._get_submatrix(minor=idx, copy=copy)
         # TODO: don't fall back to fancy indexing here

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2331,6 +2331,16 @@ class _TestSlicing:
         assert_equal(self.spmatrix((1,10), dtype=np.float32)[0,1:5].dtype, np.float32)
         assert_equal(self.spmatrix((1,10), dtype=np.float64)[0,1:5].dtype, np.float64)
 
+    def test_dtype_preservation_empty_slice(self):
+        # This should be parametrized with pytest, but something in the parent
+        # class creation used in this file breaks pytest.mark.parametrize.
+        for dt in [np.int16, np.int32, np.float32, np.float64]:
+            A = self.spmatrix((3, 2), dtype=dt)
+            assert_equal(A[:, 0:0:2].dtype, dt)
+            assert_equal(A[0:0:2, :].dtype, dt)
+            assert_equal(A[0, 0:0:2].dtype, dt)
+            assert_equal(A[0:0:2, 0].dtype, dt)
+
     def test_get_horiz_slice(self):
         B = asmatrix(arange(50.).reshape(5,10))
         A = self.spmatrix(B)
@@ -2687,10 +2697,21 @@ class _TestSlicingAssign:
         A[1, :] = x
         assert_array_equal(A.toarray(), [[0, 1, 1], [0, 0, 0], [0, 1, 1]])
 
+
 class _TestFancyIndexing:
     """Tests fancy indexing features.  The tests for any matrix formats
     that implement these features should derive from this class.
     """
+
+    def test_dtype_preservation_empty_index(self):
+        # This should be parametrized with pytest, but something in the parent
+        # class creation used in this file breaks pytest.mark.parametrize.
+        for dt in [np.int16, np.int32, np.float32, np.float64]:
+            A = self.spmatrix((3, 2), dtype=dt)
+            assert_equal(A[:, [False, False]].dtype, dt)
+            assert_equal(A[[False, False, False], :].dtype, dt)
+            assert_equal(A[:, []].dtype, dt)
+            assert_equal(A[[], :].dtype, dt)
 
     def test_bad_index(self):
         A = self.spmatrix(np.zeros([5, 5]))

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -8,14 +8,6 @@ class for generic tests" section.
 
 """
 
-__usage__ = """
-Build sparse:
-  python setup.py build
-Run tests if scipy is installed:
-  python -c 'import scipy;scipy.sparse.test()'
-Run tests if sparse is not installed:
-  python tests/test_base.py
-"""
 
 import contextlib
 import functools


### PR DESCRIPTION
When a sparse matrix was indexed with an argument that was effectively
empty (e.g. `0:0:2`, `[]`, `[False, False]`), the dtype of the matrix
was lost and the result became float64.

Closes gh-16656.