### PR TITLE
ENH: stats.dirichlet_multinomial: vectorize implementation

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -5895,9 +5895,9 @@ class dirichlet_multinomial_gen(multi_rv_generic):
 
     Methods
     -------
-    logpmf(alpha, x, n):
+    logpmf(x, alpha, n):
         Log of the probability mass function.
-    pmf(alpha, x, n):
+    pmf(x, alpha, n):
         Probability mass function.
     mean(alpha, n):
         Mean of the Dirichlet multinomial distribution.

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -6096,8 +6096,7 @@ class dirichlet_multinomial_gen(multi_rv_generic):
         var = dirichlet_multinomial.var(a, n)
 
         n, Sa = n[..., np.newaxis, np.newaxis], Sa[..., np.newaxis, np.newaxis]
-        ai, aj = a[..., :, np.newaxis], a[..., np.newaxis, :]
-        aiaj = ai*aj
+        aiaj = a[..., :, np.newaxis] * a[..., np.newaxis, :]
         cov = -n * aiaj / Sa ** 2 * (n + Sa) / (1 + Sa)
 
         ii = np.arange(cov.shape[-1])


### PR DESCRIPTION
#### Reference issue
gh-17211

#### What does this implement/fix?
In gh-17211 (`scipy.stats.dirichlet_multinomial`), I removed support for vectorized computation/broadcasting over shape parameters to simplify the PR. This makes minimal changes to add back this capability (and many more changes to document and test the capability).