### PR TITLE
MAINT: optimize.curve_fit: memoize `f` and `jac`

### DIFF
--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -496,15 +496,19 @@ def leastsq(func, x0, args=(), Dfun=None, full_output=0,
 
 
 def _lightweight_memoizer(f):
-
+    # very shallow memoization - only remember the first set of parameters
+    # and corresponding function value to address gh-13670
     def _memoized_func(params):
         if np.all(_memoized_func.last_params == params):
             return _memoized_func.last_val
-        else:
-            val = f(params)
+
+        val = f(params)
+
+        if _memoized_func.last_params is None:
             _memoized_func.last_params = np.copy(params)
             _memoized_func.last_val = val
-            return val
+
+        return val
 
     _memoized_func.last_params = None
     _memoized_func.last_val = None


### PR DESCRIPTION
#### Reference issue
Closes gh-13670

#### What does this implement/fix?
gh-13670 reported that `curve_fit` executes the model several times at the same values of the parameters. This PR uses memoization to prevent this from occurring.

#### Additional information
I added a new, minimalistic memoizing wrapper because I wasn't sure whether we wanted all the features of the other memoizing wrappers. I could try using `functools.lru_cache` or another wrapper, if desired.

I'm not sure if we want to do this. Whether we merge this or not, I think gh-13670 should be closed. Based on @andyfaff's analysis in gh-13670, it doesn't sound like these calls are egregious, so I don't think it's worth trying to fix this issue the invasive way (i.e. changing Fortran code).