### PR TITLE
MAINT: optimize.toms748: don't do newton after secant interpolation

### DIFF
--- a/scipy/optimize/_zeros_py.py
+++ b/scipy/optimize/_zeros_py.py
@@ -1044,15 +1044,15 @@ def _newton_quadratic(ab, fab, d, fd, k):
         r = a - fa / B
     else:
         r = (a if np.sign(A) * np.sign(fa) > 0 else b)
-    # Apply k Newton-Raphson steps to _P(x), starting from x=r
-    for i in range(k):
-        r1 = r - _P(r) / (B + A * (2 * r - a - b))
-        if not (ab[0] < r1 < ab[1]):
-            if (ab[0] < r < ab[1]):
-                return r
-            r = sum(ab) / 2.0
-            break
-        r = r1
+        # Apply k Newton-Raphson steps to _P(x), starting from x=r
+        for i in range(k):
+            r1 = r - _P(r) / (B + A * (2 * r - a - b))
+            if not (ab[0] < r1 < ab[1]):
+                if (ab[0] < r < ab[1]):
+                    return r
+                r = sum(ab) / 2.0
+                break
+            r = r1
 
     return r
 


### PR DESCRIPTION
#### Reference issue
Closes gh-13535

#### What does this implement/fix?
This stops TOMS748 from performing newton iteration after secant interpolation as suggested in gh-13535.

The relevant excerpt from the original paper is:
![image](https://user-images.githubusercontent.com/6570539/210931924-99930404-32c1-47af-a176-ea06474963e3.png)
It's not immediately obvious, but reading closely looks like they meant for the iterative procedure to execute only if $A\neq 0$; otherwise it would have been "if $A=0$, then $r_0 = ...$", but they wrote $r = ...$.

#### Additional information
No tests are needed; the old tests were sufficient and they still pass.

@pvanmulbregt This implements your recommendation from gh-13535. Does this close the issue?