### PR TITLE
DEV: dev.py: make lint task consistent with CI

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -183,7 +183,7 @@ rich_click.COMMAND_GROUPS = {
         },
         {
             "name": "static checkers",
-            "commands": ["lint", "flake8", "mypy"],
+            "commands": ["lint", "mypy"],
         },
         {
             "name": "environments",
@@ -884,15 +884,25 @@ def task_pep8diff():
     }
 
 
+def task_unicode_check():
+    return {
+        'basename': 'unicode-check',
+        'actions': [str(Dirs().root / 'tools' / 'unicode-check.py')],
+        'doc': 'Check for disallowed Unicode characters in the SciPy Python '
+                'and Cython source code.',
+    }
+
+
 @cli.cls_cmd('lint')
 class Lint():
-    """:dash: Run flake8, and check PEP 8 compliance on branch diff."""
+    """:dash: Run flake8, check PEP 8 compliance on branch diff and check for
+    disallowed Unicode characters."""
     output_file = Option(
         ['--output-file'], default=None, help='Redirect report to a file')
 
     def run(output_file):
         opts = {'output_file': output_file}
-        run_doit_task({'flake8': opts, 'pep8-diff': {}})
+        run_doit_task({'flake8': opts, 'pep8-diff': {}, 'unicode-check': {}})
 
 
 @cli.cls_cmd('mypy')

--- a/dev.py
+++ b/dev.py
@@ -7,7 +7,7 @@ This file contains tasks definitions for doit (https://pydoit.org).
 And also a CLI interface using click (https://click.palletsprojects.com).
 
 The CLI is ideal for project contributors while,
-doit interface is better suited for authring the development tasks.
+doit interface is better suited for authoring the development tasks.
 
 REQUIREMENTS:
 --------------
@@ -183,7 +183,7 @@ rich_click.COMMAND_GROUPS = {
         },
         {
             "name": "static checkers",
-            "commands": ["lint", "mypy"],
+            "commands": ["lint", "flake8", "mypy"],
         },
         {
             "name": "environments",
@@ -233,8 +233,8 @@ CONTEXT = UnifiedContext({
         help=':wrench: Relative path to the build directory.'),
     'no_build': Option(
         ["--no-build", "-n"], default=False, is_flag=True,
-        help=(":wrench: do not build the project"
-              " (note event python only modification require build)")),
+        help=(":wrench: Do not build the project"
+              " (note event python only modification require build).")),
     'install_prefix': Option(
         ['--install-prefix'], default=None, metavar='INSTALL_DIR',
         help=(":wrench: Relative path to the install directory."
@@ -371,7 +371,7 @@ def get_test_runner(project_module):
 
 @cli.cls_cmd('build')
 class Build(Task):
-    """:wrench: build & install package on path
+    """:wrench: Build & install package on path.
 
     \b
     ```python
@@ -621,7 +621,7 @@ class Build(Task):
 
 @cli.cls_cmd('test')
 class Test(Task):
-    """:wrench: Run tests
+    """:wrench: Run tests.
 
     \b
     ```python
@@ -730,7 +730,7 @@ class Test(Task):
 
 @cli.cls_cmd('bench')
 class Bench(Task):
-    """:wrench: Run benchmarks
+    """:wrench: Run benchmarks.
 
     \b
     ```python
@@ -880,13 +880,13 @@ def task_pep8diff():
     return {
         'basename': 'pep8-diff',
         'actions': [str(Dirs().root / 'tools' / 'lint_diff.py')],
-        'doc': 'Lint only files modified since last commit (stricker rules)',
+        'doc': 'Lint only files modified since last commit (stricter rules)',
     }
 
 
 @cli.cls_cmd('lint')
 class Lint():
-    """:dash: run flake8, and check PEP 8 compliance on branch diff."""
+    """:dash: Run flake8, and check PEP 8 compliance on branch diff."""
     output_file = Option(
         ['--output-file'], default=None, help='Redirect report to a file')
 
@@ -897,7 +897,7 @@ class Lint():
 
 @cli.cls_cmd('mypy')
 class Mypy(Task):
-    """:wrench: Run mypy on the codebase"""
+    """:wrench: Run mypy on the codebase."""
     ctx = CONTEXT
 
     TASK_META = {
@@ -943,7 +943,7 @@ class Mypy(Task):
 
 @cli.cls_cmd('doc')
 class Doc(Task):
-    """:wrench: Build documentation
+    """:wrench: Build documentation.
 
 TARGETS: Sphinx build targets [default: 'html']
 
@@ -991,7 +991,7 @@ TARGETS: Sphinx build targets [default: 'html']
 
 @cli.cls_cmd('refguide-check')
 class RefguideCheck(Task):
-    """:wrench: Run refguide check"""
+    """:wrench: Run refguide check."""
     ctx = CONTEXT
 
     submodule = Option(
@@ -1027,7 +1027,7 @@ class RefguideCheck(Task):
 
 @cli.cls_cmd('python')
 class Python():
-    """:wrench: Start a Python shell with PYTHONPATH set"""
+    """:wrench: Start a Python shell with PYTHONPATH set."""
     ctx = CONTEXT
     pythonpath = Option(
         ['--pythonpath', '-p'], metavar='PYTHONPATH', default=None,
@@ -1063,7 +1063,7 @@ class Python():
 
 @cli.cls_cmd('ipython')
 class Ipython(Python):
-    """:wrench: Start IPython shell with PYTHONPATH set"""
+    """:wrench: Start IPython shell with PYTHONPATH set."""
     ctx = CONTEXT
     pythonpath = Python.pythonpath
 
@@ -1076,7 +1076,7 @@ class Ipython(Python):
 
 @cli.cls_cmd('shell')
 class Shell(Python):
-    """:wrench: Start Unix shell with PYTHONPATH set"""
+    """:wrench: Start Unix shell with PYTHONPATH set."""
     ctx = CONTEXT
     pythonpath = Python.pythonpath
     extra_argv = Python.extra_argv
@@ -1094,7 +1094,7 @@ class Shell(Python):
 @click.argument('version_args', nargs=2)
 @click.pass_obj
 def notes(ctx_obj, version_args):
-    """:ledger: Release notes and log generation
+    """:ledger: Release notes and log generation.
 
     \b
     ```python
@@ -1119,7 +1119,8 @@ def notes(ctx_obj, version_args):
 @click.argument('revision_args', nargs=2)
 @click.pass_obj
 def authors(ctx_obj, revision_args):
-    """:ledger: Generate list of authors who contributed within revision interval
+    """:ledger: Generate list of authors who contributed within revision
+    interval.
 
     \b
     ```python

--- a/dev.py
+++ b/dev.py
@@ -889,7 +889,7 @@ def task_unicode_check():
         'basename': 'unicode-check',
         'actions': [str(Dirs().root / 'tools' / 'unicode-check.py')],
         'doc': 'Check for disallowed Unicode characters in the SciPy Python '
-                'and Cython source code.',
+               'and Cython source code.',
     }
 
 

--- a/environment.yml
+++ b/environment.yml
@@ -39,7 +39,7 @@ dependencies:
   - pydata-sphinx-theme==0.9.0
   - sphinx-design
   # For linting
-  - flake8
+  - flake8 < 6.0
   # Some optional test dependencies
   - mpmath
   - gmpy2

--- a/scipy/integrate/_odepack_py.py
+++ b/scipy/integrate/_odepack_py.py
@@ -232,7 +232,7 @@ def odeint(func, y0, t, args=(), Dfun=None, col_deriv=0, full_output=0,
         mu = -1  # changed to zero inside function call
 
     dt = np.diff(t)
-    if not((dt >= 0).all() or (dt <= 0).all()):
+    if not ((dt >= 0).all() or (dt <= 0).all()):
         raise ValueError("The values in t must be monotonically increasing "
                          "or monotonically decreasing; repeated values are "
                          "allowed.")

--- a/scipy/integrate/tests/test_quadpack.py
+++ b/scipy/integrate/tests/test_quadpack.py
@@ -670,6 +670,6 @@ class TestNQuad:
     def test_dict_as_opts(self):
         try:
             nquad(lambda x, y: x * y, [[0, 1], [0, 1]], opts={'epsrel': 0.0001})
-        except(TypeError):
+        except TypeError:
             assert False
 

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -536,7 +536,7 @@ class TestInterp1D:
         try:
             interpolant(test_array)
         except ValueError as err:
-            assert("{}".format(fail_value) in str(err))
+            assert ("{}".format(fail_value) in str(err))
 
     def _bounds_check(self, kind='linear'):
         # Test that our handling of out-of-bounds input is correct.

--- a/scipy/io/arff/_arffread.py
+++ b/scipy/io/arff/_arffread.py
@@ -186,7 +186,7 @@ class NumericAttribute(Attribute):
 
         attr_string = attr_string.lower().strip()
 
-        if(attr_string[:len('numeric')] == 'numeric' or
+        if (attr_string[:len('numeric')] == 'numeric' or
            attr_string[:len('int')] == 'int' or
            attr_string[:len('real')] == 'real'):
             return cls(name)

--- a/scipy/linalg/_matfuncs.py
+++ b/scipy/linalg/_matfuncs.py
@@ -869,7 +869,7 @@ def khatri_rao(a, b):
     a = np.asarray(a)
     b = np.asarray(b)
 
-    if not(a.ndim == 2 and b.ndim == 2):
+    if not (a.ndim == 2 and b.ndim == 2):
         raise ValueError("The both arrays should be 2-dimensional.")
 
     if not a.shape[1] == b.shape[1]:

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -2331,7 +2331,7 @@ class TestOrdQZ:
             # once the sorting criterion was not matched all subsequent
             # eigenvalues also shouldn't match
             if not lastsort:
-                assert(not cursort)
+                assert not cursort
             lastsort = cursort
 
     def check_all(self, sort):

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -1467,7 +1467,7 @@ class TestBlockedQR:
             geqrt, gemqrt = get_lapack_funcs(('geqrt', 'gemqrt'), dtype=dtype)
 
             a, t, info = geqrt(n, A)
-            assert(info == 0)
+            assert info == 0
 
             # Extract elementary reflectors from lower triangle, adding the
             # main diagonal of ones.
@@ -1491,7 +1491,7 @@ class TestBlockedQR:
             for side in ('L', 'R'):
                 for trans in ('N', transpose):
                     c, info = gemqrt(a, t, C, side=side, trans=trans)
-                    assert(info == 0)
+                    assert info == 0
 
                     if trans == transpose:
                         q = Q.T.conj()
@@ -1508,7 +1508,7 @@ class TestBlockedQR:
                     # Test default arguments
                     if (side, trans) == ('L', 'N'):
                         c_default, info = gemqrt(a, t, C)
-                        assert(info == 0)
+                        assert info == 0
                         assert_equal(c_default, c)
 
             # Test invalid side/trans
@@ -1534,7 +1534,7 @@ class TestBlockedQR:
             # triangular
             for l in (0, n // 2, n):
                 a, b, t, info = tpqrt(l, n, A, B)
-                assert(info == 0)
+                assert info == 0
 
                 # Check that lower triangular part of A has not been modified
                 assert_equal(np.tril(a, -1), np.tril(A, -1))
@@ -1570,7 +1570,7 @@ class TestBlockedQR:
                     for trans in ('N', transpose):
                         c, d, info = tpmqrt(l, b, t, C, D, side=side,
                                             trans=trans)
-                        assert(info == 0)
+                        assert info == 0
 
                         if trans == transpose:
                             q = Q.T.conj()
@@ -1590,7 +1590,7 @@ class TestBlockedQR:
 
                         if (side, trans) == ('L', 'N'):
                             c_default, d_default, info = tpmqrt(l, b, t, C, D)
-                            assert(info == 0)
+                            assert info == 0
                             assert_equal(c_default, c)
                             assert_equal(d_default, d)
 

--- a/scipy/optimize/_dual_annealing.py
+++ b/scipy/optimize/_dual_annealing.py
@@ -201,7 +201,7 @@ class EnergyState:
             val = self.callback(x, e, context)
             if val is not None:
                 if val:
-                    return('Callback function requested to stop early by '
+                    return ('Callback function requested to stop early by '
                            'returning True')
 
     def update_current(self, e, x):
@@ -669,7 +669,7 @@ def dual_annealing(func, bounds, args=(), maxiter=1000,
 
     t1 = np.exp((visit - 1) * np.log(2.0)) - 1.0
     # Run the search loop
-    while(not need_to_stop):
+    while not need_to_stop:
         for i in range(maxiter):
             # Compute temperature for this step
             s = float(i) + 2.0

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -260,7 +260,7 @@ def _get_delta(A, b, c, x, y, z, tau, kappa, gamma, eta, sparse=False,
         # 3. scipy.sparse.linalg.splu
         # 4. scipy.sparse.linalg.lsqr
         solved = False
-        while(not solved):
+        while not solved:
             try:
                 # [4] Equation 8.28
                 p, q = _sym_solve(Dinv, A, c, b, solve)

--- a/scipy/optimize/_linprog_util.py
+++ b/scipy/optimize/_linprog_util.py
@@ -302,7 +302,7 @@ def _clean_inputs(lp):
             raise ValueError(
                 "Invalid input for linprog: c must be a 1-D array and must "
                 "not have more than one non-singleton dimension")
-        if not(np.isfinite(c).all()):
+        if not np.isfinite(c).all():
             raise ValueError(
                 "Invalid input for linprog: c must not contain values "
                 "inf, nan, or None")
@@ -341,7 +341,7 @@ def _clean_inputs(lp):
                 "must not have more than one non-singleton dimension and "
                 "the number of rows in A_ub must equal the number of values "
                 "in b_ub")
-        if not(np.isfinite(b_ub).all()):
+        if not np.isfinite(b_ub).all():
             raise ValueError(
                 "Invalid input for linprog: b_ub must not contain values "
                 "inf, nan, or None")
@@ -380,7 +380,7 @@ def _clean_inputs(lp):
                 "must not have more than one non-singleton dimension and "
                 "the number of rows in A_eq must equal the number of values "
                 "in b_eq")
-        if not(np.isfinite(b_eq).all()):
+        if not np.isfinite(b_eq).all():
             raise ValueError(
                 "Invalid input for linprog: b_eq must not contain values "
                 "inf, nan, or None")

--- a/scipy/optimize/_remove_redundancy.py
+++ b/scipy/optimize/_remove_redundancy.py
@@ -85,7 +85,7 @@ def _remove_zero_rows(A, b):
     message = ""
     i_zero = _row_count(A) == 0
     A = A[np.logical_not(i_zero), :]
-    if not(np.allclose(b[i_zero], 0)):
+    if not np.allclose(b[i_zero], 0):
         status = 2
         message = "There is a zero row in A_eq with a nonzero corresponding " \
                   "entry in b_eq. The problem is infeasible."

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -480,7 +480,7 @@ class TestDifferentialEvolutionSolver:
         _, fun_prev = next(solver)
         for i, soln in enumerate(solver):
             x_current, fun_current = soln
-            assert(fun_prev >= fun_current)
+            assert fun_prev >= fun_current
             _, fun_prev = x_current, fun_current
             # need to have this otherwise the solver would never stop.
             if i == 50:

--- a/scipy/optimize/tests/test_differentiable_functions.py
+++ b/scipy/optimize/tests/test_differentiable_functions.py
@@ -142,7 +142,7 @@ class TestScalarFunction(TestCase):
 
         fg = ex.fun(x0), ex.grad(x0)
         fg_allclose(analit.fun_and_grad(x0), fg)
-        assert(analit.ngev == 1)
+        assert analit.ngev == 1
 
         x0[1] = 1.
         fg = ex.fun(x0), ex.grad(x0)
@@ -152,10 +152,10 @@ class TestScalarFunction(TestCase):
         x0 = [2.0, 0.3]
         sf = ScalarFunction(ex.fun, x0, (), '3-point',
                                 ex.hess, None, (-np.inf, np.inf))
-        assert(sf.ngev == 1)
+        assert sf.ngev == 1
         fg = ex.fun(x0), ex.grad(x0)
         fg_allclose(sf.fun_and_grad(x0), fg)
-        assert(sf.ngev == 1)
+        assert sf.ngev == 1
 
         x0[1] = 1.
         fg = ex.fun(x0), ex.grad(x0)

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -423,7 +423,7 @@ class TestBasic:
             assert_equal(x, r.root)
             assert_equal((r.iterations, r.function_calls), expected_counts[derivs])
             if derivs == 0:
-                assert(r.function_calls <= r.iterations + 1)
+                assert r.function_calls <= r.iterations + 1
             else:
                 assert_equal(r.function_calls, (derivs + 1) * r.iterations)
 
@@ -690,11 +690,11 @@ def test_gh_8881():
     # The function has positive slope, x0 < root.
     # Newton succeeds in 8 iterations
     rt, r = newton(f, x0, fprime=fp, full_output=True)
-    assert(r.converged)
+    assert r.converged
     # Before the Issue 8881/PR 8882, halley would send x in the wrong direction.
     # Check that it now succeeds.
     rt, r = newton(f, x0, fprime=fp, fprime2=fpp, full_output=True)
-    assert(r.converged)
+    assert r.converged
 
 
 def test_gh_9608_preserve_array_shape():
@@ -713,7 +713,7 @@ def test_gh_9608_preserve_array_shape():
 
     x0 = np.array([-2], dtype=np.float32)
     rt, r = newton(f, x0, fprime=fp, fprime2=fpp, full_output=True)
-    assert(r.converged)
+    assert r.converged
 
     x0_array = np.array([-2, -3], dtype=np.float32)
     # This next invocation should fail

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -2340,7 +2340,7 @@ def iirdesign(wp, ws, gpass, gstop, analog=False, ftype='ellip', output='ba',
                              " (fs={} -> fs/2={})".format(fs, fs/2))
 
     if wp.shape[0] == 2:
-        if not((ws[0] < wp[0] and wp[1] < ws[1]) or
+        if not ((ws[0] < wp[0] and wp[1] < ws[1]) or
                (wp[0] < ws[0] and ws[1] < wp[1])):
             raise ValueError("Passband must lie strictly inside stopband"
                              " or vice versa")

--- a/scipy/signal/_peak_finding.py
+++ b/scipy/signal/_peak_finding.py
@@ -61,7 +61,7 @@ def _boolrelextrema(data, comparator, axis=0, order=1, mode='clip'):
     array([False, False,  True, False, False], dtype=bool)
 
     """
-    if((int(order) != order) or (order < 1)):
+    if (int(order) != order) or (order < 1):
         raise ValueError('Order must be an int >= 1')
 
     datalen = data.shape[axis]
@@ -74,7 +74,7 @@ def _boolrelextrema(data, comparator, axis=0, order=1, mode='clip'):
         minus = data.take(locs - shift, axis=axis, mode=mode)
         results &= comparator(main, plus)
         results &= comparator(main, minus)
-        if(~results.any()):
+        if ~results.any():
             return results
     return results
 
@@ -1059,14 +1059,14 @@ def _identify_ridge_lines(matr, max_distances, gap_thresh):
     as part of `find_peaks_cwt`.
 
     """
-    if(len(max_distances) < matr.shape[0]):
+    if len(max_distances) < matr.shape[0]:
         raise ValueError('Max_distances must have at least as many rows '
                          'as matr')
 
     all_max_cols = _boolrelextrema(matr, np.greater, axis=1, order=1)
     # Highest row for which there are any relative maxima
     has_relmax = np.nonzero(all_max_cols.any(axis=1))[0]
-    if(len(has_relmax) == 0):
+    if len(has_relmax) == 0:
         return []
     start_row = has_relmax[-1]
     # Each ridge line is a 3-tuple:
@@ -1096,12 +1096,12 @@ def _identify_ridge_lines(matr, max_distances, gap_thresh):
             # the max_distance to connect to, do so.
             # Otherwise start a new one.
             line = None
-            if(len(prev_ridge_cols) > 0):
+            if len(prev_ridge_cols) > 0:
                 diffs = np.abs(col - prev_ridge_cols)
                 closest = np.argmin(diffs)
                 if diffs[closest] <= max_distances[row]:
                     line = ridge_lines[closest]
-            if(line is not None):
+            if line is not None:
                 # Found a point close enough, extend current ridge line
                 line[1].append(col)
                 line[0].append(row)

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1290,7 +1290,7 @@ class TestResample:
         x = np.arange(10, dtype=np.float32)
         h = np.array([1, 1, 1], dtype=np.float32)
         y = signal.resample_poly(x, 1, 2, window=h, padtype=padtype)
-        assert(y.dtype == np.float32)
+        assert y.dtype == np.float32
 
     @pytest.mark.parametrize('padtype', padtype_options)
     @pytest.mark.parametrize('dtype', [np.float32, np.float64])
@@ -1298,7 +1298,7 @@ class TestResample:
         # Test that the dtype of x is preserved per issue #14733
         x = np.arange(10, dtype=dtype)
         y = signal.resample_poly(x, 1, 2, padtype=padtype)
-        assert(y.dtype == x.dtype)
+        assert y.dtype == x.dtype
 
     @pytest.mark.parametrize(
         "method, ext, padtype",

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -193,8 +193,8 @@ def test_shortest_path_min_only_random(n):
     for k in range(n):
         p = pred[k]
         s = sources[k]
-        while(p != -9999):
-            assert(sources[p] == s)
+        while p != -9999:
+            assert sources[p] == s
             p = pred[p]
 
 

--- a/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
@@ -265,7 +265,7 @@ def test_failure_to_run_iterations():
     Q = rnd.standard_normal((X.shape[0], 4))
     with pytest.warns(UserWarning, match="Exited at iteration"):
         eigenvalues, _ = lobpcg(A, Q, maxiter=20)
-    assert(np.max(eigenvalues) > 0)
+    assert np.max(eigenvalues) > 0
 
 
 @pytest.mark.filterwarnings("ignore:The problem size")

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -2079,7 +2079,7 @@ def test_Xdist_deprecated_args():
         for arg in ["p", "V", "VI"]:
             kwargs = {arg:"foo"}
 
-            if((arg == "V" and metric == "seuclidean") or
+            if ((arg == "V" and metric == "seuclidean") or
             (arg == "VI" and metric == "mahalanobis") or
             (arg == "p" and metric == "minkowski")):
                 continue

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -1778,7 +1778,7 @@ def clpmn(m, n, z, type=3):
         raise ValueError("n must be a non-negative integer.")
     if not isscalar(z):
         raise ValueError("z must be scalar.")
-    if not(type == 2 or type == 3):
+    if not (type == 2 or type == 3):
         raise ValueError("type must be either 2 or 3.")
     if (m < 0):
         mp = -m

--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -567,7 +567,7 @@ def binned_statistic_dd(sample, values, statistic='mean',
     Vdim, Vlen = values.shape
 
     # Make sure `values` match `sample`
-    if(statistic != 'count' and Vlen != Dlen):
+    if statistic != 'count' and Vlen != Dlen:
         raise AttributeError('The number of `values` elements must match the '
                              'length of each `sample` dimension.')
 
@@ -673,7 +673,7 @@ def binned_statistic_dd(sample, values, statistic='mean',
     result = result[core]
 
     # Unravel binnumbers into an ndarray, each row the bins for each dimension
-    if(expand_binnumbers and Ndim > 1):
+    if expand_binnumbers and Ndim > 1:
         binnumbers = np.asarray(np.unravel_index(binnumbers, nbin))
 
     if np.any(result.shape[1:] != nbin - 2):

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -694,7 +694,7 @@ class beta_gen(rv_continuous):
             return _boost._beta_ppf(q, a, b)
 
     def _stats(self, a, b):
-        return(
+        return (
             _boost._beta_mean(a, b),
             _boost._beta_variance(a, b),
             _boost._beta_skewness(a, b),
@@ -4421,7 +4421,7 @@ class geninvgauss_gen(rv_continuous):
         # following [2], the quasi-pdf is used instead of the pdf for the
         # generation of rvs
         invert_res = False
-        if not(numsamples):
+        if not numsamples:
             numsamples = 1
         if p < 0:
             # note: if X is geninvgauss(p, b), then 1/X is geninvgauss(-p, b)

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -368,7 +368,7 @@ class nbinom_gen(rv_discrete):
             return _boost._nbinom_ppf(q, n, p)
 
     def _stats(self, n, p):
-        return(
+        return (
             _boost._nbinom_mean(n, p),
             _boost._nbinom_variance(n, p),
             _boost._nbinom_skewness(n, p),

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -915,9 +915,9 @@ def test_axis_None_vs_tuple_with_broadcasting():
     res2 = stats.mannwhitneyu(x, y, axis=(0, 1))
     res3 = stats.mannwhitneyu(x2.ravel(), y2.ravel())
 
-    assert(res1 == res0)
-    assert(res2 == res0)
-    assert(res3 != res0)
+    assert res1 == res0
+    assert res2 == res0
+    assert res3 != res0
 
 
 @pytest.mark.parametrize(("axis"),

--- a/scipy/stats/tests/test_discrete_distns.py
+++ b/scipy/stats/tests/test_discrete_distns.py
@@ -472,7 +472,7 @@ class TestNCH():
 
         atol, rtol = 1e-6, 1e-6
         i = np.abs(pmf1 - pmf0) < atol + rtol*np.abs(pmf0)
-        assert(i.sum() > np.prod(shape) / 2)  # works at least half the time
+        assert i.sum() > np.prod(shape) / 2  # works at least half the time
 
         # for those that fail, discredit the naive implementation
         for N, m1, n, w in zip(N[~i], m1[~i], n[~i], w[~i]):

--- a/scipy/stats/tests/test_hypotests.py
+++ b/scipy/stats/tests/test_hypotests.py
@@ -469,19 +469,19 @@ class TestMannWhitneyU:
         res = mannwhitneyu(x, y, method=method, axis=axis)
 
         shape = (6, 3, 8)  # appropriate shape of outputs, given inputs
-        assert(res.pvalue.shape == shape)
-        assert(res.statistic.shape == shape)
+        assert res.pvalue.shape == shape
+        assert res.statistic.shape == shape
 
         # move axis of test to end for simplicity
         x, y = np.moveaxis(x, axis, -1), np.moveaxis(y, axis, -1)
 
         x = x[None, ...]  # give x a zeroth dimension
-        assert(x.ndim == y.ndim)
+        assert x.ndim == y.ndim
 
         x = np.broadcast_to(x, shape + (m,))
         y = np.broadcast_to(y, shape + (n,))
-        assert(x.shape[:-1] == shape)
-        assert(y.shape[:-1] == shape)
+        assert x.shape[:-1] == shape
+        assert y.shape[:-1] == shape
 
         # loop over pairs of samples
         statistics = np.zeros(shape)

--- a/scipy/stats/tests/test_resampling.py
+++ b/scipy/stats/tests/test_resampling.py
@@ -864,7 +864,7 @@ class TestMonteCarloHypothesisTest:
         with suppress_warnings() as sup:
             sup.filter(RuntimeWarning)
             sol = root(fun, x0=0)
-        assert(sol.success)
+        assert sol.success
 
         # get the significance level (p-value) associated with that critical
         # value

--- a/scipy/stats/tests/test_sampling.py
+++ b/scipy/stats/tests/test_sampling.py
@@ -401,7 +401,7 @@ class TestQRVS:
         qrng2 = deepcopy(qrng)
         qrvs = gen.qrvs(size=size_in, d=d_in, qmc_engine=qrng)
         if size_in is not None:
-            assert(qrvs.shape == shape_expected)
+            assert qrvs.shape == shape_expected
 
         if qrng2 is not None:
             uniform = qrng2.random(np.prod(size_in) or 1)
@@ -1122,7 +1122,7 @@ class TestNumericalInverseHermite:
         rng2 = deepcopy(rng)
         rvs = fni.rvs(size=size_in, random_state=rng)
         if size_in is not None:
-            assert(rvs.shape == size_out)
+            assert rvs.shape == size_out
 
         if rng2 is not None:
             rng2 = check_random_state(rng2)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4707,9 +4707,9 @@ class Test_ttest_ind_permutations():
         res1 = stats.ttest_ind(a, b, permutations=1000)
         res2 = stats.ttest_ind(a, b, permutations=0)
         res3 = stats.ttest_ind(a, b, permutations=np.inf)
-        assert(res1.pvalue != res0.pvalue)
-        assert(res2.pvalue == res0.pvalue)
-        assert(res3.pvalue == res1.pvalue)
+        assert res1.pvalue != res0.pvalue
+        assert res2.pvalue == res0.pvalue
+        assert res3.pvalue == res1.pvalue
 
     def test_ttest_ind_exact_distribution(self):
         # the exact distribution of the test statistic should have
@@ -4826,8 +4826,8 @@ class Test_ttest_ind_permutations():
 
             # Propagate 1d
             res = stats.ttest_ind(a.ravel(), b.ravel(), **options_p)
-            assert(np.isnan(res.pvalue))  # assert makes sure it's a scalar
-            assert(np.isnan(res.statistic))
+            assert np.isnan(res.pvalue)  # assert makes sure it's a scalar
+            assert np.isnan(res.statistic)
 
     def test_ttest_ind_permutation_check_inputs(self):
         with assert_raises(ValueError, match="Permutations must be"):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
closes #17434, closes https://github.com/scipy/scipy/issues/17394

#### What does this implement/fix?
<!--Please explain your changes.-->
As per discussion, https://github.com/scipy/scipy/issues/17434#issuecomment-1318566296, ~separates out the running of `lint_diff.py` and flake8 into separate tasks~ so that `dev.py lint` will now give the same output as the CI job.

Also very minor tidy up of consistent use of fullstops at the end of task descriptions. 
#### Additional information
<!--Any additional information you think is important.-->
