### PR TITLE
ENH: sparse.csgraph.dijkstra: add option to return sparse distance matrix

### DIFF
--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -896,9 +896,7 @@ cdef int _dijkstra_directed_sparse(
             int[:, :] pred,
             DTYPE_t limit) except -1:
     cdef:
-        unsigned int i, k, j_source, j_current
-        ITYPE_t j
-        DTYPE_t next_val
+        unsigned int i, k, j_source
         int return_pred = (pred.size > 0)
         FibonacciHeap heap
         FibonacciNode *v
@@ -1049,9 +1047,7 @@ cdef int _dijkstra_undirected_sparse(
             int[:, :] pred,
             DTYPE_t limit) except -1:
     cdef:
-        unsigned int i, k, j_source, j_current
-        ITYPE_t j
-        DTYPE_t next_val
+        unsigned int i, k, j_source
         int return_pred = (pred.size > 0)
         FibonacciHeap heap
         FibonacciNode *v

--- a/scipy/sparse/csgraph/meson.build
+++ b/scipy/sparse/csgraph/meson.build
@@ -3,7 +3,6 @@ pyx_files = [
   ['_matching', '_matching.pyx'],
   ['_min_spanning_tree', '_min_spanning_tree.pyx'],
   ['_reordering', '_reordering.pyx'],
-  ['_shortest_path', '_shortest_path.pyx'],
   ['_tools', '_tools.pyx'],
   ['_traversal', '_traversal.pyx']
 ]
@@ -24,6 +23,15 @@ foreach pyx_file: pyx_files
     subdir: 'scipy/sparse/csgraph'
   )
 endforeach
+
+py3.extension_module('_shortest_path',
+  cython_gen_cpp.process('_shortest_path.pyx'),
+  cpp_args: cython_cpp_args,
+  include_directories: inc_np,
+  dependencies: [py3_dep],
+  install: true,
+  subdir: 'scipy/sparse/csgraph'
+)
 
 python_sources = [
   '__init__.py',

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -107,6 +107,27 @@ def test_dijkstra_limit():
         check(limit, result)
 
 
+def test_dijkstra_sparse_dist():
+    limits = [0, 2, np.inf]
+    results = [undirected_SP_limit_0,
+               undirected_SP_limit_2,
+               undirected_SP]
+
+    def todense(sp_csr):
+        sp = np.full(sp_csr.shape, np.inf)
+        sp_coo = sp_csr.tocoo()
+        sp[sp_coo.row, sp_coo.col] = sp_coo.data
+        return sp
+
+    def check(limit, result):
+        SP_csr = dijkstra(undirected_G, directed=False, limit=limit,
+                             return_sparse_dist=True)
+        assert_array_almost_equal(todense(SP_csr), result)
+
+    for limit, result in zip(limits, results):
+        check(limit, result)
+
+
 def test_directed():
     def check(method):
         SP = shortest_path(directed_G, method=method, directed=True,


### PR DESCRIPTION
#### Reference issue

Closes gh-16585.

#### What does this implement/fix?

Adds an option to `csgraph.dijkstra` for returning a sparse distance matrix.

#### Additional information

I used libcpp vectors to construct the sparse distance matrix. As a result, `_shortest_path.pyx` now needs to be compiled with C++. I think I made the necessary changes to compile correctly. But it's possible I missed something.

I added new helper functions `_dijkstra_directed_sparse` and `_dijkstra_undirected_sparse` that are mostly copied from the originals. I also considered modifying the original helpers to compute a sparse representation by default. Lmk what approach you think is best.

Thanks in advance!