### PR TITLE
BLD: make MKL detection a little more robust, add notes on TODOs

### DIFF
--- a/doc/source/dev/contributor/building_faq.rst
+++ b/doc/source/dev/contributor/building_faq.rst
@@ -93,7 +93,7 @@ library is MKL and if so, use the CBLAS API instead of the BLAS API.
 If autodetection fails or if the user wants to override this
 autodetection mechanism, use the following:
 
-_For ``meson`` based builds (new in 1.9.0):_
+*For ``meson`` based builds (new in 1.9.0):*
 
 Use the ``-Duse-g77-abi=true`` build option. E.g.,::
 
@@ -106,7 +106,7 @@ example)::
     $ meson setup builddir -Duse-g77-abi=true -Dblas=blas -Dlapack=lapack -Dpython.install_env=auto
     $ meson install -C builddir
 
-_For ``distutils`` based builds:_
+*For ``distutils`` based builds:*
 
 Set the environment variable ``SCIPY_USE_G77_ABI_WRAPPER`` to 0 or 1 to disable
 or enable using CBLAS API.

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -141,7 +141,12 @@ endif
 blas = dependency(blas_name)
 lapack = dependency(lapack_name)
 
-if blas.name() == 'mkl' or lapack.name() == 'mkl' or get_option('use-g77-abi')
+# FIXME: conda-forge sets MKL_INTERFACE_LAYER=LP64,GNU, see gh-11812.
+#        This needs work on gh-16200 to make MKL robust. We should be
+#        requesting `mkl-dynamic-lp64-seq` here. And then there's work needed
+#        in general to enable the ILP64 interface (also for OpenBLAS).
+uses_mkl = blas.name().to_lower().startswith('mkl') or lapack.name().to_lower().startswith('mkl')
+if uses_mkl or get_option('use-g77-abi')
   g77_abi_wrappers = files([
     '_build_utils/src/wrap_g77_abi_f.f',
     '_build_utils/src/wrap_g77_abi_c.c'

--- a/scipy/sparse/linalg/_propack/dpropack.pyf
+++ b/scipy/sparse/linalg/_propack/dpropack.pyf
@@ -10,7 +10,7 @@ python module __user__routines
            double precision depend(m,n),check(len(y)>=(transa[0] == 'n' ? m : n)),dimension((transa[0] == 'n' ? m : n)) :: y
            integer dimension(*) :: iparm
            double precision dimension(*) :: dparm
-        end function saprod
+        end function daprod
     end interface
 end python module __user__routines
 

--- a/scipy/sparse/linalg/_propack/meson.build
+++ b/scipy/sparse/linalg/_propack/meson.build
@@ -86,8 +86,11 @@ elements = [
 ]
 
 foreach ele: elements
-  propack_lib = static_library('lib_' + ele[0], ele[1],
-    c_args: ['_OPENMP'],
+  # FIXME: this doesn't match `setup.py` for g77 ABI issue. That is pretty much
+  # broken anyway, see for example gh-15108.
+  propack_lib = static_library('lib_' + ele[0],
+    [ele[1], g77_abi_wrappers],
+    c_args: ['-D_OPENMP'],  # FIXME: this is needed now, but not good!
     fortran_args: [
       fortran_ignore_warnings, 
       _fflag_Wno_intrinsic_shadow,


### PR DESCRIPTION
If the detection happens via CMake, that results in an upper-case result for `blas.name()`. So deal with any case, and also that of using `-Dblas=mkl_rt`.
    
Note that this does not fix things for using CMake, because that defaults to the ILP64 interface (xref gh-16988). Add notes on what is left for MKL support.
    
Also add g77 ABI wrapper and fix a typo in f2py signature file in `_propack`. Note that this is an incomplete fix, because PROPACK is in a bad state, as discussed in the issue linked in the code comment.