### PR TITLE
BUG: special: Fix handling of subnormal input for lambertw.

### DIFF
--- a/scipy/special/_lambertw.pxd
+++ b/scipy/special/_lambertw.pxd
@@ -79,7 +79,7 @@ cdef inline double complex lambertw_scalar(double complex z, long k, double tol)
             ew = zexp(-w)
             wewz = w - z*ew
             wn = w - wewz/(w + 1 - (w + 2)*wewz/(2*w + 2))
-            if zabs(wn - w) < tol*zabs(wn):
+            if zabs(wn - w) <= tol*zabs(wn):
                 return wn
             else:
                 w = wn
@@ -89,7 +89,7 @@ cdef inline double complex lambertw_scalar(double complex z, long k, double tol)
             wew = w*ew
             wewz = wew - z
             wn = w - wewz/(wew + ew - (w + 2)*wewz/(2*w + 2))
-            if zabs(wn - w) < tol*zabs(wn):
+            if zabs(wn - w) <= tol*zabs(wn):
                 return wn
             else:
                 w = wn

--- a/scipy/special/tests/test_lambertw.py
+++ b/scipy/special/tests/test_lambertw.py
@@ -6,6 +6,7 @@
 # [1] mpmath source code, Subversion revision 992
 #     http://code.google.com/p/mpmath/source/browse/trunk/mpmath/tests/test_functions2.py?spec=svn994&r=992
 
+import pytest
 import numpy as np
 from numpy.testing import assert_, assert_equal, assert_array_almost_equal
 from scipy.special import lambertw
@@ -96,3 +97,13 @@ def test_lambertw_ufunc_loop_selection():
     assert_equal(lambertw(0, [0], 0).dtype, dt)
     assert_equal(lambertw(0, 0, [0]).dtype, dt)
     assert_equal(lambertw([0], [0], [0]).dtype, dt)
+
+
+@pytest.mark.parametrize('z', [1e-316, -2e-320j, -5e-318+1e-320j])
+def test_lambertw_subnormal_k0(z):
+    # Verify that subnormal inputs are handled correctly on
+    # the branch k=0 (regression test for gh-16291).
+    w = lambertw(z)
+    # For values this small, we can be sure that numerically,
+    # lambertw(z) is z.
+    assert w == z


### PR DESCRIPTION
The test for convergence in Halley's method did not consider the possibility that both terms in the test could be 0.  That can happen when the input z is subnormal and k=0.

Closes gh-16291.
