### PR TITLE
Doc: Added missing "import numpy as np" to docstring examples in the scipy.integrate module.

### DIFF
--- a/scipy/integrate/_bvp.py
+++ b/scipy/integrate/_bvp.py
@@ -895,6 +895,7 @@ def solve_bvp(fun, bc, x, y, p=None, S=None, fun_jac=None, bc_jac=None,
         y1' = y2
         y2' = -exp(y1)
 
+    >>> import numpy as np
     >>> def fun(x, y):
     ...     return np.vstack((y[1], -np.exp(y[0])))
 

--- a/scipy/integrate/_odepack_py.py
+++ b/scipy/integrate/_odepack_py.py
@@ -183,6 +183,7 @@ def odeint(func, y0, t, args=(), Dfun=None, col_deriv=0, full_output=0,
     Let `y` be the vector [`theta`, `omega`]. We implement this system
     in Python as:
 
+    >>> import numpy as np
     >>> def pend(y, t, b, c):
     ...     theta, omega = y
     ...     dydt = [omega, -b*omega - c*np.sin(theta)]

--- a/scipy/integrate/_quad_vec.py
+++ b/scipy/integrate/_quad_vec.py
@@ -209,6 +209,7 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, li
     We can compute integrations of a vector-valued function:
 
     >>> from scipy.integrate import quad_vec
+    >>> import numpy as np
     >>> import matplotlib.pyplot as plt
     >>> alpha = np.linspace(0.0, 2.0, num=30)
     >>> f = lambda x: x**alpha

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -344,6 +344,7 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
     Calculate :math:`\\int^4_0 x^2 dx` and compare with an analytic result
 
     >>> from scipy import integrate
+    >>> import numpy as np
     >>> x2 = lambda x: x**2
     >>> integrate.quad(x2, 0, 4)
     (21.333333333333332, 2.3684757858670003e-13)

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -125,6 +125,7 @@ def fixed_quad(func, a, b, args=(), n=5):
     Examples
     --------
     >>> from scipy import integrate
+    >>> import numpy as np
     >>> f = lambda x: x**8
     >>> integrate.fixed_quad(f, 0.0, 1.0, n=4)
     (0.1110884353741496, None)
@@ -247,6 +248,7 @@ def quadrature(func, a, b, args=(), tol=1.49e-8, rtol=1.49e-8, maxiter=50,
     Examples
     --------
     >>> from scipy import integrate
+    >>> import numpy as np
     >>> f = lambda x: x**8
     >>> integrate.quadrature(f, 0.0, 1.0)
     (0.11111111111111106, 4.163336342344337e-17)
@@ -341,6 +343,7 @@ def cumulative_trapezoid(y, x=None, dx=1.0, axis=-1, initial=None):
     Examples
     --------
     >>> from scipy import integrate
+    >>> import numpy as np
     >>> import matplotlib.pyplot as plt
 
     >>> x = np.linspace(-2, 2, num=20)
@@ -490,6 +493,7 @@ def simpson(y, x=None, dx=1.0, axis=-1, even='avg'):
     Examples
     --------
     >>> from scipy import integrate
+    >>> import numpy as np
     >>> x = np.arange(0, 10)
     >>> y = np.arange(0, 10)
 
@@ -599,6 +603,7 @@ def romb(y, dx=1.0, axis=-1, show=False):
     Examples
     --------
     >>> from scipy import integrate
+    >>> import numpy as np
     >>> x = np.arange(10, 14.25, 0.25)
     >>> y = np.arange(3, 12)
 
@@ -805,6 +810,7 @@ def romberg(function, a, b, args=(), tol=1.48e-8, rtol=1.48e-8, show=False,
 
     >>> from scipy import integrate
     >>> from scipy.special import erf
+    >>> import numpy as np
     >>> gaussian = lambda x: 1/np.sqrt(np.pi) * np.exp(-x**2)
     >>> result = integrate.romberg(gaussian, 0, 1, show=True)
     Romberg integration of <function vfunc at ...> from [0, 1]
@@ -961,6 +967,7 @@ def newton_cotes(rn, equal=0):
     Compute the integral of sin(x) in [0, :math:`\pi`]:
 
     >>> from scipy.integrate import newton_cotes
+    >>> import numpy as np
     >>> def f(x):
     ...     return np.sin(x)
     >>> a = 0


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
https://github.com/scipy/scipy/issues/16759

#### What does this implement/fix?
<!--Please explain your changes.-->
Added missing `import numpy as np` to docstring examples in the `scipy.integrate` module.

#### Additional information
<!--Any additional information you think is important.-->
