### PR TITLE
TST: spatial: skip failing test to make CI green again

### DIFF
--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -1469,6 +1469,7 @@ class TestPdist:
                         y2 = pdist(new_type(X1), metric=metric)
                         assert_allclose(y1, y2, rtol=eps, verbose=verbose > 2)
 
+    @pytest.mark.skip("Failing on Windows Azure jobs; see gh-18108.")
     def test_pdist_out(self):
         # Test that out parameter works properly
         eps = 1e-15

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -2073,6 +2073,7 @@ def test_Xdist_deprecated_args():
                 pdist(X1, metric, **kwargs)
 
 
+@pytest.mark.skip("Failing on Windows Azure jobs; see gh-18108.")
 def test_Xdist_non_negative_weights():
     X = eo['random-float32-data'][::5, ::2]
     w = np.ones(X.shape[1])

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -568,6 +568,7 @@ class TestCdist:
                         y2 = cdist(new_type(X1), new_type(X2), metric=metric)
                         assert_allclose(y1, y2, rtol=eps, verbose=verbose > 2)
 
+    @pytest.mark.skip("Failing on Windows Azure jobs; see gh-18108.")
     def test_cdist_out(self):
         # Test that out parameter works properly
         eps = 1e-15


### PR DESCRIPTION
#### Reference issue
gh-18108

#### What does this implement/fix?
Skips a test that has been failing in main for about two weeks. Something may still need to be fixed, so gh-18108 can remain open, but in the meantime, it is preferable for CI failures in a PR to indicate a failures caused by that PR.