### PR TITLE
MAINT: stats.multinomial: don't alter p[-1] when p[:-1].sum() is nearly 1

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -3079,14 +3079,16 @@ class multinomial_gen(multi_rv_generic):
         """
         return multinomial_frozen(n, p, seed)
 
-    def _process_parameters(self, n, p):
+    def _process_parameters(self, n, p, eps=1e-15):
         """Returns: n_, p_, npcond.
 
         n_ and p_ are arrays of the correct shape; npcond is a boolean array
         flagging values out of the domain.
         """
         p = np.array(p, dtype=np.float64, copy=True)
-        p[..., -1] = 1. - p[..., :-1].sum(axis=-1)
+        p_adjusted = 1. - p[..., :-1].sum(axis=-1)
+        i_adjusted = np.abs(p_adjusted) > eps
+        p[i_adjusted, -1] = p_adjusted[i_adjusted]
 
         # true for bad p
         pcond = np.any(p < 0, axis=-1)

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -1295,6 +1295,20 @@ class TestMultinomial:
         assert_allclose(mn_frozen.logpmf(x), multinomial.logpmf(x, n, pvals))
         assert_allclose(mn_frozen.entropy(), multinomial.entropy(n, pvals))
 
+    def test_gh_11860(self):
+        # gh-11860 reported cases in which the adjustments made by multinomial
+        # to the last element of `p` can cause `nan`s even when the input is
+        # essentially valid. Check that a pathological case returns a finite,
+        # nonzero result. (This would fail in main before the PR.)
+        n = 88
+        rng = np.random.default_rng(8879715917488330089)
+        p = rng.random(n)
+        p[-1] = 1e-30
+        p /= np.sum(p)
+        x = np.ones(n)
+        logpmf = multinomial.logpmf(x, n, p)
+        assert np.isfinite(logpmf)
+
 class TestInvwishart:
     def test_frozen(self):
         # Test that the frozen and non-frozen inverse Wishart gives the same


### PR DESCRIPTION
#### Reference issue
Closes gh-11860

#### What does this implement/fix?
The documentation of [`stats.multinomial`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.multinomial.html) states:

> *n* should be a positive integer. Each element of p should be in the interval $[0, 1]$ and the elements should sum to 1. If they do not sum to 1, the last element of the p array is not used and is replaced with the remaining probability left over from the earlier elements.

The problem is that sometimes - even when the sum of the other elements is equal to 1 - that last element can be assigned a small, negative value, which raises a flag that makes the output NaN. 

A few possibilities for how to deal with this were considered, including normalizing the input array (which doesn't always work) and otherwise altering how the values are manipulated. In the end, I think the best thing to do is just not mess with the last element when `p` is already nearly normalized. This is the solution implemented in this PR.

#### Additional information
It would be better if we *never* altered the input array, but I don't think it's worth the time to do a deprecation cycle on this behavior.

I added a test that is more concise than the original examples, but please test this PR by confirming that it addresses the original examples, too. Also, please check that the simplified unit test fails on `main` on your platform.
