### PR TITLE
Correct the comments about ` fmin_powell` in `scipy/optimize`

### DIFF
--- a/doc/source/tutorial/examples/5-1
+++ b/doc/source/tutorial/examples/5-1
@@ -7,7 +7,7 @@ Optimization Tools
 
    fmin        --  Nelder-Mead Simplex algorithm
                      (uses only function calls)
-   fmin_powell --  Powell's (modified) level set method (uses only
+   fmin_powell --  Powell's (modified) conjugate direction method (uses only
                      function calls)
    fmin_cg     --  Non-linear (Polak-Ribiere) conjugate gradient algorithm
                      (can use function and gradient).

--- a/scipy/optimize/__init__.py
+++ b/scipy/optimize/__init__.py
@@ -339,7 +339,7 @@ General-purpose multivariate methods:
    :toctree: generated/
 
    fmin - Nelder-Mead Simplex algorithm.
-   fmin_powell - Powell's (modified) level set method.
+   fmin_powell - Powell's (modified) conjugate direction method.
    fmin_cg - Non-linear (Polak-Ribiere) conjugate gradient algorithm.
    fmin_bfgs - Quasi-Newton method (Broydon-Fletcher-Goldfarb-Shanno).
    fmin_ncg - Line-search Newton Conjugate Gradient.


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes [issue 18119](https://github.com/scipy/scipy/issues/18119).

#### What does this implement/fix?
<!--Please explain your changes.-->
I corrected the comment on [`fmin_powell` under `optimize`](https://github.com/scipy/scipy/blob/main/scipy/optimize/_optimize.py).

#### Additional information
<!--Any additional information you think is important.-->
As far as I understand, [fmin_powell under optimize](https://github.com/scipy/scipy/blob/main/scipy/optimize/_optimize.py) implements a [modified version](http://www.it.uom.gr/teaching/linearalgebra/NumericalRecipiesInC/c10-5.pdf) of [Powell's conjugate direction method](https://en.wikipedia.org/wiki/Powell%27s_method). Published in 1964, it was Professor Powell's second published work on optimization, and also the second most cited work (the first and meanwhile most cited is his paper on the DFP algorithm, co-authored with late Professor Roger Fletcher FRS). See historical remarks in [Section 3 and footnote 6 of our paper](https://arxiv.org/pdf/2302.13246.pdf) on [PDFO](HTTP://www.pdfo.net).

The [comment in scipy/scipy/optimize/init.py](https://github.com/scipy/scipy/blob/81f84c818455256a08a21ee921209bde2fe91ab2/scipy/optimize/__init__.py#L342) is incorrect: it says “fmin_powell - Powell's (modified) level set method”, but there is no such thing as "Powell's (modified) level set method". As mentioned, it is indeed "Powell's (modified) conjugate direction method".

The word "level set" probably came from a miscopying / misreading / misunderstanding of the word ["Direction Set (Powell’s) Methods" in Numerical Recipies](http://www.it.uom.gr/teaching/linearalgebra/NumericalRecipiesInC/c10-5.pdf). Here, "Direction Set" refers to the set of conjugate directions generated by the algorithm. However, "[Powell's conjugate direction method](https://www.google.com/search?q=Powell%27s+conjugate+direction+method)" is a much more used name --- I have never heard anybody from the optimization community calling it a "Direction Set" method.

Fore more information, see [Powell's paper](https://academic.oup.com/comjnl/article-abstract/7/2/155/335330?redirectedFrom=fulltext&login=false), [the corresponding chapter in Numerical Recipies](http://www.it.uom.gr/teaching/linearalgebra/NumericalRecipiesInC/c10-5.pdf), and [the Wikipedia page of the method](https://en.wikipedia.org/wiki/Powell%27s_method).

Thanks.