### PR TITLE
ENH: stats.ttest_1samp: add confidence_interval and df

### DIFF
--- a/scipy/stats/_result_classes.py
+++ b/scipy/stats/_result_classes.py
@@ -17,11 +17,13 @@ Result classes
    PearsonRResult
    FitResult
    OddsRatioResult
+   Ttest_1sampResult
 
 """
 
 __all__ = ['BinomTestResult', 'RelativeRiskResult', 'TukeyHSDResult',
-           'PearsonRResult', 'FitResult', 'OddsRatioResult']
+           'PearsonRResult', 'FitResult', 'OddsRatioResult',
+           'Ttest_1sampResult']
 
 
 from ._binomtest import BinomTestResult

--- a/scipy/stats/_result_classes.py
+++ b/scipy/stats/_result_classes.py
@@ -28,5 +28,5 @@ from ._binomtest import BinomTestResult
 from ._odds_ratio import OddsRatioResult
 from ._relative_risk import RelativeRiskResult
 from ._hypotests import TukeyHSDResult
-from ._stats_py import PearsonRResult
+from ._stats_py import PearsonRResult, Ttest_1sampResult
 from ._fit import FitResult

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -6259,7 +6259,11 @@ def ttest_1samp(a, popmean, axis=0, nan_policy='propagate',
     df = n - 1
 
     mean = np.mean(a, axis)
-    d = mean - popmean[..., 0]  # popmean is an array because of decorator
+    try:
+        popmean = np.squeeze(popmean, axis=axis)
+    except ValueError as e:
+        raise ValueError("`popmean.shape[axis]` must equal 1.") from e
+    d = mean - popmean
     v = _var(a, axis, ddof=1)
     denom = np.sqrt(v / n)
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -6272,7 +6272,7 @@ def ttest_1samp(a, popmean, axis=0, nan_policy='propagate',
     t, prob = _ttest_finish(df, t, alternative)
 
     # when nan_policy='omit', `df` can be different for different axis-slices
-    df = np.broadcast_to(df, t.shape)
+    df = np.broadcast_to(df, t.shape)[()]
     # _axis_nan_policy decorator doesn't play well with strings
     alternative_num = {"less": -1, "two-sided": 0, "greater": 1}[alternative]
     return Ttest_1sampResult(t, prob, df=df, alternative=alternative_num,
@@ -6298,9 +6298,6 @@ def _t_confidence_interval(df, t, confidence_level, alternative):
         # axis of p must be the zeroth and orthogonal to all the rest
         p = np.reshape(p, [2] + [1]*np.asarray(df).ndim)
         low, high = special.stdtrit(df, p)
-    else:
-        p, nans = np.broadcast_arrays(t, np.nan)
-        low, high = nans, nans
 
     return low[()], high[()]
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -6111,8 +6111,8 @@ def ttest_1samp(a, popmean, axis=0, nan_policy='propagate',
     a : array_like
         Sample observation.
     popmean : float or array_like
-        Expected value in null hypothesis. If array_like, then it must have the
-        same shape as `a` excluding the axis dimension.
+        Expected value in null hypothesis. If array_like, then its length along
+        `axis` must equal 1, and it must otherwise be broadcastable with `a`.
     axis : int or None, optional
         Axis along which to compute test; default is 0. If None, compute over
         the whole array `a`.

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -6298,6 +6298,9 @@ def _t_confidence_interval(df, t, confidence_level, alternative):
         # axis of p must be the zeroth and orthogonal to all the rest
         p = np.reshape(p, [2] + [1]*np.asarray(df).ndim)
         low, high = special.stdtrit(df, p)
+    else:  # alternative is NaN when input is empty (see _axis_nan_policy)
+        p, nans = np.broadcast_arrays(t, np.nan)
+        low, high = nans, nans
 
     return low[()], high[()]
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -6023,13 +6023,66 @@ def _two_sample_transform(u, v):
 #       INFERENTIAL STATISTICS      #
 #####################################
 
-Ttest_1sampResult = _make_tuple_bunch('Ttest_1sampResult',
-                                      ['statistic', 'pvalue'],
-                                      ['df', 'confidence_interval'])
+TTestResultBase = _make_tuple_bunch('TTestResultBase',
+                                    ['statistic', 'pvalue'], ['df'])
+
+
+class Ttest_1sampResult(TTestResultBase):
+    """
+    Result of `ttest_1samp`.
+
+    Attributes
+    ----------
+    statistic : float or array
+        The t-statistic of the sample.
+    pvalue : float or array
+        The p-value associated with the given alternative.
+    df : float or array
+        The number of degrees of freedom used in calculation of the
+        t-statistic; this is one less than the size of the sample
+        (``a.shape[axis]``).
+
+    Methods
+    -------
+    confidence_interval
+        Computes a confidence interval around the population mean
+        for the given confidence level.
+        The confidence interval is returned in a ``namedtuple`` with
+        fields `low` and `high`.
+
+    """
+
+    def __init__(self, statistic, pvalue, df,  # public
+                 alternative, standard_error, estimate):  # private
+        super().__init__(statistic, pvalue, df=df)
+        self._alternative = alternative
+        self._standard_error = standard_error  # denominator of t-statistic
+        self._estimate = estimate  # point estimate of sample mean
+
+    def confidence_interval(self, confidence_level=0.95):
+        """
+        Parameters
+        ----------
+        confidence_level : float
+            The confidence level for the calculation of the population mean
+            confidence interval. Default is 0.95.
+
+        Returns
+        -------
+        ci : namedtuple
+            The confidence interval is returned in a ``namedtuple`` with
+            fields `low` and `high`.
+
+        """
+        low, high = _t_confidence_interval(self.df, self.statistic,
+                                           confidence_level, self._alternative)
+        low = low * self._standard_error + self._estimate
+        high = high * self._standard_error + self._estimate
+        return ConfidenceInterval(low=low, high=high)
 
 
 def ttest_1samp(a, popmean, axis=0, nan_policy='propagate',
-                alternative="two-sided", *, confidence_level=0.95):
+                alternative="two-sided"):
     """Calculate the T-test for the mean of ONE group of scores.
 
     This is a test for the null hypothesis that the expected value
@@ -6065,21 +6118,31 @@ def ttest_1samp(a, popmean, axis=0, nan_policy='propagate',
         * 'greater': the mean of the underlying distribution of the sample is
           greater than the given population mean (`popmean`)
 
-    confidence_level : float, optional
-        The confidence level for the calculation of the confidence interval
-        of the true mean, that is, the population mean of the distribution
-        underlying the sample. Default is 0.95.
-
     Returns
     -------
-    statistic : float or array
-        t-statistic.
-    pvalue : float or array
-        Two-sided p-value.
-    df : float or array
-        The number of degrees of freedom used in calculation of the
-        t-statistic; this is one less than the size of the sample
-        (``a.shape[axis]``).
+    result : `~scipy.stats._result_classes.Ttest_1sampResult`
+        An object with the following attributes:
+
+        statistic : float or array
+            The t-statistic.
+        pvalue : float or array
+            The p-value associated with the given alternative.
+        df : float or array
+            The number of degrees of freedom used in calculation of the
+            t-statistic; this is one less than the size of the sample
+            (``a.shape[axis]``).
+
+            .. versionadded:: 1.10.0
+
+        The object also has the following method:
+
+        confidence_interval(confidence_level=0.95)
+            Computes a confidence interval around the population
+            mean for the given confidence level.
+            The confidence interval is returned in a ``namedtuple`` with
+            fields `low` and `high`.
+
+            .. versionadded:: 1.10.0
 
     Notes
     -----
@@ -6104,7 +6167,7 @@ def ttest_1samp(a, popmean, axis=0, nan_policy='propagate',
     >>> rng = np.random.default_rng()
     >>> rvs = stats.uniform.rvs(size=50, random_state=rng)
     >>> stats.ttest_1samp(rvs, popmean=0.5)
-    Ttest_1sampResult(statistic=2.456308468440, pvalue=0.017628209047638)
+    Ttest_1sampResult(statistic=2.456308468440, pvalue=0.017628209047638, df=49)  # noqa
 
     As expected, the p-value of 0.017 is not below our threshold of 0.01, so
     we cannot reject the null hypothesis.
@@ -6114,7 +6177,7 @@ def ttest_1samp(a, popmean, axis=0, nan_policy='propagate',
 
     >>> rvs = stats.norm.rvs(size=50, random_state=rng)
     >>> stats.ttest_1samp(rvs, popmean=0.5)
-    Ttest_1sampResult(statistic=-7.433605518875, pvalue=1.416760157221e-09)
+    Ttest_1sampResult(statistic=-7.433605518875, pvalue=1.416760157221e-09, df=49)  # noqa
 
     Indeed, the p-value is lower than our threshold of 0.01, so we reject the
     null hypothesis in favor of the default "two-sided" alternative: the mean
@@ -6126,7 +6189,7 @@ def ttest_1samp(a, popmean, axis=0, nan_policy='propagate',
     expect the null hypothesis to be rejected.
 
     >>> stats.ttest_1samp(rvs, popmean=0.5, alternative='greater')
-    Ttest_1sampResult(statistic=-7.433605518875, pvalue=0.99999999929)
+    Ttest_1sampResult(statistic=-7.433605518875, pvalue=0.99999999929, df=49)  # noqa
 
     Unsurprisingly, with a p-value greater than our threshold, we would not
     reject the null hypothesis.
@@ -6142,6 +6205,35 @@ def ttest_1samp(a, popmean, axis=0, nan_policy='propagate',
     Indeed, even though all 100 samples above were drawn from the standard
     uniform distribution, which *does* have a population mean of 0.5, we would
     mistakenly reject the null hypothesis for one of them.
+
+    `ttest_1samp` can also computer a confidence interval around the population
+    mean.
+
+    >>> rvs = stats.norm.rvs(size=50, random_state=rng)
+    >>> res = stats.ttest_1samp(rvs, popmean=0)
+    >>> ci = res.confidence_interval(confidence_level=0.95)
+    >>> ci
+    ConfidenceInterval(low=-0.3193887540880017, high=0.2898583388980972)
+
+    The bounds of the 95% confidence interval are the
+    minimum and maximum values of the parameter `popmean` for which the
+    p-value of the test would be 0.05.
+
+    >>> res = stats.ttest_1samp(rvs, popmean=ci.low)
+    >>> np.testing.assert_allclose(res.pvalue, 0.05)
+    >>> res = stats.ttest_1samp(rvs, popmean=ci.high)
+    >>> np.testing.assert_allclose(res.pvalue, 0.05)
+
+    Under certain assumptions about the population from which a sample
+    is drawn, the confidence interval with confidence level 95% is expected
+    to contain the true population mean in 95% of sample replications.
+
+    >>> rvs = stats.norm.rvs(size=(50, 1000), loc=1, random_state=rng)
+    >>> res = stats.ttest_1samp(rvs, popmean=0)
+    >>> ci = res.confidence_interval()
+    >>> contains_pop_mean = (ci.low < 1) & (ci.high > 1)
+    >>> contains_pop_mean.sum()
+    953
 
     """
     a, axis = _chk_asarray(a, axis)
@@ -6164,15 +6256,17 @@ def ttest_1samp(a, popmean, axis=0, nan_policy='propagate',
         t = np.divide(d, denom)
     t, prob = _ttest_finish(df, t, alternative)
 
-    low, high = _t_confidence_interval(df, confidence_level, alternative)
-    low = low * denom + mean
-    high = high * denom + mean
-    ci = ConfidenceInterval(low=low, high=high)
-
-    return Ttest_1sampResult(t, prob, df=df, confidence_interval=ci)
+    return Ttest_1sampResult(t, prob, df=df, alternative=alternative,
+                             standard_error=denom, estimate=mean)
 
 
-def _t_confidence_interval(df, confidence_level, alternative):
+def _t_confidence_interval(df, t, confidence_level, alternative):
+    # Input validation on `alternative` is already done
+    # We just need IV on confidence_level
+    if confidence_level < 0 or confidence_level > 1:
+        message = "`confidence_level` must be a number between 0 and 1."
+        raise ValueError(message)
+
     if alternative == 'less':
         p = confidence_level
         low, high = np.broadcast_arrays(-np.inf, special.stdtrit(df, p))
@@ -6183,9 +6277,7 @@ def _t_confidence_interval(df, confidence_level, alternative):
         tail_probability = (1 - confidence_level)/2
         p = tail_probability, 1-tail_probability
         low, high = special.stdtrit(df, p)
-    else:
-        raise ValueError("alternative must be "
-                         "'less', 'greater' or 'two-sided'")
+
     return low[()], high[()]
 
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -6040,7 +6040,7 @@ class Ttest_1sampResult(TTestResultBase):
     df : float or array
         The number of degrees of freedom used in calculation of the
         t-statistic; this is one less than the size of the sample
-        (``a.shape[axis]``).
+        (``a.shape[axis]-1`` if there are no masked elements or omitted NaNs).
 
     Methods
     -------
@@ -6083,8 +6083,8 @@ class Ttest_1sampResult(TTestResultBase):
 
 def pack_Ttest_Result(statistic, pvalue, df, alternative, standard_error,
                       estimate):
-    # this could be any number of dimensions (including 0d), but only one
-    # unique value
+    # this could be any number of dimensions (including 0d), but there is
+    # at most one unique value
     alternative = np.atleast_1d(alternative).ravel()
     alternative = alternative[0] if alternative.size else np.nan
     return Ttest_1sampResult(statistic, pvalue, df=df, alternative=alternative,
@@ -6223,7 +6223,7 @@ def ttest_1samp(a, popmean, axis=0, nan_policy='propagate',
     uniform distribution, which *does* have a population mean of 0.5, we would
     mistakenly reject the null hypothesis for one of them.
 
-    `ttest_1samp` can also computer a confidence interval around the population
+    `ttest_1samp` can also compute a confidence interval around the population
     mean.
 
     >>> rvs = stats.norm.rvs(size=50, random_state=rng)

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -15,6 +15,13 @@ from numpy.testing import assert_allclose, assert_equal, suppress_warnings
 from scipy import stats
 from scipy.stats._axis_nan_policy import _masked_arrays_2_sentinel_arrays
 
+
+def unpack_ttest_1samp(res):
+    low, high = res.confidence_interval()
+    return (res.statistic, res.pvalue, res.df, res._standard_error,
+            res._estimate, low, high)
+
+
 axis_nan_policy_cases = [
     # function, args, kwds, number of samples, number of outputs,
     # ... paired, unpacker function
@@ -38,6 +45,8 @@ axis_nan_policy_cases = [
     (stats.moment, tuple(), dict(), 1, 1, False, lambda x: (x,)),
     (stats.moment, tuple(), dict(moment=[1, 2]), 1, 2, False, None),
     (stats.jarque_bera, tuple(), dict(), 1, 2, False, None),
+    (stats.ttest_1samp, (np.array([0]),), dict(), 1, 7, False,
+     unpack_ttest_1samp)
 ]
 
 # If the message is one of those expected, put nans in

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -1381,19 +1381,6 @@ class TestTtest_1samp():
         res2 = mstats.ttest_1samp(outcome[:, 0], 1)
         assert_allclose(res1, res2)
 
-        # 2-D inputs
-        res1 = stats.ttest_1samp(outcome[:, 0], outcome[:, 1], axis=None)
-        res2 = mstats.ttest_1samp(outcome[:, 0], outcome[:, 1], axis=None)
-        assert_allclose(res1, res2)
-
-        res1 = stats.ttest_1samp(outcome[:, :2], outcome[:, 2:], axis=0)
-        res2 = mstats.ttest_1samp(outcome[:, :2], outcome[:, 2:], axis=0)
-        assert_allclose(res1, res2, atol=1e-15)
-
-        # Check default is axis=0
-        res3 = mstats.ttest_1samp(outcome[:, :2], outcome[:, 2:])
-        assert_allclose(res2, res3)
-
     def test_fully_masked(self):
         np.random.seed(1234567)
         outcome = ma.masked_array(np.random.randn(3), mask=[1, 1, 1])

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -5173,7 +5173,7 @@ def test_ttest_1samp_new():
     assert_almost_equal(t1[0,0],t3, decimal=14)
     assert_equal(t1.shape, (n2,n3))
 
-    t1,p1 = stats.ttest_1samp(rvn1[:,:,:], np.ones((n1, 1, n3)),axis=1)
+    t1,p1 = stats.ttest_1samp(rvn1[:,:,:], np.ones((n1, 1, n3)),axis=1)  # noqa
     t2,p2 = stats.ttest_1samp(rvn1[:,:,:], 1,axis=1)
     t3,p3 = stats.ttest_1samp(rvn1[0,:,0], 1)
     assert_array_almost_equal(t1,t2, decimal=14)
@@ -5232,6 +5232,7 @@ def test_ttest_1samp_new():
     pc = converter(tr, pr, "less")
     assert_allclose(p, pc)
     assert_allclose(t, tr)
+
 
 def test_ttest_1samp_popmean_array():
     # when popmean.shape[axis] != 1, raise an error

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -5202,7 +5202,7 @@ def test_ttest_1samp_new():
     assert_almost_equal(t1[0,0],t3, decimal=14)
     assert_equal(t1.shape, (n1,n3))
 
-    t1,p1 = stats.ttest_1samp(rvn1[:,:,:], np.ones((n1,n2)),axis=2)
+    t1,p1 = stats.ttest_1samp(rvn1[:,:,:], np.ones((n1,n2,1)), axis=2)  # noqa
     t2,p2 = stats.ttest_1samp(rvn1[:,:,:], 1,axis=2)
     t3,p3 = stats.ttest_1samp(rvn1[0,0,:], 1)
     assert_array_almost_equal(t1,t2, decimal=14)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3284,28 +3284,6 @@ class TestStudentTest:
         assert_allclose(ci, ref[alternative])
         assert_equal(res.df, n-1)
 
-    @pytest.mark.parametrize("alternative", ['two-sided', 'less', 'greater'])
-    @pytest.mark.parametrize("axis", [0, 1])
-    def test_1samp_ci_nd(self, alternative, axis):
-        # test confidence interval with multi-dimensional array input
-        rng = np.random.default_rng(8066178009154342972)
-        x = rng.normal(size=(4, 5), loc=1.5, scale=2)
-
-        def reference_1d(x):
-            res = stats.ttest_1samp(x, 0, alternative=alternative)
-            ci = res.confidence_interval()
-            return ci.low, ci.high
-        x_reshape = np.moveaxis(x, axis, 0)
-        ref_low, ref_high = np.apply_along_axis(reference_1d, 0, x_reshape)
-
-        res = stats.ttest_1samp(x, 0, axis=axis, alternative=alternative)
-        ci = res.confidence_interval()
-
-        assert_allclose(ci.low, ref_low)
-        assert_allclose(ci.high, ref_high)
-        assert_equal(ci.low.shape, ref_low.shape)
-        assert_equal(ci.high.shape, ref_high.shape)
-
     def test_1samp_ci_iv(self):
         # test `confidence_interval` method input validation
         res = stats.ttest_1samp(np.arange(10), 0)
@@ -5202,7 +5180,7 @@ def test_ttest_1samp_new():
     assert_almost_equal(t1[0,0],t3, decimal=14)
     assert_equal(t1.shape, (n1,n3))
 
-    t1,p1 = stats.ttest_1samp(rvn1[:,:,:], np.ones((n1,n2,1)), axis=2)  # noqa
+    t1,p1 = stats.ttest_1samp(rvn1[:,:,:], np.ones((n1,n2,1)),axis=2)  # noqa
     t2,p2 = stats.ttest_1samp(rvn1[:,:,:], 1,axis=2)
     t3,p3 = stats.ttest_1samp(rvn1[0,0,:], 1)
     assert_array_almost_equal(t1,t2, decimal=14)


### PR DESCRIPTION
#### Reference issue
gh-15906
gh-9485

#### What does this implement/fix?
Adds a confidence interval and degree of freedom parameter to the object returned by `ttest_1samp`.

#### Additional information
Questions:
* Do we want the CI to be around the population mean itself or the difference between the population mean and the hypothesized mean?
* Should the name of the degree of freedom attribute be `df` like the name of the parameter for many distributions (e.g. `stats.t`)?
* Do we want to return `standard_error` and the mean `estimate`?