### PR TITLE
DOC: Fix broken link for environment variables NumPy doc

### DIFF
--- a/doc/source/dev/contributor/building.rst
+++ b/doc/source/dev/contributor/building.rst
@@ -183,7 +183,8 @@ SciPy has several tunable build-time options, which can be set.
 
 - Environment variables ``NPY_LAPACK_ORDER``, ``NPY_BLAS_ORDER``, ``OPENBLAS``,
   ``ATLAS``, etc., also controlling library configuration.
-  See `Numpy documentation <numpy-blasdoc>`_ for more details.
+  See :ref:`NumPy documentation <numpy:accelerated-blas-lapack-libraries>`
+  for more details.
 
 - Environment variable ``NPY_USE_BLAS_ILP64=1``: build using 64-bit
   integer size (ILP64) BLAS+LAPACK libraries.
@@ -192,5 +193,3 @@ SciPy has several tunable build-time options, which can be set.
   integer size (LP64) BLAS+LAPACK libraries to be available and
   configured. This is because only some components in SciPy make use
   of the 64-bit capabilities.
-
-.. _numpy-blasdoc: https://numpy.org/devdocs/user/building.html#accelerated-blas-lapack-libraries


### PR DESCRIPTION
#### What does this implement/fix?

Fixes a broken link on the build instructions which should point to the NumPy page on environment variables for accelerated linear algebra libraries.