### PR TITLE
DOC: single -> double colon for directive.

### DIFF
--- a/scipy/_lib/_docscrape.py
+++ b/scipy/_lib/_docscrape.py
@@ -329,7 +329,7 @@ class NumpyDocString(Mapping):
 
     def _parse_index(self, section, content):
         """
-        .. index: default
+        .. index:: default
            :refguide: something, else, and more
 
         """

--- a/scipy/sparse/linalg/_expm_multiply.py
+++ b/scipy/sparse/linalg/_expm_multiply.py
@@ -132,7 +132,7 @@ def expm_multiply(A, B, start=None, stop=None, num=None,
         For linear operators, `traceA` should be provided to ensure performance
         as the estimation is not guaranteed to be reliable for all cases.
 
-        .. versionadded: 1.9.0
+        .. versionadded:: 1.9.0
 
     Returns
     -------

--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -472,7 +472,7 @@ cdef class Rotation:
 
     Notes
     -----
-    .. versionadded: 1.2.0
+    .. versionadded:: 1.2.0
 
     Examples
     --------


### PR DESCRIPTION
It looks like those three locations should be directive and thus should have a double colon.
