### PR TITLE
ENH: CloughTocher2DInterpolator multiple times with different values

### DIFF
--- a/scipy/interpolate/_ndgriddata.py
+++ b/scipy/interpolate/_ndgriddata.py
@@ -98,6 +98,11 @@ class NearestNDInterpolator(NDInterpolatorBase):
         self.tree = cKDTree(self.points, **tree_options)
         self.values = np.asarray(y)
 
+    def _calculate_triangulation(self):
+        # This function overrides _calculate_triangulation in NDInterpolatorBase,
+        # since triangulation is not needed for NearestNDInterpolator.
+        pass
+
     def __call__(self, *args):
         """
         Evaluate interpolator at given points.
@@ -110,6 +115,8 @@ class NearestNDInterpolator(NDInterpolatorBase):
             or x1 can be array-like of float with shape ``(..., ndim)``
 
         """
+        # This function doesn't use NDInterpolatorBase._set_xi since it performs
+        # unrequired calculations.
         xi = _ndim_coords_from_arrays(args, ndim=self.points.shape[1])
         xi = self._check_call_shape(xi)
         xi = self._scale_x(xi)

--- a/scipy/interpolate/_ndgriddata.py
+++ b/scipy/interpolate/_ndgriddata.py
@@ -92,7 +92,7 @@ class NearestNDInterpolator(NDInterpolatorBase):
     def __init__(self, x, y, rescale=False, tree_options=None):
         NDInterpolatorBase.__init__(self, x, y, rescale=rescale,
                                     need_contiguous=False,
-                                    need_values=True)
+                                    need_values=False)
         if tree_options is None:
             tree_options = dict()
         self.tree = cKDTree(self.points, **tree_options)

--- a/scipy/interpolate/_ndgriddata.py
+++ b/scipy/interpolate/_ndgriddata.py
@@ -92,7 +92,7 @@ class NearestNDInterpolator(NDInterpolatorBase):
     def __init__(self, x, y, rescale=False, tree_options=None):
         NDInterpolatorBase.__init__(self, x, y, rescale=rescale,
                                     need_contiguous=False,
-                                    need_values=False)
+                                    need_values=True)
         if tree_options is None:
             tree_options = dict()
         self.tree = cKDTree(self.points, **tree_options)

--- a/scipy/interpolate/_ndgriddata.py
+++ b/scipy/interpolate/_ndgriddata.py
@@ -98,11 +98,6 @@ class NearestNDInterpolator(NDInterpolatorBase):
         self.tree = cKDTree(self.points, **tree_options)
         self.values = np.asarray(y)
 
-    def _calculate_triangulation(self):
-        # This function overrides _calculate_triangulation in NDInterpolatorBase,
-        # since triangulation is not needed for NearestNDInterpolator.
-        pass
-
     def __call__(self, *args):
         """
         Evaluate interpolator at given points.

--- a/scipy/interpolate/_ndgriddata.py
+++ b/scipy/interpolate/_ndgriddata.py
@@ -110,8 +110,9 @@ class NearestNDInterpolator(NDInterpolatorBase):
             or x1 can be array-like of float with shape ``(..., ndim)``
 
         """
-        # This function doesn't use NDInterpolatorBase._set_xi since it performs
-        # unrequired calculations.
+        # For the sake of enabling subclassing, NDInterpolatorBase._set_xi performs some operations
+        # which are not required by NearestNDInterpolator.__call__, hence here we operate
+        # on xi directly, without calling a parent class function.
         xi = _ndim_coords_from_arrays(args, ndim=self.points.shape[1])
         xi = self._check_call_shape(xi)
         xi = self._scale_x(xi)

--- a/scipy/interpolate/interpnd.pyx
+++ b/scipy/interpolate/interpnd.pyx
@@ -176,7 +176,7 @@ class NDInterpolatorBase:
         """
         if len(args) > 0:
             self.set_interpolation_points(*args)
-        elif self._xi = None:
+        elif self._xi is None:
             raise ValueError("Interpolation was called without required points")
 
         if self.is_complex:

--- a/scipy/interpolate/interpnd.pyx
+++ b/scipy/interpolate/interpnd.pyx
@@ -24,8 +24,6 @@ cimport numpy
 from libc.float cimport DBL_EPSILON
 from libc.math cimport fabs, sqrt
 
-import numpy as np
-
 import scipy.spatial._qhull as qhull
 cimport scipy.spatial._qhull as qhull
 
@@ -269,7 +267,7 @@ cdef _check_init_shape(points, values, ndim=None):
 
 class LinearNDInterpolator(NDInterpolatorBase):
     """
-    LinearNDInterpolator(points, values, fill_value=np.nan, rescale=False)
+    LinearNDInterpolator(points, values=None, fill_value=np.nan, rescale=False)
 
     Piecewise linear interpolant in N > 1 dimensions.
 
@@ -283,7 +281,7 @@ class LinearNDInterpolator(NDInterpolatorBase):
     ----------
     points : ndarray of floats, shape (npoints, ndims); or Delaunay
         2-D array of data point coordinates, or a precomputed Delaunay triangulation.
-    values : ndarray of float or complex, shape (npoints, ...)
+    values : ndarray of float or complex, shape (npoints, ...), optional
         N-D array of data values at `points`.  The length of `values` along the
         first axis must be equal to the length of `points`. Unlike some
         interpolators, the interpolation axis cannot be changed.
@@ -295,6 +293,8 @@ class LinearNDInterpolator(NDInterpolatorBase):
         Rescale points to unit cube before performing interpolation.
         This is useful if some of the input dimensions have
         incommensurable units and differ by many orders of magnitude.
+    xi : tuple of ndarrays, optional
+        The coordinates of the points to be interpolated.
 
     Notes
     -----
@@ -353,9 +353,9 @@ class LinearNDInterpolator(NDInterpolatorBase):
 
     """
 
-    def __init__(self, points, values, fill_value=np.nan, rescale=False):
+    def __init__(self, points, values=None, fill_value=np.nan, rescale=False, xi=None):
         NDInterpolatorBase.__init__(self, points, values, fill_value=fill_value,
-                rescale=rescale)
+                rescale=rescale, xi=None)
 
     def _evaluate_double(self, xi):
         return self._do_evaluate(xi, 1.0)
@@ -371,7 +371,6 @@ class LinearNDInterpolator(NDInterpolatorBase):
         cdef const int[:,::1] simplices = self.tri.simplices
         cdef double_or_complex fill_value
         cdef int i, j, k, m, ndim, isimplex, nvalues
-        cdef qhull.DelaunayInfo_t info
         cdef int[:] isimplices
         cdef double[:,:] c
 

--- a/scipy/interpolate/interpnd.pyx
+++ b/scipy/interpolate/interpnd.pyx
@@ -73,7 +73,6 @@ class NDInterpolatorBase:
         else:
             self.tri = None
 
-        self.ndim = ndim
         points = _ndim_coords_from_arrays(points)
 
         if need_contiguous:
@@ -93,16 +92,16 @@ class NDInterpolatorBase:
         self._calculate_triangulation(self.points)
         
         if need_values or values is not None:
-            self._set_values(values, fill_value, need_contiguous)
+            self._set_values(values, fill_value, need_contiguous, ndim)
         else:
             self.values = None
 
     def _calculate_triangulation(self, points):
         pass
 
-    def _set_values(self, values, fill_value=np.nan, need_contiguous=True):
+    def _set_values(self, values, fill_value=np.nan, need_contiguous=True, ndim=None):
         values = np.asarray(values)
-        _check_init_shape(self.points, values, ndim=self.ndim)
+        _check_init_shape(self.points, values, ndim=ndim)
 
         self.values_shape = values.shape[1:]
         if values.ndim == 1:
@@ -864,8 +863,6 @@ class CloughTocher2DInterpolator(NDInterpolatorBase):
         Rescale points to unit cube before performing interpolation.
         This is useful if some of the input dimensions have
         incommensurable units and differ by many orders of magnitude.
-    xi : tuple of ndarrays, optional
-        The coordinates of the points to be interpolated.
 
     Notes
     -----
@@ -879,9 +876,6 @@ class CloughTocher2DInterpolator(NDInterpolatorBase):
     of the interpolating surface is approximatively minimized. The
     gradients necessary for this are estimated using the global
     algorithm described in [Nielson83]_ and [Renka84]_.
-
-    Since most of the algorithm depeneds only on the triangulation of
-    the input 
 
     .. note:: For data on a regular grid use `interpn` instead.
 
@@ -952,7 +946,7 @@ class CloughTocher2DInterpolator(NDInterpolatorBase):
                                     fill_value=fill_value, rescale=rescale,
                                     need_values=False)
     
-    def _set_values(self, values, fill_value=np.nan, need_contiguous=True):
+    def _set_values(self, values, fill_value=np.nan, need_contiguous=True, ndim=None):
         """
         Sets the values of the interpolation points.
 
@@ -961,7 +955,7 @@ class CloughTocher2DInterpolator(NDInterpolatorBase):
         values : ndarray of float or complex, shape (npoints, ...)
             Data values.
         """
-        NDInterpolatorBase._set_values(self, values, fill_value=fill_value, need_contiguous=need_contiguous)
+        NDInterpolatorBase._set_values(self, values, fill_value=fill_value, need_contiguous=need_contiguous, ndim=ndim)
         if self.values is not None:
             self.grad = estimate_gradients_2d_global(self.tri, self.values,
                                                     tol=self.tol, maxiter=self.maxiter)

--- a/scipy/interpolate/interpnd.pyx
+++ b/scipy/interpolate/interpnd.pyx
@@ -940,8 +940,8 @@ class CloughTocher2DInterpolator(NDInterpolatorBase):
 
     def __init__(self, points, values, fill_value=np.nan,
                  tol=1e-6, maxiter=400, rescale=False):
-        self.tol = tol
-        self.maxiter = maxiter
+        self._tol = tol
+        self._maxiter = maxiter
         NDInterpolatorBase.__init__(self, points, values, ndim=2,
                                     fill_value=fill_value, rescale=rescale,
                                     need_values=False)
@@ -958,7 +958,7 @@ class CloughTocher2DInterpolator(NDInterpolatorBase):
         NDInterpolatorBase._set_values(self, values, fill_value=fill_value, need_contiguous=need_contiguous, ndim=ndim)
         if self.values is not None:
             self.grad = estimate_gradients_2d_global(self.tri, self.values,
-                                                    tol=self.tol, maxiter=self.maxiter)
+                                                    tol=self._tol, maxiter=self._maxiter)
     
     def _calculate_triangulation(self, points):
         self.tri = qhull.Delaunay(points)

--- a/scipy/interpolate/tests/test_interpnd.py
+++ b/scipy/interpolate/tests/test_interpnd.py
@@ -411,3 +411,14 @@ class TestCloughTocher2DInterpolator:
         ip.set_values(y)
         yi = ip(x)
         assert_almost_equal(y, yi)
+
+        y = np.arange(x.shape[0], dtype=np.double)
+        y1 = y - 3j*y
+        y2 = y - 5j*y
+        ip = interpnd.CloughTocher2DInterpolator(x, y1)
+        ip.set_interpolation_points(x)
+        yi = ip()
+        assert_almost_equal(y1, yi)
+        ip.set_values(y2)
+        yi = ip()
+        assert_almost_equal(y2, yi)

--- a/scipy/interpolate/tests/test_interpnd.py
+++ b/scipy/interpolate/tests/test_interpnd.py
@@ -384,32 +384,3 @@ class TestCloughTocher2DInterpolator:
         w2 = ip(p2)
         assert_allclose(w1, v1)
         assert_allclose(w2, v2)
-    
-
-    def test_set_values(self):
-        # Test at single points
-        x = np.array([(0,0), (-0.5,-0.5), (-0.5,0.5), (0.5, 0.5), (0.25, 0.3)],
-                     dtype=np.double)
-
-        ip = interpnd.CloughTocher2DInterpolator(x)
-
-        y = np.arange(x.shape[0], dtype=np.double)
-        y = y - 3j*y
-        yi = ip(x, values=y)
-        assert_almost_equal(y, yi)
-
-        
-        y = np.arange(x.shape[0], dtype=np.double)
-        ip = interpnd.CloughTocher2DInterpolator(x, y)
-        y = y - 3j*y
-        yi = ip(x, values=y)
-        assert_almost_equal(y, yi)
-
-        y = np.arange(x.shape[0], dtype=np.double)
-        y1 = y - 3j*y
-        y2 = y - 5j*y
-        ip = interpnd.CloughTocher2DInterpolator(x, y1, xi=(x,))
-        yi = ip()
-        assert_almost_equal(y1, yi)
-        yi = ip(values=y2)
-        assert_almost_equal(y2, yi)

--- a/scipy/interpolate/tests/test_interpnd.py
+++ b/scipy/interpolate/tests/test_interpnd.py
@@ -384,3 +384,30 @@ class TestCloughTocher2DInterpolator:
         w2 = ip(p2)
         assert_allclose(w1, v1)
         assert_allclose(w2, v2)
+    
+
+    def test_set_values(self):
+        # Test at single points
+        x = np.array([(0,0), (-0.5,-0.5), (-0.5,0.5), (0.5, 0.5), (0.25, 0.3)],
+                     dtype=np.double)
+
+        ip = interpnd.CloughTocher2DInterpolator(x)
+
+        y = np.arange(x.shape[0], dtype=np.double)
+        y = y - 3j*y
+        ip.set_values(y)
+        yi = ip(x)
+        assert_almost_equal(y, yi)
+
+        y = np.arange(x.shape[0], dtype=np.double)
+        y = y - 5j*y
+        ip.set_values(y)
+        yi = ip(x)
+        assert_almost_equal(y, yi)
+
+        y = np.arange(x.shape[0], dtype=np.double)
+        ip = interpnd.CloughTocher2DInterpolator(x, y)
+        y = y - 3j*y
+        ip.set_values(y)
+        yi = ip(x)
+        assert_almost_equal(y, yi)

--- a/scipy/interpolate/tests/test_interpnd.py
+++ b/scipy/interpolate/tests/test_interpnd.py
@@ -395,30 +395,21 @@ class TestCloughTocher2DInterpolator:
 
         y = np.arange(x.shape[0], dtype=np.double)
         y = y - 3j*y
-        ip.set_values(y)
-        yi = ip(x)
+        yi = ip(x, values=y)
         assert_almost_equal(y, yi)
 
-        y = np.arange(x.shape[0], dtype=np.double)
-        y = y - 5j*y
-        ip.set_values(y)
-        yi = ip(x)
-        assert_almost_equal(y, yi)
-
+        
         y = np.arange(x.shape[0], dtype=np.double)
         ip = interpnd.CloughTocher2DInterpolator(x, y)
         y = y - 3j*y
-        ip.set_values(y)
-        yi = ip(x)
+        yi = ip(x, values=y)
         assert_almost_equal(y, yi)
 
         y = np.arange(x.shape[0], dtype=np.double)
         y1 = y - 3j*y
         y2 = y - 5j*y
-        ip = interpnd.CloughTocher2DInterpolator(x, y1)
-        ip.set_interpolation_points(x)
+        ip = interpnd.CloughTocher2DInterpolator(x, y1, xi=(x,))
         yi = ip()
         assert_almost_equal(y1, yi)
-        ip.set_values(y2)
-        yi = ip()
+        yi = ip(values=y2)
         assert_almost_equal(y2, yi)


### PR DESCRIPTION
#### Reference issue
#13306 


#### What does this implement/fix?
The PR adds an ability to change interpolation values in an existing `CloughTocher2DInterpolator` object, while also saving the barycentric coordinates of interpolation points.
In a use case in which only the values at the given points change, this saves most of the function's runtime.
The PR includes basic tests.

#### Additional information
This is my first PR to `scipy`, and I am not 100% sure how to document the API, help and guidance would be appreciated.
