### PR TITLE
STY: Include Python.h before any other headers.

### DIFF
--- a/scipy/_lib/_uarray/_uarray_dispatch.cxx
+++ b/scipy/_lib/_uarray/_uarray_dispatch.cxx
@@ -1,7 +1,7 @@
+#include <Python.h>
+
 #include "small_dynamic_array.h"
 #include "vectorcall.h"
-
-#include <Python.h>
 
 #include <algorithm>
 #include <cstddef>

--- a/scipy/sparse/linalg/_dsolve/_superluobject.h
+++ b/scipy/sparse/linalg/_dsolve/_superluobject.h
@@ -8,8 +8,8 @@
 #ifndef __SUPERLU_OBJECT
 #define __SUPERLU_OBJECT
 
-#include <setjmp.h>
 #include <Python.h>
+#include <setjmp.h>
 
 /* Undef a macro from Python which conflicts with superlu */
 #ifdef c_abs

--- a/scipy/special/Faddeeva.cc
+++ b/scipy/special/Faddeeva.cc
@@ -20,6 +20,7 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 
  */
 
+#include <Python.h>
 #include "Faddeeva.hh"
 
 /* Available at: http://ab-initio.mit.edu/Faddeeva
@@ -117,7 +118,6 @@
 		       file Faddeeva.hh.
 */
 
-#include <Python.h>
 #include <cfloat>
 #include <cmath>
 


### PR DESCRIPTION
Specifically, include the visibility macros in pyconfig.h before any stdlib headers.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Inspired by [discussion](https://github.com/scipy/scipy/pull/17993#discussion_r1117456520) on #17993.

#### What does this implement/fix?
<!--Please explain your changes.-->
Make sure `Python.h` is the first file included any any file which includes it

#### Additional information
<!--Any additional information you think is important.-->
Found with [the attached script: `check_python_h_first.py`](https://github.com/scipy/scipy/files/10831513/check_python_h_first.txt)
```bash
python check_python_h_first.py $(find scipy -maxdepth 4 \( -name __pycache__ -prune \) -o -type f -a \( -name \*.c\* -o -name \*.h\* \) -print)
```