### PR TITLE
Remove handwritten `_fitpack.spalde` : a rebase of pr/17145 

### DIFF
--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -467,10 +467,7 @@ class UnivariateSpline:
         array([2.25, 3.0, 2.0, 0])
 
         """
-        d, ier = dfitpack.spalde(*(self._eval_args+(x,)))
-        if not ier == 0:
-            raise ValueError("Error code returned by spalde: %s" % ier)
-        return d
+        return _fitpack_impl.spalde(x, self._eval_args)
 
     def roots(self):
         """ Return the zeros of the spline.

--- a/scipy/interpolate/_fitpack_impl.py
+++ b/scipy/interpolate/_fitpack_impl.py
@@ -776,7 +776,7 @@ def spalde(x, tck):
         x = atleast_1d(x)
         if len(x) > 1:
             return list(map(lambda x, tck=tck: spalde(x, tck), x))
-        d, ier = _fitpack._spalde(t, c, k, x[0])
+        d, ier = dfitpack.spalde(t, c, k, x[0])
         if ier == 0:
             return d
         if ier == 10:

--- a/scipy/interpolate/_fitpack_impl.py
+++ b/scipy/interpolate/_fitpack_impl.py
@@ -776,7 +776,7 @@ def spalde(x, tck):
         x = atleast_1d(x)
         if len(x) > 1:
             return list(map(lambda x, tck=tck: spalde(x, tck), x))
-        d, ier = dfitpack.spalde(t, c, k, x[0])
+        d, ier = dfitpack.spalde(t, c, k+1, x[0])
         if ier == 0:
             return d
         if ier == 10:

--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -82,7 +82,6 @@ static PyObject *fitpack_error;
 	#else
 		#define CURFIT CURFIT_
 		#define PERCUR PERCUR_
-		#define SPALDE SPALDE_
 		#define SPLDER SPLDER_
 		#define SPLEV  SPLEV_
 		#define SPLINT SPLINT_
@@ -97,7 +96,6 @@ static PyObject *fitpack_error;
 	#if defined(NO_APPEND_FORTRAN)
 		#define CURFIT curfit
 		#define PERCUR percur
-		#define SPALDE spalde
 		#define SPLDER splder
 		#define SPLEV splev
 		#define SPLINT splint
@@ -110,7 +108,6 @@ static PyObject *fitpack_error;
 	#else
 		#define CURFIT curfit_
 		#define PERCUR percur_
-		#define SPALDE spalde_
 		#define SPLDER splder_
 		#define SPLEV splev_
 		#define SPLINT splint_
@@ -129,7 +126,6 @@ void CURFIT(F_INT*,F_INT*,double*,double*,double*,double*,
 void PERCUR(F_INT*,F_INT*,double*,double*,double*,F_INT*,
         double*,F_INT*,F_INT*,double*,double*,double*,
         double*,F_INT*,F_INT*,F_INT*);
-void SPALDE(double*,F_INT*,double*,F_INT*,double*,double*,F_INT*);
 void SPLDER(double*,F_INT*,double*,F_INT*,F_INT*,double*,
         double*,F_INT*,F_INT*,double*,F_INT*);
 void SPLEV(double*,F_INT*,double*,F_INT*,double*,double*,F_INT*,F_INT*,F_INT*);

--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -63,7 +63,6 @@ static PyObject *fitpack_error;
 /*  module_methods:
  * {"_curfit", fitpack_curfit, METH_VARARGS, doc_curfit},
  * {"_spl_", fitpack_spl_, METH_VARARGS, doc_spl_},
- * {"_spalde", fitpack_spalde, METH_VARARGS, doc_spalde},
  * {"_parcur", fitpack_parcur, METH_VARARGS, doc_parcur},
  * {"_surfit", fitpack_surfit, METH_VARARGS, doc_surfit},
  * {"_bispev", fitpack_bispev, METH_VARARGS, doc_bispev},
@@ -718,45 +717,6 @@ fail:
     return NULL;
 }
 
-static char doc_spalde[] = " [d,ier] = _spalde(t,c,k,x)";
-static PyObject *
-fitpack_spalde(PyObject *dummy, PyObject *args)
-{
-    F_INT n, k, ier, k1;
-    npy_intp dims[1];
-    double *t, *c, *d = NULL, x;
-    PyArrayObject *ap_t = NULL, *ap_c = NULL, *ap_d = NULL;
-    PyObject *t_py = NULL, *c_py = NULL;
-
-    if (!PyArg_ParseTuple(args, ("OO" F_INT_PYFMT "d"),
-                          &t_py,&c_py,&k,&x)) {
-        return NULL;
-    }
-    ap_t = (PyArrayObject *)PyArray_ContiguousFromObject(t_py, NPY_DOUBLE, 0, 1);
-    ap_c = (PyArrayObject *)PyArray_ContiguousFromObject(c_py, NPY_DOUBLE, 0, 1);
-    if ((ap_t == NULL || ap_c == NULL)) {
-        goto fail;
-    }
-    t = (double *)PyArray_DATA(ap_t);
-    c = (double *)PyArray_DATA(ap_c);
-    n = PyArray_DIMS(ap_t)[0];
-    k1 = k + 1;
-    dims[0] = k1;
-    ap_d = (PyArrayObject *)PyArray_SimpleNew(1, dims, NPY_DOUBLE);
-    if (ap_d == NULL) {
-        goto fail;
-    }
-    d = (double *)PyArray_DATA(ap_d);
-    SPALDE(t, &n, c, &k1, &x, d, &ier);
-    Py_DECREF(ap_c);
-    Py_DECREF(ap_t);
-    return Py_BuildValue(("N" F_INT_PYFMT), PyArray_Return(ap_d), ier);
-
-fail:
-    Py_XDECREF(ap_c);
-    Py_XDECREF(ap_t);
-    return NULL;
-}
 
 static char doc_insert[] = " [tt,cc,ier] = _insert(iopt,t,c,k,x,m)";
 static PyObject *
@@ -1419,9 +1379,6 @@ static struct PyMethodDef fitpack_module_methods[] = {
 {"_spl_",
     fitpack_spl_,
     METH_VARARGS, doc_spl_},
-{"_spalde",
-    fitpack_spalde,
-    METH_VARARGS, doc_spalde},
 {"_parcur",
     fitpack_parcur,
     METH_VARARGS, doc_parcur},

--- a/scipy/interpolate/src/fitpack.pyf
+++ b/scipy/interpolate/src/fitpack.pyf
@@ -168,15 +168,15 @@ static F_INT calc_regrid_lwrk(F_INT mx, F_INT my, F_INT kx, F_INT ky,
        integer intent(out) :: ier
      end subroutine sproot
 
-     subroutine spalde(t,n,c,k,x,d,ier)
-       ! d,ier = spalde(t,c,k,x)
+     subroutine spalde(t,n,c,k1,x,d,ier)
+       ! d,ier = spalde(t,c,k1,x)
        threadsafe
        real*8 dimension(n) :: t
        integer intent(hide),depend(t) :: n=len(t)
        real*8 dimension(n),depend(n),check(len(c)==n) :: c
-       integer intent(in) :: k
+       integer intent(in) :: k1
        real*8 intent(in) :: x
-       real*8 dimension(k),intent(out),depend(k) :: d
+       real*8 dimension(k1),intent(out),depend(k1) :: d
        integer intent(out) :: ier
      end subroutine spalde
 

--- a/scipy/interpolate/src/fitpack.pyf
+++ b/scipy/interpolate/src/fitpack.pyf
@@ -170,17 +170,13 @@ static F_INT calc_regrid_lwrk(F_INT mx, F_INT my, F_INT kx, F_INT ky,
 
      subroutine spalde(t,n,c,k,x,d,ier)
        ! d,ier = spalde(t,c,k,x)
-
        threadsafe
-       callprotoargument double*,F_INT*,double*,F_INT*,double*,double*,F_INT*
-       callstatement {int k1=k+1; (*f2py_func)(t,&n,c,&k1,&x,d,&ier); }
-
        real*8 dimension(n) :: t
        integer intent(hide),depend(t) :: n=len(t)
        real*8 dimension(n),depend(n),check(len(c)==n) :: c
        integer intent(in) :: k
        real*8 intent(in) :: x
-       real*8 dimension(k+1),intent(out),depend(k) :: d
+       real*8 dimension(k),intent(out),depend(k) :: d
        integer intent(out) :: ier
      end subroutine spalde
 

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -67,6 +67,13 @@ class TestUnivariateSpline:
         spl = UnivariateSpline(x, y, k=3)
         assert_almost_equal(spl.roots()[0], 1.050290639101332)
 
+    def test_derivatives(self):
+        x = [1, 3, 5, 7, 9]
+        y = [0, 4, 9, 12, 21]
+        spl = UnivariateSpline(x, y, k=3)
+        assert_almost_equal(spl.derivatives(3.5),
+                            [5.5152902, 1.7146577, -0.1830357, 0.3125])
+
     def test_resize_regression(self):
         """Regression test for #1375."""
         x = [-1., -0.65016502, -0.58856235, -0.26903553, -0.17370892,

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -6,7 +6,7 @@ from numpy.testing import (assert_equal, assert_almost_equal, assert_array_equal
 from pytest import raises as assert_raises
 
 from numpy import array, diff, linspace, meshgrid, ones, pi, shape
-from scipy.interpolate._fitpack_py import bisplrep, bisplev
+from scipy.interpolate._fitpack_py import bisplrep, bisplev, splrep, spalde
 from scipy.interpolate._fitpack2 import (UnivariateSpline,
         LSQUnivariateSpline, InterpolatedUnivariateSpline,
         LSQBivariateSpline, SmoothBivariateSpline, RectBivariateSpline,
@@ -73,6 +73,22 @@ class TestUnivariateSpline:
         spl = UnivariateSpline(x, y, k=3)
         assert_almost_equal(spl.derivatives(3.5),
                             [5.5152902, 1.7146577, -0.1830357, 0.3125])
+
+    def test_derivatives_2(self):
+        x = np.arange(8)
+        y = x**3 + 2.*x**2
+
+        tck = splrep(x, y, s=0)
+        ders = spalde(3, tck)
+        assert_allclose(ders, [45.,   # 3**3 + 2*(3)**2
+                               39.,   # 3*(3)**2 + 4*(3)
+                               22.,   # 6*(3) + 4
+                               6.],   # 6*3**0
+                        atol=1e-15)
+        spl = UnivariateSpline(x, y, s=0, k=3)
+        assert_allclose(spl.derivatives(3),
+                        ders,
+                        atol=1e-15)
 
     def test_resize_regression(self):
         """Regression test for #1375."""


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

continues and supersedes https://github.com/scipy/scipy/pull/17145

#### What does this implement/fix?
<!--Please explain your changes.-->

Remove handwritten `spalde` wrapper, use f2py wrapper instead. 

#### Additional information
<!--Any additional information you think is important.-->

All heavy-lifting is done in gh-17145, this PR just renames an argument of `dfitpack.spalde` (for cubic spines, k=3 and 4=k1) and adds a test.
