### PR TITLE
CI: test meson-python from its main branch in one CI job

### DIFF
--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -164,10 +164,14 @@ jobs:
       run: |
         python -m venv .venv
         source .venv/bin/activate
-        # Install build dependencies
-        python -m pip install numpy pybind11 pythran cython meson-python wheel pytest ninja
+        # Install build dependencies. Use meson-python from its main branch,
+        # most convenient to test in this job because we're using pip without
+        # build isolation here.
+        python -m pip install numpy pybind11 pythran cython pytest ninja
+        python -m pip install git+https://github.com/mesonbuild/meson-python.git
         # Non-isolated build, so we use dependencies installed inside the source tree
-        python -m pip install . --no-build-isolation
+        python -m pip install -U pip  # need pip >=23 for `--config-settings`
+        python -m pip install . --no-build-isolation --config-settings=compile-args=-j2
         
         # Basic tests
         cd ..


### PR DESCRIPTION
Doing it in this "venv inside source tree" job is for convenience, since it's the job using `pip install . --no-build-isolation`, and disabling build isolation is needed to avoid fetching a new meson-python wheel from PyPI.