### PR TITLE
DOC: remove space between directive name and double colon ::

### DIFF
--- a/doc/source/tutorial/interpolate/1D.rst
+++ b/doc/source/tutorial/interpolate/1D.rst
@@ -181,7 +181,7 @@ may produce vastly different curves. As an example, we consider three
 parametrizations of (a somewhat difficult) dataset, which we take from
 Chapter 6 of Ref [1] listed in the `BSpline` docstring:
 
-.. plot ::
+.. plot::
 
     >>> x = [0, 1, 2, 3, 4, 5, 6]
     >>> y = [0, 0, 0, 9, 0, 0, 0]

--- a/doc/source/tutorial/interpolate/splines_and_polynomials.rst
+++ b/doc/source/tutorial/interpolate/splines_and_polynomials.rst
@@ -212,7 +212,7 @@ is defined by :math:`k+2` knots and is zero outside of these knots.
 To illustrate, plot a collection of non-zero basis elements on a certain
 interval:
 
-.. plot ::
+.. plot::
 
     >>> k = 3      # cubic splines
     >>> t = [0., 1.4, 2., 3.1, 5.]   # internal knots

--- a/scipy/optimize/_tnc.py
+++ b/scipy/optimize/_tnc.py
@@ -317,7 +317,7 @@ def _minimize_tnc(fun, x0, args=(), jac=None, bounds=None,
         then `maxiter` is ignored.
         Default is None.
 
-        .. deprecated :: 1.9.0
+        .. deprecated:: 1.9.0
             `maxiter` is deprecated in favor of `maxfun` and will removed in
             SciPy 1.11.0.
     eta : float


### PR DESCRIPTION
While this is supported by sphinx/docutils it is not in the spec and can be interpreted differently by other parsers/syntax highlighter, in particular interpreted as a comment block.

This is as far as I can tell the only places in the codebase that use a space in this place.


See #14972 as well.