### PR TITLE
CI: move lint job from Azure to GHA

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,49 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - maintenance/**
+  pull_request:
+    branches:
+      - main
+      - maintenance/**
+
+permissions:
+   contents: read  # to fetch code (actions/checkout)
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  test_lint:
+    name: Lint
+    # If using act to run CI locally the github object does not exist and the usual skipping should not be enforced
+    if: "github.repository == 'scipy/scipy' || github.repository == ''"
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        python-version: ['3.11']
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: recursive
+
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install Python packages
+      run: |
+        python -m pip install ruff cython-lint
+
+    - name: Lint
+      run: |
+        set -euo pipefail
+        python tools/lint.py --diff-against origin/$(GITHUB_BASE_REF)
+        python tools/unicode-check.py
+        python tools/check_test_name.py

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,6 +44,6 @@ jobs:
     - name: Lint
       run: |
         set -euo pipefail
-        python tools/lint.py --diff-against origin/$(GITHUB_BASE_REF)
+        python tools/lint.py --diff-against origin/$GITHUB_BASE_REF
         python tools/unicode-check.py
         python tools/check_test_name.py

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -133,32 +133,7 @@ stages:
         test_mode: fast
         numpy_spec: "numpy==1.21.6"
         use_wheel: true
-  - job: Lint
-    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/main'))  # skip for PR merges
-    pool:
-      vmImage: 'ubuntu-22.04'
-    steps:
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '3.9'
-        addToPath: true
-        architecture: 'x64'
-    - script: >-
-        python -m pip install ruff cython-lint
-      displayName: 'Install tools'
-      failOnStderr: false
-    - script: |
-        set -euo pipefail
-        # for Travis CI we used to do: git fetch --unshallow
-        # but apparently Azure clones are not as shallow
-        # so does not appear to be needed to fetch maintenance
-        # branches (which Azure logs show being checked out
-        # in Checkout stage)
-        python tools/lint.py --diff-against origin/$(System.PullRequest.TargetBranch)
-        tools/unicode-check.py
-        tools/check_test_name.py
-      displayName: 'Run Lint Checks'
-      failOnStderr: true
+
   - job: Linux_Python_39_32bit_full
     timeoutInMinutes: 90
     condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/main'))  # skip for PR merges


### PR DESCRIPTION
As the title says. Things to ask the reviewer are:

- [x] when should the job run? At the moment it's on pushes to maintenance and on PRs to main/maintenance.
- [x] is the `diff-against` flag correct? The documentation for `GITHUB_REF` is at https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables.

Completes one of the jobs in https://github.com/scipy/scipy/issues/15814#issuecomment-1506516709.