### PR TITLE
DOC: update version switcher for 1.9.3

### DIFF
--- a/doc/source/_static/version_switcher.json
+++ b/doc/source/_static/version_switcher.json
@@ -5,7 +5,12 @@
         "url": "https://scipy.github.io/devdocs/"
     },
     {
-        "name": "1.9.2 (stable)",
+        "name": "1.9.3 (stable)",
+        "version":"1.9.3",
+        "url": "https://docs.scipy.org/doc/scipy-1.9.3/"
+    },
+    {
+        "name": "1.9.2",
         "version":"1.9.2",
         "url": "https://docs.scipy.org/doc/scipy-1.9.2/"
     },


### PR DESCRIPTION
* update version switcher for 1.9.3

* maybe let Ralf or Pamphile merge this one, to be sure the new docs are correctly deployed first (in case that matters)

[skip azp] [skip actions]
