### PR TITLE
DOC: filter sphinx-design `PendingDeprecationWarning`

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -155,6 +155,9 @@ for key in (
 warnings.filterwarnings(  # matplotlib<->pyparsing issue
     'ignore', message="Exception creating Regex for oneOf.*",
     category=SyntaxWarning)
+warnings.filterwarnings(  # sphinx_design <0.2.1
+    'ignore', message=r"nodes.Node.traverse() is obsoleted by Node.findall().",
+    category=PendingDeprecationWarning)
 # warnings in examples (mostly) that we allow
 # TODO: eventually these should be eliminated!
 for key in (


### PR DESCRIPTION
Doc fails to build due to a `PendingDeprecationWarning` in sphinx-design. This is a temporary filter to get a green CI until the next release (https://github.com/executablebooks/sphinx-design/pull/76)