### PR TITLE
ENH: io.wavfile: raise verbose error when no data chunks are found

### DIFF
--- a/scipy/io/wavfile.py
+++ b/scipy/io/wavfile.py
@@ -704,6 +704,9 @@ def read(filename, mmap=False):
         else:
             fid.seek(0)
 
+    if not data_chunk_received:
+        raise ValueError(f'Wav file {filename} is corrupted: No data chunks found.')
+
     return fs, data
 
 


### PR DESCRIPTION
Previously, we would just crash with an unbound local error.

#### Reference issue
The internet is pretty full of this exact error. Just google for "scipy.wavfile UnboundLocalError".

#### What does this implement/fix?
This gives a more useful error when we cannot read a wav file instead of straight up crashing.
