### PR TITLE
BLD: link to libatomic if necessary

### DIFF
--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -293,6 +293,25 @@ else
   use_math_defines = []
 endif
 
+# Determine whether it is necessary to link libatomic. This could be the case
+# e.g. on 32-bit platforms when atomic operations are used on 64-bit types.
+# The check is copied from Mesa <https://www.mesa3d.org/>.
+atomic_dep = dependency('', required : false)
+if cc.get_id() != 'msvc'
+  if not cc.links('''
+      #include <stdint.h>
+      int main() {
+       struct {
+         uint64_t *v;
+       } x;
+       return (int)__atomic_load_n(x.v, __ATOMIC_ACQUIRE) &
+              (int)__atomic_add_fetch(x.v, (uint64_t)1, __ATOMIC_ACQ_REL);
+      }''',
+      name : 'GCC atomic builtins required -latomic')
+    atomic_dep = cc.find_library('atomic')
+  endif
+endif
+
 # Suppress warning for deprecated Numpy API.
 # (Suppress warning messages emitted by #warning directives).
 # Replace with numpy_nodepr_api after Cython 3.0 is out

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -296,19 +296,39 @@ endif
 # Determine whether it is necessary to link libatomic. This could be the case
 # e.g. on 32-bit platforms when atomic operations are used on 64-bit types.
 # The check is copied from Mesa <https://www.mesa3d.org/>.
-atomic_dep = dependency('', required : false)
+# Note that this dependency is not desired, it came in with a HiGHS update.
+# We should try to get rid of it. For discussion, see gh-17777.
+null_dep = dependency('', required : false)
+atomic_dep = null_dep
+code_non_lockfree = '''
+  #include <stdint.h>
+  int main() {
+   struct {
+     uint64_t *v;
+   } x;
+   return (int)__atomic_load_n(x.v, __ATOMIC_ACQUIRE) &
+          (int)__atomic_add_fetch(x.v, (uint64_t)1, __ATOMIC_ACQ_REL);
+  }
+'''
 if cc.get_id() != 'msvc'
-  if not cc.links('''
-      #include <stdint.h>
-      int main() {
-       struct {
-         uint64_t *v;
-       } x;
-       return (int)__atomic_load_n(x.v, __ATOMIC_ACQUIRE) &
-              (int)__atomic_add_fetch(x.v, (uint64_t)1, __ATOMIC_ACQ_REL);
-      }''',
-      name : 'GCC atomic builtins required -latomic')
-    atomic_dep = cc.find_library('atomic')
+  if not cc.links(
+      code_non_lockfree,
+      name : 'Check atomic builtins without -latomic'
+    )
+    atomic_dep = cc.find_library('atomic', required: false)
+    if atomic_dep.found()
+      # We're not sure that with `-latomic` things will work for all compilers,
+      # so verify and only keep libatomic as a dependency if this works. It is
+      # possible the build will fail later otherwise - unclear under what
+      # circumstances (compilers, runtimes, etc.) exactly.
+      if not cc.links(
+          code_non_lockfree,
+          dependencies: atomic_dep,
+          name : 'Check atomic builtins with -latomic'
+        )
+        atomic_dep = null_dep
+      endif
+    endif
   endif
 endif
 

--- a/scipy/optimize/_highs/meson.build
+++ b/scipy/optimize/_highs/meson.build
@@ -237,7 +237,7 @@ _highs_wrapper = py3.extension_module('_highs_wrapper',
     '../../_lib/highs/src/lp_data/',
     '../../_lib/highs/src/util/'
   ],
-  dependencies: thread_dep,
+  dependencies: [thread_dep, atomic_dep],
   link_args: version_link_args,
   link_with: [highs_lib, ipx_lib, basiclu_lib],
   cpp_args: [highs_flags, highs_define_macros, cython_c_args],


### PR DESCRIPTION
#### Reference issue
Closes #17670

#### What does this implement/fix?
Add a test (using the check code from Mesa) whether 64-bit atomic builtins work correctly without additional libraries, and link to libatomic if they do not. This fixes creating _highs_wrapper extension that fails to load due to missing symbols, e.g.:

    ImportError: /home/fhnw/.pyenv/versions/flask3.11.1/lib/python3.11/site-packages/scipy/optimize/_highs/_highs_wrapper.cpython-311-arm-linux-gnueabihf.so: undefined symbol: __atomic_compare_exchange_8

#### Additional information
I have tested it on Gentoo/ppc32 that experienced the same issue as described in the linked bug.
