### PR TITLE
Roadmap update: scipy.interpolate and Fortran libs

### DIFF
--- a/doc/source/dev/roadmap-detailed.rst
+++ b/doc/source/dev/roadmap-detailed.rst
@@ -148,12 +148,31 @@ complex-valued functions and integrating multiple intervals (see `gh-3325
 interpolate
 ```````````
 
-Ideas for new features:
+*Spline fitting*: we need spline fitting routines with better user control. This
+includes 
 
-- Spline fitting routines with better user control.
-- Transparent tensor-product splines.
-- NURBS support.
-- Mesh refinement and coarsening of B-splines and corresponding tensor products.
+- user-selectable alternatives for the smoothing criteria (manual,
+cross-validation etc); gh-16653 makes a start in this direction;
+- several strategies for knot placement, both manual and automatic (using
+algorithms by Dierckx, de Boor, etc). 
+
+Once we have a reasonably feature complete set, we can start taking a long look
+at the future of the venerable FITPACK Fortran library, which currently is the
+only way of constructing smoothing splines in SciPy.
+
+*Tensor-product splines*: `RegularGridInterpolator` provides a minimal
+implementation. We want to evolve it both for new features (e.g. derivatives),
+performance and API (possibly provide a transparent N-dimensional tensor-product
+B-spline object).
+
+*Scalability and performance*: For the FITPACK-based functionality, the data
+size is limited by 32-bit Fortran integer size, thus scaling requires having
+the ILP64 support in the Meson-based build system.
+For N-D scattered interpolators (which are QHull based) and N-D regular grid
+interpolators we need to check performance on large data sets and improve
+where lacking.
+
+*Ideas for new features*: NURBS support could be added.
 
 
 io

--- a/doc/source/dev/roadmap-detailed.rst
+++ b/doc/source/dev/roadmap-detailed.rst
@@ -86,6 +86,15 @@ help here, because it removes the monkey patching that is now done to enable
 Pythran).
 
 
+Use of venerable Fortran libraries
+``````````````````````````````````
+SciPy owes a lot of its success to relying on wrapping well established
+Fortran libraries (QUADPACK, FITPACK, ODRPACK, ODEPACK etc). Some of these
+libraries are aging well, others less so. We should audit our use of these
+libraries with respect to the maintenance effort, the functionality, and the
+existence of (possibly partial) alternatives, *including those inside SciPy*.
+
+
 Continuous integration
 ``````````````````````
 Continuous integration currently covers 32/64-bit Windows, macOS on x86-64, and

--- a/doc/source/dev/roadmap-detailed.rst
+++ b/doc/source/dev/roadmap-detailed.rst
@@ -160,10 +160,11 @@ interpolate
 *Spline fitting*: we need spline fitting routines with better user control. This
 includes 
 
-- user-selectable alternatives for the smoothing criteria (manual,
-cross-validation etc); gh-16653 makes a start in this direction;
-- several strategies for knot placement, both manual and automatic (using
-algorithms by Dierckx, de Boor, etc). 
+    - user-selectable alternatives for the smoothing criteria (manual,
+      cross-validation etc); gh-16653 makes a start in this direction;
+
+    - several strategies for knot placement, both manual and automatic (using
+      algorithms by Dierckx, de Boor, possibly other). 
 
 Once we have a reasonably feature complete set, we can start taking a long look
 at the future of the venerable FITPACK Fortran library, which currently is the
@@ -175,11 +176,10 @@ performance and API (possibly provide a transparent N-dimensional tensor-product
 B-spline object).
 
 *Scalability and performance*: For the FITPACK-based functionality, the data
-size is limited by 32-bit Fortran integer size, thus scaling requires having
-the ILP64 support in the Meson-based build system.
+size is limited by 32-bit Fortran integer size (for non-ILP64 builds).
 For N-D scattered interpolators (which are QHull based) and N-D regular grid
 interpolators we need to check performance on large data sets and improve
-where lacking.
+where lacking (gh-16483 makes progress in this direction).
 
 *Ideas for new features*: NURBS support could be added.
 


### PR DESCRIPTION
- update the roadmap for the scipy.interpolate subpackage
- add a brief suggestion to audit the use of venerable Fortran libs (prompted by the discussion of Ralf's *personal musing* at https://discuss.scientific-python.org/t/releasing-or-not-32-bit-windows-wheels/282)

As an aside, the more I look at the split between *the roadmap* and *the detailed roadmap*, the more it feels like these two documents could well be two sections of just TheRoadmap, but that's certainly not a part of this PR.