### PR TITLE
TST: test_location_scale proper 32bit Linux skip

### DIFF
--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -4532,7 +4532,7 @@ class TestLevyStable:
         """
 
         uname = platform.uname()
-        is_linux_32 = uname.system == 'Linux' and uname.machine == 'i686'
+        is_linux_32 = uname.system == 'Linux' and "32bit" in platform.architecture()[0]
         # Test seems to be unstable (see gh-17839 for a bug report on Debian
         # i386), so skip it.
         if is_linux_32 and case == 'pdf':


### PR DESCRIPTION
* the test skip was not being applied properly for `test_location_scale()` per the Debian report in gh-17839; I reproduced in a `i386/debian` Docker container that was running a 32-bit interpreter on a 64-bit base machine

* the adjustment used here allows the test to skip properly when using a 32-bit interpreter, even on a 64-bit machine

* as an aside, I'm pretty sure we do this kind of logic in many different places in NumPy and SciPy, sometimes using `sys.maxsize` instead, etc.