### PR TITLE
ENH: stats.Covariance: add CovViaDiagonal

### DIFF
--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -179,7 +179,9 @@ any one of the following classes to represent the covariance.
 .. autosummary::
    :toctree: generated/
 
-   CovViaPrecision        -- Covariance represented via the precision matrix
+   CovViaPrecision        -- Covariance represented via its precision matrix
+   CovViaDiagonal         -- Covariance represented via its diagonal elements
+
 
 Discrete distributions
 ----------------------
@@ -496,7 +498,7 @@ from ._rvs_sampling import rvs_ratio_uniforms
 from ._page_trend_test import page_trend_test
 from ._mannwhitneyu import mannwhitneyu
 from ._fit import fit
-from ._covariance import CovViaPrecision
+from ._covariance import CovViaPrecision, CovViaDiagonal
 
 # Deprecated namespaces, to be removed in v2.0.0
 from . import (

--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -173,14 +173,13 @@ Multivariate distributions
    multivariate_t         -- Multivariate t-distribution
    multivariate_hypergeom -- Multivariate hypergeometric distribution
 
-`scipy.stats.multivariate_normal` methods accept an instance of
-any one of the following classes to represent the covariance.
+`scipy.stats.multivariate_normal` methods accept instances
+of the following class to represent the covariance.
 
 .. autosummary::
    :toctree: generated/
 
-   CovViaPrecision        -- Covariance represented via its precision matrix
-   CovViaDiagonal         -- Covariance represented via its diagonal elements
+   Covariance             -- Representation of a covariance matrix
 
 
 Discrete distributions
@@ -498,7 +497,7 @@ from ._rvs_sampling import rvs_ratio_uniforms
 from ._page_trend_test import page_trend_test
 from ._mannwhitneyu import mannwhitneyu
 from ._fit import fit
-from ._covariance import CovViaPrecision, CovViaDiagonal
+from ._covariance import Covariance
 
 # Deprecated namespaces, to be removed in v2.0.0
 from . import (

--- a/scipy/stats/_covariance.py
+++ b/scipy/stats/_covariance.py
@@ -18,12 +18,14 @@ class Covariance:
     object representing a covariance matrix using any of several
     decompositions and perform calculations using a common interface.
 
-    Note that the `Covariance` class cannot be instantiated directly.
-    Instead, use one of the factory methods (e.g. `Covariance.from_diagonal`).
+    .. note::
+
+        The `Covariance` class cannot be instantiated directly. Instead, use
+        one of the factory methods (e.g. `Covariance.from_diagonal`).
 
     Examples
     --------
-    The most common use of the `Covariance` class is to call one of the
+    The `Covariance` class is is used by calling one of its
     factory methods to create a `Covariance` object, then pass that
     representation of the `Covariance` matrix as a shape parameter of a
     multivariate distribution.

--- a/scipy/stats/_covariance.py
+++ b/scipy/stats/_covariance.py
@@ -18,6 +18,9 @@ class Covariance:
     object representing a covariance matrix using any of several
     decompositions and perform calculations using a common interface.
 
+    Note that the `Covariance` class cannot be instantiated directly.
+    Instead, use one of the factory methods (e.g. `Covariance.from_diagonal`).
+
     Examples
     --------
     The most common use of the `Covariance` class is to call one of the
@@ -49,6 +52,11 @@ class Covariance:
     4.9595685102808205e-08
 
     """
+    def __init__(self):
+        message = ("The `Covariance` class cannot be instantiated directly. "
+                   "Please use one of the factory methods "
+                   "(e.g. `Covariance.from_diagonal`).")
+        raise NotImplementedError(message)
 
     @staticmethod
     def from_diagonal(diagonal):
@@ -149,7 +157,8 @@ class Covariance:
         >>> n = 3
         >>> A = rng.random(size=(n, n))
         >>> cov_array = A @ A.T  # make matrix symmetric positive definite
-        >>> cov_object = stats.CovViaPrecision(np.linalg.inv(cov_array))
+        >>> precision = np.linalg.inv(cov_array)
+        >>> cov_object = stats.Covariance.from_precision(precision)
         >>> x = rng.multivariate_normal(np.zeros(n), cov_array, size=(10000))
         >>> x_ = cov_object.whiten(x)
         >>> np.cov(x_, rowvar=False)  # near-identity covariance

--- a/scipy/stats/_covariance.py
+++ b/scipy/stats/_covariance.py
@@ -34,6 +34,7 @@ class Covariance:
     representing a covariance matrix:
 
     >>> from scipy import stats
+    >>> import numpy as np
     >>> d = [1, 2, 3]
     >>> A = np.diag(d)  # a diagonal covariance matrix
     >>> x = [4, -2, 5]  # a point of interest

--- a/scipy/stats/_covariance.py
+++ b/scipy/stats/_covariance.py
@@ -245,8 +245,9 @@ class CovViaPrecision(Covariance):
 
 
 def _dot_diag(x, d):
-    # If d were a full diagonal matrix, x @ d would always do what we want
-    # This is for when `d` is compressed to include only the diagonal elements
+    # If d were a full diagonal matrix, x @ d would always do what we want.
+    # Special treatment is needed for n-dimensional `d` in which each row
+    # includes only the diagonal elements of a covariance matrix.
     return x * d if x.ndim < 2 else x * np.expand_dims(d, -2)
 
 

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -51,7 +51,8 @@ class TestCovariance:
         with pytest.raises(ValueError, match=message):
             _covariance.CovViaPrecision(np.eye(3), covariance=np.eye(2))
 
-    _covariance_preprocessing = {"CovViaPrecision": np.linalg.inv,
+    _covariance_preprocessing = {"CovViaDiagonal": np.diag,
+                                 "CovViaPrecision": np.linalg.inv,
                                  "CovViaPSD": lambda x:
                                      _PSD(x, allow_singular=True)}
     _all_covariance_types = np.array(list(_covariance_preprocessing))
@@ -60,9 +61,9 @@ class TestCovariance:
                  "diagonal rank-deficient": np.diag([1, 0, 3]),
                  "general rank-deficient": [[5, -1, 0], [-1, 5, 0], [0, 0, 0]]}
     _cov_types = {"diagonal full rank": _all_covariance_types,
-                  "general full rank": _all_covariance_types,
-                  "diagonal rank-deficient": _all_covariance_types[[1]],
-                  "general rank-deficient": _all_covariance_types[[1]]}
+                  "general full rank": _all_covariance_types[1:],
+                  "diagonal rank-deficient": _all_covariance_types[[0, 2]],
+                  "general rank-deficient": _all_covariance_types[[2]]}
 
     @pytest.mark.parametrize("matrix_type", list(_matrices))
     @pytest.mark.parametrize("cov_type_name", _all_covariance_types)
@@ -534,7 +535,7 @@ class TestMultivariateNormal:
                           0.1063242573, 0.2501068509])
 
         cdf = multivariate_normal.cdf(r, mean, cov)
-        assert_allclose(cdf, r_cdf, atol=1e-5)
+        assert_allclose(cdf, r_cdf, atol=2e-5)
 
         # Also test bivariate cdf with some values precomputed
         # in R version 3.3.2 (2016-10-31) on Debian GNU/Linux.

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -177,6 +177,11 @@ class TestCovariance:
         assert_close(mvn.logcdf(x, mean, cov_object), dist0.logcdf(x))
         assert_close(dist1.logcdf(x), dist0.logcdf(x))
 
+    def test_covariance_instantiation(self):
+        message = "The `Covariance` class cannot be instantiated directly."
+        with pytest.raises(NotImplementedError, match=message):
+            Covariance()
+
 
 def _sample_orthonormal_matrix(n):
     M = np.random.randn(n, n)

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -73,7 +73,7 @@ class TestCovariance:
 
         cov_type = getattr(_covariance, f"CovVia{cov_type_name}")
         preprocessing = self._covariance_preprocessing[cov_type_name]
-        factory = getattr(_covariance.Covariance, f"from_{cov_type_name.lower()}")
+        factory = getattr(Covariance, f"from_{cov_type_name.lower()}")
 
         res = factory(preprocessing(A))
         ref = cov_type(preprocessing(A))


### PR DESCRIPTION
#### Reference issue
Followup to gh-16002

#### What does this implement/fix?
gh-16002 added the ability to specify a covariance matrix via its inverse. 
This PR adds the ability to specify a diagonal covariance matrix via its diagonal elements.

#### Additional information
This PR is much less complex than gh-16002, but there is a new question to be answered: how should we `whiten` points that are not spanned by the columns of the covariance matrix? Currently, rather than complaining or returning NaNs/zeros, it does something equivalent to projecting the points onto the span of the columns before whitening. (This is essentially what `CovViaPSD` would do naturally, if it were public.)

Regardless of what we do here, the `pdf` of the multivariate normal for such points will be zero (see gh-5288). This is currently accomplished by detecting such points and zeroing out the corresponding elements of the PDF. 

@siddhantwahal thought you might like to join us in discussing these?