### PR TITLE
DOC: Clarify minimum_spanning_tree behavior in non-connected case.

### DIFF
--- a/scipy/sparse/csgraph/_min_spanning_tree.pyx
+++ b/scipy/sparse/csgraph/_min_spanning_tree.pyx
@@ -50,6 +50,9 @@ def minimum_spanning_tree(csgraph, overwrite=False):
     Small elements < 1E-8 of the dense matrix are rounded to zero.
     All users should input sparse matrices if possible to avoid it.
 
+    If the graph is not connected, this routine returns the minimum spanning
+    forest, i.e. the union of the minimum spanning trees on each connected
+    component.
 
     Examples
     --------


### PR DESCRIPTION
AFAICT, Kruskal's algorithm (as implemented in _min_spanning_tree.pyx) works as is for the non-connected case as well: the loop `while i < n_data and n_edges_in_mst < n_verts - 1` simply keeps going while never finding an edge that connects separate components, and the separate components are effectively processed independently.

The behavior is also consistent with networkx's minimum_spanning_edges.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
