### PR TITLE
DOC: clarify input dimensions for `directed_hausdorff` method

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -309,17 +309,15 @@ def _validate_weights(w, dtype=np.double):
 def directed_hausdorff(u, v, seed=0):
     """
     Compute the directed Hausdorff distance between two 2-D arrays.
-    Each array will be interpreted as a set of points with co-ordinates
-    in N-dimensional space.
 
     Distances between pairs are calculated using a Euclidean metric.
 
     Parameters
     ----------
     u : (M,N) array_like
-        Input array.
+        Input array with M points in N dimensions.
     v : (O,N) array_like
-        Input array.
+        Input array with O points in N dimensions.
     seed : int or None
         Local `numpy.random.RandomState` seed. Default is 0, a random
         shuffling of u and v that guarantees reproducibility.

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -309,6 +309,8 @@ def _validate_weights(w, dtype=np.double):
 def directed_hausdorff(u, v, seed=0):
     """
     Compute the directed Hausdorff distance between two 2-D arrays.
+    Each array will be interpreted as a set of points with co-ordinates
+    in N-dimensional space.
 
     Distances between pairs are calculated using a Euclidean metric.
 


### PR DESCRIPTION
The docstring stated that the method accepted 2-D arrays, which (combined with the example) led me to the misunderstanding that the input co-ordinates had to be in two spatial dimensions. Now I see that the input arrays are 2-D even for N-D coordinates. Hopefully the suggested change will help other people avoid having the same misunderstanding.

Closes #17756 
