### PR TITLE
TST: stats.mstats.median_cihs: strengthen test

### DIFF
--- a/scipy/stats/tests/test_mstats_extras.py
+++ b/scipy/stats/tests/test_mstats_extras.py
@@ -161,6 +161,12 @@ def test_median_cihs():
     rng = np.random.default_rng(8824288259505800535)
     x = rng.random(size=20)
     assert_allclose(ms.median_cihs(x), (0.38663198, 0.88431272))
-    # upper confidence limits don't match for the 90% confidence interval
-    # unclear whether SciPy or R implementation is wrong
-    # assert_allclose(ms.median_cihs(x, 0.1), (0.48319773, 0.90413257))
+
+    # SciPy's 90% CI upper limit doesn't match that of EnvStats eqnpar. SciPy
+    # doesn't look wrong, and it agrees with a different reference,
+    # `median_confint_hs` from `hoehleatsu/quantileCI`.
+    # In (e.g.) Colab with R runtime:
+    # devtools::install_github("hoehleatsu/quantileCI")
+    # library(quantileCI)
+    # median_confint_hs(x=x, conf.level=0.90, interpolate=TRUE)
+    assert_allclose(ms.median_cihs(x, 0.1), (0.48319773366, 0.88094268050))


### PR DESCRIPTION
#### Reference issue
https://github.com/scipy/scipy/issues/17683#issuecomment-1517050657
gh-18020

#### What does this implement/fix?
gh-18020 added a test of `scipy.stats.mstats.median_cihs` for a 95% confidence interval, but it omitted a test of a 90% confidence interval because SciPy's result disagreed with that of the R reference. 

Based on (brief) comparison of the SciPy code against [the math](https://www.itl.nist.gov/div898/software/dataplot/refman1/auxillar/mediancl.htm) and comparison of the output against another reference, I'm not very concerned that SciPy is doing something wrong.

This adds the 90% confidence interval test against the second reference.

<details>

![image](https://user-images.githubusercontent.com/6570539/233693229-0c671077-346d-4607-92ef-5fd4c56781ec.png)

</details>
