### PR TITLE
ENH: improve precision of folded normal distribution cdf

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -2348,7 +2348,8 @@ class foldnorm_gen(rv_continuous):
         return _norm_pdf(x + c) + _norm_pdf(x-c)
 
     def _cdf(self, x, c):
-        return _norm_cdf(x-c) + _norm_cdf(x+c) - 1.0
+        sqrt_two = np.sqrt(2)
+        return 0.5 * (sc.erf((x - c)/sqrt_two) + sc.erf((x + c)/sqrt_two))
 
     def _sf(self, x, c):
         return _norm_sf(x - c) + _norm_sf(x + c)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1122,6 +1122,19 @@ class TestGompertz:
         assert_allclose(stats.gompertz.entropy(c), ref, rtol=1e-14)
 
 
+class TestFoldNorm:
+
+    # reference values were computed with mpmath with 50 digits of precision
+    # from mpmath import mp
+    # mp.dps = 50
+    # mp.mpf(0.5) * (mp.erf((x - c)/mp.sqrt(2)) + mp.erf((x + c)/mp.sqrt(2)))
+
+    @pytest.mark.parametrize('x, c, ref', [(1e-4, 1e-8, 7.978845594730578e-05),
+                                           (1e-4, 1e-4, 7.97884555483635e-05)])
+    def test_cdf(self, x, c, ref):
+        assert_allclose(stats.foldnorm.cdf(x, c), ref, rtol=1e-15)
+
+
 class TestHalfNorm:
 
     # sfx is sf(x).  The values were computed with mpmath:


### PR DESCRIPTION
#### Reference issue
No directly related issue.

#### What does this implement/fix?
Changes the implementation of `foldnorm` CDF using the formulation from Wikipedia to avoid subtracting 1. This improves precision and range in the left tail.

#### Additional information

*Comparison of main branch, PR and mpmath*

![image](https://user-images.githubusercontent.com/40656107/228346153-89144ec1-6812-405b-8fda-f4197e3bc357.png)

<details>

```
from scipy import stats
from mpmath import mp
import numpy as np
import matplotlib.pyplot as plt
from scipy import special as sc

mp.dps = 50

@np.vectorize
def foldnorm_cdf_mpmath(x, c):
    x = mp.mpf(x)
    c = mp.mpf(c)
    return mp.mpf(0.5) * (mp.erf((x - c)/mp.sqrt(2)) + mp.erf((x + c)/mp.sqrt(2)))

a, b = 1e-8, 1e100
c = 1e-8
x = np.logspace(-50, 10, 10000)
plt.loglog(x, stats.foldnorm.cdf(x, c), label="main", ls='dotted')
plt.loglog(x, 0.5 * (sc.erf((x - c)/np.sqrt(2)) + sc.erf((x + c)/np.sqrt(2))), label="PR", ls='dashdot')
plt.loglog(x, np.array(foldnorm_cdf_mpmath(x, c), np.float64), label="mpmath", ls='dashed')
plt.title(f"Foldnorm CDF: $c={c}$")
plt.legend()
plt.show()
```

</details>

*Relative error*

The relative error is very low for $>c$. Below it also increases with the new formulation but is still smaller than the main branch.

![image](https://user-images.githubusercontent.com/40656107/228346762-e652c0a4-1c68-4a00-a16c-84cf525afc46.png)

![image](https://user-images.githubusercontent.com/40656107/228347022-6477b39c-aadf-4723-a71c-46f00e0abb2a.png)

<details>

```
c = 1e-4
x = np.logspace(-20, 3, 1000)
mp.dps = 100

ref = np.array(foldnorm_cdf_mpmath(x, c), np.float64)

plt.loglog(x, np.abs((stats.foldnorm.cdf(x, c) - ref)/ref), label="main", alpha=0.5)
plt.loglog(x, np.abs((0.5 * (sc.erf((x - c)/np.sqrt(2)) + sc.erf((x + c)/np.sqrt(2))) - ref)/ref), label="PR", alpha=0.5)
plt.axvline(c, 0, 1, c='k', ls='dashed', label="$c$")
plt.legend()
plt.title(f"Foldnormal CDF relative error: $c={c}$")
plt.show()
```

</details>
