### PR TITLE
DEV: update pydevtool version to propagate exit codes

### DIFF
--- a/doc/API.rst.txt
+++ b/doc/API.rst.txt
@@ -125,7 +125,7 @@ change is made.
 
 * `scipy.optimize`
 
-  - `scipy.optimize.cython_optimize
+  - `scipy.optimize.cython_optimize`
 
 * `scipy.signal`
 

--- a/environment.yml
+++ b/environment.yml
@@ -46,4 +46,4 @@ dependencies:
   - rich-click
   - click
   - doit>=0.36.0
-  - pydevtool==0.2.0
+  - pydevtool

--- a/mypy.ini
+++ b/mypy.ini
@@ -406,6 +406,9 @@ ignore_errors = True
 [mypy-scipy.stats.tests.test_sampling]
 ignore_errors = True
 
+[mypy-scipy.stats.tests.test_odds_ratio]
+ignore_errors = True
+
 #
 # Files referencing compiled code that needs stubs added.
 #


### PR DESCRIPTION
The pin is not really needed anymore, we just want the latest version.

This change also flushes the GitHub Actions cache, which is keyed on `environment.yml`.

Closes gh-16476