### PR TITLE
STY: fix only staged files.

### DIFF
--- a/tools/lint.py
+++ b/tools/lint.py
@@ -69,7 +69,7 @@ def diff_files(sha):
 def run_ruff(files, fix):
     if not files:
         return 0, ""
-    args = ['--fix'] if fix else []
+    args = ['--fix', '--exit-non-zero-on-fix'] if fix else []
     res = subprocess.run(
         ['ruff', f'--config={CONFIG}'] + args + files,
         stdout=subprocess.PIPE,


### PR DESCRIPTION
Before, the staged tree was used only for finding the list of files.  Now, linting is run on the staged version of the code as well.

If errors are detected, we recommend to the user that they run:

  ./tools/pre-commit.py --fix

That will execute the linter with the `--fix` flag, but only on the files that were staged already.