### PR TITLE
MAINT: stats.mstats.mode: refactor to keep `kwargs` out of signature

### DIFF
--- a/scipy/stats/_mstats_basic.py
+++ b/scipy/stats/_mstats_basic.py
@@ -285,7 +285,7 @@ def rankdata(data, axis=None, use_missing=False):
 ModeResult = namedtuple('ModeResult', ('mode', 'count'))
 
 
-def mode(a, axis=0, **kwargs):
+def mode(a, axis=0):
     """
     Returns an array of the modal (most common) value in the passed array.
 
@@ -318,12 +318,11 @@ def mode(a, axis=0, **kwargs):
     ModeResult(mode=array([1.]), count=array([2.]))
 
     """
-    keepdims = kwargs.pop("_keepdims", True)
-    if kwargs:
-        unexpected = list(kwargs)[0]
-        message = f"mode() got an unexpected keyword argument '{unexpected}'"
-        raise TypeError(message)
+    return _mode(a, axis=axis, keepdims=True)
 
+
+def _mode(a, axis=0, keepdims=True):
+    # Don't want to expose `keepdims` from the public `mstats.mode`
     a, axis = _chk_asarray(a, axis)
 
     def _mode1D(a):

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -666,7 +666,7 @@ def mode(a, axis=0, nan_policy='propagate', keepdims=None):
 
     if contains_nan and nan_policy == 'omit':
         a = ma.masked_invalid(a)
-        return mstats_basic.mode(a, axis, _keepdims=keepdims)
+        return mstats_basic._mode(a, axis, keepdims=keepdims)
 
     if not np.issubdtype(a.dtype, np.number):
         warnings.warn("Support for non-numeric arrays has been deprecated "

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -773,13 +773,6 @@ class TestMode:
         mstats.mode(im, None)
         assert_equal(im, cp)
 
-    def test_unexpected_keyword_gh16429(self):
-        # `keepdims` is not added as a public parameter of `mstats.mode`
-        m_arr = np.ma.array([1, 1, 0, 0, 0, 0], mask=[0, 0, 1, 1, 1, 0])
-        message = "...got an unexpected keyword argument 'keepdims'"
-        with pytest.raises(TypeError, match=message):
-            mstats.mode(m_arr, keepdims=False)
-
 
 class TestPercentile:
     def setup_method(self):


### PR DESCRIPTION
#### Reference issue
gh-16429

#### What does this implement/fix?
gh-16429 exposed `kwargs` in the signature of `stats.mstats.mode`. This is undesirable because it 1) shows up in the signature of the function in the documentation but there is no information about how to use it (because it is not really supposed to be public) and 2) an unexpected keyword argument error needs to be raised manually. 

This PR refactors `stats.mstats.mode`  to avoid these issues: move the implementation of `stast.mstats.mode` into a private function, and call the private function form `stats.mode` and `stats.mstats.mode` as needed.
