### PR TITLE
DOC: optimize.linprog: adjust HiGHS URL

### DIFF
--- a/scipy/optimize/_highs/cython/src/_highs_wrapper.pyx
+++ b/scipy/optimize/_highs/cython/src/_highs_wrapper.pyx
@@ -555,7 +555,7 @@ def _highs_wrapper(
 
     References
     ----------
-    .. [1] https://www.maths.ed.ac.uk/hall/HiGHS
+    .. [1] https://highs.dev/
     .. [2] https://www.maths.ed.ac.uk/hall/HiGHS/HighsOptions.html
     '''
 

--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -535,7 +535,7 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
             Mathematical Programming Study 4 (1975): 146-166.
     .. [13] Huangfu, Q., Galabova, I., Feldmeier, M., and Hall, J. A. J.
             "HiGHS - high performance software for linear optimization."
-            Accessed 4/16/2020 at https://www.maths.ed.ac.uk/hall/HiGHS/#guide
+            https://highs.dev/
     .. [14] Huangfu, Q. and Hall, J. A. J. "Parallelizing the dual revised
             simplex method." Mathematical Programming Computation, 10 (1),
             119-142, 2018. DOI: 10.1007/s12532-017-0130-5

--- a/scipy/optimize/_linprog_doc.py
+++ b/scipy/optimize/_linprog_doc.py
@@ -278,7 +278,7 @@ def _linprog_highs_doc(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
     ----------
     .. [13] Huangfu, Q., Galabova, I., Feldmeier, M., and Hall, J. A. J.
            "HiGHS - high performance software for linear optimization."
-           Accessed 4/16/2020 at https://www.maths.ed.ac.uk/hall/HiGHS/#guide
+           https://highs.dev/
     .. [14] Huangfu, Q. and Hall, J. A. J. "Parallelizing the dual revised
            simplex method." Mathematical Programming Computation, 10 (1),
            119-142, 2018. DOI: 10.1007/s12532-017-0130-5
@@ -519,7 +519,7 @@ def _linprog_highs_ds_doc(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
     ----------
     .. [13] Huangfu, Q., Galabova, I., Feldmeier, M., and Hall, J. A. J.
            "HiGHS - high performance software for linear optimization."
-           Accessed 4/16/2020 at https://www.maths.ed.ac.uk/hall/HiGHS/#guide
+           https://highs.dev/
     .. [14] Huangfu, Q. and Hall, J. A. J. "Parallelizing the dual revised
            simplex method." Mathematical Programming Computation, 10 (1),
            119-142, 2018. DOI: 10.1007/s12532-017-0130-5
@@ -751,7 +751,7 @@ def _linprog_highs_ipm_doc(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
     ----------
     .. [13] Huangfu, Q., Galabova, I., Feldmeier, M., and Hall, J. A. J.
            "HiGHS - high performance software for linear optimization."
-           Accessed 4/16/2020 at https://www.maths.ed.ac.uk/hall/HiGHS/#guide
+           https://highs.dev/
     .. [14] Huangfu, Q. and Hall, J. A. J. "Parallelizing the dual revised
            simplex method." Mathematical Programming Computation, 10 (1),
            119-142, 2018. DOI: 10.1007/s12532-017-0130-5

--- a/scipy/optimize/_linprog_highs.py
+++ b/scipy/optimize/_linprog_highs.py
@@ -1,7 +1,7 @@
 """HiGHS Linear Optimization Methods
 
 Interface to HiGHS linear optimization software.
-https://www.maths.ed.ac.uk/hall/HiGHS/
+https://highs.dev/
 
 .. versionadded:: 1.5.0
 

--- a/scipy/optimize/_milp.py
+++ b/scipy/optimize/_milp.py
@@ -289,7 +289,7 @@ def milp(c, *, integrality=None, bounds=None, constraints=None, options=None):
     ----------
     .. [1] Huangfu, Q., Galabova, I., Feldmeier, M., and Hall, J. A. J.
            "HiGHS - high performance software for linear optimization."
-           Accessed 12/25/2021 at https://www.maths.ed.ac.uk/hall/HiGHS/#guide
+           https://highs.dev/
     .. [2] Huangfu, Q. and Hall, J. A. J. "Parallelizing the dual revised
            simplex method." Mathematical Programming Computation, 10 (1),
            119-142, 2018. DOI: 10.1007/s12532-017-0130-5


### PR DESCRIPTION
#### Reference issue
Per request of the HiGHS team

#### What does this implement/fix?
Change references to https://www.maths.ed.ac.uk/hall/HiGHS to https://highs.dev/
