### PR TITLE
CI: test on musllinux

### DIFF
--- a/ci/cirrus_general_ci.yml
+++ b/ci/cirrus_general_ci.yml
@@ -1,4 +1,4 @@
-# Regular CI for testing linux_aarch64 and macosx_arm64 natively
+# Regular CI for testing musllinux, linux_aarch64 and macosx_arm64 natively
 # This only runs if cirrus is not building wheels. The rationale is that
 # cibuildwheel also runs tests during the wheel build process, so there's no need
 # to have duplication.
@@ -35,6 +35,39 @@ linux_aarch64_test_task:
     python -m pip install click rich_click doit pydevtool
     python -m pip install pytest pooch
     
+    python dev.py test
+
+
+musllinux_amd64_test_task:
+  container:
+    image: alpine
+    cpu: 8
+    memory: 32G
+
+  pip_cache:
+    folder: ~/.cache/pip
+    populate_script: |
+      apk add openblas-dev python3 python3-dev openblas build-base gfortran git py3-pip
+      ln -s $(which python3.10) python
+      export PATH=$PWD:$PATH
+
+      pip install -vvv numpy
+
+  test_script: |
+    apk update
+    apk add openblas-dev python3 python3-dev openblas build-base gfortran git py3-pip
+    git submodule update --init
+
+    ln -s $(which python3.10) python
+    export PATH=$PWD:$PATH
+
+    # I don't think that the alpine py3-numpy package has the include dirs.
+    pip install -vvv numpy
+
+    python -m pip install meson ninja cython pybind11 pythran cython
+    python -m pip install click rich_click doit pydevtool
+    python -m pip install pytest pooch
+    python dev.py build
     python dev.py test
 
 

--- a/ci/cirrus_general_ci.yml
+++ b/ci/cirrus_general_ci.yml
@@ -67,25 +67,9 @@ musllinux_amd64_test_task:
     python dev.py build
 
   test_script: |
-    # split over several runs because there's a segfault in ndimage (gh17270)
+    # Don't run the ndimage tests because there's a segfault (gh17270)
     set -xe -o
-    python dev.py test -s _lib
-    python dev.py test -s cluster
-    python dev.py test -s constants
-    python dev.py test -s datasets
-    python dev.py test -s fft
-    python dev.py test -s fftpack
-    python dev.py test -s integrate
-    python dev.py test -s interpolate
-    python dev.py test -s io
-    python dev.py test -s linalg
-    python dev.py test -s misc
-    python dev.py test -s odr
-    python dev.py test -s optimize
-    python dev.py test -s signal
-    python dev.py test -s sparse
-    python dev.py test -s special
-    python dev.py test -s stats
+    python dev.py test -- --ignore=scipy/ndimage/tests
 
 
 macos_arm64_test_task:

--- a/ci/cirrus_general_ci.yml
+++ b/ci/cirrus_general_ci.yml
@@ -47,35 +47,45 @@ musllinux_amd64_test_task:
   env:
     PATH: $PWD:$PATH
 
-  pip_cache:
-    folder: ~/.cache/pip
-    populate_script: |
-      apk add openblas-dev python3 python3-dev openblas build-base gfortran git py3-pip
-      ln -sf $(which python3.10) python
-      pip install -vvv --upgrade numpy
-
   setup_script: |
     apk update
     apk add openblas-dev python3 python3-dev openblas build-base gfortran git py3-pip
     git submodule update --init
 
     ln -sf $(which python3.10) python
-    # I don't think that the alpine py3-numpy package has the include dirs.
-    pip install -vvv --upgrade numpy
+
+  pip_cache:
+    folder: ~/.cache/pip
+
+  python_dependencies_script: |
+      python -m pip install cython
+      python -m pip install -vvv --upgrade numpy    
+      python -m pip install meson ninja pybind11 pythran pytest
+      python -m pip install click rich_click doit pydevtool pooch
 
   build_script: |
-    python -m pip install meson ninja cython pybind11 pythran cython
-    python -m pip install click rich_click doit pydevtool
     python dev.py build
 
   test_script: |
-    pip install pooch pytest
     # split over several runs because there's a segfault in ndimage (gh17270)
-    python dev.py test -s _lib -s cluster -s constants
-    python dev.py test -s datasets -s fft -s fftpack -s integrate
-    python dev.py test -s interpolate -s io -s linalg -s misc
-    python dev.py test -s odr -s optimize -s signal -s sparse
-    python dev.py test -s special -s stats
+    set -xe -o
+    python dev.py test -s _lib
+    python dev.py test -s cluster
+    python dev.py test -s constants
+    python dev.py test -s datasets
+    python dev.py test -s fft
+    python dev.py test -s fftpack
+    python dev.py test -s integrate
+    python dev.py test -s interpolate
+    python dev.py test -s io
+    python dev.py test -s linalg
+    python dev.py test -s misc
+    python dev.py test -s odr
+    python dev.py test -s optimize
+    python dev.py test -s signal
+    python dev.py test -s sparse
+    python dev.py test -s special
+    python dev.py test -s stats
 
 
 macos_arm64_test_task:

--- a/ci/cirrus_general_ci.yml
+++ b/ci/cirrus_general_ci.yml
@@ -53,7 +53,7 @@ musllinux_amd64_test_task:
 
       pip install -vvv --upgrade numpy
 
-  test_script: |
+  setup_script: |
     apk update
     apk add openblas-dev python3 python3-dev openblas build-base gfortran git py3-pip
     git submodule update --init
@@ -64,11 +64,18 @@ musllinux_amd64_test_task:
     # I don't think that the alpine py3-numpy package has the include dirs.
     pip install -vvv --upgrade numpy
 
+  build_script: |
     python -m pip install meson ninja cython pybind11 pythran cython
     python -m pip install click rich_click doit pydevtool
-    python -m pip install pytest pooch
     python dev.py build
-    python dev.py test
+
+  test_script: |
+    # split over several runs because there's a segfault in ndimage (gh17270)
+    python dev.py test -s _lib -s cluster -s constants
+    python dev.py test -s datasets -s fft -s fftpack -s integrate
+    python dev.py test -s interpolate -s io -s linalg -s misc
+    python dev.py test -s odr -s optimize -s signal -s sparse
+    python dev.py test -s special -s stats
 
 
 macos_arm64_test_task:

--- a/ci/cirrus_general_ci.yml
+++ b/ci/cirrus_general_ci.yml
@@ -51,7 +51,7 @@ musllinux_amd64_test_task:
       ln -s $(which python3.10) python
       export PATH=$PWD:$PATH
 
-      pip install -vvv numpy
+      pip install -vvv --upgrade numpy
 
   test_script: |
     apk update
@@ -62,7 +62,7 @@ musllinux_amd64_test_task:
     export PATH=$PWD:$PATH
 
     # I don't think that the alpine py3-numpy package has the include dirs.
-    pip install -vvv numpy
+    pip install -vvv --upgrade numpy
 
     python -m pip install meson ninja cython pybind11 pythran cython
     python -m pip install click rich_click doit pydevtool

--- a/ci/cirrus_general_ci.yml
+++ b/ci/cirrus_general_ci.yml
@@ -60,11 +60,13 @@ musllinux_amd64_test_task:
 
     ln -sf $(which python3.10) python
     export PATH=$PWD:$PATH
-
+    printenv
     # I don't think that the alpine py3-numpy package has the include dirs.
     pip install -vvv --upgrade numpy
 
   build_script: |
+    printenv
+    ls -al
     python -m pip install meson ninja cython pybind11 pythran cython
     python -m pip install click rich_click doit pydevtool
     python dev.py build

--- a/ci/cirrus_general_ci.yml
+++ b/ci/cirrus_general_ci.yml
@@ -44,13 +44,14 @@ musllinux_amd64_test_task:
     cpu: 8
     memory: 32G
 
+  env:
+    PATH: $PWD:$PATH
+
   pip_cache:
     folder: ~/.cache/pip
     populate_script: |
       apk add openblas-dev python3 python3-dev openblas build-base gfortran git py3-pip
       ln -sf $(which python3.10) python
-      export PATH=$PWD:$PATH
-
       pip install -vvv --upgrade numpy
 
   setup_script: |
@@ -59,14 +60,10 @@ musllinux_amd64_test_task:
     git submodule update --init
 
     ln -sf $(which python3.10) python
-    export PATH=$PWD:$PATH
-    printenv
     # I don't think that the alpine py3-numpy package has the include dirs.
     pip install -vvv --upgrade numpy
 
   build_script: |
-    printenv
-    ls -al
     python -m pip install meson ninja cython pybind11 pythran cython
     python -m pip install click rich_click doit pydevtool
     python dev.py build

--- a/ci/cirrus_general_ci.yml
+++ b/ci/cirrus_general_ci.yml
@@ -69,6 +69,7 @@ musllinux_amd64_test_task:
     python dev.py build
 
   test_script: |
+    pip install pooch pytest
     # split over several runs because there's a segfault in ndimage (gh17270)
     python dev.py test -s _lib -s cluster -s constants
     python dev.py test -s datasets -s fft -s fftpack -s integrate

--- a/ci/cirrus_general_ci.yml
+++ b/ci/cirrus_general_ci.yml
@@ -48,7 +48,7 @@ musllinux_amd64_test_task:
     folder: ~/.cache/pip
     populate_script: |
       apk add openblas-dev python3 python3-dev openblas build-base gfortran git py3-pip
-      ln -s $(which python3.10) python
+      ln -sf $(which python3.10) python
       export PATH=$PWD:$PATH
 
       pip install -vvv --upgrade numpy
@@ -58,7 +58,7 @@ musllinux_amd64_test_task:
     apk add openblas-dev python3 python3-dev openblas build-base gfortran git py3-pip
     git submodule update --init
 
-    ln -s $(which python3.10) python
+    ln -sf $(which python3.10) python
     export PATH=$PWD:$PATH
 
     # I don't think that the alpine py3-numpy package has the include dirs.


### PR DESCRIPTION
Tests for musllinux, as mentioned on scipy-dev.

The first issue highlighted is #17270, so the CI will currently fail. Perhaps we should have [failure toleration](https://cirrus-ci.org/guide/writing-tasks/#failure-toleration) to start with?

I used cirrus-ci because it allows one to run tests in a docker container of one's choice. Currently pip installing numpy will require it to build numpy as there isn't a musllinux wheel. This overhead is then recovered by caching the pip cache.

It currently assumes that the alpine image is Python3.10