### PR TITLE
BLD: implement version check for minimum Cython version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -35,6 +35,9 @@ endif
 
 cc = meson.get_compiler('c')
 cpp = meson.get_compiler('cpp')
+cy = meson.get_compiler('cython')
+# generator() doesn't accept compilers, only found programs - cast it.
+cython = find_program(cy.cmd_array()[0])
 
 # Check compiler is recent enough (see "Toolchain Roadmap" for details)
 if cc.get_id() == 'gcc'
@@ -46,6 +49,9 @@ elif cc.get_id() == 'msvc'
     error('SciPy requires at least vc142 (default with Visual Studio 2019) ' + \
           'when building with MSVC')
   endif
+endif
+if not cy.version().version_compare('>=0.29.33')
+  error('SciPy requires Cython >= 0.29.33')
 endif
 
 # TODO: the below -Wno flags are all needed to silence warnings in
@@ -126,8 +132,6 @@ if not cc.links('', name: '-Wl,--version-script', args: ['-shared', version_link
   version_link_args = []
 endif
 
-# generator() doesn't accept compilers, only found programs. Cast it.
-cython = find_program(meson.get_compiler('cython').cmd_array()[0])
 generate_f2pymod = files('tools/generate_f2pymod.py')
 tempita = files('scipy/_build_utils/tempita.py')
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@
 [build-system]
 build-backend = 'mesonpy'
 requires = [
-    "meson-python>=0.9.0",
-    "Cython>=0.29.33",
+    "meson-python>=0.12.1",
+    "Cython>=0.29.33",  # when updating version, also update check in meson.build
     "pybind11>=2.10.0",
     "pythran>=0.12.0",
     # `wheel` is needed for non-isolated builds, given that `meson-python`


### PR DESCRIPTION
Also update the minimum meson-python version while we're at it, there's a number of bug fixes in the latest version that we need.

Rationale for this check: while we have the minimum version in `pyproject.toml`, the first indication a user who has a too old Cython gets is an obscure error in the middle of the build about `const` usage with `memoryview`.