### PR TITLE
DOC: config info in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_report.yml
@@ -32,6 +32,6 @@ body:
   - type: input
     attributes:
       label: SciPy/NumPy/Python version information
-      description: 'Please run the following and paste the result in a code block - `import sys, scipy, numpy; print(scipy.__version__, numpy.__version__, sys.version_info)`'
+      description: 'Please run the following and paste the result in a code block - `import scipy;scipy.show_config()` or on older versions `import sys, scipy, numpy; print(scipy.__version__, numpy.__version__, sys.version_info)`'
     validations:
       required: true


### PR DESCRIPTION
Now we have a new fancy output for `scipy.show_config` we can update the issue template to ask reporters to use this and improve our bug reporting.