### PR TITLE
BUG: ndimage: Work around gh-17270

### DIFF
--- a/ci/cirrus_general_ci.yml
+++ b/ci/cirrus_general_ci.yml
@@ -70,9 +70,8 @@ musllinux_amd64_test_task:
     python dev.py build
 
   test_script: |
-    # Don't run the ndimage tests because there's a segfault (gh17270)
     set -xe -o
-    python dev.py test -- --ignore=scipy/ndimage/tests
+    python dev.py test
 
 
 macos_arm64_test_task:

--- a/scipy/ndimage/_fourier.py
+++ b/scipy/ndimage/_fourier.py
@@ -94,7 +94,6 @@ def fourier_gaussian(input, sigma, n=-1, axis=-1, output=None):
         The axis of the real transform.
     output : ndarray, optional
         If given, the result of filtering the input is placed in this array.
-        None is returned in this case.
 
     Returns
     -------
@@ -153,7 +152,6 @@ def fourier_uniform(input, size, n=-1, axis=-1, output=None):
         The axis of the real transform.
     output : ndarray, optional
         If given, the result of filtering the input is placed in this array.
-        None is returned in this case.
 
     Returns
     -------
@@ -190,7 +188,7 @@ def fourier_ellipsoid(input, size, n=-1, axis=-1, output=None):
     """
     Multidimensional ellipsoid Fourier filter.
 
-    The array is multiplied with the fourier transform of a ellipsoid of
+    The array is multiplied with the fourier transform of an ellipsoid of
     given sizes.
 
     Parameters
@@ -211,7 +209,6 @@ def fourier_ellipsoid(input, size, n=-1, axis=-1, output=None):
         The axis of the real transform.
     output : ndarray, optional
         If given, the result of filtering the input is placed in this array.
-        None is returned in this case.
 
     Returns
     -------
@@ -278,7 +275,6 @@ def fourier_shift(input, shift, n=-1, axis=-1, output=None):
         The axis of the real transform.
     output : ndarray, optional
         If given, the result of shifting the input is placed in this array.
-        None is returned in this case.
 
     Returns
     -------

--- a/scipy/ndimage/_fourier.py
+++ b/scipy/ndimage/_fourier.py
@@ -241,6 +241,10 @@ def fourier_ellipsoid(input, size, n=-1, axis=-1, output=None):
     if input.ndim > 3:
         raise NotImplementedError("Only 1d, 2d and 3d inputs are supported")
     output = _get_output_fourier(output, input)
+    if output.size == 0:
+        # The C code has a bug that can result in a segfault with arrays
+        # that have size 0 (gh-17270), so check here.
+        return output
     axis = normalize_axis_index(axis, input.ndim)
     sizes = _ni_support._normalize_sequence(size, input.ndim)
     sizes = numpy.asarray(sizes, dtype=numpy.float64)


### PR DESCRIPTION
To avoid a bug in the C code, don't pass arrays with size 0 to
the `fourier_filter` function in the extension module code for
the Fourier ellipsoid filter.

Also remove an incorrect line from the Fourier filter docstrings.