### PR TITLE
ENH: optimize: add a new method `least_squares_lm` for `curve_fit`.

### DIFF
--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -641,12 +641,12 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
               parameters). Use ``np.inf`` with an appropriate sign to disable
               bounds on all or some parameters.
 
-    method : {'lm', 'trf', 'dogbox'}, optional
+    method : {'lm', 'trf', 'dogbox', `least_squares_lm`}, optional
         Method to use for optimization. See `least_squares` for more details.
         Default is 'lm' for unconstrained problems and 'trf' if `bounds` are
         provided. The method 'lm' won't work when the number of observations
         is less than the number of variables, use 'trf' or 'dogbox' in this
-        case.
+        case. `least_squares_lm` uses `least_squares` with 'lm' method.
 
         .. versionadded:: 0.17
     jac : callable, string or None, optional
@@ -876,8 +876,9 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
         else:
             method = 'lm'
 
-    if method == 'lm' and bounded_problem:
-        raise ValueError("Method 'lm' only works for unconstrained problems. "
+    if (method == 'lm' or method == "least_squares_lm") and bounded_problem:
+        raise ValueError("Method 'lm' and `least_squares_lm' only works for "
+                         "unconstrained problems."
                          "Use 'trf' or 'dogbox' instead.")
 
     if check_finite is None:
@@ -967,6 +968,8 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
         if ier not in [1, 2, 3, 4]:
             raise RuntimeError("Optimal parameters not found: " + errmsg)
     else:
+        if method == "least_squares_lm":
+            method = "lm"  # using "lm" of `least_squares`, not `leastsq`.
         # Rename maxfev (leastsq) to max_nfev (least_squares), if specified.
         if 'max_nfev' not in kwargs:
             kwargs['max_nfev'] = kwargs.pop('maxfev', None)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Fix #14337

#### What does this implement/fix?
<!--Please explain your changes.-->
The current `curve_fit` has these methods:
1. `lm`, which is using `leastsq`
2.  `trf`, which is using `least_squares` with `method='trf'`.
3.  `dogbox`, which is using `least_squares` with `method='dogbox'`.

So, the current `curve_fit` is missing a method that is using `least_squares` with `method='lm'`.

Both `leastsq` and `least_squares` with `method='lm'` are based on MINPACK’s lmdif and lmder functions,
but as reported in #14337, `least_squares` with `method='lm'` has some good optional arguments of `least_squares`.
(e.g. `jac_sparsity` for large systems)
So, this PR adds a new method `least_squares_lm` for `curve_fit`, which is using `least_squares` with `method='lm'` for curve fitting and enhanced unit tests for it.

#### Additional information
<!--Any additional information you think is important.-->
