### PR TITLE
ENH: optimize.minimize: add bound constraints to COBYLA

### DIFF
--- a/scipy/optimize/_cobyla_py.py
+++ b/scipy/optimize/_cobyla_py.py
@@ -219,14 +219,6 @@ def _minimize_cobyla(fun, x0, args=(), constraints=(),
         constraints = (constraints, )
 
     if bounds:
-        msg = "An upper bound is less than the corresponding lower bound."
-        if np.any(bounds.ub < bounds.lb):
-            raise ValueError(msg)
-
-        msg = "The number of bounds is not compatible with the length of `x0`."
-        if len(x0) != len(bounds.lb):
-            raise ValueError(msg)
-
         i_lb = np.isfinite(bounds.lb)
         if np.any(i_lb):
             def lb_constraint(x, *args, **kwargs):

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -145,8 +145,9 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
         dimension (n,) and ``args`` is a tuple with the fixed
         parameters.
     bounds : sequence or `Bounds`, optional
-        Bounds on variables for Nelder-Mead, L-BFGS-B, TNC, SLSQP, Powell, and
-        trust-constr methods. There are two ways to specify the bounds:
+        Bounds on variables for Nelder-Mead, L-BFGS-B, TNC, SLSQP, Powell,
+        trust-constr, and COBYLA methods. There are two ways to specify the
+        bounds:
 
             1. Instance of `Bounds` class.
             2. Sequence of ``(min, max)`` pairs for each element in `x`. None
@@ -575,8 +576,8 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
             np.any(constraints)):
         warn('Method %s cannot handle constraints.' % method,
              RuntimeWarning)
-    if meth not in ('nelder-mead', 'powell', 'l-bfgs-b', 'tnc', 'slsqp',
-                    'trust-constr', '_custom') and bounds is not None:
+    if meth not in ('nelder-mead', 'powell', 'l-bfgs-b', 'cobyla', 'slsqp',
+                    'tnc', 'trust-constr', '_custom') and bounds is not None:
         warn('Method %s cannot handle bounds.' % method,
              RuntimeWarning)
     # - return_all
@@ -713,7 +714,7 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
                             **options)
     elif meth == 'cobyla':
         res = _minimize_cobyla(fun, x0, args, constraints, callback=callback,
-                                **options)
+                               bounds=bounds, **options)
     elif meth == 'slsqp':
         res = _minimize_slsqp(fun, x0, args, jac, bounds,
                               constraints, callback=callback, **options)
@@ -978,7 +979,7 @@ def _add_to_array(x_in, i_fixed, x_fixed):
 
 def standardize_bounds(bounds, x0, meth):
     """Converts bounds to the form required by the solver."""
-    if meth in {'trust-constr', 'powell', 'nelder-mead', 'new'}:
+    if meth in {'trust-constr', 'powell', 'nelder-mead', 'cobyla', 'new'}:
         if not isinstance(bounds, Bounds):
             lb, ub = old_bound_to_new(bounds)
             bounds = Bounds(lb, ub)

--- a/scipy/optimize/tests/test_cobyla.py
+++ b/scipy/optimize/tests/test_cobyla.py
@@ -130,6 +130,8 @@ def test_vector_constraints():
 
 class TestBounds:
     # Test cobyla support for bounds (only when used via `minimize`)
+    # Invalid bounds is tested in
+    # test_optimize.TestOptimizeSimple.test_minimize_invalid_bounds
 
     def test_basic(self):
         def f(x):
@@ -144,20 +146,6 @@ class TestBounds:
         ref = [-0.5, -0.5, 1, 0, -0.5]
         assert res.success
         assert_allclose(res.x, ref, atol=1e-3)
-
-    def test_input_validation(self):
-        def f(x):
-            return np.sum(x**2)
-
-        bounds = Bounds([1, 2], [3, 4])
-        msg = 'The number of bounds is not compatible with the length of `x0`.'
-        with pytest.raises(ValueError, match=msg):
-            minimize(f, x0=[1, 2, 3], method='cobyla', bounds=bounds)
-
-        bounds = Bounds([1, 6, 1], [3, 4, 2])
-        msg = 'An upper bound is less than the corresponding lower bound.'
-        with pytest.raises(ValueError, match=msg):
-            minimize(f, x0=[1, 2, 3], method='cobyla', bounds=bounds)
 
     def test_unbounded(self):
         def f(x):

--- a/scipy/optimize/tests/test_cobyla.py
+++ b/scipy/optimize/tests/test_cobyla.py
@@ -4,7 +4,7 @@ import pytest
 
 from numpy.testing import assert_allclose, assert_, assert_array_equal
 
-from scipy.optimize import fmin_cobyla, minimize
+from scipy.optimize import fmin_cobyla, minimize, Bounds
 
 
 class TestCobyla:
@@ -127,3 +127,48 @@ def test_vector_constraints():
     sol = minimize(fun, x0, constraints=constraints, tol=1e-5)
     assert_allclose(sol.fun, 1, atol=1e-4)
 
+
+class TestBounds:
+    # Test cobyla support for bounds (only when used via `minimize`)
+
+    def test_basic(self):
+        def f(x):
+            return np.sum(x**2)
+
+        lb = [-1, None, 1, None, -0.5]
+        ub = [-0.5, -0.5, None, None, -0.5]
+        bounds = [(a, b) for a, b in zip(lb, ub)]
+        # these are converted to Bounds internally
+
+        res = minimize(f, x0=[1, 2, 3, 4, 5], method='cobyla', bounds=bounds)
+        ref = [-0.5, -0.5, 1, 0, -0.5]
+        assert res.success
+        assert_allclose(res.x, ref, atol=1e-3)
+
+    def test_input_validation(self):
+        def f(x):
+            return np.sum(x**2)
+
+        bounds = Bounds([1, 2], [3, 4])
+        msg = 'The number of bounds is not compatible with the length of `x0`.'
+        with pytest.raises(ValueError, match=msg):
+            minimize(f, x0=[1, 2, 3], method='cobyla', bounds=bounds)
+
+        bounds = Bounds([1, 6, 1], [3, 4, 2])
+        msg = 'An upper bound is less than the corresponding lower bound.'
+        with pytest.raises(ValueError, match=msg):
+            minimize(f, x0=[1, 2, 3], method='cobyla', bounds=bounds)
+
+    def test_unbounded(self):
+        def f(x):
+            return np.sum(x**2)
+
+        bounds = Bounds([-np.inf, -np.inf], [np.inf, np.inf])
+        res = minimize(f, x0=[1, 2], method='cobyla', bounds=bounds)
+        assert res.success
+        assert_allclose(res.x, 0, atol=1e-3)
+
+        bounds = Bounds([1, -np.inf], [np.inf, np.inf])
+        res = minimize(f, x0=[1, 2], method='cobyla', bounds=bounds)
+        assert res.success
+        assert_allclose(res.x, [1, 0], atol=1e-3)

--- a/scipy/optimize/tests/test_minimize_constrained.py
+++ b/scipy/optimize/tests/test_minimize_constrained.py
@@ -762,8 +762,8 @@ class TestBoundedNelderMead:
 
     def test_invalid_bounds(self):
         prob = Rosenbrock()
-        with raises(ValueError, match=r"one of the lower bounds is greater "
-                                      r"than an upper bound."):
+        message = 'An upper bound is less than the corresponding lower bound.'
+        with raises(ValueError, match=message):
             bounds = Bounds([-np.inf, 1.0], [4.0, -5.0])
             minimize(prob.fun, [-10, 3],
                      method='Nelder-Mead',

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -1543,6 +1543,22 @@ class TestOptimizeSimple(CheckOptimize):
         with assert_raises(ValueError, match=msg):
             optimize.minimize(lambda x: x, np.ones((2, 1)))
 
+    @pytest.mark.parametrize('method', ('nelder-mead', 'l-bfgs-b', 'tnc',
+                                        'powell', 'cobyla', 'trust-constr'))
+    def test_minimize_invalid_bounds(self, method):
+        def f(x):
+            return np.sum(x**2)
+
+        bounds = Bounds([1, 2], [3, 4])
+        msg = 'The number of bounds is not compatible with the length of `x0`.'
+        with pytest.raises(ValueError, match=msg):
+            optimize.minimize(f, x0=[1, 2, 3], method=method, bounds=bounds)
+
+        bounds = Bounds([1, 6, 1], [3, 4, 2])
+        msg = 'An upper bound is less than the corresponding lower bound.'
+        with pytest.raises(ValueError, match=msg):
+            optimize.minimize(f, x0=[1, 2, 3], method=method, bounds=bounds)
+
 
 @pytest.mark.parametrize(
     'method',
@@ -1599,7 +1615,7 @@ class TestLBFGSBBounds:
         ([(10, 1), (10, 1)])
     ])
     def test_minimize_l_bfgs_b_incorrect_bounds(self, bounds):
-        with pytest.raises(ValueError, match='.*bounds.*'):
+        with pytest.raises(ValueError, match='.*bound.*'):
             optimize.minimize(self.fun, [0, -1], method='L-BFGS-B',
                               jac=self.jac, bounds=bounds)
 


### PR DESCRIPTION
#### Reference issue
Closes gh-4532

#### What does this implement/fix?
gh-4532 asked for `scipy.optimize.minimize` `method='cobyla'` to support bound constraints. This is relatively easy, since COBYLA already supports inequality constraints, so this PR converts the bounds to inequality constraints.

#### Additional information
This does not add `bounds` to `fmin_cobyla` because that is considered to be a legacy function.
