### PR TITLE
ENH: Handle np array methods in stats.binned_statistic_dd

### DIFF
--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -56,8 +56,9 @@ def binned_statistic(x, values, statistic='mean',
             will be called on the values in each bin.  Empty bins will be
             represented by function([]), or NaN if this returns an error.
             If the function is `np.mean`, `np.median`, `np.sum`, `np.std`,
-            `np.min`, or `np.max`, the equivalent string-name statistic
-            code will be called instead.
+            `np.min`, or `np.max`, code that that is optimized for use with
+            `binned_statistic` will perform the desired operation without
+            calling the NumPy function explicitly.
 
     bins : int or sequence of scalars, optional
         If `bins` is an int, it defines the number of equal-width bins in the
@@ -240,8 +241,9 @@ def binned_statistic_2d(x, y, values, statistic='mean',
             will be called on the values in each bin.  Empty bins will be
             represented by function([]), or NaN if this returns an error.
             If the function is `np.mean`, `np.median`, `np.sum`, `np.std`,
-            `np.min`, or `np.max`, the equivalent string-name statistic
-            code will be called instead.
+            `np.min`, or `np.max`, code that that is optimized for use with
+            `binned_statistic` will perform the desired operation without
+            calling the NumPy function explicitly.
 
     bins : int or [int, int] or array_like or [array, array], optional
         The bin specification:
@@ -415,8 +417,9 @@ def binned_statistic_dd(sample, values, statistic='mean',
             will be called on the values in each bin.  Empty bins will be
             represented by function([]), or NaN if this returns an error.
             If the function is `np.mean`, `np.median`, `np.sum`, `np.std`,
-            `np.min`, or `np.max`, the equivalent string-name statistic
-            code will be called instead.
+            `np.min`, or `np.max`, code that that is optimized for use with
+            `binned_statistic` will perform the desired operation without
+            calling the NumPy function explicitly.
 
     bins : sequence or positive int, optional
         The bin specification must be in one of the following forms:

--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -580,14 +580,14 @@ def binned_statistic_dd(sample, values, statistic='mean',
 
     result = np.empty([Vdim, nbin.prod()], float)
 
-    if statistic == 'mean':
+    if statistic in {'mean', np.mean}:
         result.fill(np.nan)
         flatcount = np.bincount(binnumbers, None)
         a = flatcount.nonzero()
         for vv in builtins.range(Vdim):
             flatsum = np.bincount(binnumbers, values[vv])
             result[vv, a] = flatsum[a] / flatcount[a]
-    elif statistic == 'std':
+    elif statistic in {'std', np.std}:
         result.fill(np.nan)
         flatcount = np.bincount(binnumbers, None)
         a = flatcount.nonzero()
@@ -601,13 +601,13 @@ def binned_statistic_dd(sample, values, statistic='mean',
         flatcount = np.bincount(binnumbers, None)
         a = np.arange(len(flatcount))
         result[:, a] = flatcount[np.newaxis, :]
-    elif statistic == 'sum':
+    elif statistic in {'sum', np.sum}:
         result.fill(0)
         for vv in builtins.range(Vdim):
             flatsum = np.bincount(binnumbers, values[vv])
             a = np.arange(len(flatsum))
             result[vv, a] = flatsum
-    elif statistic == 'median':
+    elif statistic in {'median', np.median}:
         result.fill(np.nan)
         for vv in builtins.range(Vdim):
             i = np.lexsort((values[vv], binnumbers))
@@ -618,12 +618,12 @@ def binned_statistic_dd(sample, values, statistic='mean',
             mid_b = values[vv, i][np.ceil(mid).astype(int)]
             medians = (mid_a + mid_b) / 2
             result[vv, binnumbers[i][j]] = medians
-    elif statistic == 'min':
+    elif statistic in {'min', np.min}:
         result.fill(np.nan)
         for vv in builtins.range(Vdim):
             i = np.argsort(values[vv])[::-1]  # Reversed so the min is last
             result[vv, binnumbers[i]] = values[vv, i]
-    elif statistic == 'max':
+    elif statistic in {'max', np.max}:
         result.fill(np.nan)
         for vv in builtins.range(Vdim):
             i = np.argsort(values[vv])

--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -55,10 +55,6 @@ def binned_statistic(x, values, statistic='mean',
             values, and outputs a single numerical statistic. This function
             will be called on the values in each bin.  Empty bins will be
             represented by function([]), or NaN if this returns an error.
-            If the function is `np.mean`, `np.median`, `np.sum`, `np.std`,
-            `np.min`, or `np.max`, code that that is optimized for use with
-            `binned_statistic` will perform the desired operation without
-            calling the NumPy function explicitly.
 
     bins : int or sequence of scalars, optional
         If `bins` is an int, it defines the number of equal-width bins in the
@@ -240,10 +236,6 @@ def binned_statistic_2d(x, y, values, statistic='mean',
             values, and outputs a single numerical statistic. This function
             will be called on the values in each bin.  Empty bins will be
             represented by function([]), or NaN if this returns an error.
-            If the function is `np.mean`, `np.median`, `np.sum`, `np.std`,
-            `np.min`, or `np.max`, code that that is optimized for use with
-            `binned_statistic` will perform the desired operation without
-            calling the NumPy function explicitly.
 
     bins : int or [int, int] or array_like or [array, array], optional
         The bin specification:
@@ -416,10 +408,6 @@ def binned_statistic_dd(sample, values, statistic='mean',
             values, and outputs a single numerical statistic. This function
             will be called on the values in each bin.  Empty bins will be
             represented by function([]), or NaN if this returns an error.
-            If the function is `np.mean`, `np.median`, `np.sum`, `np.std`,
-            `np.min`, or `np.max`, code that that is optimized for use with
-            `binned_statistic` will perform the desired operation without
-            calling the NumPy function explicitly.
 
     bins : sequence or positive int, optional
         The bin specification must be in one of the following forms:

--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -55,6 +55,9 @@ def binned_statistic(x, values, statistic='mean',
             values, and outputs a single numerical statistic. This function
             will be called on the values in each bin.  Empty bins will be
             represented by function([]), or NaN if this returns an error.
+            If the function is `np.mean`, `np.median`, `np.sum`, `np.std`,
+            `np.min`, or `np.max`, the equivalent string-name statistic
+            code will be called instead.
 
     bins : int or sequence of scalars, optional
         If `bins` is an int, it defines the number of equal-width bins in the
@@ -236,6 +239,9 @@ def binned_statistic_2d(x, y, values, statistic='mean',
             values, and outputs a single numerical statistic. This function
             will be called on the values in each bin.  Empty bins will be
             represented by function([]), or NaN if this returns an error.
+            If the function is `np.mean`, `np.median`, `np.sum`, `np.std`,
+            `np.min`, or `np.max`, the equivalent string-name statistic
+            code will be called instead.
 
     bins : int or [int, int] or array_like or [array, array], optional
         The bin specification:
@@ -408,6 +414,9 @@ def binned_statistic_dd(sample, values, statistic='mean',
             values, and outputs a single numerical statistic. This function
             will be called on the values in each bin.  Empty bins will be
             represented by function([]), or NaN if this returns an error.
+            If the function is `np.mean`, `np.median`, `np.sum`, `np.std`,
+            `np.min`, or `np.max`, the equivalent string-name statistic
+            code will be called instead.
 
     bins : sequence or positive int, optional
         The bin specification must be in one of the following forms:

--- a/scipy/stats/tests/test_binned_statistic.py
+++ b/scipy/stats/tests/test_binned_statistic.py
@@ -374,9 +374,12 @@ class TestBinnedStatistic:
 
         sum1, edges1, bc = binned_statistic_dd(X, v, 'sum', bins=3)
         sum2, edges2 = np.histogramdd(X, bins=3, weights=v)
+        sum3, edges3, bc = binned_statistic_dd(X, v, np.sum, bins=3)
 
         assert_allclose(sum1, sum2)
         assert_allclose(edges1, edges2)
+        assert_allclose(sum1, sum3)
+        assert_allclose(edges1, edges3)
 
     def test_dd_mean(self):
         X = self.X


### PR DESCRIPTION
#### Reference issue
Closes gh-16819.

#### What does this implement/fix?
If e.g. `statistic=np.mean` is passed to `binned_statistic_dd`, it will use the existing `statistic="mean"` specialization rather than the generic and much slower `callable` implementation.

#### Additional information
Only minimal tests needed to be expanded as the tests already checked that e.g. `"mean"` gave the same results as `np.mean`
