### PR TITLE
DOC: update version switcher for 1.10

### DIFF
--- a/doc/source/_static/version_switcher.json
+++ b/doc/source/_static/version_switcher.json
@@ -5,7 +5,12 @@
         "url": "https://scipy.github.io/devdocs/"
     },
     {
-        "name": "1.9.3 (stable)",
+        "name": "1.10.0 (stable)",
+        "version":"1.10.0",
+        "url": "https://docs.scipy.org/doc/scipy-1.10.0/"
+    },
+    {
+        "name": "1.9.3",
         "version":"1.9.3",
         "url": "https://docs.scipy.org/doc/scipy-1.9.3/"
     },


### PR DESCRIPTION
Preparing for the release.

Will have to be ported to `main`. Or we just do it on `main` since it will only read it from `main`. As you prefer.