### PR TITLE
FIX: add const with fused type memory view in evaluate_spline

### DIFF
--- a/scipy/interpolate/_bspl.pyx
+++ b/scipy/interpolate/_bspl.pyx
@@ -91,7 +91,7 @@ cdef inline int find_interval(const double[::1] t,
 @cython.boundscheck(False)
 @cython.cdivision(True)
 def evaluate_spline(const double[::1] t,
-             double_or_complex[:, ::1] c,
+             const double_or_complex[:, ::1] c,
              int k,
              const double[::1] xp,
              int nu,

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -592,6 +592,18 @@ class TestBSpline:
                                         bc_type='natural')
         assert_allclose(bspl.c, [1, 1, 1, 1, 1, 1, 1], atol=1e-15)
 
+    def test_read_only(self):
+        t = np.array([0, 1])
+        c = np.array([3.0])
+        t.setflags(write=False)
+        c.setflags(write=False)
+
+        xx = np.linspace(0, 1, 10)
+        xx.setflags(write=False)
+
+        b = BSpline(t=t, c=c, k=0)
+        assert_allclose(b(xx), 3)
+
 
 def test_knots_multiplicity():
     # Take a spline w/ random coefficients, throw in knots of varying

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -593,6 +593,7 @@ class TestBSpline:
         assert_allclose(bspl.c, [1, 1, 1, 1, 1, 1, 1], atol=1e-15)
 
     def test_read_only(self):
+        # BSpline must work on read-only knots and coefficients.
         t = np.array([0, 1])
         c = np.array([3.0])
         t.setflags(write=False)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
This issue was identified in https://github.com/scikit-learn/scikit-learn/pull/25624

#### What does this implement/fix?
<!--Please explain your changes.-->
- Adds const with the fused type memory view of the parameter `c` in the evaluate_spline function.
- Adds a test for testing BSpline with read only parameters.

#### Additional information
<!--Any additional information you think is important.-->
CC: @jjerphan 