### PR TITLE
stats/distributions: make rv_sample public, allow subclassing

### DIFF
--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -40,7 +40,7 @@ Each univariate distribution is an instance of a subclass of `rv_continuous`
 
    rv_continuous
    rv_discrete
-   rv_sample
+   rv_count
    rv_histogram
 
 Continuous distributions
@@ -482,7 +482,7 @@ from ._warnings_errors import (ConstantInputWarning, NearConstantInputWarning,
 from ._stats_py import *
 from ._variation import variation
 from .distributions import *
-from ._distn_infrastructure import rv_sample
+from ._distn_infrastructure import rv_count
 from ._morestats import *
 from ._binomtest import binomtest
 from ._binned_statistic import *

--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -40,6 +40,7 @@ Each univariate distribution is an instance of a subclass of `rv_continuous`
 
    rv_continuous
    rv_discrete
+   rv_sample
    rv_histogram
 
 Continuous distributions
@@ -481,6 +482,7 @@ from ._warnings_errors import (ConstantInputWarning, NearConstantInputWarning,
 from ._stats_py import *
 from ._variation import variation
 from .distributions import *
+from ._distn_infrastructure import rv_sample
 from ._morestats import *
 from ._binomtest import binomtest
 from ._binned_statistic import *

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -1054,7 +1054,7 @@ class rv_generic:
             self._random_state = random_state_saved
 
         # Cast to int if discrete
-        if discrete and not isinstance(self, _rv_sample):
+        if discrete and not isinstance(self, rv_sample):
             if size == ():
                 vals = int(vals)
             else:
@@ -3130,7 +3130,7 @@ class rv_discrete(rv_generic):
         values = kwds.get('values', None)
         if values is not None:
             # dispatch to a subclass
-            return super(rv_discrete, cls).__new__(_rv_sample)
+            return super(rv_discrete, cls).__new__(rv_sample)
         else:
             # business as usual
             return super(rv_discrete, cls).__new__(cls)
@@ -3340,7 +3340,7 @@ class rv_discrete(rv_generic):
         k = asarray((k-loc))
         cond0 = self._argcheck(*args)
         cond1 = (k >= _a) & (k <= _b)
-        if not isinstance(self, _rv_sample):
+        if not isinstance(self, rv_sample):
             cond1 = cond1 & self._nonzero(k, *args)
         cond = cond0 & cond1
         output = zeros(shape(cond), 'd')
@@ -3378,7 +3378,7 @@ class rv_discrete(rv_generic):
         k = asarray((k-loc))
         cond0 = self._argcheck(*args)
         cond1 = (k >= _a) & (k <= _b)
-        if not isinstance(self, _rv_sample):
+        if not isinstance(self, rv_sample):
             cond1 = cond1 & self._nonzero(k, *args)
         cond = cond0 & cond1
         output = empty(shape(cond), 'd')
@@ -3729,7 +3729,7 @@ class rv_discrete(rv_generic):
         else:
             invfac = 1.0
 
-        if isinstance(self, _rv_sample):
+        if isinstance(self, rv_sample):
             res = self._expect(fun, lb, ub)
             return res / invfac
 
@@ -3821,7 +3821,7 @@ def _iter_chunked(x0, x1, chunksize=4, inc=1):
         yield supp
 
 
-class _rv_sample(rv_discrete):
+class rv_sample(rv_discrete):
     """A 'sample' discrete distribution defined by the support and values.
 
     The ctor ignores most of the arguments, only needs the `values` argument.

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -3837,7 +3837,7 @@ class _rv_sample(rv_discrete):
                           "SciPy 1.11.0", DeprecationWarning)
 
         if values is None:
-            raise ValueError("rv_sample.__init__(..., values=None,...)")
+            raise ValueError("rv_count.__init__(..., values=None,...)")
 
         # cf generic freeze
         self._ctor_param = dict(
@@ -3912,28 +3912,98 @@ class _rv_sample(rv_discrete):
         return self.a, self.b
 
     def _pmf(self, x):
-        return rv_sample._pmf(self, x)
+        return rv_count._pmf(self, x)
 
     def _cdf(self, x):
-        return rv_sample._cdf(self, x)
+        return rv_count._cdf(self, x)
 
     def _ppf(self, q):
-        return rv_sample._ppf(self, q)
+        return rv_count._ppf(self, q)
 
     def _rvs(self, size=None, random_state=None):
-        return rv_sample._rvs(self, size, random_state)
+        return rv_count._rvs(self, size, random_state)
 
     def _entropy(self):
-        return rv_sample._entropy(self)
+        return rv_count._entropy(self)
 
     def generic_moment(self, n):
-        return rv_sample.generic_moment(self, n)
+        return rv_count.generic_moment(self, n)
 
     def _expect(self, fun, lb, ub, *args, **kwds):
-        return rv_sample._expect(self, fun, lb, ub, *args, **kwds)
+        return rv_count._expect(self, fun, lb, ub, *args, **kwds)
 
 
-class rv_sample(rv_discrete):
+class rv_count(rv_discrete):
+    """A discrete random variable defined by support points and probabilities.
+
+    Parameters
+    ----------
+    xk : array_like
+        Support points.
+    pk : array_like
+        The probabilities, corresponding to `xk`
+    name : str, optional
+        The name of the instance. This string is used to construct the default
+        example for distributions.
+    longname : str, optional
+        This string is used as part of the first line of the docstring returned
+        when a subclass has no docstring of its own. Note: `longname` exists
+        for backwards compatibility, do not use for new subclasses.
+    seed : {None, int, `numpy.random.Generator`, `numpy.random.RandomState`}, optional
+        If `seed` is None (or `np.random`), the `numpy.random.RandomState`
+        singleton is used.
+        If `seed` is an int, a new ``RandomState`` instance is used,
+        seeded with `seed`.
+        If `seed` is already a ``Generator`` or ``RandomState`` instance then
+        that instance is used.
+
+    Methods
+    -------
+    rvs
+    pmf
+    logpmf
+    cdf
+    logcdf
+    sf
+    logsf
+    ppf
+    isf
+    moment
+    stats
+    entropy
+    expect
+    median
+    mean
+    std
+    var
+    interval
+    __call__
+    support
+
+    Notes
+    -----
+    This class is a discrete analog of `rv_histogram`.
+
+    Examples
+    --------
+
+    >>> import numpy as np
+    >>> from scipy import stats
+    >>> xk = np.arange(7)
+    >>> pk = (0.1, 0.2, 0.3, 0.1, 0.1, 0.0, 0.2)
+    >>> custm = stats.rv_count(xk, pk, name='custm')
+    >>>
+    >>> import matplotlib.pyplot as plt
+    >>> fig, ax = plt.subplots(1, 1)
+    >>> ax.plot(xk, custm.pmf(xk), 'ro', ms=12, mec='r')
+    >>> ax.vlines(xk, 0, custm.pmf(xk), colors='r', lw=4)
+    >>> plt.show()
+
+    Random number generation:
+
+    >>> R = custm.rvs(size=100)
+
+    """
     def __init__(self, xk, pk, name=None, longname=None, seed=None):
         super(rv_discrete, self).__init__(seed)
 
@@ -3985,7 +4055,7 @@ class rv_sample(rv_discrete):
         """Return the current version of _ctor_param, possibly updated by user.
 
         Used by freezing. Keep this in sync with the signature of __init__.
-        Just copy the _ctor_param for rv_sample.
+        Just copy the _ctor_param for rv_count.
         """
         dct = self._ctor_param.copy()
         return dct

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -1054,7 +1054,7 @@ class rv_generic:
             self._random_state = random_state_saved
 
         # Cast to int if discrete
-        if discrete and not isinstance(self, rv_sample):
+        if discrete and not isinstance(self, _rv_sample):
             if size == ():
                 vals = int(vals)
             else:
@@ -3126,13 +3126,11 @@ class rv_discrete(rv_generic):
     >>> R = custm.rvs(size=100)
 
     """
-    def __new__(cls, a=0, b=inf, name=None, badvalue=None,
-                moment_tol=1e-8, values=None, inc=1, longname=None,
-                shapes=None, extradoc=None, seed=None):
-
+    def __new__(cls, *args, **kwds):
+        values = kwds.get('values', None)
         if values is not None:
             # dispatch to a subclass
-            return super(rv_discrete, cls).__new__(rv_sample)
+            return super(rv_discrete, cls).__new__(_rv_sample)
         else:
             # business as usual
             return super(rv_discrete, cls).__new__(cls)
@@ -3342,7 +3340,7 @@ class rv_discrete(rv_generic):
         k = asarray((k-loc))
         cond0 = self._argcheck(*args)
         cond1 = (k >= _a) & (k <= _b)
-        if not isinstance(self, rv_sample):
+        if not isinstance(self, _rv_sample):
             cond1 = cond1 & self._nonzero(k, *args)
         cond = cond0 & cond1
         output = zeros(shape(cond), 'd')
@@ -3380,7 +3378,7 @@ class rv_discrete(rv_generic):
         k = asarray((k-loc))
         cond0 = self._argcheck(*args)
         cond1 = (k >= _a) & (k <= _b)
-        if not isinstance(self, rv_sample):
+        if not isinstance(self, _rv_sample):
             cond1 = cond1 & self._nonzero(k, *args)
         cond = cond0 & cond1
         output = empty(shape(cond), 'd')
@@ -3731,7 +3729,7 @@ class rv_discrete(rv_generic):
         else:
             invfac = 1.0
 
-        if isinstance(self, rv_sample):
+        if isinstance(self, _rv_sample):
             res = self._expect(fun, lb, ub)
             return res / invfac
 
@@ -3823,7 +3821,7 @@ def _iter_chunked(x0, x1, chunksize=4, inc=1):
         yield supp
 
 
-class rv_sample(rv_discrete):
+class _rv_sample(rv_discrete):
     """A 'sample' discrete distribution defined by the support and values.
 
     The ctor ignores most of the arguments, only needs the `values` argument.
@@ -3891,6 +3889,105 @@ class rv_sample(rv_discrete):
         attrs = ["_parse_args", "_parse_args_stats", "_parse_args_rvs"]
         [dct.pop(attr, None) for attr in attrs]
 
+        return dct
+
+    def _attach_methods(self):
+        """Attaches dynamically created argparser methods."""
+        self._attach_argparser_methods()
+
+    def _get_support(self, *args):
+        """Return the support of the (unscaled, unshifted) distribution.
+
+        Parameters
+        ----------
+        arg1, arg2, ... : array_like
+            The shape parameter(s) for the distribution (see docstring of the
+            instance object for more information).
+
+        Returns
+        -------
+        a, b : numeric (float, or int or +/-np.inf)
+            end-points of the distribution's support.
+        """
+        return self.a, self.b
+
+    def _pmf(self, x):
+        return rv_sample._pmf(self, x)
+
+    def _cdf(self, x):
+        return rv_sample._cdf(self, x)
+
+    def _ppf(self, q):
+        return rv_sample._ppf(self, q)
+
+    def _rvs(self, size=None, random_state=None):
+        return rv_sample._rvs(self, size, random_state)
+
+    def _entropy(self):
+        return rv_sample._entropy(self)
+
+    def generic_moment(self, n):
+        return rv_sample.generic_moment(self, n)
+
+    def _expect(self, fun, lb, ub, *args, **kwds):
+        return rv_sample._expect(self, fun, lb, ub, *args, **kwds)
+
+
+class rv_sample(rv_discrete):
+    def __init__(self, xk, pk, name=None, longname=None, seed=None):
+        super(rv_discrete, self).__init__(seed)
+
+        # cf generic freeze
+        self._ctor_param = dict(xk=xk, pk=pk, seed=seed,
+                                name=name, longname=longname)
+
+        self.badvalue = np.nan
+        self.vecentropy = self._entropy
+        self.inc = 1
+
+        if np.shape(xk) != np.shape(pk):
+            raise ValueError("xk and pk must have the same shape.")
+        if np.less(pk, 0.0).any():
+            raise ValueError("All elements of pk must be non-negative.")
+        if not np.allclose(np.sum(pk), 1):
+            raise ValueError("The sum of provided pk is not 1.")
+
+        indx = np.argsort(np.ravel(xk))
+        self.xk = np.take(np.ravel(xk), indx, 0)
+        self.pk = np.take(np.ravel(pk), indx, 0)
+        self.a = self.xk[0]
+        self.b = self.xk[-1]
+
+        self.qvals = np.cumsum(self.pk, axis=0)
+
+        self.shapes = ' '   # bypass inspection
+
+        self._construct_argparser(meths_to_inspect=[self._pmf],
+                                  locscale_in='loc=0',
+                                  # scale=1 for discrete RVs
+                                  locscale_out='loc, 1')
+
+        self._attach_methods()
+
+        self._construct_docstrings(name, longname, extradoc=None)
+
+    def __getstate__(self):
+        dct = self.__dict__.copy()
+
+        # these methods will be remade in rv_generic.__setstate__,
+        # which calls rv_generic._attach_methods
+        attrs = ["_parse_args", "_parse_args_stats", "_parse_args_rvs"]
+        [dct.pop(attr, None) for attr in attrs]
+
+        return dct
+
+    def _updated_ctor_param(self):
+        """Return the current version of _ctor_param, possibly updated by user.
+
+        Used by freezing. Keep this in sync with the signature of __init__.
+        Just copy the _ctor_param for rv_sample.
+        """
+        dct = self._ctor_param.copy()
         return dct
 
     def _attach_methods(self):

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -3949,7 +3949,9 @@ class rv_count(rv_discrete):
         This string is used as part of the first line of the docstring returned
         when a subclass has no docstring of its own. Note: `longname` exists
         for backwards compatibility, do not use for new subclasses.
-    seed : {None, int, `numpy.random.Generator`, `numpy.random.RandomState`}, optional
+    seed : {None, int, `numpy.random.Generator`,
+            `numpy.random.RandomState`}, optional
+
         If `seed` is None (or `np.random`), the `numpy.random.RandomState`
         singleton is used.
         If `seed` is an int, a new ``RandomState`` instance is used,

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -18,7 +18,7 @@ from scipy.stats._distn_infrastructure import rv_discrete_frozen
 
 vals = ([1, 2, 3, 4], [0.1, 0.2, 0.3, 0.4])
 distdiscrete += [[stats.rv_discrete(values=vals), ()],
-                 [stats.rv_sample(xk=vals[0], pk=vals[1]), ()]]
+                 [stats.rv_count(xk=vals[0], pk=vals[1]), ()]]
 
 # For these distributions, test_discrete_basic only runs with test mode full
 distslow = {'zipfian', 'nhypergeom'}

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -17,7 +17,8 @@ from scipy.stats._distr_params import distdiscrete, invdistdiscrete
 from scipy.stats._distn_infrastructure import rv_discrete_frozen
 
 vals = ([1, 2, 3, 4], [0.1, 0.2, 0.3, 0.4])
-distdiscrete += [[stats.rv_discrete(values=vals), ()]]
+distdiscrete += [[stats.rv_discrete(values=vals), ()],
+                 [stats.rv_sample(xk=vals[0], pk=vals[1]), ()]]
 
 # For these distributions, test_discrete_basic only runs with test mode full
 distslow = {'zipfian', 'nhypergeom'}

--- a/scipy/stats/tests/test_discrete_distns.py
+++ b/scipy/stats/tests/test_discrete_distns.py
@@ -573,6 +573,9 @@ def test_rv_sample_subclassing():
             return 42
 
     s = S(xk=[1, 2, 3], pk=[0.2, 0.7, 0.1])
-    assert_allclose(s.pmf([2, 3, 1]), [0.7, 0.1, 0.2], atol=42)
+    assert_allclose(s.pmf([2, 3, 1]), [0.7, 0.1, 0.2], atol=1e-15)
     assert s.extra() == 42
 
+    # make sure subclass freezes correctly
+    frozen_s = s()
+    assert_allclose(frozen_s.pmf([2, 3, 1]), [0.7, 0.1, 0.2], atol=1e-15)

--- a/scipy/stats/tests/test_discrete_distns.py
+++ b/scipy/stats/tests/test_discrete_distns.py
@@ -2,7 +2,6 @@ import pytest
 from scipy.stats import (betabinom, hypergeom, nhypergeom, bernoulli,
                          boltzmann, skellam, zipf, zipfian, binom, nbinom,
                          nchypergeom_fisher, nchypergeom_wallenius, randint)
-from scipy.stats import rv_sample
 
 import numpy as np
 from numpy.testing import (
@@ -564,18 +563,3 @@ def test_gh_17146():
     assert_allclose(pmf[-1], p)
     assert_allclose(pmf[0], 1-p)
     assert_equal(pmf[~i], 0)
-
-
-def test_rv_sample_subclassing():
-    # gh-8057: rv_sample cannot be subclassed easily
-    class S(rv_sample):
-        def extra(self):
-            return 42
-
-    s = S(xk=[1, 2, 3], pk=[0.2, 0.7, 0.1])
-    assert_allclose(s.pmf([2, 3, 1]), [0.7, 0.1, 0.2], atol=1e-15)
-    assert s.extra() == 42
-
-    # make sure subclass freezes correctly
-    frozen_s = s()
-    assert_allclose(frozen_s.pmf([2, 3, 1]), [0.7, 0.1, 0.2], atol=1e-15)

--- a/scipy/stats/tests/test_discrete_distns.py
+++ b/scipy/stats/tests/test_discrete_distns.py
@@ -2,6 +2,7 @@ import pytest
 from scipy.stats import (betabinom, hypergeom, nhypergeom, bernoulli,
                          boltzmann, skellam, zipf, zipfian, binom, nbinom,
                          nchypergeom_fisher, nchypergeom_wallenius, randint)
+from scipy.stats import rv_sample
 
 import numpy as np
 from numpy.testing import (
@@ -563,3 +564,15 @@ def test_gh_17146():
     assert_allclose(pmf[-1], p)
     assert_allclose(pmf[0], 1-p)
     assert_equal(pmf[~i], 0)
+
+
+def test_rv_sample_subclassing():
+    # gh-8057: rv_sample cannot be subclassed easily
+    class S(rv_sample):
+        def extra(self):
+            return 42
+
+    s = S(xk=[1, 2, 3], pk=[0.2, 0.7, 0.1])
+    assert_allclose(s.pmf([2, 3, 1]), [0.7, 0.1, 0.2], atol=42)
+    assert s.extra() == 42
+

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2812,6 +2812,20 @@ class TestRvDiscrete:
         assert_allclose(rv.expect(lambda x: x**2),
                         sum(v**2 * w for v, w in zip(y, py)), atol=1e-14)
 
+    def test_rv_count_subclassing(self):
+        # gh-8057: rv_discrete(values=(xk, pk)) cannot be subclassed easily
+        class S(stats.rv_count):
+            def extra(self):
+                return 42
+
+        s = S(xk=[1, 2, 3], pk=[0.2, 0.7, 0.1])
+        assert_allclose(s.pmf([2, 3, 1]), [0.7, 0.1, 0.2], atol=1e-15)
+        assert s.extra() == 42
+
+        # make sure subclass freezes correctly
+        frozen_s = s()
+        assert_allclose(frozen_s.pmf([2, 3, 1]), [0.7, 0.1, 0.2], atol=1e-15)
+
 
 class TestSkewCauchy:
     def test_cauchy(self):


### PR DESCRIPTION

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

closes gh-8057

#### What does this implement/fix?
<!--Please explain your changes.-->

Expose `rv_sample` to the main stats namespace. Make it play ball with subclassing: previously, subclassing `rv_discrete(values=(..., ...))` was broken. With this PR, subclassing `rv_sample` just works.

#### Additional information
<!--Any additional information you think is important.-->

After several failed attempts to fix the `__new__` dispatch in `rv_discrete` I'm throwing a towel on that. The dispatch to a subclass is a hack which apparently breaks all sorts of invariants. Which is, after all, expected --- this was originally devised as a hack around the `rv_discrete` quirk which was doing very different things in its `__init__`, depending on whether `values` are provided or not.

So, this PR instead introduces a new `rv_sample` subclass of `rv_discrete`. It is constructed with `xk, pk` arguments directly --- thus sidestepping the dispatch on `values=...`. I think it actually makes the signature lighter and more reasonable, too :-).

Deprecating `rv_discrete(values='...)` is out of scope of this PR.
Whether to actually deprecate it or not in a follow-up PR depends a bit on the timeline for the plans for revamping the distributions infrastructure. If it's planned in a finite amount of time from now, maybe there is no point causing downstream churn.
