### PR TITLE
TST: restore macOS optional test dependencies [skip azp]. Closes #13023

### DIFF
--- a/.github/workflows/macos_meson.yml
+++ b/.github/workflows/macos_meson.yml
@@ -100,6 +100,10 @@ jobs:
       shell: bash -l {0}
       run: |
         conda activate scipy-dev
+
+        # optional test dependencies
+        conda install scikit-umfpack scikit-sparse
+
         # Python.org installers still use 10.9, so let's use that too. Note
         # that scikit-learn already changed to 10.13 in Jan 2021, so increasing
         # this number in the future (if needed) should not be a problem.


### PR DESCRIPTION
Restores the optional test dependencies `scikit-umfpack`, `scikit-sparse` to a macOS CI run. 