### PR TITLE
MAINT: interpolate: remove duplicated FITPACK interface _fitpack._spl_.

### DIFF
--- a/scipy/interpolate/_fitpack_impl.py
+++ b/scipy/interpolate/_fitpack_impl.py
@@ -588,7 +588,10 @@ def splev(x, tck, der=0, ext=0):
         x = asarray(x)
         shape = x.shape
         x = atleast_1d(x).ravel()
-        y, ier = _fitpack._spl_(x, der, t, c, k, ext)
+        if der == 0:
+            y, ier = dfitpack.splev(t, c, k, x, ext)
+        else:
+            y, ier = dfitpack.splder(t, c, k, x, der, ext)
 
         if ier == 10:
             raise ValueError("Invalid input data")

--- a/scipy/interpolate/fitpack/splder.f
+++ b/scipy/interpolate/fitpack/splder.f
@@ -1,16 +1,18 @@
-      recursive subroutine splder(t,n,c,k,nu,x,y,m,e,wrk,ier)
+      recursive subroutine splder(t,n,c,nc,k,nu,x,y,m,e,wrk,ier)
       implicit none  
 c  subroutine splder evaluates in a number of points x(i),i=1,2,...,m
 c  the derivative of order nu of a spline s(x) of degree k,given in
 c  its b-spline representation.
 c
 c  calling sequence:
-c     call splder(t,n,c,k,nu,x,y,m,e,wrk,ier)
+c     call splder(t,n,c,nc,k,nu,x,y,m,e,wrk,ier)
 c
 c  input parameters:
 c    t    : array,length n, which contains the position of the knots.
 c    n    : integer, giving the total number of knots of s(x).
-c    c    : array,length n, which contains the b-spline coefficients.
+c    c    : array,length nc, containing the b-spline coefficients.
+c           the length of the array, nc >= n - k -1.
+c           further coefficients are ignored.
 c    k    : integer, giving the degree of s(x).
 c    nu   : integer, specifying the order of the derivative. 0<=nu<=k
 c    x    : array,length m, which contains the points where the deriv-
@@ -60,9 +62,9 @@ c++   - removed the restriction of the orderness of x values
 c++   - fixed initialization of sp to double precision value
 c
 c  ..scalar arguments..
-      integer n,k,nu,m,e,ier
+      integer n,nc,k,nu,m,e,ier
 c  ..array arguments..
-      real*8 t(n),c(n),x(m),y(m),wrk(n)
+      real*8 t(n),c(nc),x(m),y(m),wrk(n)
 c  ..local scalars..
       integer i,j,kk,k1,k2,l,ll,l1,l2,nk1,nk2,nn
       real*8 ak,arg,fac,sp,tb,te

--- a/scipy/interpolate/fitpack/splev.f
+++ b/scipy/interpolate/fitpack/splev.f
@@ -1,14 +1,16 @@
-      recursive subroutine splev(t,n,c,k,x,y,m,e,ier)
+      recursive subroutine splev(t,n,c,nc,k,x,y,m,e,ier)
 c  subroutine splev evaluates in a number of points x(i),i=1,2,...,m
 c  a spline s(x) of degree k, given in its b-spline representation.
 c
 c  calling sequence:
-c     call splev(t,n,c,k,x,y,m,e,ier)
+c     call splev(t,n,c,nc,k,x,y,m,e,ier)
 c
 c  input parameters:
 c    t    : array,length n, which contains the position of the knots.
 c    n    : integer, giving the total number of knots of s(x).
-c    c    : array,length n, which contains the b-spline coefficients.
+c    c    : array,length nc, containing the b-spline coefficients.
+c           the length of the array, nc >= n - k -1.
+c           further coefficients are ignored.
 c    k    : integer, giving the degree of s(x).
 c    x    : array,length m, which contains the points where s(x) must
 c           be evaluated.
@@ -58,7 +60,7 @@ c
 c  ..scalar arguments..
       integer n, k, m, e, ier
 c  ..array arguments..
-      real*8 t(n), c(n), x(m), y(m)
+      real*8 t(n), c(nc), x(m), y(m)
 c  ..local scalars..
       integer i, j, k1, l, ll, l1, nk1
 c++..

--- a/scipy/interpolate/src/fitpack.pyf
+++ b/scipy/interpolate/src/fitpack.pyf
@@ -110,34 +110,36 @@ static F_INT calc_regrid_lwrk(F_INT mx, F_INT my, F_INT kx, F_INT ky,
 
      !!!!!!!!!! Univariate spline !!!!!!!!!!!
 
-     subroutine splev(t,n,c,k,x,y,m,e,ier)
-       ! y = splev(t,c,k,x,[e])
+     subroutine splev(t,n,c,nc,k,x,y,m,e,ier)
+       ! y,ier = splev(t,c,k,x,[e])
        threadsafe
        real*8 dimension(n),intent(in) :: t
        integer intent(hide),depend(t) :: n=len(t)
-       real*8 dimension(n),depend(n,k),check(len(c)==n),intent(in) :: c
+       real*8 dimension(nc), intent(in), depend(n,k,t),check(len(c)>=n-k-1) :: c
+       integer intent(hide), depend(c) :: nc=len(c)
        integer :: k
        real*8 dimension(m),intent(in) :: x
        real*8 dimension(m),depend(m),intent(out) :: y
        integer intent(hide),depend(x) :: m=len(x)
-       integer check(0<=e && e<=2) :: e=0
-       integer intent(hide) :: ier
+       integer check(0<=e && e<=3) :: e=0
+       integer intent(out) :: ier
      end subroutine splev
 
-     subroutine splder(t,n,c,k,nu,x,y,m,e,wrk,ier)
-       ! dy = splder(t,c,k,x,[nu],[e])
+     subroutine splder(t,n,c,nc,k,nu,x,y,m,e,wrk,ier)
+       ! dy,ier = splder(t,c,k,x,[nu],[e])
        threadsafe
        real*8 dimension(n) :: t
        integer depend(t),intent(hide) :: n=len(t)
-       real*8 dimension(n),depend(n,k),check(len(c)==n),intent(in) :: c
+       real*8 dimension(nc), intent(in), depend(n,k,t),check(len(c)>=n-k-1) :: c
+       integer intent(hide), depend(c) :: nc=len(c)
        integer :: k
        integer depend(k),check(0<=nu && nu<=k) :: nu = 1
        real*8 dimension(m) :: x
        real*8 dimension(m),depend(m),intent(out) :: y
        integer depend(x),intent(hide) :: m=len(x)
-       integer check(0<=e && e<=2) :: e=0
+       integer check(0<=e && e<=3) :: e=0
        real*8 dimension(n),depend(n),intent(cache,hide) :: wrk
-       integer intent(hide) :: ier
+       integer intent(out) :: ier
      end subroutine splder
 
      function splint(t,n,c,nc,k,a,b,wrk)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
A part of https://github.com/scipy/scipy/issues/16729
Ref: https://github.com/scipy/scipy/pull/17038, https://github.com/scipy/scipy/pull/17091, #17303

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR removes handwritten `spl` wrapper, use f2py wrapper instead.

#### Additional information
<!--Any additional information you think is important.-->
