### PR TITLE
ENH: support `Bounds` class in lsq_linear

### DIFF
--- a/scipy/optimize/_lsq/lsq_linear.py
+++ b/scipy/optimize/_lsq/lsq_linear.py
@@ -12,6 +12,8 @@ from .bvls import bvls
 
 
 def prepare_bounds(bounds, n):
+    if len(bounds) != 2:
+        raise ValueError("`bounds` must contain 2 elements.")
     lb, ub = [np.asarray(b, dtype=float) for b in bounds]
 
     if lb.ndim == 0:
@@ -287,8 +289,6 @@ def lsq_linear(A, b, bounds=(-np.inf, np.inf), method='trf', tol=1e-10,
         lb = bounds.lb
         ub = bounds.ub
     else:
-        if len(bounds) != 2:
-            raise ValueError("`bounds` must contain 2 elements.")
         lb, ub = prepare_bounds(bounds, n)
 
     if lb.shape != (n,) and ub.shape != (n,):

--- a/scipy/optimize/_lsq/lsq_linear.py
+++ b/scipy/optimize/_lsq/lsq_linear.py
@@ -54,11 +54,18 @@ def lsq_linear(A, b, bounds=(-np.inf, np.inf), method='trf', tol=1e-10,
         Design matrix. Can be `scipy.sparse.linalg.LinearOperator`.
     b : array_like, shape (m,)
         Target vector.
-    bounds : 2-tuple of array_like, optional
-        Lower and upper bounds on independent variables. Defaults to no bounds.
-        Each array must have shape (n,) or be a scalar, in the latter
-        case a bound will be the same for all variables. Use ``np.inf`` with
-        an appropriate sign to disable bounds on all or some variables.
+    bounds : 2-tuple of array_like or `Bounds`, optional
+        Lower and upper bounds on parameters. Defaults to no bounds.
+        There are two ways to specify the bounds:
+
+            - Instance of `Bounds` class.
+
+            - 2-tuple of array_like: Each element of the tuple must be either
+              an array with the length equal to the number of parameters, or a
+              scalar (in which case the bound is taken to be the same for all
+              parameters). Use ``np.inf`` with an appropriate sign to disable
+              bounds on all or some parameters.
+
     method : 'trf' or 'bvls', optional
         Method to perform minimization.
 

--- a/scipy/optimize/_lsq/lsq_linear.py
+++ b/scipy/optimize/_lsq/lsq_linear.py
@@ -4,6 +4,7 @@ from numpy.linalg import norm
 from scipy.sparse import issparse, csr_matrix
 from scipy.sparse.linalg import LinearOperator, lsmr
 from scipy.optimize import OptimizeResult
+from scipy.optimize._minimize import Bounds
 
 from .common import in_bounds, compute_grad
 from .trf_linear import trf_linear
@@ -270,9 +271,6 @@ def lsq_linear(A, b, bounds=(-np.inf, np.inf), method='trf', tol=1e-10,
     if len(A.shape) != 2:  # No ndim for LinearOperator.
         raise ValueError("`A` must have at most 2 dimensions.")
 
-    if len(bounds) != 2:
-        raise ValueError("`bounds` must contain 2 elements.")
-
     if max_iter is not None and max_iter <= 0:
         raise ValueError("`max_iter` must be None or positive integer.")
 
@@ -285,7 +283,13 @@ def lsq_linear(A, b, bounds=(-np.inf, np.inf), method='trf', tol=1e-10,
     if b.size != m:
         raise ValueError("Inconsistent shapes between `A` and `b`.")
 
-    lb, ub = prepare_bounds(bounds, n)
+    if isinstance(bounds, Bounds):
+        lb = bounds.lb
+        ub = bounds.ub
+    else:
+        if len(bounds) != 2:
+            raise ValueError("`bounds` must contain 2 elements.")
+        lb, ub = prepare_bounds(bounds, n)
 
     if lb.shape != (n,) and ub.shape != (n,):
         raise ValueError("Bounds have wrong shape.")

--- a/scipy/optimize/tests/test_lsq_linear.py
+++ b/scipy/optimize/tests/test_lsq_linear.py
@@ -7,6 +7,7 @@ from numpy.testing import assert_allclose, assert_equal, assert_
 from scipy.sparse import rand, coo_matrix
 from scipy.sparse.linalg import aslinearoperator
 from scipy.optimize import lsq_linear
+from scipy.optimize._minimize import Bounds
 
 
 A = np.array([
@@ -75,6 +76,18 @@ class BaseMixin:
                              lsq_solver=lsq_solver)
             assert_allclose(res.x, np.array([0.005236663400791, -4]))
             assert_allclose(res.unbounded_sol[0], unbounded_sol)
+
+    def test_bounds_variants(self):
+        x = np.array([1, 3])
+        A = self.rnd.uniform(size=(2, 2))
+        b = A@x
+        lb = np.array([1, 1])
+        ub = np.array([2, 2])
+        bounds_old = (lb, ub)
+        bounds_new = Bounds(lb, ub)
+        res_old = lsq_linear(A, b, bounds_old)
+        res_new = lsq_linear(A, b, bounds_new)
+        assert_allclose(res_old.x, res_new.x)
 
     def test_np_matrix(self):
         # gh-10711

--- a/scipy/optimize/tests/test_lsq_linear.py
+++ b/scipy/optimize/tests/test_lsq_linear.py
@@ -87,6 +87,7 @@ class BaseMixin:
         bounds_new = Bounds(lb, ub)
         res_old = lsq_linear(A, b, bounds_old)
         res_new = lsq_linear(A, b, bounds_new)
+        assert not np.allclose(res_new.x, res_new.unbounded_sol[0])
         assert_allclose(res_old.x, res_new.x)
 
     def test_np_matrix(self):


### PR DESCRIPTION
#### What does this implement/fix?
`lsq_linear` is the only optimizer which currently does not accept bounds in form of the Bounds class. This PR adds that support. With this, there is a uniform way to provide bounds across `scipy.optimize` outside of `linprog`.

#### Additional information
There is a bigger API issue in my opinion: overall, there are three different ways to provide bounds in `optimize`.
* Bounds class
* tuple of the form [(lb, ub), (lb, ub), ...] (`minimize`)
* tuple of the form ([lb, lb, ...], [ub, ub, ...]) (`least_squares` and friends)

I guess this happened due to historic reasons. On the web, most tutorials still use the old bounds constraints (even I am still used to them myself :D). In the long run, it would probably be good if people moved to the Bounds class but I am not sure if this will really happen.