### PR TITLE
DOC: Add missing `build` parameter to `dev.py`

### DIFF
--- a/doc/source/dev/dev_quickstart.rst
+++ b/doc/source/dev/dev_quickstart.rst
@@ -87,7 +87,7 @@ Next, set up your development environment.
 Finally, build SciPy for development and run the test suite to make sure your
 installation is successful. On Linux and OSX, you should use::
 
-    python dev.py
+    python dev.py build
 
 This builds SciPy first, so the first time it may take some time.
 

--- a/doc/source/dev/dev_quickstart.rst
+++ b/doc/source/dev/dev_quickstart.rst
@@ -84,20 +84,24 @@ Next, set up your development environment.
         Your command prompt now lists the name of your new environment, like so
         ``(scipy-dev)$``.
 
-Finally, build SciPy for development and run the test suite to make sure your
-installation is successful. On Linux and OSX, you should use::
+Finally, build SciPy for development. On Linux and OSX, you should use::
 
     python dev.py build
-
-This builds SciPy first, so the first time it may take some time.
 
 If you run into a build issue, or need more detailed build documentation
 including building on Windows, see :ref:`building`.
 
+Otherwise, if the build has finished successfully, you should now be able
+to run the SciPy tests. You can run the full test suite running::
+
+    python dev.py test
+
+Notice that this will take some time, so you might want to test only the
+part of SciPy you will be working on. For details on how to do that and
+a more complete setup walkthrough, see :ref:`development-workflow`.
+
 Some of the tests in SciPy are very slow and need to be separately
 enabled. See :ref:`the-dev-py-interface` for details.
-
-For a complete setup walkthrough, see :ref:`development-workflow`.
 
 Other workflows
 ===============


### PR DESCRIPTION
#### Reference issue
No reference issue, just a small fix

#### What does this implement/fix?
Typing `python dev.py` doesn't actually build SciPy, `python dev.py build` does.

#### Additional information
<!--Any additional information you think is important.-->
N/A