### PR TITLE
CI: remove Azure sdist job

### DIFF
--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -178,6 +178,7 @@ jobs:
 
   #################################################################################
   python_debug:
+    # also uses the vcs->sdist->wheel route.
     name: Python-debug & ATLAS
     if: "github.repository == 'scipy/scipy' || github.repository == ''"
     runs-on: ubuntu-22.04  # provides python3.10-dbg
@@ -194,7 +195,7 @@ jobs:
       - name: Build SciPy
         run: |
           python3-dbg -m pip install build
-          python3-dbg -m build --wheel -Csetup-args=-Dbuildtype=debugoptimized -Csetup-args=-Dblas=blas-atlas -Csetup-args=-Dlapack=lapack-atlas -Ccompile-args=-j2
+          python3-dbg -m build -Csetup-args=-Dbuildtype=debugoptimized -Csetup-args=-Dblas=blas-atlas -Csetup-args=-Dlapack=lapack-atlas -Ccompile-args=-j2
           python3-dbg -m pip install dist/scipy*.whl
       - name: Testing SciPy
         run: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,21 +55,6 @@ stages:
   variables:
     AZURE_CI: 'true'
   jobs:
-  - job: source_distribution
-    timeoutInMinutes: 90
-    pool:
-      vmImage: 'ubuntu-22.04'
-    steps:
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '3.9'
-        addToPath: true
-        architecture: 'x64'
-    - template: ci/azure-travis-template.yaml
-      parameters:
-        test_mode: fast
-        numpy_spec: "numpy==1.21.6"
-        use_sdist: true
   - job: Linux_Python_39_32bit_full
     timeoutInMinutes: 90
     condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/main'))  # skip for PR merges

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -115,12 +115,6 @@ stages:
             TEST_MODE: fast
             BITS: 32
             SCIPY_USE_PYTHRAN: 1
-          Python310-64bit-fast:
-            PYTHON_VERSION: '3.10'
-            PYTHON_ARCH: 'x64'
-            TEST_MODE: fast
-            BITS: 64
-            SCIPY_USE_PYTHRAN: 0
     steps:
     - task: UsePythonVersion@0
       inputs:


### PR DESCRIPTION
The GHA `linux_meson` workflow already does a couple of tests from an sdist, `test_venv_install` and ` python_debug`. We can therefore remove it from the Azure setup.