### PR TITLE
MAINT: Add noexcept function declaration to `_cythonized_array_utils.pxd`

### DIFF
--- a/scipy/linalg/_cythonized_array_utils.pxd
+++ b/scipy/linalg/_cythonized_array_utils.pxd
@@ -34,7 +34,7 @@ ctypedef fused np_complex_numeric_t:
     cnp.complex128_t
 
 
-cdef void swap_c_and_f_layout(lapack_t *a, lapack_t *b, int r, int c, int n) nogil
-cdef (int, int) band_check_internal_c(np_numeric_t[:, ::1]A) nogil
-cdef bint is_sym_her_real_c_internal(np_numeric_t[:, ::1]A) nogil
-cdef bint is_sym_her_complex_c_internal(np_complex_numeric_t[:, ::1]A) nogil
+cdef void swap_c_and_f_layout(lapack_t *a, lapack_t *b, int r, int c, int n) noexcept nogil
+cdef (int, int) band_check_internal_c(np_numeric_t[:, ::1]A) noexcept nogil
+cdef bint is_sym_her_real_c_internal(np_numeric_t[:, ::1]A) noexcept nogil
+cdef bint is_sym_her_complex_c_internal(np_complex_numeric_t[:, ::1]A) noexcept nogil


### PR DESCRIPTION
to match `_cythonized_array_utils.pyx`.

#### Reference issue
Part of https://github.com/scipy/scipy/issues/17234

#### What does this implement/fix?
Added several missed `noexcept` keywords in _cythonized_array_utils.pxd to match pyx file

#### Additional information
see PR #18266
