### PR TITLE
BUG: signal: fix check_malloc extern declaration type

### DIFF
--- a/scipy/signal/_medianfilter.c
+++ b/scipy/signal/_medianfilter.c
@@ -10,7 +10,7 @@
 void f_medfilt2(float*,float*,npy_intp*,npy_intp*);
 void d_medfilt2(double*,double*,npy_intp*,npy_intp*);
 void b_medfilt2(unsigned char*,unsigned char*,npy_intp*,npy_intp*);
-extern char *check_malloc (int);
+extern char *check_malloc (size_t);
 
 
 /* The QUICK_SELECT routine is based on Hoare's Quickselect algorithm,


### PR DESCRIPTION
the definition of check_malloc takes a size_t argument. fixes a lto-type-mistatch warning.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
related to #16098

#### What does this implement/fix?
```

../../scipy/signal/_medianfilter.c:13:14: error: type of 'check_malloc' does not match original declaration [-Werror=lto-type-mismatch]
   13 | extern char *check_malloc (int);
      |              ^
../../scipy/signal/_sigtoolsmodule.c:20:7: note: type mismatch in parameter 1
   20 | char *check_malloc(size_t size)
      |       ^
```
