### PR TITLE
DOC: interpolate.{RegularGridInterpolator, interpn} add note explaining added dim when xi.ndim == 1

### DIFF
--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -280,7 +280,7 @@ class RegularGridInterpolator:
 
         Notes
         -----
-        In the case that ``xi.ndims == 1`` a new axis is inserted into
+        In the case that ``xi.ndim == 1`` a new axis is inserted into
         the 0 position of returned array so the shape is instead
         ``(1,) + values.shape[ndim:]``.
 
@@ -545,7 +545,7 @@ def interpn(points, values, xi, method="linear", bounds_error=True,
 
     .. versionadded:: 0.14
 
-    In the case that ``xi.ndims == 1`` a new axis is inserted into
+    In the case that ``xi.ndim == 1`` a new axis is inserted into
     the 0 position of returned array so the shape is instead
     ``(1,) + values.shape[ndim:]``.
 

--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -276,13 +276,14 @@ class RegularGridInterpolator:
         Returns
         -------
         values_x : ndarray, shape xi.shape[:-1] + values.shape[ndim:]
-            Interpolated values at `xi`.
+            Interpolated values at `xi`. See notes for behaviour when
+            ``xi.ndim == 1``.
 
         Notes
         -----
         In the case that ``xi.ndim == 1`` a new axis is inserted into
-        the 0 position of returned array so the shape is instead
-        ``(1,) + values.shape[ndim:]``.
+        the 0 position of the returned array, values_x, so its shape is
+        instead ``(1,) + values.shape[ndim:]``.
 
         Examples
         --------
@@ -538,7 +539,8 @@ def interpn(points, values, xi, method="linear", bounds_error=True,
     Returns
     -------
     values_x : ndarray, shape xi.shape[:-1] + values.shape[ndim:]
-        Interpolated values at input coordinates.
+        Interpolated values at `xi`. See notes for behaviour when
+        ``xi.ndim == 1``.
 
     Notes
     -----
@@ -546,8 +548,8 @@ def interpn(points, values, xi, method="linear", bounds_error=True,
     .. versionadded:: 0.14
 
     In the case that ``xi.ndim == 1`` a new axis is inserted into
-    the 0 position of returned array so the shape is instead
-    ``(1,) + values.shape[ndim:]``.
+    the 0 position of the returned array, values_x, so its shape is
+    instead ``(1,) + values.shape[ndim:]``.
 
     Examples
     --------

--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -278,6 +278,12 @@ class RegularGridInterpolator:
         values_x : ndarray, shape xi.shape[:-1] + values.shape[ndim:]
             Interpolated values at `xi`.
 
+        Notes
+        -----
+        In the case that ``xi.ndims == 1`` a new axis is inserted into
+        the 0 position of returned array so the shape is instead
+        ``(1,) + values.shape[ndim:]``.
+
         Examples
         --------
         Here we define a nearest-neighbor interpolator of a simple function
@@ -538,6 +544,10 @@ def interpn(points, values, xi, method="linear", bounds_error=True,
     -----
 
     .. versionadded:: 0.14
+
+    In the case that ``xi.ndims == 1`` a new axis is inserted into
+    the 0 position of returned array so the shape is instead
+    ``(1,) + values.shape[ndim:]``.
 
     Examples
     --------


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Follow up to #16508
#### What does this implement/fix?
<!--Please explain your changes.-->
Adds note explaining corner case where extra dimension is added to the returned array when ``xi.ndims ==1``.
#### Additional information
<!--Any additional information you think is important.-->
