### PR TITLE
BUG: Set nperseg size to the size of an already-initialized window on periodogram

### DIFF
--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -276,12 +276,13 @@ def periodogram(x, fs=1.0, window='boxcar', nperseg=None, nfft=None,
     if nperseg is None:
         if hasattr(window, 'shape'):
             nperseg = window.shape[0]
-        elif nfft == x.shape[axis]:
-            nperseg = nfft
-        elif nfft > x.shape[axis]:
-            nperseg = x.shape[axis]
-        elif nfft < x.shape[axis]:
-            nperseg = nfft
+        elif nfft is not None:
+            if nfft == x.shape[axis]:
+                nperseg = nfft
+            elif nfft > x.shape[axis]:
+                nperseg = x.shape[axis]
+            elif nfft < x.shape[axis]:
+                nperseg = nfft
 
     if nfft is None:
         nfft = x.shape[axis]

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -269,8 +269,11 @@ def periodogram(x, fs=1.0, window='boxcar', nfft=None, detrend='constant',
         window = 'boxcar'
 
     if nfft is None:
-        nperseg = x.shape[axis]
-    elif nfft == x.shape[axis]:
+        nfft = x.shape[axis]
+        if hasattr(window, 'shape'):
+            nfft = window.shape[0]
+
+    if nfft == x.shape[axis]:
         nperseg = nfft
     elif nfft > x.shape[axis]:
         nperseg = x.shape[axis]

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -153,8 +153,9 @@ def lombscargle(x,
     return pgram
 
 
-def periodogram(x, fs=1.0, window='boxcar', nfft=None, detrend='constant',
-                return_onesided=True, scaling='density', axis=-1):
+def periodogram(x, fs=1.0, window='boxcar', nperseg=None, nfft=None,
+                detrend='constant', return_onesided=True,
+                scaling='density', axis=-1):
     """
     Estimate power spectral density using a periodogram.
 
@@ -171,6 +172,10 @@ def periodogram(x, fs=1.0, window='boxcar', nfft=None, detrend='constant',
         required parameters. If `window` is array_like it will be used
         directly as the window and its length must be nperseg. Defaults
         to 'boxcar'.
+    nperseg : int, optional
+        Length of each segment. Defaults to None, but if window is str or
+        tuple, is set to 256, and if window is array_like, is set to the
+        length of the window.
     nfft : int, optional
         Length of the FFT used. If `None` the length of `x` will be
         used.
@@ -268,20 +273,22 @@ def periodogram(x, fs=1.0, window='boxcar', nfft=None, detrend='constant',
     if window is None:
         window = 'boxcar'
 
+    if nperseg is None:
+        if hasattr(window, 'shape'):
+            nperseg = window.shape[0]
+        elif nfft == x.shape[axis]:
+            nperseg = nfft
+        elif nfft > x.shape[axis]:
+            nperseg = x.shape[axis]
+        elif nfft < x.shape[axis]:
+            nperseg = nfft
+
     if nfft is None:
         nfft = x.shape[axis]
-        if hasattr(window, 'shape'):
-            nfft = window.shape[0]
-
-    if nfft == x.shape[axis]:
-        nperseg = nfft
-    elif nfft > x.shape[axis]:
-        nperseg = x.shape[axis]
     elif nfft < x.shape[axis]:
         s = [np.s_[:]]*len(x.shape)
         s[axis] = np.s_[:nfft]
         x = x[tuple(s)]
-        nperseg = nfft
         nfft = None
 
     return welch(x, fs=fs, window=window, nperseg=nperseg, noverlap=0,

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -153,9 +153,8 @@ def lombscargle(x,
     return pgram
 
 
-def periodogram(x, fs=1.0, window='boxcar', nfft=None,
-                detrend='constant', return_onesided=True,
-                scaling='density', axis=-1):
+def periodogram(x, fs=1.0, window='boxcar', nfft=None, detrend='constant',
+                return_onesided=True, scaling='density', axis=-1):
     """
     Estimate power spectral density using a periodogram.
 
@@ -269,12 +268,6 @@ def periodogram(x, fs=1.0, window='boxcar', nfft=None,
 
     if window is None:
         window = 'boxcar'
-    elif hasattr(window, 'size'):
-        axis_size = x.shape[axis]
-        window_size = window.size
-        if window_size != axis_size:
-            raise ValueError('the size of the window must be the same size '
-                             'of the input on the specified axis')
 
     if nfft is None:
         nperseg = x.shape[axis]
@@ -288,6 +281,11 @@ def periodogram(x, fs=1.0, window='boxcar', nfft=None,
         x = x[tuple(s)]
         nperseg = nfft
         nfft = None
+
+    if hasattr(window, 'size'):
+        if window.size != nperseg:
+            raise ValueError('the size of the window must be the same size '
+                             'of the input on the specified axis')
 
     return welch(x, fs=fs, window=window, nperseg=nperseg, noverlap=0,
                  nfft=nfft, detrend=detrend, return_onesided=return_onesided,

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -215,6 +215,15 @@ class TestPeriodogram:
         assert_allclose(p, q)
         assert_(p.dtype == q.dtype)
 
+    def test_shorter_window_error(self):
+        x = np.zeros(16)
+        x[0] = 1
+        win = signal.get_window('hann', 10)
+        expected_msg = ('the size of the window must be the same size '
+                        'of the input on the specified axis')
+        with assert_raises(ValueError, match=expected_msg):
+            periodogram(x, window=win)
+
 
 class TestWelch:
     def test_real_onesided_even(self):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Fixes #14809

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR makes sure that any window (array-like) that is passed as parameter to `periodogram` that has a length less than the input signal is used as-it-is instead of raising error. By doing so, the periodogram analysis is truncated to the size of the window

#### Additional information
<!--Any additional information you think is important.-->
