### PR TITLE
BLD: update to Meson 0.64.0, remove `pure: false` lines

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - setuptools<60.0
   - cython
   - compilers
-  - meson>=0.63.0
+  - meson>=0.64.0
   - meson-python
   - ninja
   - numpy

--- a/meson.build
+++ b/meson.build
@@ -6,7 +6,7 @@ project(
   # tools/version_utils.py
   version: '1.10.0.dev0',
   license: 'BSD-3',
-  meson_version: '>= 0.63.0',
+  meson_version: '>= 0.64.0',
   default_options: [
     'buildtype=debugoptimized',
     'c_std=c99',
@@ -119,9 +119,7 @@ copier = find_program(['cp', 'scipy/_build_utils/copyfiles.py'])
 
 # https://mesonbuild.com/Python-module.html
 py_mod = import('python')
-# NOTE: with Meson >=0.64.0 we can add `pure: false` here and remove that line
-# everywhere else, see https://github.com/mesonbuild/meson/pull/10783.
-py3 = py_mod.find_installation()
+py3 = py_mod.find_installation(pure: false)
 py3_dep = py3.dependency()
 
 # For now, keep supporting this environment variable (same as in setup.py)

--- a/scipy/_lib/_uarray/meson.build
+++ b/scipy/_lib/_uarray/meson.build
@@ -15,6 +15,5 @@ python_sources = [
 
 py3.install_sources(
   python_sources,
-  pure: false,
   subdir: 'scipy/_lib/_uarray'
 )

--- a/scipy/_lib/meson.build
+++ b/scipy/_lib/meson.build
@@ -126,8 +126,7 @@ python_sources = [
 
 py3.install_sources(
   python_sources,
-  pure: false,          # Will be installed next to binaries
-  subdir: 'scipy/_lib'  # Folder relative to site-packages to install to
+  subdir: 'scipy/_lib'
 )
 
 subdir('_uarray')

--- a/scipy/_lib/tests/meson.build
+++ b/scipy/_lib/tests/meson.build
@@ -16,6 +16,5 @@ python_sources = [
 
 py3.install_sources(
   python_sources,
-  pure: false,
   subdir: 'scipy/_lib/tests'
 )

--- a/scipy/cluster/meson.build
+++ b/scipy/cluster/meson.build
@@ -31,8 +31,7 @@ py3.install_sources([
     'hierarchy.py',
     'vq.py'
   ],
-  pure: false,             # Will be installed next to binaries
-  subdir: 'scipy/cluster'  # Folder relative to site-packages to install to
+  subdir: 'scipy/cluster'
 )
 
 subdir('tests')

--- a/scipy/cluster/tests/meson.build
+++ b/scipy/cluster/tests/meson.build
@@ -9,6 +9,5 @@ python_sources = [
 
 py3.install_sources(
   python_sources,
-  pure: false,
   subdir: 'scipy/cluster/tests'
 )

--- a/scipy/constants/meson.build
+++ b/scipy/constants/meson.build
@@ -9,7 +9,6 @@ python_sources = [
 
 py3.install_sources(
   python_sources,
-  pure: false,
   subdir: 'scipy/constants'
 )
 

--- a/scipy/constants/tests/meson.build
+++ b/scipy/constants/tests/meson.build
@@ -6,6 +6,5 @@ python_sources = [
 
 py3.install_sources(
   python_sources,
-  pure: false,
   subdir: 'scipy/constants/tests'
 )

--- a/scipy/datasets/meson.build
+++ b/scipy/datasets/meson.build
@@ -6,7 +6,6 @@ python_sources = [
 
 py3.install_sources(
   python_sources,
-  pure: false,
   subdir: 'scipy/datasets'
 )
 

--- a/scipy/datasets/tests/meson.build
+++ b/scipy/datasets/tests/meson.build
@@ -5,6 +5,5 @@ python_sources = [
 
 py3.install_sources(
   python_sources,
-  pure: false,
   subdir: 'scipy/datasets/tests'
 )

--- a/scipy/fft/_pocketfft/meson.build
+++ b/scipy/fft/_pocketfft/meson.build
@@ -46,7 +46,6 @@ python_sources = [
 
 py3.install_sources(
   python_sources,
-  pure: false,
   subdir: 'scipy/fft/_pocketfft'
 )
 

--- a/scipy/fft/_pocketfft/tests/meson.build
+++ b/scipy/fft/_pocketfft/tests/meson.build
@@ -6,6 +6,5 @@ python_sources = [
 
 py3.install_sources(
   python_sources,
-  pure: false,
   subdir: 'scipy/fft/_pocketfft/tests'
 )

--- a/scipy/fft/meson.build
+++ b/scipy/fft/meson.build
@@ -12,8 +12,7 @@ python_sources = [
 
 py3.install_sources(
   python_sources,
-  pure: false,         # Will be installed next to binaries
-  subdir: 'scipy/fft'  # Folder relative to site-packages to install to
+  subdir: 'scipy/fft'
 )
 
 subdir('_pocketfft')

--- a/scipy/fft/tests/meson.build
+++ b/scipy/fft/tests/meson.build
@@ -12,6 +12,5 @@ python_sources = [
 
 py3.install_sources(
   python_sources,
-  pure: false,
   subdir: 'scipy/fft/tests'
 )

--- a/scipy/fftpack/meson.build
+++ b/scipy/fftpack/meson.build
@@ -23,8 +23,7 @@ python_sources = [
 
 py3.install_sources(
   python_sources,
-  pure: false,             # Will be installed next to binaries
-  subdir: 'scipy/fftpack'  # Folder relative to site-packages to install to
+  subdir: 'scipy/fftpack'
 )
 
 subdir('tests')

--- a/scipy/fftpack/tests/meson.build
+++ b/scipy/fftpack/tests/meson.build
@@ -16,6 +16,5 @@ test_sources = [
 
 py3.install_sources(
   [python_sources, test_sources],
-  pure: false,
   subdir: 'scipy/fftpack/tests'
 )

--- a/scipy/integrate/_ivp/meson.build
+++ b/scipy/integrate/_ivp/meson.build
@@ -9,7 +9,6 @@ py3.install_sources([
     'radau.py',
     'rk.py'
   ],
-  pure: false,
   subdir: 'scipy/integrate/_ivp'
 )
 

--- a/scipy/integrate/_ivp/tests/meson.build
+++ b/scipy/integrate/_ivp/tests/meson.build
@@ -2,6 +2,5 @@ py3.install_sources([
     'test_ivp.py',
     'test_rk.py'
   ],
-  pure: false,
   subdir: 'scipy/integrate/_ivp/tests'
 )

--- a/scipy/integrate/meson.build
+++ b/scipy/integrate/meson.build
@@ -221,6 +221,5 @@ py3.install_sources([
     'quadpack.py',
     'vode.py',
   ],
-  pure: false,
   subdir: 'scipy/integrate'
 )

--- a/scipy/integrate/tests/meson.build
+++ b/scipy/integrate/tests/meson.build
@@ -8,6 +8,5 @@ py3.install_sources([
     'test_quadpack.py',
     'test_quadrature.py'
   ],
-  pure: false,
   subdir: 'scipy/integrate/tests'
 )

--- a/scipy/interpolate/meson.build
+++ b/scipy/interpolate/meson.build
@@ -178,7 +178,6 @@ if use_pythran
 else
   py3.install_sources(
     ['_rbfinterp_pythran.py'],
-    pure: false,
     subdir: 'scipy/interpolate'
   )
 endif
@@ -205,7 +204,6 @@ py3.install_sources([
     'polyint.py',
     'rbf.py'
   ],
-  pure: false,
   subdir: 'scipy/interpolate'
 )
 

--- a/scipy/interpolate/tests/meson.build
+++ b/scipy/interpolate/tests/meson.build
@@ -13,7 +13,6 @@ py3.install_sources([
     'test_rbfinterp.py', 
     'test_rgi.py'
   ],
-  pure: false,
   subdir: 'scipy/interpolate/tests'
 )
 
@@ -21,6 +20,5 @@ py3.install_sources([
     'data/bug-1310.npz',
     'data/estimate_gradients_hang.npy'
   ],
-  pure: false,
   subdir: 'scipy/interpolate/tests/data'
 )

--- a/scipy/io/_harwell_boeing/meson.build
+++ b/scipy/io/_harwell_boeing/meson.build
@@ -3,7 +3,6 @@ py3.install_sources([
     '_fortran_format_parser.py',
     'hb.py'
   ],
-  pure: false,
   subdir: 'scipy/io/_harwell_boeing'
 )
 

--- a/scipy/io/_harwell_boeing/tests/meson.build
+++ b/scipy/io/_harwell_boeing/tests/meson.build
@@ -3,6 +3,5 @@ py3.install_sources([
     'test_fortran_format.py',
     'test_hb.py'
   ],
-  pure: false,
   subdir: 'scipy/io/_harwell_boeing/tests'
 )

--- a/scipy/io/arff/meson.build
+++ b/scipy/io/arff/meson.build
@@ -3,7 +3,6 @@ py3.install_sources([
     '_arffread.py',
     'arffread.py'
   ],
-  pure: false,
   subdir: 'scipy/io/arff'
 )
 

--- a/scipy/io/arff/tests/meson.build
+++ b/scipy/io/arff/tests/meson.build
@@ -2,7 +2,6 @@ py3.install_sources([
     '__init__.py',
     'test_arffread.py'
   ],
-  pure: false,
   subdir: 'scipy/io/arff/tests'
 )
 
@@ -24,6 +23,5 @@ py3.install_sources([
     'data/test8.arff',
     'data/test9.arff'
   ],
-  pure: false,
   subdir: 'scipy/io/arff/tests/data'
 )

--- a/scipy/io/matlab/meson.build
+++ b/scipy/io/matlab/meson.build
@@ -42,7 +42,6 @@ py3.install_sources([
     'miobase.py',
     'streams.py'
   ],
-  pure: false,
   subdir: 'scipy/io/matlab'
 )
 

--- a/scipy/io/matlab/tests/meson.build
+++ b/scipy/io/matlab/tests/meson.build
@@ -9,7 +9,6 @@ py3.install_sources([
     'test_pathological.py',
     'test_streams.py'
   ],
-  pure: false,
   subdir: 'scipy/io/matlab/tests'
 )
 
@@ -125,6 +124,5 @@ py3.install_sources([
     'data/testunicode_7.4_GLNX86.mat',
     'data/testvec_4_GLNX86.mat'
   ],
-  pure: false,
   subdir: 'scipy/io/matlab/tests/data'
 )

--- a/scipy/io/meson.build
+++ b/scipy/io/meson.build
@@ -31,7 +31,6 @@ py3.install_sources([
     'netcdf.py',
     'wavfile.py'
   ],
-  pure: false,
   subdir: 'scipy/io'
 )
 

--- a/scipy/io/tests/meson.build
+++ b/scipy/io/tests/meson.build
@@ -7,7 +7,6 @@ py3.install_sources([
     'test_paths.py',
     'test_wavfile.py'
   ],
-  pure: false,
   subdir: 'scipy/io/tests'
 )
 
@@ -98,6 +97,5 @@ py3.install_sources([
     'data/test-8000Hz-le-5ch-9S-5bit.wav',
     'data/various_compressed.sav'
   ],
-  pure: false,
   subdir: 'scipy/io/tests/data'
 )

--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -28,7 +28,7 @@ cython_linalg = custom_target('cython_linalg',
   # TODO - we only want to install the .pxd files! See comments for
   #        `pxd_files` further down.
   install: true,
-  install_dir: py3.get_install_dir(pure: false) / 'scipy/linalg'
+  install_dir: py3.get_install_dir() / 'scipy/linalg'
 )
 
 # pyx -> c, pyx -> cpp generators, depending on __init__.py here.
@@ -322,7 +322,6 @@ python_sources = [
 
 py3.install_sources(
   python_sources,
-  pure: false,
   subdir: 'scipy/linalg'
 )
 
@@ -333,7 +332,7 @@ py3.install_sources(
 #       https://mesonbuild.com/Installing.html says is for build targets to
 #       use:
 #         `custom_target(..., install: true, install_dir: ...)
-#         # should use `py3.get_install_dir(pure: false) / 'scipy/linalg'` ?
+#         # should use `py3.get_install_dir() / 'scipy/linalg'` ?
 #       see https://github.com/mesonbuild/meson/issues/3206
 #
 #       For the below code to work, the script generating the files should use
@@ -351,7 +350,7 @@ py3.install_sources(
 #  output : ['cython_blas2.pxd', 'cython_lapack2.pxd'],
 #  command : ['cp', '@INPUT0@', '@OUTPUT0@', '&&', 'cp', '@INPUT1@', '@OUTPUT1@'],
 #  install : true,
-#  install_dir: py3.get_install_dir(pure: false) / 'scipy/linalg'
+#  install_dir: py3.get_install_dir() / 'scipy/linalg'
 #)
 
 subdir('tests')

--- a/scipy/linalg/tests/data/meson.build
+++ b/scipy/linalg/tests/data/meson.build
@@ -10,6 +10,5 @@ npz_files = [
 
 py3.install_sources(
   npz_files,
-  pure: false,
   subdir: 'scipy/linalg/tests/data'
 )

--- a/scipy/linalg/tests/meson.build
+++ b/scipy/linalg/tests/meson.build
@@ -27,7 +27,6 @@ python_sources = [
 
 py3.install_sources(
   python_sources,
-  pure: false,
   subdir: 'scipy/linalg/tests'
 )
 

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -156,7 +156,7 @@ generate_config = custom_target(
   output: '__config__.py',
   input: '../tools/config_utils.py',
   command: [py3, '@INPUT@', '@OUTPUT@'],
-  install_dir: py3.get_install_dir(pure: false) / 'scipy'
+  install_dir: py3.get_install_dir() / 'scipy'
 )
 
 generate_version = custom_target(
@@ -167,7 +167,7 @@ generate_version = custom_target(
   output: 'version.py',
   input: '../tools/version_utils.py',
   command: [py3, '@INPUT@', '--source-root', '@SOURCE_ROOT@'],
-  install_dir: py3.get_install_dir(pure: false) / 'scipy'
+  install_dir: py3.get_install_dir() / 'scipy'
 )
 
 python_sources = [
@@ -181,13 +181,11 @@ python_sources = [
 
 py3.install_sources(
   python_sources,
-  pure: false,
   subdir: 'scipy'
 )
 
 py3.install_sources(
   ['_build_utils/tests/test_scipy_version.py'],
-  pure: false,
   subdir: 'scipy/_lib/tests'
 )
 

--- a/scipy/misc/meson.build
+++ b/scipy/misc/meson.build
@@ -7,7 +7,6 @@ python_sources = [
 
 py3.install_sources(
   python_sources,
-  pure: false,
   subdir: 'scipy/misc'
 )
 
@@ -16,7 +15,6 @@ py3.install_sources([
     'ecg.dat',
     'face.dat'
   ],
-  pure: false,
   subdir: 'scipy/misc'
 )
 

--- a/scipy/misc/tests/meson.build
+++ b/scipy/misc/tests/meson.build
@@ -6,6 +6,5 @@ python_sources = [
 
 py3.install_sources(
   python_sources,
-  pure: false,
   subdir: 'scipy/misc/tests'
 )

--- a/scipy/ndimage/meson.build
+++ b/scipy/ndimage/meson.build
@@ -62,8 +62,7 @@ python_sources = [
 
 py3.install_sources(
   python_sources,
-  pure: false,             # Will be installed next to binaries
-  subdir: 'scipy/ndimage'  # Folder relative to site-packages to install to
+  subdir: 'scipy/ndimage'
 )
 
 subdir('tests')

--- a/scipy/ndimage/tests/meson.build
+++ b/scipy/ndimage/tests/meson.build
@@ -13,7 +13,6 @@ python_sources = [
 
 py3.install_sources(
   python_sources,
-  pure: false,
   subdir: 'scipy/ndimage/tests'
 )
 
@@ -22,6 +21,5 @@ py3.install_sources([
     'data/label_results.txt',
     'data/label_strels.txt',
   ],
-  pure: false,
   subdir: 'scipy/ndimage/tests/data'
 )

--- a/scipy/odr/meson.build
+++ b/scipy/odr/meson.build
@@ -32,7 +32,6 @@ python_sources = [
 
 py3.install_sources(
   python_sources,
-  pure: false,
   subdir: 'scipy/odr'
 )
 

--- a/scipy/odr/tests/meson.build
+++ b/scipy/odr/tests/meson.build
@@ -5,6 +5,5 @@ python_sources = [
 
 py3.install_sources(
   python_sources,
-  pure: false,
   subdir: 'scipy/odr/tests'
 )

--- a/scipy/optimize/_highs/meson.build
+++ b/scipy/optimize/_highs/meson.build
@@ -275,12 +275,10 @@ py3.install_sources([
     'cython/src/SimplexConst.pxd',
     'cython/src/highs_c_api.pxd'
   ],
-  pure: false,
   subdir: 'scipy/optimize/_highs/src/cython'
 )
 
 py3.install_sources(
   ['__init__.py'],
-  pure: false,
   subdir: 'scipy/optimize/_highs'
 )

--- a/scipy/optimize/_lsq/meson.build
+++ b/scipy/optimize/_lsq/meson.build
@@ -17,6 +17,5 @@ py3.install_sources([
     'trf.py',
     'trf_linear.py'
   ],
-  pure: false,
   subdir: 'scipy/optimize/_lsq'
 )

--- a/scipy/optimize/_shgo_lib/meson.build
+++ b/scipy/optimize/_shgo_lib/meson.build
@@ -2,6 +2,5 @@ py3.install_sources([
     '__init__.py',
     'triangulation.py'
   ],
-  pure: false,
   subdir: 'scipy/optimize/_shgo_lib'
 )

--- a/scipy/optimize/_trlib/meson.build
+++ b/scipy/optimize/_trlib/meson.build
@@ -21,6 +21,5 @@ _trlib = py3.extension_module('_trlib',
 
 py3.install_sources(
   ['__init__.py'],
-  pure: false,
   subdir: 'scipy/optimize/_trlib'
 )

--- a/scipy/optimize/_trustregion_constr/meson.build
+++ b/scipy/optimize/_trustregion_constr/meson.build
@@ -10,6 +10,5 @@ py3.install_sources([
     'report.py',
     'tr_interior_point.py'
   ],
-  pure: false,
   subdir: 'scipy/optimize/_trustregion_constr'
 )

--- a/scipy/optimize/_trustregion_constr/tests/meson.build
+++ b/scipy/optimize/_trustregion_constr/tests/meson.build
@@ -5,6 +5,5 @@ py3.install_sources([
     'test_qp_subproblem.py',
     'test_report.py'
   ],
-  pure: false,
   subdir: 'scipy/optimize/_trustregion_constr/tests'
 )

--- a/scipy/optimize/cython_optimize/meson.build
+++ b/scipy/optimize/cython_optimize/meson.build
@@ -44,6 +44,5 @@ py3.install_sources([
     '_zeros.pxd',
     'c_zeros.pxd'
   ],
-  pure: false,
   subdir: 'scipy/optimize/cython_optimize'
 )

--- a/scipy/optimize/meson.build
+++ b/scipy/optimize/meson.build
@@ -188,7 +188,6 @@ __nnls_module = custom_target('__nnls_module',
 
 py3.install_sources(
   ['__nnls.pyi'],
-  pure: false,
   subdir: 'scipy/optimize'
 )
 
@@ -264,7 +263,6 @@ subdir('tests')
 
 py3.install_sources(
   ['lbfgsb_src/README'],
-  pure: false,
   subdir: 'scipy/optimize'
 )
 
@@ -322,6 +320,5 @@ py3.install_sources([
   'tnc.py',
   'zeros.py'
 ],
-  pure: false,
   subdir: 'scipy/optimize'
 )

--- a/scipy/optimize/tests/meson.build
+++ b/scipy/optimize/tests/meson.build
@@ -39,6 +39,5 @@ py3.install_sources([
     'test_trustregion_krylov.py',
     'test_zeros.py'
   ],
-  pure: false,
   subdir: 'scipy/optimize/tests'
 )

--- a/scipy/signal/meson.build
+++ b/scipy/signal/meson.build
@@ -137,7 +137,6 @@ py3.install_sources([
     'waveforms.py',
     'wavelets.py'
   ],
-  pure: false,
   subdir: 'scipy/signal'
 )
 

--- a/scipy/signal/tests/meson.build
+++ b/scipy/signal/tests/meson.build
@@ -20,6 +20,5 @@ py3.install_sources([
     'test_wavelets.py',
     'test_windows.py'
   ],
-  pure: false,
   subdir: 'scipy/signal/tests'
 )

--- a/scipy/signal/windows/meson.build
+++ b/scipy/signal/windows/meson.build
@@ -3,6 +3,5 @@ py3.install_sources([
   '_windows.py',
   'windows.py'
   ],
-  pure: false,
   subdir: 'scipy/signal/windows'
 )

--- a/scipy/sparse/csgraph/meson.build
+++ b/scipy/sparse/csgraph/meson.build
@@ -28,7 +28,6 @@ python_sources = [
 
 py3.install_sources(
   python_sources,
-  pure: false,
   subdir: 'scipy/sparse/csgraph'
 )
 

--- a/scipy/sparse/csgraph/tests/meson.build
+++ b/scipy/sparse/csgraph/tests/meson.build
@@ -14,6 +14,5 @@ python_sources = [
 
 py3.install_sources(
   python_sources,
-  pure: false,
   subdir: 'scipy/sparse/csgraph/tests'
 )

--- a/scipy/sparse/linalg/_dsolve/meson.build
+++ b/scipy/sparse/linalg/_dsolve/meson.build
@@ -209,7 +209,6 @@ py3.install_sources([
     '_add_newdocs.py',
     'linsolve.py'
   ],
-  pure: false,
   subdir: 'scipy/sparse/linalg/_dsolve'
 )
 

--- a/scipy/sparse/linalg/_dsolve/tests/meson.build
+++ b/scipy/sparse/linalg/_dsolve/tests/meson.build
@@ -2,6 +2,5 @@ py3.install_sources([
     '__init__.py',
     'test_linsolve.py'
   ],
-  pure: false,
   subdir: 'scipy/sparse/linalg/_dsolve/tests'
 )

--- a/scipy/sparse/linalg/_eigen/arpack/meson.build
+++ b/scipy/sparse/linalg/_eigen/arpack/meson.build
@@ -114,7 +114,6 @@ py3.install_sources([
     'arpack.py',
     'ARPACK/COPYING'
   ],
-  pure: false,
   subdir: 'scipy/sparse/linalg/_eigen/arpack'
 )
 

--- a/scipy/sparse/linalg/_eigen/arpack/tests/meson.build
+++ b/scipy/sparse/linalg/_eigen/arpack/tests/meson.build
@@ -2,6 +2,5 @@ py3.install_sources([
     '__init__.py',
     'test_arpack.py'
   ],
-  pure: false,
   subdir: 'scipy/sparse/linalg/_eigen/arpack/tests'
 )

--- a/scipy/sparse/linalg/_eigen/lobpcg/meson.build
+++ b/scipy/sparse/linalg/_eigen/lobpcg/meson.build
@@ -2,7 +2,6 @@ py3.install_sources([
     '__init__.py',
     'lobpcg.py'
   ],
-  pure: false,
   subdir: 'scipy/sparse/linalg/_eigen/lobpcg'
 )
 

--- a/scipy/sparse/linalg/_eigen/lobpcg/tests/meson.build
+++ b/scipy/sparse/linalg/_eigen/lobpcg/tests/meson.build
@@ -2,6 +2,5 @@ py3.install_sources([
     '__init__.py',
     'test_lobpcg.py'
   ],
-  pure: false,
   subdir: 'scipy/sparse/linalg/_eigen/lobpcg/tests'
 )

--- a/scipy/sparse/linalg/_eigen/meson.build
+++ b/scipy/sparse/linalg/_eigen/meson.build
@@ -3,7 +3,6 @@ py3.install_sources([
     '_svds.py',
     '_svds_doc.py'
   ],
-  pure: false,
   subdir: 'scipy/sparse/linalg/_eigen'
 )
 

--- a/scipy/sparse/linalg/_eigen/tests/meson.build
+++ b/scipy/sparse/linalg/_eigen/tests/meson.build
@@ -2,6 +2,5 @@ py3.install_sources([
     '__init__.py',
     'test_svds.py'
   ],
-  pure: false,
   subdir: 'scipy/sparse/linalg/_eigen/tests'
 )

--- a/scipy/sparse/linalg/_isolve/meson.build
+++ b/scipy/sparse/linalg/_isolve/meson.build
@@ -91,7 +91,6 @@ py3.install_sources([
     'tfqmr.py',
     'utils.py',
   ],
-  pure: false,
   subdir: 'scipy/sparse/linalg/_isolve'
 )
 

--- a/scipy/sparse/linalg/_isolve/tests/meson.build
+++ b/scipy/sparse/linalg/_isolve/tests/meson.build
@@ -8,6 +8,5 @@ py3.install_sources([
     'test_minres.py',
     'test_utils.py'
   ],
-  pure: false,
   subdir: 'scipy/sparse/linalg/_isolve/tests'
 )

--- a/scipy/sparse/linalg/meson.build
+++ b/scipy/sparse/linalg/meson.build
@@ -12,7 +12,6 @@ py3.install_sources([
     'isolve.py',
     'matfuncs.py'
   ],
-  pure: false,
   subdir: 'scipy/sparse/linalg'
 )
 

--- a/scipy/sparse/linalg/tests/meson.build
+++ b/scipy/sparse/linalg/tests/meson.build
@@ -9,6 +9,5 @@ py3.install_sources([
     'test_propack.py',
     'test_pydata_sparse.py'
   ],
-  pure: false,
   subdir: 'scipy/sparse/linalg/tests'
 )

--- a/scipy/sparse/meson.build
+++ b/scipy/sparse/meson.build
@@ -52,7 +52,6 @@ python_sources = [
 
 py3.install_sources(
   python_sources,
-  pure: false,
   subdir: 'scipy/sparse'
 )
 

--- a/scipy/sparse/tests/meson.build
+++ b/scipy/sparse/tests/meson.build
@@ -15,7 +15,6 @@ python_sources = [
 
 py3.install_sources(
   python_sources,
-  pure: false,
   subdir: 'scipy/sparse/tests'
 )
 
@@ -26,6 +25,5 @@ data_sources = [
 
 py3.install_sources(
   data_sources,
-  pure: false,
   subdir: 'scipy/sparse/tests/data'
 )

--- a/scipy/spatial/meson.build
+++ b/scipy/spatial/meson.build
@@ -110,7 +110,6 @@ _hausdorff = py3.extension_module('_hausdorff',
 py3.install_sources([
     'qhull_src/COPYING.txt'
   ],
-  pure: false,
   subdir: 'scipy/spatial/qhull_src'
 )
 
@@ -120,7 +119,6 @@ py3.install_sources([
     '_voronoi.pyi',
     'distance.pyi'
   ],
-  pure: false,
   subdir: 'scipy/spatial'
 )
 
@@ -136,7 +134,6 @@ py3.install_sources([
     'kdtree.py',
     'qhull.py'
   ],
-  pure: false,
   subdir: 'scipy/spatial'
 )
 

--- a/scipy/spatial/tests/meson.build
+++ b/scipy/spatial/tests/meson.build
@@ -9,7 +9,6 @@ py3.install_sources([
     'test_slerp.py',
     'test_spherical_voronoi.py'
   ],
-  pure: false,
   subdir: 'scipy/spatial/tests'
 )
 
@@ -46,6 +45,5 @@ py3.install_sources([
     'data/random-uint-data.txt',
     'data/selfdual-4d-polytope.txt'
   ],
-  pure: false,
   subdir: 'scipy/spatial/tests/data'
 )

--- a/scipy/spatial/transform/meson.build
+++ b/scipy/spatial/transform/meson.build
@@ -9,7 +9,6 @@ rotation = py3.extension_module('_rotation',
 
 py3.install_sources(
   '_rotation.pyi',
-  pure: false,
   subdir: 'scipy/spatial/transform'
 )
 
@@ -19,7 +18,6 @@ py3.install_sources([
     '_rotation_spline.py',
     'rotation.py'
   ],
-  pure: false,
   subdir: 'scipy/spatial/transform'
 )
 

--- a/scipy/spatial/transform/tests/meson.build
+++ b/scipy/spatial/transform/tests/meson.build
@@ -4,6 +4,5 @@ py3.install_sources([
     'test_rotation_groups.py',
     'test_rotation_spline.py'
   ],
-  pure: false,
   subdir: 'scipy/spatial/transform/tests'
 )

--- a/scipy/special/_precompute/meson.build
+++ b/scipy/special/_precompute/meson.build
@@ -17,6 +17,5 @@ python_sources = [
 
 py3.install_sources(
   python_sources,
-  pure: false,
   subdir: 'scipy/special/_precompute'
 )

--- a/scipy/special/meson.build
+++ b/scipy/special/meson.build
@@ -342,7 +342,7 @@ cython_special = custom_target('cython_special',
   input: ['_generate_pyx.py', 'functions.json', '_add_newdocs.py'],
   command: [py3, '@INPUT0@', '-o', '@OUTDIR@'],
   install: true,
-  install_dir: py3.get_install_dir(pure: false) / 'scipy/special'
+  install_dir: py3.get_install_dir() / 'scipy/special'
 )
 
 # pyx -> c, pyx -> cpp generators, depending on copied pxi, pxd files.
@@ -494,7 +494,7 @@ foreach npz_file: npz_files
       '--use-timestamp', npz_file[2], '-o', '@OUTDIR@'
     ],
     install: true,
-    install_dir: py3.get_install_dir(pure: false) / 'scipy/special/tests/data'
+    install_dir: py3.get_install_dir() / 'scipy/special/tests/data'
   )
 endforeach
 
@@ -525,7 +525,6 @@ python_sources = [
 
 py3.install_sources(
   python_sources,
-  pure: false,
   subdir: 'scipy/special'
 )
 

--- a/scipy/special/tests/meson.build
+++ b/scipy/special/tests/meson.build
@@ -52,6 +52,5 @@ python_sources = [
 
 py3.install_sources(
   python_sources,
-  pure: false,
   subdir: 'scipy/special/tests'
 )

--- a/scipy/stats/_boost/meson.build
+++ b/scipy/stats/_boost/meson.build
@@ -34,6 +34,5 @@ endforeach
 py3.install_sources([
     '__init__.py'
   ],
-  pure: false,
   subdir: 'scipy/stats/_boost'
 )

--- a/scipy/stats/_levy_stable/meson.build
+++ b/scipy/stats/_levy_stable/meson.build
@@ -1,7 +1,6 @@
 py3.install_sources([
     '__init__.py',
   ],
-  pure: false,
   subdir: 'scipy/stats/_levy_stable'
 )
 

--- a/scipy/stats/_unuran/meson.build
+++ b/scipy/stats/_unuran/meson.build
@@ -227,6 +227,5 @@ py3.install_sources([
     'unuran.pxd',
     'unuran_wrapper.pyi',
   ],
-  pure: false,
   subdir: 'scipy/stats/_unuran'
 )

--- a/scipy/stats/meson.build
+++ b/scipy/stats/meson.build
@@ -92,7 +92,6 @@ _sobol = py3.extension_module('_sobol',
 py3.install_sources([
     '_sobol_direction_numbers.npz'
   ],
-  pure: false,
   subdir: 'scipy/stats'
 )
 
@@ -184,7 +183,6 @@ if use_pythran
 else
   py3.install_sources(
     ['_stats_pythran.py'],
-    pure: false,
     subdir: 'scipy/stats'
   )
 endif
@@ -240,7 +238,6 @@ py3.install_sources([
     'statlib.py',
     'stats.py'
   ],
-  pure: false,
   subdir: 'scipy/stats'
 )
 
@@ -248,7 +245,6 @@ py3.install_sources([
     '_biasedurn.pxd',
     '_stats.pxd'
   ],
-  pure: false,
   subdir: 'scipy/stats'
 )
 
@@ -256,7 +252,6 @@ py3.install_sources([
     '_qmc_cy.pyi',
     '_sobol.pyi'
   ],
-  pure: false,
   subdir: 'scipy/stats'
 )
 

--- a/scipy/stats/tests/data/levy_stable/meson.build
+++ b/scipy/stats/tests/data/levy_stable/meson.build
@@ -3,6 +3,5 @@ py3.install_sources([
     'stable-Z1-cdf-sample-data.npy',
     'stable-Z1-pdf-sample-data.npy'
   ],
-  pure: false,
   subdir: 'scipy/stats/tests/data/levy_stable'
 )

--- a/scipy/stats/tests/data/meson.build
+++ b/scipy/stats/tests/data/meson.build
@@ -2,7 +2,6 @@ py3.install_sources([
     'fisher_exact_results_from_r.py',
     'studentized_range_mpmath_ref.json'
   ],
-  pure: false,
   subdir: 'scipy/stats/tests/data'
 )
 

--- a/scipy/stats/tests/data/nist_anova/meson.build
+++ b/scipy/stats/tests/data/nist_anova/meson.build
@@ -11,6 +11,5 @@ py3.install_sources([
     'SmLs08.dat',
     'SmLs09.dat'
   ],
-  pure: false,
   subdir: 'scipy/stats/tests/data/nist_anova'
 )

--- a/scipy/stats/tests/data/nist_linregress/meson.build
+++ b/scipy/stats/tests/data/nist_linregress/meson.build
@@ -1,6 +1,5 @@
 py3.install_sources([
     'Norris.dat'
   ],
-  pure: false,
   subdir: 'scipy/stats/tests/data/nist_linregress'
 )

--- a/scipy/stats/tests/meson.build
+++ b/scipy/stats/tests/meson.build
@@ -28,7 +28,6 @@ py3.install_sources([
     'test_tukeylambda_stats.py',
     'test_variation.py'
   ],
-  pure: false,
   subdir: 'scipy/stats/tests'
 )
 

--- a/scipy/stats/tests/test_generation/meson.build
+++ b/scipy/stats/tests/test_generation/meson.build
@@ -2,6 +2,5 @@ py3.install_sources([
     'generate_fisher_exact_results_from_r.R',
     'studentized_range_mpmath_ref.py'
   ],
-  pure: false,
   subdir: 'scipy/stats/tests/test_generation'
 )


### PR DESCRIPTION
This new feature in Meson is both safer and saves a bunch of boilerplate. There are also other fixes in Meson 0.64.0 that we need; they were mostly backported to 0.63.3, but older versions have a few known issues that we should avoid.

Meson release note: https://mesonbuild.com/Release-notes-for-0-64-0.html#pythonfind_installation-now-accepts-pure-argument
