### PR TITLE
DOC: interpolate: add a note against using triangulation based intrpolators on a regular grid

### DIFF
--- a/scipy/interpolate/_ndgriddata.py
+++ b/scipy/interpolate/_ndgriddata.py
@@ -50,6 +50,8 @@ class NearestNDInterpolator(NDInterpolatorBase):
     -----
     Uses ``scipy.spatial.cKDTree``
 
+    .. note:: For data on a regular grid use `interpn` instead.
+
     Examples
     --------
     We can interpolate values on a 2D plane:
@@ -173,7 +175,7 @@ def griddata(points, values, xi, method='linear', fill_value=np.nan,
 
     .. versionadded:: 0.9
 
-    For data on a regular grid use `interpn` instead.
+    .. note:: For data on a regular grid use `interpn` instead.
 
     Examples
     --------

--- a/scipy/interpolate/interpnd.pyx
+++ b/scipy/interpolate/interpnd.pyx
@@ -236,6 +236,8 @@ class LinearNDInterpolator(NDInterpolatorBase):
     with Qhull [1]_, and on each triangle performing linear
     barycentric interpolation.
 
+    .. note:: For data on a regular grid use `interpn` instead.
+
     Examples
     --------
     We can interpolate values on a 2D plane:
@@ -835,6 +837,8 @@ class CloughTocher2DInterpolator(NDInterpolatorBase):
     of the interpolating surface is approximatively minimized. The
     gradients necessary for this are estimated using the global
     algorithm described in [Nielson83]_ and [Renka84]_.
+
+    .. note:: For data on a regular grid use `interpn` instead.
 
     Examples
     --------


### PR DESCRIPTION
#### Reference issue
Attempting to close #17378

#### What does this implement/fix?
Increases clarity for 4 multivariate interpolation functions.
- scipy.interpolate.griddata
- scipy.interpolate.LinearNDInterpolator
- scipy.interpolate.NearestNDInterpolator
- scipy.interpolate.CloughTocher2DInterpolator

#### Additional information
Some tests failed on my local environment, but I was instructed to send a PR by [this message](https://github.com/scipy/scipy/issues/17378#issuecomment-1400684546).