### PR TITLE
ENH: improve integrate.simpson for even number of points

### DIFF
--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -656,7 +656,7 @@ def simpson(y, x=None, dx=1.0, axis=-1, even=None):
                              "same as y.")
 
     # even keyword parameter is deprecated
-    if 'even' is not None:
+    if even is not None:
         warnings.warn(
             "The 'even' keyword is deprecated as of SciPy 1.11.0 and will be "
             "removed in SciPy 1.13.0",

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -566,7 +566,7 @@ def simpson(y, x=None, dx=1.0, axis=-1, **kwds):
 
         'simpson' : Use Simpson's rule for the first N-2 intervals with the
                   addition of a 3-point parabolic segment for the last
-                  interval using equations outlined by Cartwright [1]_
+                  interval using equations outlined by Cartwright [1]_.
                   If the axis to be integrated over only has two points then
                   the integration falls back to a trapezoidal integration.
 

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -609,7 +609,7 @@ def simpson(y, x=None, dx=1.0, axis=-1, **kwds):
     ----------
     .. [1] Cartwright, Kenneth V. Simpson's Rule Cumulative Integration with
            MS Excel and Irregularly-spaced Data. Journal of Mathematical
-           Sciences and Mathematics Education. 12 (2): 1–9
+           Sciences and Mathematics Education. 12 (2): 1-9
 
     Examples
     --------

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -611,7 +611,6 @@ def simpson(y, x=None, dx=1.0, axis=-1, **kwds):
            MS Excel and Irregularly-spaced Data. Journal of Mathematical
            Sciences and Mathematics Education. 12 (2): 1–9
 
-    ..
     Examples
     --------
     >>> from scipy import integrate
@@ -624,7 +623,7 @@ def simpson(y, x=None, dx=1.0, axis=-1, **kwds):
 
     >>> y = np.power(x, 3)
     >>> integrate.simpson(y, x)
-    1642.5
+    1640.5
     >>> integrate.quad(lambda x: x**3, 0, 9)[0]
     1640.25
 
@@ -693,7 +692,7 @@ def simpson(y, x=None, dx=1.0, axis=-1, **kwds):
             slice2 = tupleset(slice_all, axis, -2)
             slice3 = tupleset(slice_all, axis, -3)
 
-            h = [dx, dx]
+            h = np.asfarray([dx, dx])
             if x is not None:
                 # grab the last two spacings from the appropriate axis
                 hm2 = tupleset(slice_all, axis, slice(-2, -1, 1))
@@ -722,7 +721,7 @@ def simpson(y, x=None, dx=1.0, axis=-1, **kwds):
                 where=den != 0
             )
 
-            num = h[1] ** 2 + 3 * h[0] * h[1]
+            num = h[1] ** 2 + 3.0 * h[0] * h[1]
             den = 6 * h[0]
             beta = np.true_divide(
                 num,
@@ -731,7 +730,7 @@ def simpson(y, x=None, dx=1.0, axis=-1, **kwds):
                 where=den != 0
             )
 
-            num = h[1] ** 3
+            num = 1 * h[1] ** 3
             den = 6 * h[0] * (h[0] + h[1])
             eta = np.true_divide(
                 num,

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -531,7 +531,7 @@ def simps(y, x=None, dx=1.0, axis=-1, **kwds):
     return simpson(y, x=x, dx=dx, axis=axis, **kwds)
 
 
-def simpson(y, x=None, dx=1.0, axis=-1, **kwds):
+def simpson(y, x=None, dx=1.0, axis=-1, even=None):
     """
     Integrate y(x) using samples along the given axis and the composite
     Simpson's rule. If x is None, spacing of dx is assumed.
@@ -577,8 +577,8 @@ def simpson(y, x=None, dx=1.0, axis=-1, **kwds):
             accurate in most situations.
 
         .. deprecated:: 1.11.0
-            Parameter `even` is deprecated and will be removed in a future
-            version of scipy.
+            Parameter `even` is deprecated and will be removed in SciPy
+            1.13.0.
 
     Returns
     -------
@@ -655,8 +655,9 @@ def simpson(y, x=None, dx=1.0, axis=-1, **kwds):
     # even keyword parameter is deprecated
     if 'even' in kwds:
         warnings.warn(
-            "The 'even' keyword will be removed in a future release of scipy",
-            DeprecationWarning
+            "The 'even' keyword is deprecated as of SciPy 1.11.0 and will be "
+            "removed in SciPy 1.13.0",
+            DeprecationWarning, stacklevel=2
         )
 
     if N % 2 == 0:

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -522,13 +522,13 @@ def _basic_simpson(y, start, stop, x, dx, axis):
 
 # Note: alias kept for backwards compatibility. simps was renamed to simpson
 # because the former is a slur in colloquial English (see gh-12924).
-def simps(y, x=None, dx=1.0, axis=-1, **kwds):
+def simps(y, x=None, dx=1.0, axis=-1, even=None):
     """An alias of `simpson`.
 
     `simps` is kept for backwards compatibility. For new code, prefer
     `simpson` instead.
     """
-    return simpson(y, x=x, dx=dx, axis=axis, **kwds)
+    return simpson(y, x=x, dx=dx, axis=axis, even=even)
 
 
 def simpson(y, x=None, dx=1.0, axis=-1, even=None):
@@ -551,7 +551,7 @@ def simpson(y, x=None, dx=1.0, axis=-1, even=None):
         `x` is None. Default is 1.
     axis : int, optional
         Axis along which to integrate. Default is the last axis.
-    even : str {'simpson', 'avg', 'first', 'last'}, optional
+    even : {None, 'simpson', 'avg', 'first', 'last'}, optional
         'avg' : Average two results:
             1) use the first N-2 intervals with
                a trapezoidal rule on the last interval and
@@ -564,13 +564,15 @@ def simpson(y, x=None, dx=1.0, axis=-1, even=None):
         'last' : Use Simpson's rule for the last N-2 intervals with a
                trapezoidal rule on the first interval.
 
+        None : equivalent to 'simpson' (default)
+
         'simpson' : Use Simpson's rule for the first N-2 intervals with the
                   addition of a 3-point parabolic segment for the last
                   interval using equations outlined by Cartwright [1]_.
                   If the axis to be integrated over only has two points then
                   the integration falls back to a trapezoidal integration.
 
-                  .. versionadded:: 1.11
+                  .. versionadded:: 1.11.0
 
         .. versionchanged:: 1.11.0
             The newly added 'simpson' option is now the default as it is more
@@ -578,7 +580,8 @@ def simpson(y, x=None, dx=1.0, axis=-1, even=None):
 
         .. deprecated:: 1.11.0
             Parameter `even` is deprecated and will be removed in SciPy
-            1.13.0.
+            1.13.0. After this time the behaviour for an even number of
+            points will follow that of `even='simpson'`.
 
     Returns
     -------
@@ -653,7 +656,7 @@ def simpson(y, x=None, dx=1.0, axis=-1, even=None):
                              "same as y.")
 
     # even keyword parameter is deprecated
-    if 'even' in kwds:
+    if 'even' is not None:
         warnings.warn(
             "The 'even' keyword is deprecated as of SciPy 1.11.0 and will be "
             "removed in SciPy 1.13.0",
@@ -665,7 +668,9 @@ def simpson(y, x=None, dx=1.0, axis=-1, even=None):
         result = 0.0
         slice_all = (slice(None),) * nd
 
-        even = kwds.get('even', 'simpson')
+        # default is 'simpson'
+        even = even if even is not None else "simpson"
+
         if even not in ['avg', 'last', 'first', 'simpson']:
             raise ValueError(
                 "Parameter 'even' must be 'simpson', "
@@ -682,7 +687,8 @@ def simpson(y, x=None, dx=1.0, axis=-1, even=None):
                 last_dx = x[slice1] - x[slice2]
             val += 0.5 * last_dx * (y[slice1] + y[slice2])
 
-            # calculation is finished.
+            # calculation is finished. Set `even` to None to skip other
+            # scenarios
             even = None
 
         if even == 'simpson':

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -154,24 +154,45 @@ class TestQuadrature:
         assert_equal(simpson(y, x=x, even='first'), 13.75)
         assert_equal(simpson(y, x=x, even='last'), 14)
 
-        # `even='cart'`
+        # `even='simpson'`
         # integral should be exactly 21
         f = lambda x: x ** 2
-        assert_allclose(simpson(f(x), x=x, even='cart'), 21.0)
+        assert_allclose(simpson(f(x), x=x, even='simpson'), 21.0)
         assert_allclose(simpson(f(x), x=x, even='avg'), 21 + 1/6)
 
         # integral should be exactly 114
         x = np.linspace(1, 7, 4)
-        assert_allclose(simpson(f(x), dx=2.0, even='cart'), 114)
+        assert_allclose(simpson(f(x), dx=2.0, even='simpson'), 114)
         assert_allclose(simpson(f(x), dx=2.0, even='avg'), 115 + 1/3)
 
-        # `even='cart'`, test multi-axis behaviour
+        # `even='simpson'`, test multi-axis behaviour
         a = np.arange(16).reshape(4, 4)
         x = np.arange(64.).reshape(4, 4, 4)
         y = f(x)
-
         for i in range(3):
-            r = simpson(y, x=x, even='cart', axis=i)
+            r = simpson(y, x=x, even='simpson', axis=i)
+            it = np.nditer(a, flags=['multi_index'])
+            for _ in it:
+                idx = list(it.multi_index)
+                idx.insert(i, slice(None))
+                integral = x[tuple(idx)][-1]**3 / 3 - x[tuple(idx)][0]**3 / 3
+                assert_allclose(r[it.multi_index], integral)
+
+        # test when integration axis only has two points
+        x = np.arange(16).reshape(8, 2)
+        y = f(x)
+        for even in ['simpson', 'avg', 'first', 'last']:
+            r = simpson(y, x=x, even=even, axis=-1)
+
+            integral = 0.5 * (y[:, 1] + y[:, 0]) * (x[:, 1] - x[, 0])
+            assert_allclose(r, integral)
+
+        # odd points, test multi-axis behaviour
+        a = np.arange(25).reshape(5, 5)
+        x = np.arange(125).reshape(5, 5, 5)
+        y = f(x)
+        for i in range(3):
+            r = simpson(y, x=x, axis=i)
             it = np.nditer(a, flags=['multi_index'])
             for _ in it:
                 idx = list(it.multi_index)

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -155,10 +155,12 @@ class TestQuadrature:
         assert_equal(simpson(y, x=x, even='last'), 14)
 
         # `even='cart'`
-        # integral should be 21.0 exactly
+        # integral should be exactly 21
         f = lambda x: x ** 2
         assert_allclose(simpson(f(x), x=x, even='cart'), 21.0)
         assert_allclose(simpson(f(x), x=x, even='avg'), 21 + 1/6)
+
+        # integral should be exactly 114
         x = np.linspace(1, 7, 4)
         assert_allclose(simpson(f(x), dx=2.0, even='cart'), 114)
         assert_allclose(simpson(f(x), dx=2.0, even='avg'), 115 + 1/3)

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -154,6 +154,29 @@ class TestQuadrature:
         assert_equal(simpson(y, x=x, even='first'), 13.75)
         assert_equal(simpson(y, x=x, even='last'), 14)
 
+        # `even='cart'`
+        # integral should be 21.0 exactly
+        f = lambda x: x ** 2
+        assert_allclose(simpson(f(x), x=x, even='cart'), 21.0)
+        assert_allclose(simpson(f(x), x=x, even='avg'), 21 + 1/6)
+        x = np.linspace(1, 7, 4)
+        assert_allclose(simpson(f(x), dx=2.0, even='cart'), 114)
+        assert_allclose(simpson(f(x), dx=2.0, even='avg'), 115 + 1/3)
+
+        # `even='cart'`, test multi-axis behaviour
+        a = np.arange(16).reshape(4, 4)
+        x = np.arange(64.).reshape(4, 4, 4)
+        y = f(x)
+
+        for i in range(3):
+            r = simpson(y, x=x, even='cart', axis=i)
+            it = np.nditer(a, flags=['multi_index'])
+            for _ in it:
+                idx = list(it.multi_index)
+                idx.insert(i, slice(None))
+                integral = x[tuple(idx)][-1]**3 / 3 - x[tuple(idx)][0]**3 / 3
+                assert_allclose(r[it.multi_index], integral)
+
         # Tests for checking base case
         x = np.array([3])
         y = np.power(x, 2)

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -142,6 +142,8 @@ class TestQuadrature:
         numeric_integral = np.dot(wts, y)
         assert_almost_equal(numeric_integral, exact_integral)
 
+    # ignore the DeprecationWarning emitted by the even kwd
+    @pytest.mark.filterwarnings('ignore::DeprecationWarning')
     def test_simpson(self):
         y = np.arange(17)
         assert_equal(simpson(y), 128)
@@ -156,6 +158,7 @@ class TestQuadrature:
 
         # `even='simpson'`
         # integral should be exactly 21
+        x = np.linspace(1, 4, 4)
         f = lambda x: x ** 2
         assert_allclose(simpson(f(x), x=x, even='simpson'), 21.0)
         assert_allclose(simpson(f(x), x=x, even='avg'), 21 + 1/6)
@@ -184,7 +187,7 @@ class TestQuadrature:
         for even in ['simpson', 'avg', 'first', 'last']:
             r = simpson(y, x=x, even=even, axis=-1)
 
-            integral = 0.5 * (y[:, 1] + y[:, 0]) * (x[:, 1] - x[, 0])
+            integral = 0.5 * (y[:, 1] + y[:, 0]) * (x[:, 1] - x[:, 0])
             assert_allclose(r, integral)
 
         # odd points, test multi-axis behaviour
@@ -203,27 +206,28 @@ class TestQuadrature:
         # Tests for checking base case
         x = np.array([3])
         y = np.power(x, 2)
-        assert_equal(simpson(y, x=x, axis=0), 0.0)
-        assert_equal(simpson(y, x=x, axis=-1), 0.0)
+        assert_allclose(simpson(y, x=x, axis=0), 0.0)
+        assert_allclose(simpson(y, x=x, axis=-1), 0.0)
 
         x = np.array([3, 3, 3, 3])
         y = np.power(x, 2)
-        assert_equal(simpson(y, x=x, axis=0), 0.0)
-        assert_equal(simpson(y, x=x, axis=-1), 0.0)
+        assert_allclose(simpson(y, x=x, axis=0), 0.0)
+        assert_allclose(simpson(y, x=x, axis=-1), 0.0)
 
         x = np.array([[1, 2, 4, 8], [1, 2, 4, 8], [1, 2, 4, 8]])
         y = np.power(x, 2)
         zero_axis = [0.0, 0.0, 0.0, 0.0]
-        default_axis = [175.75, 175.75, 175.75]
-        assert_equal(simpson(y, x=x, axis=0), zero_axis)
-        assert_equal(simpson(y, x=x, axis=-1), default_axis)
+        default_axis = [170 + 1/3] * 3   # 8**3 / 3 - 1/3
+        assert_allclose(simpson(y, x=x, axis=0), zero_axis)
+        # the following should be exact for even='simpson'
+        assert_allclose(simpson(y, x=x, axis=-1), default_axis)
 
         x = np.array([[1, 2, 4, 8], [1, 2, 4, 8], [1, 8, 16, 32]])
         y = np.power(x, 2)
         zero_axis = [0.0, 136.0, 1088.0, 8704.0]
-        default_axis = [175.75, 175.75, 11292.25]
-        assert_equal(simpson(y, x=x, axis=0), zero_axis)
-        assert_equal(simpson(y, x=x, axis=-1), default_axis)
+        default_axis = [170 + 1/3, 170 + 1/3, 32**3 / 3 - 1/3]
+        assert_allclose(simpson(y, x=x, axis=0), zero_axis)
+        assert_allclose(simpson(y, x=x, axis=-1), default_axis)
 
     @pytest.mark.parametrize('droplast', [False, True])
     def test_simpson_2d_integer_no_x(self, droplast):
@@ -239,10 +243,12 @@ class TestQuadrature:
 
     def test_simps(self):
         # Basic coverage test for the alias
-        y = np.arange(4)
+        y = np.arange(5)
         x = 2**y
-        assert_equal(simpson(y, x=x, dx=0.5, even='first'),
-                     simps(y, x=x, dx=0.5, even='first'))
+        assert_allclose(
+            simpson(y, x=x, dx=0.5),
+            simps(y, x=x, dx=0.5)
+        )
 
 
 class TestCumulative_trapezoid:

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -231,6 +231,12 @@ class TestQuadrature:
         assert_allclose(simpson(y, x=x, axis=0), zero_axis)
         assert_allclose(simpson(y, x=x, axis=-1), default_axis)
 
+    def test_simpson_even_is_deprecated(self):
+        x = np.linspace(0, 3, 4)
+        y = x**2
+        with pytest.deprecated_call():
+            simpson(y, x=x, even='first')
+
     @pytest.mark.parametrize('droplast', [False, True])
     def test_simpson_2d_integer_no_x(self, droplast):
         # The inputs are 2d integer arrays.  The results should be

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -159,7 +159,9 @@ class TestQuadrature:
         # `even='simpson'`
         # integral should be exactly 21
         x = np.linspace(1, 4, 4)
-        f = lambda x: x ** 2
+        def f(x):
+            return x**2
+
         assert_allclose(simpson(f(x), x=x, even='simpson'), 21.0)
         assert_allclose(simpson(f(x), x=x, even='avg'), 21 + 1/6)
 


### PR DESCRIPTION
Closes #5618

This PR improves the accuracy of `integrate.simpson` when there is an even number of points (odd number of intervals).

Historical behaviour has been to use trapezoidal integration for the last/first intervals and adding it on to the `_basic_simpson` sum of the other intervals. This is what the `even` kwd was used for. When `even='avg'` the mean of `last` and `first` approaches was returned.

It was pointed out in #18151 that there is a more accurate way of dealing with this situation, as outlined on [wikipedia](https://en.wikipedia.org/wiki/Simpson%27s_rule#Composite_Simpson's_rule_for_irregularly_spaced_data). This uses a parabolic segment over the last three points to calculate the sum of the last interval, thereby using *simpson* behaviour for the last interval as well.

This PR:

- adds the machinery for performing the improved calculation for the last interval when there is an even number of samples.
- this machinery is accessed by adding a `'simpson'` option to the `even` kwd.
- Since `even='simpson'` should offer improved behaviour in most cases (i.e. it continues the quadratic nature of the rest of the summation) this now becomes the default for the `even` kwd.
- Because `even='simpson'` offers this improved behaviour it shouldn't be necessary to access the `{'first', 'last', 'avg'}`  options anymore. It's therefore suggested that the `even` kwd be deprecated and removed in a future version of scipy. After that point the `'simpson'` behaviour will be used all the time.
- To achieve this deprecation the `even` kwd` is removed from the function signature and replaced by `**kwds`. Existing code that uses `even` will continue to work, but will receive a warning.
- If the integration axis only has two points (i.e. impossible to form a parabolic segment with the last three points) then the integration is done trapezoidally.
- Tests are added to check `simpson` integration over multiple axes, for odd and even number of points in the integration axis. These tests were missing and strengthen the test suite.

If there is downstream code using `simpson` they will:

- start getting the `DeprecationWarning`. This may come as a surprise as the `even` keyword for `simpson` has been present for a long time.
- get different results if they integrate with an even number of points. The new behaviour is more accurate, but people may complain that their code isn't giving the same numbers any more.
