### PR TITLE
DOC: adding references to the UnivariateSpline docstring #17828

### DIFF
--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -190,6 +190,7 @@ class UnivariateSpline:
     References
     ----------
     Based on algorithms described in [1]_, [2]_, [3]_, and [4]_:
+
     .. [1] P. Dierckx, "An algorithm for smoothing, differentiation and
        integration of experimental data using spline functions",
        J.Comp.Appl.Maths 1 (1975) 165-184.

--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -187,6 +187,20 @@ class UnivariateSpline:
     Notice the need to replace a ``nan`` by a numerical value (precise value
     does not matter as long as the corresponding weight is zero.)
 
+    References
+    ----------
+    Based on algorithms described in [1]_, [2]_, [3]_, and [4]_:
+    .. [1] P. Dierckx, "An algorithm for smoothing, differentiation and
+       integration of experimental data using spline functions",
+       J.Comp.Appl.Maths 1 (1975) 165-184.
+    .. [2] P. Dierckx, "A fast algorithm for smoothing data on a rectangular
+       grid while using spline functions", SIAM J.Numer.Anal. 19 (1982)
+       1286-1304.
+    .. [3] P. Dierckx, "An improved algorithm for curve fitting with spline
+       functions", report tw54, Dept. Computer Science,K.U. Leuven, 1981.
+    .. [4] P. Dierckx, "Curve and surface fitting with splines", Monographs on
+       Numerical Analysis, Oxford University Press, 1993.
+
     Examples
     --------
     >>> import numpy as np


### PR DESCRIPTION
`UnivariateSpline` and `splrep` use the same algorithm, the first lacks references and the latter has citations to original papers and the Dierckx's book so I added references to the UnivariateSpline docstring #17828
<img width="830" alt="image" src="https://user-images.githubusercontent.com/65843206/222969561-2ca8a95f-5f01-49ee-bd2f-03b8bcd290b2.png">
