### PR TITLE
DOC: signal: Update the examples in the remez docstring.

### DIFF
--- a/scipy/signal/_fir_filter_design.py
+++ b/scipy/signal/_fir_filter_design.py
@@ -767,81 +767,86 @@ def remez(numtaps, bands, desired, weight=None, Hz=None, type='bandpass',
 
     Examples
     --------
-    In these examples `remez` gets used creating a bandpass, bandstop, lowpass
-    and highpass filter. The used parameters are the filter order, an array
-    with according frequency boundaries, the desired attenuation values and the
-    sampling frequency. Using `freqz` the corresponding frequency response
-    gets calculated and plotted.
+    In these examples, `remez` is used to design low-pass, high-pass,
+    band-pass and band-stop filters.  The parameters that define each filter
+    are the filter order, the band boundaries, the transition widths of the
+    boundaries, the desired gains in each band, and the sampling frequency.
 
+    We'll use a sample frequency of 22050 Hz in all the examples.  In each
+    example, the desired gain in each band is either 0 (for a stop band)
+    or 1 (for a pass band).
+
+    `freqz` is used to compute the frequency response of each filter, and
+    the utility function ``plot_response`` defined below is used to plot
+    the response.
+
+    >>> import numpy as np
     >>> from scipy import signal
     >>> import matplotlib.pyplot as plt
 
-    >>> def plot_response(fs, w, h, title):
+    >>> fs = 22050   # Sample rate, Hz
+
+    >>> def plot_response(w, h, title):
     ...     "Utility function to plot response functions"
     ...     fig = plt.figure()
     ...     ax = fig.add_subplot(111)
-    ...     ax.plot(0.5*fs*w/np.pi, 20*np.log10(np.abs(h)))
+    ...     ax.plot(w, 20*np.log10(np.abs(h)))
     ...     ax.set_ylim(-40, 5)
-    ...     ax.set_xlim(0, 0.5*fs)
     ...     ax.grid(True)
     ...     ax.set_xlabel('Frequency (Hz)')
     ...     ax.set_ylabel('Gain (dB)')
     ...     ax.set_title(title)
 
-    This example shows a steep low pass transition according to the small
-    transition width and high filter order:
+    The first example is a low-pass filter, with cutoff frequency 8 kHz.
+    The filter length is 325, and the transition width from pass to stop
+    is 100 Hz.
 
-    >>> fs = 22050.0       # Sample rate, Hz
     >>> cutoff = 8000.0    # Desired cutoff frequency, Hz
-    >>> trans_width = 100  # Width of transition from pass band to stop band, Hz
-    >>> numtaps = 400      # Size of the FIR filter.
+    >>> trans_width = 100  # Width of transition from pass to stop, Hz
+    >>> numtaps = 325      # Size of the FIR filter.
     >>> taps = signal.remez(numtaps, [0, cutoff, cutoff + trans_width, 0.5*fs],
     ...                     [1, 0], fs=fs)
-    >>> w, h = signal.freqz(taps, [1], worN=2000)
-    >>> plot_response(fs, w, h, "Low-pass Filter")
+    >>> w, h = signal.freqz(taps, [1], worN=2000, fs=fs)
+    >>> plot_response(w, h, "Low-pass Filter")
+    >>> plt.show()
 
-    This example shows a high pass filter:
+    This example shows a high-pass filter:
 
-    >>> fs = 22050.0       # Sample rate, Hz
     >>> cutoff = 2000.0    # Desired cutoff frequency, Hz
-    >>> trans_width = 250  # Width of transition from pass band to stop band, Hz
+    >>> trans_width = 250  # Width of transition from pass to stop, Hz
     >>> numtaps = 125      # Size of the FIR filter.
     >>> taps = signal.remez(numtaps, [0, cutoff - trans_width, cutoff, 0.5*fs],
     ...                     [0, 1], fs=fs)
-    >>> w, h = signal.freqz(taps, [1], worN=2000)
-    >>> plot_response(fs, w, h, "High-pass Filter")
+    >>> w, h = signal.freqz(taps, [1], worN=2000, fs=fs)
+    >>> plot_response(w, h, "High-pass Filter")
+    >>> plt.show()
 
-    For a signal sampled with 22 kHz a bandpass filter with a pass band of 2-5
-    kHz gets calculated using the Remez algorithm. The transition width is 260
-    Hz and the filter order 10:
+    This example shows a band-pass filter with a pass-band from 2 kHz to
+    5 kHz.  The transition width is 260 Hz and the length of the filter
+    is 63, which is smaller than in the other examples:
 
-    >>> fs = 22000.0         # Sample rate, Hz
     >>> band = [2000, 5000]  # Desired pass band, Hz
-    >>> trans_width = 260    # Width of transition from pass band to stop band, Hz
-    >>> numtaps = 10        # Size of the FIR filter.
+    >>> trans_width = 260    # Width of transition from pass to stop, Hz
+    >>> numtaps = 63         # Size of the FIR filter.
     >>> edges = [0, band[0] - trans_width, band[0], band[1],
     ...          band[1] + trans_width, 0.5*fs]
     >>> taps = signal.remez(numtaps, edges, [0, 1, 0], fs=fs)
-    >>> w, h = signal.freqz(taps, [1], worN=2000)
-    >>> plot_response(fs, w, h, "Band-pass Filter")
+    >>> w, h = signal.freqz(taps, [1], worN=2000, fs=fs)
+    >>> plot_response(w, h, "Band-pass Filter")
+    >>> plt.show()
 
-    It can be seen that for this bandpass filter, the low order leads to higher
-    ripple and less steep transitions. There is very low attenuation in the
-    stop band and little overshoot in the pass band.  Of course the desired
-    gain can be better approximated with a higher filter order.
+    The low order leads to higher ripple and less steep transitions.
 
-    The next example shows a bandstop filter. Because of the high filter order
-    the transition is quite steep:
+    The next example shows a band-stop filter.
 
-    >>> fs = 20000.0         # Sample rate, Hz
     >>> band = [6000, 8000]  # Desired stop band, Hz
-    >>> trans_width = 200    # Width of transition from pass band to stop band, Hz
+    >>> trans_width = 200    # Width of transition from pass to stop, Hz
     >>> numtaps = 175        # Size of the FIR filter.
-    >>> edges = [0, band[0] - trans_width, band[0], band[1], band[1] + trans_width, 0.5*fs]
+    >>> edges = [0, band[0] - trans_width, band[0], band[1],
+    ...          band[1] + trans_width, 0.5*fs]
     >>> taps = signal.remez(numtaps, edges, [1, 0, 1], fs=fs)
-    >>> w, h = signal.freqz(taps, [1], worN=2000)
-    >>> plot_response(fs, w, h, "Band-stop Filter")
-
+    >>> w, h = signal.freqz(taps, [1], worN=2000, fs=fs)
+    >>> plot_response(w, h, "Band-stop Filter")
     >>> plt.show()
 
     """
@@ -868,7 +873,7 @@ def remez(numtaps, bands, desired, weight=None, Hz=None, type='bandpass',
 
     bands = np.asarray(bands).copy()
     return _sigtools._remez(numtaps, bands, desired, weight, tnum, fs,
-                           maxiter, grid_density)
+                            maxiter, grid_density)
 
 
 def firls(numtaps, bands, desired, weight=None, nyq=None, fs=None):


### PR DESCRIPTION
* Increase numtaps for the band-pass example, so the pass band
  is more than just a single lobe.
* Lower numtaps in the low-pass example (save a few CPU cycles,
  with the same impact as before).
* Use the same value for fs in all the examples.
* Use fs in the freqz() calls, so it is not needed in the
  plot_response() function.
* Call plt.plot() for each example, so the plots appear with
  the relevant text and code, instead of all at the end.
* Add `import numpy as np`.
* Copy-edit.
