### PR TITLE
REL, MAINT: prep for 1.10.2

### DIFF
--- a/doc/release/1.10.2-notes.rst
+++ b/doc/release/1.10.2-notes.rst
@@ -1,0 +1,24 @@
+==========================
+SciPy 1.10.2 Release Notes
+==========================
+
+.. contents::
+
+SciPy 1.10.2 is a bug-fix release with no new features
+compared to 1.10.1.
+
+
+
+Authors
+=======
+* Name (commits)
+
+
+
+Issues closed for 1.10.2
+------------------------
+
+
+
+Pull requests for 1.10.2
+------------------------

--- a/doc/source/release.1.10.2.rst
+++ b/doc/source/release.1.10.2.rst
@@ -1,0 +1,1 @@
+.. include:: ../release/1.10.2-notes.rst

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -8,6 +8,7 @@ see the `commit logs <https://github.com/scipy/scipy/commits/>`_.
 .. toctree::
    :maxdepth: 1
 
+   release.1.10.2
    release.1.10.1
    release.1.10.0
    release.1.9.3

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@ project(
   # Note that the git commit hash cannot be added dynamically here (it is added
   # in the dynamically generated and installed `scipy/version.py` though - see
   # tools/version_utils.py
-  version: '1.10.1',
+  version: '1.10.2.dev0',
   license: 'BSD-3',
   meson_version: '>= 0.64.0',
   default_options: [

--- a/tools/version_utils.py
+++ b/tools/version_utils.py
@@ -5,8 +5,8 @@ import argparse
 
 MAJOR = 1
 MINOR = 10
-MICRO = 1
-ISRELEASED = True
+MICRO = 2
+ISRELEASED = False
 IS_RELEASE_BRANCH = True
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 


### PR DESCRIPTION
* prepare for SciPy `1.10.2`

* for docs-related changes I've assumed we still use the "old way" because the release notes tree reorg has not been backported

[skip azp] [skip actions] [skip cirrus]