### PR TITLE
BUG: at least one entry from trial should be used in exponential crossover

### DIFF
--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -1521,6 +1521,7 @@ class DifferentialEvolutionSolver:
             i = 0
             crossovers = rng.uniform(size=self.parameter_count)
             crossovers = crossovers < self.cross_over_probability
+            crossovers[0] = True
             while (i < self.parameter_count and crossovers[i]):
                 trial[fill_point] = bprime[fill_point]
                 fill_point = (fill_point + 1) % self.parameter_count


### PR DESCRIPTION
According to [10.1023/A:1008202821328](http://dx.doi.org/10.1023/A:1008202821328) it seems like at least one point should be used from the trial vector during exponential crossover.

This is backed up [J Heuristics ](http://dx.doi.org/10.1007/s10732-010-9151-1).

This is obviously a reasonably long standing issue, but since the exponential crossovers aren't the default strategy hopefully the impact wouldn't be large.