### PR TITLE
BLD: fix usage of `get_install_data`, which defaults to purelib

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -66,6 +66,8 @@ copier = find_program(['cp', 'scipy/_build_utils/copyfiles.py'])
 
 # https://mesonbuild.com/Python-module.html
 py_mod = import('python')
+# NOTE: with Meson >=0.64.0 we can add `pure: false` here and remove that line
+# everywhere else, see https://github.com/mesonbuild/meson/pull/10783.
 py3 = py_mod.find_installation()
 py3_dep = py3.dependency()
 

--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -28,7 +28,7 @@ cython_linalg = custom_target('cython_linalg',
   # TODO - we only want to install the .pxd files! See comments for
   #        `pxd_files` further down.
   install: true,
-  install_dir: py3.get_install_dir() / 'scipy/linalg'
+  install_dir: py3.get_install_dir(pure: false) / 'scipy/linalg'
 )
 
 # pyx -> c, pyx -> cpp generators, depending on __init__.py here.
@@ -322,7 +322,7 @@ py3.install_sources(
 #       https://mesonbuild.com/Installing.html says is for build targets to
 #       use:
 #         `custom_target(..., install: true, install_dir: ...)
-#         # should use `py3.get_install_dir() / 'scipy/linalg'` ?
+#         # should use `py3.get_install_dir(pure: false) / 'scipy/linalg'` ?
 #       see https://github.com/mesonbuild/meson/issues/3206
 #
 #       For the below code to work, the script generating the files should use
@@ -340,7 +340,7 @@ py3.install_sources(
 #  output : ['cython_blas2.pxd', 'cython_lapack2.pxd'],
 #  command : ['cp', '@INPUT0@', '@OUTPUT0@', '&&', 'cp', '@INPUT1@', '@OUTPUT1@'],
 #  install : true,
-#  install_dir: py3.get_install_dir() / 'scipy/linalg'
+#  install_dir: py3.get_install_dir(pure: false) / 'scipy/linalg'
 #)
 
 subdir('tests')

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -158,7 +158,7 @@ generate_config = custom_target(
   output: '__config__.py',
   input: '../tools/config_utils.py',
   command: [py3, '@INPUT@', '@OUTPUT@'],
-  install_dir: py3.get_install_dir() / 'scipy'
+  install_dir: py3.get_install_dir(pure: false) / 'scipy'
 )
 
 generate_version = custom_target(
@@ -169,7 +169,7 @@ generate_version = custom_target(
   output: 'version.py',
   input: '../tools/version_utils.py',
   command: [py3, '@INPUT@', '--source-root', '@SOURCE_ROOT@'],
-  install_dir: py3.get_install_dir() / 'scipy'
+  install_dir: py3.get_install_dir(pure: false) / 'scipy'
 )
 
 python_sources = [

--- a/scipy/special/meson.build
+++ b/scipy/special/meson.build
@@ -341,7 +341,7 @@ cython_special = custom_target('cython_special',
   input: ['_generate_pyx.py', 'functions.json', '_add_newdocs.py'],
   command: [py3, '@INPUT0@', '-o', '@OUTDIR@'],
   install: true,
-  install_dir: py3.get_install_dir() / 'scipy/special'
+  install_dir: py3.get_install_dir(pure: false) / 'scipy/special'
 )
 
 # pyx -> c, pyx -> cpp generators, depending on copied pxi, pxd files.
@@ -486,7 +486,7 @@ foreach npz_file: npz_files
       '--use-timestamp', npz_file[2], '-o', '@OUTDIR@'
     ],
     install: true,
-    install_dir: py3.get_install_dir() / 'scipy/special/tests/data'
+    install_dir: py3.get_install_dir(pure: false) / 'scipy/special/tests/data'
   )
 endforeach
 


### PR DESCRIPTION
This resulted in `{py_purelib}/` entries in `<build-dir>/meson-info/intro-install_plan.json`, and there should be zero of those.

[skip azp] [skip circle]

Note that this is a pretty bad bug, which results in the build working fine but a few files being installed to the wrong location _only on Python installs where `purelib` and `platlib` don't match_. It looks like that broke `import scipy` on Gentoo (see https://github.com/FFY00/meson-python/issues/127).