### PR TITLE
MAINT: prepare for SciPy 1.10.0rc2

### DIFF
--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -372,6 +372,7 @@ Authors
 * Sebastian Berg (1)
 * Aaron Berk (1) +
 * boatwrong (1) +
+* boeleman (1) +
 * Jake Bowhay (50)
 * Matthew Brett (4)
 * Evgeni Burovski (93)
@@ -392,7 +393,7 @@ Authors
 * cmgodwin (1) +
 * Christopher Cowden (2) +
 * Henry Cuzco (2) +
-* Anirudh Dagar (10)
+* Anirudh Dagar (12)
 * Hans Dembinski (2) +
 * Jaiden di Lanzo (24) +
 * Felipe Dias (1) +
@@ -419,7 +420,7 @@ Authors
 * David Gilbertson (1) +
 * Ralf Gommers (251)
 * Marco Gorelli (2) +
-* Matt Haberland (381)
+* Matt Haberland (383)
 * Andrew Hawryluk (2) +
 * Christoph Hohnerlein (2) +
 * Loïc Houpert (2) +
@@ -471,7 +472,7 @@ Authors
 * Naoto Mizuno (2)
 * Shashaank N (1)
 * Pablo S Naharro (1) +
-* nboudrie (1) +
+* nboudrie (2) +
 * Andrew Nelson (52)
 * Nico Schlömer (1)
 * NiMlr (1) +
@@ -489,12 +490,12 @@ Authors
 * Ilhan Polat (6)
 * Akshita Prasanth (2) +
 * Sean Quinn (1)
-* Tyler Reddy (117)
+* Tyler Reddy (134)
 * Martin Reinecke (1)
 * Ned Richards (1)
 * Marie Roald (1) +
 * Sam Rosen (4) +
-* Pamphile Roy (103)
+* Pamphile Roy (105)
 * sabonerune (2) +
 * Atsushi Sakai (94)
 * Daniel Schmitz (27)
@@ -540,7 +541,7 @@ Authors
 * Egor Zemlyanoy (19)
 * Gavin Zhang (3) +
 
-A total of 180 people contributed to this release.
+A total of 181 people contributed to this release.
 People with a "+" by their names contributed a patch for the first time.
 This list of names is automatically generated, and may not be fully complete.
 
@@ -570,6 +571,7 @@ Issues closed for 1.10.0
 * `#9440 <https://github.com/scipy/scipy/issues/9440>`__: Unexpected successful optimization with minimize when number...
 * `#9451 <https://github.com/scipy/scipy/issues/9451>`__: Add shgo to optimize benchmarks
 * `#10737 <https://github.com/scipy/scipy/issues/10737>`__: Goodness of fit tests for distributions with unknown parameters
+* `#10911 <https://github.com/scipy/scipy/issues/10911>`__: scipy.optimize.minimize_scalar does not automatically select...
 * `#11026 <https://github.com/scipy/scipy/issues/11026>`__: rv_discrete.interval returning wrong values for alpha = 1
 * `#11053 <https://github.com/scipy/scipy/issues/11053>`__: scipy.stats: Allow specifying inverse-variance matrix to multivariate_normal
 * `#11131 <https://github.com/scipy/scipy/issues/11131>`__: DOC: stats.fisher_exact does not match R functionality for \`oddsratio\`...
@@ -682,6 +684,7 @@ Issues closed for 1.10.0
 * `#17468 <https://github.com/scipy/scipy/issues/17468>`__: Weird errors with running the tests \`scipy.stats.tests.test_distributions\`...
 * `#17523 <https://github.com/scipy/scipy/issues/17523>`__: BUG: \`[source]\` button in the docs sending to the wrong place
 * `#17578 <https://github.com/scipy/scipy/issues/17578>`__: TST, BLD, CI: 1.10.0rc1 wheel build/test failures
+* `#17619 <https://github.com/scipy/scipy/issues/17619>`__: BUG: core dump when calling scipy.optimize.linprog
 
 ************************
 Pull requests for 1.10.0
@@ -1158,6 +1161,7 @@ Pull requests for 1.10.0
 * `#17439 <https://github.com/scipy/scipy/pull/17439>`__: DOC: Improve example for uniform_direction distribution
 * `#17446 <https://github.com/scipy/scipy/pull/17446>`__: MAINT: stats.gaussian_kde: error early if n_features > n_data
 * `#17447 <https://github.com/scipy/scipy/pull/17447>`__: MAINT: optimize.fminbound/minimize_scalar: add references, distinguish...
+* `#17448 <https://github.com/scipy/scipy/pull/17448>`__: MAINT: optimize.minimize_scalar: always acknowledge 'bounds'...
 * `#17449 <https://github.com/scipy/scipy/pull/17449>`__: MAINT: remove remaining occurrences of unicode
 * `#17457 <https://github.com/scipy/scipy/pull/17457>`__: DOC: Double Integral Example Typo
 * `#17466 <https://github.com/scipy/scipy/pull/17466>`__: BUG: stats: Fix for gh-17444.
@@ -1188,3 +1192,11 @@ Pull requests for 1.10.0
 * `#17569 <https://github.com/scipy/scipy/pull/17569>`__: MAINT: version bounds for 1.10.0rc1/relnotes fixes
 * `#17579 <https://github.com/scipy/scipy/pull/17579>`__: Revert "ENH: stats.ks_2samp: Pythranize remaining exact p-value...
 * `#17580 <https://github.com/scipy/scipy/pull/17580>`__: CI: native cp38-macosx_arm64 [wheel build][skip azp][skip circle][ski…
+* `#17583 <https://github.com/scipy/scipy/pull/17583>`__: MAINT: 1.10.0rc1 backports round 2
+* `#17591 <https://github.com/scipy/scipy/pull/17591>`__: MAINT: stats.pearsonr: raise error for complex input
+* `#17600 <https://github.com/scipy/scipy/pull/17600>`__: DOC: update version switcher for 1.10
+* `#17611 <https://github.com/scipy/scipy/pull/17611>`__: MAINT: Update ascent.dat file hash
+* `#17614 <https://github.com/scipy/scipy/pull/17614>`__: MAINT: optimize.milp: don't warn about \`mip_rel_gap\` option
+* `#17627 <https://github.com/scipy/scipy/pull/17627>`__: MAINT: Cast \`datasets.ascent\` image to float64
+* `#17634 <https://github.com/scipy/scipy/pull/17634>`__: MAINT: casting errstate for NumPy 1.24
+* `#17638 <https://github.com/scipy/scipy/pull/17638>`__: MAINT, TST: alpine/musl segfault shim

--- a/doc/source/tutorial/signal.rst
+++ b/doc/source/tutorial/signal.rst
@@ -362,7 +362,7 @@ which is often used for blurring.
    >>> from scipy import signal, datasets
    >>> import matplotlib.pyplot as plt
 
-   >>> image = datasets.ascent()
+   >>> image = np.asarray(datasets.ascent(), np.float64)
    >>> w = signal.windows.gaussian(51, 10.0)
    >>> image_new = signal.sepfir2d(image, w, w)
 

--- a/scipy/datasets/_registry.py
+++ b/scipy/datasets/_registry.py
@@ -6,7 +6,7 @@
 # To generate the SHA256 hash, use the command
 # openssl sha256 <filename>
 registry = {
-    "ascent.dat": "e8a84939484463ab8051aedc5b40aa262ab33a91d6458a6cd13c6a1cad5a023d",
+    "ascent.dat": "03ce124c1afc880f87b55f6b061110e2e1e939679184f5614e38dacc6c1957e2",
     "ecg.dat": "f20ad3365fb9b7f845d0e5c48b6fe67081377ee466c3a220b7f69f35c8958baf",
     "face.dat": "9d8b0b4d081313e2b485748c770472e5a95ed1738146883d84c7030493e82886"
 }

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -1,3 +1,4 @@
+import platform
 import itertools
 import warnings
 
@@ -13,6 +14,7 @@ from numpy.testing import (assert_equal, assert_almost_equal, assert_,
 import pytest
 from pytest import raises as assert_raises
 
+from scipy._lib import _pep440
 from scipy.linalg import (solve, inv, det, lstsq, pinv, pinvh, norm,
                           solve_banded, solveh_banded, solve_triangular,
                           solve_circulant, circulant, LinAlgError, block_diag,
@@ -1132,6 +1134,11 @@ class TestLstsq:
                                           err_msg="driver: %s" % lapack_driver)
 
     def test_random_complex_exact(self):
+        if platform.system() != "Windows":
+            if _pep440.parse(np.__version__) >= _pep440.Version("1.24.0"):
+                libc_flavor = platform.libc_ver()[0]
+                if libc_flavor != "glibc":
+                    pytest.skip("segfault observed on alpine per gh-17630")
         for dtype in COMPLEX_DTYPES:
             for n in (20, 200):
                 for lapack_driver in TestLstsq.lapack_drivers:

--- a/scipy/linalg/tests/test_decomp_update.py
+++ b/scipy/linalg/tests/test_decomp_update.py
@@ -581,7 +581,8 @@ class BaseQRdelete(BaseQRdeltas):
         a, q0, r0 = self.generate('tall')
         for dtype in dts:
             q = q0.real.astype(dtype)
-            r = r0.real.astype(dtype)
+            with np.errstate(invalid="ignore"):
+                r = r0.real.astype(dtype)
             assert_raises(ValueError, qr_delete, q, r0, 0, 1, 'row')
             assert_raises(ValueError, qr_delete, q, r0, 0, 2, 'row')
             assert_raises(ValueError, qr_delete, q, r0, 0, 1, 'col')
@@ -1125,7 +1126,8 @@ class BaseQRinsert(BaseQRdeltas):
         a, q0, r0, u0 = self.generate('sqr', which='row')
         for dtype in dts:
             q = q0.real.astype(dtype)
-            r = r0.real.astype(dtype)
+            with np.errstate(invalid="ignore"):
+                r = r0.real.astype(dtype)
             u = u0.real.astype(dtype)
             assert_raises(ValueError, qr_insert, q, r0, u0, 0, 'row')
             assert_raises(ValueError, qr_insert, q, r0, u0, 0, 'col')
@@ -1558,7 +1560,8 @@ class BaseQRupdate(BaseQRdeltas):
         a, q0, r0, u0, v0 = self.generate('tall')
         for dtype in dts:
             q = q0.real.astype(dtype)
-            r = r0.real.astype(dtype)
+            with np.errstate(invalid="ignore"):
+                r = r0.real.astype(dtype)
             u = u0.real.astype(dtype)
             v = v0.real.astype(dtype)
             assert_raises(ValueError, qr_update, q, r0, u0, v0)

--- a/scipy/optimize/_milp.py
+++ b/scipy/optimize/_milp.py
@@ -130,7 +130,8 @@ def _milp_iv(c, integrality, bounds, constraints, options):
 
     # options IV
     options = options or {}
-    supported_options = {'disp', 'presolve', 'time_limit', 'node_limit'}
+    supported_options = {'disp', 'presolve', 'time_limit', 'node_limit',
+                         'mip_rel_gap'}
     unsupported_options = set(options).difference(supported_options)
     if unsupported_options:
         message = (f"Unrecognized options detected: {unsupported_options}. "
@@ -236,6 +237,10 @@ def milp(c, *, integrality=None, bounds=None, constraints=None, options=None):
         time_limit : float, optional
             The maximum number of seconds allotted to solve the problem.
             Default is no time limit.
+        mip_rel_gap : float, optional
+            Termination criterion for MIP solver: solver will terminate when
+            the gap between the primal objective value and the dual objective
+            bound, scaled by the primal objective value, is <= mip_rel_gap.
 
     Returns
     -------
@@ -276,8 +281,8 @@ def milp(c, *, integrality=None, bounds=None, constraints=None, options=None):
             The MILP solver's final estimate of the lower bound on the optimal
             solution.
         mip_gap : float
-            The difference between the final objective function value and the
-            final dual bound.
+            The difference between the primal objective value and the dual
+            objective bound, scaled by the primal objective value.
 
     Notes
     -----

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -733,7 +733,7 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
 
 
 def minimize_scalar(fun, bracket=None, bounds=None, args=(),
-                    method='brent', tol=None, options=None):
+                    method=None, tol=None, options=None):
     """Minimization of scalar function of one variable.
 
     Parameters
@@ -749,8 +749,8 @@ def minimize_scalar(fun, bracket=None, bounds=None, args=(),
         bracket search (see `bracket`); it doesn't always mean that the
         obtained solution will satisfy ``a <= x <= c``.
     bounds : sequence, optional
-        For method 'bounded', `bounds` is mandatory and must have two items
-        corresponding to the optimization bounds.
+        For method 'bounded', `bounds` is mandatory and must have two finite
+        items corresponding to the optimization bounds.
     args : tuple, optional
         Extra arguments passed to the objective function.
     method : str or callable, optional
@@ -761,6 +761,7 @@ def minimize_scalar(fun, bracket=None, bounds=None, args=(),
             - :ref:`Golden <optimize.minimize_scalar-golden>`
             - custom - a callable object (added in version 0.14.0), see below
 
+        Default is "Bounded" if bounds are provided and "Brent" otherwise.
         See the 'Notes' section for details of each solver.
 
     tol : float, optional
@@ -794,7 +795,8 @@ def minimize_scalar(fun, bracket=None, bounds=None, args=(),
     Notes
     -----
     This section describes the available solvers that can be selected by the
-    'method' parameter. The default method is *Brent*.
+    'method' parameter. The default method is the ``"Bounded"`` Brent method if
+    `bounds` are passed and unbounded ``"Brent"`` otherwise.
 
     Method :ref:`Brent <optimize.minimize_scalar-brent>` uses Brent's
     algorithm [1]_ to find a local minimum.  The algorithm uses inverse
@@ -873,10 +875,16 @@ def minimize_scalar(fun, bracket=None, bounds=None, args=(),
 
     if callable(method):
         meth = "_custom"
+    elif method is None:
+        meth = 'brent' if bounds is None else 'bounded'
     else:
         meth = method.lower()
     if options is None:
         options = {}
+
+    if bounds is not None and meth in {'brent', 'golden'}:
+        message = f"Use of `bounds` is incompatible with 'method={method}'."
+        raise ValueError(message)
 
     if tol is not None:
         options = dict(options)

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -222,11 +222,11 @@ def _check_unknown_options(unknown_options):
         warnings.warn("Unknown solver options: %s" % msg, OptimizeWarning, 4)
 
 
-def is_array_scalar(x):
-    """Test whether `x` is either a scalar or an array scalar.
+def is_finite_scalar(x):
+    """Test whether `x` is either a finite scalar or a finite array scalar.
 
     """
-    return np.size(x) == 1
+    return np.size(x) == 1 and np.isfinite(x)
 
 
 _epsilon = sqrt(np.finfo(float).eps)
@@ -2087,7 +2087,7 @@ def fminbound(func, x1, x2, args=(), xtol=1e-5, maxfun=500,
     func : callable f(x,*args)
         Objective function to be minimized (must accept and return scalars).
     x1, x2 : float or array scalar
-        The optimization bounds.
+        Finite optimization bounds.
     args : tuple, optional
         Extra arguments passed to function.
     xtol : float, optional
@@ -2193,9 +2193,9 @@ def _minimize_scalar_bounded(func, bounds, args=(),
         raise ValueError('bounds must have two elements.')
     x1, x2 = bounds
 
-    if not (is_array_scalar(x1) and is_array_scalar(x2)):
-        raise ValueError("Optimization bounds must be scalars"
-                         " or array scalars.")
+    if not (is_finite_scalar(x1) and is_finite_scalar(x2)):
+        raise ValueError("Optimization bounds must be finite scalars.")
+
     if x1 > x2:
         raise ValueError("The lower bound exceeds the upper bound.")
 

--- a/scipy/optimize/tests/test_milp.py
+++ b/scipy/optimize/tests/test_milp.py
@@ -338,3 +338,33 @@ def test_three_constraints_16878():
     assert res1.success and res2.success
     assert_allclose(res1.x, ref.x)
     assert_allclose(res2.x, ref.x)
+
+
+@pytest.mark.xslow
+def test_mip_rel_gap_passdown():
+    # Solve problem with decreasing mip_gap to make sure mip_rel_gap decreases
+    # Adapted from test_linprog::TestLinprogHiGHSMIP::test_mip_rel_gap_passdown
+    # MIP taken from test_mip_6 above
+    A_eq = np.array([[22, 13, 26, 33, 21, 3, 14, 26],
+                     [39, 16, 22, 28, 26, 30, 23, 24],
+                     [18, 14, 29, 27, 30, 38, 26, 26],
+                     [41, 26, 28, 36, 18, 38, 16, 26]])
+    b_eq = np.array([7872, 10466, 11322, 12058])
+    c = np.array([2, 10, 13, 17, 7, 5, 7, 3])
+
+    mip_rel_gaps = [0.25, 0.01, 0.001]
+    sol_mip_gaps = []
+    for mip_rel_gap in mip_rel_gaps:
+        res = milp(c=c, bounds=(0, np.inf), constraints=(A_eq, b_eq, b_eq),
+                   integrality=True, options={"mip_rel_gap": mip_rel_gap})
+        # assert that the solution actually has mip_gap lower than the
+        # required mip_rel_gap supplied
+        assert res.mip_gap <= mip_rel_gap
+        # check that `res.mip_gap` is as defined in the documentation
+        assert res.mip_gap == (res.fun - res.mip_dual_bound)/res.fun
+        sol_mip_gaps.append(res.mip_gap)
+
+    # make sure that the mip_rel_gap parameter is actually doing something
+    # check that differences between solution gaps are declining
+    # monotonically with the mip_rel_gap parameter.
+    assert np.all(np.diff(sol_mip_gaps) < 0)

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -1632,7 +1632,7 @@ class TestOptimizeScalar:
         assert_raises(ValueError, optimize.fminbound, self.fun, 5, 1)
 
     def test_fminbound_scalar(self):
-        with pytest.raises(ValueError, match='.*must be scalar.*'):
+        with pytest.raises(ValueError, match='.*must be finite scalars.*'):
             optimize.fminbound(self.fun, np.zeros((1, 2)), 1)
 
         x = optimize.fminbound(self.fun, 1, np.array(5))
@@ -1750,8 +1750,8 @@ class TestOptimizeScalar:
 
     @pytest.mark.parametrize('method', ['brent', 'bounded', 'golden'])
     def test_result_attributes(self, method):
-        result = optimize.minimize_scalar(self.fun, method=method,
-                                          bounds=[-10, 10])
+        kwargs = {"bounds": [-10, 10]} if method == 'bounded' else {}
+        result = optimize.minimize_scalar(self.fun, method=method, **kwargs)
         assert hasattr(result, "x")
         assert hasattr(result, "success")
         assert hasattr(result, "message")
@@ -1782,10 +1782,42 @@ class TestOptimizeScalar:
             sup.filter(RuntimeWarning, ".*does not use gradient.*")
 
             count = [0]
+
+            kwargs = {"bounds": bounds} if method == 'bounded' else {}
             sol = optimize.minimize_scalar(func, bracket=bracket,
-                                           bounds=bounds, method=method,
+                                           **kwargs, method=method,
                                            options=dict(maxiter=20))
             assert_equal(sol.success, False)
+
+    def test_minimize_scalar_defaults_gh10911(self):
+        # Previously, bounds were silently ignored unless `method='bounds'`
+        # was chosen. See gh-10911. Check that this is no longer the case.
+        def f(x):
+            return x**2
+
+        res = optimize.minimize_scalar(f)
+        assert_allclose(res.x, 0, atol=1e-8)
+
+        res = optimize.minimize_scalar(f, bounds=(1, 100),
+                                       options={'xatol': 1e-10})
+        assert_allclose(res.x, 1)
+
+    def test_minimize_non_finite_bounds_gh10911(self):
+        # Previously, minimize_scalar misbehaved with infinite bounds.
+        # See gh-10911. Check that it now raises an error, instead.
+        msg = "Optimization bounds must be finite scalars."
+        with pytest.raises(ValueError, match=msg):
+            optimize.minimize_scalar(np.sin, bounds=(1, np.inf))
+        with pytest.raises(ValueError, match=msg):
+            optimize.minimize_scalar(np.sin, bounds=(np.nan, 1))
+
+    @pytest.mark.parametrize("method", ['brent', 'golden'])
+    def test_minimize_unbounded_method_with_bounds_gh10911(self, method):
+        # Previously, `bounds` were silently ignored when `method='brent'` or
+        # `method='golden'`. See gh-10911. Check that error is now raised.
+        msg = "Use of `bounds` is incompatible with..."
+        with pytest.raises(ValueError, match=msg):
+            optimize.minimize_scalar(np.sin, method=method, bounds=(1, 2))
 
 
 def test_brent_negative_tolerance():

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3241,11 +3241,13 @@ class _TestArithmetic:
 
         # check conversions
         for x in supported_dtypes:
-            A = self.__A.astype(x)
+            with np.errstate(invalid="ignore"):
+                A = self.__A.astype(x)
             Asp = self.spmatrix(A)
             for y in supported_dtypes:
                 if not np.issubdtype(y, np.complexfloating):
-                    B = self.__B.real.astype(y)
+                    with np.errstate(invalid="ignore"):
+                        B = self.__B.real.astype(y)
                 else:
                     B = self.__B.astype(y)
                 Bsp = self.spmatrix(B)
@@ -3280,13 +3282,15 @@ class _TestArithmetic:
                            self.__A @ self.__B.T)
 
         for x in supported_dtypes:
-            A = self.__A.astype(x)
+            with np.errstate(invalid="ignore"):
+                A = self.__A.astype(x)
             Asp = self.spmatrix(A)
             for y in supported_dtypes:
                 if np.issubdtype(y, np.complexfloating):
                     B = self.__B.astype(y)
                 else:
-                    B = self.__B.real.astype(y)
+                    with np.errstate(invalid="ignore"):
+                        B = self.__B.real.astype(y)
                 Bsp = self.spmatrix(B)
 
                 D1 = A @ B.T

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -4413,6 +4413,10 @@ def pearsonr(x, y, *, alternative='two-sided'):
     x = np.asarray(x)
     y = np.asarray(y)
 
+    if (np.issubdtype(x.dtype, np.complexfloating)
+            or np.issubdtype(y.dtype, np.complexfloating)):
+        raise ValueError('This function does not support complex data')
+
     # If an input is constant, the correlation coefficient is not defined.
     if (x == x[0]).all() or (y == y[0]).all():
         msg = ("An input array is constant; the correlation coefficient "

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -477,6 +477,13 @@ class TestCorrPearsonr:
         y = [2]
         assert_raises(ValueError, stats.pearsonr, x, y)
 
+    def test_complex_data(self):
+        x = [-1j, -2j, -3.0j]
+        y = [-1j, -2j, -3.0j]
+        message = 'This function does not support complex data'
+        with pytest.raises(ValueError, match=message):
+            stats.pearsonr(x, y)
+
 
 class TestFisherExact:
     """Some tests to show that fisher_exact() works correctly.


### PR DESCRIPTION
* backports included:
  - gh-17448
  - gh-17591
  - gh-17611
  - gh-17614
  - gh-17627
  - gh-17634
  - gh-17638
* update the release notes accordingly
* there was a bit of a delay here because I wanted to assess the situation with the just-released NumPy `1.24.0` to improve our long-term support prospects with future NumPy releases; although I probably missed some things, as far as CI is concerned we seem to be doing pretty well with the latest stable release of NumPy, with a few minor shims in the backports above
* ~the latest `main` branch of NumPy is another story, there appear to be some SIMD issues, and possibly other things that I don't think I'll be able to patch over easily during the short-term release cycle at least--one example I bisected out from one our test failures is here: https://github.com/numpy/numpy/issues/22845~
  - ~I think I'd vote for letting that `main` branch evolve with fixes for a while and just keep moving forward--we'll probably accept some backports in future patch releases, etc., if they help NumPy compatibility in cases where there are no NumPy bugs but rather changes in behavior~