### PR TITLE
ENH: special: Add the function _scaled_exp1

### DIFF
--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -4451,6 +4451,61 @@ add_newdoc("exp1",
 
     """)
 
+
+add_newdoc(
+    "_scaled_exp1",
+    """
+    _scaled_exp1(x, out=None):
+
+    Compute the scaled exponential integral.
+
+    This is a private function, subject to change or removal with no
+    deprecation.
+
+    This function computes F(x), where F is the factor remaining in E_1(x)
+    when exp(-x)/x is factored out.  That is,::
+
+        E_1(x) = exp(-x)/x * F(x)
+
+    or
+
+        F(x) = x * exp(x) * E_1(x)
+
+    The function is defined for real x >= 0.  For x < 0, nan is returned.
+
+    F has the properties:
+
+    * F(0) = 0
+    * F(x) is increasing on [0, inf).
+    * The limit as x goes to infinity of F(x) is 1.
+
+    Parameters
+    ----------
+    x: array_like
+        The input values. Must be real.  The implementation is limited to
+        double precision floating point, so other types will be cast to
+        to double precision.
+    out : ndarray, optional
+        Optional output array for the function results
+
+    Returns
+    -------
+    scalar or ndarray
+        Values of the scaled exponential integral.
+
+    See Also
+    --------
+    exp1 : exponential integral E_1
+
+    Examples
+    --------
+    >>> from scipy.special import _scaled_exp1
+    >>> _scaled_exp1([0, 0.1, 1, 10, 100])
+
+    """
+)
+
+
 add_newdoc("exp10",
     """
     exp10(x, out=None)

--- a/scipy/special/functions.json
+++ b/scipy/special/functions.json
@@ -549,6 +549,11 @@
             "exp1_wrap": "d->d"
         }
     },
+    "_scaled_exp1": {
+        "scaled_exp1.h": {
+            "scaled_exp1": "d->d"
+        }
+    },
     "exp10": {
         "cephes.h": {
             "exp10": "d->d"

--- a/scipy/special/meson.build
+++ b/scipy/special/meson.build
@@ -219,6 +219,7 @@ mach_sources = [
 
 ufuncs_sources = [
   '_cosine.c',
+  'scaled_exp1.c',
   'amos_wrappers.c',
   'cdf_wrappers.c',
   'specfun_wrappers.c',
@@ -385,6 +386,7 @@ py3.extension_module('cython_special',
   [
     uf_cython_gen.process(cython_special[6]),  # cython_special.pyx
     '_cosine.c',
+    'scaled_exp1.c',
     'amos_wrappers.c',
     'cdf_wrappers.c',
     'specfun_wrappers.c',

--- a/scipy/special/scaled_exp1.c
+++ b/scipy/special/scaled_exp1.c
@@ -1,0 +1,82 @@
+#include <math.h>
+
+//
+// We use exp1_wrap() from specfun_wrappers.c
+//
+extern double exp1_wrap(double x);
+
+
+//
+// Compute a factor of the exponential integral E1.
+// This is used in scaled_exp1(x) for moderate values of x.
+//
+// The function uses the continued fraction expansion given in equation 5.1.22
+// of Abramowitz & Stegun, "Handbook of Mathematical Functions".
+// For n=1, this is
+//
+//    E1(x) = exp(-x)*C(x)
+//
+// where C(x), expressed in the notation used in A&S, is the continued fraction
+//
+//            1    1    1    2    2    3    3
+//    C(x) = ---  ---  ---  ---  ---  ---  ---  ...
+//           x +  1 +  x +  1 +  x +  1 +  x +
+//
+// Here, we pull a factor of 1/z out of C(x), so
+//
+//    E1(x) = (exp(-x)/x)*F(x)
+//
+// and a bit of algebra gives the continued fraction expansion of F(x) to be
+//
+//            1    1    1    2    2    3    3
+//    F(x) = ---  ---  ---  ---  ---  ---  ---  ...
+//           1 +  x +  1 +  x +  1 +  x +  1 +
+//
+static double
+expint1_factor_cont_frac(double x)
+{
+    // The number of terms to use in the truncated continued fraction
+    // depends on x.  Larger values of x require fewer terms.
+    int m = 20 + (int) (80.0 / x);
+    double t0 = 0.0;
+    for (int k = m; k > 0; --k) {
+        t0 = k/(x + k/(1 + t0));
+    }
+    return 1/(1 + t0);
+}
+
+//
+// Scaled version  of the exponential integral E_1(x).
+//
+// Factor E_1(x) as
+//
+//    E_1(x) = exp(-x)/x * F(x)
+//
+// This function computes F(x).
+//
+// F(x) has the properties:
+//  * F(0) = 0
+//  * F is increasing on [0, inf)
+//  * lim_{x->inf} F(x) = 1.
+//
+double
+scaled_exp1(double x)
+{
+    if (x < 0) {
+        return NAN;
+    }
+    if (x == 0) {
+        return 0.0;
+    }
+    if (x <= 1) {
+        // For small x, the naive implementation is sufficiently accurate.
+        return x * exp(x) * exp1_wrap(x);
+    }
+    if (x <= 1250) {
+        // For moderate x, use the continued fraction expansion.
+        return expint1_factor_cont_frac(x);
+    }
+    // For large x, use the asymptotic expansion.  This is equation 5.1.51
+    // from Abramowitz & Stegun, "Handbook of Mathematical Functions".
+    return 1 + (-1 + (2 + (-6 + (24 - 120/x)/x)/x)/x)/x;
+}

--- a/scipy/special/scaled_exp1.h
+++ b/scipy/special/scaled_exp1.h
@@ -1,0 +1,6 @@
+#ifndef SCALED_EXP1_H
+#define SCALED_EXP1_H
+
+extern double scaled_exp1(double);
+
+#endif

--- a/scipy/special/setup.py
+++ b/scipy/special/setup.py
@@ -69,7 +69,7 @@ def configuration(parent_package='',top_path=None):
     headers = ['*.h', join('cephes', '*.h')]
     ufuncs_src = ['_ufuncs.c', 'sf_error.c',
                   'amos_wrappers.c', 'cdf_wrappers.c', 'specfun_wrappers.c',
-                  '_cosine.c']
+                  '_cosine.c', 'scaled_exp1.c']
 
     ufuncs_dep = (
         headers

--- a/scipy/special/tests/test_exponential_integrals.py
+++ b/scipy/special/tests/test_exponential_integrals.py
@@ -33,6 +33,49 @@ class TestExp1:
         assert_allclose(a.imag, b.imag, atol=0, rtol=1e-15)
 
 
+class TestScaledExp1:
+
+    @pytest.mark.parametrize('x, expected', [(0, 0), (np.inf, 1)])
+    def test_limits(self, x, expected):
+        y = sc._ufuncs._scaled_exp1(x)
+        assert y == expected
+
+    # The expected values were computed with mpmath, e.g.:
+    #
+    #   from mpmath import mp
+    #   mp.dps = 80
+    #   x = 1e-25
+    #   print(float(x*mp.exp(x)*np.expint(1, x)))
+    #
+    # prints 5.698741165994961e-24
+    #
+    # The method used to compute _scaled_exp1 changes at x=1
+    # and x=1250, so values at those inputs, and values just
+    # above and below them, are included in the test data.
+    @pytest.mark.parametrize('x, expected',
+                             [(1e-25, 5.698741165994961e-24),
+                              (0.1, 0.20146425447084518),
+                              (0.9995, 0.5962509885831002),
+                              (1.0, 0.5963473623231941),
+                              (1.0005, 0.5964436833238044),
+                              (2.5, 0.7588145912149602),
+                              (10.0, 0.9156333393978808),
+                              (100.0, 0.9901942286733019),
+                              (500.0, 0.9980079523802055),
+                              (1000.0, 0.9990019940238807),
+                              (1249.5, 0.9992009578306811),
+                              (1250.0, 0.9992012769377913),
+                              (1250.25, 0.9992014363957858),
+                              (2000.0, 0.9995004992514963),
+                              (1e4, 0.9999000199940024),
+                              (1e10, 0.9999999999),
+                              (1e15, 0.999999999999999),
+                              ])
+    def test_scaled_exp1(self, x, expected):
+        y = sc._ufuncs._scaled_exp1(x)
+        assert_allclose(y, expected, rtol=2e-15)
+
+
 class TestExpi:
 
     @pytest.mark.parametrize('result', [

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4374,10 +4374,10 @@ class invgauss_gen(rv_continuous):
         # a = log(2*pi*e*mu**3)
         #   = 1 + log(2*pi) + 3 * log(mu)
         a = 1. + np.log(2 * np.pi) + 3 * np.log(mu)
-        # b = exp(2 / mu) * exp1(2 / mu)
-        #   = exp(log(exp(2 / mu) * exp1(2 / mu)))
-        #   = exp(2 / mu + log(exp1(2 / mu)))
-        b = np.exp(2 / mu + np.log(sc.exp1(2 / mu)))
+        # b = exp(2/mu) * exp1(2/mu)
+        #   = _scaled_exp1(2/mu) / (2/mu)
+        r = 2/mu
+        b = sc._ufuncs._scaled_exp1(r)/r
         return 0.5 * a - 1.5 * b
 
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2476,11 +2476,13 @@ class TestInvgauss:
     # mu = mp.mpf(1e-2)
     # ref = (1/2 * mp.log(2 * mp.pi * mp.e * mu**3)
     #        - 3/2* mp.exp(2/mu) * mp.e1(2/mu))
-    @pytest.mark.parametrize("mu, ref", [(1e-2, -5.496279615262233),
-                                         (1e8, 3.3244822568873474),
-                                         (1e100, 3.3244828013968899)])
+    @pytest.mark.parametrize("mu, ref", [(2e-8, -25.172361826883957),
+                                         (1e-3, -8.943444010642972),
+                                         (1e-2, -5.4962796152622335),
+                                         (1e8, 3.3244822568873476),
+                                         (1e100, 3.32448280139689)])
     def test_entropy(self, mu, ref):
-        assert_allclose(stats.invgauss.entropy(mu), ref)
+        assert_allclose(stats.invgauss.entropy(mu), ref, rtol=5e-14)
 
 
 class TestLaplace:


### PR DESCRIPTION
This is an alternative to https://github.com/scipy/scipy/pull/17844.  Instead of providing a function that computes $\log(E_1(x))$, here we provide the function $F(x) = x e^x E_1(x)$.  It is currently implemented as the private function `scipy.special._scaled_exp1`.  We can interpret $F(x)$ as the "nice" part of $E_1(x)$, with the exponential decay as $x\rightarrow\infty$ removed and the singularity at 0 removed.  That is, $E_1(x) = \frac{e^{-x}}{x} F(x)$.  $F(x)$ is numerically well-behaved, with the properties that $F(0) = 0$, $F$ is increasing on $[0, \infty)$ and $\lim_{x\rightarrow\infty} F(x) = 1$.

The comments in the C function `scaled_exp1.c` explain the how $F(x)$ is computed.  The method used depends on the value of $x$:

* $0 \le x \le 1$: naive implementation $F(x) = x e^x E_1(x)$,
* $1 < x \le 1250$: continued fraction expansion,
* $x > 1250$: asymptotic expansion.

The function is private for now.  If there is interest, we can make it public here, or we can wait until additional use-cases arise in the future.  The form of $F(x)$ defined here is a nice fit  for our current use-case in the entropy function of the inverse Gaussian distribution.
