### PR TITLE
BLD: use anaconda-client to upload wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -151,13 +151,26 @@ jobs:
           path: ./wheelhouse/*.whl
           name: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}
 
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          # for installation of anaconda-client, required for upload to
+          # anaconda.org
+          # default (and activated) environment name is test
+          # Note that this step is *after* specific pythons have been used to
+          # build and test the wheel
+          auto-update-conda: true
+          python-version: "3.10"
+
       - name: Upload wheels
         if: success()
-        shell: bash
+        shell: bash -el {0}
+        # see https://github.com/marketplace/actions/setup-miniconda for why
+        # `-el {0}` is required.
         env:
           SCIPY_STAGING_UPLOAD_TOKEN: ${{ secrets.SCIPY_STAGING_UPLOAD_TOKEN }}
           SCIPY_NIGHTLY_UPLOAD_TOKEN: ${{ secrets.SCIPY_NIGHTLY_UPLOAD_TOKEN }}
         run: |
+          conda install -y anaconda-client
           source tools/wheels/upload_wheels.sh
           set_upload_vars
           # For cron jobs (restricted to main branch) or "Run workflow" trigger

--- a/ci/cirrus_wheels.yml
+++ b/ci/cirrus_wheels.yml
@@ -96,7 +96,6 @@ cirrus_wheels_upload_task:
     SCIPY_NIGHTLY_UPLOAD_TOKEN: ENCRYPTED[377be83afdaf9e8fa8bac105022bb1d362f72fff8501c2b5e827018b82270111828fb542fd7bd56bbfac9745603bd535]
 
   upload_script: |
-    apt-get install -y python3-venv python-is-python3 curl
     export IS_SCHEDULE_DISPATCH="false"
     export IS_PUSH="false"
 
@@ -112,24 +111,36 @@ cirrus_wheels_upload_task:
           export IS_PUSH="true"
     fi
     
-    # The name of the zip file is derived from the `wheels_artifact` line.
-    # If you change the artifact line to `myfile_artifact` then it would be
-    # called myfile.zip
-    
-    curl https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/wheels.zip --output wheels.zip
-    unzip wheels.zip
-    
-    source tools/wheels/upload_wheels.sh
-    set_upload_vars
-    # For cron jobs (restricted to main branch)
-    # an upload to:
-    #
-    # https://anaconda.org/scipy-wheels-nightly/scipy
-    # 
-    # Pushes to a maintenance branch that contain '[wheel build]' will
-    # cause wheels to be built and uploaded to:
-    #
-    # https://anaconda.org/multibuild-wheels-staging/scipy
-    #
-    # The tokens were originally generated at anaconda.org
-    upload_wheels
+    if [[ $IS_PUSH == "true" ]] || [[ $IS_SCHEDULE_DISPATCH == "true" ]]; then
+        apt-get update
+        apt-get install -y curl wget
+        
+        # install miniconda for uploading to anaconda
+        wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+        bash miniconda.sh -b -p ~/miniconda3
+        ~/miniconda3/bin/conda init bash
+        source ~/miniconda3/bin/activate
+        conda install -y anaconda-client
+        
+        # The name of the zip file is derived from the `wheels_artifact` line.
+        # If you change the artifact line to `myfile_artifact` then it would be
+        # called myfile.zip
+        
+        curl https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/wheels.zip --output wheels.zip
+        unzip wheels.zip
+        
+        source tools/wheels/upload_wheels.sh
+        set_upload_vars
+        # For cron jobs (restricted to main branch)
+        # an upload to:
+        #
+        # https://anaconda.org/scipy-wheels-nightly/scipy
+        # 
+        # Pushes to a maintenance branch that contain '[wheel build]' will
+        # cause wheels to be built and uploaded to:
+        #
+        # https://anaconda.org/multibuild-wheels-staging/scipy
+        #
+        # The tokens were originally generated at anaconda.org
+        upload_wheels
+    fi

--- a/tools/wheels/upload_wheels.sh
+++ b/tools/wheels/upload_wheels.sh
@@ -20,14 +20,13 @@ set_upload_vars() {
         export ANACONDA_UPLOAD="false"
     fi
 }
+
 upload_wheels() {
     echo ${PWD}
     if [[ ${ANACONDA_UPLOAD} == true ]]; then
         if [ -z ${TOKEN} ]; then
             echo no token set, not uploading
         else
-            python -m pip install \
-            git+https://github.com/Anaconda-Platform/anaconda-client.git@be1e14936a8e947da94d026c990715f0596d7043
             # sdists are located under dist folder
             if compgen -G "./dist/*.gz"; then
                 echo "Found sdist"


### PR DESCRIPTION
Uses anaconda-client to upload wheels. anaconda-client is installed via conda instead of a client installed from an old commit.