### PR TITLE
TST: stats.ksone: loosen variance test tolerance

### DIFF
--- a/scipy/stats/tests/common_tests.py
+++ b/scipy/stats/tests/common_tests.py
@@ -62,7 +62,8 @@ def check_mean_expect(distfn, arg, m, msg):
 
 
 def check_var_expect(distfn, arg, m, v, msg):
-    kwargs = {'rtol': 5e-6} if msg == "rv_histogram_instance" else {}
+    dist_looser_tolerances = {"rv_histogram_instance" , "ksone"}
+    kwargs = {'rtol': 5e-6} if msg in dist_looser_tolerances else {}
     if np.isfinite(v):
         m2 = distfn.expect(lambda x: x*x, arg)
         npt.assert_allclose(m2, v + m*m, **kwargs)


### PR DESCRIPTION
#### Reference issue
gh-15384 (closes the stats part of this issue)

#### What does this implement/fix?
gh-15384 reported a failure in the (XSLOW) generic moment test for `ksone`.

```
E   AssertionError:
E   Not equal to tolerance rtol=1e-07, atol=0
E
E   Mismatched elements: 1 / 1 (100%)
E   Max absolute difference: 1.19586248e-10
E   Max relative difference: 2.42347491e-07
E    x: array(0.000493)
E    y: array(0.000493)
```
One version of the variance is calculated using numerical integration based on the PDF (expectation of `x**2`), the other using numerical integration based on the PPF (integral of `ppf**2`). This doesn't seem very concerning. The relative accuracy is still quite close to the default tolerance (which is an arbitrary threshold for this test). Generic implementations like this cannot guarantee machine precision for arbitrary arguments, so I don't see a need to track this test failure. We should make an effort to _benchmark_ the accuracy, but that is a different issue tracked in gh-15928. Also, if there is concern about the special functions involved or `quad`, those could be raised as separate issues, but I think we can close the stats part.

#### Additional information
The test is XSLOW, so it doesn't run in CI anyway, so running CI here wouldn't catch anything but lint issues. (`dev.py lint` didn't catch any locally, and I don't see any.)