### PR TITLE
DOC, MAINT: remove use of inspect.formatargspec during doc build

### DIFF
--- a/doc/source/scipyoptdoc.py
+++ b/doc/source/scipyoptdoc.py
@@ -20,10 +20,9 @@ Produces output similar to autodoc, except
 - See Also link to the actual function documentation is inserted
 
 """
-import os, sys, re, pydoc
+import sys, pydoc
 import sphinx
 import inspect
-import collections
 import textwrap
 import warnings
 
@@ -125,8 +124,7 @@ def wrap_mangling_directive(base_directive):
             # XXX deprecation that we should fix someday using Signature (?)
             with warnings.catch_warnings(record=True):
                 warnings.simplefilter('ignore')
-                signature = inspect.formatargspec(
-                    args, varargs, keywords, defaults)
+                signature = str(inspect.signature(obj))
 
             # Produce output
             self.options['noindex'] = True


### PR DESCRIPTION
#### Reference issue

Doc build doesn't work on Python 3.11.

<details>

<summary>Sphinx build log with Python 3.11</summary>

```
fatal: bad revision '^v1.8.0'
fatal: bad revision '^v1.8.0'
fatal: bad revision '^v1.8.0'
# for testing
# @echo installed scipy 48c3dc8 matches git version 48c3dc8; exit 1
mkdir -p build/html build/doctrees
LANG=C python3 -msphinx -WT --keep-going  -b html -d build/doctrees -j12 source build/html 
Running Sphinx v5.3.0
SciPy (VERSION 1.10.0.dev0+0.48c3dc8)
/home/tirthasheshpatel/oss/virtualenvs/scipy-dev/lib/python3.11/site-packages/sphinx/util/images.py:4: DeprecationWarning: 'imghdr' is deprecated and slated for removal in Python 3.13
  import imghdr
[autosummary] generating autosummary for: dev/api-dev/api-dev-toc.rst, dev/api-dev/nan_policy.rst, dev/api-dev/special_ufuncs.rst, dev/conduct/code_of_conduct.rst, dev/conduct/report_handling_manual.rst, dev/contributor/adding_new.rst, dev/contributor/benchmarking.rst, dev/contributor/building.rst, dev/contributor/building_faq.rst, dev/contributor/compiled_code.rst, ..., tutorial/stats/discrete_zipf.rst, tutorial/stats/discrete_zipfian.rst, tutorial/stats/resampling.rst, tutorial/stats/sampling.rst, tutorial/stats/sampling_dau.rst, tutorial/stats/sampling_dgt.rst, tutorial/stats/sampling_hinv.rst, tutorial/stats/sampling_pinv.rst, tutorial/stats/sampling_srou.rst, tutorial/stats/sampling_tdr.rst
[autosummary] generating autosummary for: /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/czt-function.rst, /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/odr-function.rst, /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/scipy.LowLevelCallable.rst, /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/scipy.cluster.hierarchy.ClusterNode.rst, /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/scipy.cluster.hierarchy.DisjointSet.rst, /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/scipy.cluster.hierarchy.average.rst, /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/scipy.cluster.hierarchy.centroid.rst, /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/scipy.cluster.hierarchy.complete.rst, /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/scipy.cluster.hierarchy.cophenet.rst, /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/scipy.cluster.hierarchy.correspond.rst, ..., /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/scipy.stats.wrapcauchy.rst, /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/scipy.stats.yeojohnson.rst, /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/scipy.stats.yeojohnson_llf.rst, /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/scipy.stats.yeojohnson_normmax.rst, /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/scipy.stats.yeojohnson_normplot.rst, /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/scipy.stats.yulesimon.rst, /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/scipy.stats.zipf.rst, /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/scipy.stats.zipfian.rst, /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/scipy.stats.zmap.rst, /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/scipy.stats.zscore.rst
[autosummary] generating autosummary for: /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/scipy.LowLevelCallable.__getitem__.rst, /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/scipy.LowLevelCallable.__len__.rst, /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/scipy.LowLevelCallable.__mul__.rst, /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/scipy.LowLevelCallable.count.rst, /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/scipy.LowLevelCallable.from_cython.rst, /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/scipy.LowLevelCallable.function.rst, /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/scipy.LowLevelCallable.index.rst, /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/scipy.LowLevelCallable.signature.rst, /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/scipy.LowLevelCallable.user_data.rst, /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/scipy.cluster.hierarchy.ClusterNode.get_count.rst, ..., /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/scipy.stats.sampling.NumericalInversePolynomial.set_random_state.rst, /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/scipy.stats.sampling.NumericalInversePolynomial.u_error.rst, /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/scipy.stats.sampling.SimpleRatioUniforms.rvs.rst, /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/scipy.stats.sampling.SimpleRatioUniforms.set_random_state.rst, /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/scipy.stats.sampling.TransformedDensityRejection.hat_area.rst, /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/scipy.stats.sampling.TransformedDensityRejection.ppf_hat.rst, /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/scipy.stats.sampling.TransformedDensityRejection.rvs.rst, /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/scipy.stats.sampling.TransformedDensityRejection.set_random_state.rst, /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/scipy.stats.sampling.TransformedDensityRejection.squeeze_area.rst, /home/tirthasheshpatel/oss/scipy/doc/source/reference/generated/scipy.stats.sampling.TransformedDensityRejection.squeeze_hat_ratio.rst
loading intersphinx inventory from https://docs.python.org/3/objects.inv...
loading intersphinx inventory from https://numpy.org/devdocs/objects.inv...
loading intersphinx inventory from https://numpy.org/neps/objects.inv...
loading intersphinx inventory from https://matplotlib.org/stable/objects.inv...
loading intersphinx inventory from https://asv.readthedocs.io/en/stable/objects.inv...
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 328 source files that are out of date
updating environment: [new config] 4317 added, 0 changed, 0 removed
reading sources... [  9%] reference/generated/scipy.interpolate.BivariateSpline.ev .. reference/generated/scipy.interpolate.LSQBivariateSpline.get_coeffs                                                 
Traceback (most recent call last):
  File "/home/tirthasheshpatel/oss/virtualenvs/scipy-dev/lib/python3.11/site-packages/sphinx/cmd/build.py", line 281, in build_main
    app.build(args.force_all, args.filenames)
  File "/home/tirthasheshpatel/oss/virtualenvs/scipy-dev/lib/python3.11/site-packages/sphinx/application.py", line 347, in build
    self.builder.build_update()
  File "/home/tirthasheshpatel/oss/virtualenvs/scipy-dev/lib/python3.11/site-packages/sphinx/builders/__init__.py", line 310, in build_update
    self.build(to_build,
  File "/home/tirthasheshpatel/oss/virtualenvs/scipy-dev/lib/python3.11/site-packages/sphinx/builders/__init__.py", line 326, in build
    updated_docnames = set(self.read())
                           ^^^^^^^^^^^
  File "/home/tirthasheshpatel/oss/virtualenvs/scipy-dev/lib/python3.11/site-packages/sphinx/builders/__init__.py", line 431, in read
    self._read_parallel(docnames, nproc=self.app.parallel)
  File "/home/tirthasheshpatel/oss/virtualenvs/scipy-dev/lib/python3.11/site-packages/sphinx/builders/__init__.py", line 487, in _read_parallel
    tasks.join()
  File "/home/tirthasheshpatel/oss/virtualenvs/scipy-dev/lib/python3.11/site-packages/sphinx/util/parallel.py", line 105, in join
    if not self._join_one():
           ^^^^^^^^^^^^^^^^
  File "/home/tirthasheshpatel/oss/virtualenvs/scipy-dev/lib/python3.11/site-packages/sphinx/util/parallel.py", line 126, in _join_one
    raise SphinxParallelError(*result)
sphinx.errors.SphinxParallelError: AttributeError: module 'inspect' has no attribute 'formatargspec'

Sphinx parallel build error:
AttributeError: module 'inspect' has no attribute 'formatargspec'
make: *** [Makefile:110: html-build] Error 2

real	0m21.865s
user	1m22.244s
sys	0m14.798s
```

</details>

#### What does this implement/fix?

[`inspect.formatargspec`](https://docs.python.org/3.10/library/inspect.html#inspect.formatargspec) was deprecated in Python 3.5 and has been removed in Python 3.11. This PR replaces the use of `inspect.formatargspec` with [`inspect.signature`](https://docs.python.org/3.10/library/inspect.html#inspect.signature) so that the doc builds succeed on Python 3.11.

#### Additional information

Once this and executablebooks/sphinx-design#105 merge, doc builds should succeed on Python 3.11
