### PR TITLE
CI: Update cibuildwheel to 2.10.1

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -134,7 +134,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.9.0
+        uses: pypa/cibuildwheel@v2.10.1
         # Build all wheels here, but the macosx_arm64 job in its own entry.
         # cibuildwheel is currently unable to pass configuration flags to
         # CIBW_BUILD_FRONTEND https://github.com/pypa/cibuildwheel/issues/1227


### PR DESCRIPTION
Update the cibuildwheel version used in the wheels.yml configuration from 2.9.0 to 2.10.1.

This is mainly usefull for the updated CPython 3.11 version (from 3.11.0rc1 to v3.11.0rc2).

It might help with #16851.

Might be a backport candidate for the 1.9 branch, if we want to release Python 3.11 wheels.