### PR TITLE
ENH: Modify scipy.optimize.least_squares to accept bounds of type Bounds

### DIFF
--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -283,11 +283,14 @@ def least_squares(
         (or the exact value) for the Jacobian as an array_like (np.atleast_2d
         is applied), a sparse matrix (csr_matrix preferred for performance) or
         a `scipy.sparse.linalg.LinearOperator`.
-    bounds : 2-tuple of array_like, optional
-        Lower and upper bounds on independent variables. Defaults to no bounds.
-        Each array must match the size of `x0` or be a scalar, in the latter
-        case a bound will be the same for all variables. Use ``np.inf`` with
-        an appropriate sign to disable bounds on all or some variables.
+    bounds : 2-tuple of array_like or `Bounds`, optional
+        There are two ways to specify bounds for methods 'trf' and 'dogbox':
+            1. Instance of `Bounds` class
+            2. Lower and upper bounds on independent variables. Defaults to no
+               bounds. Each array must match the size of `x0` or be a scalar,
+               in the latter case a bound will be the same for all variables.
+               Use ``np.inf`` with an appropriate sign to disable bounds on all
+               or some variables.
     method : {'trf', 'dogbox', 'lm'}, optional
         Algorithm to perform minimization.
 

--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -284,7 +284,7 @@ def least_squares(
         is applied), a sparse matrix (csr_matrix preferred for performance) or
         a `scipy.sparse.linalg.LinearOperator`.
     bounds : 2-tuple of array_like or `Bounds`, optional
-        There are two ways to specify bounds for methods 'trf' and 'dogbox':
+        There are two ways to specify bounds:
 
             1. Instance of `Bounds` class
             2. Lower and upper bounds on independent variables. Defaults to no

--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -285,6 +285,7 @@ def least_squares(
         a `scipy.sparse.linalg.LinearOperator`.
     bounds : 2-tuple of array_like or `Bounds`, optional
         There are two ways to specify bounds for methods 'trf' and 'dogbox':
+
             1. Instance of `Bounds` class
             2. Lower and upper bounds on independent variables. Defaults to no
                bounds. Each array must match the size of `x0` or be a scalar,

--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -784,6 +784,9 @@ def least_squares(
     if verbose not in [0, 1, 2]:
         raise ValueError("`verbose` must be in [0, 1, 2].")
 
+    if max_nfev is not None and max_nfev <= 0:
+        raise ValueError("`max_nfev` must be None or positive integer.")
+
     if np.iscomplexobj(x0):
         raise ValueError("`x0` must be real.")
 
@@ -800,9 +803,6 @@ def least_squares(
             lb, ub = prepare_bounds(bounds, x0.shape[0])
         else:
             raise ValueError("`bounds` must contain 2 elements.")
-
-    if max_nfev is not None and max_nfev <= 0:
-        raise ValueError("`max_nfev` must be None or positive integer.")
 
     if method == 'lm' and not np.all((lb == -np.inf) & (ub == np.inf)):
         raise ValueError("Method 'lm' doesn't support bounds.")

--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -415,20 +415,27 @@ class BoundsMixin:
             assert_(0.5 <= res.x <= 3)
 
     def test_bounds_shape(self):
+        bounds_direkt = lambda x: x
+        bounds_instances = lambda x: Bounds(x[0], x[1])
+
         for jac in ['2-point', '3-point', 'cs', jac_2d_trivial]:
-            x0 = [1.0, 1.0]
-            res = least_squares(fun_2d_trivial, x0, jac=jac)
-            assert_allclose(res.x, [0.0, 0.0])
-            res = least_squares(fun_2d_trivial, x0, jac=jac,
-                                bounds=(0.5, [2.0, 2.0]), method=self.method)
-            assert_allclose(res.x, [0.5, 0.5])
-            res = least_squares(fun_2d_trivial, x0, jac=jac,
-                                bounds=([0.3, 0.2], 3.0), method=self.method)
-            assert_allclose(res.x, [0.3, 0.2])
-            res = least_squares(
-                fun_2d_trivial, x0, jac=jac, bounds=([-1, 0.5], [1.0, 3.0]),
-                method=self.method)
-            assert_allclose(res.x, [0.0, 0.5], atol=1e-5)
+            for bounds_func in [bounds_direkt, bounds_instances]:
+                x0 = [1.0, 1.0]
+                res = least_squares(fun_2d_trivial, x0, jac=jac)
+                assert_allclose(res.x, [0.0, 0.0])
+                res = least_squares(fun_2d_trivial, x0, jac=jac,
+                                    bounds=bounds_func((0.5, [2.0, 2.0])),
+                                    method=self.method)
+                assert_allclose(res.x, [0.5, 0.5])
+                res = least_squares(fun_2d_trivial, x0, jac=jac,
+                                    bounds=bounds_func(([0.3, 0.2], 3.0)),
+                                    method=self.method)
+                assert_allclose(res.x, [0.3, 0.2])
+                res = least_squares(
+                    fun_2d_trivial, x0, jac=jac, 
+                    bounds=bounds_func(([-1, 0.5], [1.0, 3.0])),
+                    method=self.method)
+                assert_allclose(res.x, [0.0, 0.5], atol=1e-5)
 
     def test_bounds_instances(self):
         res = least_squares(fun_trivial, 0.5, bounds=Bounds())

--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -430,7 +430,7 @@ class BoundsMixin:
                 method=self.method)
             assert_allclose(res.x, [0.0, 0.5], atol=1e-5)
 
-    def test_bound_instances(self):
+    def test_bounds_instances(self):
         res = least_squares(fun_trivial, 0.5, bounds=Bounds())
         assert_allclose(res.x, 0.0, atol=1e-4)
 

--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -8,7 +8,7 @@ from pytest import raises as assert_raises
 from scipy.sparse import issparse, lil_matrix
 from scipy.sparse.linalg import aslinearoperator
 
-from scipy.optimize import least_squares
+from scipy.optimize import least_squares, Bounds
 from scipy.optimize._lsq.least_squares import IMPLEMENTED_LOSSES
 from scipy.optimize._lsq.common import EPS, make_strictly_feasible
 
@@ -429,6 +429,27 @@ class BoundsMixin:
                 fun_2d_trivial, x0, jac=jac, bounds=([-1, 0.5], [1.0, 3.0]),
                 method=self.method)
             assert_allclose(res.x, [0.0, 0.5], atol=1e-5)
+
+    def test_bound_instances(self):
+        res = least_squares(fun_trivial, 0.5, bounds=Bounds())
+        assert_allclose(res.x, 0.0, atol=1e-4)
+
+        res = least_squares(fun_trivial, 3.0, bounds=Bounds(lb=1.0))
+        assert_allclose(res.x, 1.0, atol=1e-4)
+
+        res = least_squares(fun_trivial, 0.5, bounds=Bounds(lb=-1.0, ub=1.0))
+        assert_allclose(res.x, 0.0, atol=1e-4)
+
+        res = least_squares(fun_trivial, -3.0, bounds=Bounds(ub=-1.0))
+        assert_allclose(res.x, -1.0, atol=1e-4)
+
+        res = least_squares(fun_2d_trivial, [0.5, 0.5],
+                            bounds=Bounds(lb=[-1.0, -1.0], ub=1.0))
+        assert_allclose(res.x, [0.0, 0.0], atol=1e-5)
+
+        res = least_squares(fun_2d_trivial, [0.5, 0.5],
+                            bounds=Bounds(lb=[0.1, 0.1]))
+        assert_allclose(res.x, [0.1, 0.1], atol=1e-5)
 
     def test_rosenbrock_bounds(self):
         x0_1 = np.array([-2.0, 1.0])

--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -435,7 +435,7 @@ class BoundsMixin:
                                     method=self.method)
                 assert_allclose(res.x, [0.3, 0.2])
                 res = least_squares(
-                    fun_2d_trivial, x0, jac=jac, 
+                    fun_2d_trivial, x0, jac=jac,
                     bounds=bounds_func([-1, 0.5], [1.0, 3.0]),
                     method=self.method)
                 assert_allclose(res.x, [0.0, 0.5], atol=1e-5)

--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -415,25 +415,28 @@ class BoundsMixin:
             assert_(0.5 <= res.x <= 3)
 
     def test_bounds_shape(self):
-        bounds_direkt = lambda x: x
-        bounds_instances = lambda x: Bounds(x[0], x[1])
+        def get_bounds_direct(lb, ub):
+            return lb, ub
+
+        def get_bounds_instances(lb, ub):
+            return Bounds(lb, ub)
 
         for jac in ['2-point', '3-point', 'cs', jac_2d_trivial]:
-            for bounds_func in [bounds_direkt, bounds_instances]:
+            for bounds_func in [get_bounds_direct, get_bounds_instances]:
                 x0 = [1.0, 1.0]
                 res = least_squares(fun_2d_trivial, x0, jac=jac)
                 assert_allclose(res.x, [0.0, 0.0])
                 res = least_squares(fun_2d_trivial, x0, jac=jac,
-                                    bounds=bounds_func((0.5, [2.0, 2.0])),
+                                    bounds=bounds_func(0.5, [2.0, 2.0]),
                                     method=self.method)
                 assert_allclose(res.x, [0.5, 0.5])
                 res = least_squares(fun_2d_trivial, x0, jac=jac,
-                                    bounds=bounds_func(([0.3, 0.2], 3.0)),
+                                    bounds=bounds_func([0.3, 0.2], 3.0),
                                     method=self.method)
                 assert_allclose(res.x, [0.3, 0.2])
                 res = least_squares(
                     fun_2d_trivial, x0, jac=jac, 
-                    bounds=bounds_func(([-1, 0.5], [1.0, 3.0])),
+                    bounds=bounds_func([-1, 0.5], [1.0, 3.0]),
                     method=self.method)
                 assert_allclose(res.x, [0.0, 0.5], atol=1e-5)
 


### PR DESCRIPTION
#### What does this implement/fix?
Modified `least_squares` function to accept instances of type `Bounds` for the `bounds` parameter.

I wanted to interchange the functions `optimize.minimize` and `optimize.least_squares` easily, but unfortunately the array shape needed for bounds is transposed for these two functions.
`optimize.minimize` also accepts instances of `Bounds`, so I thought this would be a quick fix to use both methods with the same `Bounds` variable.