### PR TITLE
MAINT: 1.10.0rc2 backports, round two

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -46,7 +46,7 @@ jobs:
           gfortran --version
       - name: pip-packages
         run: |
-          pip install numpy==1.22.2 cython pybind11 pythran meson ninja pytest pytest-xdist pytest-timeout pooch
+          pip install numpy==1.22.2 cython "pybind11!=2.10.2" pythran meson ninja pytest pytest-xdist pytest-timeout pooch
       - name: openblas-libs
         run: |
           # Download and install pre-built OpenBLAS library

--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -361,6 +361,7 @@ Authors
 * Name (commits)
 * h-vetinari (10)
 * Jelle Aalbers (1)
+* Oriol Abril-Pla (1) +
 * Alan-Hung (1) +
 * Tania Allard (7)
 * Oren Amsalem (1) +
@@ -490,7 +491,7 @@ Authors
 * Ilhan Polat (6)
 * Akshita Prasanth (2) +
 * Sean Quinn (1)
-* Tyler Reddy (134)
+* Tyler Reddy (142)
 * Martin Reinecke (1)
 * Ned Richards (1)
 * Marie Roald (1) +
@@ -541,7 +542,7 @@ Authors
 * Egor Zemlyanoy (19)
 * Gavin Zhang (3) +
 
-A total of 181 people contributed to this release.
+A total of 182 people contributed to this release.
 People with a "+" by their names contributed a patch for the first time.
 This list of names is automatically generated, and may not be fully complete.
 
@@ -685,6 +686,8 @@ Issues closed for 1.10.0
 * `#17523 <https://github.com/scipy/scipy/issues/17523>`__: BUG: \`[source]\` button in the docs sending to the wrong place
 * `#17578 <https://github.com/scipy/scipy/issues/17578>`__: TST, BLD, CI: 1.10.0rc1 wheel build/test failures
 * `#17619 <https://github.com/scipy/scipy/issues/17619>`__: BUG: core dump when calling scipy.optimize.linprog
+* `#17644 <https://github.com/scipy/scipy/issues/17644>`__: BUG: 1.10.0rc2 Windows wheel tests runs all segfault
+* `#17650 <https://github.com/scipy/scipy/issues/17650>`__: BUG: Assertion failed when using HiGHS
 
 ************************
 Pull requests for 1.10.0
@@ -1200,3 +1203,6 @@ Pull requests for 1.10.0
 * `#17627 <https://github.com/scipy/scipy/pull/17627>`__: MAINT: Cast \`datasets.ascent\` image to float64
 * `#17634 <https://github.com/scipy/scipy/pull/17634>`__: MAINT: casting errstate for NumPy 1.24
 * `#17638 <https://github.com/scipy/scipy/pull/17638>`__: MAINT, TST: alpine/musl segfault shim
+* `#17640 <https://github.com/scipy/scipy/pull/17640>`__: MAINT: prepare for SciPy 1.10.0rc2
+* `#17645 <https://github.com/scipy/scipy/pull/17645>`__: MAINT: stats.rankdata: ensure consistent shape handling
+* `#17653 <https://github.com/scipy/scipy/pull/17653>`__: MAINT: pybind11 win exclusion

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = 'mesonpy'
 requires = [
     "meson-python>=0.11.0,<0.12.0",
     "Cython>=0.29.32,<3.0",
-    "pybind11>=2.10.0,<2.11.0",
+    "pybind11>=2.10.0,!=2.10.2,<2.11.0",
     "pythran>=0.12.0,<0.13.0",
     # `wheel` is needed for non-isolated builds, given that `meson-python`
     # doesn't list it as a runtime requirement (at least in 0.5.0)

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -9441,9 +9441,7 @@ def rankdata(a, method='average', *, axis=None, nan_policy='propagate'):
             nans because ranks relative to nans in the input are undefined.
             When `nan_policy` is 'omit', nans in `a` are ignored when ranking
             the other values, and the corresponding locations of the output
-            are nan. This behavior is the default because it is intuitive and
-            compatible with the behavior before the `nan_policy` parameter
-            was introduced.
+            are nan.
 
         .. versionadded:: 1.10
 
@@ -9499,15 +9497,15 @@ def rankdata(a, method='average', *, axis=None, nan_policy='propagate'):
         return np.apply_along_axis(rankdata, axis, a, method,
                                    nan_policy=nan_policy)
 
-    contains_nan, nan_policy = _contains_nan(a, nan_policy)
+    arr = np.ravel(a)
+    contains_nan, nan_policy = _contains_nan(arr, nan_policy)
     nan_indexes = None
     if contains_nan:
         if nan_policy == 'omit':
-            nan_indexes = np.isnan(a)
+            nan_indexes = np.isnan(arr)
         if nan_policy == 'propagate':
-            return np.full_like(a, np.nan)
+            return np.full_like(arr, np.nan)
 
-    arr = np.ravel(a)
     algo = 'mergesort' if method == 'ordinal' else 'quicksort'
     sorter = np.argsort(arr, kind=algo)
 

--- a/scipy/stats/tests/test_rank.py
+++ b/scipy/stats/tests/test_rank.py
@@ -224,6 +224,17 @@ class TestRankData:
 
         assert_array_equal(res, res0)
 
+    def test_nan_policy_2d_axis_none(self):
+        # 2 2d-array test with axis=None
+        data = [[0, np.nan, 3],
+                [4, 2, np.nan],
+                [1, 2, 2]]
+        assert_array_equal(rankdata(data, axis=None, nan_policy='omit'),
+                           [1., np.nan, 6., 7., 4., np.nan, 2., 4., 4.])
+        assert_array_equal(rankdata(data, axis=None, nan_policy='propagate'),
+                           [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
+                            np.nan, np.nan, np.nan])
+
     def test_nan_policy_raise(self):
         # 1 1d-array test
         data = [0, 2, 3, -2, np.nan, np.nan]


### PR DESCRIPTION
Include the backports below and update the release notes accordingly.

- gh-17645
- gh-17653

The RC2 tag has been deleted locally so I can just re-tag once this is ready/merged.