### PR TITLE
MAINT: allow typed method in `stats.sobol_indices`

### DIFF
--- a/scipy/stats/_sensitivity_analysis.py
+++ b/scipy/stats/_sensitivity_analysis.py
@@ -475,7 +475,7 @@ def sobol_indices(
 
     >>> boot = indices.bootstrap()
 
-    Then, this information can be easilly visualized.
+    Then, this information can be easily visualized.
 
     >>> import matplotlib.pyplot as plt
     >>> fig, axs = plt.subplots(1, 2, figsize=(9, 4))
@@ -609,16 +609,10 @@ def sobol_indices(
             )
             raise ValueError(message) from exc
     else:
-        kind = inspect.Parameter.POSITIONAL_OR_KEYWORD
-        parameters = (
-            inspect.Parameter('f_A', kind=kind),
-            inspect.Parameter('f_B', kind=kind),
-            inspect.Parameter('f_AB', kind=kind)
-        )
-        sig = inspect.Signature(parameters=parameters)
         indices_method_ = method
+        sig = inspect.signature(indices_method_)
 
-        if inspect.signature(indices_method_) != sig:
+        if set(sig.parameters) != {'f_A', 'f_B', 'f_AB'}:
             message = (
                 "If 'method' is a callable, it must have the following"
                 f" signature: {inspect.signature(saltelli_2010)}"

--- a/scipy/stats/tests/test_sensitivity_analysis.py
+++ b/scipy/stats/tests/test_sensitivity_analysis.py
@@ -1,3 +1,5 @@
+from typing import Tuple
+
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_less
 import pytest
@@ -184,6 +186,18 @@ class TestSobolIndices:
 
         assert_allclose(res.first_order, ishigami_ref_indices[0], atol=1e-2)
         assert_allclose(res.total_order, ishigami_ref_indices[1], atol=1e-2)
+
+        def jansen_sobol_typed(
+            f_A: np.ndarray, f_B: np.ndarray, f_AB: np.ndarray
+        ) -> Tuple[np.ndarray, np.ndarray]:
+            return jansen_sobol(f_A, f_B, f_AB)
+
+        _ = sobol_indices(
+            func=f_ishigami, n=8,
+            dists=self.dists,
+            method=jansen_sobol_typed,
+            random_state=rng
+        )
 
     def test_normalization(self, ishigami_ref_indices):
         rng = np.random.default_rng(28631265345463262246170309650372465332)


### PR DESCRIPTION
Follow up of #17628

In #17780 we fixed a similar issue when comparing signatures of function. The following approach makes the comparison robust to typing.