### PR TITLE
MAINT: use math.prod (python >= 3.8)

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -151,19 +151,6 @@ def _prune_array(array):
     return array
 
 
-def prod(iterable):
-    """
-    Product of a sequence of numbers.
-
-    Faster than np.prod for short lists like array shapes, and does
-    not overflow if using Python integers.
-    """
-    product = 1
-    for x in iterable:
-        product *= x
-    return product
-
-
 def float_factorial(n: int) -> float:
     """Compute the factorial and return as a float
 

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -1,4 +1,5 @@
 import operator
+from math import prod
 
 import numpy as np
 from numpy.core.multiarray import normalize_axis_index
@@ -8,7 +9,6 @@ from scipy.linalg import (get_lapack_funcs, LinAlgError,
 from scipy.optimize import minimize_scalar
 from . import _bspl
 from . import _fitpack_impl
-from scipy._lib._util import prod
 from scipy.sparse import csr_array
 from scipy.special import poch
 from itertools import combinations

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -1,5 +1,6 @@
 __all__ = ['interp1d', 'interp2d', 'lagrange', 'PPoly', 'BPoly', 'NdPPoly']
 
+from math import prod
 
 import numpy as np
 from numpy import (array, transpose, searchsorted, atleast_1d, atleast_2d,
@@ -7,7 +8,6 @@ from numpy import (array, transpose, searchsorted, atleast_1d, atleast_2d,
 
 import scipy.special as spec
 from scipy.special import comb
-from scipy._lib._util import prod
 
 from . import _fitpack_py
 from . import dfitpack

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -3,6 +3,7 @@
 
 import operator
 import math
+from math import prod as _prod
 import timeit
 from scipy.spatial import cKDTree
 from . import _sigtools
@@ -10,7 +11,6 @@ from ._ltisys import dlti
 from ._upfirdn import upfirdn, _output_len, _upfirdn_modes
 from scipy import linalg, fft as sp_fft
 from scipy.fft._helper import _init_nd_shape_and_axes
-from scipy._lib._util import prod as _prod
 import numpy as np
 from scipy.special import lambertw
 from .windows import get_window

--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -4,7 +4,7 @@
 import sys
 import operator
 import numpy as np
-from scipy._lib._util import prod
+from math import prod
 import scipy.sparse as sp
 
 


### PR DESCRIPTION
#### What does this implement/fix?
<!--Please explain your changes.-->

Remove `_lib._util.prod` in favor of `math.prod` --- the latter is new in python 3.8, so we're safe.
