### PR TITLE
MAINT: prepare for SciPy 1.10.0 "final"

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -46,7 +46,7 @@ jobs:
           gfortran --version
       - name: pip-packages
         run: |
-          pip install numpy==1.22.2 cython "pybind11!=2.10.2" pythran meson ninja pytest pytest-xdist pytest-timeout pooch
+          pip install numpy==1.22.2 cython pybind11 pythran meson ninja pytest pytest-xdist pytest-timeout pooch
       - name: openblas-libs
         run: |
           # Download and install pre-built OpenBLAS library

--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -517,6 +517,7 @@ Authors
 * TianyiQ (1) +
 * Tiger (1) +
 * Will Tirone (1)
+* Ajay Shanker Tripathi (1) +
 * Edgar Andrés Margffoy Tuay (1) +
 * Dmitry Ulyumdzhiev (1) +
 * Hari Vamsi (1) +
@@ -539,7 +540,7 @@ Authors
 * Egor Zemlyanoy (19)
 * Gavin Zhang (3) +
 
-A total of 183 people contributed to this release.
+A total of 184 people contributed to this release.
 People with a "+" by their names contributed a patch for the first time.
 This list of names is automatically generated, and may not be fully complete.
 

--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -2,8 +2,6 @@
 SciPy 1.10.0 Release Notes
 ==========================
 
-.. note:: Scipy 1.10.0 is not released yet!
-
 .. contents::
 
 SciPy 1.10.0 is the culmination of 6 months of hard work. It contains
@@ -419,7 +417,7 @@ Authors
 * David Gilbertson (1) +
 * Ralf Gommers (251)
 * Marco Gorelli (2) +
-* Matt Haberland (383)
+* Matt Haberland (387)
 * Andrew Hawryluk (2) +
 * Christoph Hohnerlein (2) +
 * Loïc Houpert (2) +
@@ -489,7 +487,7 @@ Authors
 * Ilhan Polat (6)
 * Akshita Prasanth (2) +
 * Sean Quinn (1)
-* Tyler Reddy (142)
+* Tyler Reddy (155)
 * Martin Reinecke (1)
 * Ned Richards (1)
 * Marie Roald (1) +
@@ -509,6 +507,7 @@ Authors
 * Alexander Soare (1) +
 * Bjørge Solli (2) +
 * Scott Staniewicz (1)
+* Ethan Steinberg (3) +
 * Albert Steppi (3)
 * Thomas Stoeger (1) +
 * Kai Striega (4)
@@ -540,7 +539,7 @@ Authors
 * Egor Zemlyanoy (19)
 * Gavin Zhang (3) +
 
-A total of 182 people contributed to this release.
+A total of 183 people contributed to this release.
 People with a "+" by their names contributed a patch for the first time.
 This list of names is automatically generated, and may not be fully complete.
 
@@ -681,6 +680,7 @@ Issues closed for 1.10.0
 * `#17412 <https://github.com/scipy/scipy/issues/17412>`__: BUG: Meson error:compiler for language "cpp", not specified for...
 * `#17444 <https://github.com/scipy/scipy/issues/17444>`__: BUG: beta.ppf causes segfault
 * `#17468 <https://github.com/scipy/scipy/issues/17468>`__: Weird errors with running the tests \`scipy.stats.tests.test_distributions\`...
+* `#17518 <https://github.com/scipy/scipy/issues/17518>`__: ENH: stats.pearsonr: support complex data
 * `#17523 <https://github.com/scipy/scipy/issues/17523>`__: BUG: \`[source]\` button in the docs sending to the wrong place
 * `#17578 <https://github.com/scipy/scipy/issues/17578>`__: TST, BLD, CI: 1.10.0rc1 wheel build/test failures
 * `#17619 <https://github.com/scipy/scipy/issues/17619>`__: BUG: core dump when calling scipy.optimize.linprog
@@ -1204,3 +1204,7 @@ Pull requests for 1.10.0
 * `#17640 <https://github.com/scipy/scipy/pull/17640>`__: MAINT: prepare for SciPy 1.10.0rc2
 * `#17645 <https://github.com/scipy/scipy/pull/17645>`__: MAINT: stats.rankdata: ensure consistent shape handling
 * `#17653 <https://github.com/scipy/scipy/pull/17653>`__: MAINT: pybind11 win exclusion
+* `#17656 <https://github.com/scipy/scipy/pull/17656>`__: MAINT: 1.10.0rc2 backports, round two
+* `#17662 <https://github.com/scipy/scipy/pull/17662>`__: Fix undefined behavior within scipy.fft
+* `#17686 <https://github.com/scipy/scipy/pull/17686>`__: REV: integrate.qmc_quad: delay release to SciPy 1.11.0
+* `#17689 <https://github.com/scipy/scipy/pull/17689>`__: REL: integrate.qmc_quad: remove from release notes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,9 @@ build-backend = 'mesonpy'
 requires = [
     "meson-python>=0.11.0,<0.12.0",
     "Cython>=0.29.32,<3.0",
-    "pybind11>=2.10.0,!=2.10.2,<2.11.0",
+    # conservatively avoid issues from
+    # https://github.com/pybind/pybind11/issues/4420
+    "pybind11==2.10.1",
     "pythran>=0.12.0,<0.13.0",
     # `wheel` is needed for non-isolated builds, given that `meson-python`
     # doesn't list it as a runtime requirement (at least in 0.5.0)

--- a/scipy/fft/_pocketfft/pypocketfft.cxx
+++ b/scipy/fft/_pocketfft/pypocketfft.cxx
@@ -37,7 +37,6 @@ using clong = std::complex<ldbl_t>;
 using f32 = float;
 using f64 = double;
 using flong = ldbl_t;
-auto None = py::none();
 
 shape_t copy_shape(const py::array &arr)
   {
@@ -716,6 +715,8 @@ out : int
 PYBIND11_MODULE(pypocketfft, m)
   {
   using namespace pybind11::literals;
+
+  auto None = py::none();
 
   m.doc() = pypocketfft_DS;
   m.def("c2c", c2c, c2c_DS, "a"_a, "axes"_a=None, "forward"_a=true,

--- a/scipy/integrate/__init__.py
+++ b/scipy/integrate/__init__.py
@@ -20,7 +20,6 @@ Integrating functions, given function object
    quadrature    -- Integrate with given tolerance using Gaussian quadrature
    romberg       -- Integrate func using Romberg integration
    newton_cotes  -- Weights and error coefficient for Newton-Cotes integration
-   qmc_quad      -- N-D integration using Quasi-Monte Carlo quadrature
    IntegrationWarning -- Warning on issues during integration
    AccuracyWarning  -- Warning on issues during quadrature integration
 

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -19,7 +19,7 @@ from scipy._lib._util import _rng_spawn
 __all__ = ['fixed_quad', 'quadrature', 'romberg', 'romb',
            'trapezoid', 'trapz', 'simps', 'simpson',
            'cumulative_trapezoid', 'cumtrapz', 'newton_cotes',
-           'qmc_quad', 'AccuracyWarning']
+           'AccuracyWarning']
 
 
 # Make See Also linking for our local copy work properly

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -1049,11 +1049,11 @@ def newton_cotes(rn, equal=0):
 def _qmc_quad_iv(func, a, b, n_points, n_estimates, qrng, log):
 
     # lazy import to avoid issues with partially-initialized submodule
-    if not hasattr(qmc_quad, 'qmc'):
+    if not hasattr(_qmc_quad, 'qmc'):
         from scipy import stats
-        qmc_quad.stats = stats
+        _qmc_quad.stats = stats
     else:
-        stats = qmc_quad.stats
+        stats = _qmc_quad.stats
 
     if not callable(func):
         message = "`func` must be callable."
@@ -1123,8 +1123,8 @@ def _qmc_quad_iv(func, a, b, n_points, n_estimates, qrng, log):
 QMCQuadResult = namedtuple('QMCQuadResult', ['integral', 'standard_error'])
 
 
-def qmc_quad(func, a, b, *, n_points=1024, n_estimates=8, qrng=None,
-             log=False, args=None):
+def _qmc_quad(func, a, b, *, n_points=1024, n_estimates=8, qrng=None,
+              log=False, args=None):
     """
     Compute an integral in N-dimensions using Quasi-Monte Carlo quadrature.
 

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -7,7 +7,7 @@ from numpy.testing import (assert_equal, assert_almost_equal, assert_allclose,
 from scipy.integrate import (quadrature, romberg, romb, newton_cotes,
                              cumulative_trapezoid, cumtrapz, trapz, trapezoid,
                              quad, simpson, simps, fixed_quad, AccuracyWarning)
-from scipy.integrate._quadrature import qmc_quad
+from scipy.integrate._quadrature import _qmc_quad as qmc_quad
 from scipy import stats, special as sc
 
 

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -6,8 +6,8 @@ from numpy.testing import (assert_equal, assert_almost_equal, assert_allclose,
 
 from scipy.integrate import (quadrature, romberg, romb, newton_cotes,
                              cumulative_trapezoid, cumtrapz, trapz, trapezoid,
-                             quad, simpson, simps, fixed_quad, AccuracyWarning,
-                             qmc_quad)
+                             quad, simpson, simps, fixed_quad, AccuracyWarning)
+from scipy.integrate._quadrature import qmc_quad
 from scipy import stats, special as sc
 
 


### PR DESCRIPTION
- Backports included:
  - gh-17662
  - gh-17686
- Update the release notes accordingly, including removal of note about SciPy `1.10.0` not being released yet--let me know if you'd prefer that I do an RC3 instead of the final release at this stage
- I went with pinning `pybind11` to version `2.10.1` in `pyproject.toml` out of an abundance of caution--we really should be safe to unpin because:
  - the fix for the segfault problem is included in this PR
  - `pybind11` `2.10.2` has been yanked from PyPI
- perhaps we go super-conservative for `1.10.0`, and then relax this later in the `1.10.x` series if things are looking solid with newer `pybind11` patch releases? (they almost certainly should be just fine)
- version numbering changes are normally done in the release process proper (i.e, switch from RC3-> final/released, etc.)
