### PR TITLE
DEV: work around pathlib bug affecting dev.py for Python 3.9 on Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -35,7 +35,7 @@ jobs:
           architecture: 'x64'
           cache: 'pip'
           cache-dependency-path: 'environment.yml'
-      - name: install-rtools
+      - name: Install rtools (mingw-w64)
         run: |
           choco install rtools --no-progress
           echo "c:\rtools40\ucrt64\bin;" >> $env:GITHUB_PATH
@@ -46,32 +46,25 @@ jobs:
       - name: pip-packages
         run: |
           pip install numpy==1.22.2 cython pybind11 pythran meson ninja pytest pytest-xdist pytest-timeout pooch rich_click click doit pydevtool
-      - name: Install OpenBlas
+      - name: Install OpenBLAS
         shell: bash
         run: |
           # same OpenBLAS install method as cibuildwheel
           set -xe
           bash tools/wheels/cibw_before_build_win.sh .
           echo "PKG_CONFIG_PATH=c:\opt\64\lib\pkgconfig;" >> $GITHUB_ENV
-      - name: build
+      - name: Build
         run: |
           echo "SCIPY_USE_PROPACK=1" >> $env:GITHUB_ENV
           python dev.py build -j 2 --win-cp-openblas
-
-          # following steps are required because the build step does not put
-          # the *.pyd files in build-install! Furthermore the --win-cp-openblas
-          # option does not seem to copy libopenblas*.dll, so manually copy it.
-          cd build
-          meson install
-          cd ..
+          # Necessary because GitHub Actions checks out the repo to D:\ while OpenBLAS
+          # got installed to C:\ higher up. The copying with `--win-cp-openblas` fails
+          # when things are split over drives.
           cp C:\opt\64\bin\*.dll $pwd\build-install\Lib\site-packages\scipy\.libs\
-          echo "PYTHONPATH=$PWD\build-install\Lib\site-packages" >> $env:GITHUB_ENV
           python tools\openblas_support.py --write-init $PWD\build-install\Lib\site-packages\scipy\
-      - name: test
+      - name: Test
         run: |
-          Get-ChildItem env:
-          cd $env:PYTHONPATH
-          python -c "import sys; import scipy; sys.exit(not scipy.test())"
+          python dev.py test -j2
 
 
   #############################################################################
@@ -91,9 +84,8 @@ jobs:
           cache: 'pip'
           cache-dependency-path: 'environment.yml'
 
-      - name: Win_amd64 - install rtools
+      - name: Install rtools (mingw-w64)
         run: |
-          # mingw-w64
           choco install rtools --no-progress
           echo "c:\rtools40\ucrt64\bin;" >> $env:GITHUB_PATH
 
@@ -113,9 +105,7 @@ jobs:
       - name: Build
         run: |
           python dev.py build -j 2 --win-cp-openblas
-          # Necessary because GitHub Actions checks out the repo to D:\ while OpenBLAS
-          # got installed to C:\ higher up. The copying with `--win-cp-openblas` fails
-          # when things are split over drives.
+          # Copy OpenBLAS DLL, write distributor-init (see first job in this file for why)
           cp C:\opt\64\bin\*.dll $pwd\build-install\Lib\site-packages\scipy\.libs\
           python tools\openblas_support.py --write-init $PWD\build-install\Lib\site-packages\scipy\
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -112,11 +112,10 @@ jobs:
 
       - name: Build
         run: |
-          # TODO: remove the build-dir and install-prefix flags once dev.py
-          # supplies meson with absolute paths. This is due to a pathlib bug
-          # on cp39-win.
-          python dev.py --build-dir=$pwd\build --install-prefix=$pwd\build-install build -j 2 --win-cp-openblas
-          meson install -C build
+          python dev.py build -j 2 --win-cp-openblas
+          # Necessary because GitHub Actions checks out the repo to D:\ while OpenBLAS
+          # got installed to C:\ higher up. The copying with `--win-cp-openblas` fails
+          # when things are split over drives.
           cp C:\opt\64\bin\*.dll $pwd\build-install\Lib\site-packages\scipy\.libs\
           python tools\openblas_support.py --write-init $PWD\build-install\Lib\site-packages\scipy\
 

--- a/dev.py
+++ b/dev.py
@@ -306,14 +306,22 @@ class Dirs:
         self.root = Path(__file__).parent.absolute()
         if not args:
             return
+
         self.build = Path(args.build_dir).resolve()
         if args.install_prefix:
             self.installed = Path(args.install_prefix).resolve()
         else:
             self.installed = self.build.parent / (self.build.stem + "-install")
+
+        if sys.platform == 'win32' and sys.version_info < (3, 10):
+            # Work around a pathlib bug; these must be absolute paths
+            self.build = Path(os.path.abspath(self.build))
+            self.installed = Path(os.path.abspath(self.installed))
+
         # relative path for site-package with py version
         # i.e. 'lib/python3.10/site-packages'
         self.site = self.get_site_packages()
+        print(self.site)
 
     def add_sys_path(self):
         """Add site dir to sys.path / PYTHONPATH"""
@@ -595,7 +603,8 @@ class Build(Task):
                   'command did not manage to find OpenBLAS '
                   'succesfully. Try running manually on the '
                   'command prompt for more information.')
-            return result.returncode
+            print("OpenBLAS copy failed!")
+            sys.exit(result.returncode)
 
         # Skip the drive letter of the path -> /c to get Windows drive
         # to be appended correctly to avoid "C:\c\..." from stdout.
@@ -609,6 +618,7 @@ class Build(Task):
         # Look in bin subdirectory for OpenBLAS binaries.
         bin_path = openblas_lib_path.parent / 'bin'
         # Locate, make output .libs directory in Scipy install directory.
+        print(dirs.site)
         scipy_path = dirs.site / 'scipy'
         libs_path = scipy_path / '.libs'
         libs_path.mkdir(exist_ok=True)
@@ -623,9 +633,10 @@ class Build(Task):
         # so OpenBLAS gets found
         openblas_support = import_module_from_path(
             'openblas_support',
-            dirs.root / 'tools' / 'openblas_support.py')
+            dirs.root / 'tools' / 'openblas_support.py'
+        )
         openblas_support.make_init(scipy_path)
-        return 0
+        print('OpenBLAS copied')
 
     @classmethod
     def run(cls, add_path=False, **kwargs):
@@ -642,11 +653,7 @@ class Build(Task):
             cls.build_project(dirs, args, env)
             cls.install_project(dirs, args)
             if args.win_cp_openblas and platform.system() == 'Windows':
-                if cls.copy_openblas(dirs) == 0:
-                    print('OpenBLAS copied')
-                else:
-                    print("OpenBLAS copy failed!")
-                    sys.exit(1)
+                cls.copy_openblas(dirs)
 
         # add site to sys.path
         if add_path:

--- a/dev.py
+++ b/dev.py
@@ -321,7 +321,6 @@ class Dirs:
         # relative path for site-package with py version
         # i.e. 'lib/python3.10/site-packages'
         self.site = self.get_site_packages()
-        print(self.site)
 
     def add_sys_path(self):
         """Add site dir to sys.path / PYTHONPATH"""
@@ -618,7 +617,6 @@ class Build(Task):
         # Look in bin subdirectory for OpenBLAS binaries.
         bin_path = openblas_lib_path.parent / 'bin'
         # Locate, make output .libs directory in Scipy install directory.
-        print(dirs.site)
         scipy_path = dirs.site / 'scipy'
         libs_path = scipy_path / '.libs'
         libs_path.mkdir(exist_ok=True)


### PR DESCRIPTION
Also remove a workaround in a Windows job for this issue, and clean up the code for `dev.py --win-cp-openblas` some more.

Note that `--win-cp-openblas` still doesn't always work as designed - in particular, `openblas_support.py` will silently fail to do the right thing on Windows if the git repo checkout is on the D: drive while OpenBLAS gets downloaded to the C: drive. That is happening in a GHA CI job, and it's plagued us on Azure before too (see gh-11967). It's nontrivial to fix (the `C:` drive is hardcoded in multiple scripts), so I have just added a comment to explain why the two lines in the CI job that really shouldn't have to be there are necessary.

The main win here is that `--build-dir` and `--install-prefix` are no longer needed.