### PR TITLE
TST: optimize.root_scalar: refactor tests and add Chandrupatla tests

### DIFF
--- a/scipy/optimize/_tstutils.py
+++ b/scipy/optimize/_tstutils.py
@@ -35,6 +35,9 @@ Collections of test cases suitable for testing 1-D root-finders
 #      "Algorithm 748: Enclosing Zeros of Continuous Functions",
 #      ACM Trans. Math. Softw. Volume 221(1995)
 #       doi = {10.1145/210089.210111},
+#  [2] Chandrupatla, Tirupathi R. "A new hybrid quadratic/bisection algorithm
+#      for finding the zero of a nonlinear function without using derivatives."
+#      Advances in Engineering Software 28.3 (1997): 145-149.
 
 from random import random
 
@@ -662,7 +665,8 @@ def get_tests(collection='original', smoothness=None):
     collection = collection or "original"
     subsets = {"aps": _APS_TESTS_DICTS,
                "complex": _COMPLEX_TESTS_DICTS,
-               "original": _ORIGINAL_TESTS_DICTS}
+               "original": _ORIGINAL_TESTS_DICTS,
+               "chandrupatla": _CHANDRUPATLA_TESTS_DICTS}
     tests = subsets.get(collection, [])
     if smoothness is not None:
         tests = [tc for tc in tests if tc['smoothness'] >= smoothness]
@@ -674,3 +678,118 @@ methods = [cc.bisect, cc.ridder, cc.brenth, cc.brentq]
 mstrings = ['cc.bisect', 'cc.ridder', 'cc.brenth', 'cc.brentq']
 functions = [f2, f3, f4, f5, f6]
 fstrings = ['f2', 'f3', 'f4', 'f5', 'f6']
+
+#   ##################
+#   "Chandrupatla" test cases
+#   Functions and test cases that appear in [2]
+
+def fun1(x):
+    return x**3 - 2*x - 5
+fun1.root = 2.0945514815423265  # additional precision using mpmath.findroot
+
+
+def fun2(x):
+    return 1 - 1/x**2
+fun2.root = 1
+
+
+def fun3(x):
+    return (x-3)**3
+fun3.root = 3
+
+
+def fun4(x):
+    return 6*(x-2)**5
+fun4.root = 2
+
+
+def fun5(x):
+    return x**9
+fun5.root = 0
+
+
+def fun6(x):
+    return x**19
+fun6.root = 0
+
+
+def fun7(x):
+    return 0 if abs(x) < 3.8e-4 else x*np.exp(-x**(-2))
+fun7.root = 0
+
+
+def fun8(x):
+    xi = 0.61489
+    return -(3062*(1-xi)*np.exp(-x))/(xi + (1-xi)*np.exp(-x)) - 1013 + 1628/x
+fun8.root = 1.0375360332870405
+
+
+def fun9(x):
+    return np.exp(x) - 2 - 0.01/x**2 + .000002/x**3
+fun9.root = 0.7032048403631358
+
+# Each "chandropatla" test case has
+# - a function,
+# - two starting values x0 and x1
+# - the root
+# - the number of function evaluations required by Chandrupatla's algorithm
+# - an Identifier of the test case
+#
+# Chandrupatla's is a bracketing algorithm, so a bracketing interval was
+# provided in [2] for each test case. No special support for testing with
+# secant/Newton/Halley is provided.
+
+_CHANDRUPATLA_TESTS_KEYS = ["f", "bracket", "root", "nfeval", "ID"]
+_CHANDRUPATLA_TESTS = [
+    [fun1, [2, 3], fun1.root, 7],
+    [fun1, [1, 10], fun1.root, 11],
+    [fun1, [1, 100], fun1.root, 14],
+    [fun1, [-1e4, 1e4], fun1.root, 23],
+    [fun1, [-1e10, 1e10], fun1.root, 43],
+    [fun2, [0.5, 1.51], fun2.root, 8],
+    [fun2, [1e-4, 1e4], fun2.root, 22],
+    [fun2, [1e-6, 1e6], fun2.root, 28],
+    [fun2, [1e-10, 1e10], fun2.root, 41],
+    [fun2, [1e-12, 1e12], fun2.root, 48],
+    [fun3, [0, 5], fun3.root, 21],
+    [fun3, [-10, 10], fun3.root, 23],
+    [fun3, [1e-4, 1e4], fun3.root, 36],
+    [fun3, [1e-6, 1e6], fun3.root, 45],
+    [fun3, [1e-10, 1e10], fun3.root, 55],
+    [fun4, [0, 5], fun4.root, 21],
+    [fun4, [-10, 10], fun4.root, 23],
+    [fun4, [1e-4, 1e4], fun4.root, 33],
+    [fun4, [1e-6, 1e6], fun4.root, 43],
+    [fun4, [1e-10, 1e10], fun4.root, 54],
+    [fun5, [-1, 4], fun5.root, 21],
+    [fun5, [-2, 5], fun5.root, 22],
+    [fun5, [-1, 10], fun5.root, 23],
+    [fun5, [-5, 50], fun5.root, 25],
+    [fun5, [-10, 100], fun5.root, 26],
+    [fun6, [-1., 4.], fun6.root, 21],
+    [fun6, [-2., 5.], fun6.root, 22],
+    [fun6, [-1., 10.], fun6.root, 23],
+    [fun6, [-5., 50.], fun6.root, 25],
+    [fun6, [-10., 100.], fun6.root, 26],
+    [fun7, [-1, 4], fun7.root, 8],
+    [fun7, [-2, 5], fun7.root, 8],
+    [fun7, [-1, 10], fun7.root, 11],
+    [fun7, [-5, 50], fun7.root, 18],
+    [fun7, [-10, 100], fun7.root, 19],
+    [fun8, [2e-4, 2], fun8.root, 9],
+    [fun8, [2e-4, 3], fun8.root, 10],
+    [fun8, [2e-4, 9], fun8.root, 11],
+    [fun8, [2e-4, 27], fun8.root, 12],
+    [fun8, [2e-4, 81], fun8.root, 14],
+    [fun9, [2e-4, 2], fun9.root, 7],
+    [fun9, [2e-4, 3], fun9.root, 8],
+    [fun9, [2e-4, 9], fun9.root, 10],
+    [fun9, [2e-4, 27], fun9.root, 11],
+    [fun9, [2e-4, 81], fun9.root, 13],
+]
+_CHANDRUPATLA_TESTS = [test + [f'{test[0].__name__}.{i%5+1}']
+                       for i, test in enumerate(_CHANDRUPATLA_TESTS)]
+
+_CHANDRUPATLA_TESTS_DICTS = [dict(zip(_CHANDRUPATLA_TESTS_KEYS, testcase))
+                             for testcase in _CHANDRUPATLA_TESTS]
+_add_a_b(_CHANDRUPATLA_TESTS_DICTS)

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -27,7 +27,7 @@ _FLOAT_EPS = finfo(float).eps
 bracket_methods = [zeros.bisect, zeros.ridder, zeros.brentq, zeros.brenth,
                    zeros.toms748]
 gradient_methods = [zeros.newton]
-all_methods = bracket_methods + gradient_methods
+all_methods = bracket_methods + gradient_methods  # noqa
 
 # A few test functions used frequently:
 # # A simple quadratic, (x-1)^2 - 1

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -18,11 +18,18 @@ from scipy.optimize import (_zeros_py as zeros, newton, root_scalar,
 from scipy._lib._util import getfullargspec_no_self as _getfullargspec
 
 # Import testing parameters
-from scipy.optimize._tstutils import get_tests, functions as tstutils_functions, fstrings as tstutils_fstrings
+from scipy.optimize._tstutils import (get_tests,
+                                      functions as tstutils_functions,
+                                      fstrings as tstutils_fstrings)
 
 TOL = 4*np.finfo(float).eps  # tolerance
 
 _FLOAT_EPS = finfo(float).eps
+
+bracket_methods = [zeros.bisect, zeros.ridder, zeros.brentq, zeros.brenth,
+                   zeros.toms748]
+gradient_methods = [zeros.newton]
+all_methods = bracket_methods + gradient_methods
 
 # A few test functions used frequently:
 # # A simple quadratic, (x-1)^2 - 1
@@ -61,43 +68,47 @@ def f_lrucached(x):
     return x
 
 
-class TestBasic:
+class TestScalarRootFinders:
+    # Basic tests for all scalar root finders
 
-    def run_check_by_name(self, name, smoothness=0, **kwargs):
-        a = .5
-        b = sqrt(3)
-        xtol = 4*np.finfo(float).eps
-        rtol = 4*np.finfo(float).eps
+    xtol = 4 * np.finfo(float).eps
+    rtol = 4 * np.finfo(float).eps
+
+    def check_basic_root_scalar(self, name, smoothness=0, **kwargs):
+        # Tests bracketing root finders called via `root_scalar` on a small
+        # set of simple problems, each of which has a root at `x=1`. Checks for
+        # converged status and that the root was found.
+        a, b = .5, sqrt(3)
+
         for function, fname in zip(tstutils_functions, tstutils_fstrings):
             if smoothness > 0 and fname in ['f4', 'f5', 'f6']:
                 continue
             r = root_scalar(function, method=name, bracket=[a, b], x0=a,
-                            xtol=xtol, rtol=rtol, **kwargs)
-            zero = r.root
-            assert_(r.converged)
-            assert_allclose(zero, 1.0, atol=xtol, rtol=rtol,
+                            xtol=self.xtol, rtol=self.rtol, **kwargs)
+            assert r.converged
+            assert_allclose(r.root, 1.0, atol=self.xtol, rtol=self.rtol,
                             err_msg=f'method {name}, function {fname}')
 
-    def run_check(self, method, name):
-        a = .5
-        b = sqrt(3)
-        xtol = 4 * _FLOAT_EPS
-        rtol = 4 * _FLOAT_EPS
+    def check_basic_individual(self, method, name):
+        # Tests individual bracketing root finders on a small set of simple
+        # problems, each of which has a root at `x=1`. Checks for converged
+        # status and that the root was found.
+        a, b = .5, sqrt(3)
         for function, fname in zip(tstutils_functions, tstutils_fstrings):
-            zero, r = method(function, a, b, xtol=xtol, rtol=rtol,
+            root, r = method(function, a, b, xtol=self.xtol, rtol=self.rtol,
                              full_output=True)
-            assert_(r.converged)
-            assert_allclose(zero, 1.0, atol=xtol, rtol=rtol,
+            assert r.converged
+            assert_allclose(root, 1.0, atol=self.xtol, rtol=self.rtol,
                             err_msg=f'method {name}, function {fname}')
 
-    def run_check_lru_cached(self, method, name):
+    def check_lru_cached_individual(self, method, name):
         # check that https://github.com/scipy/scipy/issues/10846 is fixed
-        a = -1
-        b = 1
-        zero, r = method(f_lrucached, a, b, full_output=True)
-        assert_(r.converged)
-        assert_allclose(zero, 0,
-                        err_msg='method {}, function {}'.format(name, 'f_lrucached'))
+        # (`root_scalar` failed when passed a function that was `@lru_cache`d)
+        a, b = -1, 1
+        root, r = method(f_lrucached, a, b, full_output=True)
+        assert r.converged
+        err_msg = f'method {name}, function {f_lrucached}'
+        assert_allclose(root, 0, err_msg=err_msg)
 
     def _run_one_test(self, tc, method, sig_args_keys=None,
                       sig_kwargs_keys=None, **kwargs):
@@ -122,9 +133,7 @@ class TestBasic:
         except Exception:
             return root, zeros.RootResults(nan, -1, -1, zeros._EVALUEERR), tc
 
-    def run_tests(self, tests, method, name,
-                  xtol=4 * _FLOAT_EPS, rtol=4 * _FLOAT_EPS,
-                  known_fail=None, **kwargs):
+    def run_tests(self, tests, method, name, known_fail=None, **kwargs):
         r"""Run test-cases using the specified method and the supplied signature.
 
         Extract the arguments for the method call from the test case
@@ -143,10 +152,10 @@ class TestBasic:
                 sig_kwargs_keys.append('fprime')
                 if name in ['halley']:
                     sig_kwargs_keys.append('fprime2')
-            kwargs['tol'] = xtol
+            kwargs['tol'] = self.xtol
         else:
-            kwargs['xtol'] = xtol
-            kwargs['rtol'] = rtol
+            kwargs['xtol'] = self.xtol
+            kwargs['rtol'] = self.rtol
 
         results = [list(self._run_one_test(
             tc, method, sig_args_keys=sig_args_keys,
@@ -178,47 +187,44 @@ class TestBasic:
         assert_equal([notclose, len(notclose)], [[], 0])
 
     def run_collection(self, collection, method, name, smoothness=None,
-                       known_fail=None,
-                       xtol=4 * _FLOAT_EPS, rtol=4 * _FLOAT_EPS,
-                       **kwargs):
+                       known_fail=None, **kwargs):
         r"""Run a collection of tests using the specified method.
 
         The name is used to determine some optional arguments."""
         tests = get_tests(collection, smoothness=smoothness)
-        self.run_tests(tests, method, name, xtol=xtol, rtol=rtol,
-                       known_fail=known_fail, **kwargs)
+        self.run_tests(tests, method, name, known_fail=known_fail, **kwargs)
 
     def test_bisect(self):
-        self.run_check(zeros.bisect, 'bisect')
-        self.run_check_lru_cached(zeros.bisect, 'bisect')
-        self.run_check_by_name('bisect')
+        self.check_basic_individual(zeros.bisect, 'bisect')
+        self.check_lru_cached_individual(zeros.bisect, 'bisect')
+        self.check_basic_root_scalar('bisect')
         self.run_collection('aps', zeros.bisect, 'bisect', smoothness=1)
 
     def test_ridder(self):
-        self.run_check(zeros.ridder, 'ridder')
-        self.run_check_lru_cached(zeros.ridder, 'ridder')
-        self.run_check_by_name('ridder')
+        self.check_basic_individual(zeros.ridder, 'ridder')
+        self.check_lru_cached_individual(zeros.ridder, 'ridder')
+        self.check_basic_root_scalar('ridder')
         self.run_collection('aps', zeros.ridder, 'ridder', smoothness=1)
 
     def test_brentq(self):
-        self.run_check(zeros.brentq, 'brentq')
-        self.run_check_lru_cached(zeros.brentq, 'brentq')
-        self.run_check_by_name('brentq')
+        self.check_basic_individual(zeros.brentq, 'brentq')
+        self.check_lru_cached_individual(zeros.brentq, 'brentq')
+        self.check_basic_root_scalar('brentq')
         # Brentq/h needs a lower tolerance to be specified
         self.run_collection('aps', zeros.brentq, 'brentq', smoothness=1,
                             xtol=1e-14, rtol=1e-14)
 
     def test_brenth(self):
-        self.run_check(zeros.brenth, 'brenth')
-        self.run_check_lru_cached(zeros.brenth, 'brenth')
-        self.run_check_by_name('brenth')
+        self.check_basic_individual(zeros.brenth, 'brenth')
+        self.check_lru_cached_individual(zeros.brenth, 'brenth')
+        self.check_basic_root_scalar('brenth')
         self.run_collection('aps', zeros.brenth, 'brenth', smoothness=1,
                             xtol=1e-14, rtol=1e-14)
 
     def test_toms748(self):
-        self.run_check(zeros.toms748, 'toms748')
-        self.run_check_lru_cached(zeros.toms748, 'toms748')
-        self.run_check_by_name('toms748')
+        self.check_basic_individual(zeros.toms748, 'toms748')
+        self.check_lru_cached_individual(zeros.toms748, 'toms748')
+        self.check_basic_root_scalar('toms748')
         self.run_collection('aps', zeros.toms748, 'toms748', smoothness=1)
 
     def test_newton_collections(self):
@@ -237,33 +243,11 @@ class TestBasic:
             self.run_collection(collection, zeros.newton, 'halley',
                                 smoothness=2, known_fail=known_fail)
 
-    @staticmethod
-    def f1(x):
-        return x**2 - 2*x - 1  # == (x-1)**2 - 2
 
-    @staticmethod
-    def f1_1(x):
-        return 2*x - 2
-
-    @staticmethod
-    def f1_2(x):
-        return 2.0 + 0*x
-
-    @staticmethod
-    def f2(x):
-        return exp(x) - cos(x)
-
-    @staticmethod
-    def f2_1(x):
-        return exp(x) + sin(x)
-
-    @staticmethod
-    def f2_2(x):
-        return exp(x) + cos(x)
+class TestNewton:
 
     def test_newton(self):
-        for f, f_1, f_2 in [(self.f1, self.f1_1, self.f1_2),
-                            (self.f2, self.f2_1, self.f2_2)]:
+        for f, f_1, f_2 in [(f1, f1_1, f1_2), (f2, f2_1, f2_2)]:
             x = zeros.newton(f, 3, tol=1e-6)
             assert_allclose(f(x), 0, atol=1e-6)
             x = zeros.newton(f, 3, x1=5, tol=1e-6)  # secant, x0 and x1
@@ -424,10 +408,10 @@ class TestBasic:
 
         for derivs in range(3):
             kwargs = {'tol': 1e-6, 'full_output': True, }
-            for k, v in [['fprime', self.f1_1], ['fprime2', self.f1_2]][:derivs]:
+            for k, v in [['fprime', f1_1], ['fprime2', f1_2]][:derivs]:
                 kwargs[k] = v
 
-            x, r = zeros.newton(self.f1, x0, disp=False, **kwargs)
+            x, r = zeros.newton(f1, x0, disp=False, **kwargs)
             assert_(r.converged)
             assert_equal(x, r.root)
             assert_equal((r.iterations, r.function_calls), expected_counts[derivs])
@@ -438,7 +422,7 @@ class TestBasic:
 
             # Now repeat, allowing one fewer iteration to force convergence failure
             iters = r.iterations - 1
-            x, r = zeros.newton(self.f1, x0, maxiter=iters, disp=False, **kwargs)
+            x, r = zeros.newton(f1, x0, maxiter=iters, disp=False, **kwargs)
             assert_(not r.converged)
             assert_equal(x, r.root)
             assert_equal(r.iterations, iters)
@@ -449,7 +433,7 @@ class TestBasic:
                 with pytest.raises(
                     RuntimeError,
                     match='Failed to converge after %d iterations, value is .*' % (iters)):
-                    x, r = zeros.newton(self.f1, x0, maxiter=iters, disp=True, **kwargs)
+                    x, r = zeros.newton(f1, x0, maxiter=iters, disp=True, **kwargs)
 
     def test_deriv_zero_warning(self):
         def func(x):
@@ -466,13 +450,6 @@ class TestBasic:
         x0_copy = x0.copy()  # Copy to test for equality.
         newton(np.sin, x0, np.cos)
         assert_array_equal(x0, x0_copy)
-
-    def test_maxiter_int_check(self):
-        for method in [zeros.bisect, zeros.newton, zeros.ridder, zeros.brentq,
-                       zeros.brenth, zeros.toms748]:
-            with pytest.raises(TypeError,
-                    match="'float' object cannot be interpreted as an integer"):
-                method(f1, 0.0, 1.0, maxiter=72.45)
 
     def test_gh17570_defaults(self):
         # Previously, when fprime was not specified, root_scalar would default
@@ -565,6 +542,7 @@ class TestRootResults:
 
     def test_type(self):
         assert isinstance(self.r, OptimizeResult)
+
 
 def test_complex_halley():
     """Test Halley's works with complex roots"""
@@ -925,3 +903,12 @@ def test_newton_complex_gh10103():
 
     res = root_scalar(f, x0=1+1j, x1=2+1.5j, method='secant')
     assert_allclose(res.root, 1, atol=1e-12)
+
+
+@pytest.mark.parametrize('method', all_methods)
+def test_maxiter_int_check_gh10236(method):
+    # gh-10236 reported that the error message when `maxiter` is not an integer
+    # was difficult to interpret. Check that this was resolved (by gh-10907).
+    message = "'float' object cannot be interpreted as an integer"
+    with pytest.raises(TypeError, match=message):
+        method(f1, 0.0, 1.0, maxiter=72.45)


### PR DESCRIPTION
#### Reference issue
Supports gh-17719

#### What does this implement/fix?
This splits scalar root finder tests into separate classes for bracketing methods and gradient-based methods. It also reactors the bracketing method tests:
- Adds comments about what the tests do
- Eliminates some redundancy (copy-paste of functions, tolerances) and unused parameters
- Fixes some PEP8
- Uses `pytest.parametrize` instead of loops/separate tests

This also adds test cases from Chandrupatla's original paper.