### PR TITLE
CI: skip doc rendering on GitHub if skipping CircleCI

### DIFF
--- a/.github/workflows/circle_artifacts.yml
+++ b/.github/workflows/circle_artifacts.yml
@@ -2,7 +2,7 @@ on: [status]
 jobs:
   circleci_artifacts_redirector_job:
     runs-on: ubuntu-20.04
-    if: "${{ github.repository == 'scipy/scipy' && github.event.context == 'ci/circleci: build_docs' }}"
+    if: "github.repository == 'scipy/scipy' && !contains(github.event.head_commit.message, '[skip circle]')  && github.event.context == 'ci/circleci: build_docs'"
     name: Run CircleCI artifacts redirector
     steps:
       - name: GitHub Action step


### PR DESCRIPTION
As pointed out in https://github.com/scipy/scipy/pull/17109#issuecomment-1261327482, if CircleCI is skipped, we should also skip the GH action that routes to the artifact.