### PR TITLE
MAINT: remove use of `NPY_UPDATEIFCOPY`

### DIFF
--- a/scipy/ndimage/src/nd_image.c
+++ b/scipy/ndimage/src/nd_image.c
@@ -44,9 +44,6 @@
 
 #include "ccallback.h"
 
-#if NPY_API_VERSION >= 0x0000000c
-    #define HAVE_WRITEBACKIFCOPY
-#endif
 
 typedef struct {
     PyObject *extra_arguments;
@@ -109,11 +106,7 @@ NI_ObjectToOptionalInputArray(PyObject *object, PyArrayObject **array)
 static int
 NI_ObjectToOutputArray(PyObject *object, PyArrayObject **array)
 {
-    #ifdef HAVE_WRITEBACKIFCOPY
-        int flags = NPY_ARRAY_BEHAVED_NS | NPY_ARRAY_WRITEBACKIFCOPY;
-    #else
-        int flags = NPY_ARRAY_BEHAVED_NS | NPY_ARRAY_UPDATEIFCOPY;
-    #endif
+    int flags = NPY_ARRAY_BEHAVED_NS | NPY_ARRAY_WRITEBACKIFCOPY;
     /*
      * This would also be caught by the PyArray_CheckFromAny call, but
      * we check it explicitly here to provide a saner error message.
@@ -197,9 +190,7 @@ static PyObject *Py_Correlate1D(PyObject *obj, PyObject *args)
 
     NI_Correlate1D(input, weights, axis, output, (NI_ExtendMode)mode, cval,
                    origin);
-    #ifdef HAVE_WRITEBACKIFCOPY
-        PyArray_ResolveWritebackIfCopy(output);
-    #endif
+    PyArray_ResolveWritebackIfCopy(output);
 
 exit:
     Py_XDECREF(input);
@@ -228,9 +219,7 @@ static PyObject *Py_Correlate(PyObject *obj, PyObject *args)
 
     NI_Correlate(input, weights, output, (NI_ExtendMode)mode, cval,
                  origin.ptr);
-    #ifdef HAVE_WRITEBACKIFCOPY
-        PyArray_ResolveWritebackIfCopy(output);
-    #endif
+    PyArray_ResolveWritebackIfCopy(output);
 
 exit:
     Py_XDECREF(input);
@@ -256,9 +245,7 @@ static PyObject *Py_UniformFilter1D(PyObject *obj, PyObject *args)
 
     NI_UniformFilter1D(input, filter_size, axis, output, (NI_ExtendMode)mode,
                        cval, origin);
-    #ifdef HAVE_WRITEBACKIFCOPY
-        PyArray_ResolveWritebackIfCopy(output);
-    #endif
+    PyArray_ResolveWritebackIfCopy(output);
 
 exit:
     Py_XDECREF(input);
@@ -282,9 +269,7 @@ static PyObject *Py_MinOrMaxFilter1D(PyObject *obj, PyObject *args)
 
     NI_MinOrMaxFilter1D(input, filter_size, axis, output, (NI_ExtendMode)mode,
                         cval, origin, minimum);
-    #ifdef HAVE_WRITEBACKIFCOPY
-        PyArray_ResolveWritebackIfCopy(output);
-    #endif
+    PyArray_ResolveWritebackIfCopy(output);
 
 exit:
     Py_XDECREF(input);
@@ -316,9 +301,7 @@ static PyObject *Py_MinOrMaxFilter(PyObject *obj, PyObject *args)
 
     NI_MinOrMaxFilter(input, footprint, structure, output, (NI_ExtendMode)mode,
                       cval, origin.ptr, minimum);
-    #ifdef HAVE_WRITEBACKIFCOPY
-        PyArray_ResolveWritebackIfCopy(output);
-    #endif
+    PyArray_ResolveWritebackIfCopy(output);
 
 exit:
     Py_XDECREF(input);
@@ -350,9 +333,7 @@ static PyObject *Py_RankFilter(PyObject *obj, PyObject *args)
 
     NI_RankFilter(input, rank, footprint, output, (NI_ExtendMode)mode, cval,
                   origin.ptr);
-    #ifdef HAVE_WRITEBACKIFCOPY
-        PyArray_ResolveWritebackIfCopy(output);
-    #endif
+    PyArray_ResolveWritebackIfCopy(output);
 
 exit:
     Py_XDECREF(input);
@@ -472,9 +453,7 @@ static PyObject *Py_GenericFilter1D(PyObject *obj, PyObject *args)
 
     NI_GenericFilter1D(input, func, data, filter_size, axis, output,
                        (NI_ExtendMode)mode, cval, origin);
-    #ifdef HAVE_WRITEBACKIFCOPY
-        PyArray_ResolveWritebackIfCopy(output);
-    #endif
+    PyArray_ResolveWritebackIfCopy(output);
 
 exit:
     if (callback.py_function != NULL || callback.c_function != NULL) {
@@ -593,9 +572,7 @@ static PyObject *Py_GenericFilter(PyObject *obj, PyObject *args)
 
     NI_GenericFilter(input, func, data, footprint, output, (NI_ExtendMode)mode,
                      cval, origin.ptr);
-    #ifdef HAVE_WRITEBACKIFCOPY
-        PyArray_ResolveWritebackIfCopy(output);
-    #endif
+    PyArray_ResolveWritebackIfCopy(output);
 
 exit:
     if (callback.py_function != NULL || callback.c_function != NULL) {
@@ -623,9 +600,7 @@ static PyObject *Py_FourierFilter(PyObject *obj, PyObject *args)
         goto exit;
 
     NI_FourierFilter(input, parameters, n, axis, output, filter_type);
-    #ifdef HAVE_WRITEBACKIFCOPY
-        PyArray_ResolveWritebackIfCopy(output);
-    #endif
+    PyArray_ResolveWritebackIfCopy(output);
 
 exit:
     Py_XDECREF(input);
@@ -648,9 +623,7 @@ static PyObject *Py_FourierShift(PyObject *obj, PyObject *args)
         goto exit;
 
     NI_FourierShift(input, shifts, n, axis, output);
-    #ifdef HAVE_WRITEBACKIFCOPY
-        PyArray_ResolveWritebackIfCopy(output);
-    #endif
+    PyArray_ResolveWritebackIfCopy(output);
 
 exit:
     Py_XDECREF(input);
@@ -670,9 +643,7 @@ static PyObject *Py_SplineFilter1D(PyObject *obj, PyObject *args)
         goto exit;
 
     NI_SplineFilter1D(input, order, axis, mode, output);
-    #ifdef HAVE_WRITEBACKIFCOPY
-        PyArray_ResolveWritebackIfCopy(output);
-    #endif
+    PyArray_ResolveWritebackIfCopy(output);
 
 exit:
     Py_XDECREF(input);
@@ -799,9 +770,7 @@ static PyObject *Py_GeometricTransform(PyObject *obj, PyObject *args)
 
     NI_GeometricTransform(input, func, data, matrix, shift, coordinates,
                           output, order, (NI_ExtendMode)mode, cval, nprepad);
-    #ifdef HAVE_WRITEBACKIFCOPY
-        PyArray_ResolveWritebackIfCopy(output);
-    #endif
+    PyArray_ResolveWritebackIfCopy(output);
 
 exit:
     if (callback.py_function != NULL || callback.c_function != NULL) {
@@ -832,9 +801,7 @@ static PyObject *Py_ZoomShift(PyObject *obj, PyObject *args)
 
     NI_ZoomShift(input, zoom, shift, output, order, (NI_ExtendMode)mode, cval,
                  nprepad, grid_mode);
-    #ifdef HAVE_WRITEBACKIFCOPY
-        PyArray_ResolveWritebackIfCopy(output);
-    #endif
+    PyArray_ResolveWritebackIfCopy(output);
 
 exit:
     Py_XDECREF(input);
@@ -1167,9 +1134,7 @@ static PyObject *Py_WatershedIFT(PyObject *obj, PyObject *args)
         goto exit;
 
     NI_WatershedIFT(input, markers, strct, output);
-    #ifdef HAVE_WRITEBACKIFCOPY
-        PyArray_ResolveWritebackIfCopy(output);
-    #endif
+    PyArray_ResolveWritebackIfCopy(output);
 
 exit:
     Py_XDECREF(input);
@@ -1195,9 +1160,7 @@ static PyObject *Py_DistanceTransformBruteForce(PyObject *obj,
         goto exit;
 
     NI_DistanceTransformBruteForce(input, metric, sampling, output, features);
-    #ifdef HAVE_WRITEBACKIFCOPY
-        PyArray_ResolveWritebackIfCopy(output);
-    #endif
+    PyArray_ResolveWritebackIfCopy(output);
 
 exit:
     Py_XDECREF(input);
@@ -1282,9 +1245,7 @@ static PyObject *Py_BinaryErosion(PyObject *obj, PyObject *args)
     if (return_coordinates) {
         cobj = PyCapsule_New(coordinate_list, NULL, _FreeCoordinateList);
     }
-    #ifdef HAVE_WRITEBACKIFCOPY
-        PyArray_ResolveWritebackIfCopy(output);
-    #endif
+    PyArray_ResolveWritebackIfCopy(output);
 
 exit:
     Py_XDECREF(input);

--- a/scipy/optimize/tnc/moduleTNC.c.old
+++ b/scipy/optimize/tnc/moduleTNC.c.old
@@ -36,13 +36,6 @@
 
 #include "tnc.h"
 
-/* NPY_ARRAY_IN_ARRAY was introduced in numpy 1.7.0 */
-#if NPY_API_VERSION < 0x00000007
-    #define NPY_ARRAY_C_CONTIGUOUS    0x0001
-    #define NPY_ARRAY_ALIGNED         0x0100
-    #define NPY_ARRAY_IN_ARRAY (NPY_ARRAY_C_CONTIGUOUS | NPY_ARRAY_ALIGNED)
-#endif
-
 typedef struct _pytnc_state
 {
   PyObject *py_function;

--- a/scipy/signal/_lfilter.c.in
+++ b/scipy/signal/_lfilter.c.in
@@ -283,14 +283,10 @@ scipy_signal__sigtools_linear_filter(PyObject * NPY_UNUSED(dummy), PyObject * ar
                 goto fail;
             }
             /* Give our reference to arVi to arVi_view */
-#if NPY_API_VERSION >= 0x00000007
             if (PyArray_SetBaseObject(arVi_view, (PyObject *)arVi) == -1) {
                 Py_DECREF(arVi_view);
                 goto fail;
             }
-#else
-            PyArray_BASE(arVi_view) = arVi;
-#endif
             arVi = arVi_view;
         }
 

--- a/scipy/sparse/sparsetools/sparsetools.cxx
+++ b/scipy/sparse/sparsetools/sparsetools.cxx
@@ -38,10 +38,6 @@
 
 #define MAX_ARGS 16
 
-#if NPY_API_VERSION >= 0x0000000c
-    #define HAVE_WRITEBACKIFCOPY
-#endif
-
 static const int supported_I_typenums[] = {NPY_INT32, NPY_INT64};
 static const int n_supported_I_typenums = sizeof(supported_I_typenums) / sizeof(int);
 
@@ -436,11 +432,9 @@ fail:
             --j;
             continue;
         }
-        #ifdef HAVE_WRITEBACKIFCOPY
-            if (is_output[j] && arg_arrays[j] != NULL && PyArray_Check(arg_arrays[j])) {
-                PyArray_ResolveWritebackIfCopy((PyArrayObject *)arg_arrays[j]);
-            }
-        #endif
+        if (is_output[j] && arg_arrays[j] != NULL && PyArray_Check(arg_arrays[j])) {
+            PyArray_ResolveWritebackIfCopy((PyArrayObject *)arg_arrays[j]);
+        }
         Py_XDECREF(arg_arrays[j]);
         if ((*p == 'i' || *p == 'l') && arg_list[j] != NULL) {
             std::free(arg_list[j]);
@@ -528,11 +522,7 @@ static PyObject *c_array_from_object(PyObject *obj, int typenum, int is_output)
         }
     }
     else {
-        #ifdef HAVE_WRITEBACKIFCOPY
-            int flags = NPY_ARRAY_C_CONTIGUOUS|NPY_ARRAY_WRITEABLE|NPY_ARRAY_WRITEBACKIFCOPY|NPY_ARRAY_NOTSWAPPED;
-        #else
-            int flags = NPY_ARRAY_C_CONTIGUOUS|NPY_ARRAY_WRITEABLE|NPY_UPDATEIFCOPY|NPY_ARRAY_NOTSWAPPED;
-        #endif
+        int flags = NPY_ARRAY_C_CONTIGUOUS|NPY_ARRAY_WRITEABLE|NPY_ARRAY_WRITEBACKIFCOPY|NPY_ARRAY_NOTSWAPPED;
         if (typenum == -1) {
             return PyArray_FROM_OF(obj, flags);
         }


### PR DESCRIPTION
`NPY_UPDATEIFCOPY` was deprecated in numpy `1.14.0` and removed in `1.23.0`. The alternative `NPY_ARRAY_WRITEBACKIFCOPY` was introduced in `1.14.0`, we can use it unconditionally now.

Also clean up some old compat shims.
