### PR TITLE
ci: touch up wheel build action

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -83,7 +83,7 @@ jobs:
         - [macos-11, macosx, x86_64]
         - [windows-2019, win, AMD64]
 
-        python: [["cp39", "3.9"], ["cp310", "3.10"], ["cp311", "3.11.0-alpha - 3.11.0"]]
+        python: [["cp39", "3.9"], ["cp310", "3.10"], ["cp311", "3.11"]]
         # python[0] is used to specify the python versions made by cibuildwheel
 
     env:
@@ -100,7 +100,7 @@ jobs:
           submodules: true
           fetch-depth: 0
 
-      - uses: actions/setup-python@v4.2.0
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.9
 
@@ -124,7 +124,7 @@ jobs:
 #        if: ${{ runner.os == 'Windows' && env.IS_32_BIT == 'true' }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.12.0
+        uses: pypa/cibuildwheel@v2.12.1
         env:
           CIBW_BUILD: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}*
           CIBW_ARCHS: ${{ matrix.buildplat[2] }}
@@ -133,9 +133,9 @@ jobs:
           # setting SDKROOT necessary when using the gfortran compiler
           # installed in cibw_before_build_macos.sh
           # MACOS_DEPLOYMENT_TARGET is set because of
-          # https://github.com/pypa/cibuildwheel/issues/1419. Once that
-          # is closed and an update to pypa/cibuildwheel is done, then
-          # that environment variable can be removed.
+          # https://github.com/mesonbuild/meson-python/pull/309. Once
+          # an update is released, then that environment variable can
+          # be removed.
           CIBW_ENVIRONMENT_MACOS: >
             SDKROOT=/Applications/Xcode_11.7.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk
             LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH


### PR DESCRIPTION
This preforms some minor cleanup on the wheel building actions. Users are copying scipy's action then opening issues in cibuildwheel. Cleaning it up a bit might help us too. :) I only did really basic cleanup - some things seem to be unused (like the 32 bit parts), but I wasn't sure enough to remove them.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
None

#### What does this implement/fix?
Minor cleanup and modernization in the wheel building, updates a comment. Should have no external effect.

#### Additional information
None.
