### PR TITLE
DOC: remove custom colours in css

### DIFF
--- a/doc/source/_static/scipy.css
+++ b/doc/source/_static/scipy.css
@@ -55,51 +55,6 @@ Nat Methods 8, 441 (2011). https://doi.org/10.1038/nmeth.1618
   color: white;
 }
 
-/* Taken from NumPy */
-
-@import url('https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,400;0,700;0,900;1,400;1,700;1,900&family=Open+Sans:ital,wght@0,400;0,600;1,400;1,600&display=swap');
-
-.navbar-brand img {
-   height: 60px;
-}
-.navbar-brand {
-   height: 75px;
-}
-
-body {
-  font-family: 'Open Sans', sans-serif;
-  color:#4A4A4A; /* numpy.org body color */
-}
-
-pre, code {
-  font-size: 100%;
-  line-height: 155%;
-}
-
-h1 {
-  font-family: "Lato", sans-serif;
-  color: #013243; /* warm black */
-}
-
-
-h2 {
-  color: #4d77cf; /* han blue */
-  letter-spacing: -.03em;
-}
-
-h3 {
-  color: #013243; /* warm black */
-  letter-spacing: -.03em;
-}
-
-/* Override some aspects of the pydata-sphinx-theme: taken from Pandas */
-
-:root {
-  /* Use softer blue from bootstrap's default info color */
-  --pst-color-info: 23, 162, 184;
-  --pst-color-active-navigation: 1, 50, 67;
-}
-
 /* Main index page overview cards */
 
 .sd-card {
@@ -199,12 +154,4 @@ html[data-theme=dark] .sd-card .sd-card-header {
 
 html[data-theme=dark] .sd-card .sd-card-footer {
   background-color:var(--pst-color-background);
-}
-
-html[data-theme=dark] h1 {
-  color: var(--pst-color-primary);
-}
-
-html[data-theme=dark] h3 {
-  color: #0a6774;
 }


### PR DESCRIPTION
Closes #16598

Removes all our custom css as PyData-Sphinx-Theme is looking good. This will help with having something coherent across the Ecosystem.