### PR TITLE
DOC: update version switcher for 1.9.1 and pin theme to 0.9

### DIFF
--- a/doc/source/_static/version_switcher.json
+++ b/doc/source/_static/version_switcher.json
@@ -5,7 +5,12 @@
         "url": "https://scipy.github.io/devdocs/"
     },
     {
-        "name": "1.9.0 (stable)",
+        "name": "1.9.1 (stable)",
+        "version":"1.9.1",
+        "url": "https://docs.scipy.org/doc/scipy-1.9.1/"
+    },
+    {
+        "name": "1.9.0",
         "version":"1.9.0",
         "url": "https://docs.scipy.org/doc/scipy-1.9.0/"
     },

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -1,7 +1,7 @@
 # Note: this should disappear at some point. For now, please keep it
 #       in sync with the doc dependencies in pyproject.toml
 Sphinx!=4.1.0
-pydata-sphinx-theme>=0.9.0
+pydata-sphinx-theme==0.9.0
 sphinx-design>=0.2.0
 numpydoc
 matplotlib>2

--- a/environment.yml
+++ b/environment.yml
@@ -36,7 +36,7 @@ dependencies:
   - numpydoc
   - ipython
   - matplotlib
-  - pydata-sphinx-theme>=0.9.0
+  - pydata-sphinx-theme==0.9.0
   - sphinx-design
   # For linting
   - flake8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ test = [
 ]
 doc = [
     "sphinx!=4.1.0",
-    "pydata-sphinx-theme>=0.9.0",
+    "pydata-sphinx-theme==0.9.0",
     "sphinx-design>=0.2.0",
     "matplotlib>2",
     "numpydoc",


### PR DESCRIPTION
Update the version switcher configuration file to account for 1.9.1.

Also it pins the pydata-sphinx-theme to the current 0.9. 0.10 will be released today and as seen in my preparatory PR #16660, build time increased significantly so we cannot update now.

Putting this in the 1.9.2 milestones in case the new release of the theme is not ready.