### PR TITLE
MAINT: change return type for `datasets.ascent` to `uint8`

### DIFF
--- a/scipy/datasets/_fetchers.py
+++ b/scipy/datasets/_fetchers.py
@@ -71,7 +71,7 @@ def ascent():
     fname = fetch_data("ascent.dat")
     # Now we just need to load it with our standard Python tools.
     with open(fname, 'rb') as f:
-        ascent = array(pickle.load(f))
+        ascent = array(pickle.load(f), dtype='uint8')
     return ascent
 
 


### PR DESCRIPTION
BUG: fix return type of SciPy.datasets.ascent

This commit sets the return type as uint8. See #15599

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
