### PR TITLE
ENH: stats.ecdf: support right-censored data

### DIFF
--- a/scipy/stats/_survival.py
+++ b/scipy/stats/_survival.py
@@ -17,8 +17,8 @@ def ecdf(sample):
 
     Parameters
     ----------
-    sample : 1D array_like or `stats.CensoredData`
-        Besides array_like, instances of `stats.CensoredData` containing
+    sample : 1D array_like or `scipy.stats.CensoredData`
+        Besides array_like, instances of `scipy.stats.CensoredData` containing
         uncensored and right-censored observations are supported. Currently,
         other instances of `stats.CensoredData` will result in a
         ``NotImplementedError``.
@@ -41,7 +41,7 @@ def ecdf(sample):
 
     When observations are lower bounds, upper bounds, or both upper and lower
     bounds, the data is said to be "censored", and `sample` may be provided as
-    an instance of `stats.CensoredData`.
+    an instance of `scipy.stats.CensoredData`.
 
     For right-censored data, the ECDF is given by the Kaplan-Meier estimator
     [2]_; other forms of censoring are not supported at this time.
@@ -93,15 +93,24 @@ def ecdf(sample):
     **Right-censored Data**
 
     As in the example from [1]_ page 91, the lives of ten car fanbelts were
-    tested. At the end of the test, five fanbelts had broken, but five were
-    still unbroken. Their survival times were recorded as follows.
+    tested. Five tests concluded because the fanbelt being tested broke, but
+    the remaining tests concluded for other reasons (e.g. the study ran out of
+    funding, but the fanbelt was still functional). The mileage driven
+    with the fanbelts were recorded as follows.
 
-    >>> broken = [77, 47, 81, 56, 80]  # in thousands of miles
+    >>> broken = [77, 47, 81, 56, 80]  # in thousands of miles driven
     >>> unbroken = [62, 60, 43, 71, 37]
+
+    Precise survival times of the fanbelts that were still functional at the
+    end of the tests are unknown, but they are known to exceed the values
+    recorded in ``unbroken``. Therefore, these observations are said to be
+    "right-censored", and the data is represented using
+    `scipy.stats.CensoredData`.
+
+    >>> sample = stats.CensoredData(uncensored=broken, right=unbroken)
 
     The empirical survival function is calculated as follows.
 
-    >>> sample = stats.CensoredData(uncensored=broken, right=unbroken)
     >>> res = stats.ecdf(sample)
     >>> res.x
     array([37., 43., 47., 56., 60., 62., 71., 77., 80., 81.])

--- a/scipy/stats/_survival.py
+++ b/scipy/stats/_survival.py
@@ -138,8 +138,9 @@ def ecdf(sample):
     elif sample.num_censored() == sample._right.size:
         res = _ecdf_right_censored(sample)
     else:
-        # Support censoring in follow-up PRs
-        message = ("Currently, only uncensored data is supported.")
+        # Support additional censoring options in follow-up PRs
+        message = ("Currently, only uncensored and right-censored data is "
+                   "supported.")
         raise NotImplementedError(message)
     return res
 

--- a/scipy/stats/_survival.py
+++ b/scipy/stats/_survival.py
@@ -19,10 +19,9 @@ def ecdf(sample):
     ----------
     sample : 1D array_like or `stats.CensoredData`
         Besides array_like, instances of `stats.CensoredData` containing
-        uncensored observations are supported. Currently, instances of
-        `stats.CensoredData` with censored data will result in a
-        ``NotImplementedError``, but future support for left-censored,
-        right-centered, and interval-censored data is planned.
+        uncensored and right-censored observations are supported. Currently,
+        other instances of `stats.CensoredData` will result in a
+        ``NotImplementedError``.
 
     Returns
     -------
@@ -38,14 +37,14 @@ def ecdf(sample):
     Notes
     -----
     When each observation of the sample is a precise measurement, the ECDF
-    steps up by ``1/len(sample)`` at each of the observations.
+    steps up by ``1/len(sample)`` at each of the observations [1]_.
 
     When observations are lower bounds, upper bounds, or both upper and lower
     bounds, the data is said to be "censored", and `sample` may be provided as
     an instance of `stats.CensoredData`.
 
     For right-censored data, the ECDF is given by the Kaplan-Meier estimator
-    [1]_; other forms of censoring are not supported at this time.
+    [2]_; other forms of censoring are not supported at this time.
 
     References
     ----------
@@ -56,8 +55,14 @@ def ecdf(sample):
            incomplete observations." Journal of the American statistical
            association 53.282 (1958): 457-481.
 
+    .. [3] Goel, Manish Kumar, Pardeep Khanna, and Jugal Kishore.
+           "Understanding survival analysis: Kaplan-Meier estimate."
+           International journal of Ayurveda research 1.4 (2010): 274.
+
     Examples
     --------
+    **Uncensored Data**
+
     As in the example from [1]_ page 79, five boys were selected at random from
     those in a single high school. Their one-mile run times were recorded as
     follows.
@@ -85,6 +90,32 @@ def ecdf(sample):
     >>> ax.set_ylabel('Empirical CDF')
     >>> plt.show()
 
+    **Right-censored Data**
+
+    As in the example from [1]_ page 91, the lives of ten car fanbelts were
+    tested. At the end of the test, five fanbelts had broken, but five were
+    still unbroken. Their survival times were recorded as follows.
+
+    >>> broken = [77, 47, 81, 56, 80]  # in thousands of miles
+    >>> unbroken = [62, 60, 43, 71, 37]
+
+    The empirical survival function is calculated as follows.
+
+    >>> sample = stats.CensoredData(uncensored=broken, right=unbroken)
+    >>> res = stats.ecdf(sample)
+    >>> res.x
+    array([37., 43., 47., 56., 60., 62., 71., 77., 80., 81.])
+    >>> res.sf
+    array([1.   , 1.   , 0.875, 0.75 , 0.75 , 0.75 , 0.75 , 0.5  , 0.25 , 0.   ])
+
+    To plot the result as a step function:
+
+    >>> ax = plt.subplot()
+    >>> ax.step(np.insert(res.x, 0, 30), np.insert(res.sf, 0, 1), where='post')
+    >>> ax.set_xlabel('Fanbelt Survival Time (thousands of miles)')
+    >>> ax.set_ylabel('Empirical SF')
+    >>> plt.show()
+
     """
     if not isinstance(sample, CensoredData):
         try:  # takes care of input standardization/validation
@@ -95,6 +126,8 @@ def ecdf(sample):
 
     if sample.num_censored() == 0:
         res = _ecdf_uncensored(sample._uncensor())
+    elif sample.num_censored() == sample._right.size:
+        res = _ecdf_right_censored(sample)
     else:
         # Support censoring in follow-up PRs
         message = ("Currently, only uncensored data is supported.")
@@ -113,3 +146,43 @@ def _ecdf_uncensored(sample):
     sf = 1 - cdf
 
     return ECDFResult(x, cdf, sf)
+
+
+def _ecdf_right_censored(sample):
+    # It is conventional to discuss right-censored data in terms of
+    # "survival time", "death", and "loss" (e.g. [2]). We'll use that
+    # terminology here.
+    # This implementation was influenced by the references cited and also
+    # https://www.youtube.com/watch?v=lxoWsVco_iM
+    # https://en.wikipedia.org/wiki/Kaplan%E2%80%93Meier_estimator
+    # In retrospect it is probably most easily compared against [3].
+    # Ultimately, the data needs to be sorted, so this implementation is
+    # written to avoid a separate call to `unique` after sorting. In hope of
+    # better performance on large datasets, it also computes survival
+    # probabilities at unique times only rather than at each observation.
+    tod = sample._uncensored  # time of "death"
+    tol = sample._right  # time of "loss"
+    times = np.concatenate((tod, tol))
+    died = np.asarray([1]*tod.size + [0]*tol.size)
+
+    # sort by times
+    i = np.argsort(times)
+    times = times[i]
+    died = died[i]
+    at_risk = np.arange(times.size, 0, -1)
+
+    # logical indices of unique times
+    j = np.diff(times, prepend=-np.inf, append=np.inf) > 0
+    j_l = j[:-1]  # first instances of unique times
+    j_r = j[1:]  # last instances of unique times
+
+    # get number at risk and deaths at each unique time
+    t = times[j_l]  # unique times
+    n = at_risk[j_l]  # number at risk at each unique time
+    cd = np.cumsum(died)[j_r]  # cumulative deaths up to/including unique times
+    d = np.diff(cd, prepend=0)  # deaths at each unique time
+
+    # compute survival function
+    sf = np.cumprod((n - d) / n)
+    cdf = 1 - sf
+    return ECDFResult(t, cdf, sf)

--- a/scipy/stats/tests/test_survival.py
+++ b/scipy/stats/tests/test_survival.py
@@ -84,7 +84,7 @@ class TestSurvival:
 
     # ref. [1] page 91
     t1 = [37, 43, 47, 56, 60, 62, 71, 77, 80, 81]  # times
-    d1 = [0, 0, 1, 1, 0, 0, 0, 1, 1, 1]  # deaths (not censored)
+    d1 = [0, 0, 1, 1, 0, 0, 0, 1, 1, 1]  # 1 means deaths (not censored)
     r1 = [1, 1, 0.875, 0.75, 0.75, 0.75, 0.75, 0.5, 0.25, 0]  # reference SF
 
     # https://sphweb.bumc.bu.edu/otlt/mph-modules/bs/bs704_survival/BS704_Survival5.html  # noqa
@@ -115,6 +115,11 @@ class TestSurvival:
         res = stats.ecdf(sample)
         assert_allclose(res.sf, ref, atol=1e-3)
         assert_equal(res.x, np.sort(np.unique(times)))
+
+        # test reference implementation
+        res = _kaplan_meier_reference(times, np.logical_not(died))
+        assert_equal(res[0], np.sort(np.unique(times)))
+        assert_allclose(res[1], ref, atol=1e-3)
 
     @pytest.mark.parametrize('seed', [182746786639392128, 737379171436494115,
                                       576033618403180168, 308115465002673650])

--- a/scipy/stats/tests/test_survival.py
+++ b/scipy/stats/tests/test_survival.py
@@ -141,12 +141,3 @@ class TestSurvival:
         assert_equal(res.x, ref.x)
         assert_allclose(res.cdf, ref.cdf, rtol=1e-14)
         assert_allclose(res.sf, ref.sf, rtol=1e-14)
-
-
-# This is for debugging a CI issue; remove before merge
-def test_repeat():
-    unique = np.asarray([1, 2, 3, 4]).astype(np.float64)
-    repeats = np.asarray([1, 2, 3, 4]).astype(np.int64)
-    repeated = np.repeat(unique, repeats)
-    reference = np.concatenate([[i]*j for i, j in zip(unique, repeats)])
-    assert_allclose(repeated, reference)

--- a/scipy/stats/tests/test_survival.py
+++ b/scipy/stats/tests/test_survival.py
@@ -47,7 +47,7 @@ class TestSurvival:
         with pytest.raises(ValueError, match=message):
             stats.ecdf([np.nan])
 
-        message = 'Currently, only uncensored data is supported.'
+        message = 'Currently, only uncensored and right-censored data...'
         with pytest.raises(NotImplementedError, match=message):
             stats.ecdf(stats.CensoredData.left_censored([1], censored=[True]))
 

--- a/scipy/stats/tests/test_survival.py
+++ b/scipy/stats/tests/test_survival.py
@@ -1,7 +1,38 @@
 import pytest
 import numpy as np
-from numpy.testing import assert_equal
+from numpy.testing import assert_equal, assert_allclose
 from scipy import stats
+
+
+def _kaplan_meier_reference(times, censored):
+    # This is a very straightforward implementation of the Kaplan-Meier
+    # estimator that does almost everything differently from the implementation
+    # in stats.ecdf.
+
+    # Begin by sorting the raw data. Note that the order of death and loss
+    # at a given time matters: death happens first. See [2] page 461:
+    # "These conventions may be paraphrased by saying that deaths recorded as
+    # of an age t are treated as if they occurred slightly before t, and losses
+    # recorded as of an age t are treated as occurring slightly after t."
+    # We implement this by sorting the data first by time, then by `censored`,
+    # (which is 0 when there is a death and 1 when there is only a loss).
+    dtype = [('time', float), ('censored', int)]
+    data = np.array([(t, d) for t, d in zip(times, censored)], dtype=dtype)
+    data = np.sort(data, order=('time', 'censored'))
+    times = data['time']
+    died = np.logical_not(data['censored'])
+
+    m = times.size
+    n = np.arange(m, 0, -1)  # number at risk
+    sf = np.cumprod((n - died) / n)
+
+    # Find the indices of the *last* occurrence of unique times. The
+    # corresponding entries of `times` and `sf` are what we want.
+    _, indices = np.unique(times[::-1], return_index=True)
+    ref_times = times[-indices - 1]
+    ref_sf = sf[-indices - 1]
+    return ref_times, ref_sf
+
 
 class TestSurvival:
     def test_input_validation(self):
@@ -49,3 +80,53 @@ class TestSurvival:
         assert_equal(res.x, ref_x)
         assert_equal(res.cdf, ref_cdf)
         assert_equal(res.sf, ref_sf)
+
+    # ref. [1] page 91
+    t1 = [37, 43, 47, 56, 60, 62, 71, 77, 80, 81]  # times
+    d1 = [0, 0, 1, 1, 0, 0, 0, 1, 1, 1]  # deaths (not censored)
+    r1 = [1, 1, 0.875, 0.75, 0.75, 0.75, 0.75, 0.5, 0.25, 0]  # reference SF
+
+    # https://sphweb.bumc.bu.edu/otlt/mph-modules/bs/bs704_survival/BS704_Survival5.html  # noqa
+    t2 = [8, 12, 26, 14, 21, 27, 8, 32, 20, 40]
+    d2 = [1, 1, 1, 1, 1, 1, 0, 0, 0, 0]
+    r2 = [0.9, 0.788, 0.675, 0.675, 0.54, 0.405, 0.27, 0.27, 0.27]
+    t3 = [33, 28, 41, 48, 48, 25, 37, 48, 25, 43]
+    d3 = [1, 1, 1, 0, 0, 0, 0, 0, 0, 0]
+    r3 = [1, 0.875, 0.75, 0.75, 0.6, 0.6, 0.6]
+
+    # https://sphweb.bumc.bu.edu/otlt/mph-modules/bs/bs704_survival/bs704_survival4.html  # noqa
+    t4 = [24, 3, 11, 19, 24, 13, 14, 2, 18, 17,
+          24, 21, 12, 1, 10, 23, 6, 5, 9, 17]
+    d4 = [0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 1]
+    r4 = [0.95, 0.95, 0.897, 0.844, 0.844, 0.844, 0.844, 0.844, 0.844,
+          0.844, 0.76, 0.676, 0.676, 0.676, 0.676, 0.507, 0.507]
+
+    # https://www.real-statistics.com/survival-analysis/kaplan-meier-procedure/confidence-interval-for-the-survival-function/  # noqa
+    t5 = [3, 5, 8, 10, 5, 5, 8, 12, 15, 14, 2, 11, 10, 9, 12, 5, 8, 11]
+    d5 = [1, 1, 1, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 1, 1]
+    r5 = [0.944, 0.889, 0.722, 0.542, 0.542, 0.542, 0.361, 0.181, 0.181, 0.181]
+
+    @pytest.mark.parametrize("case", [(t1, d1, r1), (t2, d2, r2), (t3, d3, r3),
+                                      (t4, d4, r4), (t5, d5, r5)])
+    def test_right_censored(self, case):
+        times, died, ref = case
+        sample = stats.CensoredData.right_censored(times, np.logical_not(died))
+        res = stats.ecdf(sample)
+        assert_allclose(res.sf, ref, atol=1e-3)
+        assert_equal(res.x, np.sort(np.unique(times)))
+
+    @pytest.mark.parametrize('seed', [182746786639392128, 737379171436494115,
+                                      576033618403180168, 308115465002673650])
+    def test_right_censored_property(self, seed):
+        rng = np.random.default_rng(seed)
+        n_unique = rng.integers(10, 100)
+        unique_times = rng.random(n_unique)
+        repeats = rng.integers(1, 4, n_unique)
+        times = rng.permuted(np.repeat(unique_times, repeats))
+        censored = rng.random(size=times.size) > rng.random()
+
+        sample = stats.CensoredData.right_censored(times, censored)
+        res = stats.ecdf(sample)
+        ref = _kaplan_meier_reference(times, censored)
+        assert_allclose(res.x, ref[0])
+        assert_allclose(res.sf, ref[1])


### PR DESCRIPTION
#### Reference issue
Follow-up to gh-18035

#### What does this implement/fix?
Adds support for right-censored data to `scipy.stats.ecdf` using the Kaplan-Meier estimate. Begins to address "Add tools for survival analysis" from roadmap.

#### Additional information
Next up: confidence intervals, maybe support other types of censoring. Again, we can always add convenience features like plotting and turning the data into an object with cdf/sf/ppf/isf/rvs methods. I'm starting with the technical stuff and working incrementally.
