### PR TITLE
BUG: interpolate: sanity check x and y in make_interp_spline(x, y, k=0) and k=1

### DIFF
--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -1243,9 +1243,17 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
 
     y = np.moveaxis(y, axis, 0)    # now internally interp axis is zero
 
+    # sanity check the input
     if bc_type == 'periodic' and not np.allclose(y[0], y[-1], atol=1e-15):
         raise ValueError("First and last points does not match while "
                          "periodic case expected")
+    if x.size != y.shape[0]:
+        raise ValueError('Shapes of x {} and y {} are incompatible'
+                         .format(x.shape, y.shape))
+    if np.any(x[1:] == x[:-1]):
+        raise ValueError("Expect x to not have duplicates")
+    if x.ndim != 1 or np.any(x[1:] < x[:-1]):
+        raise ValueError("Expect x to be a 1D strictly increasing sequence.")
 
     # special-case k=0 right away
     if k == 0:
@@ -1291,17 +1299,10 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
 
     t = _as_float_array(t, check_finite)
 
-    if x.ndim != 1 or np.any(x[1:] < x[:-1]):
-        raise ValueError("Expect x to be a 1-D sorted array_like.")
-    if np.any(x[1:] == x[:-1]):
-        raise ValueError("Expect x to not have duplicates")
     if k < 0:
         raise ValueError("Expect non-negative k.")
     if t.ndim != 1 or np.any(t[1:] < t[:-1]):
         raise ValueError("Expect t to be a 1-D sorted array_like.")
-    if x.size != y.shape[0]:
-        raise ValueError('Shapes of x {} and y {} are incompatible'
-                         .format(x.shape, y.shape))
     if t.size < x.size + k + 1:
         raise ValueError('Got %d knots, need at least %d.' %
                          (t.size, x.size + k + 1))

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -946,23 +946,23 @@ class TestInterp:
     def test_incompatible_x_y(self, k):
         x = [0, 1, 2, 3, 4, 5]
         y = [0, 1, 2, 3, 4, 5, 6, 7]
-        with assert_raises(ValueError):
+        with assert_raises(ValueError, match="Shapes of x"):
             make_interp_spline(x, y, k=k)
 
     @pytest.mark.parametrize('k', [0, 1, 2, 3])
     def test_broken_x(self, k):
         x = [0, 1, 1, 2, 3, 4]      # duplicates
         y = [0, 1, 2, 3, 4, 5]
-        with assert_raises(ValueError):
+        with assert_raises(ValueError, match="Expect x to not have duplicates"):
             make_interp_spline(x, y, k=k)
 
         x = [0, 2, 1, 3, 4, 5]      # unsorted
-        with assert_raises(ValueError):
+        with assert_raises(ValueError, match="Expect x to be a 1D strictly"):
             make_interp_spline(x, y, k=k)
 
         x = [0, 1, 2, 3, 4, 5]
         x = np.asarray(x).reshape((1, -1))     # 1D
-        with assert_raises(ValueError):
+        with assert_raises(ValueError, match="Expect x to be a 1D strictly"):
             make_interp_spline(x, y, k=k)
 
     def test_not_a_knot(self):

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -942,6 +942,29 @@ class TestInterp:
         b = make_interp_spline(self.xx, self.yy, k=1, axis=-1)
         assert_allclose(b(self.xx), self.yy, atol=1e-14, rtol=1e-14)
 
+    @pytest.mark.parametrize('k', [0, 1, 2, 3])
+    def test_incompatible_x_y(self, k):
+        x = [0, 1, 2, 3, 4, 5]
+        y = [0, 1, 2, 3, 4, 5, 6, 7]
+        with assert_raises(ValueError):
+            make_interp_spline(x, y, k=k)
+
+    @pytest.mark.parametrize('k', [0, 1, 2, 3])
+    def test_broken_x(self, k):
+        x = [0, 1, 1, 2, 3, 4]      # duplicates
+        y = [0, 1, 2, 3, 4, 5]
+        with assert_raises(ValueError):
+            make_interp_spline(x, y, k=k)
+
+        x = [0, 2, 1, 3, 4, 5]      # unsorted
+        with assert_raises(ValueError):
+            make_interp_spline(x, y, k=k)
+
+        x = [0, 1, 2, 3, 4, 5]
+        x = np.asarray(x).reshape((1, -1))     # 1D
+        with assert_raises(ValueError):
+            make_interp_spline(x, y, k=k)
+
     def test_not_a_knot(self):
         for k in [3, 5]:
             b = make_interp_spline(self.xx, self.yy, k)

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -953,7 +953,7 @@ class TestInterp:
     def test_broken_x(self, k):
         x = [0, 1, 1, 2, 3, 4]      # duplicates
         y = [0, 1, 2, 3, 4, 5]
-        with assert_raises(ValueError, match="Expect x to not have duplicates"):
+        with assert_raises(ValueError, match="x to not have duplicates"):
             make_interp_spline(x, y, k=k)
 
         x = [0, 2, 1, 3, 4, 5]      # unsorted


### PR DESCRIPTION
#### What does this implement/fix?
<!--Please explain your changes.-->

`make_interp_spline` short-circuits for k=0 and k=1 (piecewise constant and linear interpolation). And it does it *before* sanity checking the input arrays. This allows passing in e.g. x and y arrays of inconsistent lengths---which k>=2 modes do not allow.

Thus move the sanity checks to be earlier and add tests to assert consistent behavior of .interpolators of various degrees.

#### Additional information
<!--Any additional information you think is important.-->

The fact that this was not caught for years hints at how often this is used :-). However this was masking a separate issue in gh-16508 (which proves to be surprisingly effective in smoking out obscure problems :-)), so it makes sense to fix it separately. 