### PR TITLE
ENH : remove an expected warning in BarycentricInterpolator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 .pydevproject
 *.rej
 .settings/
+.spyproject/
 .*.sw[nop]
 .sw[nop]
 *.tmp

--- a/scipy/interpolate/_polyint.py
+++ b/scipy/interpolate/_polyint.py
@@ -658,12 +658,12 @@ class BarycentricInterpolator(_Interpolator1D):
         if x.size == 0:
             p = np.zeros((0, self.r), dtype=self.dtype)
         else:
-            c = x[...,np.newaxis]-self.xi
+            c = x[..., np.newaxis] - self.xi
             z = c == 0
             c[z] = 1
             c = self.wi/c
             with np.errstate(divide='ignore'):
-                p = np.dot(c,self.yi)/np.sum(c,axis=-1)[...,np.newaxis]
+                p = np.dot(c, self.yi) / np.sum(c, axis=-1)[..., np.newaxis]
             # Now fix where x==some xi
             r = np.nonzero(z)
             if len(r) == 1:  # evaluation at a scalar

--- a/scipy/interpolate/_polyint.py
+++ b/scipy/interpolate/_polyint.py
@@ -662,7 +662,8 @@ class BarycentricInterpolator(_Interpolator1D):
             z = c == 0
             c[z] = 1
             c = self.wi/c
-            p = np.dot(c,self.yi)/np.sum(c,axis=-1)[...,np.newaxis]
+            with np.errstate(divide='ignore'):
+                p = np.dot(c,self.yi)/np.sum(c,axis=-1)[...,np.newaxis]
             # Now fix where x==some xi
             r = np.nonzero(z)
             if len(r) == 1:  # evaluation at a scalar


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
See [this comment](https://github.com/Parallel-in-Time/pySDC/issues/149#issuecomment-1213152948) on an other project.

#### What does this implement/fix?

It remove an expected warning when evaluating a BarycentricInterpolator object (see [here...](https://github.com/scipy/scipy/blob/59dac8a9fa9ea856f4a50521d295a3497d648faa/scipy/interpolate/_polyint.py#L657-L673)).  

The reason why : in the evaluation formula for the barycentric interpolation (see https://parallel-in-time.org/pySDC/pySDC/core.html#module-core.Lagrange), there is a division by zero when an evaluated point coincides with a node. It can be reproduced with the following code :

```python
from scipy.interpolate import BarycentricInterpolator
interp = BarycentricInterpolator([0, 1], [1, 2])
yi = interp(interp.xi)
```
which outputs :
```
/prog/anaconda/lib/python3.8/site-packages/scipy/interpolate/_polyint.py:658: RuntimeWarning: divide by zero encountered in true_divide
  p = np.dot(c,self.yi)/np.sum(c,axis=-1)[...,np.newaxis]
```

Since this division by zero is actually expected and the values corrected later, this PR wraps the line raising the warning with a `with np.errstate(divide='ignore'):` statement. 

#### Additional information

Spyder IDE specific files added to `.gitignore` 
