### PR TITLE
TST: stats.jarque_bera: fix test failure due to NumPy update

### DIFF
--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -301,11 +301,7 @@ def _axis_nan_policy_test(hypotest, args, kwds, n_samples, n_outputs, paired,
                                     "approximation.")
             res = unpacker(hypotest(*data, axis=axis, nan_policy=nan_policy,
                                     *args, **kwds))
-
-        if hypotest.__name__ in {"gmean"}:
-            assert_allclose(res[0], statistics, rtol=2e-16)
-        else:
-            assert_equal(res[0], statistics)
+        assert_allclose(res[0], statistics, rtol=1e-15)
 
         assert_equal(res[0].dtype, statistics.dtype)
         if len(res) == 2:


### PR DESCRIPTION
#### Reference issue
gh-17033

#### What does this implement/fix?
This should fix some test failures with `jarque_bera` we're seeing in prerelease_deps_coverage, e.g. gh-17032.

<details>
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite--3-propagate-jarque_bera-args15-kwds15-1-2-False-None]
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite--3-omit-jarque_bera-args15-kwds15-1-2-False-None]
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite--3-raise-jarque_bera-args15-kwds15-1-2-False-None]
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite--2-propagate-jarque_bera-args15-kwds15-1-2-False-None]
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite--2-omit-jarque_bera-args15-kwds15-1-2-False-None]
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite--2-raise-jarque_bera-args15-kwds15-1-2-False-None]
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite--1-propagate-jarque_bera-args15-kwds15-1-2-False-None]
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite--1-omit-jarque_bera-args15-kwds15-1-2-False-None]
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite--1-raise-jarque_bera-args15-kwds15-1-2-False-None]
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite-0-propagate-jarque_bera-args15-kwds15-1-2-False-None]
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite-0-omit-jarque_bera-args15-kwds15-1-2-False-None]
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite-0-raise-jarque_bera-args15-kwds15-1-2-False-None]
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite-1-propagate-jarque_bera-args15-kwds15-1-2-False-None]
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite-1-omit-jarque_bera-args15-kwds15-1-2-False-None]
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite-1-raise-jarque_bera-args15-kwds15-1-2-False-None]
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite-2-propagate-jarque_bera-args15-kwds15-1-2-False-None]
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite-2-omit-jarque_bera-args15-kwds15-1-2-False-None]
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite-2-raise-jarque_bera-args15-kwds15-1-2-False-None]
</details>

#### Additional information
We've seen this before with `gmean`, so to avoid future problems, let's always use `allclose` instead of `equal`.