### PR TITLE
BUG: Fix numerical precision error of `truncnorm.logcdf` when cdf is nearly 1

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -8565,8 +8565,6 @@ def _log_sum(log_p, log_q):
 
 # same as above, but using -exp(x) = exp(x + πi)
 def _log_diff(log_p, log_q):
-    # need to broadcast in case a or b is 0.5; logsumexp doesn't
-    log_p, log_q = np.broadcast_arrays(log_p, log_q)
     return sc.logsumexp([log_p, log_q+np.pi*1j], axis=0)
 
 
@@ -8577,8 +8575,8 @@ def _log_gauss_mass(a, b):
 
     # Calculations in right tail are inaccurate, so we'll exploit the
     # symmetry and work only in the left tail
-    case_left = b <= 0.5
-    case_right = a > 0.5
+    case_left = b <= 0
+    case_right = a > 0
     case_central = ~(case_left | case_right)
 
     def mass_case_left(a, b):
@@ -8588,6 +8586,16 @@ def _log_gauss_mass(a, b):
         return mass_case_left(-b, -a)
 
     def mass_case_central(a, b):
+        # Previously, this was implemented as:
+        # left_mass = mass_case_left(a, 0)
+        # right_mass = mass_case_right(0, b)
+        # return _log_sum(left_mass, right_mass)
+        # Catastrophic cancellation occurs as np.exp(log_mass) approaches 1.
+        # Correct for this with an alternative formulation.
+        # We're not concerned with underflow here: if only one term
+        # underflows, it was insignificant; if both terms underflow,
+        # the result can't accurately be represented in logspace anyway
+        # because sc.log1p(x) ~ x for small x.
         return sc.log1p(-sc.ndtr(a) - sc.ndtr(-b))
 
     # _lazyselect not working; don't care to debug it
@@ -8646,13 +8654,23 @@ class truncnorm_gen(rv_continuous):
         return np.exp(self._logcdf(x, a, b))
 
     def _logcdf(self, x, a, b):
-        return _log_gauss_mass(a, x) - _log_gauss_mass(a, b)
+        x, a, b = np.broadcast_arrays(x, a, b)
+        logcdf = _log_gauss_mass(a, x) - _log_gauss_mass(a, b)
+        i = logcdf > -0.1  # avoid catastrophic cancellation
+        if np.any(i):
+            logcdf[i] = np.log1p(-np.exp(self._logsf(x[i], a[i], b[i])))
+        return logcdf
 
     def _sf(self, x, a, b):
         return np.exp(self._logsf(x, a, b))
 
     def _logsf(self, x, a, b):
-        return _log_gauss_mass(x, b) - _log_gauss_mass(a, b)
+        x, a, b = np.broadcast_arrays(x, a, b)
+        logsf = _log_gauss_mass(x, b) - _log_gauss_mass(a, b)
+        i = logsf > -0.1  # avoid catastrophic cancellation
+        if np.any(i):
+            logsf[i] = np.log1p(-np.exp(self._logcdf(x[i], a[i], b[i])))
+        return logsf
 
     def _ppf(self, q, a, b):
         q, a, b = np.broadcast_arrays(q, a, b)

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -8588,9 +8588,7 @@ def _log_gauss_mass(a, b):
         return mass_case_left(-b, -a)
 
     def mass_case_central(a, b):
-        left_mass = mass_case_left(a, 0.5)
-        right_mass = mass_case_right(0.5, b)
-        return _log_sum(left_mass, right_mass)
+        return sc.log1p(-sc.ndtr(a) - sc.ndtr(-b))
 
     # _lazyselect not working; don't care to debug it
     out = np.full_like(a, fill_value=np.nan, dtype=np.complex128)

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -401,18 +401,18 @@ def test_nomodify_gh9900_regression():
     # Use the right-half truncated normal
     # Check that the cdf and _cdf return the same result.
     npt.assert_almost_equal(tn.cdf(1, 0, np.inf), 0.6826894921370859)
-    npt.assert_almost_equal(tn._cdf(1, 0, np.inf), 0.6826894921370859)
+    npt.assert_almost_equal(tn._cdf([1], [0], [np.inf]), 0.6826894921370859)
 
     # Now use the left-half truncated normal
     npt.assert_almost_equal(tn.cdf(-1, -np.inf, 0), 0.31731050786291415)
-    npt.assert_almost_equal(tn._cdf(-1, -np.inf, 0), 0.31731050786291415)
+    npt.assert_almost_equal(tn._cdf([-1], [-np.inf], [0]), 0.31731050786291415)
 
     # Check that the right-half truncated normal _cdf hasn't changed
-    npt.assert_almost_equal(tn._cdf(1, 0, np.inf), 0.6826894921370859)  # NOT 1.6826894921370859
+    npt.assert_almost_equal(tn._cdf([1], [0], [np.inf]), 0.6826894921370859)  # noqa, NOT 1.6826894921370859
     npt.assert_almost_equal(tn.cdf(1, 0, np.inf), 0.6826894921370859)
 
     # Check that the left-half truncated normal _cdf hasn't changed
-    npt.assert_almost_equal(tn._cdf(-1, -np.inf, 0), 0.31731050786291415)  # Not -0.6826894921370859
+    npt.assert_almost_equal(tn._cdf([-1], [-np.inf], [0]), 0.31731050786291415)  # noqa, Not -0.6826894921370859
     npt.assert_almost_equal(tn.cdf(1, -np.inf, 0), 1)                     # Not 1.6826894921370859
     npt.assert_almost_equal(tn.cdf(-1, -np.inf, 0), 0.31731050786291415)  # Not -0.6826894921370859
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1130,6 +1130,15 @@ class TestTruncnorm:
             stats.truncnorm.rvs(-10, -5, size=5,
                                 random_state=np.random.default_rng())
 
+    def test_logcdf_tail(self):
+        a = [-np.inf, -np.inf, -8]
+        b = [np.inf, np.inf, 8]
+        x = [10, 7.5, 7.5]
+        expected = [-7.619853024160525e-24,
+                    -3.190891672910947e-14,
+                    -3.128682067168231e-14]
+        assert_allclose(stats.truncnorm(a, b).logcdf(x), expected)
+
 
 class TestGenLogistic:
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1130,14 +1130,16 @@ class TestTruncnorm:
             stats.truncnorm.rvs(-10, -5, size=5,
                                 random_state=np.random.default_rng())
 
-    def test_logcdf_tail(self):
-        a = [-np.inf, -np.inf, -8]
-        b = [np.inf, np.inf, 8]
-        x = [10, 7.5, 7.5]
-        expected = [-7.619853024160525e-24,
-                    -3.190891672910947e-14,
-                    -3.128682067168231e-14]
+    def test_logcdf_gh17064(self):
+        # regression test for gh-17064 - avoid roundoff error for logcdfs ~0
+        a = np.array([-np.inf, -np.inf, -8, -np.inf, 10])
+        b = np.array([np.inf, np.inf, 8, 10, np.inf])
+        x = np.array([10, 7.5, 7.5, 9, 20])
+        expected = [-7.619853024160525e-24, -3.190891672910947e-14,
+                    -3.128682067168231e-14, -1.1285122074235991e-19,
+                    -3.61374964828753e-66]
         assert_allclose(stats.truncnorm(a, b).logcdf(x), expected)
+        assert_allclose(stats.truncnorm(-b, -a).logsf(-x), expected)
 
 
 class TestGenLogistic:


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

Resolve the large precision error of `truncnorm.logcdf` with upper tail argument. `mass_case_central` of `_log_gauss_mass` was inaccurate due to catastrophic cancellation in `logsumexp`.

#### Additional information
<!--Any additional information you think is important.-->

- Relative error using SciPy v1.9.1

![truncnorm_logcdf_rel_error_1 9 1](https://user-images.githubusercontent.com/1255726/191490249-c1259b1c-21de-4e85-be77-b0ff986febc7.png)

- Relative error using this PR

![truncnorm_logcdf_rel_error_pr](https://user-images.githubusercontent.com/1255726/191490284-2c9c85fc-ed96-45b4-8cd9-de779173c066.png)

- Reproducible code (based on #15172)

```python
import numpy as np
import scipy
from scipy.stats import truncnorm
import mpmath
import matplotlib.pyplot as plt


def truncnorm_logcdf_mp(x, a, b):
    ndtr_x = mpmath.ncdf(x)
    ndtr_a = mpmath.ncdf(a)
    ndtr_b = mpmath.ncdf(b)
    return mpmath.log((ndtr_x - ndtr_a) / (ndtr_b - ndtr_a))


mpmath.mp.dps = 100

clips = [(-float("inf"), float("inf")), (-10, 10), (-5, 5), (-1, 1)]

fig, axes = plt.subplots(2, len(clips)//2, figsize=(9, 5), constrained_layout=True)

for (a, b), axis in zip(clips, axes.ravel()):
    if (a, b) == (-float("inf"), float("inf")):
        x = np.linspace(-10, 10, 1250, endpoint=False)
    else:
        x = np.linspace(a, b, 1250, endpoint=False)
    ymp = np.array([truncnorm_logcdf_mp(t, a, b) for t in x])
    y = truncnorm.logcdf(x, a, b)
    relerr = np.abs((y - ymp) / ymp)

    axis.plot(x, relerr)
    axis.set_yscale('log')
    axis.grid()
    axis.set_title(f'logcdf(x, {a}, {b})')

fig.suptitle('Relative error of truncnorm.logcdf(x), '
             f'SciPy version {scipy.__version__}\n ')
plt.savefig(f'truncnorm_logcdf_rel_error_{scipy.__version__}.png')
```