### PR TITLE
MAINT: stats.gaussian_kde: error early if n_features > n_data

### DIFF
--- a/scipy/stats/_kde.py
+++ b/scipy/stats/_kde.py
@@ -209,6 +209,16 @@ class gaussian_kde:
                 raise ValueError("`weights` input should be of length n")
             self._neff = 1/sum(self._weights**2)
 
+        # This can be converted to a warning once gh-10205 is resolved
+        if self.d > self.n:
+            msg = ("Number of dimensions is greater than number of samples. "
+                   "This results in a singular data covariance matrix, which "
+                   "cannot be treated using the algorithms implemented in "
+                   "`gaussian_kde`. Note that `gaussian_kde` interprets each "
+                   "*column* of `dataset` to be a point; consider transposing "
+                   "the input to `dataset`.")
+            raise ValueError(msg)
+
         try:
             self.set_bandwidth(bw_method=bw_method)
         except linalg.LinAlgError as e:

--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -589,3 +589,16 @@ def test_singular_data_covariance_gh10205():
         msg = "The data appears to lie in a lower-dimensional subspace..."
         with assert_raises(linalg.LinAlgError, match=msg):
             stats.gaussian_kde(data.T)
+
+
+def test_fewer_points_than_dimensions_gh17436():
+    # When the number of points is fewer than the number of dimensions, the
+    # the covariance matrix would be singular, and the exception tested in
+    # test_singular_data_covariance_gh10205 would occur. However, sometimes
+    # this occurs when the user passes in the transpose of what `gaussian_kde`
+    # expects. This can result in a huge covariance matrix, so bail early.
+    rng = np.random.default_rng(2046127537594925772)
+    rvs = rng.multivariate_normal(np.zeros(3), np.eye(3), size=5)
+    message = "Number of dimensions is greater than number of samples..."
+    with pytest.raises(ValueError, match=message):
+        stats.gaussian_kde(rvs)


### PR DESCRIPTION
#### Reference issue
Resolves the scipy.stats part of gh-17436

#### What does this implement/fix?
When the `dataset` passed into `gaussian_kde` has fewer points than dimensions, the covariance matrix would be singular, and `gaussian_kde` would error out when attempting to perform Cholesky decomposition. However, sometimes this occurs when the user passes in the transpose of what `gaussian_kde` expects. This can result in a huge covariance matrix, causing problems like gh-17436. This PR prevents such problems by raising an error early, whenever the the `dataset` passed into `gaussian_kde`  has more dimensions than points.
