### PR TITLE
BLD: Enable incompatible pointer types warnings

### DIFF
--- a/doc/source/dev/contributor/meson_advanced.rst
+++ b/doc/source/dev/contributor/meson_advanced.rst
@@ -210,7 +210,7 @@ in this doc section to explain what is happening):
     build scipy/linalg/_decomp_update.cpython-310-x86_64-linux-gnu.so.p/meson-generated__decomp_update.c.o: c_COMPILER scipy/linalg/_decomp_update.cpython-310-x86_64-linux-gnu.so.p/_decomp_update.c
      DEPFILE = scipy/linalg/_decomp_update.cpython-310-x86_64-linux-gnu.so.p/meson-generated__decomp_update.c.o.d
      DEPFILE_UNQUOTED = scipy/linalg/_decomp_update.cpython-310-x86_64-linux-gnu.so.p/meson-generated__decomp_update.c.o.d
-     ARGS = -Iscipy/linalg/_decomp_update.cpython-310-x86_64-linux-gnu.so.p -Iscipy/linalg -I../scipy/linalg -I/home/username/anaconda3/envs/scipy-dev/lib/python3.10/site-packages/numpy/core/include -I/home/username/anaconda3/envs/scipy-dev/include/python3.10 -fvisibility=hidden -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c99 -O2 -g -Wno-unused-but-set-variable -Wno-unused-function -Wno-conversion -Wno-misleading-indentation -Wno-incompatible-pointer-types -fPIC -Wno-cpp
+     ARGS = -Iscipy/linalg/_decomp_update.cpython-310-x86_64-linux-gnu.so.p -Iscipy/linalg -I../scipy/linalg -I/home/username/anaconda3/envs/scipy-dev/lib/python3.10/site-packages/numpy/core/include -I/home/username/anaconda3/envs/scipy-dev/include/python3.10 -fvisibility=hidden -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c99 -O2 -g -Wno-unused-but-set-variable -Wno-unused-function -Wno-conversion -Wno-misleading-indentation -fPIC -Wno-cpp
 
     # step 4: generate a symbol file (uses `meson --internal symbolextractor`); you can safely ignore this step
     build scipy/linalg/_decomp_update.cpython-310-x86_64-linux-gnu.so.p/_decomp_update.cpython-310-x86_64-linux-gnu.so.symbols: SHSYM scipy/linalg/_decomp_update.cpython-310-x86_64-linux-gnu.so
@@ -293,7 +293,6 @@ interest shows:
                     "-Wno-unused-function",
                     "-Wno-conversion",
                     "-Wno-misleading-indentation",
-                    "-Wno-incompatible-pointer-types",
                     "-fPIC",
                     "-Wno-cpp"
                 ],

--- a/meson.build
+++ b/meson.build
@@ -54,14 +54,11 @@ if not cy.version().version_compare('>=0.29.33')
   error('SciPy requires Cython >= 0.29.33')
 endif
 
-# TODO: the below -Wno flags are all needed to silence warnings in
-# f2py-generated code. This should be fixed in f2py itself.
 _global_c_args = cc.get_supported_arguments(
   '-Wno-unused-but-set-variable',
   '-Wno-unused-function',
   '-Wno-conversion',
   '-Wno-misleading-indentation',
-  '-Wno-incompatible-pointer-types',
 )
 add_project_arguments(_global_c_args, language : 'c')
 

--- a/scipy/_lib/_ccallback_c.pyx
+++ b/scipy/_lib/_ccallback_c.pyx
@@ -15,9 +15,9 @@ from .ccallback cimport (ccallback_t, ccallback_prepare, ccallback_release, CCAL
 #
 
 cdef void raw_capsule_destructor(object capsule):
-    cdef char *name
+    cdef const char *name
     name = PyCapsule_GetName(capsule)
-    free(name)
+    free(<char*>name)
 
 
 def get_raw_capsule(func_obj, name_obj, context_obj):
@@ -40,9 +40,9 @@ def get_raw_capsule(func_obj, name_obj, context_obj):
     cdef:
         void *func
         void *context
-        char *capsule_name
-        char *name
-        char *name_copy
+        const char *capsule_name
+        const char *name
+        const char *name_copy
 
     if name_obj is None:
         name = NULL
@@ -84,7 +84,7 @@ def get_raw_capsule(func_obj, name_obj, context_obj):
 
 
 def get_capsule_signature(capsule_obj):
-    cdef char *name
+    cdef const char *name
     name = PyCapsule_GetName(capsule_obj)
     if name == NULL:
         raise ValueError("Capsule has no signature")

--- a/scipy/interpolate/interpnd.pyx
+++ b/scipy/interpolate/interpnd.pyx
@@ -349,7 +349,7 @@ class GradientEstimationWarning(Warning):
     pass
 
 @cython.cdivision(True)
-cdef int _estimate_gradients_2d_global(qhull.DelaunayInfo_t *d, double *data,
+cdef int _estimate_gradients_2d_global(qhull.DelaunayInfo_t *d, const double *data,
                                        int maxiter, double tol,
                                        double *y) nogil:
     """

--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -211,7 +211,7 @@ cython_blas = py3.extension_module('cython_blas',
     cython_linalg[4],  # _blas_subroutines.h
     'fortran_defs.h'
   ],
-  c_args: cython_c_args,
+  c_args: [cython_c_args, Wno_incompatible_pointer_types],
   link_with: fwrappers,
   link_args: version_link_args,
   dependencies: [lapack, blas, np_dep],
@@ -226,7 +226,7 @@ cython_lapack = py3.extension_module('cython_lapack',
     cython_linalg[5],  # _lapack_subroutines.h
     'fortran_defs.h'
   ],
-  c_args: cython_c_args,
+  c_args: [cython_c_args, Wno_incompatible_pointer_types],
   link_with: fwrappers,
   link_args: version_link_args,
   dependencies: [lapack, blas, np_dep],

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -294,6 +294,7 @@ Wno_parentheses = cc.get_supported_arguments('-Wno-parentheses')
 Wno_switch = cc.get_supported_arguments('-Wno-switch')
 Wno_unused_label = cc.get_supported_arguments('-Wno-unused-label')
 Wno_unused_variable = cc.get_supported_arguments('-Wno-unused-variable')
+Wno_incompatible_pointer_types = cc.get_supported_arguments('-Wno-incompatible-pointer-types')
 
 # C++ warning flags
 _cpp_Wno_cpp = cpp.get_supported_arguments('-Wno-cpp')

--- a/scipy/spatial/_qhull.pxd
+++ b/scipy/spatial/_qhull.pxd
@@ -40,19 +40,19 @@ cdef int _get_delaunay_info(DelaunayInfo_t *, obj,
 #
 
 cdef int _barycentric_inside(int ndim, double *transform,
-                             double *x, double *c, double eps) nogil
+                             const double *x, double *c, double eps) nogil
 
 cdef void _barycentric_coordinate_single(int ndim, double *transform,
-                                         double *x, double *c, int i) nogil
+                                         const double *x, double *c, int i) nogil
 
 cdef void _barycentric_coordinates(int ndim, double *transform,
-                                   double *x, double *c) nogil
+                                   const double *x, double *c) nogil
 
 #
 # N+1-D geometry
 #
 
-cdef void _lift_point(DelaunayInfo_t *d, double *x, double *z) nogil
+cdef void _lift_point(DelaunayInfo_t *d, const double *x, double *z) nogil
 
 cdef double _distplane(DelaunayInfo_t *d, int isimplex, double *point) nogil
 
@@ -60,13 +60,13 @@ cdef double _distplane(DelaunayInfo_t *d, int isimplex, double *point) nogil
 # Finding simplices
 #
 
-cdef int _is_point_fully_outside(DelaunayInfo_t *d, double *x, double eps) nogil
+cdef int _is_point_fully_outside(DelaunayInfo_t *d, const double *x, double eps) nogil
 
-cdef int _find_simplex_bruteforce(DelaunayInfo_t *d, double *c, double *x,
+cdef int _find_simplex_bruteforce(DelaunayInfo_t *d, double *c, const double *x,
                                   double eps, double eps_broad) nogil
 
-cdef int _find_simplex_directed(DelaunayInfo_t *d, double *c, double *x,
+cdef int _find_simplex_directed(DelaunayInfo_t *d, double *c, const double *x,
                                 int *start, double eps, double eps_broad) nogil
 
-cdef int _find_simplex(DelaunayInfo_t *d, double *c, double *x, int *start,
+cdef int _find_simplex(DelaunayInfo_t *d, double *c, const double *x, int *start,
                        double eps, double eps_broad) nogil

--- a/scipy/spatial/_qhull.pyx
+++ b/scipy/spatial/_qhull.pyx
@@ -1151,7 +1151,7 @@ cdef double _matrix_norm1(int n, double *a) nogil:
     return maxsum
 
 cdef int _barycentric_inside(int ndim, double *transform,
-                             double *x, double *c, double eps) nogil:
+                             const double *x, double *c, double eps) nogil:
     """
     Check whether point is inside a simplex, using barycentric
     coordinates.  `c` will be filled with barycentric coordinates, if
@@ -1173,7 +1173,7 @@ cdef int _barycentric_inside(int ndim, double *transform,
     return 1
 
 cdef void _barycentric_coordinate_single(int ndim, double *transform,
-                                         double *x, double *c, int i) nogil:
+                                         const double *x, double *c, int i) nogil:
     """
     Compute a single barycentric coordinate.
 
@@ -1193,7 +1193,7 @@ cdef void _barycentric_coordinate_single(int ndim, double *transform,
             c[i] += transform[ndim*i + j] * (x[j] - transform[ndim*ndim + j])
 
 cdef void _barycentric_coordinates(int ndim, double *transform,
-                                   double *x, double *c) nogil:
+                                   const double *x, double *c) nogil:
     """
     Compute barycentric coordinates.
 
@@ -1211,7 +1211,7 @@ cdef void _barycentric_coordinates(int ndim, double *transform,
 # N-D geometry
 #------------------------------------------------------------------------------
 
-cdef void _lift_point(DelaunayInfo_t *d, double *x, double *z) nogil:
+cdef void _lift_point(DelaunayInfo_t *d, const double *x, double *z) nogil:
     cdef int i
     z[d.ndim] = 0
     for i in range(d.ndim):
@@ -1236,7 +1236,7 @@ cdef double _distplane(DelaunayInfo_t *d, int isimplex, double *point) nogil:
 # Finding simplices
 #------------------------------------------------------------------------------
 
-cdef int _is_point_fully_outside(DelaunayInfo_t *d, double *x,
+cdef int _is_point_fully_outside(DelaunayInfo_t *d, const double *x,
                                  double eps) nogil:
     """
     Is the point outside the bounding box of the triangulation?
@@ -1250,7 +1250,7 @@ cdef int _is_point_fully_outside(DelaunayInfo_t *d, double *x,
     return 0
 
 cdef int _find_simplex_bruteforce(DelaunayInfo_t *d, double *c,
-                                  double *x, double eps,
+                                  const double *x, double eps,
                                   double eps_broad) nogil:
     """
     Find simplex containing point `x` by going through all simplices.
@@ -1308,7 +1308,7 @@ cdef int _find_simplex_bruteforce(DelaunayInfo_t *d, double *c,
     return -1
 
 cdef int _find_simplex_directed(DelaunayInfo_t *d, double *c,
-                                double *x, int *start, double eps,
+                                const double *x, int *start, double eps,
                                 double eps_broad) nogil:
     """
     Find simplex containing point `x` via a directed walk in the tessellation.
@@ -1409,7 +1409,7 @@ cdef int _find_simplex_directed(DelaunayInfo_t *d, double *c,
     return isimplex
 
 cdef int _find_simplex(DelaunayInfo_t *d, double *c,
-                       double *x, int *start, double eps,
+                       const double *x, int *start, double eps,
                        double eps_broad) nogil:
     """
     Find simplex containing point `x` by walking the triangulation.

--- a/scipy/stats/_rcont/meson.build
+++ b/scipy/stats/_rcont/meson.build
@@ -8,7 +8,7 @@ py3.install_sources([
 rcont = py3.extension_module('rcont',
   ['_rcont.c', 'logfactorial.c'],
   cython_gen.process('rcont.pyx'),
-  c_args: numpy_nodepr_api,
+  c_args: [numpy_nodepr_api, Wno_incompatible_pointer_types],
   dependencies: [np_dep, npyrandom_lib, npymath_lib],
   link_args: version_link_args,
   install: true,


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
See more on gh-16942.

#### What does this implement/fix?
- Remove `-Wno-incompatible-pointer-types` from the global `meson.build`
- Add it to `_rcont`, `cython_blas` and `cython_lapack`
- Add `const` to various places to remove compiler warnings


#### Additional information
`_rcont` needs this because of an apparent mismatch between `int64_t` and `np.int64_t`

```
[6/7] Compiling C object scipy/stats/_rcont/rcont.cpython-310-darwin.so.p/meson-generated_rcont.c.o
scipy/stats/_rcont/rcont.cpython-310-darwin.so.p/rcont.c:3396:15: warning: incompatible pointer types passing '__pyx_t_5scipy_5stats_6_rcont_5rcont_tab_t *' (aka 'long *') to parameter of type 'tab_t *' (aka 'long long *') [-Wincompatible-pointer-types]
  rcont1_init((&(*__Pyx_BufPtrCContig1d(__pyx_t_5scipy_5stats_6_rcont_5rcont_tab_t *, __pyx_pybuffernd_work.rcbuffer->pybuffer.buf, __pyx_t_10, __pyx_pybuffernd_work.diminfo[0].strides))), __pyx_v_nc, (&(*((__pyx_t_5scipy_5stats_6_rcont_5rcont_tab_t *) ( /* dim=0 */ ((char *) (((__pyx_t_5scipy_5stats_6_rcont_5rcont_tab_t *) __pyx_v_col.data) + __pyx_t_12)) )))));
              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../scipy/stats/_rcont/./_rcont.h:9:25: note: passing argument to parameter 'work' here
void rcont1_init(tab_t *work, int nc, const tab_t *c);
```


`cython_blas` and `lapack` need the flag due to the issues described in gh-16942.
```
[47/50] Compiling C object scipy/linalg/cython_lapack.cpython-310-darwin.so.p/meson-generated_cython_lapack.c.o
scipy/linalg/cython_lapack.cpython-310-darwin.so.p/cython_lapack.c:1878:32: warning: incompatible pointer types passing '__pyx_t_float_complex *' to parameter of type 'npy_complex64 *' (aka 'npy_cfloat *') [-Wincompatible-pointer-types]
  F_FUNC(cladivwrp, CLADIVWRP)((&__pyx_v_out), ((npy_complex64 *)__pyx_v_x), ((npy_complex64 *)__pyx_v_y));
                               ^~~~~~~~~~~~~~
scipy/linalg/_lapack_subroutines.h:23:50: note: passing argument to parameter 'ret' here
void F_FUNC(cladivwrp, CLADIVWRP)(npy_complex64 *ret, npy_complex64 *x, npy_complex64 *y);
```
