### PR TITLE
TST: stats.studentized_range: fix incorrect test

### DIFF
--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -5699,7 +5699,7 @@ class TestStudentizedRange:
     vs = [1, 3, 10, 20, 120, np.inf]
     ks = [2, 8, 14, 20]
 
-    data = zip(product(ps, vs, ks), qs)
+    data = list(zip(product(ps, vs, ks), qs))
 
     # A small selection of large-v cases generated with R's `ptukey`
     # Each case is in the format (q, k, v, r_result)
@@ -5720,8 +5720,9 @@ class TestStudentizedRange:
     @pytest.mark.slow
     def test_ppf_against_tables(self):
         for pvk, q_expected in self.data:
-            res_q = stats.studentized_range.ppf(*pvk)
-            assert_allclose(res_q, q_expected, rtol=1e-4)
+            p, v, k = pvk
+            res_q = stats.studentized_range.ppf(p, k, v)
+            assert_allclose(res_q, q_expected, rtol=5e-4)
 
     path_prefix = os.path.dirname(__file__)
     relative_path = "data/studentized_range_mpmath_ref.json"


### PR DESCRIPTION
#### Reference issue
Closes gh-17124

#### What does this implement/fix?
gh-17124 reported a failure in `scipy.stats.tests.test_distributions.TestStudentizedRange.test_ppf_against_tables`. The test would have always failed when executed on its own, but the failure was hidden: it is supposed to loop over an iterator that is an attribute of the class, but that iterator is exhausted after running another test. 

This PR corrects the test, which passed the arguments to `studentized_range.ppf` in the wrong order and had too tight a tolerance. The coarse tolerance required for the test to pass is understandable, considering the low precision of the reference table.
