### PR TITLE
MAINT: stats.mode: fix bug with `axis!=1`, `nan_policy='omit'`, `keepdims=False`

### DIFF
--- a/scipy/stats/_mstats_basic.py
+++ b/scipy/stats/_mstats_basic.py
@@ -340,7 +340,6 @@ def _mode(a, axis=0, keepdims=True):
     else:
         output = ma.apply_along_axis(_mode1D, axis, a)
         if keepdims is None or keepdims:
-            np.moveaxis(a, -1, axis)
             newshape = list(a.shape)
             newshape[axis] = 1
             slices = [slice(None)] * output.ndim

--- a/scipy/stats/_mstats_basic.py
+++ b/scipy/stats/_mstats_basic.py
@@ -340,6 +340,7 @@ def _mode(a, axis=0, keepdims=True):
     else:
         output = ma.apply_along_axis(_mode1D, axis, a)
         if keepdims is None or keepdims:
+            np.moveaxis(a, -1, axis)
             newshape = list(a.shape)
             newshape[axis] = 1
             slices = [slice(None)] * output.ndim
@@ -348,6 +349,8 @@ def _mode(a, axis=0, keepdims=True):
             slices[axis] = 1
             counts = output[tuple(slices)].reshape(newshape)
             output = (modes, counts)
+        else:
+            output = np.moveaxis(output, axis, 0)
 
     return ModeResult(*output)
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2363,15 +2363,16 @@ class TestMode:
 
         # test nan_policy='omit'
         a = [[1, np.nan, np.nan, np.nan, 1],
-             [np.nan, np.nan, np.nan, np.nan, 2]]
+             [np.nan, np.nan, np.nan, np.nan, 2],
+             [1, 2, np.nan, 5, 5]]
 
         res = stats.mode(a, axis=1, keepdims=False, nan_policy='omit')
-        assert_array_equal(res.mode, [1, 2])
-        assert_array_equal(res.count, [2, 1])
+        assert_array_equal(res.mode, [1, 2, 5])
+        assert_array_equal(res.count, [2, 1, 2])
 
         res = stats.mode(a, axis=1, keepdims=True, nan_policy='omit')
-        assert_array_equal(res.mode, [[1], [2]])
-        assert_array_equal(res.count, [[2], [1]])
+        assert_array_equal(res.mode, [[1], [2], [5]])
+        assert_array_equal(res.count, [[2], [1], [2]])
 
         a = np.array(a)
         res = stats.mode(a, axis=None, keepdims=False, nan_policy='omit')
@@ -2383,6 +2384,15 @@ class TestMode:
         ref = stats.mode(a.ravel(), keepdims=True, nan_policy='omit')
         assert_array_equal(res, ref)
         assert res.mode.shape == ref.mode.shape == (1,)
+
+    def test_gh16952(self):
+        # Check that bug reported in gh-16952 is resolved
+        shape = (4, 3)
+        data = np.ones(shape)
+        data[0, 0] = np.nan
+        res = stats.mode(a=data, axis=1, keepdims=False, nan_policy="omit")
+        assert_array_equal(res.mode, [1, 1, 1, 1])
+        assert_array_equal(res.count, [2, 3, 3, 3])
 
 
 def test_mode_futurewarning():


### PR DESCRIPTION
#### Reference issue
Closes gh-16952

#### What does this implement/fix?
gh-16952 reported a bug with `stats.mode` with `axis!=`, `nan_policy='omit'`, and `keepdims=False`. This fixes the bug.
