### PR TITLE
ENH: Provide public API for fast DisjointSet subset size.

### DIFF
--- a/scipy/_lib/_disjoint_set.py
+++ b/scipy/_lib/_disjoint_set.py
@@ -19,6 +19,7 @@ class DisjointSet:
     merge
     connected
     subset
+    subset_size
     subsets
     __getitem__
 
@@ -75,6 +76,12 @@ class DisjointSet:
 
     >>> disjoint_set.subset('a')
     {'a', 3, 'b'}
+
+    Get the size of the subset containing 'a' (without actually instantiating
+    the subset):
+
+    >>> disjoint_set.subset_size('a')
+    3
 
     Get all subsets in the disjoint set:
 
@@ -209,6 +216,25 @@ class DisjointSet:
             result.append(nxt)
             nxt = self._nbrs[nxt]
         return set(result)
+
+    def subset_size(self, x):
+        """Get the size of the subset containing `x`.
+
+        Note that this method is faster than ``len(self.subset(x))`` because
+        the size is directly read off an internal field, without the need to
+        instantiate the full subset.
+
+        Parameters
+        ----------
+        x : hashable object
+            Input element.
+
+        Returns
+        -------
+        result : int
+            Size of the subset containing `x`.
+        """
+        return self._sizes[self[x]]
 
     def subsets(self):
         """Get all the subsets in the disjoint set.

--- a/scipy/cluster/tests/test_disjoint_set.py
+++ b/scipy/cluster/tests/test_disjoint_set.py
@@ -189,6 +189,7 @@ def test_subsets(n):
         y = elements[j]
 
         expected = {element for element in dis if {dis[element]} == {dis[x]}}
+        assert dis.subset_size(x) == len(dis.subset(x))
         assert expected == dis.subset(x)
 
         expected = {dis[element]: set() for element in dis}


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #17285.

#### What does this implement/fix?
<!--Please explain your changes.-->
Provide public API to quickly get the size of a DisjointSet subset.
This information is already stored internally as `disjoint_set._sizes`; this PR simply adds a public method to access it.

#### Additional information
<!--Any additional information you think is important.-->
