### PR TITLE
MAINT: Python 3.8 typing simplify

### DIFF
--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -56,7 +56,7 @@ class AccuracyWarning(Warning):
 if TYPE_CHECKING:
     # workaround for mypy function attributes see:
     # https://github.com/python/mypy/issues/2087#issuecomment-462726600
-    from typing_extensions import Protocol
+    from typing import Protocol
 
     class CacheAttributes(Protocol):
         cache: Dict[int, Tuple[Any, Any]]

--- a/scipy/spatial/_ckdtree.pyi
+++ b/scipy/spatial/_ckdtree.pyi
@@ -16,10 +16,7 @@ import numpy as np
 import numpy.typing as npt
 from scipy.sparse import coo_matrix, dok_matrix
 
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
+from typing import Literal
 
 # TODO: Replace `ndarray` with a 1D float64 array when possible
 _BoxType = TypeVar("_BoxType", None, npt.NDArray[np.float64])

--- a/scipy/spatial/distance.pyi
+++ b/scipy/spatial/distance.pyi
@@ -1,20 +1,13 @@
 import sys
-from typing import overload, Optional, Any, Union, Tuple, SupportsFloat
+from typing import (overload, Optional, Any, Union, Tuple, SupportsFloat,
+                    Literal, Protocol, SupportsIndex)
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
 
-if sys.version_info >= (3, 8):
-    from typing import Literal, Protocol, SupportsIndex
-else:
-    from typing_extensions import Literal, Protocol
-
 # Anything that can be parsed by `np.float64.__init__` and is thus
 # compatible with `ndarray.__setitem__` (for a float64 array)
-if sys.version_info >= (3, 8):
-    _FloatValue = Union[None, str, bytes, SupportsFloat, SupportsIndex]
-else:
-    _FloatValue = Union[None, str, bytes, SupportsFloat]
+_FloatValue = Union[None, str, bytes, SupportsFloat, SupportsIndex]
 
 class _MetricCallback1(Protocol):
     def __call__(

--- a/scipy/special/_orthogonal.pyi
+++ b/scipy/special/_orthogonal.pyi
@@ -2,12 +2,12 @@ from typing import (
     Any,
     Callable,
     List,
+    Literal,
     Optional,
     overload,
     Tuple,
     Union,
 )
-from typing_extensions import Literal
 
 import numpy
 

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -13,6 +13,7 @@ from typing import (
     ClassVar,
     Dict,
     List,
+    Literal,
     Optional,
     overload,
     Tuple,
@@ -23,7 +24,6 @@ import numpy as np
 
 if TYPE_CHECKING:
     import numpy.typing as npt
-    from typing_extensions import Literal
     from scipy._lib._util import (
         DecimalNumber, GeneratorType, IntNumber, SeedType
     )

--- a/scipy/stats/_sobol.pyi
+++ b/scipy/stats/_sobol.pyi
@@ -1,6 +1,6 @@
 import numpy as np
 from scipy._lib._util import IntNumber
-from typing_extensions import Literal
+from typing import Literal
 
 def _initialize_v(
     v : np.ndarray, 

--- a/scipy/stats/_unuran/unuran_wrapper.pyi
+++ b/scipy/stats/_unuran/unuran_wrapper.pyi
@@ -1,6 +1,6 @@
 import numpy as np
-from typing import Union, Any, Tuple, List, overload, Callable, NamedTuple
-from typing_extensions import Protocol
+from typing import (Union, Any, Tuple, List, overload, Callable, NamedTuple,
+                    Protocol)
 import numpy.typing as npt
 from scipy._lib._util import SeedType
 import scipy.stats as stats


### PR DESCRIPTION
* we've had Python `3.8` as our minimum supported Python version for quite some time now, so this branch simplifies our type checking imports accordingly

* this substantially reduces our dependence on `typing_extensions`; I think there is only one use case left, and even that may be able to go, but I did this on the airplane without wifi so couldn't look that one up at the time; also, not sure we if we really care so much about really removing that dependency--perhaps there will on occasion be new additions we'll want from `typing_extensions` in the future anyway..