### PR TITLE
MAINT: stats: fix recent CI and other issues

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -2663,7 +2663,7 @@ class genlogistic_gen(rv_continuous):
         f(x, c) = c \frac{\exp(-x)}
                          {(1 + \exp(-x))^{c+1}}
 
-    for :math:`x >= 0`, :math:`c > 0`.
+    for real :math:`x` and :math:`c > 0`.
 
     `genlogistic` takes ``c`` as a shape parameter for :math:`c`.
 
@@ -7716,8 +7716,8 @@ class powernorm_gen(rv_continuous):
 
         f(x, c) = c \phi(x) (\Phi(-x))^{c-1}
 
-    where :math:`\phi` is the normal pdf, and :math:`\Phi` is the normal cdf,
-    and :math:`x >= 0`, :math:`c > 0`.
+    where :math:`\phi` is the normal pdf, :math:`\Phi` is the normal cdf,
+    :math:`x` is any real, and :math:`c > 0`.
 
     `powernorm` takes ``c`` as a shape parameter for :math:`c`.
 

--- a/scipy/stats/tests/test_continuous_fit_censored.py
+++ b/scipy/stats/tests/test_continuous_fit_censored.py
@@ -529,7 +529,7 @@ def test_nct():
     data = CensoredData.right_censored([1, 2, 3, 5, 8, 10, 25, 25],
                                        [0, 0, 0, 0, 0, 0, 1, 1])
     # Fit just the shape parameter df and nc; loc and scale are fixed.
-    with np.errstate(over='ignore'):  # remove context once gh-14901 is resolved
+    with np.errstate(over='ignore'):  # remove context when gh-14901 is closed
         df, nc, loc, scale = nct.fit(data, floc=0, fscale=1,
                                      optimizer=optimizer)
     assert_allclose(df, 0.5432336, rtol=5e-6)
@@ -562,7 +562,7 @@ def test_ncx2():
     """
     data = CensoredData(uncensored=[2.7, 0.2, 6.5, 0.4, 0.1], right=[8, 8],
                         interval=[[0.6, 1.0]])
-    with np.errstate(over='ignore'):  # remove context once gh-14901 is resolved
+    with np.errstate(over='ignore'):  # remove context when gh-14901 is closed
         df, ncp, loc, scale = ncx2.fit(data, floc=0, fscale=1,
                                        optimizer=optimizer)
     assert_allclose(df, 1.052871, rtol=5e-6)

--- a/scipy/stats/tests/test_continuous_fit_censored.py
+++ b/scipy/stats/tests/test_continuous_fit_censored.py
@@ -529,7 +529,9 @@ def test_nct():
     data = CensoredData.right_censored([1, 2, 3, 5, 8, 10, 25, 25],
                                        [0, 0, 0, 0, 0, 0, 1, 1])
     # Fit just the shape parameter df and nc; loc and scale are fixed.
-    df, nc, loc, scale = nct.fit(data, floc=0, fscale=1, optimizer=optimizer)
+    with np.errstate(over='ignore'):  # remove context once gh-14901 is resolved
+        df, nc, loc, scale = nct.fit(data, floc=0, fscale=1,
+                                     optimizer=optimizer)
     assert_allclose(df, 0.5432336, rtol=5e-6)
     assert_allclose(nc, 2.8893565, rtol=5e-6)
     assert loc == 0
@@ -560,8 +562,9 @@ def test_ncx2():
     """
     data = CensoredData(uncensored=[2.7, 0.2, 6.5, 0.4, 0.1], right=[8, 8],
                         interval=[[0.6, 1.0]])
-    df, ncp, loc, scale = ncx2.fit(data, floc=0, fscale=1,
-                                   optimizer=optimizer)
+    with np.errstate(over='ignore'):  # remove context once gh-14901 is resolved
+        df, ncp, loc, scale = ncx2.fit(data, floc=0, fscale=1,
+                                       optimizer=optimizer)
     assert_allclose(df, 1.052871, rtol=5e-6)
     assert_allclose(ncp, 2.362934, rtol=5e-6)
     assert loc == 0

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1314,6 +1314,8 @@ class TestGenLogistic:
         assert_allclose(logp, expected, rtol=1e-13)
 
     # Expected values computed with mpmath with 50 digits of precision
+    # from mpmath import mp
+    # mp.dps = 50
     # def entropy_mp(c):
     #     c = mp.mpf(c)
     #     return float(-mp.log(c)+mp.one+mp.digamma(c + mp.one) + mp.euler)
@@ -4497,7 +4499,7 @@ class TestLevyStable:
         # Test seems to be unstable (see gh-17839 for a bug report on Debian
         # i386), so skip it.
         if is_linux_32 and case == 'pdf':
-            pytest.skip("%s fit known to fail or deprecated" % dist)
+            pytest.skip("Test unstable on some platforms; see gh-17839, 17859")
 
         data = nolan_loc_scale_sample_data
         # We only test against piecewise as location/scale transforms


### PR DESCRIPTION
#### Reference issue
gh-17857
gh-17848
gh-17859

#### What does this implement/fix?
Some test have been failing in main (e.g. gh-17857). This fixes them, except for 
```
FAILED ../testenv/lib/python3.8/site-packages/scipy/linalg/tests/test_matfuncs.py::TestFractionalMatrixPower::test_al_mohy_higham_2012_experiment_1 - AssertionError: 
```

Also, we noticed an error in the documentation of the support of two distributions (gh-17857, gh-17848). I decided to fix that here, too.
