### PR TITLE
MAINT: Windows distutils cdist/pdist shims

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -2209,7 +2209,7 @@ def pdist(X, metric='euclidean', *, out=None, **kwargs):
 
         if metric_info is not None:
             pdist_fn = metric_info.pdist_func
-            _extra_windows_error_checks(X, out, (m * (m - 1) / 2), **kwargs)
+            _extra_windows_error_checks(X, out, (m * (m - 1) / 2,), **kwargs)
             return pdist_fn(X, out=out, **kwargs)
         elif mstr.startswith("test_"):
             metric_info = _TEST_METRICS.get(mstr, None)

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -568,7 +568,6 @@ class TestCdist:
                         y2 = cdist(new_type(X1), new_type(X2), metric=metric)
                         assert_allclose(y1, y2, rtol=eps, verbose=verbose > 2)
 
-    @pytest.mark.skip("Failing on Windows Azure jobs; see gh-18108.")
     def test_cdist_out(self):
         # Test that out parameter works properly
         eps = 1e-15
@@ -1469,7 +1468,6 @@ class TestPdist:
                         y2 = pdist(new_type(X1), metric=metric)
                         assert_allclose(y1, y2, rtol=eps, verbose=verbose > 2)
 
-    @pytest.mark.skip("Failing on Windows Azure jobs; see gh-18108.")
     def test_pdist_out(self):
         # Test that out parameter works properly
         eps = 1e-15
@@ -2073,7 +2071,6 @@ def test_Xdist_deprecated_args():
                 pdist(X1, metric, **kwargs)
 
 
-@pytest.mark.skip("Failing on Windows Azure jobs; see gh-18108.")
 def test_Xdist_non_negative_weights():
     X = eo['random-float32-data'][::5, ::2]
     w = np.ones(X.shape[1])


### PR DESCRIPTION
Fixes gh-18108

* revert the temporary skips that were added in gh-18168, since `pdist` and `cdist` are both pretty heavily used

* instead, add temporary control flow shims that compensate, on Windows only,
for the fact that the old distutils Windows builds are prone to having a failure
to trigger `ValueError` from the `pybind11` bindings when performing input
validation on the `out` and `w` (weights) arguments (exact reason is not
known, but this build system is on the way out anyway...)

* note that this was pretty messy to deal with--the failures were only reproducible
on Azure pipelines so I had to debug by physically deleting the `pybind11` error
handling code on a Linux box and simulating the situation that way; it looks like
Azure + Windows + distutils is finally happy with the shims on my fork now, so opening
this

* my comments could perhaps be a bit more detailed, but all evidence points to
the fact that we should be able to delete these Python-level shims and fall back
to the desired `pybind11`-based error handling we already have once we drop
the old build system machinery for good

* I imagine we'll `grep -E "distutils"` when the final removal happens, so the
comments should suffice to remember that...