### PR TITLE
DOC: stats: fix incorrectly documented statistic attribute for SomersDResult

### DIFF
--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -748,7 +748,7 @@ def somersd(x, y=None, alternative='two-sided'):
     res : SomersDResult
         A `SomersDResult` object with the following fields:
 
-            correlation : float
+            statistic : float
                The Somers' :math:`D` statistic.
             pvalue : float
                The p-value for a hypothesis test whose null


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
In the current version of the docs its states that the `SomersDResult` object has a `correlation` attribute however this attribute is actually called `statistic`.

```
from scipy.stats import somersd
table = [[27, 25, 14, 7, 0], [7, 14, 18, 35, 12], [1, 3, 2, 7, 17]]
res = somersd(table)
print(res.correlation)
```
```
AttributeError: 'SomersDResult' object has no attribute 'correlation'
```
#### Additional information
<!--Any additional information you think is important.-->
