### PR TITLE
ENH: stats.goodness_of_fit: add Shapiro-Francia test

### DIFF
--- a/scipy/stats/_fit.py
+++ b/scipy/stats/_fit.py
@@ -1251,7 +1251,7 @@ def _filliben(dist, data):
 
     # [7] Section 8 # 4
     return _corr(X, M)
-_filliben.alternative = 'less'
+_filliben.alternative = 'less'  # type: ignore[<code>]
 
 
 def _cramer_von_mises(dist, data):

--- a/scipy/stats/_fit.py
+++ b/scipy/stats/_fit.py
@@ -1251,7 +1251,7 @@ def _filliben(dist, data):
 
     # [7] Section 8 # 4
     return _corr(X, M)
-_filliben.alternative = 'less'  # type: ignore[<code>]
+_filliben.alternative = 'less'  # type: ignore[attr-defined]
 
 
 def _cramer_von_mises(dist, data):

--- a/scipy/stats/tests/test_fit.py
+++ b/scipy/stats/tests/test_fit.py
@@ -816,6 +816,74 @@ class TestGoodnessOfFit:
         assert_allclose(res.statistic, ref.critical_values[0])
         assert_allclose(res.pvalue, ref.significance_level[0]/100, atol=5e-3)
 
+    def test_against_filliben_norm(self):
+        # Test against `stats.fit` ref. [7] Section 8 "Example"
+        rng = np.random.default_rng(8024266430745011915)
+        y = [6, 1, -4, 8, -2, 5, 0]
+        known_params = {'loc': 0, 'scale': 1}
+        res = stats.goodness_of_fit(stats.norm, y, known_params=known_params,
+                                    statistic="filliben", random_state=rng)
+        # Slight discrepancy presumably due to roundoff in Filliben's
+        # calculation. Using exact order statistic medians instead of
+        # Filliben's approximation doesn't account for it.
+        assert_allclose(res.statistic, 0.98538, atol=1e-4)
+        assert 0.75 < res.pvalue < 0.9
+
+        # Using R's ppcc library:
+        # library(ppcc)
+        # options(digits=16)
+        # x < - c(6, 1, -4, 8, -2, 5, 0)
+        # set.seed(100)
+        # ppccTest(x, "qnorm", ppos="Filliben")
+        # Discrepancy with
+        assert_allclose(res.statistic, 0.98540957187084, rtol=2e-5)
+        assert_allclose(res.pvalue, 0.8875, rtol=2e-3)
+
+    def test_filliben_property(self):
+        # Filliben's statistic should be independent of data location and scale
+        rng = np.random.default_rng(8535677809395478813)
+        x = rng.normal(loc=10, scale=0.5, size=100)
+        res = stats.goodness_of_fit(stats.norm, x,
+                                    statistic="filliben", random_state=rng)
+        known_params = {'loc': 0, 'scale': 1}
+        ref = stats.goodness_of_fit(stats.norm, x, known_params=known_params,
+                                    statistic="filliben", random_state=rng)
+        assert_allclose(res.statistic, ref.statistic, rtol=1e-15)
+
+    @pytest.mark.parametrize('case', [(25, [.928, .937, .950, .958, .966]),
+                                      (50, [.959, .965, .972, .977, .981]),
+                                      (95, [.977, .979, .983, .986, .989])])
+    def test_against_filliben_norm_table(self, case):
+        # Test against `stats.fit` ref. [7] Table 1
+        rng = np.random.default_rng(504569995557928957)
+        n, ref = case
+        x = rng.random(n)
+        known_params = {'loc': 0, 'scale': 1}
+        res = stats.goodness_of_fit(stats.norm, x, known_params=known_params,
+                                    statistic="filliben", random_state=rng)
+        percentiles = np.array([0.005, 0.01, 0.025, 0.05, 0.1])
+        res = stats.scoreatpercentile(res.null_distribution, percentiles*100)
+        assert_allclose(res, ref, atol=2e-3)
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize('case', [(5, 0.95772790260469, 0.4755),
+                                      (6, 0.95398832257958, 0.3848),
+                                      (7, 0.9432692889277, 0.2328)])
+    def test_against_ppcc(self, case):
+        # Test against R ppcc, e.g.
+        # library(ppcc)
+        # options(digits=16)
+        # x < - c(0.52325412, 1.06907699, -0.36084066, 0.15305959, 0.99093194)
+        # set.seed(100)
+        # ppccTest(x, "qrayleigh", ppos="Filliben")
+        n, ref_statistic, ref_pvalue = case
+        rng = np.random.default_rng(7777775561439803116)
+        x = rng.normal(size=n)
+        res = stats.goodness_of_fit(stats.rayleigh, x, statistic="filliben",
+                                    random_state=rng)
+        assert_allclose(res.statistic, ref_statistic, rtol=1e-4)
+        assert_allclose(res.pvalue, ref_pvalue, atol=1.5e-2)
+
     def test_params_effects(self):
         # Ensure that `guessed_params`, `fit_params`, and `known_params` have
         # the intended effects.

--- a/scipy/stats/tests/test_fit.py
+++ b/scipy/stats/tests/test_fit.py
@@ -896,22 +896,22 @@ class TestGoodnessOfFit:
         assert_allclose(res[1], -0.297, atol=1e-3)
 
         # Reference values from Blom approximation as described in
-        # Royston, Patrick. "A pocket‐calculator algorithm for the
-        # Shapiro‐Francia test for non‐normality: An application to medicine."
+        # Royston, Patrick. "A pocket-calculator algorithm for the
+        # Shapiro-Francia test for non-normality: An application to medicine."
         # Statistics in medicine 12.2 (1993): 181-184.
         res = _fit._order_statistic_evs(stats.norm(), n=12)
         ref = [-1.6292, -1.1157, -0.7929, -0.5368, -0.3122, -0.1025]
         ref = ref + [-m for m in ref[::-1]]
-        assert_allclose(res, ref, atol=5e-3)
+        assert_allclose(res, ref, atol=1e-4)
 
     @pytest.mark.parametrize('case', [(5, [.6016, .6407, .6779, .7709]),
                                       (10, [.6794, .7390, .7698, .8425]),
                                       (20, [.7930, .8346, .8551, .9027])])
     def test_against_royston_table(self, case):
         # Reference values from Table 1 of
-        # Royston, J. P. "A Simple method for evaluating the shapiro–francia W'
-        # test of non-normality." Journal of the Royal Statistical Society:
-        # Seies D (The Statistician) 32.3 (1983) 297-300
+        # Royston, J. P. "A simple method for evaluating the Shapiro-Francia
+        # W' test of non-normality." Journal of the Royal Statistical Society:
+        # Series D (The Statistician) 32.3 (1983) 297-300
         rng = np.random.default_rng(2937432036923201836)
         n, ref = case
         x = rng.random(n)
@@ -937,7 +937,7 @@ class TestGoodnessOfFit:
         known_params = {'loc': 0, 'scale': 1}
         res = stats.goodness_of_fit(stats.norm, x, known_params=known_params,
                                     statistic="sf", random_state=rng)
-        assert_allclose(res.statistic, ref_statistic, atol=3e-3)
+        assert_allclose(res.statistic, ref_statistic, atol=2e-3)
         assert_allclose(res.pvalue, ref_pvalue, atol=1e-2)
 
     def test_params_effects(self):


### PR DESCRIPTION
#### Reference issue
Follow-up to gh-18102

#### What does this implement/fix?
Add's the Shapiro-Francia test for goodness of fit via `goodness_of_fit`.

The Shapiro-Francia statistic is the square of the product-moment correlation coefficient (Pearson's R) between the ordered data and the expected values of the order statistics of the null-hypothesized distribution. That is, it looks at the linear association of a Q-Q plot using the expected values of the order statistics as the plotting positions.

For tests of non-normality, it is comparable in power to Shapiro-Wilk, which is widely regarded to be the most powerful non-normality test.

#### Additional information
~~The first four commits are part of gh-18102, so they will disappear from this PR once that one merges. In the meantime, it is easier to look at just the [last two commits](https://github.com/scipy/scipy/pull/18113/files/731fef6cb03f2c12d7b9f6a81e2cbfe9fa64ffa7..5a7a5c9a3fc5ecf324df4d46e67e8f4eeb8509c5). I'll mark this as draft so that gh-18102 merges first.~~

Some of these goodness-of-fit tests are independent of location and scale, so `goodness_of_fit` could save a lot of work by assuming `loc=0, scale=1` in some cases. I'll need to take a closer look at this in a separate PR. In the meantime, the Shapiro-Francia statistic is only implemented when _all_ parameters are fixed by the user. The reason for separating this into another PR is that the changes will affect other statistics, not just Shapiro-Francia.