### PR TITLE
CI: remove scikit-umfpack/sparse from Azure testing

### DIFF
--- a/ci/azure-travis-template.yaml
+++ b/ci/azure-travis-template.yaml
@@ -79,13 +79,7 @@ steps:
     pytest-timeout
   displayName: 'Install common python dependencies'
 - ${{ if eq(parameters.test_mode, 'full') }}:
-  - script: >-
-      pip install matplotlib pooch &&
-      pip install scikit-umfpack scikit-sparse --no-deps --no-build-isolation
-      # The above two scikits both depend on scipy, so use `--no-deps`
-      # Also note that they don't provide wheels, so we build them from
-      # source (only in this job, it's a small optional dependency so test
-      # only in a single place)
+  - script: pip install matplotlib pooch
     displayName: 'Install full mode optional dependencies'
 - ${{ if eq(parameters.coverage, true) }}:
   - script: pip install pytest-cov coverage


### PR DESCRIPTION
It's tested in the macOS tests on GitHub Actions, where we get these scikits from conda-forge. So no need to build them from source in Azure.

This just broke in CI with an error about numpy version parsing - perhaps related to the `pip` 23.1 release which changed legacy `setup.py` handling. Either way, we don't need to be building from source here if we are already pulling a suitable binary from conda-forge in another job.

Traceback this fixes (from [this log](https://dev.azure.com/scipy-org/SciPy/_build/results?buildId=24336&view=logs&j=7902a2c1-7b88-5b2d-6408-84b88759c642&t=558aec83-6cd1-53dc-3da1-588b98ee33f8)) ends in:
```
wheel.vendored.packaging._tokenizer.ParserSyntaxError: Expected end or semicolon (after version specifier)
          numpy>=1.25.0.dev0+1126.gd2ae0e759
```

Full traceback:

<details>

```
      writing manifest file 'scikit_umfpack.egg-info/SOURCES.txt'
      /opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/site-packages/setuptools/command/egg_info.py:624: SetuptoolsDeprecationWarning: Custom 'build_py' does not implement 'get_data_files_without_manifest'.
      Please extend command classes from setuptools instead of distutils.
        warnings.warn(
      reading manifest file 'scikit_umfpack.egg-info/SOURCES.txt'
      reading manifest template 'MANIFEST.in'
      adding license file 'LICENSE'
      writing manifest file 'scikit_umfpack.egg-info/SOURCES.txt'
      Copying scikit_umfpack.egg-info to build/bdist.linux-x86_64/wheel/scikit_umfpack-0.3.3-py3.9.egg-info
      running install_scripts
      Traceback (most recent call last):
        File "/opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/site-packages/wheel/vendored/packaging/requirements.py", line 35, in __init__
          parsed = parse_requirement(requirement_string)
        File "/opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/site-packages/wheel/vendored/packaging/_parser.py", line 64, in parse_requirement
          return _parse_requirement(Tokenizer(source, rules=DEFAULT_RULES))
        File "/opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/site-packages/wheel/vendored/packaging/_parser.py", line 82, in _parse_requirement
          url, specifier, marker = _parse_requirement_details(tokenizer)
        File "/opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/site-packages/wheel/vendored/packaging/_parser.py", line 126, in _parse_requirement_details
          marker = _parse_requirement_marker(
        File "/opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/site-packages/wheel/vendored/packaging/_parser.py", line 147, in _parse_requirement_marker
          tokenizer.raise_syntax_error(
        File "/opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/site-packages/wheel/vendored/packaging/_tokenizer.py", line 163, in raise_syntax_error
          raise ParserSyntaxError(
      wheel.vendored.packaging._tokenizer.ParserSyntaxError: Expected end or semicolon (after version specifier)
          numpy>=1.25.0.dev0+1126.gd2ae0e759
```

</details>