### PR TITLE
CI: allow the wheel build commit trigger anywhere in the commit message

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -45,7 +45,7 @@ jobs:
         id: commit_message
         run: |
           set -xe
-          COMMIT_MSG=$(git log --no-merges -1 --oneline)
+          COMMIT_MSG=$(git log --no-merges -1)
           echo "::set-output name=message::$COMMIT_MSG"
           echo github.ref ${{ github.ref }}
 


### PR DESCRIPTION
This trigger is: [wheel build]

Before it had to be on the first line, which is out of sync with other such commands like `[skip azp]` and `[skip circle]`.

So this commit message in a PR now should trigger a wheel build.

EDIT: this PR is a follow-up to gh-16990.