### PR TITLE
ENH:MAINT:linalg det in Cython and with nDarray support

### DIFF
--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1025,17 +1025,9 @@ def det(a, overwrite_a=False, check_finite=True):
     a1 = np.asarray_chkfinite(a) if check_finite else np.asarray(a)
     if a1.ndim < 2:
         raise ValueError('The input array must be at least two-dimensional.')
-    if a1.shape[-1] != a.shape[-2]:
+    if a1.shape[-1] != a1.shape[-2]:
         raise ValueError('Last 2 dimensions of the array must be square'
                          f' but received shape {a1.shape}.')
-
-    # Empty array has determinant 1 because math.
-    if min(*a.shape) == 0:
-        return np.ones(shape=a.shape[:-2])
-
-    # Scalar case
-    if a.shape[-2:] == (1, 1):
-        return np.squeeze(a)
 
     # Also check if dtype is LAPACK compatible
     if a1.dtype.char not in 'fdFD':
@@ -1046,6 +1038,17 @@ def det(a, overwrite_a=False, check_finite=True):
 
         a1 = a1.astype(dtype_char[0])  # makes a copy, free to scratch
         overwrite_a = True
+
+    # Empty array has determinant 1 because math.
+    if min(*a1.shape) == 0:
+        if a1.ndim == 2:
+            return 1.
+        else:
+            return np.ones(shape=a1.shape[:-2])
+
+    # Scalar case
+    if a1.shape[-2:] == (1, 1):
+        return np.squeeze(a1)
 
     # Then check overwrite permission
     if not _datacopied(a1, a):  # "a"  still alive through "a1"

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1025,16 +1025,17 @@ def det(a, overwrite_a=False, check_finite=True):
     3.0
     >>> # An array with the shape (3, 2, 2, 2)
     >>> c = np.array([[[[1., 2.], [3., 4.]],
-        ...            [[5., 6.], [7., 8.]]],
-        ...          [[[9., 10.], [11., 12.]],
-        ...           [[13., 14.], [15., 16.]]],
-        ...          [[[17., 18.], [19., 20.]],
-        ...           [[21., 22.], [23., 24.]]]])
+    ...                [[5., 6.], [7., 8.]]],
+    ...               [[[9., 10.], [11., 12.]],
+    ...                [[13., 14.], [15., 16.]]],
+    ...               [[[17., 18.], [19., 20.]],
+    ...                [[21., 22.], [23., 24.]]]])
     >>> linalg.det(c)  # The resulting shape is (3, 2)
     array([[-2., -2.],
            [-2., -2.],
            [-2., -2.]])
-
+    >>> linalg.det(c[0, 0])  # Confirm the (0, 0) slice, [[1, 2], [3, 4]]
+    -2.0
     """
     # The goal is to end up with a writable contiguous array to pass to Cython
 

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -999,15 +999,15 @@ def det(a, overwrite_a=False, check_finite=True):
     Returns
     -------
     det : (...) float or complex
-        Determinant of `a`. For stacked arrays, say, shape of (p, q, m, m),
-        the result is going to be (p, q), that is to say, for each (m, m)
-        slice in the last two dimensions, a single scalar will be returned.
+        Determinant of `a`. For stacked arrays, a scalar is returned for each
+        (m, m) slice in the last two dimensions of the input. For example, an
+        input of shape (p, q, m, m) will produce a result of shape (p, q).
 
     Notes
     -----
-    The determinant is computed via performing an LU factorization of the
-    input, through LAPACK routine 'getrf' and then calculating the product of
-    diagonal entries of ``U`` factor.
+    The determinant is computed by performing an LU factorization of the
+    input with LAPACK routine 'getrf', and then calculating the product of
+    diagonal entries of the U factor.
 
     Even the input array is single precision (float32 or complex64), the result
     will be returned in double precision (float64 or complex128) to prevent

--- a/scipy/linalg/_cythonized_array_utils.pyx
+++ b/scipy/linalg/_cythonized_array_utils.pyx
@@ -23,8 +23,8 @@ def find_det_from_lu(lapack_t[:, ::1] a):
     cdef int *piv = <int *>malloc(<int>n * sizeof(int))
     try:
         if not piv:
-            raise MemoryError('While computing determinant LU factorization '
-                              'due to failed memory allocation request.')
+            raise MemoryError('Internal memory allocation request for LU '
+                              'factorization failed in "find_det_from_lu".')
 
         if lapack_t is float:
             sgetrf(&n, &n, &a[0,0], &n, &piv[0], &info)
@@ -44,8 +44,8 @@ def find_det_from_lu(lapack_t[:, ::1] a):
                 return 0.+0.j
 
         if info < 0:
-            raise ValueError('SciPy determinant calculation has encountered '
-                             'an internal error in ?getrf routine with invalid'
+            raise ValueError('find_det_from_lu has encountered an internal'
+                             ' error in ?getrf routine with invalid'
                              f' value at {-info}-th parameter.'
                              )
         if lapack_t is float or lapack_t is double:

--- a/scipy/linalg/_cythonized_array_utils.pyx
+++ b/scipy/linalg/_cythonized_array_utils.pyx
@@ -6,8 +6,63 @@ from scipy.linalg._cythonized_array_utils cimport (
 	np_complex_numeric_t,
 	np_numeric_t
     )
+from scipy.linalg.cython_lapack cimport sgetrf, dgetrf, cgetrf, zgetrf
+from libc.stdlib cimport malloc, free
 
 __all__ = ['bandwidth', 'issymmetric', 'ishermitian']
+
+
+# =========================== find_det_from_lu : s, d, c, z ==================
+@cython.wraparound(False)
+@cython.boundscheck(False)
+@cython.initializedcheck(False)
+def find_det_from_lu(lapack_t[:, ::1] a):
+    cdef int n = a.shape[0], k, perm = 0, info = 0
+    cdef double det = 1.
+    cdef double complex detj = 1.+0.j
+    cdef int *piv = <int *>malloc(<int>n * sizeof(int))
+    try:
+        if not piv:
+            raise MemoryError('While computing determinant LU factorization '
+                              'due to failed memory allocation request.')
+
+        if lapack_t is float:
+            sgetrf(&n, &n, &a[0,0], &n, &piv[0], &info)
+            if info > 0:
+                return 0.
+        elif lapack_t is double:
+            dgetrf(&n, &n, &a[0,0], &n, &piv[0], &info)
+            if info > 0:
+                return 0.
+        elif lapack_t is floatcomplex:
+            cgetrf(&n, &n, &a[0,0], &n, &piv[0], &info)
+            if info > 0:
+                return 0.+0.j
+        else:
+            zgetrf(&n, &n, &a[0,0], &n, &piv[0], &info)
+            if info > 0:
+                return 0.+0.j
+
+        if info < 0:
+            raise ValueError('SciPy determinant calculation has encountered '
+                             'an internal error in ?getrf routine with invalid'
+                             f' value at {-info}-th parameter.'
+                             )
+        if lapack_t is float or lapack_t is double:
+            for k in range(n):
+                if piv[k] != (k + 1):
+                    perm += 1
+                det *= a[k, k]
+            return -det if perm % 2 else det
+        else:
+            for k in range(n):
+                if piv[k] != (k + 1):
+                    perm += 1
+                detj *= a[k, k]
+            return -detj if perm % 2 else detj
+    finally:
+        free(piv)
+# ============================================================================
 
 
 # ====================== swap_c_and_f_layout : s, d, c, z ====================

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -937,24 +937,24 @@ class TestDet:
         deta = det(a)
         assert deta.dtype.char == 'd'
         assert deta.shape == (4, 5)
-        assert_almost_equal(deta, np.squeeze(a))
+        assert_allclose(deta, np.squeeze(a))
 
         a = self.rng.random([4, 5, 1, 1], dtype=np.float32)*np.complex64(1.j)
         deta = det(a)
         assert deta.dtype.char == 'D'
         assert deta.shape == (4, 5)
-        assert_almost_equal(deta, np.squeeze(a))
+        assert_allclose(deta, np.squeeze(a))
 
     @pytest.mark.parametrize('shape', [[2, 2], [20, 20], [3, 2, 20, 20]])
     def test_simple_det_shapes_real_complex(self, shape):
         a = self.rng.uniform(-1., 1., size=shape)
         d1, d2 = det(a), np.linalg.det(a)
-        assert_almost_equal(d1, d2)
+        assert_allclose(d1, d2)
 
         b = self.rng.uniform(-1., 1., size=shape)*1j
         b += self.rng.uniform(-0.5, 0.5, size=shape)
         d3, d4 = det(b), np.linalg.det(b)
-        assert_almost_equal(d3, d4)
+        assert_allclose(d3, d4)
 
     def test_for_known_det_values(self):
         # Hadamard8
@@ -966,19 +966,22 @@ class TestDet:
                       [1, -1, 1, -1, -1, 1, -1, 1],
                       [1, 1, -1, -1, -1, -1, 1, 1],
                       [1, -1, -1, 1, -1, 1, 1, -1]])
-        assert_almost_equal(det(a), 4096.)
+        assert_allclose(det(a), 4096.)
 
         # consecutive number array always singular
-        assert_almost_equal(det(np.arange(25).reshape(5, 5)), 0.)
+        assert_allclose(det(np.arange(25).reshape(5, 5)), 0.)
 
-        # simple anti-diagonal array with known det
+        # simple anti-diagonal block array
+        # Upper right has det (-2+1j) and lower right has (-2-1j)
+        # det(a) = - (-2+1j) (-2-1j) = 5.
         a = np.array([[0.+0.j, 0.+0.j, 0.-1.j, 1.-1.j],
                       [0.+0.j, 0.+0.j, 1.+0.j, 0.-1.j],
                       [0.+1.j, 1.+1.j, 0.+0.j, 0.+0.j],
                       [1.+0.j, 0.+1.j, 0.+0.j, 0.+0.j]], dtype=np.complex64)
-        assert_almost_equal(det(a), 5.+0.j)
+        assert_allclose(det(a), 5.+0.j)
 
         # Fiedler companion complexified
+        # >>> a = scipy.linalg.fiedler_companion(np.arange(1, 10))
         a = np.array([[-2., -3., 1., 0., 0., 0., 0., 0.],
                       [1., 0., 0., 0., 0., 0., 0., 0.],
                       [0., -4., 0., -5., 1., 0., 0., 0.],
@@ -987,7 +990,7 @@ class TestDet:
                       [0., 0., 0., 1., 0., 0., 0., 0.],
                       [0., 0., 0., 0., 0., -8., 0., -9.],
                       [0., 0., 0., 0., 0., 1., 0., 0.]])*1.j
-        assert_almost_equal(det(a), 9.)
+        assert_allclose(det(a), 9.)
 
     # g and G dtypes are handled differently in windows and other platforms
     @pytest.mark.parametrize('typ', [x for x in np.typecodes['All'][:20]
@@ -998,7 +1001,7 @@ class TestDet:
         assert isinstance(det(a), (np.float64, np.complex128))
 
     def test_incompatible_dtype_input(self):
-
+        # Double backslashes needed for escaping pytest regex.
         msg = 'cannot be cast to float\\(32, 64\\)'
 
         for c, t in zip('SUO', ['bytes8', 'str32', 'object']):
@@ -1032,14 +1035,14 @@ class TestDet:
         a = np.arange(9).reshape(3, 3).astype(np.float32)
         ac = a.copy()
         deta = det(ac, overwrite_a=True)
-        assert_almost_equal(deta, 0.)
+        assert_allclose(deta, 0.)
         assert not (a == ac).all()
 
     def test_readonly_array(self):
         a = np.array([[2., 0., 1.], [5., 3., -1.], [1., 1., 1.]])
         a.setflags(write=False)
         # overwrite_a will be overridden
-        assert_almost_equal(det(a, overwrite_a=True), 10.)
+        assert_allclose(det(a, overwrite_a=True), 10.)
 
     def test_simple_check_finite(self):
         a = [[1, 2], [3, np.inf]]

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -5,7 +5,6 @@ import warnings
 import numpy as np
 from numpy import (arange, array, dot, zeros, identity, conjugate, transpose,
                    float32)
-import numpy.linalg as linalg
 from numpy.random import random
 
 from numpy.testing import (assert_equal, assert_almost_equal, assert_,
@@ -556,7 +555,7 @@ class TestSolve:
     def test_simple_sym_complexb(self):
         a = [[5, 2], [2, -4]]
         for b in ([1j, 0],
-                  [[1j, 1j],[0, 2]]
+                  [[1j, 1j], [0, 2]]
                   ):
             x = solve(a, b, assume_a='sym')
             assert_array_almost_equal(dot(a, x), b)
@@ -969,7 +968,9 @@ class TestDet:
         d1, d2 = det(a), np.linalg.det(a)
         assert_almost_equal(d1, d2)
 
-    @pytest.mark.parametrize('typ', [x for x in np.typecodes['All'][:20]])
+    # g and G dtypes are handled differently in windows and other platforms
+    @pytest.mark.parametrize('typ', [x for x in np.typecodes['All'][:20]
+                                     if x not in 'gG'])
     def test_sample_compatible_dtype_input(self, typ):
         n = 4
         a = self.rng.random([n, n]).astype(typ)  # value is not important
@@ -1362,9 +1363,9 @@ class TestPinv:
         n = 12
         # get a random ortho matrix for shuffling
         q, _ = qr(np.random.rand(n, n))
-        a_m = np.arange(35.0).reshape(7,5)
+        a_m = np.arange(35.0).reshape(7, 5)
         a = a_m.copy()
-        a[0,0] = 0.001
+        a[0, 0] = 0.001
         atol = 1e-5
         rtol = 0.05
         # svds of a_m is ~ [116.906, 4.234, tiny, tiny, tiny]


### PR DESCRIPTION
#### Reference issue
Related to #18208 

#### What does this implement/fix?
- Removed the dependency to custom Fortran code in `/linalg/src/det.f`
- Added some more tests 
- Touched the documentation for cosmetics
- Performance is improved (depends highly on LAPACK lib)
- Now supports arbitrary stacked arrays; `la.det(np.ones([4, 3, 5, 5]))` returns a `(4, 3)` array.
- Also supports all numeric dtypes (unlike NumPy) float16 is upcasted, <strike>complex256 is downcasted</strike>
- Single precision arrays, if they survive LU step, don't overflow in single precision(ex. `np.linalg.det(np.diag([1.e38, 1e38]).astype(np.float32))` is still finite in  `float` but gives `np.inf`)
- Handles all kinds of empty arrays
- Quick returns for (1, 1) and (..., 1, 1) shaped arrays
- Makes at most a single copy of the input to match LAPACK requirements


