### PR TITLE
DOC: linalg: Several docstring updates.

### DIFF
--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -111,6 +111,17 @@ def solve(a, b, sym_pos=False, lower=False, overwrite_a=False,
     NotImplementedError
         If transposed is True and input a is a complex matrix.
 
+    Notes
+    -----
+    If the input b matrix is a 1-D array with N elements, when supplied
+    together with an NxN input a, it is assumed as a valid column vector
+    despite the apparent size mismatch. This is compatible with the
+    numpy.dot() behavior and the returned result is still 1-D array.
+
+    The generic, symmetric, Hermitian and positive definite solutions are
+    obtained via calling ?GESV, ?SYSV, ?HESV, and ?POSV routines of
+    LAPACK respectively.
+
     Examples
     --------
     Given `a` and `b`, solve for `x`:
@@ -125,16 +136,6 @@ def solve(a, b, sym_pos=False, lower=False, overwrite_a=False,
     >>> np.dot(a, x) == b
     array([ True,  True,  True], dtype=bool)
 
-    Notes
-    -----
-    If the input b matrix is a 1-D array with N elements, when supplied
-    together with an NxN input a, it is assumed as a valid column vector
-    despite the apparent size mismatch. This is compatible with the
-    numpy.dot() behavior and the returned result is still 1-D array.
-
-    The generic, symmetric, Hermitian and positive definite solutions are
-    obtained via calling ?GESV, ?SYSV, ?HESV, and ?POSV routines of
-    LAPACK respectively.
     """
     # Flags for 1-D or N-D right-hand side
     b_is_1D = False
@@ -1510,6 +1511,16 @@ def matrix_balance(A, permute=True, scale=True, separate=False,
 
     .. versionadded:: 0.19.0
 
+    References
+    ----------
+    .. [1] : B.N. Parlett and C. Reinsch, "Balancing a Matrix for
+       Calculation of Eigenvalues and Eigenvectors", Numerische Mathematik,
+       Vol.13(4), 1969, :doi:`10.1007/BF02165404`
+    .. [2] : R. James, J. Langou, B.R. Lowery, "On matrix balancing and
+       eigenvector computation", 2014, :arxiv:`1401.5766`
+    .. [3] :  D.S. Watkins. A case where balancing is harmful.
+       Electron. Trans. Numer. Anal, Vol.23, 2006.
+
     Examples
     --------
     >>> import numpy as np
@@ -1527,18 +1538,6 @@ def matrix_balance(A, permute=True, scale=True, separate=False,
     array([[  0.5,   0. ,  0. ],  # may vary
            [  0. ,   1. ,  0. ],
            [  0. ,   0. ,  1. ]])
-
-    References
-    ----------
-    .. [1] : B.N. Parlett and C. Reinsch, "Balancing a Matrix for
-       Calculation of Eigenvalues and Eigenvectors", Numerische Mathematik,
-       Vol.13(4), 1969, :doi:`10.1007/BF02165404`
-
-    .. [2] : R. James, J. Langou, B.R. Lowery, "On matrix balancing and
-       eigenvector computation", 2014, :arxiv:`1401.5766`
-
-    .. [3] :  D.S. Watkins. A case where balancing is harmful.
-       Electron. Trans. Numer. Anal, Vol.23, 2006.
 
     """
 

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1513,12 +1513,12 @@ def matrix_balance(A, permute=True, scale=True, separate=False,
 
     References
     ----------
-    .. [1] : B.N. Parlett and C. Reinsch, "Balancing a Matrix for
+    .. [1] B.N. Parlett and C. Reinsch, "Balancing a Matrix for
        Calculation of Eigenvalues and Eigenvectors", Numerische Mathematik,
        Vol.13(4), 1969, :doi:`10.1007/BF02165404`
-    .. [2] : R. James, J. Langou, B.R. Lowery, "On matrix balancing and
+    .. [2] R. James, J. Langou, B.R. Lowery, "On matrix balancing and
        eigenvector computation", 2014, :arxiv:`1401.5766`
-    .. [3] :  D.S. Watkins. A case where balancing is harmful.
+    .. [3] D.S. Watkins. A case where balancing is harmful.
        Electron. Trans. Numer. Anal, Vol.23, 2006.
 
     Examples

--- a/scipy/linalg/_cythonized_array_utils.pyx
+++ b/scipy/linalg/_cythonized_array_utils.pyx
@@ -59,6 +59,12 @@ def bandwidth(a):
         say for N rows (N-1) means that side is full. Same example applies
         to the upper triangular part with (M-1).
 
+    Raises
+    ------
+    TypeError
+        If the dtype of the array is not supported, in particular, NumPy
+        float16, float128 and complex256 dtypes.
+
     Notes
     -----
     This helper function simply runs over the array looking for the nonzero
@@ -74,12 +80,6 @@ def bandwidth(a):
     the horizontal search is done only up to that band entries since we know
     that band is occupied. Therefore, a completely dense matrix scan cost is
     in the the order of n.
-
-    Raises
-    ------
-    TypeError
-        If the dtype of the array is not supported, in particular, NumPy
-        float16, float128 and complex256 dtypes.
 
     Examples
     --------
@@ -208,6 +208,16 @@ def issymmetric(a, atol=None, rtol=None):
     sym : bool
         Returns True if the array symmetric.
 
+    Raises
+    ------
+    TypeError
+        If the dtype of the array is not supported, in particular, NumPy
+        float16, float128 and complex256 dtypes for exact comparisons.
+
+    See Also
+    --------
+    ishermitian : Check if a square 2D array is Hermitian
+
     Notes
     -----
     For square empty arrays the result is returned True by convention. Complex
@@ -226,16 +236,6 @@ def issymmetric(a, atol=None, rtol=None):
     performance can improve or degrade depending on the size and dtype of the
     array. If one of ``atol`` or ``rtol`` given the other one is automatically
     set to zero.
-
-    See Also
-    --------
-    ishermitian : Check if a square 2D array is Hermitian
-
-    Raises
-    ------
-    TypeError
-        If the dtype of the array is not supported, in particular, NumPy
-        float16, float128 and complex256 dtypes for exact comparisons.
 
     Examples
     --------
@@ -338,6 +338,16 @@ def ishermitian(a, atol=None, rtol=None):
     her : bool
         Returns True if the array Hermitian.
 
+    Raises
+    ------
+    TypeError
+        If the dtype of the array is not supported, in particular, NumPy
+        float16, float128 and complex256 dtypes.
+
+    See Also
+    --------
+    issymmetric : Check if a square 2D array is symmetric
+
     Notes
     -----
     For square empty arrays the result is returned True by convention.
@@ -352,16 +362,6 @@ def ishermitian(a, atol=None, rtol=None):
     performance can improve or degrade depending on the size and dtype of the
     array. If one of ``atol`` or ``rtol`` given the other one is automatically
     set to zero.
-
-    Raises
-    ------
-    TypeError
-        If the dtype of the array is not supported, in particular, NumPy
-        float16, float128 and complex256 dtypes.
-
-    See Also
-    --------
-    issymmetric : Check if a square 2D array is symmetric
 
     Examples
     --------

--- a/scipy/linalg/_decomp_cossin.py
+++ b/scipy/linalg/_decomp_cossin.py
@@ -81,6 +81,11 @@ def cossin(X, p=None, q=None, separate=False,
         (``m-q`` x ``m-q``) orthogonal/unitary matrices. If ``separate=True``,
         this contains the tuple of ``(V1H, V2H)``.
 
+    References
+    ----------
+    .. [1] : Brian D. Sutton. Computing the complete CS decomposition. Numer.
+           Algorithms, 50(1):33-65, 2009.
+
     Examples
     --------
     >>> import numpy as np
@@ -100,11 +105,6 @@ def cossin(X, p=None, q=None, separate=False,
     []
     >>> np.allclose(x, u @ cs @ vdh)
     True
-
-    References
-    ----------
-    .. [1] : Brian D. Sutton. Computing the complete CS decomposition. Numer.
-           Algorithms, 50(1):33-65, 2009.
 
     """
 

--- a/scipy/linalg/_decomp_cossin.py
+++ b/scipy/linalg/_decomp_cossin.py
@@ -83,7 +83,7 @@ def cossin(X, p=None, q=None, separate=False,
 
     References
     ----------
-    .. [1] : Brian D. Sutton. Computing the complete CS decomposition. Numer.
+    .. [1] Brian D. Sutton. Computing the complete CS decomposition. Numer.
            Algorithms, 50(1):33-65, 2009.
 
     Examples

--- a/scipy/linalg/_decomp_ldl.py
+++ b/scipy/linalg/_decomp_ldl.py
@@ -67,6 +67,28 @@ def ldl(A, lower=True, hermitian=True, overwrite_a=False, check_finite=True):
         If a complex-valued array with nonzero imaginary parts on the
         diagonal is given and hermitian is set to True.
 
+    See Also
+    --------
+    cholesky, lu
+
+    Notes
+    -----
+    This function uses ``?SYTRF`` routines for symmetric matrices and
+    ``?HETRF`` routines for Hermitian matrices from LAPACK. See [1]_ for
+    the algorithm details.
+
+    Depending on the `lower` keyword value, only lower or upper triangular
+    part of the input array is referenced. Moreover, this keyword also defines
+    the structure of the outer factors of the factorization.
+
+    .. versionadded:: 1.1.0
+
+    References
+    ----------
+    .. [1] J.R. Bunch, L. Kaufman, Some stable methods for calculating
+       inertia and solving symmetric linear systems, Math. Comput. Vol.31,
+       1977. :doi:`10.2307/2005787`
+
     Examples
     --------
     Given an upper triangular array ``a`` that represents the full symmetric
@@ -94,28 +116,6 @@ def ldl(A, lower=True, hermitian=True, overwrite_a=False, check_finite=True):
     array([[ 2., -1.,  3.],
            [-1.,  2.,  0.],
            [ 3.,  0.,  1.]])
-
-    Notes
-    -----
-    This function uses ``?SYTRF`` routines for symmetric matrices and
-    ``?HETRF`` routines for Hermitian matrices from LAPACK. See [1]_ for
-    the algorithm details.
-
-    Depending on the `lower` keyword value, only lower or upper triangular
-    part of the input array is referenced. Moreover, this keyword also defines
-    the structure of the outer factors of the factorization.
-
-    .. versionadded:: 1.1.0
-
-    See Also
-    --------
-    cholesky, lu
-
-    References
-    ----------
-    .. [1] J.R. Bunch, L. Kaufman, Some stable methods for calculating
-       inertia and solving symmetric linear systems, Math. Comput. Vol.31,
-       1977. :doi:`10.2307/2005787`
 
     """
     a = atleast_2d(_asarray_validated(A, check_finite=check_finite))

--- a/scipy/linalg/_decomp_qz.py
+++ b/scipy/linalg/_decomp_qz.py
@@ -216,6 +216,10 @@ def qz(A, B, output='real', lwork=None, sort=None, overwrite_a=False,
     Z : (N, N) ndarray
         The right Schur vectors.
 
+    See Also
+    --------
+    ordqz
+
     Notes
     -----
     Q is transposed versus the equivalent function in Matlab.
@@ -301,9 +305,6 @@ def qz(A, B, output='real', lwork=None, sort=None, overwrite_a=False,
            [ 3.-0.j,  1.-0.j, -1.+0.j],
            [ 5.+0.j,  6.+0.j, -2.+0.j]])
 
-    See Also
-    --------
-    ordqz
     """
     # output for real
     # AA, BB, sdim, alphar, alphai, beta, vsl, vsr, work, info
@@ -374,6 +375,10 @@ def ordqz(A, B, sort='lhp', output='real', overwrite_a=False,
     Z : (N, N) ndarray
         The right Schur vectors.
 
+    See Also
+    --------
+    qz
+
     Notes
     -----
     On exit, ``(ALPHAR(j) + ALPHAI(j)*i)/BETA(j), j=1,...,N``, will be the
@@ -386,10 +391,6 @@ def ordqz(A, B, sort='lhp', output='real', overwrite_a=False,
     complex conjugate pair, with ``ALPHAI(j+1)`` negative.
 
     .. versionadded:: 0.17.0
-
-    See Also
-    --------
-    qz
 
     Examples
     --------

--- a/scipy/linalg/_decomp_svd.py
+++ b/scipy/linalg/_decomp_svd.py
@@ -164,6 +164,11 @@ def svdvals(a, overwrite_a=False, check_finite=True):
     LinAlgError
         If SVD computation does not converge.
 
+    See Also
+    --------
+    svd : Compute the full singular value decomposition of a matrix.
+    diagsvd : Construct the Sigma matrix, given the vector s.
+
     Notes
     -----
     ``svdvals(a)`` only differs from ``svd(a, compute_uv=False)`` by its
@@ -174,11 +179,6 @@ def svdvals(a, overwrite_a=False, check_finite=True):
     >>> from scipy.linalg import svdvals
     >>> svdvals(a)
     array([], dtype=float64)
-
-    See Also
-    --------
-    svd : Compute the full singular value decomposition of a matrix.
-    diagsvd : Construct the Sigma matrix, given the vector s.
 
     Examples
     --------

--- a/scipy/linalg/_expm_frechet.py
+++ b/scipy/linalg/_expm_frechet.py
@@ -66,22 +66,23 @@ def expm_frechet(A, E, method=None, compute_expm=True, check_finite=True):
     Examples
     --------
     >>> import numpy as np
-    >>> import scipy.linalg
+    >>> from scipy import linalg
     >>> rng = np.random.default_rng()
+
     >>> A = rng.standard_normal((3, 3))
     >>> E = rng.standard_normal((3, 3))
-    >>> expm_A, expm_frechet_AE = scipy.linalg.expm_frechet(A, E)
+    >>> expm_A, expm_frechet_AE = linalg.expm_frechet(A, E)
     >>> expm_A.shape, expm_frechet_AE.shape
     ((3, 3), (3, 3))
 
-    >>> import scipy.linalg
-    >>> rng = np.random.default_rng()
-    >>> A = rng.standard_normal((3, 3))
-    >>> E = rng.standard_normal((3, 3))
-    >>> expm_A, expm_frechet_AE = scipy.linalg.expm_frechet(A, E)
+    Create a 6x6 matrix containg [[A, E], [0, A]]:
+
     >>> M = np.zeros((6, 6))
-    >>> M[:3, :3] = A; M[:3, 3:] = E; M[3:, 3:] = A
-    >>> expm_M = scipy.linalg.expm(M)
+    >>> M[:3, :3] = A
+    >>> M[:3, 3:] = E
+    >>> M[3:, 3:] = A
+
+    >>> expm_M = linalg.expm(M)
     >>> np.allclose(expm_A, expm_M[:3, :3])
     True
     >>> np.allclose(expm_frechet_AE, expm_M[:3, 3:])
@@ -369,17 +370,17 @@ def expm_cond(A, check_finite=True):
         The relative condition number of the matrix exponential
         in the Frobenius norm
 
+    See Also
+    --------
+    expm : Compute the exponential of a matrix.
+    expm_frechet : Compute the Frechet derivative of the matrix exponential.
+
     Notes
     -----
     A faster estimate for the condition number in the 1-norm
     has been published but is not yet implemented in SciPy.
 
     .. versionadded:: 0.14.0
-
-    See Also
-    --------
-    expm : Compute the exponential of a matrix.
-    expm_frechet : Compute the Frechet derivative of the matrix exponential.
 
     Examples
     --------

--- a/scipy/linalg/_matfuncs.py
+++ b/scipy/linalg/_matfuncs.py
@@ -660,18 +660,6 @@ def funm(A, func, disp=True):
 
         1-norm of the estimated error, ||err||_1 / ||A||_1
 
-    Examples
-    --------
-    >>> import numpy as np
-    >>> from scipy.linalg import funm
-    >>> a = np.array([[1.0, 3.0], [1.0, 4.0]])
-    >>> funm(a, lambda x: x*x)
-    array([[  4.,  15.],
-           [  5.,  19.]])
-    >>> a.dot(a)
-    array([[  4.,  15.],
-           [  5.,  19.]])
-
     Notes
     -----
     This function implements the general algorithm based on Schur decomposition
@@ -693,6 +681,18 @@ def funm(A, func, disp=True):
     References
     ----------
     .. [1] Gene H. Golub, Charles F. van Loan, Matrix Computations 4th ed.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.linalg import funm
+    >>> a = np.array([[1.0, 3.0], [1.0, 4.0]])
+    >>> funm(a, lambda x: x*x)
+    array([[  4.,  15.],
+           [  5.,  19.]])
+    >>> a.dot(a)
+    array([[  4.,  15.],
+           [  5.,  19.]])
 
     """
     A = _asarray_square(A)
@@ -835,6 +835,10 @@ def khatri_rao(a, b):
     c:  (n*m, k) ndarray
         Khatri-rao product of `a` and `b`.
 
+    See Also
+    --------
+    kron : Kronecker product
+
     Notes
     -----
     The mathematical definition of the Khatri-Rao product is:
@@ -846,10 +850,6 @@ def khatri_rao(a, b):
     which is the Kronecker product of every column of A and B, e.g.::
 
         c = np.vstack([np.kron(a[:, k], b[:, k]) for k in range(b.shape[1])]).T
-
-    See Also
-    --------
-    kron : Kronecker product
 
     Examples
     --------

--- a/scipy/linalg/_sketches.py
+++ b/scipy/linalg/_sketches.py
@@ -124,48 +124,55 @@ def clarkson_woodruff_transform(input_matrix, sketch_size, seed=None):
     That said, this method does perform well on dense inputs, just slower
     on a relative scale.
 
+    References
+    ----------
+    .. [1] Kenneth L. Clarkson and David P. Woodruff. Low rank approximation
+           and regression in input sparsity time. In STOC, 2013.
+    .. [2] David P. Woodruff. Sketching as a tool for numerical linear algebra.
+           In Foundations and Trends in Theoretical Computer Science, 2014.
+
     Examples
     --------
-    Given a big dense matrix ``A``:
+    Create a big dense matrix ``A`` for the example:
 
+    >>> import numpy as np
     >>> from scipy import linalg
-    >>> n_rows, n_columns, sketch_n_rows = 15000, 100, 200
+    >>> n_rows, n_columns  = 15000, 100
     >>> rng = np.random.default_rng()
     >>> A = rng.standard_normal((n_rows, n_columns))
-    >>> sketch = linalg.clarkson_woodruff_transform(A, sketch_n_rows)
+
+    Apply the transform to create a new matrix with 200 rows:
+
+    >>> sketch_n_rows = 200
+    >>> sketch = linalg.clarkson_woodruff_transform(A, sketch_n_rows, seed=rng)
     >>> sketch.shape
     (200, 100)
-    >>> norm_A = np.linalg.norm(A)
-    >>> norm_sketch = np.linalg.norm(sketch)
 
-    Now with high probability, the true norm ``norm_A`` is close to
-    the sketched norm ``norm_sketch`` in absolute value.
+    Now with high probability, the true norm is close to the sketched norm
+    in absolute value.
+
+    >>> linalg.norm(A)
+    1224.2812927123198
+    >>> linalg.norm(sketch)
+    1226.518328407333
 
     Similarly, applying our sketch preserves the solution to a linear
     regression of :math:`\min \|Ax - b\|`.
 
-    >>> from scipy import linalg
-    >>> n_rows, n_columns, sketch_n_rows = 15000, 100, 200
-    >>> rng = np.random.default_rng()
-    >>> A = rng.standard_normal((n_rows, n_columns))
     >>> b = rng.standard_normal(n_rows)
-    >>> x = np.linalg.lstsq(A, b, rcond=None)
-    >>> Ab = np.hstack((A, b.reshape(-1,1)))
-    >>> SAb = linalg.clarkson_woodruff_transform(Ab, sketch_n_rows)
-    >>> SA, Sb = SAb[:,:-1], SAb[:,-1]
-    >>> x_sketched = np.linalg.lstsq(SA, Sb, rcond=None)
+    >>> x = linalg.lstsq(A, b)[0]
+    >>> Ab = np.hstack((A, b.reshape(-1, 1)))
+    >>> SAb = linalg.clarkson_woodruff_transform(Ab, sketch_n_rows, seed=rng)
+    >>> SA, Sb = SAb[:, :-1], SAb[:, -1]
+    >>> x_sketched = linalg.lstsq(SA, Sb)[0]
 
-    As with the matrix norm example, ``np.linalg.norm(A @ x - b)``
-    is close to ``np.linalg.norm(A @ x_sketched - b)`` with high
-    probability.
+    As with the matrix norm example, ``linalg.norm(A @ x - b)`` is close
+    to ``linalg.norm(A @ x_sketched - b)`` with high probability.
 
-    References
-    ----------
-    .. [1] Kenneth L. Clarkson and David P. Woodruff. Low rank approximation and
-           regression in input sparsity time. In STOC, 2013.
-
-    .. [2] David P. Woodruff. Sketching as a tool for numerical linear algebra.
-           In Foundations and Trends in Theoretical Computer Science, 2014.
+    >>> linalg.norm(A @ x - b)
+    122.83242365433877
+    >>> linalg.norm(A @ x_sketched - b)
+    166.58473879945151
 
     """
     S = cwt_matrix(sketch_size, input_matrix.shape[0], seed)

--- a/scipy/linalg/_solvers.py
+++ b/scipy/linalg/_solvers.py
@@ -635,6 +635,7 @@ def solve_discrete_are(a, b, q, r, e=None, s=None, balanced=True):
     --------
     Given `a`, `b`, `q`, and `r` solve for `x`:
 
+    >>> import numpy as np
     >>> from scipy import linalg as la
     >>> a = np.array([[0, 1], [0, -1]])
     >>> b = np.array([[1, 0], [2, 1]])

--- a/scipy/linalg/_special_matrices.py
+++ b/scipy/linalg/_special_matrices.py
@@ -1136,6 +1136,10 @@ def fiedler_companion(a):
     c : (N-1, N-1) ndarray
         Resulting companion matrix
 
+    See Also
+    --------
+    companion
+
     Notes
     -----
     Similar to `companion` the leading coefficient should be nonzero. In the case
@@ -1144,10 +1148,6 @@ def fiedler_companion(a):
     monic polynomial.
 
     .. versionadded:: 1.3.0
-
-    See Also
-    --------
-    companion
 
     References
     ----------

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -928,6 +928,7 @@ def get_lapack_funcs(names, arrays=(), dtype=None, ilp64=False):
     >>> import numpy as np
     >>> import scipy.linalg as LA
     >>> rng = np.random.default_rng()
+
     >>> a = rng.random((3,2))
     >>> x_lange = LA.get_lapack_funcs('lange', (a,))
     >>> x_lange.typecode
@@ -942,8 +943,6 @@ def get_lapack_funcs(names, arrays=(), dtype=None, ilp64=False):
     to the function which is often wrapped as a standalone function and
     commonly denoted as ``###_lwork``. Below is an example for ``?sysv``
 
-    >>> import scipy.linalg as LA
-    >>> rng = np.random.default_rng()
     >>> a = rng.random((1000, 1000))
     >>> b = rng.random((1000, 1)) * 1j
     >>> # We pick up zsysv and zsysv_lwork due to b array


### PR DESCRIPTION
* Fix section order for many functions to comply with the NumPy docstring standard.
* Copy-edit some examples to remove redundant code.
* Fix a mistake in the 'clarkson_woodruff_transform' docstring (need to pull out the first element of the return value of 'lstsq').

-----

I've been hacking on a variation of the script that I wrote to find docstrings where the 'Examples' section is missing 'import numpy as np'.  A new script, [`find_docstring_issues.py`](https://gist.github.com/WarrenWeckesser/2b07ae006ec8f38bdb5b411189b51b77), looks for several common issues in the docstrings.  Here's what it reports for `scipy.linalg`:

```
$ python find_docstring_issues.py linalg
scipy version 1.10.0.dev0+2057.659975f

=== linalg ===
linalg.bandwidth
    section out of order: 'Raises'
linalg.clarkson_woodruff_transform
    section out of order: 'References'
    missing 'import numpy as np' in 'Examples'
    duplicated imports in Examples:
        >>> from scipy import linalg
linalg.cossin
    section out of order: 'References'
linalg.expm_cond
    section out of order: 'See Also'
linalg.expm_frechet
    duplicated imports in Examples:
        >>> import scipy.linalg
linalg.fiedler_companion
    section out of order: 'See Also'
linalg.funm
    section out of order: 'References'
linalg.get_lapack_funcs
    duplicated imports in Examples:
        >>> import scipy.linalg as LA
linalg.ishermitian
    section out of order: 'See Also'
linalg.issymmetric
    section out of order: 'Raises'
    section out of order: 'See Also'
linalg.khatri_rao
    section out of order: 'See Also'
linalg.ldl
    section out of order: 'See Also'
    section out of order: 'References'
linalg.matrix_balance
    section out of order: 'References'
linalg.ordqz
    section out of order: 'See Also'
linalg.qz
    section out of order: 'See Also'
linalg.solve
    section out of order: 'Notes'
linalg.solve_discrete_are
    missing 'import numpy as np' in 'Examples'
linalg.svdvals
    section out of order: 'See Also'
```

This pull request fixes all those.

Most of the changes are simply shuffling around a section or two.  The most heavily edited docstring is that of `clarkson_woodruff_transform`, specfically the Examples section, where I removed duplicated code, added lines to actually show norms of the matrices, and fixed the code to pull out the first element in the return value of `lstsq` as the `x` value.  Without that, an expression such as `norm(A @ x - b)` would generate an exception, because `x` was the tuple of return values.