### PR TITLE
MAINT: Set cython compiler directive cpow to True

### DIFF
--- a/scipy/interpolate/_ppoly.pyx
+++ b/scipy/interpolate/_ppoly.pyx
@@ -1,3 +1,4 @@
+# cython: cpow=True
 """
 Routines for evaluating and manipulating piecewise polynomials in
 local power basis.

--- a/scipy/interpolate/interpnd.pyx
+++ b/scipy/interpolate/interpnd.pyx
@@ -1,3 +1,4 @@
+# cython: cpow=True
 """
 Simple N-D interpolation
 

--- a/scipy/linalg/_matfuncs_expm.pyx.in
+++ b/scipy/linalg/_matfuncs_expm.pyx.in
@@ -1,4 +1,5 @@
 # cython: language_level=3
+# cython: cpow=True
 cimport cython
 import math
 import random

--- a/scipy/signal/_spectral.pyx
+++ b/scipy/signal/_spectral.pyx
@@ -1,6 +1,8 @@
 # Author: Pim Schellart
 # 2010 - 2011
 
+# cython: cpow=True
+
 """Tools for spectral analysis of unequally sampled signals."""
 
 import numpy as np

--- a/scipy/spatial/_ckdtree.pyx
+++ b/scipy/spatial/_ckdtree.pyx
@@ -4,6 +4,8 @@
 # Balanced kd-tree construction written by Jake Vanderplas for scikit-learn
 # Released under the scipy license
 
+# cython: cpow=True
+
 # distutils: language = c++
 
 import numpy as np

--- a/scipy/spatial/_hausdorff.pyx
+++ b/scipy/spatial/_hausdorff.pyx
@@ -1,3 +1,5 @@
+# cython: cpow=True
+
 """
 Directed Hausdorff Code
 

--- a/scipy/spatial/_qhull.pyx
+++ b/scipy/spatial/_qhull.pyx
@@ -1,3 +1,5 @@
+# cython: cpow=True
+
 """
 Wrappers for Qhull triangulation, plus some additional N-D geometry utilities
 
@@ -9,6 +11,7 @@ Wrappers for Qhull triangulation, plus some additional N-D geometry utilities
 #
 # Distributed under the same BSD license as Scipy.
 #
+
 
 import numpy as np
 cimport numpy as np

--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -1,3 +1,5 @@
+# cython: cpow=True
+
 import re
 import warnings
 import numpy as np

--- a/scipy/special/_agm.pxd
+++ b/scipy/special/_agm.pxd
@@ -1,3 +1,5 @@
+# cython: cpow=True
+
 import cython
 
 from libc.math cimport log, exp, fabs, sqrt, isnan, isinf, NAN, M_PI

--- a/scipy/special/_spence.pxd
+++ b/scipy/special/_spence.pxd
@@ -1,3 +1,5 @@
+# cython: cpow=True
+
 # Implement Spence's function, a.k.a. the dilogarithm, for complex
 # arguments. Note that our definition differs from that in the sources
 # by the mapping z -> 1 - z.

--- a/scipy/special/_spherical_bessel.pxd
+++ b/scipy/special/_spherical_bessel.pxd
@@ -1,5 +1,6 @@
 # -*-cython-*-
-#
+# cython: cpow=True
+
 # Implementation of spherical Bessel functions and modified spherical Bessel
 # functions of the first and second kinds, as well as their derivatives.
 #

--- a/scipy/special/_test_internal.pyx
+++ b/scipy/special/_test_internal.pyx
@@ -1,3 +1,5 @@
+# cython: cpow=True
+
 """
 Wrappers to allow unit tests of internal C code.
 

--- a/scipy/special/_wright_bessel.pxd
+++ b/scipy/special/_wright_bessel.pxd
@@ -1,3 +1,5 @@
+# cython: cpow=True
+
 # -*-cython-*-
 #
 # Implementation of Wright's generalized Bessel function Phi, see

--- a/scipy/special/orthogonal_eval.pxd
+++ b/scipy/special/orthogonal_eval.pxd
@@ -1,4 +1,5 @@
 # -*- cython -*-
+# cython: cpow=True
 """
 Evaluate orthogonal polynomial values using recurrence relations.
 

--- a/scipy/special/sph_harm.pxd
+++ b/scipy/special/sph_harm.pxd
@@ -1,3 +1,5 @@
+# cython: cpow=True
+
 from . cimport sf_error
 from ._cephes cimport poch
 

--- a/scipy/stats/_qmc_cy.pyx
+++ b/scipy/stats/_qmc_cy.pyx
@@ -2,6 +2,7 @@
 # cython: boundscheck=False
 # cython: wraparound=False
 # cython: cdivision=True
+# cython: cpow=True
 
 # distutils: language = c++
 

--- a/scipy/stats/_stats.pyx
+++ b/scipy/stats/_stats.pyx
@@ -1,3 +1,5 @@
+# cython: cpow=True
+
 from cpython cimport bool
 from libc cimport math
 from libc.math cimport NAN, INFINITY, M_PI as PI


### PR DESCRIPTION
#### Reference issue
Part of https://github.com/scipy/scipy/issues/17234

#### What does this implement/fix?
This is part of migration to Cython 3. PR sets `cpow` directive to `True` in all modules using `**` operator. This will ensure that the behaviour of `**` operator in Cython 3 will be the same as in Cython 0.29.X. For details see:

* https://cython.readthedocs.io/en/latest/src/userguide/migrating_to_cy30.html#power-operator
* https://cython.readthedocs.io/en/latest/src/userguide/source_files_and_compilation.html#compiler-directives

This PR is fully compatible with Cython >= 0.29.33 where `cpow` directive is available as a no-op. 

#### Additional information
This functionality requires at least Cython 0.29.33 or Cython 3.0b1
