### PR TITLE
ENH: allow single observation for equal variance in `stats.ttest_ind`

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -6969,7 +6969,7 @@ def _equal_var_ttest_denom(v1, n1, v2, n2):
     v2 = 0 if n2 == 1 else v2
 
     df = n1 + n2 - 2.0
-    svar = ((n1 - 1) * v1 + (n2 - 1) * v2) / df
+    svar = np.divide((n1 - 1) * v1 + (n2 - 1) * v2, df)
     denom = np.sqrt(svar * (1.0 / n1 + 1.0 / n2))
     return df, denom
 
@@ -7427,6 +7427,10 @@ def ttest_ind(a, b, axis=0, equal_var=True, nan_policy='propagate',
         n1 = a.shape[axis]
         n2 = b.shape[axis]
 
+        if equal_var:
+            old_errstate = np.geterr()
+            np.seterr(divide='ignore', invalid='ignore')
+
         if trim == 0:
             v1 = _var(a, axis, ddof=1)
             v2 = _var(b, axis, ddof=1)
@@ -7441,6 +7445,10 @@ def ttest_ind(a, b, axis=0, equal_var=True, nan_policy='propagate',
         else:
             df, denom = _unequal_var_ttest_denom(v1, n1, v2, n2)
         res = _ttest_ind_from_stats(m1, m2, denom, df, alternative)
+
+        if equal_var:
+            np.seterr(**old_errstate)
+
     return Ttest_indResult(*res)
 
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -1156,8 +1156,7 @@ def _var(x, axis=0, ddof=0, mean=None):
     var = _moment(x, 2, axis, mean=mean)
     if ddof != 0:
         n = x.shape[axis] if axis is not None else x.size
-        with np.errstate(divide='ignore', invalid='ignore'):
-            var *= np.divide(n, n-ddof)  # to avoid error on division by zero
+        var *= np.divide(n, n-ddof)  # to avoid error on division by zero
     return var
 
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -1155,7 +1155,8 @@ def _var(x, axis=0, ddof=0, mean=None):
     var = _moment(x, 2, axis, mean=mean)
     if ddof != 0:
         n = x.shape[axis] if axis is not None else x.size
-        var *= np.divide(n, n-ddof)  # to avoid error on division by zero
+        with np.errstate(divide='ignore', invalid='ignore'):
+            var *= np.divide(n, n-ddof)  # to avoid error on division by zero
     return var
 
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -6963,6 +6963,10 @@ def _unequal_var_ttest_denom(v1, n1, v2, n2):
 
 
 def _equal_var_ttest_denom(v1, n1, v2, n2):
+    # null variance in case there is a single observation
+    v1 = 0 if n1 == 1 else v1
+    v2 = 0 if n2 == 1 else v2
+
     df = n1 + n2 - 2.0
     svar = ((n1 - 1) * v1 + (n2 - 1) * v2) / df
     denom = np.sqrt(svar * (1.0 / n1 + 1.0 / n2))

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -6964,12 +6964,16 @@ def _unequal_var_ttest_denom(v1, n1, v2, n2):
 
 
 def _equal_var_ttest_denom(v1, n1, v2, n2):
-    # null variance in case there is a single observation
-    v1 = 0 if n1 == 1 else v1
-    v2 = 0 if n2 == 1 else v2
+    # If there is a single observation in one sample, this formula for pooled
+    # variance breaks down because the variance of that sample is undefined.
+    # The pooled variance is still defined, though, because the (n-1) in the
+    # numerator should cancel with the (n-1) in the denominator, leaving only
+    # the sum of squared differences from the mean: zero.
+    v1 = np.where(n1 == 1, 0, v1)[()]
+    v2 = np.where(n2 == 1, 0, v2)[()]
 
     df = n1 + n2 - 2.0
-    svar = np.divide((n1 - 1) * v1 + (n2 - 1) * v2, df)
+    svar = ((n1 - 1) * v1 + (n2 - 1) * v2) / df
     denom = np.sqrt(svar * (1.0 / n1 + 1.0 / n2))
     return df, denom
 
@@ -7427,13 +7431,14 @@ def ttest_ind(a, b, axis=0, equal_var=True, nan_policy='propagate',
         n1 = a.shape[axis]
         n2 = b.shape[axis]
 
-        if equal_var:
-            old_errstate = np.geterr()
-            np.seterr(divide='ignore', invalid='ignore')
-
         if trim == 0:
+            if equal_var:
+                old_errstate = np.geterr()
+                np.seterr(divide='ignore', invalid='ignore')
             v1 = _var(a, axis, ddof=1)
             v2 = _var(b, axis, ddof=1)
+            if equal_var:
+                np.seterr(**old_errstate)
             m1 = np.mean(a, axis)
             m2 = np.mean(b, axis)
         else:
@@ -7445,9 +7450,6 @@ def ttest_ind(a, b, axis=0, equal_var=True, nan_policy='propagate',
         else:
             df, denom = _unequal_var_ttest_denom(v1, n1, v2, n2)
         res = _ttest_ind_from_stats(m1, m2, denom, df, alternative)
-
-        if equal_var:
-            np.seterr(**old_errstate)
 
     return Ttest_indResult(*res)
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -1131,7 +1131,8 @@ def _moment(a, moment, axis, *, mean=None):
                               keepdims=True) / np.abs(mean)
         with np.errstate(invalid='ignore'):
             precision_loss = np.any(rel_diff < eps)
-        if precision_loss:
+        n = a.shape[axis] if axis is not None else a.size
+        if precision_loss and n > 1:
             message = ("Precision loss occurred in moment calculation due to "
                        "catastrophic cancellation. This occurs when the data "
                        "are nearly identical. Results may be unreliable.")

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3199,8 +3199,8 @@ class TestStudentTest:
     P1_1_g = 1 - (P1_1 / 2)
 
     def test_onesample(self):
-        with suppress_warnings() as sup, np.errstate(invalid="ignore"), \
-                pytest.warns(RuntimeWarning, match="Precision loss occurred"):
+        with suppress_warnings() as sup, \
+                np.errstate(invalid="ignore", divide="ignore"):
             sup.filter(RuntimeWarning, "Degrees of freedom <= 0 for slice")
             t, p = stats.ttest_1samp(4., 3.)
         assert_(np.isnan(t))
@@ -4228,8 +4228,8 @@ def test_ttest_rel():
     assert_array_almost_equal([t,p],tpr)
 
     # test scalars
-    with suppress_warnings() as sup, np.errstate(invalid="ignore"), \
-            pytest.warns(RuntimeWarning, match="Precision loss occurred"):
+    with suppress_warnings() as sup, \
+            np.errstate(invalid="ignore", divide="ignore"):
         sup.filter(RuntimeWarning, "Degrees of freedom <= 0 for slice")
         t, p = stats.ttest_rel(4., 3.)
     assert_(np.isnan(t))
@@ -4455,8 +4455,7 @@ def test_ttest_ind():
                               [t, p])
 
     # test scalars
-    with suppress_warnings() as sup, np.errstate(invalid="ignore"), \
-            pytest.warns(RuntimeWarning, match="Precision loss occurred"):
+    with suppress_warnings() as sup, np.errstate(invalid="ignore"):
         sup.filter(RuntimeWarning, "Degrees of freedom <= 0 for slice")
         t, p = stats.ttest_ind(4., 3.)
     assert_(np.isnan(t))
@@ -5333,7 +5332,8 @@ def test_ttest_1samp_popmean_array():
 
 class TestDescribe:
     def test_describe_scalar(self):
-        with suppress_warnings() as sup, np.errstate(invalid="ignore"):
+        with suppress_warnings() as sup, \
+              np.errstate(invalid="ignore", divide="ignore"):
             sup.filter(RuntimeWarning, "Degrees of freedom <= 0 for slice")
             n, mm, m, v, sk, kurt = stats.describe(4.)
         assert_equal(n, 1)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -5221,6 +5221,23 @@ def test_ttest_ind_from_stats_inputs_zero():
     assert_equal(result, [np.nan, np.nan])
 
 
+def test_ttest_single_observation():
+    rng = np.random.default_rng(246834602926842)
+    x = rng.normal(size=(10000, 2))
+    y = rng.normal(size=(10000, 1))
+    res = stats.ttest_ind(x, y, equal_var=True, axis=-1)
+
+    assert_allclose(np.percentile(res.pvalue, 25), 0.25, atol=1e-2)
+    assert_allclose(np.percentile(res.pvalue, 50), 0.5, atol=1e-2)
+    assert_allclose(np.percentile(res.pvalue, 75), 0.75, atol=1e-2)
+
+    res = stats.ttest_ind(y, x, equal_var=True, axis=-1)
+
+    assert_allclose(np.percentile(res.pvalue, 25), 0.25, atol=1e-2)
+    assert_allclose(np.percentile(res.pvalue, 50), 0.5, atol=1e-2)
+    assert_allclose(np.percentile(res.pvalue, 75), 0.75, atol=1e-2)
+
+
 def test_ttest_1samp_new():
     n1, n2, n3 = (10,15,20)
     rvn1 = stats.norm.rvs(loc=5,scale=10,size=(n1,n2,n3))

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -5219,20 +5219,25 @@ def test_ttest_ind_from_stats_inputs_zero():
 
 
 def test_ttest_single_observation():
+    # test that p-values are uniformly distributed under the null hypothesis
     rng = np.random.default_rng(246834602926842)
     x = rng.normal(size=(10000, 2))
     y = rng.normal(size=(10000, 1))
-    res = stats.ttest_ind(x, y, equal_var=True, axis=-1)
+    q = rng.uniform(size=100)
 
-    assert_allclose(np.percentile(res.pvalue, 25), 0.25, atol=1e-2)
-    assert_allclose(np.percentile(res.pvalue, 50), 0.5, atol=1e-2)
-    assert_allclose(np.percentile(res.pvalue, 75), 0.75, atol=1e-2)
+    res = stats.ttest_ind(x, y, equal_var=True, axis=-1)
+    assert stats.ks_1samp(res.pvalue, stats.uniform().cdf).pvalue > 0.1
+    assert_allclose(np.percentile(res.pvalue, q*100), q, atol=1e-2)
 
     res = stats.ttest_ind(y, x, equal_var=True, axis=-1)
+    assert stats.ks_1samp(res.pvalue, stats.uniform().cdf).pvalue > 0.1
+    assert_allclose(np.percentile(res.pvalue, q*100), q, atol=1e-2)
 
-    assert_allclose(np.percentile(res.pvalue, 25), 0.25, atol=1e-2)
-    assert_allclose(np.percentile(res.pvalue, 50), 0.5, atol=1e-2)
-    assert_allclose(np.percentile(res.pvalue, 75), 0.75, atol=1e-2)
+    # reference values from R:
+    # options(digits=16)
+    # t.test(c(2, 3, 5), c(1.5), var.equal=TRUE)
+    res = stats.ttest_ind([2, 3, 5], [1.5], equal_var=True)
+    assert_allclose(res, (1.0394023007754, 0.407779907736), rtol=1e-10)
 
 
 def test_ttest_1samp_new():

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3064,9 +3064,8 @@ class TestMoments:
 
     def test_skewness(self):
         # Scalar test case
-        with pytest.warns(RuntimeWarning, match="Precision loss occurred"):
-            y = stats.skew(self.scalar_testcase)
-            assert np.isnan(y)
+        y = stats.skew(self.scalar_testcase)
+        assert np.isnan(y)
         # sum((testmathworks-mean(testmathworks,axis=0))**3,axis=0) /
         #     ((sqrt(var(testmathworks)*4/5))**3)/5
         y = stats.skew(self.testmathworks)
@@ -3113,9 +3112,8 @@ class TestMoments:
 
     def test_kurtosis(self):
         # Scalar test case
-        with pytest.warns(RuntimeWarning, match="Precision loss occurred"):
-            y = stats.kurtosis(self.scalar_testcase)
-            assert np.isnan(y)
+        y = stats.kurtosis(self.scalar_testcase)
+        assert np.isnan(y)
         #   sum((testcase-mean(testcase,axis=0))**4,axis=0)/((sqrt(var(testcase)*3/4))**4)/4
         #   sum((test2-mean(testmathworks,axis=0))**4,axis=0)/((sqrt(var(testmathworks)*4/5))**4)/5
         #   Set flags for axis = 0 and
@@ -5335,8 +5333,7 @@ def test_ttest_1samp_popmean_array():
 
 class TestDescribe:
     def test_describe_scalar(self):
-        with suppress_warnings() as sup, np.errstate(invalid="ignore"), \
-             pytest.warns(RuntimeWarning, match="Precision loss occurred"):
+        with suppress_warnings() as sup, np.errstate(invalid="ignore"):
             sup.filter(RuntimeWarning, "Degrees of freedom <= 0 for slice")
             n, mm, m, v, sk, kurt = stats.describe(4.)
         assert_equal(n, 1)
@@ -5433,10 +5430,9 @@ class TestDescribe:
 
 
 def test_normalitytests():
-    with pytest.warns(RuntimeWarning, match="Precision loss occurred"):
-        assert_raises(ValueError, stats.skewtest, 4.)
-        assert_raises(ValueError, stats.kurtosistest, 4.)
-        assert_raises(ValueError, stats.normaltest, 4.)
+    assert_raises(ValueError, stats.skewtest, 4.)
+    assert_raises(ValueError, stats.kurtosistest, 4.)
+    assert_raises(ValueError, stats.normaltest, 4.)
 
     # numbers verified with R: dagoTest in package fBasics
     st_normal, st_skew, st_kurt = (3.92371918, 1.98078826, -0.01403734)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes #18069

#### What does this implement/fix?

Single observation in `ttest_ind` are currently not possible due to a cancellation. This allows it by setting a null variance when only a single observation is available.


Adding warning filtering is causing some issues. Hence skipping the CI for now:

```python
FAILED scipy/stats/tests/test_stats.py::TestMoments::test_skewness - Failed: DID NOT WARN. No warnings of type (<class 'RuntimeWarning'>,) were emitted. The list of emitted warnings is: [].
FAILED scipy/stats/tests/test_stats.py::TestMoments::test_kurtosis - Failed: DID NOT WARN. No warnings of type (<class 'RuntimeWarning'>,) were emitted. The list of emitted warnings is: [].
FAILED scipy/stats/tests/test_stats.py::TestStudentTest::test_onesample - Failed: DID NOT WARN. No warnings of type (<class 'RuntimeWarning'>,) were emitted. The list of emitted warnings is: [].
FAILED scipy/stats/tests/test_stats.py::test_ttest_rel - Failed: DID NOT WARN. No warnings of type (<class 'RuntimeWarning'>,) were emitted. The list of emitted warnings is: [].
FAILED scipy/stats/tests/test_stats.py::test_ttest_ind - ZeroDivisionError: float division by zero
FAILED scipy/stats/tests/test_stats.py::test_gh5686 - ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
FAILED scipy/stats/tests/test_stats.py::TestDescribe::test_describe_scalar - Failed: DID NOT WARN. No warnings of type (<class 'RuntimeWarning'>,) were emitted. The list of emitted warnings is: [].
FAILED scipy/stats/tests/test_stats.py::test_normalitytests - Failed: DID NOT WARN. No warnings of type (<class 'RuntimeWarning'>,) were emitted. The list of emitted warnings is: [].
```

