### PR TITLE
MAINT: optimize.toms748: correct "rtol too small" message

### DIFF
--- a/scipy/optimize/_zeros_py.py
+++ b/scipy/optimize/_zeros_py.py
@@ -1372,7 +1372,7 @@ def toms748(f, a, b, args=(), k=1,
     if xtol <= 0:
         raise ValueError("xtol too small (%g <= 0)" % xtol)
     if rtol < _rtol / 4:
-        raise ValueError("rtol too small (%g < %g)" % (rtol, _rtol))
+        raise ValueError("rtol too small (%g < %g)" % (rtol, _rtol/4))
     maxiter = operator.index(maxiter)
     if maxiter < 1:
         raise ValueError("maxiter must be greater than 0")

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -836,3 +836,26 @@ def test_gh5584(solver_name, rs_interface):
     res = res if rs_interface else res[1]
     assert res.converged
     assert_allclose(res.root, 0, atol=1e-8)
+
+
+def test_gh13407():
+    # gh-13407 reported that the message produced by `scipy.optimize.toms748`
+    # when `rtol < eps` is incorrect, and also that toms748 is unusual in
+    # accepting `rtol` as low as eps while other solvers raise at 4*eps. Check
+    # that the error message has been corrected and that `rtol=eps` can produce
+    # a lower function value than `rtol=4*eps`.
+    def f(x):
+        return x**3 - 2*x - 5
+
+    xtol = 1e-300
+    eps = np.finfo(float).eps
+    x1 = zeros.toms748(f, 1e-10, 1e10, xtol=xtol, rtol=1*eps)
+    f1 = f(x1)
+    x4 = zeros.toms748(f, 1e-10, 1e10, xtol=xtol, rtol=4*eps)
+    f4 = f(x4)
+    assert f1 < f4
+
+    # using old-style syntax to get exactly the same message
+    message = r"rtol too small \(%g < %g\)" % (eps/2, eps)
+    with pytest.raises(ValueError, match=message):
+        zeros.toms748(f, 1e-10, 1e10, xtol=xtol, rtol=eps/2)


### PR DESCRIPTION
#### Reference issue
Closes gh-13407

#### What does this implement/fix?
gh-13407 reported that the error message produced by `scipy.optimize.toms748` when `rtol < eps` (where `eps = np.finfo(float).eps`) is incorrect. It also notes that `toms748` is unusual in that it accepts `rtol` as low as `eps` while other solvers raise at `4*eps`. 

This PR fixes the error message. It also demonstrates that `rtol=eps` can produce a lower function value than `rtol=4*eps`, so it is not wrong to allow the user to pass `rtol=eps`.

