### PR TITLE
WIP: BLD: build libnpymath and libnpyrandom as Meson subprojects

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,3 +17,6 @@
 	path = scipy/_lib/highs
 	url = https://github.com/scipy/highs
 	shallow = true
+[submodule "subprojects/npy-staticlibs"]
+	path = subprojects/npy-staticlibs
+	url = https://github.com/rgommers/npy-staticlibs.git

--- a/meson.build
+++ b/meson.build
@@ -17,6 +17,10 @@ project(
   ],
 )
 
+npy_staticlibs = subproject('npy-staticlibs')
+npymath_lib = npy_staticlibs.get_variable('libnpymath_dep')
+npyrandom_lib = npy_staticlibs.get_variable('libnpyrandom_dep')
+
 cc = meson.get_compiler('c')
 cpp = meson.get_compiler('cpp')
 

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -51,13 +51,6 @@ incdir_f2py = incdir_numpy / '..' / '..' / 'f2py' / 'src'
 inc_f2py = include_directories(incdir_f2py)
 fortranobject_c = incdir_f2py / 'fortranobject.c'
 
-cc = meson.get_compiler('c')
-npymath_path = incdir_numpy / '..' / 'lib'
-npymath_lib = cc.find_library('npymath', dirs: npymath_path)
-npyrandom_path = incdir_numpy / '..' / '..' / 'random' / 'lib'
-# Note: `required: false` can be removed once numpy 1.19 is the minimum version
-npyrandom_lib = cc.find_library('npyrandom', dirs: npyrandom_path, required: false)
-
 # pybind11 include directory - needed in several submodules
 incdir_pybind11 = run_command(py3,
   [

--- a/scipy/stats/_biasedurn.pyx
+++ b/scipy/stats/_biasedurn.pyx
@@ -17,7 +17,7 @@ from cpython.pycapsule cimport PyCapsule_GetPointer, PyCapsule_IsValid
 cdef extern from *:
     """
     extern "C" {
-      #include "numpy/random/distributions.h"
+      #include "distributions.h"
     }
     """
     double random_normal(bitgen_t*, double, double) nogil


### PR DESCRIPTION
Addresses gh-17498. See also https://github.com/numpy/numpy/issues/20880 for context.

This is feasible now that NumPy also builds with Meson. This PR isn't ready, since it depends on a hacky/temporary repo
(https://github.com/rgommers/npy-staticlibs) - but it works at least locally.

The changes inside the SciPy repo are minimal. The standalone static libraries, at least `libnpymath`, need to be trimmed down further and probably need to have all their public symbols renamed with a new prefix.

