### PR TITLE
DOC: Add Legacy directive

### DIFF
--- a/doc/source/_static/scipy.css
+++ b/doc/source/_static/scipy.css
@@ -169,6 +169,7 @@ html[data-theme=dark] .sd-card .sd-card-footer {
 .sd-dropdown .sd-card-header {
   padding: 0px 0px 0px 0px;
   text-align: left;
+}
 
 /* Legacy admonition */
 

--- a/doc/source/_static/scipy.css
+++ b/doc/source/_static/scipy.css
@@ -79,7 +79,7 @@ Nat Methods 8, 441 (2011). https://doi.org/10.1038/nmeth.1618
   margin-right: auto;
 }
 
-  .sd-card .sd-card-header {
+.sd-card .sd-card-header {
   border: none;
   background-color:white;
   color: #150458 !important;
@@ -169,4 +169,18 @@ html[data-theme=dark] .sd-card .sd-card-footer {
 .sd-dropdown .sd-card-header {
   padding: 0px 0px 0px 0px;
   text-align: left;
+
+/* Legacy admonition */
+
+div.admonition-legacy {
+  border-color: var(--pst-color-warning);
+}
+
+.admonition-legacy.admonition > .admonition-title:before {
+  color: var(--pst-color-warning);
+  content: var(--pst-icon-admonition-attention);
+}
+
+.admonition-legacy.admonition > .admonition-title:after {
+  background-color: var(--pst-color-warning);
 }

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -440,7 +440,9 @@ class LegacyDirective(Directive):
             self.content[0] = text+" "+self.content[0]
         except IndexError:
             # Content is empty; use the default text
-            source, lineno = self.state_machine.get_source_and_line(self.lineno)
+            source, lineno = self.state_machine.get_source_and_line(
+                self.lineno
+            )
             self.content.append(
                 text,
                 source=source,
@@ -459,6 +461,7 @@ class LegacyDirective(Directive):
         self.state.nested_parse(self.content, self.content_offset,
                                 admonition_node)
         return [admonition_node]
+
 
 def setup(app):
     app.add_directive("legacy", LegacyDirective)

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -433,7 +433,12 @@ class LegacyDirective(Directive):
     node_class = nodes.admonition
 
     def run(self):
-        text = ("This submodule is now considered legacy and will no longer "
+        try:
+            obj = self.arguments[0]
+        except IndexError:
+            # Argument is empty; use default text
+            obj = "submodule"
+        text = (f"This {obj} is now considered legacy and will no longer "
                 "receive updates.")
 
         try:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -4,7 +4,12 @@ from os.path import relpath, dirname
 import re
 import sys
 import warnings
+<<<<<<< HEAD
 from datetime import date
+=======
+from docutils import nodes
+from docutils.parsers.rst import Directive
+>>>>>>> 27a0ea8e0 (DOC: Add legacy directive for documentation)
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -416,3 +421,44 @@ def linkcode_resolve(domain, info):
 SphinxDocString._str_examples = _rng_html_rewrite(
     SphinxDocString._str_examples
 )
+class LegacyDirective(Directive):
+    """
+    Adapted from docutils/parsers/rst/directives/admonitions.py
+
+    Uses a default text if the directive does not have contents. If it does,
+    the default text is concatenated to the contents.
+
+    """
+    has_content = True
+    node_class = nodes.admonition
+
+    def run(self):
+        text = ("This submodule is now considered legacy and will no longer "
+                "receive updates.")
+
+        try:
+            self.content[0] = text+" "+self.content[0]
+        except IndexError:
+            # Content is empty; use the default text
+            source, lineno = self.state_machine.get_source_and_line(self.lineno)
+            self.content.append(
+                text,
+                source=source,
+                offset=lineno
+            )
+        text = '\n'.join(self.content)
+        # Create the admonition node, to be populated by `nested_parse`.
+        admonition_node = self.node_class(rawsource=text)
+        # Set custom title
+        title_text = "Legacy"
+        textnodes, _ = self.state.inline_text(title_text, self.lineno)
+        title = nodes.title(title_text, '', *textnodes)
+        # Set up admonition node
+        admonition_node += title
+        # Parse the directive contents.
+        self.state.nested_parse(self.content, self.content_offset,
+                                admonition_node)
+        return [admonition_node]
+
+def setup(app):
+    app.add_directive("legacy", LegacyDirective)

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -418,6 +418,8 @@ def linkcode_resolve(domain, info):
 SphinxDocString._str_examples = _rng_html_rewrite(
     SphinxDocString._str_examples
 )
+
+
 class LegacyDirective(Directive):
     """
     Adapted from docutils/parsers/rst/directives/admonitions.py
@@ -436,8 +438,9 @@ class LegacyDirective(Directive):
         except IndexError:
             # Argument is empty; use default text
             obj = "submodule"
-        text = (f"This {obj} is now considered legacy and will no longer "
-                "receive updates.")
+        text = (f"This {obj} is considered legacy and will no longer receive "
+                "updates. This could also mean it will be removed in future "
+                "SciPy versions.")
 
         try:
             self.content[0] = text+" "+self.content[0]

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -4,12 +4,9 @@ from os.path import relpath, dirname
 import re
 import sys
 import warnings
-<<<<<<< HEAD
 from datetime import date
-=======
 from docutils import nodes
 from docutils.parsers.rst import Directive
->>>>>>> 27a0ea8e0 (DOC: Add legacy directive for documentation)
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -431,6 +428,7 @@ class LegacyDirective(Directive):
     """
     has_content = True
     node_class = nodes.admonition
+    optional_arguments = 1
 
     def run(self):
         try:
@@ -454,7 +452,7 @@ class LegacyDirective(Directive):
                 offset=lineno
             )
         text = '\n'.join(self.content)
-        # Create the admonition node, to be populated by `nested_parse`.
+        # Create the admonition node, to be populated by `nested_parse`
         admonition_node = self.node_class(rawsource=text)
         # Set custom title
         title_text = "Legacy"
@@ -462,7 +460,9 @@ class LegacyDirective(Directive):
         title = nodes.title(title_text, '', *textnodes)
         # Set up admonition node
         admonition_node += title
-        # Parse the directive contents.
+        # Select custom class for CSS styling
+        admonition_node['classes'] = ['admonition-legacy']
+        # Parse the directive contents
         self.state.nested_parse(self.content, self.content_offset,
                                 admonition_node)
         return [admonition_node]

--- a/doc/source/dev/contributor/rendering_documentation.rst
+++ b/doc/source/dev/contributor/rendering_documentation.rst
@@ -286,6 +286,7 @@ the use of a seed in their program. The consequence is that users cannot
 reproduce the results of the example exactly, so examples using random data
 should not refer to precise numerical values based on random data or rely on
 them to make their point.
+
 Legacy directive
 ~~~~~~~~~~~~~~~~
 
@@ -311,6 +312,15 @@ will create the following output:
 .. legacy::
 
    New code should use :mod:`scipy.fft`.
+
+Finally, if you want to mention a function, method (or any custom object)
+instead of a *submodule*, you can use an optional argument::
+
+    .. legacy:: function
+
+This will create the following output:
+
+.. legacy:: function
 
 
 .. _GitHub: https://github.com/

--- a/doc/source/dev/contributor/rendering_documentation.rst
+++ b/doc/source/dev/contributor/rendering_documentation.rst
@@ -300,8 +300,8 @@ following output:
 .. legacy::
 
 
-If you need to include a custom message, such as a new API to replace the old
-one, this message will be appended to the default message::
+We strongly recommend that you also add a custom message, such as a new API to
+replace the old one. This message will be appended to the default message::
 
    .. legacy::
 

--- a/doc/source/dev/contributor/rendering_documentation.rst
+++ b/doc/source/dev/contributor/rendering_documentation.rst
@@ -286,6 +286,32 @@ the use of a seed in their program. The consequence is that users cannot
 reproduce the results of the example exactly, so examples using random data
 should not refer to precise numerical values based on random data or rely on
 them to make their point.
+Legacy directive
+~~~~~~~~~~~~~~~~
+
+If a function, module or API is in *legacy* mode, meaning that it is kept around
+for backwards compatibility reasons, but is not recommended to use in new code,
+you can use the ``.. legacy::`` directive.
+
+By default, if used with no arguments, the legacy directive will generate the
+following output:
+
+.. legacy::
+
+
+If you need to include a custom message, such as a new API to replace the old
+one, this message will be appended to the default message::
+
+   .. legacy::
+
+      New code should use :mod:`scipy.fft`.
+
+will create the following output:
+
+.. legacy::
+
+   New code should use :mod:`scipy.fft`.
+
 
 .. _GitHub: https://github.com/
 .. _CircleCI: https://circleci.com/vcs-authorize/

--- a/doc/source/dev/contributor/rendering_documentation.rst
+++ b/doc/source/dev/contributor/rendering_documentation.rst
@@ -322,6 +322,7 @@ This will create the following output:
 
 .. legacy:: function
 
+---
 
 .. _GitHub: https://github.com/
 .. _CircleCI: https://circleci.com/vcs-authorize/

--- a/scipy/fftpack/__init__.py
+++ b/scipy/fftpack/__init__.py
@@ -3,10 +3,9 @@
 Legacy discrete Fourier transforms (:mod:`scipy.fftpack`)
 =========================================================
 
-.. warning::
+.. legacy::
 
-   This submodule is now considered legacy, new code should use
-   :mod:`scipy.fft`.
+   New code should use :mod:`scipy.fft`.
 
 Fast Fourier Transforms (FFTs)
 ==============================

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -385,7 +385,7 @@ class interp1d(_Interpolator1D):
     """
     Interpolate a 1-D function.
 
-    .. legacy:: function
+    .. legacy:: class
 
     `x` and `y` are arrays of values used to approximate some function f:
     ``y = f(x)``. This class returns a function whose call method uses

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -383,9 +383,9 @@ def _do_extrapolate(fill_value):
 
 class interp1d(_Interpolator1D):
     """
-    .. legacy:: function
-
     Interpolate a 1-D function.
+
+    .. legacy:: function
 
     `x` and `y` are arrays of values used to approximate some function f:
     ``y = f(x)``. This class returns a function whose call method uses

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -383,6 +383,8 @@ def _do_extrapolate(fill_value):
 
 class interp1d(_Interpolator1D):
     """
+    .. legacy:: function
+
     Interpolate a 1-D function.
 
     `x` and `y` are arrays of values used to approximate some function f:

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -52,7 +52,6 @@ from sphinx.directives.other import SeeAlso, Only
 directives.register_directive('seealso', SeeAlso)
 directives.register_directive('only', Only)
 
-
 BASE_MODULE = "scipy"
 
 PUBLIC_SUBMODULES = [
@@ -341,7 +340,7 @@ def validate_rst_syntax(text, name, dots=True):
         return False, "ERROR: %s: no documentation" % (name,)
 
     ok_unknown_items = set([
-        'mod', 'currentmodule', 'autosummary', 'data',
+        'mod', 'currentmodule', 'autosummary', 'data', 'legacy',
         'obj', 'versionadded', 'versionchanged', 'module', 'class', 'meth',
         'ref', 'func', 'toctree', 'moduleauthor', 'deprecated',
         'sectionauthor', 'codeauthor', 'eq', 'doi', 'DOI', 'arXiv', 'arxiv'


### PR DESCRIPTION
Implements a legacy directive to be used in the documentation. 

This has been discussed in the community meetings. See also [this discussion on the mailing list](https://mail.python.org/archives/list/scipy-dev@python.org/thread/Z33JO27EX6BX7LVBI6CW6MX64VQZIJ66/#6GLVRHX5XBTZNL62LFN4YPGACY5BDPLA).

#### What does this implement/fix?
Creates a custom Sphinx `Admonition` to be used as a note in functions, modules or pages that are considered legacy. 

Example usage:

```
.. legacy::

   New code should use :mod:`scipy.fft`.
```

The result is

![Screenshot_20221214_085149](https://user-images.githubusercontent.com/3949932/207588390-8eed59f5-5673-4ca0-8a73-74c92880b3dd.png)

Both styling and implementation could be improved, feedback is welcome!

