### PR TITLE
DOC: stats.skew/kurtosis: returns NaN when input has only one unique value

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -9415,6 +9415,8 @@ class rv_histogram(rv_continuous):
         but warns if the bin widths are variable. Set `density` explicitly
         to silence the warning.
 
+        .. versionadded:: 1.10.0
+
     Notes
     -----
     When a histogram has unequal bin widths, there is a distinction between

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -1313,8 +1313,8 @@ def skew(a, axis=0, bias=True, nan_policy='propagate'):
     Returns
     -------
     skewness : ndarray
-        The skewness of values along an axis, returning 0 where all values are
-        equal.
+        The skewness of values along an axis, returning NaN where all values
+        are equal.
 
     Notes
     -----
@@ -1422,8 +1422,8 @@ def kurtosis(a, axis=0, fisher=True, bias=True, nan_policy='propagate'):
     Returns
     -------
     kurtosis : array
-        The kurtosis of values along an axis. If all values are equal,
-        return -3 for Fisher's definition and 0 for Pearson's definition.
+        The kurtosis of values along an axis, returning NaN where all values
+        are equal.
 
     References
     ----------


### PR DESCRIPTION
#### Reference issue
Closes gh-16765

#### What does this implement/fix?
gh-16765 reported that the documentation of `skew` states that 0 is returned when the input has only one unique value. This is inaccurate as of 1.9.0; it returns NaN. `kurtosis` does the same.

This also takes the opportunity to add a `versionadded` label to the new `density` parameter of `rv_histogram`. Totally unrelated, but also a very small change. Figured I should make the most of the CI run.