### PR TITLE
MAINT: merge _validate_bounds from optimize and qmc to _util

### DIFF
--- a/scipy/_lib/_bounds.py
+++ b/scipy/_lib/_bounds.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import (
+    Tuple,
+    TYPE_CHECKING,
+)
+
+import numpy as np
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
+
+def _validate_bounds(
+    l_bounds: npt.ArrayLike, u_bounds: npt.ArrayLike, x0: np.ndarray
+) -> Tuple[np.ndarray, ...]:
+    """Bounds input validation.
+
+    Parameters
+    ----------
+    l_bounds, u_bounds : array_like (d,)
+        Lower and upper bounds.
+    x0 : np.ndarray
+        Array to use for broadcasting.
+
+    Returns
+    -------
+    l_bounds, u_bounds : array_like (d,)
+        Lower and upper bounds.
+
+    """
+    try:
+        lower = np.broadcast_to(l_bounds, x0.shape)
+        upper = np.broadcast_to(u_bounds, x0.shape)
+    except ValueError as exc:
+        msg = (
+            "The number of bounds is not compatible with the length of "
+            f"``x0={x0}``."
+        )
+        raise ValueError(msg) from exc
+
+    if not np.all(lower < upper):
+        msg = "An upper bound is less than the corresponding lower bound."
+        raise ValueError(msg)
+
+    return lower, upper

--- a/scipy/_lib/_bounds.py
+++ b/scipy/_lib/_bounds.py
@@ -39,7 +39,7 @@ def _validate_bounds(
         )
         raise ValueError(msg) from exc
 
-    if not np.all(lower < upper):
+    if np.any(lower > upper):
         msg = "An upper bound is less than the corresponding lower bound."
         raise ValueError(msg)
 

--- a/scipy/_lib/meson.build
+++ b/scipy/_lib/meson.build
@@ -98,6 +98,7 @@ py3.extension_module('messagestream',
 
 python_sources = [
   '__init__.py',
+  '_bounds.py',
   '_bunch.py',
   '_ccallback.py',
   '_disjoint_set.py',

--- a/scipy/_lib/tests/meson.build
+++ b/scipy/_lib/tests/meson.build
@@ -5,6 +5,7 @@ python_sources = [
   'test__testutils.py',
   'test__threadsafety.py',
   'test__util.py',
+  'test_bounds.py',
   'test_bunch.py',
   'test_ccallback.py',
   'test_deprecation.py',

--- a/scipy/_lib/tests/test_bounds.py
+++ b/scipy/_lib/tests/test_bounds.py
@@ -1,0 +1,22 @@
+import numpy as np
+import pytest
+
+from scipy._lib._bounds import _validate_bounds
+
+
+def test_bounds():
+    sample = np.array([[0, 0], [1, 1], [0.5, 0.5]])
+
+    msg = "An upper bound is less than the corresponding lower bound"
+    with pytest.raises(ValueError, match=msg):
+        bounds = np.array([[-2, 6], [6, 5]])
+        _validate_bounds(l_bounds=bounds[0], u_bounds=bounds[1], x0=sample)
+
+    msg = "The number of bounds is not compatible"
+    with pytest.raises(ValueError, match=msg):
+        l_bounds, u_bounds = [-2, 0, 2], [6, 5]
+        _validate_bounds(l_bounds=l_bounds, u_bounds=u_bounds, x0=sample)
+
+    with pytest.raises(ValueError, match=msg):
+        bounds = np.array([[-2, 0, 2], [6, 5, 5]])
+        _validate_bounds(l_bounds=bounds[0], u_bounds=bounds[1], x0=sample)

--- a/scipy/_lib/tests/test_bounds.py
+++ b/scipy/_lib/tests/test_bounds.py
@@ -1,10 +1,26 @@
 import numpy as np
+from numpy.testing import assert_allclose
 import pytest
 
 from scipy._lib._bounds import _validate_bounds
 
 
 def test_bounds():
+    l_bounds = np.array([5., 0.])
+    u_bounds = np.array([5., 0.95])
+    x0 = np.array([5., 0.52])
+
+    bounds = _validate_bounds(l_bounds=l_bounds, u_bounds=u_bounds, x0=x0)
+    assert_allclose(bounds[0], l_bounds)
+    assert_allclose(bounds[1], u_bounds)
+
+    u_bounds = np.array([5.])
+    bounds = _validate_bounds(l_bounds, u_bounds, x0=x0)
+    assert_allclose(bounds[0], l_bounds)
+    assert_allclose(bounds[1], np.array([5., 5.]))
+
+
+def test_raises():
     sample = np.array([[0, 0], [1, 1], [0.5, 0.5]])
 
     msg = "An upper bound is less than the corresponding lower bound"

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -1550,7 +1550,7 @@ class TestOptimizeSimple(CheckOptimize):
             return np.sum(x**2)
 
         bounds = Bounds([1, 2], [3, 4])
-        msg = 'The number of bounds is not compatible with the length of `x0`.'
+        msg = 'The number of bounds is not compatible with the length of ``x0='
         with pytest.raises(ValueError, match=msg):
             optimize.minimize(f, x0=[1, 2, 3], method=method, bounds=bounds)
 

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -29,9 +29,10 @@ if TYPE_CHECKING:
     )
 
 import scipy.stats as stats
+from scipy._lib._bounds import _validate_bounds
 from scipy._lib._util import rng_integers
 from scipy.spatial import distance, Voronoi
-from scipy.special import gammainc
+from scipy.special import gammainc  # noqa
 from ._sobol import (
     _initialize_v, _cscramble, _fill_p_cumulative, _draw, _fast_forward,
     _categorize, _MAXDIM
@@ -154,7 +155,7 @@ def scale(
         raise ValueError('Sample is not a 2D array')
 
     lower, upper = _validate_bounds(
-        l_bounds=l_bounds, u_bounds=u_bounds, d=sample.shape[1]
+        l_bounds=l_bounds, u_bounds=u_bounds, x0=sample
     )
 
     if not reverse:
@@ -2556,35 +2557,3 @@ def _validate_workers(workers: IntNumber = 1) -> IntNumber:
                          "or > 0")
 
     return workers
-
-
-def _validate_bounds(
-    l_bounds: npt.ArrayLike, u_bounds: npt.ArrayLike, d: int
-) -> Tuple[np.ndarray, ...]:
-    """Bounds input validation.
-
-    Parameters
-    ----------
-    l_bounds, u_bounds : array_like (d,)
-        Lower and upper bounds.
-    d : int
-        Dimension to use for broadcasting.
-
-    Returns
-    -------
-    l_bounds, u_bounds : array_like (d,)
-        Lower and upper bounds.
-
-    """
-    try:
-        lower = np.broadcast_to(l_bounds, d)
-        upper = np.broadcast_to(u_bounds, d)
-    except ValueError as exc:
-        msg = ("'l_bounds' and 'u_bounds' must be broadcastable and respect"
-               " the sample dimension")
-        raise ValueError(msg) from exc
-
-    if not np.all(lower < upper):
-        raise ValueError("Bounds are not consistent 'l_bounds' < 'u_bounds'")
-
-    return lower, upper

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -155,7 +155,7 @@ def scale(
         raise ValueError('Sample is not a 2D array')
 
     lower, upper = _validate_bounds(
-        l_bounds=l_bounds, u_bounds=u_bounds, x0=sample
+        l_bounds=l_bounds, u_bounds=u_bounds, x0=sample[0]
     )
 
     if not reverse:

--- a/scipy/stats/tests/test_qmc.py
+++ b/scipy/stats/tests/test_qmc.py
@@ -62,23 +62,6 @@ class TestUtils:
             space = [0, 1, 0.5]
             qmc.scale(space, l_bounds=-2, u_bounds=6)
 
-        with pytest.raises(ValueError, match=r"Bounds are not consistent"):
-            space = [[0, 0], [1, 1], [0.5, 0.5]]
-            bounds = np.array([[-2, 6], [6, 5]])
-            qmc.scale(space, l_bounds=bounds[0], u_bounds=bounds[1])
-
-        with pytest.raises(ValueError, match=r"'l_bounds' and 'u_bounds'"
-                                             r" must be broadcastable"):
-            space = [[0, 0], [1, 1], [0.5, 0.5]]
-            l_bounds, u_bounds = [-2, 0, 2], [6, 5]
-            qmc.scale(space, l_bounds=l_bounds, u_bounds=u_bounds)
-
-        with pytest.raises(ValueError, match=r"'l_bounds' and 'u_bounds'"
-                                             r" must be broadcastable"):
-            space = [[0, 0], [1, 1], [0.5, 0.5]]
-            bounds = np.array([[-2, 0, 2], [6, 5, 5]])
-            qmc.scale(space, l_bounds=bounds[0], u_bounds=bounds[1])
-
         with pytest.raises(ValueError, match=r"Sample is not in unit "
                                              r"hypercube"):
             space = [[0, 0], [1, 1.5], [0.5, 0.5]]


### PR DESCRIPTION
Follow up of #17679 where we added a bound validation to `scipy.optimize`. Since we already have similar code in `scipy.stats.qmc`, this PR merges both.