### PR TITLE
BUG: Fix error in linalg/_matfuncs_sqrtm.py

### DIFF
--- a/scipy/linalg/_matfuncs_sqrtm.py
+++ b/scipy/linalg/_matfuncs_sqrtm.py
@@ -172,7 +172,7 @@ def sqrtm(A, disp=True, blocksize=64):
     keep_it_real = np.isrealobj(A)
     if keep_it_real:
         T, Z = schur(A)
-        if not np.array_equal(T, np.triu(T)):
+        if not np.allclose(T, np.triu(T)):
             T, Z = rsf2csf(T, Z)
     else:
         T, Z = schur(A, output='complex')


### PR DESCRIPTION
bugfix: manage unexpected conversion to complex matrix during computation of square root matrix

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
"Complex matrix square root of positive semi-definite matrix https://github.com/scipy/scipy/issues/12247"

#### What does this implement/fix?
<!--Please explain your changes.-->
Fix  bug when computing complex matrix square root of positive semi-definite matrix. 
Positive semi-definite matrix became complex after sqrt() execution.

#### Additional information
<!--Any additional information you think is important.-->