### PR TITLE
ENH: optimize.OptimizeResult: improve pretty-printing

### DIFF
--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -573,8 +573,8 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
     and residuals (slacks) are also available.
 
     >>> res.ineqlin
-     marginals: array([-0., -1.])
-      residual: array([39.,  0.])
+      residual: [ 3.900e+01  0.000e+00]
+     marginals: [-0.000e+00 -1.000e+00]
 
     For example, because the marginal associated with the second inequality
     constraint is -1, we expect the optimal value of the objective function

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -179,8 +179,8 @@ class OptimizeResult(dict):
     __delattr__ = dict.__delitem__
 
     def __repr__(self):
-        order_keys = ['message', 'success', 'status', 'fun', 'x', 'nit',
-                      'lower', 'upper', 'eqlin', 'ineqlin']
+        order_keys = ['message', 'success', 'status', 'fun', 'funl', 'x', 'xl',
+                      'col_ind', 'nit', 'lower', 'upper', 'eqlin', 'ineqlin']
         # 'slack', 'con' are redundant with residuals
         # 'crossover_nit' is probably not interesting to most users
         omit_keys = {'slack', 'con', 'crossover_nit'}

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -117,8 +117,8 @@ def _dict_formatter(d, n=0, mplus=1, sorter=None):
                        _indenter(_dict_formatter(v, m+n+2, 0, sorter), m+2)
                        for k, v in sorter(d)])  # +2 for ': '
     else:
-        # By default, NumPy arrays print with linewidth is 76; `n` is
-        # the indent at which they begin printing, so it is subtracted
+        # By default, NumPy arrays print with linewidth=76. `n` is
+        # the indent at which a line begins printing, so it is subtracted
         # from the default to avoid exceeding 76 characters total.
         # `edgeitems` is the number of elements to include before and after
         # ellipses when arrays are not shown in full.

--- a/scipy/optimize/_qap.py
+++ b/scipy/optimize/_qap.py
@@ -120,8 +120,8 @@ def quadratic_assignment(A, B, method="faq", options=None):
     ...               [0, 0, 0, 3], [0, 0, 0, 0]])
     >>> res = quadratic_assignment(A, B)
     >>> print(res)
-     col_ind: array([0, 3, 2, 1])
          fun: 3260
+     col_ind: [0 3 2 1]
          nit: 9
 
     The see the relationship between the returned ``col_ind`` and ``fun``,
@@ -163,8 +163,8 @@ def quadratic_assignment(A, B, method="faq", options=None):
     ...               [8, 5, 0, 5], [4, 2, 5, 0]])
     >>> res = quadratic_assignment(A, B)
     >>> print(res)
-     col_ind: array([1, 0, 3, 2])
          fun: 178
+     col_ind: [1 0 3 2]
          nit: 13
 
     If accuracy is important, consider using  :ref:`'2opt' <optimize.qap-2opt>`
@@ -174,8 +174,8 @@ def quadratic_assignment(A, B, method="faq", options=None):
     >>> res = quadratic_assignment(A, B, method="2opt",
     ...                            options = {'partial_guess': guess})
     >>> print(res)
-     col_ind: array([1, 2, 3, 0])
          fun: 176
+     col_ind: [1 2 3 0]
          nit: 17
 
     """

--- a/scipy/optimize/_shgo.py
+++ b/scipy/optimize/_shgo.py
@@ -394,6 +394,7 @@ def shgo(func, bounds, args=(), constraints=None, n=None, iters=1,
     ...         {'type': 'eq', 'fun': h1})
     >>> bounds = [(0, 1.0),]*4
     >>> res = shgo(f, bounds, iters=3, constraints=cons)
+    >>> res
      message: Optimization terminated successfully.
      success: True
          fun: 29.894378159142136

--- a/scipy/optimize/_shgo.py
+++ b/scipy/optimize/_shgo.py
@@ -394,18 +394,17 @@ def shgo(func, bounds, args=(), constraints=None, n=None, iters=1,
     ...         {'type': 'eq', 'fun': h1})
     >>> bounds = [(0, 1.0),]*4
     >>> res = shgo(f, bounds, iters=3, constraints=cons)
-    >>> res
-         fun: 29.894378159142136
-        funl: array([29.89437816])
-     message: 'Optimization terminated successfully.'
-        nfev: 114
-         nit: 3
-       nlfev: 35
-       nlhev: 0
-       nljev: 5
+     message: Optimization terminated successfully.
      success: True
-           x: array([6.35521569e-01, 1.13700270e-13, 3.12701881e-01, 5.17765506e-02])
-          xl: array([[6.35521569e-01, 1.13700270e-13, 3.12701881e-01, 5.17765506e-02]])
+         fun: 29.894378159142136
+        funl: [ 2.989e+01]
+           x: [ 6.355e-01  1.137e-13  3.127e-01  5.178e-02]
+          xl: [[ 6.355e-01  1.137e-13  3.127e-01  5.178e-02]]
+         nit: 3
+        nfev: 114
+       nlfev: 35
+       nljev: 5
+       nlhev: 0
 
     >>> g1(res.x), g2(res.x), h1(res.x)
     (-5.062616992290714e-14, -2.9594104944408173e-12, 0.0)


### PR DESCRIPTION
#### What does this implement/fix?
`OptimizeResult` pretty-printing was fine, but when we added dictionaries as attributes, it started looking pretty rough. This PR improves pretty-printing of `OptimizeResults`.

For example, previously an `OptimizeResult` returned by `linprog` might look like:
```
           con: array([], dtype=float64)
 crossover_nit: 0
         eqlin:  marginals: array([], dtype=float64)
  residual: array([], dtype=float64)
           fun: -106.63507542058261
       ineqlin:  marginals: array([-3.34425901e-01, -3.33322186e-01, -3.32251914e-01, -0.00000000e+00,
       -0.00000000e+00, -0.00000000e+00, -0.00000000e+00, -0.00000000e+00,
       -0.00000000e+00, -0.00000000e+00, -0.00000000e+00, -0.00000000e+00,
       -0.00000000e+00, -0.00000000e+00, -0.00000000e+00, -0.00000000e+00,
       -0.00000000e+00, -0.00000000e+00, -0.00000000e+00, -0.00000000e+00,
       -0.00000000e+00, -0.00000000e+00, -3.34425901e-05, -3.33322186e-05,
       -0.00000000e+00, -3.32251914e-05, -0.00000000e+00])
  residual: array([0.00000000e+00, 0.00000000e+00, 0.00000000e+00, 9.66557410e+01,
       1.00000000e+02, 0.00000000e+00, 0.00000000e+00, 1.00000000e+02,
       1.00000000e+02, 9.00000000e+02, 9.00000000e+02, 9.00000000e+02,
       9.00000000e+02, 9.00000000e+02, 9.00000000e+02, 0.00000000e+00,
       2.00000000e-02, 2.06655741e-02, 0.00000000e+00, 2.06655741e-02,
       0.00000000e+00, 9.33449246e+01, 0.00000000e+00, 0.00000000e+00,
       1.00000000e+02, 0.00000000e+00, 1.00000000e+02])
         lower:  marginals: array([0.        , 0.        , 0.03339577, 0.        , 0.        ,
       0.        , 0.00321082, 0.3344333 , 0.33329255, 0.66550754,
       0.33439246, 0.3333259 , 0.33225563, 0.3344259 , 0.        ,
       0.        , 0.33332219, 0.        , 0.33225191])
  residual: array([ 3.09979334e+02,  3.34425901e+00,  0.00000000e+00,  1.00000000e+02,
        1.00000000e+02, -4.29362130e-15,  0.00000000e+00,  0.00000000e+00,
        0.00000000e+00,  0.00000000e+00,  0.00000000e+00,  0.00000000e+00,
        0.00000000e+00,  0.00000000e+00,  2.00000000e-02,  2.06655741e-02,
        0.00000000e+00,  2.06655741e-02,  0.00000000e+00])
       message: 'Optimization terminated successfully. (HiGHS Status 7: Optimal)'
           nit: 6
         slack: array([0.00000000e+00, 0.00000000e+00, 0.00000000e+00, 9.66557410e+01,
       1.00000000e+02, 0.00000000e+00, 0.00000000e+00, 1.00000000e+02,
       1.00000000e+02, 9.00000000e+02, 9.00000000e+02, 9.00000000e+02,
       9.00000000e+02, 9.00000000e+02, 9.00000000e+02, 0.00000000e+00,
       2.00000000e-02, 2.06655741e-02, 0.00000000e+00, 2.06655741e-02,
       0.00000000e+00, 9.33449246e+01, 0.00000000e+00, 0.00000000e+00,
       1.00000000e+02, 0.00000000e+00, 1.00000000e+02])
        status: 0
       success: True
         upper:  marginals: array([ 0.        ,  0.        ,  0.        , -1.06313994, -0.00321082,
        0.        ,  0.        ,  0.        ,  0.        ,  0.        ,
        0.        ,  0.        ,  0.        ,  0.        ,  0.        ,
        0.        ,  0.        ,  0.        ,  0.        ])
  residual: array([         inf,  96.65574099, 100.        ,   0.        ,
         0.        , 100.        , 100.        , 900.        ,
       900.        , 900.        , 900.        , 900.        ,
       900.        ,          inf,          inf,          inf,
                inf,          inf,          inf])
             x: array([ 3.09979334e+02,  3.34425901e+00,  0.00000000e+00,  1.00000000e+02,
        1.00000000e+02, -4.29362130e-15,  0.00000000e+00,  0.00000000e+00,
        0.00000000e+00,  0.00000000e+00,  0.00000000e+00,  0.00000000e+00,
        0.00000000e+00,  0.00000000e+00,  2.00000000e-02,  2.06655741e-02,
        0.00000000e+00,  2.06655741e-02,  0.00000000e+00])
```

Now:
```
       message: Optimization terminated successfully. (HiGHS Status 7: Optimal)
       success: True
        status: 0
           fun: -106.63507542058261
             x: [ 3.100e+02  3.344e+00 ...  2.067e-02  0.000e+00]
           nit: 6
         lower:  residual: [ 3.100e+02  3.344e+00 ...  2.067e-02  0.000e+00]
                marginals: [ 0.000e+00  0.000e+00 ...  0.000e+00  3.323e-01]
         upper:  residual: [       inf  9.666e+01 ...        inf        inf]
                marginals: [ 0.000e+00  0.000e+00 ...  0.000e+00  0.000e+00]
         eqlin:  residual: []
                marginals: []
       ineqlin:  residual: [ 0.000e+00  0.000e+00 ...  0.000e+00  1.000e+02]
                marginals: [-3.344e-01 -3.333e-01 ... -3.323e-05 -0.000e+00]
```

The result for the `minimize` docstring example was like:
```
      fun: 1.4759786947522541e-15
 hess_inv: array([[0.00763624, 0.0125159 , 0.02359808, 0.0465684 , 0.09317974],
       [0.0125159 , 0.02489687, 0.04727754, 0.09353774, 0.18708048],
       [0.02359808, 0.04727754, 0.09483095, 0.18783847, 0.37561493],
       [0.0465684 , 0.09353774, 0.18783847, 0.37715312, 0.75414172],
       [0.09317974, 0.18708048, 0.37561493, 0.75414172, 1.51296479]])
      jac: array([ 9.93918700e-07,  4.21980188e-07,  2.23775033e-07, -6.10304485e-07,
        1.34057054e-07])
  message: 'Optimization terminated successfully.'
     nfev: 31
      nit: 26
     njev: 31
   status: 0
  success: True
        x: array([1., 1., 1., 1., 1.])
```
Now:
```
  message: Optimization terminated successfully.
  success: True
   status: 0
      fun: 1.4759786947522541e-15
        x: [ 1.000e+00  1.000e+00  1.000e+00  1.000e+00  1.000e+00]
      nit: 26
      jac: [ 9.939e-07  4.220e-07  2.238e-07 -6.103e-07  1.341e-07]
 hess_inv: [[ 7.636e-03  1.252e-02 ...  4.657e-02  9.318e-02]
            [ 1.252e-02  2.490e-02 ...  9.354e-02  1.871e-01]
            ...
            [ 4.657e-02  9.354e-02 ...  3.772e-01  7.541e-01]
            [ 9.318e-02  1.871e-01 ...  7.541e-01  1.513e+00]]
     nfev: 31
     njev: 31
```

#### Additional information
Let's see if a ton of docstring examples need to be updated...

