### PR TITLE
DOC: Update pip + venv instructions in the contributor documentation to include missing dependencies

### DIFF
--- a/doc/source/dev/contributor/ubuntu_guide.rst
+++ b/doc/source/dev/contributor/ubuntu_guide.rst
@@ -112,7 +112,7 @@ Building SciPy
 
 Inside the ``scipy-dev`` environment, install the python-level dependencies::
 
-    python -m pip install numpy pytest cython pythran pybind11 meson ninja
+    python -m pip install numpy pytest cython pythran pybind11 meson ninja pydevtool rich-click
 
 Note that when the virtual environment is active, the system-wide names ``pip3``
 and ``python3`` are aliased to ``pip`` and ``python``, respectively.

--- a/doc/source/dev/contributor/ubuntu_guide.rst
+++ b/doc/source/dev/contributor/ubuntu_guide.rst
@@ -93,10 +93,9 @@ Install the ``venv`` package::
 
     sudo apt install -y python3-venv
 
-Change the directory to your home folder and create a directory ``.venvs`` there.
-Create the virtualenvironment::
+Create a virtual environment within ``$HOME/.venvs``::
 
-    python3 -m venv scipy-dev
+    python3 -m venv $HOME/.venvs/scipy-dev
 
 To activate the environment, use ::
 

--- a/doc/source/dev/dev_quickstart.rst
+++ b/doc/source/dev/dev_quickstart.rst
@@ -75,7 +75,7 @@ Next, set up your development environment.
         .. code:: bash
 
             # Create the virtual environment
-            python -m venv scipy-dev
+            python -m venv $HOME/.venvs/scipy-dev
             # Activate the environment
             source $HOME/.venvs/scipy-dev/bin/activate
             # Install python-level dependencies

--- a/doc/source/dev/dev_quickstart.rst
+++ b/doc/source/dev/dev_quickstart.rst
@@ -79,7 +79,7 @@ Next, set up your development environment.
             # Activate the environment
             source $HOME/.venvs/scipy-dev/bin/activate
             # Install python-level dependencies
-            python -m pip install numpy pytest cython pythran pybind11 meson ninja
+            python -m pip install numpy pytest cython pythran pybind11 meson ninja pydevtool rich-click
 
         Your command prompt now lists the name of your new environment, like so
         ``(scipy-dev)$``.


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue

Addresses documentation build errors discussed in https://github.com/scipy/scipy/issues/17819#issuecomment-1413275216 as part of #17819. 
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

This pull request adds missing Python package dependencies to the `pip` + `venv` instructions in both the "Development environment guide (Ubuntu)" and "Contributor quickstart guide" so that the build instructions execute successfully.

In addition, this pull request fixes a minor error in the virtual environment creation step of the `pip` + `venv` instructions in the "Contributor quickstart guide", and modifies the `python -m venv` commands in both the "Contributor quickstart guide" as well as the "Development environment guide (Ubuntu)" to use absolute paths. It's easy to overlook an instruction like "Change the directory to your home folder and create a directory `.venvs` there" when debugging the "Contributor quickstart guide" directions. A beneficial side effect of using absolute paths in the `python -m venv` commands is that potential contributors that copy the terminal commands without paying close attention to the surrounding text are less likely to create inadvertently a virtual environment within their local copy of the SciPy repository.

#### Additional information
<!--Any additional information you think is important.-->
It might be a good idea to recommend that users install `pooch` in the virtual environment provisioning step because running `python dev.py test` will emit errors unless `pooch` is installed, and attempting to build the project documentation will emit several warnings unless `pooch` is installed.