### PR TITLE
BUG: Fix powm1 test case

### DIFF
--- a/scipy/special/tests/test_powm1.py
+++ b/scipy/special/tests/test_powm1.py
@@ -44,7 +44,7 @@ def test_powm1(x, y, expected, rtol):
                           (np.inf, -np.inf, -1.0),
                           (np.inf, 0.0, 0.0),
                           (-np.inf, 0.0, 0.0),
-                          (-np.inf, 2.0, np.inf),
+                          (-np.inf, 2.0, -np.inf),
                           (-np.inf, 3.0, -np.inf),
                           (-1.0, float(2**53 - 1), -2.0)])
 def test_powm1_exact_cases(x, y, expected):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

No open issue. Related PRs are #17855 and #17432.

#### What does this implement/fix?
<!--Please explain your changes.-->

Fix test case that now fails because of changes made in #17855. `-INF**2 - 1` should be `-INF` not `+INF`

#### Additional information
<!--Any additional information you think is important.-->

Failure can be found [here](https://github.com/scipy/scipy/actions/runs/4021661656/jobs/6910727313#step:13:601).
