### PR TITLE
BUG: signal: Compare window_length to correct axis in savgol_filter

### DIFF
--- a/scipy/signal/_savitzky_golay.py
+++ b/scipy/signal/_savitzky_golay.py
@@ -340,7 +340,7 @@ def savgol_filter(x, window_length, polyorder, deriv=0, delta=1.0,
     coeffs = savgol_coeffs(window_length, polyorder, deriv=deriv, delta=delta)
 
     if mode == "interp":
-        if window_length > x.size:
+        if window_length > x.shape[axis]:
             raise ValueError("If mode is 'interp', window_length must be less "
                              "than or equal to the size of x.")
 

--- a/scipy/signal/tests/test_savitzky_golay.py
+++ b/scipy/signal/tests/test_savitzky_golay.py
@@ -1,7 +1,7 @@
 import numpy as np
 from numpy.testing import (assert_allclose, assert_equal,
                            assert_almost_equal, assert_array_equal,
-                           assert_array_almost_equal)
+                           assert_array_almost_equal, assert_raises)
 
 from scipy.ndimage import convolve1d
 
@@ -337,3 +337,21 @@ def test_sg_filter_interp_edges_3d():
 
     dy = savgol_filter(z, 7, 3, axis=0, mode='interp', deriv=1, delta=delta)
     assert_allclose(dy, dz, atol=1e-10)
+
+
+def test_sg_filter_valid_window_length_3d():
+    """Tests that the window_length check is using the correct axis."""
+
+    x = np.random.rand(10, 20, 30)
+
+    savgol_filter(x, window_length=29, polyorder=3, mode='interp')
+
+    with assert_raises(ValueError):
+
+        savgol_filter(x, window_length=31, polyorder=3, mode='interp')
+
+    savgol_filter(x, window_length=9, polyorder=3, axis=0, mode='interp')
+
+    with assert_raises(ValueError):
+        # Can only raise window_length error if axis 0 is the one being checked
+        savgol_filter(x, window_length=11, polyorder=3, axis=0, mode='interp')

--- a/scipy/signal/tests/test_savitzky_golay.py
+++ b/scipy/signal/tests/test_savitzky_golay.py
@@ -347,7 +347,7 @@ def test_sg_filter_valid_window_length_3d():
 
     savgol_filter(x, window_length=29, polyorder=3, mode='interp')
 
-    with pytest.raises(ValueError,  match='window_length must be less than'):
+    with pytest.raises(ValueError, match='window_length must be less than'):
         # window_length is more than x.shape[-1].
         savgol_filter(x, window_length=31, polyorder=3, mode='interp')
 

--- a/scipy/signal/tests/test_savitzky_golay.py
+++ b/scipy/signal/tests/test_savitzky_golay.py
@@ -1,7 +1,8 @@
+import pytest
 import numpy as np
 from numpy.testing import (assert_allclose, assert_equal,
                            assert_almost_equal, assert_array_equal,
-                           assert_array_almost_equal, assert_raises)
+                           assert_array_almost_equal)
 
 from scipy.ndimage import convolve1d
 
@@ -342,16 +343,16 @@ def test_sg_filter_interp_edges_3d():
 def test_sg_filter_valid_window_length_3d():
     """Tests that the window_length check is using the correct axis."""
 
-    x = np.random.rand(10, 20, 30)
+    x = np.ones((10, 20, 30))
 
     savgol_filter(x, window_length=29, polyorder=3, mode='interp')
 
-    with assert_raises(ValueError):
-
+    with pytest.raises(ValueError,  match='window_length must be less than'):
+        # window_length is more than x.shape[-1].
         savgol_filter(x, window_length=31, polyorder=3, mode='interp')
 
     savgol_filter(x, window_length=9, polyorder=3, axis=0, mode='interp')
 
-    with assert_raises(ValueError):
-        # Can only raise window_length error if axis 0 is the one being checked
+    with pytest.raises(ValueError, match='window_length must be less than'):
+        # window_length is more than x.shape[0].
         savgol_filter(x, window_length=11, polyorder=3, axis=0, mode='interp')


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
No related issues found.

#### What does this implement/fix?
<!--Please explain your changes.-->
In the savgolay filter from scipy.signal, the window_length comparison before filtering should be made against the axis that the filtering will be applied to not the `size` of the entire array. The docs say that the filter will be applied to the last axis not the entire array flattened, so `size` is only appropriate when the input is 1D.

There are actually two errors that can arise from this bug.

1. False positive: ValueError is raise unnecessarily
2. False negative: ValueError is not raised, then further along the execution another error is raised because window_length was > the axis length

But I only test one of these cases because I think it is sufficient to check that the correct axis is being compared.

```
x = np.random.rand(33, 3, 5)
x1 = scipy.signal.savgol_filter(x, window_length=17, polyorder=3, axis=0)
```
In this example, the windows length is valid (17 < 33), but the current implementation checks the wrong axis (compares 5 and 17).

#### Additional information

Related https://github.com/scipy/scipy/pull/7596