### PR TITLE
BLD: avoid running `run_command(py3, ...)`, for better cross-compiling

### DIFF
--- a/doc/source/dev/contributor/meson_advanced.rst
+++ b/doc/source/dev/contributor/meson_advanced.rst
@@ -62,6 +62,32 @@ twice, while ``build`` does support that.
         -I/path/to/include-dir
 
 
+Cross compilation
+=================
+
+Cross compilation is a complex topic, we only add some hopefully helpful hints
+here (for now). Please see
+`Meson's documentation on cross compilation <https://mesonbuild.com/Cross-compilation.html>`__
+for context.
+
+One common hiccup is that ``numpy``, ``pybind11`` and ``pythran`` require
+running Python code in order to obtain their include directories. This tends to
+not work well, either accidentally picking up the packages from the build
+(native) Python rather than the host (cross) Python or requiring ``crossenv``
+or QEMU to run the host Python. To avoid this problem, specify the paths to the
+relevant directories in your *cross file*:
+
+.. code:: ini
+
+    [constants]
+    sitepkg = '/abspath/to/host-pythons/site-packages/'
+
+    [properties]
+    numpy-include-dir = sitepkg + 'numpy/core/include'
+    pybind11-include-dir = sitepkg + 'pybind11/include'
+    pythran-include-dir = sitepkg + 'pythran'
+
+
 Use different build types with Meson
 ====================================
 

--- a/meson.build
+++ b/meson.build
@@ -123,17 +123,9 @@ py_mod = import('python')
 py3 = py_mod.find_installation(pure: false)
 py3_dep = py3.dependency()
 
-# For now, keep supporting this environment variable (same as in setup.py)
-# Once setup.py-based builds are gone, we can convert this to a command-line flag, or make Pythran non-optional.
-use_pythran = run_command(py3,
-  [
-    '-c',
-    'import os; print(os.environ.get("SCIPY_USE_PYTHRAN", 1))'
-  ],
-  check: true
-).stdout().strip() == '1'
+use_pythran = get_option('use-pythran')
 if use_pythran
-  pythran = find_program('pythran')
+  pythran = find_program('pythran', native: true)
 endif
 
 subdir('scipy')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,3 +6,7 @@ option('use-g77-abi', type: 'boolean', value: false,
         description: 'If set to true, forces using g77 compatibility wrappers ' +
                      'for LAPACK functions. The default is to use gfortran ' +
                      'ABI for all LAPACK libraries except MKL.')
+option('use-pythran', type: 'boolean', value: true,
+        description: 'If set to false, disables using Pythran (it falls back ' +
+                     'to either pure Python code or Cython code, depending on ' +
+                     'the implementation).')

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -45,10 +45,19 @@ thread_dep = dependency('threads', required: false)
 # an absolute path. Relative paths are needed when for example a virtualenv is
 # placed inside the source tree; Meson rejects absolute paths to places inside
 # the source tree.
-incdir_numpy = run_command(py3,
-  [
-    '-c',
-    '''import os
+# For cross-compilation it is often not possible to run the Python interpreter
+# in order to retrieve numpy's include directory. It can be specified in the
+# cross file instead:
+#   [properties]
+#   numpy-include-dir = /abspath/to/host-pythons/site-packages/numpy/core/include
+#
+# This uses the path as is, and avoids running the interpreter.
+incdir_numpy = meson.get_external_property('numpy-include-dir', 'not-given')
+if incdir_numpy == 'not-given'
+  incdir_numpy = run_command(py3,
+    [
+      '-c',
+      '''import os
 os.chdir(os.path.join("..", "tools"))
 import numpy as np
 try:
@@ -56,10 +65,19 @@ try:
 except Exception:
   incdir = np.get_include()
 print(incdir)
-'''
-  ],
-  check: true
-).stdout().strip()
+  '''
+    ],
+    check: true
+  ).stdout().strip()
+
+  # We do need an absolute path to feed to `cc.find_library` below
+  _incdir_numpy_abs = run_command(py3,
+    ['-c', 'import os; os.chdir(".."); import numpy; print(numpy.get_include())'],
+    check: true
+  ).stdout().strip()
+else
+  _incdir_numpy_abs = incdir_numpy
+endif
 inc_np = include_directories(incdir_numpy)
 np_dep = declare_dependency(include_directories: inc_np)
 
@@ -67,13 +85,6 @@ incdir_f2py = incdir_numpy / '..' / '..' / 'f2py' / 'src'
 inc_f2py = include_directories(incdir_f2py)
 fortranobject_c = incdir_f2py / 'fortranobject.c'
 
-# We do need an absolute path to feed to `cc.find_library` below
-_incdir_numpy_abs = run_command(py3,
-  ['-c', 'import os; os.chdir(".."); import numpy; print(numpy.get_include())'],
-  check: true
-).stdout().strip()
-
-cc = meson.get_compiler('c')
 npymath_path = _incdir_numpy_abs / '..' / 'lib'
 npyrandom_path = _incdir_numpy_abs / '..' / '..' / 'random' / 'lib'
 npymath_lib = cc.find_library('npymath', dirs: npymath_path)
@@ -81,33 +92,42 @@ npyrandom_lib = cc.find_library('npyrandom', dirs: npyrandom_path)
 
 # pybind11 include directory - needed in several submodules
 #
-# in meson 1.1.0, this will find the pyproject.toml build-requires version
-pybind11_dep = dependency('pybind11', version: '>=2.10.0', required: false, allow_fallback: true)
-if not pybind11_dep.found()
-  incdir_pybind11 = run_command(py3,
-    [
-      '-c',
-      '''from os.path import relpath
+# first check if the user specified a path in a cross file
+incdir_pybind11 = meson.get_external_property('pybind11-include-dir', 'not-given')
+if incdir_pybind11 == 'not-given'
+  # in meson 1.1.0, this will find the pyproject.toml build-requires version
+  pybind11_dep = dependency('pybind11', version: '>=2.10.0', required: false, allow_fallback: true)
+  if not pybind11_dep.found()
+    incdir_pybind11 = run_command(py3,
+      [
+        '-c',
+        '''from os.path import relpath
 import pybind11
 try:
   incdir = relpath(pybind11.get_include())
 except Exception:
   incdir = pybind11.get_include()
 print(incdir)
-  '''
-    ],
-    check: true
-  ).stdout().strip()
-
+'''
+      ],
+      check: true
+    ).stdout().strip()
+    pybind11_dep = declare_dependency(include_directories: incdir_pybind11)
+  endif
+else
   pybind11_dep = declare_dependency(include_directories: incdir_pybind11)
 endif
 
 # Pythran include directory and build flags
 if use_pythran
-  incdir_pythran = run_command(py3,
-    [
-      '-c',
-    '''import os
+  # This external-property may not be needed if we can use the native include
+  # dir, see https://github.com/serge-sans-paille/pythran/issues/1394
+  incdir_pythran = meson.get_external_property('pythran-include-dir', 'not-given')
+  if incdir_pythran == 'not-given'
+    incdir_pythran = run_command(py3,
+      [
+        '-c',
+      '''import os
 os.chdir(os.path.join("..", "tools"))
 import pythran
 try:
@@ -116,9 +136,10 @@ except Exception:
   incdir = pythran.get_include()
 print(incdir)
 '''
-    ],
-    check: true
-  ).stdout().strip()
+      ],
+      check: true
+    ).stdout().strip()
+  endif
   pythran_dep = declare_dependency(include_directories: incdir_pythran)
 else
   pythran_dep = []
@@ -401,8 +422,7 @@ foreach name, compiler : compilers
 endforeach
 # Add `pythran` information if present
 if use_pythran
-  pythran_version_command = run_command('pythran', '-V', check: true)
-  conf_data.set('PYTHRAN_VERSION', pythran_version_command.stdout().strip())
+  conf_data.set('PYTHRAN_VERSION', pythran.version())
   conf_data.set('PYTHRAN_INCDIR', incdir_pythran)
 endif
 


### PR DESCRIPTION
Adding the ability to specify the paths to the numpy, pybind11 and pythran include directories was discussed in gh-14812. Short of pkg-config files for these packages and/or builtin support for them in Meson, this is a decent solution.

Closes gh-16783.

To do:

- [x] verify that this indeed solves the problem for conda-forge (Cc @h-vetinari) or another packaging system
- ~[ ] add a CI job for cross-compiling (probably Linux x86-64 -> aarch64)~