### PR TITLE
ENH: Extend Rotation.align_vectors() to allow an infinite weight, as well as minimum-distance rotations for single vectors

### DIFF
--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -2777,10 +2777,11 @@ cdef class Rotation:
         shortest distance rotation between the primary infinite weight vectors
         is calculated as above. Then, the rotation about the aligned primary
         vectors is calculated such that the secondary vectors are optimally
-        aligned per the above loss function. The result is then the
-        composition of these two rotations. The result via this process is the
-        same as the Kabsch algorithm as the corresponding weight approaches
-        infinity in the limit.
+        aligned per the above loss function. The result is the composition
+        of these two rotations. The result via this process is the same as the
+        Kabsch algorithm as the corresponding weight approaches infinity in
+        the limit. For a single secondary vector this is known as the
+        align-constrain algorithm [2]_.
 
         For both special cases (single vectors or an infinite weight), the
         sensitivity matrix does not have physical meaning and an error will be
@@ -2834,26 +2835,30 @@ cdef class Rotation:
         this rotation vector assuming that the vectors in `a` was measured with
         errors significantly less than their lengths. To get the true
         covariance matrix, the returned sensitivity matrix must be multiplied
-        by harmonic mean [2]_ of variance in each observation. Note that
+        by harmonic mean [3]_ of variance in each observation. Note that
         `weights` are supposed to be inversely proportional to the observation
         variances to get consistent results. For example, if all vectors are
         measured with the same accuracy of 0.01 (`weights` must be all equal),
         then you should multiple the sensitivity matrix by 0.01**2 to get the
         covariance.
 
-        Refer to [3]_ for more rigorous discussion of the covariance
-        estimation. See [4]_ for more discussion of the pointing problem and
+        Refer to [4]_ for more rigorous discussion of the covariance
+        estimation. See [5]_ for more discussion of the pointing problem and
         minimal proper pointing.
 
         References
         ----------
         .. [1] https://en.wikipedia.org/wiki/Kabsch_algorithm
-        .. [2] https://en.wikipedia.org/wiki/Harmonic_mean
-        .. [3] F. Landis Markley,
+        .. [2] Magner, Robert,
+                "Extending target tracking capabilities through trajectory and
+                momentum setpoint optimization." Small Satellite Conference,
+                2018.
+        .. [3] https://en.wikipedia.org/wiki/Harmonic_mean
+        .. [4] F. Landis Markley,
                 "Attitude determination using vector observations: a fast
                 optimal matrix algorithm", Journal of Astronautical Sciences,
                 Vol. 41, No.2, 1993, pp. 261-280.
-        .. [4] Bar-Itzhack, Itzhack Y., Daniel Hershkowitz, and Leiba Rodman,
+        .. [5] Bar-Itzhack, Itzhack Y., Daniel Hershkowitz, and Leiba Rodman,
                 "Pointing in Real Euclidean Space", Journal of Guidance,
                 Control, and Dynamics, Vol. 20, No. 5, 1997, pp. 916-922.
 
@@ -2963,13 +2968,13 @@ cdef class Rotation:
         else:
             weights = np.array(weights, dtype=float)
             if weights.ndim != 1:
-                raise ValueError("Expected `weights` to be 1 dimensional, got "
-                                "shape {}.".format(weights.shape))
+                raise ValueError("Expected `weights` to be 1 dimensional, "
+                                 "got shape {}.".format(weights.shape))
             if N > 1 and (weights.shape[0] != N):
-                raise ValueError("Expected `weights` to have number of values "
-                                "equal to number of input vectors, got "
-                                "{} values and {} vectors.".format(
-                                    weights.shape[0], N))
+                raise ValueError("Expected `weights` to have number of"
+                                 "values equal to number of input vectors, "
+                                 "got {} values and {} vectors.".format(
+                                     weights.shape[0], N))
             if (weights < 0).any():
                 raise ValueError("`weights` may not contain negative values")
 

--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -2971,7 +2971,7 @@ cdef class Rotation:
                 raise ValueError("Expected `weights` to be 1 dimensional, "
                                  "got shape {}.".format(weights.shape))
             if N > 1 and (weights.shape[0] != N):
-                raise ValueError("Expected `weights` to have number of"
+                raise ValueError("Expected `weights` to have number of "
                                  "values equal to number of input vectors, "
                                  "got {} values and {} vectors.".format(
                                      weights.shape[0], N))

--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -2766,36 +2766,64 @@ cdef class Rotation:
 
         where :math:`w_i`'s are the `weights` corresponding to each vector.
 
-        The rotation is estimated with Kabsch algorithm [1]_.
+        The rotation is estimated with Kabsch algorithm [1]_, and solves what
+        is known as the "pointing problem", or "Wahba's problem".
+
+        There are two special cases. The first is if a single vector is given
+        for `a` and `b`, in which the shortest distance rotation that aligns
+        `b` to `a` is returned.
+
+        The second is when one of the weights is infinity. In this case, the
+        shortest distance rotation between the primary infinite weight vectors
+        is calculated as above. Then, the rotation about the aligned primary
+        vectors is calculated such that the secondary vectors are optimally
+        aligned per the above loss function. The result is then the
+        composition of these two rotations. The result via this process is the
+        same as the Kabsch algorithm as the corresponding weight approaches
+        infinity in the limit.
+
+        For both special cases (single vectors or an infinite weight), the
+        sensitivity matrix does not have physical meaning and an error will be
+        raised if it is requested. For these cases also, the portion of `rssd`
+        due to the single or infinite weight vectors will be forced to 0.
 
         Parameters
         ----------
-        a : array_like, shape (N, 3)
+        a : array_like, shape (3,) or (N, 3)
             Vector components observed in initial frame A. Each row of `a`
             denotes a vector.
-        b : array_like, shape (N, 3)
+        b : array_like, shape (3,) or (N, 3)
             Vector components observed in another frame B. Each row of `b`
             denotes a vector.
         weights : array_like shape (N,), optional
             Weights describing the relative importance of the vector
             observations. If None (default), then all values in `weights` are
-            assumed to be 1.
+            assumed to be 1. One and only one weight may be infinity, and
+            weights must be positive.
         return_sensitivity : bool, optional
             Whether to return the sensitivity matrix. See Notes for details.
             Default is False.
 
         Returns
         -------
-        estimated_rotation : `Rotation` instance
+        rotation : `Rotation` instance
             Best estimate of the rotation that transforms `b` to `a`.
         rssd : float
-            Square root of the weighted sum of the squared distances between
-            the given sets of vectors after alignment. It is equal to
-            ``sqrt(2 * minimum_loss)``, where ``minimum_loss`` is the loss
-            function evaluated for the found optimal rotation.
+            Stands for "root sum squared distance". Square root of the weighted
+            sum of the squared distances between the given sets of vectors
+            after alignment. It is equal to ``sqrt(2 * minimum_loss)``, where
+            ``minimum_loss`` is the loss function evaluated for the found
+            optimal rotation.
+            Note that the result will also be weighted by the vectors'
+            magnitudes, so perfectly aligned vector pairs will have nonzero
+            `rssd` if they are not of the same length. So, depending on the
+            use case it may be desirable to normalize the input vectors to unit
+            length before calling this method.
         sensitivity_matrix : ndarray, shape (3, 3)
             Sensitivity matrix of the estimated rotation estimate as explained
-            in Notes. Returned only when `return_sensitivity` is True.
+            in Notes. Returned only when `return_sensitivity` is True. Not
+            valid if aligning a single pair of vectors of if there is an
+            infinite weight, in which cases an error will be raised.
 
         Notes
         -----
@@ -2806,54 +2834,233 @@ cdef class Rotation:
         this rotation vector assuming that the vectors in `a` was measured with
         errors significantly less than their lengths. To get the true
         covariance matrix, the returned sensitivity matrix must be multiplied
-        by harmonic mean [3]_ of variance in each observation. Note that
+        by harmonic mean [2]_ of variance in each observation. Note that
         `weights` are supposed to be inversely proportional to the observation
         variances to get consistent results. For example, if all vectors are
         measured with the same accuracy of 0.01 (`weights` must be all equal),
         then you should multiple the sensitivity matrix by 0.01**2 to get the
         covariance.
 
-        Refer to [2]_ for more rigorous discussion of the covariance
-        estimation.
+        Refer to [3]_ for more rigorous discussion of the covariance
+        estimation. See [4]_ for more discussion of the pointing problem and
+        minimal proper pointing.
 
         References
         ----------
         .. [1] https://en.wikipedia.org/wiki/Kabsch_algorithm
-        .. [2] F. Landis Markley,
+        .. [2] https://en.wikipedia.org/wiki/Harmonic_mean
+        .. [3] F. Landis Markley,
                 "Attitude determination using vector observations: a fast
                 optimal matrix algorithm", Journal of Astronautical Sciences,
                 Vol. 41, No.2, 1993, pp. 261-280.
-        .. [3] https://en.wikipedia.org/wiki/Harmonic_mean
-        """
-        a = np.asarray(a)
-        if a.ndim != 2 or a.shape[-1] != 3:
-            raise ValueError("Expected input `a` to have shape (N, 3), "
-                             "got {}".format(a.shape))
-        b = np.asarray(b)
-        if b.ndim != 2 or b.shape[-1] != 3:
-            raise ValueError("Expected input `b` to have shape (N, 3), "
-                             "got {}.".format(b.shape))
+        .. [4] Bar-Itzhack, Itzhack Y., Daniel Hershkowitz, and Leiba Rodman,
+                "Pointing in Real Euclidean Space", Journal of Guidance,
+                Control, and Dynamics, Vol. 20, No. 5, 1997, pp. 916-922.
 
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from scipy.spatial.transform import Rotation as R
+
+        Best align two sets of vectors with the Kabsch algorithm, where there
+        is noise on the last two vector measurements of the ``b`` set:
+
+        >>> a = [[0, 1, 0], [0, 1, 1], [0, 1, 1]]
+        >>> b = [[1, 0, 0], [1, 1.1, 0], [1, 0.9, 0]]
+        >>> rot, rssd, sens = R.align_vectors(a, b, return_sensitivity=True)
+        >>> rot.as_matrix()
+        array([[0., 0., 1.],
+               [1., 0., 0.],
+               [0., 1., 0.]])
+
+        When we apply the rotation to ``b``, we get vectors close to ``a``:
+
+        >>> rot.apply(b)
+        array([[0. , 1. , 0. ],
+               [0. , 1. , 1.1],
+               [0. , 1. , 0.9]])
+
+        The error for the first vector is 0, and for the last two the error is
+        magnitude 0.1. The `rssd` is the square root of the sum of the
+        weighted squared errors, and the default weights are all 1, so in this
+        case the `rssd` is calculated as
+        ``sqrt(1 * 0**2 + 1 * 0.1**2 + 1 * (-0.1)**2) = 0.141421356237308``
+
+        >>> a - rot.apply(b)
+        array([[ 0., 0.,  0. ],
+               [ 0., 0., -0.1],
+               [ 0., 0.,  0.1]])
+        >>> np.sqrt(np.sum(np.ones(3) @ (a - rot.apply(b))**2))
+        0.141421356237308
+        >>> rssd
+        0.141421356237308
+
+        The sensitivity matrix for this example is as follows:
+
+        >>> sens
+        array([[0.2, 0. , 0.],
+               [0. , 1.5, 1.],
+               [0. , 1. , 1.]])
+
+        Special case 1: Find a minimum rotation between single vectors:
+
+        >>> a = [1, 0, 0]
+        >>> b = [0, 1, 0]
+        >>> rot, _ = R.align_vectors(a, b)
+        >>> rot.as_matrix()
+        array([[0., 1., 0.],
+               [-1., 0., 0.],
+               [0., 0., 1.]])
+        >>> rot.apply(b)
+        array([1., 0., 0.])
+
+        Special case 2: One infinite weight. Here we find a rotation between
+        primary and secondary vectors that can align exactly:
+
+        >>> a = [[0, 1, 0], [0, 1, 1]]
+        >>> b = [[1, 0, 0], [1, 1, 0]]
+        >>> rot, _ = R.align_vectors(a, b, weights=[np.inf, 1])
+        >>> rot.as_matrix()
+        array([[0., 0., 1.],
+               [1., 0., 0.],
+               [0., 1., 0.]])
+        >>> rot.apply(b)
+        array([[0., 1., 0.],
+               [0., 1., 1.]])
+
+        Here the secondary vectors must be best-fit:
+
+        >>> b = [[1, 0, 0], [1, 2, 0]]
+        >>> rot, _ = R.align_vectors(a, b, weights=[np.inf, 1])
+        >>> rot.as_matrix()
+        array([[0., 0., 1.],
+               [1., 0., 0.],
+               [0., 1., 0.]])
+        >>> rot.apply(b)
+        array([[0., 1., 0.],
+               [0., 1., 2.]])
+        """
+        # Check input vectors
+        a_original = np.array(a, dtype=float)
+        b_original = np.array(b, dtype=float)
+        a = np.atleast_2d(a_original)
+        b = np.atleast_2d(b_original)
+        if a.shape[-1] != 3:
+            raise ValueError("Expected input `a` to have shape (3,) or "
+                             "(N, 3), got {}".format(a_original.shape))
+        if b.shape[-1] != 3:
+            raise ValueError("Expected input `b` to have shape (3,) or "
+                             "(N, 3), got {}".format(b_original.shape))
         if a.shape != b.shape:
             raise ValueError("Expected inputs `a` and `b` to have same shapes"
                              ", got {} and {} respectively.".format(
-                                a.shape, b.shape))
+                                 a_original.shape, b_original.shape))
+        N = len(a)
 
+        # Check weights
         if weights is None:
-            weights = np.ones(len(b))
+            weights = np.ones(N)
         else:
-            weights = np.asarray(weights)
+            weights = np.array(weights, dtype=float)
             if weights.ndim != 1:
                 raise ValueError("Expected `weights` to be 1 dimensional, got "
-                                 "shape {}.".format(weights.shape))
-            if weights.shape[0] != b.shape[0]:
+                                "shape {}.".format(weights.shape))
+            if N > 1 and (weights.shape[0] != N):
                 raise ValueError("Expected `weights` to have number of values "
-                                 "equal to number of input vectors, got "
-                                 "{} values and {} vectors.".format(
-                                    weights.shape[0], b.shape[0]))
+                                "equal to number of input vectors, got "
+                                "{} values and {} vectors.".format(
+                                    weights.shape[0], N))
             if (weights < 0).any():
                 raise ValueError("`weights` may not contain negative values")
 
+        # For the special case of a single vector pair, we use the infinite
+        # weight code path
+        if N == 1:
+            weight_is_inf = np.array([True])
+        else:
+            weight_is_inf = np.isposinf(weights)
+        n_inf = np.sum(weight_is_inf)
+
+        # Check for an infinite weight, which indicates that the corresponding
+        # vector pair is the primary unmoving reference to which we align the
+        # other secondary vectors
+        if n_inf > 1:
+            raise ValueError("Only one infinite weight is allowed")
+
+        elif n_inf == 1:
+            if return_sensitivity:
+                raise ValueError("Cannot return sensitivity matrix with an "
+                                 "infinite weight or one vector pair")
+            a_pri = a[weight_is_inf]
+            b_pri = b[weight_is_inf]
+            a_pri_norm = _norm3(a_pri[0])
+            b_pri_norm = _norm3(b_pri[0])
+            if a_pri_norm == 0 or b_pri_norm == 0:
+                raise ValueError("Cannot align zero length primary vectors")
+            a_pri /= a_pri_norm
+            b_pri /= b_pri_norm
+
+            # We first find the minimum angle rotation between the primary
+            # vectors.
+            cross = np.cross(b_pri[0], a_pri[0])
+            theta = atan2(_norm3(cross), np.dot(a_pri[0], b_pri[0]))
+            if theta < 1e-3:  # small angle Taylor series approximation
+                theta2 = theta * theta
+                r = cross * (1 + theta2 / 6 + theta2 * theta2 * 7 / 360)
+            else:
+                r = cross * theta / np.sin(theta)
+            R_pri = cls.from_rotvec(r)
+
+            if N == 1:
+                # No secondary vectors, so we are done
+                R_opt = R_pri
+            else:
+                a_sec = a[~weight_is_inf]
+                b_sec = b[~weight_is_inf]
+                weights_sec = weights[~weight_is_inf]
+
+                # We apply the first rotation to the b vectors to align the
+                # primary vectors, resulting in vectors c. The secondary
+                # vectors must now be rotated about that primary vector to best
+                # align c to a.
+                c_sec = R_pri.apply(b_sec)
+
+                # Calculate vector components for the angle calculation. The
+                # angle phi to rotate a single 2D vector C to align to 2D
+                # vector A in the xy plane can be found with the equation
+                # phi = atan2(cross(C, A), dot(C, A))
+                #     = atan2(|C|*|A|*sin(phi), |C|*|A|*cos(phi))
+                # The below equations perform the same operation, but with the
+                # 3D rotation restricted to the 2D plane normal to a_pri, where
+                # the secondary vectors are projected into that plane. The
+                # weighted sum of the components gives the average of all the
+                # angles.
+                # Note that einsum('ij,ij->i', X, Y) is the row-wise dot
+                # product of X and Y.
+                sin_term = np.einsum('ij,ij->i', np.cross(c_sec, a_sec), a_pri)
+                cos_term = (np.einsum('ij,ij->i', c_sec, a_sec)
+                            - (np.einsum('ij,ij->i', c_sec, a_pri)
+                               * np.einsum('ij,ij->i', a_sec, a_pri)))
+                phi = atan2(np.sum(weights_sec * sin_term),
+                            np.sum(weights_sec * cos_term))
+                R_sec = cls.from_rotvec(phi * a_pri[0])
+
+                # Compose these to get the optimal rotation
+                R_opt = R_sec * R_pri
+
+            # Calculated the root sum squared distance. We force the error to
+            # be zero for the infinite weight vectors since they will align
+            # exactly.
+            weights_inf_zero = weights.copy()
+            weights_inf_zero[weight_is_inf] = 0
+            a_est = R_opt.apply(b)
+            rssd = np.sqrt(np.sum(weights_inf_zero @ (a - a_est)**2))
+
+            return R_opt, rssd
+
+        # If no infinite weights and multiple vectors, proceed with normal
+        # algorithm
+        # Note that einsum('ji,jk->ik', X, Y) is equivalent to np.dot(X.T, Y)
         B = np.einsum('ji,jk->ik', weights[:, None] * a, b)
         u, s, vh = np.linalg.svd(B)
 
@@ -2881,7 +3088,6 @@ cdef class Rotation:
             return cls.from_matrix(C), rssd, sensitivity
         else:
             return cls.from_matrix(C), rssd
-
 
 class Slerp:
     """Spherical Linear Interpolation of Rotations.

--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -2968,13 +2968,13 @@ cdef class Rotation:
         else:
             weights = np.array(weights, dtype=float)
             if weights.ndim != 1:
-                raise ValueError("Expected `weights` to be 1 dimensional, "
-                                 "got shape {}.".format(weights.shape))
+                raise ValueError("Expected `weights` to be 1 dimensional, got "
+                                 "shape {}.".format(weights.shape))
             if N > 1 and (weights.shape[0] != N):
-                raise ValueError("Expected `weights` to have number of "
-                                 "values equal to number of input vectors, "
-                                 "got {} values and {} vectors.".format(
-                                     weights.shape[0], N))
+                raise ValueError("Expected `weights` to have number of values "
+                                 "equal to number of input vectors, got "
+                                 "{} values and {} vectors.".format(
+                                    weights.shape[0], N))
             if (weights < 0).any():
                 raise ValueError("`weights` may not contain negative values")
 

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -1207,13 +1207,22 @@ def test_n_rotations():
     assert_equal(len(r[:-1]), 1)
 
 
+def test_random_rotation_shape():
+    rnd = np.random.RandomState(0)
+    assert_equal(Rotation.random(random_state=rnd).as_quat().shape, (4,))
+    assert_equal(Rotation.random(None, random_state=rnd).as_quat().shape, (4,))
+
+    assert_equal(Rotation.random(1, random_state=rnd).as_quat().shape, (1, 4))
+    assert_equal(Rotation.random(5, random_state=rnd).as_quat().shape, (5, 4))
+
+
 def test_align_vectors_no_rotation():
     x = np.array([[1, 2, 3], [4, 5, 6]])
     y = x.copy()
 
-    r, rmsd = Rotation.align_vectors(x, y)
+    r, rssd = Rotation.align_vectors(x, y)
     assert_array_almost_equal(r.as_matrix(), np.eye(3))
-    assert_allclose(rmsd, 0, atol=1e-6)
+    assert_allclose(rssd, 0, atol=1e-6)
 
 
 def test_align_vectors_no_noise():
@@ -1222,9 +1231,9 @@ def test_align_vectors_no_noise():
     b = rnd.normal(size=(5, 3))
     a = c.apply(b)
 
-    est, rmsd = Rotation.align_vectors(a, b)
+    est, rssd = Rotation.align_vectors(a, b)
     assert_allclose(c.as_quat(), est.as_quat())
-    assert_allclose(rmsd, 0, atol=1e-7)
+    assert_allclose(rssd, 0, atol=1e-7)
 
 
 def test_align_vectors_improper_rotation():
@@ -1234,22 +1243,35 @@ def test_align_vectors_improper_rotation():
     y = np.array([[0.02386536, -0.82176463, 0.5693271],
                   [-0.27654929, -0.95191427, -0.1318321]])
 
-    est, rmsd = Rotation.align_vectors(x, y)
+    est, rssd = Rotation.align_vectors(x, y)
     assert_allclose(x, est.apply(y), atol=1e-6)
-    assert_allclose(rmsd, 0, atol=1e-7)
+    assert_allclose(rssd, 0, atol=1e-7)
+
+
+def test_align_vectors_rssd_sensitivity():
+    rssd_expected = 0.141421356237308
+    sens_expected = np.array([[0.2, 0. , 0.],
+                              [0. , 1.5, 1.],
+                              [0. , 1. , 1.]])
+    atol = 1e-6
+    a = [[0, 1, 0], [0, 1, 1], [0, 1, 1]]
+    b = [[1, 0, 0], [1, 1.1, 0], [1, 0.9, 0]]
+    rot, rssd, sens = Rotation.align_vectors(a, b, return_sensitivity=True)
+    assert np.isclose(rssd, rssd_expected, atol=atol)
+    assert np.allclose(sens, sens_expected, atol=atol)
 
 
 def test_align_vectors_scaled_weights():
-    rng = np.random.RandomState(0)
-    c = Rotation.random(random_state=rng)
-    b = rng.normal(size=(5, 3))
-    a = c.apply(b)
+    n = 10
+    a = Rotation.random(n, random_state=0).apply([1, 0, 0])
+    b = Rotation.random(n, random_state=1).apply([1, 0, 0])
+    scale = 2
 
-    est1, rmsd1, cov1 = Rotation.align_vectors(a, b, np.ones(5), True)
-    est2, rmsd2, cov2 = Rotation.align_vectors(a, b, 2 * np.ones(5), True)
+    est1, rssd1, cov1 = Rotation.align_vectors(a, b, np.ones(n), True)
+    est2, rssd2, cov2 = Rotation.align_vectors(a, b, scale * np.ones(n), True)
 
     assert_allclose(est1.as_matrix(), est2.as_matrix())
-    assert_allclose(np.sqrt(2) * rmsd1, rmsd2)
+    assert_allclose(np.sqrt(scale) * rssd1, rssd2, atol=1e-6)
     assert_allclose(cov1, cov2)
 
 
@@ -1274,7 +1296,7 @@ def test_align_vectors_noise():
     # rotations to each vector.
     noisy_result = noise.apply(result)
 
-    est, rmsd, cov = Rotation.align_vectors(noisy_result, vectors,
+    est, rssd, cov = Rotation.align_vectors(noisy_result, vectors,
                                             return_sensitivity=True)
 
     # Use rotation compositions to find out closeness
@@ -1289,21 +1311,15 @@ def test_align_vectors_noise():
     assert_allclose(cov[1, 1], 0, atol=tolerance)
     assert_allclose(cov[2, 2], 0, atol=tolerance)
 
-    assert_allclose(rmsd, np.sum((noisy_result - est.apply(vectors))**2)**0.5)
-
-
-def test_align_vectors_single_vector():
-    with pytest.warns(UserWarning, match="Optimal rotation is not"):
-        r_estimate, rmsd = Rotation.align_vectors([[1, -1, 1]], [[1, 1, -1]])
-        assert_allclose(rmsd, 0, atol=1e-16)
+    assert_allclose(rssd, np.sum((noisy_result - est.apply(vectors))**2)**0.5)
 
 
 def test_align_vectors_invalid_input():
     with pytest.raises(ValueError, match="Expected input `a` to have shape"):
-        Rotation.align_vectors([1, 2, 3], [[1, 2, 3]])
+        Rotation.align_vectors([1, 2, 3, 4], [1, 2, 3])
 
     with pytest.raises(ValueError, match="Expected input `b` to have shape"):
-        Rotation.align_vectors([[1, 2, 3]], [1, 2, 3])
+        Rotation.align_vectors([1, 2, 3], [1, 2, 3, 4])
 
     with pytest.raises(ValueError, match="Expected inputs `a` and `b` "
                                          "to have same shapes"):
@@ -1315,20 +1331,133 @@ def test_align_vectors_invalid_input():
 
     with pytest.raises(ValueError,
                        match="Expected `weights` to have number of values"):
-        Rotation.align_vectors([[1, 2, 3]], [[1, 2, 3]], weights=[1, 2])
+        Rotation.align_vectors([[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]],
+                               weights=[1, 2, 3])
 
     with pytest.raises(ValueError,
                        match="`weights` may not contain negative values"):
         Rotation.align_vectors([[1, 2, 3]], [[1, 2, 3]], weights=[-1])
 
+    with pytest.raises(ValueError,
+                       match="Only one infinite weight is allowed"):
+        Rotation.align_vectors([[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]],
+                               weights=[np.inf, np.inf])
 
-def test_random_rotation_shape():
-    rnd = np.random.RandomState(0)
-    assert_equal(Rotation.random(random_state=rnd).as_quat().shape, (4,))
-    assert_equal(Rotation.random(None, random_state=rnd).as_quat().shape, (4,))
+    with pytest.raises(ValueError,
+                       match="Cannot align zero length primary vectors"):
+        Rotation.align_vectors([[0, 0, 0]], [[1, 2, 3]])
 
-    assert_equal(Rotation.random(1, random_state=rnd).as_quat().shape, (1, 4))
-    assert_equal(Rotation.random(5, random_state=rnd).as_quat().shape, (5, 4))
+    with pytest.raises(ValueError,
+                       match="Cannot return sensitivity matrix"):
+        Rotation.align_vectors([[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]],
+                               return_sensitivity=True, weights=[np.inf, 1])
+
+    with pytest.raises(ValueError,
+                       match="Cannot return sensitivity matrix"):
+        Rotation.align_vectors([[1, 2, 3]], [[1, 2, 3]],
+                               return_sensitivity=True)
+
+
+def test_align_vectors_align_constrain():
+    # Align the primary +X B axis with the primary +Y A axis, and rotate about
+    # it such that the +Y B axis (residual of the [1, 1, 0] secondary b vector)
+    # is aligned with the +Z A axis (residual of the [0, 1, 1] secondary a
+    # vector)
+    atol = 1e-12
+    b = [[1, 0, 0], [1, 1, 0]]
+    a = [[0, 1, 0], [0, 1, 1]]
+    m_expected = np.array([[0, 0, 1],
+                           [1, 0, 0],
+                           [0, 1, 0]])
+    R, rssd = Rotation.align_vectors(a, b, weights=[np.inf, 1])
+    assert_allclose(R.as_matrix(), m_expected, atol=atol)
+    assert_allclose(R.apply(b), a, atol=atol)  # Pri and sec align exactly
+    assert np.isclose(rssd, 0, atol=atol)
+
+    # Do the same but with an inexact secondary rotation
+    b = [[1, 0, 0], [1, 2, 0]]
+    rssd_expected = 1.0
+    R, rssd = Rotation.align_vectors(a, b, weights=[np.inf, 1])
+    assert_allclose(R.as_matrix(), m_expected, atol=atol)
+    assert_allclose(R.apply(b)[0], a[0], atol=atol)  # Only pri aligns exactly
+    assert np.isclose(rssd, rssd_expected, atol=atol)
+    a_expected = [[0, 1, 0], [0, 1, 2]]
+    assert_allclose(R.apply(b), a_expected, atol=atol)
+
+    # Check random vectors
+    b = [[1, 2, 3], [-2, 3, -1]]
+    a = [[-1, 3, 2], [1, -1, 2]]
+    rssd_expected = 1.3101595297515016
+    R, rssd = Rotation.align_vectors(a, b, weights=[np.inf, 1])
+    assert_allclose(R.apply(b)[0], a[0], atol=atol)  # Only pri aligns exactly
+    assert np.isclose(rssd, rssd_expected, atol=atol)
+
+
+def test_align_vectors_near_inf():
+    # align_vectors should return near the same result for high weights as for
+    # infinite weights. rssd will be different with floating point error on the
+    # exactly aligned vector being multiplied by a large non-infinite weight
+    n = 100
+    mats = []
+    for i in range(6):
+        mats.append(Rotation.random(n, random_state=10 + i).as_matrix())
+
+    for i in range(n):
+        # Get random pairs of 3-element vectors
+        a = [1*mats[0][i][0], 2*mats[1][i][0]]
+        b = [3*mats[2][i][0], 4*mats[3][i][0]]
+
+        R, _ = Rotation.align_vectors(a, b, weights=[1e10, 1])
+        R2, _ = Rotation.align_vectors(a, b, weights=[np.inf, 1])
+        assert_allclose(R.as_matrix(), R2.as_matrix(), atol=1e-4)
+
+    for i in range(n):
+        # Get random triplets of 3-element vectors
+        a = [1*mats[0][i][0], 2*mats[1][i][0], 3*mats[2][i][0]]
+        b = [4*mats[3][i][0], 5*mats[4][i][0], 6*mats[5][i][0]]
+
+        R, _ = Rotation.align_vectors(a, b, weights=[1e10, 2, 1])
+        R2, _ = Rotation.align_vectors(a, b, weights=[np.inf, 2, 1])
+        assert_allclose(R.as_matrix(), R2.as_matrix(), atol=1e-4)
+
+
+def test_align_vectors_parallel():
+    atol = 1e-12
+    a = [[1, 0, 0], [0, 1, 0]]
+    b = [[0, 1, 0], [0, 1, 0]]
+    m_expected = np.array([[0, 1, 0],
+                           [-1, 0, 0],
+                           [0, 0, 1]])
+    R, _ = Rotation.align_vectors(a, b, weights=[np.inf, 1])
+    assert_allclose(R.as_matrix(), m_expected, atol=atol)
+    R, _ = Rotation.align_vectors(a[0], b[0])
+    assert_allclose(R.as_matrix(), m_expected, atol=atol)
+    assert_allclose(R.apply(b[0]), a[0], atol=atol)
+
+    b = [[1, 0, 0], [1, 0, 0]]
+    m_expected = np.array([[1, 0, 0],
+                           [0, 1, 0],
+                           [0, 0, 1]])
+    R, _ = Rotation.align_vectors(a, b, weights=[np.inf, 1])
+    assert_allclose(R.as_matrix(), m_expected, atol=atol)
+    R, _ = Rotation.align_vectors(a[0], b[0])
+    assert_allclose(R.as_matrix(), m_expected, atol=atol)
+    assert_allclose(R.apply(b[0]), a[0], atol=atol)
+
+
+def test_align_vectors_primary_only():
+    atol = 1e-12
+    mats_a = Rotation.random(100, random_state=0).as_matrix()
+    mats_b = Rotation.random(100, random_state=1).as_matrix()
+    for mat_a, mat_b in zip(mats_a, mats_b):
+        # Get random 3-element unit vectors
+        a = mat_a[0]
+        b = mat_b[0]
+
+        # Compare to align_vectors with primary only
+        R, rssd = Rotation.align_vectors(a, b)
+        assert_allclose(R.apply(b), a, atol=atol)
+        assert np.isclose(rssd, 0, atol=atol)
 
 
 def test_slerp():


### PR DESCRIPTION
#### Reference issue
Closes https://github.com/scipy/scipy/issues/17462
Closes https://github.com/scipy/scipy/issues/16880

#### What does this implement/fix?
This implements [the "align-constrain" algorithm](https://digitalcommons.usu.edu/cgi/viewcontent.cgi?article=4112&context=smallsat) for defining a rotation. The user passes in primary and secondary vectors in reference frames A and B. The algorithm calculates a rotation from B to A that exactly aligns the primary vectors, and then rotates about that axis to most closely align the constrained secondary vectors.

This algorithm is equivalent to `align_vectors()` with sets of two vectors, an infinite weight on the first pair of vectors, and a finite nonzero weight on the second pair of vectors. There is a test included here to verify that internal consistency.

#### Additional information
~~I would appreciate some feedback on how to handle the case where primary and secondary vectors are parallel. Currently I have it defined such that if the secondary vector is parallel to the primary to within an angular tolerance `atol`, the rotation is unconstrained and so the vector [1, 0, 0] is arbitrarily chosen as the secondary (followed by [0, 1, 0] if that is also parallel). Another option would be to error out if the vectors are parallel. A third option would be to error out if the user passes in `atol = None` and choose the secondary axis otherwise.~~

Update: The functionality is modified so that in the instance of parallel pairs, only the primary vectors are aligned via a rotation that has no change in angle about the primary axis.