### PR TITLE
DOC: ttest_ind_from_stats: discuss negative stdev

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -7029,6 +7029,12 @@ def ttest_ind_from_stats(mean1, std1, nobs1, mean2, std2, nobs2,
     standard error. Therefore, the statistic will be positive when `mean1` is
     greater than `mean2` and negative when `mean1` is less than `mean2`.
 
+    This method does not check whether any of the elements of `std1` or `std2`
+    are negative. If any elements of the `std1` or `std2` parameters are
+    negative in a call to this method, this method will return the same result
+    as if it were passed ``numpy.abs(std1)`` and ``numpy.abs(std2)``,
+    respectively, instead; no exceptions or warnings will be emitted.
+
     References
     ----------
     .. [1] https://en.wikipedia.org/wiki/T-test#Independent_two-sample_t-test


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes gh-17819.

#### What does this implement/fix?
<!--Please explain your changes.-->

Following discussion in gh-17819, this commit adds a remark to the `scipy.stats.ttest_ind_from_stats` method regarding its behavior when passed a negative standard deviation in any element of either of its standard deviation arguments (`std1` or `std2`).

While it is unlikely that a user would intentionally pass negative values in those arguments, it is possible for a user to pass such values unwittingly.

Signed-off-by: Geoffrey M. Oxberry <goxberry@gmail.com>

#### Additional information
<!--Any additional information you think is important.-->
None that I can think of.