### PR TITLE
BUG: linalg: stop `sqrtm` outputting `complex256` array

### DIFF
--- a/scipy/linalg/_matfuncs_sqrtm.py
+++ b/scipy/linalg/_matfuncs_sqrtm.py
@@ -185,12 +185,8 @@ def sqrtm(A, disp=True, blocksize=64):
             # float byte size range: f2 ~ f16
             X = X.astype(f"f{np.clip(byte_size, 2, 16)}", copy=False)
         else:
-            # complex byte size range: c8 ~ c32.
-            # c32(complex256) might not be supported in some environments.
-            if hasattr(np, 'complex256'):
-                X = X.astype(f"c{np.clip(byte_size*2, 8, 32)}", copy=False)
-            else:
-                X = X.astype(f"c{np.clip(byte_size*2, 8, 16)}", copy=False)
+            # complex byte size range: c8 ~ c16.
+			X = X.astype(f"c{np.clip(byte_size*2, 8, 16)}", copy=False)
     except SqrtmError:
         failflag = True
         X = np.empty_like(A)

--- a/scipy/linalg/_matfuncs_sqrtm.py
+++ b/scipy/linalg/_matfuncs_sqrtm.py
@@ -186,7 +186,7 @@ def sqrtm(A, disp=True, blocksize=64):
             X = X.astype(f"f{np.clip(byte_size, 2, 16)}", copy=False)
         else:
             # complex byte size range: c8 ~ c16.
-			X = X.astype(f"c{np.clip(byte_size*2, 8, 16)}", copy=False)
+            X = X.astype(f"c{np.clip(byte_size*2, 8, 16)}", copy=False)
     except SqrtmError:
         failflag = True
         X = np.empty_like(A)


### PR DESCRIPTION
…s this is type is not supported by any other scipy.linalg functions and results in immediate downcasting to type  complex128  and even worse results in errors in  numpy.linalg  functions. This causes problems in large scientific projects which include both  numpy  and  scipy  packages. Sample proof of concepts showing this behavior are shown on gh-18250 and [numpy issue 23536](https://github.com/numpy/numpy/issues/23536). 'scipy.linalg.sqrtm  already will not double the precision of a  complex256  variable (if given a  complex256  array as input it will output a  complex256  type variable). This cap should be set at  complex128  to ensure compatability with outher  scipy  and  numpy  functions.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
