### PR TITLE
DOC: missing-bits: document recommendations on return object type

### DIFF
--- a/doc/source/dev/missing-bits.rst
+++ b/doc/source/dev/missing-bits.rst
@@ -48,6 +48,46 @@ additional parameters can be added to the function anywhere after the
 ``*``; new parameters do not have to be added after the existing parameters.
 
 
+Return Objects
+~~~~~~~~~~~~~~
+For new functions or methods that return two or more conceptually distinct
+elements, return the elements in an object type that is not iterable. In
+particular, do not return a ``tuple``, ``namedtuple``, or a "bunch" produced
+by `~scipy._lib._bunch.make_tuple_bunch`, the latter being reserved for adding
+new attributes to iterables returned by existing functions. Instead, use an
+existing return class (e.g. `~scipy.optimize.OptimizeResult`), a new, custom
+return class, or use `~dataclasses.make_dataclass`.
+
+This practice of returning non-iterable objects forces callers to be more
+explicit about the element of the returned object that they wish to access,
+and it makes it easier to extend the function or method in a backward
+compatible way.
+
+If the return class is simple and not public (i.e. importable from a public
+module), it may be documented like::
+
+    Returns
+    -------
+    res : MyResultObject
+        An object with attributes:
+
+        attribute1 : ndarray
+            Customized description of attribute 1.
+        attribute2 : ndarray
+            Customized description of attribute 2.
+
+Here "MyResultObject" above does not link to external documentation because it
+is simple enough to fully document all attributes immediately below its name.
+
+Some return classes are sufficiently complex to deserve their own rendered
+documentation. This is fairly standard if the return class is public, but
+return classes should only be public if 1) they are intended to be imported by
+end-users and 2) if they have been approved by the mailing list. For complex,
+private return classes, please see  how `~scipy.stats.binomtest` summarizes
+`~scipy.stats._result_classes.BinomTestResult` and links to its documentation,
+but note that ``BinomTestResult`` cannot be imported from `~scipy.stats`.
+
+
 Test functions from `numpy.testing`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 In new code, don't use `assert_almost_equal`, `assert_approx_equal` or

--- a/doc/source/dev/missing-bits.rst
+++ b/doc/source/dev/missing-bits.rst
@@ -53,10 +53,10 @@ Return Objects
 For new functions or methods that return two or more conceptually distinct
 elements, return the elements in an object type that is not iterable. In
 particular, do not return a ``tuple``, ``namedtuple``, or a "bunch" produced
-by `~scipy._lib._bunch.make_tuple_bunch`, the latter being reserved for adding
+by ``scipy._lib._bunch.make_tuple_bunch``, the latter being reserved for adding
 new attributes to iterables returned by existing functions. Instead, use an
 existing return class (e.g. `~scipy.optimize.OptimizeResult`), a new, custom
-return class, or use `~dataclasses.make_dataclass`.
+return class.
 
 This practice of returning non-iterable objects forces callers to be more
 explicit about the element of the returned object that they wish to access,
@@ -85,7 +85,7 @@ return classes should only be public if 1) they are intended to be imported by
 end-users and 2) if they have been approved by the mailing list. For complex,
 private return classes, please see  how `~scipy.stats.binomtest` summarizes
 `~scipy.stats._result_classes.BinomTestResult` and links to its documentation,
-but note that ``BinomTestResult`` cannot be imported from `~scipy.stats`.
+and note that ``BinomTestResult`` cannot be imported from `~scipy.stats`.
 
 
 Test functions from `numpy.testing`


### PR DESCRIPTION
#### Reference issue
gh-12323
gh-13118

#### What does this implement/fix?
There was a lot of discussion in gh-17126 about return object types, but I think that everyone involved agreed on the following:
when a new function needs to return more than one distinct piece of information, a non-iterable class is preferable to a `tuple`, `namedtuple`, or bunch. This PR would document that decision in "Code and Documentation Style Guide - The Missing Bits".

#### What does this implement/fix?
Wording suggestions welcome. If you tend to agree that "The Missing Bits" is a good place to document the results of such a discussion, please use thumbs up. If this recommendation should not be documented, please thumbs down.
I'll send a post to the mailing list if there's some support here.