### PR TITLE
MemoizeJac can be imported from scipy.optimize.

### DIFF
--- a/scipy/optimize/__init__.py
+++ b/scipy/optimize/__init__.py
@@ -318,6 +318,14 @@ Benchmark problems
    rosen_hess - The Hessian matrix of the Rosenbrock function.
    rosen_hess_prod - Product of the Rosenbrock Hessian with a vector.
 
+Other
+-----
+
+.. autosummary::
+   :toctree: generated/
+
+   MemoizeJac - Decorator that caches function returning `(fun, grad)`.
+
 Legacy functions
 ================
 

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -21,7 +21,7 @@ __all__ = ['fmin', 'fmin_powell', 'fmin_bfgs', 'fmin_ncg', 'fmin_cg',
            'fminbound', 'brent', 'golden', 'bracket', 'rosen', 'rosen_der',
            'rosen_hess', 'rosen_hess_prod', 'brute', 'approx_fprime',
            'line_search', 'check_grad', 'OptimizeResult', 'show_options',
-           'OptimizeWarning']
+           'OptimizeWarning', 'MemoizeJac']
 
 __docformat__ = "restructuredtext en"
 

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -55,8 +55,27 @@ _status_message = {'success': 'Optimization terminated successfully.',
 
 
 class MemoizeJac:
-    """ Decorator that caches the return values of a function returning `(fun, grad)`
-        each time it is called. """
+    """Decorator that caches the return values of a function which returns both
+    the function's and its gradient's results each time it is called with the
+    same arguments.
+
+    Parameters
+    ----------
+    fun : function
+        Array function of the form ``f(x)`` returning ``(f(x), df(x)/dx)``.
+
+    Examples
+    --------
+
+    >>> import numpy as np
+    >>> from scipy.optimize import MemoizeJac
+    >>> @MemoizeJac
+    ... def f(x):
+    ...     return 2*x**2, 4*x
+    >>> f(np.array([1., 2., 3.]))
+    array([ 2.,  8., 18.])
+
+    """
 
     def __init__(self, fun):
         self.fun = fun

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -74,6 +74,8 @@ class MemoizeJac:
     ...     return 2*x**2, 4*x
     >>> f(np.array([1., 2., 3.]))
     array([ 2.,  8., 18.])
+    >>> f.jac
+    array([ 4.,  8., 12.])
 
     """
 


### PR DESCRIPTION
Fixes #17572

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

This import used to work:

```
from scipy.optimize.optimize import MemoizeJac
```

Now a deprecation error is given:

```
DeprecationWarning: Please use `MemoizeJac` from the `scipy.optimize` namespace, the `scipy.optimize.optimize` namespace is deprecated.
  from scipy.optimize.optimize import MemoizeJac
```

But when you try:

```
from scipy.optimize import MemoizeJac
```

you get an import error.

This PR causes `from scipy.optimize import MemoizeJac` to work.

#### Additional information
<!--Any additional information you think is important.-->
I haven't tested the import locally because I haven't built scipy (admittedly I think I haven't built scipy in about a decade now). I'll have to figure out how to do so, if that is necessary.
