### PR TITLE
DOC: remove hidden stats sections from sidebar/toctree

### DIFF
--- a/doc/API.rst.txt
+++ b/doc/API.rst.txt
@@ -177,9 +177,6 @@ change is made.
    spatial
    special
    stats
-   stats.mstats
-   stats.qmc
-   stats.sampling
    ccallback
 
 SciPy structure

--- a/doc/source/reference/stats.rst
+++ b/doc/source/reference/stats.rst
@@ -2,9 +2,3 @@
    :no-members:
    :no-inherited-members:
    :no-special-members:
-
-.. toctree::
-   :hidden:
-
-   stats._result_classes
-   stats.contingency

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -4108,11 +4108,11 @@ def filtfilt(b, a, x, axis=-1, padtype='odd', padlen=None, method='pad',
     argument.  The difference between `y1` and `y2` is small.  For long
     signals, using `irlen` gives a significant performance improvement.
 
-    >>> x = rng.standard_normal(5000)
+    >>> x = rng.standard_normal(4000)
     >>> y1 = signal.filtfilt(b, a, x, method='gust')
     >>> y2 = signal.filtfilt(b, a, x, method='gust', irlen=approx_impulse_len)
     >>> print(np.max(np.abs(y1 - y2)))
-    1.80056858312e-10
+    2.875334415008979e-10
 
     """
     b = np.atleast_1d(b)

--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -572,7 +572,11 @@ Warnings / Errors used in :mod:`scipy.stats`
 Result classes used in :mod:`scipy.stats`
 -----------------------------------------
 
-.. warning:: These classes are private. Do not import them.
+.. warning::
+
+    These classes are private, but they are included here because instances
+    of them are returned by other statistical functions. User import and
+    instantiation is not supported.
 
 .. toctree::
    :maxdepth: 2

--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -569,6 +569,16 @@ Warnings / Errors used in :mod:`scipy.stats`
    NearConstantInputWarning
    FitError
 
+Result classes used in :mod:`scipy.stats`
+-----------------------------------------
+
+.. warning:: These classes are private. Do not import them.
+
+.. toctree::
+   :maxdepth: 2
+
+   stats._result_classes
+
 """
 
 from ._warnings_errors import (ConstantInputWarning, NearConstantInputWarning,


### PR DESCRIPTION
Closes #17866

Remove the result classes and contingency tables from the toctree.

(I also always have a linalg error in an example locally, so I fixed it)