### PR TITLE
MAINT: interpolate: remove duplicated FITPACK interface `spalde`

### DIFF
--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -462,10 +462,7 @@ class UnivariateSpline:
         array([2.25, 3.0, 2.0, 0])
 
         """
-        d, ier = dfitpack.spalde(*(self._eval_args+(x,)))
-        if not ier == 0:
-            raise ValueError("Error code returned by spalde: %s" % ier)
-        return d
+        return _fitpack_impl.spalde(x, self._eval_args)
 
     def roots(self):
         """ Return the zeros of the spline.

--- a/scipy/interpolate/_fitpack_impl.py
+++ b/scipy/interpolate/_fitpack_impl.py
@@ -776,7 +776,7 @@ def spalde(x, tck):
         x = atleast_1d(x)
         if len(x) > 1:
             return list(map(lambda x, tck=tck: spalde(x, tck), x))
-        d, ier = _fitpack._spalde(t, c, k, x[0])
+        d, ier = dfitpack.spalde(t, c, k, x[0])
         if ier == 0:
             return d
         if ier == 10:

--- a/scipy/interpolate/_fitpack_impl.py
+++ b/scipy/interpolate/_fitpack_impl.py
@@ -776,7 +776,7 @@ def spalde(x, tck):
         x = atleast_1d(x)
         if len(x) > 1:
             return list(map(lambda x, tck=tck: spalde(x, tck), x))
-        d, ier = dfitpack.spalde(t, c, k, x[0])
+        d, ier = dfitpack.spalde(t, c, k+1, x[0])
         if ier == 0:
             return d
         if ier == 10:

--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -82,7 +82,6 @@ static PyObject *fitpack_error;
 	#else
 		#define CURFIT CURFIT_
 		#define PERCUR PERCUR_
-		#define SPALDE SPALDE_
 		#define SPLDER SPLDER_
 		#define SPLEV  SPLEV_
 		#define SPLINT SPLINT_
@@ -97,7 +96,6 @@ static PyObject *fitpack_error;
 	#if defined(NO_APPEND_FORTRAN)
 		#define CURFIT curfit
 		#define PERCUR percur
-		#define SPALDE spalde
 		#define SPLDER splder
 		#define SPLEV splev
 		#define SPLINT splint
@@ -110,7 +108,6 @@ static PyObject *fitpack_error;
 	#else
 		#define CURFIT curfit_
 		#define PERCUR percur_
-		#define SPALDE spalde_
 		#define SPLDER splder_
 		#define SPLEV splev_
 		#define SPLINT splint_
@@ -129,7 +126,6 @@ void CURFIT(F_INT*,F_INT*,double*,double*,double*,double*,
 void PERCUR(F_INT*,F_INT*,double*,double*,double*,F_INT*,
         double*,F_INT*,F_INT*,double*,double*,double*,
         double*,F_INT*,F_INT*,F_INT*);
-void SPALDE(double*,F_INT*,double*,F_INT*,double*,double*,F_INT*);
 void SPLDER(double*,F_INT*,double*,F_INT*,F_INT*,double*,
         double*,F_INT*,F_INT*,double*,F_INT*);
 void SPLEV(double*,F_INT*,double*,F_INT*,double*,double*,F_INT*,F_INT*,F_INT*);

--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -63,7 +63,6 @@ static PyObject *fitpack_error;
 /*  module_methods:
  * {"_curfit", fitpack_curfit, METH_VARARGS, doc_curfit},
  * {"_spl_", fitpack_spl_, METH_VARARGS, doc_spl_},
- * {"_spalde", fitpack_spalde, METH_VARARGS, doc_spalde},
  * {"_parcur", fitpack_parcur, METH_VARARGS, doc_parcur},
  * {"_surfit", fitpack_surfit, METH_VARARGS, doc_surfit},
  * {"_bispev", fitpack_bispev, METH_VARARGS, doc_bispev},
@@ -718,45 +717,6 @@ fail:
     return NULL;
 }
 
-static char doc_spalde[] = " [d,ier] = _spalde(t,c,k,x)";
-static PyObject *
-fitpack_spalde(PyObject *dummy, PyObject *args)
-{
-    F_INT n, k, ier, k1;
-    npy_intp dims[1];
-    double *t, *c, *d = NULL, x;
-    PyArrayObject *ap_t = NULL, *ap_c = NULL, *ap_d = NULL;
-    PyObject *t_py = NULL, *c_py = NULL;
-
-    if (!PyArg_ParseTuple(args, ("OO" F_INT_PYFMT "d"),
-                          &t_py,&c_py,&k,&x)) {
-        return NULL;
-    }
-    ap_t = (PyArrayObject *)PyArray_ContiguousFromObject(t_py, NPY_DOUBLE, 0, 1);
-    ap_c = (PyArrayObject *)PyArray_ContiguousFromObject(c_py, NPY_DOUBLE, 0, 1);
-    if ((ap_t == NULL || ap_c == NULL)) {
-        goto fail;
-    }
-    t = (double *)PyArray_DATA(ap_t);
-    c = (double *)PyArray_DATA(ap_c);
-    n = PyArray_DIMS(ap_t)[0];
-    k1 = k + 1;
-    dims[0] = k1;
-    ap_d = (PyArrayObject *)PyArray_SimpleNew(1, dims, NPY_DOUBLE);
-    if (ap_d == NULL) {
-        goto fail;
-    }
-    d = (double *)PyArray_DATA(ap_d);
-    SPALDE(t, &n, c, &k1, &x, d, &ier);
-    Py_DECREF(ap_c);
-    Py_DECREF(ap_t);
-    return Py_BuildValue(("N" F_INT_PYFMT), PyArray_Return(ap_d), ier);
-
-fail:
-    Py_XDECREF(ap_c);
-    Py_XDECREF(ap_t);
-    return NULL;
-}
 
 static char doc_insert[] = " [tt,cc,ier] = _insert(iopt,t,c,k,x,m)";
 static PyObject *
@@ -1419,9 +1379,6 @@ static struct PyMethodDef fitpack_module_methods[] = {
 {"_spl_",
     fitpack_spl_,
     METH_VARARGS, doc_spl_},
-{"_spalde",
-    fitpack_spalde,
-    METH_VARARGS, doc_spalde},
 {"_parcur",
     fitpack_parcur,
     METH_VARARGS, doc_parcur},

--- a/scipy/interpolate/src/fitpack.pyf
+++ b/scipy/interpolate/src/fitpack.pyf
@@ -170,17 +170,13 @@ static F_INT calc_regrid_lwrk(F_INT mx, F_INT my, F_INT kx, F_INT ky,
 
      subroutine spalde(t,n,c,k,x,d,ier)
        ! d,ier = spalde(t,c,k,x)
-
        threadsafe
-       callprotoargument double*,F_INT*,double*,F_INT*,double*,double*,F_INT*
-       callstatement {int k1=k+1; (*f2py_func)(t,&n,c,&k1,&x,d,&ier); }
-
        real*8 dimension(n) :: t
        integer intent(hide),depend(t) :: n=len(t)
        real*8 dimension(n),depend(n),check(len(c)==n) :: c
        integer intent(in) :: k
        real*8 intent(in) :: x
-       real*8 dimension(k+1),intent(out),depend(k) :: d
+       real*8 dimension(k),intent(out),depend(k) :: d
        integer intent(out) :: ier
      end subroutine spalde
 

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -67,6 +67,13 @@ class TestUnivariateSpline:
         spl = UnivariateSpline(x, y, k=3)
         assert_almost_equal(spl.roots()[0], 1.050290639101332)
 
+    def test_derivatives(self):
+        x = [1, 3, 5, 7, 9]
+        y = [0, 4, 9, 12, 21]
+        spl = UnivariateSpline(x, y, k=3)
+        assert_almost_equal(spl.derivatives(3.5),
+                            [5.5152902, 1.7146577, -0.1830357, 0.3125])
+
     def test_resize_regression(self):
         """Regression test for #1375."""
         x = [-1., -0.65016502, -0.58856235, -0.26903553, -0.17370892,


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
A part of https://github.com/scipy/scipy/issues/16729
Ref: https://github.com/scipy/scipy/pull/17038, #17091

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR removed duplication of FITPACK interface `spalde` following the same strategy of https://github.com/scipy/scipy/pull/17038.
Also, I added a test for `UnivariateSpline.derivatives` because it is missed.

#### Additional information
<!--Any additional information you think is important.-->
