### PR TITLE
ENH: Add support for bounds class in curve_fit

### DIFF
--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -595,14 +595,15 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
         Lower and upper bounds on parameters. Defaults to no bounds.
         There are two ways to specify the bounds:
 
-        1. Instance of `Bounds` class.
-        2. 2-tuple of array_like: Each element of the tuple must be either
-        an array with the length equal to the number of parameters, or a
-        scalar (in which case the bound is taken to be the same for all
-        parameters). Use ``np.inf`` with an appropriate sign to disable
-        bounds on all or some parameters.
+            - Instance of `Bounds` class.
 
-        .. versionadded:: 0.17
+            - 2-tuple of array_like: Each element of the tuple must be either
+              an array with the length equal to the number of parameters, or a
+              scalar (in which case the bound is taken to be the same for all
+              parameters). Use ``np.inf`` with an appropriate sign to disable
+              bounds on all or some parameters.
+
+              .. versionadded:: 0.17
     method : {'lm', 'trf', 'dogbox'}, optional
         Method to use for optimization. See `least_squares` for more details.
         Default is 'lm' for unconstrained problems and 'trf' if `bounds` are

--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -13,6 +13,8 @@ from ._optimize import OptimizeResult, _check_unknown_options, OptimizeWarning
 from ._lsq import least_squares
 # from ._lsq.common import make_strictly_feasible
 from ._lsq.least_squares import prepare_bounds
+from scipy.optimize._minimize import Bounds
+
 
 error = _minpack.error
 
@@ -590,12 +592,16 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
         and raise a ValueError if they do. Setting this parameter to
         False may silently produce nonsensical results if the input arrays
         do contain nans. Default is True.
-    bounds : 2-tuple of array_like, optional
+    bounds : 2-tuple of array_like or `Bounds`, optional
         Lower and upper bounds on parameters. Defaults to no bounds.
-        Each element of the tuple must be either an array with the length equal
-        to the number of parameters, or a scalar (in which case the bound is
-        taken to be the same for all parameters). Use ``np.inf`` with an
-        appropriate sign to disable bounds on all or some parameters.
+        There are two ways to specify the bounds:
+
+        1. Instance of `Bounds` class.
+        2. 2-tuple of array_like: Each element of the tuple must be either
+        an array with the length equal to the number of parameters, or a
+        scalar (in which case the bound is taken to be the same for all
+        parameters). Use ``np.inf`` with an appropriate sign to disable
+        bounds on all or some parameters.
 
         .. versionadded:: 0.17
     method : {'lm', 'trf', 'dogbox'}, optional
@@ -763,7 +769,10 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
         p0 = np.atleast_1d(p0)
         n = p0.size
 
-    lb, ub = prepare_bounds(bounds, n)
+    if isinstance(bounds, Bounds):
+        lb, ub = bounds.lb, bounds.ub
+    else:
+        lb, ub = prepare_bounds(bounds, n)
     if p0 is None:
         p0 = _initialize_feasible(lb, ub)
 

--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -15,7 +15,6 @@ from ._lsq import least_squares
 from ._lsq.least_squares import prepare_bounds
 from scipy.optimize._minimize import Bounds
 
-
 error = _minpack.error
 
 __all__ = ['fsolve', 'leastsq', 'fixed_point', 'curve_fit']

--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -603,7 +603,6 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
               parameters). Use ``np.inf`` with an appropriate sign to disable
               bounds on all or some parameters.
 
-              .. versionadded:: 0.17
     method : {'lm', 'trf', 'dogbox'}, optional
         Method to use for optimization. See `least_squares` for more details.
         Default is 'lm' for unconstrained problems and 'trf' if `bounds` are

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -15,6 +15,7 @@ from scipy import optimize
 from scipy.special import lambertw
 from scipy.optimize._minpack_py import leastsq, curve_fit, fixed_point
 from scipy.optimize import OptimizeWarning
+from scipy.optimize._minimize import Bounds
 
 
 class ReturnShape:
@@ -605,11 +606,21 @@ class TestCurveFit:
 
         # The minimum w/out bounds is at [2., 2.],
         # and with bounds it's at [1.5, smth].
-        bounds = ([1., 0], [1.5, 3.])
+        lb = [1., 0]
+        ub = [1.5, 3.]
+
+        # Test that both variants of the bounds yield the same result
+        bounds = (lb, ub)
+        bounds_class = Bounds(lb, ub)
         for method in [None, 'trf', 'dogbox']:
             popt, pcov = curve_fit(f, xdata, ydata, bounds=bounds,
                                    method=method)
             assert_allclose(popt[0], 1.5)
+
+            popt_class, pcov_class = curve_fit(f, xdata, ydata,
+                                               bounds=bounds_class,
+                                               method=method)
+            assert_allclose(popt_class, popt)
 
         # With bounds, the starting estimate is feasible.
         popt, pcov = curve_fit(f, xdata, ydata, method='trf',


### PR DESCRIPTION
#### What does this implement/fix?
Recently, support for the `Bounds` class was added to `least_squares`. I think it makes sense to support it also in  `curve_fit` .

So far, the bounds for `curve_fit` have to be provided in a different way than for `minimize` and the global optimizers. This complicates the overall API of `scipy.optimize`. Now, almost all optimizers support the `Bounds` class.

#### Additional information
<!--Any additional information you think is important.-->
