### PR TITLE
CI: pin to rtools40

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -107,7 +107,7 @@ jobs:
       - name: win_amd64 - install rtools
         run: |
           # mingw-w64
-          choco install rtools --no-progress
+          choco install rtools -y --no-progress --force --version=4.0.0.20220206
           echo "c:\rtools40\ucrt64\bin;" >> $env:GITHUB_PATH
         if: ${{ runner.os == 'Windows' && env.IS_32_BIT == 'false' }}
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -37,10 +37,8 @@ jobs:
           cache-dependency-path: 'environment.yml'
       - name: Install rtools (mingw-w64)
         run: |
-          choco install rtools --no-progress
+          choco install rtools --no-progress --version=4.0.0.20220206
           echo "c:\rtools40\ucrt64\bin;" >> $env:GITHUB_PATH
-          choco install pkgconfiglite
-          echo "C:\ProgramData\chocolatey\bin\;" >> $env:GITHUB_PATH
 
       - name: show-gfortran
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,7 +21,7 @@ jobs:
     name: cp310 (meson) fast
     # Ensure (a) this doesn't run on forks by default, and
     #        (b) it does run with Act locally (`github` doesn't exist there)
-    if: "github.repository == 'scipy/scipy' || github.repository == ''"
+    if: "github.repository == 'andyfaff/scipy' || github.repository == ''"
     runs-on: windows-2019
     steps:
       - name: Checkout
@@ -39,6 +39,9 @@ jobs:
         run: |
           choco install rtools --no-progress
           echo "c:\rtools40\ucrt64\bin;" >> $env:GITHUB_PATH
+          choco install pkgconfiglite
+          echo "C:\ProgramData\chocolatey\bin\;" >> $env:GITHUB_PATH
+
       - name: show-gfortran
         run: |
           gcc --version

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,7 +21,7 @@ jobs:
     name: cp310 (meson) fast
     # Ensure (a) this doesn't run on forks by default, and
     #        (b) it does run with Act locally (`github` doesn't exist there)
-    if: "github.repository == 'andyfaff/scipy' || github.repository == ''"
+    if: "github.repository == 'scipy/scipy' || github.repository == ''"
     runs-on: windows-2019
     steps:
       - name: Checkout
@@ -37,7 +37,7 @@ jobs:
           cache-dependency-path: 'environment.yml'
       - name: Install rtools (mingw-w64)
         run: |
-          choco install rtools --no-progress --force --version=4.0.0.20220206
+          choco install rtools -y --no-progress --force --version=4.0.0.20220206
           echo "c:\rtools40\ucrt64\bin;" >> $env:GITHUB_PATH
 
       - name: show-gfortran
@@ -87,7 +87,7 @@ jobs:
 
       - name: Install rtools (mingw-w64)
         run: |
-          choco install rtools --no-progress
+          choco install rtools -y --no-progress --force --version=4.0.0.20220206
           echo "c:\rtools40\ucrt64\bin;" >> $env:GITHUB_PATH
 
       - name: Install OpenBLAS
@@ -136,7 +136,7 @@ jobs:
       - name: Win_amd64 - install rtools
         run: |
           # mingw-w64
-          choco install rtools --no-progress
+          choco install rtools -y --no-progress --force --version=4.0.0.20220206
           echo "c:\rtools40\ucrt64\bin;" >> $env:GITHUB_PATH
 
       - name: Install OpenBLAS

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -37,7 +37,7 @@ jobs:
           cache-dependency-path: 'environment.yml'
       - name: Install rtools (mingw-w64)
         run: |
-          choco install rtools --no-progress --version=4.0.0.20220206
+          choco install rtools --no-progress --force --version=4.0.0.20220206
           echo "c:\rtools40\ucrt64\bin;" >> $env:GITHUB_PATH
 
       - name: show-gfortran


### PR DESCRIPTION
There is a new rtools release on `choco`, version 4.3. This has caused a large proportion of Windows CI to stop working as the binaries are in a different place to the previous version available on choco. This meant that meson couldn't find pkg-config (different install location), so the whole build ground to a halt.

This PR pins the rtools version to 4.0. Decided to stick with that because 4.3 may bundle different gcc versions, etc.