### PR TITLE
DOC: replace `set_tight_layout` with `set_layout_engine` in example

### DIFF
--- a/scipy/ndimage/_interpolation.py
+++ b/scipy/ndimage/_interpolation.py
@@ -877,7 +877,7 @@ def rotate(input, angle, axes=(1, 0), reshape=True, output=None, order=3,
     >>> ax2.set_axis_off()
     >>> ax3.imshow(full_img_45, cmap='gray')
     >>> ax3.set_axis_off()
-    >>> fig.set_tight_layout(True)
+    >>> fig.set_layout_engine('tight')
     >>> plt.show()
     >>> print(img.shape)
     (512, 512)


### PR DESCRIPTION
There's a PendingDeprecationWarning for this introduced in Matplotlib 3.6 (released 16 Sep 2022). It should be fine to depend on latest Matplotlib in this one example.

[skip azp] [skip actions]