### PR TITLE
TST: linalg: temporarily silence failure in test_solve_discrete_are

### DIFF
--- a/scipy/linalg/tests/test_solvers.py
+++ b/scipy/linalg/tests/test_solvers.py
@@ -307,7 +307,6 @@ def test_solve_continuous_are():
         _test_factory(case, min_decimal[ind])
 
 
-
 def test_solve_discrete_are():
 
     cases = [

--- a/scipy/linalg/tests/test_solvers.py
+++ b/scipy/linalg/tests/test_solvers.py
@@ -307,6 +307,7 @@ def test_solve_continuous_are():
         _test_factory(case, min_decimal[ind])
 
 
+
 def test_solve_discrete_are():
 
     cases = [
@@ -474,7 +475,7 @@ def test_solve_discrete_are():
          np.array([[0], [1]]),
          np.eye(2),
          np.array([[1]]),
-         None),
+         "Presumed issue with OpenBLAS, see gh-16926"),
         # TEST CASE 16 : darex #13
         (np.array([[16, 10, -2],
                   [10, 13, -8],


### PR DESCRIPTION
#### Reference issue
gh-16926

#### What does this implement/fix?
gh-17057 xfailed a test failure similar to the one we're now seeing in linux_aarch64_test; this xfails the new one so that it is easier to see when there is a problem in a new PR.  

#### Additional information
This should be reverted when gh-16926 gets resolved.
gh-17272 should address the issue in macos-arm64.