### PR TITLE
MAINT: optimize.root_scalar: raise when NaN is encountered

### DIFF
--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -773,14 +773,16 @@ def test_gh9551_raise_error_if_disp_true():
 @pytest.mark.parametrize('solver_name',
                          ['brentq', 'brenth', 'bisect', 'ridder', 'toms748'])
 @pytest.mark.parametrize('rs_interface', [True, False])
-def test_gh3089(solver_name, rs_interface):
+def test_gh3089_8394(solver_name, rs_interface):
+    # gh-3089 and gh-8394 reported that bracketing solvers returned incorrect
+    # results when they encountered NaNs. Check that this is resolved.
     solver = ((lambda f, a, b: root_scalar(f, bracket=(a, b))) if rs_interface
               else getattr(zeros, solver_name))
 
     def f(x):
         return np.nan
 
-    message = "The function value is NaN at at least one end of the bracketing"
+    message = "The function value at x..."
     with pytest.raises(ValueError, match=message):
         solver(f, 0, 1)
 
@@ -789,6 +791,8 @@ def test_gh3089(solver_name, rs_interface):
                          ['brentq', 'brenth', 'bisect', 'ridder', 'toms748'])
 @pytest.mark.parametrize('rs_interface', [True, False])
 def test_function_calls(solver_name, rs_interface):
+    # There do not appear to be checks that the bracketing solvers report the
+    # correct number of function evaluations. Check that this is the case.
     solver = ((lambda f, a, b, **kwargs: root_scalar(f, bracket=(a, b)))
               if rs_interface else getattr(zeros, solver_name))
 

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -768,3 +768,38 @@ def test_gh9551_raise_error_if_disp_true():
         zeros.newton(f, 1.0, f_p)
     root = zeros.newton(f, complex(10.0, 10.0), f_p)
     assert_allclose(root, complex(0.0, 1.0))
+
+
+@pytest.mark.parametrize('solver_name',
+                         ['brentq', 'brenth', 'bisect', 'ridder', 'toms748'])
+@pytest.mark.parametrize('rs_interface', [True, False])
+def test_gh3089(solver_name, rs_interface):
+    solver = ((lambda f, a, b: root_scalar(f, bracket=(a, b))) if rs_interface
+              else getattr(zeros, solver_name))
+
+    def f(x):
+        return np.nan
+
+    message = "The function value is NaN at at least one end of the bracketing"
+    with pytest.raises(ValueError, match=message):
+        solver(f, 0, 1)
+
+
+@pytest.mark.parametrize('solver_name',
+                         ['brentq', 'brenth', 'bisect', 'ridder', 'toms748'])
+@pytest.mark.parametrize('rs_interface', [True, False])
+def test_function_calls(solver_name, rs_interface):
+    solver = ((lambda f, a, b, **kwargs: root_scalar(f, bracket=(a, b)))
+              if rs_interface else getattr(zeros, solver_name))
+
+    def f(x):
+        f.calls += 1
+        return x**2 - 1
+    f.calls = 0
+
+    res = solver(f, 0, 10, full_output=True)
+
+    if rs_interface:
+        assert res.function_calls == f.calls
+    else:
+        assert res[1].function_calls == f.calls


### PR DESCRIPTION
#### Reference issue
Closes gh-3089
Closes gh-8394
Closes gh-14414

#### What does this implement/fix?
The bracketing scalar root-finders can return incorrect results when the function returns NaN. Instead, raise an error.

#### Additional information
The linked issues only report problems when the function is NaN at one of the initial bracketing interval endpoints, so the approach of the first commit was to only check for NaNs at the bracketing interval endpoints. However, I imagine there could also be problems if the solver does not encounter a NaN at the initial endpoints but later. One option is to also check whether the final function value is NaN, but this is not guaranteed to catch problems, and it could allow the algorithm to proceed long after the first NaN is encountered. I ended up changing the approach to check for NaN on every function evaluation using a wrapper. The performance hit seems small. In main:

```python3
import numpy as np
from scipy import stats
rng = np.random.default_rng(1638083107694713882823079058616272161)
p = rng.random(1000)
mu = 1.5
x = stats.recipinvgauss.ppf(p, mu)  # uses `brentq`
# 1.01 s ± 8.14 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
with this PR:
```python3
1.03 s ± 3.27 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
This could probably be reduced by doing the NaN check in the compiled code itself as is discussed in https://github.com/scipy/scipy/issues/8394#issuecomment-364605533, but since gh-3089 was reported almost a decade ago, it seems there is some hesitation to modify all those compiled functions.
