### PR TITLE
ENH: default `cond` parameter of `linalg.lstsq`

### DIFF
--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1037,7 +1037,8 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
     cond : float, optional
         Cutoff for 'small' singular values; used to determine effective
         rank of a. Singular values smaller than
-        ``cond * largest_singular_value`` are considered zero.
+        ``cond * largest_singular_value`` are considered zero. Default is 
+        machine precision times `max(M, N)`.
     overwrite_a : bool, optional
         Discard data in `a` (may enhance performance). Default is False.
     overwrite_b : bool, optional
@@ -1177,7 +1178,7 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
     overwrite_b = overwrite_b or _datacopied(b1, b)
 
     if cond is None:
-        cond = np.finfo(lapack_func.dtype).eps
+        cond = np.finfo(lapack_func.dtype).eps * max(m, n)
 
     if driver in ('gelss', 'gelsd'):
         if driver == 'gelss':

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1037,7 +1037,7 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
     cond : float, optional
         Cutoff for 'small' singular values; used to determine effective
         rank of a. Singular values smaller than
-        ``cond * largest_singular_value`` are considered zero. Default is 
+        ``cond * largest_singular_value`` are considered zero. Default is
         machine precision times `max(M, N)`.
     overwrite_a : bool, optional
         Discard data in `a` (may enhance performance). Default is False.

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -1267,6 +1267,14 @@ class TestLstsq:
             assert_(rank == 0, 'expected rank 0')
             assert_equal(s, np.empty((0,)))
 
+    def test_effective_rank(self):
+        m = np.eye(4)
+        # rank deficient after gh-16786
+        m[-1, -1] = 7e-16
+        n = np.array([2, 3, 4, 5])
+        actual_rank = lstsq(m, n)[2]
+        assert actual_rank == 3
+
 
 class TestPinv:
     def setup_method(self):


### PR DESCRIPTION
This commit changes the default `cond` to be consistent with the default `rcond` in `numpy` and `torch`.

According to [this thread](https://stackoverflow.com/a/44678023), for most practical purposes, the `cond` parameter for `lstsq` should be set to `EPS * max(M, N)`, where `EPS` is the machine precision of `A`'s dtype and `A` has shape `(M, N)`.

This is the default behavior in [`numpy.linalg.lstsq`](https://numpy.org/doc/stable/reference/generated/numpy.linalg.lstsq.html) and [`torch.linalg.lstsq`](https://pytorch.org/docs/stable/generated/torch.linalg.lstsq.html#torch.linalg.lstsq).

According to the StackOverflow thread linked above, the `cond` parameter in `scipy` used to be set optimally by default, but looking at the current code, I don't think that's the case now.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
