### PR TITLE
BLD: fix issue with incomplete threads dependency handling

### DIFF
--- a/scipy/fft/_pocketfft/meson.build
+++ b/scipy/fft/_pocketfft/meson.build
@@ -1,12 +1,8 @@
-thread_dep = dependency('threads', required: false)
-
-# mingw-w64 does not implement pthread_pfork, needed by pocket_fft
-win_gcc = is_windows and meson.get_compiler('cpp').get_id() == 'gcc'
-
 pocketfft_threads = []
 fft_deps = []
 if is_windows
-  if win_gcc
+  if is_mingw
+    # mingw-w64 does not implement pthread_pfork, needed by pocket_fft
     # Disable threading completely, because of freezes using threading for
     # mingw-w64 gcc: https://github.com/mreineck/pocketfft/issues/1
     pocketfft_threads += ['-DPOCKETFFT_NO_MULTITHREADING']

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -34,6 +34,8 @@ if is_windows
   endif
 endif
 
+thread_dep = dependency('threads', required: false)
+
 # NumPy include directory - needed in all submodules
 incdir_numpy = run_command(py3,
   [

--- a/scipy/optimize/_highs/meson.build
+++ b/scipy/optimize/_highs/meson.build
@@ -104,6 +104,7 @@ ipx_lib = static_library('ipx',
     '../../_lib/highs/extern/',
     'cython/src/'
   ],
+  dependencies: thread_dep,
   cpp_args: [highs_flags, highs_define_macros]
 )
 
@@ -220,6 +221,7 @@ highs_lib = static_library('highs',
     '../../_lib/highs/src/lp_data/',
     '../../_lib/highs/src/util/',
   ],
+  dependencies: thread_dep,
   cpp_args: [highs_flags, highs_define_macros]
 )
 
@@ -234,6 +236,7 @@ _highs_wrapper = py3.extension_module('_highs_wrapper',
     '../../_lib/highs/src/lp_data/',
     '../../_lib/highs/src/util/'
   ],
+  dependencies: thread_dep,
   link_args: version_link_args,
   link_with: [highs_lib, ipx_lib, basiclu_lib],
   cpp_args: [highs_flags, highs_define_macros, cython_c_args],
@@ -252,6 +255,7 @@ _highs_constants = py3.extension_module('_highs_constants',
     '../../_lib/highs/src/lp_data/',
     '../../_lib/highs/src/simplex/'
   ],
+  dependencies: thread_dep,
   link_args: version_link_args,
   install: true,
   subdir: 'scipy/optimize/_highs'

--- a/scipy/stats/meson.build
+++ b/scipy/stats/meson.build
@@ -96,12 +96,10 @@ py3.install_sources([
   subdir: 'scipy/stats'
 )
 
-pthread = dependency('threads')
-
 _qmc_cy = py3.extension_module('_qmc_cy',
   cython_gen_cpp.process('_qmc_cy.pyx'),
   cpp_args: cython_cpp_args,
-  dependencies: [pthread],
+  dependencies: thread_dep,
   include_directories: [inc_np],
   link_args: version_link_args,
   install: true,


### PR DESCRIPTION
All code using `#include <thread>` needs to have this `thread_dep` dependency. HiGHS code was missing it, and for `stats/_qmc_cy.pyx` it was incorrectly specified.

It's wrong in the distutils build as well, but let's ignore that since it's much harder to change and we'll get rid of that build soon.

See gh-17193 for the type of compile error this causes.