### PR TITLE
DOC: stats.jarque_bera: add semi-realistic example

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -1878,7 +1878,8 @@ def jarque_bera(x, *, axis=None):
     sampling data from a normally distributed population that produces such an
     extreme value of the statistic - this may be taken as evidence against
     the null hypothesis in favor of the alternative: the sample was not
-    drawn from a normal distribution.
+    drawn from a normal distribution. The inverse is not true; that is,
+    the test is not used to provide evidence for the null hypothesis.
 
     Note that the chi-squared distribution provides an asymptotic approximation
     of the null distribution; it is only accurate for samples with many
@@ -1896,7 +1897,7 @@ def jarque_bera(x, *, axis=None):
     ...         density=True)
     >>> ax.plot(jb_val, dist.pdf(jb_val))
     >>> ax.legend(['Monte Carlo approximation (11 observations)',
-                   'aymptotic approximation (many observations'])
+    ...            'aymptotic approximation (many observations'])
     >>> ax.set_title("Jarque-Bera Null Distribution")
     >>> ax.set_xlabel("statistic")
     >>> ax.set_ylabel("frequency density")

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -1817,20 +1817,96 @@ def jarque_bera(x, *, axis=None):
     .. [1] Jarque, C. and Bera, A. (1980) "Efficient tests for normality,
            homoscedasticity and serial independence of regression residuals",
            6 Econometric Letters 255-259.
+    .. [2] Shapiro, S. S., & Wilk, M. B. (1965). An analysis of variance test
+           for normality (complete samples). Biometrika, 52(3/4), 591-611.
+    .. [3] B. Phipson and G. K. Smyth. "Permutation P-values Should Never Be
+           Zero: Calculating Exact P-values When Permutations Are Randomly
+           Drawn." Statistical Applications in Genetics and Molecular Biology
+           9.1 (2010).
 
     Examples
     --------
+    Suppose we wish to infer from measurements whether the weights of adult
+    human males in a medical study are not normally distributed [2]_.
+    The weights (lbs) are recorded in the array ``x`` below.
+
     >>> import numpy as np
+    >>> x = np.array([148, 154, 158, 160, 161, 162, 166, 170, 182, 195, 236])
+
+    The Jarque-Bera test begins by computing a statistic based on the sample
+    skewness and kurtosis.
+
     >>> from scipy import stats
-    >>> rng = np.random.default_rng()
-    >>> x = rng.normal(0, 1, 100000)
-    >>> jarque_bera_test = stats.jarque_bera(x)
-    >>> jarque_bera_test
-    Jarque_beraResult(statistic=3.3415184718131554, pvalue=0.18810419594996775)
-    >>> jarque_bera_test.statistic
-    3.3415184718131554
-    >>> jarque_bera_test.pvalue
-    0.18810419594996775
+    >>> res = stats.jarque_bera(x)
+    >>> res.statistic
+    6.982848237344646
+    >>> s = stats.skew(x)  # calculate the sample skewness
+    >>> k = stats.kurtosis(x)  # calculate the sample kurtosis
+    >>> len(x)/6 * (s**2 + k**2/4)  # calculate the Jarque-Bera statistic
+    6.982848237344646
+
+    Because the normal distribution has zero skewness and zero
+    ("excess" or "Fisher") kurtosis, the value of this statistic tends to be
+    low for samples drawn from a normal distribution.
+
+    The test is performed by comparing the observed value of the statistic
+    against the null distribution: the distribution of statistic values derived
+    under the null hypothesis that the sample *is* normally distributed.
+    For the Jarque-Bera test, the null distribution for very large samples is
+    the chi-squared distribution with two degrees of freedom.
+
+    >>> import matplotlib.pyplot as plt
+    >>> fig, ax = plt.subplots()
+    >>> dist = stats.chi2(df=2)
+    >>> jb_val = np.linspace(0, 10, 100)
+    >>> ax.plot(jb_val, dist.pdf(jb_val))
+    >>> ax.set_title("PDF of Jarque-Bera Null Distribution")
+    >>> ax.set_xlabel("statistic")
+    >>> ax.set_ylabel("probability density")
+    >>> plt.show()
+
+    The comparison is quantified by the p-value: the proportion of values in
+    the null distribution greater than or equal to the observed value of the
+    statistic.
+
+    >>> dist.sf(res.statistic)
+    0.03045746622458189
+    >>> res.pvalue
+    0.03045746622458189
+
+    If the p-value is small - that is, if there is a low probability of
+    sampling data from a normally distributed population that produces such an
+    extreme value of the statistic - this may be taken as evidence against
+    the null hypothesis in favor of the alternative: the sample was not
+    drawn from a normal distribution.
+
+    Note that the chi-squared distribution provides an asymptotic approximation
+    of the null distribution; it is only accurate for samples with many
+    observations. For small samples like ours, `scipy.stats.monte_carlo_test`
+    may provide a more accurate, albeit stochastic, approximation of the
+    exact p-value.
+
+    >>> def statistic(x, axis):
+    ...     s = stats.skew(x, axis=axis)
+    ...     k = stats.kurtosis(x, axis=axis)
+    ...     return x.shape[axis]/6 * (s**2 + k**2/4)
+    >>> res = stats.monte_carlo_test(x, stats.norm.rvs, statistic)
+    >>> fig, ax = plt.subplots()
+    >>> ax.hist(res.null_distribution, bins=np.linspace(0, 10, 50),
+    ...         density=True)
+    >>> ax.plot(jb_val, dist.pdf(jb_val))
+    >>> ax.legend(['Monte Carlo approximation (11 observations)',
+                   'aymptotic approximation (many observations'])
+    >>> ax.set_title("Jarque-Bera Null Distribution")
+    >>> ax.set_xlabel("statistic")
+    >>> ax.set_ylabel("frequency density")
+    >>> plt.show()
+    >>> res.pvalue
+    0.0142  # may vary
+
+    Furthermore, despite their stochastic nature, p-values computed in this way
+    can be used to exactly control the rate of false rejections of the null
+    hypothesis [3]_.
 
     """
     x = np.asarray(x)

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -1875,8 +1875,8 @@ def jarque_bera(x, *, axis=None):
     >>> jb_plot(ax)
     >>> pvalue = dist.sf(res.statistic)
     >>> annotation = (f'p-value={pvalue:.6f}\n(shaded area)')
-    >>> arrowprops=dict(facecolor='black', width=1, headwidth=5, headlength=8)
-    >>> ax.annotate(annotation, (7.5, 0.01), (8, 0.05), arrowprops=arrowprops)
+    >>> props = dict(facecolor='black', width=1, headwidth=5, headlength=8)
+    >>> _ = ax.annotate(annotation, (7.5, 0.01), (8, 0.05), arrowprops=props)
     >>> i = jb_val >= res.statistic  # indices of more extreme statistic values
     >>> ax.fill_between(jb_val[i], y1=0, y2=pdf[i])
     >>> ax.set_xlim(0, 11)
@@ -1915,7 +1915,7 @@ def jarque_bera(x, *, axis=None):
     >>> ax.hist(res.null_distribution, np.linspace(0, 10, 50),
     ...         density=True)
     >>> ax.legend(['aymptotic approximation (many observations)',
-                   'Monte Carlo approximation (11 observations)'])
+    ...            'Monte Carlo approximation (11 observations)'])
     >>> ax.set_title("Jarque-Bera Null Distribution")
     >>> ax.set_xlabel("statistic")
     >>> ax.set_ylabel("probability density")


### PR DESCRIPTION
#### What does this implement/fix?
This adds a semi-realistic example to the documentation of `scipy.stats.jarque_bera`.