### PR TITLE
CI: enable uploads for (weekly) nightlies and update how action triggers are specified

### DIFF
--- a/.github/workflows/circle_artifacts.yml
+++ b/.github/workflows/circle_artifacts.yml
@@ -2,6 +2,7 @@ on: [status]
 jobs:
   circleci_artifacts_redirector_job:
     runs-on: ubuntu-20.04
+    if: github.repository == 'scipy/scipy'
     name: Run CircleCI artifacts redirector
     steps:
       - name: GitHub Action step

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -19,7 +19,9 @@ on:
   - cron: "9  9 * * 6"
   # push:
   pull_request:
-      types: [labeled, opened, synchronize, reopened]
+    branches:
+      - main
+      - maintenance/**
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -193,22 +193,19 @@ jobs:
           path: ./wheelhouse/*.whl
           name: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}
 
-        # TODO uncomment when those responsible for uploading
-        # nightly/release wheels want to make this script live.
-
-      # - name: Upload wheels
-      #  if: success()
-      #  shell: bash
-      #  env:
-      #    SCIPY_STAGING_UPLOAD_TOKEN: ${{ secrets.SCIPY_STAGING_UPLOAD_TOKEN }}
-      #    SCIPY_NIGHTLY_UPLOAD_TOKEN: ${{ secrets.SCIPY_NIGHTLY_UPLOAD_TOKEN }}
-      #  run: |
-      #    source tools/wheels/upload_wheels.sh
-      #    set_upload_vars
-      #    # trigger an upload to
-      #    # https://anaconda.org/scipy-wheels-nightly/scipy
-      #    # for cron jobs or "Run workflow" (restricted to main branch).
-      #    # Tags will upload to
-      #    # https://anaconda.org/multibuild-wheels-staging/scipy
-      #    # The tokens were originally generated at anaconda.org
-      #    upload_wheels
+      - name: Upload wheels
+        if: success()
+        shell: bash
+        env:
+          SCIPY_STAGING_UPLOAD_TOKEN_GHA: ${{ secrets.SCIPY_STAGING_UPLOAD_TOKEN }}
+          SCIPY_NIGHTLY_UPLOAD_TOKEN: ${{ secrets.SCIPY_NIGHTLY_UPLOAD_TOKEN }}
+        run: |
+          source tools/wheels/upload_wheels.sh
+          set_upload_vars
+          # trigger an upload to
+          # https://anaconda.org/scipy-wheels-nightly/scipy
+          # for cron jobs or "Run workflow" (restricted to main branch).
+          # Tags will upload to
+          # https://anaconda.org/multibuild-wheels-staging/scipy
+          # The tokens were originally generated at anaconda.org
+          upload_wheels


### PR DESCRIPTION
This requires two secrets: `SCIPY_NIGHTLY_UPLOAD_TOKEN` and `SCIPY_STAGING_UPLOAD_TOKEN`. Those can be configured, for the folks with permissions to manage the Anaconda buckets, at:

- https://anaconda.org/multibuild-wheels-staging/settings/access
- https://anaconda.org/scipy-wheels-nightly/settings/access

Also see the docs at https://docs.anaconda.com/anacondaorg/user-guide/tasks/work-with-accounts/#creating-access-tokens

Once this is happy, we should stop the upload from https://github.com/MacPython/scipy-wheels for nightlies as a follow-up.