### PR TITLE
ENH: stats.expectile: add axis, nan_policy, keepdims, MA support

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -10190,6 +10190,13 @@ def rankdata(a, method='average', *, axis=None, nan_policy='propagate'):
     return result
 
 
+def _n_samples_expectile(kwargs):
+    return 2 if np.shape(kwargs.get('alpha', None)) else 1
+
+
+@_axis_nan_policy_factory(lambda x: x, result_to_tuple=lambda x: (x,),
+                          n_samples=_n_samples_expectile, n_outputs=1,
+                          kwd_samples=['weights'])
 def expectile(a, alpha=0.5, *, weights=None):
     r"""Compute the expectile at the specified level.
 
@@ -10201,8 +10208,10 @@ def expectile(a, alpha=0.5, *, weights=None):
     ----------
     a : array_like
         Array containing numbers whose expectile is desired.
-    alpha : float, default: 0.5
+    alpha : float or array_like, default: 0.5
         The level of the expectile; e.g., `alpha=0.5` gives the mean.
+        If array_like, then its length along `axis` must equal 1, and it must
+        otherwise be broadcastable with `a`.
     weights : array_like, optional
         An array of weights associated with the values in `a`.
         The `weights` must be broadcastable to the same shape as `a`.
@@ -10289,6 +10298,8 @@ def expectile(a, alpha=0.5, *, weights=None):
             "The expectile level alpha must be in the range [0, 1]."
         )
     a = np.asarray(a)
+    if a.size == 0:
+        return np.float64('nan')
 
     if weights is not None:
         weights = np.broadcast_to(weights, a.shape)

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -48,6 +48,7 @@ axis_nan_policy_cases = [
     (stats.jarque_bera, tuple(), dict(), 1, 2, False, None),
     (stats.ttest_1samp, (np.array([0]),), dict(), 1, 7, False,
      unpack_ttest_result),
+    (stats.expectile, (np.array([0.5]),), dict(), 1, 1, False, lambda x: (x,)),
     (stats.ttest_rel, tuple(), dict(), 2, 7, True, unpack_ttest_result),
     (stats.mode, tuple(), dict(), 1, 2, True, lambda x: (x.mode, x.count))
 ]


### PR DESCRIPTION
#### Reference issue
gh-17039

#### What does this implement/fix?
Add `axis`, `nan_policy`, `keepdims`, and masked array support to `scipy.stats.expectile`.

#### Additional information
As written, broadcasting with `alpha` is treated as though `alpha` were a sample of size 1. This is what `ttest_1samp` does, and it gives the user complete control over whether the elements of `alpha` correspond with the elements of `a`, like:
```python3
from scipy.stats import expectile
stats.expectile([[1, 2, 3], [2, 3, 4]], [[0], [1]], axis=-1)  # array([1., 4.])
```
or whether each element of `alpha` is to be used with every element of `a`:
```python3
stats.expectile([[1, 2, 3], [2, 3, 4]], [[[0]], [[1]]], axis=-1)
# array([[1., 2.],
#        [3., 4.]])
```

This is different from the convention of `numpy.percentile`, in which each element of `alpha` is *always* used with every slice of `a` (combinatorially):
```python3
import numpy as np
np.percentile([[1, 2, 3], [2, 3, 4]], [0, 100], axis=-1)
# array([[1., 2.],
#        [3., 4.]])
```

A third option is to think of each 1d slice of `a` as an "element" and each scalar of `alpha` as an "element"; _then_ apply normal broadcasting rules. When `axis=-1`, this is equivalent to automatically appending a singleton dimension to `alpha`.
```python3
from scipy.stats import expectile
stats.expectile([[1, 2, 3], [2, 3, 4]], [0, 1], axis=-1)  # array([1., 4.])
stats.expectile([[1, 2, 3], [2, 3, 4]], [[0], [1]], axis=-1)
# array([[1., 2.],
#        [3., 4.]])
```
I'd need to think a bit more about how this generalizes, though. There's not a ton of precedent within SciPy, and I don't really agree with the NumPy `percentile` convention because of the lack of control.
