### PR TITLE
DOC: replace `sphinx_panels` and `sphinx_tabs` with `sphinx_design`

### DIFF
--- a/doc/source/_static/scipy.css
+++ b/doc/source/_static/scipy.css
@@ -113,7 +113,7 @@ h3 {
   text-align: center;
 }
 
-.sd-card p.sd-card-text {
+.sd-card .sd-card-header .sd-card-text {
   margin: 0px;
 }
 
@@ -138,7 +138,7 @@ h3 {
   background-color:white;
 }
 
-.sd-card .sd-card-footer p.sd-card-text{
+.sd-card .sd-card-footer .sd-card-text{
   max-width: 220px;
   margin-left: auto;
   margin-right: auto;
@@ -183,8 +183,13 @@ html[data-theme=dark] .MathJax_SVG *  {
 }
 
 /* Main index page overview cards */
-html[data-theme=dark] .shadow {
-    box-shadow: 0 .5rem 1rem rgba(250, 250, 250, .6) !important
+
+html[data-theme=dark] .sd-card {
+  background-color:var(--pst-color-background);
+}
+
+html[data-theme=dark] .sd-shadow-sm {
+    box-shadow: 0 .1rem 1rem rgba(250, 250, 250, .6) !important
 }
 
 html[data-theme=dark] .sd-card .sd-card-header {

--- a/doc/source/_static/scipy.css
+++ b/doc/source/_static/scipy.css
@@ -102,25 +102,29 @@ h3 {
 
 /* Main index page overview cards */
 
-.intro-card {
+.sd-card {
   background: #fff;
   border-radius: 0;
   padding: 30px 10px 20px 10px;
   margin: 10px 0px;
 }
 
-.intro-card p.card-text {
+.sd-card .sd-card-header {
+  text-align: center;
+}
+
+.sd-card p.sd-card-text {
   margin: 0px;
 }
 
-.intro-card .card-img-top {
+.sd-card .sd-card-img-top {
   height: 52px;
   width: 52px;
   margin-left: auto;
   margin-right: auto;
 }
 
-.intro-card .card-header {
+  .sd-card .sd-card-header {
   border: none;
   background-color:white;
   color: #150458 !important;
@@ -129,12 +133,12 @@ h3 {
   padding: 2.5rem 0rem 0.5rem 0rem;
 }
 
-.intro-card .card-footer {
+.sd-card .sd-card-footer {
   border: none;
   background-color:white;
 }
 
-.intro-card .card-footer p.card-text{
+.sd-card .sd-card-footer p.sd-card-text{
   max-width: 220px;
   margin-left: auto;
   margin-right: auto;
@@ -183,12 +187,12 @@ html[data-theme=dark] .shadow {
     box-shadow: 0 .5rem 1rem rgba(250, 250, 250, .6) !important
 }
 
-html[data-theme=dark] .intro-card .card-header {
+html[data-theme=dark] .sd-card .sd-card-header {
   background-color:var(--pst-color-background);
   color: #150458 !important;
 }
 
-html[data-theme=dark] .intro-card .card-footer {
+html[data-theme=dark] .sd-card .sd-card-footer {
   background-color:var(--pst-color-background);
 }
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -44,11 +44,10 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.intersphinx',
     'numpydoc',
-    'sphinx_panels',
+    'sphinx_design',
     'scipyoptdoc',
     'doi_role',
     'matplotlib.sphinxext.plot_directive',
-    'sphinx_tabs.tabs',
 ]
 
 # Determine if the matplotlib has a recent enough version of the
@@ -62,10 +61,6 @@ import matplotlib
 matplotlib.use('agg')
 import matplotlib.pyplot as plt
 plt.ioff()
-
-# sphinx-panels shouldn't add bootstrap css since the pydata-sphinx-theme
-# already loads it
-panels_add_bootstrap_css = False
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/doc/source/dev/contributor/building.rst
+++ b/doc/source/dev/contributor/building.rst
@@ -25,9 +25,9 @@ dependencies to build it on your system.
     You can skip these steps if you are using ``conda``, as these dependencies
     will be installed automatically.
 
-.. tabs::
+.. tab-set::
 
-  .. tab:: Linux
+  .. tab-item:: Linux
   
     If you want to use the system Python and ``pip``, you will need:
 
@@ -41,9 +41,9 @@ dependencies to build it on your system.
       `ATLAS <http://math-atlas.sourceforge.net/>`__ and
       `MKL <https://software.intel.com/en-us/intel-mkl>`__. 
 
-    .. tabs::
+    .. tab-set::
 
-      .. tab:: Debian/Ubuntu Linux
+      .. tab-item:: Debian/Ubuntu Linux
 
         .. note::
 
@@ -67,7 +67,7 @@ dependencies to build it on your system.
         See also :ref:`ubuntu-guide`.
 
 
-      .. tab:: Fedora
+      .. tab-item:: Fedora
 
         To install SciPy build requirements, you can do::
 
@@ -81,7 +81,7 @@ dependencies to build it on your system.
         advantage that new dependencies or updates to required versions are
         handled by the package managers.
 
-      .. tab:: CentOS/RHEL
+      .. tab-item:: CentOS/RHEL
 
         To install SciPy build requirements, you can do::
 
@@ -95,7 +95,7 @@ dependencies to build it on your system.
         advantage that new dependencies or updates to required versions are
         handled by the package managers.
 
-      .. tab:: Arch
+      .. tab-item:: Arch
 
         To install SciPy build requirements, you can do::
 
@@ -115,7 +115,7 @@ dependencies to build it on your system.
     If you are using conda, these dependencies can be installed in the conda
     environment itself. See :ref:`conda-guide` for more details.
 
-  .. tab:: OSX
+  .. tab-item:: OSX
 
     Install Apple Developer Tools. An easy way to do this is to
     `open a terminal window <https://blog.teamtreehouse.com/introduction-to-the-mac-os-x-command-line>`_,
@@ -129,7 +129,7 @@ dependencies to build it on your system.
     `git <https://git-scm.com/>`_, the software we need to download and manage the
     SciPy source code. See also :ref:`build-osx`.
 
-  .. tab:: Windows
+  .. tab-item:: Windows
 
     See :ref:`build-windows`.
 

--- a/doc/source/dev/contributor/rendering_documentation.rst
+++ b/doc/source/dev/contributor/rendering_documentation.rst
@@ -25,11 +25,11 @@ To render the documentation on your own machine:
    You need to be able to ``import scipy`` regardless of Python's working
    directory; the ``python setup.py develop`` and ``conda develop`` commands
    from the :ref:`quickstart <dev-env>` guides make this possible.
-#. Install `Sphinx`_, `PyData Sphinx theme`_, `Sphinx-Panels`_, `Sphinx-Tabs`_
+#. Install `Sphinx`_, `PyData Sphinx theme`_, `Sphinx-Design`_
    and `matplotlib`_. For example, if you're using the Anaconda distribution of
    Python, enter in a terminal window::
       
-      conda install sphinx pydata-sphinx-theme sphinx-panels sphinx-tabs matplotlib --channel conda-forge
+      conda install sphinx pydata-sphinx-theme sphinx-design matplotlib --channel conda-forge
       
    The list of requirements is in ``scipy/doc_requirements.txt``.
 #. In a terminal window, browse to the ``scipy/doc`` directory. Note the
@@ -73,8 +73,7 @@ on the cloud.
 .. _CircleCI: https://circleci.com/vcs-authorize/
 .. _Sphinx: https://www.sphinx-doc.org/en/master/
 .. _PyData Sphinx theme: https://pydata-sphinx-theme.readthedocs.io/en/latest/
-.. _Sphinx-Panels: https://sphinx-panels.readthedocs.io/en/latest/
-.. _Sphinx-Tabs: https://sphinx-tabs.readthedocs.io/en/latest/
+.. _Sphinx-Design: https://sphinx-design.readthedocs.io
 .. _matplotlib: https://www.matplotlib.org/
 .. _Rendering SciPy Documentation with Sphinx: https://youtu.be/kGSYU39EhJQ
 .. _git submodules: https://git-scm.com/book/en/v2/Git-Tools-Submodules

--- a/doc/source/dev/contributor/ubuntu_guide.rst
+++ b/doc/source/dev/contributor/ubuntu_guide.rst
@@ -159,7 +159,7 @@ With conda
 	  or Linux PATH?" in the `Anaconda FAQ`_.
 
 #. Enter ``conda config --env --add channels conda-forge`` to tell Anaconda the
-   source we want for our packages. Then enter ``conda create --name scipy-dev python=3.9 numpy pybind11 cython pythran pytest gfortran gxx sphinx pydata-sphinx-theme sphinx-panels matplotlib mypy git``. |br| This tells ``conda`` to create a virtual environment named ``scipy-dev`` (or another name that you prefer) with several packages.
+   source we want for our packages. Then enter ``conda create --name scipy-dev python=3.9 numpy pybind11 cython pythran pytest gfortran gxx sphinx pydata-sphinx-theme sphinx-design matplotlib mypy git``. |br| This tells ``conda`` to create a virtual environment named ``scipy-dev`` (or another name that you prefer) with several packages.
 
    * ``numpy pybind11 cython pythran`` are four packages that SciPy depends on.
 
@@ -167,7 +167,7 @@ With conda
 
    * ``pytest`` is needed for running the test suite.
 
-   * ``sphinx``, ``pydata-sphinx-theme``, ``sphinx-panels`` and ``matplotlib`` are required to render the SciPy documentation.
+   * ``sphinx``, ``pydata-sphinx-theme``, ``sphinx-design`` and ``matplotlib`` are required to render the SciPy documentation.
 
    * ``mypy`` is a static type checker for Python. Consider using it.
 

--- a/doc/source/dev/core-dev/distributing.rst.inc
+++ b/doc/source/dev/core-dev/distributing.rst.inc
@@ -45,7 +45,7 @@ are:
 - wheel_ (``python setup.py bdist_wheel``)
 - Sphinx_ (docs)
 - `PyData Sphinx theme`_ (docs)
-- `Sphinx-Panels`_  (docs)
+- `Sphinx-Design`_  (docs)
 - matplotlib_ (docs)
 
 Furthermore of course one needs C, C++ and Fortran compilers to build SciPy,
@@ -216,7 +216,7 @@ Wheelhouse_, see at the wheel_ and Wheelhouse_ docs.
 .. _MingwPy: https://mingwpy.github.io
 .. _Sphinx: http://www.sphinx-doc.org/
 .. _PyData Sphinx theme: https://pydata-sphinx-theme.readthedocs.io/en/latest/
-.. _Sphinx-Panels: https://sphinx-panels.readthedocs.io/en/latest/
+.. _Sphinx-Design: https://sphinx-design.readthedocs.io
 .. _six: https://pypi.org/project/six
 .. _decorator: https://github.com/micheles/decorator
 .. _manylinux: https://github.com/pypa/manylinux/

--- a/doc/source/dev/dev_quickstart.rst
+++ b/doc/source/dev/dev_quickstart.rst
@@ -47,9 +47,9 @@ account and then create your local repository via::
 
 Next, set up your development environment.
 
-.. tabs::
+.. tab-set::
 
-    .. tab:: conda
+    .. tab-item:: conda
 
         With ``conda`` installed (through
         `Miniforge or Mambaforge <https://github.com/conda-forge/miniforge>`_,
@@ -66,7 +66,7 @@ Next, set up your development environment.
         Your command prompt now lists the name of your new environment, like so
         ``(scipy-dev)$``.
 
-    .. tab:: pip+venv
+    .. tab-item:: pip+venv
 
         **With** :ref:`system-level dependencies <system-level>` **installed**, execute
         the following commands at the terminal from the base directory of your

--- a/doc/source/dev/toolchain.rst
+++ b/doc/source/dev/toolchain.rst
@@ -350,8 +350,7 @@ Building the Documentation
 ====================  =================================================
 Sphinx                Whatever recent versions work. >= 2.0.
 PyData Sphinx theme   Whatever recent versions work. >= 0.8.1.
-Sphinx-Panels         Whatever recent versions work. >= 0.5.2.
-Sphinx-Tabs           Whatever recent versions work. >= 3.2.0.
+Sphinx-Design         Whatever recent versions work. >= 0.2.0.
 numpydoc              Whatever recent versions work. >= 0.8.0.
 matplotlib            Generally suggest >= 2.0.
 ====================  =================================================

--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -7,7 +7,7 @@ Getting started
 Installation
 ------------
 
-.. panels::
+.. grid:: 1 2 2 2
     :card: + install-card
     :column: col-lg-6 col-md-6 col-sm-12 col-xs-12 p-3
 

--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -37,6 +37,7 @@ Installation
             pip install scipy
 
     .. grid-item-card::
+        :columns: 12
 
         In-depth instructions?
         ^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -7,47 +7,46 @@ Getting started
 Installation
 ------------
 
-.. grid:: 1 2 2 2
-    :card: + install-card
-    :column: col-lg-6 col-md-6 col-sm-12 col-xs-12 p-3
+.. grid:: 2
 
-    Working with conda?
-    ^^^^^^^^^^^^^^^^^^^
+    .. grid-item-card::
 
-    SciPy is part of the `Anaconda <https://docs.continuum.io/anaconda/>`__
-    distribution and can be installed with Anaconda or Miniconda:
+        Working with conda?
+        ^^^^^^^^^^^^^^^^^^^
 
-    ++++++++++++++++++++++
+        SciPy is part of the `Anaconda <https://docs.continuum.io/anaconda/>`__
+        distribution and can be installed with Anaconda or Miniconda:
 
-    .. code-block:: bash
+        ++++++++++++++++++++++
 
-        conda install scipy
+        .. code-block:: bash
 
-    ---
+            conda install scipy
 
-    Prefer pip?
-    ^^^^^^^^^^^
+    .. grid-item-card::
 
-    SciPy can be installed via pip from `PyPI <https://pypi.org/project/scipy>`__.
+        Prefer pip?
+        ^^^^^^^^^^^
 
-    ++++
+        SciPy can be installed via pip from `PyPI <https://pypi.org/project/scipy>`__.
 
-    .. code-block:: bash
+        ++++
 
-        pip install scipy
+        .. code-block:: bash
 
-    ---
-    :column: col-12 p-3
+            pip install scipy
 
-    In-depth instructions?
-    ^^^^^^^^^^^^^^^^^^^^^^
+    .. grid-item-card::
 
-    Installing a specific version? Installing from source? Check the
-    installation page.
+        In-depth instructions?
+        ^^^^^^^^^^^^^^^^^^^^^^
 
-    .. container:: custom-button
+        Installing a specific version? Installing from source? Check the
+        installation page.
 
-        `Learn more <https://scipy.org/install/>`__
+        .. container:: custom-button
+
+            `Learn more <https://scipy.org/install/>`__
 
 Tutorials
 ---------

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -35,6 +35,7 @@ science, and engineering.
 
         .. button-ref:: getting_started_ref
             :expand:
+            :color: secondary
             :click-parent:
 
             To the getting started guides
@@ -52,6 +53,7 @@ science, and engineering.
 
         .. button-ref:: user_guide
             :expand:
+            :color: secondary
             :click-parent:
 
             To the user guide
@@ -70,6 +72,7 @@ science, and engineering.
 
         .. button-ref:: scipy-api
             :expand:
+            :color: secondary
             :click-parent:
 
             To the reference guide
@@ -88,6 +91,7 @@ science, and engineering.
 
         .. button-ref:: scipy-development
             :expand:
+            :color: secondary
             :click-parent:
 
             To the development guide

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -20,75 +20,77 @@ SciPy documentation
 **SciPy** (pronounced "Sigh Pie") is an open-source software for mathematics,
 science, and engineering.
 
-.. grid:: 1 2 2 2
-    :card: + intro-card text-center
-    :column: col-lg-6 col-md-6 col-sm-6 col-xs-12 d-flex
+.. grid:: 2
 
-    ---
-    :img-top: _static/index_getting_started.png
+    .. grid-item-card::
+        :img-top: _static/index_getting_started.png
 
-    Getting started
-    ^^^^^^^^^^^^^^^
+        Getting started
+        ^^^^^^^^^^^^^^^
 
-    New to *SciPy*? Check out the getting started guides. They contain an
-    introduction to *SciPy's* main concepts and links to additional tutorials.
+        New to *SciPy*? Check out the getting started guides. They contain an
+        introduction to *SciPy's* main concepts and links to additional tutorials.
 
-    +++
+        +++
 
-    .. link-button:: getting_started_ref
-            :type: ref
-            :text: To the getting started guides
-            :classes: btn-block btn-secondary stretched-link
+        .. button-ref:: getting_started_ref
+            :expand:
+            :click-parent:
 
-    ---
-    :img-top: _static/index_user_guide.png
+            To the getting started guides
 
-    User guide
-    ^^^^^^^^^^
+    .. grid-item-card::
+        :img-top: _static/index_user_guide.png
 
-    The user guide provides in-depth information on the
-    key concepts of SciPy with useful background information and explanation.
+        User guide
+        ^^^^^^^^^^
 
-    +++
+        The user guide provides in-depth information on the
+        key concepts of SciPy with useful background information and explanation.
 
-    .. link-button:: user_guide
-            :type: ref
-            :text: To the user guide
-            :classes: btn-block btn-secondary stretched-link
+        +++
 
-    ---
-    :img-top: _static/index_api.png
+        .. button-ref:: user_guide
+            :expand:
+            :click-parent:
 
-    API reference
-    ^^^^^^^^^^^^^
+            To the user guide
 
-    The reference guide contains a detailed description of
-    the SciPy API. The reference describes how the methods work and which parameters can
-    be used. It assumes that you have an understanding of the key concepts.
+    .. grid-item-card::
+        :img-top: _static/index_api.png
 
-    +++
+        API reference
+        ^^^^^^^^^^^^^
 
-    .. link-button:: scipy-api
-            :type: ref
-            :text: To the reference guide
-            :classes: btn-block btn-secondary stretched-link
+        The reference guide contains a detailed description of
+        the SciPy API. The reference describes how the methods work and which parameters can
+        be used. It assumes that you have an understanding of the key concepts.
 
-    ---
-    :img-top: _static/index_contribute.png
+        +++
 
-    Developer guide
-    ^^^^^^^^^^^^^^^
+        .. button-ref:: scipy-api
+            :expand:
+            :click-parent:
 
-    Saw a typo in the documentation? Want to improve
-    existing functionalities? The contributing guidelines will guide
-    you through the process of improving SciPy.
+            To the reference guide
 
-    +++
+    .. grid-item-card::
+        :img-top: _static/index_contribute.png
 
-    .. link-button:: scipy-development
-            :type: ref
-            :text: To the development guide
-            :classes: btn-block btn-secondary stretched-link
+        Developer guide
+        ^^^^^^^^^^^^^^^
+
+        Saw a typo in the documentation? Want to improve
+        existing functionalities? The contributing guidelines will guide
+        you through the process of improving SciPy.
+
+        +++
+
+        .. button-ref:: scipy-development
+            :expand:
+            :click-parent:
+
+            To the development guide
 
 .. toctree::
    :maxdepth: 1

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -20,7 +20,7 @@ SciPy documentation
 **SciPy** (pronounced "Sigh Pie") is an open-source software for mathematics,
 science, and engineering.
 
-.. panels::
+.. grid:: 1 2 2 2
     :card: + intro-card text-center
     :column: col-lg-6 col-md-6 col-sm-6 col-xs-12 d-flex
 

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -2,7 +2,6 @@
 #       in sync with the doc dependencies in pyproject.toml
 Sphinx!=4.1.0
 pydata-sphinx-theme>=0.9.0
-sphinx-panels>=0.5.2
-sphinx-tabs
+sphinx-design>=0.2.0
 numpydoc
 matplotlib>2

--- a/environment.yml
+++ b/environment.yml
@@ -35,8 +35,7 @@ dependencies:
   - ipython
   - matplotlib
   - pydata-sphinx-theme>=0.9.0
-  - sphinx-panels
-  - sphinx-tabs
+  - sphinx-design
   # For linting
   - flake8
   # Some optional test dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,10 +104,9 @@ test = [
 doc = [
     "sphinx!=4.1.0",
     "pydata-sphinx-theme>=0.9.0",
-    "sphinx-panels>=0.5.2",
+    "sphinx-design>=0.2.0",
     "matplotlib>2",
     "numpydoc",
-    "sphinx-tabs",
 ]
 dev = [
     "mypy",


### PR DESCRIPTION
Sphinx-Panels is deprecated in favour of Sphinx-Design. It also allows to remove the the extra dependency to Sphinx-Tabs

See https://sphinx-design.readthedocs.io/en/pydata-theme/index.html