### PR TITLE
DOC: clarify use of bounds with basinhopping

### DIFF
--- a/scipy/optimize/_basinhopping.py
+++ b/scipy/optimize/_basinhopping.py
@@ -646,21 +646,29 @@ def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
     The minimum at -1.0109 is actually the global minimum, found already on the
     8th iteration.
 
-    Now let's implement bounds on the problem using a custom `accept_test`:
+    Now let's restrict new accepted solutions to be within some
+    bounds by providing a custom `accept_test`:
 
-    >>> class MyBounds:
+    >>> class MyAcceptanceBounds:
     ...     def __init__(self):
     ...         self.xmax = np.array([1.1, 1.1])
     ...         self.xmin = np.array([-1.1, -1.1])
-    ...     def __call__(self, **kwargs):
-    ...         x = kwargs["x_new"]
-    ...         tmax = bool(np.all(x <= self.xmax))
-    ...         tmin = bool(np.all(x >= self.xmin))
+    ...     def __call__(self, f_new, x_new, f_old, x_old):
+    ...         tmax = bool(np.all(x_new <= self.xmax))
+    ...         tmin = bool(np.all(x_new >= self.xmin))
     ...         return tmax and tmin
 
-    >>> mybounds = MyBounds()
+    >>> accept_bounds = MyAcceptanceBounds()
     >>> ret = basinhopping(func2d, x0, minimizer_kwargs=minimizer_kwargs,
-    ...                    niter=10, accept_test=mybounds)
+    ...                    niter=10, accept_test=accept_bounds)
+
+    .. note::
+
+        This snippet only restrict new candidates to be within bounds.
+        The local minimization and stepping process can still evaluate points
+        outside bounds. To completely restrict the problem to specific bounds,
+        bounds need to be defined for all `minimizer_kwargs`, `take_step` and
+        `accept_test`.
 
     """
     if target_accept_rate <= 0. or target_accept_rate >= 1.:

--- a/scipy/optimize/_basinhopping.py
+++ b/scipy/optimize/_basinhopping.py
@@ -646,30 +646,6 @@ def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
     The minimum at -1.0109 is actually the global minimum, found already on the
     8th iteration.
 
-    Now let's restrict new accepted solutions to be within some
-    bounds by providing a custom `accept_test`:
-
-    >>> class MyAcceptanceBounds:
-    ...     def __init__(self):
-    ...         self.xmax = np.array([1.1, 1.1])
-    ...         self.xmin = np.array([-1.1, -1.1])
-    ...     def __call__(self, f_new, x_new, f_old, x_old):
-    ...         tmax = bool(np.all(x_new <= self.xmax))
-    ...         tmin = bool(np.all(x_new >= self.xmin))
-    ...         return tmax and tmin
-
-    >>> accept_bounds = MyAcceptanceBounds()
-    >>> ret = basinhopping(func2d, x0, minimizer_kwargs=minimizer_kwargs,
-    ...                    niter=10, accept_test=accept_bounds)
-
-    .. note::
-
-        This snippet only restrict new candidates to be within bounds.
-        The local minimization and stepping process can still evaluate points
-        outside bounds. To completely restrict the problem to specific bounds,
-        bounds need to be defined for all `minimizer_kwargs`, `take_step` and
-        `accept_test`.
-
     """
     if target_accept_rate <= 0. or target_accept_rate >= 1.:
         raise ValueError('target_accept_rate has to be in range (0, 1)')

--- a/scipy/optimize/_basinhopping.py
+++ b/scipy/optimize/_basinhopping.py
@@ -331,7 +331,7 @@ class Metropolis:
             #
             # RuntimeWarning: invalid value encountered in multiply
             #
-            # Ignore this warning so so when the algorithm is on a flat plane, it always
+            # Ignore this warning so when the algorithm is on a flat plane, it always
             # accepts the step, to try to move off the plane.
             prod = -(energy_new - energy_old) * self.beta
             w = math.exp(min(0, prod))

--- a/scipy/optimize/_basinhopping.py
+++ b/scipy/optimize/_basinhopping.py
@@ -331,7 +331,7 @@ class Metropolis:
             #
             # RuntimeWarning: invalid value encountered in multiply
             #
-            # Ignore this warning so when the algorithm is on a flat plane, it always
+            # Ignore this warning so so when the algorithm is on a flat plane, it always
             # accepts the step, to try to move off the plane.
             prod = -(energy_new - energy_old) * self.beta
             w = math.exp(min(0, prod))
@@ -367,55 +367,55 @@ def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
     ----------
     func : callable ``f(x, *args)``
         Function to be optimized.  ``args`` can be passed as an optional item
-        in the dict ``minimizer_kwargs``
+        in the dict `minimizer_kwargs`
     x0 : array_like
         Initial guess.
     niter : integer, optional
         The number of basin-hopping iterations. There will be a total of
         ``niter + 1`` runs of the local minimizer.
     T : float, optional
-        The "temperature" parameter for the accept or reject criterion. Higher
-        "temperatures" mean that larger jumps in function value will be
-        accepted.  For best results ``T`` should be comparable to the
+        The "temperature" parameter for the acceptance or rejection criterion.
+        Higher "temperatures" mean that larger jumps in function value will be
+        accepted.  For best results `T` should be comparable to the
         separation (in function value) between local minima.
     stepsize : float, optional
         Maximum step size for use in the random displacement.
     minimizer_kwargs : dict, optional
         Extra keyword arguments to be passed to the local minimizer
-        ``scipy.optimize.minimize()`` Some important options could be:
+        `scipy.optimize.minimize` Some important options could be:
 
             method : str
                 The minimization method (e.g. ``"L-BFGS-B"``)
             args : tuple
-                Extra arguments passed to the objective function (``func``) and
+                Extra arguments passed to the objective function (`func`) and
                 its derivatives (Jacobian, Hessian).
 
     take_step : callable ``take_step(x)``, optional
         Replace the default step-taking routine with this routine. The default
         step-taking routine is a random displacement of the coordinates, but
         other step-taking algorithms may be better for some systems.
-        ``take_step`` can optionally have the attribute ``take_step.stepsize``.
-        If this attribute exists, then ``basinhopping`` will adjust
+        `take_step` can optionally have the attribute ``take_step.stepsize``.
+        If this attribute exists, then `basinhopping` will adjust
         ``take_step.stepsize`` in order to try to optimize the global minimum
         search.
     accept_test : callable, ``accept_test(f_new=f_new, x_new=x_new, f_old=fold, x_old=x_old)``, optional
-        Define a test which will be used to judge whether or not to accept the
-        step.  This will be used in addition to the Metropolis test based on
-        "temperature" ``T``.  The acceptable return values are True,
+        Define a test which will be used to judge whether to accept the
+        step. This will be used in addition to the Metropolis test based on
+        "temperature" `T`. The acceptable return values are True,
         False, or ``"force accept"``. If any of the tests return False
         then the step is rejected. If the latter, then this will override any
         other tests in order to accept the step. This can be used, for example,
-        to forcefully escape from a local minimum that ``basinhopping`` is
+        to forcefully escape from a local minimum that `basinhopping` is
         trapped in.
     callback : callable, ``callback(x, f, accept)``, optional
         A callback function which will be called for all minima found. ``x``
         and ``f`` are the coordinates and function value of the trial minimum,
-        and ``accept`` is whether or not that minimum was accepted. This can
+        and ``accept`` is whether that minimum was accepted. This can
         be used, for example, to save the lowest N minima found. Also,
-        ``callback`` can be used to specify a user defined stop criterion by
-        optionally returning True to stop the ``basinhopping`` routine.
+        `callback` can be used to specify a user defined stop criterion by
+        optionally returning True to stop the `basinhopping` routine.
     interval : integer, optional
-        interval for how often to update the ``stepsize``
+        interval for how often to update the `stepsize`
     disp : bool, optional
         Set to True to print status messages
     niter_success : integer, optional
@@ -452,7 +452,7 @@ def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
     Returns
     -------
     res : OptimizeResult
-        The optimization result represented as a ``OptimizeResult`` object.
+        The optimization result represented as a `OptimizeResult` object.
         Important attributes are: ``x`` the solution array, ``fun`` the value
         of the function at the solution, and ``message`` which describes the
         cause of the termination. The ``OptimizeResult`` object returned by the
@@ -464,7 +464,7 @@ def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
     --------
     minimize :
         The local minimization function called once for each basinhopping step.
-        ``minimizer_kwargs`` is passed to this routine.
+        `minimizer_kwargs` is passed to this routine.
 
     Notes
     -----
@@ -496,39 +496,39 @@ def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
 
     See the free software program `GMIN <https://www-wales.ch.cam.ac.uk/GMIN>`_
     for a Fortran implementation of basin-hopping. This implementation has many
-    different variations of the procedure described above, including more
+    variations of the procedure described above, including more
     advanced step taking algorithms and alternate acceptance criterion.
 
     For stochastic global optimization there is no way to determine if the true
     global minimum has actually been found. Instead, as a consistency check,
     the algorithm can be run from a number of different random starting points
     to ensure the lowest minimum found in each example has converged to the
-    global minimum. For this reason, ``basinhopping`` will by default simply
-    run for the number of iterations ``niter`` and return the lowest minimum
+    global minimum. For this reason, `basinhopping` will by default simply
+    run for the number of iterations `niter` and return the lowest minimum
     found. It is left to the user to ensure that this is in fact the global
     minimum.
 
-    Choosing ``stepsize``:  This is a crucial parameter in ``basinhopping`` and
+    Choosing `stepsize`:  This is a crucial parameter in `basinhopping` and
     depends on the problem being solved. The step is chosen uniformly in the
     region from x0-stepsize to x0+stepsize, in each dimension. Ideally, it
     should be comparable to the typical separation (in argument values) between
-    local minima of the function being optimized. ``basinhopping`` will, by
-    default, adjust ``stepsize`` to find an optimal value, but this may take
+    local minima of the function being optimized. `basinhopping` will, by
+    default, adjust `stepsize` to find an optimal value, but this may take
     many iterations. You will get quicker results if you set a sensible
     initial value for ``stepsize``.
 
-    Choosing ``T``: The parameter ``T`` is the "temperature" used in the
+    Choosing `T`: The parameter `T` is the "temperature" used in the
     Metropolis criterion. Basinhopping steps are always accepted if
     ``func(xnew) < func(xold)``. Otherwise, they are accepted with
     probability::
 
         exp( -(func(xnew) - func(xold)) / T )
 
-    So, for best results, ``T`` should to be comparable to the typical
+    So, for best results, `T` should to be comparable to the typical
     difference (in function values) between local minima. (The height of
     "walls" between local minima is irrelevant.)
 
-    If ``T`` is 0, the algorithm becomes Monotonic Basin-Hopping, in which all
+    If `T` is 0, the algorithm becomes Monotonic Basin-Hopping, in which all
     steps that increase energy are rejected.
 
     .. versionadded:: 0.12.0
@@ -558,12 +558,12 @@ def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
     >>> import numpy as np
     >>> from scipy.optimize import basinhopping
     >>> func = lambda x: np.cos(14.5 * x - 0.3) + (x + 0.2) * x
-    >>> x0=[1.]
+    >>> x0 = [1.]
 
     Basinhopping, internally, uses a local minimization algorithm. We will use
-    the parameter ``minimizer_kwargs`` to tell basinhopping which algorithm to
+    the parameter `minimizer_kwargs` to tell basinhopping which algorithm to
     use and how to set up that minimizer. This parameter will be passed to
-    ``scipy.optimize.minimize()``.
+    `scipy.optimize.minimize`.
 
     >>> minimizer_kwargs = {"method": "BFGS"}
     >>> ret = basinhopping(func, x0, minimizer_kwargs=minimizer_kwargs,
@@ -594,7 +594,6 @@ def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
     ...                                                           ret.fun))
     global minimum: x = [-0.1951, -0.1000], f(x) = -1.0109
 
-
     Here is an example using a custom step-taking routine. Imagine you want
     the first coordinate to take larger steps than the rest of the coordinates.
     This can be implemented like so:
@@ -610,7 +609,7 @@ def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
     ...        return x
 
     Since ``MyTakeStep.stepsize`` exists basinhopping will adjust the magnitude
-    of ``stepsize`` to optimize the search. We'll use the same 2-D function as
+    of `stepsize` to optimize the search. We'll use the same 2-D function as
     before
 
     >>> mytakestep = MyTakeStep()
@@ -620,7 +619,6 @@ def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
     ...                                                           ret.x[1],
     ...                                                           ret.fun))
     global minimum: x = [-0.1951, -0.1000], f(x) = -1.0109
-
 
     Now, let's do an example using a custom callback function which prints the
     value of every minimum found
@@ -645,16 +643,15 @@ def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
     at minimum -0.7425 accepted 1
     at minimum -0.9073 accepted 1
 
-
     The minimum at -1.0109 is actually the global minimum, found already on the
     8th iteration.
 
-    Now let's implement bounds on the problem using a custom ``accept_test``:
+    Now let's implement bounds on the problem using a custom `accept_test`:
 
     >>> class MyBounds:
-    ...     def __init__(self, xmax=[1.1,1.1], xmin=[-1.1,-1.1] ):
-    ...         self.xmax = np.array(xmax)
-    ...         self.xmin = np.array(xmin)
+    ...     def __init__(self):
+    ...         self.xmax = np.array([1.1, 1.1])
+    ...         self.xmin = np.array([-1.1, -1.1])
     ...     def __call__(self, **kwargs):
     ...         x = kwargs["x_new"]
     ...         tmax = bool(np.all(x <= self.xmax))


### PR DESCRIPTION
#### Reference issue
Closes gh-6688

#### What does this implement/fix?
Aims to clarify how to setup bounds. As it is, you must add bounds to `minimizer_kwargs`, and `accept_test`. See bellow on why the `minimizer_kwargs` is needed.

`take_step` should also be adapted so that new candidates are not evaluated if outside of bounds. Optional as points outside of bounds would be discarded with the `accept_test`, but would do some extra evaluations for nothing.

That was the original reported issue, being able to specify criteria before evaluation. We decided not to do that as this can be done using `take_step`.

In general there could be some heavier rework of the API, but hard to do in a backward compatible way. (And some work on the internals, e.g. removing `Storage` which is useless)

(The first commit is just some backticks update)

#### Additional information
While working on this, I noticed there is an extra local optimization happening at initialization. This defeats the purpose of providing x0 which is not even kept in the `Storage` object. This should be removed as not part of basinhopping iterations. Additionally, and even more concerning, the result of this first optimization is not checked against the acceptance criteria.