### PR TITLE
MAINT: interpolate/RGI: make all _evaluate_YYY methods use self.values

### DIFF
--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -345,7 +345,7 @@ class RegularGridInterpolator:
         elif method in self._SPLINE_METHODS:
             if is_method_changed:
                 self._validate_grid_dimensions(self.grid, method)
-            result = self._evaluate_spline(self.values, xi, method)
+            result = self._evaluate_spline(xi, method)
 
         if not self.bounds_error and self.fill_value is not None:
             result[out_of_bounds] = self.fill_value
@@ -399,7 +399,7 @@ class RegularGridInterpolator:
                                  f" but method {method} requires at least "
                                  f" {k+1} points per dimension.")
 
-    def _evaluate_spline(self, values, xi, method):
+    def _evaluate_spline(self, xi, method):
         # ensure xi is 2D list of points to evaluate (`m` is the number of
         # points and `n` is the number of interpolation dimensions,
         # ``n == len(self.grid)``.)
@@ -413,9 +413,9 @@ class RegularGridInterpolator:
         # the 0th axis of its argument array (for 1D routine it's its ``y``
         # array). Thus permute the interpolation axes of `values` *and keep
         # trailing dimensions trailing*.
-        axes = tuple(range(values.ndim))
+        axes = tuple(range(self.values.ndim))
         axx = axes[:n][::-1] + axes[n:]
-        values = values.transpose(axx)
+        values = self.values.transpose(axx)
 
         if method == 'pchip':
             _eval_func = self._do_pchip


### PR DESCRIPTION
A trivial clean-up: make all private `_evaluate_XXX` methods consistently use `self.values` instead of `_evaluate_spline` receiving it as an argument.
Found when looking at https://github.com/scipy/scipy/pull/10860#issuecomment-1277234492