### PR TITLE
MAINT: stats.rv_count: revert gh-17236

### DIFF
--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -40,7 +40,6 @@ Each univariate distribution is an instance of a subclass of `rv_continuous`
 
    rv_continuous
    rv_discrete
-   rv_count
    rv_histogram
 
 Continuous distributions
@@ -486,7 +485,6 @@ from ._warnings_errors import (ConstantInputWarning, NearConstantInputWarning,
 from ._stats_py import *
 from ._variation import variation
 from .distributions import *
-from ._distn_infrastructure import rv_count
 from ._morestats import *
 from ._binomtest import binomtest
 from ._binned_statistic import *

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -17,8 +17,7 @@ from scipy.stats._distr_params import distdiscrete, invdistdiscrete
 from scipy.stats._distn_infrastructure import rv_discrete_frozen
 
 vals = ([1, 2, 3, 4], [0.1, 0.2, 0.3, 0.4])
-distdiscrete += [[stats.rv_discrete(values=vals), ()],
-                 [stats.rv_count(xk=vals[0], pk=vals[1]), ()]]
+distdiscrete += [[stats.rv_discrete(values=vals), ()]]
 
 # For these distributions, test_discrete_basic only runs with test mode full
 distslow = {'zipfian', 'nhypergeom'}

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2812,20 +2812,6 @@ class TestRvDiscrete:
         assert_allclose(rv.expect(lambda x: x**2),
                         sum(v**2 * w for v, w in zip(y, py)), atol=1e-14)
 
-    def test_rv_count_subclassing(self):
-        # gh-8057: rv_discrete(values=(xk, pk)) cannot be subclassed easily
-        class S(stats.rv_count):
-            def extra(self):
-                return 42
-
-        s = S(xk=[1, 2, 3], pk=[0.2, 0.7, 0.1])
-        assert_allclose(s.pmf([2, 3, 1]), [0.7, 0.1, 0.2], atol=1e-15)
-        assert s.extra() == 42
-
-        # make sure subclass freezes correctly
-        frozen_s = s()
-        assert_allclose(frozen_s.pmf([2, 3, 1]), [0.7, 0.1, 0.2], atol=1e-15)
-
 
 class TestSkewCauchy:
     def test_cauchy(self):


### PR DESCRIPTION
#### Reference issue
gh-17236

#### What does this implement/fix?
gh-17236 introduced `rv_count`, a discrete analog of `rv_histogram`. It is really just a wrapper of the corresponding feature of `rv_discrete` needed to fix gh-8057. However, https://github.com/scipy/scipy/pull/17236#issuecomment-1288420090 exposed many bugs in this feature of `rv_count` (stemming from shortcomings of `rv_discrete`), so I don't think we should announce this as a new feature. Since SciPy 1.10 is branching soon, I think we need to revert so we can take our time to resolve these issues.