### PR TITLE
MAINT: optimize.minimize: enhance `callback` for remaining `minimize` methods and `fmin`s

### DIFF
--- a/scipy/optimize/_lbfgsb_py.py
+++ b/scipy/optimize/_lbfgsb_py.py
@@ -36,8 +36,9 @@ Functions
 import numpy as np
 from numpy import array, asarray, float64, zeros
 from . import _lbfgsb
-from ._optimize import (MemoizeJac, OptimizeResult,
-                       _check_unknown_options, _prepare_scalar_function)
+from ._optimize import (MemoizeJac, OptimizeResult, _call_callback_maybe_halt,
+                        _wrap_callback, _check_unknown_options,
+                        _prepare_scalar_function)
 from ._constraints import old_bound_to_new
 
 from scipy.sparse.linalg import LinearOperator
@@ -183,6 +184,7 @@ def fmin_l_bfgs_b(func, x0, fprime=None, args=(),
         jac = fprime
 
     # build options
+    callback = _wrap_callback(callback)
     opts = {'disp': disp,
             'iprint': iprint,
             'maxcor': m,
@@ -360,9 +362,10 @@ def _minimize_lbfgsb(fun, x0, args=(), jac=None, bounds=None,
         elif task_str.startswith(b'NEW_X'):
             # new iteration
             n_iterations += 1
-            if callback is not None:
-                callback(np.copy(x))
 
+            intermediate_result = OptimizeResult(x=x, fun=f)
+            if _call_callback_maybe_halt(callback, intermediate_result):
+                task[:] = 'STOP: CALLBACK REQUESTED HALT'
             if n_iterations >= maxiter:
                 task[:] = 'STOP: TOTAL NO. of ITERATIONS REACHED LIMIT'
             elif sf.nfev > maxfun:

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -42,7 +42,9 @@ MINIMIZE_METHODS = ['nelder-mead', 'powell', 'cg', 'bfgs', 'newton-cg',
                     'dogleg', 'trust-ncg', 'trust-exact', 'trust-krylov']
 
 # These methods support the new callback interface (passed an OptimizeResult)
-MINIMIZE_METHODS_NEW_CB = ['nelder-mead', 'trust-constr']
+MINIMIZE_METHODS_NEW_CB = ['nelder-mead', 'powell', 'cg', 'bfgs', 'newton-cg',
+                           'l-bfgs-b', 'trust-constr', 'dogleg', 'trust-ncg',
+                           'trust-exact', 'trust-krylov']
 
 MINIMIZE_SCALAR_METHODS = ['brent', 'bounded', 'golden']
 
@@ -196,7 +198,7 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
     callback : callable, optional
         A callable called after each iteration.
 
-        Methods nelder-mead and trust-constr support a callable with
+        All methods except TNC, SLSQP, and COBYLA support a callable with
         the signature:
 
             ``callback(OptimizeResult: intermediate_result)``
@@ -208,11 +210,15 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
         to be passed an `OptimizeResult`. These methods will also terminate if
         the callback raises `StopIteration`.
 
-        All methods except trust-constr support a signature like:
+        All methods except trust-constr (also) support a signature like:
 
             ``callback(xk)``
 
         where ``xk`` is the current parameter vector.
+
+        All methods except TNC, SLSQP, and COBYLA will terminate if the
+        callback raises `StopIteration`. Introspection is used to determine
+        which of the signatures above to invoke.
 
     Returns
     -------

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -134,7 +134,7 @@ def _dict_formatter(d, n=0, mplus=1, sorter=None):
 
 def _wrap_callback(callback, method=None):
     """Wrap a user-provided callback so that attributes can be attached."""
-    if callback is None or method not in {'nelder-mead', 'trust-constr', None}:
+    if callback is None or method in {'tnc', 'slsqp', 'cobyla'}:
         return callback  # don't wrap
 
     p1 = (inspect.Parameter('intermediate_result',
@@ -1355,6 +1355,7 @@ def fmin_bfgs(f, x0, fprime=None, args=(), gtol=1e-5, norm=Inf,
             'maxiter': maxiter,
             'return_all': retall}
 
+    callback = _wrap_callback(callback)
     res = _minimize_bfgs(f, x0, args, fprime, callback=callback, **opts)
 
     if full_output:
@@ -1458,9 +1459,10 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
 
         yk = gfkp1 - gfk
         gfk = gfkp1
-        if callback is not None:
-            callback(xk)
         k += 1
+        intermediate_result = OptimizeResult(x=xk, fun=old_fval)
+        if _call_callback_maybe_halt(callback, intermediate_result):
+            break
         gnorm = vecnorm(gfk, ord=norm)
         if (gnorm <= gtol):
             break
@@ -1683,6 +1685,7 @@ def fmin_cg(f, x0, fprime=None, args=(), gtol=1e-5, norm=Inf, epsilon=_epsilon,
             'maxiter': maxiter,
             'return_all': retall}
 
+    callback = _wrap_callback(callback)
     res = _minimize_cg(f, x0, args, fprime, callback=callback, **opts)
 
     if full_output:
@@ -1810,9 +1813,10 @@ def _minimize_cg(fun, x0, args=(), jac=None, callback=None,
 
         if retall:
             allvecs.append(xk)
-        if callback is not None:
-            callback(xk)
         k += 1
+        intermediate_result = OptimizeResult(x=xk, fun=old_fval)
+        if _call_callback_maybe_halt(callback, intermediate_result):
+            break
 
     fval = old_fval
     if warnflag == 2:
@@ -1939,6 +1943,7 @@ def fmin_ncg(f, x0, fprime, fhess_p=None, fhess=None, args=(), avextol=1e-5,
             'disp': disp,
             'return_all': retall}
 
+    callback = _wrap_callback(callback)
     res = _minimize_newtoncg(f, x0, args, fprime, fhess, fhess_p,
                              callback=callback, **opts)
 
@@ -2120,11 +2125,13 @@ def _minimize_newtoncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
 
         update = alphak * pk
         xk = xk + update        # upcast if necessary
-        if callback is not None:
-            callback(xk)
         if retall:
             allvecs.append(xk)
         k += 1
+        intermediate_result = OptimizeResult(x=xk, fun=old_fval)
+        if _call_callback_maybe_halt(callback, intermediate_result):
+            return terminate(5, "")
+
     else:
         if np.isnan(old_fval) or np.isnan(update).any():
             return terminate(3, _status_message['nan'])
@@ -3229,6 +3236,7 @@ def fmin_powell(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None,
             'direc': direc,
             'return_all': retall}
 
+    callback = _wrap_callback(callback)
     res = _minimize_powell(func, x0, args, callback=callback, **opts)
 
     if full_output:
@@ -3407,10 +3415,11 @@ def _minimize_powell(func, x0, args=(), callback=None, bounds=None,
                     delta = fx2 - fval
                     bigind = i
             iter += 1
-            if callback is not None:
-                callback(x)
             if retall:
                 allvecs.append(x)
+            intermediate_result = OptimizeResult(x=x, fun=fval)
+            if _call_callback_maybe_halt(callback, intermediate_result):
+                break
             bnd = ftol * (np.abs(fx) + np.abs(fval)) + 1e-20
             if 2.0 * (fx - fval) <= bnd:
                 break

--- a/scipy/optimize/_trustregion.py
+++ b/scipy/optimize/_trustregion.py
@@ -5,7 +5,8 @@ import warnings
 import numpy as np
 import scipy.linalg
 from ._optimize import (_check_unknown_options, _status_message,
-                       OptimizeResult, _prepare_scalar_function)
+                        OptimizeResult, _prepare_scalar_function,
+                        _call_callback_maybe_halt)
 from scipy.optimize._hessian_update_strategy import HessianUpdateStrategy
 from scipy.optimize._differentiable_functions import FD_METHODS
 __all__ = []
@@ -255,9 +256,11 @@ def _minimize_trust_region(fun, x0, args=(), jac=None, hess=None, hessp=None,
         # append the best guess, call back, increment the iteration count
         if return_all:
             allvecs.append(np.copy(x))
-        if callback is not None:
-            callback(np.copy(x))
         k += 1
+
+        intermediate_result = OptimizeResult(x=x, fun=m.fun)
+        if _call_callback_maybe_halt(callback, intermediate_result):
+            break
 
         # check if the gradient is small enough to stop
         if m.jac_mag < gtol:


### PR DESCRIPTION
#### Reference issue
Follow-up to gh-17486

#### What does this implement/fix?
Does for other `minimize` methods and `fmin` optimizers what gh-17486 did for `trust-constr` and Nelder-Mead.

#### Additional information
`fmin_` optimizers need to first wrap the callback method (it was already done by `minimize` for the minimize methods), and the `_minimize` functions need to use `_call_callback_maybe_halt` instead of just calling the callback.