### PR TITLE
DOC: stats: describe attributes of `DunnettResult`

### DIFF
--- a/scipy/stats/_multicomp.py
+++ b/scipy/stats/_multicomp.py
@@ -25,6 +25,19 @@ __all__ = [
 
 @dataclass
 class DunnettResult:
+    """Result object returned by `scipy.stats.dunnett`.
+
+    Attributes
+    ----------
+    statistic : float ndarray
+        The computed statistic of the test for each comparison. The element
+        at index ``i`` is the statistic for the comparison between
+        groups ``i`` and the control.
+    pvalue : float ndarray
+        The computed p-value of the test for each comparison. The element
+        at index ``i`` is the p-value for the comparison between
+        group ``i`` and the control.
+    """
     statistic: np.ndarray
     pvalue: np.ndarray
     _alternative: Literal['two-sided', 'less', 'greater'] = field(repr=False)


### PR DESCRIPTION
An oversight when we added `scipy.stats.dunnett`

The added documentation is the same as what's in the main documentation of the function.