### PR TITLE
MAINT: stats.logistic.fit: ensure scale is positive

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -5787,12 +5787,19 @@ class logistic_gen(rv_continuous):
         # scale parameters are roots of the two equations described in `func`.
         # Source: Statistical Distributions, 3rd Edition. Evans, Hastings, and
         # Peacock (2000), Page 130
+        # Note: gh-18176 reported data for which the reported MLE had
+        # `scale < 0`. To fix the bug, we'll use abs(scale). This is not
+        # expected to cause convergence issues because a) `dl_dscale` is an
+        # even function, b) dl_dloc appears to be approximately even at the
+        # solution, and c) in 10k randomly-generated tests, the fit override
+        # always outperformed the generic fit. Ideally, though, we would
+        # *constrain* `scale` to be positive.
         def dl_dloc(loc, scale=fscale):
-            c = (data - loc) / scale
+            c = (data - loc) / abs(scale)
             return np.sum(sc.expit(c)) - n/2
 
         def dl_dscale(scale, loc=floc):
-            c = (data - loc) / scale
+            c = (data - loc) / abs(scale)
             return np.sum(c*np.tanh(c/2)) - n
 
         def func(params):
@@ -5811,6 +5818,7 @@ class logistic_gen(rv_continuous):
             res = optimize.root(func, (loc, scale))
             loc, scale = res.x
 
+        scale = abs(scale)
         return ((loc, scale) if res.success
                 else super().fit(data, *args, **kwds))
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1892,6 +1892,14 @@ class TestLogistic:
                     -1.9287498479639178e-22, -7.124576406741286e-218]
         assert_allclose(y, expected, rtol=2e-15)
 
+    def test_fit_gh_18176(self):
+        # logistic.fit returned `scale < 0` for this data. Check that this has
+        # been fixed.
+        data = np.array([-459, 37, 43, 45, 45, 48, 54, 55, 58]
+                        + [59] * 3 + [61] * 9)
+        # If scale were negative, NLLF would be infinite, so this would fail
+        _assert_less_or_close_loglike(stats.logistic, data)
+
 
 class TestLogser:
     def setup_method(self):


### PR DESCRIPTION
#### Reference issue
Closes gh-18176

#### What does this implement/fix?
gh-18176 reported a case in which the reported solution had `scale < 0`. To fix the bug, ~~we'll use~~ we return `abs(scale)`.
* `dl_dscale` is an even function
* `dl_dloc` ~~appears to be approximately even at the solution~~ is odd, and 
* in 10k randomly-generated tests, the fit override always outperformed the generic fit. This appears to be true even when the data is not distributed according to the logistic distribution and when scale/loc are fixed at random values.

#### Additional information
~~As a future enhancement, we would *constrain* `scale` to be positive. The fixed scale/fixed loc cases can use a bracketing root finder, for instance.~~

<details>

The usual experiment:
```python3
import numpy as np
from scipy import stats
from time import perf_counter
import matplotlib.pyplot as plt
from itertools import product

rng = np.random.default_rng(24330062354926113)
qrng = stats.qmc.Halton(6, seed=rng)
dist = stats.logistic

N = 10000

megadict = {}
i_stop = {}

for fix_params in product((False, True), repeat=2):
    if np.all(fix_params):
        continue

    print(fix_params)

    times_pr = np.full(N, np.nan)
    times_super = np.full(N, np.nan)
    nllfs_super = np.full(N, np.nan)
    nllfs_pr = np.full(N, np.nan)

    for i in range(N):
        fparams = {}

        if i % 50 == 0:
            print(i)

        sample = qrng.random()
        sample = stats.qmc.scale(sample,
                                 [-3, -3, -3, -3, 1, -1],
                                 [+3, +3, +3, +3, 5, +1])[0]
        b, c, loc, scale, size = 10 ** sample[:-1]  # some aren't used here
        c = c + 1
        loc_sign = np.sign(sample[-1])
        loc *= loc_sign
        size = int(size)

        params_true = loc, scale
        rvs = dist.rvs(*params_true, size=size, random_state=rng)

        if fix_params[-2]:
            fparams['floc'] = loc
        if fix_params[-1]:
            fparams['fscale'] = scale

        if i_stop and i not in i_stop:
            continue

        try:
            tic = perf_counter()
            params_fit = dist.fit(rvs, **fparams)
            toc = perf_counter()
            nllf_pr = dist.nnlf(params_fit, rvs)
            nllfs_pr[i] = nllf_pr
            times_pr[i] = toc - tic

        except Exception as e:
            print(f"Failure in {i}: {e}")
            print(*params_fit, size)

        try:
            tic = perf_counter()
            params_fit = dist.fit(rvs, **fparams, superfit=True)
            toc = perf_counter()
            nllf_super = dist.nnlf(params_fit, rvs)
            nllfs_super[i] = nllf_super
            times_super[i] = toc - tic

        except Exception as e:
            print(f"Failure in {i}: {e}")
            print(*params_fit, size)

    megadict[fix_params] = {'times_pr': times_pr,
                            'times_super': times_super,
                            'nllfs_pr': nllfs_pr,
                            'nllfs_super': nllfs_super}

    # print(s, loc, scale, size, nllf_super < nllf_pr)
    # if i in i_stop:
    # break

np.savez("logistic_fitresults", megadict=megadict)


import numpy as np
from numpy.testing import assert_allclose, assert_equal
from scipy import stats, optimize, integrate
import matplotlib.pyplot as plt
from mpmath import mp
mp.dps = 50
rng = np.random.default_rng(1638083107694713882823079058616272161)

megadict = np.load("logistic_fitresults.npz", allow_pickle=True)['megadict'][()]

fig, axs = plt.subplots(1, 3, figsize=(10, 5), sharex=True, sharey=True)
plt.subplots_adjust(hspace=0.25)

for i, item in enumerate(megadict.items()):
    ax = axs.ravel()[i]
    key, val = item

    labels = np.array(['floc', 'fscale'])
    title = ", ".join(labels[np.array(key)]) or "all free"

    nllfs_pr = val['nllfs_pr']
    nllfs_super = val['nllfs_super']
    times_pr = val['times_pr']
    times_super = val['times_super']
    nllf_diff = (nllfs_pr - nllfs_super) / np.abs(nllfs_super)
    nllf_diff = nllf_diff[np.isfinite(nllf_diff)]
    nllf_diff_good = -nllf_diff[nllf_diff < 0]
    nllf_diff_bad = nllf_diff[nllf_diff > 0]
    new_nans = np.isnan(nllfs_pr) & (~np.isnan(nllfs_super))
    title = title + f", {np.sum(new_nans)} new NaNs"

    bins = np.arange(-4.5, 0, 0.25)
    ax.hist(np.log10(times_pr), bins=bins, alpha=0.5)
    ax.hist(np.log10(times_super), bins=bins, alpha=0.5)
    ax.set_title(title)

plt.xlabel('log10 of `fit` execution time (s)')
plt.ylabel('Frequency')
plt.legend(('PR', 'main'))
fig.suptitle('Histogram of log10 of `fit` execution time (s)')
plt.show()

fig, axs = plt.subplots(1, 3, figsize=(10, 5), sharex=True, sharey=True)
plt.subplots_adjust(hspace=0.25)

for i, item in enumerate(megadict.items()):
    ax = axs.ravel()[i]
    key, val = item

    labels = np.array(['floc', 'fscale'])
    title = ", ".join(labels[np.array(key)]) or "all free"

    nllfs_pr = val['nllfs_pr']
    nllfs_super = val['nllfs_super']
    nllf_diff = (nllfs_pr - nllfs_super) / np.abs(nllfs_super)
    nllf_diff2 = (nllfs_pr - nllfs_super) / np.abs(nllfs_pr)
    nllf_diff[np.isnan(nllf_diff)] = nllf_diff2[np.isnan(nllf_diff)]
    nllf_diff = nllf_diff[np.isfinite(nllf_diff)]
    nllf_diff_good = -nllf_diff[nllf_diff < 0]
    nllf_diff_bad = nllf_diff[nllf_diff > 0]

    ax.hist(np.log10(nllf_diff_good), alpha=0.5)
    ax.hist(np.log10(nllf_diff_bad), alpha=0.5)

    old_nans = np.sum(np.isnan(nllfs_pr) & (~np.isnan(nllfs_super)))
    new_nans = np.sum(np.isnan(nllfs_super) & (~np.isnan(nllfs_pr)))
    same_nans = np.sum(np.isnan(nllfs_super) & np.isnan(nllfs_pr))

    close = np.isclose(nllfs_pr, nllfs_super, rtol=1e-14)
    better = np.sum((nllfs_pr < nllfs_super) & ~close) + old_nans
    worse = np.sum((nllfs_pr > nllfs_super) & ~close) + new_nans
    same = np.sum(close) + same_nans
    assert (better + worse + same) == len(nllfs_super)
    title = title + f"\n{better}+, {worse}-, {same}="
    ax.set_title(title)

plt.xlabel('Histogram of log10 of NLLF relative changes')
plt.ylabel('Frequency')
plt.legend(('PR', 'main'))
fig.suptitle('Histogram of log10 of NLLF relative changes')
plt.show()

```

![image](https://user-images.githubusercontent.com/6570539/226412740-797ba04c-bb22-4cc9-af5a-09f0a286e22f.png)
</details>