### PR TITLE
MAINT: stats.pearsonr: raise error for complex input

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -4413,7 +4413,8 @@ def pearsonr(x, y, *, alternative='two-sided'):
     x = np.asarray(x)
     y = np.asarray(y)
 
-    if True in np.iscomplex(x) or True in np.iscomplex(y):
+    if (np.issubdtype(x.dtype, np.complexfloating) 
+            or np.issubdtype(y.dtype, np.complexfloating)):
         raise ValueError('This function does not support complex data')
 
     # If an input is constant, the correlation coefficient is not defined.

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -4413,6 +4413,9 @@ def pearsonr(x, y, *, alternative='two-sided'):
     x = np.asarray(x)
     y = np.asarray(y)
 
+    if True in np.iscomplex(x) or True in np.iscomplex(y):
+        raise ValueError('This function does not support complex data')
+
     # If an input is constant, the correlation coefficient is not defined.
     if (x == x[0]).all() or (y == y[0]).all():
         msg = ("An input array is constant; the correlation coefficient "

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -4413,7 +4413,7 @@ def pearsonr(x, y, *, alternative='two-sided'):
     x = np.asarray(x)
     y = np.asarray(y)
 
-    if (np.issubdtype(x.dtype, np.complexfloating) 
+    if (np.issubdtype(x.dtype, np.complexfloating)
             or np.issubdtype(y.dtype, np.complexfloating)):
         raise ValueError('This function does not support complex data')
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -480,7 +480,9 @@ class TestCorrPearsonr:
     def test_complex_data(self):
         x = [-1j, -2j, -3.0j]
         y = [-1j, -2j, -3.0j]
-        assert_raises(ValueError, stats.pearsonr, x, y)
+        message = 'This function does not support complex data'
+        with pytest.raises(ValueError, match=message):
+            stats.pearsonr(x, y)
 
 
 class TestFisherExact:

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -477,6 +477,11 @@ class TestCorrPearsonr:
         y = [2]
         assert_raises(ValueError, stats.pearsonr, x, y)
 
+    def test_complex_data(self):
+        x = [-1j, -2j, -3.0j]
+        y = [-1j, -2j, -3.0j]
+        assert_raises(ValueError, stats.pearsonr, x, y)
+
 
 class TestFisherExact:
     """Some tests to show that fisher_exact() works correctly.


### PR DESCRIPTION
In pearsonr rasie a ValueError for complex data.
Unit test included to show the intended error.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes gh-17518

#### What does this implement/fix?
Implement a conditional to check input arrays for complex data.
If the conditional is taken raise ValueError

#### Additional information
<!--Any additional information you think is important.-->
