### PR TITLE
BLD: fix Meson build warnings about multiple targets

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,7 +2,7 @@ option('blas', type: 'string', value: 'openblas',
         description: 'option for BLAS library switching')
 option('lapack', type: 'string', value: 'openblas',
         description: 'option for LAPACK library switching')
-option('use-g77-abi', type: 'boolean', value: 'false',
+option('use-g77-abi', type: 'boolean', value: false,
         description: 'If set to true, forces using g77 compatibility wrappers ' +
                      'for LAPACK functions. The default is to use gfortran ' +
                      'ABI for all LAPACK libraries except MKL.')

--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -22,6 +22,17 @@ cython_linalg = custom_target('cython_linalg',
   install_dir: py3.get_install_dir() / 'scipy/linalg'
 )
 
+# This dummy custom target is only needed to establish a dependency on
+# cython_linalg in a generator below. Adding that dependency directly yields
+# warnings about multiple outputs. And using `depends: cython_linalg[2]` does
+# not work, because that generator depends does not accept CustomTargetIndex,
+# only CustomTarget. See https://github.com/mesonbuild/meson/issues/9837
+cython_blas_pxd = custom_target(
+  output: '_dummy_cython_blas.pxd',
+  input: cython_linalg[2],
+  command: [py3, '-c', '"@INPUT@"'],
+)
+
 # pyx -> c, pyx -> cpp generators, depending on __init__.py here.
 linalg_init_cython_gen = generator(cython,
   arguments : cython_args,
@@ -38,7 +49,7 @@ linalg_init_utils_cython_gen = generator(cython,
 linalg_cython_gen = generator(cython,
   arguments : cython_args,
   output : '@BASENAME@.c',
-  depends : [_cython_tree, __init__py, cython_linalg])
+  depends : [_cython_tree, __init__py, cython_blas_pxd])#, cython_linalg])
 
 # fblas
 fblas_module = custom_target('fblas_module',

--- a/scipy/optimize/meson.build
+++ b/scipy/optimize/meson.build
@@ -234,7 +234,7 @@ _dummy_init_optimize = fs.copyfile('__init__.py')
 opt_gen = generator(cython,
   arguments : cython_args,
   output : '@BASENAME@.c',
-  depends : [_cython_tree, cython_linalg, _dummy_init_optimize])
+  depends : [_cython_tree, cython_blas_pxd, _dummy_init_optimize])
 
 _bglu_dense_c = opt_gen.process('_bglu_dense.pyx')
 

--- a/scipy/special/meson.build
+++ b/scipy/special/meson.build
@@ -306,6 +306,14 @@ cython_special = custom_target('cython_special',
   install_dir: py3.get_install_dir() / 'scipy/special'
 )
 
+# Only needed to establish a dependency; see comments in linalg/meson.build
+# for cython_blas_pxd
+cython_special_pxd = custom_target('_dummy_cython_special.pxd',
+  output: '_dummy_cython_special.pxd',
+  input: cython_special[7],
+  command: [py3, '-c', '"@INPUT@"'],
+)
+
 # pyx -> c, pyx -> cpp generators, depending on copied pxi, pxd files.
 uf_cython_gen = generator(cython,
   arguments : cython_args,

--- a/scipy/stats/meson.build
+++ b/scipy/stats/meson.build
@@ -12,7 +12,7 @@ stats_special_cython_gen = generator(cython,
     _cython_tree,
     _ufuncs_pxi_pxd_sources,
     _stats_pxd,
-    cython_special])
+    cython_special_pxd])
 
 statlib_lib = static_library('statlib_lib',
   [
@@ -115,10 +115,18 @@ _stats_gen_pyx = custom_target('_stats_gen_pyx',
   depends: _stats_pxd
 )
 
+# Only needed to establish a dependency; see comments in linalg/meson.build
+# for cython_blas_pxd
+_stats_gen_pyx_dummy = custom_target('_dummy_stats_gen_pyx',
+  output: '_dummy_stats_gen.pxd',
+  input: _stats_gen_pyx[2],
+  command: [py3, '-c', '"@INPUT@"'],
+)
+
 cython_stats_gen_cpp = generator(cython,
   arguments : cython_cplus_args,
   output : '@BASENAME@.cpp',
-  depends : [_cython_tree, _stats_gen_pyx])
+  depends : [_cython_tree, _stats_gen_pyx_dummy])
 
 # Build recipes defined here to get correct output path when used from
 # other subdirs.


### PR DESCRIPTION
The fixed warnings looked like (many times these):
```
WARNING: custom_target 'cython_special' has more than one output! Using the first one. Consider using `cython_special[0]`.
WARNING: custom_target '_stats_gen_pyx' has more than one output! Using the first one. Consider using `_stats_gen_pyx[0]`.
WARNING: custom_target 'cython_linalg' has more than one output! Using the first one. Consider using `cython_linalg[0]`.
```

Also fix a small issue in `meson_options.txt` for which Meson now emits a deprecation warning.

This works around https://github.com/mesonbuild/meson/issues/9837. Getting that fixed in the future so we can directly use `cython_special[0]` or a similar `CustomTargetIndex` is still needed, but less urgent now that the warnings are silenced.