### PR TITLE
DOC: css adjustment in dark mode and hidden toctree in dev section

### DIFF
--- a/doc/source/_static/scipy.css
+++ b/doc/source/_static/scipy.css
@@ -82,7 +82,7 @@ Nat Methods 8, 441 (2011). https://doi.org/10.1038/nmeth.1618
 .sd-card .sd-card-header {
   border: none;
   background-color:white;
-  color: #150458 !important;
+  color: #150458;
   font-size: var(--pst-font-size-h5);
   font-weight: bold;
   padding: 2.5rem 0rem 0.5rem 0rem;
@@ -149,7 +149,7 @@ html[data-theme=dark] .sd-shadow-sm {
 
 html[data-theme=dark] .sd-card .sd-card-header {
   background-color:var(--pst-color-background);
-  color: #150458 !important;
+  color: var(--sd-color-card-text);
 }
 
 html[data-theme=dark] .sd-card .sd-card-footer {

--- a/doc/source/_templates/sidebar-nav-bs.html
+++ b/doc/source/_templates/sidebar-nav-bs.html
@@ -3,7 +3,7 @@
     {% if pagename.startswith("reference") %}
     {{ generate_nav_html("sidebar", maxdepth=1, collapse=True, includehidden=True, titles_only=True) }}
     {% else %}
-    {{ generate_nav_html("sidebar", maxdepth=2, collapse=True, includehidden=True, titles_only=True) }}
+    {{ generate_nav_html("sidebar", maxdepth=2, collapse=True, titles_only=True) }}
     {% endif %}
   </div>
 </nav>


### PR DESCRIPTION
Related to #18300

Adjust the colour of the card header to use the default text colour:

<img width="500" alt="Screenshot 2023-04-14 at 17 56 09" src="https://user-images.githubusercontent.com/23188539/232094784-e2cb162b-483f-4949-98fc-f7acdc8fcc32.png">

And while I was building the doc I noticed that we were polluting the toctree when outside of the ref section. So I changed the toctree hiding. I did not notice bad behaviours with this change so I think it's ok.

<img width="296" alt="Screenshot 2023-04-14 at 17 56 43" src="https://user-images.githubusercontent.com/23188539/232095187-e9a142b9-6fb8-498b-88aa-0c42e8deb0eb.png">