### PR TITLE
BUG: interpolate: add x-y length validation for `make_smoothing_spline`.

### DIFF
--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -1877,9 +1877,9 @@ def make_smoothing_spline(x, y, w=None, lam=None):
     Parameters
     ----------
     x : array_like, shape (n,)
-        Abscissas.
+        Abscissas. `n` must be larger than 5.
     y : array_like, shape (n,)
-        Ordinates.
+        Ordinates. `n` must be larger than 5.
     w : array_like, shape (n,), optional
         Vector of weights. Default is ``np.ones_like(x)``.
     lam : float, (:math:`\lambda \geq 0`), optional
@@ -1979,6 +1979,9 @@ def make_smoothing_spline(x, y, w=None, lam=None):
 
     t = np.r_[[x[0]] * 3, x, [x[-1]] * 3]
     n = x.shape[0]
+
+    if n <= 4:
+        raise ValueError('``x`` and ``y`` length must be larger than 5')
 
     # It is known that the solution to the stated minimization problem exists
     # and is a natural cubic spline with vector of knots equal to the unique

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -1560,6 +1560,13 @@ class TestSmoothingSpline:
         with assert_raises(ValueError):
             make_smoothing_spline(x_dupl, y)
 
+        # x and y length must be larger than 5
+        x = np.arange(4)
+        y = np.ones(4)
+        exception_message = "``x`` and ``y`` length must be larger than 5"
+        with pytest.raises(ValueError, match=exception_message):
+            make_smoothing_spline(x, y)
+
     def test_compare_with_GCVSPL(self):
         """
         Data is generated in the following way:


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
To fix #18115 

#### What does this implement/fix?
<!--Please explain your changes.-->
I added x-y length validation for `make_smoothing_spline` and tests.

#### Additional information
<!--Any additional information you think is important.-->
