### PR TITLE
ENH: stats.logistic: override fit for remaining cases

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -5385,7 +5385,7 @@ class logistic_gen(rv_continuous):
         # rv_continuous provided guesses
         loc, scale = self._fitstart(data)
         # these are trumped by user-provided guesses
-        loc, scale = kwds.pop('loc', loc), kwds.pop('scale', scale)
+        loc, scale = kwds.get('loc', loc), kwds.get('scale', scale)
 
         # the maximum likelihood estimators `a` and `b` of the location and
         # scale parameters are roots of the two equations described in `func`.
@@ -5404,15 +5404,19 @@ class logistic_gen(rv_continuous):
             return dl_dloc(loc, scale), dl_dscale(scale, loc)
 
         if fscale is not None and floc is None:
-            loc = optimize.root(dl_dloc, (loc,)).x[0]
+            res = optimize.root(dl_dloc, (loc,))
+            loc = res.x[0]
             scale = fscale
         elif floc is not None and fscale is None:
-            scale = optimize.root(dl_dscale, (scale,)).x[0]
+            res = optimize.root(dl_dscale, (scale,))
+            scale = res.x[0]
             loc = floc
         else:
-            loc, scale = optimize.root(func, (loc, scale)).x
+            res = optimize.root(func, (loc, scale))
+            loc, scale = res.x
 
-        return loc, scale
+        return ((loc, scale) if res.success
+                else super().fit(data, *args, **kwds))
 
 
 logistic = logistic_gen(name='logistic')

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1408,15 +1408,16 @@ class TestLogistic:
         # to this system of equations are equal
         assert_allclose(fit_method, expected_solution, atol=1e-30)
 
-    @pytest.mark.parametrize("loc_rvs,scale_rvs", [np.random.rand(2)])
-    def test_fit_comp_optimizer(self, loc_rvs, scale_rvs):
-        data = stats.logistic.rvs(size=100, loc=loc_rvs, scale=scale_rvs)
+    def test_fit_comp_optimizer(self):
+        data = stats.logistic.rvs(size=100, loc=0.5, scale=2)
 
         # obtain objective function to compare results of the fit methods
         args = [data, (stats.logistic._fitstart(data),)]
         func = stats.logistic._reduce_func(args, {})[1]
 
         _assert_less_or_close_loglike(stats.logistic, data, func)
+        _assert_less_or_close_loglike(stats.logistic, data, func, floc=1)
+        _assert_less_or_close_loglike(stats.logistic, data, func, fscale=1)
 
     @pytest.mark.parametrize('testlogcdf', [True, False])
     def test_logcdfsf_tails(self, testlogcdf):


### PR DESCRIPTION
#### Reference issue
Followup to gh-12738
Progress toward gh-11782

#### What does this implement/fix?
gh-12738 overrode the `fit` method of `logistic` for the case in which both `loc` and `scale` are unknown. The same equations can be used when only one of the two parameters is unknown. This PR overrides fit in these cases, too.

#### Additional information
It might be possible to solve one of the equations analytically. I didn't check carefully.

In these cases, speed is improved by about an order of magnitude.

Typical speed improvement (fixed location shown).
![image](https://user-images.githubusercontent.com/6570539/193200558-bde0633e-fa41-476e-bf8d-01dfb4542633.png)

Typical accuracy improvement
![image](https://user-images.githubusercontent.com/6570539/193201142-56f60666-da75-40c6-b02b-083e01dcf996.png)

<details>

```python3
import numpy as np
from scipy import stats
from time import perf_counter
import matplotlib.pyplot as plt

dist_family = stats.logistic
n_params = len(dist_family._shape_info())

rng = np.random.default_rng(243300623549261137)
qrng = stats.qmc.Halton(n_params+4, seed=rng)

N = 1000
times_pr = np.full(N, np.nan)
times_super = np.full(N, np.nan)
nllfs_true = np.full(N, np.nan)
nllfs_pr = np.full(N, np.nan)
nllfs_super= np.full(N, np.nan)
params_true = np.full((N, n_params+2), np.nan)
params_pr = np.full((N, n_params+2), np.nan)
params_super = np.full((N, n_params+2), np.nan)


for i in range(N):
    print(i)
    sample = qrng.random()
    lbounds = [] + [-3, -3, 1, -1]
    ubounds = [] + [3, 3, 5, 1]
    sample = stats.qmc.scale(sample, lbounds, ubounds)[0]
    shapes = 10**sample[:-4]
    loc, scale, size = 10**sample[-4:-1]
    loc_sign = np.sign(sample[-1])
    loc *= loc_sign
    size = int(size)
    true_params = list(shapes) + [np.nextafter(loc, -loc_sign*np.inf), np.nextafter(scale, np.inf)]

    # fixed = {'f0': shapes[0], 'floc': loc}

    # fixed = {'fscale': scale, 'floc': loc}
    # fixed = {'fscale': scale*rng.random()}
    fixed = {'floc': loc*rng.random()}
    # fixed = {}

    dist = dist_family(*true_params)
    rvs = dist.rvs(size=size, random_state=rng)

    params_true[i] = true_params
    nllf_true = dist_family.nnlf(true_params, rvs)
    nllfs_true[i] = nllf_true

    try:
        tic = perf_counter()
        params_fit = dist_family.fit(rvs, **fixed)
        toc = perf_counter()

        nllf_fit = dist_family.nnlf(params_fit, rvs)

        params_pr[i] = params_fit
        nllfs_pr[i] = nllf_fit

        times_pr[i] = toc-tic

    except Exception as e:
        print(f"Failure in pr: {e}")

    try:
        tic = perf_counter()
        params_fit = dist_family.fit(rvs, **fixed, superfit=True)
        toc = perf_counter()

        nllf_super = dist_family.nnlf(params_fit, rvs)

        params_super[i] = params_fit
        nllfs_super[i] = nllf_super

        times_super[i] = toc-tic

    except Exception as e:
        print(f"Failure in super: {e}")

    # if i == 11:
    #     raise Exception()

nllf_errs_pr = (nllfs_pr - nllfs_true)/abs(nllfs_true)
nllf_errs_super = (nllfs_super - nllfs_true)/abs(nllfs_true)
nllf_diff = (nllfs_pr - nllfs_super)/abs(nllfs_super)

nllf_errs_pr = nllf_errs_pr[np.isfinite(nllf_errs_pr)]
nllf_errs_super = nllf_errs_super[np.isfinite(nllf_errs_super)]

nllf_errs_pr_good = -nllf_errs_pr[nllf_errs_pr < 0]
nllf_errs_pr_bad = nllf_errs_pr[nllf_errs_pr > 0]
nllf_errs_super_good = -nllf_errs_super[nllf_errs_super < 0]
nllf_errs_super_bad = nllf_errs_super[nllf_errs_super > 0]
nllf_diff_good = -nllf_diff[nllf_diff < 0]
nllf_diff_bad = nllf_diff[nllf_diff > 0]

bins = np.arange(-4, 0, 0.125)
plt.hist(np.log10(times_pr), bins=bins, alpha=0.5)
plt.hist(np.log10(times_super), bins=bins, alpha=0.5)
plt.legend(('PR', 'superfit'))
plt.xlabel('log10 of `fit` execution time (s)')
plt.ylabel('Frequency')
plt.title('Histogram of log10 of `fit` execution time (s)')

# plt.hist(np.log10(nllf_diff_good), alpha=0.5)
# plt.hist(np.log10(nllf_diff_bad), alpha=0.5)
# plt.legend(('good', 'bad'))
# plt.xlabel('log10 of NLLF relative changes')
# plt.ylabel('Frequency')
# plt.title('Histogram of log10 of NLLF relative changes')

print(f'finite: {np.isfinite(nllf_diff).sum()}')
print(f'finite: {np.isfinite(nllfs_pr).sum()}')
print(f'bad: {nllf_diff_bad}')
```

</details>