### PR TITLE
ENH: improve halfnorm CDF precision

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -4107,7 +4107,7 @@ class halfnorm_gen(rv_continuous):
         return 0.5 * np.log(2.0/np.pi) - x*x/2.0
 
     def _cdf(self, x):
-        return _norm_cdf(x)*2-1.0
+        return sc.erf(x / np.sqrt(2))
 
     def _ppf(self, q):
         return sc.ndtri((1+q)/2.0)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1018,6 +1018,19 @@ class TestHalfNorm:
         assert_allclose(stats.halfnorm.sf(x), sfx, rtol=1e-14)
         assert_allclose(stats.halfnorm.isf(sfx), x, rtol=1e-14)
 
+    #   reference values were computed via mpmath
+    #   from mpmath import mp
+    #   mp.dps = 100
+    #   def halfnorm_cdf_mpmath(x):
+    #       x = mp.mpf(x)
+    #       return float(mp.erf(x/mp.sqrt(2.)))
+
+    @pytest.mark.parametrize('x, ref', [(1e-40, 7.978845608028653e-41),
+                                        (1e-18, 7.978845608028654e-19),
+                                        (8, 0.9999999999999988)])
+    def test_cdf(self, x, ref):
+        assert_allclose(stats.halfnorm.cdf(x), ref, rtol=1e-15)
+
 
 class TestHalfgennorm:
     def test_expon(self):


### PR DESCRIPTION
#### Reference issue
No directly related issue.

#### What does this implement/fix?
Increases the precision of the halfnormal distribution's CDF method in the left tail. The formula was simply changed to use the one from Wikipedia to avoid substracting 1.

#### Additional information
Comparison of main branch and this PR:

![halfnorm_cdf](https://user-images.githubusercontent.com/40656107/219939758-09c803ef-fa4f-47e7-b2e5-c1a4b1f35141.png)

<details>

```
import numpy as np
import matplotlib.pyplot as plt
from scipy import stats
from scipy import special as sc

x = np.logspace(-17, -14, 200)
print(stats.halfnorm.cdf(x))
plt.semilogx(x, stats.halfnorm.cdf(x), label="main", ls="dashed")
plt.semilogx(x, sc.erf(x/np.sqrt(2)), label="PR", ls="dotted")
plt.legend()
plt.title("Halfnorm CDF")
plt.show()
```

</details>
