### PR TITLE
WIP: interpolate: bump nxest, nyest on a failure

### DIFF
--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -1293,6 +1293,27 @@ class SmoothBivariateSpline(BivariateSpline):
                                                                     s=s,
                                                                     eps=eps,
                                                                     lwrk2=ier)
+        if ier == 1:
+            # nxest or nyest was too small, re-run
+            nxest = 2*kx + 2 + len(x)
+            nyest = 2*ky + 2 + len(y)
+            nx, tx, ny, ty, c, fp, wrk1, ier = dfitpack.surfit_smth(x, y, z, w,
+                                                                    xb, xe, yb,
+                                                                    ye, kx, ky,
+                                                                    s=s, eps=eps,
+                                                                    lwrk2=1,
+                                                                    nxest=nxest,
+                                                                    nyest=nyest)
+            if ier > 10:          # lwrk2 was to small, re-run
+                nx, tx, ny, ty, c, fp, wrk1, ier = dfitpack.surfit_smth(x, y, z, w,
+                                                                        xb, xe, yb,
+                                                                        ye, kx, ky,
+                                                                        s=s,
+                                                                        eps=eps,
+                                                                        lwrk2=ier,
+                                                                        nxest=nxest,
+                                                                        nyest=nyest)
+
         if ier in [0, -1, -2]:  # normal return
             pass
         else:

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -537,11 +537,7 @@ class TestSmoothBivariateSpline:
         x = [1,1,1,2,2,2,4,4,4]
         y = [1,2,3,1,2,3,1,2,3]
         z = array([0,7,8,3,4,7,1,3,4])
-
-        with suppress_warnings() as sup:
-            # This seems to fail (ier=1, see ticket 1642).
-            sup.filter(UserWarning, "\nThe required storage space")
-            lut = SmoothBivariateSpline(x, y, z, kx=1, ky=1, s=0)
+        lut = SmoothBivariateSpline(x, y, z, kx=1, ky=1, s=0)
 
         tx = [1,2,4]
         ty = [1,2,3]


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

closes gh-2167 when complete

#### What does this implement/fix?
<!--Please explain your changes.-->

The warning from FITPACK is for `s=0` (interpolation) and is literally 

    The required storage space exceeds the available storage space: nxest  or nyest too small, or s too small.

These nxest, nyest give a maximum number of knots to insert. For the test case from gh-2167 (which is https://github.com/scipy/scipy/blob/main/scipy/interpolate/tests/test_fitpack2.py#L536), FITPACK actually runs into the nxest, nyest limit. The limit comes from the f2py wrapper, `nxest = imax(kx+1+sqrt(m/2),2*(kx+1))` where `m` is the number of data points. This value can be traced to the comment in surfit.f, which literally says

    in most practical situation nxest = kx+1+sqrt(m/2), nyest = ky+1+sqrt(m/2) will be sufficient.

So here we have a situation where it is not sufficient. Since the data does not seem special, I suspect it's typical for kx=ky=1, i.e. linear interpolation. 

Therefore, in case of a failure, bump the allowed number of knots and rerun. Spot-checking the interpolator shows that (i) in main, `lut.fp` is non-zero (meaning, the result is *not* an interpolating spline) and in this PR it is, so that the interpolation conditions are satisfied.

However, the test fails down the line on the value of the integral. This needs to be figured out.

#### Additional information
<!--Any additional information you think is important.-->

 - [ ] the fix will need to be checked on other test cases from gh-2167, gh-4138 and the SO report linked in that issue.
 - [ ] need to implement the fix in `bisplrep` interface, too
 - [ ] need to think about the API: is it the automatic rerun or we better expose the `nxest/nyest` parameters to a user so that they are in control
