### PR TITLE
MAINT: special: remove more `npy_math.h` usage

### DIFF
--- a/scipy/special/_faddeeva.cxx
+++ b/scipy/special/_faddeeva.cxx
@@ -76,7 +76,7 @@ npy_cdouble faddeeva_dawsn_complex(npy_cdouble zp)
 npy_cdouble faddeeva_ndtr(npy_cdouble zp)
 {
     complex<double> z(zp.real, zp.imag);
-    z *= NPY_SQRT1_2;
+    z *= M_SQRT1_2;
     complex<double> w = 0.5 * Faddeeva::erfc(-z);
     return npy_cpack(real(w), imag(w));
 }
@@ -105,7 +105,7 @@ npy_cdouble faddeeva_ndtr(npy_cdouble zp)
  */
 double faddeeva_log_ndtr(double x)
 {
-    double t = x*NPY_SQRT1_2;
+    double t = x*M_SQRT1_2;
     if (x < -1.0) {
         return log(faddeeva_erfcx(-t)/2) - t*t;
     }
@@ -127,13 +127,13 @@ npy_cdouble faddeeva_log_ndtr_complex(npy_cdouble zp)
     complex<double> z(zp.real, zp.imag);
     if (zp.real > 6) {
         // Underflow. Close to the real axis, expand the log in log(1 - ndtr(-z)).
-        complex<double> w = -0.5 * Faddeeva::erfc(z*NPY_SQRT1_2);
+        complex<double> w = -0.5 * Faddeeva::erfc(z*M_SQRT1_2);
         if (abs(w) < 1e-8) {
             return npy_cpack(real(w), imag(w));
         }
     }
 
-    z *= -NPY_SQRT1_2;
+    z *= -M_SQRT1_2;
     double x = real(z), y = imag(z);
 
     /* Compute the principal branch of $log(exp(-z^2))$, using the fact that
@@ -143,8 +143,8 @@ npy_cdouble faddeeva_log_ndtr_complex(npy_cdouble zp)
     double mRe_z2 = (y - x) * (x + y); // Re(-z^2), being careful of overflow
     double mIm_z2 = -2*x*y; // Im(-z^2)
 
-    double im = fmod(mIm_z2, 2.0*NPY_PI);
-    if (im > NPY_PI) {im -= 2.0*NPY_PI;}
+    double im = fmod(mIm_z2, 2.0*M_PI);
+    if (im > M_PI) {im -= 2.0*M_PI;}
 
     complex<double> val1 = complex<double>(mRe_z2, im);
 
@@ -155,8 +155,8 @@ npy_cdouble faddeeva_log_ndtr_complex(npy_cdouble zp)
      * the imaginary part of the result should belong to [-pi, pi].
      */
     im = imag(result);
-    if (im >= NPY_PI){ im -= 2*NPY_PI; }
-    if (im < -NPY_PI){ im += 2*NPY_PI; }
+    if (im >= M_PI){ im -= 2*M_PI; }
+    if (im < -M_PI){ im += 2*M_PI; }
 
     return npy_cpack(real(result), im);
 }
@@ -174,7 +174,7 @@ double faddeeva_voigt_profile(double x, double sigma, double gamma)
                 return INFINITY;
             return 0;
         }
-        return gamma / NPY_PI / (x*x + gamma*gamma);
+        return gamma / M_PI / (x*x + gamma*gamma);
     }
     if (gamma == 0){
         return 1 / SQRT_2PI / sigma * exp(-(x/sigma)*(x/sigma) / 2);

--- a/scipy/special/_sici.pxd
+++ b/scipy/special/_sici.pxd
@@ -12,9 +12,6 @@ cimport numpy as np
 
 from . cimport sf_error
 
-cdef extern from "numpy/npy_math.h":
-    double NPY_EULER
-
 from ._complexstuff cimport (
     npy_cdouble_from_double_complex, double_complex_from_npy_cdouble,
     zabs, zlog, zpack)
@@ -24,6 +21,7 @@ cdef extern from "specfun_wrappers.h":
 
 DEF MAXITER = 100
 DEF TOL = 2.220446092504131e-16
+DEF EULER = 0.577215664901532860606512090082402431  # Euler constant
     
 
 cdef inline double complex zexpi(double complex z) nogil:
@@ -80,7 +78,7 @@ cdef inline int csici(double complex z,
             sf_error.error("sici", sf_error.DOMAIN, NULL)
             ci[0] = zpack(-INFINITY, NAN)
         else:
-            ci[0] += NPY_EULER + zlog(z)
+            ci[0] += EULER + zlog(z)
         return 0
     
     # DLMF 6.5.5/6.5.6 plus DLMF 6.4.4/6.4.6/6.4.7
@@ -129,7 +127,7 @@ cdef inline int cshichi(double complex z,
             sf_error.error("shichi", sf_error.DOMAIN, NULL)
             chi[0] = zpack(-INFINITY, NAN)
         else:
-            chi[0] += NPY_EULER + zlog(z)
+            chi[0] += EULER + zlog(z)
         return 0
 
     term1 = zexpi(z)

--- a/scipy/special/amos_wrappers.c
+++ b/scipy/special/amos_wrappers.c
@@ -77,7 +77,7 @@ double sin_pi(double x)
          */
         return 0;
     }
-    return sin(NPY_PI * x);
+    return sin(M_PI * x);
 }
 
 static double cos_pi(double x)
@@ -89,7 +89,7 @@ static double cos_pi(double x)
          */
         return 0;
     }
-    return cos(NPY_PI * x);
+    return cos(M_PI * x);
 }
 
 static npy_cdouble
@@ -144,7 +144,7 @@ static npy_cdouble
 rotate_i(npy_cdouble i, npy_cdouble k, double v)
 {
     npy_cdouble w;
-    double s = sin(v * NPY_PI)*(2.0/NPY_PI);
+    double s = sin(v * M_PI)*(2.0/M_PI);
     w.real = i.real + s*k.real;
     w.imag = i.imag + s*k.imag;
     return w;
@@ -352,7 +352,7 @@ npy_cdouble cbesi_wrap_e( double v, npy_cdouble z) {
       F_FUNC(zbesk,ZBESK)(CADDR(z), &v,  &kode, &n, CADDR(cy_k), &nz, &ierr);
       DO_SFERR("ive(kv):", &cy_k);
       /* adjust scaling to match zbesi */
-      cy_k = rotate(cy_k, -z.imag/NPY_PI);
+      cy_k = rotate(cy_k, -z.imag/M_PI);
       if (z.real > 0) {
           cy_k.real *= exp(-2*z.real);
           cy_k.imag *= exp(-2*z.real);

--- a/scipy/special/cdf_wrappers.h
+++ b/scipy/special/cdf_wrappers.h
@@ -13,8 +13,6 @@
 
 #include "sf_error.h"
 
-#include <numpy/npy_math.h>
-
 extern double cdfbet3_wrap(double p, double x, double b);
 extern double cdfbet4_wrap(double p, double x, double a);
 

--- a/scipy/special/cephes/airy.c
+++ b/scipy/special/cephes/airy.c
@@ -278,7 +278,7 @@ double x, *ai, *aip, *bi, *bip;
 	zz = z * z;
 	uf = 1.0 + zz * polevl(zz, AFN, 8) / p1evl(zz, AFD, 9);
 	ug = z * polevl(zz, AGN, 10) / p1evl(zz, AGD, 10);
-	theta = zeta + 0.25 * NPY_PI;
+	theta = zeta + 0.25 * M_PI;
 	f = sin(theta);
 	g = cos(theta);
 	*ai = k * (f * uf - g * ug);

--- a/scipy/special/cephes/bdtr.c
+++ b/scipy/special/cephes/bdtr.c
@@ -147,7 +147,6 @@
  */
 
 #include "mconf.h"
-#include <numpy/npy_math.h>
 
 double bdtrc(double k, int n, double p)
 {

--- a/scipy/special/cephes/ellie.c
+++ b/scipy/special/cephes/ellie.c
@@ -74,10 +74,10 @@ double ellie(double phi, double m)
     if (m == 0.0)
 	return (phi);
     lphi = phi;
-    npio2 = floor(lphi / NPY_PI_2);
+    npio2 = floor(lphi / M_PI_2);
     if (fmod(fabs(npio2), 2.0) == 1.0)
 	npio2 += 1;
-    lphi = lphi - npio2 * NPY_PI_2;
+    lphi = lphi - npio2 * M_PI_2;
     if (lphi < 0.0) {
 	lphi = -lphi;
 	sign = -1;
@@ -131,15 +131,15 @@ double ellie(double phi, double m)
 
     while (fabs(c / a) > MACHEP) {
 	temp = b / a;
-	lphi = lphi + atan(t * temp) + mod * NPY_PI;
+	lphi = lphi + atan(t * temp) + mod * M_PI;
         denom = 1 - temp * t * t;
         if (fabs(denom) > 10*MACHEP) {
             t = t * (1.0 + temp) / denom;
-            mod = (lphi + NPY_PI_2) / NPY_PI;
+            mod = (lphi + M_PI_2) / M_PI;
         }
         else {
             t = tan(lphi);
-            mod = (int)floor((lphi - atan(t))/NPY_PI);
+            mod = (int)floor((lphi - atan(t))/M_PI);
         }
 	c = (a - b) / 2.0;
 	temp = sqrt(a * b);
@@ -150,7 +150,7 @@ double ellie(double phi, double m)
     }
 
     temp = E / ellpk(1.0 - m);
-    temp *= (atan(t) + mod * NPY_PI) / (d * a);
+    temp *= (atan(t) + mod * M_PI) / (d * a);
     temp += e;
 
   done:

--- a/scipy/special/cephes/ellik.c
+++ b/scipy/special/cephes/ellik.c
@@ -58,8 +58,6 @@
 #include "mconf.h"
 extern double MACHEP;
 
-#include <numpy/npy_math.h>
-
 static double ellik_neg_m(double phi, double m);
 
 double ellik(double phi,  double m)
@@ -89,7 +87,7 @@ double ellik(double phi,  double m)
 	    return (INFINITY);
 	}
         /* DLMF 19.6.8, and 4.23.42 */
-       return npy_asinh(tan(phi));
+       return asinh(tan(phi));
     }
     npio2 = floor(phi / NPY_PI_2);
     if (fmod(fabs(npio2), 2.0) == 1.0)

--- a/scipy/special/cephes/ellik.c
+++ b/scipy/special/cephes/ellik.c
@@ -82,19 +82,19 @@ double ellik(double phi,  double m)
 	return (phi);
     a = 1.0 - m;
     if (a == 0.0) {
-	if (fabs(phi) >= (double)NPY_PI_2) {
+	if (fabs(phi) >= (double)M_PI_2) {
 	    sf_error("ellik", SF_ERROR_SINGULAR, NULL);
 	    return (INFINITY);
 	}
         /* DLMF 19.6.8, and 4.23.42 */
        return asinh(tan(phi));
     }
-    npio2 = floor(phi / NPY_PI_2);
+    npio2 = floor(phi / M_PI_2);
     if (fmod(fabs(npio2), 2.0) == 1.0)
 	npio2 += 1;
     if (npio2 != 0.0) {
 	K = ellpk(a);
-	phi = phi - npio2 * NPY_PI_2;
+	phi = phi - npio2 * M_PI_2;
     }
     else
 	K = 0.0;
@@ -129,15 +129,15 @@ double ellik(double phi,  double m)
 
     while (fabs(c / a) > MACHEP) {
 	temp = b / a;
-	phi = phi + atan(t * temp) + mod * NPY_PI;
+	phi = phi + atan(t * temp) + mod * M_PI;
         denom = 1.0 - temp * t * t;
         if (fabs(denom) > 10*MACHEP) {
 	    t = t * (1.0 + temp) / denom;
-            mod = (phi + NPY_PI_2) / NPY_PI;
+            mod = (phi + M_PI_2) / M_PI;
         }
         else {
             t = tan(phi);
-            mod = (int)floor((phi - atan(t))/NPY_PI);
+            mod = (int)floor((phi - atan(t))/M_PI);
         }
 	c = (a - b) / 2.0;
 	temp = sqrt(a * b);
@@ -146,7 +146,7 @@ double ellik(double phi,  double m)
 	d += d;
     }
 
-    temp = (atan(t) + mod * NPY_PI) / (d * a);
+    temp = (atan(t) + mod * M_PI) / (d * a);
 
   done:
     if (sign < 0)

--- a/scipy/special/cephes/ellpj.c
+++ b/scipy/special/cephes/ellpj.c
@@ -100,7 +100,7 @@ int ellpj(double u, double m, double *sn, double *cn, double *dn, double *ph)
         phi = 1.0 / b;
         twon = b * sinh(u);
         *sn = t + ai * (twon - u) / (b * b);
-        *ph = 2.0 * atan(exp(u)) - NPY_PI_2 + ai * (twon - u) / b;
+        *ph = 2.0 * atan(exp(u)) - M_PI_2 + ai * (twon - u) / b;
         ai *= t * phi;
         *cn = phi - ai * (twon - u);
         *dn = phi + ai * (twon + u);

--- a/scipy/special/cephes/erfinv.c
+++ b/scipy/special/cephes/erfinv.c
@@ -29,7 +29,7 @@ double erfinv(double y) {
         return y / M_2_SQRTPI;
     } 
     if ((domain_lb < y) && (y < domain_ub)) {
-        return ndtri(0.5 * (y+1)) * NPY_SQRT1_2;
+        return ndtri(0.5 * (y+1)) * M_SQRT1_2;
     }
     else if (y == domain_lb) {
         return -INFINITY;
@@ -59,7 +59,7 @@ double erfcinv(double y) {
     const double domain_ub = 2;
 
     if ((domain_lb < y) && (y < domain_ub)) {
-        return -ndtri(0.5 * y) * NPY_SQRT1_2;
+        return -ndtri(0.5 * y) * M_SQRT1_2;
     }
     else if (y == domain_lb) {
         return INFINITY;

--- a/scipy/special/cephes/fresnl.c
+++ b/scipy/special/cephes/fresnl.c
@@ -185,8 +185,8 @@ double xxa, *ssa, *cca;
          * http://functions.wolfram.com/GammaBetaErf/FresnelC/06/02/
          * http://functions.wolfram.com/GammaBetaErf/FresnelS/06/02/
          */
-	cc = 0.5 + 1/(NPY_PI*x) * sin(NPY_PI*x*x/2);
-	ss = 0.5 - 1/(NPY_PI*x) * cos(NPY_PI*x*x/2);
+	cc = 0.5 + 1/(M_PI*x) * sin(M_PI*x*x/2);
+	ss = 0.5 - 1/(M_PI*x) * cos(M_PI*x*x/2);
 	goto done;
     }
 
@@ -195,16 +195,16 @@ double xxa, *ssa, *cca;
      *             for large argument
      */
     x2 = x * x;
-    t = NPY_PI * x2;
+    t = M_PI * x2;
     u = 1.0 / (t * t);
     t = 1.0 / t;
     f = 1.0 - u * polevl(u, fn, 9) / p1evl(u, fd, 10);
     g = t * polevl(u, gn, 10) / p1evl(u, gd, 11);
 
-    t = NPY_PI_2 * x2;
+    t = M_PI_2 * x2;
     c = cos(t);
     s = sin(t);
-    t = NPY_PI * x;
+    t = M_PI * x;
     cc = 0.5 + (f * s - g * c) / t;
     ss = 0.5 - (f * c + g * s) / t;
 

--- a/scipy/special/cephes/gamma.c
+++ b/scipy/special/cephes/gamma.c
@@ -184,12 +184,12 @@ double Gamma(double x)
 		p += 1.0;
 		z = q - p;
 	    }
-	    z = q * sin(NPY_PI * z);
+	    z = q * sin(M_PI * z);
 	    if (z == 0.0) {
 		return (sgngam * INFINITY);
 	    }
 	    z = fabs(z);
-	    z = NPY_PI / (z * stirf(q));
+	    z = M_PI / (z * stirf(q));
 	}
 	else {
 	    z = stirf(x);
@@ -307,10 +307,10 @@ double lgam_sgn(double x, int *sign)
 	    p += 1.0;
 	    z = p - q;
 	}
-	z = q * sin(NPY_PI * z);
+	z = q * sin(M_PI * z);
 	if (z == 0.0)
 	    goto lgsing;
-	/*     z = log(NPY_PI) - log( z ) - w; */
+	/*     z = log(M_PI) - log( z ) - w; */
 	z = LOGPI - log(z) - w;
 	return (z);
     }

--- a/scipy/special/cephes/igam.c
+++ b/scipy/special/cephes/igam.c
@@ -417,7 +417,7 @@ static double asymptotic_series(double a, double x, int func)
 	absoldterm = absterm;
 	afac /= a;
     }
-    res += sgn * exp(-0.5 * a * eta * eta) * sum / sqrt(2 * NPY_PI * a);
+    res += sgn * exp(-0.5 * a * eta * eta) * sum / sqrt(2 * M_PI * a);
 
     return res;
 }

--- a/scipy/special/cephes/igami.c
+++ b/scipy/special/cephes/igami.c
@@ -107,13 +107,13 @@ static double find_inverse_gamma(double a, double p, double q)
                 u = pow(p * g * a, 1 / a);
             }
             else {
-                u = exp((-q / a) - NPY_EULER);
+                u = exp((-q / a) - SCIPY_EULER);
             }
             result = u / (1 - (u / (a + 1)));
         }
         else if ((a < 0.3) && (b >= 0.35)) {
             /* DiDonato & Morris Eq 22: */
-            double t = exp(-NPY_EULER - b);
+            double t = exp(-SCIPY_EULER - b);
             double u = t * exp(t);
             result = t * exp(u);
         }

--- a/scipy/special/cephes/j0.c
+++ b/scipy/special/cephes/j0.c
@@ -63,7 +63,7 @@
  * The domain is divided into the intervals [0, 5] and
  * (5, infinity). In the first interval a rational approximation
  * R(x) is employed to compute
- *   y0(x)  = R(x)  +   2 * log(x) * j0(x) / NPY_PI.
+ *   y0(x)  = R(x)  +   2 * log(x) * j0(x) / M_PI.
  * Thus a call to j0() is required.
  *
  * In the second interval, the Hankel asymptotic expansion
@@ -204,7 +204,7 @@ double x;
     q = 25.0 / (x * x);
     p = polevl(q, PP, 6) / polevl(q, PQ, 6);
     q = polevl(q, QP, 7) / p1evl(q, QQ, 7);
-    xn = x - NPY_PI_4;
+    xn = x - M_PI_4;
     p = p * cos(xn) - w * q * sin(xn);
     return (p * SQ2OPI / sqrt(x));
 }
@@ -213,14 +213,9 @@ double x;
 /* Bessel function of second kind, order zero  */
 
 /* Rational approximation coefficients YP[], YQ[] are used here.
- * The function computed is  y0(x)  -  2 * log(x) * j0(x) / NPY_PI,
- * whose value at x = 0 is  2 * ( log(0.5) + EUL ) / NPY_PI
+ * The function computed is  y0(x)  -  2 * log(x) * j0(x) / M_PI,
+ * whose value at x = 0 is  2 * ( log(0.5) + EUL ) / M_PI
  * = 0.073804295108687225.
- */
-
-/*
- * #define NPY_PI_4 .78539816339744830962
- * #define SQ2OPI .79788456080286535588
  */
 
 double y0(x)
@@ -239,7 +234,7 @@ double x;
 	}
 	z = x * x;
 	w = polevl(z, YP, 7) / p1evl(z, YQ, 7);
-	w += NPY_2_PI * log(x) * j0(x);
+	w += M_2_PI * log(x) * j0(x);
 	return (w);
     }
 
@@ -247,7 +242,7 @@ double x;
     z = 25.0 / (x * x);
     p = polevl(z, PP, 6) / polevl(z, PQ, 6);
     q = polevl(z, QP, 7) / p1evl(z, QQ, 7);
-    xn = x - NPY_PI_4;
+    xn = x - M_PI_4;
     p = p * sin(xn) + w * q * cos(xn);
     return (p * SQ2OPI / sqrt(x));
 }

--- a/scipy/special/cephes/j1.c
+++ b/scipy/special/cephes/j1.c
@@ -213,7 +213,7 @@ double x;
 	}
 	z = x * x;
 	w = x * (polevl(z, YP, 5) / p1evl(z, YQ, 8));
-	w += NPY_2_PI * (j1(x) * log(x) - 1.0 / x);
+	w += M_2_PI * (j1(x) * log(x) - 1.0 / x);
 	return (w);
     }
 

--- a/scipy/special/cephes/jv.c
+++ b/scipy/special/cephes/jv.c
@@ -508,8 +508,8 @@ static double hankel(double n, double x)
     }
 
   hank1:
-    u = x - (0.5 * n + 0.25) * NPY_PI;
-    t = sqrt(2.0 / (NPY_PI * x)) * (pp * cos(u) - qq * sin(u));
+    u = x - (0.5 * n + 0.25) * M_PI;
+    t = sqrt(2.0 / (M_PI * x)) * (pp * cos(u) - qq * sin(u));
 #if CEPHES_DEBUG
     printf("hank: %.6e\n", t);
 #endif

--- a/scipy/special/cephes/kn.c
+++ b/scipy/special/cephes/kn.c
@@ -232,6 +232,6 @@ double x;
     while (fabs(t / s) > MACHEP);
 
   adone:
-    ans = exp(-x) * sqrt(NPY_PI / (2.0 * x)) * s;
+    ans = exp(-x) * sqrt(M_PI / (2.0 * x)) * s;
     return (ans);
 }

--- a/scipy/special/cephes/kolmogorov.c
+++ b/scipy/special/cephes/kolmogorov.c
@@ -584,9 +584,9 @@ pow2Scaled_D(double2 a, int m, int *pExponent)
      *              <= 665/(1-y.x[0])
      * Quick check to see if we might need to break up the exponentiation
      */
-    if (m*(y.x[0]-1) / y.x[0] < -_MAX_EXPONENT * NPY_LOGE2) {
+    if (m*(y.x[0]-1) / y.x[0] < -_MAX_EXPONENT * SCIPY_LOGE2) {
         /* Now do it carefully, calling log() */
-        double lg2y = log(y.x[0]) / NPY_LOGE2;
+        double lg2y = log(y.x[0]) / SCIPY_LOGE2;
         double lgAns = m * lg2y;
         if (lgAns <= -_MAX_EXPONENT) {
             maxExpt = (int)(nextPowerOf2(-_MAX_EXPONENT / lg2y + 1)/2);
@@ -943,7 +943,7 @@ _smirnovi(int n, double psf, double pcdf)
      */
     maxlogpcdf = logpow4(1, 0.0, n, 0, 1) + logpow4(n, 1, n, 0, n - 1);
     if (logpcdf <= maxlogpcdf) {
-        double xmin = pcdf / NPY_El;
+        double xmin = pcdf / SCIPY_El;
         double xmax = pcdf;
         double P1 = pow4(n, 1, n, 0, n - 1) / n;
         double R = pcdf/P1;

--- a/scipy/special/cephes/kolmogorov.c
+++ b/scipy/special/cephes/kolmogorov.c
@@ -584,9 +584,9 @@ pow2Scaled_D(double2 a, int m, int *pExponent)
      *              <= 665/(1-y.x[0])
      * Quick check to see if we might need to break up the exponentiation
      */
-    if (m*(y.x[0]-1) / y.x[0] < -_MAX_EXPONENT * SCIPY_LOGE2) {
+    if (m*(y.x[0]-1) / y.x[0] < -_MAX_EXPONENT * M_LN2) {
         /* Now do it carefully, calling log() */
-        double lg2y = log(y.x[0]) / SCIPY_LOGE2;
+        double lg2y = log(y.x[0]) / M_LN2;
         double lgAns = m * lg2y;
         if (lgAns <= -_MAX_EXPONENT) {
             maxExpt = (int)(nextPowerOf2(-_MAX_EXPONENT / lg2y + 1)/2);

--- a/scipy/special/cephes/kolmogorov.c
+++ b/scipy/special/cephes/kolmogorov.c
@@ -95,8 +95,8 @@ extern double MINLOG;
 /* exp() of anything below this returns 0 */
 static const int MIN_EXPABLE = (-708 - 38);
 
-#ifndef NPY_LOGSQRT2PI
-#define NPY_LOGSQRT2PI 0.91893853320467274178032973640561764
+#ifndef LOGSQRT2PI
+#define LOGSQRT2PI 0.91893853320467274178032973640561764
 #endif
 
 /* Struct to hold the CDF, SF and PDF, which are computed simultaneously */
@@ -169,7 +169,7 @@ _kolmogorov(double x)
         RETURN_3PROBS(1.0, 0.0, 0);
     }
     /* x <= 0.040611972203751713 */
-    if (x <= (double)NPY_PI/sqrt(-MIN_EXPABLE * 8)) {
+    if (x <= (double)M_PI/sqrt(-MIN_EXPABLE * 8)) {
         RETURN_3PROBS(1.0, 0.0, 0);
     }
 
@@ -180,8 +180,8 @@ _kolmogorov(double x)
          *  w = sqrt(2pi)/x
          *  P = w*u * (1 + u^8 + u^24 + u^48 + ...)
          */
-        double w = sqrt(2 * NPY_PI)/x;
-        double logu8 = -NPY_PI * NPY_PI/(x * x); /* log(u^8) */
+        double w = sqrt(2 * M_PI)/x;
+        double logu8 = -M_PI * M_PI/(x * x); /* log(u^8) */
         double u = exp(logu8/8);
         if (u == 0) {
             /*
@@ -201,7 +201,7 @@ _kolmogorov(double x)
             P = 1 + u8 * P;
             D = 1*1 + u8 * D;
 
-            D = NPY_PI * NPY_PI/4/(x*x) * D - P;
+            D = M_PI * M_PI/4/(x*x) * D - P;
             D *=  w * u/x;
             P = w * u * P;
         }
@@ -278,14 +278,13 @@ _kolmogi(double psf, double pcdf)
     if (pcdf <= 0.5) {
         /* p ~ (sqrt(2pi)/x) *exp(-pi^2/8x^2).  Generate lower and upper bounds  */
         double logpcdf = log(pcdf);
-        const double SQRT2 = NPY_SQRT2;
-        const double LOGSQRT2 = NPY_LOGSQRT2PI;
-        /* Nnow that 1 >= x >= sqrt(p) */
+        const double SQRT2 = M_SQRT2;
+        /* Now that 1 >= x >= sqrt(p) */
         /* Iterate twice: x <- pi/(sqrt(8) sqrt(log(sqrt(2pi)) - log(x) - log(pdf))) */
-        a = NPY_PI / (2 * SQRT2 * sqrt(-(logpcdf + logpcdf/2 - LOGSQRT2)));
-        b = NPY_PI / (2 * SQRT2 * sqrt(-(logpcdf + 0 - LOGSQRT2)));
-        a = NPY_PI / (2 * SQRT2 * sqrt(-(logpcdf + log(a) - LOGSQRT2)));
-        b = NPY_PI / (2 * SQRT2 * sqrt(-(logpcdf + log(b) - LOGSQRT2)));
+        a = M_PI / (2 * SQRT2 * sqrt(-(logpcdf + logpcdf/2 - LOGSQRT2PI)));
+        b = M_PI / (2 * SQRT2 * sqrt(-(logpcdf + 0 - LOGSQRT2PI)));
+        a = M_PI / (2 * SQRT2 * sqrt(-(logpcdf + log(a) - LOGSQRT2PI)));
+        b = M_PI / (2 * SQRT2 * sqrt(-(logpcdf + log(b) - LOGSQRT2PI)));
         x =  (a + b) / 2.0;
     }
     else {

--- a/scipy/special/cephes/mconf.h
+++ b/scipy/special/cephes/mconf.h
@@ -100,7 +100,7 @@
 #ifndef cephes_isnan
 #define cephes_isnan(x) isnan(x)
 #define cephes_isinf(x) isinf(x)
-#define cephes_isfinite(x) npy_isfinite(x)
+#define cephes_isfinite(x) isfinite(x)
 #endif
 
 #endif				/* CEPHES_MCONF_H */

--- a/scipy/special/cephes/mconf.h
+++ b/scipy/special/cephes/mconf.h
@@ -54,7 +54,6 @@
 #define CEPHES_MCONF_H
 
 #include <Python.h>
-#include <numpy/npy_math.h>
 #include <math.h>
 
 #include "cephes_names.h"
@@ -102,5 +101,10 @@
 #define cephes_isinf(x) isinf(x)
 #define cephes_isfinite(x) isfinite(x)
 #endif
+
+/* Constants needed that are not available in the C standard library */
+#define SCIPY_EULER     0.577215664901532860606512090082402431   /* Euler constant */
+#define SCIPY_El        2.718281828459045235360287471352662498L  /* e as long double */
+#define SCIPY_LOGE2     0.693147180559945309417232121458176568   /* log_e 2 */
 
 #endif				/* CEPHES_MCONF_H */

--- a/scipy/special/cephes/mconf.h
+++ b/scipy/special/cephes/mconf.h
@@ -105,6 +105,5 @@
 /* Constants needed that are not available in the C standard library */
 #define SCIPY_EULER     0.577215664901532860606512090082402431   /* Euler constant */
 #define SCIPY_El        2.718281828459045235360287471352662498L  /* e as long double */
-#define SCIPY_LOGE2     0.693147180559945309417232121458176568   /* log_e 2 */
 
 #endif				/* CEPHES_MCONF_H */

--- a/scipy/special/cephes/ndtr.c
+++ b/scipy/special/cephes/ndtr.c
@@ -207,10 +207,10 @@ double ndtr(double a)
         return NAN;
     }
 
-    x = a * NPY_SQRT1_2;
+    x = a * M_SQRT1_2;
     z = fabs(x);
 
-    if (z < NPY_SQRT1_2) {
+    if (z < M_SQRT1_2) {
         y = 0.5 + 0.5 * erf(x);
     }
     else {

--- a/scipy/special/cephes/owens_t.c
+++ b/scipy/special/cephes/owens_t.c
@@ -130,11 +130,11 @@ static double owensT1(double h, double a, double m) {
     double hs = -0.5 * h * h;
     double dhs = exp(hs);
     double as = a * a;
-    double aj = a / (2 * NPY_PI);
+    double aj = a / (2 * M_PI);
     double dj = expm1(hs);
     double gj = hs * dhs;
 
-    double val = atan(a) / (2 * NPY_PI);
+    double val = atan(a) / (2 * M_PI);
 
     while (1) {
 	val += dj*aj / jj;
@@ -160,7 +160,7 @@ static double owensT2(double h, double a, double ah, double m) {
     double as = -a * a;
     double y = 1.0 / hs;
     double val = 0.0;
-    double vi = a*exp(-0.5 * ah * ah) / sqrt(2 * NPY_PI);
+    double vi = a*exp(-0.5 * ah * ah) / sqrt(2 * M_PI);
     double z = (ndtr(ah) - 0.5) / h;
 
     while (1) {
@@ -172,7 +172,7 @@ static double owensT2(double h, double a, double ah, double m) {
 	vi *= as;
 	i += 2;
     }
-    val *= exp(-0.5 * hs) / sqrt(2 * NPY_PI);
+    val *= exp(-0.5 * hs) / sqrt(2 * M_PI);
 
     return val;
 }
@@ -186,7 +186,7 @@ static double owensT3(double h, double a, double ah) {
     hh = h * h;
     y = 1 / hh;
 
-    vi = a * exp(-ah * ah/ 2) / sqrt(2 * NPY_PI);
+    vi = a * exp(-ah * ah/ 2) / sqrt(2 * M_PI);
     zi = owens_t_norm1(ah) / h;
     result = 0;
 
@@ -196,7 +196,7 @@ static double owensT3(double h, double a, double ah) {
         vi *= aa;
     }
 
-    result *= exp(-hh / 2) / sqrt(2 * NPY_PI);
+    result *= exp(-hh / 2) / sqrt(2 * M_PI);
 
     return result;
 }
@@ -211,7 +211,7 @@ static double owensT4(double h, double a, double m) {
     naa = -a * a;
 
     i = 1;
-    ai = a * exp(-hh * (1 - naa) / 2) / (2 * NPY_PI);
+    ai = a * exp(-hh * (1 - naa) / 2) / (2 * M_PI);
     yi = 1;
     result = 0;
 
@@ -260,7 +260,7 @@ static double owensT6(double h, double a) {
     result = normh * (1 - normh) / 2;
 
     if (r != 0) {
-        result -= r * exp(-y * h * h / (2 * r)) / (2 * NPY_PI);
+        result -= r * exp(-y * h * h / (2 * r)) / (2 * M_PI);
     }
 
     return result;
@@ -272,7 +272,7 @@ static double owens_t_dispatch(double h, double a, double ah) {
     double m, result;
 
     if (h == 0) {
-        return atan(a) / (2 * NPY_PI);
+        return atan(a) / (2 * M_PI);
     }
     if (a == 0) {
 	return 0;

--- a/scipy/special/cephes/poch.c
+++ b/scipy/special/cephes/poch.c
@@ -29,7 +29,7 @@ double poch(double a, double m)
         }
         m -= 1.0;
         r *= (a + m);
-        if (!npy_isfinite(r) || r == 0) {
+        if (!isfinite(r) || r == 0) {
             break;
         }
     }
@@ -41,7 +41,7 @@ double poch(double a, double m)
         }
         r /= (a + m);
         m += 1.0;
-        if (!npy_isfinite(r) || r == 0) {
+        if (!isfinite(r) || r == 0) {
             break;
         }
     }

--- a/scipy/special/cephes/psi.c
+++ b/scipy/special/cephes/psi.c
@@ -169,7 +169,7 @@ double psi(double x)
 	    sf_error("psi", SF_ERROR_SINGULAR, NULL);
 	    return NAN;
 	}
-	y = -NPY_PI / tan(NPY_PI * r);
+	y = -M_PI / tan(M_PI * r);
 	x = 1.0 - x;
     }
 

--- a/scipy/special/cephes/psi.c
+++ b/scipy/special/cephes/psi.c
@@ -179,7 +179,7 @@ double psi(double x)
 	for (i = 1; i < n; i++) {
 	    y += 1.0 / i;
 	}
-	y -= NPY_EULER;
+	y -= SCIPY_EULER;
 	return y;
     }
 

--- a/scipy/special/cephes/rgamma.c
+++ b/scipy/special/cephes/rgamma.c
@@ -97,7 +97,7 @@ double x;
 	    sign = -1;
 	}
 
-	y = log(w * z) - log(NPY_PI) + lgam(w);
+	y = log(w * z) - log(M_PI) + lgam(w);
 	if (y < -MAXLOG) {
 	    sf_error(name, SF_ERROR_UNDERFLOW, NULL);
 	    return (sign * 0.0);

--- a/scipy/special/cephes/scipy_iv.c
+++ b/scipy/special/cephes/scipy_iv.c
@@ -373,7 +373,7 @@ static int temme_ik_series(double v, double x, double *K, double *K1)
     sigma = -a * v;
     c = fabs(v) < MACHEP ? 1 : sin(M_PI * v) / (v * M_PI);
     d = fabs(sigma) < MACHEP ? 1 : sinh(sigma) / sigma;
-    gamma1 = fabs(v) < MACHEP ? -NPY_EULER : (0.5f / v) * (gp - gm) * c;
+    gamma1 = fabs(v) < MACHEP ? -SCIPY_EULER : (0.5f / v) * (gp - gm) * c;
     gamma2 = (2 + gp + gm) * c / 2;
 
     /* initial values */

--- a/scipy/special/cephes/scipy_iv.c
+++ b/scipy/special/cephes/scipy_iv.c
@@ -148,7 +148,7 @@ static double iv_asymptotic(double v, double x)
     double sum, term, prefactor, factor;
     int k;
 
-    prefactor = exp(x) / sqrt(2 * NPY_PI * x);
+    prefactor = exp(x) / sqrt(2 * M_PI * x);
 
     if (prefactor == INFINITY) {
 	return prefactor;
@@ -266,10 +266,10 @@ static void ikv_asymptotic_uniform(double v, double x,
     t2 = t * t;
     eta = sqrt(1 + z * z) + log(z / (1 + 1 / t));
 
-    i_prefactor = sqrt(t / (2 * NPY_PI * v)) * exp(v * eta);
+    i_prefactor = sqrt(t / (2 * M_PI * v)) * exp(v * eta);
     i_sum = 1.0;
 
-    k_prefactor = sqrt(NPY_PI * t / (2 * v)) * exp(-v * eta);
+    k_prefactor = sqrt(M_PI * t / (2 * v)) * exp(-v * eta);
     k_sum = 1.0;
 
     divisor = v;
@@ -325,7 +325,7 @@ static void ikv_asymptotic_uniform(double v, double x,
 	else {
 	    /* (AMS 9.6.2) */
 	    *i_value = (i_prefactor * i_sum
-			+ (2 / NPY_PI) * sin(NPY_PI * v) * k_prefactor * k_sum);
+			+ (2 / M_PI) * sin(M_PI * v) * k_prefactor * k_sum);
 	}
     }
 }
@@ -371,7 +371,7 @@ static int temme_ik_series(double v, double x, double *K, double *K1)
     a = log(x / 2);
     b = exp(v * a);
     sigma = -a * v;
-    c = fabs(v) < MACHEP ? 1 : sin(NPY_PI * v) / (v * NPY_PI);
+    c = fabs(v) < MACHEP ? 1 : sin(M_PI * v) / (v * M_PI);
     d = fabs(sigma) < MACHEP ? 1 : sinh(sigma) / sigma;
     gamma1 = fabs(v) < MACHEP ? -NPY_EULER : (0.5f / v) * (gp - gm) * c;
     gamma2 = (2 + gp + gm) * c / 2;
@@ -513,7 +513,7 @@ static int CF2_ik(double v, double x, double *Kv, double *Kv1)
 	sf_error("ikv_temme(CF2_ik)", SF_ERROR_NO_RESULT, NULL);
     }
 
-    *Kv = sqrt(NPY_PI / (2 * x)) * exp(-x) / S;
+    *Kv = sqrt(M_PI / (2 * x)) * exp(-x) / S;
     *Kv1 = *Kv * (0.5f + v + x + (v * v - 0.25f) * f) / x;
 
     return 0;
@@ -576,7 +576,7 @@ static void ikv_temme(double v, double x, double *Iv_p, double *Kv_p)
 	if (reflect && (kind & need_i)) {
 	    double z = (u + n % 2);
 
-	    Iv = sin((double)NPY_PI * z) == 0 ? Iv : INFINITY;
+	    Iv = sin((double)M_PI * z) == 0 ? Iv : INFINITY;
 	    if (Iv == INFINITY || Iv == -INFINITY) {
 		sf_error("ikv_temme", SF_ERROR_OVERFLOW, NULL);
 	    }
@@ -636,7 +636,7 @@ static void ikv_temme(double v, double x, double *Iv_p, double *Kv_p)
 	double z = (u + n % 2);
 
 	if (Iv_p != NULL) {
-	    *Iv_p = Iv + (2 / NPY_PI) * sin(NPY_PI * z) * Kv;	/* reflection formula */
+	    *Iv_p = Iv + (2 / M_PI) * sin(M_PI * z) * Kv;	/* reflection formula */
 	}
 	if (Kv_p != NULL) {
 	    *Kv_p = Kv;

--- a/scipy/special/cephes/shichi.c
+++ b/scipy/special/cephes/shichi.c
@@ -264,7 +264,7 @@ done:
 
     *si = s;
 
-    *ci = NPY_EULER + log(x) + c;
+    *ci = SCIPY_EULER + log(x) + c;
     return (0);
 }
 

--- a/scipy/special/cephes/sici.c
+++ b/scipy/special/cephes/sici.c
@@ -52,8 +52,6 @@
  * Copyright 1984, 1987, 1989 by Stephen L. Moshier
  * Direct inquiries to 30 Frost Street, Cambridge, MA 02140
  */
-#include <Python.h>
-#include <numpy/npy_math.h>
 
 #include "mconf.h"
 

--- a/scipy/special/cephes/sici.c
+++ b/scipy/special/cephes/sici.c
@@ -211,16 +211,16 @@ double *si, *ci;
     if (x > 1.0e9) {
 	if (cephes_isinf(x)) {
 	    if (sign == -1) {
-		*si = -NPY_PI_2;
+		*si = -M_PI_2;
 		*ci = NAN;
 	    }
 	    else {
-		*si = NPY_PI_2;
+		*si = M_PI_2;
 		*ci = 0;
 	    }
 	    return 0;
 	}
-	*si = NPY_PI_2 - cos(x) / x;
+	*si = M_PI_2 - cos(x) / x;
 	*ci = sin(x) / x;
     }
 
@@ -244,7 +244,7 @@ double *si, *ci;
     /* The auxiliary functions are:
      *
      *
-     * *si = *si - NPY_PI_2;
+     * *si = *si - M_PI_2;
      * c = cos(x);
      * s = sin(x);
      *
@@ -269,7 +269,7 @@ double *si, *ci;
 	f = polevl(z, FN8, 8) / (x * p1evl(z, FD8, 8));
 	g = z * polevl(z, GN8, 8) / p1evl(z, GD8, 9);
     }
-    *si = NPY_PI_2 - f * c - g * s;
+    *si = M_PI_2 - f * c - g * s;
     if (sign)
 	*si = -(*si);
     *ci = f * s - g * c;

--- a/scipy/special/cephes/sici.c
+++ b/scipy/special/cephes/sici.c
@@ -236,7 +236,7 @@ double *si, *ci;
     if (sign)
 	s = -s;
     *si = s;
-    *ci = NPY_EULER + log(x) + c;	/* real part if x < 0 */
+    *ci = SCIPY_EULER + log(x) + c;	/* real part if x < 0 */
     return (0);
 
 

--- a/scipy/special/cephes/sindg.c
+++ b/scipy/special/cephes/sindg.c
@@ -116,7 +116,7 @@ double x;
 	return (0.0);
     }
 
-    y = floor(x / 45.0);	/* integer part of x/NPY_PI_4 */
+    y = floor(x / 45.0);	/* integer part of x/M_PI_4 */
 
     /* strip high bits of integer part to prevent integer overflow */
     z = ldexp(y, -4);

--- a/scipy/special/cephes/spence.c
+++ b/scipy/special/cephes/spence.c
@@ -89,7 +89,7 @@ double x;
 	return (0.0);
 
     if (x == 0.0)
-	return (NPY_PI * NPY_PI / 6.0);
+	return (M_PI * M_PI / 6.0);
 
     flag = 0;
 
@@ -115,7 +115,7 @@ double x;
     y = -w * polevl(w, A, 7) / polevl(w, B, 7);
 
     if (flag & 1)
-	y = (NPY_PI * NPY_PI) / 6.0 - log(x) * log(1.0 - x) - y;
+	y = (M_PI * M_PI) / 6.0 - log(x) * log(1.0 - x) - y;
 
     if (flag & 2) {
 	z = log(x);

--- a/scipy/special/cephes/stdtr.c
+++ b/scipy/special/cephes/stdtr.c
@@ -139,7 +139,7 @@ double t;
 	    }
 	    p += f * xsqk / z;
 	}
-	p *= 2.0 / NPY_PI;
+	p *= 2.0 / M_PI;
     }
 
 

--- a/scipy/special/cephes/struve.c
+++ b/scipy/special/cephes/struve.c
@@ -255,7 +255,7 @@ double struve_power_series(double v, double z, int is_h, double *err)
         if (fabs(term) > maxterm) {
             maxterm = fabs(term);
         }
-        if (fabs(term) < SUM_TINY * fabs(sum) || term == 0 || !npy_isfinite(sum)) {
+        if (fabs(term) < SUM_TINY * fabs(sum) || term == 0 || !isfinite(sum)) {
             break;
         }
     }
@@ -310,7 +310,7 @@ double struve_bessel_series(double v, double z, int is_h, double *err)
         if (fabs(term) > maxterm) {
             maxterm = fabs(term);
         }
-        if (fabs(term) < SUM_EPS * fabs(sum) || term == 0 || !npy_isfinite(sum)) {
+        if (fabs(term) < SUM_EPS * fabs(sum) || term == 0 || !isfinite(sum)) {
             break;
         }
     }
@@ -374,7 +374,7 @@ double struve_asymp_large_z(double v, double z, int is_h, double *err)
         if (fabs(term) > maxterm) {
             maxterm = fabs(term);
         }
-        if (fabs(term) < SUM_EPS * fabs(sum) || term == 0 || !npy_isfinite(sum)) {
+        if (fabs(term) < SUM_EPS * fabs(sum) || term == 0 || !isfinite(sum)) {
             break;
         }
     }

--- a/scipy/special/cephes/tukey.c
+++ b/scipy/special/cephes/tukey.c
@@ -9,8 +9,6 @@
  */
 
 #include <Python.h>
-#include <numpy/npy_math.h>
-
 #include <math.h>
 
 #define SMALLVAL 1e-4

--- a/scipy/special/cephes/unity.c
+++ b/scipy/special/cephes/unity.c
@@ -51,7 +51,7 @@ double log1p(double x)
     double z;
 
     z = 1.0 + x;
-    if ((z < NPY_SQRT1_2) || (z > NPY_SQRT2))
+    if ((z < M_SQRT1_2) || (z > M_SQRT2))
 	return (log(z));
     z = x * x;
     z = -0.5 * z + x * (z * polevl(x, LP, 6) / p1evl(x, LQ, 6));
@@ -145,7 +145,7 @@ double cosm1(double x)
 {
     double xx;
 
-    if ((x < -NPY_PI_4) || (x > NPY_PI_4))
+    if ((x < -M_PI_4) || (x > M_PI_4))
 	return (cos(x) - 1.0);
     xx = x * x;
     xx = -0.5 * xx + xx * xx * polevl(xx, coscof, 6);

--- a/scipy/special/cephes/unity.c
+++ b/scipy/special/cephes/unity.c
@@ -162,7 +162,7 @@ static double lgam1p_taylor(double x)
     if (x == 0) {
         return 0;
     }
-    res = -NPY_EULER * x;
+    res = -SCIPY_EULER * x;
     xfac = -x;
     for (n = 2; n < 42; n++) {
         xfac *= -x;

--- a/scipy/special/cephes/yv.c
+++ b/scipy/special/cephes/yv.c
@@ -27,7 +27,7 @@ double yv(double v, double x)
         return NAN;
     }
 
-    t = NPY_PI * v;
+    t = M_PI * v;
     y = (cos(t) * jv(v, x) - jv(-v, x)) / sin(t);
 
     if (cephes_isinf(y)) {

--- a/scipy/special/cephes/zetac.c
+++ b/scipy/special/cephes/zetac.c
@@ -320,11 +320,11 @@ static inline double zeta_reflection(double x)
 
     /* Reduce the argument to sine */
     x_shift = fmod(x, 4);
-    small_term = -SQRT_2_PI * sin(0.5 * NPY_PI * x_shift);
+    small_term = -SQRT_2_PI * sin(0.5 * M_PI * x_shift);
     small_term *= lanczos_sum_expg_scaled(x + 1) * zeta(x + 1, 1);
 
     /* Group large terms together to prevent overflow */
-    base = (x + lanczos_g + 0.5) / (2 * NPY_PI * NPY_E);
+    base = (x + lanczos_g + 0.5) / (2 * M_PI * M_E);
     large_term = pow(base, x + 0.5);
     if (isfinite(large_term)) {
       return large_term * small_term;

--- a/scipy/special/cephes/zetac.c
+++ b/scipy/special/cephes/zetac.c
@@ -326,7 +326,7 @@ static inline double zeta_reflection(double x)
     /* Group large terms together to prevent overflow */
     base = (x + lanczos_g + 0.5) / (2 * NPY_PI * NPY_E);
     large_term = pow(base, x + 0.5);
-    if (npy_isfinite(large_term)) {
+    if (isfinite(large_term)) {
       return large_term * small_term;
     }
     /*

--- a/scipy/special/meson.build
+++ b/scipy/special/meson.build
@@ -417,7 +417,6 @@ py3.extension_module('_test_round',
   cython_gen.process('_test_round.pyx'),
   include_directories: [inc_np, 'cephes', '../_lib', '../_build_utils/src'],
   link_args: version_link_args,
-  dependencies: [npymath_lib],
   install: true,
   subdir: 'scipy/special'
 )

--- a/scipy/special/specfun_wrappers.c
+++ b/scipy/special/specfun_wrappers.c
@@ -211,7 +211,7 @@ double it2struve0_wrap(double x) {
   F_FUNC(itth0,ITTH0)(&x,&out);
   CONVINF("it2struve0", out);
   if (flag) {
-    out = NPY_PI - out;
+    out = M_PI - out;
   }
   return out;
 }


### PR DESCRIPTION
Cephes is now free of all `npy_*` and `NPY_*` symbols. This reduces usage down to the not-yet-replaceable typedefs and complex dtype functions.