### PR TITLE
ENH: early exit random-cd optimization in 1D

### DIFF
--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -2276,6 +2276,10 @@ def _random_cd(
     if d == 0 or n == 0:
         return np.empty((n, d))
 
+    if d == 1:
+        # discrepancy measures are invariant under permuting factors and runs
+        return best_sample
+
     best_disc = discrepancy(best_sample)
 
     if n == 1:

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -2276,14 +2276,11 @@ def _random_cd(
     if d == 0 or n == 0:
         return np.empty((n, d))
 
-    if d == 1:
+    if d == 1 or n == 1:
         # discrepancy measures are invariant under permuting factors and runs
         return best_sample
 
     best_disc = discrepancy(best_sample)
-
-    if n == 1:
-        return best_sample
 
     bounds = ([0, d - 1],
               [0, n - 1],

--- a/scipy/stats/tests/test_qmc.py
+++ b/scipy/stats/tests/test_qmc.py
@@ -693,6 +693,16 @@ class TestLHS(QMCEngineTests):
                 res_set = {tuple(row) for row in res}
                 assert_equal(res_set, desired)
 
+    def test_optimizer_1d(self):
+        # discrepancy measures are invariant under permuting factors and runs
+        engine = self.engine(d=1, scramble=False)
+        sample_ref = engine.random(n=64)
+
+        optimal_ = self.engine(d=1, scramble=False, optimization="random-CD")
+        sample_ = optimal_.random(n=64)
+
+        assert_array_equal(sample_ref, sample_)
+
     def test_raises(self):
         message = r"not a valid strength"
         with pytest.raises(ValueError, match=message):


### PR DESCRIPTION
Follow up of #17940 

The previous PR correctly fix the general issue of sampling rows and columns from the wholes sample, including the last row and the last column.

In the 1D case, we can go further and directly return as the centered discrepancy is invariant to sample ordering. (From Fang2006 in our refs, criteria known as C1.) This is not a bug fix as the current implementation would just try to swap the order of the 1D sample which would result in the same discrepancy (small differences are most likely numerical noise as I measured differences in the order of 1e-14, hence close to machine resolution).

This adds an early exit condition and also a test.

Thanks Matt for pointing this out!
