### PR TITLE
Fix undefined behavior within scipy.fft

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -46,7 +46,7 @@ jobs:
           gfortran --version
       - name: pip-packages
         run: |
-          pip install numpy==1.22.2 cython "pybind11!=2.10.2" pythran meson ninja pytest pytest-xdist pytest-timeout pooch
+          pip install numpy==1.22.2 cython pybind11 pythran meson ninja pytest pytest-xdist pytest-timeout pooch
       - name: openblas-libs
         run: |
           # Download and install pre-built OpenBLAS library

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -46,7 +46,7 @@ jobs:
           gfortran --version
       - name: pip-packages
         run: |
-          pip install numpy==1.22.2 cython pybind11 pythran meson ninja pytest pytest-xdist pytest-timeout pooch
+          pip install numpy==1.22.2 cython "pybind11!=2.10.2" pythran meson ninja pytest pytest-xdist pytest-timeout pooch
       - name: openblas-libs
         run: |
           # Download and install pre-built OpenBLAS library

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = 'mesonpy'
 requires = [
     "meson-python>=0.9.0",
     "Cython>=0.29.32",
-    "pybind11>=2.10.0",
+    "pybind11>=2.10.0,!=2.10.2",
     "pythran>=0.12.0",
     # `wheel` is needed for non-isolated builds, given that `meson-python`
     # doesn't list it as a runtime requirement (at least in 0.5.0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = 'mesonpy'
 requires = [
     "meson-python>=0.9.0",
     "Cython>=0.29.32",
-    "pybind11>=2.10.0,!=2.10.2",
+    "pybind11>=2.10.0",
     "pythran>=0.12.0",
     # `wheel` is needed for non-isolated builds, given that `meson-python`
     # doesn't list it as a runtime requirement (at least in 0.5.0)

--- a/scipy/fft/_pocketfft/pypocketfft.cxx
+++ b/scipy/fft/_pocketfft/pypocketfft.cxx
@@ -37,7 +37,6 @@ using clong = std::complex<ldbl_t>;
 using f32 = float;
 using f64 = double;
 using flong = ldbl_t;
-auto None = py::none();
 
 shape_t copy_shape(const py::array &arr)
   {
@@ -716,6 +715,8 @@ out : int
 PYBIND11_MODULE(pypocketfft, m)
   {
   using namespace pybind11::literals;
+
+  auto None = py::none();
 
   m.doc() = pypocketfft_DS;
   m.def("c2c", c2c, c2c_DS, "a"_a, "axes"_a=None, "forward"_a=true,


### PR DESCRIPTION
#### Reference issue
Closes #17644

#### What does this implement/fix?
scipy.fft currently triggers undefined behavior by calling Python functions before Python is initialized. 

This fixes that by moving the function call of py::none() into the module init function.

This also reverts https://github.com/scipy/scipy/pull/17653

CC @tylerjereddy 
