### PR TITLE
DOC: Subheadings for statistical functions in special docs landing page

### DIFF
--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -212,6 +212,9 @@ Raw statistical functions
 
 .. seealso:: :mod:`scipy.stats`: Friendly versions of these functions.
 
+Binomial distribution
+^^^^^^^^^^^^^^^^^^^^^
+
 .. autosummary::
    :toctree: generated/
 
@@ -220,66 +223,172 @@ Raw statistical functions
    bdtri        -- Inverse function to `bdtr` with respect to `p`.
    bdtrik       -- Inverse function to `bdtr` with respect to `k`.
    bdtrin       -- Inverse function to `bdtr` with respect to `n`.
+
+Beta distribution
+^^^^^^^^^^^^^^^^^
+
+.. autosummary::
+   :toctree: generated/
+
    btdtr        -- Cumulative distribution function of the beta distribution.
    btdtri       -- The `p`-th quantile of the beta distribution.
    btdtria      -- Inverse of `btdtr` with respect to `a`.
    btdtrib      -- btdtria(a, p, x).
+
+F distribution
+^^^^^^^^^^^^^^
+
+.. autosummary::
+   :toctree: generated/
+
    fdtr         -- F cumulative distribution function.
    fdtrc        -- F survival function.
    fdtri        -- The `p`-th quantile of the F-distribution.
    fdtridfd     -- Inverse to `fdtr` vs dfd.
+
+Gamma distribution
+^^^^^^^^^^^^^^^^^^
+
+.. autosummary::
+   :toctree: generated/
+
    gdtr         -- Gamma distribution cumulative distribution function.
    gdtrc        -- Gamma distribution survival function.
    gdtria       -- Inverse of `gdtr` vs a.
    gdtrib       -- Inverse of `gdtr` vs b.
    gdtrix       -- Inverse of `gdtr` vs x.
+
+Negative binomial distribution
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autosummary::
+   :toctree: generated/
+
    nbdtr        -- Negative binomial cumulative distribution function.
    nbdtrc       -- Negative binomial survival function.
    nbdtri       -- Inverse of `nbdtr` vs `p`.
    nbdtrik      -- Inverse of `nbdtr` vs `k`.
    nbdtrin      -- Inverse of `nbdtr` vs `n`.
+
+Noncentral F distribution
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autosummary::
+   :toctree: generated/
+
    ncfdtr       -- Cumulative distribution function of the non-central F distribution.
    ncfdtridfd   -- Calculate degrees of freedom (denominator) for the noncentral F-distribution.
    ncfdtridfn   -- Calculate degrees of freedom (numerator) for the noncentral F-distribution.
    ncfdtri      -- Inverse cumulative distribution function of the non-central F distribution.
    ncfdtrinc    -- Calculate non-centrality parameter for non-central F distribution.
+
+Noncentral t distribution
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autosummary::
+   :toctree: generated/
+
    nctdtr       -- Cumulative distribution function of the non-central `t` distribution.
    nctdtridf    -- Calculate degrees of freedom for non-central t distribution.
    nctdtrit     -- Inverse cumulative distribution function of the non-central t distribution.
    nctdtrinc    -- Calculate non-centrality parameter for non-central t distribution.
+
+Normal distribution
+^^^^^^^^^^^^^^^^^^^
+
+.. autosummary::
+   :toctree: generated/
+
    nrdtrimn     -- Calculate mean of normal distribution given other params.
    nrdtrisd     -- Calculate standard deviation of normal distribution given other params.
+   ndtr         -- Normal cumulative distribution function.
+   log_ndtr     -- Logarithm of normal cumulative distribution function.
+   ndtri        -- Inverse of `ndtr` vs x.
+   ndtri_exp    -- Inverse of `log_ndtr` vs x.
+
+Poisson distribution
+^^^^^^^^^^^^^^^^^^^^
+
+.. autosummary::
+   :toctree: generated/
+
    pdtr         -- Poisson cumulative distribution function.
    pdtrc        -- Poisson survival function.
    pdtri        -- Inverse to `pdtr` vs m.
    pdtrik       -- Inverse to `pdtr` vs k.
+
+Student t distribution
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. autosummary::
+   :toctree: generated/
+
    stdtr        -- Student t distribution cumulative distribution function.
    stdtridf     -- Inverse of `stdtr` vs df.
    stdtrit      -- Inverse of `stdtr` vs `t`.
+
+Chi square distribution
+^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autosummary::
+   :toctree: generated/
+
    chdtr        -- Chi square cumulative distribution function.
    chdtrc       -- Chi square survival function.
    chdtri       -- Inverse to `chdtrc`.
    chdtriv      -- Inverse to `chdtr` vs `v`.
-   ndtr         -- Gaussian cumulative distribution function.
-   log_ndtr     -- Logarithm of Gaussian cumulative distribution function.
-   ndtri        -- Inverse of `ndtr` vs x.
-   ndtri_exp    -- Inverse of `log_ndtr` vs x.
+
+Non-central chi square distribution
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autosummary::
+   :toctree: generated/
+
    chndtr       -- Non-central chi square cumulative distribution function.
    chndtridf    -- Inverse to `chndtr` vs `df`.
    chndtrinc    -- Inverse to `chndtr` vs `nc`.
    chndtrix     -- Inverse to `chndtr` vs `x`.
+
+Kolmogorov distribution
+^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autosummary::
+   :toctree: generated/
+
    smirnov      -- Kolmogorov-Smirnov complementary cumulative distribution function.
    smirnovi     -- Inverse to `smirnov`.
    kolmogorov   -- Complementary cumulative distribution function of Kolmogorov distribution.
    kolmogi      -- Inverse function to `kolmogorov`.
-   tklmbda      -- Tukey-Lambda cumulative distribution function.
-   logit        -- Logit ufunc for ndarrays.
-   expit        -- Logistic sigmoid function.
-   log_expit    -- Logarithm of the logistic sigmoid function.
+
+Box-Cox transformation
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. autosummary::
+   :toctree: generated/
+
    boxcox       -- Compute the Box-Cox transformation.
    boxcox1p     -- Compute the Box-Cox transformation of 1 + `x`.
    inv_boxcox   -- Compute the inverse of the Box-Cox transformation.
    inv_boxcox1p -- Compute the inverse of the Box-Cox transformation.
+
+
+Sigmoidal functions
+^^^^^^^^^^^^^^^^^^^
+
+.. autosummary::
+   :toctree: generated/
+
+   logit        -- Logit ufunc for ndarrays.
+   expit        -- Logistic sigmoid function.
+   log_expit    -- Logarithm of the logistic sigmoid function.
+
+Miscellaneous
+^^^^^^^^^^^^^
+
+.. autosummary::
+   :toctree: generated/
+
+   tklmbda      -- Tukey-Lambda cumulative distribution function.
    owens_t      -- Owen's T Function.
 
 


### PR DESCRIPTION
#### What does this implement/fix?
The statistical functions in `special` contain app. 60 Functions which are simpliy listed one after another. Here I propose to introduce subheadings for each distribution. See the screenshots below for an example.

Current docs:
![image](https://user-images.githubusercontent.com/40656107/201512325-fd751d8f-9a57-4c76-94e0-239d6698ec98.png)

With this PR:
![image](https://user-images.githubusercontent.com/40656107/201512311-b5c4dd42-6788-41ac-ba4f-96a21680ce6c.png)

#### Additional information
FWIW, the functions `logit`, `expit` and `log_expit` could be moved under "Information Theory functions".
