### PR TITLE
WHL: bump macos image, OpenBLAS version, gfortran-11, MACOSX_DEPLOYMENT_TARGET=10.11

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -39,38 +39,13 @@ jobs:
         cache: 'pip'
         cache-dependency-path: 'environment.yml'
 
-    - name: Setup gfortran
+    - name: Install gfortran + OpenBLAS
       run: |
         # this is taken verbatim from the numpy azure pipeline setup.
         set -xe
-        # same version of gfortran as the open-libs and numpy-wheel builds
-        curl -L https://github.com/MacPython/gfortran-install/raw/master/archives/gfortran-4.9.0-Mavericks.dmg -o gfortran.dmg
-        GFORTRAN_SHA256=$(shasum -a 256 gfortran.dmg)
-        KNOWN_SHA256="d2d5ca5ba8332d63bbe23a07201c4a0a5d7e09ee56f0298a96775f928c3c4b30  gfortran.dmg"
-        if [ "$GFORTRAN_SHA256" != "$KNOWN_SHA256" ]; then
-            echo sha256 mismatch
-            exit 1
-        fi
-        hdiutil attach -mountpoint /Volumes/gfortran gfortran.dmg
-        sudo installer -pkg /Volumes/gfortran/gfortran.pkg -target /
-        otool -L /usr/local/gfortran/lib/libgfortran.3.dylib
-        # Manually symlink gfortran-4.9 to plain gfortran for f2py.
-        # No longer needed after Feb 13 2020 as gfortran is already present
-        # and the attempted link errors. Keep this for future reference.
-        # ln -s /usr/local/bin/gfortran-4.9 /usr/local/bin/gfortran
-
-    - name: Setup openblas
-      run: |
-        # this is taken verbatim from the numpy azure pipeline setup.
-        set -xe
-        target=$(python tools/openblas_support.py)
-        ls -lR $target
-        # manually link to appropriate system paths
-        cp $target/lib/lib* /usr/local/lib/
-        cp $target/include/* /usr/local/include/
-
-        # otool -L /usr/local/lib/libopenblas*
-
+        bash tools/wheel/cibw_before_build_macos.sh $PWD
+        
+        # create site.cfg
         echo "[openblas]" > site.cfg
         echo "libraries = openblas" >> site.cfg
         echo "library_dirs = /usr/local/lib" >> site.cfg
@@ -88,6 +63,8 @@ jobs:
         pip install setuptools==59.8.0 wheel cython pytest pytest-xdist pytest-timeout pybind11 pytest-xdist mpmath gmpy2 pythran pooch
 
     - name: Test SciPy
+      env:
+        SDKROOT=/Applications/Xcode_11.7.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk MACOSX_DEPLOYMENT_TARGET=10.11
       run: |
         export LIBRARY_PATH="$LIBRARY_PATH:/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib"
         SCIPY_USE_PYTHRAN=`test ${{ matrix.python-version }} != 3.9; echo $?` python -u runtests.py -- --durations=10 --timeout=60

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -64,7 +64,7 @@ jobs:
 
     - name: Test SciPy
       env:
-        SDKROOT=/Applications/Xcode_11.7.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk MACOSX_DEPLOYMENT_TARGET=10.11
+        SDKROOT: /Applications/Xcode_11.7.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk MACOSX_DEPLOYMENT_TARGET=10.11
       run: |
-        export LIBRARY_PATH="$LIBRARY_PATH:/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib"
+        # export LIBRARY_PATH="$LIBRARY_PATH:/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib"
         SCIPY_USE_PYTHRAN=`test ${{ matrix.python-version }} != 3.9; echo $?` python -u runtests.py -- --durations=10 --timeout=60

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -41,9 +41,8 @@ jobs:
 
     - name: Install gfortran + OpenBLAS
       run: |
-        # this is taken verbatim from the numpy azure pipeline setup.
         set -xe
-        bash tools/wheel/cibw_before_build_macos.sh $PWD
+        bash tools/wheels/cibw_before_build_macos.sh $PWD
         
         # create site.cfg
         echo "[openblas]" > site.cfg

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -63,7 +63,7 @@ jobs:
 
     - name: Test SciPy
       env:
-        SDKROOT: /Applications/Xcode_11.7.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk MACOSX_DEPLOYMENT_TARGET=10.11
+        SDKROOT: /Applications/Xcode_11.7.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk
       run: |
         # export LIBRARY_PATH="$LIBRARY_PATH:/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib"
         SCIPY_USE_PYTHRAN=`test ${{ matrix.python-version }} != 3.9; echo $?` python -u runtests.py -- --durations=10 --timeout=60

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -58,6 +58,7 @@ jobs:
           echo "message=$RUN" >> $GITHUB_OUTPUT
           echo github.ref ${{ github.ref }}
 
+
   build_wheels:
     name: Build wheel for ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }} ${{ matrix.buildplat[2] }}
     needs: get_commit_message
@@ -85,7 +86,7 @@ jobs:
         # recent gfortran (gfortran-9 is present on the macOS-11.0 image), and
         # will probably require that the prebuilt openBLAS is updated.
         # xref https://github.com/andyfaff/scipy/pull/28#issuecomment-1203496836
-        - [macos-10.15, macosx, x86_64]
+        - [macos-11, macosx, x86_64]
         - [macos-12, macosx, arm64]
         - [windows-2019, win, AMD64]
 
@@ -116,7 +117,7 @@ jobs:
           submodules: true
           fetch-depth: 0
 
-      - uses: actions/setup-python@v4.2.0
+      - uses: actions/setup-python@v4.3.0
         with:
           python-version: 3.8
 
@@ -140,7 +141,7 @@ jobs:
 #        if: ${{ runner.os == 'Windows' && env.IS_32_BIT == 'true' }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.10.1
+        uses: pypa/cibuildwheel@v2.11.2
         # Build all wheels here, apart from macosx_arm64, linux_aarch64
         # cibuildwheel is currently unable to pass configuration flags to
         # CIBW_BUILD_FRONTEND https://github.com/pypa/cibuildwheel/issues/1227
@@ -155,6 +156,12 @@ jobs:
           CIBW_BUILD: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}*
           CIBW_ARCHS: ${{ matrix.buildplat[2] }}
           CIBW_ENVIRONMENT_PASS_LINUX: RUNNER_OS
+          CIBW_ENVIRONMENT_MACOS: >
+            SDKROOT=/Applications/Xcode_11.7.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk MACOSX_DEPLOYMENT_TARGET=10.11
+          CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
+            DYLD_LIBRARY_PATH=/usr/local/gfortran/lib delocate-listdeps {wheel} &&
+            DYLD_LIBRARY_PATH=/usr/local/gfortran/lib delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}
+
 
       - name: Build cp38-macosx_arm64
         # This is solely used to build cp38-macosx_arm64. As soon as 3.8 is
@@ -181,26 +188,34 @@ jobs:
           # The install script requires the PLAT variable in order to set
           # the FC variable
           export PLAT=arm64
+
           install_arm64_cross_gfortran
           export FC=$FC_ARM64
-          export PATH=$FC_LOC:$PATH
+          F_LOC=/opt/gfortran-darwin-arm64-cross
+          export PATH=$F_LOC/bin:$PATH
+          sudo ln -s $FC $F_LOC/bin/gfortran
+          libgfortran="$(find $F_LOC/lib -name libgfortran.dylib)"
+          echo $libgfortran
+          FC_LIBDIR=$(dirname $libgfortran)  
+          echo $FC_LIBDIR
 
           export FFLAGS=" -arch arm64 $FFLAGS"
           export LDFLAGS=" $FC_ARM64_LDFLAGS $LDFLAGS -L/opt/arm64-builds/lib -arch arm64"
-          sudo ln -s $FC $FC_LOC/gfortran
           echo $(type -p gfortran)
+
+          # having a test fortran program has helped in debugging problems with the
+          # compiler environment.
+          # $FC $FFLAGS tools/wheels/test.f $LDFLAGS
+          $FC tools/wheels/test.f
+          ls -al *.out
+          otool -L a.out
+          lipo -info a.out
 
           # OpenBLAS
           curl -L https://anaconda.org/multibuild-wheels-staging/openblas-libs/v0.3.20-140-gbfd9c1b5/download/openblas-v0.3.20-140-gbfd9c1b5-macosx_11_0_arm64-gf_f26990f.tar.gz -o openblas.tar.gz
           sudo tar -xv -C / -f openblas.tar.gz
           # force a dynamic link, there may be a more elegant way of doing this.
           sudo rm /opt/arm64-builds/lib/*.a
-
-          # having a test fortran program has helped in debugging problems with the
-          # compiler environment.
-          $FC $FFLAGS tools/wheels/test.f $LDFLAGS
-          ls -al *.out
-          otool -L a.out      
 
           export PKG_CONFIG_PATH=/opt/arm64-builds/lib/pkgconfig
           export PKG_CONFIG=/usr/local/bin/pkg-config
@@ -232,7 +247,7 @@ jobs:
           # The `.so` are all converted to `-rpath/libgfortran` by
           # gfortran/meson, with all absolute paths removed.
           # Enables delocate to find the libopenblas/libgfortran libraries.
-          export DYLD_LIBRARY_PATH=/opt/gfortran-darwin-arm64/lib/gcc/arm64-apple-darwin20.0.0/10.2.1:/opt/arm64-builds/lib
+          export DYLD_LIBRARY_PATH=$FC_LIBDIR:/opt/arm64-builds/lib
           delocate-listdeps dist/scipy*.whl
           delocate-wheel --require-archs=arm64 -k -w wheelhouse dist/scipy*.whl
 

--- a/ci/cirrus_wheels.yml
+++ b/ci/cirrus_wheels.yml
@@ -1,6 +1,6 @@
 build_and_store_wheels: &BUILD_AND_STORE_WHEELS
   install_cibuildwheel_script:
-    - python -m pip install cibuildwheel==2.10.1
+    - python -m pip install cibuildwheel==2.11.2
   cibuildwheel_script:
     - cibuildwheel
   wheels_artifacts:

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -13,8 +13,8 @@ from tempfile import mkstemp, gettempdir
 from urllib.request import urlopen, Request
 from urllib.error import HTTPError
 
-OPENBLAS_V = '0.3.18'
-OPENBLAS_LONG = 'v0.3.18'
+OPENBLAS_V = '0.3.21'
+OPENBLAS_LONG = 'v0.3.21'
 BASE_LOC = 'https://anaconda.org/multibuild-wheels-staging/openblas-libs'
 BASEURL = f'{BASE_LOC}/{OPENBLAS_LONG}/download'
 SUPPORTED_PLATFORMS = [
@@ -77,7 +77,7 @@ def download_openblas(target, plat, ilp64):
         suffix = f'manylinux{ml_ver}_{arch}.tar.gz'
         typ = 'tar.gz'
     elif plat == 'macosx-x86_64':
-        suffix = 'macosx_10_9_x86_64-gf_1becaaa.tar.gz'
+        suffix = 'macosx_10_11_x86_64-gf_dd3e148.tar.gz'
         typ = 'tar.gz'
     elif plat == 'macosx-arm64':
         suffix = 'macosx_11_0_arm64-gf_f26990f.tar.gz'

--- a/tools/wheels/cibw_before_build_macos.sh
+++ b/tools/wheels/cibw_before_build_macos.sh
@@ -18,21 +18,15 @@ if [[ $PLATFORM == "macosx-x86_64" ]]; then
   cp -r $basedir/lib/* /usr/local/lib
   cp $basedir/include/* /usr/local/include
 
-  #GFORTRAN=$(type -p gfortran-9)
-  #sudo ln -s $GFORTRAN /usr/local/bin/gfortran
-  # same version of gfortran as the openblas-libs and scipy-wheel builds
-  curl -L https://github.com/MacPython/gfortran-install/raw/master/archives/gfortran-4.9.0-Mavericks.dmg -o gfortran.dmg
-  GFORTRAN_SHA256=$(shasum -a 256 gfortran.dmg)
-  KNOWN_SHA256="d2d5ca5ba8332d63bbe23a07201c4a0a5d7e09ee56f0298a96775f928c3c4b30  gfortran.dmg"
-  if [ "$GFORTRAN_SHA256" != "$KNOWN_SHA256" ]; then
-      echo sha256 mismatch
-      exit 1
-  fi
+  source tools/wheels/gfortran_utils.sh
+  # for this compiler to work SDKROOT needs to be set, along the lines of
+  # export SDKROOT=/Applications/Xcode_11.7.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk
+  install_gfortran
 
-  hdiutil attach -mountpoint /Volumes/gfortran gfortran.dmg
-  sudo installer -pkg /Volumes/gfortran/gfortran.pkg -target /
-  otool -L /usr/local/gfortran/lib/libgfortran.3.dylib
+  type -p gfortran
+  gfortran --version
 fi
+
 
 if [[ $PLATFORM == "macosx-arm64" ]]; then
   # OpenBLAS

--- a/tools/wheels/cross_arm64.txt
+++ b/tools/wheels/cross_arm64.txt
@@ -9,7 +9,7 @@
 c = ['clang', '-arch', 'arm64']
 cpp = ['clang++', '-arch', 'arm64']
 strip = ['strip']
-fortran = ['/opt/gfortran-darwin-arm64/bin/arm64-apple-darwin20.0.0-gfortran']
+fortran = ['/opt/gfortran-darwin-arm64-cross/bin/gfortran']
 pkg-config = '/usr/local/bin/pkg-config'
 
 [host_machine]


### PR DESCRIPTION
Github Actions is going to shutdown the macos-10.15 image at some point in the near future. This is going to involve a few changes to wheel building/CI infrastructure. This PR implements the required changes.

1. The wheel building will have to occur on at least the `macos-11` image.
2. The venerable `gfortran-4.9` won't work on that image, so a bump to the gfortran compiler (targetting macosx_x86_64) is definitely necessary.
3. [gfortran from a repackaged conda tarball](https://github.com/MacPython/gfortran-install/pull/11/files) seemed like a good way to go about things. This is because this compiler can build for older `MACOSX_DEPLOYMENT_TARGET`, whereas other available gfortran compilers could only target later macOS versions (e.g. 11.5, 10.15). This particular PR bumps to `gfortran-11` for the `macos_x86_64` native build and the the `cp38-macosx_arm64` cross build. (@isuruf did some nice work on making the compiler package).
4. There are OpenBLAS builds for` openblas-v0.3.21-macosx_10_11_x86_64` on anaconda, so this PR takes the opportunity to bump the OpenBLAS version to v0.3.21 for wheel builds, and to bump the MACOSX_DEPLOYMENT_TARGET to 10.11. There is an open [numpy PR](https://github.com/numpy/numpy/pull/22534) bumping to OpenBLAS v0.3.21.

Hopefully changing the deployment target to 10.11 isn't controversial, Yosemite (10.10) ran out of support in 2017. It may be possible to retain 10.9 compatibility (and even OpenBLAS v0.3.18), but that would require more experimentation. Now seems like a good idea to bump things.

CI configurations for non-wheel runs were not touched.

CC: @charris @rgommers @h-vetinari @mattip 