### PR TITLE
MAINT: optimize.minimize_scalar: enforce output shape consistency

### DIFF
--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -921,18 +921,21 @@ def minimize_scalar(fun, bracket=None, bounds=None, args=(),
         options['disp'] = 2 * int(disp)
 
     if meth == '_custom':
-        return method(fun, args=args, bracket=bracket, bounds=bounds, **options)
+        res = method(fun, args=args, bracket=bracket, bounds=bounds, **options)
     elif meth == 'brent':
-        return _minimize_scalar_brent(fun, bracket, args, **options)
+        res = _minimize_scalar_brent(fun, bracket, args, **options)
     elif meth == 'bounded':
         if bounds is None:
             raise ValueError('The `bounds` parameter is mandatory for '
                              'method `bounded`.')
-        return _minimize_scalar_bounded(fun, bounds, args, **options)
+        res = _minimize_scalar_bounded(fun, bounds, args, **options)
     elif meth == 'golden':
-        return _minimize_scalar_golden(fun, bracket, args, **options)
+        res = _minimize_scalar_golden(fun, bracket, args, **options)
     else:
         raise ValueError('Unknown solver %s' % method)
+
+    res.x = np.asarray(res.x).squeeze()[()]
+    return res
 
 
 def _remove_from_bounds(bounds, i_fixed):

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -934,7 +934,11 @@ def minimize_scalar(fun, bracket=None, bounds=None, args=(),
     else:
         raise ValueError('Unknown solver %s' % method)
 
-    res.x = np.asarray(res.x).squeeze()[()]
+    # gh-16196 reported inconsistencies in the output shape of `res.x`. While
+    # fixing this, future-proof it for when the function is vectorized:
+    # the shape of `res.x` should match that of `res.fun`.
+    res.fun = np.asarray(res.fun)[()]
+    res.x = np.reshape(res.x, res.fun.shape)[()]
     return res
 
 

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -1881,12 +1881,13 @@ class TestOptimizeScalar:
     @pytest.mark.filterwarnings('ignore::RuntimeWarning')
     @pytest.mark.parametrize("method", MINIMIZE_SCALAR_METHODS)
     @pytest.mark.parametrize("tol", [1, 1e-6])
-    def test_minimize_scalar_output_dimensionality_gh16196(self, method, tol):
+    @pytest.mark.parametrize("fshape", [(), (1,), (1, 1)])
+    def test_minimize_scalar_dimensionality_gh16196(self, method, tol, fshape):
         # gh-16196 reported that the output shape of `minimize_scalar` was not
-        # consistent when an objective function returned an array.
-        # Check that the output is always a NumPy scalar.
+        # consistent when an objective function returned an array. Check that
+        # `res.fun` and `res.x` are now consistent.
         def f(x):
-            return np.array(x**4).reshape(1)
+            return np.array(x**4).reshape(fshape)
 
         a, b = -0.1, 0.2
         kwargs = (dict(bracket=(a, b)) if method != "bounded"
@@ -1894,8 +1895,7 @@ class TestOptimizeScalar:
         kwargs.update(dict(method=method, tol=tol))
 
         res = optimize.minimize_scalar(f, **kwargs)
-        assert res.x.shape == tuple()
-        assert res.fun.shape == f(res.x).shape
+        assert res.x.shape == res.fun.shape == f(res.x).shape == fshape
 
 
 def test_brent_negative_tolerance():


### PR DESCRIPTION
#### Reference issue
Closes gh-16196

#### What does this implement/fix?
gh-16196 reported that the output shape of `minimize_scalar`'s result object `x` attribute was consistent when an objective function returned an array. This PR ensures that `x` attribute is always a NumPy scalar.

#### Additional information
The user is only supposed to pass in a 1D array for `bounds`/`bracket`, so ensuring 0D output would not be wrong. But we should vectorize this function in the future, and while we're fixing this bug, it would better for the policy be that the shape of `res.x` (the values of `x` that zero all outputs of `f(x)`) should match that of `res.fun == f(res.x)`, which is controlled by the user. 

This will also be less disruptive to users. Those who use `brent` and `bounded` have already accommodated for `res.x` being an array if `f` returns an array, e.g. `res.x[0]`. If we were to enforce that `res.x` should be a scalar, they will begin to get an error. Users of `golden` will begin getting the array that they should have been getting all along, but size 1 NumPy arrays tend to behave just like scalars in computations in most cases. And this way, we don't change things _again_ when we want to vectorize things.
