### PR TITLE
MAINT : interpolate: added test for DivideByZero warning silencing in BarycentricInterpolator

### DIFF
--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -388,6 +388,16 @@ class TestBarycentric:
         factor = P.wi[0]
         assert_almost_equal(P.wi / (2 * factor), w)
 
+    def test_warning(self):
+        # Test if the divide-by-zero warning is properly ignored when building
+        # the weights
+        P = BarycentricInterpolator([0, 1], [1, 2])
+        with np.errstate(divide='raise'):
+            yi = P(P.xi)
+
+        # Additionaly check if the interpolated values are the nodes values
+        assert_almost_equal(yi, P.yi.ravel())
+
 
 class TestPCHIP:
     def _make_random(self, npts=20):

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -389,8 +389,8 @@ class TestBarycentric:
         assert_almost_equal(P.wi / (2 * factor), w)
 
     def test_warning(self):
-        # Test if the divide-by-zero warning is properly ignored when building
-        # the weights
+        # Test if the divide-by-zero warning is properly ignored when computing
+        # interpolated values equals to interpolation points
         P = BarycentricInterpolator([0, 1], [1, 2])
         with np.errstate(divide='raise'):
             yi = P(P.xi)


### PR DESCRIPTION
#### Reference issue
See https://github.com/scipy/scipy/pull/16857#issuecomment-1221068549

#### What does this implement/fix?
Add a test, that turns on error when divide by zero, and check that evaluating the BarycentricInterpolator on interpolating points still works.

#### Additional information
<!--Any additional information you think is important.-->
None