### PR TITLE
DOC: Fix signal docstrings; finish adding 'import numpy as np'

### DIFF
--- a/scipy/datasets/_fetchers.py
+++ b/scipy/datasets/_fetchers.py
@@ -122,6 +122,7 @@ def electrocardiogram():
     E.g., the first few seconds show the electrical activity of a heart in
     normal sinus rhythm as seen below.
 
+    >>> import numpy as np
     >>> import matplotlib.pyplot as plt
     >>> fs = 360
     >>> time = np.arange(ecg.size) / fs

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -635,6 +635,10 @@ def group_delay(system, w=512, whole=False, fs=2*pi):
     gd : ndarray
         The group delay.
 
+    See Also
+    --------
+    freqz : Frequency response of a digital filter
+
     Notes
     -----
     The similar function in MATLAB is called `grpdelay`.
@@ -647,10 +651,6 @@ def group_delay(system, w=512, whole=False, fs=2*pi):
     For the details of numerical computation of the group delay refer to [1]_.
 
     .. versionadded:: 0.16.0
-
-    See Also
-    --------
-    freqz : Frequency response of a digital filter
 
     References
     ----------
@@ -3538,6 +3538,12 @@ def bessel(N, Wn, btype='low', analog=False, output='ba', norm='phase',
 
     The ``'sos'`` output parameter was added in 0.16.0.
 
+    References
+    ----------
+    .. [1] Thomson, W.E., "Delay Networks having Maximally Flat Frequency
+           Characteristics", Proceedings of the Institution of Electrical
+           Engineers, Part III, November 1949, Vol. 96, No. 44, pp. 487-490.
+
     Examples
     --------
     Plot the phase-normalized frequency response, showing the relationship
@@ -3602,12 +3608,6 @@ def bessel(N, Wn, btype='low', analog=False, output='ba', norm='phase',
     >>> plt.margins(0, 0.1)
     >>> plt.grid(which='both', axis='both')
     >>> plt.show()
-
-    References
-    ----------
-    .. [1] Thomson, W.E., "Delay Networks having Maximally Flat Frequency
-           Characteristics", Proceedings of the Institution of Electrical
-           Engineers, Part III, November 1949, Vol. 96, No. 44, pp. 487-490.
 
     """
     return iirfilter(N, Wn, btype=btype, analog=analog,

--- a/scipy/signal/_fir_filter_design.py
+++ b/scipy/signal/_fir_filter_design.py
@@ -546,7 +546,7 @@ def firwin2(numtaps, freq, gain, nfreqs=None, window='hamming', nyq=None,
         The filter coefficients of the FIR filter, as a 1-D array of length
         `numtaps`.
 
-    See also
+    See Also
     --------
     firls
     firwin
@@ -919,7 +919,7 @@ def firls(numtaps, bands, desired, weight=None, nyq=None, fs=None):
     coeffs : ndarray
         Coefficients of the optimal (in a least squares sense) FIR filter.
 
-    See also
+    See Also
     --------
     firwin
     firwin2
@@ -1179,6 +1179,25 @@ def minimum_phase(h, method='homomorphic', n_fft=None):
 
         http://dspguru.com/dsp/howtos/how-to-design-minimum-phase-fir-filters
 
+    References
+    ----------
+    .. [1] N. Damera-Venkata and B. L. Evans, "Optimal design of real and
+           complex minimum phase digital FIR filters," Acoustics, Speech,
+           and Signal Processing, 1999. Proceedings., 1999 IEEE International
+           Conference on, Phoenix, AZ, 1999, pp. 1145-1148 vol.3.
+           :doi:`10.1109/ICASSP.1999.756179`
+    .. [2] X. Chen and T. W. Parks, "Design of optimal minimum phase FIR
+           filters by direct factorization," Signal Processing,
+           vol. 10, no. 4, pp. 369-383, Jun. 1986.
+    .. [3] T. Saramaki, "Finite Impulse Response Filter Design," in
+           Handbook for Digital Signal Processing, chapter 4,
+           New York: Wiley-Interscience, 1993.
+    .. [4] J. S. Lim, Advanced Topics in Signal Processing.
+           Englewood Cliffs, N.J.: Prentice Hall, 1988.
+    .. [5] A. V. Oppenheim, R. W. Schafer, and J. R. Buck,
+           "Discrete-Time Signal Processing," 2nd edition.
+           Upper Saddle River, N.J.: Prentice Hall, 1999.
+
     Examples
     --------
     Create an optimal linear-phase filter, then convert it to minimum phase:
@@ -1219,24 +1238,6 @@ def minimum_phase(h, method='homomorphic', n_fft=None):
     >>> axs[3].set(ylabel='Group delay')
     >>> plt.tight_layout()
 
-    References
-    ----------
-    .. [1] N. Damera-Venkata and B. L. Evans, "Optimal design of real and
-           complex minimum phase digital FIR filters," Acoustics, Speech,
-           and Signal Processing, 1999. Proceedings., 1999 IEEE International
-           Conference on, Phoenix, AZ, 1999, pp. 1145-1148 vol.3.
-           :doi:`10.1109/ICASSP.1999.756179`
-    .. [2] X. Chen and T. W. Parks, "Design of optimal minimum phase FIR
-           filters by direct factorization," Signal Processing,
-           vol. 10, no. 4, pp. 369-383, Jun. 1986.
-    .. [3] T. Saramaki, "Finite Impulse Response Filter Design," in
-           Handbook for Digital Signal Processing, chapter 4,
-           New York: Wiley-Interscience, 1993.
-    .. [4] J. S. Lim, Advanced Topics in Signal Processing.
-           Englewood Cliffs, N.J.: Prentice Hall, 1988.
-    .. [5] A. V. Oppenheim, R. W. Schafer, and J. R. Buck,
-           "Discrete-Time Signal Processing," 2nd edition.
-           Upper Saddle River, N.J.: Prentice Hall, 1999.
     """  # noqa
     h = np.asarray(h)
     if np.iscomplexobj(h):

--- a/scipy/signal/_lti_conversion.py
+++ b/scipy/signal/_lti_conversion.py
@@ -384,6 +384,21 @@ def cont2discrete(system, dt, method="zoh", alpha=None):
     approximation is based on [2]_ and [3]_, the First-Order Hold (foh) method
     is based on [4]_.
 
+    References
+    ----------
+    .. [1] https://en.wikipedia.org/wiki/Discretization#Discretization_of_linear_state_space_models
+
+    .. [2] http://techteach.no/publications/discretetime_signals_systems/discrete.pdf
+
+    .. [3] G. Zhang, X. Chen, and T. Chen, Digital redesign via the generalized
+        bilinear transformation, Int. J. Control, vol. 82, no. 4, pp. 741-754,
+        2009.
+        (https://www.mypolyuweb.hk/~magzhang/Research/ZCC09_IJC.pdf)
+
+    .. [4] G. F. Franklin, J. D. Powell, and M. L. Workman, Digital control
+        of dynamic systems, 3rd ed. Menlo Park, Calif: Addison-Wesley,
+        pp. 204-206, 1998.
+
     Examples
     --------
     We can transform a continuous state-space system to a discrete one:
@@ -414,21 +429,6 @@ def cont2discrete(system, dt, method="zoh", alpha=None):
     >>> ax.legend(loc='best')
     >>> fig.tight_layout()
     >>> plt.show()
-
-    References
-    ----------
-    .. [1] https://en.wikipedia.org/wiki/Discretization#Discretization_of_linear_state_space_models
-
-    .. [2] http://techteach.no/publications/discretetime_signals_systems/discrete.pdf
-
-    .. [3] G. Zhang, X. Chen, and T. Chen, Digital redesign via the generalized
-        bilinear transformation, Int. J. Control, vol. 82, no. 4, pp. 741-754,
-        2009.
-        (https://www.mypolyuweb.hk/~magzhang/Research/ZCC09_IJC.pdf)
-
-    .. [4] G. F. Franklin, J. D. Powell, and M. L. Workman, Digital control
-        of dynamic systems, 3rd ed. Menlo Park, Calif: Addison-Wesley,
-        pp. 204-206, 1998.
 
     """
     if len(system) == 1:

--- a/scipy/signal/_ltisys.py
+++ b/scipy/signal/_ltisys.py
@@ -1806,6 +1806,10 @@ def lsim2(system, U=None, T=None, X0=None, **kwargs):
     xout : ndarray
         The time-evolution of the state-vector.
 
+    See Also
+    --------
+    lsim
+
     Notes
     -----
     This function uses `scipy.integrate.odeint` to solve the
@@ -1816,10 +1820,6 @@ def lsim2(system, U=None, T=None, X0=None, **kwargs):
     If (num, den) is passed in for ``system``, coefficients for both the
     numerator and denominator should be specified in descending exponent
     order (e.g. ``s^2 + 3s + 5`` would be represented as ``[1, 3, 5]``).
-
-    See Also
-    --------
-    lsim
 
     Examples
     --------
@@ -2394,7 +2394,7 @@ def step(system, X0=None, T=None, N=None):
     yout : 1D ndarray
         Step response of system.
 
-    See also
+    See Also
     --------
     scipy.signal.step2
 
@@ -2473,7 +2473,7 @@ def step2(system, X0=None, T=None, N=None, **kwargs):
     yout : 1D ndarray
         Step response of system.
 
-    See also
+    See Also
     --------
     scipy.signal.step
 

--- a/scipy/signal/_savitzky_golay.py
+++ b/scipy/signal/_savitzky_golay.py
@@ -38,6 +38,14 @@ def savgol_coeffs(window_length, polyorder, deriv=0, delta=1.0, pos=None,
     coeffs : 1-D ndarray
         The filter coefficients.
 
+    See Also
+    --------
+    savgol_filter
+
+    Notes
+    -----
+    .. versionadded:: 0.14.0
+
     References
     ----------
     A. Savitzky, M. J. E. Golay, Smoothing and Differentiation of Data by
@@ -46,15 +54,6 @@ def savgol_coeffs(window_length, polyorder, deriv=0, delta=1.0, pos=None,
     Jianwen Luo, Kui Ying, and Jing Bai. 2005. Savitzky-Golay smoothing and
     differentiation filter for even number data. Signal Process.
     85, 7 (July 2005), 1429-1434.
-
-    See Also
-    --------
-    savgol_filter
-
-    Notes
-    -----
-
-    .. versionadded:: 0.14.0
 
     Examples
     --------

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -171,6 +171,7 @@ def correlate(in1, in2, mode='full', method='auto'):
     Implement a matched filter using cross-correlation, to recover a signal
     that has passed through a noisy channel.
 
+    >>> import numpy as np
     >>> from scipy import signal
     >>> import matplotlib.pyplot as plt
     >>> rng = np.random.default_rng()
@@ -300,16 +301,16 @@ def correlation_lags(in1_len, in2_len, mode='full'):
         A string indicating the size of the output.
         See the documentation `correlate` for more information.
 
-    See Also
-    --------
-    correlate : Compute the N-dimensional cross-correlation.
-
     Returns
     -------
     lags : array
         Returns an array containing cross-correlation lag/displacement indices.
         Indices can be indexed with the np.argmax of the correlation to return
         the lag/displacement.
+
+    See Also
+    --------
+    correlate : Compute the N-dimensional cross-correlation.
 
     Notes
     -----
@@ -832,6 +833,14 @@ def oaconvolve(in1, in2, mode="full", axes=None):
     -----
     .. versionadded:: 1.4.0
 
+    References
+    ----------
+    .. [1] Wikipedia, "Overlap-add_method".
+           https://en.wikipedia.org/wiki/Overlap-add_method
+    .. [2] Richard G. Lyons. Understanding Digital Signal Processing,
+           Third Edition, 2011. Chapter 13.10.
+           ISBN 13: 978-0137-02741-5
+
     Examples
     --------
     Convolve a 100,000 sample signal with a 512-sample filter.
@@ -851,14 +860,6 @@ def oaconvolve(in1, in2, mode="full", axes=None):
     >>> ax_mag.set_title('Filtered noise')
     >>> fig.tight_layout()
     >>> fig.show()
-
-    References
-    ----------
-    .. [1] Wikipedia, "Overlap-add_method".
-           https://en.wikipedia.org/wiki/Overlap-add_method
-    .. [2] Richard G. Lyons. Understanding Digital Signal Processing,
-           Third Edition, 2011. Chapter 13.10.
-           ISBN 13: 978-0137-02741-5
 
     """
     in1 = np.asarray(in1)
@@ -1581,9 +1582,18 @@ def wiener(im, mysize=None, noise=None):
     out : ndarray
         Wiener filtered result with the same shape as `im`.
 
+    Notes
+    -----
+    This implementation is similar to wiener2 in Matlab/Octave.
+    For more details see [1]_
+
+    References
+    ----------
+    .. [1] Lim, Jae S., Two-Dimensional Signal and Image Processing,
+           Englewood Cliffs, NJ, Prentice Hall, 1990, p. 548.
+
     Examples
     --------
-
     >>> from scipy.datasets import face
     >>> from scipy.signal import wiener
     >>> import matplotlib.pyplot as plt
@@ -1595,17 +1605,6 @@ def wiener(im, mysize=None, noise=None):
     >>> plot1.imshow(img)
     >>> plot2.imshow(filtered_img)
     >>> plt.show()
-
-    Notes
-    -----
-    This implementation is similar to wiener2 in Matlab/Octave.
-    For more details see [1]_
-
-    References
-    ----------
-    .. [1] Lim, Jae S., Two-Dimensional Signal and Image Processing,
-           Englewood Cliffs, NJ, Prentice Hall, 1990, p. 548.
-
 
     """
     im = np.asarray(im)
@@ -1779,6 +1778,7 @@ def correlate2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
     Use 2D cross-correlation to find the location of a template in a noisy
     image:
 
+    >>> import numpy as np
     >>> from scipy import signal
     >>> from scipy import datasets
     >>> rng = np.random.default_rng()
@@ -1850,7 +1850,7 @@ def medfilt2d(input, kernel_size=3):
         An array the same size as input containing the median filtered
         result.
 
-    See also
+    See Also
     --------
     scipy.ndimage.median_filter
 
@@ -2227,6 +2227,11 @@ def deconvolve(signal, divisor):
     remainder : ndarray
         Remainder
 
+    See Also
+    --------
+    numpy.polydiv : performs polynomial division (same operation, but
+                    also accepts poly1d objects)
+
     Examples
     --------
     Deconvolve a signal that's been filtered:
@@ -2240,11 +2245,6 @@ def deconvolve(signal, divisor):
     >>> recovered, remainder = signal.deconvolve(recorded, impulse_response)
     >>> recovered
     array([ 0.,  1.,  0.,  0.,  1.,  1.,  0.,  0.])
-
-    See Also
-    --------
-    numpy.polydiv : performs polynomial division (same operation, but
-                    also accepts poly1d objects)
 
     """
     num = np.atleast_1d(signal)
@@ -2300,6 +2300,15 @@ def hilbert(x, N=None, axis=-1):
     transformed signal can be obtained from ``np.imag(hilbert(x))``, and the
     original signal from ``np.real(hilbert(x))``.
 
+    References
+    ----------
+    .. [1] Wikipedia, "Analytic signal".
+           https://en.wikipedia.org/wiki/Analytic_signal
+    .. [2] Leon Cohen, "Time-Frequency Analysis", 1995. Chapter 2.
+    .. [3] Alan V. Oppenheim, Ronald W. Schafer. Discrete-Time Signal
+           Processing, Third Edition, 2009. Chapter 12.
+           ISBN 13: 978-1292-02572-8
+
     Examples
     --------
     In this example we use the Hilbert transform to determine the amplitude
@@ -2340,15 +2349,6 @@ def hilbert(x, N=None, axis=-1):
     >>> ax1.set_xlabel("time in seconds")
     >>> ax1.set_ylim(0.0, 120.0)
     >>> fig.tight_layout()
-
-    References
-    ----------
-    .. [1] Wikipedia, "Analytic signal".
-           https://en.wikipedia.org/wiki/Analytic_signal
-    .. [2] Leon Cohen, "Time-Frequency Analysis", 1995. Chapter 2.
-    .. [3] Alan V. Oppenheim, Ronald W. Schafer. Discrete-Time Signal
-           Processing, Third Edition, 2009. Chapter 12.
-           ISBN 13: 978-1292-02572-8
 
     """
     x = np.asarray(x)
@@ -3277,7 +3277,9 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0),
     sample of the next cycle for the FFT method, and gets closer to zero
     for the polyphase method:
 
+    >>> import numpy as np
     >>> from scipy import signal
+    >>> import matplotlib.pyplot as plt
 
     >>> x = np.linspace(0, 10, 20, endpoint=False)
     >>> y = np.cos(-x**2/6.0)
@@ -3285,7 +3287,6 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0),
     >>> f_poly = signal.resample_poly(y, 100, 20)
     >>> xnew = np.linspace(0, 10, 100, endpoint=False)
 
-    >>> import matplotlib.pyplot as plt
     >>> plt.plot(xnew, f_fft, 'b.-', xnew, f_poly, 'r.-')
     >>> plt.plot(x, y, 'ko-')
     >>> plt.plot(10, y[0], 'bo', 10, 0., 'ro')  # boundaries
@@ -3293,9 +3294,6 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0),
     >>> plt.show()
 
     This default behaviour can be changed by using the padtype option:
-
-    >>> import numpy as np
-    >>> from scipy import signal
 
     >>> N = 5
     >>> x = np.linspace(0, 1, N, endpoint=False)
@@ -3309,7 +3307,6 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0),
     >>> y3 = signal.resample_poly(Y, up, 1, padtype='mean')
     >>> y4 = signal.resample_poly(Y, up, 1, padtype='line')
 
-    >>> import matplotlib.pyplot as plt
     >>> for i in [0,1]:
     ...     plt.figure()
     ...     plt.plot(xr, y4[:,i], 'g.', label='line')

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -60,6 +60,14 @@ def lombscargle(x,
     ValueError
         If the input arrays `x` and `y` do not have the same shape.
 
+    See Also
+    --------
+    istft: Inverse Short Time Fourier Transform
+    check_COLA: Check whether the Constant OverLap Add (COLA) constraint is met
+    welch: Power spectral density by Welch's method
+    spectrogram: Spectrogram by Welch's method
+    csd: Cross spectral density by Welch's method
+
     Notes
     -----
     This subroutine calculates the periodogram using a slightly
@@ -82,14 +90,6 @@ def lombscargle(x,
     .. [3] R.H.D. Townsend, "Fast calculation of the Lomb-Scargle
            periodogram using graphics processing units.", The Astrophysical
            Journal Supplement Series, vol 191, pp. 247-253, 2010
-
-    See Also
-    --------
-    istft: Inverse Short Time Fourier Transform
-    check_COLA: Check whether the Constant OverLap Add (COLA) constraint is met
-    welch: Power spectral density by Welch's method
-    spectrogram: Spectrogram by Welch's method
-    csd: Cross spectral density by Welch's method
 
     Examples
     --------
@@ -203,14 +203,14 @@ def periodogram(x, fs=1.0, window='boxcar', nfft=None, detrend='constant',
     Pxx : ndarray
         Power spectral density or power spectrum of `x`.
 
-    Notes
-    -----
-    .. versionadded:: 0.12.0
-
     See Also
     --------
     welch: Estimate power spectral density using Welch's method
     lombscargle: Lomb-Scargle periodogram for unevenly sampled data
+
+    Notes
+    -----
+    .. versionadded:: 0.12.0
 
     Examples
     --------

--- a/scipy/signal/_wavelets.py
+++ b/scipy/signal/_wavelets.py
@@ -84,6 +84,11 @@ def qmf(hk):
     hk : array_like
         Coefficients of high-pass filter.
 
+    Returns
+    -------
+    array_like
+        High-pass filter coefficients.
+
     """
     N = len(hk) - 1
     asgn = [{0: 1, 1: -1}[k % 2] for k in range(N + 1)]
@@ -365,6 +370,7 @@ def morlet2(M, s, w=5):
 
     Examples
     --------
+    >>> import numpy as np
     >>> from scipy import signal
     >>> import matplotlib.pyplot as plt
 
@@ -378,9 +384,6 @@ def morlet2(M, s, w=5):
     This example shows basic use of `morlet2` with `cwt` in time-frequency
     analysis:
 
-    >>> import numpy as np
-    >>> from scipy import signal
-    >>> import matplotlib.pyplot as plt
     >>> t, dt = np.linspace(0, 1, 200, retstep=True)
     >>> fs = 1/dt
     >>> w = 6.

--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -54,6 +54,11 @@ def general_cosine(M, a, sym=True):
         design.
         When False, generates a periodic window, for use in spectral analysis.
 
+    Returns
+    -------
+    w : ndarray
+        The array of window values.
+
     References
     ----------
     .. [1] A. Nuttall, "Some windows with very good sidelobe behavior," IEEE
@@ -84,6 +89,7 @@ def general_cosine(M, a, sym=True):
     Figure 42 by plotting the window and its frequency response, and confirm
     the sidelobe level in red:
 
+    >>> import numpy as np
     >>> from scipy.signal.windows import general_cosine
     >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
@@ -962,6 +968,10 @@ def general_hamming(M, alpha, sym=True):
         The window, with the maximum value normalized to 1 (though the value 1
         does not appear if `M` is even and `sym` is True).
 
+    See Also
+    --------
+    hamming, hann
+
     Notes
     -----
     The generalized Hamming window is defined as
@@ -973,9 +983,17 @@ def general_hamming(M, alpha, sym=True):
     generalized Hamming window with :math:`\alpha` = 0.54 and :math:`\alpha` =
     0.5, respectively [2]_.
 
-    See Also
-    --------
-    hamming, hann
+    References
+    ----------
+    .. [1] DSPRelated, "Generalized Hamming Window Family",
+           https://www.dsprelated.com/freebooks/sasp/Generalized_Hamming_Window_Family.html
+    .. [2] Wikipedia, "Window function",
+           https://en.wikipedia.org/wiki/Window_function
+    .. [3] Riccardo Piantanida ESA, "Sentinel-1 Level 1 Detailed Algorithm
+           Definition",
+           https://sentinel.esa.int/documents/247904/1877131/Sentinel-1-Level-1-Detailed-Algorithm-Definition
+    .. [4] Matthieu Bourbigot ESA, "Sentinel-1 Product Definition",
+           https://sentinel.esa.int/documents/247904/1877131/Sentinel-1-Product-Definition
 
     Examples
     --------
@@ -986,6 +1004,7 @@ def general_hamming(M, alpha, sym=True):
     :math:`\alpha` values include 0.75, 0.7 and 0.52 [4]_. As an example, we
     plot these different windows.
 
+    >>> import numpy as np
     >>> from scipy.signal.windows import general_hamming
     >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
@@ -1010,17 +1029,6 @@ def general_hamming(M, alpha, sym=True):
     >>> freq_plot.legend(loc="upper right")
     >>> spatial_plot.legend(loc="upper right")
 
-    References
-    ----------
-    .. [1] DSPRelated, "Generalized Hamming Window Family",
-           https://www.dsprelated.com/freebooks/sasp/Generalized_Hamming_Window_Family.html
-    .. [2] Wikipedia, "Window function",
-           https://en.wikipedia.org/wiki/Window_function
-    .. [3] Riccardo Piantanida ESA, "Sentinel-1 Level 1 Detailed Algorithm
-           Definition",
-           https://sentinel.esa.int/documents/247904/1877131/Sentinel-1-Level-1-Detailed-Algorithm-Definition
-    .. [4] Matthieu Bourbigot ESA, "Sentinel-1 Product Definition",
-           https://sentinel.esa.int/documents/247904/1877131/Sentinel-1-Product-Definition
     """
     return general_cosine(M, [alpha, 1. - alpha], sym)
 
@@ -1270,6 +1278,7 @@ def kaiser_bessel_derived(M, beta, *, sym=True):
     Plot the Kaiser-Bessel derived window based on the wikipedia
     reference [2]_:
 
+    >>> import numpy as np
     >>> from scipy import signal
     >>> import matplotlib.pyplot as plt
     >>> fig, ax = plt.subplots()
@@ -1778,6 +1787,7 @@ def taylor(M, nbar=4, sll=30, norm=True, sym=True):
     --------
     Plot the window and its frequency response:
 
+    >>> import numpy as np
     >>> from scipy import signal
     >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt
@@ -2145,6 +2155,7 @@ def lanczos(M, *, sym=True):
     --------
     Plot the window
 
+    >>> import numpy as np
     >>> from scipy.signal.windows import lanczos
     >>> from scipy.fft import fft, fftshift
     >>> import matplotlib.pyplot as plt

--- a/scipy/sparse/linalg/_isolve/iterative.py
+++ b/scipy/sparse/linalg/_isolve/iterative.py
@@ -133,6 +133,7 @@ def set_docstring(header, Ainfo, footer='', atol_default='0'):
                footer="""\
                Examples
                --------
+               >>> import numpy as np
                >>> from scipy.sparse import csc_matrix
                >>> from scipy.sparse.linalg import bicg
                >>> A = csc_matrix([[3, 2, 0], [1, -1, 0], [0, 5, 1]], dtype=float)


### PR DESCRIPTION
* Add the import of numpy in the 'Examples' where needed.
* Add missing 'Returns' section for some functions.
* Fix the section order in a few docstrings to comply with
  the NumPy docstring standard.