### PR TITLE
BLD: use a bit more idiomatic approach to constructing paths in meson

### DIFF
--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -28,7 +28,7 @@ cython_linalg = custom_target('cython_linalg',
   # TODO - we only want to install the .pxd files! See comments for
   #        `pxd_files` further down.
   install: true,
-  install_dir: py3.get_install_dir() + 'scipy/linalg'
+  install_dir: py3.get_install_dir() / 'scipy/linalg'
 )
 
 # pyx -> c, pyx -> cpp generators, depending on __init__.py here.
@@ -324,7 +324,7 @@ py3.install_sources(
 #       https://mesonbuild.com/Installing.html says is for build targets to
 #       use:
 #         `custom_target(..., install: true, install_dir: ...)
-#         # should use `py3.get_install_dir() + 'scipy/linalg'` ?
+#         # should use `py3.get_install_dir() / 'scipy/linalg'` ?
 #       see https://github.com/mesonbuild/meson/issues/3206
 #
 #       For the below code to work, the script generating the files should use
@@ -342,7 +342,7 @@ py3.install_sources(
 #  output : ['cython_blas2.pxd', 'cython_lapack2.pxd'],
 #  command : ['cp', '@INPUT0@', '@OUTPUT0@', '&&', 'cp', '@INPUT1@', '@OUTPUT1@'],
 #  install : true,
-#  install_dir: py3.get_install_dir() + 'scipy/linalg'
+#  install_dir: py3.get_install_dir() / 'scipy/linalg'
 #)
 
 subdir('tests')

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -158,7 +158,7 @@ generate_config = custom_target(
   output: '__config__.py',
   input: '../tools/config_utils.py',
   command: [py3, '@INPUT@', '@OUTPUT@'],
-  install_dir: py3.get_install_dir() + '/scipy'
+  install_dir: py3.get_install_dir() / 'scipy'
 )
 
 generate_version = custom_target(
@@ -169,7 +169,7 @@ generate_version = custom_target(
   output: 'version.py',
   input: '../tools/version_utils.py',
   command: [py3, '@INPUT@', '--source-root', '@SOURCE_ROOT@'],
-  install_dir: py3.get_install_dir() + '/scipy'
+  install_dir: py3.get_install_dir() / 'scipy'
 )
 
 python_sources = [

--- a/scipy/special/meson.build
+++ b/scipy/special/meson.build
@@ -347,7 +347,7 @@ cython_special = custom_target('cython_special',
   input: ['_generate_pyx.py', 'functions.json', '_add_newdocs.py'],
   command: [py3, '@INPUT0@', '-o', '@OUTDIR@'],
   install: true,
-  install_dir: py3.get_install_dir() + '/scipy/special'
+  install_dir: py3.get_install_dir() / 'scipy/special'
 )
 
 # pyx -> c, pyx -> cpp generators, depending on copied pxi, pxd files.
@@ -492,7 +492,7 @@ foreach npz_file: npz_files
       '--use-timestamp', npz_file[2], '-o', '@OUTDIR@'
     ],
     install: true,
-    install_dir: py3.get_install_dir() + '/scipy/special/tests/data'
+    install_dir: py3.get_install_dir() / 'scipy/special/tests/data'
   )
 endforeach
 


### PR DESCRIPTION
Instead of string concatenation, use Meson's path operator, which was designed based on the same concept as pathlib.Path and uses the / operator overload (but effectively using .as_posix() for consistency). This guarantees consistent handling, and also avoids e.g. introspection files containing duplicated path separators such as `.../site-packages//scipy/...`

This is also required in order for Meson to internally track when an install_dir string comes from py3.get_install_dir() after path-based joining semantics, which is needed for improvements to the mesonpy build backend.


/cc @rgommers