### PR TITLE
ENH: special: add complex-valued `trigamma` and `tetragamma` support

### DIFF
--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -435,6 +435,8 @@ Gamma and related functions
    polygamma    -- Polygamma function n.
    multigammaln -- Returns the log of multivariate gamma, also sometimes called the generalized gamma.
    digamma      -- psi(x[, out]).
+   trigamma     -- polygamma(1, x).
+   tetragamma   -- polygamma(2, x).
    poch         -- Rising factorial (z)_m.
 
 Error function and Fresnel integrals

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -4114,6 +4114,22 @@ class TestPolygamma:
         assert_allclose(special.polygamma(0, x), special.psi(x),
                         atol=1.5e-7, rtol=0)
 
+        # Test complex trigamma(z) and tetragamma(z)
+        z = [-1+2j, 0.5+0.1j, 100+1000j, -10+1000j, -10-1000j]
+        # values from mpmath.psi(1, z), mpmath.psi(2, z)
+        cexpected1 = [-0.245068837859055 - 0.31782555014723j,
+            4.47809863329661 - 1.56159416419215j,
+            9.85246060778847e-5 - 9.901968825938283e-4j,
+            -1.04988451266512e-5 - 9.998898454319752e-4j,
+            -1.04988451266512e-5 + 9.998898454319752e-4j]
+        cexpected2 = [0.0390243540536495 - 0.157432524041303j,
+            -13.328673738077 + 8.55964691468135j,
+            9.70782843658137e-7 + 1.95117547163695e-7j,
+            9.9966956049056e-7 - 2.09953807598792e-8j,
+            9.9966956049056e-7 + 2.09953807598792e-8j]
+        assert_almost_equal(special.polygamma(1, z), cexpected1)
+        assert_almost_equal(special.polygamma(2, z), cexpected2)
+
         # Test broadcasting
         n = [0, 1, 2]
         x = [0.5, 1.5, 2.5]


### PR DESCRIPTION
# scipy/special: Add complex-valued trigamma and tetragamma support
* Add complex-valued trigamma and tetragamma support
* Add tests
* Implements https://github.com/scipy/scipy/issues/7410

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes https://github.com/scipy/scipy/issues/7410

#### What does this implement/fix?
Adds complex-valued support for the trigamma and tetragamma functions. Complex-valued support currently exists for the digamma, but not higher order polygamy functions in `spicy.special`.

