### PR TITLE
BUG: fix mutable data types as default arguments in `ord.{Data,RealData}`

### DIFF
--- a/scipy/odr/_odrpack.py
+++ b/scipy/odr/_odrpack.py
@@ -257,7 +257,7 @@ class Data:
 
     """
 
-    def __init__(self, x, y=None, we=None, wd=None, fix=None, meta={}):
+    def __init__(self, x, y=None, we=None, wd=None, fix=None, meta=None):
         self.x = _conv(x)
 
         if not isinstance(self.x, numpy.ndarray):
@@ -269,7 +269,7 @@ class Data:
         self.we = _conv(we)
         self.wd = _conv(wd)
         self.fix = _conv(fix)
-        self.meta = meta
+        self.meta = {} if meta is None else meta
 
     def set_meta(self, **kwds):
         """ Update the metadata dictionary with the keywords and data provided
@@ -355,7 +355,7 @@ class RealData(Data):
     """
 
     def __init__(self, x, y=None, sx=None, sy=None, covx=None, covy=None,
-                 fix=None, meta={}):
+                 fix=None, meta=None):
         if (sx is not None) and (covx is not None):
             raise ValueError("cannot set both sx and covx")
         if (sy is not None) and (covy is not None):
@@ -385,7 +385,7 @@ class RealData(Data):
         self.covx = _conv(covx)
         self.covy = _conv(covy)
         self.fix = _conv(fix)
-        self.meta = meta
+        self.meta = {} if meta is None else meta
 
     def _sd2wt(self, sd):
         """ Convert standard deviation to weights.


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
`Data` and`RealData` use mutable data types as default arguments which are evaluated at definition so multiple instances of these classes can end up sharing the same meta object as shown bellow.
```
In [1]: from scipy.odr import Data

In [2]: import numpy as np

In [3]: a = Data(np.array([]))

In [4]: b = Data(np.array([]))

In [6]: a.set_meta(foo=4)

In [7]: a.meta
Out[7]: {'foo': 4}

In [8]: b.meta
Out[8]: {'foo': 4}
```
#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
