### PR TITLE
ENH: stats.fit: add plot_types to FitResult.plot

### DIFF
--- a/scipy/stats/_fit.py
+++ b/scipy/stats/_fit.py
@@ -140,7 +140,9 @@ class FitResult:
         support = self._dist.support(*fit_params)
         lb = support[0] if np.isfinite(support[0]) else min(self._data)
         ub = support[1] if np.isfinite(support[1]) else max(self._data)
+        return self._hist_plot(MaxNLocator, ax, fit_params, lb, ub)
 
+    def _hist_plot(self, MaxNLocator, ax, fit_params, lb, ub):
         if self.discrete:
             x = np.arange(lb, ub + 2)
             y = self.pxf(x, *fit_params)

--- a/scipy/stats/_fit.py
+++ b/scipy/stats/_fit.py
@@ -192,7 +192,7 @@ class FitResult:
             ax.plot(self._data, np.zeros_like(self._data), "*",
                     label='Data', color='C1')
 
-        ax.set_title(f"`{self._dist.name}` Fit Histogram")
+        ax.set_title(rf"$\tt {self._dist.name}$ Fit Histogram")
         ax.legend(*ax.get_legend_handles_labels())
         return ax
 
@@ -251,9 +251,9 @@ class FitResult:
 
         ax.set_xlim(lim)
         ax.set_ylim(lim)
-        ax.set_xlabel(f"Fitted `{self._dist.name}` Theoretical {qp}")
+        ax.set_xlabel(rf"Fitted $\tt {self._dist.name}$ Theoretical {qp}")
         ax.set_ylabel(f"Data {qp}")
-        ax.set_title(f"Fitted `{self._dist.name}` {plot_type} Plot")
+        ax.set_title(rf"Fitted $\tt {self._dist.name}$ {plot_type} Plot")
         ax.legend(*ax.get_legend_handles_labels())
         ax.set_aspect('equal')
         return ax

--- a/scipy/stats/_fit.py
+++ b/scipy/stats/_fit.py
@@ -145,7 +145,7 @@ class FitResult:
             import matplotlib  # noqa
         except ModuleNotFoundError as exc:
             message = "matplotlib must be installed to use method `plot`."
-            raise ValueError(message) from exc
+            raise ModuleNotFoundError(message) from exc
 
         plots = {'histogram': self._hist_plot, 'qq': self._qq_plot,
                  'pp': self._pp_plot}

--- a/scipy/stats/_fit.py
+++ b/scipy/stats/_fit.py
@@ -274,7 +274,7 @@ class FitResult:
     def _cdf_plot(self, ax, fit_params):
         data = np.sort(self._data)
         ecdf = self._plotting_positions(len(self._data))
-        ls = '--' if self.discrete else '-'
+        ls = '--' if len(np.unique(data)) < 30 else '.'
         xlabel = 'k' if self.discrete else 'x'
         ax.step(data, ecdf, ls, label='Empirical CDF', color='C1', zorder=0)
 

--- a/scipy/stats/tests/test_fit.py
+++ b/scipy/stats/tests/test_fit.py
@@ -570,6 +570,12 @@ class TestFitResult:
         data = stats.norm.rvs(0, 1, size=100)  # random state doesn't matter
         bounds = [(0, 30), (0, 1)]
         res = stats.fit(stats.norm, data, bounds)
-        message = r"`plot_type` must be one of \{'..."
-        with pytest.raises(ValueError, match=message):
-            res.plot(plot_type='llama')
+        try:
+            import matplotlib  # noqa
+            message = r"`plot_type` must be one of \{'..."
+            with pytest.raises(ValueError, match=message):
+                res.plot(plot_type='llama')
+        except (ModuleNotFoundError, ImportError):
+            message = r"matplotlib must be installed to use method `plot`."
+            with pytest.raises(ModuleNotFoundError, match=message):
+                res.plot(plot_type='llama')

--- a/scipy/stats/tests/test_fit.py
+++ b/scipy/stats/tests/test_fit.py
@@ -570,6 +570,6 @@ class TestFitResult:
         data = stats.norm.rvs(0, 1, size=100)  # random state doesn't matter
         bounds = [(0, 30), (0, 1)]
         res = stats.fit(stats.norm, data, bounds)
-        message = r"`plot_type` must be one of \{'histogram',..."
+        message = r"`plot_type` must be one of \{'..."
         with pytest.raises(ValueError, match=message):
             res.plot(plot_type='llama')

--- a/scipy/stats/tests/test_fit.py
+++ b/scipy/stats/tests/test_fit.py
@@ -563,3 +563,13 @@ class TestFit:
 
         res = stats.fit(dist, data, bounds, guess=params, optimizer=self.opt)
         assert_allclose(res.params, params, **self.tols)
+
+
+class TestFitResult:
+    def test_plot_iv(self):
+        data = stats.norm.rvs(0, 1, size=100)  # random state doesn't matter
+        bounds = [(0, 30), (0, 1)]
+        res = stats.fit(stats.norm, data, bounds)
+        message = r"`plot_type` must be one of \{'histogram',..."
+        with pytest.raises(ValueError, match=message):
+            res.plot(plot_type='llama')


### PR DESCRIPTION
#### Reference issue
Follow-up to gh-15436

#### What does this implement/fix?
Adds Q-Q and P-P plot types to the `FitResult` `plot` method.

```python3
from scipy import stats
data = stats.norm.rvs(5, 0.5, size=100)
bounds = [(0, 30), (0, 10)]
res = stats.fit(stats.norm, data, bounds)
res.plot(plot_type='qq')
```
![image](https://user-images.githubusercontent.com/6570539/188248938-4a754b91-f86a-4e0f-bce5-1e0bdc3e3ba8.png)

```python3
res.plot(plot_type='pp')
```
![image](https://user-images.githubusercontent.com/6570539/188248953-fccd727b-6004-4bf9-a437-a8f1000d4982.png)

And for discrete distributions:
```python3
from scipy import stats
data = stats.nbinom.rvs(5, 0.5, size=30)
bounds = [(0, 30), (0, 10)]
res = stats.fit(stats.nbinom, data, bounds)
res.plot(plot_type='qq')
```

![image](https://user-images.githubusercontent.com/6570539/188256732-7823dcd0-ec4f-445a-889d-eb16abc800fd.png)

```python3
res.plot(plot_type='pp')
```
![image](https://user-images.githubusercontent.com/6570539/188256737-42a80f21-1893-482b-bd35-2b0963d648a8.png)


#### Additional information
One more plot type I'd like to add is the theoretical vs empirical CDF, and then it would be nice for the function to be able to plot all of them on the same axes. For that reason, instead of `plot_type`, I think an appropriate name for the parameter would be `types`.
