### PR TITLE
CI: move gcc-8 test to GHA 

### DIFF
--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -228,7 +228,7 @@ jobs:
         run: |
           pip install "numpy==1.21.6" &&
           # build deps
-          pip install build meson-python ninja pythran pybind11 cython
+          pip install build meson-python ninja pythran pybind11 cython wheel
           # test deps
           pip install gmpy2 threadpoolctl mpmath pooch pythran pybind11 pytest pytest-xdist==2.5.0 pytest-timeout
 

--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -222,17 +222,15 @@ jobs:
           sudo apt-get -y update
           sudo apt install -y g++-8 gcc-8 gfortran-8
           sudo apt install -y libatlas-base-dev liblapack-dev libgmp-dev \
-            libmpfr-dev libmpc-dev pkg-config libsuitesparse-dev
-
-          # install openblas
-          chmod +x tools/wheels/cibw_before_build_linux.sh
-          sudo tools/wheels/cibw_before_build_linux.sh .
+            libmpfr-dev libmpc-dev pkg-config libsuitesparse-dev liblapack-dev
 
       - name: Setup Python deps
         run: |
-          pip install --upgrade "numpy==1.21.6" &&
-          pip install --upgrade pip setuptools==59.6.0 wheel build meson meson-python ninja &&
-          pip install "cython<3.0b1" gmpy2 threadpoolctl mpmath pooch pythran pybind11 pytest pytest-xdist==2.5.0 pytest-timeout
+          pip install "numpy==1.21.6" &&
+          # build deps
+          pip install build meson-python ninja pythran pybind11 cython
+          # test deps
+          pip install gmpy2 threadpoolctl mpmath pooch pythran pybind11 pytest pytest-xdist==2.5.0 pytest-timeout
 
       - name: Build wheel and install
         run: |
@@ -240,15 +238,13 @@ jobs:
           export PYTHONOPTIMIZE=2
 
           # specify which compilers to use using environment variables
-          CC=gcc-8 CXX=g++-8 FC=gfortran-8 python -m build --no-isolation
-          pip install dist/scipy*.whl
+          CC=gcc-8 CXX=g++-8 FC=gfortran-8 python -m build --wheel --no-isolation -Csetup-args=-Dblas=blas-atlas -Csetup-args=-Dlapack=lapack-atlas -Ccompile-args=-j2
+          python -m pip install dist/scipy*.whl
 
       - name: Run tests
         run: |
-          export PYTHONOPTIMIZE=2
-          set -xeuo pipefail
-
           # can't be in source directory
           pushd $RUNNER_TEMP
-          bash $GITHUB_WORKSPACE/tools/wheels/cibw_test_command.sh $GITHUB_WORKSPACE
+          export PYTHONOPTIMIZE=2
+          python -m pytest --pyargs scipy -n2 --durations=10
           popd

--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -120,6 +120,7 @@ jobs:
         export SCIPY_USE_PROPACK=1
         python dev.py --no-build test -j 2 -- --durations 10 --timeout=60
 
+  #################################################################################
   test_venv_install:
     name: Pip install into venv
     if: "github.repository == 'scipy/scipy' || github.repository == ''"
@@ -174,6 +175,7 @@ jobs:
         python -c "import scipy.linalg"
         python -c "from scipy import cluster; cluster.test()"
 
+  #################################################################################
   python_debug:
     name: Python-debug & ATLAS
     if: "github.repository == 'scipy/scipy' || github.repository == ''"
@@ -198,3 +200,55 @@ jobs:
           cd doc
           python3-dbg -m pip install pytest pytest-xdist pytest-timeout mpmath gmpy2 threadpoolctl pooch
           python3-dbg -m pytest --pyargs scipy -n2 --durations=10 -m "not slow"
+
+  #################################################################################
+  gcc8:
+    # Purpose is to examine builds with oldest-supported gcc.
+    name: Build with gcc-8
+    if: "github.repository == 'scipy/scipy' || github.repository == ''"
+    runs-on: ubuntu-20.04  # 22.04 doesn't support gcc-8
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+
+      - name: Setup OS
+        run: |
+          sudo apt-get -y update
+          sudo apt install -y g++-8 gcc-8 gfortran-8
+          sudo apt install -y libatlas-base-dev liblapack-dev libgmp-dev \
+            libmpfr-dev libmpc-dev pkg-config libsuitesparse-dev
+
+          # install openblas
+          chmod +x tools/wheels/cibw_before_build_linux.sh
+          sudo tools/wheels/cibw_before_build_linux.sh .
+
+      - name: Setup Python deps
+        run: |
+          pip install --upgrade "numpy==1.21.6" &&
+          pip install --upgrade pip setuptools==59.6.0 wheel build meson meson-python ninja &&
+          pip install "cython<3.0b1" gmpy2 threadpoolctl mpmath pooch pythran pybind11 pytest pytest-xdist==2.5.0 pytest-timeout
+
+      - name: Build wheel and install
+        run: |
+          set -euo pipefail
+          export PYTHONOPTIMIZE=2
+
+          # specify which compilers to use using environment variables
+          CC=gcc-8 CXX=g++-8 FC=gfortran-8 python -m build --no-isolation
+          pip install dist/scipy*.whl
+
+      - name: Run tests
+        run: |
+          export PYTHONOPTIMIZE=2
+          set -xeuo pipefail
+
+          # can't be in source directory
+          pushd $RUNNER_TEMP
+          bash $GITHUB_WORKSPACE/tools/wheels/cibw_test_command.sh $GITHUB_WORKSPACE
+          popd

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -104,35 +104,6 @@ stages:
         test_mode: fast
         numpy_spec: "numpy==1.21.6"
         use_sdist: true
-  - job: wheel_optimized_gcc8
-    timeoutInMinutes: 90
-    pool:
-      vmImage: 'ubuntu-20.04'  # 22.04 does not have gfortran-8
-    variables:
-      # The following is needed for optimized "-OO" test run but since we use
-      # pytest-xdist plugin for load scheduling its workers don't pick up the
-      # flag. This environment variable starts all Py instances in -OO mode.
-      PYTHONOPTIMIZE: 2
-      # Use gcc version 6
-      CC: gcc-8
-      CXX: g++-8
-      FC: gfortran-8
-    steps:
-    - script: |
-        set -euo pipefail
-        sudo apt update -y
-        sudo apt install -y g++-8 gcc-8 gfortran-8
-      displayName: 'Install GCC 8'
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '3.9'
-        addToPath: true
-        architecture: 'x64'
-    - template: ci/azure-travis-template.yaml
-      parameters:
-        test_mode: fast
-        numpy_spec: "numpy==1.21.6"
-        use_wheel: true
   - job: Lint
     condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/main'))  # skip for PR merges
     pool:


### PR DESCRIPTION
As the title says. I've tried to keep the test doing exactly what Azure was doing, but building the wheel with meson instead of setup.py.

Completes one of the jobs in https://github.com/scipy/scipy/issues/15814#issuecomment-1506516709.