### PR TITLE
BUG: correctly handle array-like types in scipy.io.savemat

### DIFF
--- a/scipy/io/matlab/_mio5.py
+++ b/scipy/io/matlab/_mio5.py
@@ -466,6 +466,8 @@ def to_writeable(source):
         return source
     if source is None:
         return None
+    if hasattr(source, "__array__"):
+        return np.asarray(source)
     # Objects that implement mappings
     is_mapping = (hasattr(source, 'keys') and hasattr(source, 'values') and
                   hasattr(source, 'items'))

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -1237,6 +1237,17 @@ def test_save_unicode_field(tmpdir):
     savemat(filename, test_dict)
 
 
+def test_save_custom_array_type(tmpdir):
+    class CustomArray:
+        def __array__(self):
+            return np.arange(6.0).reshape(2, 3)
+    a = CustomArray()
+    filename = os.path.join(str(tmpdir), 'test.mat')
+    savemat(filename, {'a': a})
+    out = loadmat(filename)
+    assert_array_equal(out['a'], np.array(a))
+
+
 def test_filenotfound():
     # Check the correct error is thrown
     assert_raises(OSError, loadmat, "NotExistentFile00.mat")


### PR DESCRIPTION
Previously, the presence of a `__dict__` attribute would unconditionally cause `savemat` to treat its argument as a mapping. This is problematic in the case of custom array-like types, because by default *any* python class will have a `__dict__` attribute. This change makes it so that if an `__array__` attribute is present, the object will be treated as an array rather than as a mapping.

Here's a minimal reproduction of the issue:
```python
from scipy.io import savemat, loadmat

class CustomArray:
    def __array__(self):
        return np.arange(6.0).reshape(2, 3)

savemat('test.mat', {'a': CustomArray()})
out = loadmat('test.mat')
print(out['a'])
# [[None]]
```
This can be fixed by changing the type definition so that it lacks a `__dict__` attribute, e.g. by specifying `__slots__`:
```python
class CustomArrayNoDict:
    __slots__ = []
    def __array__(self):
        return np.arange(6.0).reshape(2, 3)

savemat('test.mat', {'a': CustomArrayNoDict()})
out = loadmat('test.mat')
print(out['a'])
# [[0. 1. 2.]
#  [3. 4. 5.]]
```
Still, scipy ignoring `__array__` in favor of `__dict__` for custom array objects is surprising behavior.

This came up recently from a JAX user who noted that `savemat` stopped working after the implementation of `jax.Array` changed (https://github.com/google/jax/issues/13815). The same bug has also has been reported previously in the scipy repository in relation to other array-like objects (https://github.com/scipy/scipy/issues/5371).

cc/ @shoyer 