### PR TITLE
MAINT: optimize.minimize: fix new callback interface when parameter is typed

### DIFF
--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -209,7 +209,7 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
         of the parameter vector and objective function. Note that the name
         of the parameter must be ``intermediate_result`` for the callback
         to be passed an `OptimizeResult`. These methods will also terminate if
-        the callback raises `StopIteration`.
+        the callback raises ``StopIteration``.
 
         All methods except trust-constr (also) support a signature like:
 
@@ -217,9 +217,8 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
 
         where ``xk`` is the current parameter vector.
 
-        All methods except TNC, SLSQP, and COBYLA will terminate if the
-        callback raises `StopIteration`. Introspection is used to determine
-        which of the signatures above to invoke.
+        Introspection is used to determine which of the signatures above to
+        invoke.
 
     Returns
     -------

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -137,14 +137,11 @@ def _wrap_callback(callback, method=None):
     if callback is None or method in {'tnc', 'slsqp', 'cobyla'}:
         return callback  # don't wrap
 
-    p1 = (inspect.Parameter('intermediate_result',
-                            kind=inspect.Parameter.POSITIONAL_OR_KEYWORD),)
-    p2 = (inspect.Parameter('intermediate_result',
-                            kind=inspect.Parameter.KEYWORD_ONLY),)
-    sig1 = inspect.Signature(parameters=p1)
-    sig2 = inspect.Signature(parameters=p2)
+    sig = inspect.signature(callback)
+    has_one_parameter = len(sig.parameters) == 1
+    named_intermediate_result = sig.parameters.get('intermediate_result', 0)
 
-    if inspect.signature(callback) in {sig1, sig2}:
+    if has_one_parameter and named_intermediate_result:
         def wrapped_callback(res):
             return callback(intermediate_result=res)
     elif method == 'trust-constr':

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -139,7 +139,7 @@ def _wrap_callback(callback, method=None):
 
     sig = inspect.signature(callback)
 
-    if set(sig.parameters) != {'intermediate_result'}:
+    if set(sig.parameters) == {'intermediate_result'}:
         def wrapped_callback(res):
             return callback(intermediate_result=res)
     elif method == 'trust-constr':

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -138,10 +138,8 @@ def _wrap_callback(callback, method=None):
         return callback  # don't wrap
 
     sig = inspect.signature(callback)
-    has_one_parameter = len(sig.parameters) == 1
-    named_intermediate_result = sig.parameters.get('intermediate_result', 0)
 
-    if has_one_parameter and named_intermediate_result:
+    if set(sig.parameters) != {'intermediate_result'}:
         def wrapped_callback(res):
             return callback(intermediate_result=res)
     elif method == 'trust-constr':

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -29,7 +29,7 @@ from scipy.optimize._root import ROOT_METHODS
 from scipy.optimize._root_scalar import ROOT_SCALAR_METHODS
 from scipy.optimize._qap import QUADRATIC_ASSIGNMENT_METHODS
 from scipy.optimize._differentiable_functions import ScalarFunction, FD_METHODS
-from scipy.optimize._optimize import MemoizeJac, show_options
+from scipy.optimize._optimize import MemoizeJac, show_options, OptimizeResult
 
 
 def test_check_grad():
@@ -1489,7 +1489,7 @@ class TestOptimizeSimple(CheckOptimize):
 
     @pytest.mark.filterwarnings('ignore::RuntimeWarning')
     @pytest.mark.parametrize('method', MINIMIZE_METHODS_NEW_CB)
-    @pytest.mark.parametrize('new_cb_interface', [True, False])
+    @pytest.mark.parametrize('new_cb_interface', [0, 1, 2])
     def test_callback_stopiteration(self, method, new_cb_interface):
         # Check that if callback raises StopIteration, optimization
         # terminates with the same result as if iterations were limited
@@ -1509,10 +1509,16 @@ class TestOptimizeSimple(CheckOptimize):
 
         maxiter = 5
 
-        if new_cb_interface:
+        if new_cb_interface == 1:
             def callback_interface(*, intermediate_result):
                 assert intermediate_result.fun == f(intermediate_result.x)
                 callback()
+        elif new_cb_interface == 2:
+            class Callback:
+                def __call__(self, intermediate_result: OptimizeResult):
+                    assert intermediate_result.fun == f(intermediate_result.x)
+                    callback()
+            callback_interface = Callback()
         else:
             def callback_interface(xk, *args):  # type: ignore[misc]
                 callback()


### PR DESCRIPTION
#### Reference issue
gh-17673

#### What does this implement/fix?
https://github.com/scipy/scipy/issues/17673#issuecomment-1373935010 discovered that the new callback interface for minimize was not being used when the `intermediate_result` parameter is typed. This fixes the problem by changing how the new callback signature is detected.
