### PR TITLE
DEP, DOC: Show deprecated methods in docs and fix overwriting with `_deprecated`

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -299,6 +299,12 @@ coverage_ignore_c_items = {}
 #------------------------------------------------------------------------------
 
 plot_pre_code = """
+import warnings
+for key in (
+        'gilbrat'  # misspelling for gibrat and has been deprecated
+        ):
+    warnings.filterwarnings(action='ignore', message='.*' + key + '.*')
+
 import numpy as np
 np.random.seed(123)
 """

--- a/scipy/_lib/deprecation.py
+++ b/scipy/_lib/deprecation.py
@@ -18,7 +18,7 @@ def _deprecated(msg, stacklevel=2):
             warnings.warn(msg, category=DeprecationWarning,
                           stacklevel=stacklevel)
             return fun(*args, **kwargs)
-        call.__doc__ = msg
+        call.__doc__ = fun.__doc__
         return call
 
     return wrap

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -817,9 +817,9 @@ def kulsinski(u, v, w=None):
     :math:`k < n`.
 
     .. deprecated:: 0.12.0
-        Kulsinski has been deprecated from `scipy.spatial.distance` in
+        `kulsinski` has been deprecated from `scipy.spatial.distance` in
         SciPy 1.9.0 and it will be removed in SciPy 1.11.0. It is superseded
-        by scipy.spatial.distance.kulczynski1.
+        by `scipy.spatial.distance.kulczynski1`.
 
     Parameters
     ----------

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -60,6 +60,7 @@ computing the distances between all pairs.
    dice             -- the Dice dissimilarity.
    hamming          -- the Hamming distance.
    jaccard          -- the Jaccard distance.
+   kulsinski        -- the Kulsinski distance.
    kulczynski1      -- the Kulczynski 1 distance.
    rogerstanimoto   -- the Rogers-Tanimoto dissimilarity.
    russellrao       -- the Russell-Rao dissimilarity.

--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -86,6 +86,7 @@ Continuous distributions
    genhyperbolic     -- Generalized Hyperbolic
    geninvgauss       -- Generalized Inverse Gaussian
    gibrat            -- Gibrat
+   gilbrat           -- Gilbrat
    gompertz          -- Gompertz (Truncated Gumbel)
    gumbel_r          -- Right Sided Gumbel, Log-Weibull, Fisher-Tippett, Extreme Value Type I
    gumbel_l          -- Left Sided Gumbel, etc.

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -5668,6 +5668,14 @@ deprmsg = ("`gilbrat` is a misspelling of the correct name for the `gibrat` "
 class gilbrat_gen(gibrat_gen):
     # override __call__ protocol from rv_generic to also
     # deprecate instantiation of frozen distributions
+    r"""
+
+    .. deprecated:: 1.9.0
+        `gilbrat` is deprecated, use `gibrat` instead!
+        `gilbrat` is a misspelling of the correct name for the `gibrat`
+        distribution, and will be removed in SciPy 1.11.
+
+    """
     def __call__(self, *args, **kwds):
         # align with warning text from np.deprecated that's used for methods
         msg = "`gilbrat` is deprecated, use `gibrat` instead!\n" + deprmsg

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -2701,7 +2701,7 @@ def binom_test(x, n=None, p=0.5, alternative='two-sided'):
     is `p`.
 
     .. deprecated:: 1.10.0
-        'binom_test' is deprecated in favour of 'binomtest' and will
+        `binom_test` is deprecated in favour of `binomtest` and will
         be removed in Scipy 1.12.0.
 
     Parameters

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -119,7 +119,6 @@ DOCTEST_SKIPLIST = set([
     'scipy.stats.kstwobign',  # inaccurate cdf or ppf
     'scipy.stats.levy_stable',
     'scipy.special.sinc',  # comes from numpy
-    'scipy.misc.who',  # comes from numpy
     'scipy.optimize.show_options',
     'io.rst',   # XXX: need to figure out how to deal w/ mat files
 ])
@@ -129,7 +128,6 @@ DOCTEST_SKIPLIST = set([
 REFGUIDE_ALL_SKIPLIST = [
     r'scipy\.sparse\.csgraph',
     r'scipy\.sparse\.linalg',
-    r'scipy\.spatial\.distance',
     r'scipy\.linalg\.blas\.[sdczi].*',
     r'scipy\.linalg\.lapack\.[sdczi].*',
 ]


### PR DESCRIPTION
#### Reference issue
#16846 

#### What does this implement/fix?
- Fix overwriting of docs by only a plain deprecation warning after the usage of `scipy._lib.deprecation._deprecated`. Now the complete docstring is utilized and one must create a deprecated directive to show the warninng.
- Add back `gilbrat` and `kulsinski` to the documentation with appropriate deprecation warning at the top of the docs. Users can follow the suggested alternate method from the deprecation warning (the links should be clickable after soon upgrading to `pydata-sphinx-theme>=0.10.0`). Note that the removal of  `NumericalInverseHermite` is set for SciPy 1.10.0, hence it is ok to remove it from the toctree. (these were removed in https://github.com/scipy/scipy/pull/16273)
- All deprecated methods running examples with plotting can be added to `plot_pre_code` warning filtering list in `conf.py`. #15901 will follow the same pattern to avoid [failure](https://app.circleci.com/pipelines/github/scipy/scipy/14934/workflows/a84ad115-b46f-41f3-a29a-3a0f7c7e9845/jobs/53157?invite=true#step-104-57) of the plot directive. Any docstring example with plotting which uses a deprecation function in the future should be added to this list.