### PR TITLE
MAINT, CI: GHA MacOS setup.py update

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -90,4 +90,7 @@ jobs:
     - name: Test SciPy
       run: |
         export LIBRARY_PATH="$LIBRARY_PATH:/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib"
-        SCIPY_USE_PYTHRAN=`test ${{ matrix.python-version }} != 3.9; echo $?` python -u runtests.py -- --durations=10 --timeout=60
+        export SCIPY_USE_PYTHRAN=1
+        python setup.py install
+        cd /tmp
+        python -m pytest --pyargs scipy --durations=10 --timeout=80 -n 3


### PR DESCRIPTION
* the `setup.py` MacOS Python `3.8` CI job is starting to fail with timeouts for `multiprocessing` `Pool`-related code in recent unrelated PRs like gh-17777 and gh-17829

* nothing stands out in the build logs when I do a side-by-side diff vs. succeeding versions of the job, and the GHA job history seems to suggest the failure doesn't happen every time the CI is flushed, but perhaps more often lately

* make a few cleanups here in attempt to fix
  - previous discussions like gh-11835 with MacOS Python 3.8 `multiprocessing` `Pool` hangs were complicated, but sometimes using `runtests.py` contributed to hangs b/c of `multiprocessing` import orders. So, try to use `pytest` directly instead to see if it helps.
  - we can simplify the Pythran config--there's only one job left in this file after the splitting with `meson`, and it is Python `3.8`
  - I've also extended the timeout limit a little bit, and since GHA MacOS runners have 3 cores I've tried using all 3 for the testsuite here because I once had the job pass on my fork during testing, but it took 66 minutes: https://github.com/tylerjereddy/scipy/pull/65

* I think there's still something a bit weird here, so it is a combination of measures that seemed to help a bit on my fork but perhaps long-term the removal of Python 3.8 support along with sunsetting `runtests.py` means that this mess may disappear before we need to dig much deeper

[skip azp] [skip circle] [skip cirrus]