### PR TITLE
MAINT: fix a compiler warning in `signal/_firfilter.c`

### DIFF
--- a/scipy/signal/_firfilter.c
+++ b/scipy/signal/_firfilter.c
@@ -122,7 +122,7 @@ reflect_symm_index(int64_t j, int64_t m)
 {
     // First map j to k in the interval [0, 2*m-1).
     // Then flip the k values that are greater than or equal to m.
-    int64_t k = (j >= 0) ? (j % (2*m)) : (abs(j + 1) % (2*m));
+    int64_t k = (j >= 0) ? (j % (2*m)) : (llabs(j + 1) % (2*m));
     return (k >= m) ? (2*m - k - 1) : k;
 }
 


### PR DESCRIPTION
The warning shows up with Clang 11 and up on macOS:
```
../scipy/signal/_firfilter.c:125:43: warning: absolute value function 'abs' given an argument of type 'long long' but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
    int64_t k = (j >= 0) ? (j % (2*m)) : (abs(j + 1) % (2*m));
                                          ^
../scipy/signal/_firfilter.c:125:43: note: use function 'llabs' instead
    int64_t k = (j >= 0) ? (j % (2*m)) : (abs(j + 1) % (2*m));
                                          ^~~
                                          llabs
```