### PR TITLE
MAINT: optimize.basinhopping: fix acceptance of failed local search

### DIFF
--- a/scipy/optimize/_basinhopping.py
+++ b/scipy/optimize/_basinhopping.py
@@ -27,9 +27,8 @@ class Storage:
         self.minres.x = np.copy(minres.x)
 
     def update(self, minres):
-        cond1 = minres.fun < self.minres.fun and minres.success
-        cond2 = minres.success and not self.minres.success
-        if cond1 or cond2:
+        if minres.success and (minres.fun < self.minres.fun
+                               or not self.minres.success)
             self._add(minres)
             return True
         else:

--- a/scipy/optimize/_basinhopping.py
+++ b/scipy/optimize/_basinhopping.py
@@ -28,7 +28,7 @@ class Storage:
 
     def update(self, minres):
         if minres.success and (minres.fun < self.minres.fun
-                               or not self.minres.success)
+                               or not self.minres.success):
             self._add(minres)
             return True
         else:

--- a/scipy/optimize/_basinhopping.py
+++ b/scipy/optimize/_basinhopping.py
@@ -3,10 +3,16 @@ basinhopping: The basinhopping global optimization algorithm
 """
 import numpy as np
 import math
+import inspect
 import scipy.optimize
 from scipy._lib._util import check_random_state
 
 __all__ = ['basinhopping']
+
+
+_params = (inspect.Parameter('res_new', kind=inspect.Parameter.KEYWORD_ONLY),
+           inspect.Parameter('res_old', kind=inspect.Parameter.KEYWORD_ONLY))
+_new_accept_test_signature = inspect.Signature(parameters=_params)
 
 
 class Storage:
@@ -21,7 +27,9 @@ class Storage:
         self.minres.x = np.copy(minres.x)
 
     def update(self, minres):
-        if minres.fun < self.minres.fun:
+        cond1 = minres.fun < self.minres.fun and minres.success
+        cond2 = minres.success and not self.minres.success
+        if cond1 or cond2:
             self._add(minres)
             return True
         else:
@@ -75,6 +83,7 @@ class BasinHoppingRunner:
                 print("warning: basinhopping: local minimization failure")
         self.x = np.copy(minres.x)
         self.energy = minres.fun
+        self.incumbent_minres = minres  # best minimize result found so far
         if self.disp:
             print("basinhopping step %d: f %g" % (self.nstep, self.energy))
 
@@ -107,7 +116,6 @@ class BasinHoppingRunner:
             self.res.minimization_failures += 1
             if self.disp:
                 print("warning: basinhopping: local minimization failure")
-
         if hasattr(minres, "nfev"):
             self.res.nfev += minres.nfev
         if hasattr(minres, "njev"):
@@ -122,8 +130,12 @@ class BasinHoppingRunner:
         # steps are not sufficient.
         accept = True
         for test in self.accept_tests:
-            testres = test(f_new=energy_after_quench, x_new=x_after_quench,
-                           f_old=self.energy, x_old=self.x)
+            if inspect.signature(test) == _new_accept_test_signature:
+                testres = test(res_new=minres, res_old=self.incumbent_minres)
+            else:
+                testres = test(f_new=energy_after_quench, x_new=x_after_quench,
+                               f_old=self.energy, x_old=self.x)
+
             if testres == 'force accept':
                 accept = True
                 break
@@ -153,6 +165,7 @@ class BasinHoppingRunner:
         if accept:
             self.energy = minres.fun
             self.x = np.copy(minres.x)
+            self.incumbent_minres = minres  # best minimize result found so far
             new_global_min = self.storage.update(minres)
 
         # print some information
@@ -318,8 +331,9 @@ class Metropolis:
         self.beta = 1.0 / T if T != 0 else float('inf')
         self.random_gen = check_random_state(random_gen)
 
-    def accept_reject(self, energy_new, energy_old):
+    def accept_reject(self, res_new, res_old):
         """
+        Assuming the local search underlying res_new was successful:
         If new energy is lower than old, it will always be accepted.
         If new is higher than old, there is a chance it will be accepted,
         less likely for larger differences.
@@ -333,18 +347,17 @@ class Metropolis:
             #
             # Ignore this warning so when the algorithm is on a flat plane, it always
             # accepts the step, to try to move off the plane.
-            prod = -(energy_new - energy_old) * self.beta
+            prod = -(res_new.fun - res_old.fun) * self.beta
             w = math.exp(min(0, prod))
 
         rand = self.random_gen.uniform()
-        return w >= rand
+        return w >= rand and (res_new.success or not res_old.success)
 
-    def __call__(self, **kwargs):
+    def __call__(self, *, res_new, res_old):
         """
         f_new and f_old are mandatory in kwargs
         """
-        return bool(self.accept_reject(kwargs["f_new"],
-                    kwargs["f_old"]))
+        return bool(self.accept_reject(res_new, res_old))
 
 
 def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,


### PR DESCRIPTION
#### Reference issue
Closes gh-7799

#### What does this implement/fix?
`basinhopping` does not consider the `success` message of `minimize` when it decides whether to accept a step. This can lead to incorrect results (e.g. gh-7799). This PR implements the solutions suggested in https://github.com/scipy/scipy/issues/7799#issuecomment-1286053309.

#### Additional information
I have not yet documented the new `accept_test` interface. It does not necessarily need to be public.

Besides fixing a bug, this PR also shows how we can change the callback interface in a backward-compatible way. This may be useful for many local and global optimizers, since we've discussed making callbacks more consistent by passing in only one parameter - and `OptimizeResult`.