### PR TITLE
CI: fix gh17539 failures of the alpine linux run

### DIFF
--- a/ci/cirrus_general_ci.yml
+++ b/ci/cirrus_general_ci.yml
@@ -14,6 +14,11 @@ modified_clone: &MODIFIED_CLONE
       # it's a PR so clone the main branch then merge the changes from the PR
       git clone --recursive https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
       git fetch origin pull/$CIRRUS_PR/head:pull/$CIRRUS_PR
+    
+      # CIRRUS_BASE_BRANCH will probably be `main` for the majority of the time
+      # However, if you do a PR against a maintenance branch we will want to
+      # merge the PR into the maintenance branch, not main
+      git checkout $CIRRUS_BASE_BRANCH
 
       # alpine git package needs default user.name and user.email to be set before a merge
       git -c user.email="you@example.com" merge --no-commit pull/$CIRRUS_PR

--- a/ci/cirrus_general_ci.yml
+++ b/ci/cirrus_general_ci.yml
@@ -14,6 +14,11 @@ modified_clone: &MODIFIED_CLONE
       # it's a PR so clone the main branch then merge the changes from the PR
       git clone --recursive https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
       git fetch origin pull/$CIRRUS_PR/head:pull/$CIRRUS_PR
+
+      # alpine needs default user.name and user.email to be set before a merge
+      git config --global user.email "you@example.com"
+      git config --global user.name "Your Name"
+
       git merge --no-commit pull/$CIRRUS_PR
     fi
 

--- a/ci/cirrus_general_ci.yml
+++ b/ci/cirrus_general_ci.yml
@@ -15,11 +15,8 @@ modified_clone: &MODIFIED_CLONE
       git clone --recursive https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
       git fetch origin pull/$CIRRUS_PR/head:pull/$CIRRUS_PR
 
-      # alpine needs default user.name and user.email to be set before a merge
-      git config --global user.email "you@example.com"
-      git config --global user.name "Your Name"
-
-      git merge --no-commit pull/$CIRRUS_PR
+      # alpine git package needs default user.name and user.email to be set before a merge
+      git -c user.email="you@example.com" merge --no-commit pull/$CIRRUS_PR
     fi
 
 


### PR DESCRIPTION
@WarrenWeckesser should fix #17539, the occasional fails on the Alpine Linux job. That job fails because a `git merge` (of the PR into main) needs to have an `user.email` and `user.name`. I thought we wouldn't need it because we're doing a merge without the commit. Anyway, this PR sets a default user name and email. We should be ok unless we start using CI to make auto commits.