### PR TITLE
DEP: linalg: deprecate tri{,u,l}

### DIFF
--- a/scipy/linalg/_matfuncs.py
+++ b/scipy/linalg/_matfuncs.py
@@ -5,14 +5,13 @@ from itertools import product
 
 import numpy as np
 from numpy import (Inf, dot, diag, prod, logical_not, ravel, transpose,
-                   conjugate, absolute, amax, sign, isfinite)
+                   conjugate, absolute, amax, sign, isfinite, triu)
 from numpy.lib.scimath import sqrt as csqrt
 
 # Local imports
 from scipy.linalg import LinAlgError, bandwidth
 from ._misc import norm
 from ._basic import solve, inv
-from ._special_matrices import triu
 from ._decomp_svd import svd
 from ._decomp_schur import schur, rsf2csf
 from ._expm_frechet import expm_frechet, expm_cond

--- a/scipy/linalg/_special_matrices.py
+++ b/scipy/linalg/_special_matrices.py
@@ -61,7 +61,8 @@ def tri(N, M=None, k=0, dtype=None):
            [1, 1, 0, 0, 0]])
 
     """
-    warnings.warn("'tri'/'tril/'triu' is deprecated as of SciPy 1.11.0 in favour of"
+    warnings.warn("'tri'/'tril/'triu' are deprecated as of SciPy 1.11.0 and will "
+                   "be removed in v1.13.0. Please use numpy.(tri/tril/triu) instead."
                   "'numpy.tri' and will be removed in SciPy 1.13.0",
                   DeprecationWarning, stacklevel=2)
     

--- a/scipy/linalg/_special_matrices.py
+++ b/scipy/linalg/_special_matrices.py
@@ -1,4 +1,6 @@
 import math
+import warnings
+
 import numpy as np
 from numpy.lib.stride_tricks import as_strided
 
@@ -19,6 +21,10 @@ __all__ = ['tri', 'tril', 'triu', 'toeplitz', 'circulant', 'hankel',
 
 def tri(N, M=None, k=0, dtype=None):
     """
+    .. deprecated:: 1.11.0
+        `tri` is deprecated in favour of `numpy.tri` and will be removed in
+        SciPy 1.13.0.    
+    
     Construct (N, M) matrix filled with ones at and below the kth diagonal.
 
     The matrix has A[i,j] == 1 for j <= i + k
@@ -55,6 +61,10 @@ def tri(N, M=None, k=0, dtype=None):
            [1, 1, 0, 0, 0]])
 
     """
+    warnings.warn("'tri'/'tril/'triu' is deprecated as of SciPy 1.11.0 in favour of"
+                  "'numpy.tri' and will be removed in SciPy 1.13.0",
+                  DeprecationWarning, stacklevel=2)
+    
     if M is None:
         M = N
     if isinstance(M, str):
@@ -71,6 +81,10 @@ def tri(N, M=None, k=0, dtype=None):
 
 def tril(m, k=0):
     """
+    .. deprecated:: 1.11.0
+        `tril` is deprecated in favour of `numpy.tril` and will be removed in
+        SciPy 1.13.0.
+
     Make a copy of a matrix with elements above the kth diagonal zeroed.
 
     Parameters
@@ -104,6 +118,10 @@ def tril(m, k=0):
 
 def triu(m, k=0):
     """
+    .. deprecated:: 1.11.0
+        `tril` is deprecated in favour of `numpy.triu` and will be removed in
+        SciPy 1.13.0.
+
     Make a copy of a matrix with elements below the kth diagonal zeroed.
 
     Parameters

--- a/scipy/linalg/_special_matrices.py
+++ b/scipy/linalg/_special_matrices.py
@@ -63,7 +63,7 @@ def tri(N, M=None, k=0, dtype=None):
     """
     warnings.warn("'tri'/'tril/'triu' are deprecated as of SciPy 1.11.0 and "
                   "will be removed in v1.13.0. Please use "
-                  "numpy.(tri/tril/triu) instead."
+                  "numpy.(tri/tril/triu) instead.",
                   DeprecationWarning, stacklevel=2)
     
     if M is None:

--- a/scipy/linalg/_special_matrices.py
+++ b/scipy/linalg/_special_matrices.py
@@ -61,9 +61,9 @@ def tri(N, M=None, k=0, dtype=None):
            [1, 1, 0, 0, 0]])
 
     """
-    warnings.warn("'tri'/'tril/'triu' are deprecated as of SciPy 1.11.0 and will "
-                   "be removed in v1.13.0. Please use numpy.(tri/tril/triu) instead."
-                  "'numpy.tri' and will be removed in SciPy 1.13.0",
+    warnings.warn("'tri'/'tril/'triu' are deprecated as of SciPy 1.11.0 and "
+                  "will be removed in v1.13.0. Please use "
+                  "numpy.(tri/tril/triu) instead."
                   DeprecationWarning, stacklevel=2)
     
     if M is None:

--- a/scipy/linalg/tests/test_special_matrices.py
+++ b/scipy/linalg/tests/test_special_matrices.py
@@ -20,7 +20,10 @@ def get_mat(n):
     data = add.outer(data, data)
     return data
 
+dep_filter = np.testing.suppress_warnings()
+dep_filter.filter(DeprecationWarning, "'tri'/'tril/'triu'")
 
+@dep_filter
 class TestTri:
     def test_basic(self):
         assert_equal(tri(4), array([[1, 0, 0, 0],
@@ -61,6 +64,7 @@ class TestTri:
                                              [1, 1, 0]]))
 
 
+@dep_filter
 class TestTril:
     def test_basic(self):
         a = (100*get_mat(5)).astype('l')
@@ -84,6 +88,7 @@ class TestTril:
         assert_equal(tril(a, k=-2), b)
 
 
+@dep_filter
 class TestTriu:
     def test_basic(self):
         a = (100*get_mat(5)).astype('l')
@@ -105,6 +110,12 @@ class TestTriu:
             for l in range(k+3, 5):
                 b[l, k] = 0
         assert_equal(triu(a, k=-2), b)
+
+
+@pytest.mark.parametrize("func", [tri, tril, triu])
+def test_special_matrices_deprecation(func):
+    with pytest.warns(DeprecationWarning, match="'tri'/'tril/'triu'"):
+        func(np.array([[1]]))
 
 
 class TestToeplitz:


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
#15702
#### What does this implement/fix?
<!--Please explain your changes.-->
Deprecates tri, triu & tril as discussed in the original issue
#### Additional information
<!--Any additional information you think is important.-->
https://mail.python.org/archives/list/scipy-dev@python.org/thread/7AET7TIJG5IC3SC3OX6EETT7CMG44FRD/