### PR TITLE
MAINT: better handling of mode/center outside of the domain in stats.sampling

### DIFF
--- a/scipy/stats/_unuran/unuran_wrapper.pyx.templ
+++ b/scipy/stats/_unuran/unuran_wrapper.pyx.templ
@@ -882,14 +882,14 @@ cdef class TransformedDensityRejection(Method):
                 raise UNURANError(self._messages.get())
             _pack_distr(self.distr, self.callbacks)
 
+            if domain is not None:
+                self._check_errorcode(unur_distr_cont_set_domain(self.distr, domain[0],
+                                                                 domain[1]))
+
             if mode is not None:
                 self._check_errorcode(unur_distr_cont_set_mode(self.distr, mode))
             if center is not None:
                 self._check_errorcode(unur_distr_cont_set_center(self.distr, center))
-
-            if domain is not None:
-                self._check_errorcode(unur_distr_cont_set_domain(self.distr, domain[0],
-                                                                 domain[1]))
 
             self.par = unur_tdr_new(self.distr)
             if self.par == NULL:
@@ -1172,12 +1172,13 @@ cdef class SimpleRatioUniforms(Method):
                 raise UNURANError(self._messages.get())
             _pack_distr(self.distr, self.callbacks)
 
-            if mode is not None:
-                self._check_errorcode(unur_distr_cont_set_mode(self.distr, mode))
-
             if domain is not None:
                 self._check_errorcode(unur_distr_cont_set_domain(self.distr, domain[0],
                                                                  domain[1]))
+
+            if mode is not None:
+                self._check_errorcode(unur_distr_cont_set_mode(self.distr, mode))
+
             self._check_errorcode(unur_distr_cont_set_pdfarea(self.distr, pdf_area))
 
             self.par = unur_srou_new(self.distr)
@@ -1445,14 +1446,14 @@ cdef class NumericalInversePolynomial(Method):
                 raise UNURANError(self._messages.get())
             _pack_distr(self.distr, self.callbacks)
 
+            if domain is not None:
+                self._check_errorcode(unur_distr_cont_set_domain(self.distr, domain[0],
+                                                                 domain[1]))
+
             if mode is not None:
                 self._check_errorcode(unur_distr_cont_set_mode(self.distr, mode))
             if center is not None:
                 self._check_errorcode(unur_distr_cont_set_center(self.distr, center))
-
-            if domain is not None:
-                self._check_errorcode(unur_distr_cont_set_domain(self.distr, domain[0],
-                                                                 domain[1]))
 
             self.par = unur_pinv_new(self.distr)
             if self.par == NULL:

--- a/scipy/stats/tests/test_sampling.py
+++ b/scipy/stats/tests/test_sampling.py
@@ -319,6 +319,30 @@ def check_discr_samples(rng, pv, mv_ex):
     assert pval > 0.1
 
 
+def test_warning_center_not_in_domain():
+    # UNURAN will warn if the center provided or the one computed w/o the
+    # domain is outside of the domain
+    msg = "102 : center moved into domain of distribution"
+    with pytest.warns(RuntimeWarning, match=msg):
+        gen = NumericalInversePolynomial(StandardNormal(),
+                                         center=0, domain=(3, 5))
+    with pytest.warns(RuntimeWarning, match=msg):
+        gen = NumericalInversePolynomial(StandardNormal(), domain=(3, 5))
+
+@pytest.mark.parametrize('method', ["SimpleRatioUniforms",
+                                    "NumericalInversePolynomial",
+                                    "TransformedDensityRejection"])
+def test_error_mode_not_in_domain(method):
+    # UNURAN raises an error if the mode is not in the domain
+    # the behavior is different compared to the case that center is not in the
+    # domain. mode is supposed to be the exact value, center can be an
+    # approximate value
+    Method = getattr(stats.sampling, method)
+    msg = "17 : mode not in domain"
+    with pytest.raises(UNURANError, match=msg):
+        gen = Method(StandardNormal(), mode=0, domain=(3, 5))
+
+
 @pytest.mark.parametrize('method', ["NumericalInverseHermite",
                                     "NumericalInversePolynomial"])
 class TestQRVS:

--- a/scipy/stats/tests/test_sampling.py
+++ b/scipy/stats/tests/test_sampling.py
@@ -324,10 +324,10 @@ def test_warning_center_not_in_domain():
     # domain is outside of the domain
     msg = "102 : center moved into domain of distribution"
     with pytest.warns(RuntimeWarning, match=msg):
-        gen = NumericalInversePolynomial(StandardNormal(),
-                                         center=0, domain=(3, 5))
+        NumericalInversePolynomial(StandardNormal(), center=0, domain=(3, 5))
     with pytest.warns(RuntimeWarning, match=msg):
-        gen = NumericalInversePolynomial(StandardNormal(), domain=(3, 5))
+        NumericalInversePolynomial(StandardNormal(), domain=(3, 5))
+
 
 @pytest.mark.parametrize('method', ["SimpleRatioUniforms",
                                     "NumericalInversePolynomial",
@@ -340,7 +340,7 @@ def test_error_mode_not_in_domain(method):
     Method = getattr(stats.sampling, method)
     msg = "17 : mode not in domain"
     with pytest.raises(UNURANError, match=msg):
-        gen = Method(StandardNormal(), mode=0, domain=(3, 5))
+        Method(StandardNormal(), mode=0, domain=(3, 5))
 
 
 @pytest.mark.parametrize('method', ["NumericalInverseHermite",


### PR DESCRIPTION

#### Reference issue
N/A

#### What does this implement/fix?
If we set up the distribution object to be used by UNU.RAN, one first needs to set the domain, then mode/center.
- If the center is not in the domain, it is re-computed by UNU.RAN and a warning is raised.
- If the mode is not in the domain, an error is raised (mode has to be exact, it is not "guessed" like center)

In main, there is no warning/error, so I assume that mode/center are simply ignored if the domain is set.

#### Additional information
--
