### PR TITLE
MAINT: add missing `__init__.py` in test folder

### DIFF
--- a/scipy/integrate/_ivp/tests/meson.build
+++ b/scipy/integrate/_ivp/tests/meson.build
@@ -1,4 +1,5 @@
 py3.install_sources([
+    '__init__.py',
     'test_ivp.py',
     'test_rk.py'
   ],


### PR DESCRIPTION
#### What does this implement/fix?

This adds a missing `__init__.py` in `scipy.integrate._ivp.tests`

Not super crucial but this is the only `tests` folder without an `__init__.py` as can be seen from running:
```bash
for d in $(find -name tests -type d); do
    if [[ ! -f $d/__init__.py ]]; then
        echo missing __init__ in $d
    fi
done
```

```
missing __init__ in ./scipy/integrate/_ivp/tests
```

I noticed this by doing:
```
pytest --pyargs scipy.integrate._ivp.tests
```
which gives the following error:
```
ERROR: module or package not found: scipy.integrate._ivp.tests (missing __init__.py?)
```

#### Additional information

Note `pytest` is still able to discover the tests when doing `pytest --pyargs scipy.integrate`
