### PR TITLE
BUG: `rng_integers` in `_random_cd` now samples on a closed interval of 0 to d - 1 or n - 1

### DIFF
--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -2290,9 +2290,9 @@ def _random_cd(
     while n_nochange_ < n_nochange and n_iters_ < n_iters:
         n_iters_ += 1
 
-        col = rng_integers(rng, *bounds[0])
-        row_1 = rng_integers(rng, *bounds[1])
-        row_2 = rng_integers(rng, *bounds[2])
+        col = rng_integers(rng, *bounds[0], endpoint=True)
+        row_1 = rng_integers(rng, *bounds[1], endpoint=True)
+        row_2 = rng_integers(rng, *bounds[2], endpoint=True)
         disc = _perturb_discrepancy(best_sample,
                                     row_1, row_2, col,
                                     best_disc)

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -2290,9 +2290,9 @@ def _random_cd(
     while n_nochange_ < n_nochange and n_iters_ < n_iters:
         n_iters_ += 1
 
-        col = rng_integers(rng, *bounds[0], endpoint=True)
-        row_1 = rng_integers(rng, *bounds[1], endpoint=True)
-        row_2 = rng_integers(rng, *bounds[2], endpoint=True)
+        col = rng_integers(rng, *bounds[0], endpoint=True)  # type: ignore[misc]
+        row_1 = rng_integers(rng, *bounds[1], endpoint=True)  # type: ignore[misc]
+        row_2 = rng_integers(rng, *bounds[2], endpoint=True)  # type: ignore[misc]
         disc = _perturb_discrepancy(best_sample,
                                     row_1, row_2, col,
                                     best_disc)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

This closes gh-17938, and the code provided in that issue runs without exception on this branch.  

#### What does this implement/fix?
<!--Please explain your changes.-->

Previously, the calls to `rng_integers` in `_random_cd` sampled on the half-open interval, causing them to actually sample between 0 and upper bound - 2.

#### Additional information
<!--Any additional information you think is important.-->

CC @tupui 
