### PR TITLE
DOC: fix section title typo in interpolation tutorial

### DIFF
--- a/doc/source/tutorial/interpolate/extrapolation_examples.rst
+++ b/doc/source/tutorial/interpolate/extrapolation_examples.rst
@@ -397,7 +397,7 @@ However the basic idea is the same.
 
 .. _tutorial-extrapolation-CT_NN:
 
-Exrapolation in ``D > 1``
+Extrapolation in ``D > 1``
 =========================
 
 The basic idea of implementing extrapolation manually in a wrapper class


### PR DESCRIPTION
#### What does this implement/fix?
A misspelling in a subsection title: "Exrapolate" --> corrected to --> "Extrapolate"
