### PR TITLE
MAINT: bump OpenBLAS version, bump macOS image used in GHA

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,11 +21,11 @@ jobs:
   test_macos:
     name: macOS Test Matrix
     if: "github.repository == 'scipy/scipy' || github.repository == ''"
-    runs-on: macos-latest
+    runs-on: macos-11
     strategy:
       max-parallel: 3
       matrix:
-        python-version: ["3.8"]
+        python-version: ["3.9"]
         numpy-version: ['--upgrade numpy']
 
     steps:
@@ -39,37 +39,9 @@ jobs:
         cache: 'pip'
         cache-dependency-path: 'environment.yml'
 
-    - name: Setup gfortran
+    - name: Setup gfortran + OpenBLAS
       run: |
-        # this is taken verbatim from the numpy azure pipeline setup.
-        set -xe
-        # same version of gfortran as the open-libs and numpy-wheel builds
-        curl -L https://github.com/MacPython/gfortran-install/raw/master/archives/gfortran-4.9.0-Mavericks.dmg -o gfortran.dmg
-        GFORTRAN_SHA256=$(shasum -a 256 gfortran.dmg)
-        KNOWN_SHA256="d2d5ca5ba8332d63bbe23a07201c4a0a5d7e09ee56f0298a96775f928c3c4b30  gfortran.dmg"
-        if [ "$GFORTRAN_SHA256" != "$KNOWN_SHA256" ]; then
-            echo sha256 mismatch
-            exit 1
-        fi
-        hdiutil attach -mountpoint /Volumes/gfortran gfortran.dmg
-        sudo installer -pkg /Volumes/gfortran/gfortran.pkg -target /
-        otool -L /usr/local/gfortran/lib/libgfortran.3.dylib
-        # Manually symlink gfortran-4.9 to plain gfortran for f2py.
-        # No longer needed after Feb 13 2020 as gfortran is already present
-        # and the attempted link errors. Keep this for future reference.
-        # ln -s /usr/local/bin/gfortran-4.9 /usr/local/bin/gfortran
-
-    - name: Setup openblas
-      run: |
-        # this is taken verbatim from the numpy azure pipeline setup.
-        set -xe
-        target=$(python tools/openblas_support.py)
-        ls -lR $target
-        # manually link to appropriate system paths
-        cp $target/lib/lib* /usr/local/lib/
-        cp $target/include/* /usr/local/include/
-
-        # otool -L /usr/local/lib/libopenblas*
+        bash tools/wheels/cibw_before_build_macos.sh $PWD
 
         echo "[openblas]" > site.cfg
         echo "libraries = openblas" >> site.cfg
@@ -89,7 +61,9 @@ jobs:
 
     - name: Test SciPy
       run: |
-        export LIBRARY_PATH="$LIBRARY_PATH:/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib"
+        # Set SDKROOT env variable if not set
+        export SDKROOT=${SDKROOT:-$(xcrun --show-sdk-path)}
+
         export SCIPY_USE_PYTHRAN=1
         python setup.py install
         cd /tmp

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -61,7 +61,8 @@ jobs:
 
     - name: Test SciPy
       run: |
-        # Set SDKROOT env variable if not set
+        # Set SDKROOT env variable if not set. Refer to
+        # tools/wheels/cibw_before_build_macos.sh to see why it's necessary
         export SDKROOT=${SDKROOT:-$(xcrun --show-sdk-path)}
 
         export SCIPY_USE_PYTHRAN=1

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -85,7 +85,7 @@ jobs:
         # recent gfortran (gfortran-9 is present on the macOS-11.0 image), and
         # will probably require that the prebuilt openBLAS is updated.
         # xref https://github.com/andyfaff/scipy/pull/28#issuecomment-1203496836
-        - [macos-10.15, macosx, x86_64]
+        - [macos-11, macosx, x86_64]
         - [windows-2019, win, AMD64]
 
         python: [["cp38", "3.8"], ["cp39", "3.9"], ["cp310", "3.10"], ["cp311", "3.11.0-alpha - 3.11.0"]]
@@ -114,6 +114,8 @@ jobs:
           # mingw-w64
           choco install rtools --no-progress
           echo "c:\rtools40\ucrt64\bin;" >> $env:GITHUB_PATH
+          #          $env:PATH = "$env:RTOOLS40_HOME\\mingw64\\bin;$env:PATH"
+          #          echo $env:PATH >> $env:GITHUB_PATH
         if: ${{ runner.os == 'Windows' && env.IS_32_BIT == 'false' }}
 
 #      - name: win32 - configure mingw for 32-bit builds
@@ -129,7 +131,7 @@ jobs:
 #        if: ${{ runner.os == 'Windows' && env.IS_32_BIT == 'true' }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.11.3
+        uses: pypa/cibuildwheel@v2.12.0
         # Build all wheels here, apart from macosx_arm64, linux_aarch64
         # cibuildwheel is currently unable to pass configuration flags to
         # CIBW_BUILD_FRONTEND https://github.com/pypa/cibuildwheel/issues/1227
@@ -144,6 +146,22 @@ jobs:
           CIBW_BUILD: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}*
           CIBW_ARCHS: ${{ matrix.buildplat[2] }}
           CIBW_ENVIRONMENT_PASS_LINUX: RUNNER_OS
+
+          # setting SDKROOT necessary when using the gfortran compiler
+          # installed in cibw_before_build_macos.sh
+          # MACOS_DEPLOYMENT_TARGET is set because of
+          # https://github.com/pypa/cibuildwheel/issues/1419. Once that
+          # is closed and an update to pypa/cibuildwheel is done, then
+          # that environment variable can be removed.
+          CIBW_ENVIRONMENT_MACOS: >
+            SDKROOT=/Applications/Xcode_11.7.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk
+            LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+            MACOSX_DEPLOYMENT_TARGET=10.9
+            MACOS_DEPLOYMENT_TARGET=10.9
+            _PYTHON_HOST_PLATFORM=macosx-10.9-x86_64
+          CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
+            DYLD_LIBRARY_PATH=/usr/local/lib delocate-listdeps {wheel} &&
+            DYLD_LIBRARY_PATH=/usr/local/lib delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -114,8 +114,6 @@ jobs:
           # mingw-w64
           choco install rtools --no-progress
           echo "c:\rtools40\ucrt64\bin;" >> $env:GITHUB_PATH
-          #          $env:PATH = "$env:RTOOLS40_HOME\\mingw64\\bin;$env:PATH"
-          #          echo $env:PATH >> $env:GITHUB_PATH
         if: ${{ runner.os == 'Windows' && env.IS_32_BIT == 'false' }}
 
 #      - name: win32 - configure mingw for 32-bit builds

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,10 +18,10 @@ pr:
     include:
     - '*'  # must quote since "*" is a YAML reserved character; we want a string
 
-# the version of OpenBLAS used is currently 0.3.18
+# the version of OpenBLAS used is currently 0.3.21
 # and should be updated to match scipy-wheels as appropriate
 variables:
-    openblas_version: 0.3.18
+    openblas_version: 0.3.21
     pre_wheels: https://pypi.anaconda.org/scipy-wheels-nightly/simple
     CCACHE_DIR: $(Pipeline.Workspace)/ccache
     SCIPY_AVAILABLE_MEM: 3G
@@ -274,19 +274,19 @@ stages:
             Download-OpenBLAS('1')
         }
       displayName: 'Download / Install OpenBLAS'
-    - script: |
-        choco install -y llvm
-        set PATH=C:\Program Files\LLVM\bin;%PATH%
-        echo '##vso[task.setvariable variable=PATH]%PATH%'
-      displayName: 'Install clang-cl'
-    - script: |
-        clang-cl.exe --version
-      displayName: 'clang-cl version'
+
     - powershell: |
         # wheels must use same version
-        choco install -y mingw --forcex86 --force --version=7.3.0
+        choco install -y mingw rtools
+      displayName: 'Install 64-bit mingw for 64-bit builds'
+      condition: and(succeeded(), eq(variables['BITS'], 64))
+
+    - powershell: |
+        # wheels must use same version
+        choco install -y mingw --forcex86 --force --version=8.1.0
       displayName: 'Install 32-bit mingw for 32-bit builds'
       condition: and(succeeded(), eq(variables['BITS'], 32))
+
     - script: >-
         python -m pip install
         cython==0.29.24
@@ -326,7 +326,6 @@ stages:
         Set-StrictMode -Version Latest
         $global:erroractionpreference = 1
 
-
         If ($(BITS) -eq 32) {
             # 32-bit build requires careful adjustments
             # until Microsoft has a switch we can use
@@ -335,9 +334,14 @@ stages:
             $env:CFLAGS = "-m32"
             $env:CXXFLAGS = "-m32"
             $env:LDFLAGS = "-m32"
+
+            $env:PATH = "C:\\ProgramData\\chocolatey\\lib\\mingw\\tools\\install\\mingw$(BITS)\\bin;" + $env:PATH
             refreshenv
         }
-        $env:PATH = "C:\\ProgramData\\chocolatey\\lib\\mingw\\tools\\install\\mingw$(BITS)\\bin;" + $env:PATH
+        Else
+        {
+            $env:PATH = "C:\\rtools40\\ucrt64\\bin;" + $env:PATH
+        }
         $env:SCIPY_USE_PYTHRAN=$(SCIPY_USE_PYTHRAN)
 
         # Still testing distutils here (`pip wheel --no-use-pep517` cannot be
@@ -348,7 +352,14 @@ stages:
         }
       displayName: 'Build SciPy'
     - powershell: |
-        $env:PATH = "C:\\ProgramData\\chocolatey\\lib\\mingw\\tools\\install\\mingw$(BITS)\\bin;" + $env:PATH
+        If ($(BITS) -eq 32) {
+            $env:PATH = "C:\\ProgramData\\chocolatey\\lib\\mingw\\tools\\install\\mingw$(BITS)\\bin;" + $env:PATH
+            refreshenv
+        }
+        Else
+        {
+            $env:PATH = "C:\\rtools40\\ucrt64\\bin;" + $env:PATH
+        }
         python runtests.py -n --mode=$(TEST_MODE) -- -n 2 --junitxml=junit/test-results.xml --durations=10 --timeout=60
       displayName: 'Run SciPy Test Suite'
     - task: PublishTestResults@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -281,6 +281,16 @@ stages:
       displayName: 'Install 64-bit mingw for 64-bit builds'
       condition: and(succeeded(), eq(variables['BITS'], 64))
 
+    - script: |
+        # provides clang-cl, which is required by Pythran
+        choco install -y llvm
+        set PATH=C:\Program Files\LLVM\bin;%PATH%
+        echo '##vso[task.setvariable variable=PATH]%PATH%'
+      displayName: 'Install clang-cl'
+    - script: |
+        clang-cl.exe --version
+      displayName: 'clang-cl version'
+
     - powershell: |
         # wheels must use same version
         choco install -y mingw --forcex86 --force --version=8.1.0

--- a/ci/cirrus_wheels.yml
+++ b/ci/cirrus_wheels.yml
@@ -1,6 +1,6 @@
 build_and_store_wheels: &BUILD_AND_STORE_WHEELS
   install_cibuildwheel_script:
-    - python -m pip install cibuildwheel==2.11.3
+    - python -m pip install cibuildwheel==2.12.0
   cibuildwheel_script:
     - cibuildwheel
   wheels_artifacts:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,4 +172,4 @@ select = "*-win_amd64"
 # An alternative is to set CMAKE_PREFIX_PATH="c:/opt/openblas/if_32/32"
 # Don't use double backslash for path separators, they don't get passed
 # to the build correctly
-environment = { PKG_CONFIG_PATH="c:/opt/openblas/if_32/64/lib/pkgconfig" }
+environment = { PKG_CONFIG_PATH="c:/opt/64/lib/pkgconfig" }

--- a/scipy/linalg/tests/test_solvers.py
+++ b/scipy/linalg/tests/test_solvers.py
@@ -1,7 +1,7 @@
 import os
 import numpy as np
 
-from numpy.testing import assert_array_almost_equal
+from numpy.testing import assert_array_almost_equal, assert_allclose
 import pytest
 from pytest import raises as assert_raises
 
@@ -629,9 +629,9 @@ def test_solve_generalized_discrete_are():
          None),
         ]
 
-    min_decimal = (11, 11, 16)
+    max_atol = (1.5e-11, 1.5e-11, 3.5e-16)
 
-    def _test_factory(case, dec):
+    def _test_factory(case, atol):
         """Checks if X = A'XA-(A'XB)(R+B'XB)^-1(B'XA)+Q) is true"""
         a, b, q, r, e, s, knownfailure = case
         if knownfailure:
@@ -648,10 +648,13 @@ def test_solve_generalized_discrete_are():
                           (b.conj().T.dot(x.dot(a)) + s.conj().T)
                           )
                 )
-        assert_array_almost_equal(res, np.zeros_like(res), decimal=dec)
+        # changed from:
+        # assert_array_almost_equal(res, np.zeros_like(res), decimal=dec)
+        # in gh-17950 because of a Linux 32 bit fail.
+        assert_allclose(res, np.zeros_like(res), atol=atol)
 
     for ind, case in enumerate(cases):
-        _test_factory(case, min_decimal[ind])
+        _test_factory(case, max_atol[ind])
 
 
 def test_are_validate_args():

--- a/tools/wheels/cibw_before_build_macos.sh
+++ b/tools/wheels/cibw_before_build_macos.sh
@@ -43,7 +43,9 @@ if [[ $PLATFORM == "macosx-x86_64" ]]; then
 
   # Set SDKROOT env variable if not set
   # This step is required whenever the gfortran compilers sourced from
-  # conda-forge (built by isuru fernando) are used
+  # conda-forge (built by isuru fernando) are used outside of a conda-forge
+  # environment (so it mirrors what is done in the conda-forge compiler
+  # activation scripts)
   export SDKROOT=${SDKROOT:-$(xcrun --show-sdk-path)}
   gfortran tools/wheels/test.f
 fi
@@ -74,8 +76,5 @@ if [[ $PLATFORM == "macosx-arm64" ]]; then
 
   hdiutil attach -mountpoint /Volumes/gfortran gfortran.dmg
   sudo installer -pkg /Volumes/gfortran/gfortran.pkg -target /
-  # required so that gfortran knows where to find the linking libraries.
-  # export SDKROOT=/Applications/Xcode_13.3.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk
-  # export SDKROOT=$(xcrun --show-sdk-path)
   type -p gfortran
 fi

--- a/tools/wheels/cibw_before_build_macos.sh
+++ b/tools/wheels/cibw_before_build_macos.sh
@@ -21,17 +21,31 @@ if [[ $PLATFORM == "macosx-x86_64" ]]; then
   #GFORTRAN=$(type -p gfortran-9)
   #sudo ln -s $GFORTRAN /usr/local/bin/gfortran
   # same version of gfortran as the openblas-libs and scipy-wheel builds
-  curl -L https://github.com/MacPython/gfortran-install/raw/master/archives/gfortran-4.9.0-Mavericks.dmg -o gfortran.dmg
-  GFORTRAN_SHA256=$(shasum -a 256 gfortran.dmg)
-  KNOWN_SHA256="d2d5ca5ba8332d63bbe23a07201c4a0a5d7e09ee56f0298a96775f928c3c4b30  gfortran.dmg"
+  curl -L https://github.com/isuruf/gcc/releases/download/gcc-11.3.0-2/gfortran-darwin-x86_64-native.tar.gz -o gfortran.tar.gz
+
+  GFORTRAN_SHA256=$(shasum -a 256 gfortran.tar.gz)
+  KNOWN_SHA256="981367dd0ad4335613e91bbee453d60b6669f5d7e976d18c7bdb7f1966f26ae4  gfortran.tar.gz"
   if [ "$GFORTRAN_SHA256" != "$KNOWN_SHA256" ]; then
       echo sha256 mismatch
       exit 1
   fi
 
-  hdiutil attach -mountpoint /Volumes/gfortran gfortran.dmg
-  sudo installer -pkg /Volumes/gfortran/gfortran.pkg -target /
-  otool -L /usr/local/gfortran/lib/libgfortran.3.dylib
+  sudo mkdir -p /opt/
+  # places gfortran in /opt/gfortran-darwin-x86_64-native. There's then
+  # bin, lib, include, libexec underneath that.
+  sudo tar -xv -C /opt -f gfortran.tar.gz
+
+  # Link these into /usr/local so that there's no need to add rpath or -L
+  for f in libgfortran.dylib libgfortran.5.dylib libgcc_s.1.dylib libgcc_s.1.1.dylib libquadmath.dylib libquadmath.0.dylib; do
+    ln -sf /opt/gfortran-darwin-x86_64-native/lib/$f /usr/local/lib/$f
+  done
+  ln -sf /opt/gfortran-darwin-x86_64-native/bin/gfortran /usr/local/bin/gfortran
+
+  # Set SDKROOT env variable if not set
+  # This step is required whenever the gfortran compilers sourced from
+  # conda-forge (built by isuru fernando) are used
+  export SDKROOT=${SDKROOT:-$(xcrun --show-sdk-path)}
+  gfortran tools/wheels/test.f
 fi
 
 if [[ $PLATFORM == "macosx-arm64" ]]; then

--- a/tools/wheels/cibw_before_build_win.sh
+++ b/tools/wheels/cibw_before_build_win.sh
@@ -9,8 +9,8 @@ cat $PROJECT_DIR/tools/wheels/LICENSE_win32.txt >> $PROJECT_DIR/LICENSE.txt
 
 # Install Openblas
 PYTHONPATH=tools python -c "import openblas_support; openblas_support.make_init('scipy')"
-mkdir -p /c/opt/openblas/if_32/32/lib/pkgconfig
-mkdir -p /c/opt/openblas/if_32/64/lib/pkgconfig
+mkdir -p /c/opt/32/lib/pkgconfig
+mkdir -p /c/opt/64/lib/pkgconfig
 
 # delvewheel is the equivalent of delocate/auditwheel for windows.
 python -m pip install delvewheel
@@ -20,17 +20,17 @@ python -m pip install delvewheel
 mkdir -p /c/opt/openblas/openblas_dll
 which strip
 
+target=$(python -c "import tools.openblas_support as obs; plat=obs.get_plat(); ilp64=obs.get_ilp64(); target=f'openblas_{plat}.zip'; obs.download_openblas(target, plat, ilp64);print(target)")
+
 # The 32/64 bit Fortran wheels are currently coming from different locations.
 if [[ $PLATFORM == 'win-32' ]]; then
   # 32-bit openBLAS
   # Download 32 bit openBLAS and put it into c/opt/32/lib
-  target=$(python -c "import tools.openblas_support as obs; plat=obs.get_plat(); ilp64=obs.get_ilp64(); target=f'openblas_{plat}.zip'; obs.download_openblas(target, plat, ilp64);print(target)")
-  unzip $target -d /c/opt/openblas/if_32/
-  cp /c/opt/openblas/if_32/32/bin/*.dll /c/opt/openblas/openblas_dll
+  unzip $target -d /c/opt/
+  cp /c/opt/32/bin/*.dll /c/opt/openblas/openblas_dll
   # rm /c/opt/openblas/if_32/32/lib/*.dll.a
 else
   # 64-bit openBLAS
-  curl -L https://github.com/scipy/scipy-ci-artifacts/raw/main/openblas_32_if.zip -o openblas_32_if.zip
-  unzip openblas_32_if.zip -d /c
-  cp /c/opt/openblas/if_32/64/bin/*.dll /c/opt/openblas/openblas_dll
+  unzip $target -d /c/opt/
+  cp /c/opt/64/bin/*.dll /c/opt/openblas/openblas_dll
 fi


### PR DESCRIPTION
Bumps OpenBLAS version from 0.3.18 to 0.3.21. The changeset is a bit larger that may be expected because the bump comes with alterations to compiler paths, openblas paths, etc.

Note, a few test fails are expected. These will probably need to result in test tweaks to tolerances, etc. I don't believe that they're materially caused by this PR, just the blas bump itself.

[EDIT] - More context:
This PR bumps the macOS image used on Github Actions, both in wheel building and in general CI. Previously the `macOS-10.15` image was being used, it's now bumped to at least `macOS-11`. This is because the 10.15 image has been [unsupported](https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/) for a long time .
I was having challenges using the older gfortran compiler that was being used in various places (gfortran-4.9) when bumping the image, so needed  to update the gfortran compiler being used. This gfortran bump also required a more recent OpenBLAS build than one from 2 years ago. I settled on 0.3.21 as this is what numpy is using. Bumping the OpenBLAS version has required some adjustments to test tolerances.
