### PR TITLE
MAINT: stats.dgamma.entropy: avoid deprecated NumPy usage and simplify

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1658,18 +1658,7 @@ class dgamma_gen(rv_continuous):
                         0.5 + 0.5*sc.gammainc(a, -x))
 
     def _entropy(self, a):
-        a = np.asarray([a])
-
-        def h1(a):
-            h1 = a + np.log(2) + sc.gammaln(a) + (1 - a) * sc.digamma(a)
-            return h1
-
-        def h2(a):
-            h2 = np.log(2) + 0.5 * (1 + np.log(a) + np.log(2 * np.pi))
-            return h2
-
-        h = _lazywhere(a > 1e8, (a), f=h2, f2=h1)
-        return h
+        return stats.gamma._entropy(a) - np.log(0.5)
 
     def _ppf(self, q, a):
         return np.where(q > 0.5,


### PR DESCRIPTION
#### Reference issue
Toward gh-18331

#### What does this implement/fix?
gh-18331 notes that tests of `stats.dgamma.entropy` are failing due to a NumPy deprecation. This attempts to avoid the deprecated NumPy usage. Incidentally, it also simplifies the override by relying on `stats.gamma._entropy` to perform the calculation.

#### Additional information
See https://github.com/scipy/scipy/pull/18162#discussion_r1139336238 for related derivation. The same approach can be used for any similar "double" distributions.

gh-18352 will fix the pesky lint failure.