### PR TITLE
BLD: fix invalid shebang for build helper script

### DIFF
--- a/scipy/_build_utils/cythoner.py
+++ b/scipy/_build_utils/cythoner.py
@@ -1,4 +1,4 @@
-#!python3
+#!/usr/bin/env python3
 """ Scipy variant of Cython command
 
 Cython, as applied to single pyx file.


### PR DESCRIPTION
Shebangs do not work this way, but Meson could usually paper over the differences by noticing that the last element is "python3" and rewiring it to use its own sys.executable. However, this failed on WSL, likely because platform quirks meant the script was directly executable, while simultaneously having a shebang that was a fatal error.

Use a standard shebang indicating this script would like to run with some form of python3 (which is exactly what it needs).

Fixes #17020
