### PR TITLE
MAINT: add test against generic fit method for vonmises distribution

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -9613,13 +9613,15 @@ class vonmises_gen(rv_continuous):
         def find_mu(data):
             return stats.circmean(data)
 
-        def find_kappa(data):
-            # kappa is the solution to
-            # r = I[1](kappa)/I[0](kappa)
-            #   = I[1](kappa) * exp(-kappa)/(I[0](kappa) * exp(-kappa))
-            #   = sc.i1e(kappa)/sc.i0e(kappa)
-            # where r = mean resultant length
-            r = 1 - stats.circvar(data)
+        def find_kappa(data, loc):
+            # Usually, sources list the following as the equation to solve for
+            # the MLE of the shape parameter:
+            # r = I[1](kappa)/I[0](kappa), where r = mean resultant length
+            # This is valid when the location is the MLE of location.
+            # More generally, when the location may be fixed at an arbitrary
+            # value, r should be defined as follows:
+            r = np.sum(np.cos(loc - data))/len(data)
+            # See gh-18128 for more information.
 
             def solve_for_kappa(kappa):
                 return sc.i1e(kappa)/sc.i0e(kappa) - r
@@ -9628,14 +9630,13 @@ class vonmises_gen(rv_continuous):
                                    bracket=(1e-8, 1e12))
             return root_res.root
 
-        if floc is None:
-            floc = find_mu(data)
-            fshape = find_kappa(data)
-        else:
-            fshape = find_kappa(data)
+        # location likelihood equation has a solution independent of kappa
+        loc = floc if floc is not None else find_mu(data)
+        # shape likelihood equation depends on location
+        shape = fshape if fshape is not None else find_kappa(data, loc)
 
-        floc = np.mod(floc + np.pi, 2 * np.pi) - np.pi  # ensure in [-pi, pi]
-        return fshape, floc, 1  # scale is not handled
+        loc = np.mod(loc + np.pi, 2 * np.pi) - np.pi  # ensure in [-pi, pi]
+        return shape, loc, 1  # scale is not handled
 
 
 vonmises = vonmises_gen(name='vonmises')

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -198,6 +198,28 @@ class TestVonMises:
         assert_allclose(np.angle(res), loc % (2*np.pi))
         assert np.issubdtype(res.dtype, np.complexfloating)
 
+    @pytest.mark.parametrize("rvs_loc", [0, 2])
+    @pytest.mark.parametrize("rvs_scale", [1, 100])
+    @pytest.mark.parametrize('fix_loc', [True, False])
+    def test_fit_MLE_comp_optimzer(self, rvs_loc, rvs_scale,
+                                   fix_loc):
+
+        rng = np.random.default_rng(6762668991392531563)
+        data = stats.vonmises.rvs(rvs_scale, size=1000, loc=rvs_loc,
+                                  random_state=rng)
+
+        def negative_loglikelihood(fit_result, data):
+            kappa, loc, scale = fit_result
+            logpdf = stats.vonmises(kappa, loc=loc).logpdf(data).sum()
+            return -logpdf
+
+        kwds = {}
+        if fix_loc:
+            kwds['floc'] = rvs_loc
+
+        _assert_less_or_close_loglike(stats.vonmises, data,
+                                      negative_loglikelihood, **kwds)
+
     @pytest.mark.parametrize('loc', [-0.5 * np.pi, 0, np.pi])
     @pytest.mark.parametrize('kappa', [1, 10, 100, 1000])
     def test_vonmises_fit_all(self, kappa, loc):


### PR DESCRIPTION
#### Reference issue
Follow-up of #18013

#### What does this implement/fix?
In #18013, an additional test was requested to to compare the overwritten fit method of the vonmises distribution with the generic one. THis adds that.

#### Additional information
With this, the tests for von mises take 5.5 seconds on my machine. I think marking the new tests as slow when the PR is accepted would be a good choice to save a little on CI.

I did not fully understand the `_assert_less_or_close_loglike` machinery, that's why I ended up implementing the log likelihood function as the criterion. The methods used for the other distributions did not work, probably because `_fitstart` does not exist for vonmises.