### PR TITLE
MAINT: remove `from numpy.math cimport` usages, update `npy_blas.h`

### DIFF
--- a/scipy/_build_utils/src/npy_cblas.h
+++ b/scipy/_build_utils/src/npy_cblas.h
@@ -3,8 +3,8 @@
  * because not all providers of cblas provide cblas.h. For instance, MKL provides
  * mkl_cblas.h and also typedefs the CBLAS_XXX enums.
  */
-#ifndef _NPY_CBLAS_H_
-#define _NPY_CBLAS_H_
+#ifndef NUMPY_CORE_SRC_COMMON_NPY_CBLAS_H_
+#define NUMPY_CORE_SRC_COMMON_NPY_CBLAS_H_
 
 #include <stddef.h>
 
@@ -47,8 +47,10 @@ enum CBLAS_SIDE {CblasLeft=141, CblasRight=142};
 
 #ifdef HAVE_BLAS_ILP64
 #define CBLAS_INT npy_int64
+#define CBLAS_INT_MAX NPY_MAX_INT64
 #else
 #define CBLAS_INT int
+#define CBLAS_INT_MAX INT_MAX
 #endif
 
 #define BLASNAME(name) CBLAS_FUNC(name)
@@ -59,8 +61,41 @@ enum CBLAS_SIDE {CblasLeft=141, CblasRight=142};
 #undef BLASINT
 #undef BLASNAME
 
+
+/*
+ * Convert NumPy stride to BLAS stride. Returns 0 if conversion cannot be done
+ * (BLAS won't handle negative or zero strides the way we want).
+ */
+static inline CBLAS_INT
+blas_stride(npy_intp stride, unsigned itemsize)
+{
+    /*
+     * Should probably check pointer alignment also, but this may cause
+     * problems if we require complex to be 16 byte aligned.
+     */
+    if (stride > 0 && (stride % itemsize) == 0) {
+        stride /= itemsize;
+        if (stride <= CBLAS_INT_MAX) {
+            return stride;
+        }
+    }
+    return 0;
+}
+
+/*
+ * Define a chunksize for CBLAS.
+ *
+ * The chunksize is the greatest power of two less than CBLAS_INT_MAX.
+ */
+#if NPY_MAX_INTP > CBLAS_INT_MAX
+# define NPY_CBLAS_CHUNK  (CBLAS_INT_MAX / 2 + 1)
+#else
+# define NPY_CBLAS_CHUNK  NPY_MAX_INTP
+#endif
+
+
 #ifdef __cplusplus
 }
 #endif
 
-#endif
+#endif  /* NUMPY_CORE_SRC_COMMON_NPY_CBLAS_H_ */

--- a/scipy/_build_utils/src/npy_cblas.h
+++ b/scipy/_build_utils/src/npy_cblas.h
@@ -6,6 +6,7 @@
 #ifndef NUMPY_CORE_SRC_COMMON_NPY_CBLAS_H_
 #define NUMPY_CORE_SRC_COMMON_NPY_CBLAS_H_
 
+#include <numpy/npy_common.h>
 #include <stddef.h>
 
 /* Allow the use in C++ code.  */

--- a/scipy/_build_utils/src/npy_cblas_base.h
+++ b/scipy/_build_utils/src/npy_cblas_base.h
@@ -9,6 +9,9 @@
  * Prototypes for level 1 BLAS functions (complex are recast as routines)
  * ===========================================================================
  */
+#ifndef NUMPY_CORE_SRC_COMMON_NPY_CBLAS_BASE_H_
+#define NUMPY_CORE_SRC_COMMON_NPY_CBLAS_BASE_H_
+
 float  BLASNAME(cblas_sdsdot)(const BLASINT N, const float alpha, const float *X,
                               const BLASINT incX, const float *Y, const BLASINT incY);
 double BLASNAME(cblas_dsdot)(const BLASINT N, const float *X, const BLASINT incX, const float *Y,
@@ -555,3 +558,5 @@ void BLASNAME(cblas_zher2k)(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO 
                             void *C, const BLASINT ldc);
 
 void BLASNAME(cblas_xerbla)(BLASINT p, const char *rout, const char *form, ...);
+
+#endif  /* NUMPY_CORE_SRC_COMMON_NPY_CBLAS_BASE_H_ */

--- a/scipy/sparse/csgraph/_matching.pyx
+++ b/scipy/sparse/csgraph/_matching.pyx
@@ -3,7 +3,7 @@ import warnings
 cimport cython
 import numpy as np
 cimport numpy as np
-from numpy.math cimport INFINITY
+from libc.math cimport INFINITY
 
 
 from scipy.sparse import isspmatrix_coo, isspmatrix_csc, isspmatrix_csr

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -20,7 +20,7 @@ from scipy.sparse.csgraph._validation import validate_graph
 cimport cython
 
 from libc.stdlib cimport malloc, free
-from numpy.math cimport INFINITY
+from libc.math cimport INFINITY
 
 np.import_array()
 

--- a/scipy/spatial/_ckdtree.pyx
+++ b/scipy/spatial/_ckdtree.pyx
@@ -10,12 +10,11 @@ import numpy as np
 import scipy.sparse
 
 cimport numpy as np
-from numpy.math cimport INFINITY
 
 from cpython.mem cimport PyMem_Malloc, PyMem_Free
 from libcpp.vector cimport vector
 from libcpp cimport bool
-from libc.math cimport isinf
+from libc.math cimport isinf, INFINITY
 
 cimport cython
 import os

--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -7,8 +7,7 @@ from ._rotation_groups import create_group
 cimport numpy as np
 cimport cython
 from cython.view cimport array
-from libc.math cimport sqrt, sin, cos, atan2, acos, hypot
-from numpy.math cimport PI as pi, NAN, isnan # avoid MSVC error
+from libc.math cimport sqrt, sin, cos, atan2, acos, hypot, isnan, NAN, pi
 
 np.import_array()
 

--- a/scipy/special/_ellip_harm.pxd
+++ b/scipy/special/_ellip_harm.pxd
@@ -32,9 +32,8 @@ import cython
 
 from . cimport sf_error
 
-from libc.math cimport sqrt, fabs, pow
+from libc.math cimport sqrt, fabs, pow, NAN
 from libc.stdlib cimport malloc, free
-from numpy.math cimport NAN, PI
 
 cdef extern from "lapack_defs.h":
     ctypedef int CBLAS_INT  # actual type defined in the header

--- a/scipy/special/_hyp0f1.pxd
+++ b/scipy/special/_hyp0f1.pxd
@@ -1,5 +1,4 @@
-from libc.math cimport pow, sqrt, floor, log, log1p, exp, M_PI, fabs
-from numpy.math cimport NAN, isinf
+from libc.math cimport pow, sqrt, floor, log, log1p, exp, M_PI, NAN, fabs, isinf
 cimport numpy as np
 
 from ._cephes cimport iv, jv, Gamma, lgam, gammasgn

--- a/scipy/stats/_stats.pyx
+++ b/scipy/stats/_stats.pyx
@@ -1,11 +1,10 @@
 from cpython cimport bool
 from libc cimport math
+from libc.math cimport NAN, INFINITY, M_PI as PI
 cimport cython
 cimport numpy as np
-from numpy.math cimport PI
-from numpy.math cimport INFINITY
-from numpy.math cimport NAN
 from numpy cimport ndarray, int64_t, float64_t, intp_t
+
 import warnings
 import numpy as np
 import scipy.stats, scipy.special


### PR DESCRIPTION
We'd like to get rid of `libnpymath`, and the (unrelated) `numpy.math` in the Python API was also just deprecated. So best to not use `numpy.math` from Cython either.

EDIT: the second commit syncs changes to `npy_blas.h` from NumPy, and the third commit fixes an issue with a missing include statement in `npy_blas.h` which was surfaced by the removal of a `from numpy.math cimport` statement elsewhere.