### PR TITLE
ENH: stats.ecdf: add `evaluate` and `plot` methods; restructure result

### DIFF
--- a/scipy/stats/_survival.py
+++ b/scipy/stats/_survival.py
@@ -15,11 +15,11 @@ class EmpiricalDistributionFunction:
 
     Attributes
     ----------
-    points : ndarray
+    p : ndarray
         The point estimate of the cumulative distribution function (CDF) or its
         complement, the survival function (SF), at unique values of the sample.
     """
-    points: np.ndarray
+    p: np.ndarray
     # Exclude these from __str__
     _x: np.ndarray = field(repr=False)  # points at which function is estimated
     _n: np.ndarray = field(repr=False)  # number "at risk"
@@ -27,12 +27,12 @@ class EmpiricalDistributionFunction:
     _sf: np.ndarray = field(repr=False)  # survival function for var estimate
     _kind: str = field(repr=False)  # type of function: "cdf" or "sf"
 
-    def __init__(self, x, points, n, d, kind):
-        self.points = points
+    def __init__(self, x, p, n, d, kind):
+        self.p = p
         self._x = x
         self._n = n
         self._d = d
-        self._sf = points if kind == 'sf' else 1 - points
+        self._sf = p if kind == 'sf' else 1 - p
         self._kind = kind
 
     def confidence_interval(self, confidence_level=0.95, *, method='linear'):
@@ -108,8 +108,8 @@ class EmpiricalDistributionFunction:
         z = special.ndtri(1 / 2 + confidence_level / 2)
 
         z_se = z * se
-        low = self.points - z_se
-        high = self.points + z_se
+        low = self.p - z_se
+        high = self.p + z_se
 
         return low, high
 
@@ -189,7 +189,7 @@ def ecdf(sample):
 
         The `cdf` and `sf` attributes themselves have the following attributes.
 
-        points : ndarray
+        p : ndarray
             The point estimate of the CDF/SF at the values in `x`.
 
         And the following method:
@@ -248,7 +248,7 @@ def ecdf(sample):
     >>> res = stats.ecdf(sample)
     >>> res.x
     array([5.2 , 5.58, 6.23, 6.42, 7.06])
-    >>> res.cdf.points
+    >>> res.cdf.p
     array([0.2, 0.4, 0.6, 0.8, 1. ])
 
     To plot the result as a step function:
@@ -256,7 +256,7 @@ def ecdf(sample):
     >>> import numpy as np
     >>> import matplotlib.pyplot as plt
     >>> ax = plt.subplot()
-    >>> ax.step(np.insert(res.x, 0, 4), np.insert(res.cdf.points, 0, 0),
+    >>> ax.step(np.insert(res.x, 0, 4), np.insert(res.cdf.p, 0, 0),
     ...         where='post')
     >>> ax.set_xlabel('One-Mile Run Time (minutes)')
     >>> ax.set_ylabel('Empirical CDF')
@@ -286,13 +286,13 @@ def ecdf(sample):
     >>> res = stats.ecdf(sample)
     >>> res.x
     array([37., 43., 47., 56., 60., 62., 71., 77., 80., 81.])
-    >>> res.sf.points
+    >>> res.sf.p
     array([1.   , 1.   , 0.875, 0.75 , 0.75 , 0.75 , 0.75 , 0.5  , 0.25 , 0.   ])
 
     To plot the result as a step function:
 
     >>> ax = plt.subplot()
-    >>> ax.step(np.insert(res.x, 0, 30), np.insert(res.sf.points, 0, 1),
+    >>> ax.step(np.insert(res.x, 0, 30), np.insert(res.sf.p, 0, 1),
     ...         where='post')
     >>> ax.set_xlabel('Fanbelt Survival Time (thousands of miles)')
     >>> ax.set_ylabel('Empirical SF')

--- a/scipy/stats/_survival.py
+++ b/scipy/stats/_survival.py
@@ -71,7 +71,7 @@ class EmpiricalDistributionFunction:
         """
         return self._f(x)
 
-    def plot(self, ax=None, **kwargs):
+    def plot(self, ax=None, **matplotlib_kwargs):
         """Plot the empirical distribution function
 
         Available only if ``matplotlib`` is installed.
@@ -81,7 +81,7 @@ class EmpiricalDistributionFunction:
         ax : matplotlib.axes.Axes
             Axes object to draw the plot onto, otherwise uses the current Axes.
 
-        **kwargs : dict, optional
+        **matplotlib_kwargs : dict, optional
             Keyword arguments passed directly to `matplotlib.axes.Axes.step`.
             Unless overridden, ``where='post'``.
 
@@ -100,14 +100,14 @@ class EmpiricalDistributionFunction:
             import matplotlib.pyplot as plt
             ax = plt.gca()
 
-        kwds = {'where': 'post'}
-        kwds.update(kwargs)
+        kwargs = {'where': 'post'}
+        kwargs.update(matplotlib_kwargs)
 
         delta = np.ptp(self.quantiles)*0.05  # how far past sample edge to plot
         q = self.quantiles
         q = [q[0] - delta] + list(q) + [q[-1] + delta]
 
-        return ax.step(q, self.evaluate(q), **kwds)
+        return ax.step(q, self.evaluate(q), **kwargs)
 
     def confidence_interval(self, confidence_level=0.95, *, method='linear'):
         """Compute a confidence interval around the CDF/SF point estimate

--- a/scipy/stats/_survival.py
+++ b/scipy/stats/_survival.py
@@ -103,10 +103,9 @@ class EmpiricalDistributionFunction:
         kwds = {'where': 'post'}
         kwds.update(kwargs)
 
-        factor = 0.05  # how far past the edges of the sample to plot
-        ptp = np.ptp(self.quantiles)
+        delta = np.ptp(self.quantiles)*0.05  # how far past sample edge to plot
         q = self.quantiles
-        q = [q[0] - ptp*factor] + list(q) + [q[-1] + ptp*factor]
+        q = [q[0] - delta] + list(q) + [q[-1] + delta]
 
         return ax.step(q, self.evaluate(q), **kwds)
 
@@ -283,7 +282,7 @@ def ecdf(sample: npt.ArrayLike | CensoredData) -> ECDFResult:
         The `cdf` and `sf` attributes themselves have the following attributes.
 
         quantiles : ndarray
-            The unique values in the sample.
+            The unique values in the sample that defines the empirical CDF/SF.
         probabilities : ndarray
             The point estimates of the probabilities corresponding with
             `quantiles`.
@@ -614,13 +613,9 @@ def logrank(
     >>> import matplotlib.pyplot as plt
     >>> ax = plt.subplot()
     >>> ecdf_x = stats.ecdf(x)
-    >>> ax.step(np.insert(ecdf_x.x, 0, 0),
-    ...         np.insert(ecdf_x.sf.points, 0, 1),
-    ...         where='post', label='Astrocytoma')
+    >>> ecdf_x.sf.plot(ax, label='Astrocytoma')
     >>> ecdf_y = stats.ecdf(y)
-    >>> ax.step(np.insert(ecdf_y.x, 0, 0),
-    ...         np.insert(ecdf_y.sf.points, 0, 1),
-    ...         ls='-.', where='post', label='Glioblastoma')
+    >>> ecdf_x.sf.plot(ax, label='Glioblastoma')
     >>> ax.set_xlabel('Time to death (weeks)')
     >>> ax.set_ylabel('Empirical SF')
     >>> plt.legend()

--- a/scipy/stats/_survival.py
+++ b/scipy/stats/_survival.py
@@ -62,6 +62,45 @@ class EmpiricalDistributionFunction:
         """
         return self._f(x)
 
+    def plot(self, ax=None, **kwargs):
+        """Plot the empirical distribution function
+
+        Available only if ``matplotlib`` is installed.
+
+        Parameters
+        ----------
+        ax : matplotlib.axes.Axes
+            Axes object to draw the plot onto, otherwise uses the current Axes.
+
+        **kwargs : dict, optional
+            Keyword arguments passed directly to `matplotlib.axes.Axes.step`.
+            Unless overridden, ``where='post'``.
+
+        Returns
+        -------
+        lines : list of `matplotlib.lines.Line2D`
+            Objects representing the plotted data
+        """
+        try:
+            import matplotlib  # noqa
+        except ModuleNotFoundError as exc:
+            message = "matplotlib must be installed to use method `plot`."
+            raise ModuleNotFoundError(message) from exc
+
+        if ax is None:
+            import matplotlib.pyplot as plt
+            ax = plt.gca()
+
+        kwds = {'where': 'post'}
+        kwds.update(kwargs)
+
+        factor = 0.05  # how far past the edges of the sample to plot
+        ptp = np.ptp(self.quantiles)
+        q = self.quantiles
+        q = [q[0] - ptp*factor] + list(q) + [q[-1] + ptp*factor]
+
+        return ax.step(q, self.evaluate(q), **kwds)
+
     def confidence_interval(self, confidence_level=0.95, *, method='linear'):
         """Compute a confidence interval around the CDF/SF point estimate
 
@@ -292,8 +331,7 @@ def ecdf(sample):
 
     >>> import matplotlib.pyplot as plt
     >>> ax = plt.subplot()
-    >>> x = [res.cdf.quantiles[0]-1] + list(res.cdf.quantiles) + [res.cdf.quantiles[-1] + 1]
-    >>> ax.step(x, res.cdf.evaluate(x), where='post')
+    >>> res.cdf.plot(ax)
     >>> ax.set_xlabel('One-Mile Run Time (minutes)')
     >>> ax.set_ylabel('Empirical CDF')
     >>> plt.show()
@@ -328,8 +366,7 @@ def ecdf(sample):
     To plot the result as a step function:
 
     >>> ax = plt.subplot()
-    >>> x = [res.sf.quantiles[0] - 1] + list(res.sf.quantiles) + [res.sf.quantiles[-1] + 1]
-    >>> ax.step(x, res.sf.evaluate(x), where='post')
+    >>> res.cdf.plot(ax)
     >>> ax.set_xlabel('Fanbelt Survival Time (thousands of miles)')
     >>> ax.set_ylabel('Empirical SF')
     >>> plt.show()

--- a/scipy/stats/_survival.py
+++ b/scipy/stats/_survival.py
@@ -79,9 +79,10 @@ class EmpiricalDistributionFunction:
         Returns
         -------
         ci : ``ConfidenceInterval``
-            An object with attributes ``low`` and ``high``: arrays of the
-            lower and upper bounds of the confidence interval at unique values
-            of the sample.
+            An object with attributes ``low`` and ``high``, instances of
+            `~scipy.stats._result_classes.EmpiricalDistributionFunction` that
+            represent the lower and upper bounds (respectively) of the
+            confidence interval.
 
         Notes
         -----
@@ -100,6 +101,11 @@ class EmpiricalDistributionFunction:
                https://www.math.wustl.edu/~sawyer/handouts/greenwood.pdf
 
         """
+        message = ("Confidence interval bounds do not implement a "
+                   "`confidence_interval` method.")
+        if self._n is None:
+            raise NotImplementedError(message)
+
         methods = {'linear': self._linear_ci,
                    'log-log': self._loglog_ci}
 
@@ -121,7 +127,11 @@ class EmpiricalDistributionFunction:
         if np.any(np.isnan(low) | np.isnan(high)):
             warnings.warn(message, RuntimeWarning, stacklevel=2)
 
-        return ConfidenceInterval(np.clip(low, 0, 1), np.clip(high, 0, 1))
+        low = EmpiricalDistributionFunction(self.q, np.clip(low, 0, 1),
+                                            None, None, self._kind)
+        high = EmpiricalDistributionFunction(self.q, np.clip(high, 0, 1),
+                                            None, None, self._kind)
+        return ConfidenceInterval(low, high)
 
     def _linear_ci(self, confidence_level):
         sf, d, n = self._sf, self._d, self._n

--- a/scipy/stats/_survival.py
+++ b/scipy/stats/_survival.py
@@ -15,15 +15,16 @@ class EmpiricalDistributionFunction:
 
     Attributes
     ----------
-    q : ndarray
+    quantiles : ndarray
         The unique values of the sample from which the
         `EmpiricalDistributionFunction` was estimated.
-    p : ndarray
+    probabilities : ndarray
         The point estimates of the cumulative distribution function (CDF) or
-        its complement, the survival function (SF), corresponding with `q`.
+        its complement, the survival function (SF), corresponding with
+        `quantiles`.
     """
-    q: np.ndarray
-    p: np.ndarray
+    quantiles: np.ndarray
+    probabilities: np.ndarray
     # Exclude these from __str__
     _n: np.ndarray = field(repr=False)  # number "at risk"
     _d: np.ndarray = field(repr=False)  # number of "deaths"
@@ -260,19 +261,23 @@ def ecdf(sample):
 
         The `cdf` and `sf` attributes themselves have the following attributes.
 
-        q : ndarray
+        quantiles : ndarray
             The unique values in the sample.
-        p : ndarray
-            The point estimates of the probability corresponding with `q`.
+        probabilities : ndarray
+            The point estimates of the probabilities corresponding with
+            `quantiles`.
 
         And the following methods:
 
-        evaluate(q) :
+        evaluate(x) :
             Evaluate the CDF/SF at the argument.
+
+        plot(ax) :
+            Plot the CDF/SF on the provided axes.
 
         confidence_interval(confidence_level=0.95) :
             Compute the confidence interval around the CDF/SF at the values in
-            `q`.
+            `quantiles`.
 
     Notes
     -----

--- a/scipy/stats/tests/test_survival.py
+++ b/scipy/stats/tests/test_survival.py
@@ -371,3 +371,16 @@ class TestSurvival:
         assert_equal(res.sf._n, ref.sf._n)
         assert_equal(res.sf._d[:-1], ref.sf._d[:-1])  # difference @ [-1]
         assert_allclose(res.sf._sf[:-1], ref.sf._sf[:-1], rtol=1e-14)
+    def test_plot_iv(self):
+        rng = np.random.default_rng(1769658657308472721)
+        n_unique = rng.integers(10, 100)
+        sample, _, _ = self.get_random_sample(rng, n_unique)
+        res = stats.ecdf(sample)
+
+        try:
+            import matplotlib.pyplot as plt  # noqa
+            res.sf.plot()  # no other errors occur
+        except (ModuleNotFoundError, ImportError):
+            message = r"matplotlib must be installed to use method `plot`."
+            with pytest.raises(ModuleNotFoundError, match=message):
+                res.sf.plot()

--- a/scipy/stats/tests/test_survival.py
+++ b/scipy/stats/tests/test_survival.py
@@ -79,11 +79,11 @@ class TestSurvival:
     def test_edge_cases(self):
         res = stats.ecdf([])
         assert_equal(res.x, [])
-        assert_equal(res.cdf.points, [])
+        assert_equal(res.cdf.p, [])
 
         res = stats.ecdf([1])
         assert_equal(res.x, [1])
-        assert_equal(res.cdf.points, [1])
+        assert_equal(res.cdf.p, [1])
 
     def test_unique(self):
         # Example with unique observations; `stats.ecdf` ref. [1] page 80
@@ -93,8 +93,8 @@ class TestSurvival:
         ref_cdf = np.arange(1, 6) / 5
         ref_sf = 1 - ref_cdf
         assert_equal(res.x, ref_x)
-        assert_equal(res.cdf.points, ref_cdf)
-        assert_equal(res.sf.points, ref_sf)
+        assert_equal(res.cdf.p, ref_cdf)
+        assert_equal(res.sf.p, ref_sf)
 
     def test_nonunique(self):
         # Example with non-unique observations; `stats.ecdf` ref. [1] page 82
@@ -104,8 +104,8 @@ class TestSurvival:
         ref_cdf = np.array([1/6, 2/6, 4/6, 5/6, 1])
         ref_sf = 1 - ref_cdf
         assert_equal(res.x, ref_x)
-        assert_equal(res.cdf.points, ref_cdf)
-        assert_equal(res.sf.points, ref_sf)
+        assert_equal(res.cdf.p, ref_cdf)
+        assert_equal(res.sf.p, ref_sf)
 
     # ref. [1] page 91
     t1 = [37, 43, 47, 56, 60, 62, 71, 77, 80, 81]  # times
@@ -139,7 +139,7 @@ class TestSurvival:
         times, died, ref = case
         sample = stats.CensoredData.right_censored(times, np.logical_not(died))
         res = stats.ecdf(sample)
-        assert_allclose(res.sf.points, ref, atol=1e-3)
+        assert_allclose(res.sf.p, ref, atol=1e-3)
         assert_equal(res.x, np.sort(np.unique(times)))
 
         # test reference implementation against other implementations
@@ -157,7 +157,7 @@ class TestSurvival:
         res = stats.ecdf(sample)
         ref = _kaplan_meier_reference(times, censored)
         assert_allclose(res.x, ref[0])
-        assert_allclose(res.sf.points, ref[1])
+        assert_allclose(res.sf.p, ref[1])
 
         # If all observations are uncensored, the KM estimate should match
         # the usual estimate for uncensored data
@@ -165,8 +165,8 @@ class TestSurvival:
         res = _survival._ecdf_right_censored(sample)  # force Kaplan-Meier
         ref = stats.ecdf(times)
         assert_equal(res[0], ref.x)
-        assert_allclose(res[1], ref.cdf.points, rtol=1e-14)
-        assert_allclose(res[2], ref.sf.points, rtol=1e-14)
+        assert_allclose(res[1], ref.cdf.p, rtol=1e-14)
+        assert_allclose(res[2], ref.sf.p, rtol=1e-14)
 
     def test_right_censored_ci(self):
         # test "greenwood" confidence interval against example 4 (URL above).
@@ -179,13 +179,13 @@ class TestSurvival:
 
         sf_ci = res.sf.confidence_interval()
         cdf_ci = res.cdf.confidence_interval()
-        allowance = res.sf.points - sf_ci.low
+        allowance = res.sf.p - sf_ci.low
 
         assert_allclose(allowance, ref_allowance, atol=1e-3)
-        assert_allclose(sf_ci.low, np.clip(res.sf.points - allowance, 0, 1))
-        assert_allclose(sf_ci.high, np.clip(res.sf.points + allowance, 0, 1))
-        assert_allclose(cdf_ci.low, np.clip(res.cdf.points - allowance, 0, 1))
-        assert_allclose(cdf_ci.high, np.clip(res.cdf.points + allowance, 0, 1))
+        assert_allclose(sf_ci.low, np.clip(res.sf.p - allowance, 0, 1))
+        assert_allclose(sf_ci.high, np.clip(res.sf.p + allowance, 0, 1))
+        assert_allclose(cdf_ci.low, np.clip(res.cdf.p - allowance, 0, 1))
+        assert_allclose(cdf_ci.high, np.clip(res.cdf.p + allowance, 0, 1))
 
         # test "log-log" confidence interval against Mathematica
         # e = {24, 3, 11, 19, 24, 13, 14, 2, 18, 17, 24, 21, 12, 1, 10, 23, 6, 5,

--- a/scipy/stats/tests/test_survival.py
+++ b/scipy/stats/tests/test_survival.py
@@ -109,6 +109,24 @@ class TestSurvival:
         assert_equal(res.sf.q, ref_x)
         assert_equal(res.sf.p, ref_sf)
 
+    def test_evaluate_methods(self):
+        # Test CDF and SF `evaluate` methods
+        rng = np.random.default_rng(1162729143302572461)
+        sample, _, _ = self.get_random_sample(rng, 15)
+        res = stats.ecdf(sample)
+        x = res.cdf.q
+        xr = x + np.diff(x, append=x[-1]+1)/2  # right shifted points
+
+        assert_equal(res.cdf.evaluate(x), res.cdf.p)
+        assert_equal(res.cdf.evaluate(xr), res.cdf.p)
+        assert_equal(res.cdf.evaluate(x[0]-1), 0)  # CDF starts at 0
+        assert_equal(res.cdf.evaluate([-np.inf, np.inf]), [0, 1])
+
+        assert_equal(res.sf.evaluate(x), res.sf.p)
+        assert_equal(res.sf.evaluate(xr), res.sf.p)
+        assert_equal(res.sf.evaluate(x[0]-1), 1)  # SF starts at 1
+        assert_equal(res.sf.evaluate([-np.inf, np.inf]), [1, 0])
+
     # ref. [1] page 91
     t1 = [37, 43, 47, 56, 60, 62, 71, 77, 80, 81]  # times
     d1 = [0, 0, 1, 1, 0, 0, 0, 1, 1, 1]  # 1 means deaths (not censored)


### PR DESCRIPTION
#### Reference issue
gh-18136

#### What does this implement/fix?
This implements many of the changes to the `ecdf` result object suggested in https://github.com/scipy/scipy/pull/18136#issuecomment-1475438813:
- Replace `EmpiricalDistributionFunction` attribute `points` with attribute `probabilities`
- Remove `ECDFResult` attribute `x`; instead use `EmpiricalDistributionFunction` attribute `quantiles`
- Add methods `evaluate` and `plot` to `EmpiricalDistributionFunction`

```python3
import numpy as np
from scipy import stats
import matplotlib.pyplot as plt

rng = np.random.default_rng(3810954496107292580)
res = stats.ecdf(rng.normal(size=100))

# Here is much of what's new in one statement
np.testing.assert_allclose(res.sf.evaluate(res.sf.quantiles),
                           res.sf.probabilities)
# Similarly,
np.testing.assert_allclose(res.cdf.evaluate(res.cdf.quantiles),
                           res.cdf.probabilities)

low, high = res.sf.confidence_interval()
ax = plt.gca()
res.sf.plot(ax, color='C0')
low.plot(ax, color='C1')
high.plot(ax, color='C1')
plt.xlabel('quantile')
plt.ylabel('probability')
plt.title('Empirical survival function and 95% CI')
plt.show()
```

![image](https://user-images.githubusercontent.com/6570539/228747021-9e545815-463a-43dc-82ec-23d78bdb7ca7.png)

<details>
Was:

```python3
import numpy as np
from scipy import stats
import matplotlib.pyplot as plt

rng = np.random.default_rng(3810954496107292580)
res = stats.ecdf(rng.normal(size=100))

# Here is most of what's new in one line
np.testing.assert_allclose(res.sf.evaluate(res.sf.q), res.sf.p)
# Similarly,
np.testing.assert_allclose(res.cdf.evaluate(res.cdf.q), res.cdf.p)

# Also note that confidence interval bounds now have `evaluate` method
q = [-3] + list(res.sf.q) + [3]
low, high = res.sf.confidence_interval()
plt.step(q, res.sf.evaluate(q), color='C0', where='<removed>')  # correct value of `where` removed to make a point
plt.step(q, low.evaluate(q), color='C1', where='<removed>')
plt.step(q, high.evaluate(q), color='C1', where='<removed>')
plt.xlabel('quantile')
plt.ylabel('probability')
plt.title('Empirical survival function and 95% CI')
plt.show()
```

</details>


#### Additional information
Please review https://github.com/scipy/scipy/pull/18136#issuecomment-1475438813 for justification.

It will probably be easiest to review commit by commit. See commit messages.

One thing that would be in scope that I didn't implement here is to rename `ecdf` to `nonparametric_fit`. The latter might not be a good name after all because that might be confused with nonparametric regression or spline fitting.

@lorentzenchr I thought you would be interested in this given your requests for `ecdf` to return a distribution object. After the distribution infrastructure overhaul is complete, perhaps we can make it easy to convert an `ECDFResult` into a new distribution object. In the meantime, I hope that the `evaluate` method of the `sf` and `cdf` attributes is a good start toward what you were after, and I'd be happy if someone else would like to add `ppf`, `isf`, and `rvs` attributes.