### PR TITLE
MAINT: remove certifi py3.11 warning filter

### DIFF
--- a/scipy/datasets/_fetchers.py
+++ b/scipy/datasets/_fetchers.py
@@ -3,11 +3,7 @@ from ._registry import registry, registry_urls
 import warnings
 
 try:
-    # https://github.com/scipy/scipy/pull/15607#issuecomment-1176457275
-    # TODO: Remove warning filter after next certifi release
-    with warnings.catch_warnings():
-        warnings.filterwarnings('ignore', category=DeprecationWarning)
-        import pooch
+    import pooch
 except ImportError:
     pooch = None
     data_fetcher = None

--- a/scipy/datasets/_fetchers.py
+++ b/scipy/datasets/_fetchers.py
@@ -1,6 +1,5 @@
 from numpy import array, frombuffer, load
 from ._registry import registry, registry_urls
-import warnings
 
 try:
     import pooch

--- a/scipy/datasets/tests/test_data.py
+++ b/scipy/datasets/tests/test_data.py
@@ -6,11 +6,7 @@ import os
 import pytest
 
 try:
-    # https://github.com/scipy/scipy/pull/15607#issuecomment-1176457275
-    # TODO: Remove warning filter after next certifi release
-    with suppress_warnings() as sup:
-        sup.filter(category=DeprecationWarning)
-        import pooch
+    import pooch
 except ImportError:
     raise ImportError("Missing optional dependency 'pooch' required "
                       "for scipy.datasets module. Please use pip or "

--- a/scipy/datasets/tests/test_data.py
+++ b/scipy/datasets/tests/test_data.py
@@ -1,7 +1,7 @@
 from scipy.datasets._registry import registry
 from scipy.datasets._fetchers import fetch_data, data_fetcher
 from scipy.datasets import ascent, face, electrocardiogram
-from numpy.testing import assert_equal, assert_almost_equal, suppress_warnings
+from numpy.testing import assert_equal, assert_almost_equal
 import os
 import pytest
 


### PR DESCRIPTION
#### Reference issue
#16983

#### What does this implement/fix?
`certifi` made a [release](https://pypi.org/project/certifi/#history) recently, which includes a fix for the py3.11 deprecation warning that popped up before (https://github.com/certifi/python-certifi/commit/47fb7ab715965684e035292d2ad3386aabdc4d25). `requests` (pooch dependency) should now pick up the latest version of `certifi`. Thus we should be able to remove these warning filters on the `pooch` import.
