### PR TITLE
DOC: stats: example treatment odd_ratio

### DIFF
--- a/scipy/stats/_odds_ratio.py
+++ b/scipy/stats/_odds_ratio.py
@@ -409,16 +409,16 @@ def odds_ratio(table, *, kind='conditional'):
     In [4]_, the use of aspirin to prevent cardiovascular events in women
     and men was investigated. The study notably concluded:
 
-        For women and men, aspirin therapy reduced the risk of a composite of
+        ...aspirin therapy reduced the risk of a composite of
         cardiovascular events due to its effect on reducing the risk of
         ischemic stroke in women [...]
 
-    The article list multiple studies for various cardiovascular events. Let's
+    The article lists studies of various cardiovascular events. Let's
     focus on the ischemic stoke in women.
 
     The following table summarizes the results of the experiment in which
     participants took aspirin or a placebo on a regular basis for several
-    years. Occurences of ischemic stroke were recorded::
+    years. Cases of ischemic stroke were recorded::
 
                           Aspirin   Control/Placebo
         Ischemic stroke     176           230
@@ -435,7 +435,7 @@ def odds_ratio(table, *, kind='conditional'):
     0.7646037659999126
 
     For this sample, the odds of getting an ischemic stroke for those who have
-    been taking aspiring to the chemical are 0.76 times that of those
+    been taking aspirin are 0.76 times that of those
     who have received the placebo.
 
     To make statistical inferences about the population under study,

--- a/scipy/stats/_odds_ratio.py
+++ b/scipy/stats/_odds_ratio.py
@@ -376,6 +376,10 @@ def odds_ratio(table, *, kind='conditional'):
     .. [3] H. Sahai and A. Khurshid (1996), Statistics in Epidemiology:
            Methods, Techniques, and Applications, CRC Press LLC, Boca
            Raton, Florida.
+    .. [4] Berger, Jeffrey S. et al. "Aspirin for the Primary Prevention of
+           Cardiovascular Events in Women and Men: A Sex-Specific
+           Meta-analysis of Randomized Controlled Trials."
+           JAMA, 295(3):306–313, :doi:`10.1001/jama.295.3.306`, 2006.
 
     Examples
     --------
@@ -402,36 +406,45 @@ def odds_ratio(table, *, kind='conditional'):
     given to the rows and columns of the table when interpreting the
     odds ratio.
 
-    Consider a hypothetical example where it is hypothesized that
-    exposure to a certain chemical is assocated with increased occurrence
-    of a certain disease.  Suppose we have the following table for a
-    collection of 410 people::
+    In [4]_, the use of aspirin to prevent cardiovascular events in women
+    and men was investigated. The study notably concluded:
 
-                  exposed   unexposed
-        cases         7         15
-        noncases     58        472
+        For women and men, aspirin therapy reduced the risk of a composite of
+        cardiovascular events due to its effect on reducing the risk of
+        ischemic stroke in women [...]
 
-    The question we ask is "Is exposure to the chemical associated with
-    increased risk of the disease?"
+    The article list multiple studies for various cardiovascular events. Let's
+    focus on the ischemic stoke in women.
+
+    The following table summarizes the results of the experiment in which
+    took aspirin or a placebo on a regular basis for several
+    years. Occurences of ischemic stroke were recorded::
+
+                          Aspirin   Control/Placebo
+        Ischemic stroke     176           230
+        No stroke         21035         21018
+
+    The question we ask is "Is there evidence that the aspirin reduces the
+    risk of ischemic stroke?"
 
     Compute the odds ratio:
 
     >>> from scipy.stats.contingency import odds_ratio
-    >>> res = odds_ratio([[7, 15], [58, 472]])
+    >>> res = odds_ratio([[176, 230], [21035, 21018]])
     >>> res.statistic
-    3.7836687705553493
+    0.7646037659999126
 
-    For this sample, the odds of getting the disease for those who have
-    been exposed to the chemical are almost 3.8 times that of those who
-    have not been exposed.
+    For this sample, the odds of getting an ischemic stroke for those who have
+    been taking aspiring to the chemical are 0.76 times that of those
+    who have received the placebo. Which means almost 25% less risk.
 
     We can compute the 95% confidence interval for the odds ratio:
 
     >>> res.confidence_interval(confidence_level=0.95)
-    ConfidenceInterval(low=1.2514829132266785, high=10.363493716701269)
+    ConfidenceInterval(low=0.6241234078749812, high=0.9354102892100372)
 
     The 95% confidence interval for the conditional odds ratio is
-    approximately (1.25, 10.4).
+    approximately (0.62, 0.94).
     """
     if kind not in ['conditional', 'sample']:
         raise ValueError("`kind` must be 'conditional' or 'sample'.")

--- a/scipy/stats/_odds_ratio.py
+++ b/scipy/stats/_odds_ratio.py
@@ -379,7 +379,7 @@ def odds_ratio(table, *, kind='conditional'):
     .. [4] Berger, Jeffrey S. et al. "Aspirin for the Primary Prevention of
            Cardiovascular Events in Women and Men: A Sex-Specific
            Meta-analysis of Randomized Controlled Trials."
-           JAMA, 295(3):306–313, :doi:`10.1001/jama.295.3.306`, 2006.
+           JAMA, 295(3):306-313, :doi:`10.1001/jama.295.3.306`, 2006.
 
     Examples
     --------
@@ -417,7 +417,7 @@ def odds_ratio(table, *, kind='conditional'):
     focus on the ischemic stoke in women.
 
     The following table summarizes the results of the experiment in which
-    took aspirin or a placebo on a regular basis for several
+    participants took aspirin or a placebo on a regular basis for several
     years. Occurences of ischemic stroke were recorded::
 
                           Aspirin   Control/Placebo
@@ -436,15 +436,20 @@ def odds_ratio(table, *, kind='conditional'):
 
     For this sample, the odds of getting an ischemic stroke for those who have
     been taking aspiring to the chemical are 0.76 times that of those
-    who have received the placebo. Which means almost 25% less risk.
+    who have received the placebo.
 
-    We can compute the 95% confidence interval for the odds ratio:
+    To make statistical inferences about the population under study,
+    we can compute the 95% confidence interval for the odds ratio:
 
     >>> res.confidence_interval(confidence_level=0.95)
     ConfidenceInterval(low=0.6241234078749812, high=0.9354102892100372)
 
     The 95% confidence interval for the conditional odds ratio is
     approximately (0.62, 0.94).
+
+The fact that the entire 95% confidence interval falls below 1 supports
+the authors' conclusion that the aspirin was associated with a statistically
+significant reduction in ischemic stroke.```
     """
     if kind not in ['conditional', 'sample']:
         raise ValueError("`kind` must be 'conditional' or 'sample'.")

--- a/scipy/stats/_odds_ratio.py
+++ b/scipy/stats/_odds_ratio.py
@@ -447,9 +447,9 @@ def odds_ratio(table, *, kind='conditional'):
     The 95% confidence interval for the conditional odds ratio is
     approximately (0.62, 0.94).
 
-The fact that the entire 95% confidence interval falls below 1 supports
-the authors' conclusion that the aspirin was associated with a statistically
-significant reduction in ischemic stroke.```
+    The fact that the entire 95% confidence interval falls below 1 supports
+    the authors' conclusion that the aspirin was associated with a
+    statistically significant reduction in ischemic stroke.
     """
     if kind not in ['conditional', 'sample']:
         raise ValueError("`kind` must be 'conditional' or 'sample'.")


### PR DESCRIPTION
Replace a made up example using the same example as in #17610.

This was suggested in https://github.com/scipy/scipy/pull/17610/files#r1051034735 as a good complementary analysis for this case.