### PR TITLE
FIX: `dev.py build` parallelism behaviour and fixed typos

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -403,17 +403,18 @@ class Build(Task):
     debug = Option(
         ['--debug', '-d'], default=False, is_flag=True, help="Debug build")
     parallel = Option(
-        ['--parallel', '-j'], default=1, metavar='N_JOBS',
-        help="Number of parallel jobs for build and testing")
+        ['--parallel', '-j'], default=None, metavar='N_JOBS',
+        help=("Number of parallel jobs for building. "
+              "This defaults to 2 * n_cpus + 2."))
     show_build_log = Option(
         ['--show-build-log'], default=False, is_flag=True,
         help="Show build output rather than using a log file")
     win_cp_openblas = Option(
         ['--win-cp-openblas'], default=False, is_flag=True,
-        help=("If set, and on Windows, copy OpenBLAS lib to install directory"
+        help=("If set, and on Windows, copy OpenBLAS lib to install directory "
               "after meson install. "
               "Note: this argument may be removed in the future once a "
-              "`site.cfg`-like mechanism to select BLAS/LAPACK libraries is"
+              "`site.cfg`-like mechanism to select BLAS/LAPACK libraries is "
               "implemented for Meson"))
 
     @classmethod
@@ -475,7 +476,7 @@ class Build(Task):
         Build a dev version of the project.
         """
         cmd = ["ninja", "-C", str(dirs.build)]
-        if args.parallel > 1:
+        if args.parallel is not None:
             cmd += ["-j", str(args.parallel)]
 
         # Building with ninja-backend


### PR DESCRIPTION
#### Reference issue
N/A

#### What does this implement/fix?
- Fixes a couple small typos (missing spaces due to multi-line string formatting)
- Forwards parallelism argument to `ninja` command when anything other than `None`.
- Sets default value for build-parallelism to `None`, in which case `ninja` uses its default parallelism behavior of setting `2 * n_cpus + 2`  tasks. Note that this was default behavior before this PR when calling `python dev.py build -j1` since the parallelism arg was only forwarded when `>1`.

#### Additional information
This fixes the awkward case where `python dev.py build -j1` fully-saturates the system despite requesting only task.

@tupui