### PR TITLE
CI: fix pre-release job that is failing on Cython 3.0b1

### DIFF
--- a/ci/azure-travis-template.yaml
+++ b/ci/azure-travis-template.yaml
@@ -70,7 +70,7 @@ steps:
     pip install --upgrade ${{parameters.numpy_spec}} &&
     pip install --upgrade pip setuptools==59.6.0 wheel build meson meson-python &&
     pip install ${{parameters.other_spec}}
-    cython
+    cython<3.0b1  # unpin when gh-17234 is addressed
     gmpy2
     threadpoolctl
     mpmath

--- a/ci/azure-travis-template.yaml
+++ b/ci/azure-travis-template.yaml
@@ -70,7 +70,7 @@ steps:
     pip install --upgrade ${{parameters.numpy_spec}} &&
     pip install --upgrade pip setuptools==59.6.0 wheel build meson meson-python &&
     pip install ${{parameters.other_spec}}
-    cython<3.0b1  # unpin when gh-17234 is addressed
+    "cython<3.0b1"  # unpin when gh-17234 is addressed
     gmpy2
     threadpoolctl
     mpmath

--- a/ci/azure-travis-template.yaml
+++ b/ci/azure-travis-template.yaml
@@ -70,7 +70,7 @@ steps:
     pip install --upgrade ${{parameters.numpy_spec}} &&
     pip install --upgrade pip setuptools==59.6.0 wheel build meson meson-python &&
     pip install ${{parameters.other_spec}}
-    "cython<3.0b1"  # unpin when gh-17234 is addressed
+    "cython<3.0b1"
     gmpy2
     threadpoolctl
     mpmath


### PR DESCRIPTION
by pinning to `<3.0b1`. xref gh-17234 for the remaining issues

[skip actions] [skip cirrus] [skip circle]