### PR TITLE
MAINT: optimize.root_scalar: return gracefully when callable returns NaN

### DIFF
--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -764,19 +764,33 @@ def test_gh9551_raise_error_if_disp_true():
 
 @pytest.mark.parametrize('solver_name',
                          ['brentq', 'brenth', 'bisect', 'ridder', 'toms748'])
-@pytest.mark.parametrize('rs_interface', [True, False])
-def test_gh3089_8394(solver_name, rs_interface):
+def test_gh3089_8394(solver_name):
     # gh-3089 and gh-8394 reported that bracketing solvers returned incorrect
     # results when they encountered NaNs. Check that this is resolved.
-    solver = ((lambda f, a, b: root_scalar(f, bracket=(a, b))) if rs_interface
-              else getattr(zeros, solver_name))
-
     def f(x):
         return np.nan
 
-    message = "The function value at x..."
-    with pytest.raises(ValueError, match=message):
+    solver = getattr(zeros, solver_name)
+    with pytest.raises(ValueError, match="The function value at x..."):
         solver(f, 0, 1)
+
+
+@pytest.mark.parametrize('method',
+                         ['brentq', 'brenth', 'bisect', 'ridder', 'toms748'])
+def test_gh18171(method):
+    # gh-3089 and gh-8394 reported that bracketing solvers returned incorrect
+    # results when they encountered NaNs. Check that `root_scalar` returns
+    # normally but indicates that convergence was unsuccessful. See gh-18171.
+    def f(x):
+        f._count += 1
+        return np.nan
+    f._count = 0
+
+    res = root_scalar(f, bracket=(0, 1), method=method)
+    assert res.converged is False
+    assert res.flag.startswith("The function value at x")
+    assert res.function_calls == f._count
+    assert str(res.root) in res.flag
 
 
 @pytest.mark.parametrize('solver_name',


### PR DESCRIPTION
#### Reference issue
Closes gh-18171

#### What does this implement/fix?
gh-17622 fixed bugs in low-level scalar root solvers by raising an error rather than returning incorrect solutions when a function evaluation returns a NaN. The consequence to the high-level `root_scalar` interface was overlooked: `root_scalar` currently raises an exception in these cases rather than returning a `RootResults` object with attribute `converged` equal to `False`. This PR fixes the bug.
