### PR TITLE
BUG: nan segfault in KDTree, reject non-finite input

### DIFF
--- a/scipy/spatial/_ckdtree.pyx
+++ b/scipy/spatial/_ckdtree.pyx
@@ -557,7 +557,7 @@ cdef class cKDTree:
         if data.ndim != 2:
             raise ValueError("data must be 2 dimensions")
 
-        if (~np.isfinite(data)).sum() > 0:
+        if not np.isfinite(data).all():
             raise ValueError("data must be finite, check for nan or inf values")
 
         self.data = data

--- a/scipy/spatial/_ckdtree.pyx
+++ b/scipy/spatial/_ckdtree.pyx
@@ -557,6 +557,9 @@ cdef class cKDTree:
         if data.ndim != 2:
             raise ValueError("data must be 2 dimensions")
 
+        if (~np.isfinite(data)).sum() > 0:
+            raise ValueError("data must be finite, check for nan or inf values")
+
         self.data = data
         cself.n = data.shape[0]
         cself.m = data.shape[1]
@@ -588,17 +591,6 @@ cdef class cKDTree:
         self.mins = np.ascontiguousarray(
             np.amin(self.data,axis=0) if self.n > 0 else np.zeros(self.m),
             dtype=np.float64)
-        # NOTE: these tricky shims are required to allow
-        # test_kdtree_nan and test_gh_18223 to both pass;
-        # blanket usage of nanmin/max causes the former to fail
-        if self.maxes.size > 1 and np.isfinite(self.maxes).sum() == 0:
-            self.maxes = np.ascontiguousarray(
-                np.nanmax(self.data, axis=0) if self.n > 0 else np.zeros(self.m),
-                dtype=np.float64)
-        if self.mins.size > 1 and np.isfinite(self.mins).sum() == 0:
-            self.mins = np.ascontiguousarray(
-                np.nanmin(self.data,axis=0) if self.n > 0 else np.zeros(self.m),
-                dtype=np.float64)
         self.indices = np.ascontiguousarray(np.arange(self.n,dtype=np.intp))
 
         self._pre_init()

--- a/scipy/spatial/_ckdtree.pyx
+++ b/scipy/spatial/_ckdtree.pyx
@@ -588,6 +588,17 @@ cdef class cKDTree:
         self.mins = np.ascontiguousarray(
             np.amin(self.data,axis=0) if self.n > 0 else np.zeros(self.m),
             dtype=np.float64)
+        # NOTE: these tricky shims are required to allow
+        # test_kdtree_nan and test_gh_18223 to both pass;
+        # blanket usage of nanmin/max causes the former to fail
+        if self.maxes.size > 1 and np.isfinite(self.maxes).sum() == 0:
+            self.maxes = np.ascontiguousarray(
+                np.nanmax(self.data, axis=0) if self.n > 0 else np.zeros(self.m),
+                dtype=np.float64)
+        if self.mins.size > 1 and np.isfinite(self.mins).sum() == 0:
+            self.mins = np.ascontiguousarray(
+                np.nanmin(self.data,axis=0) if self.n > 0 else np.zeros(self.m),
+                dtype=np.float64)
         self.indices = np.ascontiguousarray(np.arange(self.n,dtype=np.intp))
 
         self._pre_init()

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -1464,18 +1464,20 @@ def test_kdtree_nan():
     vals = [1, 5, -10, 7, -4, -16, -6, 6, 3, -11]
     n = len(vals)
     data = np.concatenate([vals, np.full(n, np.nan)])[:, None]
-
-    query_with_nans = KDTree(data).query_pairs(2)
-    query_without_nans = KDTree(data[:n]).query_pairs(2)
-    assert query_with_nans == query_without_nans
+    with pytest.raises(ValueError, match="must be finite"):
+        KDTree(data)
 
 
 def test_gh_18223():
     rng = np.random.default_rng(12345)
     coords = rng.uniform(size=(100, 3), low=0.0, high=0.1)
-    tree1 = KDTree(coords, balanced_tree=False, compact_nodes=False)
+    KDTree(coords, balanced_tree=False, compact_nodes=False)
     coords[0, :] = np.nan
-    tree2 = KDTree(coords, balanced_tree=True, compact_nodes=False)
-    tree3 = KDTree(coords, balanced_tree=False, compact_nodes=True)
-    tree4 = KDTree(coords, balanced_tree=True, compact_nodes=True)
-    tree5 = KDTree(coords, balanced_tree=False, compact_nodes=False)
+    with pytest.raises(ValueError, match="must be finite"):
+        KDTree(coords, balanced_tree=True, compact_nodes=False)
+    with pytest.raises(ValueError, match="must be finite"):
+        KDTree(coords, balanced_tree=False, compact_nodes=True)
+    with pytest.raises(ValueError, match="must be finite"):
+        KDTree(coords, balanced_tree=True, compact_nodes=True)
+    with pytest.raises(ValueError, match="must be finite"):
+        KDTree(coords, balanced_tree=False, compact_nodes=False)

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -1468,3 +1468,14 @@ def test_kdtree_nan():
     query_with_nans = KDTree(data).query_pairs(2)
     query_without_nans = KDTree(data[:n]).query_pairs(2)
     assert query_with_nans == query_without_nans
+
+
+def test_gh_18223():
+    rng = np.random.default_rng(12345)
+    coords = rng.uniform(size=(100, 3), low=0.0, high=0.1)
+    tree1 = KDTree(coords, balanced_tree=False, compact_nodes=False)
+    coords[0, :] = np.nan
+    tree2 = KDTree(coords, balanced_tree=True, compact_nodes=False)
+    tree3 = KDTree(coords, balanced_tree=False, compact_nodes=True)
+    tree4 = KDTree(coords, balanced_tree=True, compact_nodes=True)
+    tree5 = KDTree(coords, balanced_tree=False, compact_nodes=False)


### PR DESCRIPTION
* Fixes #18223, though I'd prefer not do to this (see discussion below)

* add regression test + fix for the above issue; in short, don't allow `nan` to be assigned as a maximum or minimum value array prior to tree construction logic when the array has size greater than 1

* this is an improvement in the sense of segfault avoidance, though it doesn't necessarily guarantee that we get the correct tree/attributes when `nan` is present (indeed, the shim is pretty darn strange, see note in code...)

* I'm a bit hesitant to add a bunch of `nan` support here generally though; for example, what does it even mean if a 3D coordinate has "x" as np.nan, but regular floats for "y" and "z?" I doubt we handle all of these kinds of scenarios "correctly," whatever correctly would even mean here

* this really is a rabbit hole I think, there's a similar unresolved discussion for `nan` handling in the conceptually similar `pdist/cdist` usage here, unresolved after 9 years:
https://github.com/scipy/scipy/issues/3870

* I think I'm actually tempted to error out when `nan` is present, rather than maintaining a bunch of code that might otherwise have to temporarily mask out the nans and then recalculate indices before/after the C++ code or whatever, but this likely requires some discussion...

@sturlamolden @peterbell10 thoughts? I suspect you'll agree this is a rabbit hole, but curious if you'd think i.e., erroring out with `np.nan` present might be desirable long-term?