### PR TITLE
BUG: signal: Change types in the upfirdn utility function _output_len()

### DIFF
--- a/scipy/signal/_upfirdn_apply.pyx
+++ b/scipy/signal/_upfirdn_apply.pyx
@@ -59,10 +59,10 @@ cdef struct ArrayInfo:
     np.intp_t ndim
 
 
-def _output_len(np.intp_t len_h,
-                np.intp_t in_len,
-                np.intp_t up,
-                np.intp_t down):
+def _output_len(np.int64_t len_h,
+                np.int64_t in_len,
+                np.int64_t up,
+                np.int64_t down):
     """The output length that results from a given input"""
     # ceil(((in_len - 1) * up + len_h) / down), but using integer arithmetic
     return (((in_len - 1) * up + len_h) - 1) // down + 1

--- a/scipy/signal/tests/test_upfirdn.py
+++ b/scipy/signal/tests/test_upfirdn.py
@@ -271,3 +271,17 @@ class TestUpfirdn:
 
         atol = rtol = np.finfo(dtype).eps * 1e2
         assert_allclose(y, y_expected, atol=atol, rtol=rtol)
+
+
+def test_output_len_long_input():
+    # Regression test for gh-17375.  On Windows, a large enough input
+    # that should have been well within the capabilities of 64 bit integers
+    # would result in a 32 bit overflow because of a bug in Cython 0.29.32.
+    len_h = 1001
+    in_len = 10**8
+    up = 320
+    down = 441
+    out_len = _output_len(len_h, in_len, up, down)
+    # The expected value was computed "by hand" from the formula
+    #   (((in_len - 1) * up + len_h) - 1) // down + 1
+    assert out_len == 72562360


### PR DESCRIPTION
Change the types of the parameters of the Cython function `_output_len()`
from `np.intp_t` to the `np.int64_t`.  This avoids the potential
overflow that can occur if `np.intp_t` is 32 bit (e.g. 32 bit Linux
or Windows) and the input is very long, and also avoids a bug in
Cython 0.29.32 that occurs in 64 bit Windows.

Closes gh-17375.