### PR TITLE
DOC: Replace runtests.py with dev.py where appropriate

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -14,14 +14,7 @@ git submodule update --init
 
 Now to build both SciPy itself and the docs, use:
 ```
-python3 dev.py doc
-```
-
-Alternatively, if you prefer to build SciPy and the docs separately rather
-than use `dev.py`:
-```
-python setup.py develop  # in the root of the repo
-cd doc && make html
+python dev.py doc
 ```
 
 In case the SciPy version found by the above command is different from that of the

--- a/doc/README.md
+++ b/doc/README.md
@@ -14,11 +14,11 @@ git submodule update --init
 
 Now to build both SciPy itself and the docs, use:
 ```
-python3 runtests.py --doc html
+python3 dev.py doc
 ```
 
 Alternatively, if you prefer to build SciPy and the docs separately rather
-than use `runtests.py`:
+than use `dev.py`:
 ```
 python setup.py develop  # in the root of the repo
 cd doc && make html

--- a/doc/source/dev/contributor/conda_guide.rst
+++ b/doc/source/dev/contributor/conda_guide.rst
@@ -58,24 +58,23 @@ the latest release of conda from either
 
 #. Initialize git submodules: ``git submodule update --init``.
 
-#. Do an in-place build: enter ``python setup.py build_ext --inplace``.
-   This will compile the C, C++, and Fortran code that comes with SciPy. We
-   installed ``python`` with Anaconda. ``setup.py`` is a script in the root
-   directory of SciPy, which is why you have to be in the SciPy root directory
-   to call it. ``build_ext`` is a command defined in ``setup.py``, and
-   ``--inplace`` is an option we'll use to ensure that the compiling happens in
-   the SciPy directory you already have rather than the default location for
-   Python packages. By building in-place, you avoid having to re-build SciPy
-   before you can test changes to the Python code.
+#. Build SciPy: enter ``python dev.py build``. 
 
-#. Test the build: enter ``python runtests.py -v``.
+    This will compile the C, C++, and Fortran code that comes with SciPy and
+    install it in the directory you already have rather than the default
+    location for Python packages. We installed ``python3`` with Anaconda.
+    ``dev.py`` is a script in the root directory of SciPy which can be used to
+    execute several development tasks (see :ref:`the-dev-py-interface` for
+    details).
 
-   * ``runtests.py`` is another script in the SciPy root directory. It runs a
-     suite of tests that make sure SciPy is working as it should, and ``-v``
-     activates the ``--verbose`` option to show all the test output. If the
-     tests are successful, you now have a working development build of SciPy!
-     You could stop here, but you would only be able to use this development
-     build when the Python working directory is the SciPy root directory.
+#. Test the build: enter ``python dev.py test -v``.
+
+    This command runs a suite of tests that make sure SciPy is working as it
+    should, and ``-v`` activates the ``--verbose`` option to show all the test
+    output. If the tests are successful, you now have a working development
+    build of SciPy!
+    You could stop here, but you would only be able to use this development
+    build when the Python working directory is the SciPy root directory.
 
 #. Enter ``conda develop .``, where ``.`` refers to the present directory.
    This will allow us to ``import`` the development version of SciPy in Python

--- a/doc/source/dev/contributor/conda_guide.rst
+++ b/doc/source/dev/contributor/conda_guide.rst
@@ -62,7 +62,7 @@ the latest release of conda from either
 
     This will compile the C, C++, and Fortran code that comes with SciPy and
     install it in the directory you already have rather than the default
-    location for Python packages. We installed ``python3`` with Anaconda.
+    location for Python packages. We installed ``python`` with Anaconda.
     ``dev.py`` is a script in the root directory of SciPy which can be used to
     execute several development tasks (see :ref:`the-dev-py-interface` for
     details).

--- a/doc/source/dev/contributor/development_workflow.rst
+++ b/doc/source/dev/contributor/development_workflow.rst
@@ -114,10 +114,10 @@ development environment, you'll need to activate your development virtual
 environment, perform an in-place build, and run tests::
 
    conda activate name-of-your-virtual-environment
-   python setup.py build_ext --inplace
-   python runtests.py -v
+   python dev.py build
+   python dev.py test -v
 
-Otherwise, see :ref:`building`, :ref:`runtests` for more information.
+Otherwise, see :ref:`building`, :ref:`meson` for more information.
 
 .. _editing-workflow:
 
@@ -275,7 +275,7 @@ Checklist before submitting a PR
    :ref:`license-considerations`.
 -  Are there unit tests with good code coverage? See
    `NumPy/SciPy Testing Guidelines`_.
--  Do all unit tests pass locally? See :ref:`runtests`.
+-  Do all unit tests pass locally? See :ref:`the-dev-py-interface`.
 -  Do all public function have docstrings including examples? See the
    `numpydoc docstring guide`_.
 -  Does the documentation render correctly? See :ref:`rendering-documentation`.

--- a/doc/source/dev/contributor/development_workflow.rst
+++ b/doc/source/dev/contributor/development_workflow.rst
@@ -114,7 +114,6 @@ development environment, you'll need to activate your development virtual
 environment, perform an in-place build, and run tests::
 
    conda activate name-of-your-virtual-environment
-   python dev.py build
    python dev.py test -v
 
 Otherwise, see :ref:`building`, :ref:`meson` for more information.

--- a/doc/source/dev/contributor/meson.rst
+++ b/doc/source/dev/contributor/meson.rst
@@ -96,6 +96,7 @@ running the tests should also work, for example::
 The full test suite should pass, without any build warnings on Linux (with GCC
 9 at least) and a moderate amount on the other platforms.
 
+.. _the-dev-py-interface:
 
 The ``dev.py`` interface
 ========================

--- a/doc/source/dev/contributor/quickstart_docker.rst
+++ b/doc/source/dev/contributor/quickstart_docker.rst
@@ -124,7 +124,7 @@ container do not persist after you close it.
 
    This will compile the C, C++, and Fortran code that comes with SciPy and
    install it in the directory you already have rather than the default
-   location for Python packages. We installed ``python3`` with Anaconda.
+   location for Python packages. We installed ``python`` with Anaconda.
    ``dev.py`` is a script in the root directory of SciPy which can be used to
    execute several development tasks (see :ref:`the-dev-py-interface` for
    details).

--- a/doc/source/dev/contributor/quickstart_docker.rst
+++ b/doc/source/dev/contributor/quickstart_docker.rst
@@ -118,25 +118,24 @@ container do not persist after you close it.
 
 #. Initialize git submodules: ``git submodule update --init``.
 
-#. Do an in-place build by entering::
+#. Build SciPy by entering::
 
-      python setup.py build_ext --inplace
+      python dev.py build
 
-   This will compile the C,
-   C++, and Fortran code that comes with SciPy. ``setup.py`` is a
-   script in the root directory of SciPy, which is why you have to be
-   in the SciPy root directory to call it. ``build_ext`` is a command
-   defined in ``setup.py``, and ``--inplace`` is an option we’ll use to
-   ensure that the compiling happens in the SciPy directory you already
-   have rather than some other folder on your computer. 
+   This will compile the C, C++, and Fortran code that comes with SciPy and
+   install it in the directory you already have rather than the default
+   location for Python packages. We installed ``python3`` with Anaconda.
+   ``dev.py`` is a script in the root directory of SciPy which can be used to
+   execute several development tasks (see :ref:`the-dev-py-interface` for
+   details).
 
 #. Test the build by entering::
 
-      python runtests.py -v
+      python dev.py test -v
 
-   ``runtests.py`` is another script in the SciPy root directory. It runs a
-   suite of tests that make sure SciPy is working as it should, and ``-v``
-   activates the ``–verbose`` option to show all the test output.
+   This command runs a suite of tests that make sure SciPy is working as it
+   should, and ``-v`` activates the ``--verbose`` option to show all the test
+   output.
 
 #. If you want to :ref:`build the documentation <rendering-documentation>`
    or import SciPy from any directory other than the SciPy root, you should

--- a/doc/source/dev/contributor/reviewing_prs.rst
+++ b/doc/source/dev/contributor/reviewing_prs.rst
@@ -85,8 +85,7 @@ Assuming you set up your development environment according to one of the
 
 build the code and test it::
 
-   python setup.py build_ext --inplace
-   python runtests.py -v
+   python dev.py test -v
 
 and if you ``import`` SciPy from Python, you'll be importing the
 author's modified version of SciPy.

--- a/doc/source/dev/contributor/ubuntu_guide.rst
+++ b/doc/source/dev/contributor/ubuntu_guide.rst
@@ -204,9 +204,23 @@ With conda
 
 #. Initialize git submodules: ``git submodule update --init``.
 
-#. Do an in-place build: enter ``python3 setup.py build_ext --inplace``. |br| This will compile the C, C++, and Fortran code that comes with SciPy. We installed ``python3`` with Anaconda. ``setup.py`` is a script in the root directory of SciPy, which is why you have to be in the SciPy root directory to call it. ``build_ext`` is a command defined in ``setup.py``, and ``--inplace`` is an option we'll use to ensure that the compiling happens in the SciPy directory you already have rather than the default location for Python packages. By building in-place, you avoid having to re-build SciPy before you can test changes to the Python code.
+#. Build SciPy: enter ``python3 dev.py build`` |br|
 
-#. Test the build: enter ``python3 runtests.py -v``. ``runtests.py`` is another script in the SciPy root directory. It runs a suite of tests that make sure SciPy is working as it should, and ``-v`` activates the ``--verbose`` option to show all the test output. If the tests are successful, you now have a working development build of SciPy! You could stop here, but you would only be able to use this development build when the Python working directory is the SciPy root directory.
+    This will compile the C, C++, and Fortran code that comes with SciPy and
+    install it in the directory you already have rather than the default
+    location for Python packages. We installed ``python3`` with Anaconda.
+    ``dev.py`` is a script in the root directory of SciPy which can be used to
+    execute several development tasks (see :ref:`the-dev-py-interface` for
+    details).
+
+#. Test the build: enter ``python3 dev.py test -v``.  
+
+    This command runs a suite of tests that make sure SciPy is working as it
+    should, and ``-v`` activates the ``--verbose`` option to show all the test
+    output. If the tests are successful, you now have a working development
+    build of SciPy!
+    You could stop here, but you would only be able to use this development
+    build when the Python working directory is the SciPy root directory.
 
 #. Enter ``conda develop .``, where ``.`` refers to the present directory. |br| This will allow us to ``import`` the development version of SciPy in Python regardless of Python's working directory.
 

--- a/doc/source/dev/contributor/ubuntu_guide.rst
+++ b/doc/source/dev/contributor/ubuntu_guide.rst
@@ -204,7 +204,7 @@ With conda
 
 #. Initialize git submodules: ``git submodule update --init``.
 
-#. Build SciPy: enter ``python3 dev.py build`` |br|
+#. Build SciPy: enter ``python3 dev.py build``
 
     This will compile the C, C++, and Fortran code that comes with SciPy and
     install it in the directory you already have rather than the default


### PR DESCRIPTION
This PR removes a few mentions of `runtests.py` in the contributor guide.

cc @tupui 