### PR TITLE
BUG: integrate: simpson didn't handle integer n-d arrays.

### DIFF
--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -406,7 +406,7 @@ def _basic_simpson(y, start, stop, x, dx, axis):
     slice2 = tupleset(slice_all, axis, slice(start+2, stop+2, step))
 
     if x is None:  # Even-spaced Simpson's rule.
-        result = np.sum(y[slice0] + 4*y[slice1] + y[slice2], axis=axis)
+        result = np.sum(y[slice0] + 4.0*y[slice1] + y[slice2], axis=axis)
         result *= dx / 3.0
     else:
         # Account for possibly different spacings.
@@ -473,6 +473,11 @@ def simpson(y, x=None, dx=1.0, axis=-1, even='avg'):
 
         'last' : Use Simpson's rule for the last N-2 intervals with a
                trapezoidal rule on the first interval.
+
+    Returns
+    -------
+    float
+        The estimated integral computed with the composite Simpson's rule.
 
     See Also
     --------

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -971,6 +971,11 @@ def newton_cotes(rn, equal=0):
     B : float
         Error coefficient.
 
+    Notes
+    -----
+    Normally, the Newton-Cotes rules are used on smaller integration
+    regions and a composite rule is used to return the total integral.
+
     Examples
     --------
     Compute the integral of sin(x) in [0, :math:`\pi`]:
@@ -995,11 +1000,6 @@ def newton_cotes(rn, equal=0):
      6   2.000017814   1.78136e-05
      8   1.999999835   1.64725e-07
     10   2.000000001   1.14677e-09
-
-    Notes
-    -----
-    Normally, the Newton-Cotes rules are used on smaller integration
-    regions and a composite rule is used to return the total integral.
 
     """
     try:

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -10,21 +10,20 @@ from scipy.integrate import (quadrature, romberg, romb, newton_cotes,
                              qmc_quad)
 from scipy import stats, special as sc
 
+
 class TestFixedQuad:
     def test_scalar(self):
         n = 4
-        func = lambda x: x**(2*n - 1)
         expected = 1/(2*n)
-        got, _ = fixed_quad(func, 0, 1, n=n)
+        got, _ = fixed_quad(lambda x: x**(2*n - 1), 0, 1, n=n)
         # quadrature exact for this input
         assert_allclose(got, expected, rtol=1e-12)
 
     def test_vector(self):
         n = 4
         p = np.arange(1, 2*n)
-        func = lambda x: x**p[:,None]
         expected = 1/(p + 1)
-        got, _ = fixed_quad(func, 0, 1, n=n)
+        got, _ = fixed_quad(lambda x: x**p[:, None], 0, 1, n=n)
         assert_allclose(got, expected, rtol=1e-12)
 
 

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -179,6 +179,18 @@ class TestQuadrature:
         assert_equal(simpson(y, x=x, axis=0), zero_axis)
         assert_equal(simpson(y, x=x, axis=-1), default_axis)
 
+    @pytest.mark.parametrize('droplast', [False, True])
+    def test_simpson_2d_integer_no_x(self, droplast):
+        # The inputs are 2d integer arrays.  The results should be
+        # identical to the results when the inputs are floating point.
+        y = np.array([[2, 2, 4, 4, 8, 8, -4, 5],
+                      [4, 4, 2, -4, 10, 22, -2, 10]])
+        if droplast:
+            y = y[:, :-1]
+        result = simpson(y, axis=-1)
+        expected = simpson(np.array(y, dtype=np.float64), axis=-1)
+        assert_equal(result, expected)
+
     def test_simps(self):
         # Basic coverage test for the alias
         y = np.arange(4)


### PR DESCRIPTION
A call such as `simpson([[1, 2, 3, 4, 5]], axis=-1)` would raise
an exception, because a calculation left an intermediate result
as an integer array, and then the code attempted to multiply
that result in-place by a floating point value.  Simply changing
a coefficient from 4 to 4.0 ensures that the array has a floating
point type.

Other fixes:

* Added the missing "Returns" section to the `simpson` docstring.
* Fix some PEP-8 issues in test_quadrature.py.
* Fix the position of the 'Notes' section of the `newton_cotes` docstring.
