### PR TITLE
TST: optimize: fix test_milp_timeout

### DIFF
--- a/scipy/optimize/tests/test_milp.py
+++ b/scipy/optimize/tests/test_milp.py
@@ -295,9 +295,7 @@ _msg_iter = "Iteration limit reached. (HiGHS Status 14:"
 
 @pytest.mark.skipif(np.intp(0).itemsize < 8,
                     reason="Unhandled 32-bit GCC FP bug")
-@pytest.mark.slow
-@pytest.mark.timeout(360)
-@pytest.mark.parametrize(["options", "msg"], [({"time_limit": 10}, _msg_time),
+@pytest.mark.parametrize(["options", "msg"], [({"time_limit": 0.1}, _msg_time),
                                               ({"node_limit": 1}, _msg_iter)])
 def test_milp_timeout_16545(options, msg):
     # Ensure solution is not thrown away if MILP solver times out

--- a/scipy/optimize/tests/test_milp.py
+++ b/scipy/optimize/tests/test_milp.py
@@ -295,6 +295,7 @@ _msg_iter = "Iteration limit reached. (HiGHS Status 14:"
 
 @pytest.mark.skipif(np.intp(0).itemsize < 8,
                     reason="Unhandled 32-bit GCC FP bug")
+@pytest.mark.slow
 @pytest.mark.parametrize(["options", "msg"], [({"time_limit": 0.1}, _msg_time),
                                               ({"node_limit": 1}, _msg_iter)])
 def test_milp_timeout_16545(options, msg):


### PR DESCRIPTION
#### Reference issue
Closes gh-17137

#### What does this implement/fix?
gh-17137 `test_milp_timeout` fails on some platforms. Here, we'll try to fix it.

#### Additional information
I removed the `slow` and `timeout` marks to explore what happens on all CI platforms. Before merging, we need to check the `durations` to see if this is running for longer than expected.
With the time limit change, this test passes for me locally. @WarrenWeckesser @andyfaff how about you?