### PR TITLE
REV: integrate.qmc_quad: delay release to SciPy 1.11.0

### DIFF
--- a/scipy/integrate/__init__.py
+++ b/scipy/integrate/__init__.py
@@ -20,7 +20,6 @@ Integrating functions, given function object
    quadrature    -- Integrate with given tolerance using Gaussian quadrature
    romberg       -- Integrate func using Romberg integration
    newton_cotes  -- Weights and error coefficient for Newton-Cotes integration
-   qmc_quad      -- N-D integration using Quasi-Monte Carlo quadrature
    IntegrationWarning -- Warning on issues during integration
    AccuracyWarning  -- Warning on issues during quadrature integration
 

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -19,7 +19,7 @@ from scipy._lib._util import _rng_spawn
 __all__ = ['fixed_quad', 'quadrature', 'romberg', 'romb',
            'trapezoid', 'trapz', 'simps', 'simpson',
            'cumulative_trapezoid', 'cumtrapz', 'newton_cotes',
-           'qmc_quad', 'AccuracyWarning']
+           'AccuracyWarning']
 
 
 # Make See Also linking for our local copy work properly

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -1049,11 +1049,11 @@ def newton_cotes(rn, equal=0):
 def _qmc_quad_iv(func, a, b, n_points, n_estimates, qrng, log):
 
     # lazy import to avoid issues with partially-initialized submodule
-    if not hasattr(qmc_quad, 'qmc'):
+    if not hasattr(_qmc_quad, 'qmc'):
         from scipy import stats
-        qmc_quad.stats = stats
+        _qmc_quad.stats = stats
     else:
-        stats = qmc_quad.stats
+        stats = _qmc_quad.stats
 
     if not callable(func):
         message = "`func` must be callable."
@@ -1123,8 +1123,8 @@ def _qmc_quad_iv(func, a, b, n_points, n_estimates, qrng, log):
 QMCQuadResult = namedtuple('QMCQuadResult', ['integral', 'standard_error'])
 
 
-def qmc_quad(func, a, b, *, n_points=1024, n_estimates=8, qrng=None,
-             log=False, args=None):
+def _qmc_quad(func, a, b, *, n_points=1024, n_estimates=8, qrng=None,
+              log=False, args=None):
     """
     Compute an integral in N-dimensions using Quasi-Monte Carlo quadrature.
 

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -7,7 +7,7 @@ from numpy.testing import (assert_equal, assert_almost_equal, assert_allclose,
 from scipy.integrate import (quadrature, romberg, romb, newton_cotes,
                              cumulative_trapezoid, cumtrapz, trapz, trapezoid,
                              quad, simpson, simps, fixed_quad, AccuracyWarning)
-from scipy.integrate._quadrature import qmc_quad
+from scipy.integrate._quadrature import _qmc_quad as qmc_quad
 from scipy import stats, special as sc
 
 

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -6,8 +6,8 @@ from numpy.testing import (assert_equal, assert_almost_equal, assert_allclose,
 
 from scipy.integrate import (quadrature, romberg, romb, newton_cotes,
                              cumulative_trapezoid, cumtrapz, trapz, trapezoid,
-                             quad, simpson, simps, fixed_quad, AccuracyWarning,
-                             qmc_quad)
+                             quad, simpson, simps, fixed_quad, AccuracyWarning)
+from scipy.integrate._quadrature import qmc_quad
 from scipy import stats, special as sc
 
 


### PR DESCRIPTION
#### Reference issue
gh-16923
gh-17628

#### What does this implement/fix?
gh-16923 added `scipy.integrate.qmc_quad`. In gh-17628, we discussed that the interface of the callable accepted by both of these functions should match, but they currently do not. To avoid rushing a change in the interface of either function, this makes `qmc_quad` private (and renames it to `_qmc_quad`. Once we settle on the desired interface, we'll make it public again for release in 1.11.0.

#### Additional information
Hope this is an easy backport @tylerjereddy, since the diff is small. Sorry to ask for this so late in the game, but we think it's important to maintain consistency.