### PR TITLE
ENH: stats.gaussian_kde: replace use of inv_cov in logpdf

### DIFF
--- a/scipy/stats/_kde.py
+++ b/scipy/stats/_kde.py
@@ -566,13 +566,13 @@ class gaussian_kde:
         covariance_factor().
         """
         self.factor = self.covariance_factor()
-        # Cache covariance and permuted cholesky decomp of permuted covariance
+        # Cache covariance and cholesky decomp of covariance
         if not hasattr(self, '_data_cho_cov'):
             self._data_covariance = atleast_2d(cov(self.dataset, rowvar=1,
                                                bias=False,
                                                aweights=self.weights))
-            self._data_cho_cov = linalg.cholesky(
-                self._data_covariance[::-1, ::-1]).T[::-1, ::-1]
+            self._data_cho_cov = linalg.cholesky(self._data_covariance,
+                                                 lower=True)
 
         self.covariance = self._data_covariance * self.factor**2
         self.cho_cov = (self._data_cho_cov * self.factor).astype(np.float64)

--- a/scipy/stats/_kde.py
+++ b/scipy/stats/_kde.py
@@ -566,7 +566,7 @@ class gaussian_kde:
         covariance_factor().
         """
         self.factor = self.covariance_factor()
-        # Cache covariance and cholesky decomp of covariance
+        # Cache covariance and Cholesky decomp of covariance
         if not hasattr(self, '_data_cho_cov'):
             self._data_covariance = atleast_2d(cov(self.dataset, rowvar=1,
                                                bias=False,
@@ -623,7 +623,7 @@ class gaussian_kde:
         output_dtype, spec = _get_output_dtype(self.covariance, points)
         result = gaussian_kernel_estimate_log[spec](
             self.dataset.T, self.weights[:, None],
-            points.T, self.inv_cov, output_dtype)
+            points.T, self.cho_cov, output_dtype)
 
         return result[:, 0]
 

--- a/scipy/stats/_stats.pyx
+++ b/scipy/stats/_stats.pyx
@@ -753,7 +753,7 @@ def gaussian_kernel_estimate(points, values, xi, cho_cov, dtype,
     xi : array_like with shape (m, d)
         Coordinates to evaluate the estimate at in d dimensions.
     cho_cov : array_like with shape (d, d)
-        Permuted Cholesky factor of permuted covariance of the data.
+        (Lower) Cholesky factor of the covariance.
 
     Returns
     -------
@@ -778,9 +778,9 @@ def gaussian_kernel_estimate(points, values, xi, cho_cov, dtype,
 
     # Rescale the data
     cho_cov_ = cho_cov.astype(dtype, copy=False)
-    points_ = np.asarray(solve_triangular(cho_cov, points.T, lower=False).T,
+    points_ = np.asarray(solve_triangular(cho_cov, points.T, lower=True).T,
                          dtype=dtype)
-    xi_ = np.asarray(solve_triangular(cho_cov, xi.T, lower=False).T,
+    xi_ = np.asarray(solve_triangular(cho_cov, xi.T, lower=True).T,
                      dtype=dtype)
     values_ = values.astype(dtype, copy=False)
 

--- a/scipy/stats/_stats.pyx
+++ b/scipy/stats/_stats.pyx
@@ -805,9 +805,9 @@ cdef real logsumexp(real a, real b):
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def gaussian_kernel_estimate_log(points, values, xi, precision, dtype, real _=0):
+def gaussian_kernel_estimate_log(points, values, xi, cho_cov, dtype, real _=0):
     """
-    def gaussian_kernel_estimate_log(points, real[:, :] values, xi, precision)
+    def gaussian_kernel_estimate_log(points, real[:, :] values, xi, cho_cov)
 
     Evaluate the log of the estimated pdf on a provided set of points.
 
@@ -819,8 +819,8 @@ def gaussian_kernel_estimate_log(points, values, xi, precision, dtype, real _=0)
         Multivariate values associated with the data points.
     xi : array_like with shape (m, d)
         Coordinates to evaluate the estimate at in ``d`` dimensions.
-    precision : array_like with shape (d, d)
-        Precision matrix for the Gaussian kernel.
+    cho_cov : array_like with shape (d, d)
+        (Lower) Cholesky factor of the covariance.
 
     Returns
     -------
@@ -829,7 +829,7 @@ def gaussian_kernel_estimate_log(points, values, xi, precision, dtype, real _=0)
         input coordinates.
     """
     cdef:
-        real[:, :] points_, xi_, values_, log_values_, estimate, whitening
+        real[:, :] points_, xi_, values_, log_values_, estimate, cho_cov_
         int i, j, k
         int n, d, m, p
         real arg, residual, log_norm
@@ -841,13 +841,15 @@ def gaussian_kernel_estimate_log(points, values, xi, precision, dtype, real _=0)
 
     if xi.shape[1] != d:
         raise ValueError("points and xi must have same trailing dim")
-    if precision.shape[0] != d or precision.shape[1] != d:
-        raise ValueError("precision matrix must match data dims")
+    if cho_cov.shape[0] != d or cho_cov.shape[1] != d:
+        raise ValueError("Covariance matrix must match data dims")
 
     # Rescale the data
-    whitening = np.linalg.cholesky(precision).astype(dtype, copy=False)
-    points_ = np.dot(points, whitening).astype(dtype, copy=False)
-    xi_ = np.dot(xi, whitening).astype(dtype, copy=False)
+    cho_cov_ = cho_cov.astype(dtype, copy=False)
+    points_ = np.asarray(solve_triangular(cho_cov, points.T, lower=True).T,
+                         dtype=dtype)
+    xi_ = np.asarray(solve_triangular(cho_cov, xi.T, lower=True).T,
+                     dtype=dtype)
     values_ = values.astype(dtype, copy=False)
 
     log_values_ = np.empty((n, p), dtype)
@@ -858,7 +860,7 @@ def gaussian_kernel_estimate_log(points, values, xi, precision, dtype, real _=0)
     # Evaluate the normalisation
     log_norm = (- d / 2) * math.log(2 * PI)
     for i in range(d):
-        log_norm += math.log(whitening[i, i])
+        log_norm -= math.log(cho_cov[i, i])
 
     # Create the result array and evaluate the weighted sum
     estimate = np.full((m, p), fill_value=-np.inf, dtype=dtype)


### PR DESCRIPTION
#### Reference issue
gh-16692

#### What does this implement/fix?
gh-16692 used Cholesky decomposition to avoid the inversion of the covariance matrix in `gaussian_kde.pdf`.
We wanted to wait for gh-15493 to finish before implementing that change in `gaussian_kde.logpdf`.
Now that gh-15493 is done, this makes the change to `gaussian_kde.logpdf`. 

It also simplifies what we did in gh-16692. In that, we found a way to use Cholesky decomposition to compute $L^T x$, where $L L^T = \Sigma^{-1}$ (that is, $L$ is a Cholesky factor of the precision matrix / inverse covariance matrix).
Ultimately, we don't need $L^T x$; it was just one way to get to $x^T \Sigma^{-1} x$. There is a simpler way to get that while still avoiding the matrix inversion: $x^T \Sigma^{-1} x = y^T y$, where $C y = x$ and $CC^T = \Sigma$ (that is, $C$ is a Cholesky factor of the original covariance matrix rather than the precision matrix). The short calculation is shown [here](https://www.math.wsu.edu/faculty/genz/papers/mvn.pdf).

@steppi I think someone else can review this since it's simpler than gh-16692, but I thought you might find it interesting that those permutations weren't necessary to get the end result.