### PR TITLE
ENH: Add `download_all` utility method & script 

### DIFF
--- a/scipy/datasets/__init__.py
+++ b/scipy/datasets/__init__.py
@@ -77,7 +77,7 @@ the internet connectivity.
 
 
 from ._fetchers import face, ascent, electrocardiogram  # noqa: E402
-from .download_all import download_all
+from ._download_all import download_all
 __all__ = ['ascent', 'electrocardiogram', 'face', 'download_all']
 
 

--- a/scipy/datasets/__init__.py
+++ b/scipy/datasets/__init__.py
@@ -5,12 +5,23 @@ Datasets (:mod:`scipy.datasets`)
 
 .. currentmodule:: scipy.datasets
 
+Dataset Methods
+=======================================
+
 .. autosummary::
    :toctree: generated/
 
    ascent
    face
    electrocardiogram
+
+Utility Methods
+=======================================
+
+.. autosummary::
+   :toctree: generated/
+
+   download_all    -- Download all the dataset files to specified path.
 
 
 Usage of Datasets
@@ -66,7 +77,8 @@ the internet connectivity.
 
 
 from ._fetchers import face, ascent, electrocardiogram  # noqa: E402
-__all__ = ['ascent', 'electrocardiogram', 'face']
+from .download_all import download_all
+__all__ = ['ascent', 'electrocardiogram', 'face', 'download_all']
 
 
 from scipy._lib._testutils import PytestTester

--- a/scipy/datasets/__init__.py
+++ b/scipy/datasets/__init__.py
@@ -6,7 +6,7 @@ Datasets (:mod:`scipy.datasets`)
 .. currentmodule:: scipy.datasets
 
 Dataset Methods
-=======================================
+===============
 
 .. autosummary::
    :toctree: generated/
@@ -16,7 +16,7 @@ Dataset Methods
    electrocardiogram
 
 Utility Methods
-=======================================
+===============
 
 .. autosummary::
    :toctree: generated/

--- a/scipy/datasets/_download_all.py
+++ b/scipy/datasets/_download_all.py
@@ -1,10 +1,10 @@
 #!python3
 """
 Platform independent script to download all the
-`scipy.dataset` module data files.
+`scipy.datasets` module data files.
 This doesn't require a full scipy build.
 
-Run: python download_all.py <download_dir>
+Run: python _download_all.py <download_dir>
 """
 
 import argparse
@@ -46,9 +46,10 @@ def download_all(path=None):
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Download SciPy dataset files.')
-    parser.add_argument("path", type=str, default=pooch.os_cache('scipy-data'),
-                        help="Directory path to download all the dataset files.")
+    parser = argparse.ArgumentParser(description='Download SciPy data files.')
+    parser.add_argument("path", type=str,
+                        default=pooch.os_cache('scipy-data'),
+                        help="Directory path to download all the data files.")
     args = parser.parse_args()
     download_all(args.path)
 

--- a/scipy/datasets/_download_all.py
+++ b/scipy/datasets/_download_all.py
@@ -1,4 +1,3 @@
-#!python3
 """
 Platform independent script to download all the
 `scipy.datasets` module data files.
@@ -29,7 +28,7 @@ def download_all(path=None):
 
     Parameters
     ----------
-    path : str
+    path : str, optional
         Directory path to download all the dataset files.
         If None, default to the system cache_dir detected by pooch.
     """
@@ -47,7 +46,7 @@ def download_all(path=None):
 
 def main():
     parser = argparse.ArgumentParser(description='Download SciPy data files.')
-    parser.add_argument("path", type=str,
+    parser.add_argument("path", nargs='?', type=str,
                         default=pooch.os_cache('scipy-data'),
                         help="Directory path to download all the data files.")
     args = parser.parse_args()

--- a/scipy/datasets/download_all.py
+++ b/scipy/datasets/download_all.py
@@ -1,0 +1,48 @@
+#!python3
+"""
+Platform independent script to download all the
+`scipy.dataset` module data files.
+This doesn't require a full scipy build.
+
+Run: python download_all.py <download_dir>
+"""
+
+import os
+import argparse
+import pooch
+
+if __package__ is None or __package__ == '':
+    # Running as python script, use absolute import
+    import _registry  # type: ignore
+else:
+    # Running as python module, use relative import
+    from . import _registry
+
+
+def download_all(path=pooch.os_cache('scipy-data')):
+    """
+    Utility method to download all the dataset files
+    for `scipy.datasets` module.
+
+    Parameters
+    ----------
+    path : str
+        Directory path to download all the dataset files.
+        Defaults to the system cache_dir detected by pooch.
+    """
+    for dataset_name, dataset_hash in _registry.registry.items():
+        pooch.retrieve(url=_registry.registry_urls[dataset_name],
+                       known_hash=dataset_hash,
+                       fname=dataset_name, path=path)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Download SciPy dataset files.')
+    parser.add_argument("path", type=str, default=os.getcwd(),
+                        help="Directory path to download all the dataset files.")
+    args = parser.parse_args()
+    download_all(args.path)
+
+
+if __name__ == "__main__":
+    main()

--- a/scipy/datasets/download_all.py
+++ b/scipy/datasets/download_all.py
@@ -8,7 +8,11 @@ Run: python download_all.py <download_dir>
 """
 
 import argparse
-import pooch
+try:
+    import pooch
+except ImportError:
+    pooch = None
+
 
 if __package__ is None or __package__ == '':
     # Running as python script, use absolute import
@@ -18,7 +22,7 @@ else:
     from . import _registry
 
 
-def download_all(path=pooch.os_cache('scipy-data')):
+def download_all(path=None):
     """
     Utility method to download all the dataset files
     for `scipy.datasets` module.
@@ -27,8 +31,14 @@ def download_all(path=pooch.os_cache('scipy-data')):
     ----------
     path : str
         Directory path to download all the dataset files.
-        Defaults to the system cache_dir detected by pooch.
+        If None, default to the system cache_dir detected by pooch.
     """
+    if pooch is None:
+        raise ImportError("Missing optional dependency 'pooch' required "
+                          "for scipy.datasets module. Please use pip or "
+                          "conda to install 'pooch'.")
+    if path is None:
+        path = pooch.os_cache('scipy-data')
     for dataset_name, dataset_hash in _registry.registry.items():
         pooch.retrieve(url=_registry.registry_urls[dataset_name],
                        known_hash=dataset_hash,

--- a/scipy/datasets/download_all.py
+++ b/scipy/datasets/download_all.py
@@ -7,7 +7,6 @@ This doesn't require a full scipy build.
 Run: python download_all.py <download_dir>
 """
 
-import os
 import argparse
 import pooch
 
@@ -38,7 +37,7 @@ def download_all(path=pooch.os_cache('scipy-data')):
 
 def main():
     parser = argparse.ArgumentParser(description='Download SciPy dataset files.')
-    parser.add_argument("path", type=str, default=os.getcwd(),
+    parser.add_argument("path", type=str, default=pooch.os_cache('scipy-data'),
                         help="Directory path to download all the dataset files.")
     args = parser.parse_args()
     download_all(args.path)

--- a/scipy/datasets/meson.build
+++ b/scipy/datasets/meson.build
@@ -2,7 +2,7 @@ python_sources = [
   '__init__.py',
   '_fetchers.py',
   '_registry.py',
-  'download_all.py'
+  '_download_all.py'
 ]
 
 py3.install_sources(

--- a/scipy/datasets/meson.build
+++ b/scipy/datasets/meson.build
@@ -2,6 +2,7 @@ python_sources = [
   '__init__.py',
   '_fetchers.py',
   '_registry.py',
+  'download_all.py'
 ]
 
 py3.install_sources(

--- a/scipy/datasets/tests/test_data.py
+++ b/scipy/datasets/tests/test_data.py
@@ -1,6 +1,6 @@
 from scipy.datasets._registry import registry
-from scipy.datasets._fetchers import fetch_data, data_fetcher
-from scipy.datasets import ascent, face, electrocardiogram
+from scipy.datasets._fetchers import data_fetcher
+from scipy.datasets import ascent, face, electrocardiogram, download_all
 from numpy.testing import assert_equal, assert_almost_equal
 import os
 import pytest
@@ -30,8 +30,7 @@ class TestDatasets:
         # This fixture requires INTERNET CONNECTION
 
         # test_setup phase
-        for dataset in registry:
-            fetch_data(dataset)
+        download_all()
 
         yield
 


### PR DESCRIPTION
#### Reference issue
#16983

#### What does this implement/fix?
`_download_all.py` can be run as a standalone script to download all the data files required by `scipy.datasets` at once without the need to build SciPy first. This could be useful; for example, SciPy Debian, Fedora etc. packages may have build time constraints for downloading from external links.

As per the discussion with Ralf earlier today, the steps might look something like this:
```
git clone ...
git submodule update ...
# Download dataset files
python _download_all.py 

...continue the build process
```
Although I couldn't find the exact SciPy Debian build script in https://salsa.debian.org/python-team/packages/scipy, where something like this should be placed, it would be great to hear @drew-parsons, your thoughts and if could help us review this. Thanks!

Besides, `download_all` can also be used as a utility method within the `scipy.datasets` module if required.
```python
from scipy import datasets

# Cache all datasets
datasets.download_all()

# Now work without an internet connection
```

cc @rgommers

### Additional Information

Sharing [Network access by Debian package builds](https://lwn.net/Articles/700465/) by Nathan Willis, talks about some constraints when using the internet at build time in Debian packages for people who didn't know about this strict rule.
I found it a nice read since I recently learnt about the constraint when working on `scipy.datasets` module.
