### PR TITLE
BUG: Fix handling of `powm1` overflow errors

### DIFF
--- a/scipy/special/boost_special_functions.h
+++ b/scipy/special/boost_special_functions.h
@@ -90,7 +90,14 @@ Real powm1_wrap(Real x, Real y)
         z = NAN;
     } catch (const std::overflow_error& e) {
         sf_error("powm1", SF_ERROR_OVERFLOW, NULL);
-        z = INFINITY;
+        if (x > 0)
+        {
+            z = INFINITY;
+        }
+        else
+        {
+            z = -INFINITY;
+        }
     } catch (const std::underflow_error& e) {
         sf_error("powm1", SF_ERROR_UNDERFLOW, NULL);
         z = 0;

--- a/scipy/special/boost_special_functions.h
+++ b/scipy/special/boost_special_functions.h
@@ -90,12 +90,10 @@ Real powm1_wrap(Real x, Real y)
         z = NAN;
     } catch (const std::overflow_error& e) {
         sf_error("powm1", SF_ERROR_OVERFLOW, NULL);
-        if (x > 0)
-        {
+        if (x > 0) {
             z = INFINITY;
         }
-        else
-        {
+        else {
             z = -INFINITY;
         }
     } catch (const std::underflow_error& e) {


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

No open issue. Fixes handling of overflow errors that are on the Boost.Math develop branch found in https://github.com/scipy/scipy/pull/17432

#### What does this implement/fix?
<!--Please explain your changes.-->

Overflow errors always returned positive infinity. This changes the behavior based on the value of x to return negative infinity such as in the failing test case: `x = -INF, y = 3`

#### Additional information
<!--Any additional information you think is important.-->

N/A
