### PR TITLE
MAINT: stats._axis_nan_policy: preserve dtype of masked arrays where possible

### DIFF
--- a/scipy/stats/_axis_nan_policy.py
+++ b/scipy/stats/_axis_nan_policy.py
@@ -214,10 +214,10 @@ def _masked_arrays_2_sentinel_arrays(samples):
     # replace masked elements with sentinel value
     out_samples = []
     for sample in samples:
-        mask = getattr(sample, 'mask', False)
-        if np.any(mask):
+        mask = getattr(sample, 'mask', None)
+        if mask is not None:  # turn all masked arrays into sentinel arrays
             mask = np.broadcast_to(mask, sample.shape)
-            sample = sample.data.copy()  # don't modify original array
+            sample = np.asarray(sample)  # don't modify original array
             sample[mask] = sentinel
         out_samples.append(sample)
 

--- a/scipy/stats/_axis_nan_policy.py
+++ b/scipy/stats/_axis_nan_policy.py
@@ -200,7 +200,7 @@ def _masked_arrays_2_sentinel_arrays(samples):
     # For simplicity, min_possible/np.infs are not candidate sentinel values
     while sentinel > min_possible:
         for sample in samples:
-            if np.any(sample == sentinel): # choose a new sentinel value
+            if np.any(sample == sentinel):  # choose a new sentinel value
                 sentinel = nextafter(sentinel, -np.inf)
                 break
         else:  # when sentinel value is OK, break the while loop
@@ -217,7 +217,8 @@ def _masked_arrays_2_sentinel_arrays(samples):
         mask = getattr(sample, 'mask', None)
         if mask is not None:  # turn all masked arrays into sentinel arrays
             mask = np.broadcast_to(mask, sample.shape)
-            sample = np.asarray(sample)  # don't modify original array
+            sample = sample.data.copy() if np.any(mask) else sample.data
+            sample = np.asarray(sample)  # `sample.data` could be a memoryview?
             sample[mask] = sentinel
         out_samples.append(sample)
 

--- a/scipy/stats/_axis_nan_policy.py
+++ b/scipy/stats/_axis_nan_policy.py
@@ -183,22 +183,33 @@ def _masked_arrays_2_sentinel_arrays(samples):
 
     # Choose a sentinel value. We can't use `np.nan`, because sentinel (masked)
     # values are always omitted, but there are different nan policies.
+    dtype = np.result_type(*samples)
+    dtype = dtype if np.issubdtype(dtype, np.number) else np.float64
     for i in range(len(samples)):
         # Things get more complicated if the arrays are of different types.
         # We could have different sentinel values for each array, but
         # the purpose of this code is convenience, not efficiency.
-        samples[i] = samples[i].astype(np.float64, copy=False)
+        samples[i] = samples[i].astype(dtype, copy=False)
 
-    max_possible, eps = np.finfo(np.float64).max, np.finfo(np.float64).eps
+    inexact = np.issubdtype(dtype, np.inexact)
+    info = np.finfo if inexact else np.iinfo
+    max_possible, min_possible = info(dtype).max, info(dtype).min
+    nextafter = np.nextafter if inexact else (lambda x, _: x - 1)
 
     sentinel = max_possible
-    while sentinel > 0:
+    # For simplicity, min_possible/np.infs are not candidate sentinel values
+    while sentinel > min_possible:
         for sample in samples:
-            if np.any(sample == sentinel):
-                sentinel *= (1 - 2*eps)  # choose a new sentinel value
+            if np.any(sample == sentinel): # choose a new sentinel value
+                sentinel = nextafter(sentinel, -np.inf)
                 break
         else:  # when sentinel value is OK, break the while loop
             break
+    else:
+        message = ("This function replaces masked elements with sentinel "
+                   "values, but the data contains all distinct values of this "
+                   "data type. Consider promoting the dtype to `np.float64`.")
+        raise ValueError(message)
 
     # replace masked elements with sentinel value
     out_samples = []

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -748,6 +748,10 @@ def test_masked_dtype():
     with pytest.raises(ValueError, match=message):
         _masked_arrays_2_sentinel_arrays([a0])
 
+    # test that dtype is preserved in functions
+    a = np.ma.array([1, 2, 3], mask=[0, 1, 0], dtype=np.float32)
+    assert stats.gmean(a).dtype == np.float32
+
 
 def test_masked_stat_1d():
     # basic test of _axis_nan_policy_factory with 1D masked sample

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -672,27 +672,81 @@ def test_masked_array_2_sentinel_array():
     # set arbitrary elements to special values
     # (these values might have been considered for use as sentinel values)
     max_float = np.finfo(np.float64).max
-    eps = np.finfo(np.float64).eps
+    max_float2 = np.nextafter(max_float, -np.inf)
+    max_float3 = np.nextafter(max_float2, -np.inf)
     A[3, 4, 1] = np.nan
     A[4, 5, 2] = np.inf
     A[5, 6, 3] = max_float
     B[8] = np.nan
     B[7] = np.inf
-    B[6] = max_float * (1 - 2*eps)
+    B[6] = max_float2
 
     # convert masked A to array with sentinel value, don't modify B
     out_arrays, sentinel = _masked_arrays_2_sentinel_arrays([A, B])
     A_out, B_out = out_arrays
 
     # check that good sentinel value was chosen (according to intended logic)
-    assert (sentinel != max_float) and (sentinel != max_float * (1 - 2*eps))
-    assert sentinel == max_float * (1 - 2*eps)**2
+    assert (sentinel != max_float) and (sentinel != max_float2)
+    assert sentinel == max_float3
 
     # check that output arrays are as intended
     A_reference = A.data
     A_reference[A.mask] = sentinel
     np.testing.assert_array_equal(A_out, A_reference)
     assert B_out is B
+
+
+def test_masked_dtype():
+    # When _masked_arrays_2_sentinel_arrays was first added, it always
+    # upcast the arrays to np.float64. After gh16662, check expected promotion
+    # and that the expected sentinel is found.
+
+    # these are important because the max of the promoted dtype is the first
+    # candidate to be the sentinel value
+    max16 = np.iinfo(np.int16).max
+    max128c = np.finfo(np.complex128).max
+
+    # a is a regular array, b has masked elements, and c has no masked elements
+    a = np.array([1, 2, max16], dtype=np.int16)
+    b = np.ma.array([1, 2, 1], dtype=np.int8, mask=[0, 1, 0])
+    c = np.ma.array([1, 2, 1], dtype=np.complex128, mask=[0, 0, 0])
+
+    # check integer masked -> sentinel conversion
+    out_arrays, sentinel = _masked_arrays_2_sentinel_arrays([a, b])
+    a_out, b_out = out_arrays
+    assert sentinel == max16-1  # not max16 because max16 was in the data
+    assert b_out.dtype == np.int16  # check expected promotion
+    assert_allclose(b_out, [b[0], sentinel, b[-1]])  # check sentinel placement
+    assert a_out is a  # not a masked array, so left untouched
+    assert not isinstance(b_out, np.ma.MaskedArray)  # b became regular array
+
+    # similarly with complex
+    out_arrays, sentinel = _masked_arrays_2_sentinel_arrays([b, c])
+    b_out, c_out = out_arrays
+    assert sentinel == max128c  # max128c was not in the data
+    assert b_out.dtype == np.complex128  # b got promoted
+    assert_allclose(b_out, [b[0], sentinel, b[-1]])  # check sentinel placement
+    assert not isinstance(b_out, np.ma.MaskedArray)  # b became regular array
+    assert not isinstance(c_out, np.ma.MaskedArray)  # c became regular array
+
+    # Also, check edge case when a sentinel value cannot be found in the data
+    min8, max8 = np.iinfo(np.int8).min, np.iinfo(np.int8).max
+    a = np.arange(min8, max8+1, dtype=np.int8)  # use all possible values
+    mask1 = np.zeros_like(a, dtype=bool)
+    mask0 = np.zeros_like(a, dtype=bool)
+
+    # a masked value can be used as the sentinel
+    mask1[1] = True
+    a1 = np.ma.array(a, mask=mask1)
+    out_arrays, sentinel = _masked_arrays_2_sentinel_arrays([a1,])
+    assert sentinel == min8+1
+
+    # unless it's the smallest possible; skipped for simiplicity (see code)
+    mask0[0] = True
+    a0 = np.ma.array(a, mask=mask0)
+    message = "This function replaces masked elements with sentinel..."
+    with pytest.raises(ValueError, match=message):
+            _masked_arrays_2_sentinel_arrays([a0,])
 
 
 def test_masked_stat_1d():

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -738,7 +738,7 @@ def test_masked_dtype():
     # a masked value can be used as the sentinel
     mask1[1] = True
     a1 = np.ma.array(a, mask=mask1)
-    out_arrays, sentinel = _masked_arrays_2_sentinel_arrays([a1,])
+    out_arrays, sentinel = _masked_arrays_2_sentinel_arrays([a1])
     assert sentinel == min8+1
 
     # unless it's the smallest possible; skipped for simiplicity (see code)
@@ -746,7 +746,7 @@ def test_masked_dtype():
     a0 = np.ma.array(a, mask=mask0)
     message = "This function replaces masked elements with sentinel..."
     with pytest.raises(ValueError, match=message):
-            _masked_arrays_2_sentinel_arrays([a0,])
+        _masked_arrays_2_sentinel_arrays([a0])
 
 
 def test_masked_stat_1d():


### PR DESCRIPTION
#### Reference issue
Followup to gh-15239

#### What does this implement/fix?
When gh-15239 added masked array support to functions with the `_axis_nan_policy` decorator, it did so at the cost of casting inputs to `np.float64`. Consequently, some stats functions no longer performed calculations with the intended dtype when passed masked arrays.

This PR ensures that the conversion is to `np.result_type` of the arrays so that conversions are performed only as needed to keep types consistent.