### PR TITLE
BLD: avoid build warnings on Windows, bump pybind11 and meson min versions

### DIFF
--- a/doc/source/dev/contributor/meson_advanced.rst
+++ b/doc/source/dev/contributor/meson_advanced.rst
@@ -72,7 +72,7 @@ here (for now). Please see
 `Meson's documentation on cross compilation <https://mesonbuild.com/Cross-compilation.html>`__
 for context.
 
-One common hiccup is that ``numpy``, ``pybind11`` and ``pythran`` require
+One common hiccup is that ``numpy`` and ``pythran`` require
 running Python code in order to obtain their include directories. This tends to
 not work well, either accidentally picking up the packages from the build
 (native) Python rather than the host (cross) Python or requiring ``crossenv``
@@ -86,7 +86,6 @@ relevant directories in your *cross file*:
 
     [properties]
     numpy-include-dir = sitepkg + 'numpy/core/include'
-    pybind11-include-dir = sitepkg + 'pybind11/include'
     pythran-include-dir = sitepkg + 'pythran'
 
 

--- a/meson.build
+++ b/meson.build
@@ -6,7 +6,7 @@ project(
   # tools/version_utils.py
   version: '1.11.0.dev0',
   license: 'BSD-3',
-  meson_version: '>= 0.64.0',
+  meson_version: '>= 1.1.0',
   default_options: [
     'buildtype=debugoptimized',
     'b_ndebug=if-release',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = 'mesonpy'
 requires = [
     "meson-python>=0.12.1",
     "Cython>=0.29.33",  # when updating version, also update check in meson.build
-    "pybind11>=2.10.0",
+    "pybind11>=2.10.4",
     "pythran>=0.12.0",
     # `wheel` is needed for non-isolated builds, given that `meson-python`
     # doesn't list it as a runtime requirement (at least in 0.5.0)

--- a/scipy/__config__.py.in
+++ b/scipy/__config__.py.in
@@ -90,6 +90,12 @@ CONFIG = _cleanup(
                 "openblas configuration": "@LAPACK_OPENBLAS_CONFIG@",
                 "pc file directory": r"@LAPACK_PCFILEDIR@",
             },
+            "pybind11": {
+                "name": "@PYBIND11_NAME@",
+                "version": "@PYBIND11_VERSION@",
+                "detection method": "@PYBIND11_TYPE_NAME@",
+                "include directory": r"@PYBIND11_INCLUDEDIR@",
+            },
         },
         "Python Information": {
             "path": r"@PYTHON_PATH@",

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -16,7 +16,8 @@ if is_windows
     # https://bugs.python.org/issue28267
     bitness = run_command('_build_utils/gcc_build_bitness.py', check: true).stdout().strip()
     if bitness == '64'
-      add_project_arguments('-DMS_WIN64', language: ['c', 'cpp', 'fortran'])
+      # The `=` is a little odd, but avoids redefinition warnings (see meson#11592)
+      add_project_arguments('-DMS_WIN64=', language: ['c', 'cpp', 'fortran'])
     endif
     # Silence warnings emitted by PyOS_snprintf for (%zd), see
     # https://github.com/rgommers/scipy/issues/118.

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -14,7 +14,7 @@ if is_windows
     add_project_arguments('-D__USE_MINGW_ANSI_STDIO=1', language: ['c', 'cpp'])
     # Manual add of MS_WIN64 macro when not using MSVC.
     # https://bugs.python.org/issue28267
-    bitness = run_command('_build_utils/gcc_build_bitness.py').stdout().strip()
+    bitness = run_command('_build_utils/gcc_build_bitness.py', check: true).stdout().strip()
     if bitness == '64'
       add_project_arguments('-DMS_WIN64', language: ['c', 'cpp', 'fortran'])
     endif

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -90,33 +90,7 @@ npyrandom_path = _incdir_numpy_abs / '..' / '..' / 'random' / 'lib'
 npymath_lib = cc.find_library('npymath', dirs: npymath_path)
 npyrandom_lib = cc.find_library('npyrandom', dirs: npyrandom_path)
 
-# pybind11 include directory - needed in several submodules
-#
-# first check if the user specified a path in a cross file
-incdir_pybind11 = meson.get_external_property('pybind11-include-dir', 'not-given')
-if incdir_pybind11 == 'not-given'
-  # in meson 1.1.0, this will find the pyproject.toml build-requires version
-  pybind11_dep = dependency('pybind11', version: '>=2.10.0', required: false, allow_fallback: true)
-  if not pybind11_dep.found()
-    incdir_pybind11 = run_command(py3,
-      [
-        '-c',
-        '''from os.path import relpath
-import pybind11
-try:
-  incdir = relpath(pybind11.get_include())
-except Exception:
-  incdir = pybind11.get_include()
-print(incdir)
-'''
-      ],
-      check: true
-    ).stdout().strip()
-    pybind11_dep = declare_dependency(include_directories: incdir_pybind11)
-  endif
-else
-  pybind11_dep = declare_dependency(include_directories: incdir_pybind11)
-endif
+pybind11_dep = dependency('pybind11', version: '>=2.10.4')
 
 # Pythran include directory and build flags
 if use_pythran
@@ -196,10 +170,10 @@ endif
 blas = dependency(blas_name)
 lapack = dependency(lapack_name)
 
-# TODO: Add `pybind11` when available as a dependency
 dependency_map = {
   'BLAS': blas,
   'LAPACK': lapack,
+  'PYBIND11': pybind11_dep,
 }
 
 # FIXME: conda-forge sets MKL_INTERFACE_LAYER=LP64,GNU, see gh-11812.


### PR DESCRIPTION
Changes:

1. The new Windows GHA CI job revealed some build warnings, so fix those. Closes gh-18329.
2. Increase the minimum `meson` and `pybind11` to 1.1.0 and 2.10.4 respectively. Benefits:
    - This makes `dependency('pybind11')` work, and removes quite a bit of complexity in the detection logic
    - `scipy.show_config()` now shows details for `pybind11`, like detected version and include dir location