### PR TITLE
DOC: orthogonal_procrustes fix date of reference paper and DOI

### DIFF
--- a/scipy/linalg/_procrustes.py
+++ b/scipy/linalg/_procrustes.py
@@ -54,6 +54,7 @@ def orthogonal_procrustes(A, B, check_finite=True):
     ----------
     .. [1] Peter H. Schonemann, "A generalized solution of the orthogonal
            Procrustes problem", Psychometrica -- Vol. 31, No. 1, March, 1966.
+           :doi:`10.1007/BF02289451`
 
     Examples
     --------

--- a/scipy/linalg/_procrustes.py
+++ b/scipy/linalg/_procrustes.py
@@ -53,7 +53,7 @@ def orthogonal_procrustes(A, B, check_finite=True):
     References
     ----------
     .. [1] Peter H. Schonemann, "A generalized solution of the orthogonal
-           Procrustes problem", Psychometrica -- Vol. 31, No. 1, March, 1996.
+           Procrustes problem", Psychometrica -- Vol. 31, No. 1, March, 1966.
 
     Examples
     --------


### PR DESCRIPTION
Changed reference date from 1996 to 1966, see link below for confirmation.

https://link.springer.com/article/10.1007/BF02289451

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Did not raise an issue

#### What does this implement/fix?
Fixes date in a reference

#### Additional information
N/A