### PR TITLE
DOC: integrate.dblquad/tplquad: update result descriptions

### DIFF
--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -686,7 +686,7 @@ def dblquad(func, a, b, gfun, hfun, args=(), epsabs=1.49e-8, epsrel=1.49e-8):
         abserr : float
             The maximum of the estimates of the absolute error in the
             two integration results.
-        neval : dict, optional
+        neval : int
             The number of integrand evaluations.
 
     See Also
@@ -828,7 +828,7 @@ def tplquad(func, a, b, gfun, hfun, qfun, rfun, args=(), epsabs=1.49e-8,
         abserr : float
             The maximum of the estimates of the absolute error in the
             three integration results.
-        neval : dict, optional
+        neval : int
             The number of integrand evaluations.
 
     See Also
@@ -1024,7 +1024,7 @@ def nquad(func, ranges, args=None, opts=None, full_output=None):
         abserr : float
             The maximum of the estimates of the absolute error in the various
             integration results.
-        neval : dict, optional
+        neval : int
             The number of integrand evaluations.
 
     See Also

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -678,10 +678,16 @@ def dblquad(func, a, b, gfun, hfun, args=(), epsabs=1.49e-8, epsrel=1.49e-8):
 
     Returns
     -------
-    y : float
-        The resultant integral.
-    abserr : float
-        An estimate of the error.
+    res : QuadResult
+        An object with the following attributes:
+
+        integral : float
+            The result of the integration.
+        abserr : float
+            The maximum of the estimates of the absolute error in the
+            two integration results.
+        neval : dict, optional
+            The number of integrand evaluations.
 
     See Also
     --------
@@ -814,10 +820,16 @@ def tplquad(func, a, b, gfun, hfun, qfun, rfun, args=(), epsabs=1.49e-8,
 
     Returns
     -------
-    y : float
-        The resultant integral.
-    abserr : float
-        An estimate of the error.
+    res : QuadResult
+        An object with the following attributes:
+
+        integral : float
+            The result of the integration.
+        abserr : float
+            The maximum of the estimates of the absolute error in the
+            three integration results.
+        neval : dict, optional
+            The number of integrand evaluations.
 
     See Also
     --------
@@ -1004,7 +1016,8 @@ def nquad(func, ranges, args=None, opts=None, full_output=None):
 
     Returns
     -------
-    A result object with the following attributes:
+    res : QuadResult
+        An object with the following attributes:
 
         integral : float
             The result of the integration.


### PR DESCRIPTION
#### Reference issue
gh-17837

#### What does this implement/fix?
Updates the result object descriptions of `dblquad` and `tplquad` following gh-17837.

#### Additional information
I'm leaving the example outputs alone. I'm never sure what to do when the output is too long for a line. If we can agree on a policy for that, fixing these throughout SciPy (since there are probably other places we have used bunches but haven't updated the examples) would make a good first issue at SciPy 2023?