### PR TITLE
DOC: Add plot to circmean docstring

### DIFF
--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -3765,6 +3765,7 @@ def circmean(samples, high=2*pi, low=0, axis=None, nan_policy='propagate'):
     ...             label='circmean')
     >>> plt.scatter(np.cos(mean), np.sin(mean), c='r', label='mean')
     >>> plt.legend()
+    >>> plt.show()
 
     """
     samples, sin_samp, cos_samp, nmask = _circfuncs_common(samples, high, low,

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -3741,14 +3741,29 @@ def circmean(samples, high=2*pi, low=0, axis=None, nan_policy='propagate'):
 
     Examples
     --------
+    For simplicity, all angles are printed out in degrees.
+
     >>> import numpy as np
     >>> from scipy.stats import circmean
-    >>> circmean([0.1, 2*np.pi+0.2, 6*np.pi+0.3])
-    0.2
+    >>> import matplotlib.pyplot as plt
+    >>> angles=np.deg2rad(np.array([20, 30, 330]))
+    >>> circmean=circmean(angles)
+    >>> np.rad2deg(circmean)
+    7.294976657784009
 
-    >>> from scipy.stats import circmean
-    >>> circmean([0.2, 1.4, 2.6], high = 1, low = 0)
-    0.4
+    >>> mean=angles.mean()
+    >>> np.rad2deg(mean)
+    126.66666666666666
+
+    Plot and compare the results of *circmean* and the regular *mean*.
+    >>> plt.plot(np.cos(np.linspace(0, 2*np.pi, 500),
+    ...          np.sin(np.linspace(0, 2*np.pi, 500),
+    ...          c='k')
+    >>> plt.scatter(np.cos(angles) , np.sin(angles), c='k')
+    >>> plt.scatter(np.cos(circmean), np.sin(circmean), c='b',
+    ...             label='circmean')
+    >>> plt.scatter(np.cos(mean), np.sin(mean), c='r', label='mean')
+    >>> plt.legend()
 
     """
     samples, sin_samp, cos_samp, nmask = _circfuncs_common(samples, high, low,

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -3746,25 +3746,26 @@ def circmean(samples, high=2*pi, low=0, axis=None, nan_policy='propagate'):
     >>> import numpy as np
     >>> from scipy.stats import circmean
     >>> import matplotlib.pyplot as plt
-    >>> angles=np.deg2rad(np.array([20, 30, 330]))
-    >>> circmean=circmean(angles)
+    >>> angles = np.deg2rad(np.array([20, 30, 330]))
+    >>> circmean = circmean(angles)
     >>> np.rad2deg(circmean)
     7.294976657784009
 
-    >>> mean=angles.mean()
+    >>> mean = angles.mean()
     >>> np.rad2deg(mean)
     126.66666666666666
 
-    Plot and compare the results of *circmean* and the regular *mean*.
+    Plot and compare the circular mean against the arithmetic mean.
 
     >>> plt.plot(np.cos(np.linspace(0, 2*np.pi, 500)),
     ...          np.sin(np.linspace(0, 2*np.pi, 500)),
     ...          c='k')
-    >>> plt.scatter(np.cos(angles) , np.sin(angles), c='k')
+    >>> plt.scatter(np.cos(angles), np.sin(angles), c='k')
     >>> plt.scatter(np.cos(circmean), np.sin(circmean), c='b',
     ...             label='circmean')
     >>> plt.scatter(np.cos(mean), np.sin(mean), c='r', label='mean')
     >>> plt.legend()
+    >>> plt.axis('equal')
     >>> plt.show()
 
     """

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -3757,8 +3757,8 @@ def circmean(samples, high=2*pi, low=0, axis=None, nan_policy='propagate'):
 
     Plot and compare the results of *circmean* and the regular *mean*.
 
-    >>> plt.plot(np.cos(np.linspace(0, 2*np.pi, 500),
-    ...          np.sin(np.linspace(0, 2*np.pi, 500),
+    >>> plt.plot(np.cos(np.linspace(0, 2*np.pi, 500)),
+    ...          np.sin(np.linspace(0, 2*np.pi, 500)),
     ...          c='k')
     >>> plt.scatter(np.cos(angles) , np.sin(angles), c='k')
     >>> plt.scatter(np.cos(circmean), np.sin(circmean), c='b',

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -3756,6 +3756,7 @@ def circmean(samples, high=2*pi, low=0, axis=None, nan_policy='propagate'):
     126.66666666666666
 
     Plot and compare the results of *circmean* and the regular *mean*.
+
     >>> plt.plot(np.cos(np.linspace(0, 2*np.pi, 500),
     ...          np.sin(np.linspace(0, 2*np.pi, 500),
     ...          c='k')


### PR DESCRIPTION
#### What does this implement/fix?
Include a plot of circular data and a comparison of circular and regular mean in the docstring of `stats.circmean`

#### Additional information
I think for many users the functionality under circular/directional statistics is not immediately clear. In case of `circmean`, the usefulness can very easily be demonstrated by a plot of circular data and their circular/regular mean values.