### PR TITLE
DOC: interpolate: add an example of splPrep/PPoly.from_spline interop

### DIFF
--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -1333,6 +1333,49 @@ class PPoly(_PPolyBase):
             If bool, determines whether to extrapolate to out-of-bounds points
             based on first and last intervals, or to return NaNs.
             If 'periodic', periodic extrapolation is used. Default is True.
+
+        Examples
+        --------
+
+        This funcion only supports 1D splines out of the box.
+
+        If the ``tck`` object represents a parametric spline (e.g. constructed
+        by `splprep` or a `BSpline` with ``c.ndim > 1``), you will need to loop
+        over the dimensions manually.
+
+        >>> from scipy.interpolate import splprep, splev, PPoly
+        >>> t = np.arange(0, 1.1, .1)
+        >>> x = np.sin(2*np.pi*t)
+        >>> y = np.cos(2*np.pi*t)
+        >>> (t, c, k), u = splprep([x, y], s=0)
+
+        Note that ``c`` is a list of two arrays of length 11.
+
+        >>> unew = np.arange(0, 1.01, 0.01)
+        >>> out = splev(unew, (t, c, k))
+
+        To convert this spline to the power basis, we convert each
+        component of the list of b-spline coefficients, ``c``, into the
+        corresponding cubic polynomial. 
+
+        >>> polys = [PPoly.from_spline((t, cj, k)) for cj in c]
+        >>> polys[0].c.shape
+        (4, 14)
+
+        Note that the coefficients of the polynomials `polys` are in the
+        power basis and their dimensions reflect just that: here 4 is the order
+        (degree+1), and 14 is the number of intervals---which is nothing but
+        the length of the knot array of the original `tck`.
+
+        Optionally, we can stack the components into a single `PPoly` along
+        the third dimension:
+
+        >>> cc = np.dstack([p.c for p in polys])    # has shape = (4, 14, 2)
+        >>> poly = PPoly(cc, polys[0].x)
+        >>> np.allclose(poly(unew).T,     # note the transpose to match `splev`
+        ...             out, atol=1e-15)
+        True
+
         """
         if isinstance(tck, BSpline):
             t, c, k = tck.tck

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -1337,7 +1337,7 @@ class PPoly(_PPolyBase):
         Examples
         --------
 
-        This funcion only supports 1D splines out of the box.
+        This function only supports 1D splines out of the box.
 
         If the ``tck`` object represents a parametric spline (e.g. constructed
         by `splprep` or a `BSpline` with ``c.ndim > 1``), you will need to loop
@@ -1356,7 +1356,7 @@ class PPoly(_PPolyBase):
 
         To convert this spline to the power basis, we convert each
         component of the list of b-spline coefficients, ``c``, into the
-        corresponding cubic polynomial. 
+        corresponding cubic polynomial.
 
         >>> polys = [PPoly.from_spline((t, cj, k)) for cj in c]
         >>> polys[0].c.shape

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -1336,15 +1336,24 @@ class PPoly(_PPolyBase):
 
         Examples
         --------
+        Construct an interpolating spline and convert it to a `PPoly` instance 
 
-        This function only supports 1D splines out of the box.
+        >>> from scipy.interpolate import splrep, PPoly
+        >>> x = np.linspace(0, 1, 11)
+        >>> y = np.sin(2*np.pi*x)
+        >>> tck = splrep(x, y, s=0)
+        >>> p = PPoly.from_spline(tck)
+        >>> isinstance(p, PPoly)
+        True
+
+        Note that this function only supports 1D splines out of the box.
 
         If the ``tck`` object represents a parametric spline (e.g. constructed
         by `splprep` or a `BSpline` with ``c.ndim > 1``), you will need to loop
         over the dimensions manually.
 
-        >>> from scipy.interpolate import splprep, splev, PPoly
-        >>> t = np.arange(0, 1.1, .1)
+        >>> from scipy.interpolate import splprep, splev
+        >>> t = np.linspace(0, 1, 11)
         >>> x = np.sin(2*np.pi*t)
         >>> y = np.cos(2*np.pi*t)
         >>> (t, c, k), u = splprep([x, y], s=0)
@@ -1365,7 +1374,7 @@ class PPoly(_PPolyBase):
         Note that the coefficients of the polynomials `polys` are in the
         power basis and their dimensions reflect just that: here 4 is the order
         (degree+1), and 14 is the number of intervals---which is nothing but
-        the length of the knot array of the original `tck`.
+        the length of the knot array of the original `tck` minus one.
 
         Optionally, we can stack the components into a single `PPoly` along
         the third dimension:


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

closes gh-14348

#### What does this implement/fix?
<!--Please explain your changes.-->

Give  `PPoly.from_spline` a docstring example of using it for parametric splines. There are two issues: `from_spline` only accepts 1D arrays of coefficients, hence in the N-D case users need to loop over the dimensions. Second is that `splPrep` returns the coefficients in a length-N list of arrays and this is incompatible with BSpline and PPoly which use *trailing* dimensions. This is a known wart, and it cannot be fixed in a reasonable way.

An alternative of vectorizing from_spline is not really viable because it needs to accept both tck-tuples (list-of-arrays) and BSpines (trailing dimensions). There is no reliable way to decide which convention to use. 

Thus, document the workaround and leave it at that.

[skip actions]
