### PR TITLE
MAINT: optimize.linprog: ensure integrality can be an array

### DIFF
--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -581,7 +581,7 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
         warning_message = "x0 is used only when method is 'revised simplex'. "
         warn(warning_message, OptimizeWarning)
 
-    if integrality and not meth == "highs":
+    if np.any(integrality) and not meth == "highs":
         integrality = None
         warning_message = ("Only `method='highs'` supports integer "
                            "constraints. Ignoring `integrality`.")

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -2230,12 +2230,13 @@ class TestLinprogHiGHSMIP():
         # source: slide 5,
         # https://www.cs.upc.edu/~erodri/webpage/cps/theory/lp/milp/slides.pdf
 
+        # use all array inputs to test gh-16681 (integrality couldn't be array)
         A_ub = np.array([[2, -2], [-8, 10]])
         b_ub = np.array([-1, 13])
         c = -np.array([1, 1])
 
-        bounds = [(0, np.inf)] * len(c)
-        integrality = [1] * len(c)
+        bounds = np.array([(0, np.inf)] * len(c))
+        integrality = np.ones_like(c)
 
         res = linprog(c=c, A_ub=A_ub, b_ub=b_ub, bounds=bounds,
                       method=self.method, integrality=integrality)


### PR DESCRIPTION
#### Reference issue
Closes gh-16681

#### What does this implement/fix?
`scipy.optimize.lingprog`'s new `integrality` parameter did not accept `np.ndarray` because a branching statement relied on its "truthiness" (i.e. `if integrality`). This PR fixes that and adds to an existing test to guard against regression.
