### PR TITLE
DOC: fix underlying of title in extrapolate

### DIFF
--- a/doc/source/tutorial/interpolate/extrapolation_examples.rst
+++ b/doc/source/tutorial/interpolate/extrapolation_examples.rst
@@ -398,7 +398,7 @@ However the basic idea is the same.
 .. _tutorial-extrapolation-CT_NN:
 
 Extrapolation in ``D > 1``
-=========================
+==========================
 
 The basic idea of implementing extrapolation manually in a wrapper class
 or function can be easily generalized to higher dimensions. As an


### PR DESCRIPTION
#18027 introduced a build issue as the underlying of the title is 1 chars too short.