### PR TITLE
MAINT: forward port 1.10.0 relnotes

### DIFF
--- a/doc/release/1.10.0-notes.rst
+++ b/doc/release/1.10.0-notes.rst
@@ -2,11 +2,9 @@
 SciPy 1.10.0 Release Notes
 ==========================
 
-.. note:: Scipy 1.10.0 is not released yet!
-
 .. contents::
 
-SciPy 1.10.0 is the culmination of X months of hard work. It contains
+SciPy 1.10.0 is the culmination of 6 months of hard work. It contains
 many new features, numerous bug-fixes, improved test coverage and better
 documentation. There have been a number of deprecations and API changes
 in this release, which are documented below. All users are encouraged to
@@ -71,14 +69,8 @@ New features
 
 `scipy.integrate` improvements
 ==============================
-- Added `scipy.integrate.qmc_quad`, which performs quadrature using Quasi-Monte
-  Carlo points.
 - Added parameter ``complex_func`` to `scipy.integrate.quad`, which can be set
   ``True`` to integrate a complex integrand.
-
-
-`scipy.cluster` improvements
-============================
 
 
 `scipy.interpolate` improvements
@@ -162,17 +154,10 @@ New features
   Lanczos window, also known as a sinc window.
 
 
-`scipy.sparse` improvements
-===========================
-
-
 `scipy.sparse.csgraph` improvements
 ===================================
 - the performance of `scipy.sparse.csgraph.dijkstra` has been improved, and
   star graphs in particular see a marked performance improvement
-
-`scipy.spatial` improvements
-============================
 
 
 `scipy.special` improvements
@@ -193,123 +178,137 @@ New features
   Cramer-von Mises, and Anderson-Darling).
 - Improved `scipy.stats.bootstrap`: Default method ``'BCa'`` now supports
   multi-sample statistics. Also, the bootstrap distribution is returned in the
-  result object, and the result object can be passed into the function to add
-  additional resamples or change the confidence interval level and type.
-- Added a ``confidence_interval`` method to the result object returned by
-  `scipy.stats.ttest_1samp` and `scipy.stats.ttest_rel``.
+  result object, and the result object can be passed into the function as
+  parameter ``bootstrap_result`` to add additional resamples or change the
+  confidence interval level and type.
 - Added maximum spacing estimation to `scipy.stats.fit`.
-- Added `scipy.stats.contingency.odds_ratio` to compute both the conditional and
-  unconditional odds ratio for 2x2 contingency tables and corresponding
-  confidence intervals.
 - Added the Poisson means test ("E-test") as `scipy.stats.poisson_means_test`.
-- Added `scipy.stats.expectile`, which generalizes the expected value in the
-  same way as quantiles are a generalization of the median.
+- Added new sample statistics.
+
+  - Added `scipy.stats.contingency.odds_ratio` to compute both the conditional
+    and unconditional odds ratios and corresponding confidence intervals for
+    2x2 contingency tables.
+  - Added `scipy.stats.directional_stats` to compute sample statistics of
+    n-dimensional directional data.
+  - Added `scipy.stats.expectile`, which generalizes the expected value in the
+    same way as quantiles are a generalization of the median.
+
 - Added new statistical distributions.
+
   - Added `scipy.stats.uniform_direction`, a multivariate distribution to
-  sample uniformly from the surface of a hypersphere.
+    sample uniformly from the surface of a hypersphere.
   - Added `scipy.stats.random_table`, a multivariate distribution to sample
-  uniformly from m x n contingency tables with provided marginals.
+    uniformly from m x n contingency tables with provided marginals.
   - Added `scipy.stats.truncpareto`, the truncated Pareto distribution.
+
 - Improved the ``fit`` method of several distributions.
+
   - `scipy.stats.skewnorm` and `scipy.stats.weibull_min` now use an analytical
-  solution when ``method='mm'``, which also serves a starting guess to improve
-  the performance of ``method='mle'``.
+    solution when ``method='mm'``, which also serves a starting guess to
+    improve the performance of ``method='mle'``.
   - `scipy.stats.gumbel_r` and `scipy.stats.gumbel_l`: analytical maximum
-  likelihood estimates have been extended to the cases in which location or
-  scale are fixed by the user.
+    likelihood estimates have been extended to the cases in which location or
+    scale are fixed by the user.
   - Analytical maximum likelihood estimates have been added for
-  `scipy.stats.powerlaw`.
+    `scipy.stats.powerlaw`.
+
 - Improved random variate sampling of several distributions.
+
   - Drawing multiple samples from `scipy.stats.matrix_normal`,
-  `scipy.stats.ortho_group`, `scipy.stats.special_ortho_group`, and
-  `scipy.stats.unitary_group` is faster.
+    `scipy.stats.ortho_group`, `scipy.stats.special_ortho_group`, and
+    `scipy.stats.unitary_group` is faster.
   - The ``rvs`` method of `scipy.stats.vonmises` now wraps to the interval
-  ``[-np.pi, np.pi]``
+    ``[-np.pi, np.pi]``.
   - Improved the reliability of `scipy.stats.loggamma` ``rvs`` method for small
-  values of the shape parameter.
+    values of the shape parameter.
+
 - Improved the speed and/or accuracy of functions of several statistical
   distributions.
+
   - Added `scipy.stats.Covariance` for better speed, accuracy, and user control
-  in multivariate normal calculations.
+    in multivariate normal calculations.
   - `scipy.stats.skewnorm` methods ``cdf``, ``sf``, ``ppf``, and ``isf``
-  methods now use the implementations from Boost, improving speed while
-  maintaining accuracy. The calculation of higher-order moments is also faster
-  and more accurate.
+    methods now use the implementations from Boost, improving speed while
+    maintaining accuracy. The calculation of higher-order moments is also
+    faster and more accurate.
   - `scipy.stats.invgauss` methods ``ppf`` and ``isf`` methods now use the
-  implementations from Boost, improving speed and accuracy.
+    implementations from Boost, improving speed and accuracy.
   - `scipy.stats.invweibull` methods ``sf`` and ``isf`` are more accurate for
-  small probability masses.
+    small probability masses.
   - `scipy.stats.nct` and `scipy.stats.ncx2` now rely on the implementations
-  from Boost, improving speed and accuracy.
+    from Boost, improving speed and accuracy.
   - Implemented the ``logpdf`` method of `scipy.stats.vonmises` for reliability
-  in extreme tails.
+    in extreme tails.
   - Implemented the ``isf`` method of `scipy.stats.levy` for speed and
-  accuracy.
+    accuracy.
   - Improved the robustness of `scipy.stats.studentized_range` for large ``df``
-  by adding an infinite degree-of-freedom approximation.
+    by adding an infinite degree-of-freedom approximation.
   - Added a parameter ``lower_limit`` to `scipy.stats.multivariate_normal`,
-  allowing the user to change the integration limit from -inf to a desired
-  value.
+    allowing the user to change the integration limit from -inf to a desired
+    value.
   - Improved the robustness of ``entropy`` of `scipy.stats.vonmises` for large
-  concentration values
+    concentration values.
+
 - Enhanced `scipy.stats.gaussian_kde`.
+
   - Added `scipy.stats.gaussian_kde.marginal`, which returns the desired
-  marginal distribution of the original kernel density estimate distribution.
+    marginal distribution of the original kernel density estimate distribution.
   - The ``cdf`` method of `scipy.stats.gaussian_kde` now accepts a
-  ``lower_limit`` parameter for integrating the PDF over a rectangular region.
+    ``lower_limit`` parameter for integrating the PDF over a rectangular region.
   - Moved calculations for `scipy.stats.gaussian_kde.logpdf` to Cython,
-  improving speed.
+    improving speed.
   - The global interpreter lock is released by the ``pdf`` method of
-  `scipy.stats.gaussian_kde` for improved multithreading performance.
+    `scipy.stats.gaussian_kde` for improved multithreading performance.
   - Replaced explicit matrix inversion with Cholesky decomposition for speed
-  and accuracy.
-- Statistical test functions that previously returned plain tuples now return
-  bunches, allowing attributes to be accessed by name. The `scipy.stats`
-  functions ``combine_pvalues``, ``fisher_exact``, ``chi2_contingency``,
-  ``median_test`` and ``mood`` have been updated.
-- The result objects returned by statistical test functions now consistently
-  use the attribute names ``statistic`` and ``pvalue``. Old attribute names are
-  allowed for backward compatibility. The `scipy.stats` functions
-  ``multiscale_graphcorr``, ``anderson_ksamp``, ``binomtest``, ``crosstab``,
-  ``pointbiserialr``, ``spearmanr``, ``kendalltau`` and ``weightedtau`` have
-  been updated.
-- `scipy.stats.anderson` now returns the parameters of the fitted distribution
-  in a `scipy.stats._result_classes.FitResult` object.
-- Kolmogorov-Smirnov tests (e.g. `scipy.stats.kstest`) return more information:
-  the location (argmax) at which the statistic is calculated, and the variant
-  of the statistic used.
-- Improved the performance of `scipy.stats.cramervonmises_2samp` and
-  `scipy.stats.ks_2samp` with ``method='exact'``.
-- Improved the performance of `scipy.stats.siegelslopes`.
-- Improved the performance of `scipy.stats.hdquantile_sd`
-- Added the ``scramble`` optional argument to `scipy.stats.qmc.LatinHypercube`. It
-  replaces ``centered`` which is now deprecated.
+    and accuracy.
+
+- Enhanced the result objects returned by many `scipy.stats` functions
+
+  - Added a ``confidence_interval`` method to the result object returned by
+    `scipy.stats.ttest_1samp` and `scipy.stats.ttest_rel`.
+  - The `scipy.stats` functions ``combine_pvalues``, ``fisher_exact``,
+    ``chi2_contingency``, ``median_test`` and ``mood`` now return
+    bunch objects rather than plain tuples, allowing attributes to be
+    accessed by name.
+  - Attributes of the result objects returned by ``multiscale_graphcorr``,
+    ``anderson_ksamp``, ``binomtest``, ``crosstab``, ``pointbiserialr``,
+    ``spearmanr``, ``kendalltau``, and ``weightedtau`` have been renamed to
+    ``statistic`` and ``pvalue`` for consistency throughout `scipy.stats`.
+    Old attribute names are still allowed for backward compatibility.
+  - `scipy.stats.anderson` now returns the parameters of the fitted
+    distribution in a `scipy.stats._result_classes.FitResult` object.
+  - The ``plot`` method of `scipy.stats._result_classes.FitResult` now accepts
+    a ``plot_type`` parameter; the options are ``'hist'`` (histogram, default),
+    ``'qq'`` (Q-Q plot), ``'pp'`` (P-P plot), and ``'cdf'`` (empirical CDF
+    plot).
+  - Kolmogorov-Smirnov tests (e.g. `scipy.stats.kstest`) now return the
+    location (argmax) at which the statistic is calculated and the variant
+    of the statistic used.
+
+- Improved the performance of several `scipy.stats` functions.
+
+  - Improved the performance of `scipy.stats.cramervonmises_2samp` and
+    `scipy.stats.ks_2samp` with ``method='exact'``.
+  - Improved the performance of `scipy.stats.siegelslopes`.
+  - Improved the performance of `scipy.stats.mstats.hdquantile_sd`.
+  - Improved the performance of `scipy.stats.binned_statistic_dd` for several
+    NumPy statistics, and binned statistics methods now support complex data.
+
+- Added the ``scramble`` optional argument to `scipy.stats.qmc.LatinHypercube`.
+  It replaces ``centered``, which is now deprecated.
 - Added a parameter ``optimization`` to all `scipy.stats.qmc.QMCEngine`
-  subclasses to improve characteristics of the quasi-random variates
-- Added `scipy.stats.directional_stats` to compute sample statistics of
-  n-dimensional directional data.
-- The ``plot`` method of `scipy.stats._result_classes.FitResult` now accepts a
-  ``plot_type`` parameter; the options are ``'hist'`` (histogram, default),
-  ``'qq'`` (Q-Q plot), ``'pp'`` (P-P plot), and ``'cdf'`` (empirical CDF plot).
+  subclasses to improve characteristics of the quasi-random variates.
 - Added tie correction to `scipy.stats.mood`.
 - Added tutorials for resampling methods in `scipy.stats`.
 - `scipy.stats.bootstrap`, `scipy.stats.permutation_test`, and
   `scipy.stats.monte_carlo_test` now automatically detect whether the provided
   ``statistic`` is vectorized, so passing the ``vectorized`` argument
   explicitly is no longer required to take advantage of vectorized statistics.
-- Improved speed of `scipy.stats.permutation_test` for permutation types
+- Improved the speed of `scipy.stats.permutation_test` for permutation types
   ``'samples'`` and ``'pairings'``.
-- Improved the performance of `scipy.stats.binned_statistic_dd` for several
-  NumPy statistics, and binned statistics methods now support complex data.
 - Added ``axis``, ``nan_policy``, and masked array support to
-  `scipy.stats.jarque_bera`
+  `scipy.stats.jarque_bera`.
 - Added the ``nan_policy`` optional argument to `scipy.stats.rankdata`.
-
-
-Other
------
-
-
 
 
 *******************
@@ -328,16 +327,13 @@ Deprecated features
 Expired Deprecations
 ********************
 - There is an ongoing effort to follow through on long-standing deprecations.
-  The following previously deprecated features are affected:
+- The following previously deprecated features are affected:
+
   - Removed ``cond`` & ``rcond`` kwargs in ``linalg.pinv``
   - Removed wrappers ``scipy.linalg.blas.{clapack, flapack}``
   - Removed ``scipy.stats.NumericalInverseHermite`` and removed ``tol`` & ``max_intervals`` kwargs from ``scipy.stats.sampling.NumericalInverseHermite``
   - Removed ``local_search_options`` kwarg frrom ``scipy.optimize.dual_annealing``.
 
-
-******************************
-Backwards incompatible changes
-******************************
 
 *************
 Other changes
@@ -361,6 +357,7 @@ Authors
 * Name (commits)
 * h-vetinari (10)
 * Jelle Aalbers (1)
+* Oriol Abril-Pla (1) +
 * Alan-Hung (1) +
 * Tania Allard (7)
 * Oren Amsalem (1) +
@@ -372,6 +369,7 @@ Authors
 * Sebastian Berg (1)
 * Aaron Berk (1) +
 * boatwrong (1) +
+* boeleman (1) +
 * Jake Bowhay (50)
 * Matthew Brett (4)
 * Evgeni Burovski (93)
@@ -392,7 +390,7 @@ Authors
 * cmgodwin (1) +
 * Christopher Cowden (2) +
 * Henry Cuzco (2) +
-* Anirudh Dagar (10)
+* Anirudh Dagar (12)
 * Hans Dembinski (2) +
 * Jaiden di Lanzo (24) +
 * Felipe Dias (1) +
@@ -419,7 +417,7 @@ Authors
 * David Gilbertson (1) +
 * Ralf Gommers (251)
 * Marco Gorelli (2) +
-* Matt Haberland (378)
+* Matt Haberland (387)
 * Andrew Hawryluk (2) +
 * Christoph Hohnerlein (2) +
 * Loïc Houpert (2) +
@@ -471,8 +469,8 @@ Authors
 * Naoto Mizuno (2)
 * Shashaank N (1)
 * Pablo S Naharro (1) +
-* nboudrie (1) +
-* Andrew Nelson (51)
+* nboudrie (2) +
+* Andrew Nelson (52)
 * Nico Schlömer (1)
 * NiMlr (1) +
 * o-alexandre-felipe (1) +
@@ -489,12 +487,12 @@ Authors
 * Ilhan Polat (6)
 * Akshita Prasanth (2) +
 * Sean Quinn (1)
-* Tyler Reddy (114)
+* Tyler Reddy (155)
 * Martin Reinecke (1)
 * Ned Richards (1)
 * Marie Roald (1) +
 * Sam Rosen (4) +
-* Pamphile Roy (103)
+* Pamphile Roy (105)
 * sabonerune (2) +
 * Atsushi Sakai (94)
 * Daniel Schmitz (27)
@@ -509,6 +507,7 @@ Authors
 * Alexander Soare (1) +
 * Bjørge Solli (2) +
 * Scott Staniewicz (1)
+* Ethan Steinberg (3) +
 * Albert Steppi (3)
 * Thomas Stoeger (1) +
 * Kai Striega (4)
@@ -518,6 +517,7 @@ Authors
 * TianyiQ (1) +
 * Tiger (1) +
 * Will Tirone (1)
+* Ajay Shanker Tripathi (1) +
 * Edgar Andrés Margffoy Tuay (1) +
 * Dmitry Ulyumdzhiev (1) +
 * Hari Vamsi (1) +
@@ -540,7 +540,7 @@ Authors
 * Egor Zemlyanoy (19)
 * Gavin Zhang (3) +
 
-A total of 180 people contributed to this release.
+A total of 184 people contributed to this release.
 People with a "+" by their names contributed a patch for the first time.
 This list of names is automatically generated, and may not be fully complete.
 
@@ -570,6 +570,7 @@ Issues closed for 1.10.0
 * `#9440 <https://github.com/scipy/scipy/issues/9440>`__: Unexpected successful optimization with minimize when number...
 * `#9451 <https://github.com/scipy/scipy/issues/9451>`__: Add shgo to optimize benchmarks
 * `#10737 <https://github.com/scipy/scipy/issues/10737>`__: Goodness of fit tests for distributions with unknown parameters
+* `#10911 <https://github.com/scipy/scipy/issues/10911>`__: scipy.optimize.minimize_scalar does not automatically select...
 * `#11026 <https://github.com/scipy/scipy/issues/11026>`__: rv_discrete.interval returning wrong values for alpha = 1
 * `#11053 <https://github.com/scipy/scipy/issues/11053>`__: scipy.stats: Allow specifying inverse-variance matrix to multivariate_normal
 * `#11131 <https://github.com/scipy/scipy/issues/11131>`__: DOC: stats.fisher_exact does not match R functionality for \`oddsratio\`...
@@ -680,7 +681,12 @@ Issues closed for 1.10.0
 * `#17412 <https://github.com/scipy/scipy/issues/17412>`__: BUG: Meson error:compiler for language "cpp", not specified for...
 * `#17444 <https://github.com/scipy/scipy/issues/17444>`__: BUG: beta.ppf causes segfault
 * `#17468 <https://github.com/scipy/scipy/issues/17468>`__: Weird errors with running the tests \`scipy.stats.tests.test_distributions\`...
+* `#17518 <https://github.com/scipy/scipy/issues/17518>`__: ENH: stats.pearsonr: support complex data
 * `#17523 <https://github.com/scipy/scipy/issues/17523>`__: BUG: \`[source]\` button in the docs sending to the wrong place
+* `#17578 <https://github.com/scipy/scipy/issues/17578>`__: TST, BLD, CI: 1.10.0rc1 wheel build/test failures
+* `#17619 <https://github.com/scipy/scipy/issues/17619>`__: BUG: core dump when calling scipy.optimize.linprog
+* `#17644 <https://github.com/scipy/scipy/issues/17644>`__: BUG: 1.10.0rc2 Windows wheel tests runs all segfault
+* `#17650 <https://github.com/scipy/scipy/issues/17650>`__: BUG: Assertion failed when using HiGHS
 
 ************************
 Pull requests for 1.10.0
@@ -1157,6 +1163,7 @@ Pull requests for 1.10.0
 * `#17439 <https://github.com/scipy/scipy/pull/17439>`__: DOC: Improve example for uniform_direction distribution
 * `#17446 <https://github.com/scipy/scipy/pull/17446>`__: MAINT: stats.gaussian_kde: error early if n_features > n_data
 * `#17447 <https://github.com/scipy/scipy/pull/17447>`__: MAINT: optimize.fminbound/minimize_scalar: add references, distinguish...
+* `#17448 <https://github.com/scipy/scipy/pull/17448>`__: MAINT: optimize.minimize_scalar: always acknowledge 'bounds'...
 * `#17449 <https://github.com/scipy/scipy/pull/17449>`__: MAINT: remove remaining occurrences of unicode
 * `#17457 <https://github.com/scipy/scipy/pull/17457>`__: DOC: Double Integral Example Typo
 * `#17466 <https://github.com/scipy/scipy/pull/17466>`__: BUG: stats: Fix for gh-17444.
@@ -1178,8 +1185,27 @@ Pull requests for 1.10.0
 * `#17512 <https://github.com/scipy/scipy/pull/17512>`__: TST: interpolate: stop skipping a test with zero-sized arrays
 * `#17513 <https://github.com/scipy/scipy/pull/17513>`__: BUG: optimize: fixed issue 17380
 * `#17526 <https://github.com/scipy/scipy/pull/17526>`__: BUG, DOC: stats: fix \`[source]\` button redicting to the wrong...
+* `#17534 <https://github.com/scipy/scipy/pull/17534>`__: DOC: 1.10.0 release notes
 * `#17536 <https://github.com/scipy/scipy/pull/17536>`__: DOC: Examples for \`yve\` and \`jve\`
 * `#17540 <https://github.com/scipy/scipy/pull/17540>`__: DOC: fix documentation of \`make_smoothing_spline\`
 * `#17543 <https://github.com/scipy/scipy/pull/17543>`__: CI: fix gh17539 failures of the alpine linux run
 * `#17545 <https://github.com/scipy/scipy/pull/17545>`__: BUG: special: Fix handling of subnormal input for lambertw.
 * `#17551 <https://github.com/scipy/scipy/pull/17551>`__: BUG Fix: Update lobpcg.py to turn history arrays into lists for...
+* `#17569 <https://github.com/scipy/scipy/pull/17569>`__: MAINT: version bounds for 1.10.0rc1/relnotes fixes
+* `#17579 <https://github.com/scipy/scipy/pull/17579>`__: Revert "ENH: stats.ks_2samp: Pythranize remaining exact p-value...
+* `#17580 <https://github.com/scipy/scipy/pull/17580>`__: CI: native cp38-macosx_arm64 [wheel build][skip azp][skip circle][ski…
+* `#17583 <https://github.com/scipy/scipy/pull/17583>`__: MAINT: 1.10.0rc1 backports round 2
+* `#17591 <https://github.com/scipy/scipy/pull/17591>`__: MAINT: stats.pearsonr: raise error for complex input
+* `#17600 <https://github.com/scipy/scipy/pull/17600>`__: DOC: update version switcher for 1.10
+* `#17611 <https://github.com/scipy/scipy/pull/17611>`__: MAINT: Update ascent.dat file hash
+* `#17614 <https://github.com/scipy/scipy/pull/17614>`__: MAINT: optimize.milp: don't warn about \`mip_rel_gap\` option
+* `#17627 <https://github.com/scipy/scipy/pull/17627>`__: MAINT: Cast \`datasets.ascent\` image to float64
+* `#17634 <https://github.com/scipy/scipy/pull/17634>`__: MAINT: casting errstate for NumPy 1.24
+* `#17638 <https://github.com/scipy/scipy/pull/17638>`__: MAINT, TST: alpine/musl segfault shim
+* `#17640 <https://github.com/scipy/scipy/pull/17640>`__: MAINT: prepare for SciPy 1.10.0rc2
+* `#17645 <https://github.com/scipy/scipy/pull/17645>`__: MAINT: stats.rankdata: ensure consistent shape handling
+* `#17653 <https://github.com/scipy/scipy/pull/17653>`__: MAINT: pybind11 win exclusion
+* `#17656 <https://github.com/scipy/scipy/pull/17656>`__: MAINT: 1.10.0rc2 backports, round two
+* `#17662 <https://github.com/scipy/scipy/pull/17662>`__: Fix undefined behavior within scipy.fft
+* `#17686 <https://github.com/scipy/scipy/pull/17686>`__: REV: integrate.qmc_quad: delay release to SciPy 1.11.0
+* `#17689 <https://github.com/scipy/scipy/pull/17689>`__: REL: integrate.qmc_quad: remove from release notes

--- a/doc/source/_static/version_switcher.json
+++ b/doc/source/_static/version_switcher.json
@@ -5,7 +5,12 @@
         "url": "https://scipy.github.io/devdocs/"
     },
     {
-        "name": "1.9.3 (stable)",
+        "name": "1.10.0 (stable)",
+        "version":"1.10.0",
+        "url": "https://docs.scipy.org/doc/scipy-1.10.0/"
+    },
+    {
+        "name": "1.9.3",
         "version":"1.9.3",
         "url": "https://docs.scipy.org/doc/scipy-1.9.3/"
     },


### PR DESCRIPTION
* forward port the SciPy `1.10.0` release notes and the docs version switcher following the
release this evening