### PR TITLE
MAINT: interpolate: use _fitpack_impl in fitpack2

### DIFF
--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -24,7 +24,7 @@ import warnings
 from numpy import zeros, concatenate, ravel, diff, array, ones
 import numpy as np
 
-from . import _fitpack_py
+from . import _fitpack_impl
 from . import dfitpack
 
 
@@ -359,7 +359,7 @@ class UnivariateSpline:
                 ext = _extrap_modes[ext]
             except KeyError as e:
                 raise ValueError("Unknown extrapolation mode %s." % ext) from e
-        return _fitpack_py.splev(x, self._eval_args, der=nu, ext=ext)
+        return _fitpack_impl.splev(x, self._eval_args, der=nu, ext=ext)
 
     def get_knots(self):
         """ Return positions of interior knots of the spline.
@@ -546,7 +546,7 @@ class UnivariateSpline:
         :math:`\\cos(x) = \\sin'(x)`.
 
         """
-        tck = _fitpack_py.splder(self._eval_args, n)
+        tck = _fitpack_impl.splder(self._eval_args, n)
         # if self.ext is 'const', derivative.ext will be 'zeros'
         ext = 1 if self.ext == 3 else self.ext
         return UnivariateSpline._from_tck(tck, ext=ext)
@@ -602,7 +602,7 @@ class UnivariateSpline:
         2.2572053268208538
 
         """
-        tck = _fitpack_py.splantider(self._eval_args, n)
+        tck = _fitpack_impl.splantider(self._eval_args, n)
         return UnivariateSpline._from_tck(tck, self.ext)
 
 


### PR DESCRIPTION
Pure maintenance: `_fitpack_py` does essentially

```
if isinstance(tck, BSpline):
    # dispatch to BSpline methods
else:
    # dispatch to _fitpack_impl
```

Since it certain that here tck is a tuple not a BSpline, can
skip this level of checking.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
