### PR TITLE
MAINT: fix NumPy upper bound

### DIFF
--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -148,7 +148,7 @@ else:
     # In maintenance branch, change to np_maxversion N+3 if numpy is at N
     # See setup.py for more details
     np_minversion = '1.18.5'
-    np_maxversion = '1.25.0'
+    np_maxversion = '1.26.0'
     if (_pep440.parse(__numpy_version__) < _pep440.Version(np_minversion) or
             _pep440.parse(__numpy_version__) >= _pep440.Version(np_maxversion)):
         import warnings

--- a/setup.py
+++ b/setup.py
@@ -450,7 +450,7 @@ def setup_package():
     #            in N+1 will turn into errors in N+3
     # For Python versions, if releases is (e.g.) <=3.9.x, set bound to 3.10
     np_minversion = '1.18.5'
-    np_maxversion = '1.25.0'
+    np_maxversion = '1.26.0'
     python_minversion = '3.8'
     python_maxversion = '3.12'
     if IS_RELEASE_BRANCH:


### PR DESCRIPTION
* deals with gh-16964 -- it looks like we've been using
lower version bounds than we should for NumPy in i.e.,
`setup.py` (but not `pyproject.toml`) since the `1.7.x` series; it looks like
the wheel-distributed metadata is configured from `setup.py`
until we switch to `meson`/`cibuildwheel`; we're planning to
do that soon anyway, but the fixes still seem sensible to
apply for consistency, or in case last minute `cibuildwheel` blockers
pop up for `1.9.2` (I'm less certain if we should backport this
all the way to `1.7.x`)

* please do double check carefully, since this version bound stuff
has apparently slipped through the cracks a few times now--perhaps
part of the confusion is the `np_maxversion` variable name, since it
is conceptually `np_maxversion_plus_one`, but I've perhaps accidentally
treated it as the former