### PR TITLE
TST: stats.dunnett: fix seed in test_shapes

### DIFF
--- a/scipy/stats/tests/test_multicomp.py
+++ b/scipy/stats/tests/test_multicomp.py
@@ -390,12 +390,13 @@ class TestDunnett:
         with pytest.raises(ValueError, match="Confidence level must"):
             res.confidence_interval(confidence_level=3)
 
+    @pytest.mark.filterwarnings("ignore:Computation of the confidence")
     @pytest.mark.parametrize('n_samples', [1, 2, 3])
     def test_shapes(self, n_samples):
         rng = np.random.default_rng(689448934110805334)
         samples = rng.normal(size=(n_samples, 10))
         control = rng.normal(size=10)
-        res = stats.dunnett(*samples, control=control)
+        res = stats.dunnett(*samples, control=control, random_state=rng)
         assert res.statistic.shape == (n_samples,)
         assert res.pvalue.shape == (n_samples,)
         ci = res.confidence_interval()


### PR DESCRIPTION
#### Reference issue
gh-18231, for example

#### What does this implement/fix?
A new test is failing sporadically by emitting a warning. The warning is expected to occur sometimes, but it should not be allowed to cause the test to fail. To ensure that this doesn't happen again, this PR fixes the random state (which should be sufficient) and filters the warning (in case new architectures in CI emit the warning with this random state).

