### PR TITLE
DOC: fix readme logo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-.. image:: https://github.com/scipy/scipy/blob/main/doc/source/_static/logo.svg
+.. image:: https://raw.githubusercontent.com/scipy/scipy/main/doc/source/_static/logo.svg
   :target: https://scipy.org
   :width: 110
   :height: 110


### PR DESCRIPTION
Closes #18007

Explanations in the issue. We need to use `raw.githubusercontent.com` to get to the artifact.