### PR TITLE
ENH: stats.ttest_rel: add confidence_interval to result

### DIFF
--- a/scipy/stats/_result_classes.py
+++ b/scipy/stats/_result_classes.py
@@ -17,18 +17,18 @@ Result classes
    PearsonRResult
    FitResult
    OddsRatioResult
-   Ttest_Result
+   TtestResult
 
 """
 
 __all__ = ['BinomTestResult', 'RelativeRiskResult', 'TukeyHSDResult',
            'PearsonRResult', 'FitResult', 'OddsRatioResult',
-           'Ttest_Result']
+           'TtestResult']
 
 
 from ._binomtest import BinomTestResult
 from ._odds_ratio import OddsRatioResult
 from ._relative_risk import RelativeRiskResult
 from ._hypotests import TukeyHSDResult
-from ._stats_py import PearsonRResult, Ttest_Result
+from ._stats_py import PearsonRResult, TtestResult
 from ._fit import FitResult

--- a/scipy/stats/_result_classes.py
+++ b/scipy/stats/_result_classes.py
@@ -17,18 +17,18 @@ Result classes
    PearsonRResult
    FitResult
    OddsRatioResult
-   Ttest_1sampResult
+   Ttest_Result
 
 """
 
 __all__ = ['BinomTestResult', 'RelativeRiskResult', 'TukeyHSDResult',
            'PearsonRResult', 'FitResult', 'OddsRatioResult',
-           'Ttest_1sampResult']
+           'Ttest_Result']
 
 
 from ._binomtest import BinomTestResult
 from ._odds_ratio import OddsRatioResult
 from ._relative_risk import RelativeRiskResult
 from ._hypotests import TukeyHSDResult
-from ._stats_py import PearsonRResult, Ttest_1sampResult
+from ._stats_py import PearsonRResult, Ttest_Result
 from ._fit import FitResult

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -6023,13 +6023,17 @@ def _two_sample_transform(u, v):
 #       INFERENTIAL STATISTICS      #
 #####################################
 
-TTestResultBase = _make_tuple_bunch('TTestResultBase',
+TtestResultBase = _make_tuple_bunch('TtestResultBase',
                                     ['statistic', 'pvalue'], ['df'])
 
 
-class Ttest_1sampResult(TTestResultBase):
+class TtestResult(TtestResultBase):
     """
-    Result of `ttest_1samp`.
+    Result of a t-test.
+
+    See the documentation of the particular t-test function for more
+    information about the definition of the statistic and meaning of
+    the confidence interval.
 
     Attributes
     ----------
@@ -6045,7 +6049,7 @@ class Ttest_1sampResult(TTestResultBase):
     Methods
     -------
     confidence_interval
-        Computes a confidence interval around the population mean
+        Computes a confidence interval around the population statistic
         for the given confidence level.
         The confidence interval is returned in a ``namedtuple`` with
         fields `low` and `high`.
@@ -6081,23 +6085,23 @@ class Ttest_1sampResult(TTestResultBase):
         return ConfidenceInterval(low=low, high=high)
 
 
-def pack_Ttest_Result(statistic, pvalue, df, alternative, standard_error,
+def pack_TtestResult(statistic, pvalue, df, alternative, standard_error,
                       estimate):
     # this could be any number of dimensions (including 0d), but there is
     # at most one unique value
     alternative = np.atleast_1d(alternative).ravel()
     alternative = alternative[0] if alternative.size else np.nan
-    return Ttest_1sampResult(statistic, pvalue, df=df, alternative=alternative,
-                             standard_error=standard_error, estimate=estimate)
+    return TtestResult(statistic, pvalue, df=df, alternative=alternative,
+                       standard_error=standard_error, estimate=estimate)
 
 
-def unpack_Ttest_Result(res):
+def unpack_TtestResult(res):
     return (res.statistic, res.pvalue, res.df, res._alternative,
             res._standard_error, res._estimate)
 
 
-@_axis_nan_policy_factory(pack_Ttest_Result, default_axis=0, n_samples=2,
-                          result_to_tuple=unpack_Ttest_Result, n_outputs=6)
+@_axis_nan_policy_factory(pack_TtestResult, default_axis=0, n_samples=2,
+                          result_to_tuple=unpack_TtestResult, n_outputs=6)
 def ttest_1samp(a, popmean, axis=0, nan_policy='propagate',
                 alternative="two-sided"):
     """Calculate the T-test for the mean of ONE group of scores.
@@ -6137,7 +6141,7 @@ def ttest_1samp(a, popmean, axis=0, nan_policy='propagate',
 
     Returns
     -------
-    result : `~scipy.stats._result_classes.Ttest_1sampResult`
+    result : `~scipy.stats._result_classes.TtestResult`
         An object with the following attributes:
 
         statistic : float or array
@@ -6184,7 +6188,7 @@ def ttest_1samp(a, popmean, axis=0, nan_policy='propagate',
     >>> rng = np.random.default_rng()
     >>> rvs = stats.uniform.rvs(size=50, random_state=rng)
     >>> stats.ttest_1samp(rvs, popmean=0.5)
-    Ttest_1sampResult(statistic=2.456308468440, pvalue=0.017628209047638, df=49)  # noqa
+    TtestResult(statistic=2.456308468440, pvalue=0.017628209047638, df=49)
 
     As expected, the p-value of 0.017 is not below our threshold of 0.01, so
     we cannot reject the null hypothesis.
@@ -6194,7 +6198,7 @@ def ttest_1samp(a, popmean, axis=0, nan_policy='propagate',
 
     >>> rvs = stats.norm.rvs(size=50, random_state=rng)
     >>> stats.ttest_1samp(rvs, popmean=0.5)
-    Ttest_1sampResult(statistic=-7.433605518875, pvalue=1.416760157221e-09, df=49)  # noqa
+    TtestResult(statistic=-7.433605518875, pvalue=1.416760157221e-09, df=49)
 
     Indeed, the p-value is lower than our threshold of 0.01, so we reject the
     null hypothesis in favor of the default "two-sided" alternative: the mean
@@ -6206,7 +6210,7 @@ def ttest_1samp(a, popmean, axis=0, nan_policy='propagate',
     expect the null hypothesis to be rejected.
 
     >>> stats.ttest_1samp(rvs, popmean=0.5, alternative='greater')
-    Ttest_1sampResult(statistic=-7.433605518875, pvalue=0.99999999929, df=49)  # noqa
+    TtestResult(statistic=-7.433605518875, pvalue=0.99999999929, df=49)
 
     Unsurprisingly, with a p-value greater than our threshold, we would not
     reject the null hypothesis.
@@ -6275,8 +6279,8 @@ def ttest_1samp(a, popmean, axis=0, nan_policy='propagate',
     df = np.broadcast_to(df, t.shape)[()]
     # _axis_nan_policy decorator doesn't play well with strings
     alternative_num = {"less": -1, "two-sided": 0, "greater": 1}[alternative]
-    return Ttest_1sampResult(t, prob, df=df, alternative=alternative_num,
-                             standard_error=denom, estimate=mean)
+    return TtestResult(t, prob, df=df, alternative=alternative_num,
+                       standard_error=denom, estimate=mean)
 
 
 def _t_confidence_interval(df, t, confidence_level, alternative):
@@ -7021,9 +7025,9 @@ def _get_len(a, axis, msg):
     return n
 
 
-Ttest_relResult = namedtuple('Ttest_relResult', ('statistic', 'pvalue'))
-
-
+@_axis_nan_policy_factory(pack_TtestResult, default_axis=0, n_samples=2,
+                          result_to_tuple=unpack_TtestResult, n_outputs=6,
+                          paired=True)
 def ttest_rel(a, b, axis=0, nan_policy='propagate', alternative="two-sided"):
     """Calculate the t-test on TWO RELATED samples of scores, a and b.
 
@@ -7061,10 +7065,28 @@ def ttest_rel(a, b, axis=0, nan_policy='propagate', alternative="two-sided"):
 
     Returns
     -------
-    statistic : float or array
-        t-statistic.
-    pvalue : float or array
-        The p-value.
+    result : `~scipy.stats._result_classes.TtestResult`
+        An object with the following attributes:
+        statistic : float or array
+            The t-statistic.
+        pvalue : float or array
+            The p-value associated with the given alternative.
+        df : float or array
+            The number of degrees of freedom used in calculation of the
+            t-statistic; this is one less than the size of the sample
+            (``a.shape[axis]``).
+
+            .. versionadded:: 1.10.0
+
+        The object also has the following method:
+
+        confidence_interval(confidence_level=0.95)
+            Computes a confidence interval around the difference in
+            population means for the given confidence level.
+            The confidence interval is returned in a ``namedtuple`` with
+            fields `low` and `high`.
+
+            .. versionadded:: 1.10.0
 
     Notes
     -----
@@ -7078,8 +7100,8 @@ def ttest_rel(a, b, axis=0, nan_policy='propagate', alternative="two-sided"):
     hypothesis of equal averages. Small p-values are associated with
     large t-statistics.
 
-    The statistic is calculated as ``np.mean(a - b)/se``, where ``se`` is the
-    standard error. Therefore, the statistic will be positive when the sample
+    The t-statistic is calculated as ``np.mean(a - b)/se``, where ``se`` is the
+    standard error. Therefore, the t-statistic will be positive when the sample
     mean of ``a - b`` is greater than zero and negative when the sample mean of
     ``a - b`` is less than zero.
 
@@ -7097,36 +7119,24 @@ def ttest_rel(a, b, axis=0, nan_policy='propagate', alternative="two-sided"):
     >>> rvs2 = (stats.norm.rvs(loc=5, scale=10, size=500, random_state=rng)
     ...         + stats.norm.rvs(scale=0.2, size=500, random_state=rng))
     >>> stats.ttest_rel(rvs1, rvs2)
-    Ttest_relResult(statistic=-0.4549717054410304, pvalue=0.6493274702088672)
+    TtestResult(statistic=-0.4549717054410304, pvalue=0.6493274702088672, df=499)  # noqa
     >>> rvs3 = (stats.norm.rvs(loc=8, scale=10, size=500, random_state=rng)
     ...         + stats.norm.rvs(scale=0.2, size=500, random_state=rng))
     >>> stats.ttest_rel(rvs1, rvs3)
-    Ttest_relResult(statistic=-5.879467544540889, pvalue=7.540777129099917e-09)
+    TtestResult(statistic=-5.879467544540889, pvalue=7.540777129099917e-09, df=499)  # noqa
 
     """
     a, b, axis = _chk2_asarray(a, b, axis)
-
-    cna, npa = _contains_nan(a, nan_policy)
-    cnb, npb = _contains_nan(b, nan_policy)
-    contains_nan = cna or cnb
-    if npa == 'omit' or npb == 'omit':
-        nan_policy = 'omit'
-
-    if contains_nan and nan_policy == 'omit':
-        a = ma.masked_invalid(a)
-        b = ma.masked_invalid(b)
-        m = ma.mask_or(ma.getmask(a), ma.getmask(b))
-        aa = ma.array(a, mask=m, copy=True)
-        bb = ma.array(b, mask=m, copy=True)
-        return mstats_basic.ttest_rel(aa, bb, axis, alternative)
 
     na = _get_len(a, axis, "first argument")
     nb = _get_len(b, axis, "second argument")
     if na != nb:
         raise ValueError('unequal length arrays')
 
-    if na == 0:
-        return _ttest_nans(a, b, axis, Ttest_relResult)
+    if na == 0 or nb == 0:
+        # _axis_nan_policy decorator ensures this only happens with 1d input
+        return TtestResult(np.nan, np.nan, df=np.nan, alternative=np.nan,
+                           standard_error=np.nan, estimate=np.nan)
 
     n = a.shape[axis]
     df = n - 1
@@ -7140,7 +7150,13 @@ def ttest_rel(a, b, axis=0, nan_policy='propagate', alternative="two-sided"):
         t = np.divide(dm, denom)
     t, prob = _ttest_finish(df, t, alternative)
 
-    return Ttest_relResult(t, prob)
+    # when nan_policy='omit', `df` can be different for different axis-slices
+    df = np.broadcast_to(df, t.shape)[()]
+
+    # _axis_nan_policy decorator doesn't play well with strings
+    alternative_num = {"less": -1, "two-sided": 0, "greater": 1}[alternative]
+    return TtestResult(t, prob, df=df, alternative=alternative_num,
+                       standard_error=denom, estimate=dm)
 
 
 # Map from names to lambda_ values used in power_divergence().

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -7067,6 +7067,7 @@ def ttest_rel(a, b, axis=0, nan_policy='propagate', alternative="two-sided"):
     -------
     result : `~scipy.stats._result_classes.TtestResult`
         An object with the following attributes:
+
         statistic : float or array
             The t-statistic.
         pvalue : float or array

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -16,7 +16,7 @@ from scipy import stats
 from scipy.stats._axis_nan_policy import _masked_arrays_2_sentinel_arrays
 
 
-def unpack_ttest_1samp(res):
+def unpack_ttest_result(res):
     low, high = res.confidence_interval()
     return (res.statistic, res.pvalue, res.df, res._standard_error,
             res._estimate, low, high)
@@ -46,7 +46,8 @@ axis_nan_policy_cases = [
     (stats.moment, tuple(), dict(moment=[1, 2]), 1, 2, False, None),
     (stats.jarque_bera, tuple(), dict(), 1, 2, False, None),
     (stats.ttest_1samp, (np.array([0]),), dict(), 1, 7, False,
-     unpack_ttest_1samp)
+     unpack_ttest_result),
+    (stats.ttest_rel, tuple(), dict(), 2, 7, True, unpack_ttest_result)
 ]
 
 # If the message is one of those expected, put nans in


### PR DESCRIPTION
#### Reference issue
gh-15906
gh-9485
Follow-up of gh-16835

#### What does this implement/fix?
Adds a confidence interval and degree of freedom parameter to the object returned by `ttest_rel`.