### PR TITLE
TST: stats.fit: fix random state

### DIFF
--- a/scipy/stats/tests/test_fit.py
+++ b/scipy/stats/tests/test_fit.py
@@ -567,9 +567,14 @@ class TestFit:
 
 class TestFitResult:
     def test_plot_iv(self):
-        data = stats.norm.rvs(0, 1, size=100)  # random state doesn't matter
+        rng = np.random.default_rng(1769658657308472721)
+        data = stats.norm.rvs(0, 1, size=100, random_state=rng)
+
+        def optimizer(*args, **kwargs):
+            return differential_evolution(*args, **kwargs, seed=rng)
+
         bounds = [(0, 30), (0, 1)]
-        res = stats.fit(stats.norm, data, bounds)
+        res = stats.fit(stats.norm, data, bounds, optimizer=optimizer)
         try:
             import matplotlib  # noqa
             message = r"`plot_type` must be one of \{'..."


### PR DESCRIPTION
#### Reference issue
closes gh-17031

#### What does this implement/fix?
The random state wasn't fixed in `scipy.stats.tests.test_fit::TestFitResult::test_plot_iv`, and a harmless overflow in `differential_evolution` (setting `scale` near zero, it looks like) was intermittently causing the test to fail. This fixes the random state of the test to one for which the overflow does not occur.