### PR TITLE
ENH: stats.Covariance: specifying covariance matrix by its eigendecomposition

### DIFF
--- a/scipy/stats/_covariance.py
+++ b/scipy/stats/_covariance.py
@@ -126,13 +126,13 @@ class Covariance:
         return CovViaPrecision(precision, covariance)
 
     @staticmethod
-    def from_cholesky(L):
+    def from_cholesky(cholesky):
         r"""
         Representation of a covariance provided via the (lower) Cholesky factor
 
         Parameters
         ----------
-        L : array_like
+        cholesky : array_like
             The lower triangular Cholesky factor of the covariance matrix.
 
         Notes
@@ -149,7 +149,7 @@ class Covariance:
         covariance matrix.
 
         """
-        return CovViaCholesky(L)
+        return CovViaCholesky(cholesky)
 
     @staticmethod
     def from_eigendecomposition(eigendecomposition):
@@ -388,8 +388,8 @@ class CovViaDiagonal(Covariance):
 
 class CovViaCholesky(Covariance):
 
-    def __init__(self, L):
-        L = self._validate_matrix(L, 'L')
+    def __init__(self, cholesky):
+        L = self._validate_matrix(cholesky, 'cholesky')
 
         self._factor = L
         self._log_pdet = 2*np.log(np.diag(self._factor)).sum(axis=-1)

--- a/scipy/stats/_covariance.py
+++ b/scipy/stats/_covariance.py
@@ -103,20 +103,22 @@ class Covariance:
         >>> A = np.diag(rng.random(n))
         >>> x = rng.random(size=n)
 
-        Extract the diagonal from ``A`` and create the ``Covariance`` object.
+        Extract the diagonal from ``A`` and create the `Covariance` object.
 
         >>> d = np.diag(A)
         >>> cov = stats.Covariance.from_diagonal(d)
 
-        Compare the functionality of the ``Covariance`` object against a
+        Compare the functionality of the `Covariance` object against a
         reference implementations.
 
         >>> res = cov.whiten(x)
         >>> ref = np.diag(d**-0.5) @ x
-        >>> np.testing.assert_allclose(res, ref)
+        >>> np.allclose(res, ref)
+        True
         >>> res = cov.log_pdet
         >>> ref = np.linalg.slogdet(A)[-1]
-        >>> np.testing.assert_allclose(res, ref)
+        >>> np.allclose(res, ref)
+        True
 
         """
         return CovViaDiagonal(diagonal)
@@ -165,19 +167,21 @@ class Covariance:
         >>> P = P @ P.T  # a precision matrix must be positive definite
         >>> x = rng.random(size=n)
 
-        Create the ``Covariance`` object.
+        Create the `Covariance` object.
 
         >>> cov = stats.Covariance.from_precision(P)
 
-        Compare the functionality of the ``Covariance`` object against
+        Compare the functionality of the `Covariance` object against
         reference implementations.
 
         >>> res = cov.whiten(x)
         >>> ref = x @ np.linalg.cholesky(P)
-        >>> np.testing.assert_allclose(res, ref)
+        >>> np.allclose(res, ref)
+        True
         >>> res = cov.log_pdet
         >>> ref = -np.linalg.slogdet(P)[-1]
-        >>> np.testing.assert_allclose(res, ref)
+        >>> np.allclose(res, ref)
+        True
 
         """
         return CovViaPrecision(precision, covariance)
@@ -219,21 +223,23 @@ class Covariance:
         >>> x = rng.random(size=n)
 
         Perform the Cholesky decomposition of ``A`` and create the
-        ``Covariance`` object.
+        `Covariance` object.
 
         >>> L = np.linalg.cholesky(A)
         >>> cov = stats.Covariance.from_cholesky(L)
 
-        Compare the functionality of the ``Covariance`` object against
+        Compare the functionality of the `Covariance` object against
         reference implementation.
 
         >>> from scipy.linalg import solve_triangular
         >>> res = cov.whiten(x)
         >>> ref = solve_triangular(L, x, lower=True)
-        >>> np.testing.assert_allclose(res, ref)
+        >>> np.allclose(res, ref)
+        True
         >>> res = cov.log_pdet
         >>> ref = np.linalg.slogdet(A)[-1]
-        >>> np.testing.assert_allclose(res, ref)
+        >>> np.allclose(res, ref)
+        True
 
         """
         return CovViaCholesky(cholesky)
@@ -283,21 +289,23 @@ class Covariance:
         >>> A = A @ A.T  # make the covariance symmetric positive definite
         >>> x = rng.random(size=n)
 
-        Perform the eigendecomposition of ``A`` and create the ``Covariance``
+        Perform the eigendecomposition of ``A`` and create the `Covariance`
         object.
 
         >>> w, v = np.linalg.eigh(A)
         >>> cov = stats.Covariance.from_eigendecomposition((w, v))
 
-        Compare the functionality of the ``Covariance`` object against
+        Compare the functionality of the `Covariance` object against
         reference implementations.
 
         >>> res = cov.whiten(x)
         >>> ref = x @ (v @ np.diag(w**-0.5))
-        >>> np.testing.assert_allclose(res, ref)
+        >>> np.allclose(res, ref)
+        True
         >>> res = cov.log_pdet
         >>> ref = np.linalg.slogdet(A)[-1]
-        >>> np.testing.assert_allclose(res, ref)
+        >>> np.allclose(res, ref)
+        True
 
         """
         return CovViaEigendecomposition(eigendecomposition)

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -53,6 +53,14 @@ class TestCovariance:
         with pytest.raises(ValueError, match=message):
             _covariance.CovViaPrecision(np.eye(3), covariance=np.eye(2))
 
+        message = "The input `diagonal` must be a one-dimensional array..."
+        with pytest.raises(ValueError, match=message):
+            _covariance.CovViaDiagonal("alpaca")
+
+        message = "The input `cholesky` must be a square, two-dimensional..."
+        with pytest.raises(ValueError, match=message):
+            _covariance.CovViaCholesky(np.ones(2))
+
         message = "The input `eigenvalues` must be a one-dimensional..."
         with pytest.raises(ValueError, match=message):
             _covariance.CovViaEigendecomposition(("alpaca", np.eye(2)))

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -44,6 +44,7 @@ def assert_close(res, ref, *args, **kwargs):
 class TestCovariance:
 
     def test_input_validation(self):
+
         message = "The input `precision` must be a square, two-dimensional..."
         with pytest.raises(ValueError, match=message):
             _covariance.CovViaPrecision(np.ones(2))
@@ -52,20 +53,33 @@ class TestCovariance:
         with pytest.raises(ValueError, match=message):
             _covariance.CovViaPrecision(np.eye(3), covariance=np.eye(2))
 
+        message = "The input `eigenvalues` must be a one-dimensional..."
+        with pytest.raises(ValueError, match=message):
+            _covariance.CovViaEigendecomposition(("alpaca", np.eye(2)))
+
+        message = "The input `eigenvectors` must be a square..."
+        with pytest.raises(ValueError, match=message):
+            _covariance.CovViaEigendecomposition((np.ones(2), "alpaca"))
+
+        message = "The shapes of `eigenvalues` and `eigenvectors` must be..."
+        with pytest.raises(ValueError, match=message):
+            _covariance.CovViaEigendecomposition(([1, 2, 3], np.eye(2)))
+
     _covariance_preprocessing = {"Diagonal": np.diag,
                                  "Precision": np.linalg.inv,
                                  "Cholesky": np.linalg.cholesky,
+                                 "Eigendecomposition": np.linalg.eigh,
                                  "PSD": lambda x:
                                      _PSD(x, allow_singular=True)}
     _all_covariance_types = np.array(list(_covariance_preprocessing))
     _matrices = {"diagonal full rank": np.diag([1, 2, 3]),
                  "general full rank": [[5, 1, 3], [1, 6, 4], [3, 4, 7]],
-                 "diagonal rank-deficient": np.diag([1, 0, 3]),
-                 "general rank-deficient": [[5, -1, 0], [-1, 5, 0], [0, 0, 0]]}
+                 "diagonal singular": np.diag([1, 0, 3]),
+                 "general singular": [[5, -1, 0], [-1, 5, 0], [0, 0, 0]]}
     _cov_types = {"diagonal full rank": _all_covariance_types,
                   "general full rank": _all_covariance_types[1:],
-                  "diagonal rank-deficient": _all_covariance_types[[0, -1]],
-                  "general rank-deficient": _all_covariance_types[[-1]]}
+                  "diagonal singular": _all_covariance_types[[0, -2, -1]],
+                  "general singular": _all_covariance_types[-2:]}
 
     @pytest.mark.parametrize("cov_type_name", _all_covariance_types[:-1])
     def test_factories(self, cov_type_name):


### PR DESCRIPTION
#### Reference issue
Followup to gh-16002
Addresses part of gh-15675

#### What does this implement/fix?
gh-16002 added the ability to specify a covariance matrix via its inverse. 
This PR adds the ability to specify a diagonal covariance matrix via its eigendecomposition.

#### Additional information
It might make sense to take a look at the three commits separately.
* The first adds the eigendecomposition functionality
* The second adds tests that I forgot to add in previous PRs
* The third adds docstring examples I should have added in previous PRs

I can move the second and third commits to a separate PR if desired.
