### PR TITLE
BUG: sparse: Use _ascontainer for argmin/argmax

### DIFF
--- a/scipy/sparse/_data.py
+++ b/scipy/sparse/_data.py
@@ -250,7 +250,7 @@ class _minmax_mixin:
         if axis == 1:
             ret = ret.reshape(-1, 1)
 
-        return matrix(ret)
+        return self._ascontainer(ret)
 
     def _arg_min_or_max(self, axis, out, op, compare):
         if out is not None:

--- a/scipy/sparse/_data.py
+++ b/scipy/sparse/_data.py
@@ -9,7 +9,7 @@
 import numpy as np
 
 from ._base import spmatrix, _ufuncs_with_fixed_point_at_zero
-from ._sputils import isscalarlike, validateaxis, matrix
+from ._sputils import isscalarlike, validateaxis
 
 __all__ = []
 

--- a/scipy/sparse/tests/test_array_api.py
+++ b/scipy/sparse/tests/test_array_api.py
@@ -60,14 +60,19 @@ def test_mean(A):
 
 @parametrize_sparrays
 def test_min_max(A):
-    assert not isinstance(A.min(axis=1), np.matrix), \
-        "Expected array, got matrix"
-    assert not isinstance(A.max(axis=1), np.matrix), \
-        "Expected array, got matrix"
-    assert not isinstance(A.argmin(axis=1), np.matrix), \
-        "Expected array, got matrix"
-    assert not isinstance(A.argmax(axis=1), np.matrix), \
-        "Expected array, got matrix"
+    # Some formats don't support min/max operations, so we skip those here.
+    if hasattr(A, 'min'):
+        assert not isinstance(A.min(axis=1), np.matrix), \
+            "Expected array, got matrix"
+    if hasattr(A, 'max'):
+        assert not isinstance(A.max(axis=1), np.matrix), \
+            "Expected array, got matrix"
+    if hasattr(A, 'argmin'):
+        assert not isinstance(A.argmin(axis=1), np.matrix), \
+            "Expected array, got matrix"
+    if hasattr(A, 'argmax'):
+        assert not isinstance(A.argmax(axis=1), np.matrix), \
+            "Expected array, got matrix"
 
 
 @parametrize_sparrays

--- a/scipy/sparse/tests/test_array_api.py
+++ b/scipy/sparse/tests/test_array_api.py
@@ -59,6 +59,18 @@ def test_mean(A):
 
 
 @parametrize_sparrays
+def test_min_max(A):
+    assert not isinstance(A.min(axis=1), np.matrix), \
+        "Expected array, got matrix"
+    assert not isinstance(A.max(axis=1), np.matrix), \
+        "Expected array, got matrix"
+    assert not isinstance(A.argmin(axis=1), np.matrix), \
+        "Expected array, got matrix"
+    assert not isinstance(A.argmax(axis=1), np.matrix), \
+        "Expected array, got matrix"
+
+
+@parametrize_sparrays
 def test_todense(A):
     assert not isinstance(A.todense(), np.matrix), \
         "Expected array, got matrix"


### PR DESCRIPTION
#### Reference issue
Fixes gh-18111

#### What does this implement/fix?
The current implementation of sparse arrays relies on the use of `_container` and `_ascontainer` classmethods to dispatch to the correct output type when returning dense results. In this case, we'd overlooked a callsite that was unconditionally invoking `np.matrix`.