### PR TITLE
DOC/MAINT: clean doctests namespace

### DIFF
--- a/doc/source/dev/contributor/continuous_integration.rst
+++ b/doc/source/dev/contributor/continuous_integration.rst
@@ -36,6 +36,7 @@ GitHub Actions
 * ``Linux Tests``: test suite runs for Linux (``x86_64``)
 * ``macOS Tests``: test suite runs for macOS (``x86_64``)
 * ``wheels``: builds wheels for SciPy releases as well as *nightly* builds.
+* ``Check the rendered docs here!``: live preview of the documentation
 
 The test suite runs on GitHub Actions and other platforms cover a range of
 test/environment conditions: Python and NumPy versions
@@ -57,9 +58,14 @@ Azure
 CircleCI
 --------
 * ``build_docs``: build the documentation
-* ``build_docs artifact``: live preview of the documentation
 * ``build_scipy``
 * ``run_benchmarks``: verify how the changes impact performance
+
+CirrusCI
+--------
+* ``Tests``: test suite for specific architecture like
+  ``musllinux, arm, aarch``
+* ``Wheels``: build and upload some wheels
 
 Codecov
 -------
@@ -95,7 +101,7 @@ GitHub Actions' workflows::
 
     DOC: improve QMCEngine examples.
 
-    [skip azp] [skip actions]
+    [skip azp] [skip actions] [skip cirrus]
 
 Wheel builds
 ============

--- a/doc/source/tutorial/fft.rst
+++ b/doc/source/tutorial/fft.rst
@@ -42,6 +42,7 @@ These transforms can be calculated by means of :func:`fft` and :func:`ifft`,
 respectively, as shown in the following example.
 
 >>> from scipy.fft import fft, ifft
+>>> import numpy as np
 >>> x = np.array([1.0, 2.0, 1.0, -1.0, 1.5])
 >>> y = fft(x)
 >>> y
@@ -83,6 +84,7 @@ The example plots the FFT of the sum of two sines.
     :alt: "This code generates an X-Y plot showing amplitude on the Y axis vs frequency on the X axis. A single blue trace has an amplitude of zero all the way across with the exception of two peaks. The taller first peak is at 50 Hz with a second peak at 80 Hz."
 
     >>> from scipy.fft import fft, fftfreq
+    >>> import numpy as np
     >>> # Number of sample points
     >>> N = 600
     >>> # sample spacing
@@ -111,6 +113,7 @@ truncated for illustrative purposes).
     :alt: "This code generates an X-Y log-linear plot with amplitude on the Y axis vs frequency on the X axis. The first trace is the FFT with two peaks at 50 and 80 Hz and a noise floor around an amplitude of 1e-2. The second trace is the windowed FFT and has the same two peaks but the noise floor is much lower around an amplitude of 1e-7 due to the window function."
 
     >>> from scipy.fft import fft, fftfreq
+    >>> import numpy as np
     >>> # Number of sample points
     >>> N = 600
     >>> # sample spacing
@@ -156,6 +159,7 @@ asymmetric spectrum.
     :alt: "This code generates an X-Y plot with amplitude on the Y axis vs frequency on the X axis. The trace is zero-valued across the plot except for two sharp peaks at -80 and 50 Hz. The 50 Hz peak on the right is twice as tall."
 
     >>> from scipy.fft import fft, fftfreq, fftshift
+    >>> import numpy as np
     >>> # number of signal points
     >>> N = 400
     >>> # sample spacing
@@ -240,6 +244,7 @@ The example below demonstrates a 2-D IFFT and plots the resulting
     >>> from scipy.fft import ifftn
     >>> import matplotlib.pyplot as plt
     >>> import matplotlib.cm as cm
+    >>> import numpy as np
     >>> N = 30
     >>> f, ((ax1, ax2, ax3), (ax4, ax5, ax6)) = plt.subplots(2, 3, sharex='col', sharey='row')
     >>> xf = np.zeros((N,N))

--- a/doc/source/tutorial/general.rst
+++ b/doc/source/tutorial/general.rst
@@ -30,19 +30,6 @@ package. Some general Python facility is also assumed, such as could be
 acquired by working through the Python distribution's Tutorial. For further
 introductory help the user is directed to the NumPy documentation.
 
-For brevity and convenience, we will often assume that the main
-packages (numpy, scipy, and matplotlib) have been imported as::
-
-    >>> import numpy as np
-    >>> import matplotlib as mpl
-    >>> import matplotlib.pyplot as plt
-
-These are the import conventions that our community has adopted
-after discussion on public mailing lists.  You will see these
-conventions used throughout NumPy and SciPy source code and
-documentation.  While we obviously don't require you to follow
-these conventions in your own code, it is highly recommended.
-
 SciPy Organization
 ------------------
 

--- a/doc/source/tutorial/integrate.rst
+++ b/doc/source/tutorial/integrate.rst
@@ -101,6 +101,7 @@ is desired (and the fact that this integral can be computed as
 ``vec_expint`` based on the routine :obj:`quad`:
 
     >>> from scipy.integrate import quad
+    >>> import numpy as np
     >>> def integrand(t, n, x):
     ...     return np.exp(-x*t) / t**n
     ...

--- a/doc/source/tutorial/ndimage.rst
+++ b/doc/source/tutorial/ndimage.rst
@@ -46,6 +46,7 @@ desired `numpy` type object to the output argument. For example:
 .. code:: python
 
     >>> from scipy.ndimage import correlate
+    >>> import numpy as np
     >>> correlate(np.arange(10), [1, 2.5])
     array([ 0,  2,  6,  9, 13, 16, 20, 23, 27, 30])
     >>> correlate(np.arange(10), [1, 2.5], output=np.float64)

--- a/doc/source/tutorial/spatial.rst
+++ b/doc/source/tutorial/spatial.rst
@@ -26,6 +26,7 @@ Delaunay triangulation can be computed using `scipy.spatial` as follows:
    :alt: "This code generates an X-Y plot with four green points annotated 0 through 3 roughly in the shape of a box. The box is outlined with a diagonal line between points 0 and 3 forming two adjacent triangles. The top triangle is annotated as #1 and the bottom triangle is annotated as #0."
 
    >>> from scipy.spatial import Delaunay
+   >>> import numpy as np
    >>> points = np.array([[0, 0], [0, 1.1], [1, 0], [1, 1]])
    >>> tri = Delaunay(points)
 

--- a/doc/source/tutorial/special.rst
+++ b/doc/source/tutorial/special.rst
@@ -38,6 +38,7 @@ drum head anchored at the edge:
    :alt: "This code generates a 3-D representation of the vibrational modes on a drum head viewed at a three-quarter angle. A circular region on the X-Y plane is defined with a Z value of 0 around the edge. Within the circle a single smooth valley exists on the -X side and a smooth peak exists on the +X side. The image resembles a yin-yang at this angle."
 
    >>> from scipy import special
+   >>> import numpy as np
    >>> def drumhead_height(n, k, distance, angle, t):
    ...    kth_zero = special.jn_zeros(n, k)[-1]
    ...    return np.cos(t) * np.cos(n*angle) * special.jn(n, distance*kth_zero)

--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -1680,6 +1680,7 @@ class SmoothSphereBivariateSpline(SphereBivariateSpline):
     Suppose we have global data on a coarse grid (the input data does not
     have to be on a grid):
 
+    >>> import numpy as np
     >>> theta = np.linspace(0., np.pi, 7)
     >>> phi = np.linspace(0., 2*np.pi, 9)
     >>> data = np.empty((theta.shape[0], phi.shape[0]))
@@ -1825,6 +1826,7 @@ class LSQSphereBivariateSpline(SphereBivariateSpline):
     have to be on a grid):
 
     >>> from scipy.interpolate import LSQSphereBivariateSpline
+    >>> import numpy as np
     >>> import matplotlib.pyplot as plt
 
     >>> theta = np.linspace(0, np.pi, num=7)
@@ -2030,6 +2032,7 @@ class RectSphereBivariateSpline(SphereBivariateSpline):
     --------
     Suppose we have global data on a coarse grid
 
+    >>> import numpy as np
     >>> lats = np.linspace(10, 170, 9) * np.pi / 180.
     >>> lons = np.linspace(0, 350, 18) * np.pi / 180.
     >>> data = np.dot(np.atleast_2d(90. - np.linspace(-80., 80., 18)).T,

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -471,6 +471,7 @@ class interp1d(_Interpolator1D):
 
     Examples
     --------
+    >>> import numpy as np
     >>> import matplotlib.pyplot as plt
     >>> from scipy import interpolate
     >>> x = np.arange(0, 10)

--- a/scipy/interpolate/_ndgriddata.py
+++ b/scipy/interpolate/_ndgriddata.py
@@ -55,6 +55,7 @@ class NearestNDInterpolator(NDInterpolatorBase):
     We can interpolate values on a 2D plane:
 
     >>> from scipy.interpolate import NearestNDInterpolator
+    >>> import numpy as np
     >>> import matplotlib.pyplot as plt
     >>> rng = np.random.default_rng()
     >>> x = rng.random(10) - 0.5

--- a/scipy/interpolate/_rbf.py
+++ b/scipy/interpolate/_rbf.py
@@ -134,6 +134,7 @@ class Rbf:
 
     Examples
     --------
+    >>> import numpy as np
     >>> from scipy.interpolate import Rbf
     >>> rng = np.random.default_rng()
     >>> x, y, z, d = rng.random((4, 50))

--- a/scipy/interpolate/_rbfinterp.py
+++ b/scipy/interpolate/_rbfinterp.py
@@ -260,6 +260,7 @@ class RBFInterpolator:
     --------
     Demonstrate interpolating scattered data to a grid in 2-D.
 
+    >>> import numpy as np
     >>> import matplotlib.pyplot as plt
     >>> from scipy.interpolate import RBFInterpolator
     >>> from scipy.stats.qmc import Halton

--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -117,6 +117,7 @@ class RegularGridInterpolator:
     a 3-D grid:
 
     >>> from scipy.interpolate import RegularGridInterpolator
+    >>> import numpy as np
     >>> def f(x, y, z):
     ...     return 2 * x**3 + 3 * y**2 - z
     >>> x = np.linspace(1, 4, 11)
@@ -312,6 +313,7 @@ class RegularGridInterpolator:
         --------
         Here we define a nearest-neighbor interpolator of a simple function
 
+        >>> import numpy as np
         >>> x, y = np.array([0, 1, 2]), np.array([1, 3, 7])
         >>> def f(x, y):
         ...     return x**2 + y**2

--- a/scipy/interpolate/interpnd.pyx
+++ b/scipy/interpolate/interpnd.pyx
@@ -241,6 +241,7 @@ class LinearNDInterpolator(NDInterpolatorBase):
     We can interpolate values on a 2D plane:
 
     >>> from scipy.interpolate import LinearNDInterpolator
+    >>> import numpy as np
     >>> import matplotlib.pyplot as plt
     >>> rng = np.random.default_rng()
     >>> x = rng.random(10) - 0.5
@@ -840,6 +841,7 @@ class CloughTocher2DInterpolator(NDInterpolatorBase):
     We can interpolate values on a 2D plane:
 
     >>> from scipy.interpolate import CloughTocher2DInterpolator
+    >>> import numpy as np
     >>> import matplotlib.pyplot as plt
     >>> rng = np.random.default_rng()
     >>> x = rng.random(10) - 0.5

--- a/scipy/io/_fortran.py
+++ b/scipy/io/_fortran.py
@@ -73,6 +73,7 @@ class FortranFile:
     To create an unformatted sequential Fortran file:
 
     >>> from scipy.io import FortranFile
+    >>> import numpy as np
     >>> f = FortranFile('test.unf', 'w')
     >>> f.write_record(np.array([1,2,3,4,5], dtype=np.int32))
     >>> f.write_record(np.linspace(0,1,20).reshape((5,4)).T)

--- a/scipy/io/_netcdf.py
+++ b/scipy/io/_netcdf.py
@@ -179,6 +179,7 @@ class netcdf_file:
     To create a NetCDF file:
 
     >>> from scipy.io import netcdf_file
+    >>> import numpy as np
     >>> f = netcdf_file('simple.nc', 'w')
     >>> f.history = 'Created for a test'
     >>> f.createDimension('time', 10)

--- a/scipy/linalg/_decomp_svd.py
+++ b/scipy/linalg/_decomp_svd.py
@@ -175,6 +175,7 @@ def svdvals(a, overwrite_a=False, check_finite=True):
     handling of the edge case of empty ``a``, where it returns an
     empty sequence:
 
+    >>> import numpy as np
     >>> a = np.empty((0, 2))
     >>> from scipy.linalg import svdvals
     >>> svdvals(a)

--- a/scipy/odr/_models.py
+++ b/scipy/odr/_models.py
@@ -95,6 +95,7 @@ class _MultilinearModel(Model):
     dimensional linear model:
 
     >>> from scipy import odr
+    >>> import numpy as np
     >>> x = np.linspace(0.0, 5.0)
     >>> y = 10.0 + 5.0 * x
     >>> data = odr.Data(x, y)
@@ -188,6 +189,7 @@ class _ExponentialModel(Model):
     We can calculate orthogonal distance regression with an exponential model:
 
     >>> from scipy import odr
+    >>> import numpy as np
     >>> x = np.linspace(0.0, 5.0)
     >>> y = -10.0 + np.exp(0.5*x)
     >>> data = odr.Data(x, y)
@@ -258,6 +260,7 @@ class _UnilinearModel(Model):
     We can calculate orthogonal distance regression with an unilinear model:
 
     >>> from scipy import odr
+    >>> import numpy as np
     >>> x = np.linspace(0.0, 5.0)
     >>> y = 1.0 * x + 2.0
     >>> data = odr.Data(x, y)
@@ -290,6 +293,7 @@ class _QuadraticModel(Model):
     We can calculate orthogonal distance regression with a quadratic model:
 
     >>> from scipy import odr
+    >>> import numpy as np
     >>> x = np.linspace(0.0, 5.0)
     >>> y = 1.0 * x ** 2 + 2.0 * x + 3.0
     >>> data = odr.Data(x, y)

--- a/scipy/optimize/_constraints.py
+++ b/scipy/optimize/_constraints.py
@@ -99,6 +99,7 @@ class NonlinearConstraint:
     Constrain ``x[0] < sin(x[1]) + 1.9``
 
     >>> from scipy.optimize import NonlinearConstraint
+    >>> import numpy as np
     >>> con = lambda x: x[0] - np.sin(x[1])
     >>> nlc = NonlinearConstraint(con, -np.inf, 1.9)
 

--- a/scipy/signal/_czt.py
+++ b/scipy/signal/_czt.py
@@ -187,6 +187,7 @@ class CZT:
     Compute multiple prime-length FFTs:
 
     >>> from scipy.signal import CZT
+    >>> import numpy as np
     >>> a = np.random.rand(7)
     >>> b = np.random.rand(7)
     >>> c = np.random.rand(7)

--- a/scipy/signal/_ltisys.py
+++ b/scipy/signal/_ltisys.py
@@ -1265,7 +1265,7 @@ class StateSpace(LinearTimeInvariant):
     Examples
     --------
     >>> from scipy import signal
-
+    >>> import numpy as np
     >>> a = np.array([[0, 1], [0, 0]])
     >>> b = np.array([[0], [1]])
     >>> c = np.array([[1, 0]])

--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -90,6 +90,7 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
     Examples
     --------
     >>> from scipy.sparse import bsr_matrix
+    >>> import numpy as np
     >>> bsr_matrix((3, 4), dtype=np.int8).toarray()
     array([[0, 0, 0, 0],
            [0, 0, 0, 0],

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -90,6 +90,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
     --------
 
     >>> # Constructing an empty matrix
+    >>> import numpy as np
     >>> from scipy.sparse import coo_matrix
     >>> coo_matrix((3, 4), dtype=np.int8).toarray()
     array([[0, 0, 0, 0],

--- a/scipy/sparse/csgraph/_tools.pyx
+++ b/scipy/sparse/csgraph/_tools.pyx
@@ -253,6 +253,7 @@ def csgraph_to_dense(csgraph, null_value=0):
     This illustrates the difference in behavior:
 
     >>> from scipy.sparse import csr_matrix, csgraph
+    >>> import numpy as np
     >>> data = np.array([2, 3])
     >>> indices = np.array([1, 1])
     >>> indptr = np.array([0, 2, 2])

--- a/scipy/spatial/_qhull.pyx
+++ b/scipy/spatial/_qhull.pyx
@@ -1751,6 +1751,7 @@ class Delaunay(_QhullUser):
     --------
     Triangulation of a set of points:
 
+    >>> import numpy as np
     >>> points = np.array([[0, 0], [0, 1.1], [1, 0], [1, 1]])
     >>> from scipy.spatial import Delaunay
     >>> tri = Delaunay(points)
@@ -2360,6 +2361,7 @@ class ConvexHull(_QhullUser):
     Convex hull of a random set of points:
 
     >>> from scipy.spatial import ConvexHull, convex_hull_plot_2d
+    >>> import numpy as np
     >>> rng = np.random.default_rng()
     >>> points = rng.random((30, 2))   # 30 random points in 2-D
     >>> hull = ConvexHull(points)
@@ -2562,6 +2564,7 @@ class Voronoi(_QhullUser):
     --------
     Voronoi diagram for a set of point:
 
+    >>> import numpy as np
     >>> points = np.array([[0, 0], [0, 1], [0, 2], [1, 0], [1, 1], [1, 2],
     ...                    [2, 0], [2, 1], [2, 2]])
     >>> from scipy.spatial import Voronoi, voronoi_plot_2d
@@ -2728,6 +2731,7 @@ class HalfspaceIntersection(_QhullUser):
     Halfspace intersection of planes forming some polygon
 
     >>> from scipy.spatial import HalfspaceIntersection
+    >>> import numpy as np
     >>> halfspaces = np.array([[-1, 0., 0.],
     ...                        [0., -1., 0.],
     ...                        [2., 1., -4.],

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -373,6 +373,7 @@ def directed_hausdorff(u, v, seed=0):
     coordinates:
 
     >>> from scipy.spatial.distance import directed_hausdorff
+    >>> import numpy as np
     >>> u = np.array([(1.0, 0.0),
     ...               (0.0, 1.0),
     ...               (-1.0, 0.0),
@@ -1265,6 +1266,7 @@ def jensenshannon(p, q, base=None, *, axis=0, keepdims=False):
     Examples
     --------
     >>> from scipy.spatial import distance
+    >>> import numpy as np
     >>> distance.jensenshannon([1.0, 0.0, 0.0], [0.0, 1.0, 0.0], 2.0)
     1.0
     >>> distance.jensenshannon([1.0, 0.0], [0.5, 0.5])
@@ -2857,6 +2859,7 @@ def cdist(XA, XB, metric='euclidean', *, out=None, **kwargs):
     Find the Euclidean distances between four 2-D coordinates:
 
     >>> from scipy.spatial import distance
+    >>> import numpy as np
     >>> coords = [(35.0456, -85.2672),
     ...           (35.1174, -89.9711),
     ...           (35.9728, -83.9422),

--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -359,6 +359,7 @@ cdef class Rotation:
     Examples
     --------
     >>> from scipy.spatial.transform import Rotation as R
+    >>> import numpy as np
 
     A `Rotation` instance can be initialized in any of the above formats and
     converted to any of the others. The underlying object is independent of the
@@ -668,6 +669,7 @@ cdef class Rotation:
         Examples
         --------
         >>> from scipy.spatial.transform import Rotation as R
+        >>> import numpy as np
 
         Initialize a single rotation:
 
@@ -821,6 +823,7 @@ cdef class Rotation:
         Examples
         --------
         >>> from scipy.spatial.transform import Rotation as R
+        >>> import numpy as np
 
         Initialize a single rotation:
 
@@ -1094,6 +1097,7 @@ cdef class Rotation:
         Examples
         --------
         >>> from scipy.spatial.transform import Rotation as R
+        >>> import numpy as np
 
         Initialize a single rotation:
 
@@ -1177,6 +1181,7 @@ cdef class Rotation:
         Examples
         --------
         >>> from scipy.spatial.transform import Rotation as R
+        >>> import numpy as np
 
         Represent a single rotation:
 
@@ -1227,6 +1232,7 @@ cdef class Rotation:
         Examples
         --------
         >>> from scipy.spatial.transform import Rotation as R
+        >>> import numpy as np
 
         Represent a single rotation:
 
@@ -1339,6 +1345,7 @@ cdef class Rotation:
         Examples
         --------
         >>> from scipy.spatial.transform import Rotation as R
+        >>> import numpy as np
 
         Represent a single rotation:
 
@@ -1463,6 +1470,7 @@ cdef class Rotation:
         Examples
         --------
         >>> from scipy.spatial.transform import Rotation as R
+        >>> import numpy as np
 
         Represent a single rotation:
 
@@ -1547,6 +1555,7 @@ cdef class Rotation:
         Examples
         --------
         >>> from scipy.spatial.transform import Rotation as R
+        >>> import numpy as np
 
         Represent a single rotation:
 
@@ -1666,6 +1675,7 @@ cdef class Rotation:
         Examples
         --------
         >>> from scipy.spatial.transform import Rotation as R
+        >>> import numpy as np
 
         Single rotation applied on a single vector:
 
@@ -1806,6 +1816,7 @@ cdef class Rotation:
         Examples
         --------
         >>> from scipy.spatial.transform import Rotation as R
+        >>> import numpy as np
 
         Composition of two single rotations:
 
@@ -1869,6 +1880,7 @@ cdef class Rotation:
         Examples
         --------
         >>> from scipy.spatial.transform import Rotation as R
+        >>> import numpy as np
 
         Inverting a single rotation:
 
@@ -1907,6 +1919,7 @@ cdef class Rotation:
         Examples
         --------
         >>> from scipy.spatial.transform import Rotation as R
+        >>> import numpy as np
         >>> r = R.from_quat(np.eye(4))
         >>> r.magnitude()
         array([3.14159265, 3.14159265, 3.14159265, 0.        ])

--- a/scipy/spatial/transform/_rotation_spline.py
+++ b/scipy/spatial/transform/_rotation_spline.py
@@ -278,6 +278,7 @@ class RotationSpline:
     Examples
     --------
     >>> from scipy.spatial.transform import Rotation, RotationSpline
+    >>> import numpy as np
 
     Define the sequence of times and rotations from the Euler angles:
 

--- a/scipy/stats/_unuran/unuran_wrapper.pyx.templ
+++ b/scipy/stats/_unuran/unuran_wrapper.pyx.templ
@@ -778,6 +778,7 @@ cdef class TransformedDensityRejection(Method):
     Examples
     --------
     >>> from scipy.stats.sampling import TransformedDensityRejection
+    >>> import numpy as np
 
     Suppose we have a density:
 
@@ -989,6 +990,7 @@ cdef class TransformedDensityRejection(Method):
         --------
         >>> from scipy.stats.sampling import TransformedDensityRejection
         >>> from scipy.stats import norm
+        >>> import numpy as np
         >>> from math import exp
         >>>
         >>> class MyDist:
@@ -1096,6 +1098,7 @@ cdef class SimpleRatioUniforms(Method):
     Examples
     --------
     >>> from scipy.stats.sampling import SimpleRatioUniforms
+    >>> import numpy as np
 
     Suppose we have the normal distribution:
 
@@ -1332,6 +1335,7 @@ cdef class NumericalInversePolynomial(Method):
     --------
     >>> from scipy.stats.sampling import NumericalInversePolynomial
     >>> from scipy.stats import norm
+    >>> import numpy as np
 
     To create a generator to sample from the standard normal distribution, do:
 
@@ -1866,6 +1870,7 @@ cdef class NumericalInverseHermite(Method):
     >>> from scipy.stats.sampling import NumericalInverseHermite
     >>> from scipy.stats import norm, genexpon
     >>> from scipy.special import ndtr
+    >>> import numpy as np
 
     To create a generator to sample from the standard normal distribution, do:
 
@@ -2327,6 +2332,7 @@ cdef class DiscreteAliasUrn(Method):
     Examples
     --------
     >>> from scipy.stats.sampling import DiscreteAliasUrn
+    >>> import numpy as np
 
     To create a random number generator using a probability vector, use:
 
@@ -2590,6 +2596,7 @@ cdef class DiscreteGuideTable(Method):
     Examples
     --------
     >>> from scipy.stats.sampling import DiscreteGuideTable
+    >>> import numpy as np
 
     To create a random number generator using a probability vector, use:
 

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -39,9 +39,7 @@ from doctest import NORMALIZE_WHITESPACE, ELLIPSIS, IGNORE_EXCEPTION_DETAIL
 
 import docutils.core
 import numpy as np
-import sphinx
 from docutils.parsers.rst import directives
-from pkg_resources import parse_version
 
 from numpydoc.docscrape_sphinx import get_doc_object
 from numpydoc.docscrape import NumpyDocString  # noqa
@@ -49,20 +47,10 @@ from scipy.stats._distr_params import distcont, distdiscrete  # noqa
 from scipy import stats  # noqa
 
 
-if parse_version(sphinx.__version__) >= parse_version('1.5'):
-    # Enable specific Sphinx directives
-    from sphinx.directives.other import SeeAlso, Only
-    directives.register_directive('seealso', SeeAlso)
-    directives.register_directive('only', Only)
-else:
-    # Remove sphinx directives that don't run without Sphinx environment.
-    # Sphinx < 1.5 installs all directives on import...
-    directives._directives.pop('versionadded', None)
-    directives._directives.pop('versionchanged', None)
-    directives._directives.pop('moduleauthor', None)
-    directives._directives.pop('sectionauthor', None)
-    directives._directives.pop('codeauthor', None)
-    directives._directives.pop('toctree', None)
+# Enable specific Sphinx directives
+from sphinx.directives.other import SeeAlso, Only
+directives.register_directive('seealso', SeeAlso)
+directives.register_directive('only', Only)
 
 
 BASE_MODULE = "scipy"
@@ -417,12 +405,7 @@ def check_rest(module, names, dots=True):
 
     Returns: [(name, success_flag, output), ...]
     """
-
-    try:
-        skip_types = (dict, str, unicode, float, int)
-    except NameError:
-        # python 3
-        skip_types = (dict, str, float, int)
+    skip_types = (dict, str, float, int)
 
     results = []
 
@@ -479,7 +462,7 @@ def check_rest(module, names, dots=True):
 ### Doctest helpers ####
 
 # the namespace to run examples in
-DEFAULT_NAMESPACE = {'np': np}
+DEFAULT_NAMESPACE = {}
 
 # the namespace to do checks in
 CHECK_NAMESPACE = {

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -107,6 +107,15 @@ DOCTEST_SKIPLIST = set([
     'scipy.stats.kstwobign',  # inaccurate cdf or ppf
     'scipy.stats.levy_stable',
     'scipy.special.sinc',  # comes from numpy
+    'scipy.fft.fftfreq',
+    'scipy.fft.rfftfreq',
+    'scipy.fft.fftshift',
+    'scipy.fft.ifftshift',
+    'scipy.fftpack.fftfreq',
+    'scipy.fftpack.fftshift',
+    'scipy.fftpack.ifftshift',
+    'scipy.integrate.trapezoid',
+    'scipy.linalg.LinAlgError',
     'scipy.optimize.show_options',
     'io.rst',   # XXX: need to figure out how to deal w/ mat files
 ])


### PR DESCRIPTION
Closes #16759

Since #17349, all examples should be exempts of implicit NumPy imports. I tested this locally and if there are leftover example without explicit import, the ref guide check will fail.

This PR removes the import in the doctests logic and do some other cleanup I noticed while on this.