### PR TITLE
MAINT: cast `linear_sum_assignment` to PyCFunction

### DIFF
--- a/scipy/optimize/_lsap.c
+++ b/scipy/optimize/_lsap.c
@@ -103,7 +103,7 @@ cleanup:
 
 static PyMethodDef lsap_methods[] = {
     { "linear_sum_assignment",
-      linear_sum_assignment,
+      (PyCFunction)linear_sum_assignment,
       METH_VARARGS | METH_KEYWORDS,
 "Solve the linear sum assignment problem.\n"
 "\n"


### PR DESCRIPTION
One more `-Wincompatible-function-pointer-types` fix. `linear_sum_assignment` has the correct signature for `METH_VARARGS | METH_KEYWORDS`: `PyCFunctionWithKeywords` which is `PyObject* (*f)(PyObject*,PyObject*,PyObject*)`. The `ml_meth` entry in `PyMethodDef` must have type `PyCFunction` which is `PyObject* (*f)(PyObject*,PyObject*)`. To prevent an error, we have to cast it explicitly.