### PR TITLE
MAINT: optimize.fminbound/minimize_scalar: add references, distinguish between minimum and minimizer

### DIFF
--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -797,17 +797,17 @@ def minimize_scalar(fun, bracket=None, bounds=None, args=(),
     'method' parameter. The default method is *Brent*.
 
     Method :ref:`Brent <optimize.minimize_scalar-brent>` uses Brent's
-    algorithm to find a local minimum.  The algorithm uses inverse
+    algorithm [1]_ to find a local minimum.  The algorithm uses inverse
     parabolic interpolation when possible to speed up convergence of
     the golden section method.
 
     Method :ref:`Golden <optimize.minimize_scalar-golden>` uses the
-    golden section search technique. It uses analog of the bisection
+    golden section search technique [1]_. It uses analog of the bisection
     method to decrease the bracketed interval. It is usually
     preferable to use the *Brent* method.
 
     Method :ref:`Bounded <optimize.minimize_scalar-bounded>` can
-    perform bounded minimization. It uses the Brent method to find a
+    perform bounded minimization [2]_ [3]_. It uses the Brent method to find a
     local minimum in the interval x1 < xopt < x2.
 
     **Custom minimizers**
@@ -829,6 +829,16 @@ def minimize_scalar(fun, bracket=None, bounds=None, args=(),
 
     .. versionadded:: 0.11.0
 
+    References
+    ----------
+    .. [1] Press, W., S.A. Teukolsky, W.T. Vetterling, and B.P. Flannery.
+           Numerical Recipes in C. Cambridge University Press.
+    .. [2] Forsythe, G.E., M. A. Malcolm, and C. B. Moler. "Computer Methods
+           for Mathematical Computations." Prentice-Hall Series in Automatic
+           Computation 259 (1977).
+    .. [3] Brent, Richard P. Algorithms for Minimization Without Derivatives.
+           Courier Corporation, 2013.
+
     Examples
     --------
     Consider the problem of minimizing the following function.
@@ -840,6 +850,11 @@ def minimize_scalar(fun, bracket=None, bounds=None, args=(),
 
     >>> from scipy.optimize import minimize_scalar
     >>> res = minimize_scalar(f)
+    >>> res.fun
+    -9.9149495908
+
+    The minimizer is:
+
     >>> res.x
     1.28077640403
 
@@ -847,7 +862,9 @@ def minimize_scalar(fun, bracket=None, bounds=None, args=(),
     bounds as:
 
     >>> res = minimize_scalar(f, bounds=(-3, -1), method='bounded')
-    >>> res.x
+    >>> res.fun  # minimum
+    3.28365179850e-13
+    >>> res.x  # minimizer
     -2.0000002026
 
     """

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -2110,7 +2110,7 @@ def fminbound(func, x1, x2, args=(), xtol=1e-5, maxfun=500,
         Parameters (over given interval) which minimize the
         objective function.
     fval : number
-        The function value at the minimum point.
+        The function value evaluated at the minimizer.
     ierr : int
         An error flag (0 if converged, 1 if maximum number of
         function calls reached).
@@ -2128,22 +2128,34 @@ def fminbound(func, x1, x2, args=(), xtol=1e-5, maxfun=500,
     interval x1 < xopt < x2 using Brent's method. (See `brent`
     for auto-bracketing.)
 
+    References
+    ----------
+    .. [1] Forsythe, G.E., M. A. Malcolm, and C. B. Moler. "Computer Methods
+           for Mathematical Computations." Prentice-Hall Series in Automatic
+           Computation 259 (1977).
+    .. [2] Brent, Richard P. Algorithms for Minimization Without Derivatives.
+           Courier Corporation, 2013.
+
     Examples
     --------
-    `fminbound` finds the minimum of the function in the given range.
-    The following examples illustrate the same
-
-    >>> def f(x):
-    ...     return x**2
+    `fminbound` finds the minimizer of the function in the given range.
+    The following examples illustrate this.
 
     >>> from scipy import optimize
-
-    >>> minimum = optimize.fminbound(f, -1, 2)
+    >>> def f(x):
+    ...     return (x-1)**2
+    >>> minimizer = optimize.fminbound(f, -4, 4)
+    >>> minimizer
+    1.0
+    >>> minimum = f(minimizer)
     >>> minimum
     0.0
-    >>> minimum = optimize.fminbound(f, 1, 2)
+    >>> minimizer = optimize.fminbound(f, 3, 4)
+    >>> minimizer
+    3.000005960860986
+    >>> minimum = f(minimizer)
     >>> minimum
-    1.0000059608609866
+    4.000023843479476
     """
     options = {'xatol': xtol,
                'maxiter': maxfun,


### PR DESCRIPTION
#### Reference issue
Closes gh-12621
Closes gh-17445

#### What does this implement/fix?
This adds references to `fminbound` and `minimize_scalar` and distinguishes between "minimum" and "minimizer" in the examples.

#### Additional information
Numerical recipes in C was cited in original code comments of `brent` and `golden`; see https://github.com/scipy/scipy/commit/b94c30dcb1ba9ad0b4c3e2090f5e99a8a21275ab

`fminbound`/`method='bounded'` code did not give any clues:
https://github.com/scipy/scipy/commit/3f44f63b481abf676a0b344fc836acf76bc86b35

But the output of this code:
```python3
import numpy as np
from scipy import optimize
fun = np.sin
x1 = 0
x2 = 2*np.pi
optimize.fminbound(fun, x1, x2, disp=3)
```
is:
```
 Func-count     x          f(x)          Procedure
    1        2.39996      0.67549        initial
    2        3.88322     -0.67549        golden
    3        4.79993    -0.996171        golden
    4        5.08984    -0.929607        parabolic
    5        4.70582    -0.999978        parabolic
    6         4.7118           -1        parabolic
    7        4.71239           -1        parabolic
    8        4.71239           -1        parabolic
    9        4.71238           -1        parabolic

Optimization terminated successfully;
The returned value satisfies the termination criteria
(using xtol =  1e-05 )
4.7123876779707
```
Which is essentially identically to the output of Matlab's `fminbnd` for the same problem:
https://www.mathworks.com/help/matlab/ref/fminbnd.html

Suggesting that the references provided by Matlab are appropriate.

@jupsal please confirm that this addresses your gh-17445 or suggest changes.