### PR TITLE
DOC: wheel build infra updates

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,8 +18,8 @@ pr:
     include:
     - '*'  # must quote since "*" is a YAML reserved character; we want a string
 
-# the version of OpenBLAS used is currently 0.3.21
-# and should be updated to match scipy-wheels as appropriate
+# the version of OpenBLAS used is currently 0.3.21.dev
+# and should be updated to match tools/openblas_support as appropriate
 variables:
     openblas_version: 0.3.21.dev
     pre_wheels: https://pypi.anaconda.org/scipy-wheels-nightly/simple

--- a/doc/source/dev/core-dev/distributing.rst.inc
+++ b/doc/source/dev/core-dev/distributing.rst.inc
@@ -147,16 +147,14 @@ and distributing them on PyPI or elsewhere.
 - Build against the lowest NumPy version that you need to support, then it will
   work for all NumPy versions with the same major version number (NumPy does
   maintain backwards ABI compatibility).
+- The easiest available toolchain for building portable SciPy binaries
+  is our ``cibuildwheel`` infrastructure for common platforms, with
+  details available in our CI infrastructure code and available via the
+  ``cibuildwheel`` command on Windows, Linux, and MacOS, albeit with some extra
+  external dependencies required in some cases
 
 **Windows**
 
-- The currently most easily available toolchain for building
-  Python.org compatible binaries for SciPy is installing MSVC (see
-  https://wiki.python.org/moin/WindowsCompilers) and mingw64-gfortran.
-  Support for this configuration requires numpy.distutils from
-  NumPy >= 1.14.dev and a gcc/gfortran-compiled static ``openblas.a``.
-  This configuration is currently used in the Appveyor configuration for
-  https://github.com/MacPython/scipy-wheels
 - For 64-bit Windows installers built with a free toolchain, use the method
   documented at https://github.com/numpy/numpy/wiki/Mingw-static-toolchain.
   That method will likely be used for SciPy itself once it's clear that the
@@ -179,22 +177,12 @@ and distributing them on PyPI or elsewhere.
   longer supported, g77 support isn't needed anymore and SciPy can now include
   Fortran 90/95 code.
 
-**OS X**
-
-- To produce OS X wheels that work with various Python versions (from
-  python.org, Homebrew, MacPython), use the build method provided by
-  https://github.com/MacPython/scipy-wheels.
-- DMG installers for the Python from python.org on OS X can still be produced
-  by ``tools/scipy-macosx-installer/``.  SciPy doesn't distribute those
-  installers anymore though, now that there are binary wheels on PyPi.
-
 **Linux**
 
-- PyPi-compatible Linux wheels can be produced via the manylinux_ project.
-  The corresponding build setup for TravisCI for SciPy is set up in
-  https://github.com/MacPython/scipy-wheels.
+- PyPI-compatible Linux wheels can be produced via the manylinux_ project,
+  which is used under the hood by our ``cibuildwheel`` infrastructure.
 
-Other Linux build-setups result to PyPi incompatible wheels, which
+Other Linux build-setups result in PyPI incompatible wheels, which
 would need to be distributed via custom channels, e.g. in a
 Wheelhouse_, see at the wheel_ and Wheelhouse_ docs.
 

--- a/doc/source/dev/core-dev/releasing.rst.inc
+++ b/doc/source/dev/core-dev/releasing.rst.inc
@@ -152,31 +152,21 @@ by running ``python dev.py notes`` (with tags, see ``python dev.py notes
 after you've created the signed tag locally.  If this completes without issues,
 push the release commit (not the tag, see section above) to the scipy repo.
 
-To build wheels, push a commit to a branch used for the current release at
-https://github.com/MacPython/scipy-wheels . This triggers builds for all needed
-Python versions on TravisCI.  Update and check the ``.travis.yml`` and ``appveyor.yml``
-config files what commit to build, and what Python and NumPy are used for the
-builds (it needs to be the lowest supported NumPy version for each Python
-version). See the README file in the scipy-wheels repo for more details. Note that
-because several months may pass between ``SciPy`` releases, it is sometimes necessary
-to update the versions of the ``gfortran-install`` and ``multibuild`` submodules
-used for wheel builds. If the wheels builds reveal issues that need to be fixed
+To build wheels, push a commit containing the text ``[wheel build]`` to the branch
+used for the current release. This triggers ``cibuildwheel`` builds for all needed
+Python versions and platforms. The appropriate version pins for NumPy and other
+dependencies should have been updated in ``pyproject.toml`` prior to branching.
+If the wheel builds reveal issues that need to be fixed
 with backports on the maintenance branch, you may remove the local tags (for example
 ``git tag -d v1.2.0rc1``) and restart with tagging above on the new candidate commit.
 
-The TravisCI and Appveyor builds run the tests from the built wheels and if they pass,
-upload the wheels to a container pointed to at https://github.com/MacPython/scipy-wheels
-Once there are successful wheel builds, it is recommended to create a versioned branch
-in the ``scipy-wheels`` repo, which will for example be adjusted to point to different
-maintenance branch commits if there are multiple release candidates.
+The ``cibuildwheel`` infrastructure runs the tests from the built wheels and if they pass,
+uploads the wheels to https://anaconda.org/multibuild-wheels-staging/scipy.
 
 From there you can download them for uploading to PyPI. This can be
 done in an automated fashion using ``tools/download-wheels.py``::
 
   $ python tools/download-wheels.py 1.5.0rc1 -w REPO_ROOT/release/installers
-
-The correct URL to use is shown in https://github.com/MacPython/scipy-wheels
-and should agree with the above one.
 
 After this, we want to regenerate the README file, in order to have the MD5 and
 SHA256 checksums of the just downloaded wheels in it.  Run ``python dev.py
@@ -190,7 +180,7 @@ For a release there are currently five places on the web to upload things to:
 - PyPI (sdist, wheels)
 - GitHub Releases (sdist, release notes, Changelog)
 - scipy.org (an announcement of the release)
-- docs.scipy.org (html/pdf docs)
+- docs.scipy.org (html docs)
 
 **PyPI:**
 

--- a/doc/source/dev/core-dev/releasing.rst.inc
+++ b/doc/source/dev/core-dev/releasing.rst.inc
@@ -155,7 +155,7 @@ push the release commit (not the tag, see section above) to the scipy repo.
 To build wheels, push a commit containing the text ``[wheel build]`` to the branch
 used for the current release. This triggers ``cibuildwheel`` builds for all needed
 Python versions and platforms. The appropriate version pins for NumPy and other
-dependencies should have been updated in ``pyproject.toml`` prior to branching.
+dependencies should have been updated in ``pyproject.toml`` just after branching.
 If the wheel builds reveal issues that need to be fixed
 with backports on the maintenance branch, you may remove the local tags (for example
 ``git tag -d v1.2.0rc1``) and restart with tagging above on the new candidate commit.

--- a/doc/source/dev/roadmap-detailed.rst
+++ b/doc/source/dev/roadmap-detailed.rst
@@ -97,15 +97,14 @@ existence of (possibly partial) alternatives, *including those inside SciPy*.
 
 Continuous integration
 ``````````````````````
-Continuous integration currently covers 32/64-bit Windows, macOS on x86-64, and
+Continuous integration currently covers 32/64-bit Windows, macOS on x86-64/arm,
 32/64-bit Linux on x86, and Linux on aarch64 - as well as a range of versions
 of our dependencies and building release quality wheels. Reliability of CI has
-not been good recently (H2 2021), due to the large amount of configurations to
-support and some CI jobs needing an overhaul. We aim to reduce build times,
-improve caching, move more jobs to GitHub Actions, drop TravisCI and Appveyor
-in the `scipy-wheels repo <https://github.com/MacPython/scipy-wheels>`_,
-move from ``multibuild`` to ``cibuildwheel`` for building wheels for releases,
-and make the set of configurations in CI jobs more orthogonal.
+not been good recently (H1 2023), due to the large amount of configurations to
+support and some CI jobs needing an overhaul. We aim to reduce build times by
+removing the remaining distutils-based jobs when we drop that build system,
+move more jobs from Azure Pipelines to GitHub Actions, and make the set of
+configurations in CI jobs more orthogonal.
 
 
 Size of binaries

--- a/doc/source/dev/toolchain.rst
+++ b/doc/source/dev/toolchain.rst
@@ -125,13 +125,13 @@ Currently, SciPy wheels are being built as follows:
  Platform          Azure Base Image [5]_     Compilers                    Comment
 ================  ========================  ===========================  ==============================
 Linux (nightly)    ``ubuntu-20.04``          GCC 6.5                      See ``azure-pipelines.yml``
-Linux (release)    ``ubuntu-22.04``          GCC 8                        Built in separate repo [6]_
-OSX                ``macOS-10.15``           LLVM 12.0.0                  Built in separate repo [6]_
-Windows            ``windows-2019``          Visual Studio 2019 (vc142)   Built in separate repo [6]_
+Linux (release)    ``ubuntu-22.04``          GCC 8                        ``cibuildwheel``
+OSX                ``macOS-10.15``           LLVM 12.0.0                  ``cibuildwheel``
+Windows            ``windows-2019``          Visual Studio 2019 (vc142)   ``cibuildwheel``
 ================  ========================  ===========================  ==============================
 
-Note that the OSX wheels additionally vendor gfortran 4.9,
-see submodule ``gfortran-install`` in [6]_.
+Note that the OSX wheels additionally vendor gfortran 11.3.0,
+see ``tools/wheels/cibw_before_build_macos.sh``.
 
 
 C Compilers
@@ -448,7 +448,6 @@ References
 .. [3] https://scipy.github.io/devdocs/release.html
 .. [4] https://github.com/scipy/oldest-supported-numpy
 .. [5] https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted
-.. [6] https://github.com/MacPython/scipy-wheels
 .. [7] https://docs.microsoft.com/en-us/cpp/overview/visual-cpp-in-visual-studio
 .. [8] https://en.wikipedia.org/wiki/Microsoft_Visual_C%2B%2B#Internal_version_numbering
 .. [9] https://docs.microsoft.com/en-gb/cpp/windows/universal-crt-deployment

--- a/doc/source/dev/toolchain.rst
+++ b/doc/source/dev/toolchain.rst
@@ -121,17 +121,18 @@ Official Builds
 
 Currently, SciPy wheels are being built as follows:
 
-================  ========================  ===========================  ==============================
- Platform          Azure Base Image [5]_     Compilers                    Comment
-================  ========================  ===========================  ==============================
-Linux (nightly)    ``ubuntu-20.04``          GCC 6.5                      See ``azure-pipelines.yml``
-Linux (release)    ``ubuntu-22.04``          GCC 8                        ``cibuildwheel``
-OSX                ``macOS-10.15``           LLVM 12.0.0                  ``cibuildwheel``
-Windows            ``windows-2019``          Visual Studio 2019 (vc142)   ``cibuildwheel``
-================  ========================  ===========================  ==============================
+================    ==============================   ==============================   =============================
+ Platform            CI Base Images [5]_ [6]_ [7]_    Compilers                        Comment
+================    ==============================   ==============================   =============================
+Linux x86            ``ubuntu-22.04``                 GCC 10.2.1                       ``cibuildwheel``
+Linux arm            ``docker-builder-arm64``         GCC 11.3.0                       ``cibuildwheel``
+OSX x86              ``macOS-11``                     clang-13/gfortran 11.3.0         ``cibuildwheel``
+OSX arm              ``macos-monterey-xcode:14``      clang-13.1.6/gfortran 12.1.0     ``cibuildwheel``
+Windows              ``windows-2019``                 GCC 10.3 (rtools)                ``cibuildwheel``
+================    ==============================   ==============================   =============================
 
-Note that the OSX wheels additionally vendor gfortran 11.3.0,
-see ``tools/wheels/cibw_before_build_macos.sh``.
+Note that the OSX wheels additionally vendor gfortran 11.3.0 for x86_64,
+and gfortran 12.1.0 for arm64. See ``tools/wheels/cibw_before_build_macos.sh``.
 
 
 C Compilers
@@ -146,7 +147,7 @@ to the table at the end.
 
 In the past, the most restrictive compiler on relevant platform in terms
 of C support was the Microsoft Visual C++ compiler & toolset (together known
-as MSVC) [7]_ [8]_. Up until Visual Studio 2013, each MSVC version came with
+as MSVC) [8]_ [9]_. Up until Visual Studio 2013, each MSVC version came with
 an updated C Runtime (CRT) library that was incompatible with the previous
 ones.
 
@@ -163,11 +164,11 @@ to the earlier C90 standard for the language and standard library. After
 dropping support for CPython 2.7 in SciPy 1.3.x, that restriction was finally
 lifted (though only gradually at first).
 
-With the introduction of the "Universal C Runtime" (UCRT) [9]_ since the
+With the introduction of the "Universal C Runtime" (UCRT) [10]_ since the
 release of Visual Studio 2015, the ABI of C Runtime has been stable, which
 means that the restriction of having to use the same compiler version for
 SciPy as for the underlying CPython version is no longer applicable. This
-stability is not indefinite though: Microsoft has been planning [10]_ an
+stability is not indefinite though: Microsoft has been planning [11]_ an
 ABI-breaking release - across the compiler resp. C/C++ standard libraries -
 (tentatively called "vNext") for quite a while, but so far it is unclear
 when this will arrive. Once that happens, SciPy will again be restricted to
@@ -177,7 +178,7 @@ upstream with vNext-compatible compilers.
 
 More specifically, there is a distinction between the Microsoft Visual
 Studio version and the version of the targeted "toolset", which is defined
-[11]_ as "The Microsoft C++ compiler, linker, standard libraries, and related
+[12]_ as "The Microsoft C++ compiler, linker, standard libraries, and related
 utilities". Each version of Visual Studio comes with a default version of the
 MSVC toolset (for example VS2017 with vc141, VS2019 with vc142), but it is
 possible to target older toolsets even in newer versions of Visual Studio.
@@ -195,7 +196,7 @@ more of an issue for NumPy than SciPy, as the latter has only a small C API
 and is compiled against by far fewer projects than NumPy. Additionally, using
 a newer toolset means that users of libraries that compile C++ code (as SciPy
 does) might also need a newer Microsoft Visual C++ Redistributable, which
-might have to be distributed to them [12]_.
+might have to be distributed to them [13]_.
 
 Summing up, the minimal requirement for the MSVC compiler resp. toolset per
 SciPy version was determined predominantly by the oldest supported CPython
@@ -217,18 +218,18 @@ SciPy version    CPython support    MS Visual C++      Toolset version
 ==============  =================  =================  =================
 
 In terms of C language standards, it's relevant to note that C11 has optional
-features [13]_ (e.g. atomics, threading), some of which (VLAs & complex types)
+features [14]_ (e.g. atomics, threading), some of which (VLAs & complex types)
 were mandatory in the C99 standard. C17 (occasionally called C18) can be
 considered a bug fix for C11, so generally, C11 may be skipped entirely.
 
 SciPy has been restricted in the use of more advanced language features by the
 available compiler support, and Microsoft in particular has taken very long to
 achieve conformance to C99/C11/C17, however starting from MS Visual Studio 16.8,
-C11/C17 is supported [14]_ (though without the C11 optional features).
+C11/C17 is supported [15]_ (though without the C11 optional features).
 C99 ``<complex.h>`` would be particularly interesting for SciPy;
-MSVC conformance for this and ``<stdatomic.h>`` is being tracked here [15]_ [16]_.
+MSVC conformance for this and ``<stdatomic.h>`` is being tracked here [16]_ [17]_.
 However, it's still possible to use complex types on windows, provided that
-windows-specific types are used [17]_.
+windows-specific types are used [18]_.
 
 Therefore, using C features beyond C90 was only possible insofar there was support on
 Windows; however, as of as of the end of 2021, a sufficiently recent compiler is used.
@@ -271,24 +272,24 @@ CPython) has been recent enough to support even C++17.
 Since the official builds (see above) use a pretty recent version of LLVM,
 the bottleneck for C++ support is therefore the oldest supported GCC version,
 where SciPy has been constrained mainly by the version in the oldest supported
-manylinux versions & images [18]_.
+manylinux versions & images [19]_.
 
 At the end of 2021 (with the final removal of ``manylinux1`` wheels), the
-minimal requirement of GCC moved to 6.3, which has full C++14 support [19]_.
+minimal requirement of GCC moved to 6.3, which has full C++14 support [20]_.
 This corresponded to the lowest-present GCC version in relevant manylinux
 versions, though this was still considering the Debian-based "outlier"
 ``manylinux_2_24``, which - in contrast to previous manylinux images based on
 RHEL-derivative CentOS that could benefit from the ABI-compatible GCC backports
 in the "RHEL Dev Toolset" - was stuck with GCC 6.3. That image failed to take
-off not least due to those outdated compilers [20]_ and reached its EOL in
-mid-2022 [21]_. For different reasons, ``manylinux2010`` also reached its EOL
-around the same time [22]_.
+off not least due to those outdated compilers [21]_ and reached its EOL in
+mid-2022 [22]_. For different reasons, ``manylinux2010`` also reached its EOL
+around the same time [23]_.
 
 The remaining images ``manylinux2014`` and ``manylinux_2_28`` currently support
 GCC 10 and 11, respectively. The latter will continue to receive updates as new
 GCC versions become available as backports, but the former will likely not
 change since the CentOS project is not responsive anymore about publishing
-aarch64 backports of GCC 11 [23]_.
+aarch64 backports of GCC 11 [24]_.
 
 This leaves all the main platforms and their compilers with comparatively
 recent versions. However, SciPy has historically also endeavored to support
@@ -297,11 +298,11 @@ then at least by remaining compilable from source - which includes for example
 AIX, Alpine Linux and FreeBSD.
 
 For AIX 7.1 & 7.2 the default compiler is GCC 8 (AIX 6.1 had its EOL in 2017),
-but GCC 10 is installable (side-by-side) [24]_.
-The oldest currently-supported Alpine Linux release is 3.12 [25]_, and already
+but GCC 10 is installable (side-by-side) [25]_.
+The oldest currently-supported Alpine Linux release is 3.12 [26]_, and already
 comes with GCC 10.
-For FreeBSD, the oldest currently-supported 12.x release [26]_ comes with
-LLVM 10 (and GCC 10 is available as a freebsd-port [27]_).
+For FreeBSD, the oldest currently-supported 12.x release [27]_ comes with
+LLVM 10 (and GCC 10 is available as a freebsd-port [28]_).
 
 Finally there is the question of which machines are widely used by people
 needing to compile SciPy from source for other reasons (e.g. SciPy developers,
@@ -318,10 +319,10 @@ All the currently lowest-supported compiler versions (GCC 8, LLVM 12,
 VS2019 with vc142) have full support for the C++17 *core language*,
 which can therefore be used unconditionally.
 However, as of mid-2022, support for the entirety of the C++17 standard library
-has not yet been completed across all compilers [19]_, particularly LLVM.
+has not yet been completed across all compilers [20]_, particularly LLVM.
 It is therefore necessary to check if a given stdlib-feature is supported by
 all compilers before it can be used in SciPy.
-Compiler support for C++20 and C++23 is still under heavy development [19]_.
+Compiler support for C++20 and C++23 is still under heavy development [20]_.
 
 Fortran Compilers
 ~~~~~~~~~~~~~~~~~
@@ -348,7 +349,7 @@ is a build dependency (currently with the possibility to opt out).
 OpenMP support
 ^^^^^^^^^^^^^^
 
-For various reasons [28]_, SciPy cannot be distributed with built-in OpenMP support.
+For various reasons [29]_, SciPy cannot be distributed with built-in OpenMP support.
 When using the optional Pythran support, OpenMP-enabled parallel code can be
 generated when building from source.
 
@@ -447,26 +448,28 @@ References
 .. [2] https://numpy.org/doc/stable/release.html
 .. [3] https://scipy.github.io/devdocs/release.html
 .. [4] https://github.com/scipy/oldest-supported-numpy
-.. [5] https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted
-.. [7] https://docs.microsoft.com/en-us/cpp/overview/visual-cpp-in-visual-studio
-.. [8] https://en.wikipedia.org/wiki/Microsoft_Visual_C%2B%2B#Internal_version_numbering
-.. [9] https://docs.microsoft.com/en-gb/cpp/windows/universal-crt-deployment
-.. [10] https://github.com/microsoft/STL/issues/169
-.. [11] https://docs.microsoft.com/en-us/cpp/build/projects-and-build-systems-cpp#the-msvc-toolset
-.. [12] https://docs.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist
-.. [13] https://en.wikipedia.org/wiki/C11_%28C_standard_revision%29#Optional_features
-.. [14] https://docs.microsoft.com/en-us/cpp/overview/visual-cpp-language-conformance#c-standard-library-features-1
-.. [15] https://developercommunity.visualstudio.com/t/714008
-.. [16] https://developercommunity.visualstudio.com/t/1204057
-.. [17] https://docs.microsoft.com/en-us/cpp/c-runtime-library/complex-math-support
-.. [18] https://github.com/mayeut/pep600_compliance
-.. [19] https://en.cppreference.com/w/cpp/compiler_support
-.. [20] https://github.com/pypa/manylinux/issues/1012
-.. [21] https://github.com/pypa/manylinux/issues/1332
-.. [22] https://github.com/pypa/manylinux/issues/1281
-.. [23] https://github.com/pypa/manylinux/issues/1266
-.. [24] https://www.ibm.com/support/pages/aix-toolbox-open-source-software-downloads-alpha#G
-.. [25] https://alpinelinux.org/releases/
-.. [26] https://www.freebsd.org/releases/
-.. [27] https://www.freebsd.org/status/report-2021-04-2021-06/gcc/
-.. [28] https://github.com/scipy/scipy/issues/10239
+.. [5] https://github.com/actions/runner-images
+.. [6] https://cirrus-ci.org/guide/docker-builder-vm/#under-the-hood
+.. [7] https://github.com/orgs/cirruslabs/packages?tab=packages&q=macos
+.. [8] https://docs.microsoft.com/en-us/cpp/overview/visual-cpp-in-visual-studio
+.. [9] https://en.wikipedia.org/wiki/Microsoft_Visual_C%2B%2B#Internal_version_numbering
+.. [10] https://docs.microsoft.com/en-gb/cpp/windows/universal-crt-deployment
+.. [11] https://github.com/microsoft/STL/issues/169
+.. [12] https://docs.microsoft.com/en-us/cpp/build/projects-and-build-systems-cpp#the-msvc-toolset
+.. [13] https://docs.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist
+.. [14] https://en.wikipedia.org/wiki/C11_%28C_standard_revision%29#Optional_features
+.. [15] https://docs.microsoft.com/en-us/cpp/overview/visual-cpp-language-conformance#c-standard-library-features-1
+.. [16] https://developercommunity.visualstudio.com/t/714008
+.. [17] https://developercommunity.visualstudio.com/t/1204057
+.. [18] https://docs.microsoft.com/en-us/cpp/c-runtime-library/complex-math-support
+.. [19] https://github.com/mayeut/pep600_compliance
+.. [20] https://en.cppreference.com/w/cpp/compiler_support
+.. [21] https://github.com/pypa/manylinux/issues/1012
+.. [22] https://github.com/pypa/manylinux/issues/1332
+.. [23] https://github.com/pypa/manylinux/issues/1281
+.. [24] https://github.com/pypa/manylinux/issues/1266
+.. [25] https://www.ibm.com/support/pages/aix-toolbox-open-source-software-downloads-alpha#G
+.. [26] https://alpinelinux.org/releases/
+.. [27] https://www.freebsd.org/releases/
+.. [28] https://www.freebsd.org/status/report-2021-04-2021-06/gcc/
+.. [29] https://github.com/scipy/scipy/issues/10239


### PR DESCRIPTION
Fixes #17985

* update the detailed roadmap CI section to remove discussion of the old `scipy-wheels` repo, and to modernize the plans there a bit

* similarly, the core dev distributor guide has been updated to point folks to `cibuildwheel` and remove references to `scipy-wheels` repo; a few small modernizations were performed here for things that seem way out of date

* the release management guide has been modernized to describe usage of `cibuildwheel` instead of the archived `scipy-wheels` infrastructure; a few other small modernizations, but I'll delay a broader overhaul for now, since this is still a clear improvement

* update the toolchain docs to modernize references to `scipy-wheels` repo, though I didn't try to reflow the reference link numbers for sanity reasons

* azure pipelines still clones someting from the archived scipy-wheels repo, but I've tried to confine this PR to doc changes; I did upate a comment in the azure config re: OpenBLAS and scipy-wheels though

I checked that `python dev.py doc -j 10` worked locally, though I admit I did not check the HTML renders proper.

[skip azp] [skip actions] [skip cirrus]