### PR TITLE
ENH: Inverse wishart entropy

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -2895,11 +2895,10 @@ class invwishart_gen(wishart_gen):
 
         return _squeeze_output(out)
 
-    def _entropy(self, dim, df, scale):
+    def _entropy(self, dim, df, log_det_scale):
         # reference: eq. (17) from ref. 3
         psi_eval_points = [0.5 * (df - dim + i) for i in range(1, dim + 1)]
         psi_eval_points = np.asarray(psi_eval_points)
-        _, log_det_scale = self._cholesky_logdet(scale)
         return multigammaln(0.5 * df, dim) + 0.5 * dim * df + \
             0.5 * (dim + 1) * (log_det_scale - _LOG_2) - \
             0.5 * (df + dim + 1) * \
@@ -2907,7 +2906,8 @@ class invwishart_gen(wishart_gen):
 
     def entropy(self, df, scale):
         dim, df, scale = self._process_parameters(df, scale)
-        return self._entropy(dim, df, scale)
+        _, log_det_scale = self._cholesky_logdet(scale)
+        return self._entropy(dim, df, log_det_scale)
 
 
 invwishart = invwishart_gen()
@@ -2977,7 +2977,7 @@ class invwishart_frozen(multi_rv_frozen):
         return _squeeze_output(out)
 
     def entropy(self):
-        return self._dist._entropy(self.dim, self.df, self.scale)
+        return self._dist._entropy(self.dim, self.df, self.log_det_scale)
 
 
 # Set frozen generator docstrings from corresponding docstrings in

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -2896,6 +2896,7 @@ class invwishart_gen(wishart_gen):
         return _squeeze_output(out)
 
     def entropy(self, df, scale):
+        # reference: eq. (17) from ref. 3
         dim, df, scale = self._process_parameters(df, scale)
         psi_eval_points = [0.5 * (df - dim + i) for i in range(1, dim + 1)]
         psi_eval_points = np.asarray(psi_eval_points)

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -2556,6 +2556,9 @@ class invwishart_gen(wishart_gen):
     .. [2] M.C. Jones, "Generating Inverse Wishart Matrices", Communications
            in Statistics - Simulation and Computation, vol. 14.2, pp.511-514,
            1985.
+    .. [3] Gupta, M. and Srivastava, S. "Parametric Bayesian Estimation of
+           Differential Entropy and Relative Entropy". Entropy 12, 818 - 843.
+           2010.
 
     Examples
     --------
@@ -2892,9 +2895,15 @@ class invwishart_gen(wishart_gen):
 
         return _squeeze_output(out)
 
-    def entropy(self):
-        # Need to find reference for inverse Wishart entropy
-        raise AttributeError
+    def entropy(self, df, scale):
+        dim, df, scale = self._process_parameters(df, scale)
+        psi_eval_points = [0.5 * (df - dim + i) for i in range(1, dim + 1)]
+        psi_eval_points = np.asarray(psi_eval_points)
+        _, logdet = np.linalg.slogdet(scale)
+        return multigammaln(0.5 * df, dim) + 0.5 * dim * df + \
+            0.5 * (dim + 1) * (logdet - _LOG_2) - \
+            0.5 * (df + dim + 1) * \
+            psi(psi_eval_points, out=psi_eval_points).sum()
 
 
 invwishart = invwishart_gen()
@@ -2964,8 +2973,7 @@ class invwishart_frozen(multi_rv_frozen):
         return _squeeze_output(out)
 
     def entropy(self):
-        # Need to find reference for inverse Wishart entropy
-        raise AttributeError
+        self._dist.entropy(self.df, self.scale)
 
 
 # Set frozen generator docstrings from corresponding docstrings in

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -1569,7 +1569,7 @@ class TestInvwishart:
     def test_1D_is_invgamma(self):
         # The 1-dimensional inverse Wishart with an identity scale matrix is
         # just an inverse gamma distribution.
-        # Test variance, mean, pdf
+        # Test variance, mean, pdf, entropy
         # Kolgomorov-Smirnov test for rvs
         np.random.seed(482974)
 
@@ -1595,6 +1595,9 @@ class TestInvwishart:
             args = (df/2, 0, 1./2)
             alpha = 0.01
             check_distribution_rvs('invgamma', args, alpha, rvs)
+
+            # entropy
+            assert_allclose(iw.entropy(), ig.entropy())
 
     def test_wishart_invwishart_2D_rvs(self):
         dim = 3


### PR DESCRIPTION
#### What does this implement/fix?
Adds the entropy method for the inverse Wishart distribution which is currently missing.

#### Additional information
An analytical formula for the entropy was derived here: https://www.mdpi.com/1099-4300/12/4/818
It essentials reads as

![image](https://user-images.githubusercontent.com/40656107/210276592-26ff1165-dd2f-40dc-8f9a-6eb062ae287f.png)

A plot for two different scales in 3 dimensions (identity matrix and one with a few off diagonal entries):

![Inv_WIshart_Entropy](https://user-images.githubusercontent.com/40656107/210276461-49567168-f036-4566-9426-befe6bfef554.png)


