### PR TITLE
DOC: Add link to development workflow

### DIFF
--- a/doc/source/dev/contributor/meson.rst
+++ b/doc/source/dev/contributor/meson.rst
@@ -96,6 +96,7 @@ running the tests should also work, for example::
 The full test suite should pass, without any build warnings on Linux (with GCC
 9 at least) and a moderate amount on the other platforms.
 
+.. _the-dev-py-interface:
 
 The ``dev.py`` interface
 ========================

--- a/doc/source/dev/dev_quickstart.rst
+++ b/doc/source/dev/dev_quickstart.rst
@@ -95,7 +95,9 @@ If you run into a build issue, or need more detailed build documentation
 including building on Windows, see :ref:`building`.
 
 Some of the tests in SciPy are very slow and need to be separately
-enabled. See :ref:`runtests` for details.
+enabled. See :ref:`the-dev-py-interface` for details.
+
+For a complete setup walkthrough, see :ref:`development-workflow`.
 
 Other workflows
 ===============

--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -15,6 +15,7 @@ the organization section.
    conduct/code_of_conduct
    hacking
    dev_quickstart
+   contributor/development_workflow
    contributor/contributor_toc
 
 .. toctree::


### PR DESCRIPTION
Add links to development workflow to the top-level Development table of contents, and to the contributor quickstart guide.

Increases visibility of this page for newcomers, as suggested by participants in the recent SciPy development sprint. 
