### PR TITLE
DOC: update links for ARPACK to point to ARPACK-NG

### DIFF
--- a/doc/source/tutorial/arpack.rst
+++ b/doc/source/tutorial/arpack.rst
@@ -307,4 +307,4 @@ operator.
 
 References
 ----------
-.. [1] http://www.caam.rice.edu/software/ARPACK/
+.. [1] https://github.com/opencollab/arpack-ng

--- a/scipy/sparse/linalg/_eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/_eigen/arpack/arpack.py
@@ -1543,7 +1543,7 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
 
     References
     ----------
-    .. [1] ARPACK Software, http://www.caam.rice.edu/software/ARPACK/
+    .. [1] ARPACK Software, https://github.com/opencollab/arpack-ng
     .. [2] R. B. Lehoucq, D. C. Sorensen, and C. Yang,  ARPACK USERS GUIDE:
        Solution of Large Scale Eigenvalue Problems by Implicitly Restarted
        Arnoldi Methods. SIAM, Philadelphia, PA, 1998.

--- a/scipy/sparse/linalg/_eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/_eigen/arpack/arpack.py
@@ -2,7 +2,7 @@
 Find a few eigenvectors and eigenvalues of a matrix.
 
 
-Uses ARPACK: http://www.caam.rice.edu/software/ARPACK/
+Uses ARPACK: https://github.com/opencollab/arpack-ng
 
 """
 # Wrapper implementation notes

--- a/scipy/sparse/linalg/_eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/_eigen/arpack/arpack.py
@@ -1234,7 +1234,7 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
 
     References
     ----------
-    .. [1] ARPACK Software, http://www.caam.rice.edu/software/ARPACK/
+    .. [1] ARPACK Software, https://github.com/opencollab/arpack-ng
     .. [2] R. B. Lehoucq, D. C. Sorensen, and C. Yang,  ARPACK USERS GUIDE:
        Solution of Large Scale Eigenvalue Problems by Implicitly Restarted
        Arnoldi Methods. SIAM, Philadelphia, PA, 1998.


### PR DESCRIPTION
Hi 

Updation of reference link from [original link](http://www.caam.rice.edu/software/ARPACK/) which is showing 404 error to [new link](https://github.com/opencollab/arpack-ngrl)

Thank you 
Sravya
