### PR TITLE
ENH: interpolate.KroghInterpolator: raise warning about numerical stability if too many points are provided to KroghInterpolator

### DIFF
--- a/scipy/interpolate/_polyint.py
+++ b/scipy/interpolate/_polyint.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 from scipy.special import factorial
 from scipy._lib._util import _asarray_validated, float_factorial
@@ -295,6 +297,11 @@ class KroghInterpolator(_Interpolator1DWithDerivatives):
         self.xi = np.asarray(xi)
         self.yi = self._reshape_yi(yi)
         self.n, self.r = self.yi.shape
+
+        if (deg := self.xi.size) > 30:
+            warnings.warn(f"{deg} degrees provided, degrees higher than about"
+                          " thirty cause problems with numerical instability "
+                          "with 'KroghInterpolator'", stacklevel=2)
 
         c = np.zeros((self.n+1, self.r), dtype=self.dtype)
         c[0] = self.yi[0]

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -6,6 +6,7 @@ from numpy.testing import (
     assert_almost_equal, assert_array_equal, assert_array_almost_equal,
     assert_allclose, assert_equal, assert_)
 from pytest import raises as assert_raises
+import pytest
 
 from scipy.interpolate import (
     KroghInterpolator, krogh_interpolate,
@@ -280,6 +281,10 @@ class TestKrogh:
         cmplx2 = (KroghInterpolator(x, y.real).derivatives(0) +
                   1j*KroghInterpolator(x, y.imag).derivatives(0))
         assert_allclose(cmplx, cmplx2, atol=1e-15)
+
+    def test_high_degree_warning(self):
+        with pytest.warns(UserWarning, match="40 degrees provided,"):
+            KroghInterpolator(np.arange(40), np.ones(40))
 
 
 class TestTaylor:


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
closes gh-3854
#### What does this implement/fix?
<!--Please explain your changes.-->
As suggested in the issue raises a warning if more than 30 points are provided.
#### Additional information
<!--Any additional information you think is important.-->
