### PR TITLE
ENH: entropy for matrix normal distribution

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -1248,12 +1248,15 @@ class matrix_normal_gen(multi_rv_generic):
             out = out.reshape(mean.shape)
         return out
 
-    def entropy(self, mean=None, rowcov=1, colcov=1):
+    def entropy(self, rowcov=1, colcov=1):
         """Log of the matrix normal probability density function.
 
         Parameters
         ----------
-        %(_matnorm_doc_default_callparams)s
+        rowcov : array_like, optional
+            Among-row covariance matrix of the distribution (default: `1`)
+        colcov : array_like, optional
+            Among-column covariance matrix of the distribution (default: `1`)
 
         Returns
         -------
@@ -1265,8 +1268,10 @@ class matrix_normal_gen(multi_rv_generic):
         %(_matnorm_doc_callparams_note)s
 
         """
-        dims, mean, rowcov, colcov = self._process_parameters(mean, rowcov,
-                                                              colcov)
+        dummy_mean = np.zeros((rowcov.shape[0], colcov.shape[0]))
+        dims, _, rowcov, colcov = self._process_parameters(dummy_mean,
+                                                           rowcov,
+                                                           colcov)
         rowpsd = _PSD(rowcov, allow_singular=False)
         colpsd = _PSD(colcov, allow_singular=False)
 

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -897,15 +897,18 @@ class TestMatrixNormal:
                 X = frozen.rvs(random_state=1234)
                 pdf1 = frozen.pdf(X)
                 logpdf1 = frozen.logpdf(X)
+                entropy1 = frozen.entropy()
 
                 vecX = X.T.flatten()
                 vecM = M.T.flatten()
                 cov = np.kron(V,U)
                 pdf2 = multivariate_normal.pdf(vecX, mean=vecM, cov=cov)
                 logpdf2 = multivariate_normal.logpdf(vecX, mean=vecM, cov=cov)
+                entropy2 = multivariate_normal.entropy(mean=vecM, cov=cov)
 
                 assert_allclose(pdf1, pdf2, rtol=1E-10)
                 assert_allclose(logpdf1, logpdf2, rtol=1E-10)
+                assert_allclose(entropy1, entropy2)
 
     def test_array_input(self):
         # Check array of inputs has the same output as the separate entries.


### PR DESCRIPTION
#### Reference issue
gh-17748

#### What does this implement/fix?
Adds the `entropy` method for the matrix normal distribution

#### Additional information
Reference: https://statproofbook.github.io/P/matn-dent