### PR TITLE
MAINT: stats.skewnorm: fix fit when data skewness is greater than max possible population skewness

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -7887,7 +7887,7 @@ class skew_norm_gen(rv_continuous):
         # MoM won't provide a good guess. Get out early.
         s = stats.skew(data)
         s_max = skew_d(1)
-        if np.abs(s) >= s_max and method == "mle":
+        if abs(s) >= s_max and method == "mle" and fa is None and not args:
             return super().fit(data, *args, **kwds)
 
         # If method is method of moments, we don't need the user's guesses.

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -7875,16 +7875,7 @@ class skew_norm_gen(rv_continuous):
         # are specified, and also leaves them in `kwds`
         data, fa, floc, fscale = _check_fit_input_parameters(self, data,
                                                              args, kwds)
-
-        # If method is method of moments, we don't need the user's guesses.
-        # If method is "mle", extract the guesses from args and kwds.
         method = kwds.get("method", "mle").lower()
-        if method == "mm":
-            a, loc, scale = None, None, None
-        else:
-            a = args[0] if len(args) else None
-            loc = kwds.pop('loc', None)
-            scale = kwds.pop('scale', None)
 
         # See https://en.wikipedia.org/wiki/Skew_normal_distribution for
         # moment formulas.
@@ -7892,19 +7883,32 @@ class skew_norm_gen(rv_continuous):
             return (4-np.pi)/2 * ((d * np.sqrt(2 / np.pi))**3
                                   / (1 - 2*d**2 / np.pi)**(3/2))
 
+        # If skewness of data is greater than max possible population skewness,
+        # MoM won't provide a good guess. Get out early.
+        s = stats.skew(data)
+        s_max = skew_d(1)
+        if np.abs(s) >= s_max and method == "mle":
+            return super().fit(data, *args, **kwds)
+
+        # If method is method of moments, we don't need the user's guesses.
+        # If method is "mle", extract the guesses from args and kwds.
+        if method == "mm":
+            a, loc, scale = None, None, None
+        else:
+            a = args[0] if len(args) else None
+            loc = kwds.pop('loc', None)
+            scale = kwds.pop('scale', None)
+
         if fa is None and a is None:  # not fixed and no guess: use MoM
             # Solve for a that matches sample distribution skewness to sample
             # skewness.
-            s = stats.skew(data)
-            s_max = skew_d(1)
             s = np.clip(s, -s_max, s_max)
             d = root_scalar(lambda d: skew_d(d) - s, bracket=[-1, 1]).root
-            a = np.sqrt(np.divide(d**2, (1-d**2)))*np.sign(s)
-        elif fa is not None:  # fixed: use it
-            a = fa
-        # else: use the user-provided guess
-
-        d = a / np.sqrt(1 + a**2)  # simplifies code to (re)calculate here
+            with np.errstate(divide='ignore'):
+                a = np.sqrt(np.divide(d**2, (1-d**2)))*np.sign(s)
+        else:
+            a = fa if fa is not None else a
+            d = a / np.sqrt(1 + a**2)
 
         if fscale is None and scale is None:
             v = np.var(data)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2821,6 +2821,23 @@ class TestSkewNorm:
         ref = np.mean(rvs), stats.skew(rvs)
         assert_allclose(res, ref)
 
+        # Test behavior when skew of data is beyond maximum of skewnorm
+        rvs = stats.pareto.rvs(1, size=100, random_state=rng)
+
+        # MLE still works
+        res = stats.skewnorm.fit(rvs)
+        assert np.all(np.isfinite(res))
+
+        # MoM fits variance and skewness
+        a5, loc5, scale5 = stats.skewnorm.fit(rvs, method='mm')
+        assert np.isinf(a5)
+        # distribution infrastruction doesn't allow infinite shape parameters
+        # into _stats; it just bypasses it and produces NaNs. Calculate
+        # moments manually.
+        m, v = np.mean(rvs), np.var(rvs)
+        assert_allclose(m, loc5 + scale5 * np.sqrt(2/np.pi))
+        assert_allclose(v, scale5**2 * (1 - 2 / np.pi))
+
 
 class TestExpon:
     def test_zero(self):


### PR DESCRIPTION
#### Reference issue
Followup to gh-16770

#### What does this implement/fix?
In the `fit` override of `skewnorm`, there were two issues when the magnitude of the skewness of the data exceeds `0.9952717464311566`, the maximum possible skewness of a `skewnorm` distribution.

* Method of moments: the mean and variance were NaN
* MLE: error; fitting converges to values outside the domain of the distribution

This PR fixes these issues.

#### Additional information
See https://github.com/scipy/scipy/pull/16770#issuecomment-1206652525