### PR TITLE
ENH: Speed up sparse.csgraph.dijkstra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -237,7 +237,7 @@ scipy/signal/_bspline_util.c
 scipy/sparse/_csparsetools.c
 scipy/sparse/_csparsetools.pyx
 scipy/sparse/csgraph/_min_spanning_tree.c
-scipy/sparse/csgraph/_shortest_path.c
+scipy/sparse/csgraph/_shortest_path.cxx
 scipy/sparse/csgraph/_tools.c
 scipy/sparse/csgraph/_traversal.c
 scipy/sparse/csgraph/_flow.c

--- a/benchmarks/benchmarks/sparse_csgraph_dijkstra.py
+++ b/benchmarks/benchmarks/sparse_csgraph_dijkstra.py
@@ -20,7 +20,7 @@ class Dijkstra(Benchmark):
         rng = np.random.default_rng(1234)
         if format == 'random':
             # make a random connectivity matrix
-            data = scipy.sparse.rand(n, n, density=0.2, format='csc',
+            data = scipy.sparse.rand(n, n, density=0.2, format='lil',
                                      random_state=42, dtype=np.bool_)
             data.setdiag(np.zeros(n, dtype=np.bool_))
             self.data = data

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -693,6 +693,7 @@ cdef int _dijkstra(
         int return_sources = (sources.size > 0)
         int directed = (csrT_weights.size == 0)
         dijkstra_queue_t heap # pairs of {-distance, vertex index} will be pushed
+                              # to treat it as a min-heap instead of max-heap
         dist_index_pair_t v
     
     for i in range(Nind):

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -344,7 +344,7 @@ cdef void _floyd_warshall(
     # dist_matrix should be a [N,N] matrix, such that dist_matrix[i, j]
     # is the distance from point i to point j.  Zero-distances imply that
     # the points are not connected.
-    cdef int N = dist_matrix.shape[0]
+    cdef unsigned int N = dist_matrix.shape[0]
     assert dist_matrix.shape[1] == N
 
     cdef unsigned int i, j, k
@@ -687,7 +687,7 @@ cdef int _dijkstra(
     cdef:
         unsigned int Nind = source_indices.shape[0]
         unsigned int N = dist_matrix.shape[0]
-        unsigned int i, k, j_source, j_current
+        unsigned int i, j_source
         DTYPE_t next_val
         int return_pred = (pred.size > 0)
         int return_sources = (sources.size > 0)
@@ -916,7 +916,8 @@ cdef int _bellman_ford_directed(
     cdef:
         unsigned int Nind = dist_matrix.shape[0]
         unsigned int N = dist_matrix.shape[1]
-        unsigned int i, j, k, j_source, count
+        unsigned int i, j, j_source, count
+        ITYPE_t k
         DTYPE_t d1, d2, w12
         int return_pred = (pred.size > 0)
 
@@ -957,7 +958,8 @@ cdef int _bellman_ford_undirected(
     cdef:
         unsigned int Nind = dist_matrix.shape[0]
         unsigned int N = dist_matrix.shape[1]
-        unsigned int i, j, k, j_source, ind_k, count
+        unsigned int i, j, j_source, ind_k, count
+        ITYPE_t k
         DTYPE_t d1, d2, w12
         int return_pred = (pred.size > 0)
 
@@ -1185,7 +1187,9 @@ cdef void _johnson_add_weights(
             int[:] csr_indptr,
             double[:] dist_array):
     # let w(u, v) = w(u, v) + h(u) - h(v)
-    cdef unsigned int j, k, N = dist_array.shape[0]
+    cdef:
+        unsigned int j, N = dist_array.shape[0]
+        ITYPE_t k
 
     for j in range(N):
         for k in range(csr_indptr[j], csr_indptr[j + 1]):
@@ -1200,14 +1204,15 @@ cdef int _johnson_directed(
             double[:] dist_array):
     cdef:
         unsigned int N = dist_array.shape[0]
-        unsigned int j, k, count
+        unsigned int j, j_source, count
+        ITYPE_t k
         DTYPE_t d1, d2, w12
 
     # relax all edges (N+1) - 1 times
     for count in range(N):
-        for k in range(N):
-            if dist_array[k] < 0:
-                dist_array[k] = 0
+        for j in range(N):
+            if dist_array[j] < 0:
+                dist_array[j] = 0
 
         for j in range(N):
             d1 = dist_array[j]
@@ -1236,14 +1241,15 @@ cdef int _johnson_undirected(
             double[:] dist_array):
     cdef:
         unsigned int N = dist_array.shape[0]
-        unsigned int j, k, ind_k, count
+        unsigned int j, ind_k, j_source, count
+        ITYPE_t k
         DTYPE_t d1, d2, w12
 
     # relax all edges (N+1) - 1 times
     for count in range(N):
-        for k in range(N):
-            if dist_array[k] < 0:
-                dist_array[k] = 0
+        for j in range(N):
+            if dist_array[j] < 0:
+                dist_array[j] = 0
 
         for j in range(N):
             d1 = dist_array[j]

--- a/scipy/sparse/csgraph/meson.build
+++ b/scipy/sparse/csgraph/meson.build
@@ -1,21 +1,34 @@
-pyx_files = [
+pyx_files_for_c = [
   ['_flow', '_flow.pyx'],
   ['_matching', '_matching.pyx'],
   ['_min_spanning_tree', '_min_spanning_tree.pyx'],
   ['_reordering', '_reordering.pyx'],
-  ['_shortest_path', '_shortest_path.pyx'],
   ['_tools', '_tools.pyx'],
   ['_traversal', '_traversal.pyx']
 ]
+pyx_files_for_cpp = [
+  ['_shortest_path', '_shortest_path.pyx'],
+]
 
-foreach pyx_file: pyx_files
+foreach pyx_file: pyx_files_for_c
   py3.extension_module(pyx_file[0],
     cython_gen.process(pyx_file[1]),
     c_args: cython_c_args,
     include_directories: inc_np,
     link_args: version_link_args,
     install: true,
-    subdir: 'scipy/sparse/csgraph'
+    subdir: 'scipy/sparse/csgraph',
+  )
+endforeach
+
+foreach pyx_file: pyx_files_for_cpp
+  py3.extension_module(pyx_file[0],
+    cython_gen_cpp.process(pyx_file[1]),
+    cpp_args: cython_cpp_args,
+    include_directories: inc_np,
+    dependencies: py3_dep,
+    install: true,
+    subdir: 'scipy/sparse/csgraph',
   )
 endforeach
 

--- a/scipy/sparse/csgraph/setup.py
+++ b/scipy/sparse/csgraph/setup.py
@@ -8,7 +8,7 @@ def configuration(parent_package='', top_path=None):
     config.add_data_dir('tests')
 
     config.add_extension('_shortest_path',
-         sources=['_shortest_path.c'],
+         sources=['_shortest_path.cxx'],
          include_dirs=[numpy.get_include()])
 
     config.add_extension('_traversal',

--- a/scipy/sparse/csgraph/setup.py
+++ b/scipy/sparse/csgraph/setup.py
@@ -1,4 +1,11 @@
 
+def pre_build_hook(build_ext, ext):
+    from scipy._build_utils.compiler_helper import get_cxx_std_flag
+    std_flag = get_cxx_std_flag(build_ext._cxx_compiler)
+    if std_flag is not None:
+        ext.extra_compile_args.append(std_flag)
+
+
 def configuration(parent_package='', top_path=None):
     import numpy
     from numpy.distutils.misc_util import Configuration
@@ -7,9 +14,11 @@ def configuration(parent_package='', top_path=None):
 
     config.add_data_dir('tests')
 
-    config.add_extension('_shortest_path',
+    ext = config.add_extension('_shortest_path',
                          sources=['_shortest_path.cxx'],
-                         include_dirs=[numpy.get_include()])
+                         include_dirs=[numpy.get_include()],
+                         language='c++')
+    ext._pre_build_hook = pre_build_hook
 
     config.add_extension('_traversal',
                          sources=['_traversal.c'],

--- a/scipy/sparse/csgraph/setup.py
+++ b/scipy/sparse/csgraph/setup.py
@@ -8,31 +8,31 @@ def configuration(parent_package='', top_path=None):
     config.add_data_dir('tests')
 
     config.add_extension('_shortest_path',
-         sources=['_shortest_path.cxx'],
-         include_dirs=[numpy.get_include()])
+                         sources=['_shortest_path.cxx'],
+                         include_dirs=[numpy.get_include()])
 
     config.add_extension('_traversal',
-         sources=['_traversal.c'],
-         include_dirs=[numpy.get_include()])
+                         sources=['_traversal.c'],
+                         include_dirs=[numpy.get_include()])
 
     config.add_extension('_min_spanning_tree',
-         sources=['_min_spanning_tree.c'],
-         include_dirs=[numpy.get_include()])
+                         sources=['_min_spanning_tree.c'],
+                         include_dirs=[numpy.get_include()])
 
     config.add_extension('_matching',
-         sources=['_matching.c'],
-         include_dirs=[numpy.get_include()])
+                         sources=['_matching.c'],
+                         include_dirs=[numpy.get_include()])
     
     config.add_extension('_flow',
-         sources=['_flow.c'],
-         include_dirs=[numpy.get_include()])
+                         sources=['_flow.c'],
+                         include_dirs=[numpy.get_include()])
     
     config.add_extension('_reordering',
-         sources=['_reordering.c'],
-         include_dirs=[numpy.get_include()])
+                         sources=['_reordering.c'],
+                         include_dirs=[numpy.get_include()])
 
     config.add_extension('_tools',
-         sources=['_tools.c'],
-         include_dirs=[numpy.get_include()])
+                         sources=['_tools.c'],
+                         include_dirs=[numpy.get_include()])
 
     return config

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -14,6 +14,7 @@ directed_G = np.array([[0, 3, 3, 0, 0],
                        [1, 0, 0, 0, 0],
                        [2, 0, 0, 2, 0]], dtype=float)
 
+# Undirected version of directed_G
 undirected_G = np.array([[0, 3, 3, 1, 2],
                          [3, 0, 0, 2, 4],
                          [3, 0, 0, 0, 0],
@@ -22,12 +23,42 @@ undirected_G = np.array([[0, 3, 3, 1, 2],
 
 unweighted_G = (directed_G > 0).astype(float)
 
+# Correct shortest path lengths for directed_G and undirected_G
 directed_SP = [[0, 3, 3, 5, 7],
                [3, 0, 6, 2, 4],
                [np.inf, np.inf, 0, np.inf, np.inf],
                [1, 4, 4, 0, 8],
                [2, 5, 5, 2, 0]]
 
+undirected_SP = np.array([[0, 3, 3, 1, 2],
+                          [3, 0, 6, 2, 4],
+                          [3, 6, 0, 4, 5],
+                          [1, 2, 4, 0, 2],
+                          [2, 4, 5, 2, 0]], dtype=float)
+
+undirected_SP_limit_2 = np.array([[0, np.inf, np.inf, 1, 2],
+                                  [np.inf, 0, np.inf, 2, np.inf],
+                                  [np.inf, np.inf, 0, np.inf, np.inf],
+                                  [1, 2, np.inf, 0, 2],
+                                  [2, np.inf, np.inf, 2, 0]], dtype=float)
+
+undirected_SP_limit_0 = np.ones((5, 5), dtype=float) - np.eye(5)
+undirected_SP_limit_0[undirected_SP_limit_0 > 0] = np.inf
+
+# Correct predecessors for directed_G and undirected_G
+directed_pred = np.array([[-9999, 0, 0, 1, 1],
+                          [3, -9999, 0, 1, 1],
+                          [-9999, -9999, -9999, -9999, -9999],
+                          [3, 0, 0, -9999, 1],
+                          [4, 0, 0, 4, -9999]], dtype=float)
+
+undirected_pred = np.array([[-9999, 0, 0, 0, 0],
+                            [1, -9999, 0, 1, 1],
+                            [2, 0, -9999, 0, 0],
+                            [3, 3, 0, -9999, 3],
+                            [4, 4, 0, 4, -9999]], dtype=float)
+
+# Other graphs
 directed_sparse_zero_G = scipy.sparse.csr_matrix(([0, 1, 2, 3, 1], 
                                             ([0, 1, 2, 3, 4], 
                                              [1, 2, 0, 4, 3])), 
@@ -49,33 +80,6 @@ undirected_sparse_zero_SP = [[0, 0, 1, np.inf, np.inf],
                         [1, 1, 0, np.inf, np.inf],
                         [np.inf, np.inf, np.inf, 0, 1],
                         [np.inf, np.inf, np.inf, 1, 0]]
-
-directed_pred = np.array([[-9999, 0, 0, 1, 1],
-                          [3, -9999, 0, 1, 1],
-                          [-9999, -9999, -9999, -9999, -9999],
-                          [3, 0, 0, -9999, 1],
-                          [4, 0, 0, 4, -9999]], dtype=float)
-
-undirected_SP = np.array([[0, 3, 3, 1, 2],
-                          [3, 0, 6, 2, 4],
-                          [3, 6, 0, 4, 5],
-                          [1, 2, 4, 0, 2],
-                          [2, 4, 5, 2, 0]], dtype=float)
-
-undirected_SP_limit_2 = np.array([[0, np.inf, np.inf, 1, 2],
-                                  [np.inf, 0, np.inf, 2, np.inf],
-                                  [np.inf, np.inf, 0, np.inf, np.inf],
-                                  [1, 2, np.inf, 0, 2],
-                                  [2, np.inf, np.inf, 2, 0]], dtype=float)
-
-undirected_SP_limit_0 = np.ones((5, 5), dtype=float) - np.eye(5)
-undirected_SP_limit_0[undirected_SP_limit_0 > 0] = np.inf
-
-undirected_pred = np.array([[-9999, 0, 0, 0, 0],
-                            [1, -9999, 0, 1, 1],
-                            [2, 0, -9999, 0, 0],
-                            [3, 3, 0, -9999, 3],
-                            [4, 4, 0, 4, -9999]], dtype=float)
 
 methods = ['auto', 'FW', 'D', 'BF', 'J']
 

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -191,7 +191,7 @@ def test_dijkstra_min_only_random(n):
     np.random.shuffle(v)
     indices = v[:int(n*.1)]
     ds, pred, sources = dijkstra(data,
-                                 directed=False,
+                                 directed=True,
                                  indices=indices,
                                  min_only=True,
                                  return_predecessors=True)
@@ -204,6 +204,8 @@ def test_dijkstra_min_only_random(n):
 
 # n : number of vertices
 # t : number of test cases
+# Generate random graphs, run shortest_path for all methods, verify the results
+# and check consistency across different methods.
 @pytest.mark.parametrize('n, t',
                          ((3, 200),
                           (10, 200),

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -202,6 +202,7 @@ def test_dijkstra_min_only_random(n):
             assert sources[p] == s
             p = pred[p]
 
+
 # n : number of vertices
 # t : number of test cases
 # Generate random graphs, run shortest_path for all methods, verify the results
@@ -223,7 +224,8 @@ def test_shortest_path_random(n, t):
         results = []
         for method in methods:
             results.append((method, *shortest_path(data, directed=True,
-                indices=start_vertex, return_predecessors=True)))
+                                                   indices=start_vertex,
+                                                   return_predecessors=True)))
 
         for method, dist, pred in results:
             # check that dist and pred are consistent

--- a/scipy/sparse/setup.py
+++ b/scipy/sparse/setup.py
@@ -3,6 +3,13 @@ import sys
 import subprocess
 
 
+def pre_build_hook(build_ext, ext):
+    from scipy._build_utils.compiler_helper import get_cxx_std_flag
+    std_flag = get_cxx_std_flag(build_ext._cxx_compiler)
+    if std_flag is not None:
+        ext.extra_compile_args.append(std_flag)
+
+
 def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
     from scipy._build_utils.compiler_helper import set_cxx_flags_hook
@@ -53,7 +60,7 @@ def configuration(parent_package='',top_path=None):
                                   os.path.join('sparsetools', 'other.cxx'),
                                   get_sparsetools_sources]
                          )
-    sparsetools._pre_build_hook = set_cxx_flags_hook
+    sparsetools._pre_build_hook = pre_build_hook
 
     return config
 


### PR DESCRIPTION
Another pull request to speed up sparse.csgraph.dijkstra, succeeding #16696
Thank you @jjerphan for reviewing the previous pull request and giving me advice

 - Replaces FibonacciHeap with std::priority_queue which makes sparse.csgraph.dijkstra faster
      - asymptotically due to the removal of a bug in FibonacciHeap implementation
      - with regard to the constant factor due to better memory usage(?)
 - Unifies the four similar dijkstra functions into one
      - Performance overhead was negligible, probably because the priority_queue is the bottleneck
 - Adds the star graph to the benchmark as the worst case for the previous version
 - Fixes a typo in the test file name 
 - A part of the test file for dijkstra is modified for better readability, nothing really changed

Benchmark(i5-10600k, ArchLinux)
```
Before:
===== ========== ============= =============
--                          format          
---------------- ---------------------------
n    min_only      random         star    
===== ========== ============= =============
30     True      178±0.1μs     125±0.9μs  
30    False      191±0.4μs     131±0.8μs  
300     True      451±0.4μs     183±0.4μs  
300    False       4.78±0ms      1.67±0ms  
900     True     2.55±0.01ms     657±2μs   
900    False      102±0.08ms   48.4±0.08ms 
===== ========== ============= =============

After:
===== ========== ============= ===========
--                         format         
---------------- -------------------------
n    min_only      random        star   
===== ========== ============= ===========
30     True      178±0.1μs     126±1μs  
30    False      192±0.6μs    134±0.8μs 
300     True      363±0.4μs    152±0.3μs 
300    False       2.46±0ms     459±1μs  
900     True     1.93±0.01ms   200±0.2μs 
900    False     48.1±0.02ms    3.78±0ms 
===== ========== ============= ===========
```

