### PR TITLE
CI: build macosx_arm64 wheels on cirrus-ci

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -93,7 +93,11 @@ jobs:
         # The actions/setup-python can only use the form ["3.8'].
         exclude:
           - buildplat: [macos-12, macosx, arm64]
-            python: ["cp39", "3.9"], ["cp310", "3.10"], ["cp311", "3.11.0-alpha - 3.11.0"]
+            python: ["cp39", "3.9"]
+          - buildplat: [macos-12, macosx, arm64]
+            python: ["cp310", "3.10"]
+          - buildplat: [macos-12, macosx, arm64]
+            python: ["cp311", "3.11.0-alpha - 3.11.0"]
     env:
       IS_32_BIT: ${{ matrix.buildplat[2] == 'x86' }}
       IS_PUSH: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -162,7 +162,7 @@ jobs:
           export _PYTHON_HOST_PLATFORM="macosx-12.0-arm64"
           export CROSS_COMPILE=1
           # Need macOS >= 11 for arm compilation.
-          export MACOSX_DEPLOYMENT_TARGET=11.0
+          export MACOSX_DEPLOYMENT_TARGET=12.0
 
           # SDK root needs to be set early, installation of gfortran/openblas
           # needs to go in the correct location.
@@ -170,7 +170,7 @@ jobs:
           export ARCHFLAGS=" -arch arm64 "
 
           source tools/wheels/gfortran_utils.sh
-          export MACOSX_DEPLOYMENT_TARGET=11.0
+          export MACOSX_DEPLOYMENT_TARGET=12.0
 
           # The install script requires the PLAT variable in order to set
           # the FC variable

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -91,6 +91,9 @@ jobs:
         # macosx_arm64 build. Once cibuildwheel can do the macosx_arm64 cross build
         # we can get rid of this duplication and just have ["cp38", "cp39"].
         # The actions/setup-python can only use the form ["3.8'].
+        exclude:
+          - buildplat: [macos-12, macosx, arm64]
+            python: []["cp39", "3.9"], ["cp310", "3.10"], ["cp311", "3.11.0-alpha - 3.11.0"]]
     env:
       IS_32_BIT: ${{ matrix.buildplat[2] == 'x86' }}
       IS_PUSH: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -93,7 +93,7 @@ jobs:
         # The actions/setup-python can only use the form ["3.8'].
         exclude:
           - buildplat: [macos-12, macosx, arm64]
-            python: []["cp39", "3.9"], ["cp310", "3.10"], ["cp311", "3.11.0-alpha - 3.11.0"]]
+            python: [["cp39", "3.9"], ["cp310", "3.10"], ["cp311", "3.11.0-alpha - 3.11.0"]]
     env:
       IS_32_BIT: ${{ matrix.buildplat[2] == 'x86' }}
       IS_PUSH: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -105,7 +105,7 @@ jobs:
 
       - uses: actions/setup-python@v4.2.0
         with:
-          python-version: ${{ matrix.python[1]}}
+          python-version: 3.8
 
       - name: win_amd64 - install rtools
         run: |
@@ -128,7 +128,7 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.10.1
-        # Build all wheels here, but the macosx_arm64 job in its own entry.
+        # Build all wheels here, apart from macosx_arm64, linux_aarch64
         # cibuildwheel is currently unable to pass configuration flags to
         # CIBW_BUILD_FRONTEND https://github.com/pypa/cibuildwheel/issues/1227
         # (pip/build). Cross compilation with meson requires an initial
@@ -143,13 +143,17 @@ jobs:
           CIBW_ARCHS: ${{ matrix.buildplat[2] }}
           CIBW_ENVIRONMENT_PASS_LINUX: RUNNER_OS
 
-      - name: Build macosx_arm64
-        if: ${{ matrix.buildplat[1] == 'macosx' && matrix.buildplat[2] == 'arm64' }}
+      - name: Build cp38-macosx_arm64
+        # This is solely used to build cp38-macosx_arm64. As soon as 3.8 is
+        # dropped then this entry can be removed
+        if: ${{ matrix.python[1] == '3.8' && matrix.buildplat[1] == 'macosx' && matrix.buildplat[2] == 'arm64' }}
         run: |
+          # Update license
+          cat tools/wheels/LICENSE_osx.txt >> LICENSE.txt
+
           export PLAT="arm64"
           export _PYTHON_HOST_PLATFORM="macosx-12.0-arm64"
           export CROSS_COMPILE=1
-
           # Need macOS >= 11 for arm compilation.
           export MACOSX_DEPLOYMENT_TARGET=11.0
 
@@ -158,32 +162,55 @@ jobs:
           export SDKROOT=/Applications/Xcode_13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk
           export ARCHFLAGS=" -arch arm64 "
 
-          # install dependencies for the build machine
-          pip install meson cython pybind11 pythran ninja oldest-supported-numpy build delocate meson-python
+          source tools/wheels/gfortran_utils.sh
+          export MACOSX_DEPLOYMENT_TARGET=11.0
 
-          # sets up gfortran compiler/openblas, sets compiler flags.
-          bash tools/wheels/cibw_before_build_macos.sh $(pwd)
+          # The install script requires the PLAT variable in order to set
+          # the FC variable
+          export PLAT=arm64
+          install_arm64_cross_gfortran
+          export FC=$FC_ARM64
+          export PATH=$FC_LOC:$PATH
+
+          export FFLAGS=" -arch arm64 $FFLAGS"
+          export LDFLAGS=" $FC_ARM64_LDFLAGS $LDFLAGS -L/opt/arm64-builds/lib -arch arm64"
+          sudo ln -s $FC $FC_LOC/gfortran
+          echo $(type -p gfortran)
+
+          # OpenBLAS
+          curl -L https://anaconda.org/multibuild-wheels-staging/openblas-libs/v0.3.20-140-gbfd9c1b5/download/openblas-v0.3.20-140-gbfd9c1b5-macosx_11_0_arm64-gf_f26990f.tar.gz -o openblas.tar.gz
+          sudo tar -xv -C / -f openblas.tar.gz
+          # force a dynamic link, there may be a more elegant way of doing this.
+          sudo rm /opt/arm64-builds/lib/*.a
+
+          # having a test fortran program has helped in debugging problems with the
+          # compiler environment.
+          $FC $FFLAGS tools/wheels/test.f $LDFLAGS
+          ls -al *.out
+          otool -L a.out      
+
           export PKG_CONFIG_PATH=/opt/arm64-builds/lib/pkgconfig
           export PKG_CONFIG=/usr/local/bin/pkg-config
           export CFLAGS=" -arch arm64 $CFLAGS"
           export CXXFLAGS=" -arch arm64 $CXXFLAGS"
           export LD_LIBRARY_PATH="/opt/arm64-builds/lib:$FC_LIBDIR:$LD_LIBRARY_PATH"
-          meson setup --cross-file $(pwd)/tools/wheels/cross_arm64.txt build
+          
+          # install dependencies for the build machine
+          pip install meson cython pybind11 pythran ninja oldest-supported-numpy build delocate meson-python
 
+          meson setup --cross-file $(pwd)/tools/wheels/cross_arm64.txt build
           # use the pip frontend because the build front end does not end up
           # obeying the configuration flags it's passed.
           # For example: `python -m build -Cbuilddir=dir` does not end up using
           # dir as the meson build directory. This is an issue because
           # the cross-compile specification is contained in that directory.
-
           python -m pip wheel -w dist -vvv --config-settings builddir=build .
-          rm dist/numpy*.whl
 
+          rm dist/numpy*.whl
           # The `.so` are all converted to `-rpath/libgfortran` by
           # gfortran/meson, with all absolute paths removed.
           # Enables delocate to find the libopenblas/libgfortran libraries.
           export DYLD_LIBRARY_PATH=/opt/gfortran-darwin-arm64/lib/gcc/arm64-apple-darwin20.0.0/10.2.1:/opt/arm64-builds/lib
-
           delocate-listdeps dist/scipy*.whl
           delocate-wheel --require-archs=arm64 -k -w wheelhouse dist/scipy*.whl
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -162,7 +162,7 @@ jobs:
           export _PYTHON_HOST_PLATFORM="macosx-12.0-arm64"
           export CROSS_COMPILE=1
           # Need macOS >= 11 for arm compilation.
-          export MACOSX_DEPLOYMENT_TARGET=12.0
+          export MACOSX_DEPLOYMENT_TARGET=11.0
 
           # SDK root needs to be set early, installation of gfortran/openblas
           # needs to go in the correct location.
@@ -170,7 +170,7 @@ jobs:
           export ARCHFLAGS=" -arch arm64 "
 
           source tools/wheels/gfortran_utils.sh
-          export MACOSX_DEPLOYMENT_TARGET=12.0
+          export MACOSX_DEPLOYMENT_TARGET=11.0
 
           # The install script requires the PLAT variable in order to set
           # the FC variable
@@ -213,7 +213,16 @@ jobs:
           # the cross-compile specification is contained in that directory.
           python -m pip wheel -w dist -vvv --config-settings builddir=build .
 
-          rm dist/numpy*.whl
+          # change wheel names from
+          # scipy-1.10.0.dev0-cp38-cp38-macosx_11_0_arm64.whl
+          # to
+          # scipy-1.10.0.dev0-cp38-cp38-macosx_12_0_arm64.whl
+          # so they're only installable on Monterey
+          pushd dist
+          rm numpy*.whl
+          for i in *11_0*.whl; do [[ -e ${i/11_0/12_0} ]] || mv "$i" "${i/11_0/12_0}"; done
+          popd
+
           # The `.so` are all converted to `-rpath/libgfortran` by
           # gfortran/meson, with all absolute paths removed.
           # Enables delocate to find the libopenblas/libgfortran libraries.

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -93,7 +93,7 @@ jobs:
         # The actions/setup-python can only use the form ["3.8'].
         exclude:
           - buildplat: [macos-12, macosx, arm64]
-            python: [["cp39", "3.9"], ["cp310", "3.10"], ["cp311", "3.11.0-alpha - 3.11.0"]]
+            python: ["cp39", "3.9"], ["cp310", "3.10"], ["cp311", "3.11.0-alpha - 3.11.0"]
     env:
       IS_32_BIT: ${{ matrix.buildplat[2] == 'x86' }}
       IS_PUSH: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}

--- a/ci/cirrus_wheels.yml
+++ b/ci/cirrus_wheels.yml
@@ -37,6 +37,44 @@ cirrus_wheels_linux_aarch64_task:
 
 
 ######################################################################
+# Build macosx_arm64 natively
+######################################################################
+
+cirrus_wheels_macos_arm64_task:
+  only_if: $CIRRUS_REPO_FULL_NAME == "scipy/scipy"
+  depends_on: cirrus_wheel_trigger
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-monterey-xcode:13.3.1
+  matrix:
+    - env:
+        CIBW_BUILD: cp39-*
+    - env:
+        CIBW_BUILD: cp310-* cp311-*
+  env:
+    PATH: /opt/homebrew/opt/python@3.10/bin:$PATH
+    CIBW_ENVIRONMENT: MACOSX_DEPLOYMENT_TARGET=12.0 _PYTHON_HOST_PLATFORM="macosx-12.0-arm64"
+    PKG_CONFIG_PATH: /opt/arm64-builds/lib/pkgconfig
+    # assumes that the cmake config is in /usr/local/lib/cmake
+    CMAKE_PREFIX_PATH: /opt/arm64-builds/
+    REPAIR_PATH: /usr/local/gfortran/lib:/opt/arm64-builds/lib
+    CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
+      DYLD_LIBRARY_PATH=/usr/local/gfortran/lib:/opt/arm64-builds/lib delocate-listdeps {wheel} &&
+      DYLD_LIBRARY_PATH=/usr/local/gfortran/lib:/opt/arm64-builds/lib delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}
+  install_pre_requirements_script:
+    - brew install python@3.10
+    - ln -s python3 /opt/homebrew/opt/python@3.10/bin/python
+
+  build_script:
+    - which python
+    # needed for submodules
+    - git submodule update --init
+    - uname -m
+    - python -c "import platform;print(platform.python_version());print(platform.system());print(platform.machine())"
+    - clang --version
+  <<: *BUILD_AND_STORE_WHEELS
+
+
+######################################################################
 # Upload all wheels
 ######################################################################
 

--- a/ci/cirrus_wheels.yml
+++ b/ci/cirrus_wheels.yml
@@ -41,8 +41,6 @@ cirrus_wheels_linux_aarch64_task:
 ######################################################################
 
 cirrus_wheels_macos_arm64_task:
-  only_if: $CIRRUS_REPO_FULL_NAME == "scipy/scipy"
-  depends_on: cirrus_wheel_trigger
   macos_instance:
     image: ghcr.io/cirruslabs/macos-monterey-xcode:13.3.1
   matrix:
@@ -83,7 +81,9 @@ cirrus_wheels_upload_task:
   # Rather than upload wheels at the end of each cibuildwheel run we do a
   # final upload here. This is because a run may be on different OS for
   # which bash, etc, may not be present.
-  depends_on: cirrus_wheels_linux_aarch64
+  depends_on:
+    - cirrus_wheels_linux_aarch64
+    - cirrus_wheels_macos_arm64
   compute_engine_instance:
     image_project: cirrus-images
     image: family/docker-builder

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,7 +154,7 @@ before-build = "bash {project}/tools/wheels/cibw_before_build_linux.sh {project}
 
 [tool.cibuildwheel.macos]
 before-build = "bash {project}/tools/wheels/cibw_before_build_macos.sh {project}"
-test-skip = "*_arm64 *_universal2:arm64"
+test-skip = "cp38-macosx_arm64"
 
 [tool.cibuildwheel.windows]
 before-build = "bash {project}/tools/wheels/cibw_before_build_win.sh {project}"

--- a/tools/wheels/cibw_before_build_macos.sh
+++ b/tools/wheels/cibw_before_build_macos.sh
@@ -7,29 +7,17 @@ echo $PLATFORM
 # Update license
 cat $PROJECT_DIR/tools/wheels/LICENSE_osx.txt >> $PROJECT_DIR/LICENSE.txt
 
-# Install Openblas
-basedir=$(python tools/openblas_support.py)
-cp -r $basedir/lib/* /usr/local/lib
-cp $basedir/include/* /usr/local/include
-
-if [[ $RUNNER_OS == "macOS" && $PLATFORM == "macosx-arm64" ]]; then
-  # this version of openblas has the pkg-config file included. The version
-  # obtained from the openblas_support.py doesn't.
-  # Problems were experienced with meson->cmake detection of openblas when
-  # trying to cross compile.
-  curl -L https://anaconda.org/multibuild-wheels-staging/openblas-libs/v0.3.20-140-gbfd9c1b5/download/openblas-v0.3.20-140-gbfd9c1b5-macosx_11_0_arm64-gf_f26990f.tar.gz -o openblas.tar.gz
-  sudo tar -xv -C / -f openblas.tar.gz
-
-  sudo mkdir -p /opt/arm64-builds/lib /opt/arm64-builds/include
-  sudo chown -R $USER /opt/arm64-builds
-  cp -r $basedir/lib/* /opt/arm64-builds/lib
-  cp $basedir/include/* /opt/arm64-builds/include
-fi
-
 #########################################################################################
-# Install GFortran
+# Install GFortran + OpenBLAS
 
 if [[ $PLATFORM == "macosx-x86_64" ]]; then
+  # Openblas
+  basedir=$(python tools/openblas_support.py)
+
+  # copy over the OpenBLAS library stuff first
+  cp -r $basedir/lib/* /usr/local/lib
+  cp $basedir/include/* /usr/local/include
+
   #GFORTRAN=$(type -p gfortran-9)
   #sudo ln -s $GFORTRAN /usr/local/bin/gfortran
   # same version of gfortran as the openblas-libs and scipy-wheel builds
@@ -46,31 +34,34 @@ if [[ $PLATFORM == "macosx-x86_64" ]]; then
   otool -L /usr/local/gfortran/lib/libgfortran.3.dylib
 fi
 
-# arm64 stuff from gfortran_utils
 if [[ $PLATFORM == "macosx-arm64" ]]; then
-    source $PROJECT_DIR/tools/wheels/gfortran_utils.sh
-    export MACOSX_DEPLOYMENT_TARGET=11.0
+  # OpenBLAS
+  # need a version of OpenBLAS that is suited for gcc >= 11
+  basedir=$(python tools/openblas_support.py)
 
-    # The install script requires the PLAT variable in order to set
-    # the FC variable
-    export PLAT=arm64
-    install_arm64_cross_gfortran
-    export FC=$FC_ARM64
-    export PATH=$FC_LOC:$PATH
-    # force a dynamic link, there may be a more elegant way of doing this.
-    rm /opt/arm64-builds/lib/*.a
+  # use /opt/arm64-builds as a prefix, because that's what the multibuild
+  # OpenBLAS pkgconfig files state
+  sudo mkdir -p /opt/arm64-builds/lib
+  sudo mkdir -p /opt/arm64-builds/include
+  sudo cp -r $basedir/lib/* /opt/arm64-builds/lib
+  sudo cp $basedir/include/* /opt/arm64-builds/include
 
-    # required so that gfortran knows where to find the linking libraries.
-    export SDKROOT=/Applications/Xcode_13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk
-    #    export SDKROOT=$(xcrun --show-sdk-path)
-    export FFLAGS=" -arch arm64 $FFLAGS"
-    export LDFLAGS=" $FC_ARM64_LDFLAGS $LDFLAGS -L/opt/arm64-builds/lib -arch arm64"
-    sudo ln -s $FC $FC_LOC/gfortran
-    echo $(type -p gfortran)
+  # we want to force a dynamic linking
+  sudo rm /opt/arm64-builds/lib/*.a
 
-    # having a test fortran program has helped in debugging problems with the
-    # compiler environment.
-    $FC $FFLAGS $PROJECT_DIR/tools/wheels/test.f $LDFLAGS
-    ls -al *.out
-    otool -L a.out
+  curl -L https://github.com/fxcoudert/gfortran-for-macOS/releases/download/12.1-monterey/gfortran-ARM-12.1-Monterey.dmg -o gfortran.dmg
+  GFORTRAN_SHA256=$(shasum -a 256 gfortran.dmg)
+  KNOWN_SHA256="e2e32f491303a00092921baebac7ffb7ae98de4ca82ebbe9e6a866dd8501acdf  gfortran.dmg"
+
+  if [ "$GFORTRAN_SHA256" != "$KNOWN_SHA256" ]; then
+      echo sha256 mismatch
+      exit 1
+  fi
+
+  hdiutil attach -mountpoint /Volumes/gfortran gfortran.dmg
+  sudo installer -pkg /Volumes/gfortran/gfortran.pkg -target /
+  # required so that gfortran knows where to find the linking libraries.
+  # export SDKROOT=/Applications/Xcode_13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk
+  # export SDKROOT=$(xcrun --show-sdk-path)
+  type -p gfortran
 fi


### PR DESCRIPTION
Is the same in content as #17086. However, I screwed up my local and remote branches for `andyfaff/scipy/cirrus2` in git, and I didn't know how to work with with my PR branch anymore. So I'm making the PR again, sorry for the noise.

This PR adds to #17029 by transferring the cross-compile for `macosx_arm64` from Github Actions to a native build+test in cirrus-ci. (but only for cp39, cp310, cp311. cp38 is still cross-compiled on Github Actions)

This PR ensures that the the `macosx_arm64` wheels undergo the scipy.test() suite (apart from cp38). The PR also fixes the certificate problem with cp311