### PR TITLE
BUG: Use raw strings for paths in `__config__.py.in`

### DIFF
--- a/scipy/__config__.py.in
+++ b/scipy/__config__.py.in
@@ -17,7 +17,7 @@ def _cleanup(d):
     This ensures we remove values that Meson could not provide to CONFIG
     """
     if isinstance(d, dict):
-        return { k: _cleanup(v) for k, v in d.items() if v and _cleanup(v) }
+        return { k: _cleanup(v) for k, v in d.items() if v != '' and _cleanup(v) != '' }
     else:
         return d
 
@@ -51,7 +51,7 @@ CONFIG = _cleanup(
             },
             "pythran": {
                 "version": "@PYTHRAN_VERSION@",
-                "include directory": "@PYTHRAN_INCDIR@"
+                "include directory": r"@PYTHRAN_INCDIR@"
             },
         },
         "Machine Information": {
@@ -67,32 +67,32 @@ CONFIG = _cleanup(
                 "endian": "@BUILD_CPU_ENDIAN@",
                 "system": "@BUILD_CPU_SYSTEM@",
             },
-            "cross-compiled": "@CROSS_COMPILED@",
+            "cross-compiled": bool("@CROSS_COMPILED@".lower().replace('false', '')),
         },
         "Build Dependencies": {
             "blas": {
                 "name": "@BLAS_NAME@",
-                "found": "@BLAS_FOUND@",
+                "found": bool("@BLAS_FOUND@".lower().replace('false', '')),
                 "version": "@BLAS_VERSION@",
                 "detection method": "@BLAS_TYPE_NAME@",
-                "include directory": "@BLAS_INCLUDEDIR@",
-                "lib directory": "@BLAS_LIBDIR@",
+                "include directory": r"@BLAS_INCLUDEDIR@",
+                "lib directory": r"@BLAS_LIBDIR@",
                 "openblas configuration": "@BLAS_OPENBLAS_CONFIG@",
-                "pc file directory": "@BLAS_PCFILEDIR@",
+                "pc file directory": r"@BLAS_PCFILEDIR@",
             },
             "lapack": {
                 "name": "@LAPACK_NAME@",
-                "found": "@LAPACK_FOUND@",
+                "found": bool("@LAPACK_FOUND@".lower().replace('false', '')),
                 "version": "@LAPACK_VERSION@",
                 "detection method": "@LAPACK_TYPE_NAME@",
-                "include directory": "@LAPACK_INCLUDEDIR@",
-                "lib directory": "@LAPACK_LIBDIR@",
+                "include directory": r"@LAPACK_INCLUDEDIR@",
+                "lib directory": r"@LAPACK_LIBDIR@",
                 "openblas configuration": "@LAPACK_OPENBLAS_CONFIG@",
-                "pc file directory": "@LAPACK_PCFILEDIR@",
+                "pc file directory": r"@LAPACK_PCFILEDIR@",
             },
         },
         "Python Information": {
-            "path": "@PYTHON_PATH@",
+            "path": r"@PYTHON_PATH@",
             "version": "@PYTHON_VERSION@",
         },
     }


### PR DESCRIPTION
#### Reference issue
resolves #17934

#### What does this implement/fix?

* `\U` leads to strings being treated as unicode, hence we escape it with raw strings
* Changed bool parameters to real bools instead of string `"True"` and `"False"`

#### Additional information
- Regression caused in https://github.com/scipy/scipy/pull/17862
- I see the above issue marked as `[backport-candidate]`, please mark this for backport as well (I cannot add labels)