### PR TITLE
BUG, DOC: stats: fix `[source]` button redicting to the wrong function

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -375,7 +375,8 @@ def linkcode_resolve(domain, info):
             return None
 
     # Use the original function object if it is wrapped.
-    obj = getattr(obj, "__wrapped__", obj)
+    while hasattr(obj, "__wrapped__"):
+        obj = obj.__wrapped__
     # SciPy's distributions are instances of *_gen. Point to this
     # class since it contains the implementation of all the methods.
     if isinstance(obj, (rv_generic, multi_rv_generic)):


### PR DESCRIPTION
#### Reference issue

Closes #17523 

#### What does this implement/fix?

The doc build generates the incorrect link for the function if it has been wrapped multiple times. To resolve this, we just walk the `__wrapped__` attribute until we reach the innermost function.
