### PR TITLE
ENH: Added `_rvs` method for log-uniform distribution (#17832)

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -8257,6 +8257,11 @@ class reciprocal_gen(rv_continuous):
     def _get_support(self, a, b):
         return a, b
 
+    def _rvs(self, a, b, size=1, random_state=None):
+        u = random_state.uniform(size=size)
+        x = np.exp(u * (np.log(b) - np.log(a)) + np.log(a))
+        return x
+
     def _pdf(self, x, a, b):
         # reciprocal.pdf(x, a, b) = 1 / (x*(log(b) - log(a)))
         return np.exp(self._logpdf(x, a, b))

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -8127,6 +8127,13 @@ class TestLogUniform:
         mean = (b - a)/(np.log(b) - np.log(a))
         assert_allclose(dist.mean(), mean)
 
+    def test_rvs(self):
+        a = 0.3
+        b = 1.7
+        X = stats.loguniform.rvs(a, b, size=10000)
+        m = stats.loguniform.mean(a, b)
+        assert_allclose(m, np.sum(X) / len(X), rtol=1e-2)
+
 
 class TestArgus:
     def test_argus_rvs_large_chi(self):


### PR DESCRIPTION
[skip circle] [skip azp] [skip cirrus]

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Part of #17832 
#### What does this implement/fix?
<!--Please explain your changes.-->
Adds `_rvs` method for log-uniform distribution.
#### Additional information
<!--Any additional information you think is important.-->
Uses the inverse transform method to get the random variates.
[Loguniform_RVS.pdf](https://github.com/scipy/scipy/files/11022794/Loguniform_RVS.pdf)
