### PR TITLE
MAINT: stats.rv_discrete.pmf: should be zero at non-integer argument

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -3342,9 +3342,9 @@ class rv_discrete(rv_generic):
         k = asarray((k-loc))
         cond0 = self._argcheck(*args)
         cond1 = (k >= _a) & (k <= _b)
-        cond = cond0 & cond1
         if not isinstance(self, rv_sample):
             cond1 = cond1 & self._nonzero(k, *args)
+        cond = cond0 & cond1
         output = zeros(shape(cond), 'd')
         place(output, (1-cond0) + np.isnan(k), self.badvalue)
         if np.any(cond):

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -210,9 +210,9 @@ def check_pmf_cdf(distfn, arg, distname):
     npt.assert_allclose(cdfs - cdfs[0], pmfs_cum - pmfs_cum[0],
                         atol=atol, rtol=rtol)
 
-    # also check that pmf at non-integral args is zero
+    # also check that pmf at non-integral k is zero
     k = np.asarray(index)
-    k_shifted = index[:-1] + np.diff(index)/2
+    k_shifted = k[:-1] + np.diff(k)/2
     npt.assert_equal(distfn.pmf(k_shifted, *arg), 0)
 
     # better check frozen distributions, and also when loc != 0

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -210,6 +210,17 @@ def check_pmf_cdf(distfn, arg, distname):
     npt.assert_allclose(cdfs - cdfs[0], pmfs_cum - pmfs_cum[0],
                         atol=atol, rtol=rtol)
 
+    # also check that pmf at non-integral args is zero
+    k = np.asarray(index)
+    k_shifted = index[:-1] + np.diff(index)/2
+    npt.assert_equal(distfn.pmf(k_shifted, *arg), 0)
+
+    # better check frozen distributions, and also when loc != 0
+    loc = 0.5
+    dist = distfn(loc=loc, *arg)
+    npt.assert_allclose(dist.pmf(k[1:] + loc), np.diff(dist.cdf(k + loc)))
+    npt.assert_equal(dist.pmf(k_shifted + loc), 0)
+
 
 def check_moment_frozen(distfn, arg, m, k):
     npt.assert_allclose(distfn(*arg).moment(k), m,

--- a/scipy/stats/tests/test_discrete_distns.py
+++ b/scipy/stats/tests/test_discrete_distns.py
@@ -551,3 +551,15 @@ def test_nbinom_11465(mu, q, expected):
     # options(digits=16)
     # pnbinom(mu=10, size=20, q=120, log.p=TRUE)
     assert_allclose(nbinom.logcdf(q, n, p), expected)
+
+
+def test_gh_17146():
+    # Check that discrete distributions return PMF of zero at non-integral x.
+    # See gh-17146.
+    x = np.linspace(0, 1, 11)
+    p = 0.8
+    pmf = bernoulli(p).pmf(x)
+    i = (x % 1 == 0)
+    assert_allclose(pmf[-1], p)
+    assert_allclose(pmf[0], 1-p)
+    assert_equal(pmf[~i], 0)


### PR DESCRIPTION
#### Reference issue
gh-17146
gh-15932

#### What does this implement/fix?
There was a report in gh-17146 that `rv_discrete.pmf` does not return 0 at non-integer arguments as it used to. This was broken because a line in gh-15932 was out of the intended order. This fixes the order and adds tests.