### PR TITLE
MAINT: stats: mark slow tests

### DIFF
--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -35,10 +35,9 @@ not for numerically exact results.
 DECIMAL = 5  # specify the precision of the tests  # increased from 0 to 5
 
 # For skipping test_cont_basic
-# distslow are sorted by speed (very slow to slow)
 distslow = ['recipinvgauss', 'vonmises', 'kappa4', 'vonmises_line',
             'gausshyper', 'norminvgauss', 'geninvgauss', 'genhyperbolic',
-            'truncnorm']
+            'truncnorm', 'skewnorm', 'truncweibull_min']
 
 # distxslow are sorted by speed (very slow to slow)
 distxslow = ['studentized_range', 'kstwo', 'ksone', 'wrapcauchy', 'genexpon']
@@ -857,7 +856,7 @@ def test_kappa3_array_gh13582():
     npt.assert_allclose(res, res2)
 
 
-@pytest.mark.timeout(120)
+@pytest.mark.xslow
 def test_kappa4_array_gh13582():
     h = np.array([-0.5, 2.5, 3.5, 4.5, -3])
     k = np.array([-0.5, 1, -1.5, 0, 3.5])

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -4223,6 +4223,7 @@ class TestFitMethod:
         assert_raises(ValueError, stats.uniform.fit, x, floc=2.0)
         assert_raises(ValueError, stats.uniform.fit, x, fscale=5.0)
 
+    @pytest.mark.slow
     @pytest.mark.parametrize("method", ["MLE", "MM"])
     def test_fshapes(self, method):
         # take a beta distribution, with shapes='a, b', and make sure that

--- a/scipy/stats/tests/test_fit.py
+++ b/scipy/stats/tests/test_fit.py
@@ -176,9 +176,9 @@ def test_nnlf_and_related_methods(dist, params):
 
 
 def cases_test_fit():
-    # These three fail default test; check separately
-    skip_basic_fit = {'argus', 'foldnorm', 'truncpareto', 'truncweibull_min'}
-    # status of 'studentized_range', 'ksone', 'kstwo' unknown; all others pass
+    # These fail default test or hang
+    skip_basic_fit = {'argus', 'foldnorm', 'truncpareto', 'truncweibull_min',
+                      'ksone', 'levy_stable', 'studentized_range', 'kstwo'}
     slow_basic_fit = {'burr12', 'johnsonsb', 'bradford', 'fisk', 'mielke',
                       'exponpow', 'rdist', 'norminvgauss', 'betaprime',
                       'powerlaw', 'pareto', 'johnsonsu', 'loglaplace',
@@ -189,8 +189,7 @@ def cases_test_fit():
                       'kstwobign', 'gompertz', 'dweibull', 'lomax', 'invgauss',
                       'recipinvgauss', 'chi', 'foldcauchy', 'powernorm',
                       'gennorm', 'skewnorm', 'randint', 'genextreme'}
-    xslow_basic_fit = {'studentized_range', 'ksone', 'kstwo', 'levy_stable',
-                       'nchypergeom_fisher', 'nchypergeom_wallenius',
+    xslow_basic_fit = {'nchypergeom_fisher', 'nchypergeom_wallenius',
                        'gausshyper', 'genexpon', 'gengamma', 'genhyperbolic',
                        'geninvgauss', 'tukeylambda', 'skellam', 'ncx2',
                        'hypergeom', 'nhypergeom', 'zipfian', 'ncf',
@@ -215,7 +214,8 @@ def cases_test_fit():
 
 def cases_test_fitstart():
     for distname, shapes in dict(distcont).items():
-        if not isinstance(distname, str) or distname in {'studentized_range'}:
+        if (not isinstance(distname, str) or
+                distname in {'studentized_range', 'recipinvgauss'}):  # slow
             continue
         yield distname, shapes
 


### PR DESCRIPTION
#### What does this implement/fix?
Just a routine check of slow tests. `test_kappa4_array_gh13582`, in particular, caught my eye. I think it's safe to mark that as xslow, even though it won't be run regularly. It's taking more than a minute on some CI platforms.

<details>
Here are some of the slowest tests before this PR.

```
16.17s call     scipy/stats/tests/test_continuous_basic.py::test_kappa4_array_gh13582
12.12s call     scipy/stats/tests/test_continuous_basic.py::test_cont_basic[500-200-skewnorm-arg91]
4.16s call     scipy/stats/tests/test_continuous_basic.py::test_cont_basic[500-200-truncweibull_min-arg100]
2.12s call     scipy/stats/tests/test_continuous_basic.py::test_cont_basic[500-200-ncx2-arg76]
1.97s call     scipy/stats/tests/test_continuous_basic.py::test_cont_basic[500-200-gengamma-arg31]
1.86s call     scipy/stats/tests/test_continuous_basic.py::test_cont_basic[500-200-beta-arg4]
1.74s call     scipy/stats/tests/test_fit.py::test_fitstart[recipinvgauss-shapes83]
1.63s call     scipy/stats/tests/test_continuous_basic.py::test_cont_basic[500-200-gengamma-arg30]
1.61s call     scipy/stats/tests/test_distributions.py::TestFitMethod::test_fshapes[MM]
1.17s call     scipy/stats/tests/test_resampling.py::test_bootstrap_against_itself_1samp[BCa-1784]
1.12s call     scipy/stats/tests/test_fit.py::TestFit::test_basic_fit[vonmises]
1.05s call     scipy/stats/tests/test_continuous_basic.py::test_kappa3_array_gh13582
1.01s call     scipy/stats/tests/test_continuous_basic.py::test_cont_basic[500-200-crystalball-arg13]
```

</details>

