### PR TITLE
Interpn nonscalar followup

### DIFF
--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -519,8 +519,7 @@ class TestRegularGridInterpolator:
 
         rng = np.random.default_rng(1234)
 
-        num_trailing_dims = 2
-        trailing_points = [3 + i for i in range(num_trailing_dims)]
+        trailing_points = (3, 2)
         # NB: values has a `num_trailing_dims` trailing dimension
         values = rng.random((6, 7, 8, 9, *trailing_points))
         sample = rng.random(4)   # a single sample point !
@@ -739,8 +738,7 @@ class TestInterpN:
 
         rng = np.random.default_rng(1234)
 
-        num_trailing_dims = 2
-        trailing_points = [3 + i for i in range(num_trailing_dims)]
+        trailing_points = (3, 2)
         # NB: values has a `num_trailing_dims` trailing dimension
         values = rng.random((6, 7, 8, 9, *trailing_points))
         sample = rng.random(4)   # a single sample point !

--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -491,12 +491,12 @@ class TestRegularGridInterpolator:
 
         rng = np.random.default_rng(1234)
         values = rng.random((6, 6, 6, 6, 8))
-        sample = rng.random((7, 11, 4))
+        sample = rng.random((7, 3, 4))
 
         interp = RegularGridInterpolator(points, values, method=method,
                                          bounds_error=False)
         v = interp(sample)
-        assert_equal(v.shape, (7, 11, 8), err_msg=method)
+        assert_equal(v.shape, (7, 3, 8), err_msg=method)
 
         vs = []
         for j in range(8):
@@ -715,11 +715,11 @@ class TestInterpN:
 
         rng = np.random.default_rng(1234)
         values = rng.random((6, 6, 6, 6, 8))
-        sample = rng.random((7, 11, 4))
+        sample = rng.random((7, 3, 4))
 
         v = interpn(points, values, sample, method=method,
                     bounds_error=False)
-        assert_equal(v.shape, (7, 11, 8), err_msg=method)
+        assert_equal(v.shape, (7, 3, 8), err_msg=method)
 
         vs = [interpn(points, values[..., j], sample, method=method,
                       bounds_error=False) for j in range(8)]


### PR DESCRIPTION
A simple follow-up to gh-16508:
- trivially simplify a test
- use somewhat smaller array sizes in test so that  the new/updated tests are not seen in  `$ pythod dev.py test -s interpolate -- --durations`.

The latter is dominated by RBFInterpolator tests, but that is definitely for some other day.