### PR TITLE
CI: Skip some doc build artifact redirector jobs

### DIFF
--- a/.github/workflows/circle_artifacts.yml
+++ b/.github/workflows/circle_artifacts.yml
@@ -2,7 +2,7 @@ on: [status]
 jobs:
   circleci_artifacts_redirector_job:
     runs-on: ubuntu-20.04
-    if: github.repository == 'scipy/scipy'
+    if: "${{ github.repository == 'scipy/scipy' && github.event.context == 'ci/circleci: build_docs' }}"
     name: Run CircleCI artifacts redirector
     steps:
       - name: GitHub Action step


### PR DESCRIPTION
@rgommers for MNE-Python at least they show up as skipped now, which seems a bit better at least:

![image](https://user-images.githubusercontent.com/2365790/189786585-5c3c6b09-de11-49ae-a5d8-db6e20e1098e.png)

Assuming I got the syntax right, this should do something similar for SciPy