### PR TITLE
CI: upgrade CI image to run on Ubuntu 22.04 instead of 20.04

### DIFF
--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -27,7 +27,7 @@ jobs:
     name: Meson build
     # If using act to run CI locally the github object does not exist and the usual skipping should not be enforced
     if: "github.repository == 'scipy/scipy' || github.repository == ''"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ['3.9', '3.11-dev']


### PR DESCRIPTION
This brings in a newer GCC (11.2 instead of 9.3), so the `-Werror` flag will catch more issues here.

[skip azp] [skip circle]
