### PR TITLE
MAINT: stats: move `_contains_nan` function to `_lib._util.py`

### DIFF
--- a/scipy/_lib/tests/test__util.py
+++ b/scipy/_lib/tests/test__util.py
@@ -13,7 +13,8 @@ from pytest import raises as assert_raises, deprecated_call
 import scipy
 from scipy._lib._util import (_aligned_zeros, check_random_state, MapWrapper,
                               getfullargspec_no_self, FullArgSpec,
-                              rng_integers, _validate_int, _rename_parameter)
+                              rng_integers, _validate_int, _rename_parameter,
+                              _contains_nan)
 
 
 def test__aligned_zeros():
@@ -326,3 +327,54 @@ class TestRenameParameter:
         with pytest.raises(TypeError, match=message), \
                 pytest.warns(DeprecationWarning, match=dep_msg):
             self.old_keyword_deprecated(new=10, old=10)
+
+
+class TestContainsNaNTest:
+
+    def test_policy(self):
+        data = np.array([1, 2, 3, np.nan])
+
+        contains_nan, nan_policy = _contains_nan(data, nan_policy="propagate")
+        assert contains_nan
+        assert nan_policy == "propagate"
+
+        contains_nan, nan_policy = _contains_nan(data, nan_policy="omit")
+        assert contains_nan
+        assert nan_policy == "omit"
+
+        msg = "The input contains nan values"
+        with pytest.raises(ValueError, match=msg):
+            _contains_nan(data, nan_policy="raise")
+
+        msg = "nan_policy must be one of"
+        with pytest.raises(ValueError, match=msg):
+            _contains_nan(data, nan_policy="nan")
+
+    def test_contains_nan_1d(self):
+        data1 = np.array([1, 2, 3])
+        assert not _contains_nan(data1)[0]
+
+        data2 = np.array([1, 2, 3, np.nan])
+        assert _contains_nan(data2)[0]
+
+        data3 = np.array([np.nan, 2, 3, np.nan])
+        assert _contains_nan(data3)[0]
+
+        data4 = np.array([1, 2, "3", np.nan])  # converted to string "nan"
+        assert not _contains_nan(data4)[0]
+
+        data5 = np.array([1, 2, "3", np.nan], dtype='object')
+        assert _contains_nan(data5)[0]
+
+    def test_contains_nan_2d(self):
+        data1 = np.array([[1, 2], [3, 4]])
+        assert not _contains_nan(data1)[0]
+
+        data2 = np.array([[1, 2], [3, np.nan]])
+        assert _contains_nan(data2)[0]
+
+        data3 = np.array([["1", 2], [3, np.nan]])  # converted to string "nan"
+        assert not _contains_nan(data3)[0]
+
+        data4 = np.array([["1", 2], [3, np.nan]], dtype='object')
+        assert _contains_nan(data4)[0]

--- a/scipy/stats/_axis_nan_policy.py
+++ b/scipy/stats/_axis_nan_policy.py
@@ -9,6 +9,7 @@ import scipy.stats
 import scipy.stats._stats_py
 from functools import wraps
 from scipy._lib._docscrape import FunctionDoc, Parameter
+from scipy._lib._util import _contains_nan
 import inspect
 
 
@@ -475,8 +476,7 @@ def _axis_nan_policy_factory(tuple_to_result, default_axis=0,
                 # Addresses nan_policy == "raise"
                 contains_nans = []
                 for sample in samples:
-                    contains_nan, _ = (
-                        scipy.stats._stats_py._contains_nan(sample, nan_policy))
+                    contains_nan, _ = _contains_nan(sample, nan_policy)
                     contains_nans.append(contains_nan)
 
                 # Addresses nan_policy == "propagate"
@@ -523,8 +523,7 @@ def _axis_nan_policy_factory(tuple_to_result, default_axis=0,
             x = _broadcast_concatenate(samples, axis)
 
             # Addresses nan_policy == "raise"
-            contains_nan, _ = (
-                scipy.stats._stats_py._contains_nan(x, nan_policy))
+            contains_nan, _ = _contains_nan(x, nan_policy)
 
             if vectorized and not contains_nan and not sentinel:
                 res = hypotest_fun_out(*samples, axis=axis, **kwds)

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -12,12 +12,12 @@ from numpy import (isscalar, r_, log, around, unique, asarray, zeros,
 from scipy import optimize
 from scipy import special
 from scipy._lib._bunch import _make_tuple_bunch
-from scipy._lib._util import _rename_parameter
+from scipy._lib._util import (_rename_parameter, _contains_nan)
 
 from . import _statlib
 from . import _stats_py
 from ._fit import FitResult
-from ._stats_py import (find_repeats, _contains_nan, _normtest_finish,
+from ._stats_py import (find_repeats, _normtest_finish,
                         SignificanceResult)
 from .contingency import chi2_contingency
 from . import distributions

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -12,13 +12,12 @@ from numpy import (isscalar, r_, log, around, unique, asarray, zeros,
 from scipy import optimize
 from scipy import special
 from scipy._lib._bunch import _make_tuple_bunch
-from scipy._lib._util import (_rename_parameter, _contains_nan)
+from scipy._lib._util import _rename_parameter, _contains_nan
 
 from . import _statlib
 from . import _stats_py
 from ._fit import FitResult
-from ._stats_py import (find_repeats, _normtest_finish,
-                        SignificanceResult)
+from ._stats_py import find_repeats, _normtest_finish, SignificanceResult
 from .contingency import chi2_contingency
 from . import distributions
 from ._distn_infrastructure import rv_generic

--- a/scipy/stats/_mstats_basic.py
+++ b/scipy/stats/_mstats_basic.py
@@ -41,7 +41,7 @@ import warnings
 from collections import namedtuple
 
 from . import distributions
-from scipy._lib._util import (_rename_parameter, _contains_nan)
+from scipy._lib._util import _rename_parameter, _contains_nan
 from scipy._lib._bunch import _make_tuple_bunch
 import scipy.special as special
 import scipy.stats._stats_py

--- a/scipy/stats/_mstats_basic.py
+++ b/scipy/stats/_mstats_basic.py
@@ -41,7 +41,7 @@ import warnings
 from collections import namedtuple
 
 from . import distributions
-from scipy._lib._util import _rename_parameter
+from scipy._lib._util import (_rename_parameter, _contains_nan)
 from scipy._lib._bunch import _make_tuple_bunch
 import scipy.special as special
 import scipy.stats._stats_py
@@ -2484,7 +2484,7 @@ def winsorize(a, limits=None, inclusive=(True, True), inplace=False,
                 a[idx[upidx:]] = a[idx[upidx - 1]]
         return a
 
-    contains_nan, nan_policy = scipy.stats._stats_py._contains_nan(a, nan_policy)
+    contains_nan, nan_policy = _contains_nan(a, nan_policy)
     # We are going to modify a: better make a copy
     a = ma.array(a, copy=np.logical_not(inplace))
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -39,7 +39,7 @@ from numpy.testing import suppress_warnings
 from scipy.spatial.distance import cdist
 from scipy.ndimage import _measurements
 from scipy._lib._util import (check_random_state, MapWrapper,
-                              rng_integers, _rename_parameter)
+                              rng_integers, _rename_parameter, _contains_nan)
 
 import scipy.special as special
 from scipy import linalg
@@ -82,37 +82,6 @@ __all__ = ['find_repeats', 'gmean', 'hmean', 'pmean', 'mode', 'tmean', 'tvar',
            'combine_pvalues', 'wasserstein_distance', 'energy_distance',
            'brunnermunzel', 'alexandergovern']
 
-
-def _contains_nan(a, nan_policy='propagate', use_summation=True):
-    if not isinstance(a, np.ndarray):
-        use_summation = False  # some array_likes ignore nans (e.g. pandas)
-    policies = ['propagate', 'raise', 'omit']
-    if nan_policy not in policies:
-        raise ValueError("nan_policy must be one of {%s}" %
-                         ', '.join("'%s'" % s for s in policies))
-
-    if np.issubdtype(a.dtype, np.inexact):
-        # The summation method avoids creating a (potentially huge) array.
-        if use_summation:
-            with np.errstate(invalid='ignore', over='ignore'):
-                contains_nan = np.isnan(np.sum(a))
-        else:
-            contains_nan = np.isnan(a).any()
-    elif np.issubdtype(a.dtype, object):
-        contains_nan = False
-        for el in a.ravel():
-            # isnan doesn't work on non-numeric elements
-            if np.issubdtype(type(el), np.number) and np.isnan(el):
-                contains_nan = True
-                break
-    else:
-        # Only `object` and `inexact` arrays can have NaNs
-        contains_nan = False
-
-    if contains_nan and nan_policy == 'raise':
-        raise ValueError("The input contains nan values")
-
-    return contains_nan, nan_policy
 
 
 def _chk_asarray(a, axis):

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -83,7 +83,6 @@ __all__ = ['find_repeats', 'gmean', 'hmean', 'pmean', 'mode', 'tmean', 'tvar',
            'brunnermunzel', 'alexandergovern']
 
 
-
 def _chk_asarray(a, axis):
     if axis is None:
         a = np.ravel(a)

--- a/scipy/stats/_variation.py
+++ b/scipy/stats/_variation.py
@@ -1,8 +1,8 @@
 
 import numpy as np
 from numpy.core.multiarray import normalize_axis_index
-from scipy._lib._util import _nan_allsame
-from ._stats_py import _chk_asarray, _contains_nan
+from scipy._lib._util import (_nan_allsame, _contains_nan)
+from ._stats_py import _chk_asarray
 
 
 def _nanvariation(a, *, axis=0, ddof=0, keepdims=False):

--- a/scipy/stats/_variation.py
+++ b/scipy/stats/_variation.py
@@ -1,7 +1,7 @@
 
 import numpy as np
 from numpy.core.multiarray import normalize_axis_index
-from scipy._lib._util import (_nan_allsame, _contains_nan)
+from scipy._lib._util import _nan_allsame, _contains_nan
 from ._stats_py import _chk_asarray
 
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -26,7 +26,6 @@ import numpy as np
 import scipy.stats as stats
 import scipy.stats.mstats as mstats
 import scipy.stats._mstats_basic as mstats_basic
-from scipy.stats._stats_py import _contains_nan
 from scipy.stats._ksstats import kolmogn
 from scipy.special._testutils import FuncData
 from scipy.special import binom
@@ -7907,53 +7906,3 @@ def test_rename_mode_method(fun, args):
     with pytest.raises(TypeError, match=re.escape(err)):
         fun(*args, method='exact', mode='exact')
 
-
-class TestContainsNaNTest:
-
-    def test_policy(self):
-        data = np.array([1, 2, 3, np.nan])
-
-        contains_nan, nan_policy = _contains_nan(data, nan_policy="propagate")
-        assert contains_nan
-        assert nan_policy == "propagate"
-
-        contains_nan, nan_policy = _contains_nan(data, nan_policy="omit")
-        assert contains_nan
-        assert nan_policy == "omit"
-
-        msg = "The input contains nan values"
-        with pytest.raises(ValueError, match=msg):
-            _contains_nan(data, nan_policy="raise")
-
-        msg = "nan_policy must be one of"
-        with pytest.raises(ValueError, match=msg):
-            _contains_nan(data, nan_policy="nan")
-
-    def test_contains_nan_1d(self):
-        data1 = np.array([1, 2, 3])
-        assert not _contains_nan(data1)[0]
-
-        data2 = np.array([1, 2, 3, np.nan])
-        assert _contains_nan(data2)[0]
-
-        data3 = np.array([np.nan, 2, 3, np.nan])
-        assert _contains_nan(data3)[0]
-
-        data4 = np.array([1, 2, "3", np.nan])  # converted to string "nan"
-        assert not _contains_nan(data4)[0]
-
-        data5 = np.array([1, 2, "3", np.nan], dtype='object')
-        assert _contains_nan(data5)[0]
-
-    def test_contains_nan_2d(self):
-        data1 = np.array([[1, 2], [3, 4]])
-        assert not _contains_nan(data1)[0]
-
-        data2 = np.array([[1, 2], [3, np.nan]])
-        assert _contains_nan(data2)[0]
-
-        data3 = np.array([["1", 2], [3, np.nan]])  # converted to string "nan"
-        assert not _contains_nan(data3)[0]
-
-        data4 = np.array([["1", 2], [3, np.nan]], dtype='object')
-        assert _contains_nan(data4)[0]


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Fix #16912

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR moves the `_contains_nan` function in the `stats` module to `_lib._util.py` for all scipy moludes to use it.
`_lib._util.py` already has some nan related utility functions, so I think this is the best place to move.
Also, I moved unit tests for `_contains_nan` to `_lib.test.test__util.py`.

#### Additional information
<!--Any additional information you think is important.-->
