### PR TITLE
BUG: interpolate/RGI: upcast float32 to float64

### DIFF
--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -332,6 +332,7 @@ class RegularGridInterpolator:
             indices, norm_distances = self._find_indices(xi.T)
             if (ndim == 2 and hasattr(self.values, 'dtype') and
                     self.values.ndim == 2 and self.values.flags.writeable and
+                    self.values.dtype in (np.float64, np.complex128) and
                     self.values.dtype.byteorder == '='):
                 # until cython supports const fused types, the fast path
                 # cannot support non-writeable values

--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -594,6 +594,33 @@ class TestRegularGridInterpolator:
         v2 = np.expand_dims(vs, axis=0)
         assert_allclose(v, v2, atol=1e-14, err_msg=method)
 
+    @pytest.mark.parametrize("dtype",
+            [np.float32, np.float64, np.complex64, np.complex128])
+    @pytest.mark.parametrize("xi_dtype", [np.float32, np.float64])
+    def test_float32_values(self, dtype, xi_dtype):
+        # regression test for gh-17718: values.dtype=float32 fails
+        def f(x, y):
+            return 2 * x**3 + 3 * y**2
+
+        x = np.linspace(1, 4, 11)
+        y = np.linspace(4, 7, 22)
+
+        xg, yg = np.meshgrid(x, y, indexing='ij', sparse=True)
+        data = f(xg, yg)
+
+        data = data.astype(dtype)
+
+        interp = RegularGridInterpolator((x, y), data)
+
+        pts = np.array([[2.1, 6.2],
+                        [3.3, 5.2]], dtype=xi_dtype)
+
+        # the values here are just what the call returns; the test checks that
+        # that the call succeeds at all, instead of failing with cython not
+        # having a float32 kernel
+        assert_allclose(interp(pts), [134.10469388, 153.40069388], atol=1e-7)
+
+
 class MyValue:
     """
     Minimal indexable object

--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -594,8 +594,10 @@ class TestRegularGridInterpolator:
         v2 = np.expand_dims(vs, axis=0)
         assert_allclose(v, v2, atol=1e-14, err_msg=method)
 
-    @pytest.mark.parametrize("dtype",
-            [np.float32, np.float64, np.complex64, np.complex128])
+    @pytest.mark.parametrize(
+        "dtype",
+        [np.float32, np.float64, np.complex64, np.complex128]
+    )
     @pytest.mark.parametrize("xi_dtype", [np.float32, np.float64])
     def test_float32_values(self, dtype, xi_dtype):
         # regression test for gh-17718: values.dtype=float32 fails


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

closes gh-17718

#### What does this implement/fix?
<!--Please explain your changes.-->

Cython fast-path for 2D data in RGI expects float64 / complex128 values, thus upcast float32 to double precision. While I'm at it, also upcast single precision complex to double precision complex. 

#### Additional information
<!--Any additional information you think is important.-->

This is a scipy 1.10.0 regression, thus tentatively labeling this as a backport-candidate.