### PR TITLE
DOC: Add triage guide

### DIFF
--- a/HACKING.rst.txt
+++ b/HACKING.rst.txt
@@ -222,7 +222,8 @@ Triaging issues (investigating bug reports for validity and possible actions to
 take) is also a useful activity.  SciPy has many hundreds of open issues;
 closing invalid ones and correctly labelling valid ones (ideally with some first
 thoughts in a comment) allows prioritizing maintenance work and finding related
-issues easily when working on an existing function or subpackage.
+issues easily when working on an existing function or subpackage. To read more
+about issue triage, see :ref:`triaging`.
 
 Participating in discussions on the scipy-user and scipy-dev `mailing lists`_ is
 a contribution in itself.  Everyone who writes to those lists with a problem or

--- a/doc/source/dev/conduct/code_of_conduct.rst
+++ b/doc/source/dev/conduct/code_of_conduct.rst
@@ -1,3 +1,5 @@
+.. _scipy-coc:
+
 SciPy Code of Conduct
 =====================
 

--- a/doc/source/dev/contributor/contributor_toc.rst
+++ b/doc/source/dev/contributor/contributor_toc.rst
@@ -41,7 +41,7 @@ Editing SciPy
 - :ref:`git-development` is a guide to using ``git``, the distributed version-control system used to manage the changes made to SciPy code from around the world
 - :ref:`scipy-api` contains some important notes about how SciPy code is organized and documents the structure of the SciPy API; if you are going to import other SciPy code, read this first
 - :ref:`reviewing-prs` explains how to review another author's SciPy code locally
-- :ref:`triage` explains how to curate issues and PRs, as well as how GitHub team permissions work for SciPy
+- :ref:`triaging` explains how to curate issues and PRs, as well as how GitHub team permissions work for SciPy
 - :ref:`adding-new` has information on how to add new methods, functions and classes
 - :ref:`core-dev-guide` has background information including how decisions are made and how a release is prepared; it's geared toward :ref:`Core Developers <governance>`, but contains useful information for all contributors
 - :ref:`missing-bits` - code and documentation style guide

--- a/doc/source/dev/contributor/contributor_toc.rst
+++ b/doc/source/dev/contributor/contributor_toc.rst
@@ -41,6 +41,7 @@ Editing SciPy
 - :ref:`git-development` is a guide to using ``git``, the distributed version-control system used to manage the changes made to SciPy code from around the world
 - :ref:`scipy-api` contains some important notes about how SciPy code is organized and documents the structure of the SciPy API; if you are going to import other SciPy code, read this first
 - :ref:`reviewing-prs` explains how to review another author's SciPy code locally
+- :ref:`triage` explains how to curate issues and PRs, as well as how GitHub team permissions work for SciPy
 - :ref:`adding-new` has information on how to add new methods, functions and classes
 - :ref:`core-dev-guide` has background information including how decisions are made and how a release is prepared; it's geared toward :ref:`Core Developers <governance>`, but contains useful information for all contributors
 - :ref:`missing-bits` - code and documentation style guide

--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -17,7 +17,6 @@ the organization section.
    dev_quickstart
    contributor/development_workflow
    contributor/contributor_toc
-   contributor/triage
 
 .. toctree::
    :maxdepth: 1

--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -48,7 +48,7 @@ the organization section.
    contributor/adding_new
    contributor/continuous_integration
    contributor/using_act
-   contributor/triage
+   triage
 
 .. These files are not intended to be in any toctree. because they have not
    been maintained.They should only be reached via the contributor guide if

--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -48,6 +48,7 @@ the organization section.
    contributor/adding_new
    contributor/continuous_integration
    contributor/using_act
+   contributor/triage
 
 .. These files are not intended to be in any toctree. because they have not
    been maintained.They should only be reached via the contributor guide if

--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -17,6 +17,7 @@ the organization section.
    dev_quickstart
    contributor/development_workflow
    contributor/contributor_toc
+   contributor/triage
 
 .. toctree::
    :maxdepth: 1

--- a/doc/source/dev/triage.rst
+++ b/doc/source/dev/triage.rst
@@ -19,9 +19,8 @@ Roles and permissions
 =====================
 
 SciPy uses two levels of permissions: triage and core team members. **Triage
-members** can label and close issues and pull requests, while **core team
-members** can label and close issues and pull request, and can also merge pull
-requests.
+members** can label and close issues and pull requests, while **maintainers**
+can label and close issues and pull request, and can also merge pull requests.
 
 `GitHub publishes the full list of permissions for the platform.
 <https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-roles-for-an-organization>`__
@@ -64,8 +63,8 @@ Issue labels (requires triage rights)
 
 When an issue or pull request is created, SciPy may automatically assign one or
 more labels depending on the title or section of the code involved. For example,
-all issues created with title including the ``DOC:`` prefix will automatically
-receive a ``Documentation`` label.
+all issues created with title including the ``BUG:`` prefix will automatically
+receive a ``defect`` label.
 
 In some cases, it may be useful to also include other labels manually. Any
 person with triage rights can add or remove label as appropriate. Check the

--- a/doc/source/dev/triage.rst
+++ b/doc/source/dev/triage.rst
@@ -1,0 +1,79 @@
+.. _triaging:
+
+============================
+Triaging and curating issues
+============================
+
+SciPy has many hundreds of open issues. Closing invalid ones and correctly
+labelling valid ones (ideally with some first thoughts in a comment) allows
+prioritizing maintenance work and finding related issues easily when working on
+an existing function or subpackage.
+
+While anyone can comment and give more information on open issues, extra
+permissions are needed if you want to apply labels to issues in the SciPy
+repository. While there is no formal process to receive triage rights, the
+expectation is that someone should be active as a contributor before joining
+the team.
+
+Roles and permissions
+=====================
+
+SciPy uses two levels of permissions: triage and core team members. **Triage
+members** can label and close issues and pull requests, while **core team
+members** can label and close issues and pull request, and can also merge pull
+requests.
+
+`GitHub publishes the full list of permissions for the platform.
+<https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-roles-for-an-organization>`__
+
+Improving issues
+================
+
+Issue descriptions can be incomplete, inaccurate or outdated. No special
+permissions are needed to work on improving them - this can be useful and help
+reduce the workload for maintainers and other contributors. The following
+actions are typically useful:
+
+- documenting issues that are missing elements to reproduce the problem such as
+  code samples
+- suggesting to reformulate the title and description to make them more explicit
+  about the problem to be solved
+- linking to related issues or discussions while briefly describing how they are
+  related, for instance “See also #xyz for a similar attempt at this” provides
+  context and helps the discussion.
+
+Keep in mind that every comment on an issue or pull request creates a
+notification for a group of people. Be mindful and make use of the edit comment
+button when necessary.
+
+Fruitful discussions
+====================
+
+Online discussions may be harder than it seems at first glance, in particular
+given that a person new to open-source may have a very different understanding
+of the process than a seasoned maintainer. 
+
+Overall, it is useful to stay positive and assume good will.
+`This article <http://gael-varoquaux.info/programming/technical-discussions-are-hard-a-few-tips.html>`__
+explores how to lead online discussions in the context of open source. It's also
+important to remember that all interactions are expected to follow the
+:ref:`SciPy Code of Conduct <scipy-coc>`.
+
+Issue labels (requires triage rights)
+=====================================
+
+When an issue or pull request is created, SciPy may automatically assign one or
+more labels depending on the title or section of the code involved. For example,
+all issues created with title including the ``DOC:`` prefix will automatically
+receive a ``Documentation`` label.
+
+In some cases, it may be useful to also include other labels manually. Any
+person with triage rights can add or remove label as appropriate. Check the
+`full description of the current labels <https://github.com/scipy/scipy/labels>`__
+for more information.
+
+Other references
+================
+
+* `scikit-learn's documentation on Bug triaging and issue curation <https://scikit-learn.org/dev/developers/bug_triaging.html>`__
+* `pandas documentation on Issue triage <https://pandas.pydata.org/docs/development/maintaining.html>`__


### PR DESCRIPTION
As previously discussed in the community meeting, this document adds some info on triaging issues (including who has permissions to do what, and how to communicate with other community members). I am also citing some other documentation that have served as inspiration for this guide.

This is wide open for feedback and discussion 😄 