### PR TITLE
ENH: Dweibull entropy

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1738,6 +1738,10 @@ class dweibull_gen(rv_continuous):
     def _stats(self, c):
         return 0, None, 0, None
 
+    def entropy(self, c):
+        h = -np.log(c / 2) + (c - 1) * np.euler_gamma / c + 1
+        return h
+
 
 dweibull = dweibull_gen(name='dweibull')
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1739,7 +1739,7 @@ class dweibull_gen(rv_continuous):
         return 0, None, 0, None
 
     def _entropy(self, c):
-        h = -np.log(c / 2) + (c - 1) * _EULER / c + 1
+        h = stats.weibull_min._entropy(c) - np.log(0.5)
         return h
 
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1738,7 +1738,7 @@ class dweibull_gen(rv_continuous):
     def _stats(self, c):
         return 0, None, 0, None
 
-    def entropy(self, c):
+    def _entropy(self, c):
         h = -np.log(c / 2) + (c - 1) * np.euler_gamma / c + 1
         return h
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1739,7 +1739,7 @@ class dweibull_gen(rv_continuous):
         return 0, None, 0, None
 
     def _entropy(self, c):
-        h = -np.log(c / 2) + (c - 1) * np.euler_gamma / c + 1
+        h = -np.log(c / 2) + (c - 1) * _EULER / c + 1
         return h
 
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -6154,8 +6154,10 @@ class TestDweibull:
         # mp.dps = 150
         #
         # def entropy(c):
+        #     c = mp.mpf(c)
         #     def pdf(x):
-        #         y = C * mp.fabs(x) ** (c - 1) * mp.exp(-mp.fabs(x) ** c) / 2
+        #         x = mp.mpf(x)
+        #         y = c * mp.fabs(x) ** (c - mp.one) * mp.exp(-mp.fabs(x) ** c) / mp.mpf(2.)
         #         return y
         #
         #   h = -mp.quad(lambda t: pdf(t) * mp.log(pdf(t)), [-mp.inf, mp.inf])

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -6144,25 +6144,18 @@ class TestWeibull:
 
 
 class TestDweibull:
-
-    @pytest.mark.parametrize("c, ref",
-                            [(0.3, 1.5502834334489712),
-                             (13, -0.33898771699248414)])
-    def test_entropy(self, c, ref):
-        # The reference values were calculated with mpmath:
-        # from mpmath import mp
-        # mp.dps = 150
-        #
-        # def entropy(c):
-        #     c = mp.mpf(c)
-        #     def pdf(x):
-        #         x = mp.mpf(x)
-        #         y = c * mp.fabs(x) ** (c - mp.one) * mp.exp(-mp.fabs(x) ** c) / mp.mpf(2.)
-        #         return y
-        #
-        #   h = -mp.quad(lambda t: pdf(t) * mp.log(pdf(t)), [-mp.inf, mp.inf])
-        #   return float(h)
-        assert_allclose(stats.dweibull.entropy(c), ref, rtol=1e-14)
+    def test_entropy(self):
+        # Test that dweibull entropy follows that of weibull_min.
+        # (Generic tests check that the dweibull entropy is consistent
+        #  with its PDF. As for accuracy, dweibull entropy should be just
+        #  as accurate as weibull_min entropy. Checks of accuracy against
+        #  a reference need only be applied to the fundamental distribution -
+        #  weibull_min.)
+        rng = np.random.default_rng(8486259129157041777)
+        c = 10**rng.normal(scale=100, size=10)
+        res = stats.dweibull.entropy(c)
+        ref = stats.weibull_min.entropy(c) - np.log(0.5)
+        assert_allclose(res, ref, rtol=1e-15)
 
 
 class TestTruncWeibull:

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -6143,6 +6143,26 @@ class TestWeibull:
         assert_allclose(res, ref)
 
 
+class TestDweibull:
+
+    @pytest.mark.parametrize("c, ref",
+                            [(0.3, 1.5502834334489721),
+                             (13, -0.33898771699248414)])
+    def test_entropy(self, c, ref):
+        # The reference values were calculated with mpmath:
+        # from mpmath import mp
+        # mp.dps = 150
+        #
+        # def entropy(c):
+        #     def pdf(x):
+        #         y = C * mp.fabs(x) ** (c - 1) * mp.exp(-mp.fabs(x) ** c) / 2
+        #         return y
+        #
+        #   h = -mp.quad(lambda t: pdf(t) * mp.log(pdf(t)), [-mp.inf, mp.inf])
+        #   return float(h)
+        assert_allclose(stats.dweibull._entropy(c), ref, rtol=1e-14)
+
+
 class TestTruncWeibull:
 
     def test_pdf_bounds(self):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -6160,7 +6160,7 @@ class TestDweibull:
         #
         #   h = -mp.quad(lambda t: pdf(t) * mp.log(pdf(t)), [-mp.inf, mp.inf])
         #   return float(h)
-        assert_allclose(stats.dweibull._entropy(c), ref, rtol=1e-14)
+        assert_allclose(stats.dweibull.entropy(c), ref, rtol=1e-14)
 
 
 class TestTruncWeibull:

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -6146,7 +6146,7 @@ class TestWeibull:
 class TestDweibull:
 
     @pytest.mark.parametrize("c, ref",
-                            [(0.3, 1.5502834334489721),
+                            [(0.3, 1.5502834334489712),
                              (13, -0.33898771699248414)])
     def test_entropy(self, c, ref):
         # The reference values were calculated with mpmath:


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Part of #17832 
#### What does this implement/fix?
<!--Please explain your changes.-->
Adds entropy method for Dweibull distribution
#### Additional information
<!--Any additional information you think is important.-->
Since there's no gamma or digamma terms, an asymptotic expansion isn't necessary. Derivation for the entropy can be found in the attached writeup.
[Dweibull_Entropy.pdf](https://github.com/scipy/scipy/files/10994977/Dweibull_Entropy.pdf)
