### PR TITLE
MAINT: stats.betaprime: avoid spurious warnings in `fit`, `stats`

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -936,22 +936,27 @@ class betaprime_gen(rv_continuous):
 
     def _munp(self, n, a, b):
         if n == 1.0:
-            return np.where(b > 1,
-                            a/(b-1.0),
-                            np.inf)
+            return _lazywhere(
+                b > 1, (a, b),
+                lambda a, b: a/(b-1.0),
+                fillvalue=np.inf)
         elif n == 2.0:
-            return np.where(b > 2,
-                            a*(a+1.0)/((b-2.0)*(b-1.0)),
-                            np.inf)
+            return _lazywhere(
+                b > 2, (a, b),
+                lambda a, b: a*(a+1.0)/((b-2.0)*(b-1.0)),
+                fillvalue=np.inf)
         elif n == 3.0:
-            return np.where(b > 3,
-                            a*(a+1.0)*(a+2.0)/((b-3.0)*(b-2.0)*(b-1.0)),
-                            np.inf)
+            return _lazywhere(
+                b > 3, (a, b),
+                lambda a, b: (a*(a+1.0)*(a+2.0)
+                              / ((b-3.0)*(b-2.0)*(b-1.0))),
+                fillvalue=np.inf)
         elif n == 4.0:
-            return np.where(b > 4,
-                            (a*(a + 1.0)*(a + 2.0)*(a + 3.0) /
-                             ((b - 4.0)*(b - 3.0)*(b - 2.0)*(b - 1.0))),
-                            np.inf)
+            return _lazywhere(
+                b > 4, (a, b),
+                lambda a, b: (a*(a + 1.0)*(a + 2.0)*(a + 3.0) /
+                              ((b - 4.0)*(b - 3.0)*(b - 2.0)*(b - 1.0))),
+                fillvalue=np.inf)
         else:
             raise NotImplementedError
 

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -2750,7 +2750,8 @@ class rv_continuous(rv_generic):
         muhat = tmp.mean()
         mu2hat = tmp.var()
         Shat = sqrt(mu2hat / mu2)
-        Lhat = muhat - Shat*mu
+        with np.errstate(invalid='ignore'):
+            Lhat = muhat - Shat*mu
         if not np.isfinite(Lhat):
             Lhat = 0
         if not (np.isfinite(Shat) and (0 < Shat)):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -4220,6 +4220,13 @@ class TestBetaPrime:
         assert y < 1.0
         assert_allclose(y, expected, rtol=2e-5)
 
+    def test_fit_stats_gh18274(self):
+        # gh-18274 reported spurious warning emitted when fitting `betaprime`
+        # to data. Some of these were emitted by stats, too. Check that the
+        # warnings are no longer emitted.
+        stats.betaprime.fit([0.1, 0.25, 0.3, 1.2, 1.6], floc=0, fscale=1)
+        stats.betaprime(a=1, b=1).stats('mvsk')
+
 
 class TestGamma:
     def test_pdf(self):


### PR DESCRIPTION
#### Reference issue
Closes gh-18274

#### What does this implement/fix?
gh-18274 reported spurious warnings emitted by `betaprime`.
Two were from divide by zeros in `stats`. They are avoided by use of `_lazywhere` instead of `where`.
The infinite variance and mean with the guess `b=1` from `_fitstart` caused a NaN to be created and propagated in `_fit_loc_scale_support`. There was a condition to address this already, so I silenced the warning. Improvements to `_fitstart` are left to an enhancement.

