### PR TITLE
TST: sparse.linalg: Loosen tolerance for the lobpcg test 'test_tolerance_float32'

### DIFF
--- a/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
@@ -352,7 +352,7 @@ def test_tolerance_float32():
     X = rnd.standard_normal((n, m))
     X = X.astype(np.float32)
     eigvals, _ = lobpcg(A, X, tol=1.25e-5, maxiter=50, verbosityLevel=0)
-    assert_allclose(eigvals, -np.arange(1, 1 + m), atol=1.5e-5)
+    assert_allclose(eigvals, -np.arange(1, 1 + m), atol=2e-5, rtol=1e-5)
 
 
 def test_random_initial_float32():


### PR DESCRIPTION
This test has been failing occasionally in CI, with errors slightly greater than
the requested tolerances.

For example, in both https://github.com/scipy/scipy/pull/16754 and https://github.com/scipy/scipy/pull/16680, the failure report is

```
____________________________ test_tolerance_float32 ____________________________
[gw0] linux -- Python 3.9.13 /opt/hostedtoolcache/Python/3.9.13/x64/bin/python
/opt/hostedtoolcache/Python/3.9.13/x64/lib/python3.9/site-packages/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py:355: in test_tolerance_float32
    assert_allclose(eigvals, -np.arange(1, 1 + m), atol=1.5e-5)
E   AssertionError: 
E   Not equal to tolerance rtol=1e-07, atol=1.5e-05
E   
E   Mismatched elements: 1 / 3 (33.3%)
E   Max absolute difference: 1.62124634e-05
E   Max relative difference: 5.40415446e-06
E    x: array([-1.      , -1.999997, -3.000016], dtype=float32)
E    y: array([-1, -2, -3])
```

The tolerances have been bumped before, in https://github.com/scipy/scipy/pull/15271.  I think we're still working out just how accurate we can expect the function to be when the inputs are `float32`.