### PR TITLE
DOC: fix link in release notes v1.7

### DIFF
--- a/doc/source/release/1.7.0-notes.rst
+++ b/doc/source/release/1.7.0-notes.rst
@@ -142,7 +142,7 @@ The ``rotation`` methods ``from_rotvec`` and ``as_rotvec`` now accept a
 ============================
 
 Wright's generalized Bessel function for positive arguments was added as
-`scipy.special.wright_bessel.`
+`scipy.special.wright_bessel`.
 
 An implementation of the inverse of the Log CDF of the Normal Distribution is
 now available via `scipy.special.ndtri_exp`.


### PR DESCRIPTION
This fixes a link in the release notes of v1.7.