### PR TITLE
BLD: build Windows wheel for py39 against numpy 1.22.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,10 +31,11 @@ requires = [
     # On Windows we need to avoid 1.21.6, 1.22.0 and 1.22.1 because they were
     # built with vc142. 1.22.3 is the first version that has 32-bit Windows
     # wheels *and* was built with vc141. So use that:
+    "numpy==1.22.3; python_version=='3.9' and platform_system=='Windows' and platform_python_implementation != 'PyPy'",
     "numpy==1.22.3; python_version=='3.10' and platform_system=='Windows' and platform_python_implementation != 'PyPy'",
 
     # default numpy requirements
-    "numpy==1.21.6; python_version=='3.9' and platform_machine!='loongarch64' and platform_python_implementation != 'PyPy'",
+    "numpy==1.21.6; python_version=='3.9' and (platform_system!='Windows' and platform_machine!='loongarch64') and platform_python_implementation != 'PyPy'",
     # Note that 1.21.3 was the first version with a complete set of 3.10 wheels,
     # however macOS was broken and it's safe C API/ABI-wise to build against 1.21.6
     # (see oldest-supported-numpy issues gh-28 and gh-45)


### PR DESCRIPTION
This is a follow-up to gh-17959, which bumped numpy from 1.19.5 to 1.21.6, which is wrong because that version was built with vc142 (see comment above the line added in this PR).

[wheel build]
[skip circle] [skip cirrus] [skip azp]