### PR TITLE
wheel CI: Always use latest minor version of cibuildwheel

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -53,7 +53,7 @@ jobs:
           COMMIT_MSG=$(git log --no-merges -1)
           RUN="0"
           if [[ "$COMMIT_MSG" == *"[wheel build]"* ]]; then
-              RUN="1" 
+              RUN="1"
           fi
           echo "message=$RUN" >> $GITHUB_OUTPUT
           echo github.ref ${{ github.ref }}
@@ -140,7 +140,7 @@ jobs:
 #        if: ${{ runner.os == 'Windows' && env.IS_32_BIT == 'true' }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.10.1
+        uses: pypa/cibuildwheel@v2
         # Build all wheels here, apart from macosx_arm64, linux_aarch64
         # cibuildwheel is currently unable to pass configuration flags to
         # CIBW_BUILD_FRONTEND https://github.com/pypa/cibuildwheel/issues/1227
@@ -200,14 +200,14 @@ jobs:
           # compiler environment.
           $FC $FFLAGS tools/wheels/test.f $LDFLAGS
           ls -al *.out
-          otool -L a.out      
+          otool -L a.out
 
           export PKG_CONFIG_PATH=/opt/arm64-builds/lib/pkgconfig
           export PKG_CONFIG=/usr/local/bin/pkg-config
           export CFLAGS=" -arch arm64 $CFLAGS"
           export CXXFLAGS=" -arch arm64 $CXXFLAGS"
           export LD_LIBRARY_PATH="/opt/arm64-builds/lib:$FC_LIBDIR:$LD_LIBRARY_PATH"
-          
+
           # install dependencies for the build machine
           pip install meson cython pybind11 pythran ninja oldest-supported-numpy build delocate meson-python
 
@@ -254,7 +254,7 @@ jobs:
           # an upload to:
           #
           # https://anaconda.org/scipy-wheels-nightly/scipy
-          # 
+          #
           # Pushes to a maintenance branch that contain '[wheel build]' will
           # cause wheels to be built and uploaded to:
           #

--- a/ci/cirrus_wheels.yml
+++ b/ci/cirrus_wheels.yml
@@ -1,6 +1,6 @@
 build_and_store_wheels: &BUILD_AND_STORE_WHEELS
   install_cibuildwheel_script:
-    - python -m pip install cibuildwheel==2.10.1
+    - python -m pip install cibuildwheel
   cibuildwheel_script:
     - cibuildwheel
   wheels_artifacts:
@@ -110,21 +110,21 @@ cirrus_wheels_upload_task:
     if [[ "$COMMIT_MSG" == *"[wheel build]"* ]] && [[ $CIRRUS_BRANCH == maintenance* ]]; then
           export IS_PUSH="true"
     fi
-    
+
     # The name of the zip file is derived from the `wheels_artifact` line.
     # If you change the artifact line to `myfile_artifact` then it would be
     # called myfile.zip
-    
+
     curl https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/wheels.zip --output wheels.zip
     unzip wheels.zip
-    
+
     source tools/wheels/upload_wheels.sh
     set_upload_vars
     # For cron jobs (restricted to main branch)
     # an upload to:
     #
     # https://anaconda.org/scipy-wheels-nightly/scipy
-    # 
+    #
     # Pushes to a maintenance branch that contain '[wheel build]' will
     # cause wheels to be built and uploaded to:
     #


### PR DESCRIPTION
By removing the exact minor and patch version of the cibuildwheel action, it will always use the latest minor/patch version. For Travis, it will use the latest version even for new major versions.

This ensures the latest Python versions are always used to build wheels.

Major version updates will be handled by #17327 for GitHub Actions.
