### PR TITLE
CI: Fix when wheels are built for staging

### DIFF
--- a/.cirrus.star
+++ b/.cirrus.star
@@ -15,18 +15,12 @@ def main(ctx):
     # - a cron job called "nightly". The cron job is not set in this file,
     #   but on the cirrus-ci repo page
     # - commit message containing [wheel build]
-    # - a tag that begins with v, but doesn't end with dev0
-    # - all pushes to a maintenance branch
     ######################################################################
 
     if env.get("CIRRUS_REPO_FULL_NAME") != "scipy/scipy":
         return []
 
     if env.get("CIRRUS_CRON", "") == "nightly":
-        return fs.read("ci/cirrus_wheels.yml")
-
-    if "maintenance" in env.get("CIRRUS_BRANCH"):
-        # build wheels on all pushes to a maintenance branch
         return fs.read("ci/cirrus_wheels.yml")
 
     # Obtain commit message for the event. Unfortunately CIRRUS_CHANGE_MESSAGE

--- a/.cirrus.star
+++ b/.cirrus.star
@@ -16,6 +16,7 @@ def main(ctx):
     #   but on the cirrus-ci repo page
     # - commit message containing [wheel build]
     # - a tag that begins with v, but doesn't end with dev0
+    # - all pushes to a maintenance branch
     ######################################################################
 
     if env.get("CIRRUS_REPO_FULL_NAME") != "scipy/scipy":
@@ -24,21 +25,9 @@ def main(ctx):
     if env.get("CIRRUS_CRON", "") == "nightly":
         return fs.read("ci/cirrus_wheels.yml")
 
-    tag = env.get("CIRRUS_TAG")
-
-    # test if it's a tag?
-    if tag:
-        # if tag name contains "dev", then don't build any wheels
-        # I tried using a regex for this, but I don't think go supports
-        # the particular regex I wanted to use
-        if "dev" in tag:
-            return []
-        elif tag.startswith("v"):
-            # all other tags beginning with 'v' will build. cirrus_wheels.yml
-            # will only upload wheels to staging if the following bash test is
-            # True:
-            # [[ $CIRRUS_TAG =~ ^v.*[^dev0]$ ]]
-            return fs.read("ci/cirrus_wheels.yml")
+    if "maintenance" in env.get("CIRRUS_BRANCH"):
+        # build wheels on all pushes to a maintenance branch
+        return fs.read("ci/cirrus_wheels.yml")
 
     # Obtain commit message for the event. Unfortunately CIRRUS_CHANGE_MESSAGE
     # only contains the actual commit message on a non-PR trigger event.

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -62,7 +62,7 @@ jobs:
       contains(needs.get_commit_message.outputs.message, '1') ||
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'push' && startsWith(github.ref_name, 'maintenance')))
+      (github.event_name == 'push' && startsWith(github.ref_name, 'maintenance'))
     runs-on: ${{ matrix.buildplat[0] }}
 
     strategy:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -17,7 +17,9 @@ on:
   #        │  │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
   #        │  │ │ │ │
   - cron: "9  9 * * 6"
-  # push:
+  push:
+    branches:
+      - maintenance/**
   pull_request:
     branches:
       - main
@@ -60,7 +62,7 @@ jobs:
       contains(needs.get_commit_message.outputs.message, '1') ||
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && ( ! endsWith(github.ref, 'dev0')))
+      (github.event_name == 'push' && startsWith(github.ref_name, 'maintenance')))
     runs-on: ${{ matrix.buildplat[0] }}
 
     strategy:
@@ -100,7 +102,7 @@ jobs:
             python: ["cp311", "3.11.0-alpha - 3.11.0"]
     env:
       IS_32_BIT: ${{ matrix.buildplat[2] == 'x86' }}
-      IS_PUSH: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
+      IS_PUSH: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/maintenance') }}
       IS_SCHEDULE_DISPATCH: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
 
     steps:
@@ -244,10 +246,15 @@ jobs:
         run: |
           source tools/wheels/upload_wheels.sh
           set_upload_vars
-          # trigger an upload to
+          # For cron jobs (restricted to main branch) or "Run workflow" trigger
+          # an upload to:
+          #
           # https://anaconda.org/scipy-wheels-nightly/scipy
-          # for cron jobs or "Run workflow" (restricted to main branch).
-          # Tags will upload to
+          # 
+          # All pushes to a maintenance branch will cause wheels to be built
+          # and uploaded to:
+          #
           # https://anaconda.org/multibuild-wheels-staging/scipy
+          #
           # The tokens were originally generated at anaconda.org
           upload_wheels

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -61,8 +61,7 @@ jobs:
     if: >-
       contains(needs.get_commit_message.outputs.message, '1') ||
       github.event_name == 'schedule' ||
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'push' && startsWith(github.ref_name, 'maintenance'))
+      github.event_name == 'workflow_dispatch'
     runs-on: ${{ matrix.buildplat[0] }}
 
     strategy:
@@ -92,7 +91,7 @@ jobs:
         # python[1] is installed by actions/setup-python for the separate
         # macosx_arm64 build. Once cibuildwheel can do the macosx_arm64 cross build
         # we can get rid of this duplication and just have ["cp38", "cp39"].
-        # The actions/setup-python can only use the form ["3.8'].
+        # The actions/setup-python can only use the form ["3.8"].
         exclude:
           - buildplat: [macos-12, macosx, arm64]
             python: ["cp39", "3.9"]
@@ -102,7 +101,9 @@ jobs:
             python: ["cp311", "3.11.0-alpha - 3.11.0"]
     env:
       IS_32_BIT: ${{ matrix.buildplat[2] == 'x86' }}
-      IS_PUSH: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/maintenance') }}
+      # upload to staging if it's a push to a maintenance branch and the last
+      # commit message contains '[wheel build]'
+      IS_PUSH: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/maintenance') && contains(needs.get_commit_message.outputs.message, '1') }}
       IS_SCHEDULE_DISPATCH: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
 
     steps:
@@ -251,8 +252,8 @@ jobs:
           #
           # https://anaconda.org/scipy-wheels-nightly/scipy
           # 
-          # All pushes to a maintenance branch will cause wheels to be built
-          # and uploaded to:
+          # Pushes to a maintenance branch that contain '[wheel build]' will
+          # cause wheels to be built and uploaded to:
           #
           # https://anaconda.org/multibuild-wheels-staging/scipy
           #

--- a/ci/cirrus_wheels.yml
+++ b/ci/cirrus_wheels.yml
@@ -102,8 +102,11 @@ cirrus_wheels_upload_task:
     if [[ "$CIRRUS_CRON" == "nightly" ]]; then
       export IS_SCHEDULE_DISPATCH="true"
     fi
-    # it's a push event to a maintenance branch
-    if [[ $CIRRUS_BRANCH == maintenance* ]]; then
+
+    # If it's a push event to a maintenance branch, and the commit message contains
+    # '[wheel build]' then upload to staging
+    COMMIT_MSG=$(git log --no-merges -1)
+    if [[ "$COMMIT_MSG" == *"[wheel build]"* ]] && [[ $CIRRUS_BRANCH == maintenance* ]]; then
           export IS_PUSH="true"
     fi
     
@@ -121,8 +124,8 @@ cirrus_wheels_upload_task:
     #
     # https://anaconda.org/scipy-wheels-nightly/scipy
     # 
-    # All pushes to a maintenance branch will cause wheels to be built
-    # and uploaded to:
+    # Pushes to a maintenance branch that contain '[wheel build]' will
+    # cause wheels to be built and uploaded to:
     #
     # https://anaconda.org/multibuild-wheels-staging/scipy
     #

--- a/ci/cirrus_wheels.yml
+++ b/ci/cirrus_wheels.yml
@@ -102,8 +102,8 @@ cirrus_wheels_upload_task:
     if [[ "$CIRRUS_CRON" == "nightly" ]]; then
       export IS_SCHEDULE_DISPATCH="true"
     fi
-    # it's a tag event starting with 'v' and not ending with 'dev0'
-    if [[ $CIRRUS_TAG =~ ^v.*[^dev0]$ ]]; then
+    # it's a push event to a maintenance branch
+    if [[ $CIRRUS_BRANCH == maintenance* ]]; then
           export IS_PUSH="true"
     fi
     
@@ -116,10 +116,15 @@ cirrus_wheels_upload_task:
     
     source tools/wheels/upload_wheels.sh
     set_upload_vars
-    # trigger an upload to
+    # For cron jobs (restricted to main branch)
+    # an upload to:
+    #
     # https://anaconda.org/scipy-wheels-nightly/scipy
-    # for cron jobs or "Run workflow" (restricted to main branch).
-    # Tags will upload to
+    # 
+    # All pushes to a maintenance branch will cause wheels to be built
+    # and uploaded to:
+    #
     # https://anaconda.org/multibuild-wheels-staging/scipy
+    #
     # The tokens were originally generated at anaconda.org
     upload_wheels


### PR DESCRIPTION
@tylerjereddy, I hope that these changes address the issues for #17174. The changes in this PR:

Closes #17174

- cause the wheel building process to run for *every* push to a maintenance branch.
- these wheels are then uploaded to `multibuild-wheels-staging`.
- if there are multiple pushes then each push will cause a new set of wheels to be uploaded. If a push occurs before the last wheel build has finished then the CI run will abort and start again on the new push.