### PR TITLE
MAINT: add `__bool__` method to spatial.transform.Rotation

### DIFF
--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -549,13 +549,7 @@ cdef class Rotation:
     def __bool__():
         """Comply with Python convention for objects to be True.
 
-        This method is necessary because the calling bool() on an object will
-        fall back to the `Rotation.__len__()` if `Rotation.__bool__()` is not
-        implemented and `Rotation.__len__()` is. If the Rotation is not a
-        single its length is a positive integer wich is True as a boolean but
-        if it is a single `Rotation.__len__()` raises a TypeError. A single
-        Rotation object should also evaluate to True, hence this method so no
-        fallback to `Rotation.__len__()` is necessary.
+        Required because `Rotation.__len__()` is defined and not always truthy.
         """
         return True
 

--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -545,8 +545,7 @@ cdef class Rotation:
         """Whether this instance represents a single rotation."""
         return self._single
 
-    @staticmethod
-    def __bool__():
+    def __bool__(self):
         """Comply with Python convention for objects to be True.
 
         Required because `Rotation.__len__()` is defined and not always truthy.

--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -545,6 +545,20 @@ cdef class Rotation:
         """Whether this instance represents a single rotation."""
         return self._single
 
+    @staticmethod
+    def __bool__():
+        """Comply with Python convention for objects to be True.
+
+        This method is necessary because the calling bool() on an object will
+        fall back to the `Rotation.__len__()` if `Rotation.__bool__()` is not
+        implemented and `Rotation.__len__()` is. If the Rotation is not a
+        single its length is a positive integer wich is True as a boolean but
+        if it is a single `Rotation.__len__()` raises a TypeError. A single
+        Rotation object should also evaluate to True, hence this method so no
+        fallback to `Rotation.__len__()` is necessary.
+        """
+        return True
+
     def __len__(self):
         """Number of rotations contained in this object.
 

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -1348,15 +1348,16 @@ def test_concatenate():
 def test_concatenate_wrong_type():
     with pytest.raises(TypeError, match='Rotation objects only'):
         Rotation.concatenate([Rotation.identity(), 1, None])
-        
-        
+
+
+# Regression test for gh-16663
 def test_len_and_bool():
     rotation_single = Rotation([0, 0, 0, 1])
     rotation_multi = Rotation([[0, 0, 0, 1], [0, 0, 0, 1]])
-    
+
     with pytest.raises(TypeError, match="Single rotation has no len()."):
         len(rotation_single)
     assert len(rotation_multi) == 2
-    
+
     assert rotation_single
     assert rotation_multi

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -1348,3 +1348,15 @@ def test_concatenate():
 def test_concatenate_wrong_type():
     with pytest.raises(TypeError, match='Rotation objects only'):
         Rotation.concatenate([Rotation.identity(), 1, None])
+        
+        
+def test_len_and_bool():
+    rotation_single = Rotation([0, 0, 0, 1])
+    rotation_multi = Rotation([[0, 0, 0, 1], [0, 0, 0, 1]])
+    
+    with pytest.raises(TypeError, match="Single rotation has no len()."):
+        len(rotation_single)
+    assert len(rotation_multi) == 2
+    
+    assert rotation_single
+    assert rotation_multi


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #16663 

#### What does this implement/fix?
<!--Please explain your changes.-->

Docstring from the new __bool__ method:

```python
        """Comply with Python convention for objects to be True.

        This method is necessary because the calling bool() on an object will
        fall back to the `Rotation.__len__()` if `Rotation.__bool__()` is not
        implemented and `Rotation.__len__()` is. If the Rotation is not a
        single its length is a positive integer wich is True as a boolean but
        if it is a single `Rotation.__len__()` raises a TypeError. A single
        Rotation object should also evaluate to True, hence this method so no
        fallback to `Rotation.__len__()` is necessary.
        """
```
