### PR TITLE
ENH: Support multinomial distributions with n=0 trials.

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -3039,7 +3039,7 @@ p : array_like
 """
 
 _multinomial_doc_callparams_note = """\
-`n` should be a positive integer. Each element of `p` should be in the
+`n` should be a nonnegative integer. Each element of `p` should be in the
 interval :math:`[0,1]` and the elements should sum to 1. If they do not sum to
 1, the last element of the `p` array is not used and is replaced with the
 remaining probability left over from the earlier elements.
@@ -3198,7 +3198,7 @@ class multinomial_gen(multi_rv_generic):
         n = np.array(n, dtype=np.int_, copy=True)
 
         # true for bad n
-        ncond = n <= 0
+        ncond = n < 0
 
         return n, p, ncond | pcond
 

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -1419,13 +1419,13 @@ class TestMultinomial:
         for x in r_vals:
             assert_allclose(multinomial.pmf(x, n, p), r_vals[x], atol=1e-14)
 
-    def test_rvs_np(self):
+    @pytest.mark.parametrize("n", [0, 3]):
+    def test_rvs_np(self, n):
         # test that .rvs agrees w/numpy
-        for n in [0, 3]:
-            sc_rvs = multinomial.rvs(n, [1/4.]*3, size=7, random_state=123)
-            rndm = np.random.RandomState(123)
-            np_rvs = rndm.multinomial(n, [1/4.]*3, size=7)
-            assert_equal(sc_rvs, np_rvs)
+        sc_rvs = multinomial.rvs(n, [1/4.]*3, size=7, random_state=123)
+        rndm = np.random.RandomState(123)
+        np_rvs = rndm.multinomial(n, [1/4.]*3, size=7)
+        assert_equal(sc_rvs, np_rvs)
 
     def test_pmf(self):
         vals0 = multinomial.pmf((5,), 5, (1,))
@@ -1451,6 +1451,8 @@ class TestMultinomial:
         vals5 = multinomial.pmf([0, 0, 0], 0, [2/3.0, 1/3.0, 0])
         assert vals5 == 1
 
+        vals6 = multinomial.pmf([2, 1, 0], 0, [2/3.0, 1/3.0, 0])
+        assert vals6 == 0
     def test_pmf_broadcasting(self):
         vals0 = multinomial.pmf([1, 2], 3, [[.1, .9], [.2, .8]])
         assert_allclose(vals0, [.243, .384], rtol=1e-8)
@@ -1467,13 +1469,13 @@ class TestMultinomial:
         vals4 = multinomial.pmf([[1, 2], [1,1]], [[[[3]]]], [.1, .9])
         assert_allclose(vals4, [[[[.243, 0]]]], rtol=1e-8)
 
-    def test_cov(self):
-        for n in [0, 5]:
-            cov1 = multinomial.cov(n, (.2, .3, .5))
-            cov2 = [[n*.2*.8, -n*.2*.3, -n*.2*.5],
-                    [-n*.3*.2, n*.3*.7, -n*.3*.5],
-                    [-n*.5*.2, -n*.5*.3, n*.5*.5]]
-            assert_allclose(cov1, cov2, rtol=1e-8)
+    @pytest.mark.parametrize("n", [0, 5]):
+    def test_cov(self, n):
+        cov1 = multinomial.cov(n, (.2, .3, .5))
+        cov2 = [[n*.2*.8, -n*.2*.3, -n*.2*.5],
+                [-n*.3*.2, n*.3*.7, -n*.3*.5],
+                [-n*.5*.2, -n*.5*.3, n*.5*.5]]
+        assert_allclose(cov1, cov2, rtol=1e-8)
 
     def test_cov_broadcasting(self):
         cov1 = multinomial.cov(5, [[.1, .9], [.2, .8]])
@@ -1489,12 +1491,12 @@ class TestMultinomial:
                 [[5*.4*.6, -5*.4*.6], [-5*.4*.6, 5*.4*.6]]]
         assert_allclose(cov5, cov6, rtol=1e-8)
 
-    def test_entropy(self):
+    @pytest.mark.parametrize("n", [0, 2]):
+    def test_entropy(self, n):
         # this is equivalent to a binomial distribution with n=2, so the
         # entropy .77899774929 is easily computed "by hand"
-        for n in [0, 2]:
-            ent0 = multinomial.entropy(n, [.2, .8])
-            assert_allclose(ent0, binom.entropy(n, .2), rtol=1e-8)
+        ent0 = multinomial.entropy(n, [.2, .8])
+        assert_allclose(ent0, binom.entropy(n, .2), rtol=1e-8)
 
     def test_entropy_broadcasting(self):
         ent0 = multinomial.entropy([2, 3], [.2, .3])
@@ -1511,10 +1513,10 @@ class TestMultinomial:
                  [binom.entropy(8, .3), binom.entropy(8, .4)]],
                 rtol=1e-8)
 
-    def test_mean(self):
-        for n in [0, 5]:
-            mean1 = multinomial.mean(n, [.2, .8])
-            assert_allclose(mean1, [n*.2, n*.8], rtol=1e-8)
+    @pytest.mark.parametrize("n", [0, 5]):
+    def test_mean(self, n):
+        mean1 = multinomial.mean(n, [.2, .8])
+        assert_allclose(mean1, [n*.2, n*.8], rtol=1e-8)
 
     def test_mean_broadcasting(self):
         mean1 = multinomial.mean([5, 6], [.2, .8])

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -1383,10 +1383,13 @@ class TestMultinomial:
         assert_allclose(vals1, -1.483270127243324, rtol=1e-8)
 
         vals2 = multinomial.logpmf([3, 4], 0, [.3, .7])
-        assert_allclose(vals2, np.NAN, rtol=1e-8)
+        assert vals2 == -np.inf
 
-        vals3 = multinomial.logpmf([3, 4], 0, [-2, 3])
-        assert_allclose(vals3, np.NAN, rtol=1e-8)
+        vals3 = multinomial.logpmf([0, 0], 0, [.3, .7])
+        assert vals3 == 0
+
+        vals4 = multinomial.logpmf([3, 4], 0, [-2, 3])
+        assert_allclose(vals4, np.NAN, rtol=1e-8)
 
     def test_reduces_binomial(self):
         # test that the multinomial pmf reduces to the binomial pmf in the 2d
@@ -1418,10 +1421,11 @@ class TestMultinomial:
 
     def test_rvs_np(self):
         # test that .rvs agrees w/numpy
-        sc_rvs = multinomial.rvs(3, [1/4.]*3, size=7, random_state=123)
-        rndm = np.random.RandomState(123)
-        np_rvs = rndm.multinomial(3, [1/4.]*3, size=7)
-        assert_equal(sc_rvs, np_rvs)
+        for n in [0, 3]:
+            sc_rvs = multinomial.rvs(n, [1/4.]*3, size=7, random_state=123)
+            rndm = np.random.RandomState(123)
+            np_rvs = rndm.multinomial(n, [1/4.]*3, size=7)
+            assert_equal(sc_rvs, np_rvs)
 
     def test_pmf(self):
         vals0 = multinomial.pmf((5,), 5, (1,))
@@ -1444,6 +1448,9 @@ class TestMultinomial:
         vals5 = multinomial.pmf([3, 3, 0], 6, [2/3.0, 1/3.0, 0])
         assert_allclose(vals5, 0.219478737997, rtol=1e-8)
 
+        vals5 = multinomial.pmf([0, 0, 0], 0, [2/3.0, 1/3.0, 0])
+        assert vals5 == 1
+
     def test_pmf_broadcasting(self):
         vals0 = multinomial.pmf([1, 2], 3, [[.1, .9], [.2, .8]])
         assert_allclose(vals0, [.243, .384], rtol=1e-8)
@@ -1461,11 +1468,12 @@ class TestMultinomial:
         assert_allclose(vals4, [[[[.243, 0]]]], rtol=1e-8)
 
     def test_cov(self):
-        cov1 = multinomial.cov(5, (.2, .3, .5))
-        cov2 = [[5*.2*.8, -5*.2*.3, -5*.2*.5],
-                [-5*.3*.2, 5*.3*.7, -5*.3*.5],
-                [-5*.5*.2, -5*.5*.3, 5*.5*.5]]
-        assert_allclose(cov1, cov2, rtol=1e-8)
+        for n in [0, 5]:
+            cov1 = multinomial.cov(n, (.2, .3, .5))
+            cov2 = [[n*.2*.8, -n*.2*.3, -n*.2*.5],
+                    [-n*.3*.2, n*.3*.7, -n*.3*.5],
+                    [-n*.5*.2, -n*.5*.3, n*.5*.5]]
+            assert_allclose(cov1, cov2, rtol=1e-8)
 
     def test_cov_broadcasting(self):
         cov1 = multinomial.cov(5, [[.1, .9], [.2, .8]])
@@ -1484,8 +1492,9 @@ class TestMultinomial:
     def test_entropy(self):
         # this is equivalent to a binomial distribution with n=2, so the
         # entropy .77899774929 is easily computed "by hand"
-        ent0 = multinomial.entropy(2, [.2, .8])
-        assert_allclose(ent0, binom.entropy(2, .2), rtol=1e-8)
+        for n in [0, 2]:
+            ent0 = multinomial.entropy(n, [.2, .8])
+            assert_allclose(ent0, binom.entropy(n, .2), rtol=1e-8)
 
     def test_entropy_broadcasting(self):
         ent0 = multinomial.entropy([2, 3], [.2, .3])
@@ -1503,8 +1512,9 @@ class TestMultinomial:
                 rtol=1e-8)
 
     def test_mean(self):
-        mean1 = multinomial.mean(5, [.2, .8])
-        assert_allclose(mean1, [5*.2, 5*.8], rtol=1e-8)
+        for n in [0, 5]:
+            mean1 = multinomial.mean(n, [.2, .8])
+            assert_allclose(mean1, [n*.2, n*.8], rtol=1e-8)
 
     def test_mean_broadcasting(self):
         mean1 = multinomial.mean([5, 6], [.2, .8])

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -1453,6 +1453,7 @@ class TestMultinomial:
 
         vals6 = multinomial.pmf([2, 1, 0], 0, [2/3.0, 1/3.0, 0])
         assert vals6 == 0
+
     def test_pmf_broadcasting(self):
         vals0 = multinomial.pmf([1, 2], 3, [[.1, .9], [.2, .8]])
         assert_allclose(vals0, [.243, .384], rtol=1e-8)

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -1419,7 +1419,7 @@ class TestMultinomial:
         for x in r_vals:
             assert_allclose(multinomial.pmf(x, n, p), r_vals[x], atol=1e-14)
 
-    @pytest.mark.parametrize("n", [0, 3]):
+    @pytest.mark.parametrize("n", [0, 3])
     def test_rvs_np(self, n):
         # test that .rvs agrees w/numpy
         sc_rvs = multinomial.rvs(n, [1/4.]*3, size=7, random_state=123)
@@ -1469,7 +1469,7 @@ class TestMultinomial:
         vals4 = multinomial.pmf([[1, 2], [1,1]], [[[[3]]]], [.1, .9])
         assert_allclose(vals4, [[[[.243, 0]]]], rtol=1e-8)
 
-    @pytest.mark.parametrize("n", [0, 5]):
+    @pytest.mark.parametrize("n", [0, 5])
     def test_cov(self, n):
         cov1 = multinomial.cov(n, (.2, .3, .5))
         cov2 = [[n*.2*.8, -n*.2*.3, -n*.2*.5],
@@ -1491,7 +1491,7 @@ class TestMultinomial:
                 [[5*.4*.6, -5*.4*.6], [-5*.4*.6, 5*.4*.6]]]
         assert_allclose(cov5, cov6, rtol=1e-8)
 
-    @pytest.mark.parametrize("n", [0, 2]):
+    @pytest.mark.parametrize("n", [0, 2])
     def test_entropy(self, n):
         # this is equivalent to a binomial distribution with n=2, so the
         # entropy .77899774929 is easily computed "by hand"
@@ -1513,7 +1513,7 @@ class TestMultinomial:
                  [binom.entropy(8, .3), binom.entropy(8, .4)]],
                 rtol=1e-8)
 
-    @pytest.mark.parametrize("n", [0, 5]):
+    @pytest.mark.parametrize("n", [0, 5])
     def test_mean(self, n):
         mean1 = multinomial.mean(n, [.2, .8])
         assert_allclose(mean1, [n*.2, n*.8], rtol=1e-8)


### PR DESCRIPTION
With n=0 trials, there is a probability of 1 of observing a full-zero tuple.  In fact the logpmf formula works just fine; we simply needed to loosen the pre-check.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
