### PR TITLE
TST: stats.jarque_bera: fix test failure due to NumPy update

### DIFF
--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -302,10 +302,10 @@ def _axis_nan_policy_test(hypotest, args, kwds, n_samples, n_outputs, paired,
             res = unpacker(hypotest(*data, axis=axis, nan_policy=nan_policy,
                                     *args, **kwds))
         assert_allclose(res[0], statistics, rtol=1e-15)
-
         assert_equal(res[0].dtype, statistics.dtype)
+
         if len(res) == 2:
-            assert_equal(res[1], pvalues)
+            assert_allclose(res[1], pvalues, rtol=1e-15)
             assert_equal(res[1].dtype, pvalues.dtype)
 
 


### PR DESCRIPTION
#### Reference issue
gh-17033
gh-17034

#### What does this implement/fix?
This should fix some test failures with `jarque_bera` we're still seeing in prerelease_deps_coverage, e.g. gh-17034.

<details>
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite--1-raise-jarque_bera-args15-kwds15-1-2-False-None]
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite-0-propagate-jarque_bera-args15-kwds15-1-2-False-None]
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite-0-omit-jarque_bera-args15-kwds15-1-2-False-None]
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite-0-raise-jarque_bera-args15-kwds15-1-2-False-None]
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite-1-propagate-jarque_bera-args15-kwds15-1-2-False-None]
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite-1-omit-jarque_bera-args15-kwds15-1-2-False-None]
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite-1-raise-jarque_bera-args15-kwds15-1-2-False-None]
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite-2-propagate-jarque_bera-args15-kwds15-1-2-False-None]
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite-2-omit-jarque_bera-args15-kwds15-1-2-False-None]
FAILED scipy/stats/tests/test_axis_nan_policy.py::test_axis_nan_policy_full[all_finite-2-raise-jarque_bera-args15-kwds15-1-2-False-None]
</details>
