### PR TITLE
Update _stats_py.py

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -3120,6 +3120,8 @@ def gzscore(a, *, axis=0, ddof=0, nan_policy='propagate'):
     >>> fig, ax = plt.subplots()
     >>> ax.hist(gzscore(x), 50)
     >>> plt.show()
+    
+    Also for the zscore nomalize value you need to use zmap to get the correct zscore values
 
     """
     a = np.asanyarray(a)


### PR DESCRIPTION
Add a comment in the zscore definition that we have to use zmap for the standardization as if we go directly for score there is a difference between the value that we are getting from zscore=(x-mean)/std.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
This issue is for the values of zscore. If we use the mathematical formula that is z=(x-mean)/std then sometimes we get a different value when we use zscore function

#### What does this implement/fix?
<!--Please explain your changes.-->
There is no a such exact solution but we can notify users why this issue may be there and so we can use zmap separately and then go for zscore

#### Additional information
<!--Any additional information you think is important.-->
Or what else can be done is by notifying the user that there should not be null values and we make a function return (x-mean)/std directly. 
