### PR TITLE
DEV: update dev.py to only install changed files

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -499,7 +499,7 @@ class Build(Task):
             if non_empty and not dirs.site.exists():
                 raise RuntimeError("Can't install in non-empty directory: "
                                    f"'{dirs.installed}'")
-        cmd = ["meson", "install", "-C", args.build_dir]
+        cmd = ["meson", "install", "-C", args.build_dir, "--only-changed"]
         log_filename = dirs.root / 'meson-install.log'
         start_time = datetime.datetime.now()
         cmd_str = ' '.join([str(p) for p in cmd])


### PR DESCRIPTION
This doesn't make much of a difference in the speed of `python dev.py build` (it's ~ 1 sec. in both cases), but avoiding reinstalling files is very helpful for not trashing Sphinx's cache, so `python dev.py doc` can be run multiple times in a row.

[ci skip]