### PR TITLE
MAINT: optimize.newton: converged=False when secant has zero slope

### DIFF
--- a/scipy/optimize/_zeros_py.py
+++ b/scipy/optimize/_zeros_py.py
@@ -349,7 +349,7 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
                     warnings.warn(msg, RuntimeWarning)
                 p = (p1 + p0) / 2.0
                 return _results_select(
-                    full_output, (p, funcalls, itr + 1, _ECONVERGED))
+                    full_output, (p, funcalls, itr + 1, _ECONVERR))
             else:
                 if abs(q1) > abs(q0):
                     p = (-q0 / q1 * p1 + p0) / (1 - q0 / q1)

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -824,13 +824,15 @@ def test_gh_14486_converged_false():
     assert not res.converged
     assert res.flag == 'convergence error'
 
-    # This test case doesn't fail to converge for the vectorized version of
-    # newton, but this one from `def test_zero_der_nz_dp()` does.
+    # In the vectorized version of `newton`, the secant method doesn't 
+    # encounter zero slope in the problem above. Here's a problem where
+    # it does. Check that it reports failure to converge.
     dx = np.finfo(float).eps ** 0.33
     p0 = (200.0 - dx) / (2.0 + dx)
     with pytest.warns(RuntimeWarning, match='RMS of'):
         res = newton(lambda y: (y - 100.0)**2, x0=[p0]*2, full_output=True)
     assert_equal(res.converged, [False, False])
+    assert_equal(res.zero_der, [True, True])
 
 
 @pytest.mark.parametrize('solver_name',

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -824,16 +824,6 @@ def test_gh_14486_converged_false():
     assert not res.converged
     assert res.flag == 'convergence error'
 
-    # In the vectorized version of `newton`, the secant method doesn't 
-    # encounter zero slope in the problem above. Here's a problem where
-    # it does. Check that it reports failure to converge.
-    dx = np.finfo(float).eps ** 0.33
-    p0 = (200.0 - dx) / (2.0 + dx)
-    with pytest.warns(RuntimeWarning, match='RMS of'):
-        res = newton(lambda y: (y - 100.0)**2, x0=[p0]*2, full_output=True)
-    assert_equal(res.converged, [False, False])
-    assert_equal(res.zero_der, [True, True])
-
 
 @pytest.mark.parametrize('solver_name',
                          ['brentq', 'brenth', 'bisect', 'ridder', 'toms748'])


### PR DESCRIPTION
#### Reference issue
Closes gh-14486

#### What does this implement/fix?
gh-14486 reported that `scipy.optimize.newton`'s secant method reports success even when it fails to converge due to a secant with zero slope. This fixes the issue by implementing the proposed fix: replacing `_ECONVERGED` with `_ECONVERR`.