### PR TITLE
ENH: Warn about missing boundary when NOLA condition failed in ISTFT …

### DIFF
--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -1489,7 +1489,10 @@ def istft(Zxx, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
 
     # Divide out normalization where non-tiny
     if np.sum(norm > 1e-10) != len(norm):
-        warnings.warn("NOLA condition failed, STFT may not be invertible. " + ("Possibly due to missing boundary" if boundary else ""))
+        warnings.warn(
+            "NOLA condition failed, STFT may not be invertible."
+            + (" Possibly due to missing boundary" if boundary else "")
+        )
     x /= np.where(norm > 1e-10, norm, 1.0)
 
     if input_onesided:

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -1489,7 +1489,7 @@ def istft(Zxx, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
 
     # Divide out normalization where non-tiny
     if np.sum(norm > 1e-10) != len(norm):
-        warnings.warn("NOLA condition failed, STFT may not be invertible")
+        warnings.warn("NOLA condition failed, STFT may not be invertible. " + ("Possibly due to missing boundary" if boundary else ""))
     x /= np.where(norm > 1e-10, norm, 1.0)
 
     if input_onesided:

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -1491,7 +1491,7 @@ def istft(Zxx, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
     if np.sum(norm > 1e-10) != len(norm):
         warnings.warn(
             "NOLA condition failed, STFT may not be invertible."
-            + (" Possibly due to missing boundary" if boundary else "")
+            + (" Possibly due to missing boundary" if not boundary else "")
         )
     x /= np.where(norm > 1e-10, norm, 1.0)
 


### PR DESCRIPTION
Warn about missing boundary when NOLA condition failed. #17885

#### Reference issue
closes: #17885 

#### What does this implement/fix?
Add additional information to the warning message.