### PR TITLE
DOC: optimize.line_search: note that `pk` must be a descent direction

### DIFF
--- a/scipy/optimize/_linesearch.py
+++ b/scipy/optimize/_linesearch.py
@@ -178,6 +178,8 @@ line_search = line_search_wolfe1
 # Pure-Python Wolfe line and scalar searches
 #------------------------------------------------------------------------------
 
+# Note: `line_search_wolfe2` is the public `scipy.optimize.line_search`
+
 def line_search_wolfe2(f, myfprime, xk, pk, gfk=None, old_fval=None,
                        old_old_fval=None, args=(), c1=1e-4, c2=0.9, amax=None,
                        extra_condition=None, maxiter=10):
@@ -192,7 +194,8 @@ def line_search_wolfe2(f, myfprime, xk, pk, gfk=None, old_fval=None,
     xk : ndarray
         Starting point.
     pk : ndarray
-        Search direction.
+        Search direction. The search direction must be a descent direction
+        for the algorithm to converge.
     gfk : ndarray, optional
         Gradient value for x=xk (xk being the current parameter
         estimate). Will be recomputed if omitted.
@@ -245,6 +248,11 @@ def line_search_wolfe2(f, myfprime, xk, pk, gfk=None, old_fval=None,
     Uses the line search algorithm to enforce strong Wolfe
     conditions. See Wright and Nocedal, 'Numerical Optimization',
     1999, pp. 59-61.
+
+    The search direction `pk` must be a descent direction (e.g.
+    ``-myfprime(xk)``) to find a step length that satisfies the strong Wolfe
+    conditions. If the search direction is not a descent direction (e.g.
+    ``myfprime(xk)``), then `alpha`, `new_fval`, and `new_slope` will be None.
 
     Examples
     --------
@@ -517,9 +525,9 @@ def _quadmin(a, fa, fpa, b, fb):
 def _zoom(a_lo, a_hi, phi_lo, phi_hi, derphi_lo,
           phi, derphi, phi0, derphi0, c1, c2, extra_condition):
     """Zoom stage of approximate linesearch satisfying strong Wolfe conditions.
-    
+
     Part of the optimization algorithm in `scalar_search_wolfe2`.
-    
+
     Notes
     -----
     Implements Algorithm 3.6 (zoom) in Wright and Nocedal,


### PR DESCRIPTION
#### Reference issue
Closes gh-4257

#### What does this implement/fix?
This addressed the remaining issues in gh-4257

3. "Tracking down the `line_search` docstring is not completely straightforward." 

It was not much harder than tracking down other functions, and the easy way would be to click the "Source" button in the rendered documentation. It goes straight to the right place. For those like me who would guess that `_linesearch.py` is the right file but don't find `line_search` there, I've added the comment that `scipy.optimize.line_search` _is_ `line_search_wolfe2`.

4. Maybe the sign of the search direction is confusing to some users (descent direction vs. gradient).

I added an explicit note about the search direction needing to be a direction of descent, and gave as examples the gradient vs the negative of the gradient.