### PR TITLE
MAINT: SciPy 1.10.1 backports round 2

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -94,6 +94,7 @@ Bhavika Tekwani <bhavicka.7992@gmail.com> bhavikat <bhavicka.7992@gmail.com>
 Blair Azzopardi <blairuk@gmail.com> bsdz <blairuk@gmail.com>
 Blair Azzopardi <blairuk@gmail.com> Blair Azzopardi <bsdz@users.noreply.github.com>
 Brandon David <brandon.david@zoho.com> brandondavid <brandon.david@zoho.com>
+Brett Graham <brettgraham@gmail.com> Brett <brettgraham@gmail.com>
 Brett R. Murphy <bmurphy@enthought.com> brettrmurphy <bmurphy@enthought.com>
 Brian Hawthorne <brian.hawthorne@localhost> brian.hawthorne <brian.hawthorne@localhost>
 Brian Newsom <brian.newsom@colorado.edu> Brian Newsom <Brian.Newsom@Colorado.edu>
@@ -193,6 +194,7 @@ Fukumu Tsutsumi <levelfourslv@gmail.com> levelfour <levelfourslv@gmail.com>
 G Young <gfyoung17@gmail.com> gfyoung <gfyoung17@gmail.com>
 G Young <gfyoung17@gmail.com> gfyoung <gfyoung@mit.edu>
 Gagandeep Singh <gdp.1807@gmail.com> czgdp1807 <gdp.1807@gmail.com>
+Ganesh Kathiresan <ganesh3597@gmail.com> ganesh-k13 <ganesh3597@gmail.com>
 Garrett Reynolds <garrettreynolds5@gmail.com> Garrett-R <garrettreynolds5@gmail.com>
 Gaël Varoquaux <gael.varoquaux@normalesup.org> Gael varoquaux <gael.varoquaux@normalesup.org>
 Gavin Zhang <zhanggan@cn.ibm.com> GavinZhang <zhanggan@cn.ibm.com>
@@ -231,6 +233,7 @@ Jacob Vanderplas <jakevdp@gmail.com> Jake Vanderplas <jakevdp@gmail.com>
 Jacob Vanderplas <jakevdp@gmail.com> Jake Vanderplas <jakevdp@yahoo.com>
 Jacob Vanderplas <jakevdp@gmail.com> Jake Vanderplas <vanderplas@astro.washington.edu>
 Jacob Vanderplas <jakevdp@gmail.com> Jacob Vanderplas <jakevdp@yahoo.com>
+Jacopo Tissino <jacopok@gmail.com> Jacopo <jacopok@gmail.com>
 Jaime Fernandez del Rio <jaime.frio@gmail.com> jaimefrio <jaime.frio@gmail.com>
 Jaime Fernandez del Rio <jaime.frio@gmail.com> Jaime <jaime.frio@gmail.com>
 Jaime Fernandez del Rio <jaime.frio@gmail.com> Jaime Fernandez <jaimefrio@google.com>
@@ -483,6 +486,7 @@ Todd Goodall <beyondmetis@gmail.com> Todd <beyondmetis@gmail.com>
 Todd Jennings <toddrjen@gmail.com> Todd <toddrjen@gmail.com>
 Tom Waite <tom.waite@localhost> tom.waite <tom.waite@localhost>
 Tom Donoghue <tdonoghue@ucsd.edu> TomDonoghue <tdonoghue@ucsd.edu>
+Tomer Sery <tomer.sery@nextsilicon.com> Tomer.Sery <tomer.sery@nextsilicon.com>
 Tony S. Yu <tsyu80@gmail.com> tonysyu <tsyu80@gmail.com>
 Tony S. Yu <tsyu80@gmail.com> Tony S Yu <tsyu80@gmail.com>
 Toshiki Kataoka <tos.lunar@gmail.com> Toshiki Kataoka <kataoka@preferred.jp>

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
-.. image:: doc/source/_static/logo.svg
+.. image:: https://github.com/scipy/scipy/blob/main/doc/source/_static/logo.svg
   :target: https://scipy.org
-  :width: 100
-  :height: 100
+  :width: 110
+  :height: 110
   :align: left 
 
 .. image:: https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A

--- a/doc/release/1.10.1-notes.rst
+++ b/doc/release/1.10.1-notes.rst
@@ -12,22 +12,29 @@ compared to 1.10.0.
 Authors
 =======
 * Name (commits)
-* Brett (1) +
+* alice (1) +
+* Matt Borland (2) +
 * Evgeni Burovski (2)
+* CJ Carey (1)
 * Ralf Gommers (9)
+* Brett Graham (1) +
 * Matt Haberland (5)
-* Jacopo (1) +
-* Ganesh Kathiresan (1) +
+* Alex Herbert (1) +
+* Ganesh Kathiresan (2) +
 * Rishi Kulkarni (1) +
 * Loïc Estève (1)
 * Michał Górny (1) +
 * Jarrod Millman (1)
-* Andrew Nelson (1)
-* Tyler Reddy (36)
-* Pamphile Roy (1)
+* Andrew Nelson (4)
+* Tyler Reddy (50)
+* Pamphile Roy (2)
 * Eli Schwartz (2)
+* Tomer Sery (1) +
+* Kai Striega (1)
+* Jacopo Tissino (1) +
+* windows-server-2003 (1)
 
-A total of 14 people contributed to this release.
+A total of 21 people contributed to this release.
 People with a "+" by their names contributed a patch for the first time.
 This list of names is automatically generated, and may not be fully complete.
 
@@ -35,17 +42,22 @@ This list of names is automatically generated, and may not be fully complete.
 Issues closed for 1.10.1
 ------------------------
 
+* `#14980 <https://github.com/scipy/scipy/issues/14980>`__: BUG: Johnson's algorithm fails without negative cycles
 * `#17670 <https://github.com/scipy/scipy/issues/17670>`__: Failed to install on Raspberry Pi (ARM) 32bit in 3.11.1
 * `#17715 <https://github.com/scipy/scipy/issues/17715>`__: scipy.stats.bootstrap broke with statistic returning multiple...
 * `#17716 <https://github.com/scipy/scipy/issues/17716>`__: BUG: interpolate.interpn fails with read only input
 * `#17718 <https://github.com/scipy/scipy/issues/17718>`__: BUG: RegularGridInterpolator 2D mixed precision crashes
 * `#17727 <https://github.com/scipy/scipy/issues/17727>`__: BUG: RegularGridInterpolator does not work on non-native byteorder...
 * `#17736 <https://github.com/scipy/scipy/issues/17736>`__: BUG: SciPy requires OpenBLAS even when building against a different...
+* `#17775 <https://github.com/scipy/scipy/issues/17775>`__: BUG: Asymptotic computation of ksone.sf has intermediate overflow
+* `#17782 <https://github.com/scipy/scipy/issues/17782>`__: BUG: Segfault in scipy.sparse.csgraph.shortest_path() with v1.10.0
 * `#17795 <https://github.com/scipy/scipy/issues/17795>`__: BUG: stats.pearsonr one-sided hypothesis yields incorrect p-value...
 * `#17801 <https://github.com/scipy/scipy/issues/17801>`__: BUG: stats.powerlaw.fit: raises OverflowError
 * `#17808 <https://github.com/scipy/scipy/issues/17808>`__: BUG: name of cython executable is hardcoded in _build_utils/cythoner.py
 * `#17811 <https://github.com/scipy/scipy/issues/17811>`__: CI job with numpy nightly build failing on missing \`_ArrayFunctionDispatcher.__code__\`
+* `#17839 <https://github.com/scipy/scipy/issues/17839>`__: BUG: 1.10.0 tests fail on i386 and other less common arches
 * `#17896 <https://github.com/scipy/scipy/issues/17896>`__: DOC: publicly expose \`multivariate_normal\` attributes \`mean\`...
+* `#17934 <https://github.com/scipy/scipy/issues/17934>`__: BUG: meson \`__config__\` generation - truncated unicode characters
 * `#17938 <https://github.com/scipy/scipy/issues/17938>`__: BUG: \`scipy.stats.qmc.LatinHypercube\` with \`optimization="random-cd"\`...
 
 
@@ -59,18 +71,29 @@ Pull requests for 1.10.1
 * `#17735 <https://github.com/scipy/scipy/pull/17735>`__: MAINT: stats.bootstrap: fix BCa with vector-valued statistics
 * `#17743 <https://github.com/scipy/scipy/pull/17743>`__: DOC: improve the docs on using BLAS/LAPACK libraries with Meson
 * `#17777 <https://github.com/scipy/scipy/pull/17777>`__: BLD: link to libatomic if necessary
+* `#17783 <https://github.com/scipy/scipy/pull/17783>`__: BUG: Correct intermediate overflow in KS one asymptotic in SciPy.stats
+* `#17790 <https://github.com/scipy/scipy/pull/17790>`__: BUG: signal: fix check_malloc extern declaration type
 * `#17797 <https://github.com/scipy/scipy/pull/17797>`__: MAINT: stats.pearsonr: correct p-value with negative correlation...
+* `#17800 <https://github.com/scipy/scipy/pull/17800>`__: [sparse.csgraph] Fix a bug in dijkstra and johnson algorithm
 * `#17803 <https://github.com/scipy/scipy/pull/17803>`__: MAINT: add missing \`__init__.py\` in test folder
 * `#17806 <https://github.com/scipy/scipy/pull/17806>`__: MAINT: stats.powerlaw.fit: fix overflow when np.min(data)==0
 * `#17810 <https://github.com/scipy/scipy/pull/17810>`__: BLD: use Meson's found cython instead of a wrapper script
 * `#17831 <https://github.com/scipy/scipy/pull/17831>`__: MAINT, CI: GHA MacOS setup.py update
 * `#17850 <https://github.com/scipy/scipy/pull/17850>`__: MAINT: remove use of \`__code__\` in \`scipy.integrate\`
 * `#17854 <https://github.com/scipy/scipy/pull/17854>`__: TST: mark test for \`stats.kde.marginal\` as xslow
+* `#17855 <https://github.com/scipy/scipy/pull/17855>`__: BUG: Fix handling of \`powm1\` overflow errors
 * `#17859 <https://github.com/scipy/scipy/pull/17859>`__: TST: fix test failures on i386, s390x, ppc64, riscv64 (Debian)
 * `#17862 <https://github.com/scipy/scipy/pull/17862>`__: BLD: Meson \`__config__\` generation
+* `#17863 <https://github.com/scipy/scipy/pull/17863>`__: BUG: fix Johnson's algorithm
+* `#17872 <https://github.com/scipy/scipy/pull/17872>`__: BUG: fix powm1 overflow handling
 * `#17904 <https://github.com/scipy/scipy/pull/17904>`__: ENH: \`multivariate_normal_frozen\`: restore \`cov\` attribute
 * `#17910 <https://github.com/scipy/scipy/pull/17910>`__: CI: use nightly numpy musllinux_x86_64 wheel
 * `#17931 <https://github.com/scipy/scipy/pull/17931>`__: TST: test_location_scale proper 32bit Linux skip
 * `#17932 <https://github.com/scipy/scipy/pull/17932>`__: TST: 32-bit tol for test_pdist_jensenshannon_iris
+* `#17936 <https://github.com/scipy/scipy/pull/17936>`__: BUG: Use raw strings for paths in \`__config__.py.in\`
 * `#17940 <https://github.com/scipy/scipy/pull/17940>`__: BUG: \`rng_integers\` in \`_random_cd\` now samples on a closed...
 * `#17942 <https://github.com/scipy/scipy/pull/17942>`__: BLD: update classifiers for Python 3.11
+* `#17963 <https://github.com/scipy/scipy/pull/17963>`__: MAINT: backports/prep for SciPy 1.10.1
+* `#17981 <https://github.com/scipy/scipy/pull/17981>`__: BLD: make sure macosx_x86_64 10.9 tags are being made on maintenance/1.10.x
+* `#17984 <https://github.com/scipy/scipy/pull/17984>`__: DOC: update link of the logo in the readme
+* `#17997 <https://github.com/scipy/scipy/pull/17997>`__: BUG: at least one entry from trial should be used in exponential...

--- a/scipy/__config__.py.in
+++ b/scipy/__config__.py.in
@@ -17,7 +17,7 @@ def _cleanup(d):
     This ensures we remove values that Meson could not provide to CONFIG
     """
     if isinstance(d, dict):
-        return { k: _cleanup(v) for k, v in d.items() if v and _cleanup(v) }
+        return { k: _cleanup(v) for k, v in d.items() if v != '' and _cleanup(v) != '' }
     else:
         return d
 
@@ -51,7 +51,7 @@ CONFIG = _cleanup(
             },
             "pythran": {
                 "version": "@PYTHRAN_VERSION@",
-                "include directory": "@PYTHRAN_INCDIR@"
+                "include directory": r"@PYTHRAN_INCDIR@"
             },
         },
         "Machine Information": {
@@ -67,32 +67,32 @@ CONFIG = _cleanup(
                 "endian": "@BUILD_CPU_ENDIAN@",
                 "system": "@BUILD_CPU_SYSTEM@",
             },
-            "cross-compiled": "@CROSS_COMPILED@",
+            "cross-compiled": bool("@CROSS_COMPILED@".lower().replace('false', '')),
         },
         "Build Dependencies": {
             "blas": {
                 "name": "@BLAS_NAME@",
-                "found": "@BLAS_FOUND@",
+                "found": bool("@BLAS_FOUND@".lower().replace('false', '')),
                 "version": "@BLAS_VERSION@",
                 "detection method": "@BLAS_TYPE_NAME@",
-                "include directory": "@BLAS_INCLUDEDIR@",
-                "lib directory": "@BLAS_LIBDIR@",
+                "include directory": r"@BLAS_INCLUDEDIR@",
+                "lib directory": r"@BLAS_LIBDIR@",
                 "openblas configuration": "@BLAS_OPENBLAS_CONFIG@",
-                "pc file directory": "@BLAS_PCFILEDIR@",
+                "pc file directory": r"@BLAS_PCFILEDIR@",
             },
             "lapack": {
                 "name": "@LAPACK_NAME@",
-                "found": "@LAPACK_FOUND@",
+                "found": bool("@LAPACK_FOUND@".lower().replace('false', '')),
                 "version": "@LAPACK_VERSION@",
                 "detection method": "@LAPACK_TYPE_NAME@",
-                "include directory": "@LAPACK_INCLUDEDIR@",
-                "lib directory": "@LAPACK_LIBDIR@",
+                "include directory": r"@LAPACK_INCLUDEDIR@",
+                "lib directory": r"@LAPACK_LIBDIR@",
                 "openblas configuration": "@LAPACK_OPENBLAS_CONFIG@",
-                "pc file directory": "@LAPACK_PCFILEDIR@",
+                "pc file directory": r"@LAPACK_PCFILEDIR@",
             },
         },
         "Python Information": {
-            "path": "@PYTHON_PATH@",
+            "path": r"@PYTHON_PATH@",
             "version": "@PYTHON_VERSION@",
         },
     }

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -1497,6 +1497,7 @@ class DifferentialEvolutionSolver:
             i = 0
             crossovers = rng.uniform(size=self.parameter_count)
             crossovers = crossovers < self.cross_over_probability
+            crossovers[0] = True
             while (i < self.parameter_count and crossovers[i]):
                 trial[fill_point] = bprime[fill_point]
                 fill_point = (fill_point + 1) % self.parameter_count

--- a/scipy/signal/_medianfilter.c
+++ b/scipy/signal/_medianfilter.c
@@ -10,7 +10,7 @@
 void f_medfilt2(float*,float*,npy_intp*,npy_intp*);
 void d_medfilt2(double*,double*,npy_intp*,npy_intp*);
 void b_medfilt2(unsigned char*,unsigned char*,npy_intp*,npy_intp*);
-extern char *check_malloc (int);
+extern char *check_malloc (size_t);
 
 
 /* The QUICK_SELECT routine is based on Hoare's Quickselect algorithm,

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -1337,6 +1337,7 @@ cdef int _johnson_directed(
             const int[:] csr_indices,
             const int[:] csr_indptr,
             double[:] dist_array):
+    # Note: The contents of dist_array must be initialized to zero on entry
     cdef:
         unsigned int N = dist_array.shape[0]
         unsigned int j, k, count
@@ -1344,10 +1345,6 @@ cdef int _johnson_directed(
 
     # relax all edges (N+1) - 1 times
     for count in range(N):
-        for k in range(N):
-            if dist_array[k] < 0:
-                dist_array[k] = 0
-
         for j in range(N):
             d1 = dist_array[j]
             for k in range(csr_indptr[j], csr_indptr[j + 1]):
@@ -1373,6 +1370,7 @@ cdef int _johnson_undirected(
             const int[:] csr_indices,
             const int[:] csr_indptr,
             double[:] dist_array):
+    # Note: The contents of dist_array must be initialized to zero on entry
     cdef:
         unsigned int N = dist_array.shape[0]
         unsigned int j, k, ind_k, count
@@ -1380,10 +1378,6 @@ cdef int _johnson_undirected(
 
     # relax all edges (N+1) - 1 times
     for count in range(N):
-        for k in range(N):
-            if dist_array[k] < 0:
-                dist_array[k] = 0
-
         for j in range(N):
             d1 = dist_array[j]
             for k in range(csr_indptr[j], csr_indptr[j + 1]):

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -1556,7 +1556,7 @@ cdef void decrease_val(FibonacciHeap* heap,
         # at the leftmost end of the roots' linked-list.
         remove(node)
         node.right_sibling = heap.min_node
-        heap.min_node.left_sibling = node.right_sibling
+        heap.min_node.left_sibling = node
         heap.min_node = node
 
 

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -1,7 +1,7 @@
 from io import StringIO
 import warnings
 import numpy as np
-from numpy.testing import assert_array_almost_equal, assert_array_equal
+from numpy.testing import assert_array_almost_equal, assert_array_equal, assert_allclose
 from pytest import raises as assert_raises
 from scipy.sparse.csgraph import (shortest_path, dijkstra, johnson,
                                   bellman_ford, construct_dist_matrix,
@@ -78,6 +78,14 @@ undirected_pred = np.array([[-9999, 0, 0, 0, 0],
                             [2, 0, -9999, 0, 0],
                             [3, 3, 0, -9999, 3],
                             [4, 4, 0, 4, -9999]], dtype=float)
+
+directed_negative_weighted_G = np.array([[0, 0, 0],
+                                         [-1, 0, 0],
+                                         [0, -1, 0]], dtype=float)
+
+directed_negative_weighted_SP = np.array([[0, np.inf, np.inf],
+                                          [-1, 0, np.inf],
+                                          [-2, -1, 0]], dtype=float)
 
 methods = ['auto', 'FW', 'D', 'BF', 'J']
 
@@ -321,6 +329,12 @@ def test_negative_cycles():
     for method in ['FW', 'J', 'BF']:
         for directed in (True, False):
             check(method, directed)
+
+
+@pytest.mark.parametrize("method", ['FW', 'J', 'BF'])
+def test_negative_weights(method):
+    SP = shortest_path(directed_negative_weighted_G, method, directed=True)
+    assert_allclose(SP, directed_negative_weighted_SP, atol=1e-10)
 
 
 def test_masked_input():

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -1,3 +1,4 @@
+from io import StringIO
 import warnings
 import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_array_equal
@@ -6,6 +7,7 @@ from scipy.sparse.csgraph import (shortest_path, dijkstra, johnson,
                                   bellman_ford, construct_dist_matrix,
                                   NegativeCycleError)
 import scipy.sparse
+from scipy.io import mmread
 import pytest
 
 directed_G = np.array([[0, 3, 3, 0, 0],
@@ -176,7 +178,7 @@ def test_dijkstra_indices_min_only(directed, SP_ans, indices):
 
 
 @pytest.mark.parametrize('n', (10, 100, 1000))
-def test_shortest_path_min_only_random(n):
+def test_dijkstra_min_only_random(n):
     np.random.seed(1234)
     data = scipy.sparse.rand(n, n, density=0.5, format='lil',
                              random_state=42, dtype=np.float64)
@@ -186,7 +188,7 @@ def test_shortest_path_min_only_random(n):
     np.random.shuffle(v)
     indices = v[:int(n*.1)]
     ds, pred, sources = dijkstra(data,
-                                 directed=False,
+                                 directed=True,
                                  indices=indices,
                                  min_only=True,
                                  return_predecessors=True)
@@ -196,6 +198,48 @@ def test_shortest_path_min_only_random(n):
         while p != -9999:
             assert sources[p] == s
             p = pred[p]
+
+
+def test_dijkstra_random():
+    # reproduces the hang observed in gh-17782
+    n = 10
+    indices = [0, 4, 4, 5, 7, 9, 0, 6, 2, 3, 7, 9, 1, 2, 9, 2, 5, 6]
+    indptr = [0, 0, 2, 5, 6, 7, 8, 12, 15, 18, 18]
+    data = [0.33629, 0.40458, 0.47493, 0.42757, 0.11497, 0.91653, 0.69084,
+            0.64979, 0.62555, 0.743, 0.01724, 0.99945, 0.31095, 0.15557,
+            0.02439, 0.65814, 0.23478, 0.24072]
+    graph = scipy.sparse.csr_matrix((data, indices, indptr), shape=(n, n))
+    dijkstra(graph, directed=True, return_predecessors=True)
+
+
+def test_gh_17782_segfault():
+    text = """%%MatrixMarket matrix coordinate real general
+                84 84 22
+                2 1 4.699999809265137e+00
+                6 14 1.199999973177910e-01
+                9 6 1.199999973177910e-01
+                10 16 2.012000083923340e+01
+                11 10 1.422000026702881e+01
+                12 1 9.645999908447266e+01
+                13 18 2.012000083923340e+01
+                14 13 4.679999828338623e+00
+                15 11 1.199999973177910e-01
+                16 12 1.199999973177910e-01
+                18 15 1.199999973177910e-01
+                32 2 2.299999952316284e+00
+                33 20 6.000000000000000e+00
+                33 32 5.000000000000000e+00
+                36 9 3.720000028610229e+00
+                36 37 3.720000028610229e+00
+                36 38 3.720000028610229e+00
+                37 44 8.159999847412109e+00
+                38 32 7.903999328613281e+01
+                43 20 2.400000000000000e+01
+                43 33 4.000000000000000e+00
+                44 43 6.028000259399414e+01
+    """
+    data = mmread(StringIO(text))
+    dijkstra(data, directed=True, return_predecessors=True)
 
 
 def test_shortest_path_indices():

--- a/scipy/special/boost_special_functions.h
+++ b/scipy/special/boost_special_functions.h
@@ -90,7 +90,12 @@ Real powm1_wrap(Real x, Real y)
         z = NAN;
     } catch (const std::overflow_error& e) {
         sf_error("powm1", SF_ERROR_OVERFLOW, NULL);
-        z = INFINITY;
+        if (x > 0) {
+            z = INFINITY;
+        }
+        else {
+            z = -INFINITY;
+        }
     } catch (const std::underflow_error& e) {
         sf_error("powm1", SF_ERROR_UNDERFLOW, NULL);
         z = 0;

--- a/scipy/special/boost_special_functions.h
+++ b/scipy/special/boost_special_functions.h
@@ -90,11 +90,42 @@ Real powm1_wrap(Real x, Real y)
         z = NAN;
     } catch (const std::overflow_error& e) {
         sf_error("powm1", SF_ERROR_OVERFLOW, NULL);
+        
+        // See: https://en.cppreference.com/w/cpp/numeric/math/pow
         if (x > 0) {
+            if (y < 0) {
+                z = 0;
+            }
+            else if (y == 0) {
+                z = 1;
+            }
+            else {
+                z = INFINITY;
+            }
+        }
+        else if (x == 0) {
             z = INFINITY;
         }
         else {
-            z = -INFINITY;
+            if (y < 0) {
+                if (std::fmod(y, 2) == 0) {
+                    z = 0;
+                }
+                else {
+                    z = -0;
+                }
+            }
+            else if (y == 0) {
+                z = 1;
+            }
+            else {
+                if (std::fmod(y, 2) == 0) {
+                    z = INFINITY;
+                }
+                else {
+                    z = -INFINITY;
+                }
+            }
         }
     } catch (const std::underflow_error& e) {
         sf_error("powm1", SF_ERROR_UNDERFLOW, NULL);

--- a/scipy/special/cephes/kolmogorov.c
+++ b/scipy/special/cephes/kolmogorov.c
@@ -774,10 +774,16 @@ _smirnov(int n, double x)
     /* Special case:  n is so big, take too long to compute */
     if (n > SMIRNOV_MAX_COMPUTE_N) {
         /* p ~ e^(-(6nx+1)^2 / 18n) */
-        double logp = -pow(6*n*x+1.0, 2)/18.0/n;
-        sf = exp(logp);
-        cdf = 1 - sf;
-        pdf = (6 * nx + 1) * 2 * sf/3;
+        double logp = -pow(6.0*n*x+1, 2)/18.0/n;
+        /* Maximise precision for small p-value. */
+        if (logp < -M_LN2) {
+            sf = exp(logp);
+            cdf = 1 - sf;
+        } else {
+            cdf = -expm1(logp);
+            sf = 1 - cdf;
+        }
+        pdf = (6.0*n*x+1) * 2 * sf/3;
         RETURN_3PROBS(sf, cdf, pdf);
     }
     {


### PR DESCRIPTION
After manually scanning through bug fixes that were merged after `1.10.0`, and adding a few more to the list, the backports listed below have been included here.

I updated `.mailmap` as well as I could from a quick glance at folks' GitHub profiles.

Although I think we dealt with the 32-bit Debian testing issues with SciPy, I wasn't able to provide the level of supported I wanted to Fedora in this regard just yet (see: https://github.com/scipy/scipy/issues/17912#issuecomment-1435776174). I suggest we move forward with `1.10.1` nonetheless, at around 30 backports merged now, and perhaps I'll get better at using the Fedora tooling to better support/reproduce in the future.

Includes these backports:

1. gh-17783
2. gh-17790
3. gh-17800
4. gh-17855
5. gh-17863
6. gh-17872
7. gh-17936
8. gh-17984
9. gh-17997

TODO:

- [x] make sure the full CI matrix is passing
- [x] make sure the wheels build properly after that (a bit more convenient to catch issues before I start release process proper)