### PR TITLE
ENH: Maxwell distribution `sf`/`isf` override

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -6047,6 +6047,12 @@ class maxwell_gen(rv_continuous):
     def _ppf(self, q):
         return np.sqrt(2*sc.gammaincinv(1.5, q))
 
+    def _sf(self, x):
+        return sc.gammaincc(1.5, x*x/2.0)
+
+    def _isf(self, q):
+        return np.sqrt(2*sc.gammainccinv(1.5, q))
+
     def _stats(self):
         val = 3*np.pi-8
         return (2*np.sqrt(2.0/np.pi),

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -6091,6 +6091,27 @@ class TestTriang:
             assert_equal(stats.triang.cdf(1., 1.), 1)
 
 
+class TestMaxwell:
+
+    # reference values were computed with wolfram alpha
+    # erfc(x/sqrt(2)) + sqrt(2/pi) * x * e^(-x^2/2)
+
+    @pytest.mark.parametrize("x, ref",
+                             [(20, 2.2138865931011177e-86),
+                              (0.01, 0.999999734046458435)])
+    def test_sf(self, x, ref):
+        assert_allclose(stats.maxwell.sf(x), ref, rtol=1e-14)
+
+    # reference values were computed with wolfram alpha
+    # sqrt(2) * sqrt(Q^(-1)(3/2, q))
+
+    @pytest.mark.parametrize("q, ref",
+                             [(0.001, 4.033142223656157022),
+                              (0.99999, 0.0335049635129162318)])
+    def test_isf(self, q, ref):
+        assert_allclose(stats.maxwell.isf(q), ref, rtol=5e-12)
+
+
 class TestMielke:
     def test_moments(self):
         k, s = 4.642, 0.597

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -6107,9 +6107,10 @@ class TestMaxwell:
 
     @pytest.mark.parametrize("q, ref",
                              [(0.001, 4.033142223656157022),
-                              (0.99999, 0.0335049635129162318)])
+                              (0.9999847412109375, 0.0385743284050381),
+                              (2**-55, 8.95564974719481)])
     def test_isf(self, q, ref):
-        assert_allclose(stats.maxwell.isf(q), ref, rtol=5e-12)
+        assert_allclose(stats.maxwell.isf(q), ref, rtol=1e-15)
 
 
 class TestMielke:


### PR DESCRIPTION
#### Reference issue
Low-hanging fruit part of #17832 

#### What does this implement/fix?
Overrides survival function and inverse survival function for the Maxwell distribution to improve precision in the tails.

