### PR TITLE
DOC: Fix link to rendered docs in documentation guide

### DIFF
--- a/doc/source/dev/contributor/rendering_documentation.rst
+++ b/doc/source/dev/contributor/rendering_documentation.rst
@@ -107,7 +107,7 @@ on the cloud.
 #. Log in to `GitHub`_.
 #. Log in `CircleCI`_ using your GitHub account.
 #. Back in GitHub, at the bottom of the PR, select “Show all Checks”.
-#. Next to “ci/circleci: build_docs artifact”, select “Details”.
+#. Next to “Check the rendered docs here!”, select “Details”.
 
 .. _docs-guidelines:
 


### PR DESCRIPTION
#### What does this implement/fix?
The [documentation guide](https://docs.scipy.org/doc/scipy/dev/contributor/rendering_documentation.html#rendering-documentation) currently shows wrong information about where to find the rendered docs on a PR:

<img width="236" alt="image" src="https://user-images.githubusercontent.com/40656107/189217455-b460ff90-93e0-4744-bc1e-ac3dc712b4d7.png">

This fixes the fourth item.

#### Additional information
I noticed that the doc pages on CircleCI often take a long time to load. Just a question of enough computational resources?