### PR TITLE
DOC: fix broken links

### DIFF
--- a/HACKING.rst.txt
+++ b/HACKING.rst.txt
@@ -286,7 +286,7 @@ improvements, and submit your first PR!
 
 .. _Pytest: https://pytest.org/
 
-.. _mailing lists: https://www.scipy.org/mailing-lists/
+.. _mailing lists: https://projects.scipy.org/scipylib/mailing-lists.html
 
 .. _Spyder: https://www.spyder-ide.org/
 

--- a/HACKING.rst.txt
+++ b/HACKING.rst.txt
@@ -286,7 +286,7 @@ improvements, and submit your first PR!
 
 .. _Pytest: https://pytest.org/
 
-.. _mailing lists: https://projects.scipy.org/scipylib/mailing-lists.html
+.. _mailing lists: https://scipy.org/community/#scipy-mailing-list
 
 .. _Spyder: https://www.spyder-ide.org/
 

--- a/doc/API.rst.txt
+++ b/doc/API.rst.txt
@@ -220,6 +220,6 @@ following, a *SciPy module* is defined as a Python package, say
 
 See the existing SciPy submodules for guidance.
 
-For further details on NumPy distutils, see `NumPy Distutils - User's Guide <https://github.com/numpy/numpy/blob/main/doc/DISTUTILS.rst.txt>`_.
+For further details on NumPy distutils, see `NumPy Distutils - User's Guide <https://github.com/numpy/numpy/blob/main/doc/DISTUTILS.rst>`_.
 
 .. _NumPy documentation style: https://numpydoc.readthedocs.io/en/latest/format.html

--- a/doc/source/dev/contributor/public_cython_api.rst
+++ b/doc/source/dev/contributor/public_cython_api.rst
@@ -13,12 +13,12 @@ via a public ``cdef`` Cython API declarations:
 - ``scipy.optimize.cython_optimize``
 - ``scipy.special.cython_special``
 
-This uses `Cython's declaration sharing features
-<cython-sharing-declarations>`_, where shared ``cdef`` items are
-declared in ``*.pxd`` files that are distributed together with the
-corresponding DLL/SO files in binary SciPy installations.
+This uses `Cython's declaration sharing features`_, where shared
+``cdef`` items are declared in ``*.pxd`` files that are distributed
+together with the corresponding DLL/SO files in binary SciPy
+installations.
 
-.. _cython-sharing-declarations: https://cython.readthedocs.io/en/latest/src/userguide/sharing_declarations.html
+.. _Cython's declaration sharing features: https://cython.readthedocs.io/en/latest/src/userguide/sharing_declarations.html
 
 
 Application Binary Interface

--- a/doc/source/dev/core-dev/distributing.rst.inc
+++ b/doc/source/dev/core-dev/distributing.rst.inc
@@ -50,7 +50,7 @@ are:
 
 Furthermore of course one needs C, C++ and Fortran compilers to build SciPy,
 but those we don't consider to be dependencies and are therefore not discussed
-here.  For details, see https://scipy.github.io/devdocs/building/.
+here.  For details, see https://scipy.github.io/devdocs/dev/contributor/building.html.
 
 When a package provides useful functionality and it's proposed as a new
 dependency, consider also if it makes sense to vendor (i.e. ship a copy of it with
@@ -134,7 +134,7 @@ Building binary installers
 
    This section is only about building SciPy binary installers to *distribute*.
    For info on building SciPy on the same machine as where it will be used, see
-   `this scipy.org page <https://scipy.github.io/devdocs/building/>`_.
+   `this scipy.org page <https://scipy.github.io/devdocs/dev/contributor/building.html>`_.
 
 There are a number of things to take into consideration when building binaries
 and distributing them on PyPI or elsewhere.
@@ -161,7 +161,7 @@ and distributing them on PyPI or elsewhere.
   That method will likely be used for SciPy itself once it's clear that the
   maintenance of that toolchain is sustainable long-term.  See the MingwPy_
   project and `this thread
-  <https://mail.scipy.org/pipermail/numpy-discussion/2015-October/074056.html>`_ for
+  <https://mail.python.org/pipermail/numpy-discussion/2015-October/074056.html>`_ for
   details.
 - The other way to produce 64-bit Windows installers is with ``icc``, ``ifort``
   plus ``MKL`` (or ``MSVC`` instead of ``icc``).  For Intel toolchain
@@ -208,7 +208,7 @@ Wheelhouse_, see at the wheel_ and Wheelhouse_ docs.
 .. _mpmath: http://mpmath.org
 .. _Cython: https://cython.org
 .. _pybind11: https://github.com/pybind/pybind11
-.. _setuptools: https://bitbucket.org/pypa/setuptools
+.. _setuptools: https://github.com/pypa/setuptools
 .. _wheel: https://wheel.readthedocs.io/
 .. _pip: https://pip.pypa.io/en/stable/
 .. _Python Packaging User Guide: https://packaging.python.org

--- a/doc/source/dev/governance.rst
+++ b/doc/source/dev/governance.rst
@@ -330,7 +330,7 @@ A list of current Institutional Partners is maintained at the page
 Document history
 ================
 
-https://github.com/scipy/scipy/commits/master/doc/source/dev/governance/governance.rst
+https://github.com/scipy/scipy/commits/main/doc/source/dev/governance/governance.rst
 
 Acknowledgements
 ================

--- a/doc/source/dev/roadmap-detailed.rst
+++ b/doc/source/dev/roadmap-detailed.rst
@@ -106,7 +106,7 @@ SciPy binaries are quite large (e.g. an unzipped manylinux wheel for 1.7.3 is
 example for use in AWS Lambda, which has a 250 MB size limit. We aim to keep
 binary size as low as possible; when adding new compiled extensions, this needs
 checking. Stripping of debug symbols in ``multibuild`` can perhaps be improved
-(see `this issue <https://github.com/matthew-brett/multibuild/issues/162>`__).
+(see `this issue <https://github.com/multi-build/multibuild/issues/162>`__).
 An effort should be made to slim down where possible, and not add new large
 files. In the future, things that are being considered (very tentatively) and
 may help are separating out the bundled` ``libopenblas`` and removing support

--- a/doc/source/tutorial/stats.rst
+++ b/doc/source/tutorial/stats.rst
@@ -382,8 +382,7 @@ i.e., the percent point function, requires a different definition:
 
     ppf(q) = min{x : cdf(x) >= q, x integer}
 
-For further info, see the docs `here
-<https://docs.scipy.org/doc/scipy/reference/tutorial/stats/discrete.html#percent-point-function-inverse-cdf>`__.
+For further info, see the docs :ref:`here<discrete-ppf>`.
 
 
 We can look at the hypergeometric distribution as an example


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
N/A
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
This PR fixes a number of broken links in the documentation.
<!--Please explain your changes.-->

#### Additional information
An additional broken link that is not included in this PR is the link to the official ARPACK website found here: https://github.com/scipy/scipy/blob/main/doc/source/tutorial/arpack.rst#references . I've not been able to find a working link to this, and I've sent an inquiry to the host asking for this. It might just be a temporary issue with their website redesign, as stated with the 404 message.

<!--Any additional information you think is important.-->
