### PR TITLE
ENH: stats.goodness_of_fit: add Filliben's test

### DIFF
--- a/scipy/stats/_fit.py
+++ b/scipy/stats/_fit.py
@@ -1251,7 +1251,7 @@ def _filliben(dist, data):
 
     # [7] Section 8 # 4
     return _corr(X, M)
-_filliben.alternative = 'less'
+_filliben.alternative = 'less'  # type: ignore[<code>]
 
 
 def _cramer_von_mises(dist, data):

--- a/scipy/stats/_fit.py
+++ b/scipy/stats/_fit.py
@@ -1251,7 +1251,7 @@ def _filliben(dist, data):
 
     # [7] Section 8 # 4
     return _corr(X, M)
-_filliben.alternative = 'less'  # type: ignore[<code>]
+_filliben.alternative = 'less'  # type: ignore[attr-defined]
 
 
 def _cramer_von_mises(dist, data):

--- a/scipy/stats/tests/test_fit.py
+++ b/scipy/stats/tests/test_fit.py
@@ -816,6 +816,74 @@ class TestGoodnessOfFit:
         assert_allclose(res.statistic, ref.critical_values[0])
         assert_allclose(res.pvalue, ref.significance_level[0]/100, atol=5e-3)
 
+    def test_against_filliben_norm(self):
+        # Test against `stats.fit` ref. [7] Section 8 "Example"
+        rng = np.random.default_rng(8024266430745011915)
+        y = [6, 1, -4, 8, -2, 5, 0]
+        known_params = {'loc': 0, 'scale': 1}
+        res = stats.goodness_of_fit(stats.norm, y, known_params=known_params,
+                                    statistic="filliben", random_state=rng)
+        # Slight discrepancy presumably due to roundoff in Filliben's
+        # calculation. Using exact order statistic medians instead of
+        # Filliben's approximation doesn't account for it.
+        assert_allclose(res.statistic, 0.98538, atol=1e-4)
+        assert 0.75 < res.pvalue < 0.9
+
+        # Using R's ppcc library:
+        # library(ppcc)
+        # options(digits=16)
+        # x < - c(6, 1, -4, 8, -2, 5, 0)
+        # set.seed(100)
+        # ppccTest(x, "qnorm", ppos="Filliben")
+        # Discrepancy with
+        assert_allclose(res.statistic, 0.98540957187084, rtol=2e-5)
+        assert_allclose(res.pvalue, 0.8875, rtol=2e-3)
+
+    def test_filliben_property(self):
+        # Filliben's statistic should be independent of data location and scale
+        rng = np.random.default_rng(8535677809395478813)
+        x = rng.normal(loc=10, scale=0.5, size=100)
+        res = stats.goodness_of_fit(stats.norm, x,
+                                    statistic="filliben", random_state=rng)
+        known_params = {'loc': 0, 'scale': 1}
+        ref = stats.goodness_of_fit(stats.norm, x, known_params=known_params,
+                                    statistic="filliben", random_state=rng)
+        assert_allclose(res.statistic, ref.statistic, rtol=1e-15)
+
+    @pytest.mark.parametrize('case', [(25, [.928, .937, .950, .958, .966]),
+                                      (50, [.959, .965, .972, .977, .981]),
+                                      (95, [.977, .979, .983, .986, .989])])
+    def test_against_filliben_norm_table(self, case):
+        # Test against `stats.fit` ref. [7] Table 1
+        rng = np.random.default_rng(504569995557928957)
+        n, ref = case
+        x = rng.random(n)
+        known_params = {'loc': 0, 'scale': 1}
+        res = stats.goodness_of_fit(stats.norm, x, known_params=known_params,
+                                    statistic="filliben", random_state=rng)
+        percentiles = np.array([0.005, 0.01, 0.025, 0.05, 0.1])
+        res = stats.scoreatpercentile(res.null_distribution, percentiles*100)
+        assert_allclose(res, ref, atol=2e-3)
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize('case', [(5, 0.95772790260469, 0.4755),
+                                      (6, 0.95398832257958, 0.3848),
+                                      (7, 0.9432692889277, 0.2328)])
+    def test_against_ppcc(self, case):
+        # Test against R ppcc, e.g.
+        # library(ppcc)
+        # options(digits=16)
+        # x < - c(0.52325412, 1.06907699, -0.36084066, 0.15305959, 0.99093194)
+        # set.seed(100)
+        # ppccTest(x, "qrayleigh", ppos="Filliben")
+        n, ref_statistic, ref_pvalue = case
+        rng = np.random.default_rng(7777775561439803116)
+        x = rng.normal(size=n)
+        res = stats.goodness_of_fit(stats.rayleigh, x, statistic="filliben",
+                                    random_state=rng)
+        assert_allclose(res.statistic, ref_statistic, rtol=1e-4)
+        assert_allclose(res.pvalue, ref_pvalue, atol=1.5e-2)
+
     def test_params_effects(self):
         # Ensure that `guessed_params`, `fit_params`, and `known_params` have
         # the intended effects.


### PR DESCRIPTION
#### Reference issue
Followup to gh-16967

#### What does this implement/fix?
Add's Filliben's test for goodness of fit via `goodness_of_fit`.
Filliben's statistic is the product-moment correlation coefficient (Pearson's R) between the ordered data and the medians of the order statistics of the null-hypothesized distribution. That is, is looks at the linear association of a Q-Q plot (using the medians of the order statistics as the plotting positions).

```python3
import numpy as np
from scipy import stats
import matplotlib.pyplot as plt
rng = np.random.default_rng(7777775561439803116)
x = stats.chi(df=10, loc=0, scale=2).rvs(size=100, random_state=rng)
res = stats.goodness_of_fit(stats.rayleigh, x, statistic='filliben',
                            random_state = rng)
res.pvalue  # 0.0174
dist = stats.rayleigh(res.fit_result.params.loc, res.fit_result.params.scale)
res.fit_result.plot(plot_type='qq')
plt.show()
```
![image](https://user-images.githubusercontent.com/6570539/222983538-6f53776b-d835-4e76-a8cb-39214f00f54f.png)

#### Additional information
I doubt many people feel this is missing, but it was something I had in mind while working on gh-16967, so I wanted to finish it. I think after adding this and Shapiro-Francia, I will be content with the statistics supported by `goodness_of_fit` : )

I should probably ignore whether the user fixes `loc` and `scale` and just fix them, since this statistic is invariant to location and scale.