### PR TITLE
DOC: tutorial: rST typo

### DIFF
--- a/doc/source/tutorial/interpolate/smoothing_splines.rst
+++ b/doc/source/tutorial/interpolate/smoothing_splines.rst
@@ -405,7 +405,7 @@ formally corresponds to interpolation, :math:`g(x_i, y_j) = z_{i, j}`.
 
     If the input data, ``x`` and ``y``, is such that input dimensions
     have incommensurate units and differ by many orders of magnitude, the
-    interpolant `math`:g(x, y): may have numerical artifacts. Consider
+    interpolant :math:`g(x, y)` may have numerical artifacts. Consider
     rescaling the data before interpolation.
 
 We now consider the two spline fitting problems in turn.


### PR DESCRIPTION
fix a trivial typo in ReST markup.