### PR TITLE
MAINT: optimize.milp: fix input validation when three constraints are passed

### DIFF
--- a/scipy/optimize/_milp.py
+++ b/scipy/optimize/_milp.py
@@ -43,7 +43,7 @@ def _constraints_to_components(constraints):
             # argument could be a single tuple representing a LinearConstraint
             try:
                 constraints = [LinearConstraint(*constraints)]
-            except TypeError:
+            except (TypeError, ValueError, np.VisibleDeprecationWarning):
                 # argument was not a tuple representing a LinearConstraint
                 pass
 

--- a/scipy/optimize/tests/test_milp.py
+++ b/scipy/optimize/tests/test_milp.py
@@ -271,3 +271,28 @@ def test_infeasible_prob_16609():
     res = milp(c, integrality=integrality, bounds=bounds,
                constraints=constraints)
     np.testing.assert_equal(res.status, 2)
+
+
+def test_three_constraints_16878():
+    # `milp` failed when exactly three constraints were passed
+    # Ensure that this is no longer the case.
+    rng = np.random.default_rng(5123833489170494244)
+    A = rng.integers(0, 5, size=(6, 6))
+    bl = np.full(6, fill_value=-np.inf)
+    bu = np.full(6, fill_value=10)
+    constraints = [LinearConstraint(A[:2], bl[:2], bu[:2]),
+                   LinearConstraint(A[2:4], bl[2:4], bu[2:4]),
+                   LinearConstraint(A[4:], bl[4:], bu[4:])]
+    constraints2 = [(A[:2], bl[:2], bu[:2]),
+                    (A[2:4], bl[2:4], bu[2:4]),
+                    (A[4:], bl[4:], bu[4:])]
+    lb = np.zeros(6)
+    ub = np.ones(6)
+    variable_bounds = Bounds(lb, ub)
+    c = -np.ones(6)
+    res1 = milp(c, bounds=variable_bounds, constraints=constraints)
+    res2 = milp(c, bounds=variable_bounds, constraints=constraints2)
+    ref = milp(c, bounds=variable_bounds, constraints=(A, bl, bu))
+    assert res1.success and res2.success
+    assert_allclose(res1.x, ref.x)
+    assert_allclose(res2.x, ref.x)


### PR DESCRIPTION
#### Reference issue
Closes gh-16878 

#### What does this implement/fix?
`milp` failed when exactly three constraints were passed. The problem was that `milp` interpreted this as a tuple of inputs that represented a single `LinearConstraint`, and a single `LinearConstraint` object  was successfully created out of them, only to cause problems later. This fixes the problem by making `LinearConstraint`'s input validation stricter, raising an error in such cases. `milp` input validation detects the error, and then does the right thing with the three constraints.

#### Additional information
Let's see if CI lets me use `simplefilter` to cause warnings to `raise`...