### PR TITLE
MAINT: update GH bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Create a report to help us improve SciPy
-title: "BUG: "
+title: "BUG: <Please write a comprehensive title after the 'BUG: ' prefix>"
 labels: [defect]
 
 body:
@@ -29,9 +29,10 @@ body:
       render: shell
     validations:
       required: true
-  - type: input
+  - type: textarea
     attributes:
-      label: SciPy/NumPy/Python version information
-      description: 'Please run the following and paste the result in a code block - `import scipy;scipy.show_config()` or on older versions `import sys, scipy, numpy; print(scipy.__version__, numpy.__version__, sys.version_info)`'
+      label: SciPy/NumPy/Python version and system information
+      description: 'Please run the following and paste the result in a code block - `import sys, scipy, numpy; print(scipy.__version__, numpy.__version__, sys.version_info); scipy.show_config()`'
+      render: shell
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_report.yml
@@ -32,7 +32,7 @@ body:
   - type: textarea
     attributes:
       label: SciPy/NumPy/Python version and system information
-      description: 'Please run the following and paste the result in a code block - `import sys, scipy, numpy; print(scipy.__version__, numpy.__version__, sys.version_info); scipy.show_config()`'
+      description: 'Please run the following and paste the result here - `import sys, scipy, numpy; print(scipy.__version__, numpy.__version__, sys.version_info); scipy.show_config()`'
       render: shell
     validations:
       required: true


### PR DESCRIPTION
Adjusting slightly the bug template as the new command actually does not provide SciPy's version and even if, we need the other command to be ran for people using released versions.

e.g. of issue #18039