### PR TITLE
MAINT: refer to python3 in refguide_check

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -1006,7 +1006,9 @@ class RefguideCheck(Task):
         args = Args(**kwargs)
         dirs = Dirs(args)
 
-        cmd = [str(dirs.root / 'tools' / 'refguide_check.py'), '--doctests']
+        cmd = [f'{sys.executable}',
+               str(dirs.root / 'tools' / 'refguide_check.py'),
+               '--doctests']
         if args.verbose:
             cmd += ['-vvv']
         if args.submodule:

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 refguide_check.py [OPTIONS] [-- ARGS]
 
@@ -7,7 +7,7 @@ correspond to the objects included in the reference guide.
 
 Example of usage::
 
-    $ python refguide_check.py optimize
+    $ python3 refguide_check.py optimize
 
 Note that this is a helper script to be able to check if things are missing;
 the output of this script does need to be checked manually.  In some cases
@@ -19,7 +19,7 @@ in docstrings. This is different from doctesting [we do not aim to have
 scipy docstrings doctestable!], this is just to make sure that code in
 docstrings is valid python::
 
-    $ python refguide_check.py --doctests optimize
+    $ python3 refguide_check.py --doctests optimize
 
 """
 import copy


### PR DESCRIPTION
#### What does this implement/fix?
On systems with `python3` but no `python` executable, running refguide-check via dev.py would result in failure. This PR updates the tool to refer to `python3` specifically.
