### PR TITLE
MAINT: clearer error in `LinearOperator * spmatrix`

### DIFF
--- a/scipy/sparse/linalg/_interface.py
+++ b/scipy/sparse/linalg/_interface.py
@@ -344,6 +344,7 @@ class LinearOperator:
                     "Unable to multiply a LinearOperator with a sparse matrix."
                     " Wrap the matrix in aslinearoperator first."
                 ) from e
+            raise
 
         if isinstance(Y, np.matrix):
             Y = asmatrix(Y)
@@ -391,6 +392,7 @@ class LinearOperator:
                     "Unable to multiply a LinearOperator with a sparse matrix."
                     " Wrap the matrix in aslinearoperator() first."
                 ) from e
+            raise
 
         if isinstance(Y, np.matrix):
             Y = asmatrix(Y)

--- a/scipy/sparse/linalg/_interface.py
+++ b/scipy/sparse/linalg/_interface.py
@@ -336,7 +336,14 @@ class LinearOperator:
             raise ValueError('dimension mismatch: %r, %r'
                              % (self.shape, X.shape))
 
-        Y = self._matmat(X)
+        try:
+            Y = self._matmat(X)
+        except Exception as e:
+            if isspmatrix(X) or is_pydata_spmatrix(X):
+                raise TypeError(
+                    "Unable to multiply a LinearOperator with a sparse matrix."
+                    " Wrap the matrix in aslinearoperator first."
+                ) from e
 
         if isinstance(Y, np.matrix):
             Y = asmatrix(Y)
@@ -376,7 +383,15 @@ class LinearOperator:
             raise ValueError('dimension mismatch: %r, %r'
                              % (self.shape, X.shape))
 
-        Y = self._rmatmat(X)
+        try:
+            Y = self._rmatmat(X)
+        except Exception as e:
+            if isspmatrix(X) or is_pydata_spmatrix(X):
+                raise TypeError(
+                    "Unable to multiply a LinearOperator with a sparse matrix."
+                    " Wrap the matrix in aslinearoperator() first."
+                ) from e
+
         if isinstance(Y, np.matrix):
             Y = asmatrix(Y)
         return Y

--- a/scipy/sparse/linalg/_interface.py
+++ b/scipy/sparse/linalg/_interface.py
@@ -325,8 +325,8 @@ class LinearOperator:
         _matmat method to ensure that y has the correct type.
 
         """
-
-        X = np.asanyarray(X)
+        if not (isspmatrix(X) or is_pydata_spmatrix(X)):
+            X = np.asanyarray(X)
 
         if X.ndim != 2:
             raise ValueError('expected 2-d ndarray or matrix, not %d-d'
@@ -372,8 +372,8 @@ class LinearOperator:
         This rmatmat wraps the user-specified rmatmat routine.
 
         """
-
-        X = np.asanyarray(X)
+        if not (isspmatrix(X) or is_pydata_spmatrix(X)):
+            X = np.asanyarray(X)
 
         if X.ndim != 2:
             raise ValueError('expected 2-d ndarray or matrix, not %d-d'

--- a/scipy/sparse/linalg/_interface.py
+++ b/scipy/sparse/linalg/_interface.py
@@ -429,7 +429,9 @@ class LinearOperator:
         elif np.isscalar(x):
             return _ScaledLinearOperator(self, x)
         else:
-            x = np.asarray(x)
+            if not isspmatrix(x) and not is_pydata_spmatrix(x):
+                # Sparse matrices shouldn't be converted to numpy arrays.
+                x = np.asarray(x)
 
             if x.ndim == 1 or x.ndim == 2 and x.shape[1] == 1:
                 return self.matvec(x)
@@ -480,7 +482,9 @@ class LinearOperator:
         elif np.isscalar(x):
             return _ScaledLinearOperator(self, x)
         else:
-            x = np.asarray(x)
+            if not isspmatrix(x) and not is_pydata_spmatrix(x):
+                # Sparse matrices shouldn't be converted to numpy arrays.
+                x = np.asarray(x)
 
             # We use transpose instead of rmatvec/rmatmat to avoid
             # unnecessary complex conjugation if possible.

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -451,3 +451,9 @@ def test_transpose_noconjugate():
 
     assert_equal(B.dot(v), Y.dot(v))
     assert_equal(B.T.dot(v), Y.T.dot(v))
+
+def test_sparse_matmat_exception():
+    A = interface.LinearOperator((2, 2), matvec=lambda x: x)
+    B = sparse.identity(2)
+    assert_raises(TypeError, A * B)
+    assert_raises(TypeError, B * A)

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -455,5 +455,12 @@ def test_transpose_noconjugate():
 def test_sparse_matmat_exception():
     A = interface.LinearOperator((2, 2), matvec=lambda x: x)
     B = sparse.identity(2)
-    assert_raises(TypeError, A * B)
-    assert_raises(TypeError, B * A)
+    msg = "Unable to multiply a LinearOperator with a sparse matrix."
+    with assert_raises(TypeError, match=msg):
+        A * B
+    with assert_raises(TypeError, match=msg):
+        B * A
+    with assert_raises(ValueError):
+        A * np.identity(4)
+    with assert_raises(ValueError):
+        np.identity(4) * A

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -457,10 +457,10 @@ def test_sparse_matmat_exception():
     B = sparse.identity(2)
     msg = "Unable to multiply a LinearOperator with a sparse matrix."
     with assert_raises(TypeError, match=msg):
-        A * B
+        A @ B
     with assert_raises(TypeError, match=msg):
-        B * A
+        B @ A
     with assert_raises(ValueError):
-        A * np.identity(4)
+        A @ np.identity(4)
     with assert_raises(ValueError):
-        np.identity(4) * A
+        np.identity(4) @ A


### PR DESCRIPTION
#### Reference issue
Closes #11564.

#### What does this implement/fix?
If any exception is raised when multiplying a linear operator with a sparse matrix, this will recommend the user to wrap their matrix in `aslinearoperator` instead.

#### Additional information
Alternatively, we could expand the error message by adding a suggestion to implement a custom matmat, but I don't think this would benefit most users.