### PR TITLE
DOC: interpolate: declare Rbf legacy

### DIFF
--- a/scipy/interpolate/_rbf.py
+++ b/scipy/interpolate/_rbf.py
@@ -59,7 +59,8 @@ class Rbf:
     A class for radial basis function interpolation of functions from
     N-D scattered data to an M-D domain.
 
-    .. note::
+    .. legacy:: class
+
         `Rbf` is legacy code, for new usage please use `RBFInterpolator`
         instead.
 


### PR DESCRIPTION


#### Reference issue
<!--Example: Closes gh-WXYZ.-->

As discussed at https://github.com/scipy/scipy/issues/17044#issuecomment-1270589848

#### What does this implement/fix?
<!--Please explain your changes.-->

Now that we have a proper `.. legacy::` admonition, use it on `Rbf` and point users to the recommended `RBFInterpolator`.

#### Additional information
<!--Any additional information you think is important.-->

A note in passing is that it might be nice if `.. legacy::` directive produced a note in the main listing of routines, like `.. deprecated::` does (cf e.g. https://docs.scipy.org/doc/scipy/reference/interpolate.html -- see `interp1d`). 
