### PR TITLE
TST: stats.nct: add test for crash with large nc

### DIFF
--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -5521,6 +5521,10 @@ class TestNct:
         assert_allclose(nct_mean, expected_stats[0], rtol=1e-10)
         assert_allclose(nct_stats, expected_stats, rtol=1e-9)
 
+    def test_cdf_large_nc(self):
+        # gh-17916 reported a crash with large `nc` values
+        assert_allclose(stats.nct.cdf(2, 2, float(2**16)), 0)
+
 
 class TestRecipInvGauss:
 


### PR DESCRIPTION
#### Reference issue
Closes gh-17916

#### What does this implement/fix?
Here's a test of the most recent case reported in gh-17916. Tests for the other cases were merged in gh-17432.

*Update: CI failures seem unrelated.*

#### Additional information
Now we get a crash with `stats.nct.cdf(2, 2, float(2**32))`, but there are plans to fix this and exit more gracefully (https://github.com/scipy/scipy/issues/17916#issuecomment-1440524607). I don't think the issue needs to remain open on the SciPy side; it will be fixed when we update Boost again.
