### PR TITLE
MAINT: avoid non-recommended numpy functions and constants

### DIFF
--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -1557,7 +1557,7 @@ def fmin_cg(f, x0, fprime=None, args=(), gtol=1e-5, norm=Inf, epsilon=_epsilon,
         Stop when the norm of the gradient is less than `gtol`.
     norm : float, optional
         Order to use for the norm of the gradient
-        (``-np.Inf`` is min, ``np.Inf`` is max).
+        (``-np.inf`` is min, ``np.inf`` is max).
     epsilon : float or ndarray, optional
         Step size(s) to use when `fprime` is approximated numerically. Can be a
         scalar or a 1-D array. Defaults to ``sqrt(eps)``, with eps the

--- a/scipy/optimize/_trustregion_exact.py
+++ b/scipy/optimize/_trustregion_exact.py
@@ -242,7 +242,7 @@ class IterativeSubproblem(BaseQuadraticSubproblem):
         self.dimension = len(self.hess)
         self.hess_gershgorin_lb,\
             self.hess_gershgorin_ub = gershgorin_bounds(self.hess)
-        self.hess_inf = norm(self.hess, np.Inf)
+        self.hess_inf = norm(self.hess, np.inf)
         self.hess_fro = norm(self.hess, 'fro')
 
         # A constant such that for vectors smaler than that

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -4505,7 +4505,7 @@ def _arc_jac_sn(w, m):
         if niter > _ARC_JAC_SN_MAXITER:
             raise ValueError('Landen transformation not converging')
 
-    K = np.product(1 + np.array(ks[1:])) * np.pi/2
+    K = np.prod(1 + np.array(ks[1:])) * np.pi/2
 
     wns = [w]
 

--- a/scipy/special/tests/test_hypergeometric.py
+++ b/scipy/special/tests/test_hypergeometric.py
@@ -35,7 +35,7 @@ class TestHyp1f1:
         assert np.isnan(sc.hyp1f1(a, b, x))
 
     def test_poles(self):
-        assert_equal(sc.hyp1f1(1, [0, -1, -2, -3, -4], 0.5), np.infty)
+        assert_equal(sc.hyp1f1(1, [0, -1, -2, -3, -4], 0.5), np.inf)
 
     @pytest.mark.parametrize('a, b, x, result', [
         (-1, 1, 0.5, 0.5),

--- a/scipy/stats/_levy_stable/__init__.py
+++ b/scipy/stats/_levy_stable/__init__.py
@@ -1116,8 +1116,8 @@ class levy_stable_gen(rv_continuous):
     def _stats(self, alpha, beta):
         mu = 0 if alpha > 1 else np.nan
         mu2 = 2 if alpha == 2 else np.inf
-        g1 = 0.0 if alpha == 2.0 else np.NaN
-        g2 = 0.0 if alpha == 2.0 else np.NaN
+        g1 = 0.0 if alpha == 2.0 else np.nan
+        g2 = 0.0 if alpha == 2.0 else np.nan
         return mu, mu2, g1, g2
 
 

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -3272,11 +3272,11 @@ class multinomial_gen(multi_rv_generic):
         # replace values for which x was out of the domain; broadcast
         # xcond to the right shape
         xcond_ = xcond | np.zeros(npcond.shape, dtype=np.bool_)
-        result = self._checkresult(result, xcond_, np.NINF)
+        result = self._checkresult(result, xcond_, -np.inf)
 
         # replace values bad for n or p; broadcast npcond to the right shape
         npcond_ = npcond | np.zeros(xcond.shape, dtype=np.bool_)
-        return self._checkresult(result, npcond_, np.NAN)
+        return self._checkresult(result, npcond_, np.nan)
 
     def pmf(self, x, n, p):
         """Multinomial probability mass function.
@@ -3312,7 +3312,7 @@ class multinomial_gen(multi_rv_generic):
         """
         n, p, npcond = self._process_parameters(n, p)
         result = n[..., np.newaxis]*p
-        return self._checkresult(result, npcond, np.NAN)
+        return self._checkresult(result, npcond, np.nan)
 
     def cov(self, n, p):
         """Covariance matrix of the multinomial distribution.
@@ -5005,7 +5005,7 @@ class multivariate_hypergeom_gen(multi_rv_generic):
         # replace values for which x was out of the domain; broadcast
         # xcond to the right shape
         xcond_ = xcond_reduced | np.zeros(mncond.shape, dtype=np.bool_)
-        result = self._checkresult(result, xcond_, np.NINF)
+        result = self._checkresult(result, xcond_, -np.inf)
 
         # replace values bad for n or m; broadcast
         # mncond to the right shape

--- a/scipy/stats/_resampling.py
+++ b/scipy/stats/_resampling.py
@@ -1300,7 +1300,7 @@ def permutation_test(data, statistic, *, permutation_type='independent',
     case, if ``n`` is an array of the number of observations within each
     sample, the number of distinct partitions is::
 
-        np.product([binom(sum(n[i:]), sum(n[i+1:])) for i in range(len(n)-1)])
+        np.prod([binom(sum(n[i:]), sum(n[i+1:])) for i in range(len(n)-1)])
 
     **Paired statistics, permute pairings** (``permutation_type='pairings'``):
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -4708,7 +4708,7 @@ class TestLevyStable:
     @pytest.mark.parametrize(
         "params,expected",
         [
-            [(1.48, -.22, 0, 1), (0, np.inf, np.NaN, np.NaN)],
+            [(1.48, -.22, 0, 1), (0, np.inf, np.nan, np.nan)],
             [(2, .9, 10, 1.5), (10, 4.5, 0, 0)]
         ]
     )

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -2574,7 +2574,7 @@ class TestMultivariateHypergeom:
             # test for `n < 0`
             ([3, 4], [5, 10], -7, np.nan),
             # test for `x.sum() != n`
-            ([3, 3], [5, 10], 7, inp.inf)
+            ([3, 3], [5, 10], 7, -np.inf)
         ]
     )
     def test_logpmf(self, x, m, n, expected):

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -1422,7 +1422,7 @@ class TestMultinomial:
         assert vals3 == 0
 
         vals4 = multinomial.logpmf([3, 4], 0, [-2, 3])
-        assert_allclose(vals4, np.NAN, rtol=1e-8)
+        assert_allclose(vals4, np.nan, rtol=1e-8)
 
     def test_reduces_binomial(self):
         # test that the multinomial pmf reduces to the binomial pmf in the 2d
@@ -2557,9 +2557,9 @@ class TestMultivariateHypergeom:
             # Ground truth value from R dmvhyper
             ([3, 4], [5, 10], 7, -1.119814),
             # test for `n=0`
-            ([3, 4], [5, 10], 0, np.NINF),
+            ([3, 4], [5, 10], 0, -np.inf),
             # test for `x < 0`
-            ([-3, 4], [5, 10], 7, np.NINF),
+            ([-3, 4], [5, 10], 7, -np.inf),
             # test for `m < 0` (RuntimeWarning issue)
             ([3, 4], [-5, 10], 7, np.nan),
             # test for all `m < 0` and `x.sum() != n`
@@ -2574,7 +2574,7 @@ class TestMultivariateHypergeom:
             # test for `n < 0`
             ([3, 4], [5, 10], -7, np.nan),
             # test for `x.sum() != n`
-            ([3, 3], [5, 10], 7, np.NINF)
+            ([3, 3], [5, 10], 7, inp.inf)
         ]
     )
     def test_logpmf(self, x, m, n, expected):

--- a/scipy/stats/tests/test_resampling.py
+++ b/scipy/stats/tests/test_resampling.py
@@ -1609,8 +1609,8 @@ def test_all_partitions_concatenated():
         partitioning = np.split(partition_concatenated, nc[:-1])
         all_partitions.add(tuple([frozenset(i) for i in partitioning]))
 
-    expected = np.product([special.binom(sum(n[i:]), sum(n[i+1:]))
-                           for i in range(len(n)-1)])
+    expected = np.prod([special.binom(sum(n[i:]), sum(n[i+1:]))
+                        for i in range(len(n)-1)])
 
     assert_equal(counter, expected)
     assert_equal(len(all_partitions), expected)


### PR DESCRIPTION
These have better alternatives or may be deprecated.

[skip cirrus] [skip azp]