### PR TITLE
CI: clean conda index upon cache invalidation

### DIFF
--- a/.github/workflows/macos_meson.yml
+++ b/.github/workflows/macos_meson.yml
@@ -74,7 +74,7 @@ jobs:
         channels: conda-forge
         channel-priority: true
         activate-environment: scipy-dev
-        use-only-tar-bz2: true
+        use-only-tar-bz2: false
         miniforge-variant: Mambaforge
         miniforge-version: latest
         use-mamba: true

--- a/.github/workflows/macos_meson.yml
+++ b/.github/workflows/macos_meson.yml
@@ -96,7 +96,9 @@ jobs:
       id: envcache
 
     - name: Update Conda Environment
-      run: mamba env update -n scipy-dev -f environment.yml
+      run: |
+        conda clean --index-cache --yes
+        mamba env update -n scipy-dev -f environment.yml
       if: steps.envcache.outputs.cache-hit != 'true'
 
     - name: Build and Install SciPy

--- a/.github/workflows/macos_meson.yml
+++ b/.github/workflows/macos_meson.yml
@@ -98,7 +98,8 @@ jobs:
     - name: Update Conda Environment
       run: |
         conda clean --index-cache --yes
-        mamba env update -n scipy-dev -f environment.yml
+        mamba env remove -n scipy-dev --yes
+        mamba env create -f environment.yml
       if: steps.envcache.outputs.cache-hit != 'true'
 
     - name: Build and Install SciPy

--- a/.github/workflows/macos_meson.yml
+++ b/.github/workflows/macos_meson.yml
@@ -96,10 +96,7 @@ jobs:
       id: envcache
 
     - name: Update Conda Environment
-      run: |
-        conda clean --index-cache --yes
-        mamba env remove -n scipy-dev --yes
-        mamba env create -f environment.yml
+      run: mamba env update -n scipy-dev -f environment.yml
       if: steps.envcache.outputs.cache-hit != 'true'
 
     - name: Build and Install SciPy


### PR DESCRIPTION
As seen in recent logs, it seems like when cache is invalidated, the index could also be cached an cause resolve issues.

https://github.com/scipy/scipy/actions/runs/4075996433/jobs/7023135535

This is an attempt at fixing it.