### PR TITLE
MAINT: stats.TTestResult: fix NaN bug in ttest confidence intervals

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -6695,8 +6695,9 @@ class TtestResult(TtestResultBase):
 def pack_TtestResult(statistic, pvalue, df, alternative, standard_error,
                      estimate):
     # this could be any number of dimensions (including 0d), but there is
-    # at most one unique value
-    alternative = np.atleast_1d(alternative).ravel()
+    # at most one unique non-NaN value
+    alternative = np.atleast_1d(alternative)  # can't index 0D object
+    alternative = alternative[np.isfinite(alternative)]
     alternative = alternative[0] if alternative.size else np.nan
     return TtestResult(statistic, pvalue, df=df, alternative=alternative,
                        standard_error=standard_error, estimate=estimate)

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -21,6 +21,14 @@ def unpack_ttest_result(res):
             res._estimate, low, high)
 
 
+def _get_ttest_ci(ttest):
+    # get a function that returns the CI bounds of provided `ttest`
+    def ttest_ci(*args, **kwargs):
+        res = ttest(*args, **kwargs)
+        return res.confidence_interval()
+    return ttest_ci
+
+
 axis_nan_policy_cases = [
     # function, args, kwds, number of samples, number of outputs,
     # ... paired, unpacker function
@@ -49,6 +57,8 @@ axis_nan_policy_cases = [
     (stats.ttest_1samp, (np.array([0]),), dict(), 1, 7, False,
      unpack_ttest_result),
     (stats.ttest_rel, tuple(), dict(), 2, 7, True, unpack_ttest_result),
+    (_get_ttest_ci(stats.ttest_1samp), (0,), dict(), 1, 2, False, None),
+    (_get_ttest_ci(stats.ttest_rel), tuple(), dict(), 2, 2, True, None),
     (stats.mode, tuple(), dict(), 1, 2, True, lambda x: (x.mode, x.count))
 ]
 
@@ -525,6 +535,9 @@ def test_axis_nan_policy_decorated_keyword_samples():
                           "paired", "unpacker"), axis_nan_policy_cases)
 def test_axis_nan_policy_decorated_pickled(hypotest, args, kwds, n_samples,
                                            n_outputs, paired, unpacker):
+    if "ttest_ci" in hypotest.__name__:
+        pytest.skip("Can't pickle functions defined within functions.")
+
     rng = np.random.default_rng(0)
 
     # Some hypothesis tests return a non-iterable that needs an `unpacker` to


### PR DESCRIPTION
#### Reference issue
gh-18210

#### What does this implement/fix?
`_axis_nan_policy` tests found a bug in the t-test confidence intervals; in certain cases, when some CI bounds were NaN, _all_ CI bounds would be NaN. This fixes the bug.
