### PR TITLE
ENH: implement array @ LinearOperator

### DIFF
--- a/scipy/sparse/linalg/_interface.py
+++ b/scipy/sparse/linalg/_interface.py
@@ -467,10 +467,12 @@ class LinearOperator:
         else:
             x = np.asarray(x)
 
+            # We use transpose instead of rmatvec/rmatmat to avoid
+            # unnecessary complex conjugation if possible.
             if x.ndim == 1 or x.ndim == 2 and x.shape[0] == 1:
-                return self.rmatvec(x.T.conj()).T.conj()
+                return self.T.matvec(x.T).T
             elif x.ndim == 2:
-                return self.rmatmat(x.T.conj()).T.conj()
+                return self.T.matmat(x.T).T
             else:
                 raise ValueError('expected 1-d or 2-d array or matrix, got %r'
                                  % x)

--- a/scipy/sparse/linalg/_interface.py
+++ b/scipy/sparse/linalg/_interface.py
@@ -138,6 +138,8 @@ class LinearOperator:
     """
 
     ndim = 2
+    # Necessary for right matmul with numpy arrays.
+    __array_ufunc__ = None
 
     def __new__(cls, *args, **kwargs):
         if cls is LinearOperator:
@@ -438,7 +440,40 @@ class LinearOperator:
         if np.isscalar(x):
             return _ScaledLinearOperator(self, x)
         else:
-            return NotImplemented
+            return self._rdot(x)
+
+    def _rdot(self, x):
+        """Matrix-matrix or matrix-vector multiplication from the right.
+
+        Parameters
+        ----------
+        x : array_like
+            1-d or 2-d array, representing a vector or matrix.
+
+        Returns
+        -------
+        xA : array
+            1-d or 2-d array (depending on the shape of x) that represents
+            the result of applying this linear operator on x from the right.
+
+        Notes
+        -----
+        This is copied from dot to implement right multiplication.
+        """
+        if isinstance(x, LinearOperator):
+            return _ProductLinearOperator(x, self)
+        elif np.isscalar(x):
+            return _ScaledLinearOperator(self, x)
+        else:
+            x = np.asarray(x)
+
+            if x.ndim == 1 or x.ndim == 2 and x.shape[0] == 1:
+                return self.rmatvec(x.T.conj()).T.conj()
+            elif x.ndim == 2:
+                return self.rmatmat(x.T.conj()).T.conj()
+            else:
+                raise ValueError('expected 1-d or 2-d array or matrix, got %r'
+                                 % x)
 
     def __pow__(self, p):
         if np.isscalar(p):

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -174,13 +174,17 @@ class TestLinearOperator:
              'rmatmat': lambda x: np.dot(self.A.T.conj(), x),
              'matmat': lambda x: np.dot(self.A, x)}
         A = interface.LinearOperator(**D)
-        B = np.array([[1, 2, 3],
+        B = np.array([[1 + 1j, 2, 3],
                       [4, 5, 6],
                       [7, 8, 9]])
         b = B[0]
 
         assert_equal(operator.matmul(A, b), A * b)
+        assert_equal(operator.matmul(A, b.reshape(-1, 1)), A * b.reshape(-1, 1))
         assert_equal(operator.matmul(A, B), A * B)
+        assert_equal(operator.matmul(b, A.H), b * A.H)
+        assert_equal(operator.matmul(b.reshape(1, -1), A.H), b.reshape(1, -1) * A.H)
+        assert_equal(operator.matmul(B, A.H), B * A.H)
         assert_raises(ValueError, operator.matmul, A, 2)
         assert_raises(ValueError, operator.matmul, 2, A)
 


### PR DESCRIPTION
#### Reference issue
Closes #17281

#### What does this implement/fix?
- Add `__array_ufunc__ = None` to `sparse.linalg.LinearOperator`. I believe this is the desired behavior because linear operators implement their algebra directly and not via ufuncs.
- Implement right multiplication by arrays. In doing so I preserved the current pattern of not distinguishing between `*` and `@`. This is consistent with left multiplication. I think using only `@` would be cleaner, but consistency seems more important.
- Added tests are comparable to the tests of the left matmul, although I extended them to also check different vector shapes

#### Notes
- I maintained the style of how left multiplication is implemented and tested.
- I labeled this as `BUG` because of the https://github.com/scipy/scipy/labels/defect label in #17281, but it could be an `ENH` too.