### PR TITLE
MAINT: stats.johnsonsu: override _stats

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -5085,6 +5085,35 @@ class johnsonsu_gen(rv_continuous):
     def _ppf(self, q, a, b):
         return np.sinh((_norm_ppf(q) - a) / b)
 
+    def _stats(self, a, b, moments='mv'):
+        # Naive implementation of first and second moment to address gh-18071.
+        # https://variation.com/wp-content/distribution_analyzer_help/hs126.htm
+        # Numerical improvements left to future enhancements.
+        mu, mu2, g1, g2 = None, None, None, None
+
+        bn2 = b**-2
+        expbn2 = np.exp(bn2)
+        a_b = a / b
+
+        if 'm' in moments:
+            mu = -expbn2**0.5 * np.sinh(a_b)
+        if 'v' in moments:
+            mu2 = 0.5*sc.expm1(bn2)*(expbn2*np.cosh(2*a_b) + 1)
+        if 's' in moments:
+            t1 = expbn2**.5 * sc.expm1(bn2)**0.5
+            t2 = 3*np.sinh(a_b)
+            t3 = expbn2 * (expbn2 + 2) * np.sinh(3*a_b)
+            denom = np.sqrt(2) * (1 + expbn2 * np.cosh(2*a_b))**(3/2)
+            g1 = -t1 * (t2 + t3) / denom
+        if 'k' in moments:
+            t1 = 3 + 6*expbn2
+            t2 = 4*expbn2**2 * (expbn2 + 2) * np.cosh(2*a_b)
+            t3 = expbn2**2 * np.cosh(4*a_b)
+            t4 = -3 + 3*expbn2**2 + 2*expbn2**3 + expbn2**4
+            denom = 2*(1 + expbn2*np.cosh(2*a_b))**2
+            g2 = (t1 + t2 + t3*t4) / denom - 3
+        return mu, mu2, g1, g2
+
 
 johnsonsu = johnsonsu_gen(name='johnsonsu')
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -5059,7 +5059,15 @@ class johnsonsu_gen(rv_continuous):
 
     `johnsonsu` takes :math:`a` and :math:`b` as shape parameters.
 
+    The first four central moments are calculated according to the formulas
+    in [1]_.
+
     %(after_notes)s
+
+    References
+    ----------
+    .. [1] Taylor Enterprises. "Johnson Family of Distributions".
+       https://variation.com/wp-content/distribution_analyzer_help/hs126.htm
 
     %(example)s
 

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -257,18 +257,20 @@ def test_levy_stable_random_state_property():
 def cases_test_moments():
     fail_normalization = set()
     fail_higher = {'ncf'}
+    fail_moment = {'johnsonsu'}  # generic `munp` is inaccurate for johnsonsu
 
     for distname, arg in distcont[:] + histogram_test_instances:
         if distname == 'levy_stable':
             continue
 
         if distname in distxslow_test_moments:
-            yield pytest.param(distname, arg, True, True, True,
+            yield pytest.param(distname, arg, True, True, True, True,
                                marks=pytest.mark.xslow(reason="too slow"))
             continue
 
         cond1 = distname not in fail_normalization
         cond2 = distname not in fail_higher
+        cond3 = distname not in fail_moment
 
         marks = list()
         # Currently unused, `marks` can be used to add a timeout to a test of
@@ -279,20 +281,22 @@ def cases_test_moments():
         #     if distname == 'skewnorm':
         #         marks.append(pytest.mark.timeout(300))
 
-        yield pytest.param(distname, arg, cond1, cond2, False, marks=marks)
+        yield pytest.param(distname, arg, cond1, cond2, cond3,
+                           False, marks=marks)
 
-        if not cond1 or not cond2:
+        if not cond1 or not cond2 or not cond3:
             # Run the distributions that have issues twice, once skipping the
             # not_ok parts, once with the not_ok parts but marked as knownfail
-            yield pytest.param(distname, arg, True, True, True,
+            yield pytest.param(distname, arg, True, True, True, True,
                                marks=[pytest.mark.xfail] + marks)
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize('distname,arg,normalization_ok,higher_ok,'
+@pytest.mark.parametrize('distname,arg,normalization_ok,higher_ok,moment_ok,'
                          'is_xfailing',
                          cases_test_moments())
-def test_moments(distname, arg, normalization_ok, higher_ok, is_xfailing):
+def test_moments(distname, arg, normalization_ok, higher_ok, moment_ok,
+                 is_xfailing):
     try:
         distfn = getattr(stats, distname)
     except TypeError:
@@ -321,7 +325,9 @@ def test_moments(distname, arg, normalization_ok, higher_ok, is_xfailing):
                 check_kurt_expect(distfn, arg, m, v, k, distname)
 
         check_loc_scale(distfn, arg, m, v, distname)
-        check_moment(distfn, arg, m, v, distname)
+
+        if moment_ok:
+            check_moment(distfn, arg, m, v, distname)
 
 
 @pytest.mark.parametrize('dist,shape_args', distcont)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -8287,15 +8287,28 @@ def test_moment_order_4():
 
 
 class TestJohnsonSU:
-    def test_moment_gh18071(self):
+    @pytest.mark.parametrize("case", [  # a, b, loc, scale, m1, m2, g1, g2
+            (-0.01, 1.1, 0.02, 0.0001, 0.02000137427557091,
+             2.1112742956578063e-08, 0.05989781342460999, 20.36324408592951-3),
+            (2.554395574161155, 2.2482281679651965, 0, 1, -1.54215386737391,
+             0.7629882028469993, -1.256656139406788, 6.303058419339775-3)])
+    def test_moment_gh18071(self, case):
         # gh-18071 reported an IntegrationWarning emitted by johnsonsu.stats
         # Check that the warning is no longer emitted and that the values
-        # are approximately unchanged from those produced by the generic
-        # implementation.
-        l, s, a, b = 0.02, 0.0001, -0.01, 1.1
-        res = stats.johnsonsu.stats(a, b, loc=l, scale=s, moments='mvsk')
-        # Reference comes from calling generic implementation
-        # (without overriding johnsonsu._stats)
-        ref = (0.020001374275567283, 2.1112742930730227e-08,
-               0.059897813624949114, 17.363273963631265)
-        assert_allclose(res, ref, rtol=2e-6)
+        # are accurate (compared against results from Mathematica).
+        # Reference values from Mathematica, e.g.
+        # Mean[JohnsonDistribution["SU",-0.01, 1.1, 0.02, 0.0001 ]]
+        res = stats.johnsonsu.stats(*case[:4], moments='mvsk')
+        assert_allclose(res, case[4:], rtol=1e-14)
+        # a, b, l, s = -0.01, 1.1, 0.02, 0.0001
+        # res = stats.johnsonsu.stats(a, b, loc=l, scale=s, moments='mvsk')
+        #
+        # ref = (0.02000137427557091, 2.1112742956578063e-08,
+        #        0.05989781342460999, 20.36324408592951-3)
+        # assert_allclose(res, ref, rtol=1e-14)
+        #
+        # a, b, l, s = 2.554395574161155, 2.2482281679651965, 0, 1
+        # res = stats.johnsonsu.stats(a, b, loc=l, scale=s, moments='mvsk')
+        # ref = (-1.54215386737391, 0.7629882028469993,
+        #        -1.256656139406788, 6.303058419339775-3)
+        # assert_allclose(res, ref, rtol=1e-14)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -8284,3 +8284,18 @@ def test_moment_order_4():
     # has since been made more accurate and efficient, so now this test
     # is expected to pass.
     assert stats.skewnorm._munp(4, 0) == 3.0
+
+
+class TestJohnsonSU:
+    def test_moment_gh18071(self):
+        # gh-18071 reported an IntegrationWarning emitted by johnsonsu.stats
+        # Check that the warning is no longer emitted and that the values
+        # are approximately unchanged from those produced by the generic
+        # implementation.
+        l, s, a, b = 0.02, 0.0001, -0.01, 1.1
+        res = stats.johnsonsu.stats(a, b, loc=l, scale=s, moments='mvsk')
+        # Reference comes from calling generic implementation
+        # (without overriding johnsonsu._stats)
+        ref = (0.020001374275567283, 2.1112742930730227e-08,
+               0.059897813624949114, 17.363273963631265)
+        assert_allclose(res, ref, rtol=2e-6)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -8295,20 +8295,8 @@ class TestJohnsonSU:
     def test_moment_gh18071(self, case):
         # gh-18071 reported an IntegrationWarning emitted by johnsonsu.stats
         # Check that the warning is no longer emitted and that the values
-        # are accurate (compared against results from Mathematica).
+        # are accurate compared against results from Mathematica.
         # Reference values from Mathematica, e.g.
-        # Mean[JohnsonDistribution["SU",-0.01, 1.1, 0.02, 0.0001 ]]
+        # Mean[JohnsonDistribution["SU",-0.01, 1.1, 0.02, 0.0001]]
         res = stats.johnsonsu.stats(*case[:4], moments='mvsk')
         assert_allclose(res, case[4:], rtol=1e-14)
-        # a, b, l, s = -0.01, 1.1, 0.02, 0.0001
-        # res = stats.johnsonsu.stats(a, b, loc=l, scale=s, moments='mvsk')
-        #
-        # ref = (0.02000137427557091, 2.1112742956578063e-08,
-        #        0.05989781342460999, 20.36324408592951-3)
-        # assert_allclose(res, ref, rtol=1e-14)
-        #
-        # a, b, l, s = 2.554395574161155, 2.2482281679651965, 0, 1
-        # res = stats.johnsonsu.stats(a, b, loc=l, scale=s, moments='mvsk')
-        # ref = (-1.54215386737391, 0.7629882028469993,
-        #        -1.256656139406788, 6.303058419339775-3)
-        # assert_allclose(res, ref, rtol=1e-14)


### PR DESCRIPTION
#### Reference issue
Closes gh-18071

#### What does this implement/fix?
gh-18071 reported a warning produced by `johnsonsu.stats`. This overrides `johnsonsu`'s `_stats` method using straightforward implementations of formulas for the moments. No attempt is made to ensure numerical stability for extreme parameter values, so the test only checks what this PR is intended to resolve: the warning is no longer produced, and the implementation is not incorrect. 

*The failure in `test_moments` (which has been xfailed) is due to inaccuracy when the second noncentral moment is computed using the generic `_munp`. The code below shows close agreement between this PR's implementation and mpmath numerical integration.*

<details>

```python3
import numpy as np
from scipy import stats
from numpy.testing import assert_allclose
from mpmath import mp
mp.dps = 100
def pdf(x, a, b):
    x, a, b = mp.mpf(x), mp.mpf(a), mp.mpf(b)
    x2 = x * x
    trm = mp.npdf(a + b * mp.log(x + np.sqrt(x2 + mp.one)))
    return b * mp.one / mp.sqrt(x2 + mp.one) * trm
x = 1.5
a, b = 2.554395574161155, 2.2482281679651965

def moment(order=1):
    return mp.quad(lambda x: x**order * pdf(x, a, b), (-mp.inf, mp.inf))

pdf1 = pdf(x, a, b)
pdf2 = stats.johnsonsu.pdf(x, a, b)
assert_allclose(float(pdf1), pdf2, rtol=1e-14)

mean1 = moment(order=1)
mean2 = stats.johnsonsu.stats(a, b, moments='m')
assert_allclose(float(mean1), mean2, rtol=1e-15)

var1 = moment(order=2) - mean1**2
var2 = stats.johnsonsu.stats(a, b, moments='v')
assert_allclose(float(var1), var2, rtol=1e-15)

skew1 = (moment(order=3) - 3*mean1*var1 - mean1**3)/var1**1.5
skew2 = stats.johnsonsu.stats(a, b, moments='s')
assert_allclose(float(skew1), skew2, rtol=1e-15)

kurtosis1 = (moment(order=4) - 4*mean1*moment(order=3) + 6*mean1**2*moment(order=2) - 3*mean1**4)/var1**2 - 3
kurtosis2 = stats.johnsonsu.stats(a, b, moments='k')
assert_allclose(float(kurtosis1), kurtosis2, rtol=1e-15)
```

</details>

#### Additional information
~~I would prefer not to add an entry to the tutorial, but I could cite the source of the formulas. I used [this](https://variation.com/wp-content/distribution_analyzer_help/hs126.htm) instead of Wikipedia because I didn't get a correct result when I tried implementing Wikipedia's formula for skewness.~~ Done.

I would recommend that future reports similar to gh-18071 be tracked in gh-17832. The warning emitted by `johnsonsu.stats` is not really a "bug"; it is just the generic implementation doing its job and warning the user when it's not sure about the accuracy. By this logic, this PR is an enhancement rather than maintenance, and perhaps it would be considered incomplete because it does not attempt to be robust. If that is the case, I am happy to close this PR.
