### PR TITLE
MAINT: implicit float conversion in rgi test

### DIFF
--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -559,7 +559,6 @@ class TestRegularGridInterpolator:
                 interp = RegularGridInterpolator(points, values[..., i, j],
                                                  method=method,
                                                  bounds_error=False)
-
                 vs[i, j] = interp(sample).item()
         v2 = np.expand_dims(vs, axis=0)
         assert_allclose(v, v2, atol=1e-14, err_msg=method)

--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -559,7 +559,8 @@ class TestRegularGridInterpolator:
                 interp = RegularGridInterpolator(points, values[..., i, j],
                                                  method=method,
                                                  bounds_error=False)
-                vs[i, j] = interp(sample)
+
+                vs[i, j] = interp(sample).item()
         v2 = np.expand_dims(vs, axis=0)
         assert_allclose(v, v2, atol=1e-14, err_msg=method)
 
@@ -590,7 +591,7 @@ class TestRegularGridInterpolator:
                 interp = RegularGridInterpolator(points, values[..., i, j],
                                                  method=method,
                                                  bounds_error=False)
-                vs[i, j] = interp(sample)
+                vs[i, j] = interp(sample).item()
         v2 = np.expand_dims(vs, axis=0)
         assert_allclose(v, v2, atol=1e-14, err_msg=method)
 


### PR DESCRIPTION
This is another small fix for array-scalar conversion like https://github.com/scipy/scipy/pull/13864. Tests will otherwise yield a warning with NumPy's https://github.com/numpy/numpy/pull/10615.