### PR TITLE
BUG: Fix handling on user-supplied filters in `signal.decimate`

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -4538,7 +4538,6 @@ def decimate(x, q, n=None, ftype='iir', axis=-1, zero_phase=True):
         sos = np.asarray(sos, dtype=result_type)
     elif isinstance(ftype, dlti):
         system = ftype._as_zpk()
-        print(system.poles.shape)
         if system.poles.shape[0] == 0:
             # FIR
             system = ftype._as_tf()


### PR DESCRIPTION
#### Reference issue

Fixes gh-17845.

#### What does this implement/fix?

Detect if user-supplied filter is FIR, and handle appropriately.

For complex-coefficient IIR filters, use `lfilter` and `filtfilt`, since `sosfilt` and `sosfiltfilt` don't handle complex coefficients.

#### Additional information

`filtfilt` doesn't handle complex coefficient filters correctly; see gh-17877.  Test added uses `filtfilt` to generate reference, so shouldn't need updating if that's fixed.  We could add an error or warning for this case in `decimate` until that is done.

Test suite passes locally (Ubuntu 20.04, x86_64, numpy 1.23.5, Python 3.10.8).