### PR TITLE
ENH: increase available range of Gompertz entropy using scaled_exp1

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -3737,7 +3737,7 @@ class gompertz_gen(rv_continuous):
         return sc.log1p(-np.log(p)/c)
 
     def _entropy(self, c):
-        return 1.0 - np.log(c) - np.exp(c)*sc.expn(1, c)
+        return 1.0 - np.log(c) - sc._ufuncs._scaled_exp1(c)/c
 
 
 gompertz = gompertz_gen(a=0.0, name='gompertz')

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1020,6 +1020,19 @@ class TestGompertz:
         assert_allclose(stats.gompertz.sf(x, c), sfx, rtol=1e-14)
         assert_allclose(stats.gompertz.isf(sfx, c), x, rtol=1e-14)
 
+    # reference values were computed with mpmath
+    # from mpmath import mp
+    # mp.dps = 100
+    # def gompertz_entropy(c):
+    #     c = mp.mpf(c)
+    #     return float(mp.one - mp.log(c) - mp.exp(c)*mp.e1(c))
+
+    @pytest.mark.parametrize('c, ref', [(1e-4, 1.5762523017634573),
+                                        (1, 0.4036526376768059),
+                                        (1000, -5.908754280976161),
+                                        (1e6, -12.815511557963275)])
+    def test_entropy(self, c, ref):
+        assert_allclose(stats.gompertz.entropy(c), ref, rtol=1e-14)
 
 class TestHalfNorm:
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1030,7 +1030,7 @@ class TestGompertz:
     @pytest.mark.parametrize('c, ref', [(1e-4, 1.5762523017634573),
                                         (1, 0.4036526376768059),
                                         (1000, -5.908754280976161),
-                                        (1e6, -12.815511557963275)])
+                                        (1e10, -22.025850930040455)])
     def test_entropy(self, c, ref):
         assert_allclose(stats.gompertz.entropy(c), ref, rtol=1e-14)
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1034,6 +1034,7 @@ class TestGompertz:
     def test_entropy(self, c, ref):
         assert_allclose(stats.gompertz.entropy(c), ref, rtol=1e-14)
 
+
 class TestHalfNorm:
 
     # sfx is sf(x).  The values were computed with mpmath:


### PR DESCRIPTION
#### Reference issue
No directly related issue

#### What does this implement/fix?
Use the new ufunc `scaled_exp1` to improve the entropy method of the Gompertz distribution.

#### Additional information
Currently, the entropy fails after approx. `c=700` due to overflow in `expn(1, c).` `scaled_exp1` works for a much wider range.
