### PR TITLE
ENH: signal: add synchronization method `nearest_advocate`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,6 +223,7 @@ scipy/optimize/_lsq/givens_elimination.c
 scipy/optimize/_trlib/_trlib.c
 scipy/optimize/tnc/moduleTNC.c
 scipy/optimize/tnc/_moduleTNC.c
+scipy/signal/_nearest_advocate_util.c
 scipy/signal/_peak_finding_utils.c
 scipy/signal/_spectral.c
 scipy/signal/_spectral.cpp

--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -195,7 +195,7 @@ Discrete-time linear systems
    dstep            -- Step response of a discrete-time LTI system.
    dfreqresp        -- Frequency response of a discrete-time LTI system.
    dbode            -- Bode magnitude and phase data (discrete-time LTI).
-   nearest_advocate -- Post-hoc synchronization of event-based time-series data.
+   nearest_advocate -- Post-hoc synchronization of event-based time-series.
 
 LTI representations
 ===================

--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -195,6 +195,7 @@ Discrete-time linear systems
    dstep            -- Step response of a discrete-time LTI system.
    dfreqresp        -- Frequency response of a discrete-time LTI system.
    dbode            -- Bode magnitude and phase data (discrete-time LTI).
+   nearest_advocate -- Post-hoc synchronization of event-based time-series data.
 
 LTI representations
 ===================
@@ -329,6 +330,7 @@ from ._savitzky_golay import savgol_coeffs, savgol_filter
 from ._spectral_py import *
 from ._wavelets import *
 from ._peak_finding import *
+from ._nearest_advocate import nearest_advocate
 from ._czt import *
 from .windows import get_window  # keep this one in signal namespace
 

--- a/scipy/signal/_nearest_advocate.py
+++ b/scipy/signal/_nearest_advocate.py
@@ -7,9 +7,9 @@ def nearest_advocate(arr_ref, arr_sig,
                      dist_max=0.0, regulate_paddings=True, dist_padding=0.0):
     """Post-hoc synchronization method for event-based time-series data.
 
-    Calculates the synchronicity of two arrays of timestamps for a search 
-    space between td_min and td_max with a precision of 1/sps. 
-    The synchronicity is given by the mean of all minimal distances between 
+    Calculates the synchronicity of two arrays of timestamps for a search
+    space between td_min and td_max with a precision of 1/sps.
+    The synchronicity is given by the mean of all minimal distances between
     each event in arr_sig and its nearest advocate in arr_ref.
 
     Parameters
@@ -17,35 +17,35 @@ def nearest_advocate(arr_ref, arr_sig,
     arr_ref : array_like
         Sorted reference array (1-D) with timestamps assumed to be correct.
     arr_sig : array_like
-        Sorted signal array (1-D) of timestamps, assumed to be shifted by an 
+        Sorted signal array (1-D) of timestamps, assumed to be shifted by an
         unknown constant time-delta.
     td_min : float
         Lower bound of the search space for the time-shift.
     td_max : float
         Upper bound of the search space for the time-shift.
     sps : int, optional
-        Number of investigated time-shifts per second, should be higher than 
+        Number of investigated time-shifts per second, should be higher than
         10 times the number of median gap of `arr_ref` (default 10).
     sparse_factor : int, optional
-        Factor for the sparseness of `arr_sig` for the calculation, higher is 
+        Factor for the sparseness of `arr_sig` for the calculation, higher is
         faster but may be less accurate (default 1).
     dist_max : float, optional
-        Maximal accepted distances between two advocate events. It should be 
+        Maximal accepted distances between two advocate events. It should be
         around 1/4 of the median gap of `arr_ref` (default).
     regulate_paddings : bool, optional
-        Regulate non-overlapping events in `arr_sig` with a maximum distance 
+        Regulate non-overlapping events in `arr_sig` with a maximum distance
         of dist_padding (default True).
     dist_padding : float, optional
-        Distance assigned to non-overlapping (padding) events. It should be 
-        around 1/4 of the median gap of `arr_ref` (default). Obsolete if 
+        Distance assigned to non-overlapping (padding) events. It should be
+        around 1/4 of the median gap of `arr_ref` (default). Obsolete if
         `regulate_paddings` is False
 
     Returns
     -------
     time_shifts : array_like
-        Two-columned 2-D array with evaluated time-shifts (between `td_min` 
-        and `td_max`) and the respective mean distances. The time-delta with 
-        the lowest mean distance is the estimation for the time-shift between 
+        Two-columned 2-D array with evaluated time-shifts (between `td_min`
+        and `td_max`) and the respective mean distances. The time-delta with
+        the lowest mean distance is the estimation for the time-shift between
         the two arrays.
 
     Notes
@@ -54,8 +54,8 @@ def nearest_advocate(arr_ref, arr_sig,
 
     References
     ----------
-    C. Schranz, S. Mayr, "Ein neuer Algorithmus zur Zeitsynchronisierung von 
-    Ereignis-basierten Zeitreihendaten als Alternative zur Kreuzkorrelation", 
+    C. Schranz, S. Mayr, "Ein neuer Algorithmus zur Zeitsynchronisierung von
+    Ereignis-basierten Zeitreihendaten als Alternative zur Kreuzkorrelation",
     Spinfortec (Chemnitz 2022). :doi:`10.5281/zenodo.7370958`
 
     Examples
@@ -65,16 +65,16 @@ def nearest_advocate(arr_ref, arr_sig,
     >>> from scipy.signal import nearest_advocate
     >>> N = 10_000
 
-    Create a reference array whose events differences are sampled from a 
-    normal distribution. The signal array is the reference but shifted by 
-    `np.pi` and addional gaussian noise. The event-timestamps of both arrays 
+    Create a reference array whose events differences are sampled from a
+    normal distribution. The signal array is the reference but shifted by
+    `np.pi` and addional gaussian noise. The event-timestamps of both arrays
     must be sorted.
 
     >>> arr_ref = np.sort(np.cumsum(np.random.normal(loc=1, scale=0.25, size=N)))
     >>> arr_sig = np.sort(arr_ref + np.pi + np.random.normal(loc=0, scale=0.1, size=N))
 
-    The function `nearest_advocate` returns a two-columned array with all 
-    investigated time-shifts and their mean distances, i.e., the measure of 
+    The function `nearest_advocate` returns a two-columned array with all
+    investigated time-shifts and their mean distances, i.e., the measure of
     the synchronicity between both array (lower is better).
 
     >>> time_shifts = nearest_advocate(arr_ref=arr_ref, arr_sig=arr_sig, td_min=-60, td_max=60, sps=20)

--- a/scipy/signal/_nearest_advocate.py
+++ b/scipy/signal/_nearest_advocate.py
@@ -1,0 +1,90 @@
+import numpy as np
+from ._nearest_advocate_util import _nearest_advocate
+
+def nearest_advocate(arr_ref, arr_sig,
+                     td_min, td_max, sps=10, sparse_factor=1,
+                     dist_max=0.0, regulate_paddings=True, dist_padding=0.0):
+    """Post-hoc synchronization method for event-based time-series data.
+    
+    Calculates the synchronicity of two arrays of timestamps for a search space between td_min and td_max with a precision of 1/sps. The synchronicity is given by the mean of all minimal distances between each event in arr_sig and its nearest advocate in arr_ref.
+
+    Parameters
+    ----------
+    arr_ref : array_like
+        Sorted reference array (1-D) with timestamps assumed to be correct.
+    arr_sig : array_like
+        Sorted signal array (1-D) of timestamps, assumed to be shifted by an unknown constant time-delta.    
+    td_min : float
+        Lower bound of the search space for the time-shift.
+    td_max : float 
+        Upper bound of the search space for the time-shift.
+    sps : int, optional
+        Number of investigated time-shifts per second, should be higher than 10 times the number of median gap of `arr_ref` (default 10).
+    sparse_factor : int, optional
+        Factor for the sparseness of `arr_sig` for the calculation, higher is faster but may be less accurate (default 1).
+    dist_max : float, optional
+        Maximal accepted distances between two advocate events. It should be around 1/4 of the median gap of `arr_ref` (default).
+    regulate_paddings : bool, optional
+        Regulate non-overlapping events in `arr_sig` with a maximum distance of dist_padding (default True).
+    dist_padding : float, optional
+        Distance assigned to non-overlapping (padding) events. It should be around 1/4 of the median gap of `arr_ref` (default). Obsolete if `regulate_paddings` is False
+
+    Returns
+    -------
+    time_shifts : array_like
+        Two-columned 2-D array with evaluated time-shifts (between `td_min` and `td_max`) and the respective mean distances. The time-delta with the lowest mean distance is the estimation for the time-shift between the two arrays.
+
+    Notes
+    -----
+    .. versionadded:: 1.9.4
+
+    References
+    ----------
+    C. Schranz, S. Mayr, "Ein neuer Algorithmus zur Zeitsynchronisierung von Ereignis-basierten Zeitreihendaten als Alternative zur Kreuzkorrelation", Spinfortec (Chemnitz 2022). :doi:`10.5281/zenodo.7370958`
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> np.random.seed(0)
+    >>> from scipy.signal import nearest_advocate
+    >>> N = 10_000 
+    
+    Create a reference array whose events differences are sampled from a normal distribution. The signal array is the reference but shifted by `np.pi` and addional gaussian noise. The event-timestamps of both arrays must be sorted.
+    
+    >>> arr_ref = np.sort(np.cumsum(np.random.normal(loc=1, scale=0.25, size=N))).astype(np.float32)
+    >>> arr_sig = np.sort(arr_ref + np.pi + np.random.normal(loc=0, scale=0.1, size=N)).astype(np.float32)
+
+    The function `nearest_advocate` returns a two-columned array with all investigated time-shifts and their mean distances, i.e., the measure of the synchronicity between both array (lower is better). 
+    
+    >>> time_shifts = nearest_advocate(arr_ref=arr_ref, arr_sig=arr_sig, td_min=-60, td_max=60, sps=20)
+    >>> time_shift, min_mean_dist = time_shifts[np.argmin(time_shifts[:,1])]
+    >>> print(time_shift, min_mean_dist)
+    3.15, 0.079508
+    
+    Plot the resulting table
+    
+    >>> import matplotlib.pyplot as plt
+    >>> plt.plot(time_shifts[:,0], time_shifts[:,1], color="steelblue", label="Mean distance")
+    >>> plt.vlines(x=time_shift, ymin=0.05, ymax=0.25, color="firebrick", label=f"Shift = {time_shift:.2f}s")
+    >>> plt.xlim(0, 8)
+    >>> plt.xlabel("Time shift (s)")
+    >>> plt.ylabel("Mean distance (s)")
+    >>> plt.legend(loc="lower right")
+    >>> plt.show()
+    """
+    assert isinstance(arr_ref, np.ndarray) and len(arr_ref.shape)==1
+    assert isinstance(arr_sig, np.ndarray) and len(arr_sig.shape)==1
+    assert isinstance(td_min, (int, float))
+    assert isinstance(td_max, (int, float))
+    assert isinstance(sps, int)
+    assert isinstance(sparse_factor, int)
+    assert isinstance(dist_max, float)
+    assert isinstance(regulate_paddings, bool)
+    assert isinstance(dist_padding, float)
+    
+    # call and return the cython function
+    return _nearest_advocate(arr_ref, arr_sig, 
+                             td_min=td_min, td_max=td_max, sps=sps, sparse_factor=sparse_factor, 
+                             dist_max=dist_max, regulate_paddings=regulate_paddings, 
+                             dist_padding=dist_padding)
+

--- a/scipy/signal/_nearest_advocate.py
+++ b/scipy/signal/_nearest_advocate.py
@@ -51,8 +51,8 @@ def nearest_advocate(arr_ref, arr_sig,
     
     Create a reference array whose events differences are sampled from a normal distribution. The signal array is the reference but shifted by `np.pi` and addional gaussian noise. The event-timestamps of both arrays must be sorted.
     
-    >>> arr_ref = np.sort(np.cumsum(np.random.normal(loc=1, scale=0.25, size=N))).astype(np.float32)
-    >>> arr_sig = np.sort(arr_ref + np.pi + np.random.normal(loc=0, scale=0.1, size=N)).astype(np.float32)
+    >>> arr_ref = np.sort(np.cumsum(np.random.normal(loc=1, scale=0.25, size=N)))
+    >>> arr_sig = np.sort(arr_ref + np.pi + np.random.normal(loc=0, scale=0.1, size=N))
 
     The function `nearest_advocate` returns a two-columned array with all investigated time-shifts and their mean distances, i.e., the measure of the synchronicity between both array (lower is better). 
     
@@ -83,7 +83,7 @@ def nearest_advocate(arr_ref, arr_sig,
     assert isinstance(dist_padding, float)
     
     # call and return the cython function
-    return _nearest_advocate(arr_ref, arr_sig, 
+    return _nearest_advocate(arr_ref.astype(np.float32), arr_sig.astype(np.float32), 
                              td_min=td_min, td_max=td_max, sps=sps, sparse_factor=sparse_factor, 
                              dist_max=dist_max, regulate_paddings=regulate_paddings, 
                              dist_padding=dist_padding)

--- a/scipy/signal/_nearest_advocate.py
+++ b/scipy/signal/_nearest_advocate.py
@@ -1,38 +1,52 @@
 import numpy as np
 from ._nearest_advocate_util import _nearest_advocate
 
+
 def nearest_advocate(arr_ref, arr_sig,
                      td_min, td_max, sps=10, sparse_factor=1,
                      dist_max=0.0, regulate_paddings=True, dist_padding=0.0):
     """Post-hoc synchronization method for event-based time-series data.
-    
-    Calculates the synchronicity of two arrays of timestamps for a search space between td_min and td_max with a precision of 1/sps. The synchronicity is given by the mean of all minimal distances between each event in arr_sig and its nearest advocate in arr_ref.
+
+    Calculates the synchronicity of two arrays of timestamps for a search 
+    space between td_min and td_max with a precision of 1/sps. 
+    The synchronicity is given by the mean of all minimal distances between 
+    each event in arr_sig and its nearest advocate in arr_ref.
 
     Parameters
     ----------
     arr_ref : array_like
         Sorted reference array (1-D) with timestamps assumed to be correct.
     arr_sig : array_like
-        Sorted signal array (1-D) of timestamps, assumed to be shifted by an unknown constant time-delta.    
+        Sorted signal array (1-D) of timestamps, assumed to be shifted by an 
+        unknown constant time-delta.
     td_min : float
         Lower bound of the search space for the time-shift.
-    td_max : float 
+    td_max : float
         Upper bound of the search space for the time-shift.
     sps : int, optional
-        Number of investigated time-shifts per second, should be higher than 10 times the number of median gap of `arr_ref` (default 10).
+        Number of investigated time-shifts per second, should be higher than 
+        10 times the number of median gap of `arr_ref` (default 10).
     sparse_factor : int, optional
-        Factor for the sparseness of `arr_sig` for the calculation, higher is faster but may be less accurate (default 1).
+        Factor for the sparseness of `arr_sig` for the calculation, higher is 
+        faster but may be less accurate (default 1).
     dist_max : float, optional
-        Maximal accepted distances between two advocate events. It should be around 1/4 of the median gap of `arr_ref` (default).
+        Maximal accepted distances between two advocate events. It should be 
+        around 1/4 of the median gap of `arr_ref` (default).
     regulate_paddings : bool, optional
-        Regulate non-overlapping events in `arr_sig` with a maximum distance of dist_padding (default True).
+        Regulate non-overlapping events in `arr_sig` with a maximum distance 
+        of dist_padding (default True).
     dist_padding : float, optional
-        Distance assigned to non-overlapping (padding) events. It should be around 1/4 of the median gap of `arr_ref` (default). Obsolete if `regulate_paddings` is False
+        Distance assigned to non-overlapping (padding) events. It should be 
+        around 1/4 of the median gap of `arr_ref` (default). Obsolete if 
+        `regulate_paddings` is False
 
     Returns
     -------
     time_shifts : array_like
-        Two-columned 2-D array with evaluated time-shifts (between `td_min` and `td_max`) and the respective mean distances. The time-delta with the lowest mean distance is the estimation for the time-shift between the two arrays.
+        Two-columned 2-D array with evaluated time-shifts (between `td_min` 
+        and `td_max`) and the respective mean distances. The time-delta with 
+        the lowest mean distance is the estimation for the time-shift between 
+        the two arrays.
 
     Notes
     -----
@@ -40,29 +54,36 @@ def nearest_advocate(arr_ref, arr_sig,
 
     References
     ----------
-    C. Schranz, S. Mayr, "Ein neuer Algorithmus zur Zeitsynchronisierung von Ereignis-basierten Zeitreihendaten als Alternative zur Kreuzkorrelation", Spinfortec (Chemnitz 2022). :doi:`10.5281/zenodo.7370958`
+    C. Schranz, S. Mayr, "Ein neuer Algorithmus zur Zeitsynchronisierung von 
+    Ereignis-basierten Zeitreihendaten als Alternative zur Kreuzkorrelation", 
+    Spinfortec (Chemnitz 2022). :doi:`10.5281/zenodo.7370958`
 
     Examples
     --------
     >>> import numpy as np
     >>> np.random.seed(0)
     >>> from scipy.signal import nearest_advocate
-    >>> N = 10_000 
-    
-    Create a reference array whose events differences are sampled from a normal distribution. The signal array is the reference but shifted by `np.pi` and addional gaussian noise. The event-timestamps of both arrays must be sorted.
-    
+    >>> N = 10_000
+
+    Create a reference array whose events differences are sampled from a 
+    normal distribution. The signal array is the reference but shifted by 
+    `np.pi` and addional gaussian noise. The event-timestamps of both arrays 
+    must be sorted.
+
     >>> arr_ref = np.sort(np.cumsum(np.random.normal(loc=1, scale=0.25, size=N)))
     >>> arr_sig = np.sort(arr_ref + np.pi + np.random.normal(loc=0, scale=0.1, size=N))
 
-    The function `nearest_advocate` returns a two-columned array with all investigated time-shifts and their mean distances, i.e., the measure of the synchronicity between both array (lower is better). 
-    
+    The function `nearest_advocate` returns a two-columned array with all 
+    investigated time-shifts and their mean distances, i.e., the measure of 
+    the synchronicity between both array (lower is better).
+
     >>> time_shifts = nearest_advocate(arr_ref=arr_ref, arr_sig=arr_sig, td_min=-60, td_max=60, sps=20)
     >>> time_shift, min_mean_dist = time_shifts[np.argmin(time_shifts[:,1])]
     >>> print(time_shift, min_mean_dist)
     3.15, 0.07883796
-    
+
     Plot the resulting table
-    
+
     >>> import matplotlib.pyplot as plt
     >>> plt.plot(time_shifts[:,0], time_shifts[:,1], color="steelblue", label="Mean distance")
     >>> plt.vlines(x=time_shift, ymin=0.05, ymax=0.25, color="firebrick", label=f"Shift = {time_shift:.2f}s")
@@ -81,9 +102,11 @@ def nearest_advocate(arr_ref, arr_sig,
     assert isinstance(dist_max, float)
     assert isinstance(regulate_paddings, bool)
     assert isinstance(dist_padding, float)
-    
+
     # call and return the cython function
-    return _nearest_advocate(arr_ref.astype(np.float32), arr_sig.astype(np.float32), 
-                             td_min=td_min, td_max=td_max, sps=sps, sparse_factor=sparse_factor, 
-                             dist_max=dist_max, regulate_paddings=regulate_paddings, 
-                             dist_padding=dist_padding)
+    return _nearest_advocate(arr_ref.astype(np.float32),
+                             arr_sig.astype(np.float32),
+                             td_min=td_min, td_max=td_max,
+                             sps=sps, sparse_factor=sparse_factor,
+                             regulate_paddings=regulate_paddings,
+                             dist_max=dist_max, dist_padding=dist_padding)

--- a/scipy/signal/_nearest_advocate.py
+++ b/scipy/signal/_nearest_advocate.py
@@ -70,32 +70,28 @@ def nearest_advocate(arr_ref, arr_sig,
     `np.pi` and addional gaussian noise. The event-timestamps of both arrays
     must be sorted.
 
-    >>> arr_ref = np.sort(np.cumsum(np.random.normal(loc=1, scale=0.25,
-    size=N)))
-    >>> arr_sig = np.sort(arr_ref + np.pi + np.random.normal(loc=0,
-    scale=0.1, size=N))
+    >>> arr_ref = np.cumsum(np.random.normal(loc=1, scale=0.25, size=N))
+    >>> arr_ref = np.sort(arr_ref)
+    >>> arr_sig = arr_ref + np.pi + np.random.normal(loc=0, scale=0.1, size=N)
+    >>> arr_sig = np.sort(arr_sig)
 
     The function `nearest_advocate` returns a two-columned array with all
     investigated time-shifts and their mean distances, i.e., the measure of
     the synchronicity between both array (lower is better).
 
-    >>> time_shifts = nearest_advocate(arr_ref=arr_ref, arr_sig=arr_sig,
-    td_min=-60, td_max=60, sps=20)
-    >>> time_shift, min_mean_dist = time_shifts[np.argmin(time_shifts[:,1])]
+    >>> shifts = nearest_advocate(arr_ref, arr_sig, -60, 60, sps=20)
+    >>> time_shift, min_mean_dist = shifts[np.argmin(shifts[:,1])]
     >>> print(time_shift, min_mean_dist)
     3.15, 0.07883796
 
     Plot the resulting table
 
     >>> import matplotlib.pyplot as plt
-    >>> plt.plot(time_shifts[:,0], time_shifts[:,1], color="steelblue",
-    label="Mean distance")
-    >>> plt.vlines(x=time_shift, ymin=0.05, ymax=0.25, color="firebrick",
-    label=f"Shift = {time_shift:.2f}s")
+    >>> plt.plot(time_shifts[:,0], time_shifts[:,1], color="steelblue")
+    >>> plt.vlines(x=time_shift, ymin=0.05, ymax=0.25, color="firebrick")
     >>> plt.xlim(0, 8)
     >>> plt.xlabel("Time shift (s)")
     >>> plt.ylabel("Mean distance (s)")
-    >>> plt.legend(loc="lower right")
     >>> plt.show()
     """
     assert isinstance(arr_ref, np.ndarray) and len(arr_ref.shape) == 1

--- a/scipy/signal/_nearest_advocate.py
+++ b/scipy/signal/_nearest_advocate.py
@@ -72,8 +72,8 @@ def nearest_advocate(arr_ref, arr_sig,
     >>> plt.legend(loc="lower right")
     >>> plt.show()
     """
-    assert isinstance(arr_ref, np.ndarray) and len(arr_ref.shape)==1
-    assert isinstance(arr_sig, np.ndarray) and len(arr_sig.shape)==1
+    assert isinstance(arr_ref, np.ndarray) and len(arr_ref.shape) == 1
+    assert isinstance(arr_sig, np.ndarray) and len(arr_sig.shape) == 1
     assert isinstance(td_min, (int, float))
     assert isinstance(td_max, (int, float))
     assert isinstance(sps, int)
@@ -87,4 +87,3 @@ def nearest_advocate(arr_ref, arr_sig,
                              td_min=td_min, td_max=td_max, sps=sps, sparse_factor=sparse_factor, 
                              dist_max=dist_max, regulate_paddings=regulate_paddings, 
                              dist_padding=dist_padding)
-

--- a/scipy/signal/_nearest_advocate.py
+++ b/scipy/signal/_nearest_advocate.py
@@ -70,16 +70,16 @@ def nearest_advocate(arr_ref, arr_sig,
     `np.pi` and addional gaussian noise. The event-timestamps of both arrays
     must be sorted.
 
-    >>> arr_ref = np.sort(np.cumsum(np.random.normal(loc=1, scale=0.25, 
+    >>> arr_ref = np.sort(np.cumsum(np.random.normal(loc=1, scale=0.25,
     size=N)))
-    >>> arr_sig = np.sort(arr_ref + np.pi + np.random.normal(loc=0, 
+    >>> arr_sig = np.sort(arr_ref + np.pi + np.random.normal(loc=0,
     scale=0.1, size=N))
 
     The function `nearest_advocate` returns a two-columned array with all
     investigated time-shifts and their mean distances, i.e., the measure of
     the synchronicity between both array (lower is better).
 
-    >>> time_shifts = nearest_advocate(arr_ref=arr_ref, arr_sig=arr_sig, 
+    >>> time_shifts = nearest_advocate(arr_ref=arr_ref, arr_sig=arr_sig,
     td_min=-60, td_max=60, sps=20)
     >>> time_shift, min_mean_dist = time_shifts[np.argmin(time_shifts[:,1])]
     >>> print(time_shift, min_mean_dist)
@@ -88,9 +88,9 @@ def nearest_advocate(arr_ref, arr_sig,
     Plot the resulting table
 
     >>> import matplotlib.pyplot as plt
-    >>> plt.plot(time_shifts[:,0], time_shifts[:,1], color="steelblue", 
+    >>> plt.plot(time_shifts[:,0], time_shifts[:,1], color="steelblue",
     label="Mean distance")
-    >>> plt.vlines(x=time_shift, ymin=0.05, ymax=0.25, color="firebrick", 
+    >>> plt.vlines(x=time_shift, ymin=0.05, ymax=0.25, color="firebrick",
     label=f"Shift = {time_shift:.2f}s")
     >>> plt.xlim(0, 8)
     >>> plt.xlabel("Time shift (s)")

--- a/scipy/signal/_nearest_advocate.py
+++ b/scipy/signal/_nearest_advocate.py
@@ -59,7 +59,7 @@ def nearest_advocate(arr_ref, arr_sig,
     >>> time_shifts = nearest_advocate(arr_ref=arr_ref, arr_sig=arr_sig, td_min=-60, td_max=60, sps=20)
     >>> time_shift, min_mean_dist = time_shifts[np.argmin(time_shifts[:,1])]
     >>> print(time_shift, min_mean_dist)
-    3.15, 0.079508
+    3.15, 0.07883796
     
     Plot the resulting table
     

--- a/scipy/signal/_nearest_advocate.py
+++ b/scipy/signal/_nearest_advocate.py
@@ -70,14 +70,17 @@ def nearest_advocate(arr_ref, arr_sig,
     `np.pi` and addional gaussian noise. The event-timestamps of both arrays
     must be sorted.
 
-    >>> arr_ref = np.sort(np.cumsum(np.random.normal(loc=1, scale=0.25, size=N)))
-    >>> arr_sig = np.sort(arr_ref + np.pi + np.random.normal(loc=0, scale=0.1, size=N))
+    >>> arr_ref = np.sort(np.cumsum(np.random.normal(loc=1, scale=0.25, 
+    size=N)))
+    >>> arr_sig = np.sort(arr_ref + np.pi + np.random.normal(loc=0, 
+    scale=0.1, size=N))
 
     The function `nearest_advocate` returns a two-columned array with all
     investigated time-shifts and their mean distances, i.e., the measure of
     the synchronicity between both array (lower is better).
 
-    >>> time_shifts = nearest_advocate(arr_ref=arr_ref, arr_sig=arr_sig, td_min=-60, td_max=60, sps=20)
+    >>> time_shifts = nearest_advocate(arr_ref=arr_ref, arr_sig=arr_sig, 
+    td_min=-60, td_max=60, sps=20)
     >>> time_shift, min_mean_dist = time_shifts[np.argmin(time_shifts[:,1])]
     >>> print(time_shift, min_mean_dist)
     3.15, 0.07883796
@@ -85,8 +88,10 @@ def nearest_advocate(arr_ref, arr_sig,
     Plot the resulting table
 
     >>> import matplotlib.pyplot as plt
-    >>> plt.plot(time_shifts[:,0], time_shifts[:,1], color="steelblue", label="Mean distance")
-    >>> plt.vlines(x=time_shift, ymin=0.05, ymax=0.25, color="firebrick", label=f"Shift = {time_shift:.2f}s")
+    >>> plt.plot(time_shifts[:,0], time_shifts[:,1], color="steelblue", 
+    label="Mean distance")
+    >>> plt.vlines(x=time_shift, ymin=0.05, ymax=0.25, color="firebrick", 
+    label=f"Shift = {time_shift:.2f}s")
     >>> plt.xlim(0, 8)
     >>> plt.xlabel("Time shift (s)")
     >>> plt.ylabel("Mean distance (s)")

--- a/scipy/signal/_nearest_advocate_util.pyx
+++ b/scipy/signal/_nearest_advocate_util.pyx
@@ -2,46 +2,61 @@ import numpy as np
 cimport numpy as np
 
 
-def _nearest_advocate(arr_ref: np.ndarray, arr_sig: np.ndarray, 
-                       td_min: float, td_max: float, sps: float=10, sparse_factor: int=1,
-                       dist_max: float=0.0, regulate_paddings: bool=True, dist_padding: float=0.0):
+def _nearest_advocate(arr_ref: np.ndarray, arr_sig: np.ndarray,
+                       td_min: float, td_max: float,
+                      sps: float=10, sparse_factor: int=1,
+                       dist_max: float=0.0,
+                      regulate_paddings: bool=True, dist_padding: float=0.0):
     """Post-hoc synchronization method for event-based time-series data.
 
-    Calculates the synchronicity of two arrays of timestamps for a search space between td_min and td_max with a precision of 1/sps. The synchronicity is given by the mean of all minimal distances between each event in arr_sig and its nearest advocate in arr_ref.
+    Calculates the synchronicity of two arrays of timestamps for a search 
+    space between td_min and td_max with a precision of 1/sps. 
+    The synchronicity is given by the mean of all minimal distances between 
+    each event in arr_sig and its nearest advocate in arr_ref.
 
     Parameters
     ----------
     arr_ref : array_like
         Sorted reference array (1-D) with timestamps assumed to be correct.
     arr_sig : array_like
-        Sorted signal array (1-D) of timestamps, assumed to be shifted by an unknown constant time-delta.    
+        Sorted signal array (1-D) of timestamps, assumed to be shifted by an 
+        unknown constant time-delta.
     td_min : float
         Lower bound of the search space for the time-shift.
-    td_max : float 
+    td_max : float
         Upper bound of the search space for the time-shift.
     sps : int, optional
-        Number of investigated time-shifts per second, should be higher than 10 times the number of median gap of `arr_ref` (default 10).
+        Number of investigated time-shifts per second, should be higher than 
+        10 times the number of median gap of `arr_ref` (default 10).
     sparse_factor : int, optional
-        Factor for the sparseness of `arr_sig` for the calculation, higher is faster but may be less accurate (default 1).
+        Factor for the sparseness of `arr_sig` for the calculation, higher is 
+        faster but may be less accurate (default 1).
     dist_max : float, optional
-        Maximal accepted distances between two advocate events. It should be around 1/4 of the median gap of `arr_ref` (default).
+        Maximal accepted distances between two advocate events. It should be 
+        around 1/4 of the median gap of `arr_ref` (default).
     regulate_paddings : bool, optional
-        Regulate non-overlapping events in `arr_sig` with a maximum distance of dist_padding (default True).
+        Regulate non-overlapping events in `arr_sig` with a maximum distance 
+        of dist_padding (default True).
     dist_padding : float, optional
-        Distance assigned to non-overlapping (padding) events. It should be around 1/4 of the median gap of `arr_ref` (default). Obsolete if `regulate_paddings` is False
+        Distance assigned to non-overlapping (padding) events. It should be 
+        around 1/4 of the median gap of `arr_ref` (default). Obsolete if 
+        `regulate_paddings` is False
 
     Returns
     -------
     time_shifts : array_like
-        Two-columned 2-D array with evaluated time-shifts (between `td_min` and `td_max`) and the respective mean distances. The time-delta with the lowest mean distance is the estimation for the time-shift between the two arrays.
+        Two-columned 2-D array with evaluated time-shifts (between `td_min` 
+        and `td_max`) and the respective mean distances. The time-delta with 
+        the lowest mean distance is the estimation for the time-shift between 
+        the two arrays.
     """
     # convert the event-based arrays to cython 1-D ndarray
     cdef np.ndarray[np.float32_t, ndim=1, cast=True] arr_ref_c = arr_ref.astype(np.float32)
     cdef np.ndarray[np.float32_t, ndim=1, cast=True] arr_sig_c = arr_sig.astype(np.float32)
-    
+
     # create a kx2 array to store the time-shifts with their respective synchronicity
-    cdef np.ndarray[np.float32_t, ndim=2] np_nearest_c = np.empty((int((td_max-td_min)*sps), 2), 
-                                                                  dtype=np.float32)
+    cdef np.ndarray[np.float32_t, ndim=2] np_nearest_c = np.empty(
+        (int((td_max-td_min)*sps), 2), dtype=np.float32)
     # fill the first column with the time-shifts to test
     idx = 0
     td = td_min
@@ -49,11 +64,12 @@ def _nearest_advocate(arr_ref: np.ndarray, arr_sig: np.ndarray,
         np_nearest_c[idx, 0] = td
         td += 1/sps
         idx += 1
-    
+
     # call and return the cython function
-    return _nearest_advocate_c(arr_ref_c, arr_sig_c, np_nearest_c=np_nearest_c, 
-                               td_min=td_min, td_max=td_max, sps=sps, sparse_factor=sparse_factor, 
-                               dist_max=dist_max, regulate_paddings=regulate_paddings, 
+    return _nearest_advocate_c(arr_ref_c, arr_sig_c, np_nearest_c=np_nearest_c,
+                               td_min=td_min, td_max=td_max,
+                               sps=sps, sparse_factor=sparse_factor, 
+                               dist_max=dist_max, regulate_paddings=regulate_paddings,
                                dist_padding=dist_padding)
 
 cdef np.ndarray[np.float32_t, ndim=2] _nearest_advocate_c(
@@ -66,7 +82,7 @@ cdef np.ndarray[np.float32_t, ndim=2] _nearest_advocate_c(
         dist_max = np.median(np.diff(arr_ref_c))/4
     if dist_padding == 0.0:
         dist_padding = np.median(np.diff(arr_ref_c))/4
-        
+
     # Random subsample
     if sparse_factor > 1:
         arr_sig_c = arr_sig_c[sparse_factor//2::sparse_factor]
@@ -87,13 +103,13 @@ cdef np.ndarray[np.float32_t, ndim=2] _nearest_advocate_c(
 
 cdef np.float32_t _nearest_advocate_single_c(np.ndarray[np.float32_t, ndim=1] arr_ref_c, 
                                              np.ndarray[np.float32_t, ndim=1] arr_sig_c, 
-                                             np.float32_t dist_max=0.0, bint regulate_paddings=True, 
+                                             np.float32_t dist_max=0.0, 
+                                             bint regulate_paddings=True,
                                              np.float32_t dist_padding=0.0):
-
     # store the lengths of the arrays
     cdef np.uint32_t l_arr_ref_c = arr_ref_c.shape[0]
     cdef np.uint32_t l_arr_sig_c = arr_sig_c.shape[0]
-    
+
     cdef np.uint32_t ref_idx = 0         # index for arr_ref_c
     cdef np.uint32_t sig_idx = 0         # index for arr_sig_c
     cdef np.uint32_t counter = 0         # number of advocate events
@@ -102,14 +118,14 @@ cdef np.float32_t _nearest_advocate_single_c(np.ndarray[np.float32_t, ndim=1] ar
     # Step 1: cut leading reference timestamps without finding advocates
     while ref_idx+1 < l_arr_ref_c and arr_ref_c[ref_idx+1] <= arr_sig_c[sig_idx]:
         ref_idx += 1
-        
+
     # return dist_max, if arr_ref_c ends before arr_sig_c starts
     if ref_idx+1 == l_arr_ref_c:
         return dist_max
-    
+
     # Case: arr_ref_c[ref_idx] < arr_sig_c[sig_idx] < arr_ref_c[ref_idx+1]
     assert arr_ref_c[ref_idx+1] > arr_sig_c[sig_idx]
-    
+
     # Step 2: count leading signal timestamps with finding advocates
     while sig_idx < l_arr_sig_c and arr_sig_c[sig_idx] < arr_ref_c[ref_idx]:
         # Invariant: arr_ref_c[ref_idx] < arr_sig_c[sig_idx] < arr_ref_c[ref_idx+1]
@@ -117,11 +133,11 @@ cdef np.float32_t _nearest_advocate_single_c(np.ndarray[np.float32_t, ndim=1] ar
             cum_distance += min(arr_ref_c[ref_idx]-arr_sig_c[sig_idx], dist_padding)
             counter += 1
         sig_idx += 1
-    
+
     # return dist_max, if arr_sig_c ends before arr_ref_c starts
     if sig_idx == l_arr_sig_c:
         return dist_max        
-    
+
     # Step 3 (regular case) and step 4 (match trailing signal timestamps)
     while sig_idx < l_arr_sig_c:
         # Step 3: regular case
@@ -135,8 +151,9 @@ cdef np.float32_t _nearest_advocate_single_c(np.ndarray[np.float32_t, ndim=1] ar
             # Invariant: arr_ref_c[ref_idx] < arr_sig_c[sig_idx] < arr_ref_c[ref_idx+1]
             # assert arr_ref_c[ref_idx] <= arr_sig_c[sig_idx]
             # assert arr_sig_c[sig_idx] < arr_ref_c[ref_idx+1]
-            
-            cum_distance += min(arr_sig_c[sig_idx]-arr_ref_c[ref_idx], arr_ref_c[ref_idx+1]-arr_sig_c[sig_idx], dist_max) 
+
+            cum_distance += min(arr_sig_c[sig_idx]-arr_ref_c[ref_idx], 
+                                arr_ref_c[ref_idx+1]-arr_sig_c[sig_idx], dist_max) 
             counter += 1
         # Step 4: match trailing reference timestamps with last signal timestamp
         elif regulate_paddings:  
@@ -149,7 +166,7 @@ cdef np.float32_t _nearest_advocate_single_c(np.ndarray[np.float32_t, ndim=1] ar
                 cum_distance += (l_arr_sig_c - sig_idx) * dist_padding
                 counter += (l_arr_sig_c - sig_idx)
                 break # stop, because the last values can be aggregated
-                
+
         sig_idx += 1
 
     # return mean cumulative distance between found advocate events

--- a/scipy/signal/_nearest_advocate_util.pyx
+++ b/scipy/signal/_nearest_advocate_util.pyx
@@ -1,0 +1,156 @@
+import numpy as np
+cimport numpy as np
+
+
+def _nearest_advocate(arr_ref: np.ndarray, arr_sig: np.ndarray, 
+                       td_min: float, td_max: float, sps: float=10, sparse_factor: int=1,
+                       dist_max: float=0.0, regulate_paddings: bool=True, dist_padding: float=0.0):
+    """Post-hoc synchronization method for event-based time-series data.
+
+    Calculates the synchronicity of two arrays of timestamps for a search space between td_min and td_max with a precision of 1/sps. The synchronicity is given by the mean of all minimal distances between each event in arr_sig and its nearest advocate in arr_ref.
+
+    Parameters
+    ----------
+    arr_ref : array_like
+        Sorted reference array (1-D) with timestamps assumed to be correct.
+    arr_sig : array_like
+        Sorted signal array (1-D) of timestamps, assumed to be shifted by an unknown constant time-delta.    
+    td_min : float
+        Lower bound of the search space for the time-shift.
+    td_max : float 
+        Upper bound of the search space for the time-shift.
+    sps : int, optional
+        Number of investigated time-shifts per second, should be higher than 10 times the number of median gap of `arr_ref` (default 10).
+    sparse_factor : int, optional
+        Factor for the sparseness of `arr_sig` for the calculation, higher is faster but may be less accurate (default 1).
+    dist_max : float, optional
+        Maximal accepted distances between two advocate events. It should be around 1/4 of the median gap of `arr_ref` (default).
+    regulate_paddings : bool, optional
+        Regulate non-overlapping events in `arr_sig` with a maximum distance of dist_padding (default True).
+    dist_padding : float, optional
+        Distance assigned to non-overlapping (padding) events. It should be around 1/4 of the median gap of `arr_ref` (default). Obsolete if `regulate_paddings` is False
+
+    Returns
+    -------
+    time_shifts : array_like
+        Two-columned 2-D array with evaluated time-shifts (between `td_min` and `td_max`) and the respective mean distances. The time-delta with the lowest mean distance is the estimation for the time-shift between the two arrays.
+    """
+    # convert the event-based arrays to cython 1-D ndarray
+    cdef np.ndarray[np.float32_t, ndim=1, cast=True] arr_ref_c = arr_ref.astype(np.float32)
+    cdef np.ndarray[np.float32_t, ndim=1, cast=True] arr_sig_c = arr_sig.astype(np.float32)
+    
+    # create a kx2 array to store the time-shifts with their respective synchronicity
+    cdef np.ndarray[np.float32_t, ndim=2] np_nearest_c = np.empty((int((td_max-td_min)*sps), 2), 
+                                                                  dtype=np.float32)
+    # fill the first column with the time-shifts to test
+    idx = 0
+    td = td_min
+    while idx < np_nearest_c.shape[0]:
+        np_nearest_c[idx, 0] = td
+        td += 1/sps
+        idx += 1
+    
+    # call and return the cython function
+    return _nearest_advocate_c(arr_ref_c, arr_sig_c, np_nearest_c=np_nearest_c, 
+                               td_min=td_min, td_max=td_max, sps=sps, sparse_factor=sparse_factor, 
+                               dist_max=dist_max, regulate_paddings=regulate_paddings, 
+                               dist_padding=dist_padding)
+
+cdef np.ndarray[np.float32_t, ndim=2] _nearest_advocate_c(
+    np.ndarray[np.float32_t, ndim=1] arr_ref_c, np.ndarray[np.float32_t, ndim=1] arr_sig_c, 
+    np.ndarray[np.float32_t, ndim=2] np_nearest_c, np.float32_t td_min, np.float32_t td_max, 
+    np.float32_t sps=10.0, np.int32_t sparse_factor=1, 
+    np.float32_t dist_max=0.0, bint regulate_paddings=1, np.float32_t dist_padding=0.0):
+    # set the default values for dist_max, dist_padding relative if not set
+    if dist_max == 0.0:
+        dist_max = np.median(np.diff(arr_ref_c))/4
+    if dist_padding == 0.0:
+        dist_padding = np.median(np.diff(arr_ref_c))/4
+        
+    # Random subsample
+    if sparse_factor > 1:
+        arr_sig_c = arr_sig_c[sparse_factor//2::sparse_factor]
+
+    # Calculate the mean distance for all time-shifts in the search space. 
+    # The shift with the lowest mean distance is the best fit for the time-shift
+    idx = 0
+    while idx < np_nearest_c.shape[0]:
+        # calculate the nearest advocate criteria
+        np_nearest_c[idx,1] = _nearest_advocate_single_c(
+             arr_ref_c, 
+             arr_sig_c-np_nearest_c[idx,0],  # the signal array is shifted by a time-delta
+             dist_max=dist_max, regulate_paddings=regulate_paddings, 
+             dist_padding=dist_padding)
+        idx += 1
+    return np_nearest_c
+
+
+cdef np.float32_t _nearest_advocate_single_c(np.ndarray[np.float32_t, ndim=1] arr_ref_c, 
+                                             np.ndarray[np.float32_t, ndim=1] arr_sig_c, 
+                                             np.float32_t dist_max=0.0, bint regulate_paddings=True, 
+                                             np.float32_t dist_padding=0.0):
+
+    # store the lengths of the arrays
+    cdef np.uint32_t l_arr_ref_c = arr_ref_c.shape[0]
+    cdef np.uint32_t l_arr_sig_c = arr_sig_c.shape[0]
+    
+    cdef np.uint32_t ref_idx = 0         # index for arr_ref_c
+    cdef np.uint32_t sig_idx = 0         # index for arr_sig_c
+    cdef np.uint32_t counter = 0         # number of advocate events
+    cdef np.float32_t cum_distance = 0.0 # cumulative distances between advocate events
+
+    # Step 1: cut leading reference timestamps without finding advocates
+    while ref_idx+1 < l_arr_ref_c and arr_ref_c[ref_idx+1] <= arr_sig_c[sig_idx]:
+        ref_idx += 1
+        
+    # return dist_max, if arr_ref_c ends before arr_sig_c starts
+    if ref_idx+1 == l_arr_ref_c:
+        return dist_max
+    
+    # Case: arr_ref_c[ref_idx] < arr_sig_c[sig_idx] < arr_ref_c[ref_idx+1]
+    assert arr_ref_c[ref_idx+1] > arr_sig_c[sig_idx]
+    
+    # Step 2: count leading signal timestamps with finding advocates
+    while sig_idx < l_arr_sig_c and arr_sig_c[sig_idx] < arr_ref_c[ref_idx]:
+        # Invariant: arr_ref_c[ref_idx] < arr_sig_c[sig_idx] < arr_ref_c[ref_idx+1]
+        if regulate_paddings:
+            cum_distance += min(arr_ref_c[ref_idx]-arr_sig_c[sig_idx], dist_padding)
+            counter += 1
+        sig_idx += 1
+    
+    # return dist_max, if arr_sig_c ends before arr_ref_c starts
+    if sig_idx == l_arr_sig_c:
+        return dist_max        
+    
+    # Step 3 (regular case) and step 4 (match trailing signal timestamps)
+    while sig_idx < l_arr_sig_c:
+        # Step 3: regular case
+        if arr_sig_c[sig_idx] < arr_ref_c[-1]:
+            # forward arr_ref_c and then arr_sig_c until regalar case
+            while ref_idx+1 < l_arr_ref_c and arr_ref_c[ref_idx+1] <= arr_sig_c[sig_idx]:
+                ref_idx += 1
+            if ref_idx+1 >= l_arr_ref_c: 
+                sig_idx += 1
+                continue
+            # Invariant: arr_ref_c[ref_idx] < arr_sig_c[sig_idx] < arr_ref_c[ref_idx+1]
+            # assert arr_ref_c[ref_idx] <= arr_sig_c[sig_idx]
+            # assert arr_sig_c[sig_idx] < arr_ref_c[ref_idx+1]
+            
+            cum_distance += min(arr_sig_c[sig_idx]-arr_ref_c[ref_idx], arr_ref_c[ref_idx+1]-arr_sig_c[sig_idx], dist_max) 
+            counter += 1
+        # Step 4: match trailing reference timestamps with last signal timestamp
+        elif regulate_paddings:  
+            # Invariant: arr_ref_c[ref_idx+1] <= arr_sig_c[sig_idx], given by the else case
+            if arr_sig_c[sig_idx]-arr_ref_c[ref_idx+1] < dist_padding:
+                cum_distance += arr_sig_c[sig_idx]-arr_ref_c[ref_idx+1]
+                counter += 1
+            else: 
+                # case with only dist_padding increments from now on
+                cum_distance += (l_arr_sig_c - sig_idx) * dist_padding
+                counter += (l_arr_sig_c - sig_idx)
+                break # stop, because the last values can be aggregated
+                
+        sig_idx += 1
+
+    # return mean cumulative distance between found advocate events
+    return cum_distance / counter

--- a/scipy/signal/meson.build
+++ b/scipy/signal/meson.build
@@ -77,6 +77,7 @@ else
 endif
 
 pyx_files = [
+  ['_nearest_advocate_util', '_nearest_advocate_util.pyx'],
   ['_peak_finding_utils', '_peak_finding_utils.pyx'],
   ['_sosfilt', '_sosfilt.pyx'],
   ['_upfirdn_apply', '_upfirdn_apply.pyx']
@@ -118,6 +119,7 @@ py3.install_sources([
     '_lti_conversion.py',
     '_ltisys.py',
     '_max_len_seq.py',
+    '_nearest_advocate.py',
     '_peak_finding.py',
     '_savitzky_golay.py',
     '_signaltools.py',

--- a/scipy/signal/setup.py
+++ b/scipy/signal/setup.py
@@ -49,6 +49,8 @@ def configuration(parent_package='', top_path=None):
             '_max_len_seq_inner', sources=['_max_len_seq_inner.c'])
 
     config.add_extension(
+        '_nearest_advocate_util', sources=['_nearest_advocate_util.c'])
+    config.add_extension(
         '_peak_finding_utils', sources=['_peak_finding_utils.c'])
     config.add_extension(
         '_sosfilt', sources=['_sosfilt.c'])

--- a/scipy/signal/tests/meson.build
+++ b/scipy/signal/tests/meson.build
@@ -10,6 +10,7 @@ py3.install_sources([
     'test_fir_filter_design.py',
     'test_ltisys.py',
     'test_max_len_seq.py',
+    'test_nearest_advocate.py',
     'test_peak_finding.py',
     'test_result_type.py',
     'test_savitzky_golay.py',

--- a/scipy/signal/tests/test_nearest_advocate.py
+++ b/scipy/signal/tests/test_nearest_advocate.py
@@ -1,4 +1,3 @@
-import pytest
 import numpy as np
 from numpy.testing import assert_equal, assert_almost_equal
 
@@ -6,107 +5,124 @@ from scipy.signal import nearest_advocate
 
 SEED = 0
 
-        
+
 def test_nearest_advocate_base():
-    N = 1_000 
-    DEF_DIST = 0.25    
-    
+    N = 1_000
+    DEF_DIST = 0.25
+
     np.random.seed(SEED)
-    arr_ref = np.sort(np.cumsum(np.random.normal(loc=1, scale=0.25, size=N))).astype(np.float32)
-    arr_sig = np.sort(arr_ref + np.pi + np.random.normal(loc=0, scale=0.1, size=N)).astype(np.float32)
+    arr_ref = np.sort(np.cumsum(np.random.normal(
+        loc=1, scale=0.25, size=N))).astype(np.float32)
+    arr_sig = np.sort(arr_ref + np.pi + np.random.normal(
+        loc=0, scale=0.1, size=N)).astype(np.float32)
 
     np_nearest = nearest_advocate(
         arr_ref=arr_ref, arr_sig=arr_sig, 
         td_min=-60, td_max=60, sps=20, sparse_factor=1, 
         dist_max=DEF_DIST, regulate_paddings=True, dist_padding=DEF_DIST)
-    time_shift, min_mean_dist = np_nearest[np.argmin(np_nearest[:,1])]
-    
+    time_shift, min_mean_dist = np_nearest[np.argmin(np_nearest[:, 1])]
+
     assert_almost_equal(time_shift, np.pi, decimal=1)
     assert_almost_equal(min_mean_dist, 0.07694374, decimal=2)  
-    
+
+
 def test_nearest_advocate_edge():
-    N = 1_000 
-    DEF_DIST = 0.25    
-    
+    N = 1_000
+    DEF_DIST = 0.25
+
     np.random.seed(SEED)
-    arr_ref = np.sort(np.cumsum(np.random.normal(loc=1, scale=0.5, size=N))).astype(np.float32)
-    arr_sig = np.sort(arr_ref + np.pi + np.random.normal(loc=0, scale=0.4, size=N)).astype(np.float32)
+    arr_ref = np.sort(np.cumsum(np.random.normal(
+        loc=1, scale=0.5, size=N))).astype(np.float32)
+    arr_sig = np.sort(arr_ref + np.pi + np.random.normal(
+        loc=0, scale=0.4, size=N)).astype(np.float32)
 
     np_nearest = nearest_advocate(
         arr_ref=arr_ref, arr_sig=arr_sig, 
         td_min=-60, td_max=60, sps=20, sparse_factor=1, 
         dist_max=DEF_DIST, regulate_paddings=True, dist_padding=DEF_DIST)
-    time_shift, min_mean_dist = np_nearest[np.argmin(np_nearest[:,1])]
-    
+    time_shift, min_mean_dist = np_nearest[np.argmin(np_nearest[:, 1])]
+
     assert_almost_equal(time_shift, np.pi, decimal=1)
     assert_almost_equal(min_mean_dist, 0.1646458, decimal=2)
-    
+
+
 def test_nearest_advocate_base_defmax():
-    N = 1_000 
+    N = 1_000
     DEF_DIST = 0.0
 
     np.random.seed(SEED)
-    arr_ref = np.sort(np.cumsum(np.random.normal(loc=1, scale=0.25, size=N))).astype(np.float32)
-    arr_sig = np.sort(arr_ref + np.pi + np.random.normal(loc=0, scale=0.1, size=N)).astype(np.float32)
+    arr_ref = np.sort(np.cumsum(np.random.normal(
+        loc=1, scale=0.25, size=N))).astype(np.float32)
+    arr_sig = np.sort(arr_ref + np.pi + np.random.normal(
+        loc=0, scale=0.1, size=N)).astype(np.float32)
 
     np_nearest = nearest_advocate(
         arr_ref=arr_ref, arr_sig=arr_sig, 
         td_min=-60, td_max=60, sps=20, sparse_factor=1, 
         dist_max=DEF_DIST, regulate_paddings=True, dist_padding=DEF_DIST)
-    time_shift, min_mean_dist = np_nearest[np.argmin(np_nearest[:,1])]
-    
+    time_shift, min_mean_dist = np_nearest[np.argmin(np_nearest[:, 1])]
+
     assert_almost_equal(time_shift, np.pi, decimal=1)
     assert_almost_equal(min_mean_dist, 0.07690712, decimal=2)
-         
+
+
 def test_nearest_advocate_base_fewoverlap():
-    N = 1_000 
+    N = 1_000
     DEF_DIST = 0.0
     TIME_SHIFT = 900
 
     np.random.seed(SEED)
-    arr_ref = np.sort(np.cumsum(np.random.normal(loc=1, scale=0.25, size=N))).astype(np.float32)
-    arr_sig = np.sort(arr_ref + TIME_SHIFT + np.random.normal(loc=0, scale=0.1, size=N)).astype(np.float32)
+    arr_ref = np.sort(np.cumsum(np.random.normal(
+        loc=1, scale=0.25, size=N))).astype(np.float32)
+    arr_sig = np.sort(arr_ref + TIME_SHIFT + np.random.normal(
+        loc=0, scale=0.1, size=N)).astype(np.float32)
 
     np_nearest = nearest_advocate(
         arr_ref=arr_ref, arr_sig=arr_sig, 
         td_min=850, td_max=950, sps=20, sparse_factor=1, 
         dist_max=DEF_DIST, regulate_paddings=True, dist_padding=DEF_DIST)
-    time_shift, min_mean_dist = np_nearest[np.argmin(np_nearest[:,1])]
-    
+    time_shift, min_mean_dist = np_nearest[np.argmin(np_nearest[:, 1])]
+
     assert_almost_equal(time_shift, TIME_SHIFT, decimal=1)
     assert_almost_equal(min_mean_dist, 0.07674612, decimal=2)
-    
+
+
 def test_nearest_advocate_base_nopadding():
-    N = 1_000 
+    N = 1_000
     DEF_DIST = 0.25
 
     np.random.seed(SEED)
-    arr_ref = np.sort(np.cumsum(np.random.normal(loc=1, scale=0.25, size=N))).astype(np.float32)
-    arr_sig = np.sort(arr_ref + np.pi + np.random.normal(loc=0, scale=0.1, size=N)).astype(np.float32)
+    arr_ref = np.sort(np.cumsum(np.random.normal(
+        loc=1, scale=0.25, size=N))).astype(np.float32)
+    arr_sig = np.sort(arr_ref + np.pi + np.random.normal(
+        loc=0, scale=0.1, size=N)).astype(np.float32)
 
     np_nearest = nearest_advocate(
         arr_ref=arr_ref, arr_sig=arr_sig, 
         td_min=-60, td_max=60, sps=20, sparse_factor=1, 
         dist_max=DEF_DIST, regulate_paddings=False)
-    time_shift, min_mean_dist = np_nearest[np.argmin(np_nearest[:,1])]
-    
+    time_shift, min_mean_dist = np_nearest[np.argmin(np_nearest[:, 1])]
+
     assert_almost_equal(time_shift, np.pi, decimal=1)
     assert_almost_equal(min_mean_dist, 0.07690712, decimal=2)
-    
+
+
 def test_nearest_advocate_base_noverlap():
-    N = 100 
+    N = 100
     DEF_DIST = 0.25
     TIME_SHIFT = 200
 
     np.random.seed(SEED)
-    arr_ref = np.sort(np.cumsum(np.random.normal(loc=1, scale=0.25, size=N))).astype(np.float32)
-    arr_sig = np.sort(arr_ref + TIME_SHIFT + np.random.normal(loc=0, scale=0.1, size=N)).astype(np.float32)
+    arr_ref = np.sort(np.cumsum(np.random.normal(
+        loc=1, scale=0.25, size=N))).astype(np.float32)
+    arr_sig = np.sort(arr_ref + TIME_SHIFT + np.random.normal(
+        loc=0, scale=0.1, size=N)).astype(np.float32)
 
     np_nearest = nearest_advocate(
         arr_ref=arr_ref, arr_sig=arr_sig, 
         td_min=-60, td_max=60, sps=20, sparse_factor=1, 
         dist_max=DEF_DIST, regulate_paddings=False)
-    time_shift, min_mean_dist = np_nearest[np.argmin(np_nearest[:,1])]
-    
-    # assert_almost_equal(time_shift, -60, decimal=1)  # each value is the same
+    time_shift, min_mean_dist = np_nearest[np.argmin(np_nearest[:, 1])]
+
+    assert_almost_equal(time_shift, -60, decimal=1)  # each value is the same
     assert_equal(min_mean_dist, DEF_DIST)

--- a/scipy/signal/tests/test_nearest_advocate.py
+++ b/scipy/signal/tests/test_nearest_advocate.py
@@ -110,5 +110,3 @@ def test_nearest_advocate_base_noverlap():
     
     # assert_almost_equal(time_shift, -60, decimal=1)  # each value is the same
     assert_equal(min_mean_dist, DEF_DIST)
-        
-    

--- a/scipy/signal/tests/test_nearest_advocate.py
+++ b/scipy/signal/tests/test_nearest_advocate.py
@@ -23,7 +23,7 @@ def test_nearest_advocate_base():
     time_shift, min_mean_dist = np_nearest[np.argmin(np_nearest[:, 1])]
 
     assert_almost_equal(time_shift, np.pi, decimal=1)
-    assert_almost_equal(min_mean_dist, 0.07694374, decimal=2)  
+    assert_almost_equal(min_mean_dist, 0.07694374, decimal=2)
 
 
 def test_nearest_advocate_edge():

--- a/scipy/signal/tests/test_nearest_advocate.py
+++ b/scipy/signal/tests/test_nearest_advocate.py
@@ -1,0 +1,114 @@
+import pytest
+import numpy as np
+from numpy.testing import assert_equal, assert_almost_equal
+
+from scipy.signal import nearest_advocate
+
+SEED = 0
+
+        
+def test_nearest_advocate_base():
+    N = 1_000 
+    DEF_DIST = 0.25    
+    
+    np.random.seed(SEED)
+    arr_ref = np.sort(np.cumsum(np.random.normal(loc=1, scale=0.25, size=N))).astype(np.float32)
+    arr_sig = np.sort(arr_ref + np.pi + np.random.normal(loc=0, scale=0.1, size=N)).astype(np.float32)
+
+    np_nearest = nearest_advocate(
+        arr_ref=arr_ref, arr_sig=arr_sig, 
+        td_min=-60, td_max=60, sps=20, sparse_factor=1, 
+        dist_max=DEF_DIST, regulate_paddings=True, dist_padding=DEF_DIST)
+    time_shift, min_mean_dist = np_nearest[np.argmin(np_nearest[:,1])]
+    
+    assert_almost_equal(time_shift, np.pi, decimal=1)
+    assert_almost_equal(min_mean_dist, 0.07694374, decimal=2)  
+    
+def test_nearest_advocate_edge():
+    N = 1_000 
+    DEF_DIST = 0.25    
+    
+    np.random.seed(SEED)
+    arr_ref = np.sort(np.cumsum(np.random.normal(loc=1, scale=0.5, size=N))).astype(np.float32)
+    arr_sig = np.sort(arr_ref + np.pi + np.random.normal(loc=0, scale=0.4, size=N)).astype(np.float32)
+
+    np_nearest = nearest_advocate(
+        arr_ref=arr_ref, arr_sig=arr_sig, 
+        td_min=-60, td_max=60, sps=20, sparse_factor=1, 
+        dist_max=DEF_DIST, regulate_paddings=True, dist_padding=DEF_DIST)
+    time_shift, min_mean_dist = np_nearest[np.argmin(np_nearest[:,1])]
+    
+    assert_almost_equal(time_shift, np.pi, decimal=1)
+    assert_almost_equal(min_mean_dist, 0.1646458, decimal=2)
+    
+def test_nearest_advocate_base_defmax():
+    N = 1_000 
+    DEF_DIST = 0.0
+
+    np.random.seed(SEED)
+    arr_ref = np.sort(np.cumsum(np.random.normal(loc=1, scale=0.25, size=N))).astype(np.float32)
+    arr_sig = np.sort(arr_ref + np.pi + np.random.normal(loc=0, scale=0.1, size=N)).astype(np.float32)
+
+    np_nearest = nearest_advocate(
+        arr_ref=arr_ref, arr_sig=arr_sig, 
+        td_min=-60, td_max=60, sps=20, sparse_factor=1, 
+        dist_max=DEF_DIST, regulate_paddings=True, dist_padding=DEF_DIST)
+    time_shift, min_mean_dist = np_nearest[np.argmin(np_nearest[:,1])]
+    
+    assert_almost_equal(time_shift, np.pi, decimal=1)
+    assert_almost_equal(min_mean_dist, 0.07690712, decimal=2)
+         
+def test_nearest_advocate_base_fewoverlap():
+    N = 1_000 
+    DEF_DIST = 0.0
+    TIME_SHIFT = 900
+
+    np.random.seed(SEED)
+    arr_ref = np.sort(np.cumsum(np.random.normal(loc=1, scale=0.25, size=N))).astype(np.float32)
+    arr_sig = np.sort(arr_ref + TIME_SHIFT + np.random.normal(loc=0, scale=0.1, size=N)).astype(np.float32)
+
+    np_nearest = nearest_advocate(
+        arr_ref=arr_ref, arr_sig=arr_sig, 
+        td_min=850, td_max=950, sps=20, sparse_factor=1, 
+        dist_max=DEF_DIST, regulate_paddings=True, dist_padding=DEF_DIST)
+    time_shift, min_mean_dist = np_nearest[np.argmin(np_nearest[:,1])]
+    
+    assert_almost_equal(time_shift, TIME_SHIFT, decimal=1)
+    assert_almost_equal(min_mean_dist, 0.07674612, decimal=2)
+    
+def test_nearest_advocate_base_nopadding():
+    N = 1_000 
+    DEF_DIST = 0.25
+
+    np.random.seed(SEED)
+    arr_ref = np.sort(np.cumsum(np.random.normal(loc=1, scale=0.25, size=N))).astype(np.float32)
+    arr_sig = np.sort(arr_ref + np.pi + np.random.normal(loc=0, scale=0.1, size=N)).astype(np.float32)
+
+    np_nearest = nearest_advocate(
+        arr_ref=arr_ref, arr_sig=arr_sig, 
+        td_min=-60, td_max=60, sps=20, sparse_factor=1, 
+        dist_max=DEF_DIST, regulate_paddings=False)
+    time_shift, min_mean_dist = np_nearest[np.argmin(np_nearest[:,1])]
+    
+    assert_almost_equal(time_shift, np.pi, decimal=1)
+    assert_almost_equal(min_mean_dist, 0.07690712, decimal=2)
+    
+def test_nearest_advocate_base_noverlap():
+    N = 100 
+    DEF_DIST = 0.25
+    TIME_SHIFT = 200
+
+    np.random.seed(SEED)
+    arr_ref = np.sort(np.cumsum(np.random.normal(loc=1, scale=0.25, size=N))).astype(np.float32)
+    arr_sig = np.sort(arr_ref + TIME_SHIFT + np.random.normal(loc=0, scale=0.1, size=N)).astype(np.float32)
+
+    np_nearest = nearest_advocate(
+        arr_ref=arr_ref, arr_sig=arr_sig, 
+        td_min=-60, td_max=60, sps=20, sparse_factor=1, 
+        dist_max=DEF_DIST, regulate_paddings=False)
+    time_shift, min_mean_dist = np_nearest[np.argmin(np_nearest[:,1])]
+    
+    # assert_almost_equal(time_shift, -60, decimal=1)  # each value is the same
+    assert_equal(min_mean_dist, DEF_DIST)
+        
+    

--- a/scipy/signal/tests/test_nearest_advocate.py
+++ b/scipy/signal/tests/test_nearest_advocate.py
@@ -17,8 +17,8 @@ def test_nearest_advocate_base():
         loc=0, scale=0.1, size=N)).astype(np.float32)
 
     np_nearest = nearest_advocate(
-        arr_ref=arr_ref, arr_sig=arr_sig, 
-        td_min=-60, td_max=60, sps=20, sparse_factor=1, 
+        arr_ref=arr_ref, arr_sig=arr_sig,
+        td_min=-60, td_max=60, sps=20, sparse_factor=1,
         dist_max=DEF_DIST, regulate_paddings=True, dist_padding=DEF_DIST)
     time_shift, min_mean_dist = np_nearest[np.argmin(np_nearest[:, 1])]
 
@@ -37,8 +37,8 @@ def test_nearest_advocate_edge():
         loc=0, scale=0.4, size=N)).astype(np.float32)
 
     np_nearest = nearest_advocate(
-        arr_ref=arr_ref, arr_sig=arr_sig, 
-        td_min=-60, td_max=60, sps=20, sparse_factor=1, 
+        arr_ref=arr_ref, arr_sig=arr_sig,
+        td_min=-60, td_max=60, sps=20, sparse_factor=1,
         dist_max=DEF_DIST, regulate_paddings=True, dist_padding=DEF_DIST)
     time_shift, min_mean_dist = np_nearest[np.argmin(np_nearest[:, 1])]
 
@@ -57,8 +57,8 @@ def test_nearest_advocate_base_defmax():
         loc=0, scale=0.1, size=N)).astype(np.float32)
 
     np_nearest = nearest_advocate(
-        arr_ref=arr_ref, arr_sig=arr_sig, 
-        td_min=-60, td_max=60, sps=20, sparse_factor=1, 
+        arr_ref=arr_ref, arr_sig=arr_sig,
+        td_min=-60, td_max=60, sps=20, sparse_factor=1,
         dist_max=DEF_DIST, regulate_paddings=True, dist_padding=DEF_DIST)
     time_shift, min_mean_dist = np_nearest[np.argmin(np_nearest[:, 1])]
 
@@ -78,8 +78,8 @@ def test_nearest_advocate_base_fewoverlap():
         loc=0, scale=0.1, size=N)).astype(np.float32)
 
     np_nearest = nearest_advocate(
-        arr_ref=arr_ref, arr_sig=arr_sig, 
-        td_min=850, td_max=950, sps=20, sparse_factor=1, 
+        arr_ref=arr_ref, arr_sig=arr_sig,
+        td_min=850, td_max=950, sps=20, sparse_factor=1,
         dist_max=DEF_DIST, regulate_paddings=True, dist_padding=DEF_DIST)
     time_shift, min_mean_dist = np_nearest[np.argmin(np_nearest[:, 1])]
 
@@ -98,8 +98,8 @@ def test_nearest_advocate_base_nopadding():
         loc=0, scale=0.1, size=N)).astype(np.float32)
 
     np_nearest = nearest_advocate(
-        arr_ref=arr_ref, arr_sig=arr_sig, 
-        td_min=-60, td_max=60, sps=20, sparse_factor=1, 
+        arr_ref=arr_ref, arr_sig=arr_sig,
+        td_min=-60, td_max=60, sps=20, sparse_factor=1,
         dist_max=DEF_DIST, regulate_paddings=False)
     time_shift, min_mean_dist = np_nearest[np.argmin(np_nearest[:, 1])]
 
@@ -119,8 +119,8 @@ def test_nearest_advocate_base_noverlap():
         loc=0, scale=0.1, size=N)).astype(np.float32)
 
     np_nearest = nearest_advocate(
-        arr_ref=arr_ref, arr_sig=arr_sig, 
-        td_min=-60, td_max=60, sps=20, sparse_factor=1, 
+        arr_ref=arr_ref, arr_sig=arr_sig,
+        td_min=-60, td_max=60, sps=20, sparse_factor=1,
         dist_max=DEF_DIST, regulate_paddings=False)
     time_shift, min_mean_dist = np_nearest[np.argmin(np_nearest[:, 1])]
 


### PR DESCRIPTION
Post-hoc time synchronization of event-based time-series data. 

#### What does this implement/fix?
This is an alternativ approach to the cross-correlation and is better suited for event-based time-series data like arrays of timestamps. 

#### Additional information
The first paper addressing this approach is [here](https://www.researchgate.net/publication/364165101) (in german) and a second larger paper is in preparation which will be submitted in February.
