### PR TITLE
MAINT: Unnecessary all-true array multiplication.

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -3584,7 +3584,7 @@ class rv_discrete(rv_generic):
         cond = cond0 & cond1
         output = np.full(shape(cond), fill_value=self.badvalue, dtype='d')
         # output type 'd' to handle nin and inf
-        place(output, (q == 0), _a - 1 + loc)
+        place(output, (q == 0)*(cond == cond), _a-1 + loc)
         place(output, cond2, _b + loc)
         if np.any(cond):
             goodargs = argsreduce(cond, *((q,)+args+(loc,)))

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -3584,7 +3584,7 @@ class rv_discrete(rv_generic):
         cond = cond0 & cond1
         output = np.full(shape(cond), fill_value=self.badvalue, dtype='d')
         # output type 'd' to handle nin and inf
-        place(output, (q == 0)*(cond == cond), _a-1 + loc)
+        place(output, (q == 0), _a - 1 + loc)
         place(output, cond2, _b + loc)
         if np.any(cond):
             goodargs = argsreduce(cond, *((q,)+args+(loc,)))
@@ -3629,8 +3629,8 @@ class rv_discrete(rv_generic):
         # output type 'd' to handle nin and inf
         lower_bound = _a - 1 + loc
         upper_bound = _b + loc
-        place(output, cond2*(cond == cond), lower_bound)
-        place(output, cond3*(cond == cond), upper_bound)
+        place(output, cond2, lower_bound)
+        place(output, cond3, upper_bound)
 
         # call place only if at least 1 valid argument
         if np.any(cond):


### PR DESCRIPTION
While testing openrefactory, I came across a SciPy report:

In particular:

 - https://pypi.openrefactory.com/scipy/62f53252fe6732ccd95a45ca#Inappropriate%20Logic-27M

 > In file: _distn_infrastructure.py, method: isf, a logical equality
 > check operation was performed with the same operand on both sides. The
 > comparison operation always returns either true or false. Such logical
 > short circuits in code lead to unintended behavior. iCR suggested that
 > the logical operation should be reviewed for correctness.

In particular the report is not totally accurate as `cond == cond` is a
quick way to create an all-True boolean array of the same size as cond,
and potentially quickly broadcast another array of different size.

Though in this particular 2 cases it seem that `q` and `cond`, or
`condX` and `cond` are anyway the same size, so my understanding is that
multiplying by `cond == cond` in those case is not necessary.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->