### PR TITLE
BUG, DOC: Fix sphinx autosummary generation for `odr` and `czt`

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -256,6 +256,16 @@ np_docscrape.ClassDoc.extra_public_methods = [  # should match class.rst
 
 autosummary_generate = True
 
+# maps functions with a name same as a class name that is indistinguishable
+# Ex: scipy.signal.czt and scipy.signal.CZT or scipy.odr.odr and scipy.odr.ODR
+# Otherwise, the stubs are overwritten when the name is same for
+# OS (like MacOS) which has a filesystem that ignores the case
+# See https://github.com/sphinx-doc/sphinx/pull/7927
+autosummary_filename_map = {
+    "scipy.odr.odr": "odr-function",
+    "scipy.signal.czt": "czt-function",
+}
+
 
 # -----------------------------------------------------------------------------
 # Autodoc


### PR DESCRIPTION
#### Issue

When building SciPy Docs on an OS which doesn't distinguish between filenames having same name but different case (Eg: MacOS) get the following warnings and failure:

<details>
  <summary>Click to expand: Failing doc build on MacOS</summary>

  ```bash
/Users/gollum/Desktop/Work/scipy/build-install/lib/python3.10/site-packages/scipy/odr/__init__.py:docstring of scipy.odr:10: WARNING: autosummary: stub file not found 'scipy.odr.odr'. Check your autosummary_generate setting.
/Users/gollum/Desktop/Work/scipy/build-install/lib/python3.10/site-packages/scipy/signal/__init__.py:docstring of scipy.signal:293: WARNING: autosummary: stub file not found 'scipy.signal.czt'. Check your autosummary_generate setting.
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] tutorial/stats/sampling_tdr
docstring of _odrpack.odr:16: WARNING: py:obj reference target not found: ODR
docstring of _odrpack.odr:28: WARNING: py:obj reference target not found: ODR
/Users/gollum/Desktop/Work/scipy/build-install/lib/python3.10/site-packages/scipy/signal/_czt.py:docstring of scipy.signal._czt.czt:41: WARNING: py:obj reference target not found: CZT
/Users/gollum/Desktop/Work/scipy/build-install/lib/python3.10/site-packages/scipy/signal/_czt.py:docstring of scipy.signal._czt.czt:53: WARNING: py:obj reference target not found: CZT
/Users/gollum/Desktop/Work/scipy/build-install/lib/python3.10/site-packages/scipy/signal/_czt.py:docstring of scipy.signal._czt.ZoomFFT:4: WARNING: py:obj reference target not found: CZT
/Users/gollum/Desktop/Work/scipy/build-install/lib/python3.10/site-packages/scipy/signal/_czt.py:docstring of scipy.signal._czt.czt_points:20: WARNING: py:obj reference target not found: CZT
/Users/gollum/Desktop/Work/scipy/build-install/lib/python3.10/site-packages/scipy/signal/_czt.py:docstring of scipy.signal._czt.czt_points:32: WARNING: py:obj reference target not found: CZT
/Users/gollum/Desktop/Work/scipy/build-install/lib/python3.10/site-packages/scipy/odr/__init__.py:docstring of scipy.odr:29:<autosummary>:1: WARNING: py:obj reference target not found: scipy.odr.ODR
/Users/gollum/Desktop/Work/scipy/build-install/lib/python3.10/site-packages/scipy/signal/__init__.py:docstring of scipy.signal:301:<autosummary>:1: WARNING: py:obj reference target not found: scipy.signal.CZT
release/1.6.0-notes.rst:47: WARNING: py:obj reference target not found: scipy.odr.ODR
release/1.8.0-notes.rst:113: WARNING: py:obj reference target not found: scipy.signal.CZT
  ```
</details>

This is due to the stubs being overwritten. Surprisingly this was never reported before. Maybe because all devs are building on linux?

Note that this doesn't occur in the CI because the docs are built on Linux where it is fine to have the same name for `scipy.signal.czt`/`scipy.odr.odr` method and `scipy.signal.CZT`/`scipy.odr.ODR` class because the filesystem respects the different case.

#### What does this implement/fix?
In https://github.com/sphinx-doc/sphinx/pull/7927, a new config value called [`autosummary_filename_map`](https://www.sphinx-doc.org/en/master/usage/extensions/autosummary.html#confval-autosummary_filename_map) was added (requires sphinx>=3.2) which is utilized here to fix the problem.

After more than 3 months of not being able to build SciPy docs, I can finally build them locally on my mac. 😁 

#### Additional Information
Related Issues: https://github.com/sphinx-doc/sphinx/issues/2024 https://github.com/sphinx-doc/sphinx/issues/4874

cc @melissawm @tupui @rgommers 