### PR TITLE
DOC: optimize.linprog: adjust tutorial to address gh16531

### DIFF
--- a/doc/source/tutorial/optimize.rst
+++ b/doc/source/tutorial/optimize.rst
@@ -1535,8 +1535,7 @@ Finally, we can solve the transformed problem using :func:`linprog`.
     >>> bounds = [x0_bounds, x1_bounds, x2_bounds, x3_bounds]
     >>> result = linprog(c, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq, bounds=bounds)
     >>> print(result.message)
-    The problem is infeasible. (HiGHS Status 8: model_status is Infeasible;
-    primal_status is At lower/fixed bound)
+    The problem is infeasible. (HiGHS Status 8: model_status is Infeasible; primal_status is At lower/fixed bound)
 
 The result states that our problem is infeasible, meaning that there is no solution vector that satisfies all the
 constraints. That doesn't necessarily mean we did anything wrong; some problems truly are infeasible.

--- a/doc/source/tutorial/optimize.rst
+++ b/doc/source/tutorial/optimize.rst
@@ -34,10 +34,10 @@ The minimum value of this function is 0 which is achieved when
 Note that the Rosenbrock function and its derivatives are included in
 `scipy.optimize`. The implementations shown in the following sections
 provide examples of how to define an objective function as well as its
-jacobian and hessian functions. Objective functions in `scipy.optimize` 
-expect a numpy array as their first parameter which is to be optimized 
+jacobian and hessian functions. Objective functions in `scipy.optimize`
+expect a numpy array as their first parameter which is to be optimized
 and must return a float value. The exact calling signature must be
-``f(x, *args)`` where ``x`` represents a numpy array and ``args`` 
+``f(x, *args)`` where ``x`` represents a numpy array and ``args``
 a tuple of additional arguments supplied to the objective function.
 
 Nelder-Mead Simplex algorithm (``method='Nelder-Mead'``)
@@ -74,23 +74,23 @@ Another optimization algorithm that needs only function calls to find
 the minimum is *Powell*'s method available by setting ``method='powell'`` in
 :func:`minimize`.
 
-To demonstrate how to supply additional arguments to an objective function, 
-let us minimize the Rosenbrock function with an additional scaling factor `a` 
+To demonstrate how to supply additional arguments to an objective function,
+let us minimize the Rosenbrock function with an additional scaling factor `a`
 and an offset `b`:
 
 .. math::
 
     f\left(\mathbf{x}, a, b\right)=\sum_{i=1}^{N-1}a\left(x_{i+1}-x_{i}^{2}\right)^{2}+\left(1-x_{i}\right)^{2} + b.
 
-Again using the :func:`minimize` routine this can be solved by the following 
-code block for the example parameters `a=0.5` and `b=1`. 
+Again using the :func:`minimize` routine this can be solved by the following
+code block for the example parameters `a=0.5` and `b=1`.
 
     >>> def rosen_with_args(x, a, b):
     ...     """The Rosenbrock function with additional arguments"""
     ...     return sum(a*(x[1:]-x[:-1]**2.0)**2.0 + (1-x[:-1])**2.0) + b
 
     >>> x0 = np.array([1.3, 0.7, 0.8, 1.9, 1.2])
-    >>> res = minimize(rosen_with_args, x0, method='nelder-mead', 
+    >>> res = minimize(rosen_with_args, x0, method='nelder-mead',
     ...		       args=(0.5, 1.), options={'xatol': 1e-8, 'disp': True})
     Optimization terminated successfully.
              Current function value: 1.000000
@@ -153,11 +153,11 @@ through the ``jac`` parameter as illustrated below.
     >>> res.x
     array([1., 1., 1., 1., 1.])
 
-Another way to supply gradient information is to write a single 
-function which returns both the objective and the gradient: this is 
-indicated by setting ``jac=True``. In this case, the Python function 
-to be optimized must return a tuple whose first value is the objective 
-and whose second value represents the gradient. For this example, the 
+Another way to supply gradient information is to write a single
+function which returns both the objective and the gradient: this is
+indicated by setting ``jac=True``. In this case, the Python function
+to be optimized must return a tuple whose first value is the objective
+and whose second value represents the gradient. For this example, the
 objective can be specified in the following way:
 
     >>> def rosen_and_der(x):
@@ -176,9 +176,9 @@ objective can be specified in the following way:
              Current function value: 0.000000
              Iterations: 25                     # may vary
              Function evaluations: 30
-             Gradient evaluations: 30    
+             Gradient evaluations: 30
 
-Supplying objective and gradient in a single function can help to avoid 
+Supplying objective and gradient in a single function can help to avoid
 redundant computations and therefore speed up the optimization significantly.
 
 Newton-Conjugate-Gradient algorithm (``method='Newton-CG'``)
@@ -776,7 +776,7 @@ This function looks like an egg carton::
    >>> plt.show()
 
 .. plot:: tutorial/examples/optimize_global_2.py
-   :alt: "A 3-D plot shown from a three-quarter view. The function is very noisy with dozens of valleys and peaks. There is no clear min or max discernable from this view and it's not possible to see all the local peaks and valleys from this view." 
+   :alt: "A 3-D plot shown from a three-quarter view. The function is very noisy with dozens of valleys and peaks. There is no clear min or max discernable from this view and it's not possible to see all the local peaks and valleys from this view."
    :align: center
    :include-source: 0
 
@@ -1534,15 +1534,9 @@ Finally, we can solve the transformed problem using :func:`linprog`.
     >>> x3_bounds = (-3.0, None)
     >>> bounds = [x0_bounds, x1_bounds, x2_bounds, x3_bounds]
     >>> result = linprog(c, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq, bounds=bounds)
-    >>> print(result)
-         con: array([15.5361242 , 16.61288005])  # may vary
-         fun: -370.2321976308326  # may vary
-     message: 'The algorithm terminated successfully and determined that the problem is infeasible.'
-         nit: 6  # may vary
-       slack: array([ 0.79314989, -1.76308532])  # may vary
-      status: 2
-     success: False
-           x: array([ 6.60059391,  3.97366609, -0.52664076,  1.09007993])  # may vary
+    >>> print(result.message)
+    The problem is infeasible. (HiGHS Status 8: model_status is Infeasible;
+    primal_status is At lower/fixed bound)
 
 The result states that our problem is infeasible, meaning that there is no solution vector that satisfies all the
 constraints. That doesn't necessarily mean we did anything wrong; some problems truly are infeasible.
@@ -1554,15 +1548,8 @@ to :math:`0 \leq x_1 \leq 6`. After adjusting our code ``x1_bounds = (0, 6)`` to
     >>> x1_bounds = (0, 6)
     >>> bounds = [x0_bounds, x1_bounds, x2_bounds, x3_bounds]
     >>> result = linprog(c, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq, bounds=bounds)
-    >>> print(result)
-        con: array([9.78840831e-09, 1.04662945e-08])  # may vary
-        fun: -505.97435889013434  # may vary
-    message: 'Optimization terminated successfully.'
-        nit: 4  # may vary
-      slack: array([ 6.52747190e-10, -2.26730279e-09])  # may vary
-     status: 0
-    success: True
-          x: array([ 9.41025641,  5.17948718, -0.25641026,  1.64102564])  # may vary
+    >>> print(result.message)
+    'Optimization terminated successfully. (HiGHS Status 7: Optimal)'
 
 The result shows the optimization was successful.
 We can check the objective value (``result.fun``) is same as :math:`c^Tx`:
@@ -1570,7 +1557,10 @@ We can check the objective value (``result.fun``) is same as :math:`c^Tx`:
 ::
 
     >>> x = np.array(result.x)
+    >>> obj = result.fun
     >>> print(c @ x)
+    -505.97435889013434  # may vary
+    >>> print(obj)
     -505.97435889013434  # may vary
 
 We can also check that all constraints are satisfied within reasonable tolerances:
@@ -1584,20 +1574,6 @@ We can also check that all constraints are satisfied within reasonable tolerance
     >>> print([0 <= result.x[0], 0 <= result.x[1] <= 6.0, result.x[2] <= 0.5, -3.0 <= result.x[3]])
     [True, True, True, True]
 
-If we need greater accuracy, typically at the expense of speed, we can solve using the ``revised simplex`` method:
-
-::
-
-    >>> result = linprog(c, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq, bounds=bounds, method='revised simplex')
-    >>> print(result)
-        con: array([0.00000000e+00, 7.10542736e-15])  # may vary
-        fun: -505.97435897435895    # may vary
-    message: 'Optimization terminated successfully.'
-        nit: 5  # may vary
-      slack: array([ 1.77635684e-15, -3.55271368e-15])  # may vary
-     status: 0
-    success: True
-          x: array([ 9.41025641,  5.17948718, -0.25641026,  1.64102564])  # may vary
 
 Assignment problems
 -------------------
@@ -1618,18 +1594,18 @@ We have a table showing times for each swimming style of five students:
  E          46.3           47.8         50.4        37.2
 ==========  ===========  ============  ===========  ===============================
 
-We need to choose a student for each of the four swimming styles such that 
+We need to choose a student for each of the four swimming styles such that
 the total relay time is minimized.
 This is a typical linear sum assignment problem. We can use :func:`linear_sum_assignment` to solve it.
 
 The linear sum assignment problem is one of the most famous combinatorial optimization problems.
 Given a "cost matrix" :math:`C`, the problem is to choose
 
-- exactly one element from each row 
-- without choosing more than one element from any column 
+- exactly one element from each row
+- without choosing more than one element from any column
 - such that the sum of the chosen elements is minimized
 
-In other words, we need to assign each row to one column such that the sum of 
+In other words, we need to assign each row to one column such that the sum of
 the corresponding entries is minimized.
 
 Formally, let :math:`X` be a boolean matrix where :math:`X[i,j] = 1` iff row  :math:`i` is assigned to column :math:`j`.

--- a/doc/source/tutorial/optimize.rst
+++ b/doc/source/tutorial/optimize.rst
@@ -1549,7 +1549,7 @@ to :math:`0 \leq x_1 \leq 6`. After adjusting our code ``x1_bounds = (0, 6)`` to
     >>> bounds = [x0_bounds, x1_bounds, x2_bounds, x3_bounds]
     >>> result = linprog(c, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq, bounds=bounds)
     >>> print(result.message)
-    'Optimization terminated successfully. (HiGHS Status 7: Optimal)'
+    Optimization terminated successfully. (HiGHS Status 7: Optimal)
 
 The result shows the optimization was successful.
 We can check the objective value (``result.fun``) is same as :math:`c^Tx`:

--- a/doc/source/tutorial/optimize.rst
+++ b/doc/source/tutorial/optimize.rst
@@ -1535,7 +1535,7 @@ Finally, we can solve the transformed problem using :func:`linprog`.
     >>> bounds = [x0_bounds, x1_bounds, x2_bounds, x3_bounds]
     >>> result = linprog(c, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq, bounds=bounds)
     >>> print(result.message)
-    The problem is infeasible. (HiGHS Status 8: model_status is Infeasible; primal_status is At lower/fixed bound)
+    The problem is infeasible. (HiGHS Status 8: model_status is Infeasible; primal_status is b'At lower/fixed bound')
 
 The result states that our problem is infeasible, meaning that there is no solution vector that satisfies all the
 constraints. That doesn't necessarily mean we did anything wrong; some problems truly are infeasible.


### PR DESCRIPTION
#### Reference issue
Addresses `linprog` part of gh-16531

#### What does this implement/fix?
A warning is emitted in the `linprog` tutorial due to outdated usage. This updates the tutorial to avoid the warning.

#### Additional information
Please tell GitHub to ignore whitespace changes. My IDE removes the trailing spaces automatically.