### PR TITLE
ENH: optimize: Add `nan_policy` optional argument for `curve_fit`.

### DIFF
--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -663,7 +663,7 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
         .. versionadded:: 1.9
     nan_policy : {'propagate', 'raise', 'omit', None}, optional
         Defines how to handle when input contains nan.
-        The following options are available (default is 'None'):
+        The following options are available (default is None):
 
           * 'propagate': just propagate nan values
           * 'raise': throws an error

--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -868,7 +868,7 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
                          "Use 'trf' or 'dogbox' instead.")
 
     if check_finite is None:
-        check_finite = False if nan_policy is not None else True
+        check_finite = True if nan_policy is None else False
 
     # optimization may produce garbage for float32 inputs, cast them to float64
     # NaNs cannot be handled

--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -625,8 +625,8 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
         If True, check that the input arrays do not contain nans of infs,
         and raise a ValueError if they do. Setting this parameter to
         False may silently produce nonsensical results if the input arrays
-        do contain nans. Default is True.
-        Note that if `nan_policy` is specified explicitly (not None), this value will be ignored.
+        do contain nans. Default is True. Note that if `nan_policy` is specified
+        explicitly (not None), this value will be ignored.
     bounds : 2-tuple of array_like or `Bounds`, optional
         Lower and upper bounds on parameters. Defaults to no bounds.
         There are two ways to specify the bounds:
@@ -667,10 +667,12 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
 
           * 'propagate': just propagate nan values without check finite.
           * 'raise': throws an error
-          * 'omit': performs the calculations ignoring nan values without check finite.
+          * 'omit': performs the calculations ignoring nan values
+          without check finite.
           * None: check nan valudes based on `check_finite` value.
 
-        Note that if thsi value is specified explicitly (not None), `check_finite` will be set as False.
+        Note that if thsi value is specified explicitly (not None),
+        `check_finite` will be set as False.
 
         .. versionadded:: 1.10
     **kwargs

--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -892,7 +892,7 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
     # the x-y data are already checked, and they don't contain nans.
     if not check_finite and nan_policy is not None:
         if nan_policy == "propagate":
-            raise ValueError("`'nan_policy='propagate'` is not supported "
+            raise ValueError("`nan_policy='propagate'` is not supported "
                              "by this function.")
 
         x_contains_nan, nan_policy = _contains_nan(xdata, nan_policy)

--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -661,19 +661,20 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
         `mesg`, and `ier`.
 
         .. versionadded:: 1.9
-    nan_policy : {'propagate', 'raise', 'omit', None}, optional
+    nan_policy : {'raise', 'omit', None}, optional
         Defines how to handle when input contains nan.
         The following options are available (default is None):
 
-          * 'propagate': just propagate nan values
           * 'raise': throws an error
           * 'omit': performs the calculations ignoring nan values
-          * None: check nan values based on `check_finite` value.
+          * None: no special handling of NaNs is performed
+          (except what is done by check_finite); the behavior when NaNs
+          are present is implementation-dependent and may change.
 
         Note that if this value is specified explicitly (not None),
         `check_finite` will be set as False.
 
-        .. versionadded:: 1.10
+        .. versionadded:: 1.11
     **kwargs
         Keyword arguments passed to `leastsq` for ``method='lm'`` or
         `least_squares` otherwise.
@@ -890,6 +891,10 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
     # nan handling is needed only if check_finite is False because if True,
     # the x-y data are already checked, and they don't contain nans.
     if not check_finite and nan_policy is not None:
+        if nan_policy == "propagate":
+            raise ValueError("`propagate` is not supported for nan_policy "
+                             "in this function.")
+
         x_contains_nan, nan_policy = _contains_nan(xdata, nan_policy)
         y_contains_nan, nan_policy = _contains_nan(ydata, nan_policy)
 

--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -892,8 +892,8 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
     # the x-y data are already checked, and they don't contain nans.
     if not check_finite and nan_policy is not None:
         if nan_policy == "propagate":
-            raise ValueError("`propagate` is not supported for nan_policy "
-                             "in this function.")
+            raise ValueError("`'nan_policy='propagate'` is not supported "
+                             "by this function.")
 
         x_contains_nan, nan_policy = _contains_nan(xdata, nan_policy)
         y_contains_nan, nan_policy = _contains_nan(ydata, nan_policy)

--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -625,8 +625,8 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
         If True, check that the input arrays do not contain nans of infs,
         and raise a ValueError if they do. Setting this parameter to
         False may silently produce nonsensical results if the input arrays
-        do contain nans. Default is True. Note that if `nan_policy` is specified
-        explicitly (not None), this value will be ignored.
+        do contain nans. Default is True. Note that if `nan_policy` is
+        specified explicitly (not None), this value will be ignored.
     bounds : 2-tuple of array_like or `Bounds`, optional
         Lower and upper bounds on parameters. Defaults to no bounds.
         There are two ways to specify the bounds:

--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -866,10 +866,8 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
         raise ValueError("Method 'lm' only works for unconstrained problems. "
                          "Use 'trf' or 'dogbox' instead.")
 
-    if nan_policy is None:  # If nan_policy is not specified explicitly
-        check_finite = True  # check finite for backward compatibility
-    elif check_finite is None:  # if only nan_policy is specified explicitly
-        check_finite = False  # not check finite
+    if check_finite is None:
+        check_finite = False if nan_policy is not None else True
 
     # optimization may produce garbage for float32 inputs, cast them to float64
     # NaNs cannot be handled

--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -871,7 +871,6 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
         check_finite = True if nan_policy is None else False
 
     # optimization may produce garbage for float32 inputs, cast them to float64
-    # NaNs cannot be handled
     if check_finite:
         ydata = np.asarray_chkfinite(ydata, float)
     else:

--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -668,8 +668,8 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
           * 'raise': throws an error
           * 'omit': performs the calculations ignoring nan values
           * None: no special handling of NaNs is performed
-          (except what is done by check_finite); the behavior when NaNs
-          are present is implementation-dependent and may change.
+            (except what is done by check_finite); the behavior when NaNs
+            are present is implementation-dependent and may change.
 
         Note that if this value is specified explicitly (not None),
         `check_finite` will be set as False.

--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -889,7 +889,7 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
 
     # nan handling is needed only if check_finite is False because if True,
     # the x-y data are already checked, and they don't contain nans.
-    if not check_finite:
+    if not check_finite and nan_policy is not None:
         x_contains_nan, nan_policy = _contains_nan(xdata, nan_policy)
         y_contains_nan, nan_policy = _contains_nan(ydata, nan_policy)
 

--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -665,13 +665,12 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
         Defines how to handle when input contains nan.
         The following options are available (default is 'None'):
 
-          * 'propagate': just propagate nan values without check finite.
+          * 'propagate': just propagate nan values
           * 'raise': throws an error
           * 'omit': performs the calculations ignoring nan values
-          without check finite.
-          * None: check nan valudes based on `check_finite` value.
+          * None: check nan values based on `check_finite` value.
 
-        Note that if thsi value is specified explicitly (not None),
+        Note that if this value is specified explicitly (not None),
         `check_finite` will be set as False.
 
         .. versionadded:: 1.10

--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -900,8 +900,7 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
         if (x_contains_nan or y_contains_nan) and nan_policy == 'omit':
             # ignore NaNs for N dimensional arrays
             has_nan = np.isnan(xdata)
-            for _ in range(xdata.ndim-1):
-                has_nan = has_nan.any(axis=0)
+            has_nan = has_nan.any(axis=tuple(range(has_nan.ndim-1)))
             has_nan |= np.isnan(ydata)
 
             xdata = xdata[..., ~has_nan]

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -605,8 +605,8 @@ class TestCurveFit:
     @pytest.mark.parametrize('method', ["lm", "trf", "dogbox"])
     def test_nan_policy_2_3d(self, n, method):
         def f(x, a, b):
-            x1 = x[0, 0, :]
-            x2 = x[0, 1, :]
+            x1 = x[..., 0, :].squeeze()
+            x2 = x[..., 1, :].squeeze()
             return a*x1 + b + x2
 
         xdata_with_nan = np.array([[[2, 3, np.nan, 4, 4, np.nan, 5],

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -568,7 +568,9 @@ class TestCurveFit:
 
         # omit test
         result_with_nan, _ = curve_fit(**kwargs, nan_policy="omit")
-        result_without_nan, _ = curve_fit(**kwargs, nan_policy="omit")
+        kwargs['xdata'] = xdata_without_nan
+        kwargs['ydata'] = ydata_without_nan
+        result_without_nan, _ = curve_fit(**kwargs)
         assert_allclose(result_with_nan, result_without_nan)
 
     @pytest.mark.parametrize('method', ["lm", "trf", "dogbox"])

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -567,9 +567,7 @@ class TestCurveFit:
             curve_fit(**kwargs, nan_policy="raise")
 
         # omit test
-        result_with_nan, _ = curve_fit(f, xdata_with_nan, ydata_with_nan,
-                                       method=method, check_finite=False,
-                                       nan_policy="omit")
+        result_with_nan, _ = curve_fit(**kwargs, nan_policy="omit")
         result_without_nan, _ = curve_fit(f, xdata_without_nan,
                                           ydata_without_nan, method=method)
         assert_allclose(result_with_nan, result_without_nan)

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -564,8 +564,7 @@ class TestCurveFit:
 
         # raise test
         with assert_raises(ValueError, match="The input contains nan"):
-            curve_fit(f, xdata_with_nan, ydata_with_nan, method=method,
-                      check_finite=False, nan_policy="raise")
+            curve_fit(**kwargs, nan_policy="raise")
 
         # omit test
         result_with_nan, _ = curve_fit(f, xdata_with_nan, ydata_with_nan,

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -554,6 +554,8 @@ class TestCurveFit:
     @staticmethod
     def _check_nan_policy(f, xdata_with_nan, xdata_without_nan,
                           ydata_with_nan, ydata_without_nan, method):
+        kwargs = {'f': f, 'xdata': xdata_with_nan, 'ydata': ydata_with_nan,
+                  'method': method, 'check_finite': False}
         # propagate test
         error_msg = ("`nan_policy='propagate'` is not supported "
                     "by this function.")

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -601,8 +601,9 @@ class TestCurveFit:
         self._check_nan_policy(f, xdata_with_nan, xdata_without_nan,
                                ydata_with_nan, ydata_without_nan, method)
 
+    @pytest.mark.parametrize('n', [2, 3])
     @pytest.mark.parametrize('method', ["lm", "trf", "dogbox"])
-    def test_nan_policy_3d(self, method):
+    def test_nan_policy_2_3d(self, n, method):
         def f(x, a, b):
             x1 = x[0, 0, :]
             x2 = x[0, 1, :]

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -558,7 +558,7 @@ class TestCurveFit:
                   'method': method, 'check_finite': False}
         # propagate test
         error_msg = ("`nan_policy='propagate'` is not supported "
-                    "by this function.")
+                     "by this function.")
         with assert_raises(ValueError, match=error_msg):
             curve_fit(**kwargs, nan_policy="propagate", maxfev=2000)
 
@@ -568,8 +568,7 @@ class TestCurveFit:
 
         # omit test
         result_with_nan, _ = curve_fit(**kwargs, nan_policy="omit")
-        result_without_nan, _ = curve_fit(f, xdata_without_nan,
-                                          ydata_without_nan, method=method)
+        result_without_nan, _ = curve_fit(**kwargs, nan_policy="omit")
         assert_allclose(result_with_nan, result_without_nan)
 
     @pytest.mark.parametrize('method', ["lm", "trf", "dogbox"])

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -555,8 +555,8 @@ class TestCurveFit:
     def _check_nan_policy(f, xdata_with_nan, xdata_without_nan,
                           ydata_with_nan, ydata_without_nan, method):
         # propagate test
-        error_msg = "`propagate` is not supported for nan_policy " \
-                    "in this function."
+        error_msg = ("`nan_policy='propagate'` is not supported "
+                    "by this function.")
         with assert_raises(ValueError, match=error_msg):
             curve_fit(f, xdata_with_nan, ydata_with_nan, method=method,
                       check_finite=False, nan_policy="propagate",

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -610,6 +610,7 @@ class TestCurveFit:
 
         xdata_with_nan = np.array([[[2, 3, np.nan, 4, 4, np.nan, 5],
                                    [2, 3, np.nan, np.nan, 4, np.nan, 7]]])
+        xdata_with_nan = xdata_with_nan.squeeze() if n==2 else xdata_with_nan
         ydata_with_nan = np.array([1, 2, 5, 3, np.nan, 7, 10])
         xdata_without_nan = np.array([[[2, 3, 5], [2, 3, 7]]])
         ydata_without_nan = np.array([1, 2, 10])

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -562,7 +562,8 @@ class TestCurveFit:
 
                 with assert_raises(OptimizeWarning, match=warning_msg):
                     curve_fit(f, xdata_with_nan, ydata_with_nan, method=method,
-                              check_finite=False, nan_policy="propagate")
+                              check_finite=False, nan_policy="propagate",
+                              maxfev=2000)
         else:  # "trf", "dogbox"
             error_msg = "Residuals are not finite in the initial point"
             with assert_raises(ValueError, match=error_msg):

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -611,7 +611,7 @@ class TestCurveFit:
 
         xdata_with_nan = np.array([[[2, 3, np.nan, 4, 4, np.nan, 5],
                                    [2, 3, np.nan, np.nan, 4, np.nan, 7]]])
-        xdata_with_nan = xdata_with_nan.squeeze() if n==2 else xdata_with_nan
+        xdata_with_nan = xdata_with_nan.squeeze() if n == 2 else xdata_with_nan
         ydata_with_nan = np.array([1, 2, 5, 3, np.nan, 7, 10])
         xdata_without_nan = np.array([[[2, 3, 5], [2, 3, 7]]])
         ydata_without_nan = np.array([1, 2, 10])

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -558,9 +558,9 @@ class TestCurveFit:
         error_msg = "`propagate` is not supported for nan_policy " \
                     "in this function."
         with assert_raises(ValueError, match=error_msg):
-                    curve_fit(f, xdata_with_nan, ydata_with_nan, method=method,
-                              check_finite=False, nan_policy="propagate",
-                              maxfev=2000)
+            curve_fit(f, xdata_with_nan, ydata_with_nan, method=method,
+                      check_finite=False, nan_policy="propagate",
+                      maxfev=2000)
 
         # raise test
         with assert_raises(ValueError, match="The input contains nan"):

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -555,20 +555,12 @@ class TestCurveFit:
     def _check_nan_policy(f, xdata_with_nan, xdata_without_nan,
                           ydata_with_nan, ydata_without_nan, method):
         # propagate test
-        if method == "lm":
-            warning_msg = "Covariance of the parameters could not be estimated"
-            with warnings.catch_warnings():
-                warnings.simplefilter("error", OptimizeWarning)
-
-                with assert_raises(OptimizeWarning, match=warning_msg):
+        error_msg = "`propagate` is not supported for nan_policy " \
+                    "in this function."
+        with assert_raises(ValueError, match=error_msg):
                     curve_fit(f, xdata_with_nan, ydata_with_nan, method=method,
                               check_finite=False, nan_policy="propagate",
                               maxfev=2000)
-        else:  # "trf", "dogbox"
-            error_msg = "Residuals are not finite in the initial point"
-            with assert_raises(ValueError, match=error_msg):
-                curve_fit(f, xdata_with_nan, ydata_with_nan, method=method,
-                          check_finite=False, nan_policy="propagate")
 
         # raise test
         with assert_raises(ValueError, match="The input contains nan"):

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -560,9 +560,7 @@ class TestCurveFit:
         error_msg = ("`nan_policy='propagate'` is not supported "
                     "by this function.")
         with assert_raises(ValueError, match=error_msg):
-            curve_fit(f, xdata_with_nan, ydata_with_nan, method=method,
-                      check_finite=False, nan_policy="propagate",
-                      maxfev=2000)
+            curve_fit(**kwargs, nan_policy="propagate", maxfev=2000)
 
         # raise test
         with assert_raises(ValueError, match="The input contains nan"):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Fix #11841
Ref #11846 (A staled PR to fix #11841)

#### What does this implement/fix?
<!--Please explain your changes.-->
As reported in #11841 and #11846, some users would like to add a nan handling functionality to ignore nans in input data for `optimize.curve_fit`.
This PR adds `nan_policy` optional argument for [`curve_fit`](http://scipy.github.io/devdocs/reference/generated/scipy.optimize.curve_fit.html?highlight=curve_fit#scipy.optimize.curve_fit) based on our [nan_policy guideline](http://scipy.github.io/devdocs/dev/api-dev/nan_policy.html).
If `omit` nan_policy is used, the nans in input data will be ignored.

#### Additional information
<!--Any additional information you think is important.-->
