### PR TITLE
DOC: sparse.linalg.svds: fix intermittent refguide check failure

### DIFF
--- a/scipy/sparse/linalg/_eigen/_svds.py
+++ b/scipy/sparse/linalg/_eigen/_svds.py
@@ -220,7 +220,7 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
     With only three singular values/vectors, the SVD approximates the original
     matrix.
 
-    >>> u2, s2, vT2 = svds(A, k=3)
+    >>> u2, s2, vT2 = svds(A, k=3, random_state=rng)
     >>> A2 = u2 @ np.diag(s2) @ vT2
     >>> np.allclose(A2, A.toarray(), atol=1e-3)
     True
@@ -228,7 +228,7 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
     With all five singular values/vectors, we can reproduce the original
     matrix.
 
-    >>> u3, s3, vT3 = svds(A, k=5)
+    >>> u3, s3, vT3 = svds(A, k=5, random_state=rng)
     >>> A3 = u3 @ np.diag(s3) @ vT3
     >>> np.allclose(A3, A.toarray())
     True


### PR DESCRIPTION
#### What does this implement/fix?
We've been getting an intermittent failure in the refguide check for a while.
```
scipy.sparse.linalg.svds
------------------------

File "build/testenv/lib/python3.9/site-packages/scipy/sparse/linalg/_eigen/_svds.py", line 241, in svds
Failed example:
    np.allclose(np.abs(u3), np.abs(u.toarray()))
Expected:
    True
Got:
    False
```

This sets the `random_state` of `svds` in hope of fixing the problem.

