### PR TITLE
ENH:MAINT:linalg:lu Cythonized and ndarray support added

### DIFF
--- a/scipy/linalg/_cythonized_array_utils.pxd
+++ b/scipy/linalg/_cythonized_array_utils.pxd
@@ -34,7 +34,7 @@ ctypedef fused np_complex_numeric_t:
     cnp.complex128_t
 
 
-cdef void swap_c_and_f_layout(lapack_t *a, lapack_t *b, int r, int c, int n) noexcept nogil
+cdef void swap_c_and_f_layout(lapack_t *a, lapack_t *b, int r, int c) noexcept nogil
 cdef (int, int) band_check_internal_c(np_numeric_t[:, ::1]A) noexcept nogil
 cdef bint is_sym_her_real_c_internal(np_numeric_t[:, ::1]A) noexcept nogil
 cdef bint is_sym_her_complex_c_internal(np_complex_numeric_t[:, ::1]A) noexcept nogil

--- a/scipy/linalg/_cythonized_array_utils.pyx
+++ b/scipy/linalg/_cythonized_array_utils.pyx
@@ -66,34 +66,23 @@ def find_det_from_lu(lapack_t[:, ::1] a):
 
 
 # ====================== swap_c_and_f_layout : s, d, c, z ====================
-@cython.cdivision(True)
+@cython.nonecheck(False)
 @cython.wraparound(False)
 @cython.boundscheck(False)
 @cython.initializedcheck(False)
-cdef void swap_c_and_f_layout(lapack_t *a, lapack_t *b, int r, int c, int n) noexcept nogil:
-    """Recursive matrix transposition for square arrays"""
-    cdef int i, j, ith_row, r2, c2
-    cdef lapack_t *bb=b
-    cdef lapack_t *aa=a
-    if r < 16:
-        for j in range(c):
-            ith_row = 0
-            for i in range(r):
-            # Basically b[i*n+j] = a[j*n+i] without index math
-                bb[ith_row] = aa[i]
-                ith_row += n
-            aa += n
-            bb += 1
-    else:
-        # If tall
-        if (r > c):
-            r2 = r//2
-            swap_c_and_f_layout(a, b, r2, c, n)
-            swap_c_and_f_layout(a + r2, b+(r2)*n, r-r2, c, n)
-        else:  # Nope
-            c2 = c//2
-            swap_c_and_f_layout(a, b, r, c2, n);
-            swap_c_and_f_layout(a+(c2)*n, b+c2, r, c-c2, n)
+cdef inline void swap_c_and_f_layout(lapack_t *a, lapack_t *b, int r, int c) nogil:
+    """Copy+transpose for Cython LAPACK interfaces"""
+    cdef int row, col, k, ith_row, r2, c2
+    cdef lapack_t *bb = b
+    cdef lapack_t *aa = a
+
+    for col in range(c):
+        ith_row = 0
+        for row in range(r):
+            bb[row] = aa[ith_row]
+            ith_row += c
+        aa += 1
+        bb += r
 # ============================================================================
 
 

--- a/scipy/linalg/_cythonized_array_utils.pyx
+++ b/scipy/linalg/_cythonized_array_utils.pyx
@@ -3,8 +3,8 @@ cimport cython
 import numpy as np
 from scipy.linalg._cythonized_array_utils cimport (
     lapack_t,
-	np_complex_numeric_t,
-	np_numeric_t
+    np_complex_numeric_t,
+    np_numeric_t
     )
 from scipy.linalg.cython_lapack cimport sgetrf, dgetrf, cgetrf, zgetrf
 from libc.stdlib cimport malloc, free
@@ -70,9 +70,12 @@ def find_det_from_lu(lapack_t[:, ::1] a):
 @cython.wraparound(False)
 @cython.boundscheck(False)
 @cython.initializedcheck(False)
-cdef inline void swap_c_and_f_layout(lapack_t *a, lapack_t *b, int r, int c) nogil:
-    """Copy+transpose for Cython LAPACK interfaces"""
-    cdef int row, col, k, ith_row, r2, c2
+cdef inline void swap_c_and_f_layout(lapack_t *a, lapack_t *b, int r, int c) noexcept nogil:
+    """
+    Swap+copy the memory layout of same sized buffers mainly
+    for Cython LAPACK interfaces.
+    """
+    cdef int row, col, ith_row
     cdef lapack_t *bb = b
     cdef lapack_t *aa = a
 

--- a/scipy/linalg/_decomp_lu.py
+++ b/scipy/linalg/_decomp_lu.py
@@ -277,7 +277,7 @@ def lu(a, permute_l=False, overwrite_a=False, check_finite=True,
             U = np.empty(shape=[*nd, k, n], dtype=a1.dtype)
             return PL, U
         else:
-            P = (np.empty([*nd, 0], dtype=int) if p_indices else
+            P = (np.empty([*nd, 0], dtype=np.int32) if p_indices else
                  np.empty([*nd, 0, 0], dtype=real_dchar))
             L = np.empty(shape=[*nd, m, k], dtype=a1.dtype)
             U = np.empty(shape=[*nd, k, n], dtype=a1.dtype)
@@ -308,7 +308,7 @@ def lu(a, permute_l=False, overwrite_a=False, check_finite=True,
 
     if not nd:  # 2D array
 
-        p = np.empty(m, dtype=int)
+        p = np.empty(m, dtype=np.int32)
         u = np.zeros([k, k], dtype=a1.dtype)
         lu_dispatcher(a1, u, p, permute_l)
         P, L, U = (p, a1, u) if m > n else (p, u, a1)
@@ -316,7 +316,7 @@ def lu(a, permute_l=False, overwrite_a=False, check_finite=True,
     else:  # Stacked array
 
         # Prepare the contiguous data holders
-        P = np.empty([*nd, m], dtype=int)  # perm vecs
+        P = np.empty([*nd, m], dtype=np.int32)  # perm vecs
 
         if m > n:  # Tall arrays, U will be created
             U = np.zeros([*nd, k, k], dtype=a1.dtype)

--- a/scipy/linalg/_decomp_lu.py
+++ b/scipy/linalg/_decomp_lu.py
@@ -3,11 +3,16 @@
 from warnings import warn
 
 from numpy import asarray, asarray_chkfinite
+import numpy as np
+from itertools import product
 
 # Local imports
 from ._misc import _datacopied, LinAlgWarning
 from .lapack import get_lapack_funcs
-from ._flinalg_py import get_flinalg_funcs
+from ._decomp_lu_cython import lu_dispatcher
+
+lapack_cast_dict = {x: ''.join([y for y in 'fdFD' if np.can_cast(x, y)])
+                    for x in np.typecodes['All']}
 
 __all__ = ['lu', 'lu_solve', 'lu_factor']
 
@@ -151,16 +156,19 @@ def lu_solve(lu_and_piv, b, trans=0, overwrite_b=False, check_finite=True):
                      % -info)
 
 
-def lu(a, permute_l=False, overwrite_a=False, check_finite=True):
+def lu(a, permute_l=False, overwrite_a=False, check_finite=True,
+       p_indices=False):
     """
-    Compute pivoted LU decomposition of a matrix.
+    Compute LU decomposition of a matrix with partial pivoting.
 
-    The decomposition is::
+    The decomposition satisfies::
 
-        A = P L U
+        A = P @ L @ U
 
-    where P is a permutation matrix, L lower triangular with unit
-    diagonal elements, and U upper triangular.
+    where ``P`` is a permutation matrix, ``L`` lower triangular with unit
+    diagonal elements, and ``U`` upper triangular. If `permute_l` is set to
+    ``True`` then ``L`` is returned already permuted and hence satisfying
+    ``A = L @ U``.
 
     Parameters
     ----------
@@ -174,53 +182,143 @@ def lu(a, permute_l=False, overwrite_a=False, check_finite=True):
         Whether to check that the input matrix contains only finite numbers.
         Disabling may give a performance gain, but may result in problems
         (crashes, non-termination) if the inputs do contain infinities or NaNs.
+    p_indices : bool, optional
+        If ``True`` the permutation information is returned as row indices.
+        The default is ``False`` for backwards-compatibility reasons.
 
     Returns
     -------
-    **(If permute_l == False)**
+    **(If `permute_l` is ``False``)**
 
-    p : (M, M) ndarray
-        Permutation matrix
-    l : (M, K) ndarray
-        Lower triangular or trapezoidal matrix with unit diagonal.
-        K = min(M, N)
-    u : (K, N) ndarray
-        Upper triangular or trapezoidal matrix
+    p : (..., M, M) ndarray
+        Permutation arrays or vectors depending on `p_indices`
+    l : (..., M, K) ndarray
+        Lower triangular or trapezoidal array with unit diagonal.
+        ``K = min(M, N)``
+    u : (..., K, N) ndarray
+        Upper triangular or trapezoidal array
 
-    **(If permute_l == True)**
+    **(If `permute_l` is ``True``)**
 
-    pl : (M, K) ndarray
+    pl : (..., M, K) ndarray
         Permuted L matrix.
-        K = min(M, N)
-    u : (K, N) ndarray
-        Upper triangular or trapezoidal matrix
+        ``K = min(M, N)``
+    u : (..., K, N) ndarray
+        Upper triangular or trapezoidal array
 
     Notes
     -----
-    This is a LU factorization routine written for SciPy.
+    Permutation matrices are costly since they are nothing but row reorder of
+    ``L`` and hence indices are strongly recommended to be used instead if the
+    permutation is required. The relation in the 2D case then becomes simply
+    ``A = L[P, :] @ U``. In higher dimensions, it is better to use `permute_l`
+    to avoid complicated indexing tricks.
+
+    In 2D case, if one has the indices however, for some reason, the
+    permutation matrix is still needed then it can be constructed by
+    ``np.eye(M)[P, :]``.
 
     Examples
     --------
+
     >>> import numpy as np
     >>> from scipy.linalg import lu
     >>> A = np.array([[2, 5, 8, 7], [5, 2, 2, 8], [7, 5, 6, 6], [5, 4, 4, 8]])
     >>> p, l, u = lu(A)
-    >>> np.allclose(A - p @ l @ u, np.zeros((4, 4)))
+    >>> np.allclose(A, p @ l @ u)
+    True
+    >>> p  # Permutation matrix
+    array([[0., 1., 0., 0.],  # Row index 1
+           [0., 0., 0., 1.],  # Row index 3
+           [1., 0., 0., 0.],  # Row index 0
+           [0., 0., 1., 0.]]) # Row index 2
+    >>> p, _, _ = lu(A, p_indices=True)
+    >>> p
+    array([1, 3, 0, 2])  # as given by row indices above
+    >>> np.allclose(A, l[p, :] @ u)
+    True
+
+    We can also use nd-arrays, for example, a demonstration with 4D array:
+
+    >>> rng = np.random.default_rng()
+    >>> A = rng.uniform(low=-4, high=4, size=[3, 2, 4, 8])
+    >>> p, l, u = lu(A)
+    >>> p.shape, l.shape, u.shape
+    ((3, 2, 4, 4), (3, 2, 4, 4), (3, 2, 4, 8))
+    >>> np.allclose(A, p @ l @ u)
+    True
+    >>> PL, U = lu(A, permute_l=True)
+    >>> np.allclose(A, PL @ U)
     True
 
     """
-    if check_finite:
-        a1 = asarray_chkfinite(a)
-    else:
-        a1 = asarray(a)
-    if len(a1.shape) != 2:
-        raise ValueError('expected matrix')
-    overwrite_a = overwrite_a or (_datacopied(a1, a))
-    flu, = get_flinalg_funcs(('lu',), (a1,))
-    p, l, u, info = flu(a1, permute_l=permute_l, overwrite_a=overwrite_a)
-    if info < 0:
-        raise ValueError('illegal value in %dth argument of '
-                         'internal lu.getrf' % -info)
-    if permute_l:
-        return l, u
-    return p, l, u
+    a1 = np.asarray_chkfinite(a) if check_finite else np.asarray(a)
+    if a1.ndim < 2:
+        raise ValueError('The input array must be at least two-dimensional.')
+
+    # Also check if dtype is LAPACK compatible
+    if a1.dtype.char not in 'fdFD':
+        dtype_char = lapack_cast_dict[a1.dtype.char]
+        if not dtype_char:  # No casting possible
+            raise TypeError(f'The dtype {a1.dtype} cannot be cast '
+                            'to float(32, 64) or complex(64, 128).')
+
+        a1 = a1.astype(dtype_char[0])  # makes a copy, free to scratch
+        overwrite_a = True
+
+    # Then check overwrite permission
+    if not _datacopied(a1, a):  # "a"  still alive through "a1"
+        if not overwrite_a:
+            # Data belongs to "a" so make a copy
+            a1 = a1.copy(order='C')
+        #  else: Do nothing we'll use "a" if possible
+    # else:  a1 has its own data thus free to scratch
+
+    # Then layout checks, might happen that overwrite is allowed but original
+    # array was read-only or non-contiguous.
+
+    if not (a1.flags['C_CONTIGUOUS'] and a1.flags['WRITEABLE']):
+        a1 = a1.copy(order='C')
+
+    *nd, m, n = a1.shape
+    k = min(m, n)
+
+    if not nd:  # 2D array
+
+        p = np.empty(m, dtype=int)
+        u = np.zeros([k, k], dtype=a1.dtype)
+        lu_dispatcher(a1, u, p, permute_l)
+        P, L, U = (p, a1, u) if m > n else (p, u, a1)
+
+    else:  # Stacked array
+
+        # Prepare the contiguous data holders
+        P = np.empty([*nd, m], dtype=int)  # perm vecs
+
+        if m > n:  # Tall arrays, U will be created
+            U = np.zeros([*nd, k, k], dtype=a1.dtype)
+            for ind in product(*[range(x) for x in a1.shape[:-2]]):
+                lu_dispatcher(a1[ind], U[ind], P[ind], permute_l)
+            L = a1
+
+        else:  # Fat arrays, L will be created
+            L = np.zeros([*nd, k, k], dtype=a1.dtype)
+            for ind in product(*[range(x) for x in a1.shape[:-2]]):
+                lu_dispatcher(a1[ind], L[ind], P[ind], permute_l)
+            U = a1
+
+    # Convert permutation vecs to permutation arrays
+    # permute_l=False needed to enter here to avoid wasted efforts
+    if (not p_indices) and (not permute_l):
+        if nd:
+            Pa = np.zeros([*nd, m, m], dtype=int)
+            # An unreadable index hack - One-hot encoding for perm matrices
+            nd_ix = np.ix_(*([np.arange(x) for x in nd]+[np.arange(m)]))
+            Pa[(*nd_ix, P)] = 1
+            P = Pa
+        else:  # 2D case
+            Pa = np.zeros([m, m])
+            Pa[np.arange(m), P] = 1
+            P = Pa
+
+    return (L, U) if permute_l else (P, L, U)

--- a/scipy/linalg/_decomp_lu_cython.pyi
+++ b/scipy/linalg/_decomp_lu_cython.pyi
@@ -1,0 +1,6 @@
+from numpy.typing import NDArray
+from typing import Any
+
+def lu_decompose(a: NDArray[Any], lu: NDArray[Any], perm: NDArray[Any], permute_l: bool) -> None: ...
+
+def lu_dispatcher(a: NDArray[Any], lu: NDArray[Any], perm: NDArray[Any], permute_l: bool) -> None: ...

--- a/scipy/linalg/_decomp_lu_cython.pyx
+++ b/scipy/linalg/_decomp_lu_cython.pyx
@@ -1,0 +1,160 @@
+# cython: language_level=3
+
+import cython
+from cpython.mem cimport PyMem_Malloc, PyMem_Free
+from libc.string cimport memcpy
+
+from scipy.linalg.cython_lapack cimport sgetrf, dgetrf, cgetrf, zgetrf
+from scipy.linalg._cythonized_array_utils cimport lapack_t, swap_c_and_f_layout
+
+import numpy as np
+cimport numpy as cnp
+cnp.import_array()
+
+
+ctypedef double complex doubleComplex
+ctypedef float complex floatComplex
+
+
+@cython.nonecheck(False)
+@cython.wraparound(False)
+@cython.boundscheck(False)
+@cython.initializedcheck(False)
+cdef void lu_decompose(cnp.ndarray[lapack_t, ndim=2] a,
+                       cnp.ndarray[lapack_t, ndim=2] lu,
+                       int[::1] perm,
+                       bint permute_l):
+    """LU decomposition and copy operations using ?getrf routines
+    
+    This function overwrites inputs. For interfacing LAPACK,
+    it creates a memory buffer and copies into with F-order
+    then swaps back to C order hence no need for dealing with
+    Fortran arrays which are inconvenient.
+    
+    After the LU factorization, to minimize the amount of data
+    copied, for rectangle arrays, and depending on the size,
+    the smaller portion is copied out to U and the rest becomes
+    either U or L. The logic is handled by the caller.
+
+            ┌     ┐
+            │ \ U │
+            │  \  │       ┌                ┐
+            │   \ │       │  \             │
+         a= │     │  or   │   \      U     │
+            │ L   │       │ L  \           │
+            │     │       └                ┘
+            └     ┘
+             tall               wide
+         (extract U)         (extract L)
+
+    """
+    cdef int m = a.shape[0], n = a.shape[1], mn = min(m, n)
+    cdef cnp.npy_intp dims[2]
+    cdef int info = 0, ind1, ind2, tmp_int
+    cdef lapack_t *aa = <lapack_t *>cnp.PyArray_DATA(a)
+    cdef lapack_t *bb
+    cdef int *ipiv = <int*>PyMem_Malloc(m * sizeof(int))
+    if not ipiv:
+        raise MemoryError('scipy.linalg.lu failed to allocate '
+                          'required memory.')
+    dims[0] = m
+    dims[1] = n
+
+    if lapack_t is float:
+        b = cnp.PyArray_SimpleNew(2, dims, cnp.NPY_FLOAT32)
+        bb = <float *>cnp.PyArray_DATA(b)
+        swap_c_and_f_layout(aa, bb, m, n)
+        sgetrf(&m, &n, bb, &m, ipiv, &info)
+    elif lapack_t is double:
+        b = cnp.PyArray_SimpleNew(2, dims, cnp.NPY_FLOAT64)
+        bb = <double *>cnp.PyArray_DATA(b)
+        swap_c_and_f_layout(aa, bb, m, n)
+        dgetrf(&m, &n, bb, &m, ipiv, &info)
+    elif lapack_t is floatcomplex:
+        b = cnp.PyArray_SimpleNew(2, dims, cnp.NPY_COMPLEX64)
+        bb = <floatComplex*>cnp.PyArray_DATA(b)
+        swap_c_and_f_layout(aa, bb, m, n)
+        cgetrf(&m, &n, bb, &m, ipiv, &info)
+    else:
+        b = cnp.PyArray_SimpleNew(2, dims, cnp.NPY_COMPLEX128)
+        bb = <doubleComplex *>cnp.PyArray_DATA(b)
+        swap_c_and_f_layout(aa, bb, m, n)
+        zgetrf(&m, &n, bb, &m, ipiv, &info)
+
+    if info < 0:
+        raise ValueError('scipy.linalg.lu has encountered an internal'
+                         ' error in ?getrf routine with invalid value'
+                         f' at {-info}-th parameter.')
+
+    # Get the result back to C-contiguous layout and clean-up
+    swap_c_and_f_layout(bb, aa, n, m)
+
+    # Convert swaps on A to permutations on L since A = P @ L @ U
+    try:
+        # Basically we are following the cycles in ipiv
+        # and swapping an "np.arange" array for the inverse perm.
+        # Initialize perm
+        for ind1 in range(m): perm[ind1] = ind1
+        for ind1 in range(mn):
+            tmp_int = perm[ipiv[ind1]-1]
+            perm[ipiv[ind1]-1] = perm[ind1]
+            perm[ind1] = tmp_int
+
+        # convert iperm to perm into ipiv and store back into perm
+        # as final. Solution without argsort : ipiv[perm] = np.arange(m)
+        for ind1 in range(m):
+            ipiv[perm[ind1]] = ind1
+        memcpy(&perm[0], ipiv, m*sizeof(int))
+    finally:
+        PyMem_Free(ipiv)
+
+    # Seperation of L and U parts
+
+    if m > n:  # tall, "a" holds bigger L
+        # Extract upper right rectangle to lu
+        for ind1 in range(mn):  # rows
+            lu[ind1, ind1:mn] = a[ind1, ind1:mn]
+
+        for ind1 in range(mn):
+            a[ind1, ind1] = 1
+            a[ind1, ind1+1:mn] = 0
+            
+    else:  # square or fat, "a" holds bigger U
+
+        lu[0, 0] = 1
+        for ind1 in range(1, mn):  # rows
+            lu[ind1, :ind1] = a[ind1, :ind1]
+            lu[ind1, ind1] = 1
+
+        for ind2 in range(mn - 1):  # cols
+            for ind1 in range(ind2+1, m):  # rows
+                a[ind1, ind2] = 0
+    
+    if permute_l:
+        # b still exists -> use it as temp array
+        # we copy everything to b and pick back
+        # rows from b as dictated by perm
+        memcpy(bb, 
+               (&a[0, 0] if m > n else &lu[0, 0]),
+               m*n*sizeof(lapack_t)
+              )
+        for ind1 in range(m):
+            if perm[ind1] == ind1:  # Row is not permuted
+                continue
+            else:
+                memcpy((&a[ind1, 0] if m > n else &lu[ind1, 0]),
+                       bb + (perm[ind1]*mn),  # stride rows
+                       mn*sizeof(lapack_t))  # copy 1 row of mem
+
+
+@cython.nonecheck(False)
+@cython.initializedcheck(False)
+def lu_dispatcher(a, u, piv, permute_l):
+    if a.dtype.char == 'f':
+        lu_decompose[float](a, u, piv, permute_l)
+    elif a.dtype.char == 'd':
+        lu_decompose[double](a, u, piv, permute_l)
+    elif a.dtype.char == 'F':
+        lu_decompose[floatcomplex](a, u, piv, permute_l)
+    else:
+        lu_decompose[doublecomplex](a, u, piv, permute_l)

--- a/scipy/linalg/_decomp_lu_cython.pyx
+++ b/scipy/linalg/_decomp_lu_cython.pyx
@@ -7,7 +7,6 @@ from libc.string cimport memcpy
 from scipy.linalg.cython_lapack cimport sgetrf, dgetrf, cgetrf, zgetrf
 from scipy.linalg._cythonized_array_utils cimport lapack_t, swap_c_and_f_layout
 
-import numpy as np
 cimport numpy as cnp
 cnp.import_array()
 
@@ -23,7 +22,7 @@ ctypedef float complex floatComplex
 cdef void lu_decompose(cnp.ndarray[lapack_t, ndim=2] a,
                        cnp.ndarray[lapack_t, ndim=2] lu,
                        int[::1] perm,
-                       bint permute_l):
+                       bint permute_l) noexcept:
     """LU decomposition and copy operations using ?getrf routines
     
     This function overwrites inputs. For interfacing LAPACK,

--- a/scipy/linalg/_matfuncs_expm.pyx.in
+++ b/scipy/linalg/_matfuncs_expm.pyx.in
@@ -299,7 +299,7 @@ cdef void pade_357_UV_calc_{{ pfx }}({{ tname }}[:, :, ::]Am, int n, int m) noex
         {{ pfx }}axpy(&n2, &neg_one, &Am[3, 0, 0], &int_one, &Am[1, 0, 0], &int_one)
 
         # Convert array layout for solving AX = B into Am[2]
-        swap_c_and_f_layout(&Am[3, 0, 0], &Am[2, 0, 0], n, n, n)
+        swap_c_and_f_layout(&Am[3, 0, 0], &Am[2, 0, 0], n, n)
 
         {{ pfx }}getrf( &n, &n, &Am[1, 0, 0], &n, &ipiv[0], &info )
         {{ pfx }}getrs(<char*>'T', &n, &n, &Am[1, 0, 0], &n, &ipiv[0], &Am[2, 0, 0], &n, &info )
@@ -308,7 +308,7 @@ cdef void pade_357_UV_calc_{{ pfx }}({{ tname }}[:, :, ::]Am, int n, int m) noex
             Am[2, i, i] = Am[2, i, i] + 1.
 
         # Put it back in Am in C order
-        swap_c_and_f_layout(&Am[2, 0, 0], &Am[0, 0, 0], n, n, n)
+        swap_c_and_f_layout(&Am[2, 0, 0], &Am[0, 0, 0], n, n)
     finally:
         free(ipiv)
 
@@ -363,7 +363,7 @@ cdef void pade_9_UV_calc_{{ pfx }}({{ tname }}[:, :, ::]Am, int n) noexcept nogi
         {{ pfx }}axpy(&n2, &neg_one, &Am[3, 0, 0], &int_one, &Am[1, 0, 0], &int_one)
 
         # Convert array layout for solving AX = B into Am[2]
-        swap_c_and_f_layout(&Am[3, 0, 0], &Am[2, 0, 0], n, n, n)
+        swap_c_and_f_layout(&Am[3, 0, 0], &Am[2, 0, 0], n, n)
 
         {{ pfx }}getrf( &n, &n, &Am[1, 0, 0], &n, &ipiv[0], &info )
         {{ pfx }}getrs(<char*>'T', &n, &n, &Am[1, 0, 0], &n, &ipiv[0], &Am[2, 0, 0], &n, &info)
@@ -372,7 +372,7 @@ cdef void pade_9_UV_calc_{{ pfx }}({{ tname }}[:, :, ::]Am, int n) noexcept nogi
             Am[2, i, i] = Am[2, i, i] + 1.
 
         # Put it back in Am in C order
-        swap_c_and_f_layout(&Am[2, 0, 0], &Am[0, 0, 0], n, n, n)
+        swap_c_and_f_layout(&Am[2, 0, 0], &Am[0, 0, 0], n, n)
     finally:
         free(work)
         free(ipiv)
@@ -449,7 +449,7 @@ cdef void pade_13_UV_calc_{{ pfx }}({{ tname }}[:, :, ::1]Am, int n) noexcept no
         {{ pfx }}axpy(&n2, &neg_one, &work2[0], &int1, &work3[0], &int1)
 
         # Convert array layout for solving AX = B into work4
-        swap_c_and_f_layout(work2, work4, n, n, n)
+        swap_c_and_f_layout(work2, work4, n, n)
 
         {{ pfx }}getrf( &n, &n, &work3[0], &n, &ipiv[0], &info )
         {{ pfx }}getrs(<char*>'T', &n, &n, &work3[0], &n, &ipiv[0], &work4[0], &n, &info )
@@ -457,7 +457,7 @@ cdef void pade_13_UV_calc_{{ pfx }}({{ tname }}[:, :, ::1]Am, int n) noexcept no
         for i in range(n):
             work4[i*(n+1)] += 1.
         # Put it back in Am in C order
-        swap_c_and_f_layout(work4, &Am[0, 0, 0], n, n, n)
+        swap_c_and_f_layout(work4, &Am[0, 0, 0], n, n)
     finally:
         free(ipiv)
         free(work2)

--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -235,6 +235,15 @@ cython_lapack = py3.extension_module('cython_lapack',
   subdir: 'scipy/linalg'
 )
 
+py3.extension_module('_decomp_lu_cython',
+  linalg_cython_gen.process('_decomp_lu_cython.pyx'),
+  c_args: cython_c_args,
+  dependencies: np_dep,
+  link_args: version_link_args,
+  install: true,
+  subdir: 'scipy/linalg'
+)
+
 _decomp_update_pyx = custom_target('_decomp_update',
   output: '_decomp_update.pyx',
   input: '_decomp_update.pyx.in',
@@ -286,6 +295,7 @@ python_sources = [
   '_decomp_cossin.py',
   '_decomp_ldl.py',
   '_decomp_lu.py',
+  '_decomp_lu_cython.pyi',
   '_decomp_polar.py',
   '_decomp_qr.py',
   '_decomp_qz.py',

--- a/scipy/linalg/setup.py
+++ b/scipy/linalg/setup.py
@@ -6,8 +6,10 @@ def configuration(parent_package='', top_path=None):
     from distutils.sysconfig import get_python_inc
     from numpy.distutils.system_info import get_info, numpy_info
     from numpy.distutils.misc_util import Configuration, get_numpy_include_dirs
-    from scipy._build_utils import (get_g77_abi_wrappers, gfortran_legacy_flag_hook,
-                                    blas_ilp64_pre_build_hook, get_f2py_int64_options,
+    from scipy._build_utils import (get_g77_abi_wrappers,
+                                    gfortran_legacy_flag_hook,
+                                    blas_ilp64_pre_build_hook,
+                                    get_f2py_int64_options,
                                     uses_blas64)
 
     config = Configuration('linalg', parent_package, top_path)
@@ -143,20 +145,17 @@ def configuration(parent_package='', top_path=None):
                          libraries=['fwrappers'],
                          extra_info=lapack_opt)
 
-    config.add_extension('_decomp_update',
-                         sources=['_decomp_update.c'])
-
-    config.add_data_files('_cythonized_array_utils.pxd')
-
     config.add_extension('_cythonized_array_utils',
                          sources=['_cythonized_array_utils.c'],
                          depends=['_cythonized_array_utils.pyx',
                                   '_cythonized_array_utils.pxd'],
                          include_dirs=['.']
                          )
+    config.add_data_files('_cythonized_array_utils.pxd')
 
-    config.add_extension('_matfuncs_expm',
-                         sources=['_matfuncs_expm.c'])
+    config.add_extension('_decomp_update', sources=['_decomp_update.c'])
+    config.add_extension('_decomp_lu_cython', sources=['_decomp_lu_cython.c'])
+    config.add_extension('_matfuncs_expm', sources=['_matfuncs_expm.c'])
 
     # Add any license files
     config.add_data_files('src/id_dist/doc/doc.tex')

--- a/scipy/linalg/tests/meson.build
+++ b/scipy/linalg/tests/meson.build
@@ -9,6 +9,7 @@ python_sources = [
   'test_decomp_cholesky.py',
   'test_decomp_cossin.py',
   'test_decomp_ldl.py',
+  'test_decomp_lu.py',
   'test_decomp_polar.py',
   'test_decomp_update.py',
   'test_fblas.py',

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -1,13 +1,3 @@
-""" Test functions for linalg.decomp module
-
-"""
-__usage__ = """
-Build linalg:
-  python setup_linalg.py build
-Run tests if scipy is installed:
-  python -c 'import scipy;scipy.linalg.test()'
-"""
-
 import itertools
 import platform
 import sys
@@ -28,8 +18,7 @@ from scipy.linalg import (eig, eigvals, lu, svd, svdvals, cholesky, qr,
                           eigh_tridiagonal, null_space, cdf2rdf, LinAlgError)
 
 from scipy.linalg.lapack import (dgbtrf, dgbtrs, zgbtrf, zgbtrs, dsbev,
-                                 dsbevd, dsbevx, zhbevd, zhbevx,
-                                 get_lapack_funcs)
+                                 dsbevd, dsbevx, zhbevd, zhbevx)
 
 from scipy.linalg._misc import norm
 from scipy.linalg._decomp_qz import _select_function
@@ -50,6 +39,7 @@ try:
     from scipy.__config__ import CONFIG
 except ImportError:
     CONFIG = None
+
 
 def _random_hermitian_matrix(n, posdef=False, dtype=float):
     "Generate random sym/hermitian array of the given size n"
@@ -911,144 +901,6 @@ class TestEigh:
         w, v = eigh(a, subset_by_index=[0, 1])
         assert_allclose(w_dep, w)
         assert_allclose(v_dep, v)
-
-
-class TestLU:
-    def setup_method(self):
-        self.a = array([[1, 2, 3], [1, 2, 3], [2, 5, 6]])
-        self.ca = array([[1, 2, 3], [1, 2, 3], [2, 5j, 6]])
-        # Those matrices are more robust to detect problems in permutation
-        # matrices than the ones above
-        self.b = array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
-        self.cb = array([[1j, 2j, 3j], [4j, 5j, 6j], [7j, 8j, 9j]])
-
-        # Reectangular matrices
-        self.hrect = array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 12, 12]])
-        self.chrect = 1.j * array([[1, 2, 3, 4],
-                                   [5, 6, 7, 8],
-                                   [9, 10, 12, 12]])
-
-        self.vrect = array([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 12, 12]])
-        self.cvrect = 1.j * array([[1, 2, 3],
-                                   [4, 5, 6],
-                                   [7, 8, 9],
-                                   [10, 12, 12]])
-
-        # Medium sizes matrices
-        self.med = random((30, 40))
-        self.cmed = random((30, 40)) + 1.j * random((30, 40))
-
-    def _test_common(self, data):
-        p, l, u = lu(data)
-        assert_array_almost_equal(p @ l @ u, data)
-        pl, u = lu(data, permute_l=1)
-        assert_array_almost_equal(pl @ u, data)
-
-    def _test_common_lu_factor(self, data):
-        l_and_u1, piv1 = lu_factor(data)
-        (getrf,) = get_lapack_funcs(("getrf",), (data,))
-        l_and_u2, piv2, _ = getrf(data, overwrite_a=False)
-        assert_array_equal(l_and_u1, l_and_u2)
-        assert_array_equal(piv1, piv2)
-
-    # Simple tests.
-    # For lu_factor gives a LinAlgWarning because these matrices are singular
-    def test_simple(self):
-        self._test_common(self.a)
-
-    def test_simple_complex(self):
-        self._test_common(self.ca)
-
-    def test_simple2(self):
-        self._test_common(self.b)
-
-    def test_simple2_complex(self):
-        self._test_common(self.cb)
-
-    # rectangular matrices tests
-    def test_hrectangular(self):
-        self._test_common(self.hrect)
-        self._test_common_lu_factor(self.hrect)
-
-    def test_vrectangular(self):
-        self._test_common(self.vrect)
-        self._test_common_lu_factor(self.vrect)
-
-    def test_hrectangular_complex(self):
-        self._test_common(self.chrect)
-        self._test_common_lu_factor(self.chrect)
-
-    def test_vrectangular_complex(self):
-        self._test_common(self.cvrect)
-        self._test_common_lu_factor(self.cvrect)
-
-    # Bigger matrices
-    def test_medium1(self):
-        """Check lu decomposition on medium size, rectangular matrix."""
-        self._test_common(self.med)
-        self._test_common_lu_factor(self.med)
-
-    def test_medium1_complex(self):
-        """Check lu decomposition on medium size, rectangular matrix."""
-        self._test_common(self.cmed)
-        self._test_common_lu_factor(self.cmed)
-
-    def test_check_finite(self):
-        p, l, u = lu(self.a, check_finite=False)
-        assert_array_almost_equal(p @ l @ u, self.a)
-
-    def test_simple_known(self):
-        # Ticket #1458
-        for order in ['C', 'F']:
-            A = np.array([[2, 1], [0, 1.]], order=order)
-            LU, P = lu_factor(A)
-            assert_array_almost_equal(LU, np.array([[2, 1], [0, 1]]))
-            assert_array_equal(P, np.array([0, 1]))
-
-
-class TestLUSingle(TestLU):
-    """LU testers for single precision, real and double"""
-
-    def setup_method(self):
-        TestLU.setup_method(self)
-
-        self.a = self.a.astype(float32)
-        self.ca = self.ca.astype(complex64)
-        self.b = self.b.astype(float32)
-        self.cb = self.cb.astype(complex64)
-
-        self.hrect = self.hrect.astype(float32)
-        self.chrect = self.hrect.astype(complex64)
-
-        self.vrect = self.vrect.astype(float32)
-        self.cvrect = self.vrect.astype(complex64)
-
-        self.med = self.vrect.astype(float32)
-        self.cmed = self.vrect.astype(complex64)
-
-
-class TestLUSolve:
-    def setup_method(self):
-        seed(1234)
-
-    def test_lu(self):
-        a0 = random((10, 10))
-        b = random((10,))
-
-        for order in ['C', 'F']:
-            a = np.array(a0, order=order)
-            x1 = solve(a, b)
-            lu_a = lu_factor(a)
-            x2 = lu_solve(lu_a, b)
-            assert_array_almost_equal(x1, x2)
-
-    def test_check_finite(self):
-        a = random((10, 10))
-        b = random((10,))
-        x1 = solve(a, b)
-        lu_a = lu_factor(a, check_finite=False)
-        x2 = lu_solve(lu_a, b, check_finite=False)
-        assert_array_almost_equal(x1, x2)
 
 
 class TestSVD_GESDD:

--- a/scipy/linalg/tests/test_decomp_lu.py
+++ b/scipy/linalg/tests/test_decomp_lu.py
@@ -1,0 +1,203 @@
+import pytest
+from pytest import raises as assert_raises
+
+import numpy as np
+from scipy.linalg import lu, lu_factor, lu_solve, get_lapack_funcs, solve
+from numpy.testing import assert_allclose, assert_array_equal
+
+
+class TestLU:
+    def setup_method(self):
+        self.rng = np.random.default_rng(1682281250228846)
+
+    @pytest.mark.parametrize('shape', [[2, 2], [2, 4], [4, 2],
+                                       [20, 20], [20, 4], [4, 20],
+                                       [3, 2, 23, 23], [3, 2, 17, 5],
+                                       [3, 2, 11, 59]])
+    def test_simple_det_shapes_real_complex(self, shape):
+        a = self.rng.uniform(-10., 10., size=shape)
+        p, l, u = lu(a)
+        assert_allclose(a, p @ l @ u)
+        pl, u = lu(a, permute_l=True)
+        assert_allclose(a, pl @ u)
+
+        b = self.rng.uniform(-10., 10., size=shape)*1j
+        b += self.rng.uniform(-10, 10, size=shape)
+        pl, u = lu(b, permute_l=True)
+        assert_allclose(b, pl @ u)
+
+    @pytest.mark.parametrize('shape', [[2, 2], [2, 4], [4, 2], [20, 20],
+                                       [20, 4], [4, 20]])
+    def test_simple_det_shapes_real_complex_2d_indices(self, shape):
+        a = self.rng.uniform(-10., 10., size=shape)
+        p, l, u = lu(a, p_indices=True)
+        assert_allclose(a, l[p, :] @ u)
+
+    def test_1by1_input_output(self):
+        a = self.rng.random([4, 5, 1, 1], dtype=np.float32)
+        p, l, u = lu(a, p_indices=True)
+        assert_allclose(p, np.zeros(shape=(4, 5, 1), dtype=int))
+        assert_allclose(l, np.ones(shape=(4, 5, 1, 1), dtype=np.float32))
+        assert_allclose(u, a)
+
+        a = self.rng.random([4, 5, 1, 1], dtype=np.float32)
+        p, l, u = lu(a)
+        assert_allclose(p, np.ones(shape=(4, 5, 1, 1), dtype=np.float32))
+        assert_allclose(l, np.ones(shape=(4, 5, 1, 1), dtype=np.float32))
+        assert_allclose(u, a)
+
+        pl, u = lu(a, permute_l=True)
+        assert_allclose(pl, np.ones(shape=(4, 5, 1, 1), dtype=np.float32))
+        assert_allclose(u, a)
+
+        a = self.rng.random([4, 5, 1, 1], dtype=np.float32)*np.complex64(1.j)
+        p, l, u = lu(a)
+        assert_allclose(p, np.ones(shape=(4, 5, 1, 1), dtype=np.complex64))
+        assert_allclose(l, np.ones(shape=(4, 5, 1, 1), dtype=np.complex64))
+        assert_allclose(u, a)
+
+    def test_empty_edge_cases(self):
+        a = np.empty([0, 0])
+        p, l, u = lu(a)
+        assert_allclose(p, np.empty(shape=(0, 0), dtype=np.float64))
+        assert_allclose(l, np.empty(shape=(0, 0), dtype=np.float64))
+        assert_allclose(u, np.empty(shape=(0, 0), dtype=np.float64))
+
+        a = np.empty([0, 3], dtype=np.float16)
+        p, l, u = lu(a)
+        assert_allclose(p, np.empty(shape=(0, 0), dtype=np.float32))
+        assert_allclose(l, np.empty(shape=(0, 0), dtype=np.float32))
+        assert_allclose(u, np.empty(shape=(0, 3), dtype=np.float32))
+
+        a = np.empty([3, 0], dtype=np.complex64)
+        p, l, u = lu(a)
+        assert_allclose(p, np.empty(shape=(0, 0), dtype=np.float32))
+        assert_allclose(l, np.empty(shape=(3, 0), dtype=np.complex64))
+        assert_allclose(u, np.empty(shape=(0, 0), dtype=np.complex64))
+        p, l, u = lu(a, p_indices=True)
+        assert_allclose(p, np.empty(shape=(0,), dtype=int))
+        assert_allclose(l, np.empty(shape=(3, 0), dtype=np.complex64))
+        assert_allclose(u, np.empty(shape=(0, 0), dtype=np.complex64))
+        pl, u = lu(a, permute_l=True)
+        assert_allclose(pl, np.empty(shape=(3, 0), dtype=np.complex64))
+        assert_allclose(u, np.empty(shape=(0, 0), dtype=np.complex64))
+
+        a = np.empty([3, 0, 0], dtype=np.complex64)
+        p, l, u = lu(a)
+        assert_allclose(p, np.empty(shape=(3, 0, 0), dtype=np.float32))
+        assert_allclose(l, np.empty(shape=(3, 0, 0), dtype=np.complex64))
+        assert_allclose(u, np.empty(shape=(3, 0, 0), dtype=np.complex64))
+
+        a = np.empty([0, 0, 3])
+        p, l, u = lu(a)
+        assert_allclose(p, np.empty(shape=(0, 0, 0)))
+        assert_allclose(l, np.empty(shape=(0, 0, 0)))
+        assert_allclose(u, np.empty(shape=(0, 0, 3)))
+
+        with assert_raises(ValueError, match='at least two-dimensional'):
+            lu(np.array([]))
+
+        a = np.array([[]])
+        p, l, u = lu(a)
+        assert_allclose(p, np.empty(shape=(0, 0)))
+        assert_allclose(l, np.empty(shape=(1, 0)))
+        assert_allclose(u, np.empty(shape=(0, 0)))
+
+        a = np.array([[[]]])
+        p, l, u = lu(a)
+        assert_allclose(p, np.empty(shape=(1, 0, 0)))
+        assert_allclose(l, np.empty(shape=(1, 1, 0)))
+        assert_allclose(u, np.empty(shape=(1, 0, 0)))
+
+
+class TestLUFactor:
+    def setup_method(self):
+        self.rng = np.random.default_rng(1682281250228846)
+
+        self.a = np.array([[1, 2, 3], [1, 2, 3], [2, 5, 6]])
+        self.ca = np.array([[1, 2, 3], [1, 2, 3], [2, 5j, 6]])
+        # Those matrices are more robust to detect problems in permutation
+        # matrices than the ones above
+        self.b = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+        self.cb = np.array([[1j, 2j, 3j], [4j, 5j, 6j], [7j, 8j, 9j]])
+
+        # Reectangular matrices
+        self.hrect = np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 12, 12]])
+        self.chrect = np.array([[1, 2, 3, 4], [5, 6, 7, 8],
+                                [9, 10, 12, 12]]) * 1.j
+
+        self.vrect = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 12, 12]])
+        self.cvrect = 1.j * np.array([[1, 2, 3],
+                                      [4, 5, 6],
+                                      [7, 8, 9],
+                                      [10, 12, 12]])
+
+        # Medium sizes matrices
+        self.med = self.rng.random((30, 40))
+        self.cmed = self.rng.random((30, 40)) + 1.j*self.rng.random((30, 40))
+
+    def _test_common_lu_factor(self, data):
+        l_and_u1, piv1 = lu_factor(data)
+        (getrf,) = get_lapack_funcs(("getrf",), (data,))
+        l_and_u2, piv2, _ = getrf(data, overwrite_a=False)
+        assert_allclose(l_and_u1, l_and_u2)
+        assert_allclose(piv1, piv2)
+
+    # Simple tests.
+    # For lu_factor gives a LinAlgWarning because these matrices are singular
+    def test_hrectangular(self):
+        self._test_common_lu_factor(self.hrect)
+
+    def test_vrectangular(self):
+        self._test_common_lu_factor(self.vrect)
+
+    def test_hrectangular_complex(self):
+        self._test_common_lu_factor(self.chrect)
+
+    def test_vrectangular_complex(self):
+        self._test_common_lu_factor(self.cvrect)
+
+    # Bigger matrices
+    def test_medium1(self):
+        """Check lu decomposition on medium size, rectangular matrix."""
+        self._test_common_lu_factor(self.med)
+
+    def test_medium1_complex(self):
+        """Check lu decomposition on medium size, rectangular matrix."""
+        self._test_common_lu_factor(self.cmed)
+
+    def test_check_finite(self):
+        p, l, u = lu(self.a, check_finite=False)
+        assert_allclose(p @ l @ u, self.a)
+
+    def test_simple_known(self):
+        # Ticket #1458
+        for order in ['C', 'F']:
+            A = np.array([[2, 1], [0, 1.]], order=order)
+            LU, P = lu_factor(A)
+            assert_allclose(LU, np.array([[2, 1], [0, 1]]))
+            assert_array_equal(P, np.array([0, 1]))
+
+
+class TestLUSolve:
+    def setup_method(self):
+        self.rng = np.random.default_rng(1682281250228846)
+
+    def test_lu(self):
+        a0 = self.rng.random((10, 10))
+        b = self.rng.random((10,))
+
+        for order in ['C', 'F']:
+            a = np.array(a0, order=order)
+            x1 = solve(a, b)
+            lu_a = lu_factor(a)
+            x2 = lu_solve(lu_a, b)
+            assert_allclose(x1, x2)
+
+    def test_check_finite(self):
+        a = self.rng.random((10, 10))
+        b = self.rng.random((10,))
+        x1 = solve(a, b)
+        lu_a = lu_factor(a, check_finite=False)
+        x2 = lu_solve(lu_a, b, check_finite=False)
+        assert_allclose(x1, x2)


### PR DESCRIPTION
Another PR for stacked versions of linalg funcs. This time it is the second and last leg of getting rid of FORTRAN module `flinalg` that was living inside `/scipy/linalg/src`. Old tests were a bit too trivial hence replaced with better ones.

It would be great if you can validate or offer new ideas for the newly introduced `p_indices` keyword. I can't think of a short and sweet alternative so went with the least confusing (to me) option. See [matlab handling it via `outputForm` parameter ](https://www.mathworks.com/help/matlab/ref/lu.html#mw_c7ac10f5-4b1d-4b24-aac5-cb08fc302896)(mathematica only returns indices anyways). I'll send a bike-shedding mail to the mailing list. 

I had to touch `matfuncs_expm.pyx.in` file to fix a generic problem I introduced when I cythonized it, but you can ignore it. It's a really big review (again, sigh... not fun authoring it either) but any feedback is welcome.



#### What does this implement/fix?
- Introduced a new keyword `p_indices` for returning permutation info as a vector instead of very costly matrices
- Removed the dependency to custom Fortran code in `/linalg/src/lu.f` (`_flinalg` module can be removed after this)
- Separated existing tests to their own file and added more
- Touched the documentation for cosmetics
- Performance is quite improved (3X-5X until roughly `n=100` then depends on LAPACK lib).
- Now supports arbitrary stacked arrays
- Also supports all numeric dtypes excluding float128, complex256.
- Handles all kinds of empty arrays
- Quick returns for `(1, 1)` and `(..., 1, 1)` shaped arrays

