### PR TITLE
TST: 32-bit tol for test_pdist_jensenshannon_iris

### DIFF
--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -1160,7 +1160,7 @@ class TestPdist:
     def test_pdist_jensenshannon_iris(self):
         if _is_32bit():
             # Test failing on 32-bit Linux on Azure otherwise, see gh-12810
-            eps = 1.5e-10
+            eps = 2.5e-10
         else:
             eps = 1e-12
 


### PR DESCRIPTION
* I noticed a slight tolerance issue here on `i386/debian` while investigating gh-17839

* note that we previously bumped the tolerance on this test around two years ago in gh-12810

[skip circle] [skip azp] [skip cirrus]
