### PR TITLE
MAINT: Cast `datasets.ascent` image to float64

### DIFF
--- a/doc/source/tutorial/signal.rst
+++ b/doc/source/tutorial/signal.rst
@@ -362,7 +362,7 @@ which is often used for blurring.
    >>> from scipy import signal, datasets
    >>> import matplotlib.pyplot as plt
 
-   >>> image = datasets.ascent()
+   >>> image = np.asarray(datasets.ascent(), np.float64)
    >>> w = signal.windows.gaussian(51, 10.0)
    >>> image_new = signal.sepfir2d(image, w, w)
 


### PR DESCRIPTION
#### Reference issue
xref https://github.com/scipy/scipy/pull/17606 https://github.com/scipy/scipy/pull/17611 https://github.com/scipy/dataset-ascent/pull/3

#### What does this implement/fix?
ascent dataset array has been updated to uint8 dtype at source file, this should fix the breaking signal docs due to the same.

Thanks @boeleman for the initial PR.

cc @tylerjereddy @rgommers
