### PR TITLE
DOC: interpolate: link to the gist with the porting guide

### DIFF
--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -127,7 +127,8 @@ class interp2d:
         `CloughTocher2DInterpolator`.
 
         For more details see
-        `https://gist.github.com/ev-br/8544371b40f414b7eaf3fe6217209bff`
+        `https://gist.github.com/ev-br/8544371b40f414b7eaf3fe6217209bff
+        <https://gist.github.com/ev-br/8544371b40f414b7eaf3fe6217209bff>`_
 
 
     Interpolate over a 2-D grid.


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

gh-18010

#### What does this implement/fix?
<!--Please explain your changes.-->

Try making the link to the gist in the deprecation message an actual hyperlink.

#### Additional information
<!--Any additional information you think is important.-->

[skip azp] [skip actions] [skip cirrus]
