### PR TITLE
DOC: interpolate: add default spline degree value for `InterpolatedUnivariateSpline`

### DIFF
--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -628,7 +628,7 @@ class InterpolatedUnivariateSpline(UnivariateSpline):
         None (default), ``bbox=[x[0], x[-1]]``.
     k : int, optional
         Degree of the smoothing spline.  Must be ``1 <= k <= 5``. Default is
-        ``k = 3`, a cubic spline.
+        ``k = 3``, a cubic spline.
     ext : int or str, optional
         Controls the extrapolation mode for elements
         not in the interval defined by the knot sequence.

--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -627,8 +627,8 @@ class InterpolatedUnivariateSpline(UnivariateSpline):
         2-sequence specifying the boundary of the approximation interval. If
         None (default), ``bbox=[x[0], x[-1]]``.
     k : int, optional
-        Degree of the smoothing spline.  Must be 1 <= `k` <= 5. Default is
-        `k` = 3, a cubic spline.
+        Degree of the smoothing spline.  Must be ``1 <= k <= 5``. Default is
+        ``k = 3`, a cubic spline.
     ext : int or str, optional
         Controls the extrapolation mode for elements
         not in the interval defined by the knot sequence.

--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -627,7 +627,8 @@ class InterpolatedUnivariateSpline(UnivariateSpline):
         2-sequence specifying the boundary of the approximation interval. If
         None (default), ``bbox=[x[0], x[-1]]``.
     k : int, optional
-        Degree of the smoothing spline.  Must be 1 <= `k` <= 5.
+        Degree of the smoothing spline.  Must be 1 <= `k` <= 5. Default is
+        `k` = 3, a cubic spline.
     ext : int or str, optional
         Controls the extrapolation mode for elements
         not in the interval defined by the knot sequence.


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Fix #14098 

#### What does this implement/fix?
<!--Please explain your changes.-->
I added the default spline degree value for `interpolatedUnivariateSpline` doc.
It is for consistency to `LSQUnivariateSpline` doc as reported in #14098:
https://github.com/scipy/scipy/blob/31351394351f944b9cf87c1fbc54213192cfe180/scipy/interpolate/fitpack2.py#L711-L713
Other docstrings seem consistent for me between `InterpolatedUnivariateSpline` and `LSQUnivariateSpline`.
#### Additional information
<!--Any additional information you think is important.-->

