### PR TITLE
[sparse.csgraph] Fix a bug in dijkstra and johnson algorithm

### DIFF
--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -1556,7 +1556,7 @@ cdef void decrease_val(FibonacciHeap* heap,
         # at the leftmost end of the roots' linked-list.
         remove(node)
         node.right_sibling = heap.min_node
-        heap.min_node.left_sibling = node.right_sibling
+        heap.min_node.left_sibling = node
         heap.min_node = node
 
 

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -187,7 +187,7 @@ def test_dijkstra_min_only_random(n):
     np.random.shuffle(v)
     indices = v[:int(n*.1)]
     ds, pred, sources = dijkstra(data,
-                                 directed=False,
+                                 directed=True,
                                  indices=indices,
                                  min_only=True,
                                  return_predecessors=True)

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -1,7 +1,6 @@
 import warnings
 import numpy as np
-from numpy.testing import (assert_almost_equal, assert_array_almost_equal,
-                           assert_array_equal)
+from numpy.testing import assert_array_almost_equal, assert_array_equal
 from pytest import raises as assert_raises
 from scipy.sparse.csgraph import (shortest_path, dijkstra, johnson,
                                   bellman_ford, construct_dist_matrix,
@@ -199,66 +198,16 @@ def test_dijkstra_min_only_random(n):
             p = pred[p]
 
 
-# ensure dijkstra does not crash or run into an infinite loop
-@pytest.mark.parametrize('n, t',
-                         ((3, 300),
-                          (10, 100),
-                          (100, 10),
-                          (500, 1)))
-def test_dijkstra_random(n, t):
-    np.random.seed(1234)
-    for testcase_index in range(t):
-        data = scipy.sparse.rand(n, n, density=2.0 / n, format='lil',
-                                 dtype=np.float64)
-        data.setdiag(np.zeros(n, dtype=np.bool_))
-        dijkstra(data, directed=True, return_predecessors=True)
-
-
-# n : number of vertices
-# t : number of test cases
-# Generate random graphs, run shortest_path for all methods, verify the results
-# and check consistency across different methods.
-@pytest.mark.parametrize('n, t',
-                         ((3, 200),
-                          (10, 200),
-                          (100, 10),
-                          (500, 1)))
-def test_shortest_path_random(n, t):
-    np.random.seed(1234)
-    density_list = [2.0 / n, 0.5]
-    for testcase_index in range(t):
-        cur_density = density_list[testcase_index % 2]
-        data = scipy.sparse.rand(n, n, density=cur_density, format='lil',
-                                 dtype=np.float64)
-        data.setdiag(np.zeros(n, dtype=np.bool_))
-        adj_mat = data.toarray(order='C')
-        start_vertex = np.random.randint(0, n)
-        # each element: (method name, distance array, predecessor array)
-        results = []
-        for method in methods:
-            results.append((method, *shortest_path(data, directed=True,
-                                                   indices=start_vertex,
-                                                   return_predecessors=True)))
-
-        for method, dist, pred in results:
-            # check that dist and pred are consistent
-            for i in range(n):
-                if pred[i] != -9999:  # vertex #i is reachable
-                    cur = i
-                    while pred[cur] != -9999:
-                        p = pred[cur]
-                        assert_almost_equal(dist[p] +
-                                            adj_mat[p][cur],
-                                            dist[cur])
-                        cur = pred[cur]
-                    assert cur == start_vertex
-            # check that further relaxation of an edge is not possible
-            for i in range(n):
-                for j in range(n):
-                    if adj_mat[i][j] != 0:
-                        assert dist[j] <= dist[i] + adj_mat[i][j]
-            # check that dist is consistent across methods
-            assert_almost_equal(results[0][1], dist)
+def test_dijkstra_random():
+    n = 10
+    # this random seed was carefully chosen in a search
+    # for reproducers of gh-17782
+    rng = np.random.default_rng(3443)
+    data = scipy.sparse.rand(n, n, density=2.0 / n, format='lil',
+                             dtype=np.float64,
+                             random_state=rng)
+    data.setdiag(np.zeros(n, dtype=np.bool_))
+    dijkstra(data, directed=True, return_predecessors=True)
 
 
 def test_shortest_path_indices():

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -1,6 +1,7 @@
 import warnings
 import numpy as np
-from numpy.testing import assert_array_almost_equal, assert_array_equal
+from numpy.testing import (assert_almost_equal, assert_array_almost_equal,
+                           assert_array_equal)
 from pytest import raises as assert_raises
 from scipy.sparse.csgraph import (shortest_path, dijkstra, johnson,
                                   bellman_ford, construct_dist_matrix,
@@ -176,7 +177,7 @@ def test_dijkstra_indices_min_only(directed, SP_ans, indices):
 
 
 @pytest.mark.parametrize('n', (10, 100, 1000))
-def test_shortest_path_min_only_random(n):
+def test_dijkstra_min_only_random(n):
     np.random.seed(1234)
     data = scipy.sparse.rand(n, n, density=0.5, format='lil',
                              random_state=42, dtype=np.float64)
@@ -196,6 +197,68 @@ def test_shortest_path_min_only_random(n):
         while p != -9999:
             assert sources[p] == s
             p = pred[p]
+
+
+# ensure dijkstra does not crash or run into an infinite loop
+@pytest.mark.parametrize('n, t',
+                         ((3, 300),
+                          (10, 100),
+                          (100, 10),
+                          (500, 1)))
+def test_dijkstra_random(n, t):
+    np.random.seed(1234)
+    for testcase_index in range(t):
+        data = scipy.sparse.rand(n, n, density=2.0 / n, format='lil',
+                                 dtype=np.float64)
+        data.setdiag(np.zeros(n, dtype=np.bool_))
+        dijkstra(data, directed=True, return_predecessors=True)
+
+
+# n : number of vertices
+# t : number of test cases
+# Generate random graphs, run shortest_path for all methods, verify the results
+# and check consistency across different methods.
+@pytest.mark.parametrize('n, t',
+                         ((3, 200),
+                          (10, 200),
+                          (100, 10),
+                          (500, 1)))
+def test_shortest_path_random(n, t):
+    np.random.seed(1234)
+    density_list = [2.0 / n, 0.5]
+    for testcase_index in range(t):
+        cur_density = density_list[testcase_index % 2]
+        data = scipy.sparse.rand(n, n, density=cur_density, format='lil',
+                                 dtype=np.float64)
+        data.setdiag(np.zeros(n, dtype=np.bool_))
+        adj_mat = data.toarray(order='C')
+        start_vertex = np.random.randint(0, n)
+        # each element: (method name, distance array, predecessor array)
+        results = []
+        for method in methods:
+            results.append((method, *shortest_path(data, directed=True,
+                                                   indices=start_vertex,
+                                                   return_predecessors=True)))
+
+        for method, dist, pred in results:
+            # check that dist and pred are consistent
+            for i in range(n):
+                if pred[i] != -9999:  # vertex #i is reachable
+                    cur = i
+                    while pred[cur] != -9999:
+                        p = pred[cur]
+                        assert_almost_equal(dist[p] +
+                                            adj_mat[p][cur],
+                                            dist[cur])
+                        cur = pred[cur]
+                    assert cur == start_vertex
+            # check that further relaxation of an edge is not possible
+            for i in range(n):
+                for j in range(n):
+                    if adj_mat[i][j] != 0:
+                        assert dist[j] <= dist[i] + adj_mat[i][j]
+            # check that dist is consistent across methods
+            assert_almost_equal(results[0][1], dist)
 
 
 def test_shortest_path_indices():


### PR DESCRIPTION
#### Reference issue
Closes #17782

#### What does this implement/fix?
My previous pull request #16696 introduced a bug in FibonacciHeap implementation in sparse/csgraph/_shortest_path.pyx which caused the dijkstra algorithm to crash or run into an infinite loop in some cases.
This pull request provides a fix for the bug as well as brute force tests using random graphs to find and avoid such bugs in the future.

The bug is that I accidentally wrote `node.right_sibling` instead of `node` which broke the linked-list structure.
One of the added tests `test_dijkstra_random` runs `dijkstra` with a lot of random graphs and is expected to find crashes/infinite loops. It indeed does not terminate for the (current) bugged version.
The other one `test_shortest_path_random` runs `shortest_path` with all methods with similar random graphs and checks the distance table/predecessor table are valid and consistent across methods. This does not immediately find any bugs, but I think this helps finding bugs in the future change.
The two tests run together in 3 seconds (when the bug is fixed) on my machine(i5-10600k, Ubuntu 20.04 on VirtualBox), which I hope is acceptable.

I found a small mistake in the specification of `directed` option in another test, so I fixed that too.

I apologize for having contaminated the project with buggy code.
I am still looking for a way to get rid of manual FibonacciHeap implementation in #17019 but still need some time due to the "too many public symbols" error, so I would like this pull request to be reviewed and merged first.

