### PR TITLE
BLD: fixes for building with MSVC and Intel Fortran

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -58,6 +58,14 @@ if ff.has_argument('-Wno-conversion')
   add_project_arguments('-Wno-conversion', language: 'fortran')
 endif
 
+is_windows = host_machine.system() == 'windows'
+
+# Intel Fortran on Windows does things differently, so deal with that
+if is_windows and ff.get_id() == 'intel-cl'
+  _ifort_flags = ff.get_supported_arguments('/MD', '/names:lowercase', '/assume:underscore')
+  add_project_arguments(_ifort_flags, language: 'fortran')
+endif
+
 cython = find_program('cython')
 pythran = find_program('pythran')
 generate_f2pymod = files('tools/generate_f2pymod.py')

--- a/scipy/fft/_pocketfft/meson.build
+++ b/scipy/fft/_pocketfft/meson.build
@@ -5,15 +5,27 @@ win_gcc = is_windows and meson.get_compiler('cpp').get_id() == 'gcc'
 
 pocketfft_threads = []
 fft_deps = []
-if not win_gcc
-  if thread_dep.found()
-    pocketfft_threads += ['-DPOCKETFFT_PTHREADS']
-    fft_deps += [thread_dep]
+if is_windows
+  if win_gcc
+    # Disable threading completely, because of freezes using threading for
+    # mingw-w64 gcc: https://github.com/mreineck/pocketfft/issues/1
+    pocketfft_threads += ['-DPOCKETFFT_NO_MULTITHREADING']
+  else
+    if thread_dep.found()
+      # Use native Windows threading for MSVC/Clang. `pthreads` is probably not
+      # installed, and native threading is always available. It is not easy to
+      # distinguish this better, Meson builtin functionality for that is in
+      # progress (see comment on gh-16957).  The code in `pocketfft_hdronly.h`
+      # will include `<threads>` anyway.
+      fft_deps += [thread_dep]
+      pocketfft_threads += []
+    endif
   endif
 else
-  # Freezes using threading for mingw-w64 gcc:
-  # https://github.com/mreineck/pocketfft/issues/1
-  pocketfft_threads += ['-DPOCKETFFT_NO_MULTITHREADING']
+  if thread_dep.found()
+    fft_deps += [thread_dep]
+    pocketfft_threads += ['-DPOCKETFFT_PTHREADS']
+  endif
 endif
 
 py3.extension_module('pypocketfft',

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -1,5 +1,4 @@
 # Platform detection
-is_windows = host_machine.system() == 'windows'
 is_mingw = is_windows and cc.get_id() == 'gcc'
 
 cython_c_args = []

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -306,7 +306,7 @@ endif
 # Suppress warning for deprecated Numpy API.
 # (Suppress warning messages emitted by #warning directives).
 # Replace with numpy_nodepr_api after Cython 3.0 is out
-cython_c_args += ['-Wno-cpp', use_math_defines]
+cython_c_args += [_cpp_Wno_cpp, use_math_defines]
 cython_cpp_args = cython_c_args
 
 # Ordering of subdirs: special and linalg come first, because other submodules


### PR DESCRIPTION
These fixes are derived from gh-16957. That PR may take a while to land, so get this in to unblock users wanting to build with these compilers (xref gh-16988).