### PR TITLE
Updated hamming to check if size of w does not match the size of u and v

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -717,10 +717,10 @@ def hamming(u, v, w=None):
         raise ValueError('The 1d arrays must have equal lengths.')
     u_ne_v = u != v
     if w is not None:
-         if (w.shape == u.shape)
-            w = _validate_weights(w)
-         else:
-            raise ValueError('w should have same dimensions as u and v')
+       if (w.shape == u.shape)
+         w = _validate_weights(w)
+       else:
+         raise ValueError('w should have same dimensions as u and v')
     return np.average(u_ne_v, weights=w)
 
 

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -717,9 +717,10 @@ def hamming(u, v, w=None):
         raise ValueError('The 1d arrays must have equal lengths.')
     u_ne_v = u != v
     if w is not None:
-        w = _validate_weights(w)
-    if w.shape != u.shape:
-        raise ValueError('w should have same dimensions as u and v')
+         if (w.shape == u.shape)
+            w = _validate_weights(w)
+         else:
+            raise ValueError('w should have same dimensions as u and v')
     return np.average(u_ne_v, weights=w)
 
 

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -718,6 +718,8 @@ def hamming(u, v, w=None):
     u_ne_v = u != v
     if w is not None:
         w = _validate_weights(w)
+    if w.shape != u.shape:
+        raise ValueError('w should have same dimensions as u and v')
     return np.average(u_ne_v, weights=w)
 
 

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -717,7 +717,7 @@ def hamming(u, v, w=None):
         raise ValueError('The 1d arrays must have equal lengths.')
     u_ne_v = u != v
     if w is not None:
-       if (w.shape == u.shape)
+      if (w.shape == u.shape):
          w = _validate_weights(w)
        else:
          raise ValueError('w should have same dimensions as u and v')

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -1934,6 +1934,11 @@ def test_hamming_unequal_length():
     # Used to give an AttributeError from ndarray.mean called on bool
     assert_raises(ValueError, whamming, x, y)
 
+def test_hamming_weights_length_mismatch():
+    x = [1, 0, 1, 1]
+    y = [1, 1, 0, 1]
+    w = [1, 3, 1]
+    assert_raises(ValueError, x, y, w)
 
 def test_hamming_string_array():
     # https://github.com/scikit-learn/scikit-learn/issues/4014


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #17725 .
<!---->

#### What does this implement/fix?
Added an if-condition to check if shape of weights does not match the shape of inputs, if true, an error is raised.
<!-- ->

#### Additional information
<!--Any additional information you think is important.-->
