### PR TITLE
Fix explanation of LIst of List sparse matrix

### DIFF
--- a/scipy/sparse/_lil.py
+++ b/scipy/sparse/_lil.py
@@ -17,7 +17,7 @@ from . import _csparsetools
 
 
 class lil_matrix(spmatrix, IndexMixin):
-    """Row-based list of lists (LInked List) sparse matrix
+    """Row-based LIst of Lists sparse matrix
 
     This is a structure for constructing sparse matrices incrementally.
     Note that inserting a single item can take linear time in the worst case;


### PR DESCRIPTION
Thanks to CJ Carey for catching the mistake.

Sparse was introduced to SciPy in this commit:

https://github.com/scipy/scipy-svn/commit/b3827deddd0c1a25986c802b91a4f7d359830ebc

A later update included a list of formats:

https://github.com/scipy/scipy-svn/commit/39730dc5482dad6f92dc8751e2048c0f27b64580

In both these patches the phrase "linked list matrix" is used, but I believe erroneously. The LIst of List format uses the following representation:

```
In [1]: import scipy.sparse

In [2]: X = scipy.sparse.lil_matrix([[0,0,0,0],[0,1,0,0],[0,0,
   ...: 0,0]])

In [3]: X.data
Out[3]: array([list([]), list([1]), list([])], dtype=object)
```

The intent is to have direct access to any row. This can be achieved with a list of lists, but not with a linked list representation.
