### PR TITLE
MAINT:optimize: shgo assorted fixes

### DIFF
--- a/scipy/optimize/_shgo.py
+++ b/scipy/optimize/_shgo.py
@@ -624,7 +624,7 @@ class SHGO:
             'newton-cg': ['jac', 'hess', 'hessp'],
             'l-bfgs-b': ['jac', 'bounds'],
             'tnc': ['jac', 'bounds'],
-            'cobyla': ['constraints'],
+            'cobyla': ['constraints', 'catol'],
             'slsqp': ['jac', 'bounds', 'constraints'],
             'dogleg': ['jac', 'hess'],
             'trust-ncg': ['jac', 'hess', 'hessp'],

--- a/scipy/optimize/_shgo_lib/_complex.py
+++ b/scipy/optimize/_shgo_lib/_complex.py
@@ -3,7 +3,7 @@ import copy
 import logging
 import itertools
 import decimal
-from functools import lru_cache
+from functools import cache
 
 import numpy
 
@@ -996,7 +996,7 @@ class Complex:
                 d_v0v1.connect(d_v1v2)
         return
 
-    @lru_cache(maxsize=None)
+    @cache
     def split_edge(self, v1, v2):
         v1 = self.V[v1]
         v2 = self.V[v2]

--- a/scipy/optimize/_shgo_lib/_complex.py
+++ b/scipy/optimize/_shgo_lib/_complex.py
@@ -142,7 +142,7 @@ class Complex:
                 constraints = (constraints,)
 
             for cons in constraints:
-                if cons['type'] == 'ineq':
+                if cons['type'] in ('ineq'):
                     self.g_cons.append(cons['fun'])
                     try:
                         self.g_args.append(cons['args'])

--- a/scipy/optimize/_shgo_lib/_vertex.py
+++ b/scipy/optimize/_shgo_lib/_vertex.py
@@ -274,16 +274,19 @@ class VertexCacheField(VertexCacheBase):
         self.Vertex = VertexScalarField
         self.field = field
         self.field_args = field_args
-        self.wfield = FieldWraper(field, field_args)  # if workers is not 1
+        self.wfield = FieldWrapper(field, field_args)  # if workers is not 1
 
         self.g_cons = g_cons
         self.g_cons_args = g_cons_args
-        self.wgcons = ConstraintWraper(g_cons, g_cons_args)
+        self.wgcons = ConstraintWrapper(g_cons, g_cons_args)
         self.gpool = set()  # A set of tuples to process for feasibility
 
         # Field processing objects
         self.fpool = set()  # A set of tuples to process for scalar function
         self.sfc_lock = False  # True if self.fpool is non-Empty
+
+        self.workers = workers
+        self._mapwrapper = MapWrapper(workers)
 
         if workers == 1:
             self.process_gpool = self.proc_gpool
@@ -292,9 +295,6 @@ class VertexCacheField(VertexCacheBase):
             else:
                 self.process_fpool = self.proc_fpool_g
         else:
-            self.workers = workers
-            self._mapwrapper = MapWrapper(workers)
-            self.pool = self._mapwrapper.pool
             self.process_gpool = self.pproc_gpool
             if g_cons is None:
                 self.process_fpool = self.pproc_fpool_nog
@@ -330,7 +330,8 @@ class VertexCacheField(VertexCacheBase):
     def feasibility_check(self, v):
         v.feasible = True
         for g, args in zip(self.g_cons, self.g_cons_args):
-            if g(v.x_a, *args) < 0.0:
+            # constraint may return more than 1 value.
+            if np.any(g(v.x_a, *args) < 0.0):
                 v.f = np.inf
                 v.feasible = False
                 break
@@ -365,7 +366,7 @@ class VertexCacheField(VertexCacheBase):
         for v in self.gpool:
             gpool_l.append(v.x_a)
 
-        G = self.pool.map(self.wgcons.gcons, gpool_l)
+        G = self._mapwrapper(self.wgcons.gcons, gpool_l)
         for v, g in zip(self.gpool, G):
             v.feasible = g  # set vertex object attribute v.feasible = g (bool)
 
@@ -395,7 +396,7 @@ class VertexCacheField(VertexCacheBase):
                 fpool_l.append(v.x_a)
             else:
                 v.f = np.inf
-        F = self.pool.map(self.wfield.func, fpool_l)
+        F = self._mapwrapper(self.wfield.func, fpool_l)
         for va, f in zip(fpool_l, F):
             vt = tuple(va)
             self[vt].f = f  # set vertex object attribute v.f = f
@@ -411,7 +412,7 @@ class VertexCacheField(VertexCacheBase):
         fpool_l = []
         for v in self.fpool:
             fpool_l.append(v.x_a)
-        F = self.pool.map(self.wfield.func, fpool_l)
+        F = self._mapwrapper(self.wfield.func, fpool_l)
         for va, f in zip(fpool_l, F):
             vt = tuple(va)
             self[vt].f = f  # set vertex object attribute v.f = f
@@ -426,7 +427,7 @@ class VertexCacheField(VertexCacheBase):
             v.maximiser()
 
 
-class ConstraintWraper:
+class ConstraintWrapper:
     """Object to wrap constraints to pass to `multiprocessing.Pool`."""
     def __init__(self, g_cons, g_cons_args):
         self.g_cons = g_cons
@@ -435,13 +436,14 @@ class ConstraintWraper:
     def gcons(self, v_x_a):
         vfeasible = True
         for g, args in zip(self.g_cons, self.g_cons_args):
-            if g(v_x_a, *args) < 0.0:
+            # constraint may return more than 1 value.
+            if np.any(g(v_x_a, *args) < 0.0):
                 vfeasible = False
                 break
         return vfeasible
 
 
-class FieldWraper:
+class FieldWrapper:
     """Object to wrap field to pass to `multiprocessing.Pool`."""
     def __init__(self, field, field_args):
         self.field = field

--- a/scipy/optimize/tests/test__shgo.py
+++ b/scipy/optimize/tests/test__shgo.py
@@ -1,4 +1,6 @@
 import logging
+import warnings
+
 import numpy
 import numpy as np
 import time
@@ -1081,13 +1083,13 @@ def test_vector_constraint():
     assert res.success
 
 
+@pytest.mark.filterwarnings("ignore:delta_grad")
 def test_trust_constr():
     def quad(x):
         x = np.asarray(x)
         return [np.sum(x ** 2)]
 
     nlc = NonlinearConstraint(quad, [2.6], [3])
-    oldc = new_constraint_to_old(nlc, np.array([1.0, 1.0]))
     minimizer_kwargs = {'method': 'trust-constr'}
     # note that we don't supply the constraints in minimizer_kwargs,
     # so if the final result obeys the constraints we know that shgo
@@ -1095,7 +1097,7 @@ def test_trust_constr():
     res = shgo(
         rosen,
         [(0, 10), (0, 10)],
-        constraints=oldc,
+        constraints=nlc,
         sampling_method='sobol',
         minimizer_kwargs=minimizer_kwargs
     )

--- a/scipy/optimize/tests/test__shgo.py
+++ b/scipy/optimize/tests/test__shgo.py
@@ -786,8 +786,10 @@ class TestShgoArguments:
 
         with Pool(2) as p:
             run_test(test1_1, n=30, workers=p.map)  # Constrained
+        run_test(test1_1, n=30, workers=map)  # Constrained
         with Pool(2) as p:
             run_test(test_s, n=30, workers=p.map)  # Unconstrained
+        run_test(test_s, n=30, workers=map)  # Unconstrained
 
     def test_20_constrained_args(self):
         """Test that constraints can be passed to arguments"""

--- a/scipy/optimize/tests/test__shgo.py
+++ b/scipy/optimize/tests/test__shgo.py
@@ -1,5 +1,4 @@
 import logging
-import warnings
 
 import numpy
 import numpy as np

--- a/scipy/optimize/tests/test__shgo.py
+++ b/scipy/optimize/tests/test__shgo.py
@@ -1076,8 +1076,30 @@ def test_vector_constraint():
     oldc = new_constraint_to_old(nlc, np.array([1.0, 1.0]))
 
     res = shgo(rosen, [(0, 10), (0, 10)], constraints=oldc, sampling_method='sobol')
-    print(res)
     assert np.all(np.sum((res.x)**2) >= 2.2)
+    assert np.all(np.sum((res.x) ** 2) <= 3.0)
+    assert res.success
+
+
+def test_trust_constr():
+    def quad(x):
+        x = np.asarray(x)
+        return [np.sum(x ** 2)]
+
+    nlc = NonlinearConstraint(quad, [2.6], [3])
+    oldc = new_constraint_to_old(nlc, np.array([1.0, 1.0]))
+    minimizer_kwargs = {'method': 'trust-constr'}
+    # note that we don't supply the constraints in minimizer_kwargs,
+    # so if the final result obeys the constraints we know that shgo
+    # passed them on to 'trust-constr'
+    res = shgo(
+        rosen,
+        [(0, 10), (0, 10)],
+        constraints=oldc,
+        sampling_method='sobol',
+        minimizer_kwargs=minimizer_kwargs
+    )
+    assert np.all(np.sum((res.x)**2) >= 2.6)
     assert np.all(np.sum((res.x) ** 2) <= 3.0)
     assert res.success
 

--- a/scipy/optimize/tests/test__shgo.py
+++ b/scipy/optimize/tests/test__shgo.py
@@ -1,11 +1,14 @@
 import logging
 import numpy
+import numpy as np
 import time
+from multiprocessing import Pool
 from numpy.testing import assert_allclose
 import pytest
 from pytest import raises as assert_raises, warns
 from scipy.optimize import (shgo, Bounds, minimize_scalar, minimize, rosen,
-                            rosen_der, rosen_hess)
+                            rosen_der, rosen_hess, NonlinearConstraint)
+from scipy.optimize._constraints import new_constraint_to_old
 from scipy.optimize._shgo import SHGO
 
 
@@ -115,6 +118,7 @@ class StructTest3(StructTestFunction):
 
     """
 
+    # amended to test vectorisation of constraints
     def f(self, x):
         return 0.01 * (x[0]) ** 2 + (x[1]) ** 2
 
@@ -124,10 +128,15 @@ class StructTest3(StructTestFunction):
     def g2(x):
         return x[0] ** 2 + x[1] ** 2 - 25.0
 
-    g = (g1, g2)
+    # g = (g1, g2)
+    # cons = wrap_constraints(g)
 
-    cons = wrap_constraints(g)
+    def g(x):
+        return x[0] * x[1] - 25.0, x[0] ** 2 + x[1] ** 2 - 25.0
 
+    # this checks that shgo can be sent new-style constraints
+    __nlc = NonlinearConstraint(g, 0, np.inf)
+    cons = (__nlc,)
 
 test3_1 = StructTest3(bounds=[(2, 50), (0, 50)],
                       expected_x=[250 ** 0.5, 2.5 ** 0.5],
@@ -775,8 +784,10 @@ class TestShgoArguments:
     def test_19_parallelization(self):
         """Test the functionality to add custom sampling methods to shgo"""
 
-        run_test(test1_1, n=30, workers=1)  # Constrained
-        run_test(test_s, n=30, workers=1)  # Unconstrained
+        with Pool(2) as p:
+            run_test(test1_1, n=30, workers=p.map)  # Constrained
+        with Pool(2) as p:
+            run_test(test_s, n=30, workers=p.map)  # Unconstrained
 
     def test_20_constrained_args(self):
         """Test that constraints can be passed to arguments"""
@@ -1051,3 +1062,53 @@ class TestShgoReturns:
 
         result = shgo(fun, bounds, sampling_method='sobol')
         numpy.testing.assert_equal(fun.nfev, result.nfev)
+
+
+def test_vector_constraint():
+    # gh15514
+    def quad(x):
+        x = np.asarray(x)
+        return [np.sum(x ** 2)]
+
+    nlc = NonlinearConstraint(quad, [2.2], [3])
+    oldc = new_constraint_to_old(nlc, np.array([1.0, 1.0]))
+
+    res = shgo(rosen, [(0, 10), (0, 10)], constraints=oldc, sampling_method='sobol')
+    print(res)
+    assert np.all(np.sum((res.x)**2) >= 2.2)
+    assert np.all(np.sum((res.x) ** 2) <= 3.0)
+    assert res.success
+
+
+def test_equality_constraints():
+    # gh16260
+    bounds = [(0.9, 4.0)] * 2  # Constrain probabilities to 0 and 1.
+
+    def faulty(x):
+        return x[0] + x[1]
+
+    nlc = NonlinearConstraint(faulty, 3.9, 3.9)
+    res = shgo(rosen, bounds=bounds, constraints=nlc)
+    assert_allclose(np.sum(res.x), 3.9)
+
+    def faulty(x):
+        return x[0] + x[1] - 3.9
+
+    constraints = {'type': 'eq', 'fun': faulty}
+    res = shgo(rosen, bounds=bounds, constraints=constraints)
+    assert_allclose(np.sum(res.x), 3.9)
+
+    bounds = [(0, 1.0)] * 4
+    # sum of variable should equal 1.
+    def faulty(x):
+        return x[0] + x[1] + x[2] + x[3] - 1
+
+    # options = {'minimize_every_iter': True, 'local_iter':10}
+    constraints = {'type': 'eq', 'fun': faulty}
+    res = shgo(
+        lambda x: - np.prod(x),
+        bounds=bounds,
+        constraints=constraints,
+        sampling_method='sobol'
+    )
+    assert_allclose(np.sum(res.x), 1.0)

--- a/scipy/optimize/tests/test__shgo.py
+++ b/scipy/optimize/tests/test__shgo.py
@@ -1136,3 +1136,20 @@ def test_equality_constraints():
         sampling_method='sobol'
     )
     assert_allclose(np.sum(res.x), 1.0)
+
+def test_gh16971():
+    def cons(x):
+        return np.sum(x**2) - 0
+
+    c = {'fun': cons, 'type': 'ineq'}
+    minimizer_kwargs = {
+        'method': 'COBYLA',
+        'options': {'rhobeg': 5, 'tol': 5e-1, 'catol': 0.05}
+    }
+
+    s = SHGO(
+        rosen, [(0, 10)]*2, constraints=c, minimizer_kwargs=minimizer_kwargs
+    )
+
+    assert s.minimizer_kwargs['method'].lower() == 'cobyla'
+    assert s.minimizer_kwargs['options']['catol'] == 0.05


### PR DESCRIPTION
 Closes #15514
 Closes #16971

This PR:
- allows constraint functions to return more than 1 value, thereby closing #15514.
- fixes parallelisation (Pools weren't being released, not all map-like callables could be used for `workers`). Parallelisation resources are definitively released via the context manager. All map-like callables can be supplied to workers. Parallelisation is tested in greater depth.
- `NonlinearConstraint`, `LinearConstraint` can now be used in `shgo`. (via `optimize._minimize.standardize_constraints`)
- If `trust-constr` is used as a local minimizer the top level constraints are automatically passed to `minimize` unless overwritten in `minimizer_kwargs`. `minimize` should automatically take care of constraint interconversion.
- documentation for the above has been updated.
- also contains fixes for #16971

