### PR TITLE
DOC: stats.wilcoxon: warn about roundoff errors in x-y

### DIFF
--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -4038,7 +4038,7 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=False,
     >>> import numpy as np
     >>> x = np.array([0.5, 0.825, 0.375, 0.5])
     >>> y = np.array([0.525, 0.775, 0.325, 0.55])
-    >>> res = stats.wilcoxon(x, y, alternative='greater')
+    >>> res = wilcoxon(x, y, alternative='greater')
     >>> res
     WilcoxonResult(statistic=5.0, pvalue=0.5625)
 
@@ -4046,7 +4046,7 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=False,
     produced different results:
 
     >>> d = [-0.025, 0.05, 0.05, -0.05]
-    >>> ref = stats.wilcoxon(d, alternative='greater')
+    >>> ref = wilcoxon(d, alternative='greater')
     >>> ref
     WilcoxonResult(statistic=6.0, pvalue=0.4375)
 
@@ -4064,7 +4064,7 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=False,
     For example:
 
     >>> d2 = np.around(x - y, decimals=3)
-    >>> stats.wilcoxon(d2, alternative='greater')
+    >>> wilcoxon(d2, alternative='greater')
     WilcoxonResult(statistic=6.0, pvalue=0.4375)
 
     """

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -3880,6 +3880,17 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=False,
         Either the second set of measurements (if ``x`` is the first set of
         measurements), or not specified (if ``x`` is the differences between
         two sets of measurements.)  Must be one-dimensional.
+
+        .. warning::
+            When `y` is provided, `wilcoxon` calculates the test statistic
+            based on the ranks of the absolute values of ``d = x - y``.
+            Roundoff error in the subtraction can result in elements of ``d``
+            being assigned different ranks even when they would be tied with
+            exact arithmetic. Rather than passing `x` and `y` separately,
+            consider computing the difference ``x - y``, rounding as needed to
+            ensure that only truly unique elements are numerically distinct,
+            and passing the result as `x`, leaving `y` at the default (None).
+
     zero_method : {"wilcox", "pratt", "zsplit"}, optional
         There are different conventions for handling pairs of observations
         with equal values ("zero-differences", or "zeros").
@@ -4019,6 +4030,43 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=False,
     of ranks of positive differences) whereas it is 24 in the two-sided
     case (the minimum of sum of ranks above and below zero).
 
+    In the example above, the differences in height between paired plants are
+    provided to `wilcoxon` directly. Alternatively, `wilcoxon` accepts two
+    samples of equal length, calculates the differences between paired
+    elements, then performs the test. Consider the samples ``x`` and ``y``:
+
+    >>> import numpy as np
+    >>> x = np.array([0.5, 0.825, 0.375, 0.5])
+    >>> y = np.array([0.525, 0.775, 0.325, 0.55])
+    >>> res = stats.wilcoxon(x, y, alternative='greater')
+    >>> res
+    WilcoxonResult(statistic=5.0, pvalue=0.5625)
+
+    Note that had we calculated the differences by hand, the test would have
+    produced different results:
+
+    >>> d = [-0.025, 0.05, 0.05, -0.05]
+    >>> ref = stats.wilcoxon(d, alternative='greater')
+    >>> ref
+    WilcoxonResult(statistic=6.0, pvalue=0.4375)
+
+    The substantial difference is due to roundoff error in the results of
+    ``x-y``:
+
+    >>> d - (x-y)
+    array([2.08166817e-17, 6.93889390e-17, 1.38777878e-17, 4.16333634e-17])
+
+    Even though we expected all the elements of ``(x-y)[1:]`` to have the same
+    magnitude ``0.05``, they have slightly different magnitudes in practice,
+    and therefore are assigned different ranks in the test. Before performing
+    the test, consider calculating ``d`` and adjusting it as necessary to
+    ensure that theoretically identically values are not numerically distinct.
+    For example:
+
+    >>> d2 = np.around(x - y, decimals=3)
+    >>> stats.wilcoxon(d2, alternative='greater')
+    WilcoxonResult(statistic=6.0, pvalue=0.4375)
+
     """
     mode = method
 
@@ -4043,6 +4091,8 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=False,
             raise ValueError('Samples x and y must be one-dimensional.')
         if len(x) != len(y):
             raise ValueError('The samples x and y must have the same length.')
+        # Future enhancement: consider warning when elements of `d` appear to
+        # be tied but are numerically distinct.
         d = x - y
 
     if len(d) == 0:


### PR DESCRIPTION
#### Reference issue
Closes gh-17667

#### What does this implement/fix?
gh-17667 noted that roundoff errors in `x - y` can cause different results in `stats.wilcoxon`.  This is the doc-only solution, which adds a warning and example so that users know to process their data appropriately before passing it to `stats.wilcoxon`.
