### PR TITLE
MAINT/TST: improved test coverage for DIRECT optimizer

### DIFF
--- a/scipy/optimize/_direct_py.py
+++ b/scipy/optimize/_direct_py.py
@@ -212,16 +212,14 @@ def direct(
     ub = np.ascontiguousarray(bounds.ub, dtype=np.float64)
 
     # validate bounds
-    if not np.all(lb < ub):
-        raise ValueError('Bounds are not consistent min < max')
-    if not len(lb) == len(ub):
-        raise ValueError('Bounds do not have the same dimensions')
-
     # check for infs and nans
     if (np.any(np.isinf(lb)) or np.any(np.isinf(ub))):
         raise ValueError("Bounds must not be inf.")
     if (np.any(np.isnan(lb)) or np.any(np.isnan(ub))):
         raise ValueError("Bounds must not be NaN.")
+    # check that lower bounds are smaller than upper bounds
+    if not np.all(lb < ub):
+        raise ValueError('Bounds are not consistent min < max')
 
     # validate tolerances
     if (vol_tol < 0 or vol_tol > 1):

--- a/scipy/optimize/_direct_py.py
+++ b/scipy/optimize/_direct_py.py
@@ -100,7 +100,7 @@ def direct(
         Terminate the optimization once the relative error between the
         current best minimum `f` and the supplied global minimum `f_min`
         is smaller than `f_min_rtol`. This parameter is only used if
-        `f_min` is also set. Default is 1e-4.
+        `f_min` is also set. Must lie between 0 and 1. Default is 1e-4.
     vol_tol : float, optional
         Terminate the optimization once the volume of the hyperrectangle
         containing the lowest function value is smaller than `vol_tol`

--- a/scipy/optimize/_direct_py.py
+++ b/scipy/optimize/_direct_py.py
@@ -212,14 +212,12 @@ def direct(
     ub = np.ascontiguousarray(bounds.ub, dtype=np.float64)
 
     # validate bounds
-    # check for infs and nans
-    if (np.any(np.isinf(lb)) or np.any(np.isinf(ub))):
-        raise ValueError("Bounds must not be inf.")
-    if (np.any(np.isnan(lb)) or np.any(np.isnan(ub))):
-        raise ValueError("Bounds must not be NaN.")
     # check that lower bounds are smaller than upper bounds
     if not np.all(lb < ub):
         raise ValueError('Bounds are not consistent min < max')
+    # check for infs and nans
+    if (np.any(np.isinf(lb)) or np.any(np.isinf(ub))):
+        raise ValueError("Bounds must not be inf.")
 
     # validate tolerances
     if (vol_tol < 0 or vol_tol > 1):

--- a/scipy/optimize/_direct_py.py
+++ b/scipy/optimize/_direct_py.py
@@ -215,7 +215,7 @@ def direct(
     # check that lower bounds are smaller than upper bounds
     if not np.all(lb < ub):
         raise ValueError('Bounds are not consistent min < max')
-    # check for infs and nans
+    # check for infs
     if (np.any(np.isinf(lb)) or np.any(np.isinf(ub))):
         raise ValueError("Bounds must not be inf.")
 

--- a/scipy/optimize/tests/test_direct.py
+++ b/scipy/optimize/tests/test_direct.py
@@ -223,13 +223,13 @@ class TestDIRECT:
                    len_tol=len_tol)
 
     @pytest.mark.parametrize("vol_tol", [-1, 2])
-    def test_len_tol_validation(self, vol_tol):
+    def test_vol_tol_validation(self, vol_tol):
         error_msg = "vol_tol must be between 0 and 1."
         with pytest.raises(ValueError, match=error_msg):
             direct(self.styblinski_tang, self.bounds_stylinski_tang,
                    vol_tol=vol_tol)
 
-    @pytest.mark.parametrize("f_min_rtol", [-1, 2, np.inf, -np.inf])
+    @pytest.mark.parametrize("f_min_rtol", [-1, 2])
     def test_fmin_rtol_validation(self, f_min_rtol):
         error_msg = "f_min_rtol must be between 0 and 1."
         with pytest.raises(ValueError, match=error_msg):
@@ -269,21 +269,18 @@ class TestDIRECT:
         with pytest.raises(ValueError, match=error_msg):
             direct(self.styblinski_tang, bounds)
 
-    def test_incorrect_bounds(self):
+    @pytest.mark.parametrize("bounds",
+                             [Bounds([-1., -1], [-2, 1]),
+                              Bounds([-np.nan, -1], [-2, np.nan])
+                             ])
+    def test_incorrect_bounds(self, bounds):
         error_msg = 'Bounds are not consistent min < max'
-        bounds = Bounds([-1., -1], [-2, 1])
         with pytest.raises(ValueError, match=error_msg):
             direct(self.styblinski_tang, bounds)
 
     def test_inf_bounds(self):
         error_msg = 'Bounds must not be inf.'
         bounds = Bounds([-np.inf, -1], [-2, np.inf])
-        with pytest.raises(ValueError, match=error_msg):
-            direct(self.styblinski_tang, bounds)
-
-    def test_nan_bounds(self):
-        error_msg = 'Bounds must not be NaN.'
-        bounds = Bounds([np.nan, -1], [-2, np.nan])
         with pytest.raises(ValueError, match=error_msg):
             direct(self.styblinski_tang, bounds)
 

--- a/scipy/optimize/tests/test_direct.py
+++ b/scipy/optimize/tests/test_direct.py
@@ -299,6 +299,7 @@ class TestDIRECT:
                               Bounds([-np.nan, -1], [-2, np.nan]),
                               ]
                              )
+
     def test_incorrect_bounds(self, bounds):
         error_msg = 'Bounds are not consistent min < max'
         with pytest.raises(ValueError, match=error_msg):

--- a/scipy/optimize/tests/test_direct.py
+++ b/scipy/optimize/tests/test_direct.py
@@ -117,7 +117,8 @@ class TestDIRECT:
         assert res.success
         assert_allclose(res.x, np.zeros((4, )))
         message = ("The side length measure of the hyperrectangle containing "
-                   f"the lowest function value found is below len_tol={len_tol}")
+                   "the lowest function value found is below "
+                   f"len_tol={len_tol}")
         assert res.message == message
 
     @pytest.mark.parametrize("vol_tol", [1e-6, 1e-8])
@@ -295,8 +296,9 @@ class TestDIRECT:
 
     @pytest.mark.parametrize("bounds",
                              [Bounds([-1., -1], [-2, 1]),
-                              Bounds([-np.nan, -1], [-2, np.nan])
-                             ])
+                              Bounds([-np.nan, -1], [-2, np.nan]),
+                              ]
+                             )
     def test_incorrect_bounds(self, bounds):
         error_msg = 'Bounds are not consistent min < max'
         with pytest.raises(ValueError, match=error_msg):

--- a/scipy/optimize/tests/test_direct.py
+++ b/scipy/optimize/tests/test_direct.py
@@ -214,3 +214,82 @@ class TestDIRECT:
         result = direct(self.inf_fun, bounds,
                         locally_biased=locally_biased)
         assert result is not None
+
+    @pytest.mark.parametrize("len_tol", [-1, 2])
+    def test_len_tol_validation(self, len_tol):
+        error_msg = "len_tol must be between 0 and 1."
+        with pytest.raises(ValueError, match=error_msg):
+            direct(self.styblinski_tang, self.bounds_stylinski_tang,
+                   len_tol=len_tol)
+
+    @pytest.mark.parametrize("vol_tol", [-1, 2])
+    def test_len_tol_validation(self, vol_tol):
+        error_msg = "vol_tol must be between 0 and 1."
+        with pytest.raises(ValueError, match=error_msg):
+            direct(self.styblinski_tang, self.bounds_stylinski_tang,
+                   vol_tol=vol_tol)
+
+    @pytest.mark.parametrize("f_min_rtol", [-1, 2, np.inf, -np.inf])
+    def test_fmin_rtol_validation(self, f_min_rtol):
+        error_msg = "f_min_rtol must be between 0 and 1."
+        with pytest.raises(ValueError, match=error_msg):
+            direct(self.styblinski_tang, self.bounds_stylinski_tang,
+                   f_min_rtol=f_min_rtol, f_min=0.)
+
+    @pytest.mark.parametrize("maxfun", [1.5, "string", (1, 2)])
+    def test_maxfun_wrong_type(self, maxfun):
+        error_msg = "maxfun must be of type int."
+        with pytest.raises(ValueError, match=error_msg):
+            direct(self.styblinski_tang, self.bounds_stylinski_tang,
+                   maxfun=maxfun)
+
+    @pytest.mark.parametrize("maxiter", [1.5, "string", (1, 2)])
+    def test_maxiter_wrong_type(self, maxiter):
+        error_msg = "maxiter must be of type int."
+        with pytest.raises(ValueError, match=error_msg):
+            direct(self.styblinski_tang, self.bounds_stylinski_tang,
+                   maxiter=maxiter)
+
+    def test_negative_maxiter(self):
+        error_msg = "maxiter must be > 0."
+        with pytest.raises(ValueError, match=error_msg):
+            direct(self.styblinski_tang, self.bounds_stylinski_tang,
+                   maxiter=-1)
+
+    def test_negative_maxfun(self):
+        error_msg = "maxfun must be > 0."
+        with pytest.raises(ValueError, match=error_msg):
+            direct(self.styblinski_tang, self.bounds_stylinski_tang,
+                   maxfun=-1)
+
+    @pytest.mark.parametrize("bounds", ["bounds", 2., 0])
+    def test_invalid_bounds_type(self, bounds):
+        error_msg = ("bounds must be a sequence or "
+                     "instance of Bounds class")
+        with pytest.raises(ValueError, match=error_msg):
+            direct(self.styblinski_tang, bounds)
+
+    def test_incorrect_bounds(self):
+        error_msg = 'Bounds are not consistent min < max'
+        bounds = Bounds([-1., -1], [-2, 1])
+        with pytest.raises(ValueError, match=error_msg):
+            direct(self.styblinski_tang, bounds)
+
+    def test_inf_bounds(self):
+        error_msg = 'Bounds must not be inf.'
+        bounds = Bounds([-np.inf, -1], [-2, np.inf])
+        with pytest.raises(ValueError, match=error_msg):
+            direct(self.styblinski_tang, bounds)
+
+    def test_nan_bounds(self):
+        error_msg = 'Bounds must not be NaN.'
+        bounds = Bounds([np.nan, -1], [-2, np.nan])
+        with pytest.raises(ValueError, match=error_msg):
+            direct(self.styblinski_tang, bounds)
+
+    @pytest.mark.parametrize("locally_biased", ["bias", [0, 0], 2.])
+    def test_locally_biased_validation(self, locally_biased):
+        error_msg = 'locally_biased must be True or False.'
+        with pytest.raises(ValueError, match=error_msg):
+            direct(self.styblinski_tang, self.bounds_stylinski_tang,
+                   locally_biased=locally_biased)

--- a/scipy/optimize/tests/test_direct.py
+++ b/scipy/optimize/tests/test_direct.py
@@ -116,6 +116,22 @@ class TestDIRECT:
         assert res.status == 5
         assert res.success
         assert_allclose(res.x, np.zeros((4, )))
+        message = ("The side length measure of the hyperrectangle containing "
+                   f"the lowest function value found is below len_tol={len_tol}")
+        assert res.message == message
+
+    @pytest.mark.parametrize("vol_tol", [1e-6, 1e-8])
+    @pytest.mark.parametrize("locally_biased", [True, False])
+    def test_vol_tol(self, vol_tol, locally_biased):
+        bounds = 4*[(-10., 10.)]
+        res = direct(self.sphere, bounds=bounds, vol_tol=vol_tol,
+                     len_tol=0., locally_biased=locally_biased)
+        assert res.status == 4
+        assert res.success
+        assert_allclose(res.x, np.zeros((4, )))
+        message = ("The volume of the hyperrectangle containing the lowest "
+                   f"function value found is below vol_tol={vol_tol}")
+        assert res.message == message
 
     @pytest.mark.parametrize("f_min_rtol", [1e-3, 1e-5, 1e-7])
     @pytest.mark.parametrize("locally_biased", [True, False])
@@ -130,6 +146,9 @@ class TestDIRECT:
         assert res.status == 3
         assert res.success
         assert res.fun < f_min * (1. + f_min_rtol)
+        message = ("The best function value found is within a relative "
+                   f"error={f_min_rtol} of the (known) global optimum f_min")
+        assert res.message == message
 
     def circle_with_args(self, x, a, b):
         return np.square(x[0] - a) + np.square(x[1] - b).sum()
@@ -153,6 +172,9 @@ class TestDIRECT:
         assert result.success is False
         assert result.status == 1
         assert result.nfev >= maxfun
+        message = ("Number of function evaluations done is "
+                   f"larger than maxfun={maxfun}")
+        assert result.message == message
 
     @pytest.mark.parametrize("locally_biased", [True, False])
     def test_failure_maxiter(self, locally_biased):
@@ -165,6 +187,8 @@ class TestDIRECT:
         assert result.success is False
         assert result.status == 2
         assert result.nit >= maxiter
+        message = f"Number of iterations is larger than maxiter={maxiter}"
+        assert result.message == message
 
     @pytest.mark.parametrize("locally_biased", [True, False])
     def test_bounds_variants(self, locally_biased):

--- a/scipy/optimize/tests/test_direct.py
+++ b/scipy/optimize/tests/test_direct.py
@@ -299,7 +299,6 @@ class TestDIRECT:
                               Bounds([-np.nan, -1], [-2, np.nan]),
                               ]
                              )
-
     def test_incorrect_bounds(self, bounds):
         error_msg = 'Bounds are not consistent min < max'
         with pytest.raises(ValueError, match=error_msg):


### PR DESCRIPTION
#### Reference issue
The test coverage for [_direct_py.py](https://github.com/scipy/scipy/blob/main/scipy/optimize/_direct_py.py) is only 46%. https://app.codecov.io/gh/scipy/scipy/tree/master/scipy/optimize

#### What does this implement/fix?
Additional tests for all the input validation and return messages are added.

It turned out that two input validation if statements are actually not necessary (covered by the Bounds class or by the check that lower bounds must be indeed lower than the upper bounds), so they were removed

#### Additional information
CC @czgdp1807 : would you have time to review? I guess it would be a lot easier for you than any other scipy maintainer.