### PR TITLE
BUG: Change defaults in lapack/blas to check if it was built with ILP64.

### DIFF
--- a/scipy/linalg/blas.py
+++ b/scipy/linalg/blas.py
@@ -409,7 +409,7 @@ def _memoize_get_funcs(func):
 
 
 @_memoize_get_funcs
-def get_blas_funcs(names, arrays=(), dtype=None, ilp64=False):
+def get_blas_funcs(names, arrays=(), dtype=None, ilp64='preferred'):
     """Return available BLAS function objects from names.
 
     Arrays are used to determine the optimal prefix of BLAS routines.
@@ -430,7 +430,7 @@ def get_blas_funcs(names, arrays=(), dtype=None, ilp64=False):
     ilp64 : {True, False, 'preferred'}, optional
         Whether to return ILP64 routine variant.
         Choosing 'preferred' returns ILP64 routine if available,
-        and otherwise the 32-bit routine. Default: False
+        and otherwise the 32-bit routine. Default: `'preferred'`.
 
     Returns
     -------

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -879,7 +879,7 @@ del regex_compile, p1, p2, backtickrepl
 
 
 @_memoize_get_funcs
-def get_lapack_funcs(names, arrays=(), dtype=None, ilp64=False):
+def get_lapack_funcs(names, arrays=(), dtype=None, ilp64='preferred'):
     """Return available LAPACK function objects from names.
 
     Arrays are used to determine the optimal prefix of LAPACK routines.
@@ -900,7 +900,7 @@ def get_lapack_funcs(names, arrays=(), dtype=None, ilp64=False):
     ilp64 : {True, False, 'preferred'}, optional
         Whether to return ILP64 routine variant.
         Choosing 'preferred' returns ILP64 routine if available, and
-        otherwise the 32-bit routine. Default: False
+        otherwise the 32-bit routine. Default: `'preferred'`.
 
     Returns
     -------


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #17275

#### What does this implement/fix?
<!--Please explain your changes.-->
Rather than default to 32-bit blas/lapack as default, this instead defaults to check whether SciPy was built with ilp64 and calls the 64-bit version if Scipy was built with 64 bits.
#### Additional information
<!--Any additional information you think is important.-->
