### PR TITLE
DEP: integrate.quad: deprecate argument `full_output`

### DIFF
--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -480,9 +480,9 @@ def quad(func, a, b, args=(), full_output=None, epsabs=1.49e-8, epsrel=1.49e-8,
             msgexp["imag"] = im_retval[2:]
             return retval + (msgexp,)
         else:
-            infodict = {"real" : re_retval.infodict, "imag": re_retval.infodict}
-            message = {"real" : re_retval.message, "imag": re_retval.message}
-            explain = {"real" : re_retval.explain, "imag": re_retval.explain}
+            infodict = {"real" : re_retval.infodict, "imag": im_retval.infodict}
+            message = {"real" : re_retval.message, "imag": im_retval.message}
+            explain = {"real" : re_retval.explain, "imag": im_retval.explain}
             return QuadResult(integral=integral, abserr=error_estimate,
                               infodict=infodict, message=message,
                               explain=explain)
@@ -539,9 +539,9 @@ def quad(func, a, b, args=(), full_output=None, epsabs=1.49e-8, epsrel=1.49e-8,
         else:
             warnings.warn(msg, IntegrationWarning, stacklevel=2)
             if weight in ['cos', 'sin'] and (b == Inf or a == -Inf):
-                return QuadResult(*retval[:-1], msg, explain)
+                return QuadResult(*retval[:-2], infodict=retval[-1], message=msg, explain=explain)
             else:
-                return QuadResult(retval[:-1], msg)
+                return QuadResult(*retval[:-2], infodict=retval[-1], message=msg, explain="")
 
     elif ier == 6:  # Forensic decision tree when QUADPACK throws ier=6
         if epsabs <= 0:  # Small error tolerance - applies to all methods

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -76,8 +76,8 @@ def quad(func, a, b, args=(), full_output=None, epsabs=1.49e-8, epsrel=1.49e-8,
         (``complex_func=False``: default) or complex (``complex_func=True``).
         In both cases, the function's argument is real.
         The `infodict`, `message`, and
-        `explain` for the real and complex components are returned in
-        a dictionary with keys "real output" and "imag output".
+        `explain` for the real and complex components are
+        a dictionaries with keys "real output" and "imag output".
 
     Returns
     -------

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -150,10 +150,10 @@ def quad(func, a, b, args=(), full_output=None, epsabs=1.49e-8, epsrel=1.49e-8,
 
     **Extra information for quad() inputs and outputs**
 
-    `infodict` is a dictionary with entries as tabulated below. For
-    infinite limits, the range is transformed to (0,1) and the
+    The `infodict` attribute is a dictionary with entries as tabulated below.
+    For infinite limits, the range is transformed to (0,1) and the
     optional outputs are given with respect to this transformed range.
-    Let M be the input argument limit and let K be infodict['last'].
+    Let M be the input argument limit and let K be ``infodict['last']``.
     The entries are:
 
     'neval'
@@ -182,7 +182,7 @@ def quad(func, a, b, args=(), full_output=None, epsabs=1.49e-8, epsrel=1.49e-8,
         decreasing sequence.
 
     If the input argument points is provided (i.e., it is not None),
-    the following additional outputs are placed in the output
+    the following additional outputs are placed in the `infodict` attribute
     dictionary. Assume the points sequence is of length P.
 
     'pts'
@@ -231,7 +231,7 @@ def quad(func, a, b, args=(), full_output=None, epsabs=1.49e-8, epsrel=1.49e-8,
 
     For finite integration limits, the integration is performed using a
     Clenshaw-Curtis method which uses Chebyshev moments. For repeated
-    calculations, these moments are saved in the output dictionary:
+    calculations, these moments are saved in the `infodict` attribute dictionary:
 
     'momcom'
         The maximum level of Chebyshev moments that have been computed,
@@ -252,10 +252,10 @@ def quad(func, a, b, args=(), full_output=None, epsabs=1.49e-8, epsrel=1.49e-8,
 
     If one of the integration limits is infinite, then a Fourier integral is
     computed (assuming w neq 0). If a numerical error
-    is encountered, besides the error message attached to the output tuple,
-    a dictionary is also appended to the output tuple which translates the
+    is encountered, besides the `message` attribute of the results object,
+    the `explain` attribute translates the
     error codes in the array ``info['ierlst']`` to English messages. The
-    output information dictionary contains the following entries instead of
+    `infodict` attribute dictionary contains the following entries instead of
     'last', 'alist', 'blist', 'rlist', and 'elist':
 
     'lst'

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -70,14 +70,14 @@ def quad(func, a, b, args=(), full_output=None, epsabs=1.49e-8, epsrel=1.49e-8,
         .. deprecated:: 1.11.0
            Parameter `full_output` is deprecated and will be removed in
            version 1.13.0. When `full_output` is unspecified, the contents
-           of ``infodict`` are provided as attributes of the result object.
+           of `infodict` are provided as attributes of the result object.
     complex_func : bool, optional
         Indicate if the function's (`func`) return type is real
         (``complex_func=False``: default) or complex (``complex_func=True``).
         In both cases, the function's argument is real.
         The `infodict`, `message`, and
         `explain` for the real and complex components are
-       dictionaries with keys "real" and "imag".
+        dictionaries with keys "real" and "imag".
 
     Returns
     -------

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -509,7 +509,10 @@ def quad(func, a, b, args=(), full_output=None, epsabs=1.49e-8, epsrel=1.49e-8,
 
     ier = retval[-1]
     if ier == 0:
-        return QuadResult(*retval[:-2], infodict=retval[-2], message="", explain="")
+        if full_output:
+            return retval[:-1]
+        else:
+            return QuadResult(*retval[:-2], infodict=retval[-2], message="", explain="")
 
     msgs = {80: "A Python error occurred possibly while calling the function.",
              1: "The maximum number of subdivisions (%d) has been achieved.\n  If increasing the limit yields no improvement it is advised to analyze \n  the integrand in order to determine the difficulties.  If the position of a \n  local difficulty can be determined (singularity, discontinuity) one will \n  probably gain from splitting up the interval and calling the integrator \n  on the subranges.  Perhaps a special-purpose integrator should be used." % limit,

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -229,7 +229,7 @@ def quad(func, a, b, args=(), full_output=None, epsabs=1.49e-8, epsrel=1.49e-8,
     For the 'cos' and 'sin' weighting, additional inputs and outputs are
     available.
 
-    For finite integration limits, the integration is performed using a/f
+    For finite integration limits, the integration is performed using a
     Clenshaw-Curtis method which uses Chebyshev moments. For repeated
     calculations, these moments are saved in the output dictionary:
 

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -77,7 +77,7 @@ def quad(func, a, b, args=(), full_output=None, epsabs=1.49e-8, epsrel=1.49e-8,
         In both cases, the function's argument is real.
         The `infodict`, `message`, and
         `explain` for the real and complex components are
-        a dictionaries with keys "real output" and "imag output".
+       dictionaries with keys "real" and "imag".
 
     Returns
     -------

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -117,7 +117,7 @@ def quad(func, a, b, args=(), full_output=None, epsabs=1.49e-8, epsrel=1.49e-8,
         singularities, discontinuities). The sequence does not have
         to be sorted. Note that this option cannot be used in conjunction
         with ``weight``.
-    weight : float or int, optional
+    weight : str, optional
         String indicating weighting function. Full explanation for this
         and the remaining arguments can be found below.
     wvar : optional

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -66,7 +66,7 @@ def quad(func, a, b, args=(), full_output=None, epsabs=1.49e-8, epsrel=1.49e-8,
         Non-zero to return a dictionary of integration information.
         If non-zero, warning messages are also suppressed and the
         message is appended to the output tuple.
-        
+
         .. deprecated:: 1.11.0
            Parameter `full_output` is deprecated and will be removed in
            version 1.13.0. When `full_output` is unspecified, the contents
@@ -456,7 +456,7 @@ def quad(func, a, b, args=(), full_output=None, epsabs=1.49e-8, epsrel=1.49e-8,
                "now be accessed as attributes of the object returned by "
                "'scipy.integrate.quad'.")
         warnings.warn(msg, DeprecationWarning, stacklevel=2)
-    
+
     if not isinstance(args, tuple):
         args = (args,)
 
@@ -478,7 +478,7 @@ def quad(func, a, b, args=(), full_output=None, epsabs=1.49e-8, epsrel=1.49e-8,
                          maxp1, limlst, complex_func=False)
         integral = re_retval.integral + 1j*im_retval.integral
         error_estimate = re_retval.abserr + 1j*im_retval.abserr
-        
+
         if full_output:
             retval = integral, error_estimate
             msgexp = {}

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -503,7 +503,7 @@ def quad(func, a, b, args=(), full_output=None, epsabs=1.49e-8, epsrel=1.49e-8,
 
     ier = retval[-1]
     if ier == 0:
-        return QuadResult(*retval[:-1], message="", explain="")
+        return QuadResult(*retval[:-2], infodict=retval[-2], message="", explain="")
 
     msgs = {80: "A Python error occurred possibly while calling the function.",
              1: "The maximum number of subdivisions (%d) has been achieved.\n  If increasing the limit yields no improvement it is advised to analyze \n  the integrand in order to determine the difficulties.  If the position of a \n  local difficulty can be determined (singularity, discontinuity) one will \n  probably gain from splitting up the interval and calling the integrator \n  on the subranges.  Perhaps a special-purpose integrator should be used." % limit,
@@ -669,7 +669,7 @@ def _quad_weight(func, a, b, args, epsabs, epsrel, limlst, limit, maxp1,
             return _quadpack._qawse(func, a, b, wvar, integr, args, 1,
                                     epsabs, epsrel, limit)
         else:  # weight == 'cauchy'
-            return _quadpack._qawce(func, a, b, wvar, args, epsabs, epsrel, 1,
+            return _quadpack._qawce(func, a, b, wvar, args, 1, epsabs, epsrel,
                                     limit)
 
 

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -387,7 +387,8 @@ def quad(func, a, b, args=(), full_output=None, epsabs=1.49e-8, epsrel=1.49e-8,
     >>> from scipy import integrate
     >>> import numpy as np
     >>> x2 = lambda x: x**2
-    >>> integrate.quad(x2, 0, 4)
+    >>> res = integrate.quad(x2, 0, 4)
+    >>> (res.integral, res.abserr)
     (21.333333333333332, 2.3684757858670003e-13)
     >>> print(4**3 / 3.)  # analytical result
     21.3333333333
@@ -395,17 +396,18 @@ def quad(func, a, b, args=(), full_output=None, epsabs=1.49e-8, epsrel=1.49e-8,
     Calculate :math:`\\int^\\infty_0 e^{-x} dx`
 
     >>> invexp = lambda x: np.exp(-x)
-    >>> integrate.quad(invexp, 0, np.inf)
+    >>> res = integrate.quad(invexp, 0, np.inf)
+    >>> (res.integral, res.abserr)
     (1.0, 5.842605999138044e-11)
 
     Calculate :math:`\\int^1_0 a x \\,dx` for :math:`a = 1, 3`
 
     >>> f = lambda x, a: a*x
-    >>> y, err = integrate.quad(f, 0, 1, args=(1,))
-    >>> y
+    >>> res = integrate.quad(f, 0, 1, args=(1,))
+    >>> res.integral
     0.5
-    >>> y, err = integrate.quad(f, 0, 1, args=(3,))
-    >>> y
+    >>> res = integrate.quad(f, 0, 1, args=(3,))
+    >>> res.integral
     1.5
 
     Calculate :math:`\\int^1_0 x^2 + y^2 dx` with ctypes, holding
@@ -423,7 +425,8 @@ def quad(func, a, b, args=(), full_output=None, epsabs=1.49e-8, epsrel=1.49e-8,
        lib = ctypes.CDLL('/home/.../testlib.*') #use absolute path
        lib.func.restype = ctypes.c_double
        lib.func.argtypes = (ctypes.c_int,ctypes.c_double)
-       integrate.quad(lib.func,0,1,(1))
+       res = integrate.quad(lib.func,0,1,(1))
+       (res.integral, res.abserr)
        #(1.3333333333333333, 1.4802973661668752e-14)
        print((1.0**3/3.0 + 1.0) - (0.0**3/3.0 + 0.0)) #Analytic result
        # 1.3333333333333333
@@ -435,11 +438,14 @@ def quad(func, a, b, args=(), full_output=None, epsabs=1.49e-8, epsrel=1.49e-8,
     bounds.
 
     >>> y = lambda x: 1 if x<=0 else 0
-    >>> integrate.quad(y, -1, 1)
+    >>> res = integrate.quad(y, -1, 1)
+    >>> (res.integral, res.abserr)
     (1.0, 1.1102230246251565e-14)
-    >>> integrate.quad(y, -1, 100)
+    >>> res = integrate.quad(y, -1, 100)
+    >>> (res.integral, res.abserr)
     (1.0000000002199108, 1.0189464580163188e-08)
-    >>> integrate.quad(y, -1, 10000)
+    >>> res = integrate.quad(y, -1, 10000)
+    >>> (res.integral, res.abserr)
     (0.0, 0.0)
 
     """
@@ -539,9 +545,9 @@ def quad(func, a, b, args=(), full_output=None, epsabs=1.49e-8, epsrel=1.49e-8,
         else:
             warnings.warn(msg, IntegrationWarning, stacklevel=2)
             if weight in ['cos', 'sin'] and (b == Inf or a == -Inf):
-                return QuadResult(*retval[:-2], infodict=retval[-1], message=msg, explain=explain)
+                return QuadResult(*retval[:-2], infodict=retval[-2], message=msg, explain=explain)
             else:
-                return QuadResult(*retval[:-2], infodict=retval[-1], message=msg, explain="")
+                return QuadResult(*retval[:-2], infodict=retval[-2], message=msg, explain="")
 
     elif ier == 6:  # Forensic decision tree when QUADPACK throws ier=6
         if epsabs <= 0:  # Small error tolerance - applies to all methods

--- a/scipy/integrate/tests/test_quadpack.py
+++ b/scipy/integrate/tests/test_quadpack.py
@@ -536,6 +536,29 @@ class TestQuad:
 
         assert res_c.infodict['imag']['lst'] == res_i.infodict['lst']
 
+    def test_result_object(self):
+        # Check that result object contains attributes `integral`, `abserr`,
+        # `infodict`, `message` and `explains`. During the `full_output`
+        # deprecation period, also check that specifying `full_output`
+        # produces a warning and that values are the same whether
+        # `full_output` is True, False, or unspecified.
+        def func(x):
+            return x**2 + 1
+
+        res = quad(func, 0, 4)
+        
+        msg = "Use of parameter 'full_output' is deprecated as of SciPy "
+        with pytest.deprecated_call(match=msg):
+            res2 = quad(func, 0, 4, full_output=0)
+        with pytest.deprecated_call(match=msg):
+            res3 = quad(func, 0, 4, full_output=1)
+
+        assert_equal(res, res2)
+        assert res.integral == res2.integral
+        assert res.abserr == res2.abserr
+
+        assert_equal(res, res3[:2])
+
 
 class TestNQuad:
     def test_fixed_limits(self):

--- a/scipy/integrate/tests/test_quadpack.py
+++ b/scipy/integrate/tests/test_quadpack.py
@@ -505,6 +505,7 @@ class TestQuad:
             error_tolerance=6e-8
         )
 
+    @pytest.mark.filterwarnings("ignore::scipy.integrate._quadpack_py.IntegrationWarning")
     def test_complex(self):
         def tfunc(x):
             return np.exp(1j*x)
@@ -517,8 +518,7 @@ class TestQuad:
         # to return an error message.  The output is compared
         # against what is returned by explicit integration
         # of the parts.
-        kwargs = {'a': 0, 'b': np.inf,
-                  'weight': 'cos', 'wvar': 1}
+        kwargs = {'a': 0, 'b': np.inf, 'weight': 'cos', 'wvar': 1}
         res_c = quad(tfunc, complex_func=True, **kwargs)
         res_r = quad(lambda x: np.real(np.exp(1j*x)),
                      complex_func=False,
@@ -530,10 +530,9 @@ class TestQuad:
         np.testing.assert_equal(res_c[0], res_r[0] + 1j*res_i[0])
         np.testing.assert_equal(res_c[1], res_r[1] + 1j*res_i[1])
 
-        assert len(res_c[2]['real']) == len(res_r[2:]) == 3
-        assert res_c[2]['real'][2] == res_r[4]
-        assert res_c[2]['real'][1] == res_r[3]
-        assert res_c[2]['real'][0]['lst'] == res_r[2]['lst']
+        assert res_c.explain['real'] == res_r.explain
+        assert res_c.message['real'] == res_r.message
+        assert res_c.infodict['real']['lst'] == res_r.infodict['lst']
 
         assert len(res_c[2]['imag']) == len(res_i[2:]) == 1
         assert res_c[2]['imag'][0]['lst'] == res_i[2]['lst']

--- a/scipy/integrate/tests/test_quadpack.py
+++ b/scipy/integrate/tests/test_quadpack.py
@@ -234,8 +234,8 @@ class TestQuad:
         def f(x):
             return 1.0
 
-        res_1 = quad(f, 0, 1, weight='alg', wvar=(0, 0), full_output=True)
-        res_2 = quad(f, 1, 0, weight='alg', wvar=(0, 0), full_output=True)
+        res_1 = quad(f, 0, 1, weight='alg', wvar=(0, 0))
+        res_2 = quad(f, 1, 0, weight='alg', wvar=(0, 0))
         err = max(res_1[1], res_2[1])
         assert_allclose(res_1[0], -res_2[0], atol=err)
 
@@ -517,7 +517,7 @@ class TestQuad:
         # to return an error message.  The output is compared
         # against what is returned by explicit integration
         # of the parts.
-        kwargs = {'a': 0, 'b': np.inf, 'full_output': True,
+        kwargs = {'a': 0, 'b': np.inf,
                   'weight': 'cos', 'wvar': 1}
         res_c = quad(tfunc, complex_func=True, **kwargs)
         res_r = quad(lambda x: np.real(np.exp(1j*x)),

--- a/scipy/integrate/tests/test_quadpack.py
+++ b/scipy/integrate/tests/test_quadpack.py
@@ -546,7 +546,7 @@ class TestQuad:
             return x**2 + 1
 
         res = quad(func, 0, 4)
-        
+
         msg = "Use of parameter 'full_output' is deprecated as of SciPy "
         with pytest.deprecated_call(match=msg):
             res2 = quad(func, 0, 4, full_output=0)

--- a/scipy/integrate/tests/test_quadpack.py
+++ b/scipy/integrate/tests/test_quadpack.py
@@ -534,8 +534,7 @@ class TestQuad:
         assert res_c.message['real'] == res_r.message
         assert res_c.infodict['real']['lst'] == res_r.infodict['lst']
 
-        assert len(res_c[2]['imag']) == len(res_i[2:]) == 1
-        assert res_c[2]['imag'][0]['lst'] == res_i[2]['lst']
+        assert res_c.infodict['imag']['lst'] == res_i.infodict['lst']
 
 
 class TestNQuad:

--- a/scipy/stats/_levy_stable/__init__.py
+++ b/scipy/stats/_levy_stable/__init__.py
@@ -272,7 +272,7 @@ def _pdf_single_value_piecewise_post_rounding_Z0(x0, alpha, beta, quad_eps):
             # exp_height = 1 is handled by peak
         ]
         intg_points = [0, peak] + tail_points
-        
+
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=IntegrationWarning)
             intg = integrate.quad(


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
closes #7816
#### What does this implement/fix?
<!--Please explain your changes.-->

Attempts to clean up the rather mind-numbing return behaviour of `quad`.

- Deprecates `full_output` argument
- Returns a bunch results object

There are two parts which could be up for debate:

- `infodict`: This dictionary contains a ton of diagnostic outputs. Currently, I have just made this an attribute of the results object. Instead do we want each entry to be an attribute?
- Return behaviour for complex integrals vs real integrals. The previous behaviour is extremely confusing IMHO.
    - Real & `full_output=0`: the function returns `(integral, abserr)`
    -  Real & `full_output=1`: the function returns `(integral, abserr, real_infodict, real_message, explain)` 
    -  Complex & `full_output=0`: the function returns `(integral, abserr)`
    -  Complex & `full_output=1`: the function returns `(integral, abserr, {"real: (real_infodict, real_message, explain), "imag": (imag_infodict, imag_message, imag_explain)})`

So the function either returned 2,3 or 5 things depending on the combination of inputs!

New behaviour:
- Real: the function returns `QuadResult(integral, abserr, infodict=infodictm, message=message, explain=explain)`
-  Complex: the function returns `QuadResult(integral, abserr, infodict={"real": real_infodict, "imag":imag_infodict}, message={"real": real_message, "imag":imag_message}, explain={"real": real_infodict, "imag":imag_infodict})`

Is this what we want the result to look like or should there be a separate result object for complex integrals?
#### Additional information
<!--Any additional information you think is important.-->
