### PR TITLE
DOC: stats: additional normality test examples

### DIFF
--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1767,10 +1767,7 @@ def shapiro(x):
     -----
     The algorithm used is described in [4]_ but censoring parameters as
     described are not implemented. For N > 5000 the W test statistic is
-    accurate, but the p-value may not be. Nonetheless, the p-
-
-    The chance of rejecting the null hypothesis when it is true is close to 5%
-    regardless of sample size.
+    accurate, but the p-value may not be.
 
     References
     ----------
@@ -1826,7 +1823,7 @@ def shapiro(x):
     >>> def plot(ax):  # we'll re-use this
     ...     ax.hist(ref.null_distribution, density=True, bins=bins)
     ...     ax.set_title("Shapiro-Wilk Test Null Distribution \n"
-                         "(Monte Carlo Approximation, 11 Observations)")
+    ...                  "(Monte Carlo Approximation, 11 Observations)")
     ...     ax.set_xlabel("statistic")
     ...     ax.set_ylabel("probability density")
     >>> plot(ax)

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1741,7 +1741,7 @@ ShapiroResult = namedtuple('ShapiroResult', ('statistic', 'pvalue'))
 
 
 def shapiro(x):
-    """Perform the Shapiro-Wilk test for normality.
+    r"""Perform the Shapiro-Wilk test for normality.
 
     The Shapiro-Wilk test tests the null hypothesis that the
     data was drawn from a normal distribution.
@@ -1766,8 +1766,8 @@ def shapiro(x):
     Notes
     -----
     The algorithm used is described in [4]_ but censoring parameters as
-    described are not implemented. For N > 5000 the W test statistic is accurate
-    but the p-value may not be.
+    described are not implemented. For N > 5000 the W test statistic is
+    accurate, but the p-value may not be. Nonetheless, the p-
 
     The chance of rejecting the null hypothesis when it is true is close to 5%
     regardless of sample size.
@@ -1781,20 +1781,87 @@ def shapiro(x):
            Kolmogorov-Smirnov, Lilliefors and Anderson-Darling tests, Journal of
            Statistical Modeling and Analytics, Vol. 2, pp. 21-33.
     .. [4] ALGORITHM AS R94 APPL. STATIST. (1995) VOL. 44, NO. 4.
+    .. [5] B. Phipson and G. K. Smyth. "Permutation P-values Should Never Be
+           Zero: Calculating Exact P-values When Permutations Are Randomly
+           Drawn." Statistical Applications in Genetics and Molecular Biology
+           9.1 (2010).
+    .. [6] Panagiotakos, D. B. (2008). The value of p-value in biomedical
+           research. The open cardiovascular medicine journal, 2, 97.
 
     Examples
     --------
+    Suppose we wish to infer from measurements whether the weights of adult
+    human males in a medical study are not normally distributed [2]_.
+    The weights (lbs) are recorded in the array ``x`` below.
+
     >>> import numpy as np
+    >>> x = np.array([148, 154, 158, 160, 161, 162, 166, 170, 182, 195, 236])
+
+    The normality test of [1]_ and [2]_ begins by computing a statistic based
+    on the relationship between the observations and the expected order
+    statistics of a normal distribution.
+
     >>> from scipy import stats
-    >>> rng = np.random.default_rng()
-    >>> x = stats.norm.rvs(loc=5, scale=3, size=100, random_state=rng)
-    >>> shapiro_test = stats.shapiro(x)
-    >>> shapiro_test
-    ShapiroResult(statistic=0.9813305735588074, pvalue=0.16855233907699585)
-    >>> shapiro_test.statistic
-    0.9813305735588074
-    >>> shapiro_test.pvalue
-    0.16855233907699585
+    >>> res = stats.shapiro(x)
+    >>> res.statistic
+    0.7888147830963135
+
+    The value of this statistic tends to be high (close to 1) for samples drawn
+    from a normal distribution.
+
+    The test is performed by comparing the observed value of the statistic
+    against the null distribution: the distribution of statistic values formed
+    under the null hypothesis that the weights were drawn from a normal
+    distribution. For this normality test, the null distribution is not easy to
+    calculate exactly, so it is usually approximated by Monte Carlo methods.
+
+    >>> def statistic(x):
+    ...     # Get only the `shapiro` statistic; ignore its p-value
+    ...     return stats.shapiro(x).statistic
+    >>> ref = stats.monte_carlo_test(x, stats.norm.rvs, statistic,
+    ...                              alternative='less')
+    >>> import matplotlib.pyplot as plt
+    >>> fig, ax = plt.subplots(figsize=(8, 5))
+    >>> bins = np.linspace(0.65, 1, 50)
+    >>> def plot(ax):  # we'll re-use this
+    ...     ax.hist(ref.null_distribution, density=True, bins=bins)
+    ...     ax.set_title("Shapiro-Wilk Test Null Distribution \n"
+                         "(Monte Carlo Approximation, 11 Observations)")
+    ...     ax.set_xlabel("statistic")
+    ...     ax.set_ylabel("probability density")
+    >>> plot(ax)
+    >>> plt.show()
+
+    The comparison is quantified by the p-value: the proportion of values in
+    the null distribution less than or equal to the observed value of the
+    statistic.
+
+    >>> fig, ax = plt.subplots(figsize=(8, 5))
+    >>> plot(ax)
+    >>> annotation = (f'p-value={res.pvalue:.6f}\n(highlighted area)')
+    >>> props = dict(facecolor='black', width=1, headwidth=5, headlength=8)
+    >>> _ = ax.annotate(annotation, (0.75, 0.1), (0.68, 0.7), arrowprops=props)
+    >>> i_extreme = np.where(bins <= res.statistic)[0]
+    >>> for i in i_extreme:
+    ...     ax.patches[i].set_color('C1')
+    >>> plt.xlim(0.65, 0.9)
+    >>> plt.ylim(0, 4)
+    >>> plt.show
+    >>> res.pvalue
+    0.006703833118081093
+
+    If the p-value is "small" - that is, if there is a low probability of
+    sampling data from a normally distributed population that produces such an
+    extreme value of the statistic - this may be taken as evidence against
+    the null hypothesis in favor of the alternative: the weights were not
+    drawn from a normal distribution. Note that:
+
+    - The inverse is not true; that is, the test is not used to provide
+      evidence *for* the null hypothesis.
+    - The threshold for values that will be considered "small" is a choice that
+      should be made before the data is analyzed [5]_ with consideration of the
+      risks of both false positives (incorrectly rejecting the null hypothesis)
+      and false negatives (failure to reject a false null hypothesis).
 
     """
     x = np.ravel(x)

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -1805,7 +1805,7 @@ NormaltestResult = namedtuple('NormaltestResult', ('statistic', 'pvalue'))
 
 
 def normaltest(a, axis=0, nan_policy='propagate'):
-    """Test whether a sample differs from a normal distribution.
+    r"""Test whether a sample differs from a normal distribution.
 
     This function tests the null hypothesis that a sample comes
     from a normal distribution.  It is based on D'Agostino and
@@ -1839,28 +1839,116 @@ def normaltest(a, axis=0, nan_policy='propagate'):
     ----------
     .. [1] D'Agostino, R. B. (1971), "An omnibus test of normality for
            moderate and large sample size", Biometrika, 58, 341-348
-
     .. [2] D'Agostino, R. and Pearson, E. S. (1973), "Tests for departure from
            normality", Biometrika, 60, 613-622
+    .. [3] Shapiro, S. S., & Wilk, M. B. (1965). An analysis of variance test
+           for normality (complete samples). Biometrika, 52(3/4), 591-611.
+    .. [4] B. Phipson and G. K. Smyth. "Permutation P-values Should Never Be
+           Zero: Calculating Exact P-values When Permutations Are Randomly
+           Drawn." Statistical Applications in Genetics and Molecular Biology
+           9.1 (2010).
+    .. [5] Panagiotakos, D. B. (2008). The value of p-value in biomedical
+           research. The open cardiovascular medicine journal, 2, 97.
 
     Examples
     --------
+    Suppose we wish to infer from measurements whether the weights of adult
+    human males in a medical study are not normally distributed [3]_.
+    The weights (lbs) are recorded in the array ``x`` below.
+
     >>> import numpy as np
+    >>> x = np.array([148, 154, 158, 160, 161, 162, 166, 170, 182, 195, 236])
+
+    The normality test of [1]_ and [2] begins by computing a statistic based on
+    the sample skewness and kurtosis.
+
     >>> from scipy import stats
-    >>> rng = np.random.default_rng()
-    >>> pts = 1000
-    >>> a = rng.normal(0, 1, size=pts)
-    >>> b = rng.normal(2, 1, size=pts)
-    >>> x = np.concatenate((a, b))
-    >>> k2, p = stats.normaltest(x)
-    >>> alpha = 1e-3
-    >>> print("p = {:g}".format(p))
-    p = 8.4713e-19
-    >>> if p < alpha:  # null hypothesis: x comes from a normal distribution
-    ...     print("The null hypothesis can be rejected")
-    ... else:
-    ...     print("The null hypothesis cannot be rejected")
-    The null hypothesis can be rejected
+    >>> res = stats.normaltest(x)
+    >>> res.statistic
+    13.034263121192582
+
+    (The test warns that our sample has too few observations to perform the
+    test. We'll return to this at the end of the example.)
+    Because the normal distribution has zero skewness and zero
+    ("excess" or "Fisher") kurtosis, the value of this statistic tends to be
+    low for samples drawn from a normal distribution.
+
+    The test is performed by comparing the observed value of the statistic
+    against the null distribution: the distribution of statistic values derived
+    under the null hypothesis that the weights were drawn from a normal
+    distribution.
+    For this normality test, the null distribution for very large samples is
+    the chi-squared distribution with two degrees of freedom.
+
+    >>> import matplotlib.pyplot as plt
+    >>> dist = stats.chi2(df=2)
+    >>> stat_vals = np.linspace(0, 16, 100)
+    >>> pdf = dist.pdf(stat_vals)
+    >>> fig, ax = plt.subplots(figsize=(8, 5))
+    >>> def plot(ax):  # we'll re-use this
+    ...     ax.plot(stat_vals, pdf)
+    ...     ax.set_title("Normality Test Null Distribution")
+    ...     ax.set_xlabel("statistic")
+    ...     ax.set_ylabel("probability density")
+    >>> ax = plot(ax)
+    >>> plt.show()
+
+    The comparison is quantified by the p-value: the proportion of values in
+    the null distribution greater than or equal to the observed value of the
+    statistic.
+
+    >>> fig, ax = plt.subplots(figsize=(8, 5))
+    >>> plot(ax)
+    >>> pvalue = dist.sf(res.statistic)
+    >>> annotation = (f'p-value={pvalue:.6f}\n(shaded area)')
+    >>> props = dict(facecolor='black', width=1, headwidth=5, headlength=8)
+    >>> _ = ax.annotate(annotation, (13.5, 5e-4), (14, 5e-3), arrowprops=props)
+    >>> i = stat_vals >= res.statistic  # index more extreme statistic values
+    >>> ax.fill_between(stat_vals[i], y1=0, y2=pdf[i])
+    >>> ax.set_xlim(8, 16)
+    >>> ax.set_ylim(0, 0.01)
+    >>> plt.show()
+    >>> res.pvalue
+    0.0014779023013100172
+
+    If the p-value is "small" - that is, if there is a low probability of
+    sampling data from a normally distributed population that produces such an
+    extreme value of the statistic - this may be taken as evidence against
+    the null hypothesis in favor of the alternative: the weights were not
+    drawn from a normal distribution. Note that:
+
+    - The inverse is not true; that is, the test is not used to provide
+      evidence for the null hypothesis.
+    - The threshold for values that will be considered "small" is a choice that
+      should be made before the data is analyzed [4]_ with consideration of the
+      risks of both false positives (incorrectly rejecting the null hypothesis)
+      and false negatives (failure to reject a false null hypothesis).
+
+    Note that the chi-squared distribution provides an asymptotic
+    approximation of the null distribution; it is only accurate for samples
+    with many observations. This is the reason we received a warning at the
+    beginning of the example; our sample is quite small. In this case,
+    `scipy.stats.monte_carlo_test` may provide a more accurate, albeit
+    stochastic, approximation of the exact p-value.
+
+    >>> def statistic(x, axis):
+    ...     # Get only the `normaltest` statistic; ignore approximate p-value
+    ...     return stats.normaltest(x, axis=axis).statistic
+    >>> res = stats.monte_carlo_test(x, stats.norm.rvs, statistic)
+    >>> fig, ax = plt.subplots(figsize=(8, 5))
+    >>> plot(ax)
+    >>> ax.hist(res.null_distribution, np.linspace(0, 10, 50),
+    ...         density=True)
+    >>> ax.legend(['aymptotic approximation (many observations)',
+    ...            'Monte Carlo approximation (11 observations)'])
+    >>> ax.set_xlim(0, 14)
+    >>> plt.show()
+    >>> res.pvalue
+    0.0186  # may vary
+
+    Furthermore, despite their stochastic nature, p-values computed in this way
+    can be used to exactly control the rate of false rejections of the null
+    hypothesis [5]_.
 
     """
     a, axis = _chk_asarray(a, axis)

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -1590,7 +1590,7 @@ def skewtest(a, axis=0, nan_policy='propagate', alternative='two-sided'):
     ...     ax.set_title("Skew Test Null Distribution")
     ...     ax.set_xlabel("statistic")
     ...     ax.set_ylabel("probability density")
-    >>> ax = st_plot(ax)
+    >>> st_plot(ax)
     >>> plt.show()
 
     The comparison is quantified by the p-value: the proportion of values in
@@ -1785,7 +1785,7 @@ def kurtosistest(a, axis=0, nan_policy='propagate', alternative='two-sided'):
     ...     ax.set_title("Kurtosis Test Null Distribution")
     ...     ax.set_xlabel("statistic")
     ...     ax.set_ylabel("probability density")
-    >>> ax = kt_plot(ax)
+    >>> kt_plot(ax)
     >>> plt.show()
 
     The comparison is quantified by the p-value: the proportion of values in
@@ -1949,8 +1949,8 @@ def normaltest(a, axis=0, nan_policy='propagate'):
     >>> import numpy as np
     >>> x = np.array([148, 154, 158, 160, 161, 162, 166, 170, 182, 195, 236])
 
-    The normality test of [1]_ and [2] begins by computing a statistic based on
-    the sample skewness and kurtosis.
+    The normality test of [1]_ and [2]_ begins by computing a statistic based
+    on the sample skewness and kurtosis.
 
     >>> from scipy import stats
     >>> res = stats.normaltest(x)
@@ -1980,7 +1980,7 @@ def normaltest(a, axis=0, nan_policy='propagate'):
     ...     ax.set_title("Normality Test Null Distribution")
     ...     ax.set_xlabel("statistic")
     ...     ax.set_ylabel("probability density")
-    >>> ax = plot(ax)
+    >>> plot(ax)
     >>> plt.show()
 
     The comparison is quantified by the p-value: the proportion of values in
@@ -2024,17 +2024,18 @@ def normaltest(a, axis=0, nan_policy='propagate'):
     >>> def statistic(x, axis):
     ...     # Get only the `normaltest` statistic; ignore approximate p-value
     ...     return stats.normaltest(x, axis=axis).statistic
-    >>> res = stats.monte_carlo_test(x, stats.norm.rvs, statistic)
+    >>> res = stats.monte_carlo_test(x, stats.norm.rvs, statistic,
+    ...                              alternative='greater')
     >>> fig, ax = plt.subplots(figsize=(8, 5))
     >>> plot(ax)
-    >>> ax.hist(res.null_distribution, np.linspace(0, 10, 50),
+    >>> ax.hist(res.null_distribution, np.linspace(0, 25, 50),
     ...         density=True)
     >>> ax.legend(['aymptotic approximation (many observations)',
     ...            'Monte Carlo approximation (11 observations)'])
     >>> ax.set_xlim(0, 14)
     >>> plt.show()
     >>> res.pvalue
-    0.0186  # may vary
+    0.0082  # may vary
 
     Furthermore, despite their stochastic nature, p-values computed in this way
     can be used to exactly control the rate of false rejections of the null
@@ -2139,7 +2140,7 @@ def jarque_bera(x, *, axis=None):
     ...     ax.set_title("Jarque-Bera Null Distribution")
     ...     ax.set_xlabel("statistic")
     ...     ax.set_ylabel("probability density")
-    >>> ax = jb_plot(ax)
+    >>> jb_plot(ax)
     >>> plt.show()
 
     The comparison is quantified by the p-value: the proportion of values in
@@ -2184,7 +2185,8 @@ def jarque_bera(x, *, axis=None):
     ...     s = stats.skew(x, axis=axis)
     ...     k = stats.kurtosis(x, axis=axis)
     ...     return x.shape[axis]/6 * (s**2 + k**2/4)
-    >>> res = stats.monte_carlo_test(x, stats.norm.rvs, statistic)
+    >>> res = stats.monte_carlo_test(x, stats.norm.rvs, statistic,
+    ...                              alternative='greater')
     >>> fig, ax = plt.subplots(figsize=(8, 5))
     >>> jb_plot(ax)
     >>> ax.hist(res.null_distribution, np.linspace(0, 10, 50),
@@ -2193,7 +2195,7 @@ def jarque_bera(x, *, axis=None):
     ...            'Monte Carlo approximation (11 observations)'])
     >>> plt.show()
     >>> res.pvalue
-    0.0142  # may vary
+    0.0097  # may vary
 
     Furthermore, despite their stochastic nature, p-values computed in this way
     can be used to exactly control the rate of false rejections of the null


### PR DESCRIPTION
#### Reference issue
gh-17747 

#### What does this implement/fix?
This adds similar examples to the remaining normality tests: `kurtosistest`, `normaltest`, and `shapiro`.

#### Additional information
I'd rather not modify the examples of `anderson` or `goodness_of_fit` at this time. `anderson` is all but superseded by `goodness_of_fit`, and the `goodness_of_fit` example is already thorough.

There is also a minor adjustment to the `jarque_bera` example here because I forgot to run `monte_carlo_test` with `alternative='greater'`.