### PR TITLE
ENH: increase range of vonmises entropy

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -9233,8 +9233,16 @@ class vonmises_gen(rv_continuous):
         return 0, None, 0, None
 
     def _entropy(self, kappa):
-        return (-kappa * sc.i1(kappa) / sc.i0(kappa) +
-                np.log(2 * np.pi * sc.i0(kappa)))
+        # vonmises.entropy(kappa) = -kappa * I[1](kappa) / I[0](kappa) +
+        #                           log(2 * np.pi * I[0](kappa))
+        #                         = -kappa * I[1](kappa) * exp(-kappa) /
+        #                           (I[0](kappa) * exp(-kappa)) +
+        #                           log(2 * np.pi *
+        #                           I[0](kappa) * exp(-kappa) / exp(-kappa))
+        #                         = -kappa * sc.i1e(kappa) / sc.i0e(kappa) +
+        #                           log(2 * np.pi * i0e(kappa)) + kappa
+        return (-kappa * sc.i1e(kappa) / sc.i0e(kappa) +
+                np.log(2 * np.pi * sc.i0e(kappa)) + kappa)
 
 
 vonmises = vonmises_gen(name='vonmises')

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -132,6 +132,26 @@ def test_vonmises_pdf(x, kappa, expected_pdf):
     assert_allclose(pdf, expected_pdf, rtol=1e-15)
 
 
+# Expected values of the vonmises entropy were computed using
+# mpmath with 50 digits of precision:
+#
+# def vonmises_entropy(kappa):
+#     kappa = mpmath.mpf(kappa)
+#     return (-kappa * mpmath.besseli(1, kappa) /
+#             mpmath.besseli(0, kappa) + mpmath.log(2 * mpmath.pi *
+#             mpmath.besseli(0, kappa)))
+# >>> float(vonmises_entropy(kappa))
+
+@pytest.mark.parametrize('kappa, expected_entropy',
+                         [(1, 1.6274014590199897),
+                          (5, 0.6756431570114528),
+                          (100, -0.8811275441649473),
+                          (1000, -2.03468891852547),
+                          (2000, -2.3813876496587847)])
+def test_vonmises_entropy(kappa, expected_entropy):
+    entropy = stats.vonmises.entropy(kappa)
+    assert_allclose(entropy, expected_entropy, rtol=1e-13)
+
 def test_vonmises_rvs_gh4598():
     # check that random variates wrap around as discussed in gh-4598
     seed = abs(hash('von_mises_rvs'))


### PR DESCRIPTION
#### What does this implement/fix?
Increases the range of the entropy calculation of the von mises distribution by using exponentially scaled Bessel functions.

#### Additional information
The old calculation resulted in nans for app. $\kappa > 800$.

See the plot below.

<details>

```
def _entropy(kappa):
    return (-kappa * sc.i1(kappa) / sc.i0(kappa) +
            np.log(2 * np.pi * sc.i0(kappa)))

def _entropy_new(kappa):
    return (-kappa * sc.i1e(kappa) / sc.i0e(kappa) +
            np.log(2 * np.pi * sc.i0e(kappa))) + kappa

def _entropy_mpmath(kappa):
    return (-kappa * mpmath.besseli(1, kappa) / mpmath.besseli(0, kappa) +
        mpmath.log(2 * mpmath.pi * mpmath.besseli(0, kappa)))

kappas = np.linspace(0, 5000)
old_entropies = _entropy(kappas)
new_entropies = _entropy_new(kappas)
plt.plot(kappas, old_entropies, label="Old: unscaled Bessel", ls="dashdot")
plt.plot(kappas, new_entropies, label="New: scaled Bessel", ls="dotted")
plt.legend()
plt.xlabel("$\kappa$")
plt.ylabel("Von Mises entropy")
```

</details>

![Entropies](https://user-images.githubusercontent.com/40656107/204059807-22ed4424-a969-4b2d-86fa-a7822456c2aa.png)

There was no accuracy test for the entropy before from what I see. For completeness, here the relative errors of the old and new implementation for the five implemented test cases on my machine (x86_64, Windows subsystem for Linux).

<details>

```
testkappas = [1, 5, 100, 1000, 2000]
for kappa in testkappas:
    old = _entropy(kappa)
    new = _entropy_new(kappa)
    ref = float(_entropy_mpmath(kappa))
    print(f"rel. error new: {(new- ref)/ref}, rel. error old: {(old- ref)/ref}")
```

</details>

| kappa | New  | Old |
| ---- | ------------- | ------------- |
| 1 |  -2.7288239628191694e-16  |  -1.3644119814095847e-16 |
| 5 | -1.6432091601962856e-16 |  -1.6432091601962856e-16 |
| 100 | 7.812016317341908e-15 | 2.3940050004757457e-14 | 
| 1000 | 6.547770607192752e-14 | nan |
|  2000 | -9.2868721535958e-14 | nan |
