### PR TITLE
MAINT: integrate.qmc_quad: correct behavior of parameter `log`

### DIFF
--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -369,7 +369,7 @@ class TestQMCQuad:
         assert_allclose(np.exp(logres.integral), res.integral, rtol=1e-14)
         assert np.imag(logres.integral) == (np.pi if np.prod(signs) < 0 else 0)
         assert_allclose(np.exp(logres.standard_error),
-                        res.standard_error, rtol=1e-14, atol=1e-17)
+                        res.standard_error, rtol=1e-14, atol=2e-17)
 
     @pytest.mark.parametrize("n_points", [2**8, 2**12])
     @pytest.mark.parametrize("n_estimates", [8, 16])

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -369,7 +369,7 @@ class TestQMCQuad:
         assert_allclose(np.exp(logres.integral), res.integral, rtol=1e-14)
         assert np.imag(logres.integral) == (np.pi if np.prod(signs) < 0 else 0)
         assert_allclose(np.exp(logres.standard_error),
-                        res.standard_error, rtol=1e-14, atol=2e-17)
+                        res.standard_error, rtol=1e-14, atol=1e-16)
 
     @pytest.mark.parametrize("n_points", [2**8, 2**12])
     @pytest.mark.parametrize("n_estimates", [8, 16])

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -366,8 +366,10 @@ class TestQMCQuad:
         logres = qmc_quad(lambda *args: np.log(func(*args)), a, b,
                           n_points=n_points, n_estimates=n_estimates,
                           log=True, qrng=qrng)
-        assert_allclose(np.exp(logres.integral), res.integral)
+        assert_allclose(np.exp(logres.integral), res.integral, rtol=1e-14)
         assert np.imag(logres.integral) == (np.pi if np.prod(signs) < 0 else 0)
+        assert_allclose(np.exp(logres.standard_error),
+                        res.standard_error, rtol=1e-14, atol=1e-17)
 
     @pytest.mark.parametrize("n_points", [2**8, 2**12])
     @pytest.mark.parametrize("n_estimates", [8, 16])


### PR DESCRIPTION
#### Reference issue
None. Might as well just fix it.

#### What does this implement/fix?
This adjusts the output of `qmc_quad` when `log=True`.

When `log=False`, the mean of the independent integral estimates is an unbiased estimator of the true integral, so when `log=True`, we should be returning the `log` of this quantity. But currently, we return the *mean of the log* of the integral estimates, which is not the same because the order of taking the log and the mean matters. This PR corrects this.

Similarly, when `log=True`, we currently return the SEM of the log of the integral estimates; this PR would return the log of the SEM of the integral estimates.

Numerically, the difference is small when the independent estimates are accurate, which is why the tests didn't catch it. This PR improves the sensitivity of the relevant test so that it would fail in main.

#### Additional information
<details>

Test scripts for the `mean`, `std`, and `sem` functions defined within `qmc_quad`:

```python3
import numpy as np
from numpy.testing import assert_allclose, assert_equal
from scipy import stats, optimize, integrate
import matplotlib.pyplot as plt
rng = np.random.default_rng(1638083107694713882823079058616272161)
from scipy.special import logsumexp

n_estimates = 20
x = rng.random(n_estimates)


def sum_product(integrands, dA, log=False):
    if log:
        return logsumexp(integrands) + np.log(dA)
    else:
        return np.sum(integrands * dA)


def mean(estimates, log=False):
    if log:
        return logsumexp(estimates) - np.log(n_estimates)
    else:
        return np.mean(estimates)


def std(estimates, m=None, ddof=0, log=False):
    m = m or mean(estimates, log)
    if log:
        estimates, m = np.broadcast_arrays(estimates, m)
        temp = np.vstack((estimates, m + np.pi * 1j))
        diff = logsumexp(temp, axis=0)
        return np.real(0.5 * (logsumexp(2 * diff)
                              - np.log(n_estimates - ddof)))
    else:
        return np.std(estimates, ddof=ddof)


def sem(estimates, m=None, s=None, log=False):
    m = m or mean(estimates, log)
    s = s or std(estimates, m, ddof=1, log=log)
    if log:
        return s - 0.5 * np.log(n_estimates)
    else:
        return s / np.sqrt(n_estimates)

print(np.mean(x))
print(mean(x, log=False))
print(np.exp(mean(np.log(x), log=True)))

print(np.std(x, ddof=1))
print(std(x, ddof=1, log=False))
print(np.exp(std(np.log(x), ddof=1, log=True)))

print(stats.sem(x))
print(sem(x, log=False))
print(np.exp(sem(np.log(x), log=True)))
```

</details>