### PR TITLE
DOC: integrate: document limitation of numerical integration

### DIFF
--- a/doc/source/tutorial/integrate.rst
+++ b/doc/source/tutorial/integrate.rst
@@ -140,6 +140,36 @@ integrand from the use of :obj:`quad` ). The integral in this case is
 This last example shows that multiple integration can be handled using
 repeated calls to :func:`quad`.
 
+.. warning::
+
+    Numerical integration algorithms sample the integrand at a finite number of points.
+    Consequently, they cannot guarantee accurate results (or accuracy estimates) for
+    arbitrary integrands and limits of integration. Consider the Gaussian integral,
+    for example:
+
+    >>> def gaussian(x):
+    ...     return np.exp(-x**2)
+    >>> res = integrate.quad(gaussian, -np.inf, np.inf)
+    >>> res
+    (1.7724538509055159, 1.4202636756659625e-08)
+    >>> np.allclose(res[0], np.sqrt(np.pi))  # compare against theoretical result
+    True
+
+    Since the integrand is nearly zero except near the origin, we would expect
+    large but finite limits of integration to yield the same result. However:
+
+    >>> integrate.quad(gaussian, -10000, 10000)
+    (1.975190562208035e-203, 0.0)
+
+    This happens because the adaptive quadrature routine implemented in :func:`quad`,
+    while working as designed, does not notice the small, important part of the function
+    within such a large, finite interval. For best results, consider using integration
+    limits that tightly surround the important part of the integrand.
+
+    >>> integrate.quad(gaussian, -15, 15)
+    (1.772453850905516, 8.476526631214648e-11)
+
+    Integrands with several important regions can be broken into pieces as necessary.
 
 General multiple integration (:func:`dblquad`, :func:`tplquad`, :func:`nquad`)
 ------------------------------------------------------------------------------


### PR DESCRIPTION
#### Reference issue
gh-5428, gh-11571, etc.

#### What does this implement/fix?
We have received several reports of unexpected results from `quad`, and quite often the root cause is that the integrator misses the nonzero part of the integrand within a large, finite interval. This adds a note to the documentation about this limitation, which other numerical integrators suffer from, too (e.g. [Matlab](https://www.mathworks.com/matlabcentral/answers/276764-numerical-integration-gives-0#answer_216121), [Mathematica](https://mathematica.stackexchange.com/questions/156608/nintegrate-returned-zero)).
