### PR TITLE
MAINT: interpolate: remove duplicated `splint` from `_fitpack`

### DIFF
--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -7,7 +7,6 @@ from scipy.linalg import (get_lapack_funcs, LinAlgError,
                           solve, solve_banded)
 from . import _bspl
 from . import _fitpack_impl
-from . import _fitpack as _dierckx
 from scipy._lib._util import prod
 from scipy.sparse import csr_array
 from scipy.special import poch
@@ -657,8 +656,7 @@ class BSpline:
             if self.c.ndim == 1:
                 # Fast path: use FITPACK's routine
                 # (cf _fitpack_impl.splint).
-                t, c, k = self.tck
-                integral, wrk = _dierckx._splint(t, c, k, a, b)
+                integral = _fitpack_impl.splint(a, b, self.tck)
                 return integral * sign
 
         out = np.empty((2, prod(self.c.shape[1:])), dtype=self.c.dtype)

--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -437,7 +437,7 @@ class UnivariateSpline:
         0.0
 
         """
-        return dfitpack.splint(*(self._eval_args+(a, b)))
+        return _fitpack_impl.splint(a, b, self._eval_args)
 
     def derivatives(self, x):
         """ Return all derivatives of the spline at the point x.

--- a/scipy/interpolate/_fitpack_impl.py
+++ b/scipy/interpolate/_fitpack_impl.py
@@ -654,7 +654,13 @@ def splint(a, b, tck, full_output=0):
         return list(map(lambda c, a=a, b=b, t=t, k=k:
                         splint(a, b, [t, c, k]), c))
     else:
-        aint, wrk = _fitpack._splint(t, c, k, a, b)
+        if t.size != c.size:
+            if c.size >= t.size - k - 1:
+                # If t and c are not the same size, c is padded with zeros.
+                c = np.pad(c, (0, t.size - c.size))
+            else:
+                raise ValueError("t and c are invalid length.")
+        aint, wrk = dfitpack.splint(t, c, k, a, b)
         if full_output:
             return aint, wrk
         else:

--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -63,7 +63,6 @@ static PyObject *fitpack_error;
 /*  module_methods:
  * {"_curfit", fitpack_curfit, METH_VARARGS, doc_curfit},
  * {"_spl_", fitpack_spl_, METH_VARARGS, doc_spl_},
- * {"_splint", fitpack_splint, METH_VARARGS, doc_splint},
  * {"_sproot", fitpack_sproot, METH_VARARGS, doc_sproot},
  * {"_spalde", fitpack_spalde, METH_VARARGS, doc_spalde},
  * {"_parcur", fitpack_parcur, METH_VARARGS, doc_parcur},
@@ -719,45 +718,6 @@ fitpack_spl_(PyObject *dummy, PyObject *args)
 fail:
     free(wrk);
     Py_XDECREF(ap_x);
-    Py_XDECREF(ap_c);
-    Py_XDECREF(ap_t);
-    return NULL;
-}
-
-static char doc_splint[] = " [aint,wrk] = _splint(t,c,k,a,b)";
-static PyObject *
-fitpack_splint(PyObject *dummy, PyObject *args)
-{
-    F_INT k, n;
-    npy_intp dims[1];
-    double *t, *c, *wrk = NULL, a, b, aint;
-    PyArrayObject *ap_t = NULL, *ap_c = NULL;
-    PyArrayObject *ap_wrk = NULL;
-    PyObject *t_py = NULL, *c_py = NULL;
-
-    if (!PyArg_ParseTuple(args, ("OO" F_INT_PYFMT "dd"),&t_py,&c_py,&k,&a,&b)) {
-        return NULL;
-    }
-    ap_t = (PyArrayObject *)PyArray_ContiguousFromObject(t_py, NPY_DOUBLE, 0, 1);
-    ap_c = (PyArrayObject *)PyArray_ContiguousFromObject(c_py, NPY_DOUBLE, 0, 1);
-    if ((ap_t == NULL || ap_c == NULL)) {
-        goto fail;
-    }
-    t = (double *)PyArray_DATA(ap_t);
-    c = (double *)PyArray_DATA(ap_c);
-    n = PyArray_DIMS(ap_t)[0];
-    dims[0] = n;
-    ap_wrk = (PyArrayObject *)PyArray_SimpleNew(1, dims, NPY_DOUBLE);
-    if (ap_wrk == NULL) {
-        goto fail;
-    }
-    wrk = (double *)PyArray_DATA(ap_wrk);
-    aint = SPLINT(t,&n,c,&k,&a,&b,wrk);
-    Py_DECREF(ap_c);
-    Py_DECREF(ap_t);
-    return Py_BuildValue("dN", aint, PyArray_Return(ap_wrk));
-
-fail:
     Py_XDECREF(ap_c);
     Py_XDECREF(ap_t);
     return NULL;
@@ -1514,9 +1474,6 @@ static struct PyMethodDef fitpack_module_methods[] = {
 {"_spl_",
     fitpack_spl_,
     METH_VARARGS, doc_spl_},
-{"_splint",
-    fitpack_splint,
-    METH_VARARGS, doc_splint},
 {"_sproot",
     fitpack_sproot,
     METH_VARARGS, doc_sproot},

--- a/scipy/interpolate/src/fitpack.pyf
+++ b/scipy/interpolate/src/fitpack.pyf
@@ -141,7 +141,7 @@ static F_INT calc_regrid_lwrk(F_INT mx, F_INT my, F_INT kx, F_INT ky,
      end subroutine splder
 
      function splint(t,n,c,k,a,b,wrk)
-       ! iy = splint(t,c,k,a,b)
+       ! iy, wrk = splint(t,c,k,a,b)
        threadsafe
        real*8 dimension(n),intent(in) :: t
        integer intent(hide),depend(t) :: n=len(t)
@@ -149,7 +149,7 @@ static F_INT calc_regrid_lwrk(F_INT mx, F_INT my, F_INT kx, F_INT ky,
        integer intent(in) :: k
        real*8 intent(in) :: a
        real*8 intent(in) :: b
-       real*8 dimension(n),depend(n),intent(cache,hide) :: wrk
+       real*8 dimension(n),depend(n),intent(cache,hide,out) :: wrk
        real*8 :: splint
      end function splint
 

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -13,7 +13,6 @@ from scipy.interpolate._bsplines import (_not_a_knot, _augknt,
                                         _woodbury_algorithm, _periodic_knots,
                                          _make_interp_per_full_matr)
 import scipy.interpolate._fitpack_impl as _impl
-from scipy.interpolate._fitpack import _splint
 
 
 class TestBSpline:
@@ -343,9 +342,8 @@ class TestBSpline:
         assert_allclose(b.integrate(1, -1, extrapolate=False), -1 * 0.5)
 
         # Test ``_fitpack._splint()``
-        t, c, k = b.tck
         assert_allclose(b.integrate(1, -1, extrapolate=False),
-                        _splint(t, c, k, 1, -1)[0])
+                        _impl.splint(1, -1, b.tck))
 
         # Test ``extrapolate='periodic'``.
         b.extrapolate = 'periodic'
@@ -886,6 +884,10 @@ class TestInterop:
         assert_equal(integr.shape, (3, 2))
         assert_allclose(integr,
                         splint(0, 1, b), atol=1e-14)
+
+        with assert_raises(ValueError, match="t and c are invalid length."):
+            splint(0, 1, (np.ones(10), np.ones(5), 3))
+
 
     def test_splder(self):
         for b in [self.b, self.b2]:

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -888,7 +888,6 @@ class TestInterop:
         with assert_raises(ValueError, match="t and c are invalid length."):
             splint(0, 1, (np.ones(10), np.ones(5), 3))
 
-
     def test_splder(self):
         for b in [self.b, self.b2]:
             # pad the c array (FITPACK convention)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
A part of #16729
This PR is another option to #16871

#### What does this implement/fix?
<!--Please explain your changes.-->
As reported in #16729, _fitpack and dfitpack have some dupricated interfaces of FITPACK.
This PR focuses on `splint` and remove the _fitpack interface.

#### Additional information
<!--Any additional information you think is important.-->
