### PR TITLE
CI: migrate ref guide-check to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,7 +169,7 @@ jobs:
       - apt-install
 
       - run:
-          name: build docs
+          name: refguide_check
           no_output_timeout: 25m
           command: |
             sudo apt-get install -y wamerican-small

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,6 +158,24 @@ jobs:
           path: benchmarks/html
           destination: html-benchmarks
 
+# Reference guide checking
+  refguide_check:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/
+
+      - check-skip
+      - apt-install
+
+      - run:
+          name: build docs
+          no_output_timeout: 25m
+          command: |
+            sudo apt-get install -y wamerican-small
+            export PYTHONPATH=$PWD/build-install/lib/python3.9/site-packages
+            python dev.py --no-build refguide-check
+
 # Upload build output to scipy/devdocs repository, using SSH deploy keys.
 # The keys are only available for builds on main branch.
 # https://developer.github.com/guides/managing-deploy-keys/
@@ -203,6 +221,9 @@ workflows:
           requires:
             - build_scipy
       - run_benchmarks:
+          requires:
+            - build_scipy
+      - refguide_check:
           requires:
             - build_scipy
       - deploy:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,22 +55,6 @@ stages:
   variables:
     AZURE_CI: 'true'
   jobs:
-  - job: refguide_check
-    timeoutInMinutes: 90
-    pool:
-      vmImage: 'ubuntu-22.04'
-    steps:
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '3.9'
-        addToPath: true
-        architecture: 'x64'
-    - template: ci/azure-travis-template.yaml
-      parameters:
-        test_mode: fast
-        numpy_spec: "numpy==1.23.5"
-        refguide_check: true
-        use_wheel: true
   - job: source_distribution
     timeoutInMinutes: 90
     pool:

--- a/ci/azure-travis-template.yaml
+++ b/ci/azure-travis-template.yaml
@@ -11,9 +11,6 @@ parameters:
 - name: coverage
   type: boolean
   default: false
-- name: refguide_check
-  type: boolean
-  default: false
 - name: use_wheel
   type: boolean
   default: false
@@ -84,11 +81,6 @@ steps:
 - ${{ if eq(parameters.coverage, true) }}:
   - script: pip install pytest-cov coverage
     displayName: 'Install coverage dependencies'
-- ${{ if eq(parameters.refguide_check, true) }}:
-  - script: pip install matplotlib sphinx numpydoc pooch
-    displayName: 'Install documentation dependencies'
-  - script: sudo apt-get install -y wamerican-small
-    displayName: 'Install word list (for csgraph tutorial)'
 - script: pip uninstall -y nose
   displayName: 'Uninstall Nose'
 - script: git submodule update --init
@@ -147,9 +139,6 @@ steps:
   ${{ if eq(parameters.coverage, false) }}:
     condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/main'))  # skip for PR merges
   displayName: 'Run tests'
-- ${{ if and(ne(variables['Build.SourceBranch'], 'refs/heads/main'), eq(parameters.refguide_check, true)) }}:
-  - script: python runtests.py -g --refguide-check
-    displayName: 'Refguide Check'
 - script: ./tools/check_pyext_symbol_hiding.sh build
   displayName: "Check dynamic symbol hiding works"
   condition: ne(variables['Build.SourceBranch'], 'refs/heads/main')

--- a/doc/source/dev/contributor/continuous_integration.rst
+++ b/doc/source/dev/contributor/continuous_integration.rst
@@ -38,6 +38,10 @@ GitHub Actions
 * ``macOS Tests``: test suite runs for macOS (``x86_64``)
 * ``wheels``: builds wheels for SciPy releases as well as *nightly* builds.
 * ``Check the rendered docs here!``: live preview of the documentation
+* ``prerelease_deps_coverage_64bit_blas``: use pre-released version of the
+  dependencies and check coverage
+* ``gcc-8``: build with minimal supported version of GCC, install the wheel,
+  then run the test suite with `python -OO`
 
 The test suite runs on GitHub Actions and other platforms cover a range of
 test/environment conditions: Python and NumPy versions
@@ -48,29 +52,20 @@ Azure
 -----
 * ``Windows Python``: test suite runs for Windows
 * ``Linux_Python_xx_32bit_full``: 32-bit Linux
-* ``wheel_optimized_gcc``: install the wheel, then run the test suite with
-  `python -OO`
 * ``source_distribution``: install via ``sdist``, then run the test suite
-* ``refguide_check``: doctests from examples and benchmarks
-* ``prerelease_deps_coverage_64bit_blas``: use pre-released version of the
-  dependencies and check coverage
 
 CircleCI
 --------
 * ``build_docs``: build the documentation
 * ``build_scipy``
 * ``run_benchmarks``: verify how the changes impact performance
+* ``refguide_check``: doctests from examples and benchmarks
 
 CirrusCI
 --------
 * ``Tests``: test suite for specific architecture like
   ``musllinux, arm, aarch``
 * ``Wheels``: build and upload some wheels
-
-Codecov
--------
-* ``patch``: the impact on code coverage due to your changes
-* ``project``: the coverage of the whole project
 
 .. _skip-ci:
 


### PR DESCRIPTION
Part of https://github.com/scipy/scipy/issues/15814#issuecomment-1506516709

Migrate the reference guide check to CircleCI to have doc related jobs aside.

It would be good to migrate the asv job to GH action. This way doc PR can just ask to run CircleCI.