### PR TITLE
MAINT:linalg: Empty array argument support 

### DIFF
--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1019,6 +1019,11 @@ def det(a, overwrite_a=False, check_finite=True):
 
     """
     a1 = _asarray_validated(a, check_finite=check_finite)
+     
+    # handle empty array, determinate of empty array (identity array) is 1.
+    if a1.size == 0:
+        return 1
+
     if len(a1.shape) != 2 or a1.shape[0] != a1.shape[1]:
         raise ValueError('expected square matrix')
     overwrite_a = overwrite_a or _datacopied(a1, a)

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -931,6 +931,11 @@ def inv(a, overwrite_a=False, check_finite=True):
     a1 = _asarray_validated(a, check_finite=check_finite)
     if len(a1.shape) != 2 or a1.shape[0] != a1.shape[1]:
         raise ValueError('expected square matrix')
+
+    # accomadate empty arrays
+    if a1.size == 0:
+        return np.asfortranarray(a.copy())
+
     overwrite_a = overwrite_a or _datacopied(a1, a)
     # XXX: I found no advantage or disadvantage of using finv.
 #     finv, = get_flinalg_funcs(('inv',),(a1,))

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1022,7 +1022,7 @@ def det(a, overwrite_a=False, check_finite=True):
      
     # handle empty array, determinate of empty array (identity array) is 1.
     if a1.size == 0:
-        return 1
+        return 1.0
 
     if len(a1.shape) != 2 or a1.shape[0] != a1.shape[1]:
         raise ValueError('expected square matrix')

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -932,9 +932,9 @@ def inv(a, overwrite_a=False, check_finite=True):
     if len(a1.shape) != 2 or a1.shape[0] != a1.shape[1]:
         raise ValueError('expected square matrix')
 
-    # accomadate empty arrays
+    # accommodate empty square matrices
     if a1.size == 0:
-        return np.asfortranarray(a.copy())
+        return a1.copy()
 
     overwrite_a = overwrite_a or _datacopied(a1, a)
     # XXX: I found no advantage or disadvantage of using finv.
@@ -1020,7 +1020,8 @@ def det(a, overwrite_a=False, check_finite=True):
     """
     a1 = _asarray_validated(a, check_finite=check_finite)
      
-    # handle empty array, determinate of empty array (identity array) is 1.
+    # accommodate square empty matrix, determinate of empty matrix is 1.
+    # See: https://www.researchgate.net/publication/234783851_An_empty_exercise
     if a1.size == 0:
         return 1.0
 
@@ -1358,9 +1359,9 @@ def pinv(a, atol=None, rtol=None, return_rank=False, check_finite=True,
     """
     a = _asarray_validated(a, check_finite=check_finite)
 
-    # accomadate empty arrays
+    # accommodate empty matrices
     if a.size == 0:
-        return np.asfortranarray(a.copy())
+        return a.copy()
 
     u, s, vh = _decomp_svd.svd(a, full_matrices=False, check_finite=False)
     t = u.dtype.char.lower()

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1357,6 +1357,11 @@ def pinv(a, atol=None, rtol=None, return_rank=False, check_finite=True,
 
     """
     a = _asarray_validated(a, check_finite=check_finite)
+
+    # accomadate empty arrays
+    if a.size == 0:
+        return np.asfortranarray(a.copy())
+
     u, s, vh = _decomp_svd.svd(a, full_matrices=False, check_finite=False)
     t = u.dtype.char.lower()
     maxS = np.max(s)

--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -214,9 +214,9 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
     if len(a1.shape) != 2 or a1.shape[0] != a1.shape[1]:
         raise ValueError('expected square matrix')
 
-    # Quick return for square empty matrix
+    # accommodate square empty matrix
     if a1.size == 0:
-        return a1.copy()
+        return (numpy.array([]), a1.copy())
 
     overwrite_a = overwrite_a or (_datacopied(a1, a))
     if b is not None:
@@ -466,9 +466,9 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
     if len(a1.shape) != 2 or a1.shape[0] != a1.shape[1]:
         raise ValueError('expected square "a" matrix')
 
-    # Quick return for square empty matrix
+    # accommodate square empty matrix
     if a1.size == 0:
-        return a1.copy()
+        return (numpy.array([]), a1.copy())
 
     overwrite_a = overwrite_a or (_datacopied(a1, a))
     cplx = True if iscomplexobj(a1) else False

--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -213,6 +213,11 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
     a1 = _asarray_validated(a, check_finite=check_finite)
     if len(a1.shape) != 2 or a1.shape[0] != a1.shape[1]:
         raise ValueError('expected square matrix')
+
+    # Quick return for square empty matrix
+    if a1.size == 0:
+        return a1.copy()
+
     overwrite_a = overwrite_a or (_datacopied(a1, a))
     if b is not None:
         b1 = _asarray_validated(b, check_finite=check_finite)
@@ -460,6 +465,11 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
     a1 = _asarray_validated(a, check_finite=check_finite)
     if len(a1.shape) != 2 or a1.shape[0] != a1.shape[1]:
         raise ValueError('expected square "a" matrix')
+
+    # Quick return for square empty matrix
+    if a1.size == 0:
+        return a1.copy()
+
     overwrite_a = overwrite_a or (_datacopied(a1, a))
     cplx = True if iscomplexobj(a1) else False
     n = a1.shape[0]

--- a/scipy/linalg/_decomp_qr.py
+++ b/scipy/linalg/_decomp_qr.py
@@ -130,6 +130,11 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False,
         a1 = numpy.asarray(a)
     if len(a1.shape) != 2:
         raise ValueError("expected a 2-D array")
+    
+    # Quick return for square empty array
+    if a1.size == 0:
+        return a1.copy()
+
     M, N = a1.shape
     overwrite_a = overwrite_a or (_datacopied(a1, a))
 

--- a/scipy/linalg/_decomp_qr.py
+++ b/scipy/linalg/_decomp_qr.py
@@ -131,9 +131,9 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False,
     if len(a1.shape) != 2:
         raise ValueError("expected a 2-D array")
     
-    # Quick return for square empty array
+    # accommodate square empty matrix
     if a1.size == 0:
-        return a1.copy()
+        return (a1.copy(), a1.copy())
 
     M, N = a1.shape
     overwrite_a = overwrite_a or (_datacopied(a1, a))

--- a/scipy/linalg/_decomp_svd.py
+++ b/scipy/linalg/_decomp_svd.py
@@ -109,7 +109,7 @@ def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False,
     if len(a1.shape) != 2:
         raise ValueError('expected matrix')
 
-    # Quick return for square empty array
+    # accommodate square empty matrix
     if a1.size == 0:
         return a1.copy()
 

--- a/scipy/linalg/_decomp_svd.py
+++ b/scipy/linalg/_decomp_svd.py
@@ -108,6 +108,11 @@ def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False,
     a1 = _asarray_validated(a, check_finite=check_finite)
     if len(a1.shape) != 2:
         raise ValueError('expected matrix')
+
+    # Quick return for square empty array
+    if a1.size == 0:
+        return a1.copy()
+
     m, n = a1.shape
     overwrite_a = overwrite_a or (_datacopied(a1, a))
 

--- a/scipy/linalg/_special_matrices.py
+++ b/scipy/linalg/_special_matrices.py
@@ -477,6 +477,11 @@ def kron(a, b):
            [3, 3, 3, 4, 4, 4]])
 
     """
+    # accommodate empty arrays
+    if a.size == 0:
+        return a.copy()
+    if b.size == 0:
+        return a.copy()
     if not a.flags['CONTIGUOUS']:
         a = np.reshape(a, a.shape)
     if not b.flags['CONTIGUOUS']:

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -1358,7 +1358,7 @@ class TestPinv:
 
     def test_empty(self):
         a = np.array([]).reshape((0,0))
-        a_empty = inv(a)
+        a_empty = pinv(a)
         assert_allclose(a_empty, a)
 
 

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -1356,6 +1356,11 @@ class TestPinv:
         assert_allclose(np.linalg.norm(adiff1), 4.233, rtol=0.01)
         assert_allclose(np.linalg.norm(adiff2), 4.233, rtol=0.01)
 
+    def test_empty(self):
+        a = np.array([]).reshape((0,0))
+        a_empty = inv(a)
+        assert_allclose(a_empty, a)
+
 
 class TestPinvSymmetric:
 

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -931,7 +931,7 @@ class TestInv:
     def test_empty(self):
         a = np.array([]).reshape((0,0))
         a_empty = inv(a)
-        assert_equal(a_empty, [])
+        assert_array_almost_equal(a_empty, a)
 
 class TestDet:
     def setup_method(self):
@@ -973,7 +973,7 @@ class TestDet:
     def test_empty(self):
         a = np.array([]).reshape((0,0))
         a_empty = det(a)
-        assert_equal(a_empty, 1)
+        assert_array_almost_equal(a_empty, 1)
 
 
 def direct_lstsq(a, b, cmplx=0):

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -931,7 +931,7 @@ class TestInv:
     def test_empty(self):
         a = np.array([]).reshape((0,0))
         a_empty = inv(a)
-        assert_array_almost_equal(a_empty, a)
+        assert_allclose(a_empty, a)
 
 class TestDet:
     def setup_method(self):
@@ -973,7 +973,7 @@ class TestDet:
     def test_empty(self):
         a = np.array([]).reshape((0,0))
         a_empty = det(a)
-        assert_array_almost_equal(a_empty, 1)
+        assert_allclose(a_empty, 1)
 
 
 def direct_lstsq(a, b, cmplx=0):

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -928,6 +928,10 @@ class TestInv:
         a_inv = inv(a, check_finite=False)
         assert_array_almost_equal(dot(a, a_inv), [[1, 0], [0, 1]])
 
+    def test_empty(self):
+        a = np.array([]).reshape((0,0))
+        a_empty = inv(a)
+        assert_equal(a_empty, [])
 
 class TestDet:
     def setup_method(self):
@@ -965,6 +969,11 @@ class TestDet:
         a = [[1, 2], [3, 4]]
         a_det = det(a, check_finite=False)
         assert_almost_equal(a_det, -2.0)
+
+    def test_empty(self):
+        a = np.array([]).reshape((0,0))
+        a_empty = det(a)
+        assert_equal(a_empty, 1)
 
 
 def direct_lstsq(a, b, cmplx=0):

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -13,6 +13,7 @@ import platform
 import sys
 
 import numpy as np
+
 from numpy.testing import (assert_equal, assert_almost_equal,
                            assert_array_almost_equal, assert_array_equal,
                            assert_, assert_allclose)
@@ -147,8 +148,9 @@ class TestEigVals:
 
     def test_empty(self):
         a = np.array([]).reshape((0,0))
-        a_empty = eig(a)
-        assert_allclose(a_empty, a)
+        b = np.array([])
+        a_empty = eigvals(a)
+        assert_equal(a_empty, (b,a))
 
 
 class TestEig:
@@ -370,8 +372,9 @@ class TestEig:
 
     def test_empty(self):
         a = np.array([]).reshape((0,0))
+        b = np.array([])
         a_empty = eig(a)
-        assert_allclose(a_empty, a)
+        assert_equal(a_empty, (b,a))
 
 
 class TestEigBanded:
@@ -924,8 +927,11 @@ class TestEigh:
 
     def test_empty(self):
         a = np.array([]).reshape((0,0))
-        a_empty = eig(a)
-        assert_allclose(a_empty, a)
+        b = np.array([])
+        goal = (b,a)
+        a_empty = eigh(a)
+        for i in range(len(a_empty)):
+            assert_allclose(a_empty[i], goal[i])
 
 
 class TestLU:
@@ -1216,8 +1222,12 @@ class TestSVD_GESDD:
 
     def test_empty(self):
         a = np.array([]).reshape((0,0))
+        b = np.array([])
+        goal = (a,b,a)
         a_empty = svd(a)
-        assert_allclose(a_empty, a)
+        for i in range(len(a_empty)):
+            assert_allclose(a_empty[i], goal[i])
+
 
 
 class TestSVD_GESVD(TestSVD_GESDD):
@@ -1831,10 +1841,10 @@ class TestQR:
         assert_raises(Exception, qr, (a,), {'lwork': 0})
         assert_raises(Exception, qr, (a,), {'lwork': 2})
 
-    def test_empty(self):
+    def test_empty_matrix(self):
         a = np.array([]).reshape((0,0))
         a_empty = qr(a)
-        assert_allclose(a_empty, a)
+        assert_allclose(a_empty, (a,a))
 
 
 class TestRQ:

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -1816,6 +1816,11 @@ class TestQR:
         assert_raises(Exception, qr, (a,), {'lwork': 0})
         assert_raises(Exception, qr, (a,), {'lwork': 2})
 
+    def test_empty(self):
+        a = np.array([]).reshape((0,0))
+        a_empty = qr(a)
+        assert_allclose(a_empty, a)
+
 
 class TestRQ:
 

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -145,6 +145,11 @@ class TestEigVals:
         exact_w = [(9+sqrt(93))/2, 0, (9-sqrt(93))/2]
         assert_array_almost_equal(w, exact_w)
 
+    def test_empty(self):
+        a = np.array([]).reshape((0,0))
+        a_empty = eig(a)
+        assert_allclose(a_empty, a)
+
 
 class TestEig:
 
@@ -362,6 +367,11 @@ class TestEig:
         B = np.arange(9.0).reshape(3, 3)
         assert_raises(ValueError, eig, A, B)
         assert_raises(ValueError, eig, B, A)
+
+    def test_empty(self):
+        a = np.array([]).reshape((0,0))
+        a_empty = eig(a)
+        assert_allclose(a_empty, a)
 
 
 class TestEigBanded:
@@ -911,6 +921,11 @@ class TestEigh:
         w, v = eigh(a, subset_by_index=[0, 1])
         assert_allclose(w_dep, w)
         assert_allclose(v_dep, v)
+
+    def test_empty(self):
+        a = np.array([]).reshape((0,0))
+        a_empty = eig(a)
+        assert_allclose(a_empty, a)
 
 
 class TestLU:

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -1199,6 +1199,11 @@ class TestSVD_GESDD:
         assert_allclose(s[0], 1.0)
         assert_allclose(u[0, 0] * vh[0, -1], 1.0)
 
+    def test_empty(self):
+        a = np.array([]).reshape((0,0))
+        a_empty = svd(a)
+        assert_allclose(a_empty, a)
+
 
 class TestSVD_GESVD(TestSVD_GESDD):
     def setup_method(self):

--- a/scipy/linalg/tests/test_decomp_cholesky.py
+++ b/scipy/linalg/tests/test_decomp_cholesky.py
@@ -1,4 +1,5 @@
-from numpy.testing import assert_array_almost_equal, assert_array_equal
+import numpy as np
+from numpy.testing import assert_array_almost_equal, assert_array_equal, assert_allclose
 from pytest import raises as assert_raises
 
 from numpy import array, transpose, dot, conjugate, zeros_like, empty
@@ -64,6 +65,11 @@ class TestCholesky:
             c = transpose(c)
             a = dot(c, transpose(conjugate(c)))
             assert_array_almost_equal(cholesky(a, lower=1), c)
+
+    def test_empty(self):
+        a = np.array([]).reshape((0,0))
+        a_empty = cholesky(a)
+        assert_allclose(a_empty, a)
 
 
 class TestCholeskyBanded:

--- a/scipy/linalg/tests/test_special_matrices.py
+++ b/scipy/linalg/tests/test_special_matrices.py
@@ -322,6 +322,11 @@ class TestKron:
                           [33, 44]])
         assert_array_equal(a, expected)
 
+    def test_empty(self):
+        a = np.array([]).reshape((0,0))
+        a_empty = kron(a,a)
+        assert_allclose(a_empty, a)
+
 
 class TestHelmert:
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Contributes to gh-17658

#### What does this implement/fix?
Adds empty matrix support to functions in scipy.linalg. This brings the functions with equivalents found in numpy.linalg to the same behavior when given empty matrices.

#### Additional information
