### PR TITLE
DEV: add conda-build to enviroment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -49,3 +49,5 @@ dependencies:
   - click
   - doit>=0.36.0
   - pydevtool
+  # For importing development version of SciPy
+  - conda-build


### PR DESCRIPTION

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
Finally got around to moving to the new `dev.py` interface and was follow development environment instructions [here](https://scipy.github.io/devdocs/dev/contributor/conda_guide.html#conda-guide).

The instructions were fine until
https://github.com/scipy/scipy/blame/main/doc/source/dev/contributor/conda_guide.rst#L79-L81

where I hit the following error:
```
(scipy-dev) [jakeb@jake-vostro157510 scipy]$ conda develop .

CommandNotFoundError: To use 'conda develop', install conda-build.
```
This was resolved by adding `conda-build` to the `enviroment.yml` file.
#### Additional information
<!--Any additional information you think is important.-->
