### PR TITLE
Revert "DOC: missing-bits: document rule on return object type"

### DIFF
--- a/doc/source/dev/missing-bits.rst
+++ b/doc/source/dev/missing-bits.rst
@@ -47,15 +47,6 @@ would probably do anyway even without the use of ``*``), *and* it means
 additional parameters can be added to the function anywhere after the
 ``*``; new parameters do not have to be added after the existing parameters.
 
-Return Objects
-~~~~~~~~~~~~~~
-For new functions or methods that return two or more conceptually distinct
-elements, use an object type that is not iterable. In particular, do not use
-``tuple``, ``namedtuple``, or ``make_tuple_bunch``, the latter of which is
-only for adding new attributes to the object returned by existing functions.
-This practice forces callers to be more explicit about the element of the
-returned object that they wish to access, and it makes it easier to extend
-the function or method in a backward compatible way.
 
 Test functions from `numpy.testing`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This is a quick revert of the merge of gh-17306, as suggested in https://github.com/scipy/scipy/pull/17306#issuecomment-1296560841