### PR TITLE
DOC: improve installing from source instructions

### DIFF
--- a/doc/source/dev/contributor/building.rst
+++ b/doc/source/dev/contributor/building.rst
@@ -7,8 +7,8 @@ Building from sources
 
 .. note::
 
-   If you are only trying to install SciPy, see
-   `Installation <https://scipy.org/install>`__.
+   If you are only trying to install SciPy, we recommend using binaries - see
+   `Installation <https://scipy.org/install>`__ for details on that.
 
 Build instructions for different operating systems and an FAQ.
 
@@ -28,7 +28,7 @@ dependencies to build it on your system.
 .. tab-set::
 
   .. tab-item:: Linux
-  
+
     If you want to use the system Python and ``pip``, you will need:
 
     * C, C++, and Fortran compilers (typically ``gcc``, ``g++``, and ``gfortran``).
@@ -39,7 +39,7 @@ dependencies to build it on your system.
     * BLAS and LAPACK libraries. `OpenBLAS <https://github.com/xianyi/OpenBLAS/>`__
       is the SciPy default; other variants include
       `ATLAS <http://math-atlas.sourceforge.net/>`__ and
-      `MKL <https://software.intel.com/en-us/intel-mkl>`__. 
+      `MKL <https://software.intel.com/en-us/intel-mkl>`__.
 
     .. tab-set::
 
@@ -71,7 +71,7 @@ dependencies to build it on your system.
 
         To install SciPy build requirements, you can do::
 
-          sudo dnf install gcc-gfortran python3-devel openblas-devel lapack-devel
+          sudo dnf install gcc-gfortran python3-devel openblas-devel lapack-devel pkgconfig
 
         Alternatively, you can do::
 
@@ -85,7 +85,7 @@ dependencies to build it on your system.
 
         To install SciPy build requirements, you can do::
 
-          sudo yum install gcc-gfortran python3-devel openblas-devel lapack-devel
+          sudo yum install gcc-gfortran python3-devel openblas-devel lapack-devel pkgconfig
 
         Alternatively, you can do::
 
@@ -99,11 +99,11 @@ dependencies to build it on your system.
 
         To install SciPy build requirements, you can do::
 
-          sudo pacman -S gcc-fortran openblas
+          sudo pacman -S gcc-fortran openblas pkgconf
 
     All further work should proceed in a virtual environment. Popular options
     include the standard library ``venv`` module or a separate ``virtualenv``
-    package. 
+    package.
 
     * The `Cython <https://cython.org/>`__ and
       `Pythran <https://pythran.readthedocs.io>`__ ahead-of-time compilers are also
@@ -132,6 +132,28 @@ dependencies to build it on your system.
   .. tab-item:: Windows
 
     See :ref:`build-windows`.
+
+Building SciPy from source
+--------------------------
+
+If you want to only install SciPy from source once and not do any development
+work, then the recommended way to build and install is to use ``pip``::
+
+    # For the latest stable release:
+    pip install scipy --no-binary scipy
+
+    # For the latest development version, directly from GitHub:
+    pip install https://github.com/scipy/scipy/archive/refs/heads/main.zip
+
+    # If you have a local clone of the SciPy git repository:
+    pip install .
+
+If you want to build from source in order to work on SciPy itself, then use
+our ``dev.py`` developer interface with::
+
+    python dev.py build
+
+For more details on developing with ``dev.py``, see :ref:`meson`.
 
 Detailed instructions
 ---------------------

--- a/doc/source/dev/contributor/osx.rst
+++ b/doc/source/dev/contributor/osx.rst
@@ -36,28 +36,23 @@ MacPorts, Fink).
 Compilers (C/C++/FORTRAN/Cython/Pythran)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Though virtually any commercial C/C++ compiler may be used with SciPy, Clang
-C/C++ compiler, which is a Xcode command line tool, can be used for OS X. The
-only thing missing is the GNU FORTRAN compiler.
+Though virtually any C/C++ compiler may be used with SciPy, on macOS we
+recommend using the default Clang C/C++ compiler. It can be installed as
+an Xcode command line tool (this is what the ``xcode-select`` command given
+higher up has already done).
 
-We recommend gfortran; this is a free, open source, F95 compiler. We suggest you
-use the following binaries:
-
-* gfortran installed via `Homebrew <https://brew.sh/>`__, or,
-* http://r.research.att.com/tools/gcc-42-5666.3-darwin11.pkg (for Xcode
-  4.2 or higher)
-
-See `this site <http://r.research.att.com/tools/>`__ for the most recent links.
+The only thing missing is a Fortran compiler.  We recommend you
+use ``gfortran``, and install it with `Homebrew <https://brew.sh/>`__.
 
 BLAS/LAPACK Installation
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 You will also need to install a library providing the BLAS and LAPACK
-interfaces. ATLAS, OpenBLAS, and MKL all work. OpenBLAS can be installed
-via `Homebrew <https://brew.sh/>`.
+interfaces. OpenBLAS, ATLAS and MKL all work. OpenBLAS can be installed
+via `Homebrew <https://brew.sh/>`, and is the library we recommend using.
 
 .. note::
 
-    As of SciPy version 1.2.0, we do not support compiling against the system
+    As of SciPy >=1.2.0, we do not support compiling against the system
     Accelerate library for BLAS and LAPACK. It does not support a sufficiently
     recent LAPACK interface.


### PR DESCRIPTION
Updates outdated macOS instructions, and makes a clear difference between regular building from source to install once as a user vs. using ``dev.py`` to work on SciPy itself.

[skip github]
[skip azp]

This follows up on feedback from @oscarbenjamin at https://github.com/scipy/scipy/issues/16308#issuecomment-1222415255