### PR TITLE
MAINT: 1.9.1 backports

### DIFF
--- a/doc/API.rst.txt
+++ b/doc/API.rst.txt
@@ -125,6 +125,8 @@ change is made.
 
 * `scipy.optimize`
 
+  - `scipy.optimize.cython_optimize
+
 * `scipy.signal`
 
   - `scipy.signal.windows`

--- a/doc/API.rst.txt
+++ b/doc/API.rst.txt
@@ -125,7 +125,7 @@ change is made.
 
 * `scipy.optimize`
 
-  - `scipy.optimize.cython_optimize
+  - `scipy.optimize.cython_optimize`
 
 * `scipy.signal`
 

--- a/doc/release/1.9.1-notes.rst
+++ b/doc/release/1.9.1-notes.rst
@@ -5,15 +5,44 @@ SciPy 1.9.1 Release Notes
 .. contents::
 
 SciPy 1.9.1 is a bug-fix release with no new features
-compared to 1.9.0.
+compared to 1.9.0. Notably, some important meson build
+fixes are included.
 
 Authors
 =======
 
+* Anirudh Dagar (1)
+* Ralf Gommers (4)
+* Matt Haberland (2)
+* Tyler Reddy (10)
+* Atsushi Sakai (1)
+* Eli Schwartz (1)
+* Warren Weckesser (1)
+
+A total of 7 people contributed to this release.
+People with a "+" by their names contributed a patch for the first time.
+This list of names is automatically generated, and may not be fully complete.
 
 Issues closed for 1.9.1
 -----------------------
 
+* `#14517 <https://github.com/scipy/scipy/issues/14517>`__: scipy/linalg/tests/test_decomp.py::TestSchur::test_sort test...
+* `#16765 <https://github.com/scipy/scipy/issues/16765>`__: DOC: \`scipy.stats.skew\` no longer returns 0 on constant input
+* `#16787 <https://github.com/scipy/scipy/issues/16787>`__: BUG: Can't build 1.10 with mingw-w64 toolchain and numpy 1.21.6...
+* `#16813 <https://github.com/scipy/scipy/issues/16813>`__: BUG: scipy.interpolate interp1d extrapolate behaviour change...
+* `#16878 <https://github.com/scipy/scipy/issues/16878>`__: BUG: optimize.milp fails to execute when given exactly 3 constraints
+
 
 Pull requests for 1.9.1
 -----------------------
+
+* `#16736 <https://github.com/scipy/scipy/pull/16736>`__: REL: prep for SciPy 1.9.1
+* `#16749 <https://github.com/scipy/scipy/pull/16749>`__: BLD: install missing \`.pxd\` files, and update TODOs/FIXMEs...
+* `#16750 <https://github.com/scipy/scipy/pull/16750>`__: BLD: make OpenBLAS detection work with CMake
+* `#16760 <https://github.com/scipy/scipy/pull/16760>`__: BLD: use a bit more idiomatic approach to constructing paths...
+* `#16768 <https://github.com/scipy/scipy/pull/16768>`__: DOC: stats.skew/kurtosis: returns NaN when input has only one...
+* `#16794 <https://github.com/scipy/scipy/pull/16794>`__: BLD/REL: on Windows use numpy 1.22.3 as the version to build...
+* `#16822 <https://github.com/scipy/scipy/pull/16822>`__: BUG/TST: linalg: Check the results of 'schur' more carefully.
+* `#16825 <https://github.com/scipy/scipy/pull/16825>`__: BUG: interpolate: fix "previous" and "next" extrapolate logic...
+* `#16862 <https://github.com/scipy/scipy/pull/16862>`__: BUG, DOC: Fix sphinx autosummary generation for \`odr\` and \`czt\`
+* `#16881 <https://github.com/scipy/scipy/pull/16881>`__: MAINT: optimize.milp: fix input validation when three constraints...

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -261,6 +261,16 @@ np_docscrape.ClassDoc.extra_public_methods = [  # should match class.rst
 
 autosummary_generate = True
 
+# maps functions with a name same as a class name that is indistinguishable
+# Ex: scipy.signal.czt and scipy.signal.CZT or scipy.odr.odr and scipy.odr.ODR
+# Otherwise, the stubs are overwritten when the name is same for
+# OS (like MacOS) which has a filesystem that ignores the case
+# See https://github.com/sphinx-doc/sphinx/pull/7927
+autosummary_filename_map = {
+    "scipy.odr.odr": "odr-function",
+    "scipy.signal.czt": "czt-function",
+}
+
 
 # -----------------------------------------------------------------------------
 # Autodoc

--- a/environment.yml
+++ b/environment.yml
@@ -45,4 +45,4 @@ dependencies:
   - rich-click
   - click
   - doit>=0.36.0
-  - pydevtool==0.2.0
+  - pydevtool

--- a/meson.build
+++ b/meson.build
@@ -10,7 +10,7 @@ project(
   default_options: [
     'buildtype=debugoptimized',
     'c_std=c99',
-    'cpp_std=c++14',  # TODO: use c++11 if 14 is not available
+    'cpp_std=c++14',
     # TODO: the below -Wno flags are all needed to silence warnings in
     # f2py-generated code. This should be fixed in f2py itself.
     'c_args=-Wno-unused-function -Wno-conversion -Wno-misleading-indentation -Wno-incompatible-pointer-types',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,13 +37,18 @@ requires = [
     # loongarch64 requires numpy>=1.22.0
     "numpy==1.22.0; platform_machine=='loongarch64'",
 
+    # On Windows we need to avoid 1.21.6, 1.22.0 and 1.22.1 because they were
+    # built with vc142. 1.22.3 is the first version that has 32-bit Windows
+    # wheels *and* was built with vc141. So use that:
+    "numpy==1.22.3; python_version=='3.10' and platform_machine=='win32' and platform_python_implementation != 'PyPy'",
+
     # default numpy requirements
     "numpy==1.18.5; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64' and platform_machine!='loongarch64' and platform_python_implementation != 'PyPy'",
     "numpy==1.19.3; python_version=='3.9' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='loongarch64' and platform_python_implementation != 'PyPy'",
     # Note that 1.21.3 was the first version with a complete set of 3.10 wheels,
-    # however macOS was broken and it's safe to build against 1.21.6 on all platforms
+    # however macOS was broken and it's safe C API/ABI-wise to build against 1.21.6
     # (see oldest-supported-numpy issues gh-28 and gh-45)
-    "numpy==1.21.6; python_version=='3.10' and platform_machine!='loongarch64' and platform_python_implementation != 'PyPy'",
+    "numpy==1.21.6; python_version=='3.10' and (platform_machine!='win32' and platform_machine!='loongarch64') and platform_python_implementation != 'PyPy'",
 
     # For Python versions which aren't yet officially supported,
     # we specify an unpinned NumPy which allows source distributions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,8 @@ requires = [
 
 [project]
 name = "SciPy"
+# TODO: add `license-files` once PEP 639 is accepted (see meson-python#88)
+#       at that point, no longer include them in `py3.install_sources()`
 license = {file = "LICENSE.txt"}
 description = "Fundamental algorithms for scientific computing in Python"
 maintainers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,12 +49,13 @@ requires = [
     # however macOS was broken and it's safe C API/ABI-wise to build against 1.21.6
     # (see oldest-supported-numpy issues gh-28 and gh-45)
     "numpy==1.21.6; python_version=='3.10' and (platform_machine!='win32' and platform_machine!='loongarch64') and platform_python_implementation != 'PyPy'",
+    "numpy==1.23.2; python_version=='3.11' and platform_python_implementation != 'PyPy'",
 
     # For Python versions which aren't yet officially supported,
     # we specify an unpinned NumPy which allows source distributions
     # to be used and allows wheels to be used as soon as they
     # become available.
-    "numpy; python_version>='3.11'",
+    "numpy; python_version>='3.12'",
     "numpy; python_version>='3.8' and platform_python_implementation=='PyPy'",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ requires = [
     # On Windows we need to avoid 1.21.6, 1.22.0 and 1.22.1 because they were
     # built with vc142. 1.22.3 is the first version that has 32-bit Windows
     # wheels *and* was built with vc141. So use that:
-    "numpy==1.22.3; python_version=='3.10' and platform_machine=='win32' and platform_python_implementation != 'PyPy'",
+    "numpy==1.22.3; python_version=='3.10' and platform_system=='Windows' and platform_python_implementation != 'PyPy'",
 
     # default numpy requirements
     "numpy==1.18.5; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64' and platform_machine!='loongarch64' and platform_python_implementation != 'PyPy'",

--- a/scipy/_lib/_uarray/meson.build
+++ b/scipy/_lib/_uarray/meson.build
@@ -1,8 +1,3 @@
-# TODO: add_data_files('license')
-
-# TODO: this used -std=c++14 if available, add c++11 otherwise
-#       can we now rely on c++14 unconditionally?
-
 py3.extension_module('_uarray',
   ['_uarray_dispatch.cxx', 'vectorcall.cxx'],
   cpp_args: ['-Wno-terminate', '-Wno-unused-function'],
@@ -15,6 +10,7 @@ py3.extension_module('_uarray',
 python_sources = [
   '__init__.py',
   '_backend.py',
+  'LICENSE'
 ]
 
 py3.install_sources(

--- a/scipy/fft/_pocketfft/meson.build
+++ b/scipy/fft/_pocketfft/meson.build
@@ -16,7 +16,6 @@ else
   pocketfft_threads += ['-DPOCKETFFT_NO_MULTITHREADING']
 endif
 
-#TODO: add the equivalent of set_cxx_flags_hook
 py3.extension_module('pypocketfft',
   'pypocketfft.cxx',
   cpp_args: pocketfft_threads,
@@ -32,6 +31,7 @@ python_sources = [
   '__init__.py',
   'basic.py',
   'helper.py',
+  'LICENSE.md',
   'realtransforms.py'
 ]
 

--- a/scipy/integrate/meson.build
+++ b/scipy/integrate/meson.build
@@ -190,8 +190,6 @@ py3.extension_module('_test_multivariate',
   subdir: 'scipy/integrate'
 )
 
-# FIXME: something is wrong with the signature file, subroutines are not used
-# _test_odeint_banded
 _test_odeint_banded_module = custom_target('_test_odeint_banded_module',
   output: ['_test_odeint_bandedmodule.c', '_test_odeint_banded-f2pywrappers.f'],
   input: 'tests/banded5x5.pyf',

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -519,7 +519,8 @@ class interp1d(_Interpolator1D):
                 self._call = self.__class__._call_previousnext
                 if _do_extrapolate(fill_value):
                     self._check_and_update_bounds_error_for_extrapolation()
-                    fill_value = (np.nan, self.y.max(axis=axis))
+                    # assume y is sorted by x ascending order here.
+                    fill_value = (np.nan, np.take(self.y, -1, axis))
             elif kind == 'next':
                 self._side = 'right'
                 self._ind = 1
@@ -528,7 +529,8 @@ class interp1d(_Interpolator1D):
                 self._call = self.__class__._call_previousnext
                 if _do_extrapolate(fill_value):
                     self._check_and_update_bounds_error_for_extrapolation()
-                    fill_value = (self.y.min(axis=axis), np.nan)
+                    # assume y is sorted by x ascending order here.
+                    fill_value = (np.take(self.y, 0, axis), np.nan)
             else:
                 # Check if we can delegate to numpy.interp (2x-10x faster).
                 np_types = (np.float_, np.int_)

--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -28,7 +28,7 @@ cython_linalg = custom_target('cython_linalg',
   # TODO - we only want to install the .pxd files! See comments for
   #        `pxd_files` further down.
   install: true,
-  install_dir: py3.get_install_dir() + 'scipy/linalg'
+  install_dir: py3.get_install_dir() / 'scipy/linalg'
 )
 
 # pyx -> c, pyx -> cpp generators, depending on __init__.py here.
@@ -331,7 +331,7 @@ py3.install_sources(
 #       https://mesonbuild.com/Installing.html says is for build targets to
 #       use:
 #         `custom_target(..., install: true, install_dir: ...)
-#         # should use `py3.get_install_dir() + 'scipy/linalg'` ?
+#         # should use `py3.get_install_dir() / 'scipy/linalg'` ?
 #       see https://github.com/mesonbuild/meson/issues/3206
 #
 #       For the below code to work, the script generating the files should use
@@ -349,7 +349,7 @@ py3.install_sources(
 #  output : ['cython_blas2.pxd', 'cython_lapack2.pxd'],
 #  command : ['cp', '@INPUT0@', '@OUTPUT0@', '&&', 'cp', '@INPUT1@', '@OUTPUT1@'],
 #  install : true,
-#  install_dir: py3.get_install_dir() + 'scipy/linalg'
+#  install_dir: py3.get_install_dir() / 'scipy/linalg'
 #)
 
 subdir('tests')

--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -25,8 +25,8 @@ cython_linalg = custom_target('cython_linalg',
   ],
   input: '_generate_pyx.py',
   command: [py3, '@INPUT@', '-o', '@OUTDIR@'],
-  # FIXME - we only want to install the .pxd files! See comments for
-  #         `pxd_files` further down.
+  # TODO - we only want to install the .pxd files! See comments for
+  #        `pxd_files` further down.
   install: true,
   install_dir: py3.get_install_dir() + 'scipy/linalg'
 )
@@ -166,7 +166,6 @@ py3.extension_module('_interpolative',
     '-Wno-tabs', '-Wno-conversion', '-Wno-argument-mismatch',
     '-Wno-unused-dummy-argument', '-Wno-maybe-uninitialized'
   ],
-  # TODO: add -fallow-argument-mismatch for gfortran >= 10, see gh-11842
   include_directories: [inc_np, inc_f2py],
   dependencies: [py3_dep, lapack],
   install: true,

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -117,8 +117,18 @@ numpy_nodepr_api = '-DNPY_NO_DEPRECATED_API=NPY_1_9_API_VERSION'
 # For MKL and for auto-detecting one of multiple libs, we'll need a custom
 # dependency in Meson (like is done for scalapack) - see
 # https://github.com/mesonbuild/meson/issues/2835
-blas = dependency(get_option('blas'))
-lapack = dependency(get_option('lapack'))
+blas_name = get_option('blas')
+lapack_name = get_option('lapack')
+# pkg-config uses a lower-case name while CMake uses a capitalized name, so try
+# that too to make the fallback detection with CMake work
+if blas_name == 'openblas'
+  blas_name = ['openblas', 'OpenBLAS']
+endif
+if lapack_name == 'openblas'
+  lapack_name = ['openblas', 'OpenBLAS']
+endif
+blas = dependency(blas_name)
+lapack = dependency(lapack_name)
 
 if blas.name() == 'mkl' or lapack.name() == 'mkl' or get_option('use-g77-abi')
   g77_abi_wrappers = files([

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -147,7 +147,7 @@ generate_config = custom_target(
   output: '__config__.py',
   input: '../tools/config_utils.py',
   command: [py3, '@INPUT@', '@OUTPUT@'],
-  install_dir: py3.get_install_dir() + '/scipy'
+  install_dir: py3.get_install_dir() / 'scipy'
 )
 
 generate_version = custom_target(
@@ -158,7 +158,7 @@ generate_version = custom_target(
   output: 'version.py',
   input: '../tools/version_utils.py',
   command: [py3, '@INPUT@', '--source-root', '@SOURCE_ROOT@'],
-  install_dir: py3.get_install_dir() + '/scipy'
+  install_dir: py3.get_install_dir() / 'scipy'
 )
 
 python_sources = [

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -140,8 +140,6 @@ generate_config = custom_target(
   install_dir: py3.get_install_dir() + '/scipy'
 )
 
-#FIXME: the git revision is Unknown; script works when invoked directly, but
-#       not when it's run by Ninja. See https://github.com/rgommers/scipy/pull/57
 generate_version = custom_target(
   'generate-version',
   install: true,
@@ -156,7 +154,10 @@ generate_version = custom_target(
 python_sources = [
   '__init__.py',
   '_distributor_init.py',
-  'conftest.py'
+  'conftest.py',
+  'linalg.pxd',
+  'optimize.pxd',
+  'special.pxd'
 ]
 
 py3.install_sources(
@@ -176,14 +177,16 @@ _cython_tree = custom_target('_cython_tree',
   output: [
     '__init__.py',
     'linalg.pxd',
+    'optimize.pxd',
     'special.pxd'
   ],
   input: [
     '__init__.py',
     'linalg.pxd',
+    'optimize.pxd',
     'special.pxd'
   ],
-  command: [copier, '@INPUT@', '@OUTDIR@']
+  command: [copier, '@INPUT@', '@OUTDIR@'],
 )
 cython_tree = declare_dependency(sources: _cython_tree)
 

--- a/scipy/optimize/_highs/meson.build
+++ b/scipy/optimize/_highs/meson.build
@@ -262,9 +262,6 @@ _highs_wrapper = py3.extension_module('_highs_wrapper',
     '-Wno-format-truncation',
     '-Wno-non-virtual-dtor',
     '-Wno-class-memaccess',
-    # Pass despite __STDC_FORMAT_MACROS redefinition warning.
-    # Remove after merge of https://github.com/ERGO-Code/HiGHS/pull/674
-    '-Wp,-w',
     Wno_unused_but_set,
     highs_define_macros,
     cython_c_args,

--- a/scipy/optimize/_milp.py
+++ b/scipy/optimize/_milp.py
@@ -43,7 +43,7 @@ def _constraints_to_components(constraints):
             # argument could be a single tuple representing a LinearConstraint
             try:
                 constraints = [LinearConstraint(*constraints)]
-            except TypeError:
+            except (TypeError, ValueError, np.VisibleDeprecationWarning):
                 # argument was not a tuple representing a LinearConstraint
                 pass
 

--- a/scipy/optimize/cython_optimize/meson.build
+++ b/scipy/optimize/cython_optimize/meson.build
@@ -1,4 +1,5 @@
 # Needed to trick Cython, it won't do a relative import outside a package
+# (see https://github.com/mesonbuild/meson/issues/8961)
 _dummy_init_cyoptimize = custom_target('_dummy_init_cyoptimize',
   output: [
     '__init__.py',
@@ -13,8 +14,6 @@ _dummy_init_cyoptimize = custom_target('_dummy_init_cyoptimize',
   command: [copier, '@INPUT@', '@OUTDIR@']
 )
 
-# FIXME: generated .pyx which has relative cimport in it doesn't work yet (see
-#        https://github.com/mesonbuild/meson/issues/8961)
 _zeros_pyx = custom_target('_zeros_pyx',
   output: '_zeros.pyx',
   input: '_zeros.pyx.in',

--- a/scipy/optimize/meson.build
+++ b/scipy/optimize/meson.build
@@ -316,6 +316,7 @@ py3.install_sources([
   '_tstutils.py',
   '_zeros_py.py',
   'cobyla.py',
+  'cython_optimize.pxd',
   'lbfgsb.py',
   'linesearch.py',
   'minpack.py',

--- a/scipy/optimize/tests/test_milp.py
+++ b/scipy/optimize/tests/test_milp.py
@@ -270,3 +270,28 @@ def test_infeasible_prob_16609():
     res = milp(c, integrality=integrality, bounds=bounds,
                constraints=constraints)
     np.testing.assert_equal(res.status, 2)
+
+
+def test_three_constraints_16878():
+    # `milp` failed when exactly three constraints were passed
+    # Ensure that this is no longer the case.
+    rng = np.random.default_rng(5123833489170494244)
+    A = rng.integers(0, 5, size=(6, 6))
+    bl = np.full(6, fill_value=-np.inf)
+    bu = np.full(6, fill_value=10)
+    constraints = [LinearConstraint(A[:2], bl[:2], bu[:2]),
+                   LinearConstraint(A[2:4], bl[2:4], bu[2:4]),
+                   LinearConstraint(A[4:], bl[4:], bu[4:])]
+    constraints2 = [(A[:2], bl[:2], bu[:2]),
+                    (A[2:4], bl[2:4], bu[2:4]),
+                    (A[4:], bl[4:], bu[4:])]
+    lb = np.zeros(6)
+    ub = np.ones(6)
+    variable_bounds = Bounds(lb, ub)
+    c = -np.ones(6)
+    res1 = milp(c, bounds=variable_bounds, constraints=constraints)
+    res2 = milp(c, bounds=variable_bounds, constraints=constraints2)
+    ref = milp(c, bounds=variable_bounds, constraints=(A, bl, bu))
+    assert res1.success and res2.success
+    assert_allclose(res1.x, ref.x)
+    assert_allclose(res2.x, ref.x)

--- a/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
@@ -351,8 +351,8 @@ def test_tolerance_float32():
     A = A.astype(np.float32)
     X = rnd.standard_normal((n, m))
     X = X.astype(np.float32)
-    eigvals, _ = lobpcg(A, X, tol=1e-5, maxiter=50, verbosityLevel=0)
-    assert_allclose(eigvals, -np.arange(1, 1 + m), atol=1.5e-5)
+    eigvals, _ = lobpcg(A, X, tol=1.25e-5, maxiter=50, verbosityLevel=0)
+    assert_allclose(eigvals, -np.arange(1, 1 + m), atol=2e-5, rtol=1e-5)
 
 
 def test_random_initial_float32():

--- a/scipy/special/meson.build
+++ b/scipy/special/meson.build
@@ -347,7 +347,7 @@ cython_special = custom_target('cython_special',
   input: ['_generate_pyx.py', 'functions.json', '_add_newdocs.py'],
   command: [py3, '@INPUT0@', '-o', '@OUTDIR@'],
   install: true,
-  install_dir: py3.get_install_dir() + '/scipy/special'
+  install_dir: py3.get_install_dir() / 'scipy/special'
 )
 
 # pyx -> c, pyx -> cpp generators, depending on copied pxi, pxd files.
@@ -494,7 +494,7 @@ foreach npz_file: npz_files
       '--use-timestamp', npz_file[2], '-o', '@OUTDIR@'
     ],
     install: true,
-    install_dir: py3.get_install_dir() + '/scipy/special/tests/data'
+    install_dir: py3.get_install_dir() / 'scipy/special/tests/data'
   )
 endforeach
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -9151,8 +9151,6 @@ class rv_histogram(rv_continuous):
       The second containing the (n+1) bin boundaries
       In particular the return value np.histogram is accepted
 
-        .. versionadded:: 1.10.0
-
     Notes
     -----
     There are no additional shape parameters except for the loc and scale.

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -9151,6 +9151,8 @@ class rv_histogram(rv_continuous):
       The second containing the (n+1) bin boundaries
       In particular the return value np.histogram is accepted
 
+        .. versionadded:: 1.10.0
+
     Notes
     -----
     There are no additional shape parameters except for the loc and scale.

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -1283,8 +1283,8 @@ def skew(a, axis=0, bias=True, nan_policy='propagate'):
     Returns
     -------
     skewness : ndarray
-        The skewness of values along an axis, returning 0 where all values are
-        equal.
+        The skewness of values along an axis, returning NaN where all values
+        are equal.
 
     Notes
     -----
@@ -1392,8 +1392,8 @@ def kurtosis(a, axis=0, fisher=True, bias=True, nan_policy='propagate'):
     Returns
     -------
     kurtosis : array
-        The kurtosis of values along an axis. If all values are equal,
-        return -3 for Fisher's definition and 0 for Pearson's definition.
+        The kurtosis of values along an axis, returning NaN where all values
+        are equal.
 
     References
     ----------

--- a/scipy/stats/_unuran/meson.build
+++ b/scipy/stats/_unuran/meson.build
@@ -164,7 +164,7 @@ unuran_include_dirs = [
   '../../_lib/unuran/unuran/src/tests'
 ]
 
-unuran_version = '16:0:0'  # TODO: grab from configure.ac file
+unuran_version = '16:0:0'  # taken from `_lib/unuran/unuran/configure.ac`
 
 unuran_defines = [
   '-DHAVE_ALARM=1',

--- a/tools/version_utils.py
+++ b/tools/version_utils.py
@@ -98,7 +98,8 @@ def git_version(cwd):
         # point from the current branch (assuming a full `git clone`, it may be
         # less if `--depth` was used - commonly the default in CI):
         prev_version_tag = '^v{}.{}.0'.format(MAJOR, MINOR - 2)
-        out = _minimal_ext_cmd(['git', 'rev-list', 'HEAD', prev_version_tag,
+        out = _minimal_ext_cmd(['git', '--git-dir', git_dir,
+                                'rev-list', 'HEAD', prev_version_tag,
                                 '--count'])
         COMMIT_COUNT = out.strip().decode('ascii')
         COMMIT_COUNT = '0' if not COMMIT_COUNT else COMMIT_COUNT


### PR DESCRIPTION
Backports the following PRs, which are all currently-merged PRs with an active backport label, for which there were no merge conflicts observed during cherry-picking. It looks like we'll delay Python `3.11` wheels to SciPy `1.9.2`. In the absence of a compelling reason to delay/issue in the wheels repo (etc.), I think the plan is to try to get a release out this weekend for `1.9.1`.

- https://github.com/scipy/scipy/pull/16749
- https://github.com/scipy/scipy/pull/16750
- https://github.com/scipy/scipy/pull/16760
- https://github.com/scipy/scipy/pull/16768
- https://github.com/scipy/scipy/pull/16794
- https://github.com/scipy/scipy/pull/16822
- https://github.com/scipy/scipy/pull/16825
- https://github.com/scipy/scipy/pull/16862
- https://github.com/scipy/scipy/pull/16881