### PR TITLE
BUG: throw ValueError for mismatched w dimensions and test for error

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -737,6 +737,8 @@ def hamming(u, v, w=None):
     u_ne_v = u != v
     if w is not None:
         w = _validate_weights(w)
+        if w.shape != u.shape:
+            raise ValueError("'w' should have the same length as 'u' and 'v'.")
     return np.average(u_ne_v, weights=w)
 
 

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -1935,6 +1935,15 @@ def test_hamming_unequal_length():
     assert_raises(ValueError, whamming, x, y)
 
 
+def test_hamming_unequal_length_with_w():
+    u = [0, 0, 1]
+    v = [0, 0, 1]
+    w = [1, 0, 1, 0]
+    msg = "'w' should have the same length as 'u' and 'v'."
+    with assert_raises(ValueError, match=msg):
+        whamming(u, v, w)
+
+
 def test_hamming_string_array():
     # https://github.com/scikit-learn/scikit-learn/issues/4014
     a = np.array(['eggs', 'spam', 'spam', 'eggs', 'spam', 'spam', 'spam',


### PR DESCRIPTION
#### Reference issue
Closes #17725 

#### What does this implement/fix?
Fixes misleading error message in hamming function when dimensions of optional argument w do not match u and v. Also implements new test in test_distance.py that checks for the error.

#### Additional information
N/A
