### PR TITLE
BLD/TST: datasets: Allow disabling network requiring tests

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,3 +6,6 @@ option('use-g77-abi', type: 'boolean', value: 'false',
         description: 'If set to true, forces using g77 compatibility wrappers ' +
                      'for LAPACK functions. The default is to use gfortran ' +
                      'ABI for all LAPACK libraries except MKL.')
+option('disable-network-tests', type: 'boolean', value: 'false',
+        description: 'If set to true, disables tests that require internet ' +
+                     'connection, such as those downloading datasets.')

--- a/scipy/datasets/meson.build
+++ b/scipy/datasets/meson.build
@@ -11,4 +11,6 @@ py3.install_sources(
   subdir: 'scipy/datasets'
 )
 
-subdir('tests')
+if not get_option('disable-network-tests')
+  subdir('tests')
+endif


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?

Allow disabling tests that require internet connection. Useful for distributions such as Nix and Guix that disallow network access during builds.

#### Additional information