### PR TITLE
MAINT: rotate CircleCI ssh key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,7 +171,7 @@ jobs:
 
       - add_ssh_keys:
           fingerprints:
-            - "08:18:07:68:71:e3:f9:5f:bd:95:f0:6a:df:a9:47:a2"
+            - "1d:47:cf:2e:ea:7c:15:cf:ec:bb:1f:44:e2:56:16:d3"
 
       - run:
           name: upload


### PR DESCRIPTION
 * this is related to the security issue patched
    in NumPy here:
    https://github.com/numpy/numpy/pull/22943
    
 * I deleted our SSH key for SciPy main repo
    on CircleCI, replaced it with another elliptical
    private SSH key, and put the new fingerprint in this
    PR (all CircleCI PRs may fail until this is reviewed/merged
    I think b/c I purged the old key)
    
 * I placed the public version of the SSH key in the `scipy/devdocs` repo
    settings, purging out the previous one that was from Stefan
    I think
    
 * as far as I can tell from scanning our settings on both
    GitHub and CircleCI, this is really the only "secret" we
    have related to CircleCI -- we don't use CircleCI deploy keys (beyond the ssh key for devdocs deploy)
    so I saw little reason to add more complexity to what already
    seems to be working

* of course, let me know if I've missed a key/setting somewhere--I guess
we'll soon see if CircleCI is happy, though can't remember if that only
really gets checked on merge to trigger deploy...
    
    [skip azp] [skip actions] [skip cirrus]
