### PR TITLE
DOC: consistent use of `=` for argument documentation

### DIFF
--- a/scipy/fft/_pocketfft/pypocketfft.cxx
+++ b/scipy/fft/_pocketfft/pypocketfft.cxx
@@ -647,7 +647,7 @@ nthreads : int
     Number of threads to use. If 0, use the system default (typically governed
     by the `OMP_NUM_THREADS` environment variable).
 ortho: bool
-    Orthogonalize transform (defaults to ``inorm==1``)
+    Orthogonalize transform (defaults to ``inorm=1``)
 
 Returns
 -------
@@ -687,7 +687,7 @@ nthreads : int
     Number of threads to use. If 0, use the system default (typically governed
     by the `OMP_NUM_THREADS` environment variable).
 ortho: bool
-    Orthogonalize transform (defaults to ``inorm==1``)
+    Orthogonalize transform (defaults to ``inorm=1``)
 
 Returns
 -------

--- a/scipy/fft/_realtransforms.py
+++ b/scipy/fft/_realtransforms.py
@@ -39,7 +39,7 @@ def dctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
         See :func:`~scipy.fft.fft` for more details.
     orthogonalize : bool, optional
         Whether to use the orthogonalized DCT variant (see Notes).
-        Defaults to ``True`` when ``norm=="ortho"`` and ``False`` otherwise.
+        Defaults to ``True`` when ``norm="ortho"`` and ``False`` otherwise.
 
         .. versionadded:: 1.8.0
 
@@ -104,7 +104,7 @@ def idctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
         See :func:`~scipy.fft.fft` for more details.
     orthogonalize : bool, optional
         Whether to use the orthogonalized IDCT variant (see Notes).
-        Defaults to ``True`` when ``norm=="ortho"`` and ``False`` otherwise.
+        Defaults to ``True`` when ``norm="ortho"`` and ``False`` otherwise.
 
         .. versionadded:: 1.8.0
 
@@ -169,7 +169,7 @@ def dstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
         See :func:`~scipy.fft.fft` for more details.
     orthogonalize : bool, optional
         Whether to use the orthogonalized DST variant (see Notes).
-        Defaults to ``True`` when ``norm=="ortho"`` and ``False`` otherwise.
+        Defaults to ``True`` when ``norm="ortho"`` and ``False`` otherwise.
 
         .. versionadded:: 1.8.0
 
@@ -234,7 +234,7 @@ def idstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
         See :func:`~scipy.fft.fft` for more details.
     orthogonalize : bool, optional
         Whether to use the orthogonalized IDST variant (see Notes).
-        Defaults to ``True`` when ``norm=="ortho"`` and ``False`` otherwise.
+        Defaults to ``True`` when ``norm="ortho"`` and ``False`` otherwise.
 
         .. versionadded:: 1.8.0
 
@@ -293,7 +293,7 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None,
         See :func:`~scipy.fft.fft` for more details.
     orthogonalize : bool, optional
         Whether to use the orthogonalized DCT variant (see Notes).
-        Defaults to ``True`` when ``norm=="ortho"`` and ``False`` otherwise.
+        Defaults to ``True`` when ``norm="ortho"`` and ``False`` otherwise.
 
         .. versionadded:: 1.8.0
 
@@ -444,7 +444,7 @@ def idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
         See :func:`~scipy.fft.fft` for more details.
     orthogonalize : bool, optional
         Whether to use the orthogonalized IDCT variant (see Notes).
-        Defaults to ``True`` when ``norm=="ortho"`` and ``False`` otherwise.
+        Defaults to ``True`` when ``norm="ortho"`` and ``False`` otherwise.
 
         .. versionadded:: 1.8.0
 
@@ -524,7 +524,7 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None,
         See :func:`~scipy.fft.fft` for more details.
     orthogonalize : bool, optional
         Whether to use the orthogonalized DST variant (see Notes).
-        Defaults to ``True`` when ``norm=="ortho"`` and ``False`` otherwise.
+        Defaults to ``True`` when ``norm="ortho"`` and ``False`` otherwise.
 
         .. versionadded:: 1.8.0
 
@@ -659,7 +659,7 @@ def idst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
         See :func:`~scipy.fft.fft` for more details.
     orthogonalize : bool, optional
         Whether to use the orthogonalized IDST variant (see Notes).
-        Defaults to ``True`` when ``norm=="ortho"`` and ``False`` otherwise.
+        Defaults to ``True`` when ``norm="ortho"`` and ``False`` otherwise.
 
         .. versionadded:: 1.8.0
 

--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -128,7 +128,7 @@ def fsolve(func, x0, args=(), fprime=None, full_output=0,
     See Also
     --------
     root : Interface to root finding algorithms for multivariate
-           functions. See the ``method=='hybr'`` in particular.
+           functions. See the ``method='hybr'`` in particular.
 
     Notes
     -----
@@ -374,7 +374,7 @@ def leastsq(func, x0, args=(), Dfun=None, full_output=0,
     See Also
     --------
     least_squares : Newer interface to solve nonlinear least-squares problems
-        with bounds on the variables. See ``method=='lm'`` in particular.
+        with bounds on the variables. See ``method='lm'`` in particular.
 
     Notes
     -----

--- a/scipy/optimize/_nonlin.py
+++ b/scipy/optimize/_nonlin.py
@@ -815,7 +815,7 @@ class BroydenFirst(GenericBroyden):
     See Also
     --------
     root : Interface to root finding algorithms for multivariate
-           functions. See ``method=='broyden1'`` in particular.
+           functions. See ``method='broyden1'`` in particular.
 
     Notes
     -----
@@ -929,7 +929,7 @@ class BroydenSecond(BroydenFirst):
     See Also
     --------
     root : Interface to root finding algorithms for multivariate
-           functions. See ``method=='broyden2'`` in particular.
+           functions. See ``method='broyden2'`` in particular.
 
     Notes
     -----
@@ -1001,7 +1001,7 @@ class Anderson(GenericBroyden):
     See Also
     --------
     root : Interface to root finding algorithms for multivariate
-           functions. See ``method=='anderson'`` in particular.
+           functions. See ``method='anderson'`` in particular.
 
     References
     ----------
@@ -1156,7 +1156,7 @@ class DiagBroyden(GenericBroyden):
     See Also
     --------
     root : Interface to root finding algorithms for multivariate
-           functions. See ``method=='diagbroyden'`` in particular.
+           functions. See ``method='diagbroyden'`` in particular.
 
     Examples
     --------
@@ -1221,7 +1221,7 @@ class LinearMixing(GenericBroyden):
     See Also
     --------
     root : Interface to root finding algorithms for multivariate
-           functions. See ``method=='linearmixing'`` in particular.
+           functions. See ``method='linearmixing'`` in particular.
 
     """
 
@@ -1262,7 +1262,7 @@ class ExcitingMixing(GenericBroyden):
     See Also
     --------
     root : Interface to root finding algorithms for multivariate
-           functions. See ``method=='excitingmixing'`` in particular.
+           functions. See ``method='excitingmixing'`` in particular.
 
     Parameters
     ----------
@@ -1360,7 +1360,7 @@ class KrylovJacobian(Jacobian):
     See Also
     --------
     root : Interface to root finding algorithms for multivariate
-           functions. See ``method=='krylov'`` in particular.
+           functions. See ``method='krylov'`` in particular.
     scipy.sparse.linalg.gmres
     scipy.sparse.linalg.lgmres
 

--- a/scipy/sparse/linalg/_expm_multiply.py
+++ b/scipy/sparse/linalg/_expm_multiply.py
@@ -142,7 +142,7 @@ def expm_multiply(A, B, start=None, stop=None, num=None,
     Warns
     -----
     UserWarning
-        If `A` is a linear operator and ``traceA==None`` (default).
+        If `A` is a linear operator and ``traceA=None`` (default).
 
     Notes
     -----

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -1510,7 +1510,7 @@ class rv_generic:
         ``ppf`` is the inverse cumulative distribution function and
         ``p_tail = (1-confidence)/2``. Suppose ``[c, d]`` is the support of a
         discrete distribution; then ``ppf([0, 1]) == (c-1, d)``. Therefore,
-        when ``confidence==1`` and the distribution is discrete, the left end
+        when ``confidence=1`` and the distribution is discrete, the left end
         of the interval will be beyond the support of the distribution.
         For discrete distributions, the interval will limit the probability
         in each tail to be less than or equal to ``p_tail`` (usually

--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -1571,7 +1571,7 @@ def cramervonmises_2samp(x, y, method='auto'):
     - ``exact``: The exact p-value is computed by enumerating all
       possible combinations of the test statistic, see [2]_.
 
-    If ``method=='auto'``, the exact approach is used
+    If ``method='auto'``, the exact approach is used
     if both samples contain equal to or less than 20 observations,
     otherwise the asymptotic distribution is used.
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Follow up to #17199
#### What does this implement/fix?
<!--Please explain your changes.-->

In the review it was agreed (https://github.com/scipy/scipy/pull/17199#issuecomment-1304352569) that `=` was preferred over `==` when referring to specific argument values. This pr changes the remaining occurrences so they are all consistent.

> A quick grep gives:
>== (``[\w]+==[\w'"]+``) : 29 occurrences
>= (``[\w]+=[\w'"]+``): 497 occurrences
>So it looks like = is the more frequently used.

#### Additional information
<!--Any additional information you think is important.-->
