### PR TITLE
BUG: interpolate: work array sizes for RectSphereBivariateSpline

### DIFF
--- a/scipy/interpolate/src/fitpack.pyf
+++ b/scipy/interpolate/src/fitpack.pyf
@@ -685,7 +685,7 @@ static F_INT calc_regrid_lwrk(F_INT mx, F_INT my, F_INT kx, F_INT ky,
        real*8 optional :: r1
        real*8 optional,check(0.0<=s) :: s = 0.0
        integer intent(hide),depend(mu),check(nuest>=8) &
-            :: nuest = mu+6
+            :: nuest = mu+6+2
        integer intent(hide),depend(mv),check(nvest>=8) &
             :: nvest = mv+7
        integer intent(out) :: nu

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -1236,6 +1236,20 @@ class TestRectSphereBivariateSpline:
                         [-49.0625, -46.54315]])
         assert_array_almost_equal(data_interp, ans)
 
+    def test_pole_continuity_gh_14591(self):
+        # regression test for https://github.com/scipy/scipy/issues/14591
+        # with pole_continuty=(True, True), the internal work array size
+        # was too small, leading to a FITPACK data validation error.
+
+        # The reproducer in gh-14591 was using a NetCDF4 file with
+        # 361x507 arrays, so here we trivialize array sizes to a minimum
+        # which still demonstrates the issue.
+        u = np.arange(1, 10) * np.pi / 10
+        v = np.arange(1, 10) * np.pi / 10
+        r = np.zeros((9, 9))
+        for p in [(True, True), (True, False), (False, False)]:
+            RectSphereBivariateSpline(u, v, r, s=0, pole_continuity=p)
+
 
 def _numdiff_2d(func, x, y, dx=0, dy=0, eps=1e-8):
     if dx == 0 and dy == 0:


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

closes gh-14591

#### What does this implement/fix?
<!--Please explain your changes.-->

Make sure that `nuest` parameter is large enough when `s=0` and `pole_continuity=(True, True)`. This value translates to
`iopt(2) = iopt(3) = 1` in the FITPACK routine `spgrid.f`.
This routine contains the following comment:

      c  nuest : integer. unchanged on exit.
      c  nvest : integer. unchanged on exit.
      c          on entry, nuest and nvest must specify an upper bound for the
      c          number of knots required in the u- and v-directions respect.
      c          these numbers will also determine the storage space needed by
      c          the routine. nuest >= 8, nvest >= 8.
      c          in most practical situation nuest = mu/2, nvest=mv/2, will
      c          be sufficient. always large enough are nuest=mu+6+iopt(2)+
      c          iopt(3), nvest = mv+7, the number of knots needed for
      c          interpolation (s=0).

Therefore, we set in the f2py wrappers `nuest = mu+6+2`, which is the maximum needed: each `iopt` array element is at most 1.

#### Additional information
<!--Any additional information you think is important.-->

The fix is precisely what @rkern suggested in https://github.com/scipy/scipy/issues/14591#issuecomment-938762699
