### PR TITLE
MAINT: stats.vonmises.fit: maintain backward compatibility

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -9541,8 +9541,10 @@ class vonmises_gen(rv_continuous):
 
     @_call_super_mom
     @extend_notes_in_docstring(rv_continuous, notes="""\
-        The `scale` parameter is ignored. Fit data is assumed to represent
-        angles and will be wrapped onto the unit circle.\n\n""")
+        Fit data is assumed to represent angles and will be wrapped onto the
+        unit circle. `f0` and `fscale` are ignored; the returned shape is
+        always the maximum likelihood estimate and the scale is always 
+        1. Initial guesses are ignored.\n\n""")
     def fit(self, data, *args, **kwds):
         if kwds.pop('superfit', False):
             return super().fit(data, *args, **kwds)
@@ -9577,10 +9579,11 @@ class vonmises_gen(rv_continuous):
         if floc is None:
             floc = find_mu(data)
             fshape = find_kappa(data)
-            return floc, fshape
         else:
             fshape = find_kappa(data)
-            return floc, fshape
+
+        floc = np.mod(floc + np.pi, 2 * np.pi) - np.pi  # ensure in [-pi, pi]
+        return fshape, floc, 1  # scale is not handled
 
 
 vonmises = vonmises_gen(name='vonmises')

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -60,16 +60,6 @@ def test_api_regression():
     _assert_hasattr(scipy.stats.distributions, 'f_gen')
 
 
-def check_vonmises_pdf_periodic(k, L, s, x):
-    vm = stats.vonmises(k, loc=L, scale=s)
-    assert_almost_equal(vm.pdf(x), vm.pdf(x % (2*numpy.pi*s)))
-
-
-def check_vonmises_cdf_periodic(k, L, s, x):
-    vm = stats.vonmises(k, loc=L, scale=s)
-    assert_almost_equal(vm.cdf(x) % 1, vm.cdf(x % (2*numpy.pi*s)) % 1)
-
-
 def test_distributions_submodule():
     actual = set(scipy.stats.distributions.__all__)
     continuous = [dist[0] for dist in distcont]    # continuous dist names
@@ -85,164 +75,164 @@ def test_distributions_submodule():
     assert actual == expected
 
 
-def test_vonmises_pdf_periodic():
-    for k in [0.1, 1, 101]:
-        for x in [0, 1, numpy.pi, 10, 100]:
-            check_vonmises_pdf_periodic(k, 0, 1, x)
-            check_vonmises_pdf_periodic(k, 1, 1, x)
-            check_vonmises_pdf_periodic(k, 0, 10, x)
+class TestVonMises:
+    @pytest.mark.parametrize('k', [0.1, 1, 101])
+    @pytest.mark.parametrize('x', [0, 1, np.pi, 10, 100])
+    def test_vonmises_periodic(self, k, x):
+        def check_vonmises_pdf_periodic(k, L, s, x):
+            vm = stats.vonmises(k, loc=L, scale=s)
+            assert_almost_equal(vm.pdf(x), vm.pdf(x % (2 * np.pi * s)))
 
-            check_vonmises_cdf_periodic(k, 0, 1, x)
-            check_vonmises_cdf_periodic(k, 1, 1, x)
-            check_vonmises_cdf_periodic(k, 0, 10, x)
+        def check_vonmises_cdf_periodic(k, L, s, x):
+            vm = stats.vonmises(k, loc=L, scale=s)
+            assert_almost_equal(vm.cdf(x) % 1,
+                                vm.cdf(x % (2 * np.pi * s)) % 1)
 
+        check_vonmises_pdf_periodic(k, 0, 1, x)
+        check_vonmises_pdf_periodic(k, 1, 1, x)
+        check_vonmises_pdf_periodic(k, 0, 10, x)
 
-def test_vonmises_line_support():
-    assert_equal(stats.vonmises_line.a, -np.pi)
-    assert_equal(stats.vonmises_line.b, np.pi)
+        check_vonmises_cdf_periodic(k, 0, 1, x)
+        check_vonmises_cdf_periodic(k, 1, 1, x)
+        check_vonmises_cdf_periodic(k, 0, 10, x)
 
+    def test_vonmises_line_support(self):
+        assert_equal(stats.vonmises_line.a, -np.pi)
+        assert_equal(stats.vonmises_line.b, np.pi)
 
-def test_vonmises_numerical():
-    vm = stats.vonmises(800)
-    assert_almost_equal(vm.cdf(0), 0.5)
+    def test_vonmises_numerical(self):
+        vm = stats.vonmises(800)
+        assert_almost_equal(vm.cdf(0), 0.5)
 
+    # Expected values of the vonmises PDF were computed using
+    # mpmath with 50 digits of precision:
+    #
+    # def vmpdf_mp(x, kappa):
+    #     x = mpmath.mpf(x)
+    #     kappa = mpmath.mpf(kappa)
+    #     num = mpmath.exp(kappa*mpmath.cos(x))
+    #     den = 2 * mpmath.pi * mpmath.besseli(0, kappa)
+    #     return num/den
 
-# Expected values of the vonmises PDF were computed using
-# mpmath with 50 digits of precision:
-#
-# def vmpdf_mp(x, kappa):
-#     x = mpmath.mpf(x)
-#     kappa = mpmath.mpf(kappa)
-#     num = mpmath.exp(kappa*mpmath.cos(x))
-#     den = 2 * mpmath.pi * mpmath.besseli(0, kappa)
-#     return num/den
+    @pytest.mark.parametrize('x, kappa, expected_pdf',
+                             [(0.1, 0.01, 0.16074242744907072),
+                              (0.1, 25.0, 1.7515464099118245),
+                              (0.1, 800, 0.2073272544458798),
+                              (2.0, 0.01, 0.15849003875385817),
+                              (2.0, 25.0, 8.356882934278192e-16),
+                              (2.0, 800, 0.0)])
+    def test_vonmises_pdf(self, x, kappa, expected_pdf):
+        pdf = stats.vonmises.pdf(x, kappa)
+        assert_allclose(pdf, expected_pdf, rtol=1e-15)
 
-@pytest.mark.parametrize('x, kappa, expected_pdf',
-                         [(0.1, 0.01, 0.16074242744907072),
-                          (0.1, 25.0, 1.7515464099118245),
-                          (0.1, 800, 0.2073272544458798),
-                          (2.0, 0.01, 0.15849003875385817),
-                          (2.0, 25.0, 8.356882934278192e-16),
-                          (2.0, 800, 0.0)])
-def test_vonmises_pdf(x, kappa, expected_pdf):
-    pdf = stats.vonmises.pdf(x, kappa)
-    assert_allclose(pdf, expected_pdf, rtol=1e-15)
+    # Expected values of the vonmises entropy were computed using
+    # mpmath with 50 digits of precision:
+    #
+    # def vonmises_entropy(kappa):
+    #     kappa = mpmath.mpf(kappa)
+    #     return (-kappa * mpmath.besseli(1, kappa) /
+    #             mpmath.besseli(0, kappa) + mpmath.log(2 * mpmath.pi *
+    #             mpmath.besseli(0, kappa)))
+    # >>> float(vonmises_entropy(kappa))
 
+    @pytest.mark.parametrize('kappa, expected_entropy',
+                             [(1, 1.6274014590199897),
+                              (5, 0.6756431570114528),
+                              (100, -0.8811275441649473),
+                              (1000, -2.03468891852547),
+                              (2000, -2.3813876496587847)])
+    def test_vonmises_entropy(self, kappa, expected_entropy):
+        entropy = stats.vonmises.entropy(kappa)
+        assert_allclose(entropy, expected_entropy, rtol=1e-13)
 
-# Expected values of the vonmises entropy were computed using
-# mpmath with 50 digits of precision:
-#
-# def vonmises_entropy(kappa):
-#     kappa = mpmath.mpf(kappa)
-#     return (-kappa * mpmath.besseli(1, kappa) /
-#             mpmath.besseli(0, kappa) + mpmath.log(2 * mpmath.pi *
-#             mpmath.besseli(0, kappa)))
-# >>> float(vonmises_entropy(kappa))
+    def test_vonmises_rvs_gh4598(self):
+        # check that random variates wrap around as discussed in gh-4598
+        seed = abs(hash('von_mises_rvs'))
+        rng1 = np.random.default_rng(seed)
+        rng2 = np.random.default_rng(seed)
+        rng3 = np.random.default_rng(seed)
+        rvs1 = stats.vonmises(1, loc=0, scale=1).rvs(random_state=rng1)
+        rvs2 = stats.vonmises(1, loc=2*np.pi, scale=1).rvs(random_state=rng2)
+        rvs3 = stats.vonmises(1, loc=0,
+                              scale=(2*np.pi/abs(rvs1)+1)).rvs(random_state=rng3)
+        assert_allclose(rvs1, rvs2, atol=1e-15)
+        assert_allclose(rvs1, rvs3, atol=1e-15)
 
-@pytest.mark.parametrize('kappa, expected_entropy',
-                         [(1, 1.6274014590199897),
-                          (5, 0.6756431570114528),
-                          (100, -0.8811275441649473),
-                          (1000, -2.03468891852547),
-                          (2000, -2.3813876496587847)])
-def test_vonmises_entropy(kappa, expected_entropy):
-    entropy = stats.vonmises.entropy(kappa)
-    assert_allclose(entropy, expected_entropy, rtol=1e-13)
+    # Expected values of the vonmises LOGPDF were computed
+    # using wolfram alpha:
+    # kappa * cos(x) - log(2*pi*I0(kappa))
+    @pytest.mark.parametrize('x, kappa, expected_logpdf',
+                             [(0.1, 0.01, -1.8279520246003170),
+                              (0.1, 25.0, 0.5604990605420549),
+                              (0.1, 800, -1.5734567947337514),
+                              (2.0, 0.01, -1.8420635346185686),
+                              (2.0, 25.0, -34.7182759850871489),
+                              (2.0, 800, -1130.4942582548682739)])
+    def test_vonmises_logpdf(self, x, kappa, expected_logpdf):
+        logpdf = stats.vonmises.logpdf(x, kappa)
+        assert_allclose(logpdf, expected_logpdf, rtol=1e-15)
 
+    def test_vonmises_expect(self):
+        """
+        Test that the vonmises expectation values are
+        computed correctly.  This test checks that the
+        numeric integration estimates the correct normalization
+        (1) and mean angle (loc).  These expectations are
+        independent of the chosen 2pi interval.
+        """
+        rng = np.random.default_rng(6762668991392531563)
 
-def test_vonmises_rvs_gh4598():
-    # check that random variates wrap around as discussed in gh-4598
-    seed = abs(hash('von_mises_rvs'))
-    rng1 = np.random.default_rng(seed)
-    rng2 = np.random.default_rng(seed)
-    rng3 = np.random.default_rng(seed)
-    rvs1 = stats.vonmises(1, loc=0, scale=1).rvs(random_state=rng1)
-    rvs2 = stats.vonmises(1, loc=2*np.pi, scale=1).rvs(random_state=rng2)
-    rvs3 = stats.vonmises(1, loc=0,
-                          scale=(2*np.pi/abs(rvs1)+1)).rvs(random_state=rng3)
-    assert_allclose(rvs1, rvs2, atol=1e-15)
-    assert_allclose(rvs1, rvs3, atol=1e-15)
+        loc, kappa, lb = rng.random(3) * 10
+        res = stats.vonmises(loc=loc, kappa=kappa).expect(lambda x: 1)
+        assert_allclose(res, 1)
+        assert np.issubdtype(res.dtype, np.floating)
 
+        bounds = lb, lb + 2 * np.pi
+        res = stats.vonmises(loc=loc, kappa=kappa).expect(lambda x: 1, *bounds)
+        assert_allclose(res, 1)
+        assert np.issubdtype(res.dtype, np.floating)
 
-# Expected values of the vonmises LOGPDF were computed
-# using wolfram alpha:
-# kappa * cos(x) - log(2*pi*I0(kappa))
-@pytest.mark.parametrize('x, kappa, expected_logpdf',
-                         [(0.1, 0.01, -1.8279520246003170),
-                          (0.1, 25.0, 0.5604990605420549),
-                          (0.1, 800, -1.5734567947337514),
-                          (2.0, 0.01, -1.8420635346185686),
-                          (2.0, 25.0, -34.7182759850871489),
-                          (2.0, 800, -1130.4942582548682739)])
-def test_vonmises_logpdf(x, kappa, expected_logpdf):
-    logpdf = stats.vonmises.logpdf(x, kappa)
-    assert_allclose(logpdf, expected_logpdf, rtol=1e-15)
+        bounds = lb, lb + 2 * np.pi
+        res = stats.vonmises(loc=loc, kappa=kappa).expect(lambda x: np.exp(1j*x),
+                                                          *bounds, complex_func=1)
+        assert_allclose(np.angle(res), loc % (2*np.pi))
+        assert np.issubdtype(res.dtype, np.complexfloating)
 
+    @pytest.mark.parametrize('loc', [-0.5 * np.pi, 0, np.pi])
+    @pytest.mark.parametrize('kappa', [1, 10, 100, 1000])
+    def test_vonmises_fit_all(self, kappa, loc):
+        rng = np.random.default_rng(6762668991392531563)
+        data = stats.vonmises(loc=loc, kappa=kappa).rvs(100000, random_state=rng)
+        kappa_fit, loc_fit, scale_fit = stats.vonmises.fit(data)
+        assert scale_fit == 1
+        loc_vec = np.array([np.cos(loc), np.sin(loc)])
+        loc_fit_vec = np.array([np.cos(loc_fit), np.sin(loc_fit)])
+        angle = np.arccos(loc_vec.dot(loc_fit_vec))
+        assert_allclose(angle, 0, atol=1e-2, rtol=0)
+        assert_allclose(kappa, kappa_fit, rtol=1e-2)
 
-def test_vonmises_expect():
-    """
-    Test that the vonmises expectation values are
-    computed correctly.  This test checks that the
-    numeric integration estimates the correct normalization
-    (1) and mean angle (loc).  These expectations are
-    independent of the chosen 2pi interval.
-    """
-    rng = np.random.default_rng(6762668991392531563)
+    def test_vonmises_fit_shape(self):
+        rng = np.random.default_rng(6762668991392531563)
+        loc = 0.25*np.pi
+        kappa = 10
+        data = stats.vonmises(loc=loc, kappa=kappa).rvs(100000, random_state=rng)
+        kappa_fit, loc_fit, scale_fit = stats.vonmises.fit(data, floc=loc)
+        assert loc_fit == loc
+        assert scale_fit == 1
+        assert_allclose(kappa, kappa_fit, rtol=1e-2)
 
-    loc, kappa, lb = rng.random(3) * 10
-    res = stats.vonmises(loc=loc, kappa=kappa).expect(lambda x: 1)
-    assert_allclose(res, 1)
-    assert np.issubdtype(res.dtype, np.floating)
-
-    bounds = lb, lb + 2 * np.pi
-    res = stats.vonmises(loc=loc, kappa=kappa).expect(lambda x: 1, *bounds)
-    assert_allclose(res, 1)
-    assert np.issubdtype(res.dtype, np.floating)
-
-    bounds = lb, lb + 2 * np.pi
-    res = stats.vonmises(loc=loc, kappa=kappa).expect(lambda x: np.exp(1j*x),
-                                                      *bounds, complex_func=1)
-    assert_allclose(np.angle(res), loc % (2*np.pi))
-    assert np.issubdtype(res.dtype, np.complexfloating)
-
-
-@pytest.mark.parametrize('loc', [-0.5 * np.pi, 0, np.pi])
-@pytest.mark.parametrize('kappa', [1, 10, 100, 1000])
-def test_vonmises_fit_all(kappa, loc):
-    rng = np.random.default_rng(6762668991392531563)
-    data = stats.vonmises(loc=loc, kappa=kappa).rvs(100000, random_state=rng)
-    kappa_fit, loc_fit, scale_fit = stats.vonmises.fit(data)
-    assert scale_fit == 1
-    loc_vec = np.array([np.cos(loc), np.sin(loc)])
-    loc_fit_vec = np.array([np.cos(loc_fit), np.sin(loc_fit)])
-    angle = np.arccos(loc_vec.dot(loc_fit_vec))
-    assert_allclose(angle, 0, atol=1e-2, rtol=0)
-    assert_allclose(kappa, kappa_fit, rtol=1e-2)
-
-
-def test_vonmises_fit_shape():
-    rng = np.random.default_rng(6762668991392531563)
-    loc = 0.25*np.pi
-    kappa = 10
-    data = stats.vonmises(loc=loc, kappa=kappa).rvs(100000, random_state=rng)
-    kappa_fit, loc_fit, scale_fit = stats.vonmises.fit(data, floc=loc)
-    assert loc_fit == loc
-    assert scale_fit == 1
-    assert_allclose(kappa, kappa_fit, rtol=1e-2)
-
-
-@pytest.mark.parametrize('sign', [-1, 1])
-def test_vonmises_fit_unwrapped_data(sign):
-    rng = np.random.default_rng(6762668991392531563)
-    data = stats.vonmises(loc=sign*0.5*np.pi, kappa=10).rvs(100000,
-                                                            random_state=rng)
-    shifted_data = data + 4*np.pi
-    kappa_fit, loc_fit, scale_fit = stats.vonmises.fit(data)
-    kappa_fit_shifted, loc_fit_shifted, _ = stats.vonmises.fit(shifted_data)
-    assert_allclose(loc_fit, loc_fit_shifted)
-    assert_allclose(kappa_fit, kappa_fit_shifted)
-    assert scale_fit == 1
-    assert -np.pi < loc_fit < np.pi
+    @pytest.mark.parametrize('sign', [-1, 1])
+    def test_vonmises_fit_unwrapped_data(self, sign):
+        rng = np.random.default_rng(6762668991392531563)
+        data = stats.vonmises(loc=sign*0.5*np.pi, kappa=10).rvs(100000,
+                                                                random_state=rng)
+        shifted_data = data + 4*np.pi
+        kappa_fit, loc_fit, scale_fit = stats.vonmises.fit(data)
+        kappa_fit_shifted, loc_fit_shifted, _ = stats.vonmises.fit(shifted_data)
+        assert_allclose(loc_fit, loc_fit_shifted)
+        assert_allclose(kappa_fit, kappa_fit_shifted)
+        assert scale_fit == 1
+        assert -np.pi < loc_fit < np.pi
 
 
 def _assert_less_or_close_loglike(dist, data, func, **kwds):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -211,7 +211,8 @@ def test_vonmises_expect():
 def test_vonmises_fit_all(kappa, loc):
     rng = np.random.default_rng(6762668991392531563)
     data = stats.vonmises(loc=loc, kappa=kappa).rvs(100000, random_state=rng)
-    loc_fit, kappa_fit = stats.vonmises.fit(data)
+    kappa_fit, loc_fit, scale_fit = stats.vonmises.fit(data)
+    assert scale_fit == 1
     loc_vec = np.array([np.cos(loc), np.sin(loc)])
     loc_fit_vec = np.array([np.cos(loc_fit), np.sin(loc_fit)])
     angle = np.arccos(loc_vec.dot(loc_fit_vec))
@@ -224,20 +225,24 @@ def test_vonmises_fit_shape():
     loc = 0.25*np.pi
     kappa = 10
     data = stats.vonmises(loc=loc, kappa=kappa).rvs(100000, random_state=rng)
-    loc_fit, kappa_fit = stats.vonmises.fit(data, floc=loc)
+    kappa_fit, loc_fit, scale_fit = stats.vonmises.fit(data, floc=loc)
     assert loc_fit == loc
+    assert scale_fit == 1
     assert_allclose(kappa, kappa_fit, rtol=1e-2)
 
 
-def test_vonmises_fit_unwrapped_data():
+@pytest.mark.parametrize('sign', [-1, 1])
+def test_vonmises_fit_unwrapped_data(sign):
     rng = np.random.default_rng(6762668991392531563)
-    data = stats.vonmises(loc=0.5*np.pi, kappa=10).rvs(100000,
-                                                       random_state=rng)
+    data = stats.vonmises(loc=sign*0.5*np.pi, kappa=10).rvs(100000,
+                                                            random_state=rng)
     shifted_data = data + 4*np.pi
-    loc_fit, kappa_fit = stats.vonmises.fit(data)
-    loc_fit_shifted, kappa_fit_shifted = stats.vonmises.fit(shifted_data)
+    kappa_fit, loc_fit, scale_fit = stats.vonmises.fit(data)
+    kappa_fit_shifted, loc_fit_shifted, _ = stats.vonmises.fit(shifted_data)
     assert_allclose(loc_fit, loc_fit_shifted)
     assert_allclose(kappa_fit, kappa_fit_shifted)
+    assert scale_fit == 1
+    assert -np.pi < loc_fit < np.pi
 
 
 def _assert_less_or_close_loglike(dist, data, func, **kwds):


### PR DESCRIPTION
#### Reference issue
gh-17585

#### What does this implement/fix?
gh-17585 overrode `vonmises.fit`. It works well, but it does not conform to the previous API, which is documented. This PR fixes the order of the shape and loc outputs, returns `scale` (always `1`), and ensures that `loc` $\in [-\pi, \pi]$.

#### Additional information
I was in the neighborhood so I just went ahead and fixed this rather than filing an issue.

Before we merge, I would like to push a second commit that collects all the von Mises tests into a class `TestVonMises`.

This PR does not fix another shortcoming: the override ignores `f0`, so the shape parameter cannot be fixed as it can for all other distributions. (Of course, there are many other issues with `vonmises`, so this does not really stand out, but it's something to keep in mind for the future.)