### PR TITLE
DEP: integrate.nquad: deprecate parameter `full_output`

### DIFF
--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -4,6 +4,7 @@ import sys
 import warnings
 from functools import partial
 
+from scipy._lib._bunch import _make_tuple_bunch
 from . import _quadpack
 import numpy as np
 from numpy import Inf
@@ -920,7 +921,12 @@ def tplquad(func, a, b, gfun, hfun, qfun, rfun, args=(), epsabs=1.49e-8,
             opts={"epsabs": epsabs, "epsrel": epsrel})
 
 
-def nquad(func, ranges, args=None, opts=None, full_output=False):
+QuadratureResult = _make_tuple_bunch("QuadratureResult",
+                                     field_names=["integral", "abserr"],
+                                     extra_field_names=["neval"])
+
+
+def nquad(func, ranges, args=None, opts=None, full_output=None):
     r"""
     Integration over multiple variables.
 
@@ -985,15 +991,22 @@ def nquad(func, ranges, args=None, opts=None, full_output=False):
         The number of integrand function evaluations ``neval`` can be obtained
         by setting ``full_output=True`` when calling nquad.
 
+        .. deprecated:: 1.11.0
+           Parameter `full_output` is deprecated and will be removed in version
+           1.13.0. When `full_output` is unspecified, ``neval`` is provided
+           as an attribute of the result object.
+
     Returns
     -------
-    result : float
-        The result of the integration.
-    abserr : float
-        The maximum of the estimates of the absolute error in the various
-        integration results.
-    out_dict : dict, optional
-        A dict containing additional information on the integration.
+    A result object with the following attributes:
+
+        integral : float
+            The result of the integration.
+        abserr : float
+            The maximum of the estimates of the absolute error in the various
+            integration results.
+        neval : dict, optional
+            The number of integrand evaluations.
 
     See Also
     --------
@@ -1168,7 +1181,19 @@ def nquad(func, ranges, args=None, opts=None, full_output=False):
         opts = [_OptFunc(opts)] * depth
     else:
         opts = [opt if callable(opt) else _OptFunc(opt) for opt in opts]
-    return _NQuad(func, ranges, opts, full_output).integrate(*args)
+    res = _NQuad(func, ranges, opts, True).integrate(*args)
+
+    if full_output is not None:
+        msg = ("Use of parameter `full_output` is deprecated. Please leave "
+               "`full_output` unspecified; `neval` can now be accessed as an "
+               "attribute of the object returned by `scipy.integrate.nquad`.")
+        warnings.warn(msg, DeprecationWarning, stacklevel=2)
+
+    if full_output:
+        return res
+    else:
+        return QuadratureResult(integral=res[0], abserr=res[1],
+                                neval=res[2]['neval'])
 
 
 class _RangeFunc:

--- a/scipy/integrate/tests/test_quadpack.py
+++ b/scipy/integrate/tests/test_quadpack.py
@@ -538,7 +538,6 @@ class TestQuad:
 
 
 class TestNQuad:
-    @pytest.mark.filterwarnings('ignore::DeprecationWarning')
     def test_fixed_limits(self):
         def func1(x0, x1, x2, x3):
             val = (x0**2 + x1*x2 - x3**3 + np.sin(x0) +
@@ -549,9 +548,9 @@ class TestNQuad:
             return {'points': [0.2*args[2] + 0.5 + 0.25*args[0]]}
 
         res = nquad(func1, [[0, 1], [-1, 1], [.13, .8], [-.15, 1]],
-                    opts=[opts_basic, {}, {}, {}], full_output=True)
-        assert_quad(res[:-1], 1.5267454070738635)
-        assert_(res[-1]['neval'] > 0 and res[-1]['neval'] < 4e5)
+                    opts=[opts_basic, {}, {}, {}])
+        assert_quad(res, 1.5267454070738635)
+        assert res.neval > 0 and res.neval < 4e5
 
     def test_variable_limits(self):
         scale = .1

--- a/scipy/integrate/tests/test_quadpack.py
+++ b/scipy/integrate/tests/test_quadpack.py
@@ -2,7 +2,7 @@ import sys
 import math
 import numpy as np
 from numpy import sqrt, cos, sin, arctan, exp, log, pi, Inf
-from numpy.testing import (assert_,
+from numpy.testing import (assert_, assert_equal,
         assert_allclose, assert_array_less, assert_almost_equal)
 import pytest
 
@@ -538,6 +538,7 @@ class TestQuad:
 
 
 class TestNQuad:
+    @pytest.mark.filterwarnings('ignore::DeprecationWarning')
     def test_fixed_limits(self):
         def func1(x0, x1, x2, x3):
             val = (x0**2 + x1*x2 - x3**3 + np.sin(x0) +
@@ -673,3 +674,23 @@ class TestNQuad:
         except TypeError:
             assert False
 
+    def test_result_object(self):
+        # Check that result object contains attributes `integral`, `abserr`,
+        # and `neval`. During the `full_output` deprecation period, also check
+        # that specifying `full_output` produces a warning and that values
+        # are the same whether `full_output` is True, False, or unspecified.
+        def func(x):
+            return x**2 + 1
+
+        res = nquad(func, ranges=[[0, 4]])
+        with np.testing.assert_warns(DeprecationWarning):
+            res2 = nquad(func, ranges=[[0, 4]], full_output=False)
+        with np.testing.assert_warns(DeprecationWarning):
+            res3 = nquad(func, ranges=[[0, 4]], full_output=True)
+
+        assert_equal(res, res2)
+        assert res.integral == res2.integral
+        assert res.abserr == res2.abserr
+
+        assert_equal(res, res3[:2])
+        assert_equal(res.neval, res3[2]['neval'])

--- a/scipy/integrate/tests/test_quadpack.py
+++ b/scipy/integrate/tests/test_quadpack.py
@@ -2,7 +2,7 @@ import sys
 import math
 import numpy as np
 from numpy import sqrt, cos, sin, arctan, exp, log, pi, Inf
-from numpy.testing import (assert_, assert_equal,
+from numpy.testing import (assert_equal,
         assert_allclose, assert_array_less, assert_almost_equal)
 import pytest
 


### PR DESCRIPTION
#### Reference issue
Toward gh-7816

#### What does this implement/fix?
gh-7816 reported confusion that `quad` returned only two values when four or five were expected. This was because `full_output` was not specified, and the remaining values are only available if `full_output=True` and certain conditions are met. @rgommers suggested resolving the issue by returning all information in a Bunch object. This PR implements the suggestion for `nquad`, paving the way toward resolving the issue for `quad`.

#### Additional information
Naming suggestions are welcome. I'll change the names if there is a majority vote (including me) for the change. 
In a followup PR, `dblquad` and `tplquad` will be very easy (doc only).
If someone else would like to do `uad` and the rest of the `integrate` functions following this as an example, I can review.

I'll email the mailing list.
