### PR TITLE
ENH: Close parenthesis in numpy version warning

### DIFF
--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -142,7 +142,7 @@ else:
         import warnings
         warnings.warn(f"A NumPy version >={np_minversion} and <{np_maxversion}"
                       f" is required for this version of SciPy (detected "
-                      f"version {__numpy_version__}",
+                      f"version {__numpy_version__})",
                       UserWarning)
     del _pep440
 


### PR DESCRIPTION
#### What does this implement/fix?

This adds a missing parenthesis in the warning message about numpy version.

Currently the message looks like this (missing closing parenthesis at the end):
```
UserWarning: A NumPy version >=1.16.5 and <1.23.0 is required for this version of SciPy (detected version 1.23.1
```