### PR TITLE
MAINT: Delay `pooch` import error for `scipy.datasets`

### DIFF
--- a/scipy/datasets/__init__.py
+++ b/scipy/datasets/__init__.py
@@ -63,23 +63,6 @@ the above mentioned cache directory to avoid fetching dataset errors without
 the internet connectivity.
 
 """
-import warnings
-
-try:
-    # https://github.com/scipy/scipy/pull/15607#issuecomment-1176457275
-    # TODO: Remove warning filter after next certifi release
-    with warnings.catch_warnings():
-        warnings.filterwarnings('ignore', category=DeprecationWarning)
-        import pooch
-except ImportError:
-    pooch = None
-
-msg = (
-    "Missing optional dependency 'pooch' required for scipy.datasets module. "
-    "Please use pip or conda to install 'pooch'."
-)
-if pooch is None:
-    raise ImportError(msg)
 
 
 from ._fetchers import face, ascent, electrocardiogram  # noqa: E402

--- a/scipy/datasets/tests/test_data.py
+++ b/scipy/datasets/tests/test_data.py
@@ -1,18 +1,23 @@
 from scipy.datasets._registry import registry
-from scipy.datasets._fetchers import data
+from scipy.datasets._fetchers import fetch_data, data_fetcher
 from scipy.datasets import ascent, face, electrocardiogram
 from numpy.testing import assert_equal, assert_almost_equal, suppress_warnings
 import os
 import pytest
 
+try:
+    # https://github.com/scipy/scipy/pull/15607#issuecomment-1176457275
+    # TODO: Remove warning filter after next certifi release
+    with suppress_warnings() as sup:
+        sup.filter(category=DeprecationWarning)
+        import pooch
+except ImportError:
+    raise ImportError("Missing optional dependency 'pooch' required "
+                      "for scipy.datasets module. Please use pip or "
+                      "conda to install 'pooch'.")
 
-data_dir = data.path
 
-# https://github.com/scipy/scipy/pull/15607#issuecomment-1176457275
-# TODO: Remove warning filter after next certifi release
-with suppress_warnings() as sup:
-    sup.filter(category=DeprecationWarning)
-    import pooch
+data_dir = data_fetcher.path  # type: ignore
 
 
 def _has_hash(path, expected_hash):
@@ -30,7 +35,7 @@ class TestDatasets:
 
         # test_setup phase
         for dataset in registry:
-            data.fetch(dataset)
+            fetch_data(dataset)
 
         yield
 


### PR DESCRIPTION
#### Reference issue
See discussion from https://github.com/scipy/scipy/pull/15607#issuecomment-1215110575.

#### What does this implement/fix?
This will let users still do `from scipy import *` without raising an error, even though it is a bad practice. In case `pooch` is missing, an import error is only raised when a datasets method is called. Thanks @oscarbenjamin for suggesting the simple fix, this should not change anything else with `datasets` except for the error being postponed.

```python
# Earlier without pooch installed
from scipy import datasets  # raises ImportError
# Now without pooch installed
from scipy import datasets # doesn't raise 
datasets.face()  # but this will raise
```

cc @rgommers 
