### PR TITLE
MAINT: pybind11 win exclusion

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -46,7 +46,7 @@ jobs:
           gfortran --version
       - name: pip-packages
         run: |
-          pip install numpy==1.22.2 cython pybind11 pythran meson ninja pytest pytest-xdist pytest-timeout pooch
+          pip install numpy==1.22.2 cython "pybind11!=2.10.2" pythran meson ninja pytest pytest-xdist pytest-timeout pooch
       - name: openblas-libs
         run: |
           # Download and install pre-built OpenBLAS library

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = 'mesonpy'
 requires = [
     "meson-python>=0.9.0",
     "Cython>=0.29.32",
-    "pybind11>=2.10.0",
+    "pybind11>=2.10.0,!=2.10.2",
     "pythran>=0.12.0",
     # `wheel` is needed for non-isolated builds, given that `meson-python`
     # doesn't list it as a runtime requirement (at least in 0.5.0)


### PR DESCRIPTION
Fixes #17644 (see detailed analysis over there..)

* I confirmed locally that `cibuildwheel --platform windows` passes with `pybind11` `2.10.2` excluded, whereas we currently experience a segfault that is blocking the release process on Windows

* I suspect we may be able to restrict the exclusion to Windows only in `pyproject.toml`, but I think I'm inclined to just keep the syntax simple there if folks are "ok" with this? This also assumes that `pybind11` team agrees this is a bug on their end and that the next bug fix release will deal with the issue. I'll open an issue over there shortly.

* this should also stop our Windows meson job from segfaulting for the same reason