### PR TITLE
DOC: Add examples for common Bessel functions

### DIFF
--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -6306,7 +6306,7 @@ add_newdoc("i0",
     Calculate at several points:
 
     >>> import numpy as np
-    >>> i0(np.array([-2., 0., 3.5])
+    >>> i0(np.array([-2., 0., 3.5]))
     array([2.2795853 , 1.        , 7.37820343])
 
     Plot the function from -10 to 10.
@@ -6372,7 +6372,7 @@ add_newdoc("i0e",
     Calculate the function at several points:
 
     >>> import numpy as np
-    >>> i0e(np.array([-2., 0., 3.])
+    >>> i0e(np.array([-2., 0., 3.]))
     array([0.30850832, 1.        , 0.24300035])
 
     Plot the function from -10 to 10.
@@ -6451,7 +6451,7 @@ add_newdoc("i1",
     Calculate the function at several points:
 
     >>> import numpy as np
-    >>> i1(np.array([-2., 0., 6.])
+    >>> i1(np.array([-2., 0., 6.]))
     array([-1.59063685,  0.        , 61.34193678])
 
     Plot the function between -10 and 10.
@@ -6517,7 +6517,7 @@ add_newdoc("i1e",
     Calculate the function at several points:
 
     >>> import numpy as np
-    >>> i1e(np.array([-2., 0., 6.])
+    >>> i1e(np.array([-2., 0., 6.]))
     array([-0.21526929,  0.        ,  0.15205146])
 
     Plot the function between -10 and 10.
@@ -6995,7 +6995,7 @@ add_newdoc("j0",
     Calculate the function at several points:
 
     >>> import numpy as np
-    >>> j0(np.array([-2., 0., 4.])
+    >>> j0(np.array([-2., 0., 4.]))
     array([ 0.22389078,  1.        , -0.39714981])
 
     Plot the function from -20 to 20.
@@ -7058,7 +7058,7 @@ add_newdoc("j1",
     Calculate the function at several points:
 
     >>> import numpy as np
-    >>> j1(np.array([-2., 0., 4.])
+    >>> j1(np.array([-2., 0., 4.]))
     array([-0.57672481,  0.        , -0.06604333])
 
     Plot the function from -20 to 20.
@@ -7258,7 +7258,7 @@ add_newdoc("k0",
     Calculate the function at several points:
 
     >>> import numpy as np
-    >>> k0(np.array([0.5, 2., 3.])
+    >>> k0(np.array([0.5, 2., 3.]))
     array([0.92441907, 0.11389387, 0.0347395 ])
 
     Plot the function from 0 to 10.
@@ -7322,7 +7322,7 @@ add_newdoc("k0e",
     Calculate the function at several points:
 
     >>> import numpy as np
-    >>> k0e(np.array([0.5, 2., 3.])
+    >>> k0e(np.array([0.5, 2., 3.]))
     array([1.52410939, 0.84156822, 0.6977616 ])
 
     Plot the function from 0 to 10.
@@ -7393,7 +7393,7 @@ add_newdoc("k1",
     Calculate the function at several points:
 
     >>> import numpy as np
-    >>> k1(np.array([0.5, 2., 3.])
+    >>> k1(np.array([0.5, 2., 3.]))
     array([1.65644112, 0.13986588, 0.04015643])
 
     Plot the function from 0 to 10.
@@ -7457,7 +7457,7 @@ add_newdoc("k1e",
     Calculate the function at several points:
 
     >>> import numpy as np
-    >>> k1e(np.array([0.5, 2., 3.])
+    >>> k1e(np.array([0.5, 2., 3.]))
     array([2.73100971, 1.03347685, 0.80656348])
 
     Plot the function from 0 to 10.
@@ -11368,7 +11368,7 @@ add_newdoc("y0",
     Calculate at several points:
 
     >>> import numpy as np
-    >>> y0(np.array([0.5, 2., 3.])
+    >>> y0(np.array([0.5, 2., 3.]))
     array([-0.44451873,  0.51037567,  0.37685001])
 
     Plot the function from 0 to 10.
@@ -11432,7 +11432,7 @@ add_newdoc("y1",
     Calculate at several points:
 
     >>> import numpy as np
-    >>> y1(np.array([0.5, 2., 3.])
+    >>> y1(np.array([0.5, 2., 3.]))
     array([-1.47147239, -0.10703243,  0.32467442])
 
     Plot the function from 0 to 10.

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -7167,7 +7167,7 @@ add_newdoc("k0",
 
     See also
     --------
-    kv
+    kv: Modified Bessel function of the second kind of any order
     k0e: Exponentially scaled modified Bessel function of the second kind
 
     References
@@ -7278,13 +7278,24 @@ add_newdoc("k1",
 
     See also
     --------
-    kv
-    k1e
+    kv: Modified Bessel function of the second kind of any order
+    k1e: Exponentially scaled modified Bessel function K of order 1
 
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
            http://www.netlib.org/cephes/
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.special import k1
+    >>> import matplotlib.pyplot as plt
+    >>> x = np.linspace(0., 20., 1000)
+    >>> y = k1(x)
+    >>> plt.plot(x, y)
+    >>> plt.show()
+
     """)
 
 add_newdoc("k1e",
@@ -7320,12 +7331,35 @@ add_newdoc("k1e",
     See also
     --------
     kv: Modified Bessel function of the second kind of any order
-    k1
+    k1: Modified Bessel function of the second kind of order 1
 
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
            http://www.netlib.org/cephes/
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.special import k1, k1e
+    >>> import matplotlib.pyplot as plt
+    >>> x = np.linspace(0., 20., 1000)
+    >>> y = k0e(x)
+    >>> plt.plot(x, y)
+    >>> plt.show()
+
+    Exponentially scaled Bessel functions are useful for large arguments for
+    which the unscaled Bessel functions are not precise enough.
+
+    >>> k1(1000.)
+    0.
+
+    In this case the exponentially scaled Bessel function still yields a useful
+    floating point number:
+
+    >>> k1e(1000.)
+    0.03964813081296021
+
     """)
 
 add_newdoc("kei",

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -7241,7 +7241,7 @@ add_newdoc("k0e",
     >>> k0(1000.)
     0.
 
-    While `k0` returns zero, `k0e` still yields a useful floating point number:
+    While `k0` returns zero, `k0e` still returns a finite number:
 
     >>> k0e(1000.)
     0.03962832160075422

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -6365,8 +6365,7 @@ add_newdoc("i0e",
     >>> i0(1000.)
     inf
 
-    In this case the exponentially scaled Bessel function still yields a real
-    floating point number:
+    While `i0` returns infinity, `i0e` returns a finite number in this case:
 
     >>> i0e(1000.)
     0.012617240455891257
@@ -6486,8 +6485,7 @@ add_newdoc("i1e",
     >>> i1(1000.)
     inf
 
-    In this case the exponentially scaled Bessel function still yields a real
-    floating point number:
+    While `i1` returns infinity, `i1e` returns a finite number in this case:
 
     >>> i1e(1000.)
     0.01261093025692863
@@ -6979,8 +6977,8 @@ add_newdoc("j1",
 
     See also
     --------
-    jv
-    spherical_jn : spherical Bessel functions.
+    jv: Bessel function of the first kind
+    spherical_jn: spherical Bessel functions.
 
     References
     ----------
@@ -7243,8 +7241,7 @@ add_newdoc("k0e",
     >>> k0(1000.)
     0.
 
-    In this case the exponentially scaled Bessel function still yields a useful
-    floating point number:
+    While `k0` returns zero, `k0e` still yields a useful floating point number:
 
     >>> k0e(1000.)
     0.03962832160075422

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -6297,8 +6297,20 @@ add_newdoc("i0",
 
     Examples
     --------
-    >>> import numpy as np
+    Calculate the function at one point:
+
     >>> from scipy.special import i0
+    >>> i0(1.)
+    1.2660658777520082
+
+    Calculate at several points:
+
+    >>> import numpy as np
+    >>> i0(np.array([-2., 0., 3.5])
+    array([2.2795853 , 1.        , 7.37820343])
+
+    Plot the function from -10 to 10.
+
     >>> import matplotlib.pyplot as plt
     >>> x = np.linspace(-10., 10., 1000)
     >>> y = i0(x)
@@ -6351,8 +6363,20 @@ add_newdoc("i0e",
 
     Examples
     --------
+    Calculate the function at one point:
+
+    >>> from scipy.special import i0e
+    >>> i0e(1.)
+    0.46575960759364043
+
+    Calculate the function at several points:
+
     >>> import numpy as np
-    >>> from scipy.special import i0, i0e
+    >>> i0e(np.array([-2., 0., 3.])
+    array([0.30850832, 1.        , 0.24300035])
+
+    Plot the function from -10 to 10.
+
     >>> import matplotlib.pyplot as plt
     >>> x = np.linspace(-10., 10., 1000)
     >>> y = i0e(x)
@@ -6362,6 +6386,7 @@ add_newdoc("i0e",
     Exponentially scaled Bessel functions are useful for large arguments for
     which the unscaled Bessel functions overflow or lose precision.
 
+    >>> from scipy.special import i0
     >>> i0(1000.)
     inf
 
@@ -6417,8 +6442,20 @@ add_newdoc("i1",
 
     Examples
     --------
-    >>> import numpy as np
+    Calculate the function at one point:
+
     >>> from scipy.special import i1
+    >>> i1(1.)
+    0.46575960759364043
+
+    Calculate the function at several points:
+
+    >>> import numpy as np
+    >>> i1(np.array([-2., 0., 6.])
+    array([-1.59063685,  0.        , 61.34193678])
+
+    Plot the function between -10 and 10.
+
     >>> import matplotlib.pyplot as plt
     >>> x = np.linspace(-10., 10., 1000)
     >>> y = i1(x)
@@ -6471,8 +6508,20 @@ add_newdoc("i1e",
 
     Examples
     --------
+    Calculate the function at one point:
+
+    >>> from scipy.special import i1e
+    >>> i1e(1.)
+    0.2079104153497085
+
+    Calculate the function at several points:
+
     >>> import numpy as np
-    >>> from scipy.special import i1, i1e
+    >>> i1e(np.array([-2., 0., 6.])
+    array([-0.21526929,  0.        ,  0.15205146])
+
+    Plot the function between -10 and 10.
+
     >>> import matplotlib.pyplot as plt
     >>> x = np.linspace(-10., 10., 1000)
     >>> y = i1e(x)
@@ -6482,6 +6531,7 @@ add_newdoc("i1e",
     Exponentially scaled Bessel functions are useful for large arguments for
     which the unscaled Bessel functions overflow or lose precision.
 
+    >>> from scipy.special import i1
     >>> i1(1000.)
     inf
 
@@ -6936,8 +6986,20 @@ add_newdoc("j0",
 
     Examples
     --------
-    >>> import numpy as np
+    Calculate the function at one point:
+
     >>> from scipy.special import j0
+    >>> j0(1.)
+    0.7651976865579665
+
+    Calculate the function at several points:
+
+    >>> import numpy as np
+    >>> j0(np.array([-2., 0., 4.])
+    array([ 0.22389078,  1.        , -0.39714981])
+
+    Plot the function from -20 to 20.
+
     >>> import matplotlib.pyplot as plt
     >>> x = np.linspace(-20., 20., 1000)
     >>> y = j0(x)
@@ -7175,8 +7237,20 @@ add_newdoc("k0",
 
     Examples
     --------
-    >>> import numpy as np
+    Calculate the function at one point:
+
     >>> from scipy.special import k0
+    >>> k0(1.)
+    0.42102443824070823
+
+    Calculate the function at several points:
+
+    >>> import numpy as np
+    >>> k0(np.array([0.5, 2., 3.])
+    array([0.92441907, 0.11389387, 0.0347395 ])
+
+    Plot the function from 0 to 10.
+
     >>> import matplotlib.pyplot as plt
     >>> x = np.linspace(0., 10., 1000)
     >>> y = k0(x)
@@ -7227,10 +7301,22 @@ add_newdoc("k0e",
 
     Examples
     --------
+    Calculate the function at one point:
+
+    >>> from scipy.special import k0e
+    >>> k0e(1.)
+    1.1444630798068947
+
+    Calculate the function at several points:
+
     >>> import numpy as np
-    >>> from scipy.special import k0, k0e
+    >>> k0e(np.array([0.5, 2., 3.])
+    array([1.52410939, 0.84156822, 0.6977616 ])
+
+    Plot the function from 0 to 10.
+
     >>> import matplotlib.pyplot as plt
-    >>> x = np.linspace(0., 20., 1000)
+    >>> x = np.linspace(0., 10., 1000)
     >>> y = k0e(x)
     >>> plt.plot(x, y)
     >>> plt.show()
@@ -7238,6 +7324,7 @@ add_newdoc("k0e",
     Exponentially scaled Bessel functions are useful for large arguments for
     which the unscaled Bessel functions are not precise enough.
 
+    >>> from scipy.special import k0
     >>> k0(1000.)
     0.
 
@@ -7285,10 +7372,22 @@ add_newdoc("k1",
 
     Examples
     --------
-    >>> import numpy as np
+    Calculate the function at one point:
+
     >>> from scipy.special import k1
+    >>> k1(1.)
+    0.6019072301972346
+
+    Calculate the function at several points:
+
+    >>> import numpy as np
+    >>> k1(np.array([0.5, 2., 3.])
+    array([1.65644112, 0.13986588, 0.04015643])
+
+    Plot the function from 0 to 10.
+
     >>> import matplotlib.pyplot as plt
-    >>> x = np.linspace(0., 20., 1000)
+    >>> x = np.linspace(0., 10., 1000)
     >>> y = k1(x)
     >>> plt.plot(x, y)
     >>> plt.show()
@@ -7337,10 +7436,22 @@ add_newdoc("k1e",
 
     Examples
     --------
+    Calculate the function at one point:
+
+    >>> from scipy.special import k1e
+    >>> k1e(1.)
+    1.636153486263258
+
+    Calculate the function at several points:
+
     >>> import numpy as np
-    >>> from scipy.special import k1, k1e
+    >>> k1e(np.array([0.5, 2., 3.])
+    array([2.73100971, 1.03347685, 0.80656348])
+
+    Plot the function from 0 to 10.
+
     >>> import matplotlib.pyplot as plt
-    >>> x = np.linspace(0., 20., 1000)
+    >>> x = np.linspace(0., 10., 1000)
     >>> y = k1e(x)
     >>> plt.plot(x, y)
     >>> plt.show()
@@ -7348,6 +7459,7 @@ add_newdoc("k1e",
     Exponentially scaled Bessel functions are useful for large arguments for
     which the unscaled Bessel functions are not precise enough.
 
+    >>> from scipy.special import k1
     >>> k1(1000.)
     0.
 
@@ -11235,8 +11347,20 @@ add_newdoc("y0",
 
     Examples
     --------
-    >>> import numpy as np
+    Calculate the function at one point:
+
     >>> from scipy.special import y0
+    >>> y0(1.)
+    0.08825696421567697
+
+    Calculate at several points:
+
+    >>> import numpy as np
+    >>> y0(np.array([0.5, 2., 3.])
+    array([-0.44451873,  0.51037567,  0.37685001])
+
+    Plot the function from 0 to 10.
+
     >>> import matplotlib.pyplot as plt
     >>> x = np.linspace(0., 10., 1000)
     >>> y = y0(x)
@@ -11287,8 +11411,20 @@ add_newdoc("y1",
 
     Examples
     --------
-    >>> import numpy as np
+    Calculate the function at one point:
+
     >>> from scipy.special import y1
+    >>> y1(1.)
+    -0.7812128213002888
+
+    Calculate at several points:
+
+    >>> import numpy as np
+    >>> y1(np.array([0.5, 2., 3.])
+    array([-1.47147239, -0.10703243,  0.32467442])
+
+    Plot the function from 0 to 10.
+
     >>> import matplotlib.pyplot as plt
     >>> x = np.linspace(0., 10., 1000)
     >>> y = y1(x)

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -7344,7 +7344,7 @@ add_newdoc("k1e",
     >>> from scipy.special import k1, k1e
     >>> import matplotlib.pyplot as plt
     >>> x = np.linspace(0., 20., 1000)
-    >>> y = k0e(x)
+    >>> y = k1e(x)
     >>> plt.plot(x, y)
     >>> plt.show()
 

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -6360,7 +6360,7 @@ add_newdoc("i0e",
     >>> plt.show()
 
     Exponentially scaled Bessel functions are useful for large arguments for
-    which the unscaled Bessel functions overflow or loose precision.
+    which the unscaled Bessel functions overflow or lose precision.
 
     >>> i0(1000.)
     inf
@@ -6481,7 +6481,7 @@ add_newdoc("i1e",
     >>> plt.show()
 
     Exponentially scaled Bessel functions are useful for large arguments for
-    which the unscaled Bessel functions overflow or loose precision.
+    which the unscaled Bessel functions overflow or lose precision.
 
     >>> i1(1000.)
     inf
@@ -8045,7 +8045,7 @@ add_newdoc('log_expit',
     array([-2.54463117e-13,  0.00000000e+00,  0.00000000e+00])
 
     The first value is accurate to only 3 digits, and the larger inputs
-    loose all precision and return 0.
+    lose all precision and return 0.
     """)
 
 add_newdoc('logit',

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -6287,13 +6287,26 @@ add_newdoc("i0",
 
     See also
     --------
-    iv
-    i0e
+    iv: Modified Bessel function of any order
+    i0e: Exponentially scaled modified Bessel function of order 0
 
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
            http://www.netlib.org/cephes/
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.special import i0
+    >>> import matplotlib.pyplot as plt
+
+    x = np.linspace(-10., 10., 1000)
+    y = i0(x)
+
+    plt.plot(x, y)
+    plt.show()
+
     """)
 
 add_newdoc("i0e",
@@ -6330,13 +6343,38 @@ add_newdoc("i0e",
 
     See also
     --------
-    iv
-    i0
+    iv: Modified Bessel function of the first kind
+    i0: Modified Bessel function of order 0
 
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
            http://www.netlib.org/cephes/
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.special import i0, i0e
+    >>> import matplotlib.pyplot as plt
+
+    x = np.linspace(-10., 10., 1000)
+    y = i0e(x)
+
+    plt.plot(x, y)
+    plt.show()
+
+    Exponentially scaled Bessel functions are useful for large arguments for
+    which the unscaled Bessel functions overflow or lose precision.
+
+    >>> i0(1000.)
+    inf
+
+    In this case the exponentially scaled Bessel function still yields a real
+    floating point number:
+
+    >>> i0e(1000.)
+    0.012617240455891257
+
     """)
 
 add_newdoc("i1",
@@ -6374,13 +6412,26 @@ add_newdoc("i1",
 
     See also
     --------
-    iv
-    i1e
+    iv: Modified Bessel function of the first kind
+    i1e: Exponentially scaled modified Bessel function of order 1
 
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
            http://www.netlib.org/cephes/
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.special import i1
+    >>> import matplotlib.pyplot as plt
+
+    x = np.linspace(-10., 10., 1000)
+    y = i1(x)
+
+    plt.plot(x, y)
+    plt.show()
+
     """)
 
 add_newdoc("i1e",
@@ -6417,13 +6468,38 @@ add_newdoc("i1e",
 
     See also
     --------
-    iv
-    i1
+    iv: Modified Bessel function of the first kind
+    i1: Modified Bessel function of order 1
 
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
            http://www.netlib.org/cephes/
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.special import i1, i1e
+    >>> import matplotlib.pyplot as plt
+
+    x = np.linspace(-10., 10., 1000)
+    y = i1e(x)
+
+    plt.plot(x, y)
+    plt.show()
+
+    Exponentially scaled Bessel functions are useful for large arguments for
+    which the unscaled Bessel functions overflow or lose precision.
+
+    >>> i1(1000.)
+    inf
+
+    In this case the exponentially scaled Bessel function still yields a real
+    floating point number:
+
+    >>> i1e(1000.)
+    0.01261093025692863
+
     """)
 
 add_newdoc("_igam_fac",
@@ -6867,6 +6943,19 @@ add_newdoc("j0",
     ----------
     .. [1] Cephes Mathematical Functions Library,
            http://www.netlib.org/cephes/
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.special import j0
+    >>> import matplotlib.pyplot as plt
+
+    x = np.linspace(-20., 20., 1000)
+    y = j0(x)
+
+    plt.plot(x, y)
+    plt.show()
+
     """)
 
 add_newdoc("j1",
@@ -6907,6 +6996,18 @@ add_newdoc("j1",
     ----------
     .. [1] Cephes Mathematical Functions Library,
            http://www.netlib.org/cephes/
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.special import j1
+    >>> import matplotlib.pyplot as plt
+
+    x = np.linspace(-20., 20., 1000)
+    y = j1(x)
+
+    plt.plot(x, y)
+    plt.show()
 
     """)
 
@@ -7079,12 +7180,25 @@ add_newdoc("k0",
     See also
     --------
     kv
-    k0e
+    k0e: Exponentially scaled modified Bessel function of the second kind
 
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
            http://www.netlib.org/cephes/
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.special import k0
+    >>> import matplotlib.pyplot as plt
+
+    x = np.linspace(0., 10., 1000)
+    y = k0(x)
+
+    plt.plot(x, y)
+    plt.show()
+
     """)
 
 add_newdoc("k0e",
@@ -7126,6 +7240,31 @@ add_newdoc("k0e",
     ----------
     .. [1] Cephes Mathematical Functions Library,
            http://www.netlib.org/cephes/
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.special import k0, k0e
+    >>> import matplotlib.pyplot as plt
+
+    x = np.linspace(0., 20., 1000)
+    y = k0e(x)
+
+    plt.plot(x, y)
+    plt.show()
+
+    Exponentially scaled Bessel functions are useful for large arguments for
+    which the unscaled Bessel functions are not precise enough.
+
+    >>> k0(1000.)
+    0.
+
+    In this case the exponentially scaled Bessel function still yields a seful
+    floating point number:
+
+    >>> k0e(1000.)
+    0.03962832160075422
+
     """)
 
 add_newdoc("k1",
@@ -11071,13 +11210,26 @@ add_newdoc("y0",
 
     See also
     --------
-    j0
-    yv
+    j0: Bessel function of the first kind of order 0
+    yv: Bessel function of the first kind
 
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
            http://www.netlib.org/cephes/
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.special import y0
+    >>> import matplotlib.pyplot as plt
+
+    x = np.linspace(0., 10., 1000)
+    y = y0(x)
+
+    plt.plot(x, y)
+    plt.show()
+
     """)
 
 add_newdoc("y1",
@@ -11111,14 +11263,27 @@ add_newdoc("y1",
 
     See also
     --------
-    j1
-    yn
-    yv
+    j1: Bessel function of the first kind of order 1
+    yn: Bessel function of the second kind
+    yv: Bessel function of the second kind
 
     References
     ----------
     .. [1] Cephes Mathematical Functions Library,
            http://www.netlib.org/cephes/
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.special import y1
+    >>> import matplotlib.pyplot as plt
+
+    x = np.linspace(0., 10., 1000)
+    y = y1(x)
+
+    plt.plot(x, y)
+    plt.show()
+
     """)
 
 add_newdoc("yn",

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -6301,11 +6301,11 @@ add_newdoc("i0",
     >>> from scipy.special import i0
     >>> import matplotlib.pyplot as plt
 
-    x = np.linspace(-10., 10., 1000)
-    y = i0(x)
+    >>> x = np.linspace(-10., 10., 1000)
+    >>> y = i0(x)
 
-    plt.plot(x, y)
-    plt.show()
+    >>> plt.plot(x, y)
+    >>> plt.show()
 
     """)
 
@@ -6357,11 +6357,11 @@ add_newdoc("i0e",
     >>> from scipy.special import i0, i0e
     >>> import matplotlib.pyplot as plt
 
-    x = np.linspace(-10., 10., 1000)
-    y = i0e(x)
+    >>> x = np.linspace(-10., 10., 1000)
+    >>> y = i0e(x)
 
-    plt.plot(x, y)
-    plt.show()
+    >>> plt.plot(x, y)
+    >>> plt.show()
 
     Exponentially scaled Bessel functions are useful for large arguments for
     which the unscaled Bessel functions overflow or lose precision.
@@ -6426,11 +6426,11 @@ add_newdoc("i1",
     >>> from scipy.special import i1
     >>> import matplotlib.pyplot as plt
 
-    x = np.linspace(-10., 10., 1000)
-    y = i1(x)
+    >>> x = np.linspace(-10., 10., 1000)
+    >>> y = i1(x)
 
-    plt.plot(x, y)
-    plt.show()
+    >>> plt.plot(x, y)
+    >>> plt.show()
 
     """)
 
@@ -6482,11 +6482,11 @@ add_newdoc("i1e",
     >>> from scipy.special import i1, i1e
     >>> import matplotlib.pyplot as plt
 
-    x = np.linspace(-10., 10., 1000)
-    y = i1e(x)
+    >>> x = np.linspace(-10., 10., 1000)
+    >>> y = i1e(x)
 
-    plt.plot(x, y)
-    plt.show()
+    >>> plt.plot(x, y)
+    >>> plt.show()
 
     Exponentially scaled Bessel functions are useful for large arguments for
     which the unscaled Bessel functions overflow or lose precision.
@@ -6950,11 +6950,11 @@ add_newdoc("j0",
     >>> from scipy.special import j0
     >>> import matplotlib.pyplot as plt
 
-    x = np.linspace(-20., 20., 1000)
-    y = j0(x)
+    >>> x = np.linspace(-20., 20., 1000)
+    >>> y = j0(x)
 
-    plt.plot(x, y)
-    plt.show()
+    >>> plt.plot(x, y)
+    >>> plt.show()
 
     """)
 
@@ -7003,11 +7003,11 @@ add_newdoc("j1",
     >>> from scipy.special import j1
     >>> import matplotlib.pyplot as plt
 
-    x = np.linspace(-20., 20., 1000)
-    y = j1(x)
+    >>> x = np.linspace(-20., 20., 1000)
+    >>> y = j1(x)
 
-    plt.plot(x, y)
-    plt.show()
+    >>> plt.plot(x, y)
+    >>> plt.show()
 
     """)
 
@@ -7193,11 +7193,11 @@ add_newdoc("k0",
     >>> from scipy.special import k0
     >>> import matplotlib.pyplot as plt
 
-    x = np.linspace(0., 10., 1000)
-    y = k0(x)
+    >>> x = np.linspace(0., 10., 1000)
+    >>> y = k0(x)
 
-    plt.plot(x, y)
-    plt.show()
+    >>> plt.plot(x, y)
+    >>> plt.show()
 
     """)
 
@@ -7247,11 +7247,11 @@ add_newdoc("k0e",
     >>> from scipy.special import k0, k0e
     >>> import matplotlib.pyplot as plt
 
-    x = np.linspace(0., 20., 1000)
-    y = k0e(x)
+    >>> x = np.linspace(0., 20., 1000)
+    >>> y = k0e(x)
 
-    plt.plot(x, y)
-    plt.show()
+    >>> plt.plot(x, y)
+    >>> plt.show()
 
     Exponentially scaled Bessel functions are useful for large arguments for
     which the unscaled Bessel functions are not precise enough.

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -6446,7 +6446,7 @@ add_newdoc("i1",
 
     >>> from scipy.special import i1
     >>> i1(1.)
-    0.46575960759364043
+    0.5651591039924851
 
     Calculate the function at several points:
 

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -6312,9 +6312,10 @@ add_newdoc("i0",
     Plot the function from -10 to 10.
 
     >>> import matplotlib.pyplot as plt
+    >>> fig, ax = plt.subplots()
     >>> x = np.linspace(-10., 10., 1000)
     >>> y = i0(x)
-    >>> plt.plot(x, y)
+    >>> ax.plot(x, y)
     >>> plt.show()
 
     """)
@@ -6378,9 +6379,10 @@ add_newdoc("i0e",
     Plot the function from -10 to 10.
 
     >>> import matplotlib.pyplot as plt
+     >>> fig, ax = plt.subplots()
     >>> x = np.linspace(-10., 10., 1000)
     >>> y = i0e(x)
-    >>> plt.plot(x, y)
+    >>> ax.plot(x, y)
     >>> plt.show()
 
     Exponentially scaled Bessel functions are useful for large arguments for
@@ -6457,9 +6459,10 @@ add_newdoc("i1",
     Plot the function between -10 and 10.
 
     >>> import matplotlib.pyplot as plt
+    >>> fig, ax = plt.subplots()
     >>> x = np.linspace(-10., 10., 1000)
     >>> y = i1(x)
-    >>> plt.plot(x, y)
+    >>> ax.plot(x, y)
     >>> plt.show()
 
     """)
@@ -6523,9 +6526,10 @@ add_newdoc("i1e",
     Plot the function between -10 and 10.
 
     >>> import matplotlib.pyplot as plt
+    >>> fig, ax = plt.subplots()
     >>> x = np.linspace(-10., 10., 1000)
     >>> y = i1e(x)
-    >>> plt.plot(x, y)
+    >>> ax.plot(x, y)
     >>> plt.show()
 
     Exponentially scaled Bessel functions are useful for large arguments for
@@ -7001,9 +7005,10 @@ add_newdoc("j0",
     Plot the function from -20 to 20.
 
     >>> import matplotlib.pyplot as plt
+    >>> fig, ax = plt.subplots()
     >>> x = np.linspace(-20., 20., 1000)
     >>> y = j0(x)
-    >>> plt.plot(x, y)
+    >>> ax.plot(x, y)
     >>> plt.show()
 
     """)
@@ -7064,9 +7069,10 @@ add_newdoc("j1",
     Plot the function from -20 to 20.
 
     >>> import matplotlib.pyplot as plt
+    >>> fig, ax = plt.subplots()
     >>> x = np.linspace(-20., 20., 1000)
     >>> y = j1(x)
-    >>> plt.plot(x, y)
+    >>> ax.plot(x, y)
     >>> plt.show()
 
     """)
@@ -7264,9 +7270,10 @@ add_newdoc("k0",
     Plot the function from 0 to 10.
 
     >>> import matplotlib.pyplot as plt
+    >>> fig, ax = plt.subplots()
     >>> x = np.linspace(0., 10., 1000)
     >>> y = k0(x)
-    >>> plt.plot(x, y)
+    >>> ax.plot(x, y)
     >>> plt.show()
 
     """)
@@ -7328,9 +7335,10 @@ add_newdoc("k0e",
     Plot the function from 0 to 10.
 
     >>> import matplotlib.pyplot as plt
+    >>> fig, ax = plt.subplots()
     >>> x = np.linspace(0., 10., 1000)
     >>> y = k0e(x)
-    >>> plt.plot(x, y)
+    >>> ax.plot(x, y)
     >>> plt.show()
 
     Exponentially scaled Bessel functions are useful for large arguments for
@@ -7399,9 +7407,10 @@ add_newdoc("k1",
     Plot the function from 0 to 10.
 
     >>> import matplotlib.pyplot as plt
+    >>> fig, ax = plt.subplots()
     >>> x = np.linspace(0., 10., 1000)
     >>> y = k1(x)
-    >>> plt.plot(x, y)
+    >>> ax.plot(x, y)
     >>> plt.show()
 
     """)
@@ -7463,9 +7472,10 @@ add_newdoc("k1e",
     Plot the function from 0 to 10.
 
     >>> import matplotlib.pyplot as plt
+    >>> fig, ax = plt.subplots()
     >>> x = np.linspace(0., 10., 1000)
     >>> y = k1e(x)
-    >>> plt.plot(x, y)
+    >>> ax.plot(x, y)
     >>> plt.show()
 
     Exponentially scaled Bessel functions are useful for large arguments for
@@ -11374,9 +11384,10 @@ add_newdoc("y0",
     Plot the function from 0 to 10.
 
     >>> import matplotlib.pyplot as plt
+    >>> fig, ax = plt.subplots()
     >>> x = np.linspace(0., 10., 1000)
     >>> y = y0(x)
-    >>> plt.plot(x, y)
+    >>> ax.plot(x, y)
     >>> plt.show()
 
     """)
@@ -11438,9 +11449,10 @@ add_newdoc("y1",
     Plot the function from 0 to 10.
 
     >>> import matplotlib.pyplot as plt
+    >>> fig, ax = plt.subplots()
     >>> x = np.linspace(0., 10., 1000)
     >>> y = y1(x)
-    >>> plt.plot(x, y)
+    >>> ax.plot(x, y)
     >>> plt.show()
 
     """)

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -7049,8 +7049,20 @@ add_newdoc("j1",
 
     Examples
     --------
-    >>> import numpy as np
+    Calculate the function at one point:
+
     >>> from scipy.special import j1
+    >>> j1(1.)
+    0.44005058574493355
+
+    Calculate the function at several points:
+
+    >>> import numpy as np
+    >>> j1(np.array([-2., 0., 4.])
+    array([-0.57672481,  0.        , -0.06604333])
+
+    Plot the function from -20 to 20.
+
     >>> import matplotlib.pyplot as plt
     >>> x = np.linspace(-20., 20., 1000)
     >>> y = j1(x)

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -6364,7 +6364,7 @@ add_newdoc("i0e",
     >>> plt.show()
 
     Exponentially scaled Bessel functions are useful for large arguments for
-    which the unscaled Bessel functions overflow or lose precision.
+    which the unscaled Bessel functions overflow or loose precision.
 
     >>> i0(1000.)
     inf
@@ -6489,7 +6489,7 @@ add_newdoc("i1e",
     >>> plt.show()
 
     Exponentially scaled Bessel functions are useful for large arguments for
-    which the unscaled Bessel functions overflow or lose precision.
+    which the unscaled Bessel functions overflow or loose precision.
 
     >>> i1(1000.)
     inf
@@ -7259,7 +7259,7 @@ add_newdoc("k0e",
     >>> k0(1000.)
     0.
 
-    In this case the exponentially scaled Bessel function still yields a seful
+    In this case the exponentially scaled Bessel function still yields a useful
     floating point number:
 
     >>> k0e(1000.)
@@ -8027,7 +8027,7 @@ add_newdoc('log_expit',
     array([-2.54463117e-13,  0.00000000e+00,  0.00000000e+00])
 
     The first value is accurate to only 3 digits, and the larger inputs
-    lose all precision and return 0.
+    loose all precision and return 0.
     """)
 
 add_newdoc('logit',

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -6379,7 +6379,7 @@ add_newdoc("i0e",
     Plot the function from -10 to 10.
 
     >>> import matplotlib.pyplot as plt
-     >>> fig, ax = plt.subplots()
+    >>> fig, ax = plt.subplots()
     >>> x = np.linspace(-10., 10., 1000)
     >>> y = i0e(x)
     >>> ax.plot(x, y)

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -6386,17 +6386,13 @@ add_newdoc("i0e",
     >>> plt.show()
 
     Exponentially scaled Bessel functions are useful for large arguments for
-    which the unscaled Bessel functions overflow or lose precision.
+    which the unscaled Bessel functions overflow or lose precision. In the
+    following example `i0` returns infinity whereas `i0e` still returns
+    a finite number.
 
     >>> from scipy.special import i0
-    >>> i0(1000.)
-    inf
-
-    While `i0` returns infinity, `i0e` returns a finite number in this case:
-
-    >>> i0e(1000.)
-    0.012617240455891257
-
+    >>> i0(1000.), i0e(1000.)
+    (inf, 0.012617240455891257)
     """)
 
 add_newdoc("i1",
@@ -6533,17 +6529,13 @@ add_newdoc("i1e",
     >>> plt.show()
 
     Exponentially scaled Bessel functions are useful for large arguments for
-    which the unscaled Bessel functions overflow or lose precision.
+    which the unscaled Bessel functions overflow or lose precision. In the
+    following example `i1` returns infinity whereas `i1e` still returns a
+    finite number.
 
     >>> from scipy.special import i1
-    >>> i1(1000.)
-    inf
-
-    While `i1` returns infinity, `i1e` returns a finite number in this case:
-
-    >>> i1e(1000.)
-    0.01261093025692863
-
+    >>> i1(1000.), i1e(1000.)
+    (inf, 0.01261093025692863)
     """)
 
 add_newdoc("_igam_fac",
@@ -7479,18 +7471,13 @@ add_newdoc("k1e",
     >>> plt.show()
 
     Exponentially scaled Bessel functions are useful for large arguments for
-    which the unscaled Bessel functions are not precise enough.
+    which the unscaled Bessel functions are not precise enough. In the
+    following example `k1` returns zero whereas `k1e` still returns a
+    useful floating point number.
 
     >>> from scipy.special import k1
-    >>> k1(1000.)
-    0.
-
-    In this case the exponentially scaled Bessel function still yields a useful
-    floating point number:
-
-    >>> k1e(1000.)
-    0.03964813081296021
-
+    >>> k1(1000.), k1e(1000.)
+    (0., 0.03964813081296021)
     """)
 
 add_newdoc("kei",

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -6300,10 +6300,8 @@ add_newdoc("i0",
     >>> import numpy as np
     >>> from scipy.special import i0
     >>> import matplotlib.pyplot as plt
-
     >>> x = np.linspace(-10., 10., 1000)
     >>> y = i0(x)
-
     >>> plt.plot(x, y)
     >>> plt.show()
 
@@ -6356,10 +6354,8 @@ add_newdoc("i0e",
     >>> import numpy as np
     >>> from scipy.special import i0, i0e
     >>> import matplotlib.pyplot as plt
-
     >>> x = np.linspace(-10., 10., 1000)
     >>> y = i0e(x)
-
     >>> plt.plot(x, y)
     >>> plt.show()
 
@@ -6425,10 +6421,8 @@ add_newdoc("i1",
     >>> import numpy as np
     >>> from scipy.special import i1
     >>> import matplotlib.pyplot as plt
-
     >>> x = np.linspace(-10., 10., 1000)
     >>> y = i1(x)
-
     >>> plt.plot(x, y)
     >>> plt.show()
 
@@ -6481,10 +6475,8 @@ add_newdoc("i1e",
     >>> import numpy as np
     >>> from scipy.special import i1, i1e
     >>> import matplotlib.pyplot as plt
-
     >>> x = np.linspace(-10., 10., 1000)
     >>> y = i1e(x)
-
     >>> plt.plot(x, y)
     >>> plt.show()
 
@@ -6949,10 +6941,8 @@ add_newdoc("j0",
     >>> import numpy as np
     >>> from scipy.special import j0
     >>> import matplotlib.pyplot as plt
-
     >>> x = np.linspace(-20., 20., 1000)
     >>> y = j0(x)
-
     >>> plt.plot(x, y)
     >>> plt.show()
 
@@ -7002,10 +6992,8 @@ add_newdoc("j1",
     >>> import numpy as np
     >>> from scipy.special import j1
     >>> import matplotlib.pyplot as plt
-
     >>> x = np.linspace(-20., 20., 1000)
     >>> y = j1(x)
-
     >>> plt.plot(x, y)
     >>> plt.show()
 
@@ -7192,10 +7180,8 @@ add_newdoc("k0",
     >>> import numpy as np
     >>> from scipy.special import k0
     >>> import matplotlib.pyplot as plt
-
     >>> x = np.linspace(0., 10., 1000)
     >>> y = k0(x)
-
     >>> plt.plot(x, y)
     >>> plt.show()
 
@@ -7233,8 +7219,8 @@ add_newdoc("k0e",
 
     See also
     --------
-    kv
-    k0
+    kv: Modified Bessel function of the second kind of any order
+    k0: Modified Bessel function of the second kind
 
     References
     ----------
@@ -7246,10 +7232,8 @@ add_newdoc("k0e",
     >>> import numpy as np
     >>> from scipy.special import k0, k0e
     >>> import matplotlib.pyplot as plt
-
     >>> x = np.linspace(0., 20., 1000)
     >>> y = k0e(x)
-
     >>> plt.plot(x, y)
     >>> plt.show()
 
@@ -7335,7 +7319,7 @@ add_newdoc("k1e",
 
     See also
     --------
-    kv
+    kv: Modified Bessel function of the second kind of any order
     k1
 
     References
@@ -11223,12 +11207,10 @@ add_newdoc("y0",
     >>> import numpy as np
     >>> from scipy.special import y0
     >>> import matplotlib.pyplot as plt
-
-    x = np.linspace(0., 10., 1000)
-    y = y0(x)
-
-    plt.plot(x, y)
-    plt.show()
+    >>> x = np.linspace(0., 10., 1000)
+    >>> y = y0(x)
+    >>> plt.plot(x, y)
+    >>> plt.show()
 
     """)
 
@@ -11277,12 +11259,10 @@ add_newdoc("y1",
     >>> import numpy as np
     >>> from scipy.special import y1
     >>> import matplotlib.pyplot as plt
-
-    x = np.linspace(0., 10., 1000)
-    y = y1(x)
-
-    plt.plot(x, y)
-    plt.show()
+    >>> x = np.linspace(0., 10., 1000)
+    >>> y = y1(x)
+    >>> plt.plot(x, y)
+    >>> plt.show()
 
     """)
 


### PR DESCRIPTION
#### Reference issue
Towards gh-7168

#### What does this implement/fix?
Provides examples for all functions listed unter [Common Bessel functions](https://docs.scipy.org/doc/scipy/reference/special.html#faster-versions-of-common-bessel-functions) .

#### Additional information
I have rarely used these myself, my last theoretical encounter with Bessel functions was almost ten years ago. If something is missing or mathematically misleading, let me know.

Edit: apologies for again forgetting to add the skip CI flags.

[skip actions][skip azp]