### PR TITLE
DOC: interpolate/tutorial: add an example for equally-spaced grid

### DIFF
--- a/doc/source/tutorial/interpolate/ND_regular_grid.rst
+++ b/doc/source/tutorial/interpolate/ND_regular_grid.rst
@@ -121,7 +121,7 @@ a bare-bones example originating from `the Johanness Buchner's
         def __init__(self, points, values, method='linear'):
             self.limits = np.array([[min(x), max(x)] for x in points])
             self.values = np.asarray(values, dtype=float)
-            self.order = {'linear': 1, 'cubic': 3, 'quntic': 5}[method]
+            self.order = {'linear': 1, 'cubic': 3, 'quintic': 5}[method]
 
         def __call__(self, xi):
             """
@@ -158,6 +158,8 @@ This wrapper can be used as a(n almost) drop-in replacement for the
 
 Note that the example above uses the ``map_coordinates`` boundary conditions.
 Thus, results of the ``cubic`` and ``quintic`` interpolations may differ from
-those of the ``RegularGridInterpolator``. Refer to
-`scipy.ndimage.map_coordinates` documentation for more details.
-
+those of the ``RegularGridInterpolator``. 
+Refer to `scipy.ndimage.map_coordinates` documentation for more details on
+boundary conditions and other additional arguments.
+Finally, we note that this simplified example assumes that the input data is
+given in the ascending order.

--- a/doc/source/tutorial/interpolate/ND_regular_grid.rst
+++ b/doc/source/tutorial/interpolate/ND_regular_grid.rst
@@ -103,7 +103,61 @@ controlled by the ``fill_value`` keyword parameter:
     numerical artifacts. Consider rescaling the data before interpolating.
 
 
-Finally, we note that if you are dealing with data on Cartesian grids with
-integer coordinates, e.g. resampling image data, these routines may not be the
-optimal choice. Consider using `scipy.ndimage.map_coordinates` instead.
+.. _tutorial-interpolate_cartesian-grids:
+
+Uniformly spaced data
+=====================
+
+If you are dealing with data on Cartesian grids with integer coordinates, e.g.
+resampling image data, these routines may not be the optimal choice. Consider
+using `scipy.ndimage.map_coordinates` instead.
+
+For floating-point data on grids with equal spacing, ``map_coordinates`` can
+be easily wrapped into a `RegularGridInterpolator` look-alike. The following is
+a bare-bones example originating from `the Johanness Buchner's
+'regulargrid' package <https://github.com/JohannesBuchner/regulargrid/>`_::
+
+    class CartesianGridInterpolator:
+        def __init__(self, points, values, method='linear'):
+            self.limits = np.array([[min(x), max(x)] for x in points])
+            self.values = np.asarray(values, dtype=float)
+            self.order = {'linear': 1, 'cubic': 3, 'quntic': 5}[method]
+
+        def __call__(self, xi):
+            """
+            `xi` here is an array-like (an array or a list) of points.
+
+            Each "point" is an ndim-dimensional array_like, representing
+            the coordinates of a point in ndim-dimensional space.
+            """
+            # transpose the xi array into the ``map_coordinates`` convention
+            # which takes coordinates of a point along columns of a 2D array.
+            xi = np.asarray(xi).T
+
+            # convert from data coordinates to pixel coordinates
+            ns = self.values.shape
+            coords = [(n-1)*(val - lo) / (hi - lo)
+                      for val, n, (lo, hi) in zip(xi, ns, self.limits)]
+
+            # interpolate
+            return map_coordinates(self.values, coords, 
+                                   order=self.order,
+                                   cval=np.nan)  # fill_value
+
+This wrapper can be used as a(n almost) drop-in replacement for the
+`RegularGridInterpolator`:
+
+    >>> x, y = np.arange(5), np.arange(6)
+    >>> xx, yy = np.meshgrid(x, y, indexing='ij')
+    >>> values = xx**3 + yy**3
+    >>> rgi = RegularGridInterpolator((x, y), values, method='linear')
+    >>> rgi([[1.5, 1.5], [3.5, 2.6]])
+    array([ 9. , 64.9])
+    >>> cgi = CartesianGridInterpolator((x, y), values, method='linear')
+    array([ 9. , 64.9])
+
+Note that the example above uses the ``map_coordinates`` boundary conditions.
+Thus, results of the ``cubic`` and ``quintic`` interpolations may differ from
+those of the ``RegularGridInterpolator``. Refer to
+`scipy.ndimage.map_coordinates` documentation for more details.
 


### PR DESCRIPTION

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

cross-ref gh-10180, gh-9123

#### What does this implement/fix?
<!--Please explain your changes.-->

Add an example of wrapping `ndimage.map_coordinates` into a `scipy.interpolate` compatible API to implement a `RegularGridInterpolator` for uniform grids. This should be more efficient since it takes into account the equidistant spacing of data points: avoids `np.searchsorted` and other sources of overhead in a general purpose `RegularGridInterpolator`.

The example is taken from Johannes Buchner's *regulargrid* package, https://github.com/JohannesBuchner/regulargrid/blob/master/regulargrid/cartesiangrid.py
only slightly edited.

The package is an original source of the RegularGridInterpolator, and a permission to include it into scipy
was given by the author in https://github.com/JohannesBuchner/regulargrid/issues/2

#### Additional information
<!--Any additional information you think is important.-->

This is known for many years, however probably not as widely as it deserves. The functionality was requested several times over time, see, e.g. gh-10180, gh-9123.

There is of course a question of whether to include this into the `scipy.interpolate` namespace as a full-fledged interpolator. I would lean towards adding this as a documentation example only, because

- the functionality is already available in ndimage
- the interpolate-compatible wrapper is a dozen lines of code
- the map_coordinates API is subtly different: integer vs floating-point values, boundary conditions etc. A wrapper would inevitably behave somewhat different from `RegularGridInterpolator` in some cases.

Overall I believe adding a version of this to scipy.interpolate namespace would create a third almost-but-not-quite-compatible object, and would lead to both maintenance burden and more user confusion than offering an example and leaving the details to a user to tailor to their specific problem. 
