### PR TITLE
CI: wheels only on scipy [skip azp][skip github]

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -30,8 +30,7 @@ jobs:
   get_commit_message:
     name: Get commit message
     runs-on: ubuntu-latest
-    # TODO re-enable
-    # if: github.repository == 'scipy/scipy'
+    if: github.repository == 'scipy/scipy'
     outputs:
       message: ${{ steps.commit_message.outputs.message }}
     steps:


### PR DESCRIPTION
Only run wheels.yml on scipy, not on forks