### PR TITLE
BLD/REL: on Windows use numpy 1.22.3 as the version to build wheels against

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,13 +35,18 @@ requires = [
     # loongarch64 requires numpy>=1.22.0
     "numpy==1.22.0; platform_machine=='loongarch64'",
 
+    # On Windows we need to avoid 1.21.6, 1.22.0 and 1.22.1 because they were
+    # built with vc142. 1.22.3 is the first version that has 32-bit Windows
+    # wheels *and* was built with vc141. So use that:
+    "numpy==1.22.3; python_version=='3.10' and platform_machine=='win32' and platform_python_implementation != 'PyPy'",
+
     # default numpy requirements
     "numpy==1.19.5; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64' and platform_machine!='loongarch64' and platform_python_implementation != 'PyPy'",
     "numpy==1.19.5; python_version=='3.9' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='loongarch64' and platform_python_implementation != 'PyPy'",
     # Note that 1.21.3 was the first version with a complete set of 3.10 wheels,
-    # however macOS was broken and it's safe to build against 1.21.6 on all platforms
+    # however macOS was broken and it's safe C API/ABI-wise to build against 1.21.6
     # (see oldest-supported-numpy issues gh-28 and gh-45)
-    "numpy==1.21.6; python_version=='3.10' and platform_machine!='loongarch64' and platform_python_implementation != 'PyPy'",
+    "numpy==1.21.6; python_version=='3.10' and (platform_machine!='win32' and platform_machine!='loongarch64') and platform_python_implementation != 'PyPy'",
 
     # For Python versions which aren't yet officially supported,
     # we specify an unpinned NumPy which allows source distributions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,12 +47,13 @@ requires = [
     # however macOS was broken and it's safe C API/ABI-wise to build against 1.21.6
     # (see oldest-supported-numpy issues gh-28 and gh-45)
     "numpy==1.21.6; python_version=='3.10' and (platform_machine!='win32' and platform_machine!='loongarch64') and platform_python_implementation != 'PyPy'",
+    "numpy==1.23.2; python_version=='3.11' and platform_python_implementation != 'PyPy'",
 
     # For Python versions which aren't yet officially supported,
     # we specify an unpinned NumPy which allows source distributions
     # to be used and allows wheels to be used as soon as they
     # become available.
-    "numpy; python_version>='3.11'",
+    "numpy; python_version>='3.12'",
     "numpy; python_version>='3.8' and platform_python_implementation=='PyPy'",
 ]
 


### PR DESCRIPTION
Closes gh-16787

`[ci skip]`

_Please don't merge yet, I still need to test on the `oldest-supported-numpy` repo, which has CI for these conditions_