### PR TITLE
CI: add Meson version number in environment.yml to rebuild Docker image

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - setuptools<60.0
   - cython
   - compilers
-  - meson
+  - meson>=0.63.0
   - meson-python
   - ninja
   - numpy


### PR DESCRIPTION
This Docker image with all development dependencies only gets rebuilt on a change to `environment.yml`. So if we bump the minimum version in `meson.build` only, there's a problem. Hence adding the version number here, so grepping the codebase finds this during a version bump process.

This fixes the Gitpod image build in CI, it failed on:

    ERROR: Meson version is 0.62.2 but project requires >= 0.63.0