### PR TITLE
ENH: stats: add ecdf function

### DIFF
--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -513,13 +513,14 @@ Random variate generation / CDF Inversion
 
    rvs_ratio_uniforms
 
-Distribution Fitting
---------------------
+Fitting / Survival Analysis
+---------------------------
 
 .. autosummary::
    :toctree: generated/
 
    fit
+   ecdf
 
 Directional statistical functions
 ---------------------------------
@@ -611,6 +612,7 @@ from ._mannwhitneyu import mannwhitneyu
 from ._fit import fit, goodness_of_fit
 from ._covariance import Covariance
 from ._sensitivity_analysis import *
+from ._survival import *
 
 # Deprecated namespaces, to be removed in v2.0.0
 from . import (

--- a/scipy/stats/_survival.py
+++ b/scipy/stats/_survival.py
@@ -1,0 +1,116 @@
+from dataclasses import make_dataclass
+import numpy as np
+from ._censored_data import CensoredData
+
+
+__all__ = ['ecdf']
+
+
+ECDFResult = make_dataclass('ECDFResult', ['x', 'cdf', 'sf'])
+
+
+def ecdf(sample):
+    """Empirical cumulative distribution function of a sample
+
+    The empirical cumulative distribution function (ECDF) is a step function
+    estimate of the CDF of the distribution underlying a sample.
+
+    Parameters
+    ----------
+    sample : 1D array_like or `stats.CensoredData`
+        Besides array_like, instances of `stats.CensoredData` containing
+        uncensored observations are supported. Currently, instances of
+        `stats.CensoredData` with censored data will result in a
+        ``NotImplementedError``, but future support for left-censored,
+        right-centered, and interval-censored data is planned.
+
+    Returns
+    -------
+    An object with the following attributes.
+
+    x : ndarray
+        The unique values at which the ECDF changes.
+    cdf : ndarray
+        The values of the ECDF corresponding with `x`.
+    sf : ndarray
+        The empirical survival function, the complement of the ECDF.
+
+    Notes
+    -----
+    When each observation of the sample is a precise measurement, the ECDF
+    steps up by ``1/len(sample)`` at each of the observations.
+
+    When observations are lower bounds, upper bounds, or both upper and lower
+    bounds, the data is said to be "censored", and `sample` may be provided as
+    an instance of `stats.CensoredData`.
+
+    For right-censored data, the ECDF is given by the Kaplan-Meier estimator
+    [1]; other forms of censoring are not supported at this time.
+
+    References
+    ----------
+    .. [1] Conover, William Jay. Practical nonparametric statistics. Vol. 350.
+           John Wiley & Sons, 1999.
+
+    .. [2] Kaplan, Edward L., and Paul Meier. "Nonparametric estimation from
+           incomplete observations." Journal of the American statistical
+           association 53.282 (1958): 457-481.
+
+    Examples
+    --------
+    As in the example from [1] page 79, five boys were selected at random from
+    those in a single high school. Their one-mile run times were recorded as
+    follows.
+
+    >>> sample = [6.23, 5.58, 7.06, 6.42, 5.20]  # one-mile run times (minutes)
+
+    The empirical distribution function, which approximates the distribution
+    function of one-mile run times of the population from which the boys were
+    sampled, is calculated as follows.
+
+    >>> from scipy import stats
+    >>> res = stats.ecdf(sample)
+    >>> res.x
+    array([5.2 , 5.58, 6.23, 6.42, 7.06])
+    >>> res.cdf
+    array([0.2, 0.4, 0.6, 0.8, 1. ])
+
+    To plot the result as a step function:
+
+    >>> import numpy as np
+    >>> import matplotlib.pyplot as plt
+    >>> ax = plt.subplot()
+    >>> ax.step(np.insert(res.x, 4, 0), np.insert(res.cdf, 0, 0), where='post')
+    >>> ax.set_xlabel('One-Mile Run Time (minutes)')
+    >>> ax.set_ylabel('Empirical CDF')
+    >>> plt.show()
+
+    """
+
+    if not isinstance(sample, CensoredData):
+        try:  # takes care of input standardization/validation
+            sample = CensoredData(uncensored=sample)
+        except ValueError as e:
+            message = str(e).replace('uncensored', 'sample')
+            raise type(e)(message) from e
+
+    if sample.num_censored() == 0:
+        res = _ecdf_uncensored(sample._uncensor())
+    else:
+        # Support censoring in follow-up PRs
+        message = ("Currently, only uncensored data is supported.")
+        raise NotImplementedError(message)
+    return res
+
+
+def _ecdf_uncensored(sample):
+    sample = np.sort(sample)
+    x, counts = np.unique(sample, return_counts=True)
+
+    # [1].81 "the fraction of [observations] that are less than or equal to x
+    cdf = np.cumsum(counts) / sample.size
+
+    # [1].89 "the relative frequency of the sample that exceeds x in value"
+    sf = 1 - cdf
+
+    return ECDFResult(x, cdf, sf)

--- a/scipy/stats/_survival.py
+++ b/scipy/stats/_survival.py
@@ -10,7 +10,7 @@ ECDFResult = make_dataclass('ECDFResult', ['x', 'cdf', 'sf'])
 
 
 def ecdf(sample):
-    """Empirical cumulative distribution function of a sample
+    """Empirical cumulative distribution function of a sample.
 
     The empirical cumulative distribution function (ECDF) is a step function
     estimate of the CDF of the distribution underlying a sample.
@@ -58,7 +58,7 @@ def ecdf(sample):
 
     Examples
     --------
-    As in the example from [1] page 79, five boys were selected at random from
+    As in the example from [1]_ page 79, five boys were selected at random from
     those in a single high school. Their one-mile run times were recorded as
     follows.
 
@@ -86,7 +86,6 @@ def ecdf(sample):
     >>> plt.show()
 
     """
-
     if not isinstance(sample, CensoredData):
         try:  # takes care of input standardization/validation
             sample = CensoredData(uncensored=sample)

--- a/scipy/stats/_survival.py
+++ b/scipy/stats/_survival.py
@@ -45,7 +45,7 @@ def ecdf(sample):
     an instance of `stats.CensoredData`.
 
     For right-censored data, the ECDF is given by the Kaplan-Meier estimator
-    [1]; other forms of censoring are not supported at this time.
+    [1]_; other forms of censoring are not supported at this time.
 
     References
     ----------
@@ -80,7 +80,7 @@ def ecdf(sample):
     >>> import numpy as np
     >>> import matplotlib.pyplot as plt
     >>> ax = plt.subplot()
-    >>> ax.step(np.insert(res.x, 4, 0), np.insert(res.cdf, 0, 0), where='post')
+    >>> ax.step(np.insert(res.x, 0, 4), np.insert(res.cdf, 0, 0), where='post')
     >>> ax.set_xlabel('One-Mile Run Time (minutes)')
     >>> ax.set_ylabel('Empirical CDF')
     >>> plt.show()

--- a/scipy/stats/meson.build
+++ b/scipy/stats/meson.build
@@ -217,6 +217,7 @@ py3.install_sources([
     '_sensitivity_analysis.py',
     '_stats_mstats_common.py',
     '_stats_py.py',
+    '_survival.py',
     '_tukeylambda_stats.py',
     '_variation.py',
     '_warnings_errors.py',

--- a/scipy/stats/tests/meson.build
+++ b/scipy/stats/tests/meson.build
@@ -28,6 +28,7 @@ py3.install_sources([
     'test_sampling.py',
     'test_sensitivity_analysis.py',
     'test_stats.py',
+    'test_survival.py',
     'test_tukeylambda_stats.py',
     'test_variation.py'
   ],

--- a/scipy/stats/tests/test_survival.py
+++ b/scipy/stats/tests/test_survival.py
@@ -1,0 +1,51 @@
+import pytest
+import numpy as np
+from numpy.testing import assert_equal
+from scipy import stats
+
+class TestSurvival:
+    def test_input_validation(self):
+        message = '`sample` must be a one-dimensional sequence.'
+        with pytest.raises(ValueError, match=message):
+            stats.ecdf([[1]])
+        with pytest.raises(ValueError, match=message):
+            stats.ecdf(1)
+
+        message = '`sample` must not contain nan'
+        with pytest.raises(ValueError, match=message):
+            stats.ecdf([np.nan])
+
+        message = 'Currently, only uncensored data is supported.'
+        with pytest.raises(NotImplementedError, match=message):
+            stats.ecdf(stats.CensoredData.left_censored([1], censored=[True]))
+
+    def test_edge_cases(self):
+        res = stats.ecdf([])
+        assert_equal(res.x, [])
+        assert_equal(res.cdf, [])
+
+        res = stats.ecdf([1])
+        assert_equal(res.x, [1])
+        assert_equal(res.cdf, [1])
+
+    def test_unique(self):
+        # Example with unique observations; `stats.ecdf` ref. [1] page 80
+        sample = [6.23, 5.58, 7.06, 6.42, 5.20]
+        res = stats.ecdf(sample)
+        ref_x = np.sort(np.unique(sample))
+        ref_cdf = np.arange(1, 6) / 5
+        ref_sf = 1 - ref_cdf
+        assert_equal(res.x, ref_x)
+        assert_equal(res.cdf, ref_cdf)
+        assert_equal(res.sf, ref_sf)
+
+    def test_nonunique(self):
+        # Example with non-unique observations; `stats.ecdf` ref. [1] page 82
+        sample = [0, 2, 1, 2, 3, 4]
+        res = stats.ecdf(sample)
+        ref_x = np.sort(np.unique(sample))
+        ref_cdf = np.array([1/6, 2/6, 4/6, 5/6, 1])
+        ref_sf = 1 - ref_cdf
+        assert_equal(res.x, ref_x)
+        assert_equal(res.cdf, ref_cdf)
+        assert_equal(res.sf, ref_sf)


### PR DESCRIPTION
#### Reference issue
Closes gh-17431

#### What does this implement/fix?
This PR adds an ECDF (empirical cumulative distribution function) function as requested in gh-17431.

#### Additional information
Follow-up work is planned, but I thought I'd start with the minimum complete function (i.e. uncensored data only, no confidence intervals, no bells and whistles). 

One question is whether  we should follow Matlab and duplicate the minimum value of `sample`. For example, should the docstring example be like:
```
    >>> res = stats.ecdf(sample)
    >>> res.x
    array([5.2 , 5.58, 6.23, 6.42, 7.06])
    >>> res.cdf
    array([0.2, 0.4, 0.6, 0.8, 1. ])
```
or
```
    >>> res.x
    array([5.2, 5.2 , 5.58, 6.23, 6.42, 7.06])  # 5.2 is duplicated
    >>> res.cdf
    array([0, 0.2, 0.4, 0.6, 0.8, 1. ])  # 5.2 also corresponds with CDF of zero
```
My preference is not to do this because equally valid to prepend any point lower than the minimum of the sample with a corresponding CDF of zero. Likewise, any point after the maximum could be appended with a corresponding CDF of 1. The choice is application-dependent. We can add a simple plotting function for convenience later, but we don't need to return the extra points we chose just to make the plot look nice. We could add parameters to control this behavior, but that can be done in a follow-up, too.

@hadjipantelis