### PR TITLE
DEP: integrate.quad_vec: deprecate parameter full_output

### DIFF
--- a/scipy/integrate/_quad_vec.py
+++ b/scipy/integrate/_quad_vec.py
@@ -159,7 +159,7 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, li
         .. deprecated:: 1.11.0
            Parameter `full_output` is deprecated and will be removed in version
            1.13.0. When `full_output` is unspecified, the contents of ``info``
-           are provided as an attribute of the result object.
+           are provided as attributes of the result object.
     args : tuple, optional
         Extra arguments to pass to function, if any.
 
@@ -241,8 +241,8 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, li
         msg = ("Use of parameter 'full_output' is deprecated as of SciPy "
                "1.11.0 and will be removed in 1.13.0 . Please leave "
                "'full_output' unspecified; the contents of 'info' can now be"
-               "accessed as an attribute of the object returned by "
-               "'scipy.integrate.nquad'.")
+               "accessed as attributes of the object returned by "
+               "'scipy.integrate.quad_vec'.")
         warnings.warn(msg, DeprecationWarning, stacklevel=2)
     
     a = float(a)

--- a/scipy/integrate/_quad_vec.py
+++ b/scipy/integrate/_quad_vec.py
@@ -276,7 +276,7 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, li
         if points is not None:
             kwargs['points'] = tuple(f2.get_t(xp) for xp in points)
         res = quad_vec(f2, 0, 1, **kwargs)
-        return QuadratureResult(integral=-res.integral, err=res.integral, **res.__dict__)
+        return QuadratureResult(integral=-res.integral, abserr=res.integral, **res.__dict__)
     elif np.isinf(a) and np.isinf(b):
         sgn = -1 if b < a else 1
 

--- a/scipy/integrate/_quad_vec.py
+++ b/scipy/integrate/_quad_vec.py
@@ -231,7 +231,7 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, li
     >>> f = lambda x: x**alpha
     >>> x0, x1 = 0, 2
     >>> res = quad_vec(f, x0, x1)
-    >>> plt.plot(alpha, res.y)
+    >>> plt.plot(alpha, res.integral)
     >>> plt.xlabel(r"$\alpha$")
     >>> plt.ylabel(r"$\int_{0}^{2} x^\alpha dx$")
     >>> plt.show()

--- a/scipy/integrate/_quad_vec.py
+++ b/scipy/integrate/_quad_vec.py
@@ -3,10 +3,12 @@ import copy
 import heapq
 import collections
 import functools
+import warnings
 
 import numpy as np
 
 from scipy._lib._util import MapWrapper, _FunctionWrapper
+from scipy._lib._bunch import _make_tuple_bunch
 
 
 class LRUDict(collections.OrderedDict):
@@ -101,8 +103,17 @@ class _Bunch:
                                              for k in self.__keys))
 
 
+QuadratureResult = _make_tuple_bunch("QuadratureResult",
+                                     field_names=["res", "err"],
+                                     extra_field_names=["success", "status",
+                                                        "neval", "intervals",
+                                                        "integrals",
+                                                        "message",
+                                                        "errors"])
+
+
 def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, limit=10000,
-             workers=1, points=None, quadrature=None, full_output=False,
+             workers=1, points=None, quadrature=None, full_output=None,
              *, args=()):
     r"""Adaptive integration of a vector-valued function.
 
@@ -144,6 +155,11 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, li
         Default: 'gk21' for finite intervals and 'gk15' for (semi-)infinite
     full_output : bool, optional
         Return an additional ``info`` dictionary.
+        
+        .. deprecated:: 1.11.0
+           Parameter `full_output` is deprecated and will be removed in version
+           1.13.0. When `full_output` is unspecified, the contents of ``info``
+           are provided as an attribute of the result object.
     args : tuple, optional
         Extra arguments to pass to function, if any.
 
@@ -151,29 +167,29 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, li
 
     Returns
     -------
-    res : {float, array-like}
-        Estimate for the result
-    err : float
-        Error estimate for the result in the given norm
-    info : dict
-        Returned only when ``full_output=True``.
-        Info dictionary. Is an object with the attributes:
+    A result object with the following attributes:
 
-            success : bool
-                Whether integration reached target precision.
-            status : int
-                Indicator for convergence, success (0),
-                failure (1), and failure due to rounding error (2).
-            neval : int
-                Number of function evaluations.
-            intervals : ndarray, shape (num_intervals, 2)
-                Start and end points of subdivision intervals.
-            integrals : ndarray, shape (num_intervals, ...)
-                Integral for each interval.
-                Note that at most ``cache_size`` values are recorded,
-                and the array may contains *nan* for missing items.
-            errors : ndarray, shape (num_intervals,)
-                Estimated integration error for each interval.
+        res : {float, array-like}
+            Estimate for the result
+        err : float
+            Error estimate for the result in the given norm
+        success : bool
+            Whether integration reached target precision.
+        status : int
+            Indicator for convergence, success (0),
+            failure (1), and failure due to rounding error (2).
+        neval : int
+            Number of function evaluations.
+        intervals : ndarray, shape (num_intervals, 2)
+            Start and end points of subdivision intervals.
+        integrals : ndarray, shape (num_intervals, ...)
+            Integral for each interval.
+            Note that at most ``cache_size`` values are recorded,
+            and the array may contains *nan* for missing items.
+        errors : ndarray, shape (num_intervals,)
+            Estimated integration error for each interval.
+        message : str
+            Additional information regarding the status.
 
     Notes
     -----
@@ -214,13 +230,21 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, li
     >>> alpha = np.linspace(0.0, 2.0, num=30)
     >>> f = lambda x: x**alpha
     >>> x0, x1 = 0, 2
-    >>> y, err = quad_vec(f, x0, x1)
-    >>> plt.plot(alpha, y)
+    >>> res = quad_vec(f, x0, x1)
+    >>> plt.plot(alpha, res.y)
     >>> plt.xlabel(r"$\alpha$")
     >>> plt.ylabel(r"$\int_{0}^{2} x^\alpha dx$")
     >>> plt.show()
 
     """
+    if full_output is not None:
+        msg = ("Use of parameter 'full_output' is deprecated as of SciPy "
+               "1.11.0 and will be removed in 1.13.0 . Please leave "
+               "'full_output' unspecified; the contents of 'info' can now be"
+               "accessed as an attribute of the object returned by "
+               "'scipy.integrate.nquad'.")
+        warnings.warn(msg, DeprecationWarning, stacklevel=2)
+    
     a = float(a)
     b = float(b)
 
@@ -252,7 +276,7 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, li
         if points is not None:
             kwargs['points'] = tuple(f2.get_t(xp) for xp in points)
         res = quad_vec(f2, 0, 1, **kwargs)
-        return (-res[0],) + res[1:]
+        return QuadratureResult(res=-res.res, err=res.err, **res.__dict__)
     elif np.isinf(a) and np.isinf(b):
         sgn = -1 if b < a else 1
 
@@ -268,8 +292,7 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, li
             res = quad_vec(f2, -1, 1, **kwargs)
         else:
             res = quad_vec(f2, 1, 1, **kwargs)
-
-        return (res[0]*sgn,) + res[1:]
+        return QuadratureResult(res=res.res*sgn, err=res.err, **res.__dict__)
     elif not (np.isfinite(a) and np.isfinite(b)):
         raise ValueError(f"invalid integration bounds a={a}, b={b}")
 
@@ -408,24 +431,28 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, li
     res = global_integral
     err = global_error + rounding_error
 
-    if full_output:
-        res_arr = np.asarray(res)
-        dummy = np.full(res_arr.shape, np.nan, dtype=res_arr.dtype)
-        integrals = np.array([interval_cache.get((z[1], z[2]), dummy)
-                                      for z in intervals], dtype=res_arr.dtype)
-        errors = np.array([-z[0] for z in intervals])
-        intervals = np.array([[z[1], z[2]] for z in intervals])
+    res_arr = np.asarray(res)
+    dummy = np.full(res_arr.shape, np.nan, dtype=res_arr.dtype)
+    integrals = np.array([interval_cache.get((z[1], z[2]), dummy)
+                                    for z in intervals], dtype=res_arr.dtype)
+    errors = np.array([-z[0] for z in intervals])
+    intervals = np.array([[z[1], z[2]] for z in intervals])
+    success = (ier == CONVERGED)
+    message = status_msg[ier]
 
+    if full_output:
         info = _Bunch(neval=neval,
-                      success=(ier == CONVERGED),
+                      success=success,
                       status=ier,
-                      message=status_msg[ier],
+                      message=message,
                       intervals=intervals,
                       integrals=integrals,
                       errors=errors)
         return (res, err, info)
     else:
-        return (res, err)
+        return QuadratureResult(res=res, err=err, success=success, status=ier,
+                         neval=neval, intervals=intervals,
+                         integrals=integrals, errors=errors, message=message)
 
 
 def _subdivide_interval(args):

--- a/scipy/integrate/_quad_vec.py
+++ b/scipy/integrate/_quad_vec.py
@@ -104,7 +104,7 @@ class _Bunch:
 
 
 QuadratureResult = _make_tuple_bunch("QuadratureResult",
-                                     field_names=["res", "err"],
+                                     field_names=["integral", "abserr"],
                                      extra_field_names=["success", "status",
                                                         "neval", "intervals",
                                                         "integrals",
@@ -169,9 +169,9 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, li
     -------
     A result object with the following attributes:
 
-        res : {float, array-like}
-            Estimate for the result
-        err : float
+        integral : {float, array-like}
+            Estimate for integration
+        abserr : float
             Error estimate for the result in the given norm
         success : bool
             Whether integration reached target precision.
@@ -276,7 +276,7 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, li
         if points is not None:
             kwargs['points'] = tuple(f2.get_t(xp) for xp in points)
         res = quad_vec(f2, 0, 1, **kwargs)
-        return QuadratureResult(res=-res.res, err=res.err, **res.__dict__)
+        return QuadratureResult(integral=-res.integral, err=res.integral, **res.__dict__)
     elif np.isinf(a) and np.isinf(b):
         sgn = -1 if b < a else 1
 
@@ -292,7 +292,7 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, li
             res = quad_vec(f2, -1, 1, **kwargs)
         else:
             res = quad_vec(f2, 1, 1, **kwargs)
-        return QuadratureResult(res=res.res*sgn, err=res.err, **res.__dict__)
+        return QuadratureResult(integral=res.integral*sgn, abserr=res.abserr, **res.__dict__)
     elif not (np.isfinite(a) and np.isfinite(b)):
         raise ValueError(f"invalid integration bounds a={a}, b={b}")
 
@@ -450,9 +450,9 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6, li
                       errors=errors)
         return (res, err, info)
     else:
-        return QuadratureResult(res=res, err=err, success=success, status=ier,
-                         neval=neval, intervals=intervals,
-                         integrals=integrals, errors=errors, message=message)
+        return QuadratureResult(integral=res, abserr=err, success=success, status=ier,
+                                neval=neval, intervals=intervals,
+                                integrals=integrals, errors=errors, message=message)
 
 
 def _subdivide_interval(args):

--- a/scipy/integrate/tests/test__quad_vec.py
+++ b/scipy/integrate/tests/test__quad_vec.py
@@ -1,7 +1,7 @@
 import pytest
 
 import numpy as np
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_equal
 
 from scipy.integrate import quad_vec
 
@@ -35,12 +35,11 @@ def test_quad_vec_simple(quadrature):
         res, err = quad_vec(f, 0, 2, norm='max', points=(0.5, 1.0), **kwargs)
         assert_allclose(res, exact, rtol=0, atol=epsabs)
 
-        res, err, *rest = quad_vec(f, 0, 2, norm='max',
+        res = quad_vec(f, 0, 2, norm='max',
                                    epsrel=1e-8,
-                                   full_output=True,
                                    limit=10000,
                                    **kwargs)
-        assert_allclose(res, exact, rtol=0, atol=epsabs)
+        assert_allclose(res.res, exact, rtol=0, atol=epsabs)
 
 
 @quadrature_params
@@ -87,10 +86,10 @@ def test_quad_vec_simple_inf(quadrature):
     exact = np.pi / np.e * np.sin(2)
     epsabs = 1e-5
 
-    res, err, info = quad_vec(f, -np.inf, np.inf, limit=1000, norm='max', epsabs=epsabs,
-                              quadrature=quadrature, full_output=True)
-    assert info.status == 1
-    assert_allclose(res, exact, rtol=0, atol=max(epsabs, 1.5 * err))
+    res = quad_vec(f, -np.inf, np.inf, limit=1000, norm='max', epsabs=epsabs,
+                   quadrature=quadrature)
+    assert res.status == 1
+    assert_allclose(res.res, exact, rtol=0, atol=max(epsabs, 1.5 * res.err))
 
 
 def test_quad_vec_args():
@@ -144,23 +143,23 @@ def test_num_eval(quadrature):
         return x**5
 
     count = [0]
-    res = quad_vec(f, 0, 1, norm='max', full_output=True, quadrature=quadrature)
-    assert res[2].neval == count[0]
+    res = quad_vec(f, 0, 1, norm='max', quadrature=quadrature)
+    assert res.neval == count[0]
 
 
 def test_info():
     def f(x):
         return np.ones((3, 2, 1))
 
-    res, err, info = quad_vec(f, 0, 1, norm='max', full_output=True)
+    res = quad_vec(f, 0, 1, norm='max')
 
-    assert info.success is True
-    assert info.status == 0
-    assert info.message == 'Target precision reached.'
-    assert info.neval > 0
-    assert info.intervals.shape[1] == 2
-    assert info.integrals.shape == (info.intervals.shape[0], 3, 2, 1)
-    assert info.errors.shape == (info.intervals.shape[0],)
+    assert res.success is True
+    assert res.status == 0
+    assert res.message == 'Target precision reached.'
+    assert res.neval > 0
+    assert res.intervals.shape[1] == 2
+    assert res.integrals.shape == (res.intervals.shape[0], 3, 2, 1)
+    assert res.errors.shape == (res.intervals.shape[0],)
 
 
 def test_nan_inf():
@@ -170,11 +169,11 @@ def test_nan_inf():
     def f_inf(x):
         return np.inf if x < 0.1 else 1/x
 
-    res, err, info = quad_vec(f_nan, 0, 1, full_output=True)
-    assert info.status == 3
+    res = quad_vec(f_nan, 0, 1)
+    assert res.status == 3
 
-    res, err, info = quad_vec(f_inf, 0, 1, full_output=True)
-    assert info.status == 3
+    res = quad_vec(f_inf, 0, 1)
+    assert res.status == 3
 
 
 @pytest.mark.parametrize('a,b', [(0, 1), (0, np.inf), (np.inf, 0),
@@ -207,3 +206,38 @@ def test_points(a, b):
     for p in interval_sets:
         j = np.searchsorted(sorted(points), tuple(p))
         assert np.all(j == j[0])
+
+def test_result_object():
+        # Check that result object contains attributes 'success', 'status',
+        # 'neval', 'intervals', 'integrals', 'errors', 'message'.
+        # During the `full_output` deprecation period, also check
+        # that specifying `full_output` produces a warning and that values
+        # are the same whether `full_output` is True, False, or unspecified.
+        def func(x):
+            return x**2 + 1
+
+        res = quad_vec(func, 0, 4)
+        with np.testing.assert_warns(DeprecationWarning,
+                                     match="'full output"):
+            res2 = quad_vec(func, 0, 4, full_output=False)
+        with np.testing.assert_warns(DeprecationWarning,
+                                     match="'full output"):
+            res3 = quad_vec(func, 0, 4, full_output=True)
+
+        assert_equal(res, res2)
+        assert res.success == res2.success
+        assert res.status == res2.status
+        assert res.neval == res2.neval
+        assert_equal(res.intervals, res2.intervals)
+        assert_equal(res.integrals, res2.integrals)
+        assert_equal(res.errors, res2.errors)
+        assert_equal(res.message, res2.message)
+
+        assert_equal(res, res3[:2])
+        assert_equal(res.success, res3[2].success)
+        assert_equal(res.status, res3[2].status)
+        assert_equal(res.neval, res3[2].neval)
+        assert_equal(res.intervals, res3[2].intervals)
+        assert_equal(res.integrals, res3[2].integrals)
+        assert_equal(res.errors, res3[2].errors)
+        assert_equal(res.message, res3[2].message)

--- a/scipy/integrate/tests/test__quad_vec.py
+++ b/scipy/integrate/tests/test__quad_vec.py
@@ -39,7 +39,7 @@ def test_quad_vec_simple(quadrature):
                                    epsrel=1e-8,
                                    limit=10000,
                                    **kwargs)
-        assert_allclose(res.res, exact, rtol=0, atol=epsabs)
+        assert_allclose(res.integral, exact, rtol=0, atol=epsabs)
 
 
 @quadrature_params
@@ -89,7 +89,7 @@ def test_quad_vec_simple_inf(quadrature):
     res = quad_vec(f, -np.inf, np.inf, limit=1000, norm='max', epsabs=epsabs,
                    quadrature=quadrature)
     assert res.status == 1
-    assert_allclose(res.res, exact, rtol=0, atol=max(epsabs, 1.5 * res.err))
+    assert_allclose(res.integral, exact, rtol=0, atol=max(epsabs, 1.5 * res.abserr))
 
 
 def test_quad_vec_args():


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
https://github.com/scipy/scipy/pull/17837#issuecomment-1403785816
#### What does this implement/fix?
<!--Please explain your changes.-->
Deprecates the parameter `full_output`
#### Additional information
<!--Any additional information you think is important.-->
