### PR TITLE
DOC: update version switcher for 1.9.2

### DIFF
--- a/doc/source/_static/version_switcher.json
+++ b/doc/source/_static/version_switcher.json
@@ -5,7 +5,12 @@
         "url": "https://scipy.github.io/devdocs/"
     },
     {
-        "name": "1.9.1 (stable)",
+        "name": "1.9.2 (stable)",
+        "version":"1.9.2",
+        "url": "https://docs.scipy.org/doc/scipy-1.9.2/"
+    },
+    {
+        "name": "1.9.1",
         "version":"1.9.1",
         "url": "https://docs.scipy.org/doc/scipy-1.9.1/"
     },


### PR DESCRIPTION
We need to update the version switcher when releasing.