### PR TITLE
DOC: add example to chi2_contingency

### DIFF
--- a/scipy/stats/contingency.py
+++ b/scipy/stats/contingency.py
@@ -233,13 +233,53 @@ def chi2_contingency(observed, correction=True, lambda_=None):
     .. [3] Cressie, N. and Read, T. R. C., "Multinomial Goodness-of-Fit
            Tests", J. Royal Stat. Soc. Series B, Vol. 46, No. 3 (1984),
            pp. 440-464.
+    .. [4] Berger, Jeffrey S. et al. "Aspirin for the Primary Prevention of
+           Cardiovascular Events in Women and Men: A Sex-Specific
+           Meta-analysis of Randomized Controlled Trials."
+           JAMA, 295(3):306–313, :doi:`10.1001/jama.295.3.306`, 2006.
 
     Examples
     --------
-    A two-way example (2 x 3):
+    In [4]_, the use of aspirin to prevent cardiovascular events in woman
+    and men was investigated. The study notably concluded:
+
+        For women and men, aspirin therapy reduced the risk of a composite of
+        cardiovascular events due to its effect on reducing the risk of
+        ischemic stroke in women [...]
+
+    The article list multiple studies for various cardiovascular events. Let's
+    focus on the ischemic stoke in women.
+
+    The following table summarizes two survey where women were given aspirin
+    or a placebo::
+
+                          Aspirin   Control/Placebo
+        Ischemic stroke     179           230
+        No stroke         21032         21018
+
+    Is there evidence that the aspirin reduces the risk of ischemic stroke?
+    We can formulate a null hypothesis :math:`H_0`:
+    "the placebo is as effective as the aspirin in reducing the risk of
+    ischemic stroke". Let's confront this hypothesis with a chi-square test.
 
     >>> import numpy as np
     >>> from scipy.stats import chi2_contingency
+    >>> table = np.array([[179, 230], [21032, 21018]])
+    >>> res = chi2_contingency(obs)
+    >>> res.statistic
+    6.084250213339923
+    >>> res.pvalue
+    0.013639223957976988
+
+    Using a confidence level of 5%, we would reject the null hypothesis in
+    favor of the alternative hypothesis: "aspirin has a positive effect in
+    reducing the risk of ischemic stoke in women".
+
+    Below are further examples showing how larger contingency tables can be
+    tested.
+
+    A two-way example (2 x 3):
+
     >>> obs = np.array([[10, 10, 20], [20, 20, 20]])
     >>> res = chi2_contingency(obs)
     >>> res.statistic

--- a/scipy/stats/contingency.py
+++ b/scipy/stats/contingency.py
@@ -236,7 +236,7 @@ def chi2_contingency(observed, correction=True, lambda_=None):
     .. [4] Berger, Jeffrey S. et al. "Aspirin for the Primary Prevention of
            Cardiovascular Events in Women and Men: A Sex-Specific
            Meta-analysis of Randomized Controlled Trials."
-           JAMA, 295(3):306–313, :doi:`10.1001/jama.295.3.306`, 2006.
+           JAMA, 295(3):306-313, :doi:`10.1001/jama.295.3.306`, 2006.
 
     Examples
     --------

--- a/scipy/stats/contingency.py
+++ b/scipy/stats/contingency.py
@@ -267,7 +267,7 @@ def chi2_contingency(observed, correction=True, lambda_=None):
     >>> import numpy as np
     >>> from scipy.stats import chi2_contingency
     >>> table = np.array([[179, 230], [21032, 21018]])
-    >>> res = chi2_contingency(obs)
+    >>> res = chi2_contingency(table)
     >>> res.statistic
     6.084250213339923
     >>> res.pvalue

--- a/scipy/stats/contingency.py
+++ b/scipy/stats/contingency.py
@@ -260,8 +260,8 @@ def chi2_contingency(observed, correction=True, lambda_=None):
 
     Is there evidence that the aspirin reduces the risk of ischemic stroke?
     We can formulate a null hypothesis :math:`H_0`:
-    "the placebo is equivalent to the aspirin and does not reduce the risk of
-    ischemic stroke". Let's assess the plausibility of this hypothesis with
+    "the effect of aspirin is equivalent to that of placebo".
+    Let's assess the plausibility of this hypothesis with
     a chi-square test.
 
     >>> import numpy as np
@@ -274,8 +274,12 @@ def chi2_contingency(observed, correction=True, lambda_=None):
     0.008655478161175739
 
     Using a significance level of 5%, we would reject the null hypothesis in
-    favor of the alternative hypothesis: "aspirin has a positive effect in
-    reducing the risk of ischemic stoke in women".
+    favor of the alternative hypothesis: "the effect of aspirin
+    is not equivalent to the effect of placebo".
+    Because `stats.contingency.chi2_contingency` performs a two-sided test
+    (i.e. the alternative hypothesis does not indicate the direction of the
+    effect), we can use `stats.contingency.odds_ratio` to support the
+    conclusion that aspirin *reduces* the risk of ischemic stroke.
 
     Below are further examples showing how larger contingency tables can be
     tested.

--- a/scipy/stats/contingency.py
+++ b/scipy/stats/contingency.py
@@ -423,6 +423,7 @@ def association(observed, method="cramer", correction=False, lambda_=None):
     >>> obs4x2 = np.array([[100, 150], [203, 322], [420, 700], [320, 210]])
 
     Pearson's contingency coefficient
+
     >>> association(obs4x2, method="pearson")
     0.18303298140595667
 

--- a/scipy/stats/contingency.py
+++ b/scipy/stats/contingency.py
@@ -243,24 +243,26 @@ def chi2_contingency(observed, correction=True, lambda_=None):
     In [4]_, the use of aspirin to prevent cardiovascular events in women
     and men was investigated. The study notably concluded:
 
-        For women and men, aspirin therapy reduced the risk of a composite of
+        ...aspirin therapy reduced the risk of a composite of
         cardiovascular events due to its effect on reducing the risk of
         ischemic stroke in women [...]
 
-    The article list multiple studies for various cardiovascular events. Let's
+    The article lists studies of various cardiovascular events. Let's
     focus on the ischemic stoke in women.
 
     The following table summarizes the results of the experiment in which
-    took aspirin or a placebo on a regular basis for several
-    years. Occurences of ischemic stroke were recorded::
+    participants took aspirin or a placebo on a regular basis for several
+    years. Cases of ischemic stroke were recorded::
 
                           Aspirin   Control/Placebo
         Ischemic stroke     176           230
         No stroke         21035         21018
 
     Is there evidence that the aspirin reduces the risk of ischemic stroke?
-    We can formulate a null hypothesis :math:`H_0`:
-    "the effect of aspirin is equivalent to that of placebo".
+    We begin by formulating a null hypothesis :math:`H_0`:
+
+        The effect of aspirin is equivalent to that of placebo.
+
     Let's assess the plausibility of this hypothesis with
     a chi-square test.
 
@@ -276,9 +278,9 @@ def chi2_contingency(observed, correction=True, lambda_=None):
     Using a significance level of 5%, we would reject the null hypothesis in
     favor of the alternative hypothesis: "the effect of aspirin
     is not equivalent to the effect of placebo".
-    Because `stats.contingency.chi2_contingency` performs a two-sided test
-    (i.e. the alternative hypothesis does not indicate the direction of the
-    effect), we can use `stats.contingency.odds_ratio` to support the
+    Because `scipy.stats.contingency.chi2_contingency` performs a two-sided
+    test, the alternative hypothesis does not indicate the direction of the
+    effect. We can use `stats.contingency.odds_ratio` to support the
     conclusion that aspirin *reduces* the risk of ischemic stroke.
 
     Below are further examples showing how larger contingency tables can be

--- a/scipy/stats/contingency.py
+++ b/scipy/stats/contingency.py
@@ -250,9 +250,9 @@ def chi2_contingency(observed, correction=True, lambda_=None):
     The article list multiple studies for various cardiovascular events. Let's
     focus on the ischemic stoke in women.
 
-    The following table summarizes the results of an experiment in which 
-    women were given aspirin or a placebo and occurences of ischemic stroke
-    were recorded::
+    The following table summarizes the results of the experiment in which
+    women were given aspirin or a placebo up to every day for a mean duration
+    of 6.4 years. Occurences of ischemic stroke were recorded::
 
                           Aspirin   Control/Placebo
         Ischemic stroke     179           230
@@ -260,7 +260,7 @@ def chi2_contingency(observed, correction=True, lambda_=None):
 
     Is there evidence that the aspirin reduces the risk of ischemic stroke?
     We can formulate a null hypothesis :math:`H_0`:
-    "the placebo is as effective as the aspirin in reducing the risk of
+    "the placebo is equivalent to the aspirin and does not reduce the risk of
     ischemic stroke". Let's assess the plausibility of this hypothesis with
     a chi-square test.
 

--- a/scipy/stats/contingency.py
+++ b/scipy/stats/contingency.py
@@ -251,12 +251,12 @@ def chi2_contingency(observed, correction=True, lambda_=None):
     focus on the ischemic stoke in women.
 
     The following table summarizes the results of the experiment in which
-    women were given aspirin or a placebo up to every day for a mean duration
-    of 6.4 years. Occurences of ischemic stroke were recorded::
+    took aspirin or a placebo on a regular basis for several
+    years. Occurences of ischemic stroke were recorded::
 
                           Aspirin   Control/Placebo
-        Ischemic stroke     179           230
-        No stroke         21032         21018
+        Ischemic stroke     176           230
+        No stroke         21035         21018
 
     Is there evidence that the aspirin reduces the risk of ischemic stroke?
     We can formulate a null hypothesis :math:`H_0`:
@@ -266,12 +266,12 @@ def chi2_contingency(observed, correction=True, lambda_=None):
 
     >>> import numpy as np
     >>> from scipy.stats import chi2_contingency
-    >>> table = np.array([[179, 230], [21032, 21018]])
+    >>> table = np.array([[176, 230], [21035, 21018]])
     >>> res = chi2_contingency(table)
     >>> res.statistic
-    6.084250213339923
+    6.892569132546561
     >>> res.pvalue
-    0.013639223957976988
+    0.008655478161175739
 
     Using a significance level of 5%, we would reject the null hypothesis in
     favor of the alternative hypothesis: "aspirin has a positive effect in

--- a/scipy/stats/contingency.py
+++ b/scipy/stats/contingency.py
@@ -240,7 +240,7 @@ def chi2_contingency(observed, correction=True, lambda_=None):
 
     Examples
     --------
-    In [4]_, the use of aspirin to prevent cardiovascular events in woman
+    In [4]_, the use of aspirin to prevent cardiovascular events in women
     and men was investigated. The study notably concluded:
 
         For women and men, aspirin therapy reduced the risk of a composite of
@@ -250,8 +250,9 @@ def chi2_contingency(observed, correction=True, lambda_=None):
     The article list multiple studies for various cardiovascular events. Let's
     focus on the ischemic stoke in women.
 
-    The following table summarizes two survey where women were given aspirin
-    or a placebo::
+    The following table summarizes the results of an experiment in which 
+    women were given aspirin or a placebo and occurences of ischemic stroke
+    were recorded::
 
                           Aspirin   Control/Placebo
         Ischemic stroke     179           230
@@ -260,7 +261,8 @@ def chi2_contingency(observed, correction=True, lambda_=None):
     Is there evidence that the aspirin reduces the risk of ischemic stroke?
     We can formulate a null hypothesis :math:`H_0`:
     "the placebo is as effective as the aspirin in reducing the risk of
-    ischemic stroke". Let's confront this hypothesis with a chi-square test.
+    ischemic stroke". Let's assess the plausibility of this hypothesis with
+    a chi-square test.
 
     >>> import numpy as np
     >>> from scipy.stats import chi2_contingency
@@ -271,7 +273,7 @@ def chi2_contingency(observed, correction=True, lambda_=None):
     >>> res.pvalue
     0.013639223957976988
 
-    Using a confidence level of 5%, we would reject the null hypothesis in
+    Using a significance level of 5%, we would reject the null hypothesis in
     favor of the alternative hypothesis: "aspirin has a positive effect in
     reducing the risk of ischemic stoke in women".
 


### PR DESCRIPTION
Current examples of `scipy.stats.chi2_contingency` are not very helpful.

I propose to add a real life example based on a well cited study (>500): https://jamanetwork.com/journals/jama/article-abstract/202217

```
Berger, Jeffrey S. et al. "Aspirin for the Primary Prevention of
Cardiovascular Events in Women and Men: A Sex-Specific
Meta-analysis of Randomized Controlled Trials."
JAMA, 295(3):306–313, :doi:`10.1001/jama.295.3.306`, 2006.
```