### PR TITLE
BUG: stats: Fix for gh-17444.

### DIFF
--- a/scipy/stats/_boost/include/func_defs.hpp
+++ b/scipy/stats/_boost/include/func_defs.hpp
@@ -43,7 +43,9 @@ boost::math::policies::user_overflow_error(const char* function, const char* mes
     msg += (boost::format(function) % typeid(RealType).name()).str() + ": ";
     // From Boost docs: "overflow and underflow messages do not contain this %1% specifier
     //                   (since the value of value is immaterial in these cases)."
-    msg += message;
+    if (message) {
+        msg += message;
+    }
     PyGILState_STATE save = PyGILState_Ensure();
     PyErr_SetString(PyExc_OverflowError, msg.c_str());
     PyGILState_Release(save);

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3402,7 +3402,7 @@ class TestBeta:
         # the value), because our goal here is to verify that the call does
         # not trigger a segmentation fault.
         try:
-            stats.beta.ppf(p, a, b)
+            method(p, a, b)
         except OverflowError:
             # The OverflowError exception occurs with Boost 1.80 or earlier
             # when Boost's double promotion policy is false; see

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -152,6 +152,7 @@ def test_vonmises_entropy(kappa, expected_entropy):
     entropy = stats.vonmises.entropy(kappa)
     assert_allclose(entropy, expected_entropy, rtol=1e-13)
 
+
 def test_vonmises_rvs_gh4598():
     # check that random variates wrap around as discussed in gh-4598
     seed = abs(hash('von_mises_rvs'))
@@ -3387,6 +3388,30 @@ class TestBeta:
         q, a, b = 0.995, 1.0e11, 1.0e13
         with pytest.warns(RuntimeWarning):
             stats.beta.ppf(q, a, b)
+
+    @pytest.mark.parametrize('method', [stats.beta.ppf, stats.beta.isf])
+    @pytest.mark.parametrize('a, b', [(1e-310, 12.5), (12.5, 1e-310)])
+    def test_beta_ppf_with_subnormal_a_b(self, method, a, b):
+        # Regression test for gh-17444: beta.ppf(p, a, b) and beta.isf(p, a, b)
+        # would result in a segmentation fault if either a or b was subnormal.
+        p = 0.9
+        # Depending on the version of Boost that we have vendored and
+        # our setting of the Boost double promotion policy, the call
+        # `stats.beta.ppf(p, a, b)` might raise an OverflowError or
+        # return a value.  We'll accept either behavior (and not care about
+        # the value), because our goal here is to verify that the call does
+        # not trigger a segmentation fault.
+        try:
+            stats.beta.ppf(p, a, b)
+        except OverflowError:
+            # The OverflowError exception occurs with Boost 1.80 or earlier
+            # when Boost's double promotion policy is false; see
+            #   https://github.com/boostorg/math/issues/882
+            # and
+            #   https://github.com/boostorg/math/pull/883
+            # Once we have vendored the fixed version of Boost, we can drop
+            # this try-except wrapper and just call the function.
+            pass
 
 
 class TestBetaPrime:


### PR DESCRIPTION
The argument `message` of the user defined error handler in the stats Boost wrapper can be NULL. The code didn't check for a null pointer, so it would trigger a segmentation fault when it used `message`.

Closes gh-17444.
