### PR TITLE
ENH: fix vonmises fit for bad guess of location parameter

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -10029,9 +10029,17 @@ class vonmises_gen(rv_continuous):
             def solve_for_kappa(kappa):
                 return sc.i1e(kappa)/sc.i0e(kappa) - r
 
-            root_res = root_scalar(solve_for_kappa, method="brentq",
+            try:
+                root_res = root_scalar(solve_for_kappa, method="brentq",
                                    bracket=(1e-8, 1e12))
-            return root_res.root
+                return root_res.root
+            # if the provided floc is very far from the circular mean,
+            # the likelihood equation does not have a solution.
+            # In that case, the best kappa is 0, practically the uniform
+            # distribution on the circle. As vonmises is defined for
+            # kappa > 0, return the smallest floating point value
+            except ValueError:
+                return np.finfo(float).tiny
 
         # location likelihood equation has a solution independent of kappa
         loc = floc if floc is not None else find_mu(data)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -244,6 +244,20 @@ class TestVonMises:
         assert scale_fit == 1
         assert_allclose(kappa, kappa_fit, rtol=1e-2)
 
+    @pytest.mark.xslow
+    def test_vonmises_fit_bad_floc(self):
+        data = [-0.92923506, -0.32498224, 0.13054989, -0.97252014, 2.79658071,
+                -0.89110948, 1.22520295, 1.44398065, 2.49163859, 1.50315096,
+                3.05437696, -2.73126329, -3.06272048, 1.64647173, 1.94509247,
+                -1.14328023, 0.8499056, 2.36714682, -1.6823179, -0.88359996]
+        data = np.asarray(data)
+        loc = -0.5 * np.pi
+        kappa_fit, loc_fit, scale_fit = stats.vonmises.fit(data, floc=loc)
+        assert kappa_fit == np.finfo(float).tiny
+        kwds = {'fscale': 1, 'floc': loc}
+        _assert_less_or_close_loglike(stats.vonmises, data,
+                                      stats.vonmises.nnlf, **kwds)
+
     @pytest.mark.parametrize('sign', [-1, 1])
     def test_vonmises_fit_unwrapped_data(self, sign):
         rng = np.random.default_rng(6762668991392531563)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -245,13 +245,13 @@ class TestVonMises:
         assert_allclose(kappa, kappa_fit, rtol=1e-2)
 
     @pytest.mark.xslow
-    def test_vonmises_fit_bad_floc(self):
+    @pytest.mark.parametrize('loc', [-0.5 * np.pi, -0.9 * np.pi])
+    def test_vonmises_fit_bad_floc(self, loc):
         data = [-0.92923506, -0.32498224, 0.13054989, -0.97252014, 2.79658071,
                 -0.89110948, 1.22520295, 1.44398065, 2.49163859, 1.50315096,
                 3.05437696, -2.73126329, -3.06272048, 1.64647173, 1.94509247,
                 -1.14328023, 0.8499056, 2.36714682, -1.6823179, -0.88359996]
         data = np.asarray(data)
-        loc = -0.5 * np.pi
         kappa_fit, loc_fit, scale_fit = stats.vonmises.fit(data, floc=loc)
         assert kappa_fit == np.finfo(float).tiny
         _assert_less_or_close_loglike(stats.vonmises, data,

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -254,9 +254,8 @@ class TestVonMises:
         loc = -0.5 * np.pi
         kappa_fit, loc_fit, scale_fit = stats.vonmises.fit(data, floc=loc)
         assert kappa_fit == np.finfo(float).tiny
-        kwds = {'fscale': 1, 'floc': loc}
         _assert_less_or_close_loglike(stats.vonmises, data,
-                                      stats.vonmises.nnlf, **kwds)
+                                      stats.vonmises.nnlf, fscale=1, floc=loc)
 
     @pytest.mark.parametrize('sign', [-1, 1])
     def test_vonmises_fit_unwrapped_data(self, sign):


### PR DESCRIPTION
#### Reference issue
Follow up of #18128

#### What does this implement/fix?
For a very bad guess of the location parameter, the maximum likelihood equation of the concentration parameter $\kappa$ does not have a solution. In that case, the maximum likelihood estimate is $\kappa=0$. No formal proof (see below) but intuitively, if the location does not fit at all, it is better to assume a uniform distribution on the cirlce. This PR catches the Rootfinding error and returns the tiniest floating point value.

#### Additional information
With the data of the test case and `loc=pi/2`, the `kappa` equation does not have a root. See below.

![image](https://user-images.githubusercontent.com/40656107/227007312-27ea237a-a193-43fb-ab02-8dde4c00b01f.png)

<details>
<summary>Generate the plot</summary>

```
import numpy as np
from scipy import stats
from scipy import special as sc
import matplotlib.pyplot as plt

rvs = [-0.92923506, -0.32498224,  0.13054989, -0.97252014,  2.79658071,
       -0.89110948,  1.22520295,  1.44398065,  2.49163859,  1.50315096,
        3.05437696, -2.73126329, -3.06272048,  1.64647173,  1.94509247,
       -1.14328023,  0.8499056 ,  2.36714682, -1.6823179 , -0.88359996]

data = np.asarray(rvs)

fixed = -0.5 * np.pi
r_fixed = np.sum(np.cos(fixed - data))/len(data)
r_free = 1 - stats.circvar(data,low=-np.pi, high=np.pi)

kappas = np.logspace(-20, 20, 1000)
plt.semilogx(kappas, sc.i1e(kappas)/sc.i0e(kappas) - r_fixed, label="fixed loc")
plt.semilogx(kappas, sc.i1e(kappas)/sc.i0e(kappas) - r_free, label="free loc")
plt.legend()
plt.show()
```

</details>

*Proof*

In #18128 it was mentioned that the partial derivative will of the log likelihood will tell if the MLE is the left end of the parameter range (0) or the right end ($\infty$). This result is not unambiguous though as the derivative still depends on $\kappa$. Or I might be doing a mistake here?

$$
\begin{equation}
logp(x_1, ... ,x_n| \mu, \kappa) =  \sum_{i=1}^N\kappa\cos(x_i-\mu) - \ln(2\pi)-\ln(I_0(\kappa))
\end{equation}
$$

The partial derivative:

$$
\begin{equation}
\frac{\partial logp}{\partial\kappa}(x_1, ..., ,x_n| \mu, \kappa) = \sum_{i=1}^N \underbrace{\cos(x_i-\mu)}_{\in [-1, 1]} - \underbrace{\frac{I_0'(\kappa)}{I_0(\kappa)}}_{\in [0, 1]}
\end{equation}
$$