### PR TITLE
ENH: improve accuracy of betaprime ppf in scipy.stats

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -906,6 +906,7 @@ class betaprime_gen(rv_continuous):
             f2=lambda x_, a_, b_: beta._cdf(x_/(1+x_), a_, b_))
 
     def _ppf(self, p, a, b):
+        p, a, b = np.broadcast_arrays(p, a, b)
         # by default, compute compute the ppf by solving the following:
         # p = beta._cdf(x/(1+x), a, b). This implies x = r/(1-r) with
         # r = beta._ppf(p, a, b). This can cause numerical issues if r is

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -930,6 +930,9 @@ class betaprime_gen(rv_continuous):
             )
             return out
 
+        # needed to avoid TypeError when casting float64 to float32
+        # (check_ppf_dtype in tests/test_continuous_basic.py)
+        p = np.asarray(p, dtype=float)
         out = _lazywhere(
             p < 0.5, [p, a, b],
             _ppf_direct,
@@ -937,7 +940,7 @@ class betaprime_gen(rv_continuous):
                 p_ < 1,
                 [p_, a_, b_],
                 lambda p1, a1, b1: 1/stats.beta.isf(p1, b1, a1) - 1,
-            fillvalue=np.inf)
+                fillvalue=np.inf)
         )
         return out
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -936,11 +936,7 @@ class betaprime_gen(rv_continuous):
         out = _lazywhere(
             p < 0.5, [p, a, b],
             _ppf_direct,
-            f2=lambda p_, a_, b_: _lazywhere(
-                p_ < 1,
-                [p_, a_, b_],
-                lambda p1, a1, b1: 1/stats.beta.isf(p1, b1, a1) - 1,
-                fillvalue=np.inf)
+            f2=lambda p_, a_, b_: 1/stats.beta.isf(p_, b_, a_) - 1
         )
         return out
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -916,6 +916,7 @@ class betaprime_gen(rv_continuous):
             out =  r / (1 - r)
         i = (r > 0.9999)
         out[i] = 1/stats.beta._isf(p[i], b[i], a[i]) - 1
+        return out
 
     def _munp(self, n, a, b):
         if n == 1.0:

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3682,6 +3682,37 @@ class TestBetaPrime:
         x = stats.betaprime.ppf(p, a, b)
         assert_allclose(x, expected, rtol=1e-14)
 
+    def test_ppf_boundary(self):
+        # p == 0 and p == 1.0 need to map to 0.0 and inf
+        # for p == 1.0, division by zero must not occur
+        assert_equal(stats.betaprime.ppf(0.0, 1.3, 0.1), 0.0)
+        assert_equal(stats.betaprime.ppf(1.0, 1.3, 0.1), np.inf)
+
+    @pytest.mark.parametrize(
+        'p, a, b, expected, tol',
+        [(0.9978811466052919, 0.05, 0.1, 1e22, 1e-12),
+         (0.8973027435427167, 100.0, 0.05, 1e22, 1e-14),
+         (0.38019826239901977, 10, 0.01, 1e22, 1e-13),
+         (0.9467768090820048, 0.05, 0.1, 1e8, 1e-14),
+         (0.9999999999983024, 1.5, 1.5, 1e8, 1e-5),
+         (0.4852944858726726, 100.0, 0.05, 1e8, 1e-14),
+         (0.9999966641709545, 0.05, 0.1, 1e50, 1e-1),
+         (0.995925162631006, 100.0, 0.05, 1e50, 1e-1),
+         (0.21238845427095, 0.05, 0.1, 1e-10, 1e-14),
+         (1.697652726007973e-15, 1.5, 1.5, 1e-10, 1e-14),
+         (0.40884514172337383, 0.05, 100.0, 1e-10, 1e-14),
+         (0.053349567649287326, 0.05, 0.1, 1e-22, 1e-14),
+         (1.6976527263135503e-33, 1.5, 1.5, 1e-22, 1e-14),
+         (0.10269725645728331, 0.05, 100.0, 1e-22, 1e-14),
+         (6.7163126421919795e-06, 0.05, 0.1, 1e-100, 1e-14),
+         (1.6976527263135503e-150, 1.5, 1.5, 1e-100, 1e-14),
+         (1.2928818587561651e-05, 0.05, 100.0, 1e-100, 1e-14)])
+    def test_ppf_tails(self, p, a, b, expected, tol):
+        # additional test cases for ppf for gh-17631
+        # the value p is computed as cdf(x, a, p) with the cdf
+        # defined as in self.test_cdf_tails below
+        assert_allclose(stats.betaprime.ppf(p, a, b), expected, rtol=tol)
+
     @pytest.mark.parametrize(
         'x, a, b, expected',
         [(1e22, 0.05, 0.1, 0.9978811466052919),


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes gh-17631

#### What does this implement/fix?
Improve numerical accuracy of the ppf of betaprime.

#### Additional information
Follow-up of gh-17834 (improve the cdf). I tried to explain the approach in the comments.
