### PR TITLE
ENH: subclass-friendly refactor RegularGridInterpolator

### DIFF
--- a/benchmarks/benchmarks/interpolate.py
+++ b/benchmarks/benchmarks/interpolate.py
@@ -262,12 +262,14 @@ class RegularGridInterpolator(Benchmark):
 
         # coordinates halve in size over the dimensions
         coord_sizes = [max_coord_size // 2**i for i in range(ndim)]
-        self.points = [np.sort(rng.random(size=s))[::flipped] for s in coord_sizes]
+        self.points = [np.sort(rng.random(size=s))[::flipped]
+                       for s in coord_sizes]
         self.values = rng.random(size=coord_sizes)
 
         # choose in-bounds sample points xi
         bounds = [(p.min(), p.max()) for p in self.points]
-        xi = [rng.uniform(low, high, size=n_samples) for low, high in bounds]
+        xi = [rng.uniform(low, high, size=n_samples)
+              for low, high in bounds]
         self.xi = np.array(xi).T
 
         self.interp = interpolate.RegularGridInterpolator(
@@ -275,7 +277,8 @@ class RegularGridInterpolator(Benchmark):
             self.values,
         )
 
-    def time_rgi_setup_interpolator(self, ndim, max_coord_size, n_samples, flipped):
+    def time_rgi_setup_interpolator(self, ndim, max_coord_size,
+                                    n_samples, flipped):
         self.interp = interpolate.RegularGridInterpolator(
             self.points,
             self.values,
@@ -292,8 +295,8 @@ class RegularGridInterpolatorValues(interpolate.RegularGridInterpolator):
         super().__init__(points, values, **kwargs)
         self._is_initialized = False
         # precompute values
-        self.xi, self.xi_shape, self.ndim, self.nans, self.out_of_bounds = self._prepare_xi(
-            xi)
+        (self.xi, self.xi_shape, self.ndim,
+         self.nans, self.out_of_bounds) = self._prepare_xi(xi)
         self.indices, self.norm_distances = self._find_indices(xi.T)
         self._is_initialized = True
 
@@ -302,7 +305,8 @@ class RegularGridInterpolatorValues(interpolate.RegularGridInterpolator):
             return super()._prepare_xi(xi)
         else:
             # just give back precomputed values
-            return self.xi, self.xi_shape, self.ndim, self.nans, self.out_of_bounds
+            return (self.xi, self.xi_shape, self.ndim,
+                    self.nans, self.out_of_bounds)
 
     def _find_indices(self, xi):
         if not self._is_initialized:
@@ -339,12 +343,14 @@ class RegularGridInterpolatorSubclass(Benchmark):
 
         # coordinates halve in size over the dimensions
         coord_sizes = [max_coord_size // 2**i for i in range(ndim)]
-        self.points = [np.sort(rng.random(size=s))[::flipped] for s in coord_sizes]
+        self.points = [np.sort(rng.random(size=s))[::flipped]
+                       for s in coord_sizes]
         self.values = rng.random(size=coord_sizes)
 
         # choose in-bounds sample points xi
         bounds = [(p.min(), p.max()) for p in self.points]
-        xi = [rng.uniform(low, high, size=n_samples) for low, high in bounds]
+        xi = [rng.uniform(low, high, size=n_samples)
+              for low, high in bounds]
         self.xi = np.array(xi).T
 
         self.interp = RegularGridInterpolatorValues(
@@ -352,7 +358,8 @@ class RegularGridInterpolatorSubclass(Benchmark):
             self.xi,
         )
 
-    def time_rgi_setup_interpolator(self, ndim, max_coord_size, n_samples, flipped):
+    def time_rgi_setup_interpolator(self, ndim, max_coord_size,
+                                    n_samples, flipped):
         self.interp = RegularGridInterpolatorValues(
             self.points,
             self.xi,

--- a/benchmarks/benchmarks/interpolate.py
+++ b/benchmarks/benchmarks/interpolate.py
@@ -322,7 +322,7 @@ class RegularGridInterpolatorValues(interpolate.RegularGridInterpolator):
         # check dimensionality
         self._check_dimensionality(self.grid, values)
         # flip, if needed
-        self.values = np.flip(values, axis=self.descending_dimensions)
+        self.values = np.flip(values, axis=self._descending_dimensions)
         return super().__call__(self.xi, method=method)
 
 

--- a/benchmarks/benchmarks/interpolate.py
+++ b/benchmarks/benchmarks/interpolate.py
@@ -322,7 +322,7 @@ class RegularGridInterpolatorValues(interpolate.RegularGridInterpolator):
         # check dimensionality
         self._check_dimensionality(self.grid, values)
         # flip, if needed
-        self.values = np.flip(values, axis=self._descending_dimensions)
+        self.values = np.flip(values, axis=self.descending_dimensions)
         return super().__call__(self.xi, method=method)
 
 

--- a/benchmarks/benchmarks/interpolate.py
+++ b/benchmarks/benchmarks/interpolate.py
@@ -249,23 +249,24 @@ class RegularGridInterpolator(Benchmark):
     """
     Benchmark RegularGridInterpolator with method="linear".
     """
-    param_names = ['ndim', 'max_coord_size', 'n_samples']
+    param_names = ['ndim', 'max_coord_size', 'n_samples', 'flipped']
     params = [
         [2, 3, 4],
         [10, 40, 200],
         [10, 100, 1000, 10000],
+        [1, -1]
     ]
 
-    def setup(self, ndim, max_coord_size, n_samples):
+    def setup(self, ndim, max_coord_size, n_samples, flipped):
         rng = np.random.default_rng(314159)
 
         # coordinates halve in size over the dimensions
         coord_sizes = [max_coord_size // 2**i for i in range(ndim)]
-        self.points = [np.sort(rng.random(size=s)) for s in coord_sizes]
+        self.points = [np.sort(rng.random(size=s))[::flipped] for s in coord_sizes]
         self.values = rng.random(size=coord_sizes)
 
         # choose in-bounds sample points xi
-        bounds = [(p[0], p[-1]) for p in self.points]
+        bounds = [(p.min(), p.max()) for p in self.points]
         xi = [rng.uniform(low, high, size=n_samples) for low, high in bounds]
         self.xi = np.array(xi).T
 
@@ -274,5 +275,88 @@ class RegularGridInterpolator(Benchmark):
             self.values,
         )
 
-    def time_rgi(self, ndim, max_coord_size, n_samples):
+    def time_rgi_setup_interpolator(self, ndim, max_coord_size, n_samples, flipped):
+        self.interp = interpolate.RegularGridInterpolator(
+            self.points,
+            self.values,
+        )
+
+    def time_rgi(self, ndim, max_coord_size, n_samples, flipped):
         self.interp(self.xi)
+
+
+class RegularGridInterpolatorValues(interpolate.RegularGridInterpolator):
+    def __init__(self, points, xi, **kwargs):
+        # create fake values for initialization
+        values = np.zeros(tuple([len(pt) for pt in points]))
+        super().__init__(points, values, **kwargs)
+        self._is_initialized = False
+        # precompute values
+        self.xi, self.xi_shape, self.ndim, self.nans, self.out_of_bounds = self._prepare_xi(
+            xi)
+        self.indices, self.norm_distances = self._find_indices(xi.T)
+        self._is_initialized = True
+
+    def _prepare_xi(self, xi):
+        if not self._is_initialized:
+            return super()._prepare_xi(xi)
+        else:
+            # just give back precomputed values
+            return self.xi, self.xi_shape, self.ndim, self.nans, self.out_of_bounds
+
+    def _find_indices(self, xi):
+        if not self._is_initialized:
+            return super()._find_indices(xi)
+        else:
+            # just give back pre-computed values
+            return self.indices, self.norm_distances
+
+    def __call__(self, values, method=None):
+        values = self._check_values(values)
+        # check fillvalue
+        self._check_fill_value(values, self.fill_value)
+        # check dimensionality
+        self._check_dimensionality(self.grid, values)
+        # flip, if needed
+        self.values = np.flip(values, axis=self._descending_dimensions)
+        return super().__call__(self.xi, method=method)
+
+
+class RegularGridInterpolatorSubclass(Benchmark):
+    """
+    Benchmark RegularGridInterpolator with method="linear".
+    """
+    param_names = ['ndim', 'max_coord_size', 'n_samples', 'flipped']
+    params = [
+        [2, 3, 4],
+        [10, 40, 200],
+        [10, 100, 1000, 10000],
+        [1, -1]
+    ]
+
+    def setup(self, ndim, max_coord_size, n_samples, flipped):
+        rng = np.random.default_rng(314159)
+
+        # coordinates halve in size over the dimensions
+        coord_sizes = [max_coord_size // 2**i for i in range(ndim)]
+        self.points = [np.sort(rng.random(size=s))[::flipped] for s in coord_sizes]
+        self.values = rng.random(size=coord_sizes)
+
+        # choose in-bounds sample points xi
+        bounds = [(p.min(), p.max()) for p in self.points]
+        xi = [rng.uniform(low, high, size=n_samples) for low, high in bounds]
+        self.xi = np.array(xi).T
+
+        self.interp = RegularGridInterpolatorValues(
+            self.points,
+            self.xi,
+        )
+
+    def time_rgi_setup_interpolator(self, ndim, max_coord_size, n_samples, flipped):
+        self.interp = RegularGridInterpolatorValues(
+            self.points,
+            self.xi,
+        )
+
+    def time_rgi(self, ndim, max_coord_size, n_samples, flipped):
+        self.interp(self.values)

--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -219,8 +219,7 @@ class RegularGridInterpolator:
         self.bounds_error = bounds_error
         values = self._check_values(values)
         self._check_dimensionality(points, values)
-        self._check_fill_value(values, fill_value)
-        self.fill_value = fill_value
+        self._fill_value = self._check_fill_value(values, fill_value)
         self._descending_dimensions = self._check_points(points)
         self.grid = tuple([np.flip(p) if i in self._descending_dimensions
                            else np.asarray(p)
@@ -257,6 +256,7 @@ class RegularGridInterpolator:
                                 casting='same_kind')):
                 raise ValueError("fill_value must be either 'None' or "
                                  "of a type compatible with values")
+        return fill_value
 
     def _check_points(self, points):
         descending_dimensions = []

--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -217,12 +217,12 @@ class RegularGridInterpolator:
             self._validate_grid_dimensions(points, method)
         self.method = method
         self.bounds_error = bounds_error
-        self.grid, self.descending_dimensions = self._check_points(points)
+        self.grid, self._descending_dimensions = self._check_points(points)
         self.values = self._check_values(values)
         self._check_dimensionality(self.grid, self.values)
         self.fill_value = self._check_fill_value(self.values, fill_value)
-        if self.descending_dimensions:
-            self.values = np.flip(values, axis=self.descending_dimensions)
+        if self._descending_dimensions:
+            self.values = np.flip(values, axis=self._descending_dimensions)
 
     def _check_dimensionality(self, points, values):
         if len(points) > values.ndim:

--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -218,10 +218,11 @@ class RegularGridInterpolator:
         self.method = method
         self.bounds_error = bounds_error
         self.grid, self.descending_dimensions = self._check_points(points)
-        values = self._check_values(values)
-        self._check_dimensionality(points, values)
-        self.fill_value = self._check_fill_value(values, fill_value)
-        self.values = np.flip(values, axis=self.descending_dimensions)
+        self.values = self._check_values(values)
+        self._check_dimensionality(self.grid, self.values)
+        self.fill_value = self._check_fill_value(self.values, fill_value)
+        if self.descending_dimensions:
+            self.values = np.flip(values, axis=self.descending_dimensions)
 
     def _check_dimensionality(self, points, values):
         if len(points) > values.ndim:
@@ -263,9 +264,8 @@ class RegularGridInterpolator:
             # early make points float
             # see https://github.com/scipy/scipy/pull/17230
             p = np.asarray(p, dtype=float)
-            diff_p = np.diff(p)
-            if not np.all(diff_p > 0.):
-                if np.all(diff_p < 0.):
+            if not np.all(p[1:] > p[:-1]):
+                if np.all(p[1:] < p[:-1]):
                     # input is descending, so make it ascending
                     descending_dimensions.append(i)
                     p = np.flip(p)

--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -218,13 +218,15 @@ class RegularGridInterpolator:
         self.method = method
         self.bounds_error = bounds_error
         # todo: sort checks in order of complexity and runtime, raising early
-        self._check_dimensionality(points, values)
         values = self._check_values(values)
+        self._check_dimensionality(points, values)
         self._check_fill_value(values, fill_value)
+        self.fill_value = fill_value
         flip = self._check_points(points)
         self.flip = flip
         self.fill_value = fill_value
-        self.grid = tuple([np.flip(p) if i in flip else np.asarray(p) for i, p in enumerate(points)])
+        self.grid = tuple([np.flip(p) if i in flip else np.asarray(p)
+                           for i, p in enumerate(points)])
         self.values = np.flip(values, axis=flip)
 
     def _check_dimensionality(self, points, values):

--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -217,20 +217,39 @@ class RegularGridInterpolator:
             self._validate_grid_dimensions(points, method)
         self.method = method
         self.bounds_error = bounds_error
+        # todo: sort checks in order of complexity and runtime, raising early
+        self._check_dimensionality(points, values)
+        values = self._check_values(values)
+        self._check_fill_value(values, fill_value)
+        flip = self._check_points(points)
+        self.flip = flip
+        self.fill_value = fill_value
+        self.grid = tuple([np.flip(p) if i in flip else np.asarray(p) for i, p in enumerate(points)])
+        self.values = np.flip(values, axis=flip)
 
+    def _check_dimensionality(self, points, values):
+        if len(points) > values.ndim:
+            raise ValueError("There are %d point arrays, but values has %d "
+                             "dimensions" % (len(points), values.ndim))
+        for i, p in enumerate(points):
+            if not np.asarray(p).ndim == 1:
+                raise ValueError("The points in dimension %d must be "
+                                 "1-dimensional" % i)
+            if not values.shape[i] == len(p):
+                raise ValueError("There are %d points and %d values in "
+                                 "dimension %d" % (len(p), values.shape[i], i))
+
+    def _check_values(self, values):
         if not hasattr(values, 'ndim'):
             # allow reasonable duck-typed values
             values = np.asarray(values)
 
-        if len(points) > values.ndim:
-            raise ValueError("There are %d point arrays, but values has %d "
-                             "dimensions" % (len(points), values.ndim))
-
         if hasattr(values, 'dtype') and hasattr(values, 'astype'):
             if not np.issubdtype(values.dtype, np.inexact):
                 values = values.astype(float)
+        return values
 
-        self.fill_value = fill_value
+    def _check_fill_value(self, values, fill_value):
         if fill_value is not None:
             fill_value_dtype = np.asarray(fill_value).dtype
             if (hasattr(values, 'dtype') and not
@@ -239,25 +258,20 @@ class RegularGridInterpolator:
                 raise ValueError("fill_value must be either 'None' or "
                                  "of a type compatible with values")
 
+    def _check_points(self, points):
+        flip = []
         for i, p in enumerate(points):
             diff_p = np.diff(p)
             if not np.all(diff_p > 0.):
                 if np.all(diff_p < 0.):
                     # input is descending, so make it ascending
-                    points, values = _make_points_and_values_ascending(
-                        points, values)
+                    flip.append(i)
                 else:
                     raise ValueError(
                         "The points in dimension %d must be strictly "
                         "ascending or descending" % i)
-            if not np.asarray(p).ndim == 1:
-                raise ValueError("The points in dimension %d must be "
-                                 "1-dimensional" % i)
-            if not values.shape[i] == len(p):
-                raise ValueError("There are %d points and %d values in "
-                                 "dimension %d" % (len(p), values.shape[i], i))
-        self.grid = tuple([np.asarray(p) for p in points])
-        self.values = values
+
+        return tuple(flip)
 
     def __call__(self, xi, method=None):
         """
@@ -313,6 +327,28 @@ class RegularGridInterpolator:
         if method not in self._ALL_METHODS:
             raise ValueError("Method '%s' is not defined" % method)
 
+        xi, xi_shape, ndim, nans, out_of_bounds = self._prepare_xi(xi)
+
+        if method == "linear":
+            indices, norm_distances = self._find_indices(xi.T)
+            result = self._evaluate_linear(indices, norm_distances)
+        elif method == "nearest":
+            indices, norm_distances = self._find_indices(xi.T)
+            result = self._evaluate_nearest(indices, norm_distances)
+        elif method in self._SPLINE_METHODS:
+            if is_method_changed:
+                self._validate_grid_dimensions(self.grid, method)
+            result = self._evaluate_spline(xi, method)
+
+        if not self.bounds_error and self.fill_value is not None:
+            result[out_of_bounds] = self.fill_value
+
+        # f(nan) = nan, if any
+        if np.any(nans):
+            result[nans] = np.nan
+        return result.reshape(xi_shape[:-1] + self.values.shape[ndim:])
+
+    def _prepare_xi(self, xi):
         ndim = len(self.grid)
         xi = _ndim_coords_from_arrays(xi, ndim=ndim)
         if xi.shape[-1] != len(self.grid):
@@ -336,24 +372,7 @@ class RegularGridInterpolator:
         else:
             out_of_bounds = self._find_out_of_bounds(xi.T)
 
-        if method == "linear":
-            indices, norm_distances = self._find_indices(xi.T)
-            result = self._evaluate_linear(indices, norm_distances)
-        elif method == "nearest":
-            indices, norm_distances = self._find_indices(xi.T)
-            result = self._evaluate_nearest(indices, norm_distances)
-        elif method in self._SPLINE_METHODS:
-            if is_method_changed:
-                self._validate_grid_dimensions(self.grid, method)
-            result = self._evaluate_spline(xi, method)
-
-        if not self.bounds_error and self.fill_value is not None:
-            result[out_of_bounds] = self.fill_value
-
-        # f(nan) = nan, if any
-        if np.any(nans):
-            result[nans] = np.nan
-        return result.reshape(xi_shape[:-1] + self.values.shape[ndim:])
+        return xi, xi_shape, ndim, nans, out_of_bounds
 
     def _evaluate_linear(self, indices, norm_distances):
         # slice for broadcasting over trailing dimensions in self.values

--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -508,13 +508,18 @@ class TestRegularGridInterpolator:
         assert_allclose(v, v2, atol=1e-14, err_msg=method)
 
     @parametrize_rgi_interp_methods
-    def test_nonscalar_values_2(self, method):
+    @pytest.mark.parametrize("flip_points", [False, True])
+    def test_nonscalar_values_2(self, method, flip_points):
         # Verify that non-scalar valued values also work : use different
         # lengths of axes to simplify tracing the internals
         points = [(0.0, 0.5, 1.0, 1.5, 2.0, 2.5),
                   (0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0),
                   (0.0, 5.0, 10.0, 15.0, 20, 25.0, 35.0, 36.0),
                   (0.0, 5.0, 10.0, 15.0, 20, 25.0, 35.0, 36.0, 47)]
+
+        # verify, that strictly decreasing dimensions work
+        if flip_points:
+            points = [tuple(reversed(p)) for p in points]
 
         rng = np.random.default_rng(1234)
 

--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -434,7 +434,8 @@ class TestRegularGridInterpolator:
         assert_equal(res[i], np.nan)
         assert_equal(res[~i], interp(z[~i]))
 
-    def test_descending_points(self):
+    @parametrize_rgi_interp_methods
+    def test_descending_points(self, method):
         def val_func_3d(x, y, z):
             return 2 * x ** 3 + 3 * y ** 2 - z
 
@@ -445,7 +446,8 @@ class TestRegularGridInterpolator:
         values = val_func_3d(
             *np.meshgrid(*points, indexing='ij', sparse=True))
         my_interpolating_function = RegularGridInterpolator(points,
-                                                            values)
+                                                            values,
+                                                            method=method)
         pts = np.array([[2.1, 6.2, 8.3], [3.3, 5.2, 7.1]])
         correct_result = my_interpolating_function(pts)
 
@@ -457,7 +459,7 @@ class TestRegularGridInterpolator:
         values_shuffled = val_func_3d(
             *np.meshgrid(*points_shuffled, indexing='ij', sparse=True))
         my_interpolating_function = RegularGridInterpolator(
-            points_shuffled, values_shuffled)
+            points_shuffled, values_shuffled, method=method)
         test_result = my_interpolating_function(pts)
 
         assert_array_equal(correct_result, test_result)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Supersedes gh-10860
#### What does this implement/fix?
<!--Please explain your changes.-->

Code is refactored to be easier to subclass (eg. overriding methods)   

#### Additional information
<!--Any additional information you think is important.-->

Added one instance variable `_descending_dimensions` which holds a `tuple` of `int` which hold the dimensions with descending order. `points` and `values` are flipped according to that tuple. Removed the current (very slow) code to sort `points`. 

A subclass where `values` instead of `xi` are evaluated on `__call__` would look like this:

```python
class RegularGridInterpolatorValues(RegularGridInterpolator):
    def __init__(self, points, xi, **kwargs):
        # create fake values for initialization
        values = np.zeros(tuple([len(pt) for pt in points]))
        super().__init__(points, values, **kwargs)
        self._is_initialized = False
        # precompute values
        self.xi, self.xi_shape, self.ndim, self.nans, self.out_of_bounds = self._prepare_xi(xi)
        self.indices, self.norm_distances = self._find_indices(xi.T)
        self._is_initialized = True

    def _prepare_xi(self, xi):
        if not self._is_initialized:
            return super()._prepare_xi(xi)
        else:
            # just give back precomputed values
            return self.xi, self.xi_shape, self.ndim, self.nans, self.out_of_bounds

    def _find_indices(self, xi):
        if not self._is_initialized:
            return super()._find_indices(xi)
        else:
            # just give back pre-computed values
            return self.indices, self.norm_distances

    def __call__(self, values, method=None):
        valiues = self._check_values(values)
        # check fillvalue
        self._check_fill_value(values, self.fill_value)
        # check dimensionality
        self._check_dimensionality(self.grid, values)
        # flip, if needed
        self.values = np.flip(values, axis=self.flip)
        return super().__call__(self.xi, method=method)
``` 