### PR TITLE
MAINT: Remove codecov

### DIFF
--- a/ci/azure-travis-template.yaml
+++ b/ci/azure-travis-template.yaml
@@ -91,7 +91,7 @@ steps:
       # only in a single place)
     displayName: 'Install full mode optional dependencies'
 - ${{ if eq(parameters.coverage, true) }}:
-  - script: pip install pytest-cov coverage codecov
+  - script: pip install pytest-cov coverage
     displayName: 'Install coverage dependencies'
 - ${{ if eq(parameters.refguide_check, true) }}:
   - script: pip install matplotlib sphinx numpydoc pooch


### PR DESCRIPTION
The codecov package has been removed (yanked) from PyPi as deprecated. This is causing the CI to fail. e.g. https://dev.azure.com/scipy-org/SciPy/_build/results?buildId=24239&view=logs&jobId=7902a2c1-7b88-5b2d-6408-84b88759c642&j=7902a2c1-7b88-5b2d-6408-84b88759c642&t=6532f367-0252-5e1e-4920-c1a53edccffd

```
ERROR: Could not find a version that satisfies the requirement codecov (from versions: none)
ERROR: No matching distribution found for codecov
```

This PR attempts to mitigate that. I am not 100% sure, but should be ok since we updated the uploader already. I think we also had a PR about coverage in the work, I will try to find it back.