### PR TITLE
DOC fix expectile docstring - empirical CDF

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -10241,7 +10241,7 @@ def expectile(a, alpha=0.5, *, weights=None):
     The empirical expectile at level :math:`\alpha` (`alpha`) of a sample
     :math:`a_i` (the array `a`) is defined by plugging in the empirical CDF of
     `a`. Given sample or case weights :math:`w` (the array `weights`), it
-    reads :math:`F_a(x) = \frac{1}{\sum_i a_i} \sum_i w_i 1_{a_i \leq x}`
+    reads :math:`F_a(x) = \frac{1}{\sum_i w_i} \sum_i w_i 1_{a_i \leq x}`
     with indicator function :math:`1_{A}`. This leads to the definition of the
     empirical expectile at level `alpha` as the unique solution :math:`t` of:
 


### PR DESCRIPTION
This fixes the formula for the empirical CDF in the docstring of `scipy.stats.expectile`.
