### PR TITLE
BLD: install missing `.pxd` files, and update TODOs/FIXMEs in meson.build files

### DIFF
--- a/doc/API.rst.txt
+++ b/doc/API.rst.txt
@@ -125,6 +125,8 @@ change is made.
 
 * `scipy.optimize`
 
+  - `scipy.optimize.cython_optimize
+
 * `scipy.signal`
 
   - `scipy.signal.windows`

--- a/meson.build
+++ b/meson.build
@@ -10,7 +10,7 @@ project(
   default_options: [
     'buildtype=debugoptimized',
     'c_std=c99',
-    'cpp_std=c++14',  # TODO: use c++11 if 14 is not available
+    'cpp_std=c++14',
     # TODO: the below -Wno flags are all needed to silence warnings in
     # f2py-generated code. This should be fixed in f2py itself.
     'c_args=-Wno-unused-function -Wno-conversion -Wno-misleading-indentation -Wno-incompatible-pointer-types',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,8 @@ requires = [
 
 [project]
 name = "SciPy"
+# TODO: add `license-files` once PEP 639 is accepted (see meson-python#88)
+#       at that point, no longer include them in `py3.install_sources()`
 license = {file = "LICENSE.txt"}
 description = "Fundamental algorithms for scientific computing in Python"
 maintainers = [

--- a/scipy/_lib/_uarray/meson.build
+++ b/scipy/_lib/_uarray/meson.build
@@ -1,5 +1,3 @@
-# TODO: add_data_files('license')
-
 py3.extension_module('_uarray',
   ['_uarray_dispatch.cxx', 'vectorcall.cxx'],
   cpp_args: ['-Wno-terminate', '-Wno-unused-function'],
@@ -11,6 +9,7 @@ py3.extension_module('_uarray',
 python_sources = [
   '__init__.py',
   '_backend.py',
+  'LICENSE'
 ]
 
 py3.install_sources(

--- a/scipy/_lib/_uarray/meson.build
+++ b/scipy/_lib/_uarray/meson.build
@@ -1,8 +1,5 @@
 # TODO: add_data_files('license')
 
-# TODO: this used -std=c++14 if available, add c++11 otherwise
-#       can we now rely on c++14 unconditionally?
-
 py3.extension_module('_uarray',
   ['_uarray_dispatch.cxx', 'vectorcall.cxx'],
   cpp_args: ['-Wno-terminate', '-Wno-unused-function'],

--- a/scipy/fft/_pocketfft/meson.build
+++ b/scipy/fft/_pocketfft/meson.build
@@ -16,7 +16,6 @@ else
   pocketfft_threads += ['-DPOCKETFFT_NO_MULTITHREADING']
 endif
 
-#TODO: add the equivalent of set_cxx_flags_hook
 py3.extension_module('pypocketfft',
   'pypocketfft.cxx',
   cpp_args: pocketfft_threads,

--- a/scipy/fft/_pocketfft/meson.build
+++ b/scipy/fft/_pocketfft/meson.build
@@ -31,6 +31,7 @@ python_sources = [
   '__init__.py',
   'basic.py',
   'helper.py',
+  'LICENSE.md',
   'realtransforms.py'
 ]
 

--- a/scipy/integrate/meson.build
+++ b/scipy/integrate/meson.build
@@ -189,8 +189,6 @@ py3.extension_module('_test_multivariate',
   subdir: 'scipy/integrate'
 )
 
-# FIXME: something is wrong with the signature file, subroutines are not used
-# _test_odeint_banded
 _test_odeint_banded_module = custom_target('_test_odeint_banded_module',
   output: ['_test_odeint_bandedmodule.c', '_test_odeint_banded-f2pywrappers.f'],
   input: 'tests/banded5x5.pyf',

--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -164,7 +164,6 @@ py3.extension_module('_interpolative',
     '-Wno-tabs', '-Wno-conversion', '-Wno-argument-mismatch',
     '-Wno-unused-dummy-argument', '-Wno-maybe-uninitialized'
   ],
-  # TODO: add -fallow-argument-mismatch for gfortran >= 10, see gh-11842
   include_directories: [inc_np, inc_f2py],
   dependencies: [lapack, fortranobject_dep],
   install: true,

--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -25,8 +25,8 @@ cython_linalg = custom_target('cython_linalg',
   ],
   input: '_generate_pyx.py',
   command: [py3, '@INPUT@', '-o', '@OUTDIR@'],
-  # FIXME - we only want to install the .pxd files! See comments for
-  #         `pxd_files` further down.
+  # TODO - we only want to install the .pxd files! See comments for
+  #        `pxd_files` further down.
   install: true,
   install_dir: py3.get_install_dir() + 'scipy/linalg'
 )

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -167,7 +167,10 @@ generate_version = custom_target(
 python_sources = [
   '__init__.py',
   '_distributor_init.py',
-  'conftest.py'
+  'conftest.py',
+  'linalg.pxd',
+  'optimize.pxd',
+  'special.pxd'
 ]
 
 py3.install_sources(
@@ -187,14 +190,16 @@ _cython_tree = custom_target('_cython_tree',
   output: [
     '__init__.py',
     'linalg.pxd',
+    'optimize.pxd',
     'special.pxd'
   ],
   input: [
     '__init__.py',
     'linalg.pxd',
+    'optimize.pxd',
     'special.pxd'
   ],
-  command: [copier, '@INPUT@', '@OUTDIR@']
+  command: [copier, '@INPUT@', '@OUTDIR@'],
 )
 cython_tree = declare_dependency(sources: _cython_tree)
 

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -151,8 +151,6 @@ generate_config = custom_target(
   install_dir: py3.get_install_dir() + '/scipy'
 )
 
-#FIXME: the git revision is Unknown; script works when invoked directly, but
-#       not when it's run by Ninja. See https://github.com/rgommers/scipy/pull/57
 generate_version = custom_target(
   'generate-version',
   install: true,

--- a/scipy/optimize/_highs/meson.build
+++ b/scipy/optimize/_highs/meson.build
@@ -261,9 +261,6 @@ _highs_wrapper = py3.extension_module('_highs_wrapper',
     '-Wno-format-truncation',
     '-Wno-non-virtual-dtor',
     '-Wno-class-memaccess',
-    # Pass despite __STDC_FORMAT_MACROS redefinition warning.
-    # Remove after merge of https://github.com/ERGO-Code/HiGHS/pull/674
-    '-Wp,-w',
     Wno_unused_but_set,
     highs_define_macros,
     cython_c_args,

--- a/scipy/optimize/cython_optimize/meson.build
+++ b/scipy/optimize/cython_optimize/meson.build
@@ -1,4 +1,5 @@
 # Needed to trick Cython, it won't do a relative import outside a package
+# (see https://github.com/mesonbuild/meson/issues/8961)
 _dummy_init_cyoptimize = custom_target('_dummy_init_cyoptimize',
   output: [
     '__init__.py',
@@ -13,8 +14,6 @@ _dummy_init_cyoptimize = custom_target('_dummy_init_cyoptimize',
   command: [copier, '@INPUT@', '@OUTDIR@']
 )
 
-# FIXME: generated .pyx which has relative cimport in it doesn't work yet (see
-#        https://github.com/mesonbuild/meson/issues/8961)
 _zeros_pyx = custom_target('_zeros_pyx',
   output: '_zeros.pyx',
   input: '_zeros.pyx.in',

--- a/scipy/optimize/meson.build
+++ b/scipy/optimize/meson.build
@@ -307,6 +307,7 @@ py3.install_sources([
   '_tstutils.py',
   '_zeros_py.py',
   'cobyla.py',
+  'cython_optimize.pxd',
   'lbfgsb.py',
   'linesearch.py',
   'minpack.py',

--- a/scipy/stats/_unuran/meson.build
+++ b/scipy/stats/_unuran/meson.build
@@ -164,7 +164,7 @@ unuran_include_dirs = [
   '../../_lib/unuran/unuran/src/tests'
 ]
 
-unuran_version = '16:0:0'  # TODO: grab from configure.ac file
+unuran_version = '16:0:0'  # taken from `_lib/unuran/unuran/configure.ac`
 
 unuran_defines = [
   '-DHAVE_ALARM=1',


### PR DESCRIPTION
The missing `.pxd` files are a pretty serious bug. Somehow no one noticed this, due to a combination of no tests (see gh-16748 for that task) and the nightlies not having been generated for a while until recently. The relevant commit should be backported to `1.9.x`.

There were also a number of open FIXME and TODO comments that were either actionable, already fixed, or no longer relevant. There are no FIXME's left, and the remaining TODO's mostly have to do with 64-bit BLAS/LAPACK support:
```ripgrep
scipy/special/meson.build
1:# TODO: 64-bit BLAS and LAPACK
331:# TODO: this installs all generated files, while we want to install only:
334:#       doesn't accept generated targets. See TODO near the end of

scipy/meson.build
122:# TODO: 64-bit BLAS and LAPACK

scipy/linalg/meson.build
1:# TODO: 64-bit BLAS and LAPACK
28:  # TODO - we only want to install the .pxd files! See comments for
96:# TODO: cblas/clapack are built *only* for ATLAS. Why? Is it still needed?
322:# TODO: install (only) these pxd files. Neither py3.install_sources nor

scipy/interpolate/meson.build
90:# TODO: Add flags for 64 bit ints
120:# TODO: Add flags for 64 bit ints
137:# TODO: Add flags for 64 bit ints

scipy/_lib/meson.build
75:# TODO: the `prefix` here is recommended in

meson.build
14:    # TODO: the below -Wno flags are all needed to silence warnings in
```