### PR TITLE
ENH: ndimage: add axes argument to rank_filter, percentile_filter, median_filter

### DIFF
--- a/scipy/ndimage/_filters.py
+++ b/scipy/ndimage/_filters.py
@@ -1200,7 +1200,7 @@ def _min_or_max_filter(input, size, footprint, structure, output, mode,
         origins = _ni_support._normalize_sequence(origin, input.ndim)
         if num_axes < input.ndim:
             if footprint.ndim != num_axes:
-                raise RuntimeError("footprint.ndim must match len(axes)")
+                raise RuntimeError("footprint array has incorrect shape")
             footprint = numpy.expand_dims(
                 footprint,
                 tuple(ax for ax in range(input.ndim) if ax not in axes)
@@ -1368,14 +1368,14 @@ def _rank_filter(input, rank, size=None, footprint=None, output=None,
 
         # insert singleton dimension along any non-filtered axes
         if footprint.ndim != num_axes:
-            raise RuntimeError("footprint.ndim must match len(axes)")
+            raise RuntimeError("footprint array has incorrect shape")
         footprint = numpy.expand_dims(
             footprint,
             tuple(ax for ax in range(input.ndim) if ax not in axes)
         )
     fshape = [ii for ii in footprint.shape if ii > 0]
     if len(fshape) != input.ndim:
-        raise RuntimeError('filter footprint array has incorrect shape.')
+        raise RuntimeError('footprint array has incorrect shape.')
     for origin, lenf in zip(origins, fshape):
         if (lenf // 2 + origin < 0) or (lenf // 2 + origin >= lenf):
             raise ValueError('invalid origin')

--- a/scipy/ndimage/_filters.py
+++ b/scipy/ndimage/_filters.py
@@ -1334,20 +1334,45 @@ def maximum_filter(input, size=None, footprint=None, output=None,
 
 @_ni_docstrings.docfiller
 def _rank_filter(input, rank, size=None, footprint=None, output=None,
-                 mode="reflect", cval=0.0, origin=0, operation='rank'):
+                 mode="reflect", cval=0.0, origin=0, operation='rank',
+                 axes=None):
     if (size is not None) and (footprint is not None):
         warnings.warn("ignoring size because footprint is set", UserWarning, stacklevel=3)
     input = numpy.asarray(input)
     if numpy.iscomplexobj(input):
         raise TypeError('Complex type not supported')
-    origins = _ni_support._normalize_sequence(origin, input.ndim)
+    axes = _ni_support._check_axes(axes, input.ndim)
+    num_axes = len(axes)
+    origins = _ni_support._normalize_sequence(origin, num_axes)
     if footprint is None:
         if size is None:
             raise RuntimeError("no footprint or filter size provided")
-        sizes = _ni_support._normalize_sequence(size, input.ndim)
+        sizes = _ni_support._normalize_sequence(size, num_axes)
         footprint = numpy.ones(sizes, dtype=bool)
     else:
         footprint = numpy.asarray(footprint, dtype=bool)
+    if num_axes < input.ndim:
+        # set origin = 0 for any axes not being filtered
+        origins_temp = [0,] * input.ndim
+        for o, ax in zip(origins, axes):
+            origins_temp[ax] = o
+        origins = origins_temp
+
+        if not isinstance(mode, str) and isinstance(mode, Iterable):
+            # set mode = 'constant' for any axes not being filtered
+            modes = _ni_support._normalize_sequence(mode, num_axes)
+            modes_temp = ['constant'] * input.ndim
+            for m, ax in zip(modes, axes):
+                modes_temp[ax] = m
+            mode = modes_temp
+
+        # insert singleton dimension along any non-filtered axes
+        if footprint.ndim != num_axes:
+            raise RuntimeError("footprint.ndim must match len(axes)")
+        footprint = numpy.expand_dims(
+            footprint,
+            tuple(ax for ax in range(input.ndim) if ax not in axes)
+        )
     fshape = [ii for ii in footprint.shape if ii > 0]
     if len(fshape) != input.ndim:
         raise RuntimeError('filter footprint array has incorrect shape.')
@@ -1375,10 +1400,10 @@ def _rank_filter(input, rank, size=None, footprint=None, output=None,
         raise RuntimeError('rank not within filter footprint size')
     if rank == 0:
         return minimum_filter(input, None, footprint, output, mode, cval,
-                              origins)
+                              origins, axes=None)
     elif rank == filter_size - 1:
         return maximum_filter(input, None, footprint, output, mode, cval,
-                              origins)
+                              origins, axes=None)
     else:
         output = _ni_support._get_output(output, input)
         temp_needed = numpy.may_share_memory(input, output)
@@ -1401,7 +1426,7 @@ def _rank_filter(input, rank, size=None, footprint=None, output=None,
 
 @_ni_docstrings.docfiller
 def rank_filter(input, rank, size=None, footprint=None, output=None,
-                mode="reflect", cval=0.0, origin=0):
+                mode="reflect", cval=0.0, origin=0, *, axes=None):
     """Calculate a multidimensional rank filter.
 
     Parameters
@@ -1415,6 +1440,9 @@ def rank_filter(input, rank, size=None, footprint=None, output=None,
     %(mode_reflect)s
     %(cval)s
     %(origin_multiple)s
+    axes : tuple of int or None, optional
+        If None, `input` is filtered along all axes. Otherwise,
+        `input` is filtered along the specified axes.
 
     Returns
     -------
@@ -1437,12 +1465,12 @@ def rank_filter(input, rank, size=None, footprint=None, output=None,
     """
     rank = operator.index(rank)
     return _rank_filter(input, rank, size, footprint, output, mode, cval,
-                        origin, 'rank')
+                        origin, 'rank', axes=axes)
 
 
 @_ni_docstrings.docfiller
 def median_filter(input, size=None, footprint=None, output=None,
-                  mode="reflect", cval=0.0, origin=0):
+                  mode="reflect", cval=0.0, origin=0, *, axes=None):
     """
     Calculate a multidimensional median filter.
 
@@ -1454,6 +1482,9 @@ def median_filter(input, size=None, footprint=None, output=None,
     %(mode_reflect)s
     %(cval)s
     %(origin_multiple)s
+    axes : tuple of int or None, optional
+        If None, `input` is filtered along all axes. Otherwise,
+        `input` is filtered along the specified axes.
 
     Returns
     -------
@@ -1485,12 +1516,13 @@ def median_filter(input, size=None, footprint=None, output=None,
     >>> plt.show()
     """
     return _rank_filter(input, 0, size, footprint, output, mode, cval,
-                        origin, 'median')
+                        origin, 'median', axes=axes)
 
 
 @_ni_docstrings.docfiller
 def percentile_filter(input, percentile, size=None, footprint=None,
-                      output=None, mode="reflect", cval=0.0, origin=0):
+                      output=None, mode="reflect", cval=0.0, origin=0, *,
+                      axes=None):
     """Calculate a multidimensional percentile filter.
 
     Parameters
@@ -1504,6 +1536,9 @@ def percentile_filter(input, percentile, size=None, footprint=None,
     %(mode_reflect)s
     %(cval)s
     %(origin_multiple)s
+    axes : tuple of int or None, optional
+        If None, `input` is filtered along all axes. Otherwise,
+        `input` is filtered along the specified axes.
 
     Returns
     -------
@@ -1525,7 +1560,7 @@ def percentile_filter(input, percentile, size=None, footprint=None,
     >>> plt.show()
     """
     return _rank_filter(input, percentile, size, footprint, output, mode,
-                        cval, origin, 'percentile')
+                        cval, origin, 'percentile', axes=axes)
 
 
 @_ni_docstrings.docfiller

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -797,6 +797,32 @@ class TestNdimageFilters:
         with pytest.raises(error_class, match=match):
             filter_func(array, *args, axes=axes)
 
+    @pytest.mark.parametrize(
+        'filter_func, kwargs',
+        [(ndimage.minimum_filter, {}),
+         (ndimage.maximum_filter, {}),
+         (ndimage.median_filter, {}),
+         (ndimage.rank_filter, dict(rank=3)),
+         (ndimage.percentile_filter, dict(percentile=30))])
+    @pytest.mark.parametrize(
+        'axes', [(0, ), (1, 2), (0, 1, 2)]
+    )
+    @pytest.mark.parametrize('separable_footprint', [False, True])
+    def test_filter_invalid_footprint_ndim(self, filter_func, kwargs, axes,
+                                           separable_footprint):
+        array = numpy.arange(6 * 8 * 12, dtype=numpy.float64).reshape(6, 8, 12)
+        # create a footprint with one too many dimensions
+        footprint = numpy.ones((3,) * (len(axes) + 1))
+        if not separable_footprint:
+            footprint[(0,) * footprint.ndim] = 0
+        if (filter_func in [ndimage.minimum_filter, ndimage.maximum_filter]
+            and separable_footprint):
+            match = "sequence argument must have length equal to input rank"
+        else:
+            match = "footprint array has incorrect shape"
+        with pytest.raises(RuntimeError, match=match):
+            filter_func(array, **kwargs, footprint=footprint, axes=axes)
+
     @pytest.mark.parametrize('n_mismatch', [1, 3])
     @pytest.mark.parametrize('filter_func, kwargs, key, val',
                              _cases_axes_tuple_length_mismatch())

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -744,12 +744,16 @@ class TestNdimageFilters:
                         mode=['reflect', 'nearest', 'constant'])
     kwargs_other = dict(origin=(-1, 0, 1),
                         mode=['reflect', 'nearest', 'constant'])
+    kwargs_rank = dict(origin=(-1, 0, 1))
 
     @pytest.mark.parametrize("filter_func, size0, size, kwargs",
                              [(ndimage.gaussian_filter, 0, 1.0, kwargs_gauss),
                               (ndimage.uniform_filter, 1, 3, kwargs_other),
                               (ndimage.maximum_filter, 1, 3, kwargs_other),
-                              (ndimage.minimum_filter, 1, 3, kwargs_other)])
+                              (ndimage.minimum_filter, 1, 3, kwargs_other),
+                              (ndimage.median_filter, 1, 3, kwargs_rank),
+                              (ndimage.rank_filter, 1, 3, kwargs_rank),
+                              (ndimage.percentile_filter, 1, 3, kwargs_rank)])
     @pytest.mark.parametrize('axes', itertools.combinations(range(-3, 3), 2))
     def test_filter_axes_kwargs(self, filter_func, size0, size, kwargs, axes):
         array = numpy.arange(6 * 8 * 12, dtype=numpy.float64).reshape(6, 8, 12)
@@ -758,20 +762,34 @@ class TestNdimageFilters:
         axes = numpy.array(axes)
         n_axes = axes.size
 
+        if filter_func == ndimage.rank_filter:
+            args = (2,)  # (rank,)
+        elif filter_func == ndimage.percentile_filter:
+            args = (30,)  # (percentile,)
+        else:
+            args = ()
+
         # form kwargs that specify only the axes in `axes`
         reduced_kwargs = {key: val[axes] for key, val in kwargs.items()}
         if len(set(axes % array.ndim)) != len(axes):
             # parametrized cases with duplicate axes raise an error
             with pytest.raises(ValueError, match="axes must be unique"):
-                filter_func(array, [size]*n_axes, axes=axes, **reduced_kwargs)
+                filter_func(array, *args, [size]*n_axes, axes=axes,
+                            **reduced_kwargs)
             return
 
-        output = filter_func(array, [size]*n_axes, axes=axes, **reduced_kwargs)
+        output = filter_func(array, *args, [size]*n_axes, axes=axes,
+                             **reduced_kwargs)
 
         # result should be equivalent to sigma=0.0/size=1 on unfiltered axes
         size_3d = numpy.full(array.ndim, fill_value=size0)
         size_3d[axes] = size
-        expected = filter_func(array, size_3d, **kwargs)
+        if 'origin' in kwargs:
+            # origin should be zero on the axis that has size 0
+            origin = numpy.array([0, 0, 0])
+            origin[axes] = reduced_kwargs['origin']
+            kwargs['origin'] = origin
+        expected = filter_func(array, *args, size_3d, **kwargs)
         assert_allclose(output, expected)
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
#### Reference issue

see requests/discussion at: https://github.com/scipy/scipy/issues/12997#issuecomment-811268933 and https://github.com/scipy/scipy/issues/16191#issuecomment-1144781807

#### What does this implement/fix?
This PR is a followup to #18261, extending `axes` support to rank filters. These differ slightly from `minimum_filter` and `maximum_filter` in that they take a footprint and cannot be decomposed into 1D filtering along each axis in turn.
- rank_filter
- percentile_filter
- median_filter

I was able to mostly reuse the existing tests, but had to introduce an `extra_args` since a couple of these take another positional argument before the `size` or `sigma` that was present in the prior PR.
