### PR TITLE
BLD: make musllinux wheels for nightly

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -78,13 +78,8 @@ jobs:
         # [windows-2019, win*, "AMD64 x86"]. However, those two require a different compiler setup
         # so easier to separate out here.
         - [ubuntu-22.04, manylinux, x86_64]
+        - [ubuntu-22.04, musllinux, x86_64]
 
-        # When the macos-10.15 image is retired the gfortran/openblas chain
-        # may have to be reworked because the gfortran-4.9.0 compiler currently
-        # used in CI doesn't work in the macos-11.0 image. This will require a more
-        # recent gfortran (gfortran-9 is present on the macOS-11.0 image), and
-        # will probably require that the prebuilt openBLAS is updated.
-        # xref https://github.com/andyfaff/scipy/pull/28#issuecomment-1203496836
         - [macos-11, macosx, x86_64]
         - [windows-2019, win, AMD64]
 
@@ -130,16 +125,6 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.12.0
-        # Build all wheels here, apart from macosx_arm64, linux_aarch64
-        # cibuildwheel is currently unable to pass configuration flags to
-        # CIBW_BUILD_FRONTEND https://github.com/pypa/cibuildwheel/issues/1227
-        # (pip/build). Cross compilation with meson requires an initial
-        # configuration step to create a build directory. The subsequent wheel
-        # build then needs to use that directory. This can be done with pip
-        # using a command like:
-        # python -m pip wheel --config-settings builddir=build .
-        if: >-
-          ( ! contains(matrix.buildplat[2], 'arm64' ) )
         env:
           CIBW_BUILD: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}*
           CIBW_ARCHS: ${{ matrix.buildplat[2] }}

--- a/ci/cirrus_wheels.yml
+++ b/ci/cirrus_wheels.yml
@@ -24,9 +24,9 @@ cirrus_wheels_linux_aarch64_task:
     # single task takes longer than 60 mins (the default time limit for a
     # cirrus-ci task).
     - env:
-        CIBW_BUILD: cp39-*
+        CIBW_BUILD: cp39-manylinux*
     - env:
-        CIBW_BUILD: cp310-* cp311-*
+        CIBW_BUILD: cp310-manylinux* cp311-manylinux*
   build_script: |
     apt install -y python3-venv python-is-python3
     which python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,7 +136,7 @@ dodoFile = "dev.py"
 
 
 [tool.cibuildwheel]
-skip = "cp36-* cp37-* cp38-* pp* *_ppc64le *_i686 *_s390x *-musllinux*"
+skip = "cp36-* cp37-* cp38-* pp* *_ppc64le *_i686 *_s390x"
 build-verbosity = "3"
 # gmpy2 and scikit-umfpack are usually added for testing. However, there are
 # currently wheels missing that make the test script fail.


### PR DESCRIPTION
This PR adds `musllinux_x86_64` to the list of wheels being built by cibuildwheel. The wheels would get uploaded to `nightly` and staging.

At the moment I believe the intention is to have wheels on there as 'unofficial wheels' suitable for downstream libraries and unofficial use (not officially supported).

