### PR TITLE
MAINT: analytical formula for genlogistic entropy

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -2692,6 +2692,9 @@ class genlogistic_gen(rv_continuous):
         g2 /= mu2**2.0
         return mu, mu2, g1, g2
 
+    def _entropy(self, c):
+        return sc.betaln(c, 1) + 1 + sc.psi(c) + 1/c - sc.psi(1)
+
 
 genlogistic = genlogistic_gen(name='genlogistic')
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -2693,7 +2693,7 @@ class genlogistic_gen(rv_continuous):
         return mu, mu2, g1, g2
 
     def _entropy(self, c):
-        return -np.log(c) + sc.psi(c) + 1/c + _EULER + 1
+        return -np.log(c) + sc.psi(c + 1) + _EULER + 1
 
 
 genlogistic = genlogistic_gen(name='genlogistic')

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -2693,7 +2693,7 @@ class genlogistic_gen(rv_continuous):
         return mu, mu2, g1, g2
 
     def _entropy(self, c):
-        return sc.betaln(c, 1) + 1 + sc.psi(c) + 1/c - sc.psi(1)
+        return sc.betaln(c, 1) + 1 + sc.psi(c) + 1/c + _EULER
 
 
 genlogistic = genlogistic_gen(name='genlogistic')

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -2693,7 +2693,7 @@ class genlogistic_gen(rv_continuous):
         return mu, mu2, g1, g2
 
     def _entropy(self, c):
-        return sc.betaln(c, 1) + 1 + sc.psi(c) + 1/c + _EULER
+        return -np.log(c) + sc.psi(c) + 1/c + _EULER + 1
 
 
 genlogistic = genlogistic_gen(name='genlogistic')

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1313,6 +1313,15 @@ class TestGenLogistic:
         logp = stats.genlogistic.logpdf(x, c)
         assert_allclose(logp, expected, rtol=1e-13)
 
+    # Expected values computed with mpmath with 50 digits of precision
+    # from mpmath import mp
+    # float(mp.log(mp.beta(c, 1)) + 1 + mp.digamma(c) + 1/c - mp.digamma(1.))
+    @pytest.mark.parametrize('c, ref', [(1e-8, 19.420680762493962),
+                                        (1e-4, 10.21050485336386),
+                                        (1e8, 1.577215669901533)])
+    def test_entropy(self, c, ref):
+        assert_allclose(stats.genlogistic.entropy(c), ref)
+
 
 class TestHypergeom:
     def setup_method(self):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1314,11 +1314,13 @@ class TestGenLogistic:
         assert_allclose(logp, expected, rtol=1e-13)
 
     # Expected values computed with mpmath with 50 digits of precision
-    # from mpmath import mp
-    # float(mp.log(mp.beta(c, 1)) + 1 + mp.digamma(c) + 1/c - mp.digamma(1.))
-    @pytest.mark.parametrize('c, ref', [(1e-8, 19.420680762493962),
-                                        (1e-4, 10.21050485336386),
-                                        (1e8, 1.577215669901533)])
+    # def entropy_mp(c):
+    #     c = mp.mpf(c)
+    #     return float(-mp.log(c)+mp.one+mp.digamma(c + mp.one) + mp.euler)
+    @pytest.mark.parametrize('c, ref', [(1e-100, 231.25850929940458),
+                                        (1e-4, 10.21050485336338),
+                                        (1e8, 1.577215669901533),
+                                        (1e100, 1.5772156649015328)])
     def test_entropy(self, c, ref):
         assert_allclose(stats.genlogistic.entropy(c), ref)
 


### PR DESCRIPTION
#### Reference issue
#17832

#### What does this implement/fix?
An analytical formula for the entropy of the `genlogistic` distribution. Results in much higher precision for small `c`:

![GenLogistic_Entropy_Small_c](https://user-images.githubusercontent.com/40656107/214655662-18b3ce92-526a-4b49-86b0-0d9d0ea7bea5.png)

Here, `main` also throws Warnings:
`IntegrationWarning: The integral is probably divergent, or slowly convergent`

<details>

```
import numpy as np
from scipy.stats import genlogistic
import matplotlib.pyplot as plt
import scipy.special as sc

def entropy_genlogistic(c):
    return (sc.betaln(c, 1) +1 + sc.psi(c) + 1/c - sc.psi(1.))


c=np.linspace(1e-8, 1e-5, 1000)

plt.plot(c, genlogistic.entropy(c), label="main")
plt.plot(c, entropy_genlogistic(c), label="custom")
plt.legend()
plt.show()
```

</details>

#### Additional information
The entropy for the (type 4) generalized logistic distribution is given here: https://www.sciencedirect.com/science/article/pii/S1110256X12000260

scipy's `genlogistic` is a special case for $\lambda=\beta=1$. The formula then simplfies to:

$$
\begin{align}
h & = \ln(B(\alpha, \beta)) - \ln\lambda - \alpha((\\psi(\alpha) - \psi(\alpha +\beta)) - \beta(\psi(\beta) - \psi(\alpha + \beta)) \\\\\\
   & \stackrel{\lambda=\beta=1}{=} \ln(B(\alpha, 1)) - \alpha\psi(\alpha) + \alpha\psi(\alpha + 1) - \psi(1) + \psi(\alpha +1)  \\\\\\ 
  & = \ln(1/\alpha)) - \psi(1) - \alpha\psi(\alpha) + (\alpha + 1)\underbrace{\psi(\alpha +1)}_{\psi(\alpha) + \frac{1}{\alpha}} \\\\\\
   &  = -\ln(\alpha) -\psi(1) - \underbrace{\alpha\psi(\alpha) + \alpha\psi(\alpha)}_0 + 1 + \psi(\alpha) + 1/\alpha \\\\\\
  & =  -\ln(\alpha) -\psi(1) + 1 + \psi(\alpha +1)
\end{align}
$$