### PR TITLE
MAINT, TST: alpine/musl segfault shim

### DIFF
--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -1,3 +1,4 @@
+import platform
 import itertools
 import warnings
 
@@ -13,6 +14,7 @@ from numpy.testing import (assert_equal, assert_almost_equal, assert_,
 import pytest
 from pytest import raises as assert_raises
 
+from scipy._lib import _pep440
 from scipy.linalg import (solve, inv, det, lstsq, pinv, pinvh, norm,
                           solve_banded, solveh_banded, solve_triangular,
                           solve_circulant, circulant, LinAlgError, block_diag,
@@ -1125,6 +1127,11 @@ class TestLstsq:
                                           err_msg="driver: %s" % lapack_driver)
 
     def test_random_complex_exact(self):
+        if platform.system() != "Windows":
+            if _pep440.parse(np.__version__) >= _pep440.Version("1.24.0"):
+                libc_flavor = platform.libc_ver()[0]
+                if libc_flavor != "glibc":
+                    pytest.skip("segfault observed on alpine per gh-17630")
         for dtype in COMPLEX_DTYPES:
             for n in (20, 200):
                 for lapack_driver in TestLstsq.lapack_drivers:


### PR DESCRIPTION
* gh-17630 describes a segfault observed in Cirrus CI (alpine) in `test_random_complex_exact` with NumPy `1.24.0`; it was not reproducible locally in an `alpine` docker container with latest SciPy + NumPy `1.24.0` built from PyPI source tarball via `pip`

* this branch aims to avoid the issue with a very-scoped test skip--only when `glibc` was not used to buid the Python interpreter, and only when NumPy is at `1.24.0` or greater

* if this shim is not sufficient (i.e., we just run into another segfault elsewhere on Cirrus `alpine`), I suggest we just temporarily pin the NumPy version down in CI for that one job since I already confirmed it isn't reproducible in a docker `alpine` container and we don't ship binaries yet for this scenario I don't think

[skip azp] [skip actions] [skip circle]