### PR TITLE
DOC: stats: Some updates:

### DIFF
--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -1902,6 +1902,7 @@ def tukey_hsd(*args):
     Here are some data comparing the time to relief of three brands of
     headache medicine, reported in minutes. Data adapted from [3]_.
 
+    >>> import numpy as np
     >>> from scipy.stats import tukey_hsd
     >>> group0 = [24.5, 23.5, 26.4, 27.1, 29.9]
     >>> group1 = [28.4, 34.2, 29.5, 32.2, 30.1]

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -311,7 +311,7 @@ def kstat(data, n=2):
     elif n == 4:
         return ((-6*S[1]**4 + 12*N*S[1]**2 * S[2] - 3*N*(N-1.0)*S[2]**2 -
                  4*N*(N+1)*S[1]*S[3] + N*N*(N+1)*S[4]) /
-                 (N*(N-1.0)*(N-2.0)*(N-3.0)))
+                (N*(N-1.0)*(N-2.0)*(N-3.0)))
     else:
         raise ValueError("Should not be here.")
 
@@ -3759,6 +3759,11 @@ def circmean(samples, high=2*pi, low=0, axis=None, nan_policy='propagate'):
     circmean : float
         Circular mean.
 
+    See Also
+    --------
+    circstd : Circular standard deviation.
+    circvar : Circular variance.
+
     Examples
     --------
     For simplicity, all angles are printed out in degrees.
@@ -3845,6 +3850,11 @@ def circvar(samples, high=2*pi, low=0, axis=None, nan_policy='propagate'):
     -------
     circvar : float
         Circular variance.
+
+    See Also
+    --------
+    circmean : Circular mean.
+    circstd : Circular standard deviation.
 
     Notes
     -----
@@ -3935,6 +3945,11 @@ def circstd(samples, high=2*pi, low=0, axis=None, nan_policy='propagate', *,
     -------
     circstd : float
         Circular standard deviation.
+
+    See Also
+    --------
+    circmean : Circular mean.
+    circvar : Circular variance.
 
     Notes
     -----

--- a/scipy/stats/contingency.py
+++ b/scipy/stats/contingency.py
@@ -53,11 +53,13 @@ def margins(a):
 
     Examples
     --------
+    >>> import numpy as np
+    >>> from scipy.stats.contingency import margins
+
     >>> a = np.arange(12).reshape(2, 6)
     >>> a
     array([[ 0,  1,  2,  3,  4,  5],
            [ 6,  7,  8,  9, 10, 11]])
-    >>> from scipy.stats.contingency import margins
     >>> m0, m1 = margins(a)
     >>> m0
     array([[15],
@@ -109,6 +111,7 @@ def expected_freq(observed):
 
     Examples
     --------
+    >>> import numpy as np
     >>> from scipy.stats.contingency import expected_freq
     >>> observed = np.array([[10, 10, 20],[20, 20, 20]])
     >>> expected_freq(observed)
@@ -205,11 +208,11 @@ def chi2_contingency(observed, correction=True, lambda_=None):
     This function does not handle masked arrays, because the calculation
     does not make sense with missing values.
 
-    Like stats.chisquare, this function computes a chi-square statistic;
-    the convenience this function provides is to figure out the expected
-    frequencies and degrees of freedom from the given contingency table.
-    If these were already known, and if the Yates' correction was not
-    required, one could use stats.chisquare.  That is, if one calls::
+    Like `scipy.stats.chisquare`, this function computes a chi-square
+    statistic; the convenience this function provides is to figure out the
+    expected frequencies and degrees of freedom from the given contingency
+    table. If these were already known, and if the Yates' correction was not
+    required, one could use `scipy.stats.chisquare`.  That is, if one calls::
 
         res = chi2_contingency(obs, correction=False)
 
@@ -235,6 +238,7 @@ def chi2_contingency(observed, correction=True, lambda_=None):
     --------
     A two-way example (2 x 3):
 
+    >>> import numpy as np
     >>> from scipy.stats import chi2_contingency
     >>> obs = np.array([[10, 10, 20], [20, 20, 20]])
     >>> res = chi2_contingency(obs)
@@ -372,6 +376,7 @@ def association(observed, method="cramer", correction=False, lambda_=None):
     --------
     An example with a 4x2 contingency table:
 
+    >>> import numpy as np
     >>> from scipy.stats.contingency import association
     >>> obs4x2 = np.array([[100, 150], [203, 322], [420, 700], [320, 210]])
 


### PR DESCRIPTION
* Add 'See Also' section for circmean, circvar and circstd.
* Add 'import numpy as np' where needed in stats function.
* Fix function names in backticks in the chi2_contingency docstring
  so the links are generated correctly.
