### PR TITLE
DEP: raise on >1-dim inputs for optimize.minimize

### DIFF
--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -515,11 +515,7 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
     x0 = np.atleast_1d(np.asarray(x0))
 
     if x0.ndim != 1:
-        message = ('Use of `minimize` with `x0.ndim != 1` is deprecated. '
-                   'Currently, singleton dimensions will be removed from '
-                   '`x0`, but an error will be raised in SciPy 1.11.0.')
-        warn(message, DeprecationWarning, stacklevel=2)
-        x0 = np.atleast_1d(np.squeeze(x0))
+        raise ValueError("'X0' must only have one dimension.")
 
     if x0.dtype.kind in np.typecodes["AllInteger"]:
         x0 = np.asarray(x0, dtype=float)

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -515,7 +515,7 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
     x0 = np.atleast_1d(np.asarray(x0))
 
     if x0.ndim != 1:
-        raise ValueError("'X0' must only have one dimension.")
+        raise ValueError("'x0' must only have one dimension.")
 
     if x0.dtype.kind in np.typecodes["AllInteger"]:
         x0 = np.asarray(x0, dtype=float)

--- a/scipy/optimize/tests/test_cobyla.py
+++ b/scipy/optimize/tests/test_cobyla.py
@@ -79,13 +79,11 @@ class TestCobyla:
         cons = ({'type': 'ineq', 'fun': c1},
                 {'type': 'ineq', 'fun': c2},
                 {'type': 'ineq', 'fun': c3})
-        w0 = np.zeros((10, 1))
-        message = 'Use of `minimize` with `x0.ndim != 1` is deprecated.'
-        with pytest.warns(DeprecationWarning, match=message):
-            sol = minimize(f, w0, method='cobyla', constraints=cons,
-                           options={'catol': 1e-6})
-            assert_(sol.maxcv > 1e-6)
-            assert_(not sol.success)
+        w0 = np.zeros((10,))
+        sol = minimize(f, w0, method='cobyla', constraints=cons,
+                       options={'catol': 1e-6})
+        assert_(sol.maxcv > 1e-6)
+        assert_(not sol.success)
 
 
 def test_vector_constraints():

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -1483,6 +1483,11 @@ class TestOptimizeSimple(CheckOptimize):
             if np.array_equal(self.trace[i - 1], self.trace[i]):
                 raise RuntimeError(
                     "Duplicate evaluations made by {}".format(method))
+    
+    def test_ndim_error(self):
+        msg = "'X0' must only have one dimension."
+        with assert_raises(ValueError, match=msg):
+            optimize.minimize(lambda x: x, np.ones((2, 1)))
 
 
 @pytest.mark.parametrize(

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -1485,7 +1485,7 @@ class TestOptimizeSimple(CheckOptimize):
                     "Duplicate evaluations made by {}".format(method))
     
     def test_ndim_error(self):
-        msg = "'X0' must only have one dimension."
+        msg = "'x0' must only have one dimension."
         with assert_raises(ValueError, match=msg):
             optimize.minimize(lambda x: x, np.ones((2, 1)))
 

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -1483,7 +1483,7 @@ class TestOptimizeSimple(CheckOptimize):
             if np.array_equal(self.trace[i - 1], self.trace[i]):
                 raise RuntimeError(
                     "Duplicate evaluations made by {}".format(method))
-    
+
     def test_ndim_error(self):
         msg = "'x0' must only have one dimension."
         with assert_raises(ValueError, match=msg):

--- a/scipy/optimize/tests/test_tnc.py
+++ b/scipy/optimize/tests/test_tnc.py
@@ -128,13 +128,11 @@ class TestTnc:
         assert_equal(len(iterx), res.nit)
 
     def test_minimize_tnc1b(self):
-        x0, bnds = matrix([-2, 1]), ([-np.inf, None],[-1.5, None])
+        x0, bnds = np.array([-2, 1]), ([-np.inf, None],[-1.5, None])
         xopt = [1, 1]
-        message = 'Use of `minimize` with `x0.ndim != 1` is deprecated.'
-        with pytest.warns(DeprecationWarning, match=message):
-            x = optimize.minimize(self.f1, x0, method='TNC',
-                                  bounds=bnds, options=self.opts).x
-            assert_allclose(self.f1(x), self.f1(xopt), atol=1e-4)
+        x = optimize.minimize(self.f1, x0, method='TNC',
+                              bounds=bnds, options=self.opts).x
+        assert_allclose(self.f1(x), self.f1(xopt), atol=1e-4)
 
     def test_minimize_tnc1c(self):
         x0, bnds = [-2, 1], ([-np.inf, None],[-1.5, None])

--- a/scipy/optimize/tests/test_tnc.py
+++ b/scipy/optimize/tests/test_tnc.py
@@ -128,7 +128,7 @@ class TestTnc:
         assert_equal(len(iterx), res.nit)
 
     def test_minimize_tnc1b(self):
-        x0, bnds = np.array([-2, 1]), ([-np.inf, None],[-1.5, None])
+        x0, bnds = np.array([-2, 1]), ([-np.inf, None], [-1.5, None])
         xopt = [1, 1]
         x = optimize.minimize(self.f1, x0, method='TNC',
                               bounds=bnds, options=self.opts).x


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
closes #15808
#### What does this implement/fix?
<!--Please explain your changes.-->
Raises `ValueError` when `x0` has more than one dimension as per the deprecation. Adds test to check error is raised and updates two old tests to follow new behaviour.
#### Additional information
<!--Any additional information you think is important.-->
