### PR TITLE
MAINT: stats._axis_nan_policy: raise appropriate TypeErrors

### DIFF
--- a/scipy/stats/_axis_nan_policy.py
+++ b/scipy/stats/_axis_nan_policy.py
@@ -404,9 +404,9 @@ def _axis_nan_policy_factory(tuple_to_result, default_axis=0,
                 params = [f"arg{i}" for i in range(len(args))] + params[1:]
 
             # raise if there are too many positional args
-            maxargs = (np.inf if inspect.getfullargspec(hypotest_fun_in).varargs
-                       else len(inspect.getfullargspec(hypotest_fun_in).args))
-            if len(args) > maxargs:  # let the function raise the right error
+            maxarg = (np.inf if inspect.getfullargspec(hypotest_fun_in).varargs
+                      else len(inspect.getfullargspec(hypotest_fun_in).args))
+            if len(args) > maxarg:  # let the function raise the right error
                 hypotest_fun_in(*args, **kwds)
 
             # raise if multiple values passed for same parameter
@@ -451,7 +451,7 @@ def _axis_nan_policy_factory(tuple_to_result, default_axis=0,
                 samples = [np.atleast_1d(kwds.pop(param))
                            for param in (params[:n_samp] + kwd_samp)]
             except KeyError:  # let the function raise the right error
-                # might need to revisit this if a required arg is not a "sample"
+                # might need to revisit this if required arg is not a "sample"
                 hypotest_fun_in(*args, **kwds)
             vectorized = True if 'axis' in params else False
             vectorized = vectorized and not override['vectorization']

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -1052,6 +1052,7 @@ def test_mean_mixed_mask_nan_weights(weighted_fun_name):
         # _no_deco mean returns masked array, last element was masked
         np.testing.assert_allclose(res5.compressed(), res[~np.isnan(res)])
 
+
 def test_raise_invalid_args_g17713():
     # other cases are handled in:
     # test_axis_nan_policy_decorated_positional_axis - multiple values for arg

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -77,6 +77,7 @@ inaccuracy_messages = {"Precision loss occurred in moment calculation",
 # For some functions, nan_policy='propagate' should not just return NaNs
 override_propagate_funcs = {stats.mode}
 
+
 def _mixed_data_generator(n_samples, n_repetitions, axis, rng,
                           paired=False):
     # generate random samples to check the response of hypothesis tests to
@@ -1050,3 +1051,23 @@ def test_mean_mixed_mask_nan_weights(weighted_fun_name):
     if weighted_fun_name not in {'pmean', 'gmean'}:
         # _no_deco mean returns masked array, last element was masked
         np.testing.assert_allclose(res5.compressed(), res[~np.isnan(res)])
+
+def test_raise_invalid_args_g17713():
+    # other cases are handled in:
+    # test_axis_nan_policy_decorated_positional_axis - multiple values for arg
+    # test_axis_nan_policy_decorated_positional_args - unexpected kwd arg
+    message = "got an unexpected keyword argument"
+    with pytest.raises(TypeError, match=message):
+        stats.gmean([1, 2, 3], invalid_arg=True)
+
+    message = " got multiple values for argument"
+    with pytest.raises(TypeError, match=message):
+        stats.gmean([1, 2, 3], a=True)
+
+    message = "missing 1 required positional argument"
+    with pytest.raises(TypeError, match=message):
+        stats.gmean()
+
+    message = "takes from 1 to 4 positional arguments but 5 were given"
+    with pytest.raises(TypeError, match=message):
+        stats.gmean([1, 2, 3], 0, float, [1, 1, 1], 10)


### PR DESCRIPTION
#### Reference issue
Closes gh-17713

#### What does this implement/fix?
Ensures that functions wrapped with `_axis_nan_policy` decorator raise common TypeErrors as appropriate.
