### PR TITLE
DOC: Add warning to butter function docstring

### DIFF
--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -3050,8 +3050,9 @@ def butter(N, Wn, btype='low', analog=False, output='ba', fs=None):
 
     .. warning::
         Designing high-order and narrowband IIR filters in TF form can
-        result in unstable or incorrect filtering due to floating point numerical precision issues.
-        Consider inspecting output filter characteristics `freqz` or designing the filters with second-order
+        result in unstable or incorrect filtering due to floating point
+        numerical precision issues. Consider inspecting output filter
+        characteristics `freqz` or designing the filters with second-order
         sections via ``output='sos'``.
 
     Examples

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -3048,6 +3048,12 @@ def butter(N, Wn, btype='low', analog=False, output='ba', fs=None):
     even for N >= 4. It is recommended to work with the SOS
     representation.
 
+    .. warning::
+        Designing high-order and narrowband IIR filters in TF form can
+        result in unstable or incorrect filtering due to floating point numerical precision issues.
+        Consider inspecting output filter characteristics `freqz` or designing the filters with second-order
+        sections via ``output='sos'``.
+
     Examples
     --------
     Design an analog filter and plot its frequency response, showing the


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes [8485](https://github.com/scipy/scipy/issues/8485)

#### What does this implement/fix?
<!--Please explain your changes.-->
Adds warning to butter function against use of high-order narrowband IIR filter

