### PR TITLE
BUG: fix `signal.sosfilt` issue with complex dtypes and Intel compiler

### DIFF
--- a/scipy/signal/_sosfilt.pyx
+++ b/scipy/signal/_sosfilt.pyx
@@ -36,6 +36,7 @@ cdef void _sosfilt_float(DTYPE_floating_t [:, ::1] sos,
     cdef Py_ssize_t i, n, s
     cdef DTYPE_floating_t x_new, x_cur
     cdef DTYPE_floating_t[:, ::1] zi_slice
+    cdef DTYPE_floating_t const_1 = 1.0
 
     # jumping through a few memoryview hoops to reduce array lookups,
     # the original version is still in the gil version below.
@@ -43,7 +44,7 @@ cdef void _sosfilt_float(DTYPE_floating_t [:, ::1] sos,
         zi_slice = zi[i, :, :]
         for n in xrange(n_samples):
 
-            x_cur = x[i, n]
+            x_cur = const_1 * x[i, n]  # make sure x_cur is a copy
 
             for s in xrange(n_sections):
                 x_new = sos[s, 0] * x_cur + zi_slice[s, 0]

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -3289,6 +3289,7 @@ class TestSOSFilt:
         # Test simple IIR
         y_r = np.array([0, 2, 4, 6, 8, 10.]).astype(dt)
         sos = cast_tf2sos(b, a)
+        assert sos.dtype.char == dt
         assert_array_almost_equal(sosfilt(cast_tf2sos(b, a), x), y_r)
 
         # Test simple FIR


### PR DESCRIPTION
This solves 12 test failures (see gh-17075) where the result for complex64 and complex128 were wildly wrong when SciPy is built with the `icc` compiler.

The code is very obscure, so it's not immediately clear whether it's a compiler bug or code that was trying to be too smart. I suspect it's the latter. For reference here is the Cython-generated C code:

Old code:
```C
      /* "scipy/signal/_sosfilt.pyx":46
 *         for n in xrange(n_samples):
 *
 *             x_cur = x[i, n]             # <<<<<<<<<<<<<<
 *
 *             for s in xrange(n_sections):
 */
      __pyx_t_8 = __pyx_v_i;
      __pyx_t_9 = __pyx_v_n;
      __pyx_v_x_cur = (*((float *) ( /* dim=1 */ ((char *) (((float *) ( /* dim=0 */ (__pyx_v_x.data + __pyx_t_8 * __pyx_v_x.strides[0]) )) + __pyx_t_9)) )));
```

New code:
```C
 *             x_cur = 1.0 * x[i, n]             # <<<<<<<<<<<<<<
 */
      __pyx_t_8 = __pyx_v_i;
      __pyx_t_9 = __pyx_v_n;
      __pyx_v_x_cur = (1.0 * (*((float *) ( /* dim=1 */ ((char *) (((float *) ( /* dim=0 */ (__pyx_v_x.data + __pyx_t_8 * __pyx_v_x.strides[0]) )) + __pyx_t_9)) ))));
```

[skip circle]