### PR TITLE
DEP: stats.mode: raise with non-numeric input

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -501,6 +501,12 @@ def mode(a, axis=0, nan_policy='propagate', keepdims=False):
 
     """  # noqa: E501
     # `axis`, `nan_policy`, and `keepdims` are handled by `_axis_nan_policy`
+    if not np.issubdtype(a.dtype, np.number):
+        message = ("Argument `a` is not recognized as numeric. "
+                   "Support for input that cannot be coerced to a numeric "
+                   "array was deprecated in SciPy 1.9.0 and removed in SciPy "
+                   "1.11.0. Please consider `pandas.DataFrame.mode`.")
+        raise TypeError(message)
 
     if a.size == 0:
         NaN = _get_nan(a)

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -446,7 +446,7 @@ def mode(a, axis=0, nan_policy='propagate', keepdims=False):
     Parameters
     ----------
     a : array_like
-        n-dimensional array of which to find mode(s).
+        Numeric, n-dimensional array of which to find mode(s).
     axis : int or None, optional
         Axis along which to operate. Default is 0. If None, compute over
         the whole array `a`.

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2209,8 +2209,6 @@ class TestScoreatpercentile:
 @pytest.mark.filterwarnings('ignore::FutureWarning')
 class TestMode:
 
-    deprecation_msg = r"Support for non-numeric arrays has been deprecated"
-
     def test_empty(self):
         vals, counts = stats.mode([])
         assert_equal(vals, np.array([]))
@@ -2292,11 +2290,7 @@ class TestMode:
     def test_mode_shape_gh_9955(self, axis, dtype=np.float64):
         rng = np.random.default_rng(984213899)
         a = rng.uniform(size=(3, 4, 5)).astype(dtype)
-        if dtype == 'object':
-            with pytest.warns(DeprecationWarning, match=self.deprecation_msg):
-                res = stats.mode(a, axis=axis, keepdims=False)
-        else:
-            res = stats.mode(a, axis=axis, keepdims=False)
+        res = stats.mode(a, axis=axis, keepdims=False)
         reference_shape = list(a.shape)
         reference_shape.pop(axis)
         np.testing.assert_array_equal(res.mode.shape, reference_shape)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2412,6 +2412,11 @@ class TestMode:
         ref = np.mean(z, axis=None, keepdims=True)
         assert res[0].shape == res[1].shape == ref.shape == (1, 1, 1)
 
+    def test_raise_non_numeric_gh18254(self):
+        message = "Argument `a` is not recognized as numeric."
+        with pytest.raises(TypeError, match=message):
+            stats.mode(np.arange(5, dtype=object))
+
 
 class TestSEM:
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2414,9 +2414,18 @@ class TestMode:
 
     def test_raise_non_numeric_gh18254(self):
         message = "Argument `a` is not recognized as numeric."
-        with pytest.raises(TypeError, match=message):
-            stats.mode(np.arange(5, dtype=object))
 
+        class ArrLike():
+            def __init__(self, x):
+                self._x = x
+
+            def __array__(self):
+                return self._x.astype(object)
+
+        with pytest.raises(TypeError, match=message):
+            stats.mode(ArrLike(np.arange(3)))
+        with pytest.raises(TypeError, match=message):
+            stats.mode(np.arange(3, dtype=object))
 
 class TestSEM:
 


### PR DESCRIPTION
#### Reference issue
https://github.com/scipy/scipy/issues/18254#issuecomment-1502436548

#### What does this implement/fix?
One resolution of gh-18245 was that `stats.mode` should raise when input is non-numeric. This implements that.