### PR TITLE
BLD: update `meson` and `meson-python` versions for 1.9.0 release

### DIFF
--- a/.github/workflows/macos_meson.yml
+++ b/.github/workflows/macos_meson.yml
@@ -97,7 +97,7 @@ jobs:
       shell: bash -l {0}
       run: |
         conda activate scipy-dev
-        python -m pip install meson==0.61.1
+        python -m pip install meson==0.62.2
         # Python.org installers still use 10.9, so let's use that too. Note
         # that scikit-learn already changed to 10.13 in Jan 2021, so increasing
         # this number in the future (if needed) should not be a problem.

--- a/meson.build
+++ b/meson.build
@@ -6,7 +6,7 @@ project(
   # tools/version_utils.py
   version: '1.9.0rc2',
   license: 'BSD-3',
-  meson_version: '>= 0.60,< 0.66',
+  meson_version: '>= 0.62.2',
   default_options: [
     'buildtype=debugoptimized',
     'c_std=c99',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@
 [build-system]
 build-backend = 'mesonpy'
 requires = [
-    "meson-python>=0.5.0,<0.7.0",
+    "meson-python>=0.7.0,<0.8.0",
+    "meson==0.62.2",  # workaround for wheel build issue, see https://github.com/FFY00/meson-python/issues/95
     "Cython>=0.29.21,<3.0",
     "pybind11>=2.4.3,<2.10.0",
     "pythran>=0.9.12,<0.12.0",


### PR DESCRIPTION
This works around an issue where `pip install .` or `python -m build` end up with a `py3-none` wheel tag, rather than the correct ABI tag.

Pinning the Meson version in `pyproject.toml` will only affect wheel building, and should be fine.

Closes gh-16555