### PR TITLE
TST: setup_method should be classmethod?

### DIFF
--- a/scipy/_lib/tests/test_bunch.py
+++ b/scipy/_lib/tests/test_bunch.py
@@ -16,9 +16,10 @@ class TestMakeTupleBunch:
     # Tests with Result
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-    def setup_method(self):
+    @classmethod
+    def setup_method(cls):
         # Set up an instance of Result.
-        self.result = Result(x=1, y=2, z=3, w=99, beta=0.5)
+        cls.result = Result(x=1, y=2, z=3, w=99, beta=0.5)
 
     def test_attribute_access(self):
         assert_equal(self.result.x, 1)

--- a/scipy/stats/tests/test_hypotests.py
+++ b/scipy/stats/tests/test_hypotests.py
@@ -169,7 +169,8 @@ class TestCvm:
 
 
 class TestMannWhitneyU:
-    def setup_method(self):
+    @classmethod
+    def setup_method(cls):
         _mwu_state._recursive = True
 
     # All magic numbers are from R wilcox.test unless otherwise specied
@@ -621,10 +622,12 @@ class TestMannWhitneyU:
 
 
 class TestMannWhitneyU_iterative(TestMannWhitneyU):
-    def setup_method(self):
+    @classmethod
+    def setup_method(cls):
         _mwu_state._recursive = False
 
-    def teardown_method(self):
+    @classmethod
+    def teardown_method(cls):
         _mwu_state._recursive = None
 
 


### PR DESCRIPTION
#### Reference issue
gh-17247

#### What does this implement/fix?
I've seen errors like this before:
```
ERROR scipy/stats/tests/test_hypotests.py::TestMannWhitneyU_iterative::test_gh_2118[x8-y8-two-sided-expected8] - pytest.PytestRemovedIn8Warning: Support for nose tests is deprecated and will be removed in a future release.
build-install/lib/python3/dist-packages/scipy/stats/tests/test_hypotests.py::TestMannWhitneyU_iterative::test_gh_2118[x8-y8-two-sided-expected8] is using nose-specific method: `setup(self)`
To remove this warning, rename it to `setup_method(self)`
See docs: https://docs.pytest.org/en/stable/deprecations.html#support-for-tests-written-for-nose
```
and I'm seeing them in gh-17247 on linux_aarch64_test, so I thought I'd try to do something about them.

There is no method `setup` in the class; it is already called `setup_method`. However, the [`pytest` documentation](https://docs.pytest.org/en/latest/how-to/xunit_setup.html#class-level-setup-teardown) suggests making these `classmethod`s, so maybe this will help?


#### Additional information
There are other `setup_method`s that are still not classmethods, but they are not causing errors.
