### PR TITLE
DOC: interpolate: improve spline smoothing parameter docs.

### DIFF
--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -84,7 +84,7 @@ class UnivariateSpline:
         1-D array of dependent input data, of the same length as `x`.
     w : (N,) array_like, optional
         Weights for spline fitting.  Must be positive.  If `w` is None,
-        weights are all equal. Default is None.
+        weights are all 1. Default is None.
     bbox : (2,) array_like, optional
         2-sequence specifying the boundary of the approximation interval. If
         `bbox` is None, ``bbox=[x[0], x[-1]]``. Default is None.
@@ -97,9 +97,20 @@ class UnivariateSpline:
 
             sum((w[i] * (y[i]-spl(x[i])))**2, axis=0) <= s
 
-        If `s` is None, ``s = len(w)`` which should be a good value if
-        ``1/w[i]`` is an estimate of the standard deviation of ``y[i]``.
-        If 0, spline will interpolate through all data points. Default is None.
+        If `s` is None, `s` will be set as `len(w)` for a smoothing spline
+        that uses all data points.
+        If 0, spline will interpolate through all data points. This is
+        equivalent to `InterpolatedUnivariateSpline`.
+        Default is None.
+        The user can use the `s` to control the tradeoff between closeness
+        and smoothness of fit. Larger `s` means more smoothing while smaller
+        values of `s` indicate less smoothing.
+        Recommended values of `s` depend on the weights, `w`. If the weights
+        represent the inverse of the standard-deviation of `y`, then a good
+        `s` value should be found in the range (m-sqrt(2*m),m+sqrt(2*m))
+        where m is the number of datapoints in `x`, `y`, and `w`. This means
+        ``s = len(w)`` should be a good value if ``1/w[i]`` is an
+        estimate of the standard deviation of ``y[i]``.
     ext : int or str, optional
         Controls the extrapolation mode for elements
         not in the interval defined by the knot sequence.
@@ -612,7 +623,7 @@ class InterpolatedUnivariateSpline(UnivariateSpline):
 
     Fits a spline y = spl(x) of degree `k` to the provided `x`, `y` data.
     Spline function passes through all provided points. Equivalent to
-    `UnivariateSpline` with  s=0.
+    `UnivariateSpline` with  `s` = 0.
 
     Parameters
     ----------
@@ -622,7 +633,7 @@ class InterpolatedUnivariateSpline(UnivariateSpline):
         input dimension of data points
     w : (N,) array_like, optional
         Weights for spline fitting.  Must be positive.  If None (default),
-        weights are all equal.
+        weights are all 1.
     bbox : (2,) array_like, optional
         2-sequence specifying the boundary of the approximation interval. If
         None (default), ``bbox=[x[0], x[-1]]``.
@@ -740,7 +751,7 @@ class LSQUnivariateSpline(UnivariateSpline):
 
     w : (N,) array_like, optional
         weights for spline fitting. Must be positive. If None (default),
-        weights are all equal.
+        weights are all 1.
     bbox : (2,) array_like, optional
         2-sequence specifying the boundary of the approximation interval. If
         None (default), ``bbox = [x[0], x[-1]]``.


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Fix #4975
Fix #11916

#### What does this implement/fix?
<!--Please explain your changes.-->
As reported in #4975 and  #11916,  smoothing parameter docs of FITPACK spline functions can be improved.

This PR improves 3 points:
1. state clearly `w` is all 1 in default
2. state clearly when `s` is None, it is for smoothing, when `s` is 0, it is for interpolation.
3. Enhance `s` tuning information based on `interpolate.splrep` docs here:
https://github.com/scipy/scipy/blob/8ac08076584b7af12a7c71b9fd7c435a2702fd9a/scipy/interpolate/_fitpack_py.py#L192-L203
 
#### Additional information
<!--Any additional information you think is important.-->
