### PR TITLE
Guard against integer overflows in fitpackmodule.c

### DIFF
--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -63,6 +63,9 @@ _mul_overflow_intp(F_INT mx, F_INT my) {
     */
     if (my != 0 && int_max/my < mx) {
         /* Integer overflow */
+        PyErr_Format(PyExc_RuntimeError,
+                     "Cannot produce output of size %dx%d (size too large)",
+                     mx, my);
         return -1;
     }
     mxy = (npy_intp)mx * (npy_intp)my;
@@ -84,6 +87,9 @@ _mul_overflow_f_int(F_INT mx, F_INT my) {
     */
     if (my != 0 && F_INT_MAX/my < mx) {
         /* Integer overflow */
+        PyErr_Format(PyExc_RuntimeError,
+                     "Cannot produce output of size %dx%d (size too large)",
+                     mx, my);
         return -1;
     }
     mxy = mx * my;
@@ -214,9 +220,6 @@ fitpack_bispev(PyObject *dummy, PyObject *args)
 
     mxy = _mul_overflow_intp(mx, my);
     if (mxy < 0) {
-        PyErr_Format(PyExc_RuntimeError,
-                     "Cannot produce output of size %dx%d (size too large)",
-                     mx, my);
         goto fail;
     }
 
@@ -229,9 +232,6 @@ fitpack_bispev(PyObject *dummy, PyObject *args)
         /* lwrk = mx*(kx + 1 - nux) + my*(ky + 1 - nuy) + (nx - kx - 1)*(ny - ky - 1); */
         lwrk = _mul_overflow_f_int(nx - kx - 1, ny - ky - 1);
         if (lwrk < 0) {
-            PyErr_Format(PyExc_RuntimeError,
-                         "Cannot produce output of size %dx%d (size too large)",
-                         nx - kx - 1, ny - ky -1);
             goto fail;
         }    
         lwrk += mx*(kx + 1 - nux) + my*(ky + 1 - nuy);
@@ -324,9 +324,6 @@ fitpack_surfit(PyObject *dummy, PyObject *args)
     /* lcest = (nxest - kx - 1)*(nyest - ky - 1); */
     lcest = _mul_overflow_f_int(nxest - kx - 1, nyest - ky - 1);
     if (lcest < 0) {
-        PyErr_Format(PyExc_RuntimeError,
-                     "Cannot produce output of size %dx%d (size too large)",
-                     nxest - kx - 1, nyest - ky -1);
         goto fail;
     }
     /* kwrk computation is unlikely to overflow if lcest above did not.*/
@@ -362,9 +359,6 @@ fitpack_surfit(PyObject *dummy, PyObject *args)
         /* lc = (nx - kx - 1)*(ny - ky - 1); */
         lc = _mul_overflow_f_int(nx - kx - 1, ny - ky -1);
         if (lc < 0) {
-            PyErr_Format(PyExc_RuntimeError,
-                         "Cannot produce output of size %dx%d (size too large)",
-                         nx - kx - 1, ny - ky -1);
             goto fail;
         }
 
@@ -393,9 +387,6 @@ fitpack_surfit(PyObject *dummy, PyObject *args)
 
     lc_intp = _mul_overflow_intp(nx - kx - 1, ny - ky -1);
     if (lc_intp < 0) {
-        PyErr_Format(PyExc_RuntimeError,
-                     "Cannot produce output of size %dx%d (size too large)",
-                     nx - kx - 1, ny - ky -1);
         goto fail;
     }
 

--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -228,6 +228,10 @@ fitpack_bispev(PyObject *dummy, PyObject *args)
         goto fail;
     }
     z = (double *) PyArray_DATA(ap_z);
+    /* Try detecting an integer overflow in computations which are quadratic
+     * in the input data size, ~mx*my. On the other hand, k{x,y} and nu{x,y}
+     *  are of the order 1..5, thus kx*mx is unlikely to overflow.
+     */
     if (nux || nuy) {
         /* lwrk = mx*(kx + 1 - nux) + my*(ky + 1 - nuy) + (nx - kx - 1)*(ny - ky - 1); */
         lwrk = _mul_overflow_f_int(nx - kx - 1, ny - ky - 1);


### PR DESCRIPTION


#### Reference issue
<!--Example: Closes gh-WXYZ.-->

closes gh-1766

#### What does this implement/fix?
<!--Please explain your changes.-->

Detect integer overflows in size computations. The approach basically copies that of gh-16649 --- the lengthy discussion is in squash-rebase of gh-16084.

In this PR I'm focusing on computations which are roughly quadratic in the the sample size. The logic is that the sample size, let's call it `m` (the number of data points, number of knots etc) is most likely much smaller than the integer limit, but  some work arrays are of size `m*m` which can overflow. So guard for those. OTOH,  `m` times a factor of order 3..5 is unlikely to overflow, so don't bother with these in this PR. 

#### Additional information
<!--Any additional information you think is important.-->

My C is rusty and these things make my head hurt, so I'd really appreciate a review from a C wizard :-). Carl @carlkl , Matthew @matthew-brett would you mind taking a look? 