### PR TITLE
ENH: stats.bootstrap: add one-sided confidence intervals

### DIFF
--- a/scipy/stats/_resampling.py
+++ b/scipy/stats/_resampling.py
@@ -154,7 +154,8 @@ def _bca_interval(data, statistic, axis, alpha, theta_hat_b, batch):
 
 
 def _bootstrap_iv(data, statistic, vectorized, paired, axis, confidence_level,
-                  n_resamples, batch, method, bootstrap_result, random_state):
+                  alternative, n_resamples, batch, method, bootstrap_result,
+                  random_state):
     """Input validation and standardization for `bootstrap`."""
 
     if vectorized not in {True, False, None}:
@@ -209,6 +210,11 @@ def _bootstrap_iv(data, statistic, vectorized, paired, axis, confidence_level,
 
     confidence_level_float = float(confidence_level)
 
+    alternative = alternative.lower()
+    alternatives = {'two-sided', 'less', 'greater'}
+    if alternative not in alternatives:
+        raise ValueError(f"`alternative` must be one of {alternatives}")
+
     n_resamples_int = int(n_resamples)
     if n_resamples != n_resamples_int or n_resamples_int < 0:
         raise ValueError("`n_resamples` must be a non-negative integer.")
@@ -240,7 +246,7 @@ def _bootstrap_iv(data, statistic, vectorized, paired, axis, confidence_level,
     random_state = check_random_state(random_state)
 
     return (data_iv, statistic, vectorized, paired, axis_int,
-            confidence_level_float, n_resamples_int, batch_iv,
+            confidence_level_float, alternative, n_resamples_int, batch_iv,
             method, bootstrap_result, random_state)
 
 
@@ -250,12 +256,14 @@ BootstrapResult = make_dataclass("BootstrapResult", fields)
 
 def bootstrap(data, statistic, *, n_resamples=9999, batch=None,
               vectorized=None, paired=False, axis=0, confidence_level=0.95,
-              method='BCa', bootstrap_result=None, random_state=None):
+              alternative='two-sided', method='BCa', bootstrap_result=None,
+              random_state=None):
     r"""
     Compute a two-sided bootstrap confidence interval of a statistic.
 
-    When `method` is ``'percentile'``, a bootstrap confidence interval is
-    computed according to the following procedure.
+    When `method` is ``'percentile'`` and `alternative` is ``'two-sided'``,
+    a bootstrap confidence interval is computed according to the following
+    procedure.
 
     1. Resample the data: for each sample in `data` and for each of
        `n_resamples`, take a random sample of the original sample
@@ -315,6 +323,15 @@ def bootstrap(data, statistic, *, n_resamples=9999, batch=None,
         calculated.
     confidence_level : float, default: ``0.95``
         The confidence level of the confidence interval.
+    alternative : {'two-sided', 'less', 'greater'}, default: ``'two-sided'``
+        Choose ``'two-sided'`` (default) for a two-sided confidence interval,
+        ``'less'`` for a one-sided confidence interval with the lower bound
+        at ``-np.inf``, and ``'greater'`` for a one-sided confidence interval
+        with the upper bound at ``np.inf``. The other bound of the one-sided
+        confidence intervals is the same as that of a two-sided confidence
+        interval with `confidence_level` twice as far from 1.0; e.g. the upper
+        bound of a 95% ``'less'``  confidence interval is the same as the upper
+        bound of a 90% ``'two-sided'`` confidence interval.
     method : {'percentile', 'basic', 'bca'}, default: ``'BCa'``
         Whether to return the 'percentile' bootstrap confidence interval
         (``'percentile'``), the 'basic' (AKA 'reverse') bootstrap confidence
@@ -567,10 +584,11 @@ def bootstrap(data, statistic, *, n_resamples=9999, batch=None,
     """
     # Input validation
     args = _bootstrap_iv(data, statistic, vectorized, paired, axis,
-                         confidence_level, n_resamples, batch, method,
-                         bootstrap_result, random_state)
-    data, statistic, vectorized, paired, axis, confidence_level = args[:6]
-    n_resamples, batch, method, bootstrap_result, random_state = args[6:]
+                         confidence_level, alternative, n_resamples, batch,
+                         method, bootstrap_result, random_state)
+    (data, statistic, vectorized, paired, axis, confidence_level,
+     alternative, n_resamples, batch, method, bootstrap_result,
+     random_state) = args
 
     theta_hat_b = ([] if bootstrap_result is None
                    else [bootstrap_result.bootstrap_distribution])
@@ -591,7 +609,8 @@ def bootstrap(data, statistic, *, n_resamples=9999, batch=None,
     theta_hat_b = np.concatenate(theta_hat_b, axis=-1)
 
     # Calculate percentile interval
-    alpha = (1 - confidence_level)/2
+    alpha = ((1 - confidence_level)/2 if alternative == 'two-sided'
+             else (1 - confidence_level))
     if method == 'bca':
         interval = _bca_interval(data, statistic, axis=-1, alpha=alpha,
                                  theta_hat_b=theta_hat_b, batch=batch)[:2]
@@ -608,6 +627,11 @@ def bootstrap(data, statistic, *, n_resamples=9999, batch=None,
     if method == 'basic':  # see [3]
         theta_hat = statistic(*data, axis=-1)
         ci_l, ci_u = 2*theta_hat - ci_u, 2*theta_hat - ci_l
+
+    if alternative == 'less':
+        ci_l = np.full_like(ci_l, -np.inf)
+    elif alternative == 'greater':
+        ci_u = np.full_like(ci_u, np.inf)
 
     return BootstrapResult(confidence_interval=ConfidenceInterval(ci_l, ci_u),
                            bootstrap_distribution=theta_hat_b,

--- a/scipy/stats/tests/test_resampling.py
+++ b/scipy/stats/tests/test_resampling.py
@@ -164,17 +164,26 @@ def test_bootstrap_vectorized(method, axis, paired):
 @pytest.mark.parametrize("method", ['basic', 'percentile', 'BCa'])
 def test_bootstrap_against_theory(method):
     # based on https://www.statology.org/confidence-intervals-python/
-    data = stats.norm.rvs(loc=5, scale=2, size=5000, random_state=0)
+    rng = np.random.default_rng(2442101192988600726)
+    data = stats.norm.rvs(loc=5, scale=2, size=5000, random_state=rng)
     alpha = 0.95
     dist = stats.t(df=len(data)-1, loc=np.mean(data), scale=stats.sem(data))
     expected_interval = dist.interval(confidence=alpha)
     expected_se = dist.std()
 
-    res = bootstrap((data,), np.mean, n_resamples=5000,
-                    confidence_level=alpha, method=method,
-                    random_state=0)
+    config = dict(data=(data,), statistic=np.mean, n_resamples=5000,
+                  method=method, random_state=rng)
+    res = bootstrap(**config, confidence_level=alpha)
     assert_allclose(res.confidence_interval, expected_interval, rtol=5e-4)
     assert_allclose(res.standard_error, expected_se, atol=3e-4)
+
+    config.update(dict(n_resamples=0, bootstrap_result=res))
+    res = bootstrap(**config, confidence_level=alpha, alternative='less')
+    assert_allclose(res.confidence_interval.high, dist.ppf(alpha), rtol=5e-4)
+
+    config.update(dict(n_resamples=0, bootstrap_result=res))
+    res = bootstrap(**config, confidence_level=alpha, alternative='greater')
+    assert_allclose(res.confidence_interval.low, dist.ppf(1-alpha), rtol=5e-4)
 
 
 tests_R = {"basic": (23.77, 79.12),
@@ -488,7 +497,7 @@ def test_bootstrap_min():
 
 
 @pytest.mark.parametrize("additional_resamples", [0, 1000])
-def test_re_boostrap(additional_resamples):
+def test_re_bootstrap(additional_resamples):
     # Test behavior of parameter `bootstrap_result`
     rng = np.random.default_rng(8958153316228384)
     x = rng.random(size=100)
@@ -511,6 +520,28 @@ def test_re_boostrap(additional_resamples):
     assert_allclose(res.standard_error, ref.standard_error, rtol=1e-14)
     assert_allclose(res.confidence_interval, ref.confidence_interval,
                     rtol=1e-14)
+
+
+@pytest.mark.parametrize("method", ['basic', 'percentile', 'BCa'])
+def test_bootstrap_alternative(method):
+    rng = np.random.default_rng(5894822712842015040)
+    dist = stats.norm(loc=2, scale=4)
+    data = (dist.rvs(size=(100), random_state=rng),)
+
+    config = dict(data=data, statistic=np.std, random_state=rng, axis=-1)
+    t = stats.bootstrap(**config, confidence_level=0.9)
+
+    config.update(dict(n_resamples=0, bootstrap_result=t))
+    l = stats.bootstrap(**config, confidence_level=0.95, alternative='less')
+    g = stats.bootstrap(**config, confidence_level=0.95, alternative='greater')
+
+    assert_equal(l.confidence_interval.high, t.confidence_interval.high)
+    assert_equal(g.confidence_interval.low, t.confidence_interval.low)
+    assert np.isneginf(l.confidence_interval.low)
+    assert np.isposinf(g.confidence_interval.high)
+
+    with pytest.raises(ValueError, match='`alternative` must be one of'):
+        stats.bootstrap(**config, alternative='ekki-ekki')
 
 
 def test_jackknife_resample():


### PR DESCRIPTION
#### Reference issue
Addresses https://github.com/scipy/scipy/pull/18227#pullrequestreview-1367911491

#### What does this implement/fix?
This adds one-sided confidence intervals to `scipy.stats.bootstrap`.

#### Additional information
Intuitively, implementation is as simple as halving `alpha = 1 - confidence_level` and setting the appropriate bound to positive or negative infinity. Roughly confirmed that this is the case against [this reference](https://projecteuclid.org/journals/statistical-science/volume-11/issue-3/Bootstrap-confidence-intervals/10.1214/ss/1032280214.full), but please check me.