### PR TITLE
DOC: how to document examples using RNG and also self-contained bits

### DIFF
--- a/doc/source/dev/contributor/rendering_documentation.rst
+++ b/doc/source/dev/contributor/rendering_documentation.rst
@@ -219,7 +219,8 @@ Some examples:
 
 Self-contained examples
 ~~~~~~~~~~~~~~~~~~~~~~~
-Each "Example" section must be self-contained. This means that all imports
+Each "Example" section (both in docstrings and general documentation)
+must be self-contained. This means that all imports
 must be explicit, the data used must be defined, and the code should "just
 work" when copy-pasted into a fresh Python interpreter.
 

--- a/doc/source/dev/contributor/rendering_documentation.rst
+++ b/doc/source/dev/contributor/rendering_documentation.rst
@@ -219,8 +219,9 @@ Some examples:
 
 Self-contained examples
 ~~~~~~~~~~~~~~~~~~~~~~~
-All examples must be self-contained. It means all imports must be explicit,
-the data used must be defined in the examples, etc.
+Each "Example" section must be self-contained. This means that all imports
+must be explicit, the data used must be defined, and the code should "just
+work" when copy-pasted into a fresh Python interpreter.
 
     Yes::
 
@@ -231,11 +232,9 @@ the data used must be defined in the examples, etc.
 
         >>> rng = np.random.default_rng()
 
-The variable scope is defined
-per docstrings. i.e. for a given function's docstrings. It means variables
-cannot be shared between functions from the same file. What is possible,
-and recommended, is to separate code within a single example block with
-explanations. Note that blank lines surrounding all block codes are required.
+What is possible (and recommended) is to intersperse blocks of code with
+explanations. Blank lines must separate each code block from the explanatory
+text.
 
     Yes::
 
@@ -251,14 +250,15 @@ explanations. Note that blank lines surrounding all block codes are required.
 
 Examples and randomness
 ~~~~~~~~~~~~~~~~~~~~~~~
-Examples are executed in the CI and the output is compared against the provided
-reference. The main goal is to ensure that the API is correctly documented and
-that we are not using outdated syntax. Doctests are not meant to be used as
-unittests.
+In the continuous integration (CI) suite, examples are executed and the output
+is compared against the provided reference. The main goal is to ensure that
+the *example* is correct; a failure warns us that the example may need to be
+adjusted (e.g. because the API has changed since it was written).
+Doctests are not meant to be used as unit tests of underlying implementation.
 
 In case a random number generator is needed, `np.random.Generator` must be
-used. The canonical way to create a NumPy generator is to use
-`np.random.default_rng()`.
+used. The canonical way to create a NumPy ``Generator`` is to use
+`np.random.default_rng`.
 
     Yes::
 
@@ -278,11 +278,11 @@ used. The canonical way to create a NumPy generator is to use
         >>> sample = np.random.random(10)
 
 Seeding the generator object is optional. If a seed is used, avoid common numbers and
-instead generate a seed with: `np.random.SeedSequence().entropy`.
+instead generate a seed with ``np.random.SeedSequence().entropy``.
 If no seed is provided, the default value
-`1638083107694713882823079058616272161`
-is used when doctests are executed. In any case, the rendered
-documentation does not show the seed on purpose. The intent is to discourage users from
+``1638083107694713882823079058616272161``
+is used when doctests are executed. In either case, the rendered
+documentation will not show the seed. The intent is to discourage users from
 copy/pasting seeds in their code and instead make an explicit decision about
 the use of a seed in their program.
 

--- a/doc/source/dev/contributor/rendering_documentation.rst
+++ b/doc/source/dev/contributor/rendering_documentation.rst
@@ -284,7 +284,10 @@ If no seed is provided, the default value
 is used when doctests are executed. In either case, the rendered
 documentation will not show the seed. The intent is to discourage users from
 copy/pasting seeds in their code and instead make an explicit decision about
-the use of a seed in their program.
+the use of a seed in their program. The consequence is that users cannot
+reproduce the results of the example exactly, so examples using random data
+should not refer to precise numerical values based on random data or rely on
+them to make their point.
 
 .. _GitHub: https://github.com/
 .. _CircleCI: https://circleci.com/vcs-authorize/

--- a/doc/source/dev/contributor/rendering_documentation.rst
+++ b/doc/source/dev/contributor/rendering_documentation.rst
@@ -217,6 +217,70 @@ Some examples:
         Some text that follows the list.
 
 
+Self-contained examples
+~~~~~~~~~~~~~~~~~~~~~~~
+All examples must be self-contained. It means all imports must be explicit,
+the data used must be defined in the examples, etc.
+
+    Yes::
+
+        >>> import numpy as np
+        >>> rng = np.random.default_rng()
+
+    No::
+
+        >>> rng = np.random.default_rng()
+
+The scope is defined
+per docstrings. i.e. for a given function's docstrings, it's possible,
+and a good thing, to separate code with explanations. Note that blank lines
+surrounding all block codes are required.
+
+    Yes::
+
+        Some initial text
+
+        >>> import numpy as np
+        >>> rng = np.random.default_rng()
+
+        This is some explanation
+
+        >>> rng.random(10)
+
+
+Examples and randomness
+~~~~~~~~~~~~~~~~~~~~~~~
+Examples are verified in the CI and output is compared. The main goal
+is to ensure that the API and usage are consistent. Doctests are not unittests.
+
+In case a random number generator is needed, `np.random.Generator` must be
+used.
+
+    Yes::
+
+        >>> import numpy as np
+        >>> rng = np.random.default_rng()
+        >>> sample = rng.random(10)
+
+    Yes::
+
+        >>> import numpy as np
+        >>> rng = np.random.default_rng(102524723947864966825913730119128190984)
+        >>> sample = rng.random(10)
+
+    No::
+
+        >>> import numpy as np
+        >>> sample = np.random.random(10)
+
+Seeding the generator object is optional. Although they must not be common
+numbers but instead be generated with: `np.random.SeedSequence().entropy`.
+If no seed is provided, a default
+value is used when doctests are executed. In any case, the rendered
+documentation does not show seed on purpose. The hope is that people do not
+copy/paste seeds in their code and are making an informed decision about
+the use of a seed in their program.
+
 .. _GitHub: https://github.com/
 .. _CircleCI: https://circleci.com/vcs-authorize/
 .. _Sphinx: https://www.sphinx-doc.org/en/master/

--- a/doc/source/dev/contributor/rendering_documentation.rst
+++ b/doc/source/dev/contributor/rendering_documentation.rst
@@ -231,10 +231,11 @@ the data used must be defined in the examples, etc.
 
         >>> rng = np.random.default_rng()
 
-The scope is defined
-per docstrings. i.e. for a given function's docstrings, it's possible,
-and a good thing, to separate code with explanations. Note that blank lines
-surrounding all block codes are required.
+The variable scope is defined
+per docstrings. i.e. for a given function's docstrings. It means variables
+cannot be shared between functions from the same file. What is possible,
+and recommended, is to separate code within a single example block with
+explanations. Note that blank lines surrounding all block codes are required.
 
     Yes::
 
@@ -250,11 +251,14 @@ surrounding all block codes are required.
 
 Examples and randomness
 ~~~~~~~~~~~~~~~~~~~~~~~
-Examples are executed in the CI and the output is compared against the provided reference. The main goal
-is to ensure that the API and usage are consistent. Doctests are not meant to be used as unittests.
+Examples are executed in the CI and the output is compared against the provided
+reference. The main goal is to ensure that the API is correctly documented and
+that we are not using outdated syntax. Doctests are not meant to be used as
+unittests.
 
 In case a random number generator is needed, `np.random.Generator` must be
-used.
+used. The canonical way to create a NumPy generator is to use
+`np.random.default_rng()`.
 
     Yes::
 
@@ -275,8 +279,9 @@ used.
 
 Seeding the generator object is optional. If a seed is used, avoid common numbers and
 instead generate a seed with: `np.random.SeedSequence().entropy`.
-If no seed is provided, a default
-value is used when doctests are executed. In any case, the rendered
+If no seed is provided, the default value
+`1638083107694713882823079058616272161`
+is used when doctests are executed. In any case, the rendered
 documentation does not show the seed on purpose. The intent is to discourage users from
 copy/pasting seeds in their code and instead make an explicit decision about
 the use of a seed in their program.

--- a/doc/source/dev/contributor/rendering_documentation.rst
+++ b/doc/source/dev/contributor/rendering_documentation.rst
@@ -250,8 +250,8 @@ surrounding all block codes are required.
 
 Examples and randomness
 ~~~~~~~~~~~~~~~~~~~~~~~
-Examples are verified in the CI and output is compared. The main goal
-is to ensure that the API and usage are consistent. Doctests are not unittests.
+Examples are executed in the CI and the output is compared against the provided reference. The main goal
+is to ensure that the API and usage are consistent. Doctests are not meant to be used as unittests.
 
 In case a random number generator is needed, `np.random.Generator` must be
 used.
@@ -273,12 +273,12 @@ used.
         >>> import numpy as np
         >>> sample = np.random.random(10)
 
-Seeding the generator object is optional. Although they must not be common
-numbers but instead be generated with: `np.random.SeedSequence().entropy`.
+Seeding the generator object is optional. If a seed is used, avoid common numbers and
+instead generate a seed with: `np.random.SeedSequence().entropy`.
 If no seed is provided, a default
 value is used when doctests are executed. In any case, the rendered
-documentation does not show seed on purpose. The hope is that people do not
-copy/paste seeds in their code and are making an informed decision about
+documentation does not show the seed on purpose. The intent is to discourage users from
+copy/pasting seeds in their code and instead make an explicit decision about
 the use of a seed in their program.
 
 .. _GitHub: https://github.com/


### PR DESCRIPTION
Follow up of #17945

Add some guidelines on how to write docs. Specifically say you can use seeds now and that the rendered HTML will not have seeds.

Also state examples should be self-contained.