### PR TITLE
BLD: make sure macosx_x86_64 10.9 tags are being made on maintenance/1.10.x

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -145,6 +145,15 @@ jobs:
           CIBW_ARCHS: ${{ matrix.buildplat[2] }}
           CIBW_ENVIRONMENT_PASS_LINUX: RUNNER_OS
 
+          # MACOS_DEPLOYMENT_TARGET is set because of
+          # https://github.com/pypa/cibuildwheel/issues/1419. Once that
+          # is closed and meson-python==0.13 is available, then
+          # that environment variable can be removed.
+          CIBW_ENVIRONMENT_MACOS: >
+            MACOSX_DEPLOYMENT_TARGET=10.9
+            MACOS_DEPLOYMENT_TARGET=10.9
+            _PYTHON_HOST_PLATFORM=macosx-10.9-x86_64
+
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl


### PR DESCRIPTION
This PR makes sure that macosx_x86_64 wheels are being tagged correctly as `10_9`. Wheels were being incorrectly tagged as `10_15` due to the issue being reported in https://github.com/pypa/cibuildwheel/issues/1419.

This PR is made against the `maintenance/1.10.x` branch because the issue will be fixed as part of #17950, and we don't want to include the entire PR because it's also bumping things like OpenBLAS.

Before this is merged the committer (@tylerjereddy ?) should check that the wheel build for `macosx_x86_64` is producing wheels tagged as `10_9`, not `10_15`.