### PR TITLE
DOC fix trivial typo in description of loggamma in _add_newdocs.py

### DIFF
--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -13433,7 +13433,7 @@ add_newdoc("loggamma",
     Parameters
     ----------
     z : array_like
-        Values in the complex plain at which to compute ``loggamma``
+        Values in the complex plane at which to compute ``loggamma``
     out : ndarray, optional
         Output array for computed values of ``loggamma``
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
This fixes a trivial typo in the documentation of the 
 [scipy.special.loggamma](https://docs.scipy.org/doc/scipy/reference/generated/scipy.special.loggamma.html#scipy.special.loggamma) function. Changes "complex plain" to "complex plane".

#### Additional information
<!--Any additional information you think is important.-->
