### PR TITLE
DOC: add real example for `stats.chisquare`

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -7513,27 +7513,31 @@ def chisquare(f_obs, f_exp=None, ddof=0, axis=0):
     In the forest, 44% of the canopy volume was Douglas fir,
     24% was ponderosa pine, 29% was grand fir, and 3% was western larch.
     The authors observed the behavior of several species of birds, one of
-    which was the red-breasted nuthatch. They made 189 observations of
-    foraging of this species noting that 23% of birds favoured Douglas
-    fir, 27% ponderosa pine, 29% grand fir, and 21% western larch.
+    which was the red-breasted nuthatch. They made 189 observations of this
+    species foraging, recording 43 ("23%") of observations in Douglas fir, 
+    52 ("28%") in ponderosa pine, 54 ("29%") in grand fir, and 40 ("21%") in
+    western larch.
 
     Using a chi-square test, we can test the null hypothesis that the
     proportions of foraging events are equal to the proportions of canopy
-    volume. As the authors of the paper, let's consider a significance level
-    of 1%.
+    volume. The authors of the paper considered a p-value less than 1% to be
+    significant.
 
     Using the above proportions of canopy volume and observed events, we can
     infer expected frequencies.
 
     >>> import numpy as np
     >>> f_exp = np.array([44, 24, 29, 3]) / 100 * 189
-    >>> f_obs = np.array([23, 27, 29, 21]) / 100 * 189
+
+    The observed frequencies of foraging were:
+
+    >>> f_obs = np.array([43, 52, 54, 40])
 
     We can now compare the observed frequencies with the expected frequencies.
 
     >>> from scipy.stats import chisquare
     >>> chisquare(f_obs=f_obs, f_exp=f_exp)
-    Power_divergenceResult(statistic=223.77170454545453, pvalue=3.071583663409687e-48)
+    Power_divergenceResult(statistic=228.23515947653874, pvalue=3.3295585338846486e-49)
 
     The p-value is well below the chosen significance level. Hence, the
     authors considered the difference to be significant and concluded

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -7514,7 +7514,7 @@ def chisquare(f_obs, f_exp=None, ddof=0, axis=0):
     24% was ponderosa pine, 29% was grand fir, and 3% was western larch.
     The authors observed the behavior of several species of birds, one of
     which was the red-breasted nuthatch. They made 189 observations of this
-    species foraging, recording 43 ("23%") of observations in Douglas fir, 
+    species foraging, recording 43 ("23%") of observations in Douglas fir,
     52 ("28%") in ponderosa pine, 54 ("29%") in grand fir, and 40 ("21%") in
     western larch.
 
@@ -7570,10 +7570,9 @@ def chisquare(f_obs, f_exp=None, ddof=0, axis=0):
     which is equivalent to applying the test to the flattened array.
 
     >>> chisquare(obs, axis=None)
-    Power_divergenceResult(statistic=2.0, pvalue=0.84914503608460956)
-    (23.31034482758621, 0.015975692534127565)
-    >>> chisquare(obs.ravel())
     Power_divergenceResult(statistic=23.31034482758621, pvalue=0.015975692534127565)
+    >>> chisquare(obs.ravel())
+    Power_divergenceResult(statistic=23.310344827586206, pvalue=0.01597569253412758)
 
     `ddof` is the change to make to the default degrees of freedom.
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -7512,14 +7512,15 @@ def chisquare(f_obs, f_exp=None, ddof=0, axis=0):
     of Oregon.
     In the forest, 44% of the canopy volume was Douglas fir,
     24% was ponderosa pine, 29% was grand fir, and 3% was western larch.
-    The authors observed the behavior of several species of birds, one
+    The authors observed the behavior of several species of birds, one of
     which was the red-breasted nuthatch. They made 189 observations of
-    foraging
-    of this species with the respective frequencies of 23%, 27%, 29%, and 21%.
+    foraging of this species noting that 23% of birds favoured Douglas
+    fir, 27% ponderosa pine, 29% grand fir, and 21% western larch.
 
     Using a chi-square test, we can test the null hypothesis that the
     proportions of foraging events are equal to the proportions of canopy
-    volume. Let's consider a significance level of 5%.
+    volume. As the authors of the paper, let's consider a significance level
+    of 1%.
 
     Using the above proportions of canopy volume and observed events, we can
     infer expected frequencies.

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -7501,14 +7501,50 @@ def chisquare(f_obs, f_exp=None, ddof=0, axis=0):
            in the case of a correlated system of variables is such that it can be reasonably
            supposed to have arisen from random sampling", Philosophical Magazine. Series 5. 50
            (1900), pp. 157-175.
+    .. [4] Mannan, R. William and E. Charles. Meslow. “Bird populations and
+           vegetation characteristics in managed and old-growth forests,
+           northeastern Oregon.” Journal of Wildlife Management
+           48, 1219-1238, :doi:`10.2307/3801783`, 1984.
 
     Examples
     --------
+
+    In [4]_ bird foraging behavior was investigated in a forest of Oregon.
+    The foraging refers to the range of activities and behaviours exhibited by
+    birds in their quest for food.
+    In an old-growth forest, 44% of the canopy volume was Douglas fir,
+    24% was ponderosa pine, 29% was grand fir, and 3% was western larch.
+    They observed the behavior of several species of birds, one of which
+    was the red-breasted nuthatches. They made 189 observations of foraging
+    of this specie with the respective frequencies of 23%, 27%, 29% and 21%.
+
+    Using a chi-square test, we can test the null hypothesis that the
+    proportions of foraging events are equal to the proportions of canopy
+    volume. Let's consider a significance level of 5%.
+
+    Using the above proportions of canopy volume and observed events, we can
+    infer expected frequencies.
+
+    >>> import numpy as np
+    >>> f_exp = np.array([44, 24, 29, 3]) / 100 * 189
+    >>> f_obs = np.array([23, 27, 29, 21]) / 100 * 189
+
+    We can now confront the observed frequencies with the expected frequencies
+
+    >>> from scipy.stats import chisquare
+    >>> chisquare(f_obs=f_obs, f_exp=f_exp)
+    Power_divergenceResult(statistic=223.77170454545453, pvalue=3.071583663409687e-48)
+
+    Hence, the p-value is well bellow the chosen significance level. The
+    difference is significant, and we can say that the birds do not
+    forage randomly in regard to the species of tree they are in.
+
+    Following are other generic examples to demonstrate how the other
+    parameters can be used.
+
     When just `f_obs` is given, it is assumed that the expected frequencies
     are uniform and given by the mean of the observed frequencies.
 
-    >>> import numpy as np
-    >>> from scipy.stats import chisquare
     >>> chisquare([16, 18, 16, 14, 12, 12])
     (2.0, 0.84914503608460956)
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -7508,7 +7508,6 @@ def chisquare(f_obs, f_exp=None, ddof=0, axis=0):
 
     Examples
     --------
-
     In [4]_ bird foraging behavior was investigated in a forest of Oregon.
     The foraging refers to the range of activities and behaviours exhibited by
     birds in their quest for food.
@@ -7546,12 +7545,12 @@ def chisquare(f_obs, f_exp=None, ddof=0, axis=0):
     are uniform and given by the mean of the observed frequencies.
 
     >>> chisquare([16, 18, 16, 14, 12, 12])
-    (2.0, 0.84914503608460956)
+    Power_divergenceResult(statistic=2.0, pvalue=0.84914503608460956)
 
     With `f_exp` the expected frequencies can be given.
 
     >>> chisquare([16, 18, 16, 14, 12, 12], f_exp=[16, 16, 16, 16, 16, 8])
-    (3.5, 0.62338762774958223)
+    Power_divergenceResult(statistic=3.5, pvalue=0.62338762774958223)
 
     When `f_obs` is 2-D, by default the test is applied to each column.
 
@@ -7559,26 +7558,27 @@ def chisquare(f_obs, f_exp=None, ddof=0, axis=0):
     >>> obs.shape
     (6, 2)
     >>> chisquare(obs)
-    (array([ 2.        ,  6.66666667]), array([ 0.84914504,  0.24663415]))
+    Power_divergenceResult(statistic=array([2.        , 6.66666667]), pvalue=array([0.84914504, 0.24663415]))
 
     By setting ``axis=None``, the test is applied to all data in the array,
     which is equivalent to applying the test to the flattened array.
 
     >>> chisquare(obs, axis=None)
+    Power_divergenceResult(statistic=2.0, pvalue=0.84914503608460956)
     (23.31034482758621, 0.015975692534127565)
     >>> chisquare(obs.ravel())
-    (23.31034482758621, 0.015975692534127565)
+    Power_divergenceResult(statistic=23.31034482758621, pvalue=0.015975692534127565)
 
     `ddof` is the change to make to the default degrees of freedom.
 
     >>> chisquare([16, 18, 16, 14, 12, 12], ddof=1)
-    (2.0, 0.73575888234288467)
+    Power_divergenceResult(statistic=2.0, pvalue=0.7357588823428847)
 
     The calculation of the p-values is done by broadcasting the
     chi-squared statistic with `ddof`.
 
     >>> chisquare([16, 18, 16, 14, 12, 12], ddof=[0,1,2])
-    (2.0, array([ 0.84914504,  0.73575888,  0.5724067 ]))
+    Power_divergenceResult(statistic=2.0, pvalue=array([0.84914504, 0.73575888, 0.5724067 ]))
 
     `f_obs` and `f_exp` are also broadcast.  In the following, `f_obs` has
     shape (6,) and `f_exp` has shape (2, 6), so the result of broadcasting
@@ -7588,7 +7588,7 @@ def chisquare(f_obs, f_exp=None, ddof=0, axis=0):
     >>> chisquare([16, 18, 16, 14, 12, 12],
     ...           f_exp=[[16, 16, 16, 16, 16, 8], [8, 20, 20, 16, 12, 12]],
     ...           axis=1)
-    (array([ 3.5 ,  9.25]), array([ 0.62338763,  0.09949846]))
+    Power_divergenceResult(statistic=array([3.5 , 9.25]), pvalue=array([0.62338763, 0.09949846]))
 
     """
     return power_divergence(f_obs, f_exp=f_exp, ddof=ddof, axis=axis,

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -7595,7 +7595,7 @@ def chisquare(f_obs, f_exp=None, ddof=0, axis=0):
     ...           axis=1)
     Power_divergenceResult(statistic=array([3.5 , 9.25]), pvalue=array([0.62338763, 0.09949846]))
 
-    """
+    """  # noqa
     return power_divergence(f_obs, f_exp=f_exp, ddof=ddof, axis=axis,
                             lambda_="pearson")
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -7508,14 +7508,14 @@ def chisquare(f_obs, f_exp=None, ddof=0, axis=0):
 
     Examples
     --------
-    In [4]_ bird foraging behavior was investigated in a forest of Oregon.
-    The foraging refers to the range of activities and behaviours exhibited by
-    birds in their quest for food.
-    In an old-growth forest, 44% of the canopy volume was Douglas fir,
+    In [4]_, bird foraging behavior was investigated in an old-growth forest
+    of Oregon.
+    In the forest, 44% of the canopy volume was Douglas fir,
     24% was ponderosa pine, 29% was grand fir, and 3% was western larch.
-    They observed the behavior of several species of birds, one of which
-    was the red-breasted nuthatches. They made 189 observations of foraging
-    of this specie with the respective frequencies of 23%, 27%, 29% and 21%.
+    The authors observed the behavior of several species of birds, one
+    which was the red-breasted nuthatch. They made 189 observations of
+    foraging
+    of this species with the respective frequencies of 23%, 27%, 29%, and 21%.
 
     Using a chi-square test, we can test the null hypothesis that the
     proportions of foraging events are equal to the proportions of canopy
@@ -7528,15 +7528,16 @@ def chisquare(f_obs, f_exp=None, ddof=0, axis=0):
     >>> f_exp = np.array([44, 24, 29, 3]) / 100 * 189
     >>> f_obs = np.array([23, 27, 29, 21]) / 100 * 189
 
-    We can now confront the observed frequencies with the expected frequencies
+    We can now compare the observed frequencies with the expected frequencies.
 
     >>> from scipy.stats import chisquare
     >>> chisquare(f_obs=f_obs, f_exp=f_exp)
     Power_divergenceResult(statistic=223.77170454545453, pvalue=3.071583663409687e-48)
 
-    Hence, the p-value is well bellow the chosen significance level. The
-    difference is significant, and we can say that the birds do not
-    forage randomly in regard to the species of tree they are in.
+    The p-value is well below the chosen significance level. Hence, the
+    authors considered the difference to be significant and concluded
+    that the relative proportions of foraging events were not the same
+    as the relative proportions of tree canopy volume.
 
     Following are other generic examples to demonstrate how the other
     parameters can be used.


### PR DESCRIPTION
Current examples for `scipy.stats.chisquare` are generic. This PR adds a real life example based on:

```
Mannan, R. William and E. Charles. Meslow. “Bird populations and
vegetation characteristics in managed and old-growth forests,
northeastern Oregon.” Journal of Wildlife Management
48, 1219-1238, DOI: 10.2307/3801783, 1984.
```

Table 6. P1232. I just had to adjust a bit the values as the sum of avg. frequencies does not go to 100. We are close to the value they report. I think it's ok anyway. Or we can take another set of values if wanted.

The other set for managed forest has low frequencies/counts. This could be used for examples in the `monte_carlo_test`.