### PR TITLE
BUG: avoid segfaults in CubicSpline with zero-sized input arrays

### DIFF
--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -25,6 +25,9 @@ def prepare_input(x, y, axis, dydx=None):
         raise ValueError("`x` must contain real values.")
     x = x.astype(float)
 
+    if y.size == 0:
+        raise ValueError("`y` cannot be an empty array.")
+
     if np.issubdtype(y.dtype, np.complexfloating):
         dtype = complex
     else:

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -704,7 +704,8 @@ class TestCubicSpline:
         assert_raises(ValueError, CubicSpline, xc, y)
         assert_raises(ValueError, CubicSpline, xn, y)
         assert_raises(ValueError, CubicSpline, x, yn)
-        assert_raises(ValueError, CubicSpline, x, y_empty)
+        with assert_raises(ValueError, match="`y` cannot be an empty array."):
+            CubicSpline(x, y_empty)
         assert_raises(ValueError, CubicSpline, xo, y)
         assert_raises(ValueError, CubicSpline, x, y3)
         assert_raises(ValueError, CubicSpline, x[:, np.newaxis], y)

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -699,10 +699,12 @@ class TestCubicSpline:
         y3 = [1, 2, 3]
         x1 = [1]
         y1 = [1]
+        y_empty = np.empty(shape=(4, 0))
 
         assert_raises(ValueError, CubicSpline, xc, y)
         assert_raises(ValueError, CubicSpline, xn, y)
         assert_raises(ValueError, CubicSpline, x, yn)
+        assert_raises(ValueError, CubicSpline, x, y_empty)
         assert_raises(ValueError, CubicSpline, xo, y)
         assert_raises(ValueError, CubicSpline, x, y3)
         assert_raises(ValueError, CubicSpline, x[:, np.newaxis], y)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes https://github.com/scipy/scipy/issues/17241

#### What does this implement/fix?
This solution prevents users from passing empty arrays to the interpolation constructors.

#### Additional information
<!--Any additional information you think is important.-->

The verdict on https://github.com/scipy/scipy/issues/17241 is not out yet and this one may be closed without merging.
This is one of the possible solutions for this issue. 