### PR TITLE
TST: stats.sampling.NumericalInverseHermite: filter all RuntimeWarnings

### DIFF
--- a/scipy/stats/tests/test_sampling.py
+++ b/scipy/stats/tests/test_sampling.py
@@ -1005,6 +1005,7 @@ class TestNumericalInverseHermite:
         with pytest.raises(err, match=msg):
             NumericalInverseHermite(StandardNormal(), domain=domain)
 
+    @pytest.mark.filterwarnings('ignore::RuntimeWarning')
     @pytest.mark.xslow
     @pytest.mark.parametrize(("distname", "shapes"), distcont)
     def test_basic_all_scipy_dists(self, distname, shapes):
@@ -1023,12 +1024,7 @@ class TestNumericalInverseHermite:
         np.random.seed(0)
 
         dist = getattr(stats, distname)(*shapes)
-
-        with np.testing.suppress_warnings() as sup:
-            sup.filter(RuntimeWarning, "overflow encountered")
-            sup.filter(RuntimeWarning, "divide by zero")
-            sup.filter(RuntimeWarning, "invalid value encountered")
-            fni = NumericalInverseHermite(dist)
+        fni = NumericalInverseHermite(dist)
 
         x = np.random.rand(10)
         p_tol = np.max(np.abs(dist.ppf(x)-fni.ppf(x))/np.abs(dist.ppf(x)))


### PR DESCRIPTION
#### Reference issue
gh-15384

#### What does this implement/fix?
gh-15384 reported an XSLOW test failure in `scipy/stats/tests/test_sampling.py::TestNumericalInverseHermite::test_basic_all_scipy_dists[anglit-shapes1]` caused by a `RuntimeWarning`. In `main`, we already filter three types of `RuntimeWarning`s in this test; this is just another type that happens to be emitted on some platforms. Rather than suppress new `RuntimeWarning`s as they arise, this suppresses them all. If the test passes the accuracy check, then the warnings aren't really concerning. 

#### Additional information
As discussed [here](https://github.com/scipy/scipy/issues/15384#issuecomment-1275603471).
@tirthasheshpatel please also see gh-17161.