### PR TITLE
MAINT: stats: remove use of interp2d from levy_stable._fitstart

### DIFF
--- a/scipy/stats/_levy_stable/__init__.py
+++ b/scipy/stats/_levy_stable/__init__.py
@@ -497,7 +497,7 @@ def _fitstart_S1(data):
     nu_beta_range = [0, 0.1, 0.2, 0.3, 0.5, 0.7, 1]
 
     # table III - alpha = psi_1(nu_alpha, nu_beta)
-    alpha_table = [
+    alpha_table = np.array([
         [2.000, 2.000, 2.000, 2.000, 2.000, 2.000, 2.000],
         [1.916, 1.924, 1.924, 1.924, 1.924, 1.924, 1.924],
         [1.808, 1.813, 1.829, 1.829, 1.829, 1.829, 1.829],
@@ -512,10 +512,12 @@ def _fitstart_S1(data):
         [0.896, 0.892, 0.884, 0.883, 0.855, 0.823, 0.769],
         [0.818, 0.812, 0.806, 0.801, 0.780, 0.756, 0.691],
         [0.698, 0.695, 0.692, 0.689, 0.676, 0.656, 0.597],
-        [0.593, 0.590, 0.588, 0.586, 0.579, 0.563, 0.513]]
+        [0.593, 0.590, 0.588, 0.586, 0.579, 0.563, 0.513]]).T
+    # transpose because interpolation with `RectBivariateSpline` is with
+    # `nu_beta` as `x` and `nu_alpha` as `y`
 
     # table IV - beta = psi_2(nu_alpha, nu_beta)
-    beta_table = [
+    beta_table = np.array([
         [0, 2.160, 1.000, 1.000, 1.000, 1.000, 1.000],
         [0, 1.592, 3.390, 1.000, 1.000, 1.000, 1.000],
         [0, 0.759, 1.800, 1.000, 1.000, 1.000, 1.000],
@@ -530,20 +532,17 @@ def _fitstart_S1(data):
         [0, 0.082, 0.163, 0.243, 0.412, 0.601, 1.596],
         [0, 0.074, 0.147, 0.220, 0.377, 0.546, 1.482],
         [0, 0.064, 0.128, 0.191, 0.330, 0.478, 1.362],
-        [0, 0.056, 0.112, 0.167, 0.285, 0.428, 1.274]]
-
-    j = np.argsort(nu_alpha_range)
-    nu_alpha_range_r = np.asarray(nu_alpha_range)[j]
-    alpha_table_r = np.asarray(alpha_table)[j, :]
-    beta_table_r = np.asarray(beta_table)[j, :]
+        [0, 0.056, 0.112, 0.167, 0.285, 0.428, 1.274]]).T
 
     # Table V and VII
+    # These are ordered with decreasing `alpha_range`; so we will need to
+    # reverse them as required by RectBivariateSpline.
     alpha_range = [2, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1,
-                   1, 0.9, 0.8, 0.7, 0.6, 0.5]
+                   1, 0.9, 0.8, 0.7, 0.6, 0.5][::-1]
     beta_range = [0, 0.25, 0.5, 0.75, 1]
 
     # Table V - nu_c = psi_3(alpha, beta)
-    nu_c_table = [
+    nu_c_table = np.array([
         [1.908, 1.908, 1.908, 1.908, 1.908],
         [1.914, 1.915, 1.916, 1.918, 1.921],
         [1.921, 1.922, 1.927, 1.936, 1.947],
@@ -559,10 +558,12 @@ def _fitstart_S1(data):
         [2.098, 2.244, 2.676, 3.265, 3.912],
         [2.189, 2.392, 3.004, 3.844, 4.775],
         [2.337, 2.634, 3.542, 4.808, 6.247],
-        [2.588, 3.073, 4.534, 6.636, 9.144]]
+        [2.588, 3.073, 4.534, 6.636, 9.144]])[::-1].T
+    # transpose because interpolation with `RectBivariateSpline` is with
+    # `beta` as `x` and `alpha` as `y`
 
     # Table VII - nu_zeta = psi_5(alpha, beta)
-    nu_zeta_table = [
+    nu_zeta_table = np.array([
         [0, 0.000, 0.000, 0.000, 0.000],
         [0, -0.017, -0.032, -0.049, -0.064],
         [0, -0.030, -0.061, -0.092, -0.123],
@@ -578,35 +579,30 @@ def _fitstart_S1(data):
         [0, -0.096, -0.250, -0.469, -0.742],
         [0, -0.089, -0.262, -0.520, -0.853],
         [0, -0.078, -0.272, -0.581, -0.997],
-        [0, -0.061, -0.279, -0.659, -1.198]]
+        [0, -0.061, -0.279, -0.659, -1.198]])[::-1].T
     # fmt: on
 
-    j = np.argsort(alpha_range)
-    alpha_range_r = np.asarray(alpha_range)[j]
-    nu_c_table_r = np.asarray(nu_c_table)[j, :]
-    nu_zeta_table_r = np.asarray(nu_zeta_table)[j, :]
-
-    psi_1 = RectBivariateSpline(nu_beta_range, nu_alpha_range_r,
-                                alpha_table_r.T, kx=1, ky=1, s=0)
+    psi_1 = RectBivariateSpline(nu_beta_range, nu_alpha_range,
+                                alpha_table, kx=1, ky=1, s=0)
 
     def psi_1_1(nu_beta, nu_alpha):
         return psi_1(nu_beta, nu_alpha) \
             if nu_beta > 0 else psi_1(-nu_beta, nu_alpha)
 
-    psi_2 = RectBivariateSpline(nu_beta_range, nu_alpha_range_r,
-                                beta_table_r.T, kx=1, ky=1, s=0)
+    psi_2 = RectBivariateSpline(nu_beta_range, nu_alpha_range,
+                                beta_table, kx=1, ky=1, s=0)
 
     def psi_2_1(nu_beta, nu_alpha):
         return psi_2(nu_beta, nu_alpha) \
             if nu_beta > 0 else -psi_2(-nu_beta, nu_alpha)
 
-    phi_3 = RectBivariateSpline(beta_range, alpha_range_r, nu_c_table_r.T,
+    phi_3 = RectBivariateSpline(beta_range, alpha_range, nu_c_table,
                                 kx=1, ky=1, s=0)
 
     def phi_3_1(beta, alpha):
         return phi_3(beta, alpha) if beta > 0 else phi_3(-beta, alpha)
 
-    phi_5 = RectBivariateSpline(beta_range, alpha_range_r, nu_zeta_table_r.T,
+    phi_5 = RectBivariateSpline(beta_range, alpha_range, nu_zeta_table,
                                 kx=1, ky=1, s=0)
 
     def phi_5_1(beta, alpha):

--- a/scipy/stats/_levy_stable/__init__.py
+++ b/scipy/stats/_levy_stable/__init__.py
@@ -6,8 +6,6 @@ from functools import partial
 
 import numpy as np
 
-from numpy.testing import assert_allclose
-
 from scipy import optimize
 from scipy import integrate
 from scipy.integrate._quadrature import _builtincoeffs
@@ -588,42 +586,30 @@ def _fitstart_S1(data):
     nu_c_table_r = np.asarray(nu_c_table)[j, :]
     nu_zeta_table_r = np.asarray(nu_zeta_table)[j, :]
 
-    psi_1_i = interpolate.interp2d(
-        nu_beta_range, nu_alpha_range, alpha_table, kind="linear"
-    )
-    psi_1 = RectBivariateSpline(nu_beta_range, nu_alpha_range_r, alpha_table_r.T, kx=1, ky=1, s=0)
+    psi_1 = RectBivariateSpline(nu_beta_range, nu_alpha_range_r,
+                                alpha_table_r.T, kx=1, ky=1, s=0)
 
     def psi_1_1(nu_beta, nu_alpha):
-        assert_allclose(psi_1(nu_beta, nu_alpha), psi_1_i(nu_beta, nu_alpha), atol=1e-15)
         return psi_1(nu_beta, nu_alpha) \
             if nu_beta > 0 else psi_1(-nu_beta, nu_alpha)
 
-    psi_2_i = interpolate.interp2d(
-        nu_beta_range, nu_alpha_range, beta_table, kind="linear"
-    )
-    psi_2 = RectBivariateSpline(nu_beta_range, nu_alpha_range_r, beta_table_r.T, kx=1, ky=1, s=0)
+    psi_2 = RectBivariateSpline(nu_beta_range, nu_alpha_range_r,
+                                beta_table_r.T, kx=1, ky=1, s=0)
 
     def psi_2_1(nu_beta, nu_alpha):
-        assert_allclose(psi_2(nu_beta, nu_alpha), psi_2_i(nu_beta, nu_alpha), atol=1e-15)
         return psi_2(nu_beta, nu_alpha) \
             if nu_beta > 0 else -psi_2(-nu_beta, nu_alpha)
 
-    phi_3_i = interpolate.interp2d(
-        beta_range, alpha_range, nu_c_table, kind="linear"
-    )
-    phi_3 = RectBivariateSpline(beta_range, alpha_range_r, nu_c_table_r.T, kx=1, ky=1, s=0)
+    phi_3 = RectBivariateSpline(beta_range, alpha_range_r, nu_c_table_r.T,
+                                kx=1, ky=1, s=0)
 
     def phi_3_1(beta, alpha):
-        assert_allclose(phi_3(beta, alpha)[0], phi_3_i(beta, alpha), atol=1e-15)
         return phi_3(beta, alpha) if beta > 0 else phi_3(-beta, alpha)
 
-    phi_5_i = interpolate.interp2d(
-        beta_range, alpha_range, nu_zeta_table, kind="linear"
-    )
-    phi_5 = RectBivariateSpline(beta_range, alpha_range_r, nu_zeta_table_r.T, kx=1, ky=1, s=0)
+    phi_5 = RectBivariateSpline(beta_range, alpha_range_r, nu_zeta_table_r.T,
+                                kx=1, ky=1, s=0)
 
     def phi_5_1(beta, alpha):
-        assert_allclose(phi_5(beta, alpha)[0], phi_5_i(beta, alpha), atol=1e-15)
         return phi_5(beta, alpha) if beta > 0 else -phi_5(-beta, alpha)
 
     # quantiles
@@ -637,7 +623,8 @@ def _fitstart_S1(data):
     nu_beta = (p95 + p05 - 2 * p50) / (p95 - p05)
 
     if nu_alpha >= 2.439:
-        alpha = np.clip(psi_1_1(nu_beta, nu_alpha)[0, 0], np.finfo(float).eps, 2.)
+        eps = np.finfo(float).eps
+        alpha = np.clip(psi_1_1(nu_beta, nu_alpha)[0, 0], eps, 2.)
         beta = np.clip(psi_2_1(nu_beta, nu_alpha)[0, 0], -1.0, 1.0)
     else:
         alpha = 2.0


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

A companion to gh-17180.

#### What does this implement/fix?
<!--Please explain your changes.-->

`levy_stable._fitstart` uses `interpolate.interp2d`,  which gh-17180 deprecates. Thus, replace interp2d usage by its direct analog, per https://gist.github.com/ev-br/8544371b40f414b7eaf3fe6217209bff

#### Additional information
<!--Any additional information you think is important.-->

Two commits here may probably be squashed: the first commit adds assertions that the new and old usage is indentical, and the second commit removes interp2d usage and assertsions. 
