### PR TITLE
BUG: enable matlab nested arrs

### DIFF
--- a/scipy/io/matlab/_mio5.py
+++ b/scipy/io/matlab/_mio5.py
@@ -491,7 +491,10 @@ def to_writeable(source):
             return EmptyStructMarker
     # Next try and convert to an array
     try:
-        narr = np.asanyarray(source)
+        # warning suppression only needed for NumPy < 1.24.0
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=np.VisibleDeprecationWarning)
+            narr = np.asanyarray(source)
     except ValueError:
         narr = np.asanyarray(source, dtype=object)
     if narr.dtype.type in (object, np.object_) and \

--- a/scipy/io/matlab/_mio5.py
+++ b/scipy/io/matlab/_mio5.py
@@ -491,10 +491,7 @@ def to_writeable(source):
             return EmptyStructMarker
     # Next try and convert to an array
     try:
-        # warning suppression only needed for NumPy < 1.24.0
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=np.VisibleDeprecationWarning)
-            narr = np.asanyarray(source)
+        narr = np.asanyarray(source)
     except ValueError:
         narr = np.asanyarray(source, dtype=object)
     if narr.dtype.type in (object, np.object_) and \

--- a/scipy/io/matlab/_mio5.py
+++ b/scipy/io/matlab/_mio5.py
@@ -490,7 +490,10 @@ def to_writeable(source):
         else:
             return EmptyStructMarker
     # Next try and convert to an array
-    narr = np.asanyarray(source)
+    try:
+        narr = np.asanyarray(source)
+    except ValueError:
+        narr = np.asanyarray(source, dtype=object)
     if narr.dtype.type in (object, np.object_) and \
        narr.shape == () and narr == source:
         # No interesting conversion possible

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -1307,10 +1307,13 @@ def test_gh_17992(tmp_path):
     array_one = rng.random((5,3))
     array_two = rng.random((6,3))
     list_of_arrays = [array_one, array_two]
-    savemat(outfile,
-            {'data': list_of_arrays},
-            long_field_names=True,
-            do_compression=True)
+    # warning suppression only needed for NumPy < 1.24.0
+    with np.testing.suppress_warnings() as sup:
+        sup.filter(np.VisibleDeprecationWarning)
+        savemat(outfile,
+                {'data': list_of_arrays},
+                long_field_names=True,
+                do_compression=True)
     # round trip check
     new_dict = {}
     loadmat(outfile,


### PR DESCRIPTION
Fixes #17992

* add a regression test + the suggested fix for the issue above, allowing for the saving of matlab files from ragged NumPy arrays