### PR TITLE
BLD: update minimum `meson` and `meson-python` versions

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -6,7 +6,7 @@ project(
   # tools/version_utils.py
   version: '1.10.0.dev0',
   license: 'BSD-3',
-  meson_version: '>= 0.60',
+  meson_version: '>= 0.62.2',
   default_options: [
     'buildtype=debugoptimized',
     'c_std=c99',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@
 [build-system]
 build-backend = 'mesonpy'
 requires = [
-    "meson-python>=0.5.0",
+    "meson-python>=0.7.0",
     "Cython>=0.29.21",
     "pybind11>=2.4.3",
     "pythran>=0.11.0",


### PR DESCRIPTION
We're relying on a few fixes or features in recent versions of both packages, and there's no reason to keep support for old versions.