### PR TITLE
BLD: Allow to set python path also via meson

### DIFF
--- a/doc/source/building/cross_compilation.rst
+++ b/doc/source/building/cross_compilation.rst
@@ -37,6 +37,8 @@ relevant directories in your *cross file*:
     [properties]
     numpy-include-dir = sitepkg + 'numpy/core/include'
     pythran-include-dir = sitepkg + 'pythran'
+    host-python-path = '/abspath/to/host-pythons/bin/python'
+    host-python-version = '3.14'
 
 For more details and the current status around cross compilation, see:
 

--- a/doc/source/dev/contributor/meson_advanced.rst
+++ b/doc/source/dev/contributor/meson_advanced.rst
@@ -86,6 +86,8 @@ relevant directories in your *cross file*:
     numpy-include-dir = sitepkg + 'numpy/core/include'
     pybind11-include-dir = sitepkg + 'pybind11/include'
     pythran-include-dir = sitepkg + 'pythran'
+    host-python-path = '/abspath/to/host-pythons/bin/python'
+    host-python-version = '3.10'
 
 
 Use different build types with Meson

--- a/scipy/__config__.py.in
+++ b/scipy/__config__.py.in
@@ -92,8 +92,8 @@ CONFIG = _cleanup(
             },
         },
         "Python Information": {
-            "path": r"@PYTHON_PATH@",
-            "version": "@PYTHON_VERSION@",
+            "path": r"@HOST_PYTHON_PATH@",
+            "version": "@HOST_PYTHON_VERSION@",
         },
     }
 )

--- a/scipy/__config__.py.in
+++ b/scipy/__config__.py.in
@@ -109,8 +109,8 @@ CONFIG = _cleanup(
             },
         },
         "Python Information": {
-            "path": r"@PYTHON_PATH@",
-            "version": "@PYTHON_VERSION@",
+            "path": r"@HOST_PYTHON_PATH@",
+            "version": "@HOST_PYTHON_VERSION@",
         },
     }
 )

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -145,6 +145,16 @@ else
   pythran_dep = []
 endif
 
+host_python_path = meson.get_external_property('host-python-path', 'not-given')
+if host_python_path == 'not-given'
+  host_python_path = py3.full_path()
+endif
+
+host_python_version = meson.get_external_property('host-python-version', 'not-given')
+if host_python_version == 'not-given'
+  host_python_version = py3.language_version()
+endif
+
 # Note: warning flags are added to this further down
 cpp_args_pythran = [
   '-DENABLE_PYTHON_MODULE',
@@ -437,8 +447,8 @@ endforeach
 conf_data.set('CROSS_COMPILED', meson.is_cross_build())
 
 # Python information
-conf_data.set('PYTHON_PATH', py3.full_path())
-conf_data.set('PYTHON_VERSION', py3.language_version())
+conf_data.set('HOST_PYTHON_PATH', host_python_path)
+conf_data.set('HOST_PYTHON_VERSION', host_python_version)
 
 # Dependencies information
 foreach name, dep : dependency_map

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -126,6 +126,16 @@ else
   pythran_dep = []
 endif
 
+host_python_path = meson.get_external_property('host-python-path', 'not-given')
+if host_python_path == 'not-given'
+  host_python_path = py3.full_path()
+endif
+
+host_python_version = meson.get_external_property('host-python-version', 'not-given')
+if host_python_version == 'not-given'
+  host_python_version = py3.language_version()
+endif
+
 # Note: warning flags are added to this further down
 cpp_args_pythran = [
   '-DENABLE_PYTHON_MODULE',
@@ -755,8 +765,8 @@ endforeach
 conf_data.set('CROSS_COMPILED', meson.is_cross_build().to_string())
 
 # Python information
-conf_data.set('PYTHON_PATH', py3.full_path().replace('\\', '/'))
-conf_data.set('PYTHON_VERSION', py3.language_version())
+conf_data.set('HOST_PYTHON_PATH', host_python_path)
+conf_data.set('HOST_PYTHON_VERSION', host_python_version)
 
 # Information on dependencies, to store in `scipy/__config__.py`
 dependency_map = {


### PR DESCRIPTION
#### Reference issue

Helps gh-14812.

#### What does this implement/fix?

This helps cross compilation, as a user will want this path to be the host's python path.

#### Additional information

Nix cross compilation framework, didn't allow me keep this reference of the cross compiled scipy to the build platform's python executable.