### PR TITLE
FIX: CI: avoid passing Cython files to ruff

### DIFF
--- a/tools/lint.py
+++ b/tools/lint.py
@@ -71,7 +71,7 @@ def run_ruff(files, fix):
         return 0, ""
     args = ['--fix', '--exit-non-zero-on-fix'] if fix else []
     res = subprocess.run(
-        ['ruff', f'--config={CONFIG}'] + args + files,
+        ['ruff', f'--config={CONFIG}'] + args + list(files),
         stdout=subprocess.PIPE,
         encoding='utf-8'
     )
@@ -82,7 +82,7 @@ def run_cython_lint(files):
     if not files:
         return 0, ""
     res = subprocess.run(
-        ['cython-lint', '--no-pycodestyle'] + files,
+        ['cython-lint', '--no-pycodestyle'] + list(files),
         stdout=subprocess.PIPE,
         encoding='utf-8'
     )
@@ -116,9 +116,9 @@ def main():
     else:
         files = args.files
 
-    cython_exts = ['.pyx']  # Add '.pxd', '.pxi' once cython-lint supports it
-    cython_files = [f for f in files if any(f.endswith(ext) for ext in cython_exts)]
-    other_files = [f for f in files if not f.endswith('.pyx')]
+    cython_exts = ('.pyx', '.pxd', '.pxi')
+    cython_files = {f for f in files if any(f.endswith(ext) for ext in cython_exts)}
+    other_files = set(files) - cython_files
 
     rc_cy, errors = run_cython_lint(cython_files)
     if errors:


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

- resolves CI lint issues discovered in https://github.com/scipy/scipy/pull/17961

#### What does this implement/fix?
<!--Please explain your changes.-->

- avoids passing unsupported Cython files to Ruff linter

#### Additional information
<!--Any additional information you think is important.-->
