### PR TITLE
MAINT: optimize.newton: avoid error with complex `x0`

### DIFF
--- a/scipy/optimize/_zeros_py.py
+++ b/scipy/optimize/_zeros_py.py
@@ -292,7 +292,8 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
                              full_output)
 
     # Convert to float (don't use float(x0); this works also for complex x0)
-    p0 = 1.0 * x0
+    x0 = np.asarray(x0)[()]
+    p0 = x0
     funcalls = 0
     if fprime is not None:
         # Newton-Raphson method

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -807,3 +807,15 @@ def test_function_calls(solver_name, rs_interface):
         assert res.function_calls == f.calls
     else:
         assert res[1].function_calls == f.calls
+
+
+def test_newton_complex_gh10103():
+    # gh-10103 report a problem with `newton` and complex x0. Check that this
+    # is resolved.
+    def f(z):
+        return z - 1
+    res = newton(f, 1+1j)
+    assert_allclose(res, 1, atol=1e-12)
+
+    res = root_scalar(f, x0=1+1j, x1=2+1.5j, method='secant')
+    assert_allclose(res.root, 1, atol=1e-12)

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -839,8 +839,8 @@ def test_gh5584(solver_name, rs_interface):
 
 
 def test_newton_complex_gh10103():
-    # gh-10103 report a problem with `newton` and complex x0. Check that this
-    # is resolved.
+    # gh-10103 reported a problem with `newton` and complex x0.
+    # Check that this is resolved.
     def f(z):
         return z - 1
     res = newton(f, 1+1j)

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -839,7 +839,8 @@ def test_gh5584(solver_name, rs_interface):
 
 
 def test_newton_complex_gh10103():
-    # gh-10103 reported a problem with `newton` and complex x0.
+    # gh-10103 reported a problem when `newton` is pass a Python complex x0,
+    # no `fprime` (secant method), and no `x1` (`x1` must be constructed).
     # Check that this is resolved.
     def f(z):
         return z - 1


### PR DESCRIPTION
#### Reference issue
Closes gh-10103

#### What does this implement/fix?
gh-10103 reported an error when a Python complex `x0` was passed to `newton`. A comment revealed that the problem disappears when `x0` is a NumPy complex value, so this PR converts `x0` to a NumPy complex dtype to fix the problem.