### PR TITLE
special: fix chgm fortran routine for large negative argument

### DIFF
--- a/scipy/special/specfun/specfun.f
+++ b/scipy/special/specfun/specfun.f
@@ -5401,6 +5401,9 @@ C       DLMF 13.2.39 (cf. above)
                     GO TO 25
                  ENDIF
 15            CONTINUE
+C       DLMF 13.2.39 (cf. above) even if the loop above does not converge
+           IF (X0.LT.0.0D0) HG=HG*EXP(X0)
+           GO TO 25
            ELSE
 C       DLMF 13.7.2 & 13.2.4, SUM2 corresponds to first sum
               Y=0.0D0

--- a/scipy/special/tests/test_hypergeometric.py
+++ b/scipy/special/tests/test_hypergeometric.py
@@ -114,3 +114,28 @@ class TestHyp1f1:
             atol=0,
             rtol=1e-14
         )
+
+    def test_gh_14149(self):
+        desired = -7.0011903214189369e-5
+        assert_allclose(
+            sc.hyp1f1(1, 0.3, -1 / 0.0001),
+            desired,
+            atol=0,
+            rtol=1e-14
+        )
+
+        desired = 1.00007001190321419
+        assert_allclose(
+            1 - sc.hyp1f1(1, 0.3, -1 / 0.0001),
+            desired,
+            atol=0,
+            rtol=1e-15
+        )
+
+        desired = 1.0007011932249443
+        assert_allclose(
+            1 - sc.hyp1f1(1, 0.3, -1 / 0.001),
+            desired,
+            atol=0,
+            rtol=1e-15
+        )

--- a/scipy/special/tests/test_hypergeometric.py
+++ b/scipy/special/tests/test_hypergeometric.py
@@ -105,3 +105,12 @@ class TestHyp1f1:
     def test_gh_11099(self, a, b, x, desired):
         # All desired results computed using Mpmath
         assert sc.hyp1f1(a, b, x) == desired
+
+    def test_gh_17120(self):
+        desired = -4.5954071598133683e-20  # Computed using Mpmath
+        assert_allclose(
+            sc.hyp1f1(9, 8.5, -355),
+            desired,
+            atol=0,
+            rtol=1e-14
+        )


### PR DESCRIPTION
#### Reference issue

Closes gh-17120

#### What does this implement/fix?

See the explanation in #17120.

I think having the value be slightly wrong (>1e-15 rtol) is better than being completely off, but I could also try to increase the number of terms used in the series, or return some error if the series fails to converge.

---

I found this error while trying to debug a version of this function that was translated to rust (f2c from the original fortran and then manual translation from C to rust), so here is the fix ported to Fortran.