### PR TITLE
DOC: mention inaccuracy of curve_fit result `pcov`

### DIFF
--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -649,9 +649,12 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
         Optimal values for the parameters so that the sum of the squared
         residuals of ``f(xdata, *popt) - ydata`` is minimized.
     pcov : 2-D array
-        The estimated covariance of popt. The diagonals provide the variance
-        of the parameter estimate. To compute one standard deviation errors
-        on the parameters use ``perr = np.sqrt(np.diag(pcov))``.
+        The estimated approximate covariance of popt. The diagonals provide
+        the variance of the parameter estimate. To compute one standard
+        deviation errors on the parameters use
+        ``perr = np.sqrt(np.diag(pcov))``. Note that for highly nonlinear
+        models these results are often a very inaccurate measure of
+        uncertainty of the model parameters.
 
         How the `sigma` parameter affects the estimated covariance
         depends on `absolute_sigma` argument, as described above.

--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -651,10 +651,10 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
     pcov : 2-D array
         The estimated approximate covariance of popt. The diagonals provide
         the variance of the parameter estimate. To compute one standard
-        deviation errors on the parameters use
+        deviation errors on the parameters, use
         ``perr = np.sqrt(np.diag(pcov))``. Note that the relationship between
-        cov and parameter error estimate is derived based on a linear
-        approximation the model function around the optimum [1].
+        `cov` and parameter error estimates is derived based on a linear
+        approximation to the model function around the optimum [1].
         When this approximation becomes inaccurate, `cov` may not provide an
         accurate measure of uncertainty.
 
@@ -742,7 +742,7 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
     ----------
     [1] K. Vugrin et al. Confidence region estimation techniques for nonlinear
         regression in groundwater flow: Three case studies. Water Resources
-        Research, Vol. 43, W03423, doi:10.1029/2005WR004804
+        Research, Vol. 43, W03423, :doi:`10.1029/2005WR004804`
 
     Examples
     --------

--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -652,9 +652,11 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
         The estimated approximate covariance of popt. The diagonals provide
         the variance of the parameter estimate. To compute one standard
         deviation errors on the parameters use
-        ``perr = np.sqrt(np.diag(pcov))``. Note that for highly nonlinear
-        models these results are often a very inaccurate measure of
-        uncertainty of the model parameters.
+        ``perr = np.sqrt(np.diag(pcov))``. Note that the relationship between
+        cov and parameter error estimate is derived based on a linear
+        approximation the model function around the optimum [1].
+        When this approximation becomes inaccurate, `cov` may not provide an
+        accurate measure of uncertainty.
 
         How the `sigma` parameter affects the estimated covariance
         depends on `absolute_sigma` argument, as described above.
@@ -735,6 +737,12 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
 
     Box constraints can be handled by methods 'trf' and 'dogbox'. Refer to
     the docstring of `least_squares` for more information.
+
+    References
+    ----------
+    [1] K. Vugrin et al. Confidence region estimation techniques for nonlinear
+        regression in groundwater flow: Three case studies. Water Resources
+        Research, Vol. 43, W03423, doi:10.1029/2005WR004804
 
     Examples
     --------


### PR DESCRIPTION
#### What does this implement/fix?
The `pcov` output of `curve_fit` has to be digested with care: the more complex the model, the less accurate this approximation becomes. This PR adds a sentence in the docstring about this behaviour.
