### PR TITLE
FIX: const with double_or_complex memory views in _bspl.pyx

### DIFF
--- a/scipy/interpolate/_bspl.pyx
+++ b/scipy/interpolate/_bspl.pyx
@@ -338,7 +338,7 @@ def _handle_lhs_derivatives(const double[::1]t, int k, double xval,
 def _norm_eq_lsq(const double[::1] x,
                  const double[::1] t,
                  int k,
-                 double_or_complex[:, ::1] y,
+                 const double_or_complex[:, ::1] y,
                  const double[::1] w,
                  double[::1, :] ab,
                  double_or_complex[::1, :] rhs):

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -1519,6 +1519,13 @@ class TestLSQ:
             y[-1] = z
             assert_raises(ValueError, make_lsq_spline, x, y, t)
 
+    def test_read_only(self):
+        # Check that make_lsq_spline works with read only arrays
+        x, y, t = self.x, self.y, self.t
+        x.setflags(write=False)
+        y.setflags(write=False)
+        t.setflags(write=False)
+        make_lsq_spline(x=x, y=y, t=t)
 
 def data_file(basename):
     return os.path.join(os.path.abspath(os.path.dirname(__file__)),


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Follow up of gh-18153

#### What does this implement/fix?
<!--Please explain your changes.-->
- Adds const to read only double_or_complex memory views in _bspl.pyx.
- Adds a test for verification. 

#### Additional information
<!--Any additional information you think is important.-->
None