### PR TITLE
DEP: interpolate: deprecate interp2d

### DIFF
--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -93,10 +93,27 @@ def lagrange(x, w):
 # !! found, get rid of it!
 
 
+dep_mesg = """\
+`interp2d` is deprecated in SciPy 1.10 and will be removed in a future SciPy version. 
+
+For legacy code, nearly bug-for-bug compatible replacements are
+`RectBivariateSpline` on regular grids, and `bisplrep`/`bisplev` for
+scattered 2D data.
+
+In new code, for regular grids use `RegularGridInterpolator` instead.
+For scattered data, prefer `LinearNDInterpolator` or
+`CloghToucher2DInterpolator`.
+
+For more details see
+`https://gist.github.com/ev-br/8544371b40f414b7eaf3fe6217209bff`
+"""
+
 class interp2d:
     """
     interp2d(x, y, z, kind='linear', copy=True, bounds_error=False,
              fill_value=None)
+
+    %(dep_mesg)s
 
     Interpolate over a 2-D grid.
 
@@ -206,6 +223,7 @@ class interp2d:
     >>> plt.show()
     """
 
+    @np.deprecate(old_name='interp2d', message=dep_mesg)    
     def __init__(self, x, y, z, kind='linear', copy=True, bounds_error=False,
                  fill_value=None):
         x = ravel(x)
@@ -263,6 +281,7 @@ class interp2d:
         self.x_min, self.x_max = np.amin(x), np.amax(x)
         self.y_min, self.y_max = np.amin(y), np.amax(y)
 
+    @np.deprecate(old_name='interp2d', message=dep_mesg)
     def __call__(self, x, y, dx=0, dy=0, assume_sorted=False):
         """Interpolate the function.
 
@@ -323,6 +342,8 @@ class interp2d:
         if len(z) == 1:
             z = z[0]
         return array(z)
+
+interp2d.__doc__ = interp2d.__doc__ % {"dep_mesg": dep_mesg}
 
 
 def _check_broadcast_up_to(arr_from, shape_to, name):

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -94,7 +94,7 @@ def lagrange(x, w):
 
 
 dep_mesg = """\
-`interp2d` is deprecated in SciPy 1.10 and will be removed in SciPy 1.12.0. 
+`interp2d` is deprecated in SciPy 1.10 and will be removed in SciPy 1.12.0.
 
 For legacy code, nearly bug-for-bug compatible replacements are
 `RectBivariateSpline` on regular grids, and `bisplrep`/`bisplev` for
@@ -115,7 +115,7 @@ class interp2d:
 
     .. deprecated:: 1.10.0
 
-    `interp2d` is deprecated in SciPy 1.10 and will be removed in SciPy 1.12.0. 
+    `interp2d` is deprecated in SciPy 1.10 and will be removed in SciPy 1.12.0.
 
     For legacy code, nearly bug-for-bug compatible replacements are
     `RectBivariateSpline` on regular grids, and `bisplrep`/`bisplev` for
@@ -237,7 +237,7 @@ class interp2d:
     >>> plt.show()
     """
 
-    @np.deprecate(old_name='interp2d', message=dep_mesg)    
+    @np.deprecate(old_name='interp2d', message=dep_mesg)
     def __init__(self, x, y, z, kind='linear', copy=True, bounds_error=False,
                  fill_value=None):
         x = ravel(x)

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -94,7 +94,7 @@ def lagrange(x, w):
 
 
 dep_mesg = """\
-`interp2d` is deprecated in SciPy 1.10 and will be removed in a future SciPy version. 
+`interp2d` is deprecated in SciPy 1.10 and will be removed in SciPy 1.12.0. 
 
 For legacy code, nearly bug-for-bug compatible replacements are
 `RectBivariateSpline` on regular grids, and `bisplrep`/`bisplev` for
@@ -113,7 +113,8 @@ class interp2d:
     interp2d(x, y, z, kind='linear', copy=True, bounds_error=False,
              fill_value=None)
 
-    %(dep_mesg)s
+    .. deprecated:: 1.10.0
+        %(dep_mesg)s
 
     Interpolate over a 2-D grid.
 
@@ -342,6 +343,7 @@ class interp2d:
         if len(z) == 1:
             z = z[0]
         return array(z)
+
 
 interp2d.__doc__ = interp2d.__doc__ % {"dep_mesg": dep_mesg}
 

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -114,7 +114,20 @@ class interp2d:
              fill_value=None)
 
     .. deprecated:: 1.10.0
-        %(dep_mesg)s
+
+    `interp2d` is deprecated in SciPy 1.10 and will be removed in SciPy 1.12.0. 
+
+    For legacy code, nearly bug-for-bug compatible replacements are
+    `RectBivariateSpline` on regular grids, and `bisplrep`/`bisplev` for
+    scattered 2D data.
+
+    In new code, for regular grids use `RegularGridInterpolator` instead.
+    For scattered data, prefer `LinearNDInterpolator` or
+    `CloughTocher2DInterpolator`.
+
+    For more details see
+    `https://gist.github.com/ev-br/8544371b40f414b7eaf3fe6217209bff`
+
 
     Interpolate over a 2-D grid.
 
@@ -343,9 +356,6 @@ class interp2d:
         if len(z) == 1:
             z = z[0]
         return array(z)
-
-
-interp2d.__doc__ = interp2d.__doc__ % {"dep_mesg": dep_mesg}
 
 
 def _check_broadcast_up_to(arr_from, shape_to, name):

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -102,7 +102,7 @@ scattered 2D data.
 
 In new code, for regular grids use `RegularGridInterpolator` instead.
 For scattered data, prefer `LinearNDInterpolator` or
-`CloghToucher2DInterpolator`.
+`CloughTocher2DInterpolator`.
 
 For more details see
 `https://gist.github.com/ev-br/8544371b40f414b7eaf3fe6217209bff`

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -28,39 +28,40 @@ class TestInterp2D:
         z = sin(x+0.5*y)
         with suppress_warnings() as sup:
             sup.filter(DeprecationWarning)
-            I = interp2d(x, y, z)
-            assert_almost_equal(I(1.0, 2.0), sin(2.0), decimal=2)
+            II = interp2d(x, y, z)
+            assert_almost_equal(II(1.0, 2.0), sin(2.0), decimal=2)
 
-            v,u = ogrid[0:2:24j, 0:pi:25j]
-            assert_almost_equal(I(u.ravel(), v.ravel()), sin(u+0.5*v), decimal=2)
+            v, u = ogrid[0:2:24j, 0:pi:25j]
+            assert_almost_equal(II(u.ravel(), v.ravel()),
+                                sin(u+0.5*v), decimal=2)
 
     def test_interp2d_meshgrid_input(self):
         # Ticket #703
         x = linspace(0, 2, 16)
         y = linspace(0, pi, 21)
-        z = sin(x[None,:] + y[:,None]/2.)
+        z = sin(x[None, :] + y[:, None]/2.)
         with suppress_warnings() as sup:
             sup.filter(DeprecationWarning)
-            I = interp2d(x, y, z)
-            assert_almost_equal(I(1.0, 2.0), sin(2.0), decimal=2)
+            II = interp2d(x, y, z)
+            assert_almost_equal(II(1.0, 2.0), sin(2.0), decimal=2)
 
     def test_interp2d_meshgrid_input_unsorted(self):
         np.random.seed(1234)
         x = linspace(0, 2, 16)
         y = linspace(0, pi, 21)
 
-        z = sin(x[None,:] + y[:,None]/2.)
+        z = sin(x[None, :] + y[:, None] / 2.)
         with suppress_warnings() as sup:
             sup.filter(DeprecationWarning)
             ip1 = interp2d(x.copy(), y.copy(), z, kind='cubic')
 
             np.random.shuffle(x)
-            z = sin(x[None,:] + y[:,None]/2.)
+            z = sin(x[None, :] + y[:, None]/2.)
             ip2 = interp2d(x.copy(), y.copy(), z, kind='cubic')
 
             np.random.shuffle(x)
             np.random.shuffle(y)
-            z = sin(x[None,:] + y[:,None]/2.)
+            z = sin(x[None, :] + y[:, None] / 2.)
             ip3 = interp2d(x, y, z, kind='cubic')
 
             x = linspace(0, 2, 31)
@@ -111,9 +112,9 @@ class TestInterp2D:
             iz = b(ix, iy)
             mx = (ix < 0) | (ix > 1)
             my = (iy < 0) | (iy > 2)
-            assert_(np.isnan(iz[my,:]).all())
-            assert_(np.isnan(iz[:,mx]).all())
-            assert_(np.isfinite(iz[~my,:][:,~mx]).all())
+            assert_(np.isnan(iz[my, :]).all())
+            assert_(np.isnan(iz[:, mx]).all())
+            assert_(np.isfinite(iz[~my, :][:, ~mx]).all())
 
 
 class TestInterp1D:

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -1,6 +1,6 @@
 from numpy.testing import (assert_, assert_equal, assert_almost_equal,
                            assert_array_almost_equal, assert_array_equal,
-                           assert_allclose)
+                           assert_allclose, suppress_warnings)
 from pytest import raises as assert_raises
 import pytest
 
@@ -26,19 +26,23 @@ class TestInterp2D:
     def test_interp2d(self):
         y, x = mgrid[0:2:20j, 0:pi:21j]
         z = sin(x+0.5*y)
-        I = interp2d(x, y, z)
-        assert_almost_equal(I(1.0, 2.0), sin(2.0), decimal=2)
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning)
+            I = interp2d(x, y, z)
+            assert_almost_equal(I(1.0, 2.0), sin(2.0), decimal=2)
 
-        v,u = ogrid[0:2:24j, 0:pi:25j]
-        assert_almost_equal(I(u.ravel(), v.ravel()), sin(u+0.5*v), decimal=2)
+            v,u = ogrid[0:2:24j, 0:pi:25j]
+            assert_almost_equal(I(u.ravel(), v.ravel()), sin(u+0.5*v), decimal=2)
 
     def test_interp2d_meshgrid_input(self):
         # Ticket #703
         x = linspace(0, 2, 16)
         y = linspace(0, pi, 21)
         z = sin(x[None,:] + y[:,None]/2.)
-        I = interp2d(x, y, z)
-        assert_almost_equal(I(1.0, 2.0), sin(2.0), decimal=2)
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning)
+            I = interp2d(x, y, z)
+            assert_almost_equal(I(1.0, 2.0), sin(2.0), decimal=2)
 
     def test_interp2d_meshgrid_input_unsorted(self):
         np.random.seed(1234)
@@ -46,42 +50,48 @@ class TestInterp2D:
         y = linspace(0, pi, 21)
 
         z = sin(x[None,:] + y[:,None]/2.)
-        ip1 = interp2d(x.copy(), y.copy(), z, kind='cubic')
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning)
+            ip1 = interp2d(x.copy(), y.copy(), z, kind='cubic')
 
-        np.random.shuffle(x)
-        z = sin(x[None,:] + y[:,None]/2.)
-        ip2 = interp2d(x.copy(), y.copy(), z, kind='cubic')
+            np.random.shuffle(x)
+            z = sin(x[None,:] + y[:,None]/2.)
+            ip2 = interp2d(x.copy(), y.copy(), z, kind='cubic')
 
-        np.random.shuffle(x)
-        np.random.shuffle(y)
-        z = sin(x[None,:] + y[:,None]/2.)
-        ip3 = interp2d(x, y, z, kind='cubic')
+            np.random.shuffle(x)
+            np.random.shuffle(y)
+            z = sin(x[None,:] + y[:,None]/2.)
+            ip3 = interp2d(x, y, z, kind='cubic')
 
-        x = linspace(0, 2, 31)
-        y = linspace(0, pi, 30)
+            x = linspace(0, 2, 31)
+            y = linspace(0, pi, 30)
 
-        assert_equal(ip1(x, y), ip2(x, y))
-        assert_equal(ip1(x, y), ip3(x, y))
+            assert_equal(ip1(x, y), ip2(x, y))
+            assert_equal(ip1(x, y), ip3(x, y))
 
     def test_interp2d_eval_unsorted(self):
         y, x = mgrid[0:2:20j, 0:pi:21j]
         z = sin(x + 0.5*y)
-        func = interp2d(x, y, z)
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning)
+            func = interp2d(x, y, z)
 
-        xe = np.array([3, 4, 5])
-        ye = np.array([5.3, 7.1])
-        assert_allclose(func(xe, ye), func(xe, ye[::-1]))
+            xe = np.array([3, 4, 5])
+            ye = np.array([5.3, 7.1])
+            assert_allclose(func(xe, ye), func(xe, ye[::-1]))
 
-        assert_raises(ValueError, func, xe, ye[::-1], 0, 0, True)
+            assert_raises(ValueError, func, xe, ye[::-1], 0, 0, True)
 
     def test_interp2d_linear(self):
         # Ticket #898
         a = np.zeros([5, 5])
         a[2, 2] = 1.0
         x = y = np.arange(5)
-        b = interp2d(x, y, a, 'linear')
-        assert_almost_equal(b(2.0, 1.5), np.array([0.5]), decimal=2)
-        assert_almost_equal(b(2.0, 2.5), np.array([0.5]), decimal=2)
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning)
+            b = interp2d(x, y, a, 'linear')
+            assert_almost_equal(b(2.0, 1.5), np.array([0.5]), decimal=2)
+            assert_almost_equal(b(2.0, 2.5), np.array([0.5]), decimal=2)
 
     def test_interp2d_bounds(self):
         x = np.linspace(0, 1, 5)
@@ -91,16 +101,19 @@ class TestInterp2D:
         ix = np.linspace(-1, 3, 31)
         iy = np.linspace(-1, 3, 33)
 
-        b = interp2d(x, y, z, bounds_error=True)
-        assert_raises(ValueError, b, ix, iy)
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning)
 
-        b = interp2d(x, y, z, fill_value=np.nan)
-        iz = b(ix, iy)
-        mx = (ix < 0) | (ix > 1)
-        my = (iy < 0) | (iy > 2)
-        assert_(np.isnan(iz[my,:]).all())
-        assert_(np.isnan(iz[:,mx]).all())
-        assert_(np.isfinite(iz[~my,:][:,~mx]).all())
+            b = interp2d(x, y, z, bounds_error=True)
+            assert_raises(ValueError, b, ix, iy)
+
+            b = interp2d(x, y, z, fill_value=np.nan)
+            iz = b(ix, iy)
+            mx = (ix < 0) | (ix > 1)
+            my = (iy < 0) | (iy > 2)
+            assert_(np.isnan(iz[my,:]).all())
+            assert_(np.isnan(iz[:,mx]).all())
+            assert_(np.isfinite(iz[~my,:][:,~mx]).all())
 
 
 class TestInterp1D:


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

mailing list discussion: https://mail.python.org/archives/list/scipy-dev@python.org/thread/LU72CAGYFH37PZWCANMUF6UWFNSPZRHU/

#### What does this implement/fix?
<!--Please explain your changes.-->

Make `interp2d` raise DeprecationWarnings starting from scipy 1.10

#### Additional information
<!--Any additional information you think is important.-->

Posting early to increase exposure: the mailing list thread needs at least two weeks (i.e., this can go in not earlier than Oct 20).
Also the transition guide link is for now to a github gist, will likely need to be updated based on the final state of gh-17178.


