### PR TITLE
ENH: stats: Implement _sf for the foldnorm distribution.

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -2199,6 +2199,9 @@ class foldnorm_gen(rv_continuous):
     def _cdf(self, x, c):
         return _norm_cdf(x-c) + _norm_cdf(x+c) - 1.0
 
+    def _sf(self, x, c):
+        return _norm_sf(x - c) + _norm_sf(x + c)
+
     def _stats(self, c):
         # Regina C. Elandt, Technometrics 3, 551 (1961)
         # https://www.jstor.org/stable/1266561

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3584,8 +3584,8 @@ class TestBetaPrime:
          (0.375, 0.25, 7.0, 0.002036820346115211)],
     )
     def test_ppf(self, p, a, b, expected):
-        p = stats.betaprime.ppf(p, a, b)
-        assert_allclose(p, expected, rtol=1e-14)
+        x = stats.betaprime.ppf(p, a, b)
+        assert_allclose(x, expected, rtol=1e-14)
 
 
 class TestGamma:

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -6614,6 +6614,30 @@ def test_foldnorm_zero():
     assert_equal(rv.cdf(0), 0)  # rv.cdf(0) previously resulted in: nan
 
 
+# Expected values for foldnorm.sf were computed with mpmath:
+#
+#    from mpmath import mp
+#    mp.dps = 60
+#    def foldnorm_sf(x, c):
+#        x = mp.mpf(x)
+#        c = mp.mpf(c)
+#        return mp.ncdf(-x+c) + mp.ncdf(-x-c)
+#
+# E.g.
+#
+#    >>> float(foldnorm_sf(2, 1))
+#    0.16000515196308715
+#
+@pytest.mark.parametrize('x, c, expected',
+                         [(2, 1, 0.16000515196308715),
+                          (20, 1, 8.527223952630977e-81),
+                          (10, 15, 0.9999997133484281),
+                          (25, 15, 7.619853024160525e-24)])
+def test_foldnorm_sf(x, c, expected):
+    sf = stats.foldnorm.sf(x, c)
+    assert_allclose(sf, expected, 1e-14)
+
+
 def test_stats_shapes_argcheck():
     # stats method was failing for vector shapes if some of the values
     # were outside of the allowed range, see gh-2678


### PR DESCRIPTION
Another straightforward enhancement that implements _sf for the foldnorm distribution.

The second commit is an unrelated tweak to a betaprime test that addresses https://github.com/scipy/scipy/pull/17562#discussion_r1044894967.  The change was not significant enough to warrant its own PR, so I include it here instead.