### PR TITLE
ENH: Support for user supplied minimizer function in dual annealing

### DIFF
--- a/scipy/optimize/_dual_annealing.py
+++ b/scipy/optimize/_dual_annealing.py
@@ -423,6 +423,10 @@ class LocalSearchWrapper:
             mres = self.minimizer(x0=x, **self.kwargs)
         else:
             mres = self.minimizer(self.func_wrapper.fun, x, **self.kwargs)
+        
+        if 'fun' in self.kwargs and 'nfev' in mres:
+            self.func_wrapper.nfev += mres.nfev
+
         if 'njev' in mres:
             self.func_wrapper.ngev += mres.njev
         if 'nhev' in mres:

--- a/scipy/optimize/_dual_annealing.py
+++ b/scipy/optimize/_dual_annealing.py
@@ -419,7 +419,10 @@ class LocalSearchWrapper:
     def local_search(self, x, e):
         # Run local search from the given x location where energy value is e
         x_tmp = np.copy(x)
-        mres = self.minimizer(self.func_wrapper.fun, x, **self.kwargs)
+        if 'fun' in self.kwargs:
+            mres = self.minimizer(x0=x, **self.kwargs)
+        else:
+            mres = self.minimizer(self.func_wrapper.fun, x, **self.kwargs)
         if 'njev' in mres:
             self.func_wrapper.ngev += mres.njev
         if 'nhev' in mres:

--- a/scipy/optimize/tests/test__dual_annealing.py
+++ b/scipy/optimize/tests/test__dual_annealing.py
@@ -377,3 +377,34 @@ class TestDualAnnealing:
                               minimizer_kwargs=dict(method='L-BFGS-B',
                                                     jac=jac))
         assert_allclose(res1.fun, res2.fun, rtol=1e-6)
+
+    def test_custom_minimizer_fun_gradient_gnev(self):
+        minimizer_opts = {
+            'fun': rosen,
+            'jac': self.rosen_der_wrapper,
+        }
+        ret = dual_annealing(rosen, self.ld_bounds,
+                             minimizer_kwargs=minimizer_opts,
+                             seed=self.seed)
+        assert ret.njev == self.ngev
+
+    def test_custom_minimizer_fun_call(self):
+        ret = dual_annealing(self.func, self.ld_bounds, 
+                             seed=self.seed, 
+                             minimizer_kwargs=dict(fun=self.func))
+        assert_equal(self.nb_fun_call, ret.nfev)
+
+    @pytest.mark.parametrize('method, atol', [
+        ('Nelder-Mead', 2e-5),
+        ('COBYLA', 1e-5),
+        ('Powell', 1e-8),
+        ('CG', 1e-8),
+        ('BFGS', 1e-8),
+        ('TNC', 1e-8),
+        ('SLSQP', 2e-7),
+    ])
+    def test_custom_minimizer_fun_multi_ls_minimizer(self, method, atol):
+        ret = dual_annealing(self.func, self.ld_bounds,
+                             minimizer_kwargs=dict(method=method,fun=self.func),
+                             seed=self.seed)
+        assert_allclose(ret.fun, 0., atol=atol)


### PR DESCRIPTION
This pull requests allows for a user supplied minimizer function via the `minimizer_kwargs` argument of `scipy.optimize.dual_annealing`.
A use case for this is when trying to minimize a function for which the gradient is returned alongside the function, as would be indicated by setting the `jac` argument of the minimizer to true.
Supplying such a function was not previously possible.