### PR TITLE
REL: DOC: update version switcher

### DIFF
--- a/doc/source/_static/version_switcher.json
+++ b/doc/source/_static/version_switcher.json
@@ -1,8 +1,13 @@
 [
     {
-        "name": "1.9.0 (dev)",
+        "name": "dev",
         "version": "dev",
         "url": "https://scipy.github.io/devdocs/"
+    },
+    {
+        "name": "1.9.0 (stable)",
+        "version":"1.9.0",
+        "url": "https://docs.scipy.org/doc/scipy-1.9.0/"
     },
     {
         "name": "1.8.1 (stable)",

--- a/doc/source/_static/version_switcher.json
+++ b/doc/source/_static/version_switcher.json
@@ -10,7 +10,7 @@
         "url": "https://docs.scipy.org/doc/scipy-1.9.0/"
     },
     {
-        "name": "1.8.1 (stable)",
+        "name": "1.8.1",
         "version":"1.8.1",
         "url": "https://docs.scipy.org/doc/scipy-1.8.1/"
     },


### PR DESCRIPTION
Update the version switcher as we released 1.9. This will make the button green instead of red.

I also removed the info about the next version number (NumPy is doing this). This will simplify a bit the next diff.