### PR TITLE
DOC: optimize.root_scalar: harmonize documentation and implementation of xtol

### DIFF
--- a/scipy/optimize/_zeros_py.py
+++ b/scipy/optimize/_zeros_py.py
@@ -508,7 +508,7 @@ def bisect(f, a, b, args=(),
     xtol : number, optional
         The computed root ``x0`` will satisfy ``np.allclose(x, x0,
         atol=xtol, rtol=rtol)``, where ``x`` is the exact root. The
-        parameter must be nonnegative.
+        parameter must be positive.
     rtol : number, optional
         The computed root ``x0`` will satisfy ``np.allclose(x, x0,
         atol=xtol, rtol=rtol)``, where ``x`` is the exact root. The
@@ -590,7 +590,7 @@ def ridder(f, a, b, args=(),
     xtol : number, optional
         The computed root ``x0`` will satisfy ``np.allclose(x, x0,
         atol=xtol, rtol=rtol)``, where ``x`` is the exact root. The
-        parameter must be nonnegative.
+        parameter must be positive.
     rtol : number, optional
         The computed root ``x0`` will satisfy ``np.allclose(x, x0,
         atol=xtol, rtol=rtol)``, where ``x`` is the exact root. The
@@ -705,7 +705,7 @@ def brentq(f, a, b, args=(),
     xtol : number, optional
         The computed root ``x0`` will satisfy ``np.allclose(x, x0,
         atol=xtol, rtol=rtol)``, where ``x`` is the exact root. The
-        parameter must be nonnegative. For nice functions, Brent's
+        parameter must be positive. For nice functions, Brent's
         method will often satisfy the above condition with ``xtol/2``
         and ``rtol/2``. [Brent1973]_
     rtol : number, optional
@@ -831,7 +831,7 @@ def brenth(f, a, b, args=(),
     xtol : number, optional
         The computed root ``x0`` will satisfy ``np.allclose(x, x0,
         atol=xtol, rtol=rtol)``, where ``x`` is the exact root. The
-        parameter must be nonnegative. As with `brentq`, for nice
+        parameter must be positive. As with `brentq`, for nice
         functions the method will often satisfy the above condition
         with ``xtol/2`` and ``rtol/2``.
     rtol : number, optional
@@ -1295,7 +1295,7 @@ def toms748(f, a, b, args=(), k=1,
     xtol : scalar, optional
         The computed root ``x0`` will satisfy ``np.allclose(x, x0,
         atol=xtol, rtol=rtol)``, where ``x`` is the exact root. The
-        parameter must be nonnegative.
+        parameter must be positive.
     rtol : scalar, optional
         The computed root ``x0`` will satisfy ``np.allclose(x, x0,
         atol=xtol, rtol=rtol)``, where ``x`` is the exact root.


### PR DESCRIPTION
#### Reference issue
Closes gh-14059
gh-5557
gh-2462

#### What does this implement/fix?
gh-14059 reported that the documentation of `xtol` ("must be nonnegative") does not agree with the implementation (an error is raised if `xtol <= 0`). Currently, this issue updates the documentation to match the implementation, but I'll see if I can get the input of the authors; it may be possible to adjust the implementation, instead.

#### Additional information
gh-2462 added the requirement that `xtol` must be strictly positive to all scalar root solvers, apparently to prevent infinite loops. gh-5557 documented that `xtol` must be nonnegative.

It also seems to me that with a slight modification to any bracketing algorithm, it should be possible to accept smaller relative tolerances: after the algorithm reduces the bracket as far as possible, there are only a few distinct values of `x` within the bracket. Why not calculate the function value at each of them (e.g. using `np.nextafter`) and return the argmin? The statement about `np.allclose(x, x0, atol=xtol, rtol=rtol)` being satisfied would not be true for `xtol == rtol == 0`, but we could return `x0` with the minimum possible error in `float64`.