### PR TITLE
TST: use norm in signal.TestBessel.test_fs_param

### DIFF
--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -2368,15 +2368,15 @@ class TestBessel:
                 for N in (0, 1, 2, 3, 10):
                     for fc in (100, 100.1, 432.12345):
                         for btype in ('lp', 'hp'):
-                            ba1 = bessel(N, fc, btype, fs=fs)
-                            ba2 = bessel(N, fc/(fs/2), btype)
+                            ba1 = bessel(N, fc, btype, norm=norm, fs=fs)
+                            ba2 = bessel(N, fc/(fs/2), btype, norm=norm)
                             assert_allclose(ba1, ba2)
                     for fc in ((100, 200), (100.1, 200.2), (321.123, 432.123)):
                         for btype in ('bp', 'bs'):
-                            ba1 = bessel(N, fc, btype, fs=fs)
+                            ba1 = bessel(N, fc, btype, norm=norm, fs=fs)
                             for seq in (list, tuple, array):
                                 fcnorm = seq([f/(fs/2) for f in fc])
-                                ba2 = bessel(N, fcnorm, btype)
+                                ba2 = bessel(N, fcnorm, btype, norm=norm)
                                 assert_allclose(ba1, ba2)
 
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
Actually uses all three norms `('phase', 'mag', 'delay')` that are iterated inside `signal.test_filter_design::TestBessel::test_fs_param()`.

Alternatively, the outer loop could also be removed to reduce test runtime. `TestBessel::test_fs_param()` is actually the longest tests of `signal.test` (1.43s on my machine) and I believe the tested code path isn't impacted by the `norm` parameter.

#### Additional information
<!--Any additional information you think is important.-->
