### PR TITLE
DOC: signal: Add 'Examples' to the 'normalize' docstring.

### DIFF
--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -273,7 +273,8 @@ def freqs_zpk(z, p, k, worN=200):
     return w, h
 
 
-def freqz(b, a=1, worN=512, whole=False, plot=None, fs=2*pi, include_nyquist=False):
+def freqz(b, a=1, worN=512, whole=False, plot=None, fs=2*pi,
+          include_nyquist=False):
     """
     Compute the frequency response of a digital filter.
 
@@ -323,8 +324,9 @@ def freqz(b, a=1, worN=512, whole=False, plot=None, fs=2*pi, include_nyquist=Fal
 
         .. versionadded:: 1.2.0
     include_nyquist : bool, optional
-        If `whole` is False and `worN` is an integer, setting `include_nyquist` to True
-        will include the last frequency (Nyquist frequency) and is otherwise ignored.
+        If `whole` is False and `worN` is an integer, setting `include_nyquist`
+        to True will include the last frequency (Nyquist frequency) and is
+        otherwise ignored.
 
         .. versionadded:: 1.5.0
 
@@ -443,7 +445,8 @@ def freqz(b, a=1, worN=512, whole=False, plot=None, fs=2*pi, include_nyquist=Fal
         if N < 0:
             raise ValueError('worN must be nonnegative, got %s' % (N,))
         lastpoint = 2 * pi if whole else pi
-        # if include_nyquist is true and whole is false, w should include end point
+        # if include_nyquist is true and whole is false, w should
+        # include end point
         w = np.linspace(0, lastpoint, N, endpoint=include_nyquist and not whole)
         if (a.size == 1 and N >= b.shape[0] and
                 sp_fft.next_fast_len(N) == N and
@@ -2341,7 +2344,7 @@ def iirdesign(wp, ws, gpass, gstop, analog=False, ftype='ellip', output='ba',
         if not((ws[0] < wp[0] and wp[1] < ws[1]) or
                (wp[0] < ws[0] and ws[1] < wp[1])):
             raise ValueError("Passband must lie strictly inside stopband"
-                         " or vice versa")
+                             " or vice versa")
 
     band_type = 2 * (len(wp) - 1)
     band_type += 1
@@ -2549,8 +2552,8 @@ def iirfilter(N, Wn, rp=None, rs=None, btype='band', analog=False,
     if not analog:
         if numpy.any(Wn <= 0) or numpy.any(Wn >= 1):
             if fs is not None:
-                raise ValueError("Digital filter critical frequencies "
-                                 "must be 0 < Wn < fs/2 (fs={} -> fs/2={})".format(fs, fs/2))
+                raise ValueError("Digital filter critical frequencies must "
+                                 f"be 0 < Wn < fs/2 (fs={fs} -> fs/2={fs/2})")
             raise ValueError("Digital filter critical frequencies "
                              "must be 0 < Wn < 1")
         fs = 2.0
@@ -2561,7 +2564,8 @@ def iirfilter(N, Wn, rp=None, rs=None, btype='band', analog=False,
     # transform to lowpass, bandpass, highpass, or bandstop
     if btype in ('lowpass', 'highpass'):
         if numpy.size(Wn) != 1:
-            raise ValueError('Must specify a single critical frequency Wn for lowpass or highpass filter')
+            raise ValueError('Must specify a single critical frequency Wn '
+                             'for lowpass or highpass filter')
 
         if btype == 'lowpass':
             z, p, k = lp2lp_zpk(z, p, k, wo=warped)
@@ -2572,8 +2576,8 @@ def iirfilter(N, Wn, rp=None, rs=None, btype='band', analog=False,
             bw = warped[1] - warped[0]
             wo = sqrt(warped[0] * warped[1])
         except IndexError as e:
-            raise ValueError('Wn must specify start and stop frequencies for bandpass or bandstop '
-                             'filter') from e
+            raise ValueError('Wn must specify start and stop frequencies for '
+                             'bandpass or bandstop filter') from e
 
         if btype == 'bandpass':
             z, p, k = lp2bp_zpk(z, p, k, wo=wo, bw=bw)
@@ -4162,6 +4166,7 @@ def cheb2ord(wp, ws, gpass, gstop, analog=False, fs=None):
 
 _POW10_LOG10 = np.log(10)
 
+
 def _pow10m1(x):
     """10 ** x - 1 for x near 0"""
     return np.expm1(_POW10_LOG10 * x)
@@ -4413,6 +4418,7 @@ EPSILON = 2e-16
 # number of terms in solving degree equation
 _ELLIPDEG_MMAX = 7
 
+
 def _ellipdeg(n, m1):
     """Solve degree equation using nomes
 
@@ -4446,6 +4452,7 @@ def _ellipdeg(n, m1):
 # sequence.  10 is conservative; unit tests pass with 4, Orfanidis
 # (see _arc_jac_cn [1]) suggests 5.
 _ARC_JAC_SN_MAXITER = 10
+
 
 def _arc_jac_sn(w, m):
     """Inverse Jacobian elliptic sn
@@ -4884,7 +4891,8 @@ def besselap(N, norm='phase'):
            of the ACM, Vol. 10, Issue 2, pp. 107-108, Feb. 1967,
            :DOI:`10.1145/363067.363115`
     .. [6] Miller and Bohn, "A Bessel Filter Crossover, and Its Relation to
-           Others", RaneNote 147, 1998, https://www.ranecommercial.com/legacy/note147.html
+           Others", RaneNote 147, 1998,
+           https://www.ranecommercial.com/legacy/note147.html
 
     """
     if abs(int(N)) != N:

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -1680,6 +1680,34 @@ def normalize(b, a):
     Coefficients for both the numerator and denominator should be specified in
     descending exponent order (e.g., ``s^2 + 3s + 5`` would be represented as
     ``[1, 3, 5]``).
+
+    Examples
+    --------
+    >>> from scipy.signal import normalize
+
+    Normalize the coefficients of the transfer function
+    ``(3*s^2 - 2*s + 5) / (2*s^2 + 3*s + 1)``:
+
+    >>> b = [3, -2, 5]
+    >>> a = [2, 3, 1]
+    >>> normalize(b, a)
+    (array([ 1.5, -1. ,  2.5]), array([1. , 1.5, 0.5]))
+
+    A warning is generated if, for example, the first coefficient of
+    `b` is 0.  In the following example, the result is as expected:
+
+    >>> import warnings
+    >>> with warnings.catch_warnings(record=True) as w:
+    ...     num, den = normalize([0, 3, 6], [2, -5, 4])
+
+    >>> num
+    array([1.5, 3. ])
+    >>> den
+    array([ 1. , -2.5,  2. ])
+
+    >>> print(w[0].message)
+    Badly conditioned filter coefficients (numerator): the results may be meaningless
+
     """
     num, den = b, a
 

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -237,6 +237,7 @@ def freqs_zpk(z, p, k, worN=200):
 
     Examples
     --------
+    >>> import numpy as np
     >>> from scipy.signal import freqs_zpk, iirfilter
 
     >>> z, p, k = iirfilter(4, [1, 10], 1, 60, analog=True, ftype='cheby1',
@@ -543,6 +544,7 @@ def freqz_zpk(z, p, k, worN=512, whole=False, fs=2*pi):
     Design a 4th-order digital Butterworth filter with cut-off of 100 Hz in a
     system with sample rate of 1000 Hz, and plot the frequency response:
 
+    >>> import numpy as np
     >>> from scipy import signal
     >>> z, p, k = signal.butter(4, 100, output='zpk', fs=1000)
     >>> w, h = signal.freqz_zpk(z, p, k, fs=1000)
@@ -2274,7 +2276,7 @@ def iirdesign(wp, ws, gpass, gstop, analog=False, ftype='ellip', output='ba',
 
     Examples
     --------
-
+    >>> import numpy as np
     >>> from scipy import signal
     >>> import matplotlib.pyplot as plt
     >>> import matplotlib.ticker
@@ -2451,6 +2453,7 @@ def iirfilter(N, Wn, rp=None, rs=None, btype='band', analog=False,
     Generate a 17th-order Chebyshev II analog bandpass filter from 50 Hz to
     200 Hz and plot the frequency response:
 
+    >>> import numpy as np
     >>> from scipy import signal
     >>> import matplotlib.pyplot as plt
 
@@ -2644,6 +2647,7 @@ def bilinear_zpk(z, p, k, fs):
 
     Examples
     --------
+    >>> import numpy as np
     >>> from scipy import signal
     >>> import matplotlib.pyplot as plt
 
@@ -5045,6 +5049,7 @@ def iirpeak(w0, Q, fs=2.0):
     Design and plot filter to remove the frequencies other than the 300 Hz
     component from a signal sampled at 1000 Hz, using a quality factor Q = 30
 
+    >>> import numpy as np
     >>> from scipy import signal
     >>> import matplotlib.pyplot as plt
 
@@ -5437,7 +5442,6 @@ def gammatone(freq, ftype, order=None, numtaps=None, fs=None):
 
     IIR Gammatone filter centered at 440 Hz
 
-    >>> from scipy import signal
     >>> import matplotlib.pyplot as plt
     >>> import numpy as np
 


### PR DESCRIPTION
Also did a little maintenance while I was editing the file.

The new example unavoidably introduces a line longer than 79 characters in the docstring of `normalize`.  As penance, I've cleaned up a bunch of other egregious PEP-8 violations in the file :smile:.