### PR TITLE
ENH:interpolate: allow interp1d to take single value

### DIFF
--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -504,7 +504,7 @@ class interp1d(_Interpolator1D):
         if kind in ('linear', 'nearest', 'nearest-up', 'previous', 'next'):
             # Make a "view" of the y array that is rotated to the interpolation
             # axis.
-            minval = 2
+            minval = 1
             if kind == 'nearest':
                 # Do division before addition to prevent possible integer
                 # overflow

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -193,7 +193,6 @@ class TestInterp1D:
         # Check for x and y having at least 1 element.
         assert_raises(ValueError, interp1d, self.x1, self.y10)
         assert_raises(ValueError, interp1d, self.x10, self.y1)
-        assert_raises(ValueError, interp1d, self.x1, self.y1)
 
         # Bad fill values
         assert_raises(ValueError, interp1d, self.x10, self.y10, kind='linear',
@@ -878,11 +877,13 @@ class TestInterp1D:
                 vals = f(xnew)
                 assert_(np.isfinite(vals).all())
 
-    @pytest.mark.parametrize('kind', ('linear', 'nearest', 'zero', 'slinear',
-                                      'quadratic', 'cubic'))
+    @pytest.mark.parametrize('kind', ('linear', 'nearest'))
     def test_single_value(self, kind):
+        # https://github.com/scipy/scipy/issues/4043
         f = interp1d([1.5], [6], kind=kind)
         assert_array_equal(f(1.5), [6])
+        f = interp1d([0], [[1,2]], axis=0)
+        assert_array_equal(f(0), [1,2])
 
 
 class TestLagrange:

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -878,6 +878,12 @@ class TestInterp1D:
                 vals = f(xnew)
                 assert_(np.isfinite(vals).all())
 
+    @pytest.mark.parametrize('kind', ('linear', 'nearest', 'zero', 'slinear',
+                                      'quadratic', 'cubic'))
+    def test_single_value(self, kind):
+        f = interp1d([1.5], [6], kind=kind)
+        assert_array_equal(f(1.5), [6])
+
 
 class TestLagrange:
 

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -877,13 +877,18 @@ class TestInterp1D:
                 vals = f(xnew)
                 assert_(np.isfinite(vals).all())
 
-    @pytest.mark.parametrize('kind', ('linear', 'nearest'))
+    @pytest.mark.parametrize(
+        "kind", ("linear", "nearest", "nearest-up", "previous", "next")
+    )
     def test_single_value(self, kind):
         # https://github.com/scipy/scipy/issues/4043
-        f = interp1d([1.5], [6], kind=kind)
-        assert_array_equal(f(1.5), [6])
-        f = interp1d([0], [[1,2]], axis=0)
-        assert_array_equal(f(0), [1,2])
+        f = interp1d([1.5], [6], kind=kind, bounds_error=False,
+                     fill_value=(2, 10))
+        assert_array_equal(f([1, 1.5, 2]), [2, 6, 10])
+        # check still error if bounds_error=True
+        f = interp1d([1.5], [6], kind=kind, bounds_error=True)
+        with assert_raises(ValueError, match="x_new is above"):
+            f(2.0)
 
 
 class TestLagrange:


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
closes #4043
#### What does this implement/fix?
<!--Please explain your changes.-->

Modifies `interp1d` to take a single value as requested. The change is trivial and is actually handled fine by the existing code.

I have only made this change to the non-spline methods as I am not sure it makes sense to do for the spline methods.

#### Additional information
<!--Any additional information you think is important.-->
