### PR TITLE
MAINT: update `meson-python` upper bound to <0.13.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@
 [build-system]
 build-backend = 'mesonpy'
 requires = [
-    "meson-python>=0.11.0,<0.12.0",
+    "meson-python>=0.11.0,<0.13.0",
     "Cython>=0.29.32,<3.0",
     # conservatively avoid issues from
     # https://github.com/pybind/pybind11/issues/4420


### PR DESCRIPTION
In 0.12.0 the traceback on build failures improved quite a bit, so that's a useful change to pull in.
