### PR TITLE
CI: move Azure cp39/full/win job to GHA

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -97,7 +97,7 @@ jobs:
           choco install rtools --no-progress
           echo "c:\rtools40\ucrt64\bin;" >> $env:GITHUB_PATH
 
-      - name: Install OpenBlas
+      - name: Install OpenBLAS
         shell: bash
         run: |
           set -xe
@@ -112,11 +112,11 @@ jobs:
 
       - name: Build
         run: |
-          $env:SCIPY_USE_PYTHRAN=1
+          # TODO: remove the build-dir and install-prefix flags once dev.py
+          # supplies meson with absolute paths. This is due to a pathlib bug
+          # on cp39-win.
           python dev.py --build-dir=$pwd\build --install-prefix=$pwd\build-install build -j 2 --win-cp-openblas
-          cd build
-          meson install
-          cd ..
+          meson install -C build
           cp C:\opt\64\bin\*.dll $pwd\build-install\Lib\site-packages\scipy\.libs\
           python tools\openblas_support.py --write-init $PWD\build-install\Lib\site-packages\scipy\
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,4 +1,4 @@
-name: Windows Meson tests
+name: Windows tests
 
 on:
   push:
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   test:
-    name: Meson Windows tests
+    name: cp39 (meson) fast
     # Ensure (a) this doesn't run on forks by default, and
     #        (b) it does run with Act locally (`github` doesn't exist there)
     if: "github.repository == 'scipy/scipy' || github.repository == ''"
@@ -46,15 +46,13 @@ jobs:
       - name: pip-packages
         run: |
           pip install numpy==1.22.2 cython pybind11 pythran meson ninja pytest pytest-xdist pytest-timeout pooch rich_click click doit pydevtool
-      - name: openblas-libs
+      - name: Install OpenBlas
+        shell: bash
         run: |
-          # Download and install pre-built OpenBLAS library
-          # Built with mingw-w64, -ucrt -static.
-          # https://github.com/matthew-brett/openblas-libs/blob/ucrt-build/build_openblas.ps1
-          choco install wget unzip -y --no-progress
-          wget -q https://anaconda.org/multibuild-wheels-staging/openblas-libs/v0.3.20-571-g3dec11c6/download/openblas-v0.3.20-571-g3dec11c6-win_amd64-gcc_10_3_0.zip
-          unzip -d c:\opt openblas-v0.3.20-571-g3dec11c6-win_amd64-gcc_10_3_0.zip
-          echo "PKG_CONFIG_PATH=c:\opt\64\lib\pkgconfig;" >> $env:GITHUB_ENV
+          # same OpenBLAS install method as cibuildwheel
+          set -xe
+          bash tools/wheels/cibw_before_build_win.sh .
+          echo "PKG_CONFIG_PATH=c:\opt\64\lib\pkgconfig;" >> $GITHUB_ENV
       - name: build
         run: |
           echo "SCIPY_USE_PROPACK=1" >> $env:GITHUB_ENV
@@ -77,9 +75,9 @@ jobs:
 
 
   #############################################################################
-  full_dev_py_minin:
-    name: dev_py-full-minimum_supported_numpy
-    if: "github.repository == 'andyfaff/scipy' || github.repository == ''"
+  full_dev_py_min_numpy:
+    name: cp39 (meson) full, dev.py, minimum numpy
+    if: "github.repository == 'scipy/scipy' || github.repository == ''"
     runs-on: windows-2019
     steps:
       - name: Checkout
@@ -114,12 +112,12 @@ jobs:
 
       - name: Build
         run: |
+          $env:SCIPY_USE_PYTHRAN=1
           python dev.py --build-dir=$pwd\build --install-prefix=$pwd\build-install build -j 2 --win-cp-openblas
           cd build
           meson install
           cd ..
           cp C:\opt\64\bin\*.dll $pwd\build-install\Lib\site-packages\scipy\.libs\
-          echo "PYTHONPATH=$PWD\build-install\Lib\site-packages" >> $env:GITHUB_ENV
           python tools\openblas_support.py --write-init $PWD\build-install\Lib\site-packages\scipy\
 
       - name: Test

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -74,3 +74,54 @@ jobs:
           Get-ChildItem env:
           cd $env:PYTHONPATH
           python -c "import sys; import scipy; sys.exit(not scipy.test())"
+
+
+  #############################################################################
+  full_dev_py_minin:
+    name: dev_py-full-minimum_supported_numpy
+    if: "github.repository == 'andyfaff/scipy' || github.repository == ''"
+    runs-on: windows-2019
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          cache: 'pip'
+          cache-dependency-path: 'environment.yml'
+
+      - name: Win_amd64 - install rtools
+        run: |
+          # mingw-w64
+          choco install rtools --no-progress
+          echo "c:\rtools40\ucrt64\bin;" >> $env:GITHUB_PATH
+
+      - name: Install OpenBlas
+        shell: bash
+        run: |
+          set -xe
+          bash tools/wheels/cibw_before_build_win.sh .
+          echo "PKG_CONFIG_PATH=c:\opt\64\lib\pkgconfig;" >> $GITHUB_ENV
+
+      - name: pip-packages
+        run: |
+          # 1.22.3 is currently the oldest numpy usable on cp3.9 according
+          # to pyproject.toml
+          python -m pip install numpy==1.22.3 cython pybind11 pythran meson-python meson ninja pytest pytest-xdist pytest-timeout pooch rich_click click doit pydevtool
+
+      - name: Build
+        run: |
+          python dev.py --build-dir=$pwd\build --install-prefix=$pwd\build-install build -j 2 --win-cp-openblas
+          cd build
+          meson install
+          cd ..
+          cp C:\opt\64\bin\*.dll $pwd\build-install\Lib\site-packages\scipy\.libs\
+          echo "PYTHONPATH=$PWD\build-install\Lib\site-packages" >> $env:GITHUB_ENV
+          python tools\openblas_support.py --write-init $PWD\build-install\Lib\site-packages\scipy\
+
+      - name: Test
+        run: |
+          python dev.py test -j2 --mode full

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   test:
-    name: cp39 (meson) fast
+    name: cp310 (meson) fast
     # Ensure (a) this doesn't run on forks by default, and
     #        (b) it does run with Act locally (`github` doesn't exist there)
     if: "github.repository == 'scipy/scipy' || github.repository == ''"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -130,12 +130,6 @@ stages:
             TEST_MODE: fast
             BITS: 32
             SCIPY_USE_PYTHRAN: 1
-          Python39-64bit-full:
-            PYTHON_VERSION: '3.9'
-            PYTHON_ARCH: 'x64'
-            TEST_MODE: full
-            BITS: 64
-            SCIPY_USE_PYTHRAN: 0
           Python311-64bit-full-ilp64:
             PYTHON_VERSION: '3.11'
             PYTHON_ARCH: 'x64'


### PR DESCRIPTION
Completes the first item of https://github.com/scipy/scipy/issues/15814#issuecomment-1515076563. I selected to use Pythran because the other GHA windows job doesn't use it.