### PR TITLE
DOC: signal.iirdesign: remove `bessel` from supported filter type

### DIFF
--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -2226,7 +2226,6 @@ def iirdesign(wp, ws, gpass, gstop, analog=False, ftype='ellip', output='ba',
             - Chebyshev I   : 'cheby1'
             - Chebyshev II  : 'cheby2'
             - Cauer/elliptic: 'ellip'
-            - Bessel/Thomson: 'bessel'
 
     output : {'ba', 'zpk', 'sos'}, optional
         Filter form of the output:


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes gh-16342

#### What does this implement/fix?
Removes `bessel` from the supported filter types of the `signal.iirdesign()` docstring, as they don't have order selection.

#### Additional information
<!--Any additional information you think is important.-->
