### PR TITLE
ENH: stats.ecdf: add `confidence_interval` methods

### DIFF
--- a/scipy/stats/_result_classes.py
+++ b/scipy/stats/_result_classes.py
@@ -18,12 +18,14 @@ Result classes
    FitResult
    OddsRatioResult
    TtestResult
+   ECDFResult
+   EmpiricalDistributionFunction
 
 """
 
 __all__ = ['BinomTestResult', 'RelativeRiskResult', 'TukeyHSDResult',
            'PearsonRResult', 'FitResult', 'OddsRatioResult',
-           'TtestResult']
+           'TtestResult', 'ECDFResult', 'EmpiricalDistributionFunction']
 
 
 from ._binomtest import BinomTestResult
@@ -32,3 +34,4 @@ from ._relative_risk import RelativeRiskResult
 from ._hypotests import TukeyHSDResult
 from ._stats_py import PearsonRResult, TtestResult
 from ._fit import FitResult
+from ._survival import ECDFResult, EmpiricalDistributionFunction

--- a/scipy/stats/_survival.py
+++ b/scipy/stats/_survival.py
@@ -1,9 +1,9 @@
+import warnings
 from dataclasses import dataclass, field
 import numpy as np
-from ._censored_data import CensoredData
 from scipy import special
-from ._common import ConfidenceInterval
-import warnings
+from scipy.stats._censored_data import CensoredData
+from scipy.stats._common import ConfidenceInterval
 
 
 __all__ = ['ecdf']

--- a/scipy/stats/_survival.py
+++ b/scipy/stats/_survival.py
@@ -99,6 +99,8 @@ def ecdf(sample):
     For right-censored data, the ECDF is given by the Kaplan-Meier estimator
     [2]_; other forms of censoring are not supported at this time.
 
+    Confidence intervals are computed according to the Greenwood formula [4]_.
+
     References
     ----------
     .. [1] Conover, William Jay. Practical nonparametric statistics. Vol. 350.
@@ -111,6 +113,10 @@ def ecdf(sample):
     .. [3] Goel, Manish Kumar, Pardeep Khanna, and Jugal Kishore.
            "Understanding survival analysis: Kaplan-Meier estimate."
            International journal of Ayurveda research 1.4 (2010): 274.
+
+    .. [4] Sawyer, Stanley. "The Greenwood and Exponential Greenwood Confidence
+           Intervals in Survival Analysis."
+           https://www.math.wustl.edu/~sawyer/handouts/greenwood.pdf
 
     Examples
     --------

--- a/scipy/stats/_survival.py
+++ b/scipy/stats/_survival.py
@@ -35,7 +35,7 @@ class EmpiricalDistributionFunction:
         self._sf = points if kind == 'sf' else 1 - points
         self._kind = kind
 
-    def confidence_interval(self, confidence_level=0.95, method='linear'):
+    def confidence_interval(self, confidence_level=0.95, *, method='linear'):
         """Compute a confidence interval around the CDF/SF point estimate
 
         Parameters

--- a/scipy/stats/tests/test_survival.py
+++ b/scipy/stats/tests/test_survival.py
@@ -107,24 +107,6 @@ class TestSurvival:
         assert_equal(res.cdf.points, ref_cdf)
         assert_equal(res.sf.points, ref_sf)
 
-    def test_call_methods(self):
-        # Test CDF and SF call methods
-        rng = np.random.default_rng(1162729143302572461)
-        sample, _, _ = self.get_random_sample(rng, 15)
-        res = stats.ecdf(sample)
-        x = res.x
-        xr = res.x + np.diff(res.x, append=x[-1]+1)/2  # right shifted points
-
-        assert_equal(res.cdf(x), res.cdf.points)
-        assert_equal(res.cdf(xr), res.cdf.points)
-        assert_equal(res.cdf(x[0]-1), 0)  # CDF starts at 0
-        assert_equal(res.cdf([-np.inf, np.inf]), [0, 1])
-
-        assert_equal(res.sf(x), res.sf.points)
-        assert_equal(res.sf(xr), res.sf.points)
-        assert_equal(res.sf(x[0]-1), 1)  # CDF starts at 1
-        assert_equal(res.sf([-np.inf, np.inf]), [1, 0])
-
     # ref. [1] page 91
     t1 = [37, 43, 47, 56, 60, 62, 71, 77, 80, 81]  # times
     d1 = [0, 0, 1, 1, 0, 0, 0, 1, 1, 1]  # 1 means deaths (not censored)
@@ -215,8 +197,8 @@ class TestSurvival:
         upper = np.array([0.991983, 0.970995, 0.87378, 0.739467, 0.739467,
                           0.739467, 0.603133, 0.430365, 0.430365, 0.430365])
 
-        sf_ci = res.sf.confidence_interval(method='exponential greenwood')
-        cdf_ci = res.cdf.confidence_interval(method='exponential greenwood')
+        sf_ci = res.sf.confidence_interval(method='log-log')
+        cdf_ci = res.cdf.confidence_interval(method='log-log')
 
         assert_allclose(sf_ci.low, lower, atol=1e-5)
         assert_allclose(sf_ci.high, upper, atol=1e-5)

--- a/scipy/stats/tests/test_survival.py
+++ b/scipy/stats/tests/test_survival.py
@@ -54,11 +54,11 @@ class TestSurvival:
     def test_edge_cases(self):
         res = stats.ecdf([])
         assert_equal(res.x, [])
-        assert_equal(res.cdf, [])
+        assert_equal(res.cdf.value, [])
 
         res = stats.ecdf([1])
         assert_equal(res.x, [1])
-        assert_equal(res.cdf, [1])
+        assert_equal(res.cdf.value, [1])
 
     def test_unique(self):
         # Example with unique observations; `stats.ecdf` ref. [1] page 80
@@ -68,8 +68,8 @@ class TestSurvival:
         ref_cdf = np.arange(1, 6) / 5
         ref_sf = 1 - ref_cdf
         assert_equal(res.x, ref_x)
-        assert_equal(res.cdf, ref_cdf)
-        assert_equal(res.sf, ref_sf)
+        assert_equal(res.cdf.value, ref_cdf)
+        assert_equal(res.sf.value, ref_sf)
 
     def test_nonunique(self):
         # Example with non-unique observations; `stats.ecdf` ref. [1] page 82
@@ -79,8 +79,8 @@ class TestSurvival:
         ref_cdf = np.array([1/6, 2/6, 4/6, 5/6, 1])
         ref_sf = 1 - ref_cdf
         assert_equal(res.x, ref_x)
-        assert_equal(res.cdf, ref_cdf)
-        assert_equal(res.sf, ref_sf)
+        assert_equal(res.cdf.value, ref_cdf)
+        assert_equal(res.sf.value, ref_sf)
 
     # ref. [1] page 91
     t1 = [37, 43, 47, 56, 60, 62, 71, 77, 80, 81]  # times
@@ -113,7 +113,7 @@ class TestSurvival:
         times, died, ref = case
         sample = stats.CensoredData.right_censored(times, np.logical_not(died))
         res = stats.ecdf(sample)
-        assert_allclose(res.sf, ref, atol=1e-3)
+        assert_allclose(res.sf.value, ref, atol=1e-3)
         assert_equal(res.x, np.sort(np.unique(times)))
 
         # test reference implementation
@@ -136,13 +136,13 @@ class TestSurvival:
         res = stats.ecdf(sample)
         ref = _kaplan_meier_reference(times, censored)
         assert_allclose(res.x, ref[0])
-        assert_allclose(res.sf, ref[1])
+        assert_allclose(res.sf.value, ref[1])
 
         # If all observations are uncensored, the KM estimate should match
         # the usual estimate for uncensored data
         sample = stats.CensoredData(uncensored=times)
         res = _survival._ecdf_right_censored(sample)  # force Kaplan-Meier
         ref = stats.ecdf(times)
-        assert_equal(res.x, ref.x)
-        assert_allclose(res.cdf, ref.cdf, rtol=1e-14)
-        assert_allclose(res.sf, ref.sf, rtol=1e-14)
+        assert_equal(res[0], ref.x)
+        assert_allclose(res[1], ref.cdf.value, rtol=1e-14)
+        assert_allclose(res[2], ref.sf.value, rtol=1e-14)


### PR DESCRIPTION
#### Reference issue
Follow-up to gh-18092

#### What does this implement/fix?
This adds confidence intervals for the CDF/SF estimated by `stats.ecdf`.

```python3
import numpy as np
from scipy import stats
import matplotlib.pyplot as plt

# Enter censored data
times = [24, 3, 11, 19, 24, 13, 14, 2, 18, 17, 24, 21, 12, 1, 10, 23, 6, 5, 9, 17]
died = [0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 1]
sample = stats.CensoredData.right_censored(times, np.logical_not(died))

# Generate point estimate and confidence interval of the survival function
res = stats.ecdf(sample)
point_estimate = res.sf.points
ci = res.sf.confidence_interval(0.90)

# plotting
ax = plt.subplot()
x = np.insert(res.x, 0, 0)  # plots look better when a leftmost point is added
ax.step(x, np.insert(point_estimate, 0, 1), color='C0', where='post')
ax.step(x, np.insert(ci.low, 0, 1), color='C0', linestyle='dashed', where='post')
ax.step(x, np.insert(ci.high, 0, 1),  color='C0', linestyle='dashed', where='post')
ax.set_xlabel("time")
ax.set_ylabel("survival function")
ax.set_title("Survival function point estimate and 90% CI")
plt.show()
```
![image](https://user-images.githubusercontent.com/6570539/224517524-c029f69d-8036-4c72-b40d-c0476b1da3eb.png)


#### Additional information
~~Other confidence interval methods can/will be added in follow-up PRs.~~ The default CI implemented here is the oldest and most common, and it's the one Matlab uses. Another, more modern method is also included.

I didn't add an example because the existing data yields NaNs in the variance calculation (correctly). I plan to substantially revise the example in a follow-up, at which point I'll show how to use the `confidence_interval` method.

~~Because this makes the `cdf` and `sf` attributes objects (instead of arrays), these objects can easily be endowed with `__call__` methods that evaluate the ECDF/ESF at user-specified points. This will respond to requests from the original PR.~~ Done. Should the upper and lower confidence intervals be objects with `__call__` methods, too?

Perhaps we should remove the `points` attributes of the `EmpiricalDistributionFunction` objects after all? The user can recover the points using the `__call__` method at the `ECDFResult` points `x`.

We've discussed that it's weird that `stats.ecdf` returns an object with an attribute `sf`. What about renaming `stats.ecdf` to something like `stats.nonparametric_fit`, and `ECDFResult` would become `NonparametricFitResult`? Ultimately, these classes should be documented on their own like [`FitResult`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats._result_classes.FitResult.html#scipy.stats._result_classes.FitResult) is.

Matlab returns confidence intervals in which the first value as NaN, even though that is not produced by Greenwood's formula. Intuitively, this makes some sense, but I'd like to check against some other references before I implement this. Also, Matlab returns NaNs in the confidence intervals, but arguably `[0, 1]` could be used instead of `[np.nan, np.nan]`.

To do?:
- [ ] ~~See what R does when we/Matlab produce NaNs~~ We agree with R survival survfit. Mathematica agrees with Matlab. Lifelines never seems to produce NaNs.
- [ ] Add other confidence interval `method`s
- [ ] Replace example
- [ ] Email about additional interface changes
- [ ] Add `__call__` methods to `cdf`/`sf`
- [ ] Add `__call__` methods to `low`/`high` ends of confidence interval?
- [ ] Rename `ecdf` to `nonparametric_fit`?
- [ ] Remove `points` attributes of `cdf`/`sf`?