### PR TITLE
MAINT: special: Loosen tolerance in test_sinpi() and test_cospi().

### DIFF
--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -963,7 +963,7 @@ class TestSystematic:
         eps = np.finfo(float).eps
         assert_mpmath_equal(_cospi,
                             mpmath.cospi,
-                            [Arg()], nan_ok=False, rtol=eps)
+                            [Arg()], nan_ok=False, rtol=2*eps)
 
     def test_cospi_complex(self):
         assert_mpmath_equal(_cospi,
@@ -1743,7 +1743,7 @@ class TestSystematic:
     def test_sinpi(self):
         eps = np.finfo(float).eps
         assert_mpmath_equal(_sinpi, mpmath.sinpi,
-                            [Arg()], nan_ok=False, rtol=eps)
+                            [Arg()], nan_ok=False, rtol=2*eps)
 
     def test_sinpi_complex(self):
         assert_mpmath_equal(_sinpi, mpmath.sinpi,


### PR DESCRIPTION
This is to fix failures that occur when SCIPY_XSLOW is defined. SCIPY_XSLOW causes these tests to be run with many more samples, and some values require another ULP of tolerance to pass.

See https://github.com/scipy/scipy/issues/15384.

I updated both `test_sinpi()` and `test_cospi()`.  In https://github.com/scipy/scipy/issues/15384 and on my Linux machine, only `test_sinpi()` fails, but on ye olde Macbook, I also get a failure of `test_cospi()`.