### PR TITLE
BUG: fix powm1 overflow handling

### DIFF
--- a/scipy/special/boost_special_functions.h
+++ b/scipy/special/boost_special_functions.h
@@ -90,11 +90,42 @@ Real powm1_wrap(Real x, Real y)
         z = NAN;
     } catch (const std::overflow_error& e) {
         sf_error("powm1", SF_ERROR_OVERFLOW, NULL);
+        
+        // See: https://en.cppreference.com/w/cpp/numeric/math/pow
         if (x > 0) {
+            if (y < 0) {
+                z = 0;
+            }
+            else if (y == 0) {
+                z = 1;
+            }
+            else {
+                z = INFINITY;
+            }
+        }
+        else if (x == 0) {
             z = INFINITY;
         }
         else {
-            z = -INFINITY;
+            if (y < 0) {
+                if (std::fmod(y, 2) == 0) {
+                    z = 0;
+                }
+                else {
+                    z = -0;
+                }
+            }
+            else if (y == 0) {
+                z = 1;
+            }
+            else {
+                if (std::fmod(y, 2) == 0) {
+                    z = INFINITY;
+                }
+                else {
+                    z = -INFINITY;
+                }
+            }
         }
     } catch (const std::underflow_error& e) {
         sf_error("powm1", SF_ERROR_UNDERFLOW, NULL);


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

No open issue. Supersedes #17855.

#### What does this implement/fix?
<!--Please explain your changes.-->

Implements complete error handling as defined in cmath https://en.cppreference.com/w/cpp/numeric/math/pow

#### Additional information
<!--Any additional information you think is important.-->

@WarrenWeckesser the C++ version of your test set with this change applied for validation can be found on this pull: https://github.com/boostorg/math/pull/931/. Sorry for the previous braindead PR.
