### PR TITLE
DOC: note about using the pre-commit hook on macOS and GUI

### DIFF
--- a/HACKING.rst.txt
+++ b/HACKING.rst.txt
@@ -91,6 +91,18 @@ tests, benchmarks, and correct code style.
 
       cp tools/pre-commit-hook.sh .git/hooks/pre-commit
 
+    .. note::
+
+        On macOS, `mapfile` is not available with the default Bash version
+        you need to install another Bash with `brew install bash`.
+        Then, modify the first line of `tools/pre-commit-hook.sh` with
+        the newly installed Bash's path: `#!/opt/homebrew/bin/bash`.
+        You can now run the copy command.
+
+        Also note that this hook will only work if you run `git commit` from
+        your activated environment. Supporting GUI tools would require
+        additional modifications. See comments in the pre-commit script.
+
     Alternatively, you may run the linter manually::
 
       python dev.py lint

--- a/doc/source/dev/contributor/pep8.rst
+++ b/doc/source/dev/contributor/pep8.rst
@@ -38,6 +38,18 @@ compliance before pushing your code:
 
    This will run linting checks before each commit is made.
 
+   .. note::
+
+       On macOS, `mapfile` is not available with the default Bash version
+       you need to install another Bash with `brew install bash`.
+       Then, modify the first line of `tools/pre-commit-hook.sh` with
+       the newly installed Bash's path: `#!/opt/homebrew/bin/bash`.
+       You can now run the copy command.
+
+       Also note that this hook will only work if you run `git commit` from
+       your activated environment. Supporting GUI tools would require
+       additional modifications. See comments in the pre-commit script.
+
    Alternatively, you can run the check manually from the SciPy root directory::
 
       python dev.py lint

--- a/tools/pre-commit-hook.sh
+++ b/tools/pre-commit-hook.sh
@@ -1,10 +1,18 @@
 #!/bin/bash
 #
+# on macOS install a newer version of Bash with `brew install bash`
+# then change the first line to #!/opt/homebrew/bin/bash
+#
 # Pre-commit linting hook.
 #
 # Install from root of repository with:
 #
 #   cp tools/pre-commit-hook.sh .git/hooks/pre-commit
+
+# If you are using GUI git tools. You also need to change the following:
+# GIT_DIR=$PWD/.git
+# export PATH=...PATH_TO_CONDA_ENV.../bin/:$PATH
+# python ../../tools/lint.py --fix --files "${changed[@]}" || ret=1
 
 # store names of files that were staged
 # add  '*.pxd', '*.pxi' once cython-lint supports it


### PR DESCRIPTION
On macOS we are stuck to Bash 3.x which is lacking `mapfile`. So I added some note about how to go around. I don't think we want to do more here, or we are really re-writing the pre-commit tool.

Also if using a GUI tool for git, we need to update the CWD and also load an env. I added some instructions as comment in the script. Again, doing all that automagically would really mean re-writing pre-commit.