### PR TITLE
BUG: allow readonly input to interpolate.interpn

### DIFF
--- a/scipy/interpolate/_rgi_cython.pyx
+++ b/scipy/interpolate/_rgi_cython.pyx
@@ -17,7 +17,7 @@ np.import_array()
 @cython.boundscheck(False)
 @cython.initializedcheck(False)
 def evaluate_linear_2d(double_or_complex[:, :] values, # cannot declare as ::1
-                       long[:, :] indices,             # unless prior
+                       const long[:, :] indices,       # unless prior
                        double[:, :] norm_distances,    # np.ascontiguousarray
                        tuple grid not None,
                        double_or_complex[:] out):
@@ -72,11 +72,13 @@ def evaluate_linear_2d(double_or_complex[:, :] values, # cannot declare as ::1
 @cython.boundscheck(False)
 @cython.cdivision(True)
 @cython.initializedcheck(False)
-def find_indices(tuple grid not None, double[:, :] xi):
+def find_indices(tuple grid not None, const double[:, :] xi):
+    # const is required for xi above in case xi is read-only
     cdef:
         long i, j, grid_i_size
         double denom, value
-        double[::1] grid_i
+        # const is required in case grid is read-only
+        const double[::1] grid_i
 
         # Axes to iterate over
         long I = xi.shape[0]


### PR DESCRIPTION
Passing a readonly array to interpolate.interpn results in an error with scipy 1.10 (but not with 1.9). This PR adds a test for this failure and fixes the issue by adding `const` to the relevant cython variable in _rgi_cython: https://github.com/scipy/scipy/blob/7b858b70c16c5559c2155a6bf2c39b32e45fbb78/scipy/interpolate/_rgi_cython.pyx#L79

#### Reference issue
Closes #17716

EDIT(ev-br): closes gh-17727

#### What does this implement/fix?
Add `const` to allow cython implementation of find_indices to accept read only input.

#### Additional information
<!--Any additional information you think is important.-->
