### PR TITLE
BUG: fix for incompatible pointer warning from stats._rcond #18282 

### DIFF
--- a/scipy/stats/_rcont/_rcont.h
+++ b/scipy/stats/_rcont/_rcont.h
@@ -2,9 +2,10 @@
 #define RCONT_H
 
 #include <numpy/random/distributions.h>
+#include <numpy/npy_common.h>
 #include <stdint.h>
 
-typedef int64_t tab_t;
+typedef npy_int64 tab_t;
 
 void rcont1_init(tab_t *work, int nc, const tab_t *c);
 

--- a/scipy/stats/_rcont/meson.build
+++ b/scipy/stats/_rcont/meson.build
@@ -8,7 +8,7 @@ py3.install_sources([
 rcont = py3.extension_module('rcont',
   ['_rcont.c', 'logfactorial.c'],
   cython_gen.process('rcont.pyx'),
-  c_args: [numpy_nodepr_api, Wno_incompatible_pointer_types],
+  c_args: numpy_nodepr_api,
   dependencies: [np_dep, npyrandom_lib, npymath_lib],
   link_args: version_link_args,
   install: true,


### PR DESCRIPTION
Match C type used by routines stats.rvs_rcont1 and stats.rvs_rcont2 with the Cython type on all platforms.

#### Reference issue
Closes gh-18282

#### What does this implement/fix?
Makes sure that C type used in the table produced by the rcont routine matches the Cython type on all platforms. For more details, see #18282