### PR TITLE
MAINT: optimize.milp: improve behavior for unexpected sparse input

### DIFF
--- a/scipy/optimize/_constraints.py
+++ b/scipy/optimize/_constraints.py
@@ -134,7 +134,7 @@ class LinearConstraint:
     ----------
     A : {array_like, sparse matrix}, shape (m, n)
         Matrix defining the constraint.
-    lb, ub : array_like, optional
+    lb, ub : dense array_like, optional
         Lower and upper limits on the constraint. Each array must have the
         shape (m,) or be a scalar, in the latter case a bound will be the same
         for all components of the constraint. Use ``np.inf`` with an
@@ -144,7 +144,7 @@ class LinearConstraint:
         interval, one-sided or equality, by setting different components of
         `lb` and `ub` as  necessary. Defaults to ``lb = -np.inf``
         and ``ub = np.inf`` (no limits).
-    keep_feasible : array_like of bool, optional
+    keep_feasible : dense array_like of bool, optional
         Whether to keep the constraint components feasible throughout
         iterations. A single value set this property for all components.
         Default is False. Has no effect for equality constraints.
@@ -176,8 +176,13 @@ class LinearConstraint:
                 self.A = np.atleast_2d(A).astype(np.float64)
         else:
             self.A = A
+        if issparse(lb) or issparse(ub):
+            raise ValueError("Constraint limits must be dense arrays.")
         self.lb = np.atleast_1d(lb).astype(np.float64)
         self.ub = np.atleast_1d(ub).astype(np.float64)
+
+        if issparse(keep_feasible):
+            raise ValueError("`keep_feasible` must be a dense array.")
         self.keep_feasible = np.atleast_1d(keep_feasible).astype(bool)
         self._input_validation()
 
@@ -224,7 +229,7 @@ class Bounds:
 
     Parameters
     ----------
-    lb, ub : array_like, optional
+    lb, ub : dense array_like, optional
         Lower and upper bounds on independent variables. `lb`, `ub`, and
         `keep_feasible` must be the same shape or broadcastable.
         Set components of `lb` and `ub` equal
@@ -233,7 +238,7 @@ class Bounds:
         different types: interval, one-sided or equality, by setting different
         components of `lb` and `ub` as necessary. Defaults to ``lb = -np.inf``
         and ``ub = np.inf`` (no bounds).
-    keep_feasible : array_like of bool, optional
+    keep_feasible : dense array_like of bool, optional
         Whether to keep the constraint components feasible throughout
         iterations. Must be broadcastable with `lb` and `ub`.
         Default is False. Has no effect for equality constraints.
@@ -247,8 +252,13 @@ class Bounds:
             raise ValueError(message)
 
     def __init__(self, lb=-np.inf, ub=np.inf, keep_feasible=False):
+        if issparse(lb) or issparse(ub):
+            raise ValueError("Lower and upper bounds must be dense arrays.")
         self.lb = np.atleast_1d(lb)
         self.ub = np.atleast_1d(ub)
+
+        if issparse(keep_feasible):
+            raise ValueError("`keep_feasible` must be a dense array.")
         self.keep_feasible = np.atleast_1d(keep_feasible).astype(bool)
         self._input_validation()
 

--- a/scipy/optimize/_milp.py
+++ b/scipy/optimize/_milp.py
@@ -1,6 +1,6 @@
 import warnings
 import numpy as np
-from scipy.sparse import csc_array, vstack
+from scipy.sparse import csc_array, vstack, issparse
 from ._highs._highs_wrapper import _highs_wrapper  # type: ignore[import]
 from ._constraints import LinearConstraint, Bounds
 from ._optimize import OptimizeResult
@@ -74,6 +74,8 @@ def _constraints_to_components(constraints):
 
 def _milp_iv(c, integrality, bounds, constraints, options):
     # objective IV
+    if issparse(c):
+        raise ValueError("`c` must be a dense array.")
     c = np.atleast_1d(c).astype(np.double)
     if c.ndim != 1 or c.size == 0 or not np.all(np.isfinite(c)):
         message = ("`c` must be a one-dimensional array of finite numbers "
@@ -81,6 +83,8 @@ def _milp_iv(c, integrality, bounds, constraints, options):
         raise ValueError(message)
 
     # integrality IV
+    if issparse(integrality):
+        raise ValueError("`integrality` must be a dense array.")
     message = ("`integrality` must contain integers 0-3 and be broadcastable "
                "to `c.shape`.")
     if integrality is None:
@@ -181,11 +185,11 @@ def milp(c, *, integrality=None, bounds=None, constraints=None, options=None):
 
     Parameters
     ----------
-    c : 1D array_like
+    c : 1D dense array_like
         The coefficients of the linear objective function to be minimized.
         `c` is converted to a double precision array before the problem is
         solved.
-    integrality : 1D array_like, optional
+    integrality : 1D dense array_like, optional
         Indicates the type of integrality constraint on each decision variable.
 
         ``0`` : Continuous variable; no integrality constraint.

--- a/scipy/optimize/tests/test_constraints.py
+++ b/scipy/optimize/tests/test_constraints.py
@@ -198,6 +198,16 @@ class TestBounds:
         assert b1.ub == b2.ub
 
     def test_input_validation(self):
+        message = "Lower and upper bounds must be dense arrays."
+        with pytest.raises(ValueError, match=message):
+            Bounds(sps.coo_array([1, 2]), [1, 2])
+        with pytest.raises(ValueError, match=message):
+            Bounds([1, 2], sps.coo_array([1, 2]))
+
+        message = "`keep_feasible` must be a dense array."
+        with pytest.raises(ValueError, match=message):
+            Bounds([1, 2], [1, 2], keep_feasible=sps.coo_array([True, True]))
+
         message = "`lb`, `ub`, and `keep_feasible` must be broadcastable."
         with pytest.raises(ValueError, match=message):
             Bounds([1, 2], [1, 2, 3])
@@ -221,6 +231,17 @@ class TestLinearConstraint:
         message = "`lb`, `ub`, and `keep_feasible` must be broadcastable"
         with pytest.raises(ValueError, match=message):
             LinearConstraint(A, [1, 2], [1, 2, 3])
+
+        message = "Constraint limits must be dense arrays"
+        with pytest.raises(ValueError, match=message):
+            LinearConstraint(A, sps.coo_array([1, 2]), [2, 3])
+        with pytest.raises(ValueError, match=message):
+            LinearConstraint(A, [1, 2], sps.coo_array([2, 3]))
+
+        message = "`keep_feasible` must be a dense array"
+        with pytest.raises(ValueError, match=message):
+            keep_feasible = sps.coo_array([True, True])
+            LinearConstraint(A, [1, 2], [2, 3], keep_feasible=keep_feasible)
 
         A = np.empty((4, 3, 5))
         message = "`A` must have exactly two dimensions."

--- a/scipy/optimize/tests/test_milp.py
+++ b/scipy/optimize/tests/test_milp.py
@@ -9,9 +9,14 @@ import pytest
 
 from .test_linprog import magic_square
 from scipy.optimize import milp, Bounds, LinearConstraint
+from scipy import sparse
 
 
 def test_milp_iv():
+
+    message = "`c` must be a dense array"
+    with pytest.raises(ValueError, match=message):
+        milp(sparse.coo_array([0, 0]))
 
     message = "`c` must be a one-dimensional array of finite numbers with"
     with pytest.raises(ValueError, match=message):
@@ -30,10 +35,16 @@ def test_milp_iv():
         milp(1, constraints=10)
     with pytest.raises(ValueError, match=re.escape(message)):
         milp(np.zeros(3), constraints=([[1, 2, 3]], [2, 3], [2, 3]))
+    with pytest.raises(ValueError, match=re.escape(message)):
+        milp(np.zeros(2), constraints=([[1, 2]], [2], sparse.coo_array([2])))
 
     message = "The shape of `A` must be (len(b_l), len(c))."
     with pytest.raises(ValueError, match=re.escape(message)):
         milp(np.zeros(3), constraints=([[1, 2]], [2], [2]))
+
+    message = "`integrality` must be a dense array"
+    with pytest.raises(ValueError, match=message):
+        milp([1, 2], integrality=sparse.coo_array([1, 2]))
 
     message = ("`integrality` must contain integers 0-3 and be broadcastable "
                "to `c.shape`.")
@@ -41,6 +52,10 @@ def test_milp_iv():
         milp([1, 2, 3], integrality=[1, 2])
     with pytest.raises(ValueError, match=message):
         milp([1, 2, 3], integrality=[1, 5, 3])
+
+    message = "Lower and upper bounds must be dense arrays."
+    with pytest.raises(ValueError, match=message):
+        milp([1, 2, 3], bounds=([1, 2], sparse.coo_array([3, 4])))
 
     message = "`lb`, `ub`, and `keep_feasible` must be broadcastable."
     with pytest.raises(ValueError, match=message):
@@ -128,6 +143,7 @@ def test_milp_1():
     # solve magic square problem
     n = 3
     A, b, c, numbers, M = magic_square(n)
+    A = sparse.csc_array(A)  # confirm that sparse arrays are accepted
     res = milp(c=c*0, constraints=(A, b, b), bounds=(0, 1), integrality=1)
 
     # check that solution is a magic square


### PR DESCRIPTION
#### Reference issue
Closes gh-18326

#### What does this implement/fix?
gh-18326 reported a confusing error message when sparse input is provided for `milp` arguments that are supposed to be dense. This improves the error message and clarifies the documentation.