### PR TITLE
BLD: fix meson version checks for MSVC

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -26,7 +26,7 @@ if cc.get_id() == 'gcc'
     error('SciPy requires GCC >= 8.0')
   endif
 elif cc.get_id() == 'msvc'
-  if not cc.version().version_compare('>=1920')
+  if not cc.version().version_compare('>=19.20')
     error('SciPy requires at least vc142 (default with Visual Studio 2019) ' + \
           'when building with MSVC')
   endif


### PR DESCRIPTION
The compiler version known by Meson is the same one that cl reports in its output -- a two-digit number with additional dot-separated components. The version check joined the components into a single four-digit number instead, though -- which means that this can never match any compiler, as one thousand, nine hundred and twenty is always greater than nineteen point anything, or even twenty point anything.

Fixes #16935

/cc @rgommers @andyfaff 