### PR TITLE
Add axes support to uniform_filter, minimum_filter, maximum_filter

### DIFF
--- a/scipy/ndimage/_filters.py
+++ b/scipy/ndimage/_filters.py
@@ -950,7 +950,7 @@ def uniform_filter1d(input, size, axis=-1, output=None,
 
 @_ni_docstrings.docfiller
 def uniform_filter(input, size=3, output=None, mode="reflect",
-                   cval=0.0, origin=0):
+                   cval=0.0, origin=0, *, axes=None):
     """Multidimensional uniform filter.
 
     Parameters
@@ -964,6 +964,12 @@ def uniform_filter(input, size=3, output=None, mode="reflect",
     %(mode_multiple)s
     %(cval)s
     %(origin_multiple)s
+    axes : tuple of int or None, optional
+        If None, `input` is filtered along all axes. Otherwise,
+        `input` is filtered along the specified axes. When `axes` is
+        specified, any tuples used for `size`, `origin`, and/or `mode`
+        must match the length of `axes`. The ith entry in any of these tuples
+        corresponds to the ith entry in `axes`.
 
     Returns
     -------
@@ -995,12 +1001,13 @@ def uniform_filter(input, size=3, output=None, mode="reflect",
     input = numpy.asarray(input)
     output = _ni_support._get_output(output, input,
                                      complex_output=input.dtype.kind == 'c')
-    sizes = _ni_support._normalize_sequence(size, input.ndim)
-    origins = _ni_support._normalize_sequence(origin, input.ndim)
-    modes = _ni_support._normalize_sequence(mode, input.ndim)
-    axes = list(range(input.ndim))
+    axes = _ni_support._check_axes(axes, input.ndim)
+    num_axes = len(axes)
+    sizes = _ni_support._normalize_sequence(size, num_axes)
+    origins = _ni_support._normalize_sequence(origin, num_axes)
+    modes = _ni_support._normalize_sequence(mode, num_axes)
     axes = [(axes[ii], sizes[ii], origins[ii], modes[ii])
-            for ii in range(len(axes)) if sizes[ii] > 1]
+            for ii in range(num_axes) if sizes[ii] > 1]
     if len(axes) > 0:
         for axis, size, origin, mode in axes:
             uniform_filter1d(input, int(size), axis, output, mode,

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -789,9 +789,11 @@ class TestNdimageFilters:
             for key, val in kwargs.items():
                 yield filter_func, kwargs, key, val
 
+    # TODO: Remove .__func__ from _cases_axes_tuple_length_mismatch below
+    #       once minimum supported Python version is 3.10.
     @pytest.mark.parametrize('n_mismatch', [1, 3])
     @pytest.mark.parametrize('filter_func, kwargs, key, val',
-                             _cases_axes_tuple_length_mismatch())
+                             _cases_axes_tuple_length_mismatch.__func__())
     def test_filter_tuple_length_mismatch(self, n_mismatch, filter_func,
                                           kwargs, key, val):
         # Test for the intended RuntimeError when a kwargs has an invalid size

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -1063,18 +1063,17 @@ class TestNdimageFilters:
         assert_equal(output.dtype.type, dtype_output)
 
     @pytest.mark.parametrize(
-        'function_name',
-        ['uniform_filter', 'minimum_filter', 'maximum_filter'])
+        'filter_func', [ndimage.uniform_filter, ndimage.minimum_filter,
+                        ndimage.maximum_filter])
     @pytest.mark.parametrize(
         'axes', tuple(itertools.combinations(range(-3, 3), 2)))
-    def test_filter_axes_kwargs(self, axes, function_name):
+    def test_filter_axes_kwargs(self, axes, filter_func):
         array = numpy.arange(6 * 8 * 12, dtype=numpy.float64).reshape(6, 8, 12)
         size = (3, 5)
         origin = (-1, 1)
         mode = ('reflect', 'nearest')
         axes = tuple(ax % array.ndim for ax in axes)
         kwargs = dict(size=size, mode=mode, origin=origin)
-        filter_func = getattr(ndimage, function_name)
         if len(tuple(set(axes))) != len(axes):
             # parametrized cases with duplicate axes raise an error
             with pytest.raises(ValueError, match="axes must be unique"):
@@ -1097,13 +1096,12 @@ class TestNdimageFilters:
         assert_allclose(output, expected)
 
     @pytest.mark.parametrize(
-        'function_name',
-        ['uniform_filter', 'minimum_filter', 'maximum_filter'])
+        'filter_func', [ndimage.uniform_filter, ndimage.minimum_filter,
+                        ndimage.maximum_filter])
     @pytest.mark.parametrize('tuple_ndim', [1, 3])
     @pytest.mark.parametrize('mismatched', ['mode', 'size', 'origin'])
     def test_filter_axes_tuple_length_mismatch(self, tuple_ndim, mismatched,
-                                               function_name):
-        filter_func = getattr(ndimage, function_name)
+                                               filter_func):
         array = numpy.arange(6 * 8 * 12, dtype=numpy.float64).reshape(6, 8, 12)
         kwargs = dict(size=3, origin=0, axes=(0, 1), mode='constant')
         if mismatched == 'mode':

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -693,7 +693,8 @@ class TestNdimageFilters:
         assert_array_almost_equal(output1, input)
 
     @pytest.mark.parametrize(
-        'function_name', ['gaussian_filter', 'uniform_filter'])
+        'function_name', ['gaussian_filter', 'uniform_filter',
+                          'minimum_filter', 'maximum_filter'])
     @pytest.mark.parametrize(
         'axes',
         tuple(itertools.combinations(range(-3, 3), 1))
@@ -705,7 +706,8 @@ class TestNdimageFilters:
         if function_name == 'gaussian_filter':
             sigma = 1.0
             filter_args = (array, sigma)
-        elif function_name == 'uniform_filter':
+        elif function_name in ('uniform_filter', 'minimum_filter',
+                               'maximum_filter'):
             size = 3
             filter_args = (array, size)
 
@@ -722,7 +724,8 @@ class TestNdimageFilters:
             all_sigmas = (sigma if ax in axes else 0.0
                           for ax in range(array.ndim))
             filter_args = (all_sigmas,)
-        elif function_name == 'uniform_filter':
+        elif function_name in ('uniform_filter', 'minimum_filter',
+                               'maximum_filter'):
             # result should be equivalent to size=1 on any unfiltered axes
             all_sizes = tuple(size if ax in axes else 1
                               for ax in range(array.ndim))
@@ -769,7 +772,9 @@ class TestNdimageFilters:
     @pytest.mark.parametrize(
         'function_name, kwargs',
         [('gaussian_filter', {'sigma': 1.0}),
-         ('uniform_filter', {'size': 3})])
+         ('uniform_filter', {'size': 3}),
+         ('minimum_filter', {'size': 3}),
+         ('maximum_filter', {'size': 3})])
     @pytest.mark.parametrize('axes', [(1.5,), (0, 1, 2, 3), (3,), (-4,)])
     def test_filter_invalid_axes(self, axes, function_name, kwargs):
         array = numpy.arange(6 * 8 * 12, dtype=numpy.float64).reshape(6, 8, 12)
@@ -1059,21 +1064,24 @@ class TestNdimageFilters:
         assert_equal(output.dtype.type, dtype_output)
 
     @pytest.mark.parametrize(
-        'axes', tuple(itertools.combinations(range(-3, 3), 2))
-    )
-    def test_uniform_axes_kwargs(self, axes):
+        'function_name',
+        ['uniform_filter', 'minimum_filter', 'maximum_filter'])
+    @pytest.mark.parametrize(
+        'axes', tuple(itertools.combinations(range(-3, 3), 2)))
+    def test_filter_axes_kwargs(self, axes, function_name):
         array = numpy.arange(6 * 8 * 12, dtype=numpy.float64).reshape(6, 8, 12)
         size = (3, 5)
         origin = (-1, 1)
         mode = ('reflect', 'nearest')
         axes = tuple(ax % array.ndim for ax in axes)
         kwargs = dict(size=size, mode=mode, origin=origin)
+        filter_func = getattr(ndimage, function_name)
         if len(tuple(set(axes))) != len(axes):
             # parametrized cases with duplicate axes raise an error
             with pytest.raises(ValueError, match="axes must be unique"):
-                ndimage.uniform_filter(array, axes=axes, **kwargs)
+                filter_func(array, axes=axes, **kwargs)
             return
-        output = ndimage.uniform_filter(array, axes=axes, **kwargs)
+        output = filter_func(array, axes=axes, **kwargs)
 
         # result should be equivalent to size=1 on unfiltered axes
         size_3d = [1] * array.ndim
@@ -1086,12 +1094,17 @@ class TestNdimageFilters:
         origin_3d[axes[0]] = origin[0]
         origin_3d[axes[1]] = origin[1]
         kwargs = dict(size=size_3d, mode=mode_3d, origin=origin_3d)
-        expected = ndimage.uniform_filter(array, **kwargs)
+        expected = filter_func(array, **kwargs)
         assert_allclose(output, expected)
 
+    @pytest.mark.parametrize(
+        'function_name',
+        ['uniform_filter', 'minimum_filter', 'maximum_filter'])
     @pytest.mark.parametrize('tuple_ndim', [1, 3])
     @pytest.mark.parametrize('mismatched', ['mode', 'size', 'origin'])
-    def test_uniform_tuple_length_mismatch(self, tuple_ndim, mismatched):
+    def test_filter_axes_tuple_length_mismatch(self, tuple_ndim, mismatched,
+                                               function_name):
+        filter_func = getattr(ndimage, function_name)
         array = numpy.arange(6 * 8 * 12, dtype=numpy.float64).reshape(6, 8, 12)
         kwargs = dict(size=3, origin=0, axes=(0, 1), mode='constant')
         if mismatched == 'mode':
@@ -1103,7 +1116,7 @@ class TestNdimageFilters:
 
         err_msg = "sequence argument must have length equal to input rank"
         with pytest.raises(RuntimeError, match=err_msg):
-            ndimage.uniform_filter(array, **kwargs)
+            filter_func(array, **kwargs)
 
     def test_minimum_filter01(self):
         array = numpy.array([1, 2, 3, 4, 5])
@@ -1279,6 +1292,30 @@ class TestNdimageFilters:
         assert_array_almost_equal([[7, 7, 9, 9, 5],
                                    [7, 9, 8, 9, 7],
                                    [8, 8, 8, 7, 7]], output)
+
+    @pytest.mark.parametrize(
+        'axes', tuple(itertools.combinations(range(-3, 3), 2))
+    )
+    @pytest.mark.parametrize(
+        'function_name', [ndimage.minimum_filter, ndimage.maximum_filter]
+    )
+    def test_minmax_nonseparable_axes(self, function_name, axes):
+        array = numpy.arange(6 * 8 * 12, dtype=numpy.float32).reshape(6, 8, 12)
+        # use 2D triangular footprint because it is non-separable
+        footprint = numpy.tri(5)
+        axes = tuple(ax % array.ndim for ax in axes)
+        filter_func = getattr(ndimage, function_name)
+        if len(tuple(set(axes))) != len(axes):
+            # parametrized cases with duplicate axes raise an error
+            with pytest.raises(ValueError):
+                filter_func(array, footprint=footprint, axes=axes)
+            return
+        output = filter_func(array, footprint=footprint, axes=axes)
+
+        missing_axis = tuple(set(range(3)) - set(axes))[0]
+        footprint_3d = numpy.expand_dims(footprint, missing_axis)
+        expected = filter_func(array, footprint=footprint_3d)
+        assert_allclose(output, expected)
 
     def test_rank01(self):
         array = numpy.array([1, 2, 3, 4, 5])

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -3,6 +3,7 @@ import functools
 import itertools
 import math
 import numpy
+import numpy as np
 
 from numpy.testing import (assert_equal, assert_allclose,
                            assert_array_almost_equal,
@@ -692,67 +693,75 @@ class TestNdimageFilters:
         ndimage.gaussian_filter(input, 1.0, output=input)
         assert_array_almost_equal(output1, input)
 
+    @pytest.mark.parametrize(('filter_func', 'size0', 'size'),
+                             [(ndimage.gaussian_filter, 0, 1.0),
+                              (ndimage.uniform_filter, 1, 3.0),
+                              (ndimage.minimum_filter, 1, 3.0),
+                              (ndimage.maximum_filter, 1, 3.0)])
     @pytest.mark.parametrize(
         'axes',
         tuple(itertools.combinations(range(-3, 3), 1))
         + tuple(itertools.combinations(range(-3, 3), 2))
         + ((0, 1, 2),))
-    def test_gauss_axes(self, axes):
+    def test_filter_axes(self, filter_func, size0, size, axes):
         array = numpy.arange(6 * 8 * 12, dtype=numpy.float64).reshape(6, 8, 12)
-        sigma = 1.0
+
         axes = tuple(ax % array.ndim for ax in axes)
         if len(tuple(set(axes))) != len(axes):
             # parametrized cases with duplicate axes raise an error
             with pytest.raises(ValueError, match="axes must be unique"):
-                ndimage.gaussian_filter(array, sigma, axes=axes)
+                filter_func(array, size, axes=axes)
             return
-        output = ndimage.gaussian_filter(array, sigma, axes=axes)
+        output = filter_func(array, size, axes=axes)
 
-        # result should be equivalent to sigma=0.0 on unfiltered axes
-        all_sigmas = (sigma if ax in axes else 0.0 for ax in range(array.ndim))
-        expected = ndimage.gaussian_filter(array, all_sigmas)
+        # result should be equivalent to sigma=0.0/size=1 on unfiltered axes
+        all_sizes = (size if ax in axes else size0 for ax in range(array.ndim))
+        expected = filter_func(array, all_sizes)
+        assert_allclose(output, expected)
+
+    kwargs_gauss = dict(radius=[4, 2, 3], order=[0, 1, 2],
+                        mode=['reflect', 'nearest', 'constant'])
+    kwargs_other = dict(origin=(-1, 0, 1),
+                        mode=['reflect', 'nearest', 'constant'])
+    @pytest.mark.parametrize("filter_func, size0, size, kwargs",
+                             [(ndimage.gaussian_filter, 0, 2, kwargs_gauss),
+                              (ndimage.uniform_filter, 1, 3, kwargs_other),
+                              (ndimage.maximum_filter, 1, 3, kwargs_other),
+                              (ndimage.minimum_filter, 1, 3, kwargs_other)])
+    @pytest.mark.parametrize('axes', itertools.combinations(range(-3, 3), 2))
+    def test_filter_axes_kwargs(self, filter_func, size0, size, kwargs, axes):
+        array = numpy.arange(6 * 8 * 12, dtype=numpy.float64).reshape(6, 8, 12)
+
+        kwargs = {key: np.array(val) for key, val in kwargs.items()}
+        axes = np.array(axes)
+        n_axes = axes.size
+
+        # form kwargs that specify only the axes in `axes`
+        reduced_kwargs = {key:val[axes] for key, val in kwargs.items()}
+        if len(set(axes % array.ndim)) != len(axes):
+            # parametrized cases with duplicate axes raise an error
+            with pytest.raises(ValueError, match="axes must be unique"):
+                filter_func(array, [size]*n_axes, axes=axes, **reduced_kwargs)
+            return
+
+        output = filter_func(array, [size]*n_axes, axes=axes, **reduced_kwargs)
+
+        # result should be equivalent to sigma=0.0/size=1 on unfiltered axes
+        size_3d = np.full(array.ndim, fill_value=size0)
+        size_3d[axes] = size
+        expected = filter_func(array, size_3d, **kwargs)
         assert_allclose(output, expected)
 
     @pytest.mark.parametrize(
-        'axes', tuple(itertools.combinations(range(-3, 3), 2))
-    )
-    def test_gauss_axes_kwargs(self, axes):
-        array = numpy.arange(6 * 8 * 12, dtype=numpy.float64).reshape(6, 8, 12)
-        sigma = (1.0, 0.5)
-        radius = (4, 2)
-        order = (0, 1)
-        mode = ('reflect', 'nearest')
-        axes = tuple(ax % array.ndim for ax in axes)
-        kwargs = dict(sigma=sigma, radius=radius, mode=mode, order=order)
-        if len(tuple(set(axes))) != len(axes):
-            # parametrized cases with duplicate axes raise an error
-            with pytest.raises(ValueError, match="axes must be unique"):
-                ndimage.gaussian_filter(array, axes=axes, **kwargs)
-            return
-        output = ndimage.gaussian_filter(array, axes=axes, **kwargs)
-
-        # result should be equivalent to sigma=0.0 on unfiltered axes
-        sigma_3d = [0,] * array.ndim
-        sigma_3d[axes[0]] = sigma[0]
-        sigma_3d[axes[1]] = sigma[1]
-        radius_3d = [0,] * array.ndim
-        radius_3d[axes[0]] = radius[0]
-        radius_3d[axes[1]] = radius[1]
-        mode_3d = [0,] * array.ndim
-        mode_3d[axes[0]] = mode[0]
-        mode_3d[axes[1]] = mode[1]
-        order_3d = [0,] * array.ndim
-        order_3d[axes[0]] = order[0]
-        order_3d[axes[1]] = order[1]
-        kwargs = dict(sigma=sigma_3d, radius=radius_3d, mode=mode_3d,
-                      order=order_3d)
-        expected = ndimage.gaussian_filter(array, **kwargs)
-        assert_allclose(output, expected)
-
+        'filter_func, size',
+        [(ndimage.gaussian_filter, 1.0),
+         (ndimage.uniform_filter, 3),
+         (ndimage.minimum_filter, 3),
+         (ndimage.maximum_filter, 3)])
     @pytest.mark.parametrize(
         'axes', [(1.5,), (0, 1, 2, 3), (3,), (-4,)]
     )
-    def test_gauss_invalid_axes(self, axes):
+    def test_filter_invalid_axes(self, filter_func, size, axes):
         array = numpy.arange(6 * 8 * 12, dtype=numpy.float64).reshape(6, 8, 12)
         if any(isinstance(ax, float) for ax in axes):
             error_class = TypeError
@@ -761,26 +770,37 @@ class TestNdimageFilters:
             error_class = ValueError
             match = "out of range"
         with pytest.raises(error_class, match=match):
-            ndimage.gaussian_filter(array, sigma=1.0, axes=axes)
+            ndimage.gaussian_filter(array, size, axes=axes)
 
-    @pytest.mark.parametrize('tuple_ndim', [1, 3])
-    @pytest.mark.parametrize('mismatched',
-                             ['radius', 'mode', 'sigma', 'order'])
-    def test_gauss_axes_tuple_length_mismatch(self, tuple_ndim, mismatched):
+    @staticmethod
+    def _cases_axes_tuple_length_mismatch():
+        # Generate combinations of filter function, valid kwargs, and
+        # keyword-value pairs for which the value will become with mismatched
+        # (invalid) size
+        filter_func = ndimage.gaussian_filter
+        kwargs = {'radius': 3, 'mode': 'constant', 'sigma': 1.0, 'order': 0}
+        for key, val in kwargs.items():
+            yield filter_func, kwargs, key, val
+
+        filter_funcs = [ndimage.uniform_filter, ndimage.minimum_filter,
+                        ndimage.maximum_filter]
+        kwargs = {'size': 3, 'mode': 'constant', 'origin': 0}
+        for filter_func in filter_funcs:
+            for key, val in kwargs.items():
+                yield filter_func, kwargs, key, val
+
+    @pytest.mark.parametrize('n_mismatch', [1, 3])
+    @pytest.mark.parametrize('filter_func, kwargs, key, val',
+                             _cases_axes_tuple_length_mismatch())
+    def test_filter_tuple_length_mismatch(self, n_mismatch, filter_func,
+                                          kwargs, key, val):
+        # Test for the intended RuntimeError when a kwargs has an invalid size
         array = numpy.arange(6 * 8 * 12, dtype=numpy.float64).reshape(6, 8, 12)
-        kwargs = dict(sigma=1.0, radius=(3, 3), axes=(0, 1), mode='constant')
-        if mismatched == 'radius':
-            kwargs['radius'] = (3,) * tuple_ndim
-        elif mismatched == 'mode':
-            kwargs['mode'] = ['constant'] * tuple_ndim
-        elif mismatched == 'sigma':
-            kwargs['sigma'] = (1.0,) * tuple_ndim
-        elif mismatched == 'order':
-            kwargs['order'] = (0,) * tuple_ndim
-
+        kwargs = dict(**kwargs, axes=(0, 1))
+        kwargs[key] = (val,) * n_mismatch
         err_msg = "sequence argument must have length equal to input rank"
         with pytest.raises(RuntimeError, match=err_msg):
-            ndimage.gaussian_filter(array, **kwargs)
+            filter_func(array, **kwargs)
 
     @pytest.mark.parametrize('dtype', types + complex_types)
     def test_prewitt01(self, dtype):

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -770,15 +770,14 @@ class TestNdimageFilters:
         assert_allclose(output, expected)
 
     @pytest.mark.parametrize(
-        'function_name, kwargs',
-        [('gaussian_filter', {'sigma': 1.0}),
-         ('uniform_filter', {'size': 3}),
-         ('minimum_filter', {'size': 3}),
-         ('maximum_filter', {'size': 3})])
+        'filter_func, kwargs',
+        [(ndimage.gaussian_filter, {'sigma': 1.0}),
+         (ndimage.uniform_filter, {'size': 3}),
+         (ndimage.minimum_filter, {'size': 3}),
+         (ndimage.maximum_filter, {'size': 3})])
     @pytest.mark.parametrize('axes', [(1.5,), (0, 1, 2, 3), (3,), (-4,)])
-    def test_filter_invalid_axes(self, axes, function_name, kwargs):
+    def test_filter_invalid_axes(self, axes, filter_func, kwargs):
         array = numpy.arange(6 * 8 * 12, dtype=numpy.float64).reshape(6, 8, 12)
-        filter_func = getattr(ndimage, function_name)
         if any(isinstance(ax, float) for ax in axes):
             error_class = TypeError
             match = "cannot be interpreted as an integer"
@@ -1297,14 +1296,13 @@ class TestNdimageFilters:
         'axes', tuple(itertools.combinations(range(-3, 3), 2))
     )
     @pytest.mark.parametrize(
-        'function_name', [ndimage.minimum_filter, ndimage.maximum_filter]
+        'filter_func', [ndimage.minimum_filter, ndimage.maximum_filter]
     )
-    def test_minmax_nonseparable_axes(self, function_name, axes):
+    def test_minmax_nonseparable_axes(self, filter_func, axes):
         array = numpy.arange(6 * 8 * 12, dtype=numpy.float32).reshape(6, 8, 12)
         # use 2D triangular footprint because it is non-separable
         footprint = numpy.tri(5)
         axes = tuple(ax % array.ndim for ax in axes)
-        filter_func = getattr(ndimage, function_name)
         if len(tuple(set(axes))) != len(axes):
             # parametrized cases with duplicate axes raise an error
             with pytest.raises(ValueError):

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -3,7 +3,6 @@ import functools
 import itertools
 import math
 import numpy
-import numpy as np
 
 from numpy.testing import (assert_equal, assert_allclose,
                            assert_array_almost_equal,
@@ -704,6 +703,7 @@ class TestNdimageFilters:
         + tuple(itertools.combinations(range(-3, 3), 2))
         + ((0, 1, 2),))
     def test_filter_axes(self, filter_func, size0, size, axes):
+        # Note: `size` is called `sigma` in `gaussian_filter`
         array = numpy.arange(6 * 8 * 12, dtype=numpy.float64).reshape(6, 8, 12)
 
         axes = tuple(ax % array.ndim for ax in axes)
@@ -732,8 +732,8 @@ class TestNdimageFilters:
     def test_filter_axes_kwargs(self, filter_func, size0, size, kwargs, axes):
         array = numpy.arange(6 * 8 * 12, dtype=numpy.float64).reshape(6, 8, 12)
 
-        kwargs = {key: np.array(val) for key, val in kwargs.items()}
-        axes = np.array(axes)
+        kwargs = {key: numpy.array(val) for key, val in kwargs.items()}
+        axes = numpy.array(axes)
         n_axes = axes.size
 
         # form kwargs that specify only the axes in `axes`
@@ -747,7 +747,7 @@ class TestNdimageFilters:
         output = filter_func(array, [size]*n_axes, axes=axes, **reduced_kwargs)
 
         # result should be equivalent to sigma=0.0/size=1 on unfiltered axes
-        size_3d = np.full(array.ndim, fill_value=size0)
+        size_3d = numpy.full(array.ndim, fill_value=size0)
         size_3d[axes] = size
         expected = filter_func(array, size_3d, **kwargs)
         assert_allclose(output, expected)
@@ -770,7 +770,7 @@ class TestNdimageFilters:
             error_class = ValueError
             match = "out of range"
         with pytest.raises(error_class, match=match):
-            ndimage.gaussian_filter(array, size, axes=axes)
+            filter_func(array, size, axes=axes)
 
     @staticmethod
     def _cases_axes_tuple_length_mismatch():

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -695,9 +695,9 @@ class TestNdimageFilters:
 
     @pytest.mark.parametrize(('filter_func', 'size0', 'size'),
                              [(ndimage.gaussian_filter, 0, 1.0),
-                              (ndimage.uniform_filter, 1, 3.0),
-                              (ndimage.minimum_filter, 1, 3.0),
-                              (ndimage.maximum_filter, 1, 3.0)])
+                              (ndimage.uniform_filter, 1, 3),
+                              (ndimage.minimum_filter, 1, 3),
+                              (ndimage.maximum_filter, 1, 3)])
     @pytest.mark.parametrize(
         'axes',
         tuple(itertools.combinations(range(-3, 3), 1))
@@ -724,7 +724,7 @@ class TestNdimageFilters:
     kwargs_other = dict(origin=(-1, 0, 1),
                         mode=['reflect', 'nearest', 'constant'])
     @pytest.mark.parametrize("filter_func, size0, size, kwargs",
-                             [(ndimage.gaussian_filter, 0, 2, kwargs_gauss),
+                             [(ndimage.gaussian_filter, 0, 1.0, kwargs_gauss),
                               (ndimage.uniform_filter, 1, 3, kwargs_other),
                               (ndimage.maximum_filter, 1, 3, kwargs_other),
                               (ndimage.minimum_filter, 1, 3, kwargs_other)])
@@ -778,13 +778,13 @@ class TestNdimageFilters:
         # keyword-value pairs for which the value will become with mismatched
         # (invalid) size
         filter_func = ndimage.gaussian_filter
-        kwargs = {'radius': 3, 'mode': 'constant', 'sigma': 1.0, 'order': 0}
+        kwargs = dict(radius=3, mode='constant', sigma=1.0, order=0)
         for key, val in kwargs.items():
             yield filter_func, kwargs, key, val
 
         filter_funcs = [ndimage.uniform_filter, ndimage.minimum_filter,
                         ndimage.maximum_filter]
-        kwargs = {'size': 3, 'mode': 'constant', 'origin': 0}
+        kwargs = dict(size=3, mode='constant', origin=0)
         for filter_func in filter_funcs:
             for key, val in kwargs.items():
                 yield filter_func, kwargs, key, val

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -67,6 +67,23 @@ def _complex_correlate(array, kernel, real_dtype, convolve=False,
     return output
 
 
+def _cases_axes_tuple_length_mismatch():
+    # Generate combinations of filter function, valid kwargs, and
+    # keyword-value pairs for which the value will become with mismatched
+    # (invalid) size
+    filter_func = ndimage.gaussian_filter
+    kwargs = dict(radius=3, mode='constant', sigma=1.0, order=0)
+    for key, val in kwargs.items():
+        yield filter_func, kwargs, key, val
+
+    filter_funcs = [ndimage.uniform_filter, ndimage.minimum_filter,
+                    ndimage.maximum_filter]
+    kwargs = dict(size=3, mode='constant', origin=0)
+    for filter_func in filter_funcs:
+        for key, val in kwargs.items():
+            yield filter_func, kwargs, key, val
+
+
 class TestNdimageFilters:
 
     def _validate_complex(self, array, kernel, type2, mode='reflect', cval=0):
@@ -772,28 +789,9 @@ class TestNdimageFilters:
         with pytest.raises(error_class, match=match):
             filter_func(array, size, axes=axes)
 
-    @staticmethod
-    def _cases_axes_tuple_length_mismatch():
-        # Generate combinations of filter function, valid kwargs, and
-        # keyword-value pairs for which the value will become with mismatched
-        # (invalid) size
-        filter_func = ndimage.gaussian_filter
-        kwargs = dict(radius=3, mode='constant', sigma=1.0, order=0)
-        for key, val in kwargs.items():
-            yield filter_func, kwargs, key, val
-
-        filter_funcs = [ndimage.uniform_filter, ndimage.minimum_filter,
-                        ndimage.maximum_filter]
-        kwargs = dict(size=3, mode='constant', origin=0)
-        for filter_func in filter_funcs:
-            for key, val in kwargs.items():
-                yield filter_func, kwargs, key, val
-
-    # TODO: Remove .__func__ from _cases_axes_tuple_length_mismatch below
-    #       once minimum supported Python version is 3.10.
     @pytest.mark.parametrize('n_mismatch', [1, 3])
     @pytest.mark.parametrize('filter_func, kwargs, key, val',
-                             _cases_axes_tuple_length_mismatch.__func__())
+                             _cases_axes_tuple_length_mismatch())
     def test_filter_tuple_length_mismatch(self, n_mismatch, filter_func,
                                           kwargs, key, val):
         # Test for the intended RuntimeError when a kwargs has an invalid size


### PR DESCRIPTION
#### Reference issue

see requests/discussion at: https://github.com/scipy/scipy/issues/12997#issuecomment-811268933 and https://github.com/scipy/scipy/issues/16191#issuecomment-1144781807

#### What does this implement/fix?
This PR is a followup to #18016 which added the `axes` argument to `gaussian_filter`. Here `axes` support is added to three filters which all take `size`, `mode` and `origin` arguments. Here `size` should just be set to 1 along any non-filtered axes.
- uniform_filter
- minimum_filter
- maximum_filter

I tried to reuse test cases across multiple functions to reduce code duplication.

Unlike `uniform_filter`, the min/max filters can also take a footprint array instead of `size`. In that case, a singleton axis has to be inserted into the footprint array along any axis not being filtered.

