### PR TITLE
ENH: add Dunnett's test

### DIFF
--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -394,6 +394,7 @@ Others are generalized to multiple samples.
 
    f_oneway
    tukey_hsd
+   dunnett
    kruskal
    alexandergovern
    fligner
@@ -594,6 +595,7 @@ from ._stats_py import *
 from ._variation import variation
 from .distributions import *
 from ._morestats import *
+from ._multicomp import *
 from ._binomtest import binomtest
 from ._binned_statistic import *
 from ._kde import gaussian_kde

--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -1864,6 +1864,10 @@ def tukey_hsd(*args):
         confidence_interval(confidence_level=0.95):
             Compute the confidence interval for the specified confidence level.
 
+    See Also
+    --------
+    dunnett : performs comparison of means against a control group.
+
     Notes
     -----
     The use of this test relies on several assumptions.

--- a/scipy/stats/_multicomp.py
+++ b/scipy/stats/_multicomp.py
@@ -168,7 +168,7 @@ def dunnett(
 
     pvalue = pvalue_dunnett(
         rho=rho, df=df,
-        statistic=abs(statistic), alternative=alternative,
+        statistic=statistic, alternative=alternative,
         rng=rng
     )
 
@@ -246,8 +246,11 @@ def pvalue_dunnett(
 
     mvt = stats.multivariate_t(shape=rho, df=df, seed=rng)
     if alternative == "two-sided":
+        statistic = abs(statistic)
         pvalue = 1 - mvt.cdf(statistic, lower_limit=-statistic)
+    elif alternative == "greater":
+        pvalue = 1 - mvt.cdf(statistic, lower_limit=-np.inf)
     else:
-        pvalue = 1 - mvt.cdf(statistic)
+        pvalue = 1 - mvt.cdf(np.inf, lower_limit=statistic)
 
     return pvalue

--- a/scipy/stats/_multicomp.py
+++ b/scipy/stats/_multicomp.py
@@ -11,7 +11,7 @@ from scipy.stats._qmc import check_random_state
 if TYPE_CHECKING:
     import numpy.typing as npt
     from scipy._lib._util import SeedType
-    from typing import Literal, Sequence
+    from typing import Literal, Sequence  # noqa: UP035
 
 
 __all__ = [
@@ -56,16 +56,22 @@ def dunnett(
         If `random_state` is already a ``Generator`` instance, then the
         provided instance is used.
 
+        The random number generator is used to control the randomized
+        Quasi-Monte Carlo integration of the multivariate-t distribution.
+
     Returns
     -------
     res : DunnettResult
         An object containing attributes:
 
-        statistic : scalar or ndarray
-            The t-statistic for the test.  For 1-D inputs a scalar is
-            returned.
-        pvalue : scalar ndarray
-            The p-value for the test.
+        statistic : float ndarray
+            The computed statistic of the test for each comparison. The element
+            at index ``(i,)`` is the statistic for the comparison between
+            groups ``i`` and the control.
+        pvalue : float ndarray
+            The computed p-value of the test for each comparison. The element
+            at index ``(i,)`` is the p-value for the comparison between
+            groups ``i`` and the control.
 
     See Also
     --------

--- a/scipy/stats/_multicomp.py
+++ b/scipy/stats/_multicomp.py
@@ -44,8 +44,8 @@ def dunnett(
     control : 1D array_like
         The sample measurements for the control group.
     alternative : {'two-sided', 'less', 'greater'}, optional
-        Defines the alternative hypothesis. 
-        
+        Defines the alternative hypothesis.
+
         The null hypothesis is that the means of the distributions underlying
         the samples and control are equal. The following alternative
         hypotheses are available (default is 'two-sided'):
@@ -90,7 +90,7 @@ def dunnett(
     inferences about the means of distributions from which samples were drawn.
     However, when multiple t-tests are performed at a fixed significance level,
     the "family-wise error rate" - the probability of incorrectly rejecting the
-    null hypothesis in at least one test - will exceed the significance level. 
+    null hypothesis in at least one test - will exceed the significance level.
     Dunnett's test is designed to perform multiple comparisons while
     controlling the family-wise error rate.
 

--- a/scipy/stats/_multicomp.py
+++ b/scipy/stats/_multicomp.py
@@ -31,7 +31,7 @@ def dunnett(
     alternative: Literal['two-sided', 'less', 'greater'] = "two-sided",
     random_state: SeedType = None
 ) -> DunnettResult:
-    """Dunnett's test.
+    """Dunnett's test: multiple comparisons of means against a control group.
 
     Parameters
     ----------
@@ -71,7 +71,7 @@ def dunnett(
         pvalue : float ndarray
             The computed p-value of the test for each comparison. The element
             at index ``(i,)`` is the p-value for the comparison between
-            groups ``i`` and the control.
+            group ``i`` and the control.
 
     See Also
     --------
@@ -84,7 +84,7 @@ def dunnett(
     `tukey_hsd` instead, performs pairwise comparison of means.
     It means Dunnett's test performs fewer tests, hence there is less p-value
     adjustment which makes the test more powerful.
-    It should be preferred when there is control group.
+    It should be preferred when there is a control group.
 
     The use of this test relies on several assumptions.
 
@@ -110,7 +110,7 @@ def dunnett(
     of animal is investigated.
 
     The following table summarizes the results of the experiment in which
-    two groups received different drug, and one group acted as a control.
+    two groups received different drugs, and one group acted as a control.
     Blood counts (in millions of cells per cubic millimeter) were recorded::
 
          Control      Drug A      Drug B

--- a/scipy/stats/_multicomp.py
+++ b/scipy/stats/_multicomp.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from scipy import stats
+from scipy.stats._qmc import check_random_state
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+    from scipy._lib._util import SeedType
+    from typing import Literal
+
+
+__all__ = [
+    'dunnett'
+]
+
+
+@dataclass
+class DunnettResult:
+    statistic: np.ndarray
+    pvalue: np.ndarray
+
+
+def dunnett(
+    *samples: npt.ArrayLike, control: npt.ArrayLike,
+    alternative: Literal['two-sided', 'less', 'greater'] = "two-sided",
+    random_state: SeedType = None
+) -> DunnettResult:
+    """Dunnett's test.
+
+    Parameters
+    ----------
+    sample1, sample2, ... : 1D array_like
+        The sample measurements for each experiment group.
+    control : 1D array_like
+        The sample measurements for the control group.
+    alternative : {'two-sided', 'less', 'greater'}, optional
+        Defines the alternative hypothesis.
+        The following options are available (default is 'two-sided'):
+
+        * 'two-sided': the means of the distributions underlying the samples
+          and control are unequal.
+        * 'less': the means of the distribution underlying the samples
+          is less than the mean of the distribution underlying the control.
+        * 'greater': the means of the distribution underlying the
+          samples is greater than the mean of the distribution underlying
+          the control.
+    random_state : {None, int, `numpy.random.Generator`}, optional
+        If `random_state` is an int or None, a new `numpy.random.Generator` is
+        created using ``np.random.default_rng(random_state)``.
+        If `random_state` is already a ``Generator`` instance, then the
+        provided instance is used.
+
+    Returns
+    -------
+    res : DunnettResult
+        An object containing attributes:
+
+        statistic : scalar or ndarray
+            The t-statistic for the test.  For 1-D inputs a scalar is
+            returned.
+        pvalue : scalar ndarray
+            The p-value for the test.
+
+    See Also
+    --------
+    tukey_hsd : performs pairwise comparison of means.
+
+    Notes
+    -----
+    Dunnett's test [1]_ compares the means of multiple experiment groups
+    against a control group.
+    `tukey_hsd` instead, performs pairwise comparison of means.
+    It means Dunnett's test performs fewer tests, hence there is less p-value
+    adjustment which makes the test more powerful.
+    It should be preferred when there is control group.
+
+    The use of this test relies on several assumptions.
+
+    1. The observations are independent within and among groups.
+    2. The observations within each group are normally distributed.
+    3. The distributions from which the samples are drawn have the same finite
+       variance.
+
+    References
+    ----------
+    .. [1] Charles W. Dunnett. "A Multiple Comparison Procedure for Comparing
+       Several Treatments with a Control."
+       Journal of the American Statistical Association, 50:272, 1096-1121,
+       :doi:`10.1080/01621459.1955.10501294`, 1955.
+    .. [2] K.S. Kwong, W. Liu. "Calculation of critical values for Dunnett
+       and Tamhane’s step-up multiple test procedure."
+       Statistics and Probability Letters, 49, 411-416,
+       :doi:`10.1016/S0167-7152(00)00076-6`, 2000.
+
+    Examples
+    --------
+    In [1]_, the influence of drugs on blood count measurements on three groups
+    of animal is investigated.
+
+    The following table summarizes the results of the experiment in which
+    two groups received different drug, and one group acted as a control.
+    Blood counts (in millions of cells per cubic millimeter) were recorded::
+
+         Control      Drug A      Drug B
+           7.40        9.76        12.80
+           8.50        8.80         9.68
+           7.20        7.68        12.16
+           8.24        9.36         9.20
+           9.84                    10.55
+           8.32
+
+    >>> import numpy as np
+    >>> control = np.array([7.40, 8.50, 7.20, 8.24, 9.84, 8.32])
+    >>> drug_a = np.array([9.76, 8.80, 7.68, 9.36])
+    >>> drug_b = np.array([12.80, 9.68, 12.16, 9.20, 10.55])
+
+    The `dunnett` statistic is sensitive to the difference in means between
+    the samples.
+
+    We would like to see if the means between any of the groups are
+    significantly different. First, visually examine a box and whisker plot.
+
+    >>> import matplotlib.pyplot as plt
+    >>> fig, ax = plt.subplots(1, 1)
+    >>> ax.boxplot([control, drug_a, drug_b])
+    >>> ax.set_xticklabels(["Control", "Drug A", "Drug B"])  # doctest: +SKIP
+    >>> ax.set_ylabel("mean")  # doctest: +SKIP
+    >>> plt.show()
+
+    From the box and whisker plot, we can see overlap in the interquartile
+    ranges between the control group and the group from drug A.
+    We can apply the `dunnett`
+    test to determine if the difference between means is significant. We
+    set a significance level of .05 to reject the null hypothesis.
+
+    >>> from scipy.stats import dunnett
+    >>> res = dunnett(drug_a, drug_b, control=control)
+    >>> res.pvalue
+    array([0.47773146, 0.00889328])  # random
+
+    The null hypothesis is that each group has the same mean. The p-value for
+    comparisons between ``control`` and ``drug_b`` do not exceed .05,
+    so we reject the null hypothesis that they
+    have the same means. The p-value of the comparison between ``control``
+    and ``drug_a`` exceeds .05, so we accept the null hypothesis that there
+    is not a significant difference between their means.
+
+    """
+    samples, control, rng = iv_dunnett(
+        samples=samples, control=control, random_state=random_state
+    )
+
+    rho, df, n_group = params_dunnett(
+        samples=samples, control=control
+    )
+
+    statistic = np.array([
+        stats.ttest_ind(
+            obs_, control, alternative=alternative, random_state=rng
+        ).statistic
+        for obs_ in samples
+    ])
+
+    pvalue = pvalue_dunnett(
+        rho=rho, df=df,
+        statistic=abs(statistic), alternative=alternative,
+        rng=rng
+    )
+
+    return DunnettResult(
+        statistic=statistic, pvalue=pvalue,
+    )
+
+
+def iv_dunnett(
+    samples: npt.ArrayLike, control: npt.ArrayLike, random_state: SeedType
+) -> tuple[npt.ArrayLike, np.ndarray, SeedType]:
+    """Input validation for Dunnett's test."""
+    rng = check_random_state(random_state)
+
+    ndim_msg = "Control and samples groups must be 1D arrays"
+    n_obs_msg = "Control and samples groups must have at least 1 observation"
+
+    control = np.asarray(control)
+    samples = [np.asarray(sample) for sample in samples]
+
+    # samples checks
+    for sample in (samples + [control]):
+        sample = np.asarray(sample)
+        if sample.ndim > 1:
+            raise ValueError(ndim_msg)
+
+        if len(sample) < 1:
+            raise ValueError(n_obs_msg)
+
+    return samples, control, rng
+
+
+def params_dunnett(
+    samples: npt.ArrayLike, control: npt.ArrayLike
+) -> tuple[np.ndarray, int, int]:
+    """Specific parameters for Dunnett's test.
+
+    Covariance matrix depends on the number of observations in each group:
+
+    - All groups are equals (including the control), ``rho_ij=0.5`` except for
+      the diagonal which is 1.
+    - All groups but the control are equal, balanced design.
+    - Groups are not equal, unbalanced design.
+
+    Degree of freedom is the number of observations minus the number of groups
+    including the control.
+    """
+    n_n_obs = np.array([len(obs_) for obs_ in samples])
+
+    # From Dunnett1955 p. 1100 d.f. = (sum N)-(p+1)
+    n_obs = n_n_obs.sum()
+    n_control = len(control)
+    n = n_obs + n_control
+    n_groups = len(samples)
+    df = n - n_groups - 1
+
+    # rho_ij = 1/sqrt((N0/Ni+1)(N0/Nj+1))
+    rho = n_control/n_n_obs + 1
+    rho = 1/np.sqrt(rho[:, None] * rho[None, :])
+    np.fill_diagonal(rho, 1)
+
+    return rho, df, n_groups
+
+
+def pvalue_dunnett(
+    rho: np.ndarray, df: int, statistic: np.ndarray,
+    alternative: Literal['two-sided', 'less', 'greater'],
+    rng: SeedType = None
+) -> np.ndarray:
+    """pvalue from Dunnett critical value.
+
+    Critical values come from the multivariate student-t distribution.
+    """
+    statistic = statistic.reshape(-1, 1)
+
+    mvt = stats.multivariate_t(shape=rho, df=df, seed=rng)
+    if alternative == "two-sided":
+        pvalue = 1 - mvt.cdf(statistic, lower_limit=-statistic)
+    else:
+        pvalue = 1 - mvt.cdf(statistic)
+
+    return pvalue

--- a/scipy/stats/_multicomp.py
+++ b/scipy/stats/_multicomp.py
@@ -45,10 +45,10 @@ def dunnett(
 
         * 'two-sided': the means of the distributions underlying the samples
           and control are unequal.
-        * 'less': the means of the distribution underlying the samples
-          is less than the mean of the distribution underlying the control.
-        * 'greater': the means of the distribution underlying the
-          samples is greater than the mean of the distribution underlying
+        * 'less': the means of the distributions underlying the samples
+          are less than the mean of the distribution underlying the control.
+        * 'greater': the means of the distributions underlying the
+          samples are greater than the mean of the distribution underlying
           the control.
     random_state : {None, int, `numpy.random.Generator`}, optional
         If `random_state` is an int or None, a new `numpy.random.Generator` is

--- a/scipy/stats/_result_classes.py
+++ b/scipy/stats/_result_classes.py
@@ -14,6 +14,7 @@ Result classes
    RelativeRiskResult
    BinomTestResult
    TukeyHSDResult
+   DunnettResult
    PearsonRResult
    FitResult
    OddsRatioResult
@@ -23,12 +24,13 @@ Result classes
 
 __all__ = ['BinomTestResult', 'RelativeRiskResult', 'TukeyHSDResult',
            'PearsonRResult', 'FitResult', 'OddsRatioResult',
-           'TtestResult']
+           'TtestResult', 'DunnettResult']
 
 
 from ._binomtest import BinomTestResult
 from ._odds_ratio import OddsRatioResult
 from ._relative_risk import RelativeRiskResult
 from ._hypotests import TukeyHSDResult
+from ._multicomp import DunnettResult
 from ._stats_py import PearsonRResult, TtestResult
 from ._fit import FitResult

--- a/scipy/stats/meson.build
+++ b/scipy/stats/meson.build
@@ -205,6 +205,7 @@ py3.install_sources([
     '_morestats.py',
     '_mstats_basic.py',
     '_mstats_extras.py',
+    '_multicomp.py',
     '_multivariate.py',
     '_odds_ratio.py',
     '_page_trend_test.py',

--- a/scipy/stats/tests/meson.build
+++ b/scipy/stats/tests/meson.build
@@ -19,6 +19,7 @@ py3.install_sources([
     'test_morestats.py',
     'test_mstats_basic.py',
     'test_mstats_extras.py',
+    'test_multicomp.py',
     'test_multivariate.py',
     'test_odds_ratio.py',
     'test_qmc.py',

--- a/scipy/stats/tests/test_multicomp.py
+++ b/scipy/stats/tests/test_multicomp.py
@@ -51,39 +51,72 @@ class TestDunnett:
         )
         assert_allclose(res, pvalue, atol=5e-3)
 
-    def test_unbalanced(self):
-        # compare results from Matlab's documentation on multcompare
+    # From Matlab's documentation on multcompare
+    samples_1 = [
+        [
+            24.0, 27.0, 33.0, 32.0, 28.0, 19.0, 37.0, 31.0, 36.0, 36.0,
+            34.0, 38.0, 32.0, 38.0, 32.0
+        ],
+        [26.0, 24.0, 26.0, 25.0, 29.0, 29.5, 16.5, 36.0, 44.0],
+        [25.0, 27.0, 19.0],
+        [25.0, 20.0],
+        [28.0]
+    ]
+    control_1 = [
+        18.0, 15.0, 18.0, 16.0, 17.0, 15.0, 14.0, 14.0, 14.0, 15.0, 15.0,
+        14.0, 15.0, 14.0, 22.0, 18.0, 21.0, 21.0, 10.0, 10.0, 11.0, 9.0,
+        25.0, 26.0, 17.5, 16.0, 15.5, 14.5, 22.0, 22.0, 24.0, 22.5, 29.0,
+        24.5, 20.0, 18.0, 18.5, 17.5, 26.5, 13.0, 16.5, 13.0, 13.0, 13.0,
+        28.0, 27.0, 34.0, 31.0, 29.0, 27.0, 24.0, 23.0, 38.0, 36.0, 25.0,
+        38.0, 26.0, 22.0, 36.0, 27.0, 27.0, 32.0, 28.0, 31.0
+    ]
+    pvalue_1 = [4.727e-06, 0.022346, 0.97912, 0.99953, 0.86579]
+
+    # From Dunnett1995 comparing with R's DescTools: DunnettTest
+    samples_2 = [
+        [9.76, 8.80, 7.68, 9.36], [12.80, 9.68, 12.16, 9.20, 10.55]
+    ]
+    control_2 = [7.40, 8.50, 7.20, 8.24, 9.84, 8.32]
+    pvalue_2 = [0.6201, 0.0058]
+
+    samples_3 = [
+        [55, 64, 64], [55, 49, 52], [50, 44, 41]
+    ]
+    control_3 = [55, 47, 48]
+    pvalue_3 = [0.0364, 0.8966, 0.4091]
+
+    # From Thomson and Short,
+    # Mucociliary function in health, chronic obstructive airway disease,
+    # and asbestosis, Journal of Applied Physiology, 1969. Table 1
+    # Comparing with R's DescTools: DunnettTest
+    samples_4 = [[3.8, 2.7, 4.0, 2.4], [2.8, 3.4, 3.7, 2.2, 2.0]]
+    control_4 = [2.9, 3.0, 2.5, 2.6, 3.2]
+    pvalue_4 = [0.5832, 0.9982]
+
+    @pytest.mark.parametrize(
+        'samples, control, pvalue',
+        [
+            (samples_1, control_1, pvalue_1),
+            (samples_2, control_2, pvalue_2),
+            (samples_3, control_3, pvalue_3),
+            (samples_4, control_4, pvalue_4),
+        ]
+    )
+    def test_unbalanced(self, samples, control, pvalue):
         rng = np.random.default_rng(11681140010308601919115036826969764808)
-        samples = [
-            [
-                24.0, 27.0, 33.0, 32.0, 28.0, 19.0, 37.0, 31.0, 36.0, 36.0,
-                34.0, 38.0, 32.0, 38.0, 32.0
-            ],
-            [26.0, 24.0, 26.0, 25.0, 29.0, 29.5, 16.5, 36.0, 44.0],
-            [25.0, 27.0, 19.0],
-            [25.0, 20.0],
-            [28.0]
-        ]
-        control = [
-            18.0, 15.0, 18.0, 16.0, 17.0, 15.0, 14.0, 14.0, 14.0, 15.0, 15.0,
-            14.0, 15.0, 14.0, 22.0, 18.0, 21.0, 21.0, 10.0, 10.0, 11.0, 9.0,
-            25.0, 26.0, 17.5, 16.0, 15.5, 14.5, 22.0, 22.0, 24.0, 22.5, 29.0,
-            24.5, 20.0, 18.0, 18.5, 17.5, 26.5, 13.0, 16.5, 13.0, 13.0, 13.0,
-            28.0, 27.0, 34.0, 31.0, 29.0, 27.0, 24.0, 23.0, 38.0, 36.0, 25.0,
-            38.0, 26.0, 22.0, 36.0, 27.0, 27.0, 32.0, 28.0, 31.0
-        ]
-        ref = np.array([4.727e-06, 0.022346, 0.97912, 0.99953, 0.86579])
 
         res = stats.dunnett(*samples, control=control, random_state=rng)
 
         assert isinstance(res, DunnettResult)
-        assert_allclose(res.pvalue, ref, atol=1e-3)
+        assert_allclose(res.pvalue, pvalue, atol=1e-3)
 
     @pytest.mark.parametrize(
         'alternative',
         ['two-sided', 'less', 'greater']
     )
     def test_ttest_ind(self, alternative):
+        # check that `dunnett` agrees with `ttest_ind`
+        # when there are only two groups
         rng = np.random.default_rng(114184017807316971636137493526995620351)
 
         for _ in range(10):

--- a/scipy/stats/tests/test_multicomp.py
+++ b/scipy/stats/tests/test_multicomp.py
@@ -141,6 +141,10 @@ class TestDunnett:
         ]
         control = [55, 47, 48]
 
+        # alternative
+        with pytest.raises(ValueError, match="alternative must be"):
+            stats.dunnett(*samples, control=control, alternative='bob')
+
         # 2D for a sample
         samples_ = copy.deepcopy(samples)
         samples_[0] = [samples_[0]]

--- a/scipy/stats/tests/test_multicomp.py
+++ b/scipy/stats/tests/test_multicomp.py
@@ -1,0 +1,133 @@
+import copy
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from scipy import stats
+from scipy.stats._multicomp import pvalue_dunnett, DunnettResult
+
+
+class TestDunnett:
+
+    @pytest.mark.parametrize(
+        'rho, n_groups, df, statistic, pvalue, alternative',
+        [
+            # From Dunnett1995
+            # Tables 1a and 1b pages 1117-1118
+            (0.5, 1, 10, 1.81, 0.05, "one-sided"),  # different than two-sided
+            (0.5, 3, 10, 2.34, 0.05, "one-sided"),
+            (0.5, 2, 30, 1.99, 0.05, "one-sided"),
+            (0.5, 5, 30, 2.33, 0.05, "one-sided"),
+            (0.5, 4, 12, 3.32, 0.01, "one-sided"),
+            (0.5, 7, 12, 3.56, 0.01, "one-sided"),
+            (0.5, 2, 60, 2.64, 0.01, "one-sided"),
+            (0.5, 4, 60, 2.87, 0.01, "one-sided"),
+            (0.5, 4, 60, [2.87, 2.21], [0.01, 0.05], "one-sided"),
+            # Tables 2a and 2b pages 1119-1120
+            (0.5, 1, 10, 2.23, 0.05, "two-sided"),  # two-sided
+            (0.5, 3, 10, 2.81, 0.05, "two-sided"),
+            (0.5, 2, 30, 2.32, 0.05, "two-sided"),
+            (0.5, 3, 20, 2.57, 0.05, "two-sided"),
+            (0.5, 4, 12, 3.76, 0.01, "two-sided"),
+            (0.5, 7, 12, 4.08, 0.01, "two-sided"),
+            (0.5, 2, 60, 2.90, 0.01, "two-sided"),
+            (0.5, 4, 60, 3.14, 0.01, "two-sided"),
+            (0.5, 4, 60, [3.14, 2.55], [0.01, 0.05], "two-sided"),
+            # From Kwong2000 Table 2
+            (0.5, 9, 30, 2.856, 0.05, "two-sided"),
+            (0.5, 17, 20, 3.162, 0.05, "two-sided"),
+            # balanced designs
+            (0.3, 10, 10, 3.401, 0.05, "two-sided"),
+            (0.3, 13, 20, 3.168, 0.05, "two-sided"),
+            (0.1, 12, 20, 3.184, 0.05, "two-sided"),
+            (0.1, 15, 30, 3.157, 0.05, "two-sided"),
+        ],
+    )
+    def test_critical_values(
+        self, rho, n_groups, df, statistic, pvalue, alternative
+    ):
+        rng = np.random.default_rng(165250594791731684851746311027739134893)
+        rho = np.full((n_groups, n_groups), rho)
+        np.fill_diagonal(rho, 1)
+
+        statistic = np.array(statistic)
+        res = pvalue_dunnett(
+            rho=rho, df=df, statistic=statistic,
+            alternative=alternative,
+            rng=rng
+        )
+        assert_allclose(res, pvalue, atol=5e-3)
+
+    def test_unbalanced(self):
+        # compare results from Matlab's documentation on multcompare
+        rng = np.random.default_rng(11681140010308601919115036826969764808)
+        samples = [
+            [
+                24.0, 27.0, 33.0, 32.0, 28.0, 19.0, 37.0, 31.0, 36.0, 36.0,
+                34.0, 38.0, 32.0, 38.0, 32.0
+            ],
+            [26.0, 24.0, 26.0, 25.0, 29.0, 29.5, 16.5, 36.0, 44.0],
+            [25.0, 27.0, 19.0],
+            [25.0, 20.0],
+            [28.0]
+        ]
+        control = [
+            18.0, 15.0, 18.0, 16.0, 17.0, 15.0, 14.0, 14.0, 14.0, 15.0, 15.0,
+            14.0, 15.0, 14.0, 22.0, 18.0, 21.0, 21.0, 10.0, 10.0, 11.0, 9.0,
+            25.0, 26.0, 17.5, 16.0, 15.5, 14.5, 22.0, 22.0, 24.0, 22.5, 29.0,
+            24.5, 20.0, 18.0, 18.5, 17.5, 26.5, 13.0, 16.5, 13.0, 13.0, 13.0,
+            28.0, 27.0, 34.0, 31.0, 29.0, 27.0, 24.0, 23.0, 38.0, 36.0, 25.0,
+            38.0, 26.0, 22.0, 36.0, 27.0, 27.0, 32.0, 28.0, 31.0
+        ]
+        ref = np.array([4.727e-06, 0.022346, 0.97912, 0.99953, 0.86579])
+
+        res = stats.dunnett(*samples, control=control, random_state=rng)
+
+        assert isinstance(res, DunnettResult)
+        # last value is problematic
+        assert_allclose(res.pvalue, ref, atol=0.025)
+
+    def test_ttest_ind(self):
+        rng = np.random.default_rng(114184017807316971636137493526995620351)
+
+        for _ in range(10):
+            sample = rng.integers(-100, 100, size=(10,))
+            control = rng.integers(-100, 100, size=(10,))
+
+            res = stats.dunnett(sample, control=control,random_state=rng)
+            ref = stats.ttest_ind(sample, control, random_state=rng)
+
+            assert_allclose(res.statistic, ref.statistic, atol=1e-3)
+            assert_allclose(res.pvalue, ref.pvalue, atol=1e-3)
+
+    def test_raises(self):
+        samples = [
+            [55, 64, 64],
+            [55, 49, 52],
+            [50, 44, 41]
+        ]
+        control = [55, 47, 48]
+
+        # 2D for a sample
+        samples_ = copy.deepcopy(samples)
+        samples_[0] = [samples_[0]]
+        with pytest.raises(ValueError, match="must be 1D arrays"):
+            stats.dunnett(*samples_, control=control)
+
+        # 2D for control
+        control_ = copy.deepcopy(control)
+        control_ = [control_]
+        with pytest.raises(ValueError, match="must be 1D arrays"):
+            stats.dunnett(*samples, control=control_)
+
+        # No obs in a sample
+        samples_ = copy.deepcopy(samples)
+        samples_[1] = []
+        with pytest.raises(ValueError, match="at least 1 observation"):
+            stats.dunnett(*samples_, control=control)
+
+        # No obs in control
+        control_ = []
+        with pytest.raises(ValueError, match="at least 1 observation"):
+            stats.dunnett(*samples, control=control_)

--- a/scipy/stats/tests/test_multicomp.py
+++ b/scipy/stats/tests/test_multicomp.py
@@ -86,7 +86,7 @@ class TestDunnett:
 
         assert isinstance(res, DunnettResult)
         # last value is problematic
-        assert_allclose(res.pvalue, ref, atol=0.025)
+        assert_allclose(res.pvalue, ref, atol=1e-3)
 
     @pytest.mark.parametrize(
         'alternative',

--- a/scipy/stats/tests/test_multicomp.py
+++ b/scipy/stats/tests/test_multicomp.py
@@ -5,7 +5,7 @@ import pytest
 from numpy.testing import assert_allclose
 
 from scipy import stats
-from scipy.stats._multicomp import pvalue_dunnett, DunnettResult
+from scipy.stats._multicomp import _pvalue_dunnett, DunnettResult
 
 
 class TestDunnett:
@@ -34,14 +34,6 @@ class TestDunnett:
             (0.5, 2, 60, 2.90, 0.01, "two-sided"),
             (0.5, 4, 60, 3.14, 0.01, "two-sided"),
             (0.5, 4, 60, [3.14, 2.55], [0.01, 0.05], "two-sided"),
-            # From Kwong2000 Table 2
-            (0.5, 9, 30, 2.856, 0.05, "two-sided"),
-            (0.5, 17, 20, 3.162, 0.05, "two-sided"),
-            # balanced designs
-            (0.3, 10, 10, 3.401, 0.05, "two-sided"),
-            (0.3, 13, 20, 3.168, 0.05, "two-sided"),
-            (0.1, 12, 20, 3.184, 0.05, "two-sided"),
-            (0.1, 15, 30, 3.157, 0.05, "two-sided"),
         ],
     )
     def test_critical_values(
@@ -52,7 +44,7 @@ class TestDunnett:
         np.fill_diagonal(rho, 1)
 
         statistic = np.array(statistic)
-        res = pvalue_dunnett(
+        res = _pvalue_dunnett(
             rho=rho, df=df, statistic=statistic,
             alternative=alternative,
             rng=rng
@@ -85,7 +77,6 @@ class TestDunnett:
         res = stats.dunnett(*samples, control=control, random_state=rng)
 
         assert isinstance(res, DunnettResult)
-        # last value is problematic
         assert_allclose(res.pvalue, ref, atol=1e-3)
 
     @pytest.mark.parametrize(

--- a/scipy/stats/tests/test_multicomp.py
+++ b/scipy/stats/tests/test_multicomp.py
@@ -15,15 +15,15 @@ class TestDunnett:
         [
             # From Dunnett1995
             # Tables 1a and 1b pages 1117-1118
-            (0.5, 1, 10, 1.81, 0.05, "one-sided"),  # different than two-sided
-            (0.5, 3, 10, 2.34, 0.05, "one-sided"),
-            (0.5, 2, 30, 1.99, 0.05, "one-sided"),
-            (0.5, 5, 30, 2.33, 0.05, "one-sided"),
-            (0.5, 4, 12, 3.32, 0.01, "one-sided"),
-            (0.5, 7, 12, 3.56, 0.01, "one-sided"),
-            (0.5, 2, 60, 2.64, 0.01, "one-sided"),
-            (0.5, 4, 60, 2.87, 0.01, "one-sided"),
-            (0.5, 4, 60, [2.87, 2.21], [0.01, 0.05], "one-sided"),
+            (0.5, 1, 10, 1.81, 0.05, "greater"),  # different than two-sided
+            (0.5, 3, 10, 2.34, 0.05, "greater"),
+            (0.5, 2, 30, 1.99, 0.05, "greater"),
+            (0.5, 5, 30, 2.33, 0.05, "greater"),
+            (0.5, 4, 12, 3.32, 0.01, "greater"),
+            (0.5, 7, 12, 3.56, 0.01, "greater"),
+            (0.5, 2, 60, 2.64, 0.01, "greater"),
+            (0.5, 4, 60, 2.87, 0.01, "greater"),
+            (0.5, 4, 60, [2.87, 2.21], [0.01, 0.05], "greater"),
             # Tables 2a and 2b pages 1119-1120
             (0.5, 1, 10, 2.23, 0.05, "two-sided"),  # two-sided
             (0.5, 3, 10, 2.81, 0.05, "two-sided"),
@@ -88,15 +88,25 @@ class TestDunnett:
         # last value is problematic
         assert_allclose(res.pvalue, ref, atol=0.025)
 
-    def test_ttest_ind(self):
+    @pytest.mark.parametrize(
+        'alternative',
+        ['two-sided', 'less', 'greater']
+    )
+    def test_ttest_ind(self, alternative):
         rng = np.random.default_rng(114184017807316971636137493526995620351)
 
         for _ in range(10):
             sample = rng.integers(-100, 100, size=(10,))
             control = rng.integers(-100, 100, size=(10,))
 
-            res = stats.dunnett(sample, control=control,random_state=rng)
-            ref = stats.ttest_ind(sample, control, random_state=rng)
+            res = stats.dunnett(
+                sample, control=control,
+                alternative=alternative, random_state=rng
+            )
+            ref = stats.ttest_ind(
+                sample, control,
+                alternative=alternative, random_state=rng
+            )
 
             assert_allclose(res.statistic, ref.statistic, atol=1e-3)
             assert_allclose(res.pvalue, ref.pvalue, atol=1e-3)

--- a/scipy/stats/tests/test_multicomp.py
+++ b/scipy/stats/tests/test_multicomp.py
@@ -111,6 +111,37 @@ class TestDunnett:
             assert_allclose(res.statistic, ref.statistic, atol=1e-3)
             assert_allclose(res.pvalue, ref.pvalue, atol=1e-3)
 
+    @pytest.mark.parametrize(
+        'alternative, statistic, pvalue',
+        [
+            ('less', 'low', 0),
+            ('less', 'high', 1),
+            ('greater', 'low', 1),
+            ('greater', 'high', 0),
+            ('two-sided', 'low', 0),
+            ('two-sided', 'high', 0)
+        ]
+    )
+    def test_alternatives(self, alternative, statistic, pvalue):
+        rng = np.random.default_rng(114184017807316971636137493526995620351)
+
+        for _ in range(10):
+            sample_1 = rng.integers(0, 20, size=(10,))
+            sample_2 = rng.integers(80, 100, size=(10,))
+
+            if statistic == 'high':
+                sample = sample_2
+                control = sample_1
+            else:
+                sample = sample_1
+                control = sample_2
+
+            res = stats.dunnett(
+                sample, control=control,
+                alternative=alternative, random_state=rng
+            )
+            assert_allclose(res.pvalue, pvalue, atol=1e-7)
+
     def test_raises(self):
         samples = [
             [55, 64, 64],


### PR DESCRIPTION
Add Dunnett's test.

It is similar to Tukey’s test, but instead compares all sample groups to a control group. Hence the test performs less p-value calculation and is more powerful in that situation. It is pretty much the recommended, and widely used, method when comparing groups against a control.

Note that the function is listed on our roadmap in the stats section under “post hoc tests": https://scipy.github.io/devdocs/dev/roadmap-detailed.html#stats

---

Follow up PRs will include a method to get CI in terms of allowance (see Dunnett's reference article). On top of that, a `str` method will present the information in a similar manner as we have for Tukey's test.