### PR TITLE
CI: On Azure, pin pytest-xdist to version 2.5.0

### DIFF
--- a/ci/azure-travis-template.yaml
+++ b/ci/azure-travis-template.yaml
@@ -64,6 +64,8 @@ steps:
   displayName: 'Install common apt dependencies'
 - script: 'echo "##vso[task.prependpath]/usr/lib/ccache"'
   displayName: 'Add ccache to path'
+# Use pytest-xdist 2.5.0 until https://github.com/pytest-dev/pytest-cov/issues/557
+# is resolved.
 - script: >-
     pip install --upgrade ${{parameters.numpy_spec}} &&
     pip install --upgrade pip setuptools==59.6.0 wheel build meson meson-python &&
@@ -76,7 +78,7 @@ steps:
     pythran
     pybind11
     pytest
-    pytest-xdist
+    pytest-xdist==2.5.0
     pytest-timeout
   displayName: 'Install common python dependencies'
 - ${{ if eq(parameters.test_mode, 'full') }}:


### PR DESCRIPTION
The Azure job "Main prerelease_deps_coverage_64bit_blas" is failing because of an incompatibility between pytest-cov and pytest-xdist 3.0.2, so use pytest-xdist 2.5.0 until the issue https://github.com/pytest-dev/pytest-cov/issues/557 is resolved.

[skip cirrus] [skip actions] [skip circle]
