### PR TITLE
BUG/ENH: stats: several updates for dgamma.

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1511,6 +1511,9 @@ cosine = cosine_gen(a=-np.pi, b=np.pi, name='cosine')
 class dgamma_gen(rv_continuous):
     r"""A double gamma continuous random variable.
 
+    The double gamma distribution is also known as the reflected gamma
+    distribution [1]_.
+
     %(before_notes)s
 
     Notes
@@ -1527,6 +1530,12 @@ class dgamma_gen(rv_continuous):
     `dgamma` takes ``a`` as a shape parameter for :math:`a`.
 
     %(after_notes)s
+
+    References
+    ----------
+    .. [1] Johnson, Kotz, and Balakrishnan, "Continuous Univariate
+           Distributions, Volume 1", Second Edition, John Wiley and Sons
+           (1994).
 
     %(example)s
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1559,8 +1559,14 @@ class dgamma_gen(rv_continuous):
                         0.5 + 0.5*sc.gammainc(a, -x))
 
     def _ppf(self, q, a):
-        fac = sc.gammainccinv(a, 1-abs(2*q-1))
-        return np.where(q > 0.5, fac, -fac)
+        return np.where(q > 0.5,
+                        sc.gammaincinv(a, 2*q - 1),
+                        -sc.gammainccinv(a, 2*q))
+
+    def _isf(self, q, a):
+        return np.where(q > 0.5,
+                        -sc.gammaincinv(a, 2*q - 1),
+                        sc.gammainccinv(a, 2*q))
 
     def _stats(self, a):
         mu2 = a*(a+1.0)

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1549,12 +1549,14 @@ class dgamma_gen(rv_continuous):
         return sc.xlogy(a - 1.0, ax) - ax - np.log(2) - sc.gammaln(a)
 
     def _cdf(self, x, a):
-        fac = 0.5*sc.gammainc(a, abs(x))
-        return np.where(x > 0, 0.5 + fac, 0.5 - fac)
+        return np.where(x > 0,
+                        0.5 + 0.5*sc.gammainc(a, x),
+                        0.5*sc.gammaincc(a, -x))
 
     def _sf(self, x, a):
-        fac = 0.5*sc.gammainc(a, abs(x))
-        return np.where(x > 0, 0.5-fac, 0.5+fac)
+        return np.where(x > 0,
+                        0.5*sc.gammaincc(a, x),
+                        0.5 + 0.5*sc.gammainc(a, -x))
 
     def _ppf(self, q, a):
         fac = sc.gammainccinv(a, 1-abs(2*q-1))

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -462,6 +462,7 @@ class TestChi:
     def test_entropy(self, df, ref):
         assert_allclose(stats.chi(df).entropy(), ref)
 
+
 class TestNBinom:
     def setup_method(self):
         np.random.seed(1234)
@@ -3591,6 +3592,7 @@ class TestBeta:
                               (100000, 100000, -5.377247470132859)])
     def test_entropy(self, a, b, ref):
         assert_allclose(stats.beta(a, b).entropy(), ref)
+
 
 class TestBetaPrime:
     def test_logpdf(self):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3701,6 +3701,26 @@ class TestDgamma:
         dist = stats.dgamma(a)
         assert_equal(dist.pdf(x), res)
 
+    # mpmath was used to compute the expected values.
+    # For x < 0, cdf(x, a) is mp.gammainc(a, -x, mp.inf, regularized=True)/2
+    # For x > 0, cdf(x, a) is (1 + mp.gammainc(a, 0, x, regularized=True))/2
+    # E.g.
+    #    from mpmath import mp
+    #    mp.dps = 50
+    #    print(float(mp.gammainc(1, 20, mp.inf, regularized=True)/2))
+    # prints
+    #    1.030576811219279e-09
+    @pytest.mark.parametrize('x, a, expected',
+                             [(-20, 1, 1.030576811219279e-09),
+                              (-40, 1, 2.1241771276457944e-18),
+                              (-50, 5, 2.7248509914602648e-17),
+                              (-25, 0.125, 5.333071920958156e-14)])
+    def test_cdf_sf_tail(self, x, a, expected):
+        cdf = stats.dgamma.cdf(x, a)
+        assert_allclose(cdf, expected, rtol=5e-15)
+        sf = stats.dgamma.sf(-x, a)
+        assert_allclose(sf, expected, rtol=5e-15)
+
 
 class TestChi2:
     # regression tests after precision improvements, ticket:1041, not verified

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3714,7 +3714,8 @@ class TestDgamma:
                              [(-20, 1, 1.030576811219279e-09),
                               (-40, 1, 2.1241771276457944e-18),
                               (-50, 5, 2.7248509914602648e-17),
-                              (-25, 0.125, 5.333071920958156e-14)])
+                              (-25, 0.125, 5.333071920958156e-14),
+                              (5, 1, 0.9966310265004573)])
     def test_cdf_ppf_sf_isf_tail(self, x, a, expected):
         cdf = stats.dgamma.cdf(x, a)
         assert_allclose(cdf, expected, rtol=5e-15)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3715,11 +3715,15 @@ class TestDgamma:
                               (-40, 1, 2.1241771276457944e-18),
                               (-50, 5, 2.7248509914602648e-17),
                               (-25, 0.125, 5.333071920958156e-14)])
-    def test_cdf_sf_tail(self, x, a, expected):
+    def test_cdf_ppf_sf_isf_tail(self, x, a, expected):
         cdf = stats.dgamma.cdf(x, a)
         assert_allclose(cdf, expected, rtol=5e-15)
+        ppf = stats.dgamma.ppf(expected, a)
+        assert_allclose(ppf, x, rtol=5e-15)
         sf = stats.dgamma.sf(-x, a)
         assert_allclose(sf, expected, rtol=5e-15)
+        isf = stats.dgamma.isf(expected, a)
+        assert_allclose(isf, -x, rtol=5e-15)
 
 
 class TestChi2:


### PR DESCRIPTION
For the `dgamma` distribution, fix loss of precision in the tail for `_cdf`, `_sf` and `_ppf`, and implement `_isf`.