### PR TITLE
MAINT: stats: consistently return NumPy numbers

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -735,3 +735,10 @@ def _rng_spawn(rng, n_children):
     child_rngs = [np.random.Generator(type(bg)(child_ss))
                   for child_ss in ss.spawn(n_children)]
     return child_rngs
+
+
+def _get_nan(*data):
+    # Get NaN of appropriate dtype for data
+    data = [np.asarray(item) for item in data]
+    dtype = np.result_type(*data, np.half)  # must be a float16 at least
+    return np.array(np.nan, dtype=dtype)[()]

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -12,7 +12,7 @@ from numpy import (isscalar, r_, log, around, unique, asarray, zeros,
 from scipy import optimize
 from scipy import special
 from scipy._lib._bunch import _make_tuple_bunch
-from scipy._lib._util import _rename_parameter, _contains_nan
+from scipy._lib._util import _rename_parameter, _contains_nan, _get_nan
 
 from . import _statlib
 from . import _stats_py
@@ -4104,9 +4104,10 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=False,
         d = x - y
 
     if len(d) == 0:
-        res = WilcoxonResult(np.nan, np.nan)
+        NaN = _get_nan(d)
+        res = WilcoxonResult(NaN, NaN)
         if method == 'approx':
-            res.zstatistic = np.nan
+            res.zstatistic = NaN
         return res
 
     if mode == "auto":

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -38,7 +38,7 @@ from numpy.testing import suppress_warnings
 
 from scipy.spatial.distance import cdist
 from scipy.ndimage import _measurements
-from scipy._lib._util import (check_random_state, MapWrapper,
+from scipy._lib._util import (check_random_state, MapWrapper, _get_nan,
                               rng_integers, _rename_parameter, _contains_nan)
 
 import scipy.special as special
@@ -577,7 +577,8 @@ def mode(a, axis=0, nan_policy='propagate', keepdims=False):
     # `axis`, `nan_policy`, and `keepdims` are handled by `_axis_nan_policy`
 
     if a.size == 0:
-        return ModeResult(np.nan, np.int64(0))
+        NaN = _get_nan(a)
+        return ModeResult(*np.array([NaN, 0], dtype=NaN.dtype))
 
     vals, cnts = np.unique(a, return_counts=True)
     modes, counts = vals[cnts.argmax()], cnts.max()
@@ -3474,7 +3475,7 @@ def iqr(x, axis=None, rng=(25, 75), scale=1.0, nan_policy='propagate',
     # This check prevents percentile from raising an error later. Also, it is
     # consistent with `np.var` and `np.std`.
     if not x.size:
-        return np.nan
+        return _get_nan(x)
 
     # An error may be raised here, so fail-fast, before doing lengthy
     # computations, even though `scale` is not used until later
@@ -7757,8 +7758,9 @@ def ttest_rel(a, b, axis=0, nan_policy='propagate', alternative="two-sided"):
 
     if na == 0 or nb == 0:
         # _axis_nan_policy decorator ensures this only happens with 1d input
-        return TtestResult(np.nan, np.nan, df=np.nan, alternative=np.nan,
-                           standard_error=np.nan, estimate=np.nan)
+        NaN = _get_nan(a, b)
+        return TtestResult(NaN, NaN, df=NaN, alternative=NaN,
+                           standard_error=NaN, estimate=NaN)
 
     n = a.shape[axis]
     df = n - 1
@@ -9249,7 +9251,8 @@ def kruskal(*samples, nan_policy='propagate'):
 
     for sample in samples:
         if sample.size == 0:
-            return KruskalResult(np.nan, np.nan)
+            NaN = _get_nan(*samples)
+            return KruskalResult(NaN, NaN)
         elif sample.ndim != 1:
             raise ValueError("Samples must be one-dimensional.")
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -1260,10 +1260,7 @@ def skew(a, axis=0, bias=True, nan_policy='propagate'):
             nval = np.sqrt((n - 1.0) * n) / (n - 2.0) * m3 / m2**1.5
             np.place(vals, can_correct, nval)
 
-    if vals.ndim == 0:
-        return vals.item()
-
-    return vals
+    return vals[()]
 
 
 @_axis_nan_policy_factory(
@@ -1374,10 +1371,7 @@ def kurtosis(a, axis=0, fisher=True, bias=True, nan_policy='propagate'):
             nval = 1.0/(n-2)/(n-3) * ((n**2-1.0)*m4/m2**2.0 - 3*(n-1)**2.0)
             np.place(vals, can_correct, nval + 3.0)
 
-    if vals.ndim == 0:
-        vals = vals.item()  # array scalar
-
-    return vals - 3 if fisher else vals
+    return vals[()] - 3 if fisher else vals[()]
 
 
 DescribeResult = namedtuple('DescribeResult',

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -388,7 +388,11 @@ def test_axis_nan_policy_axis_is_None(hypotest, args, kwds, n_samples,
             else:
                 assert_equal(res1db, res1da)
                 assert_equal(res1dc, res1da)
-
+                for item in list(res1da) + list(res1db) + list(res1dc):
+                    # Most functions naturally return NumPy numbers, which
+                    # are drop-in replacements for the Python versions but with
+                    # desirable attributes. Make sure this is consistent.
+                    assert np.issubdtype(item.dtype, np.number)
 
 # Test keepdims for:
 #     - single-output and multi-output functions (gmean and mannwhitneyu)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3156,7 +3156,7 @@ class TestMoments:
         assert_raises(ValueError, stats.kurtosis, x, nan_policy='foobar')
 
     def test_kurtosis_array_scalar(self):
-        assert_equal(type(stats.kurtosis([1,2,3])), float)
+        assert_equal(type(stats.kurtosis([1, 2, 3])), np.float64)
 
     def test_kurtosis_propagate_nan(self):
         # Check that the shape of the result is the same for inputs


### PR DESCRIPTION
#### Reference issue
Part of gh-14651
As noted in https://github.com/scipy/scipy/pull/17971#issuecomment-1430516925

#### What does this implement/fix?
_Note: this is a pretty obscure issue, but fortunately it's also very safe and simple to address. Might as well._

Most `stats` functions naturally return NumPy numbers (e.g. `np.float64`), which are drop-in replacements for the Python versions (e.g. `float`) but with desirable attributes. This should be consistent in functions that are wrapped by the `_axis_nan_policy` decorator, since its job is to ensure consistency. This PR adds a test for this condition. 

There is not perfect consistency yet because for various reasons, the decorator doesn't interfere with what the function wants to do in certain cases (e.g. 1D input with no NaNs), and some functions return Python floats. There are two common causes:
- use of `.item()` with 0D arrays, (fixed here). 
- returning `np.nan`, which (surprisingly) is a Python float (not yet fixed here). 

I wanted to wait for feedback before handling the latter case. Until we're ready for the decorator to get involved in all cases, the easiest fix is to change the individual functions. Another possibility is to ignore the inconsistency. If you're willing to review, let me know what you'd like to see.

<details>
I skipped running CI here because we still have several failures.

```
=================================================================== short test summary info ====================================================================
FAILED ..\..\scipy\stats\tests\test_axis_nan_policy.py::test_axis_nan_policy_axis_is_None[all_nans-omit-kruskal-args0-kwds0-3-2-False-None] - AttributeError: ...
FAILED ..\..\scipy\stats\tests\test_axis_nan_policy.py::test_axis_nan_policy_axis_is_None[all_nans-omit-wilcoxon-args3-kwds3-2-2-True-<lambda>] - AttributeErr...
FAILED ..\..\scipy\stats\tests\test_axis_nan_policy.py::test_axis_nan_policy_axis_is_None[all_nans-omit-wilcoxon-args4-kwds4-1-2-True-<lambda>] - AttributeErr...
FAILED ..\..\scipy\stats\tests\test_axis_nan_policy.py::test_axis_nan_policy_axis_is_None[all_nans-omit-wilcoxon-args5-kwds5-1-3-True-<lambda>] - AttributeErr...
FAILED ..\..\scipy\stats\tests\test_axis_nan_policy.py::test_axis_nan_policy_axis_is_None[all_nans-omit-iqr-args10-kwds10-1-1-False-<lambda>] - AttributeError...
FAILED ..\..\scipy\stats\tests\test_axis_nan_policy.py::test_axis_nan_policy_axis_is_None[all_nans-omit-ttest_rel-args19-kwds19-2-7-True-unpack_ttest_result]
FAILED ..\..\scipy\stats\tests\test_axis_nan_policy.py::test_axis_nan_policy_axis_is_None[all_nans-omit-mode-args20-kwds20-1-2-True-<lambda>] - AttributeError...
FAILED ..\..\scipy\stats\tests\test_axis_nan_policy.py::test_axis_nan_policy_axis_is_None[empty-propagate-kruskal-args0-kwds0-3-2-False-None] - AttributeError...
FAILED ..\..\scipy\stats\tests\test_axis_nan_policy.py::test_axis_nan_policy_axis_is_None[empty-propagate-wilcoxon-args3-kwds3-2-2-True-<lambda>] - AttributeE...
FAILED ..\..\scipy\stats\tests\test_axis_nan_policy.py::test_axis_nan_policy_axis_is_None[empty-propagate-wilcoxon-args4-kwds4-1-2-True-<lambda>] - AttributeE...
FAILED ..\..\scipy\stats\tests\test_axis_nan_policy.py::test_axis_nan_policy_axis_is_None[empty-propagate-wilcoxon-args5-kwds5-1-3-True-<lambda>] - AttributeE...
FAILED ..\..\scipy\stats\tests\test_axis_nan_policy.py::test_axis_nan_policy_axis_is_None[empty-propagate-iqr-args10-kwds10-1-1-False-<lambda>] - AttributeErr...
FAILED ..\..\scipy\stats\tests\test_axis_nan_policy.py::test_axis_nan_policy_axis_is_None[empty-propagate-ttest_rel-args19-kwds19-2-7-True-unpack_ttest_result]
FAILED ..\..\scipy\stats\tests\test_axis_nan_policy.py::test_axis_nan_policy_axis_is_None[empty-propagate-mode-args20-kwds20-1-2-True-<lambda>] - AttributeErr...
FAILED ..\..\scipy\stats\tests\test_axis_nan_policy.py::test_axis_nan_policy_axis_is_None[empty-omit-kruskal-args0-kwds0-3-2-False-None] - AttributeError: 'fl...
FAILED ..\..\scipy\stats\tests\test_axis_nan_policy.py::test_axis_nan_policy_axis_is_None[empty-omit-wilcoxon-args3-kwds3-2-2-True-<lambda>] - AttributeError:...
FAILED ..\..\scipy\stats\tests\test_axis_nan_policy.py::test_axis_nan_policy_axis_is_None[empty-omit-wilcoxon-args4-kwds4-1-2-True-<lambda>] - AttributeError:...
FAILED ..\..\scipy\stats\tests\test_axis_nan_policy.py::test_axis_nan_policy_axis_is_None[empty-omit-wilcoxon-args5-kwds5-1-3-True-<lambda>] - AttributeError:...
FAILED ..\..\scipy\stats\tests\test_axis_nan_policy.py::test_axis_nan_policy_axis_is_None[empty-omit-iqr-args10-kwds10-1-1-False-<lambda>] - AttributeError: '...
FAILED ..\..\scipy\stats\tests\test_axis_nan_policy.py::test_axis_nan_policy_axis_is_None[empty-omit-ttest_rel-args19-kwds19-2-7-True-unpack_ttest_result] - A...
FAILED ..\..\scipy\stats\tests\test_axis_nan_policy.py::test_axis_nan_policy_axis_is_None[empty-omit-mode-args20-kwds20-1-2-True-<lambda>] - AttributeError: '...
FAILED ..\..\scipy\stats\tests\test_axis_nan_policy.py::test_axis_nan_policy_axis_is_None[empty-raise-kruskal-args0-kwds0-3-2-False-None] - AttributeError: 'f...
FAILED ..\..\scipy\stats\tests\test_axis_nan_policy.py::test_axis_nan_policy_axis_is_None[empty-raise-wilcoxon-args3-kwds3-2-2-True-<lambda>] - AttributeError...
FAILED ..\..\scipy\stats\tests\test_axis_nan_policy.py::test_axis_nan_policy_axis_is_None[empty-raise-wilcoxon-args4-kwds4-1-2-True-<lambda>] - AttributeError...
FAILED ..\..\scipy\stats\tests\test_axis_nan_policy.py::test_axis_nan_policy_axis_is_None[empty-raise-wilcoxon-args5-kwds5-1-3-True-<lambda>] - AttributeError...
FAILED ..\..\scipy\stats\tests\test_axis_nan_policy.py::test_axis_nan_policy_axis_is_None[empty-raise-iqr-args10-kwds10-1-1-False-<lambda>] - AttributeError: ...
FAILED ..\..\scipy\stats\tests\test_axis_nan_policy.py::test_axis_nan_policy_axis_is_None[empty-raise-ttest_rel-args19-kwds19-2-7-True-unpack_ttest_result] - ...
FAILED ..\..\scipy\stats\tests\test_axis_nan_policy.py::test_axis_nan_policy_axis_is_None[empty-raise-mode-args20-kwds20-1-2-True-<lambda>] - AttributeError: ...
================================================================ 28 failed, 224 passed in 2.56s ================================================================
```

</details>

Note to self: followup in https://github.com/mdhaber/scipy/tree/gh17971b

