### PR TITLE
ENH: ndimage: add `bounding_box` function

### DIFF
--- a/scipy/ndimage/__init__.py
+++ b/scipy/ndimage/__init__.py
@@ -72,6 +72,7 @@ Measurements
 .. autosummary::
    :toctree: generated/
 
+   bounding_box - Get bounding box of nonzero values in an nd-image
    center_of_mass - The center of mass of the values of an array at labels
    extrema - Min's and max's of an array at labels, with their positions
    find_objects - Find objects in a labeled array

--- a/scipy/ndimage/_measurements.py
+++ b/scipy/ndimage/_measurements.py
@@ -38,7 +38,7 @@ from . import _morphology
 __all__ = ['label', 'find_objects', 'labeled_comprehension', 'sum', 'mean',
            'variance', 'standard_deviation', 'minimum', 'maximum', 'median',
            'minimum_position', 'maximum_position', 'extrema', 'center_of_mass',
-           'histogram', 'watershed_ift', 'sum_labels', 'value_indices']
+           'histogram', 'watershed_ift', 'sum_labels', 'value_indices', 'bounding_box']
 
 
 def label(input, structure=None, output=None):
@@ -261,7 +261,7 @@ def find_objects(input, max_label=0):
 
     See Also
     --------
-    label, center_of_mass
+    label, center_of_mass, bounding_box
 
     Notes
     -----
@@ -1673,3 +1673,50 @@ def watershed_ift(input, markers, structure=None, output=None):
     output = _ni_support._get_output(output, input)
     _nd_image.watershed_ift(input, markers, structure, output)
     return output
+
+
+def bounding_box(input):
+    """
+    Return the bounding box of the non-zero values of the input.
+
+    Equivalent to ``find_objects(image!=0)[0]``
+
+    Parameters
+    ----------
+    input : ndarray
+        N-d input array.
+
+    Returns
+    -------
+    bbox : tuple of slices
+        A tuple containing N slices (with N the dimension of the input array).
+        Slices correspond to the minimal paralleliped that contains the object.
+        If there are no non-zero values in the input, the slices are all None.
+
+    See also
+    --------
+    find_objects
+
+    Notes
+    -----
+    This function is equivalent to ``find_objects(image!=0,max_label=1)[0]``, but
+    faster and more memory efficient. Speedup is due to running in-place, whereas
+    using ``find_objects`` requires allocating a temporary array for the binary
+    comparison (``image!=0``).
+
+    .. versionadded:: 1.11.0
+
+    Examples
+    --------
+    >>> from scipy import ndimage
+    >>> a = np.array([[0, 0, 0, 0, 0],
+    ...               [0, 1, 1, 1, 0],
+    ...               [0, 1, 1, 1, 0],
+    ...               [0, 0, 0, 0, 0]])
+    >>> ndimage.bounding_box(a)
+    (slice(1, 3, None), slice(1, 4, None))
+
+    """
+    input = numpy.asarray(input)
+    
+    return _nd_image.bounding_box(input)

--- a/scipy/ndimage/_measurements.py
+++ b/scipy/ndimage/_measurements.py
@@ -1709,6 +1709,7 @@ def bounding_box(input):
     Examples
     --------
     >>> from scipy import ndimage
+    >>> import numpy as np
     >>> a = np.array([[0, 0, 0, 0, 0],
     ...               [0, 1, 1, 1, 0],
     ...               [0, 1, 1, 1, 0],

--- a/scipy/ndimage/_measurements.py
+++ b/scipy/ndimage/_measurements.py
@@ -1709,6 +1709,7 @@ def bounding_box(input):
     Examples
     --------
     >>> from scipy import ndimage
+    >>> import numpy as np
     >>> a = np.array([[0, 0, 0, 0, 0],
     ...               [0, 1, 1, 1, 0],
     ...               [0, 1, 1, 1, 0],
@@ -1718,5 +1719,5 @@ def bounding_box(input):
 
     """
     input = numpy.asarray(input)
-    
+
     return _nd_image.bounding_box(input)

--- a/scipy/ndimage/measurements.py
+++ b/scipy/ndimage/measurements.py
@@ -11,7 +11,7 @@ __all__ = [  # noqa: F822
     'sum', 'mean', 'variance', 'standard_deviation',
     'minimum', 'maximum', 'median', 'minimum_position',
     'maximum_position', 'extrema', 'center_of_mass',
-    'histogram', 'watershed_ift', 'sum_labels'
+    'histogram', 'watershed_ift', 'sum_labels', 'bounding_box'
 ]
 
 

--- a/scipy/ndimage/src/ni_measure.h
+++ b/scipy/ndimage/src/ni_measure.h
@@ -37,4 +37,6 @@ int NI_FindObjects(PyArrayObject*, npy_intp, npy_intp*);
 int NI_WatershedIFT(PyArrayObject*, PyArrayObject*, PyArrayObject*,
                     PyArrayObject*);
 
+int NI_BoundingBox(PyArrayObject*, npy_intp*);
+
 #endif

--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -1508,10 +1508,11 @@ class Test_bounding_box:
         out = ndimage.bounding_box(data)
         assert_equal(out, (slice(1, 3, None), slice(2, 5, None), slice(2, 5, None), slice(0, 1, None)))
 
-    @pytest.mark.parametrize("type", [np.float128,])
-    def test_bounding_box16(self, type):
+    def test_bounding_box16(self):
         ''' assert ValueError is raised when input dtype is not supported '''
-        data = np.zeros([5,5,5,5], dtype=type)
+        if not hasattr(np, 'float128'):
+            pytest.skip("runs only if np.float128 is available")
+        data = np.zeros([5,5,5,5], dtype=np.float128)
         data[1:3,2:5,2:5,0] = 1
         msg = "data type not supported"
         with assert_raises(RuntimeError, match=msg):

--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -1409,7 +1409,7 @@ class Test_bounding_box:
     def test_bounding_box02(self):
         data = np.zeros([], dtype=int)
         out = ndimage.bounding_box(data)
-        assert_(out == None)
+        assert_(out is None)
 
     def test_bounding_box03(self):
         data = np.ones([1], dtype=int)

--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -1395,12 +1395,10 @@ class TestWatershedIft:
 
 class Test_bounding_box:
     '''
-    supported dtypes are all `types` in __init__.py, plus: 
-    np.float16, np.complex256, and bool.
-    bool is tested separately.
+    supported dtypes are all `types` in __init__.py, plus:
+    np.float16 and bool.
     '''
-    supported_types = types + [np.float16, np.complex256]
-    
+
     def test_bounding_box01(self):
         data = np.ones([], dtype=int)
         out = ndimage.bounding_box(data)
@@ -1494,7 +1492,7 @@ class Test_bounding_box:
         out = ndimage.bounding_box(data)
         assert_equal(out, (slice(1, 3, None), slice(2, 5, None), slice(2, 5, None), slice(0, 1, None)))
 
-    @pytest.mark.parametrize("type", float_types+[np.float16])
+    @pytest.mark.parametrize("type", float_types+[np.float16,])
     def test_bounding_box14(self, type):
         ''' test floating point data types specifically - with only small values '''
         data = np.zeros([5,5,5,5],dtype=type)


### PR DESCRIPTION
**Explanation**
I have implemented a new `bounding_box()` function in ndimage.
This function finds the bounding box of the nonzero elements in an N-d array, returned as slices for each axis.

Basically, running `ndi.bounding_box(arr)` is equivalent to `ndi.find_objects(arr!=0, max_label=1)[0]`, only significantly faster and more memory efficient.
The implementation is based on that of `find_objects()`, since the underlying logic is actually almost the same.
However, using `find_objects` is between 10-30% slower, due to the fact that the argument `arr!=0` requires allocation of a new array, to store the binary comparison result. For large inputs, this can be a pretty heavy toll on memory. On the other hand, `bounding_box` runs in-place on `arr`.

**Usage example**

```
>>> a=np.zeros([5,5])
>>> a[1:3,1:4]=1
>>> ndi.bounding_box(a)
(slice(1, 3, None), slice(1, 4, None))
```

**Timing comparison with find_objects**
```
In [1]: import numpy as np

In [2]: import scipy.ndimage as ndi

In [3]: a=np.zeros([1024,1024,1024])

In [4]: a[10:30,10:40,20:50]=1

In [5]: %timeit ndi.find_objects(a!=0, max_label=1)
2.06 s ± 101 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [6]: %timeit ndi.bounding_box(a)
1.5 s ± 8.94 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

EDIT: mailing list message: https://mail.python.org/archives/list/scipy-dev@python.org/thread/TM5K3BQMG3NP5MEYOYQB47AMOUH2HYM5/#TM5K3BQMG3NP5MEYOYQB47AMOUH2HYM5
