### PR TITLE
MAINT: interpolate remove duplication of FITPACK interface `sproot`.

### DIFF
--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -510,10 +510,7 @@ class UnivariateSpline:
         """
         k = self._data[5]
         if k == 3:
-            z, m, ier = dfitpack.sproot(*self._eval_args[:2])
-            if not ier == 0:
-                raise ValueError("Error code returned by spalde: %s" % ier)
-            return z[:m]
+            return _fitpack_impl.sproot(self._eval_args)
         raise NotImplementedError('finding roots unsupported for '
                                   'non-cubic splines')
 

--- a/scipy/interpolate/_fitpack_impl.py
+++ b/scipy/interpolate/_fitpack_impl.py
@@ -714,7 +714,7 @@ def sproot(tck, mest=10):
     else:
         if len(t) < 8:
             raise TypeError("The number of knots %d>=8" % len(t))
-        z, m, ier = dfitpack.sproot(t, c, k, mest)
+        z, m, ier = dfitpack.sproot(t, c, mest)
         if ier == 10:
             raise TypeError("Invalid input data. "
                             "t1<=..<=t4<t5<..<tn-3<=..<=tn must hold.")

--- a/scipy/interpolate/_fitpack_impl.py
+++ b/scipy/interpolate/_fitpack_impl.py
@@ -714,15 +714,15 @@ def sproot(tck, mest=10):
     else:
         if len(t) < 8:
             raise TypeError("The number of knots %d>=8" % len(t))
-        z, ier = _fitpack._sproot(t, c, k, mest)
+        z, m, ier = dfitpack.sproot(t, c, k, mest)
         if ier == 10:
             raise TypeError("Invalid input data. "
                             "t1<=..<=t4<t5<..<tn-3<=..<=tn must hold.")
         if ier == 0:
-            return z
+            return z[:m]
         if ier == 1:
             warnings.warn(RuntimeWarning("The number of zeros exceeds mest"))
-            return z
+            return z[:m]
         raise TypeError("Unknown error")
 
 

--- a/scipy/interpolate/fitpack/sproot.f
+++ b/scipy/interpolate/fitpack/sproot.f
@@ -1,15 +1,19 @@
-      recursive subroutine sproot(t,n,c,zero,mest,m,ier)
+      recursive subroutine sproot(t,n,c,nc,k,zero,mest,m,ier)
       implicit none
 c  subroutine sproot finds the zeros of a cubic spline s(x),which is
 c  given in its normalized b-spline representation.
 c
 c  calling sequence:
-c     call sproot(t,n,c,zero,mest,m,ier)
+c     call sproot(t,n,c,nc,k,zero,mest,m,ier)
 c
 c  input parameters:
 c    t    : real array,length n, containing the knots of s(x).
 c    n    : integer, containing the number of knots.  n>=8
-c    c    : real array,length n, containing the b-spline coefficients.
+c    c    : array,length nc, containing the b-spline coefficients.
+c           the length of the array, nc >= n - k -1.
+c           further coefficients are ignored.
+c    k    : integer, giving the degree of s(x).
+c			This is not used in this function.
 c    mest : integer, specifying the dimension of array zero.
 c
 c  output parameters:
@@ -38,9 +42,9 @@ c  latest update : march 1987
 c
 c ..
 c ..scalar arguments..
-      integer n,mest,m,ier
+      integer n,nc,k,mest,m,ier
 c  ..array arguments..
-      real*8 t(n),c(n),zero(mest)
+      real*8 t(n),c(nc),zero(mest)
 c  ..local scalars..
       integer i,j,j1,l,n4
       real*8 ah,a0,a1,a2,a3,bh,b0,b1,c1,c2,c3,c4,c5,d4,d5,h1,h2,

--- a/scipy/interpolate/fitpack/sproot.f
+++ b/scipy/interpolate/fitpack/sproot.f
@@ -1,10 +1,10 @@
-      recursive subroutine sproot(t,n,c,nc,k,zero,mest,m,ier)
+      recursive subroutine sproot(t,n,c,nc,zero,mest,m,ier)
       implicit none
 c  subroutine sproot finds the zeros of a cubic spline s(x),which is
 c  given in its normalized b-spline representation.
 c
 c  calling sequence:
-c     call sproot(t,n,c,nc,k,zero,mest,m,ier)
+c     call sproot(t,n,c,nc,zero,mest,m,ier)
 c
 c  input parameters:
 c    t    : real array,length n, containing the knots of s(x).
@@ -12,8 +12,6 @@ c    n    : integer, containing the number of knots.  n>=8
 c    c    : array,length nc, containing the b-spline coefficients.
 c           the length of the array, nc >= n - k -1.
 c           further coefficients are ignored.
-c    k    : integer, giving the degree of s(x).
-c			This is not used in this function.
 c    mest : integer, specifying the dimension of array zero.
 c
 c  output parameters:
@@ -42,7 +40,7 @@ c  latest update : march 1987
 c
 c ..
 c ..scalar arguments..
-      integer n,nc,k,mest,m,ier
+      integer n,nc,mest,m,ier
 c  ..array arguments..
       real*8 t(n),c(nc),zero(mest)
 c  ..local scalars..

--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -63,7 +63,6 @@ static PyObject *fitpack_error;
 /*  module_methods:
  * {"_curfit", fitpack_curfit, METH_VARARGS, doc_curfit},
  * {"_spl_", fitpack_spl_, METH_VARARGS, doc_spl_},
- * {"_sproot", fitpack_sproot, METH_VARARGS, doc_sproot},
  * {"_spalde", fitpack_spalde, METH_VARARGS, doc_spalde},
  * {"_parcur", fitpack_parcur, METH_VARARGS, doc_parcur},
  * {"_surfit", fitpack_surfit, METH_VARARGS, doc_surfit},
@@ -88,7 +87,6 @@ static PyObject *fitpack_error;
 		#define SPLDER SPLDER_
 		#define SPLEV  SPLEV_
 		#define SPLINT SPLINT_
-		#define SPROOT SPROOT_
 		#define PARCUR PARCUR_
 		#define CLOCUR CLOCUR_
 		#define SURFIT SURFIT_
@@ -104,7 +102,6 @@ static PyObject *fitpack_error;
 		#define SPLDER splder
 		#define SPLEV splev
 		#define SPLINT splint
-		#define SPROOT sproot
 		#define PARCUR parcur
 		#define CLOCUR clocur
 		#define SURFIT surfit
@@ -118,7 +115,6 @@ static PyObject *fitpack_error;
 		#define SPLDER splder_
 		#define SPLEV splev_
 		#define SPLINT splint_
-		#define SPROOT sproot_
 		#define PARCUR parcur_
 		#define CLOCUR clocur_
 		#define SURFIT surfit_
@@ -139,7 +135,6 @@ void SPLDER(double*,F_INT*,double*,F_INT*,F_INT*,double*,
         double*,F_INT*,F_INT*,double*,F_INT*);
 void SPLEV(double*,F_INT*,double*,F_INT*,double*,double*,F_INT*,F_INT*,F_INT*);
 double SPLINT(double*,F_INT*,double*,F_INT*,double*,double*,double*);
-void SPROOT(double*,F_INT*,double*,double*,F_INT*,F_INT*,F_INT*);
 void PARCUR(F_INT*,F_INT*,F_INT*,F_INT*,double*,F_INT*,double*,
         double*,double*,double*,F_INT*,double*,F_INT*,F_INT*,
         double*,F_INT*,double*,double*,double*,F_INT*,F_INT*,F_INT*);
@@ -718,56 +713,6 @@ fitpack_spl_(PyObject *dummy, PyObject *args)
 fail:
     free(wrk);
     Py_XDECREF(ap_x);
-    Py_XDECREF(ap_c);
-    Py_XDECREF(ap_t);
-    return NULL;
-}
-
-static char doc_sproot[] = " [z,ier] = _sproot(t,c,k,mest)";
-static PyObject *
-fitpack_sproot(PyObject *dummy, PyObject *args)
-{
-    F_INT n, k, m, mest, ier;
-    npy_intp dims[1];
-    double *t, *c, *z = NULL;
-    PyArrayObject *ap_t = NULL, *ap_c = NULL;
-    PyArrayObject *ap_z = NULL;
-    PyObject *t_py = NULL, *c_py = NULL;
-
-    if (!PyArg_ParseTuple(args, ("OO" F_INT_PYFMT F_INT_PYFMT),
-                          &t_py,&c_py,&k,&mest)) {
-        return NULL;
-    }
-    ap_t = (PyArrayObject *)PyArray_ContiguousFromObject(t_py, NPY_DOUBLE, 0, 1);
-    ap_c = (PyArrayObject *)PyArray_ContiguousFromObject(c_py, NPY_DOUBLE, 0, 1);
-    if ((ap_t == NULL || ap_c == NULL)) {
-        goto fail;
-    }
-    t = (double *)PyArray_DATA(ap_t);
-    c = (double *)PyArray_DATA(ap_c);
-    n = PyArray_DIMS(ap_t)[0];
-    if ((z = malloc(mest*sizeof(double))) == NULL) {
-        PyErr_NoMemory();
-        goto fail;
-    }
-    m = 0;
-    SPROOT(t,&n,c,z,&mest,&m,&ier);
-    if (ier==10) {
-        m = 0;
-    }
-    dims[0] = m;
-    ap_z = (PyArrayObject *)PyArray_SimpleNew(1, dims, NPY_DOUBLE);
-    if (ap_z == NULL) {
-        goto fail;
-    }
-    memcpy(PyArray_DATA(ap_z), z, m*sizeof(double));
-    free(z);
-    Py_DECREF(ap_c);
-    Py_DECREF(ap_t);
-    return Py_BuildValue(("N" F_INT_PYFMT), PyArray_Return(ap_z), ier);
-
-fail:
-    free(z);
     Py_XDECREF(ap_c);
     Py_XDECREF(ap_t);
     return NULL;
@@ -1474,9 +1419,6 @@ static struct PyMethodDef fitpack_module_methods[] = {
 {"_spl_",
     fitpack_spl_,
     METH_VARARGS, doc_spl_},
-{"_sproot",
-    fitpack_sproot,
-    METH_VARARGS, doc_sproot},
 {"_spalde",
     fitpack_spalde,
     METH_VARARGS, doc_spalde},

--- a/scipy/interpolate/src/fitpack.pyf
+++ b/scipy/interpolate/src/fitpack.pyf
@@ -154,12 +154,14 @@ static F_INT calc_regrid_lwrk(F_INT mx, F_INT my, F_INT kx, F_INT ky,
        real*8 :: splint
      end function splint
 
-     subroutine sproot(t,n,c,zero,mest,m,ier)
-       ! zero,m,ier = sproot(t,c[,mest])
+     subroutine sproot(t,n,c,nc,k,zero,mest,m,ier)
+       ! zero,m,ier = sproot(t,c,k[,mest])
        threadsafe
        real*8 dimension(n),intent(in) :: t
        integer intent(hide),depend(t),check(n>=8) :: n=len(t)
-       real*8 dimension(n),depend(n),check(len(c)==n) :: c
+       real*8 dimension(nc), intent(in), depend(n,k,t),check(len(c)>=n-k-1) :: c
+       integer intent(hide), depend(c) :: nc=len(c)
+       integer intent(in) :: k
        real*8 dimension(mest),intent(out),depend(mest) :: zero
        integer optional,intent(in),depend(n) :: mest=3*(n-7)
        integer intent(out) :: m

--- a/scipy/interpolate/src/fitpack.pyf
+++ b/scipy/interpolate/src/fitpack.pyf
@@ -154,14 +154,14 @@ static F_INT calc_regrid_lwrk(F_INT mx, F_INT my, F_INT kx, F_INT ky,
        real*8 :: splint
      end function splint
 
-     subroutine sproot(t,n,c,nc,k,zero,mest,m,ier)
-       ! zero,m,ier = sproot(t,c,k[,mest])
+     subroutine sproot(t,n,c,nc,zero,mest,m,ier)
+       ! zero,m,ier = sproot(t,c[,mest])
        threadsafe
        real*8 dimension(n),intent(in) :: t
        integer intent(hide),depend(t),check(n>=8) :: n=len(t)
-       real*8 dimension(nc), intent(in), depend(n,k,t),check(len(c)>=n-k-1) :: c
+       ! Since sproot is only implemented for cubic splines, so k=3.
+       real*8 dimension(nc), intent(in), depend(n,k,t),check(len(c)>=n-3-1) :: c
        integer intent(hide), depend(c) :: nc=len(c)
-       integer intent(in) :: k
        real*8 dimension(mest),intent(out),depend(mest) :: zero
        integer optional,intent(in),depend(n) :: mest=3*(n-7)
        integer intent(out) :: m

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -61,6 +61,12 @@ class TestUnivariateSpline:
         spl = UnivariateSpline(x, y, k=3)
         assert_array_equal(spl([]), array([]))
 
+    def test_roots(self):
+        x = [1, 3, 5, 7, 9]
+        y = [0, 4, 9, 12, 21]
+        spl = UnivariateSpline(x, y, k=3)
+        assert_almost_equal(spl.roots()[0], 1.050290639101332)
+
     def test_resize_regression(self):
         """Regression test for #1375."""
         x = [-1., -0.65016502, -0.58856235, -0.26903553, -0.17370892,


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
A part of #16729
Ref: #17038

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR removed duplication of FITPACK interface`sproot` following the same strategy of #17038.
Also, I added a test for `UnivariateSpline.roots` because it is missed.

#### Additional information
<!--Any additional information you think is important.-->
