### PR TITLE
CI: fix testing of `SCIPY_USE_PYTHRAN=0`, and upgrade to pythran 0.12.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -296,7 +296,7 @@ stages:
         numpy==1.21.4
         Pillow
         pybind11
-        pythran==0.11.0
+        pythran==0.12.0
         pytest
         pytest-cov
         pytest-env
@@ -339,6 +339,7 @@ stages:
             refreshenv
         }
         $env:PATH = "C:\\ProgramData\\chocolatey\\lib\\mingw\\tools\\install\\mingw$(BITS)\\bin;" + $env:PATH
+        $env:SCIPY_USE_PYTHRAN=$(SCIPY_USE_PYTHRAN)
 
         # Still testing distutils here (`pip wheel --no-use-pep517` cannot be
         # used, so back to `setup.py` it is ...)
@@ -349,7 +350,6 @@ stages:
       displayName: 'Build SciPy'
     - powershell: |
         $env:PATH = "C:\\ProgramData\\chocolatey\\lib\\mingw\\tools\\install\\mingw$(BITS)\\bin;" + $env:PATH
-        $env:SCIPY_USE_PYTHRAN=$(SCIPY_USE_PYTHRAN)
         python runtests.py -n --mode=$(TEST_MODE) -- -n 2 --junitxml=junit/test-results.xml --durations=10 --timeout=60
       displayName: 'Run SciPy Test Suite'
     - task: PublishTestResults@2

--- a/mypy.ini
+++ b/mypy.ini
@@ -185,6 +185,9 @@ ignore_missing_imports = True
 [mypy-scipy.stats._stats_pythran]
 ignore_missing_imports = True
 
+[mypy-scipy.interpolate._rbfinterp_pythran]
+ignore_missing_imports = True
+
 [mypy-scipy.stats._boost.*]
 ignore_missing_imports = True
 

--- a/scipy/interpolate/meson.build
+++ b/scipy/interpolate/meson.build
@@ -166,6 +166,12 @@ if use_pythran
     install: true,
     subdir: 'scipy/interpolate'
   )
+else
+  py3.install_sources(
+    ['_rbfinterp_pythran.py'],
+    pure: false,
+    subdir: 'scipy/interpolate'
+  )
 endif
 
 py3.install_sources([
@@ -182,7 +188,6 @@ py3.install_sources([
     '_polyint.py',
     '_rbf.py',
     '_rbfinterp.py',
-    '_rbfinterp_pythran.py',
     '_rgi.py',
     'fitpack.py',
     'fitpack2.py',

--- a/scipy/optimize/meson.build
+++ b/scipy/optimize/meson.build
@@ -205,14 +205,14 @@ __nnls = py3.extension_module('__nnls',
 )
 
 if use_pythran
-  _group_columns = custom_target('_group_columns',
+  _group_columns_cpp = custom_target('_group_columns',
     output: ['_group_columns.cpp'],
     input: '_group_columns.py',
     command: [pythran, '-E', '@INPUT@', '-o', '@OUTDIR@/_group_columns.cpp']
   )
 
   _group_columns = py3.extension_module('_group_columns',
-    [_group_columns],
+    [_group_columns_cpp],
     cpp_args: cpp_args_pythran,
     include_directories: [incdir_pythran, incdir_numpy],
     link_args: version_link_args,

--- a/scipy/signal/meson.build
+++ b/scipy/signal/meson.build
@@ -118,7 +118,6 @@ py3.install_sources([
     '_lti_conversion.py',
     '_ltisys.py',
     '_max_len_seq.py',
-    '_max_len_seq_inner.py',
     '_peak_finding.py',
     '_savitzky_golay.py',
     '_signaltools.py',

--- a/scipy/stats/meson.build
+++ b/scipy/stats/meson.build
@@ -169,18 +169,24 @@ biasedurn = py3.extension_module('_biasedurn',
 )
 
 if use_pythran
-  _stats_pythran = custom_target('_stats_pythran',
+  _stats_pythran_cpp = custom_target('_stats_pythran',
     output: ['_stats_pythran.cpp'],
     input: '_stats_pythran.py',
     command: [pythran, '-E', '@INPUT@', '-o', '@OUTDIR@/_stats_pythran.cpp']
   )
 
-  _group_columns = py3.extension_module('_stats_pythran',
-    _stats_pythran,
+  _stats_pythran = py3.extension_module('_stats_pythran',
+    _stats_pythran_cpp,
     cpp_args: cpp_args_pythran,
     include_directories: [incdir_pythran, incdir_numpy],
     link_args: version_link_args,
     install: true,
+    subdir: 'scipy/stats'
+  )
+else
+  py3.install_sources(
+    ['_hypotests_pythran.py'],
+    pure: false,
     subdir: 'scipy/stats'
   )
 endif


### PR DESCRIPTION
xref gh-17102, which discovered that the `=0` usage is currently broken.

[skip actions] [skip circle]

Note that this should fail (I want to see that first) because of the bug in `scipy.stats._hypotests`.