### PR TITLE
DOC: special: Show that lambertw can solve x = a + b*exp(c*x)

### DIFF
--- a/scipy/special/_lambertw.py
+++ b/scipy/special/_lambertw.py
@@ -90,8 +90,46 @@ def lambertw(z, k=0, tol=1e-8):
     **Applications to equation-solving**
 
     The Lambert W function may be used to solve various kinds of
-    equations, such as finding the value of the infinite power
-    tower :math:`z^{z^{z^{\ldots}}}`:
+    equations.  We give two examples here.
+
+    First, the function can be used to solve implicit equations of the
+    form
+
+        :math:`x = a + b e^{c x}`
+
+    for :math:`x`.  We assume :math:`c` is not zero.  After a little
+    algebra, the equation may be written
+
+        :math:`z e^z = -b c e^{a c}`
+
+    where :math:`z = c (a - x)`.  :math:`z` may then be expressed using
+    the Lambert W function
+
+        :math:`z = W(-b c e^{a c})`
+
+    giving
+
+        :math:`x = a - W(-b c e^{a c})/c`
+
+    For example,
+
+    >>> a = 3
+    >>> b = 2
+    >>> c = -0.5
+
+    The solution to :math:`x = a + b e^{c x}` is:
+
+    >>> x = a - lambertw(-b*c*np.exp(a*c))/c
+    >>> x
+    (3.3707498368978794+0j)
+
+    Verify that it solves the equation:
+
+    >>> a + b*np.exp(c*x)
+    (3.37074983689788+0j)
+
+    The Lambert W function may also be used find the value of the infinite
+    power tower :math:`z^{z^{z^{\ldots}}}`:
 
     >>> def tower(z, n):
     ...     if n == 0:


### PR DESCRIPTION
This expands the "applications to equation-solving" examples in the `lambertw` docstring.  The function can be used to solve the implicit equation `x = a + b*exp(c*x)`.

A "real world" application of this is [solving the Colebrook equation](https://en.wikipedia.org/wiki/Darcy_friction_factor_formulae#Solving).  I didn't mention that in the docstring, as it involves too much specialized notation.