### PR TITLE
MAINT: Update ascent.dat file hash

### DIFF
--- a/scipy/datasets/_registry.py
+++ b/scipy/datasets/_registry.py
@@ -6,7 +6,7 @@
 # To generate the SHA256 hash, use the command
 # openssl sha256 <filename>
 registry = {
-    "ascent.dat": "e8a84939484463ab8051aedc5b40aa262ab33a91d6458a6cd13c6a1cad5a023d",
+    "ascent.dat": "03ce124c1afc880f87b55f6b061110e2e1e939679184f5614e38dacc6c1957e2",
     "ecg.dat": "f20ad3365fb9b7f845d0e5c48b6fe67081377ee466c3a220b7f69f35c8958baf",
     "face.dat": "9d8b0b4d081313e2b485748c770472e5a95ed1738146883d84c7030493e82886"
 }


### PR DESCRIPTION
#### Reference issue
xref https://github.com/scipy/dataset-ascent/pull/3
xref https://github.com/scipy/scipy/pull/17606

#### What does this implement/fix?
This change is required because the source file has been updated in https://github.com/scipy/dataset-ascent/pull/3
I'd expect the CI to fail until https://github.com/scipy/dataset-ascent/pull/3 is merged.


cc @tylerjereddy @rgommers