### PR TITLE
CI: use nightly numpy musllinux_x86_64 wheel

### DIFF
--- a/ci/cirrus_general_ci.yml
+++ b/ci/cirrus_general_ci.yml
@@ -97,7 +97,7 @@ musllinux_amd64_test_task:
   python_dependencies_script: |
     cd $_CWD
     python -m pip install cython
-    python -m pip install -vvv --upgrade numpy    
+    pip install --upgrade --pre -i https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
     python -m pip install meson ninja pybind11 pythran pytest
     python -m pip install click rich_click doit pydevtool pooch
 


### PR DESCRIPTION
numpy just added a nightly wheel for musllinux_x86_64. We should use this in `cirrus_general_ci` CI run instead of building it ourselves (less resources and we keep up to date). This won't succeed just yet, have to wait for the next numpy wheel building run.