### PR TITLE
BLD: fix up or suppress Fortran build warnings

### DIFF
--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -115,6 +115,11 @@ interpolative_module = custom_target('interpolative_module',
   command: [py3, generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@']
 )
 
+# id_dist contains a copy of FFTPACK, which has type mismatch warnings
+# that are hard to fix. This code is terrible and noisy during the build,
+# silence it completely.
+_suppress_all_warnings = ff.get_supported_arguments('-w')
+
 py3.extension_module('_interpolative',
   [
     'src/id_dist/src/dfft.f',
@@ -156,7 +161,7 @@ py3.extension_module('_interpolative',
     interpolative_module,
   ],
   c_args: numpy_nodepr_api,
-  fortran_args: fortran_ignore_warnings,
+  fortran_args: [fortran_ignore_warnings, _suppress_all_warnings],
   include_directories: [inc_np, inc_f2py],
   dependencies: [lapack, fortranobject_dep],
   install: true,

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -275,6 +275,7 @@ _fflag_Wno_argument_mismatch = ff.get_supported_arguments('-Wno-argument-mismatc
 _fflag_Wno_conversion = ff.get_supported_arguments('-Wno-conversion')
 _fflag_Wno_intrinsic_shadow = ff.get_supported_arguments('-Wno-intrinsic-shadow')
 _fflag_Wno_maybe_uninitialized = ff.get_supported_arguments('-Wno-maybe-uninitialized')
+_fflag_Wno_surprising = ff.get_supported_arguments('-Wno-surprising')
 _fflag_Wno_uninitialized = ff.get_supported_arguments('-Wno-uninitialized')
 _fflag_Wno_unused_dummy_argument = ff.get_supported_arguments('-Wno-unused-dummy-argument')
 _fflag_Wno_unused_label = ff.get_supported_arguments('-Wno-unused-label')

--- a/scipy/optimize/slsqp/slsqp_optmz.f
+++ b/scipy/optimize/slsqp/slsqp_optmz.f
@@ -843,7 +843,7 @@ C     20.3.1987, DIETER KRAFT, DFVLR OBERPFAFFENHOFEN
       INTEGER          jw(*),i,ie,IF,ig,iw,j,k,krank,l,lc,LE,lg,
      .                 mc,mc1,me,mg,mode,n
       DOUBLE PRECISION c(lc,n),e(LE,n),g(lg,n),d(lc),f(LE),h(lg),x(n),
-     .                 w(*),t,ddot_sl,xnrm,dnrm2_,epmach,ZERO
+     .                 w(*),t,ddot_sl,xnrm,rnorm(1),dnrm2_,epmach,ZERO
       DATA             epmach/2.22d-16/,ZERO/0.0d+00/
 
       mode=2
@@ -893,7 +893,10 @@ C  SOLVE LS WITHOUT INEQUALITY CONSTRAINTS
       mode=7
       k=MAX(LE,n)
       t=SQRT(epmach)
-      CALL hfti (w(ie),me,me,l,w(IF),k,1,t,krank,xnrm,w,w(l+1),jw)
+      CALL hfti (w(ie),me,me,l,w(IF),k,1,t,krank,rnorm,w,w(l+1),jw)
+C  HFTI IS MORE GENERIC, BUT WE ONLY CALL IT WITH NB=1, SO RETRIEVE THE
+C  SINGLE VALUE WE NEED FROM RNORM HERE
+      xnrm = rnorm(1)
       CALL dcopy_(l,w(IF),1,x(mc1),1)
       IF(krank.NE.l)                   GOTO 75
       mode=1

--- a/scipy/sparse/linalg/_eigen/arpack/meson.build
+++ b/scipy/sparse/linalg/_eigen/arpack/meson.build
@@ -81,9 +81,13 @@ arpack_sources = [
   'ARPACK/UTIL/zvout.f'
 ]
 
+# Building ARPACK yields a ton of rank mismatch (scalar and rank-1) warnings
+# that cannot be suppressed with a more specific flag.
+_suppress_all_warnings = ff.get_supported_arguments('-w')
+
 arpack_lib = static_library('arpack_lib',
   arpack_sources,
-  fortran_args: fortran_ignore_warnings,
+  fortran_args: [fortran_ignore_warnings, _suppress_all_warnings],
   include_directories: ['ARPACK/SRC']
 )
 

--- a/scipy/stats/meson.build
+++ b/scipy/stats/meson.build
@@ -67,7 +67,9 @@ mvn_module = custom_target('mvn_module',
 mvn = py3.extension_module('_mvn',
   [mvn_module, 'mvndst.f'],
   c_args: numpy_nodepr_api,
-  fortran_args: fortran_ignore_warnings,
+  # Wno-surprising is to suppress a pointless warning with GCC 10-12
+  # (see GCC bug 98411: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=98411)
+  fortran_args: [fortran_ignore_warnings, _fflag_Wno_surprising],
   dependencies: [fortranobject_dep],
   include_directories: [inc_np, inc_f2py],
   install: true,


### PR DESCRIPTION
These are all the build warnings seen on Linux with gfortran 10.3