### PR TITLE
DEP: signal: deprecate using medfilt and order_filter with float128 and object dtypes

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -1568,11 +1568,11 @@ def medfilt(volume, kernel_size=None):
     numels = np.prod(kernel_size, axis=0)
     order = numels // 2
 
-    if volume.dtype in [np.bool_, np.cfloat, np.cdouble,
-                                       np.clongdouble, np.float16,]:
+    if volume.dtype in [np.bool_, np.cfloat, np.cdouble, np.clongdouble,
+                        np.float16]:
         raise ValueError(f"dtype={volume.dtype} is not supported by medfilt")
 
-    if volume.dtype in [object, 'float128']:
+    if volume.dtype.char in ['O', 'g']:
         mesg = (f"Using medfilt with arrays of dtype {volume.dtype} is "
                 f"deprecated in SciPy 1.11 and will be removed in SciPy 1.13")
         warnings.warn(mesg, DeprecationWarning, stacklevel=2)
@@ -1581,7 +1581,7 @@ def medfilt(volume, kernel_size=None):
     else:
         size = math.prod(kernel_size)
         result = ndimage.rank_filter(volume, size // 2, size=kernel_size,
-                                      mode='constant')
+                                     mode='constant')
 
     return result
 

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -1497,8 +1497,8 @@ def order_filter(a, domain, rank):
     a = np.asarray(a)
     if a.dtype in [object, 'float128']:
         mesg = (f"Using order_filter with arrays of dtype {a.dtype} is "
-                f"  deprecated in SciPy 1.11 and will be removed in SciPy 1.13")
-        warnings.warn(mesg, DeprecationWarning)
+                f"deprecated in SciPy 1.11 and will be removed in SciPy 1.13")
+        warnings.warn(mesg, DeprecationWarning, stacklevel=2)
 
         result = _sigtools._order_filterND(a, domain, rank)
     else:
@@ -1574,8 +1574,8 @@ def medfilt(volume, kernel_size=None):
 
     if volume.dtype in [object, 'float128']:
         mesg = (f"Using medfilt with arrays of dtype {volume.dtype} is "
-               f"  deprecated in SciPy 1.11 and will be removed in SciPy 1.13")
-        warnings.warn(mesg, DeprecationWarning)
+                f"deprecated in SciPy 1.11 and will be removed in SciPy 1.13")
+        warnings.warn(mesg, DeprecationWarning, stacklevel=2)
 
         result = _sigtools._order_filterND(volume, domain, order)
     else:

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -10,6 +10,7 @@ from . import _sigtools
 from ._ltisys import dlti
 from ._upfirdn import upfirdn, _output_len, _upfirdn_modes
 from scipy import linalg, fft as sp_fft
+from scipy import ndimage
 from scipy.fft._helper import _init_nd_shape_and_axes
 import numpy as np
 from scipy.special import lambertw
@@ -1492,7 +1493,18 @@ def order_filter(a, domain, rank):
         if (dimsize % 2) != 1:
             raise ValueError("Each dimension of domain argument "
                              "should have an odd number of elements.")
-    return _sigtools._order_filterND(a, domain, rank)
+
+    a = np.asarray(a)
+    if a.dtype in [object, 'float128']:
+        mesg = (f"Using order_filter with arrays of dtype {a.dtype} is "
+                f"  deprecated in SciPy 1.11 and will be removed in SciPy 1.13")
+        warnings.warn(mesg, DeprecationWarning)
+
+        result = _sigtools._order_filterND(a, domain, rank)
+    else:
+        result = ndimage.rank_filter(a, rank, footprint=domain, mode='constant')
+
+    return result
 
 
 def medfilt(volume, kernel_size=None):
@@ -1555,7 +1567,23 @@ def medfilt(volume, kernel_size=None):
 
     numels = np.prod(kernel_size, axis=0)
     order = numels // 2
-    return _sigtools._order_filterND(volume, domain, order)
+
+    if volume.dtype in [np.bool_, np.cfloat, np.cdouble,
+                                       np.clongdouble, np.float16,]:
+        raise ValueError("_order_filterND")
+
+    if volume.dtype in [object, 'float128']:
+        mesg = (f"Using medfilt with arrays of dtype {volume.dtype} is "
+               f"  deprecated in SciPy 1.11 and will be removed in SciPy 1.13")
+        warnings.warn(mesg, DeprecationWarning)
+
+        result = _sigtools._order_filterND(volume, domain, order)
+    else:
+        size = math.prod(kernel_size)
+        result = ndimage.rank_filter(volume, size // 2, size=kernel_size,
+                                      mode='constant')
+
+    return result
 
 
 def wiener(im, mysize=None, noise=None):

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -1570,7 +1570,7 @@ def medfilt(volume, kernel_size=None):
 
     if volume.dtype in [np.bool_, np.cfloat, np.cdouble,
                                        np.clongdouble, np.float16,]:
-        raise ValueError("_order_filterND")
+        raise ValueError(f"dtype={volume.dtype} is not supported by medfilt")
 
     if volume.dtype in [object, 'float128']:
         mesg = (f"Using medfilt with arrays of dtype {volume.dtype} is "

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1088,12 +1088,21 @@ class TestMedFilt:
 
     @pytest.mark.parametrize('dtype', [np.ubyte, np.byte, np.ushort, np.short,
                                        np.uint, int, np.ulonglong, np.ulonglong,
-                                       np.float32, np.float64, np.longdouble])
+                                       np.float32, np.float64])
     def test_types(self, dtype):
         # volume input and output types match
         in_typed = np.array(self.IN, dtype=dtype)
         assert_equal(signal.medfilt(in_typed).dtype, dtype)
         assert_equal(signal.medfilt2d(in_typed).dtype, dtype)
+
+    def test_types_deprecated(self):
+        dtype = np.longdouble
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning)
+            in_typed = np.array(self.IN, dtype=dtype)
+            assert_equal(signal.medfilt(in_typed).dtype, dtype)
+            assert_equal(signal.medfilt2d(in_typed).dtype, dtype)
+
 
     @pytest.mark.parametrize('dtype', [np.bool_, np.cfloat, np.cdouble,
                                        np.clongdouble, np.float16,])
@@ -1134,10 +1143,12 @@ class TestMedFilt:
         assert_equal(x, [a, a])
 
     def test_object(self,):
-        in_object = np.array(self.IN, dtype=object)
-        out_object = np.array(self.OUT, dtype=object)
-        assert_array_equal(signal.medfilt(in_object, self.KERNEL_SIZE),
-                           out_object)
+        with suppress_warnings() as sup:
+            sup.filter(DeprecationWarning)
+            in_object = np.array(self.IN, dtype=object)
+            out_object = np.array(self.OUT, dtype=object)
+            assert_array_equal(signal.medfilt(in_object, self.KERNEL_SIZE),
+                               out_object)
 
     @pytest.mark.parametrize("dtype", [np.ubyte, np.float32, np.float64])
     def test_medfilt2d_parallel(self, dtype):

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1097,10 +1097,11 @@ class TestMedFilt:
 
     def test_types_deprecated(self):
         dtype = np.longdouble
-        with suppress_warnings() as sup:
-            sup.filter(DeprecationWarning)
-            in_typed = np.array(self.IN, dtype=dtype)
-            assert_equal(signal.medfilt(in_typed).dtype, dtype)
+        in_typed = np.array(self.IN, dtype=dtype)
+        msg = "Using medfilt with arrays of dtype"
+        with pytest.deprecated_call(match=msg):
+            assert_equal(signal.medfilt(in_typed).dtype, type)
+        with pytest.deprecated_call(match=msg):
             assert_equal(signal.medfilt2d(in_typed).dtype, dtype)
 
 
@@ -1143,8 +1144,8 @@ class TestMedFilt:
         assert_equal(x, [a, a])
 
     def test_object(self,):
-        with suppress_warnings() as sup:
-            sup.filter(DeprecationWarning)
+        msg = "Using medfilt with arrays of dtype"
+        with pytest.deprecated_call(match=msg):
             in_object = np.array(self.IN, dtype=object)
             out_object = np.array(self.OUT, dtype=object)
             assert_array_equal(signal.medfilt(in_object, self.KERNEL_SIZE),

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1100,7 +1100,7 @@ class TestMedFilt:
         in_typed = np.array(self.IN, dtype=dtype)
         msg = "Using medfilt with arrays of dtype"
         with pytest.deprecated_call(match=msg):
-            assert_equal(signal.medfilt(in_typed).dtype, type)
+            assert_equal(signal.medfilt(in_typed).dtype, dtype)
         with pytest.deprecated_call(match=msg):
             assert_equal(signal.medfilt2d(in_typed).dtype, dtype)
 
@@ -1109,10 +1109,10 @@ class TestMedFilt:
                                        np.clongdouble, np.float16,])
     def test_invalid_dtypes(self, dtype):
         in_typed = np.array(self.IN, dtype=dtype)
-        with pytest.raises(ValueError, match="order_filterND"):
+        with pytest.raises(ValueError, match="not supported"):
             signal.medfilt(in_typed)
 
-        with pytest.raises(ValueError, match="order_filterND"):
+        with pytest.raises(ValueError, match="not supported"):
             signal.medfilt2d(in_typed)
 
     def test_none(self):


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

As discussed on scipy-dev list on 22 Feb 2023:

https://mail.python.org/archives/list/scipy-dev@python.org/thread/Z3Y6CZHGJ2G5GVA3EKLGATDCJX6PDW5P/#T53S74F46GCNEJMSUSAAC4BCR4VQFO55

#### What does this implement/fix?
<!--Please explain your changes.-->

Delegate to ndimage in `signal.medfilt` and `signal.order_filter`. 
The former does not handle objects (e.g. Decimals) and longdoubles, so deprecate using them here.

#### Additional information
<!--Any additional information you think is important.-->

The goal here is to reduce duplication between ndimage and signal, and  <s>get rid of https://github.com/scipy/scipy/blob/main/scipy/signal/_lfilter.c.in entirely (700 LOC of fairly obscure C code).</s> Cannot just remove them, so deprecate first. 

EDIT (19.12.2023): the above had a typo: `_lfilter.c.in` is different, the implementation of the deprecated functionality was in `_sigtoolsmodule.c`, https://github.com/scipy/scipy/blob/v1.11.4/scipy/signal/_sigtoolsmodule.c#L848-L1203, and is being removed in gh-19673.

This PR is mainly to gauge the reaction from users and experts. For one, I am not entirely sure that our test coverage is sufficient. Thoughts?

