### PR TITLE
CI: remove set-output occurrences 

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,9 +34,9 @@ jobs:
         shell: bash
         run: |
           export raw_branch=${GITHUB_REF#refs/heads/}
-          echo "::set-output name=branch::${raw_branch//\//-}"
-          echo "::set-output name=date::$(date +'%Y%m%d')"
-          echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
+          echo "branch=${raw_branch//\//-}" >> $GITHUB_OUTPUT
+          echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
+          echo "sha8=$(echo ${GITHUB_SHA} | cut -c1-8)" >> $GITHUB_OUTPUT
         id: getrefs
 
       - name: Setup Docker Buildx

--- a/.github/workflows/gitpod.yml
+++ b/.github/workflows/gitpod.yml
@@ -25,9 +25,9 @@ jobs:
         shell: bash
         run: |
           export raw_branch=${GITHUB_REF#refs/heads/}
-          echo "::set-output name=branch::${raw_branch//\//-}"
-          echo "::set-output name=date::$(date +'%Y%m%d')"
-          echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
+          echo "branch=${raw_branch//\//-}" >> $GITHUB_OUTPUT
+          echo "name=date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
+          echo "sha8=$(echo ${GITHUB_SHA} | cut -c1-8)" >> $GITHUB_OUTPUT
         id: getrefs
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -76,9 +76,9 @@ jobs:
       shell: bash
       run: |
         mkdir -p "${CCACHE_DIR}"
-        echo "::set-output name=dir::$CCACHE_DIR"
+        echo "dir=$CCACHE_DIR" >> $GITHUB_OUTPUT
         NOW=$(date -u +"%F-%T")
-        echo "::set-output name=timestamp::${NOW}"
+        echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
 
     - name: Setup compiler cache
       uses:  actions/cache@v3

--- a/.github/workflows/macos_meson.yml
+++ b/.github/workflows/macos_meson.yml
@@ -45,9 +45,9 @@ jobs:
       shell: bash -l {0}
       run: |
         mkdir -p "${CCACHE_DIR}"
-        echo "::set-output name=dir::$CCACHE_DIR"
+        echo "dir=$CCACHE_DIR" >> $GITHUB_OUTPUT
         NOW=$(date -u +"%F-%T")
-        echo "::set-output name=timestamp::${NOW}"
+        echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
 
     - name: Setup compiler cache
       uses:  actions/cache@v3
@@ -81,7 +81,7 @@ jobs:
 
     - name: Get Date
       id: get-date
-      run: echo "::set-output name=today::$(/bin/date -u '+%Y%m%d')"
+      run: echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Cache conda

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -53,7 +53,7 @@ jobs:
           if [[ "$COMMIT_MSG" == *"[wheel build]"* ]]; then
               RUN="1" 
           fi
-          echo "::set-output name=message::$RUN"
+          echo "message=$RUN" >> $GITHUB_OUTPUT
           echo github.ref ${{ github.ref }}
 
   build_wheels:


### PR DESCRIPTION
Github Actions is going to be deprecating set-output and save-state, remove instance from CI

Closes #17206