### PR TITLE
STY: stats.Covariance: fix lint issue in `main`

### DIFF
--- a/scipy/stats/_covariance.py
+++ b/scipy/stats/_covariance.py
@@ -337,7 +337,7 @@ class Covariance:
         ----------
         .. [1] "Whitening Transformation". Wikipedia.
                https://en.wikipedia.org/wiki/Whitening_transformation
-        .. [2] Novák, Lukáš, and Miroslav Vořechovský. "Generalization of
+        .. [2] Novak, Lukas, and Miroslav Vorechovsky. "Generalization of
                coloring linear transformation". Transactions of VSB 18.2
                (2018): 31-35. :doi:`10.31490/tces-2018-0013`
 
@@ -390,7 +390,7 @@ class Covariance:
         ----------
         .. [1] "Whitening Transformation". Wikipedia.
                https://en.wikipedia.org/wiki/Whitening_transformation
-        .. [2] Novák, Lukáš, and Miroslav Vořechovský. "Generalization of
+        .. [2] Novak, Lukas, and Miroslav Vorechovsky. "Generalization of
                coloring linear transformation". Transactions of VSB 18.2
                (2018): 31-35. :doi:`10.31490/tces-2018-0013`
 


### PR DESCRIPTION
There's a lint failure in main, and this resolves it. The authors printed the cited paper without the non-ASCII characters in their names, so I don't think they'll mind.