### PR TITLE
MAINT: remove un-necessary all-true array.

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1048,7 +1048,7 @@ class burr_gen(rv_continuous):
             nc = 1. * n / c
             return d * sc.beta(1.0 - nc, d + nc)
         n, c, d = np.asarray(n), np.asarray(c), np.asarray(d)
-        return _lazywhere((c > n) & (n == n) & (d == d), (c, d, n),
+        return _lazywhere((c > n) & (d == d), (c, d, n),
                           lambda c, d, n: __munp(n, c, d),
                           np.nan)
 


### PR DESCRIPTION
`(n == n)` create an all-true array the shape of `n`,  it can be useful
in an expression to make sure the result is of the shape of `n`, but
here the subexpression of the left `(c > n)` is as far as I can tell
already of shape at least `n` as `n` is part of the expression.