### PR TITLE
DEP: remove maxiter kwarg in _minimize_tnc

### DIFF
--- a/scipy/optimize/_tnc.py
+++ b/scipy/optimize/_tnc.py
@@ -32,8 +32,6 @@ value of the function, and whose second argument is the gradient of the function
 (as a list of values); or None, to abort the minimization.
 """
 
-import warnings
-
 from scipy.optimize import _moduleTNC as moduleTNC
 from ._optimize import (MemoizeJac, OptimizeResult, _check_unknown_options,
                        _prepare_scalar_function)
@@ -284,7 +282,7 @@ def fmin_tnc(func, x0, fprime=None, args=(), approx_grad=0,
 
 def _minimize_tnc(fun, x0, args=(), jac=None, bounds=None,
                   eps=1e-8, scale=None, offset=None, mesg_num=None,
-                  maxCGit=-1, maxiter=None, eta=-1, stepmx=0, accuracy=0,
+                  maxCGit=-1, eta=-1, stepmx=0, accuracy=0,
                   minfev=0, ftol=-1, xtol=-1, gtol=-1, rescale=-1, disp=False,
                   callback=None, finite_diff_rel_step=None, maxfun=None,
                   **unknown_options):
@@ -312,14 +310,6 @@ def _minimize_tnc(fun, x0, args=(), jac=None, bounds=None,
         iteration. If maxCGit == 0, the direction chosen is
         -gradient if maxCGit < 0, maxCGit is set to
         max(1,min(50,n/2)). Defaults to -1.
-    maxiter : int, optional
-        Maximum number of function evaluations. If `maxfun` is also provided
-        then `maxiter` is ignored.
-        Default is None.
-
-        .. deprecated:: 1.9.0
-            `maxiter` is deprecated in favor of `maxfun` and will removed in
-            SciPy 1.11.0.
     eta : float
         Severity of the line search. If < 0 or > 1, set to 0.25.
         Defaults to -1.
@@ -415,15 +405,7 @@ def _minimize_tnc(fun, x0, args=(), jac=None, bounds=None,
         offset = array([])
 
     if maxfun is None:
-        if maxiter is not None:
-            warnings.warn(
-                "'maxiter' has been deprecated in favor of 'maxfun'"
-                " and will be removed in SciPy 1.11.0.",
-                DeprecationWarning, stacklevel=3
-            )
-            maxfun = maxiter
-        else:
-            maxfun = max(100, 10*len(x0))
+        maxfun = max(100, 10*len(x0))
 
     rc, nf, nit, x, funv, jacv = moduleTNC.tnc_minimize(
         func_and_grad, x0, low, up, scale,

--- a/scipy/optimize/tests/test_tnc.py
+++ b/scipy/optimize/tests/test_tnc.py
@@ -344,10 +344,3 @@ class TestTnc:
         assert_allclose(res2.x, res.x)
         assert_allclose(res2.fun, res.fun)
         assert_equal(res2.nfev, res.nfev)
-
-    def test_maxiter_depreciations(self):
-        msg = "'maxiter' has been deprecated in favor of 'maxfun'"
-        with pytest.warns(DeprecationWarning, match=msg):
-            optimize.minimize(
-                self.f1, [1, 3], method="TNC", options={"maxiter": 1}
-            )


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
closes #16269
#### What does this implement/fix?
<!--Please explain your changes.-->
Removes deprecated kwarg.
#### Additional information
<!--Any additional information you think is important.-->
It was suggested that we should consider removing maxiter option from the root minimize doc (https://github.com/scipy/scipy/issues/16269#issuecomment-1138544153) however I dont think this is necessary as #17395 has clarified any confusion. 