### PR TITLE
BUG: Fix `sym=False` for odd lengths

### DIFF
--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -23,7 +23,7 @@ def _len_guards(M):
 
 def _extend(M, sym):
     """Extend window by 1 sample if needed for DFT-even symmetry"""
-    if not sym:
+    if not sym and M % 2 == 0:
         return M + 1, True
     else:
         return M, False


### PR DESCRIPTION
Yields correct results for `hann`, `dpss`, didn't check further.

I've not confirmed this logic is correct, it's just a guess.

