### PR TITLE
MAINT/TST: _lib._finite_difference._derivative: prevent unnecessary function calls, add test coverage and fix incorrectly named arguments

### DIFF
--- a/scipy/_lib/_finite_differences.py
+++ b/scipy/_lib/_finite_differences.py
@@ -66,7 +66,7 @@ def _central_diff_weights(Np, ndiv=1):
     return w
 
 
-def _derivative(func, x0, dx=1.0, n=1, args=(), order=3):
+def _derivative(func, x0, *, dx=1.0, order=1, args=(), n=3):
     """
     Find the nth derivative of a function at a point.
 
@@ -81,11 +81,11 @@ def _derivative(func, x0, dx=1.0, n=1, args=(), order=3):
         The point at which the nth derivative is found.
     dx : float, optional
         Spacing.
-    n : int, optional
+    order : int, optional
         Order of the derivative. Default is 1.
     args : tuple, optional
         Arguments to be past to func.
-    order : int, optional
+    n : int, optional
         Number of points to use, must be odd.
 
     Notes
@@ -100,46 +100,46 @@ def _derivative(func, x0, dx=1.0, n=1, args=(), order=3):
     4.9999999999217337
 
     """
-    if order < n + 1:
+    if n < order + 1:
         raise ValueError(
-            "'order' (the number of points used to compute the derivative), "
-            "must be at least the derivative order 'n' + 1."
+            "'n' (the number of points used to compute the derivative), "
+            "must be at least the derivative order + 1."
         )
-    if order % 2 == 0:
+    if n % 2 == 0:
         raise ValueError(
-            "'order' (the number of points used to compute the derivative) "
+            "'n' (the number of points used to compute the derivative) "
             "must be odd."
         )
     # pre-computed for n=1 and 2 and low-order for speed.
-    if n == 1:
-        if order == 3:
+    if order == 1:
+        if n == 3:
             weights = array([-1, 0, 1]) / 2.0
-        elif order == 5:
+        elif n == 5:
             weights = array([1, -8, 0, 8, -1]) / 12.0
-        elif order == 7:
+        elif n == 7:
             weights = array([-1, 9, -45, 0, 45, -9, 1]) / 60.0
-        elif order == 9:
+        elif n == 9:
             weights = array([3, -32, 168, -672, 0, 672, -168, 32, -3]) / 840.0
         else:
-            weights = _central_diff_weights(order, 1)
-    elif n == 2:
-        if order == 3:
+            weights = _central_diff_weights(n, 1)
+    elif order == 2:
+        if n == 3:
             weights = array([1, -2.0, 1])
-        elif order == 5:
+        elif n == 5:
             weights = array([-1, 16, -30, 16, -1]) / 12.0
-        elif order == 7:
+        elif n == 7:
             weights = array([2, -27, 270, -490, 270, -27, 2]) / 180.0
-        elif order == 9:
+        elif n == 9:
             weights = (
                 array([-9, 128, -1008, 8064, -14350, 8064, -1008, 128, -9])
                 / 5040.0
             )
         else:
-            weights = _central_diff_weights(order, 2)
+            weights = _central_diff_weights(n, 2)
     else:
-        weights = _central_diff_weights(order, n)
+        weights = _central_diff_weights(n, order)
     val = 0.0
-    ho = order >> 1
-    for k in range(order):
+    ho = n >> 1
+    for k in range(n):
         val += weights[k] * func(x0 + (k - ho) * dx, *args)
-    return val / prod((dx,) * n, axis=0)
+    return val / prod((dx,) * order, axis=0)

--- a/scipy/_lib/_finite_differences.py
+++ b/scipy/_lib/_finite_differences.py
@@ -84,7 +84,7 @@ def _derivative(func, x0, dx=1.0, n=1, args=(), order=3):
     n : int, optional
         Order of the derivative. Default is 1.
     args : tuple, optional
-        Arguments
+        Arguments to be past to func.
     order : int, optional
         Number of points to use, must be odd.
 

--- a/scipy/_lib/tests/meson.build
+++ b/scipy/_lib/tests/meson.build
@@ -12,6 +12,7 @@ python_sources = [
   'test_public_api.py',
   'test_tmpdirs.py',
   'test_warnings.py',
+  'test__finite_differences.py'
 ]
 
 py3.install_sources(

--- a/scipy/_lib/tests/test__finite_differences.py
+++ b/scipy/_lib/tests/test__finite_differences.py
@@ -1,0 +1,12 @@
+from pytest import raises
+
+from scipy._lib._finite_differences import _derivative
+
+class TestDerivative:
+    def test_not_enough_points(self):
+        with raises(ValueError, match="derivative order \\+ 1."):
+            _derivative(lambda x: x, 0, order=5, n=3)
+    
+    def test_odd_n(self):
+        with raises(ValueError, match="must be odd."):
+            _derivative(lambda x: x,0, n=2)

--- a/scipy/_lib/tests/test__finite_differences.py
+++ b/scipy/_lib/tests/test__finite_differences.py
@@ -6,15 +6,16 @@ from numpy.testing import assert_almost_equal
 
 from scipy._lib._finite_differences import _derivative
 
+
 class TestDerivative:
     def test_not_enough_points(self):
         with raises(ValueError, match="derivative order \\+ 1."):
             _derivative(lambda x: x, 0, order=5, n=3)
-    
+
     def test_odd_n(self):
         with raises(ValueError, match="must be odd."):
-            _derivative(lambda x: x,0, n=2)
-    
+            _derivative(lambda x: x, 0, n=2)
+
     @pytest.mark.parametrize(
         ["order", "n", "expected"],
         [(1, 3, 0.9800665778256222),
@@ -30,4 +31,5 @@ class TestDerivative:
          (3, 5, -0.9992007221626407)]
     )
     def test_computation(self, order, n, expected):
-        assert_almost_equal(_derivative(sin, 0.2, dx=1e-5, order=order, n=n), expected)
+        assert_almost_equal(_derivative(sin, 0.2, dx=1e-5, order=order, n=n),
+                            expected)

--- a/scipy/_lib/tests/test__finite_differences.py
+++ b/scipy/_lib/tests/test__finite_differences.py
@@ -27,7 +27,7 @@ class TestDerivative:
          (2, 7, -0.19866908899240918),
          (2, 9, -0.19866885805734644),
          (2, 11, -0.19866834834680008),
-         (3, 5, -1.0130785099704551)]
+         (3, 5, -0.9992007221626407)]
     )
     def test_computation(self, order, n, expected):
         assert_almost_equal(_derivative(sin, 0.2, dx=1e-5, order=order, n=n), expected)

--- a/scipy/_lib/tests/test__finite_differences.py
+++ b/scipy/_lib/tests/test__finite_differences.py
@@ -1,4 +1,8 @@
+from math import sin
+
+import pytest
 from pytest import raises
+from numpy.testing import assert_almost_equal
 
 from scipy._lib._finite_differences import _derivative
 
@@ -10,3 +14,20 @@ class TestDerivative:
     def test_odd_n(self):
         with raises(ValueError, match="must be odd."):
             _derivative(lambda x: x,0, n=2)
+    
+    @pytest.mark.parametrize(
+        ["order", "n", "expected"],
+        [(1, 3, 0.9800665778256222),
+         (1, 5, 0.9800665778415817),
+         (1, 7, 0.9800665778415817),
+         (1, 9, 0.9800665778425575),
+         (1, 11, 0.9800665778419693),
+         (2, 3, -0.19866913669730477),
+         (2, 5, -0.19866948364199996),
+         (2, 7, -0.19866908899240918),
+         (2, 9, -0.19866885805734644),
+         (2, 11, -0.19866834834680008),
+         (3, 5, -1.0130785099704551)]
+    )
+    def test_computation(self, order, n, expected):
+        assert_almost_equal(_derivative(sin, 0.2, dx=1e-5, order=order, n=n), expected)

--- a/scipy/misc/_common.py
+++ b/scipy/misc/_common.py
@@ -123,7 +123,9 @@ def derivative(func, x0, dx=1.0, n=1, args=(), order=3):
     4.9999999999217337
 
     """
-    return _derivative(func, x0, dx, n, args, order)
+    # n and order are switched here as the internal version does not need to
+    # maintain backwards compatibility
+    return _derivative(func, x0, dx=dx, order=n, args=args, n=order)
 
 
 @_deprecated(msg="scipy.misc.ascent has been deprecated in SciPy v1.10.0;"

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -2015,7 +2015,7 @@ class rv_continuous(rv_generic):
         return integrate.quad(self._mom_integ1, 0, 1, args=(m,)+args)[0]
 
     def _pdf(self, x, *args):
-        return _derivative(self._cdf, x, dx=1e-5, args=args, order=5)
+        return _derivative(self._cdf, x, dx=1e-5, args=args, n=5)
 
     # Could also define any of these
     def _logpdf(self, x, *args):

--- a/scipy/stats/_ksstats.py
+++ b/scipy/stats/_ksstats.py
@@ -469,7 +469,7 @@ def _kolmogn_p(n, x):
     def _kk(_x):
         return kolmogn(n, _x)
 
-    return _derivative(_kk, x, dx=delta, order=5)
+    return _derivative(_kk, x, dx=delta, n=5)
 
 
 def _kolmogni(n, p, q):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
closes #10012
#### What does this implement/fix?
<!--Please explain your changes.-->
This pr makes a number of improvements to the derivative:

1. Prevents unnecessary functions calls by removing zero weights (as reported in #10012). This also improves numerical accuracy they are not stored as exactly zero but previously still used in the computation.
2. Adds test coverage
3. Previously `n` represented the order of the derivative and `order` represented the number of points in the stencil. Confusing right! Unfortunately this can be fixed in the public facing `misc` version as it would be a breaking change but we can at least fix this in the internal version

There are a number of changes here so happy break up into different pr's all the changes are not wanted.    

#### Additional information
<!--Any additional information you think is important.-->
