### PR TITLE
DOC: stats: add realistic examples to correlation tests

### DIFF
--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1810,7 +1810,9 @@ def shapiro(x):
     against the null distribution: the distribution of statistic values formed
     under the null hypothesis that the weights were drawn from a normal
     distribution. For this normality test, the null distribution is not easy to
-    calculate exactly, so it is usually approximated by Monte Carlo methods.
+    calculate exactly, so it is usually approximated by Monte Carlo methods,
+    that is, drawing many samples of the same size as ``x`` from a normal
+    distribution and computing the values of the statistic for each.
 
     >>> def statistic(x):
     ...     # Get only the `shapiro` statistic; ignore its p-value

--- a/tools/unicode-check.py
+++ b/tools/unicode-check.py
@@ -11,7 +11,7 @@ import argparse
 # allow in the source code.
 latin1_letters = set(chr(cp) for cp in range(192, 256))
 box_drawing_chars = set(chr(cp) for cp in range(0x2500, 0x2580))
-extra_symbols = set(['®', 'ő', 'λ', 'π', 'ω', '∫', '≠', '≥'])
+extra_symbols = set(['®', 'ő', 'λ', 'π', 'ω', '∫', '≠', '≥', 'μ'])
 allowed = latin1_letters | box_drawing_chars | extra_symbols
 
 


### PR DESCRIPTION
#### What does this implement/fix?
Adds a realistic example to `scipy.stats.spearmanr`. 

#### Additional information
When this looks good, I'll add similar examples to the other correlation tests.