### PR TITLE
MAINT: optimize.minimize: revert gh-11712 to fix macos_arm64_test

### DIFF
--- a/scipy/optimize/_trustregion_constr/minimize_trustregion_constr.py
+++ b/scipy/optimize/_trustregion_constr/minimize_trustregion_constr.py
@@ -517,7 +517,7 @@ def _minimize_trustregion_constr(fun, x0, args, grad,
             xtol, state, initial_barrier_parameter,
             initial_barrier_tolerance,
             initial_constr_penalty, initial_tr_radius,
-            factorization_method, finite_diff_bounds)
+            factorization_method)
 
     # Status 3 occurs when the callback function requests termination,
     # this is assumed to not be a success.

--- a/scipy/optimize/_trustregion_constr/tr_interior_point.py
+++ b/scipy/optimize/_trustregion_constr/tr_interior_point.py
@@ -32,7 +32,7 @@ class BarrierSubproblem:
                  constr, jac, barrier_parameter, tolerance,
                  enforce_feasibility, global_stop_criteria,
                  xtol, fun0, grad0, constr_ineq0, jac_ineq0, constr_eq0,
-                 jac_eq0, finite_diff_bounds):
+                 jac_eq0):
         # Store parameters
         self.n_vars = n_vars
         self.x0 = x0
@@ -54,8 +54,6 @@ class BarrierSubproblem:
         self.constr0 = self._compute_constr(constr_ineq0, constr_eq0, s0)
         self.jac0 = self._compute_jacobian(jac_eq0, jac_ineq0, s0)
         self.terminate = False
-        self.lb = finite_diff_bounds[0]
-        self.ub = finite_diff_bounds[1]
 
     def update(self, barrier_parameter, tolerance):
         self.barrier_parameter = barrier_parameter
@@ -80,19 +78,9 @@ class BarrierSubproblem:
         # Get variables and slack variables
         x = self.get_variables(z)
         s = self.get_slack(z)
-        # Compute function and constraints,
-        # making sure x is within any strict bounds
-        if np.any((x < self.lb) | (x > self.ub)):
-            # If x is out of the strict bounds, set f = inf,
-            # and just set both equality and inequality
-            # constraints to 0 since we can't evaluate
-            # them separately.
-            f = np.inf
-            c_eq = np.full(self.n_eq, 0)
-            c_ineq = np.full(self.n_ineq, 0)
-        else:
-            f = self.fun(x)
-            c_eq, c_ineq = self.constr(x)
+        # Compute function and constraints
+        f = self.fun(x)
+        c_eq, c_ineq = self.constr(x)
         # Return objective function and constraints
         return (self._compute_function(f, c_ineq, s),
                 self._compute_constr(c_ineq, c_eq, s))
@@ -284,8 +272,7 @@ def tr_interior_point(fun, grad, lagr_hess, n_vars, n_ineq, n_eq,
                       initial_tolerance,
                       initial_penalty,
                       initial_trust_radius,
-                      factorization_method,
-                      finite_diff_bounds):
+                      factorization_method):
     """Trust-region interior points method.
 
     Solve problem:
@@ -318,7 +305,7 @@ def tr_interior_point(fun, grad, lagr_hess, n_vars, n_ineq, n_eq,
         x0, s0, fun, grad, lagr_hess, n_vars, n_ineq, n_eq, constr, jac,
         barrier_parameter, tolerance, enforce_feasibility,
         stop_criteria, xtol, fun0, grad0, constr_ineq0, jac_ineq0,
-        constr_eq0, jac_eq0, finite_diff_bounds)
+        constr_eq0, jac_eq0)
     # Define initial parameter for the first iteration.
     z = np.hstack((x0, s0))
     fun0_subprob, constr0_subprob = subprob.fun0, subprob.constr0

--- a/scipy/optimize/tests/test_minimize_constrained.py
+++ b/scipy/optimize/tests/test_minimize_constrained.py
@@ -679,6 +679,9 @@ def test_bug_11886():
     minimize(opt, 2*[1], constraints = lin_cons)  # just checking that there are no errors
 
 
+# Remove xfail when gh-11649 is resolved
+@pytest.mark.xfail(reason="Known bug in trust-constr; see gh-11649.",
+                   strict=True)
 def test_gh11649():
     bnds = Bounds(lb=[-1, -1], ub=[1, 1], keep_feasible=True)
 

--- a/scipy/optimize/tests/test_minimize_constrained.py
+++ b/scipy/optimize/tests/test_minimize_constrained.py
@@ -4,7 +4,7 @@ import pytest
 from scipy.linalg import block_diag
 from scipy.sparse import csc_matrix
 from numpy.testing import (TestCase, assert_array_almost_equal,
-                           assert_array_less, assert_,
+                           assert_array_less, assert_, assert_allclose,
                            suppress_warnings)
 from pytest import raises
 from scipy.optimize import (NonlinearConstraint,
@@ -705,6 +705,13 @@ def test_gh11649():
     res = minimize(fun=obj, x0=x0, method='trust-constr',
                    bounds=bnds, constraints=nlcs)
     assert res.success
+    assert_inbounds(res.x)
+    assert nlcs[0].lb < nlcs[0].fun(res.x) < nlcs[0].ub
+    assert_allclose(nce(res.x), nlcs[1].ub)
+
+    ref = minimize(fun=obj, x0=x0, method='slsqp',
+                   bounds=bnds, constraints=nlcs)
+    assert_allclose(res.fun, ref.fun)
 
 
 class TestBoundedNelderMead:


### PR DESCRIPTION
#### Reference issue
gh-11649
gh-11712

#### What does this implement/fix?
macos_arm64_test has a failure in `main`:
```
FAILED scipy/optimize/tests/test_minimize_constrained.py::test_gh11649 - UserWarning: delta_grad == 0.0. Check if the approximated function is linear. If the function is linear better results can be obtained by defining the Hessian as zero instead of using quasi-Newton approximations.
```

This was just a warning, but it exposed a bug introduced in gh-11712. This PR reverts gh-11712 but leaves the test (and strengthens it), `xfail`ing it with `strict=True`. The original issue, gh-11649, has been re-opened, and the `xfail` mark can be removed when it is resolved.

#### Additional information
@dpoerio I know you are not able to merge this, but would you review it since you're familiar with the issue? I think that will help another maintainer.
