### PR TITLE
MAINT: pyproject.toml: Update build system requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,10 +10,10 @@
 [build-system]
 build-backend = 'mesonpy'
 requires = [
-    "meson-python>=0.8.0",
-    "Cython>=0.29.21",
-    "pybind11>=2.4.3",
-    "pythran>=0.11.0",
+    "meson-python>=0.9.0",
+    "Cython>=0.29.32",
+    "pybind11>=2.10.0",
+    "pythran>=0.12.0",
     # `wheel` is needed for non-isolated builds, given that `meson-python`
     # doesn't list it as a runtime requirement (at least in 0.5.0)
     "wheel",


### PR DESCRIPTION
Require `meson-python>=0.9.0`, `Cython>=0.29.32`, `pybind11>=2.10.0` and `pythran>=0.12.0` to build SciPy.

#### Reference issue
Related to https://github.com/scipy/scipy/issues/16851

#### What does this implement/fix?
These updated build-system requirements allow for consistent builds. The updated meson-python and Cython helps with Python 3.11 builds.

#### Additional information
Note that build-system requirements are only needed to build SciPy from source, not to run it after a regular pip install, and thus can be set fairly aggressive.

Probably a backport candidate to the 1.9 branch if Python 3.11 wheels are to be released on this branch.
