### PR TITLE
MAINT: stats.ecdf: store number at risk just before events

### DIFF
--- a/scipy/stats/_survival.py
+++ b/scipy/stats/_survival.py
@@ -325,12 +325,15 @@ def _ecdf_uncensored(sample):
     x, counts = np.unique(sample, return_counts=True)
 
     # [1].81 "the fraction of [observations] that are less than or equal to x
-    cdf = np.cumsum(counts) / sample.size
+    events = np.cumsum(counts)
+    n = sample.size
+    cdf = events / n
 
     # [1].89 "the relative frequency of the sample that exceeds x in value"
     sf = 1 - cdf
 
-    return x, cdf, sf, sf * sample.size, counts
+    at_risk = np.concatenate(([n], n - events[:-1]))
+    return x, cdf, sf, at_risk, counts
 
 
 def _ecdf_right_censored(sample):

--- a/scipy/stats/tests/test_survival.py
+++ b/scipy/stats/tests/test_survival.py
@@ -325,3 +325,15 @@ class TestSurvival:
                 0.8263946341076415, 0.6558775085110887, np.nan]
         assert_allclose(ci.low, low)
         assert_allclose(ci.high, high)
+
+    def test_right_censored_against_uncensored(self):
+        rng = np.random.default_rng(7463952748044886637)
+        sample = rng.integers(10, 100, size=1000)
+        censored = np.zeros_like(sample)
+        censored[np.argmax(sample)] = True
+        res = stats.ecdf(sample)
+        ref = stats.ecdf(stats.CensoredData.right_censored(sample, censored))
+        assert_equal(res.sf._x, ref.sf._x)
+        assert_equal(res.sf._n, ref.sf._n)
+        assert_equal(res.sf._d[:-1], ref.sf._d[:-1])  # difference @ [-1]
+        assert_allclose(res.sf._sf[:-1], ref.sf._sf[:-1], rtol=1e-14)


### PR DESCRIPTION
#### Reference issue
gh-18136

#### What does this implement/fix?
(in the language of survival analysis) gh-18136 stored the number "at risk" in the objects produced by `stats.ecdf`. When the data is uncensored, these were the number at risk *just after* the events, but they should be the number at risk *just before* the events as they are for censored data. This PR corrects this and adds a test that compares the objects produced when data is uncensored against those produced when data is censored.

#### Additional information
@tupui this will help with log-rank.