### PR TITLE
DOC: add docs for the main namespace

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -881,7 +881,12 @@ class Bench(Task):
 # linters
 
 def emit_cmdstr(cmd):
-    """Print the command that's being run to stdout"""
+    """Print the command that's being run to stdout
+
+    Note: cannot use this in the below tasks (yet), because as is these command
+    strings are always echoed to the console, even if the command isn't run
+    (but for example the `build` command is run).
+    """
     console = Console(theme=console_theme)
     # The [cmd] square brackets controls the font styling, typically in italics
     # to differentiate it from other stdout content
@@ -891,7 +896,7 @@ def emit_cmdstr(cmd):
 def task_lint():
     # Lint just the diff since branching off of main using a
     # stricter configuration.
-    emit_cmdstr(os.path.join('tools', 'lint.py') + ' --diff-against main')
+    # emit_cmdstr(os.path.join('tools', 'lint.py') + ' --diff-against main')
     return {
         'basename': 'lint',
         'actions': [str(Dirs().root / 'tools' / 'lint.py') +
@@ -901,7 +906,7 @@ def task_lint():
 
 
 def task_unicode_check():
-    emit_cmdstr(os.path.join('tools', 'unicode-check.py'))
+    # emit_cmdstr(os.path.join('tools', 'unicode-check.py'))
     return {
         'basename': 'unicode-check',
         'actions': [str(Dirs().root / 'tools' / 'unicode-check.py')],
@@ -911,7 +916,7 @@ def task_unicode_check():
 
 
 def task_check_test_name():
-    emit_cmdstr(os.path.join('tools', 'check_test_name.py'))
+    # emit_cmdstr(os.path.join('tools', 'check_test_name.py'))
     return {
         "basename": "check-testname",
         "actions": [str(Dirs().root / "tools" / "check_test_name.py")],

--- a/doc/API.rst.txt
+++ b/doc/API.rst.txt
@@ -88,6 +88,8 @@ unlikely to be renamed or changed in an incompatible way, and if that is
 necessary, a deprecation warning will be raised for one SciPy release before the
 change is made.
 
+* `scipy`
+
 * `scipy.cluster`
 
   - `scipy.cluster.vq`
@@ -157,6 +159,7 @@ change is made.
    :maxdepth: 1
    :hidden:
 
+   main_namespace
    cluster
    constants
    datasets

--- a/doc/source/reference/main_namespace.rst
+++ b/doc/source/reference/main_namespace.rst
@@ -1,0 +1,49 @@
+========================
+The main SciPy namespace
+========================
+
+.. currentmodule:: scipy
+
+The main ``scipy`` namespace has very few objects in it by design. Only show
+generical functionality related to testing, build info and versioning, and one
+class (`LowLevelCallable`) that didn't fit in one of the submodules, are
+present:
+
+.. autosummary::
+   :toctree: generated/
+
+   LowLevelCallable
+   show_config
+   test
+
+
+The one public attribute is:
+
+================== ===============================================
+``__version__``    SciPy version string
+================== ===============================================
+
+
+Submodules
+----------
+
+=============  ==================================================
+`cluster`      Clustering functionality
+`constants`    Physical and mathematical constants and units
+`datasets`     Load SciPy datasets
+`fft`          Discrete Fourier and related transforms
+`fftpack`      Discrete Fourier transforms (legacy)
+`integrate`    Numerical integration
+`interpolate`  Interpolation
+`io`           Scientific data format reading and writing
+`linalg`       Linear algebra functionality
+`misc`         Utility routines (deprecated)
+`ndimage`      N-dimensional image processing and interpolation
+`odr`          Orthogonal distance regression
+`optimize`     Numerical optimization
+`signal`       Signal processing
+`sparse`       Sparse arrays, linear algebra and graph algorithms
+`spatial`      Spatial data structures and algorithms
+`special`      Special functions
+`stats`        Statistical functions
+=============  ==================================================

--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -18,6 +18,7 @@ Using any of these subpackages requires an explicit import. For example,
 ::
 
  cluster                      --- Vector Quantization / Kmeans
+ constants                    --- Physical and mathematical constants and units
  datasets                     --- Dataset methods
  fft                          --- Discrete Fourier transforms
  fftpack                      --- Legacy discrete Fourier transforms
@@ -25,36 +26,24 @@ Using any of these subpackages requires an explicit import. For example,
  interpolate                  --- Interpolation Tools
  io                           --- Data input and output
  linalg                       --- Linear algebra routines
- linalg.blas                  --- Wrappers to BLAS library
- linalg.lapack                --- Wrappers to LAPACK library
- misc                         --- Various utilities that don't have
-                                  another home.
+ misc                         --- Utilities that don't have another home.
  ndimage                      --- N-D image package
  odr                          --- Orthogonal Distance Regression
  optimize                     --- Optimization Tools
  signal                       --- Signal Processing Tools
- signal.windows               --- Window functions
  sparse                       --- Sparse Matrices
- sparse.linalg                --- Sparse Linear Algebra
- sparse.linalg.dsolve         --- Linear Solvers
- sparse.linalg.dsolve.umfpack --- :Interface to the UMFPACK library:
-                                  Conjugate Gradient Method (LOBPCG)
- sparse.linalg.eigen          --- Sparse Eigenvalue Solvers
- sparse.linalg.eigen.lobpcg   --- Locally Optimal Block Preconditioned
-                                  Conjugate Gradient Method (LOBPCG)
  spatial                      --- Spatial data structures and algorithms
  special                      --- Special functions
  stats                        --- Statistical Functions
 
-Utility tools
--------------
+Public API in the main SciPy namespace
+--------------------------------------
 ::
 
- test              --- Run scipy unittests
- show_config       --- Show scipy build configuration
- show_numpy_config --- Show numpy build configuration
  __version__       --- SciPy version string
- __numpy_version__ --- Numpy version string
+ LowLevelCallable  --- Low-level callback function
+ show_config       --- Show scipy build configuration
+ test              --- Run scipy unittests
 
 """
 
@@ -164,6 +153,7 @@ else:
 
     submodules = [
         'cluster',
+        'constants',
         'datasets',
         'fft',
         'fftpack',
@@ -187,7 +177,6 @@ else:
         'test',
         'show_config',
         '__version__',
-        '__numpy_version__'
     ]
 
     def __dir__():

--- a/scipy/_lib/_testutils.py
+++ b/scipy/_lib/_testutils.py
@@ -20,9 +20,34 @@ class FPUModeChangeWarning(RuntimeWarning):
 
 class PytestTester:
     """
-    Pytest test runner entry point.
-    """
+    Run tests for this namespace
 
+    ``scipy.test()`` runs tests for all of SciPy, with the default settings.
+    When used from a submodule (e.g., ``scipy.cluster.test()``, only the tests
+    for that namespace are run.
+
+    Parameters
+    ----------
+    label : {'fast', 'full'}, optional
+        Whether to run only the fast tests, or also those marked as slow.
+        Default is 'fast'.
+    verbose : int, optional
+        Test output verbosity. Default is 1.
+    extra_argv : list, optional
+        Arguments to pass through to Pytest.
+    doctests : bool, optional
+        Whether to run doctests or not. Default is False.
+    coverage : bool, optional
+        Whether to run tests with code coverage measurements enabled.
+        Default is False.
+    tests : list of str, optional
+        List of module names to run tests for. By default, uses the module
+        from which the ``test`` function is called.
+    parallel : int, optional
+        Run tests in parallel with pytest-xdist, if number given is larger than
+        1. Default is 1.
+
+    """
     def __init__(self, module_name):
         self.module_name = module_name
 


### PR DESCRIPTION
This PR was triggered by `show_config` missing from the docs completely (xref gh-17862). The main namespace does not contain much functionality, but it should have a page which lists what is public API in the main namespace.

The regular `.. autosummary` thing unfortunately wasn't usable here, Sphinx makes a mess with duplicate labels and docstrings. So I used a plain reST table for most entries.

The PR grew a bit - also noticed that `PytestTester` needed a docstring. And I'm commenting out some noisy output of `dev.py` that didn't land in the right place.

I'll note that the doc build will likely fail until gh-17862 is merged, because the current `show_config` docstring contains one invalid reference. I didn't fix that to avoid merge conflicts with gh-17862.