### PR TITLE
ENH: stats: Implement _sf and _isf for exponweib.

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1654,6 +1654,7 @@ class dgamma_gen(rv_continuous):
 
     def _entropy(self, a):
         a = np.asarray([a])
+
         def h1(a):
             h1 = a + np.log(2) + sc.gammaln(a) + (1 - a) * sc.digamma(a)
             return h1
@@ -1942,6 +1943,25 @@ class exponnorm_gen(rv_continuous):
 exponnorm = exponnorm_gen(name='exponnorm')
 
 
+def _pow1pm1(x, y):
+    """
+    Compute (1 + x)**y - 1.
+
+    Uses expm1 and xlog1py to avoid loss of precision when
+    (1 + x)**y is close to 1.
+
+    Note that the inverse of this function with respect to x is
+    ``_pow1pm1(x, 1/y)``.  That is, if
+
+        t = _pow1pm1(x, y)
+
+    then
+
+        x = _pow1pm1(t, 1/y)
+    """
+    return np.expm1(sc.xlog1py(y, x))
+
+
 class exponweib_gen(rv_continuous):
     r"""An exponentiated Weibull continuous random variable.
 
@@ -2006,6 +2026,12 @@ class exponweib_gen(rv_continuous):
 
     def _ppf(self, q, a, c):
         return (-sc.log1p(-q**(1.0/a)))**np.asarray(1.0/c)
+
+    def _sf(self, x, a, c):
+        return -_pow1pm1(-np.exp(-x**c), a)
+
+    def _isf(self, p, a, c):
+        return (-np.log(-_pow1pm1(-p, 1/a)))**(1/c)
 
 
 exponweib = exponweib_gen(a=0.0, name='exponweib')
@@ -4247,7 +4273,7 @@ class halfnorm_gen(rv_continuous):
         return 2 * _norm_sf(x)
 
     def _isf(self, p):
-        return  _norm_isf(p/2)
+        return _norm_isf(p/2)
 
     def _stats(self):
         return (np.sqrt(2.0/np.pi),
@@ -4449,6 +4475,7 @@ class invgamma_gen(rv_continuous):
 
         h = _lazywhere(a >= 2e2, (a,), f=asymptotic, f2=regular)
         return h
+
 
 invgamma = invgamma_gen(a=0.0, name='invgamma')
 
@@ -7213,6 +7240,7 @@ class t_gen(rv_continuous):
 
         h = _lazywhere(df >= 100, (df, ), f=asymptotic, f2=regular)
         return h
+
 
 t = t_gen(name='t')
 


### PR DESCRIPTION
In `exponweib_gen`, use formulations for `_sf` and `_isf` that avoid the loss of precision in the tail that is inherent in the default implementations.

In each of the two new parametrized tests, all but the first case fails in the main development branch.  The first case in each test helps ensure that this change doesn't cause a regression for the "easy" cases where the default `_sf` and `_isf` are able to maintain precision.

xref https://github.com/scipy/scipy/issues/17832