### PR TITLE
ENH: stats.covariance: add CovViaCholesky

### DIFF
--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -54,6 +54,7 @@ class TestCovariance:
 
     _covariance_preprocessing = {"Diagonal": np.diag,
                                  "Precision": np.linalg.inv,
+                                 "Cholesky": np.linalg.cholesky,
                                  "PSD": lambda x:
                                      _PSD(x, allow_singular=True)}
     _all_covariance_types = np.array(list(_covariance_preprocessing))
@@ -63,8 +64,8 @@ class TestCovariance:
                  "general rank-deficient": [[5, -1, 0], [-1, 5, 0], [0, 0, 0]]}
     _cov_types = {"diagonal full rank": _all_covariance_types,
                   "general full rank": _all_covariance_types[1:],
-                  "diagonal rank-deficient": _all_covariance_types[[0, 2]],
-                  "general rank-deficient": _all_covariance_types[[2]]}
+                  "diagonal rank-deficient": _all_covariance_types[[0, -1]],
+                  "general rank-deficient": _all_covariance_types[[-1]]}
 
     @pytest.mark.parametrize("cov_type_name", _all_covariance_types[:-1])
     def test_factories(self, cov_type_name):


### PR DESCRIPTION
#### Reference issue
Followup to gh-16002

#### What does this implement/fix?
gh-16002 added the ability to specify a covariance matrix via its inverse. 
This PR adds the ability to specify a diagonal covariance matrix via its Cholesky decomposition.