### PR TITLE
BUG Fix: Update lobpcg.py to turn history arrays into lists for backward compatibility

### DIFF
--- a/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
@@ -963,6 +963,12 @@ def lobpcg(
         print(f"Final residual norm(s):\n{residualNorms}")
 
     if retLambdaHistory:
+        lambdaHistory = np.vsplit(lambdaHistory, np.shape(lambdaHistory)[0])
+    if retResidualNormsHistory:
+        residualNormsHistory = np.vsplit(residualNormsHistory,
+                                         np.shape(residualNormsHistory)[0])
+
+    if retLambdaHistory:
         if retResidualNormsHistory:
             return _lambda, blockVectorX, lambdaHistory, residualNormsHistory
         else:

--- a/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
@@ -964,9 +964,11 @@ def lobpcg(
 
     if retLambdaHistory:
         lambdaHistory = np.vsplit(lambdaHistory, np.shape(lambdaHistory)[0])
+        lambdaHistory = [np.squeeze(i) for i in lambdaHistory]
     if retResidualNormsHistory:
         residualNormsHistory = np.vsplit(residualNormsHistory,
                                          np.shape(residualNormsHistory)[0])
+        residualNormsHistory = [np.squeeze(i) for i in residualNormsHistory]
 
     if retLambdaHistory:
         if retResidualNormsHistory:

--- a/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
@@ -413,6 +413,10 @@ def test_maxit():
                                 retResidualNormsHistory=True)
     assert_allclose(np.shape(l_h)[0], 20+3)
     assert_allclose(np.shape(r_h)[0], 20+3)
+    assert isinstance(l_h, list)
+    assert isinstance(r_h, list)
+    assert_allclose(np.shape(l_h), np.shape(np.asarray(l_h))
+    assert_allclose(np.shape(r_h), np.shape(np.asarray(r_h))
 
 
 @pytest.mark.slow

--- a/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
@@ -408,15 +408,19 @@ def test_maxit():
         assert_allclose(np.shape(l_h)[0], maxiter+3)
         assert_allclose(np.shape(r_h)[0], maxiter+3)
     with pytest.warns(UserWarning, match="Exited at iteration"):
-        _, _, l_h, r_h = lobpcg(A, X, tol=1e-8,
+        l, _, l_h, r_h = lobpcg(A, X, tol=1e-8,
                                 retLambdaHistory=True,
                                 retResidualNormsHistory=True)
     assert_allclose(np.shape(l_h)[0], 20+3)
     assert_allclose(np.shape(r_h)[0], 20+3)
+    # Check that eigenvalue output is the last one in history
+    assert_allclose(l, l_h[-1])
+    # Make sure that both history outputs are lists
     assert isinstance(l_h, list)
     assert isinstance(r_h, list)
-    assert_allclose(np.shape(l_h), np.shape(np.asarray(l_h))
-    assert_allclose(np.shape(r_h), np.shape(np.asarray(r_h))
+    # Make sure that both history lists are arrays-like
+    assert_allclose(np.shape(l_h), np.shape(np.asarray(l_h)))
+    assert_allclose(np.shape(r_h), np.shape(np.asarray(r_h)))
 
 
 @pytest.mark.slow


### PR DESCRIPTION
turn history arrays into lists for backward compatibility

#### Reference issue
https://github.com/scipy/scipy/pull/16320#pullrequestreview-1205310098 as suggested by @rgommers 

#### What does this implement/fix?
https://github.com/scipy/scipy/pull/16320 introduced backward incompatibility to outputting history as 2D arrays rather than lists of arrays. 