### PR TITLE
DOC/BUG: add missing entropy methods in docstrings

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -945,6 +945,8 @@ class matrix_normal_gen(multi_rv_generic):
         Log of the probability density function.
     rvs(mean=None, rowcov=1, colcov=1, size=1, random_state=None)
         Draw random samples.
+    entropy(rowcol=1, colcov=1)
+        Differential entropy.
 
     Parameters
     ----------
@@ -2534,6 +2536,8 @@ class invwishart_gen(wishart_gen):
         Log of the probability density function.
     rvs(df, scale, size=1, random_state=None)
         Draw random samples from an inverse Wishart distribution.
+    entropy(df, scale)
+        Differential entropy of the distribution.
 
     Parameters
     ----------


### PR DESCRIPTION
#### Reference issue
In #17764 and #17700 method were added to calculate the differential entropy of the matrix normal and the inverse wishart distributions. I missed to add the new methods in the proper section of the docstring unfortunately. This is fixed by this PR.
CC @tupui 
