### PR TITLE
MAINT: replace use of make_dataclass with explicit dataclasses

### DIFF
--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -1,5 +1,5 @@
 from collections import namedtuple
-from dataclasses import make_dataclass
+from dataclasses import dataclass
 from math import comb
 import numpy as np
 import warnings
@@ -694,8 +694,11 @@ def _somers_d(A, alternative='two-sided'):
     return d, p
 
 
-SomersDResult = make_dataclass("SomersDResult",
-                               ("statistic", "pvalue", "table"))
+@dataclass
+class SomersDResult:
+    statistic: float
+    pvalue: float
+    table: np.ndarray
 
 
 def somersd(x, y=None, alternative='two-sided'):
@@ -903,9 +906,10 @@ def _compute_log_combinations(n):
     return gammaln(n + 1) - gammaln_arr - gammaln_arr[::-1]
 
 
-BarnardExactResult = make_dataclass(
-    "BarnardExactResult", [("statistic", float), ("pvalue", float)]
-)
+@dataclass
+class BarnardExactResult:
+    statistic: float
+    pvalue: float
 
 
 def barnard_exact(table, alternative="two-sided", pooled=True, n=32):
@@ -1173,9 +1177,10 @@ def barnard_exact(table, alternative="two-sided", pooled=True, n=32):
     return BarnardExactResult(wald_stat_obs, p_value)
 
 
-BoschlooExactResult = make_dataclass(
-    "BoschlooExactResult", [("statistic", float), ("pvalue", float)]
-)
+@dataclass
+class BoschlooExactResult:
+    statistic: float
+    pvalue: float
 
 
 def boschloo_exact(table, alternative="two-sided", n=32):

--- a/scipy/stats/_page_trend_test.py
+++ b/scipy/stats/_page_trend_test.py
@@ -3,11 +3,14 @@ import numpy as np
 import math
 from ._continuous_distns import norm
 import scipy.stats
-from dataclasses import make_dataclass
+from dataclasses import dataclass
 
 
-PageTrendTestResult = make_dataclass("PageTrendTestResult",
-                                     ("statistic", "pvalue", "method"))
+@dataclass
+class PageTrendTestResult:
+    statistic: float
+    pvalue: float
+    method: str
 
 
 def page_trend_test(data, ranked=False, predicted_ranks=None, method='auto'):

--- a/scipy/stats/_resampling.py
+++ b/scipy/stats/_resampling.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import warnings
 import numpy as np
 from itertools import combinations, permutations, product
@@ -6,7 +8,7 @@ import inspect
 from scipy._lib._util import check_random_state
 from scipy.special import ndtr, ndtri, comb, factorial
 from scipy._lib._util import rng_integers
-from dataclasses import make_dataclass
+from dataclasses import dataclass
 from ._common import ConfidenceInterval
 from ._axis_nan_policy import _broadcast_concatenate, _broadcast_arrays
 from ._warnings_errors import DegenerateDataWarning
@@ -244,8 +246,27 @@ def _bootstrap_iv(data, statistic, vectorized, paired, axis, confidence_level,
             method, bootstrap_result, random_state)
 
 
-fields = ['confidence_interval', 'bootstrap_distribution', 'standard_error']
-BootstrapResult = make_dataclass("BootstrapResult", fields)
+@dataclass
+class BootstrapResult:
+    """Result object returned by `scipy.stats.bootstrap`.
+
+    Attributes
+    ----------
+    confidence_interval : ConfidenceInterval
+        The bootstrap confidence interval as an instance of
+        `collections.namedtuple` with attributes `low` and `high`.
+    bootstrap_distribution : ndarray
+        The bootstrap distribution, that is, the value of `statistic` for
+        each resample. The last dimension corresponds with the resamples
+        (e.g. ``res.bootstrap_distribution.shape[-1] == n_resamples``).
+    standard_error : float or ndarray
+        The bootstrap standard error, that is, the sample standard
+        deviation of the bootstrap distribution.
+
+    """
+    confidence_interval: ConfidenceInterval
+    bootstrap_distribution: np.ndarray
+    standard_error: float | np.ndarray
 
 
 def bootstrap(data, statistic, *, n_resamples=9999, batch=None,
@@ -662,8 +683,23 @@ def _monte_carlo_test_iv(sample, rvs, statistic, vectorized, n_resamples,
             batch_iv, alternative, axis_int)
 
 
-fields = ['statistic', 'pvalue', 'null_distribution']
-MonteCarloTestResult = make_dataclass("MonteCarloTestResult", fields)
+@dataclass
+class MonteCarloTestResult:
+    """Result object returned by `scipy.stats.monte_carlo_test`.
+
+    Attributes
+    ----------
+    statistic : float or ndarray
+        The observed test statistic of the sample.
+    pvalue : float or ndarray
+        The p-value for the given alternative.
+    null_distribution : ndarray
+        The values of the test statistic generated under the null
+        hypothesis.
+    """
+    statistic: float | np.ndarray
+    pvalue: float | np.ndarray
+    null_distribution: np.ndarray
 
 
 def monte_carlo_test(sample, rvs, statistic, *, vectorized=None,
@@ -726,12 +762,16 @@ def monte_carlo_test(sample, rvs, statistic, *, vectorized=None,
 
     Returns
     -------
-    statistic : float or ndarray
-        The observed test statistic of the sample.
-    pvalue : float or ndarray
-        The p-value for the given alternative.
-    null_distribution : ndarray
-        The values of the test statistic generated under the null hypothesis.
+    res : MonteCarloTestResult
+        An object with attributes:
+
+        statistic : float or ndarray
+            The observed test statistic of the sample.
+        pvalue : float or ndarray
+            The p-value for the given alternative.
+        null_distribution : ndarray
+            The values of the test statistic generated under the null
+            hypothesis.
 
     References
     ----------
@@ -852,8 +892,23 @@ def monte_carlo_test(sample, rvs, statistic, *, vectorized=None,
     return MonteCarloTestResult(observed, pvalues, null_distribution)
 
 
-attributes = ('statistic', 'pvalue', 'null_distribution')
-PermutationTestResult = make_dataclass('PermutationTestResult', attributes)
+@dataclass
+class PermutationTestResult:
+    """Result object returned by `scipy.stats.permutation_test`.
+
+    Attributes
+    ----------
+    statistic : float or ndarray
+        The observed test statistic of the data.
+    pvalue : float or ndarray
+        The p-value for the given alternative.
+    null_distribution : ndarray
+        The values of the test statistic generated under the null
+        hypothesis.
+    """
+    statistic: float | np.ndarray
+    pvalue: float | np.ndarray
+    null_distribution: np.ndarray
 
 
 def _all_partitions_concatenated(ns):
@@ -1246,12 +1301,16 @@ def permutation_test(data, statistic, *, permutation_type='independent',
 
     Returns
     -------
-    statistic : float or ndarray
-        The observed test statistic of the data.
-    pvalue : float or ndarray
-        The p-value for the given alternative.
-    null_distribution : ndarray
-        The values of the test statistic generated under the null hypothesis.
+    res : PermutationTestResult
+        An object with attributes:
+
+        statistic : float or ndarray
+            The observed test statistic of the data.
+        pvalue : float or ndarray
+            The p-value for the given alternative.
+        null_distribution : ndarray
+            The values of the test statistic generated under the null
+            hypothesis.
 
     Notes
     -----

--- a/scipy/stats/_sensitivity_analysis.py
+++ b/scipy/stats/_sensitivity_analysis.py
@@ -156,8 +156,8 @@ def saltelli_2010(
 
 @dataclass
 class BootstrapSobolResult:
-    first_order: BootstrapResult  # type: ignore[valid-type]
-    total_order: BootstrapResult  # type: ignore[valid-type]
+    first_order: BootstrapResult
+    total_order: BootstrapResult
 
 
 @dataclass
@@ -171,13 +171,13 @@ class SobolResult:
     _A: np.ndarray | None = None
     _B: np.ndarray | None = None
     _AB: np.ndarray | None = None
-    _bootstrap_result: BootstrapResult = None  # type: ignore[valid-type]
+    _bootstrap_result: BootstrapResult | None = None
 
     def bootstrap(
         self,
         confidence_level: DecimalNumber = 0.95,
         n_resamples: IntNumber = 999
-    ) -> BootstrapResult:  # type: ignore[valid-type]
+    ) -> BootstrapSobolResult:
         """Bootstrap Sobol' indices to provide confidence intervals.
 
         Parameters

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -49,7 +49,7 @@ from ._stats_mstats_common import (_find_repeats, linregress, theilslopes,
                                    siegelslopes)
 from ._stats import (_kendall_dis, _toint64, _weightedrankedtau,
                      _local_correlations)
-from dataclasses import make_dataclass
+from dataclasses import dataclass
 from ._hypotests import _all_partitions
 from ._stats_pythran import _compute_outer_prob_inside_method
 from ._resampling import _batch_generator
@@ -4301,10 +4301,13 @@ def alexandergovern(*samples, nan_policy='propagate'):
 
     Returns
     -------
-    statistic : float
-        The computed A statistic of the test.
-    pvalue : float
-        The associated p-value from the chi-squared distribution.
+    res : AlexanderGovernResult
+        An object with attributes:
+
+        statistic : float
+            The computed A statistic of the test.
+        pvalue : float
+            The associated p-value from the chi-squared distribution.
 
     Warns
     -----
@@ -4437,8 +4440,10 @@ def _alexandergovern_input_validation(samples, nan_policy):
     return samples
 
 
-AlexanderGovernResult = make_dataclass("AlexanderGovernResult", ("statistic",
-                                                                 "pvalue"))
+@dataclass
+class AlexanderGovernResult:
+    statistic: float
+    pvalue: float
 
 
 def _pearsonr_fisher_ci(r, n, confidence_level, alternative):

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -32,7 +32,7 @@ __all__ = [  # noqa: F822
     'brunnermunzel', 'alexandergovern', 'gcd', 'namedtuple', 'array',
     'ma', 'cdist', 'check_random_state', 'MapWrapper',
     'rng_integers', 'float_factorial', 'linalg', 'distributions',
-    'mstats_basic', 'make_dataclass', 'ModeResult', 'DescribeResult',
+    'mstats_basic', 'ModeResult', 'DescribeResult',
     'SkewtestResult', 'KurtosistestResult', 'NormaltestResult',
     'Jarque_beraResult', 'HistogramResult', 'CumfreqResult',
     'RelfreqResult', 'SigmaclipResult', 'F_onewayResult',


### PR DESCRIPTION
The use of `dataclasses.make_dataclass` prevents IDEs to properly autocomplete or document attributes.

This PR convert usage of `dataclasses.make_dataclass` to proper dataclasses declarations.

I added some documentation when there was more than just `statistic,pvalue` it does not really matter as for now all these classes do not appear in our doc. I could change this and put all these objects in `_result_classes`. I am not sure, we can discuss that point too.