### PR TITLE
DOC, TST: clarify Voronoi Qz

### DIFF
--- a/scipy/spatial/_qhull.pyx
+++ b/scipy/spatial/_qhull.pyx
@@ -2536,10 +2536,16 @@ class Voronoi(_QhullUser):
     regions : list of list of ints, shape ``(nregions, *)``
         Indices of the Voronoi vertices forming each Voronoi region.
         -1 indicates vertex outside the Voronoi diagram.
-    point_region : list of ints, shape (npoints)
+        When qhull option "Qz" was specified, an empty sublist
+        represents the Voronoi region for a point at infinity that
+        was added internally.
+    point_region : array of ints, shape (npoints)
         Index of the Voronoi region for each input point.
         If qhull option "Qc" was not specified, the list will contain -1
         for points that are not associated with a Voronoi region.
+        If qhull option "Qz" was specified, there will be one less
+        element than the number of regions because an extra point
+        at infinity is added internally to facilitate computation.
     furthest_site
         True if this was a furthest site triangulation and False if not.
 

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -795,6 +795,41 @@ class TestConvexHull:
         assert_equal(hull.good, expected)
 
 class TestVoronoi:
+
+    @pytest.mark.parametrize("qhull_opts, extra_pts", [
+        # option Qz (default for SciPy) will add
+        # an extra point at infinity
+        ("Qbb Qc Qz", 1),
+        ("Qbb Qc", 0),
+    ])
+    @pytest.mark.parametrize("n_pts", [50, 100])
+    @pytest.mark.parametrize("ndim", [2, 3])
+    def test_point_region_structure(self,
+                                    qhull_opts,
+                                    n_pts,
+                                    extra_pts,
+                                    ndim):
+        # see gh-16773
+        rng = np.random.default_rng(7790)
+        points = rng.random((n_pts, ndim))
+        vor = Voronoi(points, qhull_options=qhull_opts)
+        pt_region = vor.point_region
+        assert pt_region.max() == n_pts - 1 + extra_pts
+        assert pt_region.size == len(vor.regions) - extra_pts
+        assert len(vor.regions) == n_pts + extra_pts
+        assert vor.points.shape[0] == n_pts
+        # if there is an empty sublist in the Voronoi
+        # regions data structure, it should never be
+        # indexed because it corresponds to an internally
+        # added point at infinity and is not a member of the
+        # generators (input points)
+        if extra_pts:
+            sublens = [len(x) for x in vor.regions]
+            # only one point at infinity (empty region)
+            # is allowed
+            assert sublens.count(0) == 1
+            assert sublens.index(0) not in pt_region
+
     def test_masked_array_fails(self):
         masked_array = np.ma.masked_all(1)
         assert_raises(ValueError, qhull.Voronoi, masked_array)


### PR DESCRIPTION
Fixes #16773

* About ten years ago in 5bdd16ddbc, Pauli
matched upstream behavior by explicitly accounting
for the internal point at infinity that `Qhull` adds
when the `Qz` option is used with `Voronoi` (which,
for us, it is by default). That means that the Voronoi
`regions` data structure will typically have one extra
empty list for a Voronoi region of a point at infinity.
Correspondingly, the `point_region` data structure will have one
less element than `regions` in these `Qz` cases because there
you are explicitly finding the correspondence to the input
points/generators only.

* This is admittedly a bit confusing, so I've tried to clarify
the docs on this matter. To be honest I was tempted to change
the behavior to be less surprising ("principle of least surprise"
or something?), but thought that this wasn't quite a bug, and was
intentionally set ten years ago to match "upstream." I'm open to
changing it on my end, but the doc-only "fix" is my first suggestion
anyway.

* I also added a test to demonstrate/test things a bit more
clearly in this regard, though formally it is hardly needed since
there's no regression fix proposed at the moment

* unrelated doc fix: `point_region` is an array, not a list, so
fix that (it is already fixed in another docstring, but not the
main one that gets exposed)