### PR TITLE
ENH: optimize.RootResults: make `RootResults` an `OptimizeResult`

### DIFF
--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -228,7 +228,9 @@ class OptimizeResult(dict):
 
     def __repr__(self):
         order_keys = ['message', 'success', 'status', 'fun', 'funl', 'x', 'xl',
-                      'col_ind', 'nit', 'lower', 'upper', 'eqlin', 'ineqlin']
+                      'col_ind', 'nit', 'lower', 'upper', 'eqlin', 'ineqlin',
+                      'converged', 'flag', 'function_calls', 'iterations',
+                      'root']
         # 'slack', 'con' are redundant with residuals
         # 'crossover_nit' is probably not interesting to most users
         omit_keys = {'slack', 'con', 'crossover_nit'}

--- a/scipy/optimize/_zeros_py.py
+++ b/scipy/optimize/_zeros_py.py
@@ -1359,7 +1359,7 @@ def toms748(f, a, b, args=(), k=1,
     1.0
     >>> results
           converged: True
-               flag: 'converged'
+               flag: converged
      function_calls: 11
          iterations: 5
                root: 1.0

--- a/scipy/optimize/_zeros_py.py
+++ b/scipy/optimize/_zeros_py.py
@@ -2,6 +2,7 @@ import warnings
 from collections import namedtuple
 import operator
 from . import _zeros
+from ._optimize import OptimizeResult
 import numpy as np
 
 
@@ -30,7 +31,7 @@ flag_map = {_ECONVERGED: CONVERGED, _ESIGNERR: SIGNERR, _ECONVERR: CONVERR,
             _EVALUEERR: VALUEERR, _EINPROGRESS: INPROGRESS}
 
 
-class RootResults:
+class RootResults(OptimizeResult):
     """Represents the root finding result.
 
     Attributes
@@ -58,13 +59,6 @@ class RootResults:
             self.flag = flag_map[flag]
         except KeyError:
             self.flag = 'unknown error %d' % (flag,)
-
-    def __repr__(self):
-        attrs = ['converged', 'flag', 'function_calls',
-                 'iterations', 'root']
-        m = max(map(len, attrs)) + 1
-        return '\n'.join([a.rjust(m) + ': ' + repr(getattr(self, a))
-                          for a in attrs])
 
 
 def results_c(full_output, r):

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -12,7 +12,8 @@ import numpy as np
 from numpy import finfo, power, nan, isclose
 
 
-from scipy.optimize import _zeros_py as zeros, newton, root_scalar
+from scipy.optimize import (_zeros_py as zeros, newton, root_scalar,
+                            OptimizeResult)
 
 from scipy._lib._util import getfullargspec_no_self as _getfullargspec
 
@@ -554,16 +555,16 @@ def test_brent_underflow_in_root_bracketing():
 
 
 class TestRootResults:
+    r = zeros.RootResults(root=1.0, iterations=44, function_calls=46, flag=0)
+
     def test_repr(self):
-        r = zeros.RootResults(root=1.0,
-                              iterations=44,
-                              function_calls=46,
-                              flag=0)
-        expected_repr = ("      converged: True\n           flag: 'converged'"
+        expected_repr = ("      converged: True\n           flag: converged"
                          "\n function_calls: 46\n     iterations: 44\n"
                          "           root: 1.0")
-        assert_equal(repr(r), expected_repr)
+        assert_equal(repr(self.r), expected_repr)
 
+    def test_type(self):
+        assert isinstance(self.r, OptimizeResult)
 
 def test_complex_halley():
     """Test Halley's works with complex roots"""


### PR DESCRIPTION
#### Reference issue
gh-17719

#### What does this implement/fix?
Makes `RootResults` inherit from `OptimizeResult`. 

#### Additional information
The reason to do this is that gh-17719 is adding a new vectorized scalar root finder. We want it to fit with the other method of `root_scalar` in returning a `RootResult`, but we want the improved pretty-printing of `OptimizeResult`.

This also sets the stage for unifying the attributes of `RootResults` and `OptimizeResult` (e.g. adding aliases; deprecating old names), and I'd be happy to see that done, but I don't personally want to do that at this time.