### PR TITLE
ENH: `ndimage.uniform_filter`: implement `nan_policy`

### DIFF
--- a/benchmarks/benchmarks/ndimage_uniform_filter.py
+++ b/benchmarks/benchmarks/ndimage_uniform_filter.py
@@ -24,5 +24,5 @@ class NdimageUniformFilter(Benchmark):
         uniform_filter(self.x, size=size, mode=mode)
 
     def time_uniform_filter_nan(self, shape, size, mode):
-        uniform_filter(self.x, size=size, mode=mode, ignore_nan=True)
+        uniform_filter(self.x, size=size, mode=mode, nan_policy='omit')
 

--- a/benchmarks/benchmarks/ndimage_uniform_filter.py
+++ b/benchmarks/benchmarks/ndimage_uniform_filter.py
@@ -1,0 +1,28 @@
+import numpy as np
+
+from .common import Benchmark
+
+try:
+    from scipy.ndimage import uniform_filter
+except ImportError:
+    pass
+
+
+class NdimageUniformFilter(Benchmark):
+    param_names = ['shape', 'size', 'mode']
+    params = [
+        [(512, 512), (2048, 2048), (4096, 4096), (128, 128, 128), (512, 512, 512)],
+        [1, 3, 5, 7, 9],
+        ['reflect', 'constant', 'nearest', 'mirror', 'wrap']
+    ]
+
+    def setup(self, shape, order, mode):
+        rstate = np.random.RandomState(5)
+        self.x = rstate.uniform(shape)
+
+    def time_uniform_filter(self, shape, size, mode):
+        uniform_filter(self.x, size=size, mode=mode)
+
+    def time_uniform_filter_nan(self, shape, size, mode):
+        uniform_filter(self.x, size=size, mode=mode, ignore_nan=True)
+

--- a/scipy/ndimage/_filters.py
+++ b/scipy/ndimage/_filters.py
@@ -893,7 +893,8 @@ def convolve(input, weights, output=None, mode='reflect', cval=0.0,
 
 @_ni_docstrings.docfiller
 def uniform_filter1d(input, size, axis=-1, output=None,
-                     mode="reflect", cval=0.0, origin=0):
+                     mode="reflect", cval=0.0, origin=0, 
+                     ignore_nan=False):
     """Calculate a 1-D uniform filter along the given axis.
 
     The lines of the array along the given axis are filtered with a
@@ -909,6 +910,8 @@ def uniform_filter1d(input, size, axis=-1, output=None,
     %(mode_reflect)s
     %(cval)s
     %(origin)s
+    ignore_nan : bool
+        If set, then acts as numpy.nanmean() over window
 
     Examples
     --------
@@ -926,20 +929,24 @@ def uniform_filter1d(input, size, axis=-1, output=None,
     if (size // 2 + origin < 0) or (size // 2 + origin >= size):
         raise ValueError('invalid origin')
     mode = _ni_support._extend_mode_to_code(mode)
+    func = (
+      _nd_image.uniform_filter1d_nan if ignore_nan else 
+      _nd_image.uniform_filter1d
+    )
+
     if not complex_output:
-        _nd_image.uniform_filter1d(input, size, axis, output, mode, cval,
-                                   origin)
+        func(input, size, axis, output, mode, cval, origin)
     else:
-        _nd_image.uniform_filter1d(input.real, size, axis, output.real, mode,
+        func(input.real, size, axis, output.real, mode,
                                    numpy.real(cval), origin)
-        _nd_image.uniform_filter1d(input.imag, size, axis, output.imag, mode,
+        func(input.imag, size, axis, output.imag, mode,
                                    numpy.imag(cval), origin)
     return output
 
 
 @_ni_docstrings.docfiller
 def uniform_filter(input, size=3, output=None, mode="reflect",
-                   cval=0.0, origin=0):
+                   cval=0.0, origin=0, ignore_nan=False):
     """Multidimensional uniform filter.
 
     Parameters
@@ -953,6 +960,8 @@ def uniform_filter(input, size=3, output=None, mode="reflect",
     %(mode_multiple)s
     %(cval)s
     %(origin_multiple)s
+    ignore_nan : bool
+        If set, then acts as numpy.nanmean() over window
 
     Returns
     -------
@@ -993,7 +1002,7 @@ def uniform_filter(input, size=3, output=None, mode="reflect",
     if len(axes) > 0:
         for axis, size, origin, mode in axes:
             uniform_filter1d(input, int(size), axis, output, mode,
-                             cval, origin)
+                             cval, origin, ignore_nan)
             input = output
     else:
         output[...] = input[...]

--- a/scipy/ndimage/src/nd_image.c
+++ b/scipy/ndimage/src/nd_image.c
@@ -266,6 +266,31 @@ exit:
     return PyErr_Occurred() ? NULL : Py_BuildValue("");
 }
 
+static PyObject *Py_UniformFilter1D_NaN(PyObject *obj, PyObject *args)
+{
+    PyArrayObject *input = NULL, *output = NULL;
+    int axis, mode;
+    npy_intp filter_size, origin;
+    double cval;
+
+    if (!PyArg_ParseTuple(args, "O&niO&idn",
+                          NI_ObjectToInputArray, &input,
+                          &filter_size, &axis,
+                          NI_ObjectToOutputArray, &output,
+                          &mode, &cval, &origin))
+        goto exit;
+
+    NI_UniformFilter1D_NaN(input, filter_size, axis, output, (NI_ExtendMode)mode,
+                       cval, origin);
+    #ifdef HAVE_WRITEBACKIFCOPY
+        PyArray_ResolveWritebackIfCopy(output);
+    #endif
+
+exit:
+    Py_XDECREF(input);
+    Py_XDECREF(output);
+    return PyErr_Occurred() ? NULL : Py_BuildValue("");
+}
 static PyObject *Py_MinOrMaxFilter1D(PyObject *obj, PyObject *args)
 {
     PyArrayObject *input = NULL, *output = NULL;
@@ -1347,6 +1372,8 @@ static PyMethodDef methods[] = {
     {"correlate",             (PyCFunction)Py_Correlate,
      METH_VARARGS, NULL},
     {"uniform_filter1d",      (PyCFunction)Py_UniformFilter1D,
+     METH_VARARGS, NULL},
+    {"uniform_filter1d_nan",  (PyCFunction)Py_UniformFilter1D_NaN,
      METH_VARARGS, NULL},
     {"min_or_max_filter1d",   (PyCFunction)Py_MinOrMaxFilter1D,
         METH_VARARGS, NULL},

--- a/scipy/ndimage/src/ni_filters.h
+++ b/scipy/ndimage/src/ni_filters.h
@@ -38,6 +38,8 @@ int NI_Correlate(PyArrayObject*, PyArrayObject*, PyArrayObject*,
                  NI_ExtendMode, double, npy_intp*);
 int NI_UniformFilter1D(PyArrayObject*, npy_intp, int, PyArrayObject*,
                        NI_ExtendMode, double, npy_intp);
+int NI_UniformFilter1D_NaN(PyArrayObject*, npy_intp, int, PyArrayObject*,
+                       NI_ExtendMode, double, npy_intp);
 int NI_MinOrMaxFilter1D(PyArrayObject*, npy_intp, int, PyArrayObject*,
                         NI_ExtendMode, double, npy_intp, int);
 int NI_MinOrMaxFilter(PyArrayObject*, PyArrayObject*, PyArrayObject*,

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -895,11 +895,10 @@ class TestNdimageFilters:
         assert_array_almost_equal([3, 5, 6], output)
 
     def test_uniform01_nan(self):
-        array  = numpy.array([2, numpy.nan, 6])
-        size   = 2
-        output = ndimage.uniform_filter1d(array, size, origin=-1, ignore_nan=True)
+        array = numpy.array([2, numpy.nan, 6])
+        size = 2
+        output = ndimage.uniform_filter1d(array, size, origin=-1, nan_policy='omit')
         assert_array_almost_equal([2, 6, 6], output)
-
 
     def test_uniform01_complex(self):
         array = numpy.array([2 + 1j, 4 + 2j, 6 + 3j], dtype=numpy.complex128)
@@ -911,7 +910,7 @@ class TestNdimageFilters:
     def test_uniform01_complex_nan(self):
         array = numpy.array([2 + 1j, numpy.nan + 2j, 6 + 3j], dtype=numpy.complex128)
         size = 2
-        output = ndimage.uniform_filter1d(array, size, origin=-1, ignore_nan=True)
+        output = ndimage.uniform_filter1d(array, size, origin=-1, nan_policy='omit')
         assert_array_almost_equal([2, 6, 6], output.real)
         assert_array_almost_equal([1.5, 2.5, 3], output.imag)
 
@@ -924,7 +923,7 @@ class TestNdimageFilters:
     def test_uniform02_nan(self):
         array = numpy.array([1, numpy.nan, 3])
         filter_shape = [0]
-        output = ndimage.uniform_filter(array, filter_shape, ignore_nan=True)
+        output = ndimage.uniform_filter(array, filter_shape, nan_policy='omit')
         assert_array_almost_equal(array, output)
 
     def test_uniform03(self):
@@ -936,7 +935,7 @@ class TestNdimageFilters:
     def test_uniform03_nan(self):
         array = numpy.array([1, numpy.nan, 3])
         filter_shape = [1]
-        output = ndimage.uniform_filter(array, filter_shape, ignore_nan=True)
+        output = ndimage.uniform_filter(array, filter_shape, nan_policy='omit')
         assert_array_almost_equal(array, output)
 
     def test_uniform04(self):
@@ -948,7 +947,7 @@ class TestNdimageFilters:
     def test_uniform04_nan(self):
         array = numpy.array([2, numpy.nan, 6])
         filter_shape = [2]
-        output = ndimage.uniform_filter(array, filter_shape, ignore_nan=True)
+        output = ndimage.uniform_filter(array, filter_shape, nan_policy='omit')
         assert_array_almost_equal([2, 2, 6], output)
 
     def test_uniform05(self):
@@ -960,7 +959,7 @@ class TestNdimageFilters:
     def test_uniform05_nan(self):
         array = []
         filter_shape = [1]
-        output = ndimage.uniform_filter(array, filter_shape, ignore_nan=True)
+        output = ndimage.uniform_filter(array, filter_shape, nan_policy='omit')
         assert_array_almost_equal([], output)
 
     @pytest.mark.parametrize('dtype_array', types)
@@ -978,10 +977,10 @@ class TestNdimageFilters:
     @pytest.mark.parametrize('dtype_output', float_types)
     def test_uniform06_nan(self, dtype_array, dtype_output):
         filter_shape = [2, 2]
-        array = numpy.array([[ 4, numpy.nan, 12],
+        array = numpy.array([[4, numpy.nan, 12],
                              [16, numpy.nan, 24]], dtype_array)
         output = ndimage.uniform_filter(
-            array, filter_shape, output=dtype_output, ignore_nan=True)
+            array, filter_shape, output=dtype_output, nan_policy='omit')
         assert_array_almost_equal([[4, 4, 12], [10, 10, 18]], output)
         assert_equal(output.dtype.type, dtype_output)
 
@@ -1000,10 +999,10 @@ class TestNdimageFilters:
     @pytest.mark.parametrize('dtype_output', complex_types)
     def test_uniform06_complex_nan(self, dtype_array, dtype_output):
         filter_shape = [2, 2]
-        array = numpy.array([[ 4, numpy.nan + 5j, 12],
+        array = numpy.array([[4, numpy.nan + 5j, 12],
                              [16, numpy.nan, 24]], dtype_array)
         output = ndimage.uniform_filter(
-            array, filter_shape, output=dtype_output, ignore_nan=True)
+            array, filter_shape, output=dtype_output, nan_policy='omit')
         assert_array_almost_equal([[4, 4, 12], [10, 10, 18]], output.real)
         assert_equal(output.dtype.type, dtype_output)
 
@@ -1717,7 +1716,7 @@ def test_multiple_modes_sequentially():
                        [1., 1., 0.],
                        [0., 0., 0.]])
     arr_nan = arr.copy()
-    arr_nan[ [0,1], [1,2] ] = numpy.nan
+    arr_nan[[0,1], [1,2]] = numpy.nan
 
     modes = ['reflect', 'wrap']
 
@@ -1732,10 +1731,10 @@ def test_multiple_modes_sequentially():
                  ndimage.uniform_filter(arr, 5, mode=modes))
 
     # Test ignore_nan
-    expected = ndimage.uniform_filter1d(arr_nan, 5, axis=0, mode=modes[0], ignore_nan=True)
-    expected = ndimage.uniform_filter1d(expected, 5, axis=1, mode=modes[1], ignore_nan=True)
+    expected = ndimage.uniform_filter1d(arr_nan, 5, axis=0, mode=modes[0], nan_policy='omit')
+    expected = ndimage.uniform_filter1d(expected, 5, axis=1, mode=modes[1], nan_policy='omit')
     assert_equal(expected,
-                 ndimage.uniform_filter(arr_nan, 5, mode=modes, ignore_nan=True) )
+                 ndimage.uniform_filter(arr_nan, 5, mode=modes, nan_policy='omit'))
 
     expected = ndimage.maximum_filter1d(arr, size=5, axis=0, mode=modes[0])
     expected = ndimage.maximum_filter1d(expected, size=5, axis=1,
@@ -1970,12 +1969,12 @@ class TestThreading:
         assert_array_equal(os, ot)
 
     def test_uniform_filter1d_nan(self):
-        d  = numpy.random.randn(5000)
-        d[ numpy.random.randint( 100 ) ] = numpy.nan
+        d = numpy.random.randn(5000)
+        d[numpy.random.randint( 100 )] = numpy.nan
         os = numpy.empty((4, d.size))
         ot = numpy.empty_like(os)
-        self.check_func_serial(4, ndimage.uniform_filter1d, (d, 5), os, ignore_nan=True)
-        self.check_func_thread(4, ndimage.uniform_filter1d, (d, 5), ot, ignore_nan=True)
+        self.check_func_serial(4, ndimage.uniform_filter1d, (d, 5), os, nan_policy='omit')
+        self.check_func_thread(4, ndimage.uniform_filter1d, (d, 5), ot, nan_policy='omit')
         assert_array_equal(os, ot)
 
     def test_minmax_filter(self):


### PR DESCRIPTION
Earlier commit (18713491f) implemented ignoring of NaNs in the uniform_filter and uniform_filter1d functions. This commit moves to using the nan_policy keyword argument for determining how NaNs are to be handled so that API calls are consistent across scipy.

Have created a new C-level function that checks/ignores NaN values when computing boxcar averages for the uniform_filter function. This new function is almost identical to the original, but now checks/ignores NaN values when summing and adjusts the number of values in the average based on finite values; i.e., a numpy.nanmean()-like average is taken over the window.

Tests have been added to the testing suite to check that NaN ignoring is working correctly.

A new benchmark has been added to the benchmarking suite; tests indicate very minimal impacts to performance when using ignore_nan=True as opposted to ignore_nan=False. More robust benchmarking should be performed to fully understand any preformance impacts; however, getting the 'right' answer (i.e., not propogating NaNs through entire dataset) is typically more important than being blazing fast.

Closes #7818
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
