### PR TITLE
DOC: sparse.linalg: Fix output in an example in the lobpcg docstring.

### DIFF
--- a/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
@@ -258,13 +258,13 @@ def lobpcg(
 
     >>> A = spdiags(vals, 0, n, n)
     >>> A.toarray()
-    array([[  1.,   0.,   0., ...,   0.,   0.,   0.],
-           [  0.,   2.,   0., ...,   0.,   0.,   0.],
-           [  0.,   0.,   3., ...,   0.,   0.,   0.],
+    array([[  1,   0,   0, ...,   0,   0,   0],
+           [  0,   2,   0, ...,   0,   0,   0],
+           [  0,   0,   3, ...,   0,   0,   0],
            ...,
-           [  0.,   0.,   0., ...,  98.,   0.,   0.],
-           [  0.,   0.,   0., ...,   0.,  99.,   0.],
-           [  0.,   0.,   0., ...,   0.,   0., 100.]])
+           [  0,   0,   0, ...,  98,   0,   0],
+           [  0,   0,   0, ...,   0,  99,   0],
+           [  0,   0,   0, ...,   0,   0, 100]])
 
     Initial guess for eigenvectors, should have linearly independent
     columns. The second mandatory input parameter, a 2D array with the


### PR DESCRIPTION
This fixes a failure that I get when I run the refguide check locally.
```
scipy.sparse.linalg
===================

scipy.sparse.linalg.lobpcg
--------------------------

File "build-install/lib/python3.10/site-packages/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py", line 260, in lobpcg
Failed example:
    A.toarray()
Expected:
    array([[  1.,   0.,   0., ...,   0.,   0.,   0.],
           [  0.,   2.,   0., ...,   0.,   0.,   0.],
           [  0.,   0.,   3., ...,   0.,   0.,   0.],
           ...,
           [  0.,   0.,   0., ...,  98.,   0.,   0.],
           [  0.,   0.,   0., ...,   0.,  99.,   0.],
           [  0.,   0.,   0., ...,   0.,   0., 100.]])
Got:
    array([[  1,   0,   0, ...,   0,   0,   0],
           [  0,   2,   0, ...,   0,   0,   0],
           [  0,   0,   3, ...,   0,   0,   0],
           ...,
           [  0,   0,   0, ...,  98,   0,   0],
           [  0,   0,   0, ...,   0,  99,   0],
           [  0,   0,   0, ...,   0,   0, 100]])


ERROR: refguide or doctests have errors
```
(Note that this change does not fix the failure seen recently in https://github.com/scipy/scipy/pull/14563.  @lobpcg has a pull request open that might change the `svds` docstring.)