### PR TITLE
MAINT: stats.rankdata: ensure consistent shape handling

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -9441,9 +9441,7 @@ def rankdata(a, method='average', *, axis=None, nan_policy='propagate'):
             nans because ranks relative to nans in the input are undefined.
             When `nan_policy` is 'omit', nans in `a` are ignored when ranking
             the other values, and the corresponding locations of the output
-            are nan. This behavior is the default because it is intuitive and
-            compatible with the behavior before the `nan_policy` parameter
-            was introduced.
+            are nan.
 
         .. versionadded:: 1.10
 
@@ -9499,15 +9497,15 @@ def rankdata(a, method='average', *, axis=None, nan_policy='propagate'):
         return np.apply_along_axis(rankdata, axis, a, method,
                                    nan_policy=nan_policy)
 
-    contains_nan, nan_policy = _contains_nan(a, nan_policy)
+    arr = np.ravel(a)
+    contains_nan, nan_policy = _contains_nan(arr, nan_policy)
     nan_indexes = None
     if contains_nan:
         if nan_policy == 'omit':
-            nan_indexes = np.isnan(a)
+            nan_indexes = np.isnan(arr)
         if nan_policy == 'propagate':
-            return np.full_like(a, np.nan)
+            return np.full_like(arr, np.nan)
 
-    arr = np.ravel(a)
     algo = 'mergesort' if method == 'ordinal' else 'quicksort'
     sorter = np.argsort(arr, kind=algo)
 

--- a/scipy/stats/tests/test_rank.py
+++ b/scipy/stats/tests/test_rank.py
@@ -224,13 +224,16 @@ class TestRankData:
 
         assert_array_equal(res, res0)
 
-    def test_nan_policy_omit_2d_flatten(self):
-        # 2 2d-array test
+    def test_nan_policy_2d_axis_none(self):
+        # 2 2d-array test with axis=None
         data = [[0, np.nan, 3],
                 [4, 2, np.nan],
                 [1, 2, 2]]
         assert_array_equal(rankdata(data, axis=None, nan_policy='omit'),
                            [1., np.nan, 6., 7., 4., np.nan, 2., 4., 4.])
+        assert_array_equal(rankdata(data, axis=None, nan_policy='propagate'),
+                           [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
+                            np.nan, np.nan, np.nan])
 
     def test_nan_policy_raise(self):
         # 1 1d-array test

--- a/scipy/stats/tests/test_rank.py
+++ b/scipy/stats/tests/test_rank.py
@@ -230,7 +230,7 @@ class TestRankData:
                 [4, 2, np.nan],
                 [1, 2, 2]]
         assert_array_equal(rankdata(data, axis=None, nan_policy='omit'),
-                           [ 1., np.nan,  6.,  7.,  4., np.nan,  2.,  4.,  4.])
+                           [1., np.nan, 6., 7., 4., np.nan, 2., 4., 4.])
 
     def test_nan_policy_raise(self):
         # 1 1d-array test

--- a/scipy/stats/tests/test_rank.py
+++ b/scipy/stats/tests/test_rank.py
@@ -224,6 +224,14 @@ class TestRankData:
 
         assert_array_equal(res, res0)
 
+    def test_nan_policy_omit_2d_flatten(self):
+        # 2 2d-array test
+        data = [[0, np.nan, 3],
+                [4, 2, np.nan],
+                [1, 2, 2]]
+        assert_array_equal(rankdata(data, axis=None, nan_policy='omit'),
+                           [ 1., np.nan,  6.,  7.,  4., np.nan,  2.,  4.,  4.])
+
     def test_nan_policy_raise(self):
         # 1 1d-array test
         data = [0, 2, 3, -2, np.nan, np.nan]


### PR DESCRIPTION
Playing with the release candidate I noticed some inconsistencies in shape handling
for rankdata when `axis=None`.

For `omit`, the nan indices were taken before the ravel step, so the function doesn't
work. I have fixed this and added a test.

```
In [2]: data = [[0, np.nan, 3],
    ...:         [4, 2, np.nan],
    ...:         [1, 2, 2]]

In [3]: scipy.stats.rankdata(data, nan_policy="omit")
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
Cell In[22], line 1
----> 1 scipy.stats.rankdata(data, nan_policy="omit")

File ~/bin/miniconda3/envs/releases/lib/python3.10/site-packages/scipy/stats/_stats_py.py:9537, in rankdata(a, method, axis, nan_policy)
   9535 if nan_indexes is not None:
   9536     result = result.astype('float64')
-> 9537     result[nan_indexes] = np.nan
   9539 return result

IndexError: too many indices for array: array is 1-dimensional, but 2 were indexed
```

For `propagate` the returned output has the original shape instead of being flattened,
which is inconsistent with what happened in previous versions and with the description for
the `axis` parameter.

I have also removed a sentence in the nan_policy description that was leftover from the
`omit` being the default policy.
