### PR TITLE
TST: mark test for `stats.kde.marginal` as xslow

### DIFF
--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -418,7 +418,7 @@ def test_marginal_1_axis():
     assert_allclose(pdf, ref, rtol=1e-6)
 
 
-@pytest.mark.slow
+@pytest.mark.xslow
 def test_marginal_2_axis():
     rng = np.random.default_rng(6111799263660870475)
     n_data = 30


### PR DESCRIPTION
This test takes ~20 sec locally, and times out in CI even after bumping the limit from 60 to 80 sec.

[skip cirrus] [skip azp] [skip circle]

xref gh-17831
