### PR TITLE
DOC: document return object type recommendations in "The Missing Bits"

### DIFF
--- a/doc/source/dev/missing-bits.rst
+++ b/doc/source/dev/missing-bits.rst
@@ -47,6 +47,15 @@ would probably do anyway even without the use of ``*``), *and* it means
 additional parameters can be added to the function anywhere after the
 ``*``; new parameters do not have to be added after the existing parameters.
 
+Return Objects
+~~~~~~~~~~~~~~
+For new functions or methods that return two or more conceptually distinct
+elements, use an object type that is not iterable. In particular, do not use
+``tuple``, ``namedtuple``, or ``make_tuple_bunch``, the latter of which is
+only for adding new attributes to the object returned by existing functions.
+This practice forces callers to be more explicit about the element of the
+returned object that they wish to access, and it makes it easier to extend
+the function or method in a backward compatible way.
 
 Test functions from `numpy.testing`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
#### Reference issue
gh-12323
gh-13118

#### What does this implement/fix?
There was a lot of discussion in gh-17126 about return object types, but I think that everyone involved agreed on the following:
when a new function needs to return more than one distinct piece of information, a non-iterable class is preferable to a `tuple`, `namedtuple`, or bunch. This PR would document that decision in "Code and Documentation Style Guide - The Missing Bits".

#### What does this implement/fix?
Wording suggestions welcome. If you tend to agree that "The Missing Bits" is a good place to document the results of such a discussion, please use thumbs up. If this recommendation should not be documented, please thumbs down.
I'll send a post to the mailing list if there's some support here.