### PR TITLE
MAINT: avoid `func_data`, it conflicts with system header on IBM i system

### DIFF
--- a/scipy/optimize/Zeros/bisect.c
+++ b/scipy/optimize/Zeros/bisect.c
@@ -5,14 +5,14 @@
 
 double
 bisect(callback_type f, double xa, double xb, double xtol, double rtol,
-       int iter, void *func_data, scipy_zeros_info *solver_stats)
+       int iter, void *func_data_param, scipy_zeros_info *solver_stats)
 {
     int i;
     double dm,xm,fm,fa,fb;
     solver_stats->error_num = INPROGRESS;
 
-    fa = (*f)(xa, func_data);
-    fb = (*f)(xb, func_data);
+    fa = (*f)(xa, func_data_param);
+    fb = (*f)(xb, func_data_param);
     solver_stats->funcalls = 2;
     if (fa*fb > 0) {
         solver_stats->error_num = SIGNERR;
@@ -32,7 +32,7 @@ bisect(callback_type f, double xa, double xb, double xtol, double rtol,
         solver_stats->iterations++;
         dm *= .5;
         xm = xa + dm;
-        fm = (*f)(xm, func_data);
+        fm = (*f)(xm, func_data_param);
         solver_stats->funcalls++;
         if (fm*fa >= 0) {
             xa = xm;

--- a/scipy/optimize/Zeros/brenth.c
+++ b/scipy/optimize/Zeros/brenth.c
@@ -36,7 +36,7 @@
 
 double
 brenth(callback_type f, double xa, double xb, double xtol, double rtol,
-       int iter, void *func_data, scipy_zeros_info *solver_stats)
+       int iter, void *func_data_param, scipy_zeros_info *solver_stats)
 {
     double xpre = xa, xcur = xb;
     double xblk = 0., fpre, fcur, fblk = 0., spre = 0., scur = 0., sbis;
@@ -46,8 +46,8 @@ brenth(callback_type f, double xa, double xb, double xtol, double rtol,
     int i;
     solver_stats->error_num = INPROGRESS;
 
-    fpre = (*f)(xpre,func_data);
-    fcur = (*f)(xcur,func_data);
+    fpre = (*f)(xpre,func_data_param);
+    fcur = (*f)(xcur,func_data_param);
     solver_stats->funcalls = 2;
     if (fpre*fcur > 0) {
         solver_stats->error_num = SIGNERR;
@@ -125,7 +125,7 @@ brenth(callback_type f, double xa, double xb, double xtol, double rtol,
             xcur += (sbis > 0 ? delta : -delta);
         }
 
-        fcur = (*f)(xcur, func_data);
+        fcur = (*f)(xcur, func_data_param);
         solver_stats->funcalls++;
     }
     solver_stats->error_num = CONVERR;

--- a/scipy/optimize/Zeros/brentq.c
+++ b/scipy/optimize/Zeros/brentq.c
@@ -35,7 +35,7 @@
 
 double
 brentq(callback_type f, double xa, double xb, double xtol, double rtol,
-       int iter, void *func_data, scipy_zeros_info *solver_stats)
+       int iter, void *func_data_param, scipy_zeros_info *solver_stats)
 {
     double xpre = xa, xcur = xb;
     double xblk = 0., fpre, fcur, fblk = 0., spre = 0., scur = 0., sbis;
@@ -45,8 +45,8 @@ brentq(callback_type f, double xa, double xb, double xtol, double rtol,
     int i;
     solver_stats->error_num = INPROGRESS;
 
-    fpre = (*f)(xpre, func_data);
-    fcur = (*f)(xcur, func_data);
+    fpre = (*f)(xpre, func_data_param);
+    fcur = (*f)(xcur, func_data_param);
     solver_stats->funcalls = 2;
     if (fpre*fcur > 0) {
         solver_stats->error_num = SIGNERR;
@@ -123,7 +123,7 @@ brentq(callback_type f, double xa, double xb, double xtol, double rtol,
             xcur += (sbis > 0 ? delta : -delta);
         }
 
-        fcur = (*f)(xcur, func_data);
+        fcur = (*f)(xcur, func_data_param);
         solver_stats->funcalls++;
     }
     solver_stats->error_num = CONVERR;

--- a/scipy/optimize/Zeros/ridder.c
+++ b/scipy/optimize/Zeros/ridder.c
@@ -16,15 +16,15 @@
 
 double
 ridder(callback_type f, double xa, double xb, double xtol, double rtol,
-       int iter, void *func_data, scipy_zeros_info *solver_stats)
+       int iter, void *func_data_param, scipy_zeros_info *solver_stats)
 {
     int i;
     double dm,dn,xm,xn=0.0,fn,fm,fa,fb,tol;
     solver_stats->error_num = INPROGRESS;
 
     tol = xtol + rtol*MIN(fabs(xa), fabs(xb));
-    fa = (*f)(xa, func_data);
-    fb = (*f)(xb, func_data);
+    fa = (*f)(xa, func_data_param);
+    fb = (*f)(xb, func_data_param);
     solver_stats->funcalls = 2;
     if (fa*fb > 0) {
         solver_stats->error_num = SIGNERR;
@@ -44,10 +44,10 @@ ridder(callback_type f, double xa, double xb, double xtol, double rtol,
         solver_stats->iterations++;
         dm = 0.5*(xb - xa);
         xm = xa + dm;
-        fm = (*f)(xm, func_data);
+        fm = (*f)(xm, func_data_param);
         dn = SIGN(fb - fa)*dm*fm/sqrt(fm*fm - fa*fb);
         xn = xm - SIGN(dn) * MIN(fabs(dn), fabs(dm) - .5*tol);
-        fn = (*f)(xn, func_data);
+        fn = (*f)(xn, func_data_param);
         solver_stats->funcalls += 2;
         if (fn*fm < 0.0) {
             xa = xn; fa = fn; xb = xm; fb = fm;

--- a/scipy/optimize/Zeros/zeros.h
+++ b/scipy/optimize/Zeros/zeros.h
@@ -25,16 +25,16 @@ typedef double (*solver_type)(callback_type, double, double, double, double,
                               int, void *, scipy_zeros_info*);
 
 extern double bisect(callback_type f, double xa, double xb, double xtol,
-                     double rtol, int iter, void *func_data,
+                     double rtol, int iter, void *func_data_param,
                      scipy_zeros_info *solver_stats);
 extern double ridder(callback_type f, double xa, double xb, double xtol,
-                     double rtol, int iter, void *func_data,
+                     double rtol, int iter, void *func_data_param,
                      scipy_zeros_info *solver_stats);
 extern double brenth(callback_type f, double xa, double xb, double xtol,
-                     double rtol, int iter, void *func_data,
+                     double rtol, int iter, void *func_data_param,
                      scipy_zeros_info *solver_stats);
 extern double brentq(callback_type f, double xa, double xb, double xtol,
-                     double rtol, int iter, void *func_data,
+                     double rtol, int iter, void *func_data_param,
                      scipy_zeros_info *solver_stats);
 
 #endif

--- a/scipy/optimize/cython_optimize/c_zeros.pxd
+++ b/scipy/optimize/cython_optimize/c_zeros.pxd
@@ -7,20 +7,20 @@ cdef extern from "../Zeros/zeros.h":
 
 cdef extern from "../Zeros/bisect.c" nogil:
     double bisect(callback_type f, double xa, double xb, double xtol,
-                  double rtol, int iter, void *func_data,
+                  double rtol, int iter, void *func_data_param,
                   scipy_zeros_info *solver_stats)
 
 cdef extern from "../Zeros/ridder.c" nogil:
     double ridder(callback_type f, double xa, double xb, double xtol,
-                  double rtol, int iter, void *func_data,
+                  double rtol, int iter, void *func_data_param,
                   scipy_zeros_info *solver_stats)
 
 cdef extern from "../Zeros/brenth.c" nogil:
     double brenth(callback_type f, double xa, double xb, double xtol,
-                  double rtol, int iter, void *func_data,
+                  double rtol, int iter, void *func_data_param,
                   scipy_zeros_info *solver_stats)
 
 cdef extern from "../Zeros/brentq.c" nogil:
     double brentq(callback_type f, double xa, double xb, double xtol,
-                  double rtol, int iter, void *func_data,
+                  double rtol, int iter, void *func_data_param,
                   scipy_zeros_info *solver_stats)


### PR DESCRIPTION
"func_data" was predefined in sys/timer.h as others. So, trying to avoid some compiler failures on AIX and IBM i operating system. Please kindly help to review and merge it. thanks.