### PR TITLE
MAINT: casting errstate for NumPy 1.24

### DIFF
--- a/scipy/linalg/tests/test_decomp_update.py
+++ b/scipy/linalg/tests/test_decomp_update.py
@@ -581,7 +581,8 @@ class BaseQRdelete(BaseQRdeltas):
         a, q0, r0 = self.generate('tall')
         for dtype in dts:
             q = q0.real.astype(dtype)
-            r = r0.real.astype(dtype)
+            with np.errstate(invalid="ignore"):
+                r = r0.real.astype(dtype)
             assert_raises(ValueError, qr_delete, q, r0, 0, 1, 'row')
             assert_raises(ValueError, qr_delete, q, r0, 0, 2, 'row')
             assert_raises(ValueError, qr_delete, q, r0, 0, 1, 'col')
@@ -1125,7 +1126,8 @@ class BaseQRinsert(BaseQRdeltas):
         a, q0, r0, u0 = self.generate('sqr', which='row')
         for dtype in dts:
             q = q0.real.astype(dtype)
-            r = r0.real.astype(dtype)
+            with np.errstate(invalid="ignore"):
+                r = r0.real.astype(dtype)
             u = u0.real.astype(dtype)
             assert_raises(ValueError, qr_insert, q, r0, u0, 0, 'row')
             assert_raises(ValueError, qr_insert, q, r0, u0, 0, 'col')
@@ -1558,7 +1560,8 @@ class BaseQRupdate(BaseQRdeltas):
         a, q0, r0, u0, v0 = self.generate('tall')
         for dtype in dts:
             q = q0.real.astype(dtype)
-            r = r0.real.astype(dtype)
+            with np.errstate(invalid="ignore"):
+                r = r0.real.astype(dtype)
             u = u0.real.astype(dtype)
             v = v0.real.astype(dtype)
             assert_raises(ValueError, qr_update, q, r0, u0, v0)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3241,11 +3241,13 @@ class _TestArithmetic:
 
         # check conversions
         for x in supported_dtypes:
-            A = self.__A.astype(x)
+            with np.errstate(invalid="ignore"):
+                A = self.__A.astype(x)
             Asp = self.spmatrix(A)
             for y in supported_dtypes:
                 if not np.issubdtype(y, np.complexfloating):
-                    B = self.__B.real.astype(y)
+                    with np.errstate(invalid="ignore"):
+                        B = self.__B.real.astype(y)
                 else:
                     B = self.__B.astype(y)
                 Bsp = self.spmatrix(B)
@@ -3280,13 +3282,15 @@ class _TestArithmetic:
                            self.__A @ self.__B.T)
 
         for x in supported_dtypes:
-            A = self.__A.astype(x)
+            with np.errstate(invalid="ignore"):
+                A = self.__A.astype(x)
             Asp = self.spmatrix(A)
             for y in supported_dtypes:
                 if np.issubdtype(y, np.complexfloating):
                     B = self.__B.astype(y)
                 else:
-                    B = self.__B.real.astype(y)
+                    with np.errstate(invalid="ignore"):
+                        B = self.__B.real.astype(y)
                 Bsp = self.spmatrix(B)
 
                 D1 = A @ B.T


### PR DESCRIPTION
* Attempts to deal with the ARM-specific portion of gh-17630 -- these issues appear to be the result of NumPy 1.24.0 change:
https://numpy.org/devdocs/release/1.24.0-notes.html#numpy-now-gives-floating-point-errors-in-casts

* I was able to reproduce and fix the issues in `scipy/sparse/tests/test_base` on an ARM node

* however, for `test_decomp_update` I actually saw more severe problems when working on a Cavium ThunderX2 B0 node; for the latter cases, I'll paste what I saw below for some of the representative failures, but for now I just tried to patch the less severe casting errors I see in the CI for those tests to see if it helps (I'm hoping that my own flavor of ARM + gcc-something-different OpenBLAS is just throwing things off locally and I can at least delay looking into that for now...)

```
FAILED scipy/linalg/tests/test_decomp_update.py::TestQRupdate_d::test_neg_strides_economic_rank_p - ValueError: array must not contain infs or NaNs
FAILED scipy/linalg/tests/test_decomp_update.py::TestQRupdate_d::test_neg_strides_rank_p - ValueError: array must not contain infs or NaNs
FAILED scipy/linalg/tests/test_decomp_update.py::TestQRupdate_d::test_non_itemsize_strides_rank_p - ValueError: array must not contain infs or NaNs
FAILED scipy/linalg/tests/test_decomp_update.py::TestQRupdate_d::test_non_native_byte_order_economic_rank_1 - ValueError: array must not contain infs or NaNs
FAILED scipy/linalg/tests/test_decomp_update.py::TestQRupdate_d::test_non_unit_strides_rank_p - ValueError: array must not contain infs or NaNs
FAILED scipy/linalg/tests/test_decomp_update.py::TestQRupdate_D::test_economic_rank_p - AssertionError:
FAILED scipy/linalg/tests/test_decomp_update.py::TestQRupdate_d::test_non_native_byte_order_rank_1 - ValueError: array must not contain infs or NaNs
FAILED scipy/linalg/tests/test_decomp_update.py::TestQRupdate_D::test_Mx1_economic_rank_p - AssertionError:
FAILED scipy/linalg/tests/test_decomp_update.py::TestQRupdate_D::test_economic_rank_1 - AssertionError:
```

* we'll see if the various ARM runs in CI agree with me here, to fix up the CI failures we currently see there