### PR TITLE
DOC: stats: add realistic examples to variance tests

### DIFF
--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -2683,17 +2683,17 @@ def bartlett(*samples):
     >>> import matplotlib.pyplot as plt
     >>> k = 3  # number of samples
     >>> dist = stats.chi2(df=k-1)
-    >>> bart_val = np.linspace(0, 5, 100)
-    >>> pdf = dist.pdf(bart_val)
+    >>> val = np.linspace(0, 5, 100)
+    >>> pdf = dist.pdf(val)
     >>> fig, ax = plt.subplots(figsize=(8, 5))
-    >>> def bart_plot(ax):  # we'll re-use this
-    ...     ax.plot(bart_val, pdf, color='C0')
-    ...     ax.set_title("Levene Test Null Distribution")
+    >>> def plot(ax):  # we'll re-use this
+    ...     ax.plot(val, pdf, color='C0')
+    ...     ax.set_title("Bartlett Test Null Distribution")
     ...     ax.set_xlabel("statistic")
     ...     ax.set_ylabel("probability density")
     ...     ax.set_xlim(0, 5)
     ...     ax.set_ylim(0, 1)
-    >>> bart_plot(ax)
+    >>> plot(ax)
     >>> plt.show()
 
     The comparison is quantified by the p-value: the proportion of values in
@@ -2701,13 +2701,13 @@ def bartlett(*samples):
     statistic.
 
     >>> fig, ax = plt.subplots(figsize=(8, 5))
-    >>> bart_plot(ax)
+    >>> plot(ax)
     >>> pvalue = dist.sf(res.statistic)
     >>> annotation = (f'p-value={pvalue:.3f}\n(shaded area)')
     >>> props = dict(facecolor='black', width=1, headwidth=5, headlength=8)
     >>> _ = ax.annotate(annotation, (1.5, 0.22), (2.25, 0.3), arrowprops=props)
-    >>> i = bart_val >= res.statistic
-    >>> ax.fill_between(bart_val[i], y1=0, y2=pdf[i], color='C0')
+    >>> i = val >= res.statistic
+    >>> ax.fill_between(val[i], y1=0, y2=pdf[i], color='C0')
     >>> plt.show()
 
     >>> res.pvalue
@@ -2730,8 +2730,8 @@ def bartlett(*samples):
       unlikely to have occurred under the null hypothesis.
 
     Note that the chi-square distribution provides an asymptotic approximation
-    of the null distribution; it is only accurate for samples with many
-    observations. For small samples, it may be more appropriate to perform a
+    of the null distribution.
+    For small samples, it may be more appropriate to perform a
     permutation test: Under the null hypothesis that all three samples were
     drawn from the same population, each of the measurements is equally likely
     to have been observed in any of the three samples. Therefore, we can form
@@ -2746,14 +2746,14 @@ def bartlett(*samples):
     ...     permutation_type='independent', alternative='greater'
     ... )
     >>> fig, ax = plt.subplots(figsize=(8, 5))
-    >>> bart_plot(ax)
+    >>> plot(ax)
     >>> bins = np.linspace(0, 5, 25)
     >>> ax.hist(
     ...     ref.null_distribution, bins=bins, density=True, facecolor="C1"
     ... )
     >>> ax.legend(['aymptotic approximation\n(many observations)',
     ...            'randomized null distribution'])
-    >>> bart_plot(ax)
+    >>> plot(ax)
     >>> plt.show()
 
     >>> ref.pvalue  # randomized test p-value
@@ -2932,17 +2932,17 @@ def levene(*samples, center='median', proportiontocut=0.05):
     >>> import matplotlib.pyplot as plt
     >>> k, n = 3, 60   # number of samples, total number of observations
     >>> dist = stats.f(dfn=k-1, dfd=n-k)
-    >>> lev_val = np.linspace(0, 5, 100)
-    >>> pdf = dist.pdf(lev_val)
+    >>> val = np.linspace(0, 5, 100)
+    >>> pdf = dist.pdf(val)
     >>> fig, ax = plt.subplots(figsize=(8, 5))
-    >>> def lev_plot(ax):  # we'll re-use this
-    ...     ax.plot(lev_val, pdf, color='C0')
+    >>> def plot(ax):  # we'll re-use this
+    ...     ax.plot(val, pdf, color='C0')
     ...     ax.set_title("Levene Test Null Distribution")
     ...     ax.set_xlabel("statistic")
     ...     ax.set_ylabel("probability density")
     ...     ax.set_xlim(0, 5)
     ...     ax.set_ylim(0, 1)
-    >>> lev_plot(ax)
+    >>> plot(ax)
     >>> plt.show()
 
     The comparison is quantified by the p-value: the proportion of values in
@@ -2950,13 +2950,13 @@ def levene(*samples, center='median', proportiontocut=0.05):
     statistic.
 
     >>> fig, ax = plt.subplots(figsize=(8, 5))
-    >>> lev_plot(ax)
+    >>> plot(ax)
     >>> pvalue = dist.sf(res.statistic)
     >>> annotation = (f'p-value={pvalue:.3f}\n(shaded area)')
     >>> props = dict(facecolor='black', width=1, headwidth=5, headlength=8)
     >>> _ = ax.annotate(annotation, (1.5, 0.22), (2.25, 0.3), arrowprops=props)
-    >>> i = lev_val >= res.statistic
-    >>> ax.fill_between(lev_val[i], y1=0, y2=pdf[i], color='C0')
+    >>> i = val >= res.statistic
+    >>> ax.fill_between(val[i], y1=0, y2=pdf[i], color='C0')
     >>> plt.show()
 
     >>> res.pvalue
@@ -2979,7 +2979,7 @@ def levene(*samples, center='median', proportiontocut=0.05):
       unlikely to have occurred under the null hypothesis.
 
     Note that the F distribution provides an asymptotic approximation of the
-    null distribution; it is only accurate for samples with many observations.
+    null distribution.
     For small samples, it may be more appropriate to perform a permutation
     test: Under the null hypothesis that all three samples were drawn from
     the same population, each of the measurements is equally likely to have
@@ -2995,14 +2995,14 @@ def levene(*samples, center='median', proportiontocut=0.05):
     ...     permutation_type='independent', alternative='greater'
     ... )
     >>> fig, ax = plt.subplots(figsize=(8, 5))
-    >>> lev_plot(ax)
+    >>> plot(ax)
     >>> bins = np.linspace(0, 5, 25)
     >>> ax.hist(
     ...     ref.null_distribution, bins=bins, density=True, facecolor="C1"
     ... )
     >>> ax.legend(['aymptotic approximation\n(many observations)',
     ...            'randomized null distribution'])
-    >>> lev_plot(ax)
+    >>> plot(ax)
     >>> plt.show()
 
     >>> ref.pvalue  # randomized test p-value
@@ -3324,17 +3324,17 @@ def fligner(*samples, center='median', proportiontocut=0.05):
     >>> import matplotlib.pyplot as plt
     >>> k = 3  # number of samples
     >>> dist = stats.chi2(df=k-1)
-    >>> flig_val = np.linspace(0, 8, 100)
-    >>> pdf = dist.pdf(flig_val)
+    >>> val = np.linspace(0, 8, 100)
+    >>> pdf = dist.pdf(val)
     >>> fig, ax = plt.subplots(figsize=(8, 5))
-    >>> def lev_plot(ax):  # we'll re-use this
-    ...     ax.plot(flig_val, pdf, color='C0')
+    >>> def plot(ax):  # we'll re-use this
+    ...     ax.plot(val, pdf, color='C0')
     ...     ax.set_title("Fligner Test Null Distribution")
     ...     ax.set_xlabel("statistic")
     ...     ax.set_ylabel("probability density")
     ...     ax.set_xlim(0, 8)
     ...     ax.set_ylim(0, 0.5)
-    >>> lev_plot(ax)
+    >>> plot(ax)
     >>> plt.show()
 
     The comparison is quantified by the p-value: the proportion of values in
@@ -3342,13 +3342,13 @@ def fligner(*samples, center='median', proportiontocut=0.05):
     statistic.
 
     >>> fig, ax = plt.subplots(figsize=(8, 5))
-    >>> lev_plot(ax)
+    >>> plot(ax)
     >>> pvalue = dist.sf(res.statistic)
     >>> annotation = (f'p-value={pvalue:.4f}\n(shaded area)')
     >>> props = dict(facecolor='black', width=1, headwidth=5, headlength=8)
     >>> _ = ax.annotate(annotation, (1.5, 0.22), (2.25, 0.3), arrowprops=props)
-    >>> i = flig_val >= res.statistic
-    >>> ax.fill_between(flig_val[i], y1=0, y2=pdf[i], color='C0')
+    >>> i = val >= res.statistic
+    >>> ax.fill_between(val[i], y1=0, y2=pdf[i], color='C0')
     >>> plt.show()
 
     >>> res.pvalue
@@ -3371,8 +3371,8 @@ def fligner(*samples, center='median', proportiontocut=0.05):
       unlikely to have occurred under the null hypothesis.
 
     Note that the chi-square distribution provides an asymptotic approximation
-    of the null distribution; it is only accurate for samples with many
-    observations. For small samples, it may be more appropriate to perform a
+    of the null distribution.
+    For small samples, it may be more appropriate to perform a
     permutation test: Under the null hypothesis that all three samples were
     drawn from the same population, each of the measurements is equally likely
     to have been observed in any of the three samples. Therefore, we can form
@@ -3387,14 +3387,14 @@ def fligner(*samples, center='median', proportiontocut=0.05):
     ...     permutation_type='independent', alternative='greater'
     ... )
     >>> fig, ax = plt.subplots(figsize=(8, 5))
-    >>> lev_plot(ax)
+    >>> plot(ax)
     >>> bins = np.linspace(0, 8, 25)
     >>> ax.hist(
     ...     ref.null_distribution, bins=bins, density=True, facecolor="C1"
     ... )
     >>> ax.legend(['aymptotic approximation\n(many observations)',
     ...            'randomized null distribution'])
-    >>> lev_plot(ax)
+    >>> plot(ax)
     >>> plt.show()
 
     >>> ref.pvalue  # randomized test p-value

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -241,8 +241,8 @@ def kstat(data, n=2):
 
     See Also
     --------
-    kstatvar: Returns an unbiased estimator of the variance of the k-statistic.
-    moment: Returns the n-th central moment about the mean for a sample.
+    kstatvar : Returns an unbiased estimator of the variance of the k-statistic
+    moment : Returns the n-th central moment about the mean for a sample.
 
     Notes
     -----
@@ -338,8 +338,8 @@ def kstatvar(data, n=2):
 
     See Also
     --------
-    kstat: Returns the n-th k-statistic.
-    moment: Returns the n-th central moment about the mean for a sample.
+    kstat : Returns the n-th k-statistic.
+    moment : Returns the n-th central moment about the mean for a sample.
 
     Notes
     -----
@@ -2683,7 +2683,7 @@ LeveneResult = namedtuple('LeveneResult', ('statistic', 'pvalue'))
 
 
 def levene(*samples, center='median', proportiontocut=0.05):
-    """Perform Levene test for equal variances.
+    r"""Perform Levene test for equal variances.
 
     The Levene test tests the null hypothesis that all input samples
     are from populations with equal variances.  Levene's test is an
@@ -2759,17 +2759,17 @@ def levene(*samples, center='median', proportiontocut=0.05):
     >>> import numpy as np
     >>> from scipy import stats
     >>> small_dose = np.array([
-    >>>     4.2, 11.5, 7.3, 5.8, 6.4, 10, 11.2, 11.2, 5.2, 7,
-    >>>     15.2, 21.5, 17.6, 9.7, 14.5, 10, 8.2, 9.4, 16.5, 9.7
-    >>> ])
+    ...     4.2, 11.5, 7.3, 5.8, 6.4, 10, 11.2, 11.2, 5.2, 7,
+    ...     15.2, 21.5, 17.6, 9.7, 14.5, 10, 8.2, 9.4, 16.5, 9.7
+    ... ])
     >>> medium_dose = np.array([
-    >>>     16.5, 16.5, 15.2, 17.3, 22.5, 17.3, 13.6, 14.5, 18.8, 15.5,
-    >>>     19.7, 23.3, 23.6, 26.4, 20, 25.2, 25.8, 21.2, 14.5, 27.3
-    >>> ])
+    ...     16.5, 16.5, 15.2, 17.3, 22.5, 17.3, 13.6, 14.5, 18.8, 15.5,
+    ...     19.7, 23.3, 23.6, 26.4, 20, 25.2, 25.8, 21.2, 14.5, 27.3
+    ... ])
     >>> large_dose = np.array([
-    >>>     23.6, 18.5, 33.9, 25.5, 26.4, 32.5, 26.7, 21.5, 23.3, 29.5,
-    >>>     25.5, 26.4, 22.4, 24.5, 24.8, 30.9, 26.4, 27.3, 29.4, 23
-    >>> ])
+    ...     23.6, 18.5, 33.9, 25.5, 26.4, 32.5, 26.7, 21.5, 23.3, 29.5,
+    ...     25.5, 26.4, 22.4, 24.5, 24.8, 30.9, 26.4, 27.3, 29.4, 23
+    ... ])
     >>> res = stats.levene(small_dose, medium_dose, large_dose)
     >>> res.statistic
     0.6457341109631506

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -2744,20 +2744,22 @@ def levene(*samples, center='median', proportiontocut=0.05):
            Zero: Calculating Exact P-values When Permutations Are Randomly
            Drawn." Statistical Applications in Genetics and Molecular Biology
            9.1 (2010).
+    .. [6] Ludbrook, J., & Dudley, H. (1998). Why permutation tests are
+           superior to t and F tests in biomedical research. The American
+           Statistician, 52(2), 127-132.
 
     Examples
     --------
     In [4]_, the influence of vitamin C on the tooth growth of guinea pigs
     was investigated. In a control study, 60 subjects were divided into
     small dose, medium dose, and large dose groups that received
-    daily doses of 0.5, 1.0 and 2.0 mg of vitamin C, respectively. 
-    After 42 days, the tooth growth, in microns, was measured.
+    daily doses of 0.5, 1.0 and 2.0 mg of vitamin C, respectively.
+    After 42 days, the tooth growth was measured.
 
-    In the following, we are interested in testing the null hypothesis that all
-    groups are from populations with equal variances.
+    The ``small_dose`, ``medium_dose``, and ``large_dose`` arrays below record
+    tooth growth measurements of the three groups in microns.
 
     >>> import numpy as np
-    >>> from scipy import stats
     >>> small_dose = np.array([
     ...     4.2, 11.5, 7.3, 5.8, 6.4, 10, 11.2, 11.2, 5.2, 7,
     ...     15.2, 21.5, 17.6, 9.7, 14.5, 10, 8.2, 9.4, 16.5, 9.7
@@ -2770,17 +2772,28 @@ def levene(*samples, center='median', proportiontocut=0.05):
     ...     23.6, 18.5, 33.9, 25.5, 26.4, 32.5, 26.7, 21.5, 23.3, 29.5,
     ...     25.5, 26.4, 22.4, 24.5, 24.8, 30.9, 26.4, 27.3, 29.4, 23
     ... ])
+
+    The `levene` statistic is sensitive to differences in variances
+    between the samples.
+
+    >>> from scipy import stats
     >>> res = stats.levene(small_dose, medium_dose, large_dose)
     >>> res.statistic
     0.6457341109631506
 
-    The test is performed by comparing the observed value of the
-    statistic against the null distribution: the distribution of statistic
-    values derived under the null hypothesis that the groups' variances are
-    drawn from a F distribution.
+    The value of the statistic tends to be high when there is a large
+    difference in variances.
+
+    We can test for inequality of variance among the groups by comparing the
+    observed value of the statistic against the null distribution: the
+    distribution of statistic values derived under the null hypothesis that
+    the population variances of the three groups are equal.
+
+    For this test, the null distribution follows the F distribution as shown
+    below.
 
     >>> import matplotlib.pyplot as plt
-    >>> k, n = 3, 20   # number of samples, sample size
+    >>> k, n = 3, 60   # number of samples, total number of observations
     >>> dist = stats.f(dfn=k-1, dfd=n-k)
     >>> lev_val = np.linspace(0, 5, 100)
     >>> pdf = dist.pdf(lev_val)
@@ -2799,7 +2812,7 @@ def levene(*samples, center='median', proportiontocut=0.05):
 
     >>> fig, ax = plt.subplots(figsize=(8, 5))
     >>> lev_plot(ax)
-    >>> pvalue = dist.cdf(-res.statistic) + dist.sf(res.statistic)
+    >>> pvalue = dist.sf(res.statistic)
     >>> annotation = (f'p-value={pvalue:.3f}\n(shaded area)')
     >>> props = dict(facecolor='black', width=1, headwidth=5, headlength=8)
     >>> _ = ax.annotate(annotation, (1.5, 0.22), (2.25, 0.3), arrowprops=props)
@@ -2812,10 +2825,10 @@ def levene(*samples, center='median', proportiontocut=0.05):
     0.5280694573759905
 
     If the p-value is "small" - that is, if there is a low probability of
-    sampling data from a F distributed population that produces such an
-    extreme value of the statistic - this may be taken as evidence against
-    the null hypothesis in favor of the alternative: the variances were not
-    drawn from a F distribution. Note that:
+    sampling data from distributions with identical variances that produces
+    such an extreme value of the statistic - this may be taken as evidence
+    against the null hypothesis in favor of the alternative: the variances of
+    the groups are not equal. Note that:
 
     - The inverse is not true; that is, the test is not used to provide
       evidence for the null hypothesis.
@@ -2823,13 +2836,19 @@ def levene(*samples, center='median', proportiontocut=0.05):
       should be made before the data is analyzed [5]_ with consideration of the
       risks of both false positives (incorrectly rejecting the null hypothesis)
       and false negatives (failure to reject a false null hypothesis).
+    - Small p-values are not evidence for a *large* effect; rather, they can
+      only provide evidence for a "significant" effect, meaning that they are
+      unlikely to have occurred under the null hypothesis.
 
     Note that the F distribution provides an asymptotic approximation of the
     null distribution; it is only accurate for samples with many observations.
     For small samples, it may be more appropriate to perform a permutation
-    test: Under the null hypothesis that all samples are drawn from populations
-    with the same variance. Therefore, we can form an *exact* null distribution
-    by calculating the statistic from the independent samples.
+    test: Under the null hypothesis that all three samples were drawn from
+    the same population, each of the measurements is equally likely to have
+    been observed in any of the three samples. Therefore, we can form a
+    randomized null distribution by calculating the statistic under many
+    randomly-generated partitionings of the observations into the three
+    samples.
 
     >>> def statistic(*samples):
     ...     return stats.levene(*samples).statistic
@@ -2844,17 +2863,18 @@ def levene(*samples, center='median', proportiontocut=0.05):
     ...     ref.null_distribution, bins=bins, density=True, facecolor="C1"
     ... )
     >>> ax.legend(['aymptotic approximation\n(many observations)',
-    ...            'exact null distribution'])
+    ...            'randomized null distribution'])
     >>> lev_plot(ax)
     >>> plt.show()
 
-     >>> ref.pvalue
-    0.4559  # exact p-value
+     >>> ref.pvalue  # randomized test p-value
+    0.4559  # may vary
 
-    Note that there is significant disagreement between the exact p-value
-    calculated here and the approximation returned by `levene` above. For small
-    samples with ties, consider performing a permutation test for more
-    accurate results.
+    Note that there is significant disagreement between the p-value calculated
+    here and the asymptotic approximation returned by `levene` above.
+    The statistical inferences that can be drawn rigorously from a permutation
+    test are limited; nonetheless, they may be the preferred approach in many
+    circumstances [6]_.
 
     Following is another generic example where the null hypothesis would be
     rejected.

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -2747,13 +2747,13 @@ def levene(*samples, center='median', proportiontocut=0.05):
 
     Examples
     --------
-    In [4]_, the influence of vitamine C on the tooth growth of guinea pigs
+    In [4]_, the influence of vitamin C on the tooth growth of guinea pigs
     was investigated. In a control study, 60 subjects were divided into
-    three groups each respectively recieving a daily doses of 0.5, 1.0 and 2.0
-    mg of vitamine C. After 42 days, the tooth
+    three groups each respectively receiving daily doses of 0.5, 1.0 and 2.0
+    mg of vitamin C. After 42 days, the tooth
     grow, in micron, was measured.
 
-    In the following, we are interested test the null hypothesis that all
+    In the following, we are interested in testing the null hypothesis that all
     groups are from populations with equal variances.
 
     >>> import numpy as np

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -2821,6 +2821,7 @@ def levene(*samples, center='median', proportiontocut=0.05):
     >>> ax.set_xlim(0, 5)
     >>> ax.set_ylim(0, 1)
     >>> plt.show()
+
     >>> res.pvalue
     0.5280694573759905
 
@@ -2867,7 +2868,7 @@ def levene(*samples, center='median', proportiontocut=0.05):
     >>> lev_plot(ax)
     >>> plt.show()
 
-     >>> ref.pvalue  # randomized test p-value
+    >>> ref.pvalue  # randomized test p-value
     0.4559  # may vary
 
     Note that there is significant disagreement between the p-value calculated

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -2756,7 +2756,7 @@ def levene(*samples, center='median', proportiontocut=0.05):
     daily doses of 0.5, 1.0 and 2.0 mg of vitamin C, respectively.
     After 42 days, the tooth growth was measured.
 
-    The ``small_dose`, ``medium_dose``, and ``large_dose`` arrays below record
+    The ``small_dose``, ``medium_dose``, and ``large_dose`` arrays below record
     tooth growth measurements of the three groups in microns.
 
     >>> import numpy as np
@@ -2803,6 +2803,8 @@ def levene(*samples, center='median', proportiontocut=0.05):
     ...     ax.set_title("Levene Test Null Distribution")
     ...     ax.set_xlabel("statistic")
     ...     ax.set_ylabel("probability density")
+    ...     ax.set_xlim(0, 5)
+    ...     ax.set_ylim(0, 1)
     >>> lev_plot(ax)
     >>> plt.show()
 
@@ -2818,8 +2820,6 @@ def levene(*samples, center='median', proportiontocut=0.05):
     >>> _ = ax.annotate(annotation, (1.5, 0.22), (2.25, 0.3), arrowprops=props)
     >>> i = lev_val >= res.statistic
     >>> ax.fill_between(lev_val[i], y1=0, y2=pdf[i], color='C0')
-    >>> ax.set_xlim(0, 5)
-    >>> ax.set_ylim(0, 1)
     >>> plt.show()
 
     >>> res.pvalue
@@ -3069,7 +3069,7 @@ FlignerResult = namedtuple('FlignerResult', ('statistic', 'pvalue'))
 
 
 def fligner(*samples, center='median', proportiontocut=0.05):
-    """Perform Fligner-Killeen test for equality of variance.
+    r"""Perform Fligner-Killeen test for equality of variance.
 
     Fligner's test tests the null hypothesis that all input samples
     are from populations with equal variances.  Fligner-Killeen's test is
@@ -3108,7 +3108,8 @@ def fligner(*samples, center='median', proportiontocut=0.05):
     Conover et al. (1981) examine many of the existing parametric and
     nonparametric tests by extensive simulations and they conclude that the
     tests proposed by Fligner and Killeen (1976) and Levene (1960) appear to be
-    superior in terms of robustness of departures from normality and power [3]_.
+    superior in terms of robustness of departures from normality and power
+    [3]_.
 
     References
     ----------
@@ -3117,32 +3118,167 @@ def fligner(*samples, center='median', proportiontocut=0.05):
            Report #99-03, Center for Likelihood Studies, Pennsylvania State
            University.
            https://cecas.clemson.edu/~cspark/cv/paper/qif/draftqif2.pdf
-
     .. [2] Fligner, M.A. and Killeen, T.J. (1976). Distribution-free two-sample
            tests for scale. 'Journal of the American Statistical Association.'
            71(353), 210-213.
-
     .. [3] Park, C. and Lindsay, B. G. (1999). Robust Scale Estimation and
            Hypothesis Testing based on Quadratic Inference Function. Technical
            Report #99-03, Center for Likelihood Studies, Pennsylvania State
            University.
-
     .. [4] Conover, W. J., Johnson, M. E. and Johnson M. M. (1981). A
            comparative study of tests for homogeneity of variances, with
            applications to the outer continental shelf biding data.
            Technometrics, 23(4), 351-361.
+    .. [5] C.I. BLISS (1952), The Statistics of Bioassay: With Special
+           Reference to the Vitamins, pp 499-503,
+           :doi:`10.1016/C2013-0-12584-6`.
+    .. [6] B. Phipson and G. K. Smyth. "Permutation P-values Should Never Be
+           Zero: Calculating Exact P-values When Permutations Are Randomly
+           Drawn." Statistical Applications in Genetics and Molecular Biology
+           9.1 (2010).
+    .. [7] Ludbrook, J., & Dudley, H. (1998). Why permutation tests are
+           superior to t and F tests in biomedical research. The American
+           Statistician, 52(2), 127-132.
 
     Examples
     --------
-    Test whether or not the lists `a`, `b` and `c` come from populations
-    with equal variances.
+    In [5]_, the influence of vitamin C on the tooth growth of guinea pigs
+    was investigated. In a control study, 60 subjects were divided into
+    small dose, medium dose, and large dose groups that received
+    daily doses of 0.5, 1.0 and 2.0 mg of vitamin C, respectively.
+    After 42 days, the tooth growth was measured.
+
+    The ``small_dose``, ``medium_dose``, and ``large_dose`` arrays below record
+    tooth growth measurements of the three groups in microns.
 
     >>> import numpy as np
-    >>> from scipy.stats import fligner
+    >>> small_dose = np.array([
+    ...     4.2, 11.5, 7.3, 5.8, 6.4, 10, 11.2, 11.2, 5.2, 7,
+    ...     15.2, 21.5, 17.6, 9.7, 14.5, 10, 8.2, 9.4, 16.5, 9.7
+    ... ])
+    >>> medium_dose = np.array([
+    ...     16.5, 16.5, 15.2, 17.3, 22.5, 17.3, 13.6, 14.5, 18.8, 15.5,
+    ...     19.7, 23.3, 23.6, 26.4, 20, 25.2, 25.8, 21.2, 14.5, 27.3
+    ... ])
+    >>> large_dose = np.array([
+    ...     23.6, 18.5, 33.9, 25.5, 26.4, 32.5, 26.7, 21.5, 23.3, 29.5,
+    ...     25.5, 26.4, 22.4, 24.5, 24.8, 30.9, 26.4, 27.3, 29.4, 23
+    ... ])
+
+    The `fligner` statistic is sensitive to differences in variances
+    between the samples.
+
+    >>> from scipy import stats
+    >>> res = stats.fligner(small_dose, medium_dose, large_dose)
+    >>> res.statistic
+    1.3878943408857916
+
+    The value of the statistic tends to be high when there is a large
+    difference in variances.
+
+    We can test for inequality of variance among the groups by comparing the
+    observed value of the statistic against the null distribution: the
+    distribution of statistic values derived under the null hypothesis that
+    the population variances of the three groups are equal.
+
+    For this test, the null distribution follows the chi-square distribution
+    as shown below.
+
+    >>> import matplotlib.pyplot as plt
+    >>> k = 3  # number of samples
+    >>> dist = stats.chi2(df=k-1)
+    >>> flig_val = np.linspace(0, 8, 100)
+    >>> pdf = dist.pdf(flig_val)
+    >>> fig, ax = plt.subplots(figsize=(8, 5))
+    >>> def lev_plot(ax):  # we'll re-use this
+    ...     ax.plot(flig_val, pdf, color='C0')
+    ...     ax.set_title("Fligner Test Null Distribution")
+    ...     ax.set_xlabel("statistic")
+    ...     ax.set_ylabel("probability density")
+    ...     ax.set_xlim(0, 8)
+    ...     ax.set_ylim(0, 0.5)
+    >>> lev_plot(ax)
+    >>> plt.show()
+
+    The comparison is quantified by the p-value: the proportion of values in
+    the null distribution greater than or equal to the observed value of the
+    statistic.
+
+    >>> fig, ax = plt.subplots(figsize=(8, 5))
+    >>> lev_plot(ax)
+    >>> pvalue = dist.sf(res.statistic)
+    >>> annotation = (f'p-value={pvalue:.4f}\n(shaded area)')
+    >>> props = dict(facecolor='black', width=1, headwidth=5, headlength=8)
+    >>> _ = ax.annotate(annotation, (1.5, 0.22), (2.25, 0.3), arrowprops=props)
+    >>> i = flig_val >= res.statistic
+    >>> ax.fill_between(flig_val[i], y1=0, y2=pdf[i], color='C0')
+    >>> plt.show()
+
+    >>> res.pvalue
+    0.49960016501182125
+
+    If the p-value is "small" - that is, if there is a low probability of
+    sampling data from distributions with identical variances that produces
+    such an extreme value of the statistic - this may be taken as evidence
+    against the null hypothesis in favor of the alternative: the variances of
+    the groups are not equal. Note that:
+
+    - The inverse is not true; that is, the test is not used to provide
+      evidence for the null hypothesis.
+    - The threshold for values that will be considered "small" is a choice that
+      should be made before the data is analyzed [6]_ with consideration of the
+      risks of both false positives (incorrectly rejecting the null hypothesis)
+      and false negatives (failure to reject a false null hypothesis).
+    - Small p-values are not evidence for a *large* effect; rather, they can
+      only provide evidence for a "significant" effect, meaning that they are
+      unlikely to have occurred under the null hypothesis.
+
+    Note that the chi-square distribution provides an asymptotic approximation
+    of the null distribution; it is only accurate for samples with many
+    observations. For small samples, it may be more appropriate to perform a
+    permutation test: Under the null hypothesis that all three samples were
+    drawn from the same population, each of the measurements is equally likely
+    to have been observed in any of the three samples. Therefore, we can form
+    a randomized null distribution by calculating the statistic under many
+    randomly-generated partitionings of the observations into the three
+    samples.
+
+    >>> def statistic(*samples):
+    ...     return stats.fligner(*samples).statistic
+    >>> ref = stats.permutation_test(
+    ...     (small_dose, medium_dose, large_dose), statistic,
+    ...     permutation_type='independent', alternative='greater'
+    ... )
+    >>> fig, ax = plt.subplots(figsize=(8, 5))
+    >>> lev_plot(ax)
+    >>> bins = np.linspace(0, 8, 25)
+    >>> ax.hist(
+    ...     ref.null_distribution, bins=bins, density=True, facecolor="C1"
+    ... )
+    >>> ax.legend(['aymptotic approximation\n(many observations)',
+    ...            'randomized null distribution'])
+    >>> lev_plot(ax)
+    >>> plt.show()
+
+    >>> ref.pvalue  # randomized test p-value
+    0.4332  # may vary
+
+    Note that there is significant disagreement between the p-value calculated
+    here and the asymptotic approximation returned by `fligner` above.
+    The statistical inferences that can be drawn rigorously from a permutation
+    test are limited; nonetheless, they may be the preferred approach in many
+    circumstances [7]_.
+
+    Following is another generic example where the null hypothesis would be
+    rejected.
+
+    Test whether the lists `a`, `b` and `c` come from populations
+    with equal variances.
+
     >>> a = [8.88, 9.12, 9.04, 8.98, 9.00, 9.08, 9.01, 8.85, 9.06, 8.99]
     >>> b = [8.88, 8.95, 9.29, 9.44, 9.15, 9.58, 8.36, 9.18, 8.67, 9.05]
     >>> c = [8.95, 9.12, 8.95, 8.85, 9.03, 8.84, 9.07, 8.98, 8.86, 8.98]
-    >>> stat, p = fligner(a, b, c)
+    >>> stat, p = stats.fligner(a, b, c)
     >>> p
     0.00450826080004775
 

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -2580,7 +2580,7 @@ BartlettResult = namedtuple('BartlettResult', ('statistic', 'pvalue'))
 
 
 def bartlett(*samples):
-    """Perform Bartlett's test for equal variances.
+    r"""Perform Bartlett's test for equal variances.
 
     Bartlett's test tests the null hypothesis that all input samples
     are from populations with equal variances.  For samples
@@ -2616,22 +2616,159 @@ def bartlett(*samples):
     References
     ----------
     .. [1]  https://www.itl.nist.gov/div898/handbook/eda/section3/eda357.htm
-
     .. [2]  Snedecor, George W. and Cochran, William G. (1989), Statistical
               Methods, Eighth Edition, Iowa State University Press.
-
     .. [3] Park, C. and Lindsay, B. G. (1999). Robust Scale Estimation and
            Hypothesis Testing based on Quadratic Inference Function. Technical
            Report #99-03, Center for Likelihood Studies, Pennsylvania State
            University.
-
     .. [4] Bartlett, M. S. (1937). Properties of Sufficiency and Statistical
            Tests. Proceedings of the Royal Society of London. Series A,
            Mathematical and Physical Sciences, Vol. 160, No.901, pp. 268-282.
+    .. [5] C.I. BLISS (1952), The Statistics of Bioassay: With Special
+           Reference to the Vitamins, pp 499-503,
+           :doi:`10.1016/C2013-0-12584-6`.
+    .. [6] B. Phipson and G. K. Smyth. "Permutation P-values Should Never Be
+           Zero: Calculating Exact P-values When Permutations Are Randomly
+           Drawn." Statistical Applications in Genetics and Molecular Biology
+           9.1 (2010).
+    .. [7] Ludbrook, J., & Dudley, H. (1998). Why permutation tests are
+           superior to t and F tests in biomedical research. The American
+           Statistician, 52(2), 127-132.
 
     Examples
     --------
-    Test whether or not the lists `a`, `b` and `c` come from populations
+    In [5]_, the influence of vitamin C on the tooth growth of guinea pigs
+    was investigated. In a control study, 60 subjects were divided into
+    small dose, medium dose, and large dose groups that received
+    daily doses of 0.5, 1.0 and 2.0 mg of vitamin C, respectively.
+    After 42 days, the tooth growth was measured.
+
+    The ``small_dose``, ``medium_dose``, and ``large_dose`` arrays below record
+    tooth growth measurements of the three groups in microns.
+
+    >>> import numpy as np
+    >>> small_dose = np.array([
+    ...     4.2, 11.5, 7.3, 5.8, 6.4, 10, 11.2, 11.2, 5.2, 7,
+    ...     15.2, 21.5, 17.6, 9.7, 14.5, 10, 8.2, 9.4, 16.5, 9.7
+    ... ])
+    >>> medium_dose = np.array([
+    ...     16.5, 16.5, 15.2, 17.3, 22.5, 17.3, 13.6, 14.5, 18.8, 15.5,
+    ...     19.7, 23.3, 23.6, 26.4, 20, 25.2, 25.8, 21.2, 14.5, 27.3
+    ... ])
+    >>> large_dose = np.array([
+    ...     23.6, 18.5, 33.9, 25.5, 26.4, 32.5, 26.7, 21.5, 23.3, 29.5,
+    ...     25.5, 26.4, 22.4, 24.5, 24.8, 30.9, 26.4, 27.3, 29.4, 23
+    ... ])
+
+    The `bartlett` statistic is sensitive to differences in variances
+    between the samples.
+
+    >>> from scipy import stats
+    >>> res = stats.bartlett(small_dose, medium_dose, large_dose)
+    >>> res.statistic
+    0.6654670663030519
+
+    The value of the statistic tends to be high when there is a large
+    difference in variances.
+
+    We can test for inequality of variance among the groups by comparing the
+    observed value of the statistic against the null distribution: the
+    distribution of statistic values derived under the null hypothesis that
+    the population variances of the three groups are equal.
+
+    For this test, the null distribution follows the chi-square distribution
+    as shown below.
+
+    >>> import matplotlib.pyplot as plt
+    >>> k = 3  # number of samples
+    >>> dist = stats.chi2(df=k-1)
+    >>> bart_val = np.linspace(0, 5, 100)
+    >>> pdf = dist.pdf(bart_val)
+    >>> fig, ax = plt.subplots(figsize=(8, 5))
+    >>> def bart_plot(ax):  # we'll re-use this
+    ...     ax.plot(bart_val, pdf, color='C0')
+    ...     ax.set_title("Levene Test Null Distribution")
+    ...     ax.set_xlabel("statistic")
+    ...     ax.set_ylabel("probability density")
+    ...     ax.set_xlim(0, 5)
+    ...     ax.set_ylim(0, 1)
+    >>> bart_plot(ax)
+    >>> plt.show()
+
+    The comparison is quantified by the p-value: the proportion of values in
+    the null distribution greater than or equal to the observed value of the
+    statistic.
+
+    >>> fig, ax = plt.subplots(figsize=(8, 5))
+    >>> bart_plot(ax)
+    >>> pvalue = dist.sf(res.statistic)
+    >>> annotation = (f'p-value={pvalue:.3f}\n(shaded area)')
+    >>> props = dict(facecolor='black', width=1, headwidth=5, headlength=8)
+    >>> _ = ax.annotate(annotation, (1.5, 0.22), (2.25, 0.3), arrowprops=props)
+    >>> i = bart_val >= res.statistic
+    >>> ax.fill_between(bart_val[i], y1=0, y2=pdf[i], color='C0')
+    >>> plt.show()
+
+    >>> res.pvalue
+    0.71696121509966
+
+    If the p-value is "small" - that is, if there is a low probability of
+    sampling data from distributions with identical variances that produces
+    such an extreme value of the statistic - this may be taken as evidence
+    against the null hypothesis in favor of the alternative: the variances of
+    the groups are not equal. Note that:
+
+    - The inverse is not true; that is, the test is not used to provide
+      evidence for the null hypothesis.
+    - The threshold for values that will be considered "small" is a choice that
+      should be made before the data is analyzed [6]_ with consideration of the
+      risks of both false positives (incorrectly rejecting the null hypothesis)
+      and false negatives (failure to reject a false null hypothesis).
+    - Small p-values are not evidence for a *large* effect; rather, they can
+      only provide evidence for a "significant" effect, meaning that they are
+      unlikely to have occurred under the null hypothesis.
+
+    Note that the chi-square distribution provides an asymptotic approximation
+    of the null distribution; it is only accurate for samples with many
+    observations. For small samples, it may be more appropriate to perform a
+    permutation test: Under the null hypothesis that all three samples were
+    drawn from the same population, each of the measurements is equally likely
+    to have been observed in any of the three samples. Therefore, we can form
+    a randomized null distribution by calculating the statistic under many
+    randomly-generated partitionings of the observations into the three
+    samples.
+
+    >>> def statistic(*samples):
+    ...     return stats.bartlett(*samples).statistic
+    >>> ref = stats.permutation_test(
+    ...     (small_dose, medium_dose, large_dose), statistic,
+    ...     permutation_type='independent', alternative='greater'
+    ... )
+    >>> fig, ax = plt.subplots(figsize=(8, 5))
+    >>> bart_plot(ax)
+    >>> bins = np.linspace(0, 5, 25)
+    >>> ax.hist(
+    ...     ref.null_distribution, bins=bins, density=True, facecolor="C1"
+    ... )
+    >>> ax.legend(['aymptotic approximation\n(many observations)',
+    ...            'randomized null distribution'])
+    >>> bart_plot(ax)
+    >>> plt.show()
+
+    >>> ref.pvalue  # randomized test p-value
+    0.5387  # may vary
+
+    Note that there is significant disagreement between the p-value calculated
+    here and the asymptotic approximation returned by `bartlett` above.
+    The statistical inferences that can be drawn rigorously from a permutation
+    test are limited; nonetheless, they may be the preferred approach in many
+    circumstances [7]_.
+
+    Following is another generic example where the null hypothesis would be
+    rejected.
+
+    Test whether the lists `a`, `b` and `c` come from populations
     with equal variances.
 
     >>> import numpy as np

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -2749,9 +2749,10 @@ def levene(*samples, center='median', proportiontocut=0.05):
     --------
     In [4]_, the influence of vitamin C on the tooth growth of guinea pigs
     was investigated. In a control study, 60 subjects were divided into
-    three groups each respectively receiving daily doses of 0.5, 1.0 and 2.0
-    mg of vitamin C. After 42 days, the tooth
-    grow, in micron, was measured.
+    small dose, medium dose, and large dose groups that received
+    daily doses of 0.5, 1.0 and 2.0 mg of vitamin C, respectively. 
+    After 42 days, the tooth
+    growth, in microns, was measured.
 
     In the following, we are interested in testing the null hypothesis that all
     groups are from populations with equal variances.

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -2729,9 +2729,10 @@ def bartlett(*samples):
       only provide evidence for a "significant" effect, meaning that they are
       unlikely to have occurred under the null hypothesis.
 
-    Note that the chi-square distribution provides an asymptotic approximation
-    of the null distribution.
-    For small samples, it may be more appropriate to perform a
+    Note that the chi-square distribution provides the null distribution
+    when the observations are normally distributed. For small samples
+    drawn from non-normal populations, it may be more appropriate to
+    perform a
     permutation test: Under the null hypothesis that all three samples were
     drawn from the same population, each of the measurements is equally likely
     to have been observed in any of the three samples. Therefore, we can form


### PR DESCRIPTION
#### What does this implement/fix?
Adds a realistic example to `scipy.stats.levene`. The example is from:

```
C.I. BLISS (1952), The Statistics of Bioassay: With Special
Reference to the Vitamins, pp 499-503,
doi: 10.1016/C2013-0-12584-6.
```

#### Additional information
When this looks good, I'll add similar examples to the other variance tests.
