### PR TITLE
ENH: allow dividing LinearOperator by number

### DIFF
--- a/scipy/sparse/linalg/_interface.py
+++ b/scipy/sparse/linalg/_interface.py
@@ -707,6 +707,12 @@ class _ScaledLinearOperator(LinearOperator):
             raise ValueError('LinearOperator expected as A')
         if not np.isscalar(alpha):
             raise ValueError('scalar expected as alpha')
+        if isinstance(A, type(self)):
+            A, alpha_original = A.args
+            # Avoid in-place multiplication so that we don't accidentally mutate
+            # the original prefactor.
+            alpha = alpha * alpha_original
+
         dtype = _get_dtype([A], [type(alpha)])
         super().__init__(dtype, A.shape)
         self.args = (A, alpha)

--- a/scipy/sparse/linalg/_interface.py
+++ b/scipy/sparse/linalg/_interface.py
@@ -392,8 +392,10 @@ class LinearOperator:
         return self.dot(x)
 
     def __truediv__(self, other):
-        if np.isscalar(other):
-            return _ScaledLinearOperator(self, 1.0/other)
+        if not np.isscalar(other):
+            raise ValueError("Can only divide a linear operator by a scalar.")
+
+        return _ScaledLinearOperator(self, 1.0/other)
 
     def dot(self, x):
         """Matrix-matrix or matrix-vector multiplication.

--- a/scipy/sparse/linalg/_interface.py
+++ b/scipy/sparse/linalg/_interface.py
@@ -394,6 +394,10 @@ class LinearOperator:
     def __mul__(self, x):
         return self.dot(x)
 
+    def __truediv__(self, other):
+        if np.isscalar(other):
+            return _ScaledLinearOperator(self, 1.0/other)
+
     def dot(self, x):
         """Matrix-matrix or matrix-vector multiplication.
 

--- a/scipy/sparse/linalg/_interface.py
+++ b/scipy/sparse/linalg/_interface.py
@@ -329,12 +329,10 @@ class LinearOperator:
         X = np.asanyarray(X)
 
         if X.ndim != 2:
-            raise ValueError('expected 2-d ndarray or matrix, not %d-d'
-                             % X.ndim)
+            raise ValueError(f'expected 2-d ndarray or matrix, not {X.ndim}-d')
 
         if X.shape[0] != self.shape[1]:
-            raise ValueError('dimension mismatch: %r, %r'
-                             % (self.shape, X.shape))
+            raise ValueError(f'dimension mismatch: {self.shape}, {X.shape}')
 
         Y = self._matmat(X)
 
@@ -373,8 +371,7 @@ class LinearOperator:
                              % X.ndim)
 
         if X.shape[0] != self.shape[0]:
-            raise ValueError('dimension mismatch: %r, %r'
-                             % (self.shape, X.shape))
+            raise ValueError(f'dimension mismatch: {self.shape}, {X.shape}')
 
         Y = self._rmatmat(X)
         if isinstance(Y, np.matrix):
@@ -650,8 +647,7 @@ class _SumLinearOperator(LinearOperator):
                 not isinstance(B, LinearOperator):
             raise ValueError('both operands have to be a LinearOperator')
         if A.shape != B.shape:
-            raise ValueError('cannot add %r and %r: shape mismatch'
-                             % (A, B))
+            raise ValueError(f'cannot add {A} and {B}: shape mismatch')
         self.args = (A, B)
         super().__init__(_get_dtype([A, B]), A.shape)
 
@@ -678,8 +674,7 @@ class _ProductLinearOperator(LinearOperator):
                 not isinstance(B, LinearOperator):
             raise ValueError('both operands have to be a LinearOperator')
         if A.shape[1] != B.shape[0]:
-            raise ValueError('cannot multiply %r and %r: shape mismatch'
-                             % (A, B))
+            raise ValueError(f'cannot multiply {A} and {B}: shape mismatch')
         super().__init__(_get_dtype([A, B]),
                                                      (A.shape[0], B.shape[1]))
         self.args = (A, B)

--- a/scipy/sparse/linalg/_interface.py
+++ b/scipy/sparse/linalg/_interface.py
@@ -704,7 +704,7 @@ class _ScaledLinearOperator(LinearOperator):
             raise ValueError('LinearOperator expected as A')
         if not np.isscalar(alpha):
             raise ValueError('scalar expected as alpha')
-        if isinstance(A, type(self)):
+        if isinstance(A, _ScaledLinearOperator):
             A, alpha_original = A.args
             # Avoid in-place multiplication so that we don't accidentally mutate
             # the original prefactor.

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -115,6 +115,7 @@ class TestLinearOperator:
             assert_(isinstance(A-A, interface._SumLinearOperator))
             assert_(isinstance(A/2, interface._ScaledLinearOperator))
             assert_(isinstance(A/2j, interface._ScaledLinearOperator))
+            assert_(((A * 3) / 3).args[0] is A)  # check for simplification
 
             assert_((2j*A).dtype == np.complex_)
 

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -113,6 +113,8 @@ class TestLinearOperator:
             assert_(isinstance(A+A, interface._SumLinearOperator))
             assert_(isinstance(-A, interface._ScaledLinearOperator))
             assert_(isinstance(A-A, interface._SumLinearOperator))
+            assert_(isinstance(A/2, interface._ScaledLinearOperator))
+            assert_(isinstance(A/2j, interface._ScaledLinearOperator))
 
             assert_((2j*A).dtype == np.complex_)
 

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -119,6 +119,9 @@ class TestLinearOperator:
 
             assert_((2j*A).dtype == np.complex_)
 
+            # Test division by non-scalar
+            assert_raises(ValueError, lambda: A / np.array([1, 2]))
+
             assert_raises(ValueError, A.matvec, np.array([1,2]))
             assert_raises(ValueError, A.matvec, np.array([1,2,3,4]))
             assert_raises(ValueError, A.matvec, np.array([[1],[2]]))

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -117,6 +117,12 @@ class TestLinearOperator:
             assert_(isinstance(A/2j, interface._ScaledLinearOperator))
             assert_(((A * 3) / 3).args[0] is A)  # check for simplification
 
+            # Test that prefactor is of _ScaledLinearOperator is not mutated
+            # when the operator is multiplied by a number
+            result = A @ np.array([1, 2, 3])
+            B = A * 3
+            assert_equal(A @ np.array([1, 2, 3]), result)
+
             assert_((2j*A).dtype == np.complex_)
 
             # Test division by non-scalar

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -120,7 +120,9 @@ class TestLinearOperator:
             assert_((2j*A).dtype == np.complex_)
 
             # Test division by non-scalar
-            assert_raises(ValueError, lambda: A / np.array([1, 2]))
+            msg = "Can only divide a linear operator by a scalar."
+            with assert_raises(ValueError, match=msg):
+                A / np.array([1, 2])
 
             assert_raises(ValueError, A.matvec, np.array([1,2]))
             assert_raises(ValueError, A.matvec, np.array([1,2,3,4]))

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -121,6 +121,7 @@ class TestLinearOperator:
             # when the operator is multiplied by a number
             result = A @ np.array([1, 2, 3])
             B = A * 3
+            C = A / 5
             assert_equal(A @ np.array([1, 2, 3]), result)
 
             assert_((2j*A).dtype == np.complex_)


### PR DESCRIPTION
also optimize nested _ScaledLinearOperator

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
N/A

#### What does this implement/fix?
- Allow dividing `LinearOperator` by a number and returning a `_ScaledLinearOperator`
- Optimize away nested `_ScaledLinearOperator`s to multiply away the prefactors
