### PR TITLE
ENH: Clarify the index of element corresponding to a label in SciPy.ndImage

### DIFF
--- a/scipy/ndimage/_measurements.py
+++ b/scipy/ndimage/_measurements.py
@@ -256,7 +256,8 @@ def find_objects(input, max_label=0):
         A list of tuples, with each tuple containing N slices (with N the
         dimension of the input array). Slices correspond to the minimal
         parallelepiped that contains the object. If a number is missing,
-        None is returned instead of a slice.
+        None is returned instead of a slice. The label `l` corresponds to
+        the index `l-1` in the returned list.
 
     See Also
     --------

--- a/scipy/ndimage/_measurements.py
+++ b/scipy/ndimage/_measurements.py
@@ -256,8 +256,8 @@ def find_objects(input, max_label=0):
         A list of tuples, with each tuple containing N slices (with N the
         dimension of the input array). Slices correspond to the minimal
         parallelepiped that contains the object. If a number is missing,
-        None is returned instead of a slice. The label `l` corresponds to
-        the index `l-1` in the returned list.
+        None is returned instead of a slice. The label ``l`` corresponds to
+        the index ``l-1`` in the returned list.
 
     See Also
     --------


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #17312 ENH: Clarify that ndimage.find_objects returns slices ordered by indices

#### What does this implement/fix?
Adds clarification regarding the elements corresponding to the labels in the find_objects function

#### Additional information
N/A
