### PR TITLE
FIX trigger indptr/indices copy when data are copied in astype

### DIFF
--- a/scipy/sparse/_csparsetools.pyx.in
+++ b/scipy/sparse/_csparsetools.pyx.in
@@ -176,7 +176,11 @@ def _lil_get_lengths_{{NAME}}(object[:] input,
 
 {{define_dispatch_map('_LIL_GET_LENGTHS_DISPATCH', '_lil_get_lengths', IDX_TYPES)}}
 
-def lil_flatten_to_array(object[:] input,
+ctypedef fused obj_fused:
+    object
+    double
+
+def lil_flatten_to_array(const obj_fused[:] input,
                          cnp.ndarray output):
     return _LIL_FLATTEN_TO_ARRAY_DISPATCH[output.dtype](input, output)
 
@@ -311,7 +315,7 @@ def _lil_fancy_set_{{PYIDX}}_{{PYVALUE}}(cnp.npy_intp M, cnp.npy_intp N,
 
 
 def lil_get_row_ranges(cnp.npy_intp M, cnp.npy_intp N,
-                       object[:] rows, object[:] datas,
+                       const obj_fused[:] rows, const obj_fused[:] datas,
                        object[:] new_rows, object[:] new_datas,
                        object irows,
                        cnp.npy_intp j_start,

--- a/scipy/sparse/_csparsetools.pyx.in
+++ b/scipy/sparse/_csparsetools.pyx.in
@@ -176,6 +176,10 @@ def _lil_get_lengths_{{NAME}}(object[:] input,
 
 {{define_dispatch_map('_LIL_GET_LENGTHS_DISPATCH', '_lil_get_lengths', IDX_TYPES)}}
 
+# We define the fuse type below because Cython does not currently allow to
+# declare object memory views (cf. https://github.com/cython/cython/issues/2485)
+# We can track the support of object memory views in
+# https://github.com/cython/cython/pull/4712
 ctypedef fused obj_fused:
     object
     double

--- a/scipy/sparse/_data.py
+++ b/scipy/sparse/_data.py
@@ -68,9 +68,11 @@ class _data_matrix(spmatrix):
     def astype(self, dtype, casting='unsafe', copy=True):
         dtype = np.dtype(dtype)
         if self.dtype != dtype:
-            return self._with_data(
-                self._deduped_data().astype(dtype, casting=casting, copy=copy),
-                copy=copy)
+            matrix = self._with_data(
+                self.data.astype(dtype, casting=casting, copy=True),
+                copy=True
+            )
+            return matrix._with_data(matrix._deduped_data(), copy=False)
         elif copy:
             return self.copy()
         else:

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1302,6 +1302,10 @@ class _TestCommon:
         S = self.spmatrix(D)
         if hasattr(S, 'data'):
             S.data.flags.writeable = False
+        if hasattr(S, 'indptr'):
+            S.indptr.flags.writeable = False
+        if hasattr(S, 'indices'):
+            S.indices.flags.writeable = False
         for x in supported_dtypes:
             D_casted = D.astype(x)
             S_casted = S.astype(x)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1294,6 +1294,20 @@ class _TestCommon:
                 for attribute in ('offsets', 'data'):
                     check_equal_but_not_same_array_attribute(attribute)
 
+    @sup_complex
+    def test_astype_immutable(self):
+        D = array([[2.0 + 3j, 0, 0],
+                   [0, 4.0 + 5j, 0],
+                   [0, 0, 0]])
+        S = self.spmatrix(D)
+        if hasattr(S, 'data'):
+            S.data.flags.writeable = False
+        for x in supported_dtypes:
+            D_casted = D.astype(x)
+            S_casted = S.astype(x)
+            assert_equal(S_casted.dtype, D_casted.dtype)
+
+
     def test_asfptype(self):
         A = self.spmatrix(arange(6,dtype='int32').reshape(2,3))
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
closes gh-8678
closes gh-8679
supersede gh-8679

#### What does this implement/fix?
<!--Please explain your changes.-->

In some cases, it happens that the internal arrays of the scipy matrices are memmaped in read-only mode (e.g. using `joblib.Parallel`). Calling `astype` calls `sum_duplicates` (called within `_deduped_data`) that intends to sort the indices of the matrix in place. It will therefore raise an error due to the read-only property.

Here, I trigger a copy of `intptr` and `indices` in the case the `dtype` does not match.

#### Additional information
<!--Any additional information you think is important.-->

As reported in the issue, this problem was reported several times in scikit-learn: https://github.com/scikit-learn/scikit-learn/issues/15924, https://github.com/scikit-learn/scikit-learn/issues/25935, etc.
