### PR TITLE
DOC: Add an example showing how to plot Rotations to the docs

### DIFF
--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -658,10 +658,12 @@ cdef class Rotation:
     >>> plot_rotated_axes(ax, r0, name="r0", offset=(0, 0, 0))
     >>> plot_rotated_axes(ax, r1, name="r1", offset=(3, 0, 0))
     >>> plot_rotated_axes(ax, r2, name="r2", offset=(6, 0, 0))
-    >>> ax.annotate("r0: Identity Rotation\\n"
-    ...             "r1: Intrinsic Euler Rotation (ZYX)\\n"
-    ...             "r2: Extrinsic Euler Rotation (zyx)",
-    ...             xy=(0.6, 0.7), xycoords="axes fraction", ha="left")
+    >>> _ = ax.annotate(
+    ...     "r0: Identity Rotation\\n"
+    ...     "r1: Intrinsic Euler Rotation (ZYX)\\n"
+    ...     "r2: Extrinsic Euler Rotation (zyx)",
+    ...     xy=(0.6, 0.7), xycoords="axes fraction", ha="left"
+    ... )
     >>> ax.set(xlim=(-1.25, 7.25), ylim=(-1.25, 1.25), zlim=(-1.25, 1.25))
     >>> ax.set(xticks=range(-1, 8), yticks=[-1, 0, 1], zticks=[-1, 0, 1])
     >>> ax.set_aspect("equal", adjustable="box")

--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -617,6 +617,61 @@ cdef class Rotation:
     array([[-90.,   0.,   0.],
            [-45.,   0.,   0.]])
 
+    The following function can be used to plot rotations with Matplotlib by
+    showing how they transform the standard x, y, z coordinate axes:
+
+    >>> import matplotlib.pyplot as plt
+
+    >>> def plot_rotated_axes(ax, r, name=None, offset=(0, 0, 0), scale=1):
+    ...     colors = ("#FF6666", "#005533", "#1199EE")  # Colorblind-safe RGB
+    ...     loc = np.array([offset, offset])
+    ...     for i, (axis, c) in enumerate(zip((ax.xaxis, ax.yaxis, ax.zaxis),
+    ...                                       colors)):
+    ...         axlabel = axis.axis_name
+    ...         axis.set_label_text(axlabel)
+    ...         axis.label.set_color(c)
+    ...         axis.line.set_color(c)
+    ...         axis.set_tick_params(colors=c)
+    ...         line = np.zeros((2, 3))
+    ...         line[1, i] = scale
+    ...         line_rot = r.apply(line)
+    ...         line_plot = line_rot + loc
+    ...         ax.plot(line_plot[:, 0], line_plot[:, 1], line_plot[:, 2], c)
+    ...         text_loc = line[1]*1.2
+    ...         text_loc_rot = r.apply(text_loc)
+    ...         text_plot = text_loc_rot + loc[0]
+    ...         ax.text(*text_plot, axlabel.upper(), color=c,
+    ...                 va="center", ha="center")
+    ...     ax.text(*offset, name, color="k", va="center", ha="center",
+    ...             bbox={"fc": "w", "alpha": 0.8, "boxstyle": "circle"})
+
+    Create three rotations - the identity and two Euler rotations using
+    intrinsic and extrinsic conventions:
+
+    >>> r0 = R.identity()
+    >>> r1 = R.from_euler("ZYX", [90, -30, 0], degrees=True)  # intrinsic
+    >>> r2 = R.from_euler("zyx", [90, -30, 0], degrees=True)  # extrinsic
+
+    Add all three rotations to a single plot:
+
+    >>> ax = plt.figure().add_subplot(projection="3d", proj_type="ortho")
+    >>> plot_rotated_axes(ax, r0, name="r0", offset=(0, 0, 0))
+    >>> plot_rotated_axes(ax, r1, name="r1", offset=(3, 0, 0))
+    >>> plot_rotated_axes(ax, r2, name="r2", offset=(6, 0, 0))
+    >>> ax.annotate("r0: Identity Rotation\\n"
+    ...             "r1: Intrinsic Euler Rotation (ZYX)\\n"
+    ...             "r2: Extrinsic Euler Rotation (zyx)",
+    ...             xy=(0.6, 0.7), xycoords="axes fraction", ha="left")
+    >>> ax.set(xlim=(-1.25, 7.25), ylim=(-1.25, 1.25), zlim=(-1.25, 1.25))
+    >>> ax.set(xticks=range(-1, 8), yticks=[-1, 0, 1], zticks=[-1, 0, 1])
+    >>> ax.set_aspect("equal", adjustable="box")
+    >>> ax.figure.set_size_inches(6, 5)
+    >>> plt.tight_layout()
+
+    Show the plot:
+
+    >>> plt.show()
+
     These examples serve as an overview into the `Rotation` class and highlight
     major functionalities. For more thorough examples of the range of input and
     output formats supported, consult the individual method's examples.
@@ -2182,7 +2237,7 @@ cdef class Rotation:
 
         quat = np.asarray(self._quat)
         K = np.dot(weights * quat.T, quat)
-        l, v = np.linalg.eigh(K)
+        _, v = np.linalg.eigh(K)
         return self.__class__(v[:, -1], normalize=False)
 
     @cython.embedsignature(True)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
This adds an example of how to plot Rotations to the main Rotation object docstring. This also serves as an example of intrinsic vs extrinsic Euler angle conventions.

#### Additional information
<!--Any additional information you think is important.-->
