### PR TITLE
MAINT/ENH: stats.multivariate_normal.rvs: fix shape and speed up with Covariance

### DIFF
--- a/scipy/stats/_covariance.py
+++ b/scipy/stats/_covariance.py
@@ -337,6 +337,9 @@ class Covariance:
         ----------
         .. [1] "Whitening Transformation". Wikipedia.
                https://en.wikipedia.org/wiki/Whitening_transformation
+        .. [2] Novák, Lukáš, and Miroslav Vořechovský. "Generalization of
+               coloring linear transformation". Transactions of VSB 18.2
+               (2018): 31-35. :doi:`10.31490/tces-2018-0013`
 
         Examples
         --------
@@ -362,7 +365,7 @@ class Covariance:
         """
         Perform a colorizing transformation on data.
 
-        "Colorizing" ("color" as in "colored noise", in which differenct
+        "Colorizing" ("color" as in "colored noise", in which different
         frequencies may have different magnitudes) transforms a set of
         uncorrelated random variables into a new set of random variables with
         the desired covariance. When a coloring transform is applied to a
@@ -387,6 +390,9 @@ class Covariance:
         ----------
         .. [1] "Whitening Transformation". Wikipedia.
                https://en.wikipedia.org/wiki/Whitening_transformation
+        .. [2] Novák, Lukáš, and Miroslav Vořechovský. "Generalization of
+               coloring linear transformation". Transactions of VSB 18.2
+               (2018): 31-35. :doi:`10.31490/tces-2018-0013`
 
         Examples
         --------

--- a/scipy/stats/_covariance.py
+++ b/scipy/stats/_covariance.py
@@ -380,13 +380,6 @@ class Covariance:
         return self._covariance
 
     @property
-    def dimensionality(self):
-        """
-        Dimensionality of the vector space
-        """
-        return np.array(self._dimensionality, dtype=int)[()]
-
-    @property
     def shape(self):
         """
         Shape of the covariance array
@@ -428,7 +421,6 @@ class CovViaPrecision(Covariance):
         self._rank = precision.shape[-1]  # must be full rank if invertible
         self._precision = precision
         self._cov_matrix = covariance
-        self._dimensionality = self._rank
         self._shape = precision.shape
         self._allow_singular = False
 
@@ -437,7 +429,7 @@ class CovViaPrecision(Covariance):
 
     @cached_property
     def _covariance(self):
-        n = self._dimensionality
+        n = self._shape[-1]
         return (linalg.cho_solve((self._chol_P, True), np.eye(n))
                 if self._cov_matrix is None else self._cov_matrix)
 
@@ -466,7 +458,6 @@ class CovViaDiagonal(Covariance):
         self._LP = psuedo_reciprocals
         self._rank = positive_diagonal.shape[-1] - i_zero.sum(axis=-1)
         self._covariance = np.apply_along_axis(np.diag, -1, diagonal)
-        self._dimensionality = diagonal.shape[-1]
         self._i_zero = i_zero
         self._shape = self._covariance.shape
         self._allow_singular = True
@@ -490,7 +481,6 @@ class CovViaCholesky(Covariance):
         self._log_pdet = 2*np.log(np.diag(self._factor)).sum(axis=-1)
         self._rank = L.shape[-1]  # must be full rank for cholesky
         self._covariance = L @ L.T
-        self._dimensionality = self._rank
         self._shape = L.shape
         self._allow_singular = False
 
@@ -528,7 +518,6 @@ class CovViaEigendecomposition(Covariance):
         self._rank = positive_eigenvalues.shape[-1] - i_zero.sum(axis=-1)
         self._w = eigenvalues
         self._v = eigenvectors
-        self._dimensionality = eigenvalues.shape[-1]
         self._shape = eigenvectors.shape
         self._null_basis = eigenvectors * i_zero
         # This is only used for `_support_mask`, not to decide whether
@@ -561,7 +550,6 @@ class CovViaPSD(Covariance):
         self._log_pdet = psd.log_pdet
         self._rank = psd.rank
         self._covariance = psd._M
-        self._dimensionality = psd._M.shape[-1]
         self._shape = psd._M.shape
         self._psd = psd
         self._allow_singular = False  # by default

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -418,7 +418,7 @@ class multivariate_normal_gen(multi_rv_generic):
             return dim, mean, cov_object
 
     def _process_parameters_Covariance(self, mean, cov):
-        dim = cov.dimensionality
+        dim = cov.shape[-1]
         mean = np.array([0.]) if mean is None else mean
         message = (f"`cov` represents a covariance matrix in {dim} dimensions,"
                    f"and so `mean` must be broadcastable to shape {(dim,)}")

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -745,11 +745,20 @@ class multivariate_normal_gen(multi_rv_generic):
 
         """
         dim, mean, cov_object = self._process_parameters(mean, cov)
-        cov = cov_object.covariance
-
         random_state = self._get_random_state(random_state)
-        out = random_state.multivariate_normal(mean, cov, size)
-        return _squeeze_output(out)
+
+        if isinstance(cov_object, _covariance.CovViaPSD):
+            cov = cov_object.covariance
+            out = random_state.multivariate_normal(mean, cov, size)
+            out = _squeeze_output(out)
+        else:
+            size = size or tuple()
+            if not np.iterable(size):
+                size = (size,)
+            shape = tuple(size) + (cov_object.shape[-1],)
+            x = random_state.normal(size=shape)
+            out = mean + cov_object.colorize(x)
+        return out
 
     def entropy(self, mean=None, cov=1):
         """Compute the differential entropy of the multivariate normal.

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -144,7 +144,7 @@ class TestCovariance:
         if hasattr(cov_object, "_colorize") and "singular" not in matrix_type:
             assert_close(cov_object.colorize(res), x)
 
-    @pytest.mark.parametrize("size", [tuple(), (2, 4, 3)])
+    @pytest.mark.parametrize("size", [None, tuple(), 1, (2, 4, 3)])
     @pytest.mark.parametrize("matrix_type", list(_matrices))
     @pytest.mark.parametrize("cov_type_name", _all_covariance_types)
     def test_mvn_with_covariance(self, size, matrix_type, cov_type_name):
@@ -169,8 +169,13 @@ class TestCovariance:
         x1 = mvn.rvs(mean, cov_object, size=size, random_state=rng)
         rng = np.random.default_rng(5292808890472453840)
         x2 = mvn(mean, cov_object, seed=rng).rvs(size=size)
-        assert_close(x1, x)
-        assert_close(x2, x)
+        if isinstance(cov_object, _covariance.CovViaPSD):
+            assert_close(x1, np.squeeze(x))  # for backward compatibility
+            assert_close(x2, np.squeeze(x))
+        else:
+            assert_close(x1.shape, x.shape)
+            assert_close(x2.shape, x.shape)
+            assert_close(x2, x1)
 
         assert_close(mvn.pdf(x, mean, cov_object), dist0.pdf(x))
         assert_close(dist1.pdf(x), dist0.pdf(x))

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -37,6 +37,7 @@ from unittest.mock import patch
 
 
 def assert_close(res, ref, *args, **kwargs):
+    res, ref = np.asarray(res), np.asarray(ref)
     assert_allclose(res, ref, *args, **kwargs)
     assert_equal(res.shape, ref.shape)
 
@@ -120,9 +121,8 @@ class TestCovariance:
         # test properties
         cov_object = cov_type(preprocessing(A))
         assert_close(cov_object.log_pdet, psd.log_pdet)
-        assert_close(cov_object.rank, np.int64(psd.rank))
-        assert_close(cov_object.dimensionality,
-                     np.int64(np.array(A).shape[-1]))
+        assert_close(cov_object.rank, psd.rank)
+        assert_equal(cov_object.shape, np.asarray(A).shape)
         assert_close(cov_object.covariance, np.asarray(A))
 
         # test whitening 1D x

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -121,7 +121,7 @@ class TestCovariance:
         # test properties
         cov_object = cov_type(preprocessing(A))
         assert_close(cov_object.log_pdet, psd.log_pdet)
-        assert_close(cov_object.rank, psd.rank)
+        assert_equal(cov_object.rank, psd.rank)
         assert_equal(cov_object.shape, np.asarray(A).shape)
         assert_close(cov_object.covariance, np.asarray(A))
 
@@ -173,8 +173,8 @@ class TestCovariance:
             assert_close(x1, np.squeeze(x))  # for backward compatibility
             assert_close(x2, np.squeeze(x))
         else:
-            assert_close(x1.shape, x.shape)
-            assert_close(x2.shape, x.shape)
+            assert_equal(x1.shape, x.shape)
+            assert_equal(x2.shape, x.shape)
             assert_close(x2, x1)
 
         assert_close(mvn.pdf(x, mean, cov_object), dist0.pdf(x))

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -125,19 +125,24 @@ class TestCovariance:
         assert_equal(cov_object.shape, np.asarray(A).shape)
         assert_close(cov_object.covariance, np.asarray(A))
 
-        # test whitening 1D x
+        # test whitening/coloring 1D x
         rng = np.random.default_rng(5292808890472453840)
         x = rng.random(size=3)
         res = cov_object.whiten(x)
         ref = x @ psd.U
         # res != ref in general; but res @ res == ref @ ref
         assert_close(res @ res, ref @ ref)
+        if hasattr(cov_object, "_colorize") and "singular" not in matrix_type:
+            # CovViaPSD does not have _colorize
+            assert_close(cov_object.colorize(res), x)
 
-        # test whitening 3D x
+        # test whitening/coloring 3D x
         x = rng.random(size=(2, 4, 3))
         res = cov_object.whiten(x)
         ref = x @ psd.U
         assert_close((res**2).sum(axis=-1), (ref**2).sum(axis=-1))
+        if hasattr(cov_object, "_colorize") and "singular" not in matrix_type:
+            assert_close(cov_object.colorize(res), x)
 
     @pytest.mark.parametrize("size", [tuple(), (2, 4, 3)])
     @pytest.mark.parametrize("matrix_type", list(_matrices))


### PR DESCRIPTION
#### Reference issue
gh-16278
https://github.com/scipy/scipy/pull/12312#issuecomment-640298227 (direct call to BLAS can come later...)
supersedes gh-12184 

#### What does this implement/fix?
`stats.multivariate_normal.rvs` generates random variates using the Generator's `multivariate_normal`, which doesn't cache its factorization of the covariance matrix, so repeated calls require refactorizing the covariance matrix whether the distribution is frozen or not. The `Covariance` objects remember their factorization whether the distribution is frozen or not. 

Also, `stats.multivariate_normal.rvs` does an "indiscriminate squeeze", so singleton dimensions requested by the user are not present in the output. When the user passes an array as the covariance matrix, it is not easy to fix this in a backward-compatible way. But if the user passes a new `Covariance` instance, it might as well return an array of the correct shape.

This PR adds a `colorize` method to the `Covariance` class and uses it to generate random variates in `multivariate_normal.rvs`.

```python3
import numpy as np
from scipy import stats
import matplotlib.pyplot as plt

rng = np.random.default_rng(984261616848)
size = (10, 10, 10)

mean = [10, 20]
V = np.array([[1, 1], [-1, 1]]) * np.sqrt(2)/2
W = np.diag([1, 5])
A = V.T @ W @ V

rvs1 = stats.multivariate_normal.rvs(mean, A, size=size, random_state=rng)
rvs1 = rvs1.reshape(1000, -1)

cov = stats.Covariance.from_cholesky(np.linalg.cholesky(A))
# cov = stats.Covariance.from_precision(np.linalg.inv(A))
# cov = stats.Covariance.from_eigendecomposition(np.linalg.eigh(A))
rvs2 = stats.multivariate_normal.rvs(mean, cov, size=size, random_state=rng)
rvs2 = rvs2.reshape(1000, -1)

plt.plot(*rvs1.T, '.', *rvs2.T, '.', alpha=0.5)
# plt.plot(*rvs2.T, '.', *rvs1.T, '.', alpha=0.5)  # looks the same
```

![image](https://user-images.githubusercontent.com/6570539/197363116-e3d5412d-900f-484c-9a3a-2d5f4031f1a7.png)

<details>

Even in low dimensional spaces and considering the cost of `Covariance` construction, the speed of the `Covariance` versions is comparable to that of NumPy's generator, which we currently rely on.

```python3
import numpy as np
from scipy import stats
rng = np.random.default_rng(984261616848)

mean = rng.random(10)
A = np.random.rand(10, 10)
A = A @ A.T

# One sample
%timeit rng.multivariate_normal(mean, A, size=None)
87 µs ± 811 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

%timeit cov = stats.Covariance.from_cholesky(np.linalg.cholesky(A)); stats.multivariate_normal.rvs(mean, cov, size=None, random_state=rng)
# 45.8 µs ± 107 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

%timeit cov = stats.Covariance.from_eigendecomposition(np.linalg.eigh(A)); stats.multivariate_normal.rvs(mean, cov, size=None, random_state=rng)
# 116 µs ± 1.2 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)

# Many samples
size = (10, 10, 10)

%timeit rng.multivariate_normal(mean, A, size=size)
# 207 µs ± 7.5 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

%timeit cov = stats.Covariance.from_cholesky(np.linalg.cholesky(A)); stats.multivariate_normal.rvs(mean, cov, size=size, random_state=rng)
# 205 µs ± 734 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

%timeit cov = stats.Covariance.from_eigendecomposition(np.linalg.eigh(A)); stats.multivariate_normal.rvs(mean, cov, size=size, random_state=rng)
# 292 µs ± 419 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```

The situation is even better in high-dimensional spaces.
```python3
n = 1000
mean = rng.random(n)
A = np.random.rand(n, n)
A = A @ A.T

%timeit rng.multivariate_normal(mean, A, size=None)
# 165 ms ± 503 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

%timeit cov = stats.Covariance.from_cholesky(np.linalg.cholesky(A)); stats.multivariate_normal.rvs(mean, cov, size=None, random_state=rng)
# 16.3 ms ± 92.1 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

%timeit cov = stats.Covariance.from_eigendecomposition(np.linalg.eigh(A)); stats.multivariate_normal.rvs(mean, cov, size=None, random_state=rng)
# 59.5 ms ± 1.81 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

And of course, if the covariance matrix is diagonal, the `Covariance` object created by `from_diagonal` is more accurate and faster still.

</details>


#### Additional information
Should the method be called `color` or `colorize`?

We'll fix the shape of `pdf`/`logpdf` output in a separate PR. We can use `Covariance` similarly in a few other multivariate distributions. IIUC, part of the speed increase is because these never use SVD. If we need a `from_SVD` version, it can easily be added.

@siddhantwahal 