### PR TITLE
DOC: remove content related to `setup.py` usage from the docs

### DIFF
--- a/doc/source/dev/contributor/building_faq.rst
+++ b/doc/source/dev/contributor/building_faq.rst
@@ -4,78 +4,11 @@
 Build/Install FAQ
 =================
 
-How do I set up multiple versions of SciPy on my machine?
-=========================================================
-
-You may want to set up a development version of SciPy in parallel to a released
-version that you use to do your job/research.
-
-If you use the ``conda`` package manager, this is covered in the
-:ref:`conda-guide`.
-
-Another simple way to achieve this is to install the released version in
-site-packages, by using a binary installer or pip, for example, and set
-up the development version in a virtualenv. First, install
-`virtualenv`_ (optionally, use `virtualenvwrapper`_), then create your
-virtualenv (named scipy-dev here) with::
-
-    $ virtualenv scipy-dev
-
-Now, whenever you want to switch to the virtual environment, you can use the
-command ``source scipy-dev/bin/activate``, and ``deactivate`` to exit from the
-virtual environment and back to your previous shell. With scipy-dev
-activated, first install Scipy's dependencies::
-
-    $ pip install numpy pytest cython pybind11
-
-After that, you can install a development version of Scipy, for example, via::
-
-    $ python setup.py install
-
-The installation goes to the virtual environment.
-
-How do I set up an in-place build for development?
-==================================================
-
-For development, you can set up an in-place build so that changes made to
-``.py`` files have effect without rebuild. First, run::
-
-    $ python setup.py build_ext -i
-
-Then you need to point your PYTHONPATH environment variable to this directory.
-Some IDEs (`Spyder`_, for example) have utilities to manage PYTHONPATH. On Linux
-and OSX, you can run the command::
-
-    $ export PYTHONPATH=$PWD
-
-and on Windows::
-
-    $ set PYTHONPATH=/path/to/scipy
-
-Now, editing a Python source file in SciPy allows you to immediately
-test and use your changes (in ``.py`` files), by simply restarting the
-interpreter.
-
-.. _virtualenv: https://virtualenv.pypa.io/
-
-.. _virtualenvwrapper: https://bitbucket.org/dhellmann/virtualenvwrapper/
-
-.. _Spyder: https://www.spyder-ide.org/
-
 How do I checkout a pull request from GitHub locally?
 =====================================================
 
-Second to code review pull requests it is helpful to have a local copy of the
-code changes in the pull request. The preferred method to bring a PR from the
-github repository to your local repo in a new branch::
+Please use `the GitHub CLI <https://cli.github.com>`__ for this.
 
-    $ git fetch upstream pull/PULL_REQUEST_ID/head:NEW_BRANCH_NAME
-
-The value of ``PULL_REQUEST_ID`` will be the PR number and the
-``NEW_BRANCH_NAME`` will be the name of the branch in your local repository
-where the diffs will reside.
-
-Now you have a branch in your local development area to code review in Python.
 
 How do I deal with Fortran ABI mismatch?
 ========================================
@@ -93,8 +26,6 @@ library is MKL and if so, use the CBLAS API instead of the BLAS API.
 If autodetection fails or if the user wants to override this
 autodetection mechanism, use the following:
 
-*For ``meson`` based builds (new in 1.9.0):*
-
 Use the ``-Duse-g77-abi=true`` build option. E.g.,::
 
     $ meson setup build -Duse-g77-abi=true
@@ -106,58 +37,9 @@ example)::
     $ meson setup builddir -Duse-g77-abi=true -Dblas=blas -Dlapack=lapack -Dpython.install_env=auto
     $ meson install -C builddir
 
-*For ``distutils`` based builds:*
-
-Set the environment variable ``SCIPY_USE_G77_ABI_WRAPPER`` to 0 or 1 to disable
-or enable using CBLAS API.
 
 How do I use a custom BLAS distribution on Linux?
 =================================================
 
-To customize which BLAS is used, you can set up a ``site.cfg`` file. See the
-``site.cfg.example`` file in the numpy source for the options you can set.
+See :ref:`blas-lapack-selection` for details on this topic.
 
-Note that Debian and Ubuntu package optimized BLAS libraries in an exchangeable
-way. You can install libraries, such as ATLAS or OpenBLAS and change the default
-one used via the alternatives mechanism::
-
-    $ sudo apt-get install libopenblas-base libatlas3-base
-    $ update-alternatives --list libblas.so.3
-    /usr/lib/atlas-base/atlas/libblas.so.3
-    /usr/lib/libblas/libblas.so.3
-    /usr/lib/openblas-base/libopenblas.so.0
-
-    $ sudo update-alternatives --set libblas.so.3 /usr/lib/openblas-base/libopenblas.so.0
-
-See ``/usr/share/doc/libatlas3-base/README.Debian`` for instructions on how to
-build optimized ATLAS packages for your specific CPU. The packaged OpenBLAS
-chooses the optimal code at runtime so it does not need recompiling unless the
-packaged version does not yet support the used CPU.
-
-You can also use a library you built yourself by preloading it. This does not
-require administrator rights::
-
-    LD_PRELOAD=/path/to/libatlas.so.3 ./my-application
-
-
-Version-specific notes
-======================
-
-If you have any problems installing SciPy on your Mac
-based on these instructions, please check the `scipy-dev mailing list archives
-<https://www.scipy.org/mailing-lists>`__
-for possible solutions. If you
-are still stuck, feel free to join scipy-dev for further
-assistance. Please have the following information ready:
-
-* Your OS version
-
-* The versions of gcc and gfortran and where you obtained gfortran
-
-  * ``$ gcc --version``
-
-  * ``$ gfortran --version``
-
-* The versions of NumPy and SciPy that you are trying to install
-
-* The full output of ``$ python setup.py build``

--- a/doc/source/dev/contributor/cython.rst
+++ b/doc/source/dev/contributor/cython.rst
@@ -21,14 +21,15 @@ code with Cython:
 
 #. Include your code in a file with a ``.pyx``
    extension rather than a ``.py`` extension. All files with a ``.pyx``
-   extension are automatically converted by Cython to ``.c`` files when
-   SciPy is built.
+   extension are automatically converted by Cython to ``.c`` or ``.cpp``
+   files when SciPy is built.
 
-#. Add an extension from this ``.c`` file to the
-   configuration of the subpackage in which your code lives. Typically,
-   this is very easy: add a single, formulaic line to the subpackage’s
-   ``setup.py`` file. Once added as an extension, the ``.c`` code will be
-   compiled by your C compiler to machine code when SciPy is built.
+#. Add the new ``.pyx`` file to the ``meson.build`` build configuration
+   of the subpackage in which your code lives. Typically, there are already
+   other ``.pyx`` patterns present (if not, look in another submodule) so
+   there's an example to follow for what exact content to add to
+   ``meson.build``.
+
 
 Example
 -------
@@ -47,20 +48,34 @@ written in Cython; the only way so far that we can tell they are Cython
 classes is that they are defined in a file with a ``.pyx`` extension.
 
 Even in ``/scipy/optimize/_bglu_dense.pyx``, most of the code resembles
-Python. The most notable differences are the presence of |cimport|_,
-|cdef|_, and `Cython decorators`_. None of these are strictly
+Python. The most notable differences are the presence of ``cimport``,
+``cdef``, and `Cython decorators`_. None of these are strictly
 necessary. Without them, the pure Python code can still be compiled by
 Cython. The Cython language extensions are \*just\* tweaks to improve
 performance. This ``.pyx`` file is automatically converted to a ``.c``
 file by Cython when SciPy is built.
 
-The only thing left is to add an extension from this ``.c`` file using
-|distutils|_. This takes just a single line in |optimize-setup|_:
-``config.add_extension('_bglu_dense', sources=['_bglu_dense.c'])``,
-``_bglu_dense.c`` is the source and ``_bglu_dense`` is the name of the
-extension (for consistency). When SciPy is built, ``_bglu_dense.c`` will
-be compiled to machine code, and we will be able to import the ``LU``
-and ``BGLU`` classes from the extension ``_bglu_dense``.
+The only thing left is to add the build configuration, which will look
+something like:
+
+.. code:: meson
+
+    _bglu_dense_c = opt_gen.process('_bglu_dense.pyx')
+
+    py3.extension_module('_bglu_dense',
+      _bglu_dense_c,
+      c_args: cython_c_args,
+      dependencies: np_dep,
+      link_args: version_link_args,
+      install: true,
+      subdir: 'scipy/optimize'
+    )
+
+When SciPy is built, ``_bglu_dense.pyx`` will be transpiled by ``cython``
+to C code, and then that generated C file is treated by Meson like any other C
+code in SciPy - producing an extension modules that we will be able to import
+and use the ``LU`` and ``BGLU`` classes from.
+
 
 Exercise
 --------
@@ -99,22 +114,13 @@ Exercise
 
 #. Save your ``.py`` file to a ``.pyx`` file, e.g. \ ``mycython.pyx``.
 
-#. Build SciPy. Note that a ``.c`` file has been added to the
-   ``/scipy/optimize`` directory.
+#. Add the ``.pyx`` to ``scipy/optimize/meson.build``, in the way described in
+   the previous section.
 
-#. Somewhere near similar lines, add an extension from your ``.c`` file
-   to ``/scipy/optimize/setup.py``. e.g.:
+#. Rebuild SciPy. Note that an extension module (a ``.so`` or ``.pyd`` file)
+   has been added to the ``build/scipy/optimize/`` directory.
 
-   ::
-
-      config.add_extension('_group_columns', sources=['_group_columns.c'],)  # was already here
-      config.add_extension('mycython', sources=['mycython.c'],)  # this was new
-      config.add_extension('_bglu_dense', sources=['_bglu_dense.c'])  # was already there
-
-#. Rebuild SciPy. Note that a ``.so`` file has been added to the
-   ``/scipy/optimize`` directory.
-
-#. Time it:
+#. Time it, e.g. by dropping into IPython with ``python dev.py ipython`` and then:
 
    ::
 
@@ -179,12 +185,6 @@ the alternative is many low-level operations in Python.
 .. _Cython website: https://cython.org/
 .. _Cython documentation: http://docs.cython.org/en/latest/
 
-.. |cimport| replace:: ``cimport``
-.. _cimport: https://cython.readthedocs.io/en/latest/src/userguide/sharing_declarations.html
-
-.. |cdef| replace:: ``cdef``
-.. _cdef: https://github.com/scipy/scipy/blob/main/scipy/optimize/setup.py
-
 .. _Cython decorators: https://cython.readthedocs.io/en/latest/src/userguide/numpy_tutorial.html
 
 .. |linprog-rs| replace:: ``scipy.optimize._linprog_rs.py``
@@ -192,11 +192,5 @@ the alternative is many low-level operations in Python.
 
 .. |bglu-dense| replace:: ``/scipy/optimize/_bglu_dense.pyx``
 .. _bglu-dense: https://github.com/scipy/scipy/blob/main/scipy/optimize/_bglu_dense.pyx
-
-.. |distutils| replace:: ``numpy.distutils``
-.. _distutils: https://docs.scipy.org/doc/numpy/reference/distutils.html
-
-.. |optimize-setup| replace:: ``scipy/optimize/setup.py``
-.. _optimize-setup: https://github.com/scipy/scipy/blob/main/scipy/optimize/setup.py
 
 .. _Cythonizing SciPy Code: https://youtu.be/K9bF7cjUJ7c

--- a/doc/source/dev/contributor/development_workflow.rst
+++ b/doc/source/dev/contributor/development_workflow.rst
@@ -282,12 +282,10 @@ Checklist before submitting a PR
 -  Is the docstring of the new functionality tagged with
    ``.. versionadded:: X.Y.Z`` (where ``X.Y.Z`` is the version number of the
    next release? See the ``updating``, ``workers``, and ``constraints``
-   documentation of |differential_evolution|_, for example. You can get the
-   next version number from the most recent release notes on `the wiki`_ or
-   from the ``MAJOR`` and ``MINOR`` version number variables in |setup.py|_.
+   documentation of |differential_evolution|_, for example.
 -  In case of larger additions, is there a tutorial or more extensive
    module-level description? Tutorial files are in ``doc/source/tutorial``.
--  If compiled code is added, is it integrated correctly via ``setup.py``?
+-  If new files are added, are they integrated correctly via ``meson.build``?
    See :ref:`compiled-code` for more information.
 
 .. include:: ../gitwash/git_links.inc
@@ -306,6 +304,3 @@ Checklist before submitting a PR
 
 .. |differential_evolution| replace:: ``differential_evolution``
 .. _differential_evolution: https://github.com/scipy/scipy/blob/main/scipy/optimize/_differentialevolution.py
-
-.. |setup.py| replace:: ``setup.py``
-.. _setup.py: https://github.com/scipy/scipy/blob/main/setup.py

--- a/doc/source/dev/contributor/quickstart_docker.rst
+++ b/doc/source/dev/contributor/quickstart_docker.rst
@@ -81,8 +81,7 @@ instructions each time you want to start the container, as changes made to a
 container do not persist after you close it.
 
 #. In a terminal window, change the directory (using the ``cd`` command)
-   to the root folder of the SciPy git repository, which contains the file
-   ``setup.py``.
+   to the root folder of the SciPy git repository.
 
 #. Ensure that Docker Desktop (or Docker Toolbox) is running, and start up the
    SciPy Docker container by entering the following command in a terminal

--- a/doc/source/dev/contributor/windows.rst
+++ b/doc/source/dev/contributor/windows.rst
@@ -148,7 +148,7 @@ You can see all available options via
    git tag
 
 Now change the directory one level up via :code:`cd ..` to get out of the
-directory and create a file named `build_openblas.sh`. The easiest way is to
+directory and create a file named ``build_openblas.sh``. The easiest way is to
 type
 
 .. code:: shell
@@ -297,7 +297,7 @@ Once you have built OpenBLAS, it's time to build SciPy. Before continuing, make
 sure to install the following software for building on the latest Python
 version. For building on other Python versions, see the WindowsCompilers_ page.
 We are also assuming that your Python is on the system path. That is to say,
-when you type `python` in the Windows command prompt the correct Python is
+when you type ``python`` in the Windows command prompt the correct Python is
 executed.
 
 Install Microsoft Visual Studio 2017 or 2019 Community Edition (use the
@@ -379,7 +379,7 @@ Now install the dependencies that we need to build and test SciPy.
 
 .. code:: shell
 
-    python -m pip install wheel setuptools numpy Cython pybind11 pythran pytest pytest-xdist
+    python -m pip install numpy meson-python Cython pybind11 pythran pytest pytest-xdist
 
 .. note::
 
@@ -391,43 +391,32 @@ The last two are for using SciPy's test suite, which is handy if you want to tes
 some new change locally.
 
 Please note that this is a simpler procedure than what is used for the official
-binaries. **Your binaries will only work with the latest NumPy**.
-For building against older NumPy versions, see
-`Building Against an Older NumPy Version`_.
+binaries.
 
-Assuming that you are in the top of the SciPy repository directory where
-``setup.py`` is and assuming that you have set up everything correctly, you
-are ready to build. Run the following commands:
+Assuming that you are in the top of the SciPy repository directory and assuming
+that you have set up everything correctly, you are ready to build. Run the
+following commands:
 
 .. code:: shell
 
-    python setup.py build
+    pip wheel . -v --no-build-isolation  # will produce a wheel in `dist/`
 
 You may verify that the OpenBLAS library was correctly picked up by looking for
 the following in your build log:
 
-.. code:: shell
+.. code::
 
-   FOUND:
-      libraries = ['openblas']
-      library_dirs = ['C:\...........\lib']
-      language = f77
-      define_macros = [('HAVE_CBLAS', None)]
+   Run-time dependency openblas found: YES 0.3.21
 
 Notice that there will be multiple lines similar to these. You only need to
 track the OpenBLAS one.
 
 When everything finishes without an error, congratulations! You've built
-SciPy!
-
-You can further install the built SciPy via
+SciPy! You can further install the built SciPy via
 
 .. code:: shell
 
-    python setup.py install
-
-Just make sure that you uninstalled the existing installation of other SciPy if
-there were any (by the regular ``pip uninstall scipy`` machinery).
+    pip install dist/scipy*.whl
 
 
 .. _BLAS: https://en.wikipedia.org/wiki/Basic_Linear_Algebra_Subprograms
@@ -438,23 +427,6 @@ there were any (by the regular ``pip uninstall scipy`` machinery).
 .. _`pre-built zip files`: https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/
 .. _WindowsCompilers: https://wiki.python.org/moin/WindowsCompilers
 
-Building Against an Older NumPy Version
----------------------------------------
-
-If you want to build SciPy to work with an older NumPy version, then you will need
-to replace the NumPy "distutils" folder with the folder from the latest numpy.
-The following Powershell snippet can upgrade NumPy distutils while retaining an older
-NumPy ABI_.
-
-.. code:: shell
-
-      $NumpyDir = $((python -c 'import os; import numpy; print(os.path.dirname(numpy.__file__))') | Out-String).Trim()
-      rm -r -Force "$NumpyDir\distutils"
-      $tmpdir = New-TemporaryFile | %{ rm $_; mkdir $_ }
-      git clone -q --depth=1 -b master https://github.com/numpy/numpy.git $tmpdir
-      mv $tmpdir\numpy\distutils $NumpyDir
-
-.. _ABI: https://en.wikipedia.org/wiki/Application_binary_interface
 
 Additional Resources
 --------------------

--- a/doc/source/dev/roadmap-detailed.rst
+++ b/doc/source/dev/roadmap-detailed.rst
@@ -61,12 +61,10 @@ Making this easier is a priority.
 
 Moving to the Meson build system
 ````````````````````````````````
-Support for the Meson build system was merged into SciPy main in Dec 2021.
-This significantly improves build performance, and will fix multiple issues
-(e.g., our issues with Windows compilers, cross-compilation support). The aim
-is to make it the default build system for SciPy 1.9.0, and then remove support
-for ``numpy.distutils``/``setuptools`` in SciPy 1.10.0. For more details, see
-`gh-13615 <https://github.com/scipy/scipy/issues/13615>`_.
+Support for the Meson build system was merged into SciPy main in Dec 2021,
+and SciPy 1.9.3 was the first release where all wheels were also built with
+Meson. What is left to do is removing support for
+``numpy.distutils``/``setuptools``, this will happen soon.
 
 
 Use of Cython

--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -194,9 +194,7 @@ following, a *SciPy module* is defined as a Python package, say
 
 * Directory ``yyy/`` contains:
 
-  - A file ``setup.py`` that defines
-    ``configuration(parent_package='',top_path=None)`` function
-    for `numpy.distutils`.
+  - A file ``meson.build`` with build configuration for the submodule.
 
   - A directory ``tests/`` that contains files ``test_<name>.py``
     corresponding to modules ``yyy/<name>{.py,.so,/}``.
@@ -220,7 +218,5 @@ following, a *SciPy module* is defined as a Python package, say
   separate and put under ``doc/source/tutorial/``.
 
 See the existing SciPy submodules for guidance.
-
-For further details on NumPy distutils, see `NumPy Distutils - User's Guide <https://github.com/numpy/numpy/blob/main/doc/DISTUTILS.rst>`_.
 
 .. _NumPy documentation style: https://numpydoc.readthedocs.io/en/latest/format.html

--- a/doc/source/tutorial/ndimage.rst
+++ b/doc/source/tutorial/ndimage.rst
@@ -1755,25 +1755,11 @@ We can also implement the callback function with the following C code:
 
 More information on writing Python extension modules can be found
 `here`__. If the C code is in the file ``example.c``, then it can be
-compiled with the following ``setup.py``,
+compiled after adding it to ``meson.build`` (see examples inside
+``meson.build`` files) and follow what's there. After that is done,
+running the script:
 
-__ https://docs.python.org/2/extending/extending.html
-
-.. code:: python
-
-   from distutils.core import setup, Extension
-   import numpy
-
-   shift = Extension('example',
-                     ['example.c'],
-                     include_dirs=[numpy.get_include()]
-   )
-
-   setup(name='example',
-         ext_modules=[shift]
-   )
-
-and now running the script
+__ https://docs.python.org/3/extending/index.html
 
 .. code:: python
 


### PR DESCRIPTION
In addition, fixes or removes a bunch of outdated content on some of the less often visited developer-focused pages (Cython, Windows, etc.).

Since this is a fairly large diff already, I focused on pure maintenance first. I didn't reorganize anything or added new Meson-related content (e.g., making BLAS/LAPACK customizations more prominent, as discussed in gh-18239). That will happen in a follow-up PR.