### PR TITLE
DOC: Modifying t parameter documentation issue in splprep #17893

### DIFF
--- a/scipy/interpolate/_fitpack_py.py
+++ b/scipy/interpolate/_fitpack_py.py
@@ -63,8 +63,8 @@ def splprep(x, w=None, u=None, ub=None, ue=None, k=3, task=0, s=None, t=None,
         standard-deviation of y, then a good `s` value should be found in
         the range ``(m-sqrt(2*m),m+sqrt(2*m))``, where m is the number of
         data points in x, y, and w.
-    t : int, optional
-        The knots needed for task=-1.
+    t : array, optional
+        An array of knots needed for task=-1. There must be at least 2*k+2 knots if task=-1.
     full_output : int, optional
         If non-zero, then return optional outputs.
     nest : int, optional

--- a/scipy/interpolate/_fitpack_py.py
+++ b/scipy/interpolate/_fitpack_py.py
@@ -64,7 +64,8 @@ def splprep(x, w=None, u=None, ub=None, ue=None, k=3, task=0, s=None, t=None,
         the range ``(m-sqrt(2*m),m+sqrt(2*m))``, where m is the number of
         data points in x, y, and w.
     t : array, optional
-        An array of knots needed for task=-1. There must be at least 2*k+2 knots if task=-1.
+        The knots needed for ``task=-1``.
+        There must be at least ``2*k+2`` knots.
     full_output : int, optional
         If non-zero, then return optional outputs.
     nest : int, optional


### PR DESCRIPTION
Closes #17893

Modifying `t` parameter documentation issue in `scipy.interpolate.splprep`

at the moment `t` parameter is documented as `int` while it takes an `array` of values (Knots):
[https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.splprep.html](url)
<img width="131" alt="image" src="https://user-images.githubusercontent.com/65843206/221926016-696b6fda-5ae2-4abb-aa12-7bb9acfd5681.png">
Additionally, I added the least number of knots required if task=-1 to the document.
below is the summary of changes:
<img width="447" alt="image" src="https://user-images.githubusercontent.com/65843206/221926215-79d3a959-7e30-43eb-8bbe-1ac8acd42b4f.png">

