### PR TITLE
MAINT: correctly forward-declare `print_soln` in SuperLU

### DIFF
--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/cgstrs.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/cgstrs.c
@@ -120,7 +120,7 @@ cgstrs (trans_t trans, SuperMatrix *L, SuperMatrix *U,
     int      i, j, k, iptr, jcol, n, ldb, nrhs;
     complex   *work, *rhs_work, *soln;
     flops_t  solve_ops;
-    void cprint_soln();
+    void cprint_soln(int n, int nrhs, complex *soln);
 
     /* Test input parameters ... */
     *info = 0;

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/dgstrs.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/dgstrs.c
@@ -119,7 +119,7 @@ dgstrs (trans_t trans, SuperMatrix *L, SuperMatrix *U,
     int      i, j, k, iptr, jcol, n, ldb, nrhs;
     double   *work, *rhs_work, *soln;
     flops_t  solve_ops;
-    void dprint_soln();
+    void dprint_soln(int n, int nrhs, double *soln);
 
     /* Test input parameters ... */
     *info = 0;

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/sgstrs.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/sgstrs.c
@@ -119,8 +119,7 @@ sgstrs (trans_t trans, SuperMatrix *L, SuperMatrix *U,
     int      i, j, k, iptr, jcol, n, ldb, nrhs;
     float   *work, *rhs_work, *soln;
     flops_t  solve_ops;
-    void sprint_soln();
-
+    void sprint_soln(int n, int nrhs, float *soln);
     /* Test input parameters ... */
     *info = 0;
     Bstore = B->Store;

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zgstrs.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zgstrs.c
@@ -120,8 +120,7 @@ zgstrs (trans_t trans, SuperMatrix *L, SuperMatrix *U,
     int      i, j, k, iptr, jcol, n, ldb, nrhs;
     doublecomplex   *work, *rhs_work, *soln;
     flops_t  solve_ops;
-    void zprint_soln();
-
+    void zprint_soln(int n, int nrhs, doublecomplex *soln);
     /* Test input parameters ... */
     *info = 0;
     Bstore = B->Store;


### PR DESCRIPTION
In `<cdsz>gstrs.c`, `print_soln` is forward declared like `void cprint_soln();` using the old style C declarations that are allowed to be vague about the argument specification. This fixes it to forward declare with an explicit signature.