### PR TITLE
ENH: Re-enable PROPACK by default

### DIFF
--- a/.github/workflows/macos_meson.yml
+++ b/.github/workflows/macos_meson.yml
@@ -120,7 +120,6 @@ jobs:
       run: |
         conda activate scipy-dev
         export OMP_NUM_THREADS=2
-        export SCIPY_USE_PROPACK=1
         python dev.py -n test -j 2
 
     - name: Ccache statistics

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -55,7 +55,6 @@ jobs:
           echo "PKG_CONFIG_PATH=c:\opt\64\lib\pkgconfig;" >> $GITHUB_ENV
       - name: Build
         run: |
-          echo "SCIPY_USE_PROPACK=1" >> $env:GITHUB_ENV
           python dev.py build -j 2 --win-cp-openblas
           # Necessary because GitHub Actions checks out the repo to D:\ while OpenBLAS
           # got installed to C:\ higher up. The copying with `--win-cp-openblas` fails

--- a/scipy/sparse/linalg/_eigen/_svds.py
+++ b/scipy/sparse/linalg/_eigen/_svds.py
@@ -1,4 +1,3 @@
-import os
 import numpy as np
 
 from .arpack import _arpack  # type: ignore[attr-defined]
@@ -7,11 +6,7 @@ from . import eigsh
 from scipy._lib._util import check_random_state
 from scipy.sparse.linalg._interface import LinearOperator, aslinearoperator
 from scipy.sparse.linalg._eigen.lobpcg import lobpcg  # type: ignore[no-redef]
-if os.environ.get("SCIPY_USE_PROPACK"):
-    from scipy.sparse.linalg._svdp import _svdp
-    HAS_PROPACK = True
-else:
-    HAS_PROPACK = False
+from scipy.sparse.linalg._svdp import _svdp
 from scipy.linalg import svd
 
 arpack_int = _arpack.timing.nbx.dtype
@@ -493,12 +488,6 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
                            largest=largest)
 
     elif solver == 'propack':
-        if not HAS_PROPACK:
-            raise ValueError("`solver='propack'` is opt-in due "
-                             "to potential issues on Windows, "
-                             "it can be enabled by setting the "
-                             "`SCIPY_USE_PROPACK` environment "
-                             "variable before importing scipy")
         jobu = return_singular_vectors in {True, 'u'}
         jobv = return_singular_vectors in {True, 'vh'}
         irl_mode = (which == 'SM')

--- a/scipy/sparse/linalg/_eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/_eigen/tests/test_svds.py
@@ -1,4 +1,3 @@
-import os
 import re
 import copy
 import numpy as np
@@ -9,10 +8,6 @@ import pytest
 from scipy.linalg import svd, null_space
 from scipy.sparse import csc_matrix, isspmatrix, spdiags, random
 from scipy.sparse.linalg import LinearOperator, aslinearoperator
-if os.environ.get("SCIPY_USE_PROPACK"):
-    has_propack = True
-else:
-    has_propack = False
 from scipy.sparse.linalg import svds
 from scipy.sparse.linalg._eigen.arpack import ArpackNoConvergence
 
@@ -158,8 +153,6 @@ class SVDSCommonTests:
 
         # propack can do complete SVD
         if self.solver == 'propack' and k == 3:
-            if not has_propack:
-                pytest.skip("PROPACK not enabled")
             res = svds(A, k=k, solver=self.solver)
             _check_svds(A, k, *res, check_usvh_A=True, check_svd=True)
             return
@@ -260,9 +253,6 @@ class SVDSCommonTests:
     @pytest.mark.parametrize("k", [3, 5])
     @pytest.mark.parametrize("which", ["LM", "SM"])
     def test_svds_parameter_k_which(self, k, which):
-        if self.solver == 'propack':
-            if not has_propack:
-                pytest.skip("PROPACK not available")
         # check that the `k` parameter sets the number of eigenvalues/
         # eigenvectors returned.
         # Also check that the `which` parameter sets whether the largest or
@@ -280,9 +270,6 @@ class SVDSCommonTests:
 
     # loop instead of parametrize for simplicity
     def test_svds_parameter_tol(self):
-        if self.solver == 'propack':
-            if not has_propack:
-                pytest.skip("PROPACK not available")
         return  # TODO: needs work, disabling for now
         # check the effect of the `tol` parameter on solver accuracy by solving
         # the same problem with varying `tol` and comparing the eigenvalues
@@ -324,9 +311,6 @@ class SVDSCommonTests:
             assert error > accuracy/10
 
     def test_svd_v0(self):
-        if self.solver == 'propack':
-            if not has_propack:
-                pytest.skip("PROPACK not available")
         # check that the `v0` parameter affects the solution
         n = 100
         k = 1
@@ -359,9 +343,6 @@ class SVDSCommonTests:
             assert_equal(res1a, res1b)
 
     def test_svd_random_state(self):
-        if self.solver == 'propack':
-            if not has_propack:
-                pytest.skip("PROPACK not available")
         # check that the `random_state` parameter affects the solution
         # Admittedly, `n` and `k` are chosen so that all solver pass all
         # these checks. That's a tall order, since LOBPCG doesn't want to
@@ -394,10 +375,6 @@ class SVDSCommonTests:
                                               np.random.RandomState(0),
                                               np.random.default_rng(0)))
     def test_svd_random_state_2(self, random_state):
-        if self.solver == 'propack':
-            if not has_propack:
-                pytest.skip("PROPACK not available")
-
         n = 100
         k = 1
 
@@ -416,10 +393,6 @@ class SVDSCommonTests:
                                               np.random.RandomState(0),
                                               np.random.default_rng(0)))
     def test_svd_random_state_3(self, random_state):
-        if self.solver == 'propack':
-            if not has_propack:
-                pytest.skip("PROPACK not available")
-
         n = 100
         k = 5
 
@@ -441,9 +414,6 @@ class SVDSCommonTests:
     def test_svd_maxiter(self):
         # check that maxiter works as expected: should not return accurate
         # solution after 1 iteration, but should with default `maxiter`
-        if self.solver == 'propack':
-            if not has_propack:
-                pytest.skip("PROPACK not available")
         A = np.diag(np.arange(9)).astype(np.float64)
         k = 1
         u, s, vh = sorted_svd(A, k)
@@ -470,10 +440,6 @@ class SVDSCommonTests:
     @pytest.mark.parametrize("shape", ((5, 7), (6, 6), (7, 5)))
     def test_svd_return_singular_vectors(self, rsv, shape):
         # check that the return_singular_vectors parameter works as expected
-        if self.solver == 'propack':
-            if not has_propack:
-                pytest.skip("PROPACK not available")
-
         rng = np.random.default_rng(0)
         A = rng.random(shape)
         k = 2
@@ -554,10 +520,6 @@ class SVDSCommonTests:
                                          aslinearoperator))
     def test_svd_simple(self, A, k, real, transpose, lo_type):
 
-        if self.solver == 'propack':
-            if not has_propack:
-                pytest.skip("PROPACK not available")
-
         A = np.asarray(A)
         A = np.real(A) if real else A
         A = A.T if transpose else A
@@ -584,9 +546,6 @@ class SVDSCommonTests:
 
     def test_svd_linop(self):
         solver = self.solver
-        if self.solver == 'propack':
-            if not has_propack:
-                pytest.skip("PROPACK not available")
 
         nmks = [(6, 7, 3),
                 (9, 5, 4),
@@ -765,8 +724,6 @@ class SVDSCommonTests:
     # ARPACK supports only dtype float, complex, or np.float32
     @pytest.mark.parametrize("dtype", (float, complex, np.float32))
     def test_small_sigma(self, shape, dtype):
-        if not has_propack:
-            pytest.skip("PROPACK not enabled")
         # https://github.com/scipy/scipy/pull/11829
         if dtype == complex and self.solver == 'propack':
             pytest.skip("PROPACK unsupported for complex dtype")
@@ -791,9 +748,7 @@ class SVDSCommonTests:
     @pytest.mark.parametrize("dtype", (float, complex, np.float32))
     def test_small_sigma2(self, dtype):
         if self.solver == 'propack':
-            if not has_propack:
-                pytest.skip("PROPACK not enabled")
-            elif dtype == np.float32:
+            if dtype == np.float32:
                 pytest.skip("Test failures in CI, see gh-17004")
             elif dtype == complex:
                 # https://github.com/scipy/scipy/issues/11406


### PR DESCRIPTION
It's been a long story with PROPACK. There were a bunch of segfaults in the first scipy version that contained it, and ultimately it got disabled by default, because we weren't able to figure out the origin of the windows segfaults (main [issue](https://github.com/scipy/scipy/issues/15108), though there were others...).

Now it seems though that the CI gods have shown some kindness and decided to let the PROPACK tests [pass](https://github.com/conda-forge/scipy-feedstock/pull/200) as of 1.10.x. 

I discovered this after 1.10 was released, so the decision was to re-enable this for 1.11.

Fixes #15108
