### PR TITLE
ENH: Add clear_cache utility for `scipy.datasets`

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -76,6 +76,9 @@ ignore_missing_imports = True
 [mypy-pooch]
 ignore_missing_imports = True
 
+[mypy-appdirs]
+ignore_missing_imports = True
+
 #
 # Extension modules without stubs.
 #

--- a/scipy/datasets/__init__.py
+++ b/scipy/datasets/__init__.py
@@ -22,6 +22,7 @@ Utility Methods
    :toctree: generated/
 
    download_all    -- Download all the dataset files to specified path.
+   clear_cache     -- Clear cached dataset directory.
 
 
 Usage of Datasets
@@ -78,7 +79,10 @@ the internet connectivity.
 
 from ._fetchers import face, ascent, electrocardiogram  # noqa: E402
 from ._download_all import download_all
-__all__ = ['ascent', 'electrocardiogram', 'face', 'download_all']
+from ._utils import clear_cache
+
+__all__ = ['ascent', 'electrocardiogram', 'face',
+           'download_all', 'clear_cache']
 
 
 from scipy._lib._testutils import PytestTester

--- a/scipy/datasets/_registry.py
+++ b/scipy/datasets/_registry.py
@@ -16,3 +16,11 @@ registry_urls = {
     "ecg.dat": "https://raw.githubusercontent.com/scipy/dataset-ecg/main/ecg.dat",
     "face.dat": "https://raw.githubusercontent.com/scipy/dataset-face/main/face.dat"
 }
+
+# dataset method mapping with their associated filenames
+# <method_name> : ["filename1", "filename2", ...]
+method_files_map = {
+    "ascent": ["ascent.dat"],
+    "electrocardiogram": ["ecg.dat"],
+    "face": ["face.dat"]
+}

--- a/scipy/datasets/_utils.py
+++ b/scipy/datasets/_utils.py
@@ -1,0 +1,62 @@
+import os
+import shutil
+from ._registry import registry
+
+try:
+    import appdirs
+except ImportError:
+    appdirs = None
+
+
+def _clear_cache(datasets, cache_dir=None, data_registry=None):
+    if data_registry is None:
+        # Use SciPy Datasets registry map
+        data_registry = registry
+    if cache_dir is None:
+        # Use default cache_dir path
+        if appdirs is None:
+            # appdirs is pooch dependency
+            raise ImportError("Missing optional dependency 'pooch' required "
+                              "for scipy.datasets module. Please use pip or "
+                              "conda to install 'pooch'.")
+        cache_dir = appdirs.user_cache_dir("scipy-data")
+
+    if not os.path.exists(cache_dir):
+        print(f"Cache Directory {cache_dir} doesn't exist. Nothing to clear.")
+        return
+
+    if datasets is None:
+        print(f"Cleaning the cache directory {cache_dir}!")
+        shutil.rmtree(cache_dir)
+    else:
+        for dataset_name in datasets:
+            if dataset_name not in data_registry:
+                raise ValueError(f"Dataset {dataset_name} doesn't exist. "
+                                 "Please check if the passed dataset "
+                                 "is a subset of the following: "
+                                 f"{list(data_registry.keys())}")
+
+            dataset_path = os.path.join(cache_dir, dataset_name)
+            if os.path.exists(dataset_path):
+                print(f"Cleaning the {dataset_name} file!")
+                os.remove(dataset_path)
+            else:
+                print(f"Path {dataset_path} doesn't exist. Nothing to clear.")
+
+
+def clear_cache(datasets=None):
+    """
+    Cleans the scipy datasets cache directory.
+
+    If a list/tuple of dataset strings is provided, then it
+    removes all the datasets in the list/tuple.
+
+    By default, it removes all the cached data files.
+
+    Parameters
+    ----------
+    datasets : list/tuple of str or None
+        A list/tuple of datasets to be removed from cache.
+
+    """
+    _clear_cache(datasets)

--- a/scipy/datasets/meson.build
+++ b/scipy/datasets/meson.build
@@ -2,7 +2,8 @@ python_sources = [
   '__init__.py',
   '_fetchers.py',
   '_registry.py',
-  '_download_all.py'
+  '_download_all.py',
+  '_utils.py'
 ]
 
 py3.install_sources(

--- a/scipy/datasets/tests/meson.build
+++ b/scipy/datasets/tests/meson.build
@@ -1,6 +1,6 @@
 python_sources = [
   '__init__.py',
-  'test_data.py',
+  'test_data.py'
 ]
 
 py3.install_sources(

--- a/scipy/datasets/tests/test_data.py
+++ b/scipy/datasets/tests/test_data.py
@@ -79,14 +79,18 @@ def test_clear_cache(tmp_path):
 
     # clear files associated to single dataset method data0
     # also test callable argument instead of list of callables
-    def data0(): pass
+    def data0():
+        pass
     _clear_cache(datasets=data0, cache_dir=dummy_basepath,
                  method_map=dummy_method_map)
     assert not os.path.exists(dummy_basepath/"data0.dat")
 
     # clear files associated to multiple dataset methods "data3" and "data4"
-    def data1(): pass
-    def data2(): pass
+    def data1():
+        pass
+
+    def data2():
+        pass
     _clear_cache(datasets=[data1, data2], cache_dir=dummy_basepath,
                  method_map=dummy_method_map)
     assert not os.path.exists(dummy_basepath/"data1.dat")
@@ -94,7 +98,8 @@ def test_clear_cache(tmp_path):
 
     # clear multiple dataset files "data3_0.dat" and "data3_1.dat"
     # associated with dataset method "data3"
-    def data4(): pass
+    def data4():
+        pass
     # create files
     (dummy_basepath / "data4_0.dat").write_text("")
     (dummy_basepath / "data4_1.dat").write_text("")
@@ -107,7 +112,8 @@ def test_clear_cache(tmp_path):
 
     # wrong dataset method should raise ValueError since it
     # doesn't exist in the dummy_method_map
-    def data5(): pass
+    def data5():
+        pass
     with pytest.raises(ValueError):
         _clear_cache(datasets=[data5], cache_dir=dummy_basepath,
                      method_map=dummy_method_map)

--- a/scipy/datasets/tests/test_data.py
+++ b/scipy/datasets/tests/test_data.py
@@ -65,18 +65,18 @@ class TestDatasets:
                          registry["ecg.dat"])
 
 
-def test_clear_cache():
-    # Use Dummy path
-    dummy_basepath = "dummy_cache_dir"
-    os.makedirs(dummy_basepath, exist_ok=True)
+def test_clear_cache(tmp_path):
+    # Note: `tmp_path` is a pytest fixture, it handles cleanup
+    dummy_basepath = tmp_path / "dummy_cache_dir"
+    dummy_basepath.mkdir()
 
     # Create three dummy dataset files
     dummy_registry = {}
     for i in range(3):
         dataset_name = f"data{i}.dat"
         dummy_registry[dataset_name] = hash(dataset_name)
-        with open(os.path.join(dummy_basepath, dataset_name), 'a'):
-            pass
+        dataset_file = dummy_basepath / dataset_name
+        dataset_file.write_text("")
 
     # remove single dataset file from cache dir
     _clear_cache(datasets=["data0.dat"], cache_dir=dummy_basepath,

--- a/scipy/datasets/tests/test_data.py
+++ b/scipy/datasets/tests/test_data.py
@@ -70,25 +70,48 @@ def test_clear_cache(tmp_path):
     dummy_basepath = tmp_path / "dummy_cache_dir"
     dummy_basepath.mkdir()
 
-    # Create three dummy dataset files
-    dummy_registry = {}
-    for i in range(3):
-        dataset_name = f"data{i}.dat"
-        dummy_registry[dataset_name] = hash(dataset_name)
-        dataset_file = dummy_basepath / dataset_name
-        dataset_file.write_text("")
+    # Create three dummy dataset files for dummy dataset methods
+    dummy_method_map = {}
+    for i in range(4):
+        dummy_method_map[f"data{i}"] = [f"data{i}.dat"]
+        data_filepath = dummy_basepath / f"data{i}.dat"
+        data_filepath.write_text("")
 
-    # remove single dataset file from cache dir
-    _clear_cache(datasets=["data0.dat"], cache_dir=dummy_basepath,
-                 data_registry=dummy_registry)
-    assert len(os.listdir(dummy_basepath)) == len(dummy_registry) - 1
+    # clear files associated to single dataset method data0
+    # also test callable argument instead of list of callables
+    def data0(): pass
+    _clear_cache(datasets=data0, cache_dir=dummy_basepath,
+                 method_map=dummy_method_map)
+    assert not os.path.exists(dummy_basepath/"data0.dat")
 
-    # wrong dataset name should raise ValueError
+    # clear files associated to multiple dataset methods "data3" and "data4"
+    def data1(): pass
+    def data2(): pass
+    _clear_cache(datasets=[data1, data2], cache_dir=dummy_basepath,
+                 method_map=dummy_method_map)
+    assert not os.path.exists(dummy_basepath/"data1.dat")
+    assert not os.path.exists(dummy_basepath/"data2.dat")
+
+    # clear multiple dataset files "data3_0.dat" and "data3_1.dat"
+    # associated with dataset method "data3"
+    def data4(): pass
+    # create files
+    (dummy_basepath / "data4_0.dat").write_text("")
+    (dummy_basepath / "data4_1.dat").write_text("")
+
+    dummy_method_map["data4"] = ["data4_0.dat", "data4_1.dat"]
+    _clear_cache(datasets=[data4], cache_dir=dummy_basepath,
+                 method_map=dummy_method_map)
+    assert not os.path.exists(dummy_basepath/"data4_0.dat")
+    assert not os.path.exists(dummy_basepath/"data4_1.dat")
+
+    # wrong dataset method should raise ValueError since it
+    # doesn't exist in the dummy_method_map
+    def data5(): pass
     with pytest.raises(ValueError):
-        _clear_cache(datasets=["data5.dat"], cache_dir=dummy_basepath,
-                     data_registry=dummy_registry)
+        _clear_cache(datasets=[data5], cache_dir=dummy_basepath,
+                     method_map=dummy_method_map)
 
     # remove all dataset cache
-    _clear_cache(datasets=None, cache_dir=dummy_basepath,
-                 data_registry=dummy_registry)
+    _clear_cache(datasets=None, cache_dir=dummy_basepath)
     assert not os.path.exists(dummy_basepath)


### PR DESCRIPTION
#### Reference issue
#16983

#### What does this implement/fix?
This is a simple utility function used to empty the datasets cache without the need to manually look for the cache directory, which is different on different platforms.

cc @rgommers