### PR TITLE
MAINT: optimize.milp: don't warn about `mip_rel_gap` option

### DIFF
--- a/scipy/optimize/_milp.py
+++ b/scipy/optimize/_milp.py
@@ -130,7 +130,8 @@ def _milp_iv(c, integrality, bounds, constraints, options):
 
     # options IV
     options = options or {}
-    supported_options = {'disp', 'presolve', 'time_limit', 'node_limit'}
+    supported_options = {'disp', 'presolve', 'time_limit', 'node_limit',
+                         'mip_rel_gap'}
     unsupported_options = set(options).difference(supported_options)
     if unsupported_options:
         message = (f"Unrecognized options detected: {unsupported_options}. "
@@ -236,6 +237,10 @@ def milp(c, *, integrality=None, bounds=None, constraints=None, options=None):
         time_limit : float, optional
             The maximum number of seconds allotted to solve the problem.
             Default is no time limit.
+        mip_rel_gap : float, optional
+            Termination criterion for MIP solver: solver will terminate when
+            the gap between the primal objective value and the dual objective
+            bound, scaled by the primal objective value, is <= mip_rel_gap.
 
     Returns
     -------
@@ -276,8 +281,8 @@ def milp(c, *, integrality=None, bounds=None, constraints=None, options=None):
             The MILP solver's final estimate of the lower bound on the optimal
             solution.
         mip_gap : float
-            The difference between the final objective function value and the
-            final dual bound.
+            The difference between the primal objective value and the dual
+            objective bound, scaled by the primal objective value.
 
     Notes
     -----

--- a/scipy/optimize/tests/test_milp.py
+++ b/scipy/optimize/tests/test_milp.py
@@ -338,3 +338,33 @@ def test_three_constraints_16878():
     assert res1.success and res2.success
     assert_allclose(res1.x, ref.x)
     assert_allclose(res2.x, ref.x)
+
+
+@pytest.mark.xslow
+def test_mip_rel_gap_passdown():
+    # Solve problem with decreasing mip_gap to make sure mip_rel_gap decreases
+    # Adapted from test_linprog::TestLinprogHiGHSMIP::test_mip_rel_gap_passdown
+    # MIP taken from test_mip_6 above
+    A_eq = np.array([[22, 13, 26, 33, 21, 3, 14, 26],
+                     [39, 16, 22, 28, 26, 30, 23, 24],
+                     [18, 14, 29, 27, 30, 38, 26, 26],
+                     [41, 26, 28, 36, 18, 38, 16, 26]])
+    b_eq = np.array([7872, 10466, 11322, 12058])
+    c = np.array([2, 10, 13, 17, 7, 5, 7, 3])
+
+    mip_rel_gaps = [0.25, 0.01, 0.001]
+    sol_mip_gaps = []
+    for mip_rel_gap in mip_rel_gaps:
+        res = milp(c=c, bounds=(0, np.inf), constraints=(A_eq, b_eq, b_eq),
+                   integrality=True, options={"mip_rel_gap": mip_rel_gap})
+        # assert that the solution actually has mip_gap lower than the
+        # required mip_rel_gap supplied
+        assert res.mip_gap <= mip_rel_gap
+        # check that `res.mip_gap` is as defined in the documentation
+        assert res.mip_gap == (res.fun - res.mip_dual_bound)/res.fun
+        sol_mip_gaps.append(res.mip_gap)
+
+    # make sure that the mip_rel_gap parameter is actually doing something
+    # check that differences between solution gaps are declining
+    # monotonically with the mip_rel_gap parameter.
+    assert np.all(np.diff(sol_mip_gaps) < 0)


### PR DESCRIPTION
#### Reference issue
gh-16897

#### What does this implement/fix?
`milp` raised a warning unnecessarily when `mip_rel_gap` was provided as an option. This eliminates the warning and tests that `mip_rel_gap` works as advertised.

#### Additional information
@mckib2 this was requested in https://github.com/scipy/scipy/pull/16897#issuecomment-1350992965 after testing RC1. Can you review this soon so it can be included in RC2?
