### PR TITLE
DOC: interpolate: add a note on data with different scales

### DIFF
--- a/doc/source/tutorial/interpolate/ND_regular_grid.rst
+++ b/doc/source/tutorial/interpolate/ND_regular_grid.rst
@@ -80,6 +80,7 @@ and
     >>> np.allclose(result_rgi, result_interpn, atol=1e-15)
     True
 
+
 For data confined to an (N-1)-dimensional subspace of N-dimensional space, i.e.
 when one of the grid axes has length 1, the extrapolation along this axis is
 controlled by the ``fill_value`` keyword parameter:
@@ -94,6 +95,13 @@ controlled by the ``fill_value`` keyword parameter:
     >>> rgi.fill_value = -101
     >>> rgi([(2, 0), (2, 1), (2, -1)])
     array([2., -101., -101.]))
+
+.. note::
+
+    If the input data is such that input dimensions have incommensurate
+    units and differ by many orders of magnitude, the interpolant may have
+    numerical artifacts. Consider rescaling the data before interpolating.
+
 
 Finally, we note that if you are dealing with data on Cartesian grids with
 integer coordinates, e.g. resampling image data, these routines may not be the

--- a/doc/source/tutorial/interpolate/ND_unstructured.rst
+++ b/doc/source/tutorial/interpolate/ND_unstructured.rst
@@ -74,6 +74,12 @@ All these interpolation methods rely on triangulation of the data using the
     despite its name --- is not the right tool. Use `RegularGridInterpolator`
     instead.
 
+.. note::
+
+    If the input data is such that input dimensions have incommensurate
+    units and differ by many orders of magnitude, the interpolant may have
+    numerical artifacts. Consider rescaling the data before interpolating
+    or use the ``rescale=True`` keyword argument to `griddata`.
 
 
 .. _tutorial-interpolate_RBF:

--- a/doc/source/tutorial/interpolate/smoothing_splines.rst
+++ b/doc/source/tutorial/interpolate/smoothing_splines.rst
@@ -400,6 +400,14 @@ formally corresponds to interpolation, :math:`g(x_i, y_j) = z_{i, j}`.
     For scattered data interpolation, prefer `griddata`; for data on a regular
     grid, prefer `RegularGridInterpolator`. 
 
+
+.. note::
+
+    If the input data, ``x`` and ``y``, is such that input dimensions
+    have incommensurate units and differ by many orders of magnitude, the
+    interpolant `math`:g(x, y): may have numerical artifacts. Consider
+    rescaling the data before interpolation.
+
 We now consider the two spline fitting problems in turn.
 
 

--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -1276,6 +1276,10 @@ class SmoothBivariateSpline(BivariateSpline):
     -----
     The length of `x`, `y` and `z` should be at least ``(kx+1) * (ky+1)``.
 
+    If the input data is such that input dimensions have incommensurate
+    units and differ by many orders of magnitude, the interpolant may have
+    numerical artifacts. Consider rescaling the data before interpolating.
+
     """
 
     def __init__(self, x, y, z, w=None, bbox=[None] * 4, kx=3, ky=3, s=None,
@@ -1360,6 +1364,10 @@ class LSQBivariateSpline(BivariateSpline):
     Notes
     -----
     The length of `x`, `y` and `z` should be at least ``(kx+1) * (ky+1)``.
+
+    If the input data is such that input dimensions have incommensurate
+    units and differ by many orders of magnitude, the interpolant may have
+    numerical artifacts. Consider rescaling the data before interpolating.
 
     """
 
@@ -1453,6 +1461,13 @@ class RectBivariateSpline(BivariateSpline):
         a function to find a bivariate B-spline representation of a surface
     bisplev :
         a function to evaluate a bivariate B-spline and its derivatives
+
+    Notes
+    -----
+
+    If the input data is such that input dimensions have incommensurate
+    units and differ by many orders of magnitude, the interpolant may have
+    numerical artifacts. Consider rescaling the data before interpolating.
 
     """
 

--- a/scipy/interpolate/_fitpack_impl.py
+++ b/scipy/interpolate/_fitpack_impl.py
@@ -868,6 +868,10 @@ def bisplrep(x, y, z, w=None, xb=None, xe=None, yb=None, ye=None,
     See `bisplev` to evaluate the value of the B-spline given its tck
     representation.
 
+    If the input data is such that input dimensions have incommensurate
+    units and differ by many orders of magnitude, the interpolant may have
+    numerical artifacts. Consider rescaling the data before interpolation.
+
     References
     ----------
     .. [1] Dierckx P.:An algorithm for surface fitting with spline functions

--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -104,6 +104,10 @@ class RegularGridInterpolator:
 
     .. versionadded:: 1.9
 
+    If the input data is such that dimensions have incommensurate
+    units and differ by many orders of magnitude, the interpolant may have
+    numerical artifacts. Consider rescaling the data before interpolating.
+
     Examples
     --------
     **Evaluate a function on the points of a 3-D grid**
@@ -550,6 +554,10 @@ def interpn(points, values, xi, method="linear", bounds_error=True,
     In the case that ``xi.ndim == 1`` a new axis is inserted into
     the 0 position of the returned array, values_x, so its shape is
     instead ``(1,) + values.shape[ndim:]``.
+
+    If the input data is such that input dimensions have incommensurate
+    units and differ by many orders of magnitude, the interpolant may have
+    numerical artifacts. Consider rescaling the data before interpolation.
 
     Examples
     --------


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

closes gh-13021

#### What does this implement/fix?
<!--Please explain your changes.-->

If different dimensions of the N-dim data have scales which differ by many orders of magnitude, the result may be jittery or have other numerical artifacts. There is not much to do about it other than warn users to watch out and rescale the data if needed.

The issue was reported for `griddata` and `interp2d`, but normalizing the scales of the data is a good idea regardless of a specific interpolator, so add a note to this effect for all N>1 interpolators.
