### PR TITLE
BUG: fix Johnson's algorithm

### DIFF
--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -1337,6 +1337,7 @@ cdef int _johnson_directed(
             const int[:] csr_indices,
             const int[:] csr_indptr,
             double[:] dist_array):
+    # Note: The contents of dist_array must be initialized to zero on entry
     cdef:
         unsigned int N = dist_array.shape[0]
         unsigned int j, k, count
@@ -1344,10 +1345,6 @@ cdef int _johnson_directed(
 
     # relax all edges (N+1) - 1 times
     for count in range(N):
-        for k in range(N):
-            if dist_array[k] < 0:
-                dist_array[k] = 0
-
         for j in range(N):
             d1 = dist_array[j]
             for k in range(csr_indptr[j], csr_indptr[j + 1]):
@@ -1373,6 +1370,7 @@ cdef int _johnson_undirected(
             const int[:] csr_indices,
             const int[:] csr_indptr,
             double[:] dist_array):
+    # Note: The contents of dist_array must be initialized to zero on entry
     cdef:
         unsigned int N = dist_array.shape[0]
         unsigned int j, k, ind_k, count
@@ -1380,10 +1378,6 @@ cdef int _johnson_undirected(
 
     # relax all edges (N+1) - 1 times
     for count in range(N):
-        for k in range(N):
-            if dist_array[k] < 0:
-                dist_array[k] = 0
-
         for j in range(N):
             d1 = dist_array[j]
             for k in range(csr_indptr[j], csr_indptr[j + 1]):

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -1,6 +1,6 @@
 import warnings
 import numpy as np
-from numpy.testing import assert_array_almost_equal, assert_array_equal
+from numpy.testing import assert_array_almost_equal, assert_array_equal, assert_allclose
 from pytest import raises as assert_raises
 from scipy.sparse.csgraph import (shortest_path, dijkstra, johnson,
                                   bellman_ford, construct_dist_matrix,
@@ -76,6 +76,14 @@ undirected_pred = np.array([[-9999, 0, 0, 0, 0],
                             [2, 0, -9999, 0, 0],
                             [3, 3, 0, -9999, 3],
                             [4, 4, 0, 4, -9999]], dtype=float)
+
+directed_negative_weighted_G = np.array([[0, 0, 0],
+                                         [-1, 0, 0],
+                                         [0, -1, 0]], dtype=float)
+
+directed_negative_weighted_SP = np.array([[0, np.inf, np.inf],
+                                          [-1, 0, np.inf],
+                                          [-2, -1, 0]], dtype=float)
 
 methods = ['auto', 'FW', 'D', 'BF', 'J']
 
@@ -277,6 +285,12 @@ def test_negative_cycles():
     for method in ['FW', 'J', 'BF']:
         for directed in (True, False):
             check(method, directed)
+
+
+@pytest.mark.parametrize("method", ['FW', 'J', 'BF'])
+def test_negative_weights(method):
+    SP = shortest_path(directed_negative_weighted_G, method, directed=True)
+    assert_allclose(SP, directed_negative_weighted_SP, atol=1e-10)
 
 
 def test_masked_input():


### PR DESCRIPTION
#### Reference issue
Closes [#14980](https://github.com/scipy/scipy/issues/14980)

#### What does this implement/fix?
Remove unnecessary reset of dist_array during Bellman-Ford weight updates.
Add unit test for negative weighted shortest paths. 

