### PR TITLE
DOC: edited t_span parameter description in integrate.solve_ivp

### DIFF
--- a/scipy/integrate/_ivp/ivp.py
+++ b/scipy/integrate/_ivp/ivp.py
@@ -188,8 +188,8 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
         options is determined by `vectorized` argument (see below). The
         vectorized implementation allows a faster approximation of the Jacobian
         by finite differences (required for stiff solvers).
-    t_span : 2-tuple of floats
-        Interval of integration (t0, tf). The solver starts with t=t0 and
+    t_span : array_like, shape (2,)
+        Interval of integration [t0, tf]. The solver starts with t=t0 and
         integrates until it reaches t=tf.
     y0 : array_like, shape (n,)
         Initial state. For problems in the complex domain, pass `y0` with a

--- a/scipy/integrate/_ivp/ivp.py
+++ b/scipy/integrate/_ivp/ivp.py
@@ -188,9 +188,10 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
         options is determined by `vectorized` argument (see below). The
         vectorized implementation allows a faster approximation of the Jacobian
         by finite differences (required for stiff solvers).
-    t_span : array_like, shape (2,)
-        Interval of integration [t0, tf]. The solver starts with t=t0 and
-        integrates until it reaches t=tf.
+    t_span : 2-member iterable
+        Interval of integration (t0, tf). The solver starts with t=t0 and
+        integrates until it reaches t=tf. Both t0 and tf must be floats
+        or values interpretable by the float conversion function.
     y0 : array_like, shape (n,)
         Initial state. For problems in the complex domain, pass `y0` with a
         complex data type (even if the initial value is purely real).

--- a/scipy/integrate/_ivp/ivp.py
+++ b/scipy/integrate/_ivp/ivp.py
@@ -188,7 +188,7 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
         options is determined by `vectorized` argument (see below). The
         vectorized implementation allows a faster approximation of the Jacobian
         by finite differences (required for stiff solvers).
-    t_span : 2-member iterable
+    t_span : 2-member sequence
         Interval of integration (t0, tf). The solver starts with t=t0 and
         integrates until it reaches t=tf. Both t0 and tf must be floats
         or values interpretable by the float conversion function.


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #16978

#### What does this implement/fix?
A simple documentation fix; as pointed out, t_span is an array_like object but was described as a tuple.

#### Additional information
<!--Any additional information you think is important.-->
