### PR TITLE
TST: fix minor tolerance issue for `stats.multivariate_t` test

### DIFF
--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -2456,7 +2456,7 @@ class TestMultivariateT:
                                        allow_singular=True)
         with np.errstate(invalid='ignore'):
             ref = _qsimvtv(20000, df, cov, np.inf*a, b - mean, rng)[0]
-        assert_allclose(res, ref, atol=1e-4, rtol=1e-3)
+        assert_allclose(res, ref, atol=2e-4, rtol=1e-3)
 
         # with lower limit
         res = stats.multivariate_t.cdf(b, mean, cov, df, lower_limit=a,


### PR DESCRIPTION
Failure looked like this on a fairly standard 64-bit Linux build setup from our default `environment.yml`:

```
E   Not equal to tolerance rtol=0.001, atol=0.0001
E
E   Mismatched elements: 1 / 1 (100%)
E   Max absolute difference: 0.00018462
E   Max relative difference: inf
E    x: array(0.000185)
E    y: array(0.)

FAILED scipy/stats/tests/test_multivariate.py::TestMultivariateT::test_cdf_against_qsimvtv[True-3363958638-5]
```