### PR TITLE
ENH: stats.qmc.Hammersley: add Hammersley QMCEngine

### DIFF
--- a/scipy/stats/qmc.py
+++ b/scipy/stats/qmc.py
@@ -22,6 +22,7 @@ Engines
    QMCEngine
    Sobol
    Halton
+   Hammersley
    LatinHypercube
    PoissonDisk
    MultinomialQMC

--- a/scipy/stats/tests/test_qmc.py
+++ b/scipy/stats/tests/test_qmc.py
@@ -650,8 +650,8 @@ class TestHammersley(QMCEngineTests):
         if scramble:
             pytest.skip("Not applicable: the value of reference sample is"
                         " implementation dependent.")
-        col1 = qmc.Halton(d=1, scramble=False).random(10)
-        col2 = np.linspace(0.1, 1, 10)[:, np.newaxis]
+        col1 = np.linspace(0, 0.9, 10)[:, np.newaxis]
+        col2 = qmc.Halton(d=1, scramble=False).random(10)
         return np.concatenate((col1, col2), axis=1)
 
     def test_optimizers(self):

--- a/scipy/stats/tests/test_qmc.py
+++ b/scipy/stats/tests/test_qmc.py
@@ -636,6 +636,30 @@ class TestHalton(QMCEngineTests):
         assert_equal(sample, ref_sample)
 
 
+class TestHammersley(QMCEngineTests):
+    qmce = qmc.Hammersley
+    can_scramble = True
+
+    def test_continuing(self, *args):
+        pytest.skip("Not applicable: not a sequence.")
+
+    def test_fast_forward(self, *args):
+        pytest.skip("Not applicable: not a sequence.")
+
+    def reference(self, scramble: bool) -> np.ndarray:
+        if scramble:
+            pytest.skip("Not applicable: the value of reference sample is"
+                        " implementation dependent.")
+        col1 = qmc.Halton(d=1, scramble=False).random(10)
+        col2 = np.linspace(0.1, 1, 10)[:, np.newaxis]
+        return np.concatenate((col1, col2), axis=1)
+
+    def test_optimizers(self):
+        # Lloyd isn't guaranteed to improve discrepancy. It doesn't in the
+        # existing test.
+        return super().test_optimizers("random-CD", qmc.discrepancy)
+
+
 class TestLHS(QMCEngineTests):
     qmce = qmc.LatinHypercube
     can_scramble = False


### PR DESCRIPTION
#### Reference issue
gh-14510

#### What does this implement/fix?
Adds Hammersley as another QMCEngine, as suggested in gh-14510.

```python3
qrng = stats.qmc.Hammersley(2, scramble=False)
print(qrng.random(10))

# [[0.     0.    ]
#  [0.1    0.5   ]
#  [0.2    0.25  ]
#  [0.3    0.75  ]
#  [0.4    0.125 ]
#  [0.5    0.625 ]
#  [0.6    0.375 ]
#  [0.7    0.875 ]
#  [0.8    0.0625]
#  [0.9    0.5625]]

qrng = stats.qmc.Hammersley(2, scramble=True)
print(qrng.random(10))

[[0.08111914 0.25730402]
#  [0.19591757 0.75730402]
#  [0.21223727 0.00730402]
#  [0.31683404 0.50730402]
#  [0.44729893 0.38230402]
#  [0.58623788 0.88230402]
#  [0.65291462 0.13230402]
#  [0.79968586 0.63230402]
#  [0.89184771 0.31980402]
#  [0.93587213 0.81980402]]
```

#### Additional information
- ~~should the linear sweep be in the first or last column?~~ first
- should the sweep be permuted? If that's ok, we could use `LatinHypercube` in the implementation.
- ~~I think in some references the sweep starts with 0 instead of 1/n. That would be preferable to keep it on [0, 1). Shall we do that?~~ yes
- We should make a method `_reset` so that `QMCEngines` don't have to override `reset` and redefine the documentation if they want to change something simple about the behavior.
- `QMCEngine` input validation should produce an error with `d < 0`.
- Why don't we think of `LatinHypercub` with `centered=False` as a "scrambled" LHS? Isn't `centered=False` basically the same as `scramble=True`? (If so, it would be good to replace the parameter for interface consistency.)
