### PR TITLE
REL: Prep for SciPy 1.9.4

### DIFF
--- a/doc/release/1.9.4-notes.rst
+++ b/doc/release/1.9.4-notes.rst
@@ -1,0 +1,20 @@
+==========================
+SciPy 1.9.4 Release Notes
+==========================
+
+.. contents::
+
+SciPy 1.9.4 is a bug-fix release with no new features
+compared to 1.9.3.
+
+Authors
+=======
+
+
+Issues closed for 1.9.4
+-----------------------
+
+
+
+Pull requests for 1.9.4
+-----------------------

--- a/doc/source/release.1.9.4.rst
+++ b/doc/source/release.1.9.4.rst
@@ -1,0 +1,1 @@
+.. include:: ../release/1.9.4-notes.rst

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -8,6 +8,7 @@ see the `commit logs <https://github.com/scipy/scipy/commits/>`_.
 .. toctree::
    :maxdepth: 1
 
+   release.1.9.4
    release.1.9.3
    release.1.9.2
    release.1.9.1

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@ project(
   # Note that the git commit hash cannot be added dynamically here (it is added
   # in the dynamically generated and installed `scipy/version.py` though - see
   # tools/version_utils.py
-  version: '1.9.3',
+  version: '1.9.4',
   license: 'BSD-3',
   meson_version: '>= 0.62.2',
   default_options: [

--- a/tools/version_utils.py
+++ b/tools/version_utils.py
@@ -5,8 +5,8 @@ import argparse
 
 MAJOR = 1
 MINOR = 9
-MICRO = 3
-ISRELEASED = True
+MICRO = 4
+ISRELEASED = False
 IS_RELEASE_BRANCH = True
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 


### PR DESCRIPTION
* no real intention to do `1.9.4` but prep just in case

* current plan is to send the email proposing `1.10` schedule to mailing list on Nov. 9th, similar to last November cycle