### PR TITLE
ENH/MAINT: `qmc.LatinHypercube`: deprecate centered with scramble

### DIFF
--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -711,8 +711,8 @@ class QMCEngine(ABC):
         optimization: Optional[Literal["random-cd", "lloyd"]] = None,
         seed: SeedType = None
     ) -> None:
-        if not np.issubdtype(type(d), np.integer):
-            raise ValueError('d must be an integer value')
+        if not np.issubdtype(type(d), np.integer) or d < 0:
+            raise ValueError('d must be a positive integer value')
 
         self.d = d
         self.rng = check_random_state(seed)

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -1102,9 +1102,9 @@ class LatinHypercube(QMCEngine):
     distinct rows occur the same number of times. The elements of :math:`A`
     are in the set :math:`\{0, 1, ..., p-1\}`, also called symbols.
     The constraint that :math:`p` must be a prime number is to allow modular
-    arithmetic. The strength add some symmetry in sub-projections to a sample.
-    With strength 2, samples are symmetric along the diagonals of
-    2D sub-projections. Which may be undesirable, but on the other hand, the
+    arithmetic. Increasing strength adds some symmetry to the sub-projections
+    of a sample. With strength 2, samples are symmetric along the diagonals of
+    2D sub-projections. This may be undesirable, but on the other hand, the
     sample dispersion is improved.
 
     Strength 1 (plain LHS) brings an advantage over strength 0 (MC) and

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -712,7 +712,7 @@ class QMCEngine(ABC):
         seed: SeedType = None
     ) -> None:
         if not np.issubdtype(type(d), np.integer) or d < 0:
-            raise ValueError('d must be a positive integer value')
+            raise ValueError('d must be a non-negative integer value')
 
         self.d = d
         self.rng = check_random_state(seed)
@@ -1034,19 +1034,20 @@ class LatinHypercube(QMCEngine):
     d : int
         Dimension of the parameter space.
     centered : bool, optional
-        Center the point within the multi-dimensional grid. Default is False.
+        Center samples within a multi-dimensional grid. Default is False.
 
         .. deprecated:: 1.10.0
             `centered` is deprecated as of SciPy 1.10.0 and will be removed in
-            1.11.0. Use `scramble` instead. ``centered=True`` corresponds to
+            1.12.0. Use `scramble` instead. ``centered=True`` corresponds to
             ``scramble=False``.
 
     scramble : bool, optional
-        When False, center the point within the multi-dimensional grid.
+        When False, center samples within a multi-dimensional grid.
+        Otherwise, samples are randomly placed within the grid.
 
         .. note::
-            Not scrambling will not make the sample constant. For that,
-            use the `seed` parameter.
+            Setting ``scramble=False`` does not ensure deterministic output.
+            For that, use the `seed` parameter.
 
         Default is True.
 
@@ -1101,6 +1102,8 @@ class LatinHypercube(QMCEngine):
     are in the set :math:`\{0, 1, ..., p-1\}`, also called symbols.
     The constraint that :math:`p` must be a prime number is to allow modular
     arithmetic. The strength add some symettry in sub-projections to a sample.
+    With strength 2, samples are symettric along the diagonals of
+    2D sub-projections.
 
     Strength 1 (plain LHS) brings an advantage over strength 0 (MC) and
     strength 2 is a useful increment over strength 1. Going to strength 3 is
@@ -1199,10 +1202,9 @@ class LatinHypercube(QMCEngine):
         if centered:
             scramble = False
             warnings.warn(
-                "'centered' is deprecated and will be removed in SciPy 1.11."
+                "'centered' is deprecated and will be removed in SciPy 1.12."
                 " Please use 'scramble' instead. 'centered=True' corresponds"
-                " to 'scramble=False'. Hence the value of 'scramble' was"
-                " changed to False.",
+                " to 'scramble=False'.",
                 stacklevel=2
             )
 

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -1035,6 +1035,23 @@ class LatinHypercube(QMCEngine):
         Dimension of the parameter space.
     centered : bool, optional
         Center the point within the multi-dimensional grid. Default is False.
+
+        .. deprecated:: 1.10.0
+            `centered` is deprecated as of SciPy 1.10.0 and will be removed in
+            1.11.0. Use `scramble` instead. ``centered=True`` corresponds to
+            ``scramble=False``.
+
+    scramble : bool, optional
+        When False, center the point within the multi-dimensional grid.
+
+        .. note::
+            Not scrambling will not make the sample constant. For that,
+            use the `seed` parameter.
+
+        Default is True.
+
+        .. versionadded:: 1.10.0
+
     optimization : {None, "random-cd", "lloyd"}, optional
         Whether to use an optimization scheme to improve the quality after
         sampling. Note that this is a post-processing step that does not
@@ -1083,7 +1100,7 @@ class LatinHypercube(QMCEngine):
     distinct rows occur the same number of times. The elements of :math:`A`
     are in the set :math:`\{0, 1, ..., p-1\}`, also called symbols.
     The constraint that :math:`p` must be a prime number is to allow modular
-    arithmetic.
+    arithmetic. The strength add some symettry in sub-projections to a sample.
 
     Strength 1 (plain LHS) brings an advantage over strength 0 (MC) and
     strength 2 is a useful increment over strength 1. Going to strength 3 is
@@ -1174,15 +1191,26 @@ class LatinHypercube(QMCEngine):
 
     def __init__(
         self, d: IntNumber, *, centered: bool = False,
+        scramble: bool = True,
         strength: int = 1,
         optimization: Optional[Literal["random-cd", "lloyd"]] = None,
         seed: SeedType = None
     ) -> None:
+        if centered:
+            scramble = False
+            warnings.warn(
+                "'centered' is deprecated and will be removed in SciPy 1.11."
+                " Please use 'scramble' instead. 'centered=True' corresponds"
+                " to 'scramble=False'. Hence the value of 'scramble' was"
+                " changed to False.",
+                stacklevel=2
+            )
+
         # Used in `scipy.integrate.qmc_quad`
-        self._init_quad = {'d': d, 'centered': centered, 'strength': strength,
+        self._init_quad = {'d': d, 'scramble': True, 'strength': strength,
                            'optimization': optimization}
         super().__init__(d=d, seed=seed, optimization=optimization)
-        self.centered = centered
+        self.scramble = scramble
 
         lhs_method_strength = {
             1: self._random_lhs,
@@ -1204,7 +1232,7 @@ class LatinHypercube(QMCEngine):
 
     def _random_lhs(self, n: IntNumber = 1) -> np.ndarray:
         """Base LHS algorithm."""
-        if self.centered:
+        if not self.scramble:
             samples: np.ndarray | float = 0.5
         else:
             samples = self.rng.uniform(size=(n, self.d))
@@ -1251,7 +1279,7 @@ class LatinHypercube(QMCEngine):
 
         # following is making a scrambled OA into an OA-LHS
         oa_lhs_sample = np.zeros(shape=(n_row, n_col))
-        lhs_engine = LatinHypercube(d=1, centered=self.centered, strength=1,
+        lhs_engine = LatinHypercube(d=1, scramble=self.scramble, strength=1,
                                     seed=self.rng)  # type: QMCEngine
         for j in range(n_col):
             for k in range(p):

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -1034,7 +1034,8 @@ class LatinHypercube(QMCEngine):
     d : int
         Dimension of the parameter space.
     centered : bool, optional
-        Center samples within a multi-dimensional grid. Default is False.
+        Center samples within cells of a multi-dimensional grid.
+        Default is False.
 
         .. deprecated:: 1.10.0
             `centered` is deprecated as of SciPy 1.10.0 and will be removed in
@@ -1042,8 +1043,8 @@ class LatinHypercube(QMCEngine):
             ``scramble=False``.
 
     scramble : bool, optional
-        When False, center samples within a multi-dimensional grid.
-        Otherwise, samples are randomly placed within the grid.
+        When False, center samples within cells of a multi-dimensional grid.
+        Otherwise, samples are randomly placed within cells of the grid.
 
         .. note::
             Setting ``scramble=False`` does not ensure deterministic output.
@@ -1101,9 +1102,10 @@ class LatinHypercube(QMCEngine):
     distinct rows occur the same number of times. The elements of :math:`A`
     are in the set :math:`\{0, 1, ..., p-1\}`, also called symbols.
     The constraint that :math:`p` must be a prime number is to allow modular
-    arithmetic. The strength add some symettry in sub-projections to a sample.
-    With strength 2, samples are symettric along the diagonals of
-    2D sub-projections.
+    arithmetic. The strength add some symmetry in sub-projections to a sample.
+    With strength 2, samples are symmetric along the diagonals of
+    2D sub-projections. Which may be undesirable, but on the other hand, the
+    sample dispersion is improved.
 
     Strength 1 (plain LHS) brings an advantage over strength 0 (MC) and
     strength 2 is a useful increment over strength 1. Going to strength 3 is

--- a/scipy/stats/tests/test_qmc.py
+++ b/scipy/stats/tests/test_qmc.py
@@ -399,10 +399,10 @@ def test_subclassing_QMCEngine():
 
 def test_raises():
     # input validation
-    with pytest.raises(ValueError, match=r"d must be a positive integer"):
+    with pytest.raises(ValueError, match=r"d must be a non-negative integer"):
         RandomEngine((2,))  # noqa
 
-    with pytest.raises(ValueError, match=r"d must be a positive integer"):
+    with pytest.raises(ValueError, match=r"d must be a non-negative integer"):
         RandomEngine(-1)  # noqa
 
     msg = r"'u_bounds' and 'l_bounds' must be integers"
@@ -658,12 +658,13 @@ class TestLHS(QMCEngineTests):
         # * inter-sample distance is constant in 1D sub-projections
         # * after ordering, columns are equal
         rng = np.random.default_rng(230848485337593016117637089968181108379)
-        engine = qmc.LatinHypercube(d=3, scramble=False, seed=rng)
-        for _ in range(10):
-            sample = engine.random(100)
+        d, n = 3, 100
+        engine = qmc.LatinHypercube(d=d, scramble=False, seed=rng)
+        ref = np.tile(np.linspace(0.005, 0.995, n), (d, 1)).T
+        for _ in range(5):
+            sample = engine.random(n)
             sorted_sample = np.sort(sample, axis=0)
-            mean_cols = np.mean(sorted_sample, axis=1)
-            assert_allclose(mean_cols, np.linspace(0.005, 0.995, 100))
+            assert_allclose(sorted_sample, ref)
 
     @pytest.mark.parametrize("strength", [1, 2])
     @pytest.mark.parametrize("scramble", [False, True])
@@ -721,7 +722,7 @@ class TestLHS(QMCEngineTests):
             engine.random(9)
 
         message = r"'centered' is deprecated"
-        with pytest.warns(UserWarning,  match=message):
+        with pytest.warns(UserWarning, match=message):
             qmc.LatinHypercube(1, centered=True)
 
 

--- a/scipy/stats/tests/test_qmc.py
+++ b/scipy/stats/tests/test_qmc.py
@@ -399,8 +399,11 @@ def test_subclassing_QMCEngine():
 
 def test_raises():
     # input validation
-    with pytest.raises(ValueError, match=r"d must be an integer value"):
+    with pytest.raises(ValueError, match=r"d must be a positive integer"):
         RandomEngine((2,))  # noqa
+
+    with pytest.raises(ValueError, match=r"d must be a positive integer"):
+        RandomEngine(-1)  # noqa
 
     msg = r"'u_bounds' and 'l_bounds' must be integers"
     with pytest.raises(ValueError, match=msg):


### PR DESCRIPTION
We can simplify the interface of `qmc.LatinHypercube` and make it consistent with other engines by removing the `centered` parameter and adding `scramble`. Not centering, the default, can be seen as scrambling. Which is the default for other engines. Hence there is an easy deprecation path with added consistency.

In this PR:

1. Deprecate `centered` in favour of `scramble`. Scrambling is about "adding some randomness" to a sample. As not scrambling might be interpreted as having a constant output, I added a note explaining that it's not the case.
2. Add a check for `d<0` in `QMCEngine`. We were only testing for integers
3. Add a test to specifically check centering. This was missing.
