### PR TITLE
DOC: update link of the logo in the readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
-.. image:: doc/source/_static/logo.svg
+.. image:: https://github.com/scipy/scipy/blob/main/doc/source/_static/logo.svg
   :target: https://scipy.org
-  :width: 100
-  :height: 100
+  :width: 110
+  :height: 110
   :align: left 
 
 .. image:: https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A


### PR DESCRIPTION
Relative links do not render on PyPi! i.e. we don't have our logo on PyPi at the moment...

@tylerjereddy flagging this for backport if there is still time to fix the situation on PyPi. But could as well do it manually.

Also using this opportunity to enlarge a bit the logo to have better line wrapping in GitHub.