### PR TITLE
DOC: Embed method signatures of `spatial.transform.Rotation`

### DIFF
--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -552,6 +552,7 @@ cdef class Rotation:
         """
         return True
 
+    @cython.embedsignature(True)
     def __len__(self):
         """Number of rotations contained in this object.
 
@@ -571,6 +572,7 @@ cdef class Rotation:
 
         return self._quat.shape[0]
 
+    @cython.embedsignature(True)
     @classmethod
     def from_quat(cls, quat):
         """Initialize from quaternions.
@@ -633,6 +635,7 @@ cdef class Rotation:
         """
         return cls(quat, normalize=True)
 
+    @cython.embedsignature(True)
     @classmethod
     @cython.boundscheck(False)
     @cython.wraparound(False)
@@ -784,6 +787,7 @@ cdef class Rotation:
         else:
             return cls(quat, normalize=False, copy=False)
 
+    @cython.embedsignature(True)
     @classmethod
     @cython.boundscheck(False)
     @cython.wraparound(False)
@@ -892,6 +896,7 @@ cdef class Rotation:
         else:
             return cls(quat, normalize=False, copy=False)
 
+    @cython.embedsignature(True)
     @classmethod
     def from_euler(cls, seq, angles, degrees=False):
         """Initialize from Euler angles.
@@ -1049,6 +1054,7 @@ cdef class Rotation:
         else:
             return cls(quat, normalize=False, copy=False)
 
+    @cython.embedsignature(True)
     @classmethod
     @cython.boundscheck(False)
     @cython.wraparound(False)
@@ -1149,6 +1155,7 @@ cdef class Rotation:
         else:
             return cls(quat, normalize=False, copy=False)
 
+    @cython.embedsignature(True)
     def as_quat(self):
         """Represent as quaternions.
 
@@ -1199,6 +1206,7 @@ cdef class Rotation:
         else:
             return np.array(self._quat, copy=True)
 
+    @cython.embedsignature(True)
     @cython.boundscheck(False)
     @cython.wraparound(False)
     def as_matrix(self):
@@ -1302,6 +1310,7 @@ cdef class Rotation:
         else:
             return ret
 
+    @cython.embedsignature(True)
     @cython.boundscheck(False)
     @cython.wraparound(False)
     def as_rotvec(self, degrees=False):
@@ -1400,6 +1409,7 @@ cdef class Rotation:
         else:
             return np.asarray(rotvec)
 
+    @cython.embedsignature(True)
     def as_euler(self, seq, degrees=False):
         """Represent as Euler angles.
 
@@ -1510,6 +1520,7 @@ cdef class Rotation:
 
         return angles[0] if self._single else angles
 
+    @cython.embedsignature(True)
     def as_mrp(self):
         """Represent as Modified Rodrigues Parameters (MRPs).
 
@@ -1587,6 +1598,7 @@ cdef class Rotation:
         else:
             return np.asarray(mrps)
 
+    @cython.embedsignature(True)
     @classmethod
     def concatenate(cls, rotations):
         """Concatenate a sequence of `Rotation` objects.
@@ -1611,6 +1623,7 @@ cdef class Rotation:
         quats = np.concatenate([np.atleast_2d(x.as_quat()) for x in rotations])
         return cls(quats, normalize=False)
 
+    @cython.embedsignature(True)
     def apply(self, vectors, inverse=False):
         """Apply this rotation to a set of vectors.
 
@@ -1761,6 +1774,7 @@ cdef class Rotation:
         else:
             return result
 
+    @cython.embedsignature(True)
     def __mul__(Rotation self, Rotation other):
         """Compose this rotation with the other.
 
@@ -1840,6 +1854,7 @@ cdef class Rotation:
             result = result[0]
         return self.__class__(result, normalize=True, copy=False)
 
+    @cython.embedsignature(True)
     def inv(self):
         """Invert this rotation.
 
@@ -1877,6 +1892,7 @@ cdef class Rotation:
             quat = quat[0]
         return self.__class__(quat, copy=False)
 
+    @cython.embedsignature(True)
     @cython.boundscheck(False)
     @cython.wraparound(False)
     def magnitude(self):
@@ -1912,6 +1928,7 @@ cdef class Rotation:
         else:
             return np.asarray(angles)
 
+    @cython.embedsignature(True)
     def mean(self, weights=None):
         """Get the mean of the rotations.
 
@@ -1965,6 +1982,7 @@ cdef class Rotation:
         l, v = np.linalg.eigh(K)
         return self.__class__(v[:, -1], normalize=False)
 
+    @cython.embedsignature(True)
     def reduce(self, left=None, right=None, return_indices=False):
         """Reduce this rotation with the provided rotation groups.
 
@@ -2061,6 +2079,7 @@ cdef class Rotation:
         else:
             return reduced
 
+    @cython.embedsignature(True)
     @classmethod
     def create_group(cls, group, axis='Z'):
         """Create a 3D rotation group.
@@ -2099,6 +2118,7 @@ cdef class Rotation:
         """
         return create_group(cls, group, axis=axis)
 
+    @cython.embedsignature(True)
     def __getitem__(self, indexer):
         """Extract rotation(s) at given index(es) from object.
 
@@ -2185,6 +2205,7 @@ cdef class Rotation:
         quat[indexer] = value.as_quat()
         self._quat = quat
 
+    @cython.embedsignature(True)
     @classmethod
     def identity(cls, num=None):
         """Get identity rotation(s).
@@ -2209,6 +2230,7 @@ cdef class Rotation:
             q[:, 3] = 1
         return cls(q, normalize=False)
 
+    @cython.embedsignature(True)
     @classmethod
     def random(cls, num=None, random_state=None):
         """Generate uniformly distributed rotations.
@@ -2272,6 +2294,7 @@ cdef class Rotation:
 
         return cls(sample)
 
+    @cython.embedsignature(True)
     @classmethod
     def align_vectors(cls, a, b, weights=None, return_sensitivity=False):
         """Estimate a rotation to optimally align two sets of vectors.


### PR DESCRIPTION
#### Reference issue
Closes #16713 

#### What does this implement/fix?
Just used [embedsignature](https://cython.readthedocs.io/en/stable/src/userguide/source_files_and_compilation.html?highlight=embedsignature#compiler-directives) decorator before `spatial.transform.Rotation` methods to have their signatures in the docs.

#### Additional information
I did not test anything.
Also my first contribution :)
