### PR TITLE
MAINT: Mark function pointer ctypedefs as noexcept

### DIFF
--- a/scipy/cluster/_hierarchy_distance_update.pxi
+++ b/scipy/cluster/_hierarchy_distance_update.pxi
@@ -24,7 +24,7 @@ d_xyi : double
 """
 ctypedef double (*linkage_distance_update)(double d_xi, double d_yi,
                                            double d_xy, int size_x,
-                                           int size_y, int size_i)
+                                           int size_y, int size_i) noexcept
 
 
 cdef double _single(double d_xi, double d_yi, double d_xy,

--- a/scipy/optimize/cython_optimize/_zeros.pxd
+++ b/scipy/optimize/cython_optimize/_zeros.pxd
@@ -4,7 +4,7 @@
 # should be made to this file** --- any API additions/changes should be
 # done in `cython_optimize.pxd` (see gh-11793).
 
-ctypedef double (*callback_type)(double, void*)
+ctypedef double (*callback_type)(double, void*) noexcept
 
 ctypedef struct zeros_parameters:
     callback_type function

--- a/scipy/stats/_qmc_cy.pyx
+++ b/scipy/stats/_qmc_cy.pyx
@@ -290,7 +290,7 @@ cdef double c_update_discrepancy(double[::1] x_new_view,
 
 
 ctypedef double (*func_type)(double[:, ::1], Py_ssize_t,
-                             Py_ssize_t) nogil
+                             Py_ssize_t) noexcept nogil
 
 
 cdef double threaded_loops(func_type loop_func,

--- a/scipy/stats/_unuran/unuran_wrapper.pyx
+++ b/scipy/stats/_unuran/unuran_wrapper.pyx
@@ -58,7 +58,7 @@ class UNURANError(RuntimeError):
     pass
 
 
-ctypedef double (*URNG_FUNCT)(void *) nogil
+ctypedef double (*URNG_FUNCT)(void *) noexcept nogil
 
 cdef object get_numpy_rng(object seed = None):
     """


### PR DESCRIPTION

#### Reference issue
Part of https://github.com/scipy/scipy/issues/17234

#### What does this implement/fix?
This PR explicitly declare ctypedef of pointer to function as `noexcept`. This is part of migration to Cython 3, since Cython 3 changes default behavior of exception handling.

#### Additional information
This functionality requires at least Cython 0.29.31 or Cython 3.0b1
This is continuation of #18266 
