### PR TITLE
DOC: add output_type to signature of cKDTree.query_pairs

### DIFF
--- a/scipy/spatial/_ckdtree.pyx
+++ b/scipy/spatial/_ckdtree.pyx
@@ -1082,7 +1082,7 @@ cdef class cKDTree:
     def query_pairs(cKDTree self, np.float64_t r, np.float64_t p=2.,
                     np.float64_t eps=0, output_type='set'):
         """
-        query_pairs(self, r, p=2., eps=0)
+        query_pairs(self, r, p=2., eps=0, output_type='set')
 
         Find all pairs of points in `self` whose distance is at most r.
 


### PR DESCRIPTION
Fixes #17107 

- added output_type parameter to docstring

Mentioned https://github.com/scipy/scipy/issues/17107#issuecomment-1261156645


