### PR TITLE
ENH: stats.describe: add axis tuple and masked array support, `keepdims`; fix nan_policy and edge cases

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -1384,7 +1384,8 @@ DescribeResult = namedtuple('DescribeResult',
                              'kurtosis'))
 
 
-def describe(a, axis=0, ddof=1, bias=True, nan_policy='propagate'):
+def describe(a, axis=0, ddof=1, bias=True, nan_policy='propagate', *,
+             keepdims=False):
     """Compute several descriptive statistics of the passed array.
 
     Parameters
@@ -1406,6 +1407,10 @@ def describe(a, axis=0, ddof=1, bias=True, nan_policy='propagate'):
         * 'propagate': returns nan
         * 'raise': throws an error
         * 'omit': performs the calculations ignoring nan values
+    keepdims : bool, default: False
+        If this is set to True, the axes which are reduced are left
+        in the result as dimensions with size one. With this option,
+        the result will broadcast correctly against the input array.
 
     Returns
     -------
@@ -1449,24 +1454,26 @@ def describe(a, axis=0, ddof=1, bias=True, nan_policy='propagate'):
                    skewness=array([0., 0.]), kurtosis=array([-2., -2.]))
 
     """
-    a, axis = _chk_asarray(a, axis)
-
-    contains_nan, nan_policy = _contains_nan(a, nan_policy)
-
-    if contains_nan and nan_policy == 'omit':
-        a = ma.masked_invalid(a)
-        return mstats_basic.describe(a, axis, ddof, bias)
-
-    if a.size == 0:
+    if np.size(a) == 0:
         raise ValueError("The input must not be empty.")
+
+    n, _min, _max, m, v, sk, kurt = _describe(a, axis, ddof, bias,
+                                              nan_policy, keepdims=keepdims)
+    return DescribeResult(n, (_min, _max), m, v, sk, kurt)
+
+
+@_axis_nan_policy_factory(lambda *args: args, n_outputs=7)
+def _describe(a, axis=0, ddof=1, bias=True, nan_policy='propagate'):
     n = a.shape[axis]
-    mm = (np.min(a, axis=axis), np.max(a, axis=axis))
+    _min = np.min(a, axis=axis)
+    _max = np.max(a, axis=axis)
     m = np.mean(a, axis=axis)
     v = _var(a, axis=axis, ddof=ddof)
     sk = skew(a, axis, bias=bias)
     kurt = kurtosis(a, axis, bias=bias)
+    n = np.broadcast_to(n, m.shape)
+    return n, _min, _max, m, v, sk, kurt
 
-    return DescribeResult(n, mm, m, v, sk, kurt)
 
 #####################################
 #         NORMALITY TESTS           #

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -13,7 +13,7 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_equal, suppress_warnings
 from scipy import stats
 from scipy.stats._axis_nan_policy import _masked_arrays_2_sentinel_arrays
-
+from scipy.stats import _stats_py
 
 def unpack_ttest_result(res):
     low, high = res.confidence_interval()
@@ -39,6 +39,7 @@ axis_nan_policy_cases = [
     (stats.pmean, (1.42,), dict(), 1, 1, False, lambda x: (x,)),
     (stats.sem, tuple(), dict(), 1, 1, False, lambda x: (x,)),
     (stats.iqr, tuple(), dict(), 1, 1, False, lambda x: (x,)),
+    (_stats_py._describe, tuple(), dict(), 1, 7, False, lambda x: x),
     (stats.kurtosis, tuple(), dict(), 1, 1, False, lambda x: (x,)),
     (stats.skew, tuple(), dict(), 1, 1, False, lambda x: (x,)),
     (stats.kstat, tuple(), dict(), 1, 1, False, lambda x: (x,)),
@@ -66,7 +67,7 @@ too_small_messages = {"The input contains nan",  # for nan_policy="raise"
                       "Not enough test observations",
                       "Not enough other observations",
                       "At least one observation is required",
-                      "zero-size array to reduction operation maximum",
+                      "zero-size array to reduction operation",
                       "`x` and `y` must be of nonzero size.",
                       "The exact distribution of the Wilcoxon test",
                       "Data input must not be empty"}

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -13,7 +13,7 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_equal, suppress_warnings
 from scipy import stats
 from scipy.stats._axis_nan_policy import _masked_arrays_2_sentinel_arrays
-from scipy.stats import _stats_py
+
 
 def unpack_ttest_result(res):
     low, high = res.confidence_interval()
@@ -39,7 +39,6 @@ axis_nan_policy_cases = [
     (stats.pmean, (1.42,), dict(), 1, 1, False, lambda x: (x,)),
     (stats.sem, tuple(), dict(), 1, 1, False, lambda x: (x,)),
     (stats.iqr, tuple(), dict(), 1, 1, False, lambda x: (x,)),
-    (_stats_py._describe, tuple(), dict(), 1, 7, False, lambda x: x),
     (stats.kurtosis, tuple(), dict(), 1, 1, False, lambda x: (x,)),
     (stats.skew, tuple(), dict(), 1, 1, False, lambda x: (x,)),
     (stats.kstat, tuple(), dict(), 1, 1, False, lambda x: (x,)),
@@ -67,7 +66,7 @@ too_small_messages = {"The input contains nan",  # for nan_policy="raise"
                       "Not enough test observations",
                       "Not enough other observations",
                       "At least one observation is required",
-                      "zero-size array to reduction operation",
+                      "zero-size array to reduction operation maximum",
                       "`x` and `y` must be of nonzero size.",
                       "The exact distribution of the Wilcoxon test",
                       "Data input must not be empty"}

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -45,6 +45,7 @@ axis_nan_policy_cases = [
     (stats.kstatvar, tuple(), dict(), 1, 1, False, lambda x: (x,)),
     (stats.moment, tuple(), dict(), 1, 1, False, lambda x: (x,)),
     (stats.moment, tuple(), dict(moment=[1, 2]), 1, 2, False, None),
+    (stats.describe, tuple(), dict(), 1, 7, False, stats._stats_py._unpack_describe),
     (stats.jarque_bera, tuple(), dict(), 1, 2, False, None),
     (stats.ttest_1samp, (np.array([0]),), dict(), 1, 7, False,
      unpack_ttest_result),
@@ -69,7 +70,8 @@ too_small_messages = {"The input contains nan",  # for nan_policy="raise"
                       "zero-size array to reduction operation maximum",
                       "`x` and `y` must be of nonzero size.",
                       "The exact distribution of the Wilcoxon test",
-                      "Data input must not be empty"}
+                      "Data input must not be empty",
+                      "The input must not be empty"}
 
 # If the message is one of these, results of the function may be inaccurate,
 # but NaNs are not to be placed
@@ -77,7 +79,7 @@ inaccuracy_messages = {"Precision loss occurred in moment calculation",
                        "Sample size too small for normal approximation."}
 
 # For some functions, nan_policy='propagate' should not just return NaNs
-override_propagate_funcs = {stats.mode}
+override_propagate_funcs = {stats.mode, stats.describe}
 
 
 def _mixed_data_generator(n_samples, n_repetitions, axis, rng,


### PR DESCRIPTION
#### Reference issue
Toward gh-14651

#### What does this implement/fix?
Adds axis tuple support, masked array support, and `keepdims` parameter to `describe`. Fixes `nan_policy` implementation and edge cases.

#### Additional information
Need to add tests.
`describe` is unusual in that
- the shape of the first element of the result, `nobs`, depends on the presence of NaNs to be omitted. `nobs` is a scalar if there are no NaNs omitted and an array if NaNs have been omitted. Apparently, there are no tests that complain if this behavior is not maintained.
- It raises an error when the input is of zero size. This is not uncommon but causes some complications with `nobs`. It would be better if it were to just return `nobs=0` and NaN for all the rest.
- The second output, `minmax`, is a tuple containing two arrays, the minimum element and the maximum element. Ideally, these would just be two separate attributes of the result object. This is not too hard to handle.

Marking this as draft so we can decide whether we want to go through with this.

 