### PR TITLE
MAINT: interpolate: remove duplicated `splint` from `dfitpack`

### DIFF
--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -433,7 +433,7 @@ class UnivariateSpline:
         0.0
 
         """
-        return dfitpack.splint(*(self._eval_args+(a, b)))
+        return _fitpack_impl.splint(a, b, self._eval_args, full_output=0)
 
     def derivatives(self, x):
         """ Return all derivatives of the spline at the point x.

--- a/scipy/interpolate/src/fitpack.pyf
+++ b/scipy/interpolate/src/fitpack.pyf
@@ -140,19 +140,6 @@ static F_INT calc_regrid_lwrk(F_INT mx, F_INT my, F_INT kx, F_INT ky,
        integer intent(hide) :: ier
      end subroutine splder
 
-     function splint(t,n,c,k,a,b,wrk)
-       ! iy = splint(t,c,k,a,b)
-       threadsafe
-       real*8 dimension(n),intent(in) :: t
-       integer intent(hide),depend(t) :: n=len(t)
-       real*8 dimension(n),depend(n),check(len(c)==n) :: c
-       integer intent(in) :: k
-       real*8 intent(in) :: a
-       real*8 intent(in) :: b
-       real*8 dimension(n),depend(n),intent(cache,hide) :: wrk
-       real*8 :: splint
-     end function splint
-
      subroutine sproot(t,n,c,zero,mest,m,ier)
        ! zero,m,ier = sproot(t,c[,mest])
        threadsafe


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
A part of #16729
This is another option of #16932

#### What does this implement/fix?
<!--Please explain your changes.-->
As reported in #16729, _fitpack and dfitpack have some dupricated interfaces of FITPACK.
This PR focuses on `splint` and remove the dfitpack interface because _fitpack interface is used more places in scipy code base and it is used in some test codes, and it can return not only integral value, also an array of integrals, 
https://github.com/scipy/scipy/blob/dbd667afd695b5411a9f7f9bca6bd98d5ba221f3/scipy/interpolate/_fitpack_impl.py#L603-L661
`UnivarateSpline.integral` which is changed in this PR already has some unit tests and ref_guide tests, but let me know if we should add additional tests.


#### Additional information
<!--Any additional information you think is important.-->
