### PR TITLE
ENH: stats.bootstrap: extend previous bootstrap result

### DIFF
--- a/scipy/stats/_resampling.py
+++ b/scipy/stats/_resampling.py
@@ -524,6 +524,29 @@ def bootstrap(data, statistic, *, n_resamples=9999, batch=None,
     >>> print(res.confidence_interval)
     ConfidenceInterval(low=0.9950085825848624, high=0.9971212407917498)
 
+    The result object can be passed back into `bootstrap` to perform additional
+    resampling:
+
+    >>> len(res.bootstrap_distribution)
+    9999
+    >>> res = bootstrap((x, y), my_statistic, vectorized=False, paired=True,
+    ...                 n_resamples=1001, random_state=rng,
+    ...                 bootstrap_result=res)
+    >>> len(res.bootstrap_distribution)
+    11000
+
+    or to change the confidence interval options:
+
+    >>> res2 = bootstrap((x, y), my_statistic, vectorized=False, paired=True,
+    ...                  n_resamples=0, random_state=rng, bootstrap_result=res,
+    ...                  method='percentile', confidence_level=0.9)
+    >>> np.testing.assert_equal(res2.bootstrap_distribution,
+    ...                         res.bootstrap_distribution)
+    >>> res.confidence_interval
+    ConfidenceInterval(low=0.9950035351407804, high=0.9971170323404578)
+
+    without repeating computation of the original bootstrap distribution.
+
     """
     # Input validation
     args = _bootstrap_iv(data, statistic, vectorized, paired, axis,

--- a/scipy/stats/_resampling.py
+++ b/scipy/stats/_resampling.py
@@ -132,7 +132,7 @@ def _bca_interval(data, statistic, axis, alpha, theta_hat_b, batch):
 
 
 def _bootstrap_iv(data, statistic, vectorized, paired, axis, confidence_level,
-                  n_resamples, batch, method, random_state):
+                  n_resamples, batch, method, bootstrap_result, random_state):
     """Input validation and standardization for `bootstrap`."""
 
     if vectorized not in {True, False, None}:
@@ -188,8 +188,8 @@ def _bootstrap_iv(data, statistic, vectorized, paired, axis, confidence_level,
     confidence_level_float = float(confidence_level)
 
     n_resamples_int = int(n_resamples)
-    if n_resamples != n_resamples_int or n_resamples_int <= 0:
-        raise ValueError("`n_resamples` must be a positive integer.")
+    if n_resamples != n_resamples_int or n_resamples_int < 0:
+        raise ValueError("`n_resamples` must be a non-negative integer.")
 
     if batch is None:
         batch_iv = batch
@@ -207,11 +207,22 @@ def _bootstrap_iv(data, statistic, vectorized, paired, axis, confidence_level,
     if not paired and n_samples > 1 and method == 'bca':
         raise ValueError(message)
 
+    message = "`bootstrap_result` must have attribute `bootstrap_distribution'"
+    if (bootstrap_result is not None
+            and not hasattr(bootstrap_result, "bootstrap_distribution")):
+        raise ValueError(message)
+
+    message = ("Either `bootstrap_result.bootstrap_distribution.size` or "
+               "`n_resamples` must be positive.")
+    if n_resamples_int == 0 and (not bootstrap_result or
+            not bootstrap_result.bootstrap_distribution.size):
+        raise ValueError(message)
+
     random_state = check_random_state(random_state)
 
     return (data_iv, statistic, vectorized, paired, axis_int,
             confidence_level_float, n_resamples_int, batch_iv,
-            method, random_state)
+            method, bootstrap_result, random_state)
 
 
 fields = ['confidence_interval', 'bootstrap_distribution', 'standard_error']
@@ -220,7 +231,7 @@ BootstrapResult = make_dataclass("BootstrapResult", fields)
 
 def bootstrap(data, statistic, *, n_resamples=9999, batch=None,
               vectorized=None, paired=False, axis=0, confidence_level=0.95,
-              method='BCa', random_state=None):
+              method='BCa', bootstrap_result=None, random_state=None):
     r"""
     Compute a two-sided bootstrap confidence interval of a statistic.
 
@@ -291,6 +302,12 @@ def bootstrap(data, statistic, *, n_resamples=9999, batch=None,
         bootstrap confidence interval (``'BCa'``).
         Note that only ``'percentile'`` and ``'basic'`` support multi-sample
         statistics at this time.
+    bootstrap_result : BootstrapResult, optional
+        Provide the result object returned by a previous call to `bootstrap`
+        to include the previous bootstrap distribution in the new bootstrap
+        distribution. This can be used, for example, to change
+        `confidence_level`, change `method`, or see the effect of performing
+        additional resampling without repeating computations.
     random_state : {None, int, `numpy.random.Generator`,
                     `numpy.random.RandomState`}, optional
 
@@ -510,13 +527,14 @@ def bootstrap(data, statistic, *, n_resamples=9999, batch=None,
     # Input validation
     args = _bootstrap_iv(data, statistic, vectorized, paired, axis,
                          confidence_level, n_resamples, batch, method,
-                         random_state)
-    data, statistic, vectorized, paired, axis = args[:5]
-    confidence_level, n_resamples, batch, method, random_state = args[5:]
+                         bootstrap_result, random_state)
+    data, statistic, vectorized, paired, axis, confidence_level = args[:6]
+    n_resamples, batch, method, bootstrap_result, random_state = args[6:]
 
-    theta_hat_b = []
+    theta_hat_b = ([] if bootstrap_result is None
+                   else [bootstrap_result.bootstrap_distribution])
 
-    batch_nominal = batch or n_resamples
+    batch_nominal = batch or n_resamples or 1
 
     for k in range(0, n_resamples, batch_nominal):
         batch_actual = min(batch_nominal, n_resamples-k)

--- a/scipy/stats/_resampling.py
+++ b/scipy/stats/_resampling.py
@@ -214,8 +214,9 @@ def _bootstrap_iv(data, statistic, vectorized, paired, axis, confidence_level,
 
     message = ("Either `bootstrap_result.bootstrap_distribution.size` or "
                "`n_resamples` must be positive.")
-    if n_resamples_int == 0 and (not bootstrap_result or
-            not bootstrap_result.bootstrap_distribution.size):
+    if ((not bootstrap_result or
+         not bootstrap_result.bootstrap_distribution.size)
+            and n_resamples_int == 0):
         raise ValueError(message)
 
     random_state = check_random_state(random_state)


### PR DESCRIPTION
#### Reference issue
raphaelvallat/pingouin#189

#### What does this implement/fix?
This adds a parameter `bootstrap_result` so that the bootstrap distribution of a previous call to `bootstrap` can be included in the new bootstrap distribution. This allows the user to change `confidence_level`, change `method`, or see the effect of performing additional resampling without repeating earlier calculations.

```python3
import numpy as np
from scipy import stats

rng = np.random.default_rng(8958153316228384)
x = rng.random(size=100)

rng = np.random.default_rng(296689032789913033)
res = stats.bootstrap((x,), np.mean, random_state=rng, confidence_level=0.95, 
                      method='percentile')
res = stats.bootstrap((x,), np.mean, random_state=rng, confidence_level=0.90, 
                      method='BCa', bootstrap_result=res)

rng = np.random.default_rng(296689032789913033)
ref = stats.bootstrap((x,), np.mean, n_resamples=9999*2, random_state=rng,
                      confidence_level=0.90, method='BCa')

assert res.confidence_interval == ref.confidence_interval
```

#### Additional information
Ideally, there might be a stateful, object-oriented interface to bootstrapping. That's a lot more work. This adds most of that functionality with minimal changes.