### PR TITLE
WIP: CI: add a job with Intel Fortran + MSVC in Azure CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,10 +22,8 @@ pr:
 # and should be updated to match scipy-wheels as appropriate
 variables:
     openblas_version: 0.3.18
-    pre_wheels: https://pypi.anaconda.org/scipy-wheels-nightly/simple
     CCACHE_DIR: $(Pipeline.Workspace)/ccache
     SCIPY_AVAILABLE_MEM: 3G
-    NPY_NUM_BUILD_JOBS: 2
     CCACHE_COMPRESS: 1
     # Using a single thread can actually speed up some computations
     OPENBLAS_NUM_THREADS: 1
@@ -54,157 +52,6 @@ stages:
   dependsOn: Check
   variables:
     AZURE_CI: 'true'
-  jobs:
-  - job: prerelease_deps_coverage_64bit_blas
-    timeoutInMinutes: 90
-    pool:
-      vmImage: 'ubuntu-20.04'
-    steps:
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '3.9'
-        addToPath: true
-        architecture: 'x64'
-    - template: ci/azure-travis-template.yaml
-      parameters:
-        test_mode: full
-        coverage: true
-        numpy_spec: "--pre --upgrade --timeout=60 -i $PRE_WHEELS numpy"
-        other_spec: "--pre --upgrade --timeout=60"
-        use_64bit_blas: true
-  - job: refguide_asv_check
-    timeoutInMinutes: 90
-    pool:
-      vmImage: 'ubuntu-20.04'
-    steps:
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '3.9'
-        addToPath: true
-        architecture: 'x64'
-    - template: ci/azure-travis-template.yaml
-      parameters:
-        test_mode: fast
-        numpy_spec: "numpy==1.21.5"
-        refguide_check: true
-        asv_check: true
-        use_wheel: true
-  - job: source_distribution
-    timeoutInMinutes: 90
-    pool:
-      vmImage: 'ubuntu-20.04'
-    steps:
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '3.9'
-        addToPath: true
-        architecture: 'x64'
-    - template: ci/azure-travis-template.yaml
-      parameters:
-        test_mode: fast
-        numpy_spec: "numpy==1.19.5"
-        use_sdist: true
-  - job: wheel_optimized_gcc6
-    timeoutInMinutes: 90
-    pool:
-      vmImage: 'ubuntu-18.04'
-    variables:
-      # The following is needed for optimized "-OO" test run but since we use
-      # pytest-xdist plugin for load scheduling its workers don't pick up the
-      # flag. This environment variable starts all Py instances in -OO mode.
-      PYTHONOPTIMIZE: 2
-      # Use gcc version 6
-      CC: gcc-6
-      CXX: g++-6
-    steps:
-    - script: |
-        set -euo pipefail
-        sudo apt update -y
-        sudo apt install -y g++-6 gcc-6
-      displayName: 'Install GCC 6'
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '3.8'
-        addToPath: true
-        architecture: 'x64'
-    - template: ci/azure-travis-template.yaml
-      parameters:
-        test_mode: fast
-        numpy_spec: "numpy==1.19.5"
-        use_wheel: true
-  - job: Lint
-    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/main'))  # skip for PR merges
-    pool:
-      vmImage: 'ubuntu-20.04'
-    steps:
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '3.9'
-        addToPath: true
-        architecture: 'x64'
-    - script: >-
-        python -m pip install
-        flake8==3.9.2
-      displayName: 'Install tools'
-      failOnStderr: false
-    - script: |
-        set -euo pipefail
-        flake8 scipy benchmarks/benchmarks
-        # for Travis CI we used to do: git fetch --unshallow
-        # but apparently Azure clones are not as shallow
-        # so does not appear to be needed to fetch maintenance
-        # branches (which Azure logs show being checked out
-        # in Checkout stage)
-        python tools/lint_diff.py --branch origin/$(System.PullRequest.TargetBranch)
-        tools/unicode-check.py
-      displayName: 'Run Lint Checks'
-      failOnStderr: true
-  - job: Linux_Python_38_32bit_full
-    timeoutInMinutes: 90
-    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/main'))  # skip for PR merges
-    pool:
-      vmImage: 'ubuntu-20.04'
-    steps:
-    - script: |
-        git submodule update --init
-      displayName: 'Fetch submodules'
-    - script: |
-            # For when updating this job to Meson: the `openblas` used here is
-            # missing pkg-config files. Ubunty Jammy (LTS 22.04) has openblas
-            # 3.20, so if that Docker image is available by then, just remove
-            # the unusual install method. For the bug report about missing .pc
-            # files: https://github.com/MacPython/openblas-libs/issues/74
-            set -euo pipefail
-            docker pull i386/ubuntu:bionic
-            docker run -v $(pwd):/scipy i386/ubuntu:bionic /usr/bin/linux32 /bin/bash -c "cd scipy && \
-            apt-get -y update && \
-            apt-get -y install curl python3.8-dev python3.8 python3-distutils pkg-config libpng-dev libjpeg8-dev libfreetype6-dev && \
-            curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
-            python3.8 get-pip.py && \
-            pip3 --version && \
-            pip3 install setuptools==59.6.0 wheel numpy==1.19.5 cython==0.29.21 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath pythran pooch && \
-            apt-get -y install gcc-8 g++-8 gfortran-8 wget && \
-            cd .. && \
-            mkdir openblas && cd openblas && \
-            target=\$(python3.8 ../scipy/tools/openblas_support.py) && \
-            cp -r \$target/lib/* /usr/lib && \
-            cp \$target/include/* /usr/include && \
-            cd ../scipy && \
-            CC=gcc-8 CXX=g++-8 F77=gfortran-8 F90=gfortran-8 python3.8 setup.py install && \
-            python3.8 tools/openblas_support.py --check_version $(openblas_version) && \
-            python3.8 runtests.py -n --mode=full -- -n auto -s --junitxml=junit/test-results.xml --cov-config=.coveragerc --cov-report=xml --cov-report=html --durations=10 --timeout=60"
-      displayName: 'Run 32-bit Ubuntu Docker Build / Tests'
-    - task: PublishTestResults@2
-      condition: succeededOrFailed()
-      inputs:
-        testResultsFiles: '**/test-*.xml'
-        failTaskOnFailedTests: true
-        testRunTitle: 'Publish test results for Python 3.8-32 bit full Linux'
-    - task: PublishCodeCoverageResults@1
-      inputs:
-        codeCoverageTool: Cobertura
-        summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
-        reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
   - job: Windows
     timeoutInMinutes: 90
     condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/main'))  # skip for PR merges
@@ -215,28 +62,8 @@ stages:
       # but only needed for ILP64 build below
       OPENBLAS: '$(Agent.HomeDirectory)\openblaslib'
     strategy:
-      maxParallel: 4
+      maxParallel: 1
       matrix:
-          Python38-32bit-fast:
-            PYTHON_VERSION: '3.8'
-            PYTHON_ARCH: 'x86'
-            TEST_MODE: fast
-            BITS: 32
-            SCIPY_USE_PYTHRAN: 1
-          Python38-64bit-full:
-            PYTHON_VERSION: '3.8'
-            PYTHON_ARCH: 'x64'
-            TEST_MODE: full
-            BITS: 64
-            SCIPY_USE_PYTHRAN: 0
-          Python310-64bit-full-ilp64:
-            PYTHON_VERSION: '3.10'
-            PYTHON_ARCH: 'x64'
-            TEST_MODE: full
-            NPY_USE_BLAS_ILP64: 1
-            BITS: 64
-            OPENBLAS64_: $(OPENBLAS)
-            SCIPY_USE_PYTHRAN: 1
           Python39-64bit-fast:
             PYTHON_VERSION: '3.9'
             PYTHON_ARCH: 'x64'
@@ -282,78 +109,36 @@ stages:
     - script: |
         clang-cl.exe --version
       displayName: 'clang-cl version'
-    - powershell: |
-        # wheels must use same version
-        choco install -y mingw --forcex86 --force --version=7.3.0
-      displayName: 'Install 32-bit mingw for 32-bit builds'
-      condition: and(succeeded(), eq(variables['BITS'], 32))
     - script: >-
         python -m pip install
-        cython==0.29.24
+        cython==0.29.32
         matplotlib
-        mpmath
-        numpy==1.21.4
-        Pillow
+        numpy==1.23.2
         pybind11
         pythran==0.11.0
         pytest
-        pytest-cov
         pytest-env
         pytest-timeout
         pytest-xdist
         threadpoolctl
         pooch
       displayName: 'Install dependencies'
-    # DLL resolution mechanics were changed in
-    # Python 3.8: https://bugs.python.org/issue36085
-    # While we normally leave adjustment of _distributor_init.py
-    # up to the specific distributors of SciPy builds, we
-    # are the primary providers of the SciPy wheels available
-    # on PyPI, so we now regularly test that the version of
-    # _distributor_init.py in our wheels repo is capable of
-    # loading the DLLs from a master branch wheel build
-    - powershell: |
-        git clone -n --depth 1 https://github.com/MacPython/scipy-wheels.git
-        cd scipy-wheels
-        git checkout HEAD _distributor_init.py
-        cd ..
-        rm scipy/_distributor_init.py
-        mv scipy-wheels/_distributor_init.py scipy/
-      displayName: 'Copy in _distributor_init.py'
-      condition: and(succeeded(), eq(variables['PYTHON_VERSION'], '3.8'))
     - powershell: |
         # The below lines ensure exit status of every line in this step is checked
         Set-StrictMode -Version Latest
         $global:erroractionpreference = 1
 
-
-        If ($(BITS) -eq 32) {
-            # 32-bit build requires careful adjustments
-            # until Microsoft has a switch we can use
-            # directly for i686 mingw
-            $env:NPY_DISTUTILS_APPEND_FLAGS = 1
-            $env:CFLAGS = "-m32"
-            $env:CXXFLAGS = "-m32"
-            $env:LDFLAGS = "-m32"
-            refreshenv
-        }
-        $env:PATH = "C:\\ProgramData\\chocolatey\\lib\\mingw\\tools\\install\\mingw$(BITS)\\bin;" + $env:PATH
-
-        # Still testing distutils here (`pip wheel --no-use-pep517` cannot be
-        # used, so back to `setup.py` it is ...)
-        python setup.py bdist_wheel
+        python -m build --no-isolation --skip-dependency-check .
         ls dist -r | Foreach-Object {
             pip install $_.FullName
         }
       displayName: 'Build SciPy'
     - powershell: |
-        $env:PATH = "C:\\ProgramData\\chocolatey\\lib\\mingw\\tools\\install\\mingw$(BITS)\\bin;" + $env:PATH
-        $env:SCIPY_USE_PYTHRAN=$(SCIPY_USE_PYTHRAN)
-        python runtests.py -n --mode=$(TEST_MODE) -- -n 2 --junitxml=junit/test-results.xml --durations=10 --timeout=60
+        cd ..
+        python -c "import scipy; scipy.test()"
       displayName: 'Run SciPy Test Suite'
     - task: PublishTestResults@2
       condition: succeededOrFailed()
       inputs:
-        testResultsFiles: '**/test-*.xml'
         failTaskOnFailedTests: true
-        testRunTitle: 'Publish test results for Python $(python.version)'
+        testRunTitle: 'Publish test results'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,6 +27,8 @@ variables:
     CCACHE_COMPRESS: 1
     # Using a single thread can actually speed up some computations
     OPENBLAS_NUM_THREADS: 1
+    WINDOWS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18680/w_HPCKit_p_2022.2.0.173_offline.exe
+    WINDOWS_FORTRAN_COMPONENTS: intel.oneapi.win.ifort-compiler
 
 stages:
 
@@ -52,6 +54,7 @@ stages:
   dependsOn: Check
   variables:
     AZURE_CI: 'true'
+  jobs:
   - job: Windows
     timeoutInMinutes: 90
     condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/main'))  # skip for PR merges
@@ -65,12 +68,33 @@ stages:
       maxParallel: 1
       matrix:
           Python39-64bit-fast:
+            ifort: true
             PYTHON_VERSION: '3.9'
             PYTHON_ARCH: 'x64'
             TEST_MODE: fast
             BITS: 64
             SCIPY_USE_PYTHRAN: 0
     steps:
+    - task: Cache@2
+      inputs:
+        path: C:\Program Files (x86)\Intel\oneAPI
+        key: '"install" | "$(WINDOWS_HPCKIT_URL)" | "$(WINDOWS_FORTRAN_COMPONENTS)" | "compiler" | ci/intel-oneapi/cache_exclude_windows.sh'
+        cacheHitVar: CACHE_RESTORED
+      condition: eq(variables.ifort, 'true')
+    - script: ci/intel-oneapi/install_windows.bat $(WINDOWS_HPCKIT_URL) $(WINDOWS_FORTRAN_COMPONENTS)
+      displayName: install ifort
+      condition: and(ne(variables.CACHE_RESTORED, 'true'), eq(variables.ifort, 'true'))
+    - bash: ci/intel-oneapi/cache_exclude_windows.sh
+      displayName: exclude unused files from cache
+      condition: and(ne(variables.CACHE_RESTORED, 'true'), eq(variables.ifort, 'true'))
+    - task: BatchScript@1
+      displayName: insert ifort into environment
+      inputs:
+        filename: ci/intel-oneapi/activate_windows.bat
+        arguments: vs2019
+        modifyEnvironment: True
+      condition: eq(variables.ifort, 'true')
+
     - task: UsePythonVersion@0
       inputs:
         versionSpec: $(PYTHON_VERSION)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -136,6 +136,7 @@ stages:
     - script: >-
         python -m pip install
         cython==0.29.32
+        build
         matplotlib
         numpy==1.23.2
         pybind11

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,32 +31,11 @@ variables:
 
 stages:
 
-- stage: Check
-  jobs:
-    - job: Skip
-      pool:
-        vmImage: 'ubuntu-20.04'
-      variables:
-        DECODE_PERCENTS: 'false'
-        RET: 'true'
-      steps:
-      - bash: |
-          git_log=`git log --max-count=1 --skip=1 --pretty=format:"%B" | tr "\n" " "`
-          echo "##vso[task.setvariable variable=log]$git_log"
-      - bash: echo "##vso[task.setvariable variable=RET]false"
-        condition: or(contains(variables.log, '[skip azp]'), contains(variables.log, '[azp skip]'), contains(variables.log, '[skip ci]'), contains(variables.log, '[ci skip]'))
-      - bash: echo "##vso[task.setvariable variable=start_main;isOutput=true]$RET"
-        name: result
-
 - stage: Main
-  condition: and(succeeded(), eq(dependencies.Check.outputs['Skip.result.start_main'], 'true'))
-  dependsOn: Check
   variables:
     AZURE_CI: 'true'
   jobs:
   - job: Windows
-    timeoutInMinutes: 90
-    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/main'))  # skip for PR merges
     pool:
       vmImage: 'windows-2019'
     variables:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,6 @@ pr:
 # the version of OpenBLAS used is currently 0.3.18
 # and should be updated to match scipy-wheels as appropriate
 variables:
-    openblas_version: 0.3.18
     CCACHE_DIR: $(Pipeline.Workspace)/ccache
     SCIPY_AVAILABLE_MEM: 3G
     CCACHE_COMPRESS: 1
@@ -61,9 +60,7 @@ stages:
     pool:
       vmImage: 'windows-2019'
     variables:
-      # OPENBLAS64_ variable has same value
-      # but only needed for ILP64 build below
-      OPENBLAS: '$(Agent.HomeDirectory)\openblaslib'
+      PKG_CONFIG_PATH: 'c:\opt\openblas\if_32\64\lib\pkgconfig'
     strategy:
       maxParallel: 1
       matrix:
@@ -106,25 +103,6 @@ stages:
     - script: |
         python -m pip install --upgrade pip
       displayName: 'Upgrade pip'
-    - powershell: |
-        $pyversion = python -c "import sys; print(sys.version.split()[0])"
-        Write-Host "Python Version: $pyversion"
-        function Download-OpenBLAS($ilp64) {
-            if ($ilp64 -eq '1') { $target_name = "openblas64_.a" } else { $target_name = "openblas.a" }
-            $target = "$(OPENBLAS)\$target_name"
-            Write-Host "target path: $target"
-            $old_value = $env:NPY_USE_BLAS_ILP64
-            $env:NPY_USE_BLAS_ILP64 = $ilp64
-            $openblas = python tools/openblas_support.py
-            $env:NPY_USE_BLAS_ILP64 = $old_value
-            cp $openblas $target
-        }
-        mkdir $(OPENBLAS)
-        Download-OpenBLAS('0')
-        If ($env:NPY_USE_BLAS_ILP64 -eq '1') {
-            Download-OpenBLAS('1')
-        }
-      displayName: 'Download / Install OpenBLAS'
     - script: |
         choco install -y llvm
         set PATH=C:\Program Files\LLVM\bin;%PATH%
@@ -133,6 +111,13 @@ stages:
     - script: |
         clang-cl.exe --version
       displayName: 'clang-cl version'
+    - script: |
+        choco install -y pkgconfiglite
+        choco install -y unzip
+        choco install -y wget
+        wget https://github.com/scipy/scipy-ci-artifacts/raw/main/openblas_32_if.zip
+        unzip -d c:\ openblas_32_if.zip
+      displayName: 'install pkg-config and OpenBLAS'
     - script: >-
         python -m pip install
         numpy==1.23.2
@@ -144,10 +129,6 @@ stages:
         pooch
       displayName: 'Install test dependencies'
     - powershell: |
-        # The below lines ensure exit status of every line in this step is checked
-        Set-StrictMode -Version Latest
-        $global:erroractionpreference = 1
-
         # Use build isolation; tests all dependencies in pyproject.toml
         python -m pip install .
       displayName: 'Build SciPy'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -104,8 +104,8 @@ stages:
         git submodule update --init
       displayName: 'Fetch submodules'
     - script: |
-        python -m pip install --upgrade pip "setuptools==59.6.0" wheel
-      displayName: 'Install tools'
+        python -m pip install --upgrade pip
+      displayName: 'Upgrade pip'
     - powershell: |
         $pyversion = python -c "import sys; print(sys.version.split()[0])"
         Write-Host "Python Version: $pyversion"
@@ -135,33 +135,26 @@ stages:
       displayName: 'clang-cl version'
     - script: >-
         python -m pip install
-        cython==0.29.32
-        build
-        matplotlib
         numpy==1.23.2
-        pybind11
-        pythran==0.11.0
         pytest
         pytest-env
         pytest-timeout
         pytest-xdist
         threadpoolctl
         pooch
-      displayName: 'Install dependencies'
+      displayName: 'Install test dependencies'
     - powershell: |
         # The below lines ensure exit status of every line in this step is checked
         Set-StrictMode -Version Latest
         $global:erroractionpreference = 1
 
-        python -m build --no-isolation --skip-dependency-check .
-        ls dist -r | Foreach-Object {
-            pip install $_.FullName
-        }
+        # Use build isolation; tests all dependencies in pyproject.toml
+        python -m pip install .
       displayName: 'Build SciPy'
     - powershell: |
         cd ..
         python -c "import scipy; scipy.test()"
-      displayName: 'Run SciPy Test Suite'
+      displayName: 'Test SciPy'
     - task: PublishTestResults@2
       condition: succeededOrFailed()
       inputs:

--- a/ci/intel-oneapi/activate_windows.bat
+++ b/ci/intel-oneapi/activate_windows.bat
@@ -1,0 +1,16 @@
+REM SPDX-FileCopyrightText: 2020 Intel Corporation
+REM
+REM SPDX-License-Identifier: MIT
+
+set VS_VER=%1
+
+@call "C:\Program Files (x86)\Intel\oneAPI\setvars-vcvarsall.bat" %VS_VER%
+
+for /f "tokens=* usebackq" %%f in (`dir /b "C:\Program Files (x86)\Intel\oneAPI\compiler\" ^| findstr /V latest ^| sort`) do @set "LATEST_VERSION=%%f"
+@call "C:\Program Files (x86)\Intel\oneAPI\compiler\%LATEST_VERSION%\env\vars.bat"
+
+echo "Visual Studio Version: %VS_VER%"
+echo "OneAPI version: %LATEST_VERSION%"
+echo "C:\Program Files (x86)\Intel\oneAPI\compiler\%LATEST_VERSION%\env\vars.bat"
+echo "OneAPI root directory: %ONEAPI_ROOT%"
+where ifort.exe

--- a/ci/intel-oneapi/cache_exclude_windows.sh
+++ b/ci/intel-oneapi/cache_exclude_windows.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2020 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
+#shellcheck disable=SC2010
+LATEST_VERSION=$(ls -1 "C:\Program Files (x86)\Intel\oneAPI\compiler" | grep -v latest | sort | tail -1)
+
+rm -rf "C:\Program Files (x86)\Intel\oneAPI\compiler\'$LATEST_VERSION'\windows\compiler\lib\ia32_win"
+rm -rf "C:\Program Files (x86)\Intel\oneAPI\compiler\'$LATEST_VERSION'\windows\bin\intel64_ia32"
+rm -rf "C:\Program Files (x86)\Intel\oneAPI\compiler\'$LATEST_VERSION'\windows\lib\emu"
+rm -rf "C:\Program Files (x86)\Intel\oneAPI\compiler\'$LATEST_VERSION'\windows\lib\oclfpga"
+rm -rf "C:\Program Files (x86)\Intel\oneAPI\compiler\'$LATEST_VERSION'\windows\lib\ocloc"
+rm -rf "C:\Program Files (x86)\Intel\oneAPI\compiler\'$LATEST_VERSION'\windows\lib\x86"

--- a/ci/intel-oneapi/install_windows.bat
+++ b/ci/intel-oneapi/install_windows.bat
@@ -1,0 +1,16 @@
+REM SPDX-FileCopyrightText: 2022 Intel Corporation
+REM
+REM SPDX-License-Identifier: MIT
+
+set URL=%1
+set COMPONENTS=%2
+
+curl.exe --output %TEMP%\webimage.exe --url %URL% --retry 5 --retry-delay 5
+start /b /wait %TEMP%\webimage.exe -s -x -f webimage_extracted --log extract.log
+del %TEMP%\webimage.exe
+if "%COMPONENTS%"=="" (
+  webimage_extracted\bootstrapper.exe -s --action install --eula=accept -p=NEED_VS2017_INTEGRATION=0 -p=NEED_VS2019_INTEGRATION=0 -p=NEED_VS2022_INTEGRATION=0 --log-dir=.
+) else (
+  webimage_extracted\bootstrapper.exe -s --action install --components=%COMPONENTS% --eula=accept -p=NEED_VS2017_INTEGRATION=0 -p=NEED_VS2019_INTEGRATION=0 -p=NEED_VS2022_INTEGRATION=0 --log-dir=.
+)
+rd /s/q "webimage_extracted"

--- a/meson.build
+++ b/meson.build
@@ -58,6 +58,14 @@ if ff.has_argument('-Wno-conversion')
   add_project_arguments('-Wno-conversion', language: 'fortran')
 endif
 
+is_windows = host_machine.system() == 'windows'
+
+# Intel Fortran on Windows does things differently, so deal with that
+if is_windows and ff.get_id() == 'intel-cl'
+  _ifort_flags = ff.get_supported_arguments('/MD', '/names:lowercase', '/assume:underscore')
+  add_project_arguments(_ifort_flags, language: 'fortran')
+endif
+
 cython = find_program('cython')
 pythran = find_program('pythran')
 generate_f2pymod = files('tools/generate_f2pymod.py')

--- a/scipy/fft/_pocketfft/meson.build
+++ b/scipy/fft/_pocketfft/meson.build
@@ -7,8 +7,14 @@ pocketfft_threads = []
 fft_deps = []
 if not win_gcc
   if thread_dep.found()
-    pocketfft_threads += ['-DPOCKETFFT_PTHREADS']
     fft_deps += [thread_dep]
+    if not is_windows
+      # `pthreads` probably not installed, and native threading is always
+      # available. Not easy to distinguish this better, Meson builtin
+      # functionality for that in progress (see comment on gh-16957).
+      # The code on `pocketfft_hdronly.h` will include `<threads>` anyway.
+      pocketfft_threads += ['-DPOCKETFFT_PTHREADS']
+    endif
   endif
 else
   # Freezes using threading for mingw-w64 gcc:

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -293,6 +293,17 @@ fortran_ignore_warnings = ff.get_supported_arguments(
  _fflag_Wno_tabs,
 )
 
+# Intel Fortran (ifort) does not run the preprocessor by default, if Fortran
+# code uses preprocessor statements, add this compile flag to it.
+_fflag_fpp = []
+if ff.get_id() == 'intel-cl'
+  if is_windows
+    _fflag_fpp = ff.get_supported_arguments('/fpp')
+  else
+    _fflag_fpp = ff.get_supported_arguments('-fpp')
+  endif
+endif
+
 # Deal with M_PI & friends; add `use_math_defines` to c_args or cpp_args
 # Cython doesn't always get this right itself (see, e.g., gh-16800), so
 # explicitly add the define as a compiler flag for Cython-generated code.

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -1,5 +1,4 @@
 # Platform detection
-is_windows = host_machine.system() == 'windows'
 is_mingw = is_windows and cc.get_id() == 'gcc'
 
 cython_c_args = []

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -305,7 +305,7 @@ endif
 # Suppress warning for deprecated Numpy API.
 # (Suppress warning messages emitted by #warning directives).
 # Replace with numpy_nodepr_api after Cython 3.0 is out
-cython_c_args += ['-Wno-cpp', use_math_defines]
+cython_c_args += [_cpp_Wno_cpp, use_math_defines]
 cython_cpp_args = cython_c_args
 
 # Ordering of subdirs: special and linalg come first, because other submodules

--- a/scipy/sparse/linalg/_propack/meson.build
+++ b/scipy/sparse/linalg/_propack/meson.build
@@ -92,6 +92,7 @@ foreach ele: elements
       fortran_ignore_warnings, 
       _fflag_Wno_intrinsic_shadow,
       _fflag_Wno_uninitialized,
+      _fflag_fpp,
     ],
   )
 


### PR DESCRIPTION
Taken over from Meson (see [Meson issue gh-10775](https://github.com/mesonbuild/meson/issues/10775#issuecomment-1236366301)), who in turn took it over from MODFLOW, and they from https://github.com/oneapi-src/oneapi-ci (MIT license).
    
[skip actions][skip circle]

First time downloading and installing `ifort` took 4m 35s in total. Of that, 1m 24s was for the download (~1.2 GB), the rest for running the installer. After a first successful run, that download and install was cached; restoring the cache took 1m 48s (it's a hefty 1.86 GB download - 3.98 GB uncompressed). Compiler info after that:
```powershell
"Visual Studio Version: vs2019"
"OneAPI version: 2022.1.0"
"C:\Program Files (x86)\Intel\oneAPI\compiler\2022.1.0\env\vars.bat"
"OneAPI root directory: "
C:\Program Files (x86)\Intel\oneAPI\compiler\2022.1.0\windows\bin\intel64\ifort.exe
```

Configure info:
```
  C compiler for the host machine: cl (msvc 19.29.30146 "Microsoft (R) C/C++ Optimizing Compiler Version 19.29.30146 for x64")
  C linker for the host machine: link link 14.29.30146.0
  C++ compiler for the host machine: cl (msvc 19.29.30146 "Microsoft (R) C/C++ Optimizing Compiler Version 19.29.30146 for x64")
  C++ linker for the host machine: link link 14.29.30146.0
...
  Fortran compiler for the host machine: ifort (intel-cl 2021.6.0)
  Fortran linker for the host machine: xilink.exe xilink 2021.6.0
...
  Found pkg-config: C:\ProgramData\Chocolatey\bin\pkg-config.EXE (0.28)
  Run-time dependency openblas found: YES 0.3.18
  Dependency openblas found: YES 0.3.18 (cached)
```