### PR TITLE
DOC: pointbiserialr correlation formula notation fix.

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -4170,6 +4170,7 @@ class PearsonRResult(PearsonRResultBase):
         coefficient `statistic` for the given confidence level.
 
     """
+
     def __init__(self, statistic, pvalue, alternative, n):
         super().__init__(statistic, pvalue)
         self._alternative = alternative
@@ -5013,11 +5014,11 @@ def pointbiserialr(x, y):
         r_{pb} = \frac{\overline{Y_{1}} -
                  \overline{Y_{0}}}{s_{y}}\sqrt{\frac{N_{1} N_{2}}{N (N - 1))}}
 
-    Where :math:`\overline{Y_{0}}` and :math:`\overline{Y_{1}}` are means of the
-    metric observations coded 0 and 1 respectively; :math:`N_{0}` and :math:`N_{1}`
-    are number of observations coded 0 and 1 respectively; :math:`N` is the
-    total number of observations and :math:`s_{y}` is the standard
-    deviation of all the metric observations.
+    Where :math:`\overline{Y_{0}}` and :math:`\overline{Y_{1}}` are means of
+    the metric observations coded 0 and 1 respectively; :math:`N_{0}` and
+    :math:`N_{1}` are number of observations coded 0 and 1 respectively; :math:`N`
+    is the total number of observations and :math:`s_{y}` is the standard deviation
+    of all the metric observations.
 
     A value of :math:`r_{pb}` that is significantly different from zero is
     completely equivalent to a significant difference in means between the two

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -5013,8 +5013,8 @@ def pointbiserialr(x, y):
         r_{pb} = \frac{\overline{Y_{1}} -
                  \overline{Y_{0}}}{s_{y}}\sqrt{\frac{N_{1} N_{2}}{N (N - 1))}}
 
-    Where :math:`Y_{0}` and :math:`Y_{1}` are means of the metric
-    observations coded 0 and 1 respectively; :math:`N_{0}` and :math:`N_{1}`
+    Where :math:`\overline{Y_{0}}` and :math:`\overline{Y_{1}}` are means of the
+    metric observations coded 0 and 1 respectively; :math:`N_{0}` and :math:`N_{1}`
     are number of observations coded 0 and 1 respectively; :math:`N` is the
     total number of observations and :math:`s_{y}` is the standard
     deviation of all the metric observations.

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -4170,7 +4170,6 @@ class PearsonRResult(PearsonRResultBase):
         coefficient `statistic` for the given confidence level.
 
     """
-
     def __init__(self, statistic, pvalue, alternative, n):
         super().__init__(statistic, pvalue)
         self._alternative = alternative
@@ -5014,11 +5013,11 @@ def pointbiserialr(x, y):
         r_{pb} = \frac{\overline{Y_{1}} -
                  \overline{Y_{0}}}{s_{y}}\sqrt{\frac{N_{1} N_{2}}{N (N - 1))}}
 
-    Where :math:`\overline{Y_{0}}` and :math:`\overline{Y_{1}}` are means of
-    the metric observations coded 0 and 1 respectively; :math:`N_{0}` and
-    :math:`N_{1}` are number of observations coded 0 and 1 respectively; :math:`N`
-    is the total number of observations and :math:`s_{y}` is the standard deviation
-    of all the metric observations.
+    Where :math:`\overline{Y_{0}}` and :math:`\overline{Y_{1}}` are means
+    of the metric observations coded 0 and 1 respectively; :math:`N_{0}` and
+    :math:`N_{1}` are number of observations coded 0 and 1 respectively;
+    :math:`N` is the total number of observations and :math:`s_{y}` is the
+    standard deviation of all the metric observations.
 
     A value of :math:`r_{pb}` that is significantly different from zero is
     completely equivalent to a significant difference in means between the two

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -5010,8 +5010,10 @@ def pointbiserialr(x, y):
 
     .. math::
 
-        r_{pb} = \frac{\overline{Y_{1}} -
-                 \overline{Y_{0}}}{s_{y}}\sqrt{\frac{N_{1} N_{2}}{N (N - 1))}}
+        r_{pb} = \frac{\overline{Y_1} - \overline{Y_0}}
+                      {s_y}
+                 \sqrt{\frac{N_0 N_1}
+                            {N (N - 1)}}
 
     Where :math:`\overline{Y_{0}}` and :math:`\overline{Y_{1}}` are means
     of the metric observations coded 0 and 1 respectively; :math:`N_{0}` and


### PR DESCRIPTION
Adjust the Y_0, Y_1 overline to refer to the value of the mean (Y bar) instead of the set Y as it is done in the reference: https://onlinelibrary.wiley.com/doi/10.1002/9781118445112.stat06227

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
