### PR TITLE
MAINT: Resolve pydata-sphinx-theme deprecation

### DIFF
--- a/doc/source/_templates/sidebar-nav-bs.html
+++ b/doc/source/_templates/sidebar-nav-bs.html
@@ -1,9 +1,9 @@
 <nav class="bd-links" id="bd-docs-nav" aria-label="Main navigation">
   <div class="bd-toc-item active">
     {% if pagename.startswith("reference") %}
-    {{ generate_nav_html("sidebar", maxdepth=1, collapse=True, includehidden=True, titles_only=True) }}
+    {{ generate_toctree_html("sidebar", maxdepth=1, collapse=True, includehidden=True, titles_only=True) }}
     {% else %}
-    {{ generate_nav_html("sidebar", maxdepth=2, collapse=True, includehidden=True, titles_only=True) }}
+    {{ generate_toctree_html("sidebar", maxdepth=2, collapse=True, includehidden=True, titles_only=True) }}
     {% endif %}
   </div>
 </nav>


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
In pydata-sphinx-theme, `generate_nav_html` is deprecated and replaced with `generate_toctree_html` instead. 

See: https://github.com/pydata/pydata-sphinx-theme/blob/13d46921f2a5336fc58dad2cbff6a6d312dc394f/src/pydata_sphinx_theme/__init__.py#L392

#### Additional information
<!--Any additional information you think is important.-->
