### PR TITLE
MAINT: stats.shapiro: override p-value when len(x)==3

### DIFF
--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1881,6 +1881,10 @@ def shapiro(x):
     if N > 5000:
         warnings.warn("p-value may not be accurate for N > 5000.")
 
+    # `swilk` can return negative p-values for N==3; see gh-18322.
+    if N == 3:
+        # Potential improvement: precision for small p-values
+        pw = 1 - 6/np.pi*np.arccos(np.sqrt(w))
     return ShapiroResult(w, pw)
 
 

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -225,6 +225,22 @@ class TestShapiro:
 
         assert_allclose(res, ref, rtol=1e-5)
 
+    def test_length_3_gh18322(self):
+        # gh-18322 reported that the p-value could be negative for input of
+        # length 3. Check that this is resolved.
+        res = stats.shapiro([0.6931471805599453, 0.0, 0.0])
+        assert res.pvalue > 0
+
+        # R `shapiro.test` doesn't produce an accurate p-value in the case
+        # above. Check that the formula used in `stats.shapiro` is not wrong.
+        # options(digits=16)
+        # x = c(-0.7746653110021126, -0.4344432067942129, 1.8157053280290931)
+        # shapiro.test(x)
+        rng = np.random.default_rng(376593478292346598752763)
+        res = stats.shapiro(rng.normal(size=3))
+        assert_allclose(res.statistic, 0.84658770645509)
+        assert_allclose(res.pvalue, 0.2313666489882, rtol=1e-6)
+
 
 class TestAnderson:
     def test_normal(self):

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -229,15 +229,15 @@ class TestShapiro:
         # gh-18322 reported that the p-value could be negative for input of
         # length 3. Check that this is resolved.
         res = stats.shapiro([0.6931471805599453, 0.0, 0.0])
-        assert res.pvalue > 0
+        assert res.pvalue >= 0
 
         # R `shapiro.test` doesn't produce an accurate p-value in the case
         # above. Check that the formula used in `stats.shapiro` is not wrong.
         # options(digits=16)
         # x = c(-0.7746653110021126, -0.4344432067942129, 1.8157053280290931)
         # shapiro.test(x)
-        rng = np.random.default_rng(376593478292346598752763)
-        res = stats.shapiro(rng.normal(size=3))
+        x = [-0.7746653110021126, -0.4344432067942129, 1.8157053280290931]
+        res = stats.shapiro(x)
         assert_allclose(res.statistic, 0.84658770645509)
         assert_allclose(res.pvalue, 0.2313666489882, rtol=1e-6)
 


### PR DESCRIPTION
#### Reference issue
Closes gh-18322

#### What does this implement/fix?
gh-18322 reported that `shapiro` can produce negative p-values when `len(x)==3`. This PR overrides the p-value reported by `swilk` in this case.

*Lint failure unrelated. That will be fixed when gh-18321 is reverted (i.e. gh-16996 comes back)*