### PR TITLE
DOC: interpolate: small example code improvement for `BSpline.basis_element`

### DIFF
--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -310,8 +310,8 @@ class BSpline:
         Construct a quadratic B-spline on ``[0, 1, 1, 2]``, and compare
         to its explicit form:
 
-        >>> t = [-1, 0, 1, 1, 2]
-        >>> b = BSpline.basis_element(t[1:])
+        >>> t = [0, 1, 1, 2]
+        >>> b = BSpline.basis_element(t)
         >>> def f(x):
         ...     return np.where(x < 1, x*x, (2. - x)**2)
 


### PR DESCRIPTION

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
N/A

#### What does this implement/fix?
<!--Please explain your changes.-->
When I checked the `interpolate.BSpline.basis_element` [doc](https://scipy.github.io/devdocs/reference/generated/scipy.interpolate.BSpline.basis_element.html), I feel that the example code can be improved.
The doc says "Construct a quadratic B-spline on [0, 1, 1, 2]".
So, I think the knot variable should be `t = [0, 1, 1, 2]`, not `t = [-1, 0, 1, 1, 2]`.

