### PR TITLE
REL: Prep for SciPy 1.9.3

### DIFF
--- a/doc/release/1.9.3-notes.rst
+++ b/doc/release/1.9.3-notes.rst
@@ -1,0 +1,19 @@
+==========================
+SciPy 1.9.3 Release Notes
+==========================
+
+.. contents::
+
+SciPy 1.9.3 is a bug-fix release with no new features
+compared to 1.9.2.
+
+Authors
+=======
+
+
+Issues closed for 1.9.3
+-----------------------
+
+
+Pull requests for 1.9.3
+-----------------------

--- a/doc/source/release.1.9.3.rst
+++ b/doc/source/release.1.9.3.rst
@@ -1,0 +1,1 @@
+.. include:: ../release/1.9.3-notes.rst

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -8,6 +8,7 @@ see the `commit logs <https://github.com/scipy/scipy/commits/>`_.
 .. toctree::
    :maxdepth: 1
 
+   release.1.9.3
    release.1.9.2
    release.1.9.1
    release.1.9.0

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@ project(
   # Note that the git commit hash cannot be added dynamically here (it is added
   # in the dynamically generated and installed `scipy/version.py` though - see
   # tools/version_utils.py
-  version: '1.9.2',
+  version: '1.9.3',
   license: 'BSD-3',
   meson_version: '>= 0.62.2',
   default_options: [

--- a/tools/version_utils.py
+++ b/tools/version_utils.py
@@ -5,8 +5,8 @@ import argparse
 
 MAJOR = 1
 MINOR = 9
-MICRO = 2
-ISRELEASED = True
+MICRO = 3
+ISRELEASED = False
 IS_RELEASE_BRANCH = True
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 


### PR DESCRIPTION
Prepare for SciPy `1.9.3` just in case.

We made quite a few changes in `1.9.2` with `cibuildwheel` + `meson` to build released wheels on PyPI for the first time, and there were thousands of lines of adjusted code in the backports. We already got one report of a metadata issue for the license display at https://pypi.org/project/scipy/. Hopefully that's as serious as problems get, but that's within about 20 minutes of releasing so.. fingers crossed.