### PR TITLE
DEV: bump flake8 version used in CI job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -145,7 +145,7 @@ stages:
         architecture: 'x64'
     - script: >-
         python -m pip install
-        flake8==3.9.2
+        "flake8<6"
       displayName: 'Install tools'
       failOnStderr: false
     - script: |

--- a/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
@@ -266,7 +266,7 @@ def test_failure_to_run_iterations():
     Q = rnd.standard_normal((X.shape[0], 4))
     with pytest.warns(UserWarning, match="Failed at iteration"):
         eigenvalues, _ = lobpcg(A, Q, maxiter=40, tol=1e-12)
-    assert(np.max(eigenvalues) > 0)
+    assert np.max(eigenvalues) > 0
 
 
 def test_failure_to_run_iterations_nonsymmetric():


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
follow up to https://github.com/scipy/scipy/issues/17394#issuecomment-1328335872
#### What does this implement/fix?
<!--Please explain your changes.-->
As part of making `dev.py lint` consistent with the CI all E275 lint issues were fixed. As the CI uses an old version of flake8 a pr can have E275 issues and pass the lint CI job reintroducing these issue. It therefor seems sensible to bump the flake8 version used.
#### Additional information
<!--Any additional information you think is important.-->
