### PR TITLE
ENH add extrapolate to BSpline.design_matrix

### DIFF
--- a/scipy/interpolate/_bspl.pyx
+++ b/scipy/interpolate/_bspl.pyx
@@ -418,7 +418,8 @@ def _norm_eq_lsq(const double[::1] x,
 @cython.boundscheck(False)
 def _make_design_matrix(const double[::1] x,
                         const double[::1] t,
-                        int k):
+                        int k,
+                        bint extrapolate):
     """
     Returns a design matrix in CSR format
     
@@ -430,6 +431,8 @@ def _make_design_matrix(const double[::1] x,
         Sorted 1D array of knots.
     k : int
         B-spline degree.
+    extrapolate : bool, optional
+        Whether to extrapolate to ouf-of-bounds points.
 
     Returns
     -------
@@ -441,20 +444,24 @@ def _make_design_matrix(const double[::1] x,
     cdef:
         cnp.npy_intp i, ind
         cnp.npy_intp n = x.shape[0]
-        double[::1] wrk = np.empty(2*k+2, dtype=float)
+        double[::1] work = np.empty(2*k+2, dtype=float)
         double[::1] data = np.zeros(n * (k + 1), dtype=float)
         cnp.ndarray[long, ndim=1] row_ind = np.zeros(n * (k + 1), dtype=int)
         cnp.ndarray[long, ndim=1] col_ind = np.zeros(n * (k + 1), dtype=int)
+        double xval
     ind = k
     for i in range(n):
-        
-        ind = find_interval(t, k, x[i], ind, 0)
-        _deBoor_D(&t[0], x[i], k, ind, 0, &wrk[0])
+        xval = x[i]
 
-        data[(k + 1) * i : (k + 1) * (i + 1)] = wrk[:k + 1]
+        # Find correct interval. Note that interval >= 0 always as
+        # extrapolate=False and out of bound values are already dealt with in
+        # design_matrix
+        ind = find_interval(t, k, xval, ind, extrapolate)
+        _deBoor_D(&t[0], xval, k, ind, 0, &work[0])
+
+        data[(k + 1) * i : (k + 1) * (i + 1)] = work[:k + 1]
         row_ind[(k + 1) * i : (k + 1) * (i + 1)] = i
-        col_ind[(k + 1) * i : (k + 1) * (i + 1)] = np.arange(ind - k
-                                                            ,ind + 1
-                                                            ,dtype=int)
+        col_ind[(k + 1) * i : (k + 1) * (i + 1)] = np.arange(
+            ind - k, ind + 1, dtype=int)
 
     return np.asarray(data), (row_ind, col_ind)

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -332,7 +332,7 @@ class BSpline:
         return cls.construct_fast(t, c, k, extrapolate)
 
     @classmethod
-    def design_matrix(cls, x, t, k):
+    def design_matrix(cls, x, t, k, extrapolate=False):
         """
         Returns a design matrix as a CSR format sparse array.
 
@@ -344,13 +344,19 @@ class BSpline:
             Sorted 1D array of knots.
         k : int
             B-spline degree.
+        extrapolate : bool or 'periodic', optional
+            Whether to extrapolate based on the first and last intervals
+            or raise an error. If 'periodic', periodic extrapolation is used.
+            Default is False.
+
+            .. versionadded:: 1.10.0
 
         Returns
         -------
         design_matrix : `csr_array` object
-            Sparse matrix in CSR format where in each row all the basis
-            elements are evaluated at the certain point (first row - x[0],
-            ..., last row - x[-1]).
+            Sparse matrix in CSR format where each row contains all the basis
+            elements of the input row (first row = basis elements of x[0],
+            ..., last row = basis elements x[-1]).
 
         Examples
         --------
@@ -404,21 +410,37 @@ class BSpline:
         x = _as_float_array(x, True)
         t = _as_float_array(t, True)
 
+        if extrapolate != 'periodic':
+            extrapolate = bool(extrapolate)
+
+        if k < 0:
+            raise ValueError("Spline order cannot be negative.")
         if t.ndim != 1 or np.any(t[1:] < t[:-1]):
             raise ValueError(f"Expect t to be a 1-D sorted array_like, but "
                              f"got t={t}.")
         # There are `nt - k - 1` basis elements in a BSpline built on the
         # vector of knots with length `nt`, so to have at least `k + 1` basis
-        # element we need to have at least `2 * k + 2` elements in the vector
+        # elements we need to have at least `2 * k + 2` elements in the vector
         # of knots.
         if len(t) < 2 * k + 2:
             raise ValueError(f"Length t is not enough for k={k}.")
-        # Checks from `find_interval` function
-        if (min(x) < t[k]) or (max(x) > t[t.shape[0] - k - 1]):
+        if not np.isfinite(t).all():
+            raise ValueError("Knots should not have nans or infs.")
+
+        if extrapolate == 'periodic':
+            # With periodic extrapolation we map x to the segment
+            # [t[k], t[n]].
+            n = t.size - k - 1
+            x = t[k] + (x - t[k]) % (t[n] - t[k])
+            extrapolate = False
+        elif not extrapolate and (
+            (min(x) < t[k]) or (max(x) > t[t.shape[0] - k - 1])
+        ):
+            # Checks from `find_interval` function
             raise ValueError(f'Out of bounds w/ x = {x}.')
 
         n, nt = x.shape[0], t.shape[0]
-        data, idx = _bspl._make_design_matrix(x, t, k)
+        data, idx = _bspl._make_design_matrix(x, t, k, extrapolate)
         return csr_array((data, idx), (n, nt - k - 1))
 
     def __call__(self, x, nu=0, extrapolate=None):

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -424,8 +424,6 @@ class BSpline:
         # of knots.
         if len(t) < 2 * k + 2:
             raise ValueError(f"Length t is not enough for k={k}.")
-        if not np.isfinite(t).all():
-            raise ValueError("Knots should not have nans or infs.")
 
         if extrapolate == 'periodic':
             # With periodic extrapolation we map x to the segment

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -499,7 +499,6 @@ class TestBSpline:
                 BSpline.design_matrix(x, t, k, extrapolate).toarray()
             )
 
-
     def test_design_matrix_x_shapes(self):
         # test for different `x` shapes
         np.random.seed(1234)

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -472,16 +472,16 @@ class TestBSpline:
             run_design_matrix_tests(n, k, "periodic")
 
     @pytest.mark.parametrize('extrapolate', [False, True, 'periodic'])
-    @pytest.mark.parametrize('order', range(5))
-    def test_design_matrix_same_as_BSpline_call(self, extrapolate, order):
+    @pytest.mark.parametrize('degree', range(5))
+    def test_design_matrix_same_as_BSpline_call(self, extrapolate, degree):
         """Test that design_matrix(x) is equivalent to BSpline(..)(x)."""
         np.random.seed(1234)
-        x = np.random.random_sample(10 * (order + 1))
+        x = np.random.random_sample(10 * (degree + 1))
         xmin, xmax = np.amin(x), np.amax(x)
-        k = order
-        t = np.r_[np.linspace(xmin - 2, xmin - 1, order),
-                  np.linspace(xmin, xmax, 2 * (order + 1)),
-                  np.linspace(xmax + 1, xmax + 2, order)]
+        k = degree
+        t = np.r_[np.linspace(xmin - 2, xmin - 1, degree),
+                  np.linspace(xmin, xmax, 2 * (degree + 1)),
+                  np.linspace(xmax + 1, xmax + 2, degree)]
         c = np.eye(len(t) - k - 1)
         bspline = BSpline(t, c, k, extrapolate)
         assert_allclose(

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -438,8 +438,7 @@ class TestBSpline:
         '''
         def run_design_matrix_tests(n, k, bc_type):
             '''
-            To avoid repetition of the code the following function is
-            provided.
+            To avoid repetition of code the following function is provided.
             '''
             np.random.seed(1234)
             x = np.sort(np.random.random_sample(n) * 40 - 20)
@@ -471,6 +470,35 @@ class TestBSpline:
         n = 5  # smaller `n` to test `k > n` case
         for k in range(2, 7):
             run_design_matrix_tests(n, k, "periodic")
+
+    @pytest.mark.parametrize('extrapolate', [False, True, 'periodic'])
+    @pytest.mark.parametrize('order', range(5))
+    def test_design_matrix_same_as_BSpline_call(self, extrapolate, order):
+        """Test that design_matrix(x) is equivalent to BSpline(..)(x)."""
+        np.random.seed(1234)
+        x = np.random.random_sample(10 * (order + 1))
+        xmin, xmax = np.amin(x), np.amax(x)
+        k = order
+        t = np.r_[np.linspace(xmin - 2, xmin - 1, order),
+                  np.linspace(xmin, xmax, 2 * (order + 1)),
+                  np.linspace(xmax + 1, xmax + 2, order)]
+        c = np.eye(len(t) - k - 1)
+        bspline = BSpline(t, c, k, extrapolate)
+        assert_allclose(
+            bspline(x), BSpline.design_matrix(x, t, k, extrapolate).toarray()
+        )
+
+        # extrapolation regime
+        x = np.array([xmin - 10, xmin - 1, xmax + 1.5, xmax + 10])
+        if not extrapolate:
+            with pytest.raises(ValueError):
+                BSpline.design_matrix(x, t, k, extrapolate)
+        else:
+            assert_allclose(
+                bspline(x),
+                BSpline.design_matrix(x, t, k, extrapolate).toarray()
+            )
+
 
     def test_design_matrix_x_shapes(self):
         # test for different `x` shapes


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Continuation of #14344.

#### What does this implement/fix?
This PR adds `extrapolate` to `BSpline.design_matrix` such that is produces equivalent results compared to `BSpline.__call__`.

#### Additional information
This would help [scikit-learn#20998](https://github.com/scikit-learn/scikit-learn/issues/20998) a lot.
