### PR TITLE
ENH: Added `_sf` method for anglit distribution (#17832)

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -529,6 +529,9 @@ class anglit_gen(rv_continuous):
     def _cdf(self, x):
         return np.sin(x+np.pi/4)**2.0
 
+    def _sf(self, x):
+        return -(np.sin(2 * x) - 1) / 2
+
     def _ppf(self, q):
         return np.arcsin(np.sqrt(q))-np.pi/4
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -530,7 +530,7 @@ class anglit_gen(rv_continuous):
         return np.sin(x+np.pi/4)**2.0
 
     def _sf(self, x):
-        return -(np.sin(2 * x) - 1) / 2
+        return np.cos(x + np.pi / 4) ** 2.0
 
     def _ppf(self, q):
         return np.arcsin(np.sqrt(q))-np.pi/4

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -8387,6 +8387,7 @@ class TestAnglit:
         #     y = float(mp.quad(lambda z: pdf(z), [t, mp.pi / 4]))
         #     return y
         assert_allclose(stats.anglit.sf(t), ref, rtol=1e-14)
+        assert_allclose(1 - stats.anglit.cdf(t), ref, rtol=1e-14)
 
 
 class TestWrapCauchy:

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -8371,10 +8371,10 @@ class TestNakagami:
 class TestAnglit:
 
     @pytest.mark.parametrize("t, ref",
-                            [(-np.pi/4 + 1e-6, 0.999999999999),
-                             (-0.6, 0.9660195429836131),
-                             (0.6, 0.033980457016386835),
-                             (np.pi/4 - 1e-6, 1.0000000001184104e-12)])
+                             [(-np.pi/4 + 1e-6, 0.999999999999),
+                              (-0.6, 0.9660195429836131),
+                              (0.6, 0.033980457016386835),
+                              (np.pi/4 - 1e-6, 1.0000000001184104e-12)])
     def test_sf(self, t, ref):
         # Reference values were calculated with mpmath:
         # from mpmath import mp

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -8368,30 +8368,6 @@ class TestNakagami:
         assert_allclose(scale_est, scale_theo, rtol=1e-7)
 
 
-class TestAnglit:
-
-    @pytest.mark.parametrize("t, ref",
-                             [(-np.pi/4 + 1e-6, 0.999999999999),
-                              (-0.6, 0.9660195429836131),
-                              (0.6, 0.033980457016386835),
-                              (np.pi/4 - 1e-6, 1.0000000001184104e-12)])
-    def test_sf(self, t, ref):
-        # Reference values were calculated with mpmath:
-        # from mpmath import mp
-        # mp.dps = 150
-        #
-        # def sf(t):
-        #     t = mp.mpf(t)
-        #     def pdf(x):
-        #         y = mp.cos(2 * x)
-        #         return y
-        #
-        #     y = float(mp.quad(lambda z: pdf(z), [t, mp.pi / 4]))
-        #     return y
-        assert_allclose(stats.anglit.sf(t), ref, rtol=1e-14)
-        assert_allclose(1 - stats.anglit.cdf(t), ref, rtol=1e-14)
-
-
 class TestWrapCauchy:
 
     def test_cdf_shape_broadcasting(self):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -8368,6 +8368,27 @@ class TestNakagami:
         assert_allclose(scale_est, scale_theo, rtol=1e-7)
 
 
+class TestAnglit:
+
+    @pytest.mark.parametrize("t, ref",
+                            [(-0.6, 0.9660195429836131),
+                             (0.6, 0.033980457016386835)])
+    def test_sf(self, t, ref):
+        # Reference values were calculated with mpmath:
+        # from mpmath import mp
+        # mp.dps = 150
+        #
+        # def sf(t):
+        #     t = mp.mpf(t)
+        #     def pdf(x):
+        #         y = mp.cos(2 * x)
+        #         return y
+        #
+        #     y = float(mp.quad(lambda z: pdf(z), [t, mp.pi / 4]))
+        #     return y
+        assert_allclose(stats.anglit.sf(t), ref, rtol=1e-14)
+
+
 class TestWrapCauchy:
 
     def test_cdf_shape_broadcasting(self):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -8371,8 +8371,10 @@ class TestNakagami:
 class TestAnglit:
 
     @pytest.mark.parametrize("t, ref",
-                            [(-0.6, 0.9660195429836131),
-                             (0.6, 0.033980457016386835)])
+                            [(-np.pi/4 + 1e-6, 0.999999999999),
+                             (-0.6, 0.9660195429836131),
+                             (0.6, 0.033980457016386835),
+                             (np.pi/4 - 1e-6, 1.0000000001184104e-12)])
     def test_sf(self, t, ref):
         # Reference values were calculated with mpmath:
         # from mpmath import mp


### PR DESCRIPTION
[skip azp] [skip circle] [skip cirrus]

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Part of #17832
#### What does this implement/fix?
<!--Please explain your changes.-->
Adds the survival function to the anglit distribution
#### Additional information
<!--Any additional information you think is important.-->
