### PR TITLE
BLD: make OpenBLAS detection work with CMake

### DIFF
--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -128,8 +128,18 @@ fortranobject_dep = declare_dependency(
 # For MKL and for auto-detecting one of multiple libs, we'll need a custom
 # dependency in Meson (like is done for scalapack) - see
 # https://github.com/mesonbuild/meson/issues/2835
-blas = dependency(get_option('blas'))
-lapack = dependency(get_option('lapack'))
+blas_name = get_option('blas')
+lapack_name = get_option('lapack')
+# pkg-config uses a lower-case name while CMake uses a capitalized name, so try
+# that too to make the fallback detection with CMake work
+if blas_name == 'openblas'
+  blas_name = ['openblas', 'OpenBLAS']
+endif
+if lapack_name == 'openblas'
+  lapack_name = ['openblas', 'OpenBLAS']
+endif
+blas = dependency(blas_name)
+lapack = dependency(lapack_name)
 
 if blas.name() == 'mkl' or lapack.name() == 'mkl' or get_option('use-g77-abi')
   g77_abi_wrappers = files([


### PR DESCRIPTION
This is a fallback detection path, in case pkg-config fails to find `openblas`. CMake is case-sensitive, so we need to try the camelcase version of the name.

If CMake is installed and it finds OpenBLAS, the result looks like:
```
Determining dependency 'OpenBLAS' with pkg-config executable '/home/rgommers/anaconda3/envs/scipy-dev/bin/pkg-config'
env[PKG_CONFIG_PATH]:
Called `/home/rgommers/anaconda3/envs/scipy-dev/bin/pkg-config --modversion OpenBLAS` -> 1

CMake binary for 1 is cached.

Determining dependency 'OpenBLAS' with CMake executable '/home/rgommers/anaconda3/envs/scipy-dev/bin/cmake'
Try CMake generator: auto
Calling CMake (['/home/rgommers/anaconda3/envs/scipy-dev/bin/cmake']) in /home/rgommers/code/scipy/build/meson-private/cmake_OpenBLAS with:
  - "-DNAME=OpenBLAS"
  - "-DARCHS=libpyldb-util.cpython-310-x86-64-linux-gnu.so;libpyldb-util.cpython-310-x86-64-linux-gnu.so.2;libpyldb-util.cpython-310-x86-64-linux-gnu.so.2.5.0;libpytalloc-util.cpython-310-x86-64-linux-gnu.so;libpytalloc-util.cpython-310-x86-64-linux-gnu.so.2;libpytalloc-util.cpython-310-x86-64-linux-gnu.so.2.3.3;libsamba-policy.cpython-310-x86-64-linux-gnu.so;libsamba-policy.cpython-310-x86-64-linux-gnu.so.0;libsamba-policy.cpython-310-x86-64-linux-gnu.so.0.0.1"
  - "-DVERSION="
  - "-DCOMPS="
  - "--trace-expand"
  - "--trace-format=json-v1"
  - "--no-warn-unused-cli"
  - "--trace-redirect=cmake_trace.txt"
  - "-DCMAKE_TOOLCHAIN_FILE=/home/rgommers/code/scipy/build/meson-private/cmake_OpenBLAS/CMakeMesonToolchainFile.cmake"
  - "."
  - "-DCMAKE_PREFIX_PATH=/home/rgommers/anaconda3/envs/scipy-dev;/home/rgommers/anaconda3/envs/scipy-dev/x86_64-conda-linux-gnu/sysroot/usr"
using old-style CMake variables for dependency OpenBLAS
Include Dirs:         ['/home/rgommers/anaconda3/envs/scipy-dev/include']
Compiler Definitions: []
Libraries:            ['/home/rgommers/anaconda3/envs/scipy-dev/lib/libopenblas.so']
Run-time dependency openblas found: YES 0.3.20
```

This follows up on comments in gh-16308. Given that folks are running into a few issues with the changed BLAS/LAPACK detection in 1.9.0, we should backport this I think.