### PR TITLE
Deprecate scipy.signal.{bspline, quadratic, cubic}

### DIFF
--- a/doc/source/tutorial/signal.rst
+++ b/doc/source/tutorial/signal.rst
@@ -95,9 +95,7 @@ coefficients by assuming them to be mirror-symmetric also.
 Currently the package provides functions for determining second- and third-
 order cubic spline coefficients from equally-spaced samples in one and two
 dimensions (:func:`qspline1d`, :func:`qspline2d`, :func:`cspline1d`,
-:func:`cspline2d`). The package also supplies a function ( :func:`bspline` )
-for evaluating the B-spline basis function, :math:`\beta^{o}\left(x\right)` for
-arbitrary order and :math:`x.` For large :math:`o`, the B-spline basis
+:func:`cspline2d`). For large :math:`o`, the B-spline basis
 function can be approximated well by a zero-mean Gaussian function with
 standard-deviation equal to :math:`\sigma_{o}=\left(o+1\right)/12` :
 

--- a/scipy/signal/_bsplines.py
+++ b/scipy/signal/_bsplines.py
@@ -2,6 +2,7 @@ from numpy import (logical_and, asarray, pi, zeros_like,
                    piecewise, array, arctan2, tan, zeros, arange, floor)
 from numpy.core.umath import (sqrt, exp, greater, less, cos, add, sin,
                               less_equal, greater_equal)
+import numpy as np
 
 # From splinemodule.c
 from ._spline import cspline2d, sepfir2d
@@ -141,6 +142,18 @@ def _bspline_piecefunctions(order):
     return funclist, condfuncs
 
 
+msg_bspline="""`scipy.signal.bspline` is deprecated in SciPy 1.11 and will be
+removed in SciPy 1.13.
+
+The exact equivalent (for a float array `x`) is
+
+>>> from scipy.interpolate import BSpline
+>>> knots = np.arange(-(n+1)/2, (n+3)/2)
+>>> out = BSpline.basis_element(knots)(x)
+>>> out[(x < knots[0]) | (x > knots[-1])] = 0.0
+"""
+
+@np.deprecate(message=msg_bspline)
 def bspline(x, n):
     """B-spline basis function of order n.
 
@@ -190,7 +203,6 @@ def bspline(x, n):
     out = BSpline.basis_element(knots)(x)
     out[(x < knots[0]) | (x > knots[-1])] = 0
     return out
-
 
 
 def gauss_spline(x, n):
@@ -246,6 +258,17 @@ def gauss_spline(x, n):
     return 1 / sqrt(2 * pi * signsq) * exp(-x ** 2 / 2 / signsq)
 
 
+msg_cubic="""`scipy.signal.cubic` is deprecated in SciPy 1.11 and will be
+removed in SciPy 1.13.
+
+The exact equivalent (for a float array `x`) is
+
+>>> from scipy.interpolate import BSpline
+>>> out = BSpline.basis_element([-2, -1, 0, 1, 2])(x)
+>>> out[(x < -2 | (x > 2)] = 0.0
+"""
+
+@np.deprecate(message=msg_cubic)
 def cubic(x):
     """A cubic B-spline.
 
@@ -292,8 +315,25 @@ def cubic(x):
     out[(x < -2) | (x > 2)] = 0
     return out
 
+def _cubic(x):
+    x = asarray(x, dtype=float)
+    b = BSpline.basis_element([-2, -1, 0, 1, 2], extrapolate=False)
+    out = b(x)
+    out[(x < -2) | (x > 2)] = 0
+    return out
 
 
+msg_quadratic="""`scipy.signal.quadratic` is deprecated in SciPy 1.11 and
+will be removed in SciPy 1.13.
+
+The exact equivalent (for a float array `x`) is
+
+>>> from scipy.interpolate import BSpline
+>>> out = BSpline.basis_element([-1.5, -0.5, 0.5, 1.5])(x)
+>>> out[(x < -1.5 | (x > 1.5)] = 0.0
+"""
+
+@np.deprecate(message=msg_quadratic)
 def quadratic(x):
     """A quadratic B-spline.
 
@@ -334,6 +374,14 @@ def quadratic(x):
     True
 
     """
+    x = abs(asarray(x, dtype=float))
+    b = BSpline.basis_element([-1.5, -0.5, 0.5, 1.5], extrapolate=False)
+    out = b(x)
+    out[(x < -1.5) | (x > 1.5)] = 0
+    return out
+
+
+def _quadratic(x):
     x = abs(asarray(x, dtype=float))
     b = BSpline.basis_element([-1.5, -0.5, 0.5, 1.5], extrapolate=False)
     out = b(x)
@@ -593,7 +641,7 @@ def cspline1d_eval(cj, newx, dx=1.0, x0=0):
     for i in range(4):
         thisj = jlower + i
         indj = thisj.clip(0, N - 1)  # handle edge cases
-        result += cj[indj] * cubic(newx - thisj)
+        result += cj[indj] * _cubic(newx - thisj)
     res[cond3] = result
     return res
 
@@ -669,6 +717,6 @@ def qspline1d_eval(cj, newx, dx=1.0, x0=0):
     for i in range(3):
         thisj = jlower + i
         indj = thisj.clip(0, N - 1)  # handle edge cases
-        result += cj[indj] * quadratic(newx - thisj)
+        result += cj[indj] * _quadratic(newx - thisj)
     res[cond3] = result
     return res

--- a/scipy/signal/_bsplines.py
+++ b/scipy/signal/_bsplines.py
@@ -9,6 +9,7 @@ from ._spline import cspline2d, sepfir2d
 
 from scipy.special import comb
 from scipy._lib._util import float_factorial
+from scipy.interpolate import BSpline
 
 __all__ = ['spline_filter', 'bspline', 'gauss_spline', 'cubic', 'quadratic',
            'cspline1d', 'qspline1d', 'cspline1d_eval', 'qspline1d_eval']
@@ -141,7 +142,7 @@ def _bspline_piecefunctions(order):
     return funclist, condfuncs
 
 
-msg_bspline="""`scipy.signal.bspline` is deprecated in SciPy 1.11 and will be
+msg_bspline = """`scipy.signal.bspline` is deprecated in SciPy 1.11 and will be
 removed in SciPy 1.13.
 
 The exact equivalent (for a float array `x`) is
@@ -151,6 +152,7 @@ The exact equivalent (for a float array `x`) is
 >>> out = BSpline.basis_element(knots)(x)
 >>> out[(x < knots[0]) | (x > knots[-1])] = 0.0
 """
+
 
 @np.deprecate(message=msg_bspline)
 def bspline(x, n):
@@ -256,7 +258,7 @@ def gauss_spline(x, n):
     return 1 / sqrt(2 * pi * signsq) * exp(-x ** 2 / 2 / signsq)
 
 
-msg_cubic="""`scipy.signal.cubic` is deprecated in SciPy 1.11 and will be
+msg_cubic = """`scipy.signal.cubic` is deprecated in SciPy 1.11 and will be
 removed in SciPy 1.13.
 
 The exact equivalent (for a float array `x`) is
@@ -265,6 +267,7 @@ The exact equivalent (for a float array `x`) is
 >>> out = BSpline.basis_element([-2, -1, 0, 1, 2])(x)
 >>> out[(x < -2 | (x > 2)] = 0.0
 """
+
 
 @np.deprecate(message=msg_cubic)
 def cubic(x):
@@ -307,7 +310,7 @@ def cubic(x):
     True
 
     """
-    ax = abs(asarray(x))
+    ax = abs(asarray(x, dtype=float))
     res = zeros_like(ax)
     cond1 = less(ax, 1)
     if cond1.any():
@@ -319,6 +322,7 @@ def cubic(x):
         res[cond2] = 1.0 / 6 * (2 - ax2) ** 3
     return res
 
+
 def _cubic(x):
     x = asarray(x, dtype=float)
     b = BSpline.basis_element([-2, -1, 0, 1, 2], extrapolate=False)
@@ -327,7 +331,7 @@ def _cubic(x):
     return out
 
 
-msg_quadratic="""`scipy.signal.quadratic` is deprecated in SciPy 1.11 and
+msg_quadratic = """`scipy.signal.quadratic` is deprecated in SciPy 1.11 and
 will be removed in SciPy 1.13.
 
 The exact equivalent (for a float array `x`) is
@@ -336,6 +340,7 @@ The exact equivalent (for a float array `x`) is
 >>> out = BSpline.basis_element([-1.5, -0.5, 0.5, 1.5])(x)
 >>> out[(x < -1.5 | (x > 1.5)] = 0.0
 """
+
 
 @np.deprecate(message=msg_quadratic)
 def quadratic(x):

--- a/scipy/signal/_bsplines.py
+++ b/scipy/signal/_bsplines.py
@@ -184,7 +184,7 @@ def bspline(x, n):
     True
 
     """
-    ax = -abs(asarray(x))
+    ax = -abs(asarray(x, dtype=float))
     # number of pieces on the left-side is (n+1)/2
     funclist, condfuncs = _bspline_piecefunctions(n)
     condlist = [func(ax) for func in condfuncs]
@@ -337,7 +337,7 @@ def quadratic(x):
     True
 
     """
-    ax = abs(asarray(x))
+    ax = abs(asarray(x, dtype=float))
     res = zeros_like(ax)
     cond1 = less(ax, 0.5)
     if cond1.any():

--- a/scipy/signal/tests/test_bsplines.py
+++ b/scipy/signal/tests/test_bsplines.py
@@ -1,7 +1,8 @@
 # pylint: disable=missing-docstring
 import numpy as np
 from numpy import array
-from numpy.testing import (assert_allclose, assert_array_equal,
+from numpy.testing import (assert_equal,
+                           assert_allclose, assert_array_equal,
                            assert_almost_equal)
 import pytest
 from pytest import raises
@@ -11,8 +12,10 @@ from scipy import signal
 
 
 class TestBSplines:
-    """Test behaviors of B-splines. The values tested against were returned as of
-    SciPy 1.1.0 and are included for regression testing purposes"""
+    """Test behaviors of B-splines. Some of the values tested against were 
+    returned as of SciPy 1.1.0 and are included for regression testing 
+    purposes. Others (at integer points) are compared to theoretical 
+    expressions (cf. Unser, Aldroubi, Eden, IEEE TSP 1993, Table 1)."""
 
     def test_spline_filter(self):
         np.random.seed(12457)
@@ -103,6 +106,20 @@ class TestBSplines:
 
     def test_bspline(self):
         np.random.seed(12458)
+        # Verify with theoretical results at integer points up to order 5
+        assert_allclose(bsp.bspline([-1, 0, 1], 0),
+                        array([0, 1, 0]))
+        assert_allclose(bsp.bspline([-1, 0, 1], 1),
+                        array([0, 1, 0]))
+        assert_allclose(bsp.bspline([-2, -1, 0, 1, 2], 2),
+                        array([0, 1, 6, 1, 0])/8.)
+        assert_allclose(bsp.bspline([-2, -1, 0, 1, 2], 3),
+                        array([0, 1, 4, 1, 0])/6.)
+        assert_allclose(bsp.bspline([-3, -2, -1, 0, 1, 2, 3], 4),
+                        array([0, 1, 76, 230, 76, 1, 0])/384.)
+        assert_allclose(bsp.bspline([-3, -2, -1, 0, 1, 2, 3], 5),
+                        array([0, 1, 26, 66, 26, 1, 0]) / 120.)
+        # Compare with SciPy 1.1.0
         assert_allclose(bsp.bspline(np.random.rand(1, 1), 2),
                         array([[0.73694695]]))
         data_array_complex = np.random.rand(4, 4) + np.random.rand(4, 4)*1j
@@ -128,7 +145,10 @@ class TestBSplines:
 
     def test_cubic(self):
         np.random.seed(12460)
-        assert_array_equal(bsp.cubic([0]), array([0]))
+        # Verify with theoretical results at integer points (see docstring)
+        assert_allclose(bsp.cubic([-2, -1, 0, 1, 2]),
+                        array([0, 1, 4, 1, 0])/6.)
+        # Compare with SciPy 1.1.0
         data_array_complex = np.random.rand(4, 4) + np.random.rand(4, 4)*1j
         data_array_complex = 1+1j-2*data_array_complex
         # scaling the magnitude by 10 makes the results close enough to zero,
@@ -143,7 +163,10 @@ class TestBSplines:
 
     def test_quadratic(self):
         np.random.seed(12461)
-        assert_array_equal(bsp.quadratic([0]), array([0]))
+        # Verify correct results at integer points
+        assert_allclose(bsp.quadratic([-2, -1, 0, 1, 2]),
+                        array([0, 1, 6, 1, 0])/8.)
+        # Compare with SciPy 1.1.0
         data_array_complex = np.random.rand(4, 4) + np.random.rand(4, 4)*1j
         # scaling the magnitude by 10 makes the results all zero,
         # so just make the elements have a mix of positive and negative

--- a/scipy/signal/tests/test_bsplines.py
+++ b/scipy/signal/tests/test_bsplines.py
@@ -1,8 +1,7 @@
 # pylint: disable=missing-docstring
 import numpy as np
 from numpy import array
-from numpy.testing import (assert_equal,
-                           assert_allclose, assert_array_equal,
+from numpy.testing import (assert_allclose, assert_array_equal,
                            assert_almost_equal, suppress_warnings)
 import pytest
 from pytest import raises
@@ -12,9 +11,9 @@ from scipy import signal
 
 
 class TestBSplines:
-    """Test behaviors of B-splines. Some of the values tested against were 
-    returned as of SciPy 1.1.0 and are included for regression testing 
-    purposes. Others (at integer points) are compared to theoretical 
+    """Test behaviors of B-splines. Some of the values tested against were
+    returned as of SciPy 1.1.0 and are included for regression testing
+    purposes. Others (at integer points) are compared to theoretical
     expressions (cf. Unser, Aldroubi, Eden, IEEE TSP 1993, Table 1)."""
 
     def test_spline_filter(self):

--- a/scipy/signal/tests/test_bsplines.py
+++ b/scipy/signal/tests/test_bsplines.py
@@ -3,7 +3,7 @@ import numpy as np
 from numpy import array
 from numpy.testing import (assert_equal,
                            assert_allclose, assert_array_equal,
-                           assert_almost_equal)
+                           assert_almost_equal, suppress_warnings)
 import pytest
 from pytest import raises
 
@@ -68,22 +68,24 @@ class TestBSplines:
 
     def test_bspline(self):
         # Verify with theoretical results at integer points up to order 5
-        assert_allclose(bsp.bspline([-1, 0, 1], 0),
-                        array([0, 1, 0]))
-        assert_allclose(bsp.bspline([-1, 0, 1], 1),
-                        array([0, 1, 0]))
-        assert_allclose(bsp.bspline([-2, -1, 0, 1, 2], 2),
-                        array([0, 1, 6, 1, 0])/8.)
-        assert_allclose(bsp.bspline([-2, -1, 0, 1, 2], 3),
-                        array([0, 1, 4, 1, 0])/6.)
-        assert_allclose(bsp.bspline([-3, -2, -1, 0, 1, 2, 3], 4),
-                        array([0, 1, 76, 230, 76, 1, 0])/384.)
-        assert_allclose(bsp.bspline([-3, -2, -1, 0, 1, 2, 3], 5),
-                        array([0, 1, 26, 66, 26, 1, 0]) / 120.)
-        # Compare with SciPy 1.1.0
-        np.random.seed(12458)
-        assert_allclose(bsp.bspline(np.random.rand(1, 1), 2),
-                        array([[0.73694695]]))
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning)
+            assert_allclose(bsp.bspline([-1, 0, 1], 0),
+                            array([0, 1, 0]))
+            assert_allclose(bsp.bspline([-1, 0, 1], 1),
+                            array([0, 1, 0]))
+            assert_allclose(bsp.bspline([-2, -1, 0, 1, 2], 2),
+                            array([0, 1, 6, 1, 0])/8.)
+            assert_allclose(bsp.bspline([-2, -1, 0, 1, 2], 3),
+                            array([0, 1, 4, 1, 0])/6.)
+            assert_allclose(bsp.bspline([-3, -2, -1, 0, 1, 2, 3], 4),
+                            array([0, 1, 76, 230, 76, 1, 0])/384.)
+            assert_allclose(bsp.bspline([-3, -2, -1, 0, 1, 2, 3], 5),
+                            array([0, 1, 26, 66, 26, 1, 0]) / 120.)
+            # Compare with SciPy 1.1.0
+            np.random.seed(12458)
+            assert_allclose(bsp.bspline(np.random.rand(1, 1), 2),
+                            array([[0.73694695]]))
 
     def test_gauss_spline(self):
         np.random.seed(12459)
@@ -97,16 +99,20 @@ class TestBSplines:
                             array([0.15418033, 0.6909883, 0.15418033]))
 
     def test_cubic(self):
-        np.random.seed(12460)
-        # Verify with theoretical results at integer points (see docstring)
-        assert_allclose(bsp.cubic([-2, -1, 0, 1, 2]),
-                        array([0, 1, 4, 1, 0])/6.)
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning)
+            np.random.seed(12460)
+            # Verify with theoretical results at integer points (see docstring)
+            assert_allclose(bsp.cubic([-2, -1, 0, 1, 2]),
+                            array([0, 1, 4, 1, 0])/6.)
 
     def test_quadratic(self):
         np.random.seed(12461)
-        # Verify correct results at integer points
-        assert_allclose(bsp.quadratic([-2, -1, 0, 1, 2]),
-                        array([0, 1, 6, 1, 0])/8.)
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning)
+            # Verify correct results at integer points
+            assert_allclose(bsp.quadratic([-2, -1, 0, 1, 2]),
+                            array([0, 1, 6, 1, 0])/8.)
 
     def test_cspline1d(self):
         np.random.seed(12462)

--- a/scipy/signal/tests/test_bsplines.py
+++ b/scipy/signal/tests/test_bsplines.py
@@ -21,44 +21,6 @@ class TestBSplines:
         np.random.seed(12457)
         # Test the type-error branch
         raises(TypeError, bsp.spline_filter, array([0]), 0)
-        # Test the complex branch
-        data_array_complex = np.random.rand(7, 7) + np.random.rand(7, 7)*1j
-        # make the magnitude exceed 1, and make some negative
-        data_array_complex = 10*(1+1j-2*data_array_complex)
-        result_array_complex = array(
-            [[-4.61489230e-01-1.92994022j, 8.33332443+6.25519943j,
-              6.96300745e-01-9.05576038j, 5.28294849+3.97541356j,
-              5.92165565+7.68240595j, 6.59493160-1.04542804j,
-              9.84503460-5.85946894j],
-             [-8.78262329-8.4295969j, 7.20675516+5.47528982j,
-              -8.17223072+2.06330729j, -4.38633347-8.65968037j,
-              9.89916801-8.91720295j, 2.67755103+8.8706522j,
-              6.24192142+3.76879835j],
-             [-3.15627527+2.56303072j, 9.87658501-0.82838702j,
-              -9.96930313+8.72288895j, 3.17193985+6.42474651j,
-              -4.50919819-6.84576082j, 5.75423431+9.94723988j,
-              9.65979767+6.90665293j],
-             [-8.28993416-6.61064005j, 9.71416473e-01-9.44907284j,
-              -2.38331890+9.25196648j, -7.08868170-0.77403212j,
-              4.89887714+7.05371094j, -1.37062311-2.73505688j,
-              7.70705748+2.5395329j],
-             [2.51528406-1.82964492j, 3.65885472+2.95454836j,
-              5.16786575-1.66362023j, -8.77737999e-03+5.72478867j,
-              4.10533333-3.10287571j, 9.04761887+1.54017115j,
-              -5.77960968e-01-7.87758923j],
-             [9.86398506-3.98528528j, -4.71444130-2.44316983j,
-              -1.68038976-1.12708664j, 2.84695053+1.01725709j,
-              1.14315915-8.89294529j, -3.17127085-5.42145538j,
-              1.91830420-6.16370344j],
-             [7.13875294+2.91851187j, -5.35737514+9.64132309j,
-              -9.66586399+0.70250005j, -9.87717438-2.0262239j,
-              9.93160629+1.5630846j, 4.71948051-2.22050714j,
-              9.49550819+7.8995142j]])
-        # FIXME: for complex types, the computations are done in
-        # single precision (reason unclear). When this is changed,
-        # this test needs updating.
-        assert_allclose(bsp.spline_filter(data_array_complex, 0),
-                        result_array_complex, rtol=1e-6)
         # Test the real branch
         np.random.seed(12457)
         data_array_real = np.random.rand(12, 12)
@@ -105,7 +67,6 @@ class TestBSplines:
                         result_array_real)
 
     def test_bspline(self):
-        np.random.seed(12458)
         # Verify with theoretical results at integer points up to order 5
         assert_allclose(bsp.bspline([-1, 0, 1], 0),
                         array([0, 1, 0]))
@@ -120,17 +81,9 @@ class TestBSplines:
         assert_allclose(bsp.bspline([-3, -2, -1, 0, 1, 2, 3], 5),
                         array([0, 1, 26, 66, 26, 1, 0]) / 120.)
         # Compare with SciPy 1.1.0
+        np.random.seed(12458)
         assert_allclose(bsp.bspline(np.random.rand(1, 1), 2),
                         array([[0.73694695]]))
-        data_array_complex = np.random.rand(4, 4) + np.random.rand(4, 4)*1j
-        data_array_complex = 0.1*data_array_complex
-        result_array_complex = array(
-            [[0.40882362, 0.41021151, 0.40886708, 0.40905103],
-             [0.40829477, 0.41021230, 0.40966097, 0.40939871],
-             [0.41036803, 0.40901724, 0.40965331, 0.40879513],
-             [0.41032862, 0.40925287, 0.41037754, 0.41027477]])
-        assert_allclose(bsp.bspline(data_array_complex, 10),
-                        result_array_complex)
 
     def test_gauss_spline(self):
         np.random.seed(12459)
@@ -148,37 +101,12 @@ class TestBSplines:
         # Verify with theoretical results at integer points (see docstring)
         assert_allclose(bsp.cubic([-2, -1, 0, 1, 2]),
                         array([0, 1, 4, 1, 0])/6.)
-        # Compare with SciPy 1.1.0
-        data_array_complex = np.random.rand(4, 4) + np.random.rand(4, 4)*1j
-        data_array_complex = 1+1j-2*data_array_complex
-        # scaling the magnitude by 10 makes the results close enough to zero,
-        # that the assertion fails, so just make the elements have a mix of
-        # positive and negative imaginary components...
-        result_array_complex = array(
-            [[0.23056563, 0.38414406, 0.08342987, 0.06904847],
-             [0.17240848, 0.47055447, 0.63896278, 0.39756424],
-             [0.12672571, 0.65862632, 0.1116695, 0.09700386],
-             [0.3544116, 0.17856518, 0.1528841, 0.17285762]])
-        assert_allclose(bsp.cubic(data_array_complex), result_array_complex)
 
     def test_quadratic(self):
         np.random.seed(12461)
         # Verify correct results at integer points
         assert_allclose(bsp.quadratic([-2, -1, 0, 1, 2]),
                         array([0, 1, 6, 1, 0])/8.)
-        # Compare with SciPy 1.1.0
-        data_array_complex = np.random.rand(4, 4) + np.random.rand(4, 4)*1j
-        # scaling the magnitude by 10 makes the results all zero,
-        # so just make the elements have a mix of positive and negative
-        # imaginary components...
-        data_array_complex = (1+1j-2*data_array_complex)
-        result_array_complex = array(
-            [[0.23062746, 0.06338176, 0.34902312, 0.31944105],
-             [0.14701256, 0.13277773, 0.29428615, 0.09814697],
-             [0.52873842, 0.06484157, 0.09517566, 0.46420389],
-             [0.09286829, 0.09371954, 0.1422526, 0.16007024]])
-        assert_allclose(bsp.quadratic(data_array_complex),
-                        result_array_complex)
 
     def test_cspline1d(self):
         np.random.seed(12462)


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

supersedes and closes gh-14530, closes gh-14525

#### What does this implement/fix?
<!--Please explain your changes.-->

Start acting on the roadmap item (https://docs.scipy.org/doc/scipy/dev/roadmap-detailed.html#scipy-roadmap-detailed)

> B-splines: (Relevant functions are bspline, cubic, quadratic, gauss_spline, cspline1d, qspline1d, cspline2d, qspline2d, 
> cspline1d_eval, and spline_filter.) Move the good stuff to interpolate (with appropriate API changes to match how 
> things are done in interpolate), and eliminate any duplication.

There are two sorts of functions above: several do some sort of filtering, and others simply duplicate BSpline.basis_element from scipy.interpolate. This PR does not touch the former, and acts on the latter,  specifically, on the *remove duplication*  part.

Therefore, this PR deprecates `bspline`, `quadratic` and `cubic` functions from scipy.signal, and lists their direct analogs from scipy.interpolate.
The deprecation itself was discussed in https://github.com/scipy/scipy/issues/6730#issuecomment-290368820

None of this is essential for the approaching 1.10 release, so the deprecation messages mention the 1.11 release. If this comes in before the release, will adjust the deprecation message.

#### Additional information
<!--Any additional information you think is important.-->

While at it, cherry-pick parts of https://github.com/scipy/scipy/pull/14530 which stalled at fixing a bug with integer arguments, where floats <1 were rounded down to zero.
