### PR TITLE
MAINT: mmread allow leading whitespace

### DIFF
--- a/scipy/io/_mmio.py
+++ b/scipy/io/_mmio.py
@@ -386,8 +386,11 @@ class MMFile:
 
             # skip comments
             # line.startswith('%')
-            while line and line[0] in ['%', 37]:
-                line = stream.readline()
+            while line:
+                if line.lstrip() and line.lstrip()[0] in ['%', 37]:
+                    line = stream.readline()
+                else:
+                    break
 
             # skip empty lines
             while not line.strip():

--- a/scipy/io/tests/test_mmio.py
+++ b/scipy/io/tests/test_mmio.py
@@ -757,3 +757,15 @@ def test_gh11389():
     mmread(io.StringIO("%%MatrixMarket matrix coordinate complex symmetric\n"
                        " 1 1 1\n"
                        "1 1 -2.1846000000000e+02  0.0000000000000e+00"))
+
+
+def test_gh18123(tmp_path):
+    lines = [" %%MatrixMarket matrix coordinate real general\n",
+             "5 5 3\n",
+             "2 3 1.0\n",
+             "3 4 2.0\n",
+             "3 5 3.0\n"]
+    test_file = tmp_path / "test.mtx"
+    with open(test_file, "w") as f:
+        f.writelines(lines)
+    mmread(test_file)


### PR DESCRIPTION
Fixes #18123

* the discussion in that issue is pretty clear/decisive now I think--let's allow the leading whitespace despite the deviation from the standard based on the points raised over there

* the patch provided in the issue didn't cut it, but this seems to do the trick