### PR TITLE
DOC: Integrate: Add improper integral examples for `dblquad` and `tplquad`

### DIFF
--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -838,8 +838,8 @@ def tplquad(func, a, b, gfun, hfun, qfun, rfun, args=(), epsabs=1.49e-8,
 
     Compute the three-dimensional Gaussian Integral, which is the integral of
     the Gaussian function :math:`f(x,y,z) = e^{-(x^{2} + y^{2} + z^{2})}`, over
-    :math:`(-\\infty,\\infty)`. That is, compute the integral
-    :math:`\\iiint^{\\infty}_{-\\infty} e^{-(x^{2} + y^{2} + z^{2})} \\,dz\\,dy
+    :math:`(-\\infty,+\\infty)`. That is, compute the integral
+    :math:`\\iiint^{+\\infty}_{-\\infty} e^{-(x^{2} + y^{2} + z^{2})} \\,dz\\,dy
     \\,dx`:
 
     >>> import numpy as np

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -700,6 +700,17 @@ def dblquad(func, a, b, gfun, hfun, args=(), epsabs=1.49e-8, epsrel=1.49e-8):
     >>> integrate.dblquad(f, 0, 1, lambda x: x, lambda x: 2-x, args=(3,))
         (0.9999999999999999, 1.6653345369377348e-14)
 
+    Compute the two-dimensional Gaussian Integral, which is the integral of the
+    Gaussian function :math:`f(x,y) = e^{-(x^{2} + y^{2})}`, over
+    :math:`(-\\infty,\\infty)`. That is, compute the integral
+    :math:`\\iint^{\\infty}_{-\\infty} e^{-(x^{2} + y^{2})} \\,dy\\,dx`:
+
+    >>> import numpy as np
+    >>> from scipy import integrate
+    >>> f = lambda x, y: np.exp(-(x ** 2 + y ** 2))
+    >>> integrate.dblquad(f, -np.inf, np.inf, -np.inf, np.inf)
+        (3.141592653589777, 2.5173086737433208e-08)
+
     """
 
     def temp_ranges(*args):

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -702,8 +702,8 @@ def dblquad(func, a, b, gfun, hfun, args=(), epsabs=1.49e-8, epsrel=1.49e-8):
 
     Compute the two-dimensional Gaussian Integral, which is the integral of the
     Gaussian function :math:`f(x,y) = e^{-(x^{2} + y^{2})}`, over
-    :math:`(-\\infty,\\infty)`. That is, compute the integral
-    :math:`\\iint^{\\infty}_{-\\infty} e^{-(x^{2} + y^{2})} \\,dy\\,dx`:
+    :math:`(-\\infty,+\\infty)`. That is, compute the integral
+    :math:`\\iint^{+\\infty}_{-\\infty} e^{-(x^{2} + y^{2})} \\,dy\\,dx`:
 
     >>> import numpy as np
     >>> f = lambda x, y: np.exp(-(x ** 2 + y ** 2))

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -843,7 +843,6 @@ def tplquad(func, a, b, gfun, hfun, qfun, rfun, args=(), epsabs=1.49e-8,
     \\,dx`:
 
     >>> import numpy as np
-    >>> from scipy import integrate
     >>> f = lambda x, y, z: np.exp(-(x ** 2 + y ** 2 + z ** 2))
     >>> integrate.tplquad(f, -np.inf, np.inf, -np.inf, np.inf, -np.inf, np.inf)
         (5.568327996830833, 4.4619078828029765e-08)

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -837,6 +837,18 @@ def tplquad(func, a, b, gfun, hfun, qfun, rfun, args=(), epsabs=1.49e-8,
     >>> integrate.tplquad(f, 0, 1, 0, 1, 0, 1, args=(3,))
         (0.375, 1.6581101126856635e-14)
 
+    Compute the three-dimensional Gaussian Integral, which is the integral of
+    the Gaussian function :math:`f(x,y,z) = e^{-(x^{2} + y^{2} + z^{2})}`, over
+    :math:`(-\\infty,\\infty)`. That is, compute the integral
+    :math:`\\iiint^{\\infty}_{-\\infty} e^{-(x^{2} + y^{2} + z^{2})} \\,dz\\,dy
+    \\,dx`:
+
+    >>> import numpy as np
+    >>> from scipy import integrate
+    >>> f = lambda x, y, z: np.exp(-(x ** 2 + y ** 2 + z ** 2))
+    >>> integrate.tplquad(f, -np.inf, np.inf, -np.inf, np.inf, -np.inf, np.inf)
+        (5.568327996830833, 4.4619078828029765e-08)
+
     """
     # f(z, y, x)
     # qfun/rfun(x, y)

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -706,7 +706,6 @@ def dblquad(func, a, b, gfun, hfun, args=(), epsabs=1.49e-8, epsrel=1.49e-8):
     :math:`\\iint^{\\infty}_{-\\infty} e^{-(x^{2} + y^{2})} \\,dy\\,dx`:
 
     >>> import numpy as np
-    >>> from scipy import integrate
     >>> f = lambda x, y: np.exp(-(x ** 2 + y ** 2))
     >>> integrate.dblquad(f, -np.inf, np.inf, -np.inf, np.inf)
         (3.141592653589777, 2.5173086737433208e-08)

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -813,6 +813,7 @@ def tplquad(func, a, b, gfun, hfun, qfun, rfun, args=(), epsabs=1.49e-8,
     That is, :math:`\\int^{x=2}_{x=1} \\int^{y=3}_{y=2} \\int^{z=1}_{z=0} x y z
     \\,dz \\,dy \\,dx`.
 
+    >>> import numpy as np
     >>> from scipy import integrate
     >>> f = lambda z, y, x: x*y*z
     >>> integrate.tplquad(f, 1, 2, 2, 3, 0, 1)
@@ -842,7 +843,6 @@ def tplquad(func, a, b, gfun, hfun, qfun, rfun, args=(), epsabs=1.49e-8,
     :math:`\\iiint^{+\\infty}_{-\\infty} e^{-(x^{2} + y^{2} + z^{2})} \\,dz
     \\,dy\\,dx`.
 
-    >>> import numpy as np
     >>> f = lambda x, y, z: np.exp(-(x ** 2 + y ** 2 + z ** 2))
     >>> integrate.tplquad(f, -np.inf, np.inf, -np.inf, np.inf, -np.inf, np.inf)
         (5.568327996830833, 4.4619078828029765e-08)

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -839,8 +839,8 @@ def tplquad(func, a, b, gfun, hfun, qfun, rfun, args=(), epsabs=1.49e-8,
     Compute the three-dimensional Gaussian Integral, which is the integral of
     the Gaussian function :math:`f(x,y,z) = e^{-(x^{2} + y^{2} + z^{2})}`, over
     :math:`(-\\infty,+\\infty)`. That is, compute the integral
-    :math:`\\iiint^{+\\infty}_{-\\infty} e^{-(x^{2} + y^{2} + z^{2})} \\,dz\\,dy
-    \\,dx`:
+    :math:`\\iiint^{+\\infty}_{-\\infty} e^{-(x^{2} + y^{2} + z^{2})} \\,dz
+    \\,dy\\,dx`:
 
     >>> import numpy as np
     >>> f = lambda x, y, z: np.exp(-(x ** 2 + y ** 2 + z ** 2))

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -679,6 +679,7 @@ def dblquad(func, a, b, gfun, hfun, args=(), epsabs=1.49e-8, epsrel=1.49e-8):
     ``x`` ranging from 0 to 2 and ``y`` ranging from 0 to 1.
     That is, :math:`\\int^{x=2}_{x=0} \\int^{y=1}_{y=0} x y^2 \\,dy \\,dx`.
 
+    >>> import numpy as np
     >>> from scipy import integrate
     >>> f = lambda y, x: x*y**2
     >>> integrate.dblquad(f, 0, 2, 0, 1)
@@ -703,9 +704,8 @@ def dblquad(func, a, b, gfun, hfun, args=(), epsabs=1.49e-8, epsrel=1.49e-8):
     Compute the two-dimensional Gaussian Integral, which is the integral of the
     Gaussian function :math:`f(x,y) = e^{-(x^{2} + y^{2})}`, over
     :math:`(-\\infty,+\\infty)`. That is, compute the integral
-    :math:`\\iint^{+\\infty}_{-\\infty} e^{-(x^{2} + y^{2})} \\,dy\\,dx`:
+    :math:`\\iint^{+\\infty}_{-\\infty} e^{-(x^{2} + y^{2})} \\,dy\\,dx`.
 
-    >>> import numpy as np
     >>> f = lambda x, y: np.exp(-(x ** 2 + y ** 2))
     >>> integrate.dblquad(f, -np.inf, np.inf, -np.inf, np.inf)
         (3.141592653589777, 2.5173086737433208e-08)
@@ -840,7 +840,7 @@ def tplquad(func, a, b, gfun, hfun, qfun, rfun, args=(), epsabs=1.49e-8,
     the Gaussian function :math:`f(x,y,z) = e^{-(x^{2} + y^{2} + z^{2})}`, over
     :math:`(-\\infty,+\\infty)`. That is, compute the integral
     :math:`\\iiint^{+\\infty}_{-\\infty} e^{-(x^{2} + y^{2} + z^{2})} \\,dz
-    \\,dy\\,dx`:
+    \\,dy\\,dx`.
 
     >>> import numpy as np
     >>> f = lambda x, y, z: np.exp(-(x ** 2 + y ** 2 + z ** 2))


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #15792.

#### What does this implement/fix?
<!--Please explain your changes.-->
Adds clarification and code examples to the documentation covering the usage of `dblquad` and `tplquad` for computing improper integrals. 

#### Additional information
<!--Any additional information you think is important.-->
The examples define the function provided to `dblquad` and `tplquad` as the [Gaussian Integral](https://mathworld.wolfram.com/GaussianIntegral.html) since it is convergent over (-∞, +∞). It can trivially be extended for multiple variables.
