### PR TITLE
DOC: optimize.curve_fit: example output may vary

### DIFF
--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -779,7 +779,7 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
     overparameterized, calculate the condition number of the covariance matrix:
 
     >>> np.linalg.cond(pcov)
-    34.571092161547405
+    34.571092161547405  # may vary
 
     The value is small, so it does not raise much concern. If, however, we were
     to add a fourth parameter ``d`` to `func` with the same effect as ``a``:
@@ -787,7 +787,7 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
     >>> def func(x, a, b, c, d):
     ...     return a * d * np.exp(-b * x) + c  # a and d are redundant
     >>> popt, pcov = curve_fit(func, xdata, ydata)
-    >>> np.linalg.cond(pcov)
+    >>> np.linalg.cond(pcov)  # may vary
     1.13250718925596e+32
 
     Such a large value is cause for concern. The diagonal elements of the

--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -795,13 +795,13 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
     information:
 
     >>> np.diag(pcov)
-    array([1.48814742e+29, 3.78596560e-02, 5.39253738e-03, 2.76417220e+28])
+    array([1.48814742e+29, 3.78596560e-02, 5.39253738e-03, 2.76417220e+28])  # may vary
 
     Note that the first and last terms are much larger than the other elements,
     suggesting that the optimal values of these parameters are ambiguous and
     that only one of these parameters is needed in the model.
 
-    """
+    """  # noqa
     if p0 is None:
         # determine number of parameters by inspecting the function
         sig = _getfullargspec(f)

--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -787,8 +787,8 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
     >>> def func(x, a, b, c, d):
     ...     return a * d * np.exp(-b * x) + c  # a and d are redundant
     >>> popt, pcov = curve_fit(func, xdata, ydata)
-    >>> np.linalg.cond(pcov)  # may vary
-    1.13250718925596e+32
+    >>> np.linalg.cond(pcov)
+    1.13250718925596e+32  # may vary
 
     Such a large value is cause for concern. The diagonal elements of the
     covariance matrix, which is related to uncertainty of the fit, gives more


### PR DESCRIPTION
#### Reference issue
gh-17553

#### What does this implement/fix?
Since gh-17553 merged, refguide check as been failing in main. This PR is intended to fix the problem.

#### Additional information
The condition number of `pcov` in the example is very high (as that is the point of the example), so it's not surprising that it may vary a bit.
