### PR TITLE
DEV: add `--durations` argument to dev.py interface

### DIFF
--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -97,7 +97,7 @@ jobs:
       run: |
         export OMP_NUM_THREADS=2
         export SCIPY_USE_PROPACK=1
-        python dev.py --no-build test -j 2
+        python dev.py --no-build test -j 2 --durations 10
 
   test_venv_install:
     name: Pip install into venv


### PR DESCRIPTION
Also improve some of the help messages for other commands

[skip azp]

Note that this was already usable, because arbitrary arguments can be passed to pytest with `-- argxxx`, but it's not discoverable and I always struggle to remember it myself.