### PR TITLE
MAINT: fix small LSMR problem

### DIFF
--- a/scipy/sparse/linalg/_isolve/lsmr.py
+++ b/scipy/sparse/linalg/_isolve/lsmr.py
@@ -302,7 +302,7 @@ def lsmr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
         return x, istop, itn, normr, normar, normA, condA, normx
 
     if normb == 0:
-        x = b
+        x[()] = 0
         return x, istop, itn, normr, normar, normA, condA, normx
 
     if show:

--- a/scipy/sparse/linalg/tests/test_pydata_sparse.py
+++ b/scipy/sparse/linalg/tests/test_pydata_sparse.py
@@ -4,7 +4,7 @@ import numpy as np
 import scipy.sparse as sp
 import scipy.sparse.linalg as splin
 
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_equal
 
 try:
     import sparse
@@ -75,11 +75,10 @@ def test_lsmr(matrices):
     assert_allclose(res[0], res0[0], atol=1.8e-5)
 
 
-def test_lsqr(matrices):
-    A_dense, A_sparse, b = matrices
-    res0 = splin.lsqr(A_dense, b)
-    res = splin.lsqr(A_sparse, b)
-    assert_allclose(res[0], res0[0], atol=1e-5)
+# test issue 17012
+def test_lsmr_output_shape():
+    x = splin.lsmr(A=np.ones((10,1)), b=np.zeros(10), x0=np.ones(1))[0]
+    assert_equal(x.shape, x0.shape)
 
 
 def test_eigs(matrices):

--- a/scipy/sparse/linalg/tests/test_pydata_sparse.py
+++ b/scipy/sparse/linalg/tests/test_pydata_sparse.py
@@ -77,7 +77,7 @@ def test_lsmr(matrices):
 
 # test issue 17012
 def test_lsmr_output_shape():
-    x = splin.lsmr(A=np.ones((10,1)), b=np.zeros(10), x0=np.ones(1))[0]
+    x = splin.lsmr(A=np.ones((10, 1)), b=np.zeros(10), x0=np.ones(1))[0]
     assert_equal(x.shape, (1,))
 
 

--- a/scipy/sparse/linalg/tests/test_pydata_sparse.py
+++ b/scipy/sparse/linalg/tests/test_pydata_sparse.py
@@ -81,6 +81,13 @@ def test_lsmr_output_shape():
     assert_equal(x.shape, (1,))
 
 
+def test_lsqr(matrices):
+    A_dense, A_sparse, b = matrices
+    res0 = splin.lsqr(A_dense, b)
+    res = splin.lsqr(A_sparse, b)
+    assert_allclose(res[0], res0[0], atol=1e-5)
+
+
 def test_eigs(matrices):
     A_dense, A_sparse, v0 = matrices
 

--- a/scipy/sparse/linalg/tests/test_pydata_sparse.py
+++ b/scipy/sparse/linalg/tests/test_pydata_sparse.py
@@ -78,7 +78,7 @@ def test_lsmr(matrices):
 # test issue 17012
 def test_lsmr_output_shape():
     x = splin.lsmr(A=np.ones((10,1)), b=np.zeros(10), x0=np.ones(1))[0]
-    assert_equal(x.shape, x0.shape)
+    assert_equal(x.shape, (1,))
 
 
 def test_eigs(matrices):


### PR DESCRIPTION

#### Reference issue
Fixes #17012 

#### What does this implement/fix?
Fills solution vector with zeros, instead of pointing it to the RHS
