### PR TITLE
DOC/BUG: plot `ndtri` only where it is defined

### DIFF
--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -10778,7 +10778,7 @@ add_newdoc("ndtri",
     Plot the function. For that purpose, we provide a NumPy array as argument.
 
     >>> import matplotlib.pyplot as plt
-    >>> x = np.linspace(0, 1, 500)
+    >>> x = np.linspace(0.01, 1, 200)
     >>> fig, ax = plt.subplots()
     >>> ax.plot(x, ndtri(x))
     >>> ax.set_title("Standard normal percentile function")

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -10778,7 +10778,7 @@ add_newdoc("ndtri",
     Plot the function. For that purpose, we provide a NumPy array as argument.
 
     >>> import matplotlib.pyplot as plt
-    >>> x = np.linspace(-1, 1, 100)
+    >>> x = np.linspace(0, 1, 500)
     >>> fig, ax = plt.subplots()
     >>> ax.plot(x, ndtri(x))
     >>> ax.set_title("Standard normal percentile function")


### PR DESCRIPTION
#### What does this implement/fix?
The example I recently added for `special.ndtri` currently tries to plot the function between -1 and 1. As it is a percentile function, this does not make sense. This PR updates the range to [0, 1].
