### PR TITLE
DOC: spatial: Fix some docstrings.

### DIFF
--- a/scipy/spatial/_geometric_slerp.py
+++ b/scipy/spatial/_geometric_slerp.py
@@ -78,6 +78,10 @@ def geometric_slerp(
         If ``start`` and ``end`` are antipodes, not on the
         unit n-sphere, or for a variety of degenerate conditions.
 
+    See Also
+    --------
+    scipy.spatial.transform.Slerp : 3-D Slerp that works with quaternions
+
     Notes
     -----
     The implementation is based on the mathematical formula provided in [1]_,
@@ -92,10 +96,6 @@ def geometric_slerp(
     .. [1] https://en.wikipedia.org/wiki/Slerp#Geometric_Slerp
     .. [2] Ken Shoemake (1985) Animating rotation with quaternion curves.
            ACM SIGGRAPH Computer Graphics, 19(3): 245-254.
-
-    See Also
-    --------
-    scipy.spatial.transform.Slerp : 3-D Slerp that works with quaternions
 
     Examples
     --------

--- a/scipy/spatial/_kdtree.py
+++ b/scipy/spatial/_kdtree.py
@@ -15,28 +15,39 @@ def minkowski_distance_p(x, y, p=2):
     not extract the pth root. If `p` is 1 or infinity, this is equal to
     the actual L**p distance.
 
+    The last dimensions of `x` and `y` must be the same length.  Any
+    other dimensions must be compatible for broadcasting.
+
     Parameters
     ----------
-    x : (M, K) array_like
+    x : (..., K) array_like
         Input array.
-    y : (N, K) array_like
+    y : (..., K) array_like
         Input array.
     p : float, 1 <= p <= infinity
         Which Minkowski p-norm to use.
 
+    Returns
+    -------
+    dist : ndarray
+        Distance between the input arrays.  Length of the last
+        dimension will be `K`.
+
     Examples
     --------
     >>> from scipy.spatial import minkowski_distance_p
-    >>> minkowski_distance_p([[0,0],[0,0]], [[1,1],[0,1]])
+    >>> minkowski_distance_p([[0, 0], [0, 0]], [[1, 1], [0, 1]])
     array([2, 1])
 
     """
     x = np.asarray(x)
     y = np.asarray(y)
 
-    # Find smallest common datatype with float64 (return type of this function) - addresses #10262.
+    # Find smallest common datatype with float64 (return type of this
+    # function) - addresses #10262.
     # Don't just cast to float64 for complex input case.
-    common_datatype = np.promote_types(np.promote_types(x.dtype, y.dtype), 'float64')
+    common_datatype = np.promote_types(np.promote_types(x.dtype, y.dtype),
+                                       'float64')
 
     # Make sure x and y are NumPy arrays of correct datatype.
     x = x.astype(common_datatype)
@@ -53,19 +64,28 @@ def minkowski_distance_p(x, y, p=2):
 def minkowski_distance(x, y, p=2):
     """Compute the L**p distance between two arrays.
 
+    The last dimensions of `x` and `y` must be the same length.  Any
+    other dimensions must be compatible for broadcasting.
+
     Parameters
     ----------
-    x : (M, K) array_like
+    x : (..., K) array_like
         Input array.
-    y : (N, K) array_like
+    y : (..., K) array_like
         Input array.
     p : float, 1 <= p <= infinity
         Which Minkowski p-norm to use.
 
+    Returns
+    -------
+    dist : ndarray
+        Distance between the input arrays.  Length of the last
+        dimension will be `K`.
+
     Examples
     --------
     >>> from scipy.spatial import minkowski_distance
-    >>> minkowski_distance([[0,0],[0,0]], [[1,1],[0,1]])
+    >>> minkowski_distance([[0, 0], [0, 0]], [[1, 1], [0, 1]])
     array([ 1.41421356,  1.        ])
 
     """
@@ -886,7 +906,8 @@ def distance_matrix(x, y, p=2, threshold=1000000):
     n, kk = y.shape
 
     if k != kk:
-        raise ValueError("x contains %d-dimensional vectors but y contains %d-dimensional vectors" % (k, kk))
+        raise ValueError(f"x contains {k}-dimensional vectors but y contains "
+                         f"{kk}-dimensional vectors")
 
     if m*n*k <= threshold:
         return minkowski_distance(x[:,np.newaxis,:],y[np.newaxis,:,:],p)

--- a/scipy/spatial/_kdtree.py
+++ b/scipy/spatial/_kdtree.py
@@ -30,8 +30,7 @@ def minkowski_distance_p(x, y, p=2):
     Returns
     -------
     dist : ndarray
-        Distance between the input arrays.  Length of the last
-        dimension will be `K`.
+        pth power of the distance between the input arrays.
 
     Examples
     --------
@@ -79,8 +78,7 @@ def minkowski_distance(x, y, p=2):
     Returns
     -------
     dist : ndarray
-        Distance between the input arrays.  Length of the last
-        dimension will be `K`.
+        Distance between the input arrays.
 
     Examples
     --------

--- a/scipy/spatial/_qhull.pyx
+++ b/scipy/spatial/_qhull.pyx
@@ -2167,6 +2167,7 @@ class Delaunay(_QhullUser):
         z[...,-1] += self.paraboloid_shift
         return z
 
+
 def tsearch(tri, xi):
     """
     tsearch(tri, xi)
@@ -2174,16 +2175,29 @@ def tsearch(tri, xi):
     Find simplices containing the given points. This function does the
     same thing as `Delaunay.find_simplex`.
 
-    .. versionadded:: 0.9
+    Parameters
+    ----------
+    tri : DelaunayInfo
+        Delaunay triangulation
+    xi : ndarray of double, shape (..., ndim)
+        Points to locate
+
+    Returns
+    -------
+    i : ndarray of int, same shape as `xi`
+        Indices of simplices containing each point.
+        Points outside the triangulation get the value -1.
 
     See Also
     --------
     Delaunay.find_simplex
 
+    Notes
+    -----
+    .. versionadded:: 0.9
 
     Examples
     --------
-
     >>> import numpy as np
     >>> import matplotlib.pyplot as plt
     >>> from scipy.spatial import Delaunay, delaunay_plot_2d, tsearch


### PR DESCRIPTION
The docstrings for 'geometric_slerp', 'minkowski_distance', 'minkowski_distance_p' and 'tsearch' are updated:

* Add a few missing 'Returns' sections, and move some sections around to comply with the NumPy docstring standard.
* Copy-edit the 'minkowski_distance' and 'minkowski_distance_p' docstrings to reflect what they actually do.

Also fixed a few really long lines (PEP 8).
