### PR TITLE
MAINT: Handle numpy's deprecation of accepting out-of-bound integers.

### DIFF
--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -985,8 +985,8 @@ class _TestCommon:
     def test_mean(self):
         def check(dtype):
             dat = array([[0, 1, 2],
-                         [3, -4, 5],
-                         [-6, 7, 9]], dtype=dtype)
+                         [3, 4, 5],
+                         [6, 7, 9]], dtype=dtype)
             datsp = self.spmatrix(dat, dtype=dtype)
 
             assert_array_almost_equal(dat.mean(), datsp.mean())

--- a/scipy/sparse/tests/test_sparsetools.py
+++ b/scipy/sparse/tests/test_sparsetools.py
@@ -14,6 +14,13 @@ import pytest
 from pytest import raises as assert_raises
 
 
+def int_to_int8(n):
+    """
+    Wrap an integer to the interval [-128, 127].
+    """
+    return (n + 128) % 256 - 128
+
+
 def test_exception():
     assert_raises(MemoryError, _sparsetools.test_throw_error)
 
@@ -157,7 +164,7 @@ class TestInt32Overflow:
         m = dia_matrix((data, offsets), shape=(n, n))
         v = np.ones(m.shape[1], dtype=np.int8)
         r = m.dot(v)
-        assert_equal(r[0], np.int8(n))
+        assert_equal(r[0], int_to_int8(n))
         del data, offsets, m, v, r
         gc.collect()
 
@@ -219,7 +226,7 @@ class TestInt32Overflow:
 
         # _matvecs
         r = m.dot(np.ones((n, 2), dtype=np.int8))
-        assert_equal(r[0,0], np.int8(n))
+        assert_equal(r[0, 0], int_to_int8(n))
 
     def _check_bsr_matvec(self, m):
         m = m()
@@ -227,7 +234,7 @@ class TestInt32Overflow:
 
         # _matvec
         r = m.dot(np.ones((n,), dtype=np.int8))
-        assert_equal(r[0], np.int8(n))
+        assert_equal(r[0], int_to_int8(n))
 
     def _check_bsr_diagonal(self, m):
         m = m()

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -1996,11 +1996,12 @@ def test_sqeuclidean_dtypes():
         assert_(np.issubdtype(d.dtype, np.floating))
 
     for dtype in [np.uint8, np.uint16, np.uint32, np.uint64]:
-        d1 = wsqeuclidean([0], np.asarray([-1], dtype=dtype))
-        d2 = wsqeuclidean(np.asarray([-1], dtype=dtype), [0])
+        umax = np.iinfo(dtype).max
+        d1 = wsqeuclidean([0], np.asarray([umax], dtype=dtype))
+        d2 = wsqeuclidean(np.asarray([umax], dtype=dtype), [0])
 
         assert_equal(d1, d2)
-        assert_equal(d1, np.float64(np.iinfo(dtype).max)**2)
+        assert_equal(d1, np.float64(umax)**2)
 
     dtypes = [np.float32, np.float64, np.complex64, np.complex128]
     for dtype in ['float16', 'float128']:


### PR DESCRIPTION
After the change in https://github.com/numpy/numpy/pull/22385, numpy raises a deprecation warning with calls such as np.int8(5000) and np.uint32(-1).  This change avoids such calls in the tests.
