### PR TITLE
ENH: special: Add logexp1, the log of the exponential integral E_1(x)

### DIFF
--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -728,6 +728,7 @@ Other special functions
    euler       -- Euler numbers E0..En (inclusive).
    expn        -- Exponential integral E_n.
    exp1        -- Exponential integral E_1 of complex argument z.
+   logexp1     -- Logarithm of the exponential integral E_1(x) for real x.
    expi        -- Exponential integral Ei.
    factorial   -- The factorial of a number or array of numbers.
    factorial2  -- Double factorial.

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -4451,6 +4451,66 @@ add_newdoc("exp1",
 
     """)
 
+
+add_newdoc(
+    "logexp1",
+    r"""
+    logexp1(x, out=None)
+
+    Logarithm of the exponential integral E1.
+
+    The function accepts real inputs only.  The result is always calculated
+    with double precision floating point.
+
+    Parameters
+    ----------
+    x: array_like
+        The input array.
+    out : ndarray, optional
+        Optional output array for the function results
+
+    Returns
+    -------
+    scalar or ndarray
+        Values of the natural logarithm of the exponential integral E1
+
+    See Also
+    --------
+    exp1 : exponential integral :math:`E_1`
+    expi : exponential integral :math:`Ei`
+    expn : generalization of :math:`E_1`
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.special import logexp1, exp1
+
+    Mathematically, this function is equivalent to ``np.log(exp1(x))``.
+
+    >>> x = np.array([0.2, 10, 50])
+    >>> logexp1(x)
+    array([  0.20102108, -12.39072437, -53.93145509])
+    >>> np.log(exp1(x))
+    array([  0.20102108, -12.39072437, -53.93145509])
+
+    The function is useful when computing expressions in which the argument
+    ``x`` of the exponential integral function is large enough that
+    ``exp1(x)`` underflows to zero.
+
+    >>> x = np.array([500, 750, 1000])
+    >>> exp1(x)
+    array([1.42207678e-220, 0.00000000e+000, 0.00000000e+000])
+
+    The true values of the last two elements in that result are not 0, but
+    they are too small to be represented as double precision floating point
+    values.  With ``logexp1(x)``, we compute the logarithms of these values
+    accurately.
+
+    >>> logexp1(x)
+    array([ -506.21660213,  -756.62140388, -1006.90875378])
+    """)
+
+
 add_newdoc("exp10",
     """
     exp10(x, out=None)

--- a/scipy/special/functions.json
+++ b/scipy/special/functions.json
@@ -549,6 +549,11 @@
             "exp1_wrap": "d->d"
         }
     },
+    "logexp1": {
+        "logexp1.h": {
+            "logexp1": "d->d"
+        }
+    },
     "exp10": {
         "cephes.h": {
             "exp10": "d->d"

--- a/scipy/special/logexp1.c
+++ b/scipy/special/logexp1.c
@@ -1,0 +1,73 @@
+#include <math.h>
+
+//
+// We use exp1_wrap() from specfun_wrappers.c
+//
+extern double exp1_wrap(double x);
+
+//
+// Compute a factor of the result of the exponential integral E1.
+// This is used in logexp1(x) for 1 < x <= 500.
+//
+// The function uses the continued fraction expansion given in equation 5.1.22
+// of Abramowitz & Stegun, "Handbook of Mathematical Functions".
+// For n=1, this is
+//    E1(x) = exp(-x)*F(x)
+// where F(x) is expressed as a continued fraction:
+//    F(x) =                 1
+//           ---------------------------------------
+//                              1
+//           x + ------------------------------------
+//                                 1
+//               1 + ---------------------------------
+//                                    2
+//                   x + ------------------------------
+//                                       2
+//                       1 + ---------------------------
+//                                          3
+//                           x + ------------------------
+//                                             3
+//                               1 + ---------------------
+//                                                4
+//                                   x + ------------------
+//                                       1 +     [...]
+//
+static double
+expint1_cont_frac_factor(double x)
+{
+    // The number of terms to use in the truncated continued fraction
+    // depends on x.  Larger values of x require fewer terms.
+    int m = 20 + (int) (80.0 / x);
+    double t0 = 0.0;
+    for (int k = m; k > 0; --k) {
+        t0 = k/(1 + k/(x + t0));
+    }
+    return 1/(x + t0);
+}
+
+//
+// Log of the exponential integral function E1 (for real x only).
+//
+double
+logexp1(double x)
+{
+    if (x < 0) {
+        return NAN;
+    }
+    if (x == 0) {
+        return INFINITY;
+    }
+    if (x <= 1) {
+        // For small x, the naive implementation is sufficiently accurate.
+        return log(exp1_wrap(x));
+    }
+    if (x <= 500) {
+        // For moderate x, use the continued fraction expansion.
+        double t = expint1_cont_frac_factor(x);
+        return -x + log(t);
+    }
+    // For large x, use the asymptotic expansion.  This is equation 5.1.51
+    // from Abramowitz & Stegun, "Handbook of Mathematical Functions".
+    double s = (-1 + (2 + (-6 + (24 - 120/x)/x)/x)/x)/x;
+    return -x - log(x) + log1p(s);
+}

--- a/scipy/special/logexp1.h
+++ b/scipy/special/logexp1.h
@@ -1,0 +1,6 @@
+#ifndef LOGEXP1_H
+#define LOGEXP1_H
+
+extern double logexp1(double);
+
+#endif

--- a/scipy/special/meson.build
+++ b/scipy/special/meson.build
@@ -222,6 +222,7 @@ ufuncs_sources = [
   'amos_wrappers.c',
   'cdf_wrappers.c',
   'specfun_wrappers.c',
+  'logexp1.c',
   'sf_error.c'
 ]
 
@@ -388,6 +389,7 @@ py3.extension_module('cython_special',
     'amos_wrappers.c',
     'cdf_wrappers.c',
     'specfun_wrappers.c',
+    'logexp1.c',
     'sf_error.c'
   ],
   c_args: [cython_c_args, Wno_maybe_uninitialized],

--- a/scipy/special/setup.py
+++ b/scipy/special/setup.py
@@ -69,7 +69,7 @@ def configuration(parent_package='',top_path=None):
     headers = ['*.h', join('cephes', '*.h')]
     ufuncs_src = ['_ufuncs.c', 'sf_error.c',
                   'amos_wrappers.c', 'cdf_wrappers.c', 'specfun_wrappers.c',
-                  '_cosine.c']
+                  'logexp1.c', '_cosine.c']
 
     ufuncs_dep = (
         headers
@@ -117,7 +117,8 @@ def configuration(parent_package='',top_path=None):
 
     cython_special_src = ['cython_special.c', 'sf_error.c',
                           'amos_wrappers.c', 'cdf_wrappers.c',
-                          'specfun_wrappers.c', '_cosine.c']
+                          'specfun_wrappers.c', '_cosine.c',
+                          'logexp1.c']
     cython_special_dep = (
         headers
         + ufuncs_src

--- a/scipy/special/tests/test_cython_special.py
+++ b/scipy/special/tests/test_cython_special.py
@@ -190,6 +190,7 @@ PARAMS: List[Tuple[Callable, Callable, Tuple[str, ...], Optional[str]]] = [
     (special.kv, cython_special.kv, ('dd', 'dD'), None),
     (special.kve, cython_special.kve, ('dd', 'dD'), None),
     (special.log1p, cython_special.log1p, ('d', 'D'), None),
+    (special.logexp1, cython_special.logexp1, ('d',), None),
     (special.log_expit, cython_special.log_expit, ('f', 'd', 'g'), None),
     (special.log_ndtr, cython_special.log_ndtr, ('d', 'D'), None),
     (special.ndtri_exp, cython_special.ndtri_exp, ('d',), None),

--- a/scipy/special/tests/test_exponential_integrals.py
+++ b/scipy/special/tests/test_exponential_integrals.py
@@ -33,6 +33,35 @@ class TestExp1:
         assert_allclose(a.imag, b.imag, atol=0, rtol=1e-15)
 
 
+class TestLogExp1:
+
+    # The expected values were computed with mpmath, e.g.
+    #    from mpmath import mp
+    #    mp.dps = 75
+    #    x = 1000
+    #    y = mp.log(mp.expint(1, x))
+    #    print(float(y))
+    # prints
+    #    -1006.9087537832978
+    @pytest.mark.parametrize('x, expected',
+                             [(2**-50, 3.528714908615874),
+                              (0.10, 0.6004417824948862),
+                              (0.25, 0.0433301754689424),
+                              (0.996, -1.5102201140777374),
+                              (1.000, -1.5169319590020456),
+                              (1.004, -1.5236351344283192),
+                              (2.5, -3.6922885436511623),
+                              (25, -28.256715322371637),
+                              (200, -205.3032803974004),
+                              (450, -456.11146244470496),
+                              (600, -606.3985921751421),
+                              (1000, -1006.9087537832978),
+                              (1e80, -1e80)])
+    def test_logexpint1_basic(self, x, expected):
+        y = sc.logexp1(x)
+        assert_allclose(y, expected, rtol=5e-15)
+
+
 class TestExpi:
 
     @pytest.mark.parametrize('result', [


### PR DESCRIPTION
This work was motivated by a question that I saw on stackoverflow: https://stackoverflow.com/questions/66447134/log-of-exp1-in-scipy.  I added an implementation to [ufunclab](https://github.com/WarrenWeckesser/ufunclab), but I have a much lower bar for adding stuff there than we have for SciPy.  But now I see that this would be useful in a formula such as the [entropy of the inverse Gaussian distribution](https://github.com/scipy/scipy/pull/17824), and I suspect it might be useful in other contexts.  In this PR, I add it to SciPy as `scipy.special.logexp1`.