### PR TITLE
ENH: Added QR solver using QR decomposition

### DIFF
--- a/scipy/linalg/_qr_solve.py
+++ b/scipy/linalg/_qr_solve.py
@@ -63,7 +63,7 @@ def qr_solve(A,y,silent=True):
     P = np.eye(len(P))[:,P]
     
     #Let r be the number of linearly independent columns & rows in A (the rank)
-    rank = r = np.linalg.matrix_rank(A)
+    rank = r = sum(np.around(np.diag(R),12)!=0)
     
     #Q is a m by m square orthogonal matrix
     #Q_1 has m rows and r columns

--- a/scipy/linalg/_qr_solve.py
+++ b/scipy/linalg/_qr_solve.py
@@ -76,7 +76,7 @@ def qr_solve(A,y,silent=True):
     R_2 = R[:,:-(rank-m)]
     
     #z_1 is a column vector with r elements
-    z_1 = np.linalg.inv(R_1)@Q_1.T@y
+    z_1 = scipy.linalg.solve(R_1,Q_1.T@y)
     
     #We pad z_1 with r-m zeros at the bottom for a solution vector
     padding = np.zeros(n-r) #zero padding

--- a/scipy/linalg/_qr_solve.py
+++ b/scipy/linalg/_qr_solve.py
@@ -1,0 +1,90 @@
+import scipy
+import numpy as np
+import logging
+
+def qr_solve(A,y,silent=True):
+    """
+    Solves over-determined and underdetemined linar systems :math:`y=Ax`.
+
+    Parameters
+    ----------
+    A : (M, N) array_like
+        Any matrix.
+    
+    y : ndarray
+        A column vector to solve for with `M` rows.
+        
+    silent : {'True', 'False'}, optional
+        To log if the solution is a true solution.
+
+    Returns
+    -------
+    x : ndarray
+        Solution to the linear system equation
+
+    Notes
+    -----
+    This uses QR-Decomposition using the permutation matrix to find a soultion to the
+    given linear system `y=Ax` through back substitution.
+
+    References
+    ----------
+    .. [1] https://inst.eecs.berkeley.edu/~ee127/sp21/livebook/l_lineqs_solving.html
+
+    Examples
+    --------
+    Given `A` is `m\times n`, `x \in \mathbb{R}^{n}` `y\in\mathbb{R}^m` in the equation `y=Ax`, solve for `x`:
+
+    >>> import numpy as np
+    >>> from scipy import linalg
+    >>> A = np.random.rand( m, n )
+    >>> x = np.random.rand( n )
+    >>> y = A@x
+    >>> x_0 = _qr_solve.qr_solve(A, y)
+    >>> np.allclose(y, A@x_0)
+    True
+
+    """
+    
+    A = np.asarray(A)
+    y = np.asarray(y)
+    
+    #Solving y=Ax for an x_0
+    #A has m rows and n columns -> y has m rows and x has n rows
+    m,n = A.shape
+    
+    #QR decomposition
+    Q,R,P= scipy.linalg.qr(A,pivoting=True)
+    #Q is an m by m orthogonal matrix
+    #R is an m by n upper right triangle matrix
+    
+    #P is a permuntation matrix with n rows and n columns
+    #P can order A by rank for *rank revealing*
+    P = np.eye(len(P))[:,P]
+    
+    #Let r be the number of linearly independent columns & rows in A (the rank)
+    rank = r = np.linalg.matrix_rank(A)
+    
+    #Q is a m by m square orthogonal matrix
+    #Q_1 has m rows and r columns
+    Q_1 = Q[:,:rank]
+    
+    #R_1 is an r by r upper right triangular matrix
+    R_1 = R[:rank,:rank]
+    
+    #R_2 is an r by m-r matrix
+    R_2 = R[:,:-(rank-m)]
+    
+    #z_1 is a column vector with r elements
+    z_1 = np.linalg.inv(R_1)@Q_1.T@y
+    
+    #We pad z_1 with r-m zeros at the bottom for a solution vector
+    padding = np.zeros(n-r) #zero padding
+    x_0 = P@np.hstack([z_1,padding]) #Add padding
+    
+    if not silent:
+        #Log if there was a solution
+        is_solution = np.allclose(y,A@x_0)
+        logging.info("Solution Found!") if is_solution else loggin.info("No Solution!")
+        
+    return x_0

--- a/scipy/linalg/tests/meson.build
+++ b/scipy/linalg/tests/meson.build
@@ -21,7 +21,8 @@ python_sources = [
   'test_sketches.py',
   'test_solve_toeplitz.py',
   'test_solvers.py',
-  'test_special_matrices.py'
+  'test_special_matrices.py',
+  'test_qr_solve.py'
 ]
 
 

--- a/scipy/linalg/tests/test_qr_solve.py
+++ b/scipy/linalg/tests/test_qr_solve.py
@@ -1,0 +1,18 @@
+import numpy as np
+from scipy.linalg import _qr_solve
+
+class TestQRSolver(unittest.TestCase):
+    def test_is_no_soultion(self):
+        m,n = (100,150)
+        A = np.random.rand( m, n )
+        y = np.random.rand( m )
+        x_0 = _qr_solve.qr_solve(A, y, silent=True)
+        return np.allclose(y, A@x_0)
+    
+    def test_is_solution(self):
+        m,n = (100,150)
+        A = np.random.rand( m, n )
+        x = np.random.rand( n )
+        y = A@x
+        x_0 = _qr_solve.qr_solve(A, y, silent=True)
+        return np.allclose(y, A@x_0)


### PR DESCRIPTION
This is a method for solving linear systems using QR factorization and back substitution. I found no solvers like this in numpy or scipy so when I build it I thought it might help others to have. 

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
No solver if the matrix is m by n 

#### What does this implement/fix?
It adds a QR decomposition solver using back substitution.

#### Additional information
I am still going through the contribution docs to make sure everything is okay. Let me know if I did something wrong. My commit message was wrong; it did not have a prefix. I hope that is okay. 
