### PR TITLE
DOC: corrected doc of bilinear discretization of lti

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -502,3 +502,4 @@ Xingyu Liu <38244988+charlotte12l@users.noreply.github.com> 刘星雨 <liuxingyu
 Yu Feng <rainwoodman@gmail.com> Yu Feng <yfeng1@waterfall.dyn.berkeley.edu>
 Yves-Rémi Van Eycke <yves-remi@hotmail.com> vanpact <yves-remi@hotmail.com>
 Zé Vinícius <jvmirca@gmail.com> Ze Vinicius <jvmirca@gmail.com>
+Zoufiné Lauer-Bare <raszoufine@gmail.com> 

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -2095,7 +2095,7 @@ def bilinear(b, a, fs=1.0):
     Return a digital IIR filter from an analog one using a bilinear transform.
 
     Transform a set of poles and zeros from the analog s-plane to the digital
-    z-plane using Tustin's method, which substitutes ``(z-1) / (z+1)`` for
+    z-plane using Tustin's method, which substitutes ``2*fs*(z-1) / (z+1)`` for
     ``s``, maintaining the shape of the frequency response.
 
     Parameters

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -2615,7 +2615,7 @@ def bilinear_zpk(z, p, k, fs):
     Return a digital IIR filter from an analog one using a bilinear transform.
 
     Transform a set of poles and zeros from the analog s-plane to the digital
-    z-plane using Tustin's method, which substitutes ``(z-1) / (z+1)`` for
+    z-plane using Tustin's method, which substitutes ``2*fs*(z-1) / (z+1)`` for
     ``s``, maintaining the shape of the frequency response.
 
     Parameters


### PR DESCRIPTION


<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #17911

#### What does this implement/fix?

The Tustin formula in

https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.bilinear.html

is described as ```(z-1) / (z+1)```

but it should be ```fs*2*(z-1) / (z+1)```

#### Additional information
https://en.wikipedia.org/wiki/Bilinear_transform
