### PR TITLE
BUG: sparse: Avoid creating a view when ensuring that an array has native byte order.

### DIFF
--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -12,7 +12,8 @@ __all__ = ['upcast', 'getdtype', 'getdata', 'isscalarlike', 'isintlike',
            'isshape', 'issequence', 'isdense', 'ismatrix', 'get_sum_dtype']
 
 supported_dtypes = [np.bool_, np.byte, np.ubyte, np.short, np.ushort, np.intc,
-                    np.uintc, np.int_, np.uint, np.longlong, np.ulonglong, np.single, np.double,
+                    np.uintc, np.int_, np.uint, np.longlong, np.ulonglong,
+                    np.single, np.double,
                     np.longdouble, np.csingle, np.cdouble, np.clongdouble]
 
 _upcast_memo = {}
@@ -90,7 +91,19 @@ def downcast_intp_index(arr):
 
 
 def to_native(A):
-    return np.asarray(A, dtype=A.dtype.newbyteorder('native'))
+    """
+    Ensure that the data type of the NumPy array `A` has native byte order.
+
+    `A` must be a NumPy array.  If the data type of `A` does not have native
+    byte order, a copy of `A` with a native byte order is returned. Otherwise
+    `A` is returned.
+    """
+    dt = A.dtype
+    if dt.isnative:
+        # Don't call `asarray()` if A is already native, to avoid unnecessarily
+        # creating a view of the input array.
+        return A
+    return np.asarray(A, dtype=dt.newbyteorder('native'))
 
 
 def getdtype(dtype, a=None, default=None):


### PR DESCRIPTION
In NumPy 1.24+, the call

    np.asarray(A, dtype=A.dtype.newbyteorder('native'))

will *always* create a new view of A, even if
A.dtype == A.dtype.newbyteorder('native').
Avoid this by only making the call if A.dtype is
not already native order.

Closes gh-17033.
