### PR TITLE
TST: Update list of modules for import cycle checks

### DIFF
--- a/scipy/_lib/tests/test_import_cycles.py
+++ b/scipy/_lib/tests/test_import_cycles.py
@@ -1,53 +1,20 @@
 import sys
 import subprocess
+import pytest
 
+from .test_public_api import PUBLIC_MODULES, PRIVATE_BUT_PRESENT_MODULES
 
-MODULES = [
-    "scipy.cluster",
-    "scipy.cluster.vq",
-    "scipy.cluster.hierarchy",
-    "scipy.constants",
-    "scipy.fft",
-    "scipy.fftpack",
-    "scipy.fftpack.convolve",
-    "scipy.integrate",
-    "scipy.interpolate",
-    "scipy.io",
-    "scipy.io.arff",
-    "scipy.io.harwell_boeing",
-    "scipy.io.idl",
-    "scipy.io.matlab",
-    "scipy.io.netcdf",
-    "scipy.io.wavfile",
-    "scipy.linalg",
-    "scipy.linalg.blas",
-    "scipy.linalg.cython_blas",
-    "scipy.linalg.lapack",
-    "scipy.linalg.cython_lapack",
-    "scipy.linalg.interpolative",
-    "scipy.misc",
-    "scipy.ndimage",
-    "scipy.odr",
-    "scipy.optimize",
-    "scipy.signal",
-    "scipy.signal.windows",
-    "scipy.sparse",
-    "scipy.sparse.linalg",
-    "scipy.sparse.csgraph",
-    "scipy.spatial",
-    "scipy.spatial.distance",
-    "scipy.special",
-    "scipy.stats",
-    "scipy.stats.distributions",
-    "scipy.stats.mstats",
-    "scipy.stats.contingency"
-]
+# Regression tests for gh-6793.
+# Check that all modules are importable in a new Python process.
+# This is not necessarily true if there are import cycles present.
 
+def test_public_modules_importable():
+    for module in PUBLIC_MODULES:
+        cmd = f'import {module}'
+        subprocess.check_call([sys.executable, '-c', cmd])
 
-def test_modules_importable():
-    # Regression test for gh-6793.
-    # Check that all modules are importable in a new Python process.
-    # This is not necessarily true if there are import cycles present.
-    for module in MODULES:
+@pytest.mark.timeout(180)
+def test_private_but_present_modules_importable():
+    for module in PRIVATE_BUT_PRESENT_MODULES:
         cmd = f'import {module}'
         subprocess.check_call([sys.executable, '-c', cmd])

--- a/scipy/_lib/tests/test_import_cycles.py
+++ b/scipy/_lib/tests/test_import_cycles.py
@@ -1,8 +1,7 @@
 import sys
 import subprocess
-import pytest
 
-from .test_public_api import PUBLIC_MODULES, PRIVATE_BUT_PRESENT_MODULES
+from .test_public_api import PUBLIC_MODULES
 
 # Regression tests for gh-6793.
 # Check that all modules are importable in a new Python process.
@@ -10,11 +9,5 @@ from .test_public_api import PUBLIC_MODULES, PRIVATE_BUT_PRESENT_MODULES
 
 def test_public_modules_importable():
     for module in PUBLIC_MODULES:
-        cmd = f'import {module}'
-        subprocess.check_call([sys.executable, '-c', cmd])
-
-@pytest.mark.timeout(180)
-def test_private_but_present_modules_importable():
-    for module in PRIVATE_BUT_PRESENT_MODULES:
         cmd = f'import {module}'
         subprocess.check_call([sys.executable, '-c', cmd])


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
The list of modules in the import cycles check was missing a few new modules (including _spatial.transform_, _stats.qmc_, _stats.sampling_, _datasets_, and maybe one or two others). Updated to import the list from [test_public_api](https://github.com/scipy/scipy/blob/main/scipy/_lib/tests/test_public_api.py), which should fail if a module is added to scipy but not to that list, so the problem of the import cycles list being accidentally unmaintained should no longer be an issue.

#### Additional information
<!--Any additional information you think is important.-->
