### PR TITLE
DOC: optimize.curve_fit: add note about `pcov` condition number

### DIFF
--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -660,7 +660,7 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
         'lm' method returns a matrix filled with ``np.inf``, on the other hand
         'trf'  and 'dogbox' methods use Moore-Penrose pseudoinverse to compute
         the covariance matrix. Covariance matrices with large condition numbers
-        (e.g. computed with`numpy.linalg.cond`) may indicate that results are
+        (e.g. computed with `numpy.linalg.cond`) may indicate that results are
         unreliable.
     infodict : dict (returned only if `full_output` is True)
         a dictionary of optional outputs with the keys:
@@ -771,6 +771,34 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
     >>> plt.ylabel('y')
     >>> plt.legend()
     >>> plt.show()
+
+    For reliable results, the model `func` should not be overparametrized;
+    redundant parameters can cause unreliable covariance matrices and, in some
+    cases, poorer quality fits. As a quick check of whether the model may be
+    overparameterized, calculate the condition number of the covariance matrix:
+
+    >>> np.linalg.cond(pcov)
+    34.571092161547405
+
+    The value is small, so it does not raise much concern. If, however, we were
+    to add a fourth parameter ``d`` to `func` with the same effect as ``a``:
+
+    >>> def func(x, a, b, c, d):
+    ...     return a * d * np.exp(-b * x) + c  # a and d are redundant
+    >>> popt, pcov = curve_fit(func, xdata, ydata)
+    >>> np.linalg.cond(pcov)
+    1.13250718925596e+32
+
+    Such a large value is cause for concern. The diagonal elements of the
+    covariance matrix, which is related to uncertainty of the fit, gives more
+    information:
+
+    >>> np.diag(pcov)
+    array([1.48814742e+29, 3.78596560e-02, 5.39253738e-03, 2.76417220e+28])
+
+    Note that the first and last terms are much larger than the other elements,
+    suggesting that the optimal values of these parameters are ambiguous and
+    that only one of these parameters is needed in the model.
 
     """
     if p0 is None:

--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -659,7 +659,9 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
         If the Jacobian matrix at the solution doesn't have a full rank, then
         'lm' method returns a matrix filled with ``np.inf``, on the other hand
         'trf'  and 'dogbox' methods use Moore-Penrose pseudoinverse to compute
-        the covariance matrix.
+        the covariance matrix. Covariance matrices with large condition numbers
+        (e.g. computed with`numpy.linalg.cond`) may indicate that results are
+        unreliable.
     infodict : dict (returned only if `full_output` is True)
         a dictionary of optional outputs with the keys:
 


### PR DESCRIPTION
#### Reference issue
Closes gh-12715

#### What does this implement/fix?
gh-12715 reported confusion that 1) results of `curve_fit` depended on the scale of the data in an unexpected way and that 2) the covariance matrix sometimes had negative entries on the diagonal. The latter was addressed in gh-17247, and the former is explained in https://github.com/scipy/scipy/issues/12715#issuecomment-674231266, but the user wanted some way of detecting the problem in the future.

I don't think `curve_fit` should take any extra steps for this, but the user can do some simple things. For instance, a check of the covariance matrix condition number would be enough to see that something is awry: in the example, it ranges between 1e22 and infinity (depending on the scale of the data).

This PR proposes to close the issue with a note at the end of the `pcov` documentation.

#### Additional information
Suggestions for improvement are welcome. I wasn't feeling inspired with this one. Should this go somewhere else (e.g. Notes)? Do we want to suggest what the user should check about their data or `f`? Do we need to suggest what "large" is?

https://github.com/scipy/scipy/issues/12715#issuecomment-1338982011 suggests that `curve_fit` could estimate the condition number efficiently, and perhaps we could use that to issue a warning, but then there's always the question about the threshold. This PR is for a doc-only fix; I'll close it if someone else wants to submit a PR for the other route.