### PR TITLE
MAINT: update meson.build to make it work on IBM i system

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -51,8 +51,7 @@ if m_dep.found()
   add_project_link_arguments('-lm', language : 'c')
 endif
 if host_machine.system() == 'os400'
-  add_global_arguments('-pthread', language : 'cpp')
-  add_global_arguments('-D__STDC_FORMAT_MACROS', language : 'cpp')
+  add_project_arguments('-D__STDC_FORMAT_MACROS', language : 'cpp')
   add_project_link_arguments('-Wl,-bnotextro', language : 'c')
   add_project_link_arguments('-Wl,-bnotextro', language : 'cpp')
   add_project_link_arguments('-Wl,-bnotextro', language : 'fortran')

--- a/meson.build
+++ b/meson.build
@@ -50,7 +50,9 @@ m_dep = cc.find_library('m', required : false)
 if m_dep.found()
   add_project_link_arguments('-lm', language : 'c')
 endif
+
 if host_machine.system() == 'os400'
+  # IBM i system, needed to avoid build errors - see gh-17193
   add_project_arguments('-D__STDC_FORMAT_MACROS', language : 'cpp')
   add_project_link_arguments('-Wl,-bnotextro', language : 'c')
   add_project_link_arguments('-Wl,-bnotextro', language : 'cpp')

--- a/meson.build
+++ b/meson.build
@@ -50,6 +50,13 @@ m_dep = cc.find_library('m', required : false)
 if m_dep.found()
   add_project_link_arguments('-lm', language : 'c')
 endif
+if host_machine.system() == 'os400'
+  add_global_arguments('-pthread', language : 'cpp')
+  add_global_arguments('-D__STDC_FORMAT_MACROS', language : 'cpp')
+  add_project_link_arguments('-Wl,-bnotextro', language : 'c')
+  add_project_link_arguments('-Wl,-bnotextro', language : 'cpp')
+  add_project_link_arguments('-Wl,-bnotextro', language : 'fortran')
+endif
 
 # Adding at project level causes many spurious -lgfortran flags.
 add_languages('fortran', native: false)


### PR DESCRIPTION
Add extra options on IBM i to make the meson build/pip3 works.  The changes are covered by host_machine.system() == 'os400', so, it would not affect any existing systems.  Please help to review. Thanks. 

@rgommers 