### PR TITLE
MAINT: stats: Unconditionally disable boost double promotion.

### DIFF
--- a/scipy/stats/_boost/meson.build
+++ b/scipy/stats/_boost/meson.build
@@ -1,11 +1,11 @@
 cpp_args = [
   '-DBOOST_MATH_DOMAIN_ERROR_POLICY=ignore_error',
   '-DBOOST_MATH_EVALUATION_ERROR_POLICY=user_error',
-  '-DBOOST_MATH_OVERFLOW_ERROR_POLICY=user_error'
+  '-DBOOST_MATH_OVERFLOW_ERROR_POLICY=user_error',
+  '-DBOOST_MATH_PROMOTE_DOUBLE_POLICY=false'
 ]
 if meson.get_compiler('cpp').sizeof('void*') > 4
-  cpp_args += ['-DBOOST_MATH_PROMOTE_DOUBLE_POLICY=false',
-                numpy_nodepr_api]
+  cpp_args += [numpy_nodepr_api]
 endif
 
 pyx_files = [

--- a/scipy/stats/_boost/setup.py
+++ b/scipy/stats/_boost/setup.py
@@ -21,11 +21,8 @@ def configuration(parent_package='', top_path=None):
         ('BOOST_MATH_DOMAIN_ERROR_POLICY', 'ignore_error'),
         ('BOOST_MATH_EVALUATION_ERROR_POLICY', 'user_error'),
         ('BOOST_MATH_OVERFLOW_ERROR_POLICY', 'user_error'),
+        ('BOOST_MATH_PROMOTE_DOUBLE_POLICY', 'false')
     ]
-    if sys.maxsize > 2**32:
-        # 32-bit machines lose too much precision with no promotion,
-        # so only set this policy for 64-bit machines
-        DEFINES += [('BOOST_MATH_PROMOTE_DOUBLE_POLICY', 'false')]
     INCLUDES = [
         'include/',
         'src/',


### PR DESCRIPTION
Set the Boost double promotion policy to false on all platforms.
