### PR TITLE
TST: mark no_segmentation fault test for DIRECT as xslow

### DIFF
--- a/scipy/optimize/tests/test_direct.py
+++ b/scipy/optimize/tests/test_direct.py
@@ -197,6 +197,7 @@ class TestDIRECT:
         assert result.status == 4
         assert result.success
 
+    @pytest.mark.xslow
     @pytest.mark.parametrize("locally_biased", [True, False])
     def test_no_segmentation_fault(self, locally_biased):
         # test that an excessive number of function evaluations


### PR DESCRIPTION
#### What does this implement/fix?
A check in azure pipelines today showed that this test took 17 seconds (see screenshot below). Before I also noticed that this test is often the slowest one in CI.

![image](https://user-images.githubusercontent.com/40656107/197387474-d442a442-30b8-4762-a4c0-49fe7935aae9.png)

#### Additional information
Not testing this regularly should be fine. The chance that a user would reach the memory limit tested here is anyway pretty low.