### PR TITLE
MAINT: sparse.linalg: remove unused __main__ code

### DIFF
--- a/scipy/sparse/linalg/_isolve/minres.py
+++ b/scipy/sparse/linalg/_isolve/minres.py
@@ -370,23 +370,3 @@ def minres(A, b, x0=None, shift=0.0, tol=1e-5, maxiter=None,
         info = 0
 
     return (postprocess(x),info)
-
-
-if __name__ == '__main__':
-    from numpy import arange
-    from scipy.sparse import spdiags
-
-    n = 10
-
-    residuals = []
-
-    def cb(x):
-        residuals.append(norm(b - A@x))
-
-    # A = poisson((10,),format='csr')
-    A = spdiags([arange(1,n+1,dtype=float)], [0], n, n, format='csr')
-    M = spdiags([1.0/arange(1,n+1,dtype=float)], [0], n, n, format='csr')
-    A.psolve = M.matvec
-    b = zeros(A.shape[0])
-    x = minres(A,b,tol=1e-12,maxiter=None,callback=cb)
-    # x = cg(A,b,x0=b,tol=1e-12,maxiter=None,callback=cb)[0]

--- a/scipy/sparse/linalg/_isolve/tests/test_lsmr.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_lsmr.py
@@ -16,7 +16,7 @@ Dept of MS&E, Stanford University.
 
 """
 
-from numpy import array, arange, eye, zeros, ones, sqrt, transpose, hstack
+from numpy import array, arange, eye, zeros, ones, transpose, hstack
 from numpy.linalg import norm
 from numpy.testing import assert_allclose
 import pytest
@@ -183,46 +183,3 @@ def lowerBidiagonalMatrix(m, n):
         data = hstack((arange(1, n+1, dtype=float),
                        arange(1,n+1, dtype=float)))
         return coo_matrix((data,(row, col)), shape=(m,n))
-
-
-def lsmrtest(m, n, damp):
-    """Verbose testing of lsmr"""
-
-    A = lowerBidiagonalMatrix(m,n)
-    xtrue = arange(n,0,-1, dtype=float)
-    Afun = aslinearoperator(A)
-
-    b = Afun.matvec(xtrue)
-
-    atol = 1.0e-7
-    btol = 1.0e-7
-    conlim = 1.0e+10
-    itnlim = 10*n
-    show = 1
-
-    x, istop, itn, normr, normar, norma, conda, normx \
-      = lsmr(A, b, damp, atol, btol, conlim, itnlim, show)
-
-    j1 = min(n,5)
-    j2 = max(n-4,1)
-    print(' ')
-    print('First elements of x:')
-    str = ['%10.4f' % (xi) for xi in x[0:j1]]
-    print(''.join(str))
-    print(' ')
-    print('Last  elements of x:')
-    str = ['%10.4f' % (xi) for xi in x[j2-1:]]
-    print(''.join(str))
-
-    r = b - Afun.matvec(x)
-    r2 = sqrt(norm(r)**2 + (damp*norm(x))**2)
-    print(' ')
-    str = 'normr (est.)  %17.10e' % (normr)
-    str2 = 'normr (true)  %17.10e' % (r2)
-    print(str)
-    print(str2)
-    print(' ')
-
-
-if __name__ == "__main__":
-    lsmrtest(20,10,0)

--- a/scipy/sparse/linalg/_isolve/tests/test_lsqr.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_lsqr.py
@@ -4,7 +4,6 @@ import pytest
 import scipy.sparse
 import scipy.sparse.linalg
 from scipy.sparse.linalg import lsqr
-from time import time
 
 # Set up a test problem
 n = 35
@@ -119,35 +118,3 @@ def test_initialization():
     x = lsqr(G, b, show=show, atol=tol, btol=tol, iter_lim=maxit, x0=x0)
     assert_allclose(x_ref[0], x[0])
     assert_array_equal(b_copy, b)
-
-
-if __name__ == "__main__":
-    svx = np.linalg.solve(G, b)
-
-    tic = time()
-    X = lsqr(G, b, show=show, atol=tol, btol=tol, iter_lim=maxit)
-    xo = X[0]
-    phio = X[3]
-    psio = X[7]
-    k = X[2]
-    chio = X[8]
-    mg = np.amax(G - G.T)
-    if mg > 1e-14:
-        sym = 'No'
-    else:
-        sym = 'Yes'
-
-    print('LSQR')
-    print("Is linear operator symmetric? " + sym)
-    print(f"n: {n:3g}  iterations:   {k:3g}")
-    print("Norms computed in %.2fs by LSQR" % (time() - tic))
-    print(f" ||x||  {chio:9.4e}  ||r|| {phio:9.4e}  ||Ar||  {psio:9.4e} ")
-    print("Residual norms computed directly:")
-    print(" ||x||  {:9.4e}  ||r|| {:9.4e}  ||Ar||  {:9.4e}".format(norm(xo),
-                                                         norm(G*xo - b),
-                                                         norm(G.T*(G*xo-b))))
-    print("Direct solution norms:")
-    print(f" ||x||  {norm(svx):9.4e}  ||r|| {norm(G*svx - b):9.4e} ")
-    print("")
-    print(" || x_{direct} - x_{LSQR}|| %9.4e " % norm(svx-xo))
-    print("")


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
#16666
#### What does this implement/fix?
<!--Please explain your changes.-->
Removes unused `__main__`, looking at the blame most of this has not been touched for 14+ years (bar linting / python 2 to 3) so seems pretty safe to tidy up
#### Additional information
<!--Any additional information you think is important.-->
