### PR TITLE
BUG: sparse: Fix LIL full-matrix assignment

### DIFF
--- a/scipy/sparse/_lil.py
+++ b/scipy/sparse/_lil.py
@@ -322,7 +322,7 @@ class lil_matrix(spmatrix, IndexMixin):
             # Fast path for full-matrix sparse assignment.
             if (isinstance(row, slice) and isinstance(col, slice) and
                     row == slice(None) and col == slice(None) and
-                    isspmatrix(x)):
+                    isspmatrix(x) and x.shape == self.shape):
                 x = self._lil_container(x, dtype=self.dtype)
                 self.rows = x.rows
                 self.data = x.data

--- a/scipy/sparse/_lil.py
+++ b/scipy/sparse/_lil.py
@@ -314,12 +314,11 @@ class lil_matrix(spmatrix, IndexMixin):
         if isinstance(key, tuple) and len(key) == 2:
             row, col = key
             # Fast path for simple (int, int) indexing.
-            if (isinstance(row, INT_TYPES) and
-                isinstance(col, INT_TYPES)):
-            x = self.dtype.type(x)
-            if x.size > 1:
-                raise ValueError("Trying to assign a sequence to an item")
-            return self._set_intXint(row, col, x)
+            if isinstance(row, INT_TYPES) and isinstance(col, INT_TYPES):
+                x = self.dtype.type(x)
+                if x.size > 1:
+                    raise ValueError("Trying to assign a sequence to an item")
+                return self._set_intXint(row, col, x)
             # Fast path for full-matrix sparse assignment.
             if (isinstance(row, slice) and isinstance(col, slice) and
                     row == slice(None) and col == slice(None) and


### PR DESCRIPTION
#### Reference issue
Fixes gh-18202.

#### What does this implement/fix?
Previously, LIL's `__setitem__` would dispatch through `IndexMixin.__setitem__`, which doesn't currently handle slice-based keys in an efficient way: it converts slices to index arrays. This means that the eventual call to LIL's overload of `_set_arrayXarray_sparse` would not be able to detect the full-matrix assignment, and would thus densify the sparse matrix every time.

Until we improve the IndexMixin side of things, this solves the issue by moving the fast-path detection higher up in the call stack, before the slices are converted.
