### PR TITLE
BUG: special: Fix two XSLOW test failures.

### DIFF
--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -117,6 +117,7 @@ def test_hyperu_around_0():
 
     FuncData(sc.hyperu, dataset, (0, 1, 2), 3, rtol=1e-15, atol=5e-13).check()
 
+
 # ------------------------------------------------------------------------------
 # hyp2f1
 # ------------------------------------------------------------------------------
@@ -236,6 +237,7 @@ def test_hyp2f1_real_random():
         ds[4] = float(mpmath.hyp2f1(*tuple(ds[:4])))
 
     FuncData(sc.hyp2f1, dataset, (0, 1, 2, 3), 4, rtol=1e-9).check()
+
 
 # ------------------------------------------------------------------------------
 # erf (complex)
@@ -1859,17 +1861,18 @@ class TestSystematic:
     def test_riemann_zeta(self):
         assert_mpmath_equal(
             sc.zeta,
-            mpmath.zeta,
+            lambda x: mpmath.zeta(x) if x != 1 else mpmath.inf,
             [Arg(-100, 100)],
             nan_ok=False,
-            rtol=1e-13,
+            rtol=5e-13,
         )
 
     def test_zetac(self):
         assert_mpmath_equal(sc.zetac,
-                            lambda x: mpmath.zeta(x) - 1,
+                            lambda x: (mpmath.zeta(x) - 1
+                                       if x != 1 else mpmath.inf),
                             [Arg(-100, 100)],
-                            nan_ok=False, dps=45, rtol=1e-13)
+                            nan_ok=False, dps=45, rtol=5e-13)
 
     def test_boxcox(self):
 


### PR DESCRIPTION
When SCIPY_XSLOW is defined, the tests `test_riemann_zeta` and `test_zetac` (that compare the results of `zeta` and `zetac` to the results computed with `mpmath`) are run with 5000 points, and it turns out that the input value 1 is included in that case.  The SciPy functions returns `inf`, but `mpmath.zeta(1)` raises an exception, and that caused the tests to fail.

The fix is to wrap the `mpmath` function to return `mpmath.inf` when the input is 1.  After fixing that, both tests then failed because some inputs result in a relative error of roughly 2e-13, so I bumped the tolerance up to 5e-13.
