### PR TITLE
ENH: stats.loguniform: reformulate methods to avoid overflow

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -7862,6 +7862,9 @@ class reciprocal_gen(rv_continuous):
     def _entropy(self, a, b):
         return 0.5*np.log(a*b)+np.log(np.log(b*1.0/a))
 
+    def _rvs(self, a, b, size=None, random_state=None):
+        return np.exp(random_state.uniform(np.log(a), np.log(b), size=size))
+
     fit_note = """\
         `loguniform`/`reciprocal` is over-parameterized. `fit` automatically
          fixes `scale` to 1 unless `fscale` is provided by the user.\n\n"""

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -7844,26 +7844,25 @@ class reciprocal_gen(rv_continuous):
         return a, b
 
     def _pdf(self, x, a, b):
-        # reciprocal.pdf(x, a, b) = 1 / (x*log(b/a))
-        return 1.0 / (x * np.log(b * 1.0 / a))
+        # reciprocal.pdf(x, a, b) = 1 / (x*(log(b) - log(a)))
+        return np.exp(self._logpdf(x, a, b))
 
     def _logpdf(self, x, a, b):
-        return -np.log(x) - np.log(np.log(b * 1.0 / a))
+        return -np.log(x) - np.log(np.log(b) - np.log(a))
 
     def _cdf(self, x, a, b):
-        return (np.log(x)-np.log(a)) / np.log(b * 1.0 / a)
+        return (np.log(x)-np.log(a)) / (np.log(b) - np.log(a))
 
     def _ppf(self, q, a, b):
-        return a*pow(b*1.0/a, q)
+        return np.exp(np.log(a) + q*(np.log(b) - np.log(a)))
 
     def _munp(self, n, a, b):
-        return 1.0/np.log(b*1.0/a) / n * (pow(b*1.0, n) - pow(a*1.0, n))
+        t1 = 1 / (np.log(b) - np.log(a)) / n
+        t2 = np.real(np.exp(_log_diff(n * np.log(b), n*np.log(a))))
+        return t1 * t2
 
     def _entropy(self, a, b):
-        return 0.5*np.log(a*b)+np.log(np.log(b*1.0/a))
-
-    def _rvs(self, a, b, size=None, random_state=None):
-        return np.exp(random_state.uniform(np.log(a), np.log(b), size=size))
+        return 0.5*(np.log(a) + np.log(b)) + np.log(np.log(b) - np.log(a))
 
     fit_note = """\
         `loguniform`/`reciprocal` is over-parameterized. `fit` automatically

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -7359,6 +7359,20 @@ class TestLogUniform:
         a, b, loc, scale = stats.loguniform.fit(rvs, fscale=2, method=method)
         assert scale == 2
 
+    def test_rvs(self):
+        # default RVS has overflow issues
+        rng = np.random.default_rng(7136519550773909093)
+        a, b = 1e-200, 1e200
+        dist = stats.loguniform(a, b)
+        rvs = dist.rvs(size=1000, random_state=rng)
+        assert np.all(np.isfinite(rvs))
+
+        # "A positive random variable X is log-uniformly distributed if the
+        # logarithm of X is uniform distributed..."
+        dist2 = stats.uniform(np.log(a), np.log(b)-np.log(a))
+        res = stats.ks_1samp(np.log(rvs), dist2.cdf)
+        assert res.pvalue > 0.05
+
 
 class TestArgus:
     def test_argus_rvs_large_chi(self):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -7359,19 +7359,27 @@ class TestLogUniform:
         a, b, loc, scale = stats.loguniform.fit(rvs, fscale=2, method=method)
         assert scale == 2
 
-    def test_rvs(self):
-        # default RVS has overflow issues
+    def test_overflow(self):
+        # original formulation had overflow issues; check that this is resolved
+        # Extensive accuracy tests elsewhere, no need to test all methods
         rng = np.random.default_rng(7136519550773909093)
         a, b = 1e-200, 1e200
         dist = stats.loguniform(a, b)
-        rvs = dist.rvs(size=1000, random_state=rng)
-        assert np.all(np.isfinite(rvs))
 
-        # "A positive random variable X is log-uniformly distributed if the
-        # logarithm of X is uniform distributed..."
-        dist2 = stats.uniform(np.log(a), np.log(b)-np.log(a))
-        res = stats.ks_1samp(np.log(rvs), dist2.cdf)
-        assert res.pvalue > 0.05
+        # test roundtrip error
+        cdf = rng.uniform(0, 1, size=1000)
+        assert_allclose(dist.cdf(dist.ppf(cdf)), cdf)
+        rvs = dist.rvs(size=1000)
+        assert_allclose(dist.ppf(dist.cdf(rvs)), rvs)
+
+        # test a property of the pdf (and that there is no overflow)
+        x = 10.**np.arange(-200, 200)
+        pdf = dist.pdf(x)  # no overflow
+        assert_allclose(pdf[:-1]/pdf[1:], 10)
+
+        # check munp against wikipedia reference
+        mean = (b - a)/(np.log(b) - np.log(a))
+        assert_allclose(dist.mean(), mean)
 
 
 class TestArgus:


### PR DESCRIPTION
#### Reference issue
None filed.

#### What does this implement/fix?
`stats.loguniform` methods took a ratio `b/a` and raised `a` and `b` to powers, causing underflows and overflows for small `a` and large `b`. This reformulates the methods to avoid overflow/underflow.

#### Additional information
I wasn't looking for this; I just ran into issues with `rvs` when I was performing some tests for the scalar optimizers, so I went ahead and fixed it.
